### PR TITLE
Added a nimrod.cfg option to control the location of the nimcache directory.

### DIFF
--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -231,3 +231,12 @@ proc LoadConfig*(project: string) =
     var conffile = changeFileExt(project, "cfg")
     if existsFile(conffile): readConfigFile(conffile)
   
+  if existsConfigVar("nimrod.nimcachePath"):
+    var confNimcachePath = getConfigVar("nimrod.nimcachePath")
+    if isAbsolute(confNimcachePath):
+      nimcachePath = confNimcachePath.replace("%p", project)
+    else:
+      nimcachePath = joinPath([projectPath, confNimcachePath])
+  else:
+    nimcachePath = joinPath([projectPath, defNimcacheDir])
+

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -84,7 +84,7 @@ var
 proc FindFile*(f: string): string
 
 const 
-  genSubDir* = "nimcache"
+  defNimcacheDir* = "nimcache"
   NimExt* = "nim"
   RodExt* = "rod"
   HtmlExt* = "html"
@@ -104,6 +104,7 @@ var
   gConfigVars*: PStringTable
   libpath*: string = ""
   projectPath*: string = ""
+  nimcachePath*: string = ""
   gKeepComments*: bool = true # whether the parser needs to keep comments
   gImplicitMods*: TStringSeq = @[] # modules that are to be implicitly imported
 
@@ -154,16 +155,16 @@ proc removeTrailingDirSep*(path: string): string =
     result = substr(path, 0, len(path) - 2)
   else: 
     result = path
-  
+
 proc toGeneratedFile(path, ext: string): string = 
   var (head, tail) = splitPath(path)
   if len(head) > 0: head = shortenDir(head & dirSep)
-  result = joinPath([projectPath, genSubDir, head, changeFileExt(tail, ext)])
+  result = joinPath([nimcachePath, head, changeFileExt(tail, ext)])
 
 proc completeGeneratedFilePath(f: string, createSubDir: bool = true): string = 
   var (head, tail) = splitPath(f)
   if len(head) > 0: head = removeTrailingDirSep(shortenDir(head & dirSep))
-  var subdir = joinPath([projectPath, genSubDir, head])
+  var subdir = joinPath([nimcachePath, head])
   if createSubDir: 
     try: 
       createDir(subdir)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -512,6 +512,21 @@ proc cmpPaths*(pathA, pathB: string): int {.
   else:
     result = cmpIgnoreCase(pathA, pathB)
 
+proc isAbsolute*(path: string): bool {.rtl, noSideEffect.} =
+  ## Checks whether a given path is absolute.
+  ##
+  ## on Windows, network paths are considered absolute too.
+  var len = len(path)
+  when defined(doslike):
+    return  (len > 1 and (path[0] == '/' or path[0] == '\\')) or
+            (len > 2 and path[1] == ':')
+  elif defined(macos):
+    return len > 0 and path[0] != ':'
+  elif defined(RISCOS):
+    return len > 0 and path[0] == '$'
+  elif defined(posix):
+    return len > 0 and path[0] == '/'
+
 proc sameFile*(path1, path2: string): bool {.rtl, extern: "nos$1".} =
   ## Returns True if both pathname arguments refer to the same file or
   ## directory (as indicated by device number and i-node number).


### PR DESCRIPTION
Added a nimrod.cfg option to control the location of the nimcache directory.

You can specify either a path relative to the project location or absolute path. When absolute path is specified you can use the %p magic variable, which will expand to the name of the current project.

Example:
nimrod.nimcachePath = "/tmp/nimcache/%p/"

also added: isAbsolute(path) predicate to the os module. 
