### PR TITLE
Remove 'elif' from caseStmt's syntax definition 

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -1719,7 +1719,6 @@ Case statement
 Syntax::
 
   caseStmt ::= 'case' expr [':'] ('of' sliceExprList ':' stmt)*
-                                 ('elif' expr ':' stmt)*
                                  ['else' ':' stmt]
 
 Example:


### PR DESCRIPTION
I think that 'elif' was in caseStmt's syntax by mistake, so I removed it.
