### PR TITLE
repr fails on pure inherited objects

### DIFF
--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -167,6 +167,7 @@ when not defined(useNimRtl):
 
   proc reprRecordAux(result: var string, p: pointer, n: ptr TNimNode,
                      cl: var TReprClosure) =
+    if isNil(n) : return
     case n.kind
     of nkNone: sysAssert(false, "reprRecordAux")
     of nkSlot:


### PR DESCRIPTION
.... This can happen on pure objects
