### PR TITLE
Changes default macosx compiler to clang.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,8 @@ case $uos in
     ;;
   *darwin* ) 
     myos="macosx"
+    CC="clang"
+    LINKER="clang"
     LINK_FLAGS="$LINK_FLAGS -ldl -lm"
     if [ "$HOSTTYPE" = "x86_64" ] ; then
       ucpu="amd64"

--- a/config/nimrod.cfg
+++ b/config/nimrod.cfg
@@ -91,6 +91,7 @@ hint[LineTooLong]=off
 @end
 
 @if macosx:
+  cc = clang
   tlsEmulation:on
   gcc.options.always = "-w -fasm-blocks"
   gpp.options.always = "-w -fasm-blocks"


### PR DESCRIPTION
The default gcc version provided by current Xcode versions doesn't work.
Alternatively macport's gcc-4.7 is known to work too, but that is less
common for macosx users.
