### PR TITLE
install.sh failure, bootstrap = chicken & egg problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ examples/cross_todo/nimrod_backend/backend
 examples/cross_todo/nimrod_backend/testbackend
 examples/cross_todo/nimrod_backend/todo.sqlite3
 examples/cross_todo/nimrod_commandline/nimtodo
+install.sh
+deinstall.sh
 
 # iOS specific wildcards.
 *.mode1v3

--- a/koch.nim
+++ b/koch.nim
@@ -36,6 +36,7 @@ Options:
   --help, -h               shows this help and quits
 Possible Commands:
   boot [options]           bootstraps with given command line options
+  install [dir]            installs to given directory
   clean                    cleans Nimrod project; removes generated files
   web                      generates the website
   csource [options]        builds the C sources for installation
@@ -84,7 +85,9 @@ proc inno(args: string) =
        NimrodVersion)
 
 proc install(args: string) = 
-  exec("sh ./build.sh")
+  exec("nimrod cc -r tools/niminst/niminst --var:version=$# scripts compiler/nimrod.ini" %
+       NimrodVersion)
+  exec("sh ./install.sh $#" % args)  
 
 proc web(args: string) =
   exec(("nimrod cc -r tools/nimweb.nim web/nimrod --putenv:nimrodversion=$#" &


### PR DESCRIPTION
During latest build (from clean Git), I got the following failure:

```
Nimrod build detected
copying files...
cp: cannot stat ‘lib/system/gc_genms.nim’: No such file or directory
```

From looking at the Git history for 'install.sh', I see that it gets rebuilt regularly to fix this kind of bootstrap problems.

I was wondering: wouldn't it be better to
- have csources.zip contain the build.sh to go with _that particular_ bootstrap package
- have "./koch boot" generate the install.sh for the _current_ state of the tree (so it can install files which are actually there)
- have "./koch csource" generate the build.sh to go into csources.zip

In other words:
- _only_ generate a build.sh when the current state is stable enough to bootstrap from, and
- _always_ generate an install.sh which matches the current tree.

This should solve the chicken & egg problem, and neither build.sh nor install.sh need to be tracked by Git anymore.
Any comments, suggestions?
