### PR TITLE
Adds idetools --suggest test case. Refs #484.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ examples/cross_calculator/android/tags
 /testresults.json
 /tests/caas/SymbolProcRun.*/
 /tests/caas/absurd_nesting
+/tests/caas/completion_dot_syntax_main
 /tests/caas/forward_declarations
 /tests/caas/idetools_api
 /tests/caas/imported

--- a/tests/caas/completion_dot_syntax.txt
+++ b/tests/caas/completion_dot_syntax.txt
@@ -1,0 +1,8 @@
+completion_dot_syntax_main.nim
+> idetools --track:$TESTNIM,24,15 --def
+def\tskProc\t$MODULE.echoRemainingDollars
+> idetools --trackDirty:completion_dot_syntax_dirty.nim,$TESTNIM,25,12 --suggest
+sug\tskProc\tcompletion_dot_syntax_dirty.echoRemainingDollars
+# The suggestion should not mention the other echoRemaining* variants.
+!sug\tskProc\tcompletion_dot_syntax_dirty.echoRemainingEuros
+!sug\tskProc\tcompletion_dot_syntax_dirty.echoRemainingBugs

--- a/tests/caas/completion_dot_syntax_dirty.nim
+++ b/tests/caas/completion_dot_syntax_dirty.nim
@@ -1,0 +1,25 @@
+import strutils
+
+# Verifies if the --suggestion switch differentiates types for dot notation.
+
+type
+  TDollar = distinct int
+  TEuro = distinct int
+
+proc echoRemainingDollars(amount: TDollar) =
+  echo "You have $1 dollars" % [$int(amount)]
+
+proc echoRemainingEuros(amount: TEuro) =
+  echo "You have $1 euros" % [$int(amount)]
+
+proc echoRemainingBugs() =
+  echo "You still have bugs"
+
+proc main =
+  var
+    d: TDollar
+    e: TEuro
+  d = TDollar(23)
+  e = TEuro(32)
+  d.echoRemainingDollars()
+  e.echoRemai

--- a/tests/caas/completion_dot_syntax_main.nim
+++ b/tests/caas/completion_dot_syntax_main.nim
@@ -1,0 +1,24 @@
+import strutils
+
+# Verifies if the --suggestion switch differentiates types for dot notation.
+
+type
+  TDollar = distinct int
+  TEuro = distinct int
+
+proc echoRemainingDollars(amount: TDollar) =
+  echo "You have $1 dollars" % [$int(amount)]
+
+proc echoRemainingEuros(amount: TEuro) =
+  echo "You have $1 euros" % [$int(amount)]
+
+proc echoRemainingBugs() =
+  echo "You still have bugs"
+
+proc main =
+  var
+    d: TDollar
+    e: TEuro
+  d = TDollar(23)
+  e = TEuro(32)
+  d.echoRemainingDollars()


### PR DESCRIPTION
1) There are too many suggestions for the given prefix.
2) The suggestions don't take into account the preceeding type.
3) trackDirty only works on caas mode.
