### PR TITLE
Improves highlite module

### DIFF
--- a/lib/packages/docutils/highlite.nim
+++ b/lib/packages/docutils/highlite.nim
@@ -556,5 +556,5 @@ when isMainModule:
   doAssert (not keywords.isNil, "Couldn't read any keywords.txt file!")
   doAssert keywords.len == nimrodKeywords.len, "No matching lengths"
   for i in 0..keywords.len-1:
-    echo keywords[i], " == ", nimrodKeywords[i]
+    #echo keywords[i], " == ", nimrodKeywords[i]
     doAssert keywords[i] == nimrodKeywords[i], "Unexpected keyword"

--- a/tests/specials.nim
+++ b/tests/specials.nim
@@ -194,6 +194,8 @@ proc runSpecialTests(r: var TResults, options: string) =
 
   for t in os.walkFiles("tests/patterns/t*.nim"):
     runSingleTest(r, t, options)
+  for t in ["lib/packages/docutils/highlite"]:
+    runSingleTest(r, t, options)
 
 proc rejectSpecialTests(r: var TResults, options: string) =
   rejectThreadTests(r, options)


### PR DESCRIPTION
Removes the keyword.txt slurping to allow importing out of the nimrod tree. The keyword file duplicaation is added to the test cases to avoid getting out of sync with the original txt file.
