### PR TITLE
Exports TXmlNode and the ``k`` TXmlNodeKind field.

### DIFF
--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -23,8 +23,8 @@ type
   
   PXmlAttributes* = PStringTable ## an alias for a string to string mapping
   
-  TXmlNode {.pure, final, acyclic.} = object 
-    case k: TXmlNodeKind
+  TXmlNode* {.pure, final, acyclic.} = object 
+    case k*: TXmlNodeKind
     of xnText, xnComment, xnCData, xnEntity: 
       fText: string
     of xnElement:


### PR DESCRIPTION
Iterators like `items` will assert on bad input, but end user code
can't check the type beforehand because the kind field is not exported.
