### PR TITLE
Fix for Issue #510 : Moved linker flags to the end of cmd line in build.sh and bat templates

### DIFF
--- a/tools/niminst/buildbat.tmpl
+++ b/tools/niminst/buildbat.tmpl
@@ -17,8 +17,8 @@ ECHO %CC% %COMP_FLAGS% -Ibuild -c ?{f} -o ?{changeFileExt(f, "o")}
 #      linkCmd.add(" " & changeFileExt(f, "o"))
 #    end for
 
-ECHO %LINKER% %LINK_FLAGS% -o ?{firstBinPath(c)\toLower(c.name)}.exe ?linkCmd
-%LINKER% %LINK_FLAGS% -o ?{firstBinPath(c)\toLower(c.name)}.exe ?linkCmd
+ECHO %LINKER% -o ?{firstBinPath(c)\toLower(c.name)}.exe ?linkCmd %LINK_FLAGS%
+%LINKER% -o ?{firstBinPath(c)\toLower(c.name)}.exe ?linkCmd %LINK_FLAGS%
 
 #  end block
 

--- a/tools/niminst/buildsh.tmpl
+++ b/tools/niminst/buildsh.tmpl
@@ -121,8 +121,8 @@ case $myos in
     $CC $COMP_FLAGS -Ibuild -c ?{f} -o ?{changeFileExt(f, "o")}
 #        add(linkCmd, " \\\n" & changeFileExt(f, "o"))
 #      end for    
-    echo "$LINKER $LINK_FLAGS -o ?{firstBinPath(c)/toLower(c.name)} ?linkCmd"
-    $LINKER $LINK_FLAGS -o ?{firstBinPath(c)/toLower(c.name)} ?linkCmd
+    echo "$LINKER -o ?{firstBinPath(c)/toLower(c.name)} ?linkCmd $LINK_FLAGS"
+    $LINKER -o ?{firstBinPath(c)/toLower(c.name)} ?linkCmd $LINK_FLAGS
     ;;
 #    end for
   *)


### PR DESCRIPTION
Fix for Issue #510. Changed places for linker flags in build scripts templates.
You need to regenerate csources, i have compiler/mapping.txt and build/nimbase.h changed, not sure if they are correct, so i push only what i have changed by hands. I've tried to bootstrap and now the compiler builds successfully.
