### PR TITLE
Make sure TGLDouble and TGLclampd is 64 bit

### DIFF
--- a/lib/wrappers/opengl/gl.nim
+++ b/lib/wrappers/opengl/gl.nim
@@ -51,8 +51,8 @@ type
   TGLuint* = cint
   TGLfloat* = float32
   TGLclampf* = float32
-  TGLdouble* = float
-  TGLclampd* = float
+  TGLdouble* = float64
+  TGLclampd* = float64
 
 const                         # Version
   GL_VERSION_1_1* = 1         # AccumOp


### PR DESCRIPTION
On some architectures `float` is not always 64 bits. So we need to be explicit to make sure they are actually double precision floating point numbers.
