### PR TITLE
Add DragonFly as essentially a clone of FreeBSD

### DIFF
--- a/tools/niminst/buildsh.tmpl
+++ b/tools/niminst/buildsh.tmpl
@@ -54,7 +54,7 @@ case $uos in
     myos="linux" 
     LINK_FLAGS="$LINK_FLAGS -ldl -lm"
     ;;
-  *freebsd* ) 
+  *freebsd* | *dragonfly* ) 
     myos="freebsd"
     LINK_FLAGS="$LINK_FLAGS -lm"
     ;;


### PR DESCRIPTION
This builds for me on dragonflybsd, provided one either has a prebuilt nimrod or gets the boot C files and edits the included build.sh to cover the case for freebsd to  include dragonflybsd.

I'll look into tests and results later this week.
