### PR TITLE
Added a TSocketHandle type to winlean.nim and posix.nim

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -81,6 +81,9 @@ else:
       ## A type representing a directory stream.   
   
 type
+  TSocketHandle* = cint # The type used to represent socket descripters
+                        # Should this be distinct? Is this the right place?
+
   Tdirent* {.importc: "struct dirent", 
              header: "<dirent.h>", final, pure.} = object ## dirent_t struct
     d_ino*: TIno  ## File serial number.

--- a/lib/pure/asyncio.nim
+++ b/lib/pure/asyncio.nim
@@ -89,13 +89,13 @@ import sockets, os
 ##      getSocket(s).accept(client)
 
 when defined(windows):
-  from winlean import TTimeVal, TFdSet, FD_ZERO, FD_SET, FD_ISSET, select
+  from winlean import TTimeVal, TSocketHandle, TFdSet, FD_ZERO, FD_SET, FD_ISSET, select
 else:
-  from posix import TTimeVal, TFdSet, FD_ZERO, FD_SET, FD_ISSET, select
+  from posix import TTimeVal, TSocketHandle, TFdSet, FD_ZERO, FD_SET, FD_ISSET, select
 
 type
   TDelegate* = object
-    fd*: cint
+    fd*: TSocketHandle
     deleVal*: PObject
 
     handleRead*: proc (h: PObject) {.nimcall.}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -390,11 +390,11 @@ type
     h_length*: int16
     h_addr_list*: cstringArray
     
-  TWinSocket* = cint
+  TSocketHandle* = int # Make distinct? Is this the right place for this?
   
   TFdSet* {.pure, final.} = object
     fd_count*: cint # unsigned
-    fd_array*: array[0..FD_SETSIZE-1, TWinSocket]
+    fd_array*: array[0..FD_SETSIZE-1, TSocketHandle]
     
   TTimeval* {.pure, final.} = object
     tv_sec*, tv_usec*: int32
@@ -426,45 +426,45 @@ proc gethostbyaddr*(ip: ptr TInAddr, len: cuint, theType: cint): ptr THostEnt {.
 proc gethostbyname*(name: cstring): ptr THostEnt {.
   stdcall, importc: "gethostbyname", dynlib: ws2dll.}
 
-proc socket*(af, typ, protocol: cint): TWinSocket {.
+proc socket*(af, typ, protocol: cint): TSocketHandle {.
   stdcall, importc: "socket", dynlib: ws2dll.}
 
-proc closesocket*(s: TWinSocket): cint {.
+proc closesocket*(s: TSocketHandle): cint {.
   stdcall, importc: "closesocket", dynlib: ws2dll.}
 
-proc accept*(s: TWinSocket, a: ptr TSockAddr, addrlen: ptr TSockLen): TWinSocket {.
+proc accept*(s: TSocketHandle, a: ptr TSockAddr, addrlen: ptr TSockLen): TSocketHandle {.
   stdcall, importc: "accept", dynlib: ws2dll.}
-proc bindSocket*(s: TWinSocket, name: ptr TSockAddr, namelen: TSockLen): cint {.
+proc bindSocket*(s: TSocketHandle, name: ptr TSockAddr, namelen: TSockLen): cint {.
   stdcall, importc: "bind", dynlib: ws2dll.}
-proc connect*(s: TWinSocket, name: ptr TSockAddr, namelen: TSockLen): cint {.
+proc connect*(s: TSocketHandle, name: ptr TSockAddr, namelen: TSockLen): cint {.
   stdcall, importc: "connect", dynlib: ws2dll.}
-proc getsockname*(s: TWinSocket, name: ptr TSockAddr, 
+proc getsockname*(s: TSocketHandle, name: ptr TSockAddr, 
                   namelen: ptr TSockLen): cint {.
   stdcall, importc: "getsockname", dynlib: ws2dll.}
-proc getsockopt*(s: TWinSocket, level, optname: cint, optval: pointer,
+proc getsockopt*(s: TSocketHandle, level, optname: cint, optval: pointer,
                  optlen: ptr TSockLen): cint {.
   stdcall, importc: "getsockopt", dynlib: ws2dll.}
-proc setsockopt*(s: TWinSocket, level, optname: cint, optval: pointer,
+proc setsockopt*(s: TSocketHandle, level, optname: cint, optval: pointer,
                  optlen: TSockLen): cint {.
   stdcall, importc: "setsockopt", dynlib: ws2dll.}
 
-proc listen*(s: TWinSocket, backlog: cint): cint {.
+proc listen*(s: TSocketHandle, backlog: cint): cint {.
   stdcall, importc: "listen", dynlib: ws2dll.}
-proc recv*(s: TWinSocket, buf: pointer, len, flags: cint): cint {.
+proc recv*(s: TSocketHandle, buf: pointer, len, flags: cint): cint {.
   stdcall, importc: "recv", dynlib: ws2dll.}
-proc recvfrom*(s: TWinSocket, buf: cstring, len, flags: cint, 
+proc recvfrom*(s: TSocketHandle, buf: cstring, len, flags: cint, 
                fromm: ptr TSockAddr, fromlen: ptr Tsocklen): cint {.
   stdcall, importc: "recvfrom", dynlib: ws2dll.}
 proc select*(nfds: cint, readfds, writefds, exceptfds: ptr TFdSet,
              timeout: ptr TTimeval): cint {.
   stdcall, importc: "select", dynlib: ws2dll.}
-proc send*(s: TWinSocket, buf: pointer, len, flags: cint): cint {.
+proc send*(s: TSocketHandle, buf: pointer, len, flags: cint): cint {.
   stdcall, importc: "send", dynlib: ws2dll.}
-proc sendto*(s: TWinSocket, buf: pointer, len, flags: cint,
+proc sendto*(s: TSocketHandle, buf: pointer, len, flags: cint,
              to: ptr TSockAddr, tolen: Tsocklen): cint {.
   stdcall, importc: "sendto", dynlib: ws2dll.}
 
-proc shutdown*(s: TWinSocket, how: cint): cint {.
+proc shutdown*(s: TSocketHandle, how: cint): cint {.
   stdcall, importc: "shutdown", dynlib: ws2dll.}
   
 proc getnameinfo*(a1: ptr Tsockaddr, a2: Tsocklen,
@@ -475,13 +475,13 @@ proc getnameinfo*(a1: ptr Tsockaddr, a2: Tsocklen,
 proc inet_addr*(cp: cstring): int32 {.
   stdcall, importc: "inet_addr", dynlib: ws2dll.} 
 
-proc WSAFDIsSet(s: TWinSocket, FDSet: var TFDSet): bool {.
+proc WSAFDIsSet(s: TSocketHandle, FDSet: var TFDSet): bool {.
   stdcall, importc: "__WSAFDIsSet", dynlib: ws2dll.}
 
-proc FD_ISSET*(Socket: TWinSocket, FDSet: var TFDSet): cint = 
+proc FD_ISSET*(Socket: TSocketHandle, FDSet: var TFDSet): cint = 
   result = if WSAFDIsSet(Socket, FDSet): 1'i32 else: 0'i32
 
-proc FD_SET*(Socket: TWinSocket, FDSet: var TFDSet) = 
+proc FD_SET*(Socket: TSocketHandle, FDSet: var TFDSet) = 
   if FDSet.fd_count < FD_SETSIZE:
     FDSet.fd_array[int(FDSet.fd_count)] = Socket
     inc(FDSet.fd_count)


### PR DESCRIPTION
These changes fix a major law in nimrod's usage of Window's sockets - On Windows, socket handles are represented by a pointer to an unsigned long, which is 32 bits on Win32, and 64 bits on Win64. This fixes the problem by declaring a new type in posix.nim and winlean.nim - the TSocketHandle type, and using it for all representations of sockets.
