### PR TITLE
Adds link to stackoverflow nimrod tag in support section.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,9 +47,11 @@ The above steps can be performed on Windows in a similar fashion, the
 instead of ``build.sh``.
 
 ## Getting help
-A [forum](http://forum.nimrod-code.org/) is available if you have any questions,
-and you can also get help in the IRC channel
-on [Freenode](irc://irc.freenode.net/nimrod) in #nimrod.
+A [forum](http://forum.nimrod-code.org/) is available if you have any
+questions, and you can also get help in the IRC channel on
+[Freenode](irc://irc.freenode.net/nimrod) in #nimrod. If you ask questions on
+[StackOverflow use the nimrod
+tag](http://stackoverflow.com/questions/tagged/nimrod).
 
 ## License
 The compiler and the standard library are licensed under the MIT license, 

--- a/readme.txt
+++ b/readme.txt
@@ -47,9 +47,11 @@ The above steps can be performed on Windows in a similar fashion, the
 instead of ``build.sh``.
 
 ## Getting help
-A [forum](http://forum.nimrod-code.org/) is available if you have any questions,
-and you can also get help in the IRC channel
-on [Freenode](irc://irc.freenode.net/nimrod) in #nimrod.
+A [forum](http://forum.nimrod-code.org/) is available if you have any
+questions, and you can also get help in the IRC channel on
+[Freenode](irc://irc.freenode.net/nimrod) in #nimrod. If you ask questions on
+[StackOverflow use the nimrod
+tag](http://stackoverflow.com/questions/tagged/nimrod).
 
 ## License
 The compiler and the standard library are licensed under the MIT license, 


### PR DESCRIPTION
I wonder if the .md file could be a unix symbolic link to the .txt file so windows users get their .txt version and github gets the markdown rendered version…
