### PR TITLE
Makes htmlparser handle whitespace. Refs #694.

### DIFF
--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -528,7 +528,7 @@ proc parseHtml*(s: PStream, filename: string,
   ## parses the XML from stream `s` and returns a ``PXmlNode``. Every
   ## occured parsing error is added to the `errors` sequence.
   var x: TXmlParser
-  open(x, s, filename, {reportComments})
+  open(x, s, filename, {reportComments, reportWhitespace})
   next(x)
   # skip the DOCTYPE:
   if x.kind == xmlSpecial: next(x)


### PR DESCRIPTION
Without the flag, htmlparser will ignore some significant whitespace in
HTML files. A more correct fix would be to not reuse the xml parser
since the rules for HTML are slightly different, but this will do for
the moment.
