### PR TITLE
Write tracebacks to stderr instead of stdout.

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -18,7 +18,7 @@ template stackTraceNL: expr =
   (if IsNil(stackTraceNewLine): "\n" else: stackTraceNewLine)
 
 when not defined(windows) or not defined(guiapp):
-  proc writeToStdErr(msg: CString) = write(stdout, msg)
+  proc writeToStdErr(msg: CString) = write(stderr, msg)
 
 else:
   proc MessageBoxA(hWnd: cint, lpText, lpCaption: cstring, uType: int): int32 {.


### PR DESCRIPTION
This probably breaks CGI script error reporting (haven't checked), but if
it worked it first place it probably meant XSS (also haven't checked).
While documentation says "don't use stderr" I hope that no one will argue
about writing errors to error output :)

Fixes #713
