### PR TITLE
Update macros.nim

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -497,18 +497,17 @@ from strutils import cmpIgnoreStyle, format
 proc expectKind*(n: PNimrodNode; k: set[TNimrodNodeKind]) {.compileTime.} =
   assert n.kind in k, "Expected one of $1, got $2".format(k, n.kind)
 
-proc newProc*(name = newEmptyNode(); params: openarray[PNimrodNode] = [];  
+proc newProc*(name = newEmptyNode(); params: openarray[PNimrodNode] = []; returnType = newEmptyNode();
     body: PNimrodNode = newStmtList(), procType = nnkProcDef): PNimrodNode {.compileTime.} =
   ## shortcut for creating a new proc
   ##
-  ## The ``params`` array should start with the return type of the proc, 
-  ## followed by a list of IdentDefs which specify the params.
+  ## The ``params`` array is a list of IdentDefs which specify the params.
   assert procType in RoutineNodes
   result = newNimNode(procType).add(
     name,
     newEmptyNode(),
     newEmptyNode(),
-    newNimNode(nnkFormalParams).add(params), ##params
+    newNimNode(nnkFormalParams).add(returnType).add(params), ##params
     newEmptyNode(),  ## pragmas
     newEmptyNode(),
     body)


### PR DESCRIPTION
newProc() makes more sense, use returnType parameter instead of requiring it be in the params parameter
