### PR TITLE
Fix os.removeFile behavior on windows (again)

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -970,7 +970,7 @@ proc moveFile*(source, dest: string) {.rtl, extern: "nos$1",
   if crename(source, dest) != 0'i32:
     raise newException(EOS, $strerror(errno))
 
-when not defined(ENOENT):
+when not defined(ENOENT) and not defined(Windows):
   var ENOENT {.importc, header: "<errno.h>".}: cint
 
 when defined(Windows):
@@ -987,8 +987,7 @@ proc removeFile*(file: string) {.rtl, extern: "nos$1", tags: [FWriteDir].} =
   ## Removes the `file`. If this fails, `EOS` is raised. This does not fail
   ## if the file never existed in the first place.
   ## On Windows, ignores the read-only attribute.
-  if cremove(file) != 0'i32 and errno != ENOENT:
-    when defined(Windows):
+  when defined(Windows):
     when useWinUnicode:
       let f = newWideCString(file)
     else:

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -553,18 +553,26 @@ const
 
   FILE_FLAG_BACKUP_SEMANTICS* = 33554432'i32
 
+# Error Constants
+const
+  ERROR_ACCESS_DENIED* = 5
+
 when useWinUnicode:
   proc CreateFileW*(lpFileName: widecstring, dwDesiredAccess, dwShareMode: DWORD,
                     lpSecurityAttributes: pointer,
                     dwCreationDisposition, dwFlagsAndAttributes: DWORD,
                     hTemplateFile: THANDLE): THANDLE {.
       stdcall, dynlib: "kernel32", importc: "CreateFileW".}
+  proc DeleteFileW*(pathName: widecstring): int32 {.
+    importc: "DeleteFileW", dynlib: "kernel32", stdcall.}
 else:
   proc CreateFileA*(lpFileName: cstring, dwDesiredAccess, dwShareMode: DWORD,
                     lpSecurityAttributes: pointer,
                     dwCreationDisposition, dwFlagsAndAttributes: DWORD,
                     hTemplateFile: THANDLE): THANDLE {.
       stdcall, dynlib: "kernel32", importc: "CreateFileA".}
+  proc DeleteFileA*(pathName: cstring): int32 {.
+    importc: "DeleteFileA", dynlib: "kernel32", stdcall.}
 
 proc SetEndOfFile*(hFile: THANDLE): WINBOOL {.stdcall, dynlib: "kernel32",
     importc: "SetEndOfFile".}


### PR DESCRIPTION
Modified os.removeFile to act correctly when deleting a file that doesn't exist (on windows).
