### PR TITLE
Fixed 'findStartNimrod' in koch.nim to return full path

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -111,7 +111,7 @@ proc findStartNimrod: string =
   result = "bin" / nimrod
   if ExistsFile(result): return
   for dir in split(getEnv("PATH"), PathSep):
-    if ExistsFile(dir / nimrod): return nimrod
+    if ExistsFile(dir / nimrod): return dir / nimrod
   when defined(Posix):
     const buildScript = "build.sh"
     if ExistsFile(buildScript): 


### PR DESCRIPTION
Trying to compile cloned nimrod from master on OS X, when I'd previously installed nimrod from downloaded zip-file, I got the error:

```
Thorr:Nimrod skyfex$ ./koch boot
Traceback (most recent call last)
koch.nim(281)            koch
koch.nim(142)            boot
koch.nim(135)            copyExe
os.nim(748)              copyFile
os.nim(205)              OSError
Error: unhandled exception: No such file or directory [EOS]
```

`findStartNimrod` searches the PATH for a directory with nimrod, but returns only "nimrod", and not the whole path. I think this commits should fix the issue. 
