### PR TITLE
Callers of csystem now return correct exit code

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1012,7 +1012,7 @@ proc execShellCmd*(command: string): int {.rtl, extern: "nos$1",
   ## the process has finished. To execute a program without having a
   ## shell involved, use the `execProcess` proc of the `osproc`
   ## module.
-  result = csystem(command)
+  result = csystem(command) shr 8
 
 # Environment handling cannot be put into RTL, because the ``envPairs``
 # iterator depends on ``environment``.

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -788,7 +788,7 @@ elif not defined(useNimRtl):
   proc csystem(cmd: cstring): cint {.nodecl, importc: "system".}
 
   proc execCmd(command: string): int =
-    result = csystem(command)
+    result = csystem(command) shr 8
 
   proc createFdSet(fd: var TFdSet, s: seq[PProcess], m: var int) = 
     FD_ZERO(fd)


### PR DESCRIPTION
Two procs in os and osproc now call `shr 8` on their return codes, so that the correct exit code is passed to their callers.
