### PR TITLE
Added better error messages for ill-formed generics

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -891,7 +891,6 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     localError(n.info, errNoGenericParamsAllowedForX, s.name.s)
     return newOrPrevType(tyError, prev, c)
   else:
-    internalAssert s.typ.kind == tyGenericBody
 
     var m = newCandidate(c, s, n)
     matches(c, n, copyTree(n), m)


### PR DESCRIPTION
code like string[int] or int[float] was producing internal compiler errors, I changed the InternalAssert to a localError that actually says why the code is wrong.
