### PR TITLE
use `.f` instead of `.16e` for floats

### DIFF
--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -254,6 +254,8 @@ proc nimFloatToStr(x: float): string {.compilerproc.} =
   var buf: array [0..59, char]
   c_sprintf(buf, "%#.f", x)
   result = $buf
+  if result[len(result)-1] == '.':
+    result.add("0")
 
 proc nimInt64ToStr(x: int64): string {.compilerRtl.} =
   result = newString(sizeof(x)*4)


### PR DESCRIPTION
It doesn't write a trailing zero, but it's better than floats being all
over your screen.
