### PR TITLE
Fix issue where iterating over an empty TSet or TOrderedSet results in a SIGSEVG

### DIFF
--- a/tests/collections/tsets.nim
+++ b/tests/collections/tsets.nim
@@ -1,9 +1,5 @@
-discard """
-  output: '''true
-true'''
-"""
-
 import sets
+
 var
   a = initSet[int]()
   b = initSet[int]()
@@ -13,5 +9,50 @@ for i in 0..5: a.incl(i)
 for i in 1..6: b.incl(i)
 for i in 0..5: c.incl($i)
 
-echo map(a, proc(x: int): int = x + 1) == b
-echo map(a, proc(x: int): string = $x) == c
+doAssert map(a, proc(x: int): int = x + 1) == b
+doAssert map(a, proc(x: int): string = $x) == c
+
+
+proc sizeOfSet[T](s: T): int =
+  ## Count by iterating over the items in the set
+  for i in s:
+    result += 1
+
+var
+  d: TSet[int]
+  e: TOrderedSet[int]
+
+doAssert(len(d) == 0 and sizeOfSet(d) == 0)
+doAssert(len(e) == 0 and sizeOfSet(e) == 0)
+
+d.incl(1)
+e.incl(1)
+
+d = initSet[int]()
+e = initOrderedSet[int]()
+
+doAssert(len(d) == 0 and sizeOfSet(d) == 0)
+doAssert(len(e) == 0 and sizeOfSet(e) == 0)
+
+d.incl(1)
+e.incl(1)
+
+doAssert(len(d) == 1 and sizeOfSet(d) == 1)
+doAssert(len(e) == 1 and sizeOfSet(e) == 1)
+
+
+var
+  f: TSet[int]
+  g: TOrderedSet[int]
+
+doAssert(not f.containsOrIncl(1))
+doAssert(not g.containsOrIncl(1))
+
+doAssert f.contains(1)
+doAssert g.contains(1)
+
+doAssert len(f) == 1
+doAssert len(g) == 1
+
+doAssert sizeOfSet(f) == len(f)
+doAssert sizeOfSet(g) == len(g)


### PR DESCRIPTION
To reproduce bug:

``` nimrod
import sets
var t: TSet[string]  # or TOrderedSet[string]
echo(t)
```

$ nimrod c -r b.nim 
config/nimrod.cfg(37, 2) Hint: added path: '/home/tjerk/.babel/pkgs/' [Path]
Hint: used config file '/home/tjerk/apps/Nimrod/config/nimrod.cfg' [Conf]
Hint: system [Processing]
Hint: b [Processing]
Hint: sets [Processing]
Hint: os [Processing]
Hint: strutils [Processing]
Hint: parseutils [Processing]
Hint: times [Processing]
Hint: posix [Processing]
Hint: hashes [Processing]
Hint: math [Processing]
gcc   -o /home/tjerk/dev/nimrod/bfair/b  /home/tjerk/dev/nimrod/bfair/nimcache/pure_math.o /home/tjerk/dev/nimrod/bfair/nimcache/pure_hashes.o /home/tjerk/dev/nimrod/bfair/nimcache/posix_posix.o /home/tjerk/dev/nimrod/bfair/nimcache/pure_times.o /home/tjerk/dev/nimrod/bfair/nimcache/pure_parseutils.o /home/tjerk/dev/nimrod/bfair/nimcache/pure_strutils.o /home/tjerk/dev/nimrod/bfair/nimcache/pure_os.o /home/tjerk/dev/nimrod/bfair/nimcache/collections_sets.o /home/tjerk/dev/nimrod/bfair/nimcache/Nimrod_system.o /home/tjerk/dev/nimrod/bfair/nimcache/bfair_b.o  -ldl -lm
Hint: operation successful (15733 lines compiled; 0.250 sec total; 22.225MB) [SuccessX]
/home/tjerk/dev/nimrod/bfair/b 
Traceback (most recent call last)
b.nim(5)                 b
sets.nim(40)             $
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
Error: execution of an external program failed
