### PR TITLE
Changed tests and tools to use 'discard' statements

### DIFF
--- a/compiler/c2nim/cparse.nim
+++ b/compiler/c2nim/cparse.nim
@@ -540,7 +540,7 @@ proc typeAtom(p: var TParser): PNode =
       if p.tok.s == "unsigned":
         isUnsigned = true
       elif p.tok.s == "signed" or p.tok.s == "int":
-        nil
+        discard
       else:
         add(x, p.tok.s)
       getTok(p, nil)
@@ -746,7 +746,7 @@ proc directDeclarator(p: var TParser, a: PNode, ident: ptr PNode): PNode =
       result = declarator(p, a, ident)
       eat(p, pxParRi, result)
   else:
-    nil
+    discard
   return parseTypeSuffix(p, a)
 
 proc declarator(p: var TParser, a: PNode, ident: ptr PNode): PNode =
@@ -1165,7 +1165,7 @@ proc enumSpecifier(p: var TParser): PNode =
 
 proc setBaseFlags(n: PNode, base: TNumericalBase) = 
   case base
-  of base10: nil
+  of base10: discard
   of base2: incl(n.flags, nfBase2)
   of base8: incl(n.flags, nfBase8)
   of base16: incl(n.flags, nfBase16)
@@ -1686,7 +1686,7 @@ proc switchStatement(p: var TParser): PNode =
       break
     of "case", "default":
       break
-    else: nil
+    else: discard
     addSon(result, statement(p))
   if sonsLen(result) == 0:
     # translate empty statement list to Nimrod's ``nil`` statement

--- a/compiler/c2nim/cpp.nim
+++ b/compiler/c2nim/cpp.nim
@@ -103,7 +103,7 @@ proc parseDefBody(p: var TParser, m: var TMacro, params: seq[string]) =
       m.body.add(tok)
     of pxDirConc: 
       # just ignore this token: this implements token merging correctly
-      nil
+      discard
     else:
       m.body.add(p.tok)
     # we do not want macro expansion here:
@@ -166,7 +166,7 @@ proc parseStmtList(p: var TParser): PNode =
     of pxDirectiveParLe, pxDirective: 
       case p.tok.s
       of "else", "endif", "elif": break
-    else: nil
+    else: discard
     addSon(result, statement(p))
   
 proc eatEndif(p: var TParser) =

--- a/compiler/pas2nim/paslex.nim
+++ b/compiler/pas2nim/paslex.nim
@@ -342,7 +342,7 @@ proc getSymbol(L: var TLexer, tok: var TToken) =
       h = h +% ord(c)
       h = h +% h shl 10
       h = h xor (h shr 6)
-    of '_': nil
+    of '_': discard
     else: break
     inc(pos)
   h = h +% h shl 3

--- a/compiler/pas2nim/pasparse.nim
+++ b/compiler/pas2nim/pasparse.nim
@@ -335,7 +335,7 @@ proc exprColonEqExprList(p: var TParser, kind, elemKind: TNodeKind,
 
 proc setBaseFlags(n: PNode, base: TNumericalBase) = 
   case base
-  of base10: nil
+  of base10: discard
   of base2: incl(n.flags, nfBase2)
   of base8: incl(n.flags, nfBase8)
   of base16: incl(n.flags, nfBase16)
@@ -466,7 +466,7 @@ proc lowestExprAux(p: var TParser, v: var PNode, limit: int): TTokKind =
         eat(p, pxCurlyDirRi)
         opNode.ident = getIdent("&")
       else: 
-        nil
+        discard
     of pxMinus: 
       if p.tok.xkind == pxPer: 
         getTok(p)
@@ -477,7 +477,7 @@ proc lowestExprAux(p: var TParser, v: var PNode, limit: int): TTokKind =
     of pxNeq: 
       opNode.ident = getIdent("!=")
     else: 
-      nil
+      discard
     skipCom(p, opNode)        # read sub-expression with higher priority
     nextop = lowestExprAux(p, v2, opPred)
     addSon(node, opNode)
@@ -505,7 +505,7 @@ proc fixExpr(n: PNode): PNode =
             (n.sons[2].kind in {nkCharLit, nkStrLit}): 
           n.sons[0].ident = getIdent("&") # fix operator
   else: 
-    nil
+    discard
   if not (n.kind in {nkEmpty..nkNilLit}): 
     for i in countup(0, sonsLen(n) - 1): result.sons[i] = fixExpr(n.sons[i])
   
@@ -603,7 +603,7 @@ proc parseStmtList(p: var TParser): PNode =
     of pxCurlyDirLe, pxStarDirLe: 
       if not isHandledDirective(p): break 
     else: 
-      nil
+      discard
     addSon(result, parseStmt(p))
   if sonsLen(result) == 1: result = result.sons[0]
   
@@ -732,7 +732,7 @@ proc parseRepeat(p: var TParser): PNode =
   addSon(b, c)
   addSon(a, b)
   if b.sons[0].kind == nkIdent and b.sons[0].ident.id == getIdent("false").id: 
-    nil
+    discard
   else: 
     addSon(s, a)
   addSon(result, s)
@@ -840,7 +840,7 @@ proc parseParam(p: var TParser): PNode =
     getTok(p)
     v = newNodeP(nkVarTy, p)
   else: 
-    nil
+    discard
   while true: 
     case p.tok.xkind
     of pxSymbol: a = createIdentNodeP(p.tok.ident, p)
@@ -1133,7 +1133,7 @@ proc parseRecordPart(p: var TParser): PNode =
 proc exSymbol(n: var PNode) = 
   case n.kind
   of nkPostfix: 
-    nil
+    discard
   of nkPragmaExpr: 
     exSymbol(n.sons[0])
   of nkIdent, nkAccQuoted: 
@@ -1154,7 +1154,7 @@ proc fixRecordDef(n: var PNode) =
     for i in countup(0, sonsLen(n) - 1): fixRecordDef(n.sons[i])
   of nkIdentDefs: 
     for i in countup(0, sonsLen(n) - 3): exSymbol(n.sons[i])
-  of nkNilLit, nkEmpty: nil
+  of nkNilLit, nkEmpty: discard
   else: internalError(n.info, "fixRecordDef(): " & $n.kind)
   
 proc addPragmaToIdent(ident: var PNode, pragma: PNode) = 
@@ -1191,7 +1191,7 @@ proc parseRecordBody(p: var TParser, result, definition: PNode) =
     if definition != nil: addPragmaToIdent(definition.sons[0], parseCommand(p))
     else: internalError(result.info, "anonymous record is not supported")
   else: 
-    nil
+    discard
   opt(p, pxSemicolon)
   skipCom(p, result)
 
@@ -1399,7 +1399,7 @@ proc fixVarSection(p: var TParser, counter: PNode) =
 
 proc exSymbols(n: PNode) = 
   case n.kind
-  of nkEmpty..nkNilLit: nil
+  of nkEmpty..nkNilLit: discard
   of nkProcDef..nkIteratorDef: exSymbol(n.sons[namePos])
   of nkWhenStmt, nkStmtList: 
     for i in countup(0, sonsLen(n) - 1): exSymbols(n.sons[i])
@@ -1410,7 +1410,7 @@ proc exSymbols(n: PNode) =
       exSymbol(n.sons[i].sons[0])
       if n.sons[i].sons[2].kind == nkObjectTy: 
         fixRecordDef(n.sons[i].sons[2])
-  else: nil
+  else: discard
 
 proc parseBegin(p: var TParser, result: PNode) = 
   getTok(p)

--- a/examples/htmlrefs.nim
+++ b/examples/htmlrefs.nim
@@ -36,7 +36,7 @@ block mainLoop:
               case x.kind
               of xmlEof: break mainLoop
               of xmlElementClose: break
-              else: nil
+              else: discard
             x.next() # skip ``xmlElementClose``
             # now we have the description for the ``a`` element
             var desc = ""

--- a/tests/ambsym/mambsym1.nim
+++ b/tests/ambsym/mambsym1.nim
@@ -7,4 +7,4 @@ type
 proc ha() =
   var
     x: TExport # no error
-  nil
+  discard

--- a/tests/ambsym/mambsys1.nim
+++ b/tests/ambsym/mambsys1.nim
@@ -4,4 +4,4 @@ type
   TExport* = enum x, y, z
 
 proc foo*(x: int) =
-  nil
+  discard

--- a/tests/ambsym/mambsys2.nim
+++ b/tests/ambsym/mambsys2.nim
@@ -1,4 +1,4 @@
 type
   TExport* = enum x, y, z # exactly the same type!
 
-proc foo*(x: int) = nil
+proc foo*(x: int) = discard

--- a/tests/casestmt/tcasestm.nim
+++ b/tests/casestmt/tcasestm.nim
@@ -19,8 +19,8 @@ of eB, eC: write(stdout, "b or c")
 case x
 of "Andreas", "Rumpf": write(stdout, "Hallo Meister!")
 of "aa", "bb": write(stdout, "Du bist nicht mein Meister")
-of "cc", "hash", "when": nil
-of "will", "it", "finally", "be", "generated": nil
+of "cc", "hash", "when": discard
+of "will", "it", "finally", "be", "generated": discard
 
 var z = case i
   of 1..5, 8, 9: "aa"

--- a/tests/concurrency/tnodeadlocks.nim
+++ b/tests/concurrency/tnodeadlocks.nim
@@ -12,7 +12,7 @@ var
   thr: array [0..5, TThread[tuple[a, b: int]]]
   L, M, N: TLock
 
-proc doNothing() = nil
+proc doNothing() = discard
 
 proc threadFunc(interval: tuple[a, b: int]) {.thread.} = 
   doNothing()

--- a/tests/destructor/tdictdestruct.nim
+++ b/tests/destructor/tdictdestruct.nim
@@ -6,7 +6,7 @@ type
   PDict[TK, TV] = ref TDict[TK, TV]
 
 proc fakeNew[T](x: var ref T, destroy: proc (a: ref T) {.nimcall.}) =
-  nil
+  discard
 
 proc destroyDict[TK, TV](a: PDict[TK, TV]) =
     return

--- a/tests/generics/tgeneric3.nim
+++ b/tests/generics/tgeneric3.nim
@@ -32,7 +32,7 @@ const
 proc len[T,D] (n:PNode[T,D]): Int {.inline.} =
   return n.Count
 
-proc clean[T: TOrdinal|TNumber](o: var T) {.inline.} = nil
+proc clean[T: TOrdinal|TNumber](o: var T) {.inline.} = discard
 
 proc clean[T: string|seq](o: var T) {.inline.} =
   o = nil
@@ -98,7 +98,7 @@ proc DeleteItem[T,D] (n: PNode[T,D], x: Int): PNode[T,D] {.inline.} =
     of cLen3 : setLen(n.slots, cLen3)
     of cLenCenter : setLen(n.slots, cLenCenter)
     of cLen4 : setLen(n.slots, cLen4)
-    else: nil
+    else: discard
     Result = n
 
   else :
@@ -232,7 +232,7 @@ proc InsertItem[T,D](APath: RPath[T,D], ANode:PNode[T,D], AKey: T, AValue: D) =
   of cLen3: setLen(APath.Nd.slots, cLenCenter)
   of cLenCenter: setLen(APath.Nd.slots, cLen4)
   of cLen4: setLen(APath.Nd.slots, cLenMax)
-  else: nil
+  else: discard
   for i in countdown(APath.Nd.Count.int - 1, x + 1): shallowCopy(APath.Nd.slots[i], APath.Nd.slots[i - 1])
   APath.Nd.slots[x] = setItem(AKey, AValue, ANode)
 

--- a/tests/lookups/tredef.nim
+++ b/tests/lookups/tredef.nim
@@ -1,28 +1,28 @@
-template foo(a: int, b: string) = nil
+template foo(a: int, b: string) = discard
 foo(1, "test")
 
-proc bar(a: int, b: string) = nil
+proc bar(a: int, b: string) = discard
 bar(1, "test")
 
 template foo(a: int, b: string) = bar(a, b)
 foo(1, "test")
 
 block:
-  proc bar(a: int, b: string) = nil
-  template foo(a: int, b: string) = nil
+  proc bar(a: int, b: string) = discard
+  template foo(a: int, b: string) = discard
   foo(1, "test")
   bar(1, "test")
   
 proc baz =
-  proc foo(a: int, b: string) = nil
+  proc foo(a: int, b: string) = discard
   proc foo(b: string) =
-    template bar(a: int, b: string) = nil
+    template bar(a: int, b: string) = discard
     bar(1, "test")
     
   foo("test")
 
   block:
-    proc foo(b: string) = nil
+    proc foo(b: string) = discard
     foo("test")
     foo(1, "test")
 

--- a/tests/method/tmethods1.nim
+++ b/tests/method/tmethods1.nim
@@ -14,8 +14,8 @@ type
   TSomethingElse = object 
   PSomethingElse = ref TSomethingElse
 
-method foo(a: PNode, b: PSomethingElse) = nil
-method foo(a: PNodeFoo, b: PSomethingElse) = nil
+method foo(a: PNode, b: PSomethingElse) = discard
+method foo(a: PNodeFoo, b: PSomethingElse) = discard
 
 var o: TObject
 o.somethin()

--- a/tests/overload/toverwr.nim
+++ b/tests/overload/toverwr.nim
@@ -5,7 +5,7 @@ discard """
 # Test the overloading resolution in connection with a qualifier
 
 proc write(t: TFile, s: string) =
-  nil # a nop
+  discard # a nop
 
 system.write(stdout, "hello")
 #OUT hello

--- a/tests/patterns/targlist.nim
+++ b/tests/patterns/targlist.nim
@@ -2,7 +2,7 @@ discard """
   output: "12false3ha"
 """
 
-proc f(x: varargs[string, `$`]) = nil
+proc f(x: varargs[string, `$`]) = discard
 template optF{f(X)}(x: varargs[expr]) = 
   writeln(stdout, x)
 

--- a/tests/range/tsubrange2.nim
+++ b/tests/range/tsubrange2.nim
@@ -8,7 +8,7 @@ type
   TRange = range[0..40]
   
 proc p(r: TRange) =
-  nil
+  discard
   
 var
   r: TRange

--- a/tests/range/tsubrange3.nim
+++ b/tests/range/tsubrange3.nim
@@ -8,7 +8,7 @@ type
   TRange = range[0..40]
   
 proc p(r: TRange) =
-  nil
+  discard
   
 var
   r: TRange

--- a/tests/sets/tsets.nim
+++ b/tests/sets/tsets.nim
@@ -51,12 +51,12 @@ else: write(stdout, "BUG: F ist nicht in s!\n")
 a = {} #{'a'..'z'}
 for x in low(TAZ) .. high(TAZ):
   incl(a, x)
-  if x in a: nil
+  if x in a: discard
   else: write(stdout, "BUG: something not in a!\n")
 
 for x in low(TTokTypeRange) .. high(TTokTypeRange):
   if x in tokTypes:
-    nil
+    discard
     #writeln(stdout, "the token '$1' is in the set" % repr(x))
 
 #OUT Ha ein F ist in s!

--- a/tests/stdlib/tircbot.nim
+++ b/tests/stdlib/tircbot.nim
@@ -183,7 +183,7 @@ type
     channel: string
     timestamp: TTime
     case kind*: TSeenType
-    of PSeenJoin: nil
+    of PSeenJoin: discard
     of PSeenPart, PSeenQuit, PSeenMsg:
       msg: string
     of PSeenNick:
@@ -200,7 +200,7 @@ proc setSeen(d: TDb, s: TSeen) =
   var hashToSet = @[("type", $s.kind.int), ("channel", s.channel),
                     ("timestamp", $s.timestamp.int)]
   case s.kind
-  of PSeenJoin: nil
+  of PSeenJoin: discard
   of PSeenPart, PSeenMsg, PSeenQuit:
     hashToSet.add(("msg", s.msg))
   of PSeenNick:
@@ -338,7 +338,7 @@ proc hubConnect(state: PState) =
 
 proc handleIrc(irc: PAsyncIRC, event: TIRCEvent, state: PState) =
   case event.typ
-  of EvConnected: nil
+  of EvConnected: discard
   of EvDisconnected:
     while not state.ircClient.isConnected:
       try:
@@ -424,7 +424,7 @@ proc handleIrc(irc: PAsyncIRC, event: TIRCEvent, state: PState) =
       seenNick.newNick = event.params[0]
       state.database.setSeen(seenNick)
     else:
-      nil # TODO: ?
+      discard # TODO: ?
 
 proc open(port: TPort = TPort(5123)): PState =
   var res: PState

--- a/tests/stdlib/tmath2.nim
+++ b/tests/stdlib/tmath2.nim
@@ -1,7 +1,7 @@
 # tests for the interpreter
 
 proc loops(a: var int) =
-  nil
+  discard
   #var
   #  b: int
   #b = glob

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -7,6 +7,6 @@ proc walkDirTree(root: string) =
     case k 
     of pcFile, pcLinkToFile: echo(f)
     of pcDir: walkDirTree(f)
-    of pcLinkToDir: nil
+    of pcLinkToDir: discard
 
 walkDirTree(".")

--- a/tests/stdlib/tpegs.nim
+++ b/tests/stdlib/tpegs.nim
@@ -72,7 +72,7 @@ type
     rule: TNode                   ## the rule that the symbol refers to
   TNode {.final, shallow.} = object
     case kind: TPegKind
-    of pkEmpty..pkWhitespace: nil
+    of pkEmpty..pkWhitespace: discard
     of pkTerminal, pkTerminalIgnoreCase, pkTerminalIgnoreStyle: term: string
     of pkChar, pkGreedyRepChar: ch: char
     of pkCharChoice, pkGreedyRepSet: charChoice: ref set[char]
@@ -123,7 +123,7 @@ proc add(d: var TPeg, s: TPeg) {.inline.} = add(d.sons, s)
 proc copyPeg(a: TPeg): TPeg = 
   result.kind = a.kind
   case a.kind
-  of pkEmpty..pkWhitespace: nil
+  of pkEmpty..pkWhitespace: discard
   of pkTerminal, pkTerminalIgnoreCase, pkTerminalIgnoreStyle: 
     result.term = a.term
   of pkChar, pkGreedyRepChar: 
@@ -229,7 +229,7 @@ when false:
     case a.kind
     of pkEmpty, pkAny, pkAnyRune, pkGreedyAny, pkNewLine, pkTerminal,
        pkTerminalIgnoreCase, pkTerminalIgnoreStyle, pkChar, pkGreedyRepChar,
-       pkCharChoice, pkGreedyRepSet: nil
+       pkCharChoice, pkGreedyRepSet: discard
     of pkNonTerminal: return true
     else:
       for i in 0..a.sons.len-1:
@@ -318,7 +318,7 @@ proc backrefIgnoreStyle*(index: range[1..MaxSubPatterns]): TPeg {.
 
 proc spaceCost(n: TPeg): int =
   case n.kind
-  of pkEmpty: nil
+  of pkEmpty: discard
   of pkTerminal, pkTerminalIgnoreCase, pkTerminalIgnoreStyle, pkChar,
      pkGreedyRepChar, pkCharChoice, pkGreedyRepSet, 
      pkAny..pkWhitespace, pkGreedyAny:
@@ -1111,7 +1111,7 @@ proc handleHexChar(c: var TPegLexer, xi: var int) =
   of 'A'..'F': 
     xi = (xi shl 4) or (ord(c.buf[c.bufpos]) - ord('A') + 10)
     inc(c.bufpos)
-  else: nil
+  else: discard
 
 proc getEscapedChar(c: var TPegLexer, tok: var TToken) = 
   inc(c.bufpos)
@@ -1341,7 +1341,7 @@ proc getTok(c: var TPegLexer, tok: var TToken) =
       of "i": tok.modifier = modIgnoreCase
       of "y": tok.modifier = modIgnoreStyle
       of "v": tok.modifier = modVerbatim
-      else: nil
+      else: discard
       setLen(tok.literal, 0)
       if c.buf[c.bufpos] == '$':
         getDollar(c, tok)
@@ -1488,7 +1488,7 @@ proc primary(p: var TPegParser): TPeg =
   of tkCurlyAt:
     getTok(p)
     return !*\primary(p).token(p)
-  else: nil
+  else: discard
   case p.tok.kind
   of tkIdentifier:
     if p.identIsVerbatim: 

--- a/tests/table/ttableconstr.nim
+++ b/tests/table/ttableconstr.nim
@@ -1,7 +1,7 @@
 # Test if the new table constructor syntax works:
 
 template ignoreExpr(e: expr): stmt {.immediate.} =
-  nil
+  discard
 
 # test first class '..' syntactical citizen:  
 ignoreExpr x <> 2..4

--- a/tests/typerel/typalias.nim
+++ b/tests/typerel/typalias.nim
@@ -9,7 +9,7 @@ proc init: TYourObj =
   result.y = -1
   
 proc f(x: var TYourObj) =
-  nil
+  discard
   
 var m: TMyObj = init()
 f(m)

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -249,7 +249,7 @@ proc walker(dir: string) =
     of pcDir: 
       if optRecursive in options:
         walker(path)
-    else: nil
+    else: discard
   if existsFile(dir): processFile(dir)
 
 proc writeHelp() = 


### PR DESCRIPTION
Changed nearly all of the tests and tools run by "testament" to use 'discard' instead of the deprecated 'nil' for empty code blocks.
The only instance where I couldn't change nil was in drdobbs_examples - something to do with a macro generating stuff.
