### PR TITLE
Checks that exported symbols are valid C identifiers. Refs #800.

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -105,7 +105,7 @@ type
     errThreadvarCannotInit, errWrongSymbolX, errIllegalCaptureX,
     errXCannotBeClosure, errXMustBeCompileTime,
     errCannotInferTypeOfTheLiteral,
-    errBadExport, errUser
+    errUser,
     warnCannotOpenFile, 
     warnOctalEscape, warnXIsNeverRead, warnXmightNotBeenInit, 
     warnDeprecated, warnConfigDeprecated,
@@ -350,7 +350,6 @@ const
     errXCannotBeClosure: "'$1' cannot have 'closure' calling convention",
     errXMustBeCompileTime: "'$1' can only be used in compile-time context",
     errCannotInferTypeOfTheLiteral: "cannot infer the type of the $1",
-    errBadExport: "invalid exported symbol, $1",
     errUser: "$1", 
     warnCannotOpenFile: "cannot open \'$1\' [CannotOpenFile]",
     warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored [OctalEscape]", 


### PR DESCRIPTION
Examples of error messages:

```
read.nim(5, 21) Error: invalid exported symbol, can't be zero length
read.nim(5, 21) Error: invalid exported symbol, '0penpeitor' can't start with a number
read.nim(5, 21) Error: invalid exported symbol, 'peñpeitor' contains bad character at byte 2
```
