### PR TITLE
pegs.findAll iterator fix

### DIFF
--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -838,9 +838,9 @@ iterator findAll*(s: string, pattern: TPeg, start = 0): string =
     var L = rawMatch(s, pattern, i, c)
     if L < 0:
       inc(i, 1)
-      continue
-    yield substr(s, i, i+L-1)
-    inc(i, L)
+    else:
+      yield substr(s, i, i+L-1)
+      inc(i, L)
     
 proc findAll*(s: string, pattern: TPeg, start = 0): seq[string] {.
   nosideEffect, rtl, extern: "npegs$1".} = 


### PR DESCRIPTION
Modified the findAll iterator so that it continues looking for a match within the input string (bug?).
