### PR TITLE
osproc: MacOSX workaround for lack of execvpe

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -747,7 +747,7 @@ elif not defined(useNimRtl):
     var pid: TPid
     var dataCopy = data
 
-    if defined(useClone):
+    when defined(useClone):
       const stackSize = 65536
       let stackEnd = cast[clong](alloc(stackSize))
       let stack = cast[pointer](stackEnd + stackSize)


### PR DESCRIPTION
MacOS X is the only Posix system (supported by Nimrod) that doesn't have execvpe. This code works on Linux, but I don't have any Mac to test on.

If you read this and happen to use MacOS, please test this patch with the following code:

```
import osproc, strtabs
var t: PStringTable = newStringTable({"foo": "bar"})
let i = startProcess("/usr/bin/env", options={poParentStreams}, env=t)
let code = i.waitForExit()
echo code
```

should return:

```
foo=bar
0
```
