### PR TITLE
Dynamic Babel package list in library index (lib.html).

### DIFF
--- a/doc/lib.txt
+++ b/doc/lib.txt
@@ -36,7 +36,7 @@ Core
 
 * `unsigned <unsigned.html>`_
   This module implements basic arithmetic operators for unsigned integers.
-  To discourage users from using unsigned integers, it's not part 
+  To discourage users from using unsigned integers, it's not part
   of ``system``, but an extra import.
 
 * `threads <threads.html>`_
@@ -44,7 +44,7 @@ Core
   import it explicitly.
 
 * `channels <channels.html>`_
-  Nimrod message passing support for threads. **Note**: This is part of the 
+  Nimrod message passing support for threads. **Note**: This is part of the
   system module. Do not import it explicitly.
 
 * `locks <locks.html>`_
@@ -54,8 +54,8 @@ Core
   Contains the AST API and documentation of Nimrod for writing macros.
 
 * `typeinfo <typeinfo.html>`_
-  Provides (unsafe) access to Nimrod's run time type information. 
-  
+  Provides (unsafe) access to Nimrod's run time type information.
+
 * `actors <actors.html>`_
   Actor support for Nimrod; implemented as a layer on top of the threads and
   channels modules.
@@ -104,9 +104,9 @@ String handling
 
 * `unicode <unicode.html>`_
   This module provides support to handle the Unicode UTF-8 encoding.
-  
+
 * `encodings <encodings.html>`_
-  Converts between different character encodings. On UNIX, this uses 
+  Converts between different character encodings. On UNIX, this uses
   the ``iconv`` library, on Windows the Windows API.
 
 * `pegs <pegs.html>`_
@@ -153,7 +153,7 @@ Generic Operating System Services
   may provide other implementations for this standard stream interface.
 
 * `marshal <marshal.html>`_
-  Contains procs for serialization and deseralization of arbitrary Nimrod 
+  Contains procs for serialization and deseralization of arbitrary Nimrod
   data structures.
 
 * `terminal <terminal.html>`_
@@ -162,7 +162,7 @@ Generic Operating System Services
   sequences and does not depend on any other module.
 
 * `memfiles <memfiles.html>`_
-  This module provides support for memory mapped files (Posix's ``mmap``) 
+  This module provides support for memory mapped files (Posix's ``mmap``)
   on the different operating systems.
 
 * `fsmonitor <fsmonitor.html>`_
@@ -206,7 +206,7 @@ Internet Protocols and Support
   This module implements a simple HTTP client.
 
 * `smtp <smtp.html>`_
-  This module implement a simple SMTP client. 
+  This module implement a simple SMTP client.
 
 * `irc <irc.html>`_
   This module implements an asynchronous IRC client.
@@ -299,7 +299,7 @@ XML Processing
   This module parses an HTML document and creates its XML tree representation.
 
 * `htmlgen <htmlgen.html>`_
-  This module implements a simple XML and HTML code 
+  This module implements a simple XML and HTML code
   generator. Each commonly used HTML tag has a corresponding macro
   that generates a string with its HTML representation.
 
@@ -334,7 +334,7 @@ Miscellaneous
 
 * `oids <oids.html>`_
   An OID is a global ID that consists of a timestamp,
-  a unique counter and a random value. This combination should suffice to 
+  a unique counter and a random value. This combination should suffice to
   produce a globally distributed unique ID. This implementation was extracted
   from the Mongodb interface and it thus binary compatible with a Mongo OID.
 
@@ -387,7 +387,7 @@ Database support
   for other databases too.
 
 * `db_mongo <db_mongo.html>`_
-  A higher level **mongodb** wrapper. 
+  A higher level **mongodb** wrapper.
 
 
 Other
@@ -411,7 +411,7 @@ Other
   Web like loading the contents of a Web page from an URL.
 
 * `ssl <ssl.html>`_
-  This module provides an easy to use sockets-style 
+  This module provides an easy to use sockets-style
   Nimrod interface to the OpenSSL library.
 
 * `rdstdin <rdstdin.html>`_
@@ -548,5 +548,19 @@ Data Compression and Archiving
 Scientific computing
 --------------------
 
-* `libsvm <libsvm.html>`_ 
+* `libsvm <libsvm.html>`_
   Low level wrapper for `lib svm <http://www.csie.ntu.edu.tw/~cjlin/libsvm/>`_.
+
+Babel
+====================
+
+Babel is a package manager for the Nimrod programming language.
+For instructions on how to install Babel packages see
+`its README <https://github.com/nimrod-code/babel>`_.
+
+.. raw:: html
+
+  <script src="//atomshare.net/nimrod/pkglist.js"></script>
+  <noscript>
+  <a href="//atomshare.net/nimrod/pkglist.html">Package list</a>
+  </noscript>


### PR DESCRIPTION
- uses Javascript to fetch it from //atomshare.net/nimrod/pkglist.js
- this list is generated by https://github.com/zielmicha/babel-pkglist
- I couldn't make commit without editing random trailing whitespace in lib.txt - even
  `git apply` changes it.
