### PR TITLE
Provide zlib version explicitly on Linux.

### DIFF
--- a/lib/wrappers/zip/zlib.nim
+++ b/lib/wrappers/zip/zlib.nim
@@ -7,7 +7,7 @@ when defined(windows):
 elif defined(macosx):
   const libz = "libz.dylib"
 else:
-  const libz = "libz.so"
+  const libz = "libz.so.1"
 
 type
   Uint* = int32


### PR DESCRIPTION
- workaround for Gentoo (#987),
- also, it's a good practice to provide ABI version in calls to dlopen,
  so if zlib ever changes ABI, wrappers won't break silently.
