### PR TITLE
serveFile with Content-Type based on MIME type from extension

### DIFF
--- a/lib/pure/httpserver.nim
+++ b/lib/pure/httpserver.nim
@@ -60,7 +60,6 @@ when false:
     send(client, "<P>Error prohibited CGI execution." & wwwNL)
 
 proc headers(client: TSocket, filename: string) =
-  # XXX could use filename to determine file type
   send(client, "HTTP/1.1 200 OK" & wwwNL)
   send(client, ServerSig)
   var fname = filename


### PR DESCRIPTION
My browsers weren't loading up styles when I used serveFile from httpserver because the Content Type for the .css files was sent as text/html.  This uses the mimetypes module to look up the content type.
