### PR TITLE
Add token position to `nimrod scan`

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -173,6 +173,7 @@ proc prettyTok*(tok: TToken): string =
   else: result = tokToStr(tok)
   
 proc printTok*(tok: TToken) = 
+  write(stdout, tok.line, ":", tok.col, "\t")
   write(stdout, TokTypeToStr[tok.tokType])
   write(stdout, " ")
   writeln(stdout, tokToStr(tok))


### PR DESCRIPTION
A block of the format "linenum:col\t' is added to the start of each token that is printed. This should make the information outputted more helpful.
