### PR TITLE
Calling randomize() again within 1 second will now provide a different seed

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -20,6 +20,8 @@
 when defined(Posix) and not defined(haiku):
   {.passl: "-lm".}
 
+import times
+
 const
   PI* = 3.1415926535897932384626433 ## the circle constant PI (Ludolph's number)
   E* = 2.71828182845904523536028747 ## Euler's number
@@ -201,7 +203,7 @@ when not defined(JS):
       result = drand48() * max
     
   proc randomize() =
-    randomize(gettime(nil))
+    randomize(cast[int](epochTime()))
 
   proc randomize(seed: int) =
     srand(cint(seed))

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -23,6 +23,13 @@ suite "random int":
       rand = random(100..1000)
       check rand < 1000
       check rand >= 100
+  test "randomize() again gives new numbers":      
+    randomize()
+    var rand1 = random(1000000)
+    randomize()
+    var rand2 = random(1000000)
+    check rand1 != rand2
+    
 
 suite "random float":
   test "there might be some randomness":
@@ -45,3 +52,10 @@ suite "random float":
       rand = random(100.0..1000.0)
       check rand < 1000.0
       check rand >= 100.0
+  test "randomize() again gives new numbers":      
+    randomize()
+    var rand1:float = random(1000000.0)
+    randomize()
+    var rand2:float = random(1000000.0)
+    check rand1 != rand2
+


### PR DESCRIPTION
To generate a seed for randomize() with no seed specified, the existing code uses gettime() which is the C time() function that uses only seconds resolution.  So calling randomize() again within one second gives the same seed and the same set of numbers.  This causes a problem in cases where randomize() is called again at about the same time.  For example, I was trying to generate a random API key in a command line program, and if I ran my program twice in quick succession the same API key was generated.

This changes the randomize() function to use epochTime from the times module for the seed.  epochTime has a higher resolution than gettime.  Testing on my computer now always results in a new seed/set of random numbers when randomize() is called in quick succession.
