### PR TITLE
Add renderRstToJson in docutils

### DIFF
--- a/lib/packages/docutils/rstast.nim
+++ b/lib/packages/docutils/rstast.nim
@@ -9,7 +9,7 @@
 
 ## This module implements an AST for the `reStructuredText`:idx: parser.
 
-import strutils
+import strutils, json
 
 type
   TRstNodeKind* = enum        ## the possible node kinds of an PRstNode
@@ -286,28 +286,27 @@ proc renderRstToRst*(n: PRstNode, result: var string) =
   var d: TRenderContext
   renderRstToRst(d, n, result)
 
+proc renderRstToJsonNode(node: PRstNode): PJsonNode =
+  result =
+    %[
+      (key: "kind", val: %($node.kind)),
+      (key: "level", val: %BiggestInt(node.level))
+     ]
+  if node.text != nil:
+    result.add("text", %node.text)
+  if node.sons != nil and len(node.sons) > 0:
+    var accm = newSeq[PJsonNode](len(node.sons))
+    for i, son in node.sons:
+      accm[i] = renderRstToJsonNode(son)
+    result.add("sons", %accm)
+
 proc renderRstToJson*(node: PRstNode): string =
   ## Writes the given RST node as JSON that is in the form
-  ## :: code-block
+  ## :: 
   ##   {
   ##     "kind":string node.kind,
   ##     "text":optional string node.text,
   ##     "level":optional int node.level,
   ##     "sons":optional node array
   ##   }
-  result = ""
-  result.add("{\"kind\":\"" & $ node.kind & "\",")
-  if node.text != Nil:
-    # XXX Json spec requires control charecters be escaped as \uXXXX,
-    # strutils.escape writes them as \uXX
-    result.add("\"text\":" & node.text.escape & ",")
-  result.add("\"level\":" & $ node.level)
-  if node.sons == nil or len(node.sons) == 0:
-    result.add("}")
-  else:
-    result.add(",\"sons\":[")
-    for i, son in node.sons:
-      result.add(renderRstToJson(son))
-      if i < len(node.sons) - 1:
-        result.add(",")
-    result.add("]}")
+  renderRstToJsonNode(node).pretty


### PR DESCRIPTION
Added a method to render RST ASTs into JSON for debugging. It is more useful than `renderRstToRst` because it includes all the information that the AST contains.

Example output:
`{"kind":"rnInner","level":0,"sons":[{"kind":"rnInner","level":0,"sons":[{"kind":"rnLeaf","text":"Rotates","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"the","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"integer","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnInlineLiteral","level":0,"sons":[{"kind":"rnLeaf","text":"i","level":0}]},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"right","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnInlineLiteral","level":0,"sons":[{"kind":"rnLeaf","text":"distance","level":0}]},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"times","level":0},{"kind":"rnLeaf","text":".","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"This","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"is","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"an","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"unsigned","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"operation","level":0},{"kind":"rnLeaf","text":",","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"the","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"sign","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"bit","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"is","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"rotated","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"like","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"any","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"other","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"bit","level":0},{"kind":"rnLeaf","text":".","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"..","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"code","level":0},{"kind":"rnLeaf","text":"-","level":0},{"kind":"rnLeaf","text":"block","level":0},{"kind":"rnLeaf","text":"::","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"Nimrod","level":0}]},{"kind":"rnBlockQuote","level":0,"sons":[{"kind":"rnInner","level":0,"sons":[{"kind":"rnLeaf","text":"assert","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"(","level":0},{"kind":"rnLeaf","text":"0b0010","level":0},{"kind":"rnLeaf","text":"_","level":0},{"kind":"rnLeaf","text":"0000","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"rotr","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"4","level":0},{"kind":"rnLeaf","text":")","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"==","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"0b0000","level":0},{"kind":"rnLeaf","text":"_","level":0},{"kind":"rnLeaf","text":"0010","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"assert","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"(","level":0},{"kind":"rnLeaf","text":"-","level":0},{"kind":"rnLeaf","text":"0b000","level":0},{"kind":"rnLeaf","text":"_","level":0},{"kind":"rnLeaf","text":"0000i8","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"rotr","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"2","level":0},{"kind":"rnLeaf","text":")","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"==","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"0b0010","level":0},{"kind":"rnLeaf","text":"_","level":0},{"kind":"rnLeaf","text":"0000i8","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"assert","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"(","level":0},{"kind":"rnLeaf","text":"0b0000","level":0},{"kind":"rnLeaf","text":"_","level":0},{"kind":"rnLeaf","text":"0010u8","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"rotr","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"2","level":0},{"kind":"rnLeaf","text":")","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"==","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"0b1000","level":0},{"kind":"rnLeaf","text":"_","level":0},{"kind":"rnLeaf","text":"0000u8","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"assert","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"(","level":0},{"kind":"rnLeaf","text":"781652","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"rotr","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"-","level":0},{"kind":"rnLeaf","text":"2","level":0},{"kind":"rnLeaf","text":")","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"==","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"(","level":0},{"kind":"rnLeaf","text":"781652","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"rotl","level":0},{"kind":"rnLeaf","text":" ","level":0},{"kind":"rnLeaf","text":"2","level":0},{"kind":"rnLeaf","text":")","level":0}]}]}]}`

The text element is not escaped exactly as specified as the JSON specifications, so JSON parsers will not parse `\uXX` back into its character, but I don't see this as being an issue for debugging.
