### PR TITLE
Fix for #180 and #1059

### DIFF
--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -120,23 +120,18 @@ proc newModule(fileIdx: int32): PSym =
   if not isNimrodIdentifier(result.name.s):
     rawMessage(errInvalidModuleName, result.name.s)
     
-  for module in gCompiledModules:
-    if module != nil and result.name.s == module.name.s:
-      rawMessage(errInvalidModuleName, result.name.s)
-
   result.info = newLineInfo(fileIdx, 1, 1)
   result.owner = newSym(skPackage, getIdent(getPackageName(filename)), nil,
                         result.info)
   result.position = fileIdx
   
+  for module in gCompiledModules:
+    if module != nil and result.name.s == module.name.s and result.owner == module.owner:
+      rawMessage(errInvalidModuleName, result.name.s)
+
   growCache gMemCacheData, fileIdx
   growCache gCompiledModules, fileIdx
   gCompiledModules[result.position] = result
-<<<<<<< HEAD
-  
-=======
- 
->>>>>>> 739b194... Fix #180 and #1059 by checking for duplicate module names
   incl(result.flags, sfUsed)
   initStrTable(result.tab)
   strTableAdd(result.tab, result) # a module knows itself


### PR DESCRIPTION
Each time a module is created, it is checked to make sure that the name isn't already being used.
