### PR TITLE
Avoid idetools crash on nil parameters.

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -253,6 +253,7 @@ proc findUsages(node: PNode, s: PSym) =
     lastLineInfo = node.info
 
 proc findDefinition(node: PNode, s: PSym) =
+  if node.isNil or s.isNil: return
   if isTracked(node.info, s.name.s.len):
     suggestWriteln(symToStr(s, isLocal=false, sectionDef))
     suggestQuit()


### PR DESCRIPTION
Fixes the following case:

```
$ cd lib/impure
$ nimrod idetools --def --track:"zipfiles.nim,103,5" "zipfiles.nim"
```
