### PR TITLE
Adds missing import.

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -75,7 +75,7 @@
 ## constructor should be used for this purpose. However,
 ## currently only basic authentication is supported.
 
-import sockets, strutils, parseurl, parseutils, strtabs, base64
+import sockets, strutils, parseurl, parseutils, strtabs, base64, os
 import asyncnet, asyncdispatch
 import rawsockets
 


### PR DESCRIPTION
Without the import the following file:

``` nimrod
import httpclient
```

fails to compile:

```
lib/pure/httpclient.nim(291, 25) Error: undeclared identifier: 'osError'
```
