### PR TITLE
Clarify newFileSize & mappedSize params in memfiles.open() docs

### DIFF
--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -60,7 +60,6 @@ when not defined(memProfiler):
     else: interval = intervalInUs * 1000 - tickCountCorrection
   
 when withThreads:
-  import locks
   var
     profilingLock: TLock
 


### PR DESCRIPTION
Add an example to memfiles.open() that clarifies: 
1) To use newFileSize and not mappedSize when creating a new mmap file; and
2) That passing a value other than -1 for newFileSize for existing mmap files will fail.

It may be worth revisiting this and changing the behavior to ignore the newFileSize param if the file exists (currently, this check is not performed and various flags passed to system.open() are modified if newFileSize != -1, causing an exception when the file already exists).
