### PR TITLE
turned on error reporting in typeclasses

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -479,7 +479,7 @@ proc matchUserTypeClass*(c: PContext, m: var TCandidate,
     dummyParam.typ = dummyType
     addDecl(c, dummyParam)
 
-  var checkedBody = c.semTryExpr(c, body.n[3].copyTree, bufferErrors = false)
+  var checkedBody = c.semTryExpr(c, body.n[3].copyTree, bufferErrors = true)
   m.errors = bufferedMsgs
   clearBufferedMsgs()
   if checkedBody == nil: return isNone


### PR DESCRIPTION
Flipped a switch that turns on error printing during typeclass semantic analysis, this would have been useful to me several times in the past. As far as I can tell this does not cause any additional tests to fail.
