### PR TITLE
added .ilk files to the koch clean list

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -167,7 +167,7 @@ const
   cleanExt = [
     ".ppu", ".o", ".obj", ".dcu", ".~pas", ".~inc", ".~dsk", ".~dpr",
     ".map", ".tds", ".err", ".bak", ".pyc", ".exe", ".rod", ".pdb", ".idb",
-    ".idx"
+    ".idx", ".ilk"
   ]
   ignore = [
     ".bzrignore", "nimrod", "nimrod.exe", "koch", "koch.exe", ".gitignore"


### PR DESCRIPTION
ilk files are MSVC's incremental link information files. These are created by MSVC so that the linker need not relink the entire object file if only one part changes. These are compiler artifacts and should probably be cleaned by Koch clean.
