### PR TITLE
added getTotalSharedMem et al.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1434,6 +1434,20 @@ when not defined(nimrodVM) and hostOS != "standalone":
   proc getTotalMem*(): int {.rtl.}
     ## returns the number of bytes that are owned by the process.
 
+  when hasThreadSupport:
+    proc getOccupiedSharedMem*(): int {.rtl.}
+      ## returns the number of bytes that are owned by the process
+      ## on the shared heap and hold data. This is only available when
+      ## threads are enabled.
+
+    proc getFreeSharedMem*(): int {.rtl.}
+      ## returns the number of bytes that are owned by the
+      ## process on the shared heap, but do not hold any meaningful data.
+      ## This is only available when threads are enabled.
+
+    proc getTotalSharedMem*(): int {.rtl.}
+      ## returns the number of bytes on the shared heap that are owned by the
+      ## process. This is only available when threads are enabled.
 
 iterator countdown*[T](a, b: T, step = 1): T {.inline.} =
   ## Counts from ordinal value `a` down to `b` with the given

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -835,4 +835,20 @@ template instantiateForRegion(allocator: expr) =
     else:
       result = realloc(p, newsize)
 
+  when hasThreadSupport:
+
+    template sharedMemStatsShared(v: int) {.immediate.} =
+      acquireSys(heapLock)
+      result = v
+      releaseSys(heapLock)
+
+    proc getFreeSharedMem(): int =
+      sharedMemStatsShared(sharedHeap.freeMem)
+
+    proc getTotalSharedMem(): int =
+      sharedMemStatsShared(sharedHeap.currMem)
+
+    proc getOccupiedSharedMem(): int =
+      sharedMemStatsShared(sharedHeap.currMem - sharedHeap.freeMem)
+
 {.pop.}


### PR DESCRIPTION
I'm new to this, so please check that the code makes sense.

Also, i don't entirely grok the numbers -- for instance, allocating 2 bytes does not necessarily grow the result of getOccupiedSharedMem() by two, but could just as well increase it by 4096. I'm guessing this has to do with the allocator implementation, which i didn't read, but it's a little confusing to me what exactly the numbers mean.
