### PR TITLE
`=>` macro tripped on generic return types

### DIFF
--- a/lib/pure/future.nim
+++ b/lib/pure/future.nim
@@ -18,7 +18,6 @@ proc createProcType(p, b: PNimrodNode): PNimrodNode {.compileTime.} =
   result = newNimNode(nnkProcTy)
   var formalParams = newNimNode(nnkFormalParams)
 
-  expectKind(b, nnkIdent)
   formalParams.add b
 
   case p.kind


### PR DESCRIPTION
example fail `(a:int,b:int) -> Foo[int] => Foo[int](x: a + b)`
