### PR TITLE
Fixed readAllBuffer() to avoid adding garbage bytes at end.

### DIFF
--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -115,10 +115,14 @@ proc readAllBuffer(file: TFile): string =
   # bytes we need to read before the buffer is empty.
   result = ""
   var buffer = newString(BufSize)
-  var bytesRead = BufSize
-  while bytesRead == BufSize:
-    bytesRead = readBuffer(file, addr(buffer[0]), BufSize)
-    result.add(buffer)
+  while true:
+    var bytesRead = readBuffer(file, addr(buffer[0]), BufSize)
+    if bytesRead == BufSize:
+      result.add(buffer)
+    else:
+      buffer.setLen(bytesRead)
+      result.add(buffer)
+      break
   
 proc rawFileSize(file: TFile): int = 
   # this does not raise an error opposed to `getFileSize`


### PR DESCRIPTION
The function readAllBuffer() always returned a string that was a
multiple of the BufSize in length, regardless of how many bytes were
actually read, padding the result with garbage bytes on the last chunk.
This fix properly trims the last chunk to its actual size. It also sets
BufSize to a value less likely to cause unnecessary overhead with C and
OS file I/O.
