### PR TITLE
Fix assertion in queues.dequeue

### DIFF
--- a/lib/pure/collections/queues.nim
+++ b/lib/pure/collections/queues.nim
@@ -59,7 +59,7 @@ proc enqueue*[T](q: var TQueue[T], item: T) =
 
 proc dequeue*[T](q: var TQueue[T]): T =
   ## removes and returns the first element of the queue `q`.
-  assert q.count > 0
+  assert q.len > 0
   dec q.count
   result = q.data[q.rd]
   q.rd = (q.rd + 1) and q.mask


### PR DESCRIPTION
Fixes issues #1172 , which is caused by a (presumably) old assertion checking for a nonexistant 'count' member. I changed the use of 'count' to 'len'
