### PR TITLE
adding header pragma for printf ffi example

### DIFF
--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -5485,7 +5485,7 @@ the argument is missing, the C name is the Nimrod identifier *exactly as
 spelled*:
 
 .. code-block::
-  proc printf(formatstr: cstring) {.header: "stdio.h", importc: "printf", varargs.}
+  proc printf(formatstr: cstring) {.header: "<stdio.h>", importc: "printf", varargs.}
 
 Note that this pragma is somewhat of a misnomer: Other backends will provide
 the same feature under the same name.


### PR DESCRIPTION
I think the manual should not have code that does not compile. The ffi example in the manual for importing printf is causes problems when an echo precedes it.

Example (this code does not compile on 0.9.4)

```
echo("something")
proc printf(formatstr: cstring) {.importc: "printf", varargs.} #this line is from the maunal
printf("hello")
```

When adding the header pragma it works.
