### PR TITLE
Properly terminate "nimrod i" on end of file.

### DIFF
--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -82,6 +82,9 @@ when not defined(readLineFromStdin):
   proc readLineFromStdin(prompt: string, line: var string): bool =
     stdout.write(prompt)
     result = readLine(stdin, line)
+    if not result:
+      stdout.write("\n")
+      quit(0)
 
 proc endsWith*(x: string, s: set[char]): bool =
   var i = x.len-1


### PR DESCRIPTION
Nimrod in interactive mode got stuck in an infinite loop when
encountering EOF (Ctrl-D), unless GNU Readline was being used. This
change mimics the GNU Readline behavior in rdstdin.nim and calls quit(0)
when encountering EOF while reading from stdin in interactive mode.
