### PR TITLE
Make it easy to package Nimrod for Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+DESTDIR?=pkg
+
+all:
+	sh build.sh
+
+install:
+	PATH="$(shell pwd)/bin:${PATH}" ./koch install "${DESTDIR}"
+	install -d "${DESTDIR}/usr/share/nimrod/doc"
+	install -d "${DESTDIR}/usr/lib/nimrod"
+	install -d "${DESTDIR}/etc"
+	install -d "${DESTDIR}/usr/bin"
+	mv "${DESTDIR}/nimrod/lib/"* "${DESTDIR}/usr/lib/nimrod/"
+	mv "${DESTDIR}/nimrod/config/"* "${DESTDIR}/etc/"
+	cp -a "lib/packages" "${DESTDIR}/usr/lib/nimrod/"
+	mv "${DESTDIR}/nimrod/doc/"* "${DESTDIR}/usr/share/nimrod/doc/"
+	mv "${DESTDIR}/nimrod/bin/"* "${DESTDIR}/usr/bin/"
+	rm -r "${DESTDIR}/nimrod"
+	cp -r examples web "${DESTDIR}/usr/share/nimrod/doc/"
+	install -m755 "compiler/c2nim/c2nim" "${DESTDIR}/usr/bin/"
+	install -m755 "compiler/pas2nim/pas2nim" "${DESTDIR}/usr/bin/"
+	install -m644 "lib/libnimrtl.so" "${DESTDIR}/usr/lib/libnimrtl.so"
+	install -m755 "tools/nimgrep" "${DESTDIR}/usr/bin/"
+	install -Dm644 "copying.txt" "${DESTDIR}/usr/share/licenses/nimrod/LICENSE"
+
+clean:
+	cp Makefile Makefile.backup
+	./koch clean
+	mv Makefile.backup Makefile
+	rm -f koch
+	rm -rf build

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+if [ -e build/empty.txt ]; then
+  rm -f build/empty.txt
+  rmdir build
+fi
+if [ ! -e build/build.sh ]; then
+  git clone -q --depth=1 git://github.com/nimrod-code/csources build
+fi
+
+pushd build
+sh build.sh
+popd
+
+bin/nimrod c koch
+./koch boot -d:release -d:useGnuReadline
+
+export PATH="`pwd`/bin:$PATH"
+
+pushd compiler
+nimrod c -d:release c2nim/c2nim.nim
+nimrod c -d:release pas2nim/pas2nim.nim
+popd
+
+pushd lib
+nimrod c --app:lib -d:createNimRtl -d:release nimrtl.nim
+popd
+
+pushd tools
+nimrod c -d:release nimgrep.nim
+popd


### PR DESCRIPTION
Hi,

By adding the possibility of running the classical "make" and "make install" commands, it's much easier to package Nimrod for Linux. If run as "DESTDIR=/ make install", Nimrod will be installed on the system, with the required libraries, license information, binaries and documentation. This is very close to how Nimrod is already packaged for Arch Linux, but the packaging instructions are much longer than usual. This patch makes the build and installation process a lot more conventional, and easy to relate to, from the point of view of packaging Nimrod. There is room for improvement and additional configuration, of course.

Tested on Arch Linux and Red Hat 6.

Best regards,
Alexander Rødseth
