### PR TITLE
Add enum hashing

### DIFF
--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -87,6 +87,10 @@ proc hash*(x: char): THash {.inline.} =
   ## efficient hashing of characters
   result = ord(x)
 
+proc hash*(x: enum): THash {.inline.} =
+  ## efficient hashing of enums
+  result = ord(x)
+
 proc hash*(x: string): THash = 
   ## efficient hashing of strings
   var h: THash = 0


### PR DESCRIPTION
The non-existance of a hash method for enums seems to be an oversight when the hashes module was created.
