### PR TITLE
json.== handles nil now

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -621,9 +621,13 @@ proc `%`*(elements: openArray[PJsonNode]): PJsonNode =
 
 proc `==`* (a,b: PJsonNode): bool =
   ## Check two nodes for equality
-  if a.kind != b.kind: false
+  if a.isNil:
+    if b.isNil: return true
+    return false
+  elif b.isNil or a.kind != b.kind: 
+    return false
   else:
-    case a.kind
+    return case a.kind
     of JString:
       a.str == b.str
     of JInt:


### PR DESCRIPTION
I have a test too but I'm not sure where it should go

``` nimrod
import json
var 
  n1, n2: PJsonNode
echo n1 == n2
echo(%1 == nil)
echo(%[%1] == %[%1])
```

output should be "true\nfalse\ntrue"
