### PR TITLE
Forces babel package descriptions to end with a dot.

### DIFF
--- a/web/babelpkglist.nim
+++ b/web/babelpkglist.nim
@@ -28,13 +28,19 @@ proc processContent(content: string) =
     officialCount = 0
     unofficialList = ""
     unofficialCount = 0
+  let
+    endings = {'.', '!'}
 
   for pkg in jsonArr:
     assert pkg.kind == JObject
     let pkgWeb =
       if pkg.hasKey("web"): pkg["web"].str
       else: pkg["url"].str
-    let listItem = li(a(href=pkgWeb, pkg["name"].str), " ", pkg["description"].str)
+    let
+      desc = pkg["description"].str
+      # Review array index access when #1291 is solved.
+      dot = if desc.high > 0 and desc[<desc.high] in endings: "" else: "."
+      listItem = li(a(href=pkgWeb, pkg["name"].str), " ", desc & dot)
     if pkg["url"].str.startsWith("git://github.com/nimrod-code") or
        "official" in pkg["tags"].elems:
       officialCount.inc


### PR DESCRIPTION
The patch is made to work with the current behaviour displayed in #1291.
