### PR TITLE
Use monospace as fallback font on website

### DIFF
--- a/web/assets/style.css
+++ b/web/assets/style.css
@@ -93,7 +93,7 @@ html, body {
         border-left:10px solid #8f9698;
         background:#f3f6f8;
         font-size:15px;
-        font-family:courier;
+        font-family:courier, monospace;
         letter-spacing:0;
         line-height:17px;
       }


### PR DESCRIPTION
When there is no courier like font on a system, default (non-monospaced) font is shown for nimrod code on the website. This should fix it to use a monospaced font as fallback.
