### PR TITLE
Add keepIf proc and keepIfIt template to sequtils

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -270,16 +270,16 @@ template filterIt*(seq1, pred: expr): expr {.immediate.} =
     if pred: result.add(it)
   result
 
-template keepIfIt*(varSeq, pred: expr) =
+template keepItIf*(varSeq, pred: expr) =
   ## Convenience template around the ``keepIf`` proc to reduce typing.
   ##
   ## Unlike the `proc` version, the predicate needs to be an expression using
-  ## the ``it`` variable for testing, like: ``keepIfIt("abcxyz", it == 'x')``.
+  ## the ``it`` variable for testing, like: ``keepItIf("abcxyz", it == 'x')``.
   ## Example:
   ##
   ## .. code-block:: nimrod
   ##   var candidates = @["foo", "bar", "baz", "foobar"]
-  ##   keepIfIt(candidates, it.len == 3 and it[0] == 'b')
+  ##   keepItIf(candidates, it.len == 3 and it[0] == 'b')
   ##   assert candidates == @["bar", "baz"]
   var pos = 0
   for i in 0 .. <len(varSeq):
@@ -470,9 +470,9 @@ when isMainModule:
     assert acceptable == @[-2.0, 24.5, 44.31]
     assert notAcceptable == @[-272.15, 99.9, -113.44]
 
-  block: # keepIfIt test
+  block: # keepItIf test
     var candidates = @["foo", "bar", "baz", "foobar"]
-    keepIfIt(candidates, it.len == 3 and it[0] == 'b')
+    keepItIf(candidates, it.len == 3 and it[0] == 'b')
     assert candidates == @["bar", "baz"]
 
   block: # toSeq test


### PR DESCRIPTION
It's faster to filter sequences inplace, as can be seen with this:

``` nimrod
import sequtils

var x: seq[int] = @[]
for i in 1..100_000_000:
  x.add(i)

#var y = filter(x, proc(a): bool = a mod 2 == 0) # 1.8 seconds
#echo y[1000]
#echo y.len

keepIf(x, proc(a): bool = a mod 2 == 0) # 0.6 seconds
echo x[1000]
echo x.len
```

I'm not sure about the name. We can't use filter (unlike with map's two procs) because the inplace filter has the same arguments. filterDirectly is too long, removeIf (as in C++) would require negating the condition proc, which is why I chose keepIf.
