### PR TITLE
Fix generation of package-dependent init names.

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1050,6 +1050,7 @@ proc getSomeInitName(m: PSym, suffix: string): PRope =
   assert m.owner.kind == skPackage
   if {sfSystemModule, sfMainModule} * m.flags == {}:
     result = m.owner.name.s.mangle.toRope
+    result.app "_"
   result.app m.name.s
   result.app suffix
   

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -115,7 +115,7 @@ proc newModule(fileIdx: int32): PSym =
   new(result)
   result.id = - 1             # for better error checking
   result.kind = skModule
-  let filename = fileIdx.toFilename
+  let filename = fileIdx.toFullPath
   result.name = getIdent(splitFile(filename).name)
   if not isNimrodIdentifier(result.name.s):
     rawMessage(errInvalidModuleName, result.name.s)


### PR DESCRIPTION
The code incorrectly used relative instead of absolute paths to
see if *.babel files could be found, which could result in them
not being located properly.

Also added an underscore between the package and the module name
for package_moduleInit() and package_moduleDatInit() so that there
won't be spurious conflicts, e.g. for package A and module BC vs.
package AB and module C.
