### PR TITLE
Logical operations for TSet

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -174,15 +174,15 @@ proc symmetricDifference*[A](s1, s2: TSet[A]): TSet[A] =
   for item in s2:
     if containsOrIncl(result, item): excl(result, item)
 
-proc `or`*[A](s1, s2: TSet[A]): TSet[A] {.inline.} =
+proc `+`*[A](s1, s2: TSet[A]): TSet[A] {.inline.} =
   ## alias for `union`
   result = union(s1, s2)
 
-proc `and`*[A](s1, s2: TSet[A]): TSet[A] {.inline.} =
+proc `*`*[A](s1, s2: TSet[A]): TSet[A] {.inline.} =
   ## alias for `intersection`
   result = intersection(s1, s2)
 
-proc `xor`*[A](s1, s2: TSet[A]): TSet[A] {.inline.} =
+proc `-+-`*[A](s1, s2: TSet[A]): TSet[A] {.inline.} =
   ## alias for `symmetricDifference`
   result = symmetricDifference(s1, s2)
 

--- a/tests/sets/tsets3.nim
+++ b/tests/sets/tsets3.nim
@@ -8,8 +8,8 @@ let
 block union:
   let
     s1_s2 = union(s1, s2)
-    s1_s3 = s1 or s3
-    s2_s3 = s2 or s3
+    s1_s3 = s1 + s3
+    s2_s3 = s2 + s3
 
   assert s1_s2.len == 7
   assert s1_s3.len == 8
@@ -25,14 +25,14 @@ block union:
     assert i in s1_s3
     assert i in s2_s3
 
-  assert((s1 or s1) == s1)
-  assert((s2 or s1) == s1_s2)
+  assert((s1 + s1) == s1)
+  assert((s2 + s1) == s1_s2)
 
 block intersection:
   let
     s1_s2 = intersection(s1, s2)
     s1_s3 = intersection(s1, s3)
-    s2_s3 = s2 and s3
+    s2_s3 = s2 * s3
 
   assert s1_s2.len == 3
   assert s1_s3.len == 0
@@ -48,14 +48,14 @@ block intersection:
     assert i in s2
     assert i in s3
 
-  assert((s2 and s2) == s2)
-  assert((s3 and s2) == s2_s3)
+  assert((s2 * s2) == s2)
+  assert((s3 * s2) == s2_s3)
 
 block symmetricDifference:
   let
     s1_s2 = symmetricDifference(s1, s2)
-    s1_s3 = s1 xor s3
-    s2_s3 = s2 xor s3
+    s1_s3 = s1 -+- s3
+    s2_s3 = s2 -+- s3
 
   assert s1_s2.len == 4
   assert s1_s3.len == 8
@@ -71,8 +71,8 @@ block symmetricDifference:
     assert i in s1_s3 xor i in s1
     assert i in s2_s3 xor i in s2
 
-  assert((s3 xor s3) == initSet[int]())
-  assert((s3 xor s1) == s1_s3)
+  assert((s3 -+- s3) == initSet[int]())
+  assert((s3 -+- s1) == s1_s3)
 
 block disjoint:
   assert(not disjoint(s1, s2))


### PR DESCRIPTION
Added logical set operations to _sets.nim_:
- `union` (aka **`or`**)
- `intersection` (aka **`and`**)
- `symmetricDifference` (aka **`xor`**)
- `disjoint`

Also added versions of `incl` and `excl` that take another `TSet` as second argument. Added tests for new operations.
