### PR TITLE
Add 'lib/pure/concurrency' path to nimrod.ini

### DIFF
--- a/compiler/nimrod.ini
+++ b/compiler/nimrod.ini
@@ -79,6 +79,7 @@ Files: "lib/system/*.nim"
 Files: "lib/core/*.nim"
 Files: "lib/pure/*.nim"
 Files: "lib/pure/collections/*.nim"
+Files: "lib/pure/concurrency/*.nim"
 Files: "lib/impure/*.nim"
 Files: "lib/wrappers/*.nim"
 


### PR DESCRIPTION
Fixes #1303
