### PR TITLE
Change wordwrap to remove separators at newlines

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -535,7 +535,12 @@ proc wordWrap*(s: string, maxLineWidth = 80,
   ## word wraps `s`.
   result = newStringOfCap(s.len + s.len shr 6)
   var spaceLeft = maxLineWidth
+  var lastSep = ""
   for word, isSep in tokenize(s, seps):
+    if isSep:
+      lastSep = word
+      spaceLeft = spaceLeft - len(word)
+      continue
     if len(word) > spaceLeft:
       if splitLongWords and len(word) > maxLineWidth:
         result.add(substr(word, 0, spaceLeft-1))
@@ -554,7 +559,8 @@ proc wordWrap*(s: string, maxLineWidth = 80,
         result.add(word)
     else:
       spaceLeft = spaceLeft - len(word)
-      result.add(word)
+      result.add(lastSep & word)
+      lastSep.setLen(0)
 
 proc unindent*(s: string, eatAllIndent = false): string {.
                noSideEffect, rtl, extern: "nsuUnindent".} =


### PR DESCRIPTION
I don't like the current output of `wordWrap`, which looks like this for `wordWrap(txt, 45)`:

```
Lorem ipsum dolor sit amet, consectetur¬
adipiscing elit. Donec a diam lectus. Sed sit
 amet ipsum mauris. Maecenas congue ligula ac 
 quam viverra nec consectetur ante hendrerit.
 Donec et mollis dolor. Praesent et diam eget
 libero egestas mattis sit amet vitae augue.¬
Nam tincidunt congue enim, ut porta lorem¬
lacinia consectetur.
```

The `¬` at the end of lines are spaces. New behaviour looks like this (no whitespaces at start and end of line):

```
Lorem ipsum dolor sit amet, consectetur
adipiscing elit. Donec a diam lectus. Sed sit
amet ipsum mauris. Maecenas congue ligula ac
quam viverra nec consectetur ante hendrerit.
Donec et mollis dolor. Praesent et diam eget
libero egestas mattis sit amet vitae augue.
Nam tincidunt congue enim, ut porta lorem
lacinia consectetur.
```
