### PR TITLE
Don't advertise the master branch when it's not building

### DIFF
--- a/web/download.txt
+++ b/web/download.txt
@@ -122,9 +122,9 @@ Source
 ======
 
 Starting with 0.9.4 we now advise people to build directly from the
-github `master <https://github.com/Araq/Nimrod#compiling>`_ branch::
+github `devel <https://github.com/Araq/Nimrod#compiling>`_ branch::
 
-  git clone -b master git://github.com/Araq/Nimrod.git
+  git clone -b devel git://github.com/Araq/Nimrod.git
   cd Nimrod
   git clone --depth 1 git://github.com/nimrod-code/csources
   cd csources && sh build.sh


### PR DESCRIPTION
Since people are coming on IRC wondering why they can't build Nimrod, many more must be put off without even asking for help. Since the master branch is currently not building (c-sources are for devel from what I've heard?) I would suggest advertising the working branch.

Oh, and also there is some more information on https://github.com/araq/nimrod than in download.txt. Maybe the Source part of download.txt can be removed by a link to the github page?
