### PR TITLE
Allow arguments for "nimrod run"

### DIFF
--- a/compiler/service.nim
+++ b/compiler/service.nim
@@ -49,6 +49,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
     of cmdArgument:
       if argsCount == 0:
         options.command = p.key
+        if p.key == "run": gGlobalOptions.incl(optRun)
       else:
         if pass == passCmd1: options.commandArgs.add p.key
         if argsCount == 1:


### PR DESCRIPTION
With `nimrod run foo 10` I get the error

```
Error: arguments can only be given if the '--run' option is selected
```

Writing `nimrod --run run` is repetitive.

This patch adds `optRun` to the options it in `processCmdLine`, which doesn't seem like the right place to do it. I wanted to add it in `mainCommand`, but the compiler would already stop before reaching that proc.
