### PR TITLE
Fix float to string conversion for inf and nan

### DIFF
--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -260,7 +260,7 @@ proc nimFloatToStr(f: float): string {.compilerproc.} =
       hasDot = true
     elif buf[i] in {'e', 'E', '.'}: 
       hasDot = true
-  if not hasDot:
+  if not hasDot and $buf notin ["inf", "-inf", "nan", "-nan"]:
     buf[n] = '.'
     buf[n+1] = '0'
     buf[n+2] = '\0'


### PR DESCRIPTION
Right now the output of `tests/system/tfloatToString.nim` is wrong (inf, -inf and nan have .0 appended). This fixes it so that the expected values are returned.
