### PR TITLE
removed wrong example for proc `of`

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -812,11 +812,6 @@ template `isnot` *(x, y: expr): expr {.immediate.} = not (x is y)
 
 proc `of` *[T, S](x: T, y: S): bool {.magic: "Of", noSideEffect.}
   ## Checks if `x` has a type of `y`
-  ##
-  ## .. code-block:: Nimrod
-  ##   assert(EFloatingPoint is EBase)
-  ##   assert(EIO is ESystem)
-  ##   assert(EDivByZero is EBase)
 
 proc cmp*[T](x, y: T): int {.procvar.} =
   ## Generic compare proc. Returns a value < 0 iff x < y, a value > 0 iff x > y


### PR DESCRIPTION
Leave a comment
