### PR TITLE
More robust implementation for finding the beginning of the stack.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2115,6 +2115,12 @@ when not defined(JS): #and not defined(NimrodVM):
         locals = addr(locals)
         setStackBottom(locals)
 
+    proc initStackBottomWith(locals: pointer) {.inline, compilerproc.} =
+      # We need to keep initStackBottom around for now to avoid
+      # bootstrapping problems.
+      when defined(setStackBottom):
+        setStackBottom(locals)
+
     var
       strDesc: TNimType
 


### PR DESCRIPTION
This patch inserts an extra stack frame above the function that calls the actual Nimrod code and ensures that a reference to this frame is stored as the stack bottom.

The patch should not affect bootstrapping with older versions of Nimrod, but doing the inverse (compiling older versions of the compiler with this one) is not possible, as older versions lack the new function to set the bottom of the stack.

The patch should probably also be tested extensively to make sure that it works with a variety of C/C++ compilers and operating systems.
