### PR TITLE
Add empty attributes in xmldom.createDocument

### DIFF
--- a/lib/pure/xmldom.nim
+++ b/lib/pure/xmldom.nim
@@ -121,11 +121,13 @@ proc createDocument*(dom: PDOMImplementation, namespaceURI: string, qualifiedNam
   new(doc)
   doc.FNamespaceURI = namespaceURI
   doc.FImplementation = dom
+  doc.attributes = @[]
   
   var elTag: PElement
   new(elTag)
   elTag.FTagName = qualifiedName
   elTag.FNodeName = qualifiedName
+  elTag.attributes = @[]
   doc.FDocumentElement = elTag
   doc.FNodeType = DocumentNode
   
@@ -140,6 +142,7 @@ proc createDocument*(dom: PDOMImplementation, n: PElement): PDocument =
   doc.FDocumentElement = n
   doc.FImplementation = dom
   doc.FNodeType = DocumentNode
+  doc.attributes = @[]
   
   return doc
   


### PR DESCRIPTION
I'm not sure how xmldom is supposed to be used, but right now it's a bit difficult. I wanted to make this work, but had null pointers:

``` nimrod
import xmldom

var
  dom = getDOM()
  document = dom.createDocument("", "root")
  topElement = document.documentElement
  firstElement = document.createElement "element"
  textNode = document.createTextNode "Some text here"

topElement.appendChild firstElement
firstElement.appendChild textNode

echo document
```

Many more attributes are set to `nil`, but I don't know what to do about that.
