### PR TITLE
Escapes properly code blocks without highlite support.

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -775,7 +775,7 @@ proc renderCodeBlock(d: PDoc, n: PRstNode, result: var string) =
   dispA(d.target, result, "<pre>", "\\begin{rstpre}\n", [])
   if lang == langNone:
     d.msgHandler(d.filename, 1, 0, mwUnsupportedLanguage, langstr)
-    result.add(m.text)
+    for letter in m.text: escChar(d.target, result, letter)
   else:
     var g: TGeneralTokenizer
     initGeneralTokenizer(g, m.text)


### PR DESCRIPTION
Nimforum users can have a lot of fun typing the following into their browsers:

```
.. code-block:: html

   <script type="text/javascript">
   alert("I'm a l33t haxxor");
   </script>
```
