### PR TITLE
Fix swap in jsgen

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -833,8 +833,8 @@ proc genSwap(p: PProc, n: PNode) =
                  "local $1 = $2; $2 = $3; $3 = $1;$n", [
                  tmp, a.address, b.address])
     tmp = tmp2
-  appf(p.body, "var $1 = $2; $2 = $3; $3 = $1" | 
-               "local $1 = $2; $2 = $3; $3 = $1", [tmp, a.res, b.res])
+  appf(p.body, "var $1 = $2; $2 = $3; $3 = $1;" |
+               "local $1 = $2; $2 = $3; $3 = $1;", [tmp, a.res, b.res])
 
 proc getFieldPosition(f: PNode): int =
   case f.kind


### PR DESCRIPTION
Swap didn't work before, for example here:

``` nimrod
proc selectionSort[T](a: var openarray[T]) =
  let n = a.len
  for i in 0 .. <n:
    var m = i
    for j in i .. <n:
      if a[j] < a[m]:
        m = j
    swap a[i], a[m]

var a = @[4, 65, 2, -31, 0, 99, 2, 83, 782]
selectionSort a
echo a
```
