### PR TITLE
Add postgresql prepared queries

### DIFF
--- a/lib/wrappers/postgres.nim
+++ b/lib/wrappers/postgres.nim
@@ -213,6 +213,8 @@ proc PQexecParams*(conn: PPGconn, command: cstring, nParams: int32,
                    paramTypes: POid, paramValues: cstringArray, 
                    paramLengths, paramFormats: ptr int32, resultFormat: int32): PPGresult{.
     cdecl, dynlib: dllName, importc: "PQexecParams".}
+proc PQprepare*(conn: PPGconn, stmtName, query: cstring, nParams: int32,
+    paramTypes: POid): PPGresult{.cdecl, dynlib: dllName, importc: "PQprepare".}
 proc PQexecPrepared*(conn: PPGconn, stmtName: cstring, nParams: int32, 
                      paramValues: cstringArray, 
                      paramLengths, paramFormats: ptr int32, resultFormat: int32): PPGresult{.


### PR DESCRIPTION
- make use of PQexecParams to pass parameters separately from the SQL command text (recommanded against SQL injection - stop relying on string formatting for sql parameter passing and use the postgres API)
- add postgresql prepared queries:

``` nimrod
# open first the db connection with db = open(...), then:

const query = sql"SELECT id, randomNumber FROM World WHERE id = $1"
var my_prepared_query: TSqlPrepared

# do this once
my_prepared_query = db.prepare("world", query, 1)  # the query has 1 parameter

# usage (put the following in your request handlers, for example):
let row = db.getRow(my_prepared_query, random(10_000))
```
