### PR TITLE
Properly handle staticExec() generating large output.

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -12,11 +12,11 @@ import ast, types, msgs, osproc, streams, options
 proc readOutput(p: PProcess): string =
   result = ""
   var output = p.outputStream
-  discard p.waitForExit
   while not output.atEnd:
     result.add(output.readLine)
     result.add("\n")
   result.setLen(result.len - "\n".len)
+  discard p.waitForExit
 
 proc opGorge*(cmd, input: string): string =
   var p = startCmd(cmd)


### PR DESCRIPTION
A staticExec() invocation that generated more than the internal
buffer size worth of output blocked because the compiler waited
for the process to terminate before reading the output.
