### PR TITLE
Avoid unnecessary #include triggered by importc vars.

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -171,6 +171,10 @@ proc genSingleVar(p: BProc, a: PNode) =
   if sfCompileTime in v.flags: return
   var targetProc = p
   if sfGlobal in v.flags:
+    if v.flags * {sfImportc, sfExportc} == {sfImportc} and
+        a.sons[2].kind == nkEmpty and
+        v.loc.flags * {lfHeader, lfNoDecl} != {}:
+      return
     if sfPure in v.flags:
       # v.owner.kind != skModule:
       targetProc = p.module.preInitProc


### PR DESCRIPTION
When a C variable or macro is imported via an {.importc.} var or
let statement, but no definition is needed and the variable does
not have an initializer part, then there is also no need to generate
an #include for the associated header until and unless the variable
is actually used. The header is already generated upon use, but
unnecessarily also when the variable is defined.

This is an issue with the posix module in particular, where a lot
of unnecessary header files are being included because relevant
constants are defined via importc vars, and those header files
may not even be available on a given system.

This patch omits the generation of the #include directive for those
definitions where they aren't needed.
