### PR TITLE
Fix the C++ exception struct in nimbase.h.

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -175,9 +175,9 @@ __clang__
 #  define NIM_NIL 0
 struct NimException
 {
-  NimException(struct E_Base* exp, const char* msg): exp(exp), msg(msg) {}
+  NimException(struct Exception* exp, const char* msg): exp(exp), msg(msg) {}
 
-  struct E_Base* exp;
+  struct Exception* exp;
   const char* msg;
 };
 #else


### PR DESCRIPTION
The struct NimException still referred to the old exception type
E_Base, which has since been renamed to Exception. This made the
C++ backend fail on any code that used exceptions.
