### PR TITLE
More graceful handling of "const char *" by the C++ backend.

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2369,7 +2369,7 @@ proc sched_setscheduler*(a1: TPid, a2: cint, a3: var Tsched_param): cint {.
 proc sched_yield*(): cint {.importc, header: "<sched.h>".}
 
 proc strerror*(errnum: cint): cstring {.importc, header: "<string.h>".}
-proc hstrerror*(herrnum: cint): cstring {.importc, header: "<netdb.h>".}
+proc hstrerror*(herrnum: cint): cconststring {.importc, header: "<netdb.h>".}
 
 proc FD_CLR*(a1: cint, a2: var TFdSet) {.importc, header: "<sys/select.h>".}
 proc FD_ISSET*(a1: cint | TSocketHandle, a2: var TFdSet): cint {.
@@ -2552,7 +2552,7 @@ proc endprotoent*() {.importc, header: "<netdb.h>".}
 proc endservent*() {.importc, header: "<netdb.h>".}
 proc freeaddrinfo*(a1: ptr Taddrinfo) {.importc, header: "<netdb.h>".}
 
-proc gai_strerror*(a1: cint): cstring {.importc, header: "<netdb.h>".}
+proc gai_strerror*(a1: cint): cconststring {.importc, header: "<netdb.h>".}
 
 proc getaddrinfo*(a1, a2: cstring, a3: ptr Taddrinfo,
                   a4: var ptr Taddrinfo): cint {.importc, header: "<netdb.h>".}


### PR DESCRIPTION
A problem with the C++ backend is that prototypes that define the return type as "const char *" fail when the result is assigned to a "char *" variable by generated code. In order to insert the necessary casts, we define "const char *" as a separate cconststring type and supply a converter that converts it to a "char *".

While in the long term a more general solution is needed, cstring values need special treatment, anyway.

In particular, this change allows the compiler itself to be compiled with the C++ backend.

Note: This is a bit of a hack, so I'm not necessarily expecting it to be merged, but I thought I should at least get the ball rolling. A cleaner solution that handles general C++ const types would be a better way.
