### PR TITLE
Fix permissions for createDir() on Unix systems.

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1332,10 +1332,10 @@ proc removeDir*(dir: string) {.rtl, extern: "nos$1", tags: [
 
 proc rawCreateDir(dir: string) =
   when defined(solaris):
-    if mkdir(dir, 0o711) != 0'i32 and errno != EEXIST and errno != ENOSYS:
+    if mkdir(dir, 0o777) != 0'i32 and errno != EEXIST and errno != ENOSYS:
       osError(osLastError())
   elif defined(unix):
-    if mkdir(dir, 0o711) != 0'i32 and errno != EEXIST:
+    if mkdir(dir, 0o777) != 0'i32 and errno != EEXIST:
       osError(osLastError())
   else:
     when useWinUnicode:


### PR DESCRIPTION
Permissions were set to 0o711 by default; they should be 0o777, with
umask being responsible for restricting permissions further.
