### PR TITLE
Add nimblepath so Nim can find Nimble-installed packages out-of-the-box

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -40,6 +40,7 @@ path="$lib/pure/unidecode"
 
 @if nimbabel:
   babelpath="$home/.babel/pkgs/"
+  nimblepath="$home/.nimble/pkgs/"
 @end
 
 @if release or quick:


### PR DESCRIPTION
Currently, `bigbreak` doesn't set the correct `nimblepath` in its default config (nim.cfg). This patch adds a nimblepath to the config file, avoiding the following class of errors:

``` bash
file.nim(1, 7) Error: cannot open 'module'  
```

Where `module` is any nimble-installed package.
