### PR TITLE
Fixes #1561

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -40,6 +40,7 @@ path="$lib/pure/unidecode"
 
 @if nimbabel:
   babelpath="$home/.babel/pkgs/"
+  nimblepath="$home/.nimble/pkgs/"
 @end
 
 @if release or quick:

--- a/tests/modules/tmismatchedvisibility.nim
+++ b/tests/modules/tmismatchedvisibility.nim
@@ -1,0 +1,9 @@
+discard """
+  line: 8
+  errormsg: "public implementation 'tmismatchedvisibility.foo(a: int): int' has non-public forward declaration in tmismatchedvisibility.nim(6,5)"
+"""
+
+proc foo(a: int): int
+
+proc foo*(a: int): int =
+  result = a + a


### PR DESCRIPTION
Now, a procedure with a private forward declaration and a public implementation will throw an error.
@Araq please look and make sure the error message is to your satisfaction. Also, I modified the lineInfoToStr proc so that it resembles the format of line information displayed on a compiler info/error/warning.
