### PR TITLE
Fix #1599

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -71,7 +71,7 @@ hint[LineTooLong]=off
   @if not bsd:
     # -fopenmp
     gcc.options.linker = "-ldl"
-    gpp.options.linker = "-ldl"
+    gcc.cpp.options.linker = "-ldl"
     clang.options.linker = "-ldl"
     tcc.options.linker = "-ldl"
   @end
@@ -101,19 +101,19 @@ hint[LineTooLong]=off
   cc = clang
   tlsEmulation:on
   gcc.options.always = "-w -fasm-blocks"
-  gpp.options.always = "-w -fasm-blocks -fpermissive"
+  gcc.cpp.options.always = "-w -fasm-blocks -fpermissive"
 @else:
-  gcc.options.always = "-w"
-  gpp.options.always = "-w -fpermissive"
+  gcc.options.always = "-w" 
+  gcc.cpp.options.always = "-w -fpermissive"
 @end
 
 gcc.options.speed = "-O3 -fno-strict-aliasing"
 gcc.options.size = "-Os"
 gcc.options.debug = "-g3 -O0"
 
-gpp.options.speed = "-O3 -fno-strict-aliasing"
-gpp.options.size = "-Os"
-gpp.options.debug = "-g3 -O0"
+gcc.cpp.options.speed = "-O3 -fno-strict-aliasing"
+gcc.cpp.options.size = "-Os"
+gcc.cpp.options.debug = "-g3 -O0"
 #passl = "-pg"
 
 # Configuration for the LLVM GCC compiler:


### PR DESCRIPTION
Compiler-specific options are now read with the '{compiler}.cpp' prefix in C++ mode.
 GCC C++ mode is fixed.
