### PR TITLE
Remove extra trailing zero from oid

### DIFF
--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -55,7 +55,7 @@ proc oidToString*(oid: Oid, str: cstring) =
   str[24] = '\0'
 
 proc `$`*(oid: Oid): string =
-  result = newString(25)
+  result = newString(24)
   oidToString(oid, result)
 
 var


### PR DESCRIPTION
`$` would return a string of length 25, including the trailing null. String length changed to 24, avoiding an extra null byte in the output
