### PR TITLE
Koch now copies the correct binary when a '-o' or '--out' switch is passed.

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -16,7 +16,7 @@ when defined(gcc) and defined(windows):
     {.link: "icons/koch_icon.o".}
 
 import
-  os, strutils, parseopt, osproc, streams
+  os, strutils, parseopt2, osproc, streams
 
 import "compiler/nversion.nim"
 
@@ -165,9 +165,19 @@ proc thVersion(i: int): string =
   result = ("compiler" / "nim" & $i).exe
   
 proc boot(args: string) =
-  var output = "compiler" / "nim".exe
-  var finalDest = "bin" / "nim".exe
-  
+  # Look for the -o: or --output
+  var
+    output = "compiler" / "nim".exe
+    finalDest = "bin" / "nim".exe
+  let commandLine = commandLineParams()
+
+  for kind, key, val in getOpt(commandLine[1..commandLine.high()]):
+    if len(val) != 0:
+      let k = key.toLower()
+      if k == "out" or k == "o":
+        output = "compiler" / val
+        finalDest = "bin" / val
+
   copyExe(findStartNim(), 0.thVersion)
   for i in 0..2:
     echo "iteration: ", i+1

--- a/lib/pure/parseopt2.nim
+++ b/lib/pure/parseopt2.nim
@@ -124,7 +124,7 @@ type
 {.deprecated: [TGetoptResult: GetoptResult].}
 
 when declared(paramCount):
-  iterator getopt*(): GetoptResult =
+  iterator getopt*(s: seq[string] = nil): GetoptResult =
     ## This is an convenience iterator for iterating over the command line.
     ## This uses the OptParser object. Example:
     ##
@@ -143,7 +143,7 @@ when declared(paramCount):
     ##   if filename == "":
     ##     # no filename has been given, so we show the help:
     ##     writeHelp()
-    var p = initOptParser()
+    var p = initOptParser(s)
     while true:
       next(p)
       if p.kind == cmdEnd: break


### PR DESCRIPTION
Previously, if the '-o' or '--out' argument was passed after the 'boot' command when using koch.exe, koch would still try to copy 'compiler/nim.exe' to 'bin/nim.exe', either failing or copying the wrong binary. This fixes that by scanning the rest of the command line after the 'boot' command for the '-o' or '--out' arguments.

In addition, parseopt2.getOpt now accepts an optional sequence to read from.
