### PR TITLE
Add build scripts.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+set -x
+
+if [ ! -d "csources" ]; then
+	git clone --depth 1 https://github.com/nim-lang/csources.git
+fi
+
+cd "csources"
+sh build.sh
+cd ".."
+
+./bin/nim c koch
+./koch boot -d:release
+
+cp -f install.sh.template install.sh
+chmod +x install.sh
+
+exit 0

--- a/install.sh.template
+++ b/install.sh.template
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+set -x
+
+if [ "$1" != "" ]; then
+	exec ./koch install "$1"
+else
+	exec ./koch install
+fi


### PR DESCRIPTION
This adds scripts to make the process for installing from Github the same as the process for installing from the generated C sources. This would allow us to keep the HEAD option in the new Homebrew formula instead of breaking it out into a different formula.
