### PR TITLE
Switch httpclient to use net module instead of sockets

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -498,7 +498,6 @@ proc recvFull(socket: AsyncSocket, size: int): Future[string] {.async.} =
 
 proc parseChunks(client: AsyncHttpClient): Future[string] {.async.} =
   result = ""
-  var ri = 0
   while true:
     var chunkSize = 0
     var chunkSizeStr = await client.socket.recvLine()


### PR DESCRIPTION
This doesn't currently work with https connections. The old sockets module ignored return codes from SSL_shutdown, whereas net does not. This results in the following exception being thrown:

``` nimrod
Traceback (most recent call last)
a9.nim(2)                a9
httpclient.nim(377)      getContent
httpclient.nim(358)      get
httpclient.nim(332)      request
net.nim(429)             close
net.nim(260)             socketError
net.nim(143)             raiseSSLError
Error: unhandled exception: No error reported. [SslError]
```

Does anybody no the reason for this? The return codes were:

```
SSL_shutdown returns -1
SSL_get_error returns SSL_ERROR_SYSCALL (5)
ERR_get_error returns 0
errno was set to  EBADF (9) Bad file number 
```

Update: Turns out that was because:

`socket.fd.close()`

was being called too early. 
