### PR TITLE
Logo in SVG format.

### DIFF
--- a/web/assets/images/nim-logo.svg
+++ b/web/assets/images/nim-logo.svg
@@ -1,0 +1,500 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="163.84375"
+   height="124.67096"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="New document 1">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3833">
+      <stop
+         style="stop-color:#f7c41a;stop-opacity:1;"
+         offset="0"
+         id="stop3835" />
+      <stop
+         style="stop-color:#bd9510;stop-opacity:1;"
+         offset="1"
+         id="stop3837" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3825">
+      <stop
+         style="stop-color:#f3d673;stop-opacity:1;"
+         offset="0"
+         id="stop3827" />
+      <stop
+         style="stop-color:#c7a23a;stop-opacity:1;"
+         offset="1"
+         id="stop3829" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825"
+       id="radialGradient3831"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,1.3722368,813.17816)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833"
+       id="radialGradient3839"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,4.9030359,1024.9638)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833-7"
+       id="radialGradient3839-8"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,4.9030359,1024.9638)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3833-7">
+      <stop
+         style="stop-color:#f4d779;stop-opacity:1;"
+         offset="0"
+         id="stop3835-5" />
+      <stop
+         style="stop-color:#bd9510;stop-opacity:1;"
+         offset="1"
+         id="stop3837-4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3831-8"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,1.3722368,813.17816)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3825-5">
+      <stop
+         style="stop-color:#f3d673;stop-opacity:1;"
+         offset="0"
+         id="stop3827-3" />
+      <stop
+         style="stop-color:#c7a23a;stop-opacity:1;"
+         offset="1"
+         id="stop3829-7" />
+    </linearGradient>
+    <radialGradient
+       r="80.321426"
+       fy="414.17612"
+       fx="407.17349"
+       cy="414.17612"
+       cx="407.17349"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-153.01531,1007.7817)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3870"
+       xlink:href="#linearGradient3833-7"
+       inkscape:collect="always" />
+    <radialGradient
+       r="80.321426"
+       fy="414.24271"
+       fx="406.47156"
+       cy="414.24271"
+       cx="406.47156"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-156.54611,795.9961)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3872"
+       xlink:href="#linearGradient3825-5"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833-7"
+       id="radialGradient3908"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-153.01531,1007.7817)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-156.54611,795.9961)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833-7"
+       id="radialGradient3914"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-153.01531,1007.7817)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3916"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-156.54611,795.9961)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833-7"
+       id="radialGradient3918"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-153.01531,1007.7817)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3920"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-156.54611,795.9961)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833-7"
+       id="radialGradient3924"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-153.01531,1007.7817)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3926"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-156.54611,795.9961)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3933"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01462336,-0.89388887,0.97447651,-0.01594169,19.13339,796.92442)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833"
+       id="radialGradient3935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,4.9030359,1024.9638)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825"
+       id="radialGradient3937"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,1.3722368,813.17816)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833"
+       id="radialGradient3941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-75.408823,1015.0037)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825"
+       id="radialGradient3943"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-78.939622,803.21805)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3949"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01462336,-0.89388887,0.97447651,-0.01594169,19.13339,796.92442)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3953"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01462336,-0.89388887,0.97447651,-0.01594169,19.13339,796.92442)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3957"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01462336,-0.89388887,0.97447651,-0.01594169,-70.86661,796.92442)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5"
+       id="radialGradient3961"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01462336,-0.89388887,0.97447651,-0.01594169,-70.86661,796.92442)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833-79"
+       id="radialGradient3941-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-75.408823,1015.0037)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <linearGradient
+       id="linearGradient3833-79">
+      <stop
+         style="stop-color:#f4d779;stop-opacity:1;"
+         offset="0"
+         id="stop3835-55" />
+      <stop
+         style="stop-color:#bd9510;stop-opacity:1;"
+         offset="1"
+         id="stop3837-5" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-3"
+       id="radialGradient3943-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-78.939622,803.21805)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <linearGradient
+       id="linearGradient3825-3">
+      <stop
+         style="stop-color:#f3d673;stop-opacity:1;"
+         offset="0"
+         id="stop3827-0" />
+      <stop
+         style="stop-color:#c7a23a;stop-opacity:1;"
+         offset="1"
+         id="stop3829-2" />
+    </linearGradient>
+    <radialGradient
+       r="80.321426"
+       fy="414.24271"
+       fx="406.47156"
+       cy="414.24271"
+       cx="406.47156"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,91.271992,815.08835)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3985"
+       xlink:href="#linearGradient3825-3"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833"
+       id="radialGradient4029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,-75.408823,1015.0037)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825"
+       id="radialGradient4031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01492027,-0.91203843,0.99426233,-0.01626537,-78.939622,803.21805)"
+       cx="406.47156"
+       cy="414.24271"
+       fx="406.47156"
+       fy="414.24271"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833"
+       id="radialGradient4037"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,71.056847,1015.1237)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3833"
+       id="radialGradient4047"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0234034,-1.430605,0.9942623,-0.01626526,71.056847,1015.1237)"
+       cx="407.17349"
+       cy="414.17612"
+       fx="407.17349"
+       fy="414.17612"
+       r="80.321426" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#595959"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.7"
+     inkscape:cx="-296.38002"
+     inkscape:cy="91.425689"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     inkscape:window-x="0"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     sodipodi:insensitive="true"
+     style="display:none"
+     transform="translate(-391.875,-406.1875)">
+    <image
+       y="392.14789"
+       x="-90.714287"
+       id="image3047"
+       xlink:href="file:///home/tomasi/Projects/nimrod/logo/new-symbols.png"
+       height="329"
+       width="800" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline"
+     transform="translate(-391.875,-406.1875)">
+    <g
+       id="g4041">
+      <path
+         id="path4019"
+         d="m 474.37925,408.23965 c 0,0 -6.12468,5.3771 -12.34375,10.6875 -6.39764,-0.22532 -18.88846,1.38269 -25.6875,4.125 -6.26333,-4.40055 -11.8125,-9.28125 -11.8125,-9.28125 0,0 -4.69884,9.01564 -7.65625,14.28125 -4.38598,2.58703 -8.76277,5.43142 -12.6875,9.28125 -4.63902,-2.04302 -10.1875,-4.65625 -10.1875,-4.65625 l 6.25,27.875 0.9375,1.875 -1.09375,-1.875 c 0,0 8.86172,24.01192 14.8125,40 25.2159,36.89492 89.61617,39.46428 117.68751,0.71875 5.37871,-13.44336 11.62618,-31.71161 13.90625,-38.4375 l 1.25,-2.8125 5.90625,-26.78125 c 0,0 -6.87234,2.50886 -11.0625,4.28125 -2.40446,-3.40619 -6.05177,-7.01378 -11.25,-9.46875 -3.05538,-6.20497 -7.5,-14.65625 -7.5,-14.65625 0,0 -5.33268,4.38488 -11.4375,9.125 -8.24767,-1.68845 -18.23488,-3.72666 -26.62501,-3.21875 -5.71156,-5.20637 -11.40625,-11.0625 -11.40625,-11.0625 z"
+         style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path3054"
+         d="m 400.26095,460.55777 -6.25,-27.85715 c 0,0 5.53955,2.59984 10.17857,4.64286 3.92473,-3.84983 8.2926,-6.69868 12.67858,-9.28571 2.95741,-5.26561 7.67857,-14.28572 7.67857,-14.28572 0,0 5.52238,4.88517 11.78571,9.28572 6.79904,-2.74231 19.31665,-4.33247 25.71429,-4.10715 6.21906,-5.3104 12.32143,-10.71428 12.32143,-10.71428 0,0 5.71701,5.86506 11.42857,11.07143 8.39013,-0.50791 18.35947,1.52583 26.60714,3.21428 6.10482,-4.74012 11.42857,-9.10714 11.42857,-9.10714 0,0 4.44462,8.43789 7.5,14.64286 5.19824,2.45497 8.84554,6.05809 11.25,9.46428 4.19017,-1.77239 11.07143,-4.28571 11.07143,-4.28571 l -5.89286,26.78571 -6.60714,14.82143 c 0,0 -4.31067,-2.70091 -7.32143,-4.28571 -16.93933,-45.69195 -106.71744,-37.02003 -119.46428,-0.71429 -5.78255,1.30574 -8.39286,2.32143 -8.39286,2.32143 z"
+         style="fill:url(#radialGradient4047);fill-opacity:1;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path3051"
+         d="m 400.08238,460.55777 c 0,0 8.87064,24.01192 14.82143,40 25.2159,36.89492 89.60723,39.45981 117.67857,0.71428 6.64277,-16.60268 15,-41.60714 15,-41.60714 l -6.07143,11.42857 -7.63525,-0.35714 -11.82903,15 -16.96429,5 -31.07143,-17.85715 -31.25,17.5 -16.96428,-4.82142 -11.54402,-15.59885 -7.56312,2.02742 z"
+         style="fill:#ffffff;stroke:none" />
+      <path
+         sodipodi:nodetypes="scccccccccs"
+         id="path3054-8"
+         d="m 474.88371,439.45394 c 26.96263,-0.0368 50.75931,9.32331 58.9643,31.09821 0.11438,0.0602 0.25716,0.12428 0.375,0.1875 l -0.34375,0 -11.84375,15 -16.93751,5 -31.09375,-17.875 -31.25,17.5 -16.96875,-4.8125 -11.31751,-16.02955 c 6.01205,-17.4758 32.67194,-30.03082 60.41572,-30.06866 z"
+         style="fill:none;stroke:#000000;stroke-width:1.10000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
I've read in the IRC logs that somebody asked for a scalable SVG copy of Nim's logo and decided to do the conversion on my own. My starting point was a .png file created by @PhilipWitte (see http://reign-studios.net/philipwitte/nimrod/new-symbols.png, the third icon from left in the top row). My image is a poor reproduction of the original, but at least it is scalable and might be used as a starting point for something better.

I checked the image on dark and light backgrounds, it should work in both cases.
