### PR TITLE
Fixed tusertypeclasses test

### DIFF
--- a/tests/metatype/tusertypeclasses.nim
+++ b/tests/metatype/tusertypeclasses.nim
@@ -12,7 +12,7 @@ type
     (x < y) is bool
 
   ObjectContainer = generic C
-    C.len is ordinal
+    C.len is Ordinal
     for v in items(C):
       v.type is tuple|object
 


### PR DESCRIPTION
I couldn't find 'ordinal' anywhere, so I guess it was renamed/a typo?
