### PR TITLE
bugfix: fixed path and query headers formatting in httpclient.

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -294,7 +294,7 @@ proc request*(url: string, httpMethod = httpGET, extraHeaders = "",
   var r = if proxy == nil: parseUri(url) else: proxy.url
   var headers = substr($httpMethod, len("http"))
   if proxy == nil:
-    headers.add(" /" & r.path & r.query)
+    headers.add(" " & r.path & "?" & r.query)
   else:
     headers.add(" " & url)
 


### PR DESCRIPTION
Fixed path and query header formatting in httpclient, before request like `http://httpbin.org/get?arg1=5&arg2=6` had header: `GET //getarg1=5&arg2=6 HTTP/1.1`, now its correct `GET /get?arg1=5&arg2=6 HTTP/1.1`
