### PR TITLE
Rename mget to `[]`

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -121,7 +121,7 @@ proc importAllSymbolsExcept(c: PContext, fromMod: PSym, exceptSet: IntSet) =
       if s.kind != skEnumField:
         if s.kind notin ExportableSymKinds:
           internalError(s.info, "importAllSymbols: " & $s.kind)
-        if exceptSet.empty or s.name.id notin exceptSet:
+        if s.name.id notin exceptSet:
           rawImportSymbol(c, s)
     s = nextIter(i, fromMod.tab)
 
@@ -138,7 +138,7 @@ proc importForwarded(c: PContext, n: PNode, exceptSet: IntSet) =
       let s = a.sym
       if s.kind == skModule:
         importAllSymbolsExcept(c, s, exceptSet)
-      elif exceptSet.empty or s.name.id notin exceptSet:
+      elif s.name.id notin exceptSet:
         rawImportSymbol(c, s)
   of nkExportExceptStmt:
     localError(n.info, errGenerated, "'export except' not implemented")

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -17,11 +17,11 @@ type
     otherbits: char
     case isLeaf: bool
     of false: child: array[0..1, ref NodeObj[T]]
-    of true: 
+    of true:
       key: string
       when T isnot void:
         val: T
-    
+
   Node[T] = ref NodeObj[T]
   CritBitTree*[T] = object ## The crit bit tree can either be used
                            ## as a mapping from strings to
@@ -66,7 +66,7 @@ proc rawInsert[T](c: var CritBitTree[T], key: string): Node[T] =
       let ch = if it.byte < key.len: key[it.byte] else: '\0'
       let dir = (1 + (ch.ord or it.otherBits.ord)) shr 8
       it = it.child[dir]
-    
+
     var newOtherBits = 0
     var newByte = 0
     block blockX:
@@ -84,7 +84,7 @@ proc rawInsert[T](c: var CritBitTree[T], key: string): Node[T] =
     newOtherBits = newOtherBits xor 255
     let ch = it.key[newByte]
     let dir = (1 + (ord(ch) or newOtherBits)) shr 8
-    
+
     var inner: Node[T]
     new inner
     new result
@@ -93,7 +93,7 @@ proc rawInsert[T](c: var CritBitTree[T], key: string): Node[T] =
     inner.otherBits = chr(newOtherBits)
     inner.byte = newByte
     inner.child[1 - dir] = result
-    
+
     var wherep = addr(c.root)
     while true:
       var p = wherep[]
@@ -132,20 +132,31 @@ proc `[]=`*[T](c: var CritBitTree[T], key: string, val: T) =
   var n = rawInsert(c, key)
   n.val = val
 
-proc `[]`*[T](c: CritBitTree[T], key: string): T {.inline.} =
-  ## retrieves the value at ``c[key]``. If `key` is not in `t`,
-  ## default empty value for the type `B` is returned
-  ## and no exception is raised. One can check with ``hasKey`` whether the key
-  ## exists.
+template get[T](c: CritBitTree[T], key: string): T {.immediate.} =
   let n = rawGet(c, key)
   if n != nil: result = n.val
+  else:
+    when compiles($key):
+      raise newException(KeyError, "key not found: " & $key)
+    else:
+      raise newException(KeyError, "key not found")
 
-proc mget*[T](c: var CritBitTree[T], key: string): var T {.inline.} =
+proc `[]`*[T](c: CritBitTree[T], key: string): T {.inline.} =
+  ## retrieves the value at ``c[key]``. If `key` is not in `t`, the
+  ## ``KeyError`` exception is raised. One can check with ``hasKey`` whether
+  ## the key exists.
+  get(c, key)
+
+proc `[]`*[T](c: var CritBitTree[T], key: string): var T {.inline.} =
   ## retrieves the value at ``c[key]``. The value can be modified.
   ## If `key` is not in `t`, the ``KeyError`` exception is raised.
-  let n = rawGet(c, key)
-  if n != nil: result = n.val
-  else: raise newException(KeyError, "key not found: " & $key)
+  get(c, key)
+
+proc mget*[T](c: var CritBitTree[T], key: string): var T {.inline, deprecated.} =
+  ## retrieves the value at ``c[key]``. The value can be modified.
+  ## If `key` is not in `t`, the ``KeyError`` exception is raised.
+  ## Use ```[]``` instead.
+  get(c, key)
 
 proc excl*[T](c: var CritBitTree[T], key: string) =
   ## removes `key` (and its associated value) from the set `c`.
@@ -176,7 +187,7 @@ iterator leaves[T](n: Node[T]): Node[T] =
     # XXX actually we could compute the necessary stack size in advance:
     # it's roughly log2(c.count).
     var stack = @[n]
-    while stack.len > 0: 
+    while stack.len > 0:
       var it = stack.pop
       while not it.isLeaf:
         stack.add(it.child[1])
@@ -205,7 +216,7 @@ iterator items*[T](c: CritBitTree[T]): string =
 iterator pairs*[T](c: CritBitTree[T]): tuple[key: string, val: T] =
   ## yields all (key, value)-pairs of `c`.
   for x in leaves(c.root): yield (x.key, x.val)
-  
+
 iterator mpairs*[T](c: var CritBitTree[T]): tuple[key: string, val: var T] =
   ## yields all (key, value)-pairs of `c`. The yielded values can be modified.
   for x in leaves(c.root): yield (x.key, x.val)
@@ -251,7 +262,7 @@ iterator pairsWithPrefix*[T](c: CritBitTree[T],
   ## yields all (key, value)-pairs of `c` starting with `prefix`.
   let top = allprefixedAux(c, prefix)
   for x in leaves(top): yield (x.key, x.val)
-  
+
 iterator mpairsWithPrefix*[T](c: var CritBitTree[T],
                               prefix: string): tuple[key: string, val: var T] =
   ## yields all (key, value)-pairs of `c` starting with `prefix`.
@@ -297,7 +308,6 @@ when isMainModule:
 
   for w in r.items:
     echo w
-    
+
   for w in r.itemsWithPrefix("de"):
     echo w
-

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -154,7 +154,7 @@ proc rawGetKnownHC[A](s: HashSet[A], key: A, hc: THash): int {.inline.} =
 proc rawGet[A](s: HashSet[A], key: A, hc: var THash): int {.inline.} =
   rawGetImpl()
 
-proc mget*[A](s: var HashSet[A], key: A): var A =
+proc `[]`*[A](s: var HashSet[A], key: A): var A =
   ## returns the element that is actually stored in 's' which has the same
   ## value as 'key' or raises the ``EInvalidKey`` exception. This is useful
   ## when one overloaded 'hash' and '==' but still needs reference semantics
@@ -164,6 +164,13 @@ proc mget*[A](s: var HashSet[A], key: A): var A =
   var index = rawGet(s, key, hc)
   if index >= 0: result = s.data[index].key
   else: raise newException(KeyError, "key not found: " & $key)
+
+proc mget*[A](s: var HashSet[A], key: A): var A {.deprecated.} =
+  ## returns the element that is actually stored in 's' which has the same
+  ## value as 'key' or raises the ``EInvalidKey`` exception. This is useful
+  ## when one overloaded 'hash' and '==' but still needs reference semantics
+  ## for sharing. Use ```[]``` instead.
+  s[key]
 
 proc contains*[A](s: HashSet[A], key: A): bool =
   ## Returns true iff `key` is in `s`.

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -115,10 +115,15 @@ proc `[]`* (n: XmlNode, i: int): XmlNode {.inline.} =
   assert n.k == xnElement
   result = n.s[i]
 
-proc mget* (n: var XmlNode, i: int): var XmlNode {.inline.} =
+proc `[]`* (n: var XmlNode, i: int): var XmlNode {.inline.} =
   ## returns the `i`'th child of `n` so that it can be modified
   assert n.k == xnElement
   result = n.s[i]
+
+proc mget* (n: var XmlNode, i: int): var XmlNode {.inline, deprecated.} =
+  ## returns the `i`'th child of `n` so that it can be modified. Use ```[]```
+  ## instead.
+  n[i]
 
 iterator items*(n: XmlNode): XmlNode {.inline.} =
   ## iterates over any child of `n`.
@@ -128,7 +133,7 @@ iterator items*(n: XmlNode): XmlNode {.inline.} =
 iterator mitems*(n: var XmlNode): var XmlNode {.inline.} =
   ## iterates over any child of `n`.
   assert n.k == xnElement
-  for i in 0 .. n.len-1: yield mget(n, i)
+  for i in 0 .. n.len-1: yield n[i]
 
 proc attrs*(n: XmlNode): XmlAttributes {.inline.} =
   ## gets the attributes belonging to `n`.

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -18,7 +18,7 @@ proc countBits32(n: int32): int {.compilerproc.} =
   v = (v and 0x33333333'i32) +% ((v shr 2'i32) and 0x33333333'i32)
   result = ((v +% (v shr 4'i32) and 0xF0F0F0F'i32) *% 0x1010101'i32) shr 24'i32
 
-proc countBits64(n: int64): int {.compilerproc.} = 
+proc countBits64(n: int64): int {.compilerproc.} =
   result = countBits32(toU32(n and 0xffff'i64)) +
            countBits32(toU32(n shr 16'i64))
 

--- a/tests/actiontable/tactiontable.nim
+++ b/tests/actiontable/tactiontable.nim
@@ -4,24 +4,23 @@ discard """
 
 import tables
 
-proc action1(arg: string) = 
+proc action1(arg: string) =
   echo "action 1 ", arg
 
-proc action2(arg: string) = 
+proc action2(arg: string) =
   echo "action 2 ", arg
 
-proc action3(arg: string) = 
+proc action3(arg: string) =
   echo "action 3 ", arg
 
-proc action4(arg: string) = 
+proc action4(arg: string) =
   echo "action 4 ", arg
 
 var
   actionTable = {
-    "A": action1, 
-    "B": action2, 
-    "C": action3, 
+    "A": action1,
+    "B": action2,
+    "C": action3,
     "D": action4}.toTable
 
 actionTable["C"]("arg")
-

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -22,15 +22,15 @@ const
     "---00": 346677844,
     "0": 34404,
     "1": 344004,
-    "10": 34484, 
+    "10": 34484,
     "11": 34474,
     "12": 789,
     "19": 34464,
-    "2": 344774, "20": 34454, 
+    "2": 344774, "20": 34454,
     "3": 342244, "30": 34141244,
     "34": 123456,
     "4": 3412344, "40": 344114,
-    "5": 341232144, "50": 344490, 
+    "5": 341232144, "50": 344490,
     "6": 34214544, "60": 344491,
     "7": 3434544, "70": 344492,
     "8": 344544, "80": 344497,
@@ -46,7 +46,7 @@ block tableTest1:
   for x in 0..1:
     for y in 0..1:
       assert t[(x,y)] == $x & $y
-  assert($t == 
+  assert($t ==
     "{(x: 0, y: 1): 01, (x: 0, y: 0): 00, (x: 1, y: 0): 10, (x: 1, y: 1): 11}")
 
 block tableTest2:
@@ -55,14 +55,17 @@ block tableTest2:
   t["111"] = 1.000043
   t["123"] = 1.23
   t.del("111")
-  
+
   t["012"] = 67.9
   t["123"] = 1.5 # test overwriting
-  
+
   assert t["123"] == 1.5
-  assert t["111"] == 0.0 # deleted
+  try:
+    echo t["111"] # deleted
+  except KeyError:
+    discard
   assert(not hasKey(t, "111"))
-  
+
   for key, val in items(data): t[key] = val.toFloat
   for key, val in items(data): assert t[key] == val.toFloat
 

--- a/tests/collections/ttablesref.nim
+++ b/tests/collections/ttablesref.nim
@@ -22,15 +22,15 @@ const
     "---00": 346677844,
     "0": 34404,
     "1": 344004,
-    "10": 34484, 
+    "10": 34484,
     "11": 34474,
     "12": 789,
     "19": 34464,
-    "2": 344774, "20": 34454, 
+    "2": 344774, "20": 34454,
     "3": 342244, "30": 34141244,
     "34": 123456,
     "4": 3412344, "40": 344114,
-    "5": 341232144, "50": 344490, 
+    "5": 341232144, "50": 344490,
     "6": 34214544, "60": 344491,
     "7": 3434544, "70": 344492,
     "8": 344544, "80": 344497,
@@ -46,7 +46,7 @@ block tableTest1:
   for x in 0..1:
     for y in 0..1:
       assert t[(x,y)] == $x & $y
-  assert($t == 
+  assert($t ==
     "{(x: 0, y: 1): 01, (x: 0, y: 0): 00, (x: 1, y: 0): 10, (x: 1, y: 1): 11}")
 
 block tableTest2:
@@ -55,17 +55,20 @@ block tableTest2:
   t["111"] = 1.000043
   t["123"] = 1.23
   t.del("111")
-  
+
   t["012"] = 67.9
   t["123"] = 1.5 # test overwriting
-  
+
   assert t["123"] == 1.5
-  assert t["111"] == 0.0 # deleted
+  try:
+    echo t["111"] # deleted
+  except KeyError:
+    discard
   assert(not hasKey(t, "111"))
-  
+
   for key, val in items(data): t[key] = val.toFloat
   for key, val in items(data): assert t[key] == val.toFloat
-  
+
 
 block orderedTableTest1:
   var t = newOrderedTable[string, int](2)

--- a/tests/misc/teventemitter.nim
+++ b/tests/misc/teventemitter.nim
@@ -13,21 +13,20 @@ proc emit*(emitter: EventEmitter, event: string, args: EventArgs) =
   for fn in nodes(emitter.events[event]):
     fn.value(args) #call function with args.
 
-proc on*(emitter: var EventEmitter, event: string, 
+proc on*(emitter: var EventEmitter, event: string,
          fn: proc(e: EventArgs) {.nimcall.}) =
   if not hasKey(emitter.events, event):
     var list: DoublyLinkedList[proc(e: EventArgs) {.nimcall.}]
     add(emitter.events, event, list) #if not, add it.
-  append(emitter.events.mget(event), fn)
+  append(emitter.events[event], fn)
 
 proc initEmitter(emitter: var EventEmitter) =
-  emitter.events = initTable[string, 
+  emitter.events = initTable[string,
     DoublyLinkedList[proc(e: EventArgs) {.nimcall.}]]()
 
-var 
+var
   ee: EventEmitter
   args: EventArgs
 initEmitter(ee)
 ee.on("print", proc(e: EventArgs) = echo("pie"))
 ee.emit("print", args)
-

--- a/tests/stdlib/tmget.nim
+++ b/tests/stdlib/tmget.nim
@@ -1,0 +1,141 @@
+discard """
+  output: '''Can't access 6
+10
+11
+Can't access 6
+10
+11
+Can't access 6
+10
+11
+Can't access 6
+10
+11
+Can't access 6
+10
+11
+Can't access 6
+10
+11
+Can't access 6
+5
+Can't access 6
+10
+11
+Can't access 6
+10
+11'''
+"""
+
+import tables
+
+block:
+  var x = initTable[int, int]()
+  x[5] = 10
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+  x[5] += 1
+  var c = x[5]
+  echo c
+
+block:
+  var x = newTable[int, int]()
+  x[5] = 10
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+  x[5] += 1
+  var c = x[5]
+  echo c
+
+block:
+  var x = initOrderedTable[int, int]()
+  x[5] = 10
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+  x[5] += 1
+  var c = x[5]
+  echo c
+
+block:
+  var x = newOrderedTable[int, int]()
+  x[5] = 10
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+  x[5] += 1
+  var c = x[5]
+  echo c
+
+block:
+  var x = initCountTable[int]()
+  x[5] = 10
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+  x[5] += 1
+  var c = x[5]
+  echo c
+
+block:
+  var x = newCountTable[int]()
+  x[5] = 10
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+  x[5] += 1
+  var c = x[5]
+  echo c
+
+import sets
+
+block:
+  var x = initSet[int]()
+  x.incl 5
+  try:
+    echo x[6]
+  except KeyError:
+    echo "Can't access 6"
+  echo x[5]
+
+import critbits
+
+block:
+  var x: CritBitTree[int]
+  x["5"] = 10
+  try:
+    echo x["6"]
+  except KeyError:
+    echo "Can't access 6"
+  echo x["5"]
+  x["5"] += 1
+  var c = x["5"]
+  echo c
+
+import strtabs
+
+block:
+  var x = newStringTable()
+  x["5"] = "10"
+  try:
+    echo x["6"]
+  except KeyError:
+    echo "Can't access 6"
+  echo x["5"]
+  x["5"][1] = '1'
+  var c = x["5"]
+  echo c

--- a/tests/stdlib/tmitems.nim
+++ b/tests/stdlib/tmitems.nim
@@ -132,5 +132,5 @@ block:
   </Students>""")
   for x in d.mitems:
     x = <>Student(Name=x.attrs["Name"] & "foo")
-  d.mget(1).attrs["Name"] = "bar"
+  d[1].attrs["Name"] = "bar"
   echo d


### PR DESCRIPTION
- In sets, tables, strtabs, critbits, xmltree
- This uses the new var parameter overloading
- mget variants still exist, but are deprecated in favor of `[]`
- Includes tests and fixed tests and usages of mget
- The non-var `[]` now throws an exception instead of returning binary 0 or an empty string