### PR TITLE
Ignore EvError in `asyncdispatch.poll(...)` for non-windows systems

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -882,9 +882,9 @@ else:
       let data = PData(info.key.data)
       assert data.fd == info.key.fd.TAsyncFD
       #echo("In poll ", data.fd.cint)
-      if EvError in info.events:
-        closeSocket(data.fd)
-        continue
+      # There may be EvError here, but we handle them in callbacks,
+      # so that exceptions can be raised from `send(...)` and
+      # `recv(...)` routines.
 
       if EvRead in info.events:
         # Callback may add items to ``data.readCBs`` which causes issues if

--- a/tests/async/tasyncconnect.nim
+++ b/tests/async/tasyncconnect.nim
@@ -1,0 +1,33 @@
+discard """
+  file: "tasyncconnect.nim"
+  exitcode: 1
+  outputsub: "Error: unhandled exception: Connection refused [Exception]"
+"""
+
+import
+    asyncdispatch,
+    posix
+
+
+const
+    testHost = "127.0.0.1"
+    testPort = Port(17357)
+
+
+when defined(windows) or defined(nimdoc):
+    discard
+else:
+    proc testAsyncConnect() {.async.} =
+        var s = newAsyncRawSocket()
+
+        await s.connect(testHost, testPort)
+
+        var peerAddr: SockAddr
+        var addrSize = Socklen(sizeof(peerAddr))
+        var ret = SocketHandle(s).getpeername(addr(peerAddr), addr(addrSize))
+
+        if ret < 0:
+            echo("`connect(...)` failed but no exception was raised.")
+            quit(2)
+
+    waitFor(testAsyncConnect())

--- a/tests/async/tasynceverror.nim
+++ b/tests/async/tasynceverror.nim
@@ -1,0 +1,62 @@
+discard """
+  file: "tasynceverror.nim"
+  exitcode: 1
+  outputsub: "Error: unhandled exception: Connection reset by peer [Exception]"
+"""
+
+import
+    asyncdispatch,
+    asyncnet,
+    rawsockets,
+    os
+
+
+const
+    testHost = "127.0.0.1"
+    testPort = Port(17357)
+
+
+proc createListenSocket(host: string, port: Port): TAsyncFD =
+    result = newAsyncRawSocket()
+
+    SocketHandle(result).setSockOptInt(SOL_SOCKET, SO_REUSEADDR, 1)
+
+    var aiList = getAddrInfo(host, port, AF_INET)
+    if SocketHandle(result).bindAddr(aiList.ai_addr, aiList.ai_addrlen.Socklen) < 0'i32:
+      dealloc(aiList)
+      raiseOSError(osLastError())
+    dealloc(aiList)
+
+    if SocketHandle(result).listen(1) < 0'i32:
+        raiseOSError(osLastError())
+
+
+proc testAsyncSend() {.async.} =
+    var
+        ls = createListenSocket(testHost, testPort)
+        s = newAsyncSocket()
+
+    await s.connect(testHost, testPort)
+    
+    var ps = await ls.accept()
+    SocketHandle(ls).close()
+
+    await ps.send("test 1", flags={})
+    s.close()
+    # This send should raise EPIPE
+    await ps.send("test 2", flags={})
+    SocketHandle(ps).close()
+
+
+# The bug was, when the poll function handled EvError for us,
+# our callbacks may never get executed, thus making the event
+# loop block indefinitely. This is a timer to keep everything
+# rolling. 400 ms is an arbitrary value, should be enough though.
+proc timer() {.async.} =
+    await sleepAsync(400)
+    echo("Timer expired.")
+    quit(2)
+
+
+asyncCheck(testAsyncSend())
+waitFor(timer())

--- a/tests/async/tasynceverror.nim
+++ b/tests/async/tasynceverror.nim
@@ -16,47 +16,50 @@ const
     testPort = Port(17357)
 
 
-proc createListenSocket(host: string, port: Port): TAsyncFD =
-    result = newAsyncRawSocket()
+when defined(windows) or defined(nimdoc):
+    discard
+else:
+    proc createListenSocket(host: string, port: Port): TAsyncFD =
+        result = newAsyncRawSocket()
 
-    SocketHandle(result).setSockOptInt(SOL_SOCKET, SO_REUSEADDR, 1)
+        SocketHandle(result).setSockOptInt(SOL_SOCKET, SO_REUSEADDR, 1)
 
-    var aiList = getAddrInfo(host, port, AF_INET)
-    if SocketHandle(result).bindAddr(aiList.ai_addr, aiList.ai_addrlen.Socklen) < 0'i32:
-      dealloc(aiList)
-      raiseOSError(osLastError())
-    dealloc(aiList)
+        var aiList = getAddrInfo(host, port, AF_INET)
+        if SocketHandle(result).bindAddr(aiList.ai_addr, aiList.ai_addrlen.Socklen) < 0'i32:
+          dealloc(aiList)
+          raiseOSError(osLastError())
+        dealloc(aiList)
 
-    if SocketHandle(result).listen(1) < 0'i32:
-        raiseOSError(osLastError())
-
-
-proc testAsyncSend() {.async.} =
-    var
-        ls = createListenSocket(testHost, testPort)
-        s = newAsyncSocket()
-
-    await s.connect(testHost, testPort)
-    
-    var ps = await ls.accept()
-    SocketHandle(ls).close()
-
-    await ps.send("test 1", flags={})
-    s.close()
-    # This send should raise EPIPE
-    await ps.send("test 2", flags={})
-    SocketHandle(ps).close()
+        if SocketHandle(result).listen(1) < 0'i32:
+            raiseOSError(osLastError())
 
 
-# The bug was, when the poll function handled EvError for us,
-# our callbacks may never get executed, thus making the event
-# loop block indefinitely. This is a timer to keep everything
-# rolling. 400 ms is an arbitrary value, should be enough though.
-proc timer() {.async.} =
-    await sleepAsync(400)
-    echo("Timer expired.")
-    quit(2)
+    proc testAsyncSend() {.async.} =
+        var
+            ls = createListenSocket(testHost, testPort)
+            s = newAsyncSocket()
+
+        await s.connect(testHost, testPort)
+        
+        var ps = await ls.accept()
+        SocketHandle(ls).close()
+
+        await ps.send("test 1", flags={})
+        s.close()
+        # This send should raise EPIPE
+        await ps.send("test 2", flags={})
+        SocketHandle(ps).close()
 
 
-asyncCheck(testAsyncSend())
-waitFor(timer())
+    # The bug was, when the poll function handled EvError for us,
+    # our callbacks may never get executed, thus making the event
+    # loop block indefinitely. This is a timer to keep everything
+    # rolling. 400 ms is an arbitrary value, should be enough though.
+    proc timer() {.async.} =
+        await sleepAsync(400)
+        echo("Timer expired.")
+        quit(2)
+
+
+    asyncCheck(testAsyncSend())
+    waitFor(timer())


### PR DESCRIPTION
And handle I/O errors in callbacks instead, so that exceptions can be raised from `send(...)` and `recv(...)`.