### PR TITLE
 Add a handshake parameter to wrapSocket() to allow it to work on an already-connected socket.

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -87,12 +87,6 @@ type
     of false: nil
   AsyncSocket* = ref AsyncSocketDesc
 
-when defined(ssl):
-  type HandshakeType* = enum
-    handshakeNone,
-    handshakeAsClient,
-    handshakeAsServer
-
 {.deprecated: [PAsyncSocket: AsyncSocket].}
 
 # TODO: Save AF, domain etc info and reuse it in procs which need it like connect.
@@ -424,7 +418,7 @@ proc close*(socket: AsyncSocket) =
   socket.closed = true # TODO: Add extra debugging checks for this.
 
 when defined(ssl):
-  proc wrapSocket*(ctx: SslContext, socket: AsyncSocket, handshake: HandshakeType = handshakeNone) =
+  proc wrapSocket*(ctx: SslContext, socket: AsyncSocket) =
     ## Wraps a socket in an SSL context. This function effectively turns
     ## ``socket`` into an SSL socket.
     ##
@@ -440,9 +434,10 @@ when defined(ssl):
     socket.bioOut = bioNew(bio_s_mem())
     sslSetBio(socket.sslHandle, socket.bioIn, socket.bioOut)
 
+  proc wrapSocket*(ctx: SslContext, socket: AsyncSocket, handshake: SslHandshakeType) =
+    wrapSocket(ctx, socket)
+
     case handshake
-    of handshakeNone:
-      discard
     of handshakeAsClient:
       sslSetConnectState(socket.sslHandle)
     of handshakeAsServer:


### PR DESCRIPTION
(This is a new version of [pull request 2513](https://github.com/Araq/Nim/pull/2513) so it can pull from a different branch)

Some protocols involve an initial cleartext exchange before the SSL setup starts, which means having to wrap an already-connected socket. This patch adds an argument to wrapSocket() telling it to go ahead and initiate the SSL negotiation (and which side of the negotiation it's on, since SSL is asymmetric wrt the client and server).

I've tested this for both `net` and `asyncnet` but only from the client side.
