### PR TITLE
new now able to make distinction between ref and non-ref types, so we…

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -172,10 +172,16 @@ proc new*[T](a: var ref T) {.magic: "New", noSideEffect.}
   ## creates a new object of type ``T`` and returns a safe (traced)
   ## reference to it in ``a``.
 
-proc new*(T: typedesc): ref T =
+proc new*(T: typedesc): auto =
   ## creates a new object of type ``T`` and returns a safe (traced)
   ## reference to it as result value
-  new(result)
+  when (T is ref):
+      var r: T
+  else:
+      var r: ref T
+  new(r)
+  return r
+
 
 proc internalNew*[T](a: var ref T) {.magic: "New", noSideEffect.}
   ## leaked implementation detail. Do not use.


### PR DESCRIPTION
… don't get 'ref ref' type when calling new on ref type

The problem is when we have a ref type like:
```
type
    SomeType = ref object
```

and when then construct object of this ref type:
```
let o: SomeType = new(SomeType)
```
we don't get it right but receive an error like this:
```
Error: type mismatch: got (ref ObjLoader) but expected 'ObjLoader'
```

This PR tries to fix this and return ref if the parameter for new is either ref or non-ref type.