### PR TITLE
Fixes #2749, traverse full inheritance for reprRecord

### DIFF
--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -194,15 +194,15 @@ when not defined(useNimRtl):
                   cl: var TReprClosure) =
     add result, "["
     var curTyp = typ
-    var lastPart = ""
+    var first = true
     while curTyp.base != nil:
       var part = ""
       reprRecordAux(part, p, curTyp.node, cl)
       if part.len > 0:
-        if lastPart.len > 0:
+        if not first:
           add result, ",\n"
         add result, part
-      lastPart = part
+        first = false
       curTyp = curTyp.base
     add result, "]"
 

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -193,11 +193,17 @@ when not defined(useNimRtl):
   proc reprRecord(result: var string, p: pointer, typ: PNimType,
                   cl: var TReprClosure) =
     add result, "["
-    let oldLen = result.len
-    reprRecordAux(result, p, typ.node, cl)
-    if typ.base != nil: 
-      if oldLen != result.len: add result, ",\n"
-      reprRecordAux(result, p, typ.base.node, cl)
+    var curTyp = typ
+    var lastPart = ""
+    while curTyp.base != nil:
+      var part = ""
+      reprRecordAux(part, p, curTyp.node, cl)
+      if part.len > 0:
+        if lastPart.len > 0:
+          add result, ",\n"
+        add result, part
+      lastPart = part
+      curTyp = curTyp.base
     add result, "]"
 
   proc reprRef(result: var string, p: pointer, typ: PNimType,


### PR DESCRIPTION
Made reprRecord go all the way up instead of just one level (wonder who wrote that code :)) and also made it deal with "," more properly (earlier a super type without fields would add a "," anyway in output) though perhaps code can be tweaked even further. Closes #2749.