### PR TITLE
Note verbosity specified in one place & --warnings/hings:list

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -505,8 +505,7 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
     if lib.path.kind in {nkStrLit..nkTripleStrLit}:
       var s: TStringSeq = @[]
       libCandidates(lib.path.strVal, s)
-      if gVerbosity >= 2:
-        msgWriteln("Dependency: " & lib.path.strVal)
+      rawMessage(hintDependency, lib.path.strVal)
       var loadlib: Rope = nil
       for i in countup(0, high(s)):
         inc(m.labels)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -128,6 +128,18 @@ proc processOnOffSwitch(op: TOptions, arg: string, pass: TCmdLinePass,
   of wOff: gOptions = gOptions - op
   else: localError(info, errOnOrOffExpectedButXFound, arg)
 
+proc processOnOffSwitchOrList(op: TOptions, arg: string, pass: TCmdLinePass,
+                              info: TLineInfo): bool =
+  result = false
+  case whichKeyword(arg)
+  of wOn: gOptions = gOptions + op
+  of wOff: gOptions = gOptions - op
+  else:
+    if arg == "list":
+      result = true
+    else:
+      localError(info, errOnOffOrListExpectedButXFound, arg)
+
 proc processOnOffSwitchG(op: TGlobalOptions, arg: string, pass: TCmdLinePass,
                          info: TLineInfo) =
   case whichKeyword(arg)
@@ -382,10 +394,12 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
       gSelectedGC = gcNone
       defineSymbol("nogc")
     else: localError(info, errNoneBoehmRefcExpectedButXFound, arg)
-  of "warnings", "w": processOnOffSwitch({optWarns}, arg, pass, info)
+  of "warnings", "w":
+    if processOnOffSwitchOrList({optWarns}, arg, pass, info): listWarnings()
   of "warning": processSpecificNote(arg, wWarning, pass, info, switch)
   of "hint": processSpecificNote(arg, wHint, pass, info, switch)
-  of "hints": processOnOffSwitch({optHints}, arg, pass, info)
+  of "hints":
+    if processOnOffSwitchOrList({optHints}, arg, pass, info): listHints()
   of "threadanalysis": processOnOffSwitchG({optThreadAnalysis}, arg, pass, info)
   of "stacktrace": processOnOffSwitch({optStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch({optLineTrace}, arg, pass, info)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -141,6 +141,10 @@ proc expectArg(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
 proc expectNoArg(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
   if arg != "": localError(info, errCmdLineNoArgExpected, addPrefix(switch))
 
+var
+  enableNotes: TNoteKinds
+  disableNotes: TNoteKinds
+
 proc processSpecificNote(arg: string, state: TSpecialWord, pass: TCmdLinePass,
                          info: TLineInfo; orig: string) =
   var id = ""  # arg = "X]:on|off"
@@ -162,8 +166,12 @@ proc processSpecificNote(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     if x >= 0: n = TNoteKind(x + ord(warnMin))
     else: localError(info, "unknown warning: " & id)
   case whichKeyword(substr(arg, i))
-  of wOn: incl(gNotes, n)
-  of wOff: excl(gNotes, n)
+  of wOn:
+    incl(gNotes, n)
+    incl(enableNotes, n)
+  of wOff:
+    excl(gNotes, n)
+    incl(disableNotes, n)
   else: localError(info, errOnOrOffExpectedButXFound, arg)
 
 proc processCompile(filename: string) =
@@ -508,6 +516,9 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
   of "verbosity":
     expectArg(switch, arg, pass, info)
     gVerbosity = parseInt(arg)
+    gNotes = NotesVerbosity[gVerbosity]
+    incl(gNotes, enableNotes)
+    excl(gNotes, disableNotes)
   of "parallelbuild":
     expectArg(switch, arg, pass, info)
     gNumberOfProcessors = parseInt(arg)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -438,16 +438,12 @@ proc addFileToLink*(filename: string) =
   prependStr(toLink, filename)
   # BUGFIX: was ``appendStr``
 
-proc execWithEcho(cmd: string, prettyCmd = ""): int =
-  if optListCmd in gGlobalOptions or gVerbosity > 0:
-    if prettyCmd != "":
-      msgWriteln(prettyCmd)
-    else:
-      msgWriteln(cmd)
+proc execWithEcho(cmd: string, msg = hintExecuting): int =
+  rawMessage(msg, cmd)
   result = execCmd(cmd)
 
-proc execExternalProgram*(cmd: string, prettyCmd = "") =
-  if execWithEcho(cmd, prettyCmd) != 0:
+proc execExternalProgram*(cmd: string, msg = hintExecuting) =
+  if execWithEcho(cmd, msg) != 0:
     rawMessage(errExecutionOfProgramFailed, "")
 
 proc generateScript(projectFile: string, script: Rope) =
@@ -703,10 +699,8 @@ proc callCCompiler*(projectfile: string) =
           "nim", quoteShell(getPrefixDir()),
           "lib", quoteShell(libpath)])
     if optCompileOnly notin gGlobalOptions:
-      if gVerbosity == 1:
-        execExternalProgram(linkCmd, "[Linking]")
-      else:
-        execExternalProgram(linkCmd)
+      execExternalProgram(linkCmd,
+                          if gVerbosity > 1: hintExecuting else: hintLinking)
   else:
     linkCmd = ""
   if optGenScript in gGlobalOptions:

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -359,9 +359,8 @@ proc mainCommand* =
   else:
     rawMessage(errInvalidCommandX, command)
 
-  if (msgs.gErrorCounter == 0 and
-      gCmd notin {cmdInterpret, cmdRun, cmdDump} and
-      gVerbosity > 0):
+  if msgs.gErrorCounter == 0 and
+     gCmd notin {cmdInterpret, cmdRun, cmdDump}:
     rawMessage(hintSuccessX, [$gLinesCompiled,
                formatFloat(epochTime() - gLastCmdTime, ffDecimal, 3),
                formatSize(getTotalMem()),

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -127,7 +127,7 @@ type
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
     hintExecuting, hintLinking, hintDependency,
-    hintSource,
+    hintSource, hintStackTrace,
     hintUser
 
 const
@@ -422,6 +422,7 @@ const
     hintLinking: "",
     hintDependency: "$1",
     hintSource: "$1",
+    hintStackTrace: "$1",
     hintUser: "$1"]
 
 const
@@ -437,11 +438,11 @@ const
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]
 
-  HintsToStr*: array[0..20, string] = ["Success", "SuccessX", "LineTooLong",
+  HintsToStr*: array[0..21, string] = ["Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
-    "Source",
+    "Source", "StackTrace",
     "User"]
 
 const
@@ -502,15 +503,15 @@ const
                                          hintDependency,
                                          hintExecuting, hintLinking,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource},
+                                         hintSource, hintStackTrace},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
                                          warnGcUnsafe,
                                          hintDependency,
                                          hintExecuting,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource},
-    {low(TNoteKind)..high(TNoteKind)},
+                                         hintSource, hintStackTrace},
+    {low(TNoteKind)..high(TNoteKind)} - {hintStackTrace},
     {low(TNoteKind)..high(TNoteKind)}]
 
 const
@@ -787,7 +788,7 @@ type
 
 proc handleError(msg: TMsgKind, eh: TErrorHandling, s: string) =
   template quit =
-    if defined(debug) or gVerbosity >= 3 or msg == errInternal:
+    if defined(debug) or msg == errInternal or hintStackTrace in gNotes:
       if stackTraceAvailable() and isNil(writelnHook):
         writeStackTrace()
       else:

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -127,6 +127,7 @@ type
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
     hintExecuting, hintLinking, hintDependency,
+    hintSource,
     hintUser
 
 const
@@ -420,6 +421,7 @@ const
     hintExecuting: "$1",
     hintLinking: "",
     hintDependency: "$1",
+    hintSource: "$1",
     hintUser: "$1"]
 
 const
@@ -435,10 +437,11 @@ const
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]
 
-  HintsToStr*: array[0..19, string] = ["Success", "SuccessX", "LineTooLong",
+  HintsToStr*: array[0..20, string] = ["Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
+    "Source",
     "User"]
 
 const
@@ -498,13 +501,15 @@ const
                                          hintProcessing,
                                          hintDependency,
                                          hintExecuting, hintLinking,
-                                         hintCodeBegin, hintCodeEnd},
+                                         hintCodeBegin, hintCodeEnd,
+                                         hintSource},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
                                          warnGcUnsafe,
                                          hintDependency,
                                          hintExecuting,
-                                         hintCodeBegin, hintCodeEnd},
+                                         hintCodeBegin, hintCodeEnd,
+                                         hintSource},
     {low(TNoteKind)..high(TNoteKind)},
     {low(TNoteKind)..high(TNoteKind)}]
 
@@ -912,7 +917,7 @@ proc liMessage(info: TLineInfo, msg: TMsgKind, arg: string,
                        KindColor, `%`(KindFormat, kind))
     else:
       styledMsgWriteln(styleBright, x, resetStyle, color, title, resetStyle, s)
-    if optPrintSurroundingSrc and msg in errMin..errMax:
+    if msg in errMin..errMax and hintSource in gNotes:
       info.writeSurroundingSrc
   handleError(msg, eh, s)
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -127,7 +127,7 @@ type
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
     hintExecuting, hintLinking, hintDependency,
-    hintSource, hintStackTrace,
+    hintSource, hintStackTrace, hintGCStats,
     hintUser
 
 const
@@ -423,6 +423,7 @@ const
     hintDependency: "$1",
     hintSource: "$1",
     hintStackTrace: "$1",
+    hintGCStats: "$1",
     hintUser: "$1"]
 
 const
@@ -438,11 +439,11 @@ const
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]
 
-  HintsToStr*: array[0..21, string] = ["Success", "SuccessX", "LineTooLong",
+  HintsToStr*: array[0..22, string] = ["Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
-    "Source", "StackTrace",
+    "Source", "StackTrace", "GCStats",
     "User"]
 
 const
@@ -503,14 +504,16 @@ const
                                          hintDependency,
                                          hintExecuting, hintLinking,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintStackTrace},
+                                         hintSource, hintStackTrace,
+                                         hintGCStats},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
                                          warnGcUnsafe,
                                          hintDependency,
                                          hintExecuting,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintStackTrace},
+                                         hintSource, hintStackTrace,
+                                         hintGCStats},
     {low(TNoteKind)..high(TNoteKind)} - {hintStackTrace},
     {low(TNoteKind)..high(TNoteKind)}]
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -484,6 +484,21 @@ type
   ESuggestDone* = object of Exception
 
 const
+  NotesVerbosity*: array[0..3, TNoteKinds] = [
+    {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
+                                         warnProveField, warnProveIndex,
+                                         warnGcUnsafe,
+                                         hintSuccessX, hintPath, hintConf,
+                                         hintProcessing,
+                                         hintCodeBegin, hintCodeEnd},
+    {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
+                                         warnProveField, warnProveIndex,
+                                         warnGcUnsafe,
+                                         hintCodeBegin, hintCodeEnd},
+    {low(TNoteKind)..high(TNoteKind)},
+    {low(TNoteKind)..high(TNoteKind)}]
+
+const
   InvalidFileIDX* = int32(-1)
 
 var
@@ -571,9 +586,7 @@ proc raiseRecoverableError*(msg: string) {.noinline, noreturn.} =
 proc sourceLine*(i: TLineInfo): Rope
 
 var
-  gNotes*: TNoteKinds = {low(TNoteKind)..high(TNoteKind)} -
-                        {warnShadowIdent, warnUninit,
-                         warnProveField, warnProveIndex, warnGcUnsafe}
+  gNotes*: TNoteKinds = NotesVerbosity[1] # defaults to verbosity of 1
   gErrorCounter*: int = 0     # counts the number of errors
   gHintCounter*: int = 0
   gWarnCounter*: int = 0

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -126,7 +126,7 @@ type
     hintConvFromXtoItselfNotNeeded, hintExprAlwaysX, hintQuitCalled,
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
-    hintExecuting, hintLinking,
+    hintExecuting, hintLinking, hintDependency,
     hintUser
 
 const
@@ -419,6 +419,7 @@ const
     hintPattern: "$1",
     hintExecuting: "$1",
     hintLinking: "",
+    hintDependency: "$1",
     hintUser: "$1"]
 
 const
@@ -434,10 +435,10 @@ const
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]
 
-  HintsToStr*: array[0..18, string] = ["Success", "SuccessX", "LineTooLong",
+  HintsToStr*: array[0..19, string] = ["Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
-    "Path", "CondTrue", "Name", "Pattern", "Exec", "Link",
+    "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
     "User"]
 
 const
@@ -495,11 +496,13 @@ const
                                          warnGcUnsafe,
                                          hintSuccessX, hintPath, hintConf,
                                          hintProcessing,
+                                         hintDependency,
                                          hintExecuting, hintLinking,
                                          hintCodeBegin, hintCodeEnd},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
                                          warnGcUnsafe,
+                                         hintDependency,
                                          hintExecuting,
                                          hintCodeBegin, hintCodeEnd},
     {low(TNoteKind)..high(TNoteKind)},

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -30,7 +30,8 @@ type
     errStmtInvalidAfterReturn, errStmtExpected, errInvalidLabel,
     errInvalidCmdLineOption, errCmdLineArgExpected, errCmdLineNoArgExpected,
     errInvalidVarSubstitution, errUnknownVar, errUnknownCcompiler,
-    errOnOrOffExpectedButXFound, errNoneBoehmRefcExpectedButXFound,
+    errOnOrOffExpectedButXFound, errOnOffOrListExpectedButXFound,
+    errNoneBoehmRefcExpectedButXFound,
     errNoneSpeedOrSizeExpectedButXFound, errGuiConsoleOrLibExpectedButXFound,
     errUnknownOS, errUnknownCPU, errGenOutExpectedButXFound,
     errArgsNeedRunOption, errInvalidMultipleAsgn, errColonOrEqualsExpected,
@@ -181,6 +182,7 @@ const
     errUnknownVar: "unknown variable: \'$1\'",
     errUnknownCcompiler: "unknown C compiler: \'$1\'",
     errOnOrOffExpectedButXFound: "\'on\' or \'off\' expected, but \'$1\' found",
+    errOnOffOrListExpectedButXFound: "\'on\', \'off\' or \'list\' expected, but \'$1\' found",
     errNoneBoehmRefcExpectedButXFound: "'none', 'boehm' or 'refc' expected, but '$1' found",
     errNoneSpeedOrSizeExpectedButXFound: "'none', 'speed' or 'size' expected, but '$1' found",
     errGuiConsoleOrLibExpectedButXFound: "'gui', 'console' or 'lib' expected, but '$1' found",
@@ -972,6 +974,22 @@ ropes.errorHandler = proc (err: RopesError, msg: string, useWarning: bool) =
     internalError("ropes: invalid format string: " & msg)
   of rCannotOpenFile:
     rawMessage(if useWarning: warnCannotOpenFile else: errCannotOpenFile, msg)
+
+proc listWarnings*() =
+  msgWriteln("Warnings:")
+  for warn in warnMin..warnMax:
+    msgWriteln("  [$1] $2" % [
+      if warn in gNotes: "x" else: " ",
+      msgs.WarningsToStr[ord(warn) - ord(warnMin)]
+    ])
+
+proc listHints*() =
+  msgWriteln("Hints:")
+  for hint in hintMin..hintMax:
+    msgWriteln("  [$1] $2" % [
+      if hint in gNotes: "x" else: " ",
+      msgs.HintsToStr[ord(hint) - ord(hintMin)]
+    ])
 
 # enable colors by default on terminals
 if terminal.isatty(stdout):

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -126,6 +126,7 @@ type
     hintConvFromXtoItselfNotNeeded, hintExprAlwaysX, hintQuitCalled,
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
+    hintExecuting, hintLinking,
     hintUser
 
 const
@@ -416,6 +417,8 @@ const
     hintConditionAlwaysTrue: "condition is always true: '$1'",
     hintName: "name should be: '$1'",
     hintPattern: "$1",
+    hintExecuting: "$1",
+    hintLinking: "",
     hintUser: "$1"]
 
 const
@@ -431,10 +434,10 @@ const
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]
 
-  HintsToStr*: array[0..16, string] = ["Success", "SuccessX", "LineTooLong",
+  HintsToStr*: array[0..18, string] = ["Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
-    "Path", "CondTrue", "Name", "Pattern",
+    "Path", "CondTrue", "Name", "Pattern", "Exec", "Link",
     "User"]
 
 const
@@ -492,10 +495,12 @@ const
                                          warnGcUnsafe,
                                          hintSuccessX, hintPath, hintConf,
                                          hintProcessing,
+                                         hintExecuting, hintLinking,
                                          hintCodeBegin, hintCodeEnd},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
                                          warnGcUnsafe,
+                                         hintExecuting,
                                          hintCodeBegin, hintCodeEnd},
     {low(TNoteKind)..high(TNoteKind)},
     {low(TNoteKind)..high(TNoteKind)}]

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -59,7 +59,7 @@ proc handleCmdLine() =
     extccomp.initVars()
     processCmdLine(passCmd2, "")
     mainCommand()
-    if gVerbosity >= 2: echo(GC_getStatistics())
+    if optHints in gOptions and hintGCStats in gNotes: echo(GC_getStatistics())
     #echo(GC_getStatistics())
     if msgs.gErrorCounter == 0:
       when hasTinyCBackend:

--- a/compiler/nimblecmd.nim
+++ b/compiler/nimblecmd.nim
@@ -60,7 +60,7 @@ iterator chosen(packages: StringTableRef): string =
 
 proc addNimblePath(p: string, info: TLineInfo) =
   if not contains(options.searchPaths, p):
-    if gVerbosity >= 1: message(info, hintPath, p)
+    message(info, hintPath, p)
     lists.prependStr(options.lazyPaths, p)
 
 proc addPathWithNimFiles(p: string, info: TLineInfo) =

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -211,7 +211,7 @@ proc readConfigFile(filename: string) =
     while tok.tokType != tkEof: parseAssignment(L, tok)
     if len(condStack) > 0: lexMessage(L, errTokenExpected, "@end")
     closeLexer(L)
-    if gVerbosity >= 1: rawMessage(hintConf, filename)
+    rawMessage(hintConf, filename)
 
 proc getUserConfigPath(filename: string): string =
   result = joinPath(getConfigDir(), filename)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -127,9 +127,6 @@ template compilationCachePresent*: expr =
 template optPreserveOrigSource*: expr =
   optEmbedOrigSrc in gGlobalOptions
 
-template optPrintSurroundingSrc*: expr =
-  gVerbosity >= 2
-
 const
   genSubDir* = "nimcache"
   NimExt* = "nim"

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -15,7 +15,7 @@ import
 proc verboseOpen(s: PSym): PPassContext =
   #MessageOut('compiling ' + s.name.s);
   result = nil                # we don't need a context
-  if gVerbosity > 0: rawMessage(hintProcessing, s.name.s)
+  rawMessage(hintProcessing, s.name.s)
   
 proc verboseProcess(context: PPassContext, n: PNode): PNode = 
   result = n

--- a/compiler/rodread.nim
+++ b/compiler/rodread.nim
@@ -838,7 +838,7 @@ proc checkDep(fileIdx: int32): TReasonForRecompile =
         if res != rrNone:
           result = rrModDeps
           # we cannot break here, because of side-effects of `checkDep`
-  if result != rrNone and gVerbosity > 0:
+  if result != rrNone:
     rawMessage(hintProcessing, reasonToFrmt[result] % filename)
   if result != rrNone or optForceFullMake in gGlobalOptions:
     # recompilation is necessary:

--- a/compiler/syntaxes.nim
+++ b/compiler/syntaxes.nim
@@ -139,7 +139,7 @@ proc applyFilter(p: var TParsers, n: PNode, filename: string,
   of filtReplace: 
     result = filterReplace(stdin, filename, n)
   if f != filtNone: 
-    if gVerbosity >= 2: 
+    if hintCodeBegin in gNotes:
       rawMessage(hintCodeBegin, [])
       msgWriteln(result.s)
       rawMessage(hintCodeEnd, [])

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -18,9 +18,10 @@ Advanced options:
   --stdout                  output to stdout
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths           list full paths in messages
-  -w, --warnings:on|off     turn all warnings on|off
+  -w:on|off|list, --warnings:on|off|list
+                            turn all warnings on|off or list all available
   --warning[X]:on|off       turn specific warning X on|off
-  --hints:on|off            turn all hints on|off
+  --hints:on|off|list       turn all hints on|off or list all available
   --hint[X]:on|off          turn specific hint X on|off
   --lib:PATH                set the system library path
   --import:PATH             add an automatically imported module


### PR DESCRIPTION
This PR extends flexibility manipulating notes (warnings, hints) via command line. This PR does not change any existing behavior, so notes are displayed at exactly same verbosity levels as before.

### Problems solved

1. Some notes were enabled explicitly for some verbosity levels, so
   `--hintName:on` has no effect if verbosity level was too low.

2. Verbosity level for notes is not longer scattered across the source code,
   instead if now lives in `msgs.nim` `NotesVerbosity` array

3. Individual note settings have stronger effect than verbosity setting,
   so `--hintName:off` will disable hint regardless of high verbosity setting,
   and vice-versa `--hintName:on` will enable hint even on low verbosity setting.

4. Added command line `--warnings/hints:list` that allow list and check status
   of individual notes.
