### PR TITLE
Fixed parse command line with whitespaces issue

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -26,7 +26,7 @@ bootSwitch(usedNoGC, defined(nogc), "--gc:none")
 
 import
   os, msgs, options, nversion, condsyms, strutils, extccomp, platform, lists,
-  wordrecg, parseutils, nimblecmd, idents, parseopt
+  wordrecg, parseutils, nimblecmd, idents, parseopt2
 
 # but some have deps to imported modules. Yay.
 bootSwitch(usedTinyC, hasTinyCBackend, "-d:tinyc")

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -37,7 +37,7 @@ proc handleCmdLine() =
     writeCommandLineUsage()
   else:
     # Process command line arguments:
-    processCmdLine(passCmd1, "")
+    processCmdLine(passCmd1, @[])
     if gProjectName == "-":
       gProjectName = "stdinfile"
       gProjectFull = "stdinfile"
@@ -57,7 +57,7 @@ proc handleCmdLine() =
     # now process command line arguments again, because some options in the
     # command line can overwite the config file's settings
     extccomp.initVars()
-    processCmdLine(passCmd2, "")
+    processCmdLine(passCmd2, @[])
     mainCommand()
     if gVerbosity >= 2: echo(GC_getStatistics())
     #echo(GC_getStatistics())

--- a/compiler/service.nim
+++ b/compiler/service.nim
@@ -11,7 +11,7 @@
 
 import
   times, commands, options, msgs, nimconf,
-  extccomp, strutils, os, platform, parseopt
+  extccomp, strutils, os, platform, parseopt2
 
 when useCaas:
   import net
@@ -26,11 +26,11 @@ var
     # in caas mode, the list of defines and options will be given at start-up?
     # it's enough to check that the previous compilation command is the same?
 
-proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
-  var p = parseopt.initOptParser(cmd)
+proc processCmdLine*(pass: TCmdLinePass, cmd: seq[string]) =
+  var p = parseopt2.initOptParser(if cmd.len == 0: commandLineParams() else: cmd)
   var argsCount = 0
   while true:
-    parseopt.next(p)
+    parseopt2.next(p)
     case p.kind
     of cmdEnd: break
     of cmdLongoption, cmdShortOption:
@@ -48,7 +48,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
 proc serve*(action: proc (){.nimcall.}) =
   template execute(cmd) =
     curCaasCmd = cmd
-    processCmdLine(passCmd2, cmd)
+    processCmdLine(passCmd2, parseCmdLine(cmd))
     action()
     gErrorCounter = 0
 


### PR DESCRIPTION
This is a fix for #2874. I think, maybe we should use sequence of string as command line parameters, not string, and let the shell do parsing using it's rules.

Also, parseopt is deprecated, so parseopt2 used.