### PR TITLE
Real node compare for macros

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -682,11 +682,15 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcLtu:
       decodeBC(rkInt)
       regs[ra].intVal = ord(regs[rb].intVal <% regs[rc].intVal)
-    of opcEqRef, opcEqNimrodNode:
+    of opcEqRef:
       decodeBC(rkInt)
       regs[ra].intVal = ord((regs[rb].node.kind == nkNilLit and
                              regs[rc].node.kind == nkNilLit) or
                              regs[rb].node == regs[rc].node)
+    of opcEqNimrodNode:
+      decodeBC(rkInt)
+      regs[ra].intVal =
+        ord(exprStructuralEquivalent(regs[rb].node, regs[rc].node))
     of opcXor:
       decodeBC(rkInt)
       regs[ra].intVal = ord(regs[rb].intVal != regs[rc].intVal)

--- a/tests/macros/tnodecompare.nim
+++ b/tests/macros/tnodecompare.nim
@@ -1,0 +1,39 @@
+discard """
+output: '''1
+0
+1
+0
+1
+0
+1
+0'''
+"""
+
+import macros
+
+macro test(a: typed, b: typed): expr =
+  newLit(a == b)
+
+echo test(1, 1)
+echo test(1, 2)
+
+type
+  Obj = object of RootObj
+  Other = object of RootObj
+
+echo test(Obj, Obj)
+echo test(Obj, Other)
+
+var a, b: int
+
+echo test(a, a)
+echo test(a, b)
+
+macro test2: expr =
+  newLit(bindSym"Obj" == bindSym"Obj")
+
+macro test3: expr =
+  newLit(bindSym"Obj" == bindSym"Other")
+
+echo test2()
+echo test3()


### PR DESCRIPTION
Introduces `==` operator for `TNode` next, it uses that to compare nodes for VM's `opcEqNimrodNode` (aka `==` operator from *macros* module).

@Araq This is as we discussed on IRC, nodes shouldn't be compared just pointer wise in macros.