### PR TITLE
Fixed copying of aggregates in JS.

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -817,7 +817,7 @@ proc genAsgnAux(p: PProc, x, y: PNode, noCopyNeeded: bool) =
       addf(p.body, "$1 = $2;$n", [a.rdLoc, b.rdLoc])
     else:
       useMagic(p, "nimCopy")
-      addf(p.body, "$1 = nimCopy($2, $3);$n",
+      addf(p.body, "$1 = nimCopy($1, $2, $3);$n",
            [a.res, b.res, genTypeInfo(p, y.typ)])
   of etyBaseIndex:
     if a.typ != etyBaseIndex or b.typ != etyBaseIndex:
@@ -1206,7 +1206,7 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
         s = a.res
       else:
         useMagic(p, "nimCopy")
-        s = "nimCopy($1, $2)" % [a.res, genTypeInfo(p, n.typ)]
+        s = "nimCopy(null, $1, $2)" % [a.res, genTypeInfo(p, n.typ)]
     of etyBaseIndex:
       if (a.typ != etyBaseIndex): internalError(n.info, "genVarInit")
       if {sfAddrTaken, sfGlobal} * v.flags != {}:

--- a/tests/js/tcopying.nim
+++ b/tests/js/tcopying.nim
@@ -1,0 +1,13 @@
+discard """
+  output: '''123
+'''
+"""
+
+type MyArray = array[1, int]
+
+proc changeArray(a: var MyArray) =
+    a = [123]
+
+var a : MyArray
+changeArray(a)
+echo a[0]


### PR DESCRIPTION
Copying of aggregate types will not create new objects, but reuse lvalues instead. Also added a test to demonstrate the fixed bug.