### PR TITLE
Fixed unittest output.

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -39,7 +39,6 @@ when declared(stdout):
 
 when not defined(ECMAScript):
   import terminal
-  system.addQuitProc(resetAttributes)
 
 type
   TestStatus* = enum OK, FAILED


### PR DESCRIPTION
Inspired by "failing" options.nim test, which in fact did not fail, but it's output differs from expected. The reason for it is ``unittest.nim`` writes an escape sequence to terminal upon program exit to reset the attributes. However this is not needed, because that is done by ``styledEcho`` already, and it is needed only in case of messing with attributes directly, which ``unittest.nim`` doesn't do. Oh yeah, and ``options.nim`` does not fail anymore ;)