### PR TITLE
Fixed #1985

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1304,7 +1304,9 @@ iterator walkDir*(dir: string): tuple[kind: PathComponent, path: string] {.
           when defined(linux) or defined(macosx) or defined(bsd):
             if x.d_type != DT_UNKNOWN:
               if x.d_type == DT_DIR: k = pcDir
-              if x.d_type == DT_LNK: k = succ(k)
+              if x.d_type == DT_LNK:
+                if dirExists(y): k = pcLinkToDir
+                else: k = succ(k)
               yield (k, y)
               continue
 


### PR DESCRIPTION
``` Nimrod
import os
const target = "target_dir"

proc test() =
  discard execShellCmd("mkdir -p source_dir")
  if not target.existsDir:
    discard execShellCmd("ln -s source_dir " & target)

  for kind, path in walkDir("."):
    echo kind, " with path '", path, "'"

when isMainModule: test()
```
Output:
```
pcDir with path './source_dir'
pcLinkToDir with path './target_dir'
```