### PR TITLE
Fixed gcc batch issue

### DIFF
--- a/tools/niminst/buildbat.tmpl
+++ b/tools/niminst/buildbat.tmpl
@@ -18,13 +18,13 @@ REM call the compiler:
 #    for ff in items(c.cfiles[winIndex][cpuIndex]):
 #      let f = ff.toWin
 ECHO %CC% %COMP_FLAGS% -Ic_code -c ?{f} -o ?{changeFileExt(f, "o")}
-%CC% %COMP_FLAGS% -Ic_code -c ?{f} -o ?{changeFileExt(f, "o")}
+CALL %CC% %COMP_FLAGS% -Ic_code -c ?{f} -o ?{changeFileExt(f, "o")}
 #      linkCmd.add(" " & changeFileExt(f, "o"))
 IF ERRORLEVEL 1 (GOTO:END)
 #    end for
 
 ECHO %LINKER% -o ?{"%BIN_DIR%"\toLower(c.name)}.exe ?linkCmd %LINK_FLAGS%
-%LINKER% -o ?{"%BIN_DIR%"\toLower(c.name)}.exe ?linkCmd %LINK_FLAGS%
+CALL %LINKER% -o ?{"%BIN_DIR%"\toLower(c.name)}.exe ?linkCmd %LINK_FLAGS%
 
 #  end block
 


### PR DESCRIPTION
See #18 on csources. Basically, some Windows systems have gcc as a gcc.bat file. (From what I've seen, happens with Python and GHC installations mainly.) This isn't an issue unless you're calling from another batch file (like here). The call chain will follow to gcc.bat and end there, meaning only one command is processed.
 Using "CALL" before the other batch command will keep the calls in the main batch file after completion, meaning the compilation will actually succeed this way ([see technet](https://technet.microsoft.com/en-us/library/bb490873.aspx)). Otherwise you have to hope there is a gcc.exe somewhere instead.

Note this also works even if you don't have gcc.bat (gcc.exe will still work)