### PR TITLE
Resolve FdSet conflict in lib/posix/posix.nim

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -103,7 +103,7 @@ type
         d_off*: Off  ## Not an offset. Value that ``telldir()`` would return.
     d_name*: array [0..255, char] ## Name of entry.
 
-  Tflock* {.importc: "struct flock", final, pure,
+  Flock* {.importc: "struct flock", final, pure,
             header: "<fcntl.h>".} = object ## flock type
     l_type*: cshort   ## Type of lock; F_RDLCK, F_WRLCK, F_UNLCK.
     l_whence*: cshort ## Flag for starting offset.
@@ -400,7 +400,7 @@ type
               TPasswd: Passwd, TClock: Clock, TClockId: ClockId, TKey: Key,
               TSem: Sem, Tpthread_attr: PthreadAttr, Ttimespec: Timespec,
               Tdirent: Dirent, TFTW: FTW, TGlob: Glob,
-              # Tflock: Flock, # Naming conflict if we drop the `T`
+              Tflock: Flock,
               Ticonv: Iconv, Tlconv: Lconv, TMqAttr: MqAttr, Tblkcnt: Blkcnt,
               Tblksize: Blksize, Tfsblkcnt: Fsblkcnt, Tfsfilcnt: Fsfilcnt,
               Tid: Id, Tino: Ino, Tpthread_barrier: Pthread_barrier,
@@ -1124,7 +1124,7 @@ var
     importc: "_CS_POSIX_V6_LPBIG_OFFBIG_LIBS", header: "<unistd.h>".}: cint
   CS_POSIX_V6_WIDTH_RESTRICTED_ENVS* {.
     importc: "_CS_POSIX_V6_WIDTH_RESTRICTED_ENVS", header: "<unistd.h>".}: cint
-  F_LOCK* {.importc: "F_LOCK", header: "<unistd.h>".}: cint
+  f_lock* {.importc: "F_LOCK", header: "<unistd.h>".}: cint
   F_TEST* {.importc: "F_TEST", header: "<unistd.h>".}: cint
   F_TLOCK* {.importc: "F_TLOCK", header: "<unistd.h>".}: cint
   F_ULOCK* {.importc: "F_ULOCK", header: "<unistd.h>".}: cint

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -382,7 +382,7 @@ type
              final, pure.} = object ## struct timeval
     tv_sec*: int       ## Seconds.
     tv_usec*: int ## Microseconds.
-  TFdSet* {.importc: "fd_set", header: "<sys/select.h>",
+  FdSet* {.importc: "fd_set", header: "<sys/select.h>",
            final, pure.} = object
   Mcontext* {.importc: "mcontext_t", header: "<ucontext.h>",
                final, pure.} = object
@@ -418,7 +418,7 @@ type
               TsigEvent: SigEvent, TsigVal: SigVal, TSigaction: Sigaction,
               TSigStack: SigStack, TsigInfo: SigInfo, Tnl_item: Nl_item,
               Tnl_catd: Nl_catd, Tsched_param: Sched_param,
-              # TFdSet: FdSet, # Naming conflict if we drop the `T`
+              TFdSet: FdSet,
               Tmcontext: Mcontext, Tucontext: Ucontext].}
 when hasAioH:
   type
@@ -2378,16 +2378,16 @@ proc sched_yield*(): cint {.importc, header: "<sched.h>".}
 proc strerror*(errnum: cint): cstring {.importc, header: "<string.h>".}
 proc hstrerror*(herrnum: cint): cstring {.importc, header: "<netdb.h>".}
 
-proc FD_CLR*(a1: cint, a2: var TFdSet) {.importc, header: "<sys/select.h>".}
-proc FD_ISSET*(a1: cint | SocketHandle, a2: var TFdSet): cint {.
+proc FD_CLR*(a1: cint, a2: var FdSet) {.importc, header: "<sys/select.h>".}
+proc FD_ISSET*(a1: cint | SocketHandle, a2: var FdSet): cint {.
   importc, header: "<sys/select.h>".}
-proc FD_SET*(a1: cint | SocketHandle, a2: var TFdSet) {.
+proc fd_set*(a1: cint | SocketHandle, a2: var FdSet) {.
   importc: "FD_SET", header: "<sys/select.h>".}
-proc FD_ZERO*(a1: var TFdSet) {.importc, header: "<sys/select.h>".}
+proc FD_ZERO*(a1: var FdSet) {.importc, header: "<sys/select.h>".}
 
-proc pselect*(a1: cint, a2, a3, a4: ptr TFdSet, a5: ptr Timespec,
+proc pselect*(a1: cint, a2, a3, a4: ptr FdSet, a5: ptr Timespec,
          a6: var Sigset): cint  {.importc, header: "<sys/select.h>".}
-proc select*(a1: cint | SocketHandle, a2, a3, a4: ptr TFdSet, a5: ptr Timeval): cint {.
+proc select*(a1: cint | SocketHandle, a2, a3, a4: ptr FdSet, a5: ptr Timeval): cint {.
              importc, header: "<sys/select.h>".}
 
 when hasSpawnH:

--- a/lib/pure/asyncio.nim
+++ b/lib/pure/asyncio.nim
@@ -98,10 +98,10 @@ import sockets, os
 {.deprecated.}
 
 when defined(windows):
-  from winlean import TimeVal, SocketHandle, FD_SET, FD_ZERO, TFdSet,
+  from winlean import TimeVal, SocketHandle, fd_set, FD_ZERO, FdSet,
     FD_ISSET, select
 else:
-  from posix import TimeVal, SocketHandle, FD_SET, FD_ZERO, TFdSet,
+  from posix import TimeVal, SocketHandle, fd_set, FD_ZERO, FdSet,
     FD_ISSET, select
 
 type
@@ -559,13 +559,13 @@ proc timeValFromMilliseconds(timeout = 500): Timeval =
     result.tv_sec = seconds.int32
     result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-proc createFdSet(fd: var TFdSet, s: seq[Delegate], m: var int) =
+proc createFdSet(fd: var FdSet, s: seq[Delegate], m: var int) =
   FD_ZERO(fd)
   for i in items(s):
     m = max(m, int(i.fd))
-    FD_SET(i.fd, fd)
+    fd_set(i.fd, fd)
 
-proc pruneSocketSet(s: var seq[Delegate], fd: var TFdSet) =
+proc pruneSocketSet(s: var seq[Delegate], fd: var FdSet) =
   var i = 0
   var L = s.len
   while i < L:
@@ -580,7 +580,7 @@ proc select(readfds, writefds, exceptfds: var seq[Delegate],
              timeout = 500): int =
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
 
-  var rd, wr, ex: TFdSet
+  var rd, wr, ex: FdSet
   var m = 0
   createFdSet(rd, readfds, m)
   createFdSet(wr, writefds, m)

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -918,13 +918,13 @@ elif not defined(useNimRtl):
     else:
       result = csystem(command)
 
-  proc createFdSet(fd: var TFdSet, s: seq[Process], m: var int) =
+  proc createFdSet(fd: var FdSet, s: seq[Process], m: var int) =
     FD_ZERO(fd)
     for i in items(s):
       m = max(m, int(i.outHandle))
-      FD_SET(cint(i.outHandle), fd)
+      fd_set(cint(i.outHandle), fd)
 
-  proc pruneProcessSet(s: var seq[Process], fd: var TFdSet) =
+  proc pruneProcessSet(s: var seq[Process], fd: var FdSet) =
     var i = 0
     var L = s.len
     while i < L:
@@ -940,7 +940,7 @@ elif not defined(useNimRtl):
     tv.tv_sec = 0
     tv.tv_usec = timeout * 1000
 
-    var rd: TFdSet
+    var rd: FdSet
     var m = 0
     createFdSet((rd), readfds, m)
 

--- a/lib/pure/rawsockets.nim
+++ b/lib/pure/rawsockets.nim
@@ -44,7 +44,7 @@ when defined(macosx):
 
 type
   Port* = distinct uint16  ## port type
-  
+
   Domain* = enum    ## domain, which specifies the protocol family of the
                     ## created socket. Other domains than those that are listed
                     ## here are unsupported.
@@ -59,7 +59,7 @@ type
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
   Protocol* = enum      ## third argument to `socket` proc
-    IPPROTO_TCP = 6,    ## Transmission control protocol. 
+    IPPROTO_TCP = 6,    ## Transmission control protocol.
     IPPROTO_UDP = 17,   ## User datagram protocol.
     IPPROTO_IP,         ## Internet protocol. Unsupported on Windows.
     IPPROTO_IPV6,       ## Internet Protocol Version 6. Unsupported on Windows.
@@ -89,10 +89,10 @@ when useWinVersion:
   const
     IOCPARM_MASK* = 127
     IOC_IN* = int(-2147483648)
-    FIONBIO* = IOC_IN.int32 or ((sizeof(int32) and IOCPARM_MASK) shl 16) or 
+    FIONBIO* = IOC_IN.int32 or ((sizeof(int32) and IOCPARM_MASK) shl 16) or
                              (102 shl 8) or 126
 
-  proc ioctlsocket*(s: SocketHandle, cmd: clong, 
+  proc ioctlsocket*(s: SocketHandle, cmd: clong,
                    argptr: ptr clong): cint {.
                    stdcall, importc: "ioctlsocket", dynlib: "ws2_32.dll".}
 else:
@@ -141,12 +141,12 @@ when not useWinVersion:
     else: discard
 
 else:
-  proc toInt(domain: Domain): cint = 
+  proc toInt(domain: Domain): cint =
     result = toU16(ord(domain))
 
   proc toInt(typ: SockType): cint =
     result = cint(ord(typ))
-  
+
   proc toInt(p: Protocol): cint =
     result = cint(ord(p))
 
@@ -176,8 +176,8 @@ proc bindAddr*(socket: SocketHandle, name: ptr SockAddr, namelen: SockLen): cint
   result = bindSocket(socket, name, namelen)
 
 proc listen*(socket: SocketHandle, backlog = SOMAXCONN): cint {.tags: [ReadIOEffect].} =
-  ## Marks ``socket`` as accepting connections. 
-  ## ``Backlog`` specifies the maximum length of the 
+  ## Marks ``socket`` as accepting connections.
+  ## ``Backlog`` specifies the maximum length of the
   ## queue of pending connections.
   when useWinVersion:
     result = winlean.listen(socket, cint(backlog))
@@ -204,7 +204,7 @@ proc getAddrInfo*(address: string, port: Port, af: Domain = AF_INET, typ: SockTy
 proc dealloc*(ai: ptr AddrInfo) =
   freeaddrinfo(ai)
 
-proc ntohl*(x: int32): int32 = 
+proc ntohl*(x: int32): int32 =
   ## Converts 32-bit integers from network to host byte order.
   ## On machines where the host byte order is the same as network byte order,
   ## this is a no-op; otherwise, it performs a 4-byte swap operation.
@@ -234,7 +234,7 @@ proc htons*(x: int16): int16 =
   result = rawsockets.ntohs(x)
 
 proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
-  ## Searches the database from the beginning and finds the first entry for 
+  ## Searches the database from the beginning and finds the first entry for
   ## which the service name specified by ``name`` matches the s_name member
   ## and the protocol name specified by ``proto`` matches the s_proto member.
   ##
@@ -248,10 +248,10 @@ proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
   result.aliases = cstringArrayToSeq(s.s_aliases)
   result.port = Port(s.s_port)
   result.proto = $s.s_proto
-  
-proc getServByPort*(port: Port, proto: string): Servent {.tags: [ReadIOEffect].} = 
-  ## Searches the database from the beginning and finds the first entry for 
-  ## which the port specified by ``port`` matches the s_port member and the 
+
+proc getServByPort*(port: Port, proto: string): Servent {.tags: [ReadIOEffect].} =
+  ## Searches the database from the beginning and finds the first entry for
+  ## which the port specified by ``port`` matches the s_port member and the
   ## protocol name specified by ``proto`` matches the s_proto member.
   ##
   ## On posix this will search through the ``/etc/services`` file.
@@ -269,17 +269,17 @@ proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
   ## This function will lookup the hostname of an IP Address.
   var myaddr: InAddr
   myaddr.s_addr = inet_addr(ip)
-  
+
   when useWinVersion:
     var s = winlean.gethostbyaddr(addr(myaddr), sizeof(myaddr).cuint,
                                   cint(rawsockets.AF_INET))
     if s == nil: raiseOSError(osLastError())
   else:
-    var s = posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).Socklen, 
+    var s = posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).Socklen,
                                 cint(posix.AF_INET))
     if s == nil:
       raise newException(OSError, $hstrerror(h_errno))
-  
+
   result.name = $s.h_name
   result.aliases = cstringArrayToSeq(s.h_aliases)
   when useWinVersion:
@@ -294,7 +294,7 @@ proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
   result.addrList = cstringArrayToSeq(s.h_addr_list)
   result.length = int(s.h_length)
 
-proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} = 
+proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   ## This function will lookup the IP address of a hostname.
   when useWinVersion:
     var s = winlean.gethostbyname(name)
@@ -315,7 +315,7 @@ proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   result.addrList = cstringArrayToSeq(s.h_addr_list)
   result.length = int(s.h_length)
 
-proc getSockName*(socket: SocketHandle): Port = 
+proc getSockName*(socket: SocketHandle): Port =
   ## returns the socket's associated port number.
   var name: Sockaddr_in
   when useWinVersion:
@@ -331,11 +331,11 @@ proc getSockName*(socket: SocketHandle): Port =
   result = Port(rawsockets.ntohs(name.sin_port))
 
 proc getSockOptInt*(socket: SocketHandle, level, optname: int): int {.
-  tags: [ReadIOEffect].} = 
+  tags: [ReadIOEffect].} =
   ## getsockopt for integer options.
   var res: cint
   var size = sizeof(res).SockLen
-  if getsockopt(socket, cint(level), cint(optname), 
+  if getsockopt(socket, cint(level), cint(optname),
                 addr(res), addr(size)) < 0'i32:
     raiseOSError(osLastError())
   result = int(res)
@@ -344,7 +344,7 @@ proc setSockOptInt*(socket: SocketHandle, level, optname, optval: int) {.
   tags: [WriteIOEffect].} =
   ## setsockopt for integer options.
   var value = cint(optval)
-  if setsockopt(socket, cint(level), cint(optname), addr(value),  
+  if setsockopt(socket, cint(level), cint(optname), addr(value),
                 sizeof(value).SockLen) < 0'i32:
     raiseOSError(osLastError())
 
@@ -371,13 +371,13 @@ proc timeValFromMilliseconds(timeout = 500): Timeval =
     result.tv_sec = seconds.int32
     result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-proc createFdSet(fd: var FdSet, s: seq[SocketHandle], m: var int) = 
+proc createFdSet(fd: var FdSet, s: seq[SocketHandle], m: var int) =
   FD_ZERO(fd)
-  for i in items(s): 
+  for i in items(s):
     m = max(m, int(i))
     fd_set(i, fd)
-   
-proc pruneSocketSet(s: var seq[SocketHandle], fd: var FdSet) = 
+
+proc pruneSocketSet(s: var seq[SocketHandle], fd: var FdSet) =
   var i = 0
   var L = s.len
   while i < L:
@@ -391,22 +391,22 @@ proc pruneSocketSet(s: var seq[SocketHandle], fd: var FdSet) =
 proc select*(readfds: var seq[SocketHandle], timeout = 500): int =
   ## Traditional select function. This function will return the number of
   ## sockets that are ready to be read from, written to, or which have errors.
-  ## If there are none; 0 is returned. 
+  ## If there are none; 0 is returned.
   ## ``Timeout`` is in milliseconds and -1 can be specified for no timeout.
-  ## 
+  ##
   ## A socket is removed from the specific ``seq`` when it has data waiting to
   ## be read/written to or has errors (``exceptfds``).
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var rd: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), addr(rd), nil, nil, addr(tv)))
   else:
     result = int(select(cint(m+1), addr(rd), nil, nil, nil))
-  
+
   pruneSocketSet(readfds, (rd))
 
 proc selectWrite*(writefds: var seq[SocketHandle],
@@ -419,16 +419,16 @@ proc selectWrite*(writefds: var seq[SocketHandle],
   ## ``timeout`` is specified in milliseconds and ``-1`` can be specified for
   ## an unlimited time.
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var wr: FdSet
   var m = 0
   createFdSet((wr), writefds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), nil, addr(wr), nil, addr(tv)))
   else:
     result = int(select(cint(m+1), nil, addr(wr), nil, nil))
-  
+
   pruneSocketSet(writefds, (wr))
 
 when defined(Windows):

--- a/lib/pure/rawsockets.nim
+++ b/lib/pure/rawsockets.nim
@@ -371,13 +371,13 @@ proc timeValFromMilliseconds(timeout = 500): Timeval =
     result.tv_sec = seconds.int32
     result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-proc createFdSet(fd: var TFdSet, s: seq[SocketHandle], m: var int) = 
+proc createFdSet(fd: var FdSet, s: seq[SocketHandle], m: var int) = 
   FD_ZERO(fd)
   for i in items(s): 
     m = max(m, int(i))
-    FD_SET(i, fd)
+    fd_set(i, fd)
    
-proc pruneSocketSet(s: var seq[SocketHandle], fd: var TFdSet) = 
+proc pruneSocketSet(s: var seq[SocketHandle], fd: var FdSet) = 
   var i = 0
   var L = s.len
   while i < L:
@@ -398,7 +398,7 @@ proc select*(readfds: var seq[SocketHandle], timeout = 500): int =
   ## be read/written to or has errors (``exceptfds``).
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
   
-  var rd: TFdSet
+  var rd: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
   
@@ -420,7 +420,7 @@ proc selectWrite*(writefds: var seq[SocketHandle],
   ## an unlimited time.
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
   
-  var wr: TFdSet
+  var wr: FdSet
   var m = 0
   createFdSet((wr), writefds, m)
   

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -11,11 +11,11 @@
 
 import tables, os, unsigned, hashes
 
-when defined(linux): 
+when defined(linux):
   import posix, epoll
-elif defined(windows): 
+elif defined(windows):
   import winlean
-else: 
+else:
   import posix
 
 proc hash*(x: SocketHandle): Hash {.borrow.}
@@ -76,7 +76,7 @@ elif defined(linux):
       epollFD: cint
       events: array[64, epoll_event]
       fds: Table[SocketHandle, SelectorKey]
-  
+
   proc createEventStruct(events: set[Event], fd: SocketHandle): epoll_event =
     if EvRead in events:
       result.events = EPOLLIN
@@ -84,7 +84,7 @@ elif defined(linux):
       result.events = result.events or EPOLLOUT
     result.events = result.events or EPOLLRDHUP
     result.data.fd = fd.cint
-  
+
   proc register*(s: Selector, fd: SocketHandle, events: set[Event],
       data: RootRef): SelectorKey {.discardable.} =
     var event = createEventStruct(events, fd)
@@ -93,10 +93,10 @@ elif defined(linux):
         raiseOSError(osLastError())
 
     var key = SelectorKey(fd: fd, events: events, data: data)
-  
+
     s.fds[fd] = key
     result = key
-  
+
   proc update*(s: Selector, fd: SocketHandle,
       events: set[Event]): SelectorKey {.discardable.} =
     if s.fds[fd].events != events:
@@ -120,9 +120,9 @@ elif defined(linux):
           if epoll_ctl(s.epollFD, EPOLL_CTL_MOD, fd, addr(event)) != 0:
             raiseOSError(osLastError())
         s.fds[fd].events = events
-      
+
       result = s.fds[fd]
-  
+
   proc unregister*(s: Selector, fd: SocketHandle): SelectorKey {.discardable.} =
     if epoll_ctl(s.epollFD, EPOLL_CTL_DEL, fd, nil) != 0:
       let err = osLastError()
@@ -134,7 +134,7 @@ elif defined(linux):
   proc close*(s: Selector) =
     if s.epollFD.close() != 0: raiseOSError(osLastError())
     dealloc(addr s.events) # TODO: Test this
-  
+
   proc epollHasFd(s: Selector, fd: SocketHandle): bool =
     result = true
     var event = createEventStruct(s.fds[fd].events, fd)
@@ -143,7 +143,7 @@ elif defined(linux):
       if err.cint in {ENOENT, EBADF}:
         return false
       raiseOSError(osLastError())
-  
+
   proc select*(s: Selector, timeout: int): seq[ReadyInfo] =
     ##
     ## The ``events`` field of the returned ``key`` contains the original events
@@ -160,7 +160,7 @@ elif defined(linux):
     if evNum == 0: return @[]
     for i in 0 .. <evNum:
       let fd = s.events[i].data.fd.SocketHandle
-    
+
       var evSet: set[Event] = {}
       if (s.events[i].events and EPOLLERR) != 0 or (s.events[i].events and EPOLLHUP) != 0: evSet = evSet + {EvError}
       if (s.events[i].events and EPOLLIN) != 0: evSet = evSet + {EvRead}
@@ -170,7 +170,7 @@ elif defined(linux):
       result.add((selectorKey, evSet))
 
       #echo("Epoll: ", result[i].key.fd, " ", result[i].events, " ", result[i].key.events)
-  
+
   proc newSelector*(): Selector =
     new result
     result.epollFD = epoll_create(64)
@@ -232,13 +232,13 @@ elif not defined(nimdoc):
       m: var int) =
     FD_ZERO(rd); FD_ZERO(wr)
     for k, v in pairs(fds):
-      if EvRead in v.events: 
+      if EvRead in v.events:
         m = max(m, int(k))
         fd_set(k, rd)
       if EvWrite in v.events:
         m = max(m, int(k))
         fd_set(k, wr)
-     
+
   proc getReadyFDs(rd, wr: var FdSet, fds: Table[SocketHandle, SelectorKey]):
       seq[ReadyInfo] =
     result = @[]
@@ -253,17 +253,17 @@ elif not defined(nimdoc):
   proc select(fds: Table[SocketHandle, SelectorKey], timeout = 500):
     seq[ReadyInfo] =
     var tv {.noInit.}: TimeVal = timeValFromMilliseconds(timeout)
-    
+
     var rd, wr: FdSet
     var m = 0
     createFdSet(rd, wr, fds, m)
-    
+
     var retCode = 0
     if timeout != -1:
       retCode = int(select(cint(m+1), addr(rd), addr(wr), nil, addr(tv)))
     else:
       retCode = int(select(cint(m+1), addr(rd), addr(wr), nil, nil))
-    
+
     if retCode < 0:
       raiseOSError(osLastError())
     elif retCode == 0:
@@ -302,12 +302,12 @@ when not defined(testing) and isMainModule and not defined(nimdoc):
   type
     SockWrapper = ref object of RootObj
       sock: Socket
-  
+
   var sock = socket()
   if sock == sockets.invalidSocket: raiseOSError(osLastError())
   #sock.setBlocking(false)
   sock.connect("irc.freenode.net", Port(6667))
-  
+
   var selector = newSelector()
   var data = SockWrapper(sock: sock)
   let key = selector.register(sock.getFD, {EvWrite}, data)

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -228,18 +228,18 @@ elif not defined(nimdoc):
       result.tv_sec = seconds.int32
       result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-  proc createFdSet(rd, wr: var TFdSet, fds: Table[SocketHandle, SelectorKey],
+  proc createFdSet(rd, wr: var FdSet, fds: Table[SocketHandle, SelectorKey],
       m: var int) =
     FD_ZERO(rd); FD_ZERO(wr)
     for k, v in pairs(fds):
       if EvRead in v.events: 
         m = max(m, int(k))
-        FD_SET(k, rd)
+        fd_set(k, rd)
       if EvWrite in v.events:
         m = max(m, int(k))
-        FD_SET(k, wr)
+        fd_set(k, wr)
      
-  proc getReadyFDs(rd, wr: var TFdSet, fds: Table[SocketHandle, SelectorKey]):
+  proc getReadyFDs(rd, wr: var FdSet, fds: Table[SocketHandle, SelectorKey]):
       seq[ReadyInfo] =
     result = @[]
     for k, v in pairs(fds):
@@ -254,7 +254,7 @@ elif not defined(nimdoc):
     seq[ReadyInfo] =
     var tv {.noInit.}: TimeVal = timeValFromMilliseconds(timeout)
     
-    var rd, wr: TFdSet
+    var rd, wr: FdSet
     var m = 0
     createFdSet(rd, wr, fds, m)
     

--- a/lib/pure/sockets.nim
+++ b/lib/pure/sockets.nim
@@ -942,13 +942,13 @@ proc timeValFromMilliseconds(timeout = 500): Timeval =
     result.tv_sec = seconds.int32
     result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-proc createFdSet(fd: var TFdSet, s: seq[Socket], m: var int) = 
+proc createFdSet(fd: var FdSet, s: seq[Socket], m: var int) = 
   FD_ZERO(fd)
   for i in items(s): 
     m = max(m, int(i.fd))
-    FD_SET(i.fd, fd)
+    fd_set(i.fd, fd)
    
-proc pruneSocketSet(s: var seq[Socket], fd: var TFdSet) =
+proc pruneSocketSet(s: var seq[Socket], fd: var FdSet) =
   var i = 0
   var L = s.len
   while i < L:
@@ -998,7 +998,7 @@ proc select*(readfds, writefds, exceptfds: var seq[Socket],
 
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
   
-  var rd, wr, ex: TFdSet
+  var rd, wr, ex: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
   createFdSet((wr), writefds, m)
@@ -1021,7 +1021,7 @@ proc select*(readfds, writefds: var seq[Socket],
     return buffersFilled
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
   
-  var rd, wr: TFdSet
+  var rd, wr: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
   createFdSet((wr), writefds, m)
@@ -1045,7 +1045,7 @@ proc selectWrite*(writefds: var seq[Socket],
   ## an unlimited time.
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
   
-  var wr: TFdSet
+  var wr: FdSet
   var m = 0
   createFdSet((wr), writefds, m)
   
@@ -1063,7 +1063,7 @@ proc select*(readfds: var seq[Socket], timeout = 500): int =
     return buffersFilled
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
   
-  var rd: TFdSet
+  var rd: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
   

--- a/lib/pure/sockets.nim
+++ b/lib/pure/sockets.nim
@@ -51,17 +51,17 @@ else:
 
 # Note: The enumerations are mapped to Window's constants.
 
-when defined(ssl):  
+when defined(ssl):
 
   type
     SSLError* = object of Exception
 
     SSLCVerifyMode* = enum
       CVerifyNone, CVerifyPeer
-    
+
     SSLProtVersion* = enum
       protSSLv2, protSSLv3, protTLSv1, protSSLv23
-    
+
     SSLContext* = distinct SSLCTX
 
     SSLAcceptResult* = enum
@@ -93,11 +93,11 @@ type
         sslPeekChar: char
       of false: nil
     nonblocking: bool
-  
+
   Socket* = ref SocketImpl
-  
+
   Port* = distinct uint16  ## port type
-  
+
   Domain* = enum    ## domain, which specifies the protocol family of the
                     ## created socket. Other domains than those that are listed
                     ## here are unsupported.
@@ -112,7 +112,7 @@ type
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
   Protocol* = enum      ## third argument to `socket` proc
-    IPPROTO_TCP = 6,    ## Transmission control protocol. 
+    IPPROTO_TCP = 6,    ## Transmission control protocol.
     IPPROTO_UDP = 17,   ## User datagram protocol.
     IPPROTO_IP,         ## Internet protocol. Unsupported on Windows.
     IPPROTO_IPV6,       ## Internet Protocol Version 6. Unsupported on Windows.
@@ -178,7 +178,7 @@ proc `==`*(a, b: Port): bool {.borrow.}
 proc `$`*(p: Port): string {.borrow.}
   ## returns the port number as a string
 
-proc ntohl*(x: int32): int32 = 
+proc ntohl*(x: int32): int32 =
   ## Converts 32-bit integers from network to host byte order.
   ## On machines where the host byte order is the same as network byte order,
   ## this is a no-op; otherwise, it performs a 4-byte swap operation.
@@ -206,7 +206,7 @@ proc htons*(x: int16): int16 =
   ## On machines where the host byte order is the same as network byte
   ## order, this is a no-op; otherwise, it performs a 2-byte swap operation.
   result = sockets.ntohs(x)
-  
+
 when defined(Posix):
   proc toInt(domain: Domain): cint =
     case domain
@@ -234,19 +234,19 @@ when defined(Posix):
     else: discard
 
 else:
-  proc toInt(domain: Domain): cint = 
+  proc toInt(domain: Domain): cint =
     result = toU16(ord(domain))
 
   proc toInt(typ: SockType): cint =
     result = cint(ord(typ))
-  
+
   proc toInt(p: Protocol): cint =
     result = cint(ord(p))
 
 proc socket*(domain: Domain = AF_INET, typ: SockType = SOCK_STREAM,
              protocol: Protocol = IPPROTO_TCP, buffered = true): Socket =
   ## Creates a new socket; returns `InvalidSocket` if an error occurs.
-  
+
   # TODO: Perhaps this should just raise EOS when an error occurs.
   when defined(Windows):
     result = newTSocket(winlean.socket(ord(domain), ord(typ), ord(protocol)), buffered)
@@ -277,27 +277,27 @@ when defined(ssl):
       raise newException(system.IOError, "Certificate file could not be found: " & certFile)
     if keyFile != "" and not existsFile(keyFile):
       raise newException(system.IOError, "Key file could not be found: " & keyFile)
-    
+
     if certFile != "":
       var ret = SSLCTXUseCertificateChainFile(ctx, certFile)
       if ret != 1:
         raiseSslError()
-    
+
     # TODO: Password? www.rtfm.com/openssl-examples/part1.pdf
     if keyFile != "":
       if SSL_CTX_use_PrivateKey_file(ctx, keyFile,
                                      SSL_FILETYPE_PEM) != 1:
         raiseSslError()
-        
+
       if SSL_CTX_check_private_key(ctx) != 1:
         raiseSslError("Verification of private key file failed.")
 
   proc newContext*(protVersion = protSSLv23, verifyMode = CVerifyPeer,
                    certFile = "", keyFile = ""): SSLContext =
     ## Creates an SSL context.
-    ## 
-    ## Protocol version specifies the protocol to use. SSLv2, SSLv3, TLSv1 are 
-    ## are available with the addition of ``ProtSSLv23`` which allows for 
+    ##
+    ## Protocol version specifies the protocol to use. SSLv2, SSLv3, TLSv1 are
+    ## are available with the addition of ``ProtSSLv23`` which allows for
     ## compatibility with all of them.
     ##
     ## There are currently only two options for verify mode;
@@ -322,7 +322,7 @@ when defined(ssl):
       newCTX = SSL_CTX_new(SSLv3_method())
     of protTLSv1:
       newCTX = SSL_CTX_new(TLSv1_method())
-    
+
     if newCTX.SSLCTXSetCipherList("ALL") != 1:
       raiseSslError()
     case verifyMode
@@ -343,7 +343,7 @@ when defined(ssl):
     ##
     ## **Disclaimer**: This code is not well tested, may be very unsafe and
     ## prone to security vulnerabilities.
-    
+
     socket.isSSL = true
     socket.sslContext = ctx
     socket.sslHandle = SSLNew(SSLCTX(socket.sslContext))
@@ -351,7 +351,7 @@ when defined(ssl):
     socket.sslHasPeekChar = false
     if socket.sslHandle == nil:
       raiseSslError()
-    
+
     if SSLSetFd(socket.sslHandle, socket.fd) != 1:
       raiseSslError()
 
@@ -382,7 +382,7 @@ proc raiseSocketError*(socket: Socket, err: int = -1, async = false) =
         of SSL_ERROR_SYSCALL, SSL_ERROR_SSL:
           raiseSslError()
         else: raiseSslError("Unknown Error")
-  
+
   if err == -1 and not (when defined(ssl): socket.isSSL else: false):
     let lastError = osLastError()
     if async:
@@ -397,15 +397,15 @@ proc raiseSocketError*(socket: Socket, err: int = -1, async = false) =
     else: raiseOSError(lastError)
 
 proc listen*(socket: Socket, backlog = SOMAXCONN) {.tags: [ReadIOEffect].} =
-  ## Marks ``socket`` as accepting connections. 
-  ## ``Backlog`` specifies the maximum length of the 
+  ## Marks ``socket`` as accepting connections.
+  ## ``Backlog`` specifies the maximum length of the
   ## queue of pending connections.
   if listen(socket.fd, cint(backlog)) < 0'i32: raiseOSError(osLastError())
 
 proc invalidIp4(s: string) {.noreturn, noinline.} =
   raise newException(ValueError, "invalid ip4 address: " & s)
 
-proc parseIp4*(s: string): BiggestInt = 
+proc parseIp4*(s: string): BiggestInt =
   ## parses an IP version 4 in dotted decimal form like "a.b.c.d".
   ##
   ## This is equivalent to `inet_ntoa`:idx:.
@@ -469,8 +469,8 @@ proc bindAddr*(socket: Socket, port = Port(0), address = "") {.
     gaiNim(address, port, hints, aiList)
     if bindSocket(socket.fd, aiList.ai_addr, aiList.ai_addrlen.SockLen) < 0'i32:
       raiseOSError(osLastError())
-  
-proc getSockName*(socket: Socket): Port = 
+
+proc getSockName*(socket: Socket): Port =
   ## returns the socket's associated port number.
   var name: Sockaddr_in
   when defined(Windows):
@@ -485,14 +485,14 @@ proc getSockName*(socket: Socket): Port =
     raiseOSError(osLastError())
   result = Port(sockets.ntohs(name.sin_port))
 
-template acceptAddrPlain(noClientRet, successRet: expr, 
+template acceptAddrPlain(noClientRet, successRet: expr,
                          sslImplementation: stmt): stmt {.immediate.} =
   assert(client != nil)
   var sockAddress: Sockaddr_in
   var addrLen = sizeof(sockAddress).SockLen
   var sock = accept(server.fd, cast[ptr SockAddr](addr(sockAddress)),
                     addr(addrLen))
-  
+
   if sock == osInvalidSocket:
     let err = osLastError()
     when defined(windows):
@@ -537,7 +537,7 @@ proc acceptAddr*(server: Socket, client: var Socket, address: var string) {.
   ## The resulting client will inherit any properties of the server socket. For
   ## example: whether the socket is buffered or not.
   ##
-  ## **Note**: ``client`` must be initialised (with ``new``), this function 
+  ## **Note**: ``client`` must be initialised (with ``new``), this function
   ## makes no effort to initialise the ``client`` variable.
   ##
   ## **Warning:** When using SSL with non-blocking sockets, it is best to use
@@ -546,7 +546,7 @@ proc acceptAddr*(server: Socket, client: var Socket, address: var string) {.
     when defined(ssl):
       if server.isSSL:
         # We must wrap the client sock in a ssl context.
-        
+
         server.sslContext.wrapSocket(client)
         let ret = SSLAccept(client.sslHandle)
         while ret <= 0:
@@ -572,9 +572,9 @@ when defined(ssl):
   proc acceptAddrSSL*(server: Socket, client: var Socket,
                       address: var string): SSLAcceptResult {.
                       tags: [ReadIOEffect].} =
-    ## This procedure should only be used for non-blocking **SSL** sockets. 
+    ## This procedure should only be used for non-blocking **SSL** sockets.
     ## It will immediately return with one of the following values:
-    ## 
+    ##
     ## ``AcceptSuccess`` will be returned when a client has been successfully
     ## accepted and the handshake has been successfully performed between
     ## ``server`` and the newly connected client.
@@ -591,7 +591,7 @@ when defined(ssl):
         if server.isSSL:
           client.setBlocking(false)
           # We must wrap the client sock in a ssl context.
-          
+
           if not client.isSSL or client.sslHandle == nil:
             server.sslContext.wrapSocket(client)
           let ret = SSLAccept(client.sslHandle)
@@ -623,10 +623,10 @@ when defined(ssl):
 proc accept*(server: Socket, client: var Socket) {.tags: [ReadIOEffect].} =
   ## Equivalent to ``acceptAddr`` but doesn't return the address, only the
   ## socket.
-  ## 
+  ##
   ## **Note**: ``client`` must be initialised (with ``new``), this function
   ## makes no effort to initialise the ``client`` variable.
-  
+
   var addrDummy = ""
   acceptAddr(server, client, addrDummy)
 
@@ -662,7 +662,7 @@ proc close*(socket: Socket) =
       socket.sslHandle = nil
 
 proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
-  ## Searches the database from the beginning and finds the first entry for 
+  ## Searches the database from the beginning and finds the first entry for
   ## which the service name specified by ``name`` matches the s_name member
   ## and the protocol name specified by ``proto`` matches the s_proto member.
   ##
@@ -676,10 +676,10 @@ proc getServByName*(name, proto: string): Servent {.tags: [ReadIOEffect].} =
   result.aliases = cstringArrayToSeq(s.s_aliases)
   result.port = Port(s.s_port)
   result.proto = $s.s_proto
-  
-proc getServByPort*(port: Port, proto: string): Servent {.tags: [ReadIOEffect].} = 
-  ## Searches the database from the beginning and finds the first entry for 
-  ## which the port specified by ``port`` matches the s_port member and the 
+
+proc getServByPort*(port: Port, proto: string): Servent {.tags: [ReadIOEffect].} =
+  ## Searches the database from the beginning and finds the first entry for
+  ## which the port specified by ``port`` matches the s_port member and the
   ## protocol name specified by ``proto`` matches the s_proto member.
   ##
   ## On posix this will search through the ``/etc/services`` file.
@@ -697,20 +697,20 @@ proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
   ## This function will lookup the hostname of an IP Address.
   var myaddr: InAddr
   myaddr.s_addr = inet_addr(ip)
-  
+
   when defined(windows):
     var s = winlean.gethostbyaddr(addr(myaddr), sizeof(myaddr).cuint,
                                   cint(sockets.AF_INET))
     if s == nil: raiseOSError(osLastError())
   else:
-    var s = posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).Socklen, 
+    var s = posix.gethostbyaddr(addr(myaddr), sizeof(myaddr).Socklen,
                                 cint(posix.AF_INET))
     if s == nil:
       raise newException(OSError, $hstrerror(h_errno))
-  
+
   result.name = $s.h_name
   result.aliases = cstringArrayToSeq(s.h_aliases)
-  when defined(windows): 
+  when defined(windows):
     result.addrtype = Domain(s.h_addrtype)
   else:
     if s.h_addrtype == posix.AF_INET:
@@ -722,7 +722,7 @@ proc getHostByAddr*(ip: string): Hostent {.tags: [ReadIOEffect].} =
   result.addrList = cstringArrayToSeq(s.h_addr_list)
   result.length = int(s.h_length)
 
-proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} = 
+proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   ## This function will lookup the IP address of a hostname.
   when defined(Windows):
     var s = winlean.gethostbyname(name)
@@ -731,7 +731,7 @@ proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   if s == nil: raiseOSError(osLastError())
   result.name = $s.h_name
   result.aliases = cstringArrayToSeq(s.h_aliases)
-  when defined(windows): 
+  when defined(windows):
     result.addrtype = Domain(s.h_addrtype)
   else:
     if s.h_addrtype == posix.AF_INET:
@@ -744,11 +744,11 @@ proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   result.length = int(s.h_length)
 
 proc getSockOptInt*(socket: Socket, level, optname: int): int {.
-  tags: [ReadIOEffect].} = 
+  tags: [ReadIOEffect].} =
   ## getsockopt for integer options.
   var res: cint
   var size = sizeof(res).SockLen
-  if getsockopt(socket.fd, cint(level), cint(optname), 
+  if getsockopt(socket.fd, cint(level), cint(optname),
                 addr(res), addr(size)) < 0'i32:
     raiseOSError(osLastError())
   result = int(res)
@@ -757,7 +757,7 @@ proc setSockOptInt*(socket: Socket, level, optname, optval: int) {.
   tags: [WriteIOEffect].} =
   ## setsockopt for integer options.
   var value = cint(optval)
-  if setsockopt(socket.fd, cint(level), cint(optname), addr(value),  
+  if setsockopt(socket.fd, cint(level), cint(optname), addr(value),
                 sizeof(value).SockLen) < 0'i32:
     raiseOSError(osLastError())
 
@@ -776,7 +776,7 @@ proc getSockOpt*(socket: Socket, opt: SOBool, level = SOL_SOCKET): bool {.
   ## Retrieves option ``opt`` as a boolean value.
   var res: cint
   var size = sizeof(res).SockLen
-  if getsockopt(socket.fd, cint(level), toCInt(opt), 
+  if getsockopt(socket.fd, cint(level), toCInt(opt),
                 addr(res), addr(size)) < 0'i32:
     raiseOSError(osLastError())
   result = res != 0
@@ -785,11 +785,11 @@ proc setSockOpt*(socket: Socket, opt: SOBool, value: bool, level = SOL_SOCKET) {
   tags: [WriteIOEffect].} =
   ## Sets option ``opt`` to a boolean value specified by ``value``.
   var valuei = cint(if value: 1 else: 0)
-  if setsockopt(socket.fd, cint(level), toCInt(opt), addr(valuei),  
+  if setsockopt(socket.fd, cint(level), toCInt(opt), addr(valuei),
                 sizeof(valuei).SockLen) < 0'i32:
     raiseOSError(osLastError())
 
-proc connect*(socket: Socket, address: string, port = Port(0), 
+proc connect*(socket: Socket, address: string, port = Port(0),
               af: Domain = AF_INET) {.tags: [ReadIOEffect].} =
   ## Connects socket to ``address``:``port``. ``Address`` can be an IP address or a
   ## host name. If ``address`` is a host name, this function will try each IP
@@ -816,7 +816,7 @@ proc connect*(socket: Socket, address: string, port = Port(0),
 
   freeaddrinfo(aiList)
   if not success: raiseOSError(lastError)
-  
+
   when defined(ssl):
     if socket.isSSL:
       let ret = SSLConnect(socket.sslHandle)
@@ -825,7 +825,7 @@ proc connect*(socket: Socket, address: string, port = Port(0),
         case err
         of SSL_ERROR_ZERO_RETURN:
           raiseSslError("TLS/SSL connection failed to initiate, socket closed prematurely.")
-        of SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE, SSL_ERROR_WANT_CONNECT, 
+        of SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE, SSL_ERROR_WANT_CONNECT,
            SSL_ERROR_WANT_ACCEPT:
           raiseSslError("The operation did not complete. Perhaps you should use connectAsync?")
         of SSL_ERROR_WANT_X509_LOOKUP:
@@ -834,7 +834,7 @@ proc connect*(socket: Socket, address: string, port = Port(0),
           raiseSslError()
         else:
           raiseSslError("Unknown error")
-        
+
   when false:
     var s: TSockAddrIn
     s.sin_addr.s_addr = inet_addr(address)
@@ -842,7 +842,7 @@ proc connect*(socket: Socket, address: string, port = Port(0),
     when defined(windows):
       s.sin_family = toU16(ord(af))
     else:
-      case af 
+      case af
       of AF_UNIX: s.sin_family = posix.AF_UNIX
       of AF_INET: s.sin_family = posix.AF_INET
       of AF_INET6: s.sin_family = posix.AF_INET6
@@ -886,7 +886,7 @@ proc connectAsync*(socket: Socket, name: string, port = Port(0),
         if lastError.int32 == EINTR or lastError.int32 == EINPROGRESS:
           success = true
           break
-        
+
     it = it.ai_next
 
   freeaddrinfo(aiList)
@@ -942,12 +942,12 @@ proc timeValFromMilliseconds(timeout = 500): Timeval =
     result.tv_sec = seconds.int32
     result.tv_usec = ((timeout - seconds * 1000) * 1000).int32
 
-proc createFdSet(fd: var FdSet, s: seq[Socket], m: var int) = 
+proc createFdSet(fd: var FdSet, s: seq[Socket], m: var int) =
   FD_ZERO(fd)
-  for i in items(s): 
+  for i in items(s):
     m = max(m, int(i.fd))
     fd_set(i.fd, fd)
-   
+
 proc pruneSocketSet(s: var seq[Socket], fd: var FdSet) =
   var i = 0
   var L = s.len
@@ -982,13 +982,13 @@ proc checkBuffer(readfds: var seq[Socket]): int =
   if result > 0:
     readfds = res
 
-proc select*(readfds, writefds, exceptfds: var seq[Socket], 
-             timeout = 500): int {.tags: [ReadIOEffect].} = 
+proc select*(readfds, writefds, exceptfds: var seq[Socket],
+             timeout = 500): int {.tags: [ReadIOEffect].} =
   ## Traditional select function. This function will return the number of
   ## sockets that are ready to be read from, written to, or which have errors.
-  ## If there are none; 0 is returned. 
+  ## If there are none; 0 is returned.
   ## ``Timeout`` is in milliseconds and -1 can be specified for no timeout.
-  ## 
+  ##
   ## Sockets which are **not** ready for reading, writing or which don't have
   ## errors waiting on them are removed from the ``readfds``, ``writefds``,
   ## ``exceptfds`` sequences respectively.
@@ -997,44 +997,44 @@ proc select*(readfds, writefds, exceptfds: var seq[Socket],
     return buffersFilled
 
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var rd, wr, ex: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
   createFdSet((wr), writefds, m)
   createFdSet((ex), exceptfds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), addr(rd), addr(wr), addr(ex), addr(tv)))
   else:
     result = int(select(cint(m+1), addr(rd), addr(wr), addr(ex), nil))
-  
+
   pruneSocketSet(readfds, (rd))
   pruneSocketSet(writefds, (wr))
   pruneSocketSet(exceptfds, (ex))
 
-proc select*(readfds, writefds: var seq[Socket], 
+proc select*(readfds, writefds: var seq[Socket],
              timeout = 500): int {.tags: [ReadIOEffect].} =
   ## Variant of select with only a read and write list.
   let buffersFilled = checkBuffer(readfds)
   if buffersFilled > 0:
     return buffersFilled
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var rd, wr: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
   createFdSet((wr), writefds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), addr(rd), addr(wr), nil, addr(tv)))
   else:
     result = int(select(cint(m+1), addr(rd), addr(wr), nil, nil))
-  
+
   pruneSocketSet(readfds, (rd))
   pruneSocketSet(writefds, (wr))
 
-proc selectWrite*(writefds: var seq[Socket], 
+proc selectWrite*(writefds: var seq[Socket],
                   timeout = 500): int {.tags: [ReadIOEffect].} =
   ## When a socket in ``writefds`` is ready to be written to then a non-zero
   ## value will be returned specifying the count of the sockets which can be
@@ -1044,16 +1044,16 @@ proc selectWrite*(writefds: var seq[Socket],
   ## ``timeout`` is specified in milliseconds and ``-1`` can be specified for
   ## an unlimited time.
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var wr: FdSet
   var m = 0
   createFdSet((wr), writefds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), nil, addr(wr), nil, addr(tv)))
   else:
     result = int(select(cint(m+1), nil, addr(wr), nil, nil))
-  
+
   pruneSocketSet(writefds, (wr))
 
 proc select*(readfds: var seq[Socket], timeout = 500): int =
@@ -1062,16 +1062,16 @@ proc select*(readfds: var seq[Socket], timeout = 500): int =
   if buffersFilled > 0:
     return buffersFilled
   var tv {.noInit.}: Timeval = timeValFromMilliseconds(timeout)
-  
+
   var rd: FdSet
   var m = 0
   createFdSet((rd), readfds, m)
-  
+
   if timeout != -1:
     result = int(select(cint(m+1), addr(rd), nil, nil, addr(tv)))
   else:
     result = int(select(cint(m+1), addr(rd), nil, nil, nil))
-  
+
   pruneSocketSet(readfds, (rd))
 
 proc readIntoBuf(socket: Socket, flags: int32): int =
@@ -1107,12 +1107,12 @@ proc recv*(socket: Socket, data: pointer, size: int): int {.tags: [ReadIOEffect]
   if socket.isBuffered:
     if socket.bufLen == 0:
       retRead(0'i32, 0)
-    
+
     var read = 0
     while read < size:
       if socket.currPos >= socket.bufLen:
         retRead(0'i32, read)
-    
+
       let chunk = min(socket.bufLen-socket.currPos, size-read)
       var d = cast[cstring](data)
       copyMem(addr(d[read]), addr(socket.buffer[socket.currPos]), chunk)
@@ -1155,7 +1155,7 @@ proc waitFor(socket: Socket, waited: var float, timeout, size: int,
   else:
     if timeout - int(waited * 1000.0) < 1:
       raise newException(TimeoutError, "Call to '" & funcName & "' timed out.")
-    
+
     when defined(ssl):
       if socket.isSSL:
         if socket.hasDataBuffered:
@@ -1164,7 +1164,7 @@ proc waitFor(socket: Socket, waited: var float, timeout, size: int,
         let sslPending = SSLPending(socket.sslHandle)
         if sslPending != 0:
           return sslPending
-    
+
     var s = @[socket]
     var startTime = epochTime()
     let selRet = select(s, timeout - int(waited * 1000.0))
@@ -1176,8 +1176,8 @@ proc waitFor(socket: Socket, waited: var float, timeout, size: int,
 proc recv*(socket: Socket, data: pointer, size: int, timeout: int): int {.
   tags: [ReadIOEffect, TimeEffect].} =
   ## overload with a ``timeout`` parameter in milliseconds.
-  var waited = 0.0 # number of seconds already waited  
-  
+  var waited = 0.0 # number of seconds already waited
+
   var read = 0
   while read < size:
     let avail = waitFor(socket, waited, timeout, size-read, "recv")
@@ -1187,7 +1187,7 @@ proc recv*(socket: Socket, data: pointer, size: int, timeout: int): int {.
     if result < 0:
       return result
     inc(read, result)
-  
+
   result = read
 
 proc recv*(socket: Socket, data: var string, size: int, timeout = -1): int =
@@ -1231,7 +1231,7 @@ proc peekChar(socket: Socket, c: var char): int {.tags: [ReadIOEffect].} =
       var res = socket.readIntoBuf(0'i32)
       if res <= 0:
         result = res
-    
+
     c = socket.buffer[socket.currPos]
   else:
     when defined(ssl):
@@ -1239,7 +1239,7 @@ proc peekChar(socket: Socket, c: var char): int {.tags: [ReadIOEffect].} =
         if not socket.sslHasPeekChar:
           result = SSLRead(socket.sslHandle, addr(socket.sslPeekChar), 1)
           socket.sslHasPeekChar = true
-        
+
         c = socket.sslPeekChar
         return
     result = recv(socket.fd, addr(c), 1, MSG_PEEK)
@@ -1251,11 +1251,11 @@ proc recvLine*(socket: Socket, line: var TaintedString, timeout = -1): bool {.
   ## If a full line is received ``\r\L`` is not
   ## added to ``line``, however if solely ``\r\L`` is received then ``line``
   ## will be set to it.
-  ## 
+  ##
   ## ``True`` is returned if data is available. ``False`` suggests an
   ## error, EOS exceptions are not raised and ``False`` is simply returned
   ## instead.
-  ## 
+  ##
   ## If the socket is disconnected, ``line`` will be set to ``""`` and ``True``
   ## will be returned.
   ##
@@ -1264,7 +1264,7 @@ proc recvLine*(socket: Socket, line: var TaintedString, timeout = -1): bool {.
   ##
   ## **Deprecated since version 0.9.2**: This function has been deprecated in
   ## favour of readLine.
-  
+
   template addNLIfEmpty(): stmt =
     if line.len == 0:
       line.add("\c\L")
@@ -1286,7 +1286,7 @@ proc recvLine*(socket: Socket, line: var TaintedString, timeout = -1): bool {.
       elif n <= 0: return false
       addNLIfEmpty()
       return true
-    elif c == '\L': 
+    elif c == '\L':
       addNLIfEmpty()
       return true
     add(line.string, c)
@@ -1298,14 +1298,14 @@ proc readLine*(socket: Socket, line: var TaintedString, timeout = -1) {.
   ## If a full line is read ``\r\L`` is not
   ## added to ``line``, however if solely ``\r\L`` is read then ``line``
   ## will be set to it.
-  ## 
+  ##
   ## If the socket is disconnected, ``line`` will be set to ``""``.
   ##
   ## An EOS exception will be raised in the case of a socket error.
   ##
   ## A timeout can be specified in milliseconds, if data is not received within
   ## the specified time an ETimeout exception will be raised.
-  
+
   template addNLIfEmpty(): stmt =
     if line.len == 0:
       line.add("\c\L")
@@ -1327,12 +1327,12 @@ proc readLine*(socket: Socket, line: var TaintedString, timeout = -1) {.
       elif n <= 0: socket.raiseSocketError()
       addNLIfEmpty()
       return
-    elif c == '\L': 
+    elif c == '\L':
       addNLIfEmpty()
       return
     add(line.string, c)
 
-proc recvLineAsync*(socket: Socket, 
+proc recvLineAsync*(socket: Socket,
   line: var TaintedString): RecvLineResult {.tags: [ReadIOEffect], deprecated.} =
   ## Similar to ``recvLine`` but designed for non-blocking sockets.
   ##
@@ -1350,21 +1350,21 @@ proc recvLineAsync*(socket: Socket,
   while true:
     var c: char
     var n = recv(socket, addr(c), 1)
-    if n < 0: 
+    if n < 0:
       return (if line.len == 0: RecvFail else: RecvPartialLine)
-    elif n == 0: 
+    elif n == 0:
       return (if line.len == 0: RecvDisconnected else: RecvPartialLine)
     if c == '\r':
       n = peekChar(socket, c)
       if n > 0 and c == '\L':
         discard recv(socket, addr(c), 1)
-      elif n <= 0: 
+      elif n <= 0:
         return (if line.len == 0: RecvFail else: RecvPartialLine)
       return RecvFullLine
     elif c == '\L': return RecvFullLine
     add(line.string, c)
 
-proc readLineAsync*(socket: Socket, 
+proc readLineAsync*(socket: Socket,
   line: var TaintedString): ReadLineResult {.tags: [ReadIOEffect].} =
   ## Similar to ``recvLine`` but designed for non-blocking sockets.
   ##
@@ -1376,24 +1376,24 @@ proc readLineAsync*(socket: Socket,
   ##   * If no data could be retrieved; ``ReadNone`` is returned.
   ##   * If call to ``recv`` failed; **an EOS exception is raised.**
   setLen(line.string, 0)
-  
+
   template errorOrNone =
     socket.raiseSocketError(async = true)
     return ReadNone
-  
+
   while true:
     var c: char
     var n = recv(socket, addr(c), 1)
     #echo(n)
     if n < 0:
       if line.len == 0: errorOrNone else: return ReadPartialLine
-    elif n == 0: 
+    elif n == 0:
       return (if line.len == 0: ReadDisconnected else: ReadPartialLine)
     if c == '\r':
       n = peekChar(socket, c)
       if n > 0 and c == '\L':
         discard recv(socket, addr(c), 1)
-      elif n <= 0: 
+      elif n <= 0:
         if line.len == 0: errorOrNone else: return ReadPartialLine
       return ReadFullLine
     elif c == '\L': return ReadFullLine
@@ -1424,7 +1424,7 @@ proc recv*(socket: Socket): TaintedString {.tags: [ReadIOEffect], deprecated.} =
       var bytesRead = recv(socket, cstring(buf), bufSize-1)
       # Error
       if bytesRead == -1: OSError(osLastError())
-      
+
       buf[bytesRead] = '\0' # might not be necessary
       setLen(buf, bytesRead)
       add(result.string, buf)
@@ -1442,13 +1442,13 @@ proc recvTimeout*(socket: Socket, timeout: int): TaintedString {.
     var s = @[socket]
     if s.select(timeout) != 1:
       raise newException(TimeoutError, "Call to recv() timed out.")
-  
+
   return socket.recv
 {.pop.}
 
 proc recvAsync*(socket: Socket, s: var TaintedString): bool {.
   tags: [ReadIOEffect], deprecated.} =
-  ## receives all the data from a non-blocking socket. If socket is non-blocking 
+  ## receives all the data from a non-blocking socket. If socket is non-blocking
   ## and there are no messages available, `False` will be returned.
   ## Other socket errors will result in an ``EOS`` error.
   ## If socket is not a connectionless socket and socket is not connected
@@ -1478,7 +1478,7 @@ proc recvAsync*(socket: Socket, s: var TaintedString): bool {.
           of SSL_ERROR_SYSCALL, SSL_ERROR_SSL:
             raiseSslError()
           else: raiseSslError("Unknown Error")
-          
+
     if bytesRead == -1 and not (when defined(ssl): socket.isSSL else: false):
       let err = osLastError()
       when defined(windows):
@@ -1510,7 +1510,7 @@ proc recvFrom*(socket: Socket, data: var string, length: int,
   ## so when ``socket`` is buffered the non-buffered implementation will be
   ## used. Therefore if ``socket`` contains something in its buffer this
   ## function will make no effort to return it.
-  
+
   # TODO: Buffered sockets
   data.setLen(length)
   var sockAddress: Sockaddr_in
@@ -1524,7 +1524,7 @@ proc recvFrom*(socket: Socket, data: var string, length: int,
     port = ntohs(sockAddress.sin_port).Port
 
 proc recvFromAsync*(socket: Socket, data: var string, length: int,
-                    address: var string, port: var Port, 
+                    address: var string, port: var Port,
                     flags = 0'i32): bool {.tags: [ReadIOEffect].} =
   ## Variant of ``recvFrom`` for non-blocking sockets. Unlike ``recvFrom``,
   ## this function will raise an EOS error whenever a socket error occurs.
@@ -1573,11 +1573,11 @@ proc send*(socket: Socket, data: pointer, size: int): int {.
   when defined(ssl):
     if socket.isSSL:
       return SSLWrite(socket.sslHandle, cast[cstring](data), size)
-  
+
   when defined(windows) or defined(macosx):
     result = send(socket.fd, data, size.cint, 0'i32)
   else:
-    when defined(solaris): 
+    when defined(solaris):
       const MSG_NOSIGNAL = 0
     result = send(socket.fd, data, size, int32(MSG_NOSIGNAL))
 
@@ -1590,7 +1590,7 @@ proc send*(socket: Socket, data: string) {.tags: [WriteIOEffect].} =
     when defined(ssl):
       if socket.isSSL:
         raiseSslError()
-    
+
     raiseOSError(osLastError())
 
   if sent != data.len:
@@ -1633,7 +1633,7 @@ proc sendAsync*(socket: Socket, data: string): int {.tags: [WriteIOEffect].} =
       if err.int32 == EAGAIN or err.int32 == EWOULDBLOCK:
         return 0
       else: raiseOSError(err)
-  
+
 
 proc trySend*(socket: Socket, data: string): bool {.tags: [WriteIOEffect].} =
   ## safe alternative to ``send``. Does not raise an EOS when an error occurs,
@@ -1644,7 +1644,7 @@ proc sendTo*(socket: Socket, address: string, port: Port, data: pointer,
              size: int, af: Domain = AF_INET, flags = 0'i32): int {.
              tags: [WriteIOEffect].} =
   ## low-level sendTo proc. This proc sends ``data`` to the specified ``address``,
-  ## which may be an IP address or a hostname, if a hostname is specified 
+  ## which may be an IP address or a hostname, if a hostname is specified
   ## this function will try each IP of that hostname.
   ##
   ## **Note:** This proc is not available for SSL sockets.
@@ -1654,7 +1654,7 @@ proc sendTo*(socket: Socket, address: string, port: Port, data: pointer,
   hints.ai_socktype = toInt(SOCK_STREAM)
   hints.ai_protocol = toInt(IPPROTO_TCP)
   gaiNim(address, port, hints, aiList)
-  
+
   # try all possibilities:
   var success = false
   var it = aiList
@@ -1668,7 +1668,7 @@ proc sendTo*(socket: Socket, address: string, port: Port, data: pointer,
 
   freeaddrinfo(aiList)
 
-proc sendTo*(socket: Socket, address: string, port: Port, 
+proc sendTo*(socket: Socket, address: string, port: Port,
              data: string): int {.tags: [WriteIOEffect].} =
   ## Friendlier version of the low-level ``sendTo``.
   result = socket.sendTo(address, port, cstring(data), data.len)
@@ -1677,10 +1677,10 @@ when defined(Windows):
   const
     IOCPARM_MASK = 127
     IOC_IN = int(-2147483648)
-    FIONBIO = IOC_IN.int32 or ((sizeof(int32) and IOCPARM_MASK) shl 16) or 
+    FIONBIO = IOC_IN.int32 or ((sizeof(int32) and IOCPARM_MASK) shl 16) or
                              (102 shl 8) or 126
 
-  proc ioctlsocket(s: SocketHandle, cmd: clong, 
+  proc ioctlsocket(s: SocketHandle, cmd: clong,
                    argptr: ptr clong): cint {.
                    stdcall, importc:"ioctlsocket", dynlib: "ws2_32.dll".}
 
@@ -1713,7 +1713,7 @@ proc connect*(socket: Socket, address: string, port = Port(0), timeout: int,
   ## the connection to the server to be made.
   let originalStatus = not socket.nonblocking
   socket.setBlocking(false)
-  
+
   socket.connectAsync(address, port, af)
   var s: seq[Socket] = @[socket]
   if selectWrite(s, timeout) != 1:

--- a/tests/manyloc/keineschweine/dependencies/enet/enet.nim
+++ b/tests/manyloc/keineschweine/dependencies/enet/enet.nim
@@ -1,52 +1,52 @@
 discard """Copyright (c) 2002-2012 Lee Salzman
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of 
-this software and associated documentation files (the "Software"), to deal in 
-the Software without restriction, including without limitation the rights to 
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 const Lib = "libenet.so.1(|.0.3)"
 
 {.deadCodeElim: on.}
-const 
+const
   ENET_VERSION_MAJOR* = 1
   ENET_VERSION_MINOR* = 3
   ENET_VERSION_PATCH* = 3
-template ENET_VERSION_CREATE(major, minor, patch: expr): expr = 
+template ENET_VERSION_CREATE(major, minor, patch: expr): expr =
   (((major) shl 16) or ((minor) shl 8) or (patch))
 
-const 
-  ENET_VERSION* = ENET_VERSION_CREATE(ENET_VERSION_MAJOR, ENET_VERSION_MINOR, 
+const
+  ENET_VERSION* = ENET_VERSION_CREATE(ENET_VERSION_MAJOR, ENET_VERSION_MINOR,
                                       ENET_VERSION_PATCH)
-type 
+type
   TVersion* = cuint
-  TSocketType*{.size: sizeof(cint).} = enum 
+  TSocketType*{.size: sizeof(cint).} = enum
     ENET_SOCKET_TYPE_STREAM = 1, ENET_SOCKET_TYPE_DATAGRAM = 2
-  TSocketWait*{.size: sizeof(cint).} = enum 
-    ENET_SOCKET_WAIT_NONE = 0, ENET_SOCKET_WAIT_SEND = (1 shl 0), 
+  TSocketWait*{.size: sizeof(cint).} = enum
+    ENET_SOCKET_WAIT_NONE = 0, ENET_SOCKET_WAIT_SEND = (1 shl 0),
     ENET_SOCKET_WAIT_RECEIVE = (1 shl 1)
-  TSocketOption*{.size: sizeof(cint).} = enum 
-    ENET_SOCKOPT_NONBLOCK = 1, ENET_SOCKOPT_BROADCAST = 2, 
-    ENET_SOCKOPT_RCVBUF = 3, ENET_SOCKOPT_SNDBUF = 4, 
+  TSocketOption*{.size: sizeof(cint).} = enum
+    ENET_SOCKOPT_NONBLOCK = 1, ENET_SOCKOPT_BROADCAST = 2,
+    ENET_SOCKOPT_RCVBUF = 3, ENET_SOCKOPT_SNDBUF = 4,
     ENET_SOCKOPT_REUSEADDR = 5
-const 
+const
   ENET_HOST_ANY* = 0
   ENET_HOST_BROADCAST* = 0xFFFFFFFF
   ENET_PORT_ANY* = 0
-  
+
   ENET_PROTOCOL_MINIMUM_MTU* = 576
   ENET_PROTOCOL_MAXIMUM_MTU* = 4096
   ENET_PROTOCOL_MAXIMUM_PACKET_COMMANDS* = 32
@@ -57,29 +57,29 @@ const
   ENET_PROTOCOL_MAXIMUM_PEER_ID* = 0x00000FFF
 type
   PAddress* = ptr TAddress
-  TAddress*{.pure, final.} = object 
+  TAddress*{.pure, final.} = object
     host*: cuint
     port*: cushort
-  
-  TPacketFlag*{.size: sizeof(cint).} = enum 
-    FlagReliable = (1 shl 0), 
-    FlagUnsequenced = (1 shl 1), 
-    NoAllocate = (1 shl 2), 
+
+  TPacketFlag*{.size: sizeof(cint).} = enum
+    FlagReliable = (1 shl 0),
+    FlagUnsequenced = (1 shl 1),
+    NoAllocate = (1 shl 2),
     UnreliableFragment = (1 shl 3)
-  
-  TENetListNode*{.pure, final.} = object 
+
+  TENetListNode*{.pure, final.} = object
       next*: ptr T_ENetListNode
       previous*: ptr T_ENetListNode
 
   PENetListIterator* = ptr TENetListNode
-  TENetList*{.pure, final.} = object 
+  TENetList*{.pure, final.} = object
     sentinel*: TENetListNode
-  
-  T_ENetPacket*{.pure, final.} = object 
+
+  T_ENetPacket*{.pure, final.} = object
   TPacketFreeCallback* = proc (a2: ptr T_ENetPacket){.cdecl.}
-  
+
   PPacket* = ptr TPacket
-  TPacket*{.pure, final.} = object 
+  TPacket*{.pure, final.} = object
     referenceCount: csize
     flags*: cint
     data*: cstring#ptr cuchar
@@ -87,13 +87,13 @@ type
     freeCallback*: TPacketFreeCallback
 
   PAcknowledgement* = ptr TAcknowledgement
-  TAcknowledgement*{.pure, final.} = object 
+  TAcknowledgement*{.pure, final.} = object
     acknowledgementList*: TEnetListNode
     sentTime*: cuint
     command*: TEnetProtocol
 
   POutgoingCommand* = ptr TOutgoingCommand
-  TOutgoingCommand*{.pure, final.} = object 
+  TOutgoingCommand*{.pure, final.} = object
     outgoingCommandList*: TEnetListNode
     reliableSequenceNumber*: cushort
     unreliableSequenceNumber*: cushort
@@ -107,7 +107,7 @@ type
     packet*: PPacket
 
   PIncomingCommand* = ptr TIncomingCommand
-  TIncomingCommand*{.pure, final.} = object 
+  TIncomingCommand*{.pure, final.} = object
     incomingCommandList*: TEnetListNode
     reliableSequenceNumber*: cushort
     unreliableSequenceNumber*: cushort
@@ -117,52 +117,52 @@ type
     fragments*: ptr cuint
     packet*: ptr TPacket
 
-  TPeerState*{.size: sizeof(cint).} = enum 
-    ENET_PEER_STATE_DISCONNECTED = 0, ENET_PEER_STATE_CONNECTING = 1, 
-    ENET_PEER_STATE_ACKNOWLEDGING_CONNECT = 2, 
-    ENET_PEER_STATE_CONNECTION_PENDING = 3, 
-    ENET_PEER_STATE_CONNECTION_SUCCEEDED = 4, ENET_PEER_STATE_CONNECTED = 5, 
-    ENET_PEER_STATE_DISCONNECT_LATER = 6, ENET_PEER_STATE_DISCONNECTING = 7, 
+  TPeerState*{.size: sizeof(cint).} = enum
+    ENET_PEER_STATE_DISCONNECTED = 0, ENET_PEER_STATE_CONNECTING = 1,
+    ENET_PEER_STATE_ACKNOWLEDGING_CONNECT = 2,
+    ENET_PEER_STATE_CONNECTION_PENDING = 3,
+    ENET_PEER_STATE_CONNECTION_SUCCEEDED = 4, ENET_PEER_STATE_CONNECTED = 5,
+    ENET_PEER_STATE_DISCONNECT_LATER = 6, ENET_PEER_STATE_DISCONNECTING = 7,
     ENET_PEER_STATE_ACKNOWLEDGING_DISCONNECT = 8, ENET_PEER_STATE_ZOMBIE = 9
-  
-  TENetProtocolCommand*{.size: sizeof(cint).} = enum 
-    ENET_PROTOCOL_COMMAND_NONE = 0, ENET_PROTOCOL_COMMAND_ACKNOWLEDGE = 1, 
-    ENET_PROTOCOL_COMMAND_CONNECT = 2, 
-    ENET_PROTOCOL_COMMAND_VERIFY_CONNECT = 3, 
-    ENET_PROTOCOL_COMMAND_DISCONNECT = 4, ENET_PROTOCOL_COMMAND_PING = 5, 
-    ENET_PROTOCOL_COMMAND_SEND_RELIABLE = 6, 
-    ENET_PROTOCOL_COMMAND_SEND_UNRELIABLE = 7, 
-    ENET_PROTOCOL_COMMAND_SEND_FRAGMENT = 8, 
-    ENET_PROTOCOL_COMMAND_SEND_UNSEQUENCED = 9, 
-    ENET_PROTOCOL_COMMAND_BANDWIDTH_LIMIT = 10, 
-    ENET_PROTOCOL_COMMAND_THROTTLE_CONFIGURE = 11, 
-    ENET_PROTOCOL_COMMAND_SEND_UNRELIABLE_FRAGMENT = 12, 
+
+  TENetProtocolCommand*{.size: sizeof(cint).} = enum
+    ENET_PROTOCOL_COMMAND_NONE = 0, ENET_PROTOCOL_COMMAND_ACKNOWLEDGE = 1,
+    ENET_PROTOCOL_COMMAND_CONNECT = 2,
+    ENET_PROTOCOL_COMMAND_VERIFY_CONNECT = 3,
+    ENET_PROTOCOL_COMMAND_DISCONNECT = 4, ENET_PROTOCOL_COMMAND_PING = 5,
+    ENET_PROTOCOL_COMMAND_SEND_RELIABLE = 6,
+    ENET_PROTOCOL_COMMAND_SEND_UNRELIABLE = 7,
+    ENET_PROTOCOL_COMMAND_SEND_FRAGMENT = 8,
+    ENET_PROTOCOL_COMMAND_SEND_UNSEQUENCED = 9,
+    ENET_PROTOCOL_COMMAND_BANDWIDTH_LIMIT = 10,
+    ENET_PROTOCOL_COMMAND_THROTTLE_CONFIGURE = 11,
+    ENET_PROTOCOL_COMMAND_SEND_UNRELIABLE_FRAGMENT = 12,
     ENET_PROTOCOL_COMMAND_COUNT = 13, ENET_PROTOCOL_COMMAND_MASK = 0x0000000F
-  TENetProtocolFlag*{.size: sizeof(cint).} = enum 
+  TENetProtocolFlag*{.size: sizeof(cint).} = enum
     ENET_PROTOCOL_HEADER_SESSION_SHIFT = 12,
-    ENET_PROTOCOL_COMMAND_FLAG_UNSEQUENCED = (1 shl 6), 
-    ENET_PROTOCOL_COMMAND_FLAG_ACKNOWLEDGE = (1 shl 7), 
-    ENET_PROTOCOL_HEADER_SESSION_MASK = (3 shl 12), 
-    ENET_PROTOCOL_HEADER_FLAG_COMPRESSED = (1 shl 14), 
+    ENET_PROTOCOL_COMMAND_FLAG_UNSEQUENCED = (1 shl 6),
+    ENET_PROTOCOL_COMMAND_FLAG_ACKNOWLEDGE = (1 shl 7),
+    ENET_PROTOCOL_HEADER_SESSION_MASK = (3 shl 12),
+    ENET_PROTOCOL_HEADER_FLAG_COMPRESSED = (1 shl 14),
     ENET_PROTOCOL_HEADER_FLAG_SENT_TIME = (1 shl 15),
     ENET_PROTOCOL_HEADER_FLAG_MASK = ENET_PROTOCOL_HEADER_FLAG_COMPRESSED.cint or
         ENET_PROTOCOL_HEADER_FLAG_SENT_TIME.cint
-  
-  TENetProtocolHeader*{.pure, final.} = object 
+
+  TENetProtocolHeader*{.pure, final.} = object
     peerID*: cushort
     sentTime*: cushort
 
-  TENetProtocolCommandHeader*{.pure, final.} = object 
+  TENetProtocolCommandHeader*{.pure, final.} = object
     command*: cuchar
     channelID*: cuchar
     reliableSequenceNumber*: cushort
 
-  TENetProtocolAcknowledge*{.pure, final.} = object 
+  TENetProtocolAcknowledge*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     receivedReliableSequenceNumber*: cushort
     receivedSentTime*: cushort
 
-  TENetProtocolConnect*{.pure, final.} = object 
+  TENetProtocolConnect*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     outgoingPeerID*: cushort
     incomingSessionID*: cuchar
@@ -178,7 +178,7 @@ type
     connectID*: cuint
     data*: cuint
 
-  TENetProtocolVerifyConnect*{.pure, final.} = object 
+  TENetProtocolVerifyConnect*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     outgoingPeerID*: cushort
     incomingSessionID*: cuchar
@@ -193,39 +193,39 @@ type
     packetThrottleDeceleration*: cuint
     connectID*: cuint
 
-  TENetProtocolBandwidthLimit*{.pure, final.} = object 
+  TENetProtocolBandwidthLimit*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     incomingBandwidth*: cuint
     outgoingBandwidth*: cuint
 
-  TENetProtocolThrottleConfigure*{.pure, final.} = object 
+  TENetProtocolThrottleConfigure*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     packetThrottleInterval*: cuint
     packetThrottleAcceleration*: cuint
     packetThrottleDeceleration*: cuint
 
-  TENetProtocolDisconnect*{.pure, final.} = object 
+  TENetProtocolDisconnect*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     data*: cuint
 
-  TENetProtocolPing*{.pure, final.} = object 
+  TENetProtocolPing*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
 
-  TENetProtocolSendReliable*{.pure, final.} = object 
+  TENetProtocolSendReliable*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     dataLength*: cushort
 
-  TENetProtocolSendUnreliable*{.pure, final.} = object 
+  TENetProtocolSendUnreliable*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     unreliableSequenceNumber*: cushort
     dataLength*: cushort
 
-  TENetProtocolSendUnsequenced*{.pure, final.} = object 
+  TENetProtocolSendUnsequenced*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     unsequencedGroup*: cushort
     dataLength*: cushort
 
-  TENetProtocolSendFragment*{.pure, final.} = object 
+  TENetProtocolSendFragment*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
     startSequenceNumber*: cushort
     dataLength*: cushort
@@ -233,12 +233,12 @@ type
     fragmentNumber*: cuint
     totalLength*: cuint
     fragmentOffset*: cuint
-  
+
   ## this is incomplete; need helper templates or something
   ## ENetProtocol
-  TENetProtocol*{.pure, final.} = object 
+  TENetProtocol*{.pure, final.} = object
     header*: TENetProtocolCommandHeader
-const 
+const
   ENET_BUFFER_MAXIMUM* = (1 + 2 * ENET_PROTOCOL_MAXIMUM_PACKET_COMMANDS)
   ENET_HOST_RECEIVE_BUFFER_SIZE          = 256 * 1024
   ENET_HOST_SEND_BUFFER_SIZE             = 256 * 1024
@@ -270,39 +270,39 @@ when defined(Linux) or true:
   import posix
   const
     ENET_SOCKET_NULL*: cint = -1
-  type 
+  type
     TENetSocket* = cint
     PEnetBuffer* = ptr object
-    TENetBuffer*{.pure, final.} = object 
+    TENetBuffer*{.pure, final.} = object
       data*: pointer
       dataLength*: csize
     TENetSocketSet* = FdSet
   ## see if these are different on win32, if not then get rid of these
-  template ENET_HOST_TO_NET_16*(value: expr): expr = 
+  template ENET_HOST_TO_NET_16*(value: expr): expr =
     (htons(value))
-  template ENET_HOST_TO_NET_32*(value: expr): expr = 
+  template ENET_HOST_TO_NET_32*(value: expr): expr =
     (htonl(value))
-  template ENET_NET_TO_HOST_16*(value: expr): expr = 
+  template ENET_NET_TO_HOST_16*(value: expr): expr =
     (ntohs(value))
-  template ENET_NET_TO_HOST_32*(value: expr): expr = 
+  template ENET_NET_TO_HOST_32*(value: expr): expr =
     (ntohl(value))
 
-  template ENET_SOCKETSET_EMPTY*(sockset: expr): expr = 
+  template ENET_SOCKETSET_EMPTY*(sockset: expr): expr =
     FD_ZERO(addr((sockset)))
-  template ENET_SOCKETSET_ADD*(sockset, socket: expr): expr = 
+  template ENET_SOCKETSET_ADD*(sockset, socket: expr): expr =
     fd_set(socket, addr((sockset)))
-  template ENET_SOCKETSET_REMOVE*(sockset, socket: expr): expr = 
+  template ENET_SOCKETSET_REMOVE*(sockset, socket: expr): expr =
     FD_CLEAR(socket, addr((sockset)))
-  template ENET_SOCKETSET_CHECK*(sockset, socket: expr): expr = 
+  template ENET_SOCKETSET_CHECK*(sockset, socket: expr): expr =
     FD_ISSET(socket, addr((sockset)))
 
 when defined(Windows):
   ## put the content of win32.h in here
 
 
-type 
+type
   PChannel* = ptr TChannel
-  TChannel*{.pure, final.} = object 
+  TChannel*{.pure, final.} = object
     outgoingReliableSequenceNumber*: cushort
     outgoingUnreliableSequenceNumber*: cushort
     usedReliableWindows*: cushort
@@ -313,7 +313,7 @@ type
     incomingUnreliableCommands*: TENetList
 
   PPeer* = ptr TPeer
-  TPeer*{.pure, final.} = object 
+  TPeer*{.pure, final.} = object
     dispatchList*: TEnetListNode
     host*: ptr THost
     outgoingPeerID*: cushort
@@ -367,25 +367,25 @@ type
     needsDispatch*: cint
     incomingUnsequencedGroup*: cushort
     outgoingUnsequencedGroup*: cushort
-    unsequencedWindow*: array[0..ENET_PEER_UNSEQUENCED_WINDOW_SIZE div 32 - 1, 
+    unsequencedWindow*: array[0..ENET_PEER_UNSEQUENCED_WINDOW_SIZE div 32 - 1,
                               cuint]
     eventData*: cuint
 
   PCompressor* = ptr TCompressor
-  TCompressor*{.pure, final.} = object 
+  TCompressor*{.pure, final.} = object
     context*: pointer
-    compress*: proc (context: pointer; inBuffers: ptr TEnetBuffer; 
-                     inBufferCount: csize; inLimit: csize; 
+    compress*: proc (context: pointer; inBuffers: ptr TEnetBuffer;
+                     inBufferCount: csize; inLimit: csize;
                      outData: ptr cuchar; outLimit: csize): csize{.cdecl.}
-    decompress*: proc (context: pointer; inData: ptr cuchar; inLimit: csize; 
+    decompress*: proc (context: pointer; inData: ptr cuchar; inLimit: csize;
                        outData: ptr cuchar; outLimit: csize): csize{.cdecl.}
     destroy*: proc (context: pointer){.cdecl.}
 
   TChecksumCallback* = proc (buffers: ptr TEnetBuffer; bufferCount: csize): cuint{.
       cdecl.}
-  
+
   PHost* = ptr THost
-  THost*{.pure, final.} = object 
+  THost*{.pure, final.} = object
     socket*: TEnetSocket
     address*: TAddress
     incomingBandwidth*: cuint
@@ -402,14 +402,14 @@ type
     continueSending*: cint
     packetSize*: csize
     headerFlags*: cushort
-    commands*: array[0..ENET_PROTOCOL_MAXIMUM_PACKET_COMMANDS - 1, 
+    commands*: array[0..ENET_PROTOCOL_MAXIMUM_PACKET_COMMANDS - 1,
                      TEnetProtocol]
     commandCount*: csize
     buffers*: array[0..ENET_BUFFER_MAXIMUM - 1, TEnetBuffer]
     bufferCount*: csize
     checksum*: TChecksumCallback
     compressor*: TCompressor
-    packetData*: array[0..ENET_PROTOCOL_MAXIMUM_MTU - 1, 
+    packetData*: array[0..ENET_PROTOCOL_MAXIMUM_MTU - 1,
                        array[0..2 - 1, cuchar]]
     receivedAddress*: TAddress
     receivedData*: ptr cuchar
@@ -418,19 +418,19 @@ type
     totalSentPackets*: cuint
     totalReceivedData*: cuint
     totalReceivedPackets*: cuint
-  
-  TEventType*{.size: sizeof(cint).} = enum 
-    EvtNone = 0, EvtConnect = 1, 
+
+  TEventType*{.size: sizeof(cint).} = enum
+    EvtNone = 0, EvtConnect = 1,
     EvtDisconnect = 2, EvtReceive = 3
   PEvent* = ptr TEvent
-  TEvent*{.pure, final.} = object 
+  TEvent*{.pure, final.} = object
     kind*: TEventType
     peer*: ptr TPeer
     channelID*: cuchar
     data*: cuint
     packet*: ptr TPacket
 
-  TENetCallbacks*{.pure, final.} = object 
+  TENetCallbacks*{.pure, final.} = object
     malloc*: proc (size: csize): pointer{.cdecl.}
     free*: proc (memory: pointer){.cdecl.}
     no_memory*: proc (){.cdecl.}
@@ -473,10 +473,10 @@ proc send*(socket: TEnetSocket; address: var TAddress; buffer: ptr TEnetBuffer; 
   importc: "enet_socket_send", dynlib: Lib.}
 proc send*(socket: TEnetSocket; address: ptr TAddress; buffer: ptr TEnetBuffer; size: csize): cint{.
   importc: "enet_socket_send", dynlib: Lib.}
-proc receive*(socket: TEnetSocket; address: var TAddress; 
+proc receive*(socket: TEnetSocket; address: var TAddress;
                buffer: ptr TEnetBuffer; size: csize): cint{.
   importc: "enet_socket_receive", dynlib: Lib.}
-proc receive*(socket: TEnetSocket; address: ptr TAddress; 
+proc receive*(socket: TEnetSocket; address: ptr TAddress;
                buffer: ptr TEnetBuffer; size: csize): cint{.
   importc: "enet_socket_receive", dynlib: Lib.}
 proc wait*(socket: TEnetSocket; a3: ptr cuint; a4: cuint): cint{.
@@ -485,7 +485,7 @@ proc setOption*(socket: TEnetSocket; a3: TSocketOption; a4: cint): cint{.
   importc: "enet_socket_set_option", dynlib: Lib.}
 proc destroy*(socket: TEnetSocket){.
   importc: "enet_socket_destroy", dynlib: Lib.}
-proc select*(socket: TEnetSocket; a3: ptr TENetSocketSet; 
+proc select*(socket: TEnetSocket; a3: ptr TENetSocketSet;
               a4: ptr TENetSocketSet; a5: cuint): cint{.
   importc: "enet_socketset_select", dynlib: Lib.}
 
@@ -578,13 +578,13 @@ proc resetQueues*(peer: PPeer){.
 proc setupOutgoingCommand*(peer: PPeer; outgoingCommand: POutgoingCommand){.
   importc: "enet_peer_setup_outgoing_command", dynlib: Lib.}
 
-proc queueOutgoingCommand*(peer: PPeer; command: ptr TEnetProtocol; 
+proc queueOutgoingCommand*(peer: PPeer; command: ptr TEnetProtocol;
           packet: PPacket; offset: cuint; length: cushort): POutgoingCommand{.
   importc: "enet_peer_queue_outgoing_command", dynlib: Lib.}
-proc queueIncomingCommand*(peer: PPeer; command: ptr TEnetProtocol; 
+proc queueIncomingCommand*(peer: PPeer; command: ptr TEnetProtocol;
                     packet: PPacket; fragmentCount: cuint): PIncomingCommand{.
   importc: "enet_peer_queue_incoming_command", dynlib: Lib.}
-proc queueAcknowledgement*(peer: PPeer; command: ptr TEnetProtocol; 
+proc queueAcknowledgement*(peer: PPeer; command: ptr TEnetProtocol;
                             sentTime: cushort): PAcknowledgement{.
   importc: "enet_peer_queue_acknowledgement", dynlib: Lib.}
 proc dispatchIncomingUnreliableCommands*(peer: PPeer; channel: PChannel){.
@@ -596,10 +596,10 @@ proc createRangeCoder*(): pointer{.
   importc: "enet_range_coder_create", dynlib: Lib.}
 proc rangeCoderDestroy*(context: pointer){.
   importc: "enet_range_coder_destroy", dynlib: Lib.}
-proc rangeCoderCompress*(context: pointer; inBuffers: PEnetBuffer; inLimit, 
+proc rangeCoderCompress*(context: pointer; inBuffers: PEnetBuffer; inLimit,
                bufferCount: csize; outData: cstring; outLimit: csize): csize{.
   importc: "enet_range_coder_compress", dynlib: Lib.}
-proc rangeCoderDecompress*(context: pointer; inData: cstring; inLimit: csize; 
+proc rangeCoderDecompress*(context: pointer; inData: cstring; inLimit: csize;
                             outData: cstring; outLimit: csize): csize{.
   importc: "enet_range_coder_decompress", dynlib: Lib.}
 proc protocolCommandSize*(commandNumber: cuchar): csize{.

--- a/tests/manyloc/keineschweine/dependencies/enet/enet.nim
+++ b/tests/manyloc/keineschweine/dependencies/enet/enet.nim
@@ -276,7 +276,7 @@ when defined(Linux) or true:
     TENetBuffer*{.pure, final.} = object 
       data*: pointer
       dataLength*: csize
-    TENetSocketSet* = Tfd_set
+    TENetSocketSet* = FdSet
   ## see if these are different on win32, if not then get rid of these
   template ENET_HOST_TO_NET_16*(value: expr): expr = 
     (htons(value))
@@ -290,7 +290,7 @@ when defined(Linux) or true:
   template ENET_SOCKETSET_EMPTY*(sockset: expr): expr = 
     FD_ZERO(addr((sockset)))
   template ENET_SOCKETSET_ADD*(sockset, socket: expr): expr = 
-    FD_SET(socket, addr((sockset)))
+    fd_set(socket, addr((sockset)))
   template ENET_SOCKETSET_REMOVE*(sockset, socket: expr): expr = 
     FD_CLEAR(socket, addr((sockset)))
   template ENET_SOCKETSET_CHECK*(sockset, socket: expr): expr = 

--- a/web/news.txt
+++ b/web/news.txt
@@ -23,6 +23,8 @@ News
     used: ``import "scene/2d/sprite"``. The former code never was valid Nim.
   - The ``FD_SET`` proc from ``lib/wrappers/libuv.nim`` is now ``fd_set`` in
     order to resolve a naming conflict.
+  - The ``F_LOCK`` variable from ``lib/wrappers/libuv.nim`` is now ``f_lock``
+	in order to resolve a naming conflict.
 
 
   Library additions

--- a/web/news.txt
+++ b/web/news.txt
@@ -21,6 +21,8 @@ News
     and ``2f`` (float32) which means imports like ``import scene/2d/sprite``
     do not work anymore. Instead quotes have to be
     used: ``import "scene/2d/sprite"``. The former code never was valid Nim.
+  - The ``FD_SET`` proc from ``lib/wrappers/libuv.nim`` is now ``fd_set`` in
+    order to resolve a naming conflict.
 
 
   Library additions


### PR DESCRIPTION
Changes type `TFdSet` to `FdSet` and proc `FD_SET` to `fd_set`.

`TFdSet` is deprecated and `FD_SET` is added to `web/news.txt` as a breaking change.

These are additional fixes for https://github.com/nim-lang/Nim/issues/2773