### PR TITLE
Change --useColors to --colors:on|off and add help

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -537,9 +537,7 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
   of "genscript":
     expectNoArg(switch, arg, pass, info)
     incl(gGlobalOptions, optGenScript)
-  of "usecolors":
-    expectNoArg(switch, arg, pass, info)
-    incl(gGlobalOptions, optUseColors)
+  of "colors": processOnOffSwitchG({optUseColors}, arg, pass, info)
   of "lib":
     expectArg(switch, arg, pass, info)
     libpath = processPath(arg, notRelativeToProj=true)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -16,6 +16,7 @@ Advanced commands:
 Advanced options:
   -o, --out:FILE            set the output filename
   --stdout                  output to stdout
+  --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths           list full paths in messages
   -w, --warnings:on|off     turn all warnings on|off
   --warning[X]:on|off       turn specific warning X on|off


### PR DESCRIPTION
Since we introduced automatic colors on terminals (via isatty) there is no way
to turn it off, since (undocumented) --useColors just turns them on.

This replaces --useColors with --colors:on|off, so anyone who prefers
non-colored compiler messages may now turn it off now.