### PR TITLE
Rewrote procs for float32/float64

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -160,20 +160,20 @@ proc randomize*(seed: int) {.benign.}
 {.push noSideEffect.}
 when not defined(JS):
   proc sqrt*(x: float32): float32 {.importc: "sqrt", header: "<math.h>".}
-	proc sqrt*(x: float64): float64 {.importc: "sqrt", header: "<math.h>".}
+  proc sqrt*(x: float64): float64 {.importc: "sqrt", header: "<math.h>".}
     ## computes the square root of `x`.
   proc cbrt*(x: float32): float32 {.importc: "cbrt", header: "<math.h>".}
-	proc cbrt*(x: float64): float64 {.importc: "cbrt", header: "<math.h>".}
+  proc cbrt*(x: float64): float64 {.importc: "cbrt", header: "<math.h>".}
     ## computes the cubic root of `x`
 
   proc ln*(x: float32): float32 {.importc: "log", header: "<math.h>".}
-	proc ln*(x: float64): float64 {.importc: "log", header: "<math.h>".}
+  proc ln*(x: float64): float64 {.importc: "log", header: "<math.h>".}
     ## computes ln(x).
   proc log10*(x: float32): float32 {.importc: "log10", header: "<math.h>".}
-	proc log10*(x: float64): float64 {.importc: "log10", header: "<math.h>".}
+  proc log10*(x: float64): float64 {.importc: "log10", header: "<math.h>".}
   proc log2*[T: float32|float64](x: T): T = return ln(x) / ln(2.0)
   proc exp*(x: float32): float32 {.importc: "exp", header: "<math.h>".}
-	proc exp*(x: float64): float64 {.importc: "exp", header: "<math.h>".}
+  proc exp*(x: float64): float64 {.importc: "exp", header: "<math.h>".}
     ## computes e**x.
 
   proc frexp*(x: float32, exponent: var int): float32 {.
@@ -191,11 +191,11 @@ when not defined(JS):
     ## converts a float to an int by rounding.
 
   proc arccos*(x: float32): float32 {.importc: "acos", header: "<math.h>".}
-	proc arccos*(x: float64): float64 {.importc: "acos", header: "<math.h>".}
+  proc arccos*(x: float64): float64 {.importc: "acos", header: "<math.h>".}
   proc arcsin*(x: float32): float32 {.importc: "asin", header: "<math.h>".}
-	proc arcsin*(x: float64): float64 {.importc: "asin", header: "<math.h>".}
+  proc arcsin*(x: float64): float64 {.importc: "asin", header: "<math.h>".}
   proc arctan*(x: float32): float32 {.importc: "atan", header: "<math.h>".}
-	proc arctan*(x: float64): float64 {.importc: "atan", header: "<math.h>".}
+  proc arctan*(x: float64): float64 {.importc: "atan", header: "<math.h>".}
   proc arctan2*(y, x: float32): float32 {.importc: "atan2", header: "<math.h>".}
   proc arctan2*(y, x: float64): float64 {.importc: "atan2", header: "<math.h>".}
     ## Calculate the arc tangent of `y` / `x`.
@@ -204,37 +204,37 @@ when not defined(JS):
     ## (`x` near 0).
 
   proc cos*(x: float32): float32 {.importc: "cos", header: "<math.h>".}
-	proc cos*(x: float64): float64 {.importc: "cos", header: "<math.h>".}
+  proc cos*(x: float64): float64 {.importc: "cos", header: "<math.h>".}
   proc cosh*(x: float32): float32 {.importc: "cosh", header: "<math.h>".}
-	proc cosh*(x: float64): float64 {.importc: "cosh", header: "<math.h>".}
+  proc cosh*(x: float64): float64 {.importc: "cosh", header: "<math.h>".}
   proc hypot*(x, y: float32): float32 {.importc: "hypot", header: "<math.h>".}
   proc hypot*(x, y: float64): float64 {.importc: "hypot", header: "<math.h>".}
     ## same as ``sqrt(x*x + y*y)``.
 
   proc sinh*(x: float32): float32 {.importc: "sinh", header: "<math.h>".}
-	proc sinh*(x: float64): float64 {.importc: "sinh", header: "<math.h>".}
+  proc sinh*(x: float64): float64 {.importc: "sinh", header: "<math.h>".}
   proc sin*(x: float32): float32 {.importc: "sin", header: "<math.h>".}
-	proc sin*(x: float64): float64 {.importc: "sin", header: "<math.h>".}
+  proc sin*(x: float64): float64 {.importc: "sin", header: "<math.h>".}
   proc tan*(x: float32): float32 {.importc: "tan", header: "<math.h>".}
-	proc tan*(x: float64): float64 {.importc: "tan", header: "<math.h>".}
+  proc tan*(x: float64): float64 {.importc: "tan", header: "<math.h>".}
   proc tanh*(x: float32): float32 {.importc: "tanh", header: "<math.h>".}
-	proc tanh*(x: float64): float64 {.importc: "tanh", header: "<math.h>".}
+  proc tanh*(x: float64): float64 {.importc: "tanh", header: "<math.h>".}
   proc pow*(x, y: float32): float32 {.importc: "pow", header: "<math.h>".}
-	proc pow*(x, y: float64): float64 {.importc: "pow", header: "<math.h>".}
+  proc pow*(x, y: float64): float64 {.importc: "pow", header: "<math.h>".}
     ## computes x to power raised of y.
 
   proc erf*(x: float32): float32 {.importc: "erf", header: "<math.h>".}
-	proc erf*(x: float64): float64 {.importc: "erf", header: "<math.h>".}
+  proc erf*(x: float64): float64 {.importc: "erf", header: "<math.h>".}
     ## The error function
   proc erfc*(x: float32): float32 {.importc: "erfc", header: "<math.h>".}
-	proc erfc*(x: float64): float64 {.importc: "erfc", header: "<math.h>".}
+  proc erfc*(x: float64): float64 {.importc: "erfc", header: "<math.h>".}
     ## The complementary error function
 
   proc lgamma*(x: float32): float32 {.importc: "lgamma", header: "<math.h>".}
-	proc lgamma*(x: float64): float64 {.importc: "lgamma", header: "<math.h>".}
+  proc lgamma*(x: float64): float64 {.importc: "lgamma", header: "<math.h>".}
     ## Natural log of the gamma function
   proc tgamma*(x: float32): float32 {.importc: "tgamma", header: "<math.h>".}
-	proc tgamma*(x: float64): float64 {.importc: "tgamma", header: "<math.h>".}
+  proc tgamma*(x: float64): float64 {.importc: "tgamma", header: "<math.h>".}
     ## The gamma function
 
   # C procs:
@@ -288,21 +288,21 @@ when not defined(JS):
     result = int(rand()) mod max
 
   proc trunc*(x: float32): float32 {.importc: "trunc", header: "<math.h>".}
-	proc trunc*(x: float64): float64 {.importc: "trunc", header: "<math.h>".}
+  proc trunc*(x: float64): float64 {.importc: "trunc", header: "<math.h>".}
   proc floor*(x: float32): float32 {.importc: "floor", header: "<math.h>".}
-	proc floor*(x: float64): float64 {.importc: "floor", header: "<math.h>".}
+  proc floor*(x: float64): float64 {.importc: "floor", header: "<math.h>".}
   proc ceil*(x: float32): float32 {.importc: "ceil", header: "<math.h>".}
-	proc ceil*(x: float64): float64 {.importc: "ceil", header: "<math.h>".}
+  proc ceil*(x: float64): float64 {.importc: "ceil", header: "<math.h>".}
 
   proc fmod*(x, y: float32): float32 {.importc: "fmod", header: "<math.h>".}
-	proc fmod*(x, y: float64): float64 {.importc: "fmod", header: "<math.h>".}
+  proc fmod*(x, y: float64): float64 {.importc: "fmod", header: "<math.h>".}
 
 else:
   proc mathrandom(): float {.importc: "Math.random", nodecl.}
   proc floor*(x: float32): float32 {.importc: "Math.floor", nodecl.}
-	proc floor*(x: float64): float64 {.importc: "Math.floor", nodecl.}
+  proc floor*(x: float64): float64 {.importc: "Math.floor", nodecl.}
   proc ceil*(x: float32): float32 {.importc: "Math.ceil", nodecl.}
-	proc ceil*(x: float64): float64 {.importc: "Math.ceil", nodecl.}
+  proc ceil*(x: float64): float64 {.importc: "Math.ceil", nodecl.}
   proc random(max: int): int =
     result = int(floor(mathrandom() * float(max)))
   proc random(max: float): float =
@@ -311,17 +311,17 @@ else:
   proc randomize(seed: int) = discard
 
   proc sqrt*(x: float32): float32 {.importc: "Math.sqrt", nodecl.}
-	proc sqrt*(x: float64): float64 {.importc: "Math.sqrt", nodecl.}
+  proc sqrt*(x: float64): float64 {.importc: "Math.sqrt", nodecl.}
   proc ln*(x: float32): float32 {.importc: "Math.log", nodecl.}
-	proc ln*(x: float64): float64 {.importc: "Math.log", nodecl.}
+  proc ln*(x: float64): float64 {.importc: "Math.log", nodecl.}
   proc log10*[T: float32|float64](x: T): T = return ln(x) / ln(10.0)
-	proc log2*[T: float32|float64](x: T): T = return ln(x) / ln(2.0)
+  proc log2*[T: float32|float64](x: T): T = return ln(x) / ln(2.0)
 
   proc exp*(x: float32): float32 {.importc: "Math.exp", nodecl.}
-	proc exp*(x: float64): float64 {.importc: "Math.exp", nodecl.}
+  proc exp*(x: float64): float64 {.importc: "Math.exp", nodecl.}
   proc round*(x: float): int {.importc: "Math.round", nodecl.}
   proc pow*(x, y: float32): float32 {.importC: "Math.pow", nodecl.}
-	proc pow*(x, y: float64): float64 {.importc: "Math.pow", nodecl.}
+  proc pow*(x, y: float64): float64 {.importc: "Math.pow", nodecl.}
 
   proc frexp*[T: float32|float64](x: T, exponent: var int): T =
     if x == 0.0:
@@ -335,25 +335,25 @@ else:
       result = x / pow(2.0, ex)
 
   proc arccos*(x: float32): float32 {.importc: "Math.acos", nodecl.}
-	proc arccos*(x: float64): float64 {.importc: "Math.acos", nodecl.}
+  proc arccos*(x: float64): float64 {.importc: "Math.acos", nodecl.}
   proc arcsin*(x: float32): float32 {.importc: "Math.asin", nodecl.}
-	proc arcsin*(x: float64): float64 {.importc: "Math.asin", nodecl.}
+  proc arcsin*(x: float64): float64 {.importc: "Math.asin", nodecl.}
   proc arctan*(x: float32): float32 {.importc: "Math.atan", nodecl.}
-	proc arctan*(x: float64): float64 {.importc: "Math.atan", nodecl.}
+  proc arctan*(x: float64): float64 {.importc: "Math.atan", nodecl.}
   proc arctan2*(y, x: float32): float32 {.importC: "Math.atan2", nodecl.}
-	proc arctan2*(y, x: float64): float64 {.importc: "Math.atan2", nodecl.}
+  proc arctan2*(y, x: float64): float64 {.importc: "Math.atan2", nodecl.}
 
   proc cos*(x: float32): float32 {.importc: "Math.cos", nodecl.}
-	proc cos*(x: float64): float64 {.importc: "Math.cos", nodecl.}
+  proc cos*(x: float64): float64 {.importc: "Math.cos", nodecl.}
   proc cosh*(x: float32): float32 = return (exp(x)+exp(-x))*0.5
-	proc cosh*(x: float64): float64 = return (exp(x)+exp(-x))*0.5
+  proc cosh*(x: float64): float64 = return (exp(x)+exp(-x))*0.5
   proc hypot*[T: float32|float64](x, y: T): T = return sqrt(x*x + y*y)
   proc sinh*]T: float32|float64](x: T): T = return (exp(x)-exp(-x))*0.5
   proc sin*(x: float32): float32 {.importc: "Math.sin", nodecl.}
-	proc sin*(x: float64): float64 {.importc: "Math.sin", nodecl.}
+  proc sin*(x: float64): float64 {.importc: "Math.sin", nodecl.}
   proc tan*(x: float32): float32 {.importc: "Math.tan", nodecl.}
-	proc tan*(x: float64): float64 {.importc: "Math.tan", nodecl.}
-	proc tanh*[T: float32|float64](x: T): T =
+  proc tan*(x: float64): float64 {.importc: "Math.tan", nodecl.}
+  proc tanh*[T: float32|float64](x: T): T =
     var y = exp(2.0*x)
     return (y-1.0)/(y+1.0)
 

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -8,7 +8,7 @@
 #
 
 ##   Constructive mathematics is naturally typed. -- Simon Thompson
-## 
+##
 ## Basic math routines for Nim.
 ## This module is available for the `JavaScript target
 ## <backends.html#the-javascript-target>`_.
@@ -34,9 +34,9 @@ const
   MaxFloat32Precision* = 8  ## maximum number of meaningful digits
                             ## after the decimal point for Nim's
                             ## ``float32`` type.
-  MaxFloatPrecision* = MaxFloat64Precision ## maximum number of 
+  MaxFloatPrecision* = MaxFloat64Precision ## maximum number of
                                            ## meaningful digits
-                                           ## after the decimal point 
+                                           ## after the decimal point
                                            ## for Nim's ``float`` type.
 
 type
@@ -50,10 +50,10 @@ type
     fcInf,       ## value is positive infinity
     fcNegInf     ## value is negative infinity
 
-proc classify*(x: float): FloatClass = 
+proc classify*(x: float): FloatClass =
   ## classifies a floating point value. Returns `x`'s class as specified by
   ## `FloatClass`.
-  
+
   # JavaScript and most C compilers have no classify:
   if x == 0.0:
     if 1.0/x == Inf:
@@ -68,15 +68,15 @@ proc classify*(x: float): FloatClass =
   # XXX: fcSubnormal is not detected!
 
 
-proc binom*(n, k: int): int {.noSideEffect.} = 
+proc binom*(n, k: int): int {.noSideEffect.} =
   ## computes the binomial coefficient
   if k <= 0: return 1
   if 2*k > n: return binom(n, n-k)
   result = n
   for i in countup(2, k):
     result = (result * (n + 1 - i)) div i
-    
-proc fac*(n: int): int {.noSideEffect.} = 
+
+proc fac*(n: int): int {.noSideEffect.} =
   ## computes the faculty/factorial function.
   result = 1
   for i in countup(2, n):
@@ -90,7 +90,7 @@ proc isPowerOfTwo*(x: int): bool {.noSideEffect.} =
 proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
   ## returns `x` rounded up to the nearest power of two.
   ## Zero and negative numbers get rounded up to 1.
-  result = x - 1 
+  result = x - 1
   when defined(cpu64):
     result = result or (result shr 32)
   when sizeof(int) > 2:
@@ -109,8 +109,8 @@ proc countBits32*(n: int32): int {.noSideEffect.} =
   v = (v and 0x33333333'i32) +% ((v shr 2'i32) and 0x33333333'i32)
   result = ((v +% (v shr 4'i32) and 0xF0F0F0F'i32) *% 0x1010101'i32) shr 24'i32
 
-proc sum*[T](x: openArray[T]): T {.noSideEffect.} = 
-  ## computes the sum of the elements in `x`. 
+proc sum*[T](x: openArray[T]): T {.noSideEffect.} =
+  ## computes the sum of the elements in `x`.
   ## If `x` is empty, 0 is returned.
   for i in items(x): result = result + i
 
@@ -124,7 +124,7 @@ proc mean*[T](x: openArray[T]): float {.noSideEffect.} =
   result = result / toFloat(len(x))
 
 proc variance*[T](x: openArray[T]): float {.noSideEffect.} =
-  ## computes the variance of the elements in `x`. 
+  ## computes the variance of the elements in `x`.
   ## If `x` is empty, NaN is returned.
   ## ``toFloat(x: T): float`` must be defined.
   result = 0.0
@@ -151,7 +151,7 @@ proc randomize*() {.benign.}
   ## initializes the random number generator with a "random"
   ## number, i.e. a tickcount. Note: Does nothing for the JavaScript target,
   ## as JavaScript does not support this.
-  
+
 proc randomize*(seed: int) {.benign.}
   ## initializes the random number generator with a specific seed.
   ## Note: Does nothing for the JavaScript target,
@@ -159,60 +159,84 @@ proc randomize*(seed: int) {.benign.}
 
 {.push noSideEffect.}
 when not defined(JS):
-  proc sqrt*(x: float): float {.importc: "sqrt", header: "<math.h>".}
+  proc sqrt*(x: float32): float32 {.importc: "sqrt", header: "<math.h>".}
+	proc sqrt*(x: float64): float64 {.importc: "sqrt", header: "<math.h>".}
     ## computes the square root of `x`.
-  proc cbrt*(x: float): float {.importc: "cbrt", header: "<math.h>".}
+  proc cbrt*(x: float32): float32 {.importc: "cbrt", header: "<math.h>".}
+	proc cbrt*(x: float64): float64 {.importc: "cbrt", header: "<math.h>".}
     ## computes the cubic root of `x`
-  
-  proc ln*(x: float): float {.importc: "log", header: "<math.h>".}
+
+  proc ln*(x: float32): float32 {.importc: "log", header: "<math.h>".}
+	proc ln*(x: float64): float64 {.importc: "log", header: "<math.h>".}
     ## computes ln(x).
-  proc log10*(x: float): float {.importc: "log10", header: "<math.h>".}
-  proc log2*(x: float): float = return ln(x) / ln(2.0)
-  proc exp*(x: float): float {.importc: "exp", header: "<math.h>".}
+  proc log10*(x: float32): float32 {.importc: "log10", header: "<math.h>".}
+	proc log10*(x: float64): float64 {.importc: "log10", header: "<math.h>".}
+  proc log2*[T: float32|float64](x: T): T = return ln(x) / ln(2.0)
+  proc exp*(x: float32): float32 {.importc: "exp", header: "<math.h>".}
+	proc exp*(x: float64): float64 {.importc: "exp", header: "<math.h>".}
     ## computes e**x.
-  
-  proc frexp*(x: float, exponent: var int): float {.
+
+  proc frexp*(x: float32, exponent: var int): float32 {.
+    importc: "frexp", header: "<math.h>".}
+  proc frexp*(x: float64, exponent: var int): float64 {.
     importc: "frexp", header: "<math.h>".}
     ## Split a number into mantissa and exponent.
     ## `frexp` calculates the mantissa m (a float greater than or equal to 0.5
     ## and less than 1) and the integer value n such that `x` (the original
     ## float value) equals m * 2**n. frexp stores n in `exponent` and returns
     ## m.
-  
-  proc round*(x: float): int {.importc: "lrint", header: "<math.h>".}
-    ## converts a float to an int by rounding.  
-  
-  proc arccos*(x: float): float {.importc: "acos", header: "<math.h>".}
-  proc arcsin*(x: float): float {.importc: "asin", header: "<math.h>".}
-  proc arctan*(x: float): float {.importc: "atan", header: "<math.h>".}
-  proc arctan2*(y, x: float): float {.importc: "atan2", header: "<math.h>".}
+
+  proc round*(x: float32): int {.importc: "lrint", header: "<math.h>".}
+  proc round*(x: float64): int {.importc: "lrint", header: "<math.h>".}
+    ## converts a float to an int by rounding.
+
+  proc arccos*(x: float32): float32 {.importc: "acos", header: "<math.h>".}
+	proc arccos*(x: float64): float64 {.importc: "acos", header: "<math.h>".}
+  proc arcsin*(x: float32): float32 {.importc: "asin", header: "<math.h>".}
+	proc arcsin*(x: float64): float64 {.importc: "asin", header: "<math.h>".}
+  proc arctan*(x: float32): float32 {.importc: "atan", header: "<math.h>".}
+	proc arctan*(x: float64): float64 {.importc: "atan", header: "<math.h>".}
+  proc arctan2*(y, x: float32): float32 {.importc: "atan2", header: "<math.h>".}
+  proc arctan2*(y, x: float64): float64 {.importc: "atan2", header: "<math.h>".}
     ## Calculate the arc tangent of `y` / `x`.
     ## `atan2` returns the arc tangent of `y` / `x`; it produces correct
     ## results even when the resulting angle is near pi/2 or -pi/2
     ## (`x` near 0).
-  
-  proc cos*(x: float): float {.importc: "cos", header: "<math.h>".}
-  proc cosh*(x: float): float {.importc: "cosh", header: "<math.h>".}
-  proc hypot*(x, y: float): float {.importc: "hypot", header: "<math.h>".}
+
+  proc cos*(x: float32): float32 {.importc: "cos", header: "<math.h>".}
+	proc cos*(x: float64): float64 {.importc: "cos", header: "<math.h>".}
+  proc cosh*(x: float32): float32 {.importc: "cosh", header: "<math.h>".}
+	proc cosh*(x: float64): float64 {.importc: "cosh", header: "<math.h>".}
+  proc hypot*(x, y: float32): float32 {.importc: "hypot", header: "<math.h>".}
+  proc hypot*(x, y: float64): float64 {.importc: "hypot", header: "<math.h>".}
     ## same as ``sqrt(x*x + y*y)``.
-  
-  proc sinh*(x: float): float {.importc: "sinh", header: "<math.h>".}
-  proc sin*(x: float): float {.importc: "sin", header: "<math.h>".}
-  proc tan*(x: float): float {.importc: "tan", header: "<math.h>".}
-  proc tanh*(x: float): float {.importc: "tanh", header: "<math.h>".}
-  proc pow*(x, y: float): float {.importc: "pow", header: "<math.h>".}
+
+  proc sinh*(x: float32): float32 {.importc: "sinh", header: "<math.h>".}
+	proc sinh*(x: float64): float64 {.importc: "sinh", header: "<math.h>".}
+  proc sin*(x: float32): float32 {.importc: "sin", header: "<math.h>".}
+	proc sin*(x: float64): float64 {.importc: "sin", header: "<math.h>".}
+  proc tan*(x: float32): float32 {.importc: "tan", header: "<math.h>".}
+	proc tan*(x: float64): float64 {.importc: "tan", header: "<math.h>".}
+  proc tanh*(x: float32): float32 {.importc: "tanh", header: "<math.h>".}
+	proc tanh*(x: float64): float64 {.importc: "tanh", header: "<math.h>".}
+  proc pow*(x, y: float32): float32 {.importc: "pow", header: "<math.h>".}
+	proc pow*(x, y: float64): float64 {.importc: "pow", header: "<math.h>".}
     ## computes x to power raised of y.
-  
-  proc erf*(x: float): float {.importc: "erf", header: "<math.h>".}
+
+  proc erf*(x: float32): float32 {.importc: "erf", header: "<math.h>".}
+	proc erf*(x: float64): float64 {.importc: "erf", header: "<math.h>".}
     ## The error function
-  proc erfc*(x: float): float {.importc: "erfc", header: "<math.h>".}
+  proc erfc*(x: float32): float32 {.importc: "erfc", header: "<math.h>".}
+	proc erfc*(x: float64): float64 {.importc: "erfc", header: "<math.h>".}
     ## The complementary error function
-  
-  proc lgamma*(x: float): float {.importc: "lgamma", header: "<math.h>".}
+
+  proc lgamma*(x: float32): float32 {.importc: "lgamma", header: "<math.h>".}
+	proc lgamma*(x: float64): float64 {.importc: "lgamma", header: "<math.h>".}
     ## Natural log of the gamma function
-  proc tgamma*(x: float): float {.importc: "tgamma", header: "<math.h>".}
+  proc tgamma*(x: float32): float32 {.importc: "tgamma", header: "<math.h>".}
+	proc tgamma*(x: float64): float64 {.importc: "tgamma", header: "<math.h>".}
     ## The gamma function
-    
+
   # C procs:
   when defined(vcc):
     # The "secure" random, available from Windows XP
@@ -225,7 +249,7 @@ when not defined(JS):
   else:
     proc srand(seed: cint) {.importc: "srand", header: "<stdlib.h>".}
     proc rand(): cint {.importc: "rand", header: "<stdlib.h>".}
-  
+
   when not defined(windows):
     proc srand48(seed: clong) {.importc: "srand48", header: "<stdlib.h>".}
     proc drand48(): float {.importc: "drand48", header: "<stdlib.h>".}
@@ -251,7 +275,7 @@ when not defined(JS):
         # on MSDN and very unlikely to change
         const rand_max = 32767
         result = (float(rand()) / float(rand_max)) * max
-  
+
   when not defined(vcc): # the above code for vcc uses `discard` instead
     # this is either not Windows or is Windows without vcc
     proc randomize() =
@@ -259,37 +283,47 @@ when not defined(JS):
     proc randomize(seed: int) =
       srand(cint(seed)) # rand_s doesn't use srand
       when declared(srand48): srand48(seed)
-    
+
   proc random(max: int): int =
     result = int(rand()) mod max
 
-  proc trunc*(x: float): float {.importc: "trunc", header: "<math.h>".}
-  proc floor*(x: float): float {.importc: "floor", header: "<math.h>".}
-  proc ceil*(x: float): float {.importc: "ceil", header: "<math.h>".}
+  proc trunc*(x: float32): float32 {.importc: "trunc", header: "<math.h>".}
+	proc trunc*(x: float64): float64 {.importc: "trunc", header: "<math.h>".}
+  proc floor*(x: float32): float32 {.importc: "floor", header: "<math.h>".}
+	proc floor*(x: float64): float64 {.importc: "floor", header: "<math.h>".}
+  proc ceil*(x: float32): float32 {.importc: "ceil", header: "<math.h>".}
+	proc ceil*(x: float64): float64 {.importc: "ceil", header: "<math.h>".}
 
-  proc fmod*(x, y: float): float {.importc: "fmod", header: "<math.h>".}
+  proc fmod*(x, y: float32): float32 {.importc: "fmod", header: "<math.h>".}
+	proc fmod*(x, y: float64): float64 {.importc: "fmod", header: "<math.h>".}
 
 else:
   proc mathrandom(): float {.importc: "Math.random", nodecl.}
-  proc floor*(x: float): float {.importc: "Math.floor", nodecl.}
-  proc ceil*(x: float): float {.importc: "Math.ceil", nodecl.}
+  proc floor*(x: float32): float32 {.importc: "Math.floor", nodecl.}
+	proc floor*(x: float64): float64 {.importc: "Math.floor", nodecl.}
+  proc ceil*(x: float32): float32 {.importc: "Math.ceil", nodecl.}
+	proc ceil*(x: float64): float64 {.importc: "Math.ceil", nodecl.}
   proc random(max: int): int =
     result = int(floor(mathrandom() * float(max)))
   proc random(max: float): float =
     result = float(mathrandom() * float(max))
   proc randomize() = discard
   proc randomize(seed: int) = discard
-  
-  proc sqrt*(x: float): float {.importc: "Math.sqrt", nodecl.}
-  proc ln*(x: float): float {.importc: "Math.log", nodecl.}
-  proc log10*(x: float): float = return ln(x) / ln(10.0)
-  proc log2*(x: float): float = return ln(x) / ln(2.0)
 
-  proc exp*(x: float): float {.importc: "Math.exp", nodecl.}
+  proc sqrt*(x: float32): float32 {.importc: "Math.sqrt", nodecl.}
+	proc sqrt*(x: float64): float64 {.importc: "Math.sqrt", nodecl.}
+  proc ln*(x: float32): float32 {.importc: "Math.log", nodecl.}
+	proc ln*(x: float64): float64 {.importc: "Math.log", nodecl.}
+  proc log10*[T: float32|float64](x: T): T = return ln(x) / ln(10.0)
+	proc log2*[T: float32|float64](x: T): T = return ln(x) / ln(2.0)
+
+  proc exp*(x: float32): float32 {.importc: "Math.exp", nodecl.}
+	proc exp*(x: float64): float64 {.importc: "Math.exp", nodecl.}
   proc round*(x: float): int {.importc: "Math.round", nodecl.}
-  proc pow*(x, y: float): float {.importc: "Math.pow", nodecl.}
-  
-  proc frexp*(x: float, exponent: var int): float =
+  proc pow*(x, y: float32): float32 {.importC: "Math.pow", nodecl.}
+	proc pow*(x, y: float64): float64 {.importc: "Math.pow", nodecl.}
+
+  proc frexp*[T: float32|float64](x: T, exponent: var int): T =
     if x == 0.0:
       exponent = 0
       result = 0.0
@@ -300,28 +334,36 @@ else:
       exponent = round(ex)
       result = x / pow(2.0, ex)
 
-  proc arccos*(x: float): float {.importc: "Math.acos", nodecl.}
-  proc arcsin*(x: float): float {.importc: "Math.asin", nodecl.}
-  proc arctan*(x: float): float {.importc: "Math.atan", nodecl.}
-  proc arctan2*(y, x: float): float {.importc: "Math.atan2", nodecl.}
-  
-  proc cos*(x: float): float {.importc: "Math.cos", nodecl.}
-  proc cosh*(x: float): float = return (exp(x)+exp(-x))*0.5
-  proc hypot*(x, y: float): float = return sqrt(x*x + y*y)
-  proc sinh*(x: float): float = return (exp(x)-exp(-x))*0.5
-  proc sin*(x: float): float {.importc: "Math.sin", nodecl.}
-  proc tan*(x: float): float {.importc: "Math.tan", nodecl.}
-  proc tanh*(x: float): float =
+  proc arccos*(x: float32): float32 {.importc: "Math.acos", nodecl.}
+	proc arccos*(x: float64): float64 {.importc: "Math.acos", nodecl.}
+  proc arcsin*(x: float32): float32 {.importc: "Math.asin", nodecl.}
+	proc arcsin*(x: float64): float64 {.importc: "Math.asin", nodecl.}
+  proc arctan*(x: float32): float32 {.importc: "Math.atan", nodecl.}
+	proc arctan*(x: float64): float64 {.importc: "Math.atan", nodecl.}
+  proc arctan2*(y, x: float32): float32 {.importC: "Math.atan2", nodecl.}
+	proc arctan2*(y, x: float64): float64 {.importc: "Math.atan2", nodecl.}
+
+  proc cos*(x: float32): float32 {.importc: "Math.cos", nodecl.}
+	proc cos*(x: float64): float64 {.importc: "Math.cos", nodecl.}
+  proc cosh*(x: float32): float32 = return (exp(x)+exp(-x))*0.5
+	proc cosh*(x: float64): float64 = return (exp(x)+exp(-x))*0.5
+  proc hypot*[T: float32|float64](x, y: T): T = return sqrt(x*x + y*y)
+  proc sinh*]T: float32|float64](x: T): T = return (exp(x)-exp(-x))*0.5
+  proc sin*(x: float32): float32 {.importc: "Math.sin", nodecl.}
+	proc sin*(x: float64): float64 {.importc: "Math.sin", nodecl.}
+  proc tan*(x: float32): float32 {.importc: "Math.tan", nodecl.}
+	proc tan*(x: float64): float64 {.importc: "Math.tan", nodecl.}
+	proc tanh*[T: float32|float64](x: T): T =
     var y = exp(2.0*x)
     return (y-1.0)/(y+1.0)
 
 {.pop.}
 
-proc `mod`*(x, y: float): float =
+proc `mod`*[T: float32|float64](x, y: T): T =
   ## Computes the modulo operation for float operators. Equivalent
   ## to ``x - y * floor(x/y)``. Note that the remainder will always
   ## have the same sign as the divisor.
-  ## 
+  ##
   ## .. code-block:: nim
   ##  echo (4.0 mod -3.1) # -2.2
   result = if y == 0.0: x else: x - y * (x/y).floor
@@ -342,7 +384,7 @@ type
 
 {.deprecated: [TFloatClass: FloatClass, TRunningStat: RunningStat].}
 
-proc push*(s: var RunningStat, x: float) = 
+proc push*(s: var RunningStat, x: float) =
   ## pushes a value `x` for processing
   inc(s.n)
   # See Knuth TAOCP vol 2, 3rd edition, page 232
@@ -362,17 +404,17 @@ proc push*(s: var RunningStat, x: float) =
     s.oldM = s.mean
     s.oldS = s.newS
   s.sum = s.sum + x
-  
-proc push*(s: var RunningStat, x: int) = 
+
+proc push*(s: var RunningStat, x: int) =
   ## pushes a value `x` for processing. `x` is simply converted to ``float``
   ## and the other push operation is called.
   push(s, toFloat(x))
-  
-proc variance*(s: RunningStat): float = 
+
+proc variance*(s: RunningStat): float =
   ## computes the current variance of `s`
   if s.n > 1: result = s.newS / (toFloat(s.n - 1))
 
-proc standardDeviation*(s: RunningStat): float = 
+proc standardDeviation*(s: RunningStat): float =
   ## computes the current standard deviation of `s`
   result = sqrt(variance(s))
 
@@ -429,7 +471,7 @@ when isMainModule and not defined(JS):
   # Check for no side effect annotation
   proc mySqrt(num: float): float {.noSideEffect.} =
     return sqrt(num)
-  
+
   # check gamma function
   assert(tgamma(5.0) == 24.0) # 4!
   assert(lgamma(1.0) == 0.0) # ln(1.0) == 0.0

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -348,7 +348,7 @@ else:
   proc cosh*(x: float32): float32 = return (exp(x)+exp(-x))*0.5
   proc cosh*(x: float64): float64 = return (exp(x)+exp(-x))*0.5
   proc hypot*[T: float32|float64](x, y: T): T = return sqrt(x*x + y*y)
-  proc sinh*]T: float32|float64](x: T): T = return (exp(x)-exp(-x))*0.5
+  proc sinh*[T: float32|float64](x: T): T = return (exp(x)-exp(-x))*0.5
   proc sin*(x: float32): float32 {.importc: "Math.sin", nodecl.}
   proc sin*(x: float64): float64 {.importc: "Math.sin", nodecl.}
   proc tan*(x: float32): float32 {.importc: "Math.tan", nodecl.}


### PR DESCRIPTION
When a proc is `importc`-ed, made explicit. Otherwise, used `[T: float32|float64]`. For some reason, the indentations look weird. If that's the case, I'll go through and fix them
EDIT: that was the case. fixed