### PR TITLE
Updated nnkRange docs. Fixes #2929

### DIFF
--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -397,6 +397,8 @@ Ranges
 ------
 
 Ranges occur in set constructors, case statement branches, or array slices.
+Internally, the node kind ``nnkRange`` is used, but when constructing the
+AST, construction with ``..`` as an infix operator should be used instead.
 
 Concrete syntax:
 
@@ -406,7 +408,33 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
-  nnkRange(nnkIntLit(1), nnkIntLit(3))
+  nnkInfix(
+    nnkIdent(!".."),
+    nnkIntLit(1),
+    nnkIntLit(3)
+  )
+
+Example code:
+
+.. code-block:: nim
+  macro genRepeatEcho(): stmt =
+    result = newNimNode(nnkStmtList)
+
+    var forStmt = newNimNode(nnkForStmt) # generate a for statement
+    forStmt.add(ident("i")) # use the variable `i` for iteration
+
+    var rangeDef = newNimNode(nnkInfix).add(
+      ident("..")).add(
+      newIntLitNode(3),newIntLitNode(5)) # iterate over the range 3..5
+
+    forStmt.add(rangeDef)
+    forStmt.add(newCall(ident("echo"), newIntLitNode(3))) # meat of the loop
+    result.add(forStmt)
+
+  genRepeatEcho() # gives:
+                  # 3
+                  # 3
+                  # 3
 
 
 If expression


### PR DESCRIPTION
Addresses #2929 . Still mentions ``nnkRange`` as being used internally (really, ``nkRange`` is). I'm not sure what ``nnkRange`` does, but the docs now inform the user to use ``..`` as an infix operator.