### PR TITLE
Allow ftpclient and AsyncFtpClient to handle 220 Multiline messages

### DIFF
--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -79,7 +79,13 @@ proc connect*(ftp: AsyncFtpClient) {.async.} =
     # 120 Service ready in nnn minutes.
     # We wait until we receive 220.
     reply = await ftp.expectReply()
-  assertReply(reply, "220")
+
+  # Handle 220 messages from the server
+  if reply.startsWith("220"):
+    assertReply(reply, "220")
+    while reply.continuesWith("-", 3): # handle multiline 220 message
+      assertReply(reply, "220")
+      reply = await ftp.expectReply()
 
   if ftp.user != "":
     assertReply(await(ftp.send("USER " & ftp.user)), "230", "331")

--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -81,11 +81,10 @@ proc connect*(ftp: AsyncFtpClient) {.async.} =
     reply = await ftp.expectReply()
 
   # Handle 220 messages from the server
-  if reply.startsWith("220"):
+  assertReply(reply, "220")
+  while reply.continuesWith("-", 3): # handle multiline 220 message
     assertReply(reply, "220")
-    while reply.continuesWith("-", 3): # handle multiline 220 message
-      assertReply(reply, "220")
-      reply = await ftp.expectReply()
+    reply = await ftp.expectReply()
 
   if ftp.user != "":
     assertReply(await(ftp.send("USER " & ftp.user)), "230", "331")

--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -82,7 +82,7 @@ proc connect*(ftp: AsyncFtpClient) {.async.} =
 
   # Handle 220 messages from the server
   assertReply(reply, "220")
-  while reply.continuesWith("-", 3): # handle multiline 220 message
+  while reply[3] == "-": # handle multiline 220 message
     assertReply(reply, "220")
     reply = await ftp.expectReply()
 

--- a/lib/pure/ftpclient.nim
+++ b/lib/pure/ftpclient.nim
@@ -271,9 +271,9 @@ proc connect*[T](ftp: FtpBase[T]) =
 
   # Handle 220 messages from the server
   if reply.startsWith("220"):
-    assertReply(reply, "220")
+    assertReply ftp.expectReply(), "220"
     while reply.continuesWith("-", 3): # handle multiline 220 message
-      assertReply(reply, "220")
+      assertReply ftp.expectReply(), "220"
       reply = ftp.expectReply()
 
   if ftp.user != "":

--- a/lib/pure/ftpclient.nim
+++ b/lib/pure/ftpclient.nim
@@ -274,7 +274,7 @@ proc connect*[T](ftp: FtpBase[T]) =
     assertReply(reply, "220")
     while reply.continuesWith("-", 3): # handle multiline 220 message
       assertReply(reply, "220")
-      reply = await ftp.expectReply()
+      reply = ftp.expectReply()
 
   if ftp.user != "":
     assertReply(ftp.send("USER " & ftp.user), "230", "331")

--- a/lib/pure/ftpclient.nim
+++ b/lib/pure/ftpclient.nim
@@ -271,7 +271,7 @@ proc connect*[T](ftp: FtpBase[T]) =
 
   # Handle 220 messages from the server
   assertReply ftp.expectReply(), "220"
-  while reply.continuesWith("-", 3): # handle multiline 220 message
+  while reply[3] == "-": # handle multiline 220 message
     assertReply ftp.expectReply(), "220"
     reply = ftp.expectReply()
 

--- a/lib/pure/ftpclient.nim
+++ b/lib/pure/ftpclient.nim
@@ -270,11 +270,10 @@ proc connect*[T](ftp: FtpBase[T]) =
     reply = ftp.expectReply()
 
   # Handle 220 messages from the server
-  if reply.startsWith("220"):
+  assertReply ftp.expectReply(), "220"
+  while reply.continuesWith("-", 3): # handle multiline 220 message
     assertReply ftp.expectReply(), "220"
-    while reply.continuesWith("-", 3): # handle multiline 220 message
-      assertReply ftp.expectReply(), "220"
-      reply = ftp.expectReply()
+    reply = ftp.expectReply()
 
   if ftp.user != "":
     assertReply(ftp.send("USER " & ftp.user), "230", "331")


### PR DESCRIPTION
Many ftp servers can respond with multiple line 220 messages after connection and this procedure will fail because when sending user friendly command will receive still 220 welcome message. With this, these two libraries will check first multiline 220.messages then will send user and pass command if defined.