### PR TITLE
Export SO_NOSIGPIPE for koch web on Mac OS X

### DIFF
--- a/lib/pure/rawsockets.nim
+++ b/lib/pure/rawsockets.nim
@@ -42,6 +42,7 @@ export
   MSG_PEEK
 
 when defined(macosx):
+    from posix import SO_NOSIGPIPE
     export SO_NOSIGPIPE
 
 type


### PR DESCRIPTION
Wraps up #3005 - this fixes an issue in which `koch web` failed due to an error in which SO_NOSIGPIPE was not exported:

```
lib/pure/rawsockets.nim(45, 12) Error: cannot export: SO_NOSIGPIPE
```

This fixes it by importing `SO_NOSIGPIPE` from the `posix` module in `rawsockets.nim` so that it's available for export.