### PR TITLE
Fix #3018

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -585,7 +585,7 @@ proc externalFileChanged(filename: string): bool =
   if gCmd notin {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToLLVM}:
     return false
 
-  var crcFile = toGeneratedFile(filename.withPackageName, "crc")
+  var crcFile = toGeneratedFile(filename.withPackageName, "sha1")
   var currentCrc = footprint(filename)
   var f: File
   if open(f, crcFile, fmRead):


### PR DESCRIPTION
Looks like the problem is that the compiler expected the hash to be a certain
number of characters, but the file actually contained a (shorter) crc hash.