### PR TITLE
Fix SQLite3 dynlib on OS X.

### DIFF
--- a/lib/wrappers/sqlite3.nim
+++ b/lib/wrappers/sqlite3.nim
@@ -13,7 +13,7 @@ when defined(windows):
     Lib = "sqlite3.dll"
 elif defined(macosx): 
   const 
-    Lib = "(libsqlite3(|.0).dylib|sqlite-3.6.13.dylib)"
+    Lib = "libsqlite3(|.0).dylib"
 else: 
   const 
     Lib = "libsqlite3.so(|.0)"


### PR DESCRIPTION
The old dynlib name referenced an ancient version of SQLite3 and could
not be overridden with --dynlibOverride.