### PR TITLE
Added documentation guidelines (brief)

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -135,6 +135,45 @@ overloading so for routines the latter variant is better.
 pragma in the manual.
 
 
+Documentation
+=============
+
+When contributing new procedures, be sure to add documentation, especially if
+the procedure is exported from the module. Documentation begins on the line
+following the ``proc`` definition, and is prefixed by ``##`` on each line.
+
+Code examples are also encouraged. The RST syntax Nim uses has a special syntax
+for including examples.
+
+.. code-block:: nim
+
+  proc someproc*(): string =
+    ## returns "something"
+    ##
+    ## .. code-block:: nim
+    ##
+    ##  echo someproc() # "something"
+    result = "something" # single-hash comments do not produce documentation
+
+The ``.. code-block:: nim`` followed by a newline and an indentation instructs the 
+``nim doc`` and ``nim doc2`` commands to produce syntax-highlited example code with 
+the documentation.
+
+When forward declaration is used, the documentation should be included with the
+first appearance of the proc.
+
+.. code-block:: nim
+
+  proc hello*(): string
+    ## Documentation goes here
+  proc nothing() = discard
+  proc hello*(): string =
+    ## This documentation is ignored
+    echo "hello"
+
+Capitalization of the first letter on the first line is optional. As a general
+rule, if the documentation begins with a full sentence, capitalize it;
+otherwise, a lowercase letter is preferred.
 
 The Git stuff
 =============

--- a/contributing.rst
+++ b/contributing.rst
@@ -142,8 +142,8 @@ When contributing new procedures, be sure to add documentation, especially if
 the procedure is exported from the module. Documentation begins on the line
 following the ``proc`` definition, and is prefixed by ``##`` on each line.
 
-Code examples are also encouraged. The RST syntax Nim uses has a special syntax
-for including examples.
+Code examples are also encouraged. The RestructuredText Nim uses has a special 
+syntax for including examples.
 
 .. code-block:: nim
 
@@ -156,7 +156,7 @@ for including examples.
     result = "something" # single-hash comments do not produce documentation
 
 The ``.. code-block:: nim`` followed by a newline and an indentation instructs the 
-``nim doc`` and ``nim doc2`` commands to produce syntax-highlited example code with 
+``nim doc`` and ``nim doc2`` commands to produce syntax-highlighted example code with 
 the documentation.
 
 When forward declaration is used, the documentation should be included with the

--- a/contributing.rst
+++ b/contributing.rst
@@ -148,7 +148,7 @@ syntax for including examples.
 .. code-block:: nim
 
   proc someproc*(): string =
-    ## returns "something"
+    ## Return "something"
     ##
     ## .. code-block:: nim
     ##
@@ -165,15 +165,29 @@ first appearance of the proc.
 .. code-block:: nim
 
   proc hello*(): string
-    ## Documentation goes here
+    ## Put documentation here
   proc nothing() = discard
   proc hello*(): string =
-    ## This documentation is ignored
+    ## Ignore this
     echo "hello"
 
-Capitalization of the first letter on the first line is optional. As a general
-rule, if the documentation begins with a full sentence, capitalize it;
-otherwise, a lowercase letter is preferred.
+The preferred documentation style is to begin with a capital letter and use
+the imperative (command) form. That is, between:
+
+.. code-block:: nim
+
+  proc hello*(): string =
+    # Return "hello"
+    result = "hello"
+or
+
+.. code-block:: nim
+
+  proc hello*(): string =
+    # says hello
+    result = "hello"
+  
+the first is preferred.
 
 The Git stuff
 =============


### PR DESCRIPTION
Do not merge until capitalization is decided on.

Part of this depends on #3034 (currently, ``nim doc`` duplicates forward declarations). This doesn't address periods at the end of the documentation. It tries to follow the "capitalize if a full sentence" rule, but says both are fine.

I can make this more detailed easily, but one of Nim's issues is not having enough documentation and examples, so hopefully this will help out contributers.

Should I say that documentation is mandatory for new code? I assume that contributers can read the manual for where to place the ``##`` in different cases.