### PR TITLE
Update wingui.nim (delete it, probably)

### DIFF
--- a/examples/wingui.nim
+++ b/examples/wingui.nim
@@ -1,7 +1,8 @@
 # test a Windows GUI application
+# requires 'oldwinapi' package from Nimble
 
 import
-  windows, shellapi, nb30, mmsystem, shfolder
+  windows
 
 #proc MessageBox(hWnd: int, lpText, lpCaption: CString, uType: uint): int
 #  {stdcall, import: "MessageBox", header: "<windows.h>"}


### PR DESCRIPTION
Probably should just be deleted so an example doesn't rely on an external package