### PR TITLE
Reset terminal colors before running compiled program

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -378,3 +378,4 @@ proc mainCommand* =
   when SimulateCaasMemReset:
     resetMemory()
 
+  resetAttributes()

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -865,6 +865,11 @@ proc rawMessage*(msg: TMsgKind, args: openArray[string]) =
 proc rawMessage*(msg: TMsgKind, arg: string) =
   rawMessage(msg, [arg])
 
+proc resetAttributes* =
+  if optUseColors in gGlobalOptions:
+    terminal.resetAttributes()
+    stdout.flushFile()
+
 proc writeSurroundingSrc(info: TLineInfo) =
   const indent = "  "
   msgWriteln(indent & $info.sourceLine)


### PR DESCRIPTION
Otherwise when using `nim -r c file` the output will be colorized because of the final `[SuccessX]`.