### PR TITLE
Expose the name of an exception.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -389,9 +389,9 @@ type
     ## Each exception has to inherit from `Exception`. See the full `exception
     ## hierarchy`_.
     parent*: ref Exception ## parent exception (can be used as a stack)
-    name: cstring ## The exception's name is its Nim identifier.
-                  ## This field is filled automatically in the
-                  ## ``raise`` statement.
+    name*: cstring ## The exception's name is its Nim identifier.
+                   ## This field is filled automatically in the
+                   ## ``raise`` statement.
     msg* {.exportc: "message".}: string ## the exception's message. Not
                                         ## providing an exception message
                                         ## is bad style.


### PR DESCRIPTION
Exposes the name of all exceptions to be accessed by code since it's not currently possible to get the runtime type of an exception.