### PR TITLE
Added typetraits in system.nim to print object type names.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2125,7 +2125,7 @@ proc `$`*[T: tuple|object](x: T): string =
   ## .. code-block:: nim
   ##   $(23, 45) == "(23, 45)"
   ##   $() == "()"
-  result = "("
+  result = $type(x) & "("
   var firstElement = true
   for name, value in fieldPairs(x):
     if not firstElement: result.add(", ")
@@ -2362,6 +2362,12 @@ when not declared(sysFatal):
       new(e)
       e.msg = message & arg
       raise e
+
+import typetraits
+
+proc `$`*[T](some: typedesc[T]): string =
+  ## Get the name of the type `some` as a string.
+  name(T)
 
 proc getTypeInfo*[T](x: T): pointer {.magic: "GetTypeInfo", benign.}
   ## get type information for `x`. Ordinary code should not use this, but


### PR DESCRIPTION
This makes it more clear when printing an object or tuple what type is actually being printed. Let me know if there is a better way to accomplish this.

This leads to

```nim
type
  Person = tuple[name: string, age: int]
  MyType = object
    attr: string
var p: Person = (name: "Peter", age: 30)
var m = MyType(attr: "mine!")

echo p
echo m
# Prints:
#   Person(name: Peter, age: 30)
#   MyType(attr: mine!)
#
# Instead of:
#   (name: Peter, age: 30)
#   (attr: mine!)
```