### PR TITLE
Incorrect code generated for tagged unions with enums not starting at zero

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -805,7 +805,7 @@ proc discriminatorTableName(m: BModule, objtype: PType, d: PSym): Rope =
 proc discriminatorTableDecl(m: BModule, objtype: PType, d: PSym): Rope =
   discard cgsym(m, "TNimNode")
   var tmp = discriminatorTableName(m, objtype, d)
-  result = "TNimNode* $1[$2];$n" % [tmp, rope(lengthOrd(d.typ)+1)]
+  result = "TNimNode* $1[$2];$n" % [tmp, rope(lastOrd(d.typ)+2)]
 
 proc genObjectFields(m: BModule, typ: PType, n: PNode, expr: Rope) =
   case n.kind
@@ -828,7 +828,7 @@ proc genObjectFields(m: BModule, typ: PType, n: PNode, expr: Rope) =
     assert(n.sons[0].kind == nkSym)
     var field = n.sons[0].sym
     var tmp = discriminatorTableName(m, typ, field)
-    var L = lengthOrd(field.typ)
+    var L = lastOrd(field.typ)+1
     assert L > 0
     addf(m.s[cfsTypeInit3], "$1.kind = 3;$n" &
         "$1.offset = offsetof($2, $3);$n" & "$1.typ = $4;$n" &

--- a/tests/objects/tbug3096.nim
+++ b/tests/objects/tbug3096.nim
@@ -1,0 +1,21 @@
+discard """
+  output: "Ok 5"
+"""
+
+type OffsetEnum* = enum
+  oeA = 'a',
+  oeB = 'b'
+
+type WithKind = ref object
+  case kind: OffsetEnum:
+  of oeA:
+    foo: int
+  else:
+    bar: int
+
+var tmp: WithKind
+new(tmp)
+tmp.kind = oeB
+tmp.bar = 5
+
+echo "Ok ", tmp.bar


### PR DESCRIPTION
Fixes #3096

When all enums start with zero, this change does nothing.

When first item of enum is bigger than zero, NimDT array size is
equal to last element index + 2, so no out-of-bounds accesses are
generated. TNimNode.len field is also changed.