### PR TITLE
Set correct Host in request header

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -402,7 +402,7 @@ proc request*(url: string, httpMethod: string, extraHeaders = "",
 
   headers.add(" HTTP/1.1\c\L")
 
-  add(headers, "Host: " & r.hostname & "\c\L")
+  add(headers, "Host: " & parseUri(url).hostname & "\c\L")
   if userAgent != "":
     add(headers, "User-Agent: " & userAgent & "\c\L")
   if proxy != nil and proxy.auth != "":


### PR DESCRIPTION
Ensure the correct destination hostname is used in the request, otherwise the request will fail in one of a number of interesting ways when using a proxy.

Fixes https://github.com/nim-lang/Nim/issues/3166