### PR TITLE
Unittest module: Fix multiple requires in a test

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -285,7 +285,7 @@ macro check*(conditions: stmt): stmt {.immediate.} =
 
     result = getAst(rewrite(checked, checked.lineinfo, checked.toStrLit))
 
-template require*(conditions: stmt): stmt {.immediate, dirty.} =
+template require*(conditions: stmt): stmt {.immediate.} =
   ## Same as `check` except any failed test causes the program to quit
   ## immediately. Any teardown statements are not executed and the failed
   ## test output is not generated.

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -21,6 +21,11 @@ test "unittest typedescs":
   check(none(int) != some(1))
 
 
+test "unittest multiple requires":
+  require(true)
+  require(true)
+
+
 import math
 from strutils import parseInt
 proc defectiveRobot() =


### PR DESCRIPTION
A recent change to the unit test module introduced a local variable to the `require` template. Because `require` is marked as `dirty`, require can no longer be used multiple times in a test. You can see a failed build here:

https://travis-ci.org/Nycto/RBTreeNim/builds/67225776

It look like `require` doesn't need to be dirty, so this change simply removes that pragma and adds a test to ensure this doesn't break again.