### PR TITLE
Fix for inline image in rstgen (nimforum #41)

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -755,7 +755,7 @@ proc renderTocEntries*(d: var RstGenerator, j: var int, lvl: int,
 
 proc renderImage(d: PDoc, n: PRstNode, result: var string) =
   template valid(s): expr =
-    s.len > 0 and allCharsInSet(s, {'/',':','%','_','\\','\128'..'\xFF'} +
+    s.len > 0 and allCharsInSet(s, {'.','/',':','%','_','\\','\128'..'\xFF'} +
                                    Digits + Letters + WhiteSpace)
 
   var options = ""


### PR DESCRIPTION
Saw in https://github.com/nim-lang/nimforum/issues/41 that there was an
issue in rendering inline images.  Traced back through rstgen and found
that it was not counting something like:

`.. image:: http://i.imgur.com/oCem13Y.png` as valid since it contained
a period, and this wasn't in the set of valid characters, so the empty
string is returned by default.

Added a period to the allowable characters, and now renders correctly.

Test case:
```{nimrod}
import rst, rstgen, strtabs

var docConfig: StringTableRef

docConfig = rstgen.defaultConfig()
docConfig["doc.smiley_format"] = "/images/smilieys/$1.png"

proc rstToHtml(content: string): string =
    result = rstgen.rstToHtml(content, {roSupportSmilies,roSupportMarkdown},
                              docConfig)

var a: string = rstToHtml(".. image:: http://i.imgur.com/oCem13Y.png")
echo a
```