### PR TITLE
Fix documentation style reference

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -217,4 +217,4 @@ General commit rules
 
 3. Describe your commit and use your common sense.
 
-.. include:: styleguide.rst
+.. include:: docstyle.rst


### PR DESCRIPTION
The documentation style guide was renamed from `styleguide.rst` to `docstyle.rst` in https://github.com/nim-lang/Nim/commit/a98f609ae215d1fcf9922329b5d87bd1b9242800 but this reference was not updated in that comment.