### PR TITLE
other unittest pull-request

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -70,9 +70,6 @@ var ## Global unittest settings!
 
 checkpoints = @[]
 
-template testSetupIMPL*: stmt {.immediate, dirty.} = discard      #Should this be public or even exist?
-template testTeardownIMPL*: stmt {.immediate, dirty.} = discard
-
 proc shouldRun(testName: string): bool =
   result = true
 
@@ -106,9 +103,11 @@ template suite*(name: expr, body: stmt): stmt {.immediate, dirty.} =
   ##  [OK] (2 + -2) != 4
   block:
     template setup(setupBody: stmt): stmt {.immediate, dirty.} =
+      var testSetupIMPLFlag = true
       template testSetupIMPL: stmt {.immediate, dirty.} = setupBody
 
     template teardown(teardownBody: stmt): stmt {.immediate, dirty.} =
+      var testTeardownIMPLFlag = true
       template testTeardownIMPL: stmt {.immediate, dirty.} = teardownBody
 
     body
@@ -149,7 +148,7 @@ template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
     var testStatusIMPL {.inject.} = OK
 
     try:
-      testSetupIMPL()
+      when declared(testSetupIMPLFlag): testSetupIMPL()
       body
 
     except:
@@ -159,7 +158,7 @@ template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
       fail()
 
     finally:
-      testTeardownIMPL()
+      when declared(testTeardownIMPLFlag): testTeardownIMPL()
       testDone name, testStatusIMPL
 
 proc checkpoint*(msg: string) =

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -38,3 +38,48 @@ proc defectiveRobot() =
 test "unittest expect":
   expect IOError, OSError, ValueError, AssertionError:
     defectiveRobot()
+
+var
+  a = 1
+  b = -1
+  c = 1
+
+#unittests are sequential right now
+suite "suite with only teardown":
+  teardown:
+    b = 2
+
+  test "unittest with only teardown 1":
+    check a == c
+
+  test "unittest with only teardown 2":
+    check b > a
+
+suite "suite with only setup":
+  setup:
+    var testVar = "from setup"
+
+  test "unittest with only setup 1":
+    check testVar == "from setup"
+    check b > a
+    b = -1
+
+  test "unittest with only setup 2":
+    check b < a
+
+suite "suite with none":
+  test "unittest with none":
+    check b < a
+
+suite "suite with both":
+  setup:
+    a = -2
+
+  teardown:
+    c = 2
+
+  test "unittest with both 1":
+    check b > a
+
+  test "unittest with both 2":
+    check c == 2


### PR DESCRIPTION
- failed checks cause identifiers and calls to print out their values
- testSetupIMPL and testTeardownIMPL are not awkwardly public anymore while preserving setup and teardown!