### PR TITLE
Fix exponentiation operation to avoid overflow.

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -427,10 +427,12 @@ proc `^`*[T](x, y: T): T =
   var (x, y) = (x, y)
   result = 1
 
-  while y != 0:
+  while true:
     if (y and 1) != 0:
       result *= x
     y = y shr 1
+    if y == 0:
+      break
     x *= x
 
 proc gcd*[T](x, y: T): T =


### PR DESCRIPTION
The exponentation implementation unnecessarily multiplied the
result with itself at the end if the exponent was an even number.
This led to overflow if result*result > high(int).