### PR TITLE
Extending channels

### DIFF
--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -100,6 +100,9 @@ else:
     importc: "pthread_cond_wait", header: "<pthread.h>", noSideEffect.}
   proc signalSysCond(cond: var SysCond) {.
     importc: "pthread_cond_signal", header: "<pthread.h>", noSideEffect.}
+  proc broadcastSysCond(cond: var SysCond) {.
+    importc: "pthread_cond_broadcast", header: "<pthread.h>", noSideEffect.}
+
   
   proc deinitSysCond(cond: var SysCond) {.noSideEffect,
     importc: "pthread_cond_destroy", header: "<pthread.h>".}

--- a/tests/threads/message_counter.nim
+++ b/tests/threads/message_counter.nim
@@ -1,0 +1,38 @@
+import os
+import threadpool
+
+var 
+  chanA: TChannel[string]
+  chanB: TChannel[string]
+
+proc heavyTaskA() {.thread.} =
+  chanA.send("One")
+  sleep(400)
+  chanA.send("Three")
+  sleep(400)
+  chanA.close()
+
+proc heavyTaskB() {.thread.} =
+  sleep(200)
+  chanA.send("Two")
+  sleep(400)
+  chanA.send("Four")
+  chanB.close()
+
+chanA.open()
+chanB.open()
+
+var threads = newSeq[TThread[void]](2)
+createThread[void](threads[0], heavyTaskA)
+createThread[void](threads[1], heavyTaskB)
+
+var counter: int
+while not chanA.isClosed() or not chanA.isClosed():
+  waitForNextMessage(counter)
+  echo "going on, let's check, let's check..."
+  var s = ""
+  while chanA.tryRecv(s):
+    echo "from channelA: ", s
+  while chanB.tryRecv(s):
+    echo "from channelA: ", s
+  


### PR DESCRIPTION
Extending channels.nim with waitForNextMessage(counter), tryRecv(chan, msg) and isClose() functions.
Not tested on Windows.
The code below shows an example usage. The waitForNextMessage function can be a base for macros which could copy Go's switch statement.

Thanks for checking, Peter

```nim
import os
import threadpool

var 
  chanA: TChannel[string]
  chanB: TChannel[string]

proc heavyTaskA() {.thread.} =
  chanA.send("One")
  sleep(400)
  chanA.send("Three")
  sleep(400)
  chanA.close()

proc heavyTaskB() {.thread.} =
  sleep(200)
  chanA.send("Two")
  sleep(400)
  chanA.send("Four")
  chanB.close()

chanA.open()
chanB.open()

var threads = newSeq[TThread[void]](2)
createThread[void](threads[0], heavyTaskA)
createThread[void](threads[1], heavyTaskB)

var counter: int
while not chanA.isClosed() or not chanA.isClosed():
  waitForNextMessage(counter)
  echo "going on, let's check, let's check..."
  var s = ""
  while chanA.tryRecv(s):
    echo "from channelA: ", s
  while chanB.tryRecv(s):
    echo "from channelA: ", s
```