### PR TITLE
JS: Untyped pointers codegen changed. addr expression fixed.

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -136,7 +136,7 @@ proc mapType(typ: PType): TJSTypeKind =
       result = etyBaseIndex
   of tyPointer:
     # treat a tyPointer like a typed pointer to an array of bytes
-    result = etyInt
+    result = etyBaseIndex
   of tyRange, tyDistinct, tyOrdinal, tyConst, tyMutable, tyIter, tyProxy:
     result = mapType(t.sons[0])
   of tyInt..tyInt64, tyUInt..tyUInt64, tyEnum, tyChar: result = etyInt

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -13,6 +13,8 @@
 proc semAddr(c: PContext; n: PNode; isUnsafeAddr=false): PNode =
   result = newNodeI(nkAddr, n.info)
   let x = semExprWithType(c, n)
+  if x.kind == nkSym:
+    x.sym.flags.incl(sfAddrTaken)
   if isAssignable(c, x, isUnsafeAddr) notin {arLValue, arLocalLValue}:
     localError(n.info, errExprHasNoAddress)
   result.add x

--- a/tests/js/taddr.nim
+++ b/tests/js/taddr.nim
@@ -62,3 +62,11 @@ var t : tuple[a, b: int]
 var pt = addr t[1]
 pt[] = 123
 doAssert(t.b == 123)
+
+#block: # Test "untyped" pointer.
+proc testPtr(p: pointer, a: int) =
+  doAssert(a == 5)
+  (cast[ptr int](p))[] = 124
+var i = 123
+testPtr(addr i, 5)
+doAssert(i == 124)


### PR DESCRIPTION
Untyped pointers have changed their semantics in JS. Now they are treated as etyBaseIndex, and not as int. This change required to use a different pseudo-type in jssys.nim that has int semantics.

Also addr operation adds sfAddrTaken flag, that fixes another issue, demonstrated in the test.