### PR TITLE
Add widestring versions of SQLPrepare and SQLExecDirect

### DIFF
--- a/lib/wrappers/odbcsql.nim
+++ b/lib/wrappers/odbcsql.nim
@@ -680,7 +680,11 @@ proc SQLBrowseConnect*(hdbc: SqlHDBC, szConnStrIn: PSQLCHAR,
     dynlib: odbclib, importc.}
 proc SQLExecDirect*(StatementHandle: SqlHStmt, StatementText: PSQLCHAR,
                     TextLength: TSqlInteger): TSqlSmallInt{.dynlib: odbclib, importc.}
+proc SQLExecDirectW*(StatementHandle: SqlHStmt, StatementText: WideCString,
+                    TextLength: TSqlInteger): TSqlSmallInt{.dynlib: odbclib, importc.}
 proc SQLPrepare*(StatementHandle: SqlHStmt, StatementText: PSQLCHAR,
+                 TextLength: TSqlInteger): TSqlSmallInt{.dynlib: odbclib, importc.}
+proc SQLPrepareW*(StatementHandle: SqlHStmt, StatementText: WideCString,
                  TextLength: TSqlInteger): TSqlSmallInt{.dynlib: odbclib, importc.}
 proc SQLCloseCursor*(StatementHandle: SqlHStmt): TSqlSmallInt{.dynlib: odbclib,
     importc.}


### PR DESCRIPTION
SQLPrepareW and SQLExecDirectW are needed to use unicode as otherwise ODBC only recognises ansi codepages in SQL strings.