### PR TITLE
VM produces objects.

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1392,7 +1392,10 @@ proc getNullValueAux(obj: PNode, result: PNode) =
     for i in countup(1, sonsLen(obj) - 1):
       getNullValueAux(lastSon(obj.sons[i]), result)
   of nkSym:
-    addSon(result, getNullValue(obj.sym.typ, result.info))
+    let field = newNodeI(nkExprColonExpr, result.info)
+    field.add(obj)
+    field.add(getNullValue(obj.sym.typ, result.info))
+    addSon(result, field)
   else: globalError(result.info, "cannot create null element for: " & $obj)
 
 proc getNullValue(typ: PType, info: TLineInfo): PNode =
@@ -1418,7 +1421,8 @@ proc getNullValue(typ: PType, info: TLineInfo): PNode =
       result.add(newNodeIT(nkNilLit, info, t))
       result.add(newNodeIT(nkNilLit, info, t))
   of tyObject:
-    result = newNodeIT(nkPar, info, t)
+    result = newNodeIT(nkObjConstr, info, t)
+    result.add(newNodeIT(nkEmpty, info, t))
     getNullValueAux(t.n, result)
     # initialize inherited fields:
     var base = t.sons[0]

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -46,7 +46,7 @@ template wrap2svoid(op) {.immediate, dirty.} =
 
 proc getCurrentExceptionMsgWrapper(a: VmArgs) {.nimcall.} =
   setResult(a, if a.currentException.isNil: ""
-               else: a.currentException.sons[2].strVal)
+               else: a.currentException.sons[3].skipColon.strVal)
 
 proc registerAdditionalOps*(c: PCtx) =
   wrap1f(sqrt)

--- a/web/news.txt
+++ b/web/news.txt
@@ -62,6 +62,10 @@ News
     * ``libeay32.dll``: Split into ``libeay32.dll`` and ``libeay64.dll``.
 
     Compile with ``-d:nimOldDLLs`` to make the stdlib use the old DLL names.
+  - Nim VM now treats objects as nkObjConstr nodes, and not nkPar nodes as it
+    was previously. Macros that generate nkPar nodes when object is expected are
+    likely to break. Macros that expect nkPar nodes to which objects are passed
+    are likely to break as well.
 
 
   Library additions


### PR DESCRIPTION
VM will now produce nkObjConstr nodes for objects instead of nkPar nodes.
Fixes #3272.