### PR TITLE
Null string literals will not trigger cstrToNimstr

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1628,8 +1628,11 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       r.kind = resExpr
   of nkStrLit..nkTripleStrLit:
     if skipTypes(n.typ, abstractVarRange).kind == tyString:
-      useMagic(p, "cstrToNimstr")
-      r.res = "cstrToNimstr($1)" % [makeJSString(n.strVal)]
+      if n.strVal.isNil:
+        r.res = rope"null"
+      else:
+        useMagic(p, "cstrToNimstr")
+        r.res = "cstrToNimstr($1)" % [makeJSString(n.strVal)]
     else:
       r.res = makeJSString(n.strVal)
     r.kind = resExpr


### PR DESCRIPTION
Previously null string literals produced `cstrToNimstr(null)`. Now it's just `null`.