### PR TITLE
Replace incorrect warning string.

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -439,7 +439,7 @@ const
     "RedefinitionOfLabel", "UnknownSubstitutionX",
     "LanguageXNotSupported", "FieldXNotSupported",
     "CommentXIgnored", "NilStmt",
-    "TypelessParam", "DifferentHeaps", "WriteToForeignHeap",
+    "TypelessParam", "UseBase", "WriteToForeignHeap",
     "UnsafeCode", "EachIdentIsTuple", "ShadowIdent",
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]


### PR DESCRIPTION
One reference to the old warning DifferentHeaps was missed in dc047931bbde432512053c91d0cb9b8a230a7574.