### PR TITLE
[Don't merge] [RFC] not nil - default for pointer types, or nil - optional

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1204,7 +1204,6 @@ proc newType*(kind: TTypeKind, owner: PSym): PType =
   result.align = 2            # default alignment
   result.id = getID()
   result.lockLevel = UnspecifiedLockLevel
-  result.flags = {tfOrNil}
   when debugIds:
     registerId(result)
   #if result.id == 92231:

--- a/compiler/canonicalizer.nim
+++ b/compiler/canonicalizer.nim
@@ -159,7 +159,7 @@ proc hashType(c: var MD5Context, t: PType) =
   else:
     for i in 0.. <t.len: c.hashType(t.sons[i])
   if tfShared in t.flags: c &= "shared"
-  if tfNotNil in t.flags: c &= "not nil"
+  if tfOrNil  in t.flags: c &= "or nil"
 
 proc canonConst(n: PNode): TUid =
   var c: MD5Context

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1960,7 +1960,7 @@ proc checkInitialized(n: PNode, ids: IntSet, info: TLineInfo) =
         of nkOfBranch, nkElse: checkInitialized(lastSon(n.sons[i]), ids, info)
         else: internalError(info, "checkInitialized")
   of nkSym:
-    if {tfNotNil, tfNeedsInit} * n.sym.typ.flags != {} and
+    if {tfNeedsInit, tfOrNil} * n.sym.typ.flags <= {tfNeedsInit} and
         n.sym.name.id notin ids:
       message(info, errGenerated, "field not initialized: " & n.sym.name.s)
   else: internalError(info, "checkInitialized")

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -330,10 +330,12 @@ proc semIdentDef(c: PContext, n: PNode, kind: TSymKind): PSym =
   styleCheckDef(result)
 
 proc checkNilable(v: PSym) =
-  if sfGlobal in v.flags and {tfNotNil, tfNeedsInit} * v.typ.flags != {}:
+  if sfGlobal in v.flags and
+     (tfNeedsInit in v.typ.flags or
+      tfOrNil notin v.typ.flags and v.typ.kind in NilableTypes):
     if v.ast.isNil:
       message(v.info, warnProveInit, v.name.s)
-    elif tfNotNil in v.typ.flags and tfNotNil notin v.ast.typ.flags:
+    elif tfOrNil notin v.typ.flags and tfOrNil in v.ast.typ.flags:
       message(v.info, warnProveInit, v.name.s)
 
 include semasgn

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1154,7 +1154,14 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       result = semTypeExpr(c, n)
     else:
       let op = considerQuotedIdent(n.sons[0])
-      if op.id in {ord(wAnd), ord(wOr)} or op.s == "|":
+      if op.id == ord(wOr) and n.len == 3 and n.sons[2].kind == nkNilLit:
+        result = semTypeNode(c, n.sons[1], prev)
+        if result.skipTypes({tyGenericInst}).kind in NilableTypes+GenericTypes:
+          result = freshType(result, prev)
+          result.flags.incl(tfOrNil)
+        else:
+          localError(n.info, errGenerated, "invalid type")
+      elif op.id in {ord(wAnd), ord(wOr)} or op.s == "|":
         checkSonsLen(n, 3)
         var
           t1 = semTypeNode(c, n.sons[1], nil)
@@ -1175,7 +1182,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
           if result.skipTypes({tyGenericInst}).kind in NilableTypes+GenericTypes and
               n.sons[2].kind == nkNilLit:
             result = freshType(result, prev)
-            result.flags.incl(tfNotNil)
+            result.flags.excl(tfOrNil)
           else:
             localError(n.info, errGenerated, "invalid type")
         of 2:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -387,7 +387,7 @@ proc recordRel(c: var TCandidate, f, a: PType): TTypeRelation =
           if x.name.id != y.name.id: return isNone
 
 proc allowsNil(f: PType): TTypeRelation {.inline.} =
-  result = if tfNotNil notin f.flags: isSubtype else: isNone
+  result = if tfOrNil in f.flags: isSubtype else: isNone
 
 proc inconsistentVarTypes(f, a: PType): bool {.inline.} =
   result = f.kind != a.kind and (f.kind == tyVar or a.kind == tyVar)
@@ -805,7 +805,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType, doBind = true): TTypeRelation =
       else:
         result = typeRel(c, f.sons[0], a.sons[0])
         if result < isGeneric: result = isNone
-        elif tfNotNil in f.flags and tfNotNil notin a.flags:
+        elif tfOrNil notin f.flags and tfOrNil in a.flags:
           result = isNilConversion
     of tyNil: result = f.allowsNil
     else: discard
@@ -853,18 +853,18 @@ proc typeRel(c: var TCandidate, f, aOrig: PType, doBind = true): TTypeRelation =
         if typeRel(c, f.sons[i], a.sons[i]) == isNone: return isNone
       result = typeRel(c, f.lastSon, a.lastSon)
       if result <= isConvertible: result = isNone
-      elif tfNotNil in f.flags and tfNotNil notin a.flags:
+      elif tfOrNil notin f.flags and tfOrNil in a.flags:
         result = isNilConversion
     elif a.kind == tyNil: result = f.allowsNil
     else: discard
   of tyProc:
     result = procTypeRel(c, f, a)
-    if result != isNone and tfNotNil in f.flags and tfNotNil notin a.flags:
+    if result != isNone and tfOrNil notin f.flags and tfOrNil in a.flags:
       result = isNilConversion
   of tyPointer:
     case a.kind
     of tyPointer:
-      if tfNotNil in f.flags and tfNotNil notin a.flags:
+      if tfOrNil notin f.flags and tfOrNil in a.flags:
         result = isNilConversion
       else:
         result = isEqual
@@ -880,7 +880,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType, doBind = true): TTypeRelation =
   of tyString:
     case a.kind
     of tyString:
-      if tfNotNil in f.flags and tfNotNil notin a.flags:
+      if tfOrNil notin f.flags and tfOrNil in a.flags:
         result = isNilConversion
       else:
         result = isEqual
@@ -890,7 +890,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType, doBind = true): TTypeRelation =
     # conversion from string to cstring is automatic:
     case a.kind
     of tyCString:
-      if tfNotNil in f.flags and tfNotNil notin a.flags:
+      if tfOrNil notin f.flags and tfOrNil in a.flags:
         result = isNilConversion
       else:
         result = isEqual

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -413,7 +413,7 @@ const preferToResolveSymbols = {preferName, preferModuleInfo, preferGenericArg}
 
 proc addTypeFlags(name: var string, typ: PType) {.inline.} =
   if tfShared in typ.flags: name = "shared " & name
-  if tfNotNil in typ.flags: name.add(" not nil")
+  if tfOrNil  in typ.flags: name.add " or nil"
 
 proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
   var t = typ

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -283,7 +283,7 @@ proc `==` *[Enum: enum](x, y: Enum): bool {.magic: "EqEnum", noSideEffect.}
   ##    e2 = Enum1(Place2)
   ##  echo (e1 == e2) # true
   ##  echo (e1 == Place2) # raises error
-proc `==` *(x, y: pointer): bool {.magic: "EqRef", noSideEffect.}
+proc `==` *(x, y: pointer or nil): bool {.magic: "EqRef", noSideEffect.}
   ## .. code-block:: nim
   ##  var # this is a wildly dangerous example
   ##    a = cast[pointer](0)
@@ -291,7 +291,7 @@ proc `==` *(x, y: pointer): bool {.magic: "EqRef", noSideEffect.}
   ##  echo (a == b) # true due to the special meaning of `nil`/0 as a pointer
 proc `==` *(x, y: string): bool {.magic: "EqStr", noSideEffect.}
   ## Checks for equality between two `string` variables
-proc `==` *(x, y: cstring): bool {.magic: "EqCString", noSideEffect.}
+proc `==` *(x, y: cstring or nil): bool {.magic: "EqCString", noSideEffect.}
   ## Checks for equality between two `cstring` variables
 proc `==` *(x, y: char): bool {.magic: "EqCh", noSideEffect.}
   ## Checks for equality between two `char` variables
@@ -304,9 +304,9 @@ proc `==` *[T](x, y: set[T]): bool {.magic: "EqSet", noSideEffect.}
   ##  var a = {1, 2, 2, 3} # duplication in sets is ignored
   ##  var b = {1, 2, 3}
   ##  echo (a == b) # true
-proc `==` *[T](x, y: ref T): bool {.magic: "EqRef", noSideEffect.}
+proc `==` *[T](x, y: ref T or nil): bool {.magic: "EqRef", noSideEffect.}
   ## Checks that two `ref` variables refer to the same item
-proc `==` *[T](x, y: ptr T): bool {.magic: "EqRef", noSideEffect.}
+proc `==` *[T](x, y: ptr T or nil): bool {.magic: "EqRef", noSideEffect.}
   ## Checks that two `ptr` variables refer to the same item
 proc `==` *[T: proc](x, y: T): bool {.magic: "EqProc", noSideEffect.}
   ## Checks that two `proc` variables refer to the same procedure


### PR DESCRIPTION
This is in the works and currently breaks Nim, since pointer nullability must be now expressed explicitly by programmer, and Nim will check if we are testing for `nil` prior calling any proc expecting non-`nil` pointer. I will be adding commits fixing this - expressing pointer nilability.

### Rationale

Before this change all `ptr T`, `ref T`, `string` or `cstring` types could contain `nil`. However most of the functions expecting arguments of this types were not handling `nil` cases, instead having undefined behavior (likely crashing). Same applies to other APIs, like C standard library, where many functions such as `strlen` or `strdup` expect valid pointers.

At that point Nim was offering `not nil` type marker, expressing that pointer type cannot hold `nil` value, but it was not used often.

This PR reverses nilability of Nim pointer types, so from now on they are NOT nilable by default, and their nillability must be expressed explicitly by `or nil`. In theory this will make Nim detect more bugs related to uninitialized pointers or no `nil` checking at compile time.

### Plan

This change is split into several commits. First commit is neutral, just replacing reversed `tfNotNil` flag with `tfOrNil` and adding `tfOrNil` flag by default to pointer types. Effectively `tfNotNil` is gone from Nim source code, but old behavior remains.

Next commit turns off `tfOrNil` making it optional. From now on Nim breaks and likely not compile, since in many places in Nim source code we deal with `nils` but we don't express that explicitly.

Following commits fix that, one commit per one case (eg. library).

### Discussion

@Araq You were asking if this breaks a lot, it does, since all structures in Nim source code dealing with `nil` must express that explicitly. But it seems that it is not so hard to fix that.

So far I found one shortcoming with `not nil` prover:
~~~nim
if a[i] != nil: result = a[i] # <- Nim prover don't follow a[i] != nil check
~~~
This can be worked around introducing temporary variable holding `a[i]`.
