### PR TITLE
Added == operator for comparing two Object IDs

### DIFF
--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -25,6 +25,10 @@ type
 
 {.deprecated: [Toid: Oid].}
 
+proc `==`*(oid1: Oid, oid2: Oid): bool =
+    ## Compare two Mongo Object IDs for equality
+    return (oid1.time == oid2.time) and (oid1.fuzz == oid2.fuzz) and (oid1.count == oid2.count)
+
 proc hexbyte*(hex: char): int =
   case hex
   of '0'..'9': result = (ord(hex) - ord('0'))


### PR DESCRIPTION
For now Mongo Object IDs cannot be compared directly as values, because all fields are private, and the only way to compare those are comparing their string representation, like:
```
$oid1 == $oid2
```
This PR adds `==` operator that adds compare behaviour to oids