### PR TITLE
bug fix: close() only unmapViewOfFile when fHandle is valid.

### DIFF
--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -229,7 +229,7 @@ proc close*(f: var MemFile) =
   var lastErr: OSErrorCode
 
   when defined(windows):
-    if f.fHandle != INVALID_HANDLE_VALUE and wasOpened:
+    if f.fHandle != INVALID_HANDLE_VALUE and f.wasOpened:
       error = unmapViewOfFile(f.mem) == 0
       lastErr = osLastError()
       error = (closeHandle(f.mapHandle) == 0) or error
@@ -246,6 +246,7 @@ proc close*(f: var MemFile) =
   when defined(windows):
     f.fHandle = 0
     f.mapHandle = 0
+    f.wasOpened = false
   else:
     f.handle = 0
 

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -226,7 +226,7 @@ proc close*(f: var MemFile) =
   var lastErr: OSErrorCode
 
   when defined(windows):
-    if f.fHandle != INVALID_HANDLE_VALUE:
+    if f.fHandle != INVALID_HANDLE_VALUE and f.fHandle != 0:
       error = unmapViewOfFile(f.mem) == 0
       lastErr = osLastError()
       error = (closeHandle(f.mapHandle) == 0) or error

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -34,6 +34,7 @@ type
     when defined(windows):
       fHandle: int
       mapHandle: int
+      wasOpened: bool
     else:
       handle: cint
 
@@ -172,6 +173,8 @@ proc open*(filename: string, mode: FileMode = fmRead,
       if mappedSize != -1: result.size = min(fileSize, mappedSize).int
       else: result.size = fileSize.int
 
+    result.wasOpened = true
+
   else:
     template fail(errCode: OSErrorCode, msg: expr) =
       rollback()
@@ -226,7 +229,7 @@ proc close*(f: var MemFile) =
   var lastErr: OSErrorCode
 
   when defined(windows):
-    if f.fHandle != INVALID_HANDLE_VALUE:
+    if f.fHandle != INVALID_HANDLE_VALUE and wasOpened:
       error = unmapViewOfFile(f.mem) == 0
       lastErr = osLastError()
       error = (closeHandle(f.mapHandle) == 0) or error

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -226,7 +226,7 @@ proc close*(f: var MemFile) =
   var lastErr: OSErrorCode
 
   when defined(windows):
-    if f.fHandle != INVALID_HANDLE_VALUE and f.fHandle != 0:
+    if f.fHandle != INVALID_HANDLE_VALUE:
       error = unmapViewOfFile(f.mem) == 0
       lastErr = osLastError()
       error = (closeHandle(f.mapHandle) == 0) or error

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -116,7 +116,8 @@ proc open*(filename: string, mode: FileMode = fmRead,
     template callCreateFile(winApiProc, filename: expr): expr =
       winApiProc(
         filename,
-        if readonly: GENERIC_READ else: GENERIC_ALL,
+        # GENERIC_ALL != (GENERIC_READ or GENERIC_WRITE)
+        if readonly: GENERIC_READ else: GENERIC_READ or GENERIC_WRITE,
         FILE_SHARE_READ,
         nil,
         if newFileSize != -1: CREATE_ALWAYS else: OPEN_EXISTING,

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -32,9 +32,9 @@ type
     size*: int       ## size of the memory mapped file
 
     when defined(windows):
-      fHandle: int
-      mapHandle: int
-      wasOpened: bool
+      fHandle: Handle
+      mapHandle: Handle
+      wasOpened: bool   ## only close if wasOpened
     else:
       handle: cint
 

--- a/tests/stdlib/tmemfiles1.nim
+++ b/tests/stdlib/tmemfiles1.nim
@@ -1,0 +1,13 @@
+discard """
+test that closing a closed file is ignored (no error raised)
+output: nothing
+"""
+import memfiles, os
+var
+  mm: MemFile
+  fn = "test.mmap"
+# Create a new file
+mm = memfiles.open(fn, mode = fmReadWrite, newFileSize = 20)
+mm.close()
+mm.close()
+if fileExists(fn): removeFile(fn)

--- a/tests/stdlib/tmemfiles1.nim
+++ b/tests/stdlib/tmemfiles1.nim
@@ -1,6 +1,6 @@
 discard """
-test that closing a closed file is ignored (no error raised)
-output: nothing
+  test that closing a closed file is ignored (no error raised)
+  file: "tmemfiles1.nim"
 """
 import memfiles, os
 var

--- a/tests/stdlib/tmemfiles2.nim
+++ b/tests/stdlib/tmemfiles2.nim
@@ -1,0 +1,38 @@
+discard """
+  test creating/reading/writing/changing memfiles
+  file: "tmemfiles2.nim"
+  output: '''Full read size: 20
+Half read size: 10 Data: Hello'''
+"""
+import memfiles, os
+var
+  mm, mm_full, mm_half: MemFile
+  fn = "test.mmap"
+  p: pointer
+
+if fileExists(fn): removeFile(fn)
+
+# Create a new file, data all zeros
+mm = memfiles.open(fn, mode = fmReadWrite, newFileSize = 20)
+mm.close()
+
+# read, change
+mm_full = memfiles.open(fn, mode = fmWrite, mappedSize = -1)
+echo "Full read size: ",mm_full.size
+p = mm_full.mapMem(fmReadWrite, 20, 0)
+var p2 = cast[cstring](p)
+p2[0] = 'H'
+p2[1] = 'e'
+p2[2] = 'l'
+p2[3] = 'l'
+p2[4] = 'o'
+p2[5] = '\0'
+mm_full.unmapMem(p, 20)
+mm_full.close()
+
+# read half, and verify data change
+mm_half = memfiles.open(fn, mode = fmRead, mappedSize = 10)
+echo "Half read size: ",mm_half.size, " Data: ", cast[cstring](mm_half.mem)
+mm_half.close()
+
+if fileExists(fn): removeFile(fn)


### PR DESCRIPTION
Added extra condition on windows close so if already closed it
doesn't throw an exception.  Identified from #3315 