### PR TITLE
Moved teardown call to try block for namespace access reasons

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -150,6 +150,8 @@ template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
     try:
       when declared(testSetupIMPLFlag): testSetupIMPL()
       body
+      when declared(testTeardownIMPLFlag):
+        defer: testTeardownIMPL()
 
     except:
       when not defined(js):
@@ -158,7 +160,6 @@ template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
       fail()
 
     finally:
-      when declared(testTeardownIMPLFlag): testTeardownIMPL()
       testDone name, testStatusIMPL
 
 proc checkpoint*(msg: string) =


### PR DESCRIPTION
Consider the net test suite:
```nim
suite "Test allocation":

  setup:
    var p = cast[ptr int](alloc(sizeof(int)))

  test "test working with manually allocated int":
    p[] = 10
    check(p[] == 10)

  tearDown:
    dealloc(p)
```
In case the `tearDown()` is called when it is in a `finally` code block: you will receive an error, because variable `p` cannot be accessed, and we cannot `dealloc` memory for it.

The same problem appears when testing other resources like files/DBs/sockets, etc...