### PR TITLE
Fix proc closeSocket (posix): bad file descriptor error

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -992,8 +992,8 @@ else:
 
   proc closeSocket*(sock: AsyncFD) =
     let disp = getGlobalDispatcher()
-    sock.SocketHandle.close()
     disp.selector.unregister(sock.SocketHandle)
+    sock.SocketHandle.close()
 
   proc unregister*(fd: AsyncFD) =
     getGlobalDispatcher().selector.unregister(fd.SocketHandle)


### PR DESCRIPTION
Close file descriptor before `selector.unregister`, therefore `epoll_ctl(s.epollFD, EPOLL_CTL_DEL, fd, nil)` will be failed. When there are large requests, sometimes it will raise an error (assert fail):

**not selectorKey.fd != 0.SocketHandle**
