### PR TITLE
fixing TypelessParam warning in x=>x+1, added test

### DIFF
--- a/lib/pure/future.nim
+++ b/lib/pure/future.nim
@@ -75,7 +75,7 @@ macro `=>`*(p, b: expr): expr {.immediate.} =
         identDefs.add(newEmptyNode())
       of nnkIdent:
         identDefs.add(c)
-        identDefs.add(newEmptyNode())
+        identDefs.add(newIdentNode("auto"))
         identDefs.add(newEmptyNode())
       of nnkInfix:
         if c[0].kind == nnkIdent and c[0].ident == !"->":
@@ -93,7 +93,7 @@ macro `=>`*(p, b: expr): expr {.immediate.} =
   of nnkIdent:
     var identDefs = newNimNode(nnkIdentDefs)
     identDefs.add(p)
-    identDefs.add(newEmptyNode())
+    identDefs.add(newIdentNode("auto"))
     identDefs.add(newEmptyNode())
     params.add(identDefs)
   of nnkInfix:

--- a/tests/generics/tmap_auto.nim
+++ b/tests/generics/tmap_auto.nim
@@ -1,0 +1,13 @@
+import future
+
+let x = map(@[1, 2, 3], x => x+10)
+assert x == @[11, 12, 13]
+
+let y = map(@[(1,"a"), (2,"b"), (3,"c")], x => $x[0] & x[1])
+assert y == @["1a", "2b", "3c"]
+
+proc eatsTwoArgProc[T,S,U](a: T, b: S, f: proc(t: T, s: S): U): U =
+  f(a,b)
+
+let z = eatsTwoArgProc(1, "a", (t,s) => $t & s)
+assert z == "1a"


### PR DESCRIPTION
Made ``map(@[1,2,3], x=>x+10)`` working without TypelessParam warning. Added a simple test.