### PR TITLE
Avoid referencing undefined SSLv2_method on MacOSX

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -223,7 +223,7 @@ when defined(ssl):
     of protSSLv23:
       newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
     of protSSLv2:
-      raiseSslError()
+      raiseSslError("SSLv2 is no longer secure and has been deprecated, use protSSLv3")
     of protSSLv3:
       newCTX = SSL_CTX_new(SSLv3_method())
     of protTLSv1:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -223,10 +223,7 @@ when defined(ssl):
     of protSSLv23:
       newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
     of protSSLv2:
-      when not defined(linux) and not defined(macosx):
-        newCTX = SSL_CTX_new(SSLv2_method())
-      else:
-        raiseSslError()
+      raiseSslError()
     of protSSLv3:
       newCTX = SSL_CTX_new(SSLv3_method())
     of protTLSv1:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -223,7 +223,7 @@ when defined(ssl):
     of protSSLv23:
       newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
     of protSSLv2:
-      when not defined(linux):
+      when not defined(linux) and not defined(macosx):
         newCTX = SSL_CTX_new(SSLv2_method())
       else:
         raiseSslError()

--- a/lib/pure/sockets.nim
+++ b/lib/pure/sockets.nim
@@ -314,10 +314,7 @@ when defined(ssl):
     of protSSLv23:
       newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
     of protSSLv2:
-      when not defined(linux) and not defined(OpenBSD):
-        newCTX = SSL_CTX_new(SSLv2_method())
-      else:
-        raiseSslError()
+      raiseSslError()
     of protSSLv3:
       newCTX = SSL_CTX_new(SSLv3_method())
     of protTLSv1:

--- a/lib/pure/sockets.nim
+++ b/lib/pure/sockets.nim
@@ -314,7 +314,7 @@ when defined(ssl):
     of protSSLv23:
       newCTX = SSL_CTX_new(SSLv23_method()) # SSlv2,3 and TLS1 support.
     of protSSLv2:
-      raiseSslError()
+      raiseSslError("SSLv2 is no longer secure and has been deprecated, use protSSLv3")
     of protSSLv3:
       newCTX = SSL_CTX_new(SSLv3_method())
     of protTLSv1:


### PR DESCRIPTION
I'm using OSX 10.11 El Capitan and currently see an error when using `nim`@`devel` with ssl (for example with `nimble`):

```
$ ./nimble
could not import: SSLv2_method
```

OSX 10.11 does not ship with openssl, and I have openssl 1.0.2d installed via homebrew in /usr/local. I guess this version no longer ships with ssl2?

This PR avoids referencing the undefined symbol on OSX, similar to the way it was already being done for linux. I tried to use `defined(SSLv2_method)` but that didn't work.

cc https://github.com/nim-lang/nimble/issues/142