### PR TITLE
Add access to thread handle under Windows

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -428,6 +428,11 @@ proc threadId*[TArg](t: var Thread[TArg]): ThreadId[TArg] {.inline.} =
   ## returns the thread ID of `t`.
   result = addr(t)
 
+when hostOS == "windows":
+  proc threadHandle*[TArg](t: var Thread[TArg]): Handle {.inline.} =
+    ## returns the thread handle of `t`.
+    result = t.sys
+
 when false:
   proc mainThreadId*[TArg](): ThreadId[TArg] =
     ## returns the thread ID of the main thread.


### PR DESCRIPTION
Under Windows, createThread returns the thread handle, which is placed in GcThread.sys - this is of type SysHandle (itself an alias of Handle under Windows).
This PR simply exposes a function "threadHandle" to return the handle so that it may be used in Windows.

Because this function is only exposed under Windows, I chose to set the return type as Handle, rather than SysThread (which is not an exposed type).
If anyone feels the SysThread should be exposed and the function should return this type instead, just comment and I'll change it. I haven't done any developing under Linux, but a quick google implies that GcThread.sys is also set to be a thread handle in this OS. If SysThread is exposed then the "threadHandle" function might as well exist under other operating systems too.