### PR TITLE
vm: Don't fail on unknown enum position to string

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -311,7 +311,7 @@ proc opConv*(dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType): bool =
           if f.position == x:
             dest.node.strVal = if f.ast.isNil: f.name.s else: f.ast.strVal
             return
-        internalError("opConv for enum")
+        dest.node.strVal = styp.sym.name.s & " " & $x
     of tyInt..tyInt64:
       dest.node.strVal = $src.intVal
     of tyUInt..tyUInt64:


### PR DESCRIPTION
Previously trying to convert constant of enum type, where this enum type has no
entry with given constant position leaded to "internal error: opConv for enum".

Instead of producing error, now we gracefully convert it to "EnumType position".

This solves internal error in following code:
```nim
import macros

macro dumpNotImm(st: stmt): stmt =
  echo st.treeRepr
  st

dumpNotImm:
  proc clos(x: int): int =
    proc addOne: int =
      x + 1
    addOne()
```

This internal error was caused by `NimNodeKind` containing only "public" node kinds, where helper internal node kinds coming from `TNodeKind` were generated for iterators, but since macros were trying to treat them as `NimNodeKind` it was failing on `nkClosure`.