### PR TITLE
Allow testament/tester to run single file

### DIFF
--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -339,7 +339,7 @@ proc `&?.`(a, b: string): string =
   # candidate for the stdlib?
   result = if a.endswith(b): a else: a & b
 
-proc processCategory(r: var TResults, cat: Category, options: string) =
+proc processCategory(r: var TResults, cat: Category, options: string, fileGlob: string = "t*.nim") =
   case cat.string.normalize
   of "rodfiles":
     discard # Disabled for now
@@ -376,5 +376,5 @@ proc processCategory(r: var TResults, cat: Category, options: string) =
   of "nimble-all":
     testNimblePackages(r, cat, pfAll)
   else:
-    for name in os.walkFiles("tests" & DirSep &.? cat.string / "t*.nim"):
+    for name in os.walkFiles("tests" & DirSep &.? cat.string / fileGlob):
       testSpec r, makeTest(name, options, cat)

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -23,6 +23,7 @@ const
 Command:
   all                         run all tests
   c|category <category>       run all the tests of a certain category
+  r|run <test>                run single test file
   html [commit]               generate $1 from the database; uses the latest
                               commit or a specific one (use -1 for the commit
                               before latest etc)
@@ -376,6 +377,11 @@ proc main() =
     var cat = Category(p.key)
     p.next
     processCategory(r, cat, p.cmdLineRest.string)
+  of "r", "run":
+    let (dir, file) = splitPath(p.key.string)
+    let (_, subdir) = splitPath(dir)
+    var cat = Category(subdir)
+    processCategory(r, cat, p.cmdLineRest.string, file)
   of "html":
     var commit = 0
     discard parseInt(p.cmdLineRest.string, commit)


### PR DESCRIPTION
Adds a new `run` option to the tester:

```
Command:
  all                         run all tests
  c|category <category>       run all the tests of a certain category
  r|run <test>                run single test file
```

This makes it much easier to reproduce CI failures and to iterate on a single test/feature during development.

```
$ tests/testament/tester r tests/pragmas/tbitsize.nim
FAIL: tbitsize.nim
Test "tests/pragmas/tbitsize.nim" in category "pragmas"
Failure: reCodegenFailure
Expected:
\i @'unsigned int flag:2;' .*

Gotten:


$ tests/testament/tester r tests/pragmas/tbitsize.nim
PASS: tbitsize.nim
```