### PR TITLE
Generate install.sh during bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,8 +12,11 @@ cd ".."
 
 ./bin/nim c koch
 ./koch boot -d:release
+./koch geninstall
 
-cp -f install.sh.template install.sh
-chmod +x install.sh
+set +x
+
+echo
+echo 'Install Nim using "./install.sh <dir>" or "sudo ./install.sh <dir>".'
 
 exit 0

--- a/install.sh.template
+++ b/install.sh.template
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-set -x
-
-if [ "$1" != "" ]; then
-	exec ./koch install "$1"
-else
-	exec ./koch install
-fi

--- a/koch.nim
+++ b/koch.nim
@@ -41,6 +41,7 @@ Options:
 Possible Commands:
   boot [options]           bootstraps with given command line options
   install [bindir]         installs to given directory; Unix only!
+  geninstall               generate ./install.sh; Unix only!
   clean                    cleans Nim project; removes generated files
   web [options]            generates the website and the full documentation
   website [options]        generates only the website
@@ -127,9 +128,12 @@ proc nsis(args: string) =
   exec(("tools" / "niminst" / "niminst --var:version=$# --var:mingw=mingw$#" &
         " nsis compiler/installer.ini") % [VersionAsString, $(sizeof(pointer)*8)])
 
+proc geninstall(args="") =
+  exec("$# cc -r $# --var:version=$# --var:mingw=none --main:compiler/nim.nim scripts compiler/installer.ini $#" %
+       [findNim(), compileNimInst, VersionAsString, args])
+
 proc install(args: string) =
-  exec("$# cc -r $# --var:version=$# --var:mingw=none --main:compiler/nim.nim scripts compiler/installer.ini" %
-       [findNim(), compileNimInst, VersionAsString])
+  geninstall()
   exec("sh ./install.sh $#" % args)
 
 proc web(args: string) =
@@ -373,6 +377,7 @@ of cmdArgument:
   of "zip": zip(op.cmdLineRest)
   of "xz": xz(op.cmdLineRest)
   of "nsis": nsis(op.cmdLineRest)
+  of "geninstall": geninstall(op.cmdLineRest)
   of "install": install(op.cmdLineRest)
   of "test", "tests": tests(op.cmdLineRest)
   of "update":


### PR DESCRIPTION
This solves problem where bootstrap was simply copying `./install.sh.template`
into `./install.sh`. Then first call of `./install.sh` was calling `./koch install`
that was running extra compilation and overwriting `./install.sh` with new
content.

This was overcomplicated, and also caused first `sudo ./install.sh DIR` to run
compilation under root account, leaving root owned files in working directory.

Now bootstrap calls `./koch geninstall` that just generates `./install.sh`
without calling it. This `./install.sh` is FINAL one, and running it does not
generate any files aside passed DIR. This makes whole process simpler.