### PR TITLE
Add afterRunEvent callback to execProcesses()

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -675,9 +675,9 @@ proc callCCompiler*(projectfile: string) =
   let runCb = proc (idx: int, p: Process) =
     let exitCode = p.peekExitCode
     if exitCode != 0:
-      echo p.outputStream.readAll
       rawMessage(errGenerated, "execution of an external compiler program '" &
-        cmds[idx] & "' failed with exit code: " & $exitCode)
+        cmds[idx] & "' failed with exit code: " & $exitCode & "\n\n" &
+        p.outputStream.readAll.strip)
   compileCFile(toCompile, script, cmds, prettyCmds, false)
   compileCFile(externalToCompile, script, cmds, prettyCmds, true)
   if optCompileOnly notin gGlobalOptions:

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -213,6 +213,8 @@ proc compilerOutputTests(test: TTest, given: var TSpec, expected: TSpec;
       expectedmsg = expected.nimout
       givenmsg = given.nimout.strip
       nimoutCheck(test, expectedmsg, given)
+  else:
+    givenmsg = given.nimout.strip
   if given.err == reSuccess: inc(r.passed)
   r.addResult(test, expectedmsg, givenmsg, given.err)
 


### PR DESCRIPTION
This callback also lets us get rid of the "rerun with --parallelBuild:1` error message.

For example, with:

```
$ cat compilefail.nim
{.emit:"invalid".}
```

Before:

```
$ nim c compilefail.nim
Hint: system [Processing]
Hint: compilefail [Processing]
CC: compilefail
Error:  execution of an external program failed; rerun with --parallelBuild:1 to see the error message

$ nim c --parallelBuild:1 compilefail.nim
Hint: system [Processing]
Hint: compilefail [Processing]
/private/tmp/nimcache/compilefail.c:10:1: error: unknown type name 'invalid'
invalid
^
/private/tmp/nimcache/compilefail.c:11:1: error: expected identifier or '('
static N_INLINE(void, initStackBottomWith)(void* locals);
^
2 errors generated.
Error: execution of an external program failed
```

After this patch, `--parallelBuild:1` is no longer required:

```
$ nim c compilefail.nim
Hint: system [Processing]
Hint: compilefail [Processing]
CC: compilefail
/private/tmp/nimcache/compilefail.c:10:1: error: unknown type name 'invalid'
invalid
^
/private/tmp/nimcache/compilefail.c:11:1: error: expected identifier or '('
static N_INLINE(void, initStackBottomWith)(void* locals);
^
2 errors generated.

Error: execution of an external compiler program 'clang -c  -w  -I/Users/tmm1/code/nim/lib -o /private/tmp/nimcache/compilefail.o /private/tmp/nimcache/compilefail.c' failed with exit code: 256
```