### PR TITLE
In C code generation shallowCopy() was (not correctly) deep copy

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2104,7 +2104,9 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkFastAsgn:
     # transf is overly aggressive with 'nkFastAsgn', so we work around here.
     # See tests/run/tcnstseq3 for an example that would fail otherwise.
-    genAsgn(p, n, fastAsgn=p.prc != nil)
+    #
+    # Update: modified back to "fastAsgn=true". All the tests are success.
+    genAsgn(p, n, fastAsgn=true)
   of nkDiscardStmt:
     if n.sons[0].kind != nkEmpty:
       genLineDir(p, n)

--- a/tests/assign/tshallowcopy.nim
+++ b/tests/assign/tshallowcopy.nim
@@ -1,0 +1,6 @@
+
+var orig = @[1,2,3]
+var notDeepCopy: seq[int]
+shallowCopy(notDeepCopy, orig)
+orig[0] = 99
+assert(notDeepCopy[0] == 99)


### PR DESCRIPTION
if called not from a function. There was a comment in ccgexprs.nim that this is on purpose and there was a reference to tcnstseq3 test. However, after this fix all the tests remained successful (which were successful before).

I've also added a test for this case.

Peter
