### PR TITLE
fix #3416 strtabs clear() and []=

### DIFF
--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -135,18 +135,15 @@ proc enlarge(t: StringTableRef) =
     if not isNil(t.data[i].key): rawInsert(t, n, t.data[i].key, t.data[i].val)
   swap(t.data, n)
 
-proc addVal(t: StringTableRef, key, val: string) =
+proc `[]=`*(t: StringTableRef, key, val: string) {.rtl, extern: "nstPut".} =
+  ## puts a (key, value)-pair into `t`.
   var index = rawGet(t, key)
   if index >= 0:
     t.data[index].val = val
   else:
     if mustRehash(len(t.data), t.counter): enlarge(t)
     rawInsert(t, t.data, key, val)
-
-proc `[]=`*(t: StringTableRef, key, val: string) {.rtl, extern: "nstPut".} =
-  ## puts a (key, value)-pair into `t`.
-  t.addVal(key, val)
-  inc(t.counter)
+    inc(t.counter)
 
 proc raiseFormatException(s: string) =
   var e: ref ValueError
@@ -176,6 +173,9 @@ proc clear*(s: StringTableRef, mode: StringTableMode) =
   s.mode = mode
   s.counter = 0
   s.data.setLen(startSize)
+  for i in 0..<s.data.len:
+    if not isNil(s.data[i].key):
+      s.data[i].key = nil
 
 proc newStringTable*(keyValuePairs: varargs[string],
                      mode: StringTableMode): StringTableRef {.
@@ -251,3 +251,6 @@ when isMainModule:
   x.mget("11") = "23"
   assert x["11"] == "23"
 
+  x.clear(modeCaseInsensitive)
+  x["11"] = "22"
+  assert x["11"] == "22"

--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -135,15 +135,18 @@ proc enlarge(t: StringTableRef) =
     if not isNil(t.data[i].key): rawInsert(t, n, t.data[i].key, t.data[i].val)
   swap(t.data, n)
 
-proc `[]=`*(t: StringTableRef, key, val: string) {.rtl, extern: "nstPut".} =
-  ## puts a (key, value)-pair into `t`.
+proc addVal(t: StringTableRef, key, val: string) =
   var index = rawGet(t, key)
   if index >= 0:
     t.data[index].val = val
   else:
     if mustRehash(len(t.data), t.counter): enlarge(t)
     rawInsert(t, t.data, key, val)
-    inc(t.counter)
+
+proc `[]=`*(t: StringTableRef, key, val: string) {.rtl, extern: "nstPut".} =
+  ## puts a (key, value)-pair into `t`.
+  t.addVal(key, val)
+  inc(t.counter)
 
 proc raiseFormatException(s: string) =
   var e: ref ValueError


### PR DESCRIPTION
Not sure if this is the best fix.

It all resolves around the `[]=` proc calling `rawInsert()` 
which is changing the     `data: KeyValuePairSeq`
within the `ref StringTableObj`
```
  KeyValuePairSeq = seq[KeyValuePair]
  StringTableObj* = object of RootObj
    counter: int
    data: KeyValuePairSeq
    mode: StringTableMode
  StringTableRef* = ref StringTableObj ## use this type to declare string tables
```