### PR TITLE
Extend terminal module, use stderr for Nim compiler diagnostics by default

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -751,6 +751,15 @@ proc msgWriteln*(s: string) =
       when defined(windows):
         flushFile(stderr)
 
+proc stdoutWriteln*(s: string) =
+  ## Writes to stdout.
+  ## Should be used only for VM time equivalents to procs outputting to stdout.
+  if not isNil(writelnHook):
+    writelnHook(s)
+  else:
+    writeLine(stdout, s)
+    flushFile(stdout)
+
 macro callIgnoringStyle(theProc: typed, first: typed,
                         args: varargs[expr]): stmt =
   let typForegroundColor = bindSym"ForegroundColor".getType

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -811,13 +811,13 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcEcho:
       let rb = instr.regB
       if rb == 1:
-        msgWriteln(regs[ra].node.strVal)
+        stdoutWriteln(regs[ra].node.strVal)
       else:
         var outp = ""
         for i in ra..ra+rb-1:
           #if regs[i].kind != rkNode: debug regs[i]
           outp.add(regs[i].node.strVal)
-        msgWriteln(outp)
+        stdoutWriteln(outp)
     of opcContainsSet:
       decodeBC(rkInt)
       regs[ra].intVal = ord(inSet(regs[rb].node, regs[rc].regToNode))

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -292,7 +292,8 @@ proc testSpec(r: var TResults, test: TTest) =
   case expected.action
   of actionCompile:
     var given = callCompiler(expected.cmd, test.name,
-      test.options & " --hint[Path]:off --hint[Processing]:off", test.target)
+      test.options & " --stdout --hint[Path]:off --hint[Processing]:off",
+      test.target)
     compilerOutputTests(test, given, expected, r)
   of actionRun, actionRunNoSpec:
     # In this branch of code "early return" pattern is clearer than deep


### PR DESCRIPTION
Previously we were defaulting to stdout for diagnostics, which could interfere
with scripts or `nim c -r' programs outputting their results to stdout,
possibly mixing their output with compiler messages.

This change makes now Nim to be inline with other compilers emitting
diagnostics to stderr. Also now --stdout option has proper meaning making all
diagnostics to be sent to stdout instead.

The PR also extends terminal module to work with both stderr, stdout (or any other handle on UNIX), making procs assuming stdout deprecated.