### PR TITLE
system/dyncalls: OS X is already handled as posix

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -107,42 +107,6 @@ elif defined(windows) or defined(dos):
     result = getProcAddress(cast[THINSTANCE](lib), name)
     if result == nil: procAddrError(name)
 
-elif defined(mac):
-  #
-  # =======================================================================
-  # Native Mac OS X / Darwin Implementation
-  # =======================================================================
-  #
-  {.error: "no implementation for dyncalls yet".}
-
-  proc nimUnloadLibrary(lib: LibHandle) =
-    NSUnLinkModule(NSModule(lib), NSUNLINKMODULE_OPTION_RESET_LAZY_REFERENCES)
-
-  var
-    dyld_present {.importc: "_dyld_present", header: "<dyld.h>".}: int
-
-  proc nimLoadLibrary(path: string): LibHandle =
-    var
-      img: NSObjectFileImage
-      ret: NSObjectFileImageReturnCode
-      modul: NSModule
-    # this would be a rare case, but prevents crashing if it happens
-    result = nil
-    if dyld_present != 0:
-      ret = NSCreateObjectFileImageFromFile(path, addr(img))
-      if ret == NSObjectFileImageSuccess:
-        modul = NSLinkModule(img, path, NSLINKMODULE_OPTION_PRIVATE or
-                                        NSLINKMODULE_OPTION_RETURN_ON_ERROR)
-        NSDestroyObjectFileImage(img)
-        result = LibHandle(modul)
-
-  proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
-    var
-      nss: NSSymbol
-    nss = NSLookupSymbolInModule(NSModule(lib), name)
-    result = ProcAddr(NSAddressOfSymbol(nss))
-    if result == nil: ProcAddrError(name)
-
 else:
   {.error: "no implementation for dyncalls".}
 


### PR DESCRIPTION
So elif defined(mac) has absolutely no effect, also this block uses some legacy
discouraged NSCreateObjectFileImageFromFile function.