### PR TITLE
Removed libiconv prefix (on OS X) to make encodings compile on OS X.

### DIFF
--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -263,11 +263,6 @@ else:
   else:
     const iconvDll = "(libc.so.6|libiconv.so)"
 
-  when defined(macosx):
-    const prefix = "lib"
-  else:
-    const prefix = ""
-
   const
     E2BIG = 7.cint
     EINVAL = 22.cint
@@ -283,15 +278,15 @@ else:
   var errno {.importc, header: "<errno.h>".}: cint
 
   proc iconvOpen(tocode, fromcode: cstring): EncodingConverter {.
-    importc: prefix & "iconv_open", cdecl, dynlib: iconvDll.}
+    importc: "iconv_open", cdecl, dynlib: iconvDll.}
   proc iconvClose(c: EncodingConverter) {.
-    importc: prefix & "iconv_close", cdecl, dynlib: iconvDll.}
+    importc: "iconv_close", cdecl, dynlib: iconvDll.}
   proc iconv(c: EncodingConverter, inbuf: var cstring, inbytesLeft: var int,
              outbuf: var cstring, outbytesLeft: var int): int {.
-    importc: prefix & "iconv", cdecl, dynlib: iconvDll.}
+    importc: "iconv", cdecl, dynlib: iconvDll.}
   proc iconv(c: EncodingConverter, inbuf: pointer, inbytesLeft: pointer,
              outbuf: var cstring, outbytesLeft: var int): int {.
-    importc: prefix & "iconv", cdecl, dynlib: iconvDll.}
+    importc: "iconv", cdecl, dynlib: iconvDll.}
 
 proc getCurrentEncoding*(): string =
   ## retrieves the current encoding. On Unix, always "UTF-8" is returned.
@@ -462,4 +457,3 @@ when not defined(testing) and isMainModule:
   echo "Forced ibm850 encoding: ", ibm850
   echo "Current encoding: ", current
   echo "From ibm850 to current: ", convert(ibm850, current, "ibm850")
-


### PR DESCRIPTION
I am not sure since which version OS X does include the libiconv library without the `lib` prefix. But it seems this is the case for some years now. If there are ways to check for the OS X version at compile time this may be needed to support older OS X versions. But I guess thats not needed for most users working with Nim anyway.