### PR TITLE
Borrow all: type some {.borrow.} = distinct other

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -476,6 +476,7 @@ type
                       # before this is determined, we'll consider them to be a
                       # wildcard type.
     tfHasAsgn         # type has overloaded assignment operator
+    tfBorrowAll       # distinct type borrows all procs
     tfBorrowDot       # distinct type borrows '.'
     tfTriggersCompileTime # uses the NimNode type which make the proc
                           # implicitly '.compiletime'

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -545,11 +545,17 @@ proc pragmaLocks(c: PContext, it: PNode): TLockLevel =
         result = TLockLevel(x)
 
 proc typeBorrow(sym: PSym, n: PNode) =
-  if n.kind == nkExprColonExpr:
+  if n.kind == nkIdent:
+    incl(sym.typ.flags, tfBorrowAll)
+  elif n.kind == nkExprColonExpr:
     let it = n.sons[1]
-    if it.kind != nkAccQuoted:
+    if it.kind == nkAccQuoted:
+      incl(sym.typ.flags, tfBorrowDot)
+    else:
       localError(n.info, "a type can only borrow `.` for now")
-  incl(sym.typ.flags, tfBorrowDot)
+  else:
+    localError(n.info,
+               "expected 'borrow' or 'borrow: `.`', but found '" & $n & "'")
 
 proc markCompilerProc(s: PSym) =
   makeExternExport(s, "$1", s.info)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -341,12 +341,34 @@ proc tryDeref(n: PNode): PNode =
   result.typ = n.typ.skipTypes(abstractInst).sons[0]
   result.addSon(n)
 
+proc canBorrowAll(n: PNode): bool {.inline.} =
+  result = n.len >= 2 and (let t = n[1].typ;
+    t != nil and (let st = t.skipTypes({tyGenericInst});
+    st.kind == tyDistinct and tfBorrowAll in st.flags))
+
+proc tryUnwrapDistinct(n: PNode): PNode =
+  result = newNodeI(nkHiddenStdConv, n.info)
+  result.typ = n.typ.skipTypes({tyGenericInst}).sons[0]
+  result.addSon(emptyNode)
+  result.addSon(n)
+
 proc semOverloadedCall(c: PContext, n, nOrig: PNode,
                        filter: TSymKinds): PNode =
   var errors: CandidateErrors
 
   var r = resolveOverloads(c, n, nOrig, filter, errors)
   if r.state == csMatch: result = semResolvedCall(c, n, r)
+  elif canBorrowAll(n):
+    # try to unwrap distinct on the first argument and then try overloading
+    # resolution again:
+    let prevArg = n.sons[1]
+    n.sons[1] = n.sons[1].tryUnwrapDistinct
+    var r = resolveOverloads(c, n, nOrig, filter, errors)
+    if r.state == csMatch: result = semResolvedCall(c, n, r)
+    else:
+      # restore distinct for a better error message:
+      n.sons[1] = prevArg
+      notFoundError(c, n, errors)
   elif experimentalMode(c) and canDeref(n):
     # try to deref the first argument and then try overloading resolution again:
     n.sons[1] = n.sons[1].tryDeref

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1074,7 +1074,8 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
     ty = n.sons[0].typ
     return nil
   ty = skipTypes(ty, {tyGenericInst, tyVar, tyPtr, tyRef})
-  while tfBorrowDot in ty.flags: ty = ty.skipTypes({tyDistinct})
+  while {tfBorrowAll, tfBorrowDot} * ty.flags != {}:
+    ty = ty.skipTypes({tyDistinct})
   var check: PNode = nil
   if ty.kind == tyObject:
     while true:

--- a/tests/borrow/tborrowall.nim
+++ b/tests/borrow/tborrowall.nim
@@ -1,0 +1,37 @@
+discard """
+  output: "1000
+magic string
+magic some string
+Magic magic string
+10
+some string
+some some string
+some magic string"
+"""
+
+# test the new borrow all feature:
+
+type
+  SomeString = string
+  MagicString {.borrow.} = distinct string
+
+proc magic(s: MagicString): MagicString = MagicString("Magic " & s.string)
+proc magic(s: string): string = "magic " & s
+proc magic(i: int): int = 999 + i
+
+proc some(s: string): string = "some " & s
+proc some(i: int): int = 9 + i
+
+let aString = "string"
+let someString = "some string"
+let magicString = MagicString("magic string")
+
+echo 1.magic
+echo aString.magic
+echo someString.magic
+echo magicString.magic
+
+echo 1.some
+echo aString.some
+echo someString.some
+echo magicString.some


### PR DESCRIPTION
This introduces new powerful language capability of defining distinct types that borrow all procs from their supertype. Previously one could only borrow `.` operator with `{.borrow:`.`}` or explicitly borrow selected proc marking them with `{.borrow.}` pragma.

Using distinct type with `{.borrow.}` acts like inheritance for any type, not just object types, extending overloading, so when no match is found with 1st arg of original distinct type then overloading is re-run with 1st arg implicitly casted to distinct type's supertype, eg.:

``` nim
type PinCode {.borrow.} = distinct int
proc `$`(i: PinCode): string = "******"
let code = 1111*1111
let pinCode = PinCode(111*111)
echo code    #-> 1234321
echo pinCode #-> ******
```
