### PR TITLE
Add serach for libssl.so without version suffix.

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -26,7 +26,7 @@ when useWinVersion:
   from winlean import SocketHandle
 else:
   const
-    versions = "(.10|.1.0.1|.1.0.0|.0.9.9|.0.9.8)"
+    versions = "(|.10|.1.0.1|.1.0.0|.0.9.9|.0.9.8)"
   when defined(macosx):
     const
       DLLSSLName = "libssl" & versions & ".dylib"


### PR DESCRIPTION
Currently Nim search only for `libcrypto.so(.10|.1.0.1|.1.0.0|.0.9.9|.0.9.8)` . On gentoo with installed libressl there is created `libssl.so.35.0.0` and `libcrypto.so.35.0.0` with symlinks from `libssl.so` and `libcrypto.so`.