### PR TITLE
fixes #3498

### DIFF
--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -38,7 +38,8 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     if s.owner.id == c.owner.id:
       if s.kind == skParam and sfGenSym notin s.flags:
         handleParam actual.sons[s.position]
-      elif s.kind == skGenericParam:
+      elif s.kind == skGenericParam or
+           s.kind == skType and s.typ != nil and s.typ.kind == tyGenericParam:
         handleParam actual.sons[s.owner.typ.len + s.position - 1]
       else:
         internalAssert sfGenSym in s.flags

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -228,10 +228,7 @@ proc semTemplSymbol(c: PContext, n: PNode, s: PSym): PNode =
   of skParam:
     result = n
   of skType:
-    if (s.typ != nil) and (s.typ.kind != tyGenericParam):
-      result = newSymNodeTypeDesc(s, n.info)
-    else:
-      result = n
+    result = newSymNodeTypeDesc(s, n.info)
   else:
     result = newSymNode(s, n.info)
 

--- a/tests/generics/tgenerictmpl.nim
+++ b/tests/generics/tgenerictmpl.nim
@@ -1,12 +1,21 @@
+discard """
+  output: '''0
+123'''
+"""
 
-template tmp[T](x: var seq[T]) =
-  #var yz: T  # XXX doesn't work yet
+# bug #3498
+
+template defaultOf[T](t: T): expr = (var d: T; d)
+
+echo defaultOf(1) #<- excpected 0
+
+# assignment using template
+
+template tassign[T](x: var seq[T]) =
   x = @[1, 2, 3]
 
-macro tmp2[T](x: var seq[T]): stmt =
-  nil
-
 var y: seq[int]
-tmp(y)
-tmp(y)
-echo y.repr
+tassign(y) #<- x is expected = @[1, 2, 3]
+tassign(y)
+
+echo y[0], y[1], y[2]


### PR DESCRIPTION
Previously it was not possible to use template arguments in template body as
the symbols were not resolved correctly leading to Error: undeclared
identifier: 'XX', eg.:

   template defaultOf[T](t: T): expr = (var d: T; d)
   echo defaultOf(1) #<- invalid identifier, but should output 0