### PR TITLE
Patch/smaller build.sh using trace

### DIFF
--- a/tools/niminst/buildsh.tmpl
+++ b/tools/niminst/buildsh.tmpl
@@ -18,7 +18,7 @@ do
       break;
       ;;
     -*)
-      echo "Error: Unknown option: $1" >&2
+      echo 2>&1 "Error: Unknown option: $1" >&2
       exit 1
       ;;
     *)  # No more options
@@ -94,7 +94,7 @@ case $uos in
     myos="haiku"
     ;;
   *) 
-    echo "Error: unknown operating system: $uos"
+    echo 2>&1 "Error: unknown operating system: $uos"
     exit 1
     ;;
 esac
@@ -119,7 +119,7 @@ case $ucpu in
   *arm*|*armv6l* )
     mycpu="arm" ;;
   *) 
-    echo "Error: unknown processor: $ucpu"
+    echo 2>&1 "Error: unknown processor: $ucpu"
     exit 1
     ;;
 esac
@@ -143,14 +143,14 @@ case $myos in
     ;;
 #    end for
   *)
-    echo "Error: no C code generated for: [$myos: $mycpu]"
+    echo 2>&1 "Error: no C code generated for: [$myos: $mycpu]"
     exit 1
     ;;
   esac
   ;;
 #  end for
 *) 
-  echo "Error: no C code generated for: [$myos: $mycpu]"
+  echo 2>&1 "Error: no C code generated for: [$myos: $mycpu]"
   exit 1
   ;;
 esac

--- a/tools/niminst/buildsh.tmpl
+++ b/tools/niminst/buildsh.tmpl
@@ -31,6 +31,7 @@ CC="gcc"
 LINKER="gcc"
 COMP_FLAGS="?{c.ccompiler.flags}$extraBuildArgs"
 LINK_FLAGS="?{c.linker.flags}"
+PS4=""
 #  add(result, "# platform detection\n")
 ucpu=`uname -m`
 uos=`uname`
@@ -131,14 +132,13 @@ case $myos in
   case $mycpu in
 #    for cpuA in 1..c.cpus.len:
   ?{c.cpus[cpuA-1]})
+    set -x
 #      var linkCmd = ""
 #      for ff in items(c.cfiles[osA][cpuA]):
 #        let f = ff.toUnix
-    echo "$CC $COMP_FLAGS -Ic_code -c ?{f} -o ?{changeFileExt(f, "o")}"
     $CC $COMP_FLAGS -Ic_code -c ?{f} -o ?{changeFileExt(f, "o")}
 #        add(linkCmd, " \\\n" & changeFileExt(f, "o"))
 #      end for
-    echo "$LINKER -o ?{"$binDir/" & toLower(c.name)} ?linkCmd $LINK_FLAGS"
     $LINKER -o ?{"$binDir/" & toLower(c.name)} ?linkCmd $LINK_FLAGS
     ;;
 #    end for
@@ -155,4 +155,4 @@ case $myos in
   ;;
 esac
 
-echo "SUCCESS"
+: SUCCESS


### PR DESCRIPTION
Rather than issuing echo "cmd..." then cmd... itself, we enable shell trace
facility via set -x, which is POSIX shell standard command and is compatible
with all UNIX shells.

This effectively cuts build.sh size twice, since we don't need to double stuff
there, also making it human readable.

We are also setting PS4 (trace prefix) to none, instead final echo "SUCCESS",
we issue : SUCCESS command which outputs its contents in trace.