### PR TITLE
Install stdlib.nimble in lib for nimscript fix

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -89,6 +89,7 @@ Files: "web/*.txt"
 Files: "lib/nimbase.h"
 Files: "lib/*.nim"
 Files: "lib/*.cfg"
+Files: "lib/*.nimble"
 
 Files: "lib/system/*.nim"
 Files: "lib/core/*.nim"


### PR DESCRIPTION
Without stdlib.nimble in libs directory Nimscript is not work properly. I.e. switch is not working and maybe other things.

Faced with problem: if i use "nim c file.nim" there is no nimscript effects. But if i use "nim_working_copy/bin/nim c file.nim" all works fine.

So, i found that stdlib.nimble is needed in lib directory for nimscript.

Maybe lib/*.nimble is excessive. Or maybe there is more deep error why .nimble file is needed in lib. But now nimscript works fine for me.