### PR TITLE
Fixed issue 3513: wrong setupQuery realization

### DIFF
--- a/lib/impure/db_postgres.nim
+++ b/lib/impure/db_postgres.nim
@@ -167,11 +167,7 @@ proc newRow(L: int): Row =
 
 proc setupQuery(db: DbConn, query: SqlQuery,
                 args: varargs[string]): PPGresult =
-  # s is a dummy unique id str for each setupQuery query
-  let s = "setupQuery_Query_" & string(query)
-  var res = pqprepare(db, s, dbFormat(query, args), 0, nil)
-  result = pqexecPrepared(db, s, 0, nil,
-                        nil, nil, 0)
+  result = pqexec(db, dbFormat(query, args))
   if pqResultStatus(result) != PGRES_TUPLES_OK: dbError(db)
 
 proc setupQuery(db: DbConn, stmtName: SqlPrepared,

--- a/tests/untestable/tpostgres.nim
+++ b/tests/untestable/tpostgres.nim
@@ -9,5 +9,7 @@ let name = "Dom"
 db.exec(sql"INSERT INTO myTable (id, name) VALUES (0, ?)",
         name)
 doAssert db.getValue(sql"SELECT name FROM myTable") == name
+# Check issue #3513
+doAssert db.getValue(sql"SELECT name FROM myTable") == name
 
 db.close()


### PR DESCRIPTION
The problem #3513 was in wrong `setupQuery` realization: we can't call the same query twice