### PR TITLE
Fix osproc.close

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -937,9 +937,10 @@ elif not defined(useNimRtl):
     if p.inStream != nil: close(p.inStream)
     if p.outStream != nil: close(p.outStream)
     if p.errStream != nil: close(p.errStream)
-    discard close(p.inHandle)
-    discard close(p.outHandle)
-    discard close(p.errHandle)
+    if poParentStreams notin p.options:
+      discard close(p.inHandle)
+      discard close(p.outHandle)
+      discard close(p.errHandle)
 
   proc suspend(p: Process) =
     if kill(p.id, SIGSTOP) != 0'i32: raiseOsError(osLastError())


### PR DESCRIPTION
When `startPorcess()` by `poParentStreams`, `close(p: Process)` will close stdin stdout stderr of parent process.

```nim
import os, osproc

if existsEnv("CHILD_ID"):
    echo "child process running"
else:
    putEnv("CHILD_ID", "1")
    var prc = startProcess(paramStr(0), options = {poParentStreams})
    echo "child exit ", waitForExit(prc)
    close(prc)              # This will close stdin stdout stderr of parent process!
    echo "!!! child close"  # Parent stdout has been closed !!!
    while true: sleep(1000)
```
