### PR TITLE
Add 'auto-decoration' to nimGetProcAddr

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -105,7 +105,12 @@ elif defined(windows) or defined(dos):
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
     result = getProcAddress(cast[THINSTANCE](lib), name)
-    if result == nil: procAddrError(name)
+    if result != nil: return
+    for i in countup(0, 50):
+      var decorated = "_" & $name & "@" & $(i * 4)
+      result = getProcAddress(cast[THINSTANCE](lib), cstring(decorated))
+      if result != nil: return
+    procAddrError(name)
 
 else:
   {.error: "no implementation for dyncalls".}


### PR DESCRIPTION
Maintainers of win32 DLLs sometimes opt to put "decorated" function
names into the DLL's symbol table.  (Google "stdcall name
decoration").  To pull a function pointer out of a DLL like this, you
have to provide the decorated version of the function's name.  This is
painful for the authors of NIM wrappers: they have to manually add
weird punctuation to their 'importc' strings, and to make matters
worse, they have to do this conditionally only on win32.

This commit adds 'auto-decoration' to nimGetProcAddr.  This function
probes the DLL for the undecorated name, and if it doesn't find it, it
adds decoration and tries again.  This makes it so that the author of
the wrapper doesn't have to worry about it.