### PR TITLE
Add 'auto-decoration' to nimGetProcAddr

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -105,7 +105,12 @@ elif defined(windows) or defined(dos):
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
     result = getProcAddress(cast[THINSTANCE](lib), name)
-    if result == nil: procAddrError(name)
+    if result != nil: return
+    for i in countup(0, 50):
+      var decorated = "_" & $name & "@" & $(i * 4)
+      result = getProcAddress(cast[THINSTANCE](lib), cstring(decorated))
+      if result != nil: return
+    procAddrError(name)
 
 else:
   {.error: "no implementation for dyncalls".}


### PR DESCRIPTION
Maintainers of win32 DLLs can opt to provide libraries with
'decorated' function names (Google "stdcall name decoration").  To
pull a function pointer out of one of these DLLs, you have to pass a
decorated name to getProcAddress.  This is painful for the authors
of NIM DLL wrappers - they have to pass manually-decorated strings
to "importc", but only on win32.

This commit adds auto-decoration to nimGetProcAddress.  This function
will probe the DLL for the undecorated name, and if that fails, it
will automatically add decoration and try again.  That way, the author
of the wrapper doesn't have to deal with it.