### PR TITLE
Fix loop index bug in scan for a[s] in b[s..s+len2-1].

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1281,7 +1281,7 @@ proc editDistance*(a, b: string): int {.noSideEffect,
 
   # another special case:
   if len1 == 1:
-    for j in s..len2-1:
+    for j in s..s+len2-1:
       if a[s] == b[j]: return len2 - 1
     return len2
 

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -78,6 +78,7 @@ assert(editDistance("prefix__hallo_suffix", "prefix__ha_suffix") == 3)
 assert(editDistance("prefix__hallo_suffix", "prefix") == 14)
 assert(editDistance("prefix__hallo_suffix", "suffix") == 14)
 assert(editDistance("prefix__hallo_suffix", "prefix__hao_suffix") == 2)
+assert(editDistance("main", "malign") == 2)
 
 assert "/1/2/3".rfind('/') == 4
 assert "/1/2/3".rfind('/', 1) == 0


### PR DESCRIPTION
a, b must both be indexed starting from s after the common
prefix "strip" phase.  This resolves issue 3477:
  https://github.com/nim-lang/Nim/issues/3477