### PR TITLE
Fixed SIGSEGV on wrong slurp usage

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1733,8 +1733,6 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   of mEcho: genEcho(p, e[1].skipConv)
   of mArrToSeq: genArrToSeq(p, e, d)
   of mNLen..mNError, mSlurp..mQuoteAst:
-    echo "from here ", p.prc.name.s, " ", p.prc.info
-    writestacktrace()
     localError(e.info, errXMustBeCompileTime, e.sons[0].sym.name.s)
   of mSpawn:
     let n = lowerings.wrapProcForSpawn(p.module.module, e, e.typ, nil, nil)


### PR DESCRIPTION
If ``slurp`` is used like this:
```nimrod
let s = slurp"test.txt"
```
, the compiler fails with stacktrace:
```
Traceback (most recent call last)
nim.nim(107)             nim
nim.nim(71)              handleCmdLine
main.nim(251)            mainCommand
main.nim(63)             commandCompileToC
modules.nim(221)         compileProject
modules.nim(169)         compileModule
passes.nim(203)          processModule
passes.nim(137)          processTopLevelStmt
cgen.nim(1217)           myProcess
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2065)       expr
ccgstmts.nim(502)        genBlock
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2069)       expr
ccgstmts.nim(313)        genIf
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2109)       expr
ccgstmts.nim(907)        genTry
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2068)       expr
ccgstmts.nim(1116)       genStmts
ccgexprs.nim(2090)       expr
ccgstmts.nim(259)        genVarStmt
ccgstmts.nim(242)        genSingleVar
ccgstmts.nim(86)         loadInto
ccgexprs.nim(2037)       expr
ccgexprs.nim(1736)       genMagicExpr
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
FAILURE
```
when it tries to print some debug information. But when debug output is removed, it prints normal message:
```
config_test.nim(10, 23) Error: 'slurp' can only be used in compile-time context
FAILURE
```