### PR TITLE
validateUtf8: catch overlong ascii

### DIFF
--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -114,6 +114,7 @@ proc validateUtf8*(s: string): int =
     if ord(s[i]) <=% 127:
       inc(i)
     elif ord(s[i]) shr 5 == 0b110:
+      if ord(s[i]) < 0xc2: return i # Catch overlong ascii representations.
       if i+1 < L and ord(s[i+1]) shr 6 == 0b10: inc(i, 2)
       else: return i
     elif ord(s[i]) shr 4 == 0b1110:


### PR DESCRIPTION
unicode.validateUtf8() currently does not check for overlong ASCII representations, which start with 0xc0 or 0xc1 and are longer than neccessary

They are illegal according to the standard.

This introduces a simple check if the rune starts with co or c1.