### PR TITLE
Print out more detailed error messages when compilation fails

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -68,7 +68,9 @@ when defined(posix):
 
   proc nimLoadLibrary(path: string): LibHandle =
     result = dlopen(path, RTLD_NOW)
-    #c_fprintf(c_stdout, "%s\n", dlerror())
+    let error = dlerror()
+    if error != nil:
+      c_fprintf(c_stdout, "%s\n", error)
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
     result = dlsym(lib, name)


### PR DESCRIPTION
Make Nim give more detailed error messages when compilation fails. This is related to the comment about needing to uncomment `lib/system/dyncalls.nim` to get the error from the compiler:
https://github.com/nim-lang/Nim/issues/2408 . I ran into the same issue while trying to write a wrapper for a C library and that detailed error message helped me figure out quickly what I need to add. 

Unfortunately, I don't run windows so this pull request won't have any effect there. The docs for getting the error message are here: https://msdn.microsoft.com/en-us/library/windows/desktop/ms680582(v=vs.85).aspx 

I'm not really sure how to test this, so any pointers there would be welcome!