### PR TITLE
AsyncHttpClient extends RootObj to be extendable

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -598,7 +598,7 @@ proc generateHeaders(r: Uri, httpMethod: string,
   add(result, "\c\L")
 
 type
-  AsyncHttpClient* = ref object
+  AsyncHttpClient* = ref object of RootObj
     socket: AsyncSocket
     connected: bool
     currentURL: Uri ## Where we are currently connected.


### PR DESCRIPTION
Simple patch that makes AsyncHttpClient extend RootObj so you can extend it for creating custom clients.

