### PR TITLE
Fixed getAddrInfo on android

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -207,7 +207,8 @@ proc getAddrInfo*(address: string, port: Port, domain: Domain = AF_INET,
   # FreeBSD doesn't support AI_V4MAPPED but defines the macro.
   # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198092
   when not defined(freebsd) or defined(openbsd):
-    hints.ai_flags = AI_V4MAPPED
+    if domain == AF_INET6:
+      hints.ai_flags = AI_V4MAPPED
   var gaiResult = getaddrinfo(address, $port, addr(hints), result)
   if gaiResult != 0'i32:
     when useWinVersion:


### PR DESCRIPTION
According to `man getaddrinfo`, `AI_V4MAPPED` should be passed along with `AF_INET6` `ai_family`. I suppose invalid use of `AI_V4MAPPED` may lead to platform-dependant behaviour. E.g. on Android `getaddrinfo` would just fail.