### PR TITLE
macros.getType: add missing enum name for enumTy

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -127,6 +127,7 @@ proc mapTypeToAst(t: PType, info: TLineInfo; allowRecursion=false): PNode =
       result = atomicType(t.sym.name.s)
   of tyEnum:
     result = newNodeIT(nkEnumTy, info, t)
+    result.add newSymNode(t.sym)
     result.add copyTree(t.n)
   of tyTuple: result = mapTypeToBracket("tuple", t, info)
   of tySet: result = mapTypeToBracket("set", t, info)

--- a/tests/vm/tgettypeenum.nim
+++ b/tests/vm/tgettypeenum.nim
@@ -1,0 +1,16 @@
+discard """
+  output: '''PGO'''
+"""
+
+import macros
+
+type
+  PGO* = enum
+    PORTRAIT, LANDSCAPE
+  
+macro mixer(arg: typed): stmt =
+  let a = getType(arg)[0]
+  result = parseExpr("echo \"" & $a & "\"")
+  
+mixer(PORTRAIT)
+


### PR DESCRIPTION
```nimrod
type
  PGO* = enum
    PORTRAIT, LANDSCAPE
```

```text
BracketExpr
  Sym "typeDesc"
  EnumTy
    Sym "PGO"      <----- add this
    EnumTy
      Sym "PORTRAIT"
      Sym "LANDSCAPE"
```

improve consistency, because macros.getType return object name for nnkObjectTy, and also very valuable for library author who doing a lot of type interrogation.

imagine something like this:
```nimrod
proc abc(a: int, b = PORTRAIT) = discard
```

inside macro, both 'b' and 'PORTRAIT' cannot track back to PGO, but now, it can