### PR TITLE
Fixing mysql_field.

### DIFF
--- a/lib/wrappers/mysql.nim
+++ b/lib/wrappers/mysql.nim
@@ -418,6 +418,7 @@ type
     decimals*: cuint          # Number of decimals in field
     charsetnr*: cuint         # Character set
     ftype*: Enum_field_types  # Type of field. See mysql_com.h for types
+    extension*: pointer
 
   FIELD* = St_mysql_field
   PFIELD* = ptr FIELD


### PR DESCRIPTION
FIELD had the wrong size which made mysql.fetch_fields() useless.