### PR TITLE
Fix nativesockets compilation on OpenBSD

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -206,7 +206,7 @@ proc getAddrInfo*(address: string, port: Port, domain: Domain = AF_INET,
   # OpenBSD doesn't support AI_V4MAPPED and doesn't define the macro AI_V4MAPPED.
   # FreeBSD doesn't support AI_V4MAPPED but defines the macro.
   # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198092
-  when not defined(freebsd) or defined(openbsd):
+  when not defined(freebsd) and not defined(openbsd) and not defined(netbsd):
     if domain == AF_INET6:
       hints.ai_flags = AI_V4MAPPED
   var gaiResult = getaddrinfo(address, $port, addr(hints), result)


### PR DESCRIPTION
Based on the comment right above this was just a mistake for OpenBSD. I checked NetBSD and it also doesn't compile with `AI_V4MAPPED`.