### PR TITLE
Allow more switches to be set in nims

### DIFF
--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -115,7 +115,7 @@ proc setupVM*(module: PSym; scriptName: string): PEvalContext =
   cbconf getCommand:
     setResult(a, options.command)
   cbconf switch:
-    processSwitch(a.getString 0, a.getString 1, passPP, unknownLineInfo())
+    processCommand(a.getString(0) & ":" & a.getString(1), passPP)
 
 
 proc runNimScript*(scriptName: string) =


### PR DESCRIPTION
Allows the following in nims file:
```nim
switch("warning[LockLevel]", "off")
```