### PR TITLE
Fix CountTableRef#getOrDefault (#3702)

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -887,7 +887,7 @@ proc mget*[A](t: CountTableRef[A], key: A): var int {.deprecated.} =
   result = t[][key]
 
 proc getOrDefault*[A](t: CountTableRef[A], key: A): int =
-  getOrDefaultImpl(t, key)
+  result = t[].getOrDefault(key)
 
 proc hasKey*[A](t: CountTableRef[A], key: A): bool =
   ## returns true iff `key` is in the table `t`.
@@ -1028,3 +1028,15 @@ when isMainModule:
   assert(merged["foo"] == 5)
   assert(merged["bar"] == 3)
   assert(merged["baz"] == 14)
+
+  block:
+    const testKey = "TESTKEY"
+    let t: CountTableRef[string] = newCountTable[string]()
+
+    # Before, does not compile with error message:
+    #test_counttable.nim(7, 43) template/generic instantiation from here
+    #lib/pure/collections/tables.nim(117, 21) template/generic instantiation from here
+    #lib/pure/collections/tableimpl.nim(32, 27) Error: undeclared field: 'hcode
+    doAssert 0 == t.getOrDefault(testKey)
+    t.inc(testKey,3)
+    doAssert 3 == t.getOrDefault(testKey)


### PR DESCRIPTION
Fixes #3702  with CountTableRef and getOrDefault:
```{nimrod}
import tables

proc main() =
  const testKey = "TESTKEY"
  let t: CountTableRef[string] = newCountTable[string]()

  # Before, does not compile with error message:
  #test_counttable.nim(7, 43) template/generic instantiation from here
  #lib/pure/collections/tables.nim(117, 21) template/generic instantiation from here
  #lib/pure/collections/tableimpl.nim(32, 27) Error: undeclared field: 'hcode'

  echo "Count of " & testKey & " is " & $t.getOrDefault(testKey)
  t.inc(testKey,3)
  echo "Count of " & testKey & " is " & $t.getOrDefault(testKey)

when isMainModule:
  main()
```

Previously, `getOrDefault` for CountTableRef objects was calling the
`getOrDefaultImpl` template, which used the t.data.hcode object -
assuming a Table or similar object.  Because CountTableRef didn't have
an hcode in its data tuples, this wouldn't compile.  Changed to call 
`CountTable#getOrDefault`.