### PR TITLE
Added fix and test for bug #3710 and fix to renderer.nim

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -447,7 +447,7 @@ proc lsub(n: PNode): int =
         len("if_:_")
   of nkElifExpr: result = lsons(n) + len("_elif_:_")
   of nkElseExpr: result = lsub(n.sons[0]) + len("_else:_") # type descriptions
-  of nkTypeOfExpr: result = (if n.len > 0: lsub(n.sons[0]) else: 0)+len("type_")
+  of nkTypeOfExpr: result = (if n.len > 0: lsub(n.sons[0]) else: 0)+len("type__")
   of nkRefTy: result = (if n.len > 0: lsub(n.sons[0])+1 else: 0) + len("ref")
   of nkPtrTy: result = (if n.len > 0: lsub(n.sons[0])+1 else: 0) + len("ptr")
   of nkVarTy: result = (if n.len > 0: lsub(n.sons[0])+1 else: 0) + len("var")
@@ -1039,8 +1039,10 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     putWithSpace(g, tkColon, ":")
     gsub(g, n.sons[0])
   of nkTypeOfExpr:
-    putWithSpace(g, tkType, "type")
+    put(g, tkType, "type")
+    put(g, tkParLe, "(")
     if n.len > 0: gsub(g, n.sons[0])
+    put(g, tkParRi, ")")
   of nkRefTy:
     if sonsLen(n) > 0:
       putWithSpace(g, tkRef, "ref")

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1060,7 +1060,7 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
     of tyTypeParamsHolders:
       return readTypeParameter(c, ty, i, n.info)
     of tyObject, tyTuple:
-      if ty.n != nil and ty.n.kind == nkRecList:
+      if (not isTypeExpr(n.sons[0])) and ty.n != nil and ty.n.kind == nkRecList:
         for field in ty.n:
           if field.sym.name == i:
             n.typ = newTypeWithSons(c, tyFieldAccessor, @[ty, field.sym.typ])

--- a/tests/types/ttypeop.nim
+++ b/tests/types/ttypeop.nim
@@ -1,0 +1,18 @@
+discard """
+  output: '''Thing
+Thing'''
+"""
+
+# Test of type() operator
+# Bug #3710
+
+import typetraits
+
+type Thing = ref object
+    name: string
+
+var x = new(Thing)
+var y = type(x).name
+echo y
+var z = x.type.name
+echo z


### PR DESCRIPTION
This fixes bug #3710.

All tests pass in my build.

But I'm not super confident about the fix, so someone more familiar with the compiler should review it.

The fix in renderer.nim should provide clearer error messages for similar errors in the future. Previously the code `type(x).name`, i.e. the AST `nkDotExpr(nkTypeOfExpr("x"), "name")` would be rendered as `type x.name`. This fix adds parens so it renders back as `type(x).name`. It seems to me that this is more unambiguous and more consistent with prevelant coding style. If this fix is not desired I can create a new pull request without it.