### PR TITLE
Have nim --version always show the current year

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -27,7 +27,7 @@ bootSwitch(usedNoGC, defined(nogc), "--gc:none")
 
 import
   os, msgs, options, nversion, condsyms, strutils, extccomp, platform, lists,
-  wordrecg, parseutils, nimblecmd, idents, parseopt
+  wordrecg, parseutils, nimblecmd, idents, parseopt, times
 
 # but some have deps to imported modules. Yay.
 bootSwitch(usedTinyC, hasTinyCBackend, "-d:tinyc")
@@ -51,9 +51,10 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo)
 
 # implementation
 
-const
+var
   HelpMessage = "Nim Compiler Version $1 (" & CompileDate & ") [$2: $3]\n" &
-      "Copyright (c) 2006-2015 by Andreas Rumpf\n"
+      "Copyright (c) 2006-" & getTime().timeToTimeInfo().format("yyyy") &
+      " by Andreas Rumpf\n"
 
 const
   Usage = slurp"doc/basicopt.txt".replace("//", "")


### PR DESCRIPTION
before:

```console
$ nim --version
Nim Compiler Version 0.13.0 (2016-01-18) [Linux: amd64]
Copyright (c) 2006-2015 by Andreas Rumpf

git hash: a121c3f9eb2a348b9d6ae03ffd01aab26a238c30
active boot switches: -d:release
```

after:

```console
$ nim --version
Nim Compiler Version 0.13.0 (2016-01-18) [Linux: amd64]
Copyright (c) 2006-2016 by Andreas Rumpf

git hash: 91adc84cf3cebe9f14d84aea639e46bae4b3a5dc
active boot switches: -d:release
```