### PR TITLE
Revert "Fixed unicode handling in JS. Fixes #3714."

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -163,26 +163,8 @@ proc mangleName(s: PSym): Rope =
     add(result, rope(s.id))
     s.loc.r = result
 
-proc escapeJSString(s: string): string =
-  result = newStringOfCap(s.len + s.len shr 2)
-  result.add("\"")
-  for c in items(s):
-    case c
-    of '\l': result.add("\\n")
-    of '\r': result.add("\\r")
-    of '\t': result.add("\\t")
-    of '\b': result.add("\\b")
-    of '\a': result.add("\\a")
-    of '\e': result.add("\\e")
-    of '\v': result.add("\\v")
-    of '\\': result.add("\\\\")
-    of '\'': result.add("\\'")
-    of '\"': result.add("\\\"")
-    else: add(result, c)
-  result.add("\"")
-
 proc makeJSString(s: string): Rope =
-  (if s.isNil: "null".rope else: escapeJSString(s).rope)
+  (if s.isNil: "null".rope else: strutils.escape(s).rope)
 
 include jstypes
 

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -166,33 +166,14 @@ proc SetConstr() {.varargs, asmNoStackFrame, compilerproc.} =
   """
 
 proc cstrToNimstr(c: cstring): string {.asmNoStackFrame, compilerproc.} =
-  {.emit: """
-  var ln = `c`.length;
-  var result = new Array(ln);
-  var r = 0;
-  for (var i = 0; i < ln; ++i) {
-    var ch = `c`.charCodeAt(i);
-
-    if (ch < 128) {
-      result[r] = ch;
+  asm """
+    var result = [];
+    for (var i = 0; i < `c`.length; ++i) {
+      result[i] = `c`.charCodeAt(i);
     }
-    else if((ch > 127) && (ch < 2048)) {
-      result[r] = (ch >> 6) | 192;
-      ++r;
-      result[r] = (ch & 63) | 128;
-    }
-    else {
-      result[r] = (ch >> 12) | 224;
-      ++r;
-      result[r] = ((ch >> 6) & 63) | 128;
-      ++r;
-      result[r] = (ch & 63) | 128;
-    }
-    ++r;
-  }
-  result[r] = 0; // terminating zero
-  return result;
-  """.}
+    result[result.length] = 0; // terminating zero
+    return result;
+  """
 
 proc toJSStr(s: string): cstring {.asmNoStackFrame, compilerproc.} =
   asm """


### PR DESCRIPTION
Reverts nim-lang/Nim#3733

Introduced problems with arbitrary byte string literals. Will try to fix it differently.