### PR TITLE
JS: Corrected shift operators. Cast ints like C does.

### DIFF
--- a/doc/tut2.txt
+++ b/doc/tut2.txt
@@ -1000,7 +1000,9 @@ JavaScript-compatible code you should remember the following:
 - ``addr`` and ``ptr`` have slightly different semantic meaning in JavaScript.
   It is recommended to avoid those if you're not sure how they are translated
   to JavaScript.
-- ``cast[T](x)`` in JavaScript is translated to ``(x)``.
+- ``cast[T](x)`` in JavaScript is translated to ``(x)``, except for casting
+  between signed/unsigned ints, in which case it behaves as static cast in
+  C language.
 - ``cstring`` in JavaScript means JavaScript string. It is a good practice to
   use ``cstring`` only when it is semantically appropriate. E.g. don't use
   ``cstring`` as a binary data buffer.

--- a/tests/misc/tints.nim
+++ b/tests/misc/tints.nim
@@ -23,24 +23,29 @@ template test(opr, a, b, c: expr): stmt {.immediate.} =
 
 test(`+`, 12'i8, -13'i16, -1'i16)
 test(`shl`, 0b11, 0b100, 0b110000)
-test(`shl`, 0b11'i32, 0b100'i64, 0b110000'i64)
+when not defined(js):
+  test(`shl`, 0b11'i32, 0b100'i64, 0b110000'i64)
 test(`shl`, 0b11'i32, 0b100'i32, 0b110000'i32)
 
 test(`or`, 0xf0f0'i16, 0x0d0d'i16, 0xfdfd'i16)
 test(`and`, 0xf0f0'i16, 0xfdfd'i16, 0xf0f0'i16)
 
-test(`shr`, 0xffffffffffffffff'i64, 0x4'i64, 0x0fffffffffffffff'i64)
+when not defined(js):
+  test(`shr`, 0xffffffffffffffff'i64, 0x4'i64, 0x0fffffffffffffff'i64)
 test(`shr`, 0xffff'i16, 0x4'i16, 0x0fff'i16)
 test(`shr`, 0xff'i8, 0x4'i8, 0x0f'i8)
 
-test(`shr`, 0xffffffff'i64, 0x4'i64, 0x0fffffff'i64)
+when not defined(js):
+  test(`shr`, 0xffffffff'i64, 0x4'i64, 0x0fffffff'i64)
 test(`shr`, 0xffffffff'i32, 0x4'i32, 0x0fffffff'i32)
 
-test(`shl`, 0xffffffffffffffff'i64, 0x4'i64, 0xfffffffffffffff0'i64)
+when not defined(js):
+  test(`shl`, 0xffffffffffffffff'i64, 0x4'i64, 0xfffffffffffffff0'i64)
 test(`shl`, 0xffff'i16, 0x4'i16, 0xfff0'i16)
 test(`shl`, 0xff'i8, 0x4'i8, 0xf0'i8)
 
-test(`shl`, 0xffffffff'i64, 0x4'i64, 0xffffffff0'i64)
+when not defined(js):
+  test(`shl`, 0xffffffff'i64, 0x4'i64, 0xffffffff0'i64)
 test(`shl`, 0xffffffff'i32, 0x4'i32, 0xfffffff0'i32)
 
 # bug #916
@@ -50,5 +55,27 @@ proc unc(a: float): float =
 echo int(unc(0.5)), " ", int(unc(-0.5))
 echo int(0.5), " ", int(-0.5)
 
-echo("Success") #OUT Success
+block: # Casts to uint
+  template testCast(fromValue: typed, toType: typed, expectedResult: typed) =
+    let src = fromValue
+    let dst = cast[toType](src)
+    if dst != expectedResult:
+      echo "Casting ", astToStr(fromValue), " to ", astToStr(toType), " = ", dst.int, " instead of ", astToStr(expectedResult)
+    doAssert(dst == expectedResult)
 
+  testCast(-1'i16, uint16, 0xffff'u16)
+  testCast(0xffff'u16, int16, -1'i16)
+
+  testCast(0xff'u16, uint8, 0xff'u8)
+  testCast(0xffff'u16, uint8, 0xff'u8)
+
+  testCast(-1'i16, uint32, 0xffffffff'u32)
+  testCast(0xffffffff'u32, int32, -1)
+
+  testCast(0xfffffffe'u32, int32, -2'i32)
+  testCast(0xffffff'u32, int16, -1'i32)
+
+  testCast(-5'i32, uint8, 251'u8)
+
+
+echo("Success") #OUT Success

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -220,7 +220,7 @@ proc jsTests(r: var TResults, cat: Category, options: string) =
                    "actiontable/tactiontable", "method/tmultim1",
                    "method/tmultim3", "method/tmultim4",
                    "varres/tvarres0", "varres/tvarres3", "varres/tvarres4",
-                   "varres/tvartup", "misc/tunsignedinc"]:
+                   "varres/tvartup", "misc/tints", "misc/tunsignedinc"]:
     test "tests/" & testfile & ".nim"
 
   for testfile in ["pure/strutils"]:


### PR DESCRIPTION
Also enabled previously failing tests and added some more.