### PR TITLE
Switch git clone URLs to HTTPS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,9 +39,9 @@ To build from source you will need:
 If you are on a fairly modern *nix system, the following steps should work:
 
 ```
-$ git clone git://github.com/nim-lang/Nim.git
+$ git clone https://github.com/nim-lang/Nim.git
 $ cd Nim
-$ git clone --depth 1 git://github.com/nim-lang/csources
+$ git clone --depth 1 https://github.com/nim-lang/csources
 $ cd csources && sh build.sh
 $ cd ..
 $ bin/nim c koch


### PR DESCRIPTION
GitHub recommends HTTPS for security reasons.