### PR TITLE
add udp support to asyncnet

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -90,6 +90,8 @@ type
     protocol: Protocol
   AsyncSocket* = ref AsyncSocketDesc
 
+  RecvFromResult = tuple[data: string, address: string, port: Port]
+
 {.deprecated: [PAsyncSocket: AsyncSocket].}
 
 proc newAsyncSocket*(fd: AsyncFD, domain: Domain = AF_INET,
@@ -268,6 +270,49 @@ proc recv*(socket: AsyncSocket, size: int,
     let read = readInto(addr result[0], size, socket, flags)
     result.setLen(read)
 
+proc recvFrom*(socket: AsyncSocket, size: int,
+    flags = {SocketFlag.SafeDisconn}): Future[RecvFromResult] =
+  ## Reads up to ``size`` bytes from a AsyncSocket. This is for DGRAM socket
+  ## types, like UDP, and thus does not support buffered sockets.
+
+  var retFuture = newFuture[RecvFromResult]()
+
+  var readBuffer = newString(size)
+  var sockAddress: SockAddr_in
+  var addrLen = sizeof(sockAddress).SockLen
+
+  proc cb(sock: AsyncFD): bool =
+    var nullpkt: RecvFromResult
+    result = true
+    let res = recvfrom(sock.SocketHandle, cstring(readBuffer),
+                 size.cint, 0, cast[ptr SockAddr](addr(sockAddress)), addr(addrLen))
+
+    if res < 0:
+      let lastError = osLastError()
+      if lastError.int32 notin {EINTR, EWOULDBLOCK, EAGAIN}:
+        if flags.isDisconnectionError(lastError):
+          retFuture.complete(nullpkt)
+        else:
+          retFuture.fail(newException(OSError, osErrorMsg(lastError)))
+      else:
+        result = false # We still want this callback to be called.
+
+    elif res == 0:
+      # Disconnected
+      retFuture.complete(nullpkt)
+
+    else:
+      var goodpkt: RecvFromResult
+      readBuffer.setLen(res)
+      goodpkt.data = readBuffer
+      goodpkt.address = $inet_ntoa(sockAddress.sin_addr)
+      goodpkt.port = nativesockets.ntohs(sockAddress.sin_port).Port
+      retFuture.complete(goodpkt)
+
+  addRead(socket.fd.AsyncFD, cb)
+
+  return retFuture
+
 proc send*(socket: AsyncSocket, data: string,
            flags = {SocketFlag.SafeDisconn}) {.async.} =
   ## Sends ``data`` to ``socket``. The returned future will complete once all
@@ -281,6 +326,31 @@ proc send*(socket: AsyncSocket, data: string,
       await sendPendingSslData(socket, flags)
   else:
     await send(socket.fd.AsyncFD, data, flags)
+
+proc sendTo*(sock: AsyncSocket, address: string, port: Port, data: string,
+  flags = 0'i32): int =
+  ## Sends ``data`` to a AF_INET sockaddr ``address``:``port``.
+  ## This is basically the same as net.sendTo, only for DGRAM sockets like
+  ## udp.
+  ##
+  ## Returns the number of bytes sent, or -1 on failure, in which case
+  ## errno is filled.
+
+  var aiList = getAddrInfo(address, port, AF_INET)
+  var success = false
+  var it = aiList
+
+  while it != nil:
+    result = sendto(sock.fd, cstring(data), data.len.cint, flags.cint,
+      it.ai_addr, it.ai_addrlen.SockLen)
+
+    if result != -1'i32:
+      success = true
+      break
+
+    it = it.ai_next
+
+  dealloc(aiList)
 
 proc acceptAddr*(socket: AsyncSocket, flags = {SocketFlag.SafeDisconn}):
       Future[tuple[address: string, client: AsyncSocket]] =


### PR DESCRIPTION
This commit allows async udp/dgram sockets to be used properly.

What was missing was the ability to send/receive to/from specific addresses on
the same socket, since udp is a stateless protocol;
so this adds `recvFrom` and `sendTo` respectively.
## 

This is nearly a verbatim copy of existing code, only amending the parameters and return values to support passing along address/port data.

Might well be that I missed some stylistic or other issues, please check it over and let me know what you think!
