### PR TITLE
IPv6 support for httpclient

### DIFF
--- a/httpclienttest.nim
+++ b/httpclienttest.nim
@@ -1,0 +1,9 @@
+# Small test program to test httpclient i.e. for IPv6
+
+from httpclient import downloadFile
+from os import existsEnv, getEnv, getAppFilename
+
+if not existsEnv("uri") or not existsEnv("dest"):
+  raise newException(OSError, "Usage: uri=X dest=Y " & getAppFilename())
+
+downloadFile(getEnv("uri"),getEnv("dest"))

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -415,8 +415,6 @@ proc request*(url: string, httpMethod: string, extraHeaders = "",
     add(headers, "Proxy-Authorization: basic " & auth & "\c\L")
   add(headers, extraHeaders)
   add(headers, "\c\L")
-  var s = newSocket()
-  if s == nil: raiseOSError(osLastError())
   var port = net.Port(80)
   if r.scheme == "https":
     when defined(ssl):
@@ -427,6 +425,8 @@ proc request*(url: string, httpMethod: string, extraHeaders = "",
                 "SSL support is not available. Cannot connect over SSL.")
   if r.port != "":
     port = net.Port(r.port.parseInt)
+  var s = newSocket()
+  if s == nil: raiseOSError(osLastError())
 
   if timeout == -1:
     s.connect(r.hostname, port)

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -50,16 +50,24 @@ proc add*(url: var Url, a: Url) {.deprecated.} =
 proc parseAuthority(authority: string, result: var Uri) =
   var i = 0
   var inPort = false
+  var inV6 = false
   while true:
     case authority[i]
+    of '[':
+      inV6 = true
     of '@':
       swap result.password, result.port
       result.port.setLen(0)
       swap result.username, result.hostname
       result.hostname.setLen(0)
       inPort = false
-    of ':':
+    of ']':
       inPort = true
+    of ':':
+      if inV6:
+        result.hostname.add(authority[i])
+      else:
+        inPort = true
     of '\0': break
     else:
       if inPort:

--- a/uritest.nim
+++ b/uritest.nim
@@ -1,0 +1,5 @@
+# parsing IPv6 addresses in host...
+
+import uri
+
+echo(parseUri("http://[1:2::3:::]/path/:/full/?of/muck#derp").hostname)


### PR DESCRIPTION
Calling getaddrinfo twice is bad, async http client would be better, but this is quick and easy, and at least functional.

I also fixed the uri library to parse IPv6 addresses properly (i.e. http://[1234::445:6]:80/etc)