### PR TITLE
Resolve "redefintion" errors, when using MSVC.

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -14,6 +14,9 @@
 
 import dynlib
 
+when defined(vcc):
+  {.passC: "-DWIN32_LEAN_AND_MEAN".}
+
 const
   useWinUnicode* = not defined(useWinAnsi)
 


### PR DESCRIPTION
Resolve redefinitions of winsock staff in Microsoft Visual Studio headers, using MSVC
Issue #3879