### PR TITLE
Allow likely(x) and unlikely(x) in all targets, fix #3882

### DIFF
--- a/tests/js/testlikely.nim
+++ b/tests/js/testlikely.nim
@@ -1,0 +1,12 @@
+discard """
+    output: '''likely occurrence
+unlikely occurrence'''
+"""
+
+if likely(true):
+    echo "likely occurrence"
+
+if unlikely 4 == 34:
+    echo "~~wrong branch taken~~"
+else:
+    echo "unlikely occurrence"

--- a/tests/system/testlikely.nim
+++ b/tests/system/testlikely.nim
@@ -1,0 +1,12 @@
+discard """
+    output: '''likely occurrence
+unlikely occurrence'''
+"""
+
+if likely(true):
+    echo "likely occurrence"
+
+if unlikely 4 == 34:
+    echo "~~wrong branch taken~~"
+else:
+    echo "unlikely occurrence"


### PR DESCRIPTION
Provides an alternative (no-op) implementation for `likely` and `unlikely` for targets that don't use compiler hints (i.e. the VM and JS targets).