### PR TITLE
Fixed NIM_THREADVAR definition in nimbase.h

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -91,10 +91,25 @@ __clang__
 #  define NIM_CONST  const
 #endif
 
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
-#  define NIM_THREADVAR __declspec(thread)
-#else
+/*
+  NIM_THREADVAR declaration based on
+  http://stackoverflow.com/questions/18298280/how-to-declare-a-variable-as-thread-local-portably
+*/
+#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
+#  define NIM_THREADVAR _Thread_local
+#elif defined _WIN32 && ( \
+       defined _MSC_VER || \
+       defined __ICL || \
+       defined __DMC__ || \
+       defined __BORLANDC__ )
+#  define NIM_THREADVAR __declspec(thread) 
+/* note that ICC (linux) and Clang are covered by __GNUC__ */
+#elif defined __GNUC__ || \
+       defined __SUNPRO_C || \
+       defined __xlC__
 #  define NIM_THREADVAR __thread
+#else
+#  error "Cannot define NIM_THREADVAR"
 #endif
 
 /* --------------- how int64 constants should be declared: ----------- */


### PR DESCRIPTION
Fixed issue #3889. The problem was that we declared TLS variable in VC style for all the compilers on windows. 

This PR is based on the solution described here: http://stackoverflow.com/questions/18298280/how-to-declare-a-variable-as-thread-local-portably