### PR TITLE
Don't expect all keys in hashsets to have $ defined

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -163,7 +163,11 @@ proc `[]`*[A](s: var HashSet[A], key: A): var A =
   var hc: Hash
   var index = rawGet(s, key, hc)
   if index >= 0: result = s.data[index].key
-  else: raise newException(KeyError, "key not found: " & $key)
+  else:
+    when compiles($key):
+      raise newException(KeyError, "key not found: " & $key)
+    else:
+      raise newException(KeyError, "key not found")
 
 proc mget*[A](s: var HashSet[A], key: A): var A {.deprecated.} =
   ## returns the element that is actually stored in 's' which has the same


### PR DESCRIPTION
Changed hashset's `[]` proc to use when compiles($key) like hashtable's. Fixes https://github.com/nim-lang/Nim/issues/3920