### PR TITLE
 Fixed an wrong example of the uri module doc.

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -255,13 +255,13 @@ proc `/`*(x: Uri, path: string): Uri =
   ## Examples:
   ##
   ## .. code-block::
-  ##   let foo = parseUri("http://example.com/foo/bar") / parseUri("/baz")
+  ##   let foo = parseUri("http://example.com/foo/bar") / "/baz"
   ##   assert foo.path == "/foo/bar/baz"
   ##
-  ##   let bar = parseUri("http://example.com/foo/bar") / parseUri("baz")
+  ##   let bar = parseUri("http://example.com/foo/bar") / "baz"
   ##   assert bar.path == "/foo/bar/baz"
   ##
-  ##   let bar = parseUri("http://example.com/foo/bar/") / parseUri("baz")
+  ##   let bar = parseUri("http://example.com/foo/bar/") / "baz"
   ##   assert bar.path == "/foo/bar/baz"
   result = x
   if result.path[result.path.len-1] == '/':


### PR DESCRIPTION
This is a small modification of the document.

`/` Implementation:
```
proc `/` (x: Uri; path: string): Uri {.raises: [], tags: [].}
```

However, Examples are connecting the Uri and Uri.
This examples does not work.