### PR TITLE
Removed unused import of 'os' module from module 'sets'

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -18,7 +18,7 @@
 ## that ``=`` performs a copy of the set.
 
 import
-  os, hashes, math
+  hashes, math
 
 {.pragma: myShallow.}
 when not defined(nimhygiene):


### PR DESCRIPTION
Due to import of `os` modules sets didn't compile for js target. It seems like os module is not used in sets module at all for now.