### PR TITLE
Support json null in %*

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -628,6 +628,9 @@ proc newJArray*(): JsonNode =
   result.kind = JArray
   result.elems = @[]
 
+const
+  null*: string = nil ## alias for ``nil``
+
 proc getStr*(n: JsonNode, default: string = ""): string =
   ## Retrieves the string value of a `JString JsonNode`.
   ##
@@ -678,6 +681,7 @@ proc getElems*(n: JsonNode, default: seq[JsonNode] = @[]): seq[JsonNode] =
 proc `%`*(s: string): JsonNode =
   ## Generic constructor for JSON data. Creates a new `JString JsonNode`.
   new(result)
+  if s.isNil: return
   result.kind = JString
   result.str = s
 
@@ -1310,3 +1314,6 @@ when isMainModule:
       }
     ]
   doAssert j3 == %[%{"name": %"John", "age": %30}, %{"name": %"Susan", "age": %31}]
+
+  var j4 = %*{"test": null}
+  doAssert j4 == %{"test": newJNull()}

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -628,9 +628,6 @@ proc newJArray*(): JsonNode =
   result.kind = JArray
   result.elems = @[]
 
-const
-  null*: string = nil ## alias for ``nil``
-
 proc getStr*(n: JsonNode, default: string = ""): string =
   ## Retrieves the string value of a `JString JsonNode`.
   ##
@@ -1315,5 +1312,5 @@ when isMainModule:
     ]
   doAssert j3 == %[%{"name": %"John", "age": %30}, %{"name": %"Susan", "age": %31}]
 
-  var j4 = %*{"test": null}
+  var j4 = %*{"test": nil}
   doAssert j4 == %{"test": newJNull()}


### PR DESCRIPTION
This is the nicest way I found to support `null` directly in `%*`. It's nice being able to directly paste json into Nim code, otherwise we could just use `nil`. This PR fixes that `nil` used to create a string `""`, which is now a `null`.