### PR TITLE
Fix for PHP function pointer implementation.

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1963,6 +1963,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       genInfixCall(p, n, r)
     else:
       genCall(p, n, r)
+  of nkClosure: gen(p, n[0], r)
   of nkCurly: genSetConstr(p, n, r)
   of nkBracket: genArrayConstr(p, n, r)
   of nkPar: genTupleConstr(p, n, r)


### PR DESCRIPTION
Using a procvar as parameter did not work. This fixes it.

@araq said that there could be done more (regarding LL and closure support).