### PR TITLE
Try to fix addr() ref and pointer for PHP

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -775,10 +775,17 @@ proc generateHeader(p: PProc, typ: PType): Rope =
         add(result, name)
         add(result, "_Idx")
     elif not (i == 1 and param.name.s == "this"):
-      if param.typ.skipTypes({tyGenericInst}).kind == tyVar:
+      let k = param.typ.skipTypes({tyGenericInst}).kind
+      if k in { tyVar, tyRef, tyPtr, tyPointer }:
         add(result, "&")
       add(result, "$")
       add(result, name)
+      # XXX I think something like this is needed for PHP to really support
+      # ptr "inside" strings and seq
+      #if mapType(param.typ) == etyBaseIndex:
+      #  add(result, ", $")
+      #  add(result, name)
+      #  add(result, "_Idx")
 
 const
   nodeKindsNeedNoCopy = {nkCharLit..nkInt64Lit, nkStrLit..nkTripleStrLit,
@@ -961,10 +968,12 @@ proc genArrayAccess(p: PProc, n: PNode, r: var TCompRes) =
     if n.sons[0].kind in nkCallKinds+{nkStrLit..nkTripleStrLit}:
       useMagic(p, "nimAt")
       if ty.kind in {tyString, tyCString}:
+        # XXX this needs to be more like substr($1,$2)
         r.res = "ord(nimAt($1, $2))" % [r.address, r.res]
       else:
         r.res = "nimAt($1, $2)" % [r.address, r.res]
     elif ty.kind in {tyString, tyCString}:
+      # XXX this needs to be more like substr($1,$2)
       r.res = "ord($1[$2])" % [r.address, r.res]
     else:
       r.res = "$1[$2]" % [r.address, r.res]


### PR DESCRIPTION
I spent some time to make the PHP backend compile this:

```nim
import strutils

proc foo(s: ptr string) =
  s[0] = 'y'

proc bar(s: ptr char) =
  s[] = 'z'

var s = "12345"
s[0]='x'
echo s
foo (s.addr)
echo s
echo addr(s[1]) # C Backend echos: 2345 .. but see below?
bar addr(s[1]) # it is a ptr char here.
echo s
```
I got ptr string and ptr char (and ref and pointer) to work by making them PHP references but I beliefe that addr string[x] can't be supported without using etyBaseIndex as it is used in JS.

Note: In addition see the `Backend: 2345 .. see below?` comment. It differs between JS and C backend. I believe it is kinda wrong in the JS implementation (as is in the PHP implementation)