### PR TITLE
Make ropes usable in VM context

### DIFF
--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -134,11 +134,16 @@ proc rope*(s: string): Rope {.rtl, extern: "nro$1Str".} =
   ## Converts a string to a rope.
   if s.len == 0:
     result = nil
-  elif cacheEnabled:
-    result = insertInCache(s, cache)
-    cache = result
   else:
-    result = newRope(s)
+    when nimvm:
+      # No caching in VM context
+      result = newRope(s)
+    else:
+      if cacheEnabled:
+        result = insertInCache(s, cache)
+        cache = result
+      else:
+        result = newRope(s)
 
 proc rope*(i: BiggestInt): Rope {.rtl, extern: "nro$1BiggestInt".} =
   ## Converts an int to a rope.


### PR DESCRIPTION
Ropes can be handy in code-generating macros (i.e. ones that .emit code). As shown in #3956 they cannot be used in VM context right now, because of few global variables related to cache. I have not found a clean way to make those variables available in any context, and, as a simple workaround, made exception appear if cache-related methods are called in static context.

I'm open to other suggestions on how to make ropes available to macro code.