### PR TITLE
Don't try to read directories as files

### DIFF
--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -296,7 +296,7 @@ proc open(f: var File, filename: string,
       var res: Stat
       if fstat(getFileHandle(f2), res) >= 0'i32 and S_ISDIR(res.st_mode):
         close(f2)
-        return
+        return false
     result = true
     f = cast[File](p)
     if bufSize > 0 and bufSize <= high(cint).int:

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -270,7 +270,7 @@ const
     # we always use binary here as for Nim the OS line ending
     # should not be translated.
 
-when defined(posix):
+when defined(posix) and not defined(nimscript):
   type
     Mode {.importc: "mode_t", header: "<sys/types.h>".} = cint
 
@@ -288,7 +288,7 @@ proc open(f: var File, filename: string,
           bufSize: int = -1): bool =
   var p: pointer = fopen(filename, FormatOpen[mode])
   if p != nil:
-    when defined(posix):
+    when defined(posix) and not defined(nimscript):
       var f2 = cast[File](p)
       var res: Stat
       if fstat(getFileHandle(f2), res) >= 0'i32 and S_ISDIR(res.st_mode):

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -289,6 +289,9 @@ proc open(f: var File, filename: string,
   var p: pointer = fopen(filename, FormatOpen[mode])
   if p != nil:
     when defined(posix) and not defined(nimscript):
+      # How `fopen` handles opening a directory is not specified in ISO C and
+      # POSIX. We do not want to handle directories as regular files that can
+      # be opened.
       var f2 = cast[File](p)
       var res: Stat
       if fstat(getFileHandle(f2), res) >= 0'i32 and S_ISDIR(res.st_mode):


### PR DESCRIPTION
Right now, at least on Linux, you can call a directory `foo.nim` and compile the directory, which is interpreted as an empty file. This is rather strange, so I think it should be disabled.