### PR TITLE
Added TAU constant.

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -44,6 +44,7 @@ when not defined(js) and not defined(nimscript):
 
 const
   PI* = 3.1415926535897932384626433 ## the circle constant PI (Ludolph's number)
+  TAU* = 6.2831853071795864769252868 ## the circle constant TAU (= 2 * PI)
   E* = 2.71828182845904523536028747 ## Euler's number
 
   MaxFloat64Precision* = 16 ## maximum number of meaningful digits

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -44,7 +44,7 @@ when not defined(js) and not defined(nimscript):
 
 const
   PI* = 3.1415926535897932384626433 ## the circle constant PI (Ludolph's number)
-  TAU* = 6.2831853071795864769252868 ## the circle constant TAU (= 2 * PI)
+  TAU* = 2.0 * PI ## the circle constant TAU (= 2 * PI)
   E* = 2.71828182845904523536028747 ## Euler's number
 
   MaxFloat64Precision* = 16 ## maximum number of meaningful digits

--- a/tests/manyloc/keineschweine/lib/sg_assets.nim
+++ b/tests/manyloc/keineschweine/lib/sg_assets.nim
@@ -110,7 +110,6 @@ type
   TGameState* = enum
     Lobby, Transitioning, Field
 const
-  TAU* = PI * 2.0
   MomentMult* = 0.62 ## global moment of inertia multiplier
 var
   cfg: PZoneSettings


### PR DESCRIPTION
Tau (= 2 * Pi) is much more commonly used than Pi itself and should therefore be included in the standard library. Fore more details on the rationale behind Tau, see: http://tauday.com/