### PR TITLE
avoid overwriting tok.indent in lexer.getNumber

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -263,7 +263,7 @@ template eatChar(L: var TLexer, t: var TToken) =
   add(t.literal, L.buf[L.bufpos])
   inc(L.bufpos)
 
-proc getNumber(L: var TLexer): TToken =
+proc getNumber(L: var TLexer, result: var TToken) =
   proc matchUnderscoreChars(L: var TLexer, tok: var TToken, chars: set[char]) =
     var pos = L.bufpos              # use registers for pos, buf
     var buf = L.buf
@@ -1061,7 +1061,7 @@ proc rawGetTok*(L: var TLexer, tok: var TToken) =
       getCharacter(L, tok)
       tok.tokType = tkCharLit
     of '0'..'9':
-      tok = getNumber(L)
+      getNumber(L, tok)
     else:
       if c in OpChars:
         getOperator(L, tok)


### PR DESCRIPTION
if it wasn't for bug #3978, assignment from getNumber would overwrite
tok.indent (which is set at top of rawGetTok, but not in getNumber)