### PR TITLE
Fixed a typo in rational number subtraction proc

### DIFF
--- a/lib/pure/rationals.nim
+++ b/lib/pure/rationals.nim
@@ -164,7 +164,7 @@ proc `-` *[T](x: Rational[T], y: T): Rational[T] =
 
 proc `-` *[T](x: T, y: Rational[T]): Rational[T] =
   ## Subtract rational `y` from int `x`.
-  result.num = - x * y.den + y.num
+  result.num = x * y.den - y.num
   result.den = y.den
 
 proc `-=` *[T](x: var Rational[T], y: Rational[T]) =


### PR DESCRIPTION
Fixed a bug which caused this:
```nim
2 - 1//2  # returns -3/2
```
to return incorrect result.

Also, I wonder if `reduce(result)` should be added to every overloaded operator proc in rationals.nim?