### PR TITLE
add test for shallow seq copy

### DIFF
--- a/tests/seq/tshallowseq.nim
+++ b/tests/seq/tshallowseq.nim
@@ -1,0 +1,17 @@
+discard """
+  output: '''@[1, 42, 3]
+@[1, 42, 3]
+'''
+"""
+proc xxx() =
+  var x: seq[int] = @[1, 2, 3]
+  var y: seq[int]
+
+  system.shallowCopy(y, x)
+
+  y[1] = 42
+
+  echo y
+  echo x
+
+xxx()


### PR DESCRIPTION
currently looks like it's not covered (was useful when working on nlvm)