### PR TITLE
Add search functions based on predicates to the xmltree library

### DIFF
--- a/lib/pure/xmlparser.nim
+++ b/lib/pure/xmlparser.nim
@@ -121,10 +121,17 @@ proc parseXml*(s: Stream, filename: string,
   close(x)
 
 proc parseXml*(s: Stream): XmlNode =
-  ## parses the XTML from stream `s` and returns a ``PXmlNode``. All parsing
+  ## parses the XML from stream `s` and returns a ``XmlNode``. All parsing
   ## errors are turned into an ``EInvalidXML`` exception.
   var errors: seq[string] = @[]
   result = parseXml(s, "unknown_html_doc", errors)
+  if errors.len > 0: raiseInvalidXml(errors)
+
+proc parseXml*(s: string): XmlNode =
+  ## parses the XML from string `s` and returns a ``XmlNode``. All parsing
+  ## errors are turned into an ``EInvalidXML`` exception.
+  var errors: seq[string] = @[]
+  result = parseXml(s.newStringStream, "unknown_html_doc", errors)
   if errors.len > 0: raiseInvalidXml(errors)
 
 proc loadXml*(path: string, errors: var seq[string]): XmlNode =

--- a/tests/stdlib/txmltree.nim
+++ b/tests/stdlib/txmltree.nim
@@ -1,13 +1,35 @@
 discard """
-  file: "txmltree.nim"
-  output: "true"
+  action: run
 """
 
-import xmltree, strtabs
+import xmltree, strtabs, xmlparser, future, strutils, unittest
 
-var x = <>a(href="nim.de", newText("www.nim-test.de"))
+let xml = """
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:v1="http://test.lan/api/v1">
+    <SOAP-ENV:Header/>
+    <SOAP-ENV:Body>
+        <v1:LogonRequest>
+            <v1:user_name>test</v1:user_name>
+            <v1:password>pwd</v1:password>
+        </v1:LogonRequest>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>
+""".parseXml
 
-echo($x == "<a href=\"nim.de\">www.nim-test.de</a>")
+suite "xmltree":
+  test "Contructor macro":
+    let x = <>a(href="nim.de", newText("www.nim-test.de"))
+    check: $x == "<a href=\"nim.de\">www.nim-test.de</a>"
 
+  test "findAll with predicate":
+    let n = xml.findAll(n => n.tag.endsWith(":password"))
+    check: n.len == 1 and n[0].innerText() == "pwd"
 
+  test "child with predicate":
+    let c = xml.child(n => n.len == 0)
+    check: c != nil and c.tag == "SOAP-ENV:Header"
 
+  test "findAttr with predicate":
+    let ns = xml.findAttr(n => n.split(":").len == 2 and xml.attr(n) == "http://test.lan/api/v1").split(":")[1]
+    check: ns == "v1"


### PR DESCRIPTION
When I tried to use ``xmltree`` with SOAP messages, I found that it's not easy. There is no searches by criteria for child nodes and attributes. Some of these problems are related with the xml namespaces, and some of them aren't. So, I implemented some functions, similar to the existing ones. The only difference is that ``findAttr`` returns the name of the attribute instead of ``attr`` function. It can be used to parse the ``xmlns`` declarations (see the test).

```nimrod
proc child*(n: XmlNode, p: proc(n: XmlNode): bool): XmlNode
proc findAttr*(n: XmlNode, p: proc(name: string): bool): string
proc findAll*(n: XmlNode, p: proc(n: XmlNode): bool, result: var seq[XmlNode])
proc findAll*(n: XmlNode, p: proc(n: XmlNode): bool): seq[XmlNode]
```