### PR TITLE
Makes dyncall errors report to stderr.

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -23,16 +23,16 @@ proc rawWrite(f: File, s: string) =
 
 proc nimLoadLibraryError(path: string) =
   # carefully written to avoid memory allocation:
-  stdout.rawWrite("could not load: ")
-  stdout.rawWrite(path)
-  stdout.rawWrite("\n")
+  stderr.rawWrite("could not load: ")
+  stderr.rawWrite(path)
+  stderr.rawWrite("\n")
   quit(1)
 
 proc procAddrError(name: cstring) {.noinline.} =
   # carefully written to avoid memory allocation:
-  stdout.rawWrite("could not import: ")
-  stdout.write(name)
-  stdout.rawWrite("\n")
+  stderr.rawWrite("could not import: ")
+  stderr.write(name)
+  stderr.rawWrite("\n")
   quit(1)
 
 # this code was inspired from Lua's source code:
@@ -71,7 +71,7 @@ when defined(posix):
     when defined(nimDebugDlOpen):
       let error = dlerror()
       if error != nil:
-        c_fprintf(c_stdout, "%s\n", error)
+        c_fprintf(c_stderr, "%s\n", error)
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
     result = dlsym(lib, name)


### PR DESCRIPTION
Fixes #3987

Hooray for bugtracker items tagged 'Easy'. Also I happened to notice this one earlier today anyway, conveniently enough.

I ran ./koch test c dll before and after these changes and verified that they build (also introduced a trivial stupid error to dyncalls.nim to verify the build failed in that case). Note that on my box I saw some failures with the following two configurations both before and after this patch:

 * client.nim --gc:boehm -d:useNimRtl
 * client.nim -d:release --gc:boehm -d:useNimRtl

Both failed expecting rc 0 (got 1). I'm assuming these are environmental or otherwise broken just on my box, for now.