### PR TITLE
Changed the JSON object hashing procedure (fixing #3972)

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -786,7 +786,7 @@ proc hash*(n: JsonNode): Hash =
 
 proc hash*(n: Table[string, JsonNode]): Hash =
   for key, val in n:
-    result = result !& hash(key) !& hash(val)
+    result = result xor (hash(key) !& hash(val))
   result = !$result
 
 proc len*(n: JsonNode): int =


### PR DESCRIPTION
Changed the JSON object hashing procedure to use a symmetric operator to disregard key order in object hashes as discussed under issue #3972 