### PR TITLE
Gen extern "C" for .importc proc decls when compiling to C++

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -707,9 +707,11 @@ proc genProcAux(m: BModule, prc: PSym) =
   add(m.s[cfsProcs], generatedProc)
 
 proc crossesCppBoundary(m: BModule; sym: PSym): bool {.inline.} =
-  result = sfCompileToCpp in m.module.flags and
-           sfCompileToCpp notin sym.getModule().flags and
-           gCmd != cmdCompileToCpp
+  result = (sfCompileToCpp in m.module.flags and
+            sfCompileToCpp notin sym.getModule().flags and
+            gCmd != cmdCompileToCpp) or
+           (gCmd == cmdCompileToCpp and
+            sfImportc in sym.flags and sym.magic == mNone)
 
 proc genProcPrototype(m: BModule, sym: PSym) =
   useHeader(m, sym)


### PR DESCRIPTION
Currently an `importc` proc declaration (without `nodecl` or `header` pragmas) after codegen results in a declaration that will not link in C++ when you are statically linking a C library. So, for example, `--gc:boehm --dynlibOverride:gc` does not work with C++ backend.

This is an attempt to make it so that `extern "C"` is prepended to such procedure declarations. With this fix, it's possible to statically link Boehm with C++ backend. Not sure if it's the correct fix - if it's not, please suggest another one.
