### PR TITLE
openssl: fix compatibility with OpenSSL 1.0.2

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -192,7 +192,10 @@ proc ERR_load_BIO_strings*(){.cdecl, dynlib: DLLUtilName, importc.}
 proc SSLv23_client_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSLv23_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSLv2_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
-proc SSLv3_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
+when not defined(nosslv3):
+    proc SSLv3_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
+else:
+    proc SSLv3_method*(): PSSL_METHOD = nil
 proc TLSv1_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 
 proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}


### PR DESCRIPTION
OpenSSL has removed SSLv3 support in 1.0.2 and thus `SSLv3_method()` is
no longer available. If an SSL-enabled Nim program runs on a system with
OpenSSL 1.0.2, an error `could not import SSLv3_method` will occur.

This commit adds a flag `nosslv3`. When enabled, the `SSLv3_method()`
will be replaced with a stub function, and thus it will run properly
with OpenSSL 1.0.2 while not breaking any other module. Of course, the
modules will not be able to connect to SSLv3 servers with this enabled.