### PR TITLE
Add missed library dependencies on Linux and Solaris.

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -35,6 +35,15 @@ const
   hasSpawnH = not defined(haiku) # should exist for every Posix system nowadays
   hasAioH = defined(linux)
 
+when defined(linux):
+  # On Linux:
+  # timer_{create,delete,settime,gettime},
+  # clock_{getcpuclockid, getres, gettime, nanosleep, settime} lives in librt
+  {.passL: "-lrt".}
+when defined(solaris):
+  # On Solaris hstrerror lives in libresolv
+  {.passL: "-lresolv".}
+
 when false:
   const
     C_IRUSR = 0c000400 ## Read by owner.


### PR DESCRIPTION
Compiler could not be built in **Solaris** because:
hstrerror() declared in posix.nim and used in nativesockets.nim [getHostByAddr()]
On **Solaris** this function lives in **libresolv.so**.

On **Linux** timer_{create, delete, settime, gettime} and clock_{getcpuclockid, getres, gettime, nanosleep, settime} are in **librt.so**.