### PR TITLE
Add `import sharedlist` when `hasThreadSupport`

### DIFF
--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -28,6 +28,9 @@ template mulThreshold(x): expr {.immediate.} = x * 2
 
 when defined(memProfiler):
   proc nimProfile(requestedSize: int)
+  
+when hasThreadSupport:
+  import sharedlist
 
 type
   WalkOp = enum


### PR DESCRIPTION
Without this change, a user's Nim code won't compile if they're using both threads & the mark-and-sweep GC:

```
lib/system/gc_ms.nim(75, 18) Error: undeclared identifier: 'SharedList'
        toDispose: SharedList[pointer]
                   ^
```

This small code block addition was copied from `lib/system/gc.nim` (where it appears directly after a `when defined(memProfiler)` block also).