### PR TITLE
Added test for #4066

### DIFF
--- a/tests/enum/tenum.nim
+++ b/tests/enum/tenum.nim
@@ -6,3 +6,9 @@ type
 var
   en: E
 en = a
+
+# Bug #4066
+import macros
+macro genEnum(): untyped = newNimNode(nnkEnumTy).add(newEmptyNode(), newIdentNode("geItem1"))
+type GeneratedEnum = genEnum()
+doAssert(type(geItem1) is GeneratedEnum)


### PR DESCRIPTION
This PR fixes #4066, but seems somewhat wrong to me. If I return `n.typ` always (not only for tyEnum), I will fail some tests, specifically compilation fails where closures are passed to calls, e.g:
```
Test "tests/closure/tfutclosure2138.nim" in category "closure"
Failure: reNimcCrash
Expected:


Gotten:
tests/closure/tfutclosure2138.nim(10, 6) Error: type mismatch: got (varargs[string], proc (word: GenericParam): untyped)
but expected one of:
tfutclosure2138.any(list: varargs[T], pred: typedesc[proc (i0: T): bool{.closure.}])
sequtils.any(seq1: seq[T], pred: proc (item: T): bool{.closure.})
```