### PR TITLE
Correct getOverlappedResult() definition

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -769,7 +769,7 @@ proc getQueuedCompletionStatus*(CompletionPort: Handle,
                                 dwMilliseconds: DWORD): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "GetQueuedCompletionStatus".}
 
-proc getOverlappedResult*(hFile: Handle, lpOverlapped: OVERLAPPED,
+proc getOverlappedResult*(hFile: Handle, lpOverlapped: POVERLAPPED,
               lpNumberOfBytesTransferred: var DWORD, bWait: WINBOOL): WINBOOL{.
     stdcall, dynlib: "kernel32", importc: "GetOverlappedResult".}
 


### PR DESCRIPTION
**winlean's** definition of **GetOverlappedResult** was a little bit wrong.
[GetOverlappedResult function](https://msdn.microsoft.com/en-us/library/windows/desktop/ms683209(v=vs.85).aspx)