### PR TITLE
getTypeInst

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1185,19 +1185,28 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNGetType:
       let rb = instr.regB
       let rc = instr.regC
-      if rc == 0:
-        ensureKind(rkNode)
-        if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
-          regs[ra].node = opMapTypeToAst(regs[rb].node.typ, c.debug[pc])
+      case rc:
+        of 0:
+          # getType opcode:
+          ensureKind(rkNode)
+          if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
+            regs[ra].node = opMapTypeToAst(regs[rb].node.typ, c.debug[pc])
+          else:
+            stackTrace(c, tos, pc, errGenerated, "node has no type")
+        of 1:
+          # typeKind opcode:
+          ensureKind(rkInt)
+          if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
+            regs[ra].intVal = ord(regs[rb].node.typ.kind)
+          #else:
+          #  stackTrace(c, tos, pc, errGenerated, "node has no type")
         else:
-          stackTrace(c, tos, pc, errGenerated, "node has no type")
-      else:
-        # typeKind opcode:
-        ensureKind(rkInt)
-        if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
-          regs[ra].intVal = ord(regs[rb].node.typ.kind)
-        #else:
-        #  stackTrace(c, tos, pc, errGenerated, "node has no type")
+          # getTypeInst opcode:
+          ensureKind(rkNode)
+          if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
+            regs[ra].node = opMapTypeInstToAst(regs[rb].node.typ, c.debug[pc])
+          else:
+            stackTrace(c, tos, pc, errGenerated, "node has no type")
     of opcNStrVal:
       decodeB(rkNode)
       createStr regs[ra]

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1200,11 +1200,18 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
             regs[ra].intVal = ord(regs[rb].node.typ.kind)
           #else:
           #  stackTrace(c, tos, pc, errGenerated, "node has no type")
-        else:
+        of 2:
           # getTypeInst opcode:
           ensureKind(rkNode)
           if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
             regs[ra].node = opMapTypeInstToAst(regs[rb].node.typ, c.debug[pc])
+          else:
+            stackTrace(c, tos, pc, errGenerated, "node has no type")
+        else:
+          # getTypeImpl opcode:
+          ensureKind(rkNode)
+          if regs[rb].kind == rkNode and regs[rb].node.typ != nil:
+            regs[ra].node = opMapTypeImplToAst(regs[rb].node.typ, c.debug[pc])
           else:
             stackTrace(c, tos, pc, errGenerated, "node has no type")
     of opcNStrVal:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -986,7 +986,8 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     let rc = case n[0].sym.name.s:
       of "getType": 0
       of "typeKind": 1
-      else: 2  # "getTypeInst"
+      of "getTypeInst": 2
+      else: 3  # "getTypeImpl"
     c.gABC(n, opcNGetType, dest, tmp, rc)
     c.freeTemp(tmp)
     #genUnaryABC(c, n, dest, opcNGetType)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -983,7 +983,11 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNGetType:
     let tmp = c.genx(n.sons[1])
     if dest < 0: dest = c.getTemp(n.typ)
-    c.gABC(n, opcNGetType, dest, tmp, if n[0].sym.name.s == "typeKind": 1 else: 0)
+    let rc = case n[0].sym.name.s:
+      of "getType": 0
+      of "typeKind": 1
+      else: 2  # "getTypeInst"
+    c.gABC(n, opcNGetType, dest, tmp, rc)
     c.freeTemp(tmp)
     #genUnaryABC(c, n, dest, opcNGetType)
   of mNStrVal: genUnaryABC(c, n, dest, opcNStrVal)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -197,6 +197,12 @@ proc typeKind*(n: NimNode): NimTypeKind {.magic: "NGetType", noSideEffect.}
   ## Returns the type kind of the node 'n' that should represent a type, that
   ## means the node should have been obtained via `getType`.
 
+proc getTypeInst*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
+  ## Like getType except it includes generic parameters for a specific instance
+
+proc getTypeInst*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
+  ## Like getType except it includes generic parameters for a specific instance
+
 proc strVal*(n: NimNode): string  {.magic: "NStrVal", noSideEffect.}
 
 proc `intVal=`*(n: NimNode, val: BiggestInt) {.magic: "NSetIntVal", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -203,6 +203,12 @@ proc getTypeInst*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
 proc getTypeInst*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
   ## Like getType except it includes generic parameters for a specific instance
 
+proc getTypeImpl*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
+  ## Like getType except it includes generic parameters for the implementation
+
+proc getTypeImpl*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
+  ## Like getType except it includes generic parameters for the implementation
+
 proc strVal*(n: NimNode): string  {.magic: "NStrVal", noSideEffect.}
 
 proc `intVal=`*(n: NimNode, val: BiggestInt) {.magic: "NSetIntVal", noSideEffect.}

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -1,0 +1,122 @@
+discard """
+"""
+
+import macros, strUtils
+
+proc symToIdent(x: NimNode): NimNode =
+  case x.kind:
+    of nnkCharLit..nnkUInt64Lit:
+      result = newNimNode(x.kind)
+      result.intVal = x.intVal
+    of nnkFloatLit..nnkFloat64Lit:
+      result = newNimNode(x.kind)
+      result.floatVal = x.floatVal
+    of nnkStrLit..nnkTripleStrLit:
+      result = newNimNode(x.kind)
+      result.strVal = x.strVal
+    of nnkIdent, nnkSym:
+      result = newIdentNode($x)
+    else:
+      result = newNimNode(x.kind)
+      for c in x:
+        result.add symToIdent(c)
+
+macro testX(x,inst0: typed; recurse: static[bool]; implX: stmt): typed =
+  let inst = x.getTypeInst
+  let impl = x.getTypeImpl
+  let inst0r = inst0.symToIdent.treeRepr
+  let instr = inst.symToIdent.treeRepr
+  #echo inst0r
+  #echo instr
+  doAssert(instr == inst0r)
+  var impl0 =
+    if implX.kind == nnkNilLit: inst0
+    else: implX[0][2]
+  let impl0r = impl0.symToIdent.treerepr
+  let implr = impl.symToIdent.treerepr
+  #echo impl0r
+  #echo implr
+  doAssert(implr == impl0r)
+  template echoString(s:string) = echo s.replace("\n","\n  ")
+  result = newStmtList()
+  #result.add getAst(echoString("  " & inst0.repr))
+  #result.add getAst(echoString("  " & inst.repr))
+  #result.add getAst(echoString("  " & impl0.repr))
+  #result.add getAst(echoString("  " & impl.repr))
+  if recurse:
+    template testDecl(n, m :typed) =
+      testV(n, false):
+        type _ = m
+    result.add getAst(testDecl(inst.symToIdent, impl.symToIdent))
+
+template testV(inst, recurse, impl) =
+  block:
+    #echo "testV(" & astToStr(inst) & ", " & $recurse & "):" & astToStr(impl)
+    var x: inst
+    testX(x, inst, recurse, impl)
+template testT(inst, recurse) =
+  block:
+    type myType = inst
+    testV(myType, recurse):
+      type _ = inst
+
+template test(inst) =
+  testT(inst, false)
+  testV(inst, true, nil)
+template test(inst, impl) = testV(inst, true, impl)
+
+type
+  Model = object of RootObj
+  User = object of Model
+    name : string
+    password : string
+
+  Tree = object of RootObj
+    value : int
+    left,right : ref Tree
+
+  MyEnum = enum
+    valueA, valueB, valueC
+
+  MySet = set[MyEnum]
+  MySeq = seq[int]
+  MyIntPtr = ptr int
+  MyIntRef = ref int
+
+  GenericObject[T] = object
+    value:T
+  Foo[N:static[int],T] = object
+  Bar[N:static[int],T] = object
+    #baz:Foo[N+1,GenericObject[T]]
+    baz:Foo[N,GenericObject[T]]
+
+test(bool)
+test(char)
+test(int)
+test(float)
+test(ptr int)
+test(ref int)
+test(array[1..10,Bar[2,Foo[3,float]]])
+test(distinct Bar[2,Foo[3,float]])
+test(tuple[a:int,b:Foo[-1,float]])
+#test(MyEnum):
+#  type _ = enum
+#    valueA, valueB, valueC
+test(set[MyEnum])
+test(seq[int])
+test(Bar[2,Foo[3,float]]):
+  type _ = object
+    baz: Foo[2, GenericObject[Foo[3, float]]]
+test(Model):
+  type _ = object of RootObj
+test(User):
+  type _ = object of Model
+    name: string
+    password: string
+test(Tree):
+  type _ = object of RootObj
+    value: int
+    left: ref Tree
+    right: ref Tree
+test(proc (a: int, b: Foo[2,float]))
+test(proc (a: int, b: Foo[2,float]): Bar[3,int])


### PR DESCRIPTION
This adds a variant of getType that also includes the generic arguments.  It was inspired by getType2/getTypeImpl in https://github.com/nim-lang/Nim/pull/3709 but doesn't add any new magics.  The name was chosen since the major difference from getType is in the handling of the tyGenericInst node.  The intention is also to make the output resemble a syntactically correct declaration of the type, though it wouldn't typically work in a declaration since it doesn't use the correct symbols for the generic types (and I couldn't find a symbol that would work).  The output doesn't handle all cases correctly yet, but I wanted to check that it is suitable for inclusion before finishing the rest.

```nimrod
import macros
type
  Foo[N:static[int],T] = object
    bar:T
var
  a:Foo[1,float]
  b:Foo[2,Foo[3,tuple[a:int,b:distinct range[-1..4]]]]
macro test(x:typed):auto =
  result = newEmptyNode()
  echo x.getTypeInst.repr
test(a)  # Foo[1, float]
test(b)  # Foo[2, Foo[3, tuple[int, distinct range[-1, 4]]]]
```
