### PR TITLE
Fixed stacktrace error

### DIFF
--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -121,3 +121,5 @@ else:
       importc: "pthread_cond_signal", header: "<pthread.h>", noSideEffect.}
     proc deinitSysCond(cond: var SysCond) {.noSideEffect,
       importc: "pthread_cond_destroy", header: "<pthread.h>".}
+
+{.pop.}


### PR DESCRIPTION
Fixes https://github.com/dom96/jester/issues/65
Simpler steps to reproduce:
```nim
import locks

{.push stacktrace:on.}

proc someProc*() =
    raise newException(Exception, "")

{.pop.}

proc serve() =
    try:
        echo 1
        someProc()
    except:
        echo 2

    try:
        echo 3
        someProc()
        echo 4
    except:
        echo 5

serve()
```
This code hangs.