### PR TITLE
PHP codegen array constructor hack (!!!) for demo purpose only I guess

### DIFF
--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -731,16 +731,19 @@ proc genericReset(x: JSRef, ti: PNimType): JSRef {.compilerproc.} =
   else:
     discard
 
-proc arrayConstr(len: int, value: JSRef, typ: PNimType): JSRef {.
-                 asmNoStackFrame, compilerproc.} =
-  # types are fake
-  when defined(nimphp):
+when defined(nimphp):
+  proc arrayConstr(len: int, value: string, typ: string): JSRef {.
+                  asmNoStackFrame, compilerproc.} =
+    # types are fake
     asm """
       $result = array();
       for ($i = 0; $i < `len`; $i++) $result[] = `value`;
       return $result;
     """
-  else:
+else:
+  proc arrayConstr(len: int, value: JSRef, typ: PNimType): JSRef {.
+                  asmNoStackFrame, compilerproc.} =
+  # types are fake
     asm """
       var result = new Array(`len`);
       for (var i = 0; i < `len`; ++i) result[i] = nimCopy(null, `value`, `typ`);


### PR DESCRIPTION
Because of PHP can't have refs for literal function parameters I
needed to come up with a hack such that the following code compiles with
PHP target.

```nim
type Foo = tuple[a: string, b: int]

var foo: array [0..2, Foo]

foo[0] = ("Test", 1)
foo[1] = ("Me", 2)

for x in foo:
  echo x.a
  echo x.b
```