### PR TITLE
Fix missing `]`

### DIFF
--- a/lib/pure/collections/LockFreeHash.nim
+++ b/lib/pure/collections/LockFreeHash.nim
@@ -74,7 +74,7 @@ type
     copyDone: int
     next: PConcTable[K,V]
     data: EntryArr
-{.deprecated: [TEntry: Entry, TEntryArr: EntryArr.}
+{.deprecated: [TEntry: Entry, TEntryArr: EntryArr].}
 
 proc setVal[K,V](table: var PConcTable[K,V], key: int, val: int,
   expVal: int, match: bool): int


### PR DESCRIPTION
otherwise nim can't parse the file.
Introduced in https://github.com/nim-lang/Nim/commit/192ba3bbc0ae7f570c1277c9211d24eeea2cf48a#diff-1a01187da2fad29f03da8ce36ffe1f91

the way I ran into this was by running `for file in $(find path/to/nim/lib -iname "*.nim"); do nim jsondoc "$file"; done` which will fail on that file.

