### PR TITLE
Fix toJSStr for control characters

### DIFF
--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -248,8 +248,12 @@ proc toJSStr(s: string): cstring {.asmNoStackFrame, compilerproc.} =
     for (var i = 0; i < len; ++i) {
       if (nonAsciiPart !== null) {
         var offset = (i - nonAsciiOffset) * 2;
+        var code = `s`[i].toString(16);
+        if (code.length == 1) {
+          code = "0"+code;
+        }
         nonAsciiPart[offset] = "%";
-        nonAsciiPart[offset + 1] = `s`[i].toString(16);
+        nonAsciiPart[offset + 1] = code;
       }
       else if (`s`[i] < 128)
         asciiPart[i] = fcc(`s`[i]);

--- a/tests/js/testtojsstr.nim
+++ b/tests/js/testtojsstr.nim
@@ -1,6 +1,8 @@
 discard """
-  output = ""
+  output = "И\n"
 """
 
 let s: string = "И\n"
 let cs = s.cstring
+
+echo $s

--- a/tests/js/testtojsstr.nim
+++ b/tests/js/testtojsstr.nim
@@ -1,0 +1,6 @@
+discard """
+  output = ""
+"""
+
+let s: string = "И\n"
+let cs = s.cstring


### PR DESCRIPTION
fixes #4190 .
Add leading zero to encoded character if it is less than 0x10.
Add regression test.