### PR TITLE
Extending .gitignore to skip common IDE files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ nimcache/
 *.dylib
 *.zip
 *.iss
+*.log
 
 mapping.txt
 tags
@@ -42,3 +43,7 @@ xcuserdata/
 /testresults.json
 testament.db
 /csources
+
+# Private directories and files (IDEs)
+.*/
+~*


### PR DESCRIPTION
I added `.*/`, `~*` and `*.log` to GIT ignore list.

Using different IDEs for the Nim compiler I am constantly running into the problem that my global gitignore is not working for the Nim directory. This is caused by the `*` / `!*.*` like rules, which reset all other rules. So I thought a bit about a sensible filtering of common IDE special files and added that to the .gitignore.