### PR TITLE
Implementation of formatEng/formatSize and their dependencies

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -489,7 +489,7 @@ proc leValueConv(a, b: PNode): bool =
   of nkCharLit..nkUInt64Lit:
     case b.kind
     of nkCharLit..nkUInt64Lit: result = a.intVal <= b.intVal
-    of nkFloatLit..nkFloat128Lit: result = a.intVal <= round(b.floatVal)
+    of nkFloatLit..nkFloat128Lit: result = a.intVal <= round(b.floatVal).int
     else: internalError(a.info, "leValueConv")
   of nkFloatLit..nkFloat128Lit:
     case b.kind

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -657,7 +657,7 @@ template newSeqWith*(len: int, init: expr): expr =
   ##   seq2D[1][0] = true
   ##   seq2D[0][1] = true
   ##
-  ##   import math
+  ##   import random
   ##   var seqRand = newSeqWith(20, random(10))
   ##   echo seqRand
   var result {.gensym.} = newSeq[type(init)](len)

--- a/lib/pure/concurrency/cpuload.nim
+++ b/lib/pure/concurrency/cpuload.nim
@@ -11,7 +11,7 @@
 ## creating a thread is a good idea.
 
 when defined(windows):
-  import winlean, os, strutils, math
+  import winlean, os, strutils, math, random
 
   proc `-`(a, b: FILETIME): int64 = a.rdFileTime - b.rdFileTime
 elif defined(linux):

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -82,6 +82,7 @@
 import net, strutils, uri, parseutils, strtabs, base64, os, mimetypes, math
 import asyncnet, asyncdispatch
 import nativesockets
+import random
 
 type
   Response* = tuple[

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -260,6 +260,23 @@ else:
       exponent = round(ex)
       result = x / pow(2.0, ex)
 
+proc split*(x: BiggestFloat): tuple[intpart: BiggestFloat, floatpart: BiggestFloat] =
+  ## Breaks `x` into an integral and a fractional part.
+  ##
+  ## Returns a tuple containing intpart and floatpart representing
+  ## the integer part and the fractional part respectively.
+  ##
+  ## Both parts have the same sign as `x`.  Analogous to the `modf`
+  ## function in C.
+  var
+    absolute: BiggestFloat
+  absolute = abs(x)
+  result.intpart = floor(absolute)
+  result.floatpart = absolute - result.intpart
+  if x < 0:
+    result.intpart = -result.intpart
+    result.floatpart = -result.floatpart
+
 {.pop.}
 
 proc degToRad*[T: float32|float64](d: T): T {.inline.} =
@@ -348,3 +365,11 @@ when isMainModule:
     doAssert floatIsEqual(round(-547.652, -2), -500.0)
     doAssert floatIsEqual(round(-547.652, -3), -1000.0)
     doAssert floatIsEqual(round(-547.652, -4), 0.0)
+
+  block: # split() tests
+    doAssert floatIsEqual(split(54.674).intpart, 54.0)
+    doAssert floatIsEqual(split(54.674).floatpart, 0.674)
+    doAssert floatIsEqual(split(-693.4356).intpart, -693.0)
+    doAssert floatIsEqual(split(-693.4356).floatpart, -0.4356)
+    doAssert floatIsEqual(split(0.0).intpart, 0.0)
+    doAssert floatIsEqual(split(0.0).floatpart, 0.0)

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -39,8 +39,6 @@ proc fac*(n: int): int {.noSideEffect.} =
 
 when defined(Posix) and not defined(haiku):
   {.passl: "-lm".}
-when not defined(js) and not defined(nimscript):
-  import times
 
 const
   PI* = 3.1415926535897932384626433 ## the circle constant PI (Ludolph's number)
@@ -119,30 +117,6 @@ proc sum*[T](x: openArray[T]): T {.noSideEffect.} =
   ## If `x` is empty, 0 is returned.
   for i in items(x): result = result + i
 
-proc random*(max: int): int {.benign.}
-  ## Returns a random number in the range 0..max-1. The sequence of
-  ## random number is always the same, unless `randomize` is called
-  ## which initializes the random number generator with a "random"
-  ## number, i.e. a tickcount.
-
-proc random*(max: float): float {.benign.}
-  ## Returns a random number in the range 0..<max. The sequence of
-  ## random number is always the same, unless `randomize` is called
-  ## which initializes the random number generator with a "random"
-  ## number, i.e. a tickcount. This has a 16-bit resolution on windows
-  ## and a 48-bit resolution on other platforms.
-
-when not defined(nimscript):
-  proc randomize*() {.benign.}
-    ## Initializes the random number generator with a "random"
-    ## number, i.e. a tickcount. Note: Does nothing for the JavaScript target,
-    ## as JavaScript does not support this. Nor does it work for NimScript.
-
-proc randomize*(seed: int) {.benign.}
-  ## Initializes the random number generator with a specific seed.
-  ## Note: Does nothing for the JavaScript target,
-  ## as JavaScript does not support this.
-
 {.push noSideEffect.}
 when not defined(JS):
   proc sqrt*(x: float): float {.importc: "sqrt", header: "<math.h>".}
@@ -203,57 +177,6 @@ when not defined(JS):
   proc tgamma*(x: float): float {.importc: "tgamma", header: "<math.h>".}
     ## The gamma function
 
-  # C procs:
-  when defined(vcc) and false:
-    # The "secure" random, available from Windows XP
-    # https://msdn.microsoft.com/en-us/library/sxtz2fa8.aspx
-    # Present in some variants of MinGW but not enough to justify
-    # `when defined(windows)` yet
-    proc rand_s(val: var cuint) {.importc: "rand_s", header: "<stdlib.h>".}
-    # To behave like the normal version
-    proc rand(): cuint = rand_s(result)
-  else:
-    proc srand(seed: cint) {.importc: "srand", header: "<stdlib.h>".}
-    proc rand(): cint {.importc: "rand", header: "<stdlib.h>".}
-
-  when not defined(windows):
-    proc srand48(seed: clong) {.importc: "srand48", header: "<stdlib.h>".}
-    proc drand48(): float {.importc: "drand48", header: "<stdlib.h>".}
-    proc random(max: float): float =
-      result = drand48() * max
-  else:
-    when defined(vcc): # Windows with Visual C
-      proc random(max: float): float =
-        # we are hardcoding this because
-        # importc-ing macros is extremely problematic
-        # and because the value is publicly documented
-        # on MSDN and very unlikely to change
-        # See https://msdn.microsoft.com/en-us/library/296az74e.aspx
-        const rand_max = 4294967295 # UINT_MAX
-        result = (float(rand()) / float(rand_max)) * max
-      proc randomize() = discard
-      proc randomize(seed: int) = discard
-    else: # Windows with another compiler
-      proc random(max: float): float =
-        # we are hardcoding this because
-        # importc-ing macros is extremely problematic
-        # and because the value is publicly documented
-        # on MSDN and very unlikely to change
-        const rand_max = 32767
-        result = (float(rand()) / float(rand_max)) * max
-
-  when not defined(vcc): # the above code for vcc uses `discard` instead
-    # this is either not Windows or is Windows without vcc
-    when not defined(nimscript):
-      proc randomize() =
-        randomize(cast[int](epochTime()))
-    proc randomize(seed: int) =
-      srand(cint(seed)) # rand_s doesn't use srand
-      when declared(srand48): srand48(seed)
-
-  proc random(max: int): int =
-    result = int(rand()) mod max
-
   proc trunc*(x: float): float {.importc: "trunc", header: "<math.h>".}
     ## Truncates `x` to the decimal point
     ##
@@ -277,16 +200,8 @@ when not defined(JS):
     ##  echo fmod(-2.5, 0.3) ## -0.1
 
 else:
-  proc mathrandom(): float {.importc: "Math.random", nodecl.}
   proc floor*(x: float): float {.importc: "Math.floor", nodecl.}
   proc ceil*(x: float): float {.importc: "Math.ceil", nodecl.}
-  proc random(max: int): int =
-    result = int(floor(mathrandom() * float(max)))
-  proc random(max: float): float =
-    result = float(mathrandom() * float(max))
-  proc randomize() = discard
-  proc randomize(seed: int) = discard
-
   proc sqrt*(x: float): float {.importc: "Math.sqrt", nodecl.}
   proc ln*(x: float): float {.importc: "Math.log", nodecl.}
   proc log10*(x: float): float = return ln(x) / ln(10.0)
@@ -364,14 +279,6 @@ proc `mod`*(x, y: float): float =
   ##  echo (4.0 mod -3.1) # -2.2
   result = if y == 0.0: x else: x - y * (x/y).floor
 
-proc random*[T](x: Slice[T]): T =
-  ## For a slice `a .. b` returns a value in the range `a .. b-1`.
-  result = random(x.b - x.a) + x.a
-
-proc random*[T](a: openArray[T]): T =
-  ## returns a random element from the openarray `a`.
-  result = a[random(a.low..a.len)]
-
 {.pop.}
 {.pop.}
 
@@ -406,24 +313,6 @@ proc lcm*[T](x, y: T): T =
   x div gcd(x, y) * y
 
 when isMainModule and not defined(JS):
-  proc gettime(dummy: ptr cint): cint {.importc: "time", header: "<time.h>".}
-
-  # Verifies random seed initialization.
-  let seed = gettime(nil)
-  randomize(seed)
-  const SIZE = 10
-  var buf : array[0..SIZE, int]
-  # Fill the buffer with random values
-  for i in 0..SIZE-1:
-    buf[i] = random(high(int))
-  # Check that the second random calls are the same for each position.
-  randomize(seed)
-  for i in 0..SIZE-1:
-    assert buf[i] == random(high(int)), "non deterministic random seeding"
-
-  when not defined(testing):
-    echo "random values equal after reseeding"
-
   # Check for no side effect annotation
   proc mySqrt(num: float): float {.noSideEffect.} =
     return sqrt(num)
@@ -433,6 +322,7 @@ when isMainModule and not defined(JS):
   assert(lgamma(1.0) == 0.0) # ln(1.0) == 0.0
   assert(erf(6.0) > erf(5.0))
   assert(erfc(6.0) < erfc(5.0))
+
 when isMainModule:
   # Function for approximate comparison of floats
   proc floatIsEqual(x, y: float): bool = (abs(x-y) < 1e-9)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -1,0 +1,141 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2015 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+##   Constructive mathematics is naturally typed. -- Simon Thompson
+##
+## Basic random number routines for Nim.
+## This module is available for the `JavaScript target
+## <backends.html#the-javascript-target>`_.
+
+include "system/inclrtl"
+
+{.push debugger:off .} # the user does not want to trace a part
+                       # of the standard library!
+
+{.push checks:off, line_dir:off, stack_trace:off.}
+
+when not defined(js) and not defined(nimscript):
+  import times
+
+proc random*(max: int): int {.benign.}
+  ## Returns a random number in the range 0..max-1. The sequence of
+  ## random number is always the same, unless `randomize` is called
+  ## which initializes the random number generator with a "random"
+  ## number, i.e. a tickcount.
+
+proc random*(max: float): float {.benign.}
+  ## Returns a random number in the range 0..<max. The sequence of
+  ## random number is always the same, unless `randomize` is called
+  ## which initializes the random number generator with a "random"
+  ## number, i.e. a tickcount. This has a 16-bit resolution on windows
+  ## and a 48-bit resolution on other platforms.
+
+when not defined(nimscript):
+  proc randomize*() {.benign.}
+    ## Initializes the random number generator with a "random"
+    ## number, i.e. a tickcount. Note: Does nothing for the JavaScript target,
+    ## as JavaScript does not support this. Nor does it work for NimScript.
+
+proc randomize*(seed: int) {.benign.}
+  ## Initializes the random number generator with a specific seed.
+  ## Note: Does nothing for the JavaScript target,
+  ## as JavaScript does not support this.
+
+{.push noSideEffect.}
+when not defined(JS):
+  # C procs:
+  when defined(vcc) and false:
+    # The "secure" random, available from Windows XP
+    # https://msdn.microsoft.com/en-us/library/sxtz2fa8.aspx
+    # Present in some variants of MinGW but not enough to justify
+    # `when defined(windows)` yet
+    proc rand_s(val: var cuint) {.importc: "rand_s", header: "<stdlib.h>".}
+    # To behave like the normal version
+    proc rand(): cuint = rand_s(result)
+  else:
+    proc srand(seed: cint) {.importc: "srand", header: "<stdlib.h>".}
+    proc rand(): cint {.importc: "rand", header: "<stdlib.h>".}
+
+  when not defined(windows):
+    proc srand48(seed: clong) {.importc: "srand48", header: "<stdlib.h>".}
+    proc drand48(): float {.importc: "drand48", header: "<stdlib.h>".}
+    proc random(max: float): float =
+      result = drand48() * max
+  else:
+    when defined(vcc): # Windows with Visual C
+      proc random(max: float): float =
+        # we are hardcoding this because
+        # importc-ing macros is extremely problematic
+        # and because the value is publicly documented
+        # on MSDN and very unlikely to change
+        # See https://msdn.microsoft.com/en-us/library/296az74e.aspx
+        const rand_max = 4294967295 # UINT_MAX
+        result = (float(rand()) / float(rand_max)) * max
+      proc randomize() = discard
+      proc randomize(seed: int) = discard
+    else: # Windows with another compiler
+      proc random(max: float): float =
+        # we are hardcoding this because
+        # importc-ing macros is extremely problematic
+        # and because the value is publicly documented
+        # on MSDN and very unlikely to change
+        const rand_max = 32767
+        result = (float(rand()) / float(rand_max)) * max
+
+  when not defined(vcc): # the above code for vcc uses `discard` instead
+    # this is either not Windows or is Windows without vcc
+    when not defined(nimscript):
+      proc randomize() =
+        randomize(cast[int](epochTime()))
+    proc randomize(seed: int) =
+      srand(cint(seed)) # rand_s doesn't use srand
+      when declared(srand48): srand48(seed)
+
+  proc random(max: int): int =
+    result = int(rand()) mod max
+else:
+  proc mathrandom(): float {.importc: "Math.random", nodecl.}
+  proc random(max: int): int =
+    result = int(floor(mathrandom() * float(max)))
+  proc random(max: float): float =
+    result = float(mathrandom() * float(max))
+  proc randomize() = discard
+  proc randomize(seed: int) = discard
+
+{.pop.}
+
+proc random*[T](x: Slice[T]): T =
+  ## For a slice `a .. b` returns a value in the range `a .. b-1`.
+  result = random(x.b - x.a) + x.a
+
+proc random*[T](a: openArray[T]): T =
+  ## returns a random element from the openarray `a`.
+  result = a[random(a.low..a.len)]
+
+{.pop.}
+{.pop.}
+
+when isMainModule and not defined(JS):
+  block: # random tests
+    proc gettime(dummy: ptr cint): cint {.importc: "time", header: "<time.h>".}
+    # Verifies random seed initialization.
+    let seed = gettime(nil)
+    randomize(seed)
+    const SIZE = 10
+    var buf : array[0..SIZE, int]
+    # Fill the buffer with random values
+    for i in 0..SIZE-1:
+      buf[i] = random(high(int))
+    # Check that the second random calls are the same for each position.
+    randomize(seed)
+    for i in 0..SIZE-1:
+      assert buf[i] == random(high(int)), "non deterministic random seeding"
+
+    when not defined(testing):
+      echo "random values equal after reseeding"

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -311,6 +311,7 @@ macro expect*(exceptions: varargs[expr], body: stmt): stmt {.immediate.} =
   ## .. code-block:: nim
   ##
   ##  import math
+  ##  import random
   ##  proc defectiveRobot() =
   ##    randomize()
   ##    case random(1..4)

--- a/tests/overload/tstmtoverload.nim
+++ b/tests/overload/tstmtoverload.nim
@@ -10,7 +10,7 @@ template test(loopCount: int, extraI: int, testBody: stmt): stmt =
 
 template test(loopCount: int, extraF: float, testBody: stmt): stmt =
   block:
-    test(loopCount, round(extraF), testBody)
+    test(loopCount, round(extraF).int, testBody)
 
 template test(loopCount: int, testBody: stmt): stmt =
   block:

--- a/tests/parallel/twrong_refcounts.nim
+++ b/tests/parallel/twrong_refcounts.nim
@@ -2,7 +2,7 @@ discard """
   output: "Success"
 """
 
-import math, threadPool
+import math, threadPool, random
 
 # ---
 

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -1,6 +1,7 @@
 import math
 import unittest
 import sets
+import random
 
 suite "random int":
   test "there might be some randomness":

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -27,6 +27,7 @@ test "unittest multiple requires":
 
 
 import math
+import random
 from strutils import parseInt
 proc defectiveRobot() =
   randomize()

--- a/tests/threads/ttryrecv.nim
+++ b/tests/threads/ttryrecv.nim
@@ -4,7 +4,7 @@ discard """
 
 # bug #1816
 
-from math import random
+from random import random
 from os import sleep
 
 type PComm = ptr Channel[int]


### PR DESCRIPTION
formatEng (#4197) required a few changes to math.nim (as covered in #3473 and the comments in #4197).  This pull request (my first, so please be gentle!) contains the fixes to math.nim in the first three commits and the implementation of formatSize and formatEng in the last three.  I've tried to make each commit reasonably self-contained with a clear commit message saying what it's doing.

Major changes are to math.nim (modifying round and moving random to random.nim) and strutils.nim (adding formatEng and modifying formatSize).  All other changes are related to the random/round changes to update test harness and dependent code to work with the new implementations (mostly just adding "import random")