### PR TITLE
Stdlib: ropes: Fix character extraction by index.

### DIFF
--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -206,7 +206,7 @@ proc `[]`*(r: Rope, i: int): char {.rtl, extern: "nroCharAt".} =
   if x == nil: return
   while true:
     if not isConc(x):
-      if x.data.len <% j: return x.data[j]
+      if x.data.len >% j: return x.data[j]
       return '\0'
     else:
       if x.left.len >% j:


### PR DESCRIPTION
Apparently, there's a typo in `[]` proc. Before the fix, extracting characters by index didn't work:
```nim
import ropes
var r: Rope
r = rope("foo")
assert r[0] == 'f'
assert r[3] == '\0'
```