### PR TITLE
Fix issue #4001: invalid pragma {. hint[]: off .}

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -277,6 +277,7 @@ proc processDynLib(c: PContext, n: PNode, sym: PSym) =
 proc processNote(c: PContext, n: PNode) =
   if (n.kind == nkExprColonExpr) and (sonsLen(n) == 2) and
       (n.sons[0].kind == nkBracketExpr) and
+      (n.sons[0].sons.len == 2) and
       (n.sons[0].sons[1].kind == nkIdent) and
       (n.sons[0].sons[0].kind == nkIdent):
       #and (n.sons[1].kind == nkIdent):

--- a/tests/pragmas/thintoff.nim
+++ b/tests/pragmas/thintoff.nim
@@ -1,0 +1,6 @@
+# issue #4001
+discard """
+  errormsg: "invalid pragma: hint[]: off"
+"""
+
+{. hint[]: off .}

--- a/tests/pragmas/thintoff.nim
+++ b/tests/pragmas/thintoff.nim
@@ -1,6 +1,0 @@
-# issue #4001
-discard """
-  errormsg: "invalid pragma: hint[]: off"
-"""
-
-{. hint[]: off .}


### PR DESCRIPTION
The bug was in processNote, module pragmas. The code assumed that a nkBracketExpr AST node always had two children (without testing this), and tried to access elements with index 0 and 1 in the sons array of the nkBracketExpr node.

The code that triggered the bug was just {. hint[]: off .} by itself in a module; in this case the nkBracketExpr has only one children in the sons array, so the code in processNote caused an out-of-bounds array access.

This commit also adds a test to guarantee that this pragma is rejected, as is.