### PR TITLE
Stdlib: httpclient: `export strtabs` added.

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -83,6 +83,8 @@ import net, strutils, uri, parseutils, strtabs, base64, os, mimetypes, math
 import asyncnet, asyncdispatch
 import nativesockets
 
+export strtabs
+
 type
   Response* = tuple[
     version: string,


### PR DESCRIPTION
When using `httpclient`, viewing HTTP headers is impossible without importing `strtabs`, which is very much _not_ obvious; it's impossible to know without deep diving into the docs.

Dealing with headers is an essential part of working with HTTP in general, so I propose this change. The situation is analogous to this one with `nre` and `options`: https://github.com/nim-lang/Nim/issues/4158