### PR TITLE
Time has now reference semantics on js

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -95,7 +95,8 @@ elif defined(windows):
 
 elif defined(JS):
   type
-    Time* {.importc.} = object
+    Time* = ref TimeObj
+    TimeObj {.importc.} = object
       getDay: proc (): int {.tags: [], raises: [], benign.}
       getFullYear: proc (): int {.tags: [], raises: [], benign.}
       getHours: proc (): int {.tags: [], raises: [], benign.}

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -226,7 +226,7 @@ proc jsTests(r: var TResults, cat: Category, options: string) =
                    "varres/tvartup", "misc/tints", "misc/tunsignedinc"]:
     test "tests/" & testfile & ".nim"
 
-  for testfile in ["pure/strutils", "pure/json"]:
+  for testfile in ["pure/strutils", "pure/json", "pure/random", "pure/times"]:
     test "lib/" & testfile & ".nim"
 
 # ------------------------- manyloc -------------------------------------------


### PR DESCRIPTION
This fixes randomize() function on JS. Time, being a value type was broken anyway. A nicer wrapper should be invented eventually if anyone cares... Also added times and random to js tests.