### PR TITLE
Implemented string formatting functions for engineering format

### DIFF
--- a/web/news.txt
+++ b/web/news.txt
@@ -70,6 +70,8 @@ Library Additions
   into an integer part and a floating part (in the range -1<x<1).
 - Added ``trimZeros`` to ```strutils.nim`` to trim trailing zeros in a
   floating point number.
+- Added ``formatEng`` to ``strutils.nim`` to format numbers using engineering
+  notation.
 
 
 Compiler Additions


### PR DESCRIPTION
This is the last PR in my little series implementing formatEng - this is the one that actually does it (and I'll now delete PR#4211).

I've tried to take into account all the comments from the previous review, with one exception: I've left the `trim` argument with the default as `true`.  I tried lots of different alternatives for `precision` and `trim`, and none of them gave a very satisfactory result for an engineering format.  I did wonder about a default of `precision=3` and `trim=true` as I think that is probably closer to what most engineers would be interested in, but with precision being the second argument it should be easy to tweak.  As an engineer, if I try to format a capacitance of 63e-3 I would expect it to be displayed as `63 mF`, not as `63.0000000000 mF` or even `63.000 mF`.  I've tried to explain the default behaviour in the comment block.