### PR TITLE
Fix android compile time error

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2393,8 +2393,14 @@ proc sigrelse*(a1: cint): cint {.importc, header: "<signal.h>".}
 proc sigset*(a1: int, a2: proc (x: cint) {.noconv.}) {.
   importc, header: "<signal.h>".}
 proc sigsuspend*(a1: var Sigset): cint {.importc, header: "<signal.h>".}
-proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
+
+when defined(android):
+  proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
+                   a3: var Timespec, sigsetsize: csize = sizeof(culong)*2): cint {.importc: "__rt_sigtimedwait", header:"<signal.h>".}
+else:
+  proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
                    a3: var Timespec): cint {.importc, header: "<signal.h>".}
+
 proc sigwait*(a1: var Sigset, a2: var cint): cint {.
   importc, header: "<signal.h>".}
 proc sigwaitinfo*(a1: var Sigset, a2: var SigInfo): cint {.


### PR DESCRIPTION
Fix compile error on android ndk:
" undefined reference 'sigtimedwait' "