### PR TITLE
Make some proper closes.

### DIFF
--- a/lib/pure/asyncfile.nim
+++ b/lib/pure/asyncfile.nim
@@ -316,6 +316,7 @@ proc write*(f: AsyncFile, data: string): Future[void] =
 
 proc close*(f: AsyncFile) =
   ## Closes the file specified.
+  unregister(f.fd)
   when defined(windows) or defined(nimdoc):
     if not closeHandle(f.fd.Handle).bool:
       raiseOSError(osLastError())

--- a/tests/async/tasynceverror.nim
+++ b/tests/async/tasynceverror.nim
@@ -43,7 +43,7 @@ else:
         await s.connect(testHost, testPort)
 
         var ps = await ls.accept()
-        SocketHandle(ls).close()
+        closeSocket(ls)
 
         await ps.send("test 1", flags={})
         s.close()


### PR DESCRIPTION
asyncfile.nim's close() must unregister fd from async dispatcher too.
tasynceverror.nim must close acceptor socket with async close, but not system one.