### PR TITLE
adds --excessiveStackTrace:on|off flag for nim

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -409,6 +409,7 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
     if processOnOffSwitchOrList({optHints}, arg, pass, info): listHints()
   of "threadanalysis": processOnOffSwitchG({optThreadAnalysis}, arg, pass, info)
   of "stacktrace": processOnOffSwitch({optStackTrace}, arg, pass, info)
+  of "excessivestacktrace": processOnOffSwitchG({optExcessiveStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch({optLineTrace}, arg, pass, info)
   of "debugger":
     case arg.normalize

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -471,6 +471,8 @@ type
     shortName*: string         # short name of the module
     quotedName*: Rope          # cached quoted short name for codegen
                                # purposes
+    quotedFullName*: Rope      # cached quoted full name for codegen
+                               # purposes
 
     lines*: seq[Rope]          # the source code of the module
                                #   used for better error messages and
@@ -563,6 +565,7 @@ proc newFileInfo(fullPath, projPath: string): TFileInfo =
   let fileName = projPath.extractFilename
   result.shortName = fileName.changeFileExt("")
   result.quotedName = fileName.makeCString
+  result.quotedFullName = fullPath.makeCString
   if optEmbedOrigSrc in gGlobalOptions or true:
     result.lines = @[]
 
@@ -1024,7 +1027,10 @@ proc sourceLine*(i: TLineInfo): Rope =
 
 proc quotedFilename*(i: TLineInfo): Rope =
   internalAssert i.fileIndex >= 0
-  result = fileInfos[i.fileIndex].quotedName
+  if optExcessiveStackTrace in gGlobalOptions:
+    result = fileInfos[i.fileIndex].quotedFullName
+  else:
+    result = fileInfos[i.fileIndex].quotedName
 
 ropes.errorHandler = proc (err: RopesError, msg: string, useWarning: bool) =
   case err

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -67,6 +67,8 @@ type                          # please make sure we have under 32 options
     optIdeDebug               # idetools: debug mode
     optIdeTerse               # idetools: use terse descriptions
     optNoCppExceptions        # use C exception handling even with CPP
+    optExcessiveStackTrace    # fully qualified module filenames
+
   TGlobalOptions* = set[TGlobalOption]
   TCommands* = enum           # Nim's commands
                               # **keep binary compatible**


### PR DESCRIPTION
As discussed in #4307.
Add flag to display absolute file path in error messages.