### PR TITLE
Expand dbQuote to handle backslashes

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -120,6 +120,7 @@ proc dbQuote*(s: string): string =
   result = "'"
   for c in items(s):
     if c == '\'': add(result, "''")
+    if c == '\\': add(result, "\\\\")
     else: add(result, c)
   add(result, '\'')
 


### PR DESCRIPTION
Currently, inserting a string with backslashes results in a broken input. This patch replaces a single `\` with `\\`.