### PR TITLE
Implemented `in` operator support for JsonNode objects

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -848,6 +848,16 @@ proc hasKey*(node: JsonNode, key: string): bool =
   assert(node.kind == JObject)
   result = node.fields.hasKey(key)
 
+proc contains*(node: JsonNode, key: string): bool =
+  ## Checks if `key` exists in `node`.
+  assert(node.kind == JObject)
+  node.fields.hasKey(key)
+
+proc contains*(node: JsonNode, val: JsonNode): bool =
+  ## Checks if `val` exists in array `node`.
+  assert(node.kind == JArray)
+  find(node.elems, val) >= 0
+
 proc existsKey*(node: JsonNode, key: string): bool {.deprecated.} = node.hasKey(key)
   ## Deprecated for `hasKey`
 


### PR DESCRIPTION
JSON itself uses table/seq semantics for nodes and arrays, so it is naturally to have `in` operator supported for it, so the next code is possible:
```nim
import json

let x: JsonNode = %*{
    "a": 1,
    "b": 2,
    "c": ["hello", "world", "found", "in", "here"]
}

echo "a" in x                # true 
echo "d" in x                # false
echo %"found" in x["c"]      # true
echo %"not-found" in x["c"]  # false
```