### PR TITLE
Add timedWaitFor() in asyncdispatch

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1969,3 +1969,9 @@ proc waitFor*[T](fut: Future[T]): T =
     poll()
 
   fut.read
+
+proc timedWaitFor*[T](fut: Future[T], timeout: int = 500): bool =
+  ## **Blocks** the current thread until the specified future completes or timeouts.
+  ## Returns true if the future was completed, false otherwise.
+  waitFor fut or sleepAsync(timeout)
+  return fut.finished


### PR DESCRIPTION
Minor function useful for waiting until a future completes or timeouts.

This is useful in unit testing when waiting a future which completion means that the test has passed, where either the test completes successfully (function returns true because of future completion) or the test fails (function returns false because of timeout).