### PR TITLE
Fix disabling hintProcessing

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -185,6 +185,7 @@ proc processSpecificNote(arg: string, state: TSpecialWord, pass: TCmdLinePass,
   of wOff:
     excl(gNotes, n)
     incl(disableNotes, n)
+    excl(ForeignPackageNotes, n)
   else: localError(info, errOnOrOffExpectedButXFound, arg)
 
 proc processCompile(filename: string) =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -502,8 +502,6 @@ type
   ESuggestDone* = object of Exception
 
 const
-  ForeignPackageNotes*: TNoteKinds = {hintProcessing, warnUnknownMagic,
-    hintQuitCalled}
   NotesVerbosity*: array[0..3, TNoteKinds] = [
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
@@ -531,6 +529,8 @@ const
   InvalidFileIDX* = int32(-1)
 
 var
+  ForeignPackageNotes*: TNoteKinds = {hintProcessing, warnUnknownMagic,
+    hintQuitCalled}
   filenameToIndexTbl = initTable[string, int32]()
   fileInfos*: seq[TFileInfo] = @[]
   systemFileIdx*: int32


### PR DESCRIPTION
This patch fixes not being able to completely disable Processing hint via command line with --hint[Processing]:off