### PR TITLE
Fix a small typo in the manual

### DIFF
--- a/doc/manual/procs.txt
+++ b/doc/manual/procs.txt
@@ -619,7 +619,7 @@ Note that ``system.finished`` is error prone to use because it only returns
   3
   0
 
-Instead this code has be used:
+Instead this code has to be used:
 
 .. code-block:: nim
   var c = mycount # instantiate the iterator


### PR DESCRIPTION
I briefly considered moving instead to the end of the sentence, but looking at the manual it seems to favor leading with instead in lines such as these:

> instead a helper distinct or object type has to be used
> and instead the generated code should contain an #include
> to instead refer to the imported name via the namespace::identifier notation

It only seems to end with instead when the sentence can't easily be reworked to move it to the beginning, for example:
> However, depending on the use case new Foo can also be wrapped like this instead: