### PR TITLE
Fix a warning about result reused in macros.nim.

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -758,12 +758,12 @@ template findChild*(n: NimNode; cond: expr): NimNode {.
   ##   var res = findChild(n, it.kind == nnkPostfix and
   ##                          it.basename.ident == !"foo")
   block:
-    var result: NimNode
+    var res: NimNode
     for it in n.children:
       if cond:
-        result = it
+        res = it
         break
-    result
+    res
 
 proc insert*(a: NimNode; pos: int; b: NimNode) {.compileTime.} =
   ## Insert node B into A at pos


### PR DESCRIPTION
When using the findChild template you get a warning about shadowed result variable. This is easily fixed by naming it differently. Which I did.