### PR TITLE
Implemented terminal.getch() for Windows

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -502,8 +502,8 @@ proc getch*(): char =
     var numRead: cint 
     while true:
       # Block until character is entered
-      assert(waitForSingleObject(fd, INFINITE) == WAIT_OBJECT_0)
-      assert(readConsoleInput(fd, addr(keyEvent), 1, addr(numRead)) != 0)
+      doAssert(waitForSingleObject(fd, INFINITE) == WAIT_OBJECT_0)
+      doAssert(readConsoleInput(fd, addr(keyEvent), 1, addr(numRead)) != 0)
       if numRead == 0 or keyEvent.eventType != 1 or keyEvent.bKeyDown == 0:
         continue
       return char(keyEvent.uChar)

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1019,23 +1019,21 @@ proc wsaResetEvent*(hEvent: Handle): bool
      {.stdcall, importc: "WSAResetEvent", dynlib: "ws2_32.dll".}
 
 type
-  INPUT_RECORD* {.final, pure.} = object
-    eventType*: int16
-    padding: array[18, byte]
   KEY_EVENT_RECORD* {.final, pure.} = object
-    eventType*: int16
+    eventType*: uint16
+    # padding: array[2, byte]
     bKeyDown*: WINBOOL
-    wRepeatCount*: int16
-    wVirtualKeyCode*: int16
-    wVirtualScanCode*: int16
-    UnicodeChar*: int16
+    wRepeatCount*: uint16
+    wVirtualKeyCode*: uint16
+    wVirtualScanCode*: uint16
+    uChar*: uint16
     dwControlKeyState*: DWORD
 
 when defined(useWinAnsi):
   proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                         lpNumberOfEventsRead: ptr cint): cint
-       {.header: "<windows.h>", importc: "ReadConsoleInputA".}
+       {.dynlib: "kernel32", importc: "ReadConsoleInputA".}
 else:
   proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                         lpNumberOfEventsRead: ptr cint): cint
-       {.header: "<windows.h>", importc: "ReadConsoleInputW".}
+       {.dynlib: "kernel32", importc: "ReadConsoleInputW".}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1020,20 +1020,19 @@ proc wsaResetEvent*(hEvent: Handle): bool
 
 type
   KEY_EVENT_RECORD* {.final, pure.} = object
-    eventType*: uint16
-    # padding: array[2, byte]
+    eventType*: int16
     bKeyDown*: WINBOOL
-    wRepeatCount*: uint16
-    wVirtualKeyCode*: uint16
-    wVirtualScanCode*: uint16
-    uChar*: uint16
+    wRepeatCount*: int16
+    wVirtualKeyCode*: int16
+    wVirtualScanCode*: int16
+    uChar*: int16
     dwControlKeyState*: DWORD
 
 when defined(useWinAnsi):
   proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                         lpNumberOfEventsRead: ptr cint): cint
-       {.dynlib: "kernel32", importc: "ReadConsoleInputA".}
+       {.stdcall, dynlib: "kernel32", importc: "ReadConsoleInputA".}
 else:
   proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                         lpNumberOfEventsRead: ptr cint): cint
-       {.dynlib: "kernel32", importc: "ReadConsoleInputW".}
+       {.stdcall, dynlib: "kernel32", importc: "ReadConsoleInputW".}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1017,3 +1017,25 @@ proc wsaCloseEvent*(hEvent: Handle): bool
 
 proc wsaResetEvent*(hEvent: Handle): bool
      {.stdcall, importc: "WSAResetEvent", dynlib: "ws2_32.dll".}
+
+type
+  INPUT_RECORD* {.final, pure.} = object
+    eventType*: int16
+    padding: array[18, byte]
+  KEY_EVENT_RECORD* {.final, pure.} = object
+    eventType*: int16
+    bKeyDown*: WINBOOL
+    wRepeatCount*: int16
+    wVirtualKeyCode*: int16
+    wVirtualScanCode*: int16
+    UnicodeChar*: int16
+    dwControlKeyState*: DWORD
+
+when defined(useWinAnsi):
+  proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
+                        lpNumberOfEventsRead: ptr cint): cint
+       {.header: "<windows.h>", importc: "ReadConsoleInputA".}
+else:
+  proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
+                        lpNumberOfEventsRead: ptr cint): cint
+       {.header: "<windows.h>", importc: "ReadConsoleInputW".}


### PR DESCRIPTION
Implemented Windows version of `getch` proc for module `terminal`.

The only issue I have is that for some reason dynamic linkage for `readConsoleInput` proc doesn't work. When this proc gets called several times program just crashes without any message, with static linkage everything works great. I guess there are problem with [INPUT_RECORD](https://msdn.microsoft.com/en-us/library/windows/desktop/ms683499(v=vs.85).aspx) struct which is actually an union. I didn't get how to properly handle unions, so I did it same way as it being done in sdl2 module.