### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{nim,nimble}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Editorconfig helps editors maintain styling for projects, ensuring that
style guides are followed.

This editorconfig is pretty simple, as it only forces spaces rather than
tabs for indentation with an indent size of 2. It also forces line feeds
for newlines.