### PR TITLE
Adding isNilOrEmpty and isNilOrWhitespace

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -331,7 +331,7 @@ proc isNilOrEmpty*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIs
   ## Checks if `s` is nil or empty.
   result = len(s) == 0
 
-proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIsNilOrWhitespace".} = isSpace(s)
+proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIsNilOrWhitespace".} =
   ## Checks if `s` is nil or consists entirely of whitespace characters.
   ##
   ## This is an alias to `isSpace`.

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -333,8 +333,13 @@ proc isNilOrEmpty*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIs
 
 proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIsNilOrWhitespace".} =
   ## Checks if `s` is nil or consists entirely of whitespace characters.
-  ##
-  ## This is an alias to `isSpace`.
+  if len(s) == 0:
+    return true
+
+  result = true
+  for c in s:
+    if not c.isSpace():
+      return false
 
 iterator split*(s: string, seps: set[char] = Whitespace,
                 maxsplit: int = -1): string =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -160,7 +160,8 @@ proc isSpace*(s: string): bool {.noSideEffect, procvar,
 
   result = true
   for c in s:
-    result = c.isSpace() and result
+    if not c.isSpace():
+      return false
 
 proc isLower*(s: string): bool {.noSideEffect, procvar,
   rtl, extern: "nsuIsLowerStr".}=
@@ -325,6 +326,15 @@ proc toOctal*(c: char): string {.noSideEffect, rtl, extern: "nsuToOctal".} =
   for i in countdown(2, 0):
     result[i] = chr(val mod 8 + ord('0'))
     val = val div 8
+
+proc isNilOrEmpty*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIsNilOrEmpty".} =
+  ## Checks if `s` is nil or empty.
+  result = len(s) == 0
+
+proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nsuIsNilOrWhitespace".} = isSpace(s)
+  ## Checks if `s` is nil or consists entirely of whitespace characters.
+  ##
+  ## This is an alias to `isSpace`.
 
 iterator split*(s: string, seps: set[char] = Whitespace,
                 maxsplit: int = -1): string =
@@ -2155,6 +2165,17 @@ when isMainModule:
   doAssert isSpace("\t\l \v\r\f")
   doAssert isSpace("       ")
   doAssert(not isSpace("ABc   \td"))
+
+  doAssert(isNilOrEmpty(""))
+  doAssert(isNilOrEmpty(nil))
+  doAssert(not isNilOrEmpty("test"))
+  doAssert(not isNilOrEmpty(" "))
+
+  doAssert(isNilOrWhitespace(""))
+  doAssert(isNilOrWhitespace(nil))
+  doAssert(isNilOrWhitespace("       "))
+  doAssert(isNilOrWhitespace("\t\l \v\r\f"))
+  doAssert(not isNilOrWhitespace("ABc   \td"))
 
   doAssert isLower('a')
   doAssert isLower('z')

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -95,16 +95,5 @@ assert(' '.repeat(0) == "")
 assert(" ".repeat(0) == "")
 assert(spaces(0) == "")
 
-assert(isNilOrEmpty(""))
-assert(isNilOrEmpty(nil))
-assert(not isNilOrEmpty("test"))
-assert(not isNilOrEmpty(" "))
-
-assert(isNilOrWhitespace(""))
-assert(isNilOrWhitespace(nil))
-assert(isNilOrWhitespace("       "))
-assert(isNilOrWhitespace("\t\l \v\r\f"))
-assert(not isNilOrWhitespace("ABc   \td"))
-
 main()
 #OUT ha/home/a1xyz/usr/bin

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -95,5 +95,16 @@ assert(' '.repeat(0) == "")
 assert(" ".repeat(0) == "")
 assert(spaces(0) == "")
 
+assert(isNilOrEmpty(""))
+assert(isNilOrEmpty(nil))
+assert(not isNilOrEmpty("test"))
+assert(not isNilOrEmpty(" "))
+
+assert(isNilOrWhitespace(""))
+assert(isNilOrWhitespace(nil))
+assert(isNilOrWhitespace("       "))
+assert(isNilOrWhitespace("\t\l \v\r\f"))
+assert(not isNilOrWhitespace("ABc   \td"))
+
 main()
 #OUT ha/home/a1xyz/usr/bin


### PR DESCRIPTION
As discussed in #4184, this patch adds `isNilOrEmpty` and
`isNilOrWhitespace` to `strutils`. This should close #4019.

It also modifies the existing `isSpace` proc slightly to exit early
rather than looping through all characters in a string.