### PR TITLE
Remove explicit exit from bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,5 +18,3 @@ set +x
 
 echo
 echo 'Install Nim using "./install.sh <dir>" or "sudo ./install.sh <dir>".'
-
-exit 0


### PR DESCRIPTION
Explicit `exit 0` in `bootstrap.sh` creates a nuisance to start it with `source` command without `chmod` changing. It kills terminal session. I've fix it. Don't find a reason to keep explicit exit here.