### PR TITLE
Add currentSourceDir template to the system module

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3385,6 +3385,20 @@ proc instantiationInfo*(index = -1, fullPaths = false): tuple[
 template currentSourcePath*: string = instantiationInfo(-1, true).filename
   ## returns the full file-system path of the current source
 
+template currentSourceDir*: string =
+  ## Returns the absolute path of the directory containing the current
+  ## source file
+  ##
+  ## This is useful when wrapping C/C++ libraries that must be
+  ## compiled as a part of the Nim module.
+  const fileName = instantiationInfo(-1, false).fileName
+  const filePath = instantiationInfo(-1, true).fileName
+  var   result = ""
+
+  for i in 0..<(filePath.len - fileName.len - 1):
+    result.add(filePath[i])
+  result
+
 proc raiseAssert*(msg: string) {.noinline.} =
   sysFatal(AssertionError, msg)
 


### PR DESCRIPTION
This is useful for shipping libraries which wrap C code that include .h files (i.e. requiring that `-I<path_to_headers>` be passed to the compiler).  Currently, the recommended way to accomplish this (according to IRC users) is to use currentSourcePath and split the directory and filename:
```
import os
const ThisPath* = currentSourcePath.splitPath.head

{.passC: "-I"&ThisPath&"/libfixmath/libfixmath/".}
```

Unfortunately, this method has a dependency on `import os` which breaks it in standalone environments (such as cross compiling for microcontrollers).