### PR TITLE
Fix #4275: Argument count not checked in importcpp

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -260,6 +260,8 @@ proc genOtherArg(p: BProc; ri: PNode; i: int; typ: PType): Rope =
     else:
       result = genArgNoParam(p, ri.sons[i]) #, typ.n.sons[i].sym)
   else:
+    if tfVarargs notin typ.flags:
+      localError(ri.info, "wrong argument count")
     result = genArgNoParam(p, ri.sons[i])
 
 discard """

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -262,7 +262,9 @@ proc genOtherArg(p: BProc; ri: PNode; i: int; typ: PType): Rope =
   else:
     if tfVarargs notin typ.flags:
       localError(ri.info, "wrong argument count")
-    result = genArgNoParam(p, ri.sons[i])
+      result = nil
+    else:
+      result = genArgNoParam(p, ri.sons[i])
 
 discard """
 Dot call syntax in C++


### PR DESCRIPTION
Varargs is now supported, though the check still occurs at the call, not the definition.

The drawbacks I can see are: (1) slightly greater overhead due to repeated notin checks, (2) error is reported at callsite, which is potentially misleading.

Is this okay for now, or should I find a way to check at the definition?

Note: This PR supercedes https://github.com/nim-lang/Nim/pull/4355