### PR TITLE
Add the ability to pass a value with the -d flag

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -610,7 +610,7 @@ type
     mEqIdent, mEqNimrodNode, mSameNodeType, mGetImpl,
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo, mNGenSym,
-    mNimvm
+    mNimvm, mIntDefine, mStrDefine
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -122,6 +122,13 @@ proc splitSwitch(switch: string, cmd, arg: var string, pass: TCmdLinePass,
   elif switch[i] in {':', '=', '['}: arg = substr(switch, i + 1)
   else: invalidCmdLineOption(pass, switch, info)
 
+proc hasKeyValuePair(arg: string): bool =
+  for i in 0..arg.high:
+    if arg[i] in {':', '='}:
+      return true
+
+  return false
+
 proc processOnOffSwitch(op: TOptions, arg: string, pass: TCmdLinePass,
                         info: TLineInfo) =
   case whichKeyword(arg)
@@ -342,7 +349,11 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
     discard "allow for backwards compatibility, but don't do anything"
   of "define", "d":
     expectArg(switch, arg, pass, info)
-    defineSymbol(arg)
+    if hasKeyValuePair(arg):
+      splitSwitch(arg, key, val, pass, info)
+      defineSymbol(key, val)
+    else:
+      defineSymbol(arg)
   of "undef", "u":
     expectArg(switch, arg, pass, info)
     undefSymbol(arg)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -122,13 +122,6 @@ proc splitSwitch(switch: string, cmd, arg: var string, pass: TCmdLinePass,
   elif switch[i] in {':', '=', '['}: arg = substr(switch, i + 1)
   else: invalidCmdLineOption(pass, switch, info)
 
-proc hasKeyValuePair(arg: string): bool =
-  for i in 0..arg.high:
-    if arg[i] in {':', '='}:
-      return true
-
-  return false
-
 proc processOnOffSwitch(op: TOptions, arg: string, pass: TCmdLinePass,
                         info: TLineInfo) =
   case whichKeyword(arg)
@@ -349,7 +342,7 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
     discard "allow for backwards compatibility, but don't do anything"
   of "define", "d":
     expectArg(switch, arg, pass, info)
-    if hasKeyValuePair(arg):
+    if {':', '='} in arg:
       splitSwitch(arg, key, val, pass, info)
       defineSymbol(key, val)
     else:

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -19,8 +19,8 @@ var gSymbols: StringTableRef
 const
   catNone = "false"
 
-proc defineSymbol*(symbol: string) =
-  gSymbols[symbol] = "true"
+proc defineSymbol*(symbol: string, value: string = "true") =
+  gSymbols[symbol] = value
 
 proc undefSymbol*(symbol: string) =
   gSymbols[symbol] = catNone
@@ -61,6 +61,11 @@ proc isDefined*(symbol: string): bool =
     else: discard
 
 proc isDefined*(symbol: PIdent): bool = isDefined(symbol.s)
+
+proc lookupSymbol*(symbol: string): string =
+  result = if isDefined(symbol): gSymbols[symbol] else: nil
+
+proc lookupSymbol*(symbol: PIdent): string = lookupSymbol(symbol.s)
 
 iterator definedSymbolNames*: string =
   for key, val in pairs(gSymbols):

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -902,7 +902,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: int,
       of wIntDefine:
         sym.magic = mIntDefine
       of wStrDefine:
-        sym.magic = mIntDefine
+        sym.magic = mStrDefine
       else: invalidPragma(it)
     else: invalidPragma(it)
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -63,7 +63,8 @@ const
     wImportCpp, wImportObjC, wError, wNoInit, wCompileTime, wGlobal,
     wGensym, wInject, wCodegenDecl, wGuard, wGoto, wExportNims}
   constPragmas* = {wImportc, wExportc, wHeader, wDeprecated, wMagic, wNodecl,
-    wExtern, wImportCpp, wImportObjC, wError, wGensym, wInject, wExportNims}
+    wExtern, wImportCpp, wImportObjC, wError, wGensym, wInject, wExportNims,
+    wIntDefine, wStrDefine}
   letPragmas* = varPragmas
   procTypePragmas* = {FirstCallConv..LastCallConv, wVarargs, wNosideeffect,
                       wThread, wRaises, wLocks, wTags, wGcSafe}
@@ -898,6 +899,10 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: int,
       of wBase:
         noVal(it)
         sym.flags.incl sfBase
+      of wIntDefine:
+        sym.magic = mIntDefine
+      of wStrDefine:
+        sym.magic = mIntDefine
       else: invalidPragma(it)
     else: invalidPragma(it)
 

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -640,6 +640,12 @@ proc getConstExpr(m: PSym, n: PNode): PNode =
       of mNaN: result = newFloatNodeT(NaN, n)
       of mInf: result = newFloatNodeT(Inf, n)
       of mNegInf: result = newFloatNodeT(NegInf, n)
+      of mIntDefine:
+        if isDefined(s.name):
+          result = newIntNodeT(lookupSymbol(s.name).parseInt, n)
+      of mStrDefine:
+        if isDefined(s.name):
+          result = newStrNodeT(lookupSymbol(s.name), n)
       else:
         if sfFakeConst notin s.flags: result = copyTree(s.ast)
     of {skProc, skMethod}:

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -36,6 +36,7 @@ type
     wColon, wColonColon, wEquals, wDot, wDotDot,
     wStar, wMinus,
     wMagic, wThread, wFinal, wProfiler, wObjChecks,
+    wIntDefine, wStrDefine,
 
     wDestroy,
 
@@ -121,7 +122,7 @@ const
 
     ":", "::", "=", ".", "..",
     "*", "-",
-    "magic", "thread", "final", "profiler", "objchecks",
+    "magic", "thread", "final", "profiler", "objchecks", "intdefine", "strdefine",
 
     "destroy",
 

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -11,7 +11,8 @@ Arguments:
   arguments are passed to the program being run (if --run option is selected)
 Options:
   -p, --path:PATH           add path to search paths
-  -d, --define:SYMBOL       define a conditional symbol
+  -d, --define:SYMBOL(:VAL) define a conditional symbol
+                            (Optionally: Define the value for that symbol)
   -u, --undef:SYMBOL        undefine a conditional symbol
   -f, --forceBuild          force rebuilding of all modules
   --stackTrace:on|off       turn stack tracing on|off

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -11,7 +11,8 @@ Arguments:
   arguments are passed to the program being run (if --run option is selected)
 Options:
   -p, --path:PATH           add path to search paths
-  -d, --define:SYMBOL(:VAL) define a conditional symbol
+  -d, --define:SYMBOL(:VAL)
+                            define a conditional symbol
                             (Optionally: Define the value for that symbol)
   -u, --undef:SYMBOL        undefine a conditional symbol
   -f, --forceBuild          force rebuilding of all modules

--- a/doc/manual/pragmas.txt
+++ b/doc/manual/pragmas.txt
@@ -1011,3 +1011,30 @@ debugging:
 
   # ... complex code here that produces crashes ...
 
+compile time define pragmas
+---------------------------
+
+The pragmas listed here can be used to optionally accept values from
+the -d/--define option at compile time.
+
+The implementation currently provides the following possible options (various
+others may be added later).
+
+===============  ============================================
+pragma           description
+===============  ============================================
+intdefine        Reads in a build-time define as an integer
+strdefine        Reads in a build-time define as a string
+===============  ============================================
+
+.. code-block:: nim
+   const FooBar {.intdefine.}: int = 5
+   echo FooBar
+
+.. code-block:: bash
+   nim c -d:FooBar=42 foobar.c
+
+In the above example, providing the -d flag causes the symbol
+``FooBar`` to be overwritten at compile time, printing out 42. If the
+``-d:FooBar=42`` were to be omitted, the default value of 5 would be
+used.

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -98,6 +98,11 @@ enable builds in release mode (``-d:release``) where certain safety checks are
 omitted for better performance. Another common use is the ``-d:ssl`` switch to
 activate `SSL sockets <sockets.html>`_.
 
+Additionally, you may pass a value along with the symbol: ``-d:x=y``
+which may be used in conjunction with the `compile time define
+pragmas<manual.html#implementation-specific-pragmas-compile-time-define-pragmas>`_
+to override symbols during build time.
+
 
 Configuration files
 -------------------
@@ -370,7 +375,10 @@ For example, to generate code for an `AVR`:idx: processor use this command::
 For the ``standalone`` target one needs to provide
 a file ``panicoverride.nim``.
 See ``tests/manyloc/standalone/panicoverride.nim`` for an example
-implementation.
+implementation.  Additionally, users should specify the
+amount of heap space to use with the ``-d:StandaloneHeapSize=<size>``
+command line switch.  Note that the total heap size will be
+``<size> * sizeof(float64)``.
 
 
 Nim for realtime systems

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -150,8 +150,9 @@ elif defined(windows):
     #VirtualFree(p, size, MEM_DECOMMIT)
 
 elif hostOS == "standalone":
+  const StandaloneHeapSize {.magic: "IntDefine"}: int = 1024 * PageSize
   var
-    theHeap: array[1024*PageSize, float64] # 'float64' for alignment
+    theHeap: array[StandaloneHeapSize, float64] # 'float64' for alignment
     bumpPointer = cast[int](addr theHeap)
 
   proc osAllocPages(size: int): pointer {.inline.} =

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -150,7 +150,7 @@ elif defined(windows):
     #VirtualFree(p, size, MEM_DECOMMIT)
 
 elif hostOS == "standalone":
-  const StandaloneHeapSize {.magic: "IntDefine"}: int = 1024 * PageSize
+  const StandaloneHeapSize {.intdefine.}: int = 1024 * PageSize
   var
     theHeap: array[StandaloneHeapSize, float64] # 'float64' for alignment
     bumpPointer = cast[int](addr theHeap)

--- a/web/news/version_0_15_released.rst
+++ b/web/news/version_0_15_released.rst
@@ -38,8 +38,14 @@ Library Additions
 Compiler Additions
 ------------------
 
+- The ``-d/--define`` flag can now optionally take a value to be used
+  by code at compile time.
+
 Language Additions
 ------------------
+
+- Added ``{.intdefine.}`` and ``{.strdefine.}`` macros to make use of
+  (optional) compile time defines.
 
 Bugfixes
 --------


### PR DESCRIPTION
This allows the end user to use the {.intdefine/strdefine.}
pragmas to pass values into code at compile time.  This has a nice side
effect of also allowing/requiring a default value to be assigned in the
code (see osalloc.nim/StandaloneHeapSize for an example)