### PR TITLE
Fixed reprEnum() function on 32-bit systems

### DIFF
--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -73,23 +73,20 @@ proc reprChar(x: char): string {.compilerRtl.} =
   add result, "\'"
 
 proc reprEnum(e: int, typ: PNimType): string {.compilerRtl.} =
-  # we read an 'int' but this may have been too large, so mask the other bits:
-  let b = (sizeof(int)-typ.size)*8 # bits
-  let m = 1 shl (b-1) # mask
-  var o = e and ((1 shl b)-1) # clear upper bits
-  o = (o xor m) - m # sign extend
-  # XXX we need a proper narrowing based on signedness here
-  #e and ((1 shl (typ.size*8)) - 1)
+  ## Return string representation for enumeration values
+  var n = typ.node
   if ntfEnumHole notin typ.flags:
-    if o <% typ.node.len:
-      return $typ.node.sons[o].name
+    let o = e - n.sons[0].offset
+    if o >= 0 and o <% typ.node.len:
+      return $n.sons[o].name
   else:
     # ugh we need a slow linear search:
-    var n = typ.node
     var s = n.sons
     for i in 0 .. n.len-1:
-      if s[i].offset == o: return $s[i].name
-  result = $o & " (invalid data!)"
+      if s[i].offset == e:
+        return $s[i].name
+
+  result = $e & " (invalid data!)"
 
 type
   PByteArray = ptr array[0.. 0xffff, int8]


### PR DESCRIPTION
Current implementation of reprEnum fails to work on 32-bit systems.
This version fixes it.

Bad reprEnum behaviour is only observed when there are negative enum values.
Here's an example to reproduce:
```nim
type asda = enum
    ffa = -1
    ffb
    ffc
    asda_len

let vv = asda_len
echo vv
```
The output is:
```bash
ffb
```
but has to be:
```bash
asda_len
```