### PR TITLE
Fix #4422: Reset queue element on pop. Prevent NimVM confusion. Help GC.

### DIFF
--- a/lib/pure/collections/queues.nim
+++ b/lib/pure/collections/queues.nim
@@ -152,11 +152,13 @@ proc add*[T](q: var Queue[T], item: T) =
   q.data[q.wr] = item
   q.wr = (q.wr + 1) and q.mask
 
+proc default[T](t: typedesc[T]): T {.inline.} = discard
 proc pop*[T](q: var Queue[T]): T {.inline, discardable.} =
   ## Remove and returns the first (oldest) element of the queue `q`.
   emptyCheck(q)
   dec q.count
   result = q.data[q.rd]
+  q.data[q.rd] = default(type(result))
   q.rd = (q.rd + 1) and q.mask
 
 proc enqueue*[T](q: var Queue[T], item: T) =


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/4422.

Uses `default` proc from https://github.com/nim-lang/Nim/commit/5f83e869fa000598ab38866485dc8e58dd7d90d0. Redefined here. Maybe this should be an exported/reused library function?