### PR TITLE
Recursively check literals for tyEmpty.

### DIFF
--- a/tests/types/tassignemptytuple.nim
+++ b/tests/types/tassignemptytuple.nim
@@ -1,0 +1,11 @@
+discard """
+  file: "tassignemptytuple.nim"
+  line: 11
+  errormsg: "cannot infer the type of the tuple"
+"""
+
+var
+  foo: seq[int]
+  bar: tuple[a: seq[int], b: set[char]]
+
+(foo, bar) = (@[], (@[], {}))


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/3516.
