### PR TITLE
Fix #4475

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1746,8 +1746,8 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
       if formal.ast == nil:
         if formal.typ.kind == tyVarargs:
           var container = newNodeIT(nkBracket, n.info, arrayConstr(c, n.info))
-          addSon(m.call, implicitConv(nkHiddenStdConv, formal.typ,
-                                      container, m, c))
+          setSon(m.call, formal.position + 1,
+                 implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
         else:
           # no default value
           m.state = csNoMatch

--- a/tests/overload/tissue4475.nim
+++ b/tests/overload/tissue4475.nim
@@ -1,0 +1,6 @@
+# Bug: https://github.com/nim-lang/Nim/issues/4475
+# Fix: https://github.com/nim-lang/Nim/pull/4477
+
+proc test(x: varargs[string], y: int) = discard
+
+test(y = 1)


### PR DESCRIPTION
Bug explanation: If a `varargs` formal parameter is not assigned any values at a call site, it should receive a value of the empty array, `[]`. However, the existing implementation would append this value to the end of the list of parameter values (the sons of the `nkCall` node), rather than storing it into the position corresponding to the formal parameter. The location where the value should have been stored is left unassigned and defaults to `nil`. The presence of an unexpected `nil` in the sons list caused unrelated code further on in the semantic checking pass to segfault.

Ideally we should add a regression test for this, though I'm not sure where in `tests/` would be a good place to place to put it.