### PR TITLE
findExe() now by default follows symlinks.

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -212,9 +212,7 @@ proc setDefaultLibpath*() =
 
     # Special rule to support other tools (nimble) which import the compiler
     # modules and make use of them.
-    let realNimPath = # Make sure we expand the symlink
-      if symlinkExists(findExe("nim")): expandSymlink(findExe("nim"))
-      else: findExe("nim")
+    let realNimPath = findExe("nim")
     # Find out if $nim/../../lib/system.nim exists.
     let parentNimLibPath = realNimPath.parentDir().parentDir() / "lib"
     if not fileExists(libpath / "system.nim") and

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -556,12 +556,21 @@ when declared(getEnv) or defined(nimscript):
           yield substr(s, first, last-1)
           inc(last)
 
-  proc findExe*(exe: string): string {.
+  when not defined(windows) and declared(os):
+    proc checkSymlink(path: string): bool =
+      var rawInfo: Stat
+      if lstat(path, rawInfo) < 0'i32:
+        raiseOSError(osLastError())
+      S_ISLNK(rawInfo.st_mode)
+
+  proc findExe*(exe: string, followSymlinks: bool = true): string {.
     tags: [ReadDirEffect, ReadEnvEffect, ReadIOEffect].} =
     ## Searches for `exe` in the current working directory and then
     ## in directories listed in the ``PATH`` environment variable.
     ## Returns "" if the `exe` cannot be found. On DOS-like platforms, `exe`
     ## is added the `ExeExt <#ExeExt>`_ file extension if it has none.
+    ## If the system supports symlinks it also resolves them until it
+    ## meets the actual file. This behavior can be disabled if desired.
     result = addFileExt(exe, ExeExt)
     if existsFile(result): return
     var path = string(getEnv("PATH"))
@@ -572,7 +581,22 @@ when declared(getEnv) or defined(nimscript):
                result
       else:
         var x = expandTilde(candidate) / result
-      if existsFile(x): return x
+      if existsFile(x):
+        when not defined(windows) and declared(os):
+          while followSymlinks: # doubles as if here
+            if x.checkSymlink:
+              var r = newString(256)
+              var len = readlink(x, r, 256)
+              if len < 0:
+                raiseOSError(osLastError())
+              if len > 256:
+                r = newString(len+1)
+                len = readlink(x, r, len)
+              setLen(r, len)
+              x = r
+            else:
+              break
+        return x
     result = ""
 
 when defined(nimscript) or (defined(nimdoc) and not declared(os)):


### PR DESCRIPTION
`findExe()` now resolves symlinks on default. This is not supported in nimscript so far (when `ospath` is included instead of `os`)

The reason to change this is that the compiler normally looks into `bin/nim/../lib` for libraries (nim being the executable in this fake path notation). So if the compiler is linked somewhere else (like `~/bin/` it had some code to resolve this. But that code just followed one symlink and was only in the compiler. There are other tools which utilize the compiler. Nimsuggest as such did not have this symlink following. That caused strange problems, mostly because nimsuggest runs "invisible" which makes it hard to see what is happening.

By changing `findExe()` to resolve the path to the real binary file those problems can be circumvented. Resulting in a more consistent behavior of tools which use the compiler code as basis. 