### PR TITLE
Fixed findExe behaviour on Linux with symlinks relative paths

### DIFF
--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -592,7 +592,10 @@ when declared(getEnv) or defined(nimscript):
                 r = newString(len+1)
                 len = readlink(x, r, len)
               setLen(r, len)
-              x = r
+              if isAbsolute(r):
+                x = r
+              else:
+                x = parentDir(x) / r
             else:
               break
         return x


### PR DESCRIPTION
FindExe is broken after last fix on Linux.

The problem is that symlinks can have relative paths, e.g.:
```bash
krolik@krolik-nb:~/Projects/nim$ which firefox
/usr/bin/firefox
krolik@krolik-nb:~/Projects/nim$ ll /usr/bin/firefox 
lrwxrwxrwx 1 root root 25 чер  6 15:43 /usr/bin/firefox -> ../lib/firefox/firefox.sh*
```
In this case symlink's source node is defined by relative path. This fix though does not populate normalized path to symlink's source, still fixes the issue.
 