### PR TITLE
htmlparser: Allow <p> as children of <dd> and <li> Fixes #4064 

### DIFF
--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -464,9 +464,15 @@ proc untilElementEnd(x: var XmlParser, result: XmlNode,
     case x.kind
     of xmlElementStart, xmlElementOpen:
       case result.htmlTag
-      of tagLi, tagP, tagDt, tagDd, tagInput, tagOption:
-        # some tags are common to have no ``</end>``, like ``<li>``:
+      of tagP, tagInput, tagOption:
+        # some tags are common to have no ``</end>``, like ``<li>`` but
+        # allow ``<p>`` in `<dd>`, `<dt>` and ``<li>`` in next case
         if htmlTag(x.elemName) in {tagLi, tagP, tagDt, tagDd, tagInput,
+                                   tagOption}:
+          errors.add(expected(x, result))
+          break
+      of tagDd, tagDt, tagLi:
+        if htmlTag(x.elemName) in {tagLi, tagDt, tagDd, tagInput,
                                    tagOption}:
           errors.add(expected(x, result))
           break

--- a/tests/stdlib/thtmlparser2814.nim
+++ b/tests/stdlib/thtmlparser2814.nim
@@ -1,0 +1,38 @@
+discard """
+  output: "@[]"
+"""
+import htmlparser
+import xmltree
+import strutils
+from streams import newStringStream
+
+
+## builds the two cases below and test that
+## ``//[dd,li]`` has "<p>that</p>" as children
+##
+##  <dl>
+##    <dt>this</dt>
+##    <dd>
+##      <p>that</p>
+##    </dd>
+##  </dl>
+
+##
+## <ul>
+##   <li>
+##     <p>that</p>
+##   </li>
+## </ul>
+
+for ltype in [["dl","dd"], ["ul","li"]]:
+  let desc_item = if ltype[0]=="dl": "<dt>this</dt>" else: ""
+  let item = "$1<$2><p>that</p></$2>" % [desc_item, ltype[1]]
+  let list = """ <$1>
+   $2
+</$1> """ % [ltype[0], item]
+
+  var errors : seq[string] = @[]
+
+  let parseH = parseHtml(newStringStream(list),"statichtml", errors =errors)
+
+  echo $parseH.findAll(ltype[1])[0].child("p") == "<p>that</p>"

--- a/tests/stdlib/thtmlparser2814.nim
+++ b/tests/stdlib/thtmlparser2814.nim
@@ -1,5 +1,5 @@
 discard """
-  output: "@[]"
+  output: true
 """
 import htmlparser
 import xmltree
@@ -24,6 +24,7 @@ from streams import newStringStream
 ##   </li>
 ## </ul>
 
+
 for ltype in [["dl","dd"], ["ul","li"]]:
   let desc_item = if ltype[0]=="dl": "<dt>this</dt>" else: ""
   let item = "$1<$2><p>that</p></$2>" % [desc_item, ltype[1]]
@@ -35,4 +36,9 @@ for ltype in [["dl","dd"], ["ul","li"]]:
 
   let parseH = parseHtml(newStringStream(list),"statichtml", errors =errors)
 
-  echo $parseH.findAll(ltype[1])[0].child("p") == "<p>that</p>"
+  if $parseH.findAll(ltype[1])[0].child("p") != "<p>that</p>":
+    echo "case " & ltype[0] & " failed !"
+    quit(2)
+
+
+echo "true"


### PR DESCRIPTION
This fixes https://github.com/nim-lang/Nim/issues/4064 by allowing paragraphs inside lists which is pretty common. This [w3 site](http://www.w3schools.com/tags/tag_dd.asp) explicity allows for: paragraphs, line breaks, images, links, lists, etc.