### PR TITLE
make httpclient close opened Socket on error

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -446,8 +446,6 @@ proc request*(url: string, httpMethod: string, extraHeaders = "",
       s.send(body)
 
     result = parseResponse(s, httpMethod != "httpHEAD", timeout)
-  except:
-    raise
   finally:
     s.close()
 


### PR DESCRIPTION
`httpclient.request` opens a socket with `s = newSocket()` and closes it when done. However, if an error occurs (e.g. when name resolution fails and OSError is thrown from `nativesockets.nim:getAddrInfo`) the socket is not closed, resulting in "Too many open files" errors after a while.

This PR wraps everything in a `try...catch` block and closes the socket `finally`.