### PR TITLE
fix visual studio family warning

### DIFF
--- a/compiler/ccgtrav.nim
+++ b/compiler/ccgtrav.nim
@@ -143,7 +143,7 @@ proc genTraverseProcForGlobal(m: BModule, s: PSym): Rope =
 
   c.visitorFrmt = "#nimGCvisit((void*)$1, 0);$n"
   c.p = p
-  let header = "N_NIMCALL(void, $1)()" % [result]
+  let header = "N_NIMCALL(void, $1)(void)" % [result]
   genTraverseProc(c, sLoc, s.loc.t)
 
   let generatedProc = "$1 {$n$2$3$4}$n" %


### PR DESCRIPTION
this commit will fix visual studio family warning in #4459. but not VS2010 compiler error