### PR TITLE
fix #4417

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ addons:
     - libgc-dev
 before_script:
   - set -e
-  - wget http://flatassembler.net/fasm-1.71.39.tgz
-  - tar xvf fasm-1.71.39.tgz
   - git clone --depth 1 https://github.com/nim-lang/csources.git
   - cd csources
   - sh build.sh
   - cd ..
   - sed -i -e 's,cc = gcc,cc = clang,' config/nim.cfg
-  - export PATH=$(pwd)/bin:$(pwd)/fasm:$PATH
+  - export PATH=$(pwd)/bin:$PATH
 script:
   - nim c koch
   - ./koch boot

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -278,6 +278,8 @@ const
   sfImmediate* = sfDeadCodeElim
     # macro or template is immediately expanded
     # without considering any possible overloads
+  sfAllUntyped* = sfVolatile # macro or template is immediately expanded \
+    # in a generic context
 
   sfDirty* = sfPure
     # template is not hygienic (old styled template)

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -271,7 +271,6 @@ type
   TSymFlags* = set[TSymFlag]
 
 const
-  sfFakeConst* = sfDeadCodeElim  # const cannot be put into a data section
   sfDispatcher* = sfDeadCodeElim # copied method symbol is the dispatcher
   sfNoInit* = sfMainModule       # don't generate code to init the variable
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -990,12 +990,12 @@ proc add*(father, son: PNode) =
 proc `[]`*(n: PNode, i: int): PNode {.inline.} =
   result = n.sons[i]
 
-template `-|`*(b, s: expr): expr =
+template `-|`*(b, s: untyped): untyped =
   (if b >= 0: b else: s.len + b)
 
 # son access operators with support for negative indices
-template `{}`*(n: PNode, i: int): expr = n[i -| n]
-template `{}=`*(n: PNode, i: int, s: PNode): stmt =
+template `{}`*(n: PNode, i: int): untyped = n[i -| n]
+template `{}=`*(n: PNode, i: int, s: PNode) =
   n.sons[i -| n] = s
 
 when defined(useNodeIds):

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2003,10 +2003,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         internalError(n.info, "expr: proc not init " & sym.name.s)
       putLocIntoDest(p, d, sym.loc)
     of skConst:
-      if sfFakeConst in sym.flags:
-        if sfGlobal in sym.flags: genVarPrototype(p.module, sym)
-        putLocIntoDest(p, d, sym.loc)
-      elif isSimpleConst(sym.typ):
+      if isSimpleConst(sym.typ):
         putIntoDest(p, d, n.typ, genLiteral(p, sym.ast, sym.typ), OnStatic)
       else:
         genComplexConst(p, sym, d)

--- a/compiler/ccgmerge.nim
+++ b/compiler/ccgmerge.nim
@@ -113,7 +113,7 @@ proc genMergeInfo*(m: BModule): Rope =
   s.add("*/")
   result = s.rope
 
-template `^`(pos: int): expr = L.buf[pos]
+template `^`(pos: int): untyped = L.buf[pos]
 
 proc skipWhite(L: var TBaseLexer) =
   var pos = L.bufpos

--- a/compiler/ccgmerge.nim
+++ b/compiler/ccgmerge.nim
@@ -229,7 +229,7 @@ proc processMergeInfo(L: var TBaseLexer, m: BModule) =
 when not defined(nimhygiene):
   {.pragma: inject.}
 
-template withCFile(cfilename: string, body: stmt) {.immediate.} =
+template withCFile(cfilename: string, body: untyped) =
   var s = llStreamOpen(cfilename, fmRead)
   if s == nil: return
   var L {.inject.}: TBaseLexer

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -136,7 +136,7 @@ proc exprBlock(p: BProc, n: PNode, d: var TLoc) =
   expr(p, n, d)
   endBlock(p)
 
-template preserveBreakIdx(body: stmt): stmt {.immediate.} =
+template preserveBreakIdx(body: untyped): untyped =
   var oldBreakIdx = p.breakIdx
   body
   p.breakIdx = oldBreakIdx

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -269,8 +269,6 @@ proc genConstStmt(p: BProc, t: PNode) =
     if it.kind != nkConstDef: internalError(t.info, "genConstStmt")
     var c = it.sons[0].sym
     if c.typ.containsCompileTimeOnly: continue
-    if sfFakeConst in c.flags:
-      genSingleVar(p, it)
     elif c.typ.kind in ConstantDataTypes and lfNoDecl notin c.loc.flags and
         c.ast.len != 0:
       if not emitLazily(c): requestConstImpl(p, c)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -129,7 +129,7 @@ proc ropecg(m: BModule, frmt: FormatStr, args: varargs[Rope]): Rope =
     if i - 1 >= start:
       add(result, substr(frmt, start, i - 1))
 
-template rfmt(m: BModule, fmt: string, args: varargs[Rope]): expr =
+template rfmt(m: BModule, fmt: string, args: varargs[Rope]): untyped =
   ropecg(m, fmt, args)
 
 proc appcg(m: BModule, c: var Rope, frmt: FormatStr,
@@ -215,7 +215,7 @@ proc accessThreadLocalVar(p: BProc, s: PSym)
 proc emulatedThreadVars(): bool {.inline.}
 proc genProc(m: BModule, prc: PSym)
 
-template compileToCpp(m: BModule): expr =
+template compileToCpp(m: BModule): untyped =
   gCmd == cmdCompileToCpp or sfCompileToCpp in m.module.flags
 
 include "ccgtypes.nim"

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -12,7 +12,7 @@
 
 # We do this here before the 'import' statement so 'defined' does not get
 # confused with 'TGCMode.gcGenerational' etc.
-template bootSwitch(name, expr, userString: expr): expr =
+template bootSwitch(name, expr, userString) =
   # Helper to build boot constants, for debugging you can 'echo' the else part.
   const name = if expr: " " & userString else: ""
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -217,6 +217,15 @@ proc testCompileOptionArg*(switch, arg: string, info: TLineInfo): bool =
     of "none": result = gOptions * {optOptimizeSpeed, optOptimizeSize} == {}
     else: localError(info, errNoneSpeedOrSizeExpectedButXFound, arg)
   of "verbosity": result = $gVerbosity == arg
+  of "app":
+    case arg.normalize
+    of "gui":       result = contains(gGlobalOptions, optGenGuiApp)
+    of "console":   result = not contains(gGlobalOptions, optGenGuiApp)
+    of "lib":       result = contains(gGlobalOptions, optGenDynLib) and
+                      not contains(gGlobalOptions, optGenGuiApp)
+    of "staticlib": result = contains(gGlobalOptions, optGenStaticLib) and
+                      not contains(gGlobalOptions, optGenGuiApp)
+    else: localError(info, errGuiConsoleOrLibExpectedButXFound, arg)
   else: invalidCmdLineOption(passCmd1, switch, info)
 
 proc testCompileOption*(switch: string, info: TLineInfo): bool =

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -98,3 +98,4 @@ proc initDefines*() =
   defineSymbol("nimtypedescfixed")
   defineSymbol("nimKnowsNimvm")
   defineSymbol("nimArrIdx")
+  defineSymbol("nimImmediateDeprecated")

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -61,7 +61,7 @@ type
 # When adding new compilers, the cmake sources could be a good reference:
 # http://cmake.org/gitweb?p=cmake.git;a=tree;f=Modules/Platform;
 
-template compiler(name: expr, settings: stmt): stmt {.immediate.} =
+template compiler(name, settings: untyped): untyped =
   proc name: TInfoCC {.compileTime.} = settings
 
 # GNU C and C++ Compiler

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -728,12 +728,12 @@ proc simpleSlice*(a, b: PNode): BiggestInt =
     result = -1
 
 
-template isMul(x): expr = x.getMagic in someMul
-template isDiv(x): expr = x.getMagic in someDiv
-template isAdd(x): expr = x.getMagic in someAdd
-template isSub(x): expr = x.getMagic in someSub
-template isVal(x): expr = x.kind in {nkCharLit..nkUInt64Lit}
-template isIntVal(x, y): expr = x.intVal == y
+template isMul(x): untyped = x.getMagic in someMul
+template isDiv(x): untyped = x.getMagic in someDiv
+template isAdd(x): untyped = x.getMagic in someAdd
+template isSub(x): untyped = x.getMagic in someSub
+template isVal(x): untyped = x.kind in {nkCharLit..nkUInt64Lit}
+template isIntVal(x, y): untyped = x.intVal == y
 
 import macros
 
@@ -776,8 +776,8 @@ proc isMinusOne(n: PNode): bool =
 proc pleViaModel(model: TModel; aa, bb: PNode): TImplication
 
 proc ple(m: TModel; a, b: PNode): TImplication =
-  template `<=?`(a,b): expr = ple(m,a,b) == impYes
-  template `>=?`(a,b): expr = ple(m, nkIntLit.newIntNode(b), a) == impYes
+  template `<=?`(a,b): untyped = ple(m,a,b) == impYes
+  template `>=?`(a,b): untyped = ple(m, nkIntLit.newIntNode(b), a) == impYes
 
   #   0 <= 3
   if a.isValue and b.isValue:

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -176,7 +176,7 @@ proc evalImport(c: PContext, n: PNode): PNode =
     var m = myImportModule(c, n.sons[i])
     if m != nil:
       # ``addDecl`` needs to be done before ``importAllSymbols``!
-      addDecl(c, m)             # add symbol to symbol table of module
+      addDecl(c, m, n.info)             # add symbol to symbol table of module
       importAllSymbolsExcept(c, m, emptySet)
       #importForwarded(c, m.ast, emptySet)
 
@@ -186,7 +186,7 @@ proc evalFrom(c: PContext, n: PNode): PNode =
   var m = myImportModule(c, n.sons[0])
   if m != nil:
     n.sons[0] = newSymNode(m)
-    addDecl(c, m)               # add symbol to symbol table of module
+    addDecl(c, m, n.info)               # add symbol to symbol table of module
     for i in countup(1, sonsLen(n) - 1):
       if n.sons[i].kind != nkNilLit:
         importSymbol(c, n.sons[i], m)
@@ -197,7 +197,7 @@ proc evalImportExcept*(c: PContext, n: PNode): PNode =
   var m = myImportModule(c, n.sons[0])
   if m != nil:
     n.sons[0] = newSymNode(m)
-    addDecl(c, m)               # add symbol to symbol table of module
+    addDecl(c, m, n.info)               # add symbol to symbol table of module
     var exceptSet = initIntSet()
     for i in countup(1, sonsLen(n) - 1):
       let ident = lookups.considerQuotedIdent(n.sons[i])

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -95,7 +95,7 @@ type
     up: PProc     # up the call chain; required for closure support
     declaredGlobals: IntSet
 
-template `|`(a, b: expr): expr {.immediate, dirty.} =
+template `|`(a, b: untyped): untyped {.dirty.} =
   (if p.target == targetJS: a else: b)
 
 proc newGlobals(): PGlobals =

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -138,7 +138,7 @@ proc getLineInfo*(L: TLexer, tok: TToken): TLineInfo {.inline.} =
 proc isKeyword*(kind: TTokType): bool =
   result = (kind >= tokKeywordLow) and (kind <= tokKeywordHigh)
 
-template ones(n: expr): expr = ((1 shl n)-1) # for utf-8 conversion
+template ones(n): untyped = ((1 shl n)-1) # for utf-8 conversion
 
 proc isNimIdentifier*(s: string): bool =
   if s[0] in SymStartChars:
@@ -893,10 +893,10 @@ proc scanComment(L: var TLexer, tok: var TToken) =
       inc(indent)
 
     when defined(nimfix):
-      template doContinue(): expr =
+      template doContinue(): untyped =
         buf[pos] == '#' and (col == indent or lastBackslash > 0)
     else:
-      template doContinue(): expr =
+      template doContinue(): untyped =
         buf[pos] == '#' and buf[pos+1] == '#'
     if doContinue():
       tok.literal.add "\n"
@@ -942,9 +942,9 @@ proc skip(L: var TLexer, tok: var TToken) =
           break
       tok.strongSpaceA = 0
       when defined(nimfix):
-        template doBreak(): expr = buf[pos] > ' '
+        template doBreak(): untyped = buf[pos] > ' '
       else:
-        template doBreak(): expr =
+        template doBreak(): untyped =
           buf[pos] > ' ' and (buf[pos] != '#' or buf[pos+1] == '#')
       if doBreak():
         tok.indent = indent

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -162,6 +162,10 @@ proc wrongRedefinition*(info: TLineInfo, s: string) =
   if gCmd != cmdInteractive:
     localError(info, errAttemptToRedefine, s)
 
+proc addDecl*(c: PContext, sym: PSym, info: TLineInfo) =
+  if not c.currentScope.addUniqueSym(sym):
+    wrongRedefinition(info, sym.name.s)
+
 proc addDecl*(c: PContext, sym: PSym) =
   if not c.currentScope.addUniqueSym(sym):
     wrongRedefinition(sym.info, sym.name.s)

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -217,14 +217,14 @@ when defined(nimfix):
     of 'a'..'z': result = getIdent(toLower(x.s[0]) & x.s.substr(1))
     else: result = x
 
-  template fixSpelling(n: PNode; ident: PIdent; op: expr) =
+  template fixSpelling(n: PNode; ident: PIdent; op: untyped) =
     let alt = ident.altSpelling
     result = op(c, alt).skipAlias(n)
     if result != nil:
       prettybase.replaceDeprecated(n.info, ident, alt)
       return result
 else:
-  template fixSpelling(n: PNode; ident: PIdent; op: expr) = discard
+  template fixSpelling(n: PNode; ident: PIdent; op: untyped) = discard
 
 proc errorUseQualifier*(c: PContext; info: TLineInfo; s: PSym) =
   var err = "Error: ambiguous identifier: '" & s.name.s & "'"

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -38,7 +38,7 @@ proc getModule*(fileIdx: int32): PSym =
   if fileIdx >= 0 and fileIdx < gCompiledModules.len:
     result = gCompiledModules[fileIdx]
 
-template hash(x: PSym): expr =
+template hash(x: PSym): untyped =
   gMemCacheData[x.position].hash
 
 proc hashChanged(fileIdx: int32): bool =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -760,7 +760,7 @@ proc msgWriteln*(s: string, flags: MsgFlags = {}) =
         flushFile(stderr)
 
 macro callIgnoringStyle(theProc: typed, first: typed,
-                        args: varargs[expr]): stmt =
+                        args: varargs[typed]): untyped =
   let typForegroundColor = bindSym"ForegroundColor".getType
   let typBackgroundColor = bindSym"BackgroundColor".getType
   let typStyle = bindSym"Style".getType
@@ -777,7 +777,7 @@ macro callIgnoringStyle(theProc: typed, first: typed,
        typ != typTerminalCmd:
       result.add(arg)
 
-macro callStyledWriteLineStderr(args: varargs[expr]): stmt =
+macro callStyledWriteLineStderr(args: varargs[typed]): untyped =
   result = newCall(bindSym"styledWriteLine")
   result.add(bindSym"stderr")
   for arg in children(args[0][1]):
@@ -789,7 +789,7 @@ template callWritelnHook(args: varargs[string, `$`]) =
     s.add arg
   writelnHook s
 
-template styledMsgWriteln*(args: varargs[expr]) =
+template styledMsgWriteln*(args: varargs[typed]) =
   if not isNil(writelnHook):
     callIgnoringStyle(callWritelnHook, nil, args)
   elif optStdout in gGlobalOptions:
@@ -1000,11 +1000,11 @@ proc internalError*(errMsg: string) =
   writeContext(unknownLineInfo())
   rawMessage(errInternal, errMsg)
 
-template assertNotNil*(e: expr): expr =
+template assertNotNil*(e): untyped =
   if e == nil: internalError($instantiationInfo())
   e
 
-template internalAssert*(e: bool): stmt =
+template internalAssert*(e: bool) =
   if not e: internalError($instantiationInfo())
 
 proc addSourceLine*(fileIdx: int32, line: string) =

--- a/compiler/nimsets.nim
+++ b/compiler/nimsets.nim
@@ -121,7 +121,7 @@ proc toTreeSet(s: TBitSet, settype: PType, info: TLineInfo): PNode =
       e = b
     inc(e)
 
-template nodeSetOp(a, b: PNode, op: expr) {.dirty.} =
+template nodeSetOp(a, b: PNode, op: untyped) {.dirty.} =
   var x, y: TBitSet
   toBitSet(a, x)
   toBitSet(b, y)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -129,10 +129,10 @@ var
 proc importantComments*(): bool {.inline.} = gCmd in {cmdDoc, cmdIdeTools}
 proc usesNativeGC*(): bool {.inline.} = gSelectedGC >= gcRefc
 
-template compilationCachePresent*: expr =
+template compilationCachePresent*: untyped =
   {optCaasEnabled, optSymbolFiles} * gGlobalOptions != {}
 
-template optPreserveOrigSource*: expr =
+template optPreserveOrigSource*: untyped =
   optEmbedOrigSrc in gGlobalOptions
 
 const
@@ -405,10 +405,10 @@ proc binaryStrSearch*(x: openArray[string], y: string): int =
       return mid
   result = - 1
 
-template nimdbg*: expr = c.module.fileIdx == gProjectMainIdx
-template cnimdbg*: expr = p.module.module.fileIdx == gProjectMainIdx
-template pnimdbg*: expr = p.lex.fileIdx == gProjectMainIdx
-template lnimdbg*: expr = L.fileIdx == gProjectMainIdx
+template nimdbg*: untyped = c.module.fileIdx == gProjectMainIdx
+template cnimdbg*: untyped = p.module.module.fileIdx == gProjectMainIdx
+template pnimdbg*: untyped = p.lex.fileIdx == gProjectMainIdx
+template lnimdbg*: untyped = L.fileIdx == gProjectMainIdx
 
 proc parseIdeCmd*(s: string): IdeCmd =
   case s:

--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -15,7 +15,7 @@ iterator myParentDirs(p: string): string =
     if current.len == 0: break
     yield current
 
-template newPackageCache(): expr =
+template newPackageCache(): untyped =
   newStringTable(when FileSystemCaseSensitive:
                    modeCaseInsensitive
                  else:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -202,7 +202,7 @@ proc isRightAssociative(tok: TToken): bool {.inline.} =
 
 proc getPrecedence(tok: TToken, strongSpaces: bool): int =
   ## Calculates the precedence of the given token.
-  template considerStrongSpaces(x): expr =
+  template considerStrongSpaces(x): untyped =
     x + (if strongSpaces: 100 - tok.strongSpaceA.int*10 else: 0)
 
   case tok.tokType
@@ -214,7 +214,7 @@ proc getPrecedence(tok: TToken, strongSpaces: bool): int =
     if L > 1 and tok.ident.s[L-1] == '>' and
       tok.ident.s[L-2] in {'-', '~', '='}: return considerStrongSpaces(1)
 
-    template considerAsgn(value: expr) =
+    template considerAsgn(value: untyped) =
       result = if tok.ident.s[L-1] == '=': 1 else: value
 
     case relevantChar

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -98,7 +98,7 @@ proc parMessage(p: TParser, msg: TMsgKind, tok: TToken) =
   ## Produce and emit a parser message to output about the token `tok`
   parMessage(p, msg, prettyTok(tok))
 
-template withInd(p: expr, body: stmt) {.immediate.} =
+template withInd(p, body: untyped) =
   let oldInd = p.currInd
   p.currInd = p.tok.indent
   body

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -626,7 +626,10 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: int,
         processImportCompilerProc(sym, getOptionalStr(c, it, "$1"))
       of wExtern: setExternName(sym, expectStrLit(c, it))
       of wImmediate:
-        if sym.kind in {skTemplate, skMacro}: incl(sym.flags, sfImmediate)
+        if sym.kind in {skTemplate, skMacro}:
+          incl(sym.flags, sfImmediate)
+          incl(sym.flags, sfAllUntyped)
+          message(n.info, warnDeprecated, "use 'untyped' parameters instead; immediate")
         else: invalidPragma(it)
       of wDirty:
         if sym.kind == skTemplate: incl(sym.flags, sfDirty)

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -64,7 +64,7 @@ const
 const
   vintDelta = 5
 
-template encodeIntImpl(self: expr) =
+template encodeIntImpl(self) =
   var d: char
   var v = x
   var rem = v mod 190

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -53,7 +53,18 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
     if symx.kind in filter:
       syms.add((symx, o.lastOverloadScope))
     symx = nextOverloadIter(o, c, headSymbol)
-  if syms.len == 0: return
+  if syms.len == 0:
+    when false:
+      if skIterator notin filter:
+        # also try iterators, but these are 2nd class:
+        symx = initOverloadIter(o, c, headSymbol)
+        while symx != nil:
+          if symx.kind == skIterator:
+            syms.add((symx, 100))
+          symx = nextOverloadIter(o, c, headSymbol)
+        if syms.len == 0: return
+    else:
+      return
 
   var z: TCandidate
   initCandidate(c, best, syms[0][0], initialBinding, symScope)

--- a/compiler/semdestruct.nim
+++ b/compiler/semdestruct.nim
@@ -87,7 +87,7 @@ proc destroyCase(c: PContext, n: PNode, holder: PNode): PNode =
     result = nil
 
 proc destroyFieldOrFields(c: PContext, field: PNode, holder: PNode): PNode =
-  template maybeAddLine(e: expr): stmt =
+  template maybeAddLine(e) =
     let stmt = e
     if stmt != nil:
       if result == nil: result = newNode(nkStmtList)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1363,7 +1363,7 @@ proc asgnToResultVar(c: PContext, n, le, ri: PNode) {.inline.} =
       n.sons[1] = takeImplicitAddr(c, ri)
       x.typ.flags.incl tfVarIsPtr
 
-template resultTypeIsInferrable(typ: PType): expr =
+template resultTypeIsInferrable(typ: PType): untyped =
   typ.isMetaType and typ.kind != tyTypeDesc
 
 proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
@@ -1888,7 +1888,7 @@ proc semWhen(c: PContext, n: PNode, semCheck = true): PNode =
   # the correct branch. Otherwise the AST will be passed through semStmt.
   result = nil
 
-  template setResult(e: expr) =
+  template setResult(e: untyped) =
     if semCheck: result = semExpr(c, e) # do not open a new scope!
     else: result = e
 

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -648,7 +648,7 @@ proc getConstExpr(m: PSym, n: PNode): PNode =
         if isDefined(s.name):
           result = newStrNodeT(lookupSymbol(s.name), n)
       else:
-        if sfFakeConst notin s.flags: result = copyTree(s.ast)
+        result = copyTree(s.ast)
     of {skProc, skMethod}:
       result = n
     of skType:

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -143,7 +143,7 @@ proc getIntervalType*(m: TMagic, n: PNode): PType =
   const ordIntLit = {nkIntLit..nkUInt64Lit}
   result = n.typ
 
-  template commutativeOp(opr: expr) {.immediate.} =
+  template commutativeOp(opr: untyped) =
     let a = n.sons[1]
     let b = n.sons[2]
     if isIntRangeOrLit(a.typ) and isIntRangeOrLit(b.typ):
@@ -151,7 +151,7 @@ proc getIntervalType*(m: TMagic, n: PNode): PType =
                          opr(pickMinInt(a), pickMinInt(b)),
                          opr(pickMaxInt(a), pickMaxInt(b)))
 
-  template binaryOp(opr: expr) {.immediate.} =
+  template binaryOp(opr: untyped) =
     let a = n.sons[1]
     let b = n.sons[2]
     if isIntRange(a.typ) and b.kind in {nkIntLit..nkUInt64Lit}:

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -47,10 +47,10 @@ proc semGenericStmtScope(c: PContext, n: PNode,
   result = semGenericStmt(c, n, flags, ctx)
   closeScope(c)
 
-template macroToExpand(s: expr): expr =
+template macroToExpand(s): untyped =
   s.kind in {skMacro, skTemplate} and (s.typ.len == 1 or sfAllUntyped in s.flags)
 
-template macroToExpandSym(s: expr): expr =
+template macroToExpandSym(s): untyped =
   s.kind in {skMacro, skTemplate} and (s.typ.len == 1)
 
 proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -48,7 +48,10 @@ proc semGenericStmtScope(c: PContext, n: PNode,
   closeScope(c)
 
 template macroToExpand(s: expr): expr =
-  s.kind in {skMacro, skTemplate} and (s.typ.len == 1 or sfImmediate in s.flags)
+  s.kind in {skMacro, skTemplate} and (s.typ.len == 1 or sfAllUntyped in s.flags)
+
+template macroToExpandSym(s: expr): expr =
+  s.kind in {skMacro, skTemplate} and (s.typ.len == 1)
 
 proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
                           ctx: var GenericCtx): PNode =
@@ -61,14 +64,14 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
   of skProc, skMethod, skIterator, skConverter, skModule:
     result = symChoice(c, n, s, scOpen)
   of skTemplate:
-    if macroToExpand(s):
+    if macroToExpandSym(s):
       styleCheckUse(n.info, s)
       result = semTemplateExpr(c, n, s, {efNoSemCheck})
       result = semGenericStmt(c, result, {}, ctx)
     else:
       result = symChoice(c, n, s, scOpen)
   of skMacro:
-    if macroToExpand(s):
+    if macroToExpandSym(s):
       styleCheckUse(n.info, s)
       result = semMacroExpr(c, n, n, s, {efNoSemCheck})
       result = semGenericStmt(c, result, {}, ctx)

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -121,7 +121,7 @@ proc checkLocal(c: AnalysisCtx; n: PNode) =
   else:
     for i in 0 .. <n.safeLen: checkLocal(c, n.sons[i])
 
-template `?`(x): expr = x.renderTree
+template `?`(x): untyped = x.renderTree
 
 proc checkLe(c: AnalysisCtx; a, b: PNode) =
   case proveLe(c.guards, a, b)

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -260,7 +260,7 @@ proc min(a, b: PNode): PNode =
 
 proc fromSystem(op: PSym): bool = sfSystemModule in getModule(op).flags
 
-template pushSpawnId(c: expr, body: stmt) {.immediate, dirty.} =
+template pushSpawnId(c, body) {.dirty.} =
   inc c.spawns
   let oldSpawnId = c.currentSpawnId
   c.currentSpawnId = c.spawns

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -151,7 +151,7 @@ proc guardDotAccess(a: PEffects; n: PNode) =
     guardGlobal(a, n, g)
 
 proc makeVolatile(a: PEffects; s: PSym) {.inline.} =
-  template compileToCpp(a): expr =
+  template compileToCpp(a): untyped =
     gCmd == cmdCompileToCpp or sfCompileToCpp in getModule(a.owner).flags
   if a.inTryStmt > 0 and not compileToCpp(a):
     incl(s.flags, sfVolatile)
@@ -459,7 +459,7 @@ proc documentRaises*(n: PNode) =
     if p4 != nil: n.sons[pragmasPos].add p4
     if p5 != nil: n.sons[pragmasPos].add p5
 
-template notGcSafe(t): expr = {tfGcSafe, tfNoSideEffect} * t.flags == {}
+template notGcSafe(t): untyped = {tfGcSafe, tfNoSideEffect} * t.flags == {}
 
 proc importedFromC(n: PNode): bool =
   # when imported from C, we assume GC-safety.

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -632,7 +632,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     c.patterns.add(s)
 
 proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
-  template templToExpand(s: expr): expr =
+  template templToExpand(s: untyped): untyped =
     s.kind == skTemplate and (s.typ.len == 1 or sfAllUntyped in s.flags)
 
   proc newParam(c: var TemplCtx, n: PNode, s: PSym): PNode =

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -754,18 +754,18 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
     addDecl(c, s)
 
   # XXX: There are codegen errors if this is turned into a nested proc
-  template liftingWalk(typ: PType, anonFlag = false): expr =
+  template liftingWalk(typ: PType, anonFlag = false): untyped =
     liftParamType(c, procKind, genericParams, typ, paramName, info, anonFlag)
   #proc liftingWalk(paramType: PType, anon = false): PType =
 
   var paramTypId = if not anon and paramType.sym != nil: paramType.sym.name
                    else: nil
 
-  template maybeLift(typ: PType): expr =
+  template maybeLift(typ: PType): untyped =
     let lifted = liftingWalk(typ)
     (if lifted != nil: lifted else: typ)
 
-  template addImplicitGeneric(e: expr): expr =
+  template addImplicitGeneric(e): untyped =
     addImplicitGenericImpl(e, paramTypId)
 
   case paramType.kind:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -511,6 +511,6 @@ proc generateTypeInstance*(p: PContext, pt: TIdTable, info: TLineInfo,
   popInfoContext()
 
 template generateTypeInstance*(p: PContext, pt: TIdTable, arg: PNode,
-                               t: PType): expr =
+                               t: PType): untyped =
   generateTypeInstance(p, pt, arg.info, t)
 

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -575,7 +575,7 @@ proc matchUserTypeClass*(c: PContext, m: var TCandidate,
         typ = ff.sons[i]
         param: PSym
 
-      template paramSym(kind): expr =
+      template paramSym(kind): untyped =
         newSym(kind, typeParamName, body.sym, body.sym.info)
 
       case typ.kind
@@ -1585,7 +1585,7 @@ proc incrIndexType(t: PType) =
   assert t.kind == tyArrayConstr
   inc t.sons[0].n.sons[1].intVal
 
-template isVarargsUntyped(x): expr =
+template isVarargsUntyped(x): untyped =
   x.kind == tyVarargs and x.sons[0].kind == tyExpr and
     tfOldSchoolExprStmt notin x.sons[0].flags
 

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -691,7 +691,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType, doBind = true): TTypeRelation =
       put(c.bindings, f, bound)
     return res
 
-  template considerPreviousT(body: stmt) {.immediate.} =
+  template considerPreviousT(body: untyped) =
     var prev = PType(idTableGet(c.bindings, f))
     if prev == nil: body
     else: return typeRel(c, prev, a)
@@ -1591,7 +1591,7 @@ template isVarargsUntyped(x): expr =
 
 proc matchesAux(c: PContext, n, nOrig: PNode,
                 m: var TCandidate, marker: var IntSet) =
-  template checkConstraint(n: expr) {.immediate, dirty.} =
+  template checkConstraint(n: untyped) {.dirty.} =
     if not formal.constraint.isNil:
       if matchNodeKinds(formal.constraint, n):
         # better match over other routines with no such restriction:
@@ -1816,7 +1816,7 @@ proc instTypeBoundOp*(c: PContext; dc: PSym; t: PType; info: TLineInfo;
 include suggest
 
 when not declared(tests):
-  template tests(s: stmt) {.immediate.} = discard
+  template tests(s: untyped) = discard
 
 tests:
   var dummyOwner = newSym(skModule, getIdent("test_module"), nil, UnknownLineInfo())

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -138,7 +138,7 @@ proc suggestField(c: PContext, s: PSym, outputs: var int) =
     suggestResult(symToSuggest(s, isLocal=true, $ideSug, 100))
     inc outputs
 
-template wholeSymTab(cond, section: expr) {.immediate.} =
+template wholeSymTab(cond, section: untyped) =
   var isLocal = true
   for scope in walkScopes(c.currentScope):
     if scope == c.topLevelScope: isLocal = false

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -204,14 +204,8 @@ proc transformConstSection(c: PTransf, v: PNode): PTransNode =
       if it.kind != nkConstDef: internalError(it.info, "transformConstSection")
       if it.sons[0].kind != nkSym:
         internalError(it.info, "transformConstSection")
-      if sfFakeConst in it[0].sym.flags:
-        var b = newNodeI(nkConstDef, it.info)
-        addSon(b, it[0])
-        addSon(b, ast.emptyNode)            # no type description
-        addSon(b, transform(c, it[2]).PNode)
-        result[i] = PTransNode(b)
-      else:
-        result[i] = PTransNode(it)
+
+      result[i] = PTransNode(it)
 
 proc hasContinue(n: PNode): bool =
   case n.kind

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -806,7 +806,7 @@ proc sameTuple(a, b: PType, c: var TSameTypeClosure): bool =
     elif a.n != b.n and (a.n == nil or b.n == nil) and IgnoreTupleFields notin c.flags:
       result = false
 
-template ifFastObjectTypeCheckFailed(a, b: PType, body: stmt) {.immediate.} =
+template ifFastObjectTypeCheckFailed(a, b: PType, body: untyped) =
   if tfFromGeneric notin a.flags + b.flags:
     # fast case: id comparison suffices:
     result = a.id == b.id

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -914,7 +914,8 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
       while a.kind == tyDistinct: a = a.sons[0]
       if a.kind != b.kind: return false
 
-  if x.kind == tyGenericInst:
+  # this is required by tunique_type but makes no sense really:
+  if x.kind == tyGenericInst and IgnoreTupleFields notin c.flags:
     let
       lhs = x.skipGenericAlias
       rhs = y.skipGenericAlias

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -115,7 +115,7 @@ template decodeBImm(k: untyped) {.dirty.} =
   let imm = instr.regC - byteExcess
   ensureKind(k)
 
-template decodeBx(k: expr) {.dirty.} =
+template decodeBx(k: untyped) {.dirty.} =
   let rbx = instr.regBx - wordExcess
   ensureKind(k)
 
@@ -162,7 +162,7 @@ proc moveConst(x: var TFullReg, y: TFullReg) =
 
 # this seems to be the best way to model the reference semantics
 # of system.NimNode:
-template asgnRef(x, y: expr) = moveConst(x, y)
+template asgnRef(x, y: untyped) = moveConst(x, y)
 
 proc copyValue(src: PNode): PNode =
   if src == nil or nfIsRef in src.flags:
@@ -233,7 +233,7 @@ proc regToNode(x: TFullReg): PNode =
   of rkRegisterAddr: result = regToNode(x.regAddr[])
   of rkNodeAddr: result = x.nodeAddr[]
 
-template getstr(a: expr): expr =
+template getstr(a: untyped): untyped =
   (if a.kind == rkNode: a.node.strVal else: $chr(int(a.intVal)))
 
 proc pushSafePoint(f: PStackFrame; pc: int) =

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -92,34 +92,34 @@ when not defined(nimComputedGoto):
 
 proc myreset(n: var TFullReg) = reset(n)
 
-template ensureKind(k: expr) {.immediate, dirty.} =
+template ensureKind(k: untyped) {.dirty.} =
   if regs[ra].kind != k:
     myreset(regs[ra])
     regs[ra].kind = k
 
-template decodeB(k: expr) {.immediate, dirty.} =
+template decodeB(k: untyped) {.dirty.} =
   let rb = instr.regB
   ensureKind(k)
 
-template decodeBC(k: expr) {.immediate, dirty.} =
+template decodeBC(k: untyped) {.dirty.} =
   let rb = instr.regB
   let rc = instr.regC
   ensureKind(k)
 
-template declBC() {.immediate, dirty.} =
+template declBC() {.dirty.} =
   let rb = instr.regB
   let rc = instr.regC
 
-template decodeBImm(k: expr) {.immediate, dirty.} =
+template decodeBImm(k: untyped) {.dirty.} =
   let rb = instr.regB
   let imm = instr.regC - byteExcess
   ensureKind(k)
 
-template decodeBx(k: expr) {.immediate, dirty.} =
+template decodeBx(k: expr) {.dirty.} =
   let rbx = instr.regBx - wordExcess
   ensureKind(k)
 
-template move(a, b: expr) {.immediate, dirty.} = system.shallowCopy(a, b)
+template move(a, b: untyped) {.dirty.} = system.shallowCopy(a, b)
 # XXX fix minor 'shallowCopy' overloading bug in compiler
 
 proc createStrKeepNode(x: var TFullReg; keepNode=true) =
@@ -1573,7 +1573,7 @@ proc setupMacroParam(x: PNode, typ: PType): TFullReg =
 var evalMacroCounter: int
 
 proc evalMacroCall*(module: PSym, n, nOrig: PNode, sym: PSym): PNode =
-  # XXX GlobalError() is ugly here, but I don't know a better solution for now
+  # XXX globalError() is ugly here, but I don't know a better solution for now
   inc(evalMacroCounter)
   if evalMacroCounter > 100:
     globalError(n.info, errTemplateInstantiationTooNested)
@@ -1603,7 +1603,7 @@ proc evalMacroCall*(module: PSym, n, nOrig: PNode, sym: PSym): PNode =
 
   # return value:
   tos.slots[0].kind = rkNode
-  tos.slots[0].node = newNodeIT(nkEmpty, n.info, sym.typ.sons[0])
+  tos.slots[0].node = newNodeI(nkEmpty, n.info)
 
   # setup parameters:
   for i in 1.. <sym.typ.len:
@@ -1623,4 +1623,3 @@ proc evalMacroCall*(module: PSym, n, nOrig: PNode, sym: PSym): PNode =
   if cyclicTree(result): globalError(n.info, errCyclicTree)
   dec(evalMacroCounter)
   c.callsite = nil
-  #debug result

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -230,10 +230,10 @@ const
   slotSomeTemp* = slotTempUnknown
   relativeJumps* = {opcTJmp, opcFJmp, opcJmp, opcJmpBack}
 
-template opcode*(x: TInstr): TOpcode {.immediate.} = TOpcode(x.uint32 and 0xff'u32)
-template regA*(x: TInstr): TRegister {.immediate.} = TRegister(x.uint32 shr 8'u32 and 0xff'u32)
-template regB*(x: TInstr): TRegister {.immediate.} = TRegister(x.uint32 shr 16'u32 and 0xff'u32)
-template regC*(x: TInstr): TRegister {.immediate.} = TRegister(x.uint32 shr 24'u32)
-template regBx*(x: TInstr): int {.immediate.} = (x.uint32 shr 16'u32).int
+template opcode*(x: TInstr): TOpcode = TOpcode(x.uint32 and 0xff'u32)
+template regA*(x: TInstr): TRegister = TRegister(x.uint32 shr 8'u32 and 0xff'u32)
+template regB*(x: TInstr): TRegister = TRegister(x.uint32 shr 16'u32 and 0xff'u32)
+template regC*(x: TInstr): TRegister = TRegister(x.uint32 shr 24'u32)
+template regBx*(x: TInstr): int = (x.uint32 shr 16'u32).int
 
-template jmpDiff*(x: TInstr): int {.immediate.} = regBx(x) - wordExcess
+template jmpDiff*(x: TInstr): int = regBx(x) - wordExcess

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -88,27 +88,27 @@ proc mapTypeToBracketX(name: string; m: TMagic; t: PType; info: TLineInfo;
 proc mapTypeToAstX(t: PType; info: TLineInfo;
                    inst=false; allowRecursionX=false): PNode =
   var allowRecursion = allowRecursionX
-  template atomicType(name, m): expr = atomicTypeX(name, m, t, info)
-  template mapTypeToAst(t,info): expr = mapTypeToAstX(t, info, inst)
-  template mapTypeToAstR(t,info): expr = mapTypeToAstX(t, info, inst, true)
-  template mapTypeToAst(t,i,info): expr =
+  template atomicType(name, m): untyped = atomicTypeX(name, m, t, info)
+  template mapTypeToAst(t,info): untyped = mapTypeToAstX(t, info, inst)
+  template mapTypeToAstR(t,info): untyped = mapTypeToAstX(t, info, inst, true)
+  template mapTypeToAst(t,i,info): untyped =
     if i<t.len and t.sons[i]!=nil: mapTypeToAstX(t.sons[i], info, inst)
     else: ast.emptyNode
-  template mapTypeToBracket(name, m, t, info): expr =
+  template mapTypeToBracket(name, m, t, info): untyped =
     mapTypeToBracketX(name, m, t, info, inst)
-  template newNodeX(kind):expr =
+  template newNodeX(kind): untyped =
     newNodeIT(kind, if t.n.isNil: info else: t.n.info, t)
-  template newIdent(s):expr =
+  template newIdent(s): untyped =
     var r = newNodeX(nkIdent)
     r.add !s
     r
-  template newIdentDefs(n,t):expr =
+  template newIdentDefs(n,t): untyped =
     var id = newNodeX(nkIdentDefs)
     id.add n  # name
     id.add mapTypeToAst(t, info)  # type
     id.add ast.emptyNode  # no assigned value
     id
-  template newIdentDefs(s):expr = newIdentDefs(s, s.typ)
+  template newIdentDefs(s): untyped = newIdentDefs(s, s.typ)
 
   if inst:
     if t.sym != nil:  # if this node has a symbol

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1266,7 +1266,7 @@ proc checkCanEval(c: PCtx; n: PNode) =
 proc isTemp(c: PCtx; dest: TDest): bool =
   result = dest >= 0 and c.prc.slots[dest].kind >= slotTempUnknown
 
-template needsAdditionalCopy(n): expr =
+template needsAdditionalCopy(n): untyped =
   not c.isTemp(dest) and not fitsRegister(n.typ)
 
 proc skipDeref(n: PNode): PNode =
@@ -1404,7 +1404,7 @@ proc genRdVar(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
       # see tests/t99bott for an example that triggers it:
       cannotEval(n)
 
-template needsRegLoad(): expr =
+template needsRegLoad(): untyped =
   gfAddrOf notin flags and fitsRegister(n.typ.skipTypes({tyVar}))
 
 proc genArrAccess2(c: PCtx; n: PNode; dest: var TDest; opc: TOpcode;

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -231,7 +231,7 @@ proc getTempRange(cc: PCtx; n: int; kind: TSlotKind): TRegister =
 proc freeTempRange(c: PCtx; start: TRegister, n: int) =
   for i in start .. start+n-1: c.freeTemp(TRegister(i))
 
-template withTemp(tmp, typ: expr, body: stmt) {.immediate, dirty.} =
+template withTemp(tmp, typ, body: untyped) {.dirty.} =
   var tmp = getTemp(c, typ)
   body
   c.freeTemp(tmp)
@@ -241,7 +241,7 @@ proc popBlock(c: PCtx; oldLen: int) =
     c.patch(f)
   c.prc.blocks.setLen(oldLen)
 
-template withBlock(labl: PSym; body: stmt) {.immediate, dirty.} =
+template withBlock(labl: PSym; body: untyped) {.dirty.} =
   var oldLen {.gensym.} = c.prc.blocks.len
   c.prc.blocks.add TBlock(label: labl, fixups: @[])
   body

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-template setX(k, field) {.immediate, dirty.} =
+template setX(k, field) {.dirty.} =
   var s: seq[TFullReg]
   move(s, cast[seq[TFullReg]](a.slots))
   if s[a.ra].kind != k:
@@ -48,7 +48,7 @@ proc setResult*(a: VmArgs; v: seq[string]) =
   for x in v: n.add newStrNode(nkStrLit, x)
   s[a.ra].node = n
 
-template getX(k, field) {.immediate, dirty.} =
+template getX(k, field) {.dirty.} =
   doAssert i < a.rc-1
   let s = cast[seq[TFullReg]](a.slots)
   doAssert s[i+a.rb+1].kind == k

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -15,36 +15,36 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
 
 from os import getEnv, existsEnv, dirExists, fileExists, walkDir
 
-template mathop(op) {.immediate, dirty.} =
+template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
 
-template osop(op) {.immediate, dirty.} =
+template osop(op) {.dirty.} =
   registerCallback(c, "stdlib.os." & astToStr(op), `op Wrapper`)
 
-template systemop(op) {.immediate, dirty.} =
+template systemop(op) {.dirty.} =
   registerCallback(c, "stdlib.system." & astToStr(op), `op Wrapper`)
 
-template wrap1f_math(op) {.immediate, dirty.} =
+template wrap1f_math(op) {.dirty.} =
   proc `op Wrapper`(a: VmArgs) {.nimcall.} =
     setResult(a, op(getFloat(a, 0)))
   mathop op
 
-template wrap2f_math(op) {.immediate, dirty.} =
+template wrap2f_math(op) {.dirty.} =
   proc `op Wrapper`(a: VmArgs) {.nimcall.} =
     setResult(a, op(getFloat(a, 0), getFloat(a, 1)))
   mathop op
 
-template wrap1s_os(op) {.immediate, dirty.} =
+template wrap1s_os(op) {.dirty.} =
   proc `op Wrapper`(a: VmArgs) {.nimcall.} =
     setResult(a, op(getString(a, 0)))
   osop op
 
-template wrap1s_system(op) {.immediate, dirty.} =
+template wrap1s_system(op) {.dirty.} =
   proc `op Wrapper`(a: VmArgs) {.nimcall.} =
     setResult(a, op(getString(a, 0)))
   systemop op
 
-template wrap2svoid_system(op) {.immediate, dirty.} =
+template wrap2svoid_system(op) {.dirty.} =
   proc `op Wrapper`(a: VmArgs) {.nimcall.} =
     op(getString(a, 0), getString(a, 1))
   systemop op

--- a/doc/manual/generics.txt
+++ b/doc/manual/generics.txt
@@ -293,7 +293,7 @@ definition):
   var
     lastId = 0
 
-  template genId*: expr =
+  template genId*: untyped =
     bind lastId
     inc(lastId)
     lastId

--- a/doc/manual/locking.txt
+++ b/doc/manual/locking.txt
@@ -48,7 +48,7 @@ semantics and should not be used directly! It should only be used in templates
 that also implement some form of locking at runtime:
 
 .. code-block:: nim
-  template lock(a: TLock; body: stmt) =
+  template lock(a: TLock; body: untyped) =
     pthread_mutex_lock(a)
     {.locks: [a].}:
       try:
@@ -64,7 +64,7 @@ model low level lockfree mechanisms:
   var dummyLock {.compileTime.}: int
   var atomicCounter {.guard: dummyLock.}: int
 
-  template atomicRead(x): expr =
+  template atomicRead(x): untyped =
     {.locks: [dummyLock].}:
       memoryReadBarrier()
       x
@@ -167,7 +167,7 @@ the runtime check is required to ensure a global ordering for two locks ``a``
 and ``b`` of the same lock level:
 
 .. code-block:: nim
-  template multilock(a, b: ptr TLock; body: stmt) =
+  template multilock(a, b: ptr TLock; body: untyped) =
     if cast[ByteAddress](a) < cast[ByteAddress](b):
       pthread_mutex_lock(a)
       pthread_mutex_lock(b)

--- a/doc/manual/pragmas.txt
+++ b/doc/manual/pragmas.txt
@@ -213,7 +213,7 @@ statement as seen in stack backtraces:
 
 .. code-block:: nim
 
-  template myassert*(cond: expr, msg = "") =
+  template myassert*(cond: untyped, msg = "") =
     if not cond:
       # change run-time line information of the 'raise' statement:
       {.line: InstantiationInfo().}:

--- a/doc/manual/templates.txt
+++ b/doc/manual/templates.txt
@@ -57,8 +57,7 @@ A template where every parameter is ``untyped`` is called an `immediate`:idx:
 template. For historical reasons templates can be explicitly annotated with
 an ``immediate`` pragma and then these templates do not take part in
 overloading resolution and the parameters' types are *ignored* by the
-compiler. Explicit immediate templates are about to be deprecated in later
-versions of the compiler.
+compiler. Explicit immediate templates are now deprecated.
 
 **Note**: For historical reasons ``stmt`` is an alias for ``typed`` and
 ``expr`` an alias for ``untyped``, but new code should use the newer,
@@ -159,7 +158,7 @@ bound from the definition scope of the template:
   var
     lastId = 0
 
-  template genId*: expr =
+  template genId*: untyped =
     inc(lastId)
     lastId
 
@@ -181,7 +180,7 @@ In templates identifiers can be constructed with the backticks notation:
 
 .. code-block:: nim
 
-  template typedef(name: expr, typ: typedesc) {.immediate.} =
+  template typedef(name: untyped, typ: typedesc) =
     type
       `T name`* {.inject.} = typ
       `P name`* {.inject.} = ref `T name`
@@ -242,7 +241,7 @@ template cannot be accessed in the instantiation context:
 
 .. code-block:: nim
 
-  template newException*(exceptn: typedesc, message: string): expr =
+  template newException*(exceptn: typedesc, message: string): untyped =
     var
       e: ref exceptn  # e is implicitly gensym'ed here
     new(e)
@@ -264,7 +263,7 @@ is ``gensym`` and for ``proc``, ``iterator``, ``converter``, ``template``,
 template parameter, it is an inject'ed symbol:
 
 .. code-block:: nim
-  template withFile(f, fn, mode: expr, actions: stmt): stmt {.immediate.} =
+  template withFile(f, fn, mode: untyped, actions: untyped): untyped =
     block:
       var f: File  # since 'f' is a template param, it's injected implicitly
       ...
@@ -298,7 +297,7 @@ rewritten to ``f(x)``. Therefore the dot syntax has some limiations when it
 is used to invoke templates/macros:
 
 .. code-block:: nim
-  template declareVar(name: expr): stmt =
+  template declareVar(name: untyped) =
     const name {.inject.} = 45
 
   # Doesn't compile:
@@ -325,8 +324,7 @@ Macros
 ======
 
 A macro is a special kind of low level template. Macros can be used
-to implement `domain specific languages`:idx:. Like templates, macros come in
-the 2 flavors *immediate* and *ordinary*.
+to implement `domain specific languages`:idx:.
 
 While macros enable advanced compile-time code transformations, they
 cannot change Nim's syntax. However, this is no real restriction because
@@ -351,7 +349,7 @@ variable number of arguments:
   # ``macros`` module:
   import macros
 
-  macro debug(n: varargs[expr]): stmt =
+  macro debug(n: varargs[untyped]): untyped =
     # `n` is a Nim AST that contains the whole macro invocation
     # this macro returns a list of statements:
     result = newNimNode(nnkStmtList, n)
@@ -406,7 +404,7 @@ builtin can be used for that:
 .. code-block:: nim
   import macros
 
-  macro debug(n: varargs[expr]): stmt =
+  macro debug(n: varargs[typed]): untyped =
     result = newNimNode(nnkStmtList, n)
     for i in 0..n.len-1:
       # we can bind symbols in scope via 'bindSym':
@@ -454,7 +452,7 @@ regular expressions:
 .. code-block:: nim
   import macros
 
-  macro case_token(n: stmt): stmt =
+  macro case_token(n: untyped): untyped =
     # creates a lexical analyzer from regular expressions
     # ... (implementation is an exercise for the reader :-)
     discard
@@ -486,14 +484,14 @@ Whole routines (procs, iterators etc.) can also be passed to a template or
 a macro via the pragma notation:
 
 .. code-block:: nim
-  template m(s: stmt) = discard
+  template m(s: untyped) = discard
 
   proc p() {.m.} = discard
 
 This is a simple syntactic transformation into:
 
 .. code-block:: nim
-  template m(s: stmt) = discard
+  template m(s: untyped) = discard
 
   m:
     proc p() = discard

--- a/doc/manual/trmacros.txt
+++ b/doc/manual/trmacros.txt
@@ -135,7 +135,7 @@ The ``|`` operator
 The ``|`` operator if used as infix operator creates an ordered choice:
 
 .. code-block:: nim
-  template t{0|1}(): expr = 3
+  template t{0|1}(): untyped = 3
   let a = 1
   # outputs 3:
   echo a
@@ -144,7 +144,7 @@ The matching is performed after the compiler performed some optimizations like
 constant folding, so the following does not work:
 
 .. code-block:: nim
-  template t{0|1}(): expr = 3
+  template t{0|1}(): untyped = 3
   # outputs 1:
   echo 1
 
@@ -161,7 +161,7 @@ A pattern expression can be bound to a pattern parameter via the ``expr{param}``
 notation:
 
 .. code-block:: nim
-  template t{(0|1|2){x}}(x: expr): expr = x+1
+  template t{(0|1|2){x}}(x: untyped): untyped = x+1
   let a = 1
   # outputs 2:
   echo a
@@ -173,7 +173,7 @@ The ``~`` operator
 The ``~`` operator is the **not** operator in patterns:
 
 .. code-block:: nim
-  template t{x = (~x){y} and (~x){z}}(x, y, z: bool): stmt =
+  template t{x = (~x){y} and (~x){z}}(x, y, z: bool) =
     x = y
     if x: x = z
 
@@ -200,7 +200,7 @@ to ``&(a, b, c)``:
     for i in 1..len(s)-1: result.add s[i]
     inc calls
 
-  template optConc{ `&&` * a }(a: string): expr = &&a
+  template optConc{ `&&` * a }(a: string): untyped = &&a
 
   let space = " "
   echo "my" && (space & "awe" && "some " ) && "concat"
@@ -239,7 +239,7 @@ all the arguments, but also the matched operators in reverse polish notation:
   proc mat21(): Matrix =
     result.dummy = 21
 
-  macro optM{ (`+`|`-`|`*`) ** a }(a: Matrix): expr =
+  macro optM{ (`+`|`-`|`*`) ** a }(a: Matrix): untyped =
     echo treeRepr(a)
     result = newCall(bindSym"mat21")
 
@@ -273,7 +273,7 @@ parameter is of the type ``varargs`` it is treated specially and it can match
   template optWrite{
     write(f, x)
     ((write|writeLine){w})(f, y)
-  }(x, y: varargs[expr], f: File, w: expr) =
+  }(x, y: varargs[untyped], f: File, w: untyped) =
     w(f, x, y)
 
 
@@ -288,8 +288,8 @@ implemented with term rewriting:
   proc p(x, y: int; cond: bool): int =
     result = if cond: x + y else: x - y
 
-  template optP1{p(x, y, true)}(x, y: expr): expr = x + y
-  template optP2{p(x, y, false)}(x, y: expr): expr = x - y
+  template optP1{p(x, y, true)}(x, y: untyped): untyped = x + y
+  template optP2{p(x, y, false)}(x, y: untyped): untyped = x - y
 
 
 Example: Hoisting

--- a/doc/manual/types.txt
+++ b/doc/manual/types.txt
@@ -539,12 +539,12 @@ not wrapped in another implicit array construction:
   takeV([123, 2, 1]) # takeV's T is "int", not "array of int"
 
 
-``varargs[expr]`` is treated specially: It matches a variable list of arguments
+``varargs[typed]`` is treated specially: It matches a variable list of arguments
 of arbitrary type but *always* constructs an implicit array. This is required
 so that the builtin ``echo`` proc does what is expected:
 
 .. code-block:: nim
-  proc echo*(x: varargs[expr, `$`]) {...}
+  proc echo*(x: varargs[typed, `$`]) {...}
 
   echo @[1, 2, 3]
   # prints "@[1, 2, 3]" and not "123"
@@ -1082,7 +1082,7 @@ But it seems all this boilerplate code needs to be repeated for the ``Euro``
 currency. This can be solved with templates_.
 
 .. code-block:: nim
-  template additive(typ: typedesc): stmt =
+  template additive(typ: typedesc) =
     proc `+` *(x, y: typ): typ {.borrow.}
     proc `-` *(x, y: typ): typ {.borrow.}
 
@@ -1090,18 +1090,18 @@ currency. This can be solved with templates_.
     proc `+` *(x: typ): typ {.borrow.}
     proc `-` *(x: typ): typ {.borrow.}
 
-  template multiplicative(typ, base: typedesc): stmt =
+  template multiplicative(typ, base: typedesc) =
     proc `*` *(x: typ, y: base): typ {.borrow.}
     proc `*` *(x: base, y: typ): typ {.borrow.}
     proc `div` *(x: typ, y: base): typ {.borrow.}
     proc `mod` *(x: typ, y: base): typ {.borrow.}
 
-  template comparable(typ: typedesc): stmt =
+  template comparable(typ: typedesc) =
     proc `<` * (x, y: typ): bool {.borrow.}
     proc `<=` * (x, y: typ): bool {.borrow.}
     proc `==` * (x, y: typ): bool {.borrow.}
 
-  template defineCurrency(typ, base: expr): stmt =
+  template defineCurrency(typ, base: untyped) =
     type
       typ* = distinct base
     additive(typ)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -508,7 +508,7 @@ proc lispRepr*(n: NimNode): string {.compileTime, benign.} =
 
   add(result, ")")
 
-macro dumpTree*(s: stmt): stmt {.immediate.} = echo s.treeRepr
+macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ## Accepts a block of nim code and prints the parsed abstract syntax
   ## tree using the `toTree` function. Printing is done *at compile time*.
   ##
@@ -516,17 +516,17 @@ macro dumpTree*(s: stmt): stmt {.immediate.} = echo s.treeRepr
   ## tree and to discover what kind of nodes must be created to represent
   ## a certain expression/statement.
 
-macro dumpLisp*(s: stmt): stmt {.immediate.} = echo s.lispRepr
+macro dumpLisp*(s: untyped): untyped = echo s.lispRepr
   ## Accepts a block of nim code and prints the parsed abstract syntax
   ## tree using the `toLisp` function. Printing is done *at compile time*.
   ##
   ## See `dumpTree`.
 
-macro dumpTreeImm*(s: stmt): stmt {.immediate, deprecated.} = echo s.treeRepr
-  ## The ``immediate`` version of `dumpTree`.
+macro dumpTreeImm*(s: untyped): untyped {.deprecated.} = echo s.treeRepr
+  ## Deprecated.
 
-macro dumpLispImm*(s: stmt): stmt {.immediate, deprecated.} = echo s.lispRepr
-  ## The ``immediate`` version of `dumpLisp`.
+macro dumpLispImm*(s: untyped): untyped {.deprecated.} = echo s.lispRepr
+  ## Deprecated.
 
 
 proc newEmptyNode*(): NimNode {.compileTime, noSideEffect.} =
@@ -701,7 +701,7 @@ proc addPragma*(someProc, pragma: NimNode) {.compileTime.} =
     someProc.pragma = pragmaNode
   pragmaNode.add(pragma)
 
-template badNodeKind(k; f): stmt{.immediate.} =
+template badNodeKind(k, f) =
   assert false, "Invalid node kind " & $k & " for macros.`" & $f & "`"
 
 proc body*(someProc: NimNode): NimNode {.compileTime.} =
@@ -758,8 +758,7 @@ iterator children*(n: NimNode): NimNode {.inline.} =
   for i in 0 ..< n.len:
     yield n[i]
 
-template findChild*(n: NimNode; cond: expr): NimNode {.
-  immediate, dirty.} =
+template findChild*(n: NimNode; cond: untyped): NimNode {.dirty.} =
   ## Find the first child node matching condition (or nil).
   ##
   ## .. code-block:: nim

--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -274,7 +274,7 @@ proc `[]`*(pattern: Captures, name: string): string =
   let pattern = RegexMatch(pattern)
   return pattern.captures[pattern.pattern.captureNameToId.fget(name)]
 
-template toTableImpl(cond: bool): stmt {.immediate, dirty.} =
+template toTableImpl(cond: untyped) {.dirty.} =
   for key in RegexMatch(pattern).pattern.captureNameId.keys:
     let nextVal = pattern[key]
     if cond:
@@ -291,7 +291,7 @@ proc toTable*(pattern: CaptureBounds, default = none(Slice[int])):
   result = initTable[string, Option[Slice[int]]]()
   toTableImpl(nextVal.isNone)
 
-template itemsImpl(cond: bool): stmt {.immediate, dirty.} =
+template itemsImpl(cond: untyped) {.dirty.} =
   for i in 0 .. <RegexMatch(pattern).pattern.captureCount:
     let nextVal = pattern[i]
     # done in this roundabout way to avoid multiple yields (potential code
@@ -625,7 +625,7 @@ proc split*(str: string, pattern: Regex, maxSplit = -1, start = 0): seq[string] 
     result.add(str.substr(bounds.b + 1, str.high))
 
 template replaceImpl(str: string, pattern: Regex,
-                     replacement: expr): stmt {.immediate, dirty.} =
+                     replacement: untyped) {.dirty.} =
   # XXX seems very similar to split, maybe I can reduce code duplication
   # somehow?
   result = ""

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2667,7 +2667,7 @@ proc utimes*(path: cstring, times: ptr array[2, Timeval]): int {.
 
 proc handle_signal(sig: cint, handler: proc (a: cint) {.noconv.}) {.importc: "signal", header: "<signal.h>".}
 
-template onSignal*(signals: varargs[cint], body: untyped): stmt =
+template onSignal*(signals: varargs[cint], body: untyped) =
   ## Setup code to be executed when Unix signals are received. Example:
   ## from posix import SIGINT, SIGTERM
   ## onSignal(SIGINT, SIGTERM):

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -114,7 +114,7 @@ proc lowerBound*[T](a: openArray[T], key: T, cmp: proc(x,y: T): int {.closure.})
 proc lowerBound*[T](a: openArray[T], key: T): int = lowerBound(a, key, cmp[T])
 proc merge[T](a, b: var openArray[T], lo, m, hi: int,
               cmp: proc (x, y: T): int {.closure.}, order: SortOrder) =
-  template `<-` (a, b: expr) =
+  template `<-` (a, b) =
     when false:
       a = b
     elif onlySafeCode:
@@ -206,7 +206,7 @@ proc sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.},
     result[i] = a[i]
   sort(result, cmp, order)
 
-template sortedByIt*(seq1, op: expr): expr =
+template sortedByIt*(seq1, op: untyped): untyped =
   ## Convenience template around the ``sorted`` proc to reduce typing.
   ##
   ## The template injects the ``it`` variable which you can use directly in an

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -983,7 +983,7 @@ when defined(windows) or defined(nimdoc):
     let dwLocalAddressLength = Dword(sizeof (Sockaddr_in) + 16)
     let dwRemoteAddressLength = Dword(sizeof(Sockaddr_in) + 16)
 
-    template completeAccept(): stmt {.immediate, dirty.} =
+    template completeAccept() {.dirty.} =
       var listenSock = socket
       let setoptRet = setsockopt(clientSock, SOL_SOCKET,
           SO_UPDATE_ACCEPT_CONTEXT, addr listenSock,
@@ -1003,7 +1003,7 @@ when defined(windows) or defined(nimdoc):
          client: clientSock.AsyncFD)
       )
 
-    template failAccept(errcode): stmt =
+    template failAccept(errcode) =
       if flags.isDisconnectionError(errcode):
         var newAcceptFut = acceptAddr(socket, flags)
         newAcceptFut.callback =
@@ -1590,7 +1590,7 @@ proc skipStmtList(node: NimNode): NimNode {.compileTime.} =
     result = node[0]
 
 template createCb(retFutureSym, iteratorNameSym,
-                   name: expr): stmt {.immediate.} =
+                   name: untyped) =
   var nameIterVar = iteratorNameSym
   #{.push stackTrace: off.}
   proc cb {.closure,gcsafe.} =
@@ -1925,7 +1925,7 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
   #if prc[0].getName == "testInfix":
   #  echo(toStrLit(result))
 
-macro async*(prc: stmt): stmt {.immediate.} =
+macro async*(prc: untyped): untyped =
   ## Macro which processes async procedures into the appropriate
   ## iterators and yield statements.
   if prc.kind == nnkStmtList:

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -355,7 +355,7 @@ proc insert*[T](dest: var seq[T], src: openArray[T], pos=0) =
     inc(j)
 
 
-template filterIt*(seq1, pred: expr): expr =
+template filterIt*(seq1, pred: untyped): untyped =
   ## Returns a new sequence with all the items that fulfilled the predicate.
   ##
   ## Unlike the `proc` version, the predicate needs to be an expression using
@@ -374,7 +374,7 @@ template filterIt*(seq1, pred: expr): expr =
     if pred: result.add(it)
   result
 
-template keepItIf*(varSeq: seq, pred: expr) =
+template keepItIf*(varSeq: seq, pred: untyped) =
   ## Convenience template around the ``keepIf`` proc to reduce typing.
   ##
   ## Unlike the `proc` version, the predicate needs to be an expression using
@@ -409,7 +409,7 @@ proc all*[T](seq1: seq[T], pred: proc(item: T): bool {.closure.}): bool =
       return false
   return true
 
-template allIt*(seq1, pred: expr): bool {.immediate.} =
+template allIt*(seq1, pred: untyped): bool =
   ## Checks if every item fulfills the predicate.
   ##
   ## Example:
@@ -440,7 +440,7 @@ proc any*[T](seq1: seq[T], pred: proc(item: T): bool {.closure.}): bool =
       return true
   return false
 
-template anyIt*(seq1, pred: expr): bool {.immediate.} =
+template anyIt*(seq1, pred: untyped): bool =
   ## Checks if some item fulfills the predicate.
   ##
   ## Example:
@@ -456,7 +456,7 @@ template anyIt*(seq1, pred: expr): bool {.immediate.} =
       break
   result
 
-template toSeq*(iter: expr): expr {.immediate.} =
+template toSeq*(iter: untyped): untyped =
   ## Transforms any iterator into a sequence.
   ##
   ## Example:
@@ -482,7 +482,7 @@ template toSeq*(iter: expr): expr {.immediate.} =
       result.add(x)
     result
 
-template foldl*(sequence, operation: expr): expr =
+template foldl*(sequence, operation: untyped): untyped =
   ## Template to fold a sequence from left to right, returning the accumulation.
   ##
   ## The sequence is required to have at least a single element. Debug versions
@@ -519,7 +519,7 @@ template foldl*(sequence, operation: expr): expr =
     result = operation
   result
 
-template foldl*(sequence, operation: expr, first): expr =
+template foldl*(sequence, operation, first): untyped =
   ## Template to fold a sequence from left to right, returning the accumulation.
   ##
   ## This version of ``foldl`` gets a starting parameter. This makes it possible
@@ -544,7 +544,7 @@ template foldl*(sequence, operation: expr, first): expr =
     result = operation
   result
 
-template foldr*(sequence, operation: expr): expr =
+template foldr*(sequence, operation: untyped): untyped =
   ## Template to fold a sequence from right to left, returning the accumulation.
   ##
   ## The sequence is required to have at least a single element. Debug versions
@@ -581,7 +581,7 @@ template foldr*(sequence, operation: expr): expr =
     result = operation
   result
 
-template mapIt*(seq1, typ, op: expr): expr {.deprecated.}=
+template mapIt*(seq1, typ, op: untyped): untyped =
   ## Convenience template around the ``map`` proc to reduce typing.
   ##
   ## The template injects the ``it`` variable which you can use directly in an
@@ -602,7 +602,7 @@ template mapIt*(seq1, typ, op: expr): expr {.deprecated.}=
   result
 
 
-template mapIt*(seq1, op: expr): expr =
+template mapIt*(seq1, op: untyped): untyped =
   ## Convenience template around the ``map`` proc to reduce typing.
   ##
   ## The template injects the ``it`` variable which you can use directly in an
@@ -631,7 +631,7 @@ template mapIt*(seq1, op: expr): expr =
       result.add(op)
   result
 
-template applyIt*(varSeq, op: expr) =
+template applyIt*(varSeq, op: untyped) =
   ## Convenience template around the mutable ``apply`` proc to reduce typing.
   ##
   ## The template injects the ``it`` variable which you can use directly in an
@@ -648,7 +648,7 @@ template applyIt*(varSeq, op: expr) =
 
 
 
-template newSeqWith*(len: int, init: expr): expr =
+template newSeqWith*(len: int, init: untyped): untyped =
   ## creates a new sequence, calling `init` to initialize each value. Example:
   ##
   ## .. code-block::

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -20,6 +20,8 @@
 ## **Note**: This interface will change as soon as the compiler supports
 ## closures and proper coroutines.
 
+include "system/inclrtl"
+
 when not defined(nimhygiene):
   {.pragma: dirty.}
 
@@ -456,7 +458,7 @@ template anyIt*(seq1, pred: untyped): bool =
       break
   result
 
-template toSeq*(iter: untyped): untyped =
+template toSeq*(iter: untyped): untyped {.oldimmediate.} =
   ## Transforms any iterator into a sequence.
   ##
   ## Example:

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -286,7 +286,7 @@ proc excl*[A](s: var HashSet[A], key: A) =
       var r = j         # though may be adaptable to other simple sequences.
       s.data[i].hcode = 0              # mark current EMPTY
       s.data[i].key = default(type(s.data[i].key))
-      doWhile ((i >= r and r > j) or (r > j and j > i) or (j > i and i >= r)):
+      doWhile((i >= r and r > j) or (r > j and j > i) or (j > i and i >= r)):
         i = (i + 1) and msk            # increment mod table size
         if isEmpty(s.data[i].hcode):   # end of collision cluster; So all done
           return
@@ -615,7 +615,7 @@ proc card*[A](s: OrderedSet[A]): int {.inline.} =
   ## <http://en.wikipedia.org/wiki/Cardinality>`_ of a set.
   result = s.counter
 
-template forAllOrderedPairs(yieldStmt: stmt) {.dirty, immediate.} =
+template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
   var h = s.first
   while h >= 0:
     var nxt = s.data[h].next

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -256,7 +256,7 @@ proc incl*[A](s: var HashSet[A], other: HashSet[A]) =
   assert other.isValid, "The set `other` needs to be initialized."
   for item in other: incl(s, item)
 
-template doWhile(a: expr, b: stmt): stmt =
+template doWhile(a, b) =
   while true:
     b
     if not a: break
@@ -371,7 +371,7 @@ proc toSet*[A](keys: openArray[A]): HashSet[A] =
   result = initSet[A](rightSize(keys.len))
   for key in items(keys): result.incl(key)
 
-template dollarImpl(): stmt {.dirty.} =
+template dollarImpl() {.dirty.} =
   result = "{"
   for key in items(s):
     if result.len > 1: result.add(", ")

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -79,7 +79,7 @@ template addImpl(enlarge) {.dirty.} =
   rawInsert(t, t.data, key, val, hc, j)
   inc(t.counter)
 
-template maybeRehashPutImpl(enlarge) {.dirty.} =
+template maybeRehashPutImpl(enlarge) {.oldimmediate, dirty.} =
   if mustRehash(t.dataLen, t.counter):
     enlarge(t)
     index = rawGetKnownHC(t, key, hc)
@@ -87,7 +87,7 @@ template maybeRehashPutImpl(enlarge) {.dirty.} =
   rawInsert(t, t.data, key, val, hc, index)
   inc(t.counter)
 
-template putImpl(enlarge) {.dirty.} =
+template putImpl(enlarge) {.oldimmediate, dirty.} =
   var hc: Hash
   var index = rawGet(t, key, hc)
   if index >= 0: t.data[index].val = val

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -72,14 +72,14 @@ proc rawInsert[X, A, B](t: var X, data: var KeyValuePairSeq[A, B],
                      key: A, val: B, hc: Hash, h: Hash) =
   rawInsertImpl()
 
-template addImpl(enlarge) {.dirty, immediate.} =
+template addImpl(enlarge) {.dirty.} =
   if mustRehash(t.dataLen, t.counter): enlarge(t)
   var hc: Hash
   var j = rawGetDeep(t, key, hc)
   rawInsert(t, t.data, key, val, hc, j)
   inc(t.counter)
 
-template maybeRehashPutImpl(enlarge) {.dirty, immediate.} =
+template maybeRehashPutImpl(enlarge) {.dirty.} =
   if mustRehash(t.dataLen, t.counter):
     enlarge(t)
     index = rawGetKnownHC(t, key, hc)
@@ -87,13 +87,13 @@ template maybeRehashPutImpl(enlarge) {.dirty, immediate.} =
   rawInsert(t, t.data, key, val, hc, index)
   inc(t.counter)
 
-template putImpl(enlarge) {.dirty, immediate.} =
+template putImpl(enlarge) {.dirty.} =
   var hc: Hash
   var index = rawGet(t, key, hc)
   if index >= 0: t.data[index].val = val
   else: maybeRehashPutImpl(enlarge)
 
-template mgetOrPutImpl(enlarge) {.dirty, immediate.} =
+template mgetOrPutImpl(enlarge) {.dirty.} =
   var hc: Hash
   var index = rawGet(t, key, hc)
   if index < 0:
@@ -102,7 +102,7 @@ template mgetOrPutImpl(enlarge) {.dirty, immediate.} =
   # either way return modifiable val
   result = t.data[index].val
 
-template hasKeyOrPutImpl(enlarge) {.dirty, immediate.} =
+template hasKeyOrPutImpl(enlarge) {.dirty.} =
   var hc: Hash
   var index = rawGet(t, key, hc)
   if index < 0:
@@ -112,7 +112,7 @@ template hasKeyOrPutImpl(enlarge) {.dirty, immediate.} =
 
 proc default[T](t: typedesc[T]): T {.inline.} = discard
 
-template delImpl() {.dirty, immediate.} =
+template delImpl() {.dirty.} =
   var hc: Hash
   var i = rawGet(t, key, hc)
   let msk = maxHash(t)
@@ -140,7 +140,7 @@ template delImpl() {.dirty, immediate.} =
         else:
           shallowCopy(t.data[j], t.data[i]) # data[j] will be marked EMPTY next loop
 
-template clearImpl() {.dirty, immediate.} =
+template clearImpl() {.dirty.} =
   for i in 0 .. <t.data.len:
     t.data[i].hcode = 0
     t.data[i].key = default(type(t.data[i].key))

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -463,7 +463,7 @@ proc clear*[A, B](t: OrderedTable[A, B] | OrderedTableRef[A, B]) =
   t.first = -1
   t.last = -1
 
-template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
+template forAllOrderedPairs(yieldStmt: untyped) {.oldimmediate, dirty.} =
   var h = t.first
   while h >= 0:
     var nxt = t.data[h].next
@@ -649,7 +649,7 @@ proc len*[A, B](t: OrderedTableRef[A, B]): int {.inline.} =
   ## returns the number of keys in `t`.
   result = t.counter
 
-template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
+template forAllOrderedPairs(yieldStmt: untyped) {.oldimmediate, dirty.} =
   var h = t.first
   while h >= 0:
     var nxt = t.data[h].next

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -113,8 +113,8 @@ type
 
 {.deprecated: [TTable: Table, PTable: TableRef].}
 
-template maxHash(t): expr {.immediate.} = high(t.data)
-template dataLen(t): expr = len(t.data)
+template maxHash(t): untyped = high(t.data)
+template dataLen(t): untyped = len(t.data)
 
 include tableimpl
 
@@ -135,7 +135,7 @@ proc len*[A, B](t: Table[A, B]): int =
   ## returns the number of keys in `t`.
   result = t.counter
 
-template get(t, key): untyped {.immediate.} =
+template get(t, key): untyped =
   ## retrieves the value at ``t[key]``. The value can be modified.
   ## If `key` is not in `t`, the ``KeyError`` exception is raised.
   mixin rawGet
@@ -148,7 +148,7 @@ template get(t, key): untyped {.immediate.} =
     else:
       raise newException(KeyError, "key not found")
 
-template getOrDefaultImpl(t, key): untyped {.immediate.} =
+template getOrDefaultImpl(t, key): untyped =
   mixin rawGet
   var hc: Hash
   var index = rawGet(t, key, hc)
@@ -311,7 +311,7 @@ proc toTable*[A, B](pairs: openArray[(A,
   result = initTable[A, B](rightSize(pairs.len))
   for key, val in items(pairs): result[key] = val
 
-template dollarImpl(): stmt {.dirty.} =
+template dollarImpl(): untyped {.dirty.} =
   if t.len == 0:
     result = "{:}"
   else:
@@ -463,7 +463,7 @@ proc clear*[A, B](t: OrderedTable[A, B] | OrderedTableRef[A, B]) =
   t.first = -1
   t.last = -1
 
-template forAllOrderedPairs(yieldStmt: stmt) {.dirty, immediate.} =
+template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
   var h = t.first
   while h >= 0:
     var nxt = t.data[h].next
@@ -649,7 +649,7 @@ proc len*[A, B](t: OrderedTableRef[A, B]): int {.inline.} =
   ## returns the number of keys in `t`.
   result = t.counter
 
-template forAllOrderedPairs(yieldStmt: stmt) {.dirty, immediate.} =
+template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
   var h = t.first
   while h >= 0:
     var nxt = t.data[h].next
@@ -824,7 +824,7 @@ proc rawGet[A](t: CountTable[A], key: A): int =
     h = nextTry(h, high(t.data))
   result = -1 - h                   # < 0 => MISSING; insert idx = -1 - result
 
-template ctget(t, key: untyped): untyped {.immediate.} =
+template ctget(t, key: untyped): untyped =
   var index = rawGet(t, key)
   if index >= 0: result = t.data[index].val
   else:

--- a/lib/pure/future.nim
+++ b/lib/pure/future.nim
@@ -46,7 +46,7 @@ proc createProcType(p, b: NimNode): NimNode {.compileTime.} =
   #echo(treeRepr(result))
   #echo(result.toStrLit())
 
-macro `=>`*(p, b: expr): expr {.immediate.} =
+macro `=>`*(p, b: untyped): untyped =
   ## Syntax sugar for anonymous procedures.
   ##
   ## .. code-block:: nim
@@ -107,7 +107,7 @@ macro `=>`*(p, b: expr): expr {.immediate.} =
   #echo(result.toStrLit())
   #return result # TODO: Bug?
 
-macro `->`*(p, b: expr): expr {.immediate.} =
+macro `->`*(p, b: untyped): untyped =
   ## Syntax sugar for procedure types.
   ##
   ## .. code-block:: nim
@@ -125,7 +125,7 @@ macro `->`*(p, b: expr): expr {.immediate.} =
 type ListComprehension = object
 var lc*: ListComprehension
 
-macro `[]`*(lc: ListComprehension, comp, typ: expr): expr =
+macro `[]`*(lc: ListComprehension, comp, typ: untyped): untyped =
   ## List comprehension, returns a sequence. `comp` is the actual list
   ## comprehension, for example ``x | (x <- 1..10, x mod 2 == 0)``. `typ` is
   ## the type that will be stored inside the result seq.

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1000,11 +1000,11 @@ proc readLine*(socket: Socket, line: var TaintedString, timeout = -1,
   ##
   ## **Warning**: Only the ``SafeDisconn`` flag is currently supported.
 
-  template addNLIfEmpty(): stmt =
+  template addNLIfEmpty() =
     if line.len == 0:
       line.string.add("\c\L")
 
-  template raiseSockError(): stmt {.dirty, immediate.} =
+  template raiseSockError() {.dirty.} =
     let lastError = getSocketError(socket)
     if flags.isDisconnectionError(lastError): setLen(line.string, 0); return
     socket.socketError(n, lastError = lastError)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -173,24 +173,24 @@ proc osLastError*(): OSErrorCode =
 
 when defined(windows):
   when useWinUnicode:
-    template wrapUnary(varname, winApiProc, arg: expr) {.immediate.} =
+    template wrapUnary(varname, winApiProc, arg: untyped) =
       var varname = winApiProc(newWideCString(arg))
 
-    template wrapBinary(varname, winApiProc, arg, arg2: expr) {.immediate.} =
+    template wrapBinary(varname, winApiProc, arg, arg2: untyped) =
       var varname = winApiProc(newWideCString(arg), arg2)
     proc findFirstFile(a: string, b: var WIN32_FIND_DATA): Handle =
       result = findFirstFileW(newWideCString(a), b)
-    template findNextFile(a, b: expr): expr = findNextFileW(a, b)
-    template getCommandLine(): expr = getCommandLineW()
+    template findNextFile(a, b: untyped): untyped = findNextFileW(a, b)
+    template getCommandLine(): untyped = getCommandLineW()
 
-    template getFilename(f: expr): expr =
+    template getFilename(f: untyped): untyped =
       $cast[WideCString](addr(f.cFilename[0]))
   else:
-    template findFirstFile(a, b: expr): expr = findFirstFileA(a, b)
-    template findNextFile(a, b: expr): expr = findNextFileA(a, b)
-    template getCommandLine(): expr = getCommandLineA()
+    template findFirstFile(a, b: untyped): untyped = findFirstFileA(a, b)
+    template findNextFile(a, b: untyped): untyped = findNextFileA(a, b)
+    template getCommandLine(): untyped = getCommandLineA()
 
-    template getFilename(f: expr): expr = $f.cFilename
+    template getFilename(f: untyped): untyped = $f.cFilename
 
   proc skipFindData(f: WIN32_FIND_DATA): bool {.inline.} =
     # Note - takes advantage of null delimiter in the cstring

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1502,7 +1502,7 @@ type
     lastWriteTime*: Time # Time file was last modified/written to.
     creationTime*: Time # Time file was created. Not supported on all systems!
 
-template rawToFormalFileInfo(rawInfo, formalInfo): expr =
+template rawToFormalFileInfo(rawInfo, formalInfo): untyped =
   ## Transforms the native file info structure into the one nim uses.
   ## 'rawInfo' is either a 'TBY_HANDLE_FILE_INFORMATION' structure on Windows,
   ## or a 'Stat' structure on posix
@@ -1533,7 +1533,7 @@ template rawToFormalFileInfo(rawInfo, formalInfo): expr =
 
 
   else:
-    template checkAndIncludeMode(rawMode, formalMode: expr) =
+    template checkAndIncludeMode(rawMode, formalMode: untyped) =
       if (rawInfo.st_mode and rawMode) != 0'i32:
         formalInfo.permissions.incl(formalMode)
     formalInfo.id = (rawInfo.st_dev, rawInfo.st_ino)

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -475,7 +475,7 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl, extern: "
 
   result = true
   for c in s:
-    if not c.isSpace():
+    if not c.isSpaceAscii():
       return false
 
 proc substrEq(s: string, pos: int, substr: string): bool =

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -998,21 +998,14 @@ proc parseToken(info: var TimeInfo; token, value: string; j: var int) =
     info.monthday = value[j..j+1].parseInt()
     j += 2
   of "ddd":
-    case value[j..j+2].toLower()
-    of "sun":
-      info.weekday = dSun
-    of "mon":
-      info.weekday = dMon
-    of "tue":
-      info.weekday = dTue
-    of "wed":
-      info.weekday = dWed
-    of "thu":
-      info.weekday = dThu
-    of "fri":
-      info.weekday = dFri
-    of "sat":
-      info.weekday = dSat
+    case value[j..j+2].toLowerAscii()
+    of "sun": info.weekday = dSun
+    of "mon": info.weekday = dMon
+    of "tue": info.weekday = dTue
+    of "wed": info.weekday = dWed
+    of "thu": info.weekday = dThu
+    of "fri": info.weekday = dFri
+    of "sat": info.weekday = dSat
     else:
       raise newException(ValueError,
         "Couldn't parse day of week (ddd), got: " & value[j..j+2])
@@ -1066,31 +1059,19 @@ proc parseToken(info: var TimeInfo; token, value: string; j: var int) =
     j += 2
     info.month = Month(month-1)
   of "MMM":
-    case value[j..j+2].toLower():
-    of "jan":
-      info.month =  mJan
-    of "feb":
-      info.month =  mFeb
-    of "mar":
-      info.month =  mMar
-    of "apr":
-      info.month =  mApr
-    of "may":
-      info.month =  mMay
-    of "jun":
-      info.month =  mJun
-    of "jul":
-      info.month =  mJul
-    of "aug":
-      info.month =  mAug
-    of "sep":
-      info.month =  mSep
-    of "oct":
-      info.month =  mOct
-    of "nov":
-      info.month =  mNov
-    of "dec":
-      info.month =  mDec
+    case value[j..j+2].toLowerAscii():
+    of "jan": info.month =  mJan
+    of "feb": info.month =  mFeb
+    of "mar": info.month =  mMar
+    of "apr": info.month =  mApr
+    of "may": info.month =  mMay
+    of "jun": info.month =  mJun
+    of "jul": info.month =  mJul
+    of "aug": info.month =  mAug
+    of "sep": info.month =  mSep
+    of "oct": info.month =  mOct
+    of "nov": info.month =  mNov
+    of "dec": info.month =  mDec
     else:
       raise newException(ValueError,
         "Couldn't parse month (MMM), got: " & value)
@@ -1187,7 +1168,7 @@ proc parseToken(info: var TimeInfo; token, value: string; j: var int) =
         "Couldn't parse timezone offset (zzz), got: " & value[j])
     j += 6
   of "ZZZ":
-    info.tzname = value[j..j+2].toUpper()
+    info.tzname = value[j..j+2].toUpperAscii()
     j += 3
   else:
     # Ignore the token and move forward in the value string by the same length

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -77,7 +77,7 @@ checkpoints = @[]
 proc shouldRun(testName: string): bool =
   result = true
 
-template suite*(name: expr, body: stmt): stmt {.immediate, dirty.} =
+template suite*(name, body) {.dirty.} =
   ## Declare a test suite identified by `name` with optional ``setup``
   ## and/or ``teardown`` section.
   ##
@@ -106,13 +106,13 @@ template suite*(name: expr, body: stmt): stmt {.immediate, dirty.} =
   ##  [OK] 2 + 2 = 4
   ##  [OK] (2 + -2) != 4
   block:
-    template setup(setupBody: stmt): stmt {.immediate, dirty.} =
+    template setup(setupBody: untyped) {.dirty.} =
       var testSetupIMPLFlag = true
-      template testSetupIMPL: stmt {.immediate, dirty.} = setupBody
+      template testSetupIMPL: untyped {.dirty.} = setupBody
 
-    template teardown(teardownBody: stmt): stmt {.immediate, dirty.} =
+    template teardown(teardownBody: untyped) {.dirty.} =
       var testTeardownIMPLFlag = true
-      template testTeardownIMPL: stmt {.immediate, dirty.} = teardownBody
+      template testTeardownIMPL: untyped {.dirty.} = teardownBody
 
     body
 
@@ -135,7 +135,7 @@ proc testDone(name: string, s: TestStatus) =
     else:
       rawPrint()
 
-template test*(name: expr, body: stmt): stmt {.immediate, dirty.} =
+template test*(name, body) {.dirty.} =
   ## Define a single test case identified by `name`.
   ##
   ## .. code-block:: nim
@@ -226,7 +226,7 @@ template skip* =
   testStatusIMPL = SKIPPED
   checkpoints = @[]
 
-macro check*(conditions: stmt): stmt {.immediate.} =
+macro check*(conditions: untyped): untyped =
   ## Verify if a statement or a list of statements is true.
   ## A helpful error message and set checkpoints are printed out on
   ## failure (if ``outputLevel`` is not ``PRINT_NONE``).
@@ -318,7 +318,7 @@ macro check*(conditions: stmt): stmt {.immediate.} =
 
     result = getAst(rewrite(checked, checked.lineinfo, checked.toStrLit))
 
-template require*(conditions: stmt): stmt {.immediate.} =
+template require*(conditions: untyped) =
   ## Same as `check` except any failed test causes the program to quit
   ## immediately. Any teardown statements are not executed and the failed
   ## test output is not generated.
@@ -328,7 +328,7 @@ template require*(conditions: stmt): stmt {.immediate.} =
     check conditions
   abortOnError = savedAbortOnError
 
-macro expect*(exceptions: varargs[expr], body: stmt): stmt {.immediate.} =
+macro expect*(exceptions: varargs[typed], body: untyped): untyped =
   ## Test if `body` raises an exception found in the passed `exceptions`.
   ## The test passes if the raised exception is part of the acceptable
   ## exceptions. Otherwise, it fails.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -66,8 +66,10 @@ type
   `ref`* {.magic: Pointer.}[T] ## built-in generic traced pointer type
 
   `nil` {.magic: "Nil".}
-  expr* {.magic: Expr.} ## meta type to denote an expression (for templates)
-  stmt* {.magic: Stmt.} ## meta type to denote a statement (for templates)
+  expr* {.magic: Expr, deprecated.} ## meta type to denote an expression (for templates)
+                        ## **Deprecated** since version 0.15. Use ``untyped`` instead.
+  stmt* {.magic: Stmt, deprecated.} ## meta type to denote a statement (for templates)
+    ## **Deprecated** since version 0.15. Use ``typed`` instead.
   typedesc* {.magic: TypeDesc.} ## meta type to denote a type description
   void* {.magic: "VoidType".}   ## meta type to denote the absence of any type
   auto* {.magic: Expr.} ## meta type for automatic type determination

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -338,15 +338,15 @@ proc `<` *[T](x, y: ref T): bool {.magic: "LtPtr", noSideEffect.}
 proc `<` *[T](x, y: ptr T): bool {.magic: "LtPtr", noSideEffect.}
 proc `<` *(x, y: pointer): bool {.magic: "LtPtr", noSideEffect.}
 
-template `!=` * (x, y: expr): expr {.immediate.} =
+template `!=` * (x, y: untyped): untyped =
   ## unequals operator. This is a shorthand for ``not (x == y)``.
   not (x == y)
 
-template `>=` * (x, y: expr): expr {.immediate.} =
+template `>=` * (x, y: untyped): untyped =
   ## "is greater or equals" operator. This is the same as ``y <= x``.
   y <= x
 
-template `>` * (x, y: expr): expr {.immediate.} =
+template `>` * (x, y: untyped): untyped =
   ## "is greater" operator. This is the same as ``y < x``.
   y < x
 
@@ -1098,13 +1098,13 @@ proc contains*[T](s: Slice[T], value: T): bool {.noSideEffect, inline.} =
   ##   assert((1..3).contains(4) == false)
   result = s.a <= value and value <= s.b
 
-template `in` * (x, y: expr): expr {.immediate, dirty.} = contains(y, x)
+template `in` * (x, y: untyped): untyped {.dirty.} = contains(y, x)
   ## Sugar for contains
   ##
   ## .. code-block:: Nim
   ##   assert(1 in (1..3) == true)
   ##   assert(5 in (1..3) == false)
-template `notin` * (x, y: expr): expr {.immediate, dirty.} = not contains(y, x)
+template `notin` * (x, y: untyped): untyped {.dirty.} = not contains(y, x)
   ## Sugar for not containing
   ##
   ## .. code-block:: Nim
@@ -1123,7 +1123,7 @@ proc `is` *[T, S](x: T, y: S): bool {.magic: "Is", noSideEffect.}
   ##
   ##   assert(test[int](3) == 3)
   ##   assert(test[string]("xyz") == 0)
-template `isnot` *(x, y: expr): expr {.immediate.} = not (x is y)
+template `isnot` *(x, y: untyped): untyped = not (x is y)
   ## Negated version of `is`. Equivalent to ``not(x is y)``.
 
 proc `of` *[T, S](x: T, y: S): bool {.magic: "Of", noSideEffect.}
@@ -1742,11 +1742,11 @@ proc swap*[T](a, b: var T) {.magic: "Swap", noSideEffect.}
   ## swaps the values `a` and `b`. This is often more efficient than
   ## ``tmp = a; a = b; b = tmp``. Particularly useful for sorting algorithms.
 
-template `>=%` *(x, y: expr): expr {.immediate.} = y <=% x
+template `>=%` *(x, y: untyped): untyped = y <=% x
   ## treats `x` and `y` as unsigned and compares them.
   ## Returns true iff ``unsigned(x) >= unsigned(y)``.
 
-template `>%` *(x, y: expr): expr {.immediate.} = y <% x
+template `>%` *(x, y: untyped): untyped = y <% x
   ## treats `x` and `y` as unsigned and compares them.
   ## Returns true iff ``unsigned(x) > unsigned(y)``.
 
@@ -1874,7 +1874,7 @@ iterator countdown*[T](a, b: T, step = 1): T {.inline.} =
       yield res
       dec(res, step)
 
-template countupImpl(incr: stmt) {.immediate, dirty.} =
+template countupImpl(incr: untyped) {.dirty.} =
   when T is IntLikeForCount:
     var res = int(a)
     while res <= int(b):
@@ -3181,7 +3181,7 @@ proc `/`*(x, y: int): float {.inline, noSideEffect.} =
   ## integer division that results in a float.
   result = toFloat(x) / toFloat(y)
 
-template spliceImpl(s, a, L, b: expr): stmt {.immediate.} =
+template spliceImpl(s, a, L, b: untyped): untyped =
   # make room for additional elements or cut:
   var slen = s.len
   var shift = b.len - L
@@ -3467,7 +3467,7 @@ iterator mitems*(a: var string): var char {.inline.} =
 when not defined(nimhygiene):
   {.pragma: inject.}
 
-template onFailedAssert*(msg: expr, code: stmt): stmt {.dirty, immediate.} =
+template onFailedAssert*(msg, code: untyped): untyped {.dirty.} =
   ## Sets an assertion failure handler that will intercept any assert
   ## statements following `onFailedAssert` in the current module scope.
   ##
@@ -3480,7 +3480,7 @@ template onFailedAssert*(msg: expr, code: stmt): stmt {.dirty, immediate.} =
   ##    e.lineinfo = instantiationInfo(-2)
   ##    raise e
   ##
-  template failedAssertImpl(msgIMPL: string): stmt {.dirty.} =
+  template failedAssertImpl(msgIMPL: string): untyped {.dirty.} =
     let msg = msgIMPL
     code
 
@@ -3643,7 +3643,7 @@ proc `==` *(x, y: cstring): bool {.magic: "EqCString", noSideEffect,
   elif x.isNil or y.isNil: result = false
   else: result = strcmp(x, y) == 0
 
-template closureScope*(body: untyped): stmt =
+template closureScope*(body: untyped): untyped =
   ## Useful when creating a closure in a loop to capture local loop variables by
   ## their current iteration values. Example:
   ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3670,3 +3670,8 @@ template closureScope*(body: untyped): untyped =
 
 when defined(nimconfig):
   include "system/nimscript"
+
+when defined(windows) and compileOption("app", "console"):
+  proc setConsoleOutputCP(codepage: cint): cint {.stdcall, dynlib: "kernel32",
+    importc: "SetConsoleOutputCP".}
+  discard setConsoleOutputCP(65001) # 65001 - utf-8 codepage

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1874,7 +1874,7 @@ iterator countdown*[T](a, b: T, step = 1): T {.inline.} =
       yield res
       dec(res, step)
 
-template countupImpl(incr: untyped) {.dirty.} =
+template countupImpl(incr: untyped) {.oldimmediate, dirty.} =
   when T is IntLikeForCount:
     var res = int(a)
     while res <= int(b):

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -19,6 +19,11 @@
 when not defined(nimNewShared):
   {.pragma: gcsafe.}
 
+when not defined(nimImmediateDeprecated):
+  {.pragma: oldimmediate, immediate.}
+else:
+  {.pragma: oldimmediate.}
+
 when defined(createNimRtl):
   when defined(useNimRtl):
     {.error: "Cannot create and use nimrtl at the same time!".}

--- a/tests/macros/tdumptree.nim
+++ b/tests/macros/tdumptree.nim
@@ -3,7 +3,7 @@ msg: '''StmtList
   VarSection
     IdentDefs
       Ident !"x"
-      nil
+      Empty
       Call
         DotExpr
           Ident !"foo"

--- a/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/gl.nim
+++ b/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/gl.nim
@@ -6,7 +6,7 @@ export
   opengl
 
 type
-  EGL* = object of E_Base
+  EGL* = object of Exception
   EGL_code* = object of EGL
     code*: EGL_err
   EGL_err {.pure.} = enum

--- a/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/shader.nim
+++ b/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/shader.nim
@@ -8,7 +8,7 @@ type
   TShaderType* {.pure.} = enum
     frag = GL_FRAGMENT_SHADER,
     vert   = GL_VERTEX_SHADER
-  E_Shader* = object of E_Base
+  E_Shader* = object of Exception
   E_UnknownShaderType* = object of E_Shader
 
 converter pathToShaderType*(s: string): TShaderType =

--- a/tests/manyloc/named_argument_bug/tri_engine/gfx/tex.nim
+++ b/tests/manyloc/named_argument_bug/tri_engine/gfx/tex.nim
@@ -25,7 +25,7 @@ proc whiteTex*(): TTex =
   setTexParams()
 
   var pixel = [255'u8, 255'u8, 255'u8, 255'u8]
-  ?glTexImage2D(GLtexture2D, 0, GL_RGBA, 1, 1, 0, GL_BGRA, cGLUnsignedByte, pixel[0].addr)
+  ?glTexImage2D(GLtexture2D, 0, GLint GL_RGBA, 1, 1, 0, GL_BGRA, cGLUnsignedByte, pixel[0].addr)
   ?glBindTexture(GLtexture2D, 0)
 
   result = gWhiteTex

--- a/tests/stdlib/nre/find.nim
+++ b/tests/stdlib/nre/find.nim
@@ -1,4 +1,6 @@
-import unittest, sequtils, nre, optional_nonstrict
+import unittest, sequtils
+import nre except toSeq
+import optional_nonstrict
 
 suite "find":
   test "find text":

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -260,12 +260,14 @@ proc compileExample(r: var TResults, pattern, options: string, cat: Category) =
     testNoSpec r, makeTest(test, options, cat)
 
 proc testStdlib(r: var TResults, pattern, options: string, cat: Category) =
+  var disabledSet = disabledFiles.toSet()
   for test in os.walkFiles(pattern):
-    let contents = readFile(test).string
-    if contents.contains("when isMainModule"):
-      testSpec r, makeTest(test, options, cat, actionRunNoSpec)
-    else:
-      testNoSpec r, makeTest(test, options, cat, actionCompile)
+    if test notin disabledSet:
+      let contents = readFile(test).string
+      if contents.contains("when isMainModule"):
+        testSpec r, makeTest(test, options, cat, actionRunNoSpec)
+      else:
+        testNoSpec r, makeTest(test, options, cat, actionCompile)
 
 # ----------------------------- nimble ----------------------------------------
 type PackageFilter = enum

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -12,7 +12,7 @@
 import
   parseutils, strutils, pegs, os, osproc, streams, parsecfg, json,
   marshal, backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, compiler/nodejs, re, times
+  algorithm, compiler/nodejs, re, times, sets
 
 const
   resultsFile = "testresults.html"
@@ -387,6 +387,10 @@ proc makeTest(test, options: string, cat: Category, action = actionCompile,
   # start with 'actionCompile', will be overwritten in the spec:
   result = TTest(cat: cat, name: test, options: options,
                  target: target, action: action, startTime: epochTime())
+
+const
+  # array of modules disabled from compilation test of stdlib.
+  disabledFiles = ["lib/pure/coro.nim"]
 
 include categories
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,9 +1,6 @@
 version 1.0 battle plan
 =======================
 
-- tests/stdlib/tnre.nim
-- tests/closure/tflatmap.nim
-
 - fix "high priority" bugs
 - try to fix as many compiler crashes as reasonable
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,7 +1,9 @@
 version 1.0 battle plan
 =======================
 
-- Deprecate ``immediate`` for templates and macros
+- tests/stdlib/tnre.nim
+- tests/closure/tflatmap.nim
+
 - fix "high priority" bugs
 - try to fix as many compiler crashes as reasonable
 

--- a/web/news/version_0_15_released.rst
+++ b/web/news/version_0_15_released.rst
@@ -30,6 +30,10 @@ Changes affecting backwards compatibility
   discussion.
 - Overloading the special operators ``.``, ``.()``, ``.=``, ``()`` now
   should be enabled via ``{.experimental.}``.
+- ``immediate`` templates and macros are now deprecated.
+  Instead use ``untyped`` parameters.
+- The metatype ``expr`` is deprecated. Use ``untyped`` instead.
+- The metatype ``stmt`` is deprecated. Use ``typed`` instead.
 
 
 Library Additions

--- a/web/news/version_0_15_released.rst
+++ b/web/news/version_0_15_released.rst
@@ -34,6 +34,23 @@ Changes affecting backwards compatibility
   Instead use ``untyped`` parameters.
 - The metatype ``expr`` is deprecated. Use ``untyped`` instead.
 - The metatype ``stmt`` is deprecated. Use ``typed`` instead.
+- The compiler is now more picky when it comes to ``tuple`` types. The
+  following code used to compile, now it's rejected:
+
+.. code-block:: nim
+
+  import tables
+  var rocketaims = initOrderedTable[string, Table[tuple[k: int8, v: int8], int64] ]()
+  rocketaims["hi"] = {(-1.int8, 0.int8): 0.int64}.toTable()
+
+Instead be consistent in your tuple usage and use tuple names for tuples
+that have tuple name:
+
+.. code-block:: nim
+
+  import tables
+  var rocketaims = initOrderedTable[string, Table[tuple[k: int8, v: int8], int64] ]()
+  rocketaims["hi"] = {(k: -1.int8, v: 0.int8): 0.int64}.toTable()
 
 
 Library Additions

--- a/web/news/version_0_15_released.rst
+++ b/web/news/version_0_15_released.rst
@@ -26,7 +26,7 @@ Changes affecting backwards compatibility
 
     Warning: a [b] will be parsed as command syntax; spacing is deprecated
 
-  See `https://github.com/nim-lang/Nim/issues/3898`_ for the relevant
+  See `<https://github.com/nim-lang/Nim/issues/3898>`_ for the relevant
   discussion.
 - Overloading the special operators ``.``, ``.()``, ``.=``, ``()`` now
   should be enabled via ``{.experimental.}``.
@@ -52,6 +52,8 @@ that have tuple name:
   var rocketaims = initOrderedTable[string, Table[tuple[k: int8, v: int8], int64] ]()
   rocketaims["hi"] = {(k: -1.int8, v: 0.int8): 0.int64}.toTable()
 
+- Now when you compile console application for Windows, console output
+  encoding is automatically set to UTF-8.
 
 Library Additions
 -----------------


### PR DESCRIPTION
Changes default console encoding to UTF-8 for Windows OS when compiling console application. Also enables `system.compileOption` proc work with `--app` compiler switch.
@Araq should set encoding even with ``--app:gui`` + should app change console encoding back to previous after terminating?