### PR TITLE
Disable fasm usage on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,12 @@ addons:
     - libgc-dev
 before_script:
   - set -e
-  - wget http://flatassembler.net/fasm-1.71.39.tgz
-  - tar xvf fasm-1.71.39.tgz
   - git clone --depth 1 https://github.com/nim-lang/csources.git
   - cd csources
   - sh build.sh
   - cd ..
   - sed -i -e 's,cc = gcc,cc = clang,' config/nim.cfg
-  - export PATH=$(pwd)/bin:$(pwd)/fasm:$PATH
+  - export PATH=$(pwd)/bin:$PATH
 script:
   - nim c koch
   - ./koch boot

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -260,12 +260,14 @@ proc compileExample(r: var TResults, pattern, options: string, cat: Category) =
     testNoSpec r, makeTest(test, options, cat)
 
 proc testStdlib(r: var TResults, pattern, options: string, cat: Category) =
+  var disabledSet = disabledFiles.toSet()
   for test in os.walkFiles(pattern):
-    let contents = readFile(test).string
-    if contents.contains("when isMainModule"):
-      testSpec r, makeTest(test, options, cat, actionRunNoSpec)
-    else:
-      testNoSpec r, makeTest(test, options, cat, actionCompile)
+    if test notin disabledSet:
+      let contents = readFile(test).string
+      if contents.contains("when isMainModule"):
+        testSpec r, makeTest(test, options, cat, actionRunNoSpec)
+      else:
+        testNoSpec r, makeTest(test, options, cat, actionCompile)
 
 # ----------------------------- nimble ----------------------------------------
 type PackageFilter = enum

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -12,7 +12,7 @@
 import
   parseutils, strutils, pegs, os, osproc, streams, parsecfg, json,
   marshal, backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, compiler/nodejs, re, times
+  algorithm, compiler/nodejs, re, times, sets
 
 const
   resultsFile = "testresults.html"
@@ -387,6 +387,10 @@ proc makeTest(test, options: string, cat: Category, action = actionCompile,
   # start with 'actionCompile', will be overwritten in the spec:
   result = TTest(cat: cat, name: test, options: options,
                  target: target, action: action, startTime: epochTime())
+
+const
+  # array of files disabled from compilation test of stdlib.
+  disabledFiles = ["lib/pure/coro.nim"]
 
 include categories
 

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -389,7 +389,7 @@ proc makeTest(test, options: string, cat: Category, action = actionCompile,
                  target: target, action: action, startTime: epochTime())
 
 const
-  # array of files disabled from compilation test of stdlib.
+  # array of modules disabled from compilation test of stdlib.
   disabledFiles = ["lib/pure/coro.nim"]
 
 include categories


### PR DESCRIPTION
* Disable fasm usage on Travis CI
* Enable support of disabled modules in stdlib for tester.