### PR TITLE
Allowing `nil` for distinct types where the base type is nilable

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -900,6 +900,8 @@ proc typeRel(c: var TCandidate, f, aOrig: PType, doBind = true): TTypeRelation =
       if sameDistinctTypes(f, a): result = isEqual
       elif f.base.kind == tyAnything: result = isGeneric
       elif c.coerceDistincts: result = typeRel(c, f.base, a)
+    elif a.kind == tyNil and f.base.kind in NilableTypes:
+      result = f.allowsNil
     elif c.coerceDistincts: result = typeRel(c, f.base, a)
   of tySet:
     if a.kind == tySet:

--- a/tests/distinct/tnil.nim
+++ b/tests/distinct/tnil.nim
@@ -1,0 +1,47 @@
+discard """
+  file: "tnil.nim"
+  output: '''0x1
+
+nil
+
+nil
+
+'''
+"""
+
+type
+  MyPointer = distinct pointer
+  MyString = distinct string
+  MyStringNotNil = distinct (string not nil)
+  MyInt = distinct int
+
+proc foo(a: MyPointer) =
+  echo a.repr
+
+foo(cast[MyPointer](1))
+foo(cast[MyPointer](nil))
+foo(nil)
+
+var p: MyPointer
+p = cast[MyPointer](1)
+p = cast[MyPointer](nil)
+p = nil.MyPointer
+p = nil
+
+var c: MyString
+c = "Test".MyString
+c = nil.MyString
+c = nil
+
+p = nil
+doAssert(compiles(c = p) == false)
+
+var n: MyStringNotNil = "Test".MyStringNotNil # Cannot prove warning ...
+n = "Test".MyStringNotNil
+doAssert(compiles(n = nil.MyStringNotNil) == false)
+doAssert(compiles(n = nil.MyStringNotNil) == false)
+doAssert(compiles(n = nil) == false)
+
+var i: MyInt
+i = 1.MyInt
+doAssert(compiles(i = nil) == false)


### PR DESCRIPTION
This should do what we talked about. Are the tests ok like that or better "`assert()`" or output checks instead of the `doAssert()` ?