### PR TITLE
Implement codegen for mArrGet/mArrPut to handle distinct types.

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1787,8 +1787,8 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   of mReset: genReset(p, e)
   of mEcho: genEcho(p, e[1].skipConv)
   of mArrToSeq: genArrToSeq(p, e, d)
-  # For normal (non-borrow) types, mArrGet/mArrPut are handled during
-  # semantic checking. genArrGet/genArrPut are only called for borrow types.
+  # For normal (non-distinct) types, mArrGet/mArrPut are handled during
+  # semantic checking. genArrGet/genArrPut are only called for distinct types.
   of mArrGet: genArrGet(p, e, d)
   of mArrPut: genArrPut(p, e, d)
   of mNLen..mNError, mSlurp..mQuoteAst:

--- a/tests/distinct/tgetset.nim
+++ b/tests/distinct/tgetset.nim
@@ -1,0 +1,28 @@
+discard """
+  file: "tgetset.nim"
+  output: '''true'''
+"""
+type dring = distinct string
+
+let a = "Hello".dring
+let b = ", World".dring
+
+proc `[]`(d: dring; x: int): char {.borrow.}
+proc `[]=`(d: dring; x: int; b: char): void {.borrow.}
+proc `==`(x, y: dring): bool {.borrow.}
+proc `$`(d: dring): string {.borrow.}
+assert(not (a == b))
+assert(a[1] == 'e')
+assert(b[0] == ',')
+var c = b
+c[0] = 'A'
+c[2] = 'w'
+assert($c == "A world")
+assert(c == "A world".dring)
+
+let d = new(dring)
+d[] = a
+(d[])[4] = '!'
+assert($d[] == "Hell!")
+
+echo "true"


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/4491. Procs with `mArrGet`/`mArrPut` magic are rewritten during semantic checking (in `semArrGet`/`semArrPut`). Unfortunately, this occurs before `borrow` resolution. A consequence is that borrowed declarations would be difficult (and messy) to handle in the same way. This approach seems much less risky.