### PR TITLE
AsyncEvent compatible between Windows and non-Windows platforms

### DIFF
--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -1233,7 +1233,7 @@ when defined(windows) or defined(nimdoc):
 
     registerWaitableHandle(p, hProcess, flags, pcd, proccb)
 
-  proc newEvent*(): AsyncEvent =
+  proc newAsyncEvent*(): AsyncEvent =
     ## Creates new ``AsyncEvent`` object.
     var sa = SECURITY_ATTRIBUTES(
       nLength: sizeof(SECURITY_ATTRIBUTES).cint,
@@ -1314,7 +1314,7 @@ else:
       readCB: Callback
       writeCB: Callback
 
-    AsyncEvent = SelectEvent
+    AsyncEvent* = SelectEvent
 
     PDispatcher* = ref object of PDispatcherBase
       selector: Selector[AsyncData]
@@ -1419,7 +1419,7 @@ else:
               if adata.writeCB == cb:
                 adata.writeCB = nil
                 update = true
-        
+
         when supportedPlatform:
           if (customSet * events) != {}:
             let cb = keys[i].data.readCB


### PR DESCRIPTION
Two changes to upcoming asyncdispatch here:

1. Renamed Windows proc `newEvent` to `newAsyncEvent` for it to be compatible with posix platforms naming (those platforms already have `newAsyncEvent` proc).

2. Exported `AsyncEvent` type on non-Windows platforms (previously it was only exported on Windows).

I haven't tested if everything is fine on Windows with the second change. Shouldn't be any problems though.

/cc @cheatfate