### PR TITLE
Fix crash and new features in unittest

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -328,6 +328,9 @@ macro check*(conditions: untyped): untyped =
       if checked[i].kind != nnkCommentStmt:
         result.add(newCall(!"check", checked[i]))
 
+  of nnkLetSection:
+    result = checked
+
   else:
     template rewrite(Exp, lineInfoLit: expr, expLit: string): stmt =
       if not Exp:

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -253,9 +253,18 @@ macro check*(conditions: untyped): untyped =
     var a = value # XXX: we need "var: var" here in order to
                   # preserve the semantics of var params
 
+  template isNil(value: expr): expr =
+    when compiles(value == nil):
+      value == nil
+    else:
+      false
+
   template print(name, value: expr): stmt =
     when compiles(string($value)):
-      checkpoint(name & " was " & $value)
+      if isNil(value):
+        checkpoint(name & " was nil")
+      else:
+        checkpoint(name & " was " & $value)
 
   proc inspectArgs(exp: NimNode): NimNode =
     result = copyNimTree(exp)

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -279,6 +279,10 @@ macro check*(conditions: untyped): untyped =
           var paramAst = exp[i]
           if exp[i].kind == nnkIdent:
             argsPrintOuts.add getAst(print(argStr, paramAst))
+          if exp[i].kind == nnkDotExpr:
+            argsPrintOuts.add getAst(print(argStr, paramAst))
+          if exp[i].kind == nnkBracketExpr:
+            argsPrintOuts.add getAst(print(argStr, paramAst))
           if exp[i].kind in nnkCallKinds:
             var callVar = newIdentNode(":c" & $counter)
             argsAsgns.add getAst(asgn(callVar, paramAst))

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -226,6 +226,9 @@ template skip* =
   testStatusIMPL = SKIPPED
   checkpoints = @[]
 
+macro isLiteral(value: expr[typed]): expr =
+  bool(value.kind == nnkSym and value.symbol.getImpl.kind == nnkNilLit)
+
 macro check*(conditions: untyped): untyped =
   ## Verify if a statement or a list of statements is true.
   ## A helpful error message and set checkpoints are printed out on
@@ -260,7 +263,9 @@ macro check*(conditions: untyped): untyped =
       false
 
   template print(name, value: expr): stmt =
-    when compiles(string($value)):
+    when isLiteral(value):
+      discard
+    elif compiles(string($value)):
       if isNil(value):
         checkpoint(name & " was nil")
       else:


### PR DESCRIPTION
The following unit test crashes currently:

``` nim
import unittest

suite "ShowsBug":
  test "Compare with nil variable":
    let str: string = nil
    check str == "hello"
```

```
Traceback (most recent call last)
unittest.nim(267)        test_bug
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

The reason is that the unittest module just checks wheter `string($str)` compiles, and then prints out `$str` even if `str` is `nil`. I've added a check for `nil` and it doesn't crash anymore.

Maybe long term it should use something like `repr` instead of `$`, which handles `nil` and also adds quotation marks. I didn't use it here because it also prepends the memory address, which I didn't want in the test output.
