### PR TITLE
Fixed infinite recursion in setEvent and close procs in new asyncdispatch

### DIFF
--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -1686,11 +1686,11 @@ else:
 
   proc setEvent*(ev: AsyncEvent) =
     ## Sets new ``AsyncEvent`` to signaled state.
-    setEvent(SelectEvent(ev))
+    ioselectors.setEvent(SelectEvent(ev))
 
   proc close*(ev: AsyncEvent) =
     ## Closes ``AsyncEvent``
-    close(SelectEvent(ev))
+    ioselectors.close(SelectEvent(ev))
 
   proc addEvent*(ev: AsyncEvent, cb: Callback) =
     ## Start watching for event ``ev``, and call callback ``cb``, when


### PR DESCRIPTION
In non-windows systems `AsyncEvent` is defined as an alias for `SelectEvent`. This lead to infinite recursion when calling `setEvent` or `close`, despite the conversion. I changed the procs to use fully qualified name.