### PR TITLE
Get rid of initialization warning

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3232,7 +3232,7 @@ proc `[]`*[Idx, T](a: array[Idx, T], x: Slice[int]): seq[T] =
   when low(a) < 0:
     {.error: "Slicing for arrays with negative indices is unsupported.".}
   var L = x.b - x.a + 1
-  newSeq(result, L)
+  result = newSeq[T](L)
   for i in 0.. <L: result[i] = a[i + x.a]
 
 proc `[]=`*[Idx, T](a: var array[Idx, T], x: Slice[int], b: openArray[T]) =


### PR DESCRIPTION
Otherwise the compile complains that result might not be initialized.