### PR TITLE
Nicer output formatting for unittest

### DIFF
--- a/tests/js/tunittests.nim
+++ b/tests/js/tunittests.nim
@@ -1,5 +1,7 @@
 discard """
-  output: '''[OK] >:)'''
+  output: '''
+[Suite] Bacon
+  [OK] >:)'''
 """
 
 import unittest

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -1,5 +1,8 @@
 discard """
   action: run
+  output: '''
+[Suite] inet_ntop tests
+'''
 """
 
 when defined(windows):

--- a/tests/stdlib/tparseuints.nim
+++ b/tests/stdlib/tparseuints.nim
@@ -1,5 +1,7 @@
 discard """
   action: run
+  output: '''
+[Suite] parseutils'''
 """
 import unittest, strutils
 


### PR DESCRIPTION
 * if `suite` is used, write its name to the output
 * indent child tests of the suite and their error output
 * empty line before `[Suite]` so that multiple suites are separated from each other. Also makes a nice separation from the compilation output if run with `nim c -r`

Output of the example code of the unittest documentation:

#### Before

```
[OK] essential truths
test1.nim(11,12): Check failed: 1 != 1
[FAILED] slightly less obvious stuff
[OK] out of bounds error is thrown on bad access
```

#### After

```

[Suite] description for this stuff
  [OK] essential truths
    test1.nim(11,12): Check failed: 1 != 1
  [FAILED] slightly less obvious stuff
  [OK] out of bounds error is thrown on bad access
```