### PR TITLE
Uncaught exceptions in JS now always propagate with better stack trace. Fixed codegen bug.

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -560,6 +560,7 @@ proc genTry(p: PProc, n: PNode, r: var TCompRes) =
   #  ++excHandler;
   #  try {
   #    stmts;
+  #    --excHandler;
   #  } catch (EXC) {
   #    var prevJSError = lastJSError; lastJSError = EXC;
   #    --excHandler;
@@ -595,7 +596,7 @@ proc genTry(p: PProc, n: PNode, r: var TCompRes) =
   var generalCatchBranchExists = false
   let dollar = rope(if p.target == targetJS: "" else: "$")
   if p.target == targetJS and catchBranchesExist:
-    addf(p.body, "} catch (EXC) {$n var prevJSError = lastJSError;$n" &
+    addf(p.body, "--excHandler;$n} catch (EXC) {$n var prevJSError = lastJSError;$n" &
         " lastJSError = EXC;$n --excHandler;$n", [])
   elif p.target == targetPHP:
     addf(p.body, "} catch (Exception $$EXC) {$n $$prevJSError = $$lastJSError;$n $$lastJSError = $$EXC;$n", [])

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -86,9 +86,6 @@ proc auxWriteStackTrace(f: PCallFrame): string =
 proc rawWriteStackTrace(): string =
   if framePtr != nil:
     result = "Traceback (most recent call last)\n" & auxWriteStackTrace(framePtr)
-    framePtr = nil
-  elif lastJSError != nil:
-    result = $lastJSError.stack
   else:
     result = "No stack traceback available\n"
 
@@ -108,6 +105,7 @@ proc unhandledException(e: ref Exception) {.
   when NimStackTrace:
     add(buf, rawWriteStackTrace())
   let cbuf : cstring = buf
+  framePtr = nil
   {.emit: """
   if (typeof(Error) !== "undefined") {
     throw new Error(`cbuf`);

--- a/tests/exception/tunhandledexc.nim
+++ b/tests/exception/tunhandledexc.nim
@@ -14,10 +14,9 @@ proc genErrors(s: string) =
     raise newException(EsomeotherErr, "bla")
 
 when true:
+  try: discard except: discard
+
   try:
     genErrors("errssor!")
   except ESomething:
     echo("Error happened")
-
-
-

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -220,6 +220,7 @@ proc jsTests(r: var TResults, cat: Category, options: string) =
   for testfile in ["exception/texceptions", "exception/texcpt1",
                    "exception/texcsub", "exception/tfinally",
                    "exception/tfinally2", "exception/tfinally3",
+                   "exception/tunhandledexc",
                    "actiontable/tactiontable", "method/tmultim1",
                    "method/tmultim3", "method/tmultim4",
                    "varres/tvarres0", "varres/tvarres3", "varres/tvarres4",

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -334,6 +334,11 @@ proc testSpec(r: var TResults, test: TTest) =
 
     let exeCmd = (if isJsTarget: nodejs & " " else: "") & exeFile
     var (buf, exitCode) = execCmdEx(exeCmd, options = {poStdErrToStdOut})
+
+    # Treat all failure codes from nodejs as 1. Older versions of nodejs used
+    # to return other codes, but for us it is sufficient to know that it's not 0.
+    if exitCode != 0: exitCode = 1
+
     let bufB = if expected.sortoutput: makeDeterministic(strip(buf.string))
                else: strip(buf.string)
     let expectedOut = strip(expected.outp)

--- a/web/news/version_0_15_released.rst
+++ b/web/news/version_0_15_released.rst
@@ -60,6 +60,8 @@ that have tuple name:
 - Unhandled exceptions in JavaScript are now thrown regardless ``noUnhandledHandler``
   is defined. But now they do their best to provide a readable stack trace.
 
+- In JavaScript ``system.alert`` is deprecated. Use ``dom.alert`` instead.
+
 Library Additions
 -----------------
 

--- a/web/news/version_0_15_released.rst
+++ b/web/news/version_0_15_released.rst
@@ -57,6 +57,9 @@ that have tuple name:
 - Now when you compile console application for Windows, console output
   encoding is automatically set to UTF-8.
 
+- Unhandled exceptions in JavaScript are now thrown regardless ``noUnhandledHandler``
+  is defined. But now they do their best to provide a readable stack trace.
+
 Library Additions
 -----------------
 


### PR DESCRIPTION
## Uncaught exceptions stack trace
Code:
```nim
proc test() = raise newException(Exception, "hi")
test()
```
Output before:
```
/Users/yglukhov/nimcache/test.js:175
throw e_12605;}
^
Exception: 104,105,0
```
Output after:
```
/Users/yglukhov/nimcache/test.js:363
    throw new Error(cbuf_12401);
    ^

Error: Error: unhandled exception: hi [Exception]
Traceback (most recent call last)
test.test, line: 2528

    at unhandledException (/Users/yglukhov/nimcache/test.js:363:11)
    at raiseException (/Users/yglukhov/nimcache/test.js:212:1)
    at test_23003 (/Users/yglukhov/nimcache/test.js:393:1)
    at Object.<anonymous> (/Users/yglukhov/nimcache/test.js:396:1)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
```
Even with `-d:release` we still have a better stack trace.
```
/Users/yglukhov/nimcache/test.js:249
    throw new Error(cbuf_12401);
    ^

Error: Error: unhandled exception: hi [Exception]

    at unhandledException (/Users/yglukhov/nimcache/test.js:249:11)
    at raiseException (/Users/yglukhov/nimcache/test.js:173:1)
    at test_23003 (/Users/yglukhov/nimcache/test.js:274:1)
    at Object.<anonymous> (/Users/yglukhov/nimcache/test.js:276:1)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
```
## Alert deprecated
`alert` is deprecated in favor of `dom.alert`.

## Fixed codegen issues
* Uncaught exception would never occur after at least one `try` block executed without exception.
* Stack frame in try block may get corrupted after exception is raised.
* asmNoStackFrame pragma was ignored, potentially resulting in corrupted stack frame.
