### PR TITLE
Add terminal.terminalWidth for windows & posix/unix-like

### DIFF
--- a/lib/posix/termios.nim
+++ b/lib/posix/termios.nim
@@ -263,7 +263,7 @@ proc tcGetSid*(fd: cint): Pid {.importc: "tcgetsid", header: "<termios.h>".}
 # Window size ioctl.  Should work on on any Unix that xterm has been ported to.
 var TIOCGWINSZ*{.importc, header: "<sys/ioctl.h>".}: culong
 
-type IOctl_WinSize* {.importc: "struct winsize", header: "<termios.h>",
+type IOctl_WinSize* {.importc: "struct winsize", header: "<sys/ioctl.h>",
                       final, pure.} = object
   ws_row*, ws_col*, ws_xpixel*, ws_ypixel*: cushort
 

--- a/lib/posix/termios.nim
+++ b/lib/posix/termios.nim
@@ -263,9 +263,9 @@ proc tcGetSid*(fd: cint): Pid {.importc: "tcgetsid", header: "<termios.h>".}
 # Window size ioctl.  Should work on on any Unix that xterm has been ported to.
 var TIOCGWINSZ*{.importc, header: "<sys/ioctl.h>".}: culong
 
-type ioctl_winsize* {.importc: "struct winsize", header: "<termios.h>",
+type IOctl_WinSize* {.importc: "struct winsize", header: "<termios.h>",
                       final, pure.} = object
   ws_row*, ws_col*, ws_xpixel*, ws_ypixel*: cushort
 
-proc ioctl*(fd: cint, request: culong, reply: ptr ioctl_winsize): int {.
+proc ioctl*(fd: cint, request: culong, reply: ptr IOctl_WinSize): int {.
   importc: "ioctl", header: "<stdio.h>", varargs.}

--- a/lib/posix/termios.nim
+++ b/lib/posix/termios.nim
@@ -259,3 +259,13 @@ proc tcFlow*(fd: cint; action: cint): cint {.importc: "tcflow",
 # Get process group ID for session leader for controlling terminal FD.
 
 proc tcGetSid*(fd: cint): Pid {.importc: "tcgetsid", header: "<termios.h>".}
+
+# Window size ioctl.  Should work on on any Unix that xterm has been ported to.
+var TIOCGWINSZ*{.importc, header: "<sys/ioctl.h>".}: culong
+
+type ioctl_winsize* {.importc: "struct winsize", header: "<termios.h>",
+                      final, pure.} = object
+  ws_row*, ws_col*, ws_xpixel*, ws_ypixel*: cushort
+
+proc ioctl*(fd: cint, request: culong, reply: ptr ioctl_winsize): int {.
+  importc: "ioctl", header: "<stdio.h>", varargs.}

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -162,11 +162,11 @@ else:
         return int(win.ws_col)
     return 0
 
+  var L_ctermid{.importc, header: "<stdio.h>".}: cint
   proc terminalWidth*(): int =
-    ## Returns **some** reasonable terminal width from either standard file
+    ## Returns some reasonable terminal width from either standard file
     ## descriptors, controlling terminal, environment variables or tradition.
 
-    var L_ctermid{.importc, header: "<stdio.h>".}: cint
     var w = terminalWidthIoctl([0, 1, 2])   #Try standard file descriptors
     if w > 0: return w
     var cterm = newString(L_ctermid)        #Try controlling tty

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -156,7 +156,7 @@ else:
   proc terminalWidthIoctl*(fds: openArray[int]): int =
     ## Returns terminal width from first fd that supports the ioctl.
 
-    var win: ioctl_winsize
+    var win: IOctl_WinSize
     for fd in fds:
       if ioctl(cint(fd), TIOCGWINSZ, addr win) != -1:
         return int(win.ws_col)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -69,9 +69,9 @@ when defined(windows):
 
   proc terminalWidth*(): int =
     var w: int = 0
-    w = terminalWidth([ getStdHandle(STD_INPUT_HANDLE),
-                        getStdHandle(STD_OUTPUT_HANDLE),
-                        getStdHandle(STD_ERROR_HANDLE) ] )
+    w = terminalWidthIoctl([ getStdHandle(STD_INPUT_HANDLE),
+                             getStdHandle(STD_OUTPUT_HANDLE),
+                             getStdHandle(STD_ERROR_HANDLE) ] )
     if w > 0: return w
     return 80
 

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -60,19 +60,18 @@ when defined(windows):
     lpConsoleScreenBufferInfo: ptr CONSOLE_SCREEN_BUFFER_INFO): WINBOOL{.stdcall,
     dynlib: "kernel32", importc: "GetConsoleScreenBufferInfo".}
 
-  proc terminalWidth*(h: Handle): int =
+  proc terminalWidthIoctl*(handles: openArray[Handle]): int =
     var csbi: CONSOLE_SCREEN_BUFFER_INFO
-    if getConsoleScreenBufferInfo(h, addr csbi) != 0:
-      return int(csbi.srWindow.Right - csbi.srWindow.Left + 1)
+    for h in handles:
+      if getConsoleScreenBufferInfo(h, addr csbi) != 0:
+        return int(csbi.srWindow.Right - csbi.srWindow.Left + 1)
     return 0
 
   proc terminalWidth*(): int =
     var w: int = 0
-    w = terminalWidth(getStdHandle(STD_INPUT_HANDLE))
-    if w > 0: return w
-    w = terminalWidth(getStdHandle(STD_OUTPUT_HANDLE))
-    if w > 0: return w
-    w = terminalWidth(getStdHandle(STD_ERROR_HANDLE))
+    w = terminalWidth([ getStdHandle(STD_INPUT_HANDLE),
+                        getStdHandle(STD_OUTPUT_HANDLE),
+                        getStdHandle(STD_ERROR_HANDLE) ] )
     if w > 0: return w
     return 80
 

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -176,7 +176,7 @@ else:
     discard close(fd)
     if w > 0: return w
     var s = getEnv("COLUMNS")               #Try standard env var
-    if len(s) > 0 and parseInt(s, w) > 0 and w > 0:
+    if len(s) > 0 and parseInt(string(s), w) > 0 and w > 0:
       return w
     return 80                               #Finally default to venerable value
 


### PR DESCRIPTION
Hey...So, for most nice formatting for terminal like output, it is usually helpful to know at least the current terminal width.  This PR adds that proc to the standard lib.  It should compile/run/work on Windows, though it would be best for someone with a commonly used Windows Nim build environment to double-check that.