### PR TITLE
Closing AsyncEvent now also unregisters it on non-Windows platforms

### DIFF
--- a/lib/pure/ioselectors.nim
+++ b/lib/pure/ioselectors.nim
@@ -118,6 +118,7 @@ when defined(nimdoc):
 
   proc unregister*[T](s: Selector[T], ev: SelectEvent) =
     ## Unregisters event ``ev`` from selector ``s``.
+    ## Does nothing if the event is not registered.
 
   proc unregister*[T](s: Selector[T], fd: int|SocketHandle|cint) =
     ## Unregisters file/socket descriptor ``fd`` from selector ``s``.

--- a/lib/pure/ioselects/ioselectors_epoll.nim
+++ b/lib/pure/ioselects/ioselectors_epoll.nim
@@ -234,14 +234,14 @@ proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   let fdi = int(ev.efd)
   s.checkFd(fdi)
   var pkey = addr(s.fds[fdi])
-  doAssert(pkey.ident != 0)
-  doAssert(Event.User in pkey.events)
-  pkey.ident = 0
-  pkey.events = {}
-  var epv = epoll_event()
-  if epoll_ctl(s.epollFD, EPOLL_CTL_DEL, fdi.cint, addr epv) == -1:
-    raiseOSError(osLastError())
-  dec(s.count)
+  if pkey.ident != 0:
+    doAssert(Event.User in pkey.events)
+    pkey.ident = 0
+    pkey.events = {}
+    var epv = epoll_event()
+    if epoll_ctl(s.epollFD, EPOLL_CTL_DEL, fdi.cint, addr epv) == -1:
+      raiseOSError(osLastError())
+    dec(s.count)
 
 proc registerTimer*[T](s: Selector[T], timeout: int, oneshot: bool,
                        data: T): int {.discardable.} =

--- a/lib/pure/ioselects/ioselectors_kqueue.nim
+++ b/lib/pure/ioselects/ioselectors_kqueue.nim
@@ -305,12 +305,12 @@ proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   let fdi = int(ev.rfd)
   s.checkFd(fdi)
   var pkey = addr(s.fds[fdi])
-  doAssert(pkey.ident != 0)
-  doAssert(Event.User in pkey.events)
-  pkey.ident = 0
-  pkey.events = {}
-  modifyKQueue(s, fdi.uint, EVFILT_READ, EV_DELETE, 0, 0, nil)
-  dec(s.count)
+  if pkey.ident != 0:
+    doAssert(Event.User in pkey.events)
+    pkey.ident = 0
+    pkey.events = {}
+    modifyKQueue(s, fdi.uint, EVFILT_READ, EV_DELETE, 0, 0, nil)
+    dec(s.count)
 
 proc flush*[T](s: Selector[T]) =
   s.withChangeLock():

--- a/lib/pure/ioselects/ioselectors_poll.nim
+++ b/lib/pure/ioselects/ioselectors_poll.nim
@@ -187,11 +187,11 @@ proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   let fdi = int(ev.rfd)
   s.checkFd(fdi)
   var pkey = addr(s.fds[fdi])
-  doAssert(pkey.ident != 0)
-  doAssert(Event.User in pkey.events)
-  pkey.ident = 0
-  pkey.events = {}
-  s.pollRemove(fdi.cint)
+  if pkey.ident != 0:
+    doAssert(Event.User in pkey.events)
+    pkey.ident = 0
+    pkey.events = {}
+    s.pollRemove(fdi.cint)
 
 proc newSelectEvent*(): SelectEvent =
   var fds: array[2, cint]

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -1690,6 +1690,8 @@ else:
 
   proc close*(ev: AsyncEvent) =
     ## Closes ``AsyncEvent``
+    let p = getGlobalDispatcher()
+    p.selector.unregister(SelectEvent(ev))
     ioselectors.close(SelectEvent(ev))
 
   proc addEvent*(ev: AsyncEvent, cb: Callback) =


### PR DESCRIPTION
I made `proc close*(ev: AsyncEvent)` on non-Windows behave consistently with Windows version. It now unregisters the event if it is registered with the dispatcher.