### PR TITLE
Async read/write procedures no longer conflict in upcoming/asyncdispatch

### DIFF
--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -1368,19 +1368,25 @@ else:
 
   proc addRead*(fd: AsyncFD, cb: Callback) =
     let p = getGlobalDispatcher()
+    var newEvents = {Event.Read}
     withData(p.selector, fd.SocketHandle, adata) do:
       adata.readCB = cb
+      if adata.writeCB != nil:
+        newEvents.incl(Event.Write)
     do:
       raise newException(ValueError, "File descriptor not registered.")
-    p.selector.updateHandle(fd.SocketHandle, {Event.Read})
+    p.selector.updateHandle(fd.SocketHandle, newEvents)
 
   proc addWrite*(fd: AsyncFD, cb: Callback) =
     let p = getGlobalDispatcher()
+    var newEvents = {Event.Write}
     withData(p.selector, fd.SocketHandle, adata) do:
       adata.writeCB = cb
+      if adata.readCB != nil:
+        newEvents.incl(Event.Read)
     do:
       raise newException(ValueError, "File descriptor not registered.")
-    p.selector.updateHandle(fd.SocketHandle, {Event.Write})
+    p.selector.updateHandle(fd.SocketHandle, newEvents)
 
   proc poll*(timeout = 500) =
     var keys: array[64, ReadyKey[AsyncData]]


### PR DESCRIPTION
Before this fix `addRead` would remove listening for write events, and vice versa.

/cc @cheatfate