### PR TITLE
Don't update handle in upcoming/asyncdispatch poll() if it was closed

### DIFF
--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -1435,7 +1435,7 @@ else:
           p.selector.withData(fd, adata) do:
             if adata.readCB != nil: incl(newEvents, Event.Read)
             if adata.writeCB != nil: incl(newEvents, Event.Write)
-          p.selector.updateHandle(fd, newEvents)
+            p.selector.updateHandle(fd, newEvents)
         inc(i)
 
     # Timer processing.


### PR DESCRIPTION
Whenever socket was closed/unregistered in either write or read callback, it lead to an error in `poll()`, because it called `updateHandle` that asserts that the handle is registered.

/cc @cheatfate