### PR TITLE
Logging compatible with js

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -336,10 +336,11 @@ proc getLogFilter*(): Level =
 
 when not defined(testing) and isMainModule:
   var L = newConsoleLogger()
-  var fL = newFileLogger("test.log", fmtStr = verboseFmtStr)
-  var rL = newRollingFileLogger("rolling.log", fmtStr = verboseFmtStr)
+  when not defined(js):
+    var fL = newFileLogger("test.log", fmtStr = verboseFmtStr)
+    var rL = newRollingFileLogger("rolling.log", fmtStr = verboseFmtStr)
+    addHandler(fL)
+    addHandler(rL)
   addHandler(L)
-  addHandler(fL)
-  addHandler(rL)
   for i in 0 .. 25:
     info("hello", i)

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -228,8 +228,8 @@ proc jsTests(r: var TResults, cat: Category, options: string) =
                    "varres/tvartup", "misc/tints", "misc/tunsignedinc"]:
     test "tests/" & testfile & ".nim"
 
-  for testfile in ["pure/strutils", "pure/json", "pure/random", "pure/times"]:
-    test "lib/" & testfile & ".nim"
+  for testfile in ["strutils", "json", "random", "times", "logging"]:
+    test "lib/pure/" & testfile & ".nim"
 
 # ------------------------- manyloc -------------------------------------------
 #proc runSpecialTests(r: var TResults, options: string) =


### PR DESCRIPTION
1. Moved js-incompatible stuff under `when not defined(js)`.
2. ConsoleLogger will actually do `console.log` in js.