### PR TITLE
PNode sons: tidy and optimise

### DIFF
--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -32,7 +32,7 @@ proc isPartOfAux(n: PNode, b: PType, marker: var IntSet): TAnalysisResult =
     for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
-        result = isPartOfAux(lastSon(n.sons[i]), b, marker)
+        result = isPartOfAux(last(n.sons[i]), b, marker)
         if result == arYes: return
       else: internalError("isPartOfAux(record case branch)")
   of nkSym:
@@ -50,7 +50,7 @@ proc isPartOfAux(a, b: PType, marker: var IntSet): TAnalysisResult =
       result = isPartOfAux(a.sons[0].skipTypes(skipPtrs), b, marker)
     if result == arNo: result = isPartOfAux(a.n, b, marker)
   of tyGenericInst, tyDistinct:
-    result = isPartOfAux(lastSon(a), b, marker)
+    result = isPartOfAux(last(a), b, marker)
   of tyArray, tyArrayConstr, tySet, tyTuple:
     for i in countup(0, len(a) - 1):
       result = isPartOfAux(a.sons[i], b, marker)

--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -22,14 +22,14 @@ proc isPartOfAux(n: PNode, b: PType, marker: var IntSet): TAnalysisResult =
   result = arNo
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result = isPartOfAux(n.sons[i], b, marker)
       if result == arYes: return
   of nkRecCase:
     assert(n.sons[0].kind == nkSym)
     result = isPartOfAux(n.sons[0], b, marker)
     if result == arYes: return
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
         result = isPartOfAux(lastSon(n.sons[i]), b, marker)
@@ -52,7 +52,7 @@ proc isPartOfAux(a, b: PType, marker: var IntSet): TAnalysisResult =
   of tyGenericInst, tyDistinct:
     result = isPartOfAux(lastSon(a), b, marker)
   of tyArray, tyArrayConstr, tySet, tyTuple:
-    for i in countup(0, sonsLen(a) - 1):
+    for i in countup(0, len(a) - 1):
       result = isPartOfAux(a.sons[i], b, marker)
       if result == arYes: return
   else: discard

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1389,7 +1389,7 @@ proc addNilAllowed*(father, son: PNode) =
   if isNil(father.sons): father.sons = @[]
   add(father.sons, son)
 
-proc delSon*(father: PNode, idx: int) =
+proc del*(father: PNode, idx: int) =
   if isNil(father.sons): return
   var length = sonsLen(father)
   for i in countup(idx, length - 2): father.sons[i] = father.sons[i + 1]

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1228,8 +1228,8 @@ proc newSons*(father: PType, length: int) =
     setLen(father.sons, length)
 
 proc len*(n: PType): int = n.sons.len
-proc lastSon*(n: PNode): PNode = n.sons[^1]
-proc lastSon*(n: PType): PType = n.sons[^1]
+proc last*(n: PNode): PNode = n.sons[^1]
+proc last*(n: PType): PType = n.sons[^1]
 
 proc assignType*(dest, src: PType) =
   dest.kind = src.kind
@@ -1331,14 +1331,14 @@ proc skipTypes*(t: PType, kinds: TTypeKinds): PType =
   ## last child nodes of a type tree need to be searched. This is a really hot
   ## path within the compiler!
   result = t
-  while result.kind in kinds: result = lastSon(result)
+  while result.kind in kinds: result = last(result)
 
 proc skipTypesOrNil*(t: PType, kinds: TTypeKinds): PType =
   ## same as skipTypes but handles 'nil'
   result = t
   while result != nil and result.kind in kinds:
     if result.len == 0: return nil
-    result = lastSon(result)
+    result = last(result)
 
 proc isGCedMem*(t: PType): bool {.inline.} =
   result = t.kind in {tyString, tyRef, tySequence} or
@@ -1558,7 +1558,7 @@ proc skipStmtList*(n: PNode): PNode =
   if n.kind in {nkStmtList, nkStmtListExpr}:
     for i in 0 .. n.len-2:
       if n[i].kind notin {nkEmpty, nkCommentStmt}: return n
-    result = n.lastSon
+    result = n.last
   else:
     result = n
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1227,9 +1227,7 @@ proc newSons*(father: PType, length: int) =
   else:
     setLen(father.sons, length)
 
-proc sonsLen*(n: PType): int = n.sons.len
 proc len*(n: PType): int = n.sons.len
-proc sonsLen*(n: PNode): int = n.sons.len
 proc lastSon*(n: PNode): PNode = n.sons[^1]
 proc lastSon*(n: PType): PType = n.sons[^1]
 
@@ -1252,8 +1250,8 @@ proc assignType*(dest, src: PType) =
       mergeLoc(dest.sym.loc, src.sym.loc)
     else:
       dest.sym = src.sym
-  newSons(dest, sonsLen(src))
-  for i in countup(0, sonsLen(src) - 1): dest.sons[i] = src.sons[i]
+  newSons(dest, len(src))
+  for i in countup(0, len(src) - 1): dest.sons[i] = src.sons[i]
 
 proc copyType*(t: PType, owner: PSym, keepId: bool): PType =
   result = newType(t.kind, owner)
@@ -1391,7 +1389,7 @@ proc addNilAllowed*(father, son: PNode) =
 
 proc del*(father: PNode, idx: int) =
   if isNil(father.sons): return
-  var length = sonsLen(father)
+  var length = len(father)
   for i in countup(idx, length - 2): father.sons[i] = father.sons[i + 1]
   setLen(father.sons, length - 1)
 
@@ -1430,7 +1428,7 @@ proc shallowCopy*(src: PNode): PNode =
   of nkSym: result.sym = src.sym
   of nkIdent: result.ident = src.ident
   of nkStrLit..nkTripleStrLit: result.strVal = src.strVal
-  else: newSeq(result.sons, sonsLen(src))
+  else: newSeq(result.sons, len(src))
 
 proc copyTree*(src: PNode): PNode =
   # copy a whole syntax tree; performs deep copying
@@ -1450,12 +1448,12 @@ proc copyTree*(src: PNode): PNode =
   of nkIdent: result.ident = src.ident
   of nkStrLit..nkTripleStrLit: result.strVal = src.strVal
   else:
-    newSeq(result.sons, sonsLen(src))
-    for i in countup(0, sonsLen(src) - 1):
+    newSeq(result.sons, len(src))
+    for i in countup(0, len(src) - 1):
       result.sons[i] = copyTree(src.sons[i])
 
 proc hasSonWith*(n: PNode, kind: TNodeKind): bool =
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     if n.sons[i].kind == kind:
       return true
   result = false
@@ -1473,14 +1471,14 @@ proc containsNode*(n: PNode, kinds: TNodeKinds): bool =
   case n.kind
   of nkEmpty..nkNilLit: result = n.kind in kinds
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       if n.kind in kinds or containsNode(n.sons[i], kinds): return true
 
 proc hasSubnodeWith*(n: PNode, kind: TNodeKind): bool =
   case n.kind
   of nkEmpty..nkNilLit: result = n.kind == kind
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       if (n.sons[i].kind == kind) or hasSubnodeWith(n.sons[i], kind):
         return true
     result = false

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1556,13 +1556,6 @@ proc isEmptyType*(t: PType): bool {.inline.} =
   ## 'void' and 'stmt' types are often equivalent to 'nil' these days:
   result = t == nil or t.kind in {tyVoid, tyStmt}
 
-proc makeStmtList*(n: PNode): PNode =
-  if n.kind == nkStmtList:
-    result = n
-  else:
-    result = newNodeI(nkStmtList, n.info)
-    result.addSon n
-
 proc skipStmtList*(n: PNode): PNode =
   if n.kind in {nkStmtList, nkStmtListExpr}:
     for i in 0 .. n.len-2:

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1166,13 +1166,13 @@ proc newNodeIT*(kind: TNodeKind, info: TLineInfo, typ: PType): PNode =
   result.info = info
   result.typ = typ
 
-proc addSon*(father, son: PNode) =
+proc add*(father, son: PNode) =
   assert son != nil
   if isNil(father.sons): father.sons = @[]
   add(father.sons, son)
 
 var emptyParams = newNode(nkFormalParams)
-emptyParams.addSon(emptyNode)
+emptyParams.add(emptyNode)
 
 proc newProcNode*(kind: TNodeKind, info: TLineInfo, body: PNode,
                  params = emptyParams,
@@ -1380,12 +1380,12 @@ proc propagateToOwner*(owner, elem: PType) =
       # ensure this doesn't bite us in sempass2.
       owner.flags.incl tfHasGCedMem
 
-proc rawAddSon*(father, son: PType) =
+proc rawAdd*(father, son: PType) =
   if isNil(father.sons): father.sons = @[]
   add(father.sons, son)
   if not son.isNil: propagateToOwner(father, son)
 
-proc addSonNilAllowed*(father, son: PNode) =
+proc addNilAllowed*(father, son: PNode) =
   if isNil(father.sons): father.sons = @[]
   add(father.sons, son)
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -971,11 +971,6 @@ proc safeLen*(n: PNode): int {.inline.} =
   if n.kind in {nkNone..nkNilLit} or isNil(n.sons): result = 0
   else: result = len(n.sons)
 
-proc add*(father, son: PNode) =
-  assert son != nil
-  if isNil(father.sons): father.sons = @[]
-  add(father.sons, son)
-
 proc `[]`*(n: PNode, i: int): PNode {.inline.} =
   result = n.sons[i]
 
@@ -1566,7 +1561,7 @@ proc makeStmtList*(n: PNode): PNode =
     result = n
   else:
     result = newNodeI(nkStmtList, n.info)
-    result.add n
+    result.addSon n
 
 proc skipStmtList*(n: PNode): PNode =
   if n.kind in {nkStmtList, nkStmtListExpr}:

--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -165,7 +165,7 @@ proc lookupInRecord(n: PNode, field: PIdent): PSym =
     for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
-        result = lookupInRecord(lastSon(n.sons[i]), field)
+        result = lookupInRecord(last(n.sons[i]), field)
         if result != nil: return
       else: internalError(n.info, "lookupInRecord(record case branch)")
   of nkSym:

--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -155,14 +155,14 @@ proc lookupInRecord(n: PNode, field: PIdent): PSym =
   result = nil
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result = lookupInRecord(n.sons[i], field)
       if result != nil: return
   of nkRecCase:
     if (n.sons[0].kind != nkSym): internalError(n.info, "lookupInRecord")
     result = lookupInRecord(n.sons[0], field)
     if result != nil: return
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
         result = lookupInRecord(lastSon(n.sons[i]), field)
@@ -178,7 +178,7 @@ proc getModule(s: PSym): PSym =
   while result != nil and result.kind != skModule: result = result.owner
 
 proc getSymFromList(list: PNode, ident: PIdent, start: int = 0): PSym =
-  for i in countup(start, sonsLen(list) - 1):
+  for i in countup(start, len(list) - 1):
     if list.sons[i].kind == nkSym:
       result = list.sons[i].sym
       if result.name.id == ident.id: return
@@ -281,9 +281,9 @@ proc typeToYamlAux(n: PType, marker: var IntSet, indent: int,
     result = "\"$1 @$2\"" % [rope($n.kind), rope(
         strutils.toHex(cast[ByteAddress](n), sizeof(n) * 2))]
   else:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       result = rope("[")
-      for i in countup(0, sonsLen(n) - 1):
+      for i in countup(0, len(n) - 1):
         if i > 0: add(result, ",")
         addf(result, "$N$1$2", [rspaces(indent + 4), typeToYamlAux(n.sons[i],
             marker, indent + 4, maxRecDepth - 1)])
@@ -330,9 +330,9 @@ proc treeToYamlAux(n: PNode, marker: var IntSet, indent: int,
         else:
           addf(result, ",$N$1\"ident\": null", [istr])
       else:
-        if sonsLen(n) > 0:
+        if len(n) > 0:
           addf(result, ",$N$1\"sons\": [", [istr])
-          for i in countup(0, sonsLen(n) - 1):
+          for i in countup(0, len(n) - 1):
             if i > 0: add(result, ",")
             addf(result, "$N$1$2", [rspaces(indent + 4), treeToYamlAux(n.sons[i],
                 marker, indent + 4, maxRecDepth - 1)])
@@ -365,9 +365,9 @@ proc debugType(n: PType, maxRecDepth=100): Rope =
     if n.kind in IntegralTypes and n.n != nil:
       add(result, ", node: ")
       add(result, debugTree(n.n, 2, maxRecDepth-1, renderType=true))
-    if (n.kind != tyString) and (sonsLen(n) > 0) and maxRecDepth != 0:
+    if (n.kind != tyString) and (len(n) > 0) and maxRecDepth != 0:
       add(result, "(")
-      for i in countup(0, sonsLen(n) - 1):
+      for i in countup(0, len(n) - 1):
         if i > 0: add(result, ", ")
         if n.sons[i] == nil:
           add(result, "null")
@@ -411,9 +411,9 @@ proc debugTree(n: PNode, indent: int, maxRecDepth: int;
         else:
           addf(result, ",$N$1\"ident\": null", [istr])
       else:
-        if sonsLen(n) > 0:
+        if len(n) > 0:
           addf(result, ",$N$1\"sons\": [", [istr])
-          for i in countup(0, sonsLen(n) - 1):
+          for i in countup(0, len(n) - 1):
             if i > 0: add(result, ",")
             addf(result, "$N$1$2", [rspaces(indent + 4), debugTree(n.sons[i],
                 indent + 4, maxRecDepth - 1, renderType)])

--- a/compiler/canonicalizer.nim
+++ b/compiler/canonicalizer.nim
@@ -120,7 +120,7 @@ proc hashType(c: var MD5Context, t: PType) =
 
   case t.kind
   of tyGenericBody, tyGenericInst, tyGenericInvocation:
-    for i in countup(0, sonsLen(t) -1 -ord(t.kind != tyGenericInvocation)):
+    for i in countup(0, len(t) -1 -ord(t.kind != tyGenericInvocation)):
       c.hashType t.sons[i]
   of tyUserTypeClass:
     internalAssert t.sym != nil and t.sym.owner != nil
@@ -128,7 +128,7 @@ proc hashType(c: var MD5Context, t: PType) =
   of tyUserTypeClassInst:
     let body = t.base
     c.hashSym body.sym
-    for i in countup(1, sonsLen(t) - 2):
+    for i in countup(1, len(t) - 2):
       c.hashType t.sons[i]
   of tyFromExpr, tyFieldAccessor:
     c.hashTree(t.n)
@@ -137,15 +137,15 @@ proc hashType(c: var MD5Context, t: PType) =
     c.hashType(t.sons[1])
   of tyTuple:
     if t.n != nil:
-      assert(sonsLen(t.n) == sonsLen(t))
-      for i in countup(0, sonsLen(t.n) - 1):
+      assert(len(t.n) == len(t))
+      for i in countup(0, len(t.n) - 1):
         assert(t.n.sons[i].kind == nkSym)
         c &= t.n.sons[i].sym.name.s
         c &= ":"
         c.hashType(t.sons[i])
         c &= ","
     else:
-      for i in countup(0, sonsLen(t) - 1): c.hashType t.sons[i]
+      for i in countup(0, len(t) - 1): c.hashType t.sons[i]
   of tyRange:
     c.hashTree(t.n)
     c.hashType(t.sons[0])
@@ -238,7 +238,7 @@ proc encodeNode(w: PRodWriter, fInfo: TLineInfo, n: PNode,
     encodeVInt(n.sym.id, result)
     pushSym(w, n.sym)
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       encodeNode(w, n.info, n.sons[i], result)
   add(result, ')')
 
@@ -304,7 +304,7 @@ proc encodeType(w: PRodWriter, t: PType, result: var string) =
     add(result, '=')
     encodeVInt(t.align, result)
   encodeLoc(w, t.loc, result)
-  for i in countup(0, sonsLen(t) - 1):
+  for i in countup(0, len(t) - 1):
     if t.sons[i] == nil:
       add(result, "^()")
     else:

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -168,7 +168,7 @@ proc genArgNoParam(p: BProc, n: PNode): Rope =
     result = rdLoc(a)
 
 template genParamLoop(params) {.dirty.} =
-  if i < sonsLen(typ):
+  if i < len(typ):
     assert(typ.n.sons[i].kind == nkSym)
     let paramType = typ.n.sons[i]
     if not paramType.typ.isCompileTimeOnly:
@@ -186,8 +186,8 @@ proc genPrefixCall(p: BProc, le, ri: PNode, d: var TLoc) =
   # getUniqueType() is too expensive here:
   var typ = skipTypes(ri.sons[0].typ, abstractInst)
   assert(typ.kind == tyProc)
-  assert(sonsLen(typ) == sonsLen(typ.n))
-  var length = sonsLen(ri)
+  assert(len(typ) == len(typ.n))
+  var length = len(ri)
   for i in countup(1, length - 1):
     genParamLoop(params)
   fixupCall(p, le, ri, d, op.r, params)
@@ -208,9 +208,9 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
 
   var typ = skipTypes(ri.sons[0].typ, abstractInst)
   assert(typ.kind == tyProc)
-  var length = sonsLen(ri)
+  var length = len(ri)
   for i in countup(1, length - 1):
-    assert(sonsLen(typ) == sonsLen(typ.n))
+    assert(len(typ) == len(typ.n))
     genParamLoop(pl)
 
   template genCallPattern {.dirty.} =
@@ -220,7 +220,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
   let callPattern = if tfIterator in typ.flags: PatIter else: PatProc
   if typ.sons[0] != nil:
     if isInvalidReturnType(typ.sons[0]):
-      if sonsLen(ri) > 1: add(pl, ~", ")
+      if len(ri) > 1: add(pl, ~", ")
       # beware of 'result = p(result)'. We may need to allocate a temporary:
       if d.k in {locTemp, locNone} or not leftAppearsOnRightSide(le, ri):
         # Great, we can use 'd':
@@ -248,7 +248,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
     genCallPattern()
 
 proc genOtherArg(p: BProc; ri: PNode; i: int; typ: PType): Rope =
-  if i < sonsLen(typ):
+  if i < len(typ):
     # 'var T' is 'T&' in C++. This means we ignore the request of
     # any nkHiddenAddr when it's a 'var T'.
     let paramType = typ.n.sons[i]
@@ -325,7 +325,7 @@ proc genThisArg(p: BProc; ri: PNode; i: int; typ: PType): Rope =
   # for better or worse c2nim translates the 'this' argument to a 'var T'.
   # However manual wrappers may also use 'ptr T'. In any case we support both
   # for convenience.
-  internalAssert i < sonsLen(typ)
+  internalAssert i < len(typ)
   assert(typ.n.sons[i].kind == nkSym)
   # if the parameter is lying (tyVar) and thus we required an additional deref,
   # skip the deref:
@@ -416,8 +416,8 @@ proc genInfixCall(p: BProc, le, ri: PNode, d: var TLoc) =
   # getUniqueType() is too expensive here:
   var typ = skipTypes(ri.sons[0].typ, abstractInst)
   assert(typ.kind == tyProc)
-  var length = sonsLen(ri)
-  assert(sonsLen(typ) == sonsLen(typ.n))
+  var length = len(ri)
+  assert(len(typ) == len(typ.n))
   # don't call '$' here for efficiency:
   let pat = ri.sons[0].sym.loc.r.data
   internalAssert pat != nil
@@ -452,7 +452,7 @@ proc genInfixCall(p: BProc, le, ri: PNode, d: var TLoc) =
     var params: Rope
     for i in countup(2, length - 1):
       if params != nil: params.add(~", ")
-      assert(sonsLen(typ) == sonsLen(typ.n))
+      assert(len(typ) == len(typ.n))
       add(params, genOtherArg(p, ri, i, typ))
     fixupCall(p, le, ri, d, pl, params)
 
@@ -464,8 +464,8 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
   # getUniqueType() is too expensive here:
   var typ = skipTypes(ri.sons[0].typ, abstractInst)
   assert(typ.kind == tyProc)
-  var length = sonsLen(ri)
-  assert(sonsLen(typ) == sonsLen(typ.n))
+  var length = len(ri)
+  assert(len(typ) == len(typ.n))
 
   # don't call '$' here for efficiency:
   let pat = ri.sons[0].sym.loc.r.data
@@ -487,8 +487,8 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
       add(pl, ~": ")
       add(pl, genArg(p, ri.sons[2], typ.n.sons[2].sym, ri))
   for i in countup(start, length-1):
-    assert(sonsLen(typ) == sonsLen(typ.n))
-    if i >= sonsLen(typ):
+    assert(len(typ) == len(typ.n))
+    if i >= len(typ):
       internalError(ri.info, "varargs for objective C method?")
     assert(typ.n.sons[i].kind == nkSym)
     var param = typ.n.sons[i].sym
@@ -498,7 +498,7 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
     add(pl, genArg(p, ri.sons[i], param, ri))
   if typ.sons[0] != nil:
     if isInvalidReturnType(typ.sons[0]):
-      if sonsLen(ri) > 1: add(pl, ~" ")
+      if len(ri) > 1: add(pl, ~" ")
       # beware of 'result = p(result)'. We always allocate a temporary:
       if d.k in {locTemp, locNone}:
         # We already got a temp. Great, special case it:

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -119,11 +119,11 @@ proc openArrayLoc(p: BProc, n: PNode): Rope =
     of tyArray, tyArrayConstr:
       result = "$1, $2" % [rdLoc(a), rope(lengthOrd(a.t))]
     of tyPtr, tyRef:
-      case lastSon(a.t).kind
+      case last(a.t).kind
       of tyString, tySequence:
         result = "(*$1)->data, (*$1)->$2" % [a.rdLoc, lenField(p)]
       of tyArray, tyArrayConstr:
-        result = "$1, $2" % [rdLoc(a), rope(lengthOrd(lastSon(a.t)))]
+        result = "$1, $2" % [rdLoc(a), rope(lengthOrd(last(a.t)))]
       else:
         internalError("openArrayLoc: " & typeToString(a.t))
     else: internalError("openArrayLoc: " & typeToString(a.t))

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -756,7 +756,7 @@ proc genInExprAux(p: BProc, e: PNode, a, b, d: var TLoc)
 proc genFieldCheck(p: BProc, e: PNode, obj: Rope, field: PSym;
                    origTy: PType) =
   var test, u, v: TLoc
-  for i in countup(1, sonsLen(e) - 1):
+  for i in countup(1, len(e) - 1):
     var it = e.sons[i]
     assert(it.kind in nkCallKinds)
     assert(it.sons[0].kind == nkSym)
@@ -961,7 +961,7 @@ proc genStrConcat(p: BProc, e: PNode, d: var TLoc) =
   var L = 0
   var appends: Rope = nil
   var lens: Rope = nil
-  for i in countup(0, sonsLen(e) - 2):
+  for i in countup(0, len(e) - 2):
     # compute the length expression:
     initLocExpr(p, e.sons[i + 1], a)
     if skipTypes(e.sons[i + 1].typ, abstractVarRange).kind == tyChar:
@@ -999,7 +999,7 @@ proc genStrAppend(p: BProc, e: PNode, d: var TLoc) =
   assert(d.k == locNone)
   var L = 0
   initLocExpr(p, e.sons[1], dest)
-  for i in countup(0, sonsLen(e) - 3):
+  for i in countup(0, len(e) - 3):
     # compute the length expression:
     initLocExpr(p, e.sons[i + 2], a)
     if skipTypes(e.sons[i + 2].typ, abstractVarRange).kind == tyChar:
@@ -1177,8 +1177,8 @@ proc genSeqConstr(p: BProc, t: PNode, d: var TLoc) =
   if d.k == locNone:
     getTemp(p, t.typ, d)
   # generate call to newSeq before adding the elements per hand:
-  genNewSeqAux(p, d, intLiteral(sonsLen(t)))
-  for i in countup(0, sonsLen(t) - 1):
+  genNewSeqAux(p, d, intLiteral(len(t)))
+  for i in countup(0, len(t) - 1):
     initLoc(arr, locExpr, elemType(skipTypes(t.typ, typedescInst)), OnHeap)
     arr.r = rfmt(nil, "$1->data[$2]", rdLoc(d), intLiteral(i))
     arr.s = OnHeap            # we know that sequences are on the heap
@@ -1408,7 +1408,7 @@ proc fewCmps(s: PNode): bool =
   elif elemType(s.typ).kind in {tyInt, tyInt16..tyInt64}:
     result = true             # better not emit the set if int is basetype!
   else:
-    result = sonsLen(s) <= 8  # 8 seems to be a good value
+    result = len(s) <= 8  # 8 seems to be a good value
 
 proc binaryExprIn(p: BProc, e: PNode, a, b, d: var TLoc, frmt: string) =
   putIntoDest(p, d, e.typ, frmt % [rdLoc(a), rdSetElemLoc(b, a.t)])
@@ -1442,7 +1442,7 @@ proc genInOp(p: BProc, e: PNode, d: var TLoc) =
     initLocExpr(p, ea, a)
     initLoc(b, locExpr, e.typ, OnUnknown)
     b.r = rope("(")
-    var length = sonsLen(e.sons[1])
+    var length = len(e.sons[1])
     for i in countup(0, length - 1):
       if e.sons[1].sons[i].kind == nkRange:
         initLocExpr(p, e.sons[1].sons[i].sons[0], x)
@@ -1762,7 +1762,7 @@ proc genSetConstr(p: BProc, e: PNode, d: var TLoc) =
       # big set:
       useStringh(p.module)
       lineF(p, cpsStmts, "memset($1, 0, sizeof($1));$n", [rdLoc(d)])
-      for i in countup(0, sonsLen(e) - 1):
+      for i in countup(0, len(e) - 1):
         if e.sons[i].kind == nkRange:
           getTemp(p, getSysType(tyInt), idx) # our counter
           initLocExpr(p, e.sons[i].sons[0], a)
@@ -1778,7 +1778,7 @@ proc genSetConstr(p: BProc, e: PNode, d: var TLoc) =
       # small set
       var ts = "NU" & $(getSize(e.typ) * 8)
       lineF(p, cpsStmts, "$1 = 0;$n", [rdLoc(d)])
-      for i in countup(0, sonsLen(e) - 1):
+      for i in countup(0, len(e) - 1):
         if e.sons[i].kind == nkRange:
           getTemp(p, getSysType(tyInt), idx) # our counter
           initLocExpr(p, e.sons[i].sons[0], a)
@@ -1799,7 +1799,7 @@ proc genTupleConstr(p: BProc, n: PNode, d: var TLoc) =
     var t = getUniqueType(n.typ)
     discard getTypeDesc(p.module, t) # so that any fields are initialized
     if d.k == locNone: getTemp(p, t, d)
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var it = n.sons[i]
       if it.kind == nkExprColonExpr: it = it.sons[1]
       initLoc(rec, locExpr, it.typ, d.s)
@@ -1845,7 +1845,7 @@ proc genArrayConstr(p: BProc, n: PNode, d: var TLoc) =
   var arr: TLoc
   if not handleConstExpr(p, n, d):
     if d.k == locNone: getTemp(p, n.typ, d)
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       initLoc(arr, locExpr, elemType(skipTypes(n.typ, abstractInst)), d.s)
       arr.r = "$1[$2]" % [rdLoc(d), intLiteral(i)]
       expr(p, n.sons[i], arr)
@@ -1856,7 +1856,7 @@ proc genComplexConst(p: BProc, sym: PSym, d: var TLoc) =
   putLocIntoDest(p, d, sym.loc)
 
 proc genStmtListExpr(p: BProc, n: PNode, d: var TLoc) =
-  var length = sonsLen(n)
+  var length = len(n)
   for i in countup(0, length - 2): genStmts(p, n.sons[i])
   if length > 0: expr(p, n.sons[length - 1], d)
 
@@ -2056,7 +2056,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkBlockExpr, nkBlockStmt: genBlock(p, n, d)
   of nkStmtListExpr: genStmtListExpr(p, n, d)
   of nkStmtList:
-    for i in countup(0, sonsLen(n) - 1): genStmts(p, n.sons[i])
+    for i in countup(0, len(n) - 1): genStmts(p, n.sons[i])
   of nkIfExpr, nkIfStmt: genIf(p, n, d)
   of nkWhen:
     # This should be a "when nimvm" node.
@@ -2137,7 +2137,7 @@ proc genNamedConstExpr(p: BProc, n: PNode): Rope =
   else: result = genConstExpr(p, n)
 
 proc genConstSimpleList(p: BProc, n: PNode): Rope =
-  var length = sonsLen(n)
+  var length = len(n)
   result = rope("{")
   for i in countup(ord(n.kind == nkObjConstr), length - 2):
     addf(result, "$1,$n", [genNamedConstExpr(p, n.sons[i])])

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -36,7 +36,7 @@ proc isAssignedImmediately(n: PNode): bool {.inline.} =
 proc genVarTuple(p: BProc, n: PNode) =
   var tup, field: TLoc
   if n.kind != nkVarTuple: internalError(n.info, "genVarTuple")
-  var L = sonsLen(n)
+  var L = len(n)
 
   # if we have a something that's been captured, use the lowering instead:
   var useLowering = false
@@ -227,7 +227,7 @@ proc genSingleVar(p: BProc, a: PNode) =
         assert(typ.kind == tyProc)
         for i in 1.. <value.len:
           if params != nil: params.add(~", ")
-          assert(sonsLen(typ) == sonsLen(typ.n))
+          assert(len(typ) == len(typ.n))
           add(params, genOtherArg(p, value, i, typ))
         lineF(p, cpsStmts, "$#($#);$n", [decl, params])
       else:
@@ -250,7 +250,7 @@ proc genClosureVar(p: BProc, a: PNode) =
     loadInto(p, a.sons[0], a.sons[2], v)
 
 proc genVarStmt(p: BProc, n: PNode) =
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     var a = n.sons[i]
     if a.kind == nkCommentStmt: continue
     if a.kind == nkIdentDefs:
@@ -263,7 +263,7 @@ proc genVarStmt(p: BProc, n: PNode) =
       genVarTuple(p, a)
 
 proc genConstStmt(p: BProc, t: PNode) =
-  for i in countup(0, sonsLen(t) - 1):
+  for i in countup(0, len(t) - 1):
     var it = t.sons[i]
     if it.kind == nkCommentStmt: continue
     if it.kind != nkConstDef: internalError(t.info, "genConstStmt")
@@ -292,7 +292,7 @@ proc genIf(p: BProc, n: PNode, d: var TLoc) =
     getTemp(p, n.typ, d)
   genLineDir(p, n)
   let lend = getLabel(p)
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     let it = n.sons[i]
     if it.len == 2:
       when newScopeForIf: startBlock(p)
@@ -310,7 +310,7 @@ proc genIf(p: BProc, n: PNode, d: var TLoc) =
       else:
         expr(p, it.sons[1], d)
       endBlock(p)
-      if sonsLen(n) > 1:
+      if len(n) > 1:
         lineF(p, cpsStmts, "goto $1;$n", [lend])
       fixLabel(p, lelse)
     elif it.len == 1:
@@ -318,7 +318,7 @@ proc genIf(p: BProc, n: PNode, d: var TLoc) =
       expr(p, it.sons[0], d)
       endBlock(p)
     else: internalError(n.info, "genIf()")
-  if sonsLen(n) > 1: fixLabel(p, lend)
+  if len(n) > 1: fixLabel(p, lend)
 
 
 proc blockLeaveActions(p: BProc, howManyTrys, howManyExcepts: int) =
@@ -459,7 +459,7 @@ proc genWhileStmt(p: BProc, t: PNode) =
   # significantly worse code
   var
     a: TLoc
-  assert(sonsLen(t) == 2)
+  assert(len(t) == 2)
   inc(p.withinLoop)
   genLineDir(p, t)
 
@@ -500,7 +500,7 @@ proc genBlock(p: BProc, t: PNode, d: var TLoc) =
     endBlock(p)
 
 proc genParForStmt(p: BProc, t: PNode) =
-  assert(sonsLen(t) == 3)
+  assert(len(t) == 3)
   inc(p.withinLoop)
   genLineDir(p, t)
 
@@ -576,7 +576,7 @@ proc genCaseGenericBranch(p: BProc, b: PNode, e: TLoc,
                           rangeFormat, eqFormat: FormatStr, labl: TLabel) =
   var
     x, y: TLoc
-  var length = sonsLen(b)
+  var length = len(b)
   for i in countup(0, length - 2):
     if b.sons[i].kind == nkRange:
       initLocExpr(p, b.sons[i].sons[0], x)
@@ -593,7 +593,7 @@ proc genCaseSecondPass(p: BProc, t: PNode, d: var TLoc,
   for i in 1..until:
     lineF(p, cpsStmts, "LA$1: ;$n", [rope(labId + i)])
     if t.sons[i].kind == nkOfBranch:
-      var length = sonsLen(t.sons[i])
+      var length = len(t.sons[i])
       exprBlock(p, t.sons[i].sons[length - 1], d)
       lineF(p, cpsStmts, "goto $1;$n", [lend])
     else:
@@ -625,13 +625,13 @@ proc genCaseGeneric(p: BProc, t: PNode, d: var TLoc,
                     rangeFormat, eqFormat: FormatStr) =
   var a: TLoc
   initLocExpr(p, t.sons[0], a)
-  var lend = genIfForCaseUntil(p, t, d, rangeFormat, eqFormat, sonsLen(t)-1, a)
+  var lend = genIfForCaseUntil(p, t, d, rangeFormat, eqFormat, len(t)-1, a)
   fixLabel(p, lend)
 
 proc genCaseStringBranch(p: BProc, b: PNode, e: TLoc, labl: TLabel,
                          branches: var openArray[Rope]) =
   var x: TLoc
-  var length = sonsLen(b)
+  var length = len(b)
   for i in countup(0, length - 2):
     assert(b.sons[i].kind != nkRange)
     initLocExpr(p, b.sons[i], x)
@@ -643,8 +643,8 @@ proc genCaseStringBranch(p: BProc, b: PNode, e: TLoc, labl: TLabel,
 proc genStringCase(p: BProc, t: PNode, d: var TLoc) =
   # count how many constant strings there are in the case:
   var strings = 0
-  for i in countup(1, sonsLen(t) - 1):
-    if t.sons[i].kind == nkOfBranch: inc(strings, sonsLen(t.sons[i]) - 1)
+  for i in countup(1, len(t) - 1):
+    if t.sons[i].kind == nkOfBranch: inc(strings, len(t.sons[i]) - 1)
   if strings > stringCaseThreshold:
     var bitMask = math.nextPowerOfTwo(strings) - 1
     var branches: seq[Rope]
@@ -652,7 +652,7 @@ proc genStringCase(p: BProc, t: PNode, d: var TLoc) =
     var a: TLoc
     initLocExpr(p, t.sons[0], a) # fist pass: gnerate ifs+goto:
     var labId = p.labels
-    for i in countup(1, sonsLen(t) - 1):
+    for i in countup(1, len(t) - 1):
       inc(p.labels)
       if t.sons[i].kind == nkOfBranch:
         genCaseStringBranch(p, t.sons[i], a, "LA" & rope(p.labels),
@@ -668,16 +668,16 @@ proc genStringCase(p: BProc, t: PNode, d: var TLoc) =
         lineF(p, cpsStmts, "case $1: $n$2break;$n",
              [intLiteral(j), branches[j]])
     lineF(p, cpsStmts, "}$n", []) # else statement:
-    if t.sons[sonsLen(t)-1].kind != nkOfBranch:
+    if t.sons[len(t)-1].kind != nkOfBranch:
       lineF(p, cpsStmts, "goto LA$1;$n", [rope(p.labels)])
     # third pass: generate statements
-    var lend = genCaseSecondPass(p, t, d, labId, sonsLen(t)-1)
+    var lend = genCaseSecondPass(p, t, d, labId, len(t)-1)
     fixLabel(p, lend)
   else:
     genCaseGeneric(p, t, d, "", "if (#eqStrings($1, $2)) goto $3;$n")
 
 proc branchHasTooBigRange(b: PNode): bool =
-  for i in countup(0, sonsLen(b)-2):
+  for i in countup(0, len(b)-2):
     # last son is block
     if (b.sons[i].kind == nkRange) and
         b.sons[i].sons[1].intVal - b.sons[i].sons[0].intVal > RangeExpandLimit:
@@ -788,7 +788,7 @@ proc genTryCpp(p: BProc, t: PNode, d: var TLoc) =
   add(p.nestedTryStmts, t)
   startBlock(p, "try {$n")
   expr(p, t.sons[0], d)
-  let length = sonsLen(t)
+  let length = len(t)
   endBlock(p, ropecg(p.module, "} catch (NimException& $1) {$n", [exc]))
   if optStackTrace in p.options:
     linefmt(p, cpsStmts, "#setFrame((TFrame*)&FR);$n")
@@ -796,7 +796,7 @@ proc genTryCpp(p: BProc, t: PNode, d: var TLoc) =
   var i = 1
   var catchAllPresent = false
   while (i < length) and (t.sons[i].kind == nkExceptBranch):
-    let blen = sonsLen(t.sons[i])
+    let blen = len(t.sons[i])
     if i > 1: addf(p.s(cpsStmts), "else ", [])
     if blen == 1:
       # general except section:
@@ -889,7 +889,7 @@ proc genTry(p: BProc, t: PNode, d: var TLoc) =
   else:
     linefmt(p, cpsStmts, "$1.status = setjmp($1.context);$n", safePoint)
   startBlock(p, "if ($1.status == 0) {$n", [safePoint])
-  var length = sonsLen(t)
+  var length = len(t)
   add(p.nestedTryStmts, t)
   expr(p, t.sons[0], d)
   linefmt(p, cpsStmts, "#popSafePoint();$n")
@@ -901,7 +901,7 @@ proc genTry(p: BProc, t: PNode, d: var TLoc) =
   inc p.inExceptBlock
   var i = 1
   while (i < length) and (t.sons[i].kind == nkExceptBranch):
-    var blen = sonsLen(t.sons[i])
+    var blen = len(t.sons[i])
     if blen == 1:
       # general except section:
       if i > 1: lineF(p, cpsStmts, "else", [])
@@ -938,7 +938,7 @@ proc genTry(p: BProc, t: PNode, d: var TLoc) =
 
 proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
   var res = ""
-  for i in countup(0, sonsLen(t) - 1):
+  for i in countup(0, len(t) - 1):
     case t.sons[i].kind
     of nkStrLit..nkTripleStrLit:
       res.add(t.sons[i].strVal)
@@ -1038,7 +1038,7 @@ proc genWatchpoint(p: BProc, n: PNode) =
         genTypeInfo(p.module, typ)])
 
 proc genPragma(p: BProc, n: PNode) =
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     var it = n.sons[i]
     case whichPragma(it)
     of wEmit: genEmit(p, it)

--- a/compiler/ccgtrav.nim
+++ b/compiler/ccgtrav.nim
@@ -39,7 +39,7 @@ proc genTraverseProc(c: var TTraversalClosure, accessor: Rope, n: PNode) =
         genCaseRange(c.p, branch)
       else:
         lineF(p, cpsStmts, "default:$n", [])
-      genTraverseProc(c, accessor, lastSon(branch))
+      genTraverseProc(c, accessor, last(branch))
       lineF(p, cpsStmts, "break;$n", [])
     lineF(p, cpsStmts, "} $n", [])
   of nkSym:
@@ -62,7 +62,7 @@ proc genTraverseProc(c: var TTraversalClosure, accessor: Rope, typ: PType) =
   var p = c.p
   case typ.kind
   of tyGenericInst, tyGenericBody, tyTypeDesc:
-    genTraverseProc(c, accessor, lastSon(typ))
+    genTraverseProc(c, accessor, last(typ))
   of tyArrayConstr, tyArray:
     let arraySize = lengthOrd(typ.sons[0])
     var i: TLoc

--- a/compiler/ccgtrav.nim
+++ b/compiler/ccgtrav.nim
@@ -25,14 +25,14 @@ proc genTraverseProc(c: var TTraversalClosure, accessor: Rope, n: PNode) =
   if n == nil: return
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       genTraverseProc(c, accessor, n.sons[i])
   of nkRecCase:
     if (n.sons[0].kind != nkSym): internalError(n.info, "genTraverseProc")
     var p = c.p
     let disc = n.sons[0].sym
     lineF(p, cpsStmts, "switch ($1.$2) {$n", [accessor, disc.loc.r])
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       let branch = n.sons[i]
       assert branch.kind in {nkOfBranch, nkElse}
       if branch.kind == nkOfBranch:
@@ -72,14 +72,14 @@ proc genTraverseProc(c: var TTraversalClosure, accessor: Rope, typ: PType) =
     genTraverseProc(c, rfmt(nil, "$1[$2]", accessor, i.r), typ.sons[1])
     lineF(p, cpsStmts, "}$n", [])
   of tyObject:
-    for i in countup(0, sonsLen(typ) - 1):
+    for i in countup(0, len(typ) - 1):
       var x = typ.sons[i]
       if x != nil: x = x.skipTypes(skipPtrs)
       genTraverseProc(c, accessor.parentObj(c.p.module), x)
     if typ.n != nil: genTraverseProc(c, accessor, typ.n)
   of tyTuple:
     let typ = getUniqueType(typ)
-    for i in countup(0, sonsLen(typ) - 1):
+    for i in countup(0, len(typ) - 1):
       genTraverseProc(c, rfmt(nil, "$1.Field$2", accessor, i.rope), typ.sons[i])
   of tyRef, tyString, tySequence:
     lineCg(p, cpsStmts, c.visitorFrmt, accessor)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -986,10 +986,10 @@ proc genArrayInfo(m: BModule, typ: PType, name: Rope) =
 proc fakeClosureType(owner: PSym): PType =
   # we generate the same RTTI as for a tuple[pointer, ref tuple[]]
   result = newType(tyTuple, owner)
-  result.rawAddSon(newType(tyPointer, owner))
+  result.rawAdd(newType(tyPointer, owner))
   var r = newType(tyRef, owner)
-  r.rawAddSon(newType(tyTuple, owner))
-  result.rawAddSon(r)
+  r.rawAdd(newType(tyTuple, owner))
+  result.rawAdd(r)
 
 type
   TTypeInfoReason = enum  ## for what do we need the type info?

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -331,7 +331,7 @@ proc genProcParams(m: BModule, t: PType, rettype, params: var Rope,
     rettype = ~"void"
   else:
     rettype = getTypeDescAux(m, t.sons[0], check)
-  for i in countup(1, sonsLen(t.n) - 1):
+  for i in countup(1, len(t.n) - 1):
     if t.n.sons[i].kind != nkSym: internalError(t.n.info, "genProcParams")
     var param = t.n.sons[i].sym
     if isCompileTimeOnly(param.typ): continue
@@ -397,7 +397,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
   result = nil
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       add(result, genRecordFieldsAux(m, n.sons[i], accessExpr, rectype, check))
   of nkRecCase:
     if n.sons[0].kind != nkSym: internalError(n.info, "genRecordFieldsAux")
@@ -406,7 +406,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
     if accessExpr != nil: ae = "$1.$2" % [accessExpr, uname]
     else: ae = uname
     var unionBody: Rope = nil
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
         k = lastSon(n.sons[i])
@@ -495,7 +495,7 @@ proc getTupleDesc(m: BModule, typ: PType, name: Rope,
                   check: var IntSet): Rope =
   result = "$1 $2 {$n" % [structOrUnion(typ), name]
   var desc: Rope = nil
-  for i in countup(0, sonsLen(typ) - 1):
+  for i in countup(0, len(typ) - 1):
     addf(desc, "$1 Field$2;$n",
          [getTypeDescAux(m, typ.sons[i], check), rope(i)])
   if desc == nil: add(result, "char dummy;" & tnl)
@@ -811,7 +811,7 @@ proc genTypeInfoAuxBase(m: BModule; typ, origType: PType; name, base: Rope) =
 
 proc genTypeInfoAux(m: BModule, typ, origType: PType, name: Rope) =
   var base: Rope
-  if (sonsLen(typ) > 0) and (typ.sons[0] != nil):
+  if (len(typ) > 0) and (typ.sons[0] != nil):
     var x = typ.sons[0]
     if typ.kind == tyObject: x = x.skipTypes(skipPtrs)
     base = genTypeInfo(m, x)
@@ -836,7 +836,7 @@ proc discriminatorTableDecl(m: BModule, objtype: PType, d: PSym): Rope =
 proc genObjectFields(m: BModule, typ: PType, n: PNode, expr: Rope) =
   case n.kind
   of nkRecList:
-    var L = sonsLen(n)
+    var L = len(n)
     if L == 1:
       genObjectFields(m, typ, n.sons[0], expr)
     elif L > 0:
@@ -864,15 +864,15 @@ proc genObjectFields(m: BModule, typ: PType, n: PNode, expr: Rope) =
                            makeCString(field.name.s),
                            tmp, rope(L)])
     addf(m.s[cfsData], "TNimNode* $1[$2];$n", [tmp, rope(L+1)])
-    for i in countup(1, sonsLen(n)-1):
+    for i in countup(1, len(n)-1):
       var b = n.sons[i]           # branch
       var tmp2 = getNimNode(m)
       genObjectFields(m, typ, lastSon(b), tmp2)
       case b.kind
       of nkOfBranch:
-        if sonsLen(b) < 2:
+        if len(b) < 2:
           internalError(b.info, "genObjectFields; nkOfBranch broken")
-        for j in countup(0, sonsLen(b) - 2):
+        for j in countup(0, len(b) - 2):
           if b.sons[j].kind == nkRange:
             var x = int(getOrdValue(b.sons[j].sons[0]))
             var y = int(getOrdValue(b.sons[j].sons[1]))
@@ -910,7 +910,7 @@ proc genObjectInfo(m: BModule, typ, origType: PType, name: Rope) =
 proc genTupleInfo(m: BModule, typ: PType, name: Rope) =
   genTypeInfoAuxBase(m, typ, typ, name, rope("0"))
   var expr = getNimNode(m)
-  var length = sonsLen(typ)
+  var length = len(typ)
   if length > 0:
     var tmp = getTempName(m)
     addf(m.s[cfsTypeInit1], "static TNimNode* $1[$2];$n", [tmp, rope(length)])
@@ -937,7 +937,7 @@ proc genEnumInfo(m: BModule, typ: PType, name: Rope) =
   # positions will be reset after the loop.
   genTypeInfoAux(m, typ, typ, name)
   var nodePtrs = getTempName(m)
-  var length = sonsLen(typ.n)
+  var length = len(typ.n)
   addf(m.s[cfsTypeInit1], "static TNimNode* $1[$2];$n",
        [nodePtrs, rope(length)])
   var enumNames, specialCases: Rope

--- a/compiler/ccgutils.nim
+++ b/compiler/ccgutils.nim
@@ -105,15 +105,15 @@ proc getUniqueType*(key: PType): PType =
       internalError("metatype not eliminated")
   of tyDistinct:
     if key.deepCopy != nil: result = key
-    else: result = getUniqueType(lastSon(key))
+    else: result = getUniqueType(last(key))
   of tyGenericInst, tyOrdinal, tyMutable, tyConst, tyIter, tyStatic:
-    result = getUniqueType(lastSon(key))
-    #let obj = lastSon(key)
+    result = getUniqueType(last(key))
+    #let obj = last(key)
     #if obj.sym != nil and obj.sym.name.s == "TOption":
     #  echo "for ", typeToString(key), " I returned "
     #  debug result
   of tyPtr, tyRef, tyVar:
-    let elemType = lastSon(key)
+    let elemType = last(key)
     if elemType.kind in {tyBool, tyChar, tyInt..tyUInt64}:
       # no canonicalization for integral types, so that e.g. ``ptr pid_t`` is
       # produced instead of ``ptr NI``.

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -529,7 +529,7 @@ proc symInDynamicLib(m: BModule, sym: PSym) =
       params.add(", ")
     let load = "\t$1 = ($2) ($3$4));$n" %
         [tmp, getTypeDesc(m, sym.typ), params, makeCString($extname)]
-    var last = lastSon(n)
+    var last = last(n)
     if last.kind == nkHiddenStdConv: last = last.sons[1]
     internalAssert(last.kind == nkStrLit)
     let idx = last.strVal
@@ -606,7 +606,7 @@ proc deinitFrame(p: BProc): Rope =
 proc closureSetup(p: BProc, prc: PSym) =
   if tfCapturesEnv notin prc.typ.flags: return
   # prc.ast[paramsPos].last contains the type we're after:
-  var ls = lastSon(prc.ast[paramsPos])
+  var ls = last(prc.ast[paramsPos])
   if ls.kind != nkSym:
     internalError(prc.info, "closure generation failed")
   var env = ls.sym

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -639,7 +639,7 @@ proc genProcAux(m: BModule, prc: PSym) =
         #incl(res.loc.flags, lfIndirect)
         res.loc.s = OnUnknown
 
-  for i in countup(1, sonsLen(prc.typ.n) - 1):
+  for i in countup(1, len(prc.typ.n) - 1):
     var param = prc.typ.n.sons[i].sym
     if param.typ.isCompileTimeOnly: continue
     assignParam(p, param)
@@ -1280,7 +1280,7 @@ proc myClose(b: PPassContext, n: PNode): PNode =
   if sfMainModule in m.module.flags:
     incl m.flags, objHasKidsValid
     var disp = generateMethodDispatchers()
-    for i in 0..sonsLen(disp)-1: genProcAux(m, disp.sons[i].sym)
+    for i in 0..len(disp)-1: genProcAux(m, disp.sons[i].sym)
     genMainProc(m)
 
 proc cgenWriteModules* =

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -38,7 +38,7 @@ proc genConv(n: PNode, d: PType, downcast: bool): PNode =
 proc methodCall*(n: PNode): PNode =
   result = n
   # replace ordinary method by dispatcher method:
-  var disp = lastSon(result.sons[0].sym.ast).sym
+  var disp = last(result.sons[0].sym.ast).sym
   assert sfDispatcher in disp.flags
   result.sons[0].sym = disp
   # change the arguments to up/downcasts to fit the dispatcher's parameters:
@@ -64,8 +64,8 @@ proc sameMethodBucket(a, b: PSym): MethodResult =
       aa = skipTypes(aa, {tyGenericInst})
       bb = skipTypes(bb, {tyGenericInst})
       if aa.kind == bb.kind and aa.kind in {tyVar, tyPtr, tyRef}:
-        aa = aa.lastSon
-        bb = bb.lastSon
+        aa = aa.last
+        bb = bb.last
       else:
         break
     if sameType(aa, bb):
@@ -152,7 +152,7 @@ proc methodDef*(s: PSym, fromCache: bool) =
     case sameMethodBucket(disp, s)
     of Yes:
       add(gMethods[i].methods, s)
-      attachDispatcher(s, lastSon(disp.ast))
+      attachDispatcher(s, last(disp.ast))
       fixupDispatcher(s, disp)
       #echo "fixup ", disp.name.s, " ", disp.id
       when useEffectSystem: checkMethodEffects(disp, s)
@@ -211,7 +211,7 @@ proc sortBucket(a: var TSymSeq, relevantCols: IntSet) =
     if h == 1: break
 
 proc genDispatcher(methods: TSymSeq, relevantCols: IntSet): PSym =
-  var base = lastSon(methods[0].ast).sym
+  var base = last(methods[0].ast).sym
   result = base
   var paramLen = len(base.typ)
   var disp = newNodeI(nkIfStmt, base.info)

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -92,7 +92,7 @@ proc attachDispatcher(s: PSym, dispatcher: PNode) =
     # we've added a dispatcher already, so overwrite it
     s.ast.sons[L] = dispatcher
   else:
-    s.ast.add(dispatcher)
+    s.ast.addSon(dispatcher)
 
 proc createDispatcher(s: PSym): PSym =
   var disp = copySym(s)

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -42,7 +42,7 @@ proc methodCall*(n: PNode): PNode =
   assert sfDispatcher in disp.flags
   result.sons[0].sym = disp
   # change the arguments to up/downcasts to fit the dispatcher's parameters:
-  for i in countup(1, sonsLen(result)-1):
+  for i in countup(1, len(result)-1):
     result.sons[i] = genConv(result.sons[i], disp.typ.sons[i], true)
 
 # save for incremental compilation:
@@ -54,10 +54,10 @@ type
 
 proc sameMethodBucket(a, b: PSym): MethodResult =
   if a.name.id != b.name.id: return
-  if sonsLen(a.typ) != sonsLen(b.typ):
+  if len(a.typ) != len(b.typ):
     return                    # check for return type:
   if not sameTypeOrNil(a.typ.sons[0], b.typ.sons[0]): return
-  for i in countup(1, sonsLen(a.typ) - 1):
+  for i in countup(1, len(a.typ) - 1):
     var aa = a.typ.sons[i]
     var bb = b.typ.sons[i]
     while true:
@@ -105,7 +105,7 @@ proc createDispatcher(s: PSym): PSym =
   disp.ast.sons[bodyPos] = ast.emptyNode
   disp.loc.r = nil
   if s.typ.sons[0] != nil:
-    if disp.ast.sonsLen > resultPos:
+    if disp.ast.len > resultPos:
       disp.ast.sons[resultPos].sym = copySym(s.ast.sons[resultPos].sym)
     else:
       # We've encountered a method prototype without a filled-in
@@ -123,7 +123,7 @@ proc fixupDispatcher(meth, disp: PSym) =
   # from later definitions, particularly the resultPos slot. Also,
   # the lock level of the dispatcher needs to be updated/checked
   # against that of the method.
-  if disp.ast.sonsLen > resultPos and meth.ast.sonsLen > resultPos and
+  if disp.ast.len > resultPos and meth.ast.len > resultPos and
      disp.ast.sons[resultPos] == ast.emptyNode:
     disp.ast.sons[resultPos] = copyTree(meth.ast.sons[resultPos])
 
@@ -183,7 +183,7 @@ proc relevantCol(methods: TSymSeq, col: int): bool =
         return true
 
 proc cmpSignatures(a, b: PSym, relevantCols: IntSet): int =
-  for col in countup(1, sonsLen(a.typ) - 1):
+  for col in countup(1, len(a.typ) - 1):
     if contains(relevantCols, col):
       var aa = skipTypes(a.typ.sons[col], skipPtrs)
       var bb = skipTypes(b.typ.sons[col], skipPtrs)
@@ -213,7 +213,7 @@ proc sortBucket(a: var TSymSeq, relevantCols: IntSet) =
 proc genDispatcher(methods: TSymSeq, relevantCols: IntSet): PSym =
   var base = lastSon(methods[0].ast).sym
   result = base
-  var paramLen = sonsLen(base.typ)
+  var paramLen = len(base.typ)
   var disp = newNodeI(nkIfStmt, base.info)
   var ands = getSysSym("and")
   var iss = getSysSym("of")
@@ -261,7 +261,7 @@ proc generateMethodDispatchers*(): PNode =
   result = newNode(nkStmtList)
   for bucket in countup(0, len(gMethods) - 1):
     var relevantCols = initIntSet()
-    for col in countup(1, sonsLen(gMethods[bucket].methods[0].typ) - 1):
+    for col in countup(1, len(gMethods[bucket].methods[0].typ) - 1):
       if relevantCol(gMethods[bucket].methods, col): incl(relevantCols, col)
     sortBucket(gMethods[bucket].methods, relevantCols)
     add(result,

--- a/compiler/depends.nim
+++ b/compiler/depends.nim
@@ -30,14 +30,14 @@ proc addDotDependency(c: PPassContext, n: PNode): PNode =
   var g = PGen(c)
   case n.kind
   of nkImportStmt:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var imported = getModuleName(n.sons[i])
       addDependencyAux(g.module.name.s, imported)
   of nkFromStmt, nkImportExceptStmt:
     var imported = getModuleName(n.sons[0])
     addDependencyAux(g.module.name.s, imported)
   of nkStmtList, nkBlockStmt, nkStmtListExpr, nkBlockExpr:
-    for i in countup(0, sonsLen(n) - 1): discard addDotDependency(c, n.sons[i])
+    for i in countup(0, len(n) - 1): discard addDotDependency(c, n.sons[i])
   else:
     discard
 

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -535,19 +535,19 @@ proc generateDoc*(d: PDoc, n: PNode) =
     when useEffectSystem: documentRaises(n)
     genItem(d, n, n.sons[namePos], skConverter)
   of nkTypeSection, nkVarSection, nkLetSection, nkConstSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       if n.sons[i].kind != nkCommentStmt:
         # order is always 'type var let const':
         genItem(d, n.sons[i], n.sons[i].sons[0],
                 succ(skType, ord(n.kind)-ord(nkTypeSection)))
   of nkStmtList:
-    for i in countup(0, sonsLen(n) - 1): generateDoc(d, n.sons[i])
+    for i in countup(0, len(n) - 1): generateDoc(d, n.sons[i])
   of nkWhenStmt:
     # generate documentation for the first branch only:
     if not checkForFalse(n.sons[0].sons[0]):
       generateDoc(d, lastSon(n.sons[0]))
   of nkImportStmt:
-    for i in 0 .. sonsLen(n)-1: traceDeps(d, n.sons[i])
+    for i in 0 .. len(n)-1: traceDeps(d, n.sons[i])
   of nkFromStmt, nkImportExceptStmt: traceDeps(d, n.sons[0])
   else: discard
 
@@ -578,13 +578,13 @@ proc generateJson*(d: PDoc, n: PNode) =
     when useEffectSystem: documentRaises(n)
     d.add genJsonItem(d, n, n.sons[namePos], skConverter)
   of nkTypeSection, nkVarSection, nkLetSection, nkConstSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       if n.sons[i].kind != nkCommentStmt:
         # order is always 'type var let const':
         d.add genJsonItem(d, n.sons[i], n.sons[i].sons[0],
                 succ(skType, ord(n.kind)-ord(nkTypeSection)))
   of nkStmtList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       generateJson(d, n.sons[i])
   of nkWhenStmt:
     # generate documentation for the first branch only:

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -545,7 +545,7 @@ proc generateDoc*(d: PDoc, n: PNode) =
   of nkWhenStmt:
     # generate documentation for the first branch only:
     if not checkForFalse(n.sons[0].sons[0]):
-      generateDoc(d, lastSon(n.sons[0]))
+      generateDoc(d, last(n.sons[0]))
   of nkImportStmt:
     for i in 0 .. len(n)-1: traceDeps(d, n.sons[i])
   of nkFromStmt, nkImportExceptStmt: traceDeps(d, n.sons[0])
@@ -589,7 +589,7 @@ proc generateJson*(d: PDoc, n: PNode) =
   of nkWhenStmt:
     # generate documentation for the first branch only:
     if not checkForFalse(n.sons[0].sons[0]):
-      generateJson(d, lastSon(n.sons[0]))
+      generateJson(d, last(n.sons[0]))
   else: discard
 
 proc genSection(d: PDoc, kind: TSymKind) =

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -134,13 +134,13 @@ proc pack(v: PNode, typ: PType, res: pointer)
 proc getField(n: PNode; position: int): PSym =
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result = getField(n.sons[i], position)
       if result != nil: return 
   of nkRecCase:
     result = getField(n.sons[0], position)
     if result != nil: return
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
         result = getField(lastSon(n.sons[i]), position)
@@ -154,7 +154,7 @@ proc packObject(x: PNode, typ: PType, res: pointer) =
   internalAssert x.kind in {nkObjConstr, nkPar}
   # compute the field's offsets:
   discard typ.getSize
-  for i in countup(ord(x.kind == nkObjConstr), sonsLen(x) - 1):
+  for i in countup(ord(x.kind == nkObjConstr), len(x) - 1):
     var it = x.sons[i]
     if it.kind == nkExprColonExpr:
       internalAssert it.sons[0].kind == nkSym
@@ -241,7 +241,7 @@ proc unpack(x: pointer, typ: PType, n: PNode): PNode
 proc unpackObjectAdd(x: pointer, n, result: PNode) =
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       unpackObjectAdd(x, n.sons[i], result)
   of nkRecCase:
     globalError(result.info, "case objects cannot be unpacked")
@@ -271,7 +271,7 @@ proc unpackObject(x: pointer, typ: PType, n: PNode): PNode =
       globalError(n.info, "cannot map value from FFI")
     if typ.n.isNil:
       globalError(n.info, "cannot unpack unnamed tuple")
-    for i in countup(ord(n.kind == nkObjConstr), sonsLen(n) - 1):
+    for i in countup(ord(n.kind == nkObjConstr), len(n) - 1):
       var it = n.sons[i]
       if it.kind == nkExprColonExpr:
         internalAssert it.sons[0].kind == nkSym

--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -55,7 +55,7 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
     result.add(copyNode(c, templ, actual))
   else:
     var res = copyNode(c, templ, actual)
-    for i in countup(0, sonsLen(templ) - 1):
+    for i in countup(0, len(templ) - 1):
       evalTemplateAux(templ.sons[i], actual, c, res)
     result.add(res)
 

--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -28,9 +28,9 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
   template handleParam(param) =
     let x = param
     if x.kind == nkArgList:
-      for y in items(x): result.addSon(y)
+      for y in items(x): result.add(y)
     else:
-      result.addSon(copyTree(x))
+      result.add(copyTree(x))
 
   case templ.kind
   of nkSym:
@@ -48,16 +48,16 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
           x = copySym(s, false)
           x.owner = c.genSymOwner
           idTablePut(c.mapping, s, x)
-        result.addSon(newSymNode(x, if c.instLines: actual.info else: templ.info))
+        result.add(newSymNode(x, if c.instLines: actual.info else: templ.info))
     else:
-      result.addSon(copyNode(c, templ, actual))
+      result.add(copyNode(c, templ, actual))
   of nkNone..nkIdent, nkType..nkNilLit: # atom
-    result.addSon(copyNode(c, templ, actual))
+    result.add(copyNode(c, templ, actual))
   else:
     var res = copyNode(c, templ, actual)
     for i in countup(0, sonsLen(templ) - 1):
       evalTemplateAux(templ.sons[i], actual, c, res)
-    result.addSon(res)
+    result.add(res)
 
 proc evalTemplateArgs(n: PNode, s: PSym; fromHlo: bool): PNode =
   # if the template has zero arguments, it can be called without ``()``
@@ -85,7 +85,7 @@ proc evalTemplateArgs(n: PNode, s: PSym; fromHlo: bool): PNode =
 
   result = newNodeI(nkArgList, n.info)
   for i in 1 .. givenRegularParams:
-    result.addSon n.sons[i]
+    result.add n.sons[i]
 
   # handle parameters with default values, which were
   # not supplied by the user
@@ -93,13 +93,13 @@ proc evalTemplateArgs(n: PNode, s: PSym; fromHlo: bool): PNode =
     let default = s.typ.n.sons[i].sym.ast
     if default.isNil or default.kind == nkEmpty:
       localError(n.info, errWrongNumberOfArguments)
-      addSon(result, ast.emptyNode)
+      add(result, ast.emptyNode)
     else:
-      addSon(result, default.copyTree)
+      add(result, default.copyTree)
 
   # add any generic paramaters
   for i in 1 .. genericParams:
-    result.addSon n.sons[givenRegularParams + i]
+    result.add n.sons[givenRegularParams + i]
 
 var evalTemplateCounter* = 0
   # to prevent endless recursion in templates instantiation

--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -28,9 +28,9 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
   template handleParam(param) =
     let x = param
     if x.kind == nkArgList:
-      for y in items(x): result.add(y)
+      for y in items(x): result.addSon(y)
     else:
-      result.add copyTree(x)
+      result.addSon(copyTree(x))
 
   case templ.kind
   of nkSym:
@@ -48,16 +48,16 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
           x = copySym(s, false)
           x.owner = c.genSymOwner
           idTablePut(c.mapping, s, x)
-        result.add newSymNode(x, if c.instLines: actual.info else: templ.info)
+        result.addSon(newSymNode(x, if c.instLines: actual.info else: templ.info))
     else:
-      result.add copyNode(c, templ, actual)
+      result.addSon(copyNode(c, templ, actual))
   of nkNone..nkIdent, nkType..nkNilLit: # atom
-    result.add copyNode(c, templ, actual)
+    result.addSon(copyNode(c, templ, actual))
   else:
     var res = copyNode(c, templ, actual)
     for i in countup(0, sonsLen(templ) - 1):
       evalTemplateAux(templ.sons[i], actual, c, res)
-    result.add res
+    result.addSon(res)
 
 proc evalTemplateArgs(n: PNode, s: PSym; fromHlo: bool): PNode =
   # if the template has zero arguments, it can be called without ``()``

--- a/compiler/filters.nim
+++ b/compiler/filters.nim
@@ -27,7 +27,7 @@ proc invalidPragma(n: PNode) =
 proc getArg(n: PNode, name: string, pos: int): PNode =
   result = nil
   if n.kind in {nkEmpty..nkNilLit}: return
-  for i in countup(1, sonsLen(n) - 1):
+  for i in countup(1, len(n) - 1):
     if n.sons[i].kind == nkExprEqExpr:
       if n.sons[i].sons[0].kind != nkIdent: invalidPragma(n)
       if identEq(n.sons[i].sons[0].ident, name):

--- a/compiler/forloops.nim
+++ b/compiler/forloops.nim
@@ -43,7 +43,7 @@ proc counterInTree(n, loop: PNode; counter: PSym): bool =
   of nkVarSection, nkLetSection:
     # definitions are fine!
     for it in n:
-      if counterInTree(it.lastSon): return true
+      if counterInTree(it.last): return true
   else:
     for i in 0 .. <safeLen(n):
       if counterInTree(n[i], loop, counter): return true
@@ -70,7 +70,7 @@ proc extractForLoop*(loop, fullTree: PNode): ForLoop =
 
   var lastStmt = loop[1]
   while lastStmt.kind in {nkStmtList, nkStmtListExpr}:
-    lastStmt = lastStmt.lastSon
+    lastStmt = lastStmt.last
 
   let counter = getCounter(lastStmt)
   if counter.isNil or counter.ast.isNil: return

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -122,7 +122,7 @@ proc neg(n: PNode): PNode =
       var s = newNodeIT(nkCurly, n.info, n.sons[1].typ)
       for e in t.n:
         let eAsNode = newIntNode(nkIntLit, e.sym.position)
-        if not inSet(n.sons[1], eAsNode): s.addSon(eAsNode)
+        if not inSet(n.sons[1], eAsNode): s.add(eAsNode)
       result.sons[1] = s
     elif t.kind notin {tyString, tySequence} and lengthOrd(t) < 1000:
       result.sons[1] = complement(n.sons[1])
@@ -951,7 +951,7 @@ proc addFactLe*(m: var TModel; a, b: PNode) =
 
 proc settype(n: PNode): PType =
   result = newType(tySet, n.typ.owner)
-  addSonSkipIntLit(result, n.typ)
+  addSkipIntLit(result, n.typ)
 
 proc buildOf(it, loc: PNode): PNode =
   var s = newNodeI(nkCurly, it.info, it.len-1)
@@ -968,7 +968,7 @@ proc buildElse(n: PNode): PNode =
     let branch = n.sons[i]
     assert branch.kind == nkOfBranch
     for j in 0..branch.len-2:
-      s.addSon(branch.sons[j])
+      s.add(branch.sons[j])
   result = newNodeI(nkCall, n.info, 3)
   result.sons[0] = newSymNode(opContains)
   result.sons[1] = s

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -122,7 +122,7 @@ proc neg(n: PNode): PNode =
       var s = newNodeIT(nkCurly, n.info, n.sons[1].typ)
       for e in t.n:
         let eAsNode = newIntNode(nkIntLit, e.sym.position)
-        if not inSet(n.sons[1], eAsNode): s.add eAsNode
+        if not inSet(n.sons[1], eAsNode): s.addSon(eAsNode)
       result.sons[1] = s
     elif t.kind notin {tyString, tySequence} and lengthOrd(t) < 1000:
       result.sons[1] = complement(n.sons[1])
@@ -968,7 +968,7 @@ proc buildElse(n: PNode): PNode =
     let branch = n.sons[i]
     assert branch.kind == nkOfBranch
     for j in 0..branch.len-2:
-      s.add(branch.sons[j])
+      s.addSon(branch.sons[j])
   result = newNodeI(nkCall, n.info, 3)
   result.sons[0] = newSymNode(opContains)
   result.sons[1] = s

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -391,7 +391,7 @@ proc usefulFact(n: PNode): PNode =
     if n.sym.ast != nil:
       result = usefulFact(n.sym.ast)
   elif n.kind == nkStmtListExpr:
-    result = usefulFact(n.lastSon)
+    result = usefulFact(n.last)
 
 type
   TModel* = seq[PNode] # the "knowledge base"

--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -433,8 +433,8 @@ proc sameTree*(a, b: PNode): bool =
     of nkType: result = a.typ == b.typ
     of nkEmpty, nkNilLit: result = true
     else:
-      if sonsLen(a) == sonsLen(b):
-        for i in countup(0, sonsLen(a) - 1):
+      if len(a) == len(b):
+        for i in countup(0, len(a) - 1):
           if not sameTree(a.sons[i], b.sons[i]): return
         result = true
 

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -185,7 +185,7 @@ proc evalImport(c: PContext, n: PNode): PNode =
 
 proc evalFrom(c: PContext, n: PNode): PNode =
   result = n
-  checkMinSonsLen(n, 2)
+  checkMinLen(n, 2)
   var m = myImportModule(c, n.sons[0])
   if m != nil:
     n.sons[0] = newSymNode(m)
@@ -196,7 +196,7 @@ proc evalFrom(c: PContext, n: PNode): PNode =
 
 proc evalImportExcept*(c: PContext, n: PNode): PNode =
   result = n
-  checkMinSonsLen(n, 2)
+  checkMinLen(n, 2)
   var m = myImportModule(c, n.sons[0])
   if m != nil:
     n.sons[0] = newSymNode(m)

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -75,7 +75,7 @@ proc rawImportSymbol(c: PContext, s: PSym) =
   if s.kind == skType:
     var etyp = s.typ
     if etyp.kind in {tyBool, tyEnum} and sfPure notin s.flags:
-      for j in countup(0, sonsLen(etyp.n) - 1):
+      for j in countup(0, len(etyp.n) - 1):
         var e = etyp.n.sons[j].sym
         if e.kind != skEnumField:
           internalError(s.info, "rawImportSymbol")
@@ -175,7 +175,7 @@ proc myImportModule(c: PContext, n: PNode): PSym =
 proc evalImport(c: PContext, n: PNode): PNode =
   result = n
   var emptySet: IntSet
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     var m = myImportModule(c, n.sons[i])
     if m != nil:
       # ``addDecl`` needs to be done before ``importAllSymbols``!
@@ -190,7 +190,7 @@ proc evalFrom(c: PContext, n: PNode): PNode =
   if m != nil:
     n.sons[0] = newSymNode(m)
     addDecl(c, m, n.info)               # add symbol to symbol table of module
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       if n.sons[i].kind != nkNilLit:
         importSymbol(c, n.sons[i], m)
 
@@ -202,7 +202,7 @@ proc evalImportExcept*(c: PContext, n: PNode): PNode =
     n.sons[0] = newSymNode(m)
     addDecl(c, m, n.info)               # add symbol to symbol table of module
     var exceptSet = initIntSet()
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       let ident = lookups.considerQuotedIdent(n.sons[i])
       exceptSet.incl(ident.id)
     importAllSymbolsExcept(c, m, exceptSet)

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -19,7 +19,7 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
   result = nil
   case n.kind
   of nkRecList:
-    length = sonsLen(n)
+    length = len(n)
     if length == 1:
       result = genObjectFields(p, typ, n.sons[0])
     else:
@@ -37,7 +37,7 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
                    [mangleName(field, p.target), s,
                     makeJSString(field.name.s)]
   of nkRecCase:
-    length = sonsLen(n)
+    length = len(n)
     if (n.sons[0].kind != nkSym): internalError(n.info, "genObjectFields")
     field = n.sons[0].sym
     s = genTypeInfo(p, field.typ)
@@ -46,9 +46,9 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
       u = nil
       case b.kind
       of nkOfBranch:
-        if sonsLen(b) < 2:
+        if len(b) < 2:
           internalError(b.info, "genObjectFields; nkOfBranch broken")
-        for j in countup(0, sonsLen(b) - 2):
+        for j in countup(0, len(b) - 2):
           if u != nil: add(u, ", ")
           if b.sons[j].kind == nkRange:
             addf(u, "[$1, $2]", [rope(getOrdValue(b.sons[j].sons[0])),
@@ -97,7 +97,7 @@ proc genTupleInfo(p: PProc, typ: PType, name: Rope) =
   addf(p.g.typeInfo, "$1.node = NNI$2;$n", [name, rope(typ.id)])
 
 proc genEnumInfo(p: PProc, typ: PType, name: Rope) =
-  let length = sonsLen(typ.n)
+  let length = len(typ.n)
   var s: Rope = nil
   for i in countup(0, length - 1):
     if (typ.n.sons[i].kind != nkSym): internalError(typ.n.info, "genEnumInfo")
@@ -123,7 +123,7 @@ proc genEnumInfoPHP(p: PProc; t: PType): Rope =
   p.declareGlobal(t.id, result)
   if containsOrIncl(p.g.typeInfoGenerated, t.id): return
 
-  let length = sonsLen(t.n)
+  let length = len(t.n)
   var s: Rope = nil
   for i in countup(0, length - 1):
     if (t.n.sons[i].kind != nkSym): internalError(t.n.info, "genEnumInfo")

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -60,7 +60,7 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
       else: internalError(n.info, "genObjectFields(nkRecCase)")
       if result != nil: add(result, ", " & tnl)
       addf(result, "[SetConstr($1), $2]",
-           [u, genObjectFields(p, typ, lastSon(b))])
+           [u, genObjectFields(p, typ, last(b))])
     result = ("{kind: 3, offset: \"$1\", len: $3, " &
         "typ: $2, name: $4, sons: [$5]}") % [
         mangleName(field, p.target), s,
@@ -154,7 +154,7 @@ proc genTypeInfo(p: PProc, typ: PType): Rope =
               [result, rope(ord(t.kind))]
     prepend(p.g.typeInfo, s)
     addf(p.g.typeInfo, "$1.base = $2;$n",
-         [result, genTypeInfo(p, t.lastSon)])
+         [result, genTypeInfo(p, t.last)])
   of tyArrayConstr, tyArray:
     var s =
       "var $1 = {size: 0,kind: $2,base: null,node: null,finalizer: null};$n" %
@@ -166,6 +166,6 @@ proc genTypeInfo(p: PProc, typ: PType): Rope =
   of tyObject: genObjectInfo(p, t, result)
   of tyTuple: genTupleInfo(p, t, result)
   of tyStatic:
-    if t.n != nil: result = genTypeInfo(p, lastSon t)
+    if t.n != nil: result = genTypeInfo(p, last t)
     else: internalError("genTypeInfo(" & $t.kind & ')')
   else: internalError("genTypeInfo(" & $t.kind & ')')

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -392,7 +392,7 @@ proc nextOverloadIter*(o: var TOverloadIter, c: PContext, n: PNode): PSym =
   of oimOtherModule:
     result = nextIdentIter(o.it, o.m.tab).skipAlias(n)
   of oimSymChoice:
-    if o.symChoiceIndex < sonsLen(n):
+    if o.symChoiceIndex < len(n):
       result = n.sons[o.symChoiceIndex].sym
       incl(o.inSymChoice, result.id)
       inc o.symChoiceIndex

--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -46,7 +46,7 @@ proc newFastAsgnStmt(le, ri: PNode): PNode =
 
 proc lowerTupleUnpacking*(n: PNode; owner: PSym): PNode =
   assert n.kind == nkVarTuple
-  let value = n.lastSon
+  let value = n.last
   result = newNodeI(nkStmtList, n.info, n.len)
 
   var temp = newSym(skTemp, getIdent(genPrefix), owner, value.info)
@@ -71,7 +71,7 @@ proc newTupleAccessRaw*(tup: PNode, i: int): PNode =
   result.sons[1] = lit
 
 proc lowerTupleUnpackingForAsgn*(n: PNode; owner: PSym): PNode =
-  let value = n.lastSon
+  let value = n.last
   let lhs = n.sons[0]
   result = newNodeI(nkStmtList, n.info, lhs.len + 1)
 

--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -117,7 +117,7 @@ proc createObj*(owner: PSym, info: TLineInfo): PType =
 
 proc rawAddField*(obj: PType; field: PSym) =
   assert field.kind == skField
-  field.position = sonsLen(obj.n)
+  field.position = len(obj.n)
   add(obj.n, newSymNode(field))
 
 proc rawIndirectAccess*(a: PNode; field: PSym; info: TLineInfo): PNode =
@@ -138,7 +138,7 @@ proc addField*(obj: PType; s: PSym) =
   let t = skipIntLit(s.typ)
   field.typ = t
   assert t.kind != tyStmt
-  field.position = sonsLen(obj.n)
+  field.position = len(obj.n)
   add(obj.n, newSymNode(field))
 
 proc addUniqueField*(obj: PType; s: PSym) =
@@ -148,7 +148,7 @@ proc addUniqueField*(obj: PType; s: PSym) =
     let t = skipIntLit(s.typ)
     field.typ = t
     assert t.kind != tyStmt
-    field.position = sonsLen(obj.n)
+    field.position = len(obj.n)
     add(obj.n, newSymNode(field))
 
 proc newDotExpr(obj, b: PSym): PNode =

--- a/compiler/magicsys.nim
+++ b/compiler/magicsys.nim
@@ -126,7 +126,7 @@ proc skipIntLit*(t: PType): PType {.inline.} =
       return getSysType(t.kind)
   result = t
 
-proc addSonSkipIntLit*(father, son: PType) =
+proc addSkipIntLit*(father, son: PType) =
   if isNil(father.sons): father.sons = @[]
   let s = son.skipIntLit
   add(father.sons, s)

--- a/compiler/nimsets.nim
+++ b/compiler/nimsets.nim
@@ -34,7 +34,7 @@ proc inSet(s: PNode, elem: PNode): bool =
   if s.kind != nkCurly:
     internalError(s.info, "inSet")
     return false
-  for i in countup(0, sonsLen(s) - 1):
+  for i in countup(0, len(s) - 1):
     if s.sons[i].kind == nkRange:
       if leValue(s.sons[i].sons[0], elem) and
           leValue(elem, s.sons[i].sons[1]):
@@ -63,7 +63,7 @@ proc someInSet(s: PNode, a, b: PNode): bool =
   if s.kind != nkCurly:
     internalError(s.info, "SomeInSet")
     return false
-  for i in countup(0, sonsLen(s) - 1):
+  for i in countup(0, len(s) - 1):
     if s.sons[i].kind == nkRange:
       if leValue(s.sons[i].sons[0], b) and leValue(b, s.sons[i].sons[1]) or
           leValue(s.sons[i].sons[0], a) and leValue(a, s.sons[i].sons[1]):
@@ -78,7 +78,7 @@ proc toBitSet(s: PNode, b: var TBitSet) =
   var first, j: BiggestInt
   first = firstOrd(s.typ.sons[0])
   bitSetInit(b, int(getSize(s.typ)))
-  for i in countup(0, sonsLen(s) - 1):
+  for i in countup(0, len(s) - 1):
     if s.sons[i].kind == nkRange:
       j = getOrdValue(s.sons[i].sons[0])
       while j <= getOrdValue(s.sons[i].sons[1]):
@@ -155,7 +155,7 @@ proc cardSet(s: PNode): BiggestInt =
   # here we can do better than converting it into a compact set
   # we just count the elements directly
   result = 0
-  for i in countup(0, sonsLen(s) - 1):
+  for i in countup(0, len(s) - 1):
     if s.sons[i].kind == nkRange:
       result = result + getOrdValue(s.sons[i].sons[1]) -
           getOrdValue(s.sons[i].sons[0]) + 1
@@ -166,7 +166,7 @@ proc setHasRange(s: PNode): bool =
   if s.kind != nkCurly:
     internalError(s.info, "SetHasRange")
     return false
-  for i in countup(0, sonsLen(s) - 1):
+  for i in countup(0, len(s) - 1):
     if s.sons[i].kind == nkRange:
       return true
   result = false

--- a/compiler/nimsets.nim
+++ b/compiler/nimsets.nim
@@ -109,15 +109,15 @@ proc toTreeSet(s: TBitSet, settype: PType, info: TLineInfo): PNode =
       let aa = newIntTypeNode(nkIntLit, a + first, elemType)
       aa.info = info
       if a == b:
-        addSon(result, aa)
+        add(result, aa)
       else:
         n = newNodeI(nkRange, info)
         n.typ = elemType
-        addSon(n, aa)
+        add(n, aa)
         let bb = newIntTypeNode(nkIntLit, b + first, elemType)
         bb.info = info
-        addSon(n, bb)
-        addSon(result, n)
+        add(n, bb)
+        add(result, n)
       e = b
     inc(e)
 

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -232,7 +232,7 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
       result = isAssignable(owner, n.sons[1], isUnsafeAddr)
   of nkStmtList, nkStmtListExpr:
     if n.typ != nil:
-      result = isAssignable(owner, n.lastSon, isUnsafeAddr)
+      result = isAssignable(owner, n.last, isUnsafeAddr)
   else:
     discard
 

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -970,14 +970,11 @@ proc parseProcExpr(p: var TParser, isExpr: bool): PNode =
     else:
       result = newNodeI(nkProcTy, info)
 
-proc isExprStart(p: TParser): bool =
-  case p.tok.tokType
-  of tkSymbol, tkAccent, tkOpr, tkNot, tkNil, tkCast, tkIf,
-     tkProc, tkIterator, tkBind, tkAddr,
-     tkParLe, tkBracketLe, tkCurlyLe, tkIntLit..tkCharLit, tkVar, tkRef, tkPtr,
-     tkTuple, tkObject, tkType, tkWhen, tkCase, tkOut:
-    result = true
-  else: result = false
+const exprStartTypes = {tkSymbol, tkAccent, tkOpr, tkNot, tkNil, tkCast, tkIf,
+     tkProc, tkIterator, tkBind, tkAddr, tkParLe, tkBracketLe, tkCurlyLe,
+     tkIntLit..tkCharLit, tkVar, tkRef, tkPtr, tkTuple, tkObject, tkType,
+     tkWhen, tkCase, tkOut}
+template isExprStart(p: TParser): bool = p.tok.tokType in exprStartTypes
 
 proc parseSymbolList(p: var TParser, result: PNode, allowNil = false) =
   while true:

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1083,7 +1083,7 @@ proc primary(p: var TParser, mode: TPrimaryMode): PNode =
     let info = parLineInfo(p)
     getTokNoInd(p)
     let next = primary(p, pmNormal)
-    if next.kind == nkBracket and next.sonsLen == 1:
+    if next.kind == nkBracket and next.len == 1:
       result = newNode(nkStaticTy, info, @[next.sons[0]])
     else:
       result = newNode(nkStaticExpr, info, @[next])

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -34,7 +34,7 @@ proc cleanUp(c: PPassContext, n: PNode): PNode =
   if optDeadCodeElim in gGlobalOptions or n == nil: return
   case n.kind
   of nkStmtList:
-    for i in countup(0, sonsLen(n) - 1): discard cleanUp(c, n.sons[i])
+    for i in countup(0, len(n) - 1): discard cleanUp(c, n.sons[i])
   of nkProcDef, nkMethodDef:
     if n.sons[namePos].kind == nkSym:
       var s = n.sons[namePos].sym

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -151,7 +151,7 @@ proc processImplicits(implicits: seq[string], nodeKind: TNodeKind,
     var importStmt = newNodeI(nodeKind, gCmdLineInfo)
     var str = newStrNode(nkStrLit, module)
     str.info = gCmdLineInfo
-    importStmt.addSon str
+    importStmt.add str
     if not processTopLevelStmt(importStmt, a): break
 
 proc processModule*(module: PSym, stream: PLLStream,
@@ -188,11 +188,11 @@ proc processModule*(module: PSym, stream: PLLStream,
         if sfNoForward in module.flags:
           # read everything, no streaming possible
           var sl = newNodeI(nkStmtList, n.info)
-          sl.addSon(n)
+          sl.add(n)
           while true:
             var n = parseTopLevelStmt(p)
             if n.kind == nkEmpty: break
-            sl.addSon(n)
+            sl.add(n)
           discard processTopLevelStmt(sl, a)
           break
         elif not processTopLevelStmt(n, a): break

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -188,11 +188,11 @@ proc processModule*(module: PSym, stream: PLLStream,
         if sfNoForward in module.flags:
           # read everything, no streaming possible
           var sl = newNodeI(nkStmtList, n.info)
-          sl.add n
+          sl.addSon(n)
           while true:
             var n = parseTopLevelStmt(p)
             if n.kind == nkEmpty: break
-            sl.add n
+            sl.addSon(n)
           discard processTopLevelStmt(sl, a)
           break
         elif not processTopLevelStmt(n, a): break

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -204,6 +204,6 @@ proc processModule*(module: PSym, stream: PLLStream,
   else:
     openPassesCached(a, module, rd)
     var n = loadInitSection(rd)
-    for i in countup(0, sonsLen(n) - 1): processTopLevelStmtCached(n.sons[i], a)
+    for i in countup(0, len(n) - 1): processTopLevelStmtCached(n.sons[i], a)
     closePassesCached(a)
   result = true

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -249,9 +249,9 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
   if isNil(m): return nil
   # each parameter should have been bound; we simply setup a call and
   # let semantic checking deal with the rest :-)
-  result = newNodeI(nkCall, n.info)
-  result.addSon(newSymNode(s, n.info))
   let params = s.typ.n
+  result = newNodeI(nkCall, n.info, params.len)
+  result.sons[0] = newSymNode(s, n.info)
   let requiresAA = aliasAnalysisRequested(params)
   var args: PNode
   if requiresAA:
@@ -261,7 +261,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
     let x = getLazy(ctx, param)
     # couldn't bind parameter:
     if isNil(x): return nil
-    result.addSon(x)
+    result.sons[i] = x
     if requiresAA: addToArgList(args, x)
   # perform alias analysis here:
   if requiresAA:

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -98,7 +98,7 @@ proc bindOrCheck(c: PPatternContext, param: PSym, n: PNode): bool =
 proc gather(c: PPatternContext, param: PSym, n: PNode) =
   var pp = getLazy(c, param)
   if pp != nil and pp.kind == nkArgList:
-    pp.addSon(n)
+    pp.add(n)
   else:
     pp = newNodeI(nkArgList, n.info, 1)
     pp.sons[0] = n
@@ -112,13 +112,13 @@ proc matchNested(c: PPatternContext, p, n: PNode, rpn: bool): bool =
     if n.kind in nkCallKinds and matches(c, op.sons[1], n.sons[0]):
       for i in 1..sonsLen(n)-1:
         if not matchStarAux(c, op, n[i], arglist, rpn): return false
-      if rpn: arglist.addSon(n.sons[0])
+      if rpn: arglist.add(n.sons[0])
     elif n.kind == nkHiddenStdConv and n.sons[1].kind == nkBracket:
       let n = n.sons[1]
       for i in 0.. <n.len:
         if not matchStarAux(c, op, n[i], arglist, rpn): return false
     elif checkTypes(c, p.sons[2].sym, n):
-      addSon(arglist, n)
+      add(arglist, n)
     else:
       result = false
 
@@ -235,9 +235,9 @@ proc aliasAnalysisRequested(params: PNode): bool =
 
 proc addToArgList(result, n: PNode) =
   if n.typ != nil and n.typ.kind != tyStmt:
-    if n.kind != nkArgList: result.addSon(n)
+    if n.kind != nkArgList: result.add(n)
     else:
-      for i in 0 .. <n.len: result.addSon(n.sons[i])
+      for i in 0 .. <n.len: result.add(n.sons[i])
 
 proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
   ## returns a tree to semcheck if the rule triggered; nil otherwise

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -98,7 +98,7 @@ proc bindOrCheck(c: PPatternContext, param: PSym, n: PNode): bool =
 proc gather(c: PPatternContext, param: PSym, n: PNode) =
   var pp = getLazy(c, param)
   if pp != nil and pp.kind == nkArgList:
-    pp.add(n)
+    pp.addSon(n)
   else:
     pp = newNodeI(nkArgList, n.info, 1)
     pp.sons[0] = n
@@ -112,13 +112,13 @@ proc matchNested(c: PPatternContext, p, n: PNode, rpn: bool): bool =
     if n.kind in nkCallKinds and matches(c, op.sons[1], n.sons[0]):
       for i in 1..sonsLen(n)-1:
         if not matchStarAux(c, op, n[i], arglist, rpn): return false
-      if rpn: arglist.add(n.sons[0])
+      if rpn: arglist.addSon(n.sons[0])
     elif n.kind == nkHiddenStdConv and n.sons[1].kind == nkBracket:
       let n = n.sons[1]
       for i in 0.. <n.len:
         if not matchStarAux(c, op, n[i], arglist, rpn): return false
     elif checkTypes(c, p.sons[2].sym, n):
-      add(arglist, n)
+      addSon(arglist, n)
     else:
       result = false
 
@@ -235,9 +235,9 @@ proc aliasAnalysisRequested(params: PNode): bool =
 
 proc addToArgList(result, n: PNode) =
   if n.typ != nil and n.typ.kind != tyStmt:
-    if n.kind != nkArgList: result.add(n)
+    if n.kind != nkArgList: result.addSon(n)
     else:
-      for i in 0 .. <n.len: result.add(n.sons[i])
+      for i in 0 .. <n.len: result.addSon(n.sons[i])
 
 proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
   ## returns a tree to semcheck if the rule triggered; nil otherwise
@@ -250,7 +250,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
   # each parameter should have been bound; we simply setup a call and
   # let semantic checking deal with the rest :-)
   result = newNodeI(nkCall, n.info)
-  result.add(newSymNode(s, n.info))
+  result.addSon(newSymNode(s, n.info))
   let params = s.typ.n
   let requiresAA = aliasAnalysisRequested(params)
   var args: PNode
@@ -261,7 +261,7 @@ proc applyRule*(c: PContext, s: PSym, n: PNode): PNode =
     let x = getLazy(ctx, param)
     # couldn't bind parameter:
     if isNil(x): return nil
-    result.add(x)
+    result.addSon(x)
     if requiresAA: addToArgList(args, x)
   # perform alias analysis here:
   if requiresAA:

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -175,16 +175,16 @@ proc matches(c: PPatternContext, p, n: PNode): bool =
       var plen = len(p)
       # special rule for p(X) ~ f(...); this also works for stuff like
       # partial case statements, etc! - Not really ... :-/
-      let v = lastSon(p)
+      let v = last(p)
       if isPatternParam(c, v) and v.sym.typ.kind == tyVarargs:
         var arglist: PNode
         if plen <= len(n):
           for i in countup(0, plen - 2):
             if not matches(c, p.sons[i], n.sons[i]): return
-          if plen == len(n) and lastSon(n).kind == nkHiddenStdConv and
-              lastSon(n).sons[1].kind == nkBracket:
+          if plen == len(n) and last(n).kind == nkHiddenStdConv and
+              last(n).sons[1].kind == nkBracket:
             # unpack varargs:
-            let n = lastSon(n).sons[1]
+            let n = last(n).sons[1]
             arglist = newNodeI(nkArgList, n.info, n.len)
             for i in 0.. <n.len: arglist.sons[i] = n.sons[i]
           else:

--- a/compiler/plugins/itersgen.nim
+++ b/compiler/plugins/itersgen.nim
@@ -37,7 +37,7 @@ proc iterToProcImpl(c: PContext, n: PNode): PNode =
   let prc = newSym(skProc, n[3].ident, iter.sym.owner, iter.sym.info)
   prc.typ = copyType(iter.sym.typ, prc, false)
   excl prc.typ.flags, tfCapturesEnv
-  prc.typ.n.add newSymNode(getEnvParam(iter.sym))
+  prc.typ.n.addSon(newSymNode(getEnvParam(iter.sym)))
   prc.typ.rawAddSon t
   let orig = iter.sym.ast
   prc.ast = newProcNode(nkProcDef, n.info,
@@ -45,7 +45,7 @@ proc iterToProcImpl(c: PContext, n: PNode): PNode =
                         params = orig[paramsPos],
                         pragmas = orig[pragmasPos],
                         body = body)
-  prc.ast.add iter.sym.ast.sons[resultPos]
+  prc.ast.addSon(iter.sym.ast.sons[resultPos])
   addInterfaceDecl(c, prc)
 
 registerPlugin("stdlib", "system", "iterToProc", iterToProcImpl)

--- a/compiler/plugins/itersgen.nim
+++ b/compiler/plugins/itersgen.nim
@@ -28,7 +28,7 @@ proc iterToProcImpl(c: PContext, n: PNode): PNode =
     return
 
   let t = n[2].typ.skipTypes({tyTypeDesc, tyGenericInst})
-  if t.kind notin {tyRef, tyPtr} or t.lastSon.kind != tyObject:
+  if t.kind notin {tyRef, tyPtr} or t.last.kind != tyObject:
     localError(n[2].info,
         "type must be a non-generic ref|ptr to object with state field")
     return

--- a/compiler/plugins/itersgen.nim
+++ b/compiler/plugins/itersgen.nim
@@ -37,15 +37,15 @@ proc iterToProcImpl(c: PContext, n: PNode): PNode =
   let prc = newSym(skProc, n[3].ident, iter.sym.owner, iter.sym.info)
   prc.typ = copyType(iter.sym.typ, prc, false)
   excl prc.typ.flags, tfCapturesEnv
-  prc.typ.n.addSon(newSymNode(getEnvParam(iter.sym)))
-  prc.typ.rawAddSon t
+  prc.typ.n.add(newSymNode(getEnvParam(iter.sym)))
+  prc.typ.rawAdd t
   let orig = iter.sym.ast
   prc.ast = newProcNode(nkProcDef, n.info,
                         name = newSymNode(prc),
                         params = orig[paramsPos],
                         pragmas = orig[pragmasPos],
                         body = body)
-  prc.ast.addSon(iter.sym.ast.sons[resultPos])
+  prc.ast.add(iter.sym.ast.sons[resultPos])
   addInterfaceDecl(c, prc)
 
 registerPlugin("stdlib", "system", "iterToProc", iterToProcImpl)

--- a/compiler/plugins/locals/locals.nim
+++ b/compiler/plugins/locals/locals.nim
@@ -33,11 +33,11 @@ proc semLocals(c: PContext, n: PNode): PNode =
         field.position = counter
         inc(counter)
 
-        addSon(tupleType.n, newSymNode(field))
-        addSonSkipIntLit(tupleType, field.typ)
+        add(tupleType.n, newSymNode(field))
+        addSkipIntLit(tupleType, field.typ)
 
         var a = newSymNode(it, result.info)
         if it.typ.skipTypes({tyGenericInst}).kind == tyVar: a = newDeref(a)
-        result.addSon(a)
+        result.add(a)
 
 registerPlugin("stdlib", "system", "locals", semLocals)

--- a/compiler/plugins/locals/locals.nim
+++ b/compiler/plugins/locals/locals.nim
@@ -38,6 +38,6 @@ proc semLocals(c: PContext, n: PNode): PNode =
 
         var a = newSymNode(it, result.info)
         if it.typ.skipTypes({tyGenericInst}).kind == tyVar: a = newDeref(a)
-        result.add(a)
+        result.addSon(a)
 
 registerPlugin("stdlib", "system", "locals", semLocals)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -360,7 +360,7 @@ proc processPush(c: PContext, n: PNode, start: int) =
       # simply store it somewhere:
       if x.otherPragmas.isNil:
         x.otherPragmas = newNodeI(nkPragma, n.info)
-      x.otherPragmas.add n.sons[i]
+      x.otherPragmas.addSon(n.sons[i])
     #localError(n.info, errOptionExpected)
 
 proc processPop(c: PContext, n: PNode) =

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -79,7 +79,7 @@ proc invalidPragma(n: PNode) =
 proc pragmaAsm*(c: PContext, n: PNode): char =
   result = '\0'
   if n != nil:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       let it = n.sons[i]
       if it.kind == nkExprColonExpr and it.sons[0].kind == nkIdent:
         case whichKeyword(it.sons[0].ident)
@@ -271,7 +271,7 @@ proc processDynLib(c: PContext, n: PNode, sym: PSym) =
       sym.typ.callConv = ccCDecl
 
 proc processNote(c: PContext, n: PNode) =
-  if (n.kind == nkExprColonExpr) and (sonsLen(n) == 2) and
+  if (n.kind == nkExprColonExpr) and (len(n) == 2) and
       (n.sons[0].kind == nkBracketExpr) and
       (n.sons[0].sons.len == 2) and
       (n.sons[0].sons[1].kind == nkIdent) and
@@ -355,7 +355,7 @@ proc processPush(c: PContext, n: PNode, start: int) =
   x.dynlib = y.dynlib
   x.notes = gNotes
   append(c.optionStack, x)
-  for i in countup(start, sonsLen(n) - 1):
+  for i in countup(start, len(n) - 1):
     if processOption(c, n.sons[i]):
       # simply store it somewhere:
       if x.otherPragmas.isNil:
@@ -505,7 +505,7 @@ proc processPragma(c: PContext, n: PNode, i: int) =
 
   var userPragma = newSym(skTemplate, it.sons[1].ident, nil, it.info)
   var body = newNodeI(nkPragma, n.info)
-  for j in i+1 .. sonsLen(n)-1: add(body, n.sons[j])
+  for j in i+1 .. len(n)-1: add(body, n.sons[j])
   userPragma.ast = body
   strTableAdd(c.userPragmas, userPragma)
 
@@ -916,7 +916,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, n: PNode,
       let o = it.otherPragmas
       if not o.isNil:
         pushInfoContext(n.info)
-        for i in countup(0, sonsLen(o) - 1):
+        for i in countup(0, len(o) - 1):
           if singlePragma(c, sym, o, i, validPragmas):
             internalError(n.info, "implicitPragmas")
         popInfoContext()
@@ -944,7 +944,7 @@ proc hasPragma*(n: PNode, pragma: TSpecialWord): bool =
 
 proc pragmaRec(c: PContext, sym: PSym, n: PNode, validPragmas: TSpecialWords) =
   if n == nil: return
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     if n.sons[i].kind == nkPragma: pragmaRec(c, sym, n.sons[i], validPragmas)
     elif singlePragma(c, sym, n, i, validPragmas): break
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -360,7 +360,7 @@ proc processPush(c: PContext, n: PNode, start: int) =
       # simply store it somewhere:
       if x.otherPragmas.isNil:
         x.otherPragmas = newNodeI(nkPragma, n.info)
-      x.otherPragmas.addSon(n.sons[i])
+      x.otherPragmas.add(n.sons[i])
     #localError(n.info, errOptionExpected)
 
 proc processPop(c: PContext, n: PNode) =
@@ -436,7 +436,7 @@ proc semAsmOrEmit*(con: PContext, n: PNode, marker: char): PNode =
     while true:
       var b = strutils.find(str, marker, a)
       var sub = if b < 0: substr(str, a) else: substr(str, a, b - 1)
-      if sub != "": addSon(result, newStrNode(nkStrLit, sub))
+      if sub != "": add(result, newStrNode(nkStrLit, sub))
       if b < 0: break
       var c = strutils.find(str, marker, b + 1)
       if c < 0: sub = substr(str, b + 1)
@@ -446,12 +446,12 @@ proc semAsmOrEmit*(con: PContext, n: PNode, marker: char): PNode =
         if e != nil:
           if e.kind == skStub: loadStub(e)
           incl(e.flags, sfUsed)
-          addSon(result, newSymNode(e))
+          add(result, newSymNode(e))
         else:
-          addSon(result, newStrNode(nkStrLit, sub))
+          add(result, newStrNode(nkStrLit, sub))
       else:
         # an empty '``' produces a single '`'
-        addSon(result, newStrNode(nkStrLit, $marker))
+        add(result, newStrNode(nkStrLit, $marker))
       if c < 0: break
       a = c + 1
   else:
@@ -505,7 +505,7 @@ proc processPragma(c: PContext, n: PNode, i: int) =
 
   var userPragma = newSym(skTemplate, it.sons[1].ident, nil, it.info)
   var body = newNodeI(nkPragma, n.info)
-  for j in i+1 .. sonsLen(n)-1: addSon(body, n.sons[j])
+  for j in i+1 .. sonsLen(n)-1: add(body, n.sons[j])
   userPragma.ast = body
   strTableAdd(c.userPragmas, userPragma)
 

--- a/compiler/procfind.nim
+++ b/compiler/procfind.nim
@@ -14,8 +14,8 @@ import
   ast, astalgo, msgs, semdata, types, trees, strutils
 
 proc equalGenericParams(procA, procB: PNode): bool =
-  if sonsLen(procA) != sonsLen(procB): return
-  for i in countup(0, sonsLen(procA) - 1):
+  if len(procA) != len(procB): return
+  for i in countup(0, len(procA) - 1):
     if procA.sons[i].kind != nkSym:
       internalError(procA.info, "equalGenericParams")
       return
@@ -102,9 +102,9 @@ proc searchForProc*(c: PContext, scope: PScope, fn: PSym): PSym =
 
 when false:
   proc paramsFitBorrow(child, parent: PNode): bool =
-    var length = sonsLen(child)
+    var length = len(child)
     result = false
-    if length == sonsLen(parent):
+    if length == len(parent):
       for i in countup(1, length - 1):
         var m = child.sons[i].sym
         var n = parent.sons[i].sym

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -291,7 +291,7 @@ proc litAux(n: PNode, x: BiggestInt, size: int): string =
     result = t
     while result.kind in {tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal,
                           tyConst, tyMutable}:
-      result = lastSon(result)
+      result = last(result)
   if n.typ != nil and n.typ.skip.kind in {tyBool, tyEnum}:
     let enumfields = n.typ.skip.n
     # we need a slow linear search because of enums with holes:
@@ -406,7 +406,7 @@ proc lsub(n: PNode): int =
     var L = len(n)
     if n.sons[L - 2].kind != nkEmpty: result = result + lsub(n.sons[L - 2]) + 2
     if n.sons[L - 1].kind != nkEmpty: result = result + lsub(n.sons[L - 1]) + 3
-  of nkVarTuple: result = lcomma(n, 0, - 3) + len("() = ") + lsub(lastSon(n))
+  of nkVarTuple: result = lcomma(n, 0, - 3) + len("() = ") + lsub(last(n))
   of nkChckRangeF: result = len("chckRangeF") + 2 + lcomma(n)
   of nkChckRange64: result = len("chckRange64") + 2 + lcomma(n)
   of nkChckRange: result = len("chckRange") + 2 + lcomma(n)
@@ -465,7 +465,7 @@ proc lsub(n: PNode): int =
   of nkContinueStmt: result = lsub(n.sons[0]) + len("continue_")
   of nkPragma: result = lcomma(n) + 4
   of nkCommentStmt: result = if n.comment.isNil: 0 else: len(n.comment)
-  of nkOfBranch: result = lcomma(n, 0, - 2) + lsub(lastSon(n)) + len("of_:_")
+  of nkOfBranch: result = lcomma(n, 0, - 2) + lsub(last(n)) + len("of_:_")
   of nkImportAs: result = lsub(n.sons[0]) + len("_as_") + lsub(n.sons[1])
   of nkElifBranch: result = lsons(n) + len("elif_:_")
   of nkElse: result = lsub(n.sons[0]) + len("else:_")
@@ -475,7 +475,7 @@ proc lsub(n: PNode): int =
     result = lcomma(n, 1) + 2
     if n.sons[0].kind != nkEmpty: result = result + lsub(n.sons[0]) + 2
   of nkExceptBranch:
-    result = lcomma(n, 0, -2) + lsub(lastSon(n)) + len("except_:_")
+    result = lcomma(n, 0, -2) + lsub(last(n)) + len("except_:_")
   else: result = MaxLineLen + 1
 
 proc fits(g: TSrcGen, x: int): bool =
@@ -988,7 +988,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     put(g, tkParRi, ")")
     put(g, tkSpaces, Space)
     putWithSpace(g, tkEquals, "=")
-    gsub(g, lastSon(n), c)
+    gsub(g, last(n), c)
   of nkExprColonExpr:
     gsub(g, n, 0)
     putWithSpace(g, tkColon, ":")
@@ -1271,7 +1271,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     gcomma(g, n, c, 0, - 2)
     putWithSpace(g, tkColon, ":")
     gcoms(g)
-    gstmts(g, lastSon(n), c)
+    gstmts(g, last(n), c)
   of nkImportAs:
     gsub(g, n, 0)
     put(g, tkSpaces, Space)
@@ -1311,7 +1311,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     gcomma(g, n, 0, - 2)
     putWithSpace(g, tkColon, ":")
     gcoms(g)
-    gstmts(g, lastSon(n), c)
+    gstmts(g, last(n), c)
   of nkGenericParams:
     put(g, tkBracketLe, "[")
     gcomma(g, n)

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -355,7 +355,7 @@ proc atom(n: PNode): string =
 proc lcomma(n: PNode, start: int = 0, theEnd: int = - 1): int =
   assert(theEnd < 0)
   result = 0
-  for i in countup(start, sonsLen(n) + theEnd):
+  for i in countup(start, len(n) + theEnd):
     inc(result, lsub(n.sons[i]))
     inc(result, 2)            # for ``, ``
   if result > 0:
@@ -364,7 +364,7 @@ proc lcomma(n: PNode, start: int = 0, theEnd: int = - 1): int =
 proc lsons(n: PNode, start: int = 0, theEnd: int = - 1): int =
   assert(theEnd < 0)
   result = 0
-  for i in countup(start, sonsLen(n) + theEnd): inc(result, lsub(n.sons[i]))
+  for i in countup(start, len(n) + theEnd): inc(result, lsub(n.sons[i]))
 
 proc lsub(n: PNode): int =
   # computes the length of a tree
@@ -391,7 +391,7 @@ proc lsub(n: PNode): int =
   of nkTableConstr:
     result = if n.len > 0: lcomma(n) + 2 else: len("{:}")
   of nkClosedSymChoice, nkOpenSymChoice:
-    result = lsons(n) + len("()") + sonsLen(n) - 1
+    result = lsons(n) + len("()") + len(n) - 1
   of nkTupleTy: result = lcomma(n) + len("tuple[]")
   of nkTupleClassTy: result = len("tuple")
   of nkDotExpr: result = lsons(n) + 1
@@ -403,7 +403,7 @@ proc lsub(n: PNode): int =
   of nkDo: result = lsons(n) + len("do__:_")
   of nkConstDef, nkIdentDefs:
     result = lcomma(n, 0, - 3)
-    var L = sonsLen(n)
+    var L = len(n)
     if n.sons[L - 2].kind != nkEmpty: result = result + lsub(n.sons[L - 2]) + 2
     if n.sons[L - 1].kind != nkEmpty: result = result + lsub(n.sons[L - 1]) + 3
   of nkVarTuple: result = lcomma(n, 0, - 3) + len("() = ") + lsub(lastSon(n))
@@ -412,7 +412,7 @@ proc lsub(n: PNode): int =
   of nkChckRange: result = len("chckRange") + 2 + lcomma(n)
   of nkObjDownConv, nkObjUpConv, nkStringToCString, nkCStringToString:
     result = 2
-    if sonsLen(n) >= 1: result = result + lsub(n.sons[0])
+    if len(n) >= 1: result = result + lsub(n.sons[0])
     result = result + lcomma(n, 1)
   of nkExprColonExpr: result = lsons(n) + 2
   of nkInfix: result = lsons(n) + 2
@@ -446,16 +446,16 @@ proc lsub(n: PNode): int =
   of nkIteratorTy: result = lsons(n) + len("iterator_")
   of nkSharedTy: result = lsons(n) + len("shared_")
   of nkEnumTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       result = lsub(n.sons[0]) + lcomma(n, 1) + len("enum_")
     else:
       result = len("enum")
   of nkEnumFieldDef: result = lsons(n) + 3
   of nkVarSection, nkLetSection:
-    if sonsLen(n) > 1: result = MaxLineLen + 1
+    if len(n) > 1: result = MaxLineLen + 1
     else: result = lsons(n) + len("var_")
   of nkUsingStmt:
-    if sonsLen(n) > 1: result = MaxLineLen + 1
+    if len(n) > 1: result = MaxLineLen + 1
     else: result = lsons(n) + len("using_")
   of nkReturnStmt: result = lsub(n.sons[0]) + len("return_")
   of nkRaiseStmt: result = lsub(n.sons[0]) + len("raise_")
@@ -507,7 +507,7 @@ proc hasCom(n: PNode): bool =
   case n.kind
   of nkEmpty..nkNilLit: discard
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       if hasCom(n.sons[i]): return true
 
 proc putWithSpace(g: var TSrcGen, kind: TTokType, s: string) =
@@ -516,8 +516,8 @@ proc putWithSpace(g: var TSrcGen, kind: TTokType, s: string) =
 
 proc gcommaAux(g: var TSrcGen, n: PNode, ind: int, start: int = 0,
                theEnd: int = - 1, separator = tkComma) =
-  for i in countup(start, sonsLen(n) + theEnd):
-    var c = i < sonsLen(n) + theEnd
+  for i in countup(start, len(n) + theEnd):
+    var c = i < len(n) + theEnd
     var sublen = lsub(n.sons[i]) + ord(c)
     if not fits(g, sublen) and (ind + sublen < MaxLineLen): optNL(g, ind)
     let oldLen = g.tokens.len
@@ -551,15 +551,15 @@ proc gsemicolon(g: var TSrcGen, n: PNode, start: int = 0, theEnd: int = - 1) =
 
 proc gsons(g: var TSrcGen, n: PNode, c: TContext, start: int = 0,
            theEnd: int = - 1) =
-  for i in countup(start, sonsLen(n) + theEnd): gsub(g, n.sons[i], c)
+  for i in countup(start, len(n) + theEnd): gsub(g, n.sons[i], c)
 
 proc gsection(g: var TSrcGen, n: PNode, c: TContext, kind: TTokType,
               k: string) =
-  if sonsLen(n) == 0: return # empty var sections are possible
+  if len(n) == 0: return # empty var sections are possible
   putWithSpace(g, kind, k)
   gcoms(g)
   indentNL(g)
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     optNL(g)
     gsub(g, n.sons[i], c)
     gcoms(g)
@@ -569,7 +569,7 @@ proc longMode(n: PNode, start: int = 0, theEnd: int = - 1): bool =
   result = n.comment != nil
   if not result:
     # check further
-    for i in countup(start, sonsLen(n) + theEnd):
+    for i in countup(start, len(n) + theEnd):
       if (lsub(n.sons[i]) > MaxLineLen):
         result = true
         break
@@ -578,7 +578,7 @@ proc gstmts(g: var TSrcGen, n: PNode, c: TContext, doIndent=true) =
   if n.kind == nkEmpty: return
   if n.kind in {nkStmtList, nkStmtListExpr, nkStmtListType}:
     if doIndent: indentNL(g)
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       optNL(g)
       if n.sons[i].kind in {nkStmtList, nkStmtListExpr, nkStmtListType}:
         gstmts(g, n.sons[i], c, doIndent=false)
@@ -602,7 +602,7 @@ proc gif(g: var TSrcGen, n: PNode) =
     incl(c.flags, rfLongMode)
   gcoms(g)                    # a good place for comments
   gstmts(g, n.sons[0].sons[1], c)
-  var length = sonsLen(n)
+  var length = len(n)
   for i in countup(1, length - 1):
     optNL(g)
     gsub(g, n.sons[i], c)
@@ -651,7 +651,7 @@ proc gtry(g: var TSrcGen, n: PNode) =
 
 proc gfor(g: var TSrcGen, n: PNode) =
   var c: TContext
-  var length = sonsLen(n)
+  var length = len(n)
   putWithSpace(g, tkFor, "for")
   initContext(c)
   if longMode(n) or
@@ -669,7 +669,7 @@ proc gfor(g: var TSrcGen, n: PNode) =
 proc gcase(g: var TSrcGen, n: PNode) =
   var c: TContext
   initContext(c)
-  var length = sonsLen(n)
+  var length = len(n)
   var last = if n.sons[length-1].kind == nkElse: -2 else: -1
   if longMode(n, 0, last): incl(c.flags, rfLongMode)
   putWithSpace(g, tkCase, "case")
@@ -843,7 +843,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
       gcomma(g, n, 2)
       put(g, tkBracketRi, "]")
     else:
-      if sonsLen(n) >= 1: gsub(g, n.sons[0])
+      if len(n) >= 1: gsub(g, n.sons[0])
       put(g, tkParLe, "(")
       gcomma(g, n, 1)
       put(g, tkParRi, ")")
@@ -910,14 +910,14 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     gcomma(g, n)
     put(g, tkParRi, ")")
   of nkObjDownConv, nkObjUpConv, nkStringToCString, nkCStringToString:
-    if sonsLen(n) >= 1: gsub(g, n.sons[0])
+    if len(n) >= 1: gsub(g, n.sons[0])
     put(g, tkParLe, "(")
     gcomma(g, n, 1)
     put(g, tkParRi, ")")
   of nkClosedSymChoice, nkOpenSymChoice:
     if renderIds in g.flags:
       put(g, tkParLe, "(")
-      for i in countup(0, sonsLen(n) - 1):
+      for i in countup(0, len(n) - 1):
         if i > 0: put(g, tkOpr, "|")
         if n.sons[i].kind == nkSym:
           let s = n[i].sym
@@ -974,7 +974,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     gsub(g, n, bodyPos)
   of nkConstDef, nkIdentDefs:
     gcomma(g, n, 0, -3)
-    var L = sonsLen(n)
+    var L = len(n)
     if L >= 2 and n.sons[L - 2].kind != nkEmpty:
       putWithSpace(g, tkColon, ":")
       gsub(g, n, L - 2)
@@ -1050,19 +1050,19 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     if n.len > 0: gsub(g, n.sons[0])
     put(g, tkParRi, ")")
   of nkRefTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkRef, "ref")
       gsub(g, n.sons[0])
     else:
       put(g, tkRef, "ref")
   of nkPtrTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkPtr, "ptr")
       gsub(g, n.sons[0])
     else:
       put(g, tkPtr, "ptr")
   of nkVarTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkVar, "var")
       gsub(g, n.sons[0])
     else:
@@ -1087,7 +1087,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
       putWithSpace(g, tkEquals, "=")
       gsub(g, n.sons[2])
   of nkObjectTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkObject, "object")
       gsub(g, n.sons[0])
       gsub(g, n.sons[1])
@@ -1097,7 +1097,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
       put(g, tkObject, "object")
   of nkRecList:
     indentNL(g)
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       optNL(g)
       gsub(g, n.sons[i], c)
       gcoms(g)
@@ -1107,14 +1107,14 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     putWithSpace(g, tkOf, "of")
     gsub(g, n, 0)
   of nkProcTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkProc, "proc")
       gsub(g, n, 0)
       gsub(g, n, 1)
     else:
       put(g, tkProc, "proc")
   of nkIteratorTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkIterator, "iterator")
       gsub(g, n, 0)
       gsub(g, n, 1)
@@ -1127,7 +1127,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
       gsub(g, n.sons[0])
     put(g, tkBracketRi, "]")
   of nkEnumTy:
-    if sonsLen(n) > 0:
+    if len(n) > 0:
       putWithSpace(g, tkEnum, "enum")
       gsub(g, n.sons[0])
       gcoms(g)
@@ -1182,7 +1182,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     incl(a.flags, rfInConstExpr)
     gsection(g, n, a, tkConst, "const")
   of nkVarSection, nkLetSection, nkUsingStmt:
-    var L = sonsLen(n)
+    var L = len(n)
     if L == 0: return
     if n.kind == nkVarSection: putWithSpace(g, tkVar, "var")
     elif n.kind == nkLetSection: putWithSpace(g, tkLet, "let")
@@ -1359,7 +1359,7 @@ proc renderModule(n: PNode, filename: string,
     f: File
     g: TSrcGen
   initSrcGen(g, renderFlags)
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     gsub(g, n.sons[i])
     optNL(g)
     case n.sons[i].kind

--- a/compiler/rodread.nim
+++ b/compiler/rodread.nim
@@ -999,7 +999,7 @@ proc writeNode(f: File; n: PNode) =
       f.write('!')
       f.write(n.sym.id)
     else:
-      for i in countup(0, sonsLen(n) - 1):
+      for i in countup(0, len(n) - 1):
         writeNode(f, n.sons[i])
   f.write(")")
 
@@ -1069,7 +1069,7 @@ proc writeType(f: File; t: PType) =
   if t.align != 2:
     f.write('=')
     f.write($t.align)
-  for i in countup(0, sonsLen(t) - 1):
+  for i in countup(0, len(t) - 1):
     if t.sons[i] == nil:
       f.write("^()")
     else:

--- a/compiler/rodread.nim
+++ b/compiler/rodread.nim
@@ -233,11 +233,11 @@ proc decodeNodeLazyBody(r: PRodReader, fInfo: TLineInfo,
       var i = 0
       while r.s[r.pos] != ')':
         if belongsTo != nil and i == bodyPos:
-          addSonNilAllowed(result, nil)
+          addNilAllowed(result, nil)
           belongsTo.offset = r.pos
           skipNode(r)
         else:
-          addSonNilAllowed(result, decodeNodeLazyBody(r, result.info, nil))
+          addNilAllowed(result, decodeNodeLazyBody(r, result.info, nil))
         inc i
     if r.s[r.pos] == ')': inc(r.pos)
     else: internalError(result.info, "decodeNode: ')' missing")
@@ -348,10 +348,10 @@ proc decodeType(r: PRodReader, info: TLineInfo): PType =
       inc(r.pos)
       if r.s[r.pos] == ')': inc(r.pos)
       else: internalError(info, "decodeType ^(" & r.s[r.pos])
-      rawAddSon(result, nil)
+      rawAdd(result, nil)
     else:
       var d = decodeVInt(r.s, r.pos)
-      rawAddSon(result, rrGetType(r, d, info))
+      rawAdd(result, rrGetType(r, d, info))
 
 proc decodeLib(r: PRodReader, info: TLineInfo): PLib =
   result = nil
@@ -830,7 +830,7 @@ proc loadInitSection*(r: PRodReader): PNode =
     inc(r.pos)                # #10
     var p = r.pos
     r.pos = d + r.dataIdx
-    addSon(result, decodeNode(r, unknownLineInfo()))
+    add(result, decodeNode(r, unknownLineInfo()))
     r.pos = p
   r.pos = oldPos
 

--- a/compiler/rodwrite.nim
+++ b/compiler/rodwrite.nim
@@ -163,7 +163,7 @@ proc encodeNode(w: PRodWriter, fInfo: TLineInfo, n: PNode,
     encodeVInt(n.sym.id, result)
     pushSym(w, n.sym)
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       encodeNode(w, n.info, n.sons[i], result)
   add(result, ')')
 
@@ -247,7 +247,7 @@ proc encodeType(w: PRodWriter, t: PType, result: var string) =
     encodeVInt(s.id, result)
     pushSym(w, s)
   encodeLoc(w, t.loc, result)
-  for i in countup(0, sonsLen(t) - 1):
+  for i in countup(0, len(t) - 1):
     if t.sons[i] == nil:
       add(result, "^()")
     else:
@@ -572,7 +572,7 @@ proc process(c: PPassContext, n: PNode): PNode =
   var w = PRodWriter(c)
   case n.kind
   of nkStmtList:
-    for i in countup(0, sonsLen(n) - 1): discard process(c, n.sons[i])
+    for i in countup(0, len(n) - 1): discard process(c, n.sons[i])
     #var s = n.sons[namePos].sym
     #addInterfaceSym(w, s)
   of nkProcDef, nkMethodDef, nkIteratorDef, nkConverterDef,
@@ -585,12 +585,12 @@ proc process(c: PPassContext, n: PNode): PNode =
         sfForward notin s.flags:
       addInterfaceSym(w, s)
   of nkVarSection, nkLetSection, nkConstSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       addInterfaceSym(w, a.sons[0].sym)
   of nkTypeSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if a.sons[0].kind != nkSym: internalError(a.info, "rodwrite.process")
@@ -603,18 +603,18 @@ proc process(c: PPassContext, n: PNode): PNode =
       #
       #        if (a.sons[2] <> nil) and (a.sons[2].kind = nkEnumTy) then begin
       #          a := s.typ.n;
-      #          for j := 0 to sonsLen(a)-1 do
+      #          for j := 0 to len(a)-1 do
       #            addInterfaceSym(w, a.sons[j].sym);
       #        end
   of nkImportStmt:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       addModDep(w, getModuleName(n.sons[i]), n.info)
     addStmt(w, n)
   of nkFromStmt, nkImportExceptStmt:
     addModDep(w, getModuleName(n.sons[0]), n.info)
     addStmt(w, n)
   of nkIncludeStmt:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       addInclDep(w, getModuleName(n.sons[i]), n.info)
   of nkPragma:
     addStmt(w, n)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -108,7 +108,7 @@ proc commonType*(x, y: PType): PType =
     if a.sons == nil: result = a
     else:
       result = newType(tyTypeDesc, a.owner)
-      rawAddSon(result, newType(tyNone, a.owner))
+      rawAdd(result, newType(tyNone, a.owner))
   elif b.kind in {tyArray, tyArrayConstr, tySet, tySequence} and
       a.kind == b.kind:
     # check for seq[empty] vs. seq[int]
@@ -157,7 +157,7 @@ proc commonType*(x, y: PType): PType =
       if k != tyNone:
         let r = result
         result = newType(k, r.owner)
-        result.addSonSkipIntLit(r)
+        result.addSkipIntLit(r)
 
 proc newSymS(kind: TSymKind, n: PNode, c: PContext): PSym =
   result = newSym(kind, considerQuotedIdent(n), getCurrOwner(), n.info)
@@ -391,7 +391,7 @@ proc addCodeForGenerics(c: PContext, n: PNode) =
       if prc.ast == nil or prc.ast.sons[bodyPos] == nil:
         internalError(prc.info, "no code for " & prc.name.s)
       else:
-        addSon(n, prc.ast)
+        add(n, prc.ast)
   c.lastGenericIdx = c.generics.len
 
 proc myOpen(module: PSym): PPassContext =
@@ -462,7 +462,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
     addCodeForGenerics(c, a)
     if sonsLen(a) > 0:
       # a generic has been added to `a`:
-      if result.kind != nkEmpty: addSon(a, result)
+      if result.kind != nkEmpty: add(a, result)
       result = a
   result = hloStmt(c, result)
   if gCmd == cmdInteractive and not isEmptyType(result.typ):
@@ -506,7 +506,7 @@ proc myClose(context: PPassContext, n: PNode): PNode =
     internalError(n.info, "n is not nil") #result := n;
   addCodeForGenerics(c, result)
   if c.module.ast != nil:
-    result.addSon(c.module.ast)
+    result.add(c.module.ast)
   popOwner()
   popProcCon(c)
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -506,7 +506,7 @@ proc myClose(context: PPassContext, n: PNode): PNode =
     internalError(n.info, "n is not nil") #result := n;
   addCodeForGenerics(c, result)
   if c.module.ast != nil:
-    result.add(c.module.ast)
+    result.addSon(c.module.ast)
   popOwner()
   popProcCon(c)
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -460,7 +460,7 @@ proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   if c.lastGenericIdx < c.generics.len:
     var a = newNodeI(nkStmtList, n.info)
     addCodeForGenerics(c, a)
-    if sonsLen(a) > 0:
+    if len(a) > 0:
       # a generic has been added to `a`:
       if result.kind != nkEmpty: add(a, result)
       result = a

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -147,8 +147,8 @@ proc commonType*(x, y: PType): PType =
     if a.kind in {tyRef, tyPtr}:
       k = a.kind
       if b.kind != a.kind: return x
-      a = a.lastSon
-      b = b.lastSon
+      a = a.last
+      b = b.last
     if a.kind == tyObject and b.kind == tyObject:
       result = commonSuperclass(a, b)
       # this will trigger an error later:

--- a/compiler/semasgn.nim
+++ b/compiler/semasgn.nim
@@ -62,7 +62,7 @@ proc liftBodyObj(c: var TLiftCtx; n, body, x, y: PNode) =
       let L = branch.len
       branch.sons[L-1] = newNodeI(nkStmtList, c.info)
 
-      liftBodyObj(c, n[i].lastSon, branch.sons[L-1], x, y)
+      liftBodyObj(c, n[i].last, branch.sons[L-1], x, y)
       caseStmt.sons[i] = branch
     body.add(caseStmt)
     localError(c.info, "cannot lift assignment operator to 'case' object")
@@ -195,7 +195,7 @@ proc liftBodyAux(c: var TLiftCtx; t: PType; body, x, y: PNode) =
         body.add(newSeqCall(c.c, x, y))
       let i = declareCounter(c, body, firstOrd(t))
       let whileLoop = genWhileLoop(c, i, x)
-      let elemType = t.lastSon
+      let elemType = t.last
       liftBodyAux(c, elemType, whileLoop.sons[1], x.at(i, elemType),
                                                   y.at(i, elemType))
       addIncStmt(whileLoop.sons[1], i)
@@ -229,7 +229,7 @@ proc liftBodyAux(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     internalError(c.info, "assignment requested for type: " & typeToString(t))
   of tyOrdinal, tyRange,
      tyGenericInst, tyFieldAccessor, tyStatic, tyVar:
-    liftBodyAux(c, lastSon(t), body, x, y)
+    liftBodyAux(c, last(t), body, x, y)
 
 proc newProcType(info: TLineInfo; owner: PSym): PType =
   result = newType(tyProc, owner)

--- a/compiler/semasgn.nim
+++ b/compiler/semasgn.nim
@@ -73,7 +73,7 @@ proc liftBodyObj(c: var TLiftCtx; n, body, x, y: PNode) =
 
 proc genAddr(c: PContext; x: PNode): PNode =
   if x.kind == nkHiddenDeref:
-    checkSonsLen(x, 1)
+    checkLen(x, 1)
     result = x.sons[0]
   else:
     result = newNodeIT(nkHiddenAddr, x.info, makeVarType(c, x.typ))

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -356,9 +356,9 @@ proc semResolvedCall(c: PContext, n: PNode, x: TCandidate): PNode =
       for s in instantiateGenericParamList(c, gp, x.bindings):
         case s.kind
         of skConst:
-          x.call.addSon(s.ast)
+          x.call.add(s.ast)
         of skType:
-          x.call.addSon(newSymNode(s, n.info))
+          x.call.add(newSymNode(s, n.info))
         else:
           internalAssert false
 
@@ -374,7 +374,7 @@ proc canDeref(n: PNode): bool {.inline.} =
 proc tryDeref(n: PNode): PNode =
   result = newNodeI(nkHiddenDeref, n.info)
   result.typ = n.typ.skipTypes(abstractInst).sons[0]
-  result.addSon(n)
+  result.add(n)
 
 proc semOverloadedCall(c: PContext, n, nOrig: PNode,
                        filter: TSymKinds): PNode =
@@ -443,7 +443,7 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
         # type parameters:
         if safeLen(candidate.ast.sons[genericParamsPos]) == n.len-1:
           let x = explicitGenericSym(c, n, candidate)
-          if x != nil: result.addSon(x)
+          if x != nil: result.add(x)
     # get rid of nkClosedSymChoice if not ambiguous:
     if result.len == 1 and a.kind == nkClosedSymChoice:
       result = result[0]
@@ -466,7 +466,7 @@ proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
     var x: PType
     if param.typ.kind == tyVar:
       x = newTypeS(tyVar, c)
-      x.addSonSkipIntLit t.baseOfDistinct
+      x.addSkipIntLit t.baseOfDistinct
     else:
       x = t.baseOfDistinct
     call.sons[i] = newNodeIT(nkEmpty, fn.info, x)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -356,9 +356,9 @@ proc semResolvedCall(c: PContext, n: PNode, x: TCandidate): PNode =
       for s in instantiateGenericParamList(c, gp, x.bindings):
         case s.kind
         of skConst:
-          x.call.add s.ast
+          x.call.addSon(s.ast)
         of skType:
-          x.call.add newSymNode(s, n.info)
+          x.call.addSon(newSymNode(s, n.info))
         else:
           internalAssert false
 
@@ -443,7 +443,7 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
         # type parameters:
         if safeLen(candidate.ast.sons[genericParamsPos]) == n.len-1:
           let x = explicitGenericSym(c, n, candidate)
-          if x != nil: result.add(x)
+          if x != nil: result.addSon(x)
     # get rid of nkClosedSymChoice if not ambiguous:
     if result.len == 1 and a.kind == nkClosedSymChoice:
       result = result[0]
@@ -458,7 +458,7 @@ proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
   # and use the overloading resolution mechanism:
   var call = newNodeI(nkCall, fn.info)
   var hasDistinct = false
-  call.add(newIdentNode(fn.name, fn.info))
+  call.addSon(newIdentNode(fn.name, fn.info))
   for i in 1.. <fn.typ.n.len:
     let param = fn.typ.n.sons[i]
     let t = skipTypes(param.typ, abstractVar-{tyTypeDesc})
@@ -469,7 +469,7 @@ proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
       x.addSonSkipIntLit t.baseOfDistinct
     else:
       x = t.baseOfDistinct
-    call.add(newNodeIT(nkEmpty, fn.info, x))
+    call.addSon(newNodeIT(nkEmpty, fn.info, x))
   if hasDistinct:
     var resolved = semOverloadedCall(c, call, call, {fn.kind})
     if resolved != nil:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -13,8 +13,8 @@
 proc sameMethodDispatcher(a, b: PSym): bool =
   result = false
   if a.kind == skMethod and b.kind == skMethod:
-    var aa = lastSon(a.ast)
-    var bb = lastSon(b.ast)
+    var aa = last(a.ast)
+    var bb = last(b.ast)
     if aa.kind == nkSym and bb.kind == nkSym:
       if aa.sym == bb.sym:
         result = true

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -456,9 +456,9 @@ proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
   # for borrowing the sym in the symbol table is returned, else nil.
   # New approach: generate fn(x, y, z) where x, y, z have the proper types
   # and use the overloading resolution mechanism:
-  var call = newNodeI(nkCall, fn.info)
+  var call = newNodeI(nkCall, fn.info, fn.typ.n.len)
   var hasDistinct = false
-  call.addSon(newIdentNode(fn.name, fn.info))
+  call.sons[0] = newIdentNode(fn.name, fn.info)
   for i in 1.. <fn.typ.n.len:
     let param = fn.typ.n.sons[i]
     let t = skipTypes(param.typ, abstractVar-{tyTypeDesc})
@@ -469,7 +469,7 @@ proc searchForBorrowProc(c: PContext, startScope: PScope, fn: PSym): PSym =
       x.addSonSkipIntLit t.baseOfDistinct
     else:
       x = t.baseOfDistinct
-    call.addSon(newNodeIT(nkEmpty, fn.info, x))
+    call.sons[i] = newNodeIT(nkEmpty, fn.info, x)
   if hasDistinct:
     var resolved = semOverloadedCall(c, call, call, {fn.kind})
     if resolved != nil:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -218,7 +218,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       else: return
 
     if nfDotField in n.flags:
-      internalAssert f.kind == nkIdent and n.sonsLen >= 2
+      internalAssert f.kind == nkIdent and n.len >= 2
       let calleeName = newStrNode(nkStrLit, f.ident.s).withInfo(n.info)
 
       # leave the op head symbol empty,
@@ -239,7 +239,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
         tryOp "."
 
     elif nfDotSetter in n.flags:
-      internalAssert f.kind == nkIdent and n.sonsLen == 3
+      internalAssert f.kind == nkIdent and n.len == 3
       let calleeName = newStrNode(nkStrLit,
         f.ident.s[0..f.ident.s.len-2]).withInfo(n.info)
       let callOp = newIdentNode(getIdent".=", n.info)
@@ -279,7 +279,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
     elif gErrorCounter == 0:
       # don't cascade errors
       var args = "("
-      for i in countup(1, sonsLen(n) - 1):
+      for i in countup(1, len(n) - 1):
         if i > 1: add(args, ", ")
         add(args, typeToString(n.sons[i].typ))
       add(args, ")")
@@ -404,7 +404,7 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
   # binding has to stay 'nil' for this to work!
   initCandidate(c, m, s, nil)
 
-  for i in 1..sonsLen(n)-1:
+  for i in 1..len(n)-1:
     let formal = s.ast.sons[genericParamsPos].sons[i-1].typ
     let arg = n[i].typ
     let tm = typeRel(m, formal, arg, true)
@@ -416,7 +416,7 @@ proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
 
 proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
   assert n.kind == nkBracketExpr
-  for i in 1..sonsLen(n)-1:
+  for i in 1..len(n)-1:
     n.sons[i].typ = semTypeNode(c, n.sons[i], nil)
   var s = s
   var a = n.sons[0]

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -320,10 +320,10 @@ proc illFormedAst*(n: PNode) =
 proc illFormedAstLocal*(n: PNode) =
   localError(n.info, errIllFormedAstX, renderTree(n, {renderNoComments}))
 
-proc checkSonsLen*(n: PNode, length: int) =
+proc checkLen*(n: PNode, length: int) =
   if sonsLen(n) != length: illFormedAst(n)
 
-proc checkMinSonsLen*(n: PNode, length: int) =
+proc checkMinLen*(n: PNode, length: int) =
   if sonsLen(n) < length: illFormedAst(n)
 
 proc isTopLevel*(c: PContext): bool {.inline.} =

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -207,18 +207,18 @@ proc addToLib(lib: PLib, sym: PSym) =
 
 proc makePtrType(c: PContext, baseType: PType): PType =
   result = newTypeS(tyPtr, c)
-  addSonSkipIntLit(result, baseType.assertNotNil)
+  addSkipIntLit(result, baseType.assertNotNil)
 
 proc makeVarType*(c: PContext, baseType: PType): PType =
   if baseType.kind == tyVar:
     result = baseType
   else:
     result = newTypeS(tyVar, c)
-    addSonSkipIntLit(result, baseType.assertNotNil)
+    addSkipIntLit(result, baseType.assertNotNil)
 
 proc makeTypeDesc*(c: PContext, typ: PType): PType =
   result = newTypeS(tyTypeDesc, c)
-  result.addSonSkipIntLit(typ.assertNotNil)
+  result.addSkipIntLit(typ.assertNotNil)
 
 proc makeTypeSymNode*(c: PContext, typ: PType, info: TLineInfo): PNode =
   let typedesc = makeTypeDesc(c, typ)
@@ -303,11 +303,11 @@ proc fillTypeS(dest: PType, kind: TTypeKind, c: PContext) =
 proc makeRangeType*(c: PContext; first, last: BiggestInt;
                     info: TLineInfo; intType = getSysType(tyInt)): PType =
   var n = newNodeI(nkRange, info)
-  addSon(n, newIntTypeNode(nkIntLit, first, intType))
-  addSon(n, newIntTypeNode(nkIntLit, last, intType))
+  add(n, newIntTypeNode(nkIntLit, first, intType))
+  add(n, newIntTypeNode(nkIntLit, last, intType))
   result = newTypeS(tyRange, c)
   result.n = n
-  addSonSkipIntLit(result, intType) # basetype of range
+  addSkipIntLit(result, intType) # basetype of range
 
 proc markIndirect*(c: PContext, s: PSym) {.inline.} =
   if s.kind in {skProc, skConverter, skMethod, skIterator}:

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -321,10 +321,10 @@ proc illFormedAstLocal*(n: PNode) =
   localError(n.info, errIllFormedAstX, renderTree(n, {renderNoComments}))
 
 proc checkLen*(n: PNode, length: int) =
-  if sonsLen(n) != length: illFormedAst(n)
+  if len(n) != length: illFormedAst(n)
 
 proc checkMinLen*(n: PNode, length: int) =
-  if sonsLen(n) < length: illFormedAst(n)
+  if len(n) < length: illFormedAst(n)
 
 proc isTopLevel*(c: PContext): bool {.inline.} =
   result = c.currentScope.depthLevel <= 2

--- a/compiler/semdestruct.nim
+++ b/compiler/semdestruct.nim
@@ -30,7 +30,7 @@ proc instantiateDestructor(c: PContext, typ: PType): PType
 proc doDestructorStuff(c: PContext, s: PSym, n: PNode) =
   var t = s.typ.sons[1].skipTypes({tyVar})
   if t.kind == tyGenericInvocation:
-    for i in 1 .. <t.sonsLen:
+    for i in 1 .. <t.len:
       if t.sons[i].kind != tyGenericParam:
         localError(n.info, errDestructorNotGenericEnough)
         return
@@ -44,7 +44,7 @@ proc doDestructorStuff(c: PContext, s: PSym, n: PNode) =
   t.destructor = s
   # automatically insert calls to base classes' destructors
   if n.sons[bodyPos].kind != nkEmpty:
-    for i in countup(0, t.sonsLen - 1):
+    for i in countup(0, t.len - 1):
       # when inheriting directly from object
       # there will be a single nil son
       if t.sons[i] == nil: continue
@@ -202,7 +202,7 @@ proc insertDestructors(c: PContext,
   # `outer` is a statement list that should replace the original var section.
   # It will include the new truncated var section followed by the outermost
   # try block.
-  let totalVars = varSection.sonsLen
+  let totalVars = varSection.len
   for j in countup(0, totalVars - 1):
     let
       varId = varSection[j][0]

--- a/compiler/semdestruct.nim
+++ b/compiler/semdestruct.nim
@@ -73,7 +73,7 @@ proc destroyCase(c: PContext, n: PNode, holder: PNode): PNode =
     let ni = n[i]
     var caseBranch = newNode(ni.kind, ni.info, ni.sons[0..ni.len-2])
 
-    let stmt = destroyFieldOrFields(c, ni.lastSon, holder)
+    let stmt = destroyFieldOrFields(c, ni.last, holder)
     if stmt == nil:
       caseBranch.add(newNode(nkStmtList, ni.info, @[]))
     else:

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -38,12 +38,12 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
         var tupl = call.sons[i+1-ord(c.replaceByFieldName)]
         if c.field.isNil:
           result = newNodeI(nkBracketExpr, n.info)
-          result.add(tupl)
-          result.add(newIntNode(nkIntLit, c.tupleIndex))
+          result.addSon(tupl)
+          result.addSon(newIntNode(nkIntLit, c.tupleIndex))
         else:
           result = newNodeI(nkDotExpr, n.info)
-          result.add(tupl)
-          result.add(newSymNode(c.field, n.info))
+          result.addSon(tupl)
+          result.addSon(newSymNode(c.field, n.info))
         break
   else:
     if n.kind == nkContinueStmt:
@@ -68,7 +68,7 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
     openScope(c.c)
     inc c.c.inUnrolledContext
     let body = instFieldLoopBody(fc, lastSon(forLoop), forLoop)
-    father.add(semStmt(c.c, body))
+    father.addSon(semStmt(c.c, body))
     dec c.c.inUnrolledContext
     closeScope(c.c)
   of nkNilLit: discard
@@ -87,15 +87,15 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
     var access = newNodeI(nkDotExpr, forLoop.info, 2)
     access.sons[0] = call.sons[1]
     access.sons[1] = newSymNode(typ.sons[0].sym, forLoop.info)
-    caseStmt.add(semExprWithType(c.c, access))
+    caseStmt.addSon(semExprWithType(c.c, access))
     # copy the branches over, but replace the fields with the for loop body:
     for i in 1 .. <typ.len:
       var branch = copyTree(typ[i])
       let L = branch.len
       branch.sons[L-1] = newNodeI(nkStmtList, forLoop.info)
       semForObjectFields(c, typ[i].lastSon, forLoop, branch[L-1])
-      caseStmt.add(branch)
-    father.add(caseStmt)
+      caseStmt.addSon(branch)
+    father.addSon(caseStmt)
   of nkRecList:
     for t in items(typ): semForObjectFields(c, t, forLoop, father)
   else:
@@ -141,7 +141,7 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
       fc.replaceByFieldName = m == mFieldPairs
       var body = instFieldLoopBody(fc, loopBody, n)
       inc c.inUnrolledContext
-      stmts.add(semStmt(c, body))
+      stmts.addSon(semStmt(c, body))
       dec c.inUnrolledContext
       closeScope(c)
   else:
@@ -158,7 +158,7 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
   # we avoid it now if we can:
   if containsNode(stmts, {nkBreakStmt}):
     var b = newNodeI(nkBreakStmt, n.info)
-    b.add(ast.emptyNode)
-    stmts.add(b)
+    b.addSon(ast.emptyNode)
+    stmts.addSon(b)
   else:
     result = stmts

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -68,7 +68,7 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
     openScope(c.c)
     inc c.c.inUnrolledContext
     let body = instFieldLoopBody(fc, lastSon(forLoop), forLoop)
-    father.addSon(semStmt(c.c, body))
+    father.add(semStmt(c.c, body))
     dec c.c.inUnrolledContext
     closeScope(c.c)
   of nkNilLit: discard
@@ -95,7 +95,7 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
       branch.sons[L-1] = newNodeI(nkStmtList, forLoop.info)
       semForObjectFields(c, typ[i].lastSon, forLoop, branch[L-1])
       caseStmt.sons[i] = branch
-    father.addSon(caseStmt)
+    father.add(caseStmt)
   of nkRecList:
     for t in items(typ): semForObjectFields(c, t, forLoop, father)
   else:
@@ -159,7 +159,7 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
   # we avoid it now if we can:
   if containsNode(stmts, {nkBreakStmt}):
     var b = newNodeI(nkBreakStmt, n.info)
-    b.addSon(ast.emptyNode)
-    stmts.addSon(b)
+    b.add(ast.emptyNode)
+    stmts.add(b)
   else:
     result = stmts

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -23,7 +23,7 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
   of nkIdent, nkSym:
     result = n
     let ident = considerQuotedIdent(n)
-    var L = sonsLen(forLoop)
+    var L = len(forLoop)
     if c.replaceByFieldName:
       if ident.id == considerQuotedIdent(forLoop[0]).id:
         let fieldName = if c.tupleType.isNil: c.field.name.s
@@ -50,8 +50,8 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
       localError(n.info, errGenerated,
                  "'continue' not supported in a 'fields' loop")
     result = copyNode(n)
-    newSons(result, sonsLen(n))
-    for i in countup(0, sonsLen(n)-1):
+    newSons(result, len(n))
+    for i in countup(0, len(n)-1):
       result.sons[i] = instFieldLoopBody(c, n.sons[i], forLoop)
 
 type
@@ -115,9 +115,9 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
   var stmts = newNodeI(nkStmtList, n.info)
   result.sons[1] = stmts
 
-  var length = sonsLen(n)
+  var length = len(n)
   var call = n.sons[length-2]
-  if length-2 != sonsLen(call)-1 + ord(m==mFieldPairs):
+  if length-2 != len(call)-1 + ord(m==mFieldPairs):
     localError(n.info, errWrongNumberOfVariables)
     return result
 
@@ -133,8 +133,8 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
   inc(c.p.nestedLoopCounter)
   if tupleTypeA.kind == tyTuple:
     var loopBody = n.sons[length-1]
-    stmts.sons = newSeq[PNode](sonsLen(tupleTypeA))
-    for i in 0 .. <sonsLen(tupleTypeA):
+    stmts.sons = newSeq[PNode](len(tupleTypeA))
+    for i in 0 .. <len(tupleTypeA):
       openScope(c)
       var fc: TFieldInstCtx
       fc.tupleType = tupleTypeA

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -67,7 +67,7 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
     fc.replaceByFieldName = c.m == mFieldPairs
     openScope(c.c)
     inc c.c.inUnrolledContext
-    let body = instFieldLoopBody(fc, lastSon(forLoop), forLoop)
+    let body = instFieldLoopBody(fc, last(forLoop), forLoop)
     father.add(semStmt(c.c, body))
     dec c.c.inUnrolledContext
     closeScope(c.c)
@@ -93,7 +93,7 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
       var branch = copyTree(typ[i])
       let L = branch.len
       branch.sons[L-1] = newNodeI(nkStmtList, forLoop.info)
-      semForObjectFields(c, typ[i].lastSon, forLoop, branch[L-1])
+      semForObjectFields(c, typ[i].last, forLoop, branch[L-1])
       caseStmt.sons[i] = branch
     father.add(caseStmt)
   of nkRecList:

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -123,19 +123,19 @@ proc makeRange(typ: PType, first, last: BiggestInt): PType =
     result = typ
   else:
     var n = newNode(nkRange)
-    addSon(n, lowerNode)
-    addSon(n, newIntNode(nkIntLit, maxA))
+    add(n, lowerNode)
+    add(n, newIntNode(nkIntLit, maxA))
     result = newType(tyRange, typ.owner)
     result.n = n
-    addSonSkipIntLit(result, skipTypes(typ, {tyRange}))
+    addSkipIntLit(result, skipTypes(typ, {tyRange}))
 
 proc makeRangeF(typ: PType, first, last: BiggestFloat): PType =
   var n = newNode(nkRange)
-  addSon(n, newFloatNode(nkFloatLit, min(first.float, last.float)))
-  addSon(n, newFloatNode(nkFloatLit, max(first.float, last.float)))
+  add(n, newFloatNode(nkFloatLit, min(first.float, last.float)))
+  add(n, newFloatNode(nkFloatLit, max(first.float, last.float)))
   result = newType(tyRange, typ.owner)
   result.n = n
-  addSonSkipIntLit(result, skipTypes(typ, {tyRange}))
+  addSkipIntLit(result, skipTypes(typ, {tyRange}))
 
 proc getIntervalType*(m: TMagic, n: PNode): PType =
   # Nim requires interval arithmetic for ``range`` types. Lots of tedious
@@ -594,7 +594,7 @@ proc foldConStrStr(m: PSym, n: PNode): PNode =
 proc newSymNodeTypeDesc*(s: PSym; info: TLineInfo): PNode =
   result = newSymNode(s, info)
   result.typ = newType(tyTypeDesc, s.owner)
-  result.typ.addSonSkipIntLit(s.typ)
+  result.typ.addSkipIntLit(s.typ)
 
 proc getConstExpr(m: PSym, n: PNode): PNode =
   result = nil
@@ -716,8 +716,8 @@ proc getConstExpr(m: PSym, n: PNode): PNode =
     var b = getConstExpr(m, n.sons[1])
     if b == nil: return
     result = copyNode(n)
-    addSon(result, a)
-    addSon(result, b)
+    add(result, a)
+    add(result, b)
   of nkCurly:
     result = copyTree(n)
     for i in countup(0, sonsLen(n) - 1):

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -119,8 +119,8 @@ proc lookup(c: PContext, n: PNode, flags: TSemGenericFlags,
 
 proc newDot(n, b: PNode): PNode =
   result = newNodeI(nkDotExpr, n.info)
-  result.add(n.sons[0])
-  result.add(b)
+  result.addSon(n.sons[0])
+  result.addSon(b)
 
 proc fuzzyLookup(c: PContext, n: PNode, flags: TSemGenericFlags,
                  ctx: var GenericCtx; isMacro: var bool): PNode =
@@ -235,7 +235,7 @@ proc semGenericStmt(c: PContext, n: PNode,
         # do not check of 's.magic==mRoof' here because it might be some
         # other '^' but after overload resolution the proper one:
         if ctx.bracketExpr != nil and n.len == 2 and s.name.s == "^":
-          result.add ctx.bracketExpr
+          result.addSon(ctx.bracketExpr)
         first = 1
       of skGenericParam:
         result.sons[0] = newSymNodeTypeDesc(s, fn.info)
@@ -262,13 +262,13 @@ proc semGenericStmt(c: PContext, n: PNode,
       result.sons[i] = semGenericStmt(c, result.sons[i], flags, ctx)
   of nkCurlyExpr:
     result = newNodeI(nkCall, n.info)
-    result.add newIdentNode(getIdent("{}"), n.info)
-    for i in 0 ..< n.len: result.add(n[i])
+    result.addSon(newIdentNode(getIdent("{}"), n.info))
+    for i in 0 ..< n.len: result.addSon(n[i])
     result = semGenericStmt(c, result, flags, ctx)
   of nkBracketExpr:
     result = newNodeI(nkCall, n.info)
-    result.add newIdentNode(getIdent("[]"), n.info)
-    for i in 0 ..< n.len: result.add(n[i])
+    result.addSon(newIdentNode(getIdent("[]"), n.info))
+    for i in 0 ..< n.len: result.addSon(n[i])
     withBracketExpr ctx, n.sons[0]:
       result = semGenericStmt(c, result, flags, ctx)
   of nkAsgn, nkFastAsgn:
@@ -280,15 +280,15 @@ proc semGenericStmt(c: PContext, n: PNode,
     case k
     of nkCurlyExpr:
       result = newNodeI(nkCall, n.info)
-      result.add newIdentNode(getIdent("{}="), n.info)
-      for i in 0 ..< a.len: result.add(a[i])
-      result.add(b)
+      result.addSon(newIdentNode(getIdent("{}="), n.info))
+      for i in 0 ..< a.len: result.addSon(a[i])
+      result.addSon(b)
       result = semGenericStmt(c, result, flags, ctx)
     of nkBracketExpr:
       result = newNodeI(nkCall, n.info)
-      result.add newIdentNode(getIdent("[]="), n.info)
-      for i in 0 ..< a.len: result.add(a[i])
-      result.add(b)
+      result.addSon(newIdentNode(getIdent("[]="), n.info))
+      for i in 0 ..< a.len: result.addSon(a[i])
+      result.addSon(b)
       withBracketExpr ctx, a.sons[0]:
         result = semGenericStmt(c, result, flags, ctx)
     else:

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -258,7 +258,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     # in threads.nim: the subtle preprocessing here binds 'globalsSlot' which
     # is not exported and yet the generic 'threadProcWrapper' works correctly.
     let flags = if mixinContext: flags+{withinMixin} else: flags
-    for i in countup(first, sonsLen(result) - 1):
+    for i in countup(first, len(result) - 1):
       result.sons[i] = semGenericStmt(c, result.sons[i], flags, ctx)
   of nkCurlyExpr:
     result = newNodeI(nkCall, n.info, n.len + 1)
@@ -292,32 +292,32 @@ proc semGenericStmt(c: PContext, n: PNode,
       withBracketExpr ctx, a.sons[0]:
         result = semGenericStmt(c, result, flags, ctx)
     else:
-      for i in countup(0, sonsLen(n) - 1):
+      for i in countup(0, len(n) - 1):
         result.sons[i] = semGenericStmt(c, n.sons[i], flags, ctx)
   of nkIfStmt:
-    for i in countup(0, sonsLen(n)-1):
+    for i in countup(0, len(n)-1):
       n.sons[i] = semGenericStmtScope(c, n.sons[i], flags, ctx)
   of nkWhenStmt:
-    for i in countup(0, sonsLen(n)-1):
+    for i in countup(0, len(n)-1):
       n.sons[i] = semGenericStmt(c, n.sons[i], flags+{withinMixin}, ctx)
   of nkWhileStmt:
     openScope(c)
-    for i in countup(0, sonsLen(n)-1):
+    for i in countup(0, len(n)-1):
       n.sons[i] = semGenericStmt(c, n.sons[i], flags, ctx)
     closeScope(c)
   of nkCaseStmt:
     openScope(c)
     n.sons[0] = semGenericStmt(c, n.sons[0], flags, ctx)
-    for i in countup(1, sonsLen(n)-1):
+    for i in countup(1, len(n)-1):
       var a = n.sons[i]
       checkMinLen(a, 1)
-      var L = sonsLen(a)
+      var L = len(a)
       for j in countup(0, L-2):
         a.sons[j] = semGenericStmt(c, a.sons[j], flags, ctx)
       a.sons[L - 1] = semGenericStmtScope(c, a.sons[L-1], flags, ctx)
     closeScope(c)
   of nkForStmt, nkParForStmt:
-    var L = sonsLen(n)
+    var L = len(n)
     openScope(c)
     n.sons[L - 2] = semGenericStmt(c, n.sons[L-2], flags, ctx)
     for i in countup(0, L - 3):
@@ -334,36 +334,36 @@ proc semGenericStmt(c: PContext, n: PNode,
   of nkTryStmt:
     checkMinLen(n, 2)
     n.sons[0] = semGenericStmtScope(c, n.sons[0], flags, ctx)
-    for i in countup(1, sonsLen(n)-1):
+    for i in countup(1, len(n)-1):
       var a = n.sons[i]
       checkMinLen(a, 1)
-      var L = sonsLen(a)
+      var L = len(a)
       for j in countup(0, L-2):
         a.sons[j] = semGenericStmt(c, a.sons[j], flags+{withinTypeDesc}, ctx)
       a.sons[L-1] = semGenericStmtScope(c, a.sons[L-1], flags, ctx)
   of nkVarSection, nkLetSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkIdentDefs) and (a.kind != nkVarTuple): illFormedAst(a)
       checkMinLen(a, 3)
-      var L = sonsLen(a)
+      var L = len(a)
       a.sons[L-2] = semGenericStmt(c, a.sons[L-2], flags+{withinTypeDesc}, ctx)
       a.sons[L-1] = semGenericStmt(c, a.sons[L-1], flags, ctx)
       for j in countup(0, L-3):
         addTempDecl(c, getIdentNode(a.sons[j]), skVar)
   of nkGenericParams:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if (a.kind != nkIdentDefs): illFormedAst(a)
       checkMinLen(a, 3)
-      var L = sonsLen(a)
+      var L = len(a)
       a.sons[L-2] = semGenericStmt(c, a.sons[L-2], flags+{withinTypeDesc}, ctx)
       # do not perform symbol lookup for default expressions
       for j in countup(0, L-3):
         addTempDecl(c, getIdentNode(a.sons[j]), skType)
   of nkConstSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkConstDef): illFormedAst(a)
@@ -372,13 +372,13 @@ proc semGenericStmt(c: PContext, n: PNode,
       a.sons[1] = semGenericStmt(c, a.sons[1], flags+{withinTypeDesc}, ctx)
       a.sons[2] = semGenericStmt(c, a.sons[2], flags, ctx)
   of nkTypeSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
       checkLen(a, 3)
       addTempDecl(c, getIdentNode(a.sons[0]), skType)
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
@@ -391,10 +391,10 @@ proc semGenericStmt(c: PContext, n: PNode,
       else:
         a.sons[2] = semGenericStmt(c, a.sons[2], flags+{withinTypeDesc}, ctx)
   of nkEnumTy:
-    if n.sonsLen > 0:
+    if n.len > 0:
       if n.sons[0].kind != nkEmpty:
         n.sons[0] = semGenericStmt(c, n.sons[0], flags+{withinTypeDesc}, ctx)
-      for i in countup(1, sonsLen(n) - 1):
+      for i in countup(1, len(n) - 1):
         var a: PNode
         case n.sons[i].kind
         of nkEnumFieldDef: a = n.sons[i].sons[0]
@@ -407,11 +407,11 @@ proc semGenericStmt(c: PContext, n: PNode,
     checkMinLen(n, 1)
     if n.sons[0].kind != nkEmpty:
       n.sons[0] = semGenericStmt(c, n.sons[0], flags+{withinTypeDesc}, ctx)
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       var a = n.sons[i]
       if (a.kind != nkIdentDefs): illFormedAst(a)
       checkMinLen(a, 3)
-      var L = sonsLen(a)
+      var L = len(a)
       a.sons[L-2] = semGenericStmt(c, a.sons[L-2], flags+{withinTypeDesc}, ctx)
       a.sons[L-1] = semGenericStmt(c, a.sons[L-1], flags, ctx)
       for j in countup(0, L-3):
@@ -444,7 +444,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     checkMinLen(n, 2)
     result.sons[1] = semGenericStmt(c, n.sons[1], flags, ctx)
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result.sons[i] = semGenericStmt(c, n.sons[i], flags, ctx)
 
 proc semGenericStmt(c: PContext, n: PNode): PNode =

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -235,7 +235,7 @@ proc semGenericStmt(c: PContext, n: PNode,
         # do not check of 's.magic==mRoof' here because it might be some
         # other '^' but after overload resolution the proper one:
         if ctx.bracketExpr != nil and n.len == 2 and s.name.s == "^":
-          result.addSon(ctx.bracketExpr)
+          result.add(ctx.bracketExpr)
         first = 1
       of skGenericParam:
         result.sons[0] = newSymNodeTypeDesc(s, fn.info)

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -189,7 +189,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     result = semMixinStmt(c, n, ctx.toMixin)
   of nkCall, nkHiddenCallConv, nkInfix, nkPrefix, nkCommand, nkCallStrLit:
     # check if it is an expression macro:
-    checkMinSonsLen(n, 1)
+    checkMinLen(n, 1)
     let fn = n.sons[0]
     var s = qualifiedLookUp(c, fn, {})
     if s == nil and withinMixin notin flags and
@@ -272,7 +272,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     withBracketExpr ctx, n.sons[0]:
       result = semGenericStmt(c, result, flags, ctx)
   of nkAsgn, nkFastAsgn:
-    checkSonsLen(n, 2)
+    checkLen(n, 2)
     let a = n.sons[0]
     let b = n.sons[1]
 
@@ -310,7 +310,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     n.sons[0] = semGenericStmt(c, n.sons[0], flags, ctx)
     for i in countup(1, sonsLen(n)-1):
       var a = n.sons[i]
-      checkMinSonsLen(a, 1)
+      checkMinLen(a, 1)
       var L = sonsLen(a)
       for j in countup(0, L-2):
         a.sons[j] = semGenericStmt(c, a.sons[j], flags, ctx)
@@ -325,18 +325,18 @@ proc semGenericStmt(c: PContext, n: PNode,
     n.sons[L - 1] = semGenericStmt(c, n.sons[L-1], flags, ctx)
     closeScope(c)
   of nkBlockStmt, nkBlockExpr, nkBlockType:
-    checkSonsLen(n, 2)
+    checkLen(n, 2)
     openScope(c)
     if n.sons[0].kind != nkEmpty:
       addTempDecl(c, n.sons[0], skLabel)
     n.sons[1] = semGenericStmt(c, n.sons[1], flags, ctx)
     closeScope(c)
   of nkTryStmt:
-    checkMinSonsLen(n, 2)
+    checkMinLen(n, 2)
     n.sons[0] = semGenericStmtScope(c, n.sons[0], flags, ctx)
     for i in countup(1, sonsLen(n)-1):
       var a = n.sons[i]
-      checkMinSonsLen(a, 1)
+      checkMinLen(a, 1)
       var L = sonsLen(a)
       for j in countup(0, L-2):
         a.sons[j] = semGenericStmt(c, a.sons[j], flags+{withinTypeDesc}, ctx)
@@ -346,7 +346,7 @@ proc semGenericStmt(c: PContext, n: PNode,
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkIdentDefs) and (a.kind != nkVarTuple): illFormedAst(a)
-      checkMinSonsLen(a, 3)
+      checkMinLen(a, 3)
       var L = sonsLen(a)
       a.sons[L-2] = semGenericStmt(c, a.sons[L-2], flags+{withinTypeDesc}, ctx)
       a.sons[L-1] = semGenericStmt(c, a.sons[L-1], flags, ctx)
@@ -356,7 +356,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     for i in countup(0, sonsLen(n) - 1):
       var a = n.sons[i]
       if (a.kind != nkIdentDefs): illFormedAst(a)
-      checkMinSonsLen(a, 3)
+      checkMinLen(a, 3)
       var L = sonsLen(a)
       a.sons[L-2] = semGenericStmt(c, a.sons[L-2], flags+{withinTypeDesc}, ctx)
       # do not perform symbol lookup for default expressions
@@ -367,7 +367,7 @@ proc semGenericStmt(c: PContext, n: PNode,
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkConstDef): illFormedAst(a)
-      checkSonsLen(a, 3)
+      checkLen(a, 3)
       addTempDecl(c, getIdentNode(a.sons[0]), skConst)
       a.sons[1] = semGenericStmt(c, a.sons[1], flags+{withinTypeDesc}, ctx)
       a.sons[2] = semGenericStmt(c, a.sons[2], flags, ctx)
@@ -376,13 +376,13 @@ proc semGenericStmt(c: PContext, n: PNode,
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
-      checkSonsLen(a, 3)
+      checkLen(a, 3)
       addTempDecl(c, getIdentNode(a.sons[0]), skType)
     for i in countup(0, sonsLen(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
-      checkSonsLen(a, 3)
+      checkLen(a, 3)
       if a.sons[1].kind != nkEmpty:
         openScope(c)
         a.sons[1] = semGenericStmt(c, a.sons[1], flags, ctx)
@@ -404,13 +404,13 @@ proc semGenericStmt(c: PContext, n: PNode,
   of nkObjectTy, nkTupleTy, nkTupleClassTy:
     discard
   of nkFormalParams:
-    checkMinSonsLen(n, 1)
+    checkMinLen(n, 1)
     if n.sons[0].kind != nkEmpty:
       n.sons[0] = semGenericStmt(c, n.sons[0], flags+{withinTypeDesc}, ctx)
     for i in countup(1, sonsLen(n) - 1):
       var a = n.sons[i]
       if (a.kind != nkIdentDefs): illFormedAst(a)
-      checkMinSonsLen(a, 3)
+      checkMinLen(a, 3)
       var L = sonsLen(a)
       a.sons[L-2] = semGenericStmt(c, a.sons[L-2], flags+{withinTypeDesc}, ctx)
       a.sons[L-1] = semGenericStmt(c, a.sons[L-1], flags, ctx)
@@ -418,7 +418,7 @@ proc semGenericStmt(c: PContext, n: PNode,
         addTempDecl(c, getIdentNode(a.sons[j]), skParam)
   of nkProcDef, nkMethodDef, nkConverterDef, nkMacroDef, nkTemplateDef,
      nkIteratorDef, nkLambdaKinds:
-    checkSonsLen(n, bodyPos + 1)
+    checkLen(n, bodyPos + 1)
     if n.sons[namePos].kind != nkEmpty:
       addTempDecl(c, getIdentNode(n.sons[0]), skProc)
     openScope(c)
@@ -441,7 +441,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     closeScope(c)
   of nkPragma, nkPragmaExpr: discard
   of nkExprColonExpr, nkExprEqExpr:
-    checkMinSonsLen(n, 2)
+    checkMinLen(n, 2)
     result.sons[1] = semGenericStmt(c, n.sons[1], flags, ctx)
   else:
     for i in countup(0, sonsLen(n) - 1):

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -19,7 +19,7 @@ proc addObjFieldsToLocalScope(c: PContext; n: PNode) =
   of nkRecCase:
     if n.len > 0: rec n.sons[0]
     for i in countup(1, len(n)-1):
-      if n[i].kind in {nkOfBranch, nkElse}: rec lastSon(n[i])
+      if n[i].kind in {nkOfBranch, nkElse}: rec last(n[i])
   of nkSym:
     let f = n.sym
     if f.kind == skField and fieldVisible(c, f):

--- a/compiler/semmacrosanity.nim
+++ b/compiler/semmacrosanity.nim
@@ -26,7 +26,7 @@ proc ithField(n: PNode, field: var int): PSym =
     for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
-        result = ithField(lastSon(n.sons[i]), field)
+        result = ithField(last(n.sons[i]), field)
         if result != nil: return
       else: internalError(n.info, "ithField(record case branch)")
   of nkSym:

--- a/compiler/semmacrosanity.nim
+++ b/compiler/semmacrosanity.nim
@@ -16,14 +16,14 @@ proc ithField(n: PNode, field: var int): PSym =
   result = nil
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result = ithField(n.sons[i], field)
       if result != nil: return
   of nkRecCase:
     if n.sons[0].kind != nkSym: internalError(n.info, "ithField")
     result = ithField(n.sons[0], field)
     if result != nil: return
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
         result = ithField(lastSon(n.sons[i]), field)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -102,7 +102,7 @@ proc evalTypeTrait(trait: PNode, operand: PType, context: PSym): PNode =
     internalAssert false
 
 proc semTypeTraits(c: PContext, n: PNode): PNode =
-  checkMinSonsLen(n, 2)
+  checkMinLen(n, 2)
   let t = n.sons[1].typ
   internalAssert t != nil and t.kind == tyTypeDesc
   if t.sonsLen > 0:
@@ -156,10 +156,10 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
                                    flags: TExprFlags): PNode =
   case n[0].sym.magic
   of mAddr:
-    checkSonsLen(n, 2)
+    checkLen(n, 2)
     result = semAddr(c, n.sons[1], n[0].sym.name.s == "unsafeAddr")
   of mTypeOf:
-    checkSonsLen(n, 2)
+    checkLen(n, 2)
     result = semTypeOf(c, n.sons[1])
   of mArrGet: result = semArrGet(c, n, flags)
   of mArrPut: result = semArrPut(c, n, flags)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -36,8 +36,8 @@ proc skipAddr(n: PNode): PNode {.inline.} =
   (if n.kind == nkHiddenAddr: n.sons[0] else: n)
 
 proc semArrGet(c: PContext; n: PNode; flags: TExprFlags): PNode =
-  result = newNodeI(nkBracketExpr, n.info)
-  for i in 1..<n.len: result.addSon(n[i])
+  result = newNodeI(nkBracketExpr, n.info, <n.len)
+  for i in 1..<n.len: result.sons[i - 1] = n[i]
   let oldBracketExpr = c.p.bracketExpr
   result = semSubscript(c, result, flags)
   c.p.bracketExpr = oldBracketExpr
@@ -50,9 +50,9 @@ proc semArrGet(c: PContext; n: PNode; flags: TExprFlags): PNode =
 
 proc semArrPut(c: PContext; n: PNode; flags: TExprFlags): PNode =
   # rewrite `[]=`(a, i, x)  back to ``a[i] = x``.
-  let b = newNodeI(nkBracketExpr, n.info)
-  b.addSon(n[1].skipAddr)
-  for i in 2..n.len-2: b.addSon(n[i])
+  let b = newNodeI(nkBracketExpr, n.info, n.len - 2)
+  b.sons[0] = n[1].skipAddr
+  for i in 2..n.len-2: b.sons[i - 1] = n[i]
   result = newNodeI(nkAsgn, n.info, 2)
   result.sons[0] = b
   result.sons[1] = n.lastSon
@@ -75,7 +75,8 @@ proc expectIntLit(c: PContext, n: PNode): int =
   else: localError(n.info, errIntLiteralExpected)
 
 proc semInstantiationInfo(c: PContext, n: PNode): PNode =
-  result = newNodeIT(nkPar, n.info, n.typ)
+  result = newNodeI(nkPar, n.info, 2)
+  result.typ = n.typ
   let idx = expectIntLit(c, n.sons[1])
   let useFullPaths = expectIntLit(c, n.sons[2])
   let info = getInfoContext(idx)
@@ -83,8 +84,8 @@ proc semInstantiationInfo(c: PContext, n: PNode): PNode =
   filename.strVal = if useFullPaths != 0: info.toFullPath else: info.toFilename
   var line = newNodeIT(nkIntLit, n.info, getSysType(tyInt))
   line.intVal = toLinenumber(info)
-  result.addSon(filename)
-  result.addSon(line)
+  result.sons[0] = filename
+  result.sons[1] = line
 
 proc evalTypeTrait(trait: PNode, operand: PType, context: PSym): PNode =
   let typ = operand.skipTypes({tyTypeDesc})
@@ -193,21 +194,22 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = n.sons[1]
     else:
       # ^x  is rewritten to: len(a)-x
-      let lenExpr = newNodeI(nkCall, n.info)
-      lenExpr.addSon(newIdentNode(getIdent"len", n.info))
-      lenExpr.addSon(bracketExpr)
+      let lenExpr = newNodeI(nkCall, n.info, 2)
+      lenExpr.sons[0] = newIdentNode(getIdent"len", n.info)
+      lenExpr.sons[1] = bracketExpr
       let lenExprB = semExprWithType(c, lenExpr)
       if lenExprB.typ.isNil or not isOrdinalType(lenExprB.typ):
         localError(n.info, "'$#' has to be of an ordinal type for '^'" %
           renderTree(lenExpr))
         result = n.sons[1]
       else:
-        result = newNodeIT(nkCall, n.info, getSysType(tyInt))
+        result = newNodeI(nkCall, n.info, 3)
+        result.typ = getSysType(tyInt)
         let subi = getSysMagic("-", mSubI)
         #echo "got ", typeToString(subi.typ)
-        result.addSon(newSymNode(subi, n.info))
-        result.addSon(lenExprB)
-        result.addSon(n.sons[1])
+        result.sons[0] = newSymNode(subi, n.info)
+        result.sons[1] = lenExprB
+        result.sons[2] = n.sons[1]
   of mPlugin:
     let plugin = getPlugin(n[0].sym)
     if plugin.isNil:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -105,7 +105,7 @@ proc semTypeTraits(c: PContext, n: PNode): PNode =
   checkMinLen(n, 2)
   let t = n.sons[1].typ
   internalAssert t != nil and t.kind == tyTypeDesc
-  if t.sonsLen > 0:
+  if t.len > 0:
     # This is either a type known to sem or a typedesc
     # param to a regular proc (again, known at instantiation)
     result = evalTypeTrait(n[0], t, getCurrOwner())

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -17,13 +17,13 @@ proc semAddr(c: PContext; n: PNode; isUnsafeAddr=false): PNode =
     x.sym.flags.incl(sfAddrTaken)
   if isAssignable(c, x, isUnsafeAddr) notin {arLValue, arLocalLValue}:
     localError(n.info, errExprHasNoAddress)
-  result.addSon(x)
+  result.add(x)
   result.typ = makePtrType(c, x.typ)
 
 proc semTypeOf(c: PContext; n: PNode): PNode =
   result = newNodeI(nkTypeOfExpr, n.info)
   let typExpr = semExprWithType(c, n, {efInTypeof})
-  result.addSon(typExpr)
+  result.add(typExpr)
   result.typ = makeTypeDesc(c, typExpr.typ.skipTypes({tyTypeDesc, tyIter}))
 
 type
@@ -124,7 +124,7 @@ proc semOrd(c: PContext, n: PNode): PNode =
 
 proc semBindSym(c: PContext, n: PNode): PNode =
   result = copyNode(n)
-  result.addSon(n.sons[0])
+  result.add(n.sons[0])
 
   let sl = semConstExpr(c, n.sons[1])
   if sl.kind notin {nkStrLit, nkRStrLit, nkTripleStrLit}:
@@ -142,7 +142,7 @@ proc semBindSym(c: PContext, n: PNode): PNode =
   if s != nil:
     # we need to mark all symbols:
     var sc = symChoice(c, id, s, TSymChoiceRule(isMixin.intVal))
-    result.addSon(sc)
+    result.add(sc)
   else:
     localError(n.sons[1].info, errUndeclaredIdentifier, sl.strVal)
 

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -55,7 +55,7 @@ proc semArrPut(c: PContext; n: PNode; flags: TExprFlags): PNode =
   for i in 2..n.len-2: b.sons[i - 1] = n[i]
   result = newNodeI(nkAsgn, n.info, 2)
   result.sons[0] = b
-  result.sons[1] = n.lastSon
+  result.sons[1] = n.last
   result = semAsgn(c, result, noOverloadedSubscript)
 
 proc semAsgnOpr(c: PContext; n: PNode): PNode =

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -353,7 +353,7 @@ proc analyse(c: var AnalysisCtx; n: PNode) =
     # or maybe we should generate a 'try' XXX
   of nkVarSection, nkLetSection:
     for it in n:
-      let value = it.lastSon
+      let value = it.last
       let isSpawned = getMagic(value) == mSpawn
       if isSpawned:
         pushSpawnId(c):
@@ -424,7 +424,7 @@ proc transformSpawn(owner: PSym; n, barrier: PNode): PNode =
   of nkVarSection, nkLetSection:
     result = nil
     for it in n:
-      let b = it.lastSon
+      let b = it.last
       if getMagic(b) == mSpawn:
         if it.len != 3: localError(it.info, "invalid context for 'spawn'")
         let m = transformSlices(b)
@@ -471,7 +471,7 @@ proc liftParallel*(owner: PSym; n: PNode): PNode =
   #echo "PAR ", renderTree(n)
 
   var a = initAnalysisCtx()
-  let body = n.lastSon
+  let body = n.last
   analyse(a, body)
   if a.spawns == 0:
     localError(n.info, "'parallel' section without 'spawn'")

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -399,11 +399,11 @@ proc transformSlices(n: PNode): PNode =
       result = copyNode(n)
       let opSlice = newSymNode(createMagic("slice", mSlice))
       opSlice.typ = getSysType(tyInt)
-      result.add opSlice
-      result.add n[1]
+      result.addSon(opSlice)
+      result.addSon(n[1])
       let slice = n[2].skipStmtList
-      result.add slice[1]
-      result.add slice[2]
+      result.addSon(slice[1])
+      result.addSon(slice[2])
       return result
   if n.safeLen > 0:
     result = shallowCopy(n)
@@ -429,10 +429,10 @@ proc transformSpawn(owner: PSym; n, barrier: PNode): PNode =
         let m = transformSlices(b)
         if result.isNil:
           result = newNodeI(nkStmtList, n.info)
-          result.add n
+          result.addSon(n)
         let t = b[1][0].typ.sons[0]
         if spawnResult(t, true) == srByVar:
-          result.add wrapProcForSpawn(owner, m, b.typ, barrier, it[0])
+          result.addSon(wrapProcForSpawn(owner, m, b.typ, barrier, it[0]))
           it.sons[it.len-1] = emptyNode
         else:
           it.sons[it.len-1] = wrapProcForSpawn(owner, m, b.typ, barrier, nil)
@@ -487,7 +487,7 @@ proc liftParallel*(owner: PSym; n: PNode): PNode =
   let barrier = genAddrOf(tempNode)
   result = newNodeI(nkStmtList, n.info)
   generateAliasChecks(a, result)
-  result.add varSection
-  result.add callCodegenProc("openBarrier", barrier)
-  result.add transformSpawn(owner, body, barrier)
-  result.add callCodegenProc("closeBarrier", barrier)
+  result.addSon(varSection)
+  result.addSon(callCodegenProc("openBarrier", barrier))
+  result.addSon(transformSpawn(owner, body, barrier))
+  result.addSon(callCodegenProc("closeBarrier", barrier))

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -430,10 +430,10 @@ proc transformSpawn(owner: PSym; n, barrier: PNode): PNode =
         let m = transformSlices(b)
         if result.isNil:
           result = newNodeI(nkStmtList, n.info)
-          result.addSon(n)
+          result.add(n)
         let t = b[1][0].typ.sons[0]
         if spawnResult(t, true) == srByVar:
-          result.addSon(wrapProcForSpawn(owner, m, b.typ, barrier, it[0]))
+          result.add(wrapProcForSpawn(owner, m, b.typ, barrier, it[0]))
           it.sons[it.len-1] = emptyNode
         else:
           it.sons[it.len-1] = wrapProcForSpawn(owner, m, b.typ, barrier, nil)

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -399,11 +399,12 @@ proc transformSlices(n: PNode): PNode =
       result = copyNode(n)
       let opSlice = newSymNode(createMagic("slice", mSlice))
       opSlice.typ = getSysType(tyInt)
-      result.addSon(opSlice)
-      result.addSon(n[1])
+      result.sons = newSeq[PNode](4)
+      result.sons[0] = opSlice
+      result.sons[1] = n[1]
       let slice = n[2].skipStmtList
-      result.addSon(slice[1])
-      result.addSon(slice[2])
+      result.sons[2] = slice[1]
+      result.sons[3] = slice[2]
       return result
   if n.safeLen > 0:
     result = shallowCopy(n)
@@ -485,9 +486,9 @@ proc liftParallel*(owner: PSym; n: PNode): PNode =
   varSection.addVar tempNode
 
   let barrier = genAddrOf(tempNode)
-  result = newNodeI(nkStmtList, n.info)
+  result = newNodeI(nkStmtList, n.info, 4)
   generateAliasChecks(a, result)
-  result.addSon(varSection)
-  result.addSon(callCodegenProc("openBarrier", barrier))
-  result.addSon(transformSpawn(owner, body, barrier))
-  result.addSon(callCodegenProc("closeBarrier", barrier))
+  result.sons[0] = varSection
+  result.sons[1] = callCodegenProc("openBarrier", barrier)
+  result.sons[2] = transformSpawn(owner, body, barrier)
+  result.sons[3] = callCodegenProc("closeBarrier", barrier)

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -256,7 +256,7 @@ proc addToIntersection(inter: var TIntersection, s: int) =
   inter.add((id: s, count: 1))
 
 proc throws(tracked, n: PNode) =
-  if n.typ == nil or n.typ.kind != tyError: tracked.addSon(n)
+  if n.typ == nil or n.typ.kind != tyError: tracked.add(n)
 
 proc getEbase(): PType =
   result = if getCompilerProc("Exception") != nil: sysTypeFromName"Exception"
@@ -407,7 +407,7 @@ proc effectSpec(n: PNode, effectType: TSpecialWord): PNode =
       result = it.sons[1]
       if result.kind notin {nkCurly, nkBracket}:
         result = newNodeI(nkCurly, result.info)
-        result.addSon(it.sons[1])
+        result.add(it.sons[1])
       return
 
 proc documentEffect(n, x: PNode, effectType: TSpecialWord, idx: int): PNode =
@@ -438,7 +438,7 @@ proc documentWriteEffect(n: PNode; flag: TSymFlag; pragmaName: string): PNode =
   var effects = newNodeI(nkBracket, n.info)
   for i in 1 ..< params.len:
     if params[i].kind == nkSym and flag in params[i].sym.flags:
-      effects.addSon(params[i])
+      effects.add(params[i])
 
   if effects.len > 0:
     result = newNode(nkExprColonExpr, n.info, @[
@@ -461,11 +461,11 @@ proc documentRaises*(n: PNode) =
   if p1 != nil or p2 != nil or p3 != nil or p4 != nil or p5 != nil:
     if pragmas.kind == nkEmpty:
       n.sons[pragmasPos] = newNodeI(nkPragma, n.info)
-    if p1 != nil: n.sons[pragmasPos].addSon(p1)
-    if p2 != nil: n.sons[pragmasPos].addSon(p2)
-    if p3 != nil: n.sons[pragmasPos].addSon(p3)
-    if p4 != nil: n.sons[pragmasPos].addSon(p4)
-    if p5 != nil: n.sons[pragmasPos].addSon(p5)
+    if p1 != nil: n.sons[pragmasPos].add(p1)
+    if p2 != nil: n.sons[pragmasPos].add(p2)
+    if p3 != nil: n.sons[pragmasPos].add(p3)
+    if p4 != nil: n.sons[pragmasPos].add(p4)
+    if p5 != nil: n.sons[pragmasPos].add(p5)
 
 template notGcSafe(t): untyped = {tfGcSafe, tfNoSideEffect} * t.flags == {}
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -603,12 +603,12 @@ proc trackCase(tracked: PEffects, n: PNode) =
       addCaseBranchFacts(tracked.guards, n, i)
     for i in 0 .. <branch.len:
       track(tracked, branch.sons[i])
-    if not breaksBlock(branch.lastSon): inc toCover
+    if not breaksBlock(branch.last): inc toCover
     for i in oldState.. <tracked.init.len:
       addToIntersection(inter, tracked.init[i])
 
   setLen(tracked.init, oldState)
-  if not stringCase or lastSon(n).kind == nkElse:
+  if not stringCase or last(n).kind == nkElse:
     for id, count in items(inter):
       if count >= toCover: tracked.init.add id
     # else we can't merge
@@ -637,11 +637,11 @@ proc trackIf(tracked: PEffects, n: PNode) =
     setLen(tracked.init, oldState)
     for i in 0 .. <branch.len:
       track(tracked, branch.sons[i])
-    if not breaksBlock(branch.lastSon): inc toCover
+    if not breaksBlock(branch.last): inc toCover
     for i in oldState.. <tracked.init.len:
       addToIntersection(inter, tracked.init[i])
   setLen(tracked.init, oldState)
-  if lastSon(n).len == 1:
+  if last(n).len == 1:
     for id, count in items(inter):
       if count >= toCover: tracked.init.add id
     # else we can't merge as it is not exhaustive
@@ -726,7 +726,7 @@ proc track(tracked: PEffects, n: PNode) =
       # may not look like an assignment, but it is:
       let arg = n.sons[1]
       initVarViaNew(tracked, arg)
-      if {tfNeedsInit} * arg.typ.lastSon.flags != {}:
+      if {tfNeedsInit} * arg.typ.last.flags != {}:
         if a.sym.magic == mNewSeq and n[2].kind in {nkCharLit..nkUInt64Lit} and
             n[2].intVal == 0:
           # var s: seq[notnil];  newSeq(s, 0)  is a special case!
@@ -753,7 +753,7 @@ proc track(tracked: PEffects, n: PNode) =
     when false: cstringCheck(tracked, n)
   of nkVarSection, nkLetSection:
     for child in n:
-      let last = lastSon(child)
+      let last = last(child)
       if last.kind != nkEmpty: track(tracked, last)
       if child.kind == nkIdentDefs and last.kind != nkEmpty:
         for i in 0 .. child.len-3:
@@ -800,7 +800,7 @@ proc track(tracked: PEffects, n: PNode) =
     for i in 0 .. <pragmaList.len:
       if whichPragma(pragmaList.sons[i]) == wLocks:
         lockLocations(tracked, pragmaList.sons[i])
-    track(tracked, n.lastSon)
+    track(tracked, n.last)
     setLen(tracked.locked, oldLocked)
     tracked.currLockLevel = oldLockLevel
   of nkTypeSection, nkProcDef, nkConverterDef, nkMethodDef, nkIteratorDef,

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -256,7 +256,7 @@ proc addToIntersection(inter: var TIntersection, s: int) =
   inter.add((id: s, count: 1))
 
 proc throws(tracked, n: PNode) =
-  if n.typ == nil or n.typ.kind != tyError: tracked.add n
+  if n.typ == nil or n.typ.kind != tyError: tracked.addSon(n)
 
 proc getEbase(): PType =
   result = if getCompilerProc("Exception") != nil: sysTypeFromName"Exception"
@@ -407,7 +407,7 @@ proc effectSpec(n: PNode, effectType: TSpecialWord): PNode =
       result = it.sons[1]
       if result.kind notin {nkCurly, nkBracket}:
         result = newNodeI(nkCurly, result.info)
-        result.add(it.sons[1])
+        result.addSon(it.sons[1])
       return
 
 proc documentEffect(n, x: PNode, effectType: TSpecialWord, idx: int): PNode =
@@ -438,7 +438,7 @@ proc documentWriteEffect(n: PNode; flag: TSymFlag; pragmaName: string): PNode =
   var effects = newNodeI(nkBracket, n.info)
   for i in 1 ..< params.len:
     if params[i].kind == nkSym and flag in params[i].sym.flags:
-      effects.add params[i]
+      effects.addSon(params[i])
 
   if effects.len > 0:
     result = newNode(nkExprColonExpr, n.info, @[
@@ -461,11 +461,11 @@ proc documentRaises*(n: PNode) =
   if p1 != nil or p2 != nil or p3 != nil or p4 != nil or p5 != nil:
     if pragmas.kind == nkEmpty:
       n.sons[pragmasPos] = newNodeI(nkPragma, n.info)
-    if p1 != nil: n.sons[pragmasPos].add p1
-    if p2 != nil: n.sons[pragmasPos].add p2
-    if p3 != nil: n.sons[pragmasPos].add p3
-    if p4 != nil: n.sons[pragmasPos].add p4
-    if p5 != nil: n.sons[pragmasPos].add p5
+    if p1 != nil: n.sons[pragmasPos].addSon(p1)
+    if p2 != nil: n.sons[pragmasPos].addSon(p2)
+    if p3 != nil: n.sons[pragmasPos].addSon(p3)
+    if p4 != nil: n.sons[pragmasPos].addSon(p4)
+    if p5 != nil: n.sons[pragmasPos].addSon(p5)
 
 template notGcSafe(t): untyped = {tfGcSafe, tfNoSideEffect} * t.flags == {}
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -353,7 +353,7 @@ proc trackTryStmt(tracked: PEffects, n: PNode) =
   var hasFinally = false
   for i in 1 .. < n.len:
     let b = n.sons[i]
-    let blen = sonsLen(b)
+    let blen = len(b)
     if b.kind == nkExceptBranch:
       inc branches
       if blen == 1:
@@ -394,14 +394,14 @@ proc isForwardedProc(n: PNode): bool =
   result = n.kind == nkSym and sfForward in n.sym.flags
 
 proc trackPragmaStmt(tracked: PEffects, n: PNode) =
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     var it = n.sons[i]
     if whichPragma(it) == wEffects:
       # list the computed effects up to here:
       listEffects(tracked)
 
 proc effectSpec(n: PNode, effectType: TSpecialWord): PNode =
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     var it = n.sons[i]
     if it.kind == nkExprColonExpr and whichPragma(it) == effectType:
       result = it.sons[1]

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -71,7 +71,7 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule): PNode =
     while a != nil:
       if a.kind != skModule:
         incl(a.flags, sfUsed)
-        addSon(result, newSymNode(a, n.info))
+        add(result, newSymNode(a, n.info))
       a = nextOverloadIter(o, c, n)
 
 proc semBindStmt(c: PContext, n: PNode, toBind: var IntSet): PNode =
@@ -460,9 +460,9 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     case k
     of nkBracketExpr:
       result = newNodeI(nkCall, n.info)
-      result.addSon(newIdentNode(getIdent("[]="), n.info))
-      for i in 0 ..< a.len: result.addSon(a[i])
-      result.addSon(b)
+      result.add(newIdentNode(getIdent("[]="), n.info))
+      for i in 0 ..< a.len: result.add(a[i])
+      result.add(b)
       let a0 = semTemplBody(c, a.sons[0])
       withBracketExpr c, a0:
         result = semTemplBodySons(c, result)
@@ -477,7 +477,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkCallKinds-{nkPostfix}:
     result = semTemplBodySons(c, n)
     if c.bracketExpr != nil and n.len == 2 and oprIsRoof(n.sons[0]):
-      result.addSon(c.bracketExpr)
+      result.add(c.bracketExpr)
   of nkDotExpr, nkAccQuoted:
     # dotExpr is ambiguous: note that we explicitly allow 'x.TemplateParam',
     # so we use the generic code for nkDotExpr too
@@ -573,8 +573,8 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     s.typ = newTypeS(tyProc, c)
     # XXX why do we need tyStmt as a return type again?
     s.typ.n = newNodeI(nkFormalParams, n.info)
-    rawAddSon(s.typ, newTypeS(tyStmt, c))
-    addSon(s.typ.n, newNodeIT(nkType, n.info, s.typ.sons[0]))
+    rawAdd(s.typ, newTypeS(tyStmt, c))
+    add(s.typ.n, newNodeIT(nkType, n.info, s.typ.sons[0]))
   if allUntyped: incl(s.flags, sfAllUntyped)
   if n.sons[patternPos].kind != nkEmpty:
     n.sons[patternPos] = semPattern(c, n.sons[patternPos])

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -440,16 +440,16 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkPragma:
     result = onlyReplaceParams(c, n)
   of nkBracketExpr:
-    result = newNodeI(nkCall, n.info)
-    result.addSon(newIdentNode(getIdent("[]"), n.info))
-    for i in 0 ..< n.len: result.addSon(n[i])
+    result = newNodeI(nkCall, n.info, n.len + 1)
+    result.sons[0] = newIdentNode(getIdent("[]"), n.info)
+    for i in 0 ..< n.len: result.sons[i + 1] = n[i]
     let n0 = semTemplBody(c, n.sons[0])
     withBracketExpr c, n0:
       result = semTemplBodySons(c, result)
   of nkCurlyExpr:
-    result = newNodeI(nkCall, n.info)
-    result.addSon(newIdentNode(getIdent("{}"), n.info))
-    for i in 0 ..< n.len: result.addSon(n[i])
+    result = newNodeI(nkCall, n.info, n.len + 1)
+    result.sons[0] = newIdentNode(getIdent("{}"), n.info)
+    for i in 0 ..< n.len: result.sons[i + 1] = n[i]
     result = semTemplBodySons(c, result)
   of nkAsgn, nkFastAsgn:
     checkSonsLen(n, 2)
@@ -467,10 +467,10 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       withBracketExpr c, a0:
         result = semTemplBodySons(c, result)
     of nkCurlyExpr:
-      result = newNodeI(nkCall, n.info)
-      result.addSon(newIdentNode(getIdent("{}="), n.info))
-      for i in 0 ..< a.len: result.addSon(a[i])
-      result.addSon(b)
+      result = newNodeI(nkCall, n.info, a.len + 2)
+      result.sons[0] = newIdentNode(getIdent("{}="), n.info)
+      for i in 0 ..< a.len: result.sons[i + 1] = a[i]
+      result.sons[^1] = b
       result = semTemplBodySons(c, result)
     else:
       result = semTemplBodySons(c, n)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -441,15 +441,15 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     result = onlyReplaceParams(c, n)
   of nkBracketExpr:
     result = newNodeI(nkCall, n.info)
-    result.add newIdentNode(getIdent("[]"), n.info)
-    for i in 0 ..< n.len: result.add(n[i])
+    result.addSon(newIdentNode(getIdent("[]"), n.info))
+    for i in 0 ..< n.len: result.addSon(n[i])
     let n0 = semTemplBody(c, n.sons[0])
     withBracketExpr c, n0:
       result = semTemplBodySons(c, result)
   of nkCurlyExpr:
     result = newNodeI(nkCall, n.info)
-    result.add newIdentNode(getIdent("{}"), n.info)
-    for i in 0 ..< n.len: result.add(n[i])
+    result.addSon(newIdentNode(getIdent("{}"), n.info))
+    for i in 0 ..< n.len: result.addSon(n[i])
     result = semTemplBodySons(c, result)
   of nkAsgn, nkFastAsgn:
     checkSonsLen(n, 2)
@@ -460,24 +460,24 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     case k
     of nkBracketExpr:
       result = newNodeI(nkCall, n.info)
-      result.add newIdentNode(getIdent("[]="), n.info)
-      for i in 0 ..< a.len: result.add(a[i])
-      result.add(b)
+      result.addSon(newIdentNode(getIdent("[]="), n.info))
+      for i in 0 ..< a.len: result.addSon(a[i])
+      result.addSon(b)
       let a0 = semTemplBody(c, a.sons[0])
       withBracketExpr c, a0:
         result = semTemplBodySons(c, result)
     of nkCurlyExpr:
       result = newNodeI(nkCall, n.info)
-      result.add newIdentNode(getIdent("{}="), n.info)
-      for i in 0 ..< a.len: result.add(a[i])
-      result.add(b)
+      result.addSon(newIdentNode(getIdent("{}="), n.info))
+      for i in 0 ..< a.len: result.addSon(a[i])
+      result.addSon(b)
       result = semTemplBodySons(c, result)
     else:
       result = semTemplBodySons(c, n)
   of nkCallKinds-{nkPostfix}:
     result = semTemplBodySons(c, n)
     if c.bracketExpr != nil and n.len == 2 and oprIsRoof(n.sons[0]):
-      result.add c.bracketExpr
+      result.addSon(c.bracketExpr)
   of nkDotExpr, nkAccQuoted:
     # dotExpr is ambiguous: note that we explicitly allow 'x.TemplateParam',
     # so we use the generic code for nkDotExpr too

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -249,7 +249,7 @@ proc semRoutineInTemplName(c: var TemplCtx, n: PNode): PNode =
 
 proc semRoutineInTemplBody(c: var TemplCtx, n: PNode, k: TSymKind): PNode =
   result = n
-  checkSonsLen(n, bodyPos + 1)
+  checkLen(n, bodyPos + 1)
   # routines default to 'inject':
   if n.kind notin nkLambdaKinds and symBinding(n.sons[pragmasPos]) == spGenSym:
     let ident = getIdentNode(c, n.sons[namePos])
@@ -273,7 +273,7 @@ proc semTemplSomeDecl(c: var TemplCtx, n: PNode, symKind: TSymKind; start=0) =
     var a = n.sons[i]
     if a.kind == nkCommentStmt: continue
     if (a.kind != nkIdentDefs) and (a.kind != nkVarTuple): illFormedAst(a)
-    checkMinSonsLen(a, 3)
+    checkMinLen(a, 3)
     var L = sonsLen(a)
     a.sons[L-2] = semTemplBody(c, a.sons[L-2])
     a.sons[L-1] = semTemplBody(c, a.sons[L-1])
@@ -352,7 +352,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     n.sons[0] = semTemplBody(c, n.sons[0])
     for i in countup(1, sonsLen(n)-1):
       var a = n.sons[i]
-      checkMinSonsLen(a, 1)
+      checkMinLen(a, 1)
       var L = sonsLen(a)
       for j in countup(0, L-2):
         a.sons[j] = semTemplBody(c, a.sons[j])
@@ -367,7 +367,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     n.sons[L-1] = semTemplBody(c, n.sons[L-1])
     closeScope(c)
   of nkBlockStmt, nkBlockExpr, nkBlockType:
-    checkSonsLen(n, 2)
+    checkLen(n, 2)
     openScope(c)
     if n.sons[0].kind != nkEmpty:
       # labels are always 'gensym'ed:
@@ -378,11 +378,11 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     n.sons[1] = semTemplBody(c, n.sons[1])
     closeScope(c)
   of nkTryStmt:
-    checkMinSonsLen(n, 2)
+    checkMinLen(n, 2)
     n.sons[0] = semTemplBodyScope(c, n.sons[0])
     for i in countup(1, sonsLen(n)-1):
       var a = n.sons[i]
-      checkMinSonsLen(a, 1)
+      checkMinLen(a, 1)
       var L = sonsLen(a)
       for j in countup(0, L-2):
         a.sons[j] = semTemplBody(c, a.sons[j])
@@ -390,7 +390,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkVarSection: semTemplSomeDecl(c, n, skVar)
   of nkLetSection: semTemplSomeDecl(c, n, skLet)
   of nkFormalParams:
-    checkMinSonsLen(n, 1)
+    checkMinLen(n, 1)
     n.sons[0] = semTemplBody(c, n.sons[0])
     semTemplSomeDecl(c, n, skParam, 1)
   of nkConstSection:
@@ -398,7 +398,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkConstDef): illFormedAst(a)
-      checkSonsLen(a, 3)
+      checkLen(a, 3)
       addLocalDecl(c, a.sons[0], skConst)
       a.sons[1] = semTemplBody(c, a.sons[1])
       a.sons[2] = semTemplBody(c, a.sons[2])
@@ -407,13 +407,13 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
-      checkSonsLen(a, 3)
+      checkLen(a, 3)
       addLocalDecl(c, a.sons[0], skType)
     for i in countup(0, sonsLen(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
-      checkSonsLen(a, 3)
+      checkLen(a, 3)
       if a.sons[1].kind != nkEmpty:
         openScope(c)
         a.sons[1] = semTemplBody(c, a.sons[1])
@@ -452,7 +452,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     for i in 0 ..< n.len: result.sons[i + 1] = n[i]
     result = semTemplBodySons(c, result)
   of nkAsgn, nkFastAsgn:
-    checkSonsLen(n, 2)
+    checkLen(n, 2)
     let a = n.sons[0]
     let b = n.sons[1]
 

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -31,7 +31,7 @@ type
     spNone, spGenSym, spInject
 
 proc symBinding(n: PNode): TSymBinding =
-  for i in countup(0, sonsLen(n) - 1):
+  for i in countup(0, len(n) - 1):
     var it = n.sons[i]
     var key = if it.kind == nkExprColonExpr: it.sons[0] else: it
     if key.kind == nkIdent:
@@ -269,12 +269,12 @@ proc semRoutineInTemplBody(c: var TemplCtx, n: PNode, k: TSymKind): PNode =
   closeScope(c)
 
 proc semTemplSomeDecl(c: var TemplCtx, n: PNode, symKind: TSymKind; start=0) =
-  for i in countup(start, sonsLen(n) - 1):
+  for i in countup(start, len(n) - 1):
     var a = n.sons[i]
     if a.kind == nkCommentStmt: continue
     if (a.kind != nkIdentDefs) and (a.kind != nkVarTuple): illFormedAst(a)
     checkMinLen(a, 3)
-    var L = sonsLen(a)
+    var L = len(a)
     a.sons[L-2] = semTemplBody(c, a.sons[L-2])
     a.sons[L-1] = semTemplBody(c, a.sons[L-1])
     for j in countup(0, L-3):
@@ -332,7 +332,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkEmpty, nkSym..nkNilLit:
     discard
   of nkIfStmt:
-    for i in countup(0, sonsLen(n)-1):
+    for i in countup(0, len(n)-1):
       var it = n.sons[i]
       if it.len == 2:
         when newScopeForIf: openScope(c)
@@ -344,22 +344,22 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
         n.sons[i] = semTemplBodyScope(c, it)
   of nkWhileStmt:
     openScope(c)
-    for i in countup(0, sonsLen(n)-1):
+    for i in countup(0, len(n)-1):
       n.sons[i] = semTemplBody(c, n.sons[i])
     closeScope(c)
   of nkCaseStmt:
     openScope(c)
     n.sons[0] = semTemplBody(c, n.sons[0])
-    for i in countup(1, sonsLen(n)-1):
+    for i in countup(1, len(n)-1):
       var a = n.sons[i]
       checkMinLen(a, 1)
-      var L = sonsLen(a)
+      var L = len(a)
       for j in countup(0, L-2):
         a.sons[j] = semTemplBody(c, a.sons[j])
       a.sons[L-1] = semTemplBodyScope(c, a.sons[L-1])
     closeScope(c)
   of nkForStmt, nkParForStmt:
-    var L = sonsLen(n)
+    var L = len(n)
     openScope(c)
     n.sons[L-2] = semTemplBody(c, n.sons[L-2])
     for i in countup(0, L - 3):
@@ -380,10 +380,10 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkTryStmt:
     checkMinLen(n, 2)
     n.sons[0] = semTemplBodyScope(c, n.sons[0])
-    for i in countup(1, sonsLen(n)-1):
+    for i in countup(1, len(n)-1):
       var a = n.sons[i]
       checkMinLen(a, 1)
-      var L = sonsLen(a)
+      var L = len(a)
       for j in countup(0, L-2):
         a.sons[j] = semTemplBody(c, a.sons[j])
       a.sons[L-1] = semTemplBodyScope(c, a.sons[L-1])
@@ -394,7 +394,7 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     n.sons[0] = semTemplBody(c, n.sons[0])
     semTemplSomeDecl(c, n, skParam, 1)
   of nkConstSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkConstDef): illFormedAst(a)
@@ -403,13 +403,13 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       a.sons[1] = semTemplBody(c, a.sons[1])
       a.sons[2] = semTemplBody(c, a.sons[2])
   of nkTypeSection:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
       checkLen(a, 3)
       addLocalDecl(c, a.sons[0], skType)
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var a = n.sons[i]
       if a.kind == nkCommentStmt: continue
       if (a.kind != nkTypeDef): illFormedAst(a)
@@ -524,7 +524,7 @@ proc semTemplBodyDirty(c: var TemplCtx, n: PNode): PNode =
       if s != nil and contains(c.toBind, s.id):
         return symChoice(c.c, n, s, scClosed)
     result = n
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result.sons[i] = semTemplBodyDirty(c, n.sons[i])
 
 proc semTemplateDef(c: PContext, n: PNode): PNode =
@@ -560,7 +560,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
       let param = s.typ.n.sons[i].sym
       param.flags.excl sfGenSym
       if param.typ.kind != tyExpr: allUntyped = false
-    if sonsLen(gp) > 0:
+    if len(gp) > 0:
       if n.sons[genericParamsPos].kind == nkEmpty:
         # we have a list of implicit type parameters:
         n.sons[genericParamsPos] = gp
@@ -675,7 +675,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
     if stupidStmtListExpr(n):
       result = semPatternBody(c, n.lastSon)
     else:
-      for i in countup(0, sonsLen(n) - 1):
+      for i in countup(0, len(n) - 1):
         result.sons[i] = semPatternBody(c, n.sons[i])
   of nkCallKinds:
     let s = qualifiedLookUp(c.c, n.sons[0], {})
@@ -710,7 +710,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
         result.sons[1] = semPatternBody(c, n.sons[1])
         return
 
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result.sons[i] = semPatternBody(c, n.sons[i])
   else:
     # dotExpr is ambiguous: note that we explicitly allow 'x.TemplateParam',
@@ -726,7 +726,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
     of nkPar:
       if n.len == 1: return semPatternBody(c, n.sons[0])
     else: discard
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result.sons[i] = semPatternBody(c, n.sons[i])
 
 proc semPattern(c: PContext, n: PNode): PNode =

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -673,7 +673,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
       localError(n.info, errInvalidExpression)
   of nkStmtList, nkStmtListExpr:
     if stupidStmtListExpr(n):
-      result = semPatternBody(c, n.lastSon)
+      result = semPatternBody(c, n.last)
     else:
       for i in countup(0, len(n) - 1):
         result.sons[i] = semPatternBody(c, n.sons[i])

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -451,9 +451,9 @@ proc semBranchRange(c: PContext, t, a, b: PNode, covered: var BiggestInt): PNode
   let at = fitNode(c, t.sons[0].typ, ac).skipConvTakeType
   let bt = fitNode(c, t.sons[0].typ, bc).skipConvTakeType
 
-  result = newNodeI(nkRange, a.info)
-  result.addSon(at)
-  result.addSon(bt)
+  result = newNodeI(nkRange, a.info, 2)
+  result.sons[0] = at
+  result.sons[1] = bt
   if emptyRange(ac, bc): localError(b.info, errRangeIsEmpty)
   else: covered = covered + getOrdValue(bc) - getOrdValue(ac) + 1
 
@@ -1175,8 +1175,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
                 of nkClosedSymChoice, nkOpenSymChoice: x[0].sym.name
                 else: nil
     if ident != nil and ident.s == "[]":
-      let b = newNodeI(nkBracketExpr, n.info)
-      for i in 1..<n.len: b.addSon(n[i])
+      let b = newNodeI(nkBracketExpr, n.info, <n.len)
+      for i in 1..<n.len: b.sons[i - 1] = n[i]
       result = semTypeNode(c, b, prev)
     elif ident != nil and ident.id == ord(wDotDot):
       result = semRangeAux(c, n, prev)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -452,8 +452,8 @@ proc semBranchRange(c: PContext, t, a, b: PNode, covered: var BiggestInt): PNode
   let bt = fitNode(c, t.sons[0].typ, bc).skipConvTakeType
 
   result = newNodeI(nkRange, a.info)
-  result.add(at)
-  result.add(bt)
+  result.addSon(at)
+  result.addSon(bt)
   if emptyRange(ac, bc): localError(b.info, errRangeIsEmpty)
   else: covered = covered + getOrdValue(bc) - getOrdValue(ac) + 1
 
@@ -499,7 +499,7 @@ proc semCaseBranch(c: PContext, t, branch: PNode, branchIndex: int,
         branch.sons[i] = semCaseBranchSetElem(c, t, r[0], covered)
         # other elements have to be added to ``branch``
         for j in 1 .. <r.len:
-          branch.add(semCaseBranchSetElem(c, t, r[j], covered))
+          branch.addSon(semCaseBranchSetElem(c, t, r[j], covered))
           # caution! last son of branch must be the actions to execute:
           var L = branch.len
           swap(branch.sons[L-2], branch.sons[L-1])
@@ -1176,7 +1176,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
                 else: nil
     if ident != nil and ident.s == "[]":
       let b = newNodeI(nkBracketExpr, n.info)
-      for i in 1..<n.len: b.add(n[i])
+      for i in 1..<n.len: b.addSon(n[i])
       result = semTypeNode(c, b, prev)
     elif ident != nil and ident.id == ord(wDotDot):
       result = semRangeAux(c, n, prev)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -488,7 +488,7 @@ proc semCaseBranch(c: PContext, t, branch: PNode, branchIndex: int,
       var r = semConstExpr(c, b)
       if r.kind in {nkCurly, nkBracket} and len(r) == 0  and sonsLen(branch)==2:
         # discarding ``{}`` and ``[]`` branches silently
-        delSon(branch, 0)
+        del(branch, 0)
         return
       elif r.kind notin {nkCurly, nkBracket} or len(r) == 0:
         checkMinSonsLen(t, 1)
@@ -537,7 +537,7 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
       chckCovered = false
       checkSonsLen(b, 1)
     else: illFormedAst(n)
-    delSon(b, sonsLen(b) - 1)
+    del(b, sonsLen(b) - 1)
     semRecordNodeAux(c, lastSon(n.sons[i]), check, pos, b, rectype)
   if chckCovered and (covered != lengthOrd(a.sons[0].typ)):
     localError(a.info, errNotAllCasesCovered)

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -167,7 +167,7 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
       result = newNode(nkRecList, n.info)
   of nkRecWhen:
     var branch: PNode = nil              # the branch to take
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       var it = n.sons[i]
       if it == nil: illFormedAst(n)
       case it.kind
@@ -192,7 +192,7 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
     result = if cl.allowMetaTypes: n
              else: cl.c.semExpr(cl.c, n)
   else:
-    var length = sonsLen(n)
+    var length = len(n)
     if length > 0:
       newSons(result, length)
       if start > 0:
@@ -247,7 +247,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   else:
     result = searchInstTypes(t)
   if result != nil and eqTypeFlags*result.flags == eqTypeFlags*t.flags: return
-  for i in countup(1, sonsLen(t) - 1):
+  for i in countup(1, len(t) - 1):
     var x = t.sons[i]
     if x.kind == tyGenericParam:
       x = lookupTypeVar(cl, x)
@@ -279,14 +279,14 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
 
   let oldSkipTypedesc = cl.skipTypedesc
   cl.skipTypedesc = true
-  for i in countup(1, sonsLen(t) - 1):
+  for i in countup(1, len(t) - 1):
     var x = replaceTypeVarsT(cl, t.sons[i])
     assert x.kind != tyGenericInvocation
     header.sons[i] = x
     propagateToOwner(header, x)
     idTablePut(cl.typeMap, body.sons[i-1], x)
 
-  for i in countup(1, sonsLen(t) - 1):
+  for i in countup(1, len(t) - 1):
     # if one of the params is not concrete, we cannot do anything
     # but we already raised an error!
     rawAdd(result, header.sons[i])
@@ -328,11 +328,11 @@ proc eraseVoidParams*(t: PType) =
   if t.sons[0] != nil and t.sons[0].kind == tyVoid:
     t.sons[0] = nil
 
-  for i in 1 .. <t.sonsLen:
+  for i in 1 .. <t.len:
     # don't touch any memory unless necessary
     if t.sons[i].kind == tyVoid:
       var pos = i
-      for j in i+1 .. <t.sonsLen:
+      for j in i+1 .. <t.len:
         if t.sons[j].kind != tyVoid:
           t.sons[pos] = t.sons[j]
           t.n.sons[pos] = t.n.sons[j]
@@ -342,7 +342,7 @@ proc eraseVoidParams*(t: PType) =
       return
 
 proc skipIntLiteralParams*(t: PType) =
-  for i in 0 .. <t.sonsLen:
+  for i in 0 .. <t.len:
     let p = t.sons[i]
     if p == nil: continue
     let skipped = p.skipIntLit
@@ -441,7 +441,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
     bailout()
     result = instCopyType(cl, t)
     idTablePut(cl.localCache, t, result)
-    for i in 1 .. <result.sonsLen:
+    for i in 1 .. <result.len:
       result.sons[i] = replaceTypeVarsT(cl, result.sons[i])
     propagateToOwner(result, result.lastSon)
 
@@ -454,7 +454,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
       #if not cl.allowMetaTypes:
       idTablePut(cl.localCache, t, result)
 
-      for i in countup(0, sonsLen(result) - 1):
+      for i in countup(0, len(result) - 1):
         if result.sons[i] != nil:
           var r = replaceTypeVarsT(cl, result.sons[i])
           if result.kind == tyObject:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -63,7 +63,7 @@ proc cacheTypeInst*(inst: PType) =
   # XXX: add to module's generics
   #      update the refcount
   let gt = inst.sons[0]
-  let t = if gt.kind == tyGenericBody: gt.lastSon else: gt
+  let t = if gt.kind == tyGenericBody: gt.last else: gt
   if t.kind in {tyStatic, tyGenericParam} + tyTypeClasses:
     return
   gt.sym.typeInstCache.safeAdd(inst)
@@ -291,7 +291,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
     # but we already raised an error!
     rawAdd(result, header.sons[i])
 
-  let bbody = lastSon body
+  let bbody = last body
   var newbody = replaceTypeVarsT(cl, bbody)
   cl.skipTypedesc = oldSkipTypedesc
   newbody.flags = newbody.flags + (t.flags + body.flags - tfInstClearedFlags)
@@ -397,7 +397,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
   of tyGenericBody:
     localError(cl.info, errCannotInstantiateX, typeToString(t))
     result = errorType(cl.c)
-    #result = replaceTypeVarsT(cl, lastSon(t))
+    #result = replaceTypeVarsT(cl, last(t))
 
   of tyFromExpr:
     if cl.allowMetaTypes: return
@@ -443,7 +443,7 @@ proc replaceTypeVarsTAux(cl: var TReplTypeVars, t: PType): PType =
     idTablePut(cl.localCache, t, result)
     for i in 1 .. <result.len:
       result.sons[i] = replaceTypeVarsT(cl, result.sons[i])
-    propagateToOwner(result, result.lastSon)
+    propagateToOwner(result, result.last)
 
   else:
     if containsGenericType(t):

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -110,8 +110,8 @@ proc prepareNode(cl: var TReplTypeVars, n: PNode): PNode =
   let isCall = result.kind in nkCallKinds
   for i in 0 .. <n.safeLen:
     # XXX HACK: ``f(a, b)``, avoid to instantiate `f`
-    if isCall and i == 0: result.add(n[i])
-    else: result.add(prepareNode(cl, n[i]))
+    if isCall and i == 0: result.addSon(n[i])
+    else: result.addSon(prepareNode(cl, n[i]))
 
 proc isTypeParam(n: PNode): bool =
   # XXX: generic params should use skGenericParam instead of skType

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -172,14 +172,14 @@ proc replaceTypeVarsN(cl: var TReplTypeVars, n: PNode; start=0): PNode =
       if it == nil: illFormedAst(n)
       case it.kind
       of nkElifBranch:
-        checkSonsLen(it, 2)
+        checkLen(it, 2)
         var cond = prepareNode(cl, it.sons[0])
         var e = cl.c.semConstExpr(cl.c, cond)
         if e.kind != nkIntLit:
           internalError(e.info, "ReplaceTypeVarsN: when condition not a bool")
         if e.intVal != 0 and branch == nil: branch = it.sons[1]
       of nkElse:
-        checkSonsLen(it, 1)
+        checkLen(it, 1)
         if branch == nil: branch = it.sons[0]
       else: illFormedAst(n)
     if branch != nil:

--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -110,8 +110,8 @@ proc prepareNode(cl: var TReplTypeVars, n: PNode): PNode =
   let isCall = result.kind in nkCallKinds
   for i in 0 .. <n.safeLen:
     # XXX HACK: ``f(a, b)``, avoid to instantiate `f`
-    if isCall and i == 0: result.addSon(n[i])
-    else: result.addSon(prepareNode(cl, n[i]))
+    if isCall and i == 0: result.add(n[i])
+    else: result.add(prepareNode(cl, n[i]))
 
 proc isTypeParam(n: PNode): bool =
   # XXX: generic params should use skGenericParam instead of skType
@@ -267,7 +267,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
 
   result = newType(tyGenericInst, t.sons[0].owner)
   result.flags = header.flags
-  # be careful not to propagate unnecessary flags here (don't use rawAddSon)
+  # be careful not to propagate unnecessary flags here (don't use rawAdd)
   result.sons = @[header.sons[0]]
   # ugh need another pass for deeply recursive generic types (e.g. PActor)
   # we need to add the candidate here, before it's fully instantiated for
@@ -289,7 +289,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   for i in countup(1, sonsLen(t) - 1):
     # if one of the params is not concrete, we cannot do anything
     # but we already raised an error!
-    rawAddSon(result, header.sons[i])
+    rawAdd(result, header.sons[i])
 
   let bbody = lastSon body
   var newbody = replaceTypeVarsT(cl, bbody)
@@ -302,7 +302,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   # One step is enough, because the recursive nature of
   # handleGenericInvocation will handle the alias-to-alias-to-alias case
   if newbody.isGenericAlias: newbody = newbody.skipGenericAlias
-  rawAddSon(result, newbody)
+  rawAdd(result, newbody)
   checkPartialConstructedType(cl.info, newbody)
   let dc = newbody.deepCopy
   if dc != nil and sfFromGeneric notin newbody.deepCopy.flags:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1327,8 +1327,8 @@ proc localConvMatch(c: PContext, m: var TCandidate, f, a: PType,
   if f == arg.typ and arg.kind == nkHiddenStdConv: return arg
 
   var call = newNodeI(nkCall, arg.info)
-  call.add(f.n.copyTree)
-  call.add(arg.copyTree)
+  call.addSon(f.n.copyTree)
+  call.addSon(arg.copyTree)
   result = c.semExpr(c, call)
   if result != nil:
     if result.typ == nil: return nil

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -276,8 +276,8 @@ proc concreteType(c: TCandidate, t: PType): PType =
   of tyArrayConstr:
     # make it an array
     result = newType(tyArray, t.owner)
-    addSonSkipIntLit(result, t.sons[0]) # XXX: t.owner is wrong for ID!
-    addSonSkipIntLit(result, t.sons[1]) # XXX: semantic checking for the type?
+    addSkipIntLit(result, t.sons[0]) # XXX: t.owner is wrong for ID!
+    addSkipIntLit(result, t.sons[1]) # XXX: semantic checking for the type?
   of tyNil:
     result = nil              # what should it be?
   of tyTypeDesc:
@@ -1286,8 +1286,8 @@ proc implicitConv(kind: TNodeKind, f: PType, arg: PNode, m: TCandidate,
   else:
     result.typ = f
   if result.typ == nil: internalError(arg.info, "implicitConv")
-  addSon(result, ast.emptyNode)
-  addSon(result, arg)
+  add(result, ast.emptyNode)
+  add(result, arg)
 
 proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
                    arg: PNode): PNode =
@@ -1311,8 +1311,8 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       s.typ = c.converters[i].typ
       s.info = arg.info
       result = newNodeIT(nkHiddenCallConv, arg.info, dest)
-      addSon(result, s)
-      addSon(result, copyTree(arg))
+      add(result, s)
+      add(result, copyTree(arg))
       inc(m.convMatches)
       m.genericConverter = srca == isGeneric or destIsGeneric
       return result
@@ -1327,8 +1327,8 @@ proc localConvMatch(c: PContext, m: var TCandidate, f, a: PType,
   if f == arg.typ and arg.kind == nkHiddenStdConv: return arg
 
   var call = newNodeI(nkCall, arg.info)
-  call.addSon(f.n.copyTree)
-  call.addSon(arg.copyTree)
+  call.add(f.n.copyTree)
+  call.add(arg.copyTree)
   result = c.semExpr(c, call)
   if result != nil:
     if result.typ == nil: return nil
@@ -1605,13 +1605,13 @@ proc prepareNamedParam(a: PNode) =
 
 proc arrayConstr(c: PContext, n: PNode): PType =
   result = newTypeS(tyArrayConstr, c)
-  rawAddSon(result, makeRangeType(c, 0, 0, n.info))
-  addSonSkipIntLit(result, skipTypes(n.typ, {tyGenericInst, tyVar, tyOrdinal}))
+  rawAdd(result, makeRangeType(c, 0, 0, n.info))
+  addSkipIntLit(result, skipTypes(n.typ, {tyGenericInst, tyVar, tyOrdinal}))
 
 proc arrayConstr(c: PContext, info: TLineInfo): PType =
   result = newTypeS(tyArrayConstr, c)
-  rawAddSon(result, makeRangeType(c, 0, -1, info))
-  rawAddSon(result, newTypeS(tyEmpty, c)) # needs an empty basetype!
+  rawAdd(result, makeRangeType(c, 0, -1, info))
+  rawAdd(result, newTypeS(tyEmpty, c)) # needs an empty basetype!
 
 proc incrIndexType(t: PType) =
   assert t.kind == tyArrayConstr
@@ -1648,7 +1648,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
   m.call = newNodeI(n.kind, n.info)
   m.call.typ = base(m.callee) # may be nil
   var formalLen = m.callee.n.len
-  addSon(m.call, copyTree(n.sons[0]))
+  add(m.call, copyTree(n.sons[0]))
   var container: PNode = nil # constructed container
   var formal: PSym = if formalLen > 1: m.callee.n.sons[1].sym else: nil
 
@@ -1660,7 +1660,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
         setSon(m.call, formal.position + 1, container)
       else:
         incrIndexType(container.typ)
-      addSon(container, n.sons[a])
+      add(container, n.sons[a])
     elif n.sons[a].kind == nkExprEqExpr:
       # named param
       # check if m.callee has such a param:
@@ -1694,7 +1694,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
       if m.baseTypeMatch:
         #assert(container == nil)
         container = newNodeIT(nkBracket, n.sons[a].info, arrayConstr(c, arg))
-        addSon(container, arg)
+        add(container, arg)
         setSon(m.call, formal.position + 1, container)
         if f != formalLen - 1: container = nil
       else:
@@ -1709,10 +1709,10 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
           # we have no formal here to snoop at:
           n.sons[a] = prepareOperand(c, n.sons[a])
           if skipTypes(n.sons[a].typ, abstractVar-{tyTypeDesc}).kind==tyString:
-            addSon(m.call, implicitConv(nkHiddenStdConv, getSysType(tyCString),
+            add(m.call, implicitConv(nkHiddenStdConv, getSysType(tyCString),
                                         copyTree(n.sons[a]), m, c))
           else:
-            addSon(m.call, copyTree(n.sons[a]))
+            add(m.call, copyTree(n.sons[a]))
         elif formal != nil and formal.typ.kind == tyVarargs:
           # beware of the side-effects in 'prepareOperand'! So only do it for
           # varargs matching. See tests/metatype/tstatic_overloading.
@@ -1722,7 +1722,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
           var arg = paramTypesMatch(m, formal.typ, n.sons[a].typ,
                                     n.sons[a], nOrig.sons[a])
           if arg != nil and m.baseTypeMatch and container != nil:
-            addSon(container, arg)
+            add(container, arg)
             incrIndexType(container.typ)
             checkConstraint(n.sons[a])
           else:
@@ -1748,7 +1748,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
             setSon(m.call, formal.position + 1, container)
           else:
             incrIndexType(container.typ)
-          addSon(container, n.sons[a])
+          add(container, n.sons[a])
         else:
           m.baseTypeMatch = false
           n.sons[a] = prepareOperand(c, formal.typ, n.sons[a])
@@ -1763,7 +1763,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
               container = newNodeIT(nkBracket, n.sons[a].info, arrayConstr(c, arg))
             else:
               incrIndexType(container.typ)
-            addSon(container, arg)
+            add(container, arg)
             setSon(m.call, formal.position + 1,
                    implicitConv(nkHiddenStdConv, formal.typ, container, m, c))
             #if f != formalLen - 1: container = nil
@@ -1855,32 +1855,32 @@ tests:
 
   proc `|` (t1, t2: PType): PType =
     result = newType(tyOr, dummyOwner)
-    result.rawAddSon(t1)
-    result.rawAddSon(t2)
+    result.rawAdd(t1)
+    result.rawAdd(t2)
 
   proc `&` (t1, t2: PType): PType =
     result = newType(tyAnd, dummyOwner)
-    result.rawAddSon(t1)
-    result.rawAddSon(t2)
+    result.rawAdd(t1)
+    result.rawAdd(t2)
 
   proc `!` (t: PType): PType =
     result = newType(tyNot, dummyOwner)
-    result.rawAddSon(t)
+    result.rawAdd(t)
 
   proc seq(t: PType): PType =
     result = newType(tySequence, dummyOwner)
-    result.rawAddSon(t)
+    result.rawAdd(t)
 
   proc array(x: int, t: PType): PType =
     result = newType(tyArray, dummyOwner)
 
     var n = newNodeI(nkRange, UnknownLineInfo())
-    addSon(n, newIntNode(nkIntLit, 0))
-    addSon(n, newIntNode(nkIntLit, x))
+    add(n, newIntNode(nkIntLit, 0))
+    add(n, newIntNode(nkIntLit, x))
     let range = newType(tyRange, dummyOwner)
 
-    result.rawAddSon(range)
-    result.rawAddSon(t)
+    result.rawAdd(range)
+    result.rawAdd(t)
 
   suite "type classes":
     let

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -165,7 +165,7 @@ proc suggestObject(c: PContext, n: PNode, outputs: var int) =
     var L = len(n)
     if L > 0:
       suggestObject(c, n.sons[0], outputs)
-      for i in countup(1, L-1): suggestObject(c, lastSon(n.sons[i]), outputs)
+      for i in countup(1, L-1): suggestObject(c, last(n.sons[i]), outputs)
   of nkSym: suggestField(c, n.sym, outputs)
   else: discard
 

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -442,12 +442,12 @@ proc suggestExpr*(c: PContext, node: PNode) =
       var a = copyNode(n)
       var x = safeSemExpr(c, n.sons[0])
       if x.kind == nkEmpty or x.typ == nil: x = n.sons[0]
-      addSon(a, x)
+      add(a, x)
       for i in 1..sonsLen(n)-1:
         # use as many typed arguments as possible:
         var x = safeSemExpr(c, n.sons[i])
         if x.kind == nkEmpty or x.typ == nil: break
-        addSon(a, x)
+        add(a, x)
       suggestCall(c, a, n, outputs)
 
   dec(c.compilesContextId)

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -152,7 +152,7 @@ template wholeSymTab(cond, section: untyped) =
         inc outputs
 
 proc suggestSymList(c: PContext, list: PNode, outputs: var int) =
-  for i in countup(0, sonsLen(list) - 1):
+  for i in countup(0, len(list) - 1):
     if list.sons[i].kind == nkSym:
       suggestField(c, list.sons[i].sym, outputs)
     #else: InternalError(list.info, "getSymFromList")
@@ -160,9 +160,9 @@ proc suggestSymList(c: PContext, list: PNode, outputs: var int) =
 proc suggestObject(c: PContext, n: PNode, outputs: var int) =
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n)-1): suggestObject(c, n.sons[i], outputs)
+    for i in countup(0, len(n)-1): suggestObject(c, n.sons[i], outputs)
   of nkRecCase:
-    var L = sonsLen(n)
+    var L = len(n)
     if L > 0:
       suggestObject(c, n.sons[0], outputs)
       for i in countup(1, L-1): suggestObject(c, lastSon(n.sons[i]), outputs)
@@ -194,7 +194,7 @@ proc suggestCall(c: PContext, n, nOrig: PNode, outputs: var int) =
               $ideCon)
 
 proc typeFits(c: PContext, s: PSym, firstArg: PType): bool {.inline.} =
-  if s.typ != nil and sonsLen(s.typ) > 1 and s.typ.sons[1] != nil:
+  if s.typ != nil and len(s.typ) > 1 and s.typ.sons[1] != nil:
     # special rule: if system and some weird generic match via 'tyExpr'
     # or 'tyGenericParam' we won't list it either to reduce the noise (nobody
     # wants 'system.`-|` as suggestion
@@ -319,7 +319,7 @@ proc findClosestSym(n: PNode): PNode =
   if n.kind == nkSym and inCheckpoint(n.info) == cpExact:
     result = n
   elif n.kind notin {nkNone..nkNilLit}:
-    for i in 0.. <sonsLen(n):
+    for i in 0.. <len(n):
       result = findClosestSym(n.sons[i])
       if result != nil: return
 
@@ -443,7 +443,7 @@ proc suggestExpr*(c: PContext, node: PNode) =
       var x = safeSemExpr(c, n.sons[0])
       if x.kind == nkEmpty or x.typ == nil: x = n.sons[0]
       add(a, x)
-      for i in 1..sonsLen(n)-1:
+      for i in 1..len(n)-1:
         # use as many typed arguments as possible:
         var x = safeSemExpr(c, n.sons[i])
         if x.kind == nkEmpty or x.typ == nil: break

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -378,12 +378,12 @@ proc generateThunk(prc: PNode, dest: PType): PNode =
   if gCmd == cmdCompileToJS: return prc
   result = newNodeIT(nkClosure, prc.info, dest)
   var conv = newNodeIT(nkHiddenSubConv, prc.info, dest)
-  conv.add(emptyNode)
-  conv.add(prc)
+  conv.addSon(emptyNode)
+  conv.addSon(prc)
   if prc.kind == nkClosure:
     internalError(prc.info, "closure to closure created")
-  result.add(conv)
-  result.add(newNodeIT(nkNilLit, prc.info, getSysType(tyNil)))
+  result.addSon(conv)
+  result.addSon(newNodeIT(nkNilLit, prc.info, getSysType(tyNil)))
 
 proc transformConv(c: PTransf, n: PNode): PTransNode =
   # numeric types need range checks:
@@ -708,7 +708,7 @@ proc commonOptimizations*(c: PSym, n: PNode): PNode =
   var op = getMergeOp(n)
   if (op != nil) and (op.magic != mNone) and (sonsLen(n) >= 3):
     result = newNodeIT(nkCall, n.info, n.typ)
-    add(result, n.sons[0])
+    addSon(result, n.sons[0])
     var args = newNode(nkArgList)
     flattenTreeAux(args, n, op)
     var j = 0
@@ -721,7 +721,7 @@ proc commonOptimizations*(c: PSym, n: PNode): PNode =
           if not isConstExpr(b): break
           a = evalOp(op.magic, result, a, b, nil)
           inc(j)
-      add(result, a)
+      addSon(result, a)
     if len(result) == 2: result = result[1]
   else:
     var cnst = getConstExpr(c, n)
@@ -892,7 +892,7 @@ proc liftDeferAux(n: PNode) =
       for i in 0..last:
         if n.sons[i].kind == nkDefer:
           let deferPart = newNodeI(nkFinally, n.sons[i].info)
-          deferPart.add n.sons[i].sons[0]
+          deferPart.addSon(n.sons[i].sons[0])
           var tryStmt = newNodeI(nkTryStmt, n.sons[i].info)
           var body = newNodeI(n.kind, n.sons[i].info)
           if i < last:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -618,7 +618,7 @@ proc transformCase(c: PTransf, n: PNode): PTransNode =
     var elseBranch = newTransNode(nkElse, n.info, 1)
     elseBranch[0] = ifs
     result.add(elseBranch)
-  elif result.PNode.lastSon.kind != nkElse and not (
+  elif result.PNode.last.kind != nkElse and not (
       skipTypes(n.sons[0].typ, abstractVarRange).kind in
         {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32}):
     # fix a stupid code gen bug by normalizing:
@@ -690,7 +690,7 @@ proc transformCall(c: PTransf, n: PNode): PTransNode =
     # bugfix: check after 'transformSons' if it's still a method call:
     # use the dispatcher for the call:
     if s.sons[0].kind == nkSym and s.sons[0].sym.kind == skMethod:
-      let t = lastSon(s.sons[0].sym.ast)
+      let t = last(s.sons[0].sym.ast)
       if t.kind != nkSym or sfDispatcher notin t.sym.flags:
         methodDef(s.sons[0].sym, false)
       result = methodCall(s).PTransNode

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -43,8 +43,8 @@ proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkEmpty, nkNilLit, nkType: result = true
     else:
-      if sonsLen(a) == sonsLen(b):
-        for i in countup(0, sonsLen(a) - 1):
+      if len(a) == len(b):
+        for i in countup(0, len(a) - 1):
           if not exprStructuralEquivalent(a.sons[i], b.sons[i],
                                           strictSymEquality): return
         result = true
@@ -67,8 +67,8 @@ proc sameTree*(a, b: PNode): bool =
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkEmpty, nkNilLit, nkType: result = true
     else:
-      if sonsLen(a) == sonsLen(b):
-        for i in countup(0, sonsLen(a) - 1):
+      if len(a) == len(b):
+        for i in countup(0, len(a) - 1):
           if not sameTree(a.sons[i], b.sons[i]): return
         result = true
 

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -122,7 +122,7 @@ proc unnestStmts(n, result: PNode) =
   if n.kind == nkStmtList:
     for x in items(n): unnestStmts(x, result)
   elif n.kind notin {nkCommentStmt, nkNilLit}:
-    result.addSon(n)
+    result.add(n)
 
 proc flattenStmts*(n: PNode): PNode =
   result = newNodeI(nkStmtList, n.info)

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -122,7 +122,7 @@ proc unnestStmts(n, result: PNode) =
   if n.kind == nkStmtList:
     for x in items(n): unnestStmts(x, result)
   elif n.kind notin {nkCommentStmt, nkNilLit}:
-    result.add(n)
+    result.addSon(n)
 
 proc flattenStmts*(n: PNode): PNode =
   result = newNodeI(nkStmtList, n.info)

--- a/compiler/treetab.nim
+++ b/compiler/treetab.nim
@@ -32,7 +32,7 @@ proc hashTree(n: PNode): Hash =
     if not n.strVal.isNil:
       result = result !& hash(n.strVal)
   else:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result = result !& hashTree(n.sons[i])
 
 proc treesEquivalent(a, b: PNode): bool =
@@ -47,8 +47,8 @@ proc treesEquivalent(a, b: PNode): bool =
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     else:
-      if sonsLen(a) == sonsLen(b):
-        for i in countup(0, sonsLen(a) - 1):
+      if len(a) == len(b):
+        for i in countup(0, len(a) - 1):
           if not treesEquivalent(a.sons[i], b.sons[i]): return
         result = true
     if result: result = sameTypeOrNil(a.typ, b.typ)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -370,7 +370,7 @@ proc mutateNode(marker: var IntSet, n: PNode, iter: TTypeMutator,
       discard
     else:
       for i in countup(0, sonsLen(n) - 1):
-        addSon(result, mutateNode(marker, n.sons[i], iter, closure))
+        add(result, mutateNode(marker, n.sons[i], iter, closure))
 
 proc mutateTypeAux(marker: var IntSet, t: PType, iter: TTypeMutator,
                    closure: RootRef): PType =

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -616,8 +616,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcInclRange:
       decodeBC(rkNode)
       var r = newNode(nkRange)
-      r.add regs[rb].regToNode
-      r.add regs[rc].regToNode
+      r.addSon(regs[rb].regToNode)
+      r.addSon(regs[rc].regToNode)
       addSon(regs[ra].node, r.copyTree)
     of opcExcl:
       decodeB(rkNode)
@@ -810,7 +810,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcAddSeqElem:
       decodeB(rkNode)
       if regs[ra].node.kind == nkBracket:
-        regs[ra].node.add(copyTree(regs[rb].regToNode))
+        regs[ra].node.addSon(copyTree(regs[rb].regToNode))
       else:
         stackTrace(c, tos, pc, errNilAccess)
     of opcGetImpl:
@@ -916,8 +916,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                           else:
                             c.module
         var macroCall = newNodeI(nkCall, c.debug[pc])
-        macroCall.add(newSymNode(prc))
-        for i in 1 .. rc-1: macroCall.add(regs[rb+i].regToNode)
+        macroCall.addSon(newSymNode(prc))
+        for i in 1 .. rc-1: macroCall.addSon(regs[rb+i].regToNode)
         let a = evalTemplate(macroCall, prc, genSymOwner)
         ensureKind(rkNode)
         regs[ra].node = a
@@ -1138,7 +1138,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       var u = regs[rb].node
       if u.kind notin {nkEmpty..nkNilLit}:
-        u.add(regs[rc].node)
+        u.addSon(regs[rc].node)
       else:
         stackTrace(c, tos, pc, errGenerated, "cannot add to node kind: " & $u.kind)
       regs[ra].node = u
@@ -1148,7 +1148,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       var u = regs[rb].node
       if u.kind notin {nkEmpty..nkNilLit}:
         # XXX can be optimized:
-        for i in 0.. <x.len: u.add(x.sons[i])
+        for i in 0.. <x.len: u.addSon(x.sons[i])
       else:
         stackTrace(c, tos, pc, errGenerated, "cannot add to node kind: " & $u.kind)
       regs[ra].node = u

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -612,18 +612,18 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeB(rkNode)
       let b = regs[rb].regToNode
       if not inSet(regs[ra].node, b):
-        addSon(regs[ra].node, copyTree(b))
+        add(regs[ra].node, copyTree(b))
     of opcInclRange:
       decodeBC(rkNode)
       var r = newNode(nkRange)
       r.sons = newSeq[PNode](2)
       r.sons[0] = regs[rb].regToNode
       r.sons[1] = regs[rc].regToNode
-      addSon(regs[ra].node, r.copyTree)
+      add(regs[ra].node, r.copyTree)
     of opcExcl:
       decodeB(rkNode)
       var b = newNodeIT(nkCurly, regs[ra].node.info, regs[ra].node.typ)
-      addSon(b, regs[rb].regToNode)
+      add(b, regs[rb].regToNode)
       var r = diffSets(regs[ra].node, b)
       regs[ra].node.sons = newSeq[PNode](sonsLen(r))
       for i in countup(0, sonsLen(r) - 1): regs[ra].node.sons[i] =  r.sons[i]
@@ -811,7 +811,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcAddSeqElem:
       decodeB(rkNode)
       if regs[ra].node.kind == nkBracket:
-        regs[ra].node.addSon(copyTree(regs[rb].regToNode))
+        regs[ra].node.add(copyTree(regs[rb].regToNode))
       else:
         stackTrace(c, tos, pc, errNilAccess)
     of opcGetImpl:
@@ -1139,7 +1139,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       var u = regs[rb].node
       if u.kind notin {nkEmpty..nkNilLit}:
-        u.addSon(regs[rc].node)
+        u.add(regs[rc].node)
       else:
         stackTrace(c, tos, pc, errGenerated, "cannot add to node kind: " & $u.kind)
       regs[ra].node = u
@@ -1149,7 +1149,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       var u = regs[rb].node
       if u.kind notin {nkEmpty..nkNilLit}:
         # XXX can be optimized:
-        for i in 0.. <x.len: u.addSon(x.sons[i])
+        for i in 0.. <x.len: u.add(x.sons[i])
       else:
         stackTrace(c, tos, pc, errGenerated, "cannot add to node kind: " & $u.kind)
       regs[ra].node = u

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1405,7 +1405,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       let bb = regs[rb].intVal.int
       for i in countup(0, regs[rc].intVal.int-1):
-        delSon(regs[ra].node, bb)
+        del(regs[ra].node, bb)
     of opcGenSym:
       decodeBC(rkNode)
       let k = regs[rb].intVal

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -181,8 +181,8 @@ proc copyValue(src: PNode): PNode =
   of nkIdent: result.ident = src.ident
   of nkStrLit..nkTripleStrLit: result.strVal = src.strVal
   else:
-    newSeq(result.sons, sonsLen(src))
-    for i in countup(0, sonsLen(src) - 1):
+    newSeq(result.sons, len(src))
+    for i in countup(0, len(src) - 1):
       result.sons[i] = copyValue(src.sons[i])
 
 proc asgnComplex(x: var TFullReg, y: TFullReg) =
@@ -625,8 +625,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       var b = newNodeIT(nkCurly, regs[ra].node.info, regs[ra].node.typ)
       add(b, regs[rb].regToNode)
       var r = diffSets(regs[ra].node, b)
-      regs[ra].node.sons = newSeq[PNode](sonsLen(r))
-      for i in countup(0, sonsLen(r) - 1): regs[ra].node.sons[i] =  r.sons[i]
+      regs[ra].node.sons = newSeq[PNode](len(r))
+      for i in countup(0, len(r) - 1): regs[ra].node.sons[i] =  r.sons[i]
     of opcCard:
       decodeB(rkInt)
       regs[ra].intVal = nimsets.cardSet(regs[rb].node)
@@ -944,7 +944,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       # we know the next instruction is a 'fjmp':
       let branch = c.constants[instr.regBx-wordExcess]
       var cond = false
-      for j in countup(0, sonsLen(branch) - 2):
+      for j in countup(0, len(branch) - 2):
         if overlap(regs[ra].regToNode, branch.sons[j]):
           cond = true
           break
@@ -1252,7 +1252,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                                 error = formatMsg(info, msg, arg))
       if not error.isNil:
         c.errorFlag = error
-      elif sonsLen(ast) != 1:
+      elif len(ast) != 1:
         c.errorFlag = formatMsg(c.debug[pc], errExprExpected, "multiple statements")
       else:
         regs[ra].node = ast.sons[0]

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -93,9 +93,9 @@ proc objectNode(n: PNode): PNode =
     result.sons[2] = ast.emptyNode  # no assigned value
   else:
     result = copyNode(n)
-    let sonsLen = n.safeLen
-    result.sons = newSeq[PNode](sonsLen)
-    for i in 0 ..< sonsLen:
+    let len = n.safeLen
+    result.sons = newSeq[PNode](len)
+    for i in 0 ..< len:
       result.sons[i] = objectNode(n[i])
 
 proc mapTypeToAstX(t: PType; info: TLineInfo;
@@ -213,8 +213,8 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
     result.add(copyTree(t.n))
   of tyTuple:
     if inst:
-      let sonsLen = t.n.sons.len
-      result = newNodeX(nkTupleTy, sonslen)
+      let sonsLen = t.n.len
+      result = newNodeX(nkTupleTy, sonsLen)
       for i in 0 ..< sonsLen:
         result.sons[i] = newIdentDefs(t.n.sons[i])
     else:

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -163,16 +163,16 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
   of tyGenericInst:
     if inst:
       if allowRecursion:
-        result = mapTypeToAstR(t.lastSon, info)
+        result = mapTypeToAstR(t.last, info)
       else:
         result = newNodeX(nkBracketExpr, t.len - 1)
-        result.sons[0] = mapTypeToAst(t.lastSon, info)
+        result.sons[0] = mapTypeToAst(t.last, info)
         for i in 1 .. < t.len-1:
           result.sons[i] = mapTypeToAst(t.sons[i], info)
     else:
-      result = mapTypeToAst(t.lastSon, info)
+      result = mapTypeToAst(t.last, info)
   of tyGenericBody, tyOrdinal, tyUserTypeClassInst:
-    result = mapTypeToAst(t.lastSon, info)
+    result = mapTypeToAst(t.last, info)
   of tyDistinct:
     if inst:
       result = newNodeX(nkDistinctTy, 1)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -349,7 +349,7 @@ proc genIf(c: PCtx, n: PNode; dest: var TDest) =
           elsePos = c.xjmp(it.sons[0], opcFJmp, tmp) # if false
       c.clearDest(n, dest)
       c.gen(it.sons[1], dest) # then part
-      if i < sonsLen(n)-1:
+      if i < len(n)-1:
         endings.add(c.xjmp(it.sons[1], opcJmp, 0))
       c.patch(elsePos)
     else:
@@ -393,8 +393,8 @@ proc sameConstant*(a, b: PNode): bool =
     of nkType, nkNilLit: result = a.typ == b.typ
     of nkEmpty: result = true
     else:
-      if sonsLen(a) == sonsLen(b):
-        for i in countup(0, sonsLen(a) - 1):
+      if len(a) == len(b):
+        for i in countup(0, len(a) - 1):
           if not sameConstant(a.sons[i], b.sons[i]): return
         result = true
 
@@ -439,7 +439,7 @@ proc genCase(c: PCtx; n: PNode; dest: var TDest) =
         c.gABx(it, opcBranch, tmp, b)
         let elsePos = c.xjmp(it.lastSon, opcFJmp, tmp)
         c.gen(it.lastSon, dest)
-        if i < sonsLen(n)-1:
+        if i < len(n)-1:
           endings.add(c.xjmp(it.lastSon, opcJmp, 0))
         c.patch(elsePos)
       c.clearDest(n, dest)
@@ -474,7 +474,7 @@ proc genTry(c: PCtx; n: PNode; dest: var TDest) =
         c.gABx(it, opcExcept, 0, 0)
       c.gen(it.lastSon, dest)
       c.clearDest(n, dest)
-      if i < sonsLen(n)-1:
+      if i < len(n)-1:
         endings.add(c.xjmp(it, opcJmp, 0))
       c.patch(endExcept)
   for endPos in endings: c.patch(endPos)
@@ -518,7 +518,7 @@ proc genCall(c: PCtx; n: PNode; dest: var TDest) =
   # varargs need 'opcSetType' for the FFI support:
   let fntyp = skipTypes(n.sons[0].typ, abstractInst)
   for i in 0.. <n.len:
-    #if i > 0 and i < sonsLen(fntyp):
+    #if i > 0 and i < len(fntyp):
     #  let paramType = fntyp.n.sons[i]
     #  if paramType.typ.isCompileTimeOnly: continue
     var r: TRegister = x+i
@@ -1439,10 +1439,10 @@ proc genArrAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
 proc getNullValueAux(obj: PNode, result: PNode) =
   case obj.kind
   of nkRecList:
-    for i in countup(0, sonsLen(obj) - 1): getNullValueAux(obj.sons[i], result)
+    for i in countup(0, len(obj) - 1): getNullValueAux(obj.sons[i], result)
   of nkRecCase:
     getNullValueAux(obj.sons[0], result)
-    for i in countup(1, sonsLen(obj) - 1):
+    for i in countup(1, len(obj) - 1):
       getNullValueAux(lastSon(obj.sons[i]), result)
   of nkSym:
     let field = newNodeI(nkExprColonExpr, result.info, 2)
@@ -1490,9 +1490,9 @@ proc getNullValue(typ: PType, info: TLineInfo): PNode =
     for i in countup(0, < tLen):
       result.sons[i] = getNullValue(elemType(t), info)
   of tyTuple:
-    result = newNodeI(nkPar, info, sonsLen(t))
+    result = newNodeI(nkPar, info, len(t))
     result.typ = t
-    for i in countup(0, sonsLen(t) - 1):
+    for i in countup(0, len(t) - 1):
       result.sons[i] = getNullValue(t.sons[i], info)
   of tySet:
     result = newNodeIT(nkCurly, info, t)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -376,7 +376,7 @@ proc rawGenLiteral(c: PCtx; n: PNode): int =
   result = c.constants.len
   #assert(n.kind != nkCall)
   n.flags.incl nfAllConst
-  c.constants.addSon(n.canonValue)
+  c.constants.add(n.canonValue)
   internalAssert result < 0x7fff
 
 proc sameConstant*(a, b: PNode): bool =
@@ -1137,13 +1137,13 @@ proc canElimAddr(n: PNode): PNode =
     if m.kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( nkConv ( deref ( x ) ) ) --> nkConv(x)
       result = copyNode(n.sons[0])
-      result.addSon(m.sons[0])
+      result.add(m.sons[0])
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     var m = n.sons[0].sons[1]
     if m.kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( nkConv ( deref ( x ) ) ) --> nkConv(x)
       result = copyNode(n.sons[0])
-      result.addSon(m.sons[0])
+      result.add(m.sons[0])
   else:
     if n.sons[0].kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( deref ( x )) --> x
@@ -1342,7 +1342,7 @@ proc importcSym(c: PCtx; info: TLineInfo; s: PSym) =
 proc getNullValue*(typ: PType, info: TLineInfo): PNode
 
 proc genGlobalInit(c: PCtx; n: PNode; s: PSym) =
-  c.globals.addSon(getNullValue(s.typ, n.info))
+  c.globals.add(getNullValue(s.typ, n.info))
   s.position = c.globals.len
   # This is rather hard to support, due to the laziness of the VM code
   # generator. See tests/compile/tmacro2 for why this is necessary:
@@ -1448,7 +1448,7 @@ proc getNullValueAux(obj: PNode, result: PNode) =
     let field = newNodeI(nkExprColonExpr, result.info, 2)
     field.sons[0] = obj
     field.sons[1] = getNullValue(obj.sym.typ, result.info)
-    addSon(result, field)
+    add(result, field)
   else: globalError(result.info, "cannot create null element for: " & $obj)
 
 proc getNullValue(typ: PType, info: TLineInfo): PNode =
@@ -1476,7 +1476,7 @@ proc getNullValue(typ: PType, info: TLineInfo): PNode =
       result.sons[1] = newNodeIT(nkNilLit, info, t)
   of tyObject:
     result = newNodeIT(nkObjConstr, info, t)
-    result.addSon(newNodeIT(nkEmpty, info, t))
+    result.add(newNodeIT(nkEmpty, info, t))
     # initialize inherited fields:
     var base = t.sons[0]
     while base != nil:
@@ -1523,7 +1523,7 @@ proc genVarSection(c: PCtx; n: PNode) =
             #if s.ast.isNil: getNullValue(s.typ, a.info)
             #else: canonValue(s.ast)
             assert sa.kind != nkCall
-            c.globals.addSon(sa)
+            c.globals.add(sa)
             s.position = c.globals.len
         if a.sons[2].kind != nkEmpty:
           let tmp = c.genx(a.sons[0], {gfAddrOf})

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -376,7 +376,7 @@ proc rawGenLiteral(c: PCtx; n: PNode): int =
   result = c.constants.len
   #assert(n.kind != nkCall)
   n.flags.incl nfAllConst
-  c.constants.add n.canonValue
+  c.constants.addSon(n.canonValue)
   internalAssert result < 0x7fff
 
 proc sameConstant*(a, b: PNode): bool =
@@ -1137,13 +1137,13 @@ proc canElimAddr(n: PNode): PNode =
     if m.kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( nkConv ( deref ( x ) ) ) --> nkConv(x)
       result = copyNode(n.sons[0])
-      result.add m.sons[0]
+      result.addSon(m.sons[0])
   of nkHiddenStdConv, nkHiddenSubConv, nkConv:
     var m = n.sons[0].sons[1]
     if m.kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( nkConv ( deref ( x ) ) ) --> nkConv(x)
       result = copyNode(n.sons[0])
-      result.add m.sons[0]
+      result.addSon(m.sons[0])
   else:
     if n.sons[0].kind in {nkDerefExpr, nkHiddenDeref}:
       # addr ( deref ( x )) --> x
@@ -1342,7 +1342,7 @@ proc importcSym(c: PCtx; info: TLineInfo; s: PSym) =
 proc getNullValue*(typ: PType, info: TLineInfo): PNode
 
 proc genGlobalInit(c: PCtx; n: PNode; s: PSym) =
-  c.globals.add(getNullValue(s.typ, n.info))
+  c.globals.addSon(getNullValue(s.typ, n.info))
   s.position = c.globals.len
   # This is rather hard to support, due to the laziness of the VM code
   # generator. See tests/compile/tmacro2 for why this is necessary:
@@ -1446,8 +1446,8 @@ proc getNullValueAux(obj: PNode, result: PNode) =
       getNullValueAux(lastSon(obj.sons[i]), result)
   of nkSym:
     let field = newNodeI(nkExprColonExpr, result.info)
-    field.add(obj)
-    field.add(getNullValue(obj.sym.typ, result.info))
+    field.addSon(obj)
+    field.addSon(getNullValue(obj.sym.typ, result.info))
     addSon(result, field)
   else: globalError(result.info, "cannot create null element for: " & $obj)
 
@@ -1471,11 +1471,11 @@ proc getNullValue(typ: PType, info: TLineInfo): PNode =
       result = newNodeIT(nkNilLit, info, t)
     else:
       result = newNodeIT(nkPar, info, t)
-      result.add(newNodeIT(nkNilLit, info, t))
-      result.add(newNodeIT(nkNilLit, info, t))
+      result.addSon(newNodeIT(nkNilLit, info, t))
+      result.addSon(newNodeIT(nkNilLit, info, t))
   of tyObject:
     result = newNodeIT(nkObjConstr, info, t)
-    result.add(newNodeIT(nkEmpty, info, t))
+    result.addSon(newNodeIT(nkEmpty, info, t))
     # initialize inherited fields:
     var base = t.sons[0]
     while base != nil:
@@ -1519,7 +1519,7 @@ proc genVarSection(c: PCtx; n: PNode) =
             #if s.ast.isNil: getNullValue(s.typ, a.info)
             #else: canonValue(s.ast)
             assert sa.kind != nkCall
-            c.globals.add(sa)
+            c.globals.addSon(sa)
             s.position = c.globals.len
         if a.sons[2].kind != nkEmpty:
           let tmp = c.genx(a.sons[0], {gfAddrOf})

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -437,10 +437,10 @@ proc genCase(c: PCtx; n: PNode; dest: var TDest) =
       else:
         let b = rawGenLiteral(c, it)
         c.gABx(it, opcBranch, tmp, b)
-        let elsePos = c.xjmp(it.lastSon, opcFJmp, tmp)
-        c.gen(it.lastSon, dest)
+        let elsePos = c.xjmp(it.last, opcFJmp, tmp)
+        c.gen(it.last, dest)
         if i < len(n)-1:
-          endings.add(c.xjmp(it.lastSon, opcJmp, 0))
+          endings.add(c.xjmp(it.last, opcJmp, 0))
         c.patch(elsePos)
       c.clearDest(n, dest)
   for endPos in endings: c.patch(endPos)
@@ -472,13 +472,13 @@ proc genTry(c: PCtx; n: PNode; dest: var TDest) =
       if blen == 1:
         # general except section:
         c.gABx(it, opcExcept, 0, 0)
-      c.gen(it.lastSon, dest)
+      c.gen(it.last, dest)
       c.clearDest(n, dest)
       if i < len(n)-1:
         endings.add(c.xjmp(it, opcJmp, 0))
       c.patch(endExcept)
   for endPos in endings: c.patch(endPos)
-  let fin = lastSon(n)
+  let fin = last(n)
   # we always generate an 'opcFinally' as that pops the safepoint
   # from the stack
   c.gABx(fin, opcFinally, 0, 0)
@@ -1443,7 +1443,7 @@ proc getNullValueAux(obj: PNode, result: PNode) =
   of nkRecCase:
     getNullValueAux(obj.sons[0], result)
     for i in countup(1, len(obj) - 1):
-      getNullValueAux(lastSon(obj.sons[i]), result)
+      getNullValueAux(last(obj.sons[i]), result)
   of nkSym:
     let field = newNodeI(nkExprColonExpr, result.info, 2)
     field.sons[0] = obj
@@ -1755,7 +1755,7 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
     for i in 0 .. <L: gen(c, n.sons[i])
     gen(c, n.sons[L], dest, flags)
   of nkPragmaBlock:
-    gen(c, n.lastSon, dest, flags)
+    gen(c, n.last, dest, flags)
   of nkDiscardStmt:
     unused(n, dest)
     gen(c, n.sons[0])
@@ -1933,7 +1933,7 @@ proc genProc(c: PCtx; s: PSym): int =
       genGenericParams(c, s.ast[genericParamsPos])
 
     if tfCapturesEnv in s.typ.flags:
-      #let env = s.ast.sons[paramsPos].lastSon.sym
+      #let env = s.ast.sons[paramsPos].last.sym
       #assert env.position == 2
       c.prc.slots[c.prc.maxSlots] = (inUse: true, kind: slotFixedLet)
       inc c.prc.maxSlots

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -45,7 +45,8 @@ proc setResult*(a: VmArgs; v: seq[string]) =
     myreset(s[a.ra])
     s[a.ra].kind = rkNode
   var n = newNode(nkBracket)
-  for x in v: n.addSon(newStrNode(nkStrLit, x))
+  n.sons = newSeq[PNode](v.len)
+  for i in 0 .. <v.len: n.sons[i] = newStrNode(nkStrLit, v[i])
   s[a.ra].node = n
 
 template getX(k, field) {.dirty.} =

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -45,7 +45,7 @@ proc setResult*(a: VmArgs; v: seq[string]) =
     myreset(s[a.ra])
     s[a.ra].kind = rkNode
   var n = newNode(nkBracket)
-  for x in v: n.add newStrNode(nkStrLit, x)
+  for x in v: n.addSon(newStrNode(nkStrLit, x))
   s[a.ra].node = n
 
 template getX(k, field) {.dirty.} =

--- a/compiler/vmmarshal.nim
+++ b/compiler/vmmarshal.nim
@@ -170,7 +170,7 @@ proc loadAny(p: var JsonParser, t: PType,
     next(p)
     result = newNode(nkBracket)
     while p.kind != jsonArrayEnd and p.kind != jsonEof:
-      result.addSon(loadAny(p, t.elemType, tab))
+      result.add(loadAny(p, t.elemType, tab))
     if p.kind == jsonArrayEnd: next(p)
     else: raiseParseErr(p, "']' end of array expected")
   of tySequence:
@@ -182,7 +182,7 @@ proc loadAny(p: var JsonParser, t: PType,
       next(p)
       result = newNode(nkBracket)
       while p.kind != jsonArrayEnd and p.kind != jsonEof:
-        result.addSon(loadAny(p, t.elemType, tab))
+        result.add(loadAny(p, t.elemType, tab))
       if p.kind == jsonArrayEnd: next(p)
       else: raiseParseErr(p, "")
     else:
@@ -198,7 +198,7 @@ proc loadAny(p: var JsonParser, t: PType,
       next(p)
       if i >= t.len:
         raiseParseErr(p, "too many fields to tuple type " & typeToString(t))
-      result.addSon(loadAny(p, t.sons[i], tab))
+      result.add(loadAny(p, t.sons[i], tab))
       inc i
     if p.kind == jsonObjectEnd: next(p)
     else: raiseParseErr(p, "'}' end of object expected")
@@ -219,8 +219,8 @@ proc loadAny(p: var JsonParser, t: PType,
       if pos >= result.sons.len:
         setLen(result.sons, pos + 1)
       let fieldNode = newNode(nkExprColonExpr)
-      fieldNode.addSon(newSymNode(newSym(skField, ident, nil, unknownLineInfo())))
-      fieldNode.addSon(loadAny(p, field.typ, tab))
+      fieldNode.add(newSymNode(newSym(skField, ident, nil, unknownLineInfo())))
+      fieldNode.add(loadAny(p, field.typ, tab))
       result.sons[pos] = fieldNode
     if p.kind == jsonObjectEnd: next(p)
     else: raiseParseErr(p, "'}' end of object expected")
@@ -229,7 +229,7 @@ proc loadAny(p: var JsonParser, t: PType,
     next(p)
     result = newNode(nkCurly)
     while p.kind != jsonArrayEnd and p.kind != jsonEof:
-      result.addSon(loadAny(p, t.lastSon, tab))
+      result.add(loadAny(p, t.lastSon, tab))
       next(p)
     if p.kind == jsonArrayEnd: next(p)
     else: raiseParseErr(p, "']' end of array expected")

--- a/compiler/vmmarshal.nim
+++ b/compiler/vmmarshal.nim
@@ -17,13 +17,13 @@ proc ptrToInt(x: PNode): int {.inline.} =
 proc getField(n: PNode; position: int): PSym =
   case n.kind
   of nkRecList:
-    for i in countup(0, sonsLen(n) - 1):
+    for i in countup(0, len(n) - 1):
       result = getField(n.sons[i], position)
       if result != nil: return
   of nkRecCase:
     result = getField(n.sons[0], position)
     if result != nil: return
-    for i in countup(1, sonsLen(n) - 1):
+    for i in countup(1, len(n) - 1):
       case n.sons[i].kind
       of nkOfBranch, nkElse:
         result = getField(lastSon(n.sons[i]), position)
@@ -38,7 +38,7 @@ proc storeAny(s: var string; t: PType; a: PNode; stored: var IntSet)
 proc storeObj(s: var string; typ: PType; x: PNode; stored: var IntSet) =
   internalAssert x.kind == nkObjConstr
   let start = 1
-  for i in countup(start, sonsLen(x) - 1):
+  for i in countup(start, len(x) - 1):
     if i > start: s.add(", ")
     var it = x.sons[i]
     if it.kind == nkExprColonExpr:

--- a/compiler/vmmarshal.nim
+++ b/compiler/vmmarshal.nim
@@ -170,7 +170,7 @@ proc loadAny(p: var JsonParser, t: PType,
     next(p)
     result = newNode(nkBracket)
     while p.kind != jsonArrayEnd and p.kind != jsonEof:
-      result.add loadAny(p, t.elemType, tab)
+      result.addSon(loadAny(p, t.elemType, tab))
     if p.kind == jsonArrayEnd: next(p)
     else: raiseParseErr(p, "']' end of array expected")
   of tySequence:
@@ -182,7 +182,7 @@ proc loadAny(p: var JsonParser, t: PType,
       next(p)
       result = newNode(nkBracket)
       while p.kind != jsonArrayEnd and p.kind != jsonEof:
-        result.add loadAny(p, t.elemType, tab)
+        result.addSon(loadAny(p, t.elemType, tab))
       if p.kind == jsonArrayEnd: next(p)
       else: raiseParseErr(p, "")
     else:
@@ -198,7 +198,7 @@ proc loadAny(p: var JsonParser, t: PType,
       next(p)
       if i >= t.len:
         raiseParseErr(p, "too many fields to tuple type " & typeToString(t))
-      result.add loadAny(p, t.sons[i], tab)
+      result.addSon(loadAny(p, t.sons[i], tab))
       inc i
     if p.kind == jsonObjectEnd: next(p)
     else: raiseParseErr(p, "'}' end of object expected")
@@ -229,7 +229,7 @@ proc loadAny(p: var JsonParser, t: PType,
     next(p)
     result = newNode(nkCurly)
     while p.kind != jsonArrayEnd and p.kind != jsonEof:
-      result.add loadAny(p, t.lastSon, tab)
+      result.addSon(loadAny(p, t.lastSon, tab))
       next(p)
     if p.kind == jsonArrayEnd: next(p)
     else: raiseParseErr(p, "']' end of array expected")

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -56,8 +56,8 @@ proc getCurrentExceptionMsgWrapper(a: VmArgs) {.nimcall.} =
 proc staticWalkDirImpl(path: string, relative: bool): PNode =
   result = newNode(nkBracket)
   for k, f in walkDir(path, relative):
-    result.add newTree(nkPar, newIntNode(nkIntLit, k.ord),
-                              newStrNode(nkStrLit, f))
+    result.addSon(newTree(nkPar, newIntNode(nkIntLit, k.ord),
+                              newStrNode(nkStrLit, f)))
 
 proc registerAdditionalOps*(c: PCtx) =
   wrap1f_math(sqrt)

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -56,7 +56,7 @@ proc getCurrentExceptionMsgWrapper(a: VmArgs) {.nimcall.} =
 proc staticWalkDirImpl(path: string, relative: bool): PNode =
   result = newNode(nkBracket)
   for k, f in walkDir(path, relative):
-    result.addSon(newTree(nkPar, newIntNode(nkIntLit, k.ord),
+    result.add(newTree(nkPar, newIntNode(nkIntLit, k.ord),
                               newStrNode(nkStrLit, f)))
 
 proc registerAdditionalOps*(c: PCtx) =

--- a/compiler/writetracking.nim
+++ b/compiler/writetracking.nim
@@ -77,11 +77,11 @@ proc allRoots(n: PNode; result: var seq[ptr TSym]; info: var set[RootInfo]) =
       if typ != nil:
         typ = skipTypes(typ, abstractInst)
         if typ.kind != tyProc: typ = nil
-        else: assert(sonsLen(typ) == sonsLen(typ.n))
+        else: assert(len(typ) == len(typ.n))
 
       for i in 1 ..< n.len:
         let it = n.sons[i]
-        if typ != nil and i < sonsLen(typ):
+        if typ != nil and i < len(typ):
           assert(typ.n.sons[i].kind == nkSym)
           let paramType = typ.n.sons[i]
           if paramType.typ.isCompileTimeOnly: continue
@@ -157,10 +157,10 @@ proc depsArgs(w: var W; n: PNode) =
   var typ = skipTypes(n.sons[0].typ, abstractInst)
   if typ.kind != tyProc: return
   # echo n.info, " ", n, " ", w.owner.name.s, " ", typeToString(typ)
-  assert(sonsLen(typ) == sonsLen(typ.n))
+  assert(len(typ) == len(typ.n))
   for i in 1 ..< n.len:
     let it = n.sons[i]
-    if i < sonsLen(typ):
+    if i < len(typ):
       assert(typ.n.sons[i].kind == nkSym)
       let paramType = typ.n.sons[i]
       if paramType.typ.isCompileTimeOnly: continue

--- a/compiler/writetracking.nim
+++ b/compiler/writetracking.nim
@@ -65,7 +65,7 @@ proc allRoots(n: PNode; result: var seq[ptr TSym]; info: var set[RootInfo]) =
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv, nkConv,
       nkStmtList, nkStmtListExpr, nkBlockStmt, nkBlockExpr, nkOfBranch,
       nkElifBranch, nkElse, nkExceptBranch, nkFinally, nkCast:
-    allRoots(n.lastSon, result, info)
+    allRoots(n.last, result, info)
   of nkCallKinds:
     if getMagic(n) == mSlice:
       allRoots(n.sons[1], result, info)
@@ -119,7 +119,7 @@ proc returnsNewExpr*(n: PNode): NewLocation =
   of nkExprEqExpr, nkExprColonExpr, nkHiddenStdConv, nkHiddenSubConv,
       nkStmtList, nkStmtListExpr, nkBlockStmt, nkBlockExpr, nkOfBranch,
       nkElifBranch, nkElse, nkExceptBranch, nkFinally, nkCast:
-    result = returnsNewExpr(n.lastSon)
+    result = returnsNewExpr(n.last)
   of nkCurly, nkBracket, nkPar, nkObjConstr, nkClosure,
       nkIfExpr, nkIfStmt, nkWhenStmt, nkCaseStmt, nkTryStmt:
     result = newLit
@@ -177,7 +177,7 @@ proc deps(w: var W; n: PNode) =
   case n.kind
   of nkLetSection, nkVarSection:
     for child in n:
-      let last = lastSon(child)
+      let last = last(child)
       if last.kind == nkEmpty: continue
       if child.kind == nkVarTuple and last.kind == nkPar:
         internalAssert child.len-2 == last.len


### PR DESCRIPTION
Main points:
1. `ast.add` and `ast.addSons` have the same implementation. Replace calls of the former with the latter.
2. Pre-allocate `PNode` sons where possible. This reduces the compiler build time by approx 2%.

Nb: This patch reduces the size of the compiler binary too. (Around 8kb difference on my system)
