### PR TITLE
Implement population count operation in standard library

### DIFF
--- a/tests/stdlib/tmathcountbits.nim
+++ b/tests/stdlib/tmathcountbits.nim
@@ -1,0 +1,53 @@
+discard """
+  output: '''ok.'''
+"""
+
+from math import countBits
+
+# Trivial test cases:
+
+assert countBits(0x00u8) == 0
+assert countBits(0x00i8) == 0
+assert countBits(0x0000u16) == 0
+assert countBits(0x0000i16) == 0
+assert countBits(0x00000000u32) == 0
+assert countBits(0x00000000i32) == 0
+assert countBits(0x0000000000000000u64) == 0
+assert countBits(0x0000000000000000i64) == 0
+
+assert countBits(0xFFu8) == 8
+assert countBits(-0x01i8) == 8
+assert countBits(0xFFFFu16) == 16
+assert countBits(-0x0001i16) == 16
+assert countBits(0xFFFFFFFFu32) == 32
+assert countBits(-0x00000001i32) == 32
+assert countBits(0xFFFFFFFFFFFFFFFFu64) == 64
+assert countBits(-0x0000000000000001i64) == 64
+
+# Pseudorandomly generated test cases:
+
+assert countBits(0x3Au8) == 4
+assert countBits(0xCFu8) == 6
+
+assert countBits(0x57i8) == 5
+assert countBits(-0x26i8) == 5
+
+assert countBits(0x52D3u16) == 8
+assert countBits(0xAE11u16) == 7
+
+assert countBits(0x270Bi16) == 7
+assert countBits(-0x14E9i16) == 10
+
+assert countBits(0x2645FF7Eu32) == 20
+assert countBits(0xEEF7AD2Fu32) == 23
+
+assert countBits(0x78DC90B6i32) == 16
+assert countBits(-0x24FC9206i32) == 19
+
+assert countBits(0x7551227A13420B20u64) == 24
+assert countBits(0xDDC992D8CE90712Du64) == 32
+
+assert countBits(0x5D6D6A6A01DE8A36i64) == 32
+assert countBits(-0x0991174FDC4A9E3Bi64) == 33
+
+echo "ok."


### PR DESCRIPTION
Adds the countBits (population count) operation for arguments of any of the main 10 integer types.

Implementation defaults to a 256-byte lookup table, but can be switched to use the C compiler's implementation or the CPU's `popcnt` instruction (if available) though the use of compile-time flags (`-d:ccCountBits` and `-d:hardwareCountBits` respectively). This aims to preserve portability by using a software implementation that works everywhere by default, and allowing the user to switch to a better implementation if they're sure that their compiler and target CPU support it.

Also adds a simple test suite for the function. This only tests the default implementation (debug mode, lookup table). It would be nice to test all combinations of `-d:release`, `-d:ccCountBits` and `-d:hardwareCountBits` if possible, but I'm not sure how to integrate this into Nim's test suite.

Benchmarking on my machine (Intel i7-3610QM CPU, gcc 6.1.1) using a simple [benchmark program](https://gist.github.com/kierdavis/db152906d03ed5995ebedab6847d30fd) powered by [nimbench](https://github.com/ivankoster/nimbench) gives the following results:

| Function | `-d:release` | `-d:release -d:ccCountBits` | `-d:release -d:hardwareCountBits` |
| --- | --- | --- | --- |
| `countBits(uint8)` | 303.77 ps | 2730 ps | 294.27ps |
| `countBits(uint16)` | 304.75 ps | 2730 ps | 294.34ps |
| `countBits(uint32)` | 996.04 ps | 2730 ps | 313.28ps |
| `countBits(uint64)` | 2210 ps | 2730 ps | 313.29ps |

In this case when the  `popcnt` instruction is available on the target CPU and generation of it is enabled through the use of `-d:hardwareCountBits`, execution can be up to seven times faster than the lookup table implementation.

The `math` module previously contained a `countBits32` function, which performed the same operation but using a bit-twiddling software algorithm. This has been deprecated, instead favouring the `countBits` function. Whilst I've not benchmarked `countBits32`, the algorithm is similar to the implementation emitted by `gcc` when `-d:ccCountBits` is active, and so could be expected to be about as fast.
