### PR TITLE
Display error message if defer statement is used at top level

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -443,6 +443,8 @@ proc isImportSystemStmt(n: PNode): bool =
   else: discard
 
 proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
+  if n.kind == nkDefer:
+    localError(n.info, "defer statement not supported at top level")
   if c.topStmts == 0 and not isImportSystemStmt(n):
     if sfSystemModule notin c.module.flags and
         n.kind notin {nkEmpty, nkCommentStmt}:


### PR DESCRIPTION
In the manual:

> Top level defer statements are not supported since it's unclear what such a statement should refer to.

Currently, compiling a module containing a defer statement at top level, such as:

```nim
defer: echo "deferred"
echo "hello, world!"
```

causes the compiler to crash with the following traceback:

```
test.nim(1, 1) Error: internal error: expr(nkDefer); unknown node kind
Traceback (most recent call last)
nim.nim(115)             nim
nim.nim(71)              handleCmdLine
main.nim(254)            mainCommand
main.nim(65)             commandCompileToC
modules.nim(238)         compileProject
system.nim(1103)         compileModule
passes.nim(198)          processModule
passes.nim(131)          processTopLevelStmt
cgen.nim(1215)           myProcess
ccgstmts.nim(1121)       genStmts
ccgexprs.nim(2136)       expr
msgs.nim(994)            internalError
msgs.nim(968)            liMessage
msgs.nim(840)            handleError
msgs.nim(824)            quit
FAILURE
```

This PR makes the compiler produce a normal error message instead:

```
test.nim(1, 1) Error: defer statement not supported at top level
FAILURE
```
