### PR TITLE
Async: Get system backend handle.

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1238,7 +1238,7 @@ else:
 
   proc getSelector*(disp: PDispatcher): pointer =
     ## Retrieves the global thread-local dispatcher's backend as pointer.
-    result = cast[pointer](disp.selector)
+    result = cast[pointer](addr disp.selector)
 
   proc update(fd: AsyncFD, events: set[Event]) =
     let p = getGlobalDispatcher()

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -477,6 +477,10 @@ when defined(windows) or defined(nimdoc):
     if gDisp.isNil: gDisp = newDispatcher()
     result = gDisp
 
+  proc getSelector*(disp: PDispatcher): pointer =
+    ## Retrieves the global thread-local dispatcher's backend as pointer.
+    result = cast[pointer](disp.ioPort)
+
   proc register*(fd: AsyncFD) =
     ## Registers ``fd`` with the dispatcher.
     let p = getGlobalDispatcher()
@@ -1231,6 +1235,10 @@ else:
   proc getGlobalDispatcher*(): PDispatcher =
     if gDisp.isNil: gDisp = newDispatcher()
     result = gDisp
+
+  proc getSelector*(disp: PDispatcher): pointer =
+    ## Retrieves the global thread-local dispatcher's backend as pointer.
+    result = cast[pointer](disp.selector)
 
   proc update(fd: AsyncFD, events: set[Event]) =
     let p = getGlobalDispatcher()

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -483,6 +483,10 @@ when defined(windows) or defined(nimdoc):
     if gDisp.isNil: gDisp = newDispatcher()
     result = gDisp
 
+  proc getSelector*(disp: PDispatcher): pointer =
+    ## Retrieves the global thread-local dispatcher's backend as pointer.
+    result = cast[pointer](disp.ioPort)
+
   proc register*(fd: AsyncFD) =
     ## Registers ``fd`` with the dispatcher.
     let p = getGlobalDispatcher()
@@ -1385,6 +1389,10 @@ else:
   proc getGlobalDispatcher*(): PDispatcher =
     if gDisp.isNil: gDisp = newDispatcher()
     result = gDisp
+
+  proc getSelector*(disp: PDispatcher): pointer =
+    ## Retrieves the global thread-local dispatcher's backend as pointer.
+    result = cast[pointer](disp.selector)
 
   proc register*(fd: AsyncFD) =
     let p = getGlobalDispatcher()


### PR DESCRIPTION
Improve flexibility of asyncdispatch.
Windows is more flexible, then Unix OS's because almost all handles can be wrapped via RegisterWaitForSingleObject to use IOCP. But this mechanism needs access to ioPort member of PDispatcher.
Unix version of `getSelector` procedure is added for compatibility, there not so many use-cases for it.