### PR TITLE
Fix AsyncFD send

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1589,7 +1589,7 @@ proc send*(socket: AsyncFD, data: string,
                # or failed.
 
   let sendFut = socket.send(addr copiedData[0], data.len, flags)
-  sendFut.cb =
+  sendFut.callback =
     proc () =
       GC_unref(copiedData)
       if sendFut.failed:

--- a/tests/async/tasyncsend4757.nim
+++ b/tests/async/tasyncsend4757.nim
@@ -11,6 +11,4 @@ proc f(): Future[void] {.async.} =
   await s.send("123")
   echo "Finished"
 
-asyncCheck f()
-
-poll(1000)
+waitFor f()

--- a/tests/async/tasyncsend4757.nim
+++ b/tests/async/tasyncsend4757.nim
@@ -1,0 +1,16 @@
+discard """
+  file: "tasyncsend4754.nim"
+  output: "Finished"
+"""
+
+import asyncdispatch
+
+proc f(): Future[void] {.async.} =
+  let s = newAsyncNativeSocket()
+  await s.connect("example.com", 80.Port)
+  await s.send("123")
+  echo "Finished"
+
+asyncCheck f()
+
+poll(1000)


### PR DESCRIPTION
Fixes #4757.
The intermediate `Future` was already finished when returned, so `cb` was never called.