### PR TITLE
Marking forward declaration of sha1 gcsafe

### DIFF
--- a/lib/pure/securehash.nim
+++ b/lib/pure/securehash.nim
@@ -15,7 +15,7 @@ type
   Sha1Digest = array[0 .. Sha1DigestSize-1, uint8]
   SecureHash* = distinct Sha1Digest
 
-proc sha1(src: string) : Sha1Digest {.gcsafe.}
+proc sha1(src: string) : Sha1Digest {.noSideEffect.}
 
 proc secureHash*(str: string): SecureHash = SecureHash(sha1(str))
 proc secureHashFile*(filename: string): SecureHash = secureHash(readFile(filename))

--- a/lib/pure/securehash.nim
+++ b/lib/pure/securehash.nim
@@ -15,7 +15,7 @@ type
   Sha1Digest = array[0 .. Sha1DigestSize-1, uint8]
   SecureHash* = distinct Sha1Digest
 
-proc sha1(src: string) : Sha1Digest
+proc sha1(src: string) : Sha1Digest {.gcsafe.}
 
 proc secureHash*(str: string): SecureHash = SecureHash(sha1(str))
 proc secureHashFile*(filename: string): SecureHash = secureHash(readFile(filename))

--- a/lib/pure/securehash.nim
+++ b/lib/pure/securehash.nim
@@ -15,7 +15,7 @@ type
   Sha1Digest = array[0 .. Sha1DigestSize-1, uint8]
   SecureHash* = distinct Sha1Digest
 
-proc sha1(src: string) : Sha1Digest {.noSideEffect.}
+proc sha1(src: string) : Sha1Digest {.gcsafe.}
 
 proc secureHash*(str: string): SecureHash = SecureHash(sha1(str))
 proc secureHashFile*(filename: string): SecureHash = secureHash(readFile(filename))


### PR DESCRIPTION
Currently module securehash cannot be used in a thread context, because the compiler complains proc secureHash is not gcsafe. Marking the forward declaration of sha1 gcsafe seems to fix this.

Fixes #4760 