### PR TITLE
Misc minor (doc) fixes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 if [ ! -e csources/.git ]; then
-	git clone --depth 1 git://github.com/nim-lang/csources.git csources
+	git clone --depth 1 https://github.com/nim-lang/csources.git csources
 fi
 
 cd "csources"

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -674,17 +674,18 @@ variable number of arguments:
 
   macro debug(n: varargs[expr]): stmt =
     # `n` is a Nim AST that contains a list of expressions;
-    # this macro returns a list of statements:
+    # this macro returns a list of statements (n is passed for proper line
+    # information):
     result = newNimNode(nnkStmtList, n)
     # iterate over any argument that is passed to this macro:
-    for i in 0..n.len-1:
+    for x in n:
       # add a call to the statement list that writes the expression;
       # `toStrLit` converts an AST to its string representation:
-      result.add(newCall("write", newIdentNode("stdout"), toStrLit(n[i])))
+      result.add(newCall("write", newIdentNode("stdout"), toStrLit(x)))
       # add a call to the statement list that writes ": "
       result.add(newCall("write", newIdentNode("stdout"), newStrLitNode(": ")))
       # add a call to the statement list that writes the expressions value:
-      result.add(newCall("writeLine", newIdentNode("stdout"), n[i]))
+      result.add(newCall("writeLine", newIdentNode("stdout"), x))
 
   var
     a: array[0..10, int]

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -179,7 +179,7 @@ proc sort*[T](a: var openArray[T],
   ##    sort(myStrArray, system.cmp)
   ##
   ## You can inline adhoc comparison procs with the `do notation
-  ## <manual.html#do-notation>`_. Example:
+  ## <manual.html#procedures-do-notation>`_. Example:
   ##
   ## .. code-block:: nim
   ##

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1047,7 +1047,7 @@ proc copyDir*(source, dest: string) {.rtl, extern: "nos$1",
 
 proc createSymlink*(src, dest: string) =
   ## Create a symbolic link at `dest` which points to the item specified
-  ## by `src`. On most operating systems, will fail if a lonk
+  ## by `src`. On most operating systems, will fail if a link already exists.
   ##
   ## **Warning**:
   ## Some OS's (such as Microsoft Windows) restrict the creation

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1070,8 +1070,8 @@ proc createHardlink*(src, dest: string) =
   ## Create a hard link at `dest` which points to the item specified
   ## by `src`.
   ##
-  ## **Warning**: Most OS's restrict the creation of hard links to
-  ## root users (administrators) .
+  ## **Warning**: Some OS's restrict the creation of hard links to
+  ## root users (administrators).
   when defined(Windows):
     when useWinUnicode:
       var wSrc = newWideCString(src)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -891,8 +891,8 @@ proc `shl` *(x, y: int64): int64 {.magic: "ShlI", noSideEffect.}
   ## computes the `shift left` operation of `x` and `y`.
   ##
   ## .. code-block:: Nim
-  ##  1'i32 shl 4  == 0x0000_0010
-  ##  1'i64 shl 4  == 0x0000_0000_0000_0010
+  ##  1'i32 shl 4 == 0x0000_0010
+  ##  1'i64 shl 4 == 0x0000_0000_0000_0010
 
 proc `and` *(x, y: int): int {.magic: "BitandI", noSideEffect.}
 proc `and` *(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2794,7 +2794,7 @@ when not defined(JS): #and not defined(nimscript):
 
     proc writeLine*[Ty](f: File, x: varargs[Ty, `$`]) {.inline,
                              tags: [WriteIOEffect], benign.}
-      ## writes the values `x` to `f` and then writes "\n".
+      ## writes the values `x` to `f` and then writes "\\n".
       ## May throw an IO exception.
 
     proc getFileSize*(f: File): int64 {.tags: [ReadIOEffect], benign.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -226,6 +226,7 @@ proc high*[T](x: T): T {.magic: "High", noSideEffect.}
   ##  var arr = [1,2,3,4,5,6,7]
   ##  high(arr) #=> 6
   ##  high(2) #=> 9223372036854775807
+  ##  high(int) #=> 9223372036854775807
 
 proc low*[T](x: T): T {.magic: "Low", noSideEffect.}
   ## returns the lowest possible index of an array, a sequence, a string or
@@ -236,6 +237,7 @@ proc low*[T](x: T): T {.magic: "Low", noSideEffect.}
   ##  var arr = [1,2,3,4,5,6,7]
   ##  low(arr) #=> 0
   ##  low(2) #=> -9223372036854775808
+  ##  low(int) #=> -9223372036854775808
 
 type
   range*{.magic: "Range".}[T] ## Generic type to construct range types.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1313,20 +1313,20 @@ when defined(boehmgc):
 
 when taintMode:
   type TaintedString* = distinct string ## a distinct string type that
-                                        ## is `tainted`:idx:. It is an alias for
+                                        ## is `tainted`:idx:, see `taint mode
+                                        ## <manual.html#taint-mode>`_ for
+                                        ## details. It is an alias for
                                         ## ``string`` if the taint mode is not
-                                        ## turned on. Use the ``-d:taintMode``
-                                        ## command line switch to turn the taint
-                                        ## mode on.
+                                        ## turned on.
 
   proc len*(s: TaintedString): int {.borrow.}
 else:
   type TaintedString* = string          ## a distinct string type that
-                                        ## is `tainted`:idx:. It is an alias for
+                                        ## is `tainted`:idx:, see `taint mode
+                                        ## <manual.html#taint-mode>`_ for
+                                        ## details. It is an alias for
                                         ## ``string`` if the taint mode is not
-                                        ## turned on. Use the ``-d:taintMode``
-                                        ## command line switch to turn the taint
-                                        ## mode on.
+                                        ## turned on.
 
 when defined(profiler):
   proc nimProfile() {.compilerProc, noinline.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -605,7 +605,7 @@ proc `<`*[T](x: Ordinal[T]): T {.magic: "UnaryLt", noSideEffect.}
   ## unary ``<`` that can be used for nice looking excluding ranges:
   ##
   ## .. code-block:: nim
-  ##   for i in 0 .. <10: echo i
+  ##   for i in 0 .. <10: echo i #=> 0 1 2 3 4 5 6 7 8 9
   ##
   ## Semantically this is the same as ``pred``.
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1412,7 +1412,7 @@ proc del*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
   ## This is an O(1) operation.
   ##
   ## .. code-block:: nim
-  ##  var i = @[1,2,3,4,5]
+  ##  var i = @[1, 2, 3, 4, 5]
   ##  i.del(2) #=> @[1, 2, 5, 4]
   let xl = x.len - 1
   shallowCopy(x[i], x[xl])
@@ -1423,7 +1423,7 @@ proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
   ## This is an O(n) operation.
   ##
   ## .. code-block:: nim
-  ##  var i = @[1,2,3,4,5]
+  ##  var i = @[1, 2, 3, 4, 5]
   ##  i.delete(2) #=> @[1, 2, 4, 5]
   template defaultImpl =
     let xl = x.len
@@ -1442,8 +1442,8 @@ proc insert*[T](x: var seq[T], item: T, i = 0.Natural) {.noSideEffect.} =
   ## inserts `item` into `x` at position `i`.
   ##
   ## .. code-block:: nim
-  ##  var i = @[1,2,3,4,5]
-  ##  i.insert(2,4) #=> @[1, 2, 3, 4, 2, 5]
+  ##  var i = @[1, 2, 3, 4, 5]
+  ##  i.insert(2, 4) #=> @[1, 2, 3, 4, 2, 5]
   template defaultImpl =
     let xl = x.len
     setLen(x, xl+1)
@@ -1467,8 +1467,8 @@ proc repr*[T](x: T): string {.magic: "Repr", noSideEffect.}
   ## debugging tool.
   ##
   ## .. code-block:: nim
-  ##  var s: seq[string] = @["test2","test2"]
-  ##  var i = @[1,2,3,4,5]
+  ##  var s: seq[string] = @["test2", "test2"]
+  ##  var i = @[1, 2, 3, 4, 5]
   ##  repr(s) #=> 0x1055eb050[0x1055ec050"test2", 0x1055ec078"test2"]
   ##  repr(i) #=> 0x1055ed050[1, 2, 3, 4, 5]
 

--- a/tests/manyloc/keineschweine/README.md
+++ b/tests/manyloc/keineschweine/README.md
@@ -11,7 +11,7 @@ Just a dumb little game
 
 ### How to build?
 
-* `git clone --recursive git://github.com/fowlmouth/keineSchweine.git somedir`
+* `git clone --recursive https://github.com/fowlmouth/keineSchweine.git somedir`
 * `cd somedir`
 *  `nim c -r nakefile test` or `nim c -r keineschweine && ./keineschweine`
 

--- a/web/download.rst
+++ b/web/download.rst
@@ -70,9 +70,9 @@ directory where you would like the download to take place.
 The following commands can be used to download the current development branch
 and then to build it::
 
-  git clone git://github.com/nim-lang/Nim.git
+  git clone https://github.com/nim-lang/Nim.git
   cd Nim
-  git clone --depth 1 git://github.com/nim-lang/csources
+  git clone --depth 1 https://github.com/nim-lang/csources
   cd csources && sh build.sh
   cd ..
   bin/nim c koch


### PR DESCRIPTION
Minor doc fixes for a few issues I noticed while reading the docs. The first one changes git urls to always use https, not only in docs but also in a few scripts.

I'm not sure if "doc: tut2: simplify debug macro example" is entirely correct as I have no experience with nim's macros. But the result seems to work fine.