### PR TITLE
[Compiler Messages] Change kind of message position after title

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -652,7 +652,7 @@ proc suggestQuit*() =
 # Borland and Freepascal use
 const
   PosFormat    = "$1($2, $3) "
-  KindFormat   = " [$1]"
+  KindFormat   = "[$1] "
   KindColor    = fgCyan
   ErrorTitle   = "Error: "
   ErrorColor   = fgRed
@@ -894,8 +894,8 @@ proc rawMessage*(msg: TMsgKind, args: openArray[string]) =
   let s = `%`(msgKindToString(msg), args)
   if not ignoreMsgBecauseOfIdeTools(msg):
     if kind != nil:
-      styledMsgWriteln(color, title, resetStyle, s,
-                       KindColor, `%`(KindFormat, kind))
+      styledMsgWriteln(color, title, KindColor, 
+        `%`(KindFormat, kind), resetStyle, s)
     else:
       styledMsgWriteln(color, title, resetStyle, s)
   handleError(msg, doAbort, s)
@@ -959,8 +959,8 @@ proc liMessage(info: TLineInfo, msg: TMsgKind, arg: string,
   let s = getMessageStr(msg, arg)
   if not ignoreMsg and not ignoreMsgBecauseOfIdeTools(msg):
     if kind != nil:
-      styledMsgWriteln(styleBright, x, resetStyle, color, title, resetStyle, s,
-                       KindColor, `%`(KindFormat, kind))
+      styledMsgWriteln(styleBright, x, resetStyle, color, title,
+        KindColor, `%`(KindFormat, kind), resetStyle, s)
     else:
       styledMsgWriteln(styleBright, x, resetStyle, color, title, resetStyle, s)
     if msg in errMin..errMax and hintSource in gNotes:

--- a/tests/deprecated/tdeprecated.nim
+++ b/tests/deprecated/tdeprecated.nim
@@ -1,5 +1,5 @@
 discard """
-  nimout: "a is deprecated [Deprecated]"
+  nimout: "a is deprecated"
 """
 
 var

--- a/tests/exprs/tresultwarning.nim
+++ b/tests/exprs/tresultwarning.nim
@@ -1,5 +1,5 @@
 discard """
-  nimout: "Special variable 'result' is shadowed. [ResultShadowed]"
+  nimout: "Special variable 'result' is shadowed."
 """
 
 proc test(): string =

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -58,7 +58,7 @@ let
   pegLineTemplate =
     peg"{[^(]*} '(' {\d+} ', ' {\d+} ') ' 'template/generic instantiation from here'.*"
   pegOtherError = peg"'Error:' \s* {.*}"
-  pegSuccess = peg"'Hint: operation successful'.*"
+  pegSuccess = peg"'Hint: [SuccessX] operation successful'.*"
   pegOfInterest = pegLineError / pegOtherError
 
 var targets = {low(TTarget)..high(TTarget)}


### PR DESCRIPTION
With this change compiler messages are displayed in a more pleasant way (From general to more specific), which makes reading the output easier and easthetic to the eyes compared to how it was previously handled:

_Changes in tester.nim requires a careful review. I didn't find any problem in my tests but i'm not sure if i should have taken anything else into account._

![Result](https://i.imgur.com/ZVXIHqY.gif)
