### PR TITLE
fix missing procvar in asyncftpclient

### DIFF
--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -281,7 +281,7 @@ proc getFile(ftp: AsyncFtpClient, file: File, total: BiggestInt,
   assertReply(await(ftp.expectReply()), "226")
 
 proc defaultOnProgressChanged*(total, progress: BiggestInt,
-    speed: float): Future[void] {.nimcall,gcsafe.} =
+    speed: float): Future[void] {.nimcall,gcsafe,procvar.} =
   ## Default FTP ``onProgressChanged`` handler. Does nothing.
   result = newFuture[void]()
   #echo(total, " ", progress, " ", speed)


### PR DESCRIPTION
I am trying to fix issue #4681 with the missing procvar on the defaultOnProgressChanged proc. After adding the pragma the problem went away.