### PR TITLE
First attempt to fix #4777

### DIFF
--- a/tests/async/tnewasyncudp.nim
+++ b/tests/async/tnewasyncudp.nim
@@ -40,7 +40,7 @@ proc launchSwarm(name: ptr SockAddr) {.async.} =
   var i = 0
   var k = 0
   while i < swarmSize:
-    var peeraddr = prepareAddress(INADDR_ANY, 0)
+    var peeraddr = prepareAddress(INADDR_LOOPBACK, 0)
     var sock = newAsyncNativeSocket(nativesockets.AF_INET,
                                     nativesockets.SOCK_DGRAM,
                                     Protocol.IPPROTO_UDP)
@@ -81,7 +81,7 @@ proc readMessages(server: AsyncFD) {.async.} =
     inc(i)
 
 proc createServer() {.async.} =
-  var name = prepareAddress(INADDR_ANY, serverPort)
+  var name = prepareAddress(INADDR_LOOPBACK, serverPort)
   var server = newAsyncNativeSocket(nativesockets.AF_INET,
                                     nativesockets.SOCK_DGRAM,
                                     Protocol.IPPROTO_UDP)
@@ -90,7 +90,7 @@ proc createServer() {.async.} =
     raiseOSError(osLastError())
   asyncCheck readMessages(server)
 
-var name = prepareAddress(0x7F000001, serverPort) # 127.0.0.1
+var name = prepareAddress(INADDR_LOOPBACK, serverPort) # 127.0.0.1
 asyncCheck createServer()
 asyncCheck launchSwarm(cast[ptr SockAddr](name))
 while true:

--- a/tests/async/tnewasyncudp.nim
+++ b/tests/async/tnewasyncudp.nim
@@ -40,7 +40,7 @@ proc launchSwarm(name: ptr SockAddr) {.async.} =
   var i = 0
   var k = 0
   while i < swarmSize:
-    var peeraddr = prepareAddress(INADDR_LOOPBACK, 0)
+    var peeraddr = prepareAddress(0x7F000001, 0)
     var sock = newAsyncNativeSocket(nativesockets.AF_INET,
                                     nativesockets.SOCK_DGRAM,
                                     Protocol.IPPROTO_UDP)
@@ -81,7 +81,7 @@ proc readMessages(server: AsyncFD) {.async.} =
     inc(i)
 
 proc createServer() {.async.} =
-  var name = prepareAddress(INADDR_LOOPBACK, serverPort)
+  var name = prepareAddress(0x7F000001, serverPort)
   var server = newAsyncNativeSocket(nativesockets.AF_INET,
                                     nativesockets.SOCK_DGRAM,
                                     Protocol.IPPROTO_UDP)
@@ -90,7 +90,7 @@ proc createServer() {.async.} =
     raiseOSError(osLastError())
   asyncCheck readMessages(server)
 
-var name = prepareAddress(INADDR_LOOPBACK, serverPort) # 127.0.0.1
+var name = prepareAddress(0x7F000001, serverPort) # 127.0.0.1
 asyncCheck createServer()
 asyncCheck launchSwarm(cast[ptr SockAddr](name))
 while true:


### PR DESCRIPTION
It can happens Windows Firewall can block communication if socket binded to INADDR_ANY. Replaced to INADDR_LOOPBACK to avoid Windows Firewall issues.