### PR TITLE
Use array encoding for non-UTF-8 strings in marshal

### DIFF
--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -1,5 +1,7 @@
 discard """
-  output: '''{"age": 12, "name": "Cletus"}'''
+  output: '''{"age": 12, "bio": "\u042F Cletus", "blob": [65, 66, 67, 128], "name": "Cletus"}
+true
+true'''
 """
 
 import marshal
@@ -72,6 +74,12 @@ type
 
   Person = object of Entity
     age: int
+    bio: string
+    blob: string
 
-var instance1 = Person(name: "Cletus", age: 12)
+var instance1 = Person(name: "Cletus", age: 12,
+                       bio: "Я Cletus",
+                       blob: "ABC\x80")
 echo($$instance1)
+echo(to[Person]($$instance1).bio == instance1.bio)
+echo(to[Person]($$instance1).blob == instance1.blob)


### PR DESCRIPTION
Now it's backward compatible and handles binary data at the cost of additional traversal to validate UTF-8. @Araq @dom96 thoughts?