### PR TITLE
tests: tnewasyncudp: use constant

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -1694,6 +1694,8 @@ var
 
   INADDR_ANY* {.importc, header: "<netinet/in.h>".}: InAddrScalar
     ## IPv4 local host address.
+  INADDR_LOOPBACK* {.importc, header: "<netinet/in.h>".}: InAddrScalar
+    ## IPv4 loopback address.
   INADDR_BROADCAST* {.importc, header: "<netinet/in.h>".}: InAddrScalar
     ## IPv4 broadcast address.
 

--- a/tests/async/tnewasyncudp.nim
+++ b/tests/async/tnewasyncudp.nim
@@ -43,7 +43,7 @@ proc launchSwarm(name: ptr SockAddr) {.async.} =
   var slen = sizeof(Sockaddr_in).SockLen
   var saddr = Sockaddr_in()
   while i < swarmSize:
-    var peeraddr = prepareAddress(0x7F000001, 0)
+    var peeraddr = prepareAddress(INADDR_LOOPBACK, 0)
     var sock = newAsyncNativeSocket(nativesockets.AF_INET,
                                     nativesockets.SOCK_DGRAM,
                                     Protocol.IPPROTO_UDP)
@@ -94,7 +94,7 @@ proc readMessages(server: AsyncFD) {.async.} =
     inc(i)
 
 proc createServer() {.async.} =
-  var name = prepareAddress(0x7F000001, serverPort)
+  var name = prepareAddress(INADDR_LOOPBACK, serverPort)
   var server = newAsyncNativeSocket(nativesockets.AF_INET,
                                     nativesockets.SOCK_DGRAM,
                                     Protocol.IPPROTO_UDP)
@@ -103,7 +103,7 @@ proc createServer() {.async.} =
     raiseOSError(osLastError())
   asyncCheck readMessages(server)
 
-var name = prepareAddress(0x7F000001, serverPort) # 127.0.0.1
+var name = prepareAddress(INADDR_LOOPBACK, serverPort) # 127.0.0.1
 asyncCheck createServer()
 asyncCheck launchSwarm(cast[ptr SockAddr](name))
 while true:


### PR DESCRIPTION
If there's a reason why this was changed to an int instead of using the constant, please document and ignore this pull request.