### PR TITLE
add define nimBurnFree

### DIFF
--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -21,7 +21,7 @@ const
   alwaysGC = defined(fulldebug) # collect after every memory
                                 # allocation (for debugging)
   leakDetector = false
-  overwriteFree = false
+  overwriteFree = defined(nimBurnFree) # overwrite memory with 0xFF before free
   trackAllocationSource = leakDetector
 
   cycleGC = true # (de)activate the cycle GC


### PR DESCRIPTION
With this PR, new defined value will be added `nimBurnFree` which allows memory manager to fill memory with 0xFF before actually freeing it.
This is useful for debugging and security purposes.