### PR TITLE
RPATH locations for OpenBSD,NetBSD and FreeBSD.

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -122,6 +122,17 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
   clang.objc.options.linker = "-framework Foundation"
 @end
 
+# Options for FreeBSD, OpenBSD, NetBSD linker to add locations for searching
+# shared libraries.
+@if freebsd or openbsd or netbsd:
+  gcc.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+  gcc.cpp.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+  llvm_gcc.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+  llvm_gcc.cpp.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+  clang.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+  clang.cpp.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+@end
+
 # Configuration for the VxWorks
 # This has been tested with VxWorks 6.9 only
 @if vxworks:


### PR DESCRIPTION
On BSD systems there some paths, where shared libraries can be placed after installations from `ports` or from `packages`.

Nim don't use `implicit linking` so `dlopen()` could not find libraries which are not installed in `/lib` or `/usr/lib`. To resolve this we need to create dynamic section of ELF file (called `RPATH`) with some default locations for shared libraries.