### PR TITLE
Added js console object

### DIFF
--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -18,22 +18,9 @@ type Console* {.importc.} = ref object of RootObj
 proc convertToConsoleLoggable*[T](v: T): RootRef {.importcpp: "#".}
 template convertToConsoleLoggable*(v: string): RootRef = cast[RootRef](cstring(v))
 
-proc log*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.log(#)".}
-proc debug*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.debug(#)".}
-proc info*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.info(#)".}
-proc error*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.error(#)".}
-
-{.push importcpp .}
-
-proc log*[A](console: Console, a: A)
-proc debug*[A](console: Console, a: A)
-proc info*[A](console: Console, a: A)
-proc error*[A](console: Console, a: A)
-
-{.pop.}
-proc log*(console: Console, a: string) = console.log(cstring(a))
-proc debug*(console: Console, a: string) = console.log(cstring(a))
-proc info*(console: Console, a: string) = console.log(cstring(a))
-proc error*(console: Console, a: string) = console.log(cstring(a))
+proc log*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.log.apply(null, #)".}
+proc debug*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.debug.apply(null, #)".}
+proc info*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.info.apply(null, #)".}
+proc error*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.error.apply(null, #)".}
 
 var console* {.importc, nodecl.}: Console

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -1,0 +1,32 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2012 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## Wrapper for the `console` object for the `JavaScript backend
+## <backends.html#the-javascript-target>`_.
+
+when not defined(js) and not defined(Nimdoc):
+  {.error: "This module only works on the JavaScript platform".}
+
+type Console* {.importc.} = ref object of RootObj
+
+{.push importcpp .}
+
+proc log*[A](console: Console, a: A)
+proc debug*[A](console: Console, a: A)
+proc info*[A](console: Console, a: A)
+proc error*[A](console: Console, a: A)
+
+{.pop.}
+
+proc log*(console: Console, a: string) = console.log(cstring(a))
+proc debug*(console: Console, a: string) = console.log(cstring(a))
+proc info*(console: Console, a: string) = console.log(cstring(a))
+proc error*(console: Console, a: string) = console.log(cstring(a))
+
+var console* {.importc, nodecl.}: Console

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -15,6 +15,14 @@ when not defined(js) and not defined(Nimdoc):
 
 type Console* {.importc.} = ref object of RootObj
 
+proc convertToConsoleLoggable*[T](v: T): RootRef {.importcpp: "#".}
+template convertToConsoleLoggable*(v: string): RootRef = cast[RootRef](cstring(v))
+
+proc log*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.log(#)".}
+proc debug*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.debug(#)".}
+proc info*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.info(#)".}
+proc error*(console: Console, args: varargs[RootRef, convertToConsoleLoggable]) {.importcpp: "#.error(#)".}
+
 {.push importcpp .}
 
 proc log*[A](console: Console, a: A)
@@ -23,7 +31,6 @@ proc info*[A](console: Console, a: A)
 proc error*[A](console: Console, a: A)
 
 {.pop.}
-
 proc log*(console: Console, a: string) = console.log(cstring(a))
 proc debug*(console: Console, a: string) = console.log(cstring(a))
 proc info*(console: Console, a: string) = console.log(cstring(a))

--- a/tests/js/tconsole.nim
+++ b/tests/js/tconsole.nim
@@ -1,5 +1,7 @@
 discard """
-  output: "Hello, console"
+  output: '''Hello, console
+1 2 3
+1 'hi' 1.1'''
 """
 
 # This file tests the JavaScript console
@@ -7,3 +9,5 @@ discard """
 import jsconsole
 
 console.log("Hello, console")
+console.log(1, 2, 3)
+console.log(1, "hi", 1.1)

--- a/tests/js/tconsole.nim
+++ b/tests/js/tconsole.nim
@@ -1,0 +1,9 @@
+discard """
+  output: "Hello, console"
+"""
+
+# This file tests the JavaScript console
+
+import jsconsole
+
+console.log("Hello, console")


### PR DESCRIPTION
Added the js console object, which is available in most javascript environments (Node, browsers, Gnome etc.). Note that `echo` is not a substitute for this because it stringifies its arguments while browsers, for instance, output a navigable representation of objects