### PR TITLE
Enable JIT in PCRE to improve regular expressions performance

### DIFF
--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -431,7 +431,6 @@ proc initRegex(pattern: string, flags: int, study = true): Regex =
     raise SyntaxError(msg: $errorMsg, pos: errOffset, pattern: pattern)
 
   if study:
-    # XXX investigate JIT
     var options: cint = 0
     var hasJit: cint
     if pcre.config(pcre.CONFIG_JIT, addr hasJit) == 0:

--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -432,7 +432,12 @@ proc initRegex(pattern: string, flags: int, study = true): Regex =
 
   if study:
     # XXX investigate JIT
-    result.pcreExtra = pcre.study(result.pcreObj, 0x0, addr errorMsg)
+    var options: cint = 0
+    var hasJit: cint
+    if pcre.config(pcre.CONFIG_JIT, addr hasJit) == 0:
+      if hasJit == 1'i32:
+        options = pcre.STUDY_JIT_COMPILE
+    result.pcreExtra = pcre.study(result.pcreObj, options, addr errorMsg)
     if errorMsg != nil:
       raise StudyError(msg: $errorMsg)
 


### PR DESCRIPTION
Regular expressions in Nim are slow because they are not using JIT feature of PCRE. Idea of using JIT in pcre_study based on grep source. Performance impact is **huge**.

There is still bottleneck in `nre`, it is 2-3 times slower than `re`.