### PR TITLE
Some useful macros

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -890,6 +890,30 @@ proc boolVal*(n: NimNode): bool {.compileTime, noSideEffect.} =
   if n.kind == nnkIntLit: n.intVal != 0
   else: n == bindSym"true" # hacky solution for now
 
+macro expandMacros*(body: stmt): untyped =
+  ## Expands one level of macro - useful for debugging.
+  ## Can be used to inspect what happens when a macro call is expanded,
+  ## without altering its result.
+  ##
+  ## For instance,
+  ##
+  ## .. code-block:: nim
+  ##   import future, macros
+  ##
+  ##   let
+  ##     x = 10
+  ##     y = 20
+  ##   expandMacros:
+  ##     dump(x + y)
+  ##
+  ## will actually dump `x + y`, but at the same time will print at
+  ## compile time the expansion of the ``dump`` macro, which in this
+  ## case is ``debugEcho ["x + y", " = ", x + y]``.
+  template inner(x: untyped): untyped = x
+
+  result = getAst(inner(body))
+  echo result.toStrLit
+
 when not defined(booting):
   template emit*(e: static[string]): untyped {.deprecated.} =
     ## accepts a single string argument and treats it as nim code

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -890,7 +890,7 @@ proc boolVal*(n: NimNode): bool {.compileTime, noSideEffect.} =
   if n.kind == nnkIntLit: n.intVal != 0
   else: n == bindSym"true" # hacky solution for now
 
-macro expandMacros*(body: stmt): untyped =
+macro expandMacros*(body: typed): untyped =
   ## Expands one level of macro - useful for debugging.
   ## Can be used to inspect what happens when a macro call is expanded,
   ## without altering its result.

--- a/lib/pure/future.nim
+++ b/lib/pure/future.nim
@@ -177,3 +177,24 @@ macro `[]`*(lc: ListComprehension, comp, typ: untyped): untyped =
               newIdentNode("@"),
               newNimNode(nnkBracket))),
           result))))
+
+
+macro dump*(x: typed): untyped =
+  ## Dumps the content of an expression, useful for debugging.
+  ## It accepts any expression and prints a textual representation
+  ## of the tree representing the expression - as it would appear in
+  ## source code - together with the value of the expression.
+  ##
+  ## As an example,
+  ##
+  ## .. code-block:: nim
+  ##   let
+  ##     x = 10
+  ##     y = 20
+  ##   dump(x + y)
+  ##
+  ## will print ``x + y = 30``.
+  let s = x.toStrLit
+  let r = quote do:
+    debugEcho `s`, " = ", `x`
+  return r

--- a/tests/macros/tdump.nim
+++ b/tests/macros/tdump.nim
@@ -1,0 +1,13 @@
+discard """
+  output: '''x = 10
+x + y = 30
+'''
+"""
+
+import future
+
+let
+  x = 10
+  y = 20
+dump x
+dump(x + y)


### PR DESCRIPTION
I am adding here a couple of general purpose macros which are very useful but I could not find in the standard library. Since they are used for debugging purposes, I do not feel they belong to an external library.

The first one (included here) is used to dump an expression (tree + value), so that for example

```nim
import future
let
  x = 10
  y = 20
dump(x + y)
```

prints `x + y = 30`.

The second one (not here yet, coming in another commit) would be a `expandMacros` macro that expands (one level of) macro, useful for debug when writing macros