### PR TITLE
Revert change to osalloc.nim from commit 8d7a45f.

### DIFF
--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -87,8 +87,6 @@ elif defined(posix):
     const MAP_ANONYMOUS = 0x1000
   elif defined(solaris):
     const MAP_ANONYMOUS = 0x100
-  elif defined(linux):
-    const MAP_ANONYMOUS = 0x20
   else:
     var
       MAP_ANONYMOUS {.importc: "MAP_ANONYMOUS", header: "<sys/mman.h>".}: cint


### PR DESCRIPTION
Change caused MAP_ANONYMOUS to have an incorrect value when compiling
for mipsel.

Fixes #4852.