### PR TITLE
Add example for posting json content

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -50,6 +50,20 @@
 ##
 ##   echo client.postContent("http://validator.w3.org/check", multipart=data)
 ##
+## You can also make post requests with custom headers. 
+## This example sets ``Content-Type`` to ``application/json``
+## and uses a json object for the body
+##
+## .. code-block:: Nim
+##   import httpclient, json
+##   
+##   let client = newHttpClient()
+##   client.headers = newHttpHeaders({ "Content-Type": "application/json" })
+##   let body = %*{
+##       "data": "some text"
+##   }
+##   echo client.request("http://some.api", httpMethod = HttpPost, body = $body)
+##
 ## Progress reporting
 ## ==================
 ##


### PR DESCRIPTION
i struggled to figure out how to post json content with nim's http client. this is a fundamental capability in many web apps, we don't always need to send data as multipart form data (e.g. when communicating via json apis) so frankly i'm surprised it isn't part of the "post" and "postContent" procs