### PR TITLE
Bugfix for times.initInterval (issue #4889)

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -266,13 +266,13 @@ proc initInterval*(milliseconds, seconds, minutes, hours, days, months,
   result.milliseconds = `mod`(milliseconds, 1000)
   carryO = `div`(milliseconds, 1000)
   result.seconds = `mod`(carryO + seconds, 60)
-  carryO = `div`(seconds, 60)
+  carryO = `div`(carryO + seconds, 60)
   result.minutes = `mod`(carryO + minutes, 60)
-  carryO = `div`(minutes, 60)
+  carryO = `div`(carryO + minutes, 60)
   result.hours = `mod`(carryO + hours, 24)
-  carryO = `div`(hours, 24)
+  carryO = `div`(carryO + hours, 24)
   result.days = carryO + days
-  carryO = 0
+
   result.months = `mod`(months, 12)
   carryO = `div`(months, 12)
   result.years = carryO + years
@@ -283,13 +283,13 @@ proc `+`*(ti1, ti2: TimeInterval): TimeInterval =
   result.milliseconds = `mod`(ti1.milliseconds + ti2.milliseconds, 1000)
   carryO = `div`(ti1.milliseconds + ti2.milliseconds, 1000)
   result.seconds = `mod`(carryO + ti1.seconds + ti2.seconds, 60)
-  carryO = `div`(ti1.seconds + ti2.seconds, 60)
+  carryO = `div`(carryO + ti1.seconds + ti2.seconds, 60)
   result.minutes = `mod`(carryO + ti1.minutes + ti2.minutes, 60)
-  carryO = `div`(ti1.minutes + ti2.minutes, 60)
+  carryO = `div`(carryO + ti1.minutes + ti2.minutes, 60)
   result.hours = `mod`(carryO + ti1.hours + ti2.hours, 24)
-  carryO = `div`(ti1.hours + ti2.hours, 24)
+  carryO = `div`(carryO + ti1.hours + ti2.hours, 24)
   result.days = carryO + ti1.days + ti2.days
-  carryO = 0
+
   result.months = `mod`(ti1.months + ti2.months, 12)
   carryO = `div`(ti1.months + ti2.months, 12)
   result.years = carryO + ti1.years + ti2.years

--- a/tests/stdlib/ttime.nim
+++ b/tests/stdlib/ttime.nim
@@ -141,3 +141,10 @@ doAssert initInterval(months = 13) == initInterval(months = 1, years = 1)
 let day = 24.hours
 let tomorrow = getTime() + day
 doAssert tomorrow - getTime() == 60*60*24
+
+doAssert milliseconds(1000 * 60) == minutes(1)
+doAssert milliseconds(1000 * 60 * 60) == hours(1)
+doAssert milliseconds(1000 * 60 * 60 * 24) == days(1)
+doAssert seconds(60 * 60) == hours(1)
+doAssert seconds(60 * 60 * 24) == days(1)
+doAssert seconds(60 * 60 + 65) == (hours(1) + minutes(1) + seconds(5))


### PR DESCRIPTION
`initInterval` had logic to calculate and carry overflowed fields (65 seconds
turns into 5 seconds and carries 1 minute). However, we were not including that
carried value when we recalculate the carry over for the next period of time.So
if you had, for example, 3600 seconds, we carried 60 minutes into the minutes
calculation, but when we calculated how much we should carry into the hours
value we only considered what the user originally supplied for the minutes
field, and forgot to include those 60 carried minute.

So, for example, with the previous implementation this was true:

`seconds(60 * 60 * 24) == seconds(0)`

Or, as failing tests:

```nimrod
import times

assert seconds(60 * 60 * 24) != seconds(0)
assert seconds(60 * 60 * 24) == days(1)
```