### PR TITLE
Add Mingw build support for build.sh

### DIFF
--- a/tools/niminst/buildsh.tmpl
+++ b/tools/niminst/buildsh.tmpl
@@ -94,6 +94,9 @@ case $uos in
     myos="haiku"
     LINK_FLAGS="$LINK_FLAGS -lroot -lnetwork"
     ;;
+  *mingw* ) 
+    myos="windows" 
+    ;;
   *)
     echo 2>&1 "Error: unknown operating system: $uos"
     exit 1


### PR DESCRIPTION
'nuf said....

Mingw's Nim currently has a .patch file that patches the csources build.sh directly, but I figured it would just be nicer if it was officially supported. Of course, the csources repo would need to be updated afterwards.