### PR TITLE
asyncdispatch: Fix handle of error only events.

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1055,7 +1055,7 @@ else:
         # so that exceptions can be raised from `send(...)` and
         # `recv(...)` routines.
 
-        if EvRead in info.events:
+        if EvRead in info.events or info.events == {EvError}:
           # Callback may add items to ``data.readCBs`` which causes issues if
           # we are iterating over ``data.readCBs`` at the same time. We therefore
           # make a copy to iterate over.
@@ -1066,7 +1066,7 @@ else:
               # Callback wants to be called again.
               data.readCBs.add(cb)
 
-        if EvWrite in info.events:
+        if EvWrite in info.events or info.events == {EvError}:
           let currentCBs = data.writeCBs
           data.writeCBs = @[]
           for cb in currentCBs:

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -1194,21 +1194,21 @@ else:
         var fd = keys[i].fd.SocketHandle
         let events = keys[i].events
 
-        if Event.Read in events:
+        if Event.Read in events or events == {Event.Error}:
           let cb = keys[i].data.readCB
-          doAssert(cb != nil)
-          if cb(fd.AsyncFD):
-            p.selector.withData(fd, adata) do:
-              if adata.readCB == cb:
-                adata.readCB = nil
+          if cb != nil:
+            if cb(fd.AsyncFD):
+              p.selector.withData(fd, adata) do:
+                if adata.readCB == cb:
+                  adata.readCB = nil
 
-        if Event.Write in events:
+        if Event.Write in events or events == {Event.Error}:
           let cb = keys[i].data.writeCB
-          doAssert(cb != nil)
-          if cb(fd.AsyncFD):
-            p.selector.withData(fd, adata) do:
-              if adata.writeCB == cb:
-                adata.writeCB = nil
+          if cb != nil:
+            if cb(fd.AsyncFD):
+              p.selector.withData(fd, adata) do:
+                if adata.writeCB == cb:
+                  adata.writeCB = nil
 
         when supportedPlatform:
           if (customSet * events) != {}:


### PR DESCRIPTION
In some cases, **epoll** or **kqueue** can return error on descriptor without specifying Read or Write events. To handle such case i propose to call all available descriptor callbacks so they can handle this errors via calls to appropriate read/recv and/or write/send operation.