### PR TITLE
Support OpenSSL 1.0.2

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -26,7 +26,7 @@ when useWinVersion:
   from winlean import SocketHandle
 else:
   const
-    versions = "(|.10|.1.0.1|.1.0.0|.0.9.9|.0.9.8)"
+    versions = "(|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8)"
   when defined(macosx):
     const
       DLLSSLName = "libssl" & versions & ".dylib"


### PR DESCRIPTION
1.0.2 is a current OpenSSL stable release. Related to #254

There is also 1.1.0 around but it could be added in a different commit.