### PR TITLE
Table fixes. fixes #4901

### DIFF
--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -95,9 +95,24 @@ block orderedTableTest1:
   for key, val in mpairs(t): val = 99
   for val in mvalues(t): assert val == 99
 
+block orderedTableTest2:
+  var
+    s = initOrderedTable[string, int]()
+    t = initOrderedTable[string, int]()
+  assert s == t
+  for key, val in items(data): t[key] = val
+  assert s != t
+  for key, val in items(sorteddata): s[key] = val
+  assert s != t
+  t.clear()
+  assert s != t
+  for key, val in items(sorteddata): t[key] = val
+  assert s == t
+
 block countTableTest1:
   var s = data.toTable
   var t = initCountTable[string]()
+  
   for k in s.keys: t.inc(k)
   for k in t.keys: assert t[k] == 1
   t.inc("90", 3)
@@ -114,6 +129,24 @@ block countTableTest1:
     of 2: assert k == "34" and v == 2
     else: break
     inc i
+
+block countTableTest2:
+  var
+    s = initCountTable[int]()
+    t = initCountTable[int]()
+  assert s == t
+  s.inc(1)
+  assert s != t
+  t.inc(2)
+  assert s != t
+  t.inc(1)
+  assert s != t
+  s.inc(2)
+  assert s == t
+  s.inc(1)
+  assert s != t
+  t.inc(1)
+  assert s == t
 
 block mpairsTableTest1:
   var t = initTable[string, int]()


### PR DESCRIPTION
 * added `==` for OrderedTable, CountTable and the *Ref types
 * added missing documentation to all `==` procs
 * fixed clear() for OrderedTables, which did not work because `var`
   does not work well with `|`
 * added tests