### PR TITLE
Check return value of newNativeSocket before use

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1007,6 +1007,8 @@ else:
   proc newAsyncNativeSocket*(domain: cint, sockType: cint,
                              protocol: cint): AsyncFD =
     result = newNativeSocket(domain, sockType, protocol).AsyncFD
+    if result.int == -1:
+      raiseOSError(osLastError())
     result.SocketHandle.setBlocking(false)
     when defined(macosx):
       result.SocketHandle.setSockOptInt(SOL_SOCKET, SO_NOSIGPIPE, 1)
@@ -1016,6 +1018,8 @@ else:
                              sockType: SockType = SOCK_STREAM,
                              protocol: Protocol = IPPROTO_TCP): AsyncFD =
     result = newNativeSocket(domain, sockType, protocol).AsyncFD
+    if result.int == -1:
+      raiseOSError(osLastError())
     result.SocketHandle.setBlocking(false)
     when defined(macosx):
       result.SocketHandle.setSockOptInt(SOL_SOCKET, SO_NOSIGPIPE, 1)


### PR DESCRIPTION
In newAsyncNativeSocket the function setBlocking is called on the result
of newNativeSocket regardless of whether the socket returned is valid or
not. If an invalid socket is returned then the error:

```
Error: unhandled exception: Bad file descriptor [Exception]
```

is thrown.

Check the return value first so that a more appropriate error is
raised.
