### PR TITLE
async: getSystemHandle() to retrieve associated IOCP handle from dispatcher.

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -246,6 +246,11 @@ when defined(windows) or defined(nimdoc):
       raiseOSError(osLastError())
     p.handles.incl(fd)
 
+  proc getSystemHandle*(): Handle =
+    ## Retrieves handle of associated IOCP handle.
+    let p = getGlobalDispatcher()
+    result = p.ioPort
+
   proc verifyPresence(fd: AsyncFD) =
     ## Ensures that file descriptor has been registered with the dispatcher.
     let p = getGlobalDispatcher()

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -223,6 +223,11 @@ when defined(windows) or defined(nimdoc):
       raiseOSError(osLastError())
     p.handles.incl(fd)
 
+  proc getSystemHandle*(): Handle =
+    ## Retrieves handle of associated IOCP handle.
+    let p = getGlobalDispatcher()
+    result = p.ioPort
+
   proc verifyPresence(fd: AsyncFD) =
     ## Ensures that file descriptor has been registered with the dispatcher.
     let p = getGlobalDispatcher()


### PR DESCRIPTION
Add procedure `getSystemHandle()` for Windows part of `asyncdispatch.nim`.
Such procedure allow to access IOCP port handle and create more flexible async solutions, without dirty hacks.