### PR TITLE
Fix problems with persistent HTTP connections

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -133,14 +133,21 @@ proc processClient(client: AsyncSocket, address: string,
     assert client != nil
     request.client = client
 
-    # First line - GET /path HTTP/1.1
-    lineFut.mget().setLen(0)
-    lineFut.clean()
-    await client.recvLineInto(lineFut) # TODO: Timeouts.
-    if lineFut.mget == "":
-      client.close()
-      return
+    # We should skip empty lines before the request
+    # https://tools.ietf.org/html/rfc7230#section-3.5
+    while true:
+      lineFut.mget().setLen(0)
+      lineFut.clean()
+      await client.recvLineInto(lineFut) # TODO: Timeouts.
 
+      if lineFut.mget == "":
+        client.close()
+        return
+
+      if lineFut.mget != "\c\L":
+        break
+
+    # First line - GET /path HTTP/1.1
     var i = 0
     for linePart in lineFut.mget.split(' '):
       case i

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -133,9 +133,9 @@ proc processClient(client: AsyncSocket, address: string,
     assert client != nil
     request.client = client
 
-    # We should skip empty lines before the request
+    # We should skip at least one empty line before the request
     # https://tools.ietf.org/html/rfc7230#section-3.5
-    while true:
+    for i in 0..1:
       lineFut.mget().setLen(0)
       lineFut.clean()
       await client.recvLineInto(lineFut) # TODO: Timeouts.


### PR DESCRIPTION
Fixes #4969 

1. More robust request parsing in accordance with https://tools.ietf.org/html/rfc7230#section-3.5 .
2. Add `overrideHeaders` parameter to `request` procs for headers that shouldn't persist between requests.