### PR TITLE
(minor) Doc change for #3130

### DIFF
--- a/doc/manual/types.txt
+++ b/doc/manual/types.txt
@@ -716,7 +716,8 @@ untraced references are *unsafe*. However for certain low-level operations
 (accessing the hardware) untraced references are unavoidable.
 
 Traced references are declared with the **ref** keyword, untraced references
-are declared with the **ptr** keyword.
+are declared with the **ptr** keyword.  In general, a `ptr T` is implicitly
+convertible to the `pointer` type.
 
 An empty subscript ``[]`` notation can be used to derefer a reference,
 the ``addr`` procedure returns the address of an item. An address is always


### PR DESCRIPTION
Not sure where to add this, gives some background for #3130 so that it's a clear that a `ptr T` is implicitly convertible to a `pointer`.