### PR TITLE
Fixed timezone handling

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -671,13 +671,12 @@ elif defined(JS):
 
   proc toTime*(timeInfo: TimeInfo): Time =
     result = internGetTime()
-    result.setSeconds(timeInfo.second)
     result.setMinutes(timeInfo.minute)
     result.setHours(timeInfo.hour)
     result.setMonth(ord(timeInfo.month))
     result.setFullYear(timeInfo.year)
     result.setDate(timeInfo.monthday)
-    result = result + initInterval(seconds=timeInfo.timezone)
+    result.setSeconds(timeInfo.second + timeInfo.timezone)
 
   proc `$`(timeInfo: TimeInfo): string = return $(toTime(timeInfo))
   proc `$`(time: Time): string = return $time.toLocaleString()

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1127,31 +1127,33 @@ proc parseToken(info: var TimeInfo; token, value: string; j: var int) =
     j += 4
   of "z":
     if value[j] == '+':
-      info.timezone = parseInt($value[j+1])
+      info.timezone = 0-parseInt($value[j+1]) * 3600
     elif value[j] == '-':
-      info.timezone = 0-parseInt($value[j+1])
+      info.timezone = parseInt($value[j+1]) * 3600
     else:
       raise newException(ValueError,
         "Couldn't parse timezone offset (z), got: " & value[j])
     j += 2
   of "zz":
     if value[j] == '+':
-      info.timezone = value[j+1..j+2].parseInt()
+      info.timezone = 0-value[j+1..j+2].parseInt() * 3600
     elif value[j] == '-':
-      info.timezone = 0-value[j+1..j+2].parseInt()
+      info.timezone = value[j+1..j+2].parseInt() * 3600
     else:
       raise newException(ValueError,
         "Couldn't parse timezone offset (zz), got: " & value[j])
     j += 3
   of "zzz":
-    if value[j] == '+':
-      info.timezone = value[j+1..j+2].parseInt()
-    elif value[j] == '-':
-      info.timezone = 0-value[j+1..j+2].parseInt()
+    var factor = 0
+    if value[j] == '+': factor = -1
+    elif value[j] == '-': factor = 1
     else:
       raise newException(ValueError,
         "Couldn't parse timezone offset (zzz), got: " & value[j])
-    j += 6
+    info.timezone = factor * value[j+1..j+2].parseInt() * 3600
+    j += 4
+    info.timezone += factor * value[j..j+1].parseInt() * 60
+    j += 2
   of "ZZZ":
     info.tzname = value[j..j+2].toUpperAscii()
     j += 3
@@ -1188,7 +1190,7 @@ proc parse*(value, layout: string): TimeInfo =
   ##    yyyy     Displays the year to four digits.                                                  ``2012 -> 2012``
   ##    z        Displays the timezone offset from UTC.                                             ``GMT+7 -> +7``, ``GMT-5 -> -5``
   ##    zz       Same as above but with leading 0.                                                  ``GMT+7 -> +07``, ``GMT-5 -> -05``
-  ##    zzz      Same as above but with ``:00``.                                                    ``GMT+7 -> +07:00``, ``GMT-5 -> -05:00``
+  ##    zzz      Same as above but with ``:mm`` where *mm* represents minutes.                      ``GMT+7 -> +07:00``, ``GMT-5 -> -05:00``
   ##    ZZZ      Displays the name of the timezone.                                                 ``GMT -> GMT``, ``EST -> EST``
   ## ==========  =================================================================================  ================================================
   ##

--- a/tests/stdlib/ttime.nim
+++ b/tests/stdlib/ttime.nim
@@ -9,77 +9,93 @@ import
 # $ date --date='@2147483647'
 # Tue 19 Jan 03:14:07 GMT 2038
 
-var t = getGMTime(fromSeconds(2147483647))
-doAssert t.format("ddd dd MMM hh:mm:ss yyyy") == "Tue 19 Jan 03:14:07 2038"
-doAssert t.format("ddd ddMMMhh:mm:ssyyyy") == "Tue 19Jan03:14:072038"
+proc checkFormat(t: TimeInfo, format, expected: string) =
+  let actual = t.format(format)
+  if actual != expected:
+    echo "Formatting failure!"
+    echo "expected: ", expected
+    echo "actual  : ", actual
+    doAssert false
 
-doAssert t.format("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
-  " ss t tt y yy yyy yyyy yyyyy z zz zzz") ==
-  "19 19 Tue Tuesday 3 03 3 03 14 14 1 01 Jan January 7 07 A AM 8 38 038 2038 02038 0 00 00:00"
+let t = getGMTime(fromSeconds(2147483647))
+t.checkFormat("ddd dd MMM hh:mm:ss yyyy", "Tue 19 Jan 03:14:07 2038")
+t.checkFormat("ddd ddMMMhh:mm:ssyyyy", "Tue 19Jan03:14:072038")
+t.checkFormat("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
+  " ss t tt y yy yyy yyyy yyyyy z zz zzz",
+  "19 19 Tue Tuesday 3 03 3 03 14 14 1 01 Jan January 7 07 A AM 8 38 038 2038 02038 +0 +00 +00:00")
 
-doAssert t.format("yyyyMMddhhmmss") == "20380119031407"
+t.checkFormat("yyyyMMddhhmmss", "20380119031407")
 
-var t2 = getGMTime(fromSeconds(160070789)) # Mon 27 Jan 16:06:29 GMT 1975
-doAssert t2.format("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
-  " ss t tt y yy yyy yyyy yyyyy z zz zzz") ==
-  "27 27 Mon Monday 4 04 16 16 6 06 1 01 Jan January 29 29 P PM 5 75 975 1975 01975 0 00 00:00"
+let t2 = getGMTime(fromSeconds(160070789)) # Mon 27 Jan 16:06:29 GMT 1975
+t2.checkFormat("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
+  " ss t tt y yy yyy yyyy yyyyy z zz zzz",
+  "27 27 Mon Monday 4 04 16 16 6 06 1 01 Jan January 29 29 P PM 5 75 975 1975 01975 +0 +00 +00:00")
 
 when not defined(JS):
   when sizeof(Time) == 8:
     var t3 = getGMTime(fromSeconds(889067643645)) # Fri  7 Jun 19:20:45 BST 30143
-    doAssert t3.format("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
-      " ss t tt y yy yyy yyyy yyyyy z zz zzz") ==
-      "7 07 Fri Friday 6 06 18 18 20 20 6 06 Jun June 45 45 P PM 3 43 143 0143 30143 0 00 00:00"
-    doAssert t3.format(":,[]()-/") == ":,[]()-/"
+    t3.checkFormat("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
+      " ss t tt y yy yyy yyyy yyyyy z zz zzz",
+      "7 07 Fri Friday 6 06 18 18 20 20 6 06 Jun June 45 45 P PM 3 43 143 0143 30143 +0 +00 +00:00")
+    t3.checkFormat(":,[]()-/", ":,[]()-/")
 
 var t4 = getGMTime(fromSeconds(876124714)) # Mon  6 Oct 08:58:34 BST 1997
-doAssert t4.format("M MM MMM MMMM") == "10 10 Oct October"
+t4.checkFormat("M MM MMM MMMM", "10 10 Oct October")
 
 # Interval tests
-doAssert((t4 - initInterval(years = 2)).format("yyyy") == "1995")
-doAssert((t4 - initInterval(years = 7, minutes = 34, seconds = 24)).format("yyyy mm ss") == "1990 24 10")
+(t4 - initInterval(years = 2)).checkFormat("yyyy", "1995")
+(t4 - initInterval(years = 7, minutes = 34, seconds = 24)).checkFormat("yyyy mm ss", "1990 24 10")
 
 proc parseTest(s, f, sExpected: string, ydExpected: int) =
-  let parsed = s.parse(f)
-  doAssert($parsed == sExpected)
+  let
+    parsed = s.parse(f)
+    parsedStr = $getGMTime(toTime(parsed))
+  if parsedStr != sExpected:
+    echo "Parsing failure!"
+    echo "expected: ", sExpected
+    echo "actual  : ", parsedStr
+    doAssert false
   doAssert(parsed.yearday == ydExpected)
 proc parseTestTimeOnly(s, f, sExpected: string) =
   doAssert(sExpected in $s.parse(f))
 
-parseTest("Tuesday at 09:04am on Dec 15, 2015",
-    "dddd at hh:mmtt on MMM d, yyyy", "Tue Dec 15 09:04:00 2015", 348)
+# because setting a specific timezone for testing is platform-specific, we use
+# explicit timezone offsets in all tests.
+
+parseTest("Tuesday at 09:04am on Dec 15, 2015 +0",
+    "dddd at hh:mmtt on MMM d, yyyy z", "2015-12-15T09:04:00+00:00", 348)
 # ANSIC       = "Mon Jan _2 15:04:05 2006"
-parseTest("Thu Jan 12 15:04:05 2006", "ddd MMM dd HH:mm:ss yyyy",
-    "Thu Jan 12 15:04:05 2006", 11)
+parseTest("Thu Jan 12 15:04:05 2006 +0", "ddd MMM dd HH:mm:ss yyyy z",
+    "2006-01-12T15:04:05+00:00", 11)
 # UnixDate    = "Mon Jan _2 15:04:05 MST 2006"
-parseTest("Thu Jan 12 15:04:05 2006", "ddd MMM dd HH:mm:ss yyyy",
-    "Thu Jan 12 15:04:05 2006", 11)
+parseTest("Thu Jan 12 15:04:05 2006 +0", "ddd MMM dd HH:mm:ss yyyy z",
+    "2006-01-12T15:04:05+00:00", 11)
 # RubyDate    = "Mon Jan 02 15:04:05 -0700 2006"
-parseTest("Mon Feb 29 15:04:05 -07:00 2016", "ddd MMM dd HH:mm:ss zzz yyyy",
-    "Mon Feb 29 15:04:05 2016", 59) # leap day
+parseTest("Mon Feb 29 15:04:05 -07:00 2016 +0", "ddd MMM dd HH:mm:ss zzz yyyy z",
+    "2016-02-29T15:04:05+00:00", 59) # leap day
 # RFC822      = "02 Jan 06 15:04 MST"
-parseTest("12 Jan 16 15:04", "dd MMM yy HH:mm",
-    "Tue Jan 12 15:04:00 2016", 11)
+parseTest("12 Jan 16 15:04 +0", "dd MMM yy HH:mm z",
+    "2016-01-12T15:04:00+00:00", 11)
 # RFC822Z     = "02 Jan 06 15:04 -0700" # RFC822 with numeric zone
 parseTest("01 Mar 16 15:04 -07:00", "dd MMM yy HH:mm zzz",
-    "Tue Mar  1 15:04:00 2016", 60) # day after february in leap year
+    "2016-03-01T22:04:00+00:00", 60) # day after february in leap year
 # RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
-parseTest("Monday, 12-Jan-06 15:04:05", "dddd, dd-MMM-yy HH:mm:ss",
-    "Thu Jan 12 15:04:05 2006", 11)
+parseTest("Monday, 12-Jan-06 15:04:05 +0", "dddd, dd-MMM-yy HH:mm:ss z",
+    "2006-01-12T15:04:05+00:00", 11)
 # RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
-parseTest("Sun, 01 Mar 2015 15:04:05", "ddd, dd MMM yyyy HH:mm:ss",
-    "Sun Mar  1 15:04:05 2015", 59) # day after february in non-leap year
+parseTest("Sun, 01 Mar 2015 15:04:05 +0", "ddd, dd MMM yyyy HH:mm:ss z",
+    "2015-03-01T15:04:05+00:00", 59) # day after february in non-leap year
 # RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" # RFC1123 with numeric zone
 parseTest("Thu, 12 Jan 2006 15:04:05 -07:00", "ddd, dd MMM yyyy HH:mm:ss zzz",
-    "Thu Jan 12 15:04:05 2006", 11)
+    "2006-01-12T22:04:05+00:00", 11)
 # RFC3339     = "2006-01-02T15:04:05Z07:00"
 parseTest("2006-01-12T15:04:05Z-07:00", "yyyy-MM-ddTHH:mm:ssZzzz",
-    "Thu Jan 12 15:04:05 2006", 11)
+    "2006-01-12T22:04:05+00:00", 11)
 parseTest("2006-01-12T15:04:05Z-07:00", "yyyy-MM-dd'T'HH:mm:ss'Z'zzz",
-    "Thu Jan 12 15:04:05 2006", 11)
+    "2006-01-12T22:04:05+00:00", 11)
 # RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
 parseTest("2006-01-12T15:04:05.999999999Z-07:00",
-    "yyyy-MM-ddTHH:mm:ss.999999999Zzzz", "Thu Jan 12 15:04:05 2006", 11)
+    "yyyy-MM-ddTHH:mm:ss.999999999Zzzz", "2006-01-12T22:04:05+00:00", 11)
 # Kitchen     = "3:04PM"
 parseTestTimeOnly("3:04PM", "h:mmtt", "15:04:00")
 #when not defined(testing):
@@ -101,21 +117,20 @@ doAssert getDayOfWeekJulian(21, 9, 1970) == dMon
 doAssert getDayOfWeekJulian(1, 1, 2000) == dSat
 doAssert getDayOfWeekJulian(1, 1, 2021) == dFri
 
-# toSeconds tests with GM and Local timezones
-#var t4 = getGMTime(fromSeconds(876124714)) # Mon  6 Oct 08:58:34 BST 1997
-var t4L = getLocalTime(fromSeconds(876124714))
-doAssert toSeconds(timeInfoToTime(t4L)) == 876124714    # fromSeconds is effectively "localTime"
-doAssert toSeconds(timeInfoToTime(t4L)) + t4L.timezone.float == toSeconds(timeInfoToTime(t4))
+# toSeconds tests with GM timezone
+let t4L = getGMTime(fromSeconds(876124714))
+doAssert toSeconds(toTime(t4L)) == 876124714
+doAssert toSeconds(toTime(t4L)) + t4L.timezone.float == toSeconds(toTime(t4))
 
 # adding intervals
 var
-  a1L = toSeconds(timeInfoToTime(t4L + initInterval(hours = 1))) + t4L.timezone.float
-  a1G = toSeconds(timeInfoToTime(t4)) + 60.0 * 60.0
+  a1L = toSeconds(toTime(t4L + initInterval(hours = 1))) + t4L.timezone.float
+  a1G = toSeconds(toTime(t4)) + 60.0 * 60.0
 doAssert a1L == a1G
 
 # subtracting intervals
-a1L = toSeconds(timeInfoToTime(t4L - initInterval(hours = 1))) + t4L.timezone.float
-a1G = toSeconds(timeInfoToTime(t4)) - (60.0 * 60.0)
+a1L = toSeconds(toTime(t4L - initInterval(hours = 1))) + t4L.timezone.float
+a1G = toSeconds(toTime(t4)) - (60.0 * 60.0)
 doAssert a1L == a1G
 
 # add/subtract TimeIntervals and Time/TimeInfo

--- a/tests/stdlib/ttime.nim
+++ b/tests/stdlib/ttime.nim
@@ -10,26 +10,26 @@ import
 # Tue 19 Jan 03:14:07 GMT 2038
 
 var t = getGMTime(fromSeconds(2147483647))
-doAssert t.format("ddd dd MMM hh:mm:ss ZZZ yyyy") == "Tue 19 Jan 03:14:07 UTC 2038"
-doAssert t.format("ddd ddMMMhh:mm:ssZZZyyyy") == "Tue 19Jan03:14:07UTC2038"
+doAssert t.format("ddd dd MMM hh:mm:ss yyyy") == "Tue 19 Jan 03:14:07 2038"
+doAssert t.format("ddd ddMMMhh:mm:ssyyyy") == "Tue 19Jan03:14:072038"
 
 doAssert t.format("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
-  " ss t tt y yy yyy yyyy yyyyy z zz zzz ZZZ") ==
-  "19 19 Tue Tuesday 3 03 3 03 14 14 1 01 Jan January 7 07 A AM 8 38 038 2038 02038 0 00 00:00 UTC"
+  " ss t tt y yy yyy yyyy yyyyy z zz zzz") ==
+  "19 19 Tue Tuesday 3 03 3 03 14 14 1 01 Jan January 7 07 A AM 8 38 038 2038 02038 0 00 00:00"
 
 doAssert t.format("yyyyMMddhhmmss") == "20380119031407"
 
 var t2 = getGMTime(fromSeconds(160070789)) # Mon 27 Jan 16:06:29 GMT 1975
 doAssert t2.format("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
-  " ss t tt y yy yyy yyyy yyyyy z zz zzz ZZZ") ==
-  "27 27 Mon Monday 4 04 16 16 6 06 1 01 Jan January 29 29 P PM 5 75 975 1975 01975 0 00 00:00 UTC"
+  " ss t tt y yy yyy yyyy yyyyy z zz zzz") ==
+  "27 27 Mon Monday 4 04 16 16 6 06 1 01 Jan January 29 29 P PM 5 75 975 1975 01975 0 00 00:00"
 
 when not defined(JS):
   when sizeof(Time) == 8:
     var t3 = getGMTime(fromSeconds(889067643645)) # Fri  7 Jun 19:20:45 BST 30143
     doAssert t3.format("d dd ddd dddd h hh H HH m mm M MM MMM MMMM s" &
-      " ss t tt y yy yyy yyyy yyyyy z zz zzz ZZZ") ==
-      "7 07 Fri Friday 6 06 18 18 20 20 6 06 Jun June 45 45 P PM 3 43 143 0143 30143 0 00 00:00 UTC"
+      " ss t tt y yy yyy yyyy yyyyy z zz zzz") ==
+      "7 07 Fri Friday 6 06 18 18 20 20 6 06 Jun June 45 45 P PM 3 43 143 0143 30143 0 00 00:00"
     doAssert t3.format(":,[]()-/") == ":,[]()-/"
 
 var t4 = getGMTime(fromSeconds(876124714)) # Mon  6 Oct 08:58:34 BST 1997
@@ -52,22 +52,22 @@ parseTest("Tuesday at 09:04am on Dec 15, 2015",
 parseTest("Thu Jan 12 15:04:05 2006", "ddd MMM dd HH:mm:ss yyyy",
     "Thu Jan 12 15:04:05 2006", 11)
 # UnixDate    = "Mon Jan _2 15:04:05 MST 2006"
-parseTest("Thu Jan 12 15:04:05 MST 2006", "ddd MMM dd HH:mm:ss ZZZ yyyy",
+parseTest("Thu Jan 12 15:04:05 2006", "ddd MMM dd HH:mm:ss yyyy",
     "Thu Jan 12 15:04:05 2006", 11)
 # RubyDate    = "Mon Jan 02 15:04:05 -0700 2006"
 parseTest("Mon Feb 29 15:04:05 -07:00 2016", "ddd MMM dd HH:mm:ss zzz yyyy",
     "Mon Feb 29 15:04:05 2016", 59) # leap day
 # RFC822      = "02 Jan 06 15:04 MST"
-parseTest("12 Jan 16 15:04 MST", "dd MMM yy HH:mm ZZZ",
+parseTest("12 Jan 16 15:04", "dd MMM yy HH:mm",
     "Tue Jan 12 15:04:00 2016", 11)
 # RFC822Z     = "02 Jan 06 15:04 -0700" # RFC822 with numeric zone
 parseTest("01 Mar 16 15:04 -07:00", "dd MMM yy HH:mm zzz",
     "Tue Mar  1 15:04:00 2016", 60) # day after february in leap year
 # RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
-parseTest("Monday, 12-Jan-06 15:04:05 MST", "dddd, dd-MMM-yy HH:mm:ss ZZZ",
+parseTest("Monday, 12-Jan-06 15:04:05", "dddd, dd-MMM-yy HH:mm:ss",
     "Thu Jan 12 15:04:05 2006", 11)
 # RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
-parseTest("Sun, 01 Mar 2015 15:04:05 MST", "ddd, dd MMM yyyy HH:mm:ss ZZZ",
+parseTest("Sun, 01 Mar 2015 15:04:05", "ddd, dd MMM yyyy HH:mm:ss",
     "Sun Mar  1 15:04:05 2015", 59) # day after february in non-leap year
 # RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" # RFC1123 with numeric zone
 parseTest("Thu, 12 Jan 2006 15:04:05 -07:00", "ddd, dd MMM yyyy HH:mm:ss zzz",

--- a/web/news/e029_version_0_16_0.rst
+++ b/web/news/e029_version_0_16_0.rst
@@ -26,7 +26,9 @@ Changes affecting backwards compatibility
 
 - ``staticExec`` now uses the directory of the nim file that contains the
   ``staticExec`` call as the current working directory.
-
+- ``TimeInfo.tzname`` has been removed because it was broken. Because of this,
+  the option `"ZZZ"` will no longer work in format strings for formatting and
+  parsing.
 
 Library Additions
 -----------------

--- a/web/news/e029_version_0_16_0.rst
+++ b/web/news/e029_version_0_16_0.rst
@@ -26,9 +26,9 @@ Changes affecting backwards compatibility
 
 - ``staticExec`` now uses the directory of the nim file that contains the
   ``staticExec`` call as the current working directory.
-- ``TimeInfo.tzname`` has been removed because it was broken. Because of this,
-  the option `"ZZZ"` will no longer work in format strings for formatting and
-  parsing.
+- ``TimeInfo.tzname`` has been removed from ``times`` module because it was
+  broken. Because of this, the option ``"ZZZ"`` will no longer work in format
+  strings for formatting and parsing.
 
 Library Additions
 -----------------


### PR DESCRIPTION
 * mktime always interprets its input as local time even on systems where
   gmtoff is present, so using it is utterly useless for anything but getting
   the local timezone. Removed all other usage of gmtoff to avoid confusion.
 * Properly handle timezone offset in toTime()
 * Properly handle timezone offset in `$` because asctime also interprets its
   input as local time
 * Also tried to fix the JavaScript implementation

I tested this on OSX and Linux.

**Edit:** Things I want to do before merging:

 * [x] `"ZZZ"` only sets `tzname`, but not timezone. There should be a mapping table or something. **Has been completely removed.**
 * [x] `+` and `-` compare `tzname` but ignore `timezone`. The always use the local time unless `tzname` equals `"UTC"`. This is horrible and needs to be fixed.
 * [x] Check if it is feasible to set `tzname` when a timezone offset is parsed.
 * [x] Add tests. **The update of the existing tests suffices because `$` now renders timezones.**