### PR TITLE
async all() now immediately completes if arg is empty

### DIFF
--- a/lib/pure/includes/asyncfutures.nim
+++ b/lib/pure/includes/asyncfutures.nim
@@ -246,6 +246,7 @@ proc `or`*[T, Y](fut1: Future[T], fut2: Future[Y]): Future[void] =
 proc all*[T](futs: varargs[Future[T]]): auto =
   ## Returns a future which will complete once
   ## all futures in ``futs`` complete.
+  ## If the argument is empty, the returned future completes immediately.
   ##
   ## If the awaited futures are not ``Future[void]``, the returned future
   ## will hold the values of all awaited futures in a sequence.
@@ -270,6 +271,9 @@ proc all*[T](futs: varargs[Future[T]]): auto =
           if completedFutures == totalFutures:
             retFuture.complete()
 
+    if totalFutures == 0:
+      retFuture.complete()
+
     return retFuture
 
   else:
@@ -291,5 +295,8 @@ proc all*[T](futs: varargs[Future[T]]): auto =
               retFuture.complete(retValues)
 
       setCallback(i)
+
+    if retValues.len == 0:
+      retFuture.complete(retValues)
 
     return retFuture

--- a/tests/async/tasyncall.nim
+++ b/tests/async/tasyncall.nim
@@ -66,3 +66,12 @@ block:
 
   doAssert execTime * 100 < taskCount * sleepDuration
   doAssert results == expected
+
+block:
+  let
+    noIntFuturesFut = all(newSeq[Future[int]]())
+    noVoidFuturesFut = all(newSeq[Future[void]]())
+
+  doAssert noIntFuturesFut.finished and not noIntFuturesFut.failed
+  doAssert noVoidFuturesFut.finished and not noVoidFuturesFut.failed
+  doAssert noIntFuturesFut.read() == @[]


### PR DESCRIPTION
Before this patch the returned future never completed with empty arg.