### PR TITLE
Add 'noSideEffect' pragma for Time type's operators. Fixes #4981

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -104,7 +104,7 @@ elif defined(JS):
       getMinutes: proc (): int {.tags: [], raises: [], benign.}
       getMonth: proc (): int {.tags: [], raises: [], benign.}
       getSeconds: proc (): int {.tags: [], raises: [], benign.}
-      getTime: proc (): int {.tags: [], raises: [], benign.}
+      getTime: proc (): int {.tags: [], raises: [], noSideEffect, benign.}
       getTimezoneOffset: proc (): int {.tags: [], raises: [], benign.}
       getDate: proc (): int {.tags: [], raises: [], benign.}
       getUTCDate: proc (): int {.tags: [], raises: [], benign.}

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -217,21 +217,21 @@ proc `$` *(time: Time): string {.tags: [], raises: [], benign.}
   ## converts a calendar time to a string representation.
 
 proc `-`*(a, b: Time): int64 {.
-  rtl, extern: "ntDiffTime", tags: [], raises: [], benign.}
+  rtl, extern: "ntDiffTime", tags: [], raises: [], noSideEffect, benign.}
   ## computes the difference of two calendar times. Result is in seconds.
 
 proc `<`*(a, b: Time): bool {.
-  rtl, extern: "ntLtTime", tags: [], raises: [].} =
+  rtl, extern: "ntLtTime", tags: [], raises: [], noSideEffect.} =
   ## returns true iff ``a < b``, that is iff a happened before b.
   result = a - b < 0
 
 proc `<=` * (a, b: Time): bool {.
-  rtl, extern: "ntLeTime", tags: [], raises: [].}=
+  rtl, extern: "ntLeTime", tags: [], raises: [], noSideEffect.}=
   ## returns true iff ``a <= b``.
   result = a - b <= 0
 
 proc `==`*(a, b: Time): bool {.
-  rtl, extern: "ntEqTime", tags: [], raises: [].} =
+  rtl, extern: "ntEqTime", tags: [], raises: [], noSideEffect.} =
   ## returns true if ``a == b``, that is if both times represent the same value
   result = a - b == 0
 

--- a/tests/stdlib/ttime.nim
+++ b/tests/stdlib/ttime.nim
@@ -164,3 +164,14 @@ let dstT1 = parse("2016-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss")
 let dstT2 = parse("2016-06-01 00:00:00", "yyyy-MM-dd HH:mm:ss")
 doAssert dstT1 == getLocalTime(toTime(dstT1))
 doAssert dstT2 == getLocalTime(toTime(dstT2))
+
+# Comparison between Time objects should be detected by compiler
+# as 'noSideEffect'.
+proc cmpTimeNoSideEffect(t1: Time, t2: Time): bool {.noSideEffect.} =
+  result = t1 == t2
+doAssert cmpTimeNoSideEffect(0.fromSeconds, 0.fromSeconds)
+# Additionally `==` generic for seq[T] has explicit 'noSideEffect' pragma
+# so we can check above condition by comparing seq[Time] sequences
+let seqA: seq[Time] = @[]
+let seqB: seq[Time] = @[]
+doAssert seqA == seqB


### PR DESCRIPTION
I've added 'noSideEffect' pragma for [proc `-`](https://github.com/nim-lang/Nim/blob/0f3419685fecc554f6ce28dee3e4630480358c3b/lib/pure/times.nim#L219) and comparison operators.

I have not removed 'noSideEffect' from [generic `==` for seq[T]](https://github.com/nim-lang/Nim/blob/0f3419685fecc554f6ce28dee3e4630480358c3b/lib/system.nim#L2179) as suggested here https://github.com/nim-lang/Nim/issues/4981#issuecomment-257648687 because I do not fully understand how to do it properly. There are other procedures for seq[T] with this pragma and this pragma probably should be removed from them too. And personally I think that having 'noSideEffect' on `==` is generally not a bad idea.

So this PR only fixes #4981.