### PR TITLE
[enh] isUpperAscii*, isLowerAscii* speedup execution by stopping

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -179,9 +179,10 @@ proc isLowerAscii*(s: string): bool {.noSideEffect, procvar,
   if s.len() == 0:
     return false
 
-  result = true
   for c in s:
-    result = c.isLowerAscii() and result
+    if not c.isLowerAscii():
+      return false
+  true
 
 proc isUpperAscii*(s: string): bool {.noSideEffect, procvar,
   rtl, extern: "nsuIsUpperAsciiStr".}=
@@ -193,9 +194,10 @@ proc isUpperAscii*(s: string): bool {.noSideEffect, procvar,
   if s.len() == 0:
     return false
 
-  result = true
   for c in s:
-    result = c.isUpperAscii() and result
+    if not c.isUpperAscii():
+      return false
+  true
 
 proc toLowerAscii*(c: char): char {.noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiChar".} =


### PR DESCRIPTION
isUpperAscii and isLowerAscii is very slow on long lines, that is because they scan all the characters in string

this patch makes them stop scanning as soon as possible

