### PR TITLE
Fix some errors in parsexml.nim

### DIFF
--- a/lib/pure/parsexml.nim
+++ b/lib/pure/parsexml.nim
@@ -571,7 +571,7 @@ proc parseAttribute(my: var XmlParser) =
           add(my.b, buf[pos])
           inc(pos)
   else:
-    markError(my, errQuoteExpected)
+    # markError(my, errQuoteExpected)
     # error corrections: guess what was meant
     while buf[pos] != '>' and buf[pos] > ' ':
       add(my.b, buf[pos])


### PR DESCRIPTION
Fix parsing of this code:
```
<td class="" style="font-size: 12px;">
<input type=text name='name' id='number'
		value="1" size=4 style="width:30px">
</td>
```