### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tags
 install.sh
 deinstall.sh
 
+doc/html/
 doc/*.html
 doc/*.pdf
 doc/*.idx


### PR DESCRIPTION
Update .gitignore to reflect the new target dir of the generated documentation.
`./koch doc` now writes the documentation to `doc/html/...`