### PR TITLE
added dist/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ xcuserdata/
 /testresults.json
 testament.db
 /csources
+dist/
 
 # Private directories and files (IDEs)
 .*/


### PR DESCRIPTION
When using `./koch tools`, the directory `dist/` is generated (it contains the `nimble` sources).
The `dist` directory was added to .gitignore.