### PR TITLE
make 'excessivestacktrace' option available for testing.

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -264,6 +264,7 @@ proc testCompileOption*(switch: string, info: TLineInfo): bool =
   of "implicitstatic": result = contains(gOptions, optImplicitStatic)
   of "patterns": result = contains(gOptions, optPatterns)
   of "experimental": result = gExperimentalMode
+  of "excessivestacktrace": result = contains(gGlobalOptions, optExcessiveStackTrace)
   else: invalidCmdLineOption(passCmd1, switch, info)
 
 proc processPath(path: string, info: TLineInfo,


### PR DESCRIPTION
make excessiveStackTrace option available for testing, as in:
```nim
const useFullPaths = compileOption("excessiveStackTrace")
```