### PR TITLE
Add warning about cryptographic use of random.nim

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -11,6 +11,7 @@
 ## * More information: http://xoroshiro.di.unimi.it/
 ## * C implementation: http://xoroshiro.di.unimi.it/xoroshiro128plus.c
 ##
+## WARNING: user space PRNGs are not recommended for cryptographic use!
 
 include "system/inclrtl"
 {.push debugger:off.}


### PR DESCRIPTION
Some reasoning on the warning:
https://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers/