### PR TITLE
Corrected test case for #5057.

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1159,10 +1159,10 @@ when isMainModule:
       doAssert(prev < i)
       prev = i
 
-  block: # Deletion from OrederedTable should account for collision groups. See issue #5057.
+  block: # Deletion from OrderedTable should account for collision groups. See issue #5057.
     # The bug is reproducible only with exact keys
-    const key1 = "boy_jackpot.inGamma1"
-    const key2 = "boy_jackpot.outBlack2"
+    const key1 = "boy_jackpot.inGamma"
+    const key2 = "boy_jackpot.outBlack"
 
     var t = {
         key1: 0,


### PR DESCRIPTION
The keys in the test were accidentaly changed during experiments. Changed them back so that they actually reproduce the original case. Also a typo corrected.