### PR TITLE
Remove docgen.nim's dependency on things being in path

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -13,8 +13,10 @@
 
 import
   ast, strutils, strtabs, options, msgs, os, ropes, idents,
-  wordrecg, syntaxes, renderer, lexer, rstast, rst, rstgen, times, highlite,
-  importer, sempass2, json, xmltree, cgi, typesrenderer, astalgo
+  wordrecg, syntaxes, renderer, lexer, packages/docutils/rstast,
+  packages/docutils/rst, packages/docutils/rstgen, times,
+  packages/docutils/highlite, importer, sempass2, json, xmltree, cgi,
+  typesrenderer, astalgo
 
 type
   TSections = array[TSymKind, Rope]

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -4,8 +4,6 @@ hint[XDeclaredButNotUsed]:off
 path:"llvm"
 path:"$projectPath/.."
 
-path:"$lib/packages/docutils"
-
 define:booting
 #import:"$projectpath/testability"
 


### PR DESCRIPTION
`compiler/docgen.nim` relied heavily on `$lib/packages/docutils` being in `path` at compile-time. While this works fine when building Nim itself, things start breaking when using `compiler` as a nimble package.