### PR TITLE
Fixes #5065

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1003,15 +1003,11 @@ proc `$`*(timeInfo: TimeInfo): string {.tags: [], raises: [], benign.} =
     result = format(timeInfo, "yyyy-MM-dd'T'HH:mm:sszzz") # todo: optimize this
   except ValueError: assert false # cannot happen because format string is valid
 
-proc `$`*(time: Time): string {.tags: [TimeEffect], raises: [], benign.} =
+proc `$`*(time: Time): string
+    {.tags: [TimeEffect], raises: [ValueError], benign.} =
   ## converts a `Time` value to a string representation. It will use the local
   ## time zone and use the format ``yyyy-MM-dd'T'HH-mm-sszzz``.
-  when defined(windows):
-    try: result = $getLocalTime(time)
-    except ValueError:
-      result = $TimeImpl(time) & " seconds before Jan 1st 1970"
-  else:
-    result = $getLocalTime(time)
+  result = $getLocalTime(time)
 
 {.pop.}
 


### PR DESCRIPTION
Enabled `toTime()` to correctly handle times before 1970 on Windows.

This is a more or less dirty hack for the fact that `mktime` on Windows returns `-1` if called with a date that predates – interpreted in the local time zone – January 1st, 1970.

Sadly, the reverse actions – `getLocalTime` and `getGMTime` – cannot be simply adjusted likewise. That would basically be a reimplementation of `localtime` and `gmtime` because we would need to recalculate `weekday`, `yearday` and `DST`. Since this is out of scope of this PR, I instead added a proper exception for these cases on Windows. `fromSeconds(-1)` would have led to an assertion failure without `-d:release` and a segfault with `-d:release` before on Windows.