### PR TITLE
check waitpid() return value before setting exitStatus

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -965,7 +965,7 @@ elif not defined(useNimRtl):
     var ret : int
     var status : cint = 1
     ret = waitpid(p.id, status, WNOHANG)
-    if WIFEXITED(status):
+    if ret == int(p.id) and WIFEXITED(status):
       p.exitStatus = status
     if ret == 0: return true # Can't establish status. Assume running.
     result = ret == int(p.id)

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -965,10 +965,16 @@ elif not defined(useNimRtl):
     var ret : int
     var status : cint = 1
     ret = waitpid(p.id, status, WNOHANG)
-    if ret == int(p.id) and WIFEXITED(status):
-      p.exitStatus = status
-    if ret == 0: return true # Can't establish status. Assume running.
-    result = ret == int(p.id)
+    if ret == int(p.id):
+      if WIFEXITED(status):
+        p.exitStatus = status
+        return false
+      else:
+        return true
+    elif ret == 0:
+      return true # Can't establish status. Assume running.
+    else:
+      return false
 
   proc terminate(p: Process) =
     if kill(p.id, SIGTERM) != 0'i32:

--- a/tests/osproc/texitcode.nim
+++ b/tests/osproc/texitcode.nim
@@ -16,3 +16,8 @@ var running = true
 while running:
   running = running(p)
 doAssert(waitForExit(p) == QuitFailure)
+
+# make sure that first call to running() after process exit returns false
+p = startProcess(filename, dir)
+os.sleep(500)
+doAssert(not running(p))


### PR DESCRIPTION
This fixes a race with parallelBuild on DragonFly BSD.
Also fixes #5092.