### PR TITLE
Fix 4690 (WIP)

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -436,10 +436,8 @@ when not defined(JS):
     TimeInfoPtr = ptr StructTM
     Clock {.importc: "clock_t".} = distinct int
 
-  when defined(windows):
-    proc timegm(t: StructTM): Time {.
-      importc: "_mkgmtime", header: "<time.h>", tags: [].}
-  else:
+  when not defined(windows):
+    # This is not ANSI C, but common enough
     proc timegm(t: StructTM): Time {.
       importc: "timegm", header: "<time.h>", tags: [].}
 
@@ -522,18 +520,22 @@ when not defined(JS):
     # the conversion is not expensive
 
   proc timeInfoToTime(timeInfo: TimeInfo): Time =
-    var cTimeInfo = timeInfo # for C++ we have to make a copy,
-    # because the header of timegm is broken in my version of libc
-    result = timegm(timeInfoToTM(cTimeInfo))
-    # As timeInfoToTM does ignore the timezone, we need to adjust this here.
-    result = Time(TimeImpl(result) + timeInfo.timezone)
+    toTime(timeInfo)
 
   proc toTime(timeInfo: TimeInfo): Time =
-    var cTimeInfo = timeInfo # for C++ we have to make a copy,
-    # because the header of timegm is broken in my version of libc
-    result = timegm(timeInfoToTM(cTimeInfo))
-    # As timeInfoToTM does ignore the timezone, we need to adjust this here.
-    result = Time(TimeImpl(result) + timeInfo.timezone)
+    var cTimeInfo = timeInfo # for C++ we have to make a copy
+    # because the header of mktime is broken in my version of libc
+
+    when defined(windows):
+      # On Windows `mktime` is broken enough to make this work.
+      result = mktime(timeInfoToTM(cTimeInfo))
+      # mktime is defined to interpret the input as local time. As timeInfoToTM
+      # does ignore the timezone, we need to adjust this here.
+      result = Time(TimeImpl(result) - getTimezone() + timeInfo.timezone)
+    else:
+      result = timegm(timeInfoToTM(cTimeInfo))
+      # As timeInfoToTM does ignore the timezone, we need to adjust this here.
+      result = Time(TimeImpl(result) + timeInfo.timezone)
 
   const
     epochDiff = 116444736000000000'i64


### PR DESCRIPTION
This is based on @endragor's commit.

On Windows keeps the previous implementation (using `mktime`). `mktime` in Windows seems to be using the same logic for determining the timezone that the existing implementation is using (using current timezone data instead of historical), so this works. `_mkgmtime` approach doesn't work with 32-bit mingw, since the function is not present in the old msvcrt.dll.

On other systems uses `timegm` to remove the need for historical timezone data. This is non-ANSI-compliant, but seems to be supported at least by Linux (tested), FreeBSD, OpenBSD, and OS X.
Fixes #4690.