### PR TITLE
Disables ``paramCount``, ``paramStr`` when building posix dynlib. Fixes #4775

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1427,7 +1427,7 @@ elif defined(windows):
     if isNil(ownArgv): ownArgv = parseCmdLine($getCommandLine())
     return TaintedString(ownArgv[i])
 
-elif not defined(createNimRtl):
+elif not defined(createNimRtl) and not(defined(posix) and appType == "lib"):
   # On Posix, there is no portable way to get the command line from a DLL.
   var
     cmdCount {.importc: "cmdCount".}: cint


### PR DESCRIPTION
posix dynamic libraries doesn't have ``cmdCount`` and ``cmdLine``