### PR TITLE
gendepend fix and deplist introduction

### DIFF
--- a/compiler/depends.nim
+++ b/compiler/depends.nim
@@ -15,6 +15,7 @@ import
 from modulegraphs import ModuleGraph
 
 proc generateDot*(project: string)
+proc generateDepList*(project: string)
 
 type
   TGen = object of TPassContext
@@ -24,7 +25,7 @@ type
 var gDotGraph: Rope # the generated DOT file; we need a global variable
 
 proc addDependencyAux(importing, imported: string) =
-  addf(gDotGraph, "$1 -> $2;$n", [rope(importing), rope(imported)])
+  addf(gDotGraph, "$1 -> \"$2\";$n", [rope(importing), rope(imported)])
   # s1 -> s2_4[label="[0-9]"];
 
 proc addDotDependency(c: PPassContext, n: PNode): PNode =
@@ -56,3 +57,38 @@ proc myOpen(graph: ModuleGraph; module: PSym; cache: IdentCache): PPassContext =
 
 const gendependPass* = makePass(open = myOpen, process = addDotDependency)
 
+# set of file dependences
+var gDepSet: Rope
+
+proc generateDepList(project: string) =
+  let depfile = changeFileExt(project, "deps")
+  writeRope(gDepSet, depfile)
+  rawMessage(hintExecuting, "Wrote " & depfile)
+
+proc addDepFileByNode(n: PNode) =
+  let fidx = checkModuleName(n)
+  if fidx != InvalidFileIDX:
+    let ndf = toFullPath(fidx) & "\n"
+    # Check for uniqueness
+    for df in gDepSet.leaves:
+      if df == ndf:
+        return
+
+    gDepSet.add(ndf)
+
+proc addDepFile(c: PPassContext, n: PNode): PNode =
+  result = n
+  var g = PGen(c)
+  case n.kind
+  of nkImportStmt:
+    for i in countup(0, sonsLen(n) - 1):
+      addDepFileByNode(n.sons[i])
+  of nkFromStmt, nkImportExceptStmt:
+    addDepFileByNode(n.sons[0])
+  of nkStmtList, nkBlockStmt, nkStmtListExpr, nkBlockExpr:
+    for i in countup(0, sonsLen(n) - 1):
+      discard addDepFile(c, n.sons[i])
+  else:
+    discard
+
+const deplistPass* = makePass(open = myOpen, process = addDepFile)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -34,11 +34,16 @@ proc semanticPasses =
 proc commandGenDepend(graph: ModuleGraph; cache: IdentCache) =
   semanticPasses()
   registerPass(gendependPass)
-  registerPass(cleanupPass)
   compileProject(graph, cache)
   generateDot(gProjectFull)
   execExternalProgram("dot -Tpng -o" & changeFileExt(gProjectFull, "png") &
       ' ' & changeFileExt(gProjectFull, "dot"))
+
+proc commandDepList(graph: ModuleGraph; cache: IdentCache) =
+  semanticPasses()
+  registerPass(deplistPass)
+  compileProject(graph, cache)
+  generateDepList(gProjectFull)
 
 proc commandCheck(graph: ModuleGraph; cache: IdentCache) =
   msgs.gErrorMax = high(int)  # do not stop after first error
@@ -212,6 +217,9 @@ proc mainCommand*(graph: ModuleGraph; cache: IdentCache) =
   of "gendepend":
     gCmd = cmdGenDepend
     commandGenDepend(graph, cache)
+  of "deplist":
+    gCmd = cmdDepList
+    commandDepList(graph, cache)
   of "dump":
     gCmd = cmdDump
     if getConfigVar("dump.format") == "json":

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -83,7 +83,7 @@ type
     cmdCompileToJS,
     cmdCompileToPHP,
     cmdCompileToLLVM, cmdInterpret, cmdPretty, cmdDoc,
-    cmdGenDepend, cmdDump,
+    cmdGenDepend, cmdDump, cmdDepList,
     cmdCheck,                 # semantic checking for whole project
     cmdParse,                 # parse a single file (for debugging)
     cmdScan,                  # scan a single file (for debugging)

--- a/compiler/rodread.nim
+++ b/compiler/rodread.nim
@@ -587,7 +587,7 @@ proc cmdChangeTriggersRecompilation(old, new: TCommands): bool =
                cmdInteractive}:
       return false
   of cmdNone, cmdDoc, cmdInterpret, cmdPretty, cmdGenDepend, cmdDump,
-      cmdCheck, cmdParse, cmdScan, cmdIdeTools, cmdDef,
+      cmdCheck, cmdParse, cmdScan, cmdIdeTools, cmdDef, cmdDepList,
       cmdRst2html, cmdRst2tex, cmdInteractive, cmdRun:
     discard
   # else: trigger recompilation:

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -12,6 +12,8 @@ Advanced commands:
   //run                     run the project (with Tiny C backend; buggy!)
   //genDepend               generate a DOT file containing the
                             module dependency graph
+  //deplist                 generate file with list of module dependences
+                            helps to automate building toolchains
   //dump                    dump all defined conditionals and search paths
   //check                   checks the project for syntax and semantic
 


### PR DESCRIPTION
[fix] commandGenDepend: cleanupPass remove, was causing problem
      'Error: internal error: wrong AST for borrowed symbol'

[fix] addDependencyAux: DOT does not allow some special characters,
      such as /, so there is need for quotation

[new] 'deplist' compiler option, to generate module's dependeces list.
      This can help various building toolchains to decide whether or
      not to run recompilation