### PR TITLE
Define getAttributes(NS) on PNode instead of PElement.

### DIFF
--- a/lib/pure/xmldom.nim
+++ b/lib/pure/xmldom.nim
@@ -890,7 +890,7 @@ proc tagName*(el: PElement): string =
   return el.fTagName
 
 # Procedures
-proc getAttribute*(el: PElement, name: string): string =
+proc getAttribute*(el: PNode, name: string): string =
   ## Retrieves an attribute value by ``name``
   if isNil(el.attributes):
     return nil
@@ -900,7 +900,7 @@ proc getAttribute*(el: PElement, name: string): string =
   else:
     return nil
 
-proc getAttributeNS*(el: PElement, namespaceURI: string, localName: string): string =
+proc getAttributeNS*(el: PNode, namespaceURI: string, localName: string): string =
   ## Retrieves an attribute value by ``localName`` and ``namespaceURI``
   if isNil(el.attributes):
     return nil


### PR DESCRIPTION
Currently `getAttribute` and `getAttributeNS` are defined on a `PElement`. This makes getting attributes from anything returning a `seq[PNode]` annoying (it requires a cast). One prime example of this is `getElementsByTagName(NS)`

Considering the fact that the attributes are actually defined on the `Node` type and not on the `Element` type, it makes more sense to define the methods on a `PNode` instead.

For example the code which triggered this PR:

```
let operations = doc.getElementsByTagNameNS(wsdl_ns, "operation").map(proc (x: PNode) : string = PElement(x).getAttribute("name")).deduplicate.join(", ")
``` 
Will not need the cast anymore:

```
let operations = doc.getElementsByTagNameNS(wsdl_ns, "operation").map(proc (x: PNode) : string = x.getAttribute("name")).deduplicate.join(", ")
```

` 