### PR TITLE
Adds pending operations presence check function to asyncdispatch, fixes #5155

### DIFF
--- a/tests/async/tpendingcheck.nim
+++ b/tests/async/tpendingcheck.nim
@@ -1,0 +1,21 @@
+discard """
+  file: "tpendingcheck.nim"
+  exitcode: 0
+  output: ""
+"""
+
+import asyncdispatch
+
+doAssert(not hasPendingOperations())
+
+proc test() {.async.} =
+  await sleepAsync(100)
+
+var f = test()
+while not f.finished:
+  doAssert(hasPendingOperations())
+  poll(10)
+f.read
+
+doAssert(not hasPendingOperations())
+


### PR DESCRIPTION
First I wanted to add ``proc len(p: PDispatcher): int``, but then I realized that there is no public API for PDispatcher, see #5162 