### PR TITLE
Further tutorial updates

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -125,13 +125,17 @@ Documentation comments are tokens; they are only allowed at certain places in
 the input file as they belong to the syntax tree! This feature enables simpler
 documentation generators.
 
-Multiline comments are started with ``#[`` and terminated with ``]#``
+Multiline comments are started with ``#[`` and terminated with ``]#``.  Multiline
+comments can also be nested.
 
 .. code-block:: nim
   #[
   You can have any Nim code text commented
   out inside this with no indentation restrictions.
         yes("May I ask a pointless question?")
+    #[
+       Note: these can be nested!!
+    ]#
   ]#
 
 You can also use the `discard statement`_ together with *long string

--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -125,6 +125,15 @@ Documentation comments are tokens; they are only allowed at certain places in
 the input file as they belong to the syntax tree! This feature enables simpler
 documentation generators.
 
+Multiline comments are started with ``#[`` and terminated with ``]#``
+
+.. code-block:: nim
+  #[
+  You can have any Nim code text commented
+  out inside this with no indentation restrictions.
+        yes("May I ask a pointless question?")
+  ]#
+
 You can also use the `discard statement`_ together with *long string
 literals* to create block comments:
 

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -609,10 +609,10 @@ The parameters' types can be ordinary types or the meta types ``untyped``,
 type resolution is not performed before the expression is passed to the template.
 
 If the template has no explicit return type,
-``untyped`` is used for consistency with procs and methods.
+``void`` is used for consistency with procs and methods.
 
-If there is a ``typed`` parameter it should be the last in the template
-declaration. The reason is that statements can be passed to a template
+If there is a ``typed`` parameter, it should be the last in the template
+declaration.  This allows statements to be passed to a template
 via a special ``:`` syntax:
 
 .. code-block:: nim

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -637,12 +637,6 @@ avoid a common bug: to forget to close the file. Note how the
 ``let fn = filename`` statement ensures that ``filename`` is evaluated only
 once.
 
-Note: ``txt`` is a parameter to the withFile template that doesn't require 
-explicit definition prior to being passed to withFile().
-``txt`` is defined within withFile(), but needs to be a parameter so it can 
-be used in the block of statements that follow withFile()
-  
-
 Macros
 ======
 

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -616,7 +616,7 @@ To pass a block of statements to a template, use 'untyped' for the last paramete
 .. code-block:: nim
 
   template withFile(f: untyped, filename: string, mode: FileMode,
-                    body: untyped): typed {.immediate.} =
+                    body: untyped): typed =
     let fn = filename
     var f: File
     if open(f, fn, mode):

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -611,14 +611,12 @@ type resolution is not performed before the expression is passed to the template
 If the template has no explicit return type,
 ``void`` is used for consistency with procs and methods.
 
-If there is a ``typed`` parameter, it should be the last in the template
-declaration.  This allows statements to be passed to a template
-via a special ``:`` syntax:
+To pass a block of statements to a template, use 'untyped' for the last parameter:
 
 .. code-block:: nim
 
   template withFile(f: untyped, filename: string, mode: FileMode,
-                    body: typed): typed {.immediate.} =
+                    body: untyped): typed {.immediate.} =
     let fn = filename
     var f: File
     if open(f, fn, mode):
@@ -638,6 +636,12 @@ parameter. The ``withFile`` template contains boilerplate code and helps to
 avoid a common bug: to forget to close the file. Note how the
 ``let fn = filename`` statement ensures that ``filename`` is evaluated only
 once.
+
+Note: ``txt`` is a parameter to the withFile template that doesn't require 
+explicit definition prior to being passed to withFile().
+``txt`` is defined within withFile(), but needs to be a parameter so it can 
+be used in the block of statements that follow withFile()
+  
 
 Macros
 ======


### PR DESCRIPTION
Please check that the replacement description text for ``expr`` & ``stmt`` are correct.

tut1: added multiline comments
tut2: replaced expr/stmt with untyped/typed
added some more template/macro examples