### PR TITLE
Fixes No such file or dir exception

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -54,7 +54,10 @@ proc handleCmdLine(cache: IdentCache) =
       except OSError:
         gProjectFull = gProjectName
       let p = splitFile(gProjectFull)
-      gProjectPath = canonicalizePath p.dir
+      try:
+        gProjectPath = canonicalizePath p.dir
+      except:
+        gProjectPath = canonicalizePath getCurrentDir()
       gProjectName = p.name
     else:
       gProjectPath = canonicalizePath getCurrentDir()


### PR DESCRIPTION
Fixes the following usecase:
```sh
$ mkdir test && cd test
$ echo "" > foo.nim
$ nim c foo
Error: unhandled exception: No such file or directory [OSError]
```