### PR TITLE
Workaround for the high cpu usage issue in coroutines on linux

### DIFF
--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -14,8 +14,6 @@ import os, times
 import macros
 import arch
 import lists
-when defined(linux):
-  from posix import select, TimeVal
 
 const defaultStackSize = 512 * 1024
 
@@ -70,18 +68,10 @@ proc run*() =
   var node = coroutines.head
   var minDelay: float = 0
   var frame: PFrame
-  when defined(linux):
-    var timeval = TimeVal(tv_sec: 0, tv_usec: 0)
   while node != nil:
     var coro = node.value
     current = coro
-    let minDelay_ms = int(minDelay * 1000)
-    when defined(linux):
-      timeval.tvsec =  int32(minDelay_ms div 1000)
-      timeval.tvusec = (minDelay_ms mod 1000) * 1000
-      discard select(0.cint, nil, nil, nil, timeval.addr)
-    else:
-      os.sleep(minDelay_ms)
+    os.sleep(int(minDelay * 1000))
 
     var remaining = coro.sleepTime - (epochTime() - coro.lastRun);
     if remaining <= 0:

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -73,11 +73,13 @@ proc run*() =
     current = coro
     os.sleep(minDelay)
 
-    # remaining_s - remaining time in seconds
-    let remaining_s = coro.sleepTime - (epochTime() - coro.lastRun)
-    # remaining - in milliseconds
-    # comparing to the int.high is required to avoid integer overflow
-    var remaining = min(int.high.float, remaining_s * 1000).int
+    let remaining_float = # remaining time with fractional part
+      (coro.sleepTime - (epochTime() - coro.lastRun)) * 1000
+    # The integer overflow check
+    assert(remaining_float <= float(int.high),
+           "The suspend time is too long!")
+    # remaining - time in milliseconds without fractional part
+    var remaining = remaining_float.int
     if remaining <= 0:
       remaining = 0
       let res = setjmp(mainCtx)

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -73,13 +73,7 @@ proc run*() =
     current = coro
     os.sleep(minDelay)
 
-    let remaining_float = # remaining time with fractional part
-      (coro.sleepTime - (epochTime() - coro.lastRun)) * 1000
-    # The integer overflow check
-    assert(remaining_float <= float(int.high),
-           "The suspend time is too long!")
-    # remaining - time in milliseconds without fractional part
-    var remaining = remaining_float.int
+    var remaining = int((coro.sleepTime - (epochTime() - coro.lastRun)) * 1000)
     if remaining <= 0:
       remaining = 0
       let res = setjmp(mainCtx)

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -66,14 +66,18 @@ proc run*() =
   ## Starts main event loop which exits when all coroutines exit. Calling this proc
   ## starts execution of first coroutine.
   var node = coroutines.head
-  var minDelay: float = 0
+  var minDelay: int = 0 # in milliseconds
   var frame: PFrame
   while node != nil:
     var coro = node.value
     current = coro
-    os.sleep(int(minDelay * 1000))
+    os.sleep(minDelay)
 
-    var remaining = coro.sleepTime - (epochTime() - coro.lastRun);
+    # remaining_s - remaining time in seconds
+    let remaining_s = coro.sleepTime - (epochTime() - coro.lastRun)
+    # remaining - in milliseconds
+    # comparing to the int.high is required to avoid integer overflow
+    var remaining = min(int.high.float, remaining_s * 1000).int
     if remaining <= 0:
       remaining = 0
       let res = setjmp(mainCtx)

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -14,6 +14,8 @@ import os, times
 import macros
 import arch
 import lists
+when defined(linux):
+  from posix import select, TimeVal
 
 const defaultStackSize = 512 * 1024
 
@@ -68,10 +70,18 @@ proc run*() =
   var node = coroutines.head
   var minDelay: float = 0
   var frame: PFrame
+  when defined(linux):
+    var timeval = TimeVal(tv_sec: 0, tv_usec: 0)
   while node != nil:
     var coro = node.value
     current = coro
-    os.sleep(int(minDelay * 1000))
+    let minDelay_ms = int(minDelay * 1000)
+    when defined(linux):
+      timeval.tvsec =  int32(minDelay_ms div 1000)
+      timeval.tvusec = (minDelay_ms mod 1000) * 1000
+      discard select(0.cint, nil, nil, nil, timeval.addr)
+    else:
+      os.sleep(minDelay_ms)
 
     var remaining = coro.sleepTime - (epochTime() - coro.lastRun);
     if remaining <= 0:


### PR DESCRIPTION
Take a look at MWE of the issue:
```Nim
when defined(mycoro):
  from mycoro import run, start, suspend
else:
  from coro import run, start, suspend

proc test_routine() =
  while true:
    suspend(1)

start(test_routine)
start(test_routine)
run()
```
`mycoro` is a `coro` version from this PR.
This code was compiled on GNU/Linux 4.8.13-1-ARCH by Nim compiler 0.15.0 (exact git hash: 8ec28552bc2d6271ad70eb21ed1d59b00078df16)
```
nim c -d:nimCoroutines -d:mycoro -o:mytest test.nim
nim c -d:nimCoroutines -o:test test.nim
```
After running both of `test` and `mytest` executables for a 10 seconds with measurement of cpu usage by `time`, I've got the following results:
```
$ time ./test                                
^CTraceback (most recent call last)
test.nim(12)             test
coro.nim(74)             run
os.nim(1482)             sleep
SIGINT: Interrupted by Ctrl-C.

real    0m10,055s
user    0m0,230s
sys     0m0,543s
$ time ./mytest
^CTraceback (most recent call last)
test.nim(12)             test
mycoro.nim(82)           run
SIGINT: Interrupted by Ctrl-C.

real    0m9,991s
user    0m0,003s
sys     0m0,000s
```
It can be seen, that original `coro` library consumes much CPU resources when sleeping.
My investigations lead me to the [StackOverflow question](http://stackoverflow.com/questions/1125297/nanosleep-high-cpu-usage). As long as `coro` uses `os.sleep` and its underlying implementation on linux is based on `nanosleep()` system call, the coroutines will be consuming such a big amount of resources. `nanosleep()` provides the high precision delay, while its enough for coroutines to use delay with the millisecond precision. Probably, the high precision of the `nanosleep()` syscall is really necessary in other `os.sleep` application, but in `coro` it may be better to use some alternative, such as `select` with timeout (according to this [answer](http://stackoverflow.com/questions/1157209/is-there-an-alternative-sleep-function-in-c-to-milliseconds/1157237#1157237)).