### PR TITLE
fixes #4804

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -523,16 +523,10 @@ when not defined(JS):
     var cTimeInfo = timeInfo # for C++ we have to make a copy
     # because the header of mktime is broken in my version of libc
 
-    when defined(windows):
-      # On Windows `mktime` is broken enough to make this work.
-      result = mktime(timeInfoToTM(cTimeInfo))
-      # mktime is defined to interpret the input as local time. As timeInfoToTM
-      # does ignore the timezone, we need to adjust this here.
-      result = Time(TimeImpl(result) - getTimezone() + timeInfo.timezone)
-    else:
-      result = timegm(timeInfoToTM(cTimeInfo))
-      # As timeInfoToTM does ignore the timezone, we need to adjust this here.
-      result = Time(TimeImpl(result) + timeInfo.timezone)
+    result = mktime(timeInfoToTM(cTimeInfo))
+    # mktime is defined to interpret the input as local time. As timeInfoToTM
+    # does ignore the timezone, we need to adjust this here.
+    result = Time(TimeImpl(result) - getTimezone() + timeInfo.timezone)
 
   proc timeInfoToTime(timeInfo: TimeInfo): Time = toTime(timeInfo)
 


### PR DESCRIPTION
toTime(): Use the Windows-specific part for every OS, because it gives correct results on Linux too. The removed code for Linux gives wrong results.