### PR TITLE
Add waitFor on seq[Future], waitAll and more

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -163,8 +163,8 @@ include includes/asyncfutures
 
 type
   PDispatcherBase = ref object of RootRef
-    timers: HeapQueue[tuple[finishAt: float, fut: Future[void]]]
-    callbacks: Deque[proc ()]
+    timers*: HeapQueue[tuple[finishAt: float, fut: Future[void]]]
+    callbacks*: Deque[proc ()]
 
 proc processTimers(p: PDispatcherBase) {.inline.} =
   #Process just part if timers at a step


### PR DESCRIPTION
waitFor can now wait on a sequence of async procedures
waitAll waits on all existing async procs
runningAsyncProcedures and showRunningAsyncProcedures are helpers

Switch tasyncall.nim to unittest, speed it up and add new tests
