### PR TITLE
Remove colon when unpacking yielded tuples. Fixes #5173

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -331,8 +331,10 @@ proc transformYield(c: PTransf, n: PNode): PTransNode =
     e = skipConv(e)
     if e.kind == nkPar:
       for i in countup(0, sonsLen(e) - 1):
+        var v = e.sons[i]
+        if v.kind == nkExprColonExpr: v = v.sons[1]
         add(result, newAsgnStmt(c, c.transCon.forStmt.sons[i],
-                                transform(c, e.sons[i])))
+                                transform(c, v)))
     else:
       unpackTuple(c, e, result)
   else:


### PR DESCRIPTION
```
iterator iter: tuple[i, j: int] =
  yield (i: 1, j: 2)
for x, y in iter():
  echo x, y
```
expands to:
```
x = i: 1
y = j: 2
echo x, y
```
since it does a literal copy.