### PR TITLE
Reset locExprs before arg return. Fixes #5098

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -30,7 +30,7 @@ proc fixupCall(p: BProc, le, ri: PNode, d: var TLoc,
       if d.k in {locTemp, locNone} or not leftAppearsOnRightSide(le, ri):
         # Great, we can use 'd':
         if d.k == locNone: getTemp(p, typ.sons[0], d, needsInit=true)
-        elif d.k notin {locExpr, locTemp} and not hasNoInit(ri):
+        elif d.k notin {locTemp} and not hasNoInit(ri):
           # reset before pass as 'result' var:
           resetLoc(p, d)
         add(pl, addrLoc(d))
@@ -226,7 +226,7 @@ proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
         # Great, we can use 'd':
         if d.k == locNone:
           getTemp(p, typ.sons[0], d, needsInit=true)
-        elif d.k notin {locExpr, locTemp} and not hasNoInit(ri):
+        elif d.k notin {locTemp} and not hasNoInit(ri):
           # reset before pass as 'result' var:
           resetLoc(p, d)
         add(pl, addrLoc(d))

--- a/tests/ccgbugs/tret_arg_init.nim
+++ b/tests/ccgbugs/tret_arg_init.nim
@@ -1,0 +1,26 @@
+discard """
+  output: '''nil
+nil
+nil'''
+"""
+
+type Bar = object
+  s1, s2: string
+
+proc initBar(): Bar = discard
+
+var a: array[5, Bar]
+a[0].s1 = "hey"
+a[0] = initBar()
+echo a[0].s1
+
+type Foo = object
+  b: Bar
+var f: Foo
+f.b.s1 = "hi"
+f.b = initBar()
+echo f.b.s1
+
+var ad = addr f.b
+ad[] = initBar()
+echo ad[].s1


### PR DESCRIPTION
For code like `expr = foo()` where the generated function for `foo` returns by argument, `expr` needs to be reset before `foo` is called. The code generator does this when `expr` is a variable, but not when it is an array access, field access, or dereference.

I'm not sure it makes sense that these locations have kind `locExpr`, as opposed to e.g. `locField`, but this fix handles all the above cases. I don't think it overreaches, since if an expression appears on the LHS of an assignment, then it must be an l-value and should be cleared.