### PR TITLE
Naive work-around for time redefinition

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -117,10 +117,11 @@ else:
     schedh = "#define _GNU_SOURCE\n#include <sched.h>"
     pthreadh = "#define _GNU_SOURCE\n#include <pthread.h>"
 
-  when defined(linux):
-    type Time = clong
-  else:
-    type Time = int
+  when not declared(Time):
+    when defined(linux):
+      type Time = clong
+    else:
+      type Time = int
 
   type
     SysThread* {.importc: "pthread_t", header: "<sys/types.h>",

--- a/lib/system/timers.nim
+++ b/lib/system/timers.nim
@@ -78,10 +78,11 @@ elif defined(posixRealtime):
 
 else:
   # fallback Posix implementation:
-  when defined(linux):
-    type Time = clong
-  else:
-    type Time = int
+  when not declared(Time):
+    when defined(linux):
+      type Time = clong
+    else:
+      type Time = int
 
   type
     Timeval {.importc: "struct timeval", header: "<sys/select.h>",


### PR DESCRIPTION
This would be a simple way to fix #5192 

Not sure if you would prefer to use different names though.