### PR TITLE
Create temp var in deepcopy if needed

### DIFF
--- a/tests/ccgbugs/tdeepcopy_addr_rval.nim
+++ b/tests/ccgbugs/tdeepcopy_addr_rval.nim
@@ -1,0 +1,16 @@
+discard """
+  output: "3"
+"""
+
+# issue 5166
+
+type
+  Test = ref object
+    x: int
+
+let x = Test(x: 3)
+let p = cast[pointer](x)
+
+var v: Test
+deepCopy(v, cast[Test](p))
+echo v.x


### PR DESCRIPTION
Here's a bit of an issue: the C generator seems to sometimes call `addrLoc` without checking whether the location is an lvalue. This is a problem because `genCast` (for example) doesn't always produce an lvalue when it should. I don't think this problem can be solved easily, because afaik there's no way right now to differentiate a regular variable from a manifest constant, since nim library code imports constants using `var`.

This PR fixes #5166, regarding `deepCopy`. It handles the case where the r-value is of kind `locExpr`, but that might not be sufficient for the same reason as above. Also this same bug might exist in other places. I haven't been able to find any.