### PR TITLE
Fix #5128, #5184.

### DIFF
--- a/lib/pure/ioselectors.nim
+++ b/lib/pure/ioselectors.nim
@@ -237,7 +237,7 @@ else:
     when T is string:
       msg.add(message)
     elif T is OSErrorCode:
-      msg.add(osErrorMsg(message))
+      msg.add(osErrorMsg(message) & " (code: " & $int(message) & ")")
     else:
       msg.add("Internal Error\n")
     var err = newException(IOSelectorsException, msg)

--- a/lib/pure/ioselectors.nim
+++ b/lib/pure/ioselectors.nim
@@ -40,7 +40,6 @@ const ioselSupportedPlatform* = defined(macosx) or defined(freebsd) or
 const bsdPlatform = defined(macosx) or defined(freebsd) or
                     defined(netbsd) or defined(openbsd)
 
-
 when defined(nimdoc):
   type
     Selector*[T] = ref object
@@ -64,11 +63,10 @@ when defined(nimdoc):
       VnodeRename, ## NOTE_RENAME (BSD specific, file renamed)
       VnodeRevoke  ## NOTE_REVOKE (BSD specific, file revoke occurred)
 
-    ReadyKey*[T] = object
+    ReadyKey* = object
       ## An object which holds result for descriptor
       fd* : int ## file/socket descriptor
       events*: set[Event] ## set of events
-      data*: T ## application-defined data
 
     SelectEvent* = object
       ## An object which holds user defined event
@@ -142,15 +140,8 @@ when defined(nimdoc):
   proc unregister*[T](s: Selector[T], fd: int|SocketHandle|cint) =
     ## Unregisters file/socket descriptor ``fd`` from selector ``s``.
 
-  proc flush*[T](s: Selector[T]) =
-    ## Flushes all changes was made to kernel pool/queue.
-    ## This function is useful only for BSD and MacOS, because
-    ## kqueue supports bulk changes to be made.
-    ## On Linux/Windows and other Posix compatible operation systems,
-    ## ``flush`` is alias for `discard`.
-
   proc selectInto*[T](s: Selector[T], timeout: int,
-                      results: var openarray[ReadyKey[T]]): int =
+                      results: var openarray[ReadyKey]): int =
     ## Process call waiting for events registered in selector ``s``.
     ## The ``timeout`` argument specifies the minimum number of milliseconds
     ## the function will be blocked, if no events are not ready. Specifying a
@@ -159,7 +150,7 @@ when defined(nimdoc):
     ##
     ## Function returns number of triggered events.
 
-  proc select*[T](s: Selector[T], timeout: int): seq[ReadyKey[T]] =
+  proc select*[T](s: Selector[T], timeout: int): seq[ReadyKey] =
     ## Process call waiting for events registered in selector ``s``.
     ## The ``timeout`` argument specifies the minimum number of milliseconds
     ## the function will be blocked, if no events are not ready. Specifying a
@@ -167,13 +158,23 @@ when defined(nimdoc):
     ##
     ## Function returns sequence of triggered events.
 
+  proc getData*[T](s: Selector[T], fd: SocketHandle|int): T =
+    ## Retrieves application-defined ``data`` associated with descriptor ``fd``.
+    ## If specified descriptor ``fd`` is not registered, empty/default value
+    ## will be returned.
+
+  proc setData*[T](s: Selector[T], fd: SocketHandle|int, data: var T): bool =
+    ## Associate application-defined ``data`` with descriptor ``fd``.
+    ##
+    ## Returns ``true``, if data was succesfully updated, ``false`` otherwise.
+
   template isEmpty*[T](s: Selector[T]): bool =
     ## Returns ``true``, if there no registered events or descriptors
     ## in selector.
 
-  template withData*[T](s: Selector[T], fd: SocketHandle, value,
+  template withData*[T](s: Selector[T], fd: SocketHandle|int, value,
                         body: untyped) =
-    ## retrieves the application-data assigned with descriptor ``fd``
+    ## Retrieves the application-data assigned with descriptor ``fd``
     ## to ``value``. This ``value`` can be modified in the scope of
     ## the ``withData`` call.
     ##
@@ -184,9 +185,9 @@ when defined(nimdoc):
     ##     value.uid = 1000
     ##
 
-  template withData*[T](s: Selector[T], fd: SocketHandle, value,
+  template withData*[T](s: Selector[T], fd: SocketHandle|int, value,
                         body1, body2: untyped) =
-    ## retrieves the application-data assigned with descriptor ``fd``
+    ## Retrieves the application-data assigned with descriptor ``fd``
     ## to ``value``. This ``value`` can be modified in the scope of
     ## the ``withData`` call.
     ##
@@ -215,55 +216,68 @@ else:
   type
     Event* {.pure.} = enum
       Read, Write, Timer, Signal, Process, Vnode, User, Error, Oneshot,
-      VnodeWrite, VnodeDelete, VnodeExtend, VnodeAttrib, VnodeLink,
+      Finished, VnodeWrite, VnodeDelete, VnodeExtend, VnodeAttrib, VnodeLink,
       VnodeRename, VnodeRevoke
 
-    ReadyKey*[T] = object
+  type
+    IOSelectorsException* = object of Exception
+
+    ReadyKey* = object
       fd* : int
       events*: set[Event]
-      data*: T
 
     SelectorKey[T] = object
       ident: int
       events: set[Event]
       param: int
-      key: ReadyKey[T]
+      data: T
+
+  proc raiseIOSelectorsError[T](message: T) =
+    var msg = ""
+    when T is string:
+      msg.add(message)
+    elif T is OSErrorCode:
+      msg.add(osErrorMsg(message))
+    else:
+      msg.add("Internal Error\n")
+    var err = newException(IOSelectorsException, msg)
+    raise err
 
   when not defined(windows):
     import posix
+
     proc setNonBlocking(fd: cint) {.inline.} =
       var x = fcntl(fd, F_GETFL, 0)
       if x == -1:
-        raiseOSError(osLastError())
+        raiseIOSelectorsError(osLastError())
       else:
         var mode = x or O_NONBLOCK
         if fcntl(fd, F_SETFL, mode) == -1:
-          raiseOSError(osLastError())
+          raiseIOSelectorsError(osLastError())
 
-    template setKey(s, pident, pkeyfd, pevents, pparam, pdata) =
+    template setKey(s, pident, pevents, pparam, pdata: untyped) =
       var skey = addr(s.fds[pident])
       skey.ident = pident
       skey.events = pevents
       skey.param = pparam
-      skey.key.fd = pkeyfd
-      skey.key.data = pdata
+      skey.data = data
 
   when ioselSupportedPlatform:
     template blockSignals(newmask: var Sigset, oldmask: var Sigset) =
       when hasThreadSupport:
         if posix.pthread_sigmask(SIG_BLOCK, newmask, oldmask) == -1:
-          raiseOSError(osLastError())
+          raiseIOSelectorsError(osLastError())
       else:
         if posix.sigprocmask(SIG_BLOCK, newmask, oldmask) == -1:
-          raiseOSError(osLastError())
+          raiseIOSelectorsError(osLastError())
 
     template unblockSignals(newmask: var Sigset, oldmask: var Sigset) =
       when hasThreadSupport:
         if posix.pthread_sigmask(SIG_UNBLOCK, newmask, oldmask) == -1:
-          raiseOSError(osLastError())
+          raiseIOSelectorsError(osLastError())
       else:
         if posix.sigprocmask(SIG_UNBLOCK, newmask, oldmask) == -1:
-          raiseOSError(osLastError())
+          raiseIOSelectorsError(osLastError())
 
   when defined(linux):
     include ioselects/ioselectors_epoll

--- a/lib/pure/ioselects/ioselectors_kqueue.nim
+++ b/lib/pure/ioselects/ioselectors_kqueue.nim
@@ -12,10 +12,8 @@
 import posix, times, kqueue
 
 const
-  # Maximum number of cached changes.
-  MAX_KQUEUE_CHANGE_EVENTS = 64
   # Maximum number of events that can be returned.
-  MAX_KQUEUE_RESULT_EVENTS = 64
+  MAX_KQUEUE_EVENTS = 64
   # SIG_IGN and SIG_DFL declared in posix.nim as variables, but we need them
   # to be constants and GC-safe.
   SIG_DFL = cast[proc(x: cint) {.noconv,gcsafe.}](0)
@@ -45,8 +43,7 @@ when hasThreadSupport:
     SelectorImpl[T] = object
       kqFD : cint
       maxFD : int
-      changesTable: array[MAX_KQUEUE_CHANGE_EVENTS, KEvent]
-      changesCount: int
+      changes: seq[KEvent]
       fds: ptr SharedArray[SelectorKey[T]]
       count: int
       changesLock: Lock
@@ -56,8 +53,7 @@ else:
     SelectorImpl[T] = object
       kqFD : cint
       maxFD : int
-      changesTable: array[MAX_KQUEUE_CHANGE_EVENTS, KEvent]
-      changesCount: int
+      changes: seq[KEvent]
       fds: seq[SelectorKey[T]]
       count: int
     Selector*[T] = ref SelectorImpl[T]
@@ -66,9 +62,10 @@ type
   SelectEventImpl = object
     rfd: cint
     wfd: cint
-# SelectEvent is declared as `ptr` to be placed in `shared memory`,
-# so you can share one SelectEvent handle between threads.
-type SelectEvent* = ptr SelectEventImpl
+
+  SelectEvent* = ptr SelectEventImpl
+  # SelectEvent is declared as `ptr` to be placed in `shared memory`,
+  # so you can share one SelectEvent handle between threads.
 
 proc newSelector*[T](): Selector[T] =
   var maxFD = 0.cint
@@ -77,36 +74,44 @@ proc newSelector*[T](): Selector[T] =
   # Obtain maximum number of file descriptors for process
   if sysctl(addr(namearr[0]), 2, cast[pointer](addr maxFD), addr size,
             nil, 0) != 0:
-    raiseOsError(osLastError())
+    raiseIOSelectorsError(osLastError())
 
   var kqFD = kqueue()
   if kqFD < 0:
-    raiseOsError(osLastError())
+    raiseIOSelectorsError(osLastError())
 
   when hasThreadSupport:
     result = cast[Selector[T]](allocShared0(sizeof(SelectorImpl[T])))
     result.kqFD = kqFD
     result.maxFD = maxFD.int
     result.fds = allocSharedArray[SelectorKey[T]](maxFD)
+    result.changes = newSeqOfCap[KEvent](MAX_KQUEUE_EVENTS)
     initLock(result.changesLock)
   else:
     result = Selector[T]()
     result.kqFD = kqFD
     result.maxFD = maxFD.int
     result.fds = newSeq[SelectorKey[T]](maxFD)
+    result.changes = newSeqOfCap[KEvent](MAX_KQUEUE_EVENTS)
 
 proc close*[T](s: Selector[T]) =
   if posix.close(s.kqFD) != 0:
-    raiseOSError(osLastError())
+    raiseIOSelectorsError(osLastError())
   when hasThreadSupport:
     deinitLock(s.changesLock)
     deallocSharedArray(s.fds)
     deallocShared(cast[pointer](s))
 
+template clearKey[T](key: ptr SelectorKey[T]) =
+  var empty: T
+  key.ident = 0
+  key.events = {}
+  key.data = empty
+
 proc newSelectEvent*(): SelectEvent =
   var fds: array[2, cint]
   if posix.pipe(fds) == -1:
-    raiseOSError(osLastError())
+    raiseIOSelectorsError(osLastError())
   setNonBlocking(fds[0])
   setNonBlocking(fds[1])
   result = cast[SelectEvent](allocShared0(sizeof(SelectEventImpl)))
@@ -116,16 +121,18 @@ proc newSelectEvent*(): SelectEvent =
 proc setEvent*(ev: SelectEvent) =
   var data: uint64 = 1
   if posix.write(ev.wfd, addr data, sizeof(uint64)) != sizeof(uint64):
-    raiseOSError(osLastError())
+    raiseIOSelectorsError(osLastError())
 
 proc close*(ev: SelectEvent) =
-  discard posix.close(cint(ev.rfd))
-  discard posix.close(cint(ev.wfd))
+  if posix.close(cint(ev.rfd)) == -1:
+    raiseIOSelectorsError(osLastError())
+  if posix.close(cint(ev.wfd)) == -1:
+    raiseIOSelectorsError(osLastError())
   deallocShared(cast[pointer](ev))
 
 template checkFd(s, f) =
   if f >= s.maxFD:
-    raise newException(ValueError, "Maximum file descriptors exceeded")
+    raiseIOSelectorsError("Maximum file descriptors exceeded!")
 
 when hasThreadSupport:
   template withChangeLock[T](s: Selector[T], body: untyped) =
@@ -144,23 +151,18 @@ template modifyKQueue[T](s: Selector[T], nident: uint, nfilter: cshort,
                          nudata: pointer) =
   mixin withChangeLock
   s.withChangeLock():
-    s.changesTable[s.changesCount] = KEvent(ident: nident,
-                                            filter: nfilter, flags: nflags,
-                                            fflags: nfflags, data: ndata,
-                                            udata: nudata)
-    inc(s.changesCount)
-    if s.changesCount == MAX_KQUEUE_CHANGE_EVENTS:
-      if kevent(s.kqFD, addr(s.changesTable[0]), cint(s.changesCount),
-                nil, 0, nil) == -1:
-        raiseOSError(osLastError())
-      s.changesCount = 0
+    s.changes.add(KEvent(ident: nident,
+                         filter: nfilter, flags: nflags,
+                         fflags: nfflags, data: ndata,
+                         udata: nudata))
 
 proc registerHandle*[T](s: Selector[T], fd: SocketHandle,
                         events: set[Event], data: T) =
   let fdi = int(fd)
   s.checkFd(fdi)
   doAssert(s.fds[fdi].ident == 0)
-  s.setKey(fdi, fdi, events, 0, data)
+  s.setKey(fdi, events, 0, data)
+
   if events != {}:
     if Event.Read in events:
       modifyKQueue(s, fdi.uint, EVFILT_READ, EV_ADD, 0, 0, nil)
@@ -199,7 +201,7 @@ proc registerTimer*[T](s: Selector[T], timeout: int, oneshot: bool,
   var fdi = posix.socket(posix.AF_INET, posix.SOCK_STREAM,
                          posix.IPPROTO_TCP).int
   if fdi == -1:
-    raiseOsError(osLastError())
+    raiseIOSelectorsError(osLastError())
 
   s.checkFd(fdi)
   doAssert(s.fds[fdi].ident == 0)
@@ -207,7 +209,8 @@ proc registerTimer*[T](s: Selector[T], timeout: int, oneshot: bool,
   let events = if oneshot: {Event.Timer, Event.Oneshot} else: {Event.Timer}
   let flags: cushort = if oneshot: EV_ONESHOT or EV_ADD else: EV_ADD
 
-  s.setKey(fdi, fdi, events, 0, data)
+  s.setKey(fdi, events, 0, data)
+
   # EVFILT_TIMER on Open/Net(BSD) has granularity of only milliseconds,
   # but MacOS and FreeBSD allow use `0` as `fflags` to use milliseconds
   # too
@@ -220,12 +223,12 @@ proc registerSignal*[T](s: Selector[T], signal: int,
   var fdi = posix.socket(posix.AF_INET, posix.SOCK_STREAM,
                          posix.IPPROTO_TCP).int
   if fdi == -1:
-    raiseOsError(osLastError())
+    raiseIOSelectorsError(osLastError())
 
   s.checkFd(fdi)
   doAssert(s.fds[fdi].ident == 0)
 
-  s.setKey(fdi, signal, {Event.Signal}, signal, data)
+  s.setKey(fdi, {Event.Signal}, signal, data)
   var nmask, omask: Sigset
   discard sigemptyset(nmask)
   discard sigemptyset(omask)
@@ -233,23 +236,25 @@ proc registerSignal*[T](s: Selector[T], signal: int,
   blockSignals(nmask, omask)
   # to be compatible with linux semantic we need to "eat" signals
   posix.signal(cint(signal), SIG_IGN)
+
   modifyKQueue(s, signal.uint, EVFILT_SIGNAL, EV_ADD, 0, 0,
                cast[pointer](fdi))
   inc(s.count)
   result = fdi
 
 proc registerProcess*[T](s: Selector[T], pid: int,
-                             data: T): int {.discardable.} =
+                         data: T): int {.discardable.} =
   var fdi = posix.socket(posix.AF_INET, posix.SOCK_STREAM,
                          posix.IPPROTO_TCP).int
   if fdi == -1:
-    raiseOsError(osLastError())
+    raiseIOSelectorsError(osLastError())
 
   s.checkFd(fdi)
   doAssert(s.fds[fdi].ident == 0)
 
   var kflags: cushort = EV_ONESHOT or EV_ADD
-  setKey(s, fdi, pid, {Event.Process, Event.Oneshot}, pid, data)
+  setKey(s, fdi, {Event.Process, Event.Oneshot}, pid, data)
+
   modifyKQueue(s, pid.uint, EVFILT_PROC, kflags, NOTE_EXIT, 0,
                cast[pointer](fdi))
   inc(s.count)
@@ -258,7 +263,8 @@ proc registerProcess*[T](s: Selector[T], pid: int,
 proc registerEvent*[T](s: Selector[T], ev: SelectEvent, data: T) =
   let fdi = ev.rfd.int
   doAssert(s.fds[fdi].ident == 0)
-  setKey(s, fdi, fdi, {Event.User}, 0, data)
+  setKey(s, fdi, {Event.User}, 0, data)
+
   modifyKQueue(s, fdi.uint, EVFILT_READ, EV_ADD, 0, 0, nil)
   inc(s.count)
 
@@ -281,8 +287,9 @@ template processVnodeEvents(events: set[Event]): cuint =
 
 proc registerVnode*[T](s: Selector[T], fd: cint, events: set[Event], data: T) =
   let fdi = fd.int
-  setKey(s, fdi, fdi, {Event.Vnode} + events, 0, data)
+  setKey(s, fdi, {Event.Vnode} + events, 0, data)
   var fflags = processVnodeEvents(events)
+
   modifyKQueue(s, fdi.uint, EVFILT_VNODE, EV_ADD or EV_CLEAR, fflags, 0, nil)
   inc(s.count)
 
@@ -301,9 +308,11 @@ proc unregister*[T](s: Selector[T], fd: int|SocketHandle) =
         modifyKQueue(s, fdi.uint, EVFILT_WRITE, EV_DELETE, 0, 0, nil)
         dec(s.count)
     elif Event.Timer in pkey.events:
-      discard posix.close(cint(pkey.key.fd))
-      modifyKQueue(s, fdi.uint, EVFILT_TIMER, EV_DELETE, 0, 0, nil)
-      dec(s.count)
+      if posix.close(cint(pkey.ident)) == -1:
+        raiseIOSelectorsError(osLastError())
+      if Event.Finished notin pkey.events:
+        modifyKQueue(s, fdi.uint, EVFILT_TIMER, EV_DELETE, 0, 0, nil)
+        dec(s.count)
     elif Event.Signal in pkey.events:
       var nmask, omask: Sigset
       var signal = cint(pkey.param)
@@ -312,21 +321,24 @@ proc unregister*[T](s: Selector[T], fd: int|SocketHandle) =
       discard sigaddset(nmask, signal)
       unblockSignals(nmask, omask)
       posix.signal(signal, SIG_DFL)
-      discard posix.close(cint(pkey.key.fd))
+      if posix.close(cint(pkey.ident)) == -1:
+        raiseIOSelectorsError(osLastError())
       modifyKQueue(s, fdi.uint, EVFILT_SIGNAL, EV_DELETE, 0, 0, nil)
       dec(s.count)
     elif Event.Process in pkey.events:
-      discard posix.close(cint(pkey.key.fd))
-      modifyKQueue(s, fdi.uint, EVFILT_PROC, EV_DELETE, 0, 0, nil)
-      dec(s.count)
+      if posix.close(cint(pkey.ident)) == -1:
+        raiseIOSelectorsError(osLastError())
+      if Event.Finished notin pkey.events:
+        modifyKQueue(s, fdi.uint, EVFILT_PROC, EV_DELETE, 0, 0, nil)
+        dec(s.count)
     elif Event.Vnode in pkey.events:
       modifyKQueue(s, fdi.uint, EVFILT_VNODE, EV_DELETE, 0, 0, nil)
       dec(s.count)
     elif Event.User in pkey.events:
       modifyKQueue(s, fdi.uint, EVFILT_READ, EV_DELETE, 0, 0, nil)
       dec(s.count)
-  pkey.ident = 0
-  pkey.events = {}
+
+  clearKey(pkey)
 
 proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   let fdi = int(ev.rfd)
@@ -334,26 +346,18 @@ proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   var pkey = addr(s.fds[fdi])
   doAssert(pkey.ident != 0)
   doAssert(Event.User in pkey.events)
-  pkey.ident = 0
-  pkey.events = {}
+
   modifyKQueue(s, fdi.uint, EVFILT_READ, EV_DELETE, 0, 0, nil)
+  clearKey(pkey)
   dec(s.count)
 
-proc flush*[T](s: Selector[T]) =
-  s.withChangeLock():
-    var tv = Timespec()
-    if kevent(s.kqFD, addr(s.changesTable[0]), cint(s.changesCount),
-              nil, 0, addr tv) == -1:
-      raiseOSError(osLastError())
-    s.changesCount = 0
-
 proc selectInto*[T](s: Selector[T], timeout: int,
-                    results: var openarray[ReadyKey[T]]): int =
+                    results: var openarray[ReadyKey]): int =
   var
     tv: Timespec
-    resTable: array[MAX_KQUEUE_RESULT_EVENTS, KEvent]
+    resTable: array[MAX_KQUEUE_EVENTS, KEvent]
     ptv = addr tv
-    maxres = MAX_KQUEUE_RESULT_EVENTS
+    maxres = MAX_KQUEUE_EVENTS
 
   if timeout != -1:
     if timeout >= 1000:
@@ -370,115 +374,139 @@ proc selectInto*[T](s: Selector[T], timeout: int,
 
   var count = 0
   s.withChangeLock():
-    count = kevent(s.kqFD, addr(s.changesTable[0]), cint(s.changesCount),
-                   addr(resTable[0]), cint(maxres), ptv)
-    s.changesCount = 0
+    let length = cint(len(s.changes))
+    if length > 0:
+      count = kevent(s.kqFD, addr(s.changes[0]), length,
+                     addr(resTable[0]), cint(maxres), ptv)
+      s.changes.setLen(0)
+    else:
+      count = kevent(s.kqFD, nil, cint(0), addr(resTable[0]), cint(maxres), ptv)
 
   if count < 0:
     result = 0
     let err = osLastError()
     if cint(err) != EINTR:
-      raiseOSError(err)
+      raiseIOSelectorsError(err)
   elif count == 0:
     result = 0
   else:
     var i = 0
-    var k = 0
     var pkey: ptr SelectorKey[T]
     while i < count:
       let kevent = addr(resTable[i])
-      if (kevent.flags and EV_ERROR) == 0:
-        case kevent.filter:
-        of EVFILT_READ:
-          pkey = addr(s.fds[kevent.ident.int])
-          pkey.key.events = {Event.Read}
-          if Event.User in pkey.events:
-            var data: uint64 = 0
-            if posix.read(kevent.ident.cint, addr data,
-                          sizeof(uint64)) != sizeof(uint64):
-              let err = osLastError()
-              if err == OSErrorCode(EAGAIN):
-                # someone already consumed event data
-                inc(i)
-                continue
-              else:
-                raiseOSError(osLastError())
-            pkey.key.events = {Event.User}
-        of EVFILT_WRITE:
-          pkey = addr(s.fds[kevent.ident.int])
-          pkey.key.events = {Event.Write}
-        of EVFILT_TIMER:
-          pkey = addr(s.fds[kevent.ident.int])
-          if Event.Oneshot in pkey.events:
-            if posix.close(cint(pkey.ident)) == -1:
-              raiseOSError(osLastError())
-            pkey.ident = 0
-            pkey.events = {}
-            dec(s.count)
-          pkey.key.events = {Event.Timer}
-        of EVFILT_VNODE:
-          pkey = addr(s.fds[kevent.ident.int])
-          pkey.key.events = {Event.Vnode}
-          if (kevent.fflags and NOTE_DELETE) != 0:
-            pkey.key.events.incl(Event.VnodeDelete)
-          if (kevent.fflags and NOTE_WRITE) != 0:
-            pkey.key.events.incl(Event.VnodeWrite)
-          if (kevent.fflags and NOTE_EXTEND) != 0:
-            pkey.key.events.incl(Event.VnodeExtend)
-          if (kevent.fflags and NOTE_ATTRIB) != 0:
-            pkey.key.events.incl(Event.VnodeAttrib)
-          if (kevent.fflags and NOTE_LINK) != 0:
-            pkey.key.events.incl(Event.VnodeLink)
-          if (kevent.fflags and NOTE_RENAME) != 0:
-            pkey.key.events.incl(Event.VnodeRename)
-          if (kevent.fflags and NOTE_REVOKE) != 0:
-            pkey.key.events.incl(Event.VnodeRevoke)
-        of EVFILT_SIGNAL:
-          pkey = addr(s.fds[cast[int](kevent.udata)])
-          pkey.key.events = {Event.Signal}
-        of EVFILT_PROC:
-          pkey = addr(s.fds[cast[int](kevent.udata)])
-          if posix.close(cint(pkey.ident)) == -1:
-            raiseOSError(osLastError())
-          pkey.ident = 0
-          pkey.events = {}
+      var rkey = ReadyKey(fd: int(kevent.ident), events: {})
+
+      if (kevent.flags and EV_ERROR) != 0:
+        rkey.events = {Event.Error}
+
+      case kevent.filter:
+      of EVFILT_READ:
+        pkey = addr(s.fds[int(kevent.ident)])
+        rkey.events.incl(Event.Read)
+        if Event.User in pkey.events:
+          var data: uint64 = 0
+          if posix.read(cint(kevent.ident), addr data,
+                        sizeof(uint64)) != sizeof(uint64):
+            let err = osLastError()
+            if err == OSErrorCode(EAGAIN):
+              # someone already consumed event data
+              inc(i)
+              continue
+            else:
+              raiseIOSelectorsError(err)
+          rkey.events = {Event.User}
+      of EVFILT_WRITE:
+        pkey = addr(s.fds[kevent.ident.int])
+        rkey.events.incl(Event.Write)
+        rkey.events = {Event.Write}
+      of EVFILT_TIMER:
+        pkey = addr(s.fds[kevent.ident.int])
+        if Event.Oneshot in pkey.events:
+          # we will not clear key until it will be unregistered, so
+          # application can obtain data, but we will decrease counter,
+          # because kqueue is empty.
           dec(s.count)
-          pkey.key.events = {Event.Process}
-        else:
-          raise newException(ValueError, "Unsupported kqueue filter in queue")
+          # we are marking key with `Finished` event, to avoid double decrease.
+          pkey.events.incl(Event.Finished)
+        rkey.events.incl(Event.Timer)
+      of EVFILT_VNODE:
+        pkey = addr(s.fds[kevent.ident.int])
+        rkey.events.incl(Event.Vnode)
+        if (kevent.fflags and NOTE_DELETE) != 0:
+          rkey.events.incl(Event.VnodeDelete)
+        if (kevent.fflags and NOTE_WRITE) != 0:
+          rkey.events.incl(Event.VnodeWrite)
+        if (kevent.fflags and NOTE_EXTEND) != 0:
+          rkey.events.incl(Event.VnodeExtend)
+        if (kevent.fflags and NOTE_ATTRIB) != 0:
+          rkey.events.incl(Event.VnodeAttrib)
+        if (kevent.fflags and NOTE_LINK) != 0:
+          rkey.events.incl(Event.VnodeLink)
+        if (kevent.fflags and NOTE_RENAME) != 0:
+          rkey.events.incl(Event.VnodeRename)
+        if (kevent.fflags and NOTE_REVOKE) != 0:
+          rkey.events.incl(Event.VnodeRevoke)
+      of EVFILT_SIGNAL:
+        pkey = addr(s.fds[cast[int](kevent.udata)])
+        rkey.fd = cast[int](kevent.udata)
+        rkey.events.incl(Event.Signal)
+      of EVFILT_PROC:
+        pkey = addr(s.fds[cast[int](kevent.udata)])
+        # we will not clear key, until it will be unregistered, so
+        # application can obtain data, but we will decrease counter,
+        # because kqueue is empty.
+        dec(s.count)
+        # we are marking key with `Finished` event, to avoid double decrease.
+        pkey.events.incl(Event.Finished)
+        rkey.events.incl(Event.Process)
+      else:
+        pkey = addr(s.fds[cast[int](kevent.udata)])
+        raiseIOSelectorsError("Unsupported kqueue filter in queue!")
 
-        if (kevent.flags and EV_EOF) != 0:
-          pkey.key.events.incl(Event.Error)
+      if (kevent.flags and EV_EOF) != 0:
+        rkey.events.incl(Event.Error)
 
-        results[k] = pkey.key
-        inc(k)
+      results[i] = rkey
       inc(i)
-    result = k
+    result = i
 
-proc select*[T](s: Selector[T], timeout: int): seq[ReadyKey[T]] =
-  result = newSeq[ReadyKey[T]](MAX_KQUEUE_RESULT_EVENTS)
+proc select*[T](s: Selector[T], timeout: int): seq[ReadyKey] =
+  result = newSeq[ReadyKey](MAX_KQUEUE_EVENTS)
   let count = selectInto(s, timeout, result)
   result.setLen(count)
 
 template isEmpty*[T](s: Selector[T]): bool =
   (s.count == 0)
 
-template withData*[T](s: Selector[T], fd: SocketHandle, value,
-                        body: untyped) =
+proc getData*[T](s: Selector[T], fd: SocketHandle|int): T =
+  let fdi = int(fd)
+  s.checkFd(fdi)
+  if s.fds[fdi].ident != 0:
+    result = s.fds[fdi].data
+
+proc setData*[T](s: Selector[T], fd: SocketHandle|int, data: T): bool =
+  let fdi = int(fd)
+  s.checkFd(fdi)
+  if s.fds[fdi].ident != 0:
+    s.fds[fdi].data = data
+    result = true
+
+template withData*[T](s: Selector[T], fd: SocketHandle|int, value,
+                      body: untyped) =
   mixin checkFd
   let fdi = int(fd)
   s.checkFd(fdi)
   if s.fds[fdi].ident != 0:
-    var value = addr(s.fds[fdi].key.data)
+    var value = addr(s.fds[fdi].data)
     body
 
-template withData*[T](s: Selector[T], fd: SocketHandle, value, body1,
-                        body2: untyped) =
+template withData*[T](s: Selector[T], fd: SocketHandle|int, value, body1,
+                      body2: untyped) =
   mixin checkFd
   let fdi = int(fd)
   s.checkFd(fdi)
   if s.fds[fdi].ident != 0:
-    var value = addr(s.fds[fdi].key.data)
+    var value = addr(s.fds[fdi].data)
     body1
   else:
     body2

--- a/tests/async/tioselectors.nim
+++ b/tests/async/tioselectors.nim
@@ -126,15 +126,15 @@ when not defined(windows):
     var selector = newSelector[int]()
     var event = newSelectEvent()
     selector.registerEvent(event, 1)
-    selector.flush()
+    var rc0 = selector.select(0)
     event.setEvent()
     var rc1 = selector.select(0)
     event.setEvent()
     var rc2 = selector.select(0)
     var rc3 = selector.select(0)
-    assert(len(rc1) == 1 and len(rc2) == 1 and len(rc3) == 0)
-    var ev1 = rc1[0].data
-    var ev2 = rc2[0].data
+    assert(len(rc0) == 0 and len(rc1) == 1 and len(rc2) == 1 and len(rc3) == 0)
+    var ev1 = selector.getData(rc1[0].fd)
+    var ev2 = selector.getData(rc2[0].fd)
     assert(ev1 == 1 and ev2 == 1)
     selector.unregister(event)
     event.close()
@@ -150,11 +150,11 @@ when not defined(windows):
       var rc2 = selector.select(140)
       assert(len(rc1) == 1 and len(rc2) == 1)
       selector.unregister(timer)
-      selector.flush()
+      discard selector.select(0)
       selector.registerTimer(100, true, 0)
-      var rc3 = selector.select(120)
       var rc4 = selector.select(120)
-      assert(len(rc3) == 1 and len(rc4) == 0)
+      var rc5 = selector.select(120)
+      assert(len(rc4) == 1 and len(rc5) == 0)
       assert(selector.isEmpty())
       selector.close()
       result = true
@@ -193,12 +193,15 @@ when not defined(windows):
       var s1 = selector.registerSignal(SIGUSR1, 1)
       var s2 = selector.registerSignal(SIGUSR2, 2)
       var s3 = selector.registerSignal(SIGTERM, 3)
-      selector.flush()
+      discard repr(selector.select(0))
 
       discard posix.kill(pid, SIGUSR1)
       discard posix.kill(pid, SIGUSR2)
       discard posix.kill(pid, SIGTERM)
       var rc = selector.select(0)
+      var cd0 = selector.getData(rc[0].fd)
+      var cd1 = selector.getData(rc[1].fd)
+      var cd2 = selector.getData(rc[2].fd)
       selector.unregister(s1)
       selector.unregister(s2)
       selector.unregister(s3)
@@ -211,7 +214,7 @@ when not defined(windows):
           raiseOSError(osLastError())
 
       assert(len(rc) == 3)
-      assert(rc[0].data + rc[1].data + rc[2].data == 6) # 1 + 2 + 3
+      assert(cd0 + cd1 + cd2 == 6, $(cd0 + cd1 + cd2)) # 1 + 2 + 3
       assert(equalMem(addr sigset1o, addr sigset2o, sizeof(Sigset)))
       assert(selector.isEmpty())
       result = true
@@ -286,8 +289,8 @@ when not defined(windows):
         events: set[Event]
 
     proc vnode_test(): bool =
-      proc validate[T](test: openarray[ReadyKey[T]],
-                       check: openarray[valType]): bool =
+      proc validate(test: openarray[ReadyKey],
+                    check: openarray[valType]): bool =
         result = false
         if len(test) == len(check):
           for checkItem in check:
@@ -300,7 +303,7 @@ when not defined(windows):
             if not result:
               break
 
-      var res: seq[ReadyKey[int]]
+      var res: seq[ReadyKey]
       var selector = newSelector[int]()
       var events = {Event.VnodeWrite, Event.VnodeDelete, Event.VnodeExtend,
                     Event.VnodeAttrib, Event.VnodeLink, Event.VnodeRename,
@@ -315,7 +318,7 @@ when not defined(windows):
         raiseOsError(osLastError())
 
       selector.registerVnode(dirfd, events, 1)
-      selector.flush()
+      discard selector.select(0)
 
       # chmod testDirectory to 0777
       chmodPath(testDirectory, 0x1FF)
@@ -337,7 +340,6 @@ when not defined(windows):
       # open test directory for watching
       var testfd = openWatch(testDirectory & "/test")
       selector.registerVnode(testfd, events, 2)
-      selector.flush()
       doAssert(len(selector.select(0)) == 0)
 
       # rename test directory
@@ -381,7 +383,7 @@ when not defined(windows):
 
       testfd = openWatch(testDirectory & "/testfile")
       selector.registerVnode(testfd, events, 1)
-      selector.flush()
+      discard selector.select(0)
 
       # write data to test file
       writeFile(testDirectory & "/testfile", "TESTDATA")
@@ -433,7 +435,6 @@ when not defined(windows):
     proc event_wait_thread(event: SelectEvent) {.thread.} =
       var selector = newSelector[int]()
       selector.registerEvent(event, 1)
-      selector.flush()
       var rc = selector.select(1000)
       if len(rc) == 1:
         inc(counter)
@@ -573,15 +574,15 @@ else:
     var selector = newSelector[int]()
     var event = newSelectEvent()
     selector.registerEvent(event, 1)
-    selector.flush()
+    discard selector.select(0)
     event.setEvent()
     var rc1 = selector.select(0)
     event.setEvent()
     var rc2 = selector.select(0)
     var rc3 = selector.select(0)
     assert(len(rc1) == 1 and len(rc2) == 1 and len(rc3) == 0)
-    var ev1 = rc1[0].data
-    var ev2 = rc2[0].data
+    var ev1 = selector.getData(rc1[0].fd)
+    var ev2 = selector.getData(rc2[0].fd)
     assert(ev1 == 1 and ev2 == 1)
     selector.unregister(event)
     event.close()
@@ -595,7 +596,6 @@ else:
     proc event_wait_thread(event: SelectEvent) {.thread.} =
       var selector = newSelector[int]()
       selector.registerEvent(event, 1)
-      selector.flush()
       var rc = selector.select(500)
       if len(rc) == 1:
         inc(counter)

--- a/tests/async/tupcoming_async.nim
+++ b/tests/async/tupcoming_async.nim
@@ -1,5 +1,4 @@
 discard """
-  cmd: "nim c -r -f $file"
   output: '''
 OK
 OK


### PR DESCRIPTION
Fix #5128.
Fix #5184.
Removed flush() procedure from ioselectors.nim.
Changed methods of work with application-driven data.
Changed all `discard` to proper error checks.
