### PR TITLE
Removed mangling of object fields for the js target only.

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -918,7 +918,10 @@ proc genFieldAddr(p: PProc, n: PNode, r: var TCompRes) =
   else:
     if b.sons[1].kind != nkSym: internalError(b.sons[1].info, "genFieldAddr")
     var f = b.sons[1].sym
-    if f.loc.r == nil: f.loc.r = mangleName(f, p.target)
+    if f.loc.r == nil and p.target == targetJS:
+      f.loc.r = rope(f.name.s)
+    elif f.loc.r == nil:
+      f.loc.r = mangleName(f, p.target)
     r.res = makeJSString($f.loc.r)
   internalAssert a.typ != etyBaseIndex
   r.address = a.res
@@ -934,10 +937,11 @@ proc genFieldAccess(p: PProc, n: PNode, r: var TCompRes) =
   else:
     if n.sons[1].kind != nkSym: internalError(n.sons[1].info, "genFieldAccess")
     var f = n.sons[1].sym
-    if f.loc.r == nil: f.loc.r = mangleName(f, p.target)
     if p.target == targetJS:
+      if f.loc.r == nil: f.loc.r = rope(f.name.s)
       r.res = "$1.$2" % [r.res, f.loc.r]
     else:
+      if f.loc.r == nil: f.loc.r = mangleName(f, p.target)
       if {sfImportc, sfExportc} * f.flags != {}:
         r.res = "$1->$2" % [r.res, f.loc.r]
       else:

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -918,10 +918,7 @@ proc genFieldAddr(p: PProc, n: PNode, r: var TCompRes) =
   else:
     if b.sons[1].kind != nkSym: internalError(b.sons[1].info, "genFieldAddr")
     var f = b.sons[1].sym
-    if f.loc.r == nil and p.target == targetJS:
-      f.loc.r = rope(f.name.s)
-    elif f.loc.r == nil:
-      f.loc.r = mangleName(f, p.target)
+    if f.loc.r == nil: f.loc.r = rope(f.name.s)
     r.res = makeJSString($f.loc.r)
   internalAssert a.typ != etyBaseIndex
   r.address = a.res
@@ -937,11 +934,10 @@ proc genFieldAccess(p: PProc, n: PNode, r: var TCompRes) =
   else:
     if n.sons[1].kind != nkSym: internalError(n.sons[1].info, "genFieldAccess")
     var f = n.sons[1].sym
+    if f.loc.r == nil: f.loc.r = rope(f.name.s)
     if p.target == targetJS:
-      if f.loc.r == nil: f.loc.r = rope(f.name.s)
       r.res = "$1.$2" % [r.res, f.loc.r]
     else:
-      if f.loc.r == nil: f.loc.r = mangleName(f, p.target)
       if {sfImportc, sfExportc} * f.flags != {}:
         r.res = "$1->$2" % [r.res, f.loc.r]
       else:

--- a/tests/js/tmangle.nim
+++ b/tests/js/tmangle.nim
@@ -2,6 +2,7 @@ discard """
   output: '''true
 true
 true
+true
 true'''
 """
 
@@ -39,6 +40,28 @@ block:
     var obj = T(a: 11, b: "foo")
     result = obj.a.addr[] == 11
     result = result and obj.b.addr[] == "foo".cstring
+  echo test()
+
+# Test reserved words:
+block:
+  type T = ref object
+    `if`: int
+    `for`: int
+    `==`: cstring
+    `&&`: cstring
+  proc test(): bool =
+    var
+      obj1 = T(`if`: 11, `for`: 22, `==`: "foo", `&&`: "bar")
+      obj2: T
+    new obj2 # Test behaviour for createRecordVarAux.
+    result = obj1.`if` == 11
+    result = result and obj1.addr[].`for` == 22
+    result = result and obj1.`==` == "foo".cstring
+    result = result and obj1.`&&`.addr[] == "bar".cstring
+    result = result and obj2.`if` == 0
+    result = result and obj2.`for` == 0
+    result = result and obj2.`==`.isNil()
+    result = result and obj2.`&&`.isNil()
   echo test()
 
 # Test importc / exportc fields:

--- a/tests/js/tmangle.nim
+++ b/tests/js/tmangle.nim
@@ -1,0 +1,60 @@
+discard """
+  output: '''true
+true
+true
+true'''
+"""
+
+# Test not mangled:
+block:
+  type T = object
+    a: int
+    b: cstring
+  proc test(): bool =
+    let obj = T(a: 11, b: "foo")
+    {. emit: [result, " = (", obj, ".a == 11);"] .}
+    {. emit: [result, " = ", result, " && (", obj, ".b == \"foo\");"] .}
+  echo test()
+
+# Test indirect (fields in genAddr):
+block:
+  type T = object
+    a: int
+    b: cstring
+  var global = T(a: 11, b: "foo")
+  proc test(): bool =
+    var obj = T(a: 11, b: "foo")
+    {. emit: [result, " = (", obj.addr[], "[0].a == 11);"] .}
+    {. emit: [result, " = ", result, " && (", obj.addr[], "[0].b == \"foo\");"] .}
+    {. emit: [result, " = ", result, " && (", global, "[0].a == 11);"] .}
+    {. emit: [result, " = ", result, " && (", global, "[0].b == \"foo\");"] .}
+  echo test()
+
+# Test addr of field:
+block:
+  type T = object
+    a: int
+    b: cstring
+  proc test(): bool =
+    var obj = T(a: 11, b: "foo")
+    result = obj.a.addr[] == 11
+    result = result and obj.b.addr[] == "foo".cstring
+  echo test()
+
+# Test importc / exportc fields:
+block:
+  type T = object
+    a: int
+    b {. importc: "notB" .}: cstring
+  type U = object
+    a: int
+    b {. exportc: "notB" .}: cstring
+  proc test(): bool =
+    var
+      obj1 = T(a: 11, b: "foo")
+      obj2 = U(a: 11, b: "foo")
+    {. emit: [result, " = (", obj1, ".a == 11);"] .}
+    {. emit: [result, " = ", result, " && (", obj1, ".notB == \"foo\");"] .}
+    {. emit: [result, " = (", obj2, ".a == 11);"] .}
+    {. emit: [result, " = ", result, " && (", obj2, ".notB == \"foo\");"] .}
+  echo test()


### PR DESCRIPTION
This implements the changes discussed in relation to pull request #5213, and removes the need to excessively annotate object fields with `exportc` when interfacing to JavaScript. 