### PR TITLE
Fixed Mersenne Twister

### DIFF
--- a/lib/pure/mersenne.nim
+++ b/lib/pure/mersenne.nim
@@ -36,8 +36,8 @@ proc getNum*(m: var MersenneTwister): uint32 =
   m.index = (m.index + 1) mod m.mt.len
 
   result = result xor (result shr 11'u32)
-  result = result xor ((7'u32 shl result) and 0x9d2c5680'u32)
-  result = result xor ((15'u32 shl result) and 0xefc60000'u32)
+  result = result xor ((result shl 7'u32) and 0x9d2c5680'u32)
+  result = result xor ((result shl 15'u32) and 0xefc60000'u32)
   result = result xor (result shr 18'u32)
 
 # Test


### PR DESCRIPTION
There is a bug in current implementation of Mersenne Twister algorithm - ``7'u32 shl result`` in line 39, where should be ``result shl 7'u32`` and the same thing in line 40.
This causes incorrect result and also leads to undefined behavior since ``result`` is too large to use it as second operand of ``shl``.