### PR TITLE
Import ospaths instead of include

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -849,12 +849,12 @@ template walkCommon(pattern: string, filter) =
     res = findFirstFile(pattern, f)
     if res != -1:
       defer: findClose(res)
+      let dotPos = searchExtPos(pattern)
       while true:
         if not skipFindData(f) and filter(f):
           # Windows bug/gotcha: 't*.nim' matches 'tfoo.nims' -.- so we check
           # that the file extensions have the same length ...
           let ff = getFilename(f)
-          let dotPos = searchExtPos(pattern)
           let idx = ff.len - pattern.len + dotPos
           if dotPos < 0 or idx >= ff.len or ff[idx] == '.' or
               pattern[dotPos+1] == '*':

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -26,7 +26,8 @@ elif defined(posix):
 else:
   {.error: "OS module not ported to your operating system!".}
 
-include ospaths
+import ospaths
+export ospaths
 
 when defined(posix):
   when NoFakeVars:
@@ -1109,7 +1110,7 @@ proc createDir*(dir: string) {.rtl, extern: "nos$1",
   ## fail if the directory already exists because for most usages this does not
   ## indicate an error.
   var omitNext = false
-  when doslike:
+  when doslikeFileSystem:
     omitNext = isAbsolute(dir)
   for i in 1.. dir.len-1:
     if dir[i] in {DirSep, AltSep}:

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -40,8 +40,7 @@ when not declared(getEnv) or defined(nimscript):
       TOSErrorCode: OSErrorCode
   ].}
   const
-    doslike = defined(windows) or defined(OS2) or defined(DOS)
-      # DOS-like filesystem
+    doslikeFileSystem* = defined(windows) or defined(OS2) or defined(DOS)
 
   when defined(Nimdoc): # only for proper documentation:
     const
@@ -120,7 +119,7 @@ when not declared(getEnv) or defined(nimscript):
     #  waterproof. In case of equal names the first volume found will do.
     #  Two colons "::" are the relative path to the parent. Three is to the
     #  grandparent etc.
-  elif doslike:
+  elif doslikeFileSystem:
     const
       CurDir* = '.'
       ParDir* = ".."
@@ -432,7 +431,7 @@ when not declared(getEnv) or defined(nimscript):
     ## Checks whether a given `path` is absolute.
     ##
     ## On Windows, network paths are considered absolute too.
-    when doslike:
+    when doslikeFileSystem:
       var len = len(path)
       result = (len > 0 and path[0] in {'/', '\\'}) or
                (len > 1 and path[0] in {'a'..'z', 'A'..'Z'} and path[1] == ':')
@@ -461,7 +460,7 @@ when not declared(getEnv) or defined(nimscript):
       var start: int
       if path[0] == '/':
         # an absolute path
-        when doslike:
+        when doslikeFileSystem:
           if drive != "":
             result = drive & ":" & DirSep
           else:

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -330,14 +330,16 @@ when not declared(getEnv) or defined(nimscript):
     if ext == "" or ext[0] == ExtSep: result = ext # no copy needed here
     else: result = ExtSep & ext
 
-  proc searchExtPos(s: string): int =
+  proc searchExtPos*(path: string): int =
+    ## Returns index of the '.' char in `path` if it signifies the beginning
+    ## of extension. Returns -1 otherwise.
     # BUGFIX: do not search until 0! .DS_Store is no file extension!
     result = -1
-    for i in countdown(len(s)-1, 1):
-      if s[i] == ExtSep:
+    for i in countdown(len(path)-1, 1):
+      if path[i] == ExtSep:
         result = i
         break
-      elif s[i] in {DirSep, AltSep}:
+      elif path[i] in {DirSep, AltSep}:
         break # do not skip over path
 
   proc splitFile*(path: string): tuple[dir, name, ext: string] {.


### PR DESCRIPTION
This fixes linker errors when `import ospaths` and `import os` end up in one project.