### PR TITLE
system/unicode: check for overflow when trying to parse unicode runes

### DIFF
--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -57,11 +57,13 @@ template fastRuneAt*(s: string, i: int, result: untyped, doInc = true) =
     result = Rune(ord(s[i]))
     when doInc: inc(i)
   elif ord(s[i]) shr 5 == 0b110:
+    if i + 1 > s.len - 1: raise newException(ValueError, "incomplete 2-byte unicode rune")
     # assert(ord(s[i+1]) shr 6 == 0b10)
     result = Rune((ord(s[i]) and (ones(5))) shl 6 or
                   (ord(s[i+1]) and ones(6)))
     when doInc: inc(i, 2)
   elif ord(s[i]) shr 4 == 0b1110:
+    if i + 2 > s.len - 1: raise newException(ValueError, "incomplete 3-byte unicode rune")
     # assert(ord(s[i+1]) shr 6 == 0b10)
     # assert(ord(s[i+2]) shr 6 == 0b10)
     result = Rune((ord(s[i]) and ones(4)) shl 12 or
@@ -69,6 +71,7 @@ template fastRuneAt*(s: string, i: int, result: untyped, doInc = true) =
              (ord(s[i+2]) and ones(6)))
     when doInc: inc(i, 3)
   elif ord(s[i]) shr 3 == 0b11110:
+    if i + 3 > s.len - 1: raise newException(ValueError, "incomplete 4-byte unicode rune")
     # assert(ord(s[i+1]) shr 6 == 0b10)
     # assert(ord(s[i+2]) shr 6 == 0b10)
     # assert(ord(s[i+3]) shr 6 == 0b10)
@@ -78,6 +81,7 @@ template fastRuneAt*(s: string, i: int, result: untyped, doInc = true) =
              (ord(s[i+3]) and ones(6)))
     when doInc: inc(i, 4)
   elif ord(s[i]) shr 2 == 0b111110:
+    if i + 4 > s.len - 1: raise newException(ValueError, "incomplete 5-byte unicode rune")
     # assert(ord(s[i+1]) shr 6 == 0b10)
     # assert(ord(s[i+2]) shr 6 == 0b10)
     # assert(ord(s[i+3]) shr 6 == 0b10)
@@ -89,6 +93,7 @@ template fastRuneAt*(s: string, i: int, result: untyped, doInc = true) =
              (ord(s[i+4]) and ones(6)))
     when doInc: inc(i, 5)
   elif ord(s[i]) shr 1 == 0b1111110:
+    if i + 5 > s.len - 1: raise newException(ValueError, "incomplete 6-byte unicode rune")
     # assert(ord(s[i+1]) shr 6 == 0b10)
     # assert(ord(s[i+2]) shr 6 == 0b10)
     # assert(ord(s[i+3]) shr 6 == 0b10)

--- a/lib/system/widestrs.nim
+++ b/lib/system/widestrs.nim
@@ -50,10 +50,12 @@ template fastRuneAt(s: cstring, i: int, result: expr, doInc = true) =
     result = ord(s[i])
     when doInc: inc(i)
   elif ord(s[i]) shr 5 == 0b110:
+    if i + 1 > s.len - 1: raise newException(ValueError, "incomplete 2-byte unicode rune")
     #assert(ord(s[i+1]) shr 6 == 0b10)
     result = (ord(s[i]) and (ones(5))) shl 6 or (ord(s[i+1]) and ones(6))
     when doInc: inc(i, 2)
   elif ord(s[i]) shr 4 == 0b1110:
+    if i + 2 > s.len - 1: raise newException(ValueError, "incomplete 3-byte unicode rune")
     #assert(ord(s[i+1]) shr 6 == 0b10)
     #assert(ord(s[i+2]) shr 6 == 0b10)
     result = (ord(s[i]) and ones(4)) shl 12 or
@@ -61,6 +63,7 @@ template fastRuneAt(s: cstring, i: int, result: expr, doInc = true) =
              (ord(s[i+2]) and ones(6))
     when doInc: inc(i, 3)
   elif ord(s[i]) shr 3 == 0b11110:
+    if i + 3 > s.len - 1: raise newException(ValueError, "incomplete 4-byte unicode rune")
     #assert(ord(s[i+1]) shr 6 == 0b10)
     #assert(ord(s[i+2]) shr 6 == 0b10)
     #assert(ord(s[i+3]) shr 6 == 0b10)


### PR DESCRIPTION
This commit adds a bunch of string bounds checks. They trigger in dev mode, but not in release; thus, using any unicode-handling functions would be unsuitable to validate user input and read potentially invalid memory into a rune.

Found this while fuzzing library that is using pegs to split a string.

Please review. :)