### PR TITLE
Fix compilation for 16 bit targets

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -67,7 +67,7 @@ type
       rawTypePtr: pointer
 
   ppointer = ptr pointer
-  pbyteArray = ptr array[0.. 0xffff, int8]
+  pbyteArray = ptr array[0xffff, int8]
 
   TGenericSeq {.importc.} = object
     len, space: int

--- a/lib/system/assign.nim
+++ b/lib/system/assign.nim
@@ -211,14 +211,14 @@ proc genericReset(dest: pointer, mt: PNimType) =
     zeroMem(dest, mt.size) # set raw bits to zero
 
 proc selectBranch(discVal, L: int,
-                  a: ptr array[0..0x7fff, ptr TNimNode]): ptr TNimNode =
+                  a: ptr array[0x7fff, ptr TNimNode]): ptr TNimNode =
   result = a[L] # a[L] contains the ``else`` part (but may be nil)
   if discVal <% L:
     var x = a[discVal]
     if x != nil: result = x
 
 proc FieldDiscriminantCheck(oldDiscVal, newDiscVal: int,
-                            a: ptr array[0..0x7fff, ptr TNimNode],
+                            a: ptr array[0x7fff, ptr TNimNode],
                             L: int) {.compilerProc.} =
   var oldBranch = selectBranch(oldDiscVal, L, a)
   var newBranch = selectBranch(newDiscVal, L, a)

--- a/lib/system/deepcopy.nim
+++ b/lib/system/deepcopy.nim
@@ -10,7 +10,7 @@
 type
   PtrTable = ptr object
     counter, max: int
-    data: array[0..0xff_ffff, (pointer, pointer)]
+    data: array[0xff_ffff, (pointer, pointer)]
 
 template hashPtr(key: pointer): int = cast[int](key) shr 8
 template allocPtrTable: untyped =

--- a/lib/system/hti.nim
+++ b/lib/system/hti.nim
@@ -70,7 +70,7 @@ type
     typ: ptr TNimType
     name: cstring
     len: int
-    sons: ptr array[0..0x7fff, ptr TNimNode]
+    sons: ptr array[0x7fff, ptr TNimNode]
 
   TNimTypeFlag = enum
     ntfNoRefs = 0,     # type contains no tyRef, tySequence, tyString

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -89,7 +89,7 @@ proc reprEnum(e: int, typ: PNimType): string {.compilerRtl.} =
   result = $e & " (invalid data!)"
 
 type
-  PByteArray = ptr array[0.. 0xffff, int8]
+  PByteArray = ptr array[0xffff, int8]
 
 proc addSetElem(result: var string, elem: int, typ: PNimType) {.benign.} =
   case typ.kind


### PR DESCRIPTION
Seems there are some upconverting issues when using ranges to denote
array capacity on 16 bit targets. This seems to get the majority of the
ones that embedded folks might hit (though there are many other examples
in the stdlib)