### PR TITLE
Fix: upcoming asyncdispatch memory leaks on exceptions.

### DIFF
--- a/lib/pure/ioselects/ioselectors_kqueue.nim
+++ b/lib/pure/ioselects/ioselectors_kqueue.nim
@@ -146,8 +146,8 @@ proc setEvent*(ev: SelectEvent) =
     raiseIOSelectorsError(osLastError())
 
 proc close*(ev: SelectEvent) =
-  let res1 = posix.close(rfd)
-  let res2 = posix.close(wfd)
+  let res1 = posix.close(ev.rfd)
+  let res2 = posix.close(ev.wfd)
   deallocShared(cast[pointer](ev))
   if res1 != 0 or res2 != 0:
     raiseIOSelectorsError(osLastError())


### PR DESCRIPTION
1. Fix memory leaks on exceptions in ioselectors.
2. Fix memory leaks on exceptions in upcoming/asyncdispatch.nim
3. Fix some error handlers to obtain more reliable error codes.
4. Fix for asyncdispatch to remove duplicate `osLastError()` calls.
5. Fix checks on return values for posix functions.