### PR TITLE
revert nim.cfg to version before b26e6e3

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -100,7 +100,7 @@ path="$lib/pure"
 @if windows:
   #gcc.path = r"$nim\dist\mingw\bin"
   @if gcc:
-    #tlsEmulation:on
+    tlsEmulation:on
   @end
 @end
 
@@ -110,13 +110,7 @@ path="$lib/pure"
   gcc.options.always = "-w"
   gcc.cpp.options.always = "-w -fpermissive"
 @else:
-  @if cpu32:
-    gcc.options.always = "-w -m32"
-    gcc.options.linker = "-m32"
-  @else:
-    gcc.options.always = "-w -m64"
-    gcc.options.linker = "-m64"
-  @end
+  gcc.options.always = "-w"
   gcc.cpp.options.always = "-w -fpermissive"
 @end
 


### PR DESCRIPTION
... to enable building of koch on Linux again