### PR TITLE
Fixes for upcoming asyncdispatch and ioselectors.

### DIFF
--- a/lib/pure/ioselects/ioselectors_poll.nim
+++ b/lib/pure/ioselects/ioselectors_poll.nim
@@ -115,9 +115,8 @@ template pollUpdate[T](s: Selector[T], sock: cint, events: set[Event]) =
         s.pollfds[i].events = pollev
         break
       inc(i)
-
-    if i == s.pollcnt:
-      raiseIOSelectorsError("Descriptor is not registered in queue")
+    doAssert(i < s.pollcnt,
+             "Descriptor [" & $sock & "] is not registered in the queue!")
 
 template pollRemove[T](s: Selector[T], sock: cint) =
   withPollLock(s):
@@ -140,7 +139,7 @@ template pollRemove[T](s: Selector[T], sock: cint) =
 
 template checkFd(s, f) =
   if f >= s.maxFD:
-    raiseIOSelectorsError("Descriptor is not registered in queue")
+    raiseIOSelectorsError("Maximum number of descriptors is exhausted!")
 
 proc registerHandle*[T](s: Selector[T], fd: SocketHandle,
                         events: set[Event], data: T) =
@@ -157,7 +156,8 @@ proc updateHandle*[T](s: Selector[T], fd: SocketHandle,
   let fdi = int(fd)
   s.checkFd(fdi)
   var pkey = addr(s.fds[fdi])
-  doAssert(pkey.ident != 0)
+  doAssert(pkey.ident != 0,
+           "Descriptor [" & $fdi & "] is not registered in the queue!")
   doAssert(pkey.events * maskEvents == {})
 
   if pkey.events != events:
@@ -172,7 +172,7 @@ proc updateHandle*[T](s: Selector[T], fd: SocketHandle,
 
 proc registerEvent*[T](s: Selector[T], ev: SelectEvent, data: T) =
   var fdi = int(ev.rfd)
-  doAssert(s.fds[fdi].ident == 0)
+  doAssert(s.fds[fdi].ident == 0, "Event is already registered in the queue!")
   var events = {Event.User}
   setKey(s, fdi, events, 0, data)
   events.incl(Event.Read)
@@ -182,7 +182,8 @@ proc unregister*[T](s: Selector[T], fd: int|SocketHandle) =
   let fdi = int(fd)
   s.checkFd(fdi)
   var pkey = addr(s.fds[fdi])
-  doAssert(pkey.ident != 0)
+  doAssert(pkey.ident != 0,
+           "Descriptor [" & $fdi & "] is not registered in the queue!")
   pkey.ident = 0
   pkey.events = {}
   s.pollRemove(fdi.cint)
@@ -191,7 +192,7 @@ proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   let fdi = int(ev.rfd)
   s.checkFd(fdi)
   var pkey = addr(s.fds[fdi])
-  doAssert(pkey.ident != 0)
+  doAssert(pkey.ident != 0, "Event is not registered in the queue!")
   doAssert(Event.User in pkey.events)
   pkey.ident = 0
   pkey.events = {}

--- a/tests/async/tupcoming_async.nim
+++ b/tests/async/tupcoming_async.nim
@@ -1,9 +1,6 @@
 discard """
   output: '''
 OK
-OK
-OK
-OK
 '''
 """
 
@@ -31,10 +28,38 @@ when defined(upcoming):
     var fut = waitEvent(event)
     asyncCheck(delayedSet(event, 500))
     waitFor(fut or sleepAsync(1000))
-    if fut.finished:
-      echo "OK"
-    else:
+    if not fut.finished:
       echo "eventTest: Timeout expired before event received!"
+
+  proc eventTest5304() =
+    # Event should not be signaled if it was uregistered,
+    # even in case, when poll() was not called yet.
+    # Issue #5304.
+    var unregistered = false
+    let e = newAsyncEvent()
+    addEvent(e) do (fd: AsyncFD) -> bool:
+      assert(not unregistered)
+    e.setEvent()
+    e.unregister()
+    unregistered = true
+    poll()
+
+  proc eventTest5298() =
+    # Event must raise `AssertionError` if event was unregistered twice.
+    # Issue #5298.
+    let e = newAsyncEvent()
+    var eventReceived = false
+    addEvent(e) do (fd: AsyncFD) -> bool:
+      eventReceived = true
+      return true
+    e.setEvent()
+    while not eventReceived:
+      poll()
+    try:
+      e.unregister()
+    except AssertionError:
+      discard
+    e.close()
 
   when ioselSupportedPlatform or defined(windows):
 
@@ -56,7 +81,6 @@ when defined(upcoming):
 
     proc timerTest() =
       waitFor(waitTimer(200))
-      echo "OK"
 
     proc processTest() =
       when defined(windows):
@@ -70,7 +94,7 @@ when defined(upcoming):
       var fut = waitProcess(process)
       waitFor(fut or waitTimer(2000))
       if fut.finished and process.peekExitCode() == 0:
-        echo "OK"
+        discard
       else:
         echo "processTest: Timeout expired before process exited!"
 
@@ -92,23 +116,28 @@ when defined(upcoming):
       var fut = waitSignal(posix.SIGINT)
       asyncCheck(delayedSignal(posix.SIGINT, 500))
       waitFor(fut or waitTimer(1000))
-      if fut.finished:
-        echo "OK"
-      else:
+      if not fut.finished:
         echo "signalTest: Timeout expired before signal received!"
 
   when ioselSupportedPlatform:
     timerTest()
     eventTest()
+    eventTest5304()
+    eventTest5298()
     processTest()
     signalTest()
+    echo "OK"
   elif defined(windows):
     timerTest()
     eventTest()
+    eventTest5304()
+    eventTest5298()
     processTest()
     echo "OK"
   else:
     eventTest()
-    echo "OK\nOK\nOK"
+    eventTest5304()
+    eventTest5298()
+    echo "OK"
 else:
-  echo "OK\nOK\nOK\nOK"
+  echo "OK"


### PR DESCRIPTION
Fix `ioselectors_kqueue.nim` leaking FD.
Fix `asyncdispatch` do not unregisters AsyncEvents properly in posix branch.
Fix `asyncdispatch` do not unregisters AsyncEvents properly in windows, when no poll() was called.
Fix unregistering AsyncEvent twice is now generates `AssertionError` on windows and posix systems.
Fix some asserts and exceptions messages.
Added tests for #5304, #5298.
