### PR TITLE
fixes compiler ignoring passC/passL args when setting --cc:compiler.

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -509,10 +509,10 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
     else: localError(info, errGuiConsoleOrLibExpectedButXFound, arg)
   of "passc", "t":
     expectArg(switch, arg, pass, info)
-    if pass in {passCmd2, passPP}: extccomp.addCompileOption(arg)
+    if pass in {passCmd2, passPP}: extccomp.addCompileOptionCmd(arg)
   of "passl", "l":
     expectArg(switch, arg, pass, info)
-    if pass in {passCmd2, passPP}: extccomp.addLinkOption(arg)
+    if pass in {passCmd2, passPP}: extccomp.addLinkOptionCmd(arg)
   of "cincludes":
     expectArg(switch, arg, pass, info)
     if pass in {passCmd2, passPP}: cIncludes.add arg.processPath(info)


### PR DESCRIPTION
This fixes issue https://github.com/nim-lang/Nim/issues/5307
This commit change the way passC/passL cmdline arg and setting in config
files are parsed.
They are added to a separate linkOptionsCmd/compileOptionsCmd and are
inserted when compile/linking command list are requested.