### PR TITLE
Added unimplemented exception

### DIFF
--- a/doc/exception_hierarchy_fragment.txt
+++ b/doc/exception_hierarchy_fragment.txt
@@ -15,6 +15,7 @@
   * `IndexError <system.html#IndexError>`_
   * `ObjectAssignmentError <system.html#ObjectAssignmentError>`_
   * `ObjectConversionError <system.html#ObjectConversionError>`_
+  * `UnimplementedError` <system.html#UnimplementedError>`_
   * `ValueError <system.html#ValueError>`_
     * `KeyError <system.html#KeyError>`_
   * `ReraiseError <system.html#ReraiseError>`_

--- a/doc/manual/procs.txt
+++ b/doc/manual/procs.txt
@@ -402,7 +402,7 @@ type as well.
 
   method eval(e: Expression): int {.base.} =
     # override this base method
-    quit "to override!"
+    newException(UnimplementedError, "Called unimplemented method")
 
   method eval(e: Literal): int = return e.x
 

--- a/doc/manual/procs.txt
+++ b/doc/manual/procs.txt
@@ -402,7 +402,7 @@ type as well.
 
   method eval(e: Expression): int {.base.} =
     # override this base method
-    newException(UnimplementedError, "Called unimplemented method")
+    raise newException(UnimplementedError, "Called unimplemented method")
 
   method eval(e: Literal): int = return e.x
 

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -295,7 +295,7 @@ Procedures always use static dispatch. For dynamic dispatch replace the
   # watch out: 'eval' relies on dynamic binding
   method eval(e: PExpr): int =
     # override this base method
-    quit "to override!"
+    newException(UnimplementedError, "Called unimplemented method")
 
   method eval(e: PLiteral): int = e.x
   method eval(e: PPlusExpr): int = eval(e.a) + eval(e.b)

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -295,7 +295,7 @@ Procedures always use static dispatch. For dynamic dispatch replace the
   # watch out: 'eval' relies on dynamic binding
   method eval(e: PExpr): int =
     # override this base method
-    newException(UnimplementedError, "Called unimplemented method")
+    raise newException(UnimplementedError, "Called unimplemented method")
 
   method eval(e: PLiteral): int = e.x
   method eval(e: PPlusExpr): int = eval(e.a) + eval(e.b)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -514,6 +514,10 @@ type
     ## You can use ``of`` operator to check if conversion will succeed.
     ##
     ## See the full `exception hierarchy`_.
+  UnimplementedError* = object of Exception ## \
+    ## Can be used in base methods or to mark unimplemented branches.
+    ##
+    ## See the full `exception hierarchy`_.
   FloatingPointError* = object of Exception ## \
     ## Base class for floating point exceptions.
     ##


### PR DESCRIPTION
Not sure if this is helpful, but every time I'm writing an abstract `{.base.}` I'm wondering if there isn't a nicer way to communicate that this method is not supposed to be called. I've been searching in the list of exceptions for something appropriate a few times already. So I though I might as well add something.