### PR TITLE
nimweb: Show output of failed external command

### DIFF
--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -9,7 +9,7 @@
 
 import
   os, strutils, times, parseopt, parsecfg, streams, strtabs, tables,
-  re, htmlgen, macros, md5, osproc, parsecsv, algorithm
+  re, htmlgen, macros, md5, osproc, parsecsv, algorithm, terminal
 
 from xmltree import escape
 
@@ -263,8 +263,15 @@ proc findNim(): string =
 
 proc exec(cmd: string) =
   echo(cmd)
-  let (_, exitCode) = osproc.execCmdEx(cmd)
-  if exitCode != 0: quit("external program failed")
+  let (outp, exitCode) = osproc.execCmdEx(cmd)
+  if exitCode != 0: 
+    let
+      hlineWidth = if isatty(stdout): terminalWidth() else: 80
+      hline = '='.repeat(hlineWidth)
+    echo hline
+    echo outp
+    echo hline
+    quit("external program failed")
 
 proc sexec(cmds: openarray[string]) =
   ## Serial queue wrapper around exec.

--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -9,7 +9,7 @@
 
 import
   os, strutils, times, parseopt, parsecfg, streams, strtabs, tables,
-  re, htmlgen, macros, md5, osproc, parsecsv, algorithm, terminal
+  re, htmlgen, macros, md5, osproc, parsecsv, algorithm
 
 from xmltree import escape
 
@@ -264,14 +264,7 @@ proc findNim(): string =
 proc exec(cmd: string) =
   echo(cmd)
   let (outp, exitCode) = osproc.execCmdEx(cmd)
-  if exitCode != 0: 
-    let
-      hlineWidth = if isatty(stdout): terminalWidth() else: 80
-      hline = '='.repeat(hlineWidth)
-    echo hline
-    echo outp
-    echo hline
-    quit("external program failed")
+  if exitCode != 0: quit outp
 
 proc sexec(cmds: openarray[string]) =
   ## Serial queue wrapper around exec.


### PR DESCRIPTION
If an external command fails, its output is now shown to facilitate debugging.