### PR TITLE
fix in using the linenoise function

### DIFF
--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -116,7 +116,9 @@ else:
                           tags: [ReadIOEffect, WriteIOEffect].} =
     var buffer = linenoise.readLine(prompt)
     if isNil(buffer):
-      raise newException(IOError, "Linenoise returned nil")
+      result = false
+      line.string.setLen(0)
+      return
     line = TaintedString($buffer)
     if line.string.len > 0:
       historyAdd(buffer)

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -116,9 +116,8 @@ else:
                           tags: [ReadIOEffect, WriteIOEffect].} =
     var buffer = linenoise.readLine(prompt)
     if isNil(buffer):
-      result = false
       line.string.setLen(0)
-      return
+      return false
     line = TaintedString($buffer)
     if line.string.len > 0:
       historyAdd(buffer)


### PR DESCRIPTION
according to the documentation here: https://github.com/antirez/linenoise
`linenoise` is supposed to return a `nil` and the end of the file. No reason to raise an exception, just return false.