### PR TITLE
Add ``tearDownForeignThreadGc`` function

### DIFF
--- a/doc/backends.txt
+++ b/doc/backends.txt
@@ -461,3 +461,11 @@ can then attach a GC to this thread via
 It is **not** safe to disable the garbage collector and enable it after the
 call from your background thread even if the code you are calling is short
 lived.
+
+Before the thread exits, you should tear down the thread's GC to prevent memory
+leaks by calling
+
+.. code-block:: nim
+
+  system.tearDownForeignThreadGc()
+

--- a/lib/system/gc_common.nim
+++ b/lib/system/gc_common.nim
@@ -144,6 +144,9 @@ when allowForeignThreadGc:
     ## This function is available only when ``--threads:on`` and ``--tlsEmulation:off``
     ## switches are used
     if not localGcInitialized:
+      if not gch.stackBottom.isNil:
+        # GC heap has already been initialized using ``initGC``
+        return
       localGcInitialized = true
       initAllocator()
       var stackTop {.volatile.}: pointer

--- a/tests/gc/foreign_thr.nim
+++ b/tests/gc/foreign_thr.nim
@@ -32,7 +32,7 @@ when defined(linux):
     doAssert pthread_create(addr tid, addr attrs, wrapper, f) == 0
     doAssert pthread_join(tid, nil) == 0
 
-else:
+elif defined(windows):
   import winlean
   type
     WinThreadProc = proc (x: pointer): int32 {.stdcall.}
@@ -59,6 +59,9 @@ else:
     var h = createThread(nil, ThreadStackSize.int32, wrapper.WinThreadProc, cast[pointer](f), 0, dummyThreadId)
     doAssert h != 0.Handle
     doAssert waitForSingleObject(h, -1'i32) == 0.DWORD
+
+else:
+  {.fatal: "Unknown system".}
 
 proc f {.thread.} =
   var msg = "Hello " & "from foreign thread"

--- a/tests/gc/foreign_thr.nim
+++ b/tests/gc/foreign_thr.nim
@@ -17,7 +17,7 @@ const
 
 type ThreadFunc = proc() {.thread.}
 
-when defined(linux):
+when defined(posix):
   import posix
 
   proc runInForeignThread(f: ThreadFunc) =

--- a/tests/gc/foreign_thr.nim
+++ b/tests/gc/foreign_thr.nim
@@ -1,0 +1,67 @@
+discard """
+  output: '''
+Hello from foreign thread
+Hello from foreign thread
+'''
+  cmd: "nim $target --hints:on --threads:on --tlsEmulation:off $options $file"
+"""
+# Copied from stdlib
+const
+  StackGuardSize = 4096
+  ThreadStackMask = 1024*256*sizeof(int)-1
+  ThreadStackSize = ThreadStackMask+1 - StackGuardSize
+
+when defined(linux):
+  import posix
+
+  proc runInForeignThread(f: proc() {.thread.}) =
+    proc wrapper(p: pointer): pointer {.noconv.} =
+      let thr = cast[proc() {.thread.}](p)
+      setupForeignThreadGc()
+      thr()
+      tearDownForeignThreadGc()
+      setupForeignThreadGc()
+      thr()
+      tearDownForeignThreadGc()
+      result = nil
+
+    var attrs {.noinit.}: PthreadAttr
+    doAssert pthread_attr_init(addr attrs) == 0
+    doAssert pthread_attr_setstacksize(addr attrs, ThreadStackSize) == 0
+    var tid: Pthread
+    doAssert pthread_create(addr tid, addr attrs, wrapper, f) == 0
+    doAssert pthread_join(tid, nil) == 0
+
+else:
+  import winlean
+  type
+    WinThreadProc = proc (x: pointer): int32 {.stdcall.}
+
+  proc createThread(lpThreadAttributes: pointer, dwStackSize: DWORD,
+                     lpStartAddress: WinThreadProc,
+                     lpParameter: pointer,
+                     dwCreationFlags: DWORD,
+                     lpThreadId: var DWORD): Handle {.
+    stdcall, dynlib: "kernel32", importc: "CreateThread".}
+
+  proc wrapper(p: pointer): int32 {.stdcall.} =
+    let thr = cast[proc() {.thread.}](p)
+    setupForeignThreadGc()
+    thr()
+    tearDownForeignThreadGc()
+    setupForeignThreadGc()
+    thr()
+    tearDownForeignThreadGc()
+    result = 0'i32
+
+  proc runInForeignThread(f: proc() {.thread.}) =
+    var dummyThreadId: DWORD
+    var h = createThread(nil, ThreadStackSize.int32, wrapper.WinThreadProc, cast[pointer](f), 0, dummyThreadId)
+    doAssert h != 0.Handle
+    doAssert waitForSingleObject(h, -1'i32) == 0.DWORD
+
+proc f {.thread.} =
+  var msg = "Hello " & "from foreign thread"
+  echo msg
+
+runInForeignThread(f)

--- a/tests/gc/foreign_thr.nim
+++ b/tests/gc/foreign_thr.nim
@@ -1,7 +1,9 @@
 discard """
   output: '''
-Hello from foreign thread
-Hello from foreign thread
+Hello from thread
+Hello from thread
+Hello from thread
+Hello from thread
 '''
   cmd: "nim $target --hints:on --threads:on --tlsEmulation:off $options $file"
 """

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -147,6 +147,7 @@ proc gcTests(r: var TResults, cat: Category, options: string) =
       testSpec r, makeTest("tests/gc" / filename, options &
                     " -d:release --gc:boehm", cat, actionRun)
 
+  testWithoutBoehm "foreign_thr"
   test "gcemscripten"
   test "growobjcrash"
   test "gcbench"


### PR DESCRIPTION
The problem is that if we initialized GC using ``setupForeignThreadGc``, we get memory leaks on thread's exit. This PR adds function that should be used to avoid this.