### PR TITLE
Fix conversion of the collection of chars to string

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2375,6 +2375,11 @@ proc collectionToString[T: set | seq](x: T, b, e: string): string =
     when compiles(value.isNil):
       if value.isNil: result.add "nil"
       else: result.add($value)
+    elif type(value) is char:
+      if ord(value) < 32:
+        result.add("\\" & $ord(value))
+      else:
+        result.add($value)
     else:
       result.add($value)
     firstElement = false


### PR DESCRIPTION
Fixes cases when char code < 32. For example, without this PR, the code:
```nim
var x: array[3, char]
echo @x
```

echoes
```
@[
```