### PR TITLE
added rotate in algorithm

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -425,7 +425,7 @@ proc rotated_internal[T](arg: openarray[T]; first, middle, last: int): seq[T] =
     result[i] = arg[i]
 
 proc rotateLeft*[T](arg: var openarray[T]; slice: Slice[int]; dist: int): int =
-  ## Performs a left rotation on a range of elements.
+  ## Performs a left rotation on a range of elements. If you want to rotate right, use a negative ``dist``.
   ## Specifically, ``rotate`` rotates the elements at ``slice`` by ``dist`` positions..
   ## The element at index ``slice.a + dist`` will be at index ``slice.a``.
   ## The element at index ``slice.b`` will be at ``slice.a + dist -1``.
@@ -438,28 +438,36 @@ proc rotateLeft*[T](arg: var openarray[T]; slice: Slice[int]; dist: int): int =
   ##   the indices of the element range that should be rotated.
   ##
   ## ``dist``
-  ##   the distance in amount of elements that the data should be rotated.
+  ##   the distance in amount of elements that the data should be rotated. Can be negative, can be any number.
   ##
   ## .. code-block:: nim
   ##     var list     = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   ##     list.rotateLeft(1 .. 8, 3)
   ##     echo @list  # @[0, 4, 5, 6, 7, 8, 1, 2, 3, 9, 10]
-  arg.rotate_internal(slice.a, slice.a+dist, slice.b + 1)
+  let sliceLen = slice.b + 1 - slice.a
+  let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
+  arg.rotate_internal(slice.a, slice.a+distLeft, slice.b + 1)
 
 proc rotateLeft*[T](arg: var openarray[T]; dist: int): int =
   ## default arguments for slice, so that this procedure operates on the entire
   ## ``arg``, and not just on a part of it.
-  arg.rotate_internal(0, dist, arg.len)
+  let arglen = arg.len
+  let distLeft = ((dist mod arglen) + arglen) mod arglen
+  arg.rotate_internal(0, distLeft, arglen)
 
 proc rotatedLeft*[T](arg: openarray[T]; slice: Slice[int], dist: int): seq[T] =
   ## same as ``rotateLeft``, just with the difference that it does
   ## not modify the argument. It creates a new ``seq`` instead
-  arg.rotated_internal(slice.a, slice.a+dist, slice.b+1)
+  let sliceLen = slice.b + 1 - slice.a
+  let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
+  arg.rotated_internal(slice.a, slice.a+distLeft, slice.b+1)
 
 proc rotatedLeft*[T](arg: openarray[T]; dist: int): seq[T] =
   ## same as ``rotateLeft``, just with the difference that it does
   ## not modify the argument. It creates a new ``seq`` instead
-  arg.rotated_internal(0, dist, arg.len)
+  let arglen = arg.len
+  let distLeft = ((dist mod arglen) + arglen) mod arglen
+  arg.rotated_internal(0, distLeft, arg.len)
 
 when isMainModule:
   var list     = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -470,11 +478,17 @@ when isMainModule:
   doAssert list  ==  expected
   doAssert list2 == @expected
 
-  var s0,s1,s2 = "xxxabcdefgxxx"
+  var s0,s1,s2,s3,s4,s5 = "xxxabcdefgxxx"
 
   doAssert s0.rotateLeft(3 ..< 10, 3) == 7
   doAssert s0 == "xxxdefgabcxxx"
   doAssert s1.rotateLeft(3 ..< 10, 2) == 8
   doAssert s1 == "xxxcdefgabxxx"
   doAssert s2.rotateLeft(3 ..< 10, 4) == 6
-  doassert s2 == "xxxefgabcdxxx"
+  doAssert s2 == "xxxefgabcdxxx"
+  doAssert s3.rotateLeft(3 ..< 10, -3) == 6
+  doAssert s3 == "xxxefgabcdxxx"
+  doAssert s4.rotateLeft(3 ..< 10, -10) == 6
+  doAssert s4 == "xxxefgabcdxxx"
+  doAssert s5.rotateLeft(3 ..< 10, 11) == 6
+  doAssert s5 == "xxxefgabcdxxx"

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -373,11 +373,12 @@ when isMainModule:
     assert arr1.reversed(i, high(arr1)) == arr1.reversed()[0 .. high(arr1) - i]
 
 
-proc rotate_internal[T](arg: var openarray[T]; first, middle, last: int): int =
+proc rotateInternal[T](arg: var openarray[T]; first, middle, last: int): int =
+  ## A port of std::rotate from c++. Ported from `this reference <http://www.cplusplus.com/reference/algorithm/rotate/>`_.
   result = first + last - middle
 
   if first == middle or middle == last:
-     return
+    return
 
   assert first < middle
   assert middle < last
@@ -411,7 +412,7 @@ proc rotate_internal[T](arg: var openarray[T]; first, middle, last: int): int =
     elif next == last:
       next = mMiddle
 
-proc rotated_internal[T](arg: openarray[T]; first, middle, last: int): seq[T] =
+proc rotatedInternal[T](arg: openarray[T]; first, middle, last: int): seq[T] =
   result = newSeq[T](arg.len)
   for i in 0 ..< first:
     result[i] = arg[i]
@@ -426,12 +427,13 @@ proc rotated_internal[T](arg: openarray[T]; first, middle, last: int): seq[T] =
 
 proc rotateLeft*[T](arg: var openarray[T]; slice: Slice[int]; dist: int): int =
   ## Performs a left rotation on a range of elements. If you want to rotate right, use a negative ``dist``.
-  ## Specifically, ``rotate`` rotates the elements at ``slice`` by ``dist`` positions..
+  ## Specifically, ``rotateLeft`` rotates the elements at ``slice`` by ``dist`` positions.
   ## The element at index ``slice.a + dist`` will be at index ``slice.a``.
   ## The element at index ``slice.b`` will be at ``slice.a + dist -1``.
   ## The element at index ``slice.a`` will be at ``slice.b + 1 - dist``.
   ## The element at index ``slice.a + dist - 1`` will be at ``slice.b``.
-  ## Elements outsize of ``slice`` well be left unchanged.
+  #
+  ## Elements outsize of ``slice`` will be left unchanged.
   ## The time complexity is linear to ``slice.b - slice.a + 1``.
   ##
   ## ``slice``
@@ -446,28 +448,28 @@ proc rotateLeft*[T](arg: var openarray[T]; slice: Slice[int]; dist: int): int =
   ##     echo @list  # @[0, 4, 5, 6, 7, 8, 1, 2, 3, 9, 10]
   let sliceLen = slice.b + 1 - slice.a
   let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
-  arg.rotate_internal(slice.a, slice.a+distLeft, slice.b + 1)
+  arg.rotateInternal(slice.a, slice.a+distLeft, slice.b + 1)
 
 proc rotateLeft*[T](arg: var openarray[T]; dist: int): int =
   ## default arguments for slice, so that this procedure operates on the entire
   ## ``arg``, and not just on a part of it.
   let arglen = arg.len
   let distLeft = ((dist mod arglen) + arglen) mod arglen
-  arg.rotate_internal(0, distLeft, arglen)
+  arg.rotateInternal(0, distLeft, arglen)
 
 proc rotatedLeft*[T](arg: openarray[T]; slice: Slice[int], dist: int): seq[T] =
   ## same as ``rotateLeft``, just with the difference that it does
   ## not modify the argument. It creates a new ``seq`` instead
   let sliceLen = slice.b + 1 - slice.a
   let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
-  arg.rotated_internal(slice.a, slice.a+distLeft, slice.b+1)
+  arg.rotatedInternal(slice.a, slice.a+distLeft, slice.b+1)
 
 proc rotatedLeft*[T](arg: openarray[T]; dist: int): seq[T] =
   ## same as ``rotateLeft``, just with the difference that it does
   ## not modify the argument. It creates a new ``seq`` instead
   let arglen = arg.len
   let distLeft = ((dist mod arglen) + arglen) mod arglen
-  arg.rotated_internal(0, distLeft, arg.len)
+  arg.rotatedInternal(0, distLeft, arg.len)
 
 when isMainModule:
   var list     = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -445,7 +445,7 @@ proc rotateLeft*[T](arg: var openarray[T]; slice: Slice[int]; dist: int): int =
   ## .. code-block:: nim
   ##     var list     = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   ##     list.rotateLeft(1 .. 8, 3)
-  ##     echo @list  # @[0, 4, 5, 6, 7, 8, 1, 2, 3, 9, 10]
+  ##     doAssert list == [0, 4, 5, 6, 7, 8, 1, 2, 3, 9, 10]
   let sliceLen = slice.b + 1 - slice.a
   let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
   arg.rotateInternal(slice.a, slice.a+distLeft, slice.b + 1)

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -343,7 +343,7 @@ proc prevPermutation*[T](x: var openarray[T]): bool {.discardable.} =
   swap x[i-1], x[j]
 
   result = true
-  
+
 when isMainModule:
   # Tests for lowerBound
   var arr = @[1,2,3,5,6,7,8,9]
@@ -373,12 +373,14 @@ when isMainModule:
     assert arr1.reversed(i, high(arr1)) == arr1.reversed()[0 .. high(arr1) - i]
 
 
-proc rotate*[T](arg: var openarray[T]; first, middle, last: int): int {.discardable.} =
+proc rotate*[T](arg: var openarray[T]; first, middle, last: int): int =
   ## Performs a left rotation on a range of elements.
   ## Specifically, ``rotate`` swaps the elements in the range [first, last) in such a way
   ## that the element at index ``middle`` becomes the first element of the sub range and
   ## ``middle - 1`` becomes the last element of the sub range. The time complexity is
   ## linear to ``last - first``. returns ``first + (last - middle)``. ``T`` must support swap operation
+  ## returs ``first + last - middle``, the new index, where the element this was at index ``last`` will
+  ## be ater the rotation.
   ##
   ## ``first``
   ##   the index of the first element that should be rotated.
@@ -388,7 +390,7 @@ proc rotate*[T](arg: var openarray[T]; first, middle, last: int): int {.discarda
   ##
   ## ``last``
   ##   the index of the first element that should not be rotated anymore (exclusive upper bound).
-  ## 
+  ##
   ## .. code-block:: nim
   ##     var list     = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   ##     list.rotate(1,4,9)
@@ -431,15 +433,15 @@ proc rotate*[T](arg: var openarray[T]; first, middle, last: int): int {.discarda
     elif next == last:
       next = mMiddle
 
-proc rotate[T](arg: var openarray[T]; middle: int): int {.discardable.} =
-  ## default arguments for first and last, so that this procedure operates on the entire
-  ## argument, and not just on a portion of it.
+proc rotate*[T](arg: var openarray[T]; middle: int): int =
+  ## default arguments for first and last, so that this procedure operates on entire
+  ## ``arg``, and not just on a part of it.
   arg.rotate(0, middle, arg.len)
 
 proc rotated*[T](arg: openarray[T]; first, middle, last: int): seq[T] =
   ## same as ``rotate``, just with the difference that it does
-  ## not modify the argument, but writes into a new ``seq`` instead
-  
+  ## not modify the argument. It creates a new ``seq`` instead
+
   result = newSeq[T](arg.len)
 
   for i in 0 ..< first:
@@ -459,14 +461,15 @@ proc rotated*[T](arg: openarray[T]; first, middle, last: int): seq[T] =
 
 proc rotated*[T](arg: openarray[T]; middle: int): seq[T] =
   ## same as ``rotate``, just with the difference that it does
-  ## not modify the argument, but writes into a new ``seq`` instead
+  ## not modify the argument. It creates a new ``seq`` instead
+
   arg.rotated(0, middle, arg.len)
-  
+
 when isMainModule:
   var list     = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   let list2    = list.rotated(1,4,9)
   let expected = [0, 4, 5, 6, 7, 8, 1, 2, 3, 9, 10]
-  
+
   doAssert list.rotate(1,4,9) == 6
   doAssert list  ==  expected
   doAssert list2 == @expected
@@ -479,5 +482,3 @@ when isMainModule:
   doAssert s1 == "xxxcdefgabxxx"
   doAssert s2.rotate(3, 7, 10) == 6
   doassert s2 == "xxxefgabcdxxx"
-
-    


### PR DESCRIPTION
This is a reimplementation of `std::rotate` from c++. It should make c++ developers feel more at home. It is just a port of the reference implementation shown in the c++ docs here: http://www.cplusplus.com/reference/algorithm/rotate/

The reason I implemented this, was that I thought several times a rotate function would be the thing to solve the current problem, but I couldn't find it in algorithm.

I am not 100% happy with the API yet. It does copy the c++ api, but with indices instead of iterators. The problem is that the API has exclusive upper bounds, and that is not in sync with the rest of the nim API.

The only solution that I can think of, is to change the arguments to `first`, `last`, `offset`. But then I would also rather call it rotateLeft, so that the offset cannot be misinterpreted. But I would like to hear if you would even want a rotate in the algorithm library.
