### PR TITLE
Fix reverse on empty openArray

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -46,7 +46,7 @@ proc reverse*[T](a: var openArray[T], first, last: Natural) =
 
 proc reverse*[T](a: var openArray[T]) =
   ## reverses the array `a`.
-  reverse(a, 0, a.high)
+  reverse(a, 0, max(0, a.high))
 
 proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
   ## returns the reverse of the array `a[first..last]`.


### PR DESCRIPTION
Reversing an empty `openArray` would raise a RangeError. For instance for `a: seq[int] = @[]`, we have `a.high` return `-1` but `-1` is not a `Natural`. Leaving the array as-is is the expected behaviour. Another way to go about it: 

```
proc reverse*[T](a: var openArray[T]) =
  ## reverses the array `a`.
  if a.len > 0: reverse(a, 0, a.high) else: discard
```