### PR TITLE
Bugfix/double newlines in stderr

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2743,6 +2743,7 @@ when not defined(JS): #and not defined(nimscript):
       # we use binary mode on Windows:
       c_setmode(c_fileno(stdin), O_BINARY)
       c_setmode(c_fileno(stdout), O_BINARY)
+      c_setmode(c_fileno(stderr), O_BINARY)
 
     when defined(endb):
       proc endbStep()

--- a/tests/osproc/ta.nim
+++ b/tests/osproc/ta.nim
@@ -1,3 +1,0 @@
-import strutils
-let x = stdin.readLine()
-echo x.parseInt + 5

--- a/tests/osproc/ta_in.nim
+++ b/tests/osproc/ta_in.nim
@@ -1,0 +1,5 @@
+# This file is prefixed with an "a", because other tests
+# depend on it and it must be compiled first.
+import strutils
+let x = stdin.readLine()
+echo x.parseInt + 5

--- a/tests/osproc/ta_out.nim
+++ b/tests/osproc/ta_out.nim
@@ -1,3 +1,5 @@
+# This file is prefixed with an "a", because other tests
+# depend on it and it must be compiled first.
 stdout.writeLine("to stdout")
 stdout.flushFile()
 stdout.writeLine("to stdout")

--- a/tests/osproc/tb.nim
+++ b/tests/osproc/tb.nim
@@ -1,0 +1,14 @@
+stdout.writeLine("to stdout")
+stdout.flushFile()
+stdout.writeLine("to stdout")
+stdout.flushFile()
+
+stderr.writeLine("to stderr")
+stderr.flushFile()
+stderr.writeLine("to stderr")
+stderr.flushFile()
+
+stdout.writeLine("to stdout")
+stdout.flushFile()
+stdout.writeLine("to stdout")
+stdout.flushFile()

--- a/tests/osproc/tstdin.nim
+++ b/tests/osproc/tstdin.nim
@@ -4,7 +4,7 @@ discard """
 """
 import osproc, os, streams
 
-const filename = when defined(Windows): "ta.exe" else: "ta"
+const filename = when defined(Windows): "ta_in.exe" else: "ta_in"
 
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 

--- a/tests/osproc/tstdout.nim
+++ b/tests/osproc/tstdout.nim
@@ -16,7 +16,7 @@ const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 
 var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
-                     options={poStdErrToStdOut, poUsePath})
+                     options={poStdErrToStdOut})
 
 let outputStream = p.outputStream
 var x = newStringOfCap(120)

--- a/tests/osproc/tstdout.nim
+++ b/tests/osproc/tstdout.nim
@@ -1,0 +1,29 @@
+discard """
+  output: '''--------------------------------------
+to stdout
+to stdout
+to stderr
+to stderr
+to stdout
+to stdout
+--------------------------------------
+'''
+"""
+import osproc, os, streams
+
+const filename = when defined(Windows): "tb.exe" else: "tb"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     options={poStdErrToStdOut, poUsePath})
+
+let outputStream = p.outputStream
+var x = newStringOfCap(120)
+var output = ""
+while outputStream.readLine(x.TaintedString):
+  output.add(x & "\n")
+
+echo "--------------------------------------"
+stdout.write output
+echo "--------------------------------------"

--- a/tests/osproc/tstdout.nim
+++ b/tests/osproc/tstdout.nim
@@ -11,7 +11,7 @@ to stdout
 """
 import osproc, os, streams
 
-const filename = when defined(Windows): "tb.exe" else: "tb"
+const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
 
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 


### PR DESCRIPTION
This should fix #5425.

The problem is the Windows default behavior, which replaces a `\l` implicitly by `\c\l`. Since Nims writes a `\c\l` explicitly, the output becomes `\c\c\l`. This in turn causes `readLine` to break the line on the first `\c`, discarding the following `\c`, but adding another line break for the `\l`.

Problem should be simply solved like for stdin/stdoutt, by setting the mode to binary. Blocks #5410.