### PR TITLE
Fix sigsegv in getTypeImpl for unnamed tuple

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -221,7 +221,7 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
       # only named tuples have a node, unnamed tuples don't
       if t.n.isNil:
         for subType in t.sons:
-          result.add newIdentDefs(ast.emptyNode, subType)
+          result.add mapTypeToAst(subType, info)
       else:
         for s in t.n.sons:
           result.add newIdentDefs(s)

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -218,8 +218,13 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
   of tyTuple:
     if inst:
       result = newNodeX(nkTupleTy)
-      for s in t.n.sons:
-        result.add newIdentDefs(s)
+      # only named tuples have a node, unnamed tuples don't
+      if t.n.isNil:
+        for subType in t.sons:
+          result.add newIdentDefs(ast.emptyNode, subType)
+      else:
+        for s in t.n.sons:
+          result.add newIdentDefs(s)
     else:
       result = mapTypeToBracket("tuple", mTuple, t, info)
   of tySet: result = mapTypeToBracket("set", mSet, t, info)

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -120,3 +120,7 @@ test(Tree):
     right: ref Tree
 test(proc (a: int, b: Foo[2,float]))
 test(proc (a: int, b: Foo[2,float]): Bar[3,int])
+
+# bug #4862
+static:
+  discard typedesc[(int, int)].getTypeImpl


### PR DESCRIPTION
This should solve #4862. The cause of the issue is that the node pointer of an unnamed tuple is `nil`, so `t.n.sons` results in a sigsegv.

Things to consider:

- Is this actually the right place to handle the issue, or should `t.n` in fact be non-nil for a unnamed tuple? Since it does not make much sense for an unnamed tuple to refer to node, I assume the node has to be nil.
- Design question: How should the type AST look like for an unnamed tuple anyway? 
  - Should it be just a pure list of types? Drawback: Client code would have to handle named and unnamed tuple ASTs quite differently.
  - Or should it use `IdentDefs` and follow the convention from `instFieldBodyLoop` in `semfields.nim`, which would name the fields `Field0`, `Field1`, .... Drawback: Client code may want to find out if a tuple was a named or unnamed tuple, and automatically generated field names could make this tricky (and may be confusing).

I decided for a solution which uses `IdentDefs` (to make handling named/unnamed tuple identical), but leaves the field name empty (to properly represent unnamed tuples). For example:

```nimrod
import macros

macro usesGetTypeImpl*(t: typed): untyped =
  var tTypeImpl = t.getTypeImpl
  echo tTypeImpl.treeRepr
  result = quote do: discard

usesGetTypeImpl((0, 0.0, ""))
```

Output:

```
TupleTy
  IdentDefs
    Empty
    Sym "int"
    Empty
  IdentDefs
    Empty
    Sym "float64"
    Empty
  IdentDefs
    Empty
    Sym "string"
    Empty
```
