### PR TITLE
Add gethostname to nativesockets

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -542,6 +542,9 @@ proc gethostbyaddr*(ip: ptr InAddr, len: cuint, theType: cint): ptr Hostent {.
 proc gethostbyname*(name: cstring): ptr Hostent {.
   stdcall, importc: "gethostbyname", dynlib: ws2dll.}
 
+proc gethostname*(hostname: cstring, len: cint): cint {.
+  stdcall, importc: "gethostname", dynlib: ws2dll.}
+
 proc socket*(af, typ, protocol: cint): SocketHandle {.
   stdcall, importc: "socket", dynlib: ws2dll.}
 

--- a/tests/stdlib/tnativesockets.nim
+++ b/tests/stdlib/tnativesockets.nim
@@ -1,0 +1,8 @@
+import nativesockets, unittest
+
+suite "nativesockets":
+  test "getHostname":
+    let hostname = getHostname()
+    check hostname.len > 0
+    check hostname.len < 64
+


### PR DESCRIPTION
Support Posix and Windows.
Add a simple functional test.
The hostname length is documented at:
https://tools.ietf.org/html/rfc1035#section-2.3.1
https://tools.ietf.org/html/rfc2181#section-11
https://en.wikipedia.org/wiki/Hostname
https://technet.microsoft.com/en-us/library/cc959336.aspx