### PR TITLE
Fix async timers execution.

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -169,14 +169,10 @@ type
 proc processTimers(p: PDispatcherBase) {.inline.} =
   #Process just part if timers at a step
   var count = p.timers.len
-  var i = 0
-  let curTime = epochTime()
-  while i < count:
-    if curTime >= p.timers[i].finishAt:
-      p.timers[i].fut.complete()
-      p.timers.delete(i)
-      count.dec()
-    i.inc()
+  let t = epochTime()
+  while count > 0 and t >= p.timers[0].finishAt:
+    p.timers.pop().fut.complete()
+    dec count
 
 proc processPendingCallbacks(p: PDispatcherBase) =
   while p.callbacks.len > 0:

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -167,8 +167,13 @@ type
     callbacks: Deque[proc ()]
 
 proc processTimers(p: PDispatcherBase) {.inline.} =
+  #Process just part if timers at a step
+  var part = newSeq[tuple[finishAt: float, fut: Future[void]]]()
   while p.timers.len > 0 and epochTime() >= p.timers[0].finishAt:
-    p.timers.pop().fut.complete()
+    part.add(p.timers.pop())
+
+  for t in part:
+    t.fut.complete()
 
 proc processPendingCallbacks(p: PDispatcherBase) =
   while p.callbacks.len > 0:

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -168,12 +168,15 @@ type
 
 proc processTimers(p: PDispatcherBase) {.inline.} =
   #Process just part if timers at a step
-  var part = newSeq[tuple[finishAt: float, fut: Future[void]]]()
-  while p.timers.len > 0 and epochTime() >= p.timers[0].finishAt:
-    part.add(p.timers.pop())
-
-  for t in part:
-    t.fut.complete()
+  var count = p.timers.len
+  var i = 0
+  let curTime = epochTime()
+  while i < count:
+    if curTime >= p.timers[i].finishAt:
+      p.timers[i].fut.complete()
+      p.timers.del(i)
+      count.dec()
+    i.inc()
 
 proc processPendingCallbacks(p: PDispatcherBase) =
   while p.callbacks.len > 0:

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -174,7 +174,7 @@ proc processTimers(p: PDispatcherBase) {.inline.} =
   while i < count:
     if curTime >= p.timers[i].finishAt:
       p.timers[i].fut.complete()
-      p.timers.del(i)
+      p.timers.delete(i)
       count.dec()
     i.inc()
 

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -145,7 +145,7 @@ proc processTimers(p: PDispatcherBase) {.inline.} =
   while i < count:
     if curTime >= p.timers[i].finishAt:
       p.timers[i].fut.complete()
-      p.timers.del(i)
+      p.timers.delete(i)
       count.dec()
     i.inc()
 

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -139,12 +139,15 @@ type
 
 proc processTimers(p: PDispatcherBase) {.inline.} =
   #Process just part if timers at a step
-  var part = newSeq[tuple[finishAt: float, fut: Future[void]]]()
-  while p.timers.len > 0 and epochTime() >= p.timers[0].finishAt:
-    part.add(p.timers.pop())
-
-  for t in part:
-    t.fut.complete()
+  var count = p.timers.len
+  var i = 0
+  let curTime = epochTime()
+  while i < count:
+    if curTime >= p.timers[i].finishAt:
+      p.timers[i].fut.complete()
+      p.timers.del(i)
+      count.dec()
+    i.inc()
 
 proc processPendingCallbacks(p: PDispatcherBase) =
   while p.callbacks.len > 0:

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -140,14 +140,10 @@ type
 proc processTimers(p: PDispatcherBase) {.inline.} =
   #Process just part if timers at a step
   var count = p.timers.len
-  var i = 0
-  let curTime = epochTime()
-  while i < count:
-    if curTime >= p.timers[i].finishAt:
-      p.timers[i].fut.complete()
-      p.timers.delete(i)
-      count.dec()
-    i.inc()
+  let t = epochTime()
+  while count > 0 and t >= p.timers[0].finishAt:
+    p.timers.pop().fut.complete()
+    dec count
 
 proc processPendingCallbacks(p: PDispatcherBase) =
   while p.callbacks.len > 0:

--- a/lib/upcoming/asyncdispatch.nim
+++ b/lib/upcoming/asyncdispatch.nim
@@ -138,8 +138,13 @@ type
     callbacks: Deque[proc ()]
 
 proc processTimers(p: PDispatcherBase) {.inline.} =
+  #Process just part if timers at a step
+  var part = newSeq[tuple[finishAt: float, fut: Future[void]]]()
   while p.timers.len > 0 and epochTime() >= p.timers[0].finishAt:
-    p.timers.pop().fut.complete()
+    part.add(p.timers.pop())
+
+  for t in part:
+    t.fut.complete()
 
 proc processPendingCallbacks(p: PDispatcherBase) =
   while p.callbacks.len > 0:


### PR DESCRIPTION
Execute just part of timers at a time. To prevent infinite loops.

just do to make this happen.
while true:
  //check something, should happen from different async.
  //Not use await since need to perform some complex logic.
  await sleepAsync(0) # Allow to next async to be executed.
