### PR TITLE
fixes #5444 - nre.findIter keeps searching when no match is possible

### DIFF
--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -526,7 +526,6 @@ iterator findIter*(str: string, pattern: Regex, start = 0, endpos = int.high): R
        match.get.matchBounds.a > match.get.matchBounds.b:
       # 0-len match
       flags = pcre.NOTEMPTY_ATSTART
-          
     match = str.matchImpl(pattern, offset, endpos, flags)
     
     if match.isNone:

--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -527,7 +527,7 @@ iterator findIter*(str: string, pattern: Regex, start = 0, endpos = int.high): R
       # 0-len match
       flags = pcre.NOTEMPTY_ATSTART
     match = str.matchImpl(pattern, offset, endpos, flags)
-    
+
     if match.isNone:
       # either the end of the input or the string
       # cannot be split here - we also need to bail

--- a/tests/stdlib/nre/find.nim
+++ b/tests/stdlib/nre/find.nim
@@ -31,7 +31,7 @@ suite "find":
     ## we expect nothing to be found and we should be bailing out early which means that
     ## the timing difference between searching in small and large data should be well
     ## within a tolerance area
-    const tolerance = 0.00001
+    const tolerance = 0.0001
     var smallData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\"", 10)
     var largeData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\"", 1000000)
     var start = cpuTime()


### PR DESCRIPTION
nre.findIter keeps on searching when it's never matched until it reaches the end of the input. The function keeps incrementing the offset by one and searches again until len of input is reached. The function should bail early when never matched instead of searching for the next match boundary. 