### PR TITLE
Fix waiting on coroutines

### DIFF
--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -114,9 +114,9 @@ when defined(unix):
   {.passC: "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"}
 
 const
-  CORO_CREATED* = 0
-  CORO_EXECUTING* = 1
-  CORO_FINISHED* = 2
+  CORO_CREATED = 0
+  CORO_EXECUTING = 1
+  CORO_FINISHED = 2
 
 type
   Stack {.pure.} = object

--- a/tests/coroutines/twait.nim
+++ b/tests/coroutines/twait.nim
@@ -1,0 +1,19 @@
+discard """
+  output: "Exit 1\nExit 2"
+"""
+import coro
+
+var coro1: CoroutineRef
+
+proc testCoroutine1() =
+  for i in 0..<10:
+    suspend(0)
+  echo "Exit 1"
+
+proc testCoroutine2() =
+  coro1.wait()
+  echo "Exit 2"
+
+coro1 = coro.start(testCoroutine1)
+coro.start(testCoroutine2)
+run()

--- a/tests/coroutines/twait.nim.cfg
+++ b/tests/coroutines/twait.nim.cfg
@@ -1,0 +1,1 @@
+-d:nimCoroutines


### PR DESCRIPTION
@cheatfate pointed out show `wait()` implementation which mistakenly assumes that coroutine can be identified by it's function pointer. Running multiple coroutines of same proc naturally would not let us wait on specific instance of coroutine. This PR fixes the issue by returning `CoroutineRef` object on which public API operates. Reference is valid even when coroutine exits and is deallocated. Now that API operates on specific coroutine reference object waiting costs O(1) instead of O(N).

Also `Coroutine` object is allocated and managed manually. This paves way for easy coroutine migration between threads should anyone decide to implement it.