### PR TITLE
Fixes #5457 - StdLib base64 encodeInternal crashes with out of bound exception

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -50,7 +50,7 @@ template encodeInternal(s: expr, lineLen: int, newLine: string): stmt {.immediat
   var total = ((len(s) + 2) div 3) * 4
   var numLines = (total + lineLen - 1) div lineLen
   if numLines > 0: inc(total, (numLines - 1) * newLine.len)
-  
+
   result = newString(total)
   var i = 0
   var r = 0
@@ -155,7 +155,7 @@ when isMainModule:
   assert encode("easure.") == "ZWFzdXJlLg=="
   assert encode("asure.") == "YXN1cmUu"
   assert encode("sure.") == "c3VyZS4="
-  
+
   const testInputExpandsTo76 = "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
   const testInputExpands = "++++++++++++++++++++++++++++++"
   const longText = """Man is distinguished, not only by his reason, but by this
@@ -165,7 +165,7 @@ when isMainModule:
     pleasure."""
   const tests = ["", "abc", "xyz", "man", "leasure.", "sure.", "easure.",
                  "asure.", longText, testInputExpandsTo76, testInputExpands]
- 
+
   for t in items(tests):
     assert decode(encode(t)) == t
     assert decode(encode(t, lineLen=40)) == t

--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -49,8 +49,8 @@ template encodeInternal(s: expr, lineLen: int, newLine: string): stmt {.immediat
   ## `newline` is added.
   var total = ((len(s) + 2) div 3) * 4
   var numLines = (total + lineLen - 1) div lineLen
-  if numLines > 0: inc(total, (numLines-1) * newLine.len)
-
+  if numLines > 0: inc(total, (numLines - 1) * newLine.len)
+  
   result = newString(total)
   var i = 0
   var r = 0
@@ -66,7 +66,8 @@ template encodeInternal(s: expr, lineLen: int, newLine: string): stmt {.immediat
     inc(r, 4)
     inc(i, 3)
     inc(currLine, 4)
-    if currLine >= lineLen and i != s.len-2:
+    # avoid index out of bounds when lineLen == encoded length
+    if currLine >= lineLen and i != s.len-2 and r < total:
       for x in items(newLine):
         result[r] = x
         inc(r)
@@ -154,13 +155,18 @@ when isMainModule:
   assert encode("easure.") == "ZWFzdXJlLg=="
   assert encode("asure.") == "YXN1cmUu"
   assert encode("sure.") == "c3VyZS4="
-
+  
+  const testInputExpandsTo76 = "+++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+  const testInputExpands = "++++++++++++++++++++++++++++++"
   const longText = """Man is distinguished, not only by his reason, but by this
     singular passion from other animals, which is a lust of the mind,
     that by a perseverance of delight in the continued and indefatigable
     generation of knowledge, exceeds the short vehemence of any carnal
     pleasure."""
   const tests = ["", "abc", "xyz", "man", "leasure.", "sure.", "easure.",
-                 "asure.", longText]
+                 "asure.", longText, testInputExpandsTo76, testInputExpands]
+ 
   for t in items(tests):
     assert decode(encode(t)) == t
+    assert decode(encode(t, lineLen=40)) == t
+    assert decode(encode(t, lineLen=76)) == t


### PR DESCRIPTION
StdLib base64 encodeInternal crashes with out of bound exception