### PR TITLE
More robust tests for #5453

### DIFF
--- a/tests/stdlib/nre/find.nim
+++ b/tests/stdlib/nre/find.nim
@@ -32,22 +32,10 @@ suite "find":
     ## the timing difference between searching in small and large data should be well
     ## within a tolerance margin
     const small = 10
-    const large = 100000
+    const large = 1000
     var smallData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\" ", small)
     var largeData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\" ", large)
     var expression = re"^url.* = &#34;(.*?)&#34;"
 
-    var start = cpuTime()
     check(smallData.findAll(expression) == newSeq[string]())
-    var stop = cpuTime()
-    var elapsedSmall = stop - start
-
-    var tolerance = (elapsedSmall * ((large* 1.15) / small))
-
-    start = cpuTime()
     check(largeData.findAll(expression) == newSeq[string]())
-    stop = cpuTime()
-    var elapsedLarge = stop - start
-
-    var difference =  elapsedLarge - elapsedSmall
-    check(difference < tolerance)

--- a/tests/stdlib/nre/find.nim
+++ b/tests/stdlib/nre/find.nim
@@ -1,7 +1,7 @@
 import unittest, sequtils
 import nre except toSeq
 import optional_nonstrict
-import times, strutils
+import times, strutils 
 
 suite "find":
   test "find text":
@@ -30,17 +30,24 @@ suite "find":
   test "bail early":
     ## we expect nothing to be found and we should be bailing out early which means that
     ## the timing difference between searching in small and large data should be well
-    ## within a tolerance area
-    const tolerance = 0.0001
-    var smallData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\"", 10)
-    var largeData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\"", 1000000)
+    ## within a tolerance margin
+    const small = 10
+    const large = 100000
+    var smallData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\" ", small)
+    var largeData = repeat("url.sequence = \"http://whatever.com/jwhrejrhrjrhrjhrrjhrjrhrjrh\" ", large)
+    var expression = re"^url.* = &#34;(.*?)&#34;"
+
     var start = cpuTime()
-    check(largeData.findAll(re"url.*? = &#39;(.*?)&#39;") == newSeq[string]())
+    check(smallData.findAll(expression) == newSeq[string]())
     var stop = cpuTime()
-    var elapsedLarge = stop - start
-    start = cpuTime()
-    check(smallData.findAll(re"url.*? = &#39;(.*?)&#39;") == newSeq[string]())
-    stop = cpuTime()
     var elapsedSmall = stop - start
+
+    var tolerance = (elapsedSmall * ((large* 1.15) / small))
+
+    start = cpuTime()
+    check(largeData.findAll(expression) == newSeq[string]())
+    stop = cpuTime()
+    var elapsedLarge = stop - start
+
     var difference =  elapsedLarge - elapsedSmall
     check(difference < tolerance)

--- a/tests/stdlib/nre/find.nim
+++ b/tests/stdlib/nre/find.nim
@@ -1,7 +1,7 @@
 import unittest, sequtils
 import nre except toSeq
 import optional_nonstrict
-import times, strutils 
+import times, strutils
 
 suite "find":
   test "find text":


### PR DESCRIPTION
Ensure we are measuring the early bailout and not the performance of the PCRE engine itself. We anchor the expression at the beginning so we can ensure  the regexp fails fast.  Scale tolerance based on result for `smallData` and add some leeway for latency.