### PR TITLE
close #5472 nre tests should be run

### DIFF
--- a/tests/stdlib/tnre.nim
+++ b/tests/stdlib/tnre.nim
@@ -1,3 +1,25 @@
+discard """
+# Since the tests for nre are all bundled together we treat failure in one test as an nre failure
+# When running 'tests/testament/tester' a failed check() in the test suite will cause the exit
+# codes to differ and be reported as a failure
+
+  output:
+    '''[Suite] Test NRE initialization
+
+[Suite] captures
+
+[Suite] find
+
+[Suite] string splitting
+
+[Suite] match
+
+[Suite] replace
+
+[Suite] escape strings
+
+[Suite] Misc tests'''
+"""
 import nre
 import nre.init
 import nre.captures


### PR DESCRIPTION
nre tests were just being compiled - changed so that a failure causes exit code to differ from expected causing `tester` to report it as a failure