### PR TITLE
0 is valid fd on unix (if user closed stdin).  Also export handle so fs can be conserved.

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -67,6 +67,23 @@ proc debug*(n: PSym) {.deprecated.}
 proc debug*(n: PType) {.deprecated.}
 proc debug*(n: PNode) {.deprecated.}
 
+template mdbg*: bool {.dirty.} =
+  when compiles(c.module):
+    c.module.fileIdx == gProjectMainIdx
+  elif compiles(m.c.module):
+    m.c.module.fileIdx == gProjectMainIdx
+  elif compiles(cl.c.module):
+    cl.c.module.fileIdx == gProjectMainIdx
+  elif compiles(p):
+    when compiles(p.lex):
+      p.lex.fileIdx == gProjectMainIdx
+    else:
+      p.module.module.fileIdx == gProjectMainIdx
+  elif compiles(L.fileIdx):
+    L.fileIdx == gProjectMainIdx
+  else:
+    false
+
 # --------------------------- ident tables ----------------------------------
 proc idTableGet*(t: TIdTable, key: PIdObj): RootRef
 proc idTableGet*(t: TIdTable, key: int): RootRef

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -1022,7 +1022,7 @@ proc rawGetTok*(L: var TLexer, tok: var TToken) =
       inc(L.bufpos)
     of '.':
       when defined(nimsuggest):
-        if L.fileIdx == gTrackPos.fileIndex and tok.col+1 == gTrackPos.col and
+        if L.fileIdx == gTrackPos.fileIndex and tok.col == gTrackPos.col and
             tok.line == gTrackPos.line and gIdeCmd == ideSug:
           tok.tokType = tkDot
           inc(L.bufpos)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -828,6 +828,12 @@ proc getMessageStr(msg: TMsgKind, arg: string): string =
 type
   TErrorHandling = enum doNothing, doAbort, doRaise
 
+proc log*(s: string) {.procvar.} =
+  var f: File
+  if open(f, getHomeDir() / "nimsuggest.log", fmAppend):
+    f.writeLine(s)
+    close(f)
+
 proc quit(msg: TMsgKind) =
   if defined(debug) or msg == errInternal or hintStackTrace in gNotes:
     if stackTraceAvailable() and isNil(writelnHook):
@@ -837,12 +843,6 @@ proc quit(msg: TMsgKind) =
           "To create a stacktrace, rerun compilation with ./koch temp " &
           options.command & " <file>")
   quit 1
-
-proc log*(s: string) {.procvar.} =
-  var f: File
-  if open(f, getHomeDir() / "nimsuggest.log", fmAppend):
-    f.writeLine(s)
-    close(f)
 
 proc handleError(msg: TMsgKind, eh: TErrorHandling, s: string) =
   if msg >= fatalMin and msg <= fatalMax:

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -736,6 +736,8 @@ proc `??`* (info: TLineInfo, filename: string): bool =
   # only for debugging purposes
   result = filename in info.toFilename
 
+const trackPosInvalidFileIdx* = -2 # special marker so that no suggestions
+                                   # are produced within comments and string literals
 var gTrackPos*: TLineInfo
 
 type

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -420,11 +420,6 @@ proc binaryStrSearch*(x: openArray[string], y: string): int =
       return mid
   result = - 1
 
-template nimdbg*: untyped = c.module.fileIdx == gProjectMainIdx
-template cnimdbg*: untyped = p.module.module.fileIdx == gProjectMainIdx
-template pnimdbg*: untyped = p.lex.fileIdx == gProjectMainIdx
-template lnimdbg*: untyped = L.fileIdx == gProjectMainIdx
-
 proc parseIdeCmd*(s: string): IdeCmd =
   case s:
   of "sug": ideSug

--- a/compiler/prefixmatches.nim
+++ b/compiler/prefixmatches.nim
@@ -1,0 +1,86 @@
+#
+#
+#           The Nim Compiler
+#        (c) Copyright 2017 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+from strutils import toLowerAscii
+
+type
+  PrefixMatch* {.pure.} = enum
+    None,   ## no prefix detected
+    Prefix, ## prefix does match the symbol
+    Substr, ## prefix is a substring of the symbol
+    Abbrev  ## prefix is an abbreviation of the symbol
+
+proc prefixMatch*(p, s: string): PrefixMatch =
+  template eq(a, b): bool = a.toLowerAscii == b.toLowerAscii
+  if p.len > s.len: return PrefixMatch.None
+  var i = 0
+  let L = s.len
+  # check for prefix/contains:
+  while i < L:
+    if s[i] == '_': inc i
+    if eq(s[i], p[0]):
+      var ii = i+1
+      var jj = 1
+      while ii < L and jj < p.len:
+        if p[jj] == '_': inc jj
+        if s[ii] == '_': inc ii
+        if not eq(s[ii], p[jj]): break
+        inc ii
+        inc jj
+
+      if jj >= p.len:
+        if i == 0: return PrefixMatch.Prefix
+        else: return PrefixMatch.Substr
+    inc i
+  # check for abbrev:
+  if eq(s[0], p[0]):
+    i = 1
+    var j = 1
+    while i < s.len:
+      if s[i] == '_' and i < s.len-1:
+        if j < p.len and eq(p[j], s[i+1]): inc j
+        else: return PrefixMatch.None
+      if s[i] in {'A'..'Z'} and s[i-1] notin {'A'..'Z'}:
+        if j < p.len and eq(p[j], s[i]): inc j
+        else: return PrefixMatch.None
+      inc i
+    return PrefixMatch.Abbrev
+  return PrefixMatch.None
+
+when isMainModule:
+  import macros
+
+  macro check(val, body: untyped): untyped =
+    result = newStmtList()
+    expectKind body, nnkStmtList
+    for b in body:
+      expectKind b, nnkPar
+      expectLen b, 2
+      let p = b[0]
+      let s = b[1]
+      result.add quote do:
+        echo prefixMatch(`p`, `s`) == `val`
+
+  check PrefixMatch.Prefix:
+    ("abc", "abc")
+    ("a", "abc")
+    ("xyz", "X_yzzzZe")
+
+  check PrefixMatch.Substr:
+    ("b", "abc")
+    ("abc", "fooabcabc")
+    ("abC", "foo_AB_c")
+
+  check PrefixMatch.Abbrev:
+    ("abc", "AxxxBxxxCxxx")
+    ("xyz", "X_yabcZe")
+
+  check PrefixMatch.None:
+    ("foobar", "afkslfjd_as")
+    ("xyz", "X_yuuZuuZe")

--- a/compiler/prefixmatches.nim
+++ b/compiler/prefixmatches.nim
@@ -12,9 +12,9 @@ from strutils import toLowerAscii
 type
   PrefixMatch* {.pure.} = enum
     None,   ## no prefix detected
-    Prefix, ## prefix does match the symbol
-    Substr, ## prefix is a substring of the symbol
     Abbrev  ## prefix is an abbreviation of the symbol
+    Substr, ## prefix is a substring of the symbol
+    Prefix, ## prefix does match the symbol
 
 proc prefixMatch*(p, s: string): PrefixMatch =
   template eq(a, b): bool = a.toLowerAscii == b.toLowerAscii

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -27,6 +27,8 @@
 ## - Finally, sort matches by relevance. The relevance is determined by the
 ##   number of usages, so ``strutils.replace`` comes before
 ##   ``strutils.wordWrap``.
+## - In any case, sorting also considers scoping information. Local variables
+##   get high priority.
 
 # included from sigmatch.nim
 

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -156,8 +156,9 @@ proc `$`*(suggest: Suggest): string =
     if suggestVersion == 2:
       result.add(sep)
       result.add($suggest.quality)
-      result.add(sep)
-      result.add($suggest.prefix)
+      if suggest.section == ideSug:
+        result.add(sep)
+        result.add($suggest.prefix)
 
 proc symToSuggest(s: PSym, isLocal: bool, section: string;
                   quality: range[0..100], prefix: PrefixMatch; inTypeContext: bool): Suggest =

--- a/doc/nimsuggest.rst
+++ b/doc/nimsuggest.rst
@@ -25,26 +25,19 @@ already available.
 Installation
 ============
 
-Nimsuggest is available as a Nimble package but currently does not install
-properly via Nimble. As nimsuggest is part of the compiler it also doesn't make
-too much sense as a Nimble package. Instead we will do the building manually::
+Nimsuggest is part of Nim's core. Build it via::
 
-  cd compiler/nimsuggest
-  nim c -d:release nimsuggest
-  cp nimsuggest ../../bin
-  # OR: copy the nimsuggest binary to where your 'nim' binary is
-  cd ../..
-
+  koch nimsuggest
 
 
 Nimsuggest invocation
 =====================
 
-Run it via ``nimsuggest --stdin myproject.nim``. Nimsuggest is a server that
-takes queries that are related to ``myproject``. There is some support so that
-you can throw random ``.nim`` files which are not part of ``myproject`` at
-Nimsuggest too, but usually the query refer to modules/files that are part of
-``myproject``.
+Run it via ``nimsuggest --stdin --debug --v2 myproject.nim``. Nimsuggest is a
+server that takes queries that are related to ``myproject``. There is some
+support so that you can throw random ``.nim`` files which are not part
+of ``myproject`` at Nimsuggest too, but usually the query refer to modules/files
+that are part of ``myproject``.
 
 ``--stdin`` means that Nimsuggest reads the query from ``stdin``. This is great
 for testing things out and playing with it but for an editor communication

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -36,7 +36,7 @@ type
       mapHandle: Handle
       wasOpened: bool   ## only close if wasOpened
     else:
-      handle: cint
+      handle*: cint
 
 {.deprecated: [TMemFile: MemFile].}
 
@@ -250,9 +250,9 @@ proc close*(f: var MemFile) =
       error = (closeHandle(f.mapHandle) == 0) or error
       error = (closeHandle(f.fHandle) == 0) or error
   else:
-    if f.handle != 0:
-      error = munmap(f.mem, f.size) != 0
-      lastErr = osLastError()
+    error = munmap(f.mem, f.size) != 0
+    lastErr = osLastError()
+    if f.handle != -1:
       error = (close(f.handle) != 0) or error
 
   f.size = 0
@@ -263,7 +263,7 @@ proc close*(f: var MemFile) =
     f.mapHandle = 0
     f.wasOpened = false
   else:
-    f.handle = 0
+    f.handle = -1
 
   if error: raiseOSError(lastErr)
 

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -193,8 +193,8 @@ proc open*(filename: string, mode: FileMode = fmRead,
       else: result.size = fileSize.int
 
     result.wasOpened = true
-    if not allowRemap and result.handle != INVALID_HANDLE_VALUE:
-      if closeHandle(result.handle) == 0:
+    if not allowRemap and result.fHandle != INVALID_HANDLE_VALUE:
+      if closeHandle(result.fHandle) == 0:
         result.fHandle = INVALID_HANDLE_VALUE
 
   else:

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -193,7 +193,7 @@ proc open*(filename: string, mode: FileMode = fmRead,
   else:
     template fail(errCode: OSErrorCode, msg: expr) =
       rollback()
-      if result.handle != 0: discard close(result.handle)
+      if result.handle != -1: discard close(result.handle)
       raiseOSError(errCode)
 
     var flags = if readonly: O_RDONLY else: O_RDWR

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -25,8 +25,8 @@ when not declared(getEnv) or defined(nimscript):
     WriteEnvEffect* = object of WriteIOEffect ## effect that denotes a write
                                               ## to an environment variable
 
-    ReadDirEffect* = object of ReadIOEffect   ## effect that denotes a write
-                                              ## operation to the directory
+    ReadDirEffect* = object of ReadIOEffect   ## effect that denotes a read
+                                              ## operation from the directory
                                               ## structure
     WriteDirEffect* = object of WriteIOEffect ## effect that denotes a write
                                               ## operation to

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -417,7 +417,7 @@ type
     ## Base exception class.
     ##
     ## Each exception has to inherit from `Exception`. See the full `exception
-    ## hierarchy`_.
+    ## hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
     parent*: ref Exception ## parent exception (can be used as a stack)
     name*: cstring ## The exception's name is its Nim identifier.
                    ## This field is filled automatically in the
@@ -430,51 +430,51 @@ type
   SystemError* = object of Exception ## \
     ## Abstract class for exceptions that the runtime system raises.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   IOError* = object of SystemError ## \
     ## Raised if an IO error occurred.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   EOFError* = object of IOError ## \
     ## Raised if an IO "end of file" error occurred.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   OSError* = object of SystemError ## \
     ## Raised if an operating system service failed.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
     errorCode*: int32 ## OS-defined error code describing this error.
   LibraryError* = object of OSError ## \
     ## Raised if a dynamic library could not be loaded.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   ResourceExhaustedError* = object of SystemError ## \
     ## Raised if a resource request could not be fulfilled.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   ArithmeticError* = object of Exception ## \
     ## Raised if any kind of arithmetic error occurred.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   DivByZeroError* = object of ArithmeticError ## \
     ## Raised for runtime integer divide-by-zero errors.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
 
   OverflowError* = object of ArithmeticError ## \
     ## Raised for runtime integer overflows.
     ##
     ## This happens for calculations whose results are too large to fit in the
-    ## provided bits.  See the full `exception hierarchy`_.
+    ## provided bits.  See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   AccessViolationError* = object of Exception ## \
     ## Raised for invalid memory access errors
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   AssertionError* = object of Exception ## \
     ## Raised when assertion is proved wrong.
     ##
     ## Usually the result of using the `assert() template <#assert>`_.  See the
-    ## full `exception hierarchy`_.
+    ## full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   ValueError* = object of Exception ## \
     ## Raised for string and object conversion errors.
   KeyError* = object of ValueError ## \
@@ -482,66 +482,66 @@ type
     ##
     ## Mostly used by the `tables <tables.html>`_ module, it can also be raised
     ## by other collection modules like `sets <sets.html>`_ or `strtabs
-    ## <strtabs.html>`_. See the full `exception hierarchy`_.
+    ## <strtabs.html>`_. See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   OutOfMemError* = object of SystemError ## \
     ## Raised for unsuccessful attempts to allocate memory.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   IndexError* = object of Exception ## \
     ## Raised if an array index is out of bounds.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
 
   FieldError* = object of Exception ## \
     ## Raised if a record field is not accessible because its dicriminant's
     ## value does not fit.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   RangeError* = object of Exception ## \
     ## Raised if a range check error occurred.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   StackOverflowError* = object of SystemError ## \
     ## Raised if the hardware stack used for subroutine calls overflowed.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   ReraiseError* = object of Exception ## \
     ## Raised if there is no exception to reraise.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   ObjectAssignmentError* = object of Exception ## \
     ## Raised if an object gets assigned to its parent's object.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   ObjectConversionError* = object of Exception ## \
     ## Raised if an object is converted to an incompatible object type.
     ## You can use ``of`` operator to check if conversion will succeed.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   FloatingPointError* = object of Exception ## \
     ## Base class for floating point exceptions.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   FloatInvalidOpError* = object of FloatingPointError ## \
     ## Raised by invalid operations according to IEEE.
     ##
     ## Raised by ``0.0/0.0``, for example.  See the full `exception
-    ## hierarchy`_.
+    ## hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   FloatDivByZeroError* = object of FloatingPointError ## \
     ## Raised by division by zero.
     ##
     ## Divisor is zero and dividend is a finite nonzero number.  See the full
-    ## `exception hierarchy`_.
+    ## `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   FloatOverflowError* = object of FloatingPointError ## \
     ## Raised for overflows.
     ##
     ## The operation produced a result that exceeds the range of the exponent.
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   FloatUnderflowError* = object of FloatingPointError ## \
     ## Raised for underflows.
     ##
     ## The operation produced a result that is too small to be represented as a
-    ## normal number. See the full `exception hierarchy`_.
+    ## normal number. See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   FloatInexactError* = object of FloatingPointError ## \
     ## Raised for inexact results.
     ##
@@ -549,11 +549,11 @@ type
     ## precision -- for example: ``2.0 / 3.0, log(1.1)``
     ##
     ## **NOTE**: Nim currently does not detect these!  See the full
-    ## `exception hierarchy`_.
+    ## `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
   DeadThreadError* = object of Exception ## \
     ## Raised if it is attempted to send a message to a dead thread.
     ##
-    ## See the full `exception hierarchy`_.
+    ## See the full `exception hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
 
 {.deprecated: [TObject: RootObj, PObject: RootRef, TEffect: RootEffect,
   FTime: TimeEffect, FIO: IOEffect, FReadIO: ReadIOEffect,

--- a/tests/stdlib/tmemfiles2.nim
+++ b/tests/stdlib/tmemfiles2.nim
@@ -18,7 +18,7 @@ mm = memfiles.open(fn, mode = fmReadWrite, newFileSize = 20)
 mm.close()
 
 # read, change
-mm_full = memfiles.open(fn, mode = fmWrite, mappedSize = -1)
+mm_full = memfiles.open(fn, mode = fmWrite, mappedSize = -1, allowRemap = true)
 echo "Full read size: ",mm_full.size
 p = mm_full.mapMem(fmReadWrite, 20, 0)
 var p2 = cast[cstring](p)

--- a/todo.txt
+++ b/todo.txt
@@ -1,10 +1,3 @@
-nimsuggest
-==========
-
-- disable in string and comments
-- bug "goto definition for gTrackPos" in suggest.nim
-
-
 version 1.0 battle plan
 =======================
 

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,10 @@
+nimsuggest
+==========
+
+- disable in string and comments
+- bug "goto definition for gTrackPos" in suggest.nim
+
+
 version 1.0 battle plan
 =======================
 

--- a/tools/nimsuggest/nimsuggest.nim
+++ b/tools/nimsuggest/nimsuggest.nim
@@ -17,7 +17,7 @@ import compiler / [options, commands, modules, sem,
   passes, passaux, msgs, nimconf,
   extccomp, condsyms,
   sigmatch, ast, scriptconfig,
-  idents, modulegraphs, vm]
+  idents, modulegraphs, vm, prefixmatches]
 
 when defined(windows):
   import winlean
@@ -51,6 +51,11 @@ are supported.
 """
 type
   Mode = enum mstdin, mtcp, mepc, mcmdline
+  CachedMsg = object
+    info: TLineInfo
+    msg: string
+    sev: Severity
+  CachedMsgs = seq[CachedMsg]
 
 var
   gPort = 6000.Port
@@ -93,7 +98,7 @@ proc parseQuoted(cmd: string; outp: var string; start: int): int =
     i += parseUntil(cmd, outp, seps, i)
   result = i
 
-proc sexp(s: IdeCmd|TSymKind): SexpNode = sexp($s)
+proc sexp(s: IdeCmd|TSymKind|PrefixMatch): SexpNode = sexp($s)
 
 proc sexp(s: Suggest): SexpNode =
   # If you change the order here, make sure to change it over in
@@ -110,6 +115,8 @@ proc sexp(s: Suggest): SexpNode =
     s.doc,
     s.quality
   ])
+  if s.section == ideSug:
+    result.add convertSexp(s.prefix)
 
 proc sexp(s: seq[Suggest]): SexpNode =
   result = newSList()
@@ -363,7 +370,7 @@ proc replEpc(x: ThreadParams) {.thread.} =
                          "unexpected call: " & epcAPI
       quit errMessage
 
-proc execCmd(cmd: string; graph: ModuleGraph; cache: IdentCache) =
+proc execCmd(cmd: string; graph: ModuleGraph; cache: IdentCache; cachedMsgs: CachedMsgs) =
   template sentinel() =
     # send sentinel for the input reading thread:
     results.send(Suggest(section: ideNone))
@@ -415,17 +422,19 @@ proc execCmd(cmd: string; graph: ModuleGraph; cache: IdentCache) =
   if gIdeCmd == ideKnown:
     results.send(Suggest(section: ideKnown, quality: ord(fileInfoKnown(orig))))
   else:
+    if gIdeCmd == ideChk:
+      for cm in cachedMsgs: errorHook(cm.info, cm.msg, cm.sev)
     execute(gIdeCmd, orig, dirtyfile, line, col-1, graph, cache)
   sentinel()
 
 proc recompileFullProject(graph: ModuleGraph; cache: IdentCache) =
-  echo "recompiling full project"
+  #echo "recompiling full project"
   resetSystemArtifacts()
   vm.globalCtx = nil
   graph.resetAllModules()
   GC_fullcollect()
   compileProject(graph, cache)
-  echo GC_getStatistics()
+  #echo GC_getStatistics()
 
 proc mainThread(graph: ModuleGraph; cache: IdentCache) =
   if gLogging:
@@ -442,12 +451,13 @@ proc mainThread(graph: ModuleGraph; cache: IdentCache) =
   suggestionResultHook = sugResultHook
   graph.doStopCompile = proc (): bool = requests.peek() > 0
   var idle = 0
+  var cachedMsgs: CachedMsgs = @[]
   while true:
     let (hasData, req) = requests.tryRecv()
     if hasData:
       msgs.writelnHook = wrHook
       suggestionResultHook = sugResultHook
-      execCmd(req, graph, cache)
+      execCmd(req, graph, cache, cachedMsgs)
       idle = 0
     else:
       os.sleep 250
@@ -456,7 +466,9 @@ proc mainThread(graph: ModuleGraph; cache: IdentCache) =
       # we use some nimsuggest activity to enable a lazy recompile:
       gIdeCmd = ideChk
       msgs.writelnHook = proc (s: string) = discard
-      msgs.structuredErrorHook = nil
+      cachedMsgs.setLen 0
+      msgs.structuredErrorHook = proc (info: TLineInfo; msg: string; sev: Severity) =
+        cachedMsgs.add(CachedMsg(info: info, msg: msg, sev: sev))
       suggestionResultHook = proc (s: Suggest) = discard
       recompileFullProject(graph, cache)
 
@@ -525,8 +537,13 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
         suggestVersion = 2
         gMode = mstdin
         gEmitEof = true
+        gRefresh = false
       of "log": gLogging = true
-      of "refresh": gRefresh = true
+      of "refresh":
+        if p.val.len > 0:
+          gRefresh = parseBool(p.val)
+        else:
+          gRefresh = true
       else: processSwitch(pass, p)
     of cmdArgument:
       options.gProjectName = unixToNativePath(p.key)

--- a/tools/nimsuggest/nimsuggest.nim
+++ b/tools/nimsuggest/nimsuggest.nim
@@ -155,6 +155,9 @@ proc execute(cmd: IdeCmd, file, dirtyfile: string, line, col: int;
   if cmd == ideChk:
     msgs.structuredErrorHook = errorHook
     msgs.writelnHook = proc (s: string) = discard
+  else:
+    msgs.structuredErrorHook = nil
+    msgs.writelnHook = proc (s: string) = discard
   if cmd == ideUse and suggestVersion != 2:
     graph.resetAllModules()
   var isKnownFile = true

--- a/tools/nimsuggest/tester.nim
+++ b/tools/nimsuggest/tester.nim
@@ -164,7 +164,6 @@ proc sexpToAnswer(s: SexpNode): string =
   doAssert m.kind == SList
   for a in m:
     doAssert a.kind == SList
-    var first = true
     #s.section,
     #s.symkind,
     #s.qualifiedPath.map(newSString),
@@ -300,9 +299,11 @@ proc runTest(filename: string): int =
 
 proc main() =
   var failures = 0
-  when false:
-    let x = getAppDir() / "tests/tchk1.nim"
+  if os.paramCount() > 0:
+    let f = os.paramStr(1)
+    let x = getAppDir() / f
     let xx = expandFilename x
+    failures += runTest(xx)
     failures += runEpcTest(xx)
   else:
     for x in walkFiles(getAppDir() / "tests/t*.nim"):

--- a/tools/nimsuggest/tester.nim
+++ b/tools/nimsuggest/tester.nim
@@ -20,6 +20,7 @@ template tpath(): untyped = getAppDir() / "tests"
 proc parseTest(filename: string; epcMode=false): Test =
   const cursorMarker = "#[!]#"
   let nimsug = curDir & addFileExt("nimsuggest", ExeExt)
+  let libpath = findExe("nim").splitFile().dir /../ "lib"
   result.dest = getTempDir() / extractFilename(filename)
   result.cmd = nimsug & " --tester " & result.dest
   result.script = @[]
@@ -42,7 +43,7 @@ proc parseTest(filename: string; epcMode=false): Test =
       inc specSection
     elif specSection == 1:
       if x.startsWith("$nimsuggest"):
-        result.cmd = x % ["nimsuggest", nimsug, "file", filename]
+        result.cmd = x % ["nimsuggest", nimsug, "file", filename, "lib", libpath]
       elif x.startsWith("!"):
         if result.cmd.len == 0:
           result.startup.add x
@@ -54,7 +55,7 @@ proc parseTest(filename: string; epcMode=false): Test =
         result.script.add((x.substr(1).replaceWord("$path", tpath()), ""))
       elif x.len > 0:
         # expected output line:
-        let x = x % ["file", filename]
+        let x = x % ["file", filename, "lib", libpath]
         result.script[^1][1].add x.replace(";;", "\t") & '\L'
         # else: ignore empty lines for better readability of the specs
     inc i
@@ -203,6 +204,9 @@ proc sexpToAnswer(s: SexpNode): string =
       result.add doc
       result.add '\t'
       result.add a[8].getNum
+      if a.len >= 10:
+        result.add '\t'
+        result.add a[9].getStr
     result.add '\L'
 
 proc doReport(filename, answer, resp: string; report: var string) =

--- a/tools/nimsuggest/tests/tdot1.nim
+++ b/tools/nimsuggest/tests/tdot1.nim
@@ -1,9 +1,9 @@
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skField;;x;;int;;$file;;11;;4;;"";;100
-sug;;skField;;y;;int;;$file;;11;;7;;"";;100
-sug;;skProc;;tdot1.main;;proc (f: Foo);;$file;;13;;5;;"";;100
+sug;;skField;;x;;int;;$file;;11;;4;;"";;100;;None
+sug;;skField;;y;;int;;$file;;11;;7;;"";;100;;None
+sug;;skProc;;tdot1.main;;proc (f: Foo);;$file;;13;;5;;"";;100;;None
 """
 
 type

--- a/tools/nimsuggest/tests/tdot2.nim
+++ b/tools/nimsuggest/tests/tdot2.nim
@@ -17,13 +17,13 @@ proc main(f: Foo) =
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skField;;x;;int;;$file;;8;;4;;"";;100
-sug;;skField;;y;;int;;$file;;8;;7;;"";;100
-sug;;skProc;;tdot2.main;;proc (f: Foo);;$file;;12;;5;;"";;100
+sug;;skField;;x;;int;;$file;;8;;4;;"";;100;;None
+sug;;skField;;y;;int;;$file;;8;;7;;"";;100;;None
+sug;;skProc;;tdot2.main;;proc (f: Foo);;$file;;12;;5;;"";;100;;None
 !edit 0i32 1i32
 >sug $1
-sug;;skField;;x;;int;;$file;;8;;4;;"";;100
-sug;;skField;;y;;int;;$file;;8;;7;;"";;100
-sug;;skField;;z;;string;;$file;;10;;6;;"";;100
-sug;;skProc;;tdot2.main;;proc (f: Foo);;$file;;12;;5;;"";;100
+sug;;skField;;x;;int;;$file;;8;;4;;"";;100;;None
+sug;;skField;;y;;int;;$file;;8;;7;;"";;100;;None
+sug;;skField;;z;;string;;$file;;10;;6;;"";;100;;None
+sug;;skProc;;tdot2.main;;proc (f: Foo);;$file;;12;;5;;"";;100;;None
 """

--- a/tools/nimsuggest/tests/tdot3.nim
+++ b/tools/nimsuggest/tests/tdot3.nim
@@ -12,16 +12,16 @@ discard """
 !copy dep_v1.nim dep.nim
 $nimsuggest --tester $file
 >sug $1
-sug;;skField;;x;;int;;*dep.nim;;8;;4;;"";;100
-sug;;skField;;y;;int;;*dep.nim;;8;;8;;"";;100
-sug;;skProc;;tdot3.main;;proc (f: Foo);;$file;;5;;5;;"";;100
+sug;;skField;;x;;int;;*dep.nim;;8;;4;;"";;100;;None
+sug;;skField;;y;;int;;*dep.nim;;8;;8;;"";;100;;None
+sug;;skProc;;tdot3.main;;proc (f: Foo);;$file;;5;;5;;"";;100;;None
 
 !copy dep_v2.nim dep.nim
 >mod $path/dep.nim
 >sug $1
-sug;;skField;;x;;int;;*dep.nim;;8;;4;;"";;100
-sug;;skField;;y;;int;;*dep.nim;;8;;8;;"";;100
-sug;;skField;;z;;string;;*dep.nim;;9;;4;;"";;100
-sug;;skProc;;tdot3.main;;proc (f: Foo);;$file;;5;;5;;"";;100
+sug;;skField;;x;;int;;*dep.nim;;8;;4;;"";;100;;None
+sug;;skField;;y;;int;;*dep.nim;;8;;8;;"";;100;;None
+sug;;skField;;z;;string;;*dep.nim;;9;;4;;"";;100;;None
+sug;;skProc;;tdot3.main;;proc (f: Foo);;$file;;5;;5;;"";;100;;None
 !del dep.nim
 """

--- a/tools/nimsuggest/tests/tno_deref.nim
+++ b/tools/nimsuggest/tests/tno_deref.nim
@@ -9,6 +9,6 @@ x.#[!]#
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skProc;;tno_deref.foo;;proc (y: ptr int)*;;$file;;4;;5;;"";;100
+sug;;skProc;;tno_deref.foo;;proc (y: ptr int)*;;$file;;4;;5;;"";;100;;None
 *
 """

--- a/tools/nimsuggest/tests/tsug_regression.nim
+++ b/tools/nimsuggest/tests/tsug_regression.nim
@@ -1,0 +1,28 @@
+# test we only get suggestions, not error messages:
+
+import tables, sets, parsecfg
+
+type X = object
+
+proc main =
+  # bug #52
+  var
+    set0 = initSet[int]()
+    set1 = initSet[X]()
+    set2 = initSet[ref int]()
+
+    map0 = initTable[int, int]()
+    map1 = initOrderedTable[string, int]()
+    cfg = loadConfig("file")
+  map0.#[!]#
+
+discard """
+$nimsuggest --tester $file
+>sug $1
+sug;;skProc;;tables.getOrDefault;;proc (t: Table[getOrDefault.A, getOrDefault.B], key: A): B;;$lib/pure/collections/tables.nim;;178;;5;;"";;100;;None
+sug;;skProc;;tables.hasKey;;proc (t: Table[hasKey.A, hasKey.B], key: A): bool;;$lib/pure/collections/tables.nim;;233;;5;;"returns true iff `key` is in the table `t`.";;100;;None
+sug;;skProc;;tables.add;;proc (t: var Table[add.A, add.B], key: A, val: B);;$lib/pure/collections/tables.nim;;297;;5;;"puts a new (key, value)-pair into `t` even if ``t[key]`` already exists.";;100;;None
+sug;;skIterator;;tables.allValues;;iterator (t: Table[allValues.A, allValues.B], key: A): B{.inline.};;$lib/pure/collections/tables.nim;;225;;9;;"iterates over any value in the table `t` that belongs to the given `key`.";;100;;None
+sug;;skProc;;tables.clear;;proc (t: var Table[clear.A, clear.B]);;$lib/pure/collections/tables.nim;;121;;5;;"Resets the table so that it is empty.";;100;;None
+*
+"""

--- a/tools/nimsuggest/tests/twithin_macro.nim
+++ b/tools/nimsuggest/tests/twithin_macro.nim
@@ -204,10 +204,10 @@ echo r
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skField;;name;;string;;$file;;166;;6;;"";;100
-sug;;skField;;age;;int;;$file;;167;;6;;"";;100
-sug;;skMethod;;twithin_macro.age_human_yrs;;proc (self: Animal): int;;$file;;169;;9;;"";;100
-sug;;skMacro;;twithin_macro.class;;proc (head: untyped, body: untyped): untyped{.gcsafe, locks: <unknown>.};;$file;;4;;6;;"Iterates over the children of the NimNode ``n``.";;100
-sug;;skMethod;;twithin_macro.vocalize;;proc (self: Animal): string;;$file;;168;;9;;"";;100
-sug;;skMethod;;twithin_macro.vocalize;;proc (self: Rabbit): string;;$file;;184;;9;;"";;100*
+sug;;skField;;age;;int;;$file;;167;;6;;"";;100;;None
+sug;;skField;;name;;string;;$file;;166;;6;;"";;100;;None
+sug;;skMethod;;twithin_macro.age_human_yrs;;proc (self: Animal): int;;$file;;169;;9;;"";;100;;None
+sug;;skMethod;;twithin_macro.vocalize;;proc (self: Animal): string;;$file;;168;;9;;"";;100;;None
+sug;;skMethod;;twithin_macro.vocalize;;proc (self: Rabbit): string;;$file;;184;;9;;"";;100;;None
+sug;;skMacro;;twithin_macro.class;;proc (head: untyped, body: untyped): untyped{.gcsafe, locks: <unknown>.};;$file;;4;;6;;"";;50;;None*
 """

--- a/tools/nimsuggest/tests/twithin_macro_prefix.nim
+++ b/tools/nimsuggest/tests/twithin_macro_prefix.nim
@@ -204,6 +204,6 @@ echo r
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skField;;age;;int;;$file;;167;;6;;"";;100
-sug;;skMethod;;twithin_macro_prefix.age_human_yrs;;proc (self: Animal): int;;$file;;169;;9;;"";;100
+sug;;skField;;age;;int;;$file;;167;;6;;"";;100;;Prefix
+sug;;skMethod;;twithin_macro_prefix.age_human_yrs;;proc (self: Animal): int;;$file;;169;;9;;"";;100;;Prefix
 """


### PR DESCRIPTION
The current code is broken if the caller closes stdin and then uses memfiles. The correct invalid fd should be -1.

Further, the handle should either be exported (or an API to close it and set it to -1 should be added).  Handles
aka file descriptors are a scarce resource on Unix, sometimes with default limits as low as 64.  Contrariwise, memory maps are not scarce (default limits usually in the many thousands) and there is no need to keep the handle open to use the mapped file.  The only need to keep the file open on unix that might arise in the future is resizing the file after the initial map.  Then you need an fd to call `ftruncate` to resize the file.  That feature is not currently supported, though - the file can be closed any time after the initial size setting.  So, at least for now we should allow releasing that file descriptor/handle.  I don't know about Windows constraints/default limits about these things, but this PR only impacts the unix side.