### PR TITLE
Fixed typo

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -393,7 +393,7 @@ Since counting up occurs so often in programs, Nim also has a `..
   for i in 1..10:
     ...
 
-Zero-indexed counting have two shortcuts ``..<`` and ``..^`` to simplify counting to one less then the higher index:
+Zero-indexed counting have two shortcuts ``..<`` and ``..^`` to simplify counting to one less than the higher index:
 
 .. code-block:: nim
   for i in 0..<10:


### PR DESCRIPTION
I also suggest that you change line 406
OLD: for i in 0..<s.len:
NEW: for i in 0..^s.len:
So that readers can see that < and ^ are synonyms in this context (since that's what the text above implies).