### PR TITLE
Suggested small change to code

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -411,8 +411,8 @@ Other useful iterators for collections (like arrays and sequences) are
 * ``pairs`` and ``mpairs`` which provides the element and an index number (immutable and mutable respectively)
 
 .. code-block:: nim
-  for indx, itm in ["a","b"].pairs:
-    echo itm, " at index ", indx
+  for index, item in ["a","b"].pairs:
+    echo item, " at index ", index
   # => a at index 0
   # => b at index 1
 


### PR DESCRIPTION
In a code example I think it best to either use full names (index, item) or abbreviated names where that's common (i, item) but not non-standard abbreviations (indx, itm). So I've changed it to index, item since it is a tutorial, although i, item would be just as good.