### PR TITLE
Mentioned that critbits is sorted...

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -84,7 +84,7 @@ Collections and algorithms
   Efficient implementation of a set of ints as a sparse bit set.
 * `critbits <critbits.html>`_
   This module implements a *crit bit tree* which is an efficient
-  container for a set or a mapping of strings.
+  container for a sorted set of strings, or for a sorted mapping of strings.
 * `sequtils <sequtils.html>`_
   This module implements operations for the built-in seq type
   which were inspired by functional programming languages.


### PR DESCRIPTION
Having a lexicographically sorted collection is a big benefit (I asked GvR years ago to add one to Python but it was no then and seems to be no now!).
Anyone looking for a such a collection could easily miss the critbits model because very few people have heard of them (according to Wikipedia most people in a ration of approx 750:1 know them as radix trees: https://en.wikipedia.org/wiki/Talk%3ACrit_bit_tree).

I also think you should give some summary of the collections and advice on when to use which for new users (plus big-Oh notation for those who understand it).