### PR TITLE
Fixes #5062

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1634,16 +1634,8 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
   of tyEnum, tyOrdinal:
     gen(p, n.sons[1], r)
     useMagic(p, "cstrToNimstr")
-    var offset = ""
-    if t.kind == tyEnum:
-      let firstFieldOffset = t.n.sons[0].sym.position
-      if firstFieldOffset < 0:
-        offset = "+" & $(-firstFieldOffset)
-      elif firstFieldOffset > 0:
-        offset = "-" & $firstFieldOffset
-
     r.kind = resExpr
-    r.res = "cstrToNimstr($1.node.sons[$2$3].name)" % [genTypeInfo(p, t), r.res, rope(offset)]
+    r.res = "cstrToNimstr($1.node.sons[$2].name)" % [genTypeInfo(p, t), r.res]
   else:
     # XXX:
     internalError(n.info, "genRepr: Not implemented")

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -104,7 +104,7 @@ proc genEnumInfo(p: PProc, typ: PType, name: Rope) =
     let field = typ.n.sons[i].sym
     if i > 0: add(s, ", " & tnl)
     let extName = if field.ast == nil: field.name.s else: field.ast.strVal
-    addf(s, "$1: {kind: 1, offset: $1, typ: $2, name: $3, len: 0, sons: null}",
+    addf(s, "\"$1\": {kind: 1, offset: $1, typ: $2, name: $3, len: 0, sons: null}",
          [rope(field.position), name, makeJSString(extName)])
   var n = ("var NNI$1 = {kind: 2, offset: 0, typ: null, " &
       "name: null, len: $2, sons: {$3}};$n") % [rope(typ.id), rope(length), s]

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -104,10 +104,10 @@ proc genEnumInfo(p: PProc, typ: PType, name: Rope) =
     let field = typ.n.sons[i].sym
     if i > 0: add(s, ", " & tnl)
     let extName = if field.ast == nil: field.name.s else: field.ast.strVal
-    addf(s, "{kind: 1, offset: $1, typ: $2, name: $3, len: 0, sons: null}",
+    addf(s, "$1: {kind: 1, offset: $1, typ: $2, name: $3, len: 0, sons: null}",
          [rope(field.position), name, makeJSString(extName)])
   var n = ("var NNI$1 = {kind: 2, offset: 0, typ: null, " &
-      "name: null, len: $2, sons: [$3]};$n") % [rope(typ.id), rope(length), s]
+      "name: null, len: $2, sons: {$3}};$n") % [rope(typ.id), rope(length), s]
   s = ("var $1 = {size: 0, kind: $2, base: null, node: null, " &
        "finalizer: null};$n") % [name, rope(ord(typ.kind))]
   prepend(p.g.typeInfo, s)

--- a/tests/enum/tbasicenum.nim
+++ b/tests/enum/tbasicenum.nim
@@ -1,0 +1,11 @@
+discard """
+  file: "tbasicenum.nim"
+  output: "ABCDC"
+"""
+
+type
+  MyEnum = enum
+    A,B,C,D
+# trick the optimizer with an seq:
+var x = @[A,B,C,D]
+echo x[0],x[1],x[2],x[3],MyEnum(2)

--- a/tests/enum/tenumhole.nim
+++ b/tests/enum/tenumhole.nim
@@ -1,24 +1,16 @@
 discard """
   file: "tenumhole.nim"
-  output: "my value A1my value Bconc2valueCabc4abc"
+  output: "first0second32third64"
 """
 
-const
-  strValB = "my value B"
+type Holed = enum
+  hFirst = (0,"first")
+  hSecond = (32,"second")
+  hThird = (64,"third")
+  
+var x = @[0,32,64] # This is just to avoid the compiler inlining the value of the enum
 
-type
-  TMyEnum = enum
-    valueA = (1, "my value A"),
-    valueB = strValB & "conc",
-    valueC,
-    valueD = (4, "abc")
-
-# test the new "proc body can be an expr" feature:
-proc getValue: TMyEnum = valueD
-
-# trick the optimizer with a variable:
-var x = getValue()
-echo valueA, ord(valueA), valueB, ord(valueB), valueC, valueD, ord(valueD), x
+echo Holed(x[0]),ord Holed(x[0]),Holed(x[1]),ord Holed(x[1]),Holed(x[2]),ord Holed(x[2])
 
 
 

--- a/tests/enum/tenumoffset.nim
+++ b/tests/enum/tenumoffset.nim
@@ -1,0 +1,20 @@
+discard """
+  file: "tenumoffset.nim"
+  output: "my value A1my value Bconc2valueCabc4abc"
+"""
+
+const
+  strValB = "my value B"
+
+type
+  TMyEnum = enum
+    valueA = (1, "my value A"),
+    valueB = strValB & "conc",
+    valueC,
+    valueD = (4, "abc")
+
+proc getValue(i:int): TMyEnum = TMyEnum(i)
+
+# trick the optimizer with a variable:
+var x = getValue(4)
+echo getValue(1), ord(valueA), getValue(2), ord(valueB), getValue(3), getValue(4), ord(valueD), x

--- a/tests/js/tbasicenum.nim
+++ b/tests/js/tbasicenum.nim
@@ -1,0 +1,10 @@
+discard """
+  output: "ABCDC"
+"""
+
+type
+  MyEnum = enum
+    A,B,C,D
+# trick the optimizer with an seq:
+var x = @[A,B,C,D]
+echo x[0],x[1],x[2],x[3],MyEnum(2)

--- a/tests/js/tenumhole.nim
+++ b/tests/js/tenumhole.nim
@@ -10,7 +10,3 @@ type Holed = enum
 var x = @[0,32,64] # This is just to avoid the compiler inlining the value of the enum
 
 echo Holed(x[0]),ord Holed(x[0]),Holed(x[1]),ord Holed(x[1]),Holed(x[2]),ord Holed(x[2])
-
-
-
-

--- a/tests/js/tenumhole.nim
+++ b/tests/js/tenumhole.nim
@@ -1,0 +1,16 @@
+discard """
+  output: "first0second32third64"
+"""
+
+type Holed = enum
+  hFirst = (0,"first")
+  hSecond = (32,"second")
+  hThird = (64,"third")
+  
+var x = @[0,32,64] # This is just to avoid the compiler inlining the value of the enum
+
+echo Holed(x[0]),ord Holed(x[0]),Holed(x[1]),ord Holed(x[1]),Holed(x[2]),ord Holed(x[2])
+
+
+
+

--- a/tests/js/tenumnegkey.nim
+++ b/tests/js/tenumnegkey.nim
@@ -10,7 +10,3 @@ type Holed = enum
 var x = @[-12,32,64] # This is just to avoid the compiler inlining the value of the enum
 
 echo Holed(x[0]),ord Holed(x[0]),Holed(x[1]),ord Holed(x[1]),Holed(x[2]),ord Holed(x[2])
-
-
-
-

--- a/tests/js/tenumnegkey.nim
+++ b/tests/js/tenumnegkey.nim
@@ -1,0 +1,16 @@
+discard """
+  output: "first-12second32third64"
+"""
+
+type Holed = enum
+  hFirst = (-12,"first")
+  hSecond = (32,"second")
+  hThird = (64,"third")
+  
+var x = @[-12,32,64] # This is just to avoid the compiler inlining the value of the enum
+
+echo Holed(x[0]),ord Holed(x[0]),Holed(x[1]),ord Holed(x[1]),Holed(x[2]),ord Holed(x[2])
+
+
+
+

--- a/tests/js/tenumoffset.nim
+++ b/tests/js/tenumoffset.nim
@@ -1,0 +1,19 @@
+discard """
+  output: "my value A1my value Bconc2valueCabc4abc"
+"""
+
+const
+  strValB = "my value B"
+
+type
+  TMyEnum = enum
+    valueA = (1, "my value A"),
+    valueB = strValB & "conc",
+    valueC,
+    valueD = (4, "abc")
+
+proc getValue(i:int): TMyEnum = TMyEnum(i)
+
+# trick the optimizer with a variable:
+var x = getValue(4)
+echo getValue(1), ord(valueA), getValue(2), ord(valueB), getValue(3), getValue(4), ord(valueD), x


### PR DESCRIPTION
Change enums from js arrays to js object, using the offset of each element as index.  
This fixes  #5062, I also added some basic tests for enums with holes and offsets.

The behaviour should be the same, as non-holed enums simply have offsets starting from 0, but
the set of tests for the js target is a bit small, so I'd like some more validation.
