### PR TITLE
Del callSoon from callback=

### DIFF
--- a/lib/pure/includes/asyncfutures.nim
+++ b/lib/pure/includes/asyncfutures.nim
@@ -171,7 +171,7 @@ proc `callback=`*(future: FutureBase, cb: proc () {.closure,gcsafe.}) =
   ## passes ``future`` as a param to the callback.
   future.cb = cb
   if future.finished:
-    callSoon(future.cb)
+    cb()
 
 proc `callback=`*[T](future: Future[T],
     cb: proc (future: Future[T]) {.closure,gcsafe.}) =


### PR DESCRIPTION
Don't you think it's more flexible? 

In this way,  we don't need to rely on ``runForever()``.

```nim
proc f1(): Future[void] =
  var retFut = newFuture[void]()
  result = retFut
  echo "done f1"
  complete(retFut)

proc f2(): Future[void] =
  var retFut = newFuture[void]()
  result = retFut
  var f = f1()
  f.callback = proc () =
    echo "done f1 again"
  f.callback = proc () =
    echo "done f1 again again"
  complete(retFut)

asyncCheck f2()
```