### PR TITLE
Add clear() function for OrderedSet and HashSet.

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -41,6 +41,18 @@ type
 
 {.deprecated: [TSet: HashSet].}
 
+template default[T](t: typedesc[T]): T =
+  var v: T
+  v
+
+proc clear*[A](s: var HashSet[A]) = 
+  ## Clears the HashSet back to an empty state, without reallocating
+  ## any of the existing storage. O(n) where n is the size of the hash bucket.
+  s.counter = 0
+  for i in 0..<s.data.len:
+    s.data[i].hcode = 0
+    s.data[i].key   = default(type(s.data[i].key))
+
 # hcode for real keys cannot be zero.  hcode==0 signifies an empty slot.  These
 # two procs retain clarity of that encoding without the space cost of an enum.
 proc isEmpty(hcode: Hash): bool {.inline.} =

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -42,11 +42,12 @@ type
 {.deprecated: [TSet: HashSet].}
 
 template default[T](t: typedesc[T]): T =
+  ## Used by clear methods to get a default value.
   var v: T
   v
 
 proc clear*[A](s: var HashSet[A]) = 
-  ## Clears the HashSet back to an empty state, without reallocating
+  ## Clears the HashSet back to an empty state, without shrinking
   ## any of the existing storage. O(n) where n is the size of the hash bucket.
   s.counter = 0
   for i in 0..<s.data.len:
@@ -592,6 +593,18 @@ type
     counter, first, last: int
 
 {.deprecated: [TOrderedSet: OrderedSet].}
+
+proc clear*[A](s: var OrderedSet[A]) = 
+  ## Clears the OrderedSet back to an empty state, without shrinking
+  ## any of the existing storage. O(n) where n is the size of the hash bucket.
+  s.counter = 0
+  s.first = -1
+  s.last = -1
+  for i in 0..<s.data.len:
+    s.data[i].hcode = 0
+    s.data[i].next = 0
+    s.data[i].key = default(type(s.data[i].key))
+
 
 proc isValid*[A](s: OrderedSet[A]): bool =
   ## Returns `true` if the ordered set has been initialized with `initSet

--- a/tests/collections/tsets.nim
+++ b/tests/collections/tsets.nim
@@ -34,4 +34,46 @@ block setWithSequences:
   doAssert s.contains(@[1, 2, 3])
   doAssert( not s.contains(@[4, 5, 6]) )
 
+block setClearWorked:
+  var s = initSet[char]() 
+
+  for c in "this is a test":
+    s.incl(c)
+
+  doAssert len(s) == 7
+  clear(s)
+  doAssert len(s) == 0
+
+  s.incl('z')
+  for c in "this is a test":
+    s.incl(c)
+
+  doAssert len(s) == 8
+
+block orderedSetClearWorked:
+  var s = initOrderedSet[char]()
+
+  for c in "eat at joes":
+    s.incl(c)
+
+  var r = ""
+
+  for c in items(s):
+    add(r, c)
+
+  doAssert r == "eat jos"
+  clear(s)
+
+  s.incl('z')
+  for c in "eat at joes":
+    s.incl(c)
+
+  r = "" 
+  for c in items(s):
+    add(r, c)
+
+  doAssert r == "zeat jos"
+
+
+
 


### PR DESCRIPTION
Same as the clear function in collections/tables.  The implementation is pretty much the same as the tables implementation modulo field name differences.