### PR TITLE
fix #5296

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -577,6 +577,9 @@ proc trackOperand(tracked: PEffects, n: PNode, paramType: PType) =
         markGcUnsafe(tracked, a)
       elif tfNoSideEffect notin op.flags:
         markSideEffect(tracked, a)
+  if paramType != nil and paramType.kind == tyVar:
+    if n.kind == nkSym and isLocalVar(tracked, n.sym):
+      makeVolatile(tracked, n.sym)
   notNilCheck(tracked, n, paramType)
 
 proc breaksBlock(n: PNode): bool =

--- a/tests/ccgbugs/t5296.nim
+++ b/tests/ccgbugs/t5296.nim
@@ -1,0 +1,14 @@
+discard """
+cmd: "nim c -d:release $file"
+output: 1
+"""
+
+proc bug() : void =
+    var x = 0
+    try:
+        inc x
+        raise new(Exception)
+    except Exception:
+        echo x
+
+bug()


### PR DESCRIPTION
My patch follows the rest of the logic in sempass2, but don't we introduce too many volatile variables? We can try to detect only the variables used in the `except:` block.