### PR TITLE
fix getTypeImpl for tyEnum

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -214,7 +214,12 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
         result = atomicType(t.sym)
   of tyEnum:
     result = newNodeIT(nkEnumTy, if t.n.isNil: info else: t.n.info, t)
-    result.add copyTree(t.n)
+    if inst:
+      result.add ast.emptyNode
+      for c in t.n.sons:
+        result.add copyTree(c)
+    else:
+      result.add copyTree(t.n)
   of tyTuple:
     if inst:
       result = newNodeX(nkTupleTy)

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -214,12 +214,9 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
         result = atomicType(t.sym)
   of tyEnum:
     result = newNodeIT(nkEnumTy, if t.n.isNil: info else: t.n.info, t)
-    if inst:
-      result.add ast.emptyNode
-      for c in t.n.sons:
-        result.add copyTree(c)
-    else:
-      result.add copyTree(t.n)
+    result.add ast.emptyNode  # pragma node, currently always empty for enum
+    for c in t.n.sons:
+      result.add copyTree(c)
   of tyTuple:
     if inst:
       result = newNodeX(nkTupleTy)

--- a/web/news/e031_version_0_16_2.rst
+++ b/web/news/e031_version_0_16_2.rst
@@ -38,6 +38,10 @@ Changes affecting backwards compatibility
   upfront every implementation needs to fullfill these contracts.
 - ``system.getAst templateCall(x, y)`` now typechecks the ``templateCall``
   properly. You need to patch your code accordingly.
+- ``macros.getType`` and ``macros.getTypeImpl`` for an enum will now return an
+  AST that is the same as what is used to define an enum.  Previously the AST
+  returned had a repeated ``EnumTy`` node and was missing the initial pragma
+  node (which is currently empty for an enum).
 
 
 Library Additions


### PR DESCRIPTION
Currently getTypeImpl for an enum returns something like:
```nim
EnumTy
  EnumTy
    Sym "valueA"
    Sym "valueB"
    Sym "valueC"
```
This changes the result to
```nim
EnumTy
  Empty
  Sym "valueA"
  Sym "valueB"
  Sym "valueC"
```
which is what the AST that creates the type looks like.  This does not change getType, which currently returns the first version with the double ```EnumTy```.  I can change that too if desired.