### PR TITLE
Implementing `repr` for JS

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1629,13 +1629,21 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     return
   let t = skipTypes(n.sons[1].typ, abstractVarRange)
   case t.kind
-  of tyInt..tyUInt64:
-    unaryExpr(p, n, r, "", "(\"\"+ ($1))")
+  of tyInt..tyInt64,tyUInt..tyUInt64:
+    unaryExpr(p, n, r, "reprInt", "reprInt($1)")
+  of tyChar:
+    unaryExpr(p, n, r, "reprChar", "reprChar($1)")
+  of tyBool:
+    unaryExpr(p, n, r, "reprBool", "reprBool($1)")
+  of tyFloat..tyFloat128:
+    unaryExpr(p,n,r, "reprFloat","reprFloat($1)")
+  of tyString:
+    unaryExpr(p,n,r,"reprStr","reprStr($1)")
   of tyEnum, tyOrdinal:
+    useMagic(p, "reprEnum")
     gen(p, n.sons[1], r)
-    useMagic(p, "cstrToNimstr")
     r.kind = resExpr
-    r.res = "cstrToNimstr($1.node.sons[$2].name)" % [genTypeInfo(p, t), r.res]
+    r.res = "reprEnum($1,$2)" % [r.res,genTypeInfo(p, t)]
   else:
     # XXX:
     internalError(n.info, "genRepr: Not implemented")

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1659,17 +1659,22 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     useMagic(p, "reprSet")
     r.kind = resExpr
     r.res = "reprSet($1,$2)" % [r.res,genTypeInfo(p, t)]
-  of tyArray,tySequence:
-    useMagic(p, "reprAny")
-    r.kind = resExpr
-    r.res = "reprAny($1,$2)" % [r.res,genTypeInfo(p, t)]
+  of tyEmpty, tyVoid:
+    localError(n.info, "'repr' doesn't support 'void' type")
+  #of tyCString, tyArray, tyRef, tyPtr, tyPointer, tyNil, tySequence:
   of tyPointer:
+    # TODO: investigate why the element pointed to is passed as first arg to rawEcho
     useMagic(p, "reprPointer")
     r.kind = resExpr
     r.res = "reprPointer($1)" % [r.res]
   else:
-    # XXX:
-    internalError(n.info, "genRepr: Not implemented: " & $t.kind)
+    useMagic(p, "reprAny")
+    r.kind = resExpr
+    r.res = "reprAny($1,$2)" % [r.res,genTypeInfo(p, t)]
+  
+  #else:
+  #  # XXX:
+  #  internalError(n.info, "genRepr: Not implemented: " & $t.kind)
 
 proc genOf(p: PProc, n: PNode, r: var TCompRes) =
   var x: TCompRes

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1627,41 +1627,46 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
   if p.target == targetPHP:
     localError(n.info, "'repr' not available for PHP backend")
     return
+  gen(p, n.sons[1], r)
+  
   let t = skipTypes(n.sons[1].typ, abstractVarRange)
   case t.kind
   of tyInt..tyInt64,tyUInt..tyUInt64:
-    unaryExpr(p, n, r, "reprInt", "reprInt($1)")
+    useMagic(p, "reprInt")
+    r.res = "reprInt($1)" % [r.rdLoc]
+    r.kind = resExpr
   of tyChar:
-    unaryExpr(p, n, r, "reprChar", "reprChar($1)")
+    useMagic(p, "reprChar")
+    r.res = "reprChar($1)" % [r.rdLoc]
+    r.kind = resExpr
   of tyBool:
-    unaryExpr(p, n, r, "reprBool", "reprBool($1)")
+    useMagic(p, "reprBool")
+    r.res = "reprBool($1)" % [r.rdLoc]
+    r.kind = resExpr
   of tyFloat..tyFloat128:
-    unaryExpr(p,n,r, "reprFloat","reprFloat($1)")
+    useMagic(p, "reprFloat")
+    r.res = "reprFloat($1)" % [r.rdLoc]
+    r.kind = resExpr
   of tyString:
-    unaryExpr(p,n,r,"reprStr","reprStr($1)")
+    useMagic(p, "reprStr")
+    r.res = "reprStr($1)" % [r.rdLoc]
+    r.kind = resExpr
   of tyEnum, tyOrdinal:
     useMagic(p, "reprEnum")
-    gen(p, n.sons[1], r)
     r.kind = resExpr
     r.res = "reprEnum($1,$2)" % [r.res,genTypeInfo(p, t)]
   of tySet:
     useMagic(p, "reprSet")
-    gen(p, n.sons[1], r)
     r.kind = resExpr
     r.res = "reprSet($1,$2)" % [r.res,genTypeInfo(p, t)]
   of tyArray,tySequence:
     useMagic(p, "reprAny")
-    gen(p, n.sons[1], r)
     r.kind = resExpr
-    # The 0 is for the pointer index ( which we assume to start at zero )
     r.res = "reprAny($1,$2)" % [r.res,genTypeInfo(p, t)]
   of tyPointer:
     useMagic(p, "reprPointer")
-    gen(p, n.sons[1], r)
     r.kind = resExpr
-    # The 0 is for the pointer index ( which we assume to start at zero )
     r.res = "reprPointer($1)" % [r.res]
-  
   else:
     # XXX:
     internalError(n.info, "genRepr: Not implemented: " & $t.kind)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1649,15 +1649,22 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     gen(p, n.sons[1], r)
     r.kind = resExpr
     r.res = "reprSet($1,$2)" % [r.res,genTypeInfo(p, t)]
-  of tyArray, tyOpenArray:
+  of tyArray,tySequence:
     useMagic(p, "reprAny")
     gen(p, n.sons[1], r)
     r.kind = resExpr
     # The 0 is for the pointer index ( which we assume to start at zero )
-    r.res = "reprAny($1,0,$2)" % [r.res,genTypeInfo(p, t)]
+    r.res = "reprAny($1,$2)" % [r.res,genTypeInfo(p, t)]
+  of tyPointer:
+    useMagic(p, "reprPointer")
+    gen(p, n.sons[1], r)
+    r.kind = resExpr
+    # The 0 is for the pointer index ( which we assume to start at zero )
+    r.res = "reprPointer($1)" % [r.res]
+  
   else:
     # XXX:
-    internalError(n.info, "genRepr: Not implemented")
+    internalError(n.info, "genRepr: Not implemented: " & $t.kind)
 
 proc genOf(p: PProc, n: PNode, r: var TCompRes) =
   var x: TCompRes

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1652,27 +1652,27 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
   let t = skipTypes(n.sons[1].typ, abstractVarRange)
   case t.kind:
   of tyInt..tyInt64, tyUInt..tyUInt64:
-    genReprAux(p,n,r, "reprInt")
+    genReprAux(p, n, r, "reprInt")
   of tyChar:
-    genReprAux(p,n,r, "reprChar")
+    genReprAux(p, n, r, "reprChar")
   of tyBool:
-    genReprAux(p,n,r, "reprBool")
+    genReprAux(p, n, r, "reprBool")
   of tyFloat..tyFloat128:
-    genReprAux(p,n,r, "reprFloat")
+    genReprAux(p, n, r, "reprFloat")
   of tyString:
-    genReprAux(p,n,r, "reprStr")
+    genReprAux(p, n, r, "reprStr")
   of tyEnum, tyOrdinal:
-    genReprAux(p,n,r, "reprEnum", genTypeInfo(p,t))
+    genReprAux(p, n, r, "reprEnum", genTypeInfo(p, t))
   of tySet:
-    genReprAux(p,n,r, "reprSet", genTypeInfo(p,t))
+    genReprAux(p, n, r, "reprSet", genTypeInfo(p, t))
   of tyEmpty, tyVoid:
     localError(n.info, "'repr' doesn't support 'void' type")
   of tyPointer: 
-    genReprAux(p,n,r, "reprPointer")
+    genReprAux(p, n, r, "reprPointer")
   of tyOpenArray, tyVarargs:
-    genReprAux(p,n,r, "reprJSONStringify")
+    genReprAux(p, n, r, "reprJSONStringify")
   else:
-    genReprAux(p,n,r, "reprAny", genTypeInfo(p,t))
+    genReprAux(p, n, r, "reprAny", genTypeInfo(p, t))
 
 proc genOf(p: PProc, n: PNode, r: var TCompRes) =
   var x: TCompRes

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1644,6 +1644,11 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     gen(p, n.sons[1], r)
     r.kind = resExpr
     r.res = "reprEnum($1,$2)" % [r.res,genTypeInfo(p, t)]
+  of tySet:
+    useMagic(p, "reprSet")
+    gen(p, n.sons[1], r)
+    r.kind = resExpr
+    r.res = "reprSet($1,$2)" % [r.res,genTypeInfo(p, t)]
   else:
     # XXX:
     internalError(n.info, "genRepr: Not implemented")

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1623,8 +1623,8 @@ proc genToArray(p: PProc; n: PNode; r: var TCompRes) =
     localError(x.info, "'toArray' needs an array literal")
   r.res.add(")")
 
-proc genReprAux(p: PProc, n: PNode, r: var TCompRes, magic:string, typ:Rope = nil) =
-  useMagic(p,magic)
+proc genReprAux(p: PProc, n: PNode, r: var TCompRes, magic: string, typ: Rope = nil) =
+  useMagic(p, magic)
   add(r.res, magic & "(")
   var a: TCompRes
 
@@ -1632,17 +1632,17 @@ proc genReprAux(p: PProc, n: PNode, r: var TCompRes, magic:string, typ:Rope = ni
   if magic == "reprAny":
     # the pointer argument in reprAny is expandend to 
     # (pointedto, pointer), so we need to fill it
-    if a.address.isnil:
+    if a.address.isNil:
       add(r.res, a.res)
       add(r.res, ", null") 
     else:
       add(r.res, "$1, $2" % [a.address, a.res])
   else:
-    add(r.res,a.res)
+    add(r.res, a.res)
 
-  if not typ.isnil:
-    add(r.res,", ")
-    add(r.res,typ)
+  if not typ.isNil:
+    add(r.res, ", ")
+    add(r.res, typ)
   add(r.res, ")")
 
 proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
@@ -1650,8 +1650,8 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     localError(n.info, "'repr' not available for PHP backend")
     return
   let t = skipTypes(n.sons[1].typ, abstractVarRange)
-  case t.kind
-  of tyInt..tyInt64,tyUInt..tyUInt64:
+  case t.kind:
+  of tyInt..tyInt64, tyUInt..tyUInt64:
     genReprAux(p,n,r, "reprInt")
   of tyChar:
     genReprAux(p,n,r, "reprChar")
@@ -1662,17 +1662,17 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
   of tyString:
     genReprAux(p,n,r, "reprStr")
   of tyEnum, tyOrdinal:
-    genReprAux(p,n,r, "reprEnum",genTypeInfo(p,t))
+    genReprAux(p,n,r, "reprEnum", genTypeInfo(p,t))
   of tySet:
-    genReprAux(p,n,r, "reprSet",genTypeInfo(p,t))
+    genReprAux(p,n,r, "reprSet", genTypeInfo(p,t))
   of tyEmpty, tyVoid:
     localError(n.info, "'repr' doesn't support 'void' type")
   of tyPointer: 
     genReprAux(p,n,r, "reprPointer")
-  of tyOpenArray,tyVarargs:
+  of tyOpenArray, tyVarargs:
     genReprAux(p,n,r, "reprJSONStringify")
   else:
-    genReprAux(p,n,r,"reprAny",genTypeInfo(p,t))
+    genReprAux(p,n,r, "reprAny", genTypeInfo(p,t))
 
 proc genOf(p: PProc, n: PNode, r: var TCompRes) =
   var x: TCompRes

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1669,6 +1669,8 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     localError(n.info, "'repr' doesn't support 'void' type")
   of tyPointer: 
     genReprAux(p,n,r, "reprPointer")
+  of tyOpenArray,tyVarargs:
+    genReprAux(p,n,r, "reprJSONStringify")
   else:
     genReprAux(p,n,r,"reprAny",genTypeInfo(p,t))
 

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1649,6 +1649,12 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     gen(p, n.sons[1], r)
     r.kind = resExpr
     r.res = "reprSet($1,$2)" % [r.res,genTypeInfo(p, t)]
+  of tyArray, tyOpenArray:
+    useMagic(p, "reprAny")
+    gen(p, n.sons[1], r)
+    r.kind = resExpr
+    # The 0 is for the pointer index ( which we assume to start at zero )
+    r.res = "reprAny($1,0,$2)" % [r.res,genTypeInfo(p, t)]
   else:
     # XXX:
     internalError(n.info, "genRepr: Not implemented")

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -157,8 +157,8 @@ proc genTypeInfo(p: PProc, typ: PType): Rope =
          [result, genTypeInfo(p, t.lastSon)])
   of tyArray:
     var s =
-      "var $1 = {size: $3,kind: $2,base: null,node: null,finalizer: null};$n" %
-              [result, rope(ord(t.kind)), rope(lengthOrd(t))]
+      "var $1 = {size: 0,kind: $2,base: null,node: null,finalizer: null};$n" %
+              [result, rope(ord(t.kind))]
     prepend(p.g.typeInfo, s)
     addf(p.g.typeInfo, "$1.base = $2;$n",
          [result, genTypeInfo(p, t.sons[1])])

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -157,8 +157,8 @@ proc genTypeInfo(p: PProc, typ: PType): Rope =
          [result, genTypeInfo(p, t.lastSon)])
   of tyArray:
     var s =
-      "var $1 = {size: 0,kind: $2,base: null,node: null,finalizer: null};$n" %
-              [result, rope(ord(t.kind))]
+      "var $1 = {size: $3,kind: $2,base: null,node: null,finalizer: null};$n" %
+              [result, rope(ord(t.kind)), rope(lengthOrd(t))]
     prepend(p.g.typeInfo, s)
     addf(p.g.typeInfo, "$1.base = $2;$n",
          [result, genTypeInfo(p, t.sons[1])])

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -282,12 +282,12 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
     else:
       add result, reprStr(cast[string](p))
   of tyCString:
-    var fp : int
+    var fp : cstring
     asm "`fp` = `p`;"
-    if cast[cstring](fp).isnil:
+    if fp.isnil:
       add result, "nil"
     else:
-      reprStrAux(result,cast[ptr string](p)[], cast[ptr string](p)[].len)
+      reprStrAux(result,fp, fp.len)
   of tyEnum, tyOrdinal:
     var fp : int
     asm "`fp` = `p`;"

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -8,7 +8,11 @@
 #
 
 proc reprInt(x: int64): string {.compilerproc.} = return $x
-proc reprFloat(x: float): string {.compilerproc.} = return $x
+proc reprFloat(x: float): string {.compilerproc.} = 
+  # Js toString doesn't differentiate between 1.0 and 1,
+  # but we do.
+  if $x == $(x.int): $x & ".0"
+  else: $x
 
 proc reprBool(x: bool): string {.compilerRtl.} =
   if x: result = "true"
@@ -138,3 +142,130 @@ proc reprSetAux(result: var string, s:int, typ: PNimType) {.asmNoStackFrame.}=
 proc reprSet(e: int, typ: PNimType): string {.compilerRtl.} =
   result = ""
   reprSetAux(result, e, typ)
+
+type
+  ReprClosure {.final.} = object
+    recdepth: int       # do not recurse endlessly
+    indent: int         # indentation
+
+proc initReprClosure(cl: var ReprClosure) =
+  cl.recdepth = -1      # default is to display everything!
+  cl.indent = 0
+
+proc reprBreak(result: var string, cl: ReprClosure) =
+  add result, "\n"
+  for i in 0..cl.indent-1: add result, ' '
+
+proc reprAux(result: var string, p: pointer, typ: PNimType, cl: var ReprClosure) 
+
+proc reprArray(p: pointer, typ: PNimType, 
+              cl: var ReprClosure):string {.compilerRtl.} =
+  result = "["
+  for i in 0 .. < typ.size:
+    if i > 0: add result, ", "
+    reprAux(result, p, typ.base, cl )
+    # We know the actual pointer in js has a `_Idx` suffix, 
+    # so we cheat and advance the pointer. 
+    # If c can do pointer math we are allowd this, right?
+    asm "`p`_Idx++;"
+
+  add result, "]"
+
+proc reprAux(result: var string, p: pointer, typ: PNimType, 
+            cl: var ReprClosure) =
+  if cl.recdepth == 0:
+    add result, "..."
+    return
+  dec(cl.recdepth)
+  case typ.kind
+  of tyInt..tyInt64,tyUInt..tyUInt64:
+    add result, reprInt(cast[ptr int](p)[])
+  of tyChar:
+    add result, reprChar(cast[ptr char](p)[])
+  of tyBool:
+    add result, reprBool(cast[ptr bool](p)[])
+  of tyFloat..tyFloat128:
+    add result, reprFloat(cast[ptr float](p)[])
+  of tyString:
+    add result, reprStr(cast[ptr string](p)[])
+  of tyEnum, tyOrdinal:
+    add result, reprEnum(cast[ptr int](p)[],typ)
+  of tySet:
+    add result, reprSet(cast[ptr int](p)[],typ)
+  of tyArray:
+    add result, reprArray(p,typ,cl)
+  else:
+    add result, "(invalid data!)"
+  inc(cl.recdepth)
+
+proc reprAny(p: pointer, typ: PNimType): string {.compilerRtl.}=
+  var
+    cl: ReprClosure
+  initReprClosure(cl)
+  result = ""
+  if typ.kind in {tyObject, tyTuple, tyArray, tyArrayConstr, tySet}:
+    reprAux(result, p, typ, cl)
+  else:
+    var p = p
+    reprAux(result, addr(p), typ, cl)
+  add result, "\n"
+
+#[]
+
+proc reprAux(result: var string, p: pointer, typ: PNimType,
+              cl: var ReprClosure) {.benign.}
+
+  proc reprAux(result: var string, p: pointer, typ: PNimType,
+               cl: var ReprClosure) =
+    if cl.recdepth == 0:
+      add result, "..."
+      return
+    dec(cl.recdepth)
+    case typ.kind
+    of tyArray, tyArrayConstr: reprArray(result, p, typ, cl)
+    #[
+    of tySet: reprSetAux(result, p, typ)
+    of tyArray, tyArrayConstr: reprArray(result, p, typ, cl)
+    of tyTuple: reprRecord(result, p, typ, cl)
+    of tyObject:
+      var t = cast[ptr PNimType](p)[]
+      reprRecord(result, p, t, cl)
+    of tyRef, tyPtr:
+      sysAssert(p != nil, "reprAux")
+      if cast[PPointer](p)[] == nil: add result, "nil"
+      else: reprRef(result, cast[PPointer](p)[], typ, cl)
+    of tySequence:
+      reprSequence(result, cast[PPointer](p)[], typ, cl)
+    of tyInt: add result, $(cast[ptr int](p)[])
+    of tyInt8: add result, $int(cast[ptr int8](p)[])
+    of tyInt16: add result, $int(cast[ptr int16](p)[])
+    of tyInt32: add result, $int(cast[ptr int32](p)[])
+    of tyInt64: add result, $(cast[ptr int64](p)[])
+    of tyUInt: add result, $(cast[ptr uint](p)[])
+    of tyUInt8: add result, $(cast[ptr uint8](p)[])
+    of tyUInt16: add result, $(cast[ptr uint16](p)[])
+    of tyUInt32: add result, $(cast[ptr uint32](p)[])
+    of tyUInt64: add result, $(cast[ptr uint64](p)[])
+
+    of tyFloat: add result, $(cast[ptr float](p)[])
+    of tyFloat32: add result, $(cast[ptr float32](p)[])
+    of tyFloat64: add result, $(cast[ptr float64](p)[])
+    of tyEnum: add result, reprEnum(getInt(p, typ.size), typ)
+    of tyBool: add result, reprBool(cast[ptr bool](p)[])
+    of tyChar: add result, reprChar(cast[ptr char](p)[])
+    of tyString:
+      let sp = cast[ptr string](p)
+      reprStrAux(result, if sp[].isNil: nil else: sp[].cstring, sp[].len)
+    of tyCString:
+      let cs = cast[ptr cstring](p)[]
+      if cs.isNil: add result, "nil"
+      else: reprStrAux(result, cs, cs.len)
+    of tyRange: reprAux(result, p, typ.base, cl)
+    of tyProc, tyPointer:
+      if cast[PPointer](p)[] == nil: add result, "nil"
+      else: add result, reprPointer(cast[PPointer](p)[])
+    ]#
+    else:
+      add result, "(invalid data!)"
+    inc(cl.recdepth)
+]#

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -297,7 +297,7 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
     asm "`fp` = `p`;"
     add result, reprSet(fp,typ)
   of tyRange: reprAux(result,p,typ.base,cl)
-  of tyObject:
+  of tyObject,tyTuple:
     add result, reprRecord(p,typ,cl)
   of tyArray,tyArrayConstr,tySequence:
     add result, reprArray(p,typ,cl)

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -14,6 +14,9 @@ proc reprFloat(x: float): string {.compilerproc.} =
   if $x == $(x.int): $x & ".0"
   else: $x
 
+proc reprPointer(x: int): string {.compilerproc.} = $x
+  
+
 proc reprBool(x: bool): string {.compilerRtl.} =
   if x: result = "true"
   else: result = "false"
@@ -86,7 +89,7 @@ proc addSetElem(result: var string, elem: int, typ: PNimType) =
     add result, " (invalid data!)"
 
 iterator SetKeys(s:int): int {.inline.} =
-  # The type of s is a lie, it's expected to be a set.
+  # The type of s is a lie, but it's expected to be a set.
   # This means every key has to be a positive integer.
   # Iterate over the JS object representing a set 
   # and returns the keys as int.
@@ -102,6 +105,22 @@ iterator SetKeys(s:int): int {.inline.} =
     yield yieldRes
     inc i
 
+iterator ArrayItems(s:int): int {.inline.} =
+  # The type of s is a lie, but it's expected to be an array.
+  # This means every key has to be a positive integer.
+  # Iterate over the JS array items,
+  # and returns the element as a (fake) int.
+  var len: int
+  var yieldRes : int
+  var i : int = 0
+  asm """
+  `len` = `s`.length;
+  """
+  while i<len:
+    asm "`yieldRes` = `s`[`i`];\n"
+    yield yieldRes
+    inc i
+
 proc reprSetAux(result: var string, s:int, typ: PNimType) {.asmNoStackFrame.}=
   add result, "{"
   var first : bool = true
@@ -112,7 +131,7 @@ proc reprSetAux(result: var string, s:int, typ: PNimType) {.asmNoStackFrame.}=
       add result, ", "
     addSetElem(result,el,typ.base)
   #[
-  Alternative:
+  Alternative without iterator:
 
   let fieldcount: int = 0 # we cheat using asm to set it to its value.
   var el : int
@@ -136,7 +155,8 @@ proc reprSetAux(result: var string, s:int, typ: PNimType) {.asmNoStackFrame.}=
       asm "`el` = parseInt(setObjKeys[`i`],10);\n"
       if i != fieldcount-1:
         add result, ", "
-      addSetElem(result,el,typ.base)]#
+      addSetElem(result,el,typ.base)
+  ]#
   add result, "}"
 
 proc reprSet(e: int, typ: PNimType): string {.compilerRtl.} =
@@ -156,22 +176,27 @@ proc reprBreak(result: var string, cl: ReprClosure) =
   add result, "\n"
   for i in 0..cl.indent-1: add result, ' '
 
-proc reprAux(result: var string, p: pointer, typ: PNimType, cl: var ReprClosure) 
+proc reprAux(result: var string, p: int, typ: PNimType, cl: var ReprClosure) 
 
-proc reprArray(p: pointer, typ: PNimType, 
+proc reprArray(a: int, typ: PNimType, 
               cl: var ReprClosure):string {.compilerRtl.} =
-  result = "["
+  result = if typ.kind == tySequence: "@[" else: "["
+  #[]
   for i in 0 .. < typ.size:
     if i > 0: add result, ", "
     reprAux(result, p, typ.base, cl )
-    # We know the actual pointer in js has a `_Idx` suffix, 
-    # so we cheat and advance the pointer. 
-    # If c can do pointer math we are allowd this, right?
-    asm "`p`_Idx++;"
-
+    #echo (p.pointToUndefined)
+    asm "`p`_Idx++;"]#
+  var first : bool = true
+  for el in ArrayItems(a):
+    if first:
+      first  = false
+    else:
+      add result, ", "
+    reprAux(result, el, typ.base, cl )  
   add result, "]"
 
-proc reprAux(result: var string, p: pointer, typ: PNimType, 
+proc reprAux(result: var string, p: int, typ: PNimType, 
             cl: var ReprClosure) =
   if cl.recdepth == 0:
     add result, "..."
@@ -179,26 +204,26 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
   dec(cl.recdepth)
   case typ.kind
   of tyInt..tyInt64,tyUInt..tyUInt64:
-    add result, reprInt(cast[ptr int](p)[])
+    add result, reprInt(p)    
   of tyChar:
-    add result, reprChar(cast[ptr char](p)[])
+    add result, reprChar(cast[char](p))    
   of tyBool:
-    add result, reprBool(cast[ptr bool](p)[])
+    add result, reprBool(cast[bool](p))    
   of tyFloat..tyFloat128:
-    add result, reprFloat(cast[ptr float](p)[])
+    add result, reprFloat(cast[float](p))
   of tyString:
-    add result, reprStr(cast[ptr string](p)[])
+    add result, reprStr(cast[string](p))
   of tyEnum, tyOrdinal:
-    add result, reprEnum(cast[ptr int](p)[],typ)
+    add result, reprEnum(p,typ)
   of tySet:
-    add result, reprSet(cast[ptr int](p)[],typ)
-  of tyArray:
+    add result, reprSet(p,typ)
+  of tyArray,tySequence:
     add result, reprArray(p,typ,cl)
   else:
     add result, "(invalid data!)"
   inc(cl.recdepth)
 
-proc reprAny(p: pointer, typ: PNimType): string {.compilerRtl.}=
+proc reprAny(p: int, typ: PNimType): string {.compilerRtl.}=
   var
     cl: ReprClosure
   initReprClosure(cl)
@@ -206,66 +231,5 @@ proc reprAny(p: pointer, typ: PNimType): string {.compilerRtl.}=
   if typ.kind in {tyObject, tyTuple, tyArray, tyArrayConstr, tySet}:
     reprAux(result, p, typ, cl)
   else:
-    var p = p
-    reprAux(result, addr(p), typ, cl)
+    reprAux(result, p, typ, cl)
   add result, "\n"
-
-#[]
-
-proc reprAux(result: var string, p: pointer, typ: PNimType,
-              cl: var ReprClosure) {.benign.}
-
-  proc reprAux(result: var string, p: pointer, typ: PNimType,
-               cl: var ReprClosure) =
-    if cl.recdepth == 0:
-      add result, "..."
-      return
-    dec(cl.recdepth)
-    case typ.kind
-    of tyArray, tyArrayConstr: reprArray(result, p, typ, cl)
-    #[
-    of tySet: reprSetAux(result, p, typ)
-    of tyArray, tyArrayConstr: reprArray(result, p, typ, cl)
-    of tyTuple: reprRecord(result, p, typ, cl)
-    of tyObject:
-      var t = cast[ptr PNimType](p)[]
-      reprRecord(result, p, t, cl)
-    of tyRef, tyPtr:
-      sysAssert(p != nil, "reprAux")
-      if cast[PPointer](p)[] == nil: add result, "nil"
-      else: reprRef(result, cast[PPointer](p)[], typ, cl)
-    of tySequence:
-      reprSequence(result, cast[PPointer](p)[], typ, cl)
-    of tyInt: add result, $(cast[ptr int](p)[])
-    of tyInt8: add result, $int(cast[ptr int8](p)[])
-    of tyInt16: add result, $int(cast[ptr int16](p)[])
-    of tyInt32: add result, $int(cast[ptr int32](p)[])
-    of tyInt64: add result, $(cast[ptr int64](p)[])
-    of tyUInt: add result, $(cast[ptr uint](p)[])
-    of tyUInt8: add result, $(cast[ptr uint8](p)[])
-    of tyUInt16: add result, $(cast[ptr uint16](p)[])
-    of tyUInt32: add result, $(cast[ptr uint32](p)[])
-    of tyUInt64: add result, $(cast[ptr uint64](p)[])
-
-    of tyFloat: add result, $(cast[ptr float](p)[])
-    of tyFloat32: add result, $(cast[ptr float32](p)[])
-    of tyFloat64: add result, $(cast[ptr float64](p)[])
-    of tyEnum: add result, reprEnum(getInt(p, typ.size), typ)
-    of tyBool: add result, reprBool(cast[ptr bool](p)[])
-    of tyChar: add result, reprChar(cast[ptr char](p)[])
-    of tyString:
-      let sp = cast[ptr string](p)
-      reprStrAux(result, if sp[].isNil: nil else: sp[].cstring, sp[].len)
-    of tyCString:
-      let cs = cast[ptr cstring](p)[]
-      if cs.isNil: add result, "nil"
-      else: reprStrAux(result, cs, cs.len)
-    of tyRange: reprAux(result, p, typ.base, cl)
-    of tyProc, tyPointer:
-      if cast[PPointer](p)[] == nil: add result, "nil"
-      else: add result, reprPointer(cast[PPointer](p)[])
-    ]#
-    else:
-      add result, "(invalid data!)"
-    inc(cl.recdepth)
-]#

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -305,9 +305,11 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
     add result, reprPointer(p)
   of tyPtr,tyRef:
     reprRef(result,p,typ,cl)
-  #of tyProc:
-  #    if cast[PPointer](p)[] == nil: add result, "nil"
-  #    else: add result, reprPointer(cast[PPointer](p)[])
+  of tyProc:
+    if p.ispointedtonil:
+      add result, "nil"
+    else:
+      add result, reprPointer(p)
   else:
     add result, "(invalid data!)"
   inc(cl.recdepth)

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -14,8 +14,8 @@ proc reprFloat(x: float): string {.compilerproc.} =
   if $x == $(x.int): $x & ".0"
   else: $x
 
-proc reprPointer(x: int): string {.compilerproc.} = $x
-  
+proc reprPointer(p: int): string {.compilerproc.} = $p
+  # Do we need to generate the full 8bytes ? In js a pointer is an int anyway
 
 proc reprBool(x: bool): string {.compilerRtl.} =
   if x: result = "true"

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -217,12 +217,18 @@ proc reprAux(result: var string, p: int, typ: PNimType,
   of tyFloat..tyFloat128:
     add result, reprFloat(cast[float](p))
   of tyString:
+    # do we want same behaviour as C?
     add result, reprStr(cast[string](p))
+  of tyCString:
+    if cast[cstring](p).isnil:
+      add result, "nil"
+    else:
+      reprStrAux(result,cast[cstring](p),cast[cstring](p).len)
   of tyEnum, tyOrdinal:
     add result, reprEnum(p,typ)
   of tySet:
     add result, reprSet(p,typ)
-  of tyArray,tySequence:
+  of tyArray,tyArrayConstr,tySequence:
     add result, reprArray(p,typ,cl)
   else:
     add result, "(invalid data!)"

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -241,7 +241,7 @@ proc reprRecordAux(result: var string, o: pointer, typ: PNimType,cl: var ReprClo
     # if the object has only one field, len is 0  and sons is nil, the field is in node
     let key : cstring =  typ.node.name
     add result, $key & " = "
-    asm "`val` = `o`.`key`;\n"
+    asm "`val` = `o`[`key`];\n"
     reprAux(result,val,typ.node.typ,cl)
   else:
     # if the object has more than one field, sons is not nil and contains the fields.

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -157,7 +157,7 @@ proc reprArray(a: pointer, typ: PNimType,
     `dereffed`_Idx = `i`; 
     `dereffed` = `a`[`dereffed`_Idx];
     """ .}
-    reprAux(result, dereffed, typ.base, cl)  
+    reprAux(result, dereffed, typ.base, cl)
   
   add(result, "]")
 
@@ -167,7 +167,7 @@ proc isPointedToNil(p: pointer): bool {.inline.}=
 proc reprRef(result: var string, p: pointer, typ: PNimType,
           cl: var ReprClosure) =
   if p.isPointedToNil:
-    add(result  , "nil")
+    add(result , "nil")
     return
   add( result, "ref " & reprPointer(p) )
   add(result, " --> ")

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -49,7 +49,7 @@ proc reprChar(x: char): string {.compilerRtl.} =
   add(result, "\'")
 
 proc reprStrAux(result: var string, s: cstring, len: int) =
-  add result, "\""
+  add(result, "\"")
   for i in 0 .. <len:
     let c = s[i]
     case c
@@ -246,11 +246,11 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
   of tyEnum, tyOrdinal:
     var fp: int
     {. emit: "`fp` = `p`;\n" .}
-    add(result, reprEnum(fp,typ))
+    add(result, reprEnum(fp, typ))
   of tySet:
     var fp: int
     {. emit: "`fp` = `p`;\n" .}
-    add(result, reprSet(fp,typ))
+    add(result, reprSet(fp, typ))
   of tyRange: reprAux(result, p, typ.base, cl)
   of tyObject, tyTuple:
     add(result, reprRecord(p, typ, cl))

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -259,6 +259,14 @@ proc reprRecord(o: pointer, typ: PNimType,cl: var ReprClosure): string {.compile
   result = ""
   reprRecordAux(result, o, typ,cl)
 
+
+proc reprJSONStringify(p: int): string {.compilerRtl.}=
+  # As a last resort, use stringify
+  # We use this for tyOpenArray, tyVarargs while genTypeInfo is not implemented
+  var tmp : cstring
+  asm "`tmp` = JSON.stringify(`p`);"
+  result = $tmp
+
 proc reprAux(result: var string, p: pointer, typ: PNimType, 
             cl: var ReprClosure) =
   if cl.recdepth == 0:
@@ -311,7 +319,7 @@ proc reprAux(result: var string, p: pointer, typ: PNimType,
     else:
       add result, reprPointer(p)
   else:
-    add result, "(invalid data!)"
+    add result, "(invalid data!)" & reprJsonStringify(cast[int](p))
   inc(cl.recdepth)
 
 proc reprAny(p: pointer, typ: PNimType): string {.compilerRtl.}=

--- a/lib/system/reprjs.nim
+++ b/lib/system/reprjs.nim
@@ -8,16 +8,65 @@
 #
 
 proc reprInt(x: int64): string {.compilerproc.} = return $x
+proc reprFloat(x: float): string {.compilerproc.} = return $x
+
+proc reprBool(x: bool): string {.compilerRtl.} =
+  if x: result = "true"
+  else: result = "false"
+
+proc `$`(x: uint64): string =
+  if x == 0:
+    result = "0"
+  else:
+    var buf: array[60, char]
+    var i = 0
+    var n = x
+    while n != 0:
+      let nn = n div 10'u64
+      buf[i] = char(n - 10'u64 * nn + ord('0'))
+      inc i
+      n = nn
+
+    let half = i div 2
+    # Reverse
+    for t in 0 .. < half: swap(buf[t], buf[i-t-1])
+    result = $buf
+
+proc isUndefined[T](x:T):bool {.inline.} = {.emit: "`result`= `x` === undefined;"}
 
 proc reprEnum(e: int, typ: PNimType): string {.compilerRtl.} =
-  if ntfEnumHole notin typ.flags:
-    if e <% typ.node.len:
-      return $typ.node.sons[e].name
+  # CHECKME: revert to c-like behaviour? (offsets and linear search)
+  if not typ.node.sons[e].isUndefined :
+    $typ.node.sons[e].name
   else:
-    # ugh we need a slow linear search:
-    var n = typ.node
-    var s = n.sons
-    for i in 0 .. n.len-1:
-      if s[i].offset == e: return $s[i].name
-  result = $e & " (invalid data!)"
+    $e & " (invalid data!)"
+  
+proc reprChar(x: char): string {.compilerRtl.} =
+  result = "\'"
+  case x
+  of '"': add result, "\\\""
+  of '\\': add result, "\\\\"
+  of '\128' .. '\255', '\0'..'\31': add result, "\\" & reprInt(ord(x))
+  else: add result, x
+  add result, "\'"
 
+proc reprStrAux(result: var string, s: cstring; len: int) =
+  add result, "\""
+  for i in 0.. <len:
+    let c = s[i]
+    case c
+    of '"': add result, "\\\""
+    of '\\': add result, "\\\\" # BUGFIX: forgotten
+    of '\10': add result, "\\10\"\n\"" # " \n " # better readability
+    of '\128' .. '\255', '\0'..'\9', '\11'..'\31':
+      add result, "\\" & reprInt(ord(c))
+    else:
+      add result, reprInt(ord(c)) # Stop the char being repr'd
+  add result, "\""
+
+proc reprStr(s: string): string {.compilerRtl.} =
+  result = ""
+  if cast[pointer](s).isnil:
+    add result, "nil"
+    return
+  reprStrAux(result, s, s.len)

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -91,9 +91,9 @@ block chars:
 
 block strings:
   let 
-    a:string = "12345"
-    b:string = "hello,repr"
-    c:string = "hi\nthere"
+    a: string = "12345"
+    b: string = "hello,repr"
+    c: string = "hi\nthere"
   when defined js: # C prepends the pointer, JS does not.
     doAssert(repr(a) == "\"12345\"")
     doAssert(repr(b) == "\"hello,repr\"")

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -97,7 +97,7 @@ block strings:
   when defined js: # C prepends the pointer, JS does not.
     doAssert(repr(a) == "\"12345\"")
     doAssert(repr(b) == "\"hello,repr\"")
-    doAssert(repr(c) == "\"hi\nthere\"")  
+    doAssert(repr(c) == "\"hi\nthere\"")
 
 block sets:
   let

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -259,7 +259,7 @@ block procs:
 block bunch:
   type
     AnEnum = enum
-      eA,eB,eC
+      eA, eB, eC
     B = object
       a: string
       b: seq[char] 

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -1,0 +1,340 @@
+block ints:
+  let 
+    na: int8 = -120'i8
+    nb: int16 = -32700'i16
+    nc: int32 = -2147483000'i32
+    nd: int64 = -9223372036854775000'i64
+    ne: int = -1234567
+    pa: int8 = 120'i8
+    pb: int16 = 32700'i16
+    pc: int32 = 2147483000'i32
+    pd: int64 = 9223372036854775000'i64 
+    pe: int = 1234567
+  
+  doassert(repr(na) == "-120")
+  doassert(repr(nb) == "-32700")
+  doassert(repr(nc) == "-2147483000")
+  doassert(repr(nd) ==  "-9223372036854775000")
+  doassert(repr(ne) == "-1234567")
+  doassert(repr(pa) == "120")
+  doassert(repr(pb) == "32700")
+  doassert(repr(pc) == "2147483000")
+  doassert(repr(pd) ==  "9223372036854775000")
+  doassert(repr(pe) == "1234567")
+
+block uints:
+  let 
+    a: uint8 = 254'u8
+    b: uint16 = 65300'u16
+    c: uint32 =  4294967290'u32
+    # d: uint64 = 18446744073709551610'u64  -> unknown node type
+    e: uint = 1234567
+  
+  doassert(repr(a) == "254")
+  doassert(repr(b) == "65300")
+  doassert(repr(c) == "4294967290")
+  # doassert(repr(d) ==  "18446744073709551610")
+  doassert(repr(e) == "1234567")
+
+block floats:
+  let 
+    a: float32 = 3.4e38'f32
+    b: float64 = 1.7976931348623157e308'f64
+    c: float = 1234.567e89
+  
+  when defined js: 
+    doassert(repr(a) == "3.4e+38") # in C: 3.399999952144364e+038
+    doassert(repr(b) == "1.7976931348623157e+308") # in C: 1.797693134862316e+308
+    doassert(repr(c) == "1.234567e+92") # in C: 1.234567e+092
+
+block bools:
+  let 
+    a: bool = true
+    b: bool = false
+  
+  doassert(repr(a) == "true") 
+  doassert(repr(b) == "false")
+
+block enums:
+  type 
+    AnEnum = enum
+      aeA
+      aeB
+      aeC
+    HoledEnum = enum
+      heA = -12
+      heB = 15
+      heC = 123
+  
+  doassert(repr(aeA) == "aeA") 
+  doassert(repr(aeB) == "aeB")
+  doassert(repr(aeC) == "aeC") 
+  doassert(repr(heA) == "heA")
+  doassert(repr(heB) == "heB") 
+  doassert(repr(heC) == "heC")
+
+block chars:
+  let
+    a = 'a'
+    b = 'z'
+    one = '1'
+    nl = '\x0A'
+  
+  doassert(repr(a) == "'a'")
+  doassert(repr(b) == "'z'")
+  doassert(repr(one) == "'1'")
+  doassert(repr(nl) == "'\\10'")
+
+block strings:
+  let 
+    a:string = "12345"
+    b:string = "hello,repr"
+    c:string = "hi\nthere"
+  when defined js: # C prepends the pointer, JS does not.
+    doassert(repr(a) == "\"12345\"")
+    doassert(repr(b) == "\"hello,repr\"")
+    doassert(repr(c) == "\"hi\nthere\"")  
+
+block sets:
+  let
+    a: set[int16] = {1'i16,2'i16,3'i16}
+    b: set[char] = {'A','k'}
+    
+  doassert(repr(a) == "{1, 2, 3}")
+  doassert(repr(b) == "{'A', 'k'}")
+
+block ranges:
+  let 
+    a: range[0..12] = 6
+    b: range[-12..0] = -6
+  doassert(repr(a) == "6")
+  doassert(repr(b) == "-6")
+
+block tuples:
+  type 
+    ATuple = tuple
+      a: int
+      b: float
+      c: string
+      d: OtherTuple
+    OtherTuple = tuple
+      a: bool
+      b: int8
+  
+  let
+    ot: OtherTuple = (a:true,b:120'i8)
+    t: ATuple = (a:42, b:12.34,c:"tuple",d:ot)
+  when defined js:
+    doassert(repr(ot) == """
+[Field0 = true,
+Field1 = 120]
+""")
+    doassert(repr(t) == """
+[Field0 = 42,
+Field1 = 12.34,
+Field2 = "tuple",
+Field3 = [Field0 = true,
+Field1 = 120]]
+""")
+
+block objects:
+  type
+    AnObj = object
+      a: int
+      b: float
+      c: OtherObj
+    OtherObj = object
+      a: bool
+      b: int8
+  let
+    oo: OtherObj = OtherObj(a:true,b:120'i8)
+    o: AnObj = AnObj(a:42, b:12.34,c:oo)
+
+  doassert(repr(oo) == """
+[a = true,
+b = 120]
+""")
+  doassert(repr(o) == """
+[a = 42,
+b = 12.34,
+c = [a = true,
+b = 120]]
+""")
+
+block arrays:
+  type
+    AObj = object
+      x: int
+      y: array[3,float]
+  let
+    a = [0.0,1,2]
+    b = [a,a,a]
+    o = AObj(x:42,y:a)
+    c = [o,o,o]
+    d = ["hi","array","!"]
+    
+  doassert(repr(a) == "[0.0, 1.0, 2.0]\n", repr(a))
+  doassert(repr(b) == "[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]\n")
+  doassert(repr(c) == """
+[[x = 42,
+y = [0.0, 1.0, 2.0]], [x = 42,
+y = [0.0, 1.0, 2.0]], [x = 42,
+y = [0.0, 1.0, 2.0]]]
+""")
+  doassert(repr(d) == "[\"hi\", \"array\", \"!\"]\n")
+
+block seqs:
+  type
+    AObj = object
+      x: int
+      y: seq[float]
+  let
+    a = @[0.0,1,2]
+    b = @[a,a,a]
+    o = AObj(x:42,y:a)
+    c = @[o,o,o]
+    d = @["hi","array","!"]
+    
+  doassert(repr(a) == "@[0.0, 1.0, 2.0]\n", repr(a))
+  doassert(repr(b) == "@[@[0.0, 1.0, 2.0], @[0.0, 1.0, 2.0], @[0.0, 1.0, 2.0]]\n")
+  doassert(repr(c) == """
+@[[x = 42,
+y = @[0.0, 1.0, 2.0]], [x = 42,
+y = @[0.0, 1.0, 2.0]], [x = 42,
+y = @[0.0, 1.0, 2.0]]]
+""")
+  doassert(repr(d) == "@[\"hi\", \"array\", \"!\"]\n")
+
+block ptrs:
+  type 
+    AObj = object
+      x: ptr array[2, AObj]
+      y: int
+  var 
+    a = [12.0,13.0,14.0]
+    b = addr a[0]
+    c = addr a[2]
+    d = AObj()
+  
+  doassert(repr(a) == "[12.0, 13.0, 14.0]\n")
+  doassert(repr(b) == "ref 0 --> 12.0\n")
+  doassert(repr(c) == "ref 2 --> 14.0\n")
+  doassert(repr(d) == """
+[x = nil,
+y = 0]
+""")
+
+block ptrs:
+  type 
+    AObj = object
+      x: ref array[2, AObj]
+      y: int
+  var 
+    a = AObj()
+  
+  new(a.x)
+
+  doassert(repr(a) == """
+[x = ref 0 --> [[x = nil,
+y = 0], [x = nil,
+y = 0]],
+y = 0]
+""")
+
+block procs:
+  proc test(): int =
+    echo "hello"
+  var 
+    ptest = test
+    nilproc: proc(): int
+  
+  doassert(repr(test) == "0\n")
+  doassert(repr(ptest) == "0\n")
+  doassert(repr(nilproc) == "nil\n")
+
+block bunch:
+  type
+    AnEnum = enum
+      eA,eB,eC
+    B = object
+      a: string
+      b: seq[char] 
+    A = object
+      a : uint32
+      b: int
+      c: float
+      d: char
+      e: AnEnum
+      f: string
+      g: set[char]
+      h: set[int16]
+      i: array[3,string]
+      j: seq[string]
+      k: range[-12..12]
+      l: B
+      m: ref B
+      n: ptr B
+      o: tuple[ x: B, y: string]
+      p: proc(b:B):ref B
+      q: cstring
+      
+  proc refB(b:B):ref B =
+    new result
+    result[] = b
+  
+  var
+    aa : A
+    bb : B = B( a: "inner", b: @['o','b','j'])
+    cc : A = A( a:12, b:1, c:1.2, d:'\0', e:eC,
+                f:"hello", g:{'A'}, h: {2'i16},
+                i: ["hello","world","array"], 
+                j: @["hello","world","seq"], k: -1,
+                l:bb, m: refB(bb), n: addr bb,
+                o: (bb, "tuple!"), p: refB, q: "cstringtest" )
+
+  doassert(repr(aa) == """
+[a = 0,
+b = 0,
+c = 0.0,
+d = '\0',
+e = eA,
+f = nil,
+g = {},
+h = {},
+i = [nil, nil, nil],
+j = nil,
+k = 0,
+l = [a = nil,
+b = nil],
+m = nil,
+n = nil,
+o = [Field0 = [a = nil,
+b = nil],
+Field1 = nil],
+p = nil,
+q = nil]
+""")
+  doassert(repr(cc) == """
+[a = 12,
+b = 1,
+c = 1.2,
+d = '\0',
+e = eC,
+f = "hello",
+g = {'A'},
+h = {2},
+i = ["hello", "world", "array"],
+j = @["hello", "world", "seq"],
+k = -1,
+l = [a = "inner",
+b = @['o', 'b', 'j']],
+m = ref 0 --> [a = "inner",
+b = @['o', 'b', 'j']],
+n = ref 0 --> [a = "inner",
+b = @['o', 'b', 'j']],
+o = [Field0 = [a = "inner",
+b = @['o', 'b', 'j']],
+Field1 = "tuple!"],
+p = 0,
+q = "cstringtest"]
+""")

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -1,3 +1,7 @@
+discard """
+  action: run
+"""
+
 block ints:
   let 
     na: int8 = -120'i8
@@ -11,30 +15,30 @@ block ints:
     pd: int64 = 9223372036854775000'i64 
     pe: int = 1234567
   
-  doassert(repr(na) == "-120")
-  doassert(repr(nb) == "-32700")
-  doassert(repr(nc) == "-2147483000")
-  doassert(repr(nd) ==  "-9223372036854775000")
-  doassert(repr(ne) == "-1234567")
-  doassert(repr(pa) == "120")
-  doassert(repr(pb) == "32700")
-  doassert(repr(pc) == "2147483000")
-  doassert(repr(pd) ==  "9223372036854775000")
-  doassert(repr(pe) == "1234567")
+  doAssert(repr(na) == "-120")
+  doAssert(repr(nb) == "-32700")
+  doAssert(repr(nc) == "-2147483000")
+  doAssert(repr(nd) == "-9223372036854775000")
+  doAssert(repr(ne) == "-1234567")
+  doAssert(repr(pa) == "120")
+  doAssert(repr(pb) == "32700")
+  doAssert(repr(pc) == "2147483000")
+  doAssert(repr(pd) == "9223372036854775000")
+  doAssert(repr(pe) == "1234567")
 
 block uints:
   let 
     a: uint8 = 254'u8
     b: uint16 = 65300'u16
-    c: uint32 =  4294967290'u32
+    c: uint32 = 4294967290'u32
     # d: uint64 = 18446744073709551610'u64  -> unknown node type
     e: uint = 1234567
   
-  doassert(repr(a) == "254")
-  doassert(repr(b) == "65300")
-  doassert(repr(c) == "4294967290")
-  # doassert(repr(d) ==  "18446744073709551610")
-  doassert(repr(e) == "1234567")
+  doAssert(repr(a) == "254")
+  doAssert(repr(b) == "65300")
+  doAssert(repr(c) == "4294967290")
+  # doAssert(repr(d) == "18446744073709551610")
+  doAssert(repr(e) == "1234567")
 
 block floats:
   let 
@@ -43,17 +47,17 @@ block floats:
     c: float = 1234.567e89
   
   when defined js: 
-    doassert(repr(a) == "3.4e+38") # in C: 3.399999952144364e+038
-    doassert(repr(b) == "1.7976931348623157e+308") # in C: 1.797693134862316e+308
-    doassert(repr(c) == "1.234567e+92") # in C: 1.234567e+092
+    doAssert(repr(a) == "3.4e+38") # in C: 3.399999952144364e+038
+    doAssert(repr(b) == "1.7976931348623157e+308") # in C: 1.797693134862316e+308
+    doAssert(repr(c) == "1.234567e+92") # in C: 1.234567e+092
 
 block bools:
   let 
     a: bool = true
     b: bool = false
   
-  doassert(repr(a) == "true") 
-  doassert(repr(b) == "false")
+  doAssert(repr(a) == "true") 
+  doAssert(repr(b) == "false")
 
 block enums:
   type 
@@ -66,12 +70,12 @@ block enums:
       heB = 15
       heC = 123
   
-  doassert(repr(aeA) == "aeA") 
-  doassert(repr(aeB) == "aeB")
-  doassert(repr(aeC) == "aeC") 
-  doassert(repr(heA) == "heA")
-  doassert(repr(heB) == "heB") 
-  doassert(repr(heC) == "heC")
+  doAssert(repr(aeA) == "aeA") 
+  doAssert(repr(aeB) == "aeB")
+  doAssert(repr(aeC) == "aeC") 
+  doAssert(repr(heA) == "heA")
+  doAssert(repr(heB) == "heB") 
+  doAssert(repr(heC) == "heC")
 
 block chars:
   let
@@ -80,10 +84,10 @@ block chars:
     one = '1'
     nl = '\x0A'
   
-  doassert(repr(a) == "'a'")
-  doassert(repr(b) == "'z'")
-  doassert(repr(one) == "'1'")
-  doassert(repr(nl) == "'\\10'")
+  doAssert(repr(a) == "'a'")
+  doAssert(repr(b) == "'z'")
+  doAssert(repr(one) == "'1'")
+  doAssert(repr(nl) == "'\\10'")
 
 block strings:
   let 
@@ -91,24 +95,24 @@ block strings:
     b:string = "hello,repr"
     c:string = "hi\nthere"
   when defined js: # C prepends the pointer, JS does not.
-    doassert(repr(a) == "\"12345\"")
-    doassert(repr(b) == "\"hello,repr\"")
-    doassert(repr(c) == "\"hi\nthere\"")  
+    doAssert(repr(a) == "\"12345\"")
+    doAssert(repr(b) == "\"hello,repr\"")
+    doAssert(repr(c) == "\"hi\nthere\"")  
 
 block sets:
   let
-    a: set[int16] = {1'i16,2'i16,3'i16}
-    b: set[char] = {'A','k'}
+    a: set[int16] = {1'i16, 2'i16, 3'i16}
+    b: set[char] = {'A', 'k'}
     
-  doassert(repr(a) == "{1, 2, 3}")
-  doassert(repr(b) == "{'A', 'k'}")
+  doAssert(repr(a) == "{1, 2, 3}")
+  doAssert(repr(b) == "{'A', 'k'}")
 
 block ranges:
   let 
     a: range[0..12] = 6
     b: range[-12..0] = -6
-  doassert(repr(a) == "6")
-  doassert(repr(b) == "-6")
+  doAssert(repr(a) == "6")
+  doAssert(repr(b) == "-6")
 
 block tuples:
   type 
@@ -122,14 +126,14 @@ block tuples:
       b: int8
   
   let
-    ot: OtherTuple = (a:true,b:120'i8)
-    t: ATuple = (a:42, b:12.34,c:"tuple",d:ot)
+    ot: OtherTuple = (a: true, b: 120'i8)
+    t: ATuple = (a: 42, b: 12.34, c: "tuple", d: ot)
   when defined js:
-    doassert(repr(ot) == """
+    doAssert(repr(ot) == """
 [Field0 = true,
 Field1 = 120]
 """)
-    doassert(repr(t) == """
+    doAssert(repr(t) == """
 [Field0 = 42,
 Field1 = 12.34,
 Field2 = "tuple",
@@ -147,14 +151,14 @@ block objects:
       a: bool
       b: int8
   let
-    oo: OtherObj = OtherObj(a:true,b:120'i8)
-    o: AnObj = AnObj(a:42, b:12.34,c:oo)
+    oo: OtherObj = OtherObj(a: true, b: 120'i8)
+    o: AnObj = AnObj(a: 42, b: 12.34, c: oo)
 
-  doassert(repr(oo) == """
+  doAssert(repr(oo) == """
 [a = true,
 b = 120]
 """)
-  doassert(repr(o) == """
+  doAssert(repr(o) == """
 [a = 42,
 b = 12.34,
 c = [a = true,
@@ -167,21 +171,21 @@ block arrays:
       x: int
       y: array[3,float]
   let
-    a = [0.0,1,2]
-    b = [a,a,a]
-    o = AObj(x:42,y:a)
-    c = [o,o,o]
-    d = ["hi","array","!"]
+    a = [0.0, 1, 2]
+    b = [a, a, a]
+    o = AObj(x: 42, y: a)
+    c = [o, o, o]
+    d = ["hi", "array", "!"]
     
-  doassert(repr(a) == "[0.0, 1.0, 2.0]\n", repr(a))
-  doassert(repr(b) == "[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]\n")
-  doassert(repr(c) == """
+  doAssert(repr(a) == "[0.0, 1.0, 2.0]\n")
+  doAssert(repr(b) == "[[0.0, 1.0, 2.0], [0.0, 1.0, 2.0], [0.0, 1.0, 2.0]]\n")
+  doAssert(repr(c) == """
 [[x = 42,
 y = [0.0, 1.0, 2.0]], [x = 42,
 y = [0.0, 1.0, 2.0]], [x = 42,
 y = [0.0, 1.0, 2.0]]]
 """)
-  doassert(repr(d) == "[\"hi\", \"array\", \"!\"]\n")
+  doAssert(repr(d) == "[\"hi\", \"array\", \"!\"]\n")
 
 block seqs:
   type
@@ -189,21 +193,21 @@ block seqs:
       x: int
       y: seq[float]
   let
-    a = @[0.0,1,2]
-    b = @[a,a,a]
-    o = AObj(x:42,y:a)
-    c = @[o,o,o]
-    d = @["hi","array","!"]
+    a = @[0.0, 1, 2]
+    b = @[a, a, a]
+    o = AObj(x: 42, y: a)
+    c = @[o, o, o]
+    d = @["hi", "array", "!"]
     
-  doassert(repr(a) == "@[0.0, 1.0, 2.0]\n", repr(a))
-  doassert(repr(b) == "@[@[0.0, 1.0, 2.0], @[0.0, 1.0, 2.0], @[0.0, 1.0, 2.0]]\n")
-  doassert(repr(c) == """
+  doAssert(repr(a) == "@[0.0, 1.0, 2.0]\n")
+  doAssert(repr(b) == "@[@[0.0, 1.0, 2.0], @[0.0, 1.0, 2.0], @[0.0, 1.0, 2.0]]\n")
+  doAssert(repr(c) == """
 @[[x = 42,
 y = @[0.0, 1.0, 2.0]], [x = 42,
 y = @[0.0, 1.0, 2.0]], [x = 42,
 y = @[0.0, 1.0, 2.0]]]
 """)
-  doassert(repr(d) == "@[\"hi\", \"array\", \"!\"]\n")
+  doAssert(repr(d) == "@[\"hi\", \"array\", \"!\"]\n")
 
 block ptrs:
   type 
@@ -211,15 +215,15 @@ block ptrs:
       x: ptr array[2, AObj]
       y: int
   var 
-    a = [12.0,13.0,14.0]
+    a = [12.0, 13.0, 14.0]
     b = addr a[0]
     c = addr a[2]
     d = AObj()
   
-  doassert(repr(a) == "[12.0, 13.0, 14.0]\n")
-  doassert(repr(b) == "ref 0 --> 12.0\n")
-  doassert(repr(c) == "ref 2 --> 14.0\n")
-  doassert(repr(d) == """
+  doAssert(repr(a) == "[12.0, 13.0, 14.0]\n")
+  doAssert(repr(b) == "ref 0 --> 12.0\n")
+  doAssert(repr(c) == "ref 2 --> 14.0\n")
+  doAssert(repr(d) == """
 [x = nil,
 y = 0]
 """)
@@ -234,7 +238,7 @@ block ptrs:
   
   new(a.x)
 
-  doassert(repr(a) == """
+  doAssert(repr(a) == """
 [x = ref 0 --> [[x = nil,
 y = 0], [x = nil,
 y = 0]],
@@ -248,9 +252,9 @@ block procs:
     ptest = test
     nilproc: proc(): int
   
-  doassert(repr(test) == "0\n")
-  doassert(repr(ptest) == "0\n")
-  doassert(repr(nilproc) == "nil\n")
+  doAssert(repr(test) == "0\n")
+  doAssert(repr(ptest) == "0\n")
+  doAssert(repr(nilproc) == "nil\n")
 
 block bunch:
   type
@@ -260,7 +264,7 @@ block bunch:
       a: string
       b: seq[char] 
     A = object
-      a : uint32
+      a: uint32
       b: int
       c: float
       d: char
@@ -274,8 +278,8 @@ block bunch:
       l: B
       m: ref B
       n: ptr B
-      o: tuple[ x: B, y: string]
-      p: proc(b:B):ref B
+      o: tuple[x: B, y: string]
+      p: proc(b: B): ref B
       q: cstring
       
   proc refB(b:B):ref B =
@@ -283,16 +287,16 @@ block bunch:
     result[] = b
   
   var
-    aa : A
-    bb : B = B( a: "inner", b: @['o','b','j'])
-    cc : A = A( a:12, b:1, c:1.2, d:'\0', e:eC,
-                f:"hello", g:{'A'}, h: {2'i16},
-                i: ["hello","world","array"], 
-                j: @["hello","world","seq"], k: -1,
-                l:bb, m: refB(bb), n: addr bb,
+    aa: A
+    bb: B = B(a: "inner", b: @['o', 'b', 'j'])
+    cc: A = A(a: 12, b: 1, c: 1.2, d: '\0', e: eC,
+                f: "hello", g: {'A'}, h: {2'i16},
+                i: ["hello", "world", "array"], 
+                j: @["hello", "world", "seq"], k: -1,
+                l: bb, m: refB(bb), n: addr bb,
                 o: (bb, "tuple!"), p: refB, q: "cstringtest" )
 
-  doassert(repr(aa) == """
+  doAssert(repr(aa) == """
 [a = 0,
 b = 0,
 c = 0.0,
@@ -314,7 +318,7 @@ Field1 = nil],
 p = nil,
 q = nil]
 """)
-  doassert(repr(cc) == """
+  doAssert(repr(cc) == """
 [a = 12,
 b = 1,
 c = 1.2,
@@ -348,9 +352,9 @@ block another:
     Size3 = enum 
       s3e=0, s3f=2000000000
 
-  doassert(repr([s1a, s1b]) == "[s1a, s1b]\n")
-  doassert(repr([s2c, s2d]) == "[s2c, s2d]\n")
-  doassert(repr([s3e, s3f]) == "[s3e, s3f]\n")
+  doAssert(repr([s1a, s1b]) == "[s1a, s1b]\n")
+  doAssert(repr([s2c, s2d]) == "[s2c, s2d]\n")
+  doAssert(repr([s3e, s3f]) == "[s3e, s3f]\n")
 
 block another2:
   
@@ -360,7 +364,7 @@ block another2:
 
     Point {.final.} = object
       x, y, z: int
-      s: array [0..1, string]
+      s: array[0..1, string]
       e: AnEnum
 
   var
@@ -380,21 +384,21 @@ block another2:
 
   s = @[q, q, q, q]
 
-  doassert(repr(p) == """
+  doAssert(repr(p) == """
 [x = 0,
 y = 13,
 z = 45,
 s = ["abc", "xyz"],
 e = en6]
 """)
-  doassert(repr(q) == """
+  doAssert(repr(q) == """
 ref 0 --> [x = 0,
 y = 13,
 z = 45,
 s = ["abc", "xyz"],
 e = en6]
 """)
-  doassert(repr(s) == """
+  doAssert(repr(s) == """
 @[ref 0 --> [x = 0,
 y = 13,
 z = 45,
@@ -413,6 +417,6 @@ z = 45,
 s = ["abc", "xyz"],
 e = en6]]
 """)
-  doassert(repr(en4) == "en4")
+  doAssert(repr(en4) == "en4")
 
-  doassert(repr({'a'..'p'}) == "{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'}")
+  doAssert(repr({'a'..'p'}) == "{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'}")

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -338,3 +338,81 @@ Field1 = "tuple!"],
 p = 0,
 q = "cstringtest"]
 """)
+
+block another:
+  type 
+    Size1 = enum 
+      s1a, s1b
+    Size2 = enum 
+      s2c=0, s2d=20000
+    Size3 = enum 
+      s3e=0, s3f=2000000000
+
+  doassert(repr([s1a, s1b]) == "[s1a, s1b]\n")
+  doassert(repr([s2c, s2d]) == "[s2c, s2d]\n")
+  doassert(repr([s3e, s3f]) == "[s3e, s3f]\n")
+
+block another2:
+  
+  type
+    AnEnum = enum
+      en1, en2, en3, en4, en5, en6
+
+    Point {.final.} = object
+      x, y, z: int
+      s: array [0..1, string]
+      e: AnEnum
+
+  var
+    p: Point
+    q: ref Point
+    s: seq[ref Point]
+
+  p.x = 0
+  p.y = 13
+  p.z = 45
+  p.s[0] = "abc"
+  p.s[1] = "xyz"
+  p.e = en6
+
+  new(q)
+  q[] = p
+
+  s = @[q, q, q, q]
+
+  doassert(repr(p) == """
+[x = 0,
+y = 13,
+z = 45,
+s = ["abc", "xyz"],
+e = en6]
+""")
+  doassert(repr(q) == """
+ref 0 --> [x = 0,
+y = 13,
+z = 45,
+s = ["abc", "xyz"],
+e = en6]
+""")
+  doassert(repr(s) == """
+@[ref 0 --> [x = 0,
+y = 13,
+z = 45,
+s = ["abc", "xyz"],
+e = en6], ref 1 --> [x = 0,
+y = 13,
+z = 45,
+s = ["abc", "xyz"],
+e = en6], ref 2 --> [x = 0,
+y = 13,
+z = 45,
+s = ["abc", "xyz"],
+e = en6], ref 3 --> [x = 0,
+y = 13,
+z = 45,
+s = ["abc", "xyz"],
+e = en6]]
+""")
+  doassert(repr(en4) == "en4")
+
+  doassert(repr({'a'..'p'}) == "{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'}")


### PR DESCRIPTION
~~**THIS IS NOT COMPLETE YET**~~

I have been working on implementing `repr` for the js backend, to close [#343](https://github.com/nim-lang/Nim/issues/343).  
I open this pr before finishing, to allow for feedback on the way I implemented this, as I am sure there are other ways to implement this that may be better/easier. I'm also not so sure about my approach here, as C made use of a lot of pointers arithmetic that I couldn't get to replicate in JS
I tried to match the output of `repr` in the C backend, but I took some liberties:
- strings aren't prefixed by a pointer
- seqs are prefixed by a `@` instead of a pointer
- `nil` strings are represented as `nil` instead of `""`. This is because strings in an empty array are represented as `nil` ( in C backend ), and also because I think an empty string is different than a `nil` string.

I also needed to use some `asm` statements, mostly for the iterators for array,enum,sets,objects , and to allow checking for undefined.

edit: the only iterator remaining is for sets, but I can remove it.

The code is not final, I intend to do a pass to format the code following the style guide, adjusting the comments I made, adding tests and generally cleaning it up.

Here's a test with output when run with c and when run with js: [gist](https://gist.github.com/stisa/207dbaa726a4dfb49007890b93016990)

State
------

- [x] tySet
- [x] tyArray
  - [~] tyArrayConstr should work, not sure how to test
- [x] tyTuple
- [x] tyObject
- [x] tyRef
- [x] tyPtr
- [x] tySequence
- [x] tyInt - only implemented the 64 one, but all other seem to work
  - tyInt8
  - tyInt16
  - tyInt32
  - tyInt64
- [x] tyUInt - uses the implementation for int, but all other seem to work
  - tyUInt8
  - tyUInt16
  - tyUInt32
  - ~~tyUInt64~~ 
- [x] tyFloat  - only implemented the 64 one, but all other seem to work
  - tyFloat32
  - tyFloat64
- [x] tyEnum
- [x] tyBool
- [x] tyChar
- [x] tyString
- [x] tyCString
- [x] tyRange
- [x] tyProc C seems to treat this a tuple? I treat it as just a pointer.
- [x] tyPointer ~~implemented, but I need to research why in the call to rawecho the element pointed to is passed as first argument~~

edit1: progress on tyPtr,tyRef,tyPointer. Moved to using pointers in reprAny. Will work on tyTuple next.
edit2: Well that was quick. All done, needs testing now.