### PR TITLE
Deques compilation error fix

### DIFF
--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -80,7 +80,7 @@ proc `[]`*[T](deq: Deque[T], i: Natural) : T {.inline.} =
   ## Access the i-th element of `deq` by order from first to last.
   ## deq[0] is the first, deq[^1] is the last.
   xBoundsCheck(deq, i)
-  return deq.data[(deq.first + i) and deq.mask]
+  return deq.data[(deq.head + i) and deq.mask]
 
 proc `[]`*[T](deq: var Deque[T], i: Natural): var T {.inline.} =
   ## Access the i-th element of `deq` and returns a mutable

--- a/tests/collections/tdeques.nim
+++ b/tests/collections/tdeques.nim
@@ -1,0 +1,17 @@
+discard """
+  output: '''true'''
+"""
+
+import deques
+
+
+proc index(self: Deque[int], idx: Natural): int =
+  self[idx]
+
+proc main =
+  var testDeque = initDeque[int]()
+  testDeque.addFirst(1)
+  assert testDeque.index(0) == 1
+
+main()
+echo "true"


### PR DESCRIPTION
Fixes compilation error when the `[]` operator is used on Deque object.
The error:
> lib/nim/pure/collections/deques.nim(83, 23) Error: undeclared field: 'first'
