### PR TITLE
Fix segfault in db_mysql fastRows

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -175,22 +175,31 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
   if sqlres != nil:
     var
       L = int(mysql.numFields(sqlres))
-      backup = newRow(L)
       row: cstringArray
       result: Row
+      backup: Row
     newSeq(result, L)
-    for i in 0..L-1:
-      shallowCopy(result[i], backup[i])
     while true:
       row = mysql.fetchRow(sqlres)
       if row == nil: break
       for i in 0..L-1:
         if row[i] == nil:
+          if backup == nil:
+            newSeq(backup, L)
+          if backup[i] == nil and result[i] != nil:
+            shallowCopy(backup[i], result[i])
           result[i] = nil
         else:
           if result[i] == nil:
-            shallowCopy(result[i], backup[i])
-          setLen(result[i], 0)
+            if backup != nil:
+              if backup[i] == nil:
+                backup[i] = ""
+              shallowCopy(result[i], backup[i])
+              setLen(result[i], 0)
+            else:
+              result[i] = ""
+          else:
+            setLen(result[i], 0)
           add(result[i], row[i])
       yield result
     properFreeResult(sqlres, row)

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -180,10 +180,13 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
       row = mysql.fetchRow(sqlres)
       if row == nil: break
       for i in 0..L-1:
-        setLen(result[i], 0)
         if row[i] == nil:
           result[i] = nil
         else:
+          if result[i] == nil:
+            result[i] = ""
+          else:
+            setLen(result[i], 0)
           add(result[i], row[i])
       yield result
     properFreeResult(sqlres, row)

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -183,7 +183,6 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
       if row == nil: break
       for i in 0..L-1:
         if row[i] == nil:
-          shallowCopy(backup[i], result[i])
           result[i] = nil
         else:
           if result[i] == nil:

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -173,11 +173,14 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
   rawExec(db, query, args)
   var sqlres = mysql.useResult(db)
   if sqlres != nil:
-    var L = int(mysql.numFields(sqlres))
     var
-      result = newRow(L)
+      L = int(mysql.numFields(sqlres))
       backup = newRow(L)
-    var row: cstringArray
+      row: cstringArray
+      result: Row
+    newSeq(result, L)
+    for i in 0..L-1:
+      shallowCopy(result[i], backup[i])
     while true:
       row = mysql.fetchRow(sqlres)
       if row == nil: break

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -174,19 +174,21 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
   var sqlres = mysql.useResult(db)
   if sqlres != nil:
     var L = int(mysql.numFields(sqlres))
-    var result = newRow(L)
+    var
+      result = newRow(L)
+      backup = newRow(L)
     var row: cstringArray
     while true:
       row = mysql.fetchRow(sqlres)
       if row == nil: break
       for i in 0..L-1:
         if row[i] == nil:
+          shallowCopy(backup[i], result[i])
           result[i] = nil
         else:
           if result[i] == nil:
-            result[i] = ""
-          else:
-            setLen(result[i], 0)
+            shallowCopy(result[i], backup[i])
+          setLen(result[i], 0)
           add(result[i], row[i])
       yield result
     properFreeResult(sqlres, row)


### PR DESCRIPTION
The previous implementation of db_mysql fastRows had a bug - if a row in the query result had a null field, and the next row had a non-null field in the same column, a segfault would occur here:
```nimrod
setLen(result[i], 0)  # segfaults if result[i] == nil from previous row
```

I would like very much to avoid allocating the strings after nulls, but so far I haven't found any way in Nim to assign a string inside a seq without copying it.

If that would be possible we could just:
```nimrod
var
  result = newRow(L)
  backup = newRow(L)
if row[i] == nil:
  backup[i] = result[i]  # somehow, copy only the reference here
  result[i] = nil
```
and use the backup seq as a repository of strings to reuse.