### PR TITLE
asyncfile: setLen procedure for files

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2895,6 +2895,9 @@ when not defined(JS): #and not defined(nimscript):
     proc getFileSize*(f: File): int64 {.tags: [ReadIOEffect], benign.}
       ## retrieves the file size (in bytes) of `f`.
 
+    proc setFileSize*(f: File, size: int64) {.tags: [ReadIOEffect], benign.}
+      ## changes the size of file `f` (in bytes).
+
     proc readBytes*(f: File, a: var openArray[int8|uint8], start, len: Natural): int {.
       tags: [ReadIOEffect], benign.}
       ## reads `len` bytes into the buffer `a` starting at ``a[start]``. Returns

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -52,6 +52,8 @@ proc c_ferror(f: File): cint {.
   importc: "ferror", header: "<stdio.h>", tags: [].}
 proc c_setvbuf(f: File, buf: pointer, mode: cint, size: csize): cint {.
   importc: "setvbuf", header: "<stdio.h>", tags: [].}
+proc c_ftruncate(f: FileHandle, len: clong): cint {.
+  importc: "ftruncate", header: "<unistd.h>".}
 
 proc raiseEIO(msg: string) {.noinline, noreturn.} =
   sysFatal(IOError, msg)
@@ -372,6 +374,11 @@ proc getFileSize(f: File): int64 =
   discard c_fseek(f, 0, 2) # seek the end of the file
   result = getFilePos(f)
   setFilePos(f, oldPos)
+
+proc setFileSize(f: File, size: int64) =
+  ## Set a file length.
+  if c_ftruncate(getFileHandle f, size.clong) == -1:
+    raiseEIO("cannot truncate file")
 
 proc readFile(filename: string): TaintedString =
   var f: File

--- a/tests/async/tasyncfile.nim
+++ b/tests/async/tasyncfile.nim
@@ -11,9 +11,10 @@ proc main() {.async.} =
   # Simple write/read test.
   block:
     var file = openAsync(fn, fmReadWrite)
-    await file.write("test")
+    await file.write("testing")
     file.setFilePos(0)
     await file.write("foo")
+    file.setFileSize(4)
     file.setFilePos(0)
     let data = await file.readAll()
     doAssert data == "foot"
@@ -24,7 +25,7 @@ proc main() {.async.} =
     var file = openAsync(fn, fmAppend)
     await file.write("\ntest2")
     let errorTest = file.readAll()
-    echo await errorTest
+    yield errorTest
     doAssert errorTest.failed
     file.close()
     file = openAsync(fn, fmRead)


### PR DESCRIPTION
Platform independent procedure to set a file length. Useful when
replacing file content.