### PR TITLE
Add yearday calculation to getLocalTime and getGMTime, so that yearday is not 0 for TimeInfo instances under JS backend.

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -597,8 +597,11 @@ elif defined(JS):
     result.month = Month(t.getMonth())
     result.year = t.getFullYear()
     result.weekday = weekDays[t.getDay()]
-    result.yearday = 0
     result.timezone = getTimezone()
+
+    result.yearday = result.monthday - 1
+    for month in mJan..<result.month:
+      result.yearday += getDaysInMonth(month, result.year)
 
   proc getGMTime(t: Time): TimeInfo =
     result.second = t.getUTCSeconds()
@@ -608,7 +611,10 @@ elif defined(JS):
     result.month = Month(t.getUTCMonth())
     result.year = t.getUTCFullYear()
     result.weekday = weekDays[t.getUTCDay()]
-    result.yearday = 0
+
+    result.yearday = result.monthday - 1
+    for month in mJan..<result.month:
+      result.yearday += getDaysInMonth(month, result.year)
 
   proc timeInfoToTime(timeInfo: TimeInfo): Time = toTime(timeInfo)
 

--- a/tests/js/ttimes.nim
+++ b/tests/js/ttimes.nim
@@ -1,0 +1,13 @@
+# test times module with js
+discard """
+  action: run
+"""
+
+import times
+
+# $ date --date='@2147483647'
+# Tue 19 Jan 03:14:07 GMT 2038
+
+block yeardayTest:
+  # check if yearday attribute is properly set on TimeInfo creation
+  doAssert fromSeconds(2147483647).getGMTime().yearday == 0

--- a/tests/js/ttimes.nim
+++ b/tests/js/ttimes.nim
@@ -10,4 +10,4 @@ import times
 
 block yeardayTest:
   # check if yearday attribute is properly set on TimeInfo creation
-  doAssert fromSeconds(2147483647).getGMTime().yearday == 0
+  doAssert fromSeconds(2147483647).getGMTime().yearday == 18


### PR DESCRIPTION
Yearday 0 has no sense and contradicts the behaviour under C backend, where yearday is an int from 1 to 365, i.e. cannot be 0 even theoretically.