### PR TITLE
Catch illegal recursion in generic types in some cases (also fix #5629)

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1356,6 +1356,17 @@ proc skipTypesOrNil*(t: PType, kinds: TTypeKinds): PType =
     if result.len == 0: return nil
     result = lastSon(result)
 
+proc repeatsInNode*(symbol: PSym; n: PNode): bool =
+  ## Checks if a sym is repeated in the first son
+  ## somewhere in a node
+  ## useful for checking for recursion in same cases
+  result = false
+  var current = n
+  while current.kind == nkSym or safeLen(current) > 0:
+    if current.kind == nkSym:
+      return current.sym == symbol
+    current = current.sons[0]
+
 proc isGCedMem*(t: PType): bool {.inline.} =
   result = t.kind in {tyString, tyRef, tySequence} or
            t.kind == tyProc and t.callConv == ccClosure

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -859,7 +859,10 @@ proc typeSectionFinalPass(c: PContext, n: PNode) =
       checkConstructedType(s.info, s.typ)
       if s.typ.kind in {tyObject, tyTuple} and not s.typ.n.isNil:
         checkForMetaFields(s.typ.n)
-
+    elif len(a.sons) > 2 and a.sons[1].kind == nkGenericParams and 
+          repeatsInNode(a.sons[0].sym, a.sons[2]):
+      localError(n.info, errIllegalRecursionInTypeX, typeToString(a.sons[0].sym.typ))
+      
 proc semAllTypeSections(c: PContext; n: PNode): PNode =
   proc gatherStmts(c: PContext; n: PNode; result: PNode) {.nimcall.} =
     case n.kind

--- a/tests/types/tillegalgenericsrecursion.nim
+++ b/tests/types/tillegalgenericsrecursion.nim
@@ -1,0 +1,13 @@
+discard """
+  cmd: "nim $target --threads:on $options $file"
+  errormsg: "illegal recursion in type 'Executor'"
+  line: 8
+"""
+
+type
+  ExecutorObj[N] = object
+    tasks: seq[N]
+
+  Executor[N] = Executor[N]
+
+var e: Executor[int]

--- a/tests/types/tillegalgenericsrecursionptr.nim
+++ b/tests/types/tillegalgenericsrecursionptr.nim
@@ -1,0 +1,13 @@
+discard """
+  cmd: "nim $target --threads:on $options $file"
+  errormsg: "illegal recursion in type 'Executor'"
+  line: 8
+"""
+
+type
+  ExecutorObj[N] = object
+    tasks: seq[N]
+
+  Executor[N] = ptr Executor[N]
+
+var e: Executor[int]


### PR DESCRIPTION
Currently 
```nim
type
    Executor[N] = Executor[N]
var e: Executor[int]
```
will make the compiler hang. That can also lead to confusion, because this code is easy to result from a typo as in #5629 and the right error message will help the user find it immediately instead of thinking the problem is somewhere else.
