### PR TITLE
Proper fix for osproc.nim on Android

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2423,8 +2423,11 @@ proc sigset*(a1: int, a2: proc (x: cint) {.noconv.}) {.
 proc sigsuspend*(a1: var Sigset): cint {.importc, header: "<signal.h>".}
 
 when defined(android):
-  proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
-                   a3: var Timespec, sigsetsize: csize = sizeof(culong)*2): cint {.importc: "__rt_sigtimedwait", header:"<signal.h>".}
+  proc syscall(arg: clong): clong {.varargs, importc: "syscall", header: "<unistd.h>".}
+  var NR_rt_sigtimedwait {.importc: "__NR_rt_sigtimedwait", header: "<sys/syscall.h>".}: int
+
+  proc sigtimedwait*(a1: var Sigset, a2: var SigInfo, a3: var Timespec): cint =
+    result = syscall(NR_rt_sigtimedwait, a1, a2, a3)
 else:
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
                    a3: var Timespec): cint {.importc, header: "<signal.h>".}

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2425,12 +2425,13 @@ proc sigsuspend*(a1: var Sigset): cint {.importc, header: "<signal.h>".}
 when defined(android):
   proc syscall(arg: clong): clong {.varargs, importc: "syscall", header: "<unistd.h>".}
   var NR_rt_sigtimedwait {.importc: "__NR_rt_sigtimedwait", header: "<sys/syscall.h>".}: clong
+  var NSIGMAX {.importc: "NSIG", header: "<signal.h>".}: clong
 
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo, a3: var Timespec): cint =
-    result = cint(syscall(NR_rt_sigtimedwait, a1, a2, a3, sizeof(Sigset)))
+    result = cint(syscall(NR_rt_sigtimedwait, addr(a1), addr(a2), addr(a3), NSIGMAX div 8))
 else:
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
-                   a3: var Timespec): cint {.importc, header: "<signal.h>".}
+                     a3: var Timespec): cint {.importc, header: "<signal.h>".}
 
 proc sigwait*(a1: var Sigset, a2: var cint): cint {.
   importc, header: "<signal.h>".}

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2424,7 +2424,7 @@ proc sigsuspend*(a1: var Sigset): cint {.importc, header: "<signal.h>".}
 
 when defined(android):
   proc syscall(arg: clong): clong {.varargs, importc: "syscall", header: "<unistd.h>".}
-  var NR_rt_sigtimedwait {.importc: "__NR_rt_sigtimedwait", header: "<sys/syscall.h>".}: int
+  var NR_rt_sigtimedwait {.importc: "__NR_rt_sigtimedwait", header: "<sys/syscall.h>".}: clong
 
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo, a3: var Timespec): cint =
     result = syscall(NR_rt_sigtimedwait, a1, a2, a3)

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -2427,7 +2427,7 @@ when defined(android):
   var NR_rt_sigtimedwait {.importc: "__NR_rt_sigtimedwait", header: "<sys/syscall.h>".}: clong
 
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo, a3: var Timespec): cint =
-    result = syscall(NR_rt_sigtimedwait, a1, a2, a3)
+    result = cint(syscall(NR_rt_sigtimedwait, a1, a2, a3, sizeof(Sigset)))
 else:
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
                    a3: var Timespec): cint {.importc, header: "<signal.h>".}


### PR DESCRIPTION
Fix `sigtimedwait` to use direct syscall to **__NR_rt_sigtimedwait** (available since Android SDK L3).

Testing needed...