### PR TITLE
fix thread metadata allocation for genode

### DIFF
--- a/lib/genode_cpp/threads.h
+++ b/lib/genode_cpp/threads.h
@@ -13,7 +13,6 @@
 #define _GENODE_CPP__THREAD_H_
 
 #include <base/thread.h>
-#include <util/avl_tree.h>
 #include <util/reconstructible.h>
 
 namespace Nim { struct SysThread; }

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -593,6 +593,8 @@ elif defined(genode):
   proc createThread*[TArg](t: var Thread[TArg],
                            tp: proc (arg: TArg) {.thread, nimcall.},
                            param: TArg) =
+    t.core = cast[PGcThread](allocShared0(sizeof(GcThread)))
+
     when TArg isnot void: t.data = param
     t.dataFn = tp
     when hasSharedHeap: t.stackSize = ThreadStackSize


### PR DESCRIPTION
While PR #5560 was open the allocation of some thread metadata changed at 254fbcc548247865cf15200a200436024258e647.