### PR TITLE
Respect the implicit discarding with casts

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -126,7 +126,8 @@ proc semExprBranchScope(c: PContext, n: PNode): PNode =
 const
   skipForDiscardable = {nkIfStmt, nkIfExpr, nkCaseStmt, nkOfBranch,
     nkElse, nkStmtListExpr, nkTryStmt, nkFinally, nkExceptBranch,
-    nkElifBranch, nkElifExpr, nkElseExpr, nkBlockStmt, nkBlockExpr}
+    nkElifBranch, nkElifExpr, nkElseExpr, nkBlockStmt, nkBlockExpr,
+    nkHiddenStdConv, nkCast}
 
 proc implicitlyDiscardable(n: PNode): bool =
   var n = n


### PR DESCRIPTION
Fixes issue #5374

I'm not sure if you're ok with the dropping of the casts in `transform`.
I'll add some tests after the review.