### PR TITLE
Modified ospath's getConfigDir to meet XDG spec

### DIFF
--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -517,6 +517,7 @@ when declared(getEnv) or defined(nimscript):
     tags: [ReadEnvEffect, ReadIOEffect].} =
     ## Returns the config directory of the current user for applications.
     when defined(windows): return string(getEnv("APPDATA")) & "\\"
+    elif getEnv("XDG_CONFIG_DIR"): return string(getEnv("XDG_CONFIG_DIR")) & "/"
     else: return string(getEnv("HOME")) & "/.config/"
 
   proc getTempDir*(): string {.rtl, extern: "nos$1",

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -516,6 +516,14 @@ when declared(getEnv) or defined(nimscript):
   proc getConfigDir*(): string {.rtl, extern: "nos$1",
     tags: [ReadEnvEffect, ReadIOEffect].} =
     ## Returns the config directory of the current user for applications.
+    ##
+    ## On non-Windows OSs, this proc conforms to the XDG Base Directory
+    ## spec. Thus, this proc returns the value of the XDG_CONFIG_DIR environment
+    ## variable if it is set, and returns the default configuration directory,
+    ## "~/.config/", otherwise.
+    ##
+    ## An OS-dependent trailing slash is always present at the end of the
+    ## returned string; `\\` on Windows and `/` on all other OSs.
     when defined(windows): return string(getEnv("APPDATA")) & "\\"
     elif getEnv("XDG_CONFIG_DIR"): return string(getEnv("XDG_CONFIG_DIR")) & "/"
     else: return string(getEnv("HOME")) & "/.config/"

--- a/web/news/e031_version_0_16_2.rst
+++ b/web/news/e031_version_0_16_2.rst
@@ -61,6 +61,10 @@ Changes affecting backwards compatibility
   compile-time value.
 - On posix, the results of `waitForExit`, `peekExitCode`, `execCmd` will return
   128 + signal number if the application terminates via signal.
+- ``ospaths.getConfigDir`` now conforms to the XDG Base Directory specification
+  on non-Windows OSs. It returns the value of the XDG_CONFIG_DIR environment
+  variable if it is set, and returns the default configuration directory,
+  "~/.config/", otherwise.
 
 Library Additions
 -----------------


### PR DESCRIPTION
I added a check for the `XDG_CONFIG_DIR` environment variable to meet the [freedesktop XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).