### PR TITLE
Fix for #5695 make subscript operator overloadable for tuples

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1266,7 +1266,7 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags): PNode =
     result.typ = makeTypeDesc(c, semTypeNode(c, n, nil))
     #result = symNodeFromType(c, semTypeNode(c, n, nil), n.info)
   of tyTuple:
-    checkSonsLen(n, 2)
+    if n.len != 2: return nil
     n.sons[0] = makeDeref(n.sons[0])
     c.p.bracketExpr = n.sons[0]
     # [] operator for tuples requires constant expression:
@@ -1276,9 +1276,9 @@ proc semSubscript(c: PContext, n: PNode, flags: TExprFlags): PNode =
       var idx = getOrdValue(n.sons[1])
       if idx >= 0 and idx < sonsLen(arr): n.typ = arr.sons[int(idx)]
       else: localError(n.info, errInvalidIndexValueForTuple)
+      result = n
     else:
-      localError(n.info, errIndexTypesDoNotMatch)
-    result = n
+      result = nil
   else:
     let s = if n.sons[0].kind == nkSym: n.sons[0].sym
             elif n[0].kind in nkSymChoices: n.sons[0][0].sym

--- a/tests/tuples/tuple_subscript.nim
+++ b/tests/tuples/tuple_subscript.nim
@@ -1,0 +1,40 @@
+discard """
+  output: '''5
+5
+str2
+str2
+4'''
+"""
+
+proc`[]` (t: tuple, key: string): string =
+  for name, field in fieldPairs(t):
+    if name == key: 
+      return $field
+  return ""
+
+
+proc`[]` [A,B](t: tuple, key: string, op: (proc(x: A): B)): B =
+  for name, field in fieldPairs(t):
+    when field is A:
+      if name == key: 
+        return op(field)
+
+proc`[]=`[T](t: var tuple, key: string, val: T) =
+  for name, field in fieldPairs(t):
+    when field is T:
+      if name == key: 
+        field = val
+
+var tt = (a: 1, b: "str1")
+
+# test built in operator
+tt[0] = 5
+echo tt[0] 
+echo `[]`(tt, 0)
+
+
+# test overloaded operator
+tt["b"] = "str2"
+echo tt["b"] 
+echo `[]`(tt, "b")
+echo tt["b", proc(s: string) : int = s.len]


### PR DESCRIPTION
The fix turned out to be rather simple to make. semArrayAccess already does overloaded subscript if semSubscript returns nil, so the only required change was to make semSubscript return nil instead of throwing exception