### PR TITLE
Small base64.nim refactor

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -44,7 +44,7 @@
 const
   cb64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-template encodeInternal(s: typed, lineLen: int, newLine: string): untyped {.immediate.} =
+template encodeInternal(s: typed, lineLen: int, newLine: string): untyped =
   ## encodes `s` into base64 representation. After `lineLen` characters, a
   ## `newline` is added.
   var total = ((len(s) + 2) div 3) * 4

--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -44,12 +44,11 @@
 const
   cb64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-template encodeInternal(s: typed, lineLen: int, newLine: string): untyped =
+template encodeInternal(s: typed, lineLen: int, newLine: string): untyped {.immediate.} =
   ## encodes `s` into base64 representation. After `lineLen` characters, a
   ## `newline` is added.
-  let 
-    total = ((len(s) + 2) div 3) * 4
-    numLines = (total + lineLen - 1) div lineLen
+  var total = ((len(s) + 2) div 3) * 4
+  let numLines = (total + lineLen - 1) div lineLen
   if numLines > 0: inc(total, (numLines - 1) * newLine.len)
 
   result = newString(total)

--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -44,7 +44,7 @@
 const
   cb64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
-template encodeInternal(s: expr, lineLen: int, newLine: string): stmt {.immediate.} =
+template encodeInternal(s: typed, lineLen: int, newLine: string): untyped =
   ## encodes `s` into base64 representation. After `lineLen` characters, a
   ## `newline` is added.
   var total = ((len(s) + 2) div 3) * 4
@@ -52,13 +52,15 @@ template encodeInternal(s: expr, lineLen: int, newLine: string): stmt {.immediat
   if numLines > 0: inc(total, (numLines - 1) * newLine.len)
 
   result = newString(total)
-  var i = 0
-  var r = 0
-  var currLine = 0
+  var 
+    i = 0
+    r = 0
+    currLine = 0
   while i < s.len - 2:
-    var a = ord(s[i])
-    var b = ord(s[i+1])
-    var c = ord(s[i+2])
+    let
+      a = ord(s[i])
+      b = ord(s[i+1])
+      c = ord(s[i+2])
     result[r] = cb64[a shr 2]
     result[r+1] = cb64[((a and 3) shl 4) or ((b and 0xF0) shr 4)]
     result[r+2] = cb64[((b and 0x0F) shl 2) or ((c and 0xC0) shr 6)]
@@ -74,8 +76,9 @@ template encodeInternal(s: expr, lineLen: int, newLine: string): stmt {.immediat
       currLine = 0
 
   if i < s.len-1:
-    var a = ord(s[i])
-    var b = ord(s[i+1])
+    var 
+      a = ord(s[i])
+      b = ord(s[i+1])
     result[r] = cb64[a shr 2]
     result[r+1] = cb64[((a and 3) shl 4) or ((b and 0xF0) shr 4)]
     result[r+2] = cb64[((b and 0x0F) shl 2)]
@@ -127,15 +130,17 @@ proc decode*(s: string): string =
   # total is an upper bound, as we will skip arbitrary whitespace:
   result = newString(total)
 
-  var i = 0
-  var r = 0
+  var 
+    i = 0
+    r = 0
   while true:
     while s[i] in Whitespace: inc(i)
     if i < s.len-3:
-      var a = s[i].decodeByte
-      var b = s[i+1].decodeByte
-      var c = s[i+2].decodeByte
-      var d = s[i+3].decodeByte
+      let
+        a = s[i].decodeByte
+        b = s[i+1].decodeByte
+        c = s[i+2].decodeByte
+        d = s[i+3].decodeByte
 
       result[r] = chr((a shl 2) and 0xff or ((b shr 4) and 0x03))
       result[r+1] = chr((b shl 4) and 0xff or ((c shr 2) and 0x0F))

--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -47,8 +47,9 @@ const
 template encodeInternal(s: typed, lineLen: int, newLine: string): untyped =
   ## encodes `s` into base64 representation. After `lineLen` characters, a
   ## `newline` is added.
-  var total = ((len(s) + 2) div 3) * 4
-  var numLines = (total + lineLen - 1) div lineLen
+  let 
+    total = ((len(s) + 2) div 3) * 4
+    numLines = (total + lineLen - 1) div lineLen
   if numLines > 0: inc(total, (numLines - 1) * newLine.len)
 
   result = newString(total)
@@ -76,7 +77,7 @@ template encodeInternal(s: typed, lineLen: int, newLine: string): untyped =
       currLine = 0
 
   if i < s.len-1:
-    var 
+    let 
       a = ord(s[i])
       b = ord(s[i+1])
     result[r] = cb64[a shr 2]
@@ -86,7 +87,7 @@ template encodeInternal(s: typed, lineLen: int, newLine: string): untyped =
     if r+4 != result.len:
       setLen(result, r+4)
   elif i < s.len:
-    var a = ord(s[i])
+    let a = ord(s[i])
     result[r] = cb64[a shr 2]
     result[r+1] = cb64[(a and 3) shl 4]
     result[r+2] = '='


### PR DESCRIPTION
Changed `var` to `let` in some places, changed deprecated `stmt` and `expr`, put variables declaration into one block, removed `{.immediate.}` pragma