### PR TITLE
Add space to fix RST in captureBetween docs

### DIFF
--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -201,7 +201,7 @@ proc parseWhile*(s: string, token: var string, validChars: set[char],
 
 proc captureBetween*(s: string, first: char, second = '\0', start = 0): string =
   ## Finds the first occurrence of ``first``, then returns everything from there
-  ## up to ``second``(if ``second`` is '\0', then ``first`` is used).
+  ## up to ``second`` (if ``second`` is '\0', then ``first`` is used).
   var i = skipUntil(s, first, start)+1+start
   result = ""
   discard s.parseUntil(result, if second == '\0': first else: second, i)


### PR DESCRIPTION
The documentation for the `parseutils` module's `captureBetween` procedure isn't rendering properly, as can [be seen in the docs][1]. Adding the missing space character fixes it.

[1]: https://nim-lang.org/docs/parseutils.html#captureBetween