### PR TITLE
SIG_DFL

### DIFF
--- a/lib/posix/posix_other_consts.nim
+++ b/lib/posix/posix_other_consts.nim
@@ -369,6 +369,7 @@ var SCHED_OTHER* {.importc: "SCHED_OTHER", header: "<sched.h>".}: cint
 var SEM_FAILED* {.importc: "SEM_FAILED", header: "<semaphore.h>".}: pointer
 
 # <signal.h>
+var SIG_DFL* {.importc, header: "<signal.h>".}: proc (x: cint) {.noconv.}
 var SIGEV_NONE* {.importc: "SIGEV_NONE", header: "<signal.h>".}: cint
 var SIGEV_SIGNAL* {.importc: "SIGEV_SIGNAL", header: "<signal.h>".}: cint
 var SIGEV_THREAD* {.importc: "SIGEV_THREAD", header: "<signal.h>".}: cint


### PR DESCRIPTION
I don't know of a better way to revert to the previous signal-handler, but I'm open to ideas.

Actually, I was wondering why this was removed. By accident? Maybe `SIG_IGN` is needed too?

* http://en.cppreference.com/w/c/program/SIG_strategies