### PR TITLE
fixes countup/countdown for custom types.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1926,6 +1926,7 @@ iterator countdown*[T](a, b: T, step = 1): T {.inline.} =
   ## step count. `T` may be any ordinal type, `step` may only
   ## be positive. **Note**: This fails to count to ``low(int)`` if T = int for
   ## efficiency reasons.
+  mixin dec
   when T is IntLikeForCount:
     var res = int(a)
     while res >= int(b):
@@ -1954,11 +1955,13 @@ iterator countup*[S, T](a: S, b: T, step = 1): T {.inline.} =
   ## step count. `S`, `T` may be any ordinal type, `step` may only
   ## be positive. **Note**: This fails to count to ``high(int)`` if T = int for
   ## efficiency reasons.
+  mixin inc
   countupImpl:
     inc(res, step)
 
 iterator `..`*[S, T](a: S, b: T): T {.inline.} =
   ## An alias for `countup`.
+  mixin inc
   countupImpl:
     inc(res)
 
@@ -3756,6 +3759,7 @@ template `..<`*(a, b: untyped): untyped {.dirty.} =
   a .. <b
 
 iterator `..<`*[S,T](a: S, b: T): T =
+  mixin inc
   var i = T(a)
   while i < b:
     yield i


### PR DESCRIPTION
uses mixin to force open symbols for inc/dec. (for custom types)