### PR TITLE
Fixed const sets in JS

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2272,7 +2272,6 @@ proc myProcess(b: PPassContext, n: PNode): PNode =
   genModule(p, n)
   add(p.g.code, p.locals)
   add(p.g.code, p.body)
-  globals.unique = p.unique
 
 proc wholeCode(graph: ModuleGraph; m: BModule): Rope =
   for prc in globals.forwarded:

--- a/compiler/jstypes.nim
+++ b/compiler/jstypes.nim
@@ -59,7 +59,7 @@ proc genObjectFields(p: PProc, typ: PType, n: PNode): Rope =
         u = rope(lengthOrd(field.typ))
       else: internalError(n.info, "genObjectFields(nkRecCase)")
       if result != nil: add(result, ", " & tnl)
-      addf(result, "[SetConstr($1), $2]",
+      addf(result, "[setConstr($1), $2]",
            [u, genObjectFields(p, typ, lastSon(b))])
     result = ("{kind: 3, offset: \"$1\", len: $3, " &
         "typ: $2, name: $4, sons: [$5]}") % [


### PR DESCRIPTION
2 bugs:
* `SetConstr` changed to `setConstr`
* Don't reset `global.unique` because otherwise `ConstSet`s from different modules share common identifiers in the resulting JS and thus overwrite each other.