### PR TITLE
Fixed usage of sync primitives for ios

### DIFF
--- a/lib/pure/collections/sharedlist.nim
+++ b/lib/pure/collections/sharedlist.nim
@@ -73,7 +73,7 @@ proc add*[A](x: var SharedList[A]; y: A) =
     node.d[node.dataLen] = y
     inc(node.dataLen)
 
-proc initSharedList*[A](): SharedList[A] =
+proc initSharedList*[A](result: var SharedList[A]) =
   initLock result.lock
   result.head = nil
   result.tail = nil

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -191,7 +191,7 @@ proc del*[A, B](t: var SharedTable[A, B], key: A) =
   withLock t:
     delImpl()
 
-proc initSharedTable*[A, B](initialSize=64): SharedTable[A, B] =
+proc initSharedTable*[A, B](result: var SharedTable[A, B], initialSize=64) =
   ## creates a new hash table that is empty.
   ##
   ## `initialSize` needs to be a power of two. If you need to accept runtime

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -180,7 +180,7 @@ elif defined(linux):
     if result.epollFD < 0:
       raiseOSError(osLastError())
     when MultiThreaded:
-      result.fds = initSharedTable[SocketHandle, SelectorKey]()
+      result.fds.initSharedTable()
     else:
       result.fds = initTable[SocketHandle, SelectorKey]()
 
@@ -269,7 +269,7 @@ elif defined(macosx) or defined(freebsd) or defined(openbsd) or defined(netbsd):
     if result.kqFD < 0:
       raiseOSError(osLastError())
     when MultiThreaded:
-      result.fds = initSharedTable[SocketHandle, SelectorKey]()
+      result.fds.initSharedTable()
     else:
       result.fds = initTable[SocketHandle, SelectorKey]()
 
@@ -356,7 +356,7 @@ elif not defined(nimdoc):
 
   proc newSelector*(): Selector =
     when MultiThreaded:
-      result.fds = initSharedTable[SocketHandle, SelectorKey]()
+      result.fds.initSharedTable()
     else:
       result.fds = initTable[SocketHandle, SelectorKey]()
 

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -329,7 +329,7 @@ proc initGC() =
       init(gch.marked)
       init(gch.additionalRoots)
     when hasThreadSupport:
-      gch.toDispose = initSharedList[pointer]()
+      gch.toDispose.initSharedList()
 
 when useMarkForDebug or useBackupGc:
   type

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -129,7 +129,7 @@ proc initGC() =
     init(gch.additionalRoots)
     init(gch.greyStack)
     when hasThreadSupport:
-      gch.toDispose = initSharedList[pointer]()
+      gch.toDispose.initSharedList()
 
 # Which color to use for new objects is tricky: When we're marking,
 # they have to be *white* so that everything is marked that is only

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -190,7 +190,7 @@ proc initGC() =
       init(gch.allocated)
       init(gch.marked)
     when hasThreadSupport:
-      gch.toDispose = initSharedList[pointer]()
+      gch.toDispose.initSharedList()
 
 proc forAllSlotsAux(dest: pointer, n: ptr TNimNode, op: WalkOp) {.benign.} =
   var d = cast[ByteAddress](dest)

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -213,7 +213,8 @@ block clearCountTableTest:
   assert t.len() == 0
 
 block withKeyTest:
-  var t = initSharedTable[int, int]()
+  var t: SharedTable[int, int]
+  t.initSharedTable()
   t.withKey(1) do (k: int, v: var int, pairExists: var bool):
     assert(v == 0)
     pairExists = true


### PR DESCRIPTION
The issue is somewhat similar to #3936. Short description: pthread sync primitives behave quite badly when moved in memory. The behavior recently observed was infinite hang on `lock.acquire` inside `GC.fullCollect`.