### PR TITLE
Use writeable file in parsecfg.writeConfig()

### DIFF
--- a/lib/pure/parsecfg.nim
+++ b/lib/pure/parsecfg.nim
@@ -540,7 +540,8 @@ proc writeConfig*(dict: Config, filename: string) =
   ## Writes the contents of the table to the specified configuration file.
   ## Note: Comment statement will be ignored.
   let file = open(filename, fmWrite)
-  let fileStream = newFileStream(filename)
+  defer: file.close()
+  let fileStream = newFileStream(file)
   defer: fileStream.close()
   dict.writeConfig(fileStream)
 


### PR DESCRIPTION
Fixes #5816 

This works for me.