### PR TITLE
makefile.tmpl: fix error handling and cleanups

### DIFF
--- a/tools/niminst/makefile.tmpl
+++ b/tools/niminst/makefile.tmpl
@@ -12,146 +12,143 @@ binDir = ?{firstBinPath(c).toUnix}
 
 koch := $(shell sh -c 'test -s ../koch.nim && echo "yes"')
 ifeq ($(koch),yes)
-	binDir = ../bin
+  binDir = ../bin
 endif
 
 ucpu := $(shell sh -c 'uname -m | tr "[:upper:]" "[:lower:]"')
 uos := $(shell sh -c 'uname | tr "[:upper:]" "[:lower:]"')
 
 ifeq ($(uos),linux)
-	myos = linux
-	LINK_FLAGS += -ldl -lm
+  myos = linux
+  LINK_FLAGS += -ldl -lm
 endif
 ifeq ($(uos),dragonfly)
-	myos = freebsd
-	LINK_FLAGS += -lm
+  myos = freebsd
+  LINK_FLAGS += -lm
 endif
 ifeq ($(uos),freebsd)
-	myos= freebsd
-	CC = clang
-	LINKER = clang
-	LINK_FLAGS += -lm
+  myos= freebsd
+  CC = clang
+  LINKER = clang
+  LINK_FLAGS += -lm
 endif
 ifeq ($(uos),openbsd)
-	myos = openbsd
-	LINK_FLAGS += -lm
+  myos = openbsd
+  LINK_FLAGS += -lm
 endif
 ifeq ($(uos),netbsd)
-	myos = netbsd
-	LINK_FLAGS += -lm
+  myos = netbsd
+  LINK_FLAGS += -lm
 endif
 ifeq ($(uos),darwin)
-	myos = macosx
-	CC = clang
-	LINKER = clang
-	LINK_FLAGS += -ldl -lm
-	ifeq ($HOSTTYPE,x86_64)
-		ucpu = amd64
-	endif
+  myos = macosx
+  CC = clang
+  LINKER = clang
+  LINK_FLAGS += -ldl -lm
+  ifeq ($HOSTTYPE,x86_64)
+    ucpu = amd64
+  endif
 endif
 ifeq ($(uos),aix)
-	myos = aix
-	LINK_FLAGS += -dl -lm
+  myos = aix
+  LINK_FLAGS += -dl -lm
 endif
 ifeq ($(uos),solaris)
-	myos = solaris
-	LINK_FLAGS += -ldl -lm -lsocket -lnsl
+  myos = solaris
+  LINK_FLAGS += -ldl -lm -lsocket -lnsl
 endif
 ifeq ($(uos),sun)
-	myos = solaris
-	LINK_FLAGS += -ldl -lm -lsocket -lnsl
+  myos = solaris
+  LINK_FLAGS += -ldl -lm -lsocket -lnsl
 endif
 ifeq ($(uos),haiku)
-	myos = haiku
+  myos = haiku
 endif
 ifndef uos
-	@echo "Error: unknown operating system: $(uos)"
-	@exit 1
+  $(error unknown operating system: $(uos))
 endif
 
 ifeq ($(ucpu),i386)
-	mycpu = i386
+  mycpu = i386
 endif
 ifeq ($(ucpu),i486)
-	mycpu = i386
+  mycpu = i386
 endif
 ifeq ($(ucpu),i586)
-	mycpu = i386
+  mycpu = i386
 endif
 ifeq ($(ucpu),i686)
-	mycpu = i386
+  mycpu = i386
 endif
 ifeq ($(ucpu),bepc)
-	mycpu = i386
+  mycpu = i386
 endif
 ifeq ($(ucpu),i86pc)
-	mycpu = i386
+  mycpu = i386
 endif
 ifeq ($(ucpu),amd64)
-	mycpu = amd64
+  mycpu = amd64
 endif
 ifeq ($(ucpu),x86-64)
-	mycpu = amd64
+  mycpu = amd64
 endif
 ifeq ($(ucpu),x86_64)
-	mycpu = amd64
+  mycpu = amd64
 endif
 ifeq ($(ucpu),sparc)
-	mycpu = sparc
+  mycpu = sparc
 endif
 ifeq ($(ucpu),sun)
-	mycpu = sparc
+  mycpu = sparc
 endif
 ifeq ($(ucpu),ppc64)
-	mycpu = powerpc64
-	ifeq ($(myos),linux)
-		COMP_FLAGS += -m64
-		LINK_FLAGS += -m64
-	endif
+  mycpu = powerpc64
+  ifeq ($(myos),linux)
+    COMP_FLAGS += -m64
+    LINK_FLAGS += -m64
+  endif
 endif
 ifeq ($(ucpu),powerpc)
-	mycpu = powerpc
+  mycpu = powerpc
 endif
 ifeq ($(ucpu),ppc)
-	mycpu = ppc
+  mycpu = ppc
 endif
 ifeq ($(ucpu),mips)
-	mycpu = mips
+  mycpu = mips
 endif
 ifeq ($(ucpu),arm)
-	mycpu = arm
+  mycpu = arm
 endif
 ifeq ($(ucpu),armeb)
-	mycpu = arm
+  mycpu = arm
 endif
 ifeq ($(ucpu),armel)
-	mycpu = arm
+  mycpu = arm
 endif
 ifeq ($(ucpu),armv6l)
-	mycpu = arm
+  mycpu = arm
 endif
 ifndef ucpu
-	@echo "Error: unknown processor : $(ucpu)"
-	@exit 1
+  $(error unknown processor : $(ucpu))
 endif
 
 # for osA in 1..c.oses.len:
 ifeq ($(myos),?{c.oses[osA-1]})
 #   for cpuA in 1..c.cpus.len:
-	ifeq ($(mycpu),?{c.cpus[cpuA-1]})
+  ifeq ($(mycpu),?{c.cpus[cpuA-1]})
 #     var oFiles = ""
 #     for ff in c.cfiles[osA][cpuA].items:
 #       oFiles.add(" " & changeFileExt(ff.toUnix, "o"))
 #     end for
-		oFiles =?oFiles
-	endif
+    oFiles =?oFiles
+  endif
 #   end for
 endif
 # end for
 
 ifeq ($(strip $(oFiles)),)
-	@echo "Error: no C code generated for: [$(myos): $(mycpu)]"
-	@exit 1
+  $(error no C code generated for: [$(myos): $(mycpu)])
 endif
 
 %.o: %.c


### PR DESCRIPTION
This changes the indentation of all non-recipe lines from tabs to 2 spaces. While this doesn't fix anything, it avoids either make or someone interpreting those lines as a make recipe.

This also fixes the error handling by using make's $(error) function instead. Previously make gave this syntax error whenever it hit the error handling code:

```
*** recipe commences before first target.  Stop.
```

---

Discovered this while adding mips64 support to makefile.tmpl. One other issue I noticed was this on line 48:

```
  ifeq ($HOSTTYPE,x86_64)
```

This is clearly wrong because `$HOSTTYPE` = `$(H)OSTYPE` so the condition can never be true. I'm not sure what it should be instead though since `HOSTTYPE` doesn't seem to be defined anywhere.