### PR TITLE
cgen: #undef some more predefined symbols.

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -603,8 +603,18 @@ proc generateHeaders(m: BModule) =
       addf(m.s[cfsHeaders], "#include \"$1\"$N", [rope(it)])
     else:
       addf(m.s[cfsHeaders], "#include $1$N", [rope(it)])
+  add(m.s[cfsHeaders], "#undef LANGUAGE_C" & tnl)
+  add(m.s[cfsHeaders], "#undef MIPSEB" & tnl)
+  add(m.s[cfsHeaders], "#undef MIPSEL" & tnl)
+  add(m.s[cfsHeaders], "#undef PPC" & tnl)
+  add(m.s[cfsHeaders], "#undef R3000" & tnl)
+  add(m.s[cfsHeaders], "#undef R4000" & tnl)
+  add(m.s[cfsHeaders], "#undef i386" & tnl)
   add(m.s[cfsHeaders], "#undef linux" & tnl)
+  add(m.s[cfsHeaders], "#undef mips" & tnl)
   add(m.s[cfsHeaders], "#undef near" & tnl)
+  add(m.s[cfsHeaders], "#undef powerpc" & tnl)
+  add(m.s[cfsHeaders], "#undef unix" & tnl)
 
 proc initFrame(p: BProc, procname, filename: Rope): Rope =
   discard cgsym(p.module, "nimFrame")


### PR DESCRIPTION
This is a followup to issue #5171.

I've recently built a number of linux-musl-gcc-6.3.0 cross toolchains,
and by inspecting the output of each compiler's "gcc -E -dM - < /dev/null"
and "g++ -E -dM - < /dev/null" I have found that the following
non-underscored symbols are predefined in some configurations:

#define LANGUAGE_C 1
#define MIPSEB 1
#define MIPSEL 1
#define PPC 1
#define R3000 1
#define R4000 1
#define i386 1
#define linux 1
#define mips 1
#define powerpc 1
#define unix 1