### PR TITLE
proc `*` for typedesc

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -1047,6 +1047,17 @@ there is a difference between the ``$`` and ``repr`` outputs:
   # --> 3.1400000000000001e+00:3.1400000000000001e+00
 
 
+Type descriptions
+-----------------
+
+To print a typedesc, first ``import typetraits``:
+
+.. code-block: nim
+  import typetraits
+  echo type(42)
+  # --> int
+
+
 Advanced types
 ==============
 

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -19,8 +19,6 @@ proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ##
   ##   import typetraits
   ##
-  ##   proc `$`*(T: typedesc): string = name(T)
-  ##
   ##   template test(x): stmt =
   ##     echo "type: ", type(x), ", value: ", x
   ##
@@ -30,6 +28,10 @@ proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ##   # --> type: string, value: Foo
   ##   test(@['A','B'])
   ##   # --> type: seq[char], value: @[A, B]
+
+proc `$`*(t: typedesc): string =
+  ## Stringify a type, so that "echo type(42)" will work
+  name(t)
 
 proc arity*(t: typedesc): int {.magic: "TypeTrait".}
   ## Returns the arity of the given type
@@ -49,3 +51,11 @@ proc stripGenericParams*(t: typedesc): typedesc {.magic: "TypeTrait".}
   ## This trait is similar to `genericHead`, but instead of producing
   ## error for non-generic types, it will just return them unmodified
 
+when isMainModule:
+  block:
+    # echo type(42)
+    import streams
+    var ss = newStringStream()
+    ss.write($type(42)) # needs `$`
+    ss.setPosition(0)
+    doAssert ss.readAll() == "int"

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -34,10 +34,10 @@ proc `$`*(t: typedesc): string =
   name(t)
 
 proc arity*(t: typedesc): int {.magic: "TypeTrait".}
-  ## Returns the arity of the given type
+  ## Return the arity of the given type
 
 proc genericHead*(t: typedesc): typedesc {.magic: "TypeTrait".}
-  ## Accepts an instantiated generic type and returns its
+  ## Accept an instantiated generic type and return its
   ## uninstantiated form.
   ##
   ## For example:


### PR DESCRIPTION
See #5827 

I put the test in the file, as per `doc/contributing.rst`

Also fixed a couple comments, as per `doc/contributing.rst` ("Writing tests": "Stdlib")

How to use this:
```nim
import typetraits
echo(type(42))
```
```
int
```