### PR TITLE
Fix a compiler crash on array type check (#5780)

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1104,7 +1104,9 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
         else:
           return isNone
 
-      if fRange.rangeHasUnresolvedStatic:
+      if fRange.kind == tyAnything:
+        return isSubtype
+      elif fRange.rangeHasUnresolvedStatic:
         return inferStaticsInRange(c, fRange, a)
       elif c.c.inTypeClass > 0 and aRange.rangeHasUnresolvedStatic:
         return inferStaticsInRange(c, aRange, f)

--- a/tests/array/tarraytype.nim
+++ b/tests/array/tarraytype.nim
@@ -1,0 +1,19 @@
+discard """
+  file: "tarraytype.nim"
+  output: '''true
+true
+false
+'''
+"""
+
+type StringArray[N] = array[N, string]
+type IntArray[N] = array[N, int]
+
+let a = ["a", "b"]
+
+echo a is array
+echo a is StringArray
+echo a is IntArray
+
+#echo StringArray is array  ## BUG: expected true returns false
+


### PR DESCRIPTION
This pull request fixes compiler crash for the following common use case:
```
  type StringArray[N] = array[N, string]
  let a = ["one", "two"]
  echo a is StringArray
```

During the development I have found that `StringArray is array` returns false, but I couldn't find the place were the issue occurring in typeRel.