### PR TITLE
Documented shebang execution of Nimscripts

### DIFF
--- a/doc/nims.rst
+++ b/doc/nims.rst
@@ -108,3 +108,12 @@ installation of Nimble is done with this simple script:
 
   mvFile "nimble" & $id & "/src/nimble".toExe, "bin/nimble".toExe
 
+You can also use the shebang ``#!/usr/bin/env nim``, as long as your filename
+ends with ``.nims``:
+
+.. code-block:: nim
+
+  #!/usr/bin/env nim
+  mode = ScriptMode.Silent
+
+  echo "hello world"


### PR DESCRIPTION
Whilst reading the docs I thought there must be a way to run them with a portable shebang line - I discovered that this did exists and was mentioned in #3301 but not documented anywhere.

I find it a little weird it doesn't work with non `.nims` filenames, this stops nimscript from replacing some kinds of scripts where the filename is fixed. Using `#!/usr/bin/env nim e` isn't possible as not all implementations of `env` allow extra arguments.