### PR TITLE
Invoke xz -9 explicitly instead of trusting tar to interpret XZ_OPT

### DIFF
--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -679,11 +679,14 @@ RunProgram="tools\downloader.exe"
           if execShellCmd("7z a -sfx7zS2.sfx -t7z $1.exe $1" % proj) != 0:
             echo("External program failed (7z)")
       else:
-        if execShellCmd("XZ_OPT=-9 gtar Jcf $1.tar.xz $1 --exclude=.DS_Store" %
+        if execShellCmd("gtar cf $1.tar $1 --exclude=.DS_Store" %
                         proj) != 0:
           # try old 'tar' without --exclude feature:
-          if execShellCmd("XZ_OPT=-9 tar Jcf $1.tar.xz $1" % proj) != 0:
+          if execShellCmd("tar cf $1.tar $1" % proj) != 0:
             echo("External program failed")
+
+        if execShellCmd("xz -9f $1.tar" % proj) != 0:
+          echo("External program failed")
     finally:
       setCurrentDir(oldDir)
 


### PR DESCRIPTION
Right now the nim-0.17.0.tar.xz is 24 MB. After this change it should be 4 MB. On my local machine time to extract improves from 2.3 s to 0.9 s.