### PR TITLE
improved comment satement support in macros

### DIFF
--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -41,6 +41,7 @@ proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
     of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
+    of nkCommentStmt: result = a.comment == b.comment
     of nkEmpty, nkNilLit, nkType: result = true
     else:
       if sonsLen(a) == sonsLen(b):

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1406,7 +1406,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       if dest.kind in {nkStrLit..nkTripleStrLit} and
          regs[rb].kind in {rkNode}:
         dest.strVal = regs[rb].node.strVal
-      elif dest.kind == nkCommentStmt:
+      elif dest.kind == nkCommentStmt and regs[rb].kind in {rkNode}:
         dest.comment = regs[rb].node.strVal
       else:
         stackTrace(c, tos, pc, errFieldXNotFound, "strVal")

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -255,6 +255,11 @@ proc newStrLitNode*(s: string): NimNode {.compileTime, noSideEffect.} =
   result = newNimNode(nnkStrLit)
   result.strVal = s
 
+proc newCommentStmtNode*(s: string): NimNode {.compileTime, noSideEffect.} =
+  ## creates a comment statement node
+  result = newNimNode(nnkCommentStmt)
+  result.strVal = s
+
 proc newIntLitNode*(i: BiggestInt): NimNode {.compileTime.} =
   ## creates a int literal node from `i`
   result = newNimNode(nnkIntLit)
@@ -274,6 +279,7 @@ proc newIdentNode*(i: string): NimNode {.compileTime.} =
   ## creates an identifier node from `i`
   result = newNimNode(nnkIdent)
   result.ident = !i
+
 
 type
   BindSymRule* = enum    ## specifies how ``bindSym`` behaves
@@ -835,6 +841,8 @@ proc `$`*(node: NimNode): string {.compileTime.} =
     result = $node[0]
   of nnkAccQuoted:
     result = $node[0]
+  of nnkCommentStmt:
+    result = node.strVal
   else:
     badNodeKind node.kind, "$"
 

--- a/tests/macros/tnodecompare.nim
+++ b/tests/macros/tnodecompare.nim
@@ -1,33 +1,33 @@
-discard """
-output: '''true
-false
-true
-false
-true
-false
-true
-false'''
-"""
-
 import macros
+
+static:
+  let nodeA = newCommentStmtNode("this is a comment")
+  doAssert nodeA.repr == "## this is a comment"
+  doAssert nodeA.strVal == "this is a comment"
+  doAssert $nodeA == "this is a comment"
+
+  let nodeB = newCommentStmtNode("this is a comment")
+  doAssert nodeA == nodeB
+  nodeB.strVal = "this is a different comment"
+  doAssert nodeA != nodeB
 
 macro test(a: typed, b: typed): expr =
   newLit(a == b)
 
-echo test(1, 1)
-echo test(1, 2)
+doAssert test(1, 1) == true
+doAssert test(1, 2) == false
 
 type
   Obj = object of RootObj
   Other = object of RootObj
 
-echo test(Obj, Obj)
-echo test(Obj, Other)
+doAssert test(Obj, Obj) == true
+doAssert test(Obj, Other) == false
 
 var a, b: int
 
-echo test(a, a)
-echo test(a, b)
+doAssert test(a, a) == true
+doAssert test(a, b) == false
 
 macro test2: expr =
   newLit(bindSym"Obj" == bindSym"Obj")
@@ -35,5 +35,5 @@ macro test2: expr =
 macro test3: expr =
   newLit(bindSym"Obj" == bindSym"Other")
 
-echo test2()
-echo test3()
+doAssert test2() == true
+doAssert test3() == false


### PR DESCRIPTION
It was already possible to get the comment of a ``nnkCommentStmt`` node with ``strVal``, now it is also possible to compare such nodes, set their value with ``strVal=``, and create such a node with ``newCommentStmtNode``.