### PR TITLE
Remove redundant filestream.close, causes crash

### DIFF
--- a/lib/pure/parsecfg.nim
+++ b/lib/pure/parsecfg.nim
@@ -542,7 +542,6 @@ proc writeConfig*(dict: Config, filename: string) =
   let file = open(filename, fmWrite)
   defer: file.close()
   let fileStream = newFileStream(file)
-  defer: fileStream.close()
   dict.writeConfig(fileStream)
 
 proc getSectionValue*(dict: Config, section, key: string): string =


### PR DESCRIPTION
File is already being closed by defer: file.close() closing it twice causes crash.

Fixes #5906 