### PR TITLE
arrays can now be printed

### DIFF
--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -22,7 +22,7 @@ proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
     else: result = "-INF"
   else:
     var buf: array[0..80, char]
-    let newLen = c_snprintf(buf.cstring, buf.len.uint, "%#.16e%s", f, literalPostfix.cstring)
+    discard c_snprintf(buf.cstring, buf.len.uint, "%#.16e%s", f, literalPostfix.cstring)
     result = $buf.cstring
 
 proc encodeStr*(s: string, result: var string) =

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -21,9 +21,9 @@ proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
     if f > 0.0: result = "INF"
     else: result = "-INF"
   else:
-    result = newString(80)
-    let newLen = c_snprintf(result[0].addr, 81, "%#.16e" & literalPostfix, f)
-    result.setLen(newLen)
+    var buf: array[0..80, char]
+    let newLen = c_snprintf(buf.cstring, buf.len.uint, "%#.16e%s", f, literalPostfix.cstring)
+    result = $buf.cstring
 
 proc encodeStr*(s: string, result: var string) =
   for i in countup(0, len(s) - 1):

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -10,7 +10,7 @@
 ## Serialization utilities for the compiler.
 import strutils
 
-proc c_sprintf(buf, frmt: cstring) {.importc: "sprintf", header: "<stdio.h>", nodecl, varargs.}
+proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
 
 proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
   if f != f:
@@ -21,9 +21,9 @@ proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
     if f > 0.0: result = "INF"
     else: result = "-INF"
   else:
-    var buf: array[0..80, char]
-    c_sprintf(buf, "%#.16e" & literalPostfix, f)
-    result = newString(buf)
+    result = newString(80)
+    let newLen = c_snprintf(result[0].addr, 81, "%#.16e" & literalPostfix, f)
+    result.setLen(newLen)
 
 proc encodeStr*(s: string, result: var string) =
   for i in countup(0, len(s) - 1):

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -23,7 +23,7 @@ proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
   else:
     var buf: array[0..80, char]
     c_sprintf(buf, "%#.16e" & literalPostfix, f)
-    result = $buf
+    result = newString(buf)
 
 proc encodeStr*(s: string, result: var string) =
   for i in countup(0, len(s) - 1):
@@ -133,4 +133,3 @@ iterator decodeStrArray*(s: cstring): string =
   while s[i] != '\0':
     yield decodeStr(s, i)
     if s[i] == ' ': inc i
-

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -500,7 +500,7 @@ proc getLocalAddr*(socket: SocketHandle, domain: Domain): (string, Port) =
     if inet_ntop(name.sin6_family.cint,
                  addr name, buf.cstring, sizeof(buf).int32).isNil:
       raiseOSError(osLastError())
-    result = ($buf, Port(nativesockets.ntohs(name.sin6_port)))
+    result = ($buf.cstring, Port(nativesockets.ntohs(name.sin6_port)))
   else:
     raiseOSError(OSErrorCode(-1), "invalid socket family in getLocalAddr")
 
@@ -536,7 +536,7 @@ proc getPeerAddr*(socket: SocketHandle, domain: Domain): (string, Port) =
     if inet_ntop(name.sin6_family.cint,
                  addr name, buf.cstring, sizeof(buf).int32).isNil:
       raiseOSError(osLastError())
-    result = ($buf, Port(nativesockets.ntohs(name.sin6_port)))
+    result = ($buf.cstring, Port(nativesockets.ntohs(name.sin6_port)))
   else:
     raiseOSError(OSErrorCode(-1), "invalid socket family in getLocalAddr")
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1010,7 +1010,7 @@ iterator walkDir*(dir: string; relative=false): tuple[kind: PathComponent, path:
         while true:
           var x = readdir(d)
           if x == nil: break
-          var y = newString(x.d_name)
+          var y = $x.d_name.cstring
           if y != "." and y != "..":
             var s: Stat
             if not relative:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1010,7 +1010,7 @@ iterator walkDir*(dir: string; relative=false): tuple[kind: PathComponent, path:
         while true:
           var x = readdir(d)
           if x == nil: break
-          var y = $x.d_name
+          var y = newString(x.d_name)
           if y != "." and y != "..":
             var s: Stat
             if not relative:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2427,12 +2427,7 @@ proc collectionToString[T](x: T, prefix, separator, suffix: string): string =
         result.add($value)
     # prevent temporary string allocation
     elif compiles(result.add(value)):
-      # don't insert '\0' characters into the result string
-      when value is char:
-        if value != '\0':
-          result.add(value)
-      else:
-        result.add(value)
+      result.add(value)
     else:
       result.add($value)
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2425,6 +2425,14 @@ proc collectionToString[T](x: T, prefix, separator, suffix: string): string =
         result.add "nil"
       else:
         result.add($value)
+    # prevent temporary string allocation
+    elif compiles(result.add(value)):
+      # don't insert '\0' characters into the result string
+      when value is char:
+        if value != '\0':
+          result.add(value)
+      else:
+        result.add(value)
     else:
       result.add($value)
 
@@ -3306,7 +3314,6 @@ elif defined(JS):
 proc `$`*[T, IDX](x: array[IDX, T]): string =
   ## generic ``$`` operator for arrays that is lifted from the components
   collectionToString(x, "[", ", ", "]")
-
 
 proc quit*(errormsg: string, errorcode = QuitFailure) {.noReturn.} =
   ## a shorthand for ``echo(errormsg); quit(errorcode)``.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1872,21 +1872,6 @@ proc `$` *[Enum: enum](x: Enum): string {.magic: "EnumToStr", noSideEffect.}
   ## a ``$`` operator for a concrete enumeration is provided, this is
   ## used instead. (In other words: *Overwriting* is possible.)
 
-proc newString*[N](data: array[N, char]): string {.noSideEffect.} =
-  ## Construct a string from an array of characters. The `data` is
-  ## expected to be a null terminated string as it is often used in C.
-  when nimvm:
-    # cannot cast on the vm
-    # not recommended to use this procedure on the vm at all, but at least it doesn't fail.
-    result = ""
-    for c in data:
-      if c == '\0':
-        return
-      else:
-        result.add c
-  else:
-    result = $(cast[cstring](data[0].unsafeAddr))
-
 # undocumented:
 proc getRefcount*[T](x: ref T): int {.importc: "getRefcount", noSideEffect.}
 proc getRefcount*(x: string): int {.importc: "getRefcount", noSideEffect.}

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -16,9 +16,9 @@ proc reprInt(x: int64): string {.compilerproc.} = return $x
 proc reprFloat(x: float): string {.compilerproc.} = return $x
 
 proc reprPointer(x: pointer): string {.compilerproc.} =
-  result = newString(60)
-  let newLen = c_sprintf(result[0].addr, "%p", x)
-  result.setLen newLen
+  var buf: array[60, char]
+  discard c_sprintf(result[0].addr, "%p", x)
+  result = $buf.cstring
 
 proc `$`(x: uint64): string =
   if x == 0:

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -18,7 +18,7 @@ proc reprFloat(x: float): string {.compilerproc.} = return $x
 proc reprPointer(x: pointer): string {.compilerproc.} =
   var buf: array[0..59, char]
   discard c_sprintf(buf, "%p", x)
-  return $buf
+  return newString(buf)
 
 proc `$`(x: uint64): string =
   if x == 0:
@@ -36,7 +36,7 @@ proc `$`(x: uint64): string =
     let half = i div 2
     # Reverse
     for t in 0 .. < half: swap(buf[t], buf[i-t-1])
-    result = $buf
+    result = newString(buf)
 
 proc reprStrAux(result: var string, s: cstring; len: int) =
   if cast[pointer](s) == nil:

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -17,7 +17,7 @@ proc reprFloat(x: float): string {.compilerproc.} = return $x
 
 proc reprPointer(x: pointer): string {.compilerproc.} =
   var buf: array[60, char]
-  discard c_sprintf(result[0].addr, "%p", x)
+  discard c_sprintf(buf.cstring, "%p", x)
   result = $buf.cstring
 
 proc `$`(x: uint64): string =

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -16,27 +16,27 @@ proc reprInt(x: int64): string {.compilerproc.} = return $x
 proc reprFloat(x: float): string {.compilerproc.} = return $x
 
 proc reprPointer(x: pointer): string {.compilerproc.} =
-  var buf: array[0..59, char]
-  discard c_sprintf(buf, "%p", x)
-  return newString(buf)
+  result = newString(60)
+  let newLen = c_sprintf(result[0].addr, "%p", x)
+  result.setLen newLen
 
 proc `$`(x: uint64): string =
   if x == 0:
     result = "0"
   else:
-    var buf: array[60, char]
+    result = newString(60)
     var i = 0
     var n = x
     while n != 0:
       let nn = n div 10'u64
-      buf[i] = char(n - 10'u64 * nn + ord('0'))
+      result[i] = char(n - 10'u64 * nn + ord('0'))
       inc i
       n = nn
+    result.setLen i
 
     let half = i div 2
     # Reverse
-    for t in 0 .. < half: swap(buf[t], buf[i-t-1])
-    result = newString(buf)
+    for t in 0 .. < half: swap(result[t], result[i-t-1])
 
 proc reprStrAux(result: var string, s: cstring; len: int) =
   if cast[pointer](s) == nil:

--- a/tests/async/tnewasyncudp.nim
+++ b/tests/async/tnewasyncudp.nim
@@ -54,7 +54,7 @@ proc launchSwarm(name: ptr SockAddr) {.async.} =
     k = 0
     while k < messagesToSend:
       zeroMem(addr(buffer[0]), 16384)
-      zeroMem(cast[pointer](addr(saddr)), sizeof(Sockaddr_in))      
+      zeroMem(cast[pointer](addr(saddr)), sizeof(Sockaddr_in))
       var message = "Message " & $(i * messagesToSend + k)
       await sendTo(sock, addr message[0], len(message),
                    name, sizeof(Sockaddr_in).SockLen)
@@ -62,7 +62,7 @@ proc launchSwarm(name: ptr SockAddr) {.async.} =
                                     16384, cast[ptr SockAddr](addr saddr),
                                     addr slen)
       size = 0
-      var grammString = $buffer
+      var grammString = $buffer.cstring
       if grammString == message:
         saveSendingPort(sockport)
         inc(recvCount)
@@ -84,7 +84,7 @@ proc readMessages(server: AsyncFD) {.async.} =
                                   16384, cast[ptr SockAddr](addr(saddr)),
                                   addr(slen))
     size = 0
-    var grammString = $buffer
+    var grammString = $buffer.cstring
     if grammString.startswith("Message ") and
        saddr.sin_addr.s_addr == 0x100007F:
       await sendTo(server, addr grammString[0], len(grammString),

--- a/tests/gc/gctest.nim
+++ b/tests/gc/gctest.nim
@@ -31,7 +31,7 @@ type
     of nkList: sons: seq[PCaseNode]
     else: unused: seq[string]
 
-  TIdObj* = object of TObject
+  TIdObj* = object of RootObj
     id*: int  # unique id; use this for comparisons and not the pointers
 
   PIdObj* = ref TIdObj

--- a/tests/misc/treadx.nim
+++ b/tests/misc/treadx.nim
@@ -6,9 +6,8 @@ when not defined(windows):
   var buf: array[0..10, char]
   while true:
     var r = read(0, addr(buf), sizeof(buf)-1)
-    add inp, $buf
+    add inp, $buf.cstring
     if r != sizeof(buf)-1: break
 
   echo inp
   #dafkladskölklödsaf ölksdakölfölksfklwe4iojr389wr 89uweokf sdlkf jweklr jweflksdj fioewjfsdlfsd
-

--- a/tests/system/toString.nim
+++ b/tests/system/toString.nim
@@ -46,6 +46,7 @@ doAssert dataStr == $data
 
 import strutils
 # array test
+
 let arr = ['H','e','l','l','o',' ','W','o','r','l','d','!','\0']
-doAssert $arr == "[H, e, l, l, o,  , W, o, r, l, d, !, ]"
+doAssert $arr == "[H, e, l, l, o,  , W, o, r, l, d, !, \0]"
 doAssert $arr.cstring == "Hello World!"

--- a/tests/system/toString.nim
+++ b/tests/system/toString.nim
@@ -13,9 +13,6 @@ inf
 nan
 nil
 nil
-(a: 0, b: nil)
-nil
-ptr (a: 0, b: nil)'''
 """
 
 echo($(@[23, 45]))
@@ -49,12 +46,8 @@ type
     b: string
 
 var foo1: Foo
-var foo2: ref Foo
-var foo3: ptr Foo = foo1.addr
 
-echo foo1
-echo foo2
-echo foo3
+doAssert $foo1 == "(a: 0, b: nil)"
 
 const
   data = @['a','b', '\0', 'c','d']
@@ -67,5 +60,6 @@ import strutils
 # array test
 let arr = ['H','e','l','l','o',' ','W','o','r','l','d','!','\0']
 
+# not sure if this is really a good idea
 doAssert startsWith($arr, "[H, e, l, l, o,  , W, o, r, l, d, !,")
-doAssert newString(arr) == "Hello World!"
+doAssert $arr.cstring == "Hello World!"

--- a/tests/system/toString.nim
+++ b/tests/system/toString.nim
@@ -35,7 +35,8 @@ type
 
 var foo1: Foo
 
-doAssert $foo1 == "(a: 0, b: nil)"
+# nil string should be an some point in time equal to the empty string
+doAssert(($foo1)[0..9] == "(a: 0, b: ")
 
 const
   data = @['a','b', '\0', 'c','d']

--- a/tests/system/toString.nim
+++ b/tests/system/toString.nim
@@ -1,44 +1,32 @@
 discard """
-  output:'''@[23, 45]
-@[, foo, bar]
-{a, b, c}
-2.3242
-2.982
-123912.1
-123912.1823
-5.0
-1e+100
-inf
--inf
-nan
-nil
-nil
+  output:""
 """
 
-echo($(@[23, 45]))
-echo($(@["", "foo", "bar"]))
-#echo($(["", "foo", "bar"]))
-#echo($([23, 45]))
+doAssert "@[23, 45]" == $(@[23, 45])
+doAssert  "[32, 45]" == $([32, 45])
+doAssert "@[, foo, bar]" == $(@["", "foo", "bar"])
+doAssert  "[, foo, bar]" ==  $(["", "foo", "bar"])
+
 # bug #2395
-
 let alphaSet: set[char] = {'a'..'c'}
-echo alphaSet
-
-echo($(2.3242))
-echo($(2.982))
-echo($(123912.1))
-echo($(123912.1823))
-echo($(5.0))
-echo($(1e100))
-echo($(1e1000000))
-echo($(-1e1000000))
-echo($(0.0/0.0))
+doAssert "{a, b, c}" == $alphaSet
+doAssert "2.3242" == $(2.3242)
+doAssert "2.982" == $(2.982)
+doAssert "123912.1" == $(123912.1)
+doAssert "123912.1823" == $(123912.1823)
+doAssert "5.0" == $(5.0)
+doAssert "1e+100" == $(1e100)
+doAssert "inf" == $(1e1000000)
+doAssert "-inf" == $(-1e1000000)
+doAssert "nan" == $(0.0/0.0)
 
 # nil tests
+# maybe a bit inconsistent in types
 var x: seq[string]
-var y: string
-echo(x)
-echo(y)
+doAssert "nil" == $(x)
+
+var y: string = nil
+doAssert nil == $(y)
 
 type
   Foo = object

--- a/tests/system/toString.nim
+++ b/tests/system/toString.nim
@@ -47,7 +47,5 @@ doAssert dataStr == $data
 import strutils
 # array test
 let arr = ['H','e','l','l','o',' ','W','o','r','l','d','!','\0']
-
-# not sure if this is really a good idea
-doAssert startsWith($arr, "[H, e, l, l, o,  , W, o, r, l, d, !,")
+doAssert $arr == "[H, e, l, l, o,  , W, o, r, l, d, !, ]"
 doAssert $arr.cstring == "Hello World!"

--- a/tests/system/toString.nim
+++ b/tests/system/toString.nim
@@ -12,14 +12,16 @@ inf
 -inf
 nan
 nil
-nil'''
+nil
+(a: 0, b: nil)
+nil
+ptr (a: 0, b: nil)'''
 """
 
 echo($(@[23, 45]))
 echo($(@["", "foo", "bar"]))
 #echo($(["", "foo", "bar"]))
 #echo($([23, 45]))
-
 # bug #2395
 
 let alphaSet: set[char] = {'a'..'c'}
@@ -40,3 +42,30 @@ var x: seq[string]
 var y: string
 echo(x)
 echo(y)
+
+type
+  Foo = object
+    a: int
+    b: string
+
+var foo1: Foo
+var foo2: ref Foo
+var foo3: ptr Foo = foo1.addr
+
+echo foo1
+echo foo2
+echo foo3
+
+const
+  data = @['a','b', '\0', 'c','d']
+  dataStr = $data
+
+# ensure same result when on VM or when at program execution
+doAssert dataStr == $data
+
+import strutils
+# array test
+let arr = ['H','e','l','l','o',' ','W','o','r','l','d','!','\0']
+
+doAssert startsWith($arr, "[H, e, l, l, o,  , W, o, r, l, d, !,")
+doAssert newString(arr) == "Hello World!"


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/5828
```
echo([1,2,3])
```

The result of ``$`` on array of char is now something that might need some discussion. Because by thefault `$` on `char` creates a string of one unescaped character, the resulting string might be of length 1, but with the `'\0'` as only character. If this string is concatenated into the result, the result is literally a string with a terminating `\0` in the middle.

