### PR TITLE
Fix #5920

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -264,7 +264,12 @@ else:
 
     proc getThreadId*(): int =
       result = int(lwp_gettid())
-  elif defined(macosx) or defined(freebsd) or defined(openbsd) or defined(netbsd):
+  elif defined(openbsd):
+    proc getthrid(): int32 {.importc: "getthrid", header: "<unistd.h>".}
+
+    proc getThreadId*(): int =
+      result = int(getthrid())
+  elif defined(macosx) or defined(freebsd) or defined(netbsd):
     proc pthread_threadid_np(y: pointer; x: var uint64): cint {.importc, header: "pthread.h".}
 
     proc getThreadId*(): int =

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -269,7 +269,12 @@ else:
 
     proc getThreadId*(): int =
       result = int(getthrid())
-  elif defined(macosx) or defined(freebsd) or defined(netbsd):
+  elif defined(netbsd):
+    proc lwp_self(): int32 {.importc: "_lwp_self", header: "<lwp.h>".}
+
+    proc getThreadId*(): int =
+      result = int(lwp_self())
+  elif defined(macosx) or defined(freebsd):
     proc pthread_threadid_np(y: pointer; x: var uint64): cint {.importc, header: "pthread.h".}
 
     proc getThreadId*(): int =


### PR DESCRIPTION
Fix #5920.
Use native `getthrid()` instead of `pthread_threadid_np()` on OpenBSD.
The `getthrid()` syscall appeared in OpenBSD 3.9.
