### PR TITLE
add a proc that returns a set of all the members of an enum type

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3851,6 +3851,8 @@ template closureScope*(body: untyped): untyped =
   ##   myClosure() # outputs 3
   (proc() = body)()
 
+  include "system/enums"
+
 {.pop.} #{.push warning[GcMem]: off, warning[Uninit]: off.}
 
 when defined(nimconfig):

--- a/lib/system/enums.nim
+++ b/lib/system/enums.nim
@@ -1,0 +1,14 @@
+import macros
+
+# XXX: https://github.com/nim-lang/Nim/issues/5881
+macro setImpl(T: typedesc[enum]): auto =
+    result = newNimNode(nnkCurly)
+    for T in T.getType[1]:
+        if T.kind != nnkEmpty: result.add T
+
+# XXX: it should be possible to apply 'compileTime' to this proc
+proc set*(T: typedesc[enum]): auto =
+    ## generates a set that contains all the members of the enum type `T`.
+    ## It's currently not possible to specify the concrete return type
+    ## (set[T]).
+    T.setImpl

--- a/lib/system/enums.nim
+++ b/lib/system/enums.nim
@@ -3,8 +3,8 @@ import macros
 # XXX: https://github.com/nim-lang/Nim/issues/5881
 macro setImpl(T: typedesc[enum]): auto =
     result = newNimNode(nnkCurly)
-    for T in T.getType[1]:
-        if T.kind != nnkEmpty: result.add T
+    for m in T.getType[1]:
+        if m.kind != nnkEmpty: result.add m
 
 # XXX: it should be possible to apply 'compileTime' to this proc
 proc set*(T: typedesc[enum]): auto =


### PR DESCRIPTION
Can this be implemented with a macro? One thing that doesn't work right now is validating the enum range since it's not possible to pass the typedesc to `high`