### PR TITLE
restrict casting for closure.

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -229,7 +229,10 @@ proc semCast(c: PContext, n: PNode): PNode =
   if tfHasMeta in targetType.flags:
     localError(n.sons[0].info, errCastToANonConcreteType, $targetType)
   if not isCastable(targetType, castedExpr.typ):
-    localError(n.info, errExprCannotBeCastToX, $targetType & "=" & typeToString( targetType, preferDesc))
+    let tar = $targetType
+    let alt = typeToString(targetType, preferDesc)
+    let msg = if tar != alt: tar & "=" & alt else: tar
+    localError(n.info, errExprCannotBeCastToX, msg)
   result = newNodeI(nkCast, n.info)
   result.typ = targetType
   addSon(result, copyTree(n.sons[0]))

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -152,6 +152,8 @@ proc isCastable(dst, src: PType): bool =
     result = false
   elif typeAllowed(dst, skParam) != nil:
     result = false
+  elif dst.kind == tyProc and dst.callConv == ccClosure:
+    result = src.kind == tyProc and src.callConv == ccClosure
   else:
     result = (dstSize >= srcSize) or
         (skipTypes(dst, abstractInst).kind in IntegralTypes) or
@@ -227,7 +229,7 @@ proc semCast(c: PContext, n: PNode): PNode =
   if tfHasMeta in targetType.flags:
     localError(n.sons[0].info, errCastToANonConcreteType, $targetType)
   if not isCastable(targetType, castedExpr.typ):
-    localError(n.info, errExprCannotBeCastToX, $targetType)
+    localError(n.info, errExprCannotBeCastToX, $targetType & "=" & typeToString( targetType, preferDesc))
   result = newNodeI(nkCast, n.info)
   result.typ = targetType
   addSon(result, copyTree(n.sons[0]))

--- a/tests/misc/tcast.nim
+++ b/tests/misc/tcast.nim
@@ -1,0 +1,23 @@
+discard """
+  output: '''
+Hello World
+Hello World'''
+"""
+type MyProc = proc() {.cdecl.}
+type MyProc2 = proc() {.nimcall.}
+type MyProc3 = proc() #{.closure.} is implicit
+
+proc testProc()  = echo "Hello World"
+
+proc callPointer(p: pointer) =
+  # can cast to proc(){.cdecl.}
+  let ffunc0 = cast[MyProc](p)
+  # can cast to proc(){.nimcall.}
+  let ffunc1 = cast[MyProc2](p)
+  # cannot cast to proc(){.closure.}
+  doAssert(not compiles(cast[MyProc3](p)))
+
+  ffunc0()
+  ffunc1()
+
+callPointer(cast[pointer](testProc))


### PR DESCRIPTION
This commit forbid casting a closure to anything other than another
closure. use rawEnv/rawProc to access underlaying pointers.
This solve issue #5742 