### PR TITLE
Add intel compiler to condition

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -81,7 +81,7 @@ when defined(posix) and not defined(JS):
 elif defined(windows):
   import winlean
 
-  when defined(vcc) or defined(bcc):
+  when defined(vcc) or defined(bcc) or defined(icl):
     # newest version of Visual C++ defines time_t to be of 64 bits
     type TimeImpl {.importc: "time_t", header: "<time.h>".} = int64
     # visual c's c runtime exposes these under a different name


### PR DESCRIPTION
Compilation would fail without it:
```bash
E:\Projects\OsuReplay\src\nimcache\stdlib_times.c(104): error: identifier "timezone" is undefined
        result = timezone;
                 ^

compilation aborted for E:\Projects\OsuReplay\src\nimcache\stdlib_times.c (code 2)
```