### PR TITLE
Update osproc.nim to allow passing stdin, stdout and stderr handles i…

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -65,6 +65,20 @@ type
 const poUseShell* {.deprecated.} = poUsePath
   ## Deprecated alias for poUsePath.
 
+proc getRealHandle*(handle: cint) : Handle = 
+  ## Converts a C file handle to a platform native equivalent.
+  ## On Windows this uses ``_get_osfhandle`` to return a Windows 
+  ## native Handle. 
+  ## On all other platforms, the C file handle is returned.
+  ## The primary use case for this is to be able to pass
+  ## file handles for stdin/stdout/stderr to ``startProcess``
+  ## without needing to worry about platform specific issues. 
+  ## e.g. ``startProcess(..., hOut=f.getFileHandle().getRealHandle())``
+  when defined(windows):
+    result = get_osfhandle(handle)
+  else:
+    result = handle
+
 proc quoteShellWindows*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
   ## Quote s, so it can be safely passed to Windows API.
   ## Based on Python's subprocess.list2cmdline
@@ -165,7 +179,8 @@ proc startProcess*(command: string,
   ## to `startProcess`. See the documentation of ``ProcessOption`` for the
   ## meaning of these flags. `hIn`, `hOut`, and `hErr` are optional parameters for
   ## supplying your own handles for stdin, stdout, and stderr. These are only valid
-  ## when you have not specified poParentStreams in `options`. 
+  ## when you have not specified poParentStreams in `options`. See the documentation
+  ## of ``getRealHandle`` for how to specify these in a cross platform way. 
   ## You need to `close` the process when done.
   ##
   ## Note that you can't pass any `args` if you use the option

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -378,8 +378,8 @@ when not defined(useNimRtl):
       elif not running(p): break
     close(p)
 
-proc assertNoHandlesWithParentStreams(hIn, hOut, hErr: Handle) = 
-  let msg = "Can not pass in/out/err handles when poParentStreams is set"
+template assertNoHandlesWithParentStreams(hIn, hOut, hErr: Handle) = 
+  const msg = "Can not pass in/out/err handles when poParentStreams is set"
   assert(hIn == INVALID_HANDLE_VALUE, msg)
   assert(hOut == INVALID_HANDLE_VALUE, msg)
   assert(hErr == INVALID_HANDLE_VALUE, msg)

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -557,10 +557,12 @@ when defined(Windows) and not defined(useNimRtl):
       if poInteractive notin options:
         createPipeHandles(si.hStdInput, hi)
         if hIn != INVALID_HANDLE_VALUE:
+          fileClose(si.hStdInput)
           si.hStdInput = hIn
 
         createPipeHandles(ho, si.hStdOutput)
         if hOut != INVALID_HANDLE_VALUE:
+          fileClose(si.hStdOutput)
           si.hStdOutput = hOut
 
         if poStdErrToStdOut in options:
@@ -569,6 +571,7 @@ when defined(Windows) and not defined(useNimRtl):
         else:
           createPipeHandles(he, si.hStdError)
           if hErr != INVALID_HANDLE_VALUE:
+            fileClose(si.hStdError)
             si.hStdError = hErr
       else:
         createAllPipeHandles(si, hi, ho, he, cast[int](result))

--- a/tests/osproc/tstderr_fh.nim
+++ b/tests/osproc/tstderr_fh.nim
@@ -13,8 +13,6 @@ Got expected assertion when supplying hErr with poParentStreams
 # test that stderr filehandle can be supplied directly
 
 import osproc, os, streams
-when defined(windows):
-  from winlean import get_osfhandle, Handle
 
 const filename = addFileExt("ta_out", ExeExt)
 
@@ -25,12 +23,7 @@ let errname = getCurrentDir() / "tests" / "osproc" / "tstderr.txt"
 var errfile: File
 doAssert errfile.open(errname, fmWrite, bufSize=0)
 
-when defined(windows):
-  var
-    errfileHandle = errfile.getFileHandle()
-    errhandle = errfileHandle.get_osfhandle()
-else:
-  var errhandle = errfile.getFileHandle()
+var errhandle = errfile.getFileHandle().getRealHandle()
 
 var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                      options={},  # explicitly disable stdErrToStdOut
@@ -43,11 +36,7 @@ stdout.write readFile(errname)
 echo "--------------------------------------"
 
 doAssert errfile.open(errname, fmWrite, bufSize=0)
-when defined(windows):
-  errfileHandle = errfile.getFileHandle()
-  errhandle = errfileHandle.get_osfhandle()
-else:
-  errhandle = errfile.getFileHandle()
+errhandle = errfile.getFileHandle().getRealHandle()
 
 p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                  options={poStdErrToStdOut},
@@ -61,11 +50,7 @@ stdout.write readFile(errname)
 echo "--------------------------------------"
 
 doAssert errfile.open(errname, fmWrite, bufSize=0)
-when defined(windows):
-  errfileHandle = errfile.getFileHandle()
-  errhandle = errfileHandle.get_osfhandle()
-else:
-  errhandle = errfile.getFileHandle()
+errhandle = errfile.getFileHandle().getRealHandle()
 try:
   p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                   options={poParentStreams},

--- a/tests/osproc/tstderr_fh.nim
+++ b/tests/osproc/tstderr_fh.nim
@@ -1,0 +1,78 @@
+discard """
+  output: '''--------------------------------------
+to stderr
+to stderr
+--------------------------------------
+--------------------------------------
+--------------------------------------
+--------------------------------------
+Got expected assertion when supplying hErr with poParentStreams
+--------------------------------------'''
+"""
+
+# test that stderr filehandle can be supplied directly
+
+import osproc, os, streams
+when defined(windows):
+  from winlean import get_osfhandle, Handle
+
+const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+let errname = getCurrentDir() / "tests" / "osproc" / "tstderr.txt"
+
+var errfile: File
+doAssert errfile.open(errname, fmWrite, bufSize=0)
+
+when defined(windows):
+  var
+    errfileHandle = errfile.getFileHandle()
+    errhandle = errfileHandle.get_osfhandle()
+else:
+  var errhandle = errfile.getFileHandle()
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     options={},  # explicitly disable stdErrToStdOut
+                     hErr = errhandle)
+discard p.waitForExit
+errfile.close()
+
+echo "--------------------------------------"
+stdout.write readFile(errname)
+echo "--------------------------------------"
+
+doAssert errfile.open(errname, fmWrite, bufSize=0)
+when defined(windows):
+  errfileHandle = errfile.getFileHandle()
+  errhandle = errfileHandle.get_osfhandle()
+else:
+  errhandle = errfile.getFileHandle()
+
+p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                 options={poStdErrToStdOut},
+                 hErr = errhandle)
+discard p.waitForExit
+errfile.close()
+
+# we expect nothing here since stderr was sent to stdout
+echo "--------------------------------------"
+stdout.write readFile(errname)
+echo "--------------------------------------"
+
+doAssert errfile.open(errname, fmWrite, bufSize=0)
+when defined(windows):
+  errfileHandle = errfile.getFileHandle()
+  errhandle = errfileHandle.get_osfhandle()
+else:
+  errhandle = errfile.getFileHandle()
+try:
+  p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                  options={poParentStreams},
+                  hErr = errhandle)
+  discard p.waitForExit
+except AssertionError:
+  echo "--------------------------------------"
+  echo "Got expected assertion when supplying hErr with poParentStreams"
+  echo "--------------------------------------"
+errfile.close()

--- a/tests/osproc/tstderr_fh.nim
+++ b/tests/osproc/tstderr_fh.nim
@@ -16,7 +16,7 @@ import osproc, os, streams
 when defined(windows):
   from winlean import get_osfhandle, Handle
 
-const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+const filename = addFileExt("ta_out", ExeExt)
 
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 

--- a/tests/osproc/tstdin_fh.nim
+++ b/tests/osproc/tstdin_fh.nim
@@ -8,8 +8,6 @@ Got expected assertion when supplying hIn with poParentStreams
 
 # test that stdin filehandle can be supplied directly
 import osproc, os, streams
-when defined(windows):
-  from winlean import get_osfhandle, Handle
 
 const filename = addFileExt("ta_in", ExeExt)
 
@@ -21,13 +19,7 @@ writeFile(inname, "5\n")
 
 var infile: File
 doAssert infile.open(inname, fmRead)
-when defined(windows):
-  var
-    infileHandle = infile.getFileHandle()
-    inhandle = infileHandle.get_osfhandle()
-else:
-  var inhandle = infile.getFileHandle()
-
+var inhandle = infile.getFileHandle().getRealHandle()
 
 var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                      hIn = inhandle)
@@ -41,11 +33,7 @@ while true:
 
 
 doAssert infile.open(inname, fmRead)
-when defined(windows):
-  infileHandle = infile.getFileHandle()
-  inhandle = infileHandle.get_osfhandle()
-else:
-  inhandle = infile.getFileHandle()
+inhandle = infile.getFileHandle().getRealHandle()
 try:
   p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                   options={poParentStreams},

--- a/tests/osproc/tstdin_fh.nim
+++ b/tests/osproc/tstdin_fh.nim
@@ -1,0 +1,58 @@
+discard """
+  file: "tstdin_fh.nim"
+  output: '''10
+--------------------------------------
+Got expected assertion when supplying hIn with poParentStreams
+--------------------------------------'''
+"""
+
+# test that stdin filehandle can be supplied directly
+import osproc, os, streams
+when defined(windows):
+  from winlean import get_osfhandle, Handle
+
+const filename = when defined(Windows): "ta_in.exe" else: "ta_in"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+let inname = getCurrentDir() / "tests" / "osproc" / "tstdin.txt"
+
+writeFile(inname, "5\n")
+
+var infile: File
+doAssert infile.open(inname, fmRead)
+when defined(windows):
+  var
+    infileHandle = infile.getFileHandle()
+    inhandle = infileHandle.get_osfhandle()
+else:
+  var inhandle = infile.getFileHandle()
+
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     hIn = inhandle)
+
+while true:
+  let line = p.outputStream.readLine()
+  if line != "":
+    echo line
+  else:
+    break
+
+
+doAssert infile.open(inname, fmRead)
+when defined(windows):
+  infileHandle = infile.getFileHandle()
+  inhandle = infileHandle.get_osfhandle()
+else:
+  inhandle = infile.getFileHandle()
+try:
+  p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                  options={poParentStreams},
+                  hIn = infile.getFileHandle())
+  discard p.waitForExit
+except AssertionError:
+  echo "--------------------------------------"
+  echo "Got expected assertion when supplying hIn with poParentStreams"
+  echo "--------------------------------------"
+infile.close()

--- a/tests/osproc/tstdin_fh.nim
+++ b/tests/osproc/tstdin_fh.nim
@@ -11,7 +11,7 @@ import osproc, os, streams
 when defined(windows):
   from winlean import get_osfhandle, Handle
 
-const filename = when defined(Windows): "ta_in.exe" else: "ta_in"
+const filename = addFileExt("ta_in", ExeExt)
 
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 

--- a/tests/osproc/tstdout_fh.nim
+++ b/tests/osproc/tstdout_fh.nim
@@ -24,7 +24,7 @@ import osproc, os, streams
 when defined(windows):
   from winlean import get_osfhandle, Handle
 
-const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+const filename = addFileExt("ta_out", ExeExt)
 
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 

--- a/tests/osproc/tstdout_fh.nim
+++ b/tests/osproc/tstdout_fh.nim
@@ -21,8 +21,6 @@ Got expected assertion when supplying hOut with poParentStreams
 # test that stdout filehandle can be supplied directly
 
 import osproc, os, streams
-when defined(windows):
-  from winlean import get_osfhandle, Handle
 
 const filename = addFileExt("ta_out", ExeExt)
 
@@ -33,12 +31,7 @@ let outname = getCurrentDir() / "tests" / "osproc" / "tstdout.txt"
 var outfile: File
 doAssert outfile.open(outname, fmWrite, bufSize=0)
 
-when defined(windows):
-  var
-    outfileHandle = outfile.getFileHandle()
-    outhandle = outfileHandle.get_osfhandle()
-else:
-  var outhandle = outfile.getFileHandle()
+var outhandle = outfile.getFileHandle().getRealHandle()
 
 var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                      options={},  # explicitly disable stdErrToStdOut
@@ -52,11 +45,7 @@ echo "--------------------------------------"
 
 
 doAssert outfile.open(outname, fmWrite, bufSize=0)
-when defined(windows):
-  outfileHandle = outfile.getFileHandle()
-  outhandle = outfileHandle.get_osfhandle()
-else:
-  outhandle = outfile.getFileHandle()
+outhandle = outfile.getFileHandle().getRealHandle()
 
 p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                  options={poStdErrToStdOut},
@@ -70,11 +59,7 @@ echo "--------------------------------------"
 
 
 doAssert outfile.open(outname, fmWrite, bufSize=0)
-when defined(windows):
-  outfileHandle = outfile.getFileHandle()
-  outhandle = outfileHandle.get_osfhandle()
-else:
-  outhandle = outfile.getFileHandle()
+outhandle = outfile.getFileHandle().getRealHandle()
 
 try:
   p = startProcess(filename, getCurrentDir() / "tests" / "osproc",

--- a/tests/osproc/tstdout_fh.nim
+++ b/tests/osproc/tstdout_fh.nim
@@ -1,0 +1,88 @@
+discard """
+  output: '''--------------------------------------
+to stdout
+to stdout
+to stdout
+to stdout
+--------------------------------------
+--------------------------------------
+to stdout
+to stdout
+to stderr
+to stderr
+to stdout
+to stdout
+--------------------------------------
+--------------------------------------
+Got expected assertion when supplying hOut with poParentStreams
+--------------------------------------'''
+"""
+
+# test that stdout filehandle can be supplied directly
+
+import osproc, os, streams
+when defined(windows):
+  from winlean import get_osfhandle, Handle
+
+const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+let outname = getCurrentDir() / "tests" / "osproc" / "tstdout.txt"
+
+var outfile: File
+doAssert outfile.open(outname, fmWrite, bufSize=0)
+
+when defined(windows):
+  var
+    outfileHandle = outfile.getFileHandle()
+    outhandle = outfileHandle.get_osfhandle()
+else:
+  var outhandle = outfile.getFileHandle()
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     options={},  # explicitly disable stdErrToStdOut
+                     hOut = outhandle)
+discard p.waitForExit
+outfile.close()
+
+echo "--------------------------------------"
+stdout.write readFile(outname)
+echo "--------------------------------------"
+
+
+doAssert outfile.open(outname, fmWrite, bufSize=0)
+when defined(windows):
+  outfileHandle = outfile.getFileHandle()
+  outhandle = outfileHandle.get_osfhandle()
+else:
+  outhandle = outfile.getFileHandle()
+
+p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                 options={poStdErrToStdOut},
+                 hOut = outhandle)
+discard p.waitForExit
+outfile.close()
+
+echo "--------------------------------------"
+stdout.write readFile(outname)
+echo "--------------------------------------"
+
+
+doAssert outfile.open(outname, fmWrite, bufSize=0)
+when defined(windows):
+  outfileHandle = outfile.getFileHandle()
+  outhandle = outfileHandle.get_osfhandle()
+else:
+  outhandle = outfile.getFileHandle()
+
+try:
+  p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                  options={poParentStreams},
+                  hOut = outfile.getFileHandle())
+  discard p.waitForExit
+except AssertionError:
+  echo "--------------------------------------"
+  echo "Got expected assertion when supplying hOut with poParentStreams"
+  echo "--------------------------------------"
+outfile.close()

--- a/tests/osproc/tstdouterr_fh.nim
+++ b/tests/osproc/tstdouterr_fh.nim
@@ -24,8 +24,6 @@ to stdout
 # test that stdout filehandle can be supplied directly
 # (this test is essentially a clone of tstdout.nim)
 import osproc, os, streams
-when defined(windows):
-  from winlean import get_osfhandle, Handle
 
 const filename = addFileExt("ta_out", ExeExt)
 
@@ -40,17 +38,9 @@ var
   errfile: File
 doAssert outfile.open(outname, fmWrite, bufSize=0)
 doAssert errfile.open(errname, fmWrite, bufSize=0)
-when defined(windows):
-  var
-    outfileHandle = outfile.getFileHandle()
-    outhandle = outfileHandle.get_osfhandle()
-    errfileHandle = errfile.getFileHandle()
-    errhandle = errfileHandle.get_osfhandle()
-else:
-  var
-    outhandle = outfile.getFileHandle()
-    errhandle = errfile.getFileHandle()
-
+var
+  outhandle = outfile.getFileHandle().getRealHandle()
+  errhandle = errfile.getFileHandle().getRealHandle()
 
 var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                      options={},  # explicitly disable stdErrToStdOut
@@ -70,14 +60,8 @@ echo "--------------------------------------"
 
 doAssert outfile.open(outname, fmWrite, bufSize=0)
 doAssert errfile.open(errname, fmWrite, bufSize=0)
-when defined(windows):
-  outfileHandle = outfile.getFileHandle()
-  outhandle = outfileHandle.get_osfhandle()
-  errfileHandle = errfile.getFileHandle()
-  errhandle = errfileHandle.get_osfhandle()
-else:
-  outhandle = outfile.getFileHandle()
-  errhandle = errfile.getFileHandle()
+outhandle = outfile.getFileHandle().getRealHandle()
+errhandle = errfile.getFileHandle().getRealHandle()
 
 p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
                  options={poStdErrToStdOut},

--- a/tests/osproc/tstdouterr_fh.nim
+++ b/tests/osproc/tstdouterr_fh.nim
@@ -27,7 +27,7 @@ import osproc, os, streams
 when defined(windows):
   from winlean import get_osfhandle, Handle
 
-const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+const filename = addFileExt("ta_out", ExeExt)
 
 doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
 

--- a/tests/osproc/tstdouterr_fh.nim
+++ b/tests/osproc/tstdouterr_fh.nim
@@ -1,0 +1,96 @@
+discard """
+  output: '''------------- stdout -----------------
+to stdout
+to stdout
+to stdout
+to stdout
+--------------------------------------
+------------- stderr -----------------
+to stderr
+to stderr
+--------------------------------------
+------------- stdout -----------------
+to stdout
+to stdout
+to stderr
+to stderr
+to stdout
+to stdout
+--------------------------------------
+------------- stderr -----------------
+--------------------------------------'''
+"""
+
+# test that stdout filehandle can be supplied directly
+# (this test is essentially a clone of tstdout.nim)
+import osproc, os, streams
+when defined(windows):
+  from winlean import get_osfhandle, Handle
+
+const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+let
+  outname = getCurrentDir() / "tests" / "osproc" / "tstdout.txt"
+  errname = getCurrentDir() / "tests" / "osproc" / "tstderr.txt"
+
+var
+  outfile: File
+  errfile: File
+doAssert outfile.open(outname, fmWrite, bufSize=0)
+doAssert errfile.open(errname, fmWrite, bufSize=0)
+when defined(windows):
+  var
+    outfileHandle = outfile.getFileHandle()
+    outhandle = outfileHandle.get_osfhandle()
+    errfileHandle = errfile.getFileHandle()
+    errhandle = errfileHandle.get_osfhandle()
+else:
+  var
+    outhandle = outfile.getFileHandle()
+    errhandle = errfile.getFileHandle()
+
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     options={},  # explicitly disable stdErrToStdOut
+                     hOut = outhandle, 
+                     hErr = errhandle)
+discard p.waitForExit
+outfile.close()
+errfile.close()
+
+echo "------------- stdout -----------------"
+stdout.write readFile(outname)
+echo "--------------------------------------"
+
+echo "------------- stderr -----------------"
+stdout.write readFile(errname)
+echo "--------------------------------------"
+
+doAssert outfile.open(outname, fmWrite, bufSize=0)
+doAssert errfile.open(errname, fmWrite, bufSize=0)
+when defined(windows):
+  outfileHandle = outfile.getFileHandle()
+  outhandle = outfileHandle.get_osfhandle()
+  errfileHandle = errfile.getFileHandle()
+  errhandle = errfileHandle.get_osfhandle()
+else:
+  outhandle = outfile.getFileHandle()
+  errhandle = errfile.getFileHandle()
+
+p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                 options={poStdErrToStdOut},
+                 hOut = outhandle, 
+                 hErr = errhandle)
+discard p.waitForExit
+outfile.close()
+errfile.close()
+
+echo "------------- stdout -----------------"
+stdout.write readFile(outname)
+echo "--------------------------------------"
+
+echo "------------- stderr -----------------"
+stdout.write readFile(errname)
+echo "--------------------------------------"


### PR DESCRIPTION
…n the ''startProcess'' proc.  Includes tests to validate this.

This is for issue #6001 