### PR TITLE
Adding a NetworkStream type

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -138,7 +138,7 @@ type
       of false: nil
     lastError: OSErrorCode ## stores the last error on this socket
     domain: Domain
-    sockType: SockType
+    sockType*: SockType
     protocol: Protocol
 
   Socket* = ref SocketImpl


### PR DESCRIPTION
This PR implements a `NetworkStream` type. It also slightly modifies the `net` module to expose the `sockType` to ensure that the socket being used to create a `NetworkStream` is a stream type socket.

The NetworkStream doesn't support setting/getting position and as such doesn't support peeking data. Should these procedures just do nothing, or should they throw exceptions? The [.net `NetworkStream` type throws a `NotSupportedException` when using its `Position` property](https://msdn.microsoft.com/en-us/library/system.net.sockets.networkstream.position(v=vs.110).aspx).

There are also no tests included with this PR at the minute, though I have tested it manually. What is the procedure for testing networking related code where some kind of server is required?