### PR TITLE
Add convenience cut template to strutils

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2266,6 +2266,24 @@ proc removeSuffix*(s: var string, suffix: string) {.
     newLen -= len(suffix)
     s.setLen(newLen)
 
+template cut*(s: string, left = 0, right = 0): string =
+  ## Cuts the specified number of characters from the left or right side of a string.
+  ##
+  ## A call to ``cut`` is transformed to the corresponding string-slicing operation.
+  ##
+  ## .. code-block:: nim
+  ##   assert "Hello World".cut(right = 6) == "Hello"
+  ##   assert "Hello World".cut(left = 6) == "World"
+  ##   assert "Hello World".cut(left = 4, right = 4) == "o W"
+  ##
+  ## is transformed into:
+  ##
+  ## .. code-block:: nim
+  ##   assert "Hello World"[0 .. ^(6 + 1)] == "Hello"
+  ##   assert "Hello World"[6 .. ^1] == "World"
+  ##   assert "Hello World"[4 .. ^(4 + 1)] == "o W"
+  s[left .. ^(right + 1)]
+
 when isMainModule:
   doAssert align("abc", 4) == " abc"
   doAssert align("a", 0) == "a"
@@ -2475,5 +2493,9 @@ bar
     doAssert s.endsWith('f')
     doAssert s.endsWith('a') == false
     doAssert s.endsWith('\0') == false
+
+  doAssert "Hello World".cut(right = 6) == "Hello"
+  doAssert "Hello World".cut(left = 6) == "World"
+  doAssert "Hello World".cut(left = 4, right = 4) == "o W"
 
   #echo("strutils tests passed")


### PR DESCRIPTION
* In order to be able to do less cryptic string slicing, introduce the `cut` template that provides the correct slicing operation for cutting `n` characters from either the left or the right side (or both).
* Add the `alignLeft` proc to mirror the already existing `align` proc (which does right-alignment)
