### PR TITLE
Add left-aligning string proc to strutils

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1092,8 +1092,8 @@ proc alignLeft*(s: string, count: Natural, padding = ' '): string {.noSideEffect
   ##   assert alignLeft("1232", 6, '#') == "1232##"
   if s.len < count:
     result = newString(count)
-    for i in 0 ..< s.len:
-      result[i] = s[i]
+    if s.len > 0:
+      result[0 .. (s.len - 1)] = s
     for i in s.len ..< count:
       result[i] = padding
   else:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1061,8 +1061,8 @@ proc align*(s: string, count: Natural, padding = ' '): string {.
   ##
   ## `padding` characters (by default spaces) are added before `s` resulting in
   ## right alignment. If ``s.len >= count``, no spaces are added and `s` is
-  ## returned unchanged. If you need to left align a string use the `repeatChar
-  ## proc <#repeatChar>`_. Example:
+  ## returned unchanged. If you need to left align a string use the `alignLeft
+  ## proc <#alignLeft>`_. Example:
   ##
   ## .. code-block:: nim
   ##   assert align("abc", 4) == " abc"
@@ -1074,6 +1074,28 @@ proc align*(s: string, count: Natural, padding = ' '): string {.
     let spaces = count - s.len
     for i in 0..spaces-1: result[i] = padding
     for i in spaces..count-1: result[i] = s[i-spaces]
+  else:
+    result = s
+
+proc alignLeft*(s: string, count: Natural, padding = ' '): string {.noSideEffect.} =
+  ## Left-Aligns a string `s` with `padding`, so that it is of length `count`.
+  ##
+  ## `padding` characters (by default spaces) are added after `s` resulting in
+  ## left alignment. If ``s.len >= count``, no spaces are added and `s` is
+  ## returned unchanged. If you need to right align a string use the `align
+  ## proc <#align>`_. Example:
+  ##
+  ## .. code-block:: nim
+  ##   assert alignLeft("abc", 4) == "abc "
+  ##   assert alignLeft("a", 0) == "a"
+  ##   assert alignLeft("1232", 6) == "1232  "
+  ##   assert alignLeft("1232", 6, '#') == "1232##"
+  if s.len < count:
+    result = newString(count)
+    for i in 0 ..< s.len:
+      result[i] = s[i]
+    for i in s.len ..< count:
+      result[i] = padding
   else:
     result = s
 
@@ -2271,6 +2293,11 @@ when isMainModule:
   doAssert align("a", 0) == "a"
   doAssert align("1232", 6) == "  1232"
   doAssert align("1232", 6, '#') == "##1232"
+
+  doAssert alignLeft("abc", 4) == "abc "
+  doAssert alignLeft("a", 0) == "a"
+  doAssert alignLeft("1232", 6) == "1232  "
+  doAssert alignLeft("1232", 6, '#') == "1232##"
 
   let
     inp = """ this is a long text --  muchlongerthan10chars and here


### PR DESCRIPTION
Add the alignLeft proc to mirror the already existing align proc (which does right-alignment)

*Moved here into its own seperate PR from [original PR #6023](https://github.com/nim-lang/Nim/pull/6023)*

*Includes changes from https://github.com/nim-lang/Nim/pull/6023#pullrequestreview-46885169 by @euantorano*