### PR TITLE
gc: add GC_fastCollect

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2471,6 +2471,10 @@ when not defined(nimscript) and hasAlloc:
       ## forces a full garbage collection pass.
       ## Ordinary code does not need to call this (and should not).
 
+    proc GC_fastCollect*() {.rtl, benign.}
+      ## forces a fast garbage collection pass.
+      ## This will typically be faster than GC_fullCollect and may not collect cycles.
+
     proc GC_setStrategy*(strategy: GC_Strategy) {.rtl, deprecated, benign.}
       ## tells the GC the desired strategy for the application.
       ## **Deprecated** since version 0.8.14. This has always been a nop.
@@ -2508,6 +2512,9 @@ when not defined(nimscript) and hasAlloc:
 
     template GC_fullCollect* =
       {.warning: "GC_fullCollect is a no-op in JavaScript".}
+
+    template GC_fastCollect* =
+      {.warning: "GC_fastCollect is a no-op in JavaScript".}
 
     template GC_setStrategy* =
       {.warning: "GC_setStrategy is a no-op in JavaScript".}

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -944,6 +944,14 @@ when not defined(useNimRtl):
     gch.cycleThreshold = oldThreshold
     release(gch)
 
+  proc GC_fastCollect() =
+    acquire(gch)
+    var oldThreshold = gch.cycleThreshold
+    gch.cycleThreshold = high(gch.cycleThreshold)-1 # disable cycle collection
+    collectCTBody(gch)
+    gch.cycleThreshold = oldThreshold
+    release(gch)
+
   proc GC_getStatistics(): string =
     GC_disable()
     result = "[GC] total memory: " & $(getTotalMem()) & "\n" &

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -1023,6 +1023,12 @@ when not defined(useNimRtl):
     collectCT(gch)
     gch.cycleThreshold = oldThreshold
 
+  proc GC_fastCollect() =
+    var oldThreshold = gch.cycleThreshold
+    gch.cycleThreshold = high(gch.cycleThreshold)-1 # disable cycle collection
+    collectCT(gch)
+    gch.cycleThreshold = oldThreshold
+
   proc GC_getStatistics(): string =
     GC_disable()
     result = "[GC] total memory: " & $(getTotalMem()) & "\n" &

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -529,6 +529,14 @@ when not defined(useNimRtl):
     gch.cycleThreshold = oldThreshold
     release(gch)
 
+  proc GC_fastCollect() =
+    acquire(gch)
+    var oldThreshold = gch.cycleThreshold
+    gch.cycleThreshold = high(gch.cycleThreshold)-1 # disable cycle collection
+    collectCT(gch)
+    gch.cycleThreshold = oldThreshold
+    release(gch)
+
   proc GC_getStatistics(): string =
     GC_disable()
     result = "[GC] total memory: " & $getTotalMem() & "\n" &

--- a/lib/system/gc_stack.nim
+++ b/lib/system/gc_stack.nim
@@ -454,6 +454,7 @@ when hasThreadSupport:
 proc GC_disable() = discard
 proc GC_enable() = discard
 proc GC_fullCollect() = discard
+proc GC_fastCollect() = discard
 proc GC_setStrategy(strategy: GC_Strategy) = discard
 proc GC_enableMarkAndSweep() = discard
 proc GC_disableMarkAndSweep() = discard

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -138,6 +138,7 @@ when defined(boehmgc):
     proc GC_disable() = boehmGC_disable()
     proc GC_enable() = boehmGC_enable()
     proc GC_fullCollect() = boehmGCfullCollect()
+    proc GC_fastCollect() = GC_fullCollect()
     proc GC_setStrategy(strategy: GC_Strategy) = discard
     proc GC_enableMarkAndSweep() = discard
     proc GC_disableMarkAndSweep() = discard
@@ -208,6 +209,7 @@ elif defined(gogc):
   proc GC_enable() = discard
   proc goRuntimeGC(force: int32) {.importc: "runtime_gc", dynlib: goLib.}
   proc GC_fullCollect() = goRuntimeGC(2)
+  proc GC_fastCollect() = GC_fullCollect()
   proc GC_setStrategy(strategy: GC_Strategy) = discard
   proc GC_enableMarkAndSweep() = discard
   proc GC_disableMarkAndSweep() = discard
@@ -507,6 +509,7 @@ elif defined(nogc):
   proc GC_disable() = discard
   proc GC_enable() = discard
   proc GC_fullCollect() = discard
+  proc GC_fastCollect() = discard
   proc GC_setStrategy(strategy: GC_Strategy) = discard
   proc GC_enableMarkAndSweep() = discard
   proc GC_disableMarkAndSweep() = discard


### PR DESCRIPTION
```
proc GC_fastCollect*() {.rtl, benign.}
     ## forces a fast garbage collection pass.
     ## This will typically be faster than GC_fullCollect and may not collect cycles.
```

Nim default GC uses deferred reference couting which is precise (apart for marking the stack). In event loop based programs, program reach a point when stack is really small many times a second. By triggering garbage collection at this point, we can cheaply guarantee that all resources will be freed. This makes it possible to use GC to release resources like sockets or files.

This commit adds `GC_fastCollect`, which is supposed to trigger cheap garbage collection pass. In default GC, it only marks stack and processes ZCT.