### PR TITLE
Lineinfo change

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -746,7 +746,7 @@ proc toFileLine*(info: TLineInfo): string {.inline.} =
   result = info.toFilename & ":" & $info.line
 
 proc toFileLineCol*(info: TLineInfo): string {.inline.} =
-  result = info.toFilename & "(" & $info.line & "," & $info.col & ")"
+  result = info.toFilename & "(" & $info.line & ", " & $info.col & ")"
 
 proc `$`*(info: TLineInfo): string = toFileLineCol(info)
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1307,19 +1307,24 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       ensureKind(rkNode)
       if c.callsite != nil: regs[ra].node = c.callsite
       else: stackTrace(c, tos, pc, errFieldXNotFound, "callsite")
-    of opcNLineInfo:
+    of opcNGetFile:
       decodeB(rkNode)
       let n = regs[rb].node
-
-      createStr regs[ra]
-      debug(regs[rb].node)
-      echo "---"
-      debug(regs[ra].node)
-
-      #regs[ra].node.strVal = n.info.toFileLineCol
-      # result = n.info.toFilename & "(" & $n.info.line & ", " & $n.info.col & ")"
-
-      regs[ra].node.info = c.debug[pc]
+      regs[ra].node = newStrNode(nkStrLit, n.info.toFilename)
+      regs[ra].node.info = n.info
+      regs[ra].node.typ = n.typ
+    of opcNGetLine:
+      decodeB(rkNode)
+      let n = regs[rb].node
+      regs[ra].node = newIntNode(nkIntLit, n.info.line)
+      regs[ra].node.info = n.info
+      regs[ra].node.typ = n.typ
+    of opcNGetColumn:
+      decodeB(rkNode)
+      let n = regs[rb].node
+      regs[ra].node = newIntNode(nkIntLit, n.info.col)
+      regs[ra].node.info = n.info
+      regs[ra].node.typ = n.typ
     of opcEqIdent:
       decodeBC(rkInt)
       if regs[rb].node.kind == nkIdent and regs[rc].node.kind == nkIdent:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1310,8 +1310,15 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNLineInfo:
       decodeB(rkNode)
       let n = regs[rb].node
+
       createStr regs[ra]
-      regs[ra].node.strVal = n.info.toFileLineCol
+      debug(regs[rb].node)
+      echo "---"
+      debug(regs[ra].node)
+
+      #regs[ra].node.strVal = n.info.toFileLineCol
+      # result = n.info.toFilename & "(" & $n.info.line & ", " & $n.info.col & ")"
+
       regs[ra].node.info = c.debug[pc]
     of opcEqIdent:
       decodeBC(rkInt)

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -98,7 +98,7 @@ type
     opcNError,
     opcNWarning,
     opcNHint,
-    opcNLineInfo,
+    opcNGetLine, opcNGetColumn, opcNGetFile,
     opcEqIdent,
     opcStrToIdent,
     opcIdentToStr,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1071,7 +1071,16 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mEqIdent: genBinaryABC(c, n, dest, opcEqIdent)
   of mEqNimrodNode: genBinaryABC(c, n, dest, opcEqNimrodNode)
   of mSameNodeType: genBinaryABC(c, n, dest, opcSameNodeType)
-  of mNLineInfo: genUnaryABC(c, n, dest, opcNLineInfo)
+  of mNLineInfo:
+    case n[0].sym.name.s
+    of "getFile":
+      genUnaryABC(c, n, dest, opcNGetFile)
+    of "getLine":
+      genUnaryABC(c, n, dest, opcNGetLine)
+    of "getColumn":
+      genUnaryABC(c, n, dest, opcNGetColumn)
+    else:
+      internalAssert false
   of mNHint:
     unused(n, dest)
     genUnaryStmt(c, n, opcNHint)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -319,8 +319,8 @@ proc toStrLit*(n: NimNode): NimNode {.compileTime.} =
 
 type
   LineInfo* = object
-    filename: string
-    line,column: int
+    filename*: string
+    line*,column*: int
 
 proc `$`*(arg: Lineinfo): string =
   result = arg.filename & "(" & $arg.line & ", " & $arg.column & ")"

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -317,9 +317,32 @@ proc toStrLit*(n: NimNode): NimNode {.compileTime.} =
   ## in a string literal node
   return newStrLitNode(repr(n))
 
-proc lineinfo*(n: NimNode): string {.magic: "NLineInfo", noSideEffect.}
+type
+  LineInfo* = object
+    filename: string
+    line,column: int
+
+proc `$`*(arg: Lineinfo): string =
+  result = arg.filename & "(" & $arg.line & ", " & $arg.column & ")"
+
+#proc lineinfo*(n: NimNode): LineInfo {.magic: "NLineInfo", noSideEffect.}
   ## returns the position the node appears in the original source file
   ## in the form filename(line, col)
+
+proc getLine(arg: NimNode): int {.magic: "NLineInfo", noSideEffect.}
+proc getColumn(arg: NimNode): int {.magic: "NLineInfo", noSideEffect.}
+proc getFile(arg: NimNode): string {.magic: "NLineInfo", noSideEffect.}
+
+proc lineinfo*(n: NimNode): LineInfo {.compileTime.} =
+  result.filename = n.getFile
+  result.line = n.getLine
+  result.column = n.getColumn
+
+static:
+  var li = LineInfo(filename: "main.nim", line: 10, column: 11)
+  li = foobar(li)
+  #echo li
+
 
 proc internalParseExpr(s: string): NimNode {.
   magic: "ParseExprToAst", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -333,10 +333,13 @@ proc getLine(arg: NimNode): int {.magic: "NLineInfo", noSideEffect.}
 proc getColumn(arg: NimNode): int {.magic: "NLineInfo", noSideEffect.}
 proc getFile(arg: NimNode): string {.magic: "NLineInfo", noSideEffect.}
 
-proc lineinfo*(n: NimNode): LineInfo {.compileTime.} =
+proc lineInfoObj*(n: NimNode): LineInfo {.compileTime.} =
   result.filename = n.getFile
   result.line = n.getLine
   result.column = n.getColumn
+
+proc lineInfo*(arg: NimNode): string {.compileTime.} =
+  $arg.lineInfoObj
 
 proc internalParseExpr(s: string): NimNode {.
   magic: "ParseExprToAst", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -338,12 +338,6 @@ proc lineinfo*(n: NimNode): LineInfo {.compileTime.} =
   result.line = n.getLine
   result.column = n.getColumn
 
-static:
-  var li = LineInfo(filename: "main.nim", line: 10, column: 11)
-  li = foobar(li)
-  #echo li
-
-
 proc internalParseExpr(s: string): NimNode {.
   magic: "ParseExprToAst", noSideEffect.}
 

--- a/test.nim
+++ b/test.nim
@@ -1,1 +1,0 @@
-import macros

--- a/test.nim
+++ b/test.nim
@@ -1,0 +1,1 @@
+import macros

--- a/tests/method/tmapper.nim
+++ b/tests/method/tmapper.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "invalid declaration order; cannot attach 'step' to method defined here: tmapper.nim(22,7)"
+  errormsg: "invalid declaration order; cannot attach 'step' to method defined here: tmapper.nim(22, 7)"
   line: 25
 """
 

--- a/tests/modules/tmismatchedvisibility.nim
+++ b/tests/modules/tmismatchedvisibility.nim
@@ -1,6 +1,6 @@
 discard """
   line: 8
-  errormsg: "public implementation 'tmismatchedvisibility.foo(a: int)[declared in tmismatchedvisibility.nim(6,5)]' has non-public forward declaration in "
+  errormsg: "public implementation 'tmismatchedvisibility.foo(a: int)[declared in tmismatchedvisibility.nim(6, 5)]' has non-public forward declaration in "
 """
 
 proc foo(a: int): int

--- a/tests/pragmas/tused.nim
+++ b/tests/pragmas/tused.nim
@@ -1,7 +1,7 @@
 discard """
   nimout: '''
 compile start
-tused.nim(15, 8) Hint: 'tused.echoSub(a: int, b: int)[declared in tused.nim(15,7)]' is declared but not used [XDeclaredButNotUsed]
+tused.nim(15, 8) Hint: 'tused.echoSub(a: int, b: int)[declared in tused.nim(15, 7)]' is declared but not used [XDeclaredButNotUsed]
 compile end'''
   output: "8\n8"
 """

--- a/tests/showoff/tquasiquote.nim
+++ b/tests/showoff/tquasiquote.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: '''tquasiquote.nim(14,8): Check failed: 1 > 2'''
+  outputsub: '''tquasiquote.nim(14, 8): Check failed: 1 > 2'''
 """
 
 import macros


### PR DESCRIPTION
lineInfoObj now return an object with fields that were perviously contained in the lineinfo string. This is more flexible in case the lines need to be processed further in a macro.