### PR TITLE
newLit emty seq fix

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -527,10 +527,17 @@ proc newLit*[N,T](arg: array[N,T]): NimNode {.compileTime.} =
     result.add newLit(x)
 
 proc newLit*[T](arg: seq[T]): NimNode {.compileTime.} =
-  result = nnkBracket.newTree
+  var bracket = nnkBracket.newTree
   for x in arg:
-    result.add newLit(x)
-  result = nnkPrefix.newTree(bindSym"@", result)
+    bracket.add newLit(x)
+
+  result = nnkCall.newTree(
+    nnkBracketExpr.newTree(
+      nnkAccQuoted.newTree( bindSym"@" ),
+      getTypeInst( bindSym"T" )
+    ),
+    bracket
+  )
 
 proc newLit*(arg: tuple): NimNode {.compileTime.} =
   result = nnkPar.newTree

--- a/tests/macros/tnewlit.nim
+++ b/tests/macros/tnewlit.nim
@@ -138,3 +138,12 @@ macro test_newLit_ComposedType: untyped =
   result = newLit(ct)
 
 doAssert test_newLit_ComposedType == ComposedType(mt: MyType(a: 123, b:"abc"), arr: [1,2,3,4], data: @[1.byte, 3, 7, 127])
+
+macro test_newLit_empty_seq_string: untyped =
+  var strSeq = newSeq[string](0)
+  result = newLit(strSeq)
+
+block:
+  # x needs to be of type seq[string]
+  var x = test_newLit_empty_seq_string
+  x.add("xyz")


### PR DESCRIPTION
newLit on an empty seq does not loose type information anymore.

```Nim
var s = newSeq[string](0)
newLit(s)
# old code: @([])
# new code: `@`[string]([])