### PR TITLE
fixes #6046 parsecfg failed to parse negative int

### DIFF
--- a/lib/pure/parsecfg.nim
+++ b/lib/pure/parsecfg.nim
@@ -320,9 +320,13 @@ proc rawGetTok(c: var CfgParser, tok: var Token) =
     tok.literal = "="
   of '-':
     inc(c.bufpos)
-    if c.buf[c.bufpos] == '-': inc(c.bufpos)
-    tok.kind = tkDashDash
-    tok.literal = "--"
+    if c.buf[c.bufpos] == '-':
+      inc(c.bufpos)
+      tok.kind = tkDashDash
+      tok.literal = "--"
+    else:
+      dec(c.bufpos)
+      getSymbol(c, tok)
   of ':':
     tok.kind = tkColon
     inc(c.bufpos)

--- a/tests/stdlib/tparsecfg.nim
+++ b/tests/stdlib/tparsecfg.nim
@@ -2,6 +2,7 @@ discard """
   output: '''OK'''
 """
 
+#bug #6046
 import parsecfg
 
 var config = newConfig()

--- a/tests/stdlib/tparsecfg.nim
+++ b/tests/stdlib/tparsecfg.nim
@@ -1,0 +1,22 @@
+discard """
+  output: '''OK'''
+"""
+
+import parsecfg
+
+var config = newConfig()
+config.setSectionKey("foo","bar","-1")
+config.setSectionKey("foo","foo","abc")
+config.writeConfig("test.ini")
+
+# test.ini now contains
+# [foo]
+# bar=-1
+# foo=abc
+
+var config2 = loadConfig("test.ini")
+let bar = config2.getSectionValue("foo","bar")
+let foo = config2.getSectionValue("foo","foo")
+assert(bar == "-1")
+assert(foo == "abc")
+echo "OK"


### PR DESCRIPTION
this patch allow for something like

```text
bar=-1
name=-abc
```