### PR TITLE
Revert "GC_fullCollect on sync threadpool (#6107)"

### DIFF
--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -526,12 +526,10 @@ proc nimSpawn4(fn: WorkerProc; data: pointer; id: ThreadId) {.compilerProc.} =
     if selectWorker(addr(distinguishedData[id]), fn, data): break
     await(distinguishedData[id].readyForTask)
 
-template spawnInAllThreads(e: untyped) =
-  ## Spawn `e` on all of the threadpool threads.
-  for i in 0 .. <currentPoolSize:
-    pinnedSpawn(i, e)
 
-proc syncAux() {.inline.} =
+proc sync*() =
+  ## a simple barrier to wait for all spawn'ed tasks. If you need more elaborate
+  ## waiting, you have to use an explicit barrier.
   var toRelease = 0
   while true:
     var allReady = true
@@ -544,13 +542,5 @@ proc syncAux() {.inline.} =
 
   for i in 0 ..< toRelease:
     signal(gSomeReady)
-
-proc sync*(cleanup: bool = true) =
-  ## A simple barrier to wait for all spawn'ed tasks. Calls `GC_fullCollect()`
-  ## on all threads if `cleanup` is `true`. If you need more elaborate
-  ## waiting, you have to use an explicit barrier.
-  syncAux()
-  if cleanup:
-    spawnInAllThreads GC_fullCollect()
 
 setup()


### PR DESCRIPTION
This reverts commit bdb653c4156af099814df2e21b9878cdb1591190.

Unfortunately my initial implementation turned out to be completely incorrect. `pinnedSpawn` has nothing to do with previously spawned threads. I'll try to redo it, but it may take some time. 