### PR TITLE
[WIP] Custom pragmas

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -267,7 +267,8 @@ type
                       # language; for interfacing with Objective C
     sfDiscardable,    # returned value may be discarded implicitly
     sfOverriden,      # proc is overriden
-    sfGenSym          # symbol is 'gensym'ed; do not add to symbol table
+    sfGenSym,         # symbol is 'gensym'ed; do not add to symbol table
+    sfPragmaTempl     # symbol is custom pragma template
 
   TSymFlags* = set[TSymFlag]
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -872,7 +872,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: int,
         result = true
       of wPop: processPop(c, it)
       of wPragma:
-        if sym.kind == skTemplate:
+        if not sym.isNil and sym.kind == skTemplate:
           sym.flags.incl(sfPragmaTempl)
         else:
           processPragma(c, n, i)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -963,7 +963,8 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     else:
       result = semMacroExpr(c, n, n, s, flags)
   of skTemplate:
-    if efNoEvaluateGeneric in flags and s.ast[genericParamsPos].len > 0:
+    if (efNoEvaluateGeneric in flags and s.ast[genericParamsPos].len > 0) or
+        sfPragmaTempl in sym.flags:
       markUsed(n.info, s, c.graph.usageSym)
       styleCheckUse(n.info, s)
       result = newSymNode(s, n.info)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1102,13 +1102,6 @@ proc copyExcept(n: PNode, i: int): PNode =
   for j in 0.. <n.len:
     if j != i: result.add(n.sons[j])
 
-proc lookupMacro(c: PContext, n: PNode): PSym =
-  if n.kind == nkSym:
-    result = n.sym
-    if result.kind notin {skMacro, skTemplate}: result = nil
-  else:
-    result = searchInScopes(c, considerQuotedIdent(n), {skMacro, skTemplate})
-
 proc semProcAnnotation(c: PContext, prc: PNode;
                        validPragmas: TSpecialWords): PNode =
   var n = prc.sons[pragmasPos]
@@ -1124,6 +1117,9 @@ proc semProcAnnotation(c: PContext, prc: PNode;
           prc.sons[pragmasPos] = copyExcept(n, i)
         else:
           localError(prc.info, errOnlyACallOpCanBeDelegator)
+      continue
+    elif sfPragmaTempl in m.flags:
+      n.sons[i] = semPragmaTempl(c, m, it)
       continue
     # we transform ``proc p {.m, rest.}`` into ``m(do: proc p {.rest.})`` and
     # let the semantic checker deal with it:

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -622,7 +622,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   popOwner(c)
   s.ast = n
   result = n
-  if n.sons[bodyPos].kind == nkEmpty:
+  if n.sons[bodyPos].kind == nkEmpty and sfPragmaTempl notin s.flags:
     localError(n.info, errImplOfXexpected, s.name.s)
   var proto = searchForProc(c, c.currentScope, s)
   if proto == nil:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1065,7 +1065,8 @@ macro hasCustomPragma*(n: typed, cp: untyped{nkIdent}): untyped =
   ##   assert(o.myField.hasCustomPragma(myAttr) == 0)
   let pragmaNode = pragmaNodeForAttrSubj(n)
   for p in pragmaNode:
-    if p.kind == nnkCall and p.len > 0 and p[0].kind == nnkSym and $p[0] == $cp:
+    if (p.kind == nnkSym and $p == $cp) or
+        (p.kind == nnkExprColonExpr and p.len > 0 and p[0].kind == nnkSym and $p[0] == $cp):
       return newLit(true)
   return newLit(false)
 
@@ -1081,7 +1082,7 @@ macro getCustomPragmaVal*(n: typed, cp: untyped{nkIdent}): untyped =
   ##   assert(o.myField.getCustomPragmaVal(serializationKey) == "mf")
   let pragmaNode = pragmaNodeForAttrSubj(n)
   for p in pragmaNode:
-    if p.kind == nnkCall and p.len > 1 and p[0].kind == nnkSym and $p[0] == $cp:
+    if p.kind == nnkExprColonExpr and p.len > 0 and p[0].kind == nnkSym and $p[0] == $cp:
       return p[1]
   return newEmptyNode()
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1058,7 +1058,7 @@ proc pragmaNodeForAttrSubj(subj: NimNode): NimNode =
         if identDefs[i].kind == nnkPragmaExpr and identDefs[i][0].kind == nnkIdent and $identDefs[i][0] == $subj[1]:
           return identDefs[i][1]
 
-macro hasCustomPragma*(n: typed, cp: untyped{nkIdent}): untyped =
+macro hasCustomPragma*(n: typed, cp: typed{nkSym}): untyped =
   ## Expands to `true` if expression `n` which is expected to be `nnkDotExpr`
   ## has custom pragma `cp`.
   ##
@@ -1070,12 +1070,12 @@ macro hasCustomPragma*(n: typed, cp: untyped{nkIdent}): untyped =
   ##   assert(o.myField.hasCustomPragma(myAttr) == 0)
   let pragmaNode = pragmaNodeForAttrSubj(n)
   for p in pragmaNode:
-    if (p.kind == nnkSym and $p == $cp) or
-        (p.kind == nnkExprColonExpr and p.len > 0 and p[0].kind == nnkSym and $p[0] == $cp):
+    if (p.kind == nnkSym and p == cp) or
+        (p.kind == nnkExprColonExpr and p.len > 0 and p[0].kind == nnkSym and p[0] == cp):
       return newLit(true)
   return newLit(false)
 
-macro getCustomPragmaVal*(n: typed, cp: untyped{nkIdent}): untyped =
+macro getCustomPragmaVal*(n: typed, cp: typed{nkSym}): untyped =
   ## Expands to value of custom pragma `cp` of expression `n` which is expected
   ## to be `nnkDotExpr`.
   ##
@@ -1087,7 +1087,7 @@ macro getCustomPragmaVal*(n: typed, cp: untyped{nkIdent}): untyped =
   ##   assert(o.myField.getCustomPragmaVal(serializationKey) == "mf")
   let pragmaNode = pragmaNodeForAttrSubj(n)
   for p in pragmaNode:
-    if p.kind == nnkExprColonExpr and p.len > 0 and p[0].kind == nnkSym and $p[0] == $cp:
+    if p.kind == nnkExprColonExpr and p.len > 0 and p[0].kind == nnkSym and p[0] == cp:
       return p[1]
   return newEmptyNode()
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1054,7 +1054,7 @@ proc pragmaNodeForAttrSubj(subj: NimNode): NimNode =
     typDef[2].expectKind(nnkObjectTy)
     let recList = typDef[2][2]
     for identDefs in recList:
-      for i in 0 ..< identDefs.len - 2:
+      for i in 0 .. identDefs.len - 3:
         if identDefs[i].kind == nnkPragmaExpr and identDefs[i][0].kind == nnkIdent and $identDefs[i][0] == $subj[1]:
           return identDefs[i][1]
 

--- a/tests/pragmas/tcustom_pragmas.nim
+++ b/tests/pragmas/tcustom_pragmas.nim
@@ -1,7 +1,7 @@
 import macros
 
 block:
-  template myAttr(a: string) = discard
+  template myAttr(a: string) {.pragma.}
 
   type MyObj = object
     myField {.myAttr: "hi".}: int
@@ -9,8 +9,8 @@ block:
   assert o.myField.hasCustomPragma(myAttr)
 
 block: # A bit more advanced case
-  template serializationKey(s: string) = discard
-  template defaultValue(V: typed) = discard
+  template serializationKey(s: string) {.pragma.}
+  template defaultValue(V: typed) {.pragma.}
 
   type MySerializable = object
     a {.serializationKey: "asdf", defaultValue: 5.} : int

--- a/tests/pragmas/tcustom_pragmas.nim
+++ b/tests/pragmas/tcustom_pragmas.nim
@@ -1,6 +1,15 @@
 import macros
 
 block:
+  template myAttr() {.pragma.}
+  template myAttr2() {.pragma.}
+
+  proc myProc() {.myAttr.} = discard
+  const myAttrIdx = myProc.hasCustomPragma(myAttr)
+  assert(myAttrIdx)
+  assert(not myProc.hasCustomPragma(myAttr2))
+
+block:
   template myAttr(a: string) {.pragma.}
 
   type MyObj = object

--- a/tests/pragmas/tcustom_pragmas.nim
+++ b/tests/pragmas/tcustom_pragmas.nim
@@ -1,0 +1,25 @@
+import macros
+
+block:
+  template myAttr(a: string) = discard
+
+  type MyObj = object
+    myField {.myAttr: "hi".}: int
+  var o: MyObj
+  assert o.myField.hasCustomPragma(myAttr)
+
+block: # A bit more advanced case
+  template serializationKey(s: string) = discard
+  template defaultValue(V: typed) = discard
+
+  type MySerializable = object
+    a {.serializationKey: "asdf", defaultValue: 5.} : int
+    b {.defaultValue: "hello".} : int
+
+  var s: MySerializable
+
+  const aDefVal = s.a.getCustomPragmaVal(defaultValue)
+  doAssert(aDefVal == 5)
+
+  const aSerKey = s.a.getCustomPragmaVal(serializationKey)
+  doAssert(aSerKey == "asdf")


### PR DESCRIPTION
Another implementation of #6070. This pr allows custom pragmas in the following way:
```nim
template serializationKey(s: string) {.pragma.}
type MyObj = object
  a {.serializationKey: "_a".}: int

var o: MyObj
assert(o.a.getCustomPragmaVal(serializationKey) == "_a")
```
~~There are still some questions not answered.~~
- ~~Such custom pragmas can not be applied on procs because proc custom pragmas expect proc as first argument~~
- ~~I could not find a way to pass pragma symbol to `getCustomPragmaVal`, now ident is passed. That means that `getCustomPragmaVal` does not respect namespaces.~~
