### PR TITLE
Have the linker search `/usr/local/lib` on Linux

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -135,7 +135,7 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
 
 # Options for FreeBSD, OpenBSD, NetBSD linker to add locations for searching
 # shared libraries.
-@if freebsd or openbsd or netbsd:
+@if freebsd or openbsd or netbsd or linux:
   gcc.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
   gcc.cpp.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
   llvm_gcc.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"


### PR DESCRIPTION
This was causing some issues when I was trying to link a `.so` of `raylib` and `glfw`.  `/usr/local/lib` wasn't in the `-rpath` option at link time on Linux.  It is a common location for users to install libraries on Linux and should be part of the link path.