### PR TITLE
Add ``writable`` proc

### DIFF
--- a/lib/pure/asyncstreams.nim
+++ b/lib/pure/asyncstreams.nim
@@ -54,7 +54,7 @@ proc finished*[T](future: FutureStream[T]): bool =
   result = future.finished and future.queue.len == 0
 
 proc writable*[T](future: FutureStream[T]): bool =
-  ## Check if a ``FutureStream`` can accepts new data.
+  ## Check if a ``FutureStream`` can accepts new data. 
   result = future.finished
   
 proc write*[T](future: FutureStream[T], value: T): Future[void] =

--- a/lib/pure/asyncstreams.nim
+++ b/lib/pure/asyncstreams.nim
@@ -53,6 +53,10 @@ proc finished*[T](future: FutureStream[T]): bool =
   ## no data waiting to be retrieved.
   result = future.finished and future.queue.len == 0
 
+proc writable*[T](future: FutureStream[T]): bool =
+  ## Check if a ``FutureStream`` can accepts new data.
+  result = future.finished
+  
 proc write*[T](future: FutureStream[T], value: T): Future[void] =
   ## Writes the specified value inside the specified future stream.
   ##


### PR DESCRIPTION
Hello. I'm currently have a definite need to ``write()`` a ``FutureStream`` step by step. I found that the ``FutureStream.finished()`` could not correctly determine whether ``FutureStream`` accepts new data. 

And this is my example:

```nim
proc write(futStream: FutureStream[MyDataPacket], 
           conn: MyTcpConnection): Future[void] {.async.} =
  if futStream.writable:            # Parse data only when ``FutureStream`` 
                                    # accepts new data !!!!!!!!!!!!!!!!!!!!
    # ...
    var packet: MyDataPacket
    while true:
      await recv(conn)              # Recv data from the underlying ``AsyncSocket``
      parse(conn, ...)              # Parse data
      # ...                        
      if conn.parser.finished:
        break                       # A parsing operation is complete

    await write(futStream, packet)  # Write to ``FutureStream``
    if not packet.hasMoreResults:   # The end of this data packet
      complete(futStream)                      

proc query(conn: MyTcpConnection, q: SqlQuery): Future[FutureStream[MyDataPacket]]




# ...

var futStream = await query(conn, ...)             # Begin  

await write(futStream, conn)                       # Recving and Parsing ...
let (streaming0, packet0) = await read(futStream)  # Got the first result data

await write(stream, conn)                          # Recving and Parsing ...
let (streaming1, packet1) = await read(stream)     # Got the second result data
                                                   
                                                   # Complete .
 
await write(stream, conn)                          # Do nothing
let (streaming2, packet2) = await read(stream)     # streaming2 is false

await write(stream, conn)                          # Do nothing
let (streaming3, packet3) = await read(stream)     # streaming3 is false
```