### PR TITLE
Do not replace tilde on Windows in pathSubs

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -290,8 +290,9 @@ proc pathSubs*(p, config: string): string =
     "projectpath", options.gProjectPath,
     "projectdir", options.gProjectPath,
     "nimcache", getNimcacheDir()])
-  if '~' in result:
-    result = result.replace("~", home)
+  when not defined(windows):
+    if '~' in result:
+      result = result.replace("~", home)
 
 proc toGeneratedFile*(path, ext: string): string =
   ## converts "/home/a/mymodule.nim", "rod" to "/home/a/nimcache/mymodule.rod"


### PR DESCRIPTION
On Windows tilde means a whole different thing than on Unix. But Nim
replaced tilde with home dir when tilde was present in compiler switch,
which lead to broken paths when tilde was used.