### PR TITLE
various enum improvements.

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -641,7 +641,7 @@ type
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo, mNGenSym,
     mNimvm, mIntDefine, mStrDefine, mRunnableExamples,
-    mException, mBuiltinType
+    mException, mBuiltinType, mEnumOrdinal, mEnumLen
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -641,7 +641,8 @@ type
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo, mNGenSym,
     mNimvm, mIntDefine, mStrDefine, mRunnableExamples,
-    mException, mBuiltinType, mEnumOrdinal, mEnumLen
+    mException, mBuiltinType, mEnumOrdinal, mEnumLen,
+    mEnumGet
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -642,7 +642,7 @@ type
     mInstantiationInfo, mGetTypeInfo, mNGenSym,
     mNimvm, mIntDefine, mStrDefine, mRunnableExamples,
     mException, mBuiltinType, mEnumOrdinal, mEnumLen,
-    mEnumGet
+    mEnumGet, mEnumGetString
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1835,9 +1835,16 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
     var a: TLoc
     initLocExpr(p, e.sons[1], a)
     var t = skipTypes(e.sons[2].typ, abstractRange)
-    putIntoDest(p, d, e.typ,
-                ropecg(p.module, "#enumGet($1, ($2)->node->sons)", [
-                rdLoc(a), genTypeInfo(p.module, t)]), a.s)
+    putIntoDest(p, d, e,
+                ropecg(p.module, "($2)->node->sons[$1]->offset", [
+                rdLoc(a), genTypeInfo(p.module, t, e.info)]), a.storage)
+  of mEnumGetString:
+    var a: TLoc
+    initLocExpr(p, e.sons[1], a)
+    var t = skipTypes(e.sons[2].typ, abstractRange)
+    putIntoDest(p, d, e,
+                ropecg(p.module, "($2)->node->sons[$1]->name", [
+                rdLoc(a), genTypeInfo(p.module, t, e.info)]), a.storage)
   of mOf: genOf(p, e, d)
   of mNew: genNew(p, e)
   of mNewFinalize: genNewFinalize(p, e)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1831,6 +1831,13 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
   of mCStrToStr: genDollar(p, e, d, "#cstrToNimstr($1)")
   of mStrToStr: expr(p, e.sons[1], d)
   of mEnumToStr: genRepr(p, e, d)
+  of mEnumGet:
+    var a: TLoc
+    initLocExpr(p, e.sons[1], a)
+    var t = skipTypes(e.sons[2].typ, abstractRange)
+    putIntoDest(p, d, e.typ,
+                ropecg(p.module, "#enumGet($1, ($2)->node->sons)", [
+                rdLoc(a), genTypeInfo(p.module, t)]), a.s)
   of mOf: genOf(p, e, d)
   of mNew: genNew(p, e)
   of mNewFinalize: genNewFinalize(p, e)

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -113,3 +113,4 @@ proc initDefines*() =
   defineSymbol("nimHasRunnableExamples")
   defineSymbol("nimNewDot")
   defineSymbol("nimHasNilChecks")
+  defineSymbol("nimImprovedEnum")

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -317,6 +317,12 @@ proc evalOp(m: TMagic, n, a, b, c: PNode): PNode =
   of mEqProc:
     result = newIntNodeT(ord(
         exprStructuralEquivalent(a, b, strictSymEquality=true)), n)
+  of mEnumLen:
+    let t = skipTypes(a.typ, abstractRange)
+    result = newIntNodeT(t.n.sons.len, n)
+  of mEnumOrdinal:
+    let t = skipTypes(a.typ, abstractRange)
+    result = newIntNodeT(ord(tfEnumHasHoles notin t.flags), n)
   else: discard
 
 proc getConstIfExpr(c: PSym, n: PNode): PNode =

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1413,6 +1413,11 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         asgnRef(regs[ra], dest)
       else:
         globalError(c.debug[pc], "cannot evaluate cast")
+    of opcEnumGet:
+      ensureKind(rkInt)
+      let index = regs[ra].intVal.int
+      let enum_type = c.types[instr.regBx - wordExcess]
+      regs[ra].intVal = enum_type.n.sons[index].sym.position
     of opcNSetIntVal:
       decodeB(rkNode)
       var dest = regs[ra].node

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1418,6 +1418,13 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       let index = regs[ra].intVal.int
       let enum_type = c.types[instr.regBx - wordExcess]
       regs[ra].intVal = enum_type.n.sons[index].sym.position
+    of opcEnumGetString:
+      ensureKind(rkInt)
+      let index = regs[ra].intVal.int
+      let enum_type = c.types[instr.regBx - wordExcess]
+      ensureKind(rkNode)
+      createStr regs[ra]
+      regs[ra].node.strVal = $(enum_type.n.sons[index].sym.name.s) # enum value name
     of opcNSetIntVal:
       decodeB(rkNode)
       var dest = regs[ra].node

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -104,6 +104,8 @@ type
     opcIdentToStr,
     opcGetImpl,
 
+    opcEnumGet,
+
     opcEcho,
     opcIndCall, # dest = call regStart, n; where regStart = fn, arg1, ...
     opcIndCallAsgn, # dest = call regStart, n; where regStart = fn, arg1, ...

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -105,6 +105,7 @@ type
     opcGetImpl,
 
     opcEnumGet,
+    opcEnumGetString,
 
     opcEcho,
     opcIndCall, # dest = call regStart, n; where regStart = fn, arg1, ...

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1175,6 +1175,13 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
       globalError(n.info, "expandToAst requires a call expression")
   of mRunnableExamples:
     discard "just ignore any call to runnableExamples"
+  of mEnumGet:
+    let tmp = c.genx(n.sons[1])
+    if dest < 0: dest = c.getTemp(n.typ)
+    let t = skipTypes(n.sons[2].typ, abstractRange)
+    c.gABC(n, opcAsgnInt, dest, tmp)
+    c.gABx(n, opcEnumGet, dest, c.genType(t))
+    c.freeTemp(tmp)
   of mEnumLen:
     if dest < 0: dest = c.getTemp(n.typ)
     let t = skipTypes(n.sons[1].typ, abstractRange)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1182,6 +1182,13 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.gABC(n, opcAsgnInt, dest, tmp)
     c.gABx(n, opcEnumGet, dest, c.genType(t))
     c.freeTemp(tmp)
+  of mEnumGetString:
+    let tmp = c.genx(n.sons[1])
+    if dest < 0: dest = c.getTemp(n.typ)
+    let t = skipTypes(n.sons[2].typ, abstractRange)
+    c.gABC(n, opcAsgnInt, dest, tmp)
+    c.gABx(n, opcEnumGetString, dest, c.genType(t))
+    c.freeTemp(tmp)
   of mEnumLen:
     if dest < 0: dest = c.getTemp(n.typ)
     let t = skipTypes(n.sons[1].typ, abstractRange)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1175,6 +1175,14 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
       globalError(n.info, "expandToAst requires a call expression")
   of mRunnableExamples:
     discard "just ignore any call to runnableExamples"
+  of mEnumLen:
+    if dest < 0: dest = c.getTemp(n.typ)
+    let t = skipTypes(n.sons[1].typ, abstractRange)
+    c.gABx(n, opcLdImmInt, dest, t.n.sons.len)
+  of mEnumOrdinal:
+    if dest < 0: dest = c.getTemp(n.typ)
+    let t = skipTypes(n.sons[1].typ, abstractRange)
+    c.gABx(n, opcLdImmInt, dest, ord(tfEnumHasHoles notin t.flags))
   else:
     # mGCref, mGCunref,
     globalError(n.info, "cannot generate code for: " & $m)

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1088,25 +1088,48 @@ proc parseBool*(s: string): bool =
   of "n", "no", "false", "0", "off": result = false
   else: raise newException(ValueError, "cannot interpret as a bool: " & s)
 
-proc parseEnum*[T: enum](s: string): T =
-  ## Parses an enum ``T``.
-  ##
-  ## Raises ``ValueError`` for an invalid value in `s`. The comparison is
-  ## done in a style insensitive way.
-  for e in low(T)..high(T):
-    if cmpIgnoreStyle(s, $e) == 0:
-      return e
-  raise newException(ValueError, "invalid enum value: " & s)
 
-proc parseEnum*[T: enum](s: string, default: T): T =
-  ## Parses an enum ``T``.
-  ##
-  ## Uses `default` for an invalid value in `s`. The comparison is done in a
-  ## style insensitive way.
-  for e in low(T)..high(T):
-    if cmpIgnoreStyle(s, $e) == 0:
-      return e
-  result = default
+when defined(JS):
+  proc parseEnum[T: enum](s: string; default: T): T =
+    for e in T:
+      if cmpIgnoreStyle(s, $e) == 0:
+        return e
+    result = default
+
+  proc parseEnum[T: enum](s: string): T =
+    for e in T:
+      if cmpIgnoreStyle(s, $e) == 0:
+        return e
+    raise newException(ValueError, "invalid enum value: " & s)
+
+else:
+  from cstrutils import cmpIgnoreStyle
+  proc parseEnumImpl*[T: enum](s: string, value: var T): bool =
+    proc enumGet[T: enum](index: int; t: typedesc[T]): T  {.magic: "EnumGet", noSideEffect.}
+    proc enumGetString[T: enum](index: int; t: typedesc[T]): cstring  {.magic: "EnumGetString", noSideEffect.}
+    let last = T.len - 1
+    var i = 0
+    while i <= last:
+      if cmpIgnoreStyle(s, enumGetString(i, T)) == 0:
+        value= enumGet(i, T)
+        return true
+      inc(i)
+
+  proc parseEnum*[T: enum](s: string): T {.inline.}=
+    ## Parses an enum ``T``.
+    ##
+    ## Raises ``ValueError`` for an invalid value in `s`. The comparison is
+    ## done in a style insensitive way.
+    if not parseEnumImpl(s, result):
+      raise newException(ValueError, "invalid enum value: " & s)
+
+  proc parseEnum*[T: enum](s: string, default: T): T =
+    ## Parses an enum ``T``.
+    ##
+    ## Uses `default` for an invalid value in `s`. The comparison is done in a
+    ## style insensitive way.
+    result = default
+    discard parseEnumImpl(s, result)
 
 proc repeat*(c: char, count: Natural): string {.noSideEffect,
   rtl, extern: "nsuRepeatChar".} =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -393,6 +393,12 @@ proc `<` *[T](x, y: ref T): bool {.magic: "LtPtr", noSideEffect.}
 proc `<` *[T](x, y: ptr T): bool {.magic: "LtPtr", noSideEffect.}
 proc `<` *(x, y: pointer): bool {.magic: "LtPtr", noSideEffect.}
 
+proc len*[Enum: enum](x: typedesc[Enum]): int {.magic: "EnumLen", noSideEffect.}
+  ## returns the number of fields in enum
+
+proc isOrdinal*[Enum: enum](x: typedesc[Enum]): bool {.magic: "EnumOrdinal", noSideEffect.}
+  ## returns true if enum is an ordinal (ie: has no holes.)
+
 template `!=` * (x, y: untyped): untyped =
   ## unequals operator. This is a shorthand for ``not (x == y)``.
   not (x == y)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2241,10 +2241,20 @@ iterator mitems*(a: var cstring): var char {.inline.} =
     yield a[i]
     inc(i)
 
-iterator items*(E: typedesc[enum]): E =
+
+proc enumGet[T: enum](index: int; t: typedesc[T]): T  {.magic: "EnumGet", noSideEffect.}
+
+iterator items*[E: enum](t: typedesc[E]): E =
   ## iterates over the values of the enum ``E``.
-  for v in low(E)..high(E):
-    yield v
+  when defined(JS) or t.isOrdinal:
+    for v in low(E)..high(E):
+      yield v
+  else:
+    let last = E.len - 1
+    var i = 0
+    while i <= last:
+      yield enumGet(i, E)
+      inc(i)
 
 iterator items*[T](s: HSlice[T, T]): T =
   ## iterates over the slice `s`, yielding each value between `s.a` and `s.b`

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -393,11 +393,12 @@ proc `<` *[T](x, y: ref T): bool {.magic: "LtPtr", noSideEffect.}
 proc `<` *[T](x, y: ptr T): bool {.magic: "LtPtr", noSideEffect.}
 proc `<` *(x, y: pointer): bool {.magic: "LtPtr", noSideEffect.}
 
-proc len*[Enum: enum](x: typedesc[Enum]): int {.magic: "EnumLen", noSideEffect.}
-  ## returns the number of fields in enum
+when defined(nimImprovedEnum):
+  proc len*[Enum: enum](x: typedesc[Enum]): int {.magic: "EnumLen", noSideEffect.}
+    ## returns the number of fields in enum
 
-proc isOrdinal*[Enum: enum](x: typedesc[Enum]): bool {.magic: "EnumOrdinal", noSideEffect.}
-  ## returns true if enum is an ordinal (ie: has no holes.)
+  proc isOrdinal*[Enum: enum](x: typedesc[Enum]): bool {.magic: "EnumOrdinal", noSideEffect.}
+    ## returns true if enum is an ordinal (ie: has no holes.)
 
 template `!=` * (x, y: untyped): untyped =
   ## unequals operator. This is a shorthand for ``not (x == y)``.
@@ -2242,14 +2243,13 @@ iterator mitems*(a: var cstring): var char {.inline.} =
     inc(i)
 
 
-proc enumGet[T: enum](index: int; t: typedesc[T]): T  {.magic: "EnumGet", noSideEffect.}
-
 iterator items*[E: enum](t: typedesc[E]): E =
   ## iterates over the values of the enum ``E``.
-  when defined(JS) or t.isOrdinal:
+  when defined(JS) or t.isOrdinal or not defined(nimImprovedEnum):
     for v in low(E)..high(E):
       yield v
   else:
+    proc enumGet[T: enum](index: int; t: typedesc[T]): T  {.magic: "EnumGet", noSideEffect.}
     let last = E.len - 1
     var i = 0
     while i <= last:

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -77,6 +77,9 @@ proc reprChar(x: char): string {.compilerRtl.} =
   else: add result, x
   add result, "\'"
 
+# 16~24 seems like a sweet spot
+const binarySearchCutoff = 16
+
 proc reprEnum(e: int, typ: PNimType): string {.compilerRtl.} =
   ## Return string representation for enumeration values
   var n = typ.node
@@ -84,12 +87,22 @@ proc reprEnum(e: int, typ: PNimType): string {.compilerRtl.} =
     let o = e - n.sons[0].offset
     if o >= 0 and o <% typ.node.len:
       return $n.sons[o].name
-  else:
-    # ugh we need a slow linear search:
+  elif n.len < binarySearchCutoff:
+    # linear search below cutoff
     var s = n.sons
     for i in 0 .. n.len-1:
       if s[i].offset == e:
         return $s[i].name
+  else: # binary search for all others enums
+    var s = n.sons
+    var a = 0
+    var b = n.len - 1
+    while a <= b:
+      var mid = (a + b) div 2
+      var c = cmp(s[mid].offset, e)
+      if c < 0: a = mid + 1
+      elif c > 0: b = mid - 1
+      else: return $s[mid].name
 
   result = $e & " (invalid data!)"
 

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -80,6 +80,9 @@ proc reprChar(x: char): string {.compilerRtl.} =
 # 16~24 seems like a sweet spot
 const binarySearchCutoff = 16
 
+proc enumGet(idx: int, sons: ptr array[0x7FFF, ptr TNimNode]): int {.compilerRtl.} =
+  result = sons[idx].offset
+
 proc reprEnum(e: int, typ: PNimType): string {.compilerRtl.} =
   ## Return string representation for enumeration values
   var n = typ.node

--- a/tests/enum/tenumitems2.nim
+++ b/tests/enum/tenumitems2.nim
@@ -1,14 +1,29 @@
 discard """
-  output: "A\nB\nC"
+  output: "A\nB\nC\n::\nX\nY\nZ"
 """
 
 type TAlphabet = enum
   A, B, C
 
-iterator items(E: typedesc[enum]): E =
-  for v in low(E)..high(E):
-    yield v
+type TAlphabetWithHoles = enum
+  X, Y, Z=9
 
-for c in TAlphabet:
-  echo($c)
+proc get_values(): seq[string] =
+  result = @[]
+  for c in TAlphabet: # items implicit invocation
+    result.add($c)
+  result.add("::")
+  for c in TAlphabetWithHoles: # items implicit invocation
+    result.add($c)
 
+const COMPTIME_VALUES = get_values()
+let RUNTIME_VALUES = get_values()
+for i, cvalue in COMPTIME_VALUES:
+  doAssert(cvalue == RUNTIME_VALUES[i])
+  echo cvalue
+
+doAssert(TAlphabet.len == 3)
+doAssert(TAlphabetWithHoles.len == 3)
+static:
+  doAssert(TAlphabet.len == 3)
+  doAssert(TAlphabetWithHoles.len == 3)

--- a/tests/enum/tparse_enum.nim
+++ b/tests/enum/tparse_enum.nim
@@ -1,0 +1,122 @@
+import strutils
+
+
+type Enum7 {.pure.} = enum
+  KE0
+  KE1
+  KE2
+  KE3
+  KE4
+  KE5
+  KE6
+
+type Enum17 {.pure.} = enum
+  KE0
+  KE1
+  KE2
+  KE3
+  KE4
+  KE5
+  KE6
+  KE7
+  KE8
+  KE9
+  KE10
+  KE11
+  KE12
+  KE13
+  KE14
+  KE15
+  KE16
+
+type Enum75 {.pure.} = enum
+  KE0
+  KE1
+  KE2
+  KE3
+  KE4
+  KE5
+  KE6
+  KE7
+  KE8
+  KE9
+  KE10
+  KE11
+  KE12
+  KE13
+  KE14
+  KE15
+  KE16
+  KE17
+  KE18
+  KE19
+  KE20
+  KE21
+  KE22
+  KE23
+  KE24
+  KE25
+  KE26
+  KE27
+  KE28
+  KE29
+  KE30
+  KE31
+  KE32
+  KE33
+  KE34
+  KE35
+  KE36
+  KE37
+  KE38
+  KE39
+  KE40
+  KE41
+  KE42
+  KE43
+  KE44
+  KE45
+  KE46
+  KE47
+  KE48
+  KE49
+  KE50
+  KE51
+  KE52
+  KE53
+  KE54
+  KE55
+  KE56
+  KE57
+  KE58
+  KE59
+  KE60
+  KE61
+  KE62
+  KE63
+  KE64
+  KE65
+  KE66
+  KE67
+  KE68
+  KE69
+  KE70
+  KE71
+  KE72
+  KE73
+  KE74
+
+proc test[T: enum]() =
+    for k in T:
+      doAssert parseEnum[T]($k, T(0)) == k
+
+test[Enum7]()
+test[Enum17]()
+test[Enum75]()
+
+static:
+    test[Enum7]()
+    test[Enum17]()
+    test[Enum75]()
+
+echo "OK"


### PR DESCRIPTION
This PR only affect VM, C & CPP target
This PR improve **reprEnum** from O(N) to O(logN) for enums with holes.
This PR improve **parseEnum** from O(N) to O(logN) for enums with holes.
parseEnumImpl uses a custom linear search with a lookup table for enums with with large number of values. Several implementations were tested but discarded for several reasons. 
* hashmap (default nim hashtable, fastest, x10 more memory, huge additional import)
* hashmap (custom robinhood hashtable, almost as fast, x5 more memory, 600 LOC)
* cached linear search (all normalized strings allocated contiguouly, very fast, but O(N))
* logtables, and several others 

**MyEnum.items** now only return valid enum values for enums with holes.

This PR also add these two procs in ```system.nim```
```nim
proc len*[Enum: enum](x: typedesc[Enum]): int
  ## returns the number of fields in enum
proc isOrdinal*[Enum: enum](x: typedesc[Enum]): bool
  ## returns true if enum is an ordinal (ie: has no holes.)
```
@Araq How can I make the compiler on Travis and AppVeyor accept new **Magic** .
On my local computer I just disable the new code paths using the new **Magic** for recompiling nim and then reenable the code for a second recompiling.