### PR TITLE
Removed platform-specific arithm test cases

### DIFF
--- a/tests/arithm/tshr.nim
+++ b/tests/arithm/tshr.nim
@@ -3,12 +3,12 @@ discard """
 """
 
 proc T() =
-  let VI = -8
+  # let VI = -8
   let VI64 = -8'i64
   let VI32 = -8'i32
   let VI16 = -8'i16
   let VI8 = -8'i8
-  doAssert( (VI shr 1) == 9_223_372_036_854_775_804, "Actual: " & $(VI shr 1))
+  # doAssert( (VI shr 1) == 9_223_372_036_854_775_804, "Actual: " & $(VI shr 1))
   doAssert( (VI64 shr 1) == 9_223_372_036_854_775_804, "Actual: " & $(VI64 shr 1))
   doAssert( (VI32 shr 1) == 2_147_483_644, "Actual: " & $(VI32 shr 1))
   doAssert( (VI16 shr 1) == 32_764, "Actual: " & $(VI16 shr 1))

--- a/tests/arithm/tshr.nim
+++ b/tests/arithm/tshr.nim
@@ -3,18 +3,18 @@ discard """
 """
 
 proc T() =
-    let VI = -8
-    let VI64 = -8'i64
-    let VI32 = -8'i32
-    let VI16 = -8'i16
-    let VI8 = -8'i8
-    doAssert( (VI shr 1) == 9223372036854775804)
-    doAssert( (VI64 shr 1) == 9223372036854775804)
-    doAssert( (VI32 shr 1) == 2147483644)
-    doAssert( (VI16 shr 1) == 32764)
-    doAssert( (VI8 shr 1) == 124)
+  let VI = -8
+  let VI64 = -8'i64
+  let VI32 = -8'i32
+  let VI16 = -8'i16
+  let VI8 = -8'i8
+  doAssert( (VI shr 1) == 9_223_372_036_854_775_804, "Actual: " & $(VI shr 1))
+  doAssert( (VI64 shr 1) == 9_223_372_036_854_775_804, "Actual: " & $(VI64 shr 1))
+  doAssert( (VI32 shr 1) == 2_147_483_644, "Actual: " & $(VI32 shr 1))
+  doAssert( (VI16 shr 1) == 32_764, "Actual: " & $(VI16 shr 1))
+  doAssert( (VI8 shr 1) == 124, "Actual: " & $(VI8 shr 1))
 
 
 T()
 static:
-    T()
+  T()


### PR DESCRIPTION
the first assert in `tests/arithm/tshr.nim` checks against a nim `int` literal and then assumes that an `int` in Nim is always 64-bit. This breaks the test on platforms that are not 64-bit.

E.g. this causes #5772 test runs on Android ARMv7 systems to fail, since they use a 32-bit OS.
