### PR TITLE
Small fix to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ within the [doc/koch.rst](doc/koch.rst) file.
 ## Contributors
 
 This project exists thanks to all the people who contribute. [Read on to find out how to contribute](#contributing).
-<a href="graphs/contributors"><img src="https://opencollective.com/Nim/contributors.svg?width=890" /></a>
+<a href="https://github.com/nim-lang/Nim/graphs/contributors"><img src="https://opencollective.com/Nim/contributors.svg?width=890" /></a>
 
 ## Contributing
 [![Backers on Open Collective](https://opencollective.com/nim/backers/badge.svg)](#backers) [![Sponsors on Open Collective](https://opencollective.com/nim/sponsors/badge.svg)](#sponsors) [![Contribute to Nim via Gratipay][badge-nim-gratipay]][nim-gratipay]


### PR DESCRIPTION
Fixed link to github contributors page
Without it contributors image would point to https://github.com/nim-lang/Nim/blob/devel/graphs/contributors which isn't a correct link