### PR TITLE
fixed createDir undeclared error on Android

### DIFF
--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -529,7 +529,10 @@ when declared(getEnv) or defined(nimscript):
     else: return string(getEnv("HOME")) & "/.config/"
 
   when defined(android):
-    {.pragma: getTempDirEffects, tags: [ReadEnvEffect, ReadIOEffect, WriteDirEffect].}
+    when declared(os):
+      {.pragma: getTempDirEffects, tags: [ReadEnvEffect, ReadIOEffect, WriteDirEffect].}
+    else:
+      {.pragma: getTempDirEffects, tags: [ReadEnvEffect, ReadIOEffect].}
   elif defined(windows):
     {.pragma: getTempDirEffects, tags: [ReadEnvEffect, ReadIOEffect].}
   else:
@@ -545,8 +548,9 @@ when declared(getEnv) or defined(nimscript):
     elif defined(windows): return string(getEnv("TEMP")) & "\\"
     elif defined(android):
       let tempDir = getHomeDir() / "nimtempfs"
-      try: createDir(tempDir)
-      except OSError: discard
+      when declared(os):
+        try: createDir(tempDir)
+        except OSError: discard
       return tempDir
     else: return "/tmp/"
 

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -548,9 +548,7 @@ when declared(getEnv) or defined(nimscript):
     elif defined(windows): return string(getEnv("TEMP")) & "\\"
     elif defined(android):
       let tempDir = getHomeDir() / "nimtempfs"
-      when declared(os):
-        try: createDir(tempDir)
-        except OSError: discard
+      createDir(tempDir)
       return tempDir
     else: return "/tmp/"
 


### PR DESCRIPTION
when using nimscipt `createDir` is not declared in `ospaths`

Disabled implcit creation of a temporay directory when `os` is not declared.