### PR TITLE
Added missing C++ options for VCC

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -193,27 +193,40 @@ clang.options.speed = "-O3"
 clang.options.size = "-Os"
 
 # Configuration for the Visual C/C++ compiler:
-vcc.exe = "vccexe.exe"
-vcc.linkerexe = "vccexe.exe"
+vcc.exe =     "vccexe.exe"
+vcc.cpp.exe = "vccexe.exe"
+vcc.linkerexe =     "vccexe.exe"
+vcc.cpp.linkerexe = "vccexe.exe"
 
 # set the options for specific platforms:
 @if i386:
-vcc.options.always = "--platform:x86 /nologo"
-vcc.options.linker = "--platform:x86 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.options.always =      "--platform:x86 /nologo"
+vcc.cpp.options.always =  "--platform:x86 /nologo /EHsc"
+vcc.options.linker =      "--platform:x86 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker =  "--platform:x86 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
 @elif amd64:
-vcc.options.always = "--platform:amd64 /nologo"
-vcc.options.linker = "--platform:amd64 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.options.always =      "--platform:amd64 /nologo"
+vcc.cpp.options.always =  "--platform:amd64 /nologo /EHsc"
+vcc.options.linker =      "--platform:amd64 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker =  "--platform:amd64 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
 @elif arm:
-vcc.options.always = "--platform:arm /nologo"
-vcc.options.linker = "--platform:arm /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.options.always =      "--platform:arm /nologo"
+vcc.cpp.options.always =  "--platform:arm /nologo /EHsc"
+vcc.options.linker =      "--platform:arm /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker =  "--platform:arm /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
 @else:
-vcc.options.always = "/nologo"
-vcc.options.linker = "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.options.always =      "/nologo"
+vcc.cpp.options.always =  "/nologo /EHsc"
+vcc.options.linker =      "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker =  "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
 @end
 
-vcc.options.debug = "/Zi /FS /Od"
-vcc.options.speed = "/O2"
-vcc.options.size = "/O1"
+vcc.options.debug =     "/Zi /FS /Od"
+vcc.cpp.options.debug = "/Zi /FS /Od /EHsc"
+vcc.options.speed =     "/O2"
+vcc.cpp.options.speed = "/O2 /EHsc"
+vcc.options.size =     "/O1"
+vcc.cpp.options.size = "/O1 /EHsc"
 
 # Configuration for the Tiny C Compiler:
 tcc.options.always = "-w"


### PR DESCRIPTION
VCC, aka. `Microsoft (R) C/C++ Optimizing Compiler` uses nearly identical command-lines for both C and C++.

For C++, all compiler options pass the `/EHsc` option to the compiler for C++ exception handling.  
From [MSDN - /EH (Exception Handling Model)](https://msdn.microsoft.com/en-us/library/1deeycx5.aspx):
> **`/EHsc`**: catches C++ exceptions only and tells the compiler to assume that functions declared as `extern "C"` never throw a C++ exception.
