### PR TITLE
fixes 64bits type alignement issue on i386 platform.

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1509,9 +1509,26 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     dec c.inTypeContext
 
 proc setMagicType(m: PSym, kind: TTypeKind, size: int) =
+  # source : https://en.wikipedia.org/wiki/Data_structure_alignment#x86
   m.typ.kind = kind
-  m.typ.align = size.int16
   m.typ.size = size
+  # this usually works for most basic types
+  # Assuming that since ARM, ARM64  don't support unaligned access
+  # data is aligned to type size
+  m.typ.align = size.int16
+
+  # FIXME: proper support for clongdouble should be added.
+  # long double size can be 8, 10, 12, 16 bytes depending on platform & compiler
+  if targetCPU == cpuI386 and size == 8:
+    #on Linux/BSD i386, double are aligned to 4bytes (except with -malign-double)
+    if kind in {tyFloat64, tyFloat} and
+       targetOS in {osLinux, osAndroid, osNetbsd, osFreebsd, osOpenbsd, osDragonfly}:
+      m.typ.align = 4
+    # on i386, all known compiler, 64bits ints are aligned to 4bytes (except with -malign-double)
+    elif kind in {tyInt, tyUInt, tyInt64, tyUInt64}:
+      m.typ.align = 4
+  else:
+    discard
 
 proc processMagicType(c: PContext, m: PSym) =
   case m.magic


### PR DESCRIPTION
This fixes issue platform dependant type alignment issue https://github.com/nim-lang/Nim/issues/6094 in order to make PR https://github.com/nim-lang/Nim/pull/5664 usable.

An additional hurdle (only gcc-like compiler)  is passing (via passC) -malign-double to the C compiler which force 64bits type (int and float) alignment to 8bytes (this is the default on x64_86)
This would make the code return a different alignment value from the c compiled code.

It's probably not a particularly important issue, since it's pretty dangerous to use on i386 (ABI compatibility issues, etc...) and not used often, but its better to warn in advance.