### PR TITLE
fixes mitems iterator on vm. (issue with returning tuple value)

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1489,6 +1489,9 @@ proc semYieldVarResult(c: PContext, n: PNode, restype: PType) =
   var t = skipTypes(restype, {tyGenericInst, tyAlias})
   case t.kind
   of tyVar:
+    if n.sons[0].kind in {nkHiddenStdConv, nkHiddenSubConv}:
+      n.sons[0] = n.sons[0].sons[1]
+
     n.sons[0] = takeImplicitAddr(c, n.sons[0])
   of tyTuple:
     for i in 0.. <t.sonsLen:

--- a/tests/vm/tmitems.nim
+++ b/tests/vm/tmitems.nim
@@ -29,3 +29,17 @@ macro m: typed =
     result.add newCall(bindsym"echo", i)
 
 m()
+
+# bug 4741 & 5013
+proc test() =
+  var s = [("baz", 42), ("bath", 42)]
+  for i in s.mitems:
+    i[1] = 3
+  doAssert(s == [("baz", 3), ("bath", 3)])
+
+static:
+  test()
+  var s = [("baz", 42), ("bath", 42)]
+  for i in s.mitems:
+    i[1] = 3
+  doAssert(s == [("baz", 3), ("bath", 3)])


### PR DESCRIPTION
this discard any implicit conversion on iterator return value.
the previous behaviour was to return a reference to a converted copy and
thus not modifying the original value.
This  PR fixes issues #4741 & #5013

This is probably not the desired fix , but I didn't see any issue running the tests.