### PR TITLE
macros warning and hint now also has the node argument

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1315,7 +1315,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNError, opcNWarning, opcNHint:
       let message: string = regs[instr.regA].node.strVal
       var nodeForLineInfo: PNode = regs[instr.regB].node
-      debug(nodeForLineInfo)
       if nodeForLineInfo.kind == nkNilLit:
         nodeForLineInfo = nil
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1318,9 +1318,25 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       let b = regs[rb].node
       stackTrace(c, tos, pc, errUser, a.strVal, if b.kind == nkNilLit: nil else: b)
     of opcNWarning:
-      message(c.debug[pc], warnUser, regs[ra].node.strVal)
+      decodeB(rkNode)
+      let a = regs[ra].node.strVal
+      let b = regs[rb].node
+      let lineinfo =
+        if b.kind == nkNilLit:
+          c.debug[pc]
+        else:
+          b.info
+      message(lineinfo, warnUser, a)
     of opcNHint:
-      message(c.debug[pc], hintUser, regs[ra].node.strVal)
+      decodeB(rkNode)
+      let a = regs[ra].node.strVal
+      let b = regs[rb].node
+      let lineinfo =
+        if b.kind == nkNilLit:
+          c.debug[pc]
+        else:
+          b.info
+      message(lineinfo, hintUser, a)
     of opcParseExprToAst:
       decodeB(rkNode)
       # c.debug[pc].line.int - countLines(regs[rb].strVal) ?

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1140,29 +1140,14 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     else:
       internalAssert false
   of mNHint:
-    if n.len <= 1:
-      # query error condition:
-      c.gABC(n, opcQueryErrorFlag, dest)
-    else:
-      # setter
-      unused(n, dest)
-      genBinaryStmt(c, n, opcNHint)
+    unused(n, dest)
+    genBinaryStmt(c, n, opcNHint)
   of mNWarning:
-    if n.len <= 1:
-      # query error condition:
-      c.gABC(n, opcQueryErrorFlag, dest)
-    else:
-      # setter
-      unused(n, dest)
-      genBinaryStmt(c, n, opcNWarning)
+    unused(n, dest)
+    genBinaryStmt(c, n, opcNWarning)
   of mNError:
-    if n.len <= 1:
-      # query error condition:
-      c.gABC(n, opcQueryErrorFlag, dest)
-    else:
-      # setter
-      unused(n, dest)
-      genBinaryStmt(c, n, opcNError)
+    unused(n, dest)
+    genBinaryStmt(c, n, opcNError)
   of mNCallSite:
     if dest < 0: dest = c.getTemp(n.typ)
     c.gABC(n, opcCallSite, dest)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1140,11 +1140,21 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     else:
       internalAssert false
   of mNHint:
-    unused(n, dest)
-    genUnaryStmt(c, n, opcNHint)
+    if n.len <= 1:
+      # query error condition:
+      c.gABC(n, opcQueryErrorFlag, dest)
+    else:
+      # setter
+      unused(n, dest)
+      genBinaryStmt(c, n, opcNHint)
   of mNWarning:
-    unused(n, dest)
-    genUnaryStmt(c, n, opcNWarning)
+    if n.len <= 1:
+      # query error condition:
+      c.gABC(n, opcQueryErrorFlag, dest)
+    else:
+      # setter
+      unused(n, dest)
+      genBinaryStmt(c, n, opcNWarning)
   of mNError:
     if n.len <= 1:
       # query error condition:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -263,16 +263,17 @@ proc getImpl*(s: NimSym): NimNode {.magic: "GetImpl", noSideEffect.} =
 proc callsite*(): NimNode {.magic: "NCallSite", benign.}
   ## returns the AST of the invocation expression that invoked this macro.
 
-when nimvm:
-  proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign.}
-    ## writes an error message at compile time
+proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign.}
+  ## writes an error message at compile time
 
-  proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
-    ## writes a warning message at compile time
+proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
+  ## writes a warning message at compile time
 
-  proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
-    ## writes a hint message at compile time
-else:
+proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
+  ## writes a hint message at compile time
+
+#[
+when not nimvm:
   macro error*(msg: static[string]): untyped =
     ## writes an error message at compile time
     error(msg, callsite())
@@ -284,6 +285,7 @@ else:
   macro hint*(msg: static[string]): untyped =
     ## writes a hint message at compile time
     hint(msg, callsite())
+]#
 
 proc newStrLitNode*(s: string): NimNode {.compileTime, noSideEffect.} =
   ## creates a string literal node from `s`

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -263,10 +263,10 @@ proc getImpl*(s: NimSym): NimNode {.magic: "GetImpl", noSideEffect.} =
 proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign.}
   ## writes an error message at compile time
 
-proc warning*(msg: string) {.magic: "NWarning", benign.}
+proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
   ## writes a warning message at compile time
 
-proc hint*(msg: string) {.magic: "NHint", benign.}
+proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
   ## writes a hint message at compile time
 
 proc newStrLitNode*(s: string): NimNode {.compileTime, noSideEffect.} =

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -260,14 +260,30 @@ proc getImpl*(s: NimSym): NimNode {.magic: "GetImpl", noSideEffect.} =
   ## const.
   discard
 
-proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign.}
-  ## writes an error message at compile time
+proc callsite*(): NimNode {.magic: "NCallSite", benign.}
+  ## returns the AST of the invocation expression that invoked this macro.
 
-proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
-  ## writes a warning message at compile time
+when nimvm:
+  proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign.}
+    ## writes an error message at compile time
 
-proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
-  ## writes a hint message at compile time
+  proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
+    ## writes a warning message at compile time
+
+  proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
+    ## writes a hint message at compile time
+else:
+  macro error*(msg: static[string]): untyped =
+    ## writes an error message at compile time
+    error(msg, callsite())
+
+  macro warning*(msg: static[string]): untyped =
+    ## writes a warning message at compile time
+    warning(msg, callsite())
+
+  macro hint*(msg: static[string]): untyped =
+    ## writes a hint message at compile time
+    hint(msg, callsite())
 
 proc newStrLitNode*(s: string): NimNode {.compileTime, noSideEffect.} =
   ## creates a string literal node from `s`
@@ -327,9 +343,6 @@ proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   magic: "NGenSym", noSideEffect.}
   ## generates a fresh symbol that is guaranteed to be unique. The symbol
   ## needs to occur in a declaration context.
-
-proc callsite*(): NimNode {.magic: "NCallSite", benign.}
-  ## returns the AST of the invocation expression that invoked this macro.
 
 proc toStrLit*(n: NimNode): NimNode {.compileTime.} =
   ## converts the AST `n` to the concrete Nim code and wraps that

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -272,21 +272,6 @@ proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
 proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
   ## writes a hint message at compile time
 
-#[
-when not nimvm:
-  macro error*(msg: static[string]): untyped =
-    ## writes an error message at compile time
-    error(msg, callsite())
-
-  macro warning*(msg: static[string]): untyped =
-    ## writes a warning message at compile time
-    warning(msg, callsite())
-
-  macro hint*(msg: static[string]): untyped =
-    ## writes a hint message at compile time
-    hint(msg, callsite())
-]#
-
 proc newStrLitNode*(s: string): NimNode {.compileTime, noSideEffect.} =
   ## creates a string literal node from `s`
   result = newNimNode(nnkStrLit)

--- a/tests/macros/tmacros1.nim
+++ b/tests/macros/tmacros1.nim
@@ -26,4 +26,15 @@ macro outterMacro*(n, blck: untyped): untyped =
 var str: string
 outterMacro(str):
   "hellow"
+
 echo str
+
+macro mymacro(arg1,arg2,arg3: untyped): untyped =
+  # this needs to compile, but how can I test that it actually does the right thing?
+  hint("somehint")
+  warning("somewarning")
+  hint("myhint", arg1)
+  warning("mywarning", arg2)
+  error("myerror", arg3)
+
+# mymacro(ident1, ident2, ident3)


### PR DESCRIPTION
No Idea why these were not included in the initial version they would have been straight forward.