### PR TITLE
Nim Configuration cleanup for VCC

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -199,34 +199,33 @@ vcc.linkerexe =     "vccexe.exe"
 vcc.cpp.linkerexe = "vccexe.exe"
 
 # set the options for specific platforms:
-@if i386:
-vcc.options.always =      "--platform:x86 /nologo"
-vcc.cpp.options.always =  "--platform:x86 /nologo /EHsc"
-vcc.options.linker =      "--platform:x86 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-vcc.cpp.options.linker =  "--platform:x86 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-@elif amd64:
-vcc.options.always =      "--platform:amd64 /nologo"
-vcc.cpp.options.always =  "--platform:amd64 /nologo /EHsc"
-vcc.options.linker =      "--platform:amd64 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-vcc.cpp.options.linker =  "--platform:amd64 /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-@elif arm:
-vcc.options.always =      "--platform:arm /nologo"
-vcc.cpp.options.always =  "--platform:arm /nologo /EHsc"
-vcc.options.linker =      "--platform:arm /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-vcc.cpp.options.linker =  "--platform:arm /nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-@else:
 vcc.options.always =      "/nologo"
-vcc.cpp.options.always =  "/nologo /EHsc"
+vcc.cpp.options.always %=  "${vcc.options.always} /EHsc"
 vcc.options.linker =      "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
-vcc.cpp.options.linker =  "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker %=  "${vcc.options.linker}"
+@if i386:
+vcc.options.always %=      "--platform:x86 ${vcc.options.always}"
+vcc.cpp.options.always %=  "--platform:x86 ${vcc.cpp.options.always}"
+vcc.options.linker %=      "--platform:x86 ${vcc.options.linker}"
+vcc.cpp.options.linker %=  "--platform:x86 ${vcc.cpp.options.linker}"
+@elif amd64:
+vcc.options.always %=      "--platform:amd64 ${vcc.options.always}"
+vcc.cpp.options.always %=  "--platform:amd64 ${vcc.cpp.options.always}"
+vcc.options.linker %=      "--platform:amd64 ${vcc.options.linker}"
+vcc.cpp.options.linker %=  "--platform:amd64 ${vcc.cpp.options.linker}"
+@elif arm:
+vcc.options.always %=      "--platform:arm ${vcc.options.always}"
+vcc.cpp.options.always %=  "--platform:arm ${vcc.cpp.options.always}"
+vcc.options.linker %=      "--platform:arm ${vcc.options.linker}"
+vcc.cpp.options.linker %=  "--platform:arm ${vcc.cpp.options.linker}"
 @end
 
 vcc.options.debug =     "/Zi /FS /Od"
-vcc.cpp.options.debug = "/Zi /FS /Od /EHsc"
+vcc.cpp.options.debug = "/Zi /FS /Od"
 vcc.options.speed =     "/O2"
-vcc.cpp.options.speed = "/O2 /EHsc"
+vcc.cpp.options.speed = "/O2"
 vcc.options.size =     "/O1"
-vcc.cpp.options.size = "/O1 /EHsc"
+vcc.cpp.options.size = "/O1"
 
 # Configuration for the Tiny C Compiler:
 tcc.options.always = "-w"


### PR DESCRIPTION
Instead of having duplicate settings for all platforms, use `%=` instead to avoid redundencies