### PR TITLE
Generate deps file during C compilation

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -16,7 +16,7 @@ import
   cgen, jsgen, json, nversion,
   platform, nimconf, importer, passaux, depends, vm, vmdef, types, idgen,
   docgen2, service, parser, modules, ccgutils, sigmatch, ropes,
-  modulegraphs
+  modulegraphs, tables
 
 from magicsys import systemModule, resetSysTypes
 
@@ -36,6 +36,9 @@ proc writeDepsFile(g: ModuleGraph; project: string) =
   for m in g.modules:
     if m != nil:
       f.writeLine(toFullPath(m.position.int32))
+  for k in g.inclToMod.keys:
+    if g.getModule(k).isNil:  # don't repeat includes which are also modules
+      f.writeLine(k.toFullPath)
   f.close()
 
 proc commandGenDepend(graph: ModuleGraph; cache: IdentCache) =

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -77,6 +77,7 @@ proc commandCompileToC(graph: ModuleGraph; cache: IdentCache) =
     let proj = changeFileExt(gProjectFull, "")
     extccomp.callCCompiler(proj)
     extccomp.writeJsonBuildInstructions(proj)
+    writeDepsFile(graph, toGeneratedFile(proj, ""))
 
 proc commandCompileToJS(graph: ModuleGraph; cache: IdentCache) =
   #incl(gGlobalOptions, optSafeCode)


### PR DESCRIPTION
The "genDepend" command was previously taught how to generate a "deps"
file in 4910a87 (gendepend improvements; refs #5144). Such a deps file
is useful in integrating the Nim compiler with an external build system
or watch daemon, such that it's possible to only run the Nim compiler
when any of the source files are modified.

It's also useful to generate the deps file in the nimcache directory
during C compilation, without needing to re-run the compilation passes
with "genDepend". This would thus reduce overall project build times.