### PR TITLE
Fix constant folding for cast expression:cast[ proc]

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -779,8 +779,10 @@ proc getConstExpr(m: PSym, n: PNode): PNode =
     if a == nil: return
     if n.typ != nil and n.typ.kind in NilableTypes:
       # we allow compile-time 'cast' for pointer types:
-      result = a
-      result.typ = n.typ
+      # but not for procs. bug #5901
+      if n.typ.kind != tyProc:
+        result = a
+        result.typ = n.typ
   of nkBracketExpr: result = foldArrayAccess(m, n)
   of nkDotExpr: result = foldFieldAccess(m, n)
   else:

--- a/tests/misc/tcast.nim
+++ b/tests/misc/tcast.nim
@@ -7,7 +7,7 @@ type MyProc = proc() {.cdecl.}
 type MyProc2 = proc() {.nimcall.}
 type MyProc3 = proc() #{.closure.} is implicit
 
-proc testProc()  = echo "Hello World"
+proc testProc() {.exportc:"foo".} = echo "Hello World"
 
 proc callPointer(p: pointer) =
   # can cast to proc(){.cdecl.}
@@ -19,5 +19,9 @@ proc callPointer(p: pointer) =
 
   ffunc0()
   ffunc1()
+
+  # test bug 5901
+  proc foo() {.importc.}
+  (cast[proc(a: int) {.cdecl.}](foo))(5)
 
 callPointer(cast[pointer](testProc))


### PR DESCRIPTION
fixes issue #5901 
constant folding for cast[pointer types] was causing issue with casting between procs with different signatures.
EDIT: This fix need to be implemented differently. maybe by assigning to a temporary variable.