### PR TITLE
libcurl is available via nimble, doc isn't in stdlib any more

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -539,9 +539,6 @@ Network Programming and Internet Protocols
 * `joyent_http_parser <joyent_http_parser.html>`_
   Wrapper for the joyent's high-performance HTTP parser.
 
-* `libcurl <libcurl.html>`_
-  Wrapper for the libcurl library.
-
 * `openssl <openssl.html>`_
   Wrapper for OpenSSL.
 


### PR DESCRIPTION
Per [this](https://github.com/nim-lang/Nim/blob/d4e766c8dca5ebe6a11f8f60b93c8126166fbfc0/web/news/e017_version_0_12_0.rst) version - libcurl isn't in stdlib and the nim web page (obviously) doesn't go anywhere useful given that libcurl isn't in stdlib anymore