### PR TITLE
Avoid execvpe() when defined(no_gnu)

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -432,7 +432,6 @@ proc execv*(a1: cstring, a2: cstringArray): cint {.importc, header: "<unistd.h>"
 proc execve*(a1: cstring, a2, a3: cstringArray): cint {.
   importc, header: "<unistd.h>".}
 proc execvp*(a1: cstring, a2: cstringArray): cint {.importc, header: "<unistd.h>".}
-proc execvpe*(a1: cstring, a2: cstringArray, a3: cstringArray): cint {.importc, header: "<unistd.h>".}
 proc fchown*(a1: cint, a2: Uid, a3: Gid): cint {.importc, header: "<unistd.h>".}
 proc fchdir*(a1: cint): cint {.importc, header: "<unistd.h>".}
 proc fdatasync*(a1: cint): cint {.importc, header: "<unistd.h>".}

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -920,8 +920,7 @@ elif not defined(useNimRtl):
     discard write(data.pErrorPipe[writeIdx], addr error, sizeof(error))
     exitnow(1)
 
-  when not defined(uClibc) and (not defined(linux) or defined(android)):
-    var environ {.importc.}: cstringArray
+  var environ {.importc.}: cstringArray
 
   proc startProcessAfterFork(data: ptr StartProcessData) =
     # Warning: no GC here!
@@ -953,8 +952,9 @@ elif not defined(useNimRtl):
       when defined(uClibc):
         # uClibc environment (OpenWrt included) doesn't have the full execvpe
         discard execve(data.sysCommand, data.sysArgs, data.sysEnv)
-      elif defined(linux) and not defined(android):
-        discard execvpe(data.sysCommand, data.sysArgs, data.sysEnv)
+      #elif defined(linux) and not defined(android):
+      #  discard execvpe(data.sysCommand, data.sysArgs, data.sysEnv)
+      #  Old glibc lacks execvpe(), so just use execvp as for MacOSX.
       else:
         # MacOSX doesn't have execvpe, so we need workaround.
         # On MacOSX we can arrive here only from fork, so this is safe:


### PR DESCRIPTION
This pull-request is in line with [a comment from Araq](https://forum.nim-lang.org/t/1972):

> We can introduce -d:oldLinux for example for this feature. ~araq

But the problem is not really "old Linux", but more specifically "old GLIBC". GNU GLIBC-2.11 introduced [the GNU extension `execvpe()`](https://www.gnu.org/software/gnulib/manual/html_node/execvpe.html). To see when various functions were added to glibc:
* https://github.com/sulix/bingcc/blob/master/glibc_ver.h#L179

We have had a lot of discussion of this problem within my company (where we are trying to use Nim for bioinformatics). We have some customers with old GLIBC, so we build against glibc-2.5 to be safe.

Some folks are upset that Nim uses a GNU extension for the Linux build, when that function is not actually used on some other systems. One safe solution would be to copy [the source-code of `execvpe()`](https://git.musl-libc.org/cgit/musl/tree/src/process/execvp.c) directly into Nim and rename it. But this pull-request at least allows us to distribute nim-built binaries to all our customers.

References:

* https://forum.nim-lang.org/t/1972
* #1734
* #3138
* #3759

To take advantage of this change, when building the Nim compiler, per `readme.md`:

    cd csources
    ./build.sh --extraBuildArgs -Dexecvpe=execve
    cd ..
    bin/nim -d:no_gnu c koch
    ./koch boot -d:release -d:no_gnu