### PR TITLE
Fix #5870

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2262,6 +2262,8 @@ proc getNullValueAux(p: BProc; obj, cons: PNode, result: var Rope) =
     localError(cons.info, "cannot create null element for: " & $obj)
 
 proc genConstObjConstr(p: BProc; n: PNode): Rope =
+  if nfIsRef in n.flags:
+    localError(n.info, "invalid type for const: ref " & $n.typ)
   var length = sonsLen(n)
   result = nil
   let t = n.typ.skipTypes(abstractInst)

--- a/tests/misc/t5870.nim
+++ b/tests/misc/t5870.nim
@@ -1,0 +1,14 @@
+discard """
+  file: "t5870.nim"
+  line: 11
+  errormsg: "invalid type for const: ref SomeRefObj"
+"""
+
+type SomeRefObj = ref object of RootObj
+  someIntMember: int
+
+proc createSomeRefObj(v: int): SomeRefObj =
+  result.new()
+  result.someIntMember = v
+
+const compileTimeSeqOfRefObjs = @[createSomeRefObj(100500), createSomeRefObj(2)]


### PR DESCRIPTION
Now compiler outputs proper error message if user tries to create a "const" of ref type.