### PR TITLE
Changed JSON stringification to preserve UTF

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -997,22 +997,16 @@ proc escapeJson*(s: string; result: var string) =
   ## Converts a string `s` to its JSON representation.
   ## Appends to ``result``.
   result.add("\"")
-  for x in runes(s):
-    var r = int(x)
-    if r <= 127:
-      let c = chr(r)
-      case c
-      of '\L': result.add("\\n")
-      of '\b': result.add("\\b")
-      of '\f': result.add("\\f")
-      of '\t': result.add("\\t")
-      of '\r': result.add("\\r")
-      of '"': result.add("\\\"")
-      of '\\': result.add("\\\\")
-      else: result.add(c)
-    else:
-      let p = result.len
-      fastToUTF8Copy(x, result, p, false)
+  for c in s:
+    case c
+    of '\L': result.add("\\n")
+    of '\b': result.add("\\b")
+    of '\f': result.add("\\f")
+    of '\t': result.add("\\t")
+    of '\r': result.add("\\r")
+    of '"': result.add("\\\"")
+    of '\\': result.add("\\\\")
+    else: result.add(c)
   result.add("\"")
 
 proc escapeJson*(s: string): string =

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -1,5 +1,5 @@
 discard """
-  output: '''{"age": 12, "bio": "\u042F Cletus", "blob": [65, 66, 67, 128], "name": "Cletus"}
+  output: '''{"age": 12, "bio": "Я Cletus", "blob": [65, 66, 67, 128], "name": "Cletus"}
 true
 true
 alpha 100


### PR DESCRIPTION
This PR makes JSON output nicer by preserving UTF8 char sequences, according to [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf), except for `/` char for aesthetical reasons.