### PR TITLE
Revert usage of non-standard `uname -o` command in build.sh

### DIFF
--- a/tools/niminst/buildsh.tmpl
+++ b/tools/niminst/buildsh.tmpl
@@ -47,7 +47,7 @@ PS4=""
 #  add(result, "# platform detection\n")
 ucpu=`uname -m`
 uos=`uname`
-uosname=`uname -o`
+uosname=
 #  add(result, "# bin dir detection\n")
 binDir=?{firstBinPath(c).toUnix}
 


### PR DESCRIPTION
It turns out that `uname -o` which should return the operating system name is a non-standardized addition to `uname` and thus is not guaranteed to be supported on all POSIX systems. E.g.: Usage of `uname -o` breaks the build on Mac OSX.

**Workaround:** Call `build.sh` with command-line arguments like shown in the following example for android:
``` bash
sh ./build.sh --osname android
```