### PR TITLE
Fix early closure not invalidating file handle

### DIFF
--- a/lib/pure/includes/oserr.nim
+++ b/lib/pure/includes/oserr.nim
@@ -83,13 +83,19 @@ proc osErrorMsg*(errorCode: OSErrorCode): string =
         if formatMessageW(0x00000100 or 0x00001000 or 0x00000200,
                         nil, errorCode.int32, 0, addr(msgbuf), 0, nil) != 0'i32:
           result = $msgbuf
+          # strip null character
+          result = result.substr(0, result.len-3)
           if msgbuf != nil: localFree(cast[pointer](msgbuf))
       else:
         var msgbuf: cstring
         if formatMessageA(0x00000100 or 0x00001000 or 0x00000200,
                         nil, errorCode.int32, 0, addr(msgbuf), 0, nil) != 0'i32:
           result = $msgbuf
+          # strip null character
+          result = result.substr(0, result.len-3)
           if msgbuf != nil: localFree(msgbuf)
+    else:
+      result = "Error code not set"
   else:
     if errorCode != OSErrorCode(0'i32):
       result = $c_strerror(errorCode.int32)
@@ -107,7 +113,7 @@ proc raiseOSError*(errorCode: OSErrorCode; additionalInfo = "") {.noinline.} =
   if additionalInfo.len == 0:
     e.msg = osErrorMsg(errorCode)
   else:
-    e.msg = osErrorMsg(errorCode) & "\nAdditional info: " & additionalInfo
+    e.msg = osErrorMsg(errorCode) & " Additional info: " & additionalInfo
   if e.msg == "":
     e.msg = "unknown OS error"
   raise e

--- a/lib/pure/includes/oserr.nim
+++ b/lib/pure/includes/oserr.nim
@@ -83,19 +83,15 @@ proc osErrorMsg*(errorCode: OSErrorCode): string =
         if formatMessageW(0x00000100 or 0x00001000 or 0x00000200,
                         nil, errorCode.int32, 0, addr(msgbuf), 0, nil) != 0'i32:
           result = $msgbuf
-          # strip null character
-          result = result.substr(0, result.len-3)
           if msgbuf != nil: localFree(cast[pointer](msgbuf))
       else:
         var msgbuf: cstring
         if formatMessageA(0x00000100 or 0x00001000 or 0x00000200,
                         nil, errorCode.int32, 0, addr(msgbuf), 0, nil) != 0'i32:
           result = $msgbuf
-          # strip null character
-          result = result.substr(0, result.len-3)
           if msgbuf != nil: localFree(msgbuf)
     else:
-      result = "Error code not set"
+      result = "Error code not set\n"
   else:
     if errorCode != OSErrorCode(0'i32):
       result = $c_strerror(errorCode.int32)
@@ -113,7 +109,7 @@ proc raiseOSError*(errorCode: OSErrorCode; additionalInfo = "") {.noinline.} =
   if additionalInfo.len == 0:
     e.msg = osErrorMsg(errorCode)
   else:
-    e.msg = osErrorMsg(errorCode) & " Additional info: " & additionalInfo
+    e.msg = osErrorMsg(errorCode) & "\nAdditional info: " & additionalInfo
   if e.msg == "":
     e.msg = "unknown OS error"
   raise e

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -256,16 +256,16 @@ proc close*(f: var MemFile) =
 
   when defined(windows):
     if f.wasOpened:
-      if unmapViewOfFile(f.mem) == 0:
+      if unmapViewOfFile(f.mem) == 0 and not error:
         error = true
         lastErr = osLastError()
 
-      if closeHandle(f.mapHandle) == 0:
+      if closeHandle(f.mapHandle) == 0 and not error:
         error = true
         lastErr = osLastError()
 
       if f.fHandle != INVALID_HANDLE_VALUE:
-        if closeHandle(f.fHandle) == 0:
+        if closeHandle(f.fHandle) == 0 and not error:
           error = true
           lastErr = osLastError()
 

--- a/tests/stdlib/tmemfiles2.nim
+++ b/tests/stdlib/tmemfiles2.nim
@@ -1,6 +1,5 @@
 discard """
   file: "tmemfiles2.nim"
-  disabled: true
   output: '''Full read size: 20
 Half read size: 10 Data: Hello'''
 """

--- a/tests/stdlib/tmemfiles2.nim
+++ b/tests/stdlib/tmemfiles2.nim
@@ -3,7 +3,6 @@ discard """
   output: '''Full read size: 20
 Half read size: 10 Data: Hello'''
 """
-# doesn't work on windows. fmReadWrite doesn't create a file.
 import memfiles, os
 var
   mm, mm_full, mm_half: MemFile


### PR DESCRIPTION
File handle was only being being set to invalid if the early closure
failed.

Change error recording while closing file to more accurately capture
last error message.