### PR TITLE
Fixed closure compiler incompatibility

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1284,7 +1284,7 @@ else:
         result.add(x[i].convertObject())
     of JObject:
       result = newJObject()
-      asm """for (property in `x`) {
+      asm """for (var property in `x`) {
         if (`x`.hasOwnProperty(property)) {
       """
       var nimProperty: cstring


### PR DESCRIPTION
New versions of closure compiler are complaining about this:
```
 ERROR - variable property is undeclared
			for (property in x_780603) {
			     ^^^^^^^^
```