### PR TITLE
Add check for broken code-block in docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,5 @@ script:
   - ./koch csource
   - ./koch nimsuggest
 #  - nim c -r nimsuggest/tester
+  - ( ! grep -F '.. code-block' -l -r --include '*.html' --exclude contributing.html --exclude docgen.html --exclude tut2.html )
+  - ( ! grep -F '..code-block' -l -r --include '*.html' --exclude contributing.html --exclude docgen.html --exclude tut2.html )

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -305,6 +305,7 @@ proc `+`*(ti1, ti2: TimeInterval): TimeInterval =
 
 proc `-`*(ti: TimeInterval): TimeInterval =
   ## Reverses a time interval
+  ##
   ## .. code-block:: nim
   ##
   ##     let day = -initInterval(hours=24)


### PR DESCRIPTION
Add a simple grep to the Travis CI build to detect badly formatted ".. code-block::" entries.
Fix docstrings in two files.