### PR TITLE
VCC always creates debug symbols when not in release

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -205,7 +205,7 @@ vcc.options.always =      "/nologo"
 @if release:
   # no debug symbols in release builds
 @else:
-  vcc.options.always %= "${vcc.options.always} /Zi /FS" # Get VCC to output full debug symbols in a pdb file
+  vcc.options.always %= "${vcc.options.always} /Z7" # Get VCC to output full debug symbols in the obj file
 @end
 vcc.cpp.options.always %=  "${vcc.options.always} /EHsc"
 vcc.options.linker =      "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -202,6 +202,11 @@ vcc.cpp.linkerexe = "vccexe.exe"
 
 # set the options for specific platforms:
 vcc.options.always =      "/nologo"
+@if release:
+  # no debug symbols in release builds
+@else:
+  vcc.options.always %= "${vcc.options.always} /Zi /FS" # Get VCC to output full debug symbols in a pdb file
+@end
 vcc.cpp.options.always %=  "${vcc.options.always} /EHsc"
 vcc.options.linker =      "/nologo /DEBUG /Zi /F33554432" # set the stack size to 32 MiB
 vcc.cpp.options.linker %=  "${vcc.options.linker}"
@@ -222,8 +227,8 @@ vcc.options.linker %=      "--platform:arm ${vcc.options.linker}"
 vcc.cpp.options.linker %=  "--platform:arm ${vcc.cpp.options.linker}"
 @end
 
-vcc.options.debug =     "/Zi /FS /Od"
-vcc.cpp.options.debug = "/Zi /FS /Od"
+vcc.options.debug =     "/Od"
+vcc.cpp.options.debug = "/Od"
 vcc.options.speed =     "/O2"
 vcc.cpp.options.speed = "/O2"
 vcc.options.size =     "/O1"


### PR DESCRIPTION
`vcc.options.debug` is not automatically triggered for non-release builds. Therefore, move the `/Zi` (create Program Database) and `/FS` serialize PDB output compiler flags to a more general case.

`vcc.options.debug` now only affects the VCC code optimizer by specifying `/Od` (no optimization).

This change enables easy step-by-step debugging through the generated C code, while incurring no additional size to the resulting binary (as all debug information is stored in a separate .pdb file). This will be the first step to enable full Nim-PDB support for the Windows Native Debugger.

Next, replace `/Zi /FS` with `/Z7` (see [/Z7, /Zi, /ZI (Debug Information Format)](https://msdn.microsoft.com/en-us/library/958x11bc.aspx)) to store the debug information in the generated `.obj` instead of a shared `.pdb` file. This removes the need to serialize access to the shared debug information file, the debug information is now collected and merged together during linking instead. This enables parallel compilation of c-source files for debug files.