### PR TITLE
Add newSeqUninitialized, closes #6401

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -714,6 +714,18 @@ proc newSeqOfCap*[T](cap: Natural): seq[T] {.
   ## ``cap``.
   discard
 
+when not defined(JS):
+  proc newSeqUninitialized*[T: SomeNumber](len: Natural): seq[T] =
+    ## creates a new sequence of type ``seq[T]`` with length ``len``.
+    ##
+    ## Only available for numbers types. Note that the sequence will be
+    ## uninitialized. After the creation of the sequence you should assign
+    ## entries to the sequence instead of adding them.
+
+    result = newSeqOfCap[T](len)
+    var s = cast[PGenericSeq](result)
+    s.len = len
+
 proc len*[TOpenArray: openArray|varargs](x: TOpenArray): int {.
   magic: "LengthOpenArray", noSideEffect.}
 proc len*(x: string): int {.magic: "LengthStr", noSideEffect.}


### PR DESCRIPTION
This is useful as mentioned in the issue #6401 

Note that this is only implemented for seq of numbers. I'm not sure if this is the correct implementation, however testing using this method I do see random numbers when initializing and no zeros anymore.

Please review.