### PR TITLE
Fix `getPeerAddr()` `getPeerAddr()`: +`sin6_addr`

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -498,7 +498,7 @@ proc getLocalAddr*(socket: SocketHandle, domain: Domain): (string, Port) =
     # Cannot use INET6_ADDRSTRLEN here, because it's a C define.
     var buf: array[64, char]
     if inet_ntop(name.sin6_family.cint,
-                 addr name, buf.cstring, sizeof(buf).int32).isNil:
+                 addr name.sin6_addr, buf.cstring, sizeof(buf).int32).isNil:
       raiseOSError(osLastError())
     result = ($buf, Port(nativesockets.ntohs(name.sin6_port)))
   else:
@@ -534,7 +534,7 @@ proc getPeerAddr*(socket: SocketHandle, domain: Domain): (string, Port) =
     # Cannot use INET6_ADDRSTRLEN here, because it's a C define.
     var buf: array[64, char]
     if inet_ntop(name.sin6_family.cint,
-                 addr name, buf.cstring, sizeof(buf).int32).isNil:
+                 addr name.sin6_addr, buf.cstring, sizeof(buf).int32).isNil:
       raiseOSError(osLastError())
     result = ($buf, Port(nativesockets.ntohs(name.sin6_port)))
   else:


### PR DESCRIPTION
Test them by:

```nim
import nativesockets, net

var sock = newSocket(AF_INET6)
sock.bindAddr(Port(0), "::1")

assert sock.getLocalAddr()[0] == "::1"
```