### PR TITLE
Don't run "kde-open" and "gnome-open" under Unix

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -25,12 +25,9 @@ proc openDefaultBrowser*(url: string) =
   ## used if it does. Otherwise the environment variable ``BROWSER`` is 
   ## used to determine the default browser to use.
   when defined(windows):
-    when useWinUnicode:
-      var o = newWideCString("open")
-      var u = newWideCString(url)
-      discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
-    else:
-      discard shellExecuteA(0'i32, "open", url, nil, nil, SW_SHOWNORMAL)
+    var o = newWideCString("open")
+    var u = newWideCString(url)
+    discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
   elif defined(macosx):
     discard execShellCmd("open " & quoteShell(url))
   else:

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -21,10 +21,9 @@ proc openDefaultBrowser*(url: string) =
   ## opens `url` with the user's default browser. This does not block.
   ##
   ## Under Windows, ``ShellExecute`` is used. Under Mac OS X the ``open``
-  ## command is used. Under Unix, it is checked if ``gnome-open`` exists and
-  ## used if it does. Next attempt is ``kde-open``, then ``xdg-open``.
-  ## Otherwise the environment variable ``BROWSER`` is used to determine the
-  ## default browser to use.
+  ## command is used. Under Unix, it is checked if ``xdg-open`` exists and
+  ## used if it does. Otherwise the environment variable ``BROWSER`` is 
+  ## used to determine the default browser to use.
   when defined(windows):
     when useWinUnicode:
       var o = newWideCString("open")
@@ -35,10 +34,8 @@ proc openDefaultBrowser*(url: string) =
   elif defined(macosx):
     discard execShellCmd("open " & quoteShell(url))
   else:
-    const attempts = ["gnome-open ", "kde-open ", "xdg-open "]
     var u = quoteShell(url)
-    for a in items(attempts):
-      if execShellCmd(a & u) == 0: return
+    if execShellCmd("xdg-open " & u) == 0: return
     for b in getEnv("BROWSER").string.split(PathSep):
       try:
         # we use ``startProcess`` here because we don't want to block!


### PR DESCRIPTION
All these utilities where replaced by xdg-open from package xdg-utils in Linux and the BSDs.
Checked: CentOS,  Solaris,  NetBSD,  OpenBSD,  FreeBSD' they all have it in their repos.

Testing done: Run it at a Linux system works.