### PR TITLE
Futher improve seq assingment speed #6433 by 2x factor

### DIFF
--- a/lib/system/assign.nim
+++ b/lib/system/assign.nim
@@ -61,13 +61,17 @@ proc genericAssignAux(dest, src: pointer, mt: PNimType, shallow: bool) =
       unsureAsgnRef(x, s2)
       return
     sysAssert(dest != nil, "genericAssignAux 3")
-    unsureAsgnRef(x, newSeq(mt, seq.len))
-    var dst = cast[ByteAddress](cast[PPointer](dest)[])
     if ntfNoRefs in mt.base.flags:
+      var ss = nimNewSeqOfCap(mt, seq.len)
+      cast[PGenericSeq](ss).len = seq.len
+      unsureAsgnRef(x, ss)
+      var dst = cast[ByteAddress](cast[PPointer](dest)[])
       copyMem(cast[pointer](dst +% GenericSeqSize),
               cast[pointer](cast[ByteAddress](s2) +% GenericSeqSize),
               seq.len * mt.base.size)
     else:
+      unsureAsgnRef(x, newSeq(mt, seq.len))
+      var dst = cast[ByteAddress](cast[PPointer](dest)[])
       for i in 0..seq.len-1:
         genericAssignAux(
           cast[pointer](dst +% i*% mt.base.size +% GenericSeqSize),


### PR DESCRIPTION
This is roughly an idea, work must be reviewed.

Test case is the same in #6433

```Nim
import times, sequtils

proc newSeqUninitialized[T](len: Natural): seq[T] {.noSideEffect,inline.}=
  result = newSeqOfCap[T](len)
  result.setLen(len)

let size = 1000000
var data = newSeqWith(size, -3.67'f32)
var s1, s2 : seq[float32]
var start: float

start = cpuTime()
for i in 0..<10000:
  s1 = newSeqUninitialized[float32](size)
  copyMem(s1[0].addr, data[0].addr, size*sizeof(float32))
echo "copymem ", cpuTime() - start

start = cpuTime()
for i in 0..<10000:
  s2 = data
echo "assignment ", cpuTime() - start

assert s1[0] == s2[0]
assert s1[size-1] == s2[size-1]
```

Before this patch:
```
copymem 2.427948
assignment 4.052885
```

After this patch:
```
copymem 2.575448
assignment 2.451823
```