### PR TITLE
[RFC] [Patch] Allow clang with msvc abi and headers

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -81,16 +81,11 @@ when defined(posix) and not defined(JS):
 elif defined(windows):
   import winlean
 
-  when defined(vcc) or defined(bcc) or defined(icl):
-    # newest version of Visual C++ defines time_t to be of 64 bits
-    type TimeImpl {.importc: "time_t", header: "<time.h>".} = int64
-    # visual c's c runtime exposes these under a different name
-    var
-      timezone {.importc: "_timezone", header: "<time.h>".}: int
-  else:
-    type TimeImpl {.importc: "time_t", header: "<time.h>".} = int
-    var
-      timezone {.importc, header: "<time.h>".}: int
+  # newest version of Visual C++ defines time_t to be of 64 bits
+  type TimeImpl {.importc: "time_t", header: "<time.h>".} = int64
+  # visual c's c runtime exposes these under a different name
+  var
+    timezone {.importc: "_timezone", header: "<time.h>".}: int
 
   type
     Time* = distinct TimeImpl

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2868,7 +2868,7 @@ when not defined(JS): #and not defined(nimscript):
         importc: when defined(bcc): "setmode" else: "_setmode",
         header: "<io.h>".}
       var
-        O_BINARY {.importc: "O_BINARY", nodecl.}: cint
+        O_BINARY {.importc: "_O_BINARY", header:"<fcntl.h>".}: cint
 
       # we use binary mode on Windows:
       c_setmode(c_fileno(stdin), O_BINARY)

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -103,8 +103,12 @@ proc c_sprintf(buf, frmt: cstring): cint {.
   importc: "sprintf", header: "<stdio.h>", varargs, noSideEffect.}
   # we use it only in a way that cannot lead to security issues
 
-proc c_fileno(f: File): cint {.
-  importc: "fileno", header: "<fcntl.h>".}
+when defined(windows):
+  proc c_fileno(f: File): cint {.
+      importc: "_fileno", header: "<stdio.h>".}
+else:
+  proc c_fileno(f: File): cint {.
+      importc: "fileno", header: "<fcntl.h>".}
 
 proc c_malloc(size: csize): pointer {.
   importc: "malloc", header: "<stdlib.h>".}

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -15,9 +15,12 @@
 {.push debugger:off .} # the user does not want to trace a part
                        # of the standard library!
 
-
-proc c_fdopen(filehandle: cint, mode: cstring): File {.
-  importc: "fdopen", header: "<stdio.h>".}
+when defined(windows):
+  proc c_fdopen(filehandle: cint, mode: cstring): File {.
+    importc: "_fdopen", header: "<stdio.h>".}
+else:
+  proc c_fdopen(filehandle: cint, mode: cstring): File {.
+    importc: "fdopen", header: "<stdio.h>".}
 proc c_fputs(c: cstring, f: File): cint {.
   importc: "fputs", header: "<stdio.h>", tags: [WriteIOEffect].}
 proc c_fgets(c: cstring, n: cint, f: File): cstring {.

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -14,8 +14,8 @@
 
 import dynlib
 
-when defined(vcc):
-  {.passC: "-DWIN32_LEAN_AND_MEAN".}
+
+{.passC: "-DWIN32_LEAN_AND_MEAN".}
 
 const
   useWinUnicode* = not defined(useWinAnsi)


### PR DESCRIPTION
clang can parse the windows headers from the windows kits and link aganst the MS C runtime. There are some places in nim that use when defined(vcc) instead of when defined(windows). I think these should be switched over, and I think these symbols exist in the mingw headers as well.


Do not merge yet, we should run the test suite on all supported windows toolchains first.