### PR TITLE
Fix node quit

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1443,6 +1443,10 @@ elif defined(genode):
     importcpp: "genodeEnv->parent().exit(@); Genode::sleep_forever()",
     header: "<base/sleep.h>".}
 
+elif defined(nodejs):
+  proc quit*(errorcode: int = QuitSuccess) {.magic: "Exit", 
+    importc: "process.exit", noreturn.}
+
 else:
   proc quit*(errorcode: int = QuitSuccess) {.
     magic: "Exit", importc: "exit", header: "<stdlib.h>", noreturn.}


### PR DESCRIPTION
Currently `quit(x)` emits `exit(x)` for node, which is incorrect. Emit process.exit instead