### PR TITLE
Improved unittest check macro, fixes #5784

### DIFF
--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -1,11 +1,22 @@
 discard """
-  nimout: "compile start\ncompile end"
+  output: '''[Suite] suite with only teardown
+
+[Suite] suite with only setup
+
+[Suite] suite with none
+
+[Suite] suite with both
+
+[Suite] bug #4494
+
+[Suite] bug #5571
+
+[Suite] bug #5784
+
+'''
 """
 
 import unittest, sequtils
-
-static:
-  echo "compile start"
 
 proc doThings(spuds: var int): int =
   spuds = 24
@@ -103,5 +114,9 @@ suite "bug #5571":
       check: line == "a"
     doTest()
 
-static:
-  echo "compile end"
+suite "bug #5784":
+  test "`or` should short circuit":
+    type Obj = ref object
+      field: int
+    var obj: Obj
+    check obj.isNil or obj.field == 0


### PR DESCRIPTION
- `check` no longer attempts to break out expressions from `or` & `and` to avoid messing up short circuiting (fixes #5784)
- checkpoints are generated for more expression types (e.g `foo.len == 3` and `foo[0] == 3` will now generate checkpoints)
- some general cleanup (prefer `let` over `var`, prefer returning a tuple over mutating outer variables, prefere `quote do` over `getAst(tmpl(...))`)

`check a.isNil or a.field == 3` is still not very useful, since it won't generate a checkpoint for `a.field`'s value. I don't think it's a good idea to attempt to generate checkpoints for that case, because it would make an already complex macro much more complex.

Perhaps there should be a different template/macro for running some checks iff an expression evaluates to true, and otherwise fail immediately.