### PR TITLE
Fix julian day of week (fixes #3612)

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1045,9 +1045,12 @@ proc countYearsAndDays*(daySpan: int): tuple[years: int, days: int] =
   result.years = days div 365
   result.days = days mod 365
 
-proc getDayOfWeek*(day, month, year: int): WeekDay =
+proc getDayOfWeek*(day: range[1..31], month: range[1..12], year: int): WeekDay =
   ## Returns the day of the week enum from day, month and year.
-  # Day & month start from one.
+
+  assert day <= getDaysInMonth((month - 1).Month, year),
+    "Invalid day of month for " & $(month - 1).Month & " " & $year
+
   let
     a = (14 - month) div 12
     y = year - a
@@ -1058,16 +1061,25 @@ proc getDayOfWeek*(day, month, year: int): WeekDay =
   if d == 0: return dSun
   result = (d-1).WeekDay
 
-proc getDayOfWeekJulian*(day, month, year: int): WeekDay =
+proc getDayOfWeekJulian*(day: range[1..31], month: range[1..12], year: int): WeekDay =
   ## Returns the day of the week enum from day, month and year,
   ## according to the Julian calendar.
-  # Day & month start from one.
-  let
-    a = (14 - month) div 12
-    y = year - a
-    m = month + (12*a) - 2
-    d = (5 + day + y + (y div 4) + (31*m) div 12) mod 7
-  result = d.WeekDay
+  # https://en.wikipedia.org/wiki/Zeller%27s_congruence
+
+  assert day <= getDaysInMonth((month - 1).Month, year),
+    "Invalid day of month for " & $(month - 1).Month & " " & $year
+
+  let (m, y) =
+    if month in { 1, 2 }:
+      # .int to strip range type
+      ((month + 12).int, year - 1)
+    else:
+      (month, year)
+
+  let k = y mod 100
+  let j = y div 100
+  let h = (day + (13 * (m + 1)) div 5 + k + k div 4 + 5 + 6 * j) mod 7
+  result = ((h + 5) mod 7).WeekDay
 
 proc timeToTimeInfo*(t: Time): TimeInfo {.deprecated.} =
   ## Converts a Time to TimeInfo.

--- a/tests/stdlib/ttime.nim
+++ b/tests/stdlib/ttime.nim
@@ -1,5 +1,6 @@
 # test the new time module
 discard """
+  action: "run"
   file: "ttime.nim"
 """
 
@@ -116,10 +117,11 @@ doAssert getDayOfWeek(21, 9, 1970) == dMon
 doAssert getDayOfWeek(1, 1, 2000) == dSat
 doAssert getDayOfWeek(1, 1, 2021) == dFri
 # Julian tests
-doAssert getDayOfWeekJulian(21, 9, 1900) == dFri
-doAssert getDayOfWeekJulian(21, 9, 1970) == dMon
-doAssert getDayOfWeekJulian(1, 1, 2000) == dSat
-doAssert getDayOfWeekJulian(1, 1, 2021) == dFri
+doAssert getDayOfWeekJulian(21, 9, 1900) == dThu
+doAssert getDayOfWeekJulian(21, 9, 1970) == dSun
+doAssert getDayOfWeekJulian(1, 1, 2000) == dFri
+doAssert getDayOfWeekJulian(1, 1, 2021) == dThu
+doAssert getDayOfWeekJulian(1, 3, 2100) == dMon
 
 # toSeconds tests with GM timezone
 let t4L = getGMTime(fromSeconds(876124714))

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -1,7 +1,7 @@
 # test the new time module
 discard """
   action: "run"
-  file: "ttime.nim"
+  file: "ttimes.nim"
 """
 
 import


### PR DESCRIPTION
It's possible I don't understand what the proc is supposed to do. I tested the dates in the test file with C# using  `(new DateTime(2100, 3, 1, new JulianCalendar())).DayOfWeek`, which did not give the same result as what the tests expected. The tests expected the same day of week as the tests for the Gregorian calendar, which seems strange.

I updated the tests (and made them run) to use the results from C# and replaced `getDayOfWeekJulian` with an implementation of https://en.wikipedia.org/wiki/Zeller%27s_congruence, which gives the same result as C#.