### PR TITLE
Fixes #6450

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -77,6 +77,8 @@ when defined(posix) and not defined(JS):
 
   when not defined(freebsd) and not defined(netbsd) and not defined(openbsd):
     var timezone {.importc, header: "<time.h>".}: int
+    proc tzset(): void {.importc, header: "<time.h>".}
+    tzset()
 
 elif defined(windows):
   import winlean


### PR DESCRIPTION
Seems like [tzset](http://man7.org/linux/man-pages/man3/tzset.3.html) must be called to initialize the timezone variable.