### PR TITLE
Implement `toTime` in nim

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1260,8 +1260,8 @@ when not defined(JS):
     result.inc timeInfo.hour * secondsInHour
     result.inc timeInfo.minute * 60
     result.inc timeInfo.second
-    # The code above treats `ti` as GM,
-    # so we need to compensate for that here
+    # The code above ignores the UTC offset of `timeInfo`,
+    # so we need to compensate for that here.
     result.inc timeInfo.timezone
     result.dec int(timeInfo.isDST) * secondsInHour
 

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1180,19 +1180,12 @@ when not defined(JS):
     TimeInfoPtr = ptr StructTM
     Clock {.importc: "clock_t".} = distinct int
 
-  when not defined(windows):
-    # This is not ANSI C, but common enough
-    proc timegm(t: StructTM): Time {.
-      importc: "timegm", header: "<time.h>", tags: [].}
-
   proc localtime(timer: ptr Time): TimeInfoPtr {.
     importc: "localtime", header: "<time.h>", tags: [].}
   proc gmtime(timer: ptr Time): TimeInfoPtr {.
     importc: "gmtime", header: "<time.h>", tags: [].}
   proc timec(timer: ptr Time): Time {.
     importc: "time", header: "<time.h>", tags: [].}
-  proc mktime(t: StructTM): Time {.
-    importc: "mktime", header: "<time.h>", tags: [].}
   proc getClock(): Clock {.importc: "clock", header: "<time.h>", tags: [TimeEffect].}
   proc difftime(a, b: Time): float {.importc: "difftime", header: "<time.h>",
     tags: [].}
@@ -1216,20 +1209,6 @@ when not defined(JS):
       isDST: tm.isdst > 0,
       timezone: if local: getTimezone() else: 0
     )
-
-
-  proc timeInfoToTM(t: TimeInfo): StructTM =
-    const
-      weekDays: array[WeekDay, int8] = [1'i8,2'i8,3'i8,4'i8,5'i8,6'i8,0'i8]
-    result.second = t.second
-    result.minute = t.minute
-    result.hour = t.hour
-    result.monthday = t.monthday
-    result.month = ord(t.month)
-    result.year = cint(t.year - 1900)
-    result.weekday = weekDays[t.weekday]
-    result.yearday = t.yearday
-    result.isdst = if t.isDST: 1 else: 0
 
   when not defined(useNimRtl):
     proc `-` (a, b: Time): int64 =

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -215,6 +215,20 @@ block formatDst:
   doAssert ti.format("zz") == "-04"
   doAssert ti.format("zzz") == "-04:00"
 
+block toTime:
+  proc initTimeInfo(monthday, month, year, hour, minute, second, timezone: int, isDst: bool): TimeInfo =
+    TimeInfo(monthday: monthday, month: (month - 1).Month, year: year,
+      hour: hour, minute: minute, second: second, timezone: timezone, isDst: isDST)
+
+  let stockholm = initTimeInfo(11, 10, 2017, 12, 30, 30, timezone = -3600, isDST = true)
+  doAssert stockholm.toTime == fromSeconds(1507717830)
+  let london = initTimeInfo(01, 06, 1975, 07, 30, 30, timezone = 0, isDST = true)
+  doAssert london.toTime == fromSeconds(170836230)
+  let utcStart = initTimeInfo(01, 01, 1970, 00, 00, 00, timezone = 0, isDST = false)
+  doAssert utcStart.toTime == fromSeconds(0)
+  let utcNegative = initTimeInfo(01, 01, 1950, 00, 00, 00, timezone = 0, isDST = false)
+  doAssert utcNegative.toTime == fromSeconds(-631152000)
+
 block dstTest:
   let nonDst = TimeInfo(year: 2015, month: mJan, monthday: 01, yearday: 0,
       weekday: dThu, hour: 00, minute: 00, second: 00, isDST: false, timezone: 0)
@@ -222,8 +236,7 @@ block dstTest:
   dst.isDst = true
   # note that both isDST == true and isDST == false are valid here because
   # DST is in effect on January 1st in some southern parts of Australia.
-  # FIXME: Fails in UTC
-  # doAssert nonDst.toTime() - dst.toTime() == 3600
+  doAssert nonDst.toTime() - dst.toTime() == 3600
   doAssert nonDst.format("z") == "+0"
   doAssert dst.format("z") == "+1"
 


### PR DESCRIPTION
This PR replaces the existing `toTime` implementation relying on `mktime` with an implementation in pure Nim. This solves the issue described in https://github.com/nim-lang/Nim/issues/4690#issuecomment-265059761. It does not however fix the tests failing for `TZ=Asia/Novosibirsk`, so #4690 should not be closed (or it could be moved to a new issue, it's a bit confusing that the three first examples in the issue all pass).

I'll add tests for this after #6468 gets merged, so don't merge this one yet.

Also fixes #6470.