### PR TITLE
Add missing nilChecks compiling option closes #6479

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -251,6 +251,7 @@ proc testCompileOption*(switch: string, info: TLineInfo): bool =
     result = gOptions * {optNaNCheck, optInfCheck} == {optNaNCheck, optInfCheck}
   of "infchecks": result = contains(gOptions, optInfCheck)
   of "nanchecks": result = contains(gOptions, optNaNCheck)
+  of "nilchecks": result = contains(gOptions, optNilCheck)
   of "objchecks": result = contains(gOptions, optObjCheck)
   of "fieldchecks": result = contains(gOptions, optFieldCheck)
   of "rangechecks": result = contains(gOptions, optRangeCheck)
@@ -473,6 +474,7 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     processOnOffSwitch({optNaNCheck, optInfCheck}, arg, pass, info)
   of "infchecks": processOnOffSwitch({optInfCheck}, arg, pass, info)
   of "nanchecks": processOnOffSwitch({optNaNCheck}, arg, pass, info)
+  of "nilchecks": processOnOffSwitch({optNilCheck}, arg, pass, info)
   of "objchecks": processOnOffSwitch({optObjCheck}, arg, pass, info)
   of "fieldchecks": processOnOffSwitch({optFieldCheck}, arg, pass, info)
   of "rangechecks": processOnOffSwitch({optRangeCheck}, arg, pass, info)

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -29,6 +29,7 @@ Options:
   --floatChecks:on|off      turn all floating point (NaN/Inf) checks on|off
   --nanChecks:on|off        turn NaN checks on|off
   --infChecks:on|off        turn Inf checks on|off
+  --nilChecks:on|off        turn nil checks on|off
   --deadCodeElim:on|off     whole program dead code elimination on|off
   --opt:none|speed|size     optimize not at all or for speed|size
                             Note: use -d:release for a release build!

--- a/tools/nim.zsh-completion
+++ b/tools/nim.zsh-completion
@@ -60,6 +60,8 @@ _nim() {
     '*--nanChecks=off[turn NaN checks off]' \
     '*--infChecks=on[turn Inf checks on]' \
     '*--infChecks=off[turn Inf checks off]' \
+    '*--nilChecks=on[turn nil checks on]' \
+    '*--nilChecks=off[turn nil checks off]' \
     '*--deadCodeElim=on[whole program dead code elimination on]' \
     '*--deadCodeElim=off[whole program dead code elimination off]' \
     '*--opt=none[do not optimize]' \


### PR DESCRIPTION
This adds the missing nilChecks option when compiling as mentioned in #6479

Question nil checks are on by default even in release mode, I didn't change nim cfg, but isn't supposed to be turned off there in release builds?