### PR TITLE
Add support for the blockdiag suite in docgen

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -80,6 +80,7 @@ template declareClosures =
     of mwUnknownSubstitution: k = warnUnknownSubstitutionX
     of mwUnsupportedLanguage: k = warnLanguageXNotSupported
     of mwUnsupportedField: k = warnFieldXNotSupported
+    of mwFailedRendering: k = warnUser
     globalError(conf, newLineInfo(conf, AbsoluteFile filename, line, col), k, arg)
 
   proc docgenFindFile(s: string): string {.procvar.} =

--- a/examples/blockdiag.nim
+++ b/examples/blockdiag.nim
@@ -1,0 +1,46 @@
+##
+## docgen - blockdiag adaptor examples
+##
+## Generate blockdiag.html using:
+##
+## .. code-block::
+##    nim doc examples/blockdiag.nim
+##
+## Example 1:
+##
+## .. code-block::
+##    .. code-block:: blockdiag
+##
+##       blockdiag {
+##         default_shape = roundedbox;
+##         "parse .nim file" -> "generate RST AST" -> "run blockdiag" -> "embed SVG output";
+##       }
+##
+## .. code-block:: blockdiag
+##
+##    blockdiag {
+##      default_shape = roundedbox;
+##      "parse .nim file" -> "generate RST AST" -> "run blockdiag" -> "embed SVG";
+##    }
+##
+## Example 2:
+##
+## .. code-block::
+##    .. code-block:: blockdiag
+##
+##       blockdiag {
+##         default_shape = roundedbox;
+##         client -> dispatcher -> worker1, workerDots, workerN;
+##         workerDots [shape = "dots"];
+##       }
+##
+##
+## .. code-block:: blockdiag
+##
+##    blockdiag {
+##      default_shape = roundedbox;
+##      client -> dispatcher -> worker1, workerDots, workerN;
+##      workerDots [shape = "dots"];
+##    }
+##
+##

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -40,7 +40,8 @@ type
     mwRedefinitionOfLabel,
     mwUnknownSubstitution,
     mwUnsupportedLanguage,
-    mwUnsupportedField
+    mwUnsupportedField,
+    mwFailedRendering
 
   MsgHandler* = proc (filename: string, line, col: int, msgKind: MsgKind,
                        arg: string) {.closure.} ## what to do in case of an error
@@ -57,7 +58,8 @@ const
     mwRedefinitionOfLabel: "redefinition of label '$1'",
     mwUnknownSubstitution: "unknown substitution '$1'",
     mwUnsupportedLanguage: "language '$1' not supported",
-    mwUnsupportedField: "field '$1' not supported"
+    mwUnsupportedField: "field '$1' not supported",
+    mwFailedRendering: "unable to render: $1"
   ]
 
 proc rstnodeToRefname*(n: PRstNode): string

--- a/lib/packages/docutils/rstgen_blockdiag.nim
+++ b/lib/packages/docutils/rstgen_blockdiag.nim
@@ -1,0 +1,42 @@
+#
+#        Nim's Runtime Library - blockdiag adaptor
+#        (c) Copyright 2017 Federico Ceratto
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+#
+## Blockdiag rstgen adaptor
+##
+## See examples/blockdiag.nim for an example.
+
+import math, os, osproc, random
+from rstast import PRstNode
+
+type
+  BlockDiagRenderOutput* = object
+    svg*, error*: string
+
+proc renderBlockDiag*(n: PRstNode): BlockDiagRenderOutput =
+  ## Render blockdiag diagram.
+  ## Requires the blockdiag toolset from http://blockdiag.com/en/
+  const
+    input_fn = ".rstgen_blockdiag.tmp"
+    out_fn = input_fn & ".svg"
+  let
+    diag_src = n.sons[n.sons.high].sons[0].text
+    cmd = "blockdiag " & input_fn & " --nodoctype -Tsvg -o " & out_fn
+
+  writeFile(input_fn, diag_src)
+  let (output, exit_code) = execCmdEx(cmd, options={poStdErrToStdOut})
+  removeFile input_fn
+
+  if exit_code == 0:
+    let svg = readFile out_fn
+    removeFile out_fn
+    return BlockDiagRenderOutput(error: "", svg: svg)
+
+  # Fall back by showing the error message and the diagram source
+  let svg = "Error rendering diagram: " & output & "\n" & diag_src
+  return BlockDiagRenderOutput(error: output, svg: svg)
+


### PR DESCRIPTION
If tools from http://blockdiag.com/en/ are installed, render
special ".. code-block:: blockdiag" blocks into SVG.
An example file is provided.

Output example: http://bl.ocks.org/FedericoCeratto/raw/79bb6e44d327d2b31d4442410b0a01df/