### PR TITLE
Update to list Distros module in the manual

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -64,12 +64,6 @@ Core
 * `cpuinfo <cpuinfo.html>`_
   This module implements procs to determine the number of CPUs / cores.
 
-* `distros <distros.html>`_
-  This module implements the basics for OS distribution ("distro") detection and the OS's native package manager.
-  Its primary purpose is to produce output for Nimble packages, but it also contains the widely used **Distribution** enum
-  that is useful for writing platform specific code. It is imported implicitly by the compiler.
-  Do not import it directly. It relies on compiler magic to work.
-
 Collections and algorithms
 --------------------------
 
@@ -186,6 +180,12 @@ Generic Operating System Services
 * `asyncfile <asyncfile.html>`_
   This module implements asynchronous file reading and writing using
   ``asyncdispatch``.
+
+* `distros <distros.html>`_
+  This module implements the basics for OS distribution ("distro") detection and the OS's native package manager.
+  Its primary purpose is to produce output for Nimble packages, but it also contains the widely used **Distribution** enum
+  that is useful for writing platform specific code.
+
 
 Math libraries
 --------------

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -64,6 +64,11 @@ Core
 * `cpuinfo <cpuinfo.html>`_
   This module implements procs to determine the number of CPUs / cores.
 
+* `distros <distros.html>`_
+  This module implements the basics for OS distribution ("distro") detection and the OS's native package manager.
+  Its primary purpose is to produce output for Nimble packages, but it also contains the widely used **Distribution** enum
+  that is useful for writing platform specific code. It is imported implicitly by the compiler.
+  Do not import it directly. It relies on compiler magic to work.
 
 Collections and algorithms
 --------------------------


### PR DESCRIPTION
Update to list Distros module in the manual

I was updating some nim packages that I needed for Mac compatibility, and it took me a long time to find the correct way to write platform specific #ifdef code. I figured it out by looking at other nim projects like the nim-glfw project.

I tracked down the ```macosx``` constant to the ```distros``` module, but I didn't find it easily listed in the docs anywhere.
This is my attempt to add the ```distros``` module to the main docs page to make it easier to find for other people.

I hope my description and placement of the module is correct.

Thanks,
Ray