### PR TITLE
No implicit quit for Genode

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1013,10 +1013,9 @@ proc genMainProc(m: BModule) =
     ComponentConstruct =
       "void Libc::Component::construct(Libc::Env &env) {$N" &
       "\tgenodeEnv = &env;$N" &
-      "\tLibc::with_libc([&] () {$n\t" &
+      "\tLibc::with_libc([&] () {$N\t" &
       MainProcs &
       "\t});$N" &
-      "\tenv.parent().exit(0);$N" &
       "}$N$N"
 
   var nimMain, otherMain: FormatStr

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -312,7 +312,7 @@ proc ensureInitialized() =
 
   if not testsToRun.isValid:
     testsToRun.init()
-    when declared(os):
+    when declared(paramCount):
       # Read tests to run from the command line.
       for i in 1 .. paramCount():
         testsToRun.incl(paramStr(i))

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1429,7 +1429,8 @@ when defined(nimdoc):
     ## <#GC_fullCollect>`_.
     ##
     ## The proc ``quit(QuitSuccess)`` is called implicitly when your nim
-    ## program finishes without incident. A raised unhandled exception is
+    ## program finishes without incident for platforms where this is the
+    ## expected behavior. A raised unhandled exception is
     ## equivalent to calling ``quit(QuitFailure)``.
     ##
     ## Note that this is a *runtime* call and using ``quit`` inside a macro won't


### PR DESCRIPTION
Genode components do not quit by default, they must persist after the main procedure to serve RPC requests. I would also like to define a Genode only effect in system.nim to mark procedures that invoke RPC as a client.

Finally, unittest uses paramCount not as indicated.