### PR TITLE
Let the environment variable NIMBLE_DIR overrides nimblepath in cfg file

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -343,7 +343,9 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     # keep the old name for compat
     if pass in {passCmd2, passPP} and not options.gNoNimblePath:
       expectArg(switch, arg, pass, info)
-      let path = processPath(arg, info, notRelativeToProj=true)
+      var path = processPath(arg, info, notRelativeToProj=true)
+      let nimbleDir = getEnv("NIMBLE_DIR")
+      if nimbleDir.len > 0 and pass == passPP: path = nimbleDir / "pkgs"
       nimblePath(path, info)
   of "nonimblepath", "nobabelpath":
     expectNoArg(switch, arg, pass, info)

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -324,9 +324,10 @@ type PackageFilter = enum
   pfExtraOnly
   pfAll
 
+var nimbleDir = getEnv("NIMBLE_DIR")
+if nimbleDir.len == 0: nimbleDir = getHomeDir() / ".nimble"
 let
   nimbleExe = findExe("nimble")
-  nimbleDir = getHomeDir() / ".nimble"
   packageDir = nimbleDir / "pkgs"
   packageIndex = nimbleDir / "packages.json"
 

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -324,7 +324,7 @@ type PackageFilter = enum
   pfExtraOnly
   pfAll
 
-var nimbleDir = getEnv("NIMBLE_DIR")
+var nimbleDir = getEnv("NIMBLE_DIR").string
 if nimbleDir.len == 0: nimbleDir = getHomeDir() / ".nimble"
 let
   nimbleExe = findExe("nimble")

--- a/tools/nimresolve.nim
+++ b/tools/nimresolve.nim
@@ -127,7 +127,9 @@ proc resolve(t: Task) =
 
     when considerNimbleDirs:
       if not t.noNimblePath:
-        if findInNimbleDir(t, getHomeDir() / ".nimble" / "pkgs"): return
+        var nimbleDir = getEnv("NIMBLE_DIR")
+        if nimbleDir.len == 0: nimbleDir = getHomeDir() / ".nimble"
+        if findInNimbleDir(t, nimbleDir / "pkgs"): return
         when not defined(windows):
           if findInNimbleDir(t, "/opt/nimble/pkgs"): return
 


### PR DESCRIPTION
If the length of ``NIMBLE_DIR`` is larger than zero, the nimblepath
will be set to ``$NIMBLE_DIR/pkgs``, only when ``passPP``.
See nim-lang/nimble#340