### PR TITLE
Implementation of high/low for SomeReal

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2072,6 +2072,9 @@ proc max*[T](x, y: T): T =
   if y <= x: x else: y
 {.pop.}
 
+proc high(T: typedesc[SomeReal]): T = Inf
+proc low(T: typedesc[SomeReal]): T = NegInf
+
 proc clamp*[T](x, a, b: T): T =
   ## limits the value ``x`` within the interval [a, b]
   ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2072,8 +2072,8 @@ proc max*[T](x, y: T): T =
   if y <= x: x else: y
 {.pop.}
 
-proc high(T: typedesc[SomeReal]): T = Inf
-proc low(T: typedesc[SomeReal]): T = NegInf
+proc high*(T: typedesc[SomeReal]): T = Inf
+proc low*(T: typedesc[SomeReal]): T = NegInf
 
 proc clamp*[T](x, a, b: T): T =
   ## limits the value ``x`` within the interval [a, b]

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -1,0 +1,18 @@
+discard """
+  output:""
+"""
+
+# check high/low implementations
+doAssert high(int) > low(int)
+doAssert high(int8) > low(int8)
+doAssert high(int16) > low(int16)
+doAssert high(int32) > low(int32)
+doAssert high(int64) > low(int64)
+# doAssert high(uint) > low(uint) # FIXME doesn't work
+doAssert high(uint8) > low(uint8)
+doAssert high(uint16) > low(uint16)
+doAssert high(uint32) > low(uint32)
+# doAssert high(uint64) > low(uint64) # FIXME doesn't work
+doAssert high(float) > low(float)
+doAssert high(float32) > low(float32)
+doAssert high(float64) > low(float64)

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -8,11 +8,11 @@ doAssert high(int8) > low(int8)
 doAssert high(int16) > low(int16)
 doAssert high(int32) > low(int32)
 doAssert high(int64) > low(int64)
-# doAssert high(uint) > low(uint) # FIXME doesn't work
+# doAssert high(uint) > low(uint) # reconsider depending on issue #6620
 doAssert high(uint8) > low(uint8)
 doAssert high(uint16) > low(uint16)
 doAssert high(uint32) > low(uint32)
-# doAssert high(uint64) > low(uint64) # FIXME doesn't work
+# doAssert high(uint64) > low(uint64) # reconsider depending on issue #6620
 doAssert high(float) > low(float)
 doAssert high(float32) > low(float32)
 doAssert high(float64) > low(float64)


### PR DESCRIPTION
For generic functions which operate on both integers or floats it would be nice to have a definition of `high` and `low` for floats as well. This would make the [Q/A I've posted on StackOverflow today](https://stackoverflow.com/q/46875488/1804173) even more simple.

Note: The procs cannot be moved easily at the top where the other `high`/`low` procs are defined, because it depends on `Inf` and `NegInf`, which in turn depends on the definition of `/` => too much re-ordering required.