### PR TITLE
Fix #6553

### DIFF
--- a/lib/posix/linux.nim
+++ b/lib/posix/linux.nim
@@ -26,3 +26,5 @@ const
 proc clone*(fn: pointer; child_stack: pointer; flags: cint;
             arg: pointer; ptid: ptr Pid; tls: pointer;
             ctid: ptr Pid): cint {.importc, header: "<sched.h>".}
+
+proc pipe2*(a: array[0..1, cint], flags: cint): cint {.importc, header: "<unistd.h>".}

--- a/lib/posix/posix_other_consts.nim
+++ b/lib/posix/posix_other_consts.nim
@@ -119,6 +119,7 @@ var O_TRUNC* {.importc: "O_TRUNC", header: "<fcntl.h>".}: cint
 var O_APPEND* {.importc: "O_APPEND", header: "<fcntl.h>".}: cint
 var O_DSYNC* {.importc: "O_DSYNC", header: "<fcntl.h>".}: cint
 var O_NONBLOCK* {.importc: "O_NONBLOCK", header: "<fcntl.h>".}: cint
+var O_DIRECT* {.importc: "O_DIRECT", header: "<fcntl.h>".}: cint
 var O_RSYNC* {.importc: "O_RSYNC", header: "<fcntl.h>".}: cint
 var O_SYNC* {.importc: "O_SYNC", header: "<fcntl.h>".}: cint
 var O_ACCMODE* {.importc: "O_ACCMODE", header: "<fcntl.h>".}: cint

--- a/lib/posix/posix_other_consts.nim
+++ b/lib/posix/posix_other_consts.nim
@@ -119,7 +119,6 @@ var O_TRUNC* {.importc: "O_TRUNC", header: "<fcntl.h>".}: cint
 var O_APPEND* {.importc: "O_APPEND", header: "<fcntl.h>".}: cint
 var O_DSYNC* {.importc: "O_DSYNC", header: "<fcntl.h>".}: cint
 var O_NONBLOCK* {.importc: "O_NONBLOCK", header: "<fcntl.h>".}: cint
-var O_DIRECT* {.importc: "O_DIRECT", header: "<fcntl.h>".}: cint
 var O_RSYNC* {.importc: "O_RSYNC", header: "<fcntl.h>".}: cint
 var O_SYNC* {.importc: "O_SYNC", header: "<fcntl.h>".}: cint
 var O_ACCMODE* {.importc: "O_ACCMODE", header: "<fcntl.h>".}: cint


### PR DESCRIPTION
This adds the pipe2() function.

I also tried adding the O_DIRECT flag but I couldn't get detect.nim to pick it up (I added v("O_DIRECT") to it.

In addition it is only supported after Kernel 3.4 and I don't know whether it is wanted for the standard lib to require a specific kernel version. If I should add this flag tell me and I will figure out how to get detect.nim to behave.