### PR TITLE
strutils.find enhancements

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1412,7 +1412,6 @@ proc find*(s, sub: string, start: Natural = 0, last: Natural = 0): int {.noSideE
     return find(s, sub[0], start, last)
     
   var a {.noinit.}: SkipTable
-  let last = if last==0: s.high else: last
   initSkipTable(a, sub)
   result = find(a, s, sub, start, last)
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1332,7 +1332,7 @@ proc join*[T: not string](a: openArray[T], sep: string = ""): string {.
 type
   SkipTable* = array[char, int]
 
-proc initSkipTable(a: var SkipTable, sub: string)
+proc initSkipTable*(a: var SkipTable, sub: string)
   {.noSideEffect, rtl, extern: "nsuInitSkipTable".} =
   ## Preprocess table `a` for `sub`.
   let m = len(sub)
@@ -1359,6 +1359,7 @@ proc find*(a: SkipTable, s, sub: string, start: Natural = 0, last: Natural = 0):
   ##
   ## Searching is case-sensitive. If `sub` is not in `s`, -1 is returned.
   let
+    last = if last==0: s.high else: last
     m = len(sub)
     n = last + 1
   # search:


### PR DESCRIPTION
The find function with a precalculated table is useful for repeating the substring search.

Some benchmarks on my PC (ArchLinux x64, gcc 7.2):

Call | Current implementation | With this PR
------------ | -------------|----------
find("1234567890abcdef", "abc") | 19915.0 | 12176.0
find("1234567890abcdef", "a") | 15121.0 | 675.0
find("abc", "1234567890abcdef") | 9987.9 | 325.0