### PR TITLE
fixes #6589

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1929,7 +1929,7 @@ proc formatBiggestFloat*(f: BiggestFloat, format: FloatFormatMode = ffDefault,
       # but nothing else is possible:
       if buf[i] in {'.', ','}: result[i] = decimalsep
       else: result[i] = buf[i]
-    when defined(windows):
+    when defined(vcc):
       # VS pre 2015 violates the C standard: "The exponent always contains at
       # least two digits, and only as many more digits as necessary to
       # represent the exponent." [C11 §7.21.6.1]

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2373,6 +2373,7 @@ when isMainModule:
   doAssert formatBiggestFloat(0.00000000001, ffDecimal, 11) == "0.00000000001"
   doAssert formatBiggestFloat(0.00000000001, ffScientific, 1, ',') in
                                                    ["1,0e-11", "1,0e-011"]
+  # bug #6589
   doAssert formatFloat(123.456, ffScientific, precision=0) == "1.234560e+02"
 
   doAssert "$# $3 $# $#" % ["a", "b", "c"] == "a c b c"


### PR DESCRIPTION
Note: The [solutions suggested on StackOverflow](https://stackoverflow.com/a/31332367/1804173) (using `_set_output_format`) are probably not a good idea, because the function is obsolete and has been removed in the latest Visual Studio Compile. Thus, the simple post-processing should be the easiest fix.