### PR TITLE
Koch find nim

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -293,7 +293,7 @@ proc genAssignment(p: BProc, dest, src: TLoc, flags: TAssignmentFlags) =
       linefmt(p, cpsStmts, "#genericSeqAssign($1, $2, $3);$n",
               addrLoc(dest), rdLoc(src), genTypeInfo(p.module, dest.t))
   of tyString:
-    if (needToCopy notin flags and src.storage != OnStatic) or canMove(src.lode):
+    if canMove(src.lode):
       genRefAssign(p, dest, src, flags)
     else:
       if dest.storage == OnStack or not usesNativeGC():

--- a/koch.nim
+++ b/koch.nim
@@ -472,7 +472,8 @@ proc temp(args: string) =
   # 125 is the magic number to tell git bisect to skip the current
   # commit.
   let (bootArgs, programArgs) = splitArgs(args)
-  exec("nim c " & bootArgs & " compiler" / "nim", 125)
+  let nimexec = findNim()
+  exec(nimexec & " c " & bootArgs & " compiler" / "nim", 125)
   copyExe(output, finalDest)
   if programArgs.len > 0: exec(finalDest & " " & programArgs)
 


### PR DESCRIPTION
While trying to fix another bug the 'koch temp' command failed to build the freshly checkedout devel branch because my installed nim didn't know a procedure used in the development standard lib. This enables 'koch temp' to use a version of nim generated by 'koch boot'