### PR TITLE
Use findNim() in koch temp()

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -472,7 +472,8 @@ proc temp(args: string) =
   # 125 is the magic number to tell git bisect to skip the current
   # commit.
   let (bootArgs, programArgs) = splitArgs(args)
-  exec("nim c " & bootArgs & " compiler" / "nim", 125)
+  let nimexec = findNim()
+  exec(nimexec & " c " & bootArgs & " compiler" / "nim", 125)
   copyExe(output, finalDest)
   if programArgs.len > 0: exec(finalDest & " " & programArgs)
 


### PR DESCRIPTION
While trying to fix another bug the 'koch temp' command failed to build the freshly checkedout devel branch because my installed nim didn't know a procedure used in the development standard lib. This enables 'koch temp' to use a version of nim generated by 'koch boot'