### PR TITLE
Allow parsing URIs without authority

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -135,9 +135,8 @@ proc parseUri*(uri: string, result: var Uri) =
     i.inc(2) # Skip //
     var authority = ""
     i.inc parseUntil(uri, authority, {'/', '?', '#'}, i)
-    if authority == "":
-      raise newException(ValueError, "Expected authority got nothing.")
-    parseAuthority(authority, result)
+    if authority.len > 0:
+      parseAuthority(authority, result)
   else:
     result.opaque = true
 
@@ -412,6 +411,15 @@ when isMainModule:
     doAssert test.hostname == "github.com"
     doAssert test.port == "dom96"
     doAssert test.path == "/packages"
+    
+  block:
+    let str = "file:///foo/bar/baz.txt"
+    let test = parseUri(str)
+    doAssert test.scheme == "file"
+    doAssert test.username == ""
+    doAssert test.hostname == ""
+    doAssert test.port == ""
+    doAssert test.path == "/foo/bar/baz.txt"
 
   # Remove dot segments tests
   block:


### PR DESCRIPTION
Allows parsing of URIs without authority.

For example, `file:///foo/bar/baz.txt`.