### PR TITLE
Clean up compiler warning

### DIFF
--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -382,9 +382,9 @@ proc dfa(code: seq[Instr]) =
       else:
         pc2 = pc + 1
         if code[pc].kind == fork:
-          let l = pc + code[pc].dest
-          if sid >= 0 and s[l].missingOrExcl(sid):
-            w.add l
+          let pc3 = pc + code[pc].dest
+          if sid >= 0 and s[pc3].missingOrExcl(sid):
+            w.add pc3 
 
       if sid >= 0 and s[pc2].missingOrExcl(sid):
         pc = pc2


### PR DESCRIPTION
This avoids the compiler warning about using 'l' as an identifier.