### PR TITLE
Decouple futures completion from dispatchers

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -44,7 +44,7 @@ proc callSoon*(cbproc: CallbackFunc) =
   ## is called recursively. In such case `cbproc` will be called
   ## as soon as currently handled `cbproc` is complete.
   if pendingCallbacks.isNil:
-      pendingCallbacks = newSeqOfCap[CallbackFunc](8)
+    pendingCallbacks = newSeqOfCap[CallbackFunc](8)
   pendingCallbacks.add(cbproc)
 
   # Every callback is added to pendingCallbacks, but in order to avoid recursion

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -46,6 +46,17 @@ proc callSoon*(cbproc: CallbackFunc) =
   if pendingCallbacks.isNil:
       pendingCallbacks = newSeqOfCap[CallbackFunc](8)
   pendingCallbacks.add(cbproc)
+
+  # Every callback is added to pendingCallbacks, but in order to avoid recursion
+  # (some callback may result in a call to callSoon again) we start processing
+  # pendingCallbacks only upon the first addition, while still allowing for new
+  # callbacks to be appended to pendingCallbacks due to recursive reentrancy.
+
+  # More to think about. pendingCallbacks may grow as long as how many calls to
+  # callSoon are made during a single future completion cascade. That is unlikely
+  # to cause problems, but could be fixed by shrinking pendingCallbacks upon
+  # reaching some threshold.
+
   if pendingCallbacks.len == 1:
     var i = 0
     while i < pendingCallbacks.len:


### PR DESCRIPTION
This sudden idea is pretty trivial. This PR restores old future completion behavior that doesn't rely on selectors, and fixes the recursion problem differently. `callSoon` is now reentrant and launches callback processing only for the first callback. The benefits are that futures are now self sufficient and don't need a completion proc to complete properly. This also simplifies the implementation of selectors as they now don't need to care about pending futures. I will clean up the selectors code in this regards as soon as this (and probably upcoming) is merged. Please review.
@Araq, @dom96, @zielmicha, @cheatfate.