### PR TITLE
Fix getNewLocation path generation. Closes #6649

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -581,7 +581,10 @@ proc getNewLocation(lastURL: string, headers: HttpHeaders): string =
   let r = parseUri(result)
   if r.hostname == "" and r.path != "":
     var parsed = parseUri(lastURL)
-    parsed.path = r.path
+    if r.path.startswith('/'):
+      parsed.path = r.path
+    else:
+      parsed.path = "/" & r.path
     parsed.query = r.query
     parsed.anchor = r.anchor
     result = $parsed


### PR DESCRIPTION
This ensures <Uri>.path starts with a slash.
Related to #6652