### PR TITLE
Fix path for sh on Android

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -98,7 +98,6 @@ path="$lib/pure"
     clang.options.linker = "-landroid-glob"
     clang.cpp.options.linker = "-landroid-glob"
     tcc.options.linker = "-landroid-glob"
-    define:"useShPath:/system/bin/sh"
   @end
 @end
 

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -767,7 +767,9 @@ elif not defined(useNimRtl):
     var sysCommand: string
     var sysArgsRaw: seq[string]
     if poEvalCommand in options:
-      const useShPath {.strdefine.} = "/bin/sh"
+      const useShPath {.strdefine.} =
+        when not defined(android): "/bin/sh"
+        else: "/system/bin/sh"
       sysCommand = useShPath
       sysArgsRaw = @[sysCommand, "-c", command]
       assert args.len == 0, "`args` has to be empty when using poEvalCommand."


### PR DESCRIPTION
`system/bin/sh` is the correct path for `sh` on Android regardless of termux.