### PR TITLE
Fixed crash in case of error in SSLShutdown

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -857,13 +857,16 @@ proc close*(socket: Socket) =
         # shutdown i.e not wait for the peers "close notify" alert with a second
         # call to SSLShutdown
         let res = SSLShutdown(socket.sslHandle)
-        SSLFree(socket.sslHandle)
-        socket.sslHandle = nil
         if res == 0:
           discard
         elif res != 1:
           socketError(socket, res)
   finally:
+    when defineSsl:
+      if socket.isSSL and socket.sslHandle != nil:
+        SSLFree(socket.sslHandle)
+        socket.sslHandle = nil
+
     socket.fd.close()
 
 proc toCInt*(opt: SOBool): cint =


### PR DESCRIPTION
If `SSLShutdown` returns an error, we're freeing `sslHandle`, and calling `socketError` which tries to use the nil handle and crashes.