### PR TITLE
Always compile tests in the JS category with the JS backend

### DIFF
--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -418,8 +418,9 @@ proc `&?.`(a, b: string): string =
 
 proc processSingleTest(r: var TResults, cat: Category, options, test: string) =
   let test = "tests" & DirSep &.? cat.string / test
+  let target = if cat.string.normalize == "js": targetJS else: targetC
 
-  if existsFile(test): testSpec r, makeTest(test, options, cat)
+  if existsFile(test): testSpec r, makeTest(test, options, cat, target = target)
   else: echo "[Warning] - ", test, " test does not exist"
 
 proc processCategory(r: var TResults, cat: Category, options: string) =


### PR DESCRIPTION
With this change it's possible to run a single JS test file instead of always running the entire category. 