### PR TITLE
Fix for #6685

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -716,7 +716,7 @@ proc generateHeaders(requestUrl: Uri, httpMethod: string,
   result = httpMethod.toUpper()
   result.add ' '
 
-  if proxy.isNil:
+  if proxy.isNil or (not proxy.isNil and requestUrl.scheme == "https"):
     # /path?query
     if requestUrl.path[0] != '/': result.add '/'
     result.add(requestUrl.path)
@@ -1048,7 +1048,11 @@ proc newConnection(client: HttpClient | AsyncHttpClient,
       client.currentURL.scheme != url.scheme or
       client.currentURL.port != url.port or
       (not client.connected):
-    let isSsl = url.scheme.toLowerAscii() == "https"
+    # Connect to proxy if specified
+    let connectionUrl =
+      if client.proxy.isNil: url else: client.proxy.url
+
+    let isSsl = connectionUrl.scheme.toLowerAscii() == "https"
 
     if isSsl and not defined(ssl):
       raise newException(HttpRequestError,
@@ -1056,31 +1060,51 @@ proc newConnection(client: HttpClient | AsyncHttpClient,
 
     if client.connected:
       client.close()
+      client.connected = false
 
     # TODO: I should be able to write 'net.Port' here...
     let port =
-      if url.port == "":
+      if connectionUrl.port == "":
         if isSsl:
           nativesockets.Port(443)
         else:
           nativesockets.Port(80)
-      else: nativesockets.Port(url.port.parseInt)
+      else: nativesockets.Port(connectionUrl.port.parseInt)
 
     when client is HttpClient:
-      client.socket = await net.dial(url.hostname, port)
+      client.socket = await net.dial(connectionUrl.hostname, port)
     elif client is AsyncHttpClient:
-      client.socket = await asyncnet.dial(url.hostname, port)
+      client.socket = await asyncnet.dial(connectionUrl.hostname, port)
     else: {.fatal: "Unsupported client type".}
 
     when defined(ssl):
       if isSsl:
         try:
           client.sslContext.wrapConnectedSocket(
-            client.socket, handshakeAsClient, url.hostname)
+            client.socket, handshakeAsClient, connectionUrl.hostname)
         except:
           client.socket.close()
           raise getCurrentException()
 
+    # If need to CONNECT through proxy
+    if url.scheme == "https" and not client.proxy.isNil:
+      # Pass only host:port for CONNECT
+      var connectUrl = initUri()
+      connectUrl.hostname = url.hostname
+      connectUrl.port = if url.port != "": url.port else: "443"
+
+      let proxyHeaderString = generateHeaders(connectUrl, $HttpConnect, newHttpHeaders(), "", client.proxy)
+      await client.socket.send(proxyHeaderString)
+      let proxyResp = await parseResponse(client, false)
+
+      if not proxyResp.status.startsWith("200"):
+        raise newException(HttpRequestError,
+                           "The proxy server rejected a CONNECT request, " &
+                           "so a secure connection could not be established.")
+      client.sslContext.wrapConnectedSocket(
+        client.socket, handshakeAsClient, url.hostname)
+
+    # May be connected through proxy but remember actual URL being accessed
     client.currentURL = url
     client.connected = true
 
@@ -1100,32 +1124,9 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: string,
                 headers: HttpHeaders = nil): Future[Response | AsyncResponse]
                 {.multisync.} =
   # Helper that actually makes the request. Does not handle redirects.
-  let connectionUrl =
-    if client.proxy.isNil: parseUri(url) else: client.proxy.url
   let requestUrl = parseUri(url)
 
-  let savedProxy = client.proxy # client's proxy may be overwritten.
-
-  if requestUrl.scheme == "https" and not client.proxy.isNil:
-    when defined(ssl):
-      client.proxy.url = connectionUrl
-      var connectUrl = requestUrl
-      connectUrl.scheme = "http"
-      connectUrl.port = "443"
-      let proxyResp = await requestAux(client, $connectUrl, $HttpConnect)
-
-      if not proxyResp.status.startsWith("200"):
-        raise newException(HttpRequestError,
-                           "The proxy server rejected a CONNECT request, " &
-                           "so a secure connection could not be established.")
-      client.sslContext.wrapConnectedSocket(
-        client.socket, handshakeAsClient, requestUrl.hostname)
-      client.proxy = nil
-    else:
-      raise newException(HttpRequestError,
-          "SSL support not available. Cannot connect to https site over proxy.")
-  else:
-    await newConnection(client, connectionUrl)
+  await newConnection(client, requestUrl)
 
   let effectiveHeaders = client.headers.override(headers)
 
@@ -1142,9 +1143,6 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: string,
   let getBody = httpMethod.toLowerAscii() notin ["head", "connect"] and
                 client.getBody
   result = await parseResponse(client, getBody)
-
-  # Restore the clients proxy in case it was overwritten.
-  client.proxy = savedProxy
 
 proc request*(client: HttpClient | AsyncHttpClient, url: string,
               httpMethod: string, body = "",


### PR DESCRIPTION
This version fixes proxy support for SSL connections by moving all proxy interactions into the ```newConnection()``` proc instead of in ```requestAux()```.

Tested both HTTP and HTTPS sites directly and thru proxy to verify nothing broke. Ran against hundreds of sites using the following test code. Compile and run with a starter URL which program will search for URLs. 

```> nim c -r -d:ssl --threads:on test.nim http://reddit.com```

```nim
import htmlparser, httpclient, ospaths, os, re, streams, strtabs, strutils, threadpool, xmltree

proc getU(url: string): string =
    try:
        let proxystr = getenv("http_proxy")
        let proxy = if proxystr != "": newProxy(proxystr) else: nil
        let cl = newHttpClient(proxy=proxy)
        result = cl.getContent(url)
        echo "PASS: " & url
    except:
        result = ""
        echo getCurrentExceptionMsg() & ": " & url

var visited: seq[string] = @[]
let base = getU(paramStr(1))
let html = parseHtml(newStringStream(base))
for a in html.findAll("a"):
    if a.attrs.hasKey("href"):
        let href = a.attrs["href"]
        if href != "" and href.startswith("http") and not visited.contains(href):
            visited.add(href)
            discard spawn getU(href)
sync()
echo visited.len()
```