### PR TITLE
Fix definition of nimLoadProcs when using cpp backend

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1132,7 +1132,7 @@ proc genInitCode(m: BModule) =
 
   for i, el in pairs(m.extensionLoaders):
     if el != nil:
-      let ex = "N_NIMCALL(void, nimLoadProcs$1)(void) {$2}$N$N" %
+      let ex = "NIM_EXTERNC N_NIMCALL(void, nimLoadProcs$1)(void) {$2}$N$N" %
         [(i.ord - '0'.ord).rope, el]
       add(m.s[cfsInitProc], ex)
 


### PR DESCRIPTION
This fixes linker error when building [glut_example.nim](https://github.com/nim-lang/opengl/blob/master/examples/glut_example.nim) with cpp backend (using `dynlib` mechanism).  Definition of `nimLoadProcs0` requires C linkage since declaraction of [`nimLoadProcs0`](https://github.com/nim-lang/opengl/blob/e1283c7800b00372ee0e218a42212370adc37593/src/opengl/private/prelude.nim#L83) uses `{.importc.}`