### PR TITLE
Tests should not rely on external services

### DIFF
--- a/tests/async/tasyncsend4757.nim
+++ b/tests/async/tasyncsend4757.nim
@@ -3,11 +3,22 @@ discard """
   output: "Finished"
 """
 
-import asyncdispatch
+import asyncdispatch, asyncnet
+
+proc createServer(port: Port) {.async.} =
+  var server = newAsyncSocket()
+  server.setSockOpt(OptReuseAddr, true)
+  bindAddr(server, port)
+  server.listen()
+  while true:
+    let client = await server.accept()
+    discard await client.recvLine()
+
+asyncCheck createServer(10335.Port)
 
 proc f(): Future[void] {.async.} =
   let s = newAsyncNativeSocket()
-  await s.connect("example.com", 80.Port)
+  await s.connect("localhost", 10335.Port)
   await s.send("123")
   echo "Finished"
 


### PR DESCRIPTION
This test depends on example.com site to be reachable, and fails when
there is no internet connection.