### PR TITLE
Fix missing stacktraces when using -d:useNimRtl

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -374,7 +374,7 @@ when defined(endb):
   var
     dbgAborting: bool # whether the debugger wants to abort
 
-when not defined(noSignalHandler):
+when not defined(noSignalHandler) and not defined(useNimRtl):
   proc signalHandler(sign: cint) {.exportc: "signalHandler", noconv.} =
     template processSignal(s, action: untyped) {.dirty.} =
       if s == SIGINT: action("SIGINT: Interrupted by Ctrl-C.\n")


### PR DESCRIPTION
When using `-d:useNimRtl`, stack traces are useless ("No stack traceback available").
This can be verified when compiling this example program in addition to `libnimrtl.so`:
```nim
template fuzzy(x) =
  echo x[] != 9

var p: ptr int
fuzzy p       # will segfault on purpose, however "no stack traceback is available"
```
Compile with `nim c -d:useNimRtl test_segfault.nim`  and `nim c -o:libnimrtl.so nim-repo/lib/nimrtl.nim`.
Start (on linux) with `LD_LIBRARY_PATH=/path/to/libnimrtl.so  ./test_segfault`

This happens because two instances of `framePtr` exist at the same time: one from `libnimrtl.so`, and one from the test program (I ended up seeing this when `printf`ing my way around and checking the generated c files). There is also two `signalHandler` present, the one from test_segfault is the one that runs last, apparently.


The right `framePtr` from `libnimrtl.so` is updated correctly by `nimFrame` and other functions, however when for example a segfault happens, the signalHandler from the test program runs, which refer to a nil `framePtr`.
That `framePtr` doesn't contain any information on frames, thus why no stack traceback were available.

---
This change ensure that there is only one signalHander that will be registered, the one from `libnimrtl.so`, this should also avoid pulling a second nil `framePtr` by the test program.
The stack traces should now be available and shown when using `useNimRtl`.