### PR TITLE
Better hashing

### DIFF
--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -1,7 +1,7 @@
 #
 #
 #            Nim's Runtime Library
-#        (c) Copyright 2012 Andreas Rumpf
+#        (c) Copyright 2012 Andreas Rumpf, Dmitry Atamanov
 #
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
@@ -47,40 +47,217 @@ type
                ## operator instead of ``mod`` for truncation of the hash value.
 {.deprecated: [THash: Hash].}
 
-proc `!&`*(h: Hash, val: int): Hash {.inline.} =
+proc `!&`*(h: Hash, val: int): Hash {.inline, noSideEffect.} =
   ## mixes a hash value `h` with `val` to produce a new hash value. This is
   ## only needed if you need to implement a hash proc for a new datatype.
   result = h +% val
   result = result +% result shl 10
   result = result xor (result shr 6)
 
-proc `!$`*(h: Hash): Hash {.inline.} =
+proc `!$`*(h: Hash): Hash {.inline, noSideEffect.} =
   ## finishes the computation of the hash value. This is
   ## only needed if you need to implement a hash proc for a new datatype.
   result = h +% h shl 3
   result = result xor (result shr 11)
   result = result +% result shl 15
 
-proc hashData*(data: pointer, size: int): Hash =
-  ## hashes an array of bytes of size `size`
-  var h: Hash = 0
-  when defined(js):
-    var p: cstring
-    asm """`p` = `Data`;"""
-  else:
-    var p = cast[cstring](data)
-  var i = 0
-  var s = size
-  while s > 0:
-    h = h !& ord(p[i])
-    inc(i)
-    dec(s)
-  result = !$h
+template read_u8(p: ByteAddress): untyped =
+  (cast[ptr uint8](p)[])
+
+template read_u16(p: ByteAddress): untyped =
+  (cast[ptr uint16](p)[])
+
+template read_u32(p: ByteAddress): untyped =
+  (cast[ptr uint32](p)[])
+
+template read_u64(p: ByteAddress): untyped =
+  (cast[ptr uint64](p)[])
+
+template rotate_right(value: uint32; amount: uint): uint32 =
+  ((value shr amount) or (value shl (32 - amount)))
+
+template rotate_right(value: uint64; amount: uint): uint64 =
+  ((value shr amount) or (value shl (64 - amount)))
+
+template `^=`(x: var uint32, y: uint32): untyped =
+  x = x xor y
+
+template `^=`(x: var uint64, y: uint64): untyped =
+  x = x xor y
+
+when sizeof(Hash) > 4:
+  # This is a Nim port of C++ implementation the MetroHash
+  # https://github.com/jandrewrogers/MetroHash
+  # Copyright (c) 2015 J. Andrew Rogers
+  proc hashData*(data: pointer, size: int, seed: Hash = 0): Hash {.noSideEffect.} =
+    ## hashes an array of bytes of size `size`
+    const 
+      k0 = 0xD6D018F5'u64
+      k1 = 0xA2AA033B'u64
+      k2 = 0x62992FC1'u64
+      k3 = 0x30BC5B29'u64
+
+    var 
+      p = cast[ByteAddress](data)
+      e = p + size
+      hash: uint64 = (seed.uint64 + k2) * k0
+
+    if size >= 32:
+      var
+        v0 = hash
+        v1 = hash
+        v2 = hash
+        v3 = hash
+
+      while p < (e - 32):
+        v0 += read_u64(p) * k0
+        v0 = rotate_right(v0, 29) + v2
+        p += 8
+
+        v1 += read_u64(p) * k1
+        v1 = rotate_right(v1, 29) + v3
+        p += 8
+
+        v2 += read_u64(p) * k2
+        v2 = rotate_right(v2, 29) + v0
+        p += 8
+
+        v3 += read_u64(p) * k3
+        p += 8
+        v3 = rotate_right(v3, 29) + v1
+
+      v2 ^= rotate_right(((v0 + v3) * k0) + v1, 37) * k1
+      v3 ^= rotate_right(((v1 + v2) * k1) + v0, 37) * k0
+      v0 ^= rotate_right(((v0 + v2) * k0) + v3, 37) * k1
+      v1 ^= rotate_right(((v1 + v3) * k1) + v2, 37) * k0
+      hash += (v0 xor v1)
+
+    if (e - p) >= 16:
+      var
+        v0: uint64
+        v1: uint64
+
+      v0 = hash + read_u64(p) * k2
+      v0 = rotate_right(v0, 29) * k3
+      p += 8
+
+      v1 = hash + read_u64(p) * k2
+      v1 = rotate_right(v1, 29) * k3
+      p += 8
+
+      v0 ^= rotate_right(v0 * k0, 21) + v1
+      v1 ^= rotate_right(v1 * k3, 21) + v0
+      hash += v1
+
+    if (e - p) >= 8:
+      hash += read_u64(p) * k3
+      hash ^= rotate_right(hash, 55) * k1
+      p += 8
+
+    if (e - p) >= 4:
+      hash += cast[uint64](read_u32(p)) * k3
+      hash ^= rotate_right(hash, 26) * k1
+      p += 4
+
+    if (e - p) >= 2:
+      hash += cast[uint64](read_u16(p)) * k3
+      hash ^= rotate_right(hash, 48) * k1
+      p += 2
+
+    if (e - p) >= 1:
+      hash += cast[uint64](read_u8(p)) * k3
+      hash ^= rotate_right(hash, 37) * k1
+
+    hash ^= rotate_right(hash, 28)
+    hash *= k0
+    hash ^= rotate_right(hash, 29)
+
+    result = cast[Hash](hash)
+else:
+  proc hashData*(data: pointer, size: int, seed: Hash = 0): Hash {.noSideEffect.} =
+    ## hashes an array of bytes of size `size`
+    const 
+      k0 = 0xD6D018F5'u32
+      k1 = 0xA2AA033B'u32
+      k2 = 0x62992FC1'u32
+      k3 = 0x30BC5B29'u32
+
+    var 
+      p = cast[ByteAddress](data)
+      e = p + size
+      hash: uint32 = (seed.uint32 + k2) * k0
+
+    if size >= 16:
+      var
+        v0 = hash
+        v1 = hash
+        v2 = hash
+        v3 = hash
+
+      while p < (e - 16):
+        v0 += read_u32(p) * k0
+        v0 = rotate_right(v0, 29) + v2
+        p += 4
+
+        v1 += read_u32(p) * k1
+        v1 = rotate_right(v1, 29) + v3
+        p += 4
+
+        v2 += read_u32(p) * k2
+        v2 = rotate_right(v2, 29) + v0
+        p += 4
+
+        v3 += read_u32(p) * k3
+        p += 4
+        v3 = rotate_right(v3, 29) + v1
+
+      v2 ^= rotate_right(((v0 + v3) * k0) + v1, 37) * k1
+      v3 ^= rotate_right(((v1 + v2) * k1) + v0, 37) * k0
+      v0 ^= rotate_right(((v0 + v2) * k0) + v3, 37) * k1
+      v1 ^= rotate_right(((v1 + v3) * k1) + v2, 37) * k0
+      hash += (v0 xor v1)
+
+    if (e - p) >= 8:
+      var
+        v0: uint32
+        v1: uint32
+
+      v0 = hash + read_u32(p) * k2
+      v0 = rotate_right(v0, 29) * k3
+      p += 4
+
+      v1 = hash + read_u32(p) * k2
+      v1 = rotate_right(v1, 29) * k3
+      p += 4
+
+      v0 ^= rotate_right(v0 * k0, 21) + v1
+      v1 ^= rotate_right(v1 * k3, 21) + v0
+      hash += v1
+
+    if (e - p) >= 4:
+      hash += cast[uint32](read_u32(p)) * k3
+      hash ^= rotate_right(hash, 26) * k1
+      p += 4
+
+    if (e - p) >= 2:
+      hash += cast[uint32](read_u16(p)) * k3
+      hash ^= rotate_right(hash, 48) * k1
+      p += 2
+
+    if (e - p) >= 1:
+      hash += cast[uint32](read_u8(p)) * k3
+      hash ^= rotate_right(hash, 37) * k1
+
+    hash ^= rotate_right(hash, 28)
+    hash *= k0
+    hash ^= rotate_right(hash, 29)
+
+    result = cast[Hash](hash)
 
 when defined(js):
   var objectID = 0
 
-proc hash*(x: pointer): Hash {.inline.} =
+proc hash*(x: pointer): Hash {.inline, noSideEffect.} =
   ## efficient hashing of pointers
   when defined(js):
     asm """
@@ -97,67 +274,57 @@ proc hash*(x: pointer): Hash {.inline.} =
     result = (cast[Hash](x)) shr 3 # skip the alignment
 
 when not defined(booting):
-  proc hash*[T: proc](x: T): Hash {.inline.} =
+  proc hash*[T: proc](x: T): Hash {.inline, noSideEffect.} =
     ## efficient hashing of proc vars; closures are supported too.
     when T is "closure":
       result = hash(rawProc(x)) !& hash(rawEnv(x))
     else:
       result = hash(pointer(x))
 
-proc hash*(x: int): Hash {.inline.} =
+proc hash*(x: int): Hash {.inline, noSideEffect.} =
   ## efficient hashing of integers
   result = x
 
-proc hash*(x: int64): Hash {.inline.} =
+proc hash*(x: int64): Hash {.inline, noSideEffect.} =
   ## efficient hashing of int64 integers
-  result = toU32(x)
+  when sizeof(Hash) == sizeof(int64):
+    result = cast[Hash](x)
+  else:
+    result = toU32(x)
 
-proc hash*(x: uint): Hash {.inline.} =
+proc hash*(x: uint): Hash {.inline, noSideEffect.} =
   ## efficient hashing of unsigned integers
-  result = cast[int](x)
+  result = cast[Hash](x)
 
-proc hash*(x: uint64): Hash {.inline.} =
+proc hash*(x: uint64): Hash {.inline, noSideEffect.} =
   ## efficient hashing of uint64 integers
-  result = toU32(cast[int](x))
+  when sizeof(Hash) == sizeof(uint64):
+    result = cast[Hash](x)
+  else:
+    result = toU32(cast[int](x))
 
-proc hash*(x: char): Hash {.inline.} =
+proc hash*(x: char): Hash {.inline, noSideEffect.} =
   ## efficient hashing of characters
   result = ord(x)
 
-proc hash*[T: Ordinal](x: T): Hash {.inline.} =
+proc hash*[T: Ordinal](x: T): Hash {.inline, noSideEffect.} =
   ## efficient hashing of other ordinal types (e.g., enums)
   result = ord(x)
 
-proc hash*(x: string): Hash =
+proc hash*(x: string): Hash {.noSideEffect.} =
   ## efficient hashing of strings
-  var h: Hash = 0
-  for i in 0..x.len-1:
-    h = h !& ord(x[i])
-  result = !$h
+  result = hashData(unsafeAddr(x[0]), x.len)
 
-proc hash*(x: cstring): Hash =
+proc hash*(x: cstring): Hash {.noSideEffect.} =
   ## efficient hashing of null-terminated strings
-  var h: Hash = 0
-  var i = 0
-  when defined(js):
-    while i < x.len:
-      h = h !& ord(x[i])
-      inc i
-  else:
-    while x[i] != 0.char:
-      h = h !& ord(x[i])
-      inc i
-  result = !$h
+  result = hashData(cast[pointer](x), x.len)
 
-proc hash*(sBuf: string, sPos, ePos: int): Hash =
+proc hash*(sBuf: string, sPos, ePos: int): Hash {.noSideEffect.} =
   ## efficient hashing of a string buffer, from starting
   ## position `sPos` to ending position `ePos`
   ##
   ## ``hash(myStr, 0, myStr.high)`` is equivalent to ``hash(myStr)``
-  var h: Hash = 0
-  for i in sPos..ePos:
-    h = h !& ord(sBuf[i])
-  result = !$h
+  result = hashData(unsafeAddr(sBuf[sPos]), ePos - sPos + 1)
 
 proc hashIgnoreStyle*(x: string): Hash =
   ## efficient hashing of strings; style is ignored
@@ -219,49 +386,39 @@ proc hashIgnoreCase*(sBuf: string, sPos, ePos: int): Hash =
     h = h !& ord(c)
   result = !$h
 
-proc hash*(x: float): Hash {.inline.} =
+proc hash*(x: float): Hash {.inline, noSideEffect.} =
   ## efficient hashing of floats.
   var y = x + 1.0
   result = cast[ptr Hash](addr(y))[]
 
-
-# Forward declarations before methods that hash containers. This allows
-# containers to contain other containers
-proc hash*[A](x: openArray[A]): Hash
-proc hash*[A](x: set[A]): Hash
-
-
-proc hash*[T: tuple](x: T): Hash =
+proc hash*[T: tuple](x: T): Hash {.noSideEffect.} =
   ## efficient hashing of tuples.
-  for f in fields(x):
-    result = result !& hash(f)
-  result = !$result
+  result = hashData(unsafeAddr(x), x.sizeof)
 
-proc hash*[A](x: openArray[A]): Hash =
+proc hash*[A](x: openArray[A]): Hash {.noSideEffect.} =
   ## efficient hashing of arrays and sequences.
-  for it in items(x): result = result !& hash(it)
-  result = !$result
+  result = hashData(unsafeAddr(x[0]), x.len * A.sizeof)
 
-proc hash*[A](aBuf: openArray[A], sPos, ePos: int): Hash =
+proc hash*[A](aBuf: openArray[A], sPos, ePos: int): Hash {.noSideEffect.} =
   ## efficient hashing of portions of arrays and sequences.
   ##
   ## ``hash(myBuf, 0, myBuf.high)`` is equivalent to ``hash(myBuf)``
-  for i in sPos..ePos:
-    result = result !& hash(aBuf[i])
-  result = !$result
+  result = hashData(unsafeAddr(aBuf[sPos]), (ePos - sPos + 1) * A.sizeof)
 
-proc hash*[A](x: set[A]): Hash =
+proc hash*[A](x: set[A]): Hash {.noSideEffect.} =
   ## efficient hashing of sets.
-  for it in items(x): result = result !& hash(it)
-  result = !$result
+  result = hashData(unsafeAddr(x), x.sizeof)
 
 when isMainModule:
   doAssert( hash("aa bb aaaa1234") == hash("aa bb aaaa1234", 0, 13) )
   doAssert( hash("aa bb aaaa1234") == hash(cstring("aa bb aaaa1234")) )
   doAssert( hashIgnoreCase("aa bb aaaa1234") == hash("aa bb aaaa1234") )
+  doAssert( hashIgnoreCase("aa bb aaaa1234") == hashIgnoreCase("aa bb aaaa1234", 0, 13) )
   doAssert( hashIgnoreStyle("aa bb aaaa1234") == hashIgnoreCase("aa bb aaaa1234") )
+  doAssert( hashIgnoreStyle("aa bb aaaa1234") == hashIgnoreStyle("aa bb aaaa1234", 0, 13) )
   let xx = @['H','e','l','l','o']
   let ss = "Hello"
   doAssert( hash(xx) == hash(ss) )
   doAssert( hash(xx) == hash(xx, 0, xx.high) )
   doAssert( hash(ss) == hash(ss, 0, ss.high) )
+  doAssert( hash(xx, 2, 3) == hash(ss, 2, 3) )


### PR DESCRIPTION
## Benchmark code:
```nim
import times, hashes

const
  N = 5_000_000

template bench*(name: string, p: untyped): untyped =
  let timeStart = cpuTime()
  for idx in 1..N:
    p
  echo name, ": ", (cpuTime() - timeStart) * 1000000

type
  Direction = enum
    north, east, south, west
  Directions = set[Direction]

type
  Person = tuple[name: string, age: int]

let
  test_int64: int64 = 0xFFFFFFFF
  test_string: string = "012345678901234567890123456789012345678901234567890123456789012012"
  test_set_of_char = {'a'..'z', '1'..'9'}
  test_set_of_enum: Directions = {north..south}
  test_seq_of_int = @[1, 2, 3, 4, 5, 6, 7, 8, 9, 1_000, 1_000_000]
  test_tuple: Person = (name: "Peter", age: 30)

bench("int64.hash"):
  var
    h: Hash

  h = hash(test_int64)

bench("string.hash"):
  var
    h: Hash

  h = hash(test_string)

bench("set[char].hash"):
  var
    h: Hash

  h = hash(test_set_of_char)

bench("set[Direction].hash"):
  var
    h: Hash

  h = hash(test_set_of_enum)

bench("seq[int].hash"):
  var
    h: Hash

  h = hash(test_seq_of_int)

bench("tuple.hash"):
  var
    h: Hash

  h = hash(test_tuple)
```
## Results:

Type | Current implementation | New implementation
-- | -- | --
int64.hash | 103724.0 | 95619.0
string.hash | 6649052.99 | 813188.0
set[char].hash | 22221403.0 | 688367.0
set[Direction].hash | 739874.0 | 382980.0
seq[int].hash | 1829930.0 | 965272.0
tuple.hash | 968334.0 | 459737.9