### PR TITLE
Appveyor thttpclient

### DIFF
--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -3,6 +3,7 @@ discard """
   exitcode: 0
   output: "OK"
   disabled: "travis"
+  disabled: "appveyor"
 """
 
 import strutils

--- a/tests/testament/specs.nim
+++ b/tests/testament/specs.nim
@@ -13,6 +13,7 @@ import parseutils, strutils, os, osproc, streams, parsecfg
 var compilerPrefix* = "compiler" / "nim "
 
 let isTravis = existsEnv("TRAVIS")
+let isAppVeyor = existsEnv("APPVEYOR")
 
 proc cmdTemplate*(): string =
   compilerPrefix & "$target --lib:lib --hints:on -d:testing $options $file"
@@ -178,6 +179,8 @@ proc parseSpec*(filename: string): TSpec =
         when defined(posix): result.err = reIgnored
       of "travis":
         if isTravis: result.err = reIgnored
+      of "appveyor":
+        if isAppVeyor: result.err = reIgnored
       else:
         raise newException(ValueError, "cannot interpret as a bool: " & e.value)
     of "cmd":


### PR DESCRIPTION
The `thttpclient` causes AppVeyor tests to fail. Disabling that test when running on AppVeyor.

For that a new value for the test-spec disabled key is introduced: `appveyor`. Similar to `travis` it checks for the existance of the `APPVEYOR` environment variable.