### PR TITLE
Fix compiler crash (#6773)

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1613,7 +1613,7 @@ proc typeRelImpl(c: var TCandidate, f, aOrig: PType,
           if not exprStructuralEquivalent(f.n, aOrig.n):
             result = isNone
         if result != isNone: put(c, f, aOrig)
-      elif aOrig.n != nil:
+      elif aOrig.n != nil and aOrig.n.typ != nil:
         result = typeRel(c, f.lastSon, aOrig.n.typ)
         if result != isNone:
           var boundType = newTypeWithSons(c.c, tyStatic, @[aOrig.n.typ])

--- a/tests/overload/tstatic_with_converter.nim
+++ b/tests/overload/tstatic_with_converter.nim
@@ -1,0 +1,47 @@
+discard """
+output: '''
+9.0'''
+"""
+
+### bug #6773
+
+{.emit: """ /*INCLUDESECTION*/
+typedef double cimported;
+ 
+cimported set1_imported(double x) {
+  return x;
+}
+ 
+"""}
+ 
+type vfloat{.importc: "cimported".} = object
+ 
+proc set1(a: float): vfloat {.importc: "set1_imported".}
+ 
+converter scalar_to_vector(x: float): vfloat =
+  set1(x)
+ 
+proc sqrt(x: vfloat): vfloat =
+  x
+ 
+proc pow(x, y: vfloat): vfloat =
+  y
+ 
+proc `^`(x: vfloat, exp: static[int]): vfloat =
+  when exp == 0:
+    1.0
+  else:
+    x
+ 
+proc `^`(x: vfloat, exp: static[float]): vfloat =
+  when exp == 0.5:
+    sqrt(x)
+  else:
+   pow(x, exp)
+ 
+proc `$`(x: vfloat): string =
+  let y = cast[ptr float](unsafeAddr x)
+  echo y[]
+ 
+let x = set1(9.0)
+echo x^0.5


### PR DESCRIPTION
Fix compiler crash on complicated use case with overloaded functions with static arguments, converters and imported from c incomplete types.

As far as tell: aOrig.n.typ is nil because aOrig.n has incomplete type after autoconverter from float to vfloat. Multiple procs required to trigger overload resolution.

Test cases included