### PR TITLE
Add a flatItems iterator and flatten proc to sequtils

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -777,7 +777,7 @@ proc flatten*[T](s: openarray[T]): auto {.noSideEffect.}=
   ##   # A seq of arrays of seqs of arrays
   ##   let numbers = @[[@[[1],[2]], @[[3], [4]]], [@[[5], [6]], @[[7], [8]]], [@[[9], [10]], @[[11], [12]]]]
   ##   let flattened = numbers.flatten
-  ##   echo flattened # @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  ##   doAssert flattened == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
   toSeq(flatItems s)
 
 when isMainModule:
@@ -1084,12 +1084,12 @@ when isMainModule:
     let b2 = @[@["he","ll","o"], @["wo", "rl", "d"]]
 
 
-    assert a1.flatten == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-    assert a2.flatten == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-    assert a3.flatten == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    doAssert a1.flatten == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    doAssert a2.flatten == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+    doAssert a3.flatten == @[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
-    assert b1.flatten == @["he", "ll", "o", "wo", "rl", "d"]
-    assert b2.flatten == @["he", "ll", "o", "wo", "rl", "d"]
+    doAssert b1.flatten == @["he", "ll", "o", "wo", "rl", "d"]
+    doAssert b2.flatten == @["he", "ll", "o", "wo", "rl", "d"]
 
   when not defined(testing):
     echo "Finished doc tests"

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -758,9 +758,12 @@ iterator flatItems*[T](s: openarray[T]): auto {.noSideEffect.}=
   ## .. code-block:
   ##   # A seq of arrays of seqs of arrays
   ##   let numbers = @[[@[[1],[2]], @[[3], [4]]], [@[[5], [6]], @[[7], [8]]], [@[[9], [10]], @[[11], [12]]]]
-  ##   for n in flatitems(s):
-  ##     echo n
-  ##   # echoes 1, 2, 3, ..., 10, 11, 12 in separate lines
+  ##   let check = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  ##   var i = 0
+  ##   for n in flatitems(numbers):
+  ##     doAssert n == check[i]
+  ##     i += 1
+  ##   # i.e. returns 1, 2, 3, ..., 10, 11, 12
   for item in s:
     when item is array|seq:
       for subitem in flatItems(item):


### PR DESCRIPTION
Regularly people asks if there is a way to flatten nested sequences of arrays (@StefanSalewski, @superfunc).

This adds a `flatItems` iterator and `flatten` proc to sequtils.
Note that it relies on `openarray[T]` not matching `string`