### PR TITLE
favor 'select' over 'poll' on Genode

### DIFF
--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -303,6 +303,8 @@ else:
     include ioselects/ioselectors_select
   elif defined(solaris):
     include ioselects/ioselectors_poll # need to replace it with event ports
+  elif defined(genode):
+    include ioselects/ioselectors_select # TODO: use the native VFS layer
   else:
     include ioselects/ioselectors_poll
 


### PR DESCRIPTION
The 'poll' of the Genode C runtime is a wrapper over 'select'.

I had to touch-up `ioselect_select` a bit to get it to compile.