### PR TITLE
Emit relative object file paths in genScript

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -764,8 +764,9 @@ proc callCCompiler*(projectfile: string) =
       add(objfiles, quoteShell(
           addFileExt(objFile, CC[cCompiler].objExt)))
     for x in toCompile:
+      let objFile = if noAbsolutePaths(): x.obj.extractFilename else: x.obj
       add(objfiles, ' ')
-      add(objfiles, quoteShell(x.obj))
+      add(objfiles, quoteShell(objFile))
 
     linkCmd = getLinkCmd(projectfile, objfiles)
     if optCompileOnly notin gGlobalOptions:


### PR DESCRIPTION
This fixes an inconsistency in genscript. Previously object file paths in the linker command were absolute, while in compilation command they were relative. Now they are relative in the linker command.