### PR TITLE
A demonstration of my approach for JS async

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -143,6 +143,3 @@ This now needs to be written as:
 - codegenDecl pragma now works for the JavaScript backend. It returns an empty string for
   function return type placeholders.
 - Asynchronous programming for the JavaScript backend using the `asyncjs` module.
-- For string formatting / interpolation a new module
-  called [strformat](https://nim-lang.org/docs/strformat.html) has been added
-  to the stdlib.

--- a/changelog.md
+++ b/changelog.md
@@ -39,36 +39,37 @@
   what to return if the environment variable does not exist.
 - Bodies of ``for`` loops now get their own scope:
 
-.. code-block:: nim
+```nim
   # now compiles:
   for i in 0..4:
     let i = i + 1
     echo i
+```
 
 - The parsing rules of ``if`` expressions were changed so that multiple
   statements are allowed in the branches. We found few code examples that
   now fail because of this change, but here is one:
 
-.. code-block:: nim
-
+```nim
   t[ti] = if exp_negative: '-' else: '+'; inc(ti)
+```
 
 This now needs to be written as:
 
-.. code-block:: nim
-
+```nim
   t[ti] = (if exp_negative: '-' else: '+'); inc(ti)
+```
 
 - To make Nim even more robust the system iterators ``..`` and ``countup``
   now only accept a single generic type ``T``. This means the following code
   doesn't die with an "out of range" error anymore:
 
-.. code-block:: nim
-
+```nim
   var b = 5.Natural
   var a = -5
   for i in a..b:
     echo i
+```
 
 - ``formatFloat``/``formatBiggestFloat`` now support formatting floats with zero
   precision digits. The previous ``precision = 0`` behavior (default formatting)
@@ -136,6 +137,12 @@ This now needs to be written as:
   Types that shadow procs and vice versa are marked as ambiguous (bug #6693).
 - ``yield`` (or ``await`` which is mapped to ``yield``) never worked reliably
   in an array, seq or object constructor and is now prevented at compile-time.
+- For string formatting / interpolation a new module
+  called [strformat](https://nim-lang.org/docs/strformat.html) has been added
+  to the stdlib.
+- codegenDecl pragma now works for the JavaScript backend. It returns an empty string for
+  function return type placeholders.
+- Asynchronous programming for the JavaScript backend using the `asyncjs` module.
 - For string formatting / interpolation a new module
   called [strformat](https://nim-lang.org/docs/strformat.html) has been added
   to the stdlib.

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -433,6 +433,8 @@ Modules for JS backend
 * `jsffi <jsffi.html>`_
   Types and macros for easier interaction with JavaScript.
 
+* `asyncjs <asyncjs.html>`_
+  Types and macros for writing asynchronous procedures in JavaScript.
 
 Deprecated modules
 ------------------

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -1,0 +1,58 @@
+import jsffi
+import macros
+
+when not defined(js):
+  {.error "asyncjs is only available for javascript"}
+
+
+type
+  Future*[T] = ref object
+    future*: T
+
+  PromiseJs* {.importcpp: "Promise".} = ref object
+
+proc generateJsasync(arg: NimNode): NimNode
+
+macro async*(arg: untyped): untyped =
+  generateJsasync(arg)
+
+proc newPromise*[T](handler: proc(resolve: proc(response: T))): Future[T] {.importcpp: "(new Promise(#))".}
+
+## can convert cb to async
+## proc a*: Future[bool] =
+##   var promise = newPromise() do (resolve: proc(response: bool)):
+##     call() do (r: cstring):
+##       resolve(len($r) > 0)
+##   return promise
+
+proc jsResolve*[T](a: T): Future[T] {.importcpp: "#".}
+
+proc `$`*[T](future: Future[T]): string =
+  result = "Future"
+
+proc replaceReturn(node: var NimNode) =
+  var z = 0
+  for s in node:
+    var son = node[z]
+    if son.kind == nnkReturnStmt:
+      node[z] = nnkReturnStmt.newTree(nnkCall.newTree(ident("jsResolve"), son[0]))
+    elif son.kind == nnkAsgn and son[0].kind == nnkIdent and $son[0] == "result":
+      node[z] = nnkAsgn.newTree(son[0], nnkCall.newTree(ident("jsResolve"), son[1]))
+    else:
+      replaceReturn(son)
+    inc z
+
+proc generateJsasync(arg: NimNode): NimNode =
+  assert arg.kind == nnkProcDef
+  result = arg
+  if arg[3][0].kind == nnkEmpty:
+    result[3][0] = nnkBracketExpr.newTree(ident("Future"), ident("void"))
+  var code = result[^1]
+  replaceReturn(code)
+  result[^1] = nnkStmtList.newTree()
+  var q = quote:
+    proc await[T](f: Future[T]): T {.importcpp: "(await #)".}
+  result[^1].add(q)
+  for child in code:
+    result[^1].add(child)
+  # echo repr(result)

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -45,14 +45,16 @@ proc replaceReturn(node: var NimNode) =
 proc generateJsasync(arg: NimNode): NimNode =
   assert arg.kind == nnkProcDef
   result = arg
-  if arg[3][0].kind == nnkEmpty:
-    result[3][0] = nnkBracketExpr.newTree(ident("Future"), ident("void"))
-  var code = result[^1]
+  if arg.params[0].kind == nnkEmpty:
+    result.params[0] = nnkBracketExpr.newTree(ident("Future"), ident("void"))
+  var code = result.body
   replaceReturn(code)
-  result[^1] = nnkStmtList.newTree()
+  result.body = nnkStmtList.newTree()
   var q = quote:
     proc await[T](f: Future[T]): T {.importcpp: "(await #)".}
-  result[^1].add(q)
+  result.body.add(q)
   for child in code:
-    result[^1].add(child)
+    result.body.add(child)
+  result.pragma = quote:
+    {.codegenDecl: "async function $2($3)".}
   # echo repr(result)

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -1,9 +1,60 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2017 Nim Authors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+
+## This Module implements types and macros for writing asynchronous code
+## for the JS backend. It provides tools for interaction with JavaScript async API-s 
+## and libraries, writing async procedures in Nim and converting callback-based code
+## to promises.
+##
+## The pragma `{.async.}` means a procedure is asynchronous. Such a procedure
+## should always have a `Future[T]` return type or not have a return type at all.
+## A `Future[void]` return type is assumed by default.
+## 
+## This is roughly equivalent to the `async` keyword in the generated JavaScript code.
+## 
+## ..code-block:: nim
+##  proc loadGame(name: string): Future[Game] {.async.} =
+##    ..
+## 
+## should be equivalent to
+## 
+## ..code-block:: javascript
+##   async function loadGame(name) {
+##     ..
+##   }
+## 
+## A call to an asynchronous procedure usually needs `await` to wait for
+## the completion of the `Future`.
+## 
+## ..code-block:: nim
+##   var game = await loadGame(name)
+## 
+## Often, you might work with callback-based API-s. You can wrap them with
+## asynchronous procedures using promises and `newPromise`:
+## 
+## ..code-block:: nim
+##   proc loadGame(name: string): Future[Game] =
+##     var promise = newPromise() do (resolve: proc(response: Game)):
+##       cbBasedLoadGame(name) do (game: Game):
+##         resolve(game)
+##   return promise
+##
+## Forward definitions work properly, you just don't need to add the `{.async.}` pragma:
+## 
+## ..code-block:: nim
+##   proc loadGame(name: string): Future[Game]
+## 
+
 import jsffi
 import macros
 
 when not defined(js):
   {.error "asyncjs is only available for javascript"}
-
 
 type
   Future*[T] = ref object
@@ -41,12 +92,10 @@ proc generateJsasync(arg: NimNode): NimNode =
     {.codegenDecl: "async function $2($3)".}
 
 macro async*(arg: untyped): untyped =
+  ## Macro which converts normal procedures into
+  ## javascript-compatible async procedures
   generateJsasync(arg)
 
 proc newPromise*[T](handler: proc(resolve: proc(response: T))): Future[T] {.importcpp: "(new Promise(#))".}
-## can convert cb to async
-## proc a*: Future[bool] =
-##   var promise = newPromise() do (resolve: proc(response: bool)):
-##     call() do (r: cstring):
-##       resolve(len($r) > 0)
-##   return promise
+  ## A helper for wrapping callback-based functions
+  ## into promises and async procedures

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -1,0 +1,20 @@
+discard """
+  disabled: true
+  output: '''
+0
+x
+'''
+"""
+
+import asyncjs
+
+proc y(e: int): Future[string] {.async.} =
+  echo 0
+  return "x"
+
+proc x(e: int) {.async.} =
+  var s = await y(e)
+  echo s
+
+discard x(2)
+

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -8,13 +8,19 @@ x
 
 import asyncjs
 
-proc y(e: int): Future[string] {.async.} =
-  echo 0
-  return "x"
+# demonstrate forward definition
+# for js
+proc y(e: int): Future[string]
 
 proc x(e: int) {.async.} =
   var s = await y(e)
   echo s
+
+proc y(e: int): Future[string] {.async.} =
+  echo 0
+  return "x"
+
+
 
 discard x(2)
 

--- a/web/website.ini
+++ b/web/website.ini
@@ -67,7 +67,7 @@ srcdoc2: "pure/collections/heapqueue"
 srcdoc2: "pure/fenv;impure/rdstdin;pure/strformat"
 srcdoc2: "pure/segfaults"
 srcdoc2: "pure/basic2d;pure/basic3d;pure/mersenne;pure/coro;pure/httpcore"
-srcdoc2: "pure/bitops;pure/nimtracker;pure/punycode;pure/volatile"
+srcdoc2: "pure/bitops;pure/nimtracker;pure/punycode;pure/volatile;js/asyncjs"
 
 ; Note: everything under 'webdoc' doesn't get listed in the index, so wrappers
 ; should live here


### PR DESCRIPTION
Yesterday we had a discussion in the chat with @Araq , @dom96 and others about implementing some async support for the Nim's js target mapping to modern JS's async/await. (and eventually integrating an existing solution for compiling to older versions of js for people who need nim async in older js)

I've already done something like this for a project of mine, so I open this PR to see if people agree with this approach.

It was easiest to just introduce an asyncjs module, which defines a js variant of`async`. 
It replaces `return/result` inside with `return jsResolve(#) / result = jsResolve(#)` in order to satisfy the Future type (jsResolve(#) is generated as #, so no overhead).

It defines a function `await` in each body:
that seemed easier than the asyncmacro solution, because I didn't have to reimplement recognition of where to replace await nodes.  (I define it in each async body as a quick hack to make `await` out of `async` invalid)

In the end I generate `async` in jsgen for functions with `Future` return type. Overally it's a very simple approach which works for me in >100 async functions in an electron app written in Nim, however I am not sure if it seems suitable for upstream

