### PR TITLE
Use addCallback rather than callback= in asyncfutures.all()

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -59,8 +59,10 @@ export asyncfutures, asyncstreams
 ##
 ##   .. code-block::nim
 ##      var future = socket.recv(100)
-##      future.addCallback proc () =
-##        echo(future.read)
+##      future.addCallback(
+##        proc () =
+##          echo(future.read)
+##      )
 ##
 ## All asynchronous functions returning a ``Future`` will not block. They
 ## will not however return immediately. An asynchronous function will have

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -59,7 +59,7 @@ export asyncfutures, asyncstreams
 ##
 ##   .. code-block::nim
 ##      var future = socket.recv(100)
-##      future.addCallback do:
+##      future.addCallback proc () =
 ##        echo(future.read)
 ##
 ## All asynchronous functions returning a ``Future`` will not block. They

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -59,9 +59,8 @@ export asyncfutures, asyncstreams
 ##
 ##   .. code-block::nim
 ##      var future = socket.recv(100)
-##      future.callback =
-##        proc () =
-##          echo(future.read)
+##      future.addCallback do:
+##        echo(future.read)
 ##
 ## All asynchronous functions returning a ``Future`` will not block. They
 ## will not however return immediately. An asynchronous function will have

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -333,7 +333,7 @@ proc all*[T](futs: varargs[Future[T]]): auto =
     let totalFutures = len(futs)
 
     for fut in futs:
-      fut.callback = proc(f: Future[T]) =
+      fut.addCallback do (f: Future[T]):
         inc(completedFutures)
         if not retFuture.finished:
           if f.failed:
@@ -355,7 +355,7 @@ proc all*[T](futs: varargs[Future[T]]): auto =
 
     for i, fut in futs:
       proc setCallback(i: int) =
-        fut.callback = proc(f: Future[T]) =
+        fut.addCallback do (f: Future[T]):
           inc(completedFutures)
           if not retFuture.finished:
             if f.failed:

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -333,7 +333,7 @@ proc all*[T](futs: varargs[Future[T]]): auto =
     let totalFutures = len(futs)
 
     for fut in futs:
-      fut.addCallback do (f: Future[T]):
+      fut.addCallback proc (f: Future[T]) =
         inc(completedFutures)
         if not retFuture.finished:
           if f.failed:
@@ -355,7 +355,7 @@ proc all*[T](futs: varargs[Future[T]]): auto =
 
     for i, fut in futs:
       proc setCallback(i: int) =
-        fut.addCallback do (f: Future[T]):
+        fut.addCallback proc (f: Future[T]) =
           inc(completedFutures)
           if not retFuture.finished:
             if f.failed:

--- a/tests/async/tasyncall.nim
+++ b/tests/async/tasyncall.nim
@@ -40,6 +40,16 @@ proc testVarargs(x, y, z: int): seq[int] =
 
   result = waitFor all(a, b, c)
 
+proc testWithDupes() =
+  var
+    tasks = newSeq[Future[void]](taskCount)
+    fut = futureWithoutValue()
+
+  for i in 0..<taskCount:
+    tasks[i] = fut
+
+  waitFor all(tasks)
+
 block:
     let
       startTime = cpuTime()
@@ -53,6 +63,13 @@ block:
 block:
     let startTime = cpuTime()
     testFuturesWithoutValues()
+    let execTime = cpuTime() - startTime
+
+    doAssert execTime * 1000 < taskCount * sleepDuration
+
+block:
+    let startTime = cpuTime()
+    testWithDupes()
     let execTime = cpuTime() - startTime
 
     doAssert execTime * 1000 < taskCount * sleepDuration


### PR DESCRIPTION
Addresses part of #6849 

I tried doing a wider sweep of callback= but that caused some tests to fail and I didn't have time or experience to really dig into them.