### PR TITLE
Jsobject

### DIFF
--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -489,9 +489,7 @@ macro bindMethod*(procedure: typed): auto =
 
 
 
-proc generateJsObject(args: varargs[NimNode]): NimNode =
-  var properties = @args[0]
-
+proc generateJsObject(properties: NimNode): NimNode =
   var empty = newEmptyNode()
   result = nnkStmtList.newTree()
   var first = nnkTypeSection.newTree(
@@ -513,6 +511,7 @@ proc generateJsObject(args: varargs[NimNode]): NimNode =
 
   result.add(first)
   result.add(second)
+  echo repr(result)
 
 
 macro jsobject*(args: varargs[untyped]): untyped =

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -489,11 +489,6 @@ macro bindMethod*(procedure: typed): auto =
 
 
 
-proc generateJsObject(args: varargs[NimNode]): NimNode
-
-macro jsobject*(args: varargs[untyped]): untyped =
-  generateJsObject(args)
-
 proc generateJsObject(args: varargs[NimNode]): NimNode =
   var properties = @args[0]
 
@@ -510,7 +505,7 @@ proc generateJsObject(args: varargs[NimNode]): NimNode =
   var second = ident("temp")
 
   for property in properties:
-    assert property.kind == nnkExprEqExpr
+    expectKind(property, nnkExprEqExpr)
     first[0][2][2].add(nnkIdentDefs.newTree(
       property[0],
       property[1],
@@ -519,5 +514,7 @@ proc generateJsObject(args: varargs[NimNode]): NimNode =
   result.add(first)
   result.add(second)
 
-  # echo repr(result)
+
+macro jsobject*(args: varargs[untyped]): untyped =
+  generateJsObject(args)
 

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -486,3 +486,38 @@ macro bindMethod*(procedure: typed): auto =
       newTree(nnkStmtList, thisQuote, call)
   )
   result = body
+
+
+
+proc generateJsObject(args: varargs[NimNode]): NimNode
+
+macro jsobject*(args: varargs[untyped]): untyped =
+  generateJsObject(args)
+
+proc generateJsObject(args: varargs[NimNode]): NimNode =
+  var properties = @args[0]
+
+  var empty = newEmptyNode()
+  result = nnkStmtList.newTree()
+  var first = nnkTypeSection.newTree(
+    nnkTypeDef.newTree(
+      ident("temp"),
+      empty,
+      nnkObjectTy.newTree(
+        empty,
+        empty,
+        nnkRecList.newTree())))
+  var second = ident("temp")
+
+  for property in properties:
+    assert property.kind == nnkExprEqExpr
+    first[0][2][2].add(nnkIdentDefs.newTree(
+      property[0],
+      property[1],
+      newEmptyNode()))
+
+  result.add(first)
+  result.add(second)
+
+  # echo repr(result)
+


### PR DESCRIPTION
```nim
import jsffi

var test {.importc: "test".}: js

test.before(2000) do (response: jsobject(x=int, y=bool)):
  if response.x > -2:
    echo "YES"
```

with this PR `if response.x > -2` compiles to 

```javascript
if ((-2 < response_66022.x))
```

There is no other good existing way to achieve it:

```nim
test.before(2000) do (response: tuple[x: int, y: bool]):
  if response.x > -2:
    echo "YES"
```
tuples: can't work as they emit `.Field0` which is **wrong** js code if you expect {x: int, y: bool}

```nim
test.before(2000) do (response: js):
  if cast[int](response.x) > -2:
    echo "YES"
```
cast: sucks as you have to cast everywhere. which sucks

this is achieved with only a macro, and for usual js code it shouldn't matter that you can't pass such an object (as usually this `test.before` is some js lib/api which you want to typecheck AGAINST)

I am just asking if this approach seems viable and if there is a better way to macro it? 

* this temp name should be somehow more magic
* is there a way to `jsobject[x: int]`
 

