### PR TITLE
Fixed printing nimsuggest commandline help message

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -526,6 +526,9 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
     of cmdEnd: break
     of cmdLongoption, cmdShortOption:
       case p.key.normalize
+      of "help":
+        stdout.writeline(Usage)
+        quit()
       of "port":
         gPort = parseInt(p.val).Port
         gMode = mtcp


### PR DESCRIPTION
This outputs nimsuggest usage on 'nimsuggest --help'
and fixes #6854 and #5841.

Although, the usage line

> "In addition, all command line options of Nim that do not affect code generation
are supported."

would no longer be true for '--help'

