### PR TITLE
Fixed pgroup for startProcess

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -230,7 +230,7 @@ proc execProcesses*(cmds: openArray[string],
   ## executes the commands `cmds` in parallel. Creates `n` processes
   ## that execute in parallel. The highest return value of all processes
   ## is returned. Runs `beforeRunEvent` before running each command.
-  
+
   assert n > 0
   if n > 1:
     var i = 0
@@ -829,11 +829,9 @@ elif not defined(useNimRtl):
       var mask: Sigset
       chck sigemptyset(mask)
       chck posix_spawnattr_setsigmask(attr, mask)
-      chck posix_spawnattr_setpgroup(attr, 0'i32)
 
       chck posix_spawnattr_setflags(attr, POSIX_SPAWN_USEVFORK or
-                                          POSIX_SPAWN_SETSIGMASK or
-                                          POSIX_SPAWN_SETPGROUP)
+                                          POSIX_SPAWN_SETSIGMASK)
 
       if not data.optionPoParentStreams:
         chck posix_spawn_file_actions_addclose(fops, data.pStdin[writeIdx])


### PR DESCRIPTION
Removed extra pgroup attr. `posix_spawnattr_setpgroup(attr, 0'i32)` means that a new group should be created, while the default `posix_spawn` behavior is to inherit parent group, which is a more expected behavior.

This fixes the issue that can be reproduced on macos (but not on windows or linux), that the child process is not getting killed along with the parent one.

Here's a sample to demonstrate that:
```nim
import osproc, os, strutils

proc main() =
    var myName = 0
    if paramCount() != 0:
        myName = parseInt(paramStr(1))

    if myName == 0:
        echo "start process"
        discard startProcess(paramStr(0), args = ["1"], options = {poParentStreams})

    while true:
        echo myName, ": sleeping..."
        sleep(2000)

main()
```
If you run that on macos and press `Ctr+C`, the main process will be killed, but the child will continue to output to terminal.