### PR TITLE
fix #6264 and #6141

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -202,13 +202,17 @@ when not defined(js):
 
   proc countLogLines(logger: RollingFileLogger): int =
     result = 0
-    for line in logger.file.lines():
+    let fp = open(logger.baseName, fmRead)
+    for line in fp.lines():
       result.inc()
+    fp.close()
 
   proc countFiles(filename: string): int =
     # Example: file.log.1
     result = 0
-    let (dir, name, ext) = splitFile(filename)
+    var (dir, name, ext) = splitFile(filename)
+    if dir == "":
+      dir = "."
     for kind, path in walkDir(dir):
       if kind == pcFile:
         let llfn = name & ext & ExtSep


### PR DESCRIPTION
- A `newRollingFileLogger` opened in mode `fmAppend` tries to read the existing file to get the number of lines already present in the file. But a file opened in append mode can't be read. Nim currently has no way to open a file in mode "a+". So in `countLogLines`  i open the file again in mode `fmRead`to count the number of lines.
- the `countFiles` procedure doesn't find any files if the filename passed to `newRollingFileLogger` has no directory component. So i check if `splitFile(filename)` gives an empty directory and replace that by "."
- a file opened in mode `fmReadWrite` is truncated on open. So if you want to append to the current rolling log, you have to open it in mode `fmAppend`.
