### PR TITLE
modify getTypeImpl to reduce result to final implementation

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -84,10 +84,10 @@ proc mapTypeToAstX(t: PType; info: TLineInfo;
 
   if inst:
     if t.sym != nil:  # if this node has a symbol
-      if allowRecursion:  # getTypeImpl behavior: turn off recursion
-        allowRecursion = false
-      else:  # getTypeInst behavior: return symbol
+      if not allowRecursion:  # getTypeInst behavior: return symbol
         return atomicType(t.sym)
+      #else:  # getTypeImpl behavior: turn off recursion
+      #  allowRecursion = false
 
   case t.kind
   of tyNone: result = atomicType("none", mNone)

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -158,21 +158,21 @@ test(Tree):
     left: ref Tree
     right: ref Tree
 test(Concrete):
-  type _ = Generic[int]
+  type _ = seq[int]
 test(Generic[int]):
   type _ = seq[int]
 test(Generic[float]):
   type _ = seq[int]
 test(Concrete2):
-  type _ = Generic2[int,float]
+  type _ = seq[int]
 test(Generic2[int,float]):
   type _ = seq[int]
 test(Alias1):
   type _ = float
 test(Alias2):
-  type _ = Generic[int]
+  type _ = seq[int]
 test(Alias3):
-  type _ = Generic2[int,float]
+  type _ = seq[int]
 test(Vec[4,float32]):
   type _ = object
     arr: array[0..3,float32]

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -113,8 +113,12 @@ type
   Generic[T] = seq[int]
   Concrete = Generic[int]
 
+  Generic2[T1, T2] = seq[T1]
+  Concrete2 = Generic2[int, float]
+
   Alias1 = float
   Alias2 = Concrete
+  Alias3 = Concrete2
 
   Vec[N: static[int],T] = object
     arr: array[N,T]
@@ -159,10 +163,16 @@ test(Generic[int]):
   type _ = seq[int]
 test(Generic[float]):
   type _ = seq[int]
+test(Concrete2):
+  type _ = Generic2[int,float]
+test(Generic2[int,float]):
+  type _ = seq[int]
 test(Alias1):
   type _ = float
 test(Alias2):
   type _ = Generic[int]
+test(Alias3):
+  type _ = Generic2[int,float]
 test(Vec[4,float32]):
   type _ = object
     arr: array[0..3,float32]


### PR DESCRIPTION
Fixed getTypeImpl for second part of #5788.
This changes the behavior so that it will recurse and give the final implementation for a recursively defined type.