### PR TITLE
Don't yield in async await if future is ready

### DIFF
--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -111,8 +111,22 @@ template useVar(result: var NimNode, futureVarNode: NimNode, valueReceiver,
   ##                   future's value.
   ##
   ##    rootReceiver: ??? TODO
-  # -> yield future<x>
-  result.add newNimNode(nnkYieldStmt, fromNode).add(futureVarNode)
+  # -> if not future<x>.finished: yield future<x>
+  result.add nnkIfStmt.newTree(
+    nnkElifBranch.newTree(
+      nnkPrefix.newTree(
+        newIdentNode("not"),
+        nnkDotExpr.newTree(
+          futureVarNode,
+          newIdentNode("finished")
+        )
+      ),
+      nnkStmtList.newTree(
+        newNimNode(nnkYieldStmt, fromNode).add(futureVarNode)
+      )
+    )
+  )
+
   # -> future<x>.read
   valueReceiver = newDotExpr(futureVarNode, newIdentNode("read"))
   result.add generateExceptionCheck(futureVarNode, tryStmt, rootReceiver,

--- a/tests/async/tfuturestream.nim
+++ b/tests/async/tfuturestream.nim
@@ -18,8 +18,8 @@ var fs = newFutureStream[int]()
 
 proc alpha() {.async.} =
   for i in 0 .. 5:
-    await sleepAsync(1000)
     await fs.write(i)
+    await sleepAsync(1000)
 
   echo("Done")
   fs.complete()


### PR DESCRIPTION
This is one of my first macros and I just used the output from dumpAstGen. Let me know if there is a better way to write this.

Without the test change, it was printing `4 Done 5 Finished`. I think that is because the call to `await fs.write()` no longer blocked progress of the alpha coroutine. That seems like a valid semantic to me, but let me know if there is some subtlety I'm missing.