### PR TITLE
Make asyncjs Future[void] play nicely with last line discardable calls & forward declaration

### DIFF
--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -44,10 +44,10 @@
 ##         resolve(game)
 ##     return promise
 ##
-## Forward definitions work properly, you just don't need to add the ``{.async.}`` pragma:
+## Forward definitions work properly, you just need to always add the ``{.async.}`` pragma:
 ##
 ## .. code-block:: nim
-##   proc loadGame(name: string): Future[Game]
+##   proc loadGame(name: string): Future[Game] {.async.}
 ##
 ## JavaScript compatibility
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -3,6 +3,7 @@ discard """
   output: '''
 0
 x
+e
 '''
 """
 
@@ -12,14 +13,18 @@ import asyncjs
 # for js
 proc y(e: int): Future[string]
 
-proc x(e: int) {.async.} =
+proc e: int {.discardable.} =
+  echo "e"
+  return 2
+
+proc x(e: int): Future[void] {.async.} =
   var s = await y(e)
   echo s
+  e()
 
 proc y(e: int): Future[string] {.async.} =
   echo 0
   return "x"
-
 
 
 discard x(2)

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -1,7 +1,6 @@
 discard """
   disabled: true
   output: '''
-0
 x
 e
 '''
@@ -11,7 +10,7 @@ import asyncjs
 
 # demonstrate forward definition
 # for js
-proc y(e: int): Future[string]
+proc y(e: int): Future[string] {.async.}
 
 proc e: int {.discardable.} =
   echo "e"
@@ -23,8 +22,10 @@ proc x(e: int): Future[void] {.async.} =
   e()
 
 proc y(e: int): Future[string] {.async.} =
-  echo 0
-  return "x"
+  if e > 0:
+    return await y(0)
+  else:
+    return "x"
 
 
 discard x(2)


### PR DESCRIPTION
```nim
import jsffi

proc e: js {.discardable.} =
  # stuff

proc a {.async.} =
  # stuff
  e()
```

should work correctly now