### PR TITLE
Allow noreturn procs with void type

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -771,7 +771,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: int,
       of wNoreturn:
         noVal(it)
         incl(sym.flags, sfNoReturn)
-        if sym.ast[paramsPos][0].kind != nkEmpty:
+        if sym.typ[0] != nil:
           localError(sym.ast[paramsPos][0].info, errNoReturnWithReturnTypeNotAllowed)
       of wDynlib:
         processDynLib(c, it, sym)

--- a/tests/pragmas/tnoreturn.nim
+++ b/tests/pragmas/tnoreturn.nim
@@ -5,6 +5,10 @@ ccodeCheck: "\\i @'__attribute__((noreturn))' .*"
 proc noret1*(i: int) {.noreturn.} = 
   echo i
 
+
+proc noret2*(i: int): void {.noreturn.} = 
+  echo i
+
 var p {.used.}: proc(i: int): int
 doAssert(not compiles(
   p = proc(i: int): int {.noreturn.} = i # noreturn lambda returns int


### PR DESCRIPTION
Based on the feeback on https://github.com/nim-lang/Nim/pull/6954, void type return type should be allowed for noreturn procs