### PR TITLE
Fixed mutex usage in SharedList and SharedTable. Closes #6988

### DIFF
--- a/lib/pure/collections/sharedlist.nim
+++ b/lib/pure/collections/sharedlist.nim
@@ -93,7 +93,8 @@ proc deinitSharedList*[A](t: var SharedList[A]) =
   deinitLock t.lock
 
 proc initSharedList*[A](): SharedList[A] {.deprecated.} =
-  # This is not posix compliant, may introduce undefined behavior. Use `init` instead.
+  ## Deprecated. Use `init` instead.
+  ## This is not posix compliant, may introduce undefined behavior.
   initLock result.lock
   result.head = nil
   result.tail = nil

--- a/lib/pure/collections/sharedlist.nim
+++ b/lib/pure/collections/sharedlist.nim
@@ -73,10 +73,10 @@ proc add*[A](x: var SharedList[A]; y: A) =
     node.d[node.dataLen] = y
     inc(node.dataLen)
 
-proc initSharedList*[A](): SharedList[A] =
-  initLock result.lock
-  result.head = nil
-  result.tail = nil
+proc init*[A](t: var SharedList[A]) =
+  initLock t.lock
+  t.head = nil
+  t.tail = nil
 
 proc clear*[A](t: var SharedList[A]) =
   withLock(t):

--- a/lib/pure/collections/sharedlist.nim
+++ b/lib/pure/collections/sharedlist.nim
@@ -92,4 +92,10 @@ proc deinitSharedList*[A](t: var SharedList[A]) =
   clear(t)
   deinitLock t.lock
 
+proc initSharedList*[A](): SharedList[A] {.deprecated.} =
+  # This is not posix compliant, may introduce undefined behavior. Use `init` instead.
+  initLock result.lock
+  result.head = nil
+  result.tail = nil
+
 {.pop.}

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -210,7 +210,8 @@ proc deinitSharedTable*[A, B](t: var SharedTable[A, B]) =
   deinitLock t.lock
 
 proc initSharedTable*[A, B](initialSize=64): SharedTable[A, B] {.deprecated.} =
-  # This is not posix compliant, may introduce undefined behavior. Use `init` instead.
+  ## Deprecated. Use `init` instead.
+  ## This is not posix compliant, may introduce undefined behavior.
   assert isPowerOfTwo(initialSize)
   result.counter = 0
   result.dataLen = initialSize

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -192,18 +192,18 @@ proc del*[A, B](t: var SharedTable[A, B], key: A) =
   withLock t:
     delImpl()
 
-proc initSharedTable*[A, B](initialSize=64): SharedTable[A, B] =
+proc init*[A, B](t: var SharedTable[A, B], initialSize=64) =
   ## creates a new hash table that is empty.
   ##
   ## `initialSize` needs to be a power of two. If you need to accept runtime
   ## values for this you could use the ``nextPowerOfTwo`` proc from the
   ## `math <math.html>`_ module or the ``rightSize`` proc from this module.
   assert isPowerOfTwo(initialSize)
-  result.counter = 0
-  result.dataLen = initialSize
-  result.data = cast[KeyValuePairSeq[A, B]](allocShared0(
+  t.counter = 0
+  t.dataLen = initialSize
+  t.data = cast[KeyValuePairSeq[A, B]](allocShared0(
                                       sizeof(KeyValuePair[A, B]) * initialSize))
-  initLock result.lock
+  initLock t.lock
 
 proc deinitSharedTable*[A, B](t: var SharedTable[A, B]) =
   deallocShared(t.data)

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -208,3 +208,12 @@ proc init*[A, B](t: var SharedTable[A, B], initialSize=64) =
 proc deinitSharedTable*[A, B](t: var SharedTable[A, B]) =
   deallocShared(t.data)
   deinitLock t.lock
+
+proc initSharedTable*[A, B](initialSize=64): SharedTable[A, B] {.deprecated.} =
+  # This is not posix compliant, may introduce undefined behavior. Use `init` instead.
+  assert isPowerOfTwo(initialSize)
+  result.counter = 0
+  result.dataLen = initialSize
+  result.data = cast[KeyValuePairSeq[A, B]](allocShared0(
+                                     sizeof(KeyValuePair[A, B]) * initialSize))
+  initLock result.lock

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -318,7 +318,7 @@ proc initGC() =
       init(gch.marked)
       init(gch.additionalRoots)
     when hasThreadSupport:
-      gch.toDispose = initSharedList[pointer]()
+      init(gch.toDispose)
 
 when useMarkForDebug or useBackupGc:
   type

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -133,7 +133,7 @@ proc initGC() =
     init(gch.additionalRoots)
     init(gch.greyStack)
     when hasThreadSupport:
-      gch.toDispose = initSharedList[pointer]()
+      init(gch.toDispose)
 
 # Which color to use for new objects is tricky: When we're marking,
 # they have to be *white* so that everything is marked that is only

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -233,7 +233,7 @@ proc initGC() =
       init(gch.allocated)
       init(gch.marked)
     when hasThreadSupport:
-      gch.toDispose = initSharedList[pointer]()
+      init(gch.toDispose)
 
 proc forAllSlotsAux(dest: pointer, n: ptr TNimNode, op: WalkOp) {.benign.} =
   var d = cast[ByteAddress](dest)

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -213,7 +213,8 @@ block clearCountTableTest:
   assert t.len() == 0
 
 block withKeyTest:
-  var t = initSharedTable[int, int]()
+  var t: SharedTable[int, int]
+  t.init()
   t.withKey(1) do (k: int, v: var int, pairExists: var bool):
     assert(v == 0)
     pairExists = true


### PR DESCRIPTION
Ok, so it's another bug because of mutexes are copied. Related: #5803, #3936.

Here's a man: https://linux.die.net/man/3/pthread_mutex_init
Note the following:
> Only mutex itself may be used for performing synchronization. The result of referring to copies of mutex in calls to pthread_mutex_lock(), pthread_mutex_trylock(), pthread_mutex_unlock(), and pthread_mutex_destroy() is undefined.
