### PR TITLE
Add warnings about deprecation to times module

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1352,29 +1352,34 @@ else:
 proc fromSeconds*(since1970: float): Time {.tags: [], raises: [], benign, deprecated.} =
   ## Takes a float which contains the number of seconds since the unix epoch and
   ## returns a time object.
+  ##
   ## **Deprecated since v0.18.0:** use ``Time`` instead
   Time(since1970)
 
 proc fromSeconds*(since1970: int64): Time {.tags: [], raises: [], benign, deprecated.} =
   ## Takes an int which contains the number of seconds since the unix epoch and
   ## returns a time object.
+  ##
   ## **Deprecated since v0.18.0:** use ``Time`` instead
   Time(since1970)
 
 proc toSeconds*(time: Time): float {.tags: [], raises: [], benign, deprecated.} =
   ## Returns the time in seconds since the unix epoch.
+  ##
   ## **Deprecated since v0.18.0:** use ``float`` instead
   float(time)
 
 proc getLocalTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-time representation,
   ## expressed relative to the user's specified time zone.
+  ##
   ## **Deprecated since v0.18.0:** use ``local`` instead
   time.local
 
 proc getGMTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-down time representation,
   ## expressed in Coordinated Universal Time (UTC). 
+  ##
   ## **Deprecated since v0.18.0:** use ``utc`` instead
   time.utc
 

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1352,35 +1352,30 @@ else:
 proc fromSeconds*(since1970: float): Time {.tags: [], raises: [], benign, deprecated.} =
   ## Takes a float which contains the number of seconds since the unix epoch and
   ## returns a time object.
-  ## **Warning:** This procedure is deprecated since version 0.18.0.
-  ## Use ``Time`` instead.
+  ## **Deprecated since v0.18.0:** use ``Time`` instead
   Time(since1970)
 
 proc fromSeconds*(since1970: int64): Time {.tags: [], raises: [], benign, deprecated.} =
   ## Takes an int which contains the number of seconds since the unix epoch and
   ## returns a time object.
-  ## **Warning:** This procedure is deprecated since version 0.18.0.
-  ## Use ``Time`` instead.
+  ## **Deprecated since v0.18.0:** use ``Time`` instead
   Time(since1970)
 
 proc toSeconds*(time: Time): float {.tags: [], raises: [], benign, deprecated.} =
   ## Returns the time in seconds since the unix epoch.
-  ## **Warning:** This procedure is deprecated since version 0.18.0.
-  ## Use ``float`` instead.
+  ## **Deprecated since v0.18.0:** use ``float`` instead
   float(time)
 
 proc getLocalTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-time representation,
   ## expressed relative to the user's specified time zone.
-  ## **Warning:** This procedure is deprecated since version 0.18.0.
-  ## Use ``local`` instead.
+  ## **Deprecated since v0.18.0:** use ``local`` instead
   time.local
 
 proc getGMTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-down time representation,
-  ## expressed in Coordinated Universal Time (UTC).
-  ## **Warning:** This procedure is deprecated since version 0.18.0.
-  ## Use ``utc`` instead.
+  ## expressed in Coordinated Universal Time (UTC). 
+  ## **Deprecated since v0.18.0:** use ``utc`` instead
   time.utc
 
 proc getTimezone*(): int {.tags: [TimeEffect], raises: [], benign, deprecated.} =

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1352,25 +1352,35 @@ else:
 proc fromSeconds*(since1970: float): Time {.tags: [], raises: [], benign, deprecated.} =
   ## Takes a float which contains the number of seconds since the unix epoch and
   ## returns a time object.
+  ## **Warning:** This procedure is deprecated since version 0.18.0.
+  ## Use ``Time`` instead.
   Time(since1970)
 
 proc fromSeconds*(since1970: int64): Time {.tags: [], raises: [], benign, deprecated.} =
   ## Takes an int which contains the number of seconds since the unix epoch and
   ## returns a time object.
+  ## **Warning:** This procedure is deprecated since version 0.18.0.
+  ## Use ``Time`` instead.
   Time(since1970)
 
 proc toSeconds*(time: Time): float {.tags: [], raises: [], benign, deprecated.} =
   ## Returns the time in seconds since the unix epoch.
+  ## **Warning:** This procedure is deprecated since version 0.18.0.
+  ## Use ``float`` instead.
   float(time)
 
 proc getLocalTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-time representation,
   ## expressed relative to the user's specified time zone.
+  ## **Warning:** This procedure is deprecated since version 0.18.0.
+  ## Use ``local`` instead.
   time.local
 
 proc getGMTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-down time representation,
   ## expressed in Coordinated Universal Time (UTC).
+  ## **Warning:** This procedure is deprecated since version 0.18.0.
+  ## Use ``utc`` instead.
   time.utc
 
 proc getTimezone*(): int {.tags: [TimeEffect], raises: [], benign, deprecated.} =


### PR DESCRIPTION
I've added warnings about some procedures being deprecated.
Also I can't find what is the replacement for `getTimezone` proc, please help with that