### PR TITLE
times.parse performance improvement for dates

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1245,7 +1245,9 @@ proc parse*(value, layout: string, zone: Timezone = local()): DateTime =
       result = initDateTime(zone.zoneInfoFromTz(result.toAdjTime), zone)
     else:
       # Otherwise convert to `zone`
-      result = result.toTime.inZone(zone)
+      result = result.toTime.inZone(zone)   
+  elif ptDate in found_tokens:
+    result.timezone = zone
 
 proc countLeapYears*(yearSpan: int): int =
   ## Returns the number of leap years spanned by a given number of years.


### PR DESCRIPTION
PR provides a noticable performance improvement when you need to parse just the date and don't want to deal with timezones which is rather slow. Parsing token detection is added which skips timezone correction if date only tokens are encoutered.
PR also helps the parsing peformance for combinations of Date &Time by avoiding unnecessary `now()` call