### PR TITLE
Use safe limit for toRational(float, int)

### DIFF
--- a/lib/pure/rationals.nim
+++ b/lib/pure/rationals.nim
@@ -39,7 +39,7 @@ proc toRational*[T:SomeInteger](x: T): Rational[T] =
   result.num = x
   result.den = 1
 
-proc toRational*(x: float, n: int = high(int32)): Rational[int] =
+proc toRational*(x: float, n: int = high(int) shr (sizeof(int) div 2 * 8)): Rational[int] =
   ## Calculates the best rational numerator and denominator
   ## that approximates to `x`, where the denominator is
   ## smaller than `n` (default is the largest possible
@@ -323,8 +323,13 @@ when isMainModule:
   assert abs(toFloat(y) - 0.4814814814814815) < 1.0e-7
   assert toInt(z) == 0
 
-  assert toRational(0.98765432) == 2111111029 // 2137499919
-  assert toRational(PI) == 817696623 // 260280919
+  when sizeof(int) == 8:
+    assert toRational(0.98765432) == 2111111029 // 2137499919
+    assert toRational(PI) == 817696623 // 260280919
+  when sizeof(int) == 4:
+    assert toRational(0.98765432) == 80 // 81
+    assert toRational(PI) == 355 // 113
+
   assert toRational(0.1) == 1 // 10
   assert toRational(0.9) == 9 // 10
 


### PR DESCRIPTION
Current limit `high(int32)` is not safe for 32-bit platforms
and it will overflow (even when running its own test suite).
Similar behaviour would be when try to set limit to `high(int64)`
on 64-bit platforms.

This change selects safe maximum value based on platform
size of int. Safe maximum considered half of int size (for
backward compatiblity).