### PR TITLE
Unexport epochday procs

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -176,7 +176,7 @@ proc assertValidDate(monthday: MonthdayRange, month: Month, year: int) {.inline.
   assert monthday <= getDaysInMonth(month, year),
     $year & "-" & $ord(month) & "-" & $monthday & " is not a valid date"
 
-proc toEpochDay*(monthday: MonthdayRange, month: Month, year: int): int64 =
+proc toEpochDay(monthday: MonthdayRange, month: Month, year: int): int64 =
   ## Get the epoch day from a year/month/day date.
   ## The epoch day is the number of days since 1970/01/01 (it might be negative).
   assertValidDate monthday, month, year
@@ -191,7 +191,7 @@ proc toEpochDay*(monthday: MonthdayRange, month: Month, year: int): int64 =
   let doe = yoe * 365 + yoe div 4 - yoe div 100 + doy
   return era * 146097 + doe - 719468
 
-proc fromEpochDay*(epochday: int64): tuple[monthday: MonthdayRange, month: Month, year: int] =
+proc fromEpochDay(epochday: int64): tuple[monthday: MonthdayRange, month: Month, year: int] =
   ## Get the year/month/day date from a epoch day.
   ## The epoch day is the number of days since 1970/01/01 (it might be negative).
   # Based on http://howardhinnant.github.io/date_algorithms.html


### PR DESCRIPTION
Hopefully this isn't to late to undo... I think it was a mistake to export these two procs in #6552. The reason is that they use a primitive `tuple[monthday: MonthdayRange, month: Month, year: int]` type due to the current lack of a proper `Date` type.

The procs are useful, but it would be sad to be stuck with this stupid return type for `fromEpochDay`. They can be exported again when the `times` module is more complete.