### PR TITLE
Fix lists of paths in posix environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ stages:
 
 .linux_set_path: &linux_set_path_def
   before_script:
-    - export PATH=$(pwd)/bin:$PATH
+    - export PATH=$(pwd)/bin${PATH:+:$PATH}
   tags:
     - linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - sh build.sh
   - cd ..
   - sed -i -e 's,cc = gcc,cc = clang,' config/nim.cfg
-  - export PATH=$(pwd)/bin:$PATH
+  - export PATH=$(pwd)/bin${PATH:+:$PATH}
 script:
   - nim c koch
   - ./koch boot

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,7 +6,7 @@ cd csources
 sh build.sh
 cd ..
 # Add Nim to the PATH
-export PATH=$(pwd)/bin:$PATH
+export PATH=$(pwd)/bin${PATH:+:$PATH}
 # Bootstrap.
 nim -v
 nim c koch

--- a/ci/deps.sh
+++ b/ci/deps.sh
@@ -7,7 +7,7 @@ apt-get install -y -qq build-essential git libcurl4-openssl-dev libsdl1.2-dev li
 
 gcc -v
 
-export PATH=$(pwd)/bin:$PATH
+export PATH=$(pwd)/bin${PATH:+:$PATH}
 
 # Nimble deps
 nim e install_nimble.nims

--- a/koch.nim
+++ b/koch.nim
@@ -97,7 +97,7 @@ proc exec(cmd: string, errorcode: int = QuitFailure, additionalPath = "") =
     if not absolute.isAbsolute:
       absolute = getCurrentDir() / absolute
     echo("Adding to $PATH: ", absolute)
-    putEnv("PATH", prevPath & PathSep & absolute)
+    putEnv("PATH", (if prevPath.len > 0: prevPath & PathSep else: "") & absolute)
   echo(cmd)
   if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
   putEnv("PATH", prevPath)
@@ -402,7 +402,7 @@ proc winReleaseArch(arch: string) =
 
   template withMingw(path, body) =
     let prevPath = getEnv("PATH")
-    putEnv("PATH", path & PathSep & prevPath)
+    putEnv("PATH", (if path.len > 0: path & PathSep else: "") & prevPath)
     try:
       body
     finally:

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -90,7 +90,7 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string) =
     # posix relies on crappy LD_LIBRARY_PATH (ugh!):
     var libpath = getEnv"LD_LIBRARY_PATH".string
     # Temporarily add the lib directory to LD_LIBRARY_PATH:
-    putEnv("LD_LIBRARY_PATH", "tests/dll:" & libpath)
+    putEnv("LD_LIBRARY_PATH", "tests/dll" & (if libpath.len > 0: ":" & libpath else: ""))
     defer: putEnv("LD_LIBRARY_PATH", libpath)
     var nimrtlDll = DynlibFormat % "nimrtl"
     safeCopyFile("lib" / nimrtlDll, "tests/dll" / nimrtlDll)


### PR DESCRIPTION
Empty paths in a colon separated list would be considered as the current
directory, so have to ensure $PATH and $LD_LIBRARY_PATH are not empty
before separating it with :