### PR TITLE
Ast and concrete syntax different.

### DIFF
--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -918,7 +918,7 @@ This is equivalent to ``var``, but with ``nnkLetSection`` rather than
 Concrete syntax:
 
 .. code-block:: nim
-  let v = 3
+  let a = 3
 
 AST:
 


### PR DESCRIPTION
Change variable name to a from v, to match the ast and other examples.