### PR TITLE
Add additional $ fallback to fmt

### DIFF
--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -221,8 +221,10 @@ template callFormat(res, arg) {.dirty.} =
 template callFormatOption(res, arg, option) {.dirty.} =
   when compiles(format(arg, option, res)):
     format(arg, option, res)
-  else:
+  elif compiles(format(arg, option)):
     res.add format(arg, option)
+  else:
+    format($arg, option, res)
 
 macro fmt*(pattern: string{lit}): untyped =
   ## For a specification of the ``fmt`` macro, see the module level documentation.

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,0 +1,13 @@
+discard """
+    action: "run"
+"""
+
+import strformat
+
+type Obj = object
+
+proc `$`(o: Obj): string = "foobar"
+
+var o: Obj
+doAssert fmt"{o}" == "foobar"
+doAssert fmt"{o:10}" == "foobar    "


### PR DESCRIPTION
Since `fmt"{someObjWithStringifier}"` is accepted, `fmt"{someObjWithStringifier:10}"` should be accepted.