### PR TITLE
Update two links in tutorial to point to correct section

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -41,7 +41,7 @@ Save this code to the file "greetings.nim". Now compile and run it::
 
   nim compile --run greetings.nim
 
-With the ``--run`` `switch <nimc.html#command-line-switches>`_ Nim
+With the ``--run`` `switch <nimc.html#compiler-usage-command-line-switches>`_ Nim
 executes the file automatically after compilation. You can give your program
 command line arguments by appending them after the filename::
 
@@ -58,7 +58,7 @@ To compile a release version use::
 By default the Nim compiler generates a large amount of runtime checks
 aiming for your debugging pleasure. With ``-d:release`` these checks are
 `turned off and optimizations are turned on
-<nimc.html#compile-time-symbols>`_.
+<nimc.html#compiler-usage-compile-time-symbols>`_.
 
 Though it should be pretty obvious what the program does, I will explain the
 syntax: statements which are not indented are executed when the program


### PR DESCRIPTION
Seems like these two class ids on the page were renamed to reflect their hierarchy but the tutorial links weren't pointing to them, this fixes that so the links lead to the right section