### PR TITLE
Custom pragmas in procs bug fix

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -979,6 +979,7 @@ const
   nkIdentKinds* = {nkIdent, nkSym, nkAccQuoted, nkOpenSymChoice,
                    nkClosedSymChoice}
 
+  nkPragmaCallKinds* = {nkExprColonExpr, nkCall, nkCallStrLit}
   nkLiterals* = {nkCharLit..nkTripleStrLit}
   nkLambdaKinds* = {nkLambda, nkDo}
   declarativeDefs* = {nkProcDef, nkFuncDef, nkMethodDef, nkIteratorDef, nkConverterDef}

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -17,7 +17,6 @@ import
 const
   FirstCallConv* = wNimcall
   LastCallConv* = wNoconv
-  nkPragmaCallKinds = {nkExprColonExpr, nkCall, nkCallStrLit}
 
 const
   procPragmas* = {FirstCallConv..LastCallConv, wImportc, wExportc, wNodecl,

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1143,7 +1143,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
   if n == nil or n.kind == nkEmpty: return
   for i in countup(0, n.len-1):
     var it = n.sons[i]
-    var key = if it.kind in nkPragmaCallKinds and it.len > 1: it.sons[0] else: it
+    var key = if it.kind in nkPragmaCallKinds and it.len >= 1: it.sons[0] else: it
     let m = lookupMacro(c, key)
     if m == nil:
       if key.kind == nkIdent and key.ident.id == ord(wDelegator):

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1143,7 +1143,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
   if n == nil or n.kind == nkEmpty: return
   for i in countup(0, n.len-1):
     var it = n.sons[i]
-    var key = if it.kind == nkExprColonExpr: it.sons[0] else: it
+    var key = if it.kind in nkPragmaCallKinds and it.len > 1: it.sons[0] else: it
     let m = lookupMacro(c, key)
     if m == nil:
       if key.kind == nkIdent and key.ident.id == ord(wDelegator):
@@ -1164,10 +1164,12 @@ proc semProcAnnotation(c: PContext, prc: PNode;
     if prc[pragmasPos].kind != nkEmpty and prc[pragmasPos].len == 0:
       prc.sons[pragmasPos] = emptyNode
 
-    if it.kind == nkExprColonExpr:
-      # pass pragma argument to the macro too:
-      x.add(it.sons[1])
+    if it.kind in nkPragmaCallKinds and it.len > 1:
+      # pass pragma arguments to the macro too:
+      for i in 1..<it.len:
+        x.add(it.sons[i])
     x.add(prc)
+    
     # recursion assures that this works for multiple macro annotations too:
     result = semExpr(c, x)
     # since a proc annotation can set pragmas, we process these here again.

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -31,6 +31,11 @@ block: # A bit more advanced case
       d {.alternativeKey("df", 5).}: float
       e {.alternativeKey(V = 5).}: seq[bool] 
 
+
+  proc myproc(x: int, s: string) {.alternativeKey(V = 5), serializationKey"myprocSS".} = 
+    echo x, s
+
+
   var s: MySerializable
 
   const aDefVal = s.a.getCustomPragmaVal(defaultValue)
@@ -41,3 +46,8 @@ block: # A bit more advanced case
 
   const cSerKey = getCustomPragmaVal(s.field.c, serializationKey)
   static: assert(cSerKey == "cc")
+
+  const procSerKey = getCustomPragmaVal(myproc, serializationKey)
+  static: assert(procSerKey == "myprocSS")
+
+  static: assert(hasCustomPragma(myproc, alternativeKey))


### PR DESCRIPTION
Found that pragmas with new call syntax don't work in proc annotations, because I haven't patched `semProcAnnotation` to use `nkPragmaCallKinds`