### PR TITLE
Fix longgc category tests

### DIFF
--- a/tests/realtimeGC/cmain.c
+++ b/tests/realtimeGC/cmain.c
@@ -1,8 +1,8 @@
-
 #ifdef WIN
 #include <windows.h>
 #else
 #include <dlfcn.h>
+#include <unistd.h> /* for sleep(3) */
 #endif
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/realtimeGC/readme.txt
+++ b/tests/realtimeGC/readme.txt
@@ -1,21 +1,21 @@
 Test the realtime GC without linking nimrtl.dll/so.
 
 Note, this is a long running test, default is 35 minutes. To change the
-the run time see RUNTIME in main.nim and main.c.
+the run time see RUNTIME in nmain.nim and cmain.c.
 
-You can build shared.nim, main.nim, and main.c by running make (nix systems)
-or maike.bat (Windows systems). They both assume GCC and that it's in your
-path. Output: shared.(dll/so), camin(.exe), nmain(.exe).
+You can build shared.nim, nmain.nim, and cmain.c by running make (nix systems)
+or make.bat (Windows systems). They both assume GCC and that it's in your
+path. Output: shared.(dll/so), cmain(.exe), nmain(.exe).
 
 To run the test: execute either nmain or cmain in a shell window.
 
-To build buy hand:
+To build by hand:
 
   - build the shared object (shared.nim):
 
-    $ nim c shared.nim
+    $ nim c tests/realtimeGC/shared.nim
 
   - build the client executables:
 
-    $ nim c -o:nmain main.nim
-    $ gcc -o cmain main.c -ldl
+    $ nim c --threads:on tests/realtimeGC/nmain.nim
+    $ gcc -o tests/realtimeGC/cmain tests/realtimeGC/cmain.c -ldl

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -167,9 +167,9 @@ proc gcTests(r: var TResults, cat: Category, options: string) =
 
 proc longGCTests(r: var TResults, cat: Category, options: string) =
   when defined(windows):
-    let cOptions = "gcc -ldl -DWIN"
+    let cOptions = "-ldl -DWIN"
   else:
-    let cOptions = "gcc -ldl"
+    let cOptions = "-ldl"
 
   var c = initResults()
   # According to ioTests, this should compile the file


### PR DESCRIPTION
`testC` command already has "gcc" as command, second "gcc" as option
generates "file not found error", and terminates the compiler with
error code