### PR TITLE
Fix compiler crash on try expression with infix as (Fixes #7116)

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -716,7 +716,8 @@ proc transformExceptBranch(c: PTransf, n: PNode): PTransNode =
   result = transformSons(c, n)
   if n[0].isInfixAs():
     let excTypeNode = n[0][1]
-    let actions = newTransNode(nkStmtList, n[1].info, 2)
+    let stmtKind = if n[1].typ == nil: nkStmtList else: nkStmtListExpr
+    let actions = newTransNode(stmtKind, n[1].info, 2)
     # Generating `let exc = (excType)(getCurrentException())`
     # -> getCurrentException()
     let excCall = PTransNode(callCodegenProc("getCurrentException", ast.emptyNode))

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -716,8 +716,7 @@ proc transformExceptBranch(c: PTransf, n: PNode): PTransNode =
   result = transformSons(c, n)
   if n[0].isInfixAs():
     let excTypeNode = n[0][1]
-    let stmtKind = if n[1].typ == nil: nkStmtList else: nkStmtListExpr
-    let actions = newTransNode(stmtKind, n[1].info, 2)
+    let actions = newTransNode(nkStmtListExpr, n[1], 2)
     # Generating `let exc = (excType)(getCurrentException())`
     # -> getCurrentException()
     let excCall = PTransNode(callCodegenProc("getCurrentException", ast.emptyNode))

--- a/tests/exception/texcas.nim
+++ b/tests/exception/texcas.nim
@@ -21,5 +21,13 @@ proc test2() =
   testTemplate(Exception)
   doAssert(not declared(foobar))
 
+
+proc testTryAsExpr(i: int) =
+  let x = try: i    
+  except ValueError as ex:
+    echo(ex.msg)
+    -1
+
 test[Exception]()
 test2()
+testTryAsExpr(5)


### PR DESCRIPTION
fix for ICE in the `transformExceptBranch`:

Snippet to reproduce a crash
```
let x = try: 10    
  except ValueError as ex:
    echo(ex.msg)
    -1
```