### PR TITLE
Allow static linking with OpenSSL 1.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -212,9 +212,11 @@ for i in 1..15:
   styledEcho bgColor, bg, fgColor, fg, Nim, resetStyle
   int -= 0.01
   fg = intensity(fg, int)
-  
+
 setForegroundColor colRed
 setBackgroundColor colGreen
 styledEcho "Red on Green.", resetStyle
 ```
-
+- If you use ``--dynlibOverride:ssl`` with OpenSSL 1.0.x, you now have to
+  define ``openssl10`` symbol (``-d:openssl10``). By default OpenSSL 1.1.x is
+  assumed.

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -209,32 +209,38 @@ proc TLSv1_method*(): PSSL_METHOD{.cdecl, dynlib: DLLSSLName, importc.}
 
 when compileOption("dynlibOverride", "ssl"):
   # Static linking
-  proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
-  proc SSL_library_init*(): cint {.discardable.} =
-    ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
-    return OPENSSL_init_ssl(0.uint64, 0.uint8)
 
-  proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
-  proc SSLv23_method*(): PSSL_METHOD =
-    TLS_method()
+  when defined(openssl10):
+    proc SSL_library_init*(): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
+    proc SSL_load_error_strings*() {.cdecl, dynlib: DLLSSLName, importc.}
+    proc SSLv23_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+  else:
+    proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
+    proc SSL_library_init*(): cint {.discardable.} =
+      ## Initialize SSL using OPENSSL_init_ssl for OpenSSL >= 1.1.0
+      return OPENSSL_init_ssl(0.uint64, 0.uint8)
+
+    proc TLS_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+    proc SSLv23_method*(): PSSL_METHOD =
+      TLS_method()
+
+    proc OpenSSL_version_num(): culong {.cdecl, dynlib: DLLSSLName, importc.}
+
+    proc getOpenSSLVersion*(): culong =
+      ## Return OpenSSL version as unsigned long
+      OpenSSL_version_num()
+
+    proc SSL_load_error_strings*() =
+      ## Removed from OpenSSL 1.1.0
+      # This proc prevents breaking existing code calling SslLoadErrorStrings
+      # Static linking against OpenSSL < 1.1.0 is not supported
+      discard
+
+  template OpenSSL_add_all_algorithms*() = discard
 
   proc SSLv23_client_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
   proc SSLv2_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
   proc SSLv3_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
-
-  template OpenSSL_add_all_algorithms*() = discard
-
-  proc OpenSSL_version_num(): culong {.cdecl, dynlib: DLLSSLName, importc.}
-
-  proc getOpenSSLVersion*(): culong =
-    ## Return OpenSSL version as unsigned long
-    OpenSSL_version_num()
-
-  proc SSL_load_error_strings*() =
-    ## Removed from OpenSSL 1.1.0
-    # This proc prevents breaking existing code calling SslLoadErrorStrings
-    # Static linking against OpenSSL < 1.1.0 is not supported
-    discard
 
 else:
   # Here we're trying to stay compatible with openssl 1.0.* and 1.1.*. Some


### PR DESCRIPTION
This commit basically returns the code that was removed in
a78d7a31f780c6cf1e421f820d9ed19a5db64ca7, but under 'openssl102'
define symbol. OpenSSL 1.0.2 is still actively maintained, so there is
no point in dropping support of it.