### PR TITLE
Change default ARM compiler name

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -16,12 +16,17 @@ cc = gcc
 hint[LineTooLong]=off
 #hint[XDeclaredButNotUsed]=off
 
-# example of how to setup a cross-compiler:
-arm.linux.gcc.exe = "arm-linux-gcc"
-arm.linux.gcc.linkerexe = "arm-linux-gcc"
+# Examples of how to setup a cross-compiler:
 
+# Cross-compiling for Raspberry Pi.
+# (This compiler is available in gcc-arm-linux-gnueabihf package on Ubuntu)
+arm.linux.gcc.exe = "arm-linux-gnueabihf-gcc"
+arm.linux.gcc.linkerexe = "arm-linux-gnueabihf-gcc"
+
+# For OpenWRT, you will also need to adjust PATH to point to your toolchain. 
 mips.linux.gcc.exe = "mips-openwrt-linux-gcc"
 mips.linux.gcc.linkerexe = "mips-openwrt-linux-gcc"
+
 
 path="$lib/deprecated/core"
 path="$lib/deprecated/pure"


### PR DESCRIPTION
In most distros (Ubuntu, Debian, Arch Linux) the only available Linux ARM toolchain uses arm-linux-gnueabihf- prefix. That's also the correct compiler for cross-compiling code for Raspberry Pi, which is what most people will probably want.