### PR TITLE
Add error message for uninitialized variables with non-concrete types

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -531,6 +531,10 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
 
     # this can only happen for errornous var statements:
     if typ == nil: continue
+    if c.matchedConcept == nil and a.sons[length-1].kind == nkEmpty and
+          typ.isMetaType:
+      localError(a.info, errTIsNotAConcreteType, typ.typeToString)
+
     typeAllowedCheck(a.info, typ, symkind)
     liftTypeBoundOps(c, typ, a.info)
     var tup = skipTypes(typ, {tyGenericInst, tyAlias, tySink})

--- a/tests/errmsgs/t6969.nim
+++ b/tests/errmsgs/t6969.nim
@@ -1,0 +1,6 @@
+discard """
+  line: 6
+  errormsg: "'enum' is not a concrete type."
+"""
+
+var e: enum


### PR DESCRIPTION
I'm new to the compiler, so no idea if this is the right approach.

Example:
```nim
var x: proc # Error: 'proc' is not a concrete type

type C = concept x
var c: C # Error: 'C' is not a concrete type
var c: C = 1 # OK
```

This PR doesn't handle the cases where `ref`, `ptr` or `distinct` are used as the type of an uninitialized var, because it fails during parsing:
```nim
var r: ref # Error: invalid indentation
```

Fixes #6461
Fixes #6946
Fixes #6848
Fixes #6300