### PR TITLE
Fixes #7121

### DIFF
--- a/tests/system/io.nim
+++ b/tests/system/io.nim
@@ -1,5 +1,5 @@
 import
-  unittest, osproc, streams, os
+  unittest, osproc, streams, os, strformat
 const STRING_DATA = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
 const TEST_FILE = "tests/testdata/string.txt"
 
@@ -23,3 +23,25 @@ suite "io":
     test "file":
       check:
         readFile(TEST_FILE) == STRING_DATA
+
+
+proc verifyFileSize(sz: int64) =
+  # issue 7121, large file size (2-4GB and >4Gb)
+  const fn = "tmpfile112358"
+  let size_in_mb = sz div 1_000_000
+
+  when defined(windows):
+    discard execProcess(&"fsutil file createnew {fn} {sz}" )
+  else:
+    discard execProcess(&"dd if=/dev/zero of={fn} bs=1000000 count={size_in_mb}")
+
+  doAssert os.getFileSize(fn) == sz # Verify OS filesize by string
+  
+  var f = open(fn)
+  doAssert f.getFileSize() == sz # Verify file handle filesize
+  f.close()
+
+  os.removeFile(fn)
+
+for s in [50_000_000'i64, 3_000_000_000, 5_000_000_000]:
+  verifyFileSize(s)

--- a/tests/system/io.nim
+++ b/tests/system/io.nim
@@ -43,5 +43,6 @@ proc verifyFileSize(sz: int64) =
 
   os.removeFile(fn)
 
-for s in [50_000_000'i64, 3_000_000_000, 5_000_000_000]:
-  verifyFileSize(s)
+#disable tests for automatic testers
+#for s in [50_000_000'i64, 3_000_000_000, 5_000_000_000]:
+#  verifyFileSize(s)


### PR DESCRIPTION
Fixes #7121: Windows was unable to report file sizes > 2Gb, and incorrectly for >4Gb.

When tested on linux (Arch, x64), clong was of size 8, which allowed ftell to correctly report filesize, but it seems appropriate to switch to ftello anyway.

Replace ftell and fseek with (windows) _ftelli64, _fseeki64 and (posix) ftello, fseeko