### PR TITLE
Fixes #6853

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1124,7 +1124,12 @@ proc typeRelImpl(c: var TCandidate, f, aOrig: PType,
           fRange = prev
       let ff = f.sons[1].skipTypes({tyTypeDesc})
       let aa = a.sons[1].skipTypes({tyTypeDesc})
-      result = typeRel(c, ff, aa)
+      
+      if f.sons[0].kind != tyGenericParam and aa.kind == tyEmpty:
+        result = isGeneric  
+      else:
+        result = typeRel(c, ff, aa)
+     
       if result < isGeneric:
         if nimEnableCovariance and
            trNoCovariance notin flags and

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -38,3 +38,11 @@ var found: array[0..filesToCreate.high, bool]
 
 echo found.len
 
+# make sure empty arrays compile (bug #6853)
+const arr1: array[0, int] = []
+let arr2: array[0, string] = []
+
+doAssert(arr1.len == 0)
+doAssert(arr2.len == 0)
+ 
+

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -38,11 +38,11 @@ var found: array[0..filesToCreate.high, bool]
 
 echo found.len
 
-# make sure empty arrays compile (bug #6853)
+# make sure empty arrays are assignable (bug #6853)
 const arr1: array[0, int] = []
-let arr2: array[0, string] = []
+const arr2 = []
+let arr3: array[0, string] = []
 
 doAssert(arr1.len == 0)
 doAssert(arr2.len == 0)
- 
-
+doAssert(arr3.len == 0)


### PR DESCRIPTION
Fixes empty array don't compile problem. The logic to handle empty array was already present in `tyOpenArray` part of `typeRel`, just taken it from there. 