### PR TITLE
Add procs for serializing tables to JSON

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -143,7 +143,7 @@ runnableExamples:
 
 import
   hashes, tables, strutils, lexbase, streams, unicode, macros, parsejson,
-  typetraits
+  typetraits, options
 
 export
   tables.`$`
@@ -343,6 +343,16 @@ proc `%`*[T](elements: openArray[T]): JsonNode =
   ## Generic constructor for JSON data. Creates a new `JArray JsonNode`
   result = newJArray()
   for elem in elements: result.add(%elem)
+
+proc `%`*[T](table: Table[string, T]|OrderedTable[string, T]): JsonNode =
+  ## Generic constructor for JSON data. Creates a new ``JObject JsonNode``.
+  result = newJObject()
+  for k, v in table: result[k] = %v
+
+proc `%`*[T](opt: Option[T]): JsonNode =
+  ## Generic constructor for JSON data. Creates a new ``JNull JsonNode``
+  ## if ``opt`` is empty, otherwise it delegates to the underlying value.
+  if opt.isSome: %opt.get else: newJNull()
 
 when false:
   # For 'consistency' we could do this, but that only pushes people further


### PR DESCRIPTION
Ideally I think all collection types in the stdlib should be serializable to JSON, but no idea where to define the procs. I doubt it's acceptable to import all collection modules into the JSON module? Either way, the tables module is already imported into the JSON module, and it's an important type for dealing with JSON, so this is a good start.

I noticed that `toCountTable` didn't work because the proc order was wrong, so I fixed that as well.