### PR TITLE
Fix `json.to` for types with generic parameters

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1896,7 +1896,7 @@ macro to*(node: JsonNode, T: typedesc): untyped =
   ##     doAssert data.person.age == 21
   ##     doAssert data.list == @[1, 2, 3, 4]
 
-  let typeNode = getType(T)
+  let typeNode = getTypeInst(T)
   expectKind(typeNode, nnkBracketExpr)
   doAssert(($typeNode[0]).normalize == "typedesc")
 

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -381,3 +381,10 @@ when isMainModule:
     doAssert dataDeser.a == 1
     doAssert dataDeser.f == 6
     doAssert dataDeser.i == 9.9'f32
+  
+  # deserialize directly into a table
+  block:
+    let s = """{"a": 1, "b": 2}"""
+    let t = parseJson(s).to(Table[string, int])
+    doAssert t["a"] == 1
+    doAssert t["b"] == 2


### PR DESCRIPTION
I noticed that `json.to` couldn't convert directly into types with generic parameters, e.g a table. I think this fix is correct.