### PR TITLE
Fix return for js async

### DIFF
--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -71,14 +71,17 @@ type
   PromiseJs* {.importcpp: "Promise".} = ref object
   ## A JavaScript Promise
 
+
 proc replaceReturn(node: var NimNode) =
   var z = 0
   for s in node:
     var son = node[z]
+    let jsResolve = ident("jsResolve")
     if son.kind == nnkReturnStmt:
-      node[z] = nnkReturnStmt.newTree(nnkCall.newTree(ident("jsResolve"), son[0]))
+      let value = if son[0].kind != nnkEmpty: nnkCall.newTree(jsResolve, son[0]) else: jsResolve
+      node[z] = nnkReturnStmt.newTree(value)
     elif son.kind == nnkAsgn and son[0].kind == nnkIdent and $son[0] == "result":
-      node[z] = nnkAsgn.newTree(son[0], nnkCall.newTree(ident("jsResolve"), son[1]))
+      node[z] = nnkAsgn.newTree(son[0], nnkCall.newTree(jsResolve, son[1]))
     else:
       replaceReturn(son)
     inc z
@@ -92,8 +95,7 @@ proc generateJsasync(arg: NimNode): NimNode =
   assert arg.kind == nnkProcDef
   result = arg
   var isVoid = false
-  var jsResolveNode = ident("jsResolve")
-
+  let jsResolve = ident("jsResolve")
   if arg.params[0].kind == nnkEmpty:
     result.params[0] = nnkBracketExpr.newTree(ident("Future"), ident("void"))
     isVoid = true
@@ -112,7 +114,7 @@ proc generateJsasync(arg: NimNode): NimNode =
     var resolve: NimNode
     if isVoid:
       resolve = quote:
-        var `jsResolveNode` {.importcpp: "undefined".}: Future[void]
+        var `jsResolve` {.importcpp: "undefined".}: Future[void]
     else:
       resolve = quote:
         proc jsResolve[T](a: T): Future[T] {.importcpp: "#".}
@@ -124,7 +126,7 @@ proc generateJsasync(arg: NimNode): NimNode =
 
   if len(code) > 0 and isVoid:
     var voidFix = quote:
-      return `jsResolveNode`
+      return `jsResolve`
     result.body.add(voidFix)
 
   result.pragma = quote:

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -17,6 +17,8 @@ proc e: int {.discardable.} =
 
 proc x(e: int): Future[void] {.async.} =
   var s = await y(e)
+  if e > 2:
+    return
   echo s
   e()
 


### PR DESCRIPTION
early `return` without arg in js async functions was resulting in wrong expanded code