### PR TITLE
Add getPassword proc to terminal module

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -781,7 +781,7 @@ proc restoreOnInterrupt() {.noconv.} =
     writeStackTrace()
   quit("SIGINT: Interrupted by Ctrl-C")
 
-proc getPassword*(prompt = ""): string =
+proc getPassword*(prompt = ""): TaintedString =
   ## Reads a password from stdin without showing any characters. Provides
   ## handling of backspaces and unicode. Characters are inserted as hidden text,
   ## which is removed after user input is done or on SIGINT. `prompt` allows

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3216,6 +3216,8 @@ when not defined(JS): #and not defined(nimscript):
     proc setControlCHook*(hook: proc () {.noconv.} not nil)
       ## allows you to override the behaviour of your application when CTRL+C
       ## is pressed. Only one such hook is supported.
+    proc unsetControlCHook*()
+      ## reverts a call to setControlCHook
 
     proc writeStackTrace*() {.tags: [], gcsafe.}
       ## writes the current stack trace to ``stderr``. This is only works

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3216,8 +3216,10 @@ when not defined(JS): #and not defined(nimscript):
     proc setControlCHook*(hook: proc () {.noconv.} not nil)
       ## allows you to override the behaviour of your application when CTRL+C
       ## is pressed. Only one such hook is supported.
-    proc unsetControlCHook*()
-      ## reverts a call to setControlCHook
+
+    when not defined(useNimRtl):
+      proc unsetControlCHook*()
+        ## reverts a call to setControlCHook
 
     proc writeStackTrace*() {.tags: [], gcsafe.}
       ## writes the current stack trace to ``stderr``. This is only works

--- a/lib/system/embedded.nim
+++ b/lib/system/embedded.nim
@@ -41,3 +41,5 @@ proc reraiseException() {.compilerRtl.} =
 proc writeStackTrace() = discard
 
 proc setControlCHook(hook: proc () {.noconv.} not nil) = discard
+
+proc unsetControlCHook() = discard

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -486,3 +486,7 @@ proc setControlCHook(hook: proc () {.noconv.} not nil) =
   # ugly cast, but should work on all architectures:
   type SignalHandler = proc (sign: cint) {.noconv, benign.}
   c_signal(SIGINT, cast[SignalHandler](hook))
+
+proc unsetControlCHook() =
+  # proc to unset a hook set by setControlCHook
+  c_signal(SIGINT, signalHandler)

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -487,6 +487,7 @@ proc setControlCHook(hook: proc () {.noconv.} not nil) =
   type SignalHandler = proc (sign: cint) {.noconv, benign.}
   c_signal(SIGINT, cast[SignalHandler](hook))
 
-proc unsetControlCHook() =
-  # proc to unset a hook set by setControlCHook
-  c_signal(SIGINT, signalHandler)
+when not defined(noSignalHandler) and not defined(useNimRtl):
+  proc unsetControlCHook() =
+    # proc to unset a hook set by setControlCHook
+    c_signal(SIGINT, signalHandler)


### PR DESCRIPTION
Adds a `getPassword` proc to the terminal module, which allows to read passwords from stdin, i.e. read input without showing any characters. Characters are entered as hidden text, which is removed once user input is finished.
It handles backspaces as well as Unicode characters in the input.

I hope I didn't break too many conventions in this. :-) 