### PR TITLE
fix for #7252

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,9 +33,9 @@
   implemented. These are now implemented purely in ``system.nim`` without compiler
   support. There is a new "heterogenous" slice type ``system.HSlice`` that takes 2
   generic parameters which can be ``BackwardsIndex`` indices. ``BackwardsIndex`` is
-  produced by ``system.^``.  Using the ``BackwardsIndex`` on arrays
-  that are not accessed by integer types (for example enums or characters)
-  does no longer work.
+  produced by ``system.^``.
+  This means if you overload ``[]`` or ``[]=`` you need to ensure they also work
+  with ``system.BackwardsIndex`` (if applicable for the accessors).
 - ``mod`` and bitwise ``and`` do not produce ``range`` subtypes anymore. This
   turned out to be more harmful than helpful and the language is simpler
   without this special typing rule.

--- a/changelog.md
+++ b/changelog.md
@@ -33,9 +33,9 @@
   implemented. These are now implemented purely in ``system.nim`` without compiler
   support. There is a new "heterogenous" slice type ``system.HSlice`` that takes 2
   generic parameters which can be ``BackwardsIndex`` indices. ``BackwardsIndex`` is
-  produced by ``system.^``.
-  This means if you overload ``[]`` or ``[]=`` you need to ensure they also work
-  with ``system.BackwardsIndex`` (if applicable for the accessors).
+  produced by ``system.^``.  Using the ``BackwardsIndex`` on arrays
+  that are not accessed by integer types (for example enums or characters)
+  does no longer work.
 - ``mod`` and bitwise ``and`` do not produce ``range`` subtypes anymore. This
   turned out to be more harmful than helpful and the language is simpler
   without this special typing rule.

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -201,14 +201,20 @@ proc write(f: File, b: bool) =
   else: write(f, "false")
 
 proc write(f: File, r: float32) =
-  var buffer: array[64, char]
-  discard writeFloatToBuffer(buffer, r)
-  if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
+  when defined(nimscript):
+    write(f, $r)
+  else:
+    var buffer: array[64, char]
+    discard writeFloatToBuffer(buffer, r)
+    if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
 
 proc write(f: File, r: BiggestFloat) =
-  var buffer: array[64, char]
-  discard writeFloatToBuffer(buffer, r)
-  if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
+  when defined(nimscript):
+    write(f, $r)
+  else:
+    var buffer: array[64, char]
+    discard writeFloatToBuffer(buffer, r)
+    if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
 
 proc write(f: File, c: char) = discard c_putc(cint(c), f)
 proc write(f: File, a: varargs[string, `$`]) =

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -202,12 +202,12 @@ proc write(f: File, b: bool) =
 
 proc write(f: File, r: float32) =
   var buffer: array[64, char]
-  discard writeFloatTobuffer(buffer, r);
+  discard writeFloatToBuffer(buffer, r)
   if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
 
 proc write(f: File, r: BiggestFloat) =
   var buffer: array[64, char]
-  discard writeFloatTobuffer(buffer, r);
+  discard writeFloatToBuffer(buffer, r)
   if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
 
 proc write(f: File, c: char) = discard c_putc(cint(c), f)

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -199,10 +199,16 @@ proc write(f: File, i: BiggestInt) =
 proc write(f: File, b: bool) =
   if b: write(f, "true")
   else: write(f, "false")
+
 proc write(f: File, r: float32) =
-  if c_fprintf(f, "%g", r) < 0: checkErr(f)
+  var buffer: array[64, char]
+  discard writeFloatTobuffer(buffer, r);
+  if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
+
 proc write(f: File, r: BiggestFloat) =
-  if c_fprintf(f, "%g", r) < 0: checkErr(f)
+  var buffer: array[64, char]
+  discard writeFloatTobuffer(buffer, r);
+  if c_fprintf(f, "%s", buffer[0].addr) < 0: checkErr(f)
 
 proc write(f: File, c: char) = discard c_putc(cint(c), f)
 proc write(f: File, a: varargs[string, `$`]) =

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -351,14 +351,20 @@ proc writeFloatToBuffer(buf: var array[64, char]; value: BiggestFloat): int =
   else:
     return n
 
+proc add*(result: var string, buf: cstring; buflen: int) =
+  # no nimvm support needed, so it doesn't need to be fast here either
+  let oldLen = result.len
+  let newLen = oldLen + buflen
+  result.setLen newLen
+  copyMem(result[oldLen].addr, buf, buflen)
+
 proc add*(result: var string; x: BiggestFloat) =
   when nimvm:
     result.add $x
   else:
     var buffer: array[64, char]
-    let n = result.len
-    result.setLen n+writeFloatTobuffer(buffer, x)
-    c_sprintf(result[n].addr, buffer[0].addr)
+    let n = writeFloatToBuffer(buffer, x)
+    result.add(cstring(buffer[0].addr), n)
 
 proc nimFloatToStr(f: float): string {.compilerproc.} =
   result = newStringOfCap(8)

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -327,27 +327,49 @@ proc nimIntToStr(x: int): string {.compilerRtl.} =
 
 
 proc writeFloatToBuffer(buf: var array[64, char]; value: BiggestFloat): int =
-  ## returns the amount of bytes written to buffer not counting the '\0' terminating character.
+  ## This is the implementation to format floats in the Nim
+  ## programming language. The specific format for floating point
+  ## numbers is not specified in the Nim programming language and
+  ## might change slightly in the future, but at least wherever you
+  ## format a float, it should be consistent.
+  ##
+  ## returns the amount of bytes written to `buf` not counting the
+  ## terminating '\0' character.
+  ##
+  ## * `buf` - A buffer to write into. The buffer does not need to be
+  ##           initialized and it will be overridden.
+  ##
+
+  # the output is some representation of "nan". Make it uniform on
+  # all system and override the it with "nan"
+
+  # On Windows nice numbers like '1.#INF', '-1.#INF' or '1.#NAN' of
+  # '-1.#IND' are produced. We want to get rid of these here and
+  # provide a uniform representation.
+  if value != value: #is nan
+    return c_sprintf(buf[0].addr, "nan")
+  if value == Inf:
+    return c_sprintf(buf[0].addr, "inf")
+  if value == NegInf:
+    return c_sprintf(buf[0].addr, "-inf")
+
   var n: int = c_sprintf(buf[0].addr, "%.16g", value)
   var hasDot = false
   for i in 0..n-1:
+    # `sprintf` looks up the environment variable "LC_NUMERIC" for the
+    # decimal separator and on some systems it will use a comma as a
+    # decimal separator. We don't want to have such a behavior in the
+    # Nim programming language.
     if buf[i] == ',':
       buf[i] = '.'
       hasDot = true
     elif buf[i] in {'a'..'z', 'A'..'Z', '.'}:
+      # When the output is for example "1e10", we also don't want to append a ".0" postfix.
       hasDot = true
+
   if not hasDot:
+    # append ".0", to convert "0" to "0.0", "1" to "1.0", etc.
     return n + c_sprintf(buf[n].addr, ".0")
-  # On Windows nice numbers like '1.#INF', '-1.#INF' or '1.#NAN'
-  # of '-1.#IND' are produced.
-  # We want to get rid of these here:
-  if buf[n-1] in {'n', 'N', 'D', 'd'}:
-    return c_sprintf(buf[0].addr, "nan")
-  elif buf[n-1] == 'F':
-    if buf[0] == '-':
-      return c_sprintf(buf[0].addr, "-inf")
-    else:
-      return c_sprintf(buf[0].addr, "inf")
   else:
     return n
 

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -342,12 +342,12 @@ proc writeFloatToBuffer(buf: var array[64, char]; value: BiggestFloat): int =
   # of '-1.#IND' are produced.
   # We want to get rid of these here:
   if buf[n-1] in {'n', 'N', 'D', 'd'}:
-    return c_sprintf(buf[0].addr, "nan");
+    return c_sprintf(buf[0].addr, "nan")
   elif buf[n-1] == 'F':
     if buf[0] == '-':
-      return c_sprintf(buf[0].addr, "-inf");
+      return c_sprintf(buf[0].addr, "-inf")
     else:
-      return c_sprintf(buf[0].addr, "inf");
+      return c_sprintf(buf[0].addr, "inf")
   else:
     return n
 


### PR DESCRIPTION
```nim
let v32:float32 = 1.00001
let v64:float64 = 1.0000001
echo v32
echo v64
write(stdout, v32)
echo ""
write(stdout, v64)
```

output:
```
1.000010013580322
1.0000001
1.000010013580322
1.0000001
```

At least it is consistent now.
