### PR TITLE
[Windows] Fix command line arguments limit using gcc

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -778,7 +778,6 @@ proc callCCompiler*(projectfile: string) =
       add(objfiles, ' ')
       add(objfiles, quoteShell(
           addFileExt(objFile, CC[cCompiler].objExt)))
-
     for x in toCompile:
       let objFile = if noAbsolutePaths(): x.obj.extractFilename else: x.obj
       add(objfiles, ' ')
@@ -786,7 +785,7 @@ proc callCCompiler*(projectfile: string) =
 
     linkCmd = getLinkCmd(projectfile, objfiles)
     if optCompileOnly notin gGlobalOptions:
-        execLinkCmd(linkCmd)
+      execLinkCmd(linkCmd)
   else:
     linkCmd = ""
   if optGenScript in gGlobalOptions:

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -775,7 +775,7 @@ proc callCCompiler*(projectfile: string) =
     linkCmd = getLinkCmd(projectfile, objfiles)
     if optCompileOnly notin gGlobalOptions:
       when defined(windows):
-        let isCmdFileUsed = cCompiler == ccGcc and linkCmd.len > 32_767
+        let isCmdFileUsed = cCompiler == ccGcc and linkCmd.len >= 32_767
         let cmdFile = projectfile & "_linker_cmd.txt"
         if isCmdFileUsed:
           let gccExeIdx = linkCmd.find("-o")


### PR DESCRIPTION
Use `gcc @file` feature at linker phase