### PR TITLE
move `readPasswordFromStdin` from rdstdin to terminal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -263,3 +263,6 @@ bar()
 import std / [strutils, os, osproc]
 import someNimblePackage / [strutils, os]
 ```
+
+- The ``readPasswordFromStdin`` proc has been moved from the ``rdstdin``
+  to the ``terminal`` module, thus it does not depend on linenoise anymore.

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -73,32 +73,6 @@ when defined(Windows):
          discard readConsoleInputW(hStdin, irInputRecord, 1, dwEventsRead)
          return result
 
-  from unicode import toUTF8, Rune, runeLenAt
-
-  proc readPasswordFromStdin*(prompt: string, password: var TaintedString):
-                              bool {.tags: [ReadIOEffect, WriteIOEffect].} =
-    ## Reads a `password` from stdin without printing it. `password` must not
-    ## be ``nil``! Returns ``false`` if the end of the file has been reached,
-    ## ``true`` otherwise.
-    password.setLen(0)
-    stdout.write(prompt)
-    while true:
-      let c = getch()
-      case c.char
-      of '\r', chr(0xA):
-        break
-      of '\b':
-        # ensure we delete the whole UTF-8 character:
-        var i = 0
-        var x = 1
-        while i < password.len:
-          x = runeLenAt(password, i)
-          inc i, x
-        password.setLen(max(password.len - x, 0))
-      else:
-        password.add(toUTF8(c.Rune))
-    stdout.write "\n"
-
 else:
   import linenoise, termios
 
@@ -124,21 +98,3 @@ else:
     linenoise.free(buffer)
     result = true
 
-  proc readPasswordFromStdin*(prompt: string, password: var TaintedString):
-                              bool {.tags: [ReadIOEffect, WriteIOEffect].} =
-    password.setLen(0)
-    let fd = stdin.getFileHandle()
-    var cur, old: Termios
-    discard fd.tcgetattr(cur.addr)
-    old = cur
-    cur.c_lflag = cur.c_lflag and not Cflag(ECHO)
-    discard fd.tcsetattr(TCSADRAIN, cur.addr)
-    stdout.write prompt
-    result = stdin.readLine(password)
-    stdout.write "\n"
-    discard fd.tcsetattr(TCSADRAIN, old.addr)
-
-proc readPasswordFromStdin*(prompt: string): TaintedString =
-  ## Reads a password from stdin without printing it.
-  result = TaintedString("")
-  discard readPasswordFromStdin(prompt, result)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -747,7 +747,7 @@ when defined(windows):
     ## Reads a `password` from stdin without printing it. `password` must not
     ## be ``nil``! Returns ``false`` if the end of the file has been reached,
     ## ``true`` otherwise.
-    password.setLen(0)
+    password.string.setLen(0)
     stdout.write(prompt)
     while true:
       let c = getch()
@@ -759,11 +759,11 @@ when defined(windows):
         var i = 0
         var x = 1
         while i < password.len:
-          x = runeLenAt(password, i)
+          x = runeLenAt(password.string, i)
           inc i, x
-        password.setLen(max(password.len - x, 0))
+        password.string.setLen(max(password.len - x, 0))
       else:
-        password.add(toUTF8(c.Rune))
+        password.string.add(toUTF8(c.Rune))
     stdout.write "\n"
 
 else:
@@ -771,7 +771,7 @@ else:
 
   proc readPasswordFromStdin*(prompt: string, password: var TaintedString):
                             bool {.tags: [ReadIOEffect, WriteIOEffect].} =
-    password.setLen(0)
+    password.string.setLen(0)
     let fd = stdin.getFileHandle()
     var cur, old: Termios
     discard fd.tcgetattr(cur.addr)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -783,7 +783,7 @@ else:
     stdout.write "\n"
     discard fd.tcsetattr(TCSADRAIN, old.addr)
 
-proc readPasswordFromStdin*(prompt: string): TaintedString =
+proc readPasswordFromStdin*(prompt = "password: "): TaintedString =
   ## Reads a password from stdin without printing it.
   result = TaintedString("")
   discard readPasswordFromStdin(prompt, result)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -739,6 +739,56 @@ proc getch*(): char =
     result = stdin.readChar()
     discard fd.tcsetattr(TCSADRAIN, addr oldMode)
 
+when defined(windows):
+  from unicode import toUTF8, Rune, runeLenAt
+
+  proc readPasswordFromStdin*(prompt: string, password: var TaintedString):
+                              bool {.tags: [ReadIOEffect, WriteIOEffect].} =
+    ## Reads a `password` from stdin without printing it. `password` must not
+    ## be ``nil``! Returns ``false`` if the end of the file has been reached,
+    ## ``true`` otherwise.
+    password.setLen(0)
+    stdout.write(prompt)
+    while true:
+      let c = getch()
+      case c.char
+      of '\r', chr(0xA):
+        break
+      of '\b':
+        # ensure we delete the whole UTF-8 character:
+        var i = 0
+        var x = 1
+        while i < password.len:
+          x = runeLenAt(password, i)
+          inc i, x
+        password.setLen(max(password.len - x, 0))
+      else:
+        password.add(toUTF8(c.Rune))
+    stdout.write "\n"
+
+else:
+  import termios
+
+  proc readPasswordFromStdin*(prompt: string, password: var TaintedString):
+                            bool {.tags: [ReadIOEffect, WriteIOEffect].} =
+    password.setLen(0)
+    let fd = stdin.getFileHandle()
+    var cur, old: Termios
+    discard fd.tcgetattr(cur.addr)
+    old = cur
+    cur.c_lflag = cur.c_lflag and not Cflag(ECHO)
+    discard fd.tcsetattr(TCSADRAIN, cur.addr)
+    stdout.write prompt
+    result = stdin.readLine(password)
+    stdout.write "\n"
+    discard fd.tcsetattr(TCSADRAIN, old.addr)
+
+proc readPasswordFromStdin*(prompt: string): TaintedString =
+  ## Reads a password from stdin without printing it.
+  result = TaintedString("")
+  discard readPasswordFromStdin(prompt, result)
+
+
 # Wrappers assuming output to stdout:
 template hideCursor*() = hideCursor(stdout)
 template showCursor*() = showCursor(stdout)


### PR DESCRIPTION
Moves the `readPasswordFromStdin` proc from the `rdstdin` to the `terminal` module. This way the proc is not dependent on `linenoise` anymore, which it does not use anyways.

I had to convert the `password` variable (`TaintedString` argument of the proc) manually to a string, before `setLen` is called. Otherwise the call fails in taint mode. 