### PR TITLE
Resolves #5588: adds openFileStream proc that throws on failure

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -447,9 +447,19 @@ when not defined(js):
     ## creates a new stream from the file named `filename` with the mode `mode`.
     ## If the file cannot be opened, nil is returned. See the `system
     ## <system.html>`_ module for a list of available FileMode enums.
+    ## **This function returns nil in case of failure. To prevent unexpected
+    ## behavior and ensure proper error handling, use openFileStream instead.**
     var f: File
     if open(f, filename, mode, bufSize): result = newFileStream(f)
 
+  proc openFileStream*(filename: string, mode: FileMode = fmRead, bufSize: int = -1): FileStream =
+    ## creates a new stream from the file named `filename` with the mode `mode`.
+    ## If the file cannot be opened, an IO exception is raised.
+    var f: File
+    if open(f, filename, mode, bufSize):
+      return newFileStream(f)
+    else:
+      raise newEIO("cannot open file")
 
 when true:
   discard

--- a/tests/stdlib/tstreams3.nim
+++ b/tests/stdlib/tstreams3.nim
@@ -1,0 +1,10 @@
+discard """
+  file: "tstreams3.nim"
+  output: "threw exception"
+"""
+import streams
+
+try:
+  var fs = openFileStream("shouldneverexist.txt")
+except IoError:
+  echo "threw exception"


### PR DESCRIPTION
This is the ``openFileStream`` proc proposed in the RFC, along with a new test to go with it. As mentioned on the issue discussion, I did not yet deprecate ``newFileStream()``, but I did update the docs to warn users about the possibility of ``nil``.