### PR TITLE
putEnv for nimscript. Fixes 7283

### DIFF
--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -83,6 +83,8 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
     setResult(a, os.getEnv(a.getString 0, a.getString 1))
   cbconf existsEnv:
     setResult(a, os.existsEnv(a.getString 0))
+  cbconf putEnv:
+    os.putEnv(a.getString 0, a.getString 1)
   cbconf dirExists:
     setResult(a, os.dirExists(a.getString 0))
   cbconf fileExists:

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -114,6 +114,10 @@ proc existsEnv*(key: string): bool {.tags: [ReadIOEffect].} =
   ## Checks for the existence of an environment variable named `key`.
   builtin
 
+proc putEnv*(key, val: string) {.tags: [WriteIOEffect].} =
+  ## Sets the value of the environment variable named key to val.
+  builtin
+  
 proc fileExists*(filename: string): bool {.tags: [ReadIOEffect].} =
   ## Checks if the file exists.
   builtin

--- a/tests/newconfig/tfoo.nims
+++ b/tests/newconfig/tfoo.nims
@@ -23,4 +23,11 @@ task default, "default target":
   setCommand "c"
 
 # bug #6327
-discard existsEnv("dummy")
+doAssert(existsEnv("dummy") == false)
+
+# issue #7283
+putEnv("dummy", "myval")
+doAssert(existsEnv("dummy") == true)
+doAssert(getEnv("dummy") == "myval")
+
+


### PR DESCRIPTION
I have described our use cases in #7283.
We do need ``putEnv`` in nimscript to migrate from config files.
