### PR TITLE
Stop replacing all pragmas of a function with asyncjs

### DIFF
--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -129,8 +129,13 @@ proc generateJsasync(arg: NimNode): NimNode =
       return `jsResolve`
     result.body.add(voidFix)
 
-  result.pragma = quote:
+  let asyncPragma = quote:
     {.codegenDecl: "async function $2($3)".}
+  if arg.pragma.kind == nnkEmpty:
+    result.pragma = asyncPragma
+  else:
+    result.pragma = arg.pragma
+    result.pragma.add(asyncPragma[0])  
 
 
 macro async*(arg: untyped): untyped =

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -131,12 +131,8 @@ proc generateJsasync(arg: NimNode): NimNode =
 
   let asyncPragma = quote:
     {.codegenDecl: "async function $2($3)".}
-  if arg.pragma.kind == nnkEmpty:
-    result.pragma = asyncPragma
-  else:
-    result.pragma = arg.pragma
-    result.pragma.add(asyncPragma[0])  
 
+  result.addPragma(asyncPragma[0])
 
 macro async*(arg: untyped): untyped =
   ## Macro which converts normal procedures into

--- a/tests/js/tasync_pragma.nim
+++ b/tests/js/tasync_pragma.nim
@@ -1,0 +1,27 @@
+discard """
+  output: '''
+0
+t
+'''
+"""
+
+import asyncjs, macros
+
+macro f*(a: untyped): untyped =
+  assert a.kind == nnkProcDef
+  result = nnkProcDef.newTree(a.name, a[1], a[2], a.params, a.pragma, a[5], nnkStmtList.newTree())
+  let call = quote:
+    echo 0
+  result.body.add(call)
+  for child in a.body:
+    result.body.add(child)
+  echo result.body.repr
+
+proc t* {.async, f.} =
+  echo "t"
+
+proc t0* {.async.} =
+  await t()
+
+discard t0()
+

--- a/tests/js/tasync_pragma.nim
+++ b/tests/js/tasync_pragma.nim
@@ -15,7 +15,7 @@ macro f*(a: untyped): untyped =
   result.body.add(call)
   for child in a.body:
     result.body.add(child)
-  echo result.body.repr
+  #echo result.body.repr
 
 proc t* {.async, f.} =
   echo "t"


### PR DESCRIPTION
Uh, that was nasty, I should have seen it earlier.

Maybe we need some kind of `addPragma` helpers in macros, as it's seems easy to make such a mistake again?