### PR TITLE
Performance improvements for sequtils. Fixes #7295

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -398,6 +398,7 @@ template filterIt*(s, pred: untyped): untyped =
   var result = newSeq[type(s[0])]()
   for it {.inject.} in items(s):
     if pred: result.add(it)
+  shallow(result)
   result
 
 template keepItIf*(varSeq: seq, pred: untyped) =
@@ -501,12 +502,14 @@ template toSeq*(iter: untyped): untyped =
     var result = newSeq[type(iter)](iter.len)
     for x in iter:
       result[i] = x
-      inc i
+      inc it
+    shallow(result)
     result
   else:
     var result: seq[type(iter)] = @[]
     for x in iter:
       result.add(x)
+    shallow(result)
     result
 
 template foldl*(sequence, operation: untyped): untyped =
@@ -630,9 +633,10 @@ template mapIt*(s, typ, op: untyped): untyped =
   ##   assert strings == @["4", "8", "12", "16"]
   ## **Deprecated since version 0.12.0:** Use the ``mapIt(seq1, op)``
   ##   template instead.
-  var result: seq[typ] = @[]
+  var result = newSeqOfCap[typ](s.len)
   for it {.inject.} in items(s):
     result.add(op)
+  shallow(result)
   result
 
 
@@ -662,9 +666,10 @@ template mapIt*(s, op: untyped): untyped =
       result[i] = op
       i += 1
   else:
-    result = @[]
+    newSeqOfCap(result, s.len)
     for it {.inject.} in s:
       result.add(op)
+  shallow(result)
   result
 
 template applyIt*(varSeq, op: untyped) =
@@ -702,6 +707,7 @@ template newSeqWith*(len: int, init: untyped): untyped =
   var result = newSeq[type(init)](len)
   for i in 0 ..< len:
     result[i] = init
+  shallow(result)
   result
 
 proc mapLitsImpl(constructor: NimNode; op: NimNode; nested: bool;

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -502,7 +502,7 @@ template toSeq*(iter: untyped): untyped =
     var result = newSeq[type(iter)](iter.len)
     for x in iter:
       result[i] = x
-      inc it
+      inc i
     shallow(result)
     result
   else:


### PR DESCRIPTION
newSeqWith is slow due to extra copy intoduced by template's result variable. Adding shallow() to the result variable bypasses the problem.
 With the improvement in this PR, I get the following timings for the code snippet in the issue description:
```
newSeqWith: 6.849931 sec
fill:       6.800398 sec
```
I have made similar improvements to the rest of templates in the sequtils, not just newSeqWith
