### PR TITLE
Add ability for users to elide ':' or '=' when CLI authors pass a

### DIFF
--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -11,11 +11,23 @@
 ## It supports one convenience iterator over all command line options and some
 ## lower-level features.
 ##
-## Supported syntax:
+## Supported syntax with default empty ``shortNoArg``/``longNoArg``:
 ##
 ## 1. short options - ``-abcd``, where a, b, c, d are names
 ## 2. long option - ``--foo:bar``, ``--foo=bar`` or ``--foo``
 ## 3. argument - everything else
+##
+## When ``shortNoArg``/``longNoArg`` are non-empty then the ':' and '=' above
+## are still accepted, but become optional.  Note that these option key sets
+## must be updated along with the set of option keys taking no value, but
+## option keys which take values need no special updates.
+##
+## When option values begin with ':' or '=' they need to be doubled up (as in
+## ``--delim::``) or alternated (as in ``--delim=:``).
+##
+## The common ``--`` non-option argument delimiter appears as an empty string
+## long option key.  ``OptParser.cmd``, ``OptParser.pos``, and
+## ``os.parseCmdLine`` may be used to complete parsing in that case.
 
 {.push debugger: off.}
 

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -96,10 +96,11 @@ when declared(os.paramCount):
                       longNoVal: seq[string] = @[]): OptParser =
     ## inits the option parser. If ``cmdline == ""``, the real command line
     ## (as provided by the ``OS`` module) is taken.  If ``shortNoVal`` is
-    ## provided command users need not delimit short option keys and values
-    ## with a ':' or '='.  If ``longNoVal`` is provided command users need not
-    ## delimit long option keys and values with a ':' or '=' (though they still
-    ## need a space).
+    ## provided command users do not need to delimit short option keys and
+    ## values with a ':' or '='.  If ``longNoVal`` is provided command users do
+    ## not need to delimit long option keys and values with a ':' or '='
+    ## (though they still need at least a space).  In both cases, ':' or '='
+    ## may still be used if desired.  They just become optional.
     result.pos = 0
     result.inShortState = false
     result.shortNoVal = shortNoVal

--- a/tests/misc/tparseopt.nim
+++ b/tests/misc/tparseopt.nim
@@ -9,6 +9,17 @@ kind: cmdLongOption	key:val  --  left:
 kind: cmdLongOption	key:val  --  debug:3
 kind: cmdShortOption	key:val  --  l:4
 kind: cmdShortOption	key:val  --  r:2
+parseoptNoVal
+kind: cmdLongOption	key:val  --  left:
+kind: cmdLongOption	key:val  --  debug:3
+kind: cmdShortOption	key:val  --  l:
+kind: cmdShortOption	key:val  --  r:2
+kind: cmdLongOption	key:val  --  debug:2
+kind: cmdLongOption	key:val  --  debug:1
+kind: cmdShortOption	key:val  --  r:1
+kind: cmdShortOption	key:val  --  r:0
+kind: cmdShortOption	key:val  --  l:
+kind: cmdShortOption	key:val  --  r:4
 parseopt2
 first round
 kind: cmdLongOption	key:val  --  left:
@@ -36,6 +47,15 @@ block:
       break
     # reset getopt iterator and check arguments are returned correctly.
     echo "second round"
+    for kind, key, val in parseopt.getopt(p):
+      echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
+
+block:
+    echo "parseoptNoVal"
+    # test NoVal mode with custom cmdline arguments
+    var argv = "--left --debug:3 -l -r:2 --debug 2 --debug=1 -r1 -r=0 -lr4"
+    var p = parseopt.initOptParser(argv,
+                                   shortNoVal = {'l'}, longNoVal = @["left"])
     for kind, key, val in parseopt.getopt(p):
       echo "kind: ", kind, "\tkey:val  --  ", key, ":", val
 


### PR DESCRIPTION
non-empty partial symbol table.  Behavior should be identical to the
old behavior if empty partial symbol tables are passed.  "Partialness"
of the symbol table refers to the fact that one need only specify
option keys that are toggles/booleans/do not take arguments, hence
the "NoArg" suffixes in shortNoArg and longNoArg.

commandLineParams() returns seq[TaintedString], so use that consistently
in getopt() and initOptParser(seq[TaintedString]) dropping the taint at
the quoting stage just as with the paramStr() logic.

Fix capitalization inconsistency of cmdLongOption.

Export OptParser.cmd and OptParser.pos so that, at least *in principle*,
users of this API can handle "--" option processing termination or some
"git-like" sub-command stop word with a separate option sub-syntax.
{ Eg., ``case p.key of "": echo "trailing non-option args: ", p.cmd[p.pos..^1]``
or ``case p.kind of cmdArgument: if p.key == "mysubcmd": ...``. }  Really,
searching for the last delimiter before p.pos is probably needed to frame
the trailing text..Not the nicest API, but still possible with effort.

This is a follow up to https://forum.nim-lang.org/t/3592 where it sounded
like it would be welcome.