### PR TITLE
Fix background-color in nimdoc.cfg

### DIFF
--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -229,7 +229,7 @@ body {
   line-height: 20px;
   color: #444;
   letter-spacing: 0.15px;
-  background-color: rgba(252, 248, 244, 0.45); }
+  background-color: #FDFBFA; }
 
 /* Skeleton grid */
 .container {


### PR DESCRIPTION
Don't assume, that the default background-color is white.
My default background-color is dark, which makes the documentation hardly readable: https://i.imgur.com/xN0UjWz.png
The reason is the transparency of the existing color (rgba(252, 248, 244, 0.45);) 
Fixed by removing the transparency.