### PR TITLE
reuse default ident in opcNNewNimNode (performance regression)

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -53,6 +53,8 @@ type
                               # XXX 'break' should perform cleanup actions
                               # What does the C backend do for it?
 
+let defaultIdent = getIdent""
+
 proc stackTraceAux(c: PCtx; x: PStackFrame; pc: int; recursionLimit=100) =
   if x != nil:
     if recursionLimit == 0:
@@ -1490,7 +1492,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           c.debug[pc])
       x.flags.incl nfIsRef
       # prevent crashes in the compiler resulting from wrong macros:
-      if x.kind == nkIdent: x.ident = getIdent""
+      if x.kind == nkIdent: x.ident = defaultIdent
       regs[ra].node = x
     of opcNCopyNimNode:
       decodeB(rkNode)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -53,8 +53,6 @@ type
                               # XXX 'break' should perform cleanup actions
                               # What does the C backend do for it?
 
-let defaultIdent = getIdent""
-
 proc stackTraceAux(c: PCtx; x: PStackFrame; pc: int; recursionLimit=100) =
   if x != nil:
     if recursionLimit == 0:
@@ -1492,7 +1490,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           c.debug[pc])
       x.flags.incl nfIsRef
       # prevent crashes in the compiler resulting from wrong macros:
-      if x.kind == nkIdent: x.ident = defaultIdent
+      if x.kind == nkIdent: x.ident = c.cache.emptyIdent
       regs[ra].node = x
     of opcNCopyNimNode:
       decodeB(rkNode)


### PR DESCRIPTION
Compile times for codes creating lots of idents grew very large due to repeatedly creating an ident with the same string.  Since it seems this isn't intended to be used in correct macros, it is most efficient to just reuse the same ident each time.