### PR TITLE
Codegen: use type forward declarations more aggresively. Fixes #7339

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1364,6 +1364,7 @@ proc genOf(p: BProc, x: PNode, typ: PType, d: var TLoc) =
     if t.kind notin {tyVar, tyLent} or not p.module.compileToCpp:
       r = rfmt(nil, "(*$1)", r)
     t = skipTypes(t.lastSon, typedescInst)
+  discard getTypeDesc(p.module, t)
   if not p.module.compileToCpp:
     while t.kind == tyObject and t.sons[0] != nil:
       add(r, ~".Sup")
@@ -2061,6 +2062,7 @@ proc upConv(p: BProc, n: PNode, d: var TLoc) =
 
 proc downConv(p: BProc, n: PNode, d: var TLoc) =
   if p.module.compileToCpp:
+    discard getTypeDesc(p.module, skipTypes(n[0].typ, abstractPtrs))
     expr(p, n.sons[0], d)     # downcast does C++ for us
   else:
     var dest = skipTypes(n.typ, abstractPtrs)
@@ -2069,6 +2071,7 @@ proc downConv(p: BProc, n: PNode, d: var TLoc) =
     while arg.kind == nkObjDownConv: arg = arg.sons[0]
 
     var src = skipTypes(arg.typ, abstractPtrs)
+    discard getTypeDesc(p.module, src)
     var a: TLoc
     initLocExpr(p, arg, a)
     var r = rdLoc(a)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -368,6 +368,8 @@ proc getTypeForward(m: BModule, typ: PType; sig: SigHash): Rope =
     if not isImportedType(concrete):
       addf(m.s[cfsForwardTypes], getForwardStructFormat(m),
           [structOrUnion(typ), result])
+    else:
+      pushType(m, concrete)
     doAssert m.forwTypeCache[sig] == result
   else: internalError("getTypeForward(" & $typ.kind & ')')
 
@@ -665,7 +667,6 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
         let name = getTypeForward(m, et, hashType et)
         result = name & star
         m.typeCache[sig] = result
-        pushType(m, et)
     of tySequence:
       # no restriction! We have a forward declaration for structs
       let name = getTypeForward(m, et, hashType et)

--- a/tests/ccgbugs/mymodule.nim
+++ b/tests/ccgbugs/mymodule.nim
@@ -1,0 +1,12 @@
+type
+  MyRefObject* = ref object
+    s: string
+
+
+proc newMyRefObject*(s: string): MyRefObject =
+  new(result)
+  result.s = s
+  
+proc `$`*(o: MyRefObject): string =
+  o.s
+  

--- a/tests/ccgbugs/tforward_decl_only.nim
+++ b/tests/ccgbugs/tforward_decl_only.nim
@@ -3,6 +3,7 @@ ccodecheck: "\\i !@('struct tyObject_MyRefObject'[0-z]+' {')"
 output: "hello"
 """
 
+# issue #7339 
 # Test that MyRefObject is only forward declared as it used only by reference
 
 import mymodule

--- a/tests/ccgbugs/tforward_decl_only.nim
+++ b/tests/ccgbugs/tforward_decl_only.nim
@@ -1,0 +1,14 @@
+discard """
+ccodecheck: "\\i !@('struct tyObject_MyRefObject'[0-z]+' {')"
+output: "hello"
+"""
+
+# Test that MyRefObject is only forward declared as it used only by reference
+
+import mymodule
+type AnotherType = object
+  f: MyRefObject 
+
+let x = AnotherType(f: newMyRefObject("hello"))
+echo $x.f
+


### PR DESCRIPTION
I have described the use case in #7339

Summary of changes:
- ``getTypeDescAux`` no longer pushes type to be defined at finalization step if type's ptr/ref encountered
- All operations dereferencing the pointer/reference now need to call getTypeDesc for the derefed type, however it is already done in most of cases. I have found only 2 extra places where adding ``getTypeDesc`` was required: ``genOf`` and ``downConv``