### PR TITLE
Quote do now works with result in block

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1868,7 +1868,7 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
   var tmpl = semTemplateDef(c, dummyTemplate)
   quotes[0] = tmpl[namePos]
   # This adds a call to newIdentNode("result") as the first argument to the template call
-  quotes[1] = newNode(nkCall, n.info, @[newIdentNode(getIdent("newIdentNode"), n.info), newStrNode(nkStrLit, "result")])
+  quotes[1] = newNode(nkCall, n.info, @[newIdentNode(getIdent(c.cache, "newIdentNode"), n.info), newStrNode(nkStrLit, "result")])
   result = newNode(nkCall, n.info, @[
      createMagic(c.graph, "getAst", mExpandToAst).newSymNode,
     newNode(nkCall, n.info, quotes)])

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1825,8 +1825,7 @@ proc processQuotations(c: PContext; n: var PNode, op: string,
     returnQuote n[0]
   elif n.kind == nkIdent:
     if n.ident.s == "result":
-      # TODO: Create a non-colliding symbol
-      n = newIdentNode(getIdent("res"), n.info)
+      n = ids[0]
 
   for i in 0 ..< n.safeLen:
     processQuotations(c, n.sons[i], op, quotes, ids)
@@ -1848,9 +1847,8 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
   if quotedBlock.kind != nkStmtList:
     localError(c.config, n.info, errXExpected, "block")
 
-  # TODO: Create a non-colliding symbol
   # This adds a default first field to pass the result symbol
-  ids[0] = newIdentNode(getIdent("res"), n.info)
+  ids[0] = newAnonSym(c, skParam, n.info).newSymNode
   processQuotations(c, quotedBlock, op, quotes, ids)
 
   var dummyTemplate = newProcNode(

--- a/tests/macros/tquotedo.nim
+++ b/tests/macros/tquotedo.nim
@@ -1,0 +1,9 @@
+import macros
+
+macro mac(): untyped =
+  quote do:
+    proc test(): int =
+      (proc(): int = result = 123)()
+
+mac()
+echo test()

--- a/tests/macros/tquotedo.nim
+++ b/tests/macros/tquotedo.nim
@@ -7,3 +7,11 @@ macro mac(): untyped =
 
 mac()
 echo test()
+
+macro foobar(arg: untyped): untyped =
+  result = arg
+  result.add quote do:
+    `result`
+
+foobar:
+  echo "Hallo Welt"


### PR DESCRIPTION
Previously the useful "quote do" construct had an issue were the result variable would be shadowed by the macros result variable and thus get the wrong return type. These commits fixes this by adding a hidden parameter to the intermediary template and calling the template with an added `newNimNode("result")` argument. This way all results are only resolved after the macro expansion and thus avoids the shadowing of the macros own result variable.