### PR TITLE
More flexible lowerBound interface

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -84,7 +84,7 @@ proc smartBinarySearch*[T](a: openArray[T], key: T): int =
 const
   onlySafeCode = true
 
-proc lowerBound*[T](a: openArray[T], key: T, cmp: proc(x,y: T): int {.closure.}): int =
+proc lowerBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.closure.}): int =
   ## same as binarySearch except that if key is not in `a` then this
   ## returns the location where `key` would be if it were. In other
   ## words if you have a sorted sequence and you call


### PR DESCRIPTION
This allows to find lower bound of objects by their attribute. E.g.:
```nim
type Foo = object
  name: string
var s: seq[Foo]
echo lowerBound(s, "hello") do(a: Foo, b: string) -> int:
  cmp(a.name, b)
```
Otherwise a pseudo key of `Foo` has to be created.