### PR TITLE
Add column number to instantiation info

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 
 - ``re.split`` for empty regular expressions now yields every character in
   the string which is what other programming languages chose to do.
+- The returned tuple of ``system.instantiationInfo`` now has a third field
+  containing the column of the instantiation.
 
 #### Breaking changes in the compiler
 

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -81,8 +81,11 @@ proc semInstantiationInfo(c: PContext, n: PNode): PNode =
   filename.strVal = if useFullPaths != 0: info.toFullPath else: info.toFilename
   var line = newNodeIT(nkIntLit, n.info, getSysType(tyInt))
   line.intVal = toLinenumber(info)
+  var column = newNodeIT(nkIntLit, n.info, getSysType(tyInt))
+  column.intVal = toColumn(info)
   result.add(filename)
   result.add(line)
+  result.add(column)
 
 proc toNode(t: PType, i: TLineInfo): PNode =
   result = newNodeIT(nkType, i, t)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3730,7 +3730,7 @@ proc astToStr*[T](x: T): string {.magic: "AstToStr", noSideEffect.}
   ## for debugging.
 
 proc instantiationInfo*(index = -1, fullPaths = false): tuple[
-  filename: string, line: int] {. magic: "InstantiationInfo", noSideEffect.}
+  filename: string, line: int, column: int] {. magic: "InstantiationInfo", noSideEffect.}
   ## provides access to the compiler's instantiation stack line information
   ## of a template.
   ##

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -8,7 +8,7 @@ tfailedassert.nim:27 false assertion from foo
 """
 
 type
-  TLineInfo = tuple[filename: string, line: int]
+  TLineInfo = tuple[filename: string, line: int, column: int]
 
   TMyError = object of Exception
     lineinfo: TLineInfo


### PR DESCRIPTION
Instantiation info left out column number for no good reason. This adds it in as the third element of the tuple.