### PR TITLE
add D in FAQ on influences on language design

### DIFF
--- a/web/question.rst
+++ b/web/question.rst
@@ -61,7 +61,7 @@ General FAQ
   -------------------------------------------------------------
 
   The language borrows heavily from (in order of impact): Modula 3, Delphi, Ada,
-  C++, Python, Lisp, Oberon.
+  D, C++, Python, Lisp, Oberon.
 
 
 .. container:: standout


### PR DESCRIPTION
lots of reasons: 
CTFE
static if (aka when)
nim's templates are closest to D templates amongst other languages

