### PR TITLE
bitops: fastlog2 to use a single bsr instruction on x86 with GCC

### DIFF
--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -274,8 +274,8 @@ proc fastLog2*(x: SomeInteger): int {.inline, nosideeffect.} =
     else:                result = fastlog2_nim(x.uint64)
   else:
     when useGCC_builtins:
-      when sizeof(x) <= 4: result = 31 - builtin_clz(x.uint32).int
-      else:                result = 63 - builtin_clzll(x.uint64).int
+      when sizeof(x) <= 4: result = 31 xor builtin_clz(x.uint32).int
+      else:                result = 63 xor builtin_clzll(x.uint64).int
     elif useVCC_builtins:
       when sizeof(x) <= 4:
         result = vcc_scan_impl(bitScanReverse, x.culong)


### PR DESCRIPTION
Currently with `31 - builtin_clz`, this compiles into bsr + xor (from clz) + sub.
To massage GCC into producing a single bsr instruction, it is better to use xor than sub.
Those are equivalent since 31 has the form `2^n -1`