### PR TITLE
Add RISC-V "riscv64" support

### DIFF
--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -176,7 +176,7 @@ type
     cpuNone, cpuI386, cpuM68k, cpuAlpha, cpuPowerpc, cpuPowerpc64,
     cpuPowerpc64el, cpuSparc, cpuVm, cpuIa64, cpuAmd64, cpuMips, cpuMipsel,
     cpuArm, cpuArm64, cpuJS, cpuNimrodVM, cpuAVR, cpuMSP430, cpuSparc64,
-    cpuMips64, cpuMips64el
+    cpuMips64, cpuMips64el, cpuRiscV64
 
 type
   TEndian* = enum
@@ -207,7 +207,8 @@ const
     (name: "msp430", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "sparc64", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
     (name: "mips64", intSize: 64, endian: bigEndian, floatSize: 64, bit: 64),
-    (name: "mips64el", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64)]
+    (name: "mips64el", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
+    (name: "riscv64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64)]
 
 var
   targetCPU*, hostCPU*: TSystemCPU

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1372,7 +1372,8 @@ const
   hostCPU* {.magic: "HostCPU".}: string = ""
     ## a string that describes the host CPU. Possible values:
     ## "i386", "alpha", "powerpc", "powerpc64", "powerpc64el", "sparc",
-    ## "amd64", "mips", "mipsel", "arm", "arm64", "mips64", "mips64el".
+    ## "amd64", "mips", "mipsel", "arm", "arm64", "mips64", "mips64el",
+    ## "riscv64".
 
   seqShallowFlag = low(int)
   strlitFlag = 1 shl (sizeof(int)*8 - 2) # later versions of the codegen \

--- a/lib/system/platforms.nim
+++ b/lib/system/platforms.nim
@@ -29,8 +29,9 @@ type
     arm,                       ## ARM based processor
     arm64,                     ## ARM64 based processor
     vm,                        ## Some Virtual machine: Nim's VM or JavaScript
-    avr                        ## AVR based processor
-    msp430                     ## TI MSP430 microcontroller
+    avr,                       ## AVR based processor
+    msp430,                    ## TI MSP430 microcontroller
+    riscv64                    ## RISC-V 64-bit processor
 
   OsPlatform* {.pure.} = enum ## the OS this program will run on.
     none, dos, windows, os2, linux, morphos, skyos, solaris,
@@ -84,5 +85,6 @@ const
                elif defined(vm): CpuPlatform.vm
                elif defined(avr): CpuPlatform.avr
                elif defined(msp430): CpuPlatform.msp430
+               elif defined(riscv64): CpuPlatform.riscv64
                else: CpuPlatform.none
     ## the CPU this program will run on.


### PR DESCRIPTION
Tested by crosscompiling using GCC 8.0.1 from 20180321 (devel version) running koch tests under qemu-riscv64 version 2.11.50 (v2.11.0-2256-g819fd4699c-dirty).

Some tests failed due to missing libraries; The threadpool module failed to compile due to an unrecognized opcode `pause'.

This PR could be merged as a first step to add RISC-V support and more testing can be performed once real hardware is available.

Closes #7147