### PR TITLE
net.connect (with timeout), raise error on connect failure

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1664,6 +1664,9 @@ proc connect*(socket: Socket, address: string, port = Port(0),
   if selectWrite(s, timeout) != 1:
     raise newException(TimeoutError, "Call to 'connect' timed out.")
   else:
+    let res = getSockOptInt(socket.fd, SOL_SOCKET, SO_ERROR)
+    if res != 0:
+      raiseOSError(OSErrorCode(res))
     when defineSsl and not defined(nimdoc):
       if socket.isSSL:
         socket.fd.setBlocking(true)


### PR DESCRIPTION
Under Linux (probably POSIX), the current code tests for timeout, but
does not test for connection failure. connectAsync() returns successfully
upon an EINPROGRESS result; but at this point, the connection state is
still unknown. After selectWrite() is done, we need to test the socket
for errors again.