### PR TITLE
[WIP] first pass at fixing #7430: universal to conversion template

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1339,6 +1339,8 @@ else:
   proc parseJson*(buffer: string): JsonNode =
     return parseNativeJson(buffer).convertObject()
 
+proc to*(s: string; dest: typedesc[JsonNode]): auto = parseJson(s)
+
 # -- Json deserialiser macro. --
 
 proc createJsonIndexer(jsonNode: NimNode,
@@ -1979,6 +1981,7 @@ when isMainModule:
   let stringified = $testJson
   let parsedAgain = parseJson(stringified)
   doAssert(parsedAgain["b"].str == "asd")
+  doAssert parsedAgain == stringified.to(JsonNode)
 
   parsedAgain["abc"] = %5
   doAssert parsedAgain["abc"].num == 5

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1078,7 +1078,7 @@ proc parseHexStr*(s: string): string {.noSideEffect, procvar,
     else:
       result[pos div 2] = chr(val + buf shl 4)
 
-proc parseBool*(s: string): bool =
+proc to*(s: string; dest: typedesc[bool]): bool =
   ## Parses a value into a `bool`.
   ##
   ## If ``s`` is one of the following values: ``y, yes, true, 1, on``, then
@@ -1089,6 +1089,9 @@ proc parseBool*(s: string): bool =
   of "y", "yes", "true", "1", "on": result = true
   of "n", "no", "false", "0", "off": result = false
   else: raise newException(ValueError, "cannot interpret as a bool: " & s)
+
+# TODO: deprecate
+proc parseBool*(s: string): bool = s.to(bool)
 
 proc parseEnum*[T: enum](s: string): T =
   ## Parses an enum ``T``.
@@ -2498,6 +2501,8 @@ proc removePrefix*(s: var string, prefix: string) {.
     s.delete(0, prefix.len - 1)
 
 when isMainModule:
+  doAssert "yes".to(bool) == true
+
   doAssert align("abc", 4) == " abc"
   doAssert align("a", 0) == "a"
   doAssert align("1232", 6) == "  1232"
@@ -2734,3 +2739,4 @@ bar
     doAssert s.endsWith('\0') == false
 
   #echo("strutils tests passed")
+


### PR DESCRIPTION
here's a 1st pass at https://github.com/nim-lang/Nim/issues/7430 ; I (or others) can add more conversions once we agree on design principles below

design principles:

* each `to` overload should be in the module where the types / conversions are defined, eg `s.to(JsonNode)` goes in `lib/pure/json.nim` , `s.to(bool)` goes in `lib/pure/strutils.nim` etc

this is preferable to having a dedicated hodge-podge `conv.nim` module that would import everything needed and wrap for eg `parseFoo` to `to(Foo)` ; that would not scale (eg wouldn't work with nimble packages, which can't be imported by `conv.nim`) ;

* the existing `parseFoo(a:string)` `toFoo(...)` etc should become thin wrappers around the corresponding `to` proc/template (the `to` would contain the actual implementation) and eventually deprecated
eg: see this PR for parseBool becoming thin wrapper around `s.to(bool)`

* prefer `proc` to `template` whenever possible

* we should standardize ASAP on ideal signature, eg the name of arguments matters in case generic code uses named parameter syntax (eg: `to(s:foo, Bar)`; so I suggest:
```
proc to*(s: string; dest: typedesc[T]): T = ...
```
which is short and generic (`s` standing for `source`)

* new conversion functions (eg what would be currently called parseFoo or toFoo) should just use `to` and not even define `parseFoo` or `toFoo`