### PR TITLE
fix `strutils.replace` when `sub` is an empty string (fixes #7507)

### DIFF
--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -31,8 +31,8 @@ Advanced options:
   --nimcache:PATH           set the path used for generated files
   --header:FILE             the compiler should produce a .h file (FILE
                             is optional)
-  -c, --compileOnly         compile only; do not assemble or link
-  --noLinking               compile but do not link
+  -c, --compileOnly         compile Nim files only; do not assemble or link
+  --noLinking               compile Nim and generated files but do not link
   --noMain                  do not generate a main procedure
   --genScript               generate a compile script (in the 'nimcache'
                             subdirectory named 'compile_$project$scriptext')

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1640,6 +1640,8 @@ proc contains*(s: string, chars: set[char]): bool {.noSideEffect.} =
 proc replace*(s, sub: string, by = ""): string {.noSideEffect,
   rtl, extern: "nsuReplaceStr".} =
   ## Replaces `sub` in `s` by the string `by`.
+  if sub == "":
+    return s
   var a {.noinit.}: SkipTable
   result = ""
   initSkipTable(a, sub)
@@ -2542,8 +2544,14 @@ when isMainModule:
   doAssert "$animal eats $food." % ["animal", "The cat", "food", "fish"] ==
            "The cat eats fish."
 
-  doAssert "-ld a-ldz -ld".replaceWord("-ld") == " a-ldz "
-  doAssert "-lda-ldz -ld abc".replaceWord("-ld") == "-lda-ldz  abc"
+  block: # replace tests
+    doAssert "ab-cd ef".replace("ef", "gh") == "ab-cd gh"
+    doAssert "ab-cd ef".replace("cd", "") == "ab- ef"
+    doAssert "ab-cd ef".replace("", "gh") == "ab-cd ef"
+    doAssert "ab-cd ef".replace('c', 'z') == "ab-zd ef"
+    doAssert "-ld a-ldz -ld".replaceWord("-ld") == " a-ldz "
+    doAssert "-lda-ldz -ld abc".replaceWord("-ld") == "-lda-ldz  abc"
+
 
   type MyEnum = enum enA, enB, enC, enuD, enE
   doAssert parseEnum[MyEnum]("enu_D") == enuD

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -53,8 +53,11 @@ when defined(posix):
 elif defined(windows):
   import winlean
 
-  # newest version of Visual C++ defines time_t to be of 64 bits
-  type CTime {.importc: "time_t", header: "<time.h>".} = distinct int64
+  when defined(i386) and defined(gcc):
+    type CTime {.importc: "time_t", header: "<time.h>".} = distinct int32
+  else:
+    # newest version of Visual C++ defines time_t to be of 64 bits
+    type CTime {.importc: "time_t", header: "<time.h>".} = distinct int64
   # visual c's c runtime exposes these under a different name
   var timezone {.importc: "_timezone", header: "<time.h>".}: int
 
@@ -1398,7 +1401,7 @@ proc getLocalTime*(time: Time): DateTime {.tags: [], raises: [], benign, depreca
 
 proc getGMTime*(time: Time): DateTime {.tags: [], raises: [], benign, deprecated.} =
   ## Converts the calendar time `time` to broken-down time representation,
-  ## expressed in Coordinated Universal Time (UTC). 
+  ## expressed in Coordinated Universal Time (UTC).
   ##
   ## **Deprecated since v0.18.0:** use ``utc`` instead
   time.utc


### PR DESCRIPTION
fixes #7507 

Also added a couple of tests for `replace`.