### PR TITLE
fix issues #6986 and #7501

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -657,7 +657,7 @@ template mapIt*(s, op: untyped): untyped =
   when compiles(s.len):
     let t = s
     var i = 0
-    result = newSeq[outType](s.len)
+    result = newSeq[outType](t.len)
     for it {.inject.} in t:
       result[i] = op
       i += 1


### PR DESCRIPTION
oh oh, the dangers of single letter identifiers ...

issues #6986 and #7501 were both introduced by the following:
```
commit 71c5c0a47f1b733a3978236ac2f3be67547f2988
Author: narimiran <narimiran@users.noreply.github.com>
Date:   Wed Oct 25 13:41:42 2017 +0200

    Sequtils improvements (#6574)
```

interestingly there exists a relation between these two issues and #7187 (my proposed fix there is inspired by mapIt, but i didn't see that mapIt itself was buggy).