### PR TITLE
include help short option in processCmdLine of nimsuggest

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -526,7 +526,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string) =
     of cmdEnd: break
     of cmdLongoption, cmdShortOption:
       case p.key.normalize
-      of "help":
+      of "help", "h":
         stdout.writeline(Usage)
         quit()
       of "port":


### PR DESCRIPTION
In [PR 6863](https://github.com/nim-lang/Nim/pull/6863) only the interpretation of --help was added to `processCmdLine` of nimsuggest , -h still displays the standard Nim compiler help. (see #7514)