### PR TITLE
Fixes #7507

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -923,7 +923,10 @@ proc rsplit*(s: string, sep: string, maxsplit: int = -1): seq[string]
     doAssert "a,b,c".rsplit(",") == @["a", "b", "c"]
     doAssert "a man a plan a canal panama".rsplit("a ") == @["", "man ", "plan ", "canal panama"]
     doAssert "".rsplit("Elon Musk") == @[""]
+    doAssert "Elon Musk".rsplit("") == @["Elon Musk"]
     doAssert "a  largely    spaced sentence".rsplit(" ") == @["a", "", "largely", "", "", "", "spaced", "sentence"]
+  if sep.len == 0:
+    return @[s]
   accumulateResult(rsplit(s, sep, maxsplit))
   result.reverse()
 

--- a/tests/stdlib/tsplit2.nim
+++ b/tests/stdlib/tsplit2.nim
@@ -9,11 +9,6 @@ for w in split("|abc|xy|z", {'|'}):
   s.add("#")
   s.add(w)
 
-try:
-  discard "hello".split("")
-  echo "false"
-except AssertionError:
-  echo "true"
+echo "hello".split("") == @["hello"]
 
 #OUT true
-


### PR DESCRIPTION
Add check if `sub` in `replace` or `sep` in `split` is an empty string. If it is empty, return the original string.

Fixes #7507.