### PR TITLE
Add nimpretty to koch tools

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -261,6 +261,10 @@ proc buildTools(latest: bool) =
 
   let nimgrepExe = "bin/nimgrep".exe
   nimexec "c -d:release -o:" & nimgrepExe & " tools/nimgrep.nim"
+
+  let nimprettyExe = "bin/nimpretty".exe
+  nimexec "c -d:release -d:nimpretty -o:" & nimprettyExe & " tools/nimpretty.nim"
+
   when defined(windows): buildVccTool()
 
   #nimexec "c -o:" & ("bin/nimresolve".exe) & " tools/nimresolve.nim"


### PR DESCRIPTION
I found out that Nim plugin for VSCode has recently added support for ``nimpretty``, it is time to recognize as a tool and build it with the rest of the tools

It is not part of release bundle yet, let me know if you want me to add in the bundle as well.