### PR TITLE
cpp regression bug fix. Fixes #7574.

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -572,6 +572,8 @@ proc genBreakStmt(p: BProc, t: PNode) =
   lineF(p, cpsStmts, "goto $1;$n", [label])
 
 proc genRaiseStmt(p: BProc, t: PNode) =
+  if p.module.compileToCpp:
+    discard cgsym(p.module, "popCurrentExceptionEx")
   if p.nestedTryStmts.len > 0 and p.nestedTryStmts[^1].inExcept:
     # if the current try stmt have a finally block,
     # we must execute it before reraising


### PR DESCRIPTION
Quick and slightly dirty fix for #7574 to unblock cpp backend users. Fixes #7574.

It doesn't cover case when Exception object is created, but neither raised nor caught (uncommon).
In order to cover it as well I will need to add a delayed emit queue for symbols similar to BModule.typeStack for types to resolve circular dependency for Exception <-> PopCurrentExceptionEx().


