### PR TITLE
Better fix for #7574. Fixes #7574

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -571,8 +571,6 @@ proc genBreakStmt(p: BProc, t: PNode) =
   lineF(p, cpsStmts, "goto $1;$n", [label])
 
 proc genRaiseStmt(p: BProc, t: PNode) =
-  if p.module.compileToCpp:
-    discard cgsym(p.module, "popCurrentExceptionEx")
   if p.nestedTryStmts.len > 0 and p.nestedTryStmts[^1].inExcept:
     # if the current try stmt have a finally block,
     # we must execute it before reraising
@@ -812,7 +810,6 @@ proc genTryCpp(p: BProc, t: PNode, d: var TLoc) =
   if not isEmptyType(t.typ) and d.k == locNone:
     getTemp(p, t.typ, d)
   genLineDir(p, t)
-  discard cgsym(p.module, "popCurrentExceptionEx")
   add(p.nestedTryStmts, (t, false))
   startBlock(p, "try {$n")
   expr(p, t[0], d)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -580,10 +580,9 @@ proc getRecordDesc(m: BModule, typ: PType, name: Rope,
           # Add cleanup destructor to Exception base class
           appcg(m, result, "~$1() {if(this->raise_id) popCurrentExceptionEx(this->raise_id);}$n", [name])
           # hack: forward declare popCurrentExceptionEx() on top of type description,
-          # proper request to generate popCurrentExceptionEx not possible for 2 reasons:
-          # generated function will be below declared Exception type and circular dependency
-          # between Exception and popCurrentExceptionEx function
+          # otherwise generated proc will be below declared Exception type
           result = genProcHeader(m, magicsys.getCompilerProc("popCurrentExceptionEx")) & ";" & rnl & result
+          pushCgsym(m, "popCurrentExceptionEx")
       hasField = true
     else:
       appcg(m, result, " {$n  $1 Sup;$n",

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -655,7 +655,7 @@ proc cgsym(m: BModule, name: string): Rope =
   result = sym.loc.r
 
 proc pushCgsym(m: BModule, name: string) = 
-  # add cgsym to lazy emit at module's finalization step
+  # add cgsym to delayed emit at module's finalization step
   m.cgsymStack.add(name)
 
 proc finishCgsym(m: BModule) =

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -90,6 +90,7 @@ proc useHeader(m: BModule, sym: PSym) =
     m.includeHeader(str)
 
 proc cgsym(m: BModule, name: string): Rope
+proc pushCgsym(m: BModule, name: string)
 
 proc ropecg(m: BModule, frmt: FormatStr, args: varargs[Rope]): Rope =
   var i = 0
@@ -652,6 +653,16 @@ proc cgsym(m: BModule, name: string): Rope =
     # we're picky here for the system module too:
     rawMessage(errSystemNeeds, name)
   result = sym.loc.r
+
+proc pushCgsym(m: BModule, name: string) = 
+  # add cgsym to lazy emit at module's finalization step
+  m.cgsymStack.add(name)
+
+proc finishCgsym(m: BModule) =
+  var i = 0
+  while i < len(m.cgsymStack):
+    discard cgsym(m, m.cgsymStack[i])
+    inc(i)
 
 proc generateHeaders(m: BModule) =
   add(m.s[cfsHeaders], tnl & "#include \"nimbase.h\"" & tnl)
@@ -1225,6 +1236,7 @@ proc rawNewModule(g: BModuleList; module: PSym, filename: string): BModule =
   result.postInitProc = newPostInitProc(result)
   initNodeTable(result.dataCache)
   result.typeStack = @[]
+  result.cgsymStack = @[]
   result.forwardedProcs = @[]
   result.typeNodesName = getTempName(result)
   result.nimTypesName = getTempName(result)
@@ -1255,6 +1267,7 @@ proc resetModule*(m: BModule) =
   m.postInitProc = newPostInitProc(m)
   initNodeTable(m.dataCache)
   m.typeStack = @[]
+  m.cgsymStack = @[]
   m.forwardedProcs = @[]
   m.typeNodesName = getTempName(m)
   m.nimTypesName = getTempName(m)
@@ -1402,6 +1415,7 @@ proc writeModule(m: BModule, pending: bool) =
 
   if m.rd == nil or optForceFullMake in gGlobalOptions:
     genInitCode(m)
+    finishCgsym(m)
     finishTypeDescriptions(m)
     if sfMainModule in m.module.flags:
       # generate main file:
@@ -1421,6 +1435,7 @@ proc writeModule(m: BModule, pending: bool) =
     let cf = Cfile(cname: cfile, obj: completeCFilePath(toObjFile(cfile)), flags: {})
     mergeFiles(cfile, m)
     genInitCode(m)
+    finishCgsym(m)
     finishTypeDescriptions(m)
     var code = genModule(m, cf)
     writeRope(code, cfile)
@@ -1441,8 +1456,8 @@ proc updateCachedModule(m: BModule) =
   if mergeRequired(m) and sfMainModule notin m.module.flags:
     mergeFiles(cfile, m)
     genInitCode(m)
+    finishCgsym(m)
     finishTypeDescriptions(m)
-
     var code = genModule(m, cf)
     writeRope(code, cfile)
   else:

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -136,6 +136,7 @@ type
     postInitProc*: BProc      # code to be executed after the init proc
     preInitProc*: BProc       # code executed before the init proc
     typeStack*: TTypeSeq      # used for type generation
+    cgsymStack*: seq[string]    # used to generate extra compilerproc symbols at finalization
     dataCache*: TNodeTable
     forwardedProcs*: TSymSeq  # keep forwarded procs here
     typeNodes*, nimTypes*: int # used for type info generation


### PR DESCRIPTION
Better version of PR https://github.com/nim-lang/Nim/pull/7576 that is already merged.
Covers all cases of Exception type usage.

New sym queue is introduced in BModule for delayed proc emitting. 
Type cache plus this queue solves the problem of circular dependency between ``Exception`` type and ``popCurrentExceptionEx`` proc


