### PR TITLE
implement for `index,name in tup.fieldsIndexed` 

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -611,7 +611,7 @@ type
     mEqSet, mLeSet, mLtSet, mMulSet, mPlusSet, mMinusSet, mSymDiffSet,
     mConStrStr, mSlice,
     mDotDot, # this one is only necessary to give nice compile time warnings
-    mFields, mFieldPairs, mOmpParFor,
+    mFields, mFieldPairs, mFieldsIndexed, mOmpParFor,
     mAppendStrCh, mAppendStrStr, mAppendSeqElem,
     mInRange, mInSet, mRepr, mExit,
     mSetLengthStr, mSetLengthSeq,

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -114,3 +114,4 @@ proc initDefines*() =
   defineSymbol("nimNewDot")
   defineSymbol("nimHasNilChecks")
   defineSymbol("nimSymKind")
+  defineSymbol("nimHasFieldsIndexed")

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -26,7 +26,6 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
     let ident = considerQuotedIdent(n)
     var L = sonsLen(forLoop)
 
-    #TODO: different order for mFieldsIndexed
     #TODO: allow passing in just type for mFieldsIndexed
     if c.m == mFieldPairs or c.m == mFieldsIndexed:
       let indexField =

--- a/compiler/semfields.nim
+++ b/compiler/semfields.nim
@@ -15,27 +15,43 @@ type
     tupleType: PType      # if != nil we're traversing a tuple
     tupleIndex: int
     field: PSym
-    replaceByFieldName: bool
+    m: TMagic
 
 proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
+  let replaceByFieldName = c.m == mFieldPairs
   case n.kind
   of nkEmpty..pred(nkIdent), succ(nkSym)..nkNilLit: result = n
   of nkIdent, nkSym:
     result = n
     let ident = considerQuotedIdent(n)
     var L = sonsLen(forLoop)
-    if c.replaceByFieldName:
-      if ident.id == considerQuotedIdent(forLoop[0]).id:
+
+    #TODO: different order for mFieldsIndexed
+    #TODO: allow passing in just type for mFieldsIndexed
+    if c.m == mFieldPairs or c.m == mFieldsIndexed:
+      let indexField =
+        if c.m == mFieldPairs: 0
+        else: 1
+
+      if ident.id == considerQuotedIdent(forLoop[indexField]).id:
         let fieldName = if c.tupleType.isNil: c.field.name.s
                         elif c.tupleType.n.isNil: "Field" & $c.tupleIndex
                         else: c.tupleType.n.sons[c.tupleIndex].sym.name.s
         result = newStrNode(nkStrLit, fieldName)
         return
-    # other fields:
-    for i in ord(c.replaceByFieldName)..L-3:
+
+    if c.m == mFieldsIndexed:
+      if ident.id == considerQuotedIdent(forLoop[0]).id:
+        var call = forLoop.sons[L-2]
+        var tupl = call.sons[1]
+        result = newIntNode(nkIntLit, c.tupleIndex)
+
+    else:
+     # value fields:
+     for i in ord(replaceByFieldName)..L-3:
       if ident.id == considerQuotedIdent(forLoop[i]).id:
         var call = forLoop.sons[L-2]
-        var tupl = call.sons[i+1-ord(c.replaceByFieldName)]
+        var tupl = call.sons[i+1-ord(replaceByFieldName)]
         if c.field.isNil:
           result = newNodeI(nkBracketExpr, n.info)
           result.add(tupl)
@@ -44,6 +60,7 @@ proc instFieldLoopBody(c: TFieldInstCtx, n: PNode, forLoop: PNode): PNode =
           result = newNodeI(nkDotExpr, n.info)
           result.add(tupl)
           result.add(newSymNode(c.field, n.info))
+        # TODO: does it check for repeated names, eg: for k,v,v in ...
         break
   else:
     if n.kind == nkContinueStmt:
@@ -64,7 +81,7 @@ proc semForObjectFields(c: TFieldsCtx, typ, forLoop, father: PNode) =
   of nkSym:
     var fc: TFieldInstCtx  # either 'tup[i]' or 'field' is valid
     fc.field = typ.sym
-    fc.replaceByFieldName = c.m == mFieldPairs
+    fc.m = c.m
     openScope(c.c)
     inc c.c.inUnrolledContext
     let body = instFieldLoopBody(fc, lastSon(forLoop), forLoop)
@@ -117,7 +134,11 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
 
   var length = sonsLen(n)
   var call = n.sons[length-2]
-  if length-2 != sonsLen(call)-1 + ord(m==mFieldPairs):
+  if m==mFieldsIndexed:
+    if length-2 != 2:
+      localError(n.info, errWrongNumberOfVariables)
+      return result
+  elif length-2 != sonsLen(call)-1 + ord(m==mFieldPairs):
     localError(n.info, errWrongNumberOfVariables)
     return result
 
@@ -139,7 +160,7 @@ proc semForFields(c: PContext, n: PNode, m: TMagic): PNode =
       var fc: TFieldInstCtx
       fc.tupleType = tupleTypeA
       fc.tupleIndex = i
-      fc.replaceByFieldName = m == mFieldPairs
+      fc.m = m
       var body = instFieldLoopBody(fc, loopBody, n)
       inc c.inUnrolledContext
       stmts.add(semStmt(c, body))

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -714,7 +714,7 @@ proc semFor(c: PContext, n: PNode): PNode =
     n.sons[length-2] = call
   let isCallExpr = call.kind in nkCallKinds
   if isCallExpr and call[0].kind == nkSym and
-      call[0].sym.magic in {mFields, mFieldPairs, mOmpParFor}:
+      call[0].sym.magic in {mFields, mFieldPairs, mFieldsIndexed, mOmpParFor}:
     if call.sons[0].sym.magic == mOmpParFor:
       result = semForVars(c, n)
       result.kind = nkParForStmt

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2450,9 +2450,10 @@ iterator fields*[S:tuple|object, T:tuple|object](x: S, y: T): tuple[a,b: untyped
   ## Warning: This is really transforms the 'for' and unrolls the loop.
   ## The current implementation also has a bug that affects symbol binding
   ## in the loop body.
-iterator fieldsIndexed*[T: tuple|object](x: T): RootObj {.
-  magic: "FieldsIndexed", noSideEffect.}
-  ## iterates over every field of `x`, returning name, index
+when defined(nimHasFieldsIndexed):
+  iterator fieldsIndexed*[T: tuple|object](x: T): RootObj {.
+    magic: "FieldsIndexed", noSideEffect.}
+    ## iterates over every field of `x`, returning name, index
 iterator fieldPairs*[T: tuple|object](x: T): RootObj {.
   magic: "FieldPairs", noSideEffect.}
   ## Iterates over every field of `x` returning their name and value.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2450,6 +2450,9 @@ iterator fields*[S:tuple|object, T:tuple|object](x: S, y: T): tuple[a,b: untyped
   ## Warning: This is really transforms the 'for' and unrolls the loop.
   ## The current implementation also has a bug that affects symbol binding
   ## in the loop body.
+iterator fieldsIndexed*[T: tuple|object](x: T): RootObj {.
+  magic: "FieldsIndexed", noSideEffect.}
+  ## iterates over every field of `x`, returning name, index
 iterator fieldPairs*[T: tuple|object](x: T): RootObj {.
   magic: "FieldPairs", noSideEffect.}
   ## Iterates over every field of `x` returning their name and value.


### PR DESCRIPTION
## motivation: see https://forum.nim-lang.org/t/3750

Also, allows a workaround for https://github.com/nim-lang/Nim/issues/7590

## example usage:
```
proc doInit[T]():auto=
  var a: T
  return a

proc len(T: typedesc[tuple]):auto=
  const t=doInit[T]()
  var n=0
  for _ in t.fields:
    inc n
  return n

proc fieldNames[T]():auto=
  const t=doInit[T]()
  var names: array[T.len, string]
  for ind,field in t.fieldsIndexed:
    names[ind]=field
  return names

proc test1()=
  let a=(bar1:1,bar2:2)
  const names=fieldNames[a.type]()
  doAssert names == ["bar1", "bar2"]

  let a2=(foo1:1.4,foo2:"baz")
  const names2=fieldNames[a2.type]()

  ## this would be hard to do without this PR
  for ind,field in a.fieldsIndexed:
    echo (ind,field,a[ind],names2[ind],a2[ind])

test1()
```

## NOTE: this implements `tupInstance.fieldsIndexed` instead of `TupType.fieldsIndexed` 
help welcome to make `TupleType.fieldsIndexed` work, but this could be done in subsequent PR; this is already a big improvement

## NOTE: subtle issue related to bootstrapping:
locally as well as on CI, I'm getting this error:
```
lib\system.nim(2454, 8) Warning: unknown magic 'FieldsIndexed' might crash the compiler [UnknownMagic]
lib\system.nim(2453, 1) Error: implementation of 'fieldsIndexed' expected
```

that's because `FieldsIndexed` isn't considered magic yet;

to make it work locally, i had to comment this from system.nim:
```
iterator fieldsIndexed*[T: tuple|object](x: T): RootObj {.
  magic: "FieldsIndexed", noSideEffect.}
```
then rebuild ./bin/nim, then uncomment, the rebuild.

@Araq  @dom96  Is there a better way?

As for CI, what's the recommended approach? will submitting 2 subsequent PR's (one with `fieldsIndexed` commented, second one uncommented) ?

