### PR TITLE
Fix some usages of typedesc in async procs

### DIFF
--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -186,7 +186,8 @@ proc getEnvParam*(routine: PSym): PSym =
 
 proc interestingVar(s: PSym): bool {.inline.} =
   result = s.kind in {skVar, skLet, skTemp, skForVar, skParam, skResult} and
-    sfGlobal notin s.flags
+    sfGlobal notin s.flags and
+    s.typ.kind notin {tyStatic, tyTypeDesc}
 
 proc illegalCapture(s: PSym): bool {.inline.} =
   result = skipTypes(s.typ, abstractInst).kind in

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -11,7 +11,7 @@
 ## *************
 ## `asyncdispatch` module depends on the `asyncmacro` module to work properly.
 
-import macros, strutils
+import macros, strutils, asyncfutures
 
 proc skipUntilStmtList(node: NimNode): NimNode {.compileTime.} =
   # Skips a nest of StmtList's.
@@ -26,6 +26,8 @@ proc skipStmtList(node: NimNode): NimNode {.compileTime.} =
 
 template createCb(retFutureSym, iteratorNameSym,
                   strName, identName, futureVarCompletions: untyped) =
+  bind finished
+
   var nameIterVar = iteratorNameSym
   #{.push stackTrace: off.}
   proc identName {.closure.} =

--- a/tests/async/tgeneric_async.nim
+++ b/tests/async/tgeneric_async.nim
@@ -1,9 +1,40 @@
+discard """
+output: "1\nmessa"
+"""
 
-import asyncdispatch
+import async
 
-when true:
-  # bug #2377
-  proc test[T](v: T) {.async.} =
-    echo $v
+# bug #2377
+proc test[T](v: T) {.async.} =
+  echo $v
 
-  asyncCheck test[int](1)
+asyncCheck test[int](1)
+
+# More complex case involving typedesc and static params
+type
+  SomeMsg = object
+    data: string
+
+template msgId(M: type SomeMsg): int = 1
+
+proc recvMsg(): Future[tuple[msgId: int, msgData: string]] {.async.} =
+  return (1, "message")
+
+proc read(data: string, T: type SomeMsg, maxBytes: int): T =
+  result.data = data[0 ..< min(data.len, maxBytes)]
+
+proc nextMsg*(MsgType: typedesc,
+              maxBytes: static[int]): Future[MsgType] {.async.} =
+  const wantedId = MsgType.msgId
+
+  while true:
+    var (nextMsgId, nextMsgData) = await recvMsg()
+    if nextMsgId == wantedId:
+      return nextMsgData.read(MsgType, maxBytes)
+
+proc main {.async.} =
+  let msg = await nextMsg(SomeMsg, 5)
+  echo msg.data
+
+asyncCheck main()
+


### PR DESCRIPTION
This also fixes a compilation error in modules, based only on the
new async module (i.e. not importing the full asyncdispatch)