### PR TITLE
make tools/nimweb.nim compileable with latest Nim

### DIFF
--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -418,7 +418,7 @@ proc generateRss(outputFilename: string, news: seq[TRssItem]) =
           href = rss.url),
         updatedDate(rss.year, rss.month, rss.day),
         "<author><name>Nim</name></author>",
-        content(xmltree.escape(rss.content), `type` = "text"),
+        content(xmltree.escape(rss.content), `type` = "text")
       ))
 
   output.write("""</feed>""")


### PR DESCRIPTION
a small attempt to "make tests green again" after: 
[introduce nkTupleConstr AST node for unary tuple construction; breaking change](https://github.com/nim-lang/Nim/commit/47335aab4148b2cd5b28cd3012d6d6e0a0c82db7)