### PR TITLE
rename SomeReal to SomeFloat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,7 +43,10 @@
   of the more general ``NimNode``.
 - ``macros.getImpl`` now includes the pragmas of types, instead of omitting them.
 - ``macros.hasCustomPragma`` and ``macros.getCustomPragmaVal`` now
-  also support ``ref`` and ``ptr`` types, pragmas on types and variant fields.
+  also support ``ref`` and ``ptr`` types, pragmas on types and variant
+  fields.
+- ``system.SomeReal`` is now called ``SomeFloat`` for consistency and
+  correctness.
 
 ### Language additions
 
@@ -87,4 +90,3 @@
   machine.
 
 ### Bugfixes
-

--- a/lib/js/jscore.nim
+++ b/lib/js/jscore.nim
@@ -30,15 +30,15 @@ proc asinh*(m: MathLib, a: SomeNumber): float
 proc atan*(m: MathLib, a: SomeNumber): float
 proc atan2*(m: MathLib, a: SomeNumber): float
 proc atanh*(m: MathLib, a: SomeNumber): float
-proc cbrt*(m: MathLib, f: SomeReal): SomeReal
-proc ceil*(m: MathLib, f: SomeReal): SomeReal
+proc cbrt*(m: MathLib, f: SomeFloat): SomeFloat
+proc ceil*(m: MathLib, f: SomeFloat): SomeFloat
 proc clz32*(m: MathLib, f: SomeInteger): int
 proc cos*(m: MathLib, a: SomeNumber): float
 proc cosh*(m: MathLib, a: SomeNumber): float
 proc exp*(m: MathLib, a: SomeNumber): float
 proc expm1*(m: MathLib, a: SomeNumber): float
-proc floor*(m: MathLib, f: SomeReal): int
-proc fround*(m: MathLib, f: SomeReal): float32
+proc floor*(m: MathLib, f: SomeFloat): int
+proc fround*(m: MathLib, f: SomeFloat): float32
 proc hypot*(m: MathLib, args: varargs[distinct SomeNumber]): float
 proc imul*(m: MathLib, a, b: int32): int32
 proc log*(m: MathLib, a: SomeNumber): float
@@ -49,14 +49,14 @@ proc max*(m: MathLib, a, b: SomeNumber): SomeNumber
 proc min*[T: SomeNumber | JsRoot](m: MathLib, a, b: T): T
 proc pow*(m: MathLib, a, b: distinct SomeNumber): float
 proc random*(m: MathLib): float
-proc round*(m: MathLib, f: SomeReal): int
+proc round*(m: MathLib, f: SomeFloat): int
 proc sign*(m: MathLib, f: SomeNumber): int
 proc sin*(m: MathLib, a: SomeNumber): float
 proc sinh*(m: MathLib, a: SomeNumber): float
-proc sqrt*(m: MathLib, f: SomeReal): SomeReal
+proc sqrt*(m: MathLib, f: SomeFloat): SomeFloat
 proc tan*(m: MathLib, a: SomeNumber): float
 proc tanh*(m: MathLib, a: SomeNumber): float
-proc trunc*(m: MathLib, f: SomeReal): int
+proc trunc*(m: MathLib, f: SomeFloat): int
 
 # Date library
 proc now*(d: DateLib): int

--- a/lib/pure/lenientops.nim
+++ b/lib/pure/lenientops.nim
@@ -26,33 +26,33 @@
 
 import typetraits
 
-proc `+`*[I: SomeInteger, F: SomeReal](i: I, f: F): F {.noSideEffect, inline.} =
+proc `+`*[I: SomeInteger, F: SomeFloat](i: I, f: F): F {.noSideEffect, inline.} =
   F(i) + f
-proc `+`*[I: SomeInteger, F: SomeReal](f: F, i: I): F {.noSideEffect, inline.} =
+proc `+`*[I: SomeInteger, F: SomeFloat](f: F, i: I): F {.noSideEffect, inline.} =
   f + F(i)
 
-proc `-`*[I: SomeInteger, F: SomeReal](i: I, f: F): F {.noSideEffect, inline.} =
+proc `-`*[I: SomeInteger, F: SomeFloat](i: I, f: F): F {.noSideEffect, inline.} =
   F(i) - f
-proc `-`*[I: SomeInteger, F: SomeReal](f: F, i: I): F {.noSideEffect, inline.} =
+proc `-`*[I: SomeInteger, F: SomeFloat](f: F, i: I): F {.noSideEffect, inline.} =
   f - F(i)
 
-proc `*`*[I: SomeInteger, F: SomeReal](i: I, f: F): F {.noSideEffect, inline.} =
+proc `*`*[I: SomeInteger, F: SomeFloat](i: I, f: F): F {.noSideEffect, inline.} =
   F(i) * f
-proc `*`*[I: SomeInteger, F: SomeReal](f: F, i: I): F {.noSideEffect, inline.} =
+proc `*`*[I: SomeInteger, F: SomeFloat](f: F, i: I): F {.noSideEffect, inline.} =
   f * F(i)
 
-proc `/`*[I: SomeInteger, F: SomeReal](i: I, f: F): F {.noSideEffect, inline.} =
+proc `/`*[I: SomeInteger, F: SomeFloat](i: I, f: F): F {.noSideEffect, inline.} =
   F(i) / f
-proc `/`*[I: SomeInteger, F: SomeReal](f: F, i: I): F {.noSideEffect, inline.} =
+proc `/`*[I: SomeInteger, F: SomeFloat](f: F, i: I): F {.noSideEffect, inline.} =
   f / F(i)
 
-proc `<`*[I: SomeInteger, F: SomeReal](i: I, f: F): bool {.noSideEffect, inline.} =
+proc `<`*[I: SomeInteger, F: SomeFloat](i: I, f: F): bool {.noSideEffect, inline.} =
   F(i) < f
-proc `<`*[I: SomeInteger, F: SomeReal](f: F, i: I): bool {.noSideEffect, inline.} =
+proc `<`*[I: SomeInteger, F: SomeFloat](f: F, i: I): bool {.noSideEffect, inline.} =
   f < F(i)
-proc `<=`*[I: SomeInteger, F: SomeReal](i: I, f: F): bool {.noSideEffect, inline.} =
+proc `<=`*[I: SomeInteger, F: SomeFloat](i: I, f: F): bool {.noSideEffect, inline.} =
   F(i) <= f
-proc `<=`*[I: SomeInteger, F: SomeReal](f: F, i: I): bool {.noSideEffect, inline.} =
+proc `<=`*[I: SomeInteger, F: SomeFloat](f: F, i: I): bool {.noSideEffect, inline.} =
   f <= F(i)
 
 # Note that we must not defined `>=` and `>`, because system.nim already has a

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -375,7 +375,7 @@ type
                       ## ``parseStandardFormatSpecifier`` returned.
 
 proc formatInt(n: SomeNumber; radix: int; spec: StandardFormatSpecifier): string =
-  ## Converts ``n`` to string. If ``n`` is `SomeReal`, it casts to `int64`.
+  ## Converts ``n`` to string. If ``n`` is `SomeFloat`, it casts to `int64`.
   ## Conversion is done using ``radix``. If result's length is lesser than
   ## ``minimumWidth``, it aligns result to the right or left (depending on ``a``)
   ## with ``fill`` char.
@@ -503,8 +503,8 @@ proc format*(value: SomeInteger; specifier: string; res: var string) =
       " of 'x', 'X', 'b', 'd', 'o' but got: " & spec.typ)
   res.add formatInt(value, radix, spec)
 
-proc format*(value: SomeReal; specifier: string; res: var string) =
-  ## Standard format implementation for ``SomeReal``. It makes little
+proc format*(value: SomeFloat; specifier: string; res: var string) =
+  ## Standard format implementation for ``SomeFloat``. It makes little
   ## sense to call this directly, but it is required to exist
   ## by the ``&`` macro.
   let spec = parseStandardFormatSpecifier(specifier)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -105,11 +105,13 @@ type
     ## type class matching all ordinal types; however this includes enums with
     ## holes.
 
-  SomeReal* = float|float32|float64
+  SomeFloat* = float|float32|float64
     ## type class matching all floating point number types
 
-  SomeNumber* = SomeInteger|SomeReal
+  SomeNumber* = SomeInteger|SomeFloat
     ## type class matching all number types
+
+{.deprecated: [SomeReal: SomeFloat].}
 
 proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## Special compile-time procedure that checks whether `x` is
@@ -128,7 +130,7 @@ when defined(nimalias):
     TSignedInt: SomeSignedInt,
     TUnsignedInt: SomeUnsignedInt,
     TInteger: SomeInteger,
-    TReal: SomeReal,
+    TReal: SomeFloat,
     TNumber: SomeNumber,
     TOrdinal: SomeOrdinal].}
 
@@ -2171,8 +2173,8 @@ proc max*[T](x, y: T): T =
   if y <= x: x else: y
 {.pop.}
 
-proc high*(T: typedesc[SomeReal]): T = Inf
-proc low*(T: typedesc[SomeReal]): T = NegInf
+proc high*(T: typedesc[SomeFloat]): T = Inf
+proc low*(T: typedesc[SomeFloat]): T = NegInf
 
 proc clamp*[T](x, a, b: T): T =
   ## limits the value ``x`` within the interval [a, b]

--- a/tests/tuples/tuple_with_nil.nim
+++ b/tests/tuples/tuple_with_nil.nim
@@ -353,7 +353,7 @@ proc writeformat(o: var Writer; p: pointer; fmt: Format) =
     f.baseprefix = true
   writeformat(o, add, cast[uint](p), f)
 
-proc writeformat(o: var Writer; x: SomeReal; fmt: Format) =
+proc writeformat(o: var Writer; x: SomeFloat; fmt: Format) =
   ## Write real number `x` according to format `fmt` using output
   ## object `o` and output function `add`.
   var fmt = fmt
@@ -401,8 +401,8 @@ proc writeformat(o: var Writer; x: SomeReal; fmt: Format) =
       else:
         len += 4 # exponent
       # shift y so that 1 <= abs(y) < 2
-      if exp > 0: y /= pow(10.SomeReal, abs(exp).SomeReal)
-      elif exp < 0: y *= pow(10.SomeReal, abs(exp).SomeReal)
+      if exp > 0: y /= pow(10.SomeFloat, abs(exp).SomeFloat)
+      elif exp < 0: y *= pow(10.SomeFloat, abs(exp).SomeFloat)
     elif fmt.typ == ftPercent:
       len += 1 # percent sign
 
@@ -413,7 +413,7 @@ proc writeformat(o: var Writer; x: SomeReal; fmt: Format) =
     var mult = 1'i64
     for i in 1..prec: mult *= 10
     var num = y.int64
-    var fr = ((y - num.SomeReal) * mult.SomeReal).int64
+    var fr = ((y - num.SomeFloat) * mult.SomeFloat).int64
     # build integer part string
     while num != 0:
       numstr[numlen] = ('0'.int + (num mod 10)).char


### PR DESCRIPTION
The `SomeReal` types were the superset of all `Float` types. That is not only inconsistent with the names, but it is also wrong. Here is a list of reasons why calling floating point numebrs `real`  (ℝ) is wrong.

    ∞ ∈ Float
    ∞ ∉ ℝ
    NaN ∈ Float
    NaN ∉ ℝ
    ℚ ⊂ ℝ
    Float \ {NaN, ∞, -∞} ⊂ ℚ
    Float ∩ ℝ ⊂ ℚ

In words:

 * _infinity_ is a valid floating point value, but it is not a real number
 * _nan_ is a valuid floating point value, but again it is not not even a number at all, especially not a real number.
 * Leaving out the special values of float, all that is left is a subset of the rational numbers.
   Or in other words, if you take all floating point numbers that are also real numbers, there is not a single value left, that would justify to call this number type "real numbers".

Thanks to deprecation mechanisms in Nim, this change doesn't break any code.

