### PR TITLE
[doc] update macros.nim: followup on pull #7598

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -14,11 +14,8 @@ include "system/inclrtl"
 
 ## .. include:: ../../doc/astspec.txt
 
-# If you look for the implementation of the magic symbols, copy the
-# magic string and open the file "../../compiler/vm.nim" and search
-# for the magic string with the prefix "opc". For example the
-# implementation of ``{.magic: "FooBar".}`` will be right under
-# ``of opcFooBar:``.
+# If you look for the implementation of the magic symbol
+# ``{.magic: "Foo".}``, search for `mFoo` and `opcFoo`.
 
 type
   NimNodeKind* = enum


### PR DESCRIPTION
@Araq @krux02 
https://github.com/nim-lang/Nim/pull/7598 seemed inaccurate eg for NLineInfo there's `mNLineInfo` but no opcNLineInfo