### PR TITLE
[doc] fix #7562 by making --helpFull combine --help + old --advanced for easier grepping in a single cmd; add --deprecatedCommands

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -59,6 +59,7 @@ const
 const
   Usage = slurp"../doc/basicopt.txt".replace("//", "")
   AdvancedUsage = slurp"../doc/advopt.txt".replace("//", "")
+  DeprecatedUsage = slurp"../doc/deprecatedopt.txt".replace("//", "")
 
 proc getCommandLineDesc(): string =
   result = (HelpMessage % [VersionAsString, platform.OS[platform.hostOS].name,
@@ -69,12 +70,17 @@ proc helpOnError(pass: TCmdLinePass) =
     msgWriteln(getCommandLineDesc(), {msgStdout})
     msgQuit(0)
 
-proc writeAdvancedUsage(pass: TCmdLinePass) =
+proc writeHelpFull(pass: TCmdLinePass) =
   if pass == passCmd1:
     msgWriteln(`%`(HelpMessage, [VersionAsString,
                                  platform.OS[platform.hostOS].name,
                                  CPU[platform.hostCPU].name]) & Usage & AdvancedUsage,
                {msgStdout})
+    msgQuit(0)
+
+proc writeDeprecatedCommands(pass: TCmdLinePass) =
+  if pass == passCmd1:
+    msgWriteln(DeprecatedUsage, {msgStdout})
     msgQuit(0)
 
 proc writeVersionInfo(pass: TCmdLinePass) =
@@ -608,9 +614,12 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "version", "v":
     expectNoArg(switch, arg, pass, info)
     writeVersionInfo(pass)
-  of "advanced":
+  of "helpfull", "advanced":
     expectNoArg(switch, arg, pass, info)
-    writeAdvancedUsage(pass)
+    writeHelpFull(pass)
+  of "deprecatedcommands":
+    expectNoArg(switch, arg, pass, info)
+    writeDeprecatedCommands(pass)
   of "help", "h":
     expectNoArg(switch, arg, pass, info)
     helpOnError(pass)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -73,7 +73,7 @@ proc writeAdvancedUsage(pass: TCmdLinePass) =
   if pass == passCmd1:
     msgWriteln(`%`(HelpMessage, [VersionAsString,
                                  platform.OS[platform.hostOS].name,
-                                 CPU[platform.hostCPU].name]) & AdvancedUsage,
+                                 CPU[platform.hostCPU].name]) & Usage & AdvancedUsage,
                {msgStdout})
     msgQuit(0)
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -876,7 +876,7 @@ proc quit(msg: TMsgKind) =
       writeStackTrace()
     else:
       styledMsgWriteln(fgRed, "No stack traceback available\n" &
-          "To create a stacktrace, rerun compilation with ./koch temp " &
+          "To create a stacktrace, rerun compilation without `-d:release`, eg: ./koch temp " &
           options.command & " <file>")
   quit 1
 

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -87,4 +87,5 @@ Advanced options:
                             value = number of processors (0 for auto-detect)
   --verbosity:0|1|2|3       set Nim's verbosity level (1 is default)
   --experimental            enable experimental language features
+  --deprecatedCommands      show deprecated command line switches (incomplete)
   -v, --version             show detailed version information

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -36,7 +36,7 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
-  --advanced                show advanced command line switches
+  --helpFull                show full command line switches
   -h, --help                show this help
 
 Note, single letter options that take an argument require a colon. E.g. -p:PATH.

--- a/doc/deprecatedopt.txt
+++ b/doc/deprecatedopt.txt
@@ -1,0 +1,4 @@
+    deprecated command line switches
+
+advanced => helpFull
+babelpath => nimblePath


### PR DESCRIPTION
@andreaferretti
shows as:

```
./bin/nim_temp --advanced

Nim Compiler Version 0.18.1 [MacOSX: amd64]
Copyright (c) 2006-2018 by Andreas Rumpf
::

    nim command [options] [projectfile] [arguments]

Command:
  compile, c                compile project with default code generator (C)
  doc                       generate the documentation for inputfile

Arguments:
  arguments are passed to the program being run (if --run option is selected)
Options:
  -p, --path:PATH           add path to search paths
  -d, --define:SYMBOL(:VAL)
                            define a conditional symbol
                            (Optionally: Define the value for that symbol)
  -u, --undef:SYMBOL        undefine a conditional symbol

...

  -r, --run                 run the compiled program with given arguments
  --advanced                show advanced command line switches
  -h, --help                show this help

Note, single letter options that take an argument require a colon. E.g. -p:PATH.
Advanced commands:
  compileToC, cc          compile project with C code generator
  compileToCpp, cpp       compile project to C++ code
  compileToOC, objc       compile project to Objective C code
  js                      compile project to Javascript

...

  --verbosity:0|1|2|3       set Nim's verbosity level (1 is default)
  --experimental            enable experimental language features
  -v, --version             show detailed version information

```

NOTE: if needed I could move `Note, single letter options that take an argument require a colon. E.g. -p:PATH.` outside of `../doc/basicopt.txt` to move it to the end of both --help and --advanced