### PR TITLE
allow stringification of DurationZero

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -352,7 +352,9 @@ proc `$`*(dur: Duration): string =
       parts.add $quantity & " " & unitStrings[unit] & "s"
 
   result = ""
-  if parts.len == 1:
+  if parts.len == 0:
+    result.add "0 nanoseconds"
+  elif parts.len == 1:
     result = parts[0]
   elif parts.len == 2:
     result = parts[0] & " and " & parts[1]


### PR DESCRIPTION
without this PR the following produces runtime errors:
```nim
import times

echo $DurationZero

let n = now()
echo n - n
```
```
Error: unhandled exception: value out of range: -1 [RangeError]
```
