### PR TITLE
address #7586: make hintsSource print context for all msgs, add

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - nimble install sdl1
   - nimble install jester@#head
   - nimble install niminst
-  - nim c --taintMode:on -d:nimCoroutines --hint[source]:off tests/testament/tester
+  - nim c --taintMode:on -d:nimCoroutines tests/testament/tester
   - tests/testament/tester --pedantic all -d:nimCoroutines
   - ./koch web
   - ./koch csource

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
   - nimble install sdl1
   - nimble install jester@#head
   - nimble install niminst
-  - nim c --taintMode:on -d:nimCoroutines tests/testament/tester
+  - nim c --taintMode:on -d:nimCoroutines --hint[source]:off tests/testament/tester
   - tests/testament/tester --pedantic all -d:nimCoroutines
   - ./koch web
   - ./koch csource

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - cd ..
 
 build_script:
-# NOTE: keep in sync with .travis.yml (or use a common base)
+  # NOTE: keep in sync with .travis.yml (or use a common base)
   - bin\nim c koch
   - koch boot -d:release
   - koch nimble
@@ -53,7 +53,7 @@ build_script:
   - nimble install sdl1
   - nimble install jester@#head
   - nimble install niminst
-  - nim c --taintMode:on -d:nimCoroutines --hint[source]:off tests/testament/tester
+  - nim c --taintMode:on -d:nimCoroutines tests/testament/tester
 
 test_script:
   - tests\testament\tester --pedantic all -d:nimCoroutines

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ install:
   - cd ..
 
 build_script:
+# NOTE: keep in sync with .travis.yml (or use a common base)
   - bin\nim c koch
   - koch boot -d:release
   - koch nimble
@@ -52,7 +53,7 @@ build_script:
   - nimble install sdl1
   - nimble install jester@#head
   - nimble install niminst
-  - nim c --taintMode:on -d:nimCoroutines tests/testament/tester
+  - nim c --taintMode:on -d:nimCoroutines --hint[source]:off tests/testament/tester
 
 test_script:
   - tests\testament\tester --pedantic all -d:nimCoroutines

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -535,13 +535,14 @@ const
                                          hintCodeBegin, hintCodeEnd,
                                          hintSource, hintStackTrace,
                                          hintGCStats},
+    # TODO: cleaner to reuse exclustion set from a higher verbosity level
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
                                          warnGcUnsafe,
                                          hintPath,
                                          hintDependency,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintStackTrace,
+                                         hintSource, hintStackTrace,
                                          hintGCStats},
     {low(TNoteKind)..high(TNoteKind)} - {hintStackTrace, warnUninit},
     {low(TNoteKind)..high(TNoteKind)}]

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -467,7 +467,7 @@ const
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
-    "Source", "SourceError", "Performance", "StackTrace", "GCStats",
+    "Source", "Performance", "StackTrace", "GCStats",
     "User", "UserRaw"]
 
 const

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -134,7 +134,7 @@ type
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
     hintExecuting, hintLinking, hintDependency,
-    hintSource, hintPerformance, hintStackTrace, hintGCStats,
+    hintSource, hintSourceError, hintPerformance, hintStackTrace, hintGCStats,
     hintUser, hintUserRaw
 
 const
@@ -387,6 +387,8 @@ const
     errCompilerDoesntSupportTarget: "The current compiler \'$1\' doesn't support the requested compilation target",
     errInOutFlagNotExtern: "The `$1` modifier can be used only with imported types",
     errUser: "$1",
+
+    # sync with `WarningsToStr`
     warnCannotOpenFile: "cannot open \'$1\'",
     warnOctalEscape: "octal escape sequences do not exist; leading zero is ignored",
     warnXIsNeverRead: "\'$1\' is never read",
@@ -418,6 +420,8 @@ const
     warnLockLevel: "$1",
     warnResultShadowed: "Special variable 'result' is shadowed.",
     warnUser: "$1",
+
+    # sync with `HintsToStr`
     hintSuccess: "operation successful",
     hintSuccessX: "operation successful ($# lines compiled; $# sec total; $#; $#)",
     hintLineTooLong: "line too long",
@@ -438,11 +442,13 @@ const
     hintLinking: "",
     hintDependency: "$1",
     hintSource: "$1",
+    hintSourceError: "$1",
     hintPerformance: "$1",
     hintStackTrace: "$1",
     hintGCStats: "$1",
     hintUser: "$1",
-    hintUserRaw: "$1"]
+    hintUserRaw: "$1",
+  ]
 
 const
   WarningsToStr* = ["CannotOpenFile", "OctalEscape",
@@ -457,11 +463,12 @@ const
     "ProveInit", "ProveField", "ProveIndex", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed", "User"]
 
+  # TODO: this is brittle; consider using a proc that strips hint, eg: hintStackTrace => StackTrace
   HintsToStr* = ["Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
-    "Source", "Performance", "StackTrace", "GCStats",
+    "Source", "SourceError", "Performance", "StackTrace", "GCStats",
     "User", "UserRaw"]
 
 const
@@ -527,7 +534,7 @@ const
                                          hintDependency,
                                          hintExecuting, hintLinking,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintStackTrace,
+                                         hintSource, hintSourceError, hintStackTrace,
                                          hintGCStats},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
@@ -535,9 +542,9 @@ const
                                          hintPath,
                                          hintDependency,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintStackTrace,
+                                         hintSource, hintSourceError, hintStackTrace,
                                          hintGCStats},
-    {low(TNoteKind)..high(TNoteKind)} - {hintStackTrace, warnUninit},
+    {low(TNoteKind)..high(TNoteKind)} - {hintSource, hintStackTrace, warnUninit},
     {low(TNoteKind)..high(TNoteKind)}]
 
 const
@@ -1032,7 +1039,7 @@ proc liMessage(info: TLineInfo, msg: TMsgKind, arg: string,
                          KindColor, `%`(KindFormat, kind))
       else:
         styledMsgWriteln(styleBright, x, resetStyle, color, title, resetStyle, s)
-      if msg in errMin..errMax and hintSource in gNotes:
+      if hintSource in gNotes or (msg in errMin..errMax and hintSourceError in gNotes):
         info.writeSurroundingSrc
   handleError(msg, eh, s)
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -134,7 +134,7 @@ type
     hintProcessing, hintCodeBegin, hintCodeEnd, hintConf, hintPath,
     hintConditionAlwaysTrue, hintName, hintPattern,
     hintExecuting, hintLinking, hintDependency,
-    hintSource, hintSourceError, hintPerformance, hintStackTrace, hintGCStats,
+    hintSource, hintPerformance, hintStackTrace, hintGCStats,
     hintUser, hintUserRaw
 
 const
@@ -442,7 +442,6 @@ const
     hintLinking: "",
     hintDependency: "$1",
     hintSource: "$1",
-    hintSourceError: "$1",
     hintPerformance: "$1",
     hintStackTrace: "$1",
     hintGCStats: "$1",
@@ -534,7 +533,7 @@ const
                                          hintDependency,
                                          hintExecuting, hintLinking,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintSourceError, hintStackTrace,
+                                         hintSource, hintStackTrace,
                                          hintGCStats},
     {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
                                          warnProveField, warnProveIndex,
@@ -542,9 +541,9 @@ const
                                          hintPath,
                                          hintDependency,
                                          hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintSourceError, hintStackTrace,
+                                         hintStackTrace,
                                          hintGCStats},
-    {low(TNoteKind)..high(TNoteKind)} - {hintSource, hintStackTrace, warnUninit},
+    {low(TNoteKind)..high(TNoteKind)} - {hintStackTrace, warnUninit},
     {low(TNoteKind)..high(TNoteKind)}]
 
 const
@@ -1039,7 +1038,7 @@ proc liMessage(info: TLineInfo, msg: TMsgKind, arg: string,
                          KindColor, `%`(KindFormat, kind))
       else:
         styledMsgWriteln(styleBright, x, resetStyle, color, title, resetStyle, s)
-      if hintSource in gNotes or (msg in errMin..errMax and hintSourceError in gNotes):
+      if hintSource in gNotes:
         info.writeSurroundingSrc
   handleError(msg, eh, s)
 

--- a/tests/testament/specs.nim
+++ b/tests/testament/specs.nim
@@ -15,8 +15,10 @@ var compilerPrefix* = "compiler" / "nim "
 let isTravis = existsEnv("TRAVIS")
 let isAppVeyor = existsEnv("APPVEYOR")
 
+const extraArgTesting = " --hint[source]=off "
+
 proc cmdTemplate*(): string =
-  compilerPrefix & "$target --lib:lib --hints:on -d:testing $options $file"
+  compilerPrefix & "$target --lib:lib --hints:on " & extraArgTesting & " -d:testing $options $file"
 
 type
   TTestAction* = enum
@@ -186,8 +188,10 @@ proc parseSpec*(filename: string): TSpec =
         raise newException(ValueError, "cannot interpret as a bool: " & e.value)
     of "cmd":
       if e.value.startsWith("nim "):
-        result.cmd = compilerPrefix & e.value[4..^1]
+        # TODO: could we have something cleaner, based on a nim.cfg for tests only?
+        result.cmd = compilerPrefix & extraArgTesting & e.value[4..^1]
       else:
+        # TODO: can we remove this branch? seems like doesn't happen (search for '^cmd:')
         result.cmd = e.value
     of "ccodecheck": result.ccodeCheck = e.value
     of "maxcodesize": discard parseInt(e.value, result.maxCodeSize)


### PR DESCRIPTION
partially address https://github.com/nim-lang/Nim/issues/7586: make hintsSource print context for all msgs, add hintsSourceError to print context for errors (ie last entry if
compilation aborts on error); adjust these hints in verbosity; minor
code clarification


## NOTE:
also had to add `--hint[sourceError]:off` to tests/errmsgs/t5167_5.nim 