### PR TITLE
[error messages]: show col using visible marker instead of newline + caret, saves 2 lines per msg

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -970,8 +970,15 @@ proc resetAttributes* =
 
 proc writeSurroundingSrc(info: TLineInfo) =
   const indent = "  "
-  msgWriteln(indent & $info.sourceLine)
-  msgWriteln(indent & spaces(info.col) & '^')
+  let col = info.col
+  let src = $info.sourceLine
+  if optUseColors in gGlobalOptions:
+      styledMsgWriteln(indent, src[0..<col], styleUnderscore, src[col .. col],
+        resetStyle, src[col+1 .. ^1])
+  else:
+      msgWriteln(indent & $src)
+      # BUG: doesn't work if source uses chars of width !=1 (eg UTF8 chars)
+      msgWriteln(indent & spaces(col) & '^')
 
 proc formatMsg*(info: TLineInfo, msg: TMsgKind, arg: string): string =
   let title = case msg


### PR DESCRIPTION
when colors are enabled, use underline instead of newline + caret to save a line.
especially useful in combination with https://github.com/nim-lang/Nim/issues/7586 to avoid generating too many lines
as an added bonus, this works around a bug where the caret is misplaced in case there are UTF8 characters before it (since these will have width !=1 )

## after this PR:

with `--colors:on:`

![image](https://user-images.githubusercontent.com/2194784/38843323-4a80a23c-41a3-11e8-8b5d-a09b764840a3.png)

with `--colors:off:`
![image](https://user-images.githubusercontent.com/2194784/38843335-58179b3a-41a3-11e8-974d-826f575cfe50.png)
(shows pre-existing **bug** where the caret is misplaced due to preceding UTF8 chars: should point to `a`)

## before this PR:

with `--colors:on:`

![image](https://user-images.githubusercontent.com/2194784/38843389-ad37e80e-41a3-11e8-80d9-94ae23678ef5.png)
(cf same pre-existing **bug** mentioned above)

with `--colors:off:`

unchanged

## NOTE:
IIRC, nimgrep also uses underline instead of caret