### PR TITLE
[WIP] [do not review] travis: add `rvm get head` to fix error: `shell_session_update: command not found`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
     - libsfml-dev
 
 before_install:
+  # avoids: /Users/travis/.rvm/scripts/functions/support: line 57: shell_session_update: command not found
+  - rvm get head
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boehmgc; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sfml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 
 before_install:
   # avoids: /Users/travis/.rvm/scripts/functions/support: line 57: shell_session_update: command not found
-  - rvm get head
+  - rvm get head || true
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boehmgc; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sfml; fi


### PR DESCRIPTION
all travis jobs have a job that fail with:
/Users/travis/.rvm/scripts/functions/support: line 57: shell_session_update: command not found
it's an "Allowed Failures " so won't stop build, but should still be fixed;
eg:
https://travis-ci.org/nim-lang/Nim/jobs/367855705
```
8.60s$ git clone --depth 1 https://github.com/nim-lang/csources.git
Cloning into 'csources'...
remote: Counting objects: 933, done.
remote: Compressing objects: 100% (312/312), done.
remote: Total 933 (delta 793), reused 644 (delta 620), pack-reused 0
Receiving objects: 100% (933/933), 3.84 MiB | 5.42 MiB/s, done.
Resolving deltas: 100% (793/793), done.
Checking out files: 100% (4940/4940), done.
$ cd csources
/Users/travis/.rvm/scripts/functions/support: line 57: shell_session_update: command not found
```

other eg: https://travis-ci.org/nim-lang/Nim/jobs/367840604

marking as WIP until i verify it fixes the bug

## related:

https://github.com/travis-ci/travis-ci/issues/9511
https://superuser.com/questions/1044130/why-am-i-having-how-can-i-fix-this-error-shell-session-update-command-not-f

## EDIT
doesn't work yet