### PR TITLE
hasCustomPragma/getCustomPragmaVal: small fix

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1288,7 +1288,11 @@ proc customPragmaNode(n: NimNode): NimNode =
     typ = n.getTypeInst()
 
   if typ.typeKind == ntyTypeDesc:
-    return typ[1].getImpl()[0][1]
+    let impl = typ[1].getImpl()
+    if impl[0].kind == nnkPragmaExpr:
+      return impl[0][1]
+    else:
+      return impl[0] # handle types which don't have macro at all
 
   if n.kind == nnkSym: # either an variable or a proc
     let impl = n.getImpl()

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -51,6 +51,9 @@ block: # A bit more advanced case
 
   static: assert(hasCustomPragma(myproc, alternativeKey))
 
+  const hasFieldCustomPragma = s.field.hasCustomPragma(defaultValue)
+  static: assert(hasFieldCustomPragma == false)
+
   # pragma on an object
   static:
     assert Subfield.hasCustomPragma(defaultValue)
@@ -70,6 +73,8 @@ block: # ref types
 
     MyFile {.defaultValue: "closed".} = ref object
       path {.defaultValue: "invalid".}: string
+
+    TypeWithoutPragma = object
 
   var s = NodeRef()
 
@@ -102,6 +107,9 @@ block: # ref types
   static:
     assert fileDefVal == "closed"
     assert filePathDefVal == "invalid"
+  
+  static:
+    assert TypeWithoutPragma.hasCustomPragma(defaultValue) == false
 
 block:
   type

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -107,7 +107,7 @@ block: # ref types
   static:
     assert fileDefVal == "closed"
     assert filePathDefVal == "invalid"
-  
+
   static:
     assert TypeWithoutPragma.hasCustomPragma(defaultValue) == false
 

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -96,7 +96,7 @@ block: # ref types
 
   var ptrS = NodePtr(nil)
   const
-    ptrRightSerKey = getCustomPragmaVal(s.right, serializationKey)
+    ptrRightSerKey = getCustomPragmaVal(ptrS.right, serializationKey)
   static:
     assert ptrRightSerKey == "r"
 


### PR DESCRIPTION
sorry, I forgot add a check whether a type has any pragma at all.

Passing a type without a pragma to `hasCustomPragma` or `getCustomPragmaVal`, without this fix, results in an index error.