### PR TITLE
small changes to editDistance

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1898,12 +1898,12 @@ proc editDistance*(a, b: string): int {.noSideEffect,
 
   # strip common prefix:
   var s = 0
-  while a[s] == b[s] and a[s] != '\0':
+  while s < len1 and a[s] == b[s]:
     inc(s)
     dec(len1)
     dec(len2)
   # strip common suffix:
-  while len1 > 0 and len2 > 0 and a[s+len1-1] == b[s+len2-1]:
+  while len1 > 0 and a[s+len1-1] == b[s+len2-1]:
     dec(len1)
     dec(len2)
   # trivial cases:


### PR DESCRIPTION
the first change prevents checking the null byte (which is not secure when it occurs inside the string and should be changed anyways).

the second change removes a tautologic check:
at line 1905 len1 is still always <= len2 because the same operations where done to both and at the begin len1 is also definetly <= len2.
Especially this means that if `len1 > 0` also `len2 > 0` is always true.