### PR TITLE
Fixes #802, #803 and #3775 - genscript issues

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -648,6 +648,7 @@ proc processSwitch(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "genscript", "gendeps":
     expectNoArg(switch, arg, pass, info)
     incl(gGlobalOptions, optGenScript)
+    incl(gGlobalOptions, optCompileOnly)
   of "colors": processOnOffSwitchG({optUseColors}, arg, pass, info)
   of "lib":
     expectArg(switch, arg, pass, info)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -470,8 +470,9 @@ proc execExternalProgram*(cmd: string, msg = hintExecuting) =
 
 proc generateScript(projectFile: string, script: Rope) =
   let (dir, name, ext) = splitFile(projectFile)
-  writeRope(script, dir / addFileExt("compile_" & name,
+  writeRope(script, dir / "nimcache" / addFileExt("compile_" & name,
                                      platform.OS[targetOS].scriptExt))
+  copyFile(libpath / "nimbase.h", dir / "nimcache" / "nimbase.h")
 
 proc getOptSpeed(c: TSystemCC): string =
   result = getConfigVar(c, ".options.speed")

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -470,9 +470,9 @@ proc execExternalProgram*(cmd: string, msg = hintExecuting) =
 
 proc generateScript(projectFile: string, script: Rope) =
   let (dir, name, ext) = splitFile(projectFile)
-  writeRope(script, dir / "nimcache" / addFileExt("compile_" & name,
+  writeRope(script, getNimcacheDir() / addFileExt("compile_" & name,
                                      platform.OS[targetOS].scriptExt))
-  copyFile(libpath / "nimbase.h", dir / "nimcache" / "nimbase.h")
+  copyFile(libpath / "nimbase.h", getNimcacheDir() / "nimbase.h")
 
 proc getOptSpeed(c: TSystemCC): string =
   result = getConfigVar(c, ".options.speed")

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,7 +35,7 @@ Advanced options:
   --noLinking               compile Nim and generated files but do not link
   --noMain                  do not generate a main procedure
   --genScript               generate a compile script (in the 'nimcache'
-                            subdirectory named 'compile_$project$scriptext'),
+                            subdirectory named 'compile_$$project$$scriptext'),
                             implies --compileOnly
   --genDeps                 generate a '.deps' file containing the dependencies
   --os:SYMBOL               set the target operating system (cross-compilation)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,7 +35,8 @@ Advanced options:
   --noLinking               compile Nim and generated files but do not link
   --noMain                  do not generate a main procedure
   --genScript               generate a compile script (in the 'nimcache'
-                            subdirectory named 'compile_$project$scriptext')
+                            subdirectory named 'compile_$project$scriptext'),
+                            implies --compileOnly
   --genDeps                 generate a '.deps' file containing the dependencies
   --os:SYMBOL               set the target operating system (cross-compilation)
   --cpu:SYMBOL              set the target processor (cross-compilation)

--- a/tests/flags/tgenscript.nim
+++ b/tests/flags/tgenscript.nim
@@ -1,0 +1,5 @@
+discard """
+    cmd: "nim c --genscript $file"
+"""
+
+echo "--genscript"

--- a/tests/flags/tgenscript.nim
+++ b/tests/flags/tgenscript.nim
@@ -1,5 +1,5 @@
 discard """
-    cmd: "nim c --genscript $file"
+  file: "tgenscript.nim"
 """
 
 echo "--genscript"

--- a/tests/testament/backend.nim
+++ b/tests/testament/backend.nim
@@ -13,7 +13,7 @@ type
   CommitId = distinct string
 
 proc `$`*(id: MachineId): string {.borrow.}
-proc `$`(id: CommitId): string {.borrow.}
+#proc `$`(id: CommitId): string {.borrow.} # not used
 
 var
   thisMachine: MachineId

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -78,15 +78,20 @@ proc flagTests(r: var TResults, cat: Category, options: string) =
   var build = ""
   var run = ""
   var cmd = "cd " & flagsDir / "nimcache" & " && "
+  var script = "compile_tgenscript"
   when defined(windows):
     cmd = "cmd /c " & cmd & "$#"
-    build = ".bat"
+    script &= ".bat"
 
   when defined(linux):
     cmd = "bash -c \"" & cmd & "./$#\""
-    build = ".sh"
+    script &= ".sh"
 
-  build = cmd % "compile_tgenscript" & build
+    setFilePermissions(flagsDir / "nimcache" / script,
+      {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupRead,
+       fpOthersExec, fpOthersRead})
+
+  build = cmd % script
   run = cmd % "tgenscript"
 
   # Build

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -84,7 +84,7 @@ proc flagTests(r: var TResults, cat: Category, options: string) =
     script &= ".bat"
 
   when defined(linux):
-    cmd = "bash -c \"" & cmd & "./$#\""
+    cmd = "sh -c \"" & cmd & "./$#\""
     script &= ".sh"
 
     setFilePermissions(flagsDir / "nimcache" / script,

--- a/tests/testament/htmlgen.nim
+++ b/tests/testament/htmlgen.nim
@@ -121,7 +121,7 @@ proc generateAllTestsContent(outfile: File, allResults: AllTests,
 
 proc generateHtml*(filename: string, onlyFailing: bool) =
   let
-    currentTime = getTime().getLocalTime()
+    currentTime = getTime().local()
     timestring = htmlQuote format(currentTime, "yyyy-MM-dd HH:mm:ss 'UTC'zzz")
   var outfile = open(filename, fmWrite)
 

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -16,7 +16,7 @@ import
 
 const
   resultsFile = "testresults.html"
-  jsonFile = "testresults.json"
+  #jsonFile = "testresults.json" # not used
   Usage = """Usage:
   tester [options] command [arguments]
 
@@ -150,11 +150,11 @@ proc initResults: TResults =
   result.skipped = 0
   result.data = ""
 
-proc readResults(filename: string): TResults =
-  result = marshal.to[TResults](readFile(filename).string)
+#proc readResults(filename: string): TResults = # not used
+#  result = marshal.to[TResults](readFile(filename).string)
 
-proc writeResults(filename: string, r: TResults) =
-  writeFile(filename, $$r)
+#proc writeResults(filename: string, r: TResults) = # not used
+#  writeFile(filename, $$r)
 
 proc `$`(x: TResults): string =
   result = ("Tests passed: $1 / $3 <br />\n" &

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -404,6 +404,21 @@ proc testC(r: var TResults, test: TTest) =
     if exitCode != 0: given.err = reExitCodesDiffer
   if given.err == reSuccess: inc(r.passed)
 
+proc testExec(r: var TResults, test: TTest) =
+  # runs executable or script, just goes by exit code
+  inc(r.total)
+  let (outp, errC) = execCmdEx(test.options)
+  var given: TSpec
+  specDefaults(given)
+  if errC == 0:
+    given.err = reSuccess
+  else:
+    given.err = reExitCodesDiffer
+    given.msg = outp.string
+
+  if given.err == reSuccess: inc(r.passed)
+  r.addResult(test, targetC, "", given.msg, given.err)
+
 proc makeTest(test, options: string, cat: Category, action = actionCompile,
               env: string = ""): TTest =
   # start with 'actionCompile', will be overwritten in the spec:

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -407,7 +407,7 @@ proc testC(r: var TResults, test: TTest) =
 proc testExec(r: var TResults, test: TTest) =
   # runs executable or script, just goes by exit code
   inc(r.total)
-  let (outp, errC) = execCmdEx(test.options)
+  let (outp, errC) = execCmdEx(test.options.strip())
   var given: TSpec
   specDefaults(given)
   if errC == 0:


### PR DESCRIPTION
Fixes #802 - moved compile script into the `nimcache` directory - makes most sense since the idea is to take this `nimcache` directory onto the target machine to build so having the script together with the code makes sense. Also easy since the `.c` file paths don't need any adjustments in the generated script.

Fixes #803 - copies `nimbase.h` into the `nimcache` directory since it is required for build on the target machine.

Fixes #3775 - `--genscript` means `noAbsolutePaths()` so compile commands all failed due to bad paths. But there's no reason to compile anything on this machine, so `--genscript` should imply `--compileOnly`.