### PR TITLE
Don't hide overflow/underflow/divbyzero in semfold 

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -612,13 +612,13 @@ proc firstOrd*(t: PType): BiggestInt =
     else:
       assert(t.n.sons[0].kind == nkSym)
       result = t.n.sons[0].sym.position
-  of tyGenericInst, tyDistinct, tyTypeDesc, tyAlias:
+  of tyGenericInst, tyDistinct, tyTypeDesc, tyAlias, tyStatic:
     result = firstOrd(lastSon(t))
   of tyOrdinal:
     if t.len > 0: result = firstOrd(lastSon(t))
-    else: internalError("invalid kind for first(" & $t.kind & ')')
+    else: internalError("invalid kind for firstOrd(" & $t.kind & ')')
   else:
-    internalError("invalid kind for first(" & $t.kind & ')')
+    internalError("invalid kind for firstOrd(" & $t.kind & ')')
     result = 0
 
 proc lastOrd*(t: PType; fixedUnsigned = false): BiggestInt =
@@ -651,14 +651,14 @@ proc lastOrd*(t: PType; fixedUnsigned = false): BiggestInt =
   of tyEnum:
     assert(t.n.sons[sonsLen(t.n) - 1].kind == nkSym)
     result = t.n.sons[sonsLen(t.n) - 1].sym.position
-  of tyGenericInst, tyDistinct, tyTypeDesc, tyAlias:
+  of tyGenericInst, tyDistinct, tyTypeDesc, tyAlias, tyStatic:
     result = lastOrd(lastSon(t))
   of tyProxy: result = 0
   of tyOrdinal:
     if t.len > 0: result = lastOrd(lastSon(t))
-    else: internalError("invalid kind for last(" & $t.kind & ')')
+    else: internalError("invalid kind for lastOrd(" & $t.kind & ')')
   else:
-    internalError("invalid kind for last(" & $t.kind & ')')
+    internalError("invalid kind for lastOrd(" & $t.kind & ')')
     result = 0
 
 proc lengthOrd*(t: PType): BiggestInt =

--- a/tests/misc/tsemfold.nim
+++ b/tests/misc/tsemfold.nim
@@ -1,0 +1,23 @@
+discard """
+  action: run
+"""
+
+doAssertRaises(OverflowError): discard low(int8) - 1'i8
+doAssertRaises(OverflowError): discard high(int8) + 1'i8
+doAssertRaises(OverflowError): discard abs(low(int8))
+doAssertRaises(DivByZeroError): discard 1 mod 0
+doAssertRaises(DivByZeroError): discard 1 div 0
+doAssertRaises(OverflowError): discard low(int8) div -1'i8
+
+doAssertRaises(OverflowError): discard low(int64) - 1'i64
+doAssertRaises(OverflowError): discard high(int64) + 1'i64
+
+type E = enum eA, eB
+doAssertRaises(OverflowError): discard eA.pred
+doAssertRaises(OverflowError): discard eB.succ
+
+doAssertRaises(OverflowError): discard low(int8) * -1
+doAssertRaises(OverflowError): discard low(int64) * -1
+doAssertRaises(OverflowError): discard high(int8) * 2
+doAssertRaises(OverflowError): discard high(int64) * 2
+

--- a/tests/typerel/ttypelessemptyset.nim
+++ b/tests/typerel/ttypelessemptyset.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "internal error: invalid kind for last(tyEmpty)"
+  errormsg: "internal error: invalid kind for lastOrd(tyEmpty)"
 """
 var q = false
 discard (if q: {} else: {})


### PR DESCRIPTION
An attempt fix an old compiler issue...

Currently, saturated arithmetic is used to implement constant folding. This means that arithmetic operations behaves differently when evaluated by the constant folder compared to when they are evaluated during run time or by the VM, since saturated arithmetic hides overflows:
```nim
static:
    var x = high(int8)
    echo x + 1 # Error

var x = high(int8)
echo x + 1 # Error

echo high(int8) + 1 # Prints 128
```

This PR changes the behavior of constant folding so that folding only occurs when the arithmetic operation is safe (no over-/underflow or division by zero). When the operation is not safe, no folding is performed, which results in a run time error. Note that it's not a good idea to give a compile time error, because it might catch errors that logically can't happen. For example, this should compile:
```nim
const x = high(int8)
let y =
  if x == high(int8):
    x
  else:
    x + 1
```
(most of these are actually duplicates)

Fixes #6997
Fixes #5829
Fixes #2814
Fixes #1732
Fixes #5326
