### PR TITLE
Optionally disable std C++

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -265,7 +265,7 @@ proc rdCharLoc(a: TLoc): Rope =
 
 proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: TLoc,
                    takeAddr: bool) =
-  if p.module.compileToCpp and t.isException:
+  if p.module.compileToCpp and t.isException and not isDefined("noCppExceptions"):
     # init vtable in Exception object for polymorphic exceptions
     includeHeader(p.module, "<new>")
     linefmt(p, section, "new ($1) $2;$n", rdLoc(a), getTypeDesc(p.module, t))

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4172,8 +4172,9 @@ template doAssertRaises*(exception, code: untyped): typed =
   if wrong:
     raiseAssert(astToStr(exception) & " wasn't raised by:\n" & astToStr(code))
 
-when defined(cpp) and appType != "lib" and not defined(js) and
-    not defined(nimscript) and hostOS != "standalone":
+when defined(cpp) and appType != "lib" and
+    not defined(js) and not defined(nimscript) and
+    hostOS != "standalone" and not defined(noCppExceptions):
   proc setTerminate(handler: proc() {.noconv.})
     {.importc: "std::set_terminate", header: "<exception>".}
   setTerminate proc() {.noconv.} =


### PR DESCRIPTION
Compiling Nim for the Genode OS target always requires compiling to C++, but Std C++ is unacceptably complex and too bulky for us to link with by default. This also means avoiding the `new` keyword, as our C++ runtime lacks an implicit allocator backend (a feature, not an omission).