### PR TITLE
Fixes #7764

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -727,6 +727,14 @@ proc getch*(): char =
       doAssert(readConsoleInput(fd, addr(keyEvent), 1, addr(numRead)) != 0)
       if numRead == 0 or keyEvent.eventType != 1 or keyEvent.bKeyDown == 0:
         continue
+      case keyEvent.uChar
+      of 0, 0x0E:
+        # ignore the first SHIFT_PRESSED event - the subsequent read
+        # has the result. Details:
+        # https://github.com/nim-lang/Nim/issues/7764
+        if (keyEvent.dwControlKeyState and SHIFT_PRESSED) == SHIFT_PRESSED:
+          continue
+      else: discard        
       return char(keyEvent.uChar)
   else:
     let fd = getFileHandle(stdin)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -727,12 +727,6 @@ proc getch*(): char =
       doAssert(readConsoleInput(fd, addr(keyEvent), 1, addr(numRead)) != 0)
       if numRead == 0 or keyEvent.eventType != 1 or keyEvent.bKeyDown == 0:
         continue
-      if keyEvent.uChar == 0:
-        # ignore the first SHIFT_PRESSED event - the subsequent read
-        # has the result. Details:
-        # https://github.com/nim-lang/Nim/issues/7764
-        if (keyEvent.dwControlKeyState and SHIFT_PRESSED) == SHIFT_PRESSED:
-          continue     
       return char(keyEvent.uChar)
   else:
     let fd = getFileHandle(stdin)
@@ -765,6 +759,10 @@ when defined(windows):
           x = runeLenAt(password.string, i)
           inc i, x
         password.string.setLen(max(password.len - x, 0))
+      of chr(0x0):
+        # modifier key - ignore - for details see 
+        # https://github.com/nim-lang/Nim/issues/7764
+        continue
       else:
         password.string.add(toUTF8(c.Rune))
     stdout.write "\n"

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -727,8 +727,7 @@ proc getch*(): char =
       doAssert(readConsoleInput(fd, addr(keyEvent), 1, addr(numRead)) != 0)
       if numRead == 0 or keyEvent.eventType != 1 or keyEvent.bKeyDown == 0:
         continue
-      case keyEvent.uChar
-      of 0, 0x0E:
+      if keyEvent.uChar == 0:
         # ignore the first SHIFT_PRESSED event - the subsequent read
         # has the result. Details:
         # https://github.com/nim-lang/Nim/issues/7764

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -732,8 +732,7 @@ proc getch*(): char =
         # has the result. Details:
         # https://github.com/nim-lang/Nim/issues/7764
         if (keyEvent.dwControlKeyState and SHIFT_PRESSED) == SHIFT_PRESSED:
-          continue
-      else: discard        
+          continue     
       return char(keyEvent.uChar)
   else:
     let fd = getFileHandle(stdin)

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1064,17 +1064,6 @@ type
     uChar*: int16
     dwControlKeyState*: DWORD
 
-const 
-  CAPS_LOCK_ON* = 0x0080'i32
-  ENHANCED_KEY* = 0x0100'i32
-  LEFT_ALT_PRESSED* = 0x0002'i32
-  LEFT_CTRL_PRESSED* = 0x0008'i32
-  NUMLOCK_ON* = 0x0020'i32
-  RIGHT_ALT_PRESSED* = 0x0001'i32
-  RIGHT_CTRL_PRESSED* = 0x0004'i32
-  SCROLLLOCK_ON* = 0x0040'i32
-  SHIFT_PRESSED* = 0x0010'i32
-
 when defined(useWinAnsi):
   proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                         lpNumberOfEventsRead: ptr cint): cint

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1064,6 +1064,17 @@ type
     uChar*: int16
     dwControlKeyState*: DWORD
 
+const 
+  CAPS_LOCK_ON* = 0x0080'i32
+  ENHANCED_KEY* = 0x0100'i32
+  LEFT_ALT_PRESSED* = 0x0002'i32
+  LEFT_CTRL_PRESSED* = 0x0008'i32
+  NUMLOCK_ON* = 0x0020'i32
+  RIGHT_ALT_PRESSED* = 0x0001'i32
+  RIGHT_CTRL_PRESSED* = 0x0004'i32
+  SCROLLLOCK_ON* = 0x0040'i32
+  SHIFT_PRESSED* = 0x0010'i32
+
 when defined(useWinAnsi):
   proc readConsoleInput*(hConsoleInput: Handle, lpBuffer: pointer, nLength: cint,
                         lpNumberOfEventsRead: ptr cint): cint


### PR DESCRIPTION
Change getch() implementation on Windows to only return the result of the target key, for instance SHIFT+'a' return 'A'. Current behaviour would return '0x0' and then 'A'.