### PR TITLE
VM fix for refs

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -210,8 +210,14 @@ proc putIntoNode(n: var PNode; x: TFullReg) =
   of rkInt: n.intVal = x.intVal
   of rkFloat: n.floatVal = x.floatVal
   of rkNode:
-    if nfIsRef in x.node.flags: n = x.node
-    else: n[] = x.node[]
+    if nfIsRef in x.node.flags:
+      n = x.node
+    else:
+      let destIsRef = nfIsRef in n.flags    
+      n[] = x.node[]
+      # Ref-ness must be kept for the destination
+      if destIsRef:
+        n.flags.incl nfIsRef
   of rkRegisterAddr: putIntoNode(n, x.regAddr[])
   of rkNodeAddr: n[] = x.nodeAddr[][]
 

--- a/tests/vm/tref.nim
+++ b/tests/vm/tref.nim
@@ -1,0 +1,12 @@
+static:
+  var
+    a: ref string
+    b: ref string
+  new a
+
+  a[] = "Hello world"
+  b = a
+
+  b[5] = 'c'
+  doAssert a[] == "Hellocworld"
+  doAssert b[] == "Hellocworld"


### PR DESCRIPTION
First PR for the VM so it might be completely wrong. Looks like the issue was that assignments like `a[] = "Hello world"` caused the VM to discard all node flags from `a`, which meant that the VM no longer treated it as a ref type. This might be an issue for other flags as well, but I don't know if it would be correct to keep all the old flags from `a`. This PR only keeps the `nfIsRef` flag.

Fixes #7795