### PR TITLE
VM fix for nil assignment

### DIFF
--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -36,7 +36,6 @@ type
     opcAsgnFloat,
     opcAsgnRef,
     opcAsgnComplex,
-    opcRegToNode,
     opcNodeToReg,
 
     opcLdArr,  # a = b[c]

--- a/tests/vm/tnilref.nim
+++ b/tests/vm/tnilref.nim
@@ -1,0 +1,7 @@
+discard """
+  errormsg: "attempt to access a nil address"
+"""
+
+static:
+    var s: ref int
+    s[] = 1

--- a/tests/vm/tref.nim
+++ b/tests/vm/tref.nim
@@ -10,3 +10,48 @@ static:
   b[5] = 'c'
   doAssert a[] == "Hellocworld"
   doAssert b[] == "Hellocworld"
+
+  proc notGlobal() =
+    var
+      a: ref string
+      b: ref string
+    new a
+
+    a[] = "Hello world"
+    b = a
+
+    b[5] = 'c'
+    doAssert a[] == "Hellocworld"
+    doAssert b[] == "Hellocworld"
+  notGlobal()
+
+static: # bug 6081
+  block:
+    type Obj = object
+      field: ref int
+    var i: ref int
+    new(i)
+    var r = Obj(field: i)
+    var rr = r
+    r.field = nil
+    doAssert rr.field != nil
+
+  proc foo() = # Proc to avoid special global logic
+    var s: seq[ref int]
+    var i: ref int
+    new(i)
+    s.add(i)
+    var head = s[0]
+    s[0] = nil
+    doAssert head != nil
+
+  foo()
+
+static:
+
+  block: # global alias
+    var s: ref int
+    new(s)
+    var ss = s
+    s[] = 1
+    doAssert ss[] == 1


### PR DESCRIPTION
Changes with motivations:
- Don't use `putIntoNode` to implement `opcWrDeref`. `putIntoNode` was used for to many things, which made it hard to make it correct for all cases. This change also means that `putIntoNode` doesn't need to handle a bunch of edge cases that are only relevant to `opcWrDefef`.
- Rename `putIntoNode` to `writeField`. This change reflects that the proc is now only used in `opcWrObj`/`opcWrArr`, and it probably shouldn't be used anywhere else.
- Don't allow dereferencing `nil` (see test case in `tests/vm/tnilref.nim`).
- Add `nfIsRef` flag to `sym` nodes (generated by `opcNBindSym` and `opcGenSym`).

Fixes #6081