### PR TITLE
fixes #7842 if no uri.scheme specified raise ValueError with hint

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -1170,6 +1170,9 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: string,
                 {.multisync.} =
   # Helper that actually makes the request. Does not handle redirects.
   let requestUrl = parseUri(url)
+  
+  if requestUrl.scheme == "":
+    raise newException(ValueError,"No url scheme supplied. Perhaps you meant http://")
 
   await newConnection(client, requestUrl)
 

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -1172,7 +1172,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: string,
   let requestUrl = parseUri(url)
   
   if requestUrl.scheme == "":
-    raise newException(ValueError,"No url scheme supplied. Perhaps you meant http://")
+    raise newException(ValueError, "No uri scheme supplied.")
 
   await newConnection(client, requestUrl)
 


### PR DESCRIPTION
This fixes only the `newHttpClient` based version. 
Should i also fix the deprecated?

Signed-off-by: enthus1ast <david@code0.xyz>