### PR TITLE
Renames `await` and derivatives in threadpool to `waitFor`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
   to ``times.Duration`` in order to support higher time resolutions.
   The proc is no longer deprecated.
 - ``posix.Timeval.tv_sec`` has changed type to ``posix.Time``.
+- `await` and derivatives have been renamed to `waitFor` in `threadpool` module.
 
 #### Breaking changes in the compiler
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7830,7 +7830,7 @@ Nim has two flavors of parallelism:
 2) `Unstructured`:idx: parallelism via the standalone ``spawn`` statement.
 
 Nim has a builtin thread pool that can be used for CPU intensive tasks. For
-IO intensive tasks the ``async`` and ``await`` features should be
+IO intensive tasks the ``async`` and ``waitFor`` features should be
 used instead. Both parallel and spawn need the `threadpool <threadpool.html>`_
 module to work.
 
@@ -7882,7 +7882,7 @@ that ``spawn`` takes is restricted:
 
 ``spawn`` executes the passed expression on the thread pool and returns
 a `data flow variable`:idx: ``FlowVar[T]`` that can be read from. The reading
-with the ``^`` operator is **blocking**. However, one can use ``awaitAny`` to
+with the ``^`` operator is **blocking**. However, one can use ``waitForAny`` to
 wait on multiple flow variables at the same time:
 
 .. code-block:: nim
@@ -7893,10 +7893,10 @@ wait on multiple flow variables at the same time:
     var responses = newSeq[FlowVarBase](3)
     for i in 0..2:
       responses[i] = spawn tellServer(Update, "key", "value")
-    var index = awaitAny(responses)
+    var index = waitForAny(responses)
     assert index >= 0
     responses.del(index)
-    discard awaitAny(responses)
+    discard waitForAny(responses)
 
 Data flow variables ensure that no data races
 are possible. Due to technical limitations not every type ``T`` is possible in

--- a/doc/spawn.txt
+++ b/doc/spawn.txt
@@ -25,7 +25,7 @@ Spawn statement
 A standalone ``spawn`` statement is a simple construct. It executes
 the passed expression on the thread pool and returns a `data flow variable`:idx:
 ``FlowVar[T]`` that can be read from. The reading with the ``^`` operator is
-**blocking**. However, one can use ``awaitAny`` to wait on multiple flow
+**blocking**. However, one can use ``waitForAny`` to wait on multiple flow
 variables at the same time:
 
 .. code-block:: nim
@@ -36,10 +36,10 @@ variables at the same time:
     var responses = newSeq[FlowVarBase](3)
     for i in 0..2:
       responses[i] = spawn tellServer(Update, "key", "value")
-    var index = awaitAny(responses)
+    var index = waitForAny(responses)
     assert index >= 0
     responses.del(index)
-    discard awaitAny(responses)
+    discard waitForAny(responses)
 
 Data flow variables ensure that no data races
 are possible. Due to technical limitations not every type ``T`` is possible in


### PR DESCRIPTION
I can add deprecated aliases, but the whole point of this PR is to stop confusion between async's ``await`` and ``threadpool``'s. Keeping deprecated procs will still cause confusion.

Also happy to bikeshed about the name. 