### PR TITLE
add exported `initNimThread` to fix GC segfault when compiled as DLL

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2914,6 +2914,14 @@ when not defined(JS): #and not defined(nimscript):
       strDesc = TNimType(size: sizeof(string), kind: tyString, flags: {ntfAcyclic})
     {.pop.}
 
+    proc initNimThread*() =
+      # Should this have the `rtl` pragma?
+      # If I include it, I get a
+      # could not import: nimrtl_initNimThread
+      initStackBottom()
+      when not defined(gcRegions):
+         initGC()
+
 
   # ----------------- IO Part ------------------------------------------------
   type


### PR DESCRIPTION
While writing a small shared library in Nim, which is supposed to be called from Python, I got random segfaults related to the GC. @zah proposed to define a proc `initNimThread` in `system.nim`, which calls `initStackBottom` and `initGC` (which are both not exported) and call it as the first call to the shared library. That does indeed fix the segfault.

I've reduced the code I was writing to the minimum to reproduce the segfault. And I've updated to the current `devel` (https://github.com/nim-lang/Nim/commit/5db01f7abe960da9430a0440c2b579ad0f2d05bd) to check if the problem persists (yup). 
The Nim library:
```nim
type
  BitArray[T: static[int]] = object
    data*: array[T, bool]
  
proc createBitarray(size: static[int]): BitArray[size] =
  for i in 0 ..< size:
    result.data[i] = false

proc makeSegfault(ba: BitArray): string =
  ## this print function causes the segfault
  # as one would expect if memory is allocated for the result, there is
  # no segfault
  # result = newStringOfCap(10000)
  # if we grow the string however...
  result = ""
  for i in 0 .. 10000:
    # segfaults on my machine ~i == 300 - 500
    echo i
    result.add($ba.data[0])

proc decode_fpga*() {.exportc, dynlib.} =
  # initialized empty
  var bitarray1 = createBitarray(48)
  discard makeSegfault(bitarray1)

proc initThread*() {.exportc, dynlib.} =
  initNimThread()    
```
which I compile with 
```sh
nim c --app:lib gc_segfault.nim
```
Then I simply call it from Python (2.7.6) like so:
```python
from ctypes import *

if __name__=="__main__":
    # load Nim lib 
    nim_lib = CDLL("libgc_segfault.so")

    # if we call `initNimThread` the segfault does not happen
    #nim_lib.initThread()

    nim_lib.decode_fpga()
```
which results in:
```sh
528
Traceback (most recent call last)
gc_segfault.nim(23) decode_fpga
gc_segfault.nim(18) makeSegfault
gc.nim(586)              growObj
gc.nim(533)              growObj
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```
If the `initThread` call is made in the Python script, it does not segfault.

I've also:
- followed https://nim-lang.org/docs/nimc.html#dll-generation and linked against `nimrtl`:
  also crashes
- tested the different GC and the crash only happens with `refc`

@zah mentioned that `initNimThread` should probably have the `rtl` pragma. But if I include that and link against `nimrtl` I get a `could not import: nimrtl_initNimThread`. Not sure how to fix that. 