### PR TITLE
Fixed operator precedence in example

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3196,7 +3196,7 @@ notation. (Thus an operator can have more than two parameters):
     # Multiply and add
     result = a * b + c
 
-  assert `*+`(3, 4, 6) == `*`(a, `+`(b, c))
+  assert `*+`(3, 4, 6) == `+`(`*`(a, b), c)
 
 
 Export marker


### PR DESCRIPTION
The order of operations was incorrect for the right-hand side of the assert statement on line 3199, based on the operator precedence in the procedure result on line 3197. The result of the right side of the assert would actually be a * (b + c) instead of the correct (a * b) + c (this is the explicit equivalent of a * b + c).