### PR TITLE
Add note to import "std/sha1" to sha1.nim (doc)

### DIFF
--- a/lib/std/sha1.nim
+++ b/lib/std/sha1.nim
@@ -7,6 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
+## Note: Import ``std/sha1`` to use this module
+
 import strutils
 
 const Sha1DigestSize = 20


### PR DESCRIPTION
I propose adding a note to the sha1 module documentation to articulate the "import std/sha1" requirement for the time being