### PR TITLE
Support Complex[float32] and Complex[float64]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -86,7 +86,6 @@
 - Added the parameter ``val`` for the ``CritBitTree[int].inc`` proc.
 - An exception raised from ``test`` block of ``unittest`` now shows its type in
   the error message
-- ``complex.toComplex`` now accepts float.
 
 ### Language additions
 
@@ -151,5 +150,3 @@
   language extensions, it is not an all-or-nothing switch anymore.
 
 ### Bugfixes
-
-- Fixed `complex.toComplex` for integer.

--- a/changelog.md
+++ b/changelog.md
@@ -86,7 +86,7 @@
 - Added the parameter ``val`` for the ``CritBitTree[int].inc`` proc.
 - An exception raised from ``test`` block of ``unittest`` now shows its type in
   the error message
-- ``complex.toComplex`` now accepts SomeFloat.
+- ``complex.toComplex`` now accepts float.
 
 ### Language additions
 

--- a/changelog.md
+++ b/changelog.md
@@ -86,6 +86,7 @@
 - Added the parameter ``val`` for the ``CritBitTree[int].inc`` proc.
 - An exception raised from ``test`` block of ``unittest`` now shows its type in
   the error message
+- ``complex.toComplex`` now accepts SomeFloat.
 
 ### Language additions
 
@@ -150,3 +151,5 @@
   language extensions, it is not an all-or-nothing switch anymore.
 
 ### Bugfixes
+
+- Fixed `complex.toComplex` for integer.

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -29,12 +29,13 @@ const
   im*: Complex = (re: 0.0, im: 1.0)
     ## The imaginary unit. √-1.
 
-proc toComplex*(x: SomeInteger): Complex =
-  ## Convert some integer ``x`` to a complex number.
+proc toComplex*(x: SomeInteger|SomeFloat): Complex =
+  ## Convert some float ``x`` to a complex number.
   result.re = x
   result.im = 0.0
 
 proc toComplex*(x: SomeInteger): Complex =
+  ## Convert some integer ``x`` to a complex number.
   result.re = float(x)
   result.im = 0.0
 
@@ -408,8 +409,12 @@ when isMainModule:
   assert( abs(oo) == sqrt(2.0) )
   assert( conjugate(a) == (1.0, -2.0) )
   assert( sqrt(m1) == i )
-  assert( exp(ipi) =~ m1 )
 
+  block: # toComplex tests
+    doAssert toComplex(1.0) == (1.0, 0.0)
+    doAssert toComplex(1) == (1.0, 0.0)
+
+  assert( exp(ipi) =~ m1 )
   assert( pow(a,b) =~ (-3.72999124927876, -1.68815826725068) )
   assert( pow(z,a) =~ (0.0, 0.0) )
   assert( pow(z,z) =~ (1.0, 0.0) )

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -98,9 +98,18 @@ proc `==`*[X: Complex, Y: SomeFloat](x: X, y: Y): bool =
   ## Compare complex number ``x`` and float number ``y`` for equality.
   x.re == y and x.im == 0.0
 
+
 proc `=~`*(x, y: Complex): bool =
-  ## Compare two complex numbers `x` and `y` approximately.
-  result = abs(x.re-y.re)<EPS and abs(x.im-y.im)<EPS
+  ## Compare two complex numbers ``x`` and ``y`` approximately.
+  abs(x.re - y.re) < EPS and abs(x.im - y.im) < EPS
+
+proc `=~`*(x: SomeFloat, y: Complex): bool =
+  ## Compare float number ``x`` and complex number ``y`` approximately.
+  abs(x - y.re) < EPS and abs(y.im) < EPS
+
+proc `=~`*(x: Complex, y: SomeFloat): bool =
+  ## Compare complex number ``x`` and float number ``y`` approximately.
+  abs(x.re - y) < EPS and abs(x.im) < EPS
 
 
 proc `+`*(z: Complex): Complex = z

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -25,7 +25,7 @@ type
   Complex* = tuple[re, im: float]
     ## a complex number, consisting of a real and an imaginary part
 
-proc toComplex*(x: float): Complex =
+proc toComplex*(x: SomeFloat): Complex =
   ## Convert ``x`` to a complex number.
   result.re = x
   result.im = 0.0

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -29,8 +29,8 @@ const
   im*: Complex = (re: 0.0, im: 1.0)
     ## The imaginary unit. √-1.
 
-proc toComplex*(x: SomeInteger|SomeFloat): Complex =
-  ## Convert some float ``x`` to a complex number.
+proc toComplex*(x: float): Complex =
+  ## Convert float ``x`` to a complex number.
   result.re = x
   result.im = 0.0
 

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -25,10 +25,14 @@ type
   Complex* = tuple[re, im: float]
     ## a complex number, consisting of a real and an imaginary part
 
-proc toComplex*(x: SomeInteger): Complex =
-  ## Convert some integer ``x`` to a complex number.
+proc toComplex*(x: float): Complex =
+  ## Convert `x` to a complex number.
   result.re = x
-  result.im = 0
+  result.im = 0.0
+
+proc toComplex*(x: SomeInteger): Complex =
+  result.re = float(x)
+  result.im = 0.0
 
 proc `==` *(x, y: Complex): bool =
   ## Compare two complex numbers `x` and `y` for equality.

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -26,7 +26,7 @@ type
     ## a complex number, consisting of a real and an imaginary part
 
 proc toComplex*(x: float): Complex =
-  ## Convert `x` to a complex number.
+  ## Convert ``x`` to a complex number.
   result.re = x
   result.im = 0.0
 


### PR DESCRIPTION
From https://github.com/nim-lang/Nim/pull/7924 and https://github.com/nim-lang/Nim/pull/4666.
In this PR, I defined `Real = SomeInteger|SomeFloat` and `Number = Real|Complex`, I don't know it's the best name, but we need something type class for represent them. Some language support Complex[int] but here only floating point number is supported.