### PR TITLE
Rename 'im' constant to iota

### DIFF
--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -26,7 +26,7 @@ type
     ## a complex number, consisting of a real and an imaginary part
 
 const
-  im*: Complex = (re: 0.0, im: 1.0)
+  iota*: Complex = (re: 0.0, im: 1.0)
     ## The imaginary unit. √-1.
 
 proc toComplex*(x: SomeInteger): Complex =


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Imaginary_unit#Alternative_notations , the 'i' constant (`sqrt(-1)`) is often noted by use of the iota symbol (`ɩ`). I believe that the current name for `sqrt(-1)` is rather short and not very obvious, and think that 'iota' is a better name (since actually using the iota symbol would be a pain to type).

Since this constant was just added, it shouldn't break anything existing.