### PR TITLE
Fix #7936

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -521,7 +521,9 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
         localError(c.config, a.info, errWrongNumberOfVariables)
       b = newNodeI(nkVarTuple, a.info)
       newSons(b, length)
-      b.sons[length-2] = a.sons[length-2] # keep type desc for doc generator
+      # keep type desc for doc generator
+      # NOTE: at the moment this is always ast.emptyNode, see parser.nim
+      b.sons[length-2] = a.sons[length-2]
       b.sons[length-1] = def
       addToVarSection(c, result, n, b)
     elif tup.kind == tyTuple and def.kind in {nkPar, nkTupleConstr} and
@@ -560,7 +562,12 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
           # keep documentation information:
           b.comment = a.comment
         addSon(b, newSymNode(v))
-        addSon(b, a.sons[length-2])      # keep type desc for doc generator
+        # keep type desc for doc generator, but only if the user explicitly
+        # added it
+        if a.sons[length-2].kind != nkEmpty:
+          addSon(b, newNodeIT(nkType, a.info, typ))
+        else:
+          addSon(b, a.sons[length-2])
         addSon(b, copyTree(def))
         addToVarSection(c, result, n, b)
       else:


### PR DESCRIPTION
The root cause was the unsemanticized typedesc node being passed around in the AST. That's not much of a problem since it's only used during the `doc` phase but, if the definition occurs in a template, we may also run it trough the `Transf` pass.

The fix is pretty simple and beside fixing the problem at hand it also changes the documentation output from:
```nim
result114130: type(().foo) = 1
```
into
```nim
result114130: int = 1
```

Side note: I see you can't really specify the typedesc for a nkVarTuple, is that a design decision or it's just that nobody implemented it yet?

Fixes #7936