### PR TITLE
Fix isUpperAscii, isLowerAscii for strings with non-alpha chars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,10 @@
 - ``math.`mod` `` for floats now behaves the same as ``mod`` for integers
   (previously it used floor division like Python). Use ``math.floorMod`` for the old behavior.
 
+- For string input ``str``, now ``strutils.isUpperAscii(str)`` and
+  ``strutils.isLowerAscii(str)`` do the upper/lower-case checks only for
+  alphabetical characters present in ``str``.
+
 #### Breaking changes in the compiler
 
 - The undocumented ``#? braces`` parsing mode was removed.


### PR DESCRIPTION
This is a partial fix (fix only for `strutils`) for https://github.com/nim-lang/Nim/issues/7963.

Second half of the pending fix would go in `unicode` for `isUpper` and `isLower`.

This is my first code PR for Nim.

I don't understand the pragmas. So I have left them untouched for the 2 modified functions.