### PR TITLE
Fix isUpper, isLower for strings with non-alpha chars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,10 @@
 - ``math.`mod` `` for floats now behaves the same as ``mod`` for integers
   (previously it used floor division like Python). Use ``math.floorMod`` for the old behavior.
 
+- For string input ``str``, now ``unicode.isUpper(str)`` and
+  ``unicode.isLower(str)`` do the upper/lower-case checks only for alphabetical
+  Runes present in ``str``.
+
 #### Breaking changes in the compiler
 
 - The undocumented ``#? braces`` parsing mode was removed.


### PR DESCRIPTION
This PR is the second half of the fix for https://github.com/nim-lang/Nim/issues/7963.

It fixes `isUpper` and `isLower` in the `unicode` library.

First half of the fix was https://github.com/nim-lang/Nim/pull/7978.