### PR TITLE
Added FileMode to comment on asyncfile openAsync

### DIFF
--- a/lib/pure/asyncfile.nim
+++ b/lib/pure/asyncfile.nim
@@ -89,7 +89,7 @@ proc newAsyncFile*(fd: AsyncFd): AsyncFile =
 
 proc openAsync*(filename: string, mode = fmRead): AsyncFile =
   ## Opens a file specified by the path in ``filename`` using
-  ## the specified ``mode`` asynchronously.
+  ## the specified FileMode ``mode`` asynchronously.
   when defined(windows) or defined(nimdoc):
     let flags = FILE_FLAG_OVERLAPPED or FILE_ATTRIBUTE_NORMAL
     let desiredAccess = getDesiredAccess(mode)


### PR DESCRIPTION
Made a simple clarification in the comment for asyncfile.nim openAsync.
It was not self evident to me when working through the code in the Nim In Action book that I was passing a FileMode enum into the openAsync method. The code did not work as I expected and I could not find the documentation desired during simple read of the source. Maybe this change would have helped.

Accept / Reject. I am good either way. It is something simple.