### PR TITLE
fix #5930

### DIFF
--- a/tests/macros/tmacrostmt.nim
+++ b/tests/macros/tmacrostmt.nim
@@ -1,5 +1,5 @@
 import macros
-macro case_token(n: untyped): untyped {.immediate.} =
+macro case_token(n: varargs[untyped]): untyped =
   # creates a lexical analyzer from regular expressions
   # ... (implementation is an exercise for the reader :-)
   nil
@@ -21,6 +21,6 @@ case_token: inc i
 macro foo: typed =
   var exp = newCall("whatwhat", newIntLitNode(1))
   if compiles(getAst(exp)): return exp
-  else: echo "Does not compute!"
+  else: echo "Does not compute! (test OK)"
 
 foo()


### PR DESCRIPTION
my original issue was that I could not remove immediate from this test case. I want to remove immediate from this test case, because this test was where I learned about the macro case statement. I would not want that anybody else who learns from this test case also "learns" to use the deprecated immediate pragma with it.