### PR TITLE
Fixed uncaught exception in vm gen

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -804,7 +804,7 @@ proc genIntCast(c: PCtx; n: PNode; dest: var TDest) =
   else:
     globalError(c.config, n.info, "VM is only allowed to 'cast' between integers of same size")
 
-proc genVoidABC(c: PCtx, n: PNode, dest: TRegister, opcode: TOpcode) =
+proc genVoidABC(c: PCtx, n: PNode, dest: TDest, opcode: TOpcode) =
   unused(c, n, dest)
   var
     tmp1 = c.genx(n[1])


### PR DESCRIPTION
This typo (?) caused out of range exception when `dest` was `-1`. Unfortunately I could not come up with a nice reproducible sample.