### PR TITLE
hotfix 3221ac094398492e09ea618638204793b0990eca broke gc:regions/aka …

### DIFF
--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -562,7 +562,8 @@ else:
 when not declared(nimNewSeqOfCap):
   proc nimNewSeqOfCap(typ: PNimType, cap: int): pointer {.compilerproc.} =
     when defined(gcRegions):
-      result = newStr(typ, cap, ntfNoRefs notin typ.base.flags)
+      let s = mulInt(cap, typ.base.size)  # newStr already adds GenericSeqSize
+      result = newStr(typ, s, ntfNoRefs notin typ.base.flags)
     else:
       let s = addInt(mulInt(cap, typ.base.size), GenericSeqSize)
       when declared(newObjNoInit):


### PR DESCRIPTION
…gc:stack by

underallocating for sequences of any type larger than 1 byte.  This does the
necessary multiply to restore basic functionality.