### PR TITLE
[WIP] Default values for static parameters have no static

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2357,6 +2357,8 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
         var def = copyTree(formal.ast)
         if def.kind == nkNilLit:
           def = implicitConv(nkHiddenStdConv, formal.typ, def, m, c)
+        if formal.typ.kind == tyStatic:
+          def = makeStaticExpr(c, def)
         if {tfImplicitTypeParam, tfGenericTypeParam} * formal.typ.flags != {}:
           put(m, formal.typ, def.typ)
         setSon(m.call, formal.position + 1, def)


### PR DESCRIPTION
I'm not much of a compiler expert but I guess that the default parameters aren't turned into their static counterpart by `paramTypesMatchAux` (?). This is the off-the-bat solution that seems to fix both #7208 and #6928 but I'm not so sure about this, a cleaner approach would be to fill the missing parameters before the whole param shebang but, again, I guess that's been done like this for a reason.

Pinging @zah since he seems to be the `static[T]` expert.
Tests will come later if the PR lives on.