### PR TITLE
Fixed stacktrace/linetrace proc pragmas when appended by macro pragma

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1559,6 +1559,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     addParams(c, proto.typ.n, proto.kind)
     proto.info = s.info       # more accurate line information
     s.typ = proto.typ
+    proto.options = s.options
     s = proto
     n.sons[genericParamsPos] = proto.ast.sons[genericParamsPos]
     n.sons[paramsPos] = proto.ast.sons[paramsPos]

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1486,10 +1486,11 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     s.ast = n
     #s.scope = c.currentScope
 
+  s.options = c.config.options
+
   # before compiling the proc body, set as current the scope
   # where the proc was declared
   let oldScope = c.currentScope
-  let oldOptions = c.config.options
   #c.currentScope = s.scope
   pushOwner(c, s)
   openScope(c)
@@ -1569,8 +1570,6 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     proto.ast = n             # needed for code generation
     popOwner(c)
     pushOwner(c, s)
-  s.options = c.config.options
-  c.config.options = oldOptions
 
   if sfOverriden in s.flags or s.name.s[0] == '=': semOverride(c, s, n)
   if s.name.s[0] in {'.', '('}:

--- a/tests/overflw/toverflw.nim
+++ b/tests/overflw/toverflw.nim
@@ -1,21 +1,84 @@
 discard """
   file: "toverflw.nim"
-  output: "the computation overflowed"
+  output: "ok"
+  cmd: "nim $target -d:release $options $file"
+
 """
 # Tests nim's ability to detect overflows
 
 {.push overflowChecks: on.}
 
 var
-  a, b: int
-a = high(int)
-b = -2
+  a = high(int)
+  b = -2
+  overflowDetected = false
+
 try:
   writeLine(stdout, b - a)
 except OverflowError:
-  writeLine(stdout, "the computation overflowed")
+  overflowDetected = true
 
 {.pop.} # overflow check
-#OUT the computation overflowed
+
+doAssert(overflowDetected)
+
+block: # Overflow checks in a proc
+  var
+    a = high(int)
+    b = -2
+    overflowDetected = false
+
+  {.push overflowChecks: on.}
+  proc foo() =
+    let c = b - a
+  {.pop.}
+
+  try:
+    foo()
+  except OverflowError:
+    overflowDetected = true
+
+  doAssert(overflowDetected)
+
+block: # Overflow checks in a forward declared proc
+  var
+    a = high(int)
+    b = -2
+    overflowDetected = false
+
+  proc foo()
+
+  {.push overflowChecks: on.}
+  proc foo() =
+    let c = b - a
+  {.pop.}
+
+  try:
+    foo()
+  except OverflowError:
+    overflowDetected = true
+
+  doAssert(overflowDetected)
+
+block: # Overflow checks doesn't affect fwd declaration
+  var
+    a = high(int)
+    b = -2
+    overflowDetected = false
+
+  {.push overflowChecks: on.}
+  proc foo()
+  {.pop.}
+
+  proc foo() =
+    let c = b - a
+
+  try:
+    foo()
+  except OverflowError:
+    overflowDetected = true
+
+  doAssert(not overflowDetected)
 
 
+echo "ok"


### PR DESCRIPTION
Slightly refactored pragmas to allow pragmas affect particular symbol options instead of global options. This new behavior is used to apply `stacktrace` and `linetrace` pragmas directly on proc symbols, instead of messing with global options which proved to be error prone (e.g. a macro pragma applying another pragma).