### PR TITLE
Fix comparison of tyGenericBody in typerel

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1423,7 +1423,7 @@ proc typeRelImpl(c: var TCandidate, f, aOrig: PType,
 
   of tyGenericBody:
     considerPreviousT:
-      if a.kind == tyGenericInst and a.sons[0] == f:
+      if a == f or a.kind == tyGenericInst and a.sons[0] == f:
         bindingRet isGeneric
       let ff = lastSon(f)
       if ff != nil:

--- a/tests/typerel/t7734.nim
+++ b/tests/typerel/t7734.nim
@@ -1,0 +1,19 @@
+type
+  Foo[T: SomeFloat] = object
+    learning_rate: T
+
+  Bar[T: SomeFloat] = object
+    learning_rate: T
+    momentum: T
+
+  Model = object
+    weight: int
+
+  FooClass = Foo or Bar
+
+
+proc optimizer[M; T: SomeFloat](model: M, _: typedesc[Foo], learning_rate: T): Foo[T] =
+  result.learning_rate = learning_rate
+
+let a = Model(weight: 1)
+let opt = a.optimizer(Foo, 10.0)


### PR DESCRIPTION
As shown in #7734 and #7733 the logic in typerel fails to determine that `type Foo` and `type Foo` are indeed equal.
The simple solution is to check whether `a` and `f` are indeed equal, I don't know if the `==` check is enough though.