### PR TITLE
Add support for italic and strikethrough ANSI escape codes

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -467,16 +467,18 @@ proc resetAttributes*(f: File) =
     f.write(ansiResetCode)
 
 type
-  Style* = enum         ## different styles for text output
+  Style* = enum          ## different styles for text output
     styleBright = 1,     ## bright text
     styleDim,            ## dim text
-    styleUnknown,        ## unknown
+    styleItalic,         ## italic (or reverse on terminals not supporting)
     styleUnderscore = 4, ## underscored text
     styleBlink,          ## blinking/bold text
-    styleReverse = 7,    ## unknown
+    styleReverse = 7,    ## reverse
     styleHidden          ## hidden text
+    styleStrikethrough,  ## strikethrough
 
 {.deprecated: [TStyle: Style].}
+{.deprecated: [styleUnknown: styleItalic].}
 
 when not defined(windows):
   var
@@ -843,6 +845,7 @@ when not defined(testing) and isMainModule:
   write(stdout, "never mind")
   stdout.eraseLine()
   stdout.styledWriteLine("styled text ", {styleBright, styleBlink, styleUnderscore})
+  stdout.styledWriteLine("italic text ", {styleItalic})
   stdout.setBackGroundColor(bgCyan, true)
   stdout.setForeGroundColor(fgBlue)
   stdout.writeLine("ordinary text")


### PR DESCRIPTION
    \e[3m -> italic
    \e[9m -> strikethrough

Ref: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters

I have tested italics and strikethrough to work on xterm on RHEL 6.6.

I am aware that these ANSI escapes are not supported by all terminals, and probably not in Windows too. But it's useful to have these enums defined so that people wanting to use them can..

- On terminals not supporting italics, the italic ANSI code renders as reverse.

![image](https://user-images.githubusercontent.com/3578197/41485967-9283f8fe-70b0-11e8-8413-373c0f06ba45.png)
