### PR TITLE
Copy the node if the assignment rhs is not a ref

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -214,7 +214,7 @@ proc putIntoNode(n: var PNode; x: TFullReg) =
       n = x.node
     else:
       let destIsRef = nfIsRef in n.flags
-      n[] = x.node[]
+      n = copyValue(x.node)
       # Ref-ness must be kept for the destination
       if destIsRef:
         n.flags.incl nfIsRef

--- a/tests/vm/tref.nim
+++ b/tests/vm/tref.nim
@@ -10,3 +10,12 @@ static:
   b[5] = 'c'
   doAssert a[] == "Hellocworld"
   doAssert b[] == "Hellocworld"
+
+static:
+  type Obj = object
+    field: int
+  var s = newSeq[Obj](1)
+  var o = Obj()
+  s[0] = o
+  o.field = 2
+  doAssert s[0].field == 0


### PR DESCRIPTION
Fixes #7871 

Maybe a whole copy can be avoided in some more cases