### PR TITLE
Support setting foreground/background colors to terminal defaults

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -542,7 +542,9 @@ type
     fgBlue,                ## blue
     fgMagenta,             ## magenta
     fgCyan,                ## cyan
-    fgWhite                ## white
+    fgWhite,               ## white
+    fg8Bit,                ## 256-color (not supported, see ``enableTrueColors`` instead.)
+    fgDefault              ## default terminal foreground color
 
   BackgroundColor* = enum  ## terminal's background colors
     bgBlack = 40,          ## black
@@ -552,7 +554,9 @@ type
     bgBlue,                ## blue
     bgMagenta,             ## magenta
     bgCyan,                ## cyan
-    bgWhite                ## white
+    bgWhite,               ## white
+    bg8Bit,                ## 256-color (not supported, see ``enableTrueColors`` instead.)
+    bgDefault              ## default terminal background color
 
 {.deprecated: [TForegroundColor: ForegroundColor,
                TBackgroundColor: BackgroundColor].}
@@ -565,13 +569,16 @@ proc setForegroundColor*(f: File, fg: ForegroundColor, bright=false) =
     old = if bright: old or FOREGROUND_INTENSITY
           else:      old and not(FOREGROUND_INTENSITY)
     const lookup: array[ForegroundColor, int] = [
-      0,
+      0, # ForegroundColor enum with ordinal 30
       (FOREGROUND_RED),
       (FOREGROUND_GREEN),
       (FOREGROUND_RED or FOREGROUND_GREEN),
       (FOREGROUND_BLUE),
       (FOREGROUND_RED or FOREGROUND_BLUE),
       (FOREGROUND_BLUE or FOREGROUND_GREEN),
+      (FOREGROUND_BLUE or FOREGROUND_GREEN or FOREGROUND_RED),
+      0, # not supported, see enableTrueColors instead.
+      # default Windows Console foreground = White
       (FOREGROUND_BLUE or FOREGROUND_GREEN or FOREGROUND_RED)]
     discard setConsoleTextAttribute(h, toU16(old or lookup[fg]))
   else:
@@ -587,14 +594,17 @@ proc setBackgroundColor*(f: File, bg: BackgroundColor, bright=false) =
     old = if bright: old or BACKGROUND_INTENSITY
           else:      old and not(BACKGROUND_INTENSITY)
     const lookup: array[BackgroundColor, int] = [
-      0,
+      0, # BackgroundColor enum with ordinal 40
       (BACKGROUND_RED),
       (BACKGROUND_GREEN),
       (BACKGROUND_RED or BACKGROUND_GREEN),
       (BACKGROUND_BLUE),
       (BACKGROUND_RED or BACKGROUND_BLUE),
       (BACKGROUND_BLUE or BACKGROUND_GREEN),
-      (BACKGROUND_BLUE or BACKGROUND_GREEN or BACKGROUND_RED)]
+      (BACKGROUND_BLUE or BACKGROUND_GREEN or BACKGROUND_RED),
+      0, # not supported, see enableTrueColors instead.
+      # default Windows Console background = Black
+      0]
     discard setConsoleTextAttribute(h, toU16(old or lookup[bg]))
   else:
     gBG = ord(bg)
@@ -934,4 +944,7 @@ when not defined(testing) and isMainModule:
   stdout.styledWrite(" ordinary text ")
   stdout.styledWrite(fgGreen, "green text")
   echo ""
+  echo "ordinary text"
+  stdout.styledWriteLine(fgRed, "red text ", styleBright, "bold red", fgDefault, " bold text")
+  stdout.styledWriteLine(bgYellow, "text in yellow bg", styleBright, " bold text in yellow bg", bgDefault, " bold text")
   echo "ordinary text"


### PR DESCRIPTION
- Adds `fgDefault` to ForegroundColor and `bgDefault` to BackgroundColor
enums.
- Also adds the `fg8Bit` and `bg8Bit` enum values to fix the "enum with holes" error. The 8-bit color implementation is left unsupported for this PR.. will leave that for my future self or someone else :)

**Windows Console fg defaulted to white, bg defaulted to black.**

/cc @dom96 @Araq 

---

With this PR, now:

```nim
import terminal
stdout.styledWriteLine(fgRed, "red text ", styleBright, "bold red", fgDefault, " bold text")
stdout.styledWriteLine(bgYellow, "text in yellow bg", styleBright, " bold text in yellow bg", bgDefault, " bold text")
```

outputs:

**On RHEL 6.6, XTerm (default fg = white, default bg = black)**

![image](https://user-images.githubusercontent.com/3578197/41613524-cf135902-73c3-11e8-8a62-552d062772d7.png)

**On RHEL 6.6, XTerm (default fg = black, default bg = green)**

![image](https://user-images.githubusercontent.com/3578197/41620736-a10a163a-73d8-11e8-972d-1a70ffc32568.png)
