### PR TITLE
Introduce types in template parameters as typedescs

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -418,7 +418,7 @@ proc semResolvedCall(c: PContext, n: PNode, x: TCandidate): PNode =
         of skConst:
           x.call.add s.ast
         of skType:
-          x.call.add newSymNode(s, n.info)
+          x.call.add newSymNodeTypeDesc(s, n.info)
         else:
           internalAssert c.config, false
 


### PR DESCRIPTION
Instead of throwing around a skType symbol let's wrap it in a typedesc.

Fixes #7995

CC @zah 