### PR TITLE
Make `static` blocks introduce their own scope

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1772,7 +1772,9 @@ proc semStaticStmt(c: PContext, n: PNode): PNode =
   #echo "semStaticStmt"
   #writeStackTrace()
   inc c.inStaticContext
+  openScope(c)
   let a = semStmt(c, n.sons[0])
+  closeScope(c)
   dec c.inStaticContext
   n.sons[0] = a
   evalStaticStmt(c.module, c.graph, a, c.p.owner)

--- a/tests/global/t5958.nim
+++ b/tests/global/t5958.nim
@@ -1,0 +1,9 @@
+discard """
+  line: 9
+  errormsg: "undeclared identifier: 'a'"
+"""
+
+static:
+  var a = 1
+
+echo a

--- a/tests/pragmas/treorder.nim
+++ b/tests/pragmas/treorder.nim
@@ -71,5 +71,4 @@ macro make(arg: untyped): untyped =
 proc first(i: int): void =
   make(second)
 
-static:
-  var ss: string = ""
+var ss {.compileTime.}: string = ""

--- a/tests/vm/tnimnode.nim
+++ b/tests/vm/tnimnode.nim
@@ -4,14 +4,12 @@ proc assertEq(arg0,arg1: string): void =
   if arg0 != arg1:
     raiseAssert("strings not equal:\n" & arg0 & "\n" & arg1)
 
-static:
-  # a simple assignment of stmtList to another variable
-  var node: NimNode
-  # an assignment of stmtList into an array
-  var nodeArray: array[1, NimNode]
-  # an assignment of stmtList into a seq
-  var nodeSeq = newSeq[NimNode](2)
-
+# a simple assignment of stmtList to another variable
+var node {.compileTime.}: NimNode
+# an assignment of stmtList into an array
+var nodeArray {.compileTime.}: array[1, NimNode]
+# an assignment of stmtList into a seq
+var nodeSeq {.compileTime.} = newSeq[NimNode](2)
 
 proc checkNode(arg: NimNode; name: string): void {. compileTime .} =
   echo "checking ", name
@@ -35,10 +33,10 @@ proc checkNode(arg: NimNode; name: string): void {. compileTime .} =
 
   echo "OK"
 
-static:
-  # the root node that is used to generate the Ast
-  var stmtList: NimNode
+# the root node that is used to generate the Ast
+var stmtList {.compileTime.}: NimNode
 
+static:
   stmtList = newStmtList(nnkDiscardStmt.newTree(newEmptyNode()))
 
   checkNode(stmtList, "direct construction")

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -19,9 +19,9 @@ block:
     var x = default(type(0))
 
 # #6379
-static:
-  import algorithm
+import algorithm
 
+static:
   var numArray = [1, 2, 3, 4, -1]
   numArray.sort(cmp)
   assert numArray == [-1, 1, 2, 3, 4]


### PR DESCRIPTION
Treat the static block as a normal block, don't leak any identifier in
the outer scope.

Fixes #5958

I'm quoting @zah on the matter:

> This code is not valid - static blocks introduce their own scope, so there should be a proper compile-time error here. To introduce a global compile-time variable, you can use the compileTime pragma.