### PR TITLE
improve error message if literal ends with an underscore, fix #8113

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -342,7 +342,8 @@ proc getNumber(L: var TLexer, result: var TToken) =
       if buf[pos] == '_':
         if buf[pos+1] notin chars:
           lexMessage(L, errGenerated,
-            "only single underscores may occur in a token: '__' is invalid")
+            "only single underscores may occur in a token and token may not " &
+            "end with an underscore: e.g. '1__1' and '1_' are invalid")
           break
         add(tok.literal, '_')
         inc(pos)


### PR DESCRIPTION
An attempt to improve the error message if a literal ends with an underscore (fixes #8113), e.g.
```nim
echo 123_
```
will now produce:
```
Error: token must not end with an underscore: ...0_ is invalid
```
Maybe the `...` is ugly, not sure if I like it. Wanted to include the last digit before the underscore and somehow clarify that the shown digit may not cover the whole literal.