### PR TITLE
Return an error symbol as macro output if needed

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -405,7 +405,12 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
     of tyTypeDesc:
       if result.kind == nkStmtList: result.kind = nkStmtListType
       var typ = semTypeNode(c, result, nil)
-      result.typ = makeTypeDesc(c, typ)
+      if typ == nil:
+        localError(c.config, result.info, "expression has no type: " &
+                   renderTree(result, {renderNoComments}))
+        result = newSymNode(errorSym(c, result))
+      else:
+        result.typ = makeTypeDesc(c, typ)
       #result = symNodeFromType(c, typ, n.info)
     else:
       var retType = s.typ.sons[0]

--- a/tests/macros/t7454.nim
+++ b/tests/macros/t7454.nim
@@ -1,0 +1,8 @@
+discard """
+errormsg: "expression has no type:"
+line: 8
+"""
+
+macro p(t: typedesc): typedesc =
+  discard
+var a: p(int)


### PR DESCRIPTION
Return an error symbol if the macro output has no type and a typedesc
is expected.

Fixes #7454

I added a `localError` to make this case a bit more symmetric wrt the `fitNode` path.