### PR TITLE
Don't consider concept types as non-complex during codegen

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -288,7 +288,7 @@ type
 proc genRefAssign(p: BProc, dest, src: TLoc, flags: TAssignmentFlags)
 
 proc isComplexValueType(t: PType): bool {.inline.} =
-  let t = t.skipTypes(abstractInst)
+  let t = t.skipTypes(abstractInst + tyUserTypeClasses)
   result = t.kind in {tyArray, tySet, tyTuple, tyObject} or
     (t.kind == tyProc and t.callConv == ccClosure)
 

--- a/tests/concepts/tmisc_issues.nim
+++ b/tests/concepts/tmisc_issues.nim
@@ -9,7 +9,8 @@ implicit generic
 generic
 false
 true
--1'''
+-1
+Meow'''
 """
 
 # https://github.com/nim-lang/Nim/issues/1147
@@ -98,3 +99,15 @@ let b = B()
 echo b is A
 echo b.size()
 
+# https://github.com/nim-lang/Nim/issues/7125
+type
+  Thing = concept x
+    x.hello is string
+  Cat = object
+
+proc hello(d: Cat): string = "Meow"
+
+proc sayHello(c: Thing) = echo(c.hello)
+
+var a: Thing = Cat()
+a.sayHello()


### PR DESCRIPTION
Fixes #7125

CC @zah since I'm not 100% sure this is sound for every case