### PR TITLE
make basic debugging possible

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -27,9 +27,9 @@ proc lineInfoToStr*(conf: ConfigRef; info: TLineInfo): Rope
 when declared(echo):
   # these are for debugging only: They are not really deprecated, but I want
   # the warning so that release versions do not contain debugging statements:
-  proc debug*(conf: ConfigRef; n: PSym) {.deprecated.}
-  proc debug*(conf: ConfigRef; n: PType) {.deprecated.}
-  proc debug*(conf: ConfigRef; n: PNode) {.deprecated.}
+  proc debug*(n: PSym; conf: ConfigRef = nil) {.deprecated.}
+  proc debug*(n: PType; conf: ConfigRef = nil) {.deprecated.}
+  proc debug*(n: PNode; conf: ConfigRef = nil) {.deprecated.}
 
 template mdbg*: bool {.dirty.} =
   when compiles(c.module):
@@ -409,7 +409,7 @@ proc debugTree(conf: ConfigRef; n: PNode, indent: int, maxRecDepth: int;
     addf(result, "$N$1}", [rspaces(indent)])
 
 when declared(echo):
-  proc debug(conf: ConfigRef; n: PSym) =
+  proc debug(n: PSym; conf: ConfigRef) =
     if n == nil:
       echo("null")
     elif n.kind == skUnknown:
@@ -420,10 +420,10 @@ when declared(echo):
         n.name.s, $n.id, $flagsToStr(n.flags), $flagsToStr(n.loc.flags),
         $lineInfoToStr(conf, n.info), $n.kind])
 
-  proc debug(conf: ConfigRef; n: PType) =
+  proc debug(n: PType; conf: ConfigRef) =
     echo($debugType(conf, n))
 
-  proc debug(conf: ConfigRef; n: PNode) =
+  proc debug(n: PNode; conf: ConfigRef) =
     echo($debugTree(conf, n, 0, 100))
 
 proc nextTry(h, maxHash: Hash): Hash =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -155,10 +155,10 @@ proc getInfoContext*(conf: ConfigRef; index: int): TLineInfo =
   else: result = conf.m.msgContext[i]
 
 template toFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
-  (if fileIdx.int32 < 0: "???" else: conf.m.fileInfos[fileIdx.int32].projPath)
+  (if fileIdx.int32 < 0 or conf == nil: "???" else: conf.m.fileInfos[fileIdx.int32].projPath)
 
 proc toFullPath*(conf: ConfigRef; fileIdx: FileIndex): string =
-  if fileIdx.int32 < 0: result = "???"
+  if fileIdx.int32 < 0 or conf == nil: result = "???"
   else: result = conf.m.fileInfos[fileIdx.int32].fullPath
 
 proc setDirtyFile*(conf: ConfigRef; fileIdx: FileIndex; filename: string) =

--- a/koch.nim
+++ b/koch.nim
@@ -470,7 +470,7 @@ proc temp(args: string) =
   # commit.
   let (bootArgs, programArgs) = splitArgs(args)
   let nimexec = findNim()
-  exec(nimexec & " c -d:debug " & bootArgs & " compiler" / "nim", 125)
+  exec(nimexec & " c --debugger:native " & bootArgs & " compiler" / "nim", 125)
   copyExe(output, finalDest)
   if programArgs.len > 0: exec(finalDest & " " & programArgs)
 

--- a/koch.nim
+++ b/koch.nim
@@ -470,7 +470,7 @@ proc temp(args: string) =
   # commit.
   let (bootArgs, programArgs) = splitArgs(args)
   let nimexec = findNim()
-  exec(nimexec & " c --debugger:native " & bootArgs & " compiler" / "nim", 125)
+  exec(nimexec & " c -d:debug --debugger:native " & bootArgs & " compiler" / "nim", 125)
   copyExe(output, finalDest)
   if programArgs.len > 0: exec(finalDest & " " & programArgs)
 


### PR DESCRIPTION
the debug procs once in the past did not need a config object. Now they don't need it anymore. And by default it is set to nil. This doesn't work as well as if it is set, but it won't crash anymore on nil. Also the order of the arguments is reversed so that the old way to use the debug proc will just work.

I also added debug information to the debug build of the compiler. 

With these changes basic debugging of the compiler is now possible. Still a long road ahead to make debugging a better experience. But these steps are absolutely necessary.
