### PR TITLE
Reject ptr/ref void types

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -171,6 +171,9 @@ proc semAnyRef(c: PContext; n: PNode; kind: TTypeKind; prev: PType): PType =
     var t = semTypeNode(c, n.lastSon, nil)
     if t.kind == tyTypeDesc and tfUnresolved notin t.flags:
       t = t.base
+    if t.kind == tyVoid:
+      const kindToStr: array[tyPtr..tyRef, string] = ["ptr", "ref"]
+      localError(c.config, n.info, "type '$1 void' is not allowed" % kindToStr[kind])
     result = newOrPrevType(kind, prev, c)
     var isNilable = false
     # check every except the last is an object:

--- a/tests/types/t6456.nim
+++ b/tests/types/t6456.nim
@@ -1,0 +1,7 @@
+discard """
+  line: 6
+  errormsg: "type \'ptr void\' is not allowed"
+"""
+
+proc foo(x: ptr void) =
+  discard


### PR DESCRIPTION
Do this during the semantic pass to avoid tripping the following passes.

Fixes #6454