### PR TITLE
Memfiles.open fails with when mapped size is 0

### DIFF
--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -91,7 +91,8 @@ proc open*(filename: string, mode: FileMode = fmRead,
   ## with write access (e.g., with fmReadWrite).
   ##
   ##``mappedSize`` and ``offset``
-  ## can be used to map only a slice of the file.
+  ## can be used to map only a slice of the file. 
+  ## mappedSize must not be 0. If no size is supplied, it will be guessed from the file being opened
   ##
   ## ``offset`` must be multiples of the PAGE SIZE of your OS
   ## (usually 4K or 8K but is unique to your OS)
@@ -225,13 +226,16 @@ proc open*(filename: string, mode: FileMode = fmRead,
       result.size = mappedSize
     else:
       var stat: Stat
-      if fstat(result.handle, stat) != -1:
+      if fstat(result.handle, stat) != -1 and int(stat.st_size) > 0:
         # XXX: Hmm, this could be unsafe
         # Why is mmap taking int anyway?
         result.size = int(stat.st_size)
       else:
         fail(osLastError(), "error getting file size")
 
+    if result.size == 0:
+      fail(osLastError(), "mapped size cannot be zero")
+    
     result.mem = mmap(
       nil,
       result.size,


### PR DESCRIPTION
When opening a file that has 0 size or setting the mappedSize argument in memfiles.open to 0, mmap returns an EINVAL error and raises "Unhandled Exception: Invalid Argument".

Code to reproduce
```
import memfiles
var
    test_stdout: MemFile
test_stdout = memfiles.open("{path_to_new_file}")
```
This call was failing:
```    
fstat(3, {st_mode=S_IFREG|0664, st_size=0, ...}) = 0
mmap(NULL, 0, PROT_READ, MAP_PRIVATE|MAP_POPULATE, 3, 0) = -1 EINVAL (Invalid argument)
```
As per the man page for mmap:
EINVAL (since Linux 2.6.12) length was 0.