### PR TITLE
address #8160 when poStdErrToStdOut not set, stderr disappears

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -884,11 +884,9 @@ elif not defined(useNimRtl):
         chck posix_spawn_file_actions_adddup2(fops, data.pStdin[readIdx], readIdx)
         chck posix_spawn_file_actions_addclose(fops, data.pStdout[readIdx])
         chck posix_spawn_file_actions_adddup2(fops, data.pStdout[writeIdx], writeIdx)
-        chck posix_spawn_file_actions_addclose(fops, data.pStderr[readIdx])
         if (poStdErrToStdOut in data.options):
+          chck posix_spawn_file_actions_addclose(fops, data.pStderr[readIdx])
           chck posix_spawn_file_actions_adddup2(fops, data.pStdout[writeIdx], 2)
-        else:
-          chck posix_spawn_file_actions_adddup2(fops, data.pStderr[writeIdx], 2)
 
       var res: cint
       if data.workingDir.len > 0:


### PR DESCRIPTION
this addresses https://github.com/nim-lang/Nim/issues/8160

```nim
import osproc

proc test_execCmdEx*()=
  block:
    var options: set[ProcessOption] = {}
    options.incl poStdErrToStdOut
    let output=execCmdEx("echo foo && unexistant", options)
    echo output

  block:
    var options: set[ProcessOption] = {}
    let output=execCmdEx("echo foo && unexistant", options)
    echo output

    #[
output:

(output: "foo\n/bin/sh: unexistant: command not found\n", exitCode: 127)
/bin/sh: unexistant: command not found
(output: "foo\n", exitCode: 127)
    ]#

test_execCmdEx()
```
