### PR TITLE
Rewrite the memory management code for Nintendo Switch

### DIFF
--- a/lib/nintendoswitch/switch_memory.nim
+++ b/lib/nintendoswitch/switch_memory.nim
@@ -1,21 +1,36 @@
+## All of these library headers and source can be found in the github repo
+## https://github.com/switchbrew/libnx.
+
 const virtMemHeader = "<switch/kernel/virtmem.h>"
-const svcHeader = "<switch/kernel/virtmem.h>"
+const svcHeader = "<switch/kernel/svc.h>"
 const mallocHeader = "<malloc.h>"
 
+## Aligns a block of memory with request `size` to `bytes` size. For
+## example, a request of memalign(0x1000, 0x1001) == 0x2000 bytes allocated
 proc memalign*(bytes: csize, size: csize): pointer {.importc: "memalign",
     header: mallocHeader.}
 
-proc free*(address: pointer) {.importc: "free",
-    header: mallocHeader.}
+# Should be required, but not needed now because of how
+# svcUnmapMemory frees all memory
+#proc free*(address: pointer) {.importc: "free",
+#    header: mallocHeader.}
 
+## Maps a memaligned block of memory from `src_addr` to `dst_addr`. The
+## Nintendo Switch requires this call in order to make use of memory, otherwise
+## an invalid memory access occurs.
 proc svcMapMemory*(dst_addr: pointer; src_addr: pointer; size: uint64): uint32 {.
     importc: "svcMapMemory", header: svcHeader.}
 
+## Unmaps (frees) all memory from both `dst_addr` and `src_addr`. **Must** be called
+## whenever svcMapMemory is used. The Switch will expect all memory to be allocated
+## before gfxExit() calls (<switch/gfx/gfx.h>)
 proc svcUnmapMemory*(dst_addr: pointer; src_addr: pointer; size: uint64): uint32 {.
     importc: "svcUnmapMemory", header: svcHeader.}
 
 proc virtmemReserveMap*(size: csize): pointer {.importc: "virtmemReserveMap",
     header: virtMemHeader.}
 
-proc virtmemFreeMap*(address: pointer; size: csize) {.importc: "virtmemFreeMap",
-    header: virtMemHeader.}
+# Should be required, but not needed now because of how
+# svcUnmapMemory frees all memory
+#proc virtmemFreeMap*(address: pointer; size: csize) {.importc: "virtmemFreeMap",
+#    header: virtMemHeader.}

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -81,6 +81,7 @@ elif defined(genode):
   include genode/alloc # osAllocPages, osTryAllocPages, osDeallocPages
 
 elif defined(nintendoswitch):
+
   import nintendoswitch/switch_memory
 
   type
@@ -94,7 +95,7 @@ elif defined(nintendoswitch):
       heap: pointer           # pointer to main heap alloc
       heapMirror: pointer     # pointer to virtmem mapped heap
 
-  proc alignSize(size: int): int =
+  proc alignSize(size: int): int {.inline.} =
     ## Align a size integer to be in multiples of PageSize
     ## The nintendo switch will not allocate memory that is not
     ## aligned to 0x1000 bytes and will just crash.
@@ -120,7 +121,7 @@ elif defined(nintendoswitch):
       nswitchBlock.heapMirror, nswitchBlock.heap, nswitchBlock.realSize
     )
 
-  proc storeHeapData(address, heapMirror, heap: pointer, size: int) =
+  proc storeHeapData(address, heapMirror, heap: pointer, size: int) {.inline.} =
     ## Store data in the heap for deallocation purposes later
 
     # the position of our heap pointer data. Since we allocated PageSize extra
@@ -138,7 +139,7 @@ elif defined(nintendoswitch):
     nswitchBlock.heap = heap
     nswitchBlock.heapMirror = heapMirror
 
-  proc getOriginalHeapPosition(address: pointer, difference: int): pointer =
+  proc getOriginalHeapPosition(address: pointer, difference: int): pointer {.inline.} =
     ## This function sets the heap back to the originally requested
     ## size
     let
@@ -175,11 +176,11 @@ elif defined(nintendoswitch):
     allocPages(size):
       raiseOutOfMem()
 
-  proc osTryAllocPages(size: int): pointer {.inline.} =
+  proc osTryAllocPages(size: int): pointer =
     allocPages(size):
       return nil
 
-  proc osDeallocPages(p: pointer, size: int) {.inline.} =
+  proc osDeallocPages(p: pointer, size: int) =
     # Note that in order for the Switch not to crash, a call to
     # deallocHeap(runFinalizers = true, allowGcAfterwards = false)
     # must be run before gfxExit(). The Switch requires all memory


### PR DESCRIPTION
The first implementation was naive and did not account for multiple
memory allocations. However, this implementation may still be
incomplete. Currently, when running applications, the code runs fine.
When the application is exited via code (the end of the program is
reached or quit() is called), the Switch will crash. Not sure why this
happens, but I suspect it is from Nim memory allocations.

I suspect the memory allocations because when I compile the helloworld
application without any Nim allocations (just C function calls) and use
`--gc:none` as a compile option, the application exits fine.

If anyone has any tips on embedded memory allocation/deallocation issues, I would love
to hear them. I would also love to hear how Nim allocates stack memory if it's any different from C.