### PR TITLE
Fix renaming for nested templates

### DIFF
--- a/tests/template/t8052.nim
+++ b/tests/template/t8052.nim
@@ -1,0 +1,21 @@
+type
+  UintImpl*[N: static[int], T: SomeUnsignedInt] = object
+    raw_data*: array[N, T]
+
+template genLoHi(TypeImpl: untyped): untyped =
+  template loImpl[N: static[int], T: SomeUnsignedInt](dst: TypeImpl[N div 2, T], src: TypeImpl[N, T]) =
+    let halfSize = N div 2
+    for i in 0 ..< halfSize:
+      dst.raw_data[i] = src.raw_data[i]
+
+  proc lo*[N: static[int], T: SomeUnsignedInt](x: TypeImpl[N,T]): TypeImpl[N div 2, T] {.inline.}=
+    loImpl(result, x)
+
+genLoHi(UintImpl)
+
+var a: UintImpl[4, uint32]
+
+a.raw_data = [1'u32, 2'u32, 3'u32, 4'u32]
+assert a.lo.raw_data.len == 2
+assert a.lo.raw_data[0] == 1
+assert a.lo.raw_data[1] == 2


### PR DESCRIPTION
I think I've managed to pinpoint where things go south. `loImpl` goes trough two gensym passes, the first one when `genLoHigh` is instantiated and, again, when `loImpl` itself is instantiated inside `lo`. After the first pass the two `halfSize` instances become `halfSize_X` (where X is the id of the new symbol) and become `nkSym`s (they're not `nkIdent`s anymore).
When `loImpl` is instantiated we have `semTemplBody` run trough the template body: the analysis of the `nkConstSection` introduces yet another rename through `addLocalDecl`, `halfSize_X` becomes `halfSize_Y` and the latter is assigned the correct `typ`. When the for statement and, as a consequence, the `halfSize_X` symbol is analysed the code was set up not do do anything and that's how we ended up with two different symbols for `halfSize` in the AST.

The solution is pretty simple (am not sure if it is completely correct): let's just refresh the symbols by looking them up in the parent scopes.

I think we could also spare the whole `newSymNode` to avoid the allocation and just patch `result.sym` but let's focus on the gist of the patch first.

Fixes #8052 

This damn bug took me two days to debug. I now hate templates.