### PR TITLE
Fix crash with static and anonymous procs

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -873,7 +873,7 @@ proc liftParamType(c: PContext, procKind: TSymKind, genericParams: PNode,
     if base.isMetaType and procKind == skMacro:
       localError(c.config, info, errMacroBodyDependsOnGenericTypes % paramName)
     result = addImplicitGeneric(c.newTypeWithSons(tyStatic, @[base]))
-    result.flags.incl({tfHasStatic, tfUnresolved})
+    if result != nil: result.flags.incl({tfHasStatic, tfUnresolved})
 
   of tyTypeDesc:
     if tfUnresolved notin paramType.flags:

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -107,3 +107,12 @@ when true:
     assert aw2.data.high == 6
     assert aw3.data.high == 9
 
+# #6077
+block:
+  type
+    Backend = enum
+      Cpu
+
+    Tensor[B: static[Backend]; T] = object
+
+    BackProp[B: static[Backend],T] = proc (gradient: Tensor[B,T]): Tensor[B,T]


### PR DESCRIPTION
The test case hits the path with this comment:
`# This happens with anonymous proc types appearing in signatures`
it should be safe to avoid the crash like this.

Fixes #6077