### PR TITLE
Fix os.unixToNativePath proc returns wrong result(#8179)

### DIFF
--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -468,7 +468,7 @@ proc unixToNativePath*(path: string, drive=""): string {.
     elif path[0] == '.' and (path.len == 1 or path[1] == '/'):
       # current directory
       result = $CurDir
-      start = 2
+      start = when doslikeFileSystem: 1 else: 2
     else:
       result = ""
       start = 0

--- a/tests/stdlib/tospaths.nim
+++ b/tests/stdlib/tospaths.nim
@@ -1,0 +1,41 @@
+discard """
+  file: "tospaths.nim"
+  output: ""
+"""
+# test the ospaths module
+
+import os
+
+doAssert unixToNativePath("") == ""
+doAssert unixToNativePath(".") == $CurDir
+doAssert unixToNativePath("..") == $ParDir
+doAssert isAbsolute(unixToNativePath("/"))
+doAssert isAbsolute(unixToNativePath("/", "a"))
+doAssert isAbsolute(unixToNativePath("/a"))
+doAssert isAbsolute(unixToNativePath("/a", "a"))
+doAssert isAbsolute(unixToNativePath("/a/b"))
+doAssert isAbsolute(unixToNativePath("/a/b", "a"))
+doAssert unixToNativePath("a/b") == joinPath("a", "b")
+
+when defined(macos):
+    doAssert unixToNativePath("./") == ":"
+    doAssert unixToNativePath("./abc") == ":abc"
+    doAssert unixToNativePath("../abc") == "::abc"
+    doAssert unixToNativePath("../../abc") == ":::abc"
+    doAssert unixToNativePath("/abc", "a") == "abc"
+    doAssert unixToNativePath("/abc/def", "a") == "abc:def"
+elif doslikeFileSystem:
+    doAssert unixToNativePath("./") == ".\\"
+    doAssert unixToNativePath("./abc") == ".\\abc"
+    doAssert unixToNativePath("../abc") == "..\\abc"
+    doAssert unixToNativePath("../../abc") == "..\\..\\abc"
+    doAssert unixToNativePath("/abc", "a") == "a:\\abc"
+    doAssert unixToNativePath("/abc/def", "a") == "a:\\abc\\def"
+else:
+    #Tests for unix
+    doAssert unixToNativePath("./") == "./"
+    doAssert unixToNativePath("./abc") == "./abc"
+    doAssert unixToNativePath("../abc") == "../abc"
+    doAssert unixToNativePath("../../abc") == "../../abc"
+    doAssert unixToNativePath("/abc", "a") == "/abc"
+    doAssert unixToNativePath("/abc/def", "a") == "/abc/def"


### PR DESCRIPTION
This fix was tested on windows PC but not tested on macos.