### PR TITLE
Error out if vararg match isn't an exact one

### DIFF
--- a/tests/typerel/t8172.nim
+++ b/tests/typerel/t8172.nim
@@ -1,0 +1,11 @@
+discard """
+  line: 11
+  errormsg: "cannot convert array[0..0, string] to varargs[string]"
+"""
+
+proc f(v: varargs[string]) =
+  echo(v)
+
+f("b", "c")   # Works
+f(["b", "c"]) # Works
+f("b", ["c"]) # Fails


### PR DESCRIPTION
Fixes #8172 

Let's see if the CI likes it, I don't really like how the error message is worded though.