### PR TITLE
simplify typetraits.nim test

### DIFF
--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -59,9 +59,4 @@ proc supportsCopyMem*(t: typedesc): bool {.magic: "TypeTrait".}
 
 
 when isMainModule:
-  # echo type(42)
-  import streams
-  var ss = newStringStream()
-  ss.write($type(42)) # needs `$`
-  ss.setPosition(0)
-  doAssert ss.readAll() == "int"
+  doAssert $type(42) == "int"


### PR DESCRIPTION
/cc @Araq since you authored 9565da11e5014583a9afe0da6c4e2b83980a3e20
really not sure why newStringStream was used instead of this simpler alternative

also /cc @cdunn2001 bc of https://github.com/nim-lang/Nim/pull/5839