### PR TITLE
fix #7405 and #8195

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1146,7 +1146,11 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
 
 proc genStmts(p: BProc, t: PNode) =
   var a: TLoc
-  pushInfoContext(p.config, t.info)
+
+  let isPush = hintExtendedContext in p.config.notes
+  if isPush: pushInfoContext(p.config, t.info)
+  defer:
+    if isPush: popInfoContext(p.config)
+
   expr(p, t, a)
-  popInfoContext(p.config)
   internalAssert p.config, a.k in {locNone, locTemp, locLocalVar}

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1149,8 +1149,6 @@ proc genStmts(p: BProc, t: PNode) =
 
   let isPush = hintExtendedContext in p.config.notes
   if isPush: pushInfoContext(p.config, t.info)
-  defer:
-    if isPush: popInfoContext(p.config)
-
   expr(p, t, a)
+  if isPush: popInfoContext(p.config)
   internalAssert p.config, a.k in {locNone, locTemp, locLocalVar}

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1146,5 +1146,7 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
 
 proc genStmts(p: BProc, t: PNode) =
   var a: TLoc
+  pushInfoContext(p.config, t.info)
   expr(p, t, a)
+  popInfoContext(p.config)
   internalAssert p.config, a.k in {locNone, locTemp, locLocalVar}

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -162,8 +162,7 @@ type
   TNoteKind* = range[warnMin..hintMax] # "notes" are warnings or hints
   TNoteKinds* = set[TNoteKind]
 
-const
-  NotesVerbosity* = (proc(): array[0..3, TNoteKinds] =
+proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
     result[3] = {low(TNoteKind)..high(TNoteKind)} - {}
     result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext}
     result[1] = result[2] - {warnShadowIdent, warnProveField, warnProveIndex,
@@ -171,9 +170,9 @@ const
       hintSource, hintGlobalVar, hintGCStats}
     result[0] = result[1] - {hintSuccessX, hintConf, hintProcessing,
       hintPattern, hintExecuting, hintLinking}
-  )()
 
 const
+  NotesVerbosity* = computeNotesVerbosity()
   errXMustBeCompileTime* = "'$1' can only be used in compile-time context"
   errArgsNeedRunOption* = "arguments can only be given if the '--run' option is selected"
 

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -45,7 +45,8 @@ type
     hintExecuting, hintLinking, hintDependency,
     hintSource, hintPerformance, hintStackTrace, hintGCStats,
     hintGlobalVar,
-    hintUser, hintUserRaw
+    hintUser, hintUserRaw,
+    hintExtendedContext
 
 const
   MsgKindToStr*: array[TMsgKind, string] = [
@@ -116,7 +117,9 @@ const
     hintGCStats: "$1",
     hintGlobalVar: "global variable declared here",
     hintUser: "$1",
-    hintUserRaw: "$1"]
+    hintUserRaw: "$1",
+    hintExtendedContext: "$1",
+  ]
 
 const
   WarningsToStr* = ["CannotOpenFile", "OctalEscape",
@@ -132,12 +135,14 @@ const
     "GcMem", "Destructor", "LockLevel", "ResultShadowed",
     "Spacing", "User"]
 
-  HintsToStr* = ["Success", "SuccessX", "LineTooLong",
+  HintsToStr* = [
+    "Success", "SuccessX", "LineTooLong",
     "XDeclaredButNotUsed", "ConvToBaseNotNeeded", "ConvFromXtoItselfNotNeeded",
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "Name", "Pattern", "Exec", "Link", "Dependency",
     "Source", "Performance", "StackTrace", "GCStats", "GlobalVar",
-    "User", "UserRaw"]
+    "User", "UserRaw", "ExtendedContext",
+  ]
 
 const
   fatalMin* = errUnknown
@@ -158,27 +163,15 @@ type
   TNoteKinds* = set[TNoteKind]
 
 const
-  NotesVerbosity*: array[0..3, TNoteKinds] = [
-    {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
-                                         warnProveField, warnProveIndex,
-                                         warnGcUnsafe,
-                                         hintSuccessX, hintPath, hintConf,
-                                         hintProcessing, hintPattern,
-                                         hintDependency,
-                                         hintExecuting, hintLinking,
-                                         hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintStackTrace,
-                                         hintGlobalVar, hintGCStats},
-    {low(TNoteKind)..high(TNoteKind)} - {warnShadowIdent, warnUninit,
-                                         warnProveField, warnProveIndex,
-                                         warnGcUnsafe,
-                                         hintPath,
-                                         hintDependency,
-                                         hintCodeBegin, hintCodeEnd,
-                                         hintSource, hintStackTrace,
-                                         hintGlobalVar, hintGCStats},
-    {low(TNoteKind)..high(TNoteKind)} - {hintStackTrace, warnUninit},
-    {low(TNoteKind)..high(TNoteKind)}]
+  NotesVerbosity* = (proc(): array[0..3, TNoteKinds] =
+    result[3] = {low(TNoteKind)..high(TNoteKind)} - {}
+    result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext}
+    result[1] = result[2] - {warnShadowIdent, warnProveField, warnProveIndex,
+      warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
+      hintSource, hintGlobalVar, hintGCStats}
+    result[0] = result[1] - {hintSuccessX, hintConf, hintProcessing,
+      hintPattern, hintExecuting, hintLinking}
+  )()
 
 const
   errXMustBeCompileTime* = "'$1' can only be used in compile-time context"

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -907,6 +907,10 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   result = semExpr(c, result)
 
 proc semExprNoType(c: PContext, n: PNode): PNode =
+  let isPush = hintExtendedContext in c.config.notes
+  if isPush: pushInfoContext(c.config, n.info)
+  defer:
+    if isPush: popInfoContext(c.config)
   result = semExpr(c, n, {efWantStmt})
   discardCheck(c, result)
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -909,10 +909,9 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
 proc semExprNoType(c: PContext, n: PNode): PNode =
   let isPush = hintExtendedContext in c.config.notes
   if isPush: pushInfoContext(c.config, n.info)
-  defer:
-    if isPush: popInfoContext(c.config)
   result = semExpr(c, n, {efWantStmt})
   discardCheck(c, result)
+  if isPush: popInfoContext(c.config)
 
 proc isTypeExpr(n: PNode): bool =
   case n.kind

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1888,4 +1888,6 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
 proc semStmt(c: PContext, n: PNode): PNode =
   # now: simply an alias:
+  pushInfoContext(c.config, n.info)
   result = semExprNoType(c, n)
+  popInfoContext(c.config)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1888,6 +1888,4 @@ proc semStmtList(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
 proc semStmt(c: PContext, n: PNode): PNode =
   # now: simply an alias:
-  pushInfoContext(c.config, n.info)
   result = semExprNoType(c, n)
-  popInfoContext(c.config)


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/8195

fix https://github.com/nim-lang/Nim/issues/7405

NOTE: to fix these I ran:
```
(cd $git_clone_D/nim/Nim/  && ./koch temp)
$git_clone_D/nim/Nim/bin/nim_temp c -r test.nim
```
then looked at the stack trace to see a good insertion point for adding context via pushInfoContext that wasn't already covered by pushInfoContext


EG:
after this:
```
 $git_clone_D/nim/Nim/bin/nim_temp c -r bugs/t01_error_context.nim
/Users/timothee/git_clone/nim/timn/bugs/t01_error_context.nim(14, 1) template/generic instantiation from here
/Users/timothee/git_clone/nim/Nim/lib/system/sysio.nim(351, 20) Error: cannot 'importc' variable at compile time
    var p: pointer = fopen(filename, FormatOpen[mode])
                     ^
$git_clone_D/nim/Nim/bin/nim_temp c -r bugs/t30_nocontext_request_echo.nim
/Users/timothee/git_clone/nim/timn/bugs/t30_nocontext_request_echo.nim(18, 6) template/generic instantiation from here
/Users/timothee/git_clone/nim/Nim/lib/system.nim(2816, 32) Error: request to generate code for .compileTime proc: $
    proc echo*(x: varargs[typed, `$`]) {.magic: "Echo", tags: [WriteIOEffect],
                                 ^
```

before this, the "template/generic instantiation from here" was skipped
 