### PR TITLE
add os.absolutePath; fixes #8174

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -304,8 +304,7 @@ proc absolutePath*(path: string, root = getCurrentDir()): string =
   if isAbsolute(path): path
   else:
     if not root.isAbsolute:
-      # CHECKME: is that the correct exception type?
-      raise newException(ValueError, root)
+      raise newException(ValueError, "The specified root is not absolute: " & root)
     joinPath(root, path)
 
 when isMainModule:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -303,17 +303,13 @@ proc absolutePath*(path: string, root = getCurrentDir()): string =
     doAssert absolutePath("a") == getCurrentDir() / "a"
   if isAbsolute(path): path
   else:
-    doAssert root.isAbsolute, root
+    if not root.isAbsolute:
+      # CHECKME: is that the correct exception type?
+      raise newException(ValueError, root)
     joinPath(root, path)
 
 when isMainModule:
-  # TODO: use doAssertRaises pending https://github.com/nim-lang/Nim/issues/8223
-  try:
-    let a = absolutePath("a", "b")
-    doAssert false, "should've thrown"
-  except:
-    discard
-
+  doAssertRaises(ValueError): discard absolutePath("a", "b")
   doAssert absolutePath("a") == getCurrentDir() / "a"
   doAssert absolutePath("a", "/b") == "/b" / "a"
   when defined(Posix):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -296,6 +296,18 @@ proc setCurrentDir*(newDir: string) {.inline, tags: [].} =
   else:
     if chdir(newDir) != 0'i32: raiseOSError(osLastError())
 
+proc absolutePath*(path: string, root = getCurrentDir()):string=
+  ## Returns the absolute path of `path`, rooted at `root`
+  ## if `path` is absolute, return it, ignoring `root`
+  if isAbsolute(path): path
+  else: joinPath(root, path)
+
+when isMainModule:
+  assert absolutePath("a", "b") == "b" / "a"
+  when defined(Posix):
+    assert absolutePath("a", "b/") == "b" / "a"
+    assert absolutePath("/a", "b/") == "/a"
+
 proc expandFilename*(filename: string): string {.rtl, extern: "nos$1",
   tags: [ReadDirEffect].} =
   ## Returns the full (`absolute`:idx:) path of an existing file `filename`,


### PR DESCRIPTION
fixes https://github.com/nim-lang/Nim/issues/8174

NOTE: see https://github.com/nim-lang/Nim/issues/8174 and  https://forum.nim-lang.org/t/4004 for prior discussion.
`absolutePath` would be best put in `ospaths` but nim doesn't support circular dependencies (yet...).

An alternative would've been to split in 2:
```
# in ospaths:
proc absolutePath*(path: string, base: string)
# in os:
proc absolutePath*(path: string)
```
but that's uglier (and less DRY).

Another alternative would've been to add fwd reference of `getCurrentDir` in ospaths but that causes link errors in case user doesn't explicitly call `getCurrentDir`but just calls `absolutePath` in his code  (something nim could improve on IMO )
