### PR TITLE
[overridden] partially address issue #8217 by running user config.nims if possible

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -81,13 +81,23 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       conf.projectPath = canonicalizePath(conf, getCurrentDir())
     loadConfigs(DefaultConfig, cache, conf) # load all config files
     let scriptFile = conf.projectFull.changeFileExt("nims")
+    const config_nims = "config.nims"
     if fileExists(scriptFile):
       runNimScript(cache, scriptFile, freshDefines=false, conf)
       # 'nim foo.nims' means to just run the NimScript file and do nothing more:
       if scriptFile == conf.projectFull: return
-    elif fileExists(conf.projectPath / "config.nims"):
+    elif fileExists(conf.projectPath / config_nims):
       # directory wide NimScript file
-      runNimScript(cache, conf.projectPath / "config.nims", freshDefines=false, conf)
+      runNimScript(cache, conf.projectPath / config_nims, freshDefines=false, conf)
+    else:
+      # TODO: would like to apply in some sequence the nims scripts we find but
+      # if we call `runNimScript` multiple times in errors with:
+      # ???(0, 0) Error: internal error: n is not nil
+      if optSkipUserConfigFile notin conf.globalOptions:
+        let file = getUserConfigPath(config_nims)
+        if fileExists(file):
+          runNimScript(cache, file, freshDefines=false, conf)
+
     # now process command line arguments again, because some options in the
     # command line can overwite the config file's settings
     extccomp.initVars(conf)

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -219,7 +219,7 @@ proc readConfigFile(
     closeLexer(L)
     return true
 
-proc getUserConfigPath(filename: string): string =
+proc getUserConfigPath*(filename: string): string =
   result = joinPath(getConfigDir(), filename)
 
 proc getSystemConfigPath(conf: ConfigRef; filename: string): string =

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -581,6 +581,7 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
         conf.projectName = a
       # if processArgument(pass, p, argsCount): break
 
+# TODO: refactor with nimconf.nim to avoid duplicating complex logic
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   condsyms.initDefines(conf.symbols)
   defineSymbol conf.symbols, "nimsuggest"


### PR DESCRIPTION
/cc @Araq 

this PR runs user's config.nims if it exists and another nims hasn't also ran before, allowing to apply user configuration globally via nimscript instead of the more limited language nim.cfg

ideally, we would instead do the following:
* run system config.nims if exists
* run user config.nims if exists (eg in posix: ~/.config/config.nims)
* run project config.nims if exists
* run project provided_file.nims if if exists and nim cmd was run on provided_file.nim

~~but that logic fails because call `runNimScript` multiple times in errors with: `???(0, 0) Error: internal error: n is not nil`
(see https://github.com/nim-lang/Nim/issues/8235)~~ (EDIT: FIXED)

TODO in future PR: apply that same logic to `nimsuggest.nim` (and refactor to remove code duplication between nimsuggest.nim and nim.nim)

* refs: #8217