### PR TITLE
workaround issue #8223 nim doc fails with doAssertRaises

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4123,10 +4123,13 @@ else:
 
 template doAssertRaises*(exception, code: untyped): typed =
   ## Raises ``AssertionError`` if specified ``code`` does not raise the
-  ## specified exception.
-  runnableExamples:
-    doAssertRaises(ValueError):
-      raise newException(ValueError, "Hello World")
+  ## specified exception. Example:
+  ##
+  ## .. code-block:: nim
+  ##  doAssertRaises(ValueError):
+  ##    raise newException(ValueError, "Hello World")
+  # TODO: investigate why runnableExamples here caused
+  # https://github.com/nim-lang/Nim/issues/8223
   var wrong = false
   try:
     code


### PR DESCRIPTION
this fixes this issue so code can now use `doAssertRaises ` without breaking nim doc.

Another PR would be needed to fix the underlying root cause, but that's less urgent
