### PR TITLE
Handle subtype relations for converter parameters

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1801,7 +1801,7 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
     # 'f <- dest' in order to not break the unification:
     # see tests/tgenericconverter:
     let srca = typeRel(m, src, a)
-    if srca notin {isEqual, isGeneric}: continue
+    if srca notin {isEqual, isGeneric, isSubtype}: continue
 
     let destIsGeneric = containsGenericType(dest)
     if destIsGeneric:
@@ -1814,7 +1814,12 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       s.info = arg.info
       result = newNodeIT(nkHiddenCallConv, arg.info, dest)
       addSon(result, s)
-      addSon(result, copyTree(arg))
+      var param: PNode = nil
+      if srca == isSubtype:
+        param = implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
+      else:
+        param = copyTree(arg)
+      addSon(result, param)
       inc(m.convMatches)
       m.genericConverter = srca == isGeneric or destIsGeneric
       return result

--- a/tests/converter/t7098.nim
+++ b/tests/converter/t7098.nim
@@ -1,0 +1,31 @@
+type
+  Byte* = uint8
+  Bytes* = seq[Byte]
+
+  BytesRange* = object
+    bytes: Bytes
+    ibegin, iend: int
+
+proc initBytesRange*(s: var Bytes, ibegin = 0, iend = -1): BytesRange =
+  let e = if iend < 0: s.len + iend + 1
+          else: iend
+  assert ibegin >= 0 and e <= s.len
+
+  shallow(s)
+  result.bytes = s
+  result.ibegin = ibegin
+  result.iend = e
+
+converter fromSeq*(s: Bytes): BytesRange =
+  var seqCopy = s
+  return initBytesRange(seqCopy)
+
+type
+  Reader* = object
+    data: BytesRange
+    position: int
+
+proc readerFromBytes*(input: BytesRange): Reader =
+  discard
+
+let r = readerFromBytes(@[])


### PR DESCRIPTION
The other (cleaner and saner looking) alternative I see is calling `paramTypesMatchAux` on the parameter to handle all the remaining corner cases but I was afraid of any potential side-effect.

Fixes #7098