### PR TITLE
Reset typedescMatched before paramTypesMatch

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2231,6 +2231,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
         m.state = csNoMatch
         return
       m.baseTypeMatch = false
+      m.typedescMatched = false
       n.sons[a].sons[1] = prepareOperand(c, formal.typ, n.sons[a].sons[1])
       n.sons[a].typ = n.sons[a].sons[1].typ
       var arg = paramTypesMatch(m, formal.typ, n.sons[a].typ,
@@ -2266,6 +2267,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
           # beware of the side-effects in 'prepareOperand'! So only do it for
           # varargs matching. See tests/metatype/tstatic_overloading.
           m.baseTypeMatch = false
+          m.typedescMatched = false
           incl(marker, formal.position)
           n.sons[a] = prepareOperand(c, formal.typ, n.sons[a])
           var arg = paramTypesMatch(m, formal.typ, n.sons[a].typ,
@@ -2300,6 +2302,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
           addSon(container, n.sons[a])
         else:
           m.baseTypeMatch = false
+          m.typedescMatched = false
           n.sons[a] = prepareOperand(c, formal.typ, n.sons[a])
           var arg = paramTypesMatch(m, formal.typ, n.sons[a].typ,
                                     n.sons[a], nOrig.sons[a])

--- a/tests/generics/t7794.nim
+++ b/tests/generics/t7794.nim
@@ -1,0 +1,15 @@
+discard """
+output: '''
+10
+2.0
+'''
+"""
+
+type
+  Data*[T:SomeNumber, U:SomeReal] = ref object
+    x*: T
+    value*: U
+
+var d = Data[int, float64](x:10.int, value:2'f64)
+echo d.x
+echo d.value


### PR DESCRIPTION
The flag should not be carried out across different parameters.

Fixes #7794