### PR TITLE
Better doc search

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -449,10 +449,11 @@ proc generateSymbolIndex(symbols: seq[IndexEntry]): string =
         desc = if not symbols[j].linkDesc.isNil: symbols[j].linkDesc else: ""
       if desc.len > 0:
         result.addf("""<li><a class="reference external"
-          title="$3" href="$1">$2</a></li>
+          title="$3" data-doc-search-tag="$2" href="$1">$2</a></li>
           """, [url, text, desc])
       else:
-        result.addf("""<li><a class="reference external" href="$1">$2</a></li>
+        result.addf("""<li><a class="reference external" 
+          data-doc-search-tag="$2" href="$1">$2</a></li>
           """, [url, text])
       inc j
     result.add("</ul></dd>\n")
@@ -493,6 +494,7 @@ proc generateDocumentationTOC(entries: seq[IndexEntry]): string =
   # Build a list of levels and extracted titles to make processing easier.
   var
     titleRef: string
+    titleTag: string
     levels: seq[tuple[level: int, text: string]]
     L = 0
     level = 1
@@ -519,10 +521,12 @@ proc generateDocumentationTOC(entries: seq[IndexEntry]): string =
     let link = entries[L].link
     if link.isDocumentationTitle:
       titleRef = link
+      titleTag = levels[L].text
     else:
       result.add(level.indentToLevel(levels[L].level))
-      result.add("<li><a href=\"" & link & "\">" &
-        levels[L].text & "</a></li>\n")
+      result.addf("""<li><a class="reference" data-doc-search-tag="$1" href="$2"> 
+        $3</a></li>
+        """, [titleTag & " : " & levels[L].text, link, levels[L].text])
     inc L
   result.add(level.indentToLevel(1) & "</ul>\n")
   assert(not titleRef.isNil,

--- a/tools/dochack/dochack.nim
+++ b/tools/dochack/dochack.nim
@@ -268,7 +268,7 @@ proc dosearch(value: cstring): Element =
       continue
     let (score, matched) = fuzzymatch(value, c)
     if matched:
-      matches.add((db[i],matchResult.score))
+      matches.add((db[i], score))
 
   matches.sort do (a, b: auto) -> int:
     b[1] - a[1]

--- a/tools/dochack/dochack.nim
+++ b/tools/dochack/dochack.nim
@@ -266,8 +266,8 @@ proc dosearch(value: cstring): Element =
     # Ideally these should be fixed in the index to be more
     # descriptive of what they are.
       continue
-    let matchResult = fuzzymatch(value, c)
-    if matchResult.ismatch:
+    let (score, matched) = fuzzymatch(value, c)
+    if matched:
       matches.add((db[i],matchResult.score))
 
   matches.sort do (a, b: auto) -> int:

--- a/tools/dochack/fuzzysearch.nim
+++ b/tools/dochack/fuzzysearch.nim
@@ -105,7 +105,7 @@ proc fuzzymatch* (pattern, str: cstring) : FuzzyMatchResult =
               (strIndex < str.len - 1) and
               (
                 (str[strIndex + 1].toLowerAscii != pattern[patIndex + 1].toLowerAscii) and
-                ((not str[strIndex + 1].isAlphaAScii) or str[strIndex + 1].isUpperAscii)
+                (not str[strIndex + 1].isLowerAscii) 
               )
             ):
           scoreState.stateTransition(ScoreCard.WordBoundryMatch, curScore)
@@ -118,7 +118,7 @@ proc fuzzymatch* (pattern, str: cstring) : FuzzyMatchResult =
               (strIndex < str.len - 1) and
               (
                 (str[strIndex + 1].toLowerAscii != pattern[patIndex + 1].toLowerAscii) and
-                ((not str[strIndex + 1].isAlphaAScii) or str[strIndex + 1].isUpperAscii)
+                (not str[strIndex + 1].isLowerAscii) 
               )
             ):
           scoreState.stateTransition(ScoreCard.WordBoundryMatch, curScore)
@@ -170,6 +170,3 @@ proc fuzzymatch* (pattern, str: cstring) : FuzzyMatchResult =
 
   result = FuzzyMatchResult(ismatch: (curScore > 0), score: max(0, curScore))
 
-template echoAssert(expr: untyped, expected: untyped): untyped =
-  echo `expr`
-  doAssert `expr` == `expected`

--- a/tools/dochack/fuzzysearch.nim
+++ b/tools/dochack/fuzzysearch.nim
@@ -3,48 +3,36 @@
 # Heavily modified to provide more subjectively useful results
 # for on the Nim manual.
 #
-
 import strutils
 import math
 import macros
 
-type
-  FuzzyMatchResult* = object
-    ismatch*: bool
-    score*: int 
-
-
-# Fuzzy match score.
-#  A positive number is a bonus
-#  A negative number is a penalty
-type ScoreCard {.pure.} = enum 
-  Start = -100, # this acts as a state machine. So we need nil start and end states.
-  UnmatchedLeadingChar = -3, # for each unmatched character from the start of the string
-  UnmatchedChar = -1, # for each single letter does not match
-  MatchedChar = 0, # for each single letter matches
-  ConsecutiveMatch = 5, # every consecutive letter that matches after the first
-  LeadingCharMatch = 10, # The character matches the begining of the string 
-                         # or the first character of a word boundry (a space)
-                         # or a camel case boundry: 
-                         #    An upper case letter that is preceded by a lower case letter.
-                         # This bonus is only applied if a consecutive match is also found.
-                         # This is because it gives too much bias
-                         # to single char matches at word boundries.
-  WordBoundryMatch = 20
 
 const
   MaxUnmatchedLeadingChar = 3
-  # max number of times we will apply the penalty for unmatched leading chars.
+  ## Maximum number of times the penalty for unmatched leading chars is applied.
 
   HeadingScaleFactor = 0.5
-  # The score from before the colon Char is multiplied by this.
-  # This is to weight function signatures and descriptions over module titles.
+  ## The score from before the colon Char is multiplied by this.
+  ## This is to weight function signatures and descriptions over module titles.
 
-template stateTransition(currentState, nextState: ScoreCard, score: int): untyped =
-  currentState = nextState
-  score += ord(nextState)
 
-proc fuzzymatch* (pattern, str: cstring) : FuzzyMatchResult =
+type 
+  ScoreCard {.pure.} = enum 
+    Start                = -100 ## The state machine has started.
+    UnmatchedLeadingChar = -3   ## An unmatched, leading character was found.
+    UnmatchedChar        = -1   ## An unmatched character was found.
+    MatchedChar          = 0    ## A matched character was found.
+    ConsecutiveMatch     = 5    ## A consecutive match was found.
+    LeadingCharMatch     = 10   ## The character matches the begining of the
+                                ## string or the first character of a word
+                                ## or camel case boundry.
+    WordBoundryMatch     = 20   ## The last ConsecutiveCharMatch that
+                                ## immediately precedes the end of the string,
+                                ## end of the pattern, or a LeadingCharMatch.
+
+
+proc fuzzyMatch*(pattern, str: cstring) : tuple[score: int, matched: bool] =
   var
     scoreState = ScoreCard.Start
     headerMatched = false
@@ -52,121 +40,100 @@ proc fuzzymatch* (pattern, str: cstring) : FuzzyMatchResult =
     consecutiveMatchCount = 0
     strIndex = 0
     patIndex = 0
-    curScore = 0
-    normalizedStrChar : char
-    normalizedPatternChar : char
+    score = 0
+
+  template transition(nextState) =
+    scoreState = nextState
+    inc(score, ord(scoreState)) 
 
   while (strIndex < str.len) and (patIndex < pattern.len):
-    # normalize from strutils doesn't work on cstrings :-(
-    # I am doing an inline emulation of it here.
-    # lowercase everything and ignore underscores.
-    normalizedPatternChar = pattern[patIndex].toLowerAscii
-    normalizedStrChar = str[strIndex].toLowerAscii
-    #ignore certain chars
-    if
-      normalizedStrChar == '_' or
-      normalizedStrChar == ' ' or
-      normalizedStrChar == '.':
-      strIndex += 1
-      continue
-    if 
-      normalizedPatternChar == '_' or
-      normalizedPatternChar == ' ' or
-      normalizedPatternChar == '.':
+    var
+      patternChar = pattern[patIndex].toLowerAscii
+      strChar     = str[strIndex].toLowerAscii
+
+    # Ignore certain characters
+    if patternChar in {'_', ' ', '.'}:
       patIndex += 1
       continue
+    if strChar in {'_', ' ', '.'}:
+      strIndex += 1
+      continue
     
-    if not headerMatched and normalizedStrChar == ':':
-      # We matched the header. Apply the scale factor and reset the search pattern.
+    # Since this algorithm will be used to search against Nim documentation,
+    # the below logic prioritizes headers.
+    if not headerMatched and strChar == ':':
       headerMatched = true
-      curScore = toInt(floor(HeadingScaleFactor * toFloat(curScore)))
-      patIndex = 0
       scoreState = ScoreCard.Start
+      score = toInt(floor(HeadingScaleFactor * toFloat(score)))
+      patIndex = 0
       strIndex += 1
       continue
 
-    if normalizedStrChar == normalizedPatternChar:
+    if strChar == patternChar:
       case scoreState 
-      of ScoreCard.Start:
+      of ScoreCard.Start, ScoreCard.WordBoundryMatch:
         scoreState = ScoreCard.LeadingCharMatch
-        # Transition the state, but don't give the bonus yet; wait until we verify a consecutive match.
+
       of ScoreCard.MatchedChar:
-        scoreState.stateTransition(ScoreCard.ConsecutiveMatch, curScore)
-      of ScoreCard.LeadingCharMatch:
-        # Do the normal state transition. But then give the Leading Char bonus.
-        # We only want to give the leading char bonus if it also has a consectutive match.
-        # Giving a huge bonus to a single char match throws off the results too much.
-        scoreState = ScoreCard.ConsecutiveMatch
+        transition(ScoreCard.ConsecutiveMatch)
+
+      of ScoreCard.LeadingCharMatch, ScoreCard.ConsecutiveMatch:
         consecutiveMatchCount += 1
-        curScore += ord(ScoreCard.ConsecutiveMatch) * consecutiveMatchCount
-        curScore += ord(ScoreCard.LeadingCharMatch)
-        if (patIndex == pattern.len - 1) or
-           (
-              (strIndex < str.len - 1) and
-              (
-                (str[strIndex + 1].toLowerAscii != pattern[patIndex + 1].toLowerAscii) and
-                (not str[strIndex + 1].isLowerAscii) 
-              )
-            ):
-          scoreState.stateTransition(ScoreCard.WordBoundryMatch, curScore)
-      of ScoreCard.ConsecutiveMatch:
         scoreState = ScoreCard.ConsecutiveMatch
-        consecutiveMatchCount += 1
-        curScore += ord(ScoreCard.ConsecutiveMatch) * consecutiveMatchCount
-        if (patIndex == pattern.len - 1) or
-           (
-              (strIndex < str.len - 1) and
-              (
-                (str[strIndex + 1].toLowerAscii != pattern[patIndex + 1].toLowerAscii) and
-                (not str[strIndex + 1].isLowerAscii) 
-              )
-            ):
-          scoreState.stateTransition(ScoreCard.WordBoundryMatch, curScore)
-      of ScoreCard.WordBoundryMatch:
-        scoreState = ScoreCard.LeadingCharMatch
-      of ScoreCard.UnmatchedChar:
-        if
-          not str[strIndex - 1].isAlphaAScii or
-          (str[strIndex - 1].isLowerAscii and
-          str[strIndex].isUpperAscii):
-          #a non alpha or a camel case transiton counts as a leading char.
+        score += ord(ScoreCard.ConsecutiveMatch) * consecutiveMatchCount
+
+        if scoreState == ScoreCard.LeadingCharMatch:
+          score += ord(ScoreCard.LeadingCharMatch)
+          
+        var onBoundary = (patIndex == high(pattern))
+        if not onBoundary:
+          let
+            nextPatternChar = toLowerAscii(pattern[patIndex + 1])
+            nextStrChar     = toLowerAscii(str[strIndex + 1])
+
+          onBoundary = (
+            nextStrChar notin {'a'..'z'} and
+            nextStrChar != nextPatternChar
+          )
+        
+        if onBoundary:
+          transition(ScoreCard.WordBoundryMatch)
+
+      of ScoreCard.UnmatchedChar, ScoreCard.UnmatchedLeadingChar:
+        var isLeadingChar = (
+          str[strIndex - 1] notin Letters or
+          str[strIndex - 1] in {'a'..'z'} and
+          str[strIndex] in {'A'..'Z'}
+        )
+
+        if isLeadingChar:
           scoreState = ScoreCard.LeadingCharMatch
+          #a non alpha or a camel case transition counts as a leading char.
           # Transition the state, but don't give the bonus yet; wait until we verify a consecutive match.
         else:
-          scoreState.stateTransition(ScoreCard.MatchedChar, curScore)
-      of ScoreCard.UnmatchedLeadingChar:
-        if
-          not str[strIndex - 1].isAlphaAScii or
-          (str[strIndex - 1].isLowerAscii and
-          str[strIndex].isUpperAscii):
-          #a non alpha or a camel case transiton counts as a leading char.
-          scoreState = ScoreCard.LeadingCharMatch
-          # Transition the state, but don't give the bonus yet; wait until we verify a consecutive match.
-        else:
-          scoreState.stateTransition(ScoreCard.MatchedChar, curScore)
+          transition(ScoreCard.MatchedChar)
       patIndex += 1
+
     else:
       case scoreState 
       of ScoreCard.Start:
-        scoreState.stateTransition(ScoreCard.UnmatchedLeadingChar, curScore)
-      of ScoreCard.UnmatchedChar:
-        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
-      of ScoreCard.MatchedChar:
-        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
-      of ScoreCard.LeadingCharMatch:
-        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
-      of ScoreCard.WordBoundryMatch:
-        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+        transition(ScoreCard.UnmatchedLeadingChar)
+
       of ScoreCard.ConsecutiveMatch:
-        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+        transition(ScoreCard.UnmatchedChar)
         consecutiveMatchCount = 0
+
       of ScoreCard.UnmatchedLeadingChar:
-        if (unmatchedLeadingCharCount < MaxUnmatchedLeadingChar):
-          # Stop penalizing after so many unmatched leading characters.
-          scoreState.stateTransition(ScoreCard.UnmatchedLeadingChar, curScore)
+        if unmatchedLeadingCharCount < MaxUnmatchedLeadingChar:
+          transition(ScoreCard.UnmatchedLeadingChar)
         unmatchedLeadingCharCount += 1
-    
+
+      else:
+        transition(ScoreCard.UnmatchedChar)
+
     strIndex += 1
 
-  result = FuzzyMatchResult(ismatch: (curScore > 0), score: max(0, curScore))
-
+  result = (
+    score:   max(0, score),
+    matched: (score > 0),
+  )

--- a/tools/dochack/fuzzysearch.nim
+++ b/tools/dochack/fuzzysearch.nim
@@ -44,7 +44,7 @@ proc fuzzyMatch*(pattern, str: cstring) : tuple[score: int, matched: bool] =
 
   template transition(nextState) =
     scoreState = nextState
-    inc(score, ord(scoreState)) 
+    score += ord(scoreState)
 
   while (strIndex < str.len) and (patIndex < pattern.len):
     var

--- a/tools/dochack/fuzzysearch.nim
+++ b/tools/dochack/fuzzysearch.nim
@@ -1,0 +1,175 @@
+# A Fuzzy Match implementation inspired by the sublime text fuzzy match algorithm
+# as described here: https://blog.forrestthewoods.com/reverse-engineering-sublime-text-s-fuzzy-match-4cffeed33fdb
+# Heavily modified to provide more subjectively useful results
+# for on the Nim manual.
+#
+
+import strutils
+import math
+import macros
+
+type
+  FuzzyMatchResult* = object
+    ismatch*: bool
+    score*: int 
+
+
+# Fuzzy match score.
+#  A positive number is a bonus
+#  A negative number is a penalty
+type ScoreCard {.pure.} = enum 
+  Start = -100, # this acts as a state machine. So we need nil start and end states.
+  UnmatchedLeadingChar = -3, # for each unmatched character from the start of the string
+  UnmatchedChar = -1, # for each single letter does not match
+  MatchedChar = 0, # for each single letter matches
+  ConsecutiveMatch = 5, # every consecutive letter that matches after the first
+  LeadingCharMatch = 10, # The character matches the begining of the string 
+                         # or the first character of a word boundry (a space)
+                         # or a camel case boundry: 
+                         #    An upper case letter that is preceded by a lower case letter.
+                         # This bonus is only applied if a consecutive match is also found.
+                         # This is because it gives too much bias
+                         # to single char matches at word boundries.
+  WordBoundryMatch = 20
+
+const
+  MaxUnmatchedLeadingChar = 3
+  # max number of times we will apply the penalty for unmatched leading chars.
+
+  HeadingScaleFactor = 0.5
+  # The score from before the colon Char is multiplied by this.
+  # This is to weight function signatures and descriptions over module titles.
+
+template stateTransition(currentState, nextState: ScoreCard, score: int): untyped =
+  currentState = nextState
+  score += ord(nextState)
+
+proc fuzzymatch* (pattern, str: cstring) : FuzzyMatchResult =
+  var
+    scoreState = ScoreCard.Start
+    headerMatched = false
+    unmatchedLeadingCharCount = 0
+    consecutiveMatchCount = 0
+    strIndex = 0
+    patIndex = 0
+    curScore = 0
+    normalizedStrChar : char
+    normalizedPatternChar : char
+
+  while (strIndex < str.len) and (patIndex < pattern.len):
+    # normalize from strutils doesn't work on cstrings :-(
+    # I am doing an inline emulation of it here.
+    # lowercase everything and ignore underscores.
+    normalizedPatternChar = pattern[patIndex].toLowerAscii
+    normalizedStrChar = str[strIndex].toLowerAscii
+    #ignore certain chars
+    if
+      normalizedStrChar == '_' or
+      normalizedStrChar == ' ' or
+      normalizedStrChar == '.':
+      strIndex += 1
+      continue
+    if 
+      normalizedPatternChar == '_' or
+      normalizedPatternChar == ' ' or
+      normalizedPatternChar == '.':
+      patIndex += 1
+      continue
+    
+    if not headerMatched and normalizedStrChar == ':':
+      # We matched the header. Apply the scale factor and reset the search pattern.
+      headerMatched = true
+      curScore = toInt(floor(HeadingScaleFactor * toFloat(curScore)))
+      patIndex = 0
+      scoreState = ScoreCard.Start
+      strIndex += 1
+      continue
+
+    if normalizedStrChar == normalizedPatternChar:
+      case scoreState 
+      of ScoreCard.Start:
+        scoreState = ScoreCard.LeadingCharMatch
+        # Transition the state, but don't give the bonus yet; wait until we verify a consecutive match.
+      of ScoreCard.MatchedChar:
+        scoreState.stateTransition(ScoreCard.ConsecutiveMatch, curScore)
+      of ScoreCard.LeadingCharMatch:
+        # Do the normal state transition. But then give the Leading Char bonus.
+        # We only want to give the leading char bonus if it also has a consectutive match.
+        # Giving a huge bonus to a single char match throws off the results too much.
+        scoreState = ScoreCard.ConsecutiveMatch
+        consecutiveMatchCount += 1
+        curScore += ord(ScoreCard.ConsecutiveMatch) * consecutiveMatchCount
+        curScore += ord(ScoreCard.LeadingCharMatch)
+        if (patIndex == pattern.len - 1) or
+           (
+              (strIndex < str.len - 1) and
+              (
+                (str[strIndex + 1].toLowerAscii != pattern[patIndex + 1].toLowerAscii) and
+                ((not str[strIndex + 1].isAlphaAScii) or str[strIndex + 1].isUpperAscii)
+              )
+            ):
+          scoreState.stateTransition(ScoreCard.WordBoundryMatch, curScore)
+      of ScoreCard.ConsecutiveMatch:
+        scoreState = ScoreCard.ConsecutiveMatch
+        consecutiveMatchCount += 1
+        curScore += ord(ScoreCard.ConsecutiveMatch) * consecutiveMatchCount
+        if (patIndex == pattern.len - 1) or
+           (
+              (strIndex < str.len - 1) and
+              (
+                (str[strIndex + 1].toLowerAscii != pattern[patIndex + 1].toLowerAscii) and
+                ((not str[strIndex + 1].isAlphaAScii) or str[strIndex + 1].isUpperAscii)
+              )
+            ):
+          scoreState.stateTransition(ScoreCard.WordBoundryMatch, curScore)
+      of ScoreCard.WordBoundryMatch:
+        scoreState = ScoreCard.LeadingCharMatch
+      of ScoreCard.UnmatchedChar:
+        if
+          not str[strIndex - 1].isAlphaAScii or
+          (str[strIndex - 1].isLowerAscii and
+          str[strIndex].isUpperAscii):
+          #a non alpha or a camel case transiton counts as a leading char.
+          scoreState = ScoreCard.LeadingCharMatch
+          # Transition the state, but don't give the bonus yet; wait until we verify a consecutive match.
+        else:
+          scoreState.stateTransition(ScoreCard.MatchedChar, curScore)
+      of ScoreCard.UnmatchedLeadingChar:
+        if
+          not str[strIndex - 1].isAlphaAScii or
+          (str[strIndex - 1].isLowerAscii and
+          str[strIndex].isUpperAscii):
+          #a non alpha or a camel case transiton counts as a leading char.
+          scoreState = ScoreCard.LeadingCharMatch
+          # Transition the state, but don't give the bonus yet; wait until we verify a consecutive match.
+        else:
+          scoreState.stateTransition(ScoreCard.MatchedChar, curScore)
+      patIndex += 1
+    else:
+      case scoreState 
+      of ScoreCard.Start:
+        scoreState.stateTransition(ScoreCard.UnmatchedLeadingChar, curScore)
+      of ScoreCard.UnmatchedChar:
+        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+      of ScoreCard.MatchedChar:
+        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+      of ScoreCard.LeadingCharMatch:
+        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+      of ScoreCard.WordBoundryMatch:
+        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+      of ScoreCard.ConsecutiveMatch:
+        scoreState.stateTransition(ScoreCard.UnmatchedChar, curScore)
+        consecutiveMatchCount = 0
+      of ScoreCard.UnmatchedLeadingChar:
+        if (unmatchedLeadingCharCount < MaxUnmatchedLeadingChar):
+          # Stop penalizing after so many unmatched leading characters.
+          scoreState.stateTransition(ScoreCard.UnmatchedLeadingChar, curScore)
+        unmatchedLeadingCharCount += 1
+    
+    strIndex += 1
+
+  result = FuzzyMatchResult(ismatch: (curScore > 0), score: max(0, curScore))
+
+template echoAssert(expr: untyped, expected: untyped): untyped =
+  echo `expr`
+  doAssert `expr` == `expected`


### PR DESCRIPTION
**Motivation**:
The currently implemented doc search is subjectively not great.
It uses a basic regex search that is limited and misses relevant results.
It only searches exposed symbols from the standard lib, even though the manual consists of lots of other potentially useful documents, that can be exposed through `theindex.html`.
It is really odd, especially to new users, that on the main Nim language manual page, the search results do not show results from that page, but instead show results from the standard library.
A prime example of new user issues that might be helped by this is this forum post:
https://forum.nim-lang.org/t/3990
Searching for "exec" with the current search implementation does not even show `OS.execShellCmd`.
The main result is `nimscript : exec(command: string)`,
And it contains results from the db modules, Posix, and Winlean, and not in a particularly useful order.

**Proposed Solution**:
Two parts:
1.) Add a custom data attribute to `theindex.html` TOC file that provides a useful keyword tag to allow searching the entire manual effectively instead of just the exposed API symbols from the std lib.

2.) A Fuzzy Match implementation inspired by the sublime text fuzzy match algorithm
as described here: 
https://blog.forrestthewoods.com/reverse-engineering-sublime-text-s-fuzzy-match-4cffeed33fdb
Heavily modified to provide more subjectively useful results for on the Nim manual.

The search tag attribute is of the form "<manual section title> : <subheading or item title>"

The fuzzy match searches both sides of the colon, allowing you to search for specific manual sections, but gives more weight to the specific subheading or item on the right side of the colon.