### PR TITLE
Fixed a wrong AST example

### DIFF
--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -1270,10 +1270,10 @@ AST:
         nnkIdent("float32"),
         nnkEmpty()
       )
-      nnkPragma(nnkIdent("inline")),
-      nnkEmpty(), # reserved slot for future use
-      nnkStmtList(nnkDiscardStmt(nnkEmpty())) # the meat of the proc
-    )
+    ),
+    nnkPragma(nnkIdent("inline")),
+    nnkEmpty(), # reserved slot for future use
+    nnkStmtList(nnkDiscardStmt(nnkEmpty())) # the meat of the proc
   )
 
 There is another consideration. Nim has flexible type identification for


### PR DESCRIPTION
The example has the pragmas, reserved slot, and body parts of the `nnkProcDef` incorrectly inside of the `nnkFormalParams`.