### PR TITLE
add quoteShellCommand

### DIFF
--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -13,7 +13,6 @@
 include "system/inclrtl"
 
 import strutils
-import sequtils
 
 type
   ReadEnvEffect* = object of ReadIOEffect   ## effect that denotes a read
@@ -632,7 +631,9 @@ when defined(windows) or defined(posix) or defined(nintendoswitch):
       when defined(windows):
         assert quoteShellCommand(["aaa", "", "c d"]) == "aaa \"\" \"c d\""
     # can't use `map` pending https://github.com/nim-lang/Nim/issues/8303
-    result = args.mapIt(quoteShell(it)).join(" ")
+    for i in 0..<args.len:
+      if i > 0: result.add " "
+      result.add quoteShell(args[i])
 
 when isMainModule:
   assert quoteShellWindows("aaa") == "aaa"

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -631,7 +631,8 @@ when defined(windows) or defined(posix) or defined(nintendoswitch):
         assert quoteShellCommand(["aaa", "", "c d"]) == "aaa '' 'c d'"
       when defined(windows):
         assert quoteShellCommand(["aaa", "", "c d"]) == "aaa \"\" \"c d\""
-    result = args.map(quoteShell).join(" ")
+    # can't use `map` pending https://github.com/nim-lang/Nim/issues/8303
+    result = args.mapIt(quoteShell(it)).join(" ")
 
 when isMainModule:
   assert quoteShellWindows("aaa") == "aaa"

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -13,6 +13,7 @@
 include "system/inclrtl"
 
 import strutils
+import sequtils
 
 type
   ReadEnvEffect* = object of ReadIOEffect   ## effect that denotes a read
@@ -570,6 +571,8 @@ proc expandTilde*(path: string): string {.
     # TODO: handle `~bob` and `~bob/` which means home of bob
     result = path
 
+# TODO: consider whether quoteShellPosix, quoteShellWindows, quoteShell, quoteShellCommand
+# belong in `strutils` instead; they are not specific to paths
 proc quoteShellWindows*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
   ## Quote s, so it can be safely passed to Windows API.
   ## Based on Python's subprocess.list2cmdline
@@ -620,6 +623,15 @@ when defined(windows) or defined(posix) or defined(nintendoswitch):
       return quoteShellWindows(s)
     else:
       return quoteShellPosix(s)
+
+  proc quoteShellCommand*(args: openArray[string]): string =
+    ## Concatenates and quotes shell arguments `args`
+    runnableExamples:
+      when defined(posix):
+        assert quoteShellCommand(["aaa", "", "c d"]) == "aaa '' 'c d'"
+      when defined(windows):
+        assert quoteShellCommand(["aaa", "", "c d"]) == "aaa \"\" \"c d\""
+    result = args.map(quoteShell).join(" ")
 
 when isMainModule:
   assert quoteShellWindows("aaa") == "aaa"


### PR DESCRIPTION
same as:
* in D: [escapeShellCommand](https://dlang.org/library/std/process/escape_shell_command.html)
* in C#: [QuoteArguments](http://gfxmonk.net/2014/04/25/escaping-an-array-of-command-line-arguments-in-csharp.html)
* in perl: [String::ShellQuote](https://metacpan.org/pod/String::ShellQuote)
* in node: [quote](https://github.com/substack/node-shell-quote)
* in ruby: [shelljoin](https://ruby-doc.org/stdlib-2.3.0/libdoc/shellwords/rdoc/Shellwords.html)
* in go: [shellquote](https://github.com/kballard/go-shellquote)