### PR TITLE
Give different names to objects coming from cpp files

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -434,10 +434,7 @@ proc completeCFilePath*(conf: ConfigRef; cfile: string, createSubDir: bool = tru
 
 proc toObjFile*(conf: ConfigRef; filename: string): string =
   # Object file for compilation
-  #if filename.endsWith(".cpp"):
-  #  result = changeFileExt(filename, "cpp." & CC[cCompiler].objExt)
-  #else:
-  result = changeFileExt(filename, CC[conf.cCompiler].objExt)
+  result = filename & "." & CC[conf.cCompiler].objExt
 
 proc addFileToCompile*(conf: ConfigRef; cf: Cfile) =
   conf.toCompile.add(cf)


### PR DESCRIPTION
Prevent some nasty linker errors if the user switches between c and cpp
backends.