### PR TITLE
Enables using ~/ to work relative to the path the compiler was called from

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -569,7 +569,7 @@ proc findModule*(conf: ConfigRef; modulename, currentModule: string): string =
   else:
     if m.startsWith(commandPrefix):
       currentPath = conf.commandPath
-      m = m.replace(commandPrefix)
+      m.delete(0, 0)
     else:
       currentPath = currentModule.splitFile.dir
     result = currentPath / m


### PR DESCRIPTION
This PR edit options.nim in two areas to do one thing.

The first edit adds the directory the compiler was called from to the config, and also sets this new property `commandPath` via `getCurrentDir()`. This was in the config so it can be overwritten if desired by an user, in case other parts of the compiler want to use it, and so `getCurrentDir` is only called once.

The second edit detects modules with `~` in their path, and edits them to replace the `~` with the `commandPath` This means users no longer have to write everything relative to the file they're working on, but instead can work relative to wherever they can compile from.