### PR TITLE
Correctly hash inferred types

### DIFF
--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -163,7 +163,7 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
         c.hashType t.sons[i], flags
     else:
       c.hashType t.lastSon, flags
-  of tyAlias, tySink, tyUserTypeClasses:
+  of tyAlias, tySink, tyUserTypeClasses, tyInferred:
     c.hashType t.lastSon, flags
   of tyBool, tyChar, tyInt..tyUInt64:
     # no canonicalization for integral types, so that e.g. ``pid_t`` is

--- a/tests/concepts/t8280.nim
+++ b/tests/concepts/t8280.nim
@@ -1,0 +1,16 @@
+discard """
+  output: "()"
+"""
+
+type
+  Iterable[T] = concept x
+    for elem in x:
+      elem is T
+
+proc max[A](iter: Iterable[A]): A = 
+  discard
+
+type
+  MyType = object
+
+echo max(@[MyType()])


### PR DESCRIPTION
We don't really want to hash the tyInferred container since that'd make
the "real" type and its inferred counterpart produce different hashes
and types for the very same type.

Fixes #8280