### PR TITLE
Fixed $ on None[T] for T with .name

### DIFF
--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -189,7 +189,7 @@ proc `$`*[T](self: Option[T]): string =
   if self.isSome:
     "Some(" & $self.val & ")"
   else:
-    "None[" & T.name & "]"
+    "None[" & name(T) & "]"
 
 when isMainModule:
   import unittest, sequtils
@@ -298,3 +298,17 @@ when isMainModule:
     test "none[T]":
       check(none[int]().isNone)
       check(none(int) == none[int]())
+
+    test "$ on typed with .name":
+      type Named = object
+        name: string
+
+      let nobody = none(Named)
+      check($nobody == "None[Named]")
+
+    test "$ on type with name()":
+      type Person = object
+        myname: string
+
+      let noperson = none(Person)
+      check($noperson == "None[Person]")


### PR DESCRIPTION
Previously, for some

```nim
type T = object
    name: string
```

`$none(T)` would throw a type error. This is fixed, and the first test is added to show so.

The second test was never an issue but is included for good measure to ensure that a similar issue never happens in the future for a `proc(x: T): Whatever`