### PR TITLE
Fix undefined PObject reference

### DIFF
--- a/lib/deprecated/pure/asyncio.nim
+++ b/lib/deprecated/pure/asyncio.nim
@@ -272,7 +272,7 @@ proc asyncSockHandleWrite(h: RootRef) =
         AsyncSocket(h).deleg.mode = fmRead
 
 when defined(ssl):
-  proc asyncSockDoHandshake(h: PObject) {.gcsafe.} =
+  proc asyncSockDoHandshake(h: RootRef) {.gcsafe.} =
     if AsyncSocket(h).socket.isSSL and not
          AsyncSocket(h).socket.gotHandshake:
       if AsyncSocket(h).sslNeedAccept:


### PR DESCRIPTION
When ssl is defined, the PObject object reference causes a compiler error. It was replaced with RootRef in other places, so this seems logical.

Fixes #8261. 