### PR TITLE
Extend init variable tracking to tuple assignments

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -785,6 +785,15 @@ proc track(tracked: PEffects, n: PNode) =
           initVar(tracked, child.sons[i], volatileCheck=false)
           addAsgnFact(tracked.guards, child.sons[i], last)
           notNilCheck(tracked, last, child.sons[i].typ)
+      elif child.kind == nkVarTuple and last.kind != nkEmpty:
+        for i in 0 .. child.len-2:
+          if child[i].kind == nkEmpty or
+            child[i].kind == nkSym and child[i].sym.name.s == "_":
+            continue
+          initVar(tracked, child[i], volatileCheck=false)
+          if last.kind in {nkPar, nkTupleConstr}:
+            addAsgnFact(tracked.guards, child[i], last[i])
+            notNilCheck(tracked, last[i], child[i].typ)
       # since 'var (a, b): T = ()' is not even allowed, there is always type
       # inference for (a, b) and thus no nil checking is necessary.
   of nkConstSection:

--- a/tests/init/t8314.nim
+++ b/tests/init/t8314.nim
@@ -1,0 +1,21 @@
+discard """
+  nimout: '''
+t8314.nim(8, 7) Hint: BEGIN [User]
+t8314.nim(19, 7) Hint: END [User]
+  '''
+"""
+
+{.hint: "BEGIN".}
+proc foo(x: range[1..10]) =
+  block:
+    var (y,) = (x,)
+    echo y
+  block:
+    var (_,y) = (1,x)
+    echo y
+  block:
+    var (y,_,) = (x,1,)
+    echo y
+{.hint: "END".}
+
+foo(1)


### PR DESCRIPTION
How do I check for the absence of warnings in the test?

Fixes #8314