### PR TITLE
fix issue #8303 `map` overly restrictive

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -199,22 +199,18 @@ proc distribute*[T](s: seq[T], num: Positive, spread = true): seq[seq[T]] =
         result[i].add(s[g])
       first = last
 
-proc map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
-                                                            seq[S]{.inline.} =
+proc map*[Fun, T](s: openArray[T], op: Fun): auto{.inline.} =
   ## Returns a new sequence with the results of `op` applied to every item in
   ## the container `s`.
   ##
   ## Since the input is not modified you can use this version of ``map`` to
   ## transform the type of the elements in the input container.
-  ##
-  ## Example:
-  ##
-  ## .. code-block:: nim
-  ##   let
-  ##     a = @[1, 2, 3, 4]
-  ##     b = map(a, proc(x: int): string = $x)
-  ##   assert b == @["1", "2", "3", "4"]
-  newSeq(result, s.len)
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+      b = map(a, proc(x: int): string = $x)
+    doAssert b == @["1", "2", "3", "4"]
+  result = newSeq[type(op(s[0]))](s.len)
   for i in 0 ..< s.len:
     result[i] = op(s[i])
 


### PR DESCRIPTION
/cc @dom96 @Araq this workaround for #8303 doesn't work yet: I just hit the limitation of https://github.com/nim-lang/Nim/issues/7435 (type inference with lambdas doesn't work) again.  Help would be appreciated:

in https://github.com/nim-lang/Nim/pull/8272 adding this innocent looking [code](https://github.com/nim-lang/Nim/pull/8272/files#diff-f827b8fd5522bf8b8724a52aa4972c24R621): 

```nim
proc quoteShellCommand*(args: openArray[string]): string = args.map(quoteShell).join(" ")
```
results in travis/appveyor failure (see [bug](https://github.com/nim-lang/Nim/issues/8303)) because `sequtils.map` cannot handle `cdecl` procs and`quoteShell` becomes a `cdecl` in the `--define:createNimRtl` test of travis/appveyor:

```nim
proc map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}): seq[S]{.inline.}
```

but trying to make `map` less restrictive as in this PR results in exactly the type inference bug I had mentioned here (https://github.com/nim-lang/Nim/issues/7435), see where below in [1]

How do I solve this (without the workaround of using an explicit for-loop in `quoteShellCommand` or similar, which is just hiding the problem under a rug, waiting to re-occur?

is there at least a way to be generic on the pragma type, to allow both decl and cdecl?
```nim
proc map*[T, S, Pragma](s: seq[T], op: proc (x: T): S {. Pragma .} ): seq[S]= # this unfortunately doesn't work:
```

The following DOES work but is really ugly, it's not DRY:
```nim
proc map*[T, S](s: seq[T], op: proc (x: T): S ): seq[S]= ... <function body>
proc map*[T, S](s: openArray[T], op: proc (x: T): S {.cdecl.}): seq[S]{.inline.} = ... <function body>
```

I also tried:
```nim
template map*[T](s: openArray[T], op: untyped): auto =
  var res = newSeq[type(op(s[0]))](s.len)
  for i in 0 ..< s.len:
    res[i] = op(s[i])
  res
```
but gives: Error: A nested proc can have generic parameters only when it is used as an operand to another routine and the types of the generic paramers can be inferred from the expected signature.
        (x) => x.changeFileExt("").toLowerAscii()

[1] with this PR, travis/appveyor (or running `./koch nimble` locally) complains about this:
at dist/nimble/src/nimblepkg/packageparser.nim(103):
```nim
normalizedBinNames = pkgInfo.bin.map(
      (x) => x.changeFileExt("").toLowerAscii()
    )
```
