### PR TITLE
Remove cross-compile breaking env var in Nintendo Switch config

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -111,10 +111,10 @@ path="$lib/pure"
 
 @if nintendoswitch:
   cc = "switch_gcc"
-  switch_gcc.options.linker = "-g -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE $SWITCH_LIBS"
-  switch_gcc.cpp.options.linker = "-g -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE $SWITCH_LIBS"
-  switch_gcc.options.always = "-g -Wall -O2 -ffunction-sections -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE $SWITCH_INCLUDES -D__SWITCH__"
-  switch_gcc.cpp.options.always = "-g -Wall -O2 -ffunction-sections -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE $SWITCH_INCLUDES -D__SWITCH__ -fno-rtti -fno-exceptions -std=gnu++11"
+  switch_gcc.options.linker = "-g -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE"
+  switch_gcc.cpp.options.linker = "-g -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE"
+  switch_gcc.options.always = "-g -Wall -O2 -ffunction-sections -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -D__SWITCH__"
+  switch_gcc.cpp.options.always = "-g -Wall -O2 -ffunction-sections -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -D__SWITCH__ -fno-rtti -fno-exceptions -std=gnu++11"
 @end
 
 # Configuration for the Intel C/C++ compiler:

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -232,12 +232,12 @@ Cross compilation for Nintendo Switch
 =====================================
 
 Simply add --os:nintendoswitch
-to your usual ``nim c`` or ``nim cpp`` command and set the ``SWITCH_LIBS``
-and ``SWITCH_INCLUDES`` environment variables to something like:
+to your usual ``nim c`` or ``nim cpp`` command and set the ``passC``
+and ``passL`` command line switches to something like:
 
 .. code-block:: console
-  export SWITCH_INCLUDES="-I$DEVKITPRO/libnx/include"
-  export SWITCH_LIBS="-specs=$DEVKITPRO/libnx/switch.specs -L$DEVKITPRO/libnx/lib -lnx"
+  nim c ... --passC="-I$DEVKITPRO/libnx/include" ...
+  --passL="-specs=$DEVKITPRO/libnx/switch.specs -L$DEVKITPRO/libnx/lib -lnx"
 
 or setup a nim.cfg file like so:
 
@@ -258,10 +258,6 @@ This will generate a file called ``switchhomebrew.elf`` which can then be turned
 an nro file with the ``elf2nro`` tool in the DevkitPro release. Examples can be found at
 `the nim-libnx github repo <https://github.com/jyapayne/nim-libnx.git>`_ or you can use
 `the switch builder tool <https://github.com/jyapayne/switch-builder.git>`_.
-
-Environment variables are: 
-  - ``SWITCH_LIBS`` for any extra libraries required by your application (``-lLIBNAME`` or ``-LLIBPATH``)
-  - ``SWITCH_INCLUDES`` for any extra include files (``-IINCLUDE_PATH``)
 
 There are a few things that don't work because the DevkitPro libraries don't support them.
 They are:


### PR DESCRIPTION
This was bad to put in here, so my bad. It doesn't work on anything except platforms with shell support. Users can use `--passC` and `--passL` options for customization.