### PR TITLE
fix issue #8268 (joinPaths); add lots of tests  and make use of use runnableExamples

### DIFF
--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -117,13 +117,12 @@ proc cleanPath(s: string): string =
       result.add c
 
 proc joinPath(parts: seq[string]): string =
-  let nb = parts.len
-  assert nb > 0
-  if nb == 1:
-    return parts[0]
-  result = parts[0] / parts[1]
-  for i in 2..<parts.len:
-    result = result / parts[i]
+  if parts.len == 0:
+    result = ""
+  else:
+    result = parts[0]
+    for i in 1..<parts.len:
+      result = result / parts[i]
 
 proc getIncludePath(n: PNode, modulePath: string): string =
   let istr = n.renderTree.cleanPath

--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -162,27 +162,18 @@ proc joinPath*(head, tail: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Joins two directory names to one.
   ##
-  ## For example on Unix:
-  ##
-  ## .. code-block:: nim
-  ##   joinPath("usr", "lib")
-  ##
-  ## results in:
-  ##
-  ## .. code-block:: nim
-  ##   "usr/lib"
-  ##
   ## If head is the empty string, tail is returned. If tail is the empty
   ## string, head is returned with a trailing path separator. If tail starts
   ## with a path separator it will be removed when concatenated to head. Other
-  ## path separators not located on boundaries won't be modified. More
-  ## examples on Unix:
-  ##
-  ## .. code-block:: nim
-  ##   assert joinPath("usr", "") == "usr/"
-  ##   assert joinPath("", "lib") == "lib"
-  ##   assert joinPath("", "/lib") == "/lib"
-  ##   assert joinPath("usr/", "/lib") == "usr/lib"
+  ## path separators not located on boundaries won't be modified.
+  runnableExamples:
+    when defined(posix):
+      doAssert joinPath("usr", "lib") == "usr/lib"
+      doAssert joinPath("usr", "") == "usr/"
+      doAssert joinPath("", "lib") == "lib"
+      doAssert joinPath("", "/lib") == "/lib"
+      doAssert joinPath("usr/", "/lib") == "usr/lib"
+
   if len(head) == 0:
     result = tail
   elif head[len(head)-1] in {DirSep, AltSep}:

--- a/tests/stdlib/tospaths.nim
+++ b/tests/stdlib/tospaths.nim
@@ -6,32 +6,33 @@ discard """
 
 import os
 
-doAssert unixToNativePath("") == ""
-doAssert unixToNativePath(".") == $CurDir
-doAssert unixToNativePath("..") == $ParDir
-doAssert isAbsolute(unixToNativePath("/"))
-doAssert isAbsolute(unixToNativePath("/", "a"))
-doAssert isAbsolute(unixToNativePath("/a"))
-doAssert isAbsolute(unixToNativePath("/a", "a"))
-doAssert isAbsolute(unixToNativePath("/a/b"))
-doAssert isAbsolute(unixToNativePath("/a/b", "a"))
-doAssert unixToNativePath("a/b") == joinPath("a", "b")
+block unixToNativePath:
+  doAssert unixToNativePath("") == ""
+  doAssert unixToNativePath(".") == $CurDir
+  doAssert unixToNativePath("..") == $ParDir
+  doAssert isAbsolute(unixToNativePath("/"))
+  doAssert isAbsolute(unixToNativePath("/", "a"))
+  doAssert isAbsolute(unixToNativePath("/a"))
+  doAssert isAbsolute(unixToNativePath("/a", "a"))
+  doAssert isAbsolute(unixToNativePath("/a/b"))
+  doAssert isAbsolute(unixToNativePath("/a/b", "a"))
+  doAssert unixToNativePath("a/b") == joinPath("a", "b")
 
-when defined(macos):
+  when defined(macos):
     doAssert unixToNativePath("./") == ":"
     doAssert unixToNativePath("./abc") == ":abc"
     doAssert unixToNativePath("../abc") == "::abc"
     doAssert unixToNativePath("../../abc") == ":::abc"
     doAssert unixToNativePath("/abc", "a") == "abc"
     doAssert unixToNativePath("/abc/def", "a") == "abc:def"
-elif doslikeFileSystem:
+  elif doslikeFileSystem:
     doAssert unixToNativePath("./") == ".\\"
     doAssert unixToNativePath("./abc") == ".\\abc"
     doAssert unixToNativePath("../abc") == "..\\abc"
     doAssert unixToNativePath("../../abc") == "..\\..\\abc"
     doAssert unixToNativePath("/abc", "a") == "a:\\abc"
     doAssert unixToNativePath("/abc/def", "a") == "a:\\abc\\def"
-else:
+  else:
     #Tests for unix
     doAssert unixToNativePath("./") == "./"
     doAssert unixToNativePath("./abc") == "./abc"
@@ -39,3 +40,20 @@ else:
     doAssert unixToNativePath("../../abc") == "../../abc"
     doAssert unixToNativePath("/abc", "a") == "/abc"
     doAssert unixToNativePath("/abc/def", "a") == "/abc/def"
+
+block normalizePathEnd:
+  doAssert "".normalizePathEnd == ""
+  doAssert "".normalizePathEnd(trailingSep = true) == ""
+  when defined(posix):
+    doAssert "/".normalizePathEnd == "/"
+    doAssert "foo.bar".normalizePathEnd == "foo.bar"
+    doAssert "foo.bar".normalizePathEnd(trailingSep = true) == "foo.bar/"
+  when defined(Windows):
+    doAssert r"C:\\".normalizePathEnd == r"C:\"
+    doAssert r"C:\".normalizePathEnd(trailingSep = true) == r"C:\"
+    doAssert r"C:\foo\\bar\".normalizePathEnd == r"C:\foo\\bar"
+
+block joinPath:
+  when defined(posix):
+    doAssert joinPath("", "/lib") == "/lib"
+


### PR DESCRIPTION
/cc @dom96 

* fixes https://github.com/nim-lang/Nim/issues/8268 by adding an optional `absOverrides` to `joinPath` (by default, same behavior as before so no breaking change)
* correctly handles boundary bw head and tail so that there's a unique dirsep between
* adds `normalizePathEnd` (also useful in other places, can be refactored later)
* adds lots of tests (and fixes other things that were broken with joinPaths)
* add `countWhile` and `rootPrefixLength` (simplifies and fixes a lot of code)

## eg motivation
`joinPath(foo, bar)`  is often a bug when `bar` is absolute, for eg:
https://github.com/genotrance/nimterop/commit/a8bb2dc01f99a2866f586f6e1491a512ce9b3cfa#r31391178
> don't joinPath if path.isAbsolute
