### PR TITLE
or on NimNode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@
 - Added `split`, `splitWhitespace`, `size`, `alignLeft`, `align`,
   `strip`, `repeat` procs and iterators to `unicode.nim`.
 
+- Added `or` for `NimNode` in `macros`.
+
 ### Library changes
 
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -177,7 +177,7 @@ proc `[]=`*(n: NimNode, i: BackwardsIndex, child: NimNode) =
   n[n.len - i.int] = child
 
 template `or`*(x, y: NimNode): NimNode =
-  ## Evalutuate ``x`` and when it is not an empty node, return return
+  ## Evaluate ``x`` and when it is not an empty node, return
   ## it. Otherwise evaluate to ``y``. Can be used to chain several
   ## expressions that evaluates to the first expression that is not
   ## empty.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -176,6 +176,22 @@ proc `[]=`*(n: NimNode, i: BackwardsIndex, child: NimNode) =
   ## set `n`'s `i`'th child to `child`.
   n[n.len - i.int] = child
 
+template `or`*(a,b: NimNode): NimNode =
+  ## Evalutuate ``a`` and when it is not an empty node, return return
+  ## it. Otherwise evaluate to ``b``. Can be used to chain several
+  ## expressions that evaluates to the first expression that is not
+  ## empty.
+  ##
+  ## .. code-block:: nim
+  ##
+  ##   let node = mightBeEmpty() or mightAlsoBeEmpty() or fallbackNode
+
+  let arg = a
+  if arg != nil and arg.kind != nnkEmpty:
+    arg
+  else:
+    b
+
 proc add*(father, child: NimNode): NimNode {.magic: "NAdd", discardable,
   noSideEffect, locks: 0.}
   ## Adds the `child` to the `father` node. Returns the
@@ -1433,4 +1449,3 @@ proc getProjectPath*(): string = discard
   ## Returns the path to the currently compiling project, not to
   ## be confused with ``system.currentSourcePath`` which returns
   ## the path of the current module.
-

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -179,8 +179,7 @@ proc `[]=`*(n: NimNode, i: BackwardsIndex, child: NimNode) =
 template `or`*(x, y: NimNode): NimNode =
   ## Evaluate ``x`` and when it is not an empty node, return
   ## it. Otherwise evaluate to ``y``. Can be used to chain several
-  ## expressions that evaluates to the first expression that is not
-  ## empty.
+  ## expressions to get the first expression that is not empty.
   ##
   ## .. code-block:: nim
   ##

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -176,7 +176,7 @@ proc `[]=`*(n: NimNode, i: BackwardsIndex, child: NimNode) =
   ## set `n`'s `i`'th child to `child`.
   n[n.len - i.int] = child
 
-template `or`*(a,b: NimNode): NimNode =
+template `or`*(x, y: NimNode): NimNode =
   ## Evalutuate ``a`` and when it is not an empty node, return return
   ## it. Otherwise evaluate to ``b``. Can be used to chain several
   ## expressions that evaluates to the first expression that is not
@@ -186,11 +186,11 @@ template `or`*(a,b: NimNode): NimNode =
   ##
   ##   let node = mightBeEmpty() or mightAlsoBeEmpty() or fallbackNode
 
-  let arg = a
+  let arg = x
   if arg != nil and arg.kind != nnkEmpty:
     arg
   else:
-    b
+    y
 
 proc add*(father, child: NimNode): NimNode {.magic: "NAdd", discardable,
   noSideEffect, locks: 0.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -177,8 +177,8 @@ proc `[]=`*(n: NimNode, i: BackwardsIndex, child: NimNode) =
   n[n.len - i.int] = child
 
 template `or`*(x, y: NimNode): NimNode =
-  ## Evalutuate ``a`` and when it is not an empty node, return return
-  ## it. Otherwise evaluate to ``b``. Can be used to chain several
+  ## Evalutuate ``x`` and when it is not an empty node, return return
+  ## it. Otherwise evaluate to ``y``. Can be used to chain several
   ## expressions that evaluates to the first expression that is not
   ## empty.
   ##

--- a/tests/macros/tmacro1.nim
+++ b/tests/macros/tmacro1.nim
@@ -79,3 +79,17 @@ static:
   assert fooSym.kind in {nnkOpenSymChoice, nnkClosedSymChoice}
   assert    fooSym.eqIdent("fOO")
   assertNot fooSym.eqIdent("bar")
+
+  var empty: NimNode
+  var myLit = newLit("str")
+
+  assert( (empty or myLit) == myLit )
+
+  empty = newEmptyNode()
+
+  assert( (empty or myLit) == myLit )
+
+  proc bottom(): NimNode =
+    quit("may not be evaluated")
+
+  assert( (myLit or bottom()) == myLit )


### PR DESCRIPTION
I am using this code, and whenever I don't have it I copy past it. So it might be worth to have it in the macros module.

This in an example code piece where I actually use it (it is not constructed to demostrate the or operator and therefore a bit long):

```nim
proc injectTypes(framebuffer, mesh, arg: NimNode): NimNode {.compileTime.} =
  ## Inject types to the ``render .. do: ...`` node.
  arg.expectKind(nnkDo)
  let formalParams = arg[3]
  formalParams.expectKind(nnkFormalParams)

  let vertexTypeExpr = quote do:
    `mesh`.type.VertexType

  let fragmentTypeExpr = quote do:
    `framebuffer`.type.FragmentType

  let resultType = formalParams[0] or fragmentTypeExpr
  var vertexArg, vertexType, envArg, envType: NimNode

  formalParams.matchAst:
  of nnkFormalParams(_,nnkIdentDefs(`vertexArgX`, `envArgX`,nnkEmpty,_)):
    vertexArg = vertexArgX
    vertexType = vertexTypeExpr
    envArg = envArgX
    envType = nnkVarTy.newTree(bindSym"GlEnvironment")
  of nnkFormalParams(_,nnkIdentDefs(`vertexArgX`, `vertexTypeX`, _), nnkIdentDefs(`envArgX`, `envTypeX`,_)):
    vertexArg = vertexArgX
    vertexType = vertexTypeX or vertexTypeExpr
    envArg = envArgX
    envType = envTypeX or nnkVarTy.newTree(bindSym"GlEnvironment")

  let newParams =
    nnkFormalParams.newTree(
      resultType,
      nnkIdentDefs.newTree(
        vertexArg, vertexType, empty
      ),
      nnkIdentDefs.newTree(
        envArg, envType, empty
      )
    )

  result = arg
  result[3] = newParams
```

The general use case of the ``or`` operator is something I got to know from programming emacs lisp. It could also be implemented for the ``option`` type and for the pointer types such as ``ptr`` and ``ref``. 

