### PR TITLE
Add -w flag to Switch compilation to prevent deadlock

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -92,7 +92,7 @@ compiler nintendoSwitchGCC:
     optSize: " -Os -ffast-math ",
     compilerExe: "aarch64-none-elf-gcc",
     cppCompiler: "aarch64-none-elf-g++",
-    compileTmpl: "-MMD -MP -MF $dfile -c $options $include -o $objfile $file",
+    compileTmpl: "-w -MMD -MP -MF $dfile -c $options $include -o $objfile $file",
     buildGui: " -mwindows",
     buildDll: " -shared",
     buildLib: "aarch64-none-elf-gcc-ar rcs $libfile $objfiles",


### PR DESCRIPTION
See https://forum.nim-lang.org/t/4062.

The summary is that there are warnings printed when compiling and that causes a deadlock, likely due to output buffers being filled up. With the `-w` flag, the compiler outputs no warnings and the compilation is allowed to finish.