### PR TITLE
`+=` and `-=` aliases for incl and excl on set[T], minor fix to docs

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -769,7 +769,7 @@ proc incl*[T](x: var set[T], y: T) {.magic: "Incl", noSideEffect.}
   ##  a.incl(3) #=> {2, 3}
 
 template incl*[T](s: var set[T], flags: set[T]) =
-  ## includes the set of flags to the set ``x``.
+  ## includes the set of flags to the set ``s``.
   s = s + flags
 
 proc excl*[T](x: var set[T], y: T) {.magic: "Excl", noSideEffect.}
@@ -781,8 +781,16 @@ proc excl*[T](x: var set[T], y: T) {.magic: "Excl", noSideEffect.}
   ##  b.excl(5)  #=> {2,3,6,12,545}
 
 template excl*[T](s: var set[T], flags: set[T]) =
-  ## excludes the set of flags to ``x``.
+  ## excludes the set of flags to ``s``.
   s = s - flags
+  
+template `+=` *[T](s: var set[T], y: set[T]|T) =
+  ## Alias for ``incl``.
+  s.incl(flags)
+
+template `-=` *[T](s: var set[T], y: set[T]|T) =
+  ## Alias for ``excl``.
+  s.excl(flags)
 
 proc card*[T](x: set[T]): int {.magic: "Card", noSideEffect.}
   ## returns the cardinality of the set ``x``, i.e. the number of elements

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -784,13 +784,13 @@ template excl*[T](s: var set[T], flags: set[T]) =
   ## excludes the set of flags to ``s``.
   s = s - flags
   
-template `+=` *[T](s: var set[T], y: set[T]|T) =
+template `+=` *[T](x: var set[T], y: set[T]|T) =
   ## Alias for ``incl``.
-  s.incl(flags)
+  x.incl(y)
 
-template `-=` *[T](s: var set[T], y: set[T]|T) =
+template `-=` *[T](x: var set[T], y: set[T]|T) =
   ## Alias for ``excl``.
-  s.excl(flags)
+  x.excl(y)
 
 proc card*[T](x: set[T]): int {.magic: "Card", noSideEffect.}
   ## returns the cardinality of the set ``x``, i.e. the number of elements

--- a/tests/sets/tsets.nim
+++ b/tests/sets/tsets.nim
@@ -206,3 +206,13 @@ echo warnUninit in gNotes
 # 7555
 doAssert {-1.int8, -2, -2}.card == 2
 doAssert {1, 2, 2, 3..5, 4..6}.card == 6
+
+block:
+  var
+    a = {0, 1, 2, 3}
+    b = {2, 3, 4, 5}
+  a += b
+  doAssert a == {0, 1, 2, 3, 4, 5}
+  var c = {0, 1}
+  a -= c
+  doAssert a == {2, 3, 4, 5}


### PR DESCRIPTION
Suggesting we add these aliases since we use + and - for unions and differences of sets.