### PR TITLE
Add application/wasm to mimetypes.nim

### DIFF
--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -231,6 +231,7 @@ const mimes* = {
     "xcf": "application/x-xcf",
     "fig": "application/x-xfig",
     "xpi": "application/x-xpinstall",
+    "wasm": "application/wasm",
     "amr": "audio/amr",
     "awb": "audio/amr-wb",
     "amr": "audio/amr",


### PR DESCRIPTION
Suggesting adding wasm | application/wasm as a mimetype to the mimedb.

This comes from emscripten docs - 

```
To serve wasm in the most efficient way over the network, make sure your web server has the proper MIME time for .wasm files, which is application/wasm. That will allow streaming compilation, where the browser can start to compile code as it downloads.
```

http://kripken.github.io/emscripten-site/docs/compiling/WebAssembly.html#web-server-setup

Jester relies on this mimedb and if you try to serve up files with wasm extensions via Jester, it will generate errors in firefox / chrome as well.