### PR TITLE
Remove broken push pragma from jscore

### DIFF
--- a/lib/js/jscore.nim
+++ b/lib/js/jscore.nim
@@ -1,3 +1,12 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2018 Nim contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
 ## This module wraps core JavaScript functions.
 ##
 ## Unless your application has very
@@ -19,49 +28,47 @@ var
   Date* {.importc, nodecl.}: DateLib
   JSON* {.importc, nodecl.}: JsonLib
 
-{.push importcpp.}
-
 # Math library
-proc abs*(m: MathLib, a: SomeNumber): SomeNumber
-proc acos*(m: MathLib, a: SomeNumber): float
-proc acosh*(m: MathLib, a: SomeNumber): float
-proc asin*(m: MathLib, a: SomeNumber): float
-proc asinh*(m: MathLib, a: SomeNumber): float
-proc atan*(m: MathLib, a: SomeNumber): float
-proc atan2*(m: MathLib, a: SomeNumber): float
-proc atanh*(m: MathLib, a: SomeNumber): float
-proc cbrt*(m: MathLib, f: SomeFloat): SomeFloat
-proc ceil*(m: MathLib, f: SomeFloat): SomeFloat
-proc clz32*(m: MathLib, f: SomeInteger): int
-proc cos*(m: MathLib, a: SomeNumber): float
-proc cosh*(m: MathLib, a: SomeNumber): float
-proc exp*(m: MathLib, a: SomeNumber): float
-proc expm1*(m: MathLib, a: SomeNumber): float
-proc floor*(m: MathLib, f: SomeFloat): int
-proc fround*(m: MathLib, f: SomeFloat): float32
-proc hypot*(m: MathLib, args: varargs[distinct SomeNumber]): float
-proc imul*(m: MathLib, a, b: int32): int32
-proc log*(m: MathLib, a: SomeNumber): float
-proc log10*(m: MathLib, a: SomeNumber): float
-proc log1p*(m: MathLib, a: SomeNumber): float
-proc log2*(m: MathLib, a: SomeNumber): float
-proc max*(m: MathLib, a, b: SomeNumber): SomeNumber
-proc min*[T: SomeNumber | JsRoot](m: MathLib, a, b: T): T
-proc pow*(m: MathLib, a, b: distinct SomeNumber): float
-proc random*(m: MathLib): float
-proc round*(m: MathLib, f: SomeFloat): int
-proc sign*(m: MathLib, f: SomeNumber): int
-proc sin*(m: MathLib, a: SomeNumber): float
-proc sinh*(m: MathLib, a: SomeNumber): float
-proc sqrt*(m: MathLib, f: SomeFloat): SomeFloat
-proc tan*(m: MathLib, a: SomeNumber): float
-proc tanh*(m: MathLib, a: SomeNumber): float
-proc trunc*(m: MathLib, f: SomeFloat): int
+proc abs*(m: MathLib, a: SomeNumber): SomeNumber {.importcpp.}
+proc acos*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc acosh*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc asin*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc asinh*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc atan*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc atan2*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc atanh*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc cbrt*(m: MathLib, f: SomeFloat): SomeFloat {.importcpp.}
+proc ceil*(m: MathLib, f: SomeFloat): SomeFloat {.importcpp.}
+proc clz32*(m: MathLib, f: SomeInteger): int {.importcpp.}
+proc cos*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc cosh*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc exp*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc expm1*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc floor*(m: MathLib, f: SomeFloat): int {.importcpp.}
+proc fround*(m: MathLib, f: SomeFloat): float32 {.importcpp.}
+proc hypot*(m: MathLib, args: varargs[distinct SomeNumber]): float {.importcpp.}
+proc imul*(m: MathLib, a, b: int32): int32 {.importcpp.}
+proc log*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc log10*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc log1p*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc log2*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc max*(m: MathLib, a, b: SomeNumber): SomeNumber {.importcpp.}
+proc min*[T: SomeNumber | JsRoot](m: MathLib, a, b: T): T {.importcpp.}
+proc pow*(m: MathLib, a, b: distinct SomeNumber): float {.importcpp.}
+proc random*(m: MathLib): float {.importcpp.}
+proc round*(m: MathLib, f: SomeFloat): int {.importcpp.}
+proc sign*(m: MathLib, f: SomeNumber): int {.importcpp.}
+proc sin*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc sinh*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc sqrt*(m: MathLib, f: SomeFloat): SomeFloat {.importcpp.}
+proc tan*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc tanh*(m: MathLib, a: SomeNumber): float {.importcpp.}
+proc trunc*(m: MathLib, f: SomeFloat): int {.importcpp.}
 
 # Date library
-proc now*(d: DateLib): int
-proc UTC*(d: DateLib): int
-proc parse*(d: DateLib, s: cstring): int
+proc now*(d: DateLib): int {.importcpp.}
+proc UTC*(d: DateLib): int {.importcpp.}
+proc parse*(d: DateLib, s: cstring): int {.importcpp.}
 
 proc newDate*(): DateTime {.
   importcpp: "new Date()".}
@@ -73,19 +80,17 @@ proc newDate*(year, month, day, hours, minutes,
              seconds, milliseconds: int): DateTime {.
   importcpp: "new Date(#,#,#,#,#,#,#)".}
 
-proc getDay*(d: DateTime): int
-proc getFullYear*(d: DateTime): int
-proc getHours*(d: DateTime): int
-proc getMilliseconds*(d: DateTime): int
-proc getMinutes*(d: DateTime): int
-proc getMonth*(d: DateTime): int
-proc getSeconds*(d: DateTime): int
-proc getYear*(d: DateTime): int
-proc getTime*(d: DateTime): int
-proc toString*(d: DateTime): cstring
+proc getDay*(d: DateTime): int {.importcpp.}
+proc getFullYear*(d: DateTime): int {.importcpp.}
+proc getHours*(d: DateTime): int {.importcpp.}
+proc getMilliseconds*(d: DateTime): int {.importcpp.}
+proc getMinutes*(d: DateTime): int {.importcpp.}
+proc getMonth*(d: DateTime): int {.importcpp.}
+proc getSeconds*(d: DateTime): int {.importcpp.}
+proc getYear*(d: DateTime): int {.importcpp.}
+proc getTime*(d: DateTime): int {.importcpp.}
+proc toString*(d: DateTime): cstring {.importcpp.}
 
 #JSON library
-proc stringify*(l: JsonLib, s: JsRoot): cstring
-proc parse*(l: JsonLib, s: cstring): JsRoot
-
-{.pop.}
+proc stringify*(l: JsonLib, s: JsRoot): cstring {.importcpp.}
+proc parse*(l: JsonLib, s: cstring): JsRoot {.importcpp.}


### PR DESCRIPTION
The `push` pragma caused issues because apparently it overrides existing `importcpp` pragmas, which meant that none of the `newDate` overloads could be used.