### PR TITLE
simpler fix for #8323 : avoid polluting git satus after `nim doc foo`

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -608,16 +608,18 @@ proc myProcess(context: PPassContext, n: PNode): PNode =
   rod.storeNode(c.graph, c.module, result)
 
 proc testExamples(c: PContext) =
+  let outputDir = c.config.getNimcacheDir / "runnableExamples"
+  createDir(outputDir)
   let inp = toFullPath(c.config, c.module.info)
-  let outp = inp.changeFileExt"" & "_examples.nim"
+  let outp = outputDir / extractFilename(inp.changeFileExt"" & "_examples.nim")
   let nimcache = outp.changeFileExt"" & "_nimcache"
-  renderModule(c.runnableExamples, inp, outp)
+  renderModule(c.runnableExamples, inp, outp, conf = c.config)
   let backend = if isDefined(c.config, "js"): "js"
                 elif isDefined(c.config, "cpp"): "cpp"
                 elif isDefined(c.config, "objc"): "objc"
                 else: "c"
   if os.execShellCmd(os.getAppFilename() & " " & backend & " --nimcache:" & nimcache & " -r " & outp) != 0:
-    quit "[Examples] failed"
+    quit "[Examples] failed: see " & outp
   else:
     removeFile(outp)
     removeFile(outp.changeFileExt(ExeExt))


### PR DESCRIPTION
* simpler fix for #8323 : avoid polluting git satus after `nim doc foo`
(after feedback from https://github.com/nim-lang/Nim/pull/8392)
foo_nimcache,foo_examples.nim, foo_examples will be generated under nimcache/runnableExamples/
* fixes bug: was missing conf in renderModule(c.runnableExamples, inp, outp, conf = c.config)

