### PR TITLE
fix #8419 fix #8420 ; workaround #6071 workaround nim-lang/website#98

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -517,12 +517,11 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind) =
       path = path[cwd.len+1 .. ^1].replace('\\', '/')
     let gitUrl = getConfigVar(d.conf, "git.url")
     if gitUrl.len > 0:
-      var commit = getConfigVar(d.conf, "git.commit")
-      if commit.len == 0: commit = "master"
+      let commit = getConfigVar(d.conf, "git.commit", "master")
+      let develBranch = getConfigVar(d.conf, "git.devel", "devel")
       dispA(d.conf, seeSrcRope, "$1", "", [ropeFormatNamedVars(d.conf, docItemSeeSrc,
-          ["path", "line", "url", "commit"], [rope path,
-          rope($n.info.line), rope gitUrl,
-          rope commit])])
+          ["path", "line", "url", "commit", "devel"], [rope path,
+          rope($n.info.line), rope gitUrl, rope commit, rope develBranch])])
 
   add(d.section[k], ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.item"),
     ["name", "header", "desc", "itemID", "header_plain", "itemSym",

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -406,8 +406,8 @@ proc mainCommandArg*(conf: ConfigRef): string =
 proc existsConfigVar*(conf: ConfigRef; key: string): bool =
   result = hasKey(conf.configVars, key)
 
-proc getConfigVar*(conf: ConfigRef; key: string): string =
-  result = conf.configVars.getOrDefault key
+proc getConfigVar*(conf: ConfigRef; key: string, default = ""): string =
+  result = conf.configVars.getOrDefault(key, default)
 
 proc setConfigVar*(conf: ConfigRef; key, val: string) =
   conf.configVars[key] = val

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -55,6 +55,8 @@ doc.item.toc = """
 # HTML rendered for doc.item's seeSrc variable. Note that this will render to
 # the empty string if you don't pass anything through --docSeeSrcURL. Available
 # substitutaion variables here are:
+# * $commit: branch/commit to use in source link.
+# * $devel: branch to use in edit link.
 # * $path: relative path to the file being processed.
 # * $line: line of the item in the original source file.
 # * $url: whatever you did pass through the --docSeeSrcUrl switch (which also
@@ -62,7 +64,7 @@ doc.item.toc = """
 doc.item.seesrc = """&nbsp;&nbsp;<a
 href="${url}/tree/${commit}/${path}#L${line}"
 class="link-seesrc" target="_blank">Source</a>
-<a href="${url}/edit/devel/${path}#L${line}" class="link-seesrc" target="_blank" >Edit</a>
+<a href="${url}/edit/${devel}/${path}#L${line}" class="link-seesrc" target="_blank" >Edit</a>
 """
 
 doc.toc = """

--- a/koch.nim
+++ b/koch.nim
@@ -50,6 +50,7 @@ Boot options:
 
 Commands for core developers:
   web [options]            generates the website and the full documentation
+                           (see `nimweb.nim` for cmd line options)
   website [options]        generates only the website
   csource -d:release       builds the C sources for installation
   pdf                      builds the PDF documentation


### PR DESCRIPTION
/cc @Varriount  

* fix #8419
* fix #8420
* workaround #6071
* workaround https://github.com/nim-lang/website/issues/98
* Abroken: fixes fact that locally built website points to broken urls
* new nim doc flag: `--git.devel` to override hardcoded `devel` in config/nimdoc.cfg ; useful for git repos in which the development branch is not devel (it usually is `master`, not `devel`)
* some minor code cleanups

eg usage:
```
./koch web --output:/tmp/d20
open /tmp/d20/index.html # see website and docs, with non-broken links

./koch web --output:/tmp/d20 --git.commit:devel
# also shows correct source links (pertain to branch devel instead of stable on website)

./koch web --output:/tmp/d20 --git.commit:myfeaturebranch --git.url:https://github.com/timotheecour/Nim
# source/edit links use provided base url, so we can see docs for un-merged PR, or un-pushed or old commit 

#NOTE: can use --git.commit:`git rev-parse --abbrev-ref HEAD` to get current branch

./koch web --output:/tmp/d20 --onlyDocs  --git.commit:devel
open /tmp/d20/docs/ospaths.html # see docs for ospaths.html (avoids building rest)
```

* Abroken: this PR takes care of making the local links works by setting `docHTMLOutput` to $output / "docs" when user provides `--output`
(before that PR, locally generated docs leads to broken links when starting from web/upload, eg: file:///Users/timothee/git_clone/nim/Nim/web/upload/documentation.html has href to nonexisting file:///Users/timothee/git_clone/nim/Nim/web/upload/docs/lib.html)

## for future PR:
- [ ] new nim doc flag: --git.commit_current to pass in `git rev-parse --abbrev-ref HEAD` as value for git.commit which is a good default when developping: we want to see docs for branch we're currently on
- [ ] remove references to `docSeeSrcUrl` in docs (instead, reference git.commit, git.devel, git.url)
