### PR TITLE
Fix alloc type signature

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1772,7 +1772,7 @@ when not defined(nimscript):
       ## containing zero, so it is somewhat safer than ``alloc``.
       ## The allocated memory belongs to its allocating thread!
       ## Use `allocShared0` to allocate from a shared heap.
-    proc create*(T: typedesc, size = 1.Positive): ptr UncheckedArray[T] {.inline, benign.} =
+    proc create*(T: typedesc, size: Positive): ptr UncheckedArray[T] {.inline, benign.} =
       ## allocates a new memory block with at least ``T.sizeof * size``
       ## bytes. The block has to be freed with ``resize(block, 0)`` or
       ## ``dealloc(block)``. The block is initialized with all bytes

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1749,14 +1749,22 @@ when not defined(nimscript):
       ## from it before writing to it is undefined behaviour!
       ## The allocated memory belongs to its allocating thread!
       ## Use `allocShared` to allocate from a shared heap.
-    proc createU*(T: typedesc, size = 1.Positive): ptr T {.inline, benign.} =
+    proc createU*(T: typedesc, size: Positive): ptr UncheckedArray[T] {.inline, benign.} =
       ## allocates a new memory block with at least ``T.sizeof * size``
       ## bytes. The block has to be freed with ``resize(block, 0)`` or
       ## ``dealloc(block)``. The block is not initialized, so reading
       ## from it before writing to it is undefined behaviour!
       ## The allocated memory belongs to its allocating thread!
       ## Use `createSharedU` to allocate from a shared heap.
-      cast[ptr T](alloc(T.sizeof * size))
+      cast[ptr UncheckedArray[T]](alloc(T.sizeof * size))
+    proc createU*(T: typedesc): ptr T {.inline, benign.} =
+      ## allocates a new memory block with at least ``T.sizeof``
+      ## bytes. The block has to be freed with ``resize(block, 0)`` or
+      ## ``dealloc(block)``. The block is not initialized, so reading
+      ## from it before writing to it is undefined behaviour!
+      ## The allocated memory belongs to its allocating thread!
+      ## Use `createSharedU` to allocate from a shared heap.
+      cast[ptr T](alloc(T.sizeof))
     proc alloc0*(size: Natural): pointer {.noconv, rtl, tags: [], benign.}
       ## allocates a new memory block with at least ``size`` bytes. The
       ## block has to be freed with ``realloc(block, 0)`` or
@@ -1764,14 +1772,22 @@ when not defined(nimscript):
       ## containing zero, so it is somewhat safer than ``alloc``.
       ## The allocated memory belongs to its allocating thread!
       ## Use `allocShared0` to allocate from a shared heap.
-    proc create*(T: typedesc, size = 1.Positive): ptr T {.inline, benign.} =
+    proc create*(T: typedesc, size = 1.Positive): ptr UncheckedArray[T] {.inline, benign.} =
       ## allocates a new memory block with at least ``T.sizeof * size``
       ## bytes. The block has to be freed with ``resize(block, 0)`` or
       ## ``dealloc(block)``. The block is initialized with all bytes
       ## containing zero, so it is somewhat safer than ``createU``.
       ## The allocated memory belongs to its allocating thread!
       ## Use `createShared` to allocate from a shared heap.
-      cast[ptr T](alloc0(sizeof(T) * size))
+      cast[ptr UncheckedArray[T]](alloc0(sizeof(T) * size))
+    proc create*(T: typedesc): ptr T {.inline, benign.} =
+      ## allocates a new memory block with at least ``T.sizeof * size``
+      ## bytes. The block has to be freed with ``resize(block, 0)`` or
+      ## ``dealloc(block)``. The block is initialized with all bytes
+      ## containing zero, so it is somewhat safer than ``createU``.
+      ## The allocated memory belongs to its allocating thread!
+      ## Use `createShared` to allocate from a shared heap.
+      cast[ptr T](alloc0(sizeof(T)))
     proc realloc*(p: pointer, newSize: Natural): pointer {.noconv, rtl, tags: [],
                                                            benign.}
       ## grows or shrinks a given memory block. If p is **nil** then a new
@@ -1781,7 +1797,10 @@ when not defined(nimscript):
       ## be freed with ``dealloc``.
       ## The allocated memory belongs to its allocating thread!
       ## Use `reallocShared` to reallocate from a shared heap.
-    proc resize*[T](p: ptr T, newSize: Natural): ptr T {.inline, benign.} =
+    proc resize*[T](p: ptr T, newSize: Natural): ptr T {.inline, benign, deprecated.} =
+      ## **Deprecated since version 0.18.1**; Use ``resize`` on ``ptr UncheckedArray[T]`` instead.
+      cast[ptr T](realloc(p, T.sizeof * newSize))
+    proc resize*[T](p: ptr UncheckedArray[T], newSize: Natural): ptr UncheckedArray[T] {.inline, benign.} =
       ## grows or shrinks a given memory block. If p is **nil** then a new
       ## memory block is returned. In either way the block has at least
       ## ``T.sizeof * newSize`` bytes. If ``newSize == 0`` and p is not
@@ -1789,43 +1808,56 @@ when not defined(nimscript):
       ## has to be freed with ``free``. The allocated memory belongs to
       ## its allocating thread!
       ## Use `resizeShared` to reallocate from a shared heap.
-      cast[ptr T](realloc(p, T.sizeof * newSize))
+      cast[ptr UncheckedArray[T]](realloc(p, T.sizeof * newSize))
     proc dealloc*(p: pointer) {.noconv, rtl, tags: [], benign.}
       ## frees the memory allocated with ``alloc``, ``alloc0`` or
       ## ``realloc``. This procedure is dangerous! If one forgets to
       ## free the memory a leak occurs; if one tries to access freed
-      ## memory (or just freeing it twice!) a core dump may happen
+      ## memory (or just freeing it twice!) a segmentation fault may happen
       ## or other memory may be corrupted.
       ## The freed memory must belong to its allocating thread!
       ## Use `deallocShared` to deallocate from a shared heap.
-
     proc allocShared*(size: Natural): pointer {.noconv, rtl, benign.}
       ## allocates a new memory block on the shared heap with at
       ## least ``size`` bytes. The block has to be freed with
       ## ``reallocShared(block, 0)`` or ``deallocShared(block)``. The block
       ## is not initialized, so reading from it before writing to it is
       ## undefined behaviour!
-    proc createSharedU*(T: typedesc, size = 1.Positive): ptr T {.inline,
+    proc createSharedU*(T: typedesc): ptr T {.inline, benign.} =
+      ## allocates a new memory block on the shared heap with at
+      ## least ``T.sizeof`` bytes. The block has to be freed with
+      ## ``resizeShared(block, 0)`` or ``freeShared(block)``. The block
+      ## is not initialized, so reading from it before writing to it is
+      ## undefined behaviour!
+      cast[ptr T](allocShared(T.sizeof))
+    proc createSharedU*(T: typedesc, size: Positive): ptr UncheckedArray[T] {.inline,
                                                                  benign.} =
       ## allocates a new memory block on the shared heap with at
       ## least ``T.sizeof * size`` bytes. The block has to be freed with
       ## ``resizeShared(block, 0)`` or ``freeShared(block)``. The block
       ## is not initialized, so reading from it before writing to it is
       ## undefined behaviour!
-      cast[ptr T](allocShared(T.sizeof * size))
+      cast[ptr UncheckedArray[T]](allocShared(T.sizeof * size))
     proc allocShared0*(size: Natural): pointer {.noconv, rtl, benign.}
       ## allocates a new memory block on the shared heap with at
       ## least ``size`` bytes. The block has to be freed with
       ## ``reallocShared(block, 0)`` or ``deallocShared(block)``.
       ## The block is initialized with all bytes
       ## containing zero, so it is somewhat safer than ``allocShared``.
-    proc createShared*(T: typedesc, size = 1.Positive): ptr T {.inline.} =
+    proc createShared*(T: typedesc): ptr T {.inline.} =
+      ## allocates a new memory block on the shared heap with at
+      ## least ``T.sizeof`` bytes. The block has to be freed with
+      ## ``resizeShared(block, 0)`` or ``freeShared(block)``.
+      ## The block is initialized with all bytes
+      ## containing zero, so it is somewhat safer than ``createSharedU``.
+      cast[ptr T](allocShared0(T.sizeof))
+    proc createShared*(T: typedesc, size: Positive): ptr UncheckedArray[T] {.inline.} =
       ## allocates a new memory block on the shared heap with at
       ## least ``T.sizeof * size`` bytes. The block has to be freed with
       ## ``resizeShared(block, 0)`` or ``freeShared(block)``.
       ## The block is initialized with all bytes
       ## containing zero, so it is somewhat safer than ``createSharedU``.
-      cast[ptr T](allocShared0(T.sizeof * size))
+      cast[ptr UncheckedArray[T]](allocShared0(T.sizeof * size))
     proc reallocShared*(p: pointer, newSize: Natural): pointer {.noconv, rtl,
                                                                  benign.}
       ## grows or shrinks a given memory block on the heap. If p is **nil**
@@ -1833,24 +1865,31 @@ when not defined(nimscript):
       ## least ``newSize`` bytes. If ``newSize == 0`` and p is not **nil**
       ## ``reallocShared`` calls ``deallocShared(p)``. In other cases the
       ## block has to be freed with ``deallocShared``.
-    proc resizeShared*[T](p: ptr T, newSize: Natural): ptr T {.inline.} =
+    proc resizeShared*[T](p: ptr T, newSize: Natural): ptr T {.inline, deprecated.} =
       ## grows or shrinks a given memory block on the heap. If p is **nil**
       ## then a new memory block is returned. In either way the block has at
       ## least ``T.sizeof * newSize`` bytes. If ``newSize == 0`` and p is
       ## not **nil** ``resizeShared`` calls ``freeShared(p)``. In other
       ## cases the block has to be freed with ``freeShared``.
       cast[ptr T](reallocShared(p, T.sizeof * newSize))
+    proc resizeShared*[T](p: ptr UncheckedArray[T], newSize: Natural): ptr UncheckedArray[T] {.inline.} =
+      ## grows or shrinks a given memory block on the heap. If p is **nil**
+      ## then a new memory block is returned. In either way the block has at
+      ## least ``T.sizeof * newSize`` bytes. If ``newSize == 0`` and p is
+      ## not **nil** ``resizeShared`` calls ``freeShared(p)``. In other
+      ## cases the block has to be freed with ``freeShared``.
+      cast[ptr UncheckedArray[T]](reallocShared(p, T.sizeof * newSize))
     proc deallocShared*(p: pointer) {.noconv, rtl, benign.}
       ## frees the memory allocated with ``allocShared``, ``allocShared0`` or
       ## ``reallocShared``. This procedure is dangerous! If one forgets to
       ## free the memory a leak occurs; if one tries to access freed
-      ## memory (or just freeing it twice!) a core dump may happen
+      ## memory (or just freeing it twice!) a segmentation fault may happen
       ## or other memory may be corrupted.
     proc freeShared*[T](p: ptr T) {.inline, benign.} =
       ## frees the memory allocated with ``createShared``, ``createSharedU`` or
       ## ``resizeShared``. This procedure is dangerous! If one forgets to
       ## free the memory a leak occurs; if one tries to access freed
-      ## memory (or just freeing it twice!) a core dump may happen
+      ## memory (or just freeing it twice!) a segmentation fault may happen
       ## or other memory may be corrupted.
       deallocShared(p)
 

--- a/tests/system/talloc.nim
+++ b/tests/system/talloc.nim
@@ -6,11 +6,11 @@ x = cast[ptr int](x.realloc(2))
 assert x != nil
 x.dealloc()
 
-x = createU(int, 3)
+x = cast[ptr int](createU(int, 3))
 assert x != nil
 x.dealloc()
 
-x = create(int, 4)
+x = cast[ptr int](create(int, 4))
 assert cast[ptr array[4, int]](x)[0] == 0
 assert cast[ptr array[4, int]](x)[1] == 0
 assert cast[ptr array[4, int]](x)[2] == 0
@@ -24,11 +24,11 @@ x = cast[ptr int](allocShared(100))
 assert x != nil
 deallocShared(x)
 
-x = createSharedU(int, 3)
+x = cast[ptr int](createSharedU(int, 3))
 assert x != nil
 x.deallocShared()
 
-x = createShared(int, 3)
+x = cast[ptr int](createShared(int, 3))
 assert x != nil
 assert cast[ptr array[3, int]](x)[0] == 0
 assert cast[ptr array[3, int]](x)[1] == 0
@@ -39,13 +39,13 @@ x = cast[ptr int](x.resizeShared(2))
 assert x != nil
 x.deallocShared()
 
-x = create(int, 10)
+x = cast[ptr int](create(int, 10))
 assert x != nil
 x = x.resize(12)
 assert x != nil
 x.dealloc()
 
-x = createShared(int, 1)
+x = cast[ptr int](createShared(int, 1))
 assert x != nil
 x = x.resizeShared(1)
 assert x != nil

--- a/tests/system/talloc.nim
+++ b/tests/system/talloc.nim
@@ -1,57 +1,66 @@
-var x: ptr int
 
-x = cast[ptr int](alloc(7))
-assert x != nil
-x = cast[ptr int](x.realloc(2))
-assert x != nil
-x.dealloc()
+block:
+  var x = alloc(7)
+  assert x != nil
+  x = x.realloc(2)
+  assert x != nil
+  x.dealloc()
 
-x = cast[ptr int](createU(int, 3))
-assert x != nil
-x.dealloc()
+block:
+  let x = createU(int, 3)
+  assert x != nil
+  x.dealloc()
 
-x = cast[ptr int](create(int, 4))
-assert cast[ptr array[4, int]](x)[0] == 0
-assert cast[ptr array[4, int]](x)[1] == 0
-assert cast[ptr array[4, int]](x)[2] == 0
-assert cast[ptr array[4, int]](x)[3] == 0
+block:
+  var x = create(int, 4)
+  assert x[0] == 0
+  assert x[1] == 0
+  assert x[2] == 0
+  assert x[3] == 0
 
-x = x.resize(4)
-assert x != nil
-x.dealloc()
+  x = x.resize(4)
+  assert x != nil
+  x.dealloc()
 
-x = cast[ptr int](allocShared(100))
-assert x != nil
-deallocShared(x)
+block:
+  let x = allocShared(100)
+  assert x != nil
+  deallocShared(x)
 
-x = cast[ptr int](createSharedU(int, 3))
-assert x != nil
-x.deallocShared()
+block:
+  let x = createSharedU(int, 3)
+  assert x != nil
+  x.deallocShared()
 
-x = cast[ptr int](createShared(int, 3))
-assert x != nil
-assert cast[ptr array[3, int]](x)[0] == 0
-assert cast[ptr array[3, int]](x)[1] == 0
-assert cast[ptr array[3, int]](x)[2] == 0
+block:
+  var x = createShared(int, 3)
+  assert x != nil
+  assert x[0] == 0
+  assert x[1] == 0
+  assert x[2] == 0
 
-assert x != nil
-x = cast[ptr int](x.resizeShared(2))
-assert x != nil
-x.deallocShared()
+  x = x.resizeShared(2)
+  assert x != nil
+  x.deallocShared()
 
-x = cast[ptr int](create(int, 10))
-assert x != nil
-x = x.resize(12)
-assert x != nil
-x.dealloc()
+block:
+  var x = create(int, 10)
+  assert x != nil
+  x = x.resize(12)
+  assert x != nil
+  x.dealloc()
 
-x = cast[ptr int](createShared(int, 1))
-assert x != nil
-x = x.resizeShared(1)
-assert x != nil
-x.deallocShared()
+block:
+  var x = createShared(int, 1)
+  assert x != nil
+  x = x.resizeShared(1)
+  assert x != nil
+  x.deallocShared()
 
-x = cast[ptr int](alloc0(125 shl 23))
-dealloc(x)
-x = cast[ptr int](alloc0(126 shl 23))
-dealloc(x)
+block:
+  let x = alloc0(125 shl 23)
+  dealloc(x)
+
+block:
+  let x = alloc0(126 shl 23)
+  dealloc(x)


### PR DESCRIPTION
last time the exact same PR was closed because the test had too many cast operations. I now could get rid of all of them. I hope this time the value of the PR can be seem better.