### PR TITLE
Fix path resolution of submodules in the std namespace

### DIFF
--- a/compiler/modulepaths.nim
+++ b/compiler/modulepaths.nim
@@ -45,13 +45,6 @@ when false:
     if best.len > 0 and fileExists(res):
       result = res
 
-const stdlibDirs = [
-  "pure", "core", "arch",
-  "pure/collections",
-  "pure/concurrency", "impure",
-  "wrappers", "wrappers/linenoise",
-  "windows", "posix", "js"]
-
 when false:
   proc resolveDollar(project, source, pkg, subdir: string; info: TLineInfo): string =
     template attempt(a) =
@@ -120,7 +113,9 @@ proc getModuleName*(conf: ConfigRef; n: PNode): string =
   case n.kind
   of nkStrLit, nkRStrLit, nkTripleStrLit:
     try:
-      result = pathSubs(conf, n.strVal, toFullPath(conf, n.info).splitFile().dir)
+      result =
+        pathSubs(conf, n.strVal, toFullPath(conf, n.info).splitFile().dir)
+          .replace(" ")
     except ValueError:
       localError(conf, n.info, "invalid path: " & n.strVal)
       result = n.strVal
@@ -147,16 +142,9 @@ proc getModuleName*(conf: ConfigRef; n: PNode): string =
           result = ""
     else:
       let modname = getModuleName(conf, n[2])
-      if $n1 == "std":
-        template attempt(a) =
-          let x = addFileExt(a, "nim")
-          if fileExists(x): return x
-        for candidate in stdlibDirs:
-          attempt(conf.libpath / candidate / modname)
-
       # hacky way to implement 'x / y /../ z':
       result = getModuleName(conf, n1)
-      result.add renderTree(n0, {renderNoComments})
+      result.add renderTree(n0, {renderNoComments}).replace(" ")
       result.add modname
   of nkPrefix:
     when false:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -556,13 +556,28 @@ proc findFile*(conf: ConfigRef; f: string; suppressStdlib = false): string {.pro
           result = rawFindFile2(conf, f.toLowerAscii)
   patchModule(conf)
 
+const stdlibDirs = [
+  "pure", "core", "arch",
+  "pure/collections",
+  "pure/concurrency", "impure",
+  "wrappers", "wrappers/linenoise",
+  "windows", "posix", "js"]
+
 proc findModule*(conf: ConfigRef; modulename, currentModule: string): string =
   # returns path to module
   const pkgPrefix = "pkg/"
-  let m = addFileExt(modulename, NimExt)
+  const stdPrefix = "std/"
+  var m = addFileExt(modulename, NimExt)
   if m.startsWith(pkgPrefix):
     result = findFile(conf, m.substr(pkgPrefix.len), suppressStdlib = true)
   else:
+    if m.startsWith(stdPrefix):
+      let stripped = m.substr(stdPrefix.len)
+      for candidate in stdlibDirs:
+        let path = (conf.libpath / candidate / stripped)
+        if fileExists(path):
+          m = path
+          break
     let currentPath = currentModule.splitFile.dir
     result = currentPath / m
     if not existsFile(result):


### PR DESCRIPTION
Probably not the cleanest fix. The issue was that module paths are resolved recursively, and the `std` logic is applied in the last iteration. So for `std / times / datetime` the special handling of `std` was applied to `std / times`.

I noticed that the dot style for imports (e.g `import path.to.module`) doesn't support the std namespace. Is that intentional?

Refs https://github.com/nim-lang/Nim/issues/8382#issuecomment-406783739