### PR TITLE
remove redundant test for nil before `add`

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -525,8 +525,6 @@ proc checkpoint*(msg: string) =
   ##  checkpoint("Checkpoint B")
   ##
   ## outputs "Checkpoint A" once it fails.
-  if checkpoints == nil:
-    checkpoints = @[]
   checkpoints.add(msg)
   # TODO: add support for something like SCOPED_TRACE from Google Test
 


### PR DESCRIPTION
this works without checking for nil:
```
  var checkpoints {.threadvar.}: seq[string]
  proc test()=
    echo checkpoints
    echo checkpoints == nil
    # if checkpoints == nil:
    #   checkpoints = @[]
    checkpoints.add("hi")
    echo checkpoints
```