### PR TITLE
`lineInfoObj` (and `check`, `expect`) now return absolute paths

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,6 @@
 - The ``'c`` and ``'C'`` prefix for octal literals is now deprecated to
   bring the language in line with the standard library (e.g. ``parseOct``).
 
-
 #### Breaking changes in the standard library
 
 - ``re.split`` for empty regular expressions now yields every character in
@@ -59,6 +58,8 @@
   1-based coordinates on POSIX for correct behaviour; the Windows behaviour
   was always correct).
 
+- ``lineInfoObj`` now returns absolute path instead of project path.
+  It's used by ``lineInfo``, ``check``, ``expect``, ``require``, etc.
 
 #### Breaking changes in the compiler
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1416,7 +1416,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNGetFile:
       decodeB(rkNode)
       let n = regs[rb].node
-      regs[ra].node = newStrNode(nkStrLit, toMsgFilename(c.config, n.info))
+      regs[ra].node = newStrNode(nkStrLit, toFullPath(c.config, n.info))
       regs[ra].node.info = n.info
       regs[ra].node.typ = n.typ
     of opcNGetLine:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1416,7 +1416,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNGetFile:
       decodeB(rkNode)
       let n = regs[rb].node
-      regs[ra].node = newStrNode(nkStrLit, toFilename(c.config, n.info))
+      regs[ra].node = newStrNode(nkStrLit, toMsgFilename(c.config, n.info))
       regs[ra].node.info = n.info
       regs[ra].node.typ = n.typ
     of opcNGetLine:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -425,6 +425,7 @@ proc getColumn(arg: NimNode): int {.magic: "NLineInfo", noSideEffect.}
 proc getFile(arg: NimNode): string {.magic: "NLineInfo", noSideEffect.}
 
 proc lineInfoObj*(n: NimNode): LineInfo {.compileTime.} =
+  ## returns ``LineInfo`` of ``n``, using absolute path for ``filename``
   result.filename = n.getFile
   result.line = n.getLine
   result.column = n.getColumn


### PR DESCRIPTION
/cc @Varriount 

before PR:
check 1==2 would return project path regardless of --listFullPaths
(inconsistent with other logging)

after PR:
check 1==2 would return absolute path when --listFullPaths is provided
(consistent with other logging)

likewise with require.

Note: this fixes https://github.com/nim-lang/Nim/issues/7429 (item A_lineInfoObj)

**EDIT**
/cc @Araq 
new behavior after feedback from @araq is to always return absolute path instead of previous behavior which was to always return project path. New behavior is better because project path can be ambiguous for users when printed out as it depends on cmd line args (it found the first path, via `-p` cmd line, where file is found and prints the path relative to that)

- [ ] future PR could be to allow customizing what's returned by `lineInfoObj`, but that's controversial and left out of this PR