### PR TITLE
fix #7492 excessiveStackTrace:on shows non-absolute file in stacktrace

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3771,7 +3771,9 @@ template doAssert*(cond: bool, msg = "") =
   ## same as `assert` but is always turned on and not affected by the
   ## ``--assertions`` command line switch.
   bind instantiationInfo
-  {.line: instantiationInfo().}:
+  # NOTE: `true` is correct here; --excessiveStackTrace:on will control whether
+  # or not to output full paths.
+  {.line: instantiationInfo(-1, true).}:
     if not cond:
       raiseAssert(astToStr(cond) & ' ' &
                   instantiationInfo(-1, false).fileName & '(' &


### PR DESCRIPTION
/cc @Yardanico 

before this PR, ` {.line: instantiationInfo().}` was wrong, it actually created a new file instead of recognizing an existing file in
```
proc pragmaLine(c: PContext, n: PNode) =
=>
n.info.fileIndex = msgs.fileInfoIdx(c.config, x.strVal)
 ```
and after that, the stacktrace would show weirdly for this entry as shown in #7492

After PR, these problems go away, and stack traces show up correctly
(full or not full depending on`--excessiveStackTrace` )

/cc @Araq you wrote this comment:
`# XXX this produces weird paths which are not properly resolved:`
I wonder whether that comment was due to that bug being fixed here


