### PR TITLE
fixes #8468, stdlib.encodings.convert not crash anymore on windows

### DIFF
--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -333,6 +333,8 @@ when defined(windows):
     # educated guess of capacity:
     var cap = s.len + s.len shr 2
     result = newStringOfCap(cap*2)
+    # bug #8468, the result.len must not zero
+    setLen(result, cap)
     # convert to utf-16 LE
     var m = multiByteToWideChar(codePage = c.src, dwFlags = 0'i32,
                                 lpMultiByteStr = cstring(s),
@@ -348,6 +350,8 @@ when defined(windows):
                                 cchWideChar = cint(0))
       # and do the conversion properly:
       result = newStringOfCap(cap*2)
+      # bug #8468, the result.len must not zero
+      setLen(result, cap)
       m = multiByteToWideChar(codePage = c.src, dwFlags = 0'i32,
                               lpMultiByteStr = cstring(s),
                               cbMultiByte = cint(s.len),
@@ -365,6 +369,8 @@ when defined(windows):
     # otherwise the fun starts again:
     cap = s.len + s.len shr 2
     var res = newStringOfCap(cap)
+    # bug #8468, the res.len must not zero
+    setLen(res, cap)
     m = wideCharToMultiByte(
       codePage = c.dest,
       dwFlags = 0'i32,
@@ -383,6 +389,8 @@ when defined(windows):
         cbMultiByte = cint(0))
       # and do the conversion properly:
       res = newStringOfCap(cap)
+      # bug #8468, the res.len must not zero
+      setLen(res, cap)
       m = wideCharToMultiByte(
         codePage = c.dest,
         dwFlags = 0'i32,

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -332,9 +332,7 @@ when defined(windows):
     if s.len == 0: return ""
     # educated guess of capacity:
     var cap = s.len + s.len shr 2
-    result = newStringOfCap(cap*2)
-    # bug #8468, the result.len must not zero
-    setLen(result, cap)
+    result = newString(cap*2)
     # convert to utf-16 LE
     var m = multiByteToWideChar(codePage = c.src, dwFlags = 0'i32,
                                 lpMultiByteStr = cstring(s),
@@ -349,9 +347,7 @@ when defined(windows):
                                 lpWideCharStr = nil,
                                 cchWideChar = cint(0))
       # and do the conversion properly:
-      result = newStringOfCap(cap*2)
-      # bug #8468, the result.len must not zero
-      setLen(result, cap)
+      result = newString(cap*2)
       m = multiByteToWideChar(codePage = c.src, dwFlags = 0'i32,
                               lpMultiByteStr = cstring(s),
                               cbMultiByte = cint(s.len),
@@ -368,9 +364,7 @@ when defined(windows):
     if int(c.dest) == 1200: return
     # otherwise the fun starts again:
     cap = s.len + s.len shr 2
-    var res = newStringOfCap(cap)
-    # bug #8468, the res.len must not zero
-    setLen(res, cap)
+    var res = newString(cap)
     m = wideCharToMultiByte(
       codePage = c.dest,
       dwFlags = 0'i32,
@@ -388,9 +382,7 @@ when defined(windows):
         lpMultiByteStr = nil,
         cbMultiByte = cint(0))
       # and do the conversion properly:
-      res = newStringOfCap(cap)
-      # bug #8468, the res.len must not zero
-      setLen(res, cap)
+      res = newString(cap)
       m = wideCharToMultiByte(
         codePage = c.dest,
         dwFlags = 0'i32,

--- a/tests/stdlib/tencoding.nim
+++ b/tests/stdlib/tencoding.nim
@@ -1,0 +1,19 @@
+discard """
+  output: '''OK'''
+"""
+
+#bug #8468
+
+import encodings, strutils
+
+var utf16LEConverter = open(destEncoding = "utf-16", srcEncoding = "utf-8")
+var s = "some string"
+var c = utf16LEConverter.convert(s)
+
+var z = newStringOfCap(s.len * 2)
+for x in s:
+  z.add x
+  z.add chr(0)
+
+doAssert z == c
+echo "OK"

--- a/tests/stdlib/tencoding.nim
+++ b/tests/stdlib/tencoding.nim
@@ -6,14 +6,16 @@ discard """
 
 import encodings, strutils
 
-var utf16LEConverter = open(destEncoding = "utf-16", srcEncoding = "utf-8")
-var s = "some string"
-var c = utf16LEConverter.convert(s)
+when defined(windows):
+  var utf16to8 = open(destEncoding = "utf-16", srcEncoding = "utf-8")
+  var s = "some string"
+  var c = utf16to8.convert(s)
 
-var z = newStringOfCap(s.len * 2)
-for x in s:
-  z.add x
-  z.add chr(0)
+  var z = newStringOfCap(s.len * 2)
+  for x in s:
+    z.add x
+    z.add chr(0)
 
-doAssert z == c
+  doAssert z == c
+
 echo "OK"


### PR DESCRIPTION
I'm not using `newString` but `newStringOfCap + setLen`.
This is done intentionally to anticipate future v2 string,
v2 newString use alloc0 while newStringOfCap use alloc, so it is probably faster.