### PR TITLE
Genode fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,6 +55,7 @@ build_script:
   - nimble install jester@#head -y
   - nimble install niminst
   - nim c --taintMode:on -d:nimCoroutines tests/testament/tester
+  - nim c --taintMode:on -d:nimCoroutines --os:genode -d:posix --compileOnly tests/testament/tester
 
 test_script:
   - tests\testament\tester --pedantic all -d:nimCoroutines

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -981,7 +981,7 @@ proc genEcho(p: BProc, n: PNode) =
   # is threadsafe.
   internalAssert p.config, n.kind == nkBracket
   if p.config.target.targetOS == osGenode:
-    # bypass libc and print directly to the Genode LOG session
+    # echo directly to the Genode LOG session
     var args: Rope = nil
     var a: TLoc
     for it in n.sons:
@@ -989,8 +989,9 @@ proc genEcho(p: BProc, n: PNode) =
         add(args, ", \"\"")
       else:
         initLocExpr(p, it, a)
-        add(args, ropecg(p.module, ", #nimToCStringConv($1)", [rdLoc(a)]))
+        add(args, ropecg(p.module, ", Genode::Cstring($1->data, $1->len)", [rdLoc(a)]))
     p.module.includeHeader("<base/log.h>")
+    p.module.includeHeader("<util/string.h>")
     linefmt(p, cpsStmts, """Genode::log(""$1);$n""", args)
   else:
     if n.len == 0:

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -253,9 +253,14 @@ vcc.cpp.options.size = "/O1"
 tcc.options.always = "-w"
 
 # Configuration for the Genode toolchain
-amd64.genode.gcc.cpp.exe = "genode-x86-g++"
-amd64.genode.gcc.exe = "genode-x86-gcc"
-amd64.genode.gcc.path = "/usr/local/genode-gcc/bin"
-arm.genode.gcc.cpp.exe = "genode-arm-g++"
-arm.genode.gcc.exe = "genode-arm-gcc"
-arm.genode.gcc.path = "/usr/local/genode-gcc/bin"
+@if genode:
+  gcc.path = "/usr/local/genode-gcc/bin"
+  gcc.cpp.options.always = "-D__GENODE__ -fno-stack-protector"
+  @if i386 or amd64:
+    gcc.exe = "genode-x86-gcc"
+    gcc.cpp.exe = "genode-x86-g++"
+  @elif arm:
+    gcc.exe = "genode-arm-gcc"
+    gcc.cpp.exe = "genode-arm-g++"
+  @end
+@end

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -129,13 +129,13 @@ __clang__
        defined __DMC__ || \
        defined __BORLANDC__ )
 #  define NIM_THREADVAR __declspec(thread)
+#elif defined(__TINYC__) || defined(__GENODE__)
+#  define NIM_THREADVAR
 /* note that ICC (linux) and Clang are covered by __GNUC__ */
 #elif defined __GNUC__ || \
        defined __SUNPRO_C || \
        defined __xlC__
 #  define NIM_THREADVAR __thread
-#elif defined __TINYC__
-#  define NIM_THREADVAR
 #else
 #  error "Cannot define NIM_THREADVAR"
 #endif

--- a/lib/pure/ioselects/ioselectors_select.nim
+++ b/lib/pure/ioselects/ioselectors_select.nim
@@ -310,7 +310,10 @@ proc selectInto*[T](s: Selector[T], timeout: int,
   var rset, wset, eset: FdSet
 
   if timeout != -1:
-    tv.tv_sec = timeout.int32 div 1_000
+    when defined(genode):
+      tv.tv_sec = Time(timeout div 1_000)
+    else:
+      tv.tv_sec = timeout.int32 div 1_000
     tv.tv_usec = (timeout.int32 %% 1_000) * 1_000
   else:
     ptv = nil
@@ -391,7 +394,6 @@ proc contains*[T](s: Selector[T], fd: SocketHandle|int): bool {.inline.} =
     for i in 0..<FD_SETSIZE:
       if s.fds[i].ident == fdi:
         return true
-      inc(i)
 
 when hasThreadSupport:
   template withSelectLock[T](s: Selector[T], body: untyped) =

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1352,9 +1352,15 @@ elif defined(nintendoswitch):
   proc paramCount*(): int {.tags: [ReadIOEffect].} =
     raise newException(OSError, "paramCount is not implemented on Nintendo Switch")
 
+elif defined(genode):
+  proc paramStr*(i: int): TaintedString =
+    raise newException(OSError, "paramStr is not implemented on Genode")
+
+  proc paramCount*(): int =
+    raise newException(OSError, "paramCount is not implemented on Genode")
+
 elif not defined(createNimRtl) and
-  not(defined(posix) and appType == "lib") and
-  not defined(genode):
+  not(defined(posix) and appType == "lib"):
   # On Posix, there is no portable way to get the command line from a DLL.
   var
     cmdCount {.importc: "cmdCount".}: cint

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4155,8 +4155,13 @@ when defined(cpp) and appType != "lib" and
 
     let ex = getCurrentException()
     let trace = ex.getStackTrace()
-    stderr.write trace & "Error: unhandled exception: " & ex.msg &
-                 " [" & $ex.name & "]\n"
+    when defined(genode):
+      # stderr not available by default, use the LOG session
+      echo trace & "Error: unhandled exception: " & ex.msg &
+                   " [" & $ex.name & "]\n"
+    else:
+      stderr.write trace & "Error: unhandled exception: " & ex.msg &
+                   " [" & $ex.name & "]\n"
     quit 1
 
 when not defined(js):

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -50,7 +50,7 @@ when defined(windows):
     SIGTERM = cint(15)
 elif defined(macosx) or defined(linux) or defined(freebsd) or
      defined(openbsd) or defined(netbsd) or defined(solaris) or
-     defined(dragonfly) or defined(nintendoswitch):
+     defined(dragonfly) or defined(nintendoswitch) or defined(genode):
   const
     SIGABRT = cint(6)
     SIGFPE = cint(8)

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -31,7 +31,11 @@ proc showErrorMessage(data: cstring) {.gcsafe.} =
   if errorMessageWriter != nil:
     errorMessageWriter($data)
   else:
-    writeToStdErr(data)
+    when defined(genode):
+      # stderr not available by default, use the LOG session
+      echo data
+    else:
+      writeToStdErr(data)
 
 proc quitOrDebug() {.inline.} =
   when not defined(endb):


### PR DESCRIPTION
- wrap strings in "Genode::Cstring" when logging
- define SIGABRT for Genode
- disable GCC -fstack-protector