### PR TITLE
fix #8509 disable 4GB allocating test on windows that crashed appveyor

### DIFF
--- a/tests/fragmentation/tfragment_alloc.nim
+++ b/tests/fragmentation/tfragment_alloc.nim
@@ -16,9 +16,12 @@ proc main =
     dealloc p
  #   c_fprintf(stdout, "iteration: %ld size: %ld\n", i, size)
   when defined(cpu64):
-    # bug #7120
-    var x = alloc(((1 shl 29) - 4) * 8)
-    dealloc x
+    # see https://github.com/nim-lang/Nim/issues/8509
+    # this often made appveyor (on windows) fail with out of memory
+    when defined(posix):
+      # bug #7120
+      var x = alloc(((1 shl 29) - 4) * 8)
+      dealloc x
 
 main()
 


### PR DESCRIPTION
/cc @araq since you introduced that test in 6d4107b

* fixes tfragment_alloc.nim (which allocates 4GB) often makes appveyor fail with out of memory #8509
