### PR TITLE
Haiku support for Nim

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -82,19 +82,21 @@ path="$lib/pure"
     clang.cpp.options.linker = "-ldl"
     tcc.options.linker = "-ldl"
   @end
-  @if bsd or haiku:
+  @if bsd:
     # BSD got posix_spawn only recently, so we deactivate it for osproc:
     define:useFork
     # at least NetBSD has problems with thread local storage:
     tlsEmulation:on
   @end
   @if haiku:
-    # -fopenmp
-    gcc.options.linker = "-lroot -lnetwork"
-    gcc.cpp.options.linker = "-lroot -lnetwork"
-    clang.options.linker = "-lroot -lnetwork"
-    clang.cpp.options.linker = "-lroot -lnetwork"
-    tcc.options.linker = "-lroot -lnetwork"
+    # Haiku currently have problems with TLS
+    # https://dev.haiku-os.org/ticket/14342
+    tlsEmulation:on
+    gcc.options.linker = "-Wl,--as-needed -lnetwork"
+    gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork"
+    clang.options.linker = "-Wl,--as-needed -lnetwork"
+    clang.cpp.options.linker = "-Wl,--as-needed -lnetwork"
+    tcc.options.linker = "-Wl,--as-needed -lnetwork"
   @end
 @end
 

--- a/lib/deprecated/pure/sockets.nim
+++ b/lib/deprecated/pure/sockets.nim
@@ -36,6 +36,8 @@ include "system/inclrtl"
 
 when hostOS == "solaris":
   {.passl: "-lsocket -lnsl".}
+elif hostOS == "haiku":
+  {.passl: "-lnetwork".}
 
 import os, parseutils
 from times import epochTime

--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -43,6 +43,9 @@ type
 
   Dirent* {.importc: "struct dirent",
              header: "<dirent.h>", final, pure.} = object ## dirent_t struct
+    when defined(haiku):
+      d_dev*: Dev ## Device (not POSIX)
+      d_pdev*: Dev ## Parent device (only for queries) (not POSIX)
     d_ino*: Ino  ## File serial number.
     when defined(dragonfly):
       # DragonflyBSD doesn't have `d_reclen` field.
@@ -54,6 +57,9 @@ type
                     ## (not POSIX)
       when defined(linux) or defined(openbsd):
         d_off*: Off  ## Not an offset. Value that ``telldir()`` would return.
+    elif defined(haiku):
+      d_pino*: Ino ## Parent inode (only for queries) (not POSIX)
+      d_reclen*: cushort ## Length of this record. (not POSIX)
 
     d_name*: array[0..255, char] ## Name of entry.
 

--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -10,7 +10,7 @@
 {.deadCodeElim: on.}  # dce option deprecated
 
 const
-  hasSpawnH = not defined(haiku) # should exist for every Posix system nowadays
+  hasSpawnH = true # should exist for every Posix system nowadays
   hasAioH = defined(linux)
 
 when defined(linux) and not defined(android):

--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -605,6 +605,10 @@ else:
     MSG_NOSIGNAL* {.importc, header: "<sys/socket.h>".}: cint
       ## No SIGPIPE generated when an attempt to send is made on a stream-oriented socket that is no longer connected.
 
+when defined(haiku):
+  const
+    SIGKILLTHR* = 21 ## BeOS specific: Kill just the thread, not team
+
 when hasSpawnH:
   when defined(linux):
     # better be safe than sorry; Linux has this flag, macosx doesn't, don't

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -43,6 +43,10 @@ when defined(windows):
     {.warning: "ucontext coroutine backend is not available on windows, defaulting to fibers.".}
   when defined(nimCoroutinesSetjmp):
     {.warning: "setjmp coroutine backend is not available on windows, defaulting to fibers.".}
+elif defined(haiku):
+  const coroBackend = CORO_BACKEND_SETJMP
+  when defined(nimCoroutinesUcontext):
+    {.warning: "ucontext coroutine backend is not available on haiku, defaulting to setjmp".}
 elif defined(nimCoroutinesSetjmp) or defined(nimCoroutinesSetjmpBundled):
   const coroBackend = CORO_BACKEND_SETJMP
 else:

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -194,7 +194,7 @@ proc switchTo(current, to: CoroutinePtr) =
         elif to.state == CORO_CREATED:
           # Coroutine is started.
           coroExecWithStack(runCurrentTask, to.stack.bottom)
-          doAssert false
+          #doAssert false
     else:
       {.error: "Invalid coroutine backend set.".}
   # Execution was just resumed. Restore frame information and set active stack.

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -55,21 +55,21 @@ when coroBackend == CORO_BACKEND_FIBERS:
 
 elif coroBackend == CORO_BACKEND_UCONTEXT:
   type
-    stack_t {.importc, header: "<sys/ucontext.h>".} = object
+    stack_t {.importc, header: "<ucontext.h>".} = object
       ss_sp: pointer
       ss_flags: int
       ss_size: int
 
-    ucontext_t {.importc, header: "<sys/ucontext.h>".} = object
+    ucontext_t {.importc, header: "<ucontext.h>".} = object
       uc_link: ptr ucontext_t
       uc_stack: stack_t
 
     Context = ucontext_t
 
-  proc getcontext(context: var ucontext_t): int32 {.importc, header: "<sys/ucontext.h>".}
-  proc setcontext(context: var ucontext_t): int32 {.importc, header: "<sys/ucontext.h>".}
-  proc swapcontext(fromCtx, toCtx: var ucontext_t): int32 {.importc, header: "<sys/ucontext.h>".}
-  proc makecontext(context: var ucontext_t, fn: pointer, argc: int32) {.importc, header: "<sys/ucontext.h>", varargs.}
+  proc getcontext(context: var ucontext_t): int32 {.importc, header: "<ucontext.h>".}
+  proc setcontext(context: var ucontext_t): int32 {.importc, header: "<ucontext.h>".}
+  proc swapcontext(fromCtx, toCtx: var ucontext_t): int32 {.importc, header: "<ucontext.h>".}
+  proc makecontext(context: var ucontext_t, fn: pointer, argc: int32) {.importc, header: "<ucontext.h>", varargs.}
 
 elif coroBackend == CORO_BACKEND_SETJMP:
   proc coroExecWithStack*(fn: pointer, stack: pointer) {.noreturn, importc: "narch_$1", fastcall.}

--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -126,6 +126,8 @@ type
     OpenBSD
     DragonFlyBSD
 
+    Haiku
+
 
 const
   LacksDevPackages* = {Distribution.Gentoo, Distribution.Slackware,
@@ -166,6 +168,8 @@ proc detectOsImpl(d: Distribution): bool =
   of Distribution.Solaris:
     let uname = toLowerAscii(uname())
     result = ("sun" in uname) or ("solaris" in uname)
+  of Distribution.Haiku:
+    result = defined(haiku)
   else:
     let dd = toLowerAscii($d)
     result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release())
@@ -224,6 +228,8 @@ proc foreignDepInstallCmd*(foreignPackageName: string): (string, bool) =
       result = ("pacman -S " & p, true)
     else:
       result = ("<your package manager here> install " & p, true)
+  elif defined(haiku):
+    result = ("pkgman install " & p, true)
   else:
     result = ("brew install " & p, false)
 

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -255,7 +255,7 @@ when defined(windows):
 
 else:
   when defined(haiku):
-    const iconvDll = "(libc.so.6|libiconv.so|libtextencoding.so)"
+    const iconvDll = "libiconv.so"
   elif defined(macosx):
     const iconvDll = "libiconv.dylib"
   else:
@@ -272,6 +272,8 @@ else:
     const EILSEQ = 86.cint
   elif defined(solaris):
     const EILSEQ = 88.cint
+  elif defined(haiku):
+    const EILSEQ = -2147454938.cint
 
   var errno {.importc, header: "<errno.h>".}: cint
 

--- a/lib/pure/fenv.nim
+++ b/lib/pure/fenv.nim
@@ -12,7 +12,7 @@
 
 {.deadCodeElim: on.}  # dce option deprecated
 
-when defined(Posix) and not defined(haiku):
+when defined(Posix):
   {.passl: "-lm".}
 
 var

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -49,7 +49,7 @@ proc fac*(n: int): int =
 
 {.push checks:off, line_dir:off, stack_trace:off.}
 
-when defined(Posix) and not defined(haiku):
+when defined(Posix):
   {.passl: "-lm".}
 
 const

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -248,9 +248,10 @@ proc getAddrInfo*(address: string, port: Port, domain: Domain = AF_INET,
   hints.ai_socktype = toInt(sockType)
   hints.ai_protocol = toInt(protocol)
   # OpenBSD doesn't support AI_V4MAPPED and doesn't define the macro AI_V4MAPPED.
-  # FreeBSD doesn't support AI_V4MAPPED but defines the macro.
+  # FreeBSD, Haiku don't support AI_V4MAPPED but defines the macro.
   # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=198092
-  when not defined(freebsd) and not defined(openbsd) and not defined(netbsd) and not defined(android):
+  # https://dev.haiku-os.org/ticket/14323
+  when not defined(freebsd) and not defined(openbsd) and not defined(netbsd) and not defined(android) and not defined(haiku):
     if domain == AF_INET6:
       hints.ai_flags = AI_V4MAPPED
   var gaiResult = getaddrinfo(address, $port, addr(hints), result)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -615,7 +615,10 @@ proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",
 
 when not declared(ENOENT) and not defined(Windows):
   when NoFakeVars:
-    const ENOENT = cint(2) # 2 on most systems including Solaris
+    when not defined(haiku):
+      const ENOENT = cint(2) # 2 on most systems including Solaris
+    else:
+      const ENOENT = cint(-2147459069)
   else:
     var ENOENT {.importc, header: "<errno.h>".}: cint
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -972,6 +972,14 @@ proc rawCreateDir(dir: string): bool =
       result = false
     else:
       raiseOSError(osLastError(), dir)
+  elif defined(haiku):
+    let res = mkdir(dir, 0o777)
+    if res == 0'i32:
+      result = true
+    elif errno == EEXIST or errno == EROFS:
+      result = false
+    else:
+      raiseOSError(osLastError(), dir)
   elif defined(posix):
     let res = mkdir(dir, 0o777)
     if res == 0'i32:

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -892,7 +892,7 @@ else:
           weekday {.importc: "tm_wday".},
           yearday {.importc: "tm_yday".},
           isdst {.importc: "tm_isdst".}: cint
-        when defined(linux) and defined(amd64):
+        when defined(linux) and defined(amd64) or defined(haiku):
           gmtoff {.importc: "tm_gmtoff".}: clong
           zone {.importc: "tm_zone".}: cstring
   type

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1365,7 +1365,7 @@ const
   hostOS* {.magic: "HostOS".}: string = ""
     ## a string that describes the host operating system. Possible values:
     ## "windows", "macosx", "linux", "netbsd", "freebsd", "openbsd", "solaris",
-    ## "aix", "standalone".
+    ## "aix", "haiku", "standalone".
 
   hostCPU* {.magic: "HostCPU".}: string = ""
     ## a string that describes the host CPU. Possible values:

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -59,6 +59,15 @@ elif defined(macosx) or defined(linux) or defined(freebsd) or
     SIGSEGV = cint(11)
     SIGTERM = cint(15)
     SIGPIPE = cint(13)
+elif defined(haiku):
+  const
+    SIGABRT = cint(6)
+    SIGFPE = cint(8)
+    SIGILL = cint(4)
+    SIGINT = cint(2)
+    SIGSEGV = cint(11)
+    SIGTERM = cint(15)
+    SIGPIPE = cint(7)
 else:
   when NoFakeVars:
     {.error: "SIGABRT not ported to your platform".}
@@ -74,6 +83,8 @@ else:
 
 when defined(macosx):
   const SIGBUS = cint(10)
+elif defined(haiku):
+  const SIGBUS = cint(30)
 else:
   template SIGBUS: untyped = SIGSEGV
 

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -207,6 +207,9 @@ elif defined(posix):
     # some arches like mips and alpha use different values
     const MAP_ANONYMOUS = 0x20
     const MAP_PRIVATE = 0x02        # Changes are private
+  elif defined(haiku):
+    const MAP_ANONYMOUS = 0x08
+    const MAP_PRIVATE = 0x02
   else:
     var
       MAP_ANONYMOUS {.importc: "MAP_ANONYMOUS", header: "<sys/mman.h>".}: cint

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -162,10 +162,12 @@ elif defined(genode):
       mainTls
 
 else:
-  when not defined(macosx):
+  when not (defined(macosx) or defined(haiku)):
     {.passL: "-pthread".}
 
-  {.passC: "-pthread".}
+  when not defined(haiku):
+    {.passC: "-pthread".}
+
   const
     schedh = "#define _GNU_SOURCE\n#include <sched.h>"
     pthreadh = "#define _GNU_SOURCE\n#include <pthread.h>"

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -714,3 +714,13 @@ elif defined(solaris):
     if threadId == 0:
       threadId = int(thr_self())
     result = threadId
+
+elif defined(haiku):
+  type thr_id {.importc: "thread_id", header: "<OS.h>".} = distinct int32
+  proc find_thread(name: cstring): thr_id {.importc, header: "<OS.h>".}
+
+  proc getThreadId*(): int =
+    ## get the ID of the currently running thread.
+    if threadId == 0:
+      threadId = int(find_thread(nil))
+    result = threadId

--- a/tests/osproc/texitsignal.nim
+++ b/tests/osproc/texitsignal.nim
@@ -28,6 +28,9 @@ if paramCount() == 0:
     # windows kill happens using TerminateProcess(h, 0), so we should get a
     # 0 here
     echo p.waitForExit() == 0
+  elif defined(haiku):
+    # on Haiku, the program main thread receive SIGKILLTHR
+    echo p.waitForExit() == 128 + SIGKILLTHR
   else:
     # on posix (non-windows), kill sends SIGKILL
     echo p.waitForExit() == 128 + SIGKILL

--- a/tests/osproc/tworkingdir.nim
+++ b/tests/osproc/tworkingdir.nim
@@ -12,6 +12,8 @@ else:
   var process: Process
   when defined(android):
     process = startProcess("/system/bin/env", "/system/bin", ["true"])
+  elif defined(haiku):
+    process = startProcess("/bin/env", "/bin", ["true"])
   else:
     process = startProcess("/usr/bin/env", "/usr/bin", ["true"])
   let dir2 = getCurrentDir()

--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -109,10 +109,14 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string) =
     safeCopyFile("lib" / nimrtlDll, "tests/dll" / nimrtlDll)
   else:
     # posix relies on crappy LD_LIBRARY_PATH (ugh!):
-    var libpath = getEnv"LD_LIBRARY_PATH".string
+    const libpathenv = when defined(haiku):
+                         "LIBRARY_PATH"
+                       else:
+                         "LD_LIBRARY_PATH"
+    var libpath = getEnv(libpathenv).string
     # Temporarily add the lib directory to LD_LIBRARY_PATH:
-    putEnv("LD_LIBRARY_PATH", "tests/dll" & (if libpath.len > 0: ":" & libpath else: ""))
-    defer: putEnv("LD_LIBRARY_PATH", libpath)
+    putEnv(libpathenv, "tests/dll" & (if libpath.len > 0: ":" & libpath else: ""))
+    defer: putEnv(libpathenv, libpath)
     var nimrtlDll = DynlibFormat % "nimrtl"
     safeCopyFile("lib" / nimrtlDll, "tests/dll" / nimrtlDll)
 


### PR DESCRIPTION
~~Currently still WIP, please don't merge,~~ but any help is welcome!

This PR brings support inline with current Haiku (hrev52165), as well as fixing some POSIX quirks in Nim.

Only C and C++ backends are being tested so far.

Failing tests (23 tests, 1.47%):
- async
  - Due to [Haiku #14312](https://dev.haiku-os.org/ticket/14312)
    - tacceptcloserace
    - tasyncawait
    - tasyncconnect
    - tasyncdial
    - tasyncsend4757
    - tasyncssl
  - Hangs: Could be due to `ioselectors_poll` being buggy, as crash can be reproduced with Linux
    - tasyncRecvLine
    - tnewasyncudp
- cpp
  - tasync_cpp (`cannot open file: jester`)
- dll
  - client: crash on `SIGSEGV`, for all variations of the test
- fragmentation
  - tfragment_alloc (`out of memory`, my test system only have 2G of RAM)
  - tfragment_gc
    <details>

    ```
    occupied ok: true
    total peak memory: 245.902MiB
    total ok: false
    ```

    </details>
- manyloc
  - keineschweine (`cannot open file: zip/zlib`)
  - nakefile (`cannot open file: zip/zipfiles`)
- niminaction
  - tweeter (`cannot open file: jester`)
  - sdl_test (`sdl.nim(16, 16) Error: undeclared identifier: 'libName'`)
  - sfml_test (we don't have a working sfml port yet)
- stdlib
  - thttpclient (`ioselectors_poll` bug)
     <details>

      ```
      exitcode: 1
      
      Output:
      thttpclient.nim(158)     thttpclient
      asyncdispatch.nim(1647)  waitFor
      asyncdispatch.nim(1511)  poll
      asyncdispatch.nim(1277)  runOnce
      asyncdispatch.nim(183)   processPendingCallbacks
      asyncmacro.nim(36)       requestAux_continue
      httpclient.nim(1172)     requestAuxIter
      asyncmacro.nim(304)      send
      asyncmacro.nim(36)       send_continue
      asyncnet.nim(437)        sendIter
      asyncdispatch.nim(1568)  send
      asyncdispatch.nim(1362)  send
      asyncdispatch.nim(1149)  addWrite
      ioselectors_poll.nim(87) updateHandle
      system.nim(2807)         sysFatal
      [[reraised from:
      thttpclient.nim(158)     thttpclient
      asyncdispatch.nim(1647)  waitFor
      asyncdispatch.nim(1511)  poll
      asyncdispatch.nim(1277)  runOnce
      asyncdispatch.nim(183)   processPendingCallbacks
      asyncmacro.nim(39)       requestAux_continue
      httpclient.nim(1172)     requestAuxIter
      asyncfutures.nim(302)    read
      ]]
      [[reraised from:
      thttpclient.nim(158)     thttpclient
      asyncdispatch.nim(1647)  waitFor
      asyncdispatch.nim(1511)  poll
      asyncdispatch.nim(1277)  runOnce
      asyncdispatch.nim(183)   processPendingCallbacks
      asyncmacro.nim(36)       request_continue
      httpclient.nim(1193)     requestIter
      asyncfutures.nim(302)    read
      ]]
      [[reraised from:
      thttpclient.nim(158)     thttpclient
      asyncdispatch.nim(1647)  waitFor
      asyncdispatch.nim(1511)  poll
      asyncdispatch.nim(1277)  runOnce
      asyncdispatch.nim(183)   processPendingCallbacks
      asyncmacro.nim(36)       request_continue
      httpclient.nim(1216)     requestIter
      asyncfutures.nim(302)    read
      ]]
      [[reraised from:
      thttpclient.nim(158)     thttpclient
      asyncdispatch.nim(1647)  waitFor
      asyncdispatch.nim(1511)  poll
      asyncdispatch.nim(1277)  runOnce
      asyncdispatch.nim(183)   processPendingCallbacks
      asyncmacro.nim(36)       asyncTest_continue
      thttpclient.nim(18)      asyncTestIter
      asyncfutures.nim(302)    read
      ]]
      [[reraised from:
      thttpclient.nim(158)     thttpclient
      asyncdispatch.nim(1649)  waitFor
      asyncfutures.nim(302)    read
      ]]
      Error: unhandled exception: index out of bounds
      Async traceback:
        thttpclient.nim(158)     thttpclient
        asyncdispatch.nim(1647)  waitFor
        asyncdispatch.nim(1511)  poll
          ## Processes asynchronous completion events
        asyncdispatch.nim(1277)  runOnce
        asyncdispatch.nim(183)   processPendingCallbacks
          ## Executes pending callbacks
        asyncmacro.nim(36)       requestAux_continue
          ## Resumes an async procedure
        httpclient.nim(1172)     requestAuxIter
        asyncmacro.nim(304)      send
        asyncmacro.nim(36)       send_continue
          ## Resumes an async procedure
        asyncnet.nim(437)        sendIter
        asyncdispatch.nim(1568)  send
        asyncdispatch.nim(1362)  send
        asyncdispatch.nim(1149)  addWrite
        ioselectors_poll.nim(87) updateHandle
        system.nim(2807)         sysFatal
        #[
          thttpclient.nim(158)     thttpclient
          asyncdispatch.nim(1647)  waitFor
          asyncdispatch.nim(1511)  poll
            ## Processes asynchronous completion events
          asyncdispatch.nim(1277)  runOnce
          asyncdispatch.nim(183)   processPendingCallbacks
            ## Executes pending callbacks
          asyncmacro.nim(39)       requestAux_continue
            ## Resumes an async procedure
          httpclient.nim(1172)     requestAuxIter
          asyncfutures.nim(302)    read
        ]#
        #[
          thttpclient.nim(158)     thttpclient
          asyncdispatch.nim(1647)  waitFor
          asyncdispatch.nim(1511)  poll
            ## Processes asynchronous completion events
          asyncdispatch.nim(1277)  runOnce
          asyncdispatch.nim(183)   processPendingCallbacks
            ## Executes pending callbacks
          asyncmacro.nim(36)       request_continue
            ## Resumes an async procedure
          httpclient.nim(1193)     requestIter
          asyncfutures.nim(302)    read
        ]#
        #[
          thttpclient.nim(158)     thttpclient
          asyncdispatch.nim(1647)  waitFor
          asyncdispatch.nim(1511)  poll
            ## Processes asynchronous completion events
          asyncdispatch.nim(1277)  runOnce
          asyncdispatch.nim(183)   processPendingCallbacks
            ## Executes pending callbacks
          asyncmacro.nim(36)       request_continue
            ## Resumes an async procedure
          httpclient.nim(1216)     requestIter
          asyncfutures.nim(302)    read
        ]#
        #[
          thttpclient.nim(158)     thttpclient
          asyncdispatch.nim(1647)  waitFor
          asyncdispatch.nim(1511)  poll
            ## Processes asynchronous completion events
          asyncdispatch.nim(1277)  runOnce
          asyncdispatch.nim(183)   processPendingCallbacks
            ## Executes pending callbacks
          asyncmacro.nim(36)       asyncTest_continue
            ## Resumes an async procedure
          thttpclient.nim(18)      asyncTestIter
          asyncfutures.nim(302)    read
        ]#
      Exception message: index out of bounds
      Exception type: [IndexError]
      ```

     </details>

  - tnetdial (`unhandled exception: index out of bounds [IndexError]`, could be due to buggy `ioselectors_poll`, reproducable on linux with that selector)
  - tos (due to [Haiku #14311](https://dev.haiku-os.org/ticket/14311))