### PR TITLE
runnableExamples: keep (gitignored) generated foo_examples.nim for inspection even on success

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -92,7 +92,7 @@ const
     warnResultShadowed: "Special variable 'result' is shadowed.",
     warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
     warnUser: "$1",
-    hintSuccess: "operation successful",
+    hintSuccess: "operation successful: $#",
     hintSuccessX: "operation successful ($# lines compiled; $# sec total; $#; $#)",
     hintCC: "CC: \'$1\'", # unused
     hintLineTooLong: "line too long",
@@ -169,8 +169,8 @@ proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
     result[1] = result[2] - {warnShadowIdent, warnProveField, warnProveIndex,
       warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
       hintSource, hintGlobalVar, hintGCStats}
-    result[0] = result[1] - {hintSuccessX, hintConf, hintProcessing,
-      hintPattern, hintExecuting, hintLinking}
+    result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,
+      hintProcessing, hintPattern, hintExecuting, hintLinking}
 
 const
   NotesVerbosity* = computeNotesVerbosity()

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -622,7 +622,7 @@ proc testExamples(c: PContext) =
     quit "[Examples] failed: see " & outp
   else:
     # keep generated source file `outp` to allow inspection.
-    echo "success for genarated " & outp
+    rawMessage(c.config, hintSuccess, ["runnableExamples: " & outp])
     removeFile(outp.changeFileExt(ExeExt))
     try:
       removeDir(nimcache)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -621,7 +621,8 @@ proc testExamples(c: PContext) =
   if os.execShellCmd(os.getAppFilename() & " " & backend & " --nimcache:" & nimcache & " -r " & outp) != 0:
     quit "[Examples] failed: see " & outp
   else:
-    removeFile(outp)
+    # keep generated source file `outp` to allow inspection.
+    echo "success for genarated " & outp
     removeFile(outp.changeFileExt(ExeExt))
     try:
       removeDir(nimcache)


### PR DESCRIPTION
code still removes generated binary and nimcache, but now keeps generated `foo_examples.nim` file around in case of success (and prints that file)

benefits:
* useful in case user wants to see generated file
* doesn't cause any harm as it's inside a gitignore'd directory (since a previous commit) and tiny (compared to nimcache and exe)
* makes it clear to user that a runnableExamples file was generated and run (otherwise user may think it is generated when in fact it's not, because of https://github.com/nim-lang/Nim/issues/7280)

my previous workaround was to insert a `doAssert false` to make the test fail just to see what's inside or to make sure the file was generated.
