### PR TITLE
new macro for generic reflection: `extractGeneric(Foo2[float, string], 0) is float`

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4437,7 +4437,7 @@ type classes are called `bind many`:idx: types.
 
 Procs written with the implicitly generic style will often need to refer to the
 type parameters of the matched generic type. They can be easily accessed using
-the dot syntax:
+``sugar.extractGeneric`` or the dot syntax:
 
 .. code-block:: nim
   type Matrix[T, Rows, Columns] = object
@@ -4445,6 +4445,7 @@ the dot syntax:
 
   proc `[]`(m: Matrix, row, col: int): Matrix.T =
     m.data[col * high(Matrix.Columns) + row]
+    # we could've also used ``extractGeneric(Matrix, 0)``
 
 Alternatively, the `type` operator can be used over the proc params for similar
 effect when anonymous or distinct type classes are used.

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -245,7 +245,8 @@ macro extractGeneric*(T: typedesc, index:static[int]): untyped =
     type Foo[T1, T2]=object
     doAssert extractGeneric(Foo[float, string], 0) is float
     doAssert extractGeneric(Foo[float, string], 1) is string
-    doAssert extractGeneric(Foo[float, string], -1) is Foo
+    # pending https://github.com/nim-lang/Nim/issues/9855
+    # doAssert extractGeneric(Foo[float, string], -1) is Foo
 
   var impl = getTypeImpl(T)
   expectKind(impl, nnkBracketExpr)

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -2,6 +2,7 @@ discard """
   file: "tsugar.nim"
   output: ""
 """
+
 import sugar
 import macros
 
@@ -27,3 +28,18 @@ block distinctBase:
       Uint[bits: static[int]] = distinct uintImpl(bits)
 
     doAssert Uint[128].distinctBase is UintImpl[uint64]
+
+block extractGeneric:
+  type Foo[T1, T2]=object
+  type Foo2=Foo[float, string]
+  doAssert extractGeneric(Foo[float, string], 1) is string
+  doAssert extractGeneric(Foo2, 1) is string
+  # workaround for seq[int].T not working,
+  # see https://github.com/nim-lang/Nim/issues/8433
+  doAssert extractGeneric(seq[int], 0) is int
+  doAssert extractGeneric(seq[seq[string]], 0) is seq[string]
+  doAssert: not compiles(extractGeneric(seq[int], 1))
+  doAssert extractGeneric(seq[int], -1) is seq
+
+  type Foo3[T] = T
+  doAssert extractGeneric(Foo3[int], 0) is int

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -32,13 +32,18 @@ block distinctBase:
 block extractGeneric:
   type Foo[T1, T2]=object
   type Foo2=Foo[float, string]
-  doAssert extractGeneric(Foo[float, string], 1) is string
+  # pending https://github.com/nim-lang/Nim/issues/9855
+  # doAssert extractGeneric(Foo2, -1) is Foo
+  doAssert extractGeneric(Foo2, 0) is float
   doAssert extractGeneric(Foo2, 1) is string
+  doAssert extractGeneric(Foo[float, string], 1) is string
+  # pending https://github.com/nim-lang/Nim/issues/9855
+  # doAssert extractGeneric(Foo[float, string], -1) is Foo
   # workaround for seq[int].T not working,
   # see https://github.com/nim-lang/Nim/issues/8433
   doAssert extractGeneric(seq[int], 0) is int
   doAssert extractGeneric(seq[seq[string]], 0) is seq[string]
-  doAssert: not compiles(extractGeneric(seq[int], 1))
+  doAssert not compiles(extractGeneric(seq[int], 1))
   doAssert extractGeneric(seq[int], -1) is seq
 
   type Foo3[T] = T


### PR DESCRIPTION
/cc @mratsim 

* this PR supports these:
```nim
Foo2[float, string].extractGeneric(0) is float
Foo2[float, string].extractGeneric(-1) is Foo2
```

* **EDIT** fixes https://github.com/nim-lang/Nim/issues/6454
* provides complete workaround for https://github.com/nim-lang/Nim/issues/8433
* allows generic code needs to access generic params by index instead of by name

in some contexts (IMO in most contexts), it's better to access generics by index rather than by name as mentioned by @mratsim here https://github.com/nim-lang/Nim/issues/8459#issuecomment-408359281
> I'm also not super fan of this because the "T" or "N" seems to come from nowhere

I also agree with that sentiment (see https://github.com/nim-lang/Nim/issues/8433#issuecomment-410357365), mainly because it avoids polluting scope with a generics's parameters.

a user writing `Foo.Bar` may be expecting `Bar(Foo) ` when in fact compiler interprets as accessing generic param Bar from generic type Foo.

