### PR TITLE
doAssert, assert now print full path of failing line on error

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -8,6 +8,7 @@
 #
 
 include "system/inclrtl"
+include "system/helpers"
 
 ## This module contains the interface to the compiler's abstract syntax
 ## tree (`AST`:idx:). Macros operate on this tree.
@@ -422,7 +423,8 @@ type
     line*,column*: int
 
 proc `$`*(arg: Lineinfo): string =
-  result = arg.filename & "(" & $arg.line & ", " & $arg.column & ")"
+  # BUG: without `result = `, gives compile error
+  result = lineInfoToString(arg.filename, arg.line, arg.column)
 
 #proc lineinfo*(n: NimNode): LineInfo {.magic: "NLineInfo", noSideEffect.}
   ## returns the position the node appears in the original source file

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3758,7 +3758,20 @@ proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
                                     tags: [].}
   Hide(raiseAssert)(msg)
 
-template assert*(cond: bool, msg = "") =
+include "system/helpers" # for `lineInfoToString`
+
+template assertImpl(cond: bool, msg = "", enabled: static[bool], fakeLoc: static[string]) =
+  const loc = $instantiationInfo(-1, true)
+  bind instantiationInfo
+  mixin failedAssertImpl
+  when enabled:
+    if not cond:
+        # `fakeLoc` is useful for for unittests, see tfailedassert.nim
+        var msg2 =  when fakeLoc.len == 0: loc else: fakeLoc
+        msg2.add " `" & astToStr(cond) & "` " & msg
+        failedAssertImpl(msg2)
+
+template assert*(cond: bool, msg = "", fakeLoc: static[string] = "") =
   ## Raises ``AssertionError`` with `msg` if `cond` is false. Note
   ## that ``AssertionError`` is hidden from the effect system, so it doesn't
   ## produce ``{.raises: [AssertionError].}``. This exception is only supposed
@@ -3767,23 +3780,11 @@ template assert*(cond: bool, msg = "") =
   ## The compiler may not generate any code at all for ``assert`` if it is
   ## advised to do so through the ``-d:release`` or ``--assertions:off``
   ## `command line switches <nimc.html#command-line-switches>`_.
-  # NOTE: `true` is correct here; --excessiveStackTrace:on will control whether
-  # or not to output full paths.
-  bind instantiationInfo
-  mixin failedAssertImpl
-  {.line: instantiationInfo(fullPaths = true).}:
-    when compileOption("assertions"):
-      if not cond: failedAssertImpl(astToStr(cond) & ' ' & msg)
+  assertImpl(cond, msg, compileOption("assertions"), fakeLoc)
 
-template doAssert*(cond: bool, msg = "") =
-  ## same as `assert` but is always turned on and not affected by the
-  ## ``--assertions`` command line switch.
-  # NOTE: `true` is correct here; --excessiveStackTrace:on will control whether
-  # or not to output full paths.
-  bind instantiationInfo
-  mixin failedAssertImpl
-  {.line: instantiationInfo(fullPaths = true).}:
-    if not cond: failedAssertImpl(astToStr(cond) & ' ' & msg)
+template doAssert*(cond: bool, msg = "", fakeLoc: static[string] = "") =
+  ## same as ``assert`` but is always turned on regardless of ``--assertions``
+  assertImpl(cond, msg, true, fakeLoc)
 
 iterator items*[T](a: seq[T]): T {.inline.} =
   ## iterates over each item of `a`.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3766,10 +3766,9 @@ template assertImpl(cond: bool, msg = "", enabled: static[bool], fakeLoc: static
   mixin failedAssertImpl
   when enabled:
     if not cond:
-        # `fakeLoc` is useful for for unittests, see tfailedassert.nim
-        var msg2 =  when fakeLoc.len == 0: loc else: fakeLoc
-        msg2.add " `" & astToStr(cond) & "` " & msg
-        failedAssertImpl(msg2)
+      # `fakeLoc` is useful for for unittests, see tfailedassert.nim
+      const loc2 =  when fakeLoc.len == 0: loc else: fakeLoc
+      failedAssertImpl(loc2 & " `" & astToStr(cond) & "` " & msg)
 
 template assert*(cond: bool, msg = "", fakeLoc: static[string] = "") =
   ## Raises ``AssertionError`` with `msg` if `cond` is false. Note

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3760,17 +3760,15 @@ proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
 
 include "system/helpers" # for `lineInfoToString`
 
-template assertImpl(cond: bool, msg = "", enabled: static[bool], fakeLoc: static[string]) =
+template assertImpl(cond: bool, msg = "", enabled: static[bool]) =
   const loc = $instantiationInfo(-1, true)
   bind instantiationInfo
   mixin failedAssertImpl
   when enabled:
     if not cond:
-      # `fakeLoc` is useful for for unittests, see tfailedassert.nim
-      const loc2 =  when fakeLoc.len == 0: loc else: fakeLoc
-      failedAssertImpl(loc2 & " `" & astToStr(cond) & "` " & msg)
+      failedAssertImpl(loc & " `" & astToStr(cond) & "` " & msg)
 
-template assert*(cond: bool, msg = "", fakeLoc: static[string] = "") =
+template assert*(cond: bool, msg = "") =
   ## Raises ``AssertionError`` with `msg` if `cond` is false. Note
   ## that ``AssertionError`` is hidden from the effect system, so it doesn't
   ## produce ``{.raises: [AssertionError].}``. This exception is only supposed
@@ -3779,11 +3777,11 @@ template assert*(cond: bool, msg = "", fakeLoc: static[string] = "") =
   ## The compiler may not generate any code at all for ``assert`` if it is
   ## advised to do so through the ``-d:release`` or ``--assertions:off``
   ## `command line switches <nimc.html#command-line-switches>`_.
-  assertImpl(cond, msg, compileOption("assertions"), fakeLoc)
+  assertImpl(cond, msg, compileOption("assertions"))
 
-template doAssert*(cond: bool, msg = "", fakeLoc: static[string] = "") =
+template doAssert*(cond: bool, msg = "") =
   ## same as ``assert`` but is always turned on regardless of ``--assertions``
-  assertImpl(cond, msg, true, fakeLoc)
+  assertImpl(cond, msg, true)
 
 iterator items*[T](a: seq[T]): T {.inline.} =
   ## iterates over each item of `a`.

--- a/lib/system/helpers.nim
+++ b/lib/system/helpers.nim
@@ -1,0 +1,11 @@
+## helpers used system.nim and other modules, avoids code duplication while
+## also minimizing symbols exposed in system.nim
+#
+# TODO: move other things here that should not be exposed in system.nim
+
+proc lineInfoToString(file: string, line, column: int): string =
+  file & "(" & $line & ", " & $column & ")"
+
+proc `$`(info: type(instantiationInfo(0))): string =
+  # The +1 is needed here
+  lineInfoToString(info.fileName, info.line, info.column+1)

--- a/tests/assert/testhelper.nim
+++ b/tests/assert/testhelper.nim
@@ -1,0 +1,12 @@
+from strutils import endsWith, split
+from ospaths import isAbsolute
+
+proc checkMsg*(msg, expectedEnd, name: string)=
+  let filePrefix = msg.split(' ', maxSplit = 1)[0]
+  if not filePrefix.isAbsolute:
+    echo name, ":not absolute: `", msg & "`"
+  elif not msg.endsWith expectedEnd:
+    echo name, ":expected suffix:\n`" & expectedEnd & "`\ngot:\n`" & msg & "`"
+  else:
+    echo name, ":ok"
+

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -1,11 +1,20 @@
 discard """
   output: '''
-WARNING: false first assertion from bar
-ERROR: false second assertion from bar
+true
+true
+true
+true
+MOCKEDFILE `a + a == 1` doAssert failed
+MOCKEDFILE `a + a == 1` assert failed
+WARNING: MOCKEDFILE `false` first assertion from bar
+ERROR: MOCKEDFILE `false` second assertion from bar
 -1
-tfailedassert.nim:27 false assertion from foo
+tfailedassert.nim MOCKEDFILE `false` assertion from foo
 '''
 """
+
+from strutils import endsWith, split
+from ospaths import isAbsolute
 
 type
   TLineInfo = tuple[filename: string, line: int, column: int]
@@ -14,6 +23,38 @@ type
     lineinfo: TLineInfo
 
   EMyError = ref TMyError
+
+echo("")
+
+## using real files to make sure we print what we expect and prevent
+## future regressions
+try:
+  doAssert(false, "doAssert:realLoc")
+except AssertionError as e:
+  echo e.msg.endsWith("tfailedassert.nim(32, 11) `false` doAssert:realLoc")
+  echo e.msg.split(' ', maxSplit = 1)[0].isAbsolute
+
+try:
+  assert false, "assert:realLoc"
+except AssertionError as e:
+  echo e.msg.endsWith("tfailedassert.nim(38, 10) `false` assert:realLoc")
+  echo e.msg.split(' ', maxSplit = 1)[0].isAbsolute
+
+## from now on, it's simpler to use `fakeLoc` for remainder of tests
+const fakeLoc = "MOCKEDFILE"
+try:
+  let a = 1
+  doAssert(a+a==1, "doAssert failed", fakeLoc)
+  # BUG: const folding would make "1+1==1" appear as `false` in
+  # assert message
+except AssertionError as e:
+  echo e.msg
+
+try:
+  let a = 1
+  assert(a+a==1, "assert failed", fakeLoc)
+except AssertionError as e:
+  echo e.msg
 
 # module-wide policy to change the failed assert
 # exception type in order to include a lineinfo
@@ -24,28 +65,26 @@ onFailedAssert(msg):
   raise e
 
 proc foo =
-  assert(false, "assertion from foo")
+  assert(false, "assertion from foo", fakeLoc)
 
 proc bar: int =
   # local overrides that are active only
   # in this proc
   onFailedAssert(msg): echo "WARNING: " & msg
 
-  assert(false, "first assertion from bar")
+  assert(false, "first assertion from bar", fakeLoc)
 
   onFailedAssert(msg):
     echo "ERROR: " & msg
     return -1
 
-  assert(false, "second assertion from bar")
+  assert(false, "second assertion from bar", fakeLoc)
   return 10
 
-echo("")
 echo(bar())
 
 try:
   foo()
 except:
   let e = EMyError(getCurrentException())
-  echo e.lineinfo.filename, ":", e.lineinfo.line, " ", e.msg
-
+  echo e.lineinfo.filename, " ", e.msg

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -1,64 +1,64 @@
 discard """
   output: '''
-true
-true
-true
-true
-MOCKEDFILE `a + a == 1` doAssert failed
-MOCKEDFILE `a + a == 1` assert failed
-WARNING: MOCKEDFILE `false` first assertion from bar
-ERROR: MOCKEDFILE `false` second assertion from bar
+test1:ok
+test2:ok
+test3:ok
+test4:ok
+test5:ok
+test6:ok
+test7:ok
 -1
-tfailedassert.nim MOCKEDFILE `false` assertion from foo
+tfailedassert.nim
+test7:ok
 '''
 """
 
-from strutils import endsWith, split
-from ospaths import isAbsolute
+import testhelper
 
 type
   TLineInfo = tuple[filename: string, line: int, column: int]
-
   TMyError = object of Exception
     lineinfo: TLineInfo
-
   EMyError = ref TMyError
 
 echo("")
 
-## using real files to make sure we print what we expect and prevent
-## future regressions
-try:
-  doAssert(false, "doAssert:realLoc")
-except AssertionError as e:
-  echo e.msg.endsWith("tfailedassert.nim(32, 11) `false` doAssert:realLoc")
-  echo e.msg.split(' ', maxSplit = 1)[0].isAbsolute
+
+# NOTE: when entering newlines, adjust `expectedEnd` ouptuts
 
 try:
-  assert false, "assert:realLoc"
+  doAssert(false, "msg1") # doAssert test
 except AssertionError as e:
-  echo e.msg.endsWith("tfailedassert.nim(38, 10) `false` assert:realLoc")
-  echo e.msg.split(' ', maxSplit = 1)[0].isAbsolute
+  checkMsg(e.msg, "tfailedassert.nim(30, 11) `false` msg1", "test1")
 
-## from now on, it's simpler to use `fakeLoc` for remainder of tests
-const fakeLoc = "MOCKEDFILE"
+try:
+  assert false, "msg2"  # assert test
+except AssertionError as e:
+  checkMsg(e.msg, "tfailedassert.nim(35, 10) `false` msg2", "test2")
+
+try:
+  assert false # assert test with no msg
+except AssertionError as e:
+  checkMsg(e.msg, "tfailedassert.nim(40, 10) `false` ", "test3")
+
 try:
   let a = 1
-  doAssert(a+a==1, "doAssert failed", fakeLoc)
+  doAssert(a+a==1) # assert test with Ast expression
   # BUG: const folding would make "1+1==1" appear as `false` in
   # assert message
 except AssertionError as e:
-  echo e.msg
+  checkMsg(e.msg, "`a + a == 1` ", "test4")
 
 try:
   let a = 1
-  assert(a+a==1, "assert failed", fakeLoc)
+  doAssert a+a==1 # ditto with `doAssert` and no parens
 except AssertionError as e:
-  echo e.msg
+  checkMsg(e.msg, "`a + a == 1` ", "test5")
 
-proc foo2() =
+proc fooStatic() =
   # protect against https://github.com/nim-lang/Nim/issues/8758
   static: doAssert(true)
+fooStatic()
 
 # module-wide policy to change the failed assert
 # exception type in order to include a lineinfo
@@ -69,20 +69,21 @@ onFailedAssert(msg):
   raise e
 
 proc foo =
-  assert(false, "assertion from foo", fakeLoc)
+  assert(false, "assertion from foo")
+
 
 proc bar: int =
-  # local overrides that are active only
-  # in this proc
-  onFailedAssert(msg): echo "WARNING: " & msg
+  # local overrides that are active only in this proc
+  onFailedAssert(msg):
+    checkMsg(msg, "tfailedassert.nim(80, 9) `false` first assertion from bar", "test6")
 
-  assert(false, "first assertion from bar", fakeLoc)
+  assert(false, "first assertion from bar")
 
   onFailedAssert(msg):
-    echo "ERROR: " & msg
+    checkMsg(msg, "tfailedassert.nim(86, 9) `false` second assertion from bar", "test7")
     return -1
 
-  assert(false, "second assertion from bar", fakeLoc)
+  assert(false, "second assertion from bar")
   return 10
 
 echo(bar())
@@ -91,4 +92,5 @@ try:
   foo()
 except:
   let e = EMyError(getCurrentException())
-  echo e.lineinfo.filename, " ", e.msg
+  echo e.lineinfo.filename
+  checkMsg(e.msg, "tfailedassert.nim(72, 9) `false` assertion from foo", "test7")

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -56,6 +56,10 @@ try:
 except AssertionError as e:
   echo e.msg
 
+proc foo2() =
+  # protect against https://github.com/nim-lang/Nim/issues/8758
+  static: doAssert(true)
+
 # module-wide policy to change the failed assert
 # exception type in order to include a lineinfo
 onFailedAssert(msg):

--- a/tests/assert/tfaileddoassert.nim
+++ b/tests/assert/tfaileddoassert.nim
@@ -1,19 +1,20 @@
 discard """
   cmd: "nim $target -d:release $options $file"
   output: '''
-true
-MOCKEDFILE `a == 3` bar
+test1:ok
+test2:ok
 '''
 """
 
-from strutils import endsWith, split
+import testhelper
 
 onFailedAssert(msg):
-  echo msg.endsWith("tfaileddoassert.nim(15, 9) `a == 2` foo")
+  checkMsg(msg, "tfaileddoassert.nim(15, 9) `a == 2` foo", "test1")
 
 var a = 1
 doAssert(a == 2, "foo")
 
 onFailedAssert(msg):
-  echo msg
-doAssert(a == 3, "bar", "MOCKEDFILE")
+  checkMsg(msg, "tfaileddoassert.nim(20, 10) `a == 3` ", "test2")
+
+doAssert a == 3

--- a/tests/assert/tfaileddoassert.nim
+++ b/tests/assert/tfaileddoassert.nim
@@ -1,11 +1,19 @@
 discard """
   cmd: "nim $target -d:release $options $file"
   output: '''
-assertion occured!!!!!! false
+true
+MOCKEDFILE `a == 3` bar
 '''
 """
 
-onFailedAssert(msg):
-  echo("assertion occured!!!!!! ", msg)
+from strutils import endsWith, split
 
-doAssert(1 == 2)
+onFailedAssert(msg):
+  echo msg.endsWith("tfaileddoassert.nim(15, 9) `a == 2` foo")
+
+var a = 1
+doAssert(a == 2, "foo")
+
+onFailedAssert(msg):
+  echo msg
+doAssert(a == 3, "bar", "MOCKEDFILE")


### PR DESCRIPTION
/cc @Araq 

before PR:
* when assert fails, no line context was shown;
* when doAssert fails, project path was shown (can be ambiguous), via `file(line)`

after PR: 
* doAssert, assert now print full path of failing line on error: `file(line, col)` (same rationale as https://github.com/nim-lang/Nim/pull/8466)
* refactoring so lib/core/macros.nim can reuse code to print Lineinfo



