### PR TITLE
build from source on windows: build_all.bat

### DIFF
--- a/build_all.bat
+++ b/build_all.bat
@@ -7,38 +7,60 @@ rem note: this won't work if it's in a networked drive
 rem eg if using parallels on OSX, don't use a parallels shared folder, use C:\
 
 rem better to be verbose, for debugging purposes
+
 @echo on
+
+rem  lifetime of the environment will end with the termination of the batch
+setlocal
 
 echo "checks that gcc in PATH:"
 gcc -v
+IF ERRORLEVEL 1 (GOTO:END)
 
-IF EXIST csources\nul (
+IF EXIST csources\ (
   echo "csources already exists"
 ) ELSE (
   git clone --depth 1 https://github.com/nim-lang/csources.git
+  IF ERRORLEVEL 1 (GOTO:END)
 )
 
-rem nesting this inside an IF branch triggered a weird parsing error
-rem https://stackoverflow.com/questions/601089/detect-whether-current-windows-version-is-32-bit-or-64-bit
-if defined ProgramFiles(x86) (
-  echo detected 64 bit
+rem https://stackoverflow.com/questions/12322308/batch-file-to-check-64bit-or-32bit-os
+
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
+IF ERRORLEVEL 1 (GOTO:END)
+
+echo %OS%
+if %OS%==64BIT (
   set buildfilename=.\build64.bat
 ) ELSE (
-  echo detected 32 bit
   set buildfilename=.\build.bat
+  echo "OS not recognized"
 )
 
 IF EXIST .\bin\nim.exe (
   echo skipping csources\build
 ) ELSE (
   cd csources
+  IF ERRORLEVEL 1 (GOTO:END)
   rem %buildfilename%
   %buildfilename%
+  IF ERRORLEVEL 1 (GOTO:END)
   cd ..
 )
 
 bin\nim c koch
+IF ERRORLEVEL 1 (GOTO:END)
 koch boot -d:release
+IF ERRORLEVEL 1 (GOTO:END)
 
 rem Compile Nimble and other tools
 koch tools
+IF ERRORLEVEL 1 (GOTO:END)
+
+:END
+IF ERRORLEVEL 1 (
+    ECHO FAILURE
+) ELSE (
+    ECHO SUCCESS
+)
+exit /b %ERRORLEVEL%

--- a/build_all.bat
+++ b/build_all.bat
@@ -1,36 +1,44 @@
-echo "build from source on windows"
+rem "build from source on windows"
 
-rem requires `gcc` in your PATH
-rem one way is via calling finish.exe in command prompt after installing via
-rem https://nim-lang.org/install_windows.html
-rem note: this won't work if it's in a networked drive
-rem eg if using parallels on OSX, don't use a parallels shared folder, use C:\
-
-rem better to be verbose, for debugging purposes
-
-@echo on
+@echo off
+echo requires `gcc` in your PATH
+echo one way is via calling finish.exe in command prompt after installing via
+echo https://nim-lang.org/install_windows.html
+echo you can also use something like this
+echo set path="%%path%%;C:\Users\User\pathto\nim-0.18.0_x64\nim-0.18.0\dist\mingw64\bin\"
+echo
+echo note: this won't work if it's in a networked drive
+echo eg if using parallels on OSX, don't use a parallels shared folder, use C:\
+echo
+echo use "echo on" for debugging
 
 rem  lifetime of the environment will end with the termination of the batch
 setlocal
 
 echo "checks that gcc in PATH:"
 gcc -v
-IF ERRORLEVEL 1 (GOTO:END)
+IF %ERRORLEVEL% neq 0 (GOTO:END)
 
 IF EXIST csources\ (
   echo "csources already exists"
 ) ELSE (
   git clone --depth 1 https://github.com/nim-lang/csources.git
-  IF ERRORLEVEL 1 (GOTO:END)
+  IF %ERRORLEVEL% neq 0 (GOTO:END)
 )
 
+rem this didn't work in command prompt:
 rem https://stackoverflow.com/questions/12322308/batch-file-to-check-64bit-or-32bit-os
+rem reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
 
-reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set OS=32BIT || set OS=64BIT
-IF ERRORLEVEL 1 (GOTO:END)
+rem https://stackoverflow.com/questions/601089/detect-whether-current-windows-version-is-32-bit-or-64-bit
+if defined ProgramFiles(x86) (
+  set OS=64BIT
+) ELSE (
+  set OS=32BIT
+)
 
 echo %OS%
-if %OS%==64BIT (
+if %OS% == 64BIT (
   set buildfilename=.\build64.bat
 ) ELSE (
   set buildfilename=.\build.bat
@@ -41,26 +49,28 @@ IF EXIST .\bin\nim.exe (
   echo skipping csources\build
 ) ELSE (
   cd csources
-  IF ERRORLEVEL 1 (GOTO:END)
+  IF %ERRORLEVEL% neq 0 (GOTO:END)
   rem %buildfilename%
   %buildfilename%
-  IF ERRORLEVEL 1 (GOTO:END)
+  IF %ERRORLEVEL% neq 0 (GOTO:END)
   cd ..
 )
 
 bin\nim c koch
-IF ERRORLEVEL 1 (GOTO:END)
+IF %ERRORLEVEL% neq 0 (GOTO:END)
 koch boot -d:release
-IF ERRORLEVEL 1 (GOTO:END)
+IF %ERRORLEVEL% neq 0 (GOTO:END)
 
 rem Compile Nimble and other tools
 koch tools
-IF ERRORLEVEL 1 (GOTO:END)
+IF %ERRORLEVEL% neq 0 (GOTO:END)
 
 :END
-IF ERRORLEVEL 1 (
+IF %ERRORLEVEL% neq 0 (
     ECHO FAILURE
 ) ELSE (
     ECHO SUCCESS
 )
+
+rem: "TODO: error code seems ignored in command prompt"
 exit /b %ERRORLEVEL%

--- a/build_all.bat
+++ b/build_all.bat
@@ -1,0 +1,44 @@
+echo "build from source on windows"
+
+rem requires `gcc` in your PATH
+rem one way is via calling finish.exe in command prompt after installing via
+rem https://nim-lang.org/install_windows.html
+rem note: this won't work if it's in a networked drive
+rem eg if using parallels on OSX, don't use a parallels shared folder, use C:\
+
+rem better to be verbose, for debugging purposes
+@echo on
+
+echo "checks that gcc in PATH:"
+gcc -v
+
+IF EXIST csources\nul (
+  echo "csources already exists"
+) ELSE (
+  git clone --depth 1 https://github.com/nim-lang/csources.git
+)
+
+rem nesting this inside an IF branch triggered a weird parsing error
+rem https://stackoverflow.com/questions/601089/detect-whether-current-windows-version-is-32-bit-or-64-bit
+if defined ProgramFiles(x86) (
+  echo detected 64 bit
+  set buildfilename=.\build64.bat
+) ELSE (
+  echo detected 32 bit
+  set buildfilename=.\build.bat
+)
+
+IF EXIST .\bin\nim.exe (
+  echo skipping csources\build
+) ELSE (
+  cd csources
+  rem %buildfilename%
+  %buildfilename%
+  cd ..
+)
+
+bin\nim c koch
+koch boot -d:release
+
+rem Compile Nimble and other tools
+koch tools


### PR DESCRIPTION
## SCRATCH below

EDIT1: from IRC/gitter chat
Varriount @Varriount Aug 10 22:14
@timotheecour https://gist.github.com/Varriount/8f8c0d5e5224458cbf1dcf1a8916473e
Note, that's an untested prototype.

timothee:
* there’s a bug in your code, you skipped cd csources so it pulls from nim, not csources
* why no || goto:error after koch tools?
* for the last paragraph (debug mode), isn’t that what ./koch temp is for ?

Timothee Cour @timotheecour Aug 10 23:58
* btw, the path issue is still annoying for me; I have to resort to a kludge like:
setx path “C:\… C:\Users\User\timw\nim-0.18.0_x64\nim-0.18.0\dist\mingw64\bin\” which is ugly, because finish.exe didn’t work for me (to get gcc in path); any idea?
* how about using build_all.py instead of build_all.bat ???? if user wants to hack on nim soures, asking him to have python installed is OK IMO


Varriount @Varriount Aug 11 04:32
@timotheecour The thing is, the user may have a 32-bit compiler installed on a 64-bit operating system.

