### PR TITLE
Prevent false variable injections in `quote`

### DIFF
--- a/tests/macros/t7323.nim
+++ b/tests/macros/t7323.nim
@@ -1,0 +1,13 @@
+discard """
+  output: "123"
+"""
+
+import macros
+
+macro mac(): untyped =
+  quote do:
+    proc test(): int =
+      (proc(): int = result = 123)()
+
+mac()
+echo test()

--- a/tests/macros/tquote.nim
+++ b/tests/macros/tquote.nim
@@ -1,0 +1,14 @@
+discard """
+  line: 11
+  errormsg: "undeclared identifier: \'v\'"
+"""
+
+import macros
+
+macro log(): untyped =
+  let v = 10
+  # The variable `v` is _not_ captured
+  result = quote do:
+    v
+
+discard log()


### PR DESCRIPTION
I was investigating the ICE reported by @copygirl [here](https://gist.github.com/copygirl/811c025807053db7fa2a78c68f895db7) and found that the root problem is that `sevColor` leaks into the quote'd AST (along with `sevStr` and `groupStr`).

The solution is IMO the best one here: the quoted piece of code is evaluated in a detached scope in order to avoid any kind of cross-contamination.

Let's see if the CI likes it, travis spin that disk!