### PR TITLE
Add failing test for stderr redirection on macOS

### DIFF
--- a/tests/osproc/tstderr.nim
+++ b/tests/osproc/tstderr.nim
@@ -1,0 +1,26 @@
+discard """
+  output: '''--------------------------------------
+to stderr
+to stderr
+--------------------------------------
+'''
+"""
+import osproc, os, streams
+
+const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     options={})
+
+let stdoutStream = p.outputStream
+let stderrStream = p.errorStream
+var x = newStringOfCap(120)
+var output = ""
+while stderrStream.readLine(x.TaintedString):
+  output.add(x & "\n")
+
+echo "--------------------------------------"
+stderr.write output
+echo "--------------------------------------"


### PR DESCRIPTION
This PR adds a failing test to duplicate the problem I'm seeing in #8442 on macOS.  I'll keep trying to figure out how to fix it, but so far I can't see why stderr is any different than stdout.

Here's the output from running the test:

```
FAIL: tstderr.nim C
Test "tests/osproc/tstderr.nim" in category "osproc"
Failure: reOutputsDiffer
Expected:
--------------------------------------
to stderr
to stderr
--------------------------------------


Gotten:
to stderr
to stderr
--------------------------------------
--------------------------------------
```

Also, thanks for making it so easy to figure out how to run the tests!