### PR TITLE
save a backup of csources-built nim to bin/nim_csources to avoid recompiling from csources

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -11,11 +11,20 @@ echo_run(){
 }
 
 [ -d csources ] || echo_run git clone --depth 1 https://github.com/nim-lang/csources.git
-(
+
+nim_csources=bin/nim_csources
+build_nim_csources(){
   ## avoid changing dir in case of failure
-  echo_run cd csources
-  echo_run sh build.sh
-)
+  (
+    echo_run cd csources
+    echo_run sh build.sh
+  )
+  # keep $nim_csources in case needed to investigate bootstrap issues
+  # without having to rebuild from csources
+  echo_run cp bin/nim $nim_csources
+}
+
+[ -f $nim_csources ] || echo_run build_nim_csources
 
 echo_run bin/nim c koch
 echo_run ./koch boot -d:release


### PR DESCRIPTION
keeping the `nim` build from csources is useful to avoid having to rebuild it via `csources/build.sh`  whn it's needed; 
it's needed  eg to make sure bootstrap still works, see for eg https://github.com/nim-lang/Nim/issues/8577 where problem only occurs during bootstrap, not once a bin/nim is already bootstrapped)

it also makes it more efficient to rerun `sh build_all.sh` if user wants to rebuild nim+toosl after hacking on compiler
