### PR TITLE
Fix #7913 - No output in stderr when unittest has failures

### DIFF
--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -509,7 +509,7 @@ proc main() =
   backend.close()
   var failed = r.total - r.passed - r.skipped
   if failed != 0:
-    echo "FAILURE! total: ", r.total, " passed: ", r.passed, " skipped: ", r.skipped
+    system.stderr.writeLine("FAILURE! total: ", r.total, " passed: ", r.passed, " skipped: ", r.skipped)
     quit(QuitFailure)
 
 if paramCount() == 0:


### PR DESCRIPTION
Provides a tentative fix for https://github.com/nim-lang/Nim/issues/7913.

When a program exists, if it had failures running unittests it'll print a message to stderr with the number of failures.