### PR TITLE
Fixes 8618: Force compiler bin from koch when calling nimweb

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -296,16 +296,16 @@ proc install(args: string) =
 
 proc web(args: string) =
   nimexec("js tools/dochack/dochack.nim")
-  nimexec("cc -r tools/nimweb.nim $# web/website.ini --putenv:nimversion=$#" %
-       [args, VersionAsString])
+  nimexec("cc -r tools/nimweb.nim --nimCompiler=\"$#\" $# web/website.ini --putenv:nimversion=$#" %
+       [findNim(), args, VersionAsString])
 
 proc website(args: string) =
-  nimexec("cc -r tools/nimweb.nim $# --website web/website.ini --putenv:nimversion=$#" %
-       [args, VersionAsString])
+  nimexec("cc -r tools/nimweb.nim --nimCompiler=\"$#\" $# --website web/website.ini --putenv:nimversion=$#" %
+       [findNim(), args, VersionAsString])
 
 proc pdf(args="") =
-  exec("$# cc -r tools/nimweb.nim $# --pdf web/website.ini --putenv:nimversion=$#" %
-       [findNim(), args, VersionAsString], additionalPATH=findNim().splitFile.dir)
+  exec("$# cc -r tools/nimweb.nim --nimCompiler=\"$#\" $# --pdf web/website.ini --putenv:nimversion=$#" %
+       [findNim(), findNim(), args, VersionAsString], additionalPATH=findNim().splitFile.dir)
 
 # -------------- boot ---------------------------------------------------------
 


### PR DESCRIPTION
I believe this should fix https://github.com/nim-lang/Nim/issues/8618.

It just passes along to `nimweb` whatever compiler koch has detected by itself, avoiding a potentially different resolution on nimweb.