### PR TITLE
Correctly redirect stderr when using osproc's posix_spawn backend

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -884,9 +884,11 @@ elif not defined(useNimRtl):
         chck posix_spawn_file_actions_adddup2(fops, data.pStdin[readIdx], readIdx)
         chck posix_spawn_file_actions_addclose(fops, data.pStdout[readIdx])
         chck posix_spawn_file_actions_adddup2(fops, data.pStdout[writeIdx], writeIdx)
+        chck posix_spawn_file_actions_addclose(fops, data.pStderr[readIdx])
         if (poStdErrToStdOut in data.options):
-          chck posix_spawn_file_actions_addclose(fops, data.pStderr[readIdx])
           chck posix_spawn_file_actions_adddup2(fops, data.pStdout[writeIdx], 2)
+        else:
+          chck posix_spawn_file_actions_adddup2(fops, data.pStderr[writeIdx], 2)
 
       var res: cint
       if data.workingDir.len > 0:

--- a/tests/osproc/tstderr.nim
+++ b/tests/osproc/tstderr.nim
@@ -1,0 +1,26 @@
+discard """
+  output: '''--------------------------------------
+to stderr
+to stderr
+--------------------------------------
+'''
+"""
+import osproc, os, streams
+
+const filename = when defined(Windows): "ta_out.exe" else: "ta_out"
+
+doAssert fileExists(getCurrentDir() / "tests" / "osproc" / filename)
+
+var p = startProcess(filename, getCurrentDir() / "tests" / "osproc",
+                     options={})
+
+let stdoutStream = p.outputStream
+let stderrStream = p.errorStream
+var x = newStringOfCap(120)
+var output = ""
+while stderrStream.readLine(x.TaintedString):
+  output.add(x & "\n")
+
+echo "--------------------------------------"
+stderr.write output
+echo "--------------------------------------"


### PR DESCRIPTION
Fixes #8442 