### PR TITLE
[trivial] tester.nim add more diagnostics

### DIFF
--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -262,6 +262,7 @@ proc codegenCheck(test: TTest, target: TTarget, spec: TSpec, expectedMsg: var st
     echo getCurrentExceptionMsg()
   except IOError:
     given.err = reCodeNotFound
+    echo getCurrentExceptionMsg()
 
 proc nimoutCheck(test: TTest; expectedNimout: string; given: var TSpec) =
   let exp = expectedNimout.strip.replace("\C\L", "\L")
@@ -509,7 +510,8 @@ proc main() =
   backend.close()
   var failed = r.total - r.passed - r.skipped
   if failed != 0:
-    echo "FAILURE! total: ", r.total, " passed: ", r.passed, " skipped: ", r.skipped
+    echo "FAILURE! total: ", r.total, " passed: ", r.passed, " skipped: ",
+      r.skipped, " failed: ", failed
     quit(QuitFailure)
 
 if paramCount() == 0:


### PR DESCRIPTION
* `getCurrentExceptionMsg()` was added in this block:
```
except IOError:
  given.err = reCodeNotFound
```
to provide useful diagnostics when `IOError` occur; otherwise looking at logs is not helpful:

example from a failed travis job: https://travis-ci.org/nim-lang/Nim/jobs/416117242 

with this PR we get the useful line "cannot open: nimcache/tests/pragmas/tnoreturn.nim_0d61f8370cad1d412f80b84d143e1257/.tests.pragmas.tnoreturn.c" :
```
PASS: tcopying.nim JS -d:nodejs -d:release                         (1.76057816 secs)
cannot open: nimcache/tests/pragmas/tnoreturn.nim_0d61f8370cad1d412f80b84d143e1257/.tests.pragmas.tnoreturn.c
FAIL: tnoreturn.nim C
Test "tests/pragmas/tnoreturn.nim" in category "pragmas"
Failure: reCodeNotFound
Expected:
Gotten:
```

without this PR, all we get is the enigmatic "Failure: reCodeNotFound"

* `" failed: ", failed` was added in test result output, because it's easier for readers to see how many test failed without having to do some math 