### PR TITLE
Experimental typeImports

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -68,6 +68,22 @@ proc rawImportSymbol(c: PContext, s: PSym) =
     if s.kind == skConverter: addConverter(c, s)
     if hasPattern(s): addPattern(c, s)
 
+proc maybeImportForType(c: PContext, s: PSym, t: PType) =
+  ## Imports a symbol only if it has a strict relation with a type:
+  ##
+  ##  - Proc refers to the type on any of its input or output values.
+  ##
+  ## TODO: generics are not matched currently.
+  ##
+  case s.kind
+  of skProcKinds:
+    for tt in s.typ.sons.items:
+      if t == tt:
+        rawImportSymbol(c, s)
+        break
+  else:
+    discard
+
 proc importSymbol(c: PContext, n: PNode, fromMod: PSym) =
   let ident = lookups.considerQuotedIdent(c, n)
   let s = strTableGet(fromMod.tab, ident)
@@ -88,6 +104,19 @@ proc importSymbol(c: PContext, n: PNode, fromMod: PSym) =
         if e.name.id != s.name.id: internalError(c.config, n.info, "importSymbol: 3")
         rawImportSymbol(c, e)
         e = nextIdentIter(it, fromMod.tab)
+
+    of skType:
+      # import the type as expected
+      rawImportSymbol(c, s)
+
+      # types can bring attached their related symbols too
+      if typeImports in c.features:
+        var i: TTabIter
+        var ss = initTabIter(i, fromMod.tab)
+        while ss != nil:
+          maybeImportForType(c, ss, s.typ)
+          ss = nextIter(i, fromMod.tab)
+
     else: rawImportSymbol(c, s)
 
 proc importAllSymbolsExcept(c: PContext, fromMod: PSym, exceptSet: IntSet) =

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -71,14 +71,19 @@ proc rawImportSymbol(c: PContext, s: PSym) =
 proc maybeImportForType(c: PContext, s: PSym, t: PType) =
   ## Imports a symbol only if it has a strict relation with a type:
   ##
-  ##  - Proc refers to the type on any of its input or output values.
+  ##  - callable signature refers to the type
   ##
-  ## TODO: generics are not matched currently.
-  ##
+  var m: TCandidate
+  initCandidate(c, m, t)
+
   case s.kind
   of skProcKinds:
     for tt in s.typ.sons.items:
-      if t == tt:
+      #FIXME no idea why we get nulls here
+      if tt == nil:
+        continue
+
+      if typeRel(m, tt, t) >= isSubtype:
         rawImportSymbol(c, s)
         break
   else:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -120,7 +120,8 @@ type
     notnil,
     dynamicBindSym,
     forLoopMacros,
-    caseStmtMacros
+    caseStmtMacros,
+    typeImports
 
   SymbolFilesOption* = enum
     disabledSf, writeOnlySf, readOnlySf, v2Sf

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6333,6 +6333,24 @@ It's also possible to use ``from module import nil`` if one wants to import
 the module but wants to enforce fully qualified access to every symbol
 in ``module``.
 
+By using the experimental feature ``typeImports`` it's possible to bring
+all the symbols directly related to a type. Any callable that has the imported
+type as one of its arguments or return type gets automatically included with the
+import.
+
+.. code-block:: nim
+    :test: "nim c $1"
+
+  {.experimental: "typeImports".}
+
+  from colors import Color
+
+  # to string and proc imported
+  let pink = rgb(255, 192, 203)
+  echo $pink
+  # color constants are not imported though, this would fail:
+  # echo $colBlue
+
 
 Export statement
 ~~~~~~~~~~~~~~~~

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6333,23 +6333,21 @@ It's also possible to use ``from module import nil`` if one wants to import
 the module but wants to enforce fully qualified access to every symbol
 in ``module``.
 
-By using the experimental feature ``typeImports`` it's possible to bring
-all the symbols directly related to a type. Any callable that has the imported
-type as one of its arguments or return type gets automatically included with the
-import.
+By using the experimental feature ``typeImports`` it's possible to bring any
+callable that has an imported type on its signature bundled with it.
 
 .. code-block:: nim
     :test: "nim c $1"
 
   {.experimental: "typeImports".}
 
-  from colors import Color
+  from colors import Color, colBlue
 
-  # to string and proc imported
-  let pink = rgb(255, 192, 203)
-  echo $pink
-  # color constants are not imported though, this would fail:
-  # echo $colBlue
+  # related procs and operators like `$` are implicitly imported
+  let darker = intensity(colBlue, 0.3)
+  echo $darker
+  # values are not implicitly imported, this would fail:
+  #echo $colRed
 
 
 Export statement

--- a/tests/modules/ttypeimport.nim
+++ b/tests/modules/ttypeimport.nim
@@ -1,0 +1,11 @@
+discard """
+  output: "#FFC0CB"
+"""
+
+{.experimental: "typeImports".}
+
+from colors import Color
+
+# to string and proc imported
+let pink = rgb(255, 192, 203)
+echo $pink

--- a/tests/modules/ttypeimportfail.nim
+++ b/tests/modules/ttypeimportfail.nim
@@ -1,0 +1,11 @@
+discard """
+  file: "ttypeimportfail.nim"
+  errormsg: "undeclared identifier: 'colBlue'"
+"""
+
+{.experimental: "typeImports".}
+
+from colors import Color
+
+# constants of the type not imported
+discard colBlue

--- a/tests/modules/ttypeimportgen.nim
+++ b/tests/modules/ttypeimportgen.nim
@@ -1,0 +1,12 @@
+discard """
+  output: "10"
+"""
+
+{.experimental: "typeImports".}
+
+from collections.deques import Deque
+
+var dq = initDeque[int]()
+dq.addLast(10)
+assert len(dq) == 1
+echo peekLast(dq)


### PR DESCRIPTION
Changes the behaviour of `from m import T` following the discussion at https://github.com/nim-lang/Nim/issues/8013

To be clear, since it's not exactly the same as discussed on the other issue, the behaviour implemented is:

 - Automatically include any symbol that references the imported type on its signature

That doesn't include generic types, basically because they are a tad more difficult to implement and I'm not knowledgeable enough to assert if it's something that should be allowed or not regardless of me being able to do the implementation. Comments about this more than welcome :)