### PR TITLE
Nim now supports true lambdas; eg allows map(a~>a*localVar) (wo limitations of sugar.nim `=>`)

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -639,13 +639,11 @@ template foldr*(sequence, operation: untyped): untyped =
     result = operation
   result
 
-when false:
-  template map2*(s, lambda: untyped): untyped =
+# TODO: make public after merging with `map`
+template map2(s: typed, lambda: untyped): untyped =
     ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
-    runnableExamples:
-      doAssert [1,2].map2(a=>a*10) == @[10,20]
-      let foo=3
-      doAssert [1,2].map2(a=>a*foo) == @[3,6]
+    # runnableExamples:
+    #   doAssert [1,2].map2(a=>a*10) == @[10,20]
     makeLambda(lambda, lambda2)
     type outType = type((
       block:
@@ -1170,6 +1168,7 @@ when isMainModule:
     echo "Finished doc tests"
 
   block map2Test:
-    when false:
-      # PENDING https://github.com/nim-lang/Nim/issues/7280
-      discard [1].map2(a => a)
+    # PENDING https://github.com/nim-lang/Nim/issues/7280
+    discard [1].map2(a => a)
+    # once map2 is public, remove this (will be covered by runnableExamples)
+    doAssert [1,2].map2(a=>a*10) == @[10,20]

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -645,11 +645,11 @@ template map2*(s, lambda: untyped): untyped =
     doAssert [1,2].map2(a=>a*10) == @[10,20]
     let foo=3
     doAssert [1,2].map2(a=>a*foo) == @[3,6]
-
+  makeLambda(lambda, lambda2)
   type outType = type((
     block:
       var it: type(items(s))
-      lambdaEval(lambda, it)
+      lambda2(it)
       ))
 
   when compiles(s.len):
@@ -659,13 +659,13 @@ template map2*(s, lambda: untyped): untyped =
       var i = 0
       var result = newSeq[outType](s2.len)
       for it in s2:
-        result[i] = lambdaEval(lambda, it)
+        result[i] = lambda2(it)
         i += 1
       result
   else:
     var result: seq[outType] = @[]
     for it in s:
-      result.add lambdaEval(lambda, it)
+      result.add lambda2(it)
     result
 
 template mapIt*(s, typ, op: untyped): untyped =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -639,34 +639,35 @@ template foldr*(sequence, operation: untyped): untyped =
     result = operation
   result
 
-template map2*(s, lambda: untyped): untyped =
-  ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
-  runnableExamples:
-    doAssert [1,2].map2(a=>a*10) == @[10,20]
-    let foo=3
-    doAssert [1,2].map2(a=>a*foo) == @[3,6]
-  makeLambda(lambda, lambda2)
-  type outType = type((
-    block:
-      var it: type(items(s))
-      lambda2(it)
-      ))
+when false:
+  template map2*(s, lambda: untyped): untyped =
+    ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
+    runnableExamples:
+      doAssert [1,2].map2(a=>a*10) == @[10,20]
+      let foo=3
+      doAssert [1,2].map2(a=>a*foo) == @[3,6]
+    makeLambda(lambda, lambda2)
+    type outType = type((
+      block:
+        var it: type(items(s))
+        lambda2(it)
+        ))
 
-  when compiles(s.len):
-    var result: seq[outType]
-    block:
-      evalOnceAs(s2, s, compiles((let _ = s)))
-      var i = 0
-      var result = newSeq[outType](s2.len)
-      for it in s2:
-        result[i] = lambda2(it)
-        i += 1
+    when compiles(s.len):
+      var result: seq[outType]
+      block:
+        evalOnceAs(s2, s, compiles((let _ = s)))
+        var i = 0
+        var result = newSeq[outType](s2.len)
+        for it in s2:
+          result[i] = lambda2(it)
+          i += 1
+        result
+    else:
+      var result: seq[outType] = @[]
+      for it in s:
+        result.add lambda2(it)
       result
-  else:
-    var result: seq[outType] = @[]
-    for it in s:
-      result.add lambda2(it)
-    result
 
 template mapIt*(s, typ, op: untyped): untyped =
   ## Convenience template around the ``map`` proc to reduce typing.
@@ -1169,5 +1170,6 @@ when isMainModule:
     echo "Finished doc tests"
 
   block map2Test:
-    # PENDING https://github.com/nim-lang/Nim/issues/7280
-    discard [1].map2(a => a)
+    when false:
+      # PENDING https://github.com/nim-lang/Nim/issues/7280
+      discard [1].map2(a => a)

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -641,9 +641,9 @@ template foldr*(sequence, operation: untyped): untyped =
 
 # TODO: make public after merging with `map`
 template map2(s: typed, lambda: untyped): untyped =
-    ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
+    ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a ~> a*10)``
     # runnableExamples:
-    #   doAssert [1,2].map2(a=>a*10) == @[10,20]
+    #   doAssert [1,2].map2(a~>a*10) == @[10,20]
     makeLambda(lambda, lambda2)
     type outType = type((
       block:
@@ -1169,6 +1169,6 @@ when isMainModule:
 
   block map2Test:
     # PENDING https://github.com/nim-lang/Nim/issues/7280
-    discard [1].map2(a => a)
+    discard [1].map2(a ~> a)
     # once map2 is public, remove this (will be covered by runnableExamples)
-    doAssert [1,2].map2(a=>a*10) == @[10,20]
+    doAssert [1,2].map2(a ~> a*10) == @[10,20]

--- a/lib/pure/lambda.nim
+++ b/lib/pure/lambda.nim
@@ -1,6 +1,17 @@
 import macros
 
-macro lambdaEval*(lambda: untyped, arg:typed):untyped=
+# TODO: make this public in subsequent PR
+macro varargsToTuple(args:varargs[untyped]):untyped=
+  result = newTree(nnkTupleConstr)
+  if args.len != 1:
+    for a in args:
+      result.add a
+  else:
+    # PENDING https://github.com/nim-lang/Nim/issues/8706
+    if args[0].kind != nnkHiddenStdConv:
+        result.add args[0]
+
+macro lambdaEval*(lambda: untyped, arg:tuple):untyped=
   ## allows using zero-cost lambda expressions ``a=>b`` in templates. Type
   ## inference is done at evaluation site, so user doesn't need to specify
   ## types in the lambda expression.
@@ -11,8 +22,22 @@ macro lambdaEval*(lambda: untyped, arg:typed):untyped=
 
   if $lambda[0] != "=>":
     error("Expected `=>` got " & $lambda[0])
+
   var ret = newStmtList()
-  ret.add newLetStmt(lambda[1], arg)
+  expectKind(arg, nnkTupleConstr)
+  case lambda[1].kind
+  of nnkPar: # (a, b) => expr
+    if lambda[1].len != arg.len:
+      error("size mismatch: lambda:" & $lambda[1].len & " arg:" & $arg.len)
+    for i in 0..<lambda[1].len:
+      ret.add newLetStmt(lambda[1][i], arg[i])
+  of nnkIdent: # a => expr
+      if arg.len != 1:
+        error("size mismatch: " & $arg.len)
+      ret.add newLetStmt(lambda[1], arg[0])
+  else:
+    error("expected " & ${nnkPar,nnkIdent} & " got " & $lambda[1].kind)
+
   ret.add lambda[2]
   result = newBlockStmt(ret)
 
@@ -20,18 +45,26 @@ macro makeLambda*(lambdaFun: untyped, lambdaAlias:untyped): untyped =
   ## convenience macro allowing one to use ``lambda(arg)`` instead of
   ## ``lambdaEval(fun, arg)``
   runnableExamples:
-    template testCallFun[T](fun: untyped, a:T): auto =
-      makeLambda(fun, lambda)
-      lambda(lambda(a))
-    doAssert testCallFun(x => x * 3, 2) == (2 * 3) * 3
+    block:
+      template testCallFun[T](fun: untyped, a:T): auto =
+        makeLambda(fun, lambda)
+        lambda(lambda(a))
+      doAssert testCallFun(x => x * 3, 2) == (2 * 3) * 3
+
+    block:
+      template testCallFun2[T](fun: untyped, a:T, b:T): auto =
+        makeLambda(fun, lambda)
+        lambda(a, b)
+      doAssert testCallFun2((u,v) => u*v, 10, 11) == 10 * 11
 
   expectKind(lambdaAlias, nnkIdent)
   result = quote do:
-    template `lambdaAlias`(arg:untyped): untyped = lambdaEval(`lambdaFun`, arg)
+    template `lambdaAlias`(args:varargs[untyped]): untyped =
+      lambdaEval(`lambdaFun`, varargsToTuple(args))
 
 when isMainModule:
   # PENDING https://github.com/nim-lang/Nim/issues/7280
   block lambdaEvalTest:
-    discard lambdaEval(a => a, 0)
+    discard lambdaEval(a => a, (0,))
   block makeLambdaTest:
     makeLambda(a => a, _)

--- a/lib/pure/lambda.nim
+++ b/lib/pure/lambda.nim
@@ -1,9 +1,22 @@
 import macros
 
 macro lambdaEval*(lambda: untyped, arg:typed):untyped=
+  ## allows using zero-cost lambda expressions ``a=>b`` in templates. Type
+  ## inference is done at evaluation site, so user doesn't need to specify
+  ## types in the lambda expression.
+  runnableExamples:
+    template testCallFun[T](fun: untyped, a:T): auto =
+      lambdaEval(fun, lambdaEval(fun, a))
+    doAssert testCallFun(x => x * 3, 2) == (2 * 3) * 3
+
   if $lambda[0] != "=>":
     error("Expected `=>` got " & $lambda[0])
   var ret = newStmtList()
   ret.add newLetStmt(lambda[1], arg)
   ret.add lambda[2]
   result = newBlockStmt(ret)
+
+when isMainModule:
+  block lambdaEvalTest:
+    # PENDING https://github.com/nim-lang/Nim/issues/7280
+    discard lambdaEval(a => a, 0)

--- a/lib/pure/lambda.nim
+++ b/lib/pure/lambda.nim
@@ -1,0 +1,9 @@
+import macros
+
+macro lambdaEval*(lambda: untyped, arg:typed):untyped=
+  if $lambda[0] != "=>":
+    error("Expected `=>` got " & $lambda[0])
+  var ret = newStmtList()
+  ret.add newLetStmt(lambda[1], arg)
+  ret.add lambda[2]
+  result = newBlockStmt(ret)

--- a/lib/pure/lambda.nim
+++ b/lib/pure/lambda.nim
@@ -16,7 +16,22 @@ macro lambdaEval*(lambda: untyped, arg:typed):untyped=
   ret.add lambda[2]
   result = newBlockStmt(ret)
 
+macro makeLambda*(lambdaFun: untyped, lambdaAlias:untyped): untyped =
+  ## convenience macro allowing one to use ``lambda(arg)`` instead of
+  ## ``lambdaEval(fun, arg)``
+  runnableExamples:
+    template testCallFun[T](fun: untyped, a:T): auto =
+      makeLambda(fun, lambda)
+      lambda(lambda(a))
+    doAssert testCallFun(x => x * 3, 2) == (2 * 3) * 3
+
+  expectKind(lambdaAlias, nnkIdent)
+  result = quote do:
+    template `lambdaAlias`(arg:untyped): untyped = lambdaEval(`lambdaFun`, arg)
+
 when isMainModule:
+  # PENDING https://github.com/nim-lang/Nim/issues/7280
   block lambdaEvalTest:
-    # PENDING https://github.com/nim-lang/Nim/issues/7280
     discard lambdaEval(a => a, 0)
+  block makeLambdaTest:
+    makeLambda(a => a, _)

--- a/lib/pure/lambda.nim
+++ b/lib/pure/lambda.nim
@@ -12,26 +12,26 @@ macro varargsToTuple(args:varargs[untyped]):untyped=
         result.add args[0]
 
 macro lambdaEval*(lambda: untyped, arg:tuple):untyped=
-  ## allows using zero-cost lambda expressions ``a=>b`` in templates. Type
+  ## allows using zero-cost lambda expressions ``a~>b`` in templates. Type
   ## inference is done at evaluation site, so user doesn't need to specify
   ## types in the lambda expression.
   runnableExamples:
     template testCallFun[T](fun: untyped, a:T): auto =
       lambdaEval(fun, lambdaEval(fun, a))
-    doAssert testCallFun(x => x * 3, 2) == (2 * 3) * 3
+    doAssert testCallFun(x ~> x * 3, 2) == (2 * 3) * 3
 
-  if $lambda[0] != "=>":
-    error("Expected `=>` got " & $lambda[0])
+  if $lambda[0] != "~>":
+    error("Expected `~>` got " & $lambda[0])
 
   var ret = newStmtList()
   expectKind(arg, nnkTupleConstr)
   case lambda[1].kind
-  of nnkPar: # (a, b) => expr
+  of nnkPar: # (a, b) ~> expr
     if lambda[1].len != arg.len:
       error("size mismatch: lambda:" & $lambda[1].len & " arg:" & $arg.len)
     for i in 0..<lambda[1].len:
       ret.add newLetStmt(lambda[1][i], arg[i])
-  of nnkIdent: # a => expr
+  of nnkIdent: # a ~> expr
       if arg.len != 1:
         error("size mismatch: " & $arg.len)
       ret.add newLetStmt(lambda[1], arg[0])
@@ -49,13 +49,13 @@ macro makeLambda*(lambdaFun: untyped, lambdaAlias:untyped): untyped =
       template testCallFun[T](fun: untyped, a:T): auto =
         makeLambda(fun, lambda)
         lambda(lambda(a))
-      doAssert testCallFun(x => x * 3, 2) == (2 * 3) * 3
+      doAssert testCallFun(x ~> x * 3, 2) == (2 * 3) * 3
 
     block:
       template testCallFun2[T](fun: untyped, a:T, b:T): auto =
         makeLambda(fun, lambda)
         lambda(a, b)
-      doAssert testCallFun2((u,v) => u*v, 10, 11) == 10 * 11
+      doAssert testCallFun2((u,v) ~> u*v, 10, 11) == 10 * 11
 
   expectKind(lambdaAlias, nnkIdent)
   result = quote do:
@@ -65,6 +65,6 @@ macro makeLambda*(lambdaFun: untyped, lambdaAlias:untyped): untyped =
 when isMainModule:
   # PENDING https://github.com/nim-lang/Nim/issues/7280
   block lambdaEvalTest:
-    discard lambdaEval(a => a, (0,))
+    discard lambdaEval(a ~> a, (0,))
   block makeLambdaTest:
-    makeLambda(a => a, _)
+    makeLambda(a ~> a, _)

--- a/tests/stdlib/tlambda.nim
+++ b/tests/stdlib/tlambda.nim
@@ -1,0 +1,100 @@
+discard """
+"""
+
+import macros
+import lambda
+
+import typetraits
+
+block: # 0-param lambda
+  template testLambda(fun: untyped): auto =
+    makeLambda(fun, lambda)
+    # doAssert: not compiles(lambda(10))
+    lambda()
+
+  doAssert testLambda(() => 100) == 100
+
+block: # 1-param lambda
+  template testLambda[T](fun: untyped, a:T): auto =
+    makeLambda(fun, lambda)
+    lambda(a)
+
+  doAssert testLambda(a => a*10, 2) == 20
+
+block: # 2-param lambda
+  template testLambda[T](fun: untyped, a:T, b:T): auto =
+    makeLambda(fun, lambda)
+    lambda(a,b)
+
+  doAssert testLambda((u1,u2) => u1*u2, 2, 3) == 2 * 3
+
+block: # 3-param lambda
+  template testLambda[T](fun: untyped, a:T, b:T, c:T): auto =
+    makeLambda(fun, lambda)
+    when false:
+      # BUG: SIGSEGV: Illegal storage access
+      doAssert: not compiles(lambda(a,b))
+      # but `lambda(a,b)` correctly gives compile error
+    lambda(a,b,c)
+
+  doAssert testLambda((u1,u2,u3) => u1*u2*u3, 2, 3, 4) == 2 * 3 * 4
+
+block: # multiple lambda application
+  template testLambda[T](fun: untyped, a:T): auto =
+    makeLambda(fun, lambda)
+    lambda(lambda(a))
+  doAssert testLambda(x => x * 3, 2) == (2 * 3) * 3
+
+block: # lambda with local param
+  template testLambda[T](fun: untyped, a:T): auto =
+    makeLambda(fun, lambda)
+    lambda a
+  let x = 10
+  doAssert testLambda(u => u * x, 11) == 11 * x
+
+block: # nested lambda
+  template testLambda1[T](fun: untyped, a:T): auto =
+    makeLambda(fun, lambda)
+    lambda(a)
+  template testLambda2[T](fun: untyped, a:T): auto =
+    makeLambda(fun, lambda)
+    lambda a
+  doAssert testLambda1(u => u + testLambda2(v => v*3, u), 100) == 100 + 100*3
+
+block: # multiple lambdas
+  template testLambda[T](fun1: untyped, fun2: untyped, a:T, b:T): auto =
+    makeLambda(fun1, lambda1)
+    makeLambda(fun2, lambda2)
+    (lambda1(a,b), lambda2(a,b))
+
+  doAssert testLambda((u1,u2) => u1*u2, (u1,u2) => u1+u2, 2, 3) == (2 * 3, 2 + 3)
+
+block:
+  template map2(s, lambda: untyped): untyped =
+    ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
+    makeLambda(lambda, lambda2)
+    type outType = type((
+      block:
+        var it: type(items(s))
+        lambda2(it)
+        ))
+
+    when compiles(s.len):
+      block:
+        # Note: a more robust implementation would use `evalOnceAs`, see `mapIt`
+        let s2=s
+        var i = 0
+        var result = newSeq[outType](s2.len)
+        for it in s2:
+          result[i] = lambda2(it)
+          i += 1
+        result
+    else:
+      var result: seq[outType] = @[]
+      for it in s:
+        result.add lambda2(it)
+      result
+
+  doAssert [1,2].map2(a => a*10) == @[10, 20]
+  let foo=3
+  doAssert [1,2].map2(a => a*foo) == @[3, 6]

--- a/tests/stdlib/tlambda.nim
+++ b/tests/stdlib/tlambda.nim
@@ -70,7 +70,7 @@ block: # multiple lambdas
   doAssert testLambda((u1,u2) => u1*u2, (u1,u2) => u1+u2, 2, 3) == (2 * 3, 2 + 3)
 
 block:
-  template map2(s, lambda: untyped): untyped =
+  template map2(s: typed, lambda: untyped): untyped =
     ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
     makeLambda(lambda, lambda2)
     type outType = type((

--- a/tests/stdlib/tlambda.nim
+++ b/tests/stdlib/tlambda.nim
@@ -12,21 +12,21 @@ block: # 0-param lambda
     # doAssert: not compiles(lambda(10))
     lambda()
 
-  doAssert testLambda(() => 100) == 100
+  doAssert testLambda(() ~> 100) == 100
 
 block: # 1-param lambda
   template testLambda[T](fun: untyped, a:T): auto =
     makeLambda(fun, lambda)
     lambda(a)
 
-  doAssert testLambda(a => a*10, 2) == 20
+  doAssert testLambda(a ~> a*10, 2) == 20
 
 block: # 2-param lambda
   template testLambda[T](fun: untyped, a:T, b:T): auto =
     makeLambda(fun, lambda)
     lambda(a,b)
 
-  doAssert testLambda((u1,u2) => u1*u2, 2, 3) == 2 * 3
+  doAssert testLambda((u1,u2) ~> u1*u2, 2, 3) == 2 * 3
 
 block: # 3-param lambda
   template testLambda[T](fun: untyped, a:T, b:T, c:T): auto =
@@ -37,20 +37,20 @@ block: # 3-param lambda
       # but `lambda(a,b)` correctly gives compile error
     lambda(a,b,c)
 
-  doAssert testLambda((u1,u2,u3) => u1*u2*u3, 2, 3, 4) == 2 * 3 * 4
+  doAssert testLambda((u1,u2,u3) ~> u1*u2*u3, 2, 3, 4) == 2 * 3 * 4
 
 block: # multiple lambda application
   template testLambda[T](fun: untyped, a:T): auto =
     makeLambda(fun, lambda)
     lambda(lambda(a))
-  doAssert testLambda(x => x * 3, 2) == (2 * 3) * 3
+  doAssert testLambda(x ~> x * 3, 2) == (2 * 3) * 3
 
 block: # lambda with local param
   template testLambda[T](fun: untyped, a:T): auto =
     makeLambda(fun, lambda)
     lambda a
   let x = 10
-  doAssert testLambda(u => u * x, 11) == 11 * x
+  doAssert testLambda(u ~> u * x, 11) == 11 * x
 
 block: # nested lambda
   template testLambda1[T](fun: untyped, a:T): auto =
@@ -59,7 +59,7 @@ block: # nested lambda
   template testLambda2[T](fun: untyped, a:T): auto =
     makeLambda(fun, lambda)
     lambda a
-  doAssert testLambda1(u => u + testLambda2(v => v*3, u), 100) == 100 + 100*3
+  doAssert testLambda1(u ~> u + testLambda2(v ~> v*3, u), 100) == 100 + 100*3
 
 block: # multiple lambdas
   template testLambda[T](fun1: untyped, fun2: untyped, a:T, b:T): auto =
@@ -67,11 +67,11 @@ block: # multiple lambdas
     makeLambda(fun2, lambda2)
     (lambda1(a,b), lambda2(a,b))
 
-  doAssert testLambda((u1,u2) => u1*u2, (u1,u2) => u1+u2, 2, 3) == (2 * 3, 2 + 3)
+  doAssert testLambda((u1,u2) ~> u1*u2, (u1,u2) ~> u1+u2, 2, 3) == (2 * 3, 2 + 3)
 
 block:
   template map2(s: typed, lambda: untyped): untyped =
-    ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a => a*10)``
+    ## like ``mapIt`` but with cleaner syntax: ``[1,2].mapIt(a ~> a*10)``
     makeLambda(lambda, lambda2)
     type outType = type((
       block:
@@ -95,6 +95,6 @@ block:
         result.add lambda2(it)
       result
 
-  doAssert [1,2].map2(a => a*10) == @[10, 20]
+  doAssert [1,2].map2(a ~> a*10) == @[10, 20]
   let foo=3
-  doAssert [1,2].map2(a => a*foo) == @[3, 6]
+  doAssert [1,2].map2(a ~> a*foo) == @[3, 6]


### PR DESCRIPTION
I found a clean design to support lambdas in Nim via `a ~> some_expr(a)`
**EDIT** it now works with 0 or more arguments, eg: `() ~> expr` ; `a~>expr`, `(a,b)~>expr`

## advantages over `=>` from sugar.nim
* it's zero-cost, unlike sugar.nim's `=>` because the code is inlined (instead of requiring a function pointer indirection)
* it doesn't have the type inference limitations of `=>` from `sugar.nim (see https://github.com/nim-lang/Nim/issues/7435 : sugar's => requires type annotations in generics)
* it works with generics, unlike unlike sugar.nim's `=>` (see https://github.com/nim-lang/Nim/issues/7816)

## advantages over something like `mapIt(expr(it))` or `foldl(expr(a,b))`
* hardcoding `it` is too magical, unhygienic and less familiar than `~>` (eg [1] [2])
* hardcoding `a,b` in `foldl` is even worse, **as it's not even in `fold` function name** (the user has to know which template uses the magic variables)
* `mapIt` doesn't allow nesting (`it` , eg: `file.byLine.mapIt(it.split.mapIt(bar(it)))` won't work
* not clear how `mapIt` style could be extended for passing multiple lambdas
* simpler and more explicit (`lambda(a)`) use inside the template that uses the lambda: no need for `inject`
* it works with arbitrary number of arguments without magic conventions  (unlike implicit magic ones in `(1~>it, 2~>a,b etc)` in `mapIt`, `foldl`)

## example usage
```nim
template testCallFun[T](fun: untyped, a:T): auto =
  makeLambda(fun, lambda)
  lambda(lambda(a))

doAssert testCallFun(x ~> x * 3, 2) == (2 * 3) * 3

# after lambda-ifying sort, map etc
s.sort((a,b) ~> a.score < b.score)
s.sortBy(a ~> a.score)
echo stdin.byLine.map(a ~> a.splitter.filter(b ~>b.startsWith("foo")).toSeq
```

## fixes these:
* fixes this: type inference with lambdas doesn't work (requires explicit types) #7435
(provides a better way for lambdas than sugar's`=>` which are not as powerful)
* fixes: `map` shouldn't care whether proc arg is `cdecl` #8303
* fixes: future/sugar `=>` syntax breaks with generics #7816
* fixes; Cannot instantiate T from `=>` in generic #7399
* obsoletes this RFC (IMO): RFC: Placeholder AST nodes #8678
* obsoletes this RFC (IMO): Lambda expression (with inferred placeholders) #8675 
 (provides a better way)

## tasks for future PR's
- [ ] allow passing a regular proc in place of a lambda expression for `makeLambda`
- [ ] allow passing a compile time string for `makeLambda`
- [ ] type constraint: `(a:int, b) => expr(a,b)`
- [ ] find a better name for `map2` ; maybe just name it `map` and make sure everything works as before for clients of previous`map` function
- [ ] deprecate `mapIt`; `map2` is cleaner
- [ ] are there still use cases for `do` notation given this? (eg: `f2 = filter(colors) do (x: string) -> bool : x.len > 5`)
- [x] are there still use cases for `=>` from sugar.nim given this? 
return a function pointer

## Notes
* this enables parity with D's lambda's 
* this makes it zero-cost to pass lambdas in functions, eg could be used here: https://github.com/nim-lang/Nim/pull/8673 (and lots of places)

[1] https://github.com/nim-lang/Nim/issues/8675#issuecomment-413821795)
> I'm not sure about the final syntax but I always thought the "it" in mapIt and the a and b in foldl just came out of nowhere.

[2] https://github.com/nim-lang/Nim/issues/8675#issuecomment-413989537