### PR TITLE
make config.nims behave like nim.cfg in terms of where these scripts are searched / run

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -6,16 +6,16 @@ import
   compiler/[options, idents, nimconf, scriptconfig, extccomp, commands, msgs, lineinfos, modulegraphs, condsyms],
   std/os
 
-type NimProg* = ref object
-  name*: string
-  suggestMode*: bool
-  supportsStdinFile*: bool
-  processCmdLine*: proc(pass: TCmdLinePass, cmd: string; config: ConfigRef)
-  mainCommand*: proc(graph: ModuleGraph)
+type
+  NimProg* = ref object
+    suggestMode*: bool
+    supportsStdinFile*: bool
+    processCmdLine*: proc(pass: TCmdLinePass, cmd: string; config: ConfigRef)
+    mainCommand*: proc(graph: ModuleGraph)
 
-proc initDefinesProg*(self: NimProg, conf: ConfigRef) =
+proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   condsyms.initDefines(conf.symbols)
-  defineSymbol conf.symbols, self.name
+  defineSymbol conf.symbols, name
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
   self.processCmdLine(passCmd1, "", conf)

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -1,0 +1,83 @@
+## Helpers for binaries that use compiler passes, eg: nim, nimsuggest, nimfix
+
+# TODO: nimfix should use this; currently out of sync
+
+import
+  compiler/[options, idents, nimconf, scriptconfig, extccomp, commands, msgs, lineinfos, modulegraphs, condsyms],
+  std/os
+
+type ProgBase* = ref object of RootObj
+  name*: string
+  suggestMode*: bool
+
+method processCmdLine(self: ProgBase, pass: TCmdLinePass, cmd: string; config: ConfigRef) {.base.} =
+  doAssert false
+
+method mainCommand(self: ProgBase, graph: ModuleGraph) {.base.} =
+  doAssert false
+
+proc initDefinesProg*(self: ProgBase, conf: ConfigRef) =
+  condsyms.initDefines(conf.symbols)
+  defineSymbol conf.symbols, self.name
+
+proc processCmdLineAndProjectPath*(self: ProgBase, conf: ConfigRef) =
+  self.processCmdLine(passCmd1, "", conf)
+  if conf.projectName == "-":
+    conf.projectName = "stdinfile"
+    conf.projectFull = "stdinfile"
+    conf.projectPath = canonicalizePath(conf, getCurrentDir())
+    conf.projectIsStdin = true
+  elif conf.projectName != "":
+    try:
+      conf.projectFull = canonicalizePath(conf, conf.projectName)
+    except OSError:
+      conf.projectFull = conf.projectName
+    let p = splitFile(conf.projectFull)
+    let dir = if p.dir.len > 0: p.dir else: getCurrentDir()
+    conf.projectPath = canonicalizePath(conf, dir)
+    conf.projectName = p.name
+  else:
+    conf.projectPath = canonicalizePath(conf, getCurrentDir())
+
+proc loadConfigsAndRunMainCommand*(self: ProgBase, cache: IdentCache; conf: ConfigRef): bool =
+  loadConfigs(DefaultConfig, cache, conf) # load all config files
+  if self.suggestMode:
+    conf.command = "nimsuggest"
+
+  proc runNimScriptIfExists(scriptFile: string)=
+    if fileExists(scriptFile):
+      runNimScript(cache, scriptFile, freshDefines=false, conf)
+
+  # TODO:
+  # merge this complex logic with `loadConfigs`
+  # check whether these should be controlled via
+  # optSkipConfigFile, optSkipUserConfigFile
+  const configNims = "config.nims"
+  runNimScriptIfExists(getSystemConfigPath(conf, configNims))
+  runNimScriptIfExists(getUserConfigPath(configNims))
+  runNimScriptIfExists(conf.projectPath / configNims)
+  block:
+    let scriptFile = conf.projectFull.changeFileExt("nims")
+    if not self.suggestMode:
+      runNimScriptIfExists(scriptFile)
+      # 'nim foo.nims' means to just run the NimScript file and do nothing more:
+      if fileExists(scriptFile) and scriptFile.cmpPaths(conf.projectFull) == 0:
+        return false
+    else:
+      if scriptFile.cmpPaths(conf.projectFull) != 0:
+        runNimScriptIfExists(scriptFile)
+      else:
+        # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
+        discard
+
+  # now process command line arguments again, because some options in the
+  # command line can overwite the config file's settings
+  extccomp.initVars(conf)
+  self.processCmdLine(passCmd2, "", conf)
+  if conf.command == "":
+    rawMessage(conf, errGenerated, "command missing")
+
+  let graph = newModuleGraph(cache, conf)
+  graph.suggestMode = self.suggestMode
+  self.mainCommand(graph)
+  return true

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -651,7 +651,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     else: localError(conf, info, "invalid option for --symbolFiles: " & arg)
   of "skipcfg":
     expectNoArg(conf, switch, arg, pass, info)
-    incl(conf.globalOptions, optSkipConfigFile)
+    incl(conf.globalOptions, optSkipSystemConfigFile)
   of "skipprojcfg":
     expectNoArg(conf, switch, arg, pass, info)
     incl(conf.globalOptions, optSkipProjConfigFile)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -81,13 +81,13 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       conf.projectPath = canonicalizePath(conf, getCurrentDir())
     loadConfigs(DefaultConfig, cache, conf) # load all config files
     let scriptFile = conf.projectFull.changeFileExt("nims")
+    if fileExists(conf.projectPath / "config.nims"):
+      # directory wide NimScript file
+      runNimScript(cache, conf.projectPath / "config.nims", freshDefines=false, conf)
     if fileExists(scriptFile):
       runNimScript(cache, scriptFile, freshDefines=false, conf)
       # 'nim foo.nims' means to just run the NimScript file and do nothing more:
       if scriptFile == conf.projectFull: return
-    elif fileExists(conf.projectPath / "config.nims"):
-      # directory wide NimScript file
-      runNimScript(cache, conf.projectPath / "config.nims", freshDefines=false, conf)
     # now process command line arguments again, because some options in the
     # command line can overwite the config file's settings
     extccomp.initVars(conf)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -58,12 +58,11 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
 
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   let self = NimProg(
-    name: "nim_compiler",
     supportsStdinFile: true,
     processCmdLine: processCmdLine,
     mainCommand: mainCommand
   )
-  self.initDefinesProg(conf)
+  self.initDefinesProg(conf, "nim_compiler")
   if paramCount() == 0:
     writeCommandLineUsage(conf, conf.helpWritten)
     return

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -85,8 +85,14 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       if fileExists(scriptFile):
         runNimScript(cache, scriptFile, freshDefines=false, conf)
 
-    runNimScriptIfExists(getConfigDir() / "nim" / "config.nims")
-    runNimScriptIfExists(conf.projectPath / "config.nims")
+    # TODO:
+    # merge this complex logic with `loadConfigs`
+    # check whether these should be controlled via
+    # optSkipConfigFile, optSkipUserConfigFile
+    let config_nims = "config.nims"
+    runNimScriptIfExists(getSystemConfigPath(conf, config_nims))
+    runNimScriptIfExists(getUserConfigPath(config_nims))
+    runNimScriptIfExists(conf.projectPath / config_nims)
     block:
       let scriptFile = conf.projectFull.changeFileExt("nims")
       runNimScriptIfExists(scriptFile)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -81,7 +81,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       conf.projectPath = canonicalizePath(conf, getCurrentDir())
     loadConfigs(DefaultConfig, cache, conf) # load all config files
 
-    proc runNimScriptIfExists(scriptFile:string)=
+    proc runNimScriptIfExists(scriptFile: string)=
       if fileExists(scriptFile):
         runNimScript(cache, scriptFile, freshDefines=false, conf)
 
@@ -89,15 +89,15 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
     # merge this complex logic with `loadConfigs`
     # check whether these should be controlled via
     # optSkipConfigFile, optSkipUserConfigFile
-    let config_nims = "config.nims"
-    runNimScriptIfExists(getSystemConfigPath(conf, config_nims))
-    runNimScriptIfExists(getUserConfigPath(config_nims))
-    runNimScriptIfExists(conf.projectPath / config_nims)
+    const configNims = "config.nims"
+    runNimScriptIfExists(getSystemConfigPath(conf, configNims))
+    runNimScriptIfExists(getUserConfigPath(configNims))
+    runNimScriptIfExists(conf.projectPath / configNims)
     block:
       let scriptFile = conf.projectFull.changeFileExt("nims")
       runNimScriptIfExists(scriptFile)
       # 'nim foo.nims' means to just run the NimScript file and do nothing more:
-      if fileExists(scriptFile) and scriptFile == conf.projectFull: return
+      if fileExists(scriptFile) and scriptFile.cmpPaths(conf.projectFull) == 0: return
 
     # now process command line arguments again, because some options in the
     # command line can overwite the config file's settings

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -37,9 +37,7 @@ proc prependCurDir(f: string): string =
   else:
     result = f
 
-type ProgNim=ref object of ProgBase
-
-method processCmdLine(self: ProgNim, pass: TCmdLinePass, cmd: string; config: ConfigRef) =
+proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
   var p = parseopt.initOptParser(cmd)
   var argsCount = 0
   while true:
@@ -58,11 +56,13 @@ method processCmdLine(self: ProgNim, pass: TCmdLinePass, cmd: string; config: Co
     if optRun notin config.globalOptions and config.arguments.len > 0 and config.command.normalize != "run":
       rawMessage(config, errGenerated, errArgsNeedRunOption)
 
-method mainCommand(self: ProgNim, graph: ModuleGraph)=
-  mainCommand(graph)
-
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
-  let self = ProgNim(name: "nim_compiler")
+  let self = NimProg(
+    name: "nim_compiler",
+    supportsStdinFile: true,
+    processCmdLine: processCmdLine,
+    mainCommand: mainCommand
+  )
   self.initDefinesProg(conf)
   if paramCount() == 0:
     writeCommandLineUsage(conf, conf.helpWritten)

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -219,10 +219,10 @@ proc readConfigFile(
     closeLexer(L)
     return true
 
-proc getUserConfigPath(filename: string): string =
+proc getUserConfigPath*(filename: string): string =
   result = joinPath([getConfigDir(), "nim", filename])
 
-proc getSystemConfigPath(conf: ConfigRef; filename: string): string =
+proc getSystemConfigPath*(conf: ConfigRef; filename: string): string =
   # try standard configuration file (installation did not distribute files
   # the UNIX way)
   let p = getPrefixDir(conf)

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -241,7 +241,7 @@ proc loadConfigs*(cfg: string; cache: IdentCache; conf: ConfigRef) =
     if readConfigFile(configPath, cache, conf):
       add(configFiles, configPath)
 
-  if optSkipConfigFile notin conf.globalOptions:
+  if optSkipSystemConfigFile notin conf.globalOptions:
     readConfigFile(getSystemConfigPath(conf, cfg))
 
   if optSkipUserConfigFile notin conf.globalOptions:
@@ -263,4 +263,5 @@ proc loadConfigs*(cfg: string; cache: IdentCache; conf: ConfigRef) =
       readConfigFile(projectConfig)
 
   for filename in configFiles:
+    # delayed to here so that `hintConf` is honored
     rawMessage(conf, hintConf, filename)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -54,10 +54,10 @@ type                          # please make sure we have under 32 options
     optGenMapping,            # generate a mapping file
     optRun,                   # run the compiled project
     optCheckNep1,             # check that the names adhere to NEP-1
-    optSkipConfigFile,        # skip the general config file
-    optSkipProjConfigFile,    # skip the project's config file
-    optSkipUserConfigFile,    # skip the users's config file
-    optSkipParentConfigFiles, # skip parent dir's config files
+    optSkipSystemConfigFile,  # skip the system's cfg/nims config file
+    optSkipProjConfigFile,    # skip the project's cfg/nims config file
+    optSkipUserConfigFile,    # skip the users's cfg/nims config file
+    optSkipParentConfigFiles, # skip parent dir's cfg/nims config files
     optNoMain,                # do not generate a "main" proc
     optUseColors,             # use colors for hints, warnings, and errors
     optThreads,               # support for multi-threading
@@ -391,6 +391,7 @@ const
   TexExt* = "tex"
   IniExt* = "ini"
   DefaultConfig* = "nim.cfg"
+  DefaultConfigNims* = "config.nims"
   DocConfig* = "nimdoc.cfg"
   DocTexConfig* = "nimdoc.tex.cfg"
 

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -171,7 +171,7 @@ proc runNimScript*(cache: IdentCache; scriptName: string;
   incl(m.flags, sfMainModule)
   graph.vm = setupVM(m, cache, scriptName, graph)
 
-  graph.compileSystemModule()
+  graph.compileSystemModule() # TODO: see why this unsets hintConf in conf.notes
   discard graph.processModule(m, llStreamOpen(scriptName, fmRead))
 
   # ensure we load 'system.nim' again for the real non-config stuff!

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -487,9 +487,7 @@ proc mainThread(graph: ModuleGraph) =
 var
   inputThread: Thread[ThreadParams]
 
-type ProgNimsuggest=ref object of ProgBase
-
-method mainCommand(self: ProgNimsuggest, graph: ModuleGraph) =
+proc mainCommand(graph: ModuleGraph) =
   let conf = graph.config
   clearPasses(graph)
   registerPass graph, verbosePass
@@ -584,7 +582,12 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
       # if processArgument(pass, p, argsCount): break
 
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
-  let self = ProgNimsuggest(suggestMode: true, name: "nimsuggest")
+  let self = NimProg(
+    name: "nimsuggest",
+    suggestMode: true,
+    processCmdLine: processCmdLine,
+    mainCommand: mainCommand
+  )
   self.initDefinesProg(conf)
 
   if paramCount() == 0:

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -583,12 +583,11 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
 
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   let self = NimProg(
-    name: "nimsuggest",
     suggestMode: true,
     processCmdLine: processCmdLine,
     mainCommand: mainCommand
   )
-  self.initDefinesProg(conf)
+  self.initDefinesProg(conf, "nimsuggest")
 
   if paramCount() == 0:
     stdout.writeline(Usage)

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -20,7 +20,7 @@ import compiler / [options, commands, modules, sem,
   passes, passaux, msgs, nimconf,
   extccomp, condsyms,
   sigmatch, ast, scriptconfig,
-  idents, modulegraphs, vm, prefixmatches, lineinfos]
+  idents, modulegraphs, vm, prefixmatches, lineinfos, cmdlinehelper]
 
 when defined(windows):
   import winlean
@@ -487,7 +487,9 @@ proc mainThread(graph: ModuleGraph) =
 var
   inputThread: Thread[ThreadParams]
 
-proc mainCommand(graph: ModuleGraph) =
+type ProgNimsuggest=ref object of ProgBase
+
+method mainCommand(self: ProgNimsuggest, graph: ModuleGraph) =
   let conf = graph.config
   clearPasses(graph)
   registerPass graph, verbosePass
@@ -582,55 +584,28 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
       # if processArgument(pass, p, argsCount): break
 
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
-  condsyms.initDefines(conf.symbols)
-  defineSymbol conf.symbols, "nimsuggest"
+  let self = ProgNimsuggest(suggestMode: true, name: "nimsuggest")
+  self.initDefinesProg(conf)
 
   if paramCount() == 0:
     stdout.writeline(Usage)
-  else:
-    processCmdLine(passCmd1, "", conf)
-    if gMode != mstdin:
-      conf.writelnHook = proc (msg: string) = discard
-    if conf.projectName != "":
-      try:
-        conf.projectFull = canonicalizePath(conf, conf.projectName)
-      except OSError:
-        conf.projectFull = conf.projectName
-      var p = splitFile(conf.projectFull)
-      conf.projectPath = canonicalizePath(conf, p.dir)
-      conf.projectName = p.name
-    else:
-      conf.projectPath = canonicalizePath(conf, getCurrentDir())
+    return
 
-    # Find Nim's prefix dir.
-    let binaryPath = findExe("nim")
-    if binaryPath == "":
-      raise newException(IOError,
-          "Cannot find Nim standard library: Nim compiler not in PATH")
-    conf.prefixDir = binaryPath.splitPath().head.parentDir()
-    if not dirExists(conf.prefixDir / "lib"): conf.prefixDir = ""
+  self.processCmdLineAndProjectPath(conf)
 
-    #msgs.writelnHook = proc (line: string) = log(line)
-    myLog("START " & conf.projectFull)
+  if gMode != mstdin:
+    conf.writelnHook = proc (msg: string) = discard
+  # Find Nim's prefix dir.
+  let binaryPath = findExe("nim")
+  if binaryPath == "":
+    raise newException(IOError,
+        "Cannot find Nim standard library: Nim compiler not in PATH")
+  conf.prefixDir = binaryPath.splitPath().head.parentDir()
+  if not dirExists(conf.prefixDir / "lib"): conf.prefixDir = ""
 
-    loadConfigs(DefaultConfig, cache, conf) # load all config files
-    # now process command line arguments again, because some options in the
-    # command line can overwite the config file's settings
-    conf.command = "nimsuggest"
-    let scriptFile = conf.projectFull.changeFileExt("nims")
-    if fileExists(scriptFile):
-      # 'nimsuggest foo.nims' means to just auto-complete the NimScript file:
-      if scriptFile != conf.projectFull:
-        runNimScript(cache, scriptFile, freshDefines=false, conf)
-    elif fileExists(conf.projectPath / "config.nims"):
-      # directory wide NimScript file
-      runNimScript(cache, conf.projectPath / "config.nims", freshDefines=false, conf)
+  #msgs.writelnHook = proc (line: string) = log(line)
+  myLog("START " & conf.projectFull)
 
-    extccomp.initVars(conf)
-    processCmdLine(passCmd2, "", conf)
-
-    let graph = newModuleGraph(cache, conf)
-    graph.suggestMode = true
-    mainCommand(graph)
+  discard self.loadConfigsAndRunMainCommand(cache, conf)
 
 handleCmdline(newIdentCache(), newConfigRef())


### PR DESCRIPTION
/cc @Araq 
* run $systemConfigPath/config.nims if it exists
* run ~/.config/nim/config.nims if it exists
* run parendDir/config.nims if exists for each parendDir
* run project config.nims if exists
* run inputfile.nims if exists

these are controlled by `optSkip<XXX>ConfigFile 

* makes config.nims behave like nim.cfg
* supersides https://github.com/nim-lang/Nim/pull/8233
* fixes: config.nims should apply to subdirectories recursively, like nim.cfg does #8217
* refactors duplicate/out of sync code between nim.nim and nimsuggest.nim
