### PR TITLE
Update all the default parameters after an instantiation

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -399,12 +399,11 @@ proc updateDefaultParams(call: PNode) =
   # the default params with `nfDefaultParam` and `instantiateProcType`
   # computes correctly the default values for each instantiation.
   let calleeParams = call[0].sym.typ.n
-  for i in countdown(call.len - 1, 1):
-    if nfDefaultParam notin call[i].flags:
-      return
-    let def = calleeParams[i].sym.ast
-    if nfDefaultRefsParam in def.flags: call.flags.incl nfDefaultRefsParam
-    call[i] = def
+  for i in 1..<call.len:
+    if nfDefaultParam in call[i].flags:
+      let def = calleeParams[i].sym.ast
+      if nfDefaultRefsParam in def.flags: call.flags.incl nfDefaultRefsParam
+      call[i] = def
 
 proc semResolvedCall(c: PContext, x: TCandidate,
                      n: PNode, flags: TExprFlags): PNode =

--- a/tests/proc/t8683.nim
+++ b/tests/proc/t8683.nim
@@ -1,0 +1,11 @@
+discard """
+  output: "1"
+"""
+
+proc foo[T](bar: proc (x, y: T): int = system.cmp, baz: int) =
+  echo "1"
+
+proc foo[T](bar: proc (x, y: T): int = system.cmp) =
+  echo "2"
+
+foo[int](baz = 5)


### PR DESCRIPTION
The old implementation relied on the (now?) wrong assumption that
default-valued parameters can only be placed after the required ones.

Fixes #8683