### PR TITLE
sfForward is also sfReorder for skModule symbols

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -161,7 +161,7 @@ proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope) =
   var s = initTabIter(it, scope.symbols)
   var missingImpls = 0
   while s != nil:
-    if sfForward in s.flags and s.kind != skType:
+    if sfForward in s.flags and s.kind notin {skType, skModule}:
       # too many 'implementation of X' errors are annoying
       # and slow 'suggest' down:
       if missingImpls == 0:

--- a/tests/modules/t8665.nim
+++ b/tests/modules/t8665.nim
@@ -1,0 +1,1 @@
+import treorder


### PR DESCRIPTION
Take this into account while searching for undefined forward references.

Fixes #8665

This `sf...` flag reuse is an endless source of silly problems like this.