### PR TITLE
More robust handling of deprecated pragmas

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -868,11 +868,17 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wExplain:
         sym.flags.incl sfExplain
       of wDeprecated:
-        if sym != nil and sym.kind in routineKinds:
+        if sym != nil and sym.kind in routineKinds + {skType}:
           if it.kind in nkPragmaCallKinds: discard getStrLitNode(c, it)
           incl(sym.flags, sfDeprecated)
+        elif sym != nil and sym.kind != skModule:
+          # We don't support the extra annotation field
+          if it.kind in nkPragmaCallKinds:
+            localError(c.config, it.info, "annotation to deprecated not supported here")
+          incl(sym.flags, sfDeprecated)
+        # At this point we're quite sure this is a statement and applies to the
+        # whole module
         elif it.kind in nkPragmaCallKinds: deprecatedStmt(c, it)
-        elif sym != nil: incl(sym.flags, sfDeprecated)
         else: incl(c.module.flags, sfDeprecated)
       of wVarargs:
         noVal(c, it)

--- a/tests/deprecated/importme.nim
+++ b/tests/deprecated/importme.nim
@@ -1,0 +1,10 @@
+type
+  Ty* {.deprecated.} = uint32
+  Ty1* {.deprecated: "hello".} = uint32
+
+var aVar* {.deprecated.}: char
+
+proc aProc*() {.deprecated.} = discard
+proc aProc1*() {.deprecated: "hello".} = discard
+
+{.deprecated: "goodbye".}

--- a/tests/deprecated/tmodule1.nim
+++ b/tests/deprecated/tmodule1.nim
@@ -1,0 +1,23 @@
+discard """
+  nimout: '''tmodule1.nim(11, 8) Warning: goodbye; importme is deprecated [Deprecated]
+tmodule1.nim(14, 10) Warning: Ty is deprecated [Deprecated]
+tmodule1.nim(17, 10) Warning: hello; Ty1 is deprecated [Deprecated]
+tmodule1.nim(20, 8) Warning: aVar is deprecated [Deprecated]
+tmodule1.nim(22, 3) Warning: aProc is deprecated [Deprecated]
+tmodule1.nim(23, 3) Warning: hello; aProc1 is deprecated [Deprecated]
+'''
+"""
+
+import importme
+
+block:
+  var z: Ty
+  z = 0
+block:
+  var z: Ty1
+  z = 0
+block:
+  echo aVar
+block:
+  aProc()
+  aProc1()

--- a/tests/deprecated/tnoannot.nim
+++ b/tests/deprecated/tnoannot.nim
@@ -1,0 +1,7 @@
+discard """
+  line: 7
+  errormsg: "annotation to deprecated not supported here"
+"""
+
+var foo* {.deprecated.} = 42
+var foo1* {.deprecated: "no".} = 42


### PR DESCRIPTION
Prevent `deprecated` annotations to "slip" up to the parent module and
warn about unsupported annotations.

Accidentally fixes #7867