### PR TITLE
Don't consider tyAnd/tyNot/tyOr/tyAnything as generic

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -352,6 +352,11 @@ proc isOpImpl(c: PContext, n: PNode, flags: TExprFlags): PNode =
       res = t.kind == tyProc and
             t.callConv == ccClosure and
             tfIterator notin t.flags
+    of "iterator":
+      let t = skipTypes(t1, abstractRange)
+      res = t.kind == tyProc and
+            t.callConv == ccClosure and
+            tfIterator in t.flags
     else:
       res = false
   else:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1445,8 +1445,7 @@ proc containsGenericTypeIter(t: PType, closure: RootRef): bool =
     if t.base.kind == tyNone: return true
     if containsGenericTypeIter(t.base, closure): return true
     return false
-  of GenericTypes + {tyFromExpr, tyBuiltInTypeClass, tyCompositeTypeClass} +
-    tyUserTypeClasses:
+  of GenericTypes + tyTypeClasses + {tyFromExpr}:
     return true
   else:
     return false

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1445,7 +1445,8 @@ proc containsGenericTypeIter(t: PType, closure: RootRef): bool =
     if t.base.kind == tyNone: return true
     if containsGenericTypeIter(t.base, closure): return true
     return false
-  of GenericTypes + tyTypeClasses + {tyFromExpr}:
+  of GenericTypes + {tyFromExpr, tyBuiltInTypeClass, tyCompositeTypeClass} +
+    tyUserTypeClasses:
     return true
   else:
     return false

--- a/tests/magics/t8693.nim
+++ b/tests/magics/t8693.nim
@@ -1,0 +1,23 @@
+discard """
+  output: '''true
+false
+true
+false
+false
+true
+'''
+"""
+
+type Foo = int | float
+
+proc bar(t1, t2: typedesc): bool =
+  echo (t1 is t2)
+  (t2 is t1)
+
+proc bar[T](x: T, t2: typedesc): bool =
+  echo (T is t2)
+  (t2 is T)
+
+echo bar(int, Foo)
+echo bar(4, Foo)
+echo bar(any, Foo)

--- a/tests/magics/t8693.nim
+++ b/tests/magics/t8693.nim
@@ -5,6 +5,10 @@ true
 false
 false
 true
+true
+false
+true
+true
 '''
 """
 
@@ -20,4 +24,6 @@ proc bar[T](x: T, t2: typedesc): bool =
 
 echo bar(int, Foo)
 echo bar(4, Foo)
-echo bar(any, Foo)
+echo bar(any, int)
+echo bar(int, any)
+echo bar(Foo, Foo)


### PR DESCRIPTION
`containsGenericType` was too shallow and didn't check all the branches.
The resulting half-processed nodes are often simplified by the constant
folding pass but when that's not possible we get a nasty error during
codegen.

Fixes #8693

I also found out that trying to use `not <type>` often yields a stack overflow in `typerel` but didn't investigate much.