### PR TITLE
HTML generation in testament works again

### DIFF
--- a/tests/testament/htmlgen.nim
+++ b/tests/testament/htmlgen.nim
@@ -22,8 +22,8 @@ proc generateTestResultPanelPartial(outfile: File, testResultRow: JsonNode) =
     target = testResultRow["target"].str.htmlQuote()
     action = testResultRow["action"].str.htmlQuote()
     result = htmlQuote testResultRow["result"].str
-    expected = testResultRow["expected"].str
-    gotten = testResultRow["given"].str
+    expected = testResultRow["expected"].getStr
+    gotten = testResultRow["given"].getStr
     timestamp = "unknown"
   var
     panelCtxClass, textCtxClass, bgCtxClass: string


### PR DESCRIPTION
Fallout from the nil-str patch. Nothing to see here, move along.