### PR TITLE
universal toSeq: works with UFCS; works with inline & closure iterators, and with iterables

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -504,8 +504,8 @@ template anyIt*(s, pred: untyped): bool =
       break
   result
 
-template toSeq*(iter: untyped): untyped =
-  ## Transforms any iterator into a sequence.
+template toSeq*(s: not iterator): untyped =
+  ## Transforms any iterable into a sequence.
   ##
   ## Example:
   ##
@@ -517,21 +517,42 @@ template toSeq*(iter: untyped): untyped =
   ##         result = true)
   ##   assert odd_numbers == @[1, 3, 5, 7, 9]
 
-  # Note: see also `mapIt` for explanation of some of the implementation
-  # subtleties.
-  when compiles(iter.len):
+  type outType = type(items(s))
+  when compiles(s.len):
     block:
-      evalOnceAs(iter2, iter, true)
-      var result = newSeq[type(iter)](iter2.len)
+      evalOnceAs(s2, s, compiles((let _ = s)))
       var i = 0
-      for x in iter2:
-        result[i] = x
-        inc i
+      var result = newSeq[outType](s2.len)
+      for it in s2:
+        result[i] = it
+        i += 1
       result
   else:
-    var result: seq[type(iter)] = @[]
-    for x in iter:
-      result.add(x)
+    var result: seq[outType] = @[]
+    for it in s:
+      result.add(it)
+    result
+
+template toSeq*(iter: iterator): untyped =
+  evalOnceAs(iter2, iter(), false)
+  when compiles(iter2.len):
+    var i = 0
+    var result = newSeq[type(iter2)](iter2.len)
+    for x in iter2:
+      result[i] = x
+      inc i
+    result
+  else:
+    type outType = type(iter2())
+    var result: seq[outType] = @[]
+    when compiles(iter2()):
+      evalOnceAs(iter4, iter, false)
+      let iter3=iter4()
+      for x in iter3():
+        result.add(x)
+    else:
+      for x in iter2():
+        result.add(x)
     result
 
 template foldl*(sequence, operation: untyped): untyped =
@@ -1027,12 +1048,66 @@ when isMainModule:
     assert anyIt(anumbers, it > 9) == false
 
   block: # toSeq test
-    let
-      numeric = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
-      odd_numbers = toSeq(filter(numeric) do (x: int) -> bool:
-        if x mod 2 == 1:
-          result = true)
-    assert odd_numbers == @[1, 3, 5, 7, 9]
+    block:
+      let
+        numeric = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
+        odd_numbers = toSeq(filter(numeric) do (x: int) -> bool:
+          if x mod 2 == 1:
+            result = true)
+      assert odd_numbers == @[1, 3, 5, 7, 9]
+
+    block:
+      doAssert [1,2].toSeq == @[1,2]
+      doAssert @[1,2].toSeq == @[1,2]
+
+      doAssert @[1,2].toSeq == @[1,2]
+      doAssert toSeq(@[1,2]) == @[1,2]
+
+    block:
+      iterator myIter():auto{.inline.}=
+        yield 1
+        yield 2
+
+      doAssert myIter.toSeq == @[1,2]
+      doAssert toSeq(myIter) == @[1,2]
+
+    block:
+      iterator myIter():int {.closure.} =
+        yield 1
+        yield 2
+
+      doAssert myIter.toSeq == @[1,2]
+      doAssert toSeq(myIter) == @[1,2]
+
+    block:
+      proc myIter():auto=
+        iterator ret():int{.closure.}=
+          yield 1
+          yield 2
+        result = ret
+
+      doAssert myIter().toSeq == @[1,2]
+      doAssert toSeq(myIter()) == @[1,2]
+
+    block:
+      proc myIter(n:int):auto=
+        var counter = 0
+        iterator ret():int{.closure.}=
+          while counter<n:
+            yield counter
+            counter.inc
+        result = ret
+
+      block:
+        let myIter3 = myIter(3)
+        doAssert myIter3.toSeq == @[0,1,2]
+      block:
+        let myIter3 = myIter(3)
+        doAssert toSeq(myIter3) == @[0,1,2]
+      block:
+        # makes sure this does not hang forever
+        doAssert myIter(3).toSeq == @[0,1,2]
+        doAssert toSeq(myIter(3)) == @[0,1,2]
 
   block:
     # tests https://github.com/nim-lang/Nim/issues/7187

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -548,10 +548,9 @@ template toSeq2(iter: iterator): untyped =
 template toSeq*(iter: untyped): untyped =
   ## Transforms any iterable into a sequence.
   runnableExamples:
-    import sugar
     let
       numeric = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
-      odd_numbers = toSeq(filter(numeric, x => x mod 2 == 1))
+      odd_numbers = toSeq(filter(numeric, proc(x: int): bool = x mod 2 == 1))
     doAssert odd_numbers == @[1, 3, 5, 7, 9]
 
   when compiles(toSeq1(iter)):


### PR DESCRIPTION
* current sequtils.toSeq is limited: it can't be used in UFCS, and can't be used in a number of other contexts (eg iterables that are not iterators, or even when calling a proc that returns an iterator)
* this fixes all of this

See test cases for more details but here's the skinny:

```nim
iterator myIter1():auto{.inline.}= ...
iterator myIter2():int {.closure.} = ...

doAssert [1,2].toSeq == @[1,2]
doAssert @[1,2].toSeq == @[1,2]
doAssert myIter1.toSeq == @[1,2]
doAssert toSeq(myIter1) == @[1,2]
doAssert myIter2.toSeq == @[1,2]
doAssert toSeq(myIter2) == @[1,2]

proc myIter3():auto= ... # returns iterator int
proc myIter4(a:int):auto= ... # returns iterator int
doAssert myIter3().toSeq == @[1,2]
doAssert toSeq(myIter3()) == @[1,2]

doAssert myIter4(1).toSeq == @[1,2]
doAssert toSeq(myIter4(1)) == @[1,2]

# this is the only case that can't be used with UFCS as myIter5(1) has no type:
iterator myIter5(a:int):auto = ...
doAssert = toSeq(myIter5(3)) == @[1,2]
```

## note
* the split between toSeq1 and toSeq2 is needed because of this bug [1]
* toSeq handles the remaining cases (where param must be untyped), eg: `toSeq(myIter5(3))` with `iterator myIter5(a:int):auto = ...` 

## fixes
* makes test case in this work: Confusing error message when calling toSeq using a non-iterator #7182

## links
* [1] `for x in myIter(42)(): ... ` gives infinite loop; inconsistent with `let it = iterGen(42); for x in it(): ...` #8775

