### PR TITLE
Fix #8126

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -506,6 +506,7 @@ type
     tfGenericTypeParam
     tfImplicitTypeParam
     tfInferrableStatic
+    tfConceptMatchedTypeSym
     tfExplicit        # for typedescs, marks types explicitly prefixed with the
                       # `type` operator (e.g. type int)
     tfWildcard        # consider a proc like foo[T, I](x: Type[T, I])

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1342,7 +1342,7 @@ proc semTypeClass(c: PContext, n: PNode, prev: PType): PType =
     if modifier != tyNone:
       dummyName = param[0]
       dummyType = c.makeTypeWithModifier(modifier, candidateTypeSlot)
-      if modifier == tyTypeDesc: dummyType.flags.incl tfExplicit
+      if modifier == tyTypeDesc: dummyType.flags.incl tfConceptMatchedTypeSym
     else:
       dummyName = param
       dummyType = candidateTypeSlot

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -993,7 +993,8 @@ proc typeRelImpl(c: var TCandidate, f, aOrig: PType,
     useTypeLoweringRuleInTypeClass = c.c.matchedConcept != nil and
                                      not c.isNoCall and
                                      f.kind != tyTypeDesc and
-                                     tfExplicit notin aOrig.flags
+                                     tfExplicit notin aOrig.flags and
+                                     tfConceptMatchedTypeSym notin aOrig.flags
 
     aOrig = if useTypeLoweringRuleInTypeClass:
           aOrig.skipTypes({tyTypeDesc})

--- a/tests/concepts/tmonoid.nim
+++ b/tests/concepts/tmonoid.nim
@@ -11,3 +11,15 @@ type Monoid = concept x, y
 proc z(x: typedesc[int]): int = 0
 
 echo(int is Monoid)
+
+# https://github.com/nim-lang/Nim/issues/8126
+type AdditiveMonoid* = concept x, y, type T
+  x + y is T
+
+  # some redundant checks to test an alternative approaches:
+  type TT = type(x)
+  x + y is type(x)
+  x + y is TT
+
+doAssert(1 is AdditiveMonoid)
+

--- a/tests/parser/ttypeclasses.nim
+++ b/tests/parser/ttypeclasses.nim
@@ -40,3 +40,7 @@ static:
   assert y isnot tuple
   assert z isnot seq
 
+  # XXX: These cases don't work properly at the moment:
+  # assert type[int] isnot int
+  # assert type(int) isnot int
+


### PR DESCRIPTION
This is a temporary fix that will be reworked in a follow up commit that aims to eliminate the `tfExplicit` flag from the compiler. The complete and proper fix was considered too risky for inclusion just before our 0.19 release.