### PR TITLE
Pick skParam symbols when resolving type idents

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -369,7 +369,7 @@ proc semTypeIdent(c: PContext, n: PNode): PSym =
   if n.kind == nkSym:
     result = getGenSym(c, n.sym)
   else:
-    result = pickSym(c, n, {skType, skGenericParam})
+    result = pickSym(c, n, {skType, skGenericParam, skParam})
     if result.isNil:
       result = qualifiedLookUp(c, n, {checkAmbiguity, checkUndeclared})
     if result != nil:

--- a/tests/proc/t8357.nim
+++ b/tests/proc/t8357.nim
@@ -1,0 +1,10 @@
+discard """
+  output: "Hello"
+"""
+
+type
+  T = ref int
+
+let r = new(string)
+r[] = "Hello"
+echo r[]


### PR DESCRIPTION
Fixes #8357

Despite what the ticket says this has nothing to do with concepts (for once)