### PR TITLE
Fix abs & unary sub in semfold

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -69,9 +69,13 @@ proc foldSub*(a, b: BiggestInt, n: PNode; g: ModuleGraph): PNode =
       checkInRange(g.config, n, res):
     result = newIntNodeT(res, n, g)
 
+proc foldUnarySub(a: BiggestInt, n: PNode, g: ModuleGraph): PNode =
+  if a != firstOrd(g.config, n.typ):
+    result = newIntNodeT(-a, n, g)
+
 proc foldAbs*(a: BiggestInt, n: PNode; g: ModuleGraph): PNode =
   if a != firstOrd(g.config, n.typ):
-    result = newIntNodeT(a, n, g)
+    result = newIntNodeT(abs(a), n, g)
 
 proc foldMod*(a, b: BiggestInt, n: PNode; g: ModuleGraph): PNode =
   if b != 0'i64:
@@ -216,7 +220,7 @@ proc evalOp(m: TMagic, n, a, b, c: PNode; g: ModuleGraph): PNode =
   case m
   of mOrd: result = newIntNodeT(getOrdValue(a), n, g)
   of mChr: result = newIntNodeT(getInt(a), n, g)
-  of mUnaryMinusI, mUnaryMinusI64: result = newIntNodeT(- getInt(a), n, g)
+  of mUnaryMinusI, mUnaryMinusI64: result = foldUnarySub(getInt(a), n, g)
   of mUnaryMinusF64: result = newFloatNodeT(- getFloat(a), n, g)
   of mNot: result = newIntNodeT(1 - getInt(a), n, g)
   of mCard: result = newIntNodeT(nimsets.cardSet(g.config, a), n, g)

--- a/tests/misc/tsemfold.nim
+++ b/tests/misc/tsemfold.nim
@@ -9,6 +9,7 @@ doAssertRaises(DivByZeroError): discard 1 mod 0
 doAssertRaises(DivByZeroError): discard 1 div 0
 doAssertRaises(OverflowError): discard low(int8) div -1'i8
 
+doAssertRaises(OverflowError): discard -low(int64)
 doAssertRaises(OverflowError): discard low(int64) - 1'i64
 doAssertRaises(OverflowError): discard high(int64) + 1'i64
 
@@ -21,3 +22,6 @@ doAssertRaises(OverflowError): discard low(int64) * -1
 doAssertRaises(OverflowError): discard high(int8) * 2
 doAssertRaises(OverflowError): discard high(int64) * 2
 
+doAssert abs(-1) == 1
+doAssert 2 div 2 == 1
+doAssert 2 * 3 == 6


### PR DESCRIPTION
abs was incorrectly implemented, and unary sub didn't prevent against overflows.

Fixes #7814 (this PR doesn't fix the the fact that `Inf.int` is allowed, but it fixes `-low(int)` which is the cause of #7814).