### PR TITLE
[trivial] better formatting for recursive module dependency

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -259,7 +259,7 @@ proc errorUseQualifier*(c: PContext; info: TLineInfo; s: PSym) =
 proc errorUndeclaredIdentifier*(c: PContext; info: TLineInfo; name: string) =
   var err = "undeclared identifier: '" & name & "'"
   if c.recursiveDep.len > 0:
-    err.add "\nThis might be caused by a recursive module dependency: "
+    err.add "\nThis might be caused by a recursive module dependency:\n"
     err.add c.recursiveDep
     # prevent excessive errors for 'nim check'
     c.recursiveDep = ""


### PR DESCRIPTION
on error, will show:
```
This might be caused by a recursive module dependency:
/Users/timothee/git_clone/nim/Nim/compiler/msgs.nim imports /Users/timothee/git_clone/nim/Nim/compiler/options.nim
/Users/timothee/git_clone/nim/Nim/compiler/options.nim imports /Users/timothee/git_clone/nim/Nim/compiler/lineinfos.nim
/Users/timothee/git_clone/nim/Nim/compiler/lineinfos.nim imports /Users/timothee/git_clone/nim/Nim/compiler/ropes.nim
/Users/timothee/git_clone/nim/Nim/compiler/ropes.nim imports /Users/timothee/git_clone/nim/Nim/compiler/msgs.nim
```
instead of
```
This might be caused by a recursive module dependency: /Users/timothee/git_clone/nim/Nim/compiler/msgs.nim imports /Users/timothee/git_clone/nim/Nim/compiler/options.nim
/Users/timothee/git_clone/nim/Nim/compiler/options.nim imports /Users/timothee/git_clone/nim/Nim/compiler/lineinfos.nim
/Users/timothee/git_clone/nim/Nim/compiler/lineinfos.nim imports /Users/timothee/git_clone/nim/Nim/compiler/ropes.nim
/Users/timothee/git_clone/nim/Nim/compiler/ropes.nim imports /Users/timothee/git_clone/nim/Nim/compiler/msgs.nim
```