### PR TITLE
fix #8218: `nim doc --project` was failing

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -787,14 +787,13 @@ proc getOutFile2(conf: ConfigRef; filename, ext, dir: string): string =
 
 proc writeOutput*(d: PDoc, filename, outExt: string, useWarning = false) =
   var content = genOutFile(d)
-  var success = true
   if optStdout in d.conf.globalOptions:
     writeRope(stdout, content)
   else:
     let outfile = getOutFile2(d.conf, filename, outExt, "htmldocs")
-    success = writeRope(content, outfile)
-  if not success:
-    rawMessage(d.conf, if useWarning: warnCannotOpenFile else: errCannotOpenFile, filename)
+    createDir(outfile.parentDir)
+    if not writeRope(content, outfile):
+      rawMessage(d.conf, if useWarning: warnCannotOpenFile else: errCannotOpenFile, outfile)
 
 proc writeOutputJson*(d: PDoc, filename, outExt: string,
                       useWarning = false) =


### PR DESCRIPTION
/cc @Araq 
* fix: `nim doc2 --project -o:doc/ ` cannot find files in subdirectories https://github.com/nim-lang/Nim/issues/8218
* the error msg was super confusing, since it referred to a file that existed (filename) instead of the file to be created (outfile)
* fixed error by calling `createDir(outfile.parentDir)`

