### PR TITLE
New web-like targets (WebAssembly, etc.)

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -16,6 +16,7 @@ Platforms: """
   haiku: i386;amd64
   android: i386;arm;arm64
   nintendoswitch: arm64
+  web: js;asmjs;wasm32;wasm64
 """
 
 Authors: "Andreas Rumpf"

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -126,8 +126,8 @@ type
     disabledSf, writeOnlySf, readOnlySf, v2Sf
 
   TSystemCC* = enum
-    ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccLcc, ccBcc, ccDmc, ccWcc, ccVcc,
-    ccTcc, ccPcc, ccUcc, ccIcl, ccIcc
+    ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccClang, ccEmscripten, ccLcc,
+    ccBcc, ccDmc, ccWcc, ccVcc, ccTcc, ccPcc, ccUcc, ccIcl, ccIcc
 
   CfileFlag* {.pure.} = enum
     Cached,    ## no need to recompile this time
@@ -344,10 +344,10 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
     of "x8664": result = conf.target.targetCPU == cpuAmd64
     of "posix", "unix":
       result = conf.target.targetOS in {osLinux, osMorphos, osSkyos, osIrix, osPalmos,
-                            osQnx, osAtari, osAix,
-                            osHaiku, osVxWorks, osSolaris, osNetbsd,
-                            osFreebsd, osOpenbsd, osDragonfly, osMacosx,
-                            osAndroid, osNintendoSwitch}
+                                        osQnx, osAtari, osAix,
+                                        osHaiku, osVxWorks, osSolaris, osNetbsd,
+                                        osFreebsd, osOpenbsd, osDragonfly, osMacosx,
+                                        osAndroid, osNintendoSwitch}
     of "linux":
       result = conf.target.targetOS in {osLinux, osAndroid}
     of "bsd":
@@ -367,9 +367,10 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
     of "cpu16": result = CPU[conf.target.targetCPU].bit == 16
     of "cpu32": result = CPU[conf.target.targetCPU].bit == 32
     of "cpu64": result = CPU[conf.target.targetCPU].bit == 64
+    of "wasm": result = conf.target.targetCPU in {cpuWasm32, cpuWasm64}
     of "nimrawsetjmp":
       result = conf.target.targetOS in {osSolaris, osNetbsd, osFreebsd, osOpenbsd,
-                            osDragonfly, osMacosx}
+                                        osDragonfly, osMacosx}
     else: discard
 
 proc importantComments*(conf: ConfigRef): bool {.inline.} = conf.cmd in {cmdDoc, cmdIdeTools}

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -124,12 +124,23 @@ path="$lib/pure"
 @end
 
 @if wasm32:
-  emscripten.options.always %= "-s WASM=1"
+  @if debug:
+    emscripten.options.always %= "-O1 -s WASM=1"
+    emscripten.options.linker %= "-O1 -s WASM=1"
+  @end
+  # TODO: optimization option
+
   clang.options.always %= "--target=wasm32-unknown-unknown-wasm"
 @end
 
 @if wasm64:
-  emscripten.options.always %= "-s WASM=1"
+  # NOTE: does emscripten even support wasm64?
+  @if debug:
+    emscripten.options.always %= "-O1 -s WASM=1"
+    emscripten.options.linker %= "-O1 -s WASM=1"
+  @end
+  # TODO: optimization option
+
   clang.options.always %= "--target=wasm64-unknown-unknown-wasm"
 @end
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -119,6 +119,20 @@ path="$lib/pure"
   switch_gcc.cpp.options.always = "-g -Wall -O2 -ffunction-sections -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -D__SWITCH__ -fno-rtti -fno-exceptions -std=gnu++11"
 @end
 
+@if asmjs:
+  emscripten.options.always %= "-s ASM_JS=1"
+@end
+
+@if wasm32:
+  emscripten.options.always %= "-s WASM=1"
+  clang.options.always %= "--target=wasm32-unknown-unknown-wasm"
+@end
+
+@if wasm64:
+  emscripten.options.always %= "-s WASM=1"
+  clang.options.always %= "--target=wasm64-unknown-unknown-wasm"
+@end
+
 # Configuration for the Intel C/C++ compiler:
 @if windows:
   icl.options.speed = "/Ox /arch:SSE2"
@@ -266,3 +280,4 @@ tcc.options.always = "-w"
     gcc.cpp.exe = "genode-arm-g++"
   @end
 @end
+

--- a/lib/pure/dynlib.nim
+++ b/lib/pure/dynlib.nim
@@ -109,7 +109,7 @@ proc loadLibPattern*(pattern: string, global_symbols=false): LibHandle =
     result = loadLib(c, global_symbols)
     if not result.isNil: break
 
-when defined(posix):
+when defined(posix) and not defined(asmjs):
   #
   # =========================================================================
   # This is an implementation based on the dlfcn interface.


### PR DESCRIPTION
Referencing #8713, this adds new support in the compiler for `--cc:emscripten` (`asmjs`+`wasm32`) as well as `wasm32`+`wasm64` support for `--cc:clang`, as well as apparently fixing a bug where the host OS/CPU is set to the target OS/CPU inexplicably _(may need a special case for `genscript`, am unsure about this)._

Right now you have to set `--os:linux` to compile stuff with it, but some basic testing with it seems to work. Thoughts on making a new OS setting? Of course, I also need to do some work on the stdlib for this and work on adding tests.