### PR TITLE
gitignore html output of nim doc foo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,10 @@ xcuserdata/
 /compiler/nimrod.dot
 /reject.json
 /run.json
-/testresults.html
+# for `nim doc foo.nim`
+/*.html
+#/testresults.html #covered by /*.html
+
 /testresults.json
 testament.db
 /csources
@@ -62,3 +65,4 @@ dist/
 testresults/
 test.txt
 /test.ini
+


### PR DESCRIPTION
a better fix would be to output `foo.html` in nimcache when running `nim doc foo.nim`, as it would also apply to other repos without having to add a line to gitignore and would be easier to clean up in bulk mode, but that can be done in subsequent PR

NOTE: `nim doc foo.nim` is useful for both running runnableExamples and inspecting output of html when working on a PR. it shouldn't affect `git status`
