### PR TITLE
[WIP] Pervasive replacement of nkRecWhen in generic types

### DIFF
--- a/tests/objects/twhen1.nim
+++ b/tests/objects/twhen1.nim
@@ -1,0 +1,51 @@
+const Z = 0
+
+type
+  Foo[T] = object
+   when true:
+     u: int
+   else:
+     v: int
+  Foo1[T] = object
+   when T is int:
+     x: T
+   elif true:
+     z: char
+  Foo2[x:static[int]] = object
+    when (x and 1) == 1:
+      x: array[x+1,int]
+    else:
+      x: array[x,int]
+
+  Foo3 = Foo2[128]
+
+  # #8417
+  Foo4[A: static[int]] = object
+    when Z == 0:
+      discard
+    else:
+      discard
+
+block:
+  var x: Foo[int] = Foo[int](u: 42)
+  doAssert x.u == 42
+
+# Don't evaluate `when` branches before the type is instantiated
+block:
+  var x: Foo1[bool] = Foo1[bool](z: 'o')
+  doAssert x.z == 'o'
+
+block:
+  var x: Foo2[3]
+  doAssert x.x.len == 4
+
+block:
+  var x: Foo2[4]
+  doAssert x.x.len == 4
+
+block:
+  var x: Foo3
+  doAssert x.x.len == 128
+
+block:
+  var x: Foo4[0]


### PR DESCRIPTION
Long story short, even if the type contains no reference at all to its
generic parameters we still have to walk its AST and evaluate any
nkRecWhen nodes that semRecordNodeAux skipped due to the type being a
generic one.

We also must be careful to modify the type `n` node in place since it
may be referenced by the caller as seen in the tillegaltyperecursion
test.

I found this to be the nicest solution to the problem, we can't perform this resolution before the type is fully constructed as some `when` statements may refer to generic parameters and performing yet another (it'd be the third) pass over the type in order to resolve the remaining `nkRecWhen` is not that nice performance-wise.

This fixes #8417 and half of #7378.