### PR TITLE
Deprecate xlen() for strings and seqs

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4031,11 +4031,13 @@ proc procCall*(x: untyped) {.magic: "ProcCall", compileTime.} =
 
 proc xlen*(x: string): int {.magic: "XLenStr", noSideEffect,
                              deprecated: "use len() instead".} =
+  ## **Deprecated since version 0.18.1**. Use len() instead.
   discard
 proc xlen*[T](x: seq[T]): int {.magic: "XLenSeq", noSideEffect,
                                 deprecated: "use len() instead".} =
   ## returns the length of a sequence or a string without testing for 'nil'.
   ## This is an optimization that rarely makes sense.
+  ## **Deprecated since version 0.18.1**. Use len() instead.
   discard
 
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4029,8 +4029,11 @@ proc procCall*(x: untyped) {.magic: "ProcCall", compileTime.} =
   ##   procCall someMethod(a, b)
   discard
 
-proc xlen*(x: string): int {.magic: "XLenStr", noSideEffect.} = discard
-proc xlen*[T](x: seq[T]): int {.magic: "XLenSeq", noSideEffect.} =
+proc xlen*(x: string): int {.magic: "XLenStr", noSideEffect,
+                             deprecated: "use len() instead".} =
+  discard
+proc xlen*[T](x: seq[T]): int {.magic: "XLenSeq", noSideEffect,
+                                deprecated: "use len() instead".} =
   ## returns the length of a sequence or a string without testing for 'nil'.
   ## This is an optimization that rarely makes sense.
   discard


### PR DESCRIPTION
New strings/seqs make the idea of a variant of `len()`- i.e. `xlen()` - that does not check for `nil` as opposed to our standard `len()` useless.