### PR TITLE
Update html elements to current html spec

### DIFF
--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -109,13 +109,13 @@ proc xmlCheckedTag*(e: NimNode, tag: string, optAttr = "", reqAttr = "",
 macro a*(e: varargs[untyped]): untyped =
   ## generates the HTML ``a`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "a", "href charset type hreflang rel rev " &
-    "accesskey tabindex" & commonAttr)
+  result = xmlCheckedTag(e, "a", "href target download rel hreflang type " &
+    commonAttr)
 
-macro acronym*(e: varargs[untyped]): untyped =
-  ## generates the HTML ``acronym`` element.
+macro abbr*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``abbr`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "acronym", commonAttr)
+  result = xmlCheckedTag(e, "abbr", commonAttr)
 
 macro address*(e: varargs[untyped]): untyped =
   ## generates the HTML ``address`` element.
@@ -125,8 +125,24 @@ macro address*(e: varargs[untyped]): untyped =
 macro area*(e: varargs[untyped]): untyped =
   ## generates the HTML ``area`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "area", "shape coords href nohref" &
-    " accesskey tabindex" & commonAttr, "alt", true)
+  result = xmlCheckedTag(e, "area", "coords download href hreflang rel " &
+    "shape target type" & commonAttr, "alt", true)
+
+macro article*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``article`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "article", commonAttr)
+
+macro aside*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``aside`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "aside", commonAttr)
+
+macro audio*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``audio`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "audio", "src crossorigin preload " &
+    "autoplay mediagroup loop muted controls" & commonAttr)
 
 macro b*(e: varargs[untyped]): untyped =
   ## generates the HTML ``b`` element.
@@ -136,7 +152,17 @@ macro b*(e: varargs[untyped]): untyped =
 macro base*(e: varargs[untyped]): untyped =
   ## generates the HTML ``base`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "base", "", "href", true)
+  result = xmlCheckedTag(e, "base", "href target" & commonAttr, "", true)
+
+macro bdi*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``bdi`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "bdi", commonAttr)
+
+macro bdo*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``bdo`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "bdo", commonAttr)
 
 macro big*(e: varargs[untyped]): untyped =
   ## generates the HTML ``big`` element.
@@ -151,18 +177,26 @@ macro blockquote*(e: varargs[untyped]): untyped =
 macro body*(e: varargs[untyped]): untyped =
   ## generates the HTML ``body`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "body", commonAttr)
+  result = xmlCheckedTag(e, "body", "onafterprint onbeforeprint " &
+    "onbeforeunload onhashchange onmessage onoffline ononline onpagehide " &
+    "onpageshow onpopstate onstorage onunload" & commonAttr)
 
 macro br*(e: varargs[untyped]): untyped =
   ## generates the HTML ``br`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "br", "", "", true)
+  result = xmlCheckedTag(e, "br", commonAttr, "", true)
 
 macro button*(e: varargs[untyped]): untyped =
   ## generates the HTML ``button`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "button", "accesskey tabindex " &
-    "disabled name type value" & commonAttr)
+  result = xmlCheckedTag(e, "button", "autofocus disabled form formaction " &
+    "formenctype formmethod formnovalidate formtarget menu name type value" &
+    commonAttr)
+
+macro canvas*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``canvas`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "canvas", "width height" & commonAttr)
 
 macro caption*(e: varargs[untyped]): untyped =
   ## generates the HTML ``caption`` element.
@@ -182,12 +216,22 @@ macro code*(e: varargs[untyped]): untyped =
 macro col*(e: varargs[untyped]): untyped =
   ## generates the HTML ``col`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "col", "span align valign" & commonAttr, "", true)
+  result = xmlCheckedTag(e, "col", "span" & commonAttr, "", true)
 
 macro colgroup*(e: varargs[untyped]): untyped =
   ## generates the HTML ``colgroup`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "colgroup", "span align valign" & commonAttr)
+  result = xmlCheckedTag(e, "colgroup", "span" & commonAttr)
+
+macro data*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``data`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "data", "value" & commonAttr)
+
+macro datalist*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``datalist`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "datalist", commonAttr)
 
 macro dd*(e: varargs[untyped]): untyped =
   ## generates the HTML ``dd`` element.
@@ -224,16 +268,37 @@ macro em*(e: varargs[untyped]): untyped =
   let e = callsite()
   result = xmlCheckedTag(e, "em", commonAttr)
 
+macro embed*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``embed`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "embed", "src type height width" &
+    commonAttr, "", true)
+
 macro fieldset*(e: varargs[untyped]): untyped =
   ## generates the HTML ``fieldset`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "fieldset", commonAttr)
+  result = xmlCheckedTag(e, "fieldset", "disabled form name" & commonAttr)
+
+macro figure*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``figure`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "figure", commonAttr)
+
+macro figcaption*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``figcaption`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "figcaption", commonAttr)
+
+macro footer*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``footer`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "footer", commonAttr)
 
 macro form*(e: varargs[untyped]): untyped =
   ## generates the HTML ``form`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "form", "method encype accept accept-charset" &
-    commonAttr, "action")
+  result = xmlCheckedTag(e, "form", "accept-charset action autocomplete " &
+    "enctype method name novalidate target" & commonAttr)
 
 macro h1*(e: varargs[untyped]): untyped =
   ## generates the HTML ``h1`` element.
@@ -268,7 +333,12 @@ macro h6*(e: varargs[untyped]): untyped =
 macro head*(e: varargs[untyped]): untyped =
   ## generates the HTML ``head`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "head", "profile")
+  result = xmlCheckedTag(e, "head", commonAttr)
+
+macro header*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``header`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "header", commonAttr)
 
 macro html*(e: varargs[untyped]): untyped =
   ## generates the HTML ``html`` element.
@@ -285,16 +355,26 @@ macro i*(e: varargs[untyped]): untyped =
   let e = callsite()
   result = xmlCheckedTag(e, "i", commonAttr)
 
+macro iframe*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``iframe`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "iframe", "src srcdoc name sandbox width height" &
+    commonAttr)
+
 macro img*(e: varargs[untyped]): untyped =
   ## generates the HTML ``img`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "img", "longdesc height width", "src alt", true)
+  result = xmlCheckedTag(e, "img", "crossorigin usemap ismap height width" &
+    commonAttr, "src alt", true)
 
 macro input*(e: varargs[untyped]): untyped =
   ## generates the HTML ``input`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "input", "name type value checked maxlength src" &
-    " alt accept disabled readonly accesskey tabindex" & commonAttr, "", true)
+  result = xmlCheckedTag(e, "input", "accept alt autocomplete autofocus " &
+    "checked dirname disabled form formaction formenctype formmethod " &
+    "formnovalidate formtarget height inputmode list max maxlength min " &
+    "minlength multiple name pattern placeholder readonly required size " &
+    "src step type value width" & commonAttr, "", true)
 
 macro ins*(e: varargs[untyped]): untyped =
   ## generates the HTML ``ins`` element.
@@ -306,36 +386,64 @@ macro kbd*(e: varargs[untyped]): untyped =
   let e = callsite()
   result = xmlCheckedTag(e, "kbd", commonAttr)
 
+macro keygen*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``keygen`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "keygen", "autofocus challenge disabled " &
+    "form keytype name" & commonAttr)
+
 macro label*(e: varargs[untyped]): untyped =
   ## generates the HTML ``label`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "label", "for accesskey" & commonAttr)
+  result = xmlCheckedTag(e, "label", "form for" & commonAttr)
 
 macro legend*(e: varargs[untyped]): untyped =
   ## generates the HTML ``legend`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "legend", "accesskey" & commonAttr)
+  result = xmlCheckedTag(e, "legend", commonAttr)
 
 macro li*(e: varargs[untyped]): untyped =
   ## generates the HTML ``li`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "li", commonAttr)
+  result = xmlCheckedTag(e, "li", "value" & commonAttr)
 
 macro link*(e: varargs[untyped]): untyped =
   ## generates the HTML ``link`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "link", "href charset hreflang type rel rev media" &
-    commonAttr, "", true)
+  result = xmlCheckedTag(e, "link", "href crossorigin rel media hreflang " &
+    "type sizes" & commonAttr, "", true)
+
+macro main*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``main`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "main", commonAttr)
 
 macro map*(e: varargs[untyped]): untyped =
   ## generates the HTML ``map`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "map", "class title" & eventAttr, "id", false)
+  result = xmlCheckedTag(e, "map", "name" & commonAttr)
+
+macro mark*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``mark`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "mark", commonAttr)
 
 macro meta*(e: varargs[untyped]): untyped =
   ## generates the HTML ``meta`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "meta", "name http-equiv scheme", "content", true)
+  result = xmlCheckedTag(e, "meta", "name http-equiv content charset" &
+    commonAttr, "", true)
+
+macro meter*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``meter`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "meter", "value min max low high optimum" &
+    commonAttr)
+
+macro nav*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``nav`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "nav", commonAttr)
 
 macro noscript*(e: varargs[untyped]): untyped =
   ## generates the HTML ``noscript`` element.
@@ -345,13 +453,13 @@ macro noscript*(e: varargs[untyped]): untyped =
 macro `object`*(e: varargs[untyped]): untyped =
   ## generates the HTML ``object`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "object", "classid data codebase declare type " &
-    "codetype archive standby width height name tabindex" & commonAttr)
+  result = xmlCheckedTag(e, "object", "data type typemustmatch name usemap " &
+    "form width height" & commonAttr)
 
 macro ol*(e: varargs[untyped]): untyped =
   ## generates the HTML ``ol`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "ol", commonAttr)
+  result = xmlCheckedTag(e, "ol", "reversed start type" & commonAttr)
 
 macro optgroup*(e: varargs[untyped]): untyped =
   ## generates the HTML ``optgroup`` element.
@@ -361,7 +469,13 @@ macro optgroup*(e: varargs[untyped]): untyped =
 macro option*(e: varargs[untyped]): untyped =
   ## generates the HTML ``option`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "option", "selected value" & commonAttr)
+  result = xmlCheckedTag(e, "option", "disabled label selected value" &
+    commonAttr)
+
+macro output*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``output`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "output", "for form name" & commonAttr)
 
 macro p*(e: varargs[untyped]): untyped =
   ## generates the HTML ``p`` element.
@@ -371,17 +485,52 @@ macro p*(e: varargs[untyped]): untyped =
 macro param*(e: varargs[untyped]): untyped =
   ## generates the HTML ``param`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "param", "value id type valuetype", "name", true)
+  result = xmlCheckedTag(e, "param", commonAttr, "name value", true)
 
 macro pre*(e: varargs[untyped]): untyped =
   ## generates the HTML ``pre`` element.
   let e = callsite()
   result = xmlCheckedTag(e, "pre", commonAttr)
 
+macro progress*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``progress`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "progress", "value max" & commonAttr)
+
 macro q*(e: varargs[untyped]): untyped =
   ## generates the HTML ``q`` element.
   let e = callsite()
   result = xmlCheckedTag(e, "q", "cite" & commonAttr)
+
+macro rb*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``rb`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "rb", commonAttr)
+
+macro rp*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``rp`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "rp", commonAttr)
+
+macro rt*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``rt`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "rt", commonAttr)
+
+macro rtc*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``rtc`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "rtc", commonAttr)
+
+macro ruby*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``ruby`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "ruby", commonAttr)
+
+macro s*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``s`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "s", commonAttr)
 
 macro samp*(e: varargs[untyped]): untyped =
   ## generates the HTML ``samp`` element.
@@ -391,18 +540,29 @@ macro samp*(e: varargs[untyped]): untyped =
 macro script*(e: varargs[untyped]): untyped =
   ## generates the HTML ``script`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "script", "src charset defer", "type", false)
+  result = xmlCheckedTag(e, "script", "src type charset async defer " &
+    "crossorigin" & commonAttr)
+
+macro section*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``section`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "section", commonAttr)
 
 macro select*(e: varargs[untyped]): untyped =
   ## generates the HTML ``select`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "select", "name size multiple disabled tabindex" &
-    commonAttr)
+  result = xmlCheckedTag(e, "select", "autofocus disabled form multiple " &
+    "name required size" & commonAttr)
 
 macro small*(e: varargs[untyped]): untyped =
   ## generates the HTML ``small`` element.
   let e = callsite()
   result = xmlCheckedTag(e, "small", commonAttr)
+
+macro source*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``source`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "source", "type" & commonAttr, "src", true)
 
 macro span*(e: varargs[untyped]): untyped =
   ## generates the HTML ``span`` element.
@@ -417,7 +577,7 @@ macro strong*(e: varargs[untyped]): untyped =
 macro style*(e: varargs[untyped]): untyped =
   ## generates the HTML ``style`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "style", "media title", "type")
+  result = xmlCheckedTag(e, "style", "media type" & commonAttr)
 
 macro sub*(e: varargs[untyped]): untyped =
   ## generates the HTML ``sub`` element.
@@ -432,56 +592,76 @@ macro sup*(e: varargs[untyped]): untyped =
 macro table*(e: varargs[untyped]): untyped =
   ## generates the HTML ``table`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "table", "summary border cellpadding cellspacing" &
-    " frame rules width" & commonAttr)
+  result = xmlCheckedTag(e, "table", "border sortable" & commonAttr)
 
 macro tbody*(e: varargs[untyped]): untyped =
   ## generates the HTML ``tbody`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "tbody", "align valign" & commonAttr)
+  result = xmlCheckedTag(e, "tbody", commonAttr)
 
 macro td*(e: varargs[untyped]): untyped =
   ## generates the HTML ``td`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "td", "colspan rowspan abbr axis headers scope" &
-    " align valign" & commonAttr)
+  result = xmlCheckedTag(e, "td", "colspan rowspan headers" & commonAttr)
+
+macro `template`*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``template`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "template", commonAttr)
 
 macro textarea*(e: varargs[untyped]): untyped =
   ## generates the HTML ``textarea`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "textarea", " name disabled readonly accesskey" &
-    " tabindex" & commonAttr, "rows cols", false)
+  result = xmlCheckedTag(e, "textarea", "autocomplete autofocus cols " &
+    "dirname disabled form inputmode maxlength minlength name placeholder " &
+    "readonly required rows wrap" & commonAttr)
 
 macro tfoot*(e: varargs[untyped]): untyped =
   ## generates the HTML ``tfoot`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "tfoot", "align valign" & commonAttr)
+  result = xmlCheckedTag(e, "tfoot", commonAttr)
 
 macro th*(e: varargs[untyped]): untyped =
   ## generates the HTML ``th`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "th", "colspan rowspan abbr axis headers scope" &
-    " align valign" & commonAttr)
+  result = xmlCheckedTag(e, "th", "colspan rowspan headers abbr scope axis" &
+    " sorted" & commonAttr)
 
 macro thead*(e: varargs[untyped]): untyped =
   ## generates the HTML ``thead`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "thead", "align valign" & commonAttr)
+  result = xmlCheckedTag(e, "thead", commonAttr)
+
+macro time*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``time`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "time", "datetime" & commonAttr)
 
 macro title*(e: varargs[untyped]): untyped =
   ## generates the HTML ``title`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "title")
+  result = xmlCheckedTag(e, "title", commonAttr)
 
 macro tr*(e: varargs[untyped]): untyped =
   ## generates the HTML ``tr`` element.
   let e = callsite()
-  result = xmlCheckedTag(e, "tr", "align valign" & commonAttr)
+  result = xmlCheckedTag(e, "tr",  commonAttr)
+
+macro track*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``track`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "track", "kind srclang label default" &
+    commonAttr, "src", true)
 
 macro tt*(e: varargs[untyped]): untyped =
   ## generates the HTML ``tt`` element.
   let e = callsite()
   result = xmlCheckedTag(e, "tt", commonAttr)
+
+macro u*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``u`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "u", commonAttr)
 
 macro ul*(e: varargs[untyped]): untyped =
   ## generates the HTML ``ul`` element.
@@ -492,6 +672,17 @@ macro `var`*(e: varargs[untyped]): untyped =
   ## generates the HTML ``var`` element.
   let e = callsite()
   result = xmlCheckedTag(e, "var", commonAttr)
+
+macro video*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``video`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "video", "src crossorigin poster preload " &
+    "autoplay mediagroup loop muted controls width height" & commonAttr)
+
+macro wbr*(e: varargs[untyped]): untyped =
+  ## generates the HTML ``wbr`` element.
+  let e = callsite()
+  result = xmlCheckedTag(e, "wbr", commonAttr, "", true)
 
 when isMainModule:
   let nim = "Nim"


### PR DESCRIPTION
Continuation of #8788. Follows the HTML spec here: https://www.w3.org/TR/html50/dom.html#elements

- 1 obsolete element removed: `<acronym>`
- 36 elements added: `<abbr>, <article>, <aside>, <audio>, <bdi>, <bdo>, <canvas>, <data>, <datalist>, <embed>, <figure>, <figcaption>, <footer>, <header>, <iframe>, <keygen>, <main>, <mark>, <meter>, <nav>, <output>, <progress>, <rb>, <rp>, <rt>, <rtc>, <ruby>, <s>, <section>, <source>, <template>, <time>, <track>, <u>, <video>, <wbr>`
- All elements now have `commonAttr` ("global attributes" in spec)
- A number of obsolete attributes removed: `accesskey, align, charset, longdesc, profile, valign, classid, codebase, declare, codetype, archive, standby`
- 1 typo fixed: `encype` is now `enctype`
- Move some attributes that are not required to optional.