### PR TITLE
refactor everything to reuse lineInfoToString; allows customizing file(line, col) vs file:line:col for sublimtext + other editors

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -29,6 +29,8 @@ from modulegraphs import ModuleGraph
 when hasFFI:
   import evalffi
 
+import system/helpers # for `lineInfoToString`
+
 type
   TRegisterKind = enum
     rkNone, rkNode, rkInt, rkFloat, rkRegisterAddr, rkNodeAddr
@@ -66,15 +68,11 @@ proc stackTraceAux(c: PCtx; x: PStackFrame; pc: int; recursionLimit=100) =
     stackTraceAux(c, x.next, x.comesFrom, recursionLimit-1)
     var info = c.debug[pc]
     # we now use the same format as in system/except.nim
-    var s = substr(toFilename(c.config, info), 0)
+
+    var s = substr(tLineInfoToStr(c.config, info))
     # this 'substr' prevents a strange corruption. XXX This needs to be
     # investigated eventually but first attempts to fix it broke everything
     # see the araq-wip-fixed-writebarrier branch.
-    var line = toLinenumber(info)
-    if line > 0:
-      add(s, '(')
-      add(s, $line)
-      add(s, ')')
     if x.prc != nil:
       for k in 1..max(1, 25-s.len): add(s, ' ')
       add(s, x.prc.name.s)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -69,10 +69,7 @@ proc stackTraceAux(c: PCtx; x: PStackFrame; pc: int; recursionLimit=100) =
     var info = c.debug[pc]
     # we now use the same format as in system/except.nim
 
-    var s = substr(tLineInfoToStr(c.config, info))
-    # this 'substr' prevents a strange corruption. XXX This needs to be
-    # investigated eventually but first attempts to fix it broke everything
-    # see the araq-wip-fixed-writebarrier branch.
+    var s = tLineInfoToStr(c.config, info)
     if x.prc != nil:
       for k in 1..max(1, 25-s.len): add(s, ' ')
       add(s, x.prc.name.s)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -8,7 +8,7 @@
 #
 
 include "system/inclrtl"
-include "system/helpers"
+import system/helpers
 
 ## This module contains the interface to the compiler's abstract syntax
 ## tree (`AST`:idx:). Macros operate on this tree.

--- a/lib/pure/parsecsv.nim
+++ b/lib/pure/parsecsv.nim
@@ -51,6 +51,8 @@
 import
   lexbase, streams
 
+import system/helpers
+
 type
   CsvRow* = seq[string] ## a row in a CSV file
   CsvParser* = object of BaseLexer ## the parser object.
@@ -73,7 +75,7 @@ proc raiseEInvalidCsv(filename: string, line, col: int,
   if filename.len == 0:
     e.msg = "Error: " & msg
   else:
-    e.msg = filename & "(" & $line & ", " & $col & ") Error: " & msg
+    e.msg = lineInfoToString(filename, line, col) & " Error: " & msg
   raise e
 
 proc error(my: CsvParser, pos: int, msg: string) =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2899,9 +2899,8 @@ type
     fspCur            ## Seek relative to current position
     fspEnd            ## Seek relative to end
 
-include "system/helpers" # for `lineInfoToString`
-
 when not defined(JS): #and not defined(nimscript):
+  include "system/helpers"
   {.push stack_trace: off, profiler:off.}
 
   when hasAlloc:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3428,6 +3428,7 @@ when not defined(JS): #and not defined(nimscript):
       """.}
 
 elif defined(JS):
+  include "system/helpers"
   # Stubs:
   proc getOccupiedMem(): int = return -1
   proc getFreeMem(): int = return -1

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4239,3 +4239,8 @@ when defined(genode):
       componentConstructHook(env)
         # Perform application initialization
         # and return to thread entrypoint.
+
+type DummyTypeLast* = object
+  ## Use case: `when declared(DummyTypeLast): export foo` where foo is in a
+  ## `bar.nim`, where system.nim has "include bar" and another module has
+  ## `import bar` ; see example in system/helpers.nim

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -226,13 +226,11 @@ proc auxWriteStackTrace(f: PFrame; s: var seq[StackTraceEntry]) =
     it = it.prev
     dec last
 
-template addFrameEntry(s, f: untyped) =
+template addFrameEntry(s: var string, f: PFrame|StackTraceEntry) =
   var oldLen = s.len
-  add(s, f.filename)
-  if f.line > 0:
-    add(s, '(')
-    add(s, $f.line)
-    add(s, ')')
+  # TODO: factor with compiler/vm.nim
+  # TODO: add TFrame.col field
+  s.add lineInfoToString($f.filename, f.line)
   for k in 1..max(1, 25-(s.len-oldLen)): add(s, ' ')
   add(s, f.procname)
   add(s, "\n")

--- a/lib/system/helpers.nim
+++ b/lib/system/helpers.nim
@@ -3,18 +3,34 @@
 #
 # TODO: move other things here that should not be exposed in system.nim
 
+# NOTE: currently line info line numbers start with 1,
+# but column numbers start with 0, however most editors expect
+# first column to be 1, so we need to +1 here
 const colOffset = 1
 
-proc lineInfoToString(file: string, line, column: int): string =
-  file & "(" & $line & ", " & $column & ")"
+const colEmpty = -1
 
-proc `$`(info: type(instantiationInfo(0))): string =
-  # The +1 is needed here
+proc lineInfoToString(file: string, line, col = colEmpty): string =
+  when defined(locationFormatSublime):
+    # file:line:col is understood by sublimetext and other editors
+    result = file & ":" & $line
+    if col > 0:
+      result.add ":" & $col
+  else:
+    # this format is understood by other text editors: it is the same that
+    # Borland and Freepascal use
+    result = file & "(" & $line
+    if col > 0:
+      result.add ", " & $col
+    result.add ")"
+  result.add " "
+
+type InstantiationInfo = tuple[filename: string, line: int, column: int]
+
+proc `$`(info: InstantiationInfo): string =
   lineInfoToString(info.fileName, info.line, info.column+colOffset)
 
-when declared(DummyTypeLast):
-  # TODO: how to export a single overload?
-  # export `$`
+when declared(systemWasImported):
+  # TODO: how to export a single overload? (eg: above `$` overload)
   export lineInfoToString
   export colOffset
-

--- a/lib/system/helpers.nim
+++ b/lib/system/helpers.nim
@@ -3,9 +3,18 @@
 #
 # TODO: move other things here that should not be exposed in system.nim
 
+const colOffset = 1
+
 proc lineInfoToString(file: string, line, column: int): string =
   file & "(" & $line & ", " & $column & ")"
 
 proc `$`(info: type(instantiationInfo(0))): string =
   # The +1 is needed here
-  lineInfoToString(info.fileName, info.line, info.column+1)
+  lineInfoToString(info.fileName, info.line, info.column+colOffset)
+
+when declared(DummyTypeLast):
+  # TODO: how to export a single overload?
+  # export `$`
+  export lineInfoToString
+  export colOffset
+


### PR DESCRIPTION
* refactored all known instances where a (file,line) or (file,line,col) was being stringified to reuse `lineInfoToString` instead of custom code

* passing `-d:locationFormatSublime` now allows formatting all `(file,line,col)` messages using `file:line:col` instead of the default `file(line, col)` ; this is useful for editors like sublimetext and many others which understand the `file:line:col` format but not the `file(line, col)` format; for example:
typing `subl file:line:col` opens editor to file at specified line, col
it also allows other tools to work seamlessly, eg on OSX, semantic history (see attached image) allows simply clicking on a file:line:col and it'll open in editor of choice (eg sublimetext), without any other interaction required.

![image](https://user-images.githubusercontent.com/2194784/44712569-f7c37200-aa65-11e8-82a3-8b2c804e3e5c.png)

this saves a lot of time.

