### PR TITLE
fix 3 tests on OSX: "The deprecated ucontext routines require _XOPEN_SOURCE to be defined"

### DIFF
--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -115,7 +115,12 @@ elif coroBackend == CORO_BACKEND_SETJMP:
 when defined(unix):
   # GLibc fails with "*** longjmp causes uninitialized stack frame ***" because
   # our custom stacks are not initialized to a magic value.
-  {.passC: "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"}
+  when defined(osx):
+    # workaround: error: The deprecated ucontext routines require _XOPEN_SOURCE to be defined
+    const extra = " -D_XOPEN_SOURCE"
+  else:
+    const extra = ""
+  {.passC: "-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0" & extra.}
 
 const
   CORO_CREATED = 0


### PR DESCRIPTION
fixes these tests on OSX:

tests/coroutines/texceptions.nim
tests/coroutines/tgc.nim
tests/coroutines/titerators.nim


before PR:
```
Test "tests/coroutines/tgc.nim" in category "coroutines"
Failure: reNimcCrash
Expected:


Gotten:
Hint: used config file '/Users/timothee/git_clone/nim/Nim/config/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/Nim/tests/coroutines/tgc.nim.cfg' [Conf]
CC: stdlib_coro
CC: stdlib_lists
Error: execution of an external compiler program 'clang -c  -w -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0  -I/Users/timothee/git_clone/nim/Nim/lib -o /Users/timothee/git_clone/nim/Nim/nimcache/tests/coroutines/tgc.nim_0d61f8370cad1d412f80b84d143e1257/stdlib_lists.c.o /Users/timothee/git_clone/nim/Nim/nimcache/tests/coroutines/tgc.nim_0d61f8370cad1d412f80b84d143e1257/stdlib_lists.c' failed with exit code: 1

In file included from /Users/timothee/git_clone/nim/Nim/nimcache/tests/coroutines/tgc.nim_0d61f8370cad1d412f80b84d143e1257/stdlib_lists.c:11:
/usr/include/ucontext.h:43:2: error: The deprecated ucontext routines require _XOPEN_SOURCE to be defined
#error The deprecated ucontext routines require _XOPEN_SOURCE to be defined
 ^
/Users/timothee/git_clone/nim/Nim/nimcache/tests/coroutines/tgc.nim_0d61f8370cad1d412f80b84d143e1257/stdlib_lists.c:194:1: error: unknown type name 'ucontext_t'
ucontext_t execContext;
^
2 errors generated.

FAIL: titerators.nim C
```

see also: https://stackoverflow.com/questions/6330002/how-to-resolve-mac-os-xopen-source-error-in-xcode-while-compiling
it mentions: #define _XOPEN_SOURCE 600 but then another link below answer (https://stackoverflow.com/questions/6330002/how-to-resolve-mac-os-xopen-source-error-in-xcode-while-compiling#comment12322624_6330053) mentions `#define _XOPEN_SOURCE        /* or any value < 500 */`
