### PR TITLE
Improve enumerate macro

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5448,12 +5448,17 @@ type ``system.ForLoopStmt`` can rewrite the entirety of a ``for`` loop:
     newFor.add x[^2][1]
     newFor.add body
     result.add newFor
+    # now wrap the whole macro in a block to create a new scope
+    result = quote do:
+      block: `result`
 
   for a, b in enumerate(items([1, 2, 3])):
     echo a, " ", b
 
-  for a2, b2 in enumerate([1, 2, 3, 5]):
-    echo a2, " ", b2
+  # without wrapping the macro in a block, we'd need to choose different
+  # names for `a` and `b` here to avoid redefinition errors
+  for a, b in enumerate([1, 2, 3, 5]):
+    echo a, " ", b
 
 
 Currently for loop macros must be enabled explicitly

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5463,12 +5463,11 @@ via ``{.experimental: "forLoopMacros".}``.
 Case statement macros
 ---------------------
 
-A macro that needs to be called `match`:idx: can be used to
-rewrite ``case`` statements in order to
-implement `pattern matching`:idx: for certain types. The following
-example implements a simplistic form of pattern matching for tuples,
-leveraging the existing equality operator for tuples (as provided in
- ``system.==``):
+A macro that needs to be called `match`:idx: can be used to rewrite
+``case`` statements in order to implement `pattern matching`:idx: for
+certain types. The following example implements a simplistic form of
+pattern matching for tuples, leveraging the existing equality operator
+for tuples (as provided in ``system.==``):
 
 .. code-block:: nim
     :test: "nim c $1"


### PR DESCRIPTION
After discussion in irc about issue #8818 (https://irclogs.nim-lang.org/30-08-2018.html#15:54:55), the experimental `enumerate` macro was proposed as a workaround.

This PR wraps the example macro in the manual in a block to create a new scope to avoid polluting the calling scope with a bunch of (to be reused) variable names.

I left the test case untouched and also fixed the line breaks for the case statement macro in the manual below, which previously (for me locally anyways) wouldn't produce a code block.