### PR TITLE
system/excpt: nil is no longer vaild for seqs

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -307,7 +307,7 @@ when hasSomeStackTrace:
     when NimStackTrace:
       auxWriteStackTrace(framePtr, s)
     else:
-      s = nil
+      s = @[]
 
   proc stackTraceAvailable(): bool =
     when NimStackTrace:


### PR DESCRIPTION
Fix building Nim with `-d:nativeStacktrace`