### PR TITLE
new function: strAppend(1+2, "foo")

### DIFF
--- a/lib/pure/strappend.nim
+++ b/lib/pure/strappend.nim
@@ -1,0 +1,18 @@
+import std/macros
+
+macro strAppend*(args: varargs[typed]): untyped =
+  ## like ``echo`` but returns a string
+  runnableExamples:
+    doAssert strAppend() == ""
+    doAssert strAppend(1+2, "foo") == "3foo"
+  result = newStmtList()
+  var myBlock = newStmtList()
+  var ret = genSym(nskVar, "ret")
+  myBlock.add newVarStmt(ret, newStrLitNode(""))
+  for i in 0..<args.len:
+    let ai = args[i]
+    myBlock.add quote do:
+      `ret`.add $`ai`
+  myBlock.add quote do:
+    `ret`
+  result.add newBlockStmt(myBlock)


### PR DESCRIPTION
/cc @Araq 

* allows: `strAppend(arg1, arg2, arg3, ...)`
IMO `strAppend` is more readable in lots of cases, eg:
```nim
strAppend("foo", 1+2, 3==4, a[0])
"foo" & $(1+2) & $(3==4) & $a[0]  # too many symbols; it's hard to parse & and $ and easy to mistype (for me!)
```
