### PR TITLE
[WIP] Consistent use of nkArgList over nkBracket

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -995,7 +995,7 @@ proc genAndOr(p: BProc, e: PNode, d: var TLoc, m: TMagic) =
 proc genEcho(p: BProc, n: PNode) =
   # this unusal way of implementing it ensures that e.g. ``echo("hallo", 45)``
   # is threadsafe.
-  internalAssert p.config, n.kind == nkBracket
+  internalAssert p.config, n.kind == nkArgList
   if p.config.target.targetOS == osGenode:
     # echo directly to the Genode LOG session
     var args: Rope = nil
@@ -2305,6 +2305,11 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
       putIntoDest(p, d, n, genSetNode(p, n))
     else:
       genSetConstr(p, n, d)
+  of nkArgList:
+    if n.len == 0:
+      putIntoDest(p, d, n, rope"NIM_NIL")
+    else:
+      genArrayConstr(p, n, d)
   of nkBracket:
     if isDeepConstExpr(n) and n.len != 0:
       exprComplexConst(p, n, d)

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1294,7 +1294,7 @@ proc genCall(p: PProc, n: PNode, r: var TCompRes) =
 
 proc genEcho(p: PProc, n: PNode, r: var TCompRes) =
   let n = n[1].skipConv
-  internalAssert p.config, n.kind == nkBracket
+  internalAssert p.config, n.kind == nkArgList
   useMagic(p, "toJSStr") # Used in rawEcho
   useMagic(p, "rawEcho")
   add(r.res, "rawEcho(")
@@ -2095,7 +2095,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
       genCall(p, n, r)
   of nkClosure: gen(p, n[0], r)
   of nkCurly: genSetConstr(p, n, r)
-  of nkBracket: genArrayConstr(p, n, r)
+  of nkBracket, nkArgList: genArrayConstr(p, n, r)
   of nkPar, nkTupleConstr: genTupleConstr(p, n, r)
   of nkObjConstr: genObjConstr(p, n, r)
   of nkHiddenStdConv, nkHiddenSubConv, nkConv: genConv(p, n, r)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1089,7 +1089,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     unused(c, n, dest)
     let n = n[1].skipConv
     let x = c.getTempRange(n.len, slotTempUnknown)
-    internalAssert c.config, n.kind == nkBracket
+    internalAssert c.config, n.kind == nkArgList
     for i in 0..<n.len:
       var r: TRegister = x+i
       c.gen(n.sons[i], r)
@@ -1933,7 +1933,7 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
     unused(c, n, dest)
   of nkStringToCString, nkCStringToString:
     gen(c, n.sons[0], dest)
-  of nkBracket: genArrayConstr(c, n, dest)
+  of nkBracket, nkArgList: genArrayConstr(c, n, dest)
   of nkCurly: genSetConstr(c, n, dest)
   of nkObjConstr: genObjConstr(c, n, dest)
   of nkPar, nkClosure, nkTupleConstr: genTupleConstr(c, n, dest)

--- a/tests/macros/ttemplatesymbols.nim
+++ b/tests/macros/ttemplatesymbols.nim
@@ -127,22 +127,22 @@ inspectUntyped bindSym("overloadedTemplate"), """bindSym("overloadedTemplate")""
 
 inspectSymbol normalProc, """
 proc normalProc(x: int) =
-  echo [x]
+  echo x
 
 """
 
 inspectSymbol bindSym("normalProc"), """
 proc normalProc(x: int) =
-  echo [x]
+  echo x
 
 """
 
 inspectSymbol overloadedProc, """
 proc overloadedProc(x: int) =
-  echo [x]
+  echo x
 
 proc overloadedProc(x: string) =
-  echo [x]
+  echo x
 
 proc overloadedProc[T](x: T) =
   echo x
@@ -153,7 +153,7 @@ proc overloadedProc[T](x: T) =
 
 inspectSymbol overloadedProc[float], """
 proc overloadedProc(x: T) =
-  echo [x]
+  echo x
 
 """
   # As expected, when we select a specific generic, the
@@ -161,10 +161,10 @@ proc overloadedProc(x: T) =
 
 inspectSymbol bindSym("overloadedProc"), """
 proc overloadedProc(x: int) =
-  echo [x]
+  echo x
 
 proc overloadedProc(x: string) =
-  echo [x]
+  echo x
 
 proc overloadedProc[T](x: T) =
   echo x

--- a/tests/trmacros/tor.nim
+++ b/tests/trmacros/tor.nim
@@ -1,6 +1,5 @@
 discard """
-  output: '''3030
-true
+  output: '''true
 3'''
 """
 
@@ -8,7 +7,13 @@ template arithOps: untyped = (`+` | `-` | `*`)
 template testOr{ (arithOps{f})(a, b) }(a, b, f: untyped): untyped = f(a+1, b)
 
 let xx = 10
-echo 10*xx
+let yy = 10*xx
+
+# If you came here wondering why this assertion is failing keep in mind that the
+# number of expansions done here is capped by the hlo pass and, at the time of
+# writing, this limit is 300. The exact value may change as the AST changes so
+# don't worry, you didn't fuck up this test :)
+doAssert yy > 3000
 
 template t{x = (~x){y} and (~x){z}}(x, y, z: bool): typed =
   x = y


### PR DESCRIPTION
This patchset tries to bring some order in the vararg business: right
now a mixture of nkBracket and nkArgList is accepted, passed around and
converted back and forth, the aim is to only use the latter for all the
vararg needs.

I've slipped a small optimization in here, if the argument list is empty we just pass a `NULL` as argument. This is 100% safe in debug mode since the range checks catch this before it is deferenced and in release mode it just crashes your program :). Is this bad? Definitely less bad than what happens right now, if you manage to read outside of the 0-sized array you get garbage without any signal.

Let the bikeshed start!