### PR TITLE
Add translation support. Implements #8607

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -740,6 +740,10 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     else:
       conf.cppCustomNamespace = "Nim"
     defineSymbol(conf.symbols, "cppCompileToNamespace", conf.cppCustomNamespace)
+  of "language":
+    # used by doc/doc2 commands to translate docstrings
+    expectArg(conf, switch, arg, pass, info)
+    conf.translationLanguage = normalize(arg)
   else:
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -65,6 +65,30 @@ proc commandDoc2(graph: ModuleGraph; json: bool) =
   compileProject(graph)
   finishDoc2Pass(graph.config.projectName)
 
+proc parsePotFile(fn: string): Table[string, string] =
+  result = initTable[string, string]()
+  if not existsFile(fn):
+    return
+  var location = ""
+  var msgid = ""
+  for line in fn.lines:
+    if line.startsWith("#: "):
+      if location != "":
+        result[location & msgid] = ""
+        echo repr location & msgid
+      location = line[3..^1]
+      msgid = ""
+    elif line.startsWith("msgid "):
+      msgid = line[7..^2]
+
+proc genTranslation(graph: ModuleGraph, out_fn: string) =
+  ## Generate/overwrite .dot file used for translations
+  #var t = parsePotFile(out_fn)
+  graph.config.errorMax = 0 #high(int)  # do not stop after first error
+  #semanticPasses(graph)
+  registerPass(graph, docgen2PotPass)
+  compileProject(graph)
+
 proc commandCompileToC(graph: ModuleGraph) =
   let conf = graph.config
   extccomp.initVars(conf)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -178,6 +178,7 @@ type
     evalExpr*: string          # expression for idetools --eval
     lastCmdTime*: float        # when caas is enabled, we measure each command
     symbolFiles*: SymbolFilesOption
+    translationLanguage*: string
 
     cppDefines*: HashSet[string] # (*)
     headerFile*: string

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -7,6 +7,7 @@ Advanced commands:
   //rst2html                convert a reStructuredText file to HTML
   //rst2tex                 convert a reStructuredText file to TeX
   //jsondoc                 extract the documentation to a json file
+  //gentranslation          generate translation .pot file
   //ctags                   create a tags file
   //buildIndex              build an index for the whole documentation
   //run                     run the project (with Tiny C backend; buggy!)

--- a/po/translate.md
+++ b/po/translate.md
@@ -1,0 +1,45 @@
+## Documentation translation
+
+This document describes contributing to translations of Nim's documentation
+under `doc/` and the docstrings in the compiler and the standard library.
+
+### Helping with the translation
+
+Create an account on https://hosted.weblate.org/ and find the Nim project
+
+### Managing translation files
+
+The translation system does not depend on the gettext library, however it uses
+the .po and .pot formats to leverage existing tools like Weblate.
+
+Template translation files are stored as `po/<name>.pot`
+
+Translation files are stored as `po/<name>.<language>.po`
+
+<language> is usually either an ISO 639 two-letter language code, in lowercase
+or <lowercase ISO 639>_<uppercase ISO 3166> e.g. zh_TW
+
+Generate/update template files po/<name>.pot for a single file:
+
+```
+nim gentranslation <filename.nim>
+```
+
+Note: this command always appends any docstring found to the .pot file
+
+To generate/update template files po/<name>.pot for the whole project:
+- delete the .pot file if exists
+- run `nim gentranslation <filename>.nim` for all project files
+
+
+Update existing translation files using content from an updated .pot file
+```
+msgmerge --previous --update po/<name>.<language>.po po/<name>.pot
+```
+
+Generate docs in a language
+```
+./bin/nim doc2 --language:<language> <filename>.nim
+# or
+./koch docs --language:<language>
+```

--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -21,6 +21,7 @@ type
     authors, projectName, projectTitle, logo, infile, ticker: string
     vars: StringTableRef
     nimCompiler: string
+    language: string
     nimArgs: string
     gitURL: string
     docHTMLOutput: string
@@ -89,6 +90,7 @@ Options:
                       web/upload and doc/html
   --nimCompiler       overrides nim compiler; default = bin/nim
   --var:name=value    set the value of a variable
+  --language          set the translation language (default: no translation)
   --website           only build the website, not the full documentation
   --pdf               build the PDF version of the documentation
   --json2             build JSON of the documentation
@@ -159,6 +161,9 @@ proc parseCmdLine(c: var TConfigData) =
         c.docHTMLOutput = val / "docs"
       of "nimcompiler":
         c.nimCompiler = val
+      of "language":
+        c.language = val
+        c.nimArgs.add("--language:" & val & " ")
       of "parallelbuild":
         try:
           let num = parseInt(val)


### PR DESCRIPTION
An initial step to support translation.
This adds the "gentranslation" command to create .pot files and the --language option to "nim doc" to translate documentation.