### PR TITLE
Make sure addGotoOut always inserts its node

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -239,7 +239,7 @@ proc toStmtList(n: PNode): PNode =
 proc addGotoOut(n: PNode, gotoOut: PNode): PNode =
   # Make sure `n` is a stmtlist, and ends with `gotoOut`
   result = toStmtList(n)
-  if result.len != 0 and result.sons[^1].kind != nkGotoState:
+  if result.len == 0 or result.sons[^1].kind != nkGotoState:
     result.add(gotoOut)
 
 proc newTempVar(ctx: var Ctx, typ: PType): PSym =


### PR DESCRIPTION
Fixes #8773

You can find a before/after comparison of the AST below.
I hope the C compiler is smart enough to shake out the dead branches, otherwise we'll have to get smarter and drop the empty branches when the final `nkElse` is introduced.

No idea about how to test this tho.

<details>
 <summary>Broken AST</summary>

```nim
while true:
  var :state
  block :stateLoop:
    goto :state6
    state 0:
    {.push, warning[resultshadowed]: false.}
    var result: ResponseData
    {.pop.}
    block allRoutes:
      result.action = TCActionNothing
      result.code = 200
      result.content = ""
      var request = request
      block routesList:
      block routesList:
        case reqMethod(request)
        of HttpGet:
          block outerRoute:
            if pathInfo(request) == "/sendFile":
              block route:
                echo(["This doesn\'t get called"])
                var future515441 = foobar()
                :state = 1
                return result = future515441()
            else:
              :state = 4
              break :stateLoop
        of HttpPost:
        of HttpPut:
        of HttpDelete:
        of HttpHead:
        of HttpOptions:
        of HttpTrace:
        of HttpConnect:
        of HttpPatch:
        else:
          :state = 4
          break :stateLoop
    state 1:
    let send = read(future515441)
    :state = 2
    break :stateLoop
    state 2:
    discard send
    :state = 3
    break :stateLoop
    state 3:
    if checkAction(result):
      result.matched = true
      :state = 4
      break :stateLoop
    :state = 4
    break :stateLoop
    state 4:
    block routesList:
    :state = 5
    break :stateLoop
    state 5:
    complete(retFuture515427, result)
    :state = 6
    break :stateLoop
    state 6:
    :state = -1
    break :stateLoop
```

</details>

<details>
<summary>Correct AST w/ this patch</summary>

```nim
while true:
  var :state
  block :stateLoop:
    goto :state6
    state 0:
    {.push, warning[resultshadowed]: false.}
    var result: ResponseData
    {.pop.}
    block allRoutes:
      result.action = TCActionNothing
      result.code = 200
      result.content = ""
      var request = request
      block routesList:
      block routesList:
        case reqMethod(request)
        of HttpGet:
          block outerRoute:
            if pathInfo(request) == "/sendFile":
              block route:
                echo(["This doesn\'t get called"])
                var future515441 = foobar()
                :state = 1
                return result = future515441()
            else:
              :state = 4
              break :stateLoop
        of HttpPost:
          :state = 4
          break :stateLoop
        of HttpPut:
          :state = 4
          break :stateLoop
        of HttpDelete:
          :state = 4
          break :stateLoop
        of HttpHead:
          :state = 4
          break :stateLoop
        of HttpOptions:
          :state = 4
          break :stateLoop
        of HttpTrace:
          :state = 4
          break :stateLoop
        of HttpConnect:
          :state = 4
          break :stateLoop
        of HttpPatch:
          :state = 4
          break :stateLoop
        else:
          :state = 4
          break :stateLoop
    state 1:
    let send = read(future515441)
    :state = 2
    break :stateLoop
    state 2:
    discard send
    :state = 3
    break :stateLoop
    state 3:
    if checkAction(result):
      result.matched = true
      :state = 4
      break :stateLoop
    :state = 4
    break :stateLoop
    state 4:
    block routesList:
    :state = 5
    break :stateLoop
    state 5:
    complete(retFuture515427, result)
    :state = 6
    break :stateLoop
    state 6:
    :state = -1
    break :stateLoop
```
</details>