### PR TITLE
Correctly mangle `this` in the JS backend

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -243,7 +243,8 @@ proc mangleName(m: BModule, s: PSym): Rope =
           x.add("HEX" & toHex(ord(c), 2))
         inc i
       result = rope(x)
-    if s.name.s != "this" and s.kind != skField:
+    # From ES5 on reserved words can be used as object field names
+    if s.kind != skField:
       if optHotCodeReloading in m.config.options:
         # When hot reloading is enabled, we must ensure that the names
         # of functions and types will be preserved across rebuilds:

--- a/tests/js/tjsffi.nim
+++ b/tests/js/tjsffi.nim
@@ -267,8 +267,8 @@ block:
   type TestObject = object
     a: int
     onWhatever: proc(e: int): int
-  proc handleWhatever(that: TestObject, e: int): int =
-    e + that.a
+  proc handleWhatever(this: TestObject, e: int): int =
+    e + this.a
   proc test(): bool =
     let obj = TestObject(a: 9, onWhatever: bindMethod(handleWhatever))
     obj.onWhatever(1) == 10

--- a/tests/js/tthismangle.nim
+++ b/tests/js/tthismangle.nim
@@ -1,0 +1,23 @@
+proc moo1(this: int) =
+  doAssert this == 42
+
+proc moo2(x: int) =
+  var this = x
+  doAssert this == 42
+
+proc moo3() =
+  for this in [1,1,1]:
+    doAssert this == 1
+
+proc moo4() =
+  type
+    X = object
+      this: int
+
+  var q = X(this: 42)
+  doAssert q.this == 42
+
+moo1(42)
+moo2(42)
+moo3()
+moo4()


### PR DESCRIPTION
As shown in pragmagic/karax#67 using `this` as parameter name made the
codegen output wrong code (and the user didn't notice the errors in the
browser console).