### PR TITLE
This has been unnecessary as long as rawNewObj has called zeroMem,

### DIFF
--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -293,7 +293,6 @@ proc `$`*(ms: MemSlice): string {.inline.} =
   ## Return a Nim string built from a MemSlice.
   var buf = newString(ms.size)
   copyMem(addr(buf[0]), ms.data, ms.size)
-  buf[ms.size] = '\0'
   result = buf
 
 iterator memSlices*(mfile: MemFile, delim='\l', eat='\r'): MemSlice {.inline.} =


### PR DESCRIPTION
and more recently indexing past the Nim-logical end has become
illegal making this line cause a crash.

Not much more to say.