### PR TITLE
Don't use nkFastAsgn in transf inlining phase

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2355,14 +2355,9 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
   of nkCaseStmt: genCase(p, n, d)
   of nkReturnStmt: genReturnStmt(p, n)
   of nkBreakStmt: genBreakStmt(p, n)
-  of nkAsgn:
+  of nkAsgn, nkFastAsgn:
     if nfPreventCg notin n.flags:
-      genAsgn(p, n, fastAsgn=false)
-  of nkFastAsgn:
-    if nfPreventCg notin n.flags:
-      # transf is overly aggressive with 'nkFastAsgn', so we work around here.
-      # See tests/run/tcnstseq3 for an example that would fail otherwise.
-      genAsgn(p, n, fastAsgn=p.prc != nil)
+      genAsgn(p, n, fastAsgn=n.kind == nkFastAsgn)
   of nkDiscardStmt:
     let ex = n[0]
     if ex.kind != nkEmpty:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -111,6 +111,10 @@ proc transformSons(c: PTransf, n: PNode): PTransNode =
     result[i] = transform(c, n.sons[i])
 
 proc newAsgnStmt(c: PTransf, le: PNode, ri: PTransNode): PTransNode =
+  result = newTransNode(nkAsgn, PNode(ri).info, 2)
+  result[0] = PTransNode(le)
+  result[1] = ri
+proc newFastAsgnStmt(c: PTransf, le: PNode, ri: PTransNode): PTransNode =
   result = newTransNode(nkFastAsgn, PNode(ri).info, 2)
   result[0] = PTransNode(le)
   result[1] = ri
@@ -584,7 +588,7 @@ proc transformFor(c: PTransf, n: PNode): PTransNode =
       # generate a temporary and produce an assignment statement:
       var temp = newTemp(c, formal.typ, formal.info)
       addVar(v, temp)
-      add(stmtList, newAsgnStmt(c, temp, arg.PTransNode))
+      add(stmtList, newFastAsgnStmt(c, temp, arg.PTransNode))
       idNodeTablePut(newC.mapping, formal, temp)
     of paVarAsgn:
       assert(skipTypes(formal.typ, abstractInst).kind == tyVar)
@@ -595,7 +599,7 @@ proc transformFor(c: PTransf, n: PNode): PTransNode =
       addSonSkipIntLit(typ, formal.typ.sons[0])
       var temp = newTemp(c, typ, formal.info)
       addVar(v, temp)
-      add(stmtList, newAsgnStmt(c, temp, arg.PTransNode))
+      add(stmtList, newFastAsgnStmt(c, temp, arg.PTransNode))
       idNodeTablePut(newC.mapping, formal, temp)
 
   var body = iter.getBody.copyTree

--- a/tests/cnstseq/t2656.nim
+++ b/tests/cnstseq/t2656.nim
@@ -1,0 +1,20 @@
+discard """
+  output: '''onetwothreeonetwothreeonetwothree'''
+"""
+
+iterator it1(args: seq[string]): string =
+  for s in args: yield s
+
+iterator it2(args: seq[string]): string {.closure.} =
+  for s in args: yield s
+
+iterator it3(args: openArray[string]): string {.closure.} =
+  for s in args: yield s
+
+const myConstSeq = @["one", "two", "three"]
+for s in it1(myConstSeq):
+  stdout.write s
+for s in it2(myConstSeq):
+  stdout.write s
+for s in it3(myConstSeq):
+  stdout.write s


### PR DESCRIPTION
Doing so is dangerous since the argument may be allocated on the stack.

Fixes #2656

This also brings a (nice?) side-effect, this snippet
```nim
iterator it(args: seq[string]): string {.closure.} =
  for s in args:
    (unsafeAddr s)[0] = 'a'
    yield s
    (unsafeAddr s)[0] = 'a'

var c = it
var z = @["one", "two", "three"]
echo c(z)
echo z
```

now prints

```
ane
@["one", "two", "three"]
```

while previously it'd output

```
ane
@["ane", "two", "three"]
```
