### PR TITLE
add macros.comment(NimNode) magic to get node doc comment

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -657,7 +657,7 @@ type
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo,
     mNimvm, mIntDefine, mStrDefine, mRunnableExamples,
-    mException, mBuiltinType, mSymOwner
+    mException, mBuiltinType, mSymOwner, mComment
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -81,6 +81,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimAshr")
   defineSymbol("nimNoNilSeqs")
   defineSymbol("nimNoNilSeqs2")
+  defineSymbol("nimHasComment")
 
   defineSymbol("nimHasNilSeqs")
   for f in low(Feature)..high(Feature):

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -929,6 +929,11 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         regs[ra].node.flags.incl nfIsRef
       else:
         stackTrace(c, tos, pc, "node is not a symbol")
+    of opcComment:
+      decodeB(rkNode)
+      let a = regs[rb].node
+      createStr regs[ra]
+      regs[ra].node.strVal = a.comment
     of opcEcho:
       let rb = instr.regB
       if rb == 1:

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -142,7 +142,8 @@ type
     opcTypeTrait,
     opcMarshalLoad, opcMarshalStore,
     opcToNarrowInt,
-    opcSymOwner
+    opcSymOwner,
+    opcComment,
 
   TBlock* = object
     label*: PSym

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1119,6 +1119,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNLen: genUnaryABI(c, n, dest, opcLenSeq, nimNodeFlag)
   of mGetImpl: genUnaryABC(c, n, dest, opcGetImpl)
   of mSymOwner: genUnaryABC(c, n, dest, opcSymOwner)
+  of mComment: genUnaryABC(c, n, dest, opcComment)
   of mNChild: genBinaryABC(c, n, dest, opcNChild)
   of mNSetChild: genVoidABC(c, n, dest, opcNSetChild)
   of mNDel: genVoidABC(c, n, dest, opcNDel)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -243,6 +243,10 @@ when defined(nimHasSymOwnerInMacro):
     ## result is also mnde of kind nnkSym if owner exists otherwise 
     ## nnkNilLit is returned
 
+when defined(nimHasComment):
+  proc comment*(n: NimNode): string {.magic: "Comment", noSideEffect.}
+    ## returns ``n``'s comment (or empty string)
+
 proc getType*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
   ## with 'getType' you can access the node's `type`:idx:. A Nim type is
   ## mapped to a Nim AST too, so it's slightly confusing but it means the same

--- a/tests/macros/tgetimpl.nim
+++ b/tests/macros/tgetimpl.nim
@@ -47,3 +47,23 @@ static:
   doAssert isSameOwner(foo, poo)
   doAssert isSameOwner(foo, echo) == false
   doAssert isSameOwner(poo, len) == false
+
+block commmentTest:
+  type Foo = object ## Foo obj comment 1
+    ## Foo obj comment 2
+    a1:int ## a1 field comment 2
+
+  proc getCommentImpl(n: NimNode): string =
+    case n.kind
+    of nnkSym: result = n.getImpl.getCommentImpl
+    of nnkTypeDef: result = n[2].getCommentImpl
+    else: result = n.comment
+
+  macro getComment(n: typed): untyped = n.getCommentImpl
+
+  proc fun()=discard
+    ## fun comment
+
+  doAssert getComment(Foo) == "Foo obj comment 1\nFoo obj comment 2"
+  doAssert getComment(fun) == "fun comment"
+  # Note: Foo's fields's comments could be accessed by traversal


### PR DESCRIPTION
/cc @Araq 

* fixes: need a way to expose NimNode comments for user macros for tooling #8516

eg, could be used:

* here https://github.com/jboy/nim-docstrings /cc @jboy
> However, I can't work out how to extract the text content of the documentation comment from my own code

* and in cligen (see https://github.com/c-blake/cligen/issues/30) /cc @c-blake

* as well as user code that needs to reflect on comments (I need that in my project)

