### PR TITLE
Fix AST generation for case statements

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -624,7 +624,11 @@ proc transformCase(c: PTransf, n: PNode): PTransNode =
     case it.kind
     of nkElifBranch:
       if ifs.PNode == nil:
-        ifs = newTransNode(nkIfStmt, it.info, 0)
+        # Generate the right node depending on whether `n` is used as a stmt or
+        # as an expr
+        let kind = if n.typ != nil: nkIfExpr else: nkIfStmt
+        ifs = newTransNode(kind, it.info, 0)
+        ifs.PNode.typ = n.typ
       ifs.add(e)
     of nkElse:
       if ifs.PNode == nil: result.add(e)

--- a/tests/js/t7534.nim
+++ b/tests/js/t7534.nim
@@ -1,0 +1,7 @@
+proc f(x: int): int =
+  result = case x
+    of 1: 2
+    elif x == 2: 3
+    else: 1
+
+doAssert 2 == f(f(f(f(1))))


### PR DESCRIPTION
Fixes #7534

The C backend gets away without this by ignoring the `nkIfExpr` type altogether and uses the `nkCaseStmt` one instead.