### PR TITLE
fix #8925 by using `getTypeInst` instead of `getType`

### DIFF
--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -317,8 +317,8 @@ macro scanf*(input: string; pattern: static[string]; results: varargs[typed]): b
 
   template at(s: string; i: int): char = (if i < s.len: s[i] else: '\0')
   template matchError() =
-    error("type mismatch between pattern '$" & pattern[p] & "' (position: " & $p & ") and " & repr(getType(results[i])) &
-          " var '" & repr(results[i]) & "'")
+    error("type mismatch between pattern '$" & pattern[p] & "' (position: " & $p &
+      ") and " & $getTypeInst(results[i]) & " var '" & repr(results[i]) & "'")
 
   var i = 0
   var p = 0

--- a/tests/stdlib/t8925.nim
+++ b/tests/stdlib/t8925.nim
@@ -1,0 +1,16 @@
+discard """
+  file: "strscans.nim"
+  errormsg: "type mismatch between pattern '$i' (position: 1) and HourRange var 'hour'"
+"""
+
+import strscans
+
+type
+  HourRange = range[0..23]
+
+var
+  hour: HourRange
+  timeStr: string
+
+if scanf(timeStr, "$i", hour):
+  discard


### PR DESCRIPTION
The error in #8925 is a result from `getType `being used on a non base type. Using `getTypeInst` we get the named type instead, which should be more helpful as an error message (and won't let us crash in `macros.nim`).

Of course in this case e.g. `HourRange` can actually be converted using `parseInt`, but allowing `ntyRange` in https://github.com/nim-lang/Nim/blob/54d22d7cdc53c8b700d717c5924e0c588d56748e/lib/pure/strscans.nim#L359 seems wrong, if we don't check the base type of the range. At least in principle it doesn't have to contain `SomeInteger`, yes?

Does this warrant a test case?