### PR TITLE
Always emit hti object types if needed

### DIFF
--- a/lib/system/hti.nim
+++ b/lib/system/hti.nim
@@ -11,7 +11,7 @@ when declared(ThisIsSystem):
   # we are in system module:
   {.pragma: codegenType, compilerproc.}
 else:
-  {.pragma: codegenType, importc.}
+  {.pragma: codegenType.}
 
 type
   # This should be the same as ast.TTypeKind

--- a/tests/ccgbugs/thtiobj.nim
+++ b/tests/ccgbugs/thtiobj.nim
@@ -1,0 +1,8 @@
+discard """
+  targets: "c cpp"
+"""
+
+import typeinfo
+
+var x = ""
+discard (getPointer(toAny(x)))


### PR DESCRIPTION
The compiler is now smart enough to emit types only if needed without
all the importc tricks. This also fixes a codegen bug where, if all the
stars align correctly, typeinfo doesn't include any definition of
`TNimType` but uses it.

Found by @skilchen in #8938