### PR TITLE
partially fix #8916 (2nd attempt)

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -240,10 +240,10 @@ proc base*(x: Any): Any =
 
 
 proc isNil*(x: Any): bool =
-  ## `isNil` for an any `x` that represents a sequence, string, cstring,
-  ## proc or some pointer type.
-  assert x.rawType.kind in {tyString, tyCString, tyRef, tyPtr, tyPointer,
-                            tySequence, tyProc}
+  ## `isNil` for an any `x` that represents a sequence, cstring, proc or some
+  ## pointer type.
+  assert x.rawType.kind in {tyCString, tyRef, tyPtr, tyPointer, tySequence,
+    tyProc}
   result = isNil(cast[ppointer](x.value)[])
 
 proc getPointer*(x: Any): pointer =

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -105,3 +105,16 @@ r = to[Something](data2)
 
 echo r.x, " ", r.y
 
+
+block:
+  type Foo = object
+    a1: string
+    a2: string
+    a3: seq[string]
+    a4: seq[int]
+    a5: seq[int]
+    a6: seq[int]
+  var foo = Foo(a2:"", a4: @[], a6: @[1])
+  foo.a6.setLen 0
+  # Note the difference between a5: null and a6: []
+  doAssert $$foo == """{"a1": "", "a2": "", "a3": null, "a4": null, "a5": null, "a6": []}"""


### PR DESCRIPTION
github didn't allow me to reopen https://github.com/nim-lang/Nim/pull/8934 so I created a newPR

## side note
in this new PR, I'm not changing behavior of tySequence as it was causing other issues:
if I changed:
```
  of akArray, akSequence:
    if a.kind == akSequence and isNil(a): s.write("null")
    else:
    ...
```
to
```
  of akArray, akSequence:
    ...
```
it would result in `SIGSEGV` in new tests I added:
```nim
var a:seq[int]
var b = toAny(a)
var c = len(b) # SIGSEGV 
```
the SIGSEGV is here in typeinfo.nim:
`of tySequence: result = cast[PGenSeq](cast[ppointer](x.value)[]).len`
looks like `a` is a seq that's indeed `nil` (as also seen with  `repr(a)` which is `[]` )

which makes me wonder why we now consider `seq` as a value type that cannot be `nil` ; if it were, this wouldn't be a problem. /cc @araq
