### PR TITLE
Fix add(string, cstring) when the lhs is null

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2741,10 +2741,11 @@ type
 when defined(JS):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =
     asm """
-      var len = `x`.length;
+      if (`x` === null) { `x` = []; }
+      var off = `x`.length;
+      `x`.length += `y`.length;
       for (var i = 0; i < `y`.length; ++i) {
-        `x`[len] = `y`.charCodeAt(i);
-        ++len;
+        `x`[off+i] = `y`.charCodeAt(i);
       }
     """
   proc add*(x: var cstring, y: cstring) {.magic: "AppendStrStr".}

--- a/tests/js/taddnilstr.nim
+++ b/tests/js/taddnilstr.nim
@@ -1,0 +1,4 @@
+var x = "foo".cstring
+var y: string
+add(y, x)
+doAssert y == "foo"


### PR DESCRIPTION
The conversion makes no sense but it doesn't crash anymore.