### PR TITLE
Fix hashing for codegenProc (sic) types

### DIFF
--- a/lib/system/hti.nim
+++ b/lib/system/hti.nim
@@ -7,12 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-when declared(ThisIsSystem):
-  # we are in system module:
-  {.pragma: codegenType, compilerproc.}
-else:
-  {.pragma: codegenType.}
-
 type
   # This should be the same as ast.TTypeKind
   # many enum fields are not used at runtime
@@ -79,7 +73,7 @@ type
     tyVoidHidden
 
   TNimNodeKind = enum nkNone, nkSlot, nkList, nkCase
-  TNimNode {.codegenType.} = object
+  TNimNode {.compilerProc.} = object
     kind: TNimNodeKind
     offset: int
     typ: ptr TNimType
@@ -92,7 +86,7 @@ type
     ntfAcyclic = 1,    # type cannot form a cycle
     ntfEnumHole = 2    # enum has holes and thus `$` for them needs the slow
                        # version
-  TNimType {.codegenType.} = object
+  TNimType {.compilerProc.} = object
     size: int
     kind: TNimKind
     flags: set[TNimTypeFlag]
@@ -109,6 +103,6 @@ type
   PNimType = ptr TNimType
 
 when defined(nimTypeNames):
-  var nimTypeRoot {.codegenType.}: PNimType
+  var nimTypeRoot {.compilerProc.}: PNimType
 
 # node.len may be the ``first`` element of a set

--- a/tests/ccgbugs/t8964.nim
+++ b/tests/ccgbugs/t8964.nim
@@ -1,0 +1,10 @@
+discard """
+  targets: "c cpp"
+"""
+
+from json import JsonParsingError
+import marshal
+
+const nothing = ""
+doAssertRaises(JsonParsingError):
+  var bar = marshal.to[int](nothing)


### PR DESCRIPTION
Since the name mangling is inhibited we should take the user-supplied
name during the sighash computation.

Fixes #8964

CC @sinkingsugar