### PR TITLE
Fix codegen for set[T] parameters

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1596,10 +1596,11 @@ proc genSwap(p: BProc, e: PNode, d: var TLoc) =
   genAssignment(p, a, b, {})
   genAssignment(p, b, tmp, {})
 
-proc rdSetElemLoc(conf: ConfigRef; a: TLoc, setType: PType): Rope =
+proc rdSetElemLoc(conf: ConfigRef; a: TLoc, typ: PType): Rope =
   # read a location of an set element; it may need a subtraction operation
   # before the set operation
   result = rdCharLoc(a)
+  let setType = typ.skipTypes(abstractPtrs)
   assert(setType.kind == tySet)
   if firstOrd(conf, setType) != 0:
     result = "($1- $2)" % [result, rope(firstOrd(conf, setType))]

--- a/tests/ccgbugs/t8967.nim
+++ b/tests/ccgbugs/t8967.nim
@@ -1,0 +1,10 @@
+discard """
+  targets: "c cpp"
+"""
+
+import marshal
+
+let orig: set[char] = {'A'..'Z'}
+let m = $$orig
+let old = to[set[char]](m)
+doAssert orig - old == {}


### PR DESCRIPTION
Sometimes sets are materialized as arrays and we must treat them as
such: the CPP backend is pickier than the C one and would sometimes
produce invalid code.

Fixes #8967

>  we treat set[char] in getParamTypeDesc

Yeah, sure, heh.