### PR TITLE
more efficient fix for #8961

### DIFF
--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -149,6 +149,12 @@ proc readLine(f: File, line: var TaintedString): bool =
   if sp == 0:
     sp = 80
     line.string.setLen(sp)
+  else:
+    when not defined(nimscript):
+      sp = cint(cast[PGenericSeq](line.string).space)
+    else:
+      line.string.setLen(sp + 1)
+
   while true:
     # memset to \L so that we can tell how far fgets wrote, even on EOF, where
     # fgets doesn't append an \L

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -145,15 +145,8 @@ proc readLine(f: File, line: var TaintedString): bool =
   var pos = 0
 
   # Use the currently reserved space for a first try
-  var sp = line.string.len
-  if sp == 0:
-    sp = 80
-    line.string.setLen(sp)
-  else:
-    when not defined(nimscript):
-      sp = cint(cast[PGenericSeq](line.string).space)
-    else:
-      line.string.setLen(sp + 1)
+  var sp = max(line.string.len, 80)
+  line.string.setLen(sp)
 
   while true:
     # memset to \L so that we can tell how far fgets wrote, even on EOF, where


### PR DESCRIPTION
see discussions in #8961 and https://github.com/nim-lang/Nim/commit/4ab99537875a763e0540fbbe48d69cad454ca792

I am taking 
```
sp = cint(cast[PGenericSeq](line.string).space)
```
literally from the old implementation. I don't know if this is a good solution.