### PR TITLE
Improve the compiler option cppCompileToNamespace

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -679,8 +679,10 @@ proc generateHeaders(m: BModule) =
   add(m.s[cfsHeaders], "#undef powerpc\L")
   add(m.s[cfsHeaders], "#undef unix\L")
 
-proc openNamespaceNim(): Rope =
-  result.add("namespace Nim {\L")
+proc openNamespaceNim(namespace: string): Rope =
+  result.add("namespace ")
+  result.add(namespace)
+  result.add(" {\L")
 
 proc closeNamespaceNim(): Rope =
   result.add("}\L")
@@ -1036,7 +1038,10 @@ proc addIntTypes(result: var Rope; conf: ConfigRef) {.inline.} =
   addf(result, "#define NIM_NEW_MANGLING_RULES\L" &
                "#define NIM_INTBITS $1\L", [
     platform.CPU[conf.target.targetCPU].intSize.rope])
-  if optUseNimNamespace in conf.globalOptions: result.add("#define USE_NIM_NAMESPACE\L")
+  if optUseNimNamespace in conf.globalOptions: 
+    result.add("#define USE_NIM_NAMESPACE ")
+    result.add(conf.cppCustomNamespace)
+    result.add("\L")
 
 proc getCopyright(conf: ConfigRef; cfile: Cfile): Rope =
   if optCompileOnly in conf.globalOptions:
@@ -1210,10 +1215,10 @@ proc genMainProc(m: BModule) =
         [m.g.mainModInit, initStackBottomCall, rope(m.labels)])
   if optNoMain notin m.config.globalOptions:
     if optUseNimNamespace in m.config.globalOptions:
-      m.s[cfsProcs].add closeNamespaceNim() & "using namespace Nim;\L"
+      m.s[cfsProcs].add closeNamespaceNim() & "using namespace " & m.config.cppCustomNamespace & ";\L"
 
     appcg(m, m.s[cfsProcs], otherMain, [])
-    if optUseNimNamespace in m.config.globalOptions: m.s[cfsProcs].add openNamespaceNim()
+    if optUseNimNamespace in m.config.globalOptions: m.s[cfsProcs].add openNamespaceNim(m.config.cppCustomNamespace)
 
 proc getSomeInitName(m: PSym, suffix: string): Rope =
   assert m.kind == skModule
@@ -1336,7 +1341,7 @@ proc genModule(m: BModule, cfile: Cfile): Rope =
     add(result, m.s[i])
     add(result, genSectionEnd(i, m.config))
     if optUseNimNamespace in m.config.globalOptions and i == cfsHeaders:
-      result.add openNamespaceNim()
+      result.add openNamespaceNim(m.config.cppCustomNamespace)
   add(result, m.s[cfsInitProc])
   if optUseNimNamespace in m.config.globalOptions: result.add closeNamespaceNim()
 
@@ -1469,7 +1474,7 @@ proc writeHeader(m: BModule) =
     add(result, genSectionStart(i, m.config))
     add(result, m.s[i])
     add(result, genSectionEnd(i, m.config))
-    if optUseNimNamespace in m.config.globalOptions and i == cfsHeaders: result.add openNamespaceNim()
+    if optUseNimNamespace in m.config.globalOptions and i == cfsHeaders: result.add openNamespaceNim(m.config.cppCustomNamespace)
   add(result, m.s[cfsInitProc])
 
   if optGenDynLib in m.config.globalOptions:

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -735,13 +735,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "nep1":
     processOnOffSwitchG(conf, {optCheckNep1}, arg, pass, info)
   of "cppcompiletonamespace":
-    if conf != nil:
-      if arg != "":
-        conf.cppCustomNamespace = arg
-      else:
-        conf.cppCustomNamespace = "Nim"
-    incl conf.globalOptions, optUseNimNamespace
-    defineSymbol(conf.symbols, "cppCompileToNamespace")
+    if arg.len > 0:
+      conf.cppCustomNamespace = arg
+    else:
+      conf.cppCustomNamespace = "Nim"
+    defineSymbol(conf.symbols, "cppCompileToNamespace", conf.cppCustomNamespace)
   else:
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -735,7 +735,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "nep1":
     processOnOffSwitchG(conf, {optCheckNep1}, arg, pass, info)
   of "cppcompiletonamespace":
-    expectNoArg(conf, switch, arg, pass, info)
+    if conf != nil:
+      if arg != "":
+        conf.cppCustomNamespace = arg
+      else:
+        conf.cppCustomNamespace = "Nim"
     incl conf.globalOptions, optUseNimNamespace
     defineSymbol(conf.symbols, "cppCompileToNamespace")
   else:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -242,6 +242,7 @@ type
     writelnHook*: proc (output: string) {.closure.}
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure.}
+    cppCustomNamespace*: string
 
 template depConfigFields*(fn) {.dirty.} =
   fn(target)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -78,7 +78,6 @@ type                          # please make sure we have under 32 options
     optListFullPaths
     optNoNimblePath
     optDynlibOverrideAll
-    optUseNimNamespace
 
   TGlobalOptions* = set[TGlobalOption]
 

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -81,7 +81,9 @@ Advanced options:
   --NimblePath:PATH         add a path for Nimble support
   --noNimblePath            deactivate the Nimble path
   --noCppExceptions         use default exception handling with C++ backend
-  --cppCompileToNamespace   use namespace "Nim" for the generated C++ code
+  --cppCompileToNamespace:namespace
+                            use the provided namespace for the generated C++ code,
+                            if no namespace is provided "Nim" will be used
   --excludePath:PATH        exclude a path from the list of search paths
   --dynlibOverride:SYMBOL   marks SYMBOL so that dynlib:SYMBOL
                             has no effect and can be statically linked instead;

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -268,7 +268,7 @@ __clang__
 
 /* wrap all Nim typedefs into namespace Nim */
 #ifdef USE_NIM_NAMESPACE
-namespace Nim {
+namespace USE_NIM_NAMESPACE {
 #endif
 
 /* bool types (C++ has it): */


### PR DESCRIPTION
Until now the option `cppCompileToNamespace` was using a hard coded "Nim" namespace, this PR makes it possible to specify a custom namespace.

This is very useful when building dynamic libraries and plugins where we want different Nim modules compiled with different options to completely use different linked code. (requires `--noMain`, `cpp`)

This PR also removes the need to link nimRtl which is currently very well broken. (at the cost of every module having a GC or regions etc.)