### PR TITLE
Fix connectUnix/bindUnix with abstract socket paths

### DIFF
--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -410,7 +410,7 @@ else:
 
 type
   Socklen* {.importc: "socklen_t", header: "<sys/socket.h>".} = cuint
-  TSa_Family* {.importc: "sa_family_t", header: "<sys/socket.h>".} = cint
+  TSa_Family* {.importc: "sa_family_t", header: "<sys/socket.h>".} = cushort
 
   SockAddr* {.importc: "struct sockaddr", header: "<sys/socket.h>",
               pure, final.} = object ## struct sockaddr

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -964,7 +964,7 @@ when defined(posix) or defined(nimdoc):
     when not defined(nimdoc):
       var socketAddr = makeUnixAddr(path)
       if socket.fd.connect(cast[ptr SockAddr](addr socketAddr),
-                        sizeof(socketAddr).Socklen) != 0'i32:
+                           (sizeof(socketAddr.sun_family) + path.len).Socklen) != 0'i32:
         raiseOSError(osLastError())
 
   proc bindUnix*(socket: Socket, path: string) =
@@ -973,7 +973,7 @@ when defined(posix) or defined(nimdoc):
     when not defined(nimdoc):
       var socketAddr = makeUnixAddr(path)
       if socket.fd.bindAddr(cast[ptr SockAddr](addr socketAddr),
-                            sizeof(socketAddr).Socklen) != 0'i32:
+                            (sizeof(socketAddr.sun_family) + path.len).Socklen) != 0'i32:
         raiseOSError(osLastError())
 
 when defined(ssl):


### PR DESCRIPTION
The only way to make this work for both abstract and non-abstract
sockets is to send the kernel an incomplete structure.

Reported by Epictek on the forum.