### PR TITLE
Always use current module as base for import/include

### DIFF
--- a/compiler/depends.nim
+++ b/compiler/depends.nim
@@ -36,10 +36,10 @@ proc addDotDependency(c: PPassContext, n: PNode): PNode =
   case n.kind
   of nkImportStmt:
     for i in countup(0, sonsLen(n) - 1):
-      var imported = getModuleName(g.config, n.sons[i])
+      var imported = getModuleName(g.config, g.module, n.sons[i])
       addDependencyAux(b, g.module.name.s, imported)
   of nkFromStmt, nkImportExceptStmt:
-    var imported = getModuleName(g.config, n.sons[0])
+    var imported = getModuleName(g.config, g.module, n.sons[0])
     addDependencyAux(b, g.module.name.s, imported)
   of nkStmtList, nkBlockStmt, nkStmtListExpr, nkBlockExpr:
     for i in countup(0, sonsLen(n) - 1): discard addDotDependency(c, n.sons[i])

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -137,7 +137,7 @@ proc importModuleAs(c: PContext; n: PNode, realModule: PSym): PSym =
                                c.config.options)
 
 proc myImportModule(c: PContext, n: PNode; importStmtResult: PNode): PSym =
-  let f = checkModuleName(c.config, n)
+  let f = checkModuleName(c.config, c.module, n)
   if f != InvalidFileIDX:
     let L = c.graph.importStack.len
     let recursion = c.graph.importStack.find(f)

--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -150,7 +150,7 @@ proc expandIncludes(graph: ModuleGraph, module: PSym, n: PNode,
   for a in n:
     if a.kind == nkIncludeStmt:
       for i in 0..<a.len:
-        var f = checkModuleName(graph.config, a.sons[i])
+        var f = checkModuleName(graph.config, module, a.sons[i])
         if f != InvalidFileIDX:
           if containsOrIncl(includedFiles, f.int):
             localError(graph.config, a.info, "recursive dependency: '$1'" %

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -526,26 +526,26 @@ proc myOpen(graph: ModuleGraph; module: PSym): PPassContext =
     graph.config.notes = graph.config.foreignPackageNotes
   result = c
 
-proc isImportSystemStmt(g: ModuleGraph; n: PNode): bool =
-  if g.systemModule == nil: return false
+proc isImportSystemStmt(c: PContext; n: PNode): bool =
+  if c.graph.systemModule == nil: return false
   case n.kind
   of nkImportStmt:
     for x in n:
       if x.kind == nkIdent:
-        let f = checkModuleName(g.config, x, false)
-        if f == g.systemModule.info.fileIndex:
+        let f = checkModuleName(c.graph.config, c.module, x, false)
+        if f == c.graph.systemModule.info.fileIndex:
           return true
   of nkImportExceptStmt, nkFromStmt:
     if n[0].kind == nkIdent:
-      let f = checkModuleName(g.config, n[0], false)
-      if f == g.systemModule.info.fileIndex:
+      let f = checkModuleName(c.graph.config, c.module, n[0], false)
+      if f == c.graph.systemModule.info.fileIndex:
         return true
   else: discard
 
 proc semStmtAndGenerateGenerics(c: PContext, n: PNode): PNode =
   if n.kind == nkDefer:
     localError(c.config, n.info, "defer statement not supported at top level")
-  if c.topStmts == 0 and not isImportSystemStmt(c.graph, n):
+  if c.topStmts == 0 and not isImportSystemStmt(c, n):
     if sfSystemModule notin c.module.flags and
         n.kind notin {nkEmpty, nkCommentStmt}:
       c.importTable.addSym c.graph.systemModule # import the "System" identifier

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1107,7 +1107,7 @@ proc semAllTypeSections(c: PContext; n: PNode): PNode =
     case n.kind
     of nkIncludeStmt:
       for i in 0..<n.len:
-        var f = checkModuleName(c.config, n.sons[i])
+        var f = checkModuleName(c.config, c.module, n.sons[i])
         if f != InvalidFileIDX:
           if containsOrIncl(c.includedFiles, f.int):
             localError(c.config, n.info, errRecursiveDependencyX % toFilename(c.config, f))
@@ -1796,7 +1796,7 @@ proc evalInclude(c: PContext, n: PNode): PNode =
   result = newNodeI(nkStmtList, n.info)
   addSon(result, n)
   for i in countup(0, sonsLen(n) - 1):
-    var f = checkModuleName(c.config, n.sons[i])
+    var f = checkModuleName(c.config, c.module, n.sons[i])
     if f != InvalidFileIDX:
       if containsOrIncl(c.includedFiles, f.int):
         localError(c.config, n.info, errRecursiveDependencyX % toFilename(c.config, f))

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -10,7 +10,7 @@
 # Low level allocator for Nim. Has been designed to support the GC.
 {.push profiler:off.}
 
-include osalloc
+include "system/osalloc"
 
 template track(op, address, size) =
   when defined(memTracker):

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -231,7 +231,7 @@ proc nimGCunref(p: pointer) {.compilerProc.} =
     dec(i)
   decRef(usrToCell(p))
 
-include gc_common
+include "system/gc_common"
 
 template beforeDealloc(gch: var GcHeap; c: PCell; msg: typed) =
   when false:

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -326,7 +326,7 @@ proc gcInvariant*() =
     markForDebug(gch)
 {.pop.}
 
-include gc_common
+include "system/gc_common"
 
 proc initGC() =
   when not defined(useNimRtl):

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -208,7 +208,7 @@ when defined(nimGcRefLeak):
         if isNil(line): break
         c_fprintf(stdout, "[Heap] %s(%s)\n", file, line)
 
-include gc_common
+include "system/gc_common"
 
 proc initGC() =
   when not defined(useNimRtl):

--- a/tests/modules/tinclfrommacro.nim
+++ b/tests/modules/tinclfrommacro.nim
@@ -1,0 +1,11 @@
+import macros
+
+# bug #8038
+macro incM(): untyped =
+  result = newTree(nnkIncludeStmt, newStrLitNode("definitions.nim"))
+incM()
+
+# bug #7466
+macro inpM(): untyped =
+  result = newTree(nnkImportStmt, newStrLitNode("definitions"))
+inpM()


### PR DESCRIPTION
Do not use the node infos since those may be inaccurate or fabricated by
the user.

For example it is extremely easy common to have literal nodes produced
by helper functions in `macros.nim` whose info points to `macros.nim`
itself.

Fixes #7466
Fixes #8038