### PR TITLE
Fix error during field access in VM

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -557,11 +557,15 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       # a = b.c
       decodeBC(rkNode)
       let src = regs[rb].node
-      if src.kind notin {nkEmpty..nkNilLit}:
-        let n = src.sons[rc + ord(src.kind == nkObjConstr)].skipColon
+      case src.kind
+      of nkEmpty..nkNilLit:
+        stackTrace(c, tos, pc, errNilAccess)
+      of nkObjConstr:
+        let n = src.sons[rc + 1].skipColon
         regs[ra].node = n
       else:
-        stackTrace(c, tos, pc, errNilAccess)
+        let n = src.sons[rc]
+        regs[ra].node = n
     of opcWrObj:
       # a.b = c
       decodeBC(rkNode)

--- a/tests/vm/t4952.nim
+++ b/tests/vm/t4952.nim
@@ -1,0 +1,17 @@
+import macros
+
+proc doCheck(tree: NimNode) =
+  let res: tuple[n: NimNode] = (n: tree)
+  assert: tree.kind == res.n.kind
+  for sub in tree:
+    doCheck(sub)
+
+macro id(body: untyped): untyped =
+  doCheck(body)
+
+id(foo((i: int)))
+
+static:
+  let tree = newTree(nnkExprColonExpr)
+  let t = (n: tree)
+  assert: t.n.kind == tree.kind


### PR DESCRIPTION
Tuple constructors can't have nkExprColonExpr but may contain NimNodes
of that kind.

Fixes #4952