### PR TITLE
Fix macro expansion in expandMacros

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1275,7 +1275,7 @@ proc boolVal*(n: NimNode): bool {.compileTime, noSideEffect.} =
   if n.kind == nnkIntLit: n.intVal != 0
   else: n == bindSym"true" # hacky solution for now
 
-macro expandMacros*(body: typed): untyped =
+macro expandMacros*(body: typed): typed =
   ## Expands one level of macro - useful for debugging.
   ## Can be used to inspect what happens when a macro call is expanded,
   ## without altering its result.
@@ -1294,7 +1294,7 @@ macro expandMacros*(body: typed): untyped =
   ## will actually dump `x + y`, but at the same time will print at
   ## compile time the expansion of the ``dump`` macro, which in this
   ## case is ``debugEcho ["x + y", " = ", x + y]``.
-  template inner(x: untyped): untyped = x
+  macro inner(x: untyped): untyped = x
 
   result = getAst(inner(body))
   echo result.toStrLit

--- a/tests/macros/t7723.nim
+++ b/tests/macros/t7723.nim
@@ -1,0 +1,19 @@
+discard """
+  msg: '''
+proc init(foo128049: int; bar128051: typedesc[int]): int =
+  foo128049
+'''
+"""
+
+import macros
+
+macro foo1(): untyped =
+  result = newStmtList()
+  result.add quote do:
+    proc init(foo: int, bar: typedesc[int]): int =
+      foo
+
+expandMacros:
+  foo1()
+
+doAssert init(1, int) == 1


### PR DESCRIPTION
Running a semanticized node trough the semantic pass was a bad idea.

Fixes #7723