### PR TITLE
Allow underscored identifiers if within accented quotes

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -139,7 +139,7 @@ type
                               # needs so much look-ahead
     currLineIndent*: int
     strongSpaces*, allowTabs*: bool
-    inAccent*: int            # if this is 1, we're inside backticks. Used to
+    inAccent*: bool           # if this is true, we're inside backticks. Used to
                               # allow underscored identifiers in accented
                               # quotes
     cursor*: CursorPosition
@@ -844,7 +844,7 @@ proc getSymbol(L: var TLexer, tok: var TToken) =
       inc(pos)
     of '_':
       # trailing underscore allowed if we're within accents
-      if buf[pos+1] notin SymChars and L.inAccent == 0:
+      if buf[pos+1] notin SymChars and not L.inAccent:
         lexMessage(L, errGenerated, "invalid token: trailing underscore")
         break
       inc(pos)
@@ -1239,11 +1239,11 @@ proc rawGetTok*(L: var TLexer, tok: var TToken) =
     of '`':
       tok.tokType = tkAccent
       # toggle `inAccent` field
-      L.inAccent = L.inAccent xor 1
+      L.inAccent = not L.inAccent
       inc(L.bufpos)
     of '_':
       inc(L.bufpos)
-      if L.buf[L.bufpos] notin SymChars+{'_'} or L.inAccent == 1:
+      if L.buf[L.bufpos] notin SymChars+{'_'} or L.inAccent:
         tok.tokType = tkSymbol
         tok.ident = L.cache.getIdent("_")
       else:


### PR DESCRIPTION
This PR slightly modifies the grammar for identifier names by allowing arbitrary underscores in identifiers iff they are written in accent quotes ``` ` ```, e.g.
```nim
let `__x__` = 5
```
is now allowed. While this example surely doesn't justify such a change to the spec, the ones shown below might. 
If there's any chance this PR is considered to be merged, I'll happily modify the spec and provide a few test cases. To be fair I'm not sure if this change might have some unforeseen consequences. All tests seem to pass on my machine at least.
#### Identifier construction
Raised by @rayman22201 here https://gitter.im/nim-lang/Nim?at=5b85e53f58a3797aa3ce3c9d, identifier construction using accented quotes in templates allows for native snake_case:
```nim
template genProc(name: untyped): untyped =
  proc `get_ name`[T](x: T): T =
    discard

genProc(number)
```
Sure, underscores are ignored so in practice it's a non issue. 

#### Python interoperability

If Nim wants to attract Python users with really good interoperability, this would be great to have. Python's "dunder" methods use double underscore identifiers, e.g. `__dict__`. 
Discussed here https://github.com/yglukhov/nimpy/issues/43 using nimpy calls to dunder methods need to be worked around using `callMethod` explicitly currently. 
With this PR we would be able to just do the following:
```nim
import nimpy

let np = pyImport("numpy")
echo np.`__dict__`
```



cc: @erhlee-bird, @alehander42, @yglukhov 