### PR TITLE
Fix linking issue in cpp codegen

### DIFF
--- a/lib/system/hti.nim
+++ b/lib/system/hti.nim
@@ -103,6 +103,10 @@ type
   PNimType = ptr TNimType
 
 when defined(nimTypeNames):
-  var nimTypeRoot {.compilerProc.}: PNimType
+  # Declare this variable only once in system.nim
+  when declared(ThisIsSystem):
+    var nimTypeRoot {.compilerProc.}: PNimType
+  else:
+    var nimTypeRoot {.importc.}: PNimType
 
 # node.len may be the ``first`` element of a set

--- a/tests/cpp/t9013.nim
+++ b/tests/cpp/t9013.nim
@@ -1,0 +1,9 @@
+discard """
+  targets: "cpp"
+  cmd: "nim $target --debugger:native $options $file"
+"""
+
+# The --debugger switch is needed in order to enable the defined(nimTypeNames)
+# code path in hti.nim
+import typeinfo
+var tt: Any


### PR DESCRIPTION
Declare the root symbol only once and have the other modules depending
on it emit an `extern` declaration.

Fixes #9013