### PR TITLE
Allow custom pragmas on more symbols again

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1110,7 +1110,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         else: sym.flags.incl sfUsed
       of wLiftLocals: discard
       else: invalidPragma(c, it)
-    elif sym.kind in {skField,skProc,skFunc,skConverter,skMethod,skType}:
+    elif sym.kind in {skVar,skLet,skParam,skField,skProc,skFunc,skConverter,skMethod,skType}:
       n.sons[i] = semCustomPragma(c, it)
     else:
       illegalCustomPragma(c, it, sym)


### PR DESCRIPTION
#8765 disabled custom pragmas on most symbols. Until now I [was using them extensively](https://github.com/fragcolor-xyz/nim2spirv) on variables, etc.
Is the set of allowed locations specified somewhere? Would we need anything else to extend it again?