### PR TITLE
Fix locals() interaction with generic types

### DIFF
--- a/compiler/plugins/locals.nim
+++ b/compiler/plugins/locals.nim
@@ -29,7 +29,7 @@ proc semLocals*(c: PContext, n: PNode): PNode =
             {tyVarargs, tyOpenArray, tyTypeDesc, tyStatic, tyExpr, tyStmt, tyEmpty}:
 
         var field = newSym(skField, it.name, getCurrOwner(c), n.info)
-        field.typ = it.typ.skipTypes({tyGenericInst, tyVar})
+        field.typ = it.typ.skipTypes({tyVar})
         field.position = counter
         inc(counter)
 

--- a/tests/misc/tlocals.nim
+++ b/tests/misc/tlocals.nim
@@ -9,3 +9,22 @@ proc simple[T](a: T) =
 
 simple(1)
 
+type Foo2[T]=object
+  a2: T
+
+proc numFields*(T: typedesc[tuple|object]): int=
+  var t:T
+  for _ in t.fields: inc result
+
+proc test(baz: int, qux: var int): int =
+  var foo: Foo2[int]
+  let bar = "abc"
+  let c1 = locals()
+  doAssert numFields(c1.foo.type) == 1
+  doAssert c1.bar == "abc"
+  doAssert c1.baz == 123
+  doAssert c1.result == 0
+  doAssert c1.qux == 456
+
+var x1 = 456
+discard test(123, x1)


### PR DESCRIPTION
Follow the same logic as semTupleFieldsConstr and only skip skVar since
we're gonna add a nkDefer anyway.

Fixes #8985