### PR TITLE
ioselectors_poll: don't pollRemove() if not needed

### DIFF
--- a/lib/pure/ioselects/ioselectors_poll.nim
+++ b/lib/pure/ioselects/ioselectors_poll.nim
@@ -172,8 +172,9 @@ proc unregister*[T](s: Selector[T], fd: int|SocketHandle) =
   doAssert(pkey.ident != InvalidIdent,
            "Descriptor [" & $fdi & "] is not registered in the queue!")
   pkey.ident = InvalidIdent
-  pkey.events = {}
-  s.pollRemove(fdi.cint)
+  if pkey.events != {}:
+    pkey.events = {}
+    s.pollRemove(fdi.cint)
 
 proc unregister*[T](s: Selector[T], ev: SelectEvent) =
   let fdi = int(ev.rfd)


### PR DESCRIPTION
`pollAdd()` is called only if the events set isn't empty. This fixes some tests on Haiku.