### PR TITLE
Allow walkDir to work on hierarchies with dangling symbolic links

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,9 @@
   bring the language in line with the standard library (e.g. ``parseOct``).
 - The dot style for import paths (e.g ``import path.to.module`` instead of
   ``import path/to/module``) has been deprecated.
+- ``os.PathComponent`` grew a new enum element ``pcLinkUnresolvable`` to cover
+   the case of dangling symlinks on POSIX.  ``case`` statements expecting
+   complete coverage of enum values may need updating.
 
 #### Breaking changes in the standard library
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -800,7 +800,7 @@ type
     pcFile,               ## path refers to a file
     pcLinkToFile,         ## path refers to a symbolic link to a file
     pcDir,                ## path refers to a directory
-    pcLinkToDir           ## path refers to a symbolic link to a directory
+    pcLinkToDir,          ## path refers to a symbolic link to a directory
     pcLinkUnresolvable    ## path refers to an unresolvable symbolic link
 
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -801,6 +801,7 @@ type
     pcLinkToFile,         ## path refers to a symbolic link to a file
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
+    pcLinkUnresolvable    ## path refers to an unresolvable symbolic link
 
 
 when defined(posix):
@@ -809,8 +810,8 @@ when defined(posix):
     var s: Stat
     assert(path != "")
     if stat(path, s) < 0'i32:
-      raiseOSError(osLastError())
-    if S_ISDIR(s.st_mode):
+      result = pcLinkUnresolvable
+    elif S_ISDIR(s.st_mode):
       result = pcLinkToDir
     else:
       result = pcLinkToFile
@@ -957,7 +958,7 @@ proc removeDir*(dir: string) {.rtl, extern: "nos$1", tags: [
   ## existed in the first place.
   for kind, path in walkDir(dir):
     case kind
-    of pcFile, pcLinkToFile, pcLinkToDir: removeFile(path)
+    of pcFile, pcLinkToFile, pcLinkToDir, pcLinkUnresolvable: removeFile(path)
     of pcDir: removeDir(path)
   rawRemoveDir(dir)
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -919,6 +919,7 @@ iterator walkDirRec*(dir: string, yieldFilter = {pcFile},
   ## ``pcLinkToFile``        yield symbolic links to files
   ## ``pcDir``               yield real directories
   ## ``pcLinkToDir``         yield symbolic links to directories
+  ## ``pcLinkUnresolvable``  yield unresolvable symbolic links
   ## ---------------------   ---------------------------------------------
   ##
   ## ---------------------   ---------------------------------------------

--- a/lib/pure/oswalkdir.nim
+++ b/lib/pure/oswalkdir.nim
@@ -16,6 +16,7 @@ type
     pcLinkToFile,         ## path refers to a symbolic link to a file
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
+    pcLinkUnresolvable    ## path refers to an unresolvable symbolic link
 
 proc staticWalkDir(dir: string; relative: bool): seq[
                   tuple[kind: PathComponent, path: string]] =
@@ -31,5 +32,5 @@ iterator walkDirRec*(dir: string, filter={pcFile, pcDir}): string =
     for k,p in walkDir(stack.pop()):
       if k in filter:
         case k
-        of pcFile, pcLinkToFile: yield p
+        of pcFile, pcLinkToFile, pcLinkUnresolvable: yield p
         of pcDir, pcLinkToDir: stack.add(p)

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -247,7 +247,7 @@ proc walkDirRecursively(s: var seq[string], root, explicit: string,
           add(s, unixToNativePath(f))
       of pcDir:
         walkDirRecursively(s, f, explicit, allowHtml)
-      of pcLinkToDir: discard
+      else: discard
 
 proc addFiles(s: var seq[string], patterns: seq[string]) =
   for p in items(patterns):

--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -195,7 +195,7 @@ proc walkDirRecursively(s: var seq[string], root, ext: string) =
       if cmpIgnoreCase(ext, splitFile(f).ext) == 0:
         add(s, f)
     of pcDir: walkDirRecursively(s, f, ext)
-    of pcLinkToDir: discard
+    else: discard
 
 proc addFiles(s: var seq[string], dir, ext: string, patterns: seq[string]) =
   for p in items(patterns):


### PR DESCRIPTION
Currently, an exception is raised.  Instead this allows the user to decide what to do.  Only quasi-breaking change is complete coverage case statements as mentioned in the changelog.md diff.

File hierarchies with broken symlinks are not that uncommon on Unix/POSIX.  Sometimes programs will even create broken links on purpose using the link target for some other purpose, like a lock (firefox does this in $HOME/.mozilla, for example, Linux does in /proc/PID/fd for sockets and so forth).