### PR TITLE
fix `posix.onSignal` example, inject current signal as `s`

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -985,12 +985,18 @@ proc utimes*(path: cstring, times: ptr array[2, Timeval]): int {.
 proc handle_signal(sig: cint, handler: proc (a: cint) {.noconv.}) {.importc: "signal", header: "<signal.h>".}
 
 template onSignal*(signals: varargs[cint], body: untyped) =
-  ## Setup code to be executed when Unix signals are received. Example:
-  ## from posix import SIGINT, SIGTERM
-  ## onSignal(SIGINT, SIGTERM):
-  ##   echo "bye"
+  ## Setup code to be executed when Unix signals are received. The
+  ## currently handled signal is injected as ``s`` into the calling
+  ## scope.
+  ##
+  ## Example:
+  ##
+  ## .. code-block::
+  ##   from posix import SIGINT, SIGTERM
+  ##   onSignal(SIGINT, SIGTERM):
+  ##     echo "bye from signal ", s
 
-  for s in signals:
+  for s {.inject.} in signals:
     handle_signal(s,
       proc (sig: cint) {.noconv.} =
         body

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -986,7 +986,7 @@ proc handle_signal(sig: cint, handler: proc (a: cint) {.noconv.}) {.importc: "si
 
 template onSignal*(signals: varargs[cint], body: untyped) =
   ## Setup code to be executed when Unix signals are received. The
-  ## currently handled signal is injected as ``s`` into the calling
+  ## currently handled signal is injected as ``sig`` into the calling
   ## scope.
   ##
   ## Example:
@@ -994,11 +994,12 @@ template onSignal*(signals: varargs[cint], body: untyped) =
   ## .. code-block::
   ##   from posix import SIGINT, SIGTERM
   ##   onSignal(SIGINT, SIGTERM):
-  ##     echo "bye from signal ", s
+  ##     echo "bye from signal ", sig
 
-  for s {.inject.} in signals:
+  for s in signals:
     handle_signal(s,
-      proc (sig: cint) {.noconv.} =
+      proc (signal: cint) {.noconv.} =
+        let sig {.inject.} = signal
         body
     )
 


### PR DESCRIPTION
Fixes the code example for `posix.onSignal` for the docs and also injects the currently handled signal as `s` into the calling scope. 

For the latter maybe I'm missing something obvious and this isn't even necessary? If so, I can take that out again. Accessing `sig` in the body doesn't work. 