### PR TITLE
fix the ffDefault floating point formatting for the js backend

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1884,13 +1884,23 @@ proc formatBiggestFloat*(f: BiggestFloat, format: FloatFormatMode = ffDefault,
   ## If ``precision == -1``, it tries to format it nicely.
   when defined(js):
     var precision = precision
-    if precision == -1:
-      # use the same default precision as c_sprintf
+    if precision == -1 and format != ffDefault:
+      # for formats `ffDecimal` and `ffScientific`
+      # use the same default precision as c_sprintf.
       precision = 6
     var res: cstring
     case format
     of ffDefault:
-      {.emit: "`res` = `f`.toString();".}
+      if precision < 0:
+        # toString is similar to %g in sprintf
+        {.emit: "`res` = `f`.toString();".}
+      else:
+        if precision == 0:
+          # precision 0 is not allowed in js
+          precision = 1
+        # toPrecision is similar to %.pg in sprintf
+        # where p is the number of significant digits
+        {.emit: "`res` = `f`.toPrecision(`precision`);".}
     of ffDecimal:
       {.emit: "`res` = `f`.toFixed(`precision`);".}
     of ffScientific:

--- a/tests/float/tffDefault.nim
+++ b/tests/float/tffDefault.nim
@@ -1,0 +1,29 @@
+discard """
+  targets: "c c++ js"
+  output: "ok"
+"""
+
+import strutils
+
+var tdata = @[(f: -5.7123456789e-119, expected: "-5.712e-119", prec: 4),
+              (f: 0.000124356, expected: "0.0001243560000000000", prec: -2),
+              (f: 0.000124356, expected: "0.000124356", prec: -1),
+              (f: 0.000124356, expected: "0.0001", prec: 0),
+              (f: 0.000554356, expected: "0.0006", prec: 1),
+              (f: 0.000144999, expected: "0.0001", prec: 1),
+              (f: 0.000124356, expected: "0.00012436", prec: 5),
+              (f: 0.000124356, expected: "0.0001243560", prec: 7),
+              (f: 1e23, expected: "1.0e+23", prec: 2),
+              ]
+              
+proc test(tdata: seq[tuple[f: float, expected: string, prec: int]]) =
+  for d in tdata:
+    var ds: string
+    if d.prec < -1:
+      ds = formatBiggestFloat(d.f, ffDefault)
+    else:
+      ds = formatBiggestFloat(d.f, ffDefault, d.prec)
+    doAssert ds == d.expected, ds & " != " & d.expected
+    
+test(tdata)
+echo "ok"


### PR DESCRIPTION
The current [formatBiggestFloat](https://github.com/nim-lang/Nim/blob/devel/lib/pure/strutils.nim#L1871) does not take into account the desired precision in `ffDefault` mode. I am proposing a fix mimicking the `g` format specifier in C. The test case should show that using `ffDefault` mode, we now get the same string representation for more floats on the c, c++ and js backends than before.