### PR TITLE
Fix codegen for some set operations

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1732,7 +1732,7 @@ proc genSetOp(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
       getTemp(p, getSysType(p.module.g.graph, unknownLineInfo(), tyInt), i) # our counter
       initLocExpr(p, e.sons[1], a)
       initLocExpr(p, e.sons[2], b)
-      if d.k == locNone: getTemp(p, a.t, d)
+      if d.k == locNone: getTemp(p, setType, d)
       lineF(p, cpsStmts,
            "for ($1 = 0; $1 < $2; $1++) $n" &
            "  $3[$1] = $4[$1] $6 $5[$1];$n", [

--- a/tests/ccgbugs/t9098.nim
+++ b/tests/ccgbugs/t9098.nim
@@ -1,0 +1,12 @@
+discard """
+  targets: "c cpp js"
+  output: '''
+{'a', 'b'}
+'''
+"""
+
+var x = new(ref set[char])
+var y = new(ref set[char])
+x[] = {'a'}
+y[] = {'b'}
+echo x[] + y[]


### PR DESCRIPTION
Taking the LHS type when a temporary result value was needed lead to bad
code being generated if we get a tyRef.

Fixes #9098