### PR TITLE
fix #8341: add ignoreTrailingSep param to extractFilename

### DIFF
--- a/lib/pure/ospaths.nim
+++ b/lib/pure/ospaths.nim
@@ -391,8 +391,8 @@ proc splitFile*(path: string): tuple[dir, name, ext: string] {.
     result.name = substr(path, sepPos+1, dotPos-1)
     result.ext = substr(path, dotPos)
 
-proc extractFilename*(path: string, ignoreTrailingSep = false): string {.
-  noSideEffect, rtl, extern: "nos$1".} =
+proc extractFilename*(path: string, ignoreTrailingSep: bool): string {.
+  noSideEffect, rtl, extern: "nos$1ignoreTrailingSep".} =
   ## Extracts the filename of a given `path`. This is the same as
   ## ``name & ext`` from ``splitFile(path)`` (after removing the trailing
   ## separator when ``ignoreTrailingSep``  is true).
@@ -404,6 +404,12 @@ proc extractFilename*(path: string, ignoreTrailingSep = false): string {.
     result = ""
   else:
     result = splitPath(path).tail
+
+proc extractFilename*(path: string): string {.
+  noSideEffect, rtl, extern: "nos$1".} =
+  ## same as extractFilename(path, ignoreTrailingSep = false)
+  # Overload needed for bootstrapping
+  extractFilename(path, ignoreTrailingSep = false)
 
 proc changeFileExt*(filename, ext: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =

--- a/tests/stdlib/tospaths.nim
+++ b/tests/stdlib/tospaths.nim
@@ -39,3 +39,17 @@ else:
     doAssert unixToNativePath("../../abc") == "../../abc"
     doAssert unixToNativePath("/abc", "a") == "/abc"
     doAssert unixToNativePath("/abc/def", "a") == "/abc/def"
+
+block extractFilenameTest:
+  when defined(posix):
+    doAssert extractFilename("foo/bar") == "bar"
+    doAssert extractFilename("foo/bar.txt") == "bar.txt"
+    doAssert extractFilename("foo/") == ""
+    doAssert extractFilename("foo/bar.txt", ignoreTrailingSep = true) == "bar.txt"
+    doAssert extractFilename("foo/", ignoreTrailingSep = true) == "foo"
+when doslikeFileSystem:
+    doAssert extractFilename(r"foo\bar") == "bar"
+    doAssert extractFilename(r"foo\bar.txt") == "bar.txt"
+    doAssert extractFilename(r"foo\") == ""
+    doAssert extractFilename(r"foo\bar.txt", ignoreTrailingSep = true) == "bar.txt"
+    doAssert extractFilename(r"foo\", ignoreTrailingSep = true) == "foo"


### PR DESCRIPTION
/cc @araq
* no breaking change, just added `ignoreTrailingSep = false` param to extractFilename so user can choose desired behavior on trailing separator; ignoreTrailingSep = true gets behavior found in:
unix cmd line, C, D, node.js
* added tests: tests/stdlib/tospaths.nim
* normalizePathEnd block was moved, no change there
* works well in conjunction with parentDir (which ignores trailing separator); added a note to that effect in parentDir doc comment


