### PR TITLE
remove test_async.txt after test to keep git status clean

### DIFF
--- a/tests/async/tasyncfilewrite.nim
+++ b/tests/async/tasyncfilewrite.nim
@@ -9,6 +9,7 @@ import os, asyncfile, asyncdispatch
 const F = "test_async.txt"
 
 removeFile(F)
+defer: removeFile(F)
 let f = openAsync(F, fmWrite)
 var futs = newSeq[Future[void]]()
 for i in 1..3:


### PR DESCRIPTION
/cc @Araq 
fixes a bug where ./koch tests would leave a test_async.txt, making git status not clean