### PR TITLE
fix #9123: dyncalls buggy: dyncalls buggy: nimGetProcAddr called even though dlopen failed

### DIFF
--- a/compiler/ccgmerge.nim
+++ b/compiler/ccgmerge.nim
@@ -35,6 +35,7 @@ const
     cfsTypeInit2: "NIM_merge_TYPE_INIT2",
     cfsTypeInit3: "NIM_merge_TYPE_INIT3",
     cfsDebugInit: "NIM_merge_DEBUG_INIT",
+    cfsDynLibInitDlopen: "NIM_merge_DYNLIB_INIT_DLOPEN",
     cfsDynLibInit: "NIM_merge_DYNLIB_INIT",
     cfsDynLibDeinit: "NIM_merge_DYNLIB_DEINIT",
   ]

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -560,7 +560,7 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
         n.info = lib.path.info
         appcg(m, loadlib, "($1 = #nimLoadLibrary($2))$n",
               [tmp, genStringLiteral(m, n)])
-      appcg(m, m.s[cfsDynLibInit],
+      appcg(m, m.s[cfsDynLibInitDlopen],
             "if (!($1)) #nimLoadLibraryError($2);$n",
             [loadlib, genStringLiteral(m, lib.path)])
     else:
@@ -574,9 +574,9 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
       expr(p, lib.path, dest)
 
       add(m.s[cfsVars], p.s(cpsLocals))
-      add(m.s[cfsDynLibInit], p.s(cpsInit))
-      add(m.s[cfsDynLibInit], p.s(cpsStmts))
-      appcg(m, m.s[cfsDynLibInit],
+      add(m.s[cfsDynLibInitDlopen], p.s(cpsInit))
+      add(m.s[cfsDynLibInitDlopen], p.s(cpsStmts))
+      appcg(m, m.s[cfsDynLibInitDlopen],
            "if (!($1 = #nimLoadLibrary($2))) #nimLoadLibraryError($2);$n",
            [tmp, rdLoc(dest)])
 

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -36,6 +36,7 @@ type
     cfsTypeInit2,             # section 2 for init of type information
     cfsTypeInit3,             # section 3 for init of type information
     cfsDebugInit,             # section for init of debug information
+    cfsDynLibInitDlopen,      # section for dlopen of dynamic library binding
     cfsDynLibInit,            # section for init of dynamic library binding
     cfsDynLibDeinit           # section for deinitialization of dynamic
                               # libraries


### PR DESCRIPTION
/cc @Araq 

* fix #9123
loadDynamicLib can be reentrant, causing the bug #9123 ; this PR fixes the bug by creating a new file section
* show dlerror instead of ignoring it

**EDIT** that point will be moved to another PR:
~~-d:nimDebugDlOpen now also shows library path on dlsym error (otherwise it's unclear and in some cases ambiguous where failed symbol loading came from)~~ => https://github.com/nim-lang/Nim/pull/9202

