### PR TITLE
Fix ioTests category after rename

### DIFF
--- a/tests/testament/categories.nim
+++ b/tests/testament/categories.nim
@@ -218,7 +218,7 @@ proc ioTests(r: var TResults, cat: Category, options: string) =
   # dummy compile result:
   var c = initResults()
   testSpec c, makeTest("tests/system/helpers/readall_echo", options, cat)
-  testSpec r, makeTest("tests/system/io", options, cat)
+  testSpec r, makeTest("tests/system/tio", options, cat)
 
 # ------------------------- async tests ---------------------------------------
 proc asyncTests(r: var TResults, cat: Category, options: string) =


### PR DESCRIPTION
Broken in e39f2a9283fc63f529d74acb0d50b0035d513e79