### PR TITLE
Fix regression with runnableExamples in generic expr

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -225,7 +225,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     var mixinContext = false
     if s != nil:
       incl(s.flags, sfUsed)
-      mixinContext = s.magic in {mDefined, mDefinedInScope, mCompiles, mRunnableExamples}
+      mixinContext = s.magic in {mDefined, mDefinedInScope, mCompiles}
       let sc = symChoice(c, fn, s, if s.isMixedIn: scForceOpen else: scOpen)
       case s.kind
       of skMacro:
@@ -255,11 +255,11 @@ proc semGenericStmt(c: PContext, n: PNode,
         discard
       of skProc, skFunc, skMethod, skIterator, skConverter, skModule:
         result.sons[0] = sc
-        # do not check of 's.magic==mRoof' here because it might be some
-        # other '^' but after overload resolution the proper one:
-        if ctx.bracketExpr != nil and n.len == 2 and s.name.s == "^":
-          result.add ctx.bracketExpr
         first = 1
+        # We're not interested in the example code during this pass so let's
+        # skip it
+        if s.magic == mRunnableExamples:
+          inc first
       of skGenericParam:
         result.sons[0] = newSymNodeTypeDesc(s, fn.info)
         styleCheckUse(fn.info, s)

--- a/tests/generics/t8694.nim
+++ b/tests/generics/t8694.nim
@@ -1,0 +1,31 @@
+discard """
+  output: '''
+true
+true
+true
+'''
+"""
+
+when true:
+  # Error: undeclared identifier: '|'
+  proc bar[T](t:T): bool =
+    runnableExamples:
+      type Foo = int | float
+    true
+  echo bar(0)
+
+when true:
+  # ok
+  proc bar(t:int): bool =
+    runnableExamples:
+      type Foo = int | float
+    true
+  echo bar(0)
+
+when true:
+  # Error: undeclared identifier: '|'
+  proc bar(t:typedesc): bool =
+    runnableExamples:
+      type Foo = int | float
+    true
+  echo bar(int)

--- a/tests/generics/t9130.nim
+++ b/tests/generics/t9130.nim
@@ -1,0 +1,33 @@
+when true:
+  # stack overflow
+  template baz1*(iter: untyped): untyped =
+    runnableExamples:
+      import sugar
+      proc fun(a: proc(x:int): int) = discard
+      baz1(fun(x:int => x))
+    discard
+
+  proc foo1[A](ts: A) =
+    baz1(ts)
+
+when true:
+  # ok
+  template baz2*(iter: untyped): untyped =
+    runnableExamples:
+      import sugar
+      proc fun(a: proc(x:int): int) = discard
+      baz2(fun(x:int => x))
+    discard
+
+  proc foo2(ts: int) =
+    baz2(ts)
+
+when true:
+  # stack overflow
+  template baz3*(iter: untyped): untyped =
+    runnableExamples:
+      baz3(fun(x:int => x))
+    discard
+
+  proc foo3[A](ts: A) =
+    baz3(ts)


### PR DESCRIPTION
The examples should not enter the generic analysis at all.
The regression was introduced in 4cf704bb as a fix for #8694.

Fixes #9130
Fixes #8694