### PR TITLE
Fix #9126: use splitPath instead of substr

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1048,7 +1048,7 @@ proc copyDir*(source, dest: string) {.rtl, extern: "nos$1",
   ## these platforms use `copyDirWithPermissions() <#copyDirWithPermissions>`_.
   createDir(dest)
   for kind, path in walkDir(source):
-    var noSource = path.substr(source.len()+1)
+    var noSource = splitPath(path).tail
     case kind
     of pcFile:
       copyFile(path, dest / noSource)
@@ -1232,7 +1232,7 @@ proc copyDirWithPermissions*(source, dest: string,
       if not ignorePermissionErrors:
         raise
   for kind, path in walkDir(source):
-    var noSource = path.substr(source.len()+1)
+    var noSource = splitPath(path).tail
     case kind
     of pcFile:
       copyFileWithPermissions(path, dest / noSource, ignorePermissionErrors)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -43,6 +43,8 @@ true
 true
 true
 true
+true
+true
 
 '''
 """
@@ -130,6 +132,18 @@ echo dirExists("../dest/a/b")
 echo fileExists("../dest/a/b/file.txt")
 
 echo fileExists("../dest/a/b/c/fileC.txt")
+removeDir("../dest")
+
+# test copyDir:
+# if separator at the end of a path
+createDir("a/b")
+open("a/file.txt", fmWrite).close
+
+copyDir("a/", "../dest/a/")
+removeDir("a")
+
+echo dirExists("../dest/a/b")
+echo fileExists("../dest/a/file.txt")
 removeDir("../dest")
 
 # Test get/set modification times


### PR DESCRIPTION
Dear, developers.

With the use of substr, if separator at the end of the path, the first character of the filename will be removed.

So, we should use splitPath instead of substr.