### PR TITLE
Check if a int literal/range relationship during sigmatch

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -521,6 +521,8 @@ type
     tfCovariant       # covariant generic param mimicing a ptr type
     tfWeakCovariant   # covariant generic param mimicing a seq/array type
     tfContravariant   # contravariant generic param
+    tfUncheckedArray  # tyArray whose elements are accessed without preliminary
+                      # bound checking
 
   TTypeFlags* = set[TTypeFlag]
 
@@ -563,7 +565,6 @@ const
   routineKinds* = {skProc, skFunc, skMethod, skIterator,
                    skConverter, skMacro, skTemplate}
   tfIncompleteStruct* = tfVarargs
-  tfUncheckedArray* = tfVarargs
   tfUnion* = tfNoSideEffect
   tfGcSafe* = tfThread
   tfObjHasKids* = tfEnumHasHoles

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -749,7 +749,8 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
     add(result, seqStar(m))
   of tyArray:
     var n: BiggestInt = lengthOrd(m.config, t)
-    if n <= 0: n = 1   # make an array of at least one element
+    # make an array of at least one element
+    if tfUncheckedArray in t.flags or n <= 0: n = 1
     result = getTypeName(m, origTyp, sig)
     m.typeCache[sig] = result
     if not isImportedType(t):

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -82,6 +82,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimNoNilSeqs")
   defineSymbol("nimNoNilSeqs2")
   defineSymbol("nimHasUserErrors")
+  defineSymbol("nimUncheckedArrRange")
 
   defineSymbol("nimHasNilSeqs")
   for f in low(Feature)..high(Feature):

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -301,7 +301,7 @@ proc semArrayIndex(c: PContext, n: PNode): PType =
       if e.intVal < 0:
         localError(c.config, n[1].info,
           "Array length can't be negative, but was " & $e.intVal)
-      result = makeRangeType(c, 0, e.intVal-1, n.info, e.typ)
+      result = makeRangeType(c, 0, e.intVal - 1, n.info, e.typ)
     elif e.kind == nkSym and e.typ.kind == tyStatic:
       if e.sym.ast != nil:
         return semArrayIndex(c, e.sym.ast)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1365,7 +1365,8 @@ proc computeSizeAux(conf: ConfigRef; typ: PType, a: var BiggestInt): BiggestInt 
   of tyArray:
     let elemSize = computeSizeAux(conf, typ.sons[1], a)
     if elemSize < 0: return elemSize
-    result = lengthOrd(conf, typ.sons[0]) * elemSize
+    if tfUncheckedArray notin typ.flags:
+      result = lengthOrd(conf, typ.sons[0]) * elemSize
   of tyEnum:
     if firstOrd(conf, typ) < 0:
       result = 4              # use signed int32

--- a/lib/pure/collections/rtarrays.nim
+++ b/lib/pure/collections/rtarrays.nim
@@ -19,7 +19,6 @@ type
     L: Natural
     spart: seq[T]
     apart: array[ArrayPartSize, T]
-  UncheckedArray* {.unchecked.}[T] = array[0, T]
 
 template usesSeqPart(x): untyped = x.L > ArrayPartSize
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -253,9 +253,6 @@ type
   seq*{.magic: "Seq".}[T]  ## Generic type to construct sequences.
   set*{.magic: "Set".}[T]  ## Generic type to construct bit sets.
 
-  UncheckedArray* {.unchecked.}[T] = array[0, T]
-    ## Array with no bounds checking
-
 when defined(nimHasOpt):
   type opt*{.magic: "Opt".}[T]
 
@@ -298,6 +295,15 @@ proc low*(x: string): int {.magic: "Low", noSideEffect.}
   ##  low(arr) #=> 0
   ##  low(2) #=> -9223372036854775808
   ##  low(int) #=> -9223372036854775808
+
+when defined(nimUncheckedArrRange):
+  type
+    UncheckedArray* {.unchecked.}[T] = array[high(int), T]
+      ## Array with no bounds checking
+else:
+  type
+    UncheckedArray* {.unchecked.}[T] = array[0, T]
+      ## Array with no bounds checking
 
 proc shallowCopy*[T](x: var T, y: T) {.noSideEffect, magic: "ShallowCopy".}
   ## use this instead of `=` for a `shallow copy`:idx:. The shallow copy

--- a/tests/array/tunchecked.nim
+++ b/tests/array/tunchecked.nim
@@ -1,5 +1,5 @@
 {.boundchecks: on.}
-type Unchecked {.unchecked.} = array[0, char]
+type Unchecked {.unchecked.} = array[0..10, char]
 
 var x = cast[ptr Unchecked](alloc(100))
 x[5] = 'x'

--- a/tests/misc/tinvalidarrayaccess.nim
+++ b/tests/misc/tinvalidarrayaccess.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "index out of bounds"
+  errormsg: "type mismatch: got <TTestArr, int literal(2), int literal(50)>"
   line: 11
 """
 

--- a/tests/range/toverload.nim
+++ b/tests/range/toverload.nim
@@ -1,0 +1,19 @@
+discard """
+  output: 
+'''
+cool
+uncool
+'''
+"""
+
+type
+  Cool = range[5..6]
+  Uncool = range[4..5]
+
+template x(_: Cool) = echo "cool"
+template x(_: Uncool) = echo "uncool"
+
+x(6)
+x(4)
+# Ambiguous call since 5 is included by both the ranges
+doAssert(not compiles(x(5)))

--- a/tests/range/tsubrange.nim
+++ b/tests/range/tsubrange.nim
@@ -1,6 +1,6 @@
 discard """
   line: 20
-  errormsg: "cannot convert 60 to TRange"
+  errormsg: "type mismatch: got <int literal(60)> but expected 'TRange = range 0..40(int)'"
 """
 
 type


### PR DESCRIPTION
Includes a bonus commit that:
- Makes `UncheckedArray` boundaries explicit in its definition so that we don't conflate it with a zero-length array
- Makes the backend able to distinguish unchecked arrays from varargs arrays

We're now able to do some nice things thanks to this PR:
- Range checks are now applied at compile time when possible, this means they'll finally work when used as template parameters
- Overload resolution now works as you'd expect it to work (see the attached test)
- Out of boundary accesses become type errors and are caught during the sigmatch phase (see `tinvalidarrayaccess.nim`)