### PR TITLE
Remove install_nimble.nims, install_tools.nims as per #4934

### DIFF
--- a/install_nimble.nims
+++ b/install_nimble.nims
@@ -1,6 +1,0 @@
-
-mode = ScriptMode.Verbose
-
-echo "This script is deprecated. Use 'koch nimble' instead."
-
-exec "./koch nimble"

--- a/install_tools.nims
+++ b/install_tools.nims
@@ -1,6 +1,0 @@
-
-mode = ScriptMode.Verbose
-
-echo "This script is deprecated. Use 'koch tools' instead."
-
-exec "./koch tools"


### PR DESCRIPTION
It looks like these are deprecated scripts, and #4934 wanted them removed from the repo root as well. Been having a lot of fun using Nim over the last year.