### PR TITLE
Fixes unexpected transforming of runnableExamples

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1660,6 +1660,11 @@ proc isCompileTimeProc*(s: PSym): bool {.inline.} =
   result = s.kind == skMacro or
            s.kind == skProc and sfCompileTime in s.flags
 
+proc isRunnableExamples*(n: PNode): bool =
+  # Templates and generics don't perform symbol lookups.
+  result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
+    n.kind == nkIdent and n.ident.s == "runnableExamples"
+
 proc requiredParams*(s: PSym): int =
   # Returns the number of required params (without default values)
   # XXX: Perhaps we can store this in the `offset` field of the

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -377,16 +377,11 @@ proc prepareExamples(d: PDoc; n: PNode) =
   runnableExamples.add newTree(nkBlockStmt, newNode(nkEmpty), copyTree savedLastSon)
   testExample(d, runnableExamples)
 
-proc isRunnableExample(n: PNode): bool =
-  # Templates and generics don't perform symbol lookups.
-  result = n.kind == nkSym and n.sym.magic == mRunnableExamples or
-    n.kind == nkIdent and n.ident.s == "runnableExamples"
-
 proc getAllRunnableExamplesRec(d: PDoc; n, orig: PNode; dest: var Rope) =
   if n.info.fileIndex != orig.info.fileIndex: return
   case n.kind
   of nkCallKinds:
-    if isRunnableExample(n[0]) and
+    if isRunnableExamples(n[0]) and
         n.len >= 2 and n.lastSon.kind == nkStmtList:
       prepareExamples(d, n)
       dispA(d.conf, dest, "\n<p><strong class=\"examples_text\">$1</strong></p>\n",

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -493,7 +493,9 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
     else:
       result = semTemplBodySons(c, n)
   of nkCallKinds-{nkPostfix}:
-    result = semTemplBodySons(c, n)
+    # do not transform runnableExamples (bug #9143)
+    if not isRunnableExamples(n[0]):
+      result = semTemplBodySons(c, n)
   of nkDotExpr, nkAccQuoted:
     # dotExpr is ambiguous: note that we explicitly allow 'x.TemplateParam',
     # so we use the generic code for nkDotExpr too


### PR DESCRIPTION
@LemonBoy pretty much spelled out the fix, but I would have never gone in there without him doing so. Can't thank you enough for taking the time to do that.

One thing I would like to add is a a regression test. Unfortunately I was unable to figure out how to target `runnableExamples` without running the docs. Any advice?  Would it be an AST only type of test?

Before:

![image](https://user-images.githubusercontent.com/68273/46388302-4b466280-c699-11e8-9a9e-bf96f12d29e8.png)


After:

![image](https://user-images.githubusercontent.com/68273/46388312-5c8f6f00-c699-11e8-83da-5094998bb325.png)


Fixes #9143 