### PR TITLE
fix futureStream completion

### DIFF
--- a/lib/pure/asyncstreams.nim
+++ b/lib/pure/asyncstreams.nim
@@ -29,9 +29,11 @@ proc newFutureStream*[T](fromProc = "unspecified"): FutureStream[T] =
 
 proc complete*[T](future: FutureStream[T]) =
   ## Completes a ``FutureStream`` signalling the end of data.
-  future.finished = true
-  if not future.cb.isNil:
-    future.cb()
+  callSoon(proc =
+    future.finished = true
+    if not future.cb.isNil:
+      future.cb()
+  )
 
 proc `callback=`*[T](future: FutureStream[T],
     cb: proc (future: FutureStream[T]) {.closure,gcsafe.}) =


### PR DESCRIPTION
schedule completion to prevent consuming the data from some of read callbacks
as read callback implementation also relies on `cb` field and `callSoon`scheduling

fixes #8994, #9024

this is the alternative for #9003 