### PR TITLE
Conditional continuation operator for options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
   bring the language in line with the standard library (e.g. ``parseOct``).
 - The dot style for import paths (e.g ``import path.to.module`` instead of
   ``import path/to/module``) has been deprecated.
+- The ``options`` module has been split in two
 
 #### Breaking changes in the standard library
 
@@ -75,6 +76,7 @@
 - ``net.sendTo`` no longer returns an int and now raises an ``OSError``.
 - `threadpool`'s `await` and derivatives have been renamed to `blockUntil`
   to avoid confusions with `await` from the `async` macro.
+- ``options`` has been split into ``options`` and ``optionsutils``
 
 
 #### Breaking changes in the compiler

--- a/changelog.md
+++ b/changelog.md
@@ -167,6 +167,7 @@
   the desired target type (as a concrete type or as a type class)
 - The `type` operator now supports checking that the supplied expression
   matches an expected type constraint.
+- Add conditional continuation operator ``?.`` for ``options`` to enable dot-chaining on optional values
 
 ### Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -167,7 +167,7 @@
   the desired target type (as a concrete type or as a type class)
 - The `type` operator now supports checking that the supplied expression
   matches an expected type constraint.
-- Add conditional continuation operator ``?.`` for ``options`` to enable dot-chaining on optional values
+- Add existential operator ``?.`` for ``options`` to enable dot-chaining on optional values
 
 ### Language changes
 

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -146,43 +146,6 @@ proc get*[T](self: var Option[T]): var T =
     raise UnpackError(msg: "Can't obtain a value from a `none`")
   return self.val
 
-proc map*[T](self: Option[T], callback: proc (input: T)) =
-  ## Applies a callback to the value in this Option
-  if self.isSome:
-    callback(self.val)
-
-proc map*[T, R](self: Option[T], callback: proc (input: T): R): Option[R] =
-  ## Applies a callback to the value in this Option and returns an option
-  ## containing the new value. If this option is None, None will be returned
-  if self.isSome:
-    some[R]( callback(self.val) )
-  else:
-    none(R)
-
-proc flatten*[A](self: Option[Option[A]]): Option[A] =
-  ## Remove one level of structure in a nested Option.
-  if self.isSome:
-    self.val
-  else:
-    none(A)
-
-proc flatMap*[A, B](self: Option[A], callback: proc (input: A): Option[B]): Option[B] =
-  ## Applies a callback to the value in this Option and returns an
-  ## option containing the new value. If this option is None, None will be
-  ## returned. Similar to ``map``, with the difference that the callback
-  ## returns an Option, not a raw value. This allows multiple procs with a
-  ## signature of ``A -> Option[B]`` (including A = B) to be chained together.
-  map(self, callback).flatten()
-
-proc filter*[T](self: Option[T], callback: proc (input: T): bool): Option[T] =
-  ## Applies a callback to the value in this Option. If the callback returns
-  ## `true`, the option is returned as a Some. If it returns false, it is
-  ## returned as a None.
-  if self.isSome and not callback(self.val):
-    none(T)
-  else:
-    self
-
 proc `==`*(a, b: Option): bool =
   ## Returns ``true`` if both ``Option``s are ``none``,
   ## or if they have equal values
@@ -251,50 +214,6 @@ when isMainModule:
     test "$":
       check($(some("Correct")) == "Some(\"Correct\")")
       check($(stringNone) == "None[string]")
-
-    test "map with a void result":
-      var procRan = 0
-      some(123).map(proc (v: int) = procRan = v)
-      check procRan == 123
-      intNone.map(proc (v: int) = check false)
-
-    test "map":
-      check(some(123).map(proc (v: int): int = v * 2) == some(246))
-      check(intNone.map(proc (v: int): int = v * 2).isNone)
-
-    test "filter":
-      check(some(123).filter(proc (v: int): bool = v == 123) == some(123))
-      check(some(456).filter(proc (v: int): bool = v == 123).isNone)
-      check(intNone.filter(proc (v: int): bool = check false).isNone)
-
-    test "flatMap":
-      proc addOneIfNotZero(v: int): Option[int] =
-        if v != 0:
-          result = some(v + 1)
-        else:
-          result = none(int)
-
-      check(some(1).flatMap(addOneIfNotZero) == some(2))
-      check(some(0).flatMap(addOneIfNotZero) == none(int))
-      check(some(1).flatMap(addOneIfNotZero).flatMap(addOneIfNotZero) == some(3))
-
-      proc maybeToString(v: int): Option[string] =
-        if v != 0:
-          result = some($v)
-        else:
-          result = none(string)
-
-      check(some(1).flatMap(maybeToString) == some("1"))
-
-      proc maybeExclaim(v: string): Option[string] =
-        if v != "":
-          result = some v & "!"
-        else:
-          result = none(string)
-
-      check(some(1).flatMap(maybeToString).flatMap(maybeExclaim) == some("1!"))
-      check(some(0).flatMap(maybeToString).flatMap(maybeExclaim) == none(string))
-
     test "SomePointer":
       var intref: ref int
       check(option(intref).isNone)

--- a/lib/pure/optionsutils.nim
+++ b/lib/pure/optionsutils.nim
@@ -10,7 +10,8 @@
 ## This module, previously a part of ``options``, implements some more advanced
 ## ways to interact with options. It includes conditional mapping of procedures
 ## over an option, flattening of nested options, and filtering of values within
-## options.
+## options. It also includes an existential operator that works like regular
+## dot-chaining but stops if the left hand side is a none-option.
 
 import options, macros
 
@@ -52,7 +53,7 @@ proc filter*[T](self: Option[T], callback: proc (input: T): bool): Option[T] =
     self
 
 macro `?.`*(option: untyped, statements: untyped): untyped =
-  ## Optional continuation operator. Works like regular dot-chaining, but if
+  ## Existential operator. Works like regular dot-chaining, but if
   ## the left had side is a ``none`` then the right hand side is not evaluated.
   ## In the case that ``statements`` return something the return type of this
   ## will be ``Option[T]`` where ``T`` is the returned type of ``statements``.
@@ -144,7 +145,7 @@ when isMainModule:
       check(some(1).flatMap(maybeToString).flatMap(maybeExclaim) == some("1!"))
       check(some(0).flatMap(maybeToString).flatMap(maybeExclaim) == none(string))
 
-    test "conditional continuation":
+    test "existential operator":
       when not compiles(some("Hello world")?.find('w').echo):
         check false
       check (some("Hello world")?.find('w')).unsafeGet == 6

--- a/lib/pure/optionsutils.nim
+++ b/lib/pure/optionsutils.nim
@@ -85,7 +85,7 @@ macro `?.`*(option: untyped, statements: untyped): untyped =
       nnkDotExpr.newTree(opt, newIdentNode("unsafeGet")), firstBarren)
 
   result = quote do:
-    (proc (): auto =
+    (proc (): auto {.inline.} =
       let `opt` = `option`
       if `opt`.isSome:
         when compiles(`injected`) and not compiles(some(`injected`)):

--- a/lib/pure/optionsutils.nim
+++ b/lib/pure/optionsutils.nim
@@ -1,0 +1,105 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2015 Nim Contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This module, previously a part of ``options``, implements some more advanced
+## ways to interact with options. It includes conditional mapping of procedures
+## over an option, flattening of nested options, and filtering of values within
+## options.
+
+import options
+
+proc map*[T](self: Option[T], callback: proc (input: T)) =
+  ## Applies a callback to the value in this Option
+  if self.isSome:
+    callback(self.unsafeGet)
+
+proc map*[T, R](self: Option[T], callback: proc (input: T): R): Option[R] =
+  ## Applies a callback to the value in this Option and returns an option
+  ## containing the new value. If this option is None, None will be returned
+  if self.isSome:
+    some[R]( callback(self.unsafeGet) )
+  else:
+    none(R)
+
+proc flatten*[A](self: Option[Option[A]]): Option[A] =
+  ## Remove one level of structure in a nested Option.
+  if self.isSome:
+    self.unsafeGet
+  else:
+    none(A)
+
+proc flatMap*[A, B](self: Option[A], callback: proc (input: A): Option[B]): Option[B] =
+  ## Applies a callback to the value in this Option and returns an
+  ## option containing the new value. If this option is None, None will be
+  ## returned. Similar to ``map``, with the difference that the callback
+  ## returns an Option, not a raw value. This allows multiple procs with a
+  ## signature of ``A -> Option[B]`` (including A = B) to be chained together.
+  map(self, callback).flatten()
+
+proc filter*[T](self: Option[T], callback: proc (input: T): bool): Option[T] =
+  ## Applies a callback to the value in this Option. If the callback returns
+  ## `true`, the option is returned as a Some. If it returns false, it is
+  ## returned as a None.
+  if self.isSome and not callback(self.unsafeGet):
+    none(T)
+  else:
+    self
+
+when isMainModule:
+  import unittest, sequtils
+
+  suite "optionsutils":
+    # work around a bug in unittest
+    let intNone = none(int)
+    let stringNone = none(string)
+
+    test "map with a void result":
+      var procRan = 0
+      some(123).map(proc (v: int) = procRan = v)
+      check procRan == 123
+      intNone.map(proc (v: int) = check false)
+
+    test "map":
+      check(some(123).map(proc (v: int): int = v * 2) == some(246))
+      check(intNone.map(proc (v: int): int = v * 2).isNone)
+
+    test "filter":
+      check(some(123).filter(proc (v: int): bool = v == 123) == some(123))
+      check(some(456).filter(proc (v: int): bool = v == 123).isNone)
+      check(intNone.filter(proc (v: int): bool = check false).isNone)
+
+    test "flatMap":
+      proc addOneIfNotZero(v: int): Option[int] =
+        if v != 0:
+          result = some(v + 1)
+        else:
+          result = none(int)
+
+      check(some(1).flatMap(addOneIfNotZero) == some(2))
+      check(some(0).flatMap(addOneIfNotZero) == none(int))
+      check(some(1).flatMap(addOneIfNotZero).flatMap(addOneIfNotZero) == some(3))
+
+      proc maybeToString(v: int): Option[string] =
+        if v != 0:
+          result = some($v)
+        else:
+          result = none(string)
+
+      check(some(1).flatMap(maybeToString) == some("1"))
+
+      proc maybeExclaim(v: string): Option[string] =
+        if v != "":
+          result = some v & "!"
+        else:
+          result = none(string)
+
+      check(some(1).flatMap(maybeToString).flatMap(maybeExclaim) == some("1!"))
+      check(some(0).flatMap(maybeToString).flatMap(maybeExclaim) == none(string))
+
+


### PR DESCRIPTION
This adds a Rust-like `?.` operator to Nim which will only evaluate further if the value of the preceding option is a some. In that case it will unwrap the value and pass it on to the right hand side. The entire thing returns an option of the final value, or none if the left hand side is a none, or nothing in case the right hand side doesn't return anything.

Depends on PR https://github.com/nim-lang/Nim/pull/9160