### PR TITLE
define NIM_NIL nullptr when __cplusplus >= 201103L

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -280,7 +280,13 @@ namespace USE_NIM_NAMESPACE {
 #    define NIM_FALSE false
 #  endif
 #  define NIM_BOOL bool
-#  define NIM_NIL 0
+#  if __cplusplus >= 201103L
+#    /* nullptr is more type safe (less implicit conversions than 0) */
+#    define NIM_NIL nullptr
+#  else
+#    /* consider using NULL if comment below for NIM_NIL doesn't apply to C++ */
+#    define NIM_NIL 0
+#  endif
 #else
 #  ifdef bool
 #    define NIM_BOOL bool


### PR DESCRIPTION
/cc @Araq

(references https://github.com/nim-lang/Nim/commit/9bd23b2d4cc94f6b31d7c45eb9dd20dcb64ccebe)

nullptr is safer because: https://www.geeksforgeeks.org/understanding-nullptr-c/ `Unlike NULL, it is not implicitly convertible or comparable to integral types.` so could remove some potential future codegen bugs.

> use 0 instead of nullptr because travis' C++ compiler doesn't know nullptr

weird that C++ doesn't know about nullptr since it was introduced in c++11, is `-std=c++11` passed in travis?


* could we use NULL instead of 0 in the else branch?
```
/* consider using NULL if comment below for NIM_NIL doesn't apply to C++ */
#    define NIM_NIL 0
```

not sure if this comment applied only to C or also C++ (also, details or references would help...)
https://github.com/nim-lang/Nim/pull/9178/files#diff-3eb53960f439d589f7dcba608d30ca33R302
`C's NULL is fucked up in some C compilers`