### PR TITLE
test case for #9180 and re-enables the disabled tcompilerapi test

### DIFF
--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -89,6 +89,13 @@ proc findNimStdLib*(): string =
   except OSError, ValueError:
     return ""
 
+proc findNimStdLibCompileTime*(): string =
+  ## Same as ``findNimStdLib`` but uses source files used at compile time,
+  ## and asserts on error.
+  const sourcePath = currentSourcePath()
+  result = sourcePath.parentDir.parentDir / "lib"
+  doAssert fileExists(result / "system.nim"), "result:" & result
+
 proc createInterpreter*(scriptName: string;
                         searchPaths: openArray[string];
                         flags: TSandboxFlags = {}): Interpreter =

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -41,13 +41,13 @@ proc main() =
 main()
 
 block issue9180:
-  proc evalString(code: string, moduleName = "script.nim"):auto=
+  proc evalString(code: string, moduleName = "script.nim") =
     let stream = llStreamOpen(code)
-    defer: llStreamClose(stream)
     let std = findNimStdLibCompileTime()
     var intr = createInterpreter(moduleName, [std])
-    defer: destroyInterpreter(intr)
     intr.evalScript(stream)
+    destroyInterpreter(intr)
+    llStreamClose(stream)
 
   evalString("echo 10+1")
   evalString("echo 10+2")

--- a/tests/compilerapi/tcompilerapi.nim
+++ b/tests/compilerapi/tcompilerapi.nim
@@ -2,20 +2,19 @@ discard """
   output: '''top level statements are executed!
 2.0
 my secret
+11
+12
 '''
 """
 
 ## Example program that demonstrates how to use the
 ## compiler as an API to embed into your own projects.
 
-import "../../compiler" / [ast, vmdef, vm, nimeval]
+import "../../compiler" / [ast, vmdef, vm, nimeval, llstream]
 import std / [os]
 
 proc main() =
-  let std = findNimStdLib()
-  if std.len == 0:
-    quit "cannot find Nim's standard library"
-
+  let std = findNimStdLibCompileTime()
   var intr = createInterpreter("myscript.nim", [std, getAppDir()])
   intr.implementRoutine("*", "exposed", "addFloats", proc (a: VmArgs) =
     setResult(a, getFloat(a, 0) + getFloat(a, 1) + getFloat(a, 2))
@@ -28,27 +27,28 @@ proc main() =
     quit "script does not export a proc of the name: 'hostProgramRunsThis'"
   let res = intr.callRoutine(foreignProc, [newFloatNode(nkFloatLit, 0.9),
                                            newFloatNode(nkFloatLit, 0.1)])
-  if res.kind == nkFloatLit:
-    echo res.floatVal
-  else:
-    echo "bug!"
+  doAssert res.kind == nkFloatLit
+  echo res.floatVal
 
   let foreignValue = selectUniqueSymbol(intr, "hostProgramWantsThis")
   if foreignValue == nil:
     quit "script does not export a global of the name: hostProgramWantsThis"
   let val = intr.getGlobalValue(foreignValue)
-  if val.kind in {nkStrLit..nkTripleStrLit}:
-    echo val.strVal
-  else:
-    echo "bug!"
-
+  doAssert val.kind in {nkStrLit..nkTripleStrLit}
+  echo val.strVal
   destroyInterpreter(intr)
 
-if existsEnv("NIM_EXE_NOT_IN_PATH"):
-  # effectively disable this test as 'nim' is not in the PATH so tcompilerapi
-  # cannot find Nim's standard library:
-  echo "top level statements are executed!"
-  echo "2.0"
-  echo "my secret"
-else:
-  main()
+main()
+
+block issue9180:
+  proc evalString(code: string, moduleName = "script.nim"):auto=
+    let stream = llStreamOpen(code)
+    defer: llStreamClose(stream)
+    let std = findNimStdLibCompileTime()
+    var intr = createInterpreter(moduleName, [std])
+    defer: destroyInterpreter(intr)
+    intr.evalScript(stream)
+
+  evalString("echo 10+1")
+  evalString("echo 10+2")
+


### PR DESCRIPTION
/cc @araq
* fix #9180
* enables tcompilerapi test which was effectively disabled:
"effectively disable this test as 'nim' is not in the PATH so tcompilerapi cannot find Nim's standard library"
* add `findNimStdLibCompileTime`
* add test case for #9180

~~Note: https://github.com/nim-lang/Nim/issues/9184 is still an issue after this PR (no change before / after this PR regarding that issue)~~