### PR TITLE
Fixes #8994. FutureStream read procedure data loss no longer occurs.

### DIFF
--- a/lib/pure/asyncstreams.nim
+++ b/lib/pure/asyncstreams.nim
@@ -95,6 +95,8 @@ proc read*[T](future: FutureStream[T]): Future[(bool, T)] =
 
       if not resFut.finished:
         resFut.complete(res)
+      else:
+        fs.queue.addFirst(res[1])
 
       # If the saved callback isn't nil then let's call it.
       if not savedCb.isNil: savedCb()

--- a/lib/pure/asyncstreams.nim
+++ b/lib/pure/asyncstreams.nim
@@ -81,6 +81,9 @@ proc read*[T](future: FutureStream[T]): Future[(bool, T)] =
   let savedCb = future.cb
   future.callback =
     proc (fs: FutureStream[T]) =
+      # Exit early if `resFut` is already complete. (See #8994).
+      if resFut.finished: return
+
       # We don't want this callback called again.
       future.cb = nil
 
@@ -93,10 +96,7 @@ proc read*[T](future: FutureStream[T]): Future[(bool, T)] =
         res[0] = true
         res[1] = fs.queue.popFirst()
 
-      if not resFut.finished:
-        resFut.complete(res)
-      else:
-        fs.queue.addFirst(res[1])
+      resFut.complete(res)
 
       # If the saved callback isn't nil then let's call it.
       if not savedCb.isNil: savedCb()

--- a/tests/async/tfuturestream.nim
+++ b/tests/async/tfuturestream.nim
@@ -35,6 +35,26 @@ proc beta() {.async.} =
 asyncCheck alpha()
 waitFor beta()
 
+template ensureCallbacksAreScheduled =
+  # callbacks are called directly if the dispatcher is not running
+  discard getGlobalDispatcher()
+
+proc testCompletion() {.async.} =
+  ensureCallbacksAreScheduled
+
+  var stream = newFutureStream[string]()
+
+  for i in 1..5:
+    await stream.write($i)
+
+  var readFuture = stream.readAll()
+  stream.complete()
+  yield readFuture
+  let data = readFuture.read()
+  doAssert(data.len == 5, "actual data len = " & $data.len)
+
+waitFor testCompletion()
+
 # TODO: Something like this should work eventually.
 # proc delta(): FutureStream[string] {.async.} =
 #   for i in 0 .. 5:


### PR DESCRIPTION
Replaces #9159 and #9003.

See https://github.com/nim-lang/Nim/pull/9159#issuecomment-426871190 for how I arrived at this fix.