### PR TITLE
Fix no checks for multiple except blocks

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1578,7 +1578,6 @@ proc parseTry(p: var TParser; isExpr: bool): PNode =
     colcom(p, b)
     addSon(b, parseStmt(p))
     addSon(result, b)
-    if b.kind == nkFinally: break
   if b == nil: parMessage(p, "expected 'except'")
 
 proc parseExceptBlock(p: var TParser, kind: TNodeKind): PNode =

--- a/tests/errmsgs/tgeneral_excepts.nim
+++ b/tests/errmsgs/tgeneral_excepts.nim
@@ -1,0 +1,10 @@
+discard """
+errormsg: "Only one general except clause is allowed after more specific exceptions"
+"""
+
+try:
+  discard
+except:
+  discard
+except:
+  discard

--- a/tests/errmsgs/tmultiple_finally.nim
+++ b/tests/errmsgs/tmultiple_finally.nim
@@ -1,0 +1,12 @@
+discard """
+errormsg: "Only one finally is allowed after all other branches"
+"""
+
+try:
+  discard
+finally:
+  discard
+finally:
+  discard
+
+


### PR DESCRIPTION
This PR adds a check for number of general except blocks possible. It counts the number of `nkExceptBranch` nodes with only one son, and if that number exceeds 1 raises an error.

Addresses #9189 