### PR TITLE
Fix range type construction in the VM

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -237,8 +237,15 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyRange:
     result = newNodeIT(nkBracketExpr, if t.n.isNil: info else: t.n.info, t)
     result.add atomicType("range", mRange)
-    result.add t.n.sons[0].copyTree
-    result.add t.n.sons[1].copyTree
+    if inst:
+      let rng = newNodeX(nkInfix)
+      rng.add newIdentNode(getIdent(cache, ".."), info)
+      rng.add t.n.sons[0].copyTree
+      rng.add t.n.sons[1].copyTree
+      result.add rng
+    else:
+      result.add t.n.sons[0].copyTree
+      result.add t.n.sons[1].copyTree
   of tyPointer: result = atomicType("pointer", mPointer)
   of tyString: result = atomicType("string", mString)
   of tyCString: result = atomicType("cstring", mCString)

--- a/tests/macros/t9194.nim
+++ b/tests/macros/t9194.nim
@@ -1,0 +1,20 @@
+discard """
+  output: '''
+range[0 .. 100]
+array[0 .. 100, int]
+'''
+"""
+
+import macros
+
+type
+  Foo1 = range[0 .. 100]
+  Foo2 = array[0 .. 100, int]
+
+macro get(T: typedesc): untyped =
+  # Get the X out of typedesc[X]
+  let tmp = getTypeImpl(T)
+  result = newStrLitNode(getTypeImpl(tmp[1]).repr)
+
+echo Foo1.get
+echo Foo2.get


### PR DESCRIPTION
The `range[X,Y]` representation is wrong, we use `range[X .. Y]`
instead.

Fixes #9194