### PR TITLE
compiler: show name of instantiating context in error traces (#6763)

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1782,3 +1782,6 @@ template typeCompleted*(s: PSym) =
   incl s.flags, sfNoForward
 
 template getBody*(s: PSym): PNode = s.ast[bodyPos]
+
+template detailedInfo*(sym: PSym): string =
+  sym.name.s

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -248,7 +248,7 @@ type
                             ## some close token.
 
     errorOutputs*: TErrorOutputs
-    msgContext*: seq[TLineInfo]
+    msgContext*: seq[tuple[info: TLineInfo, detail: string]]
     lastError*: TLineInfo
     filenameToIndexTbl*: Table[string, FileIndex]
     fileInfos*: seq[TFileInfo]

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -444,7 +444,7 @@ const
 
 proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode =
-  pushInfoContext(c.config, nOrig.info)
+  pushInfoContext(c.config, nOrig.info, sym.detailedInfo)
 
   markUsed(c.config, n.info, sym, c.graph.usageSym)
   styleCheckUse(n.info, sym)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -26,7 +26,7 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
                      flags: TExprFlags = {}): PNode =
   markUsed(c.config, n.info, s, c.graph.usageSym)
   styleCheckUse(n.info, s)
-  pushInfoContext(c.config, n.info)
+  pushInfoContext(c.config, n.info, s.detailedInfo)
   result = evalTemplate(n, s, getCurrOwner(c), c.config, efFromHlo in flags)
   if efNoSemCheck notin flags: result = semAfterMacroCall(c, n, result, s, flags)
   popInfoContext(c.config)

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -348,7 +348,7 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
   let gp = n.sons[genericParamsPos]
   internalAssert c.config, gp.kind != nkEmpty
   n.sons[namePos] = newSymNode(result)
-  pushInfoContext(c.config, info)
+  pushInfoContext(c.config, info, fn.detailedInfo)
   var entry = TInstantiation.new
   entry.sym = result
   # we need to compare both the generic types and the concrete types:

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -34,9 +34,9 @@ proc add(x: var string; y: char)
   required type: var string
   but expression 'k' is of type: Alias
 
-t3330.nim(48, 8) template/generic instantiation from here
+t3330.nim(48, 8) template/generic instantiation of `add` from here
 t3330.nim(55, 6) Foo: 'bar.value' cannot be assigned to
-t3330.nim(48, 8) template/generic instantiation from here
+t3330.nim(48, 8) template/generic instantiation of `add` from here
 t3330.nim(56, 6) Foo: 'bar.x' cannot be assigned to
 
 expression: test(bar)'''

--- a/tests/macros/tmsginfo.nim
+++ b/tests/macros/tmsginfo.nim
@@ -1,6 +1,6 @@
 discard """
   nimout: '''tmsginfo.nim(21, 1) Warning: foo1 [User]
-tmsginfo.nim(22, 13) template/generic instantiation from here
+tmsginfo.nim(22, 13) template/generic instantiation of `foo2` from here
 tmsginfo.nim(15, 10) Warning: foo2 [User]
 tmsginfo.nim(23, 1) Hint: foo3 [User]
 tmsginfo.nim(19, 7) Hint: foo4 [User]

--- a/tests/testament/tester.nim
+++ b/tests/testament/tester.nim
@@ -53,7 +53,10 @@ let
   pegLineError =
     peg"{[^(]*} '(' {\d+} ', ' {\d+} ') ' ('Error') ':' \s* {.*}"
   pegLineTemplate =
-    peg"{[^(]*} '(' {\d+} ', ' {\d+} ') ' 'template/generic instantiation from here'.*"
+    peg"""
+      {[^(]*} '(' {\d+} ', ' {\d+} ') '
+      'template/generic instantiation' ( ' of `' [^`]+ '`' )? ' from here' .*
+    """
   pegOtherError = peg"'Error:' \s* {.*}"
   pegSuccess = peg"'Hint: operation successful'.*"
   pegOfInterest = pegLineError / pegOtherError


### PR DESCRIPTION
Make `template/generic instantiation from here` messages more specific. Fix #6763.

Not all `pushInfoContext` invocation are covered, but it is enough for cases listed in the issue.

### Example output

Code: #6677
```
i6677.nim(17, 7) template/generic instantiation of `suite` from here
i6677.nim(18, 8) template/generic instantiation of `test` from here
i6677.nim(19, 5) template/generic instantiation of `check` from here
i6677.nim(20, 48) template/generic instantiation of `check` from here
<long path skipped>/lib/pure/unittest.nim(648, 14) template/generic instantiation of `==` from here
<long path skipped>/lib/system.nim(2496, 3) Error: parallel 'fields' iterator does not work for 'case' objects
```

---

Code: #4628
```
i4628.nim(11, 10) template/generic instantiation of `==` from here
<long path skipped>/lib/system.nim(2496, 3) Error: parallel 'fields' iterator does not work for 'case' objects
```

---

Code: #4169 (it compiles nowadays, so I've slightly modified it)
```nim
import strutils
var a = "aa.bb.cc"

echo find(a, @["a"])
```
```
i4169.nim(4, 10) template/generic instantiation of `find` from here
<long path skipped>/lib/system.nim(2424, 10) Error: type mismatch: got <char, seq[string]>
but expected one of: 
proc `==`[Enum: enum](x, y: Enum): bool
  first type mismatch at position: 1
  required type: Enum: enum
  but expression 'i' is of type: char
<rest is skipped>
```