### PR TITLE
Inserted a notice that `removeDir` will delete any directory or file at the path provided.

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -947,7 +947,7 @@ proc rawRemoveDir(dir: string) =
 proc removeDir*(dir: string) {.rtl, extern: "nos$1", tags: [
   WriteDirEffect, ReadDirEffect], benign.} =
   ## Removes the directory `dir` including all subdirectories and files
-  ## in `dir` (recursively).
+  ## in `dir` (recursively). `dir` will be deleted whether it is a directory or file.
   ##
   ## If this fails, `OSError` is raised. This does not fail if the directory never
   ## existed in the first place.


### PR DESCRIPTION
Fixes #9200 with documentation. If it is desired to rework this procedure to not delete files, then this should be rejected.