### PR TITLE
[Improvement] [Issue 9200] Add `recursive` argument to `removeDir` procedure

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -952,7 +952,9 @@ proc removeDir*(dir: string, recursive: bool = true) {.raises: [IOError], rtl, e
   ##`recursive` is `true` (the default), then `dir` will be deleted even if it
   ## is a file path and not a directory path.
   ##
-  ## If this fails, `OSError` is raised. This does not fail if the directory never
+  ## If this fails because `recursive` is `false` and the path `dir` is a file,
+  ## doesn't exist, or is not empty, `IOError` is raised. If this fails for any
+  ## other reason, `OSError` is raised. This does not fail if the directory never
   ## existed in the first place.
   if recursive:
     for kind, path in walkDir(dir):
@@ -962,8 +964,6 @@ proc removeDir*(dir: string, recursive: bool = true) {.raises: [IOError], rtl, e
   else:
     if (not dirExists(dir)) and fileExists(dir):
       raise newException(IOError, "The path '" & dir & "' is a file.")
-    elif (not dirExists(dir)):
-      raise newException(IOError, "The path '" & dir & "' does not exist.")
     var dirIsEmpty: bool = true
     for _ in walkDir(dir):
       dirIsEmpty = false

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -944,7 +944,7 @@ proc rawRemoveDir(dir: string) =
   else:
     if rmdir(dir) != 0'i32 and errno != ENOENT: raiseOSError(osLastError())
 
-proc removeDir*(dir: string, recursive = true) {.raises: [OSError], rtl, extern: "nos$1", tags: [
+proc removeDir*(dir: string, recursive = true) {.rtl, extern: "nos$1", tags: [
   WriteDirEffect, ReadDirEffect], benign.} =
   ## Removes the directory ``dir``. Additionally removes all subdirectories and files recursively
   ## if ``recursive`` is ``true``.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -946,11 +946,8 @@ proc rawRemoveDir(dir: string) =
 
 proc removeDir*(dir: string, recursive = true) {.raises: [OSError], rtl, extern: "nos$1", tags: [
   WriteDirEffect, ReadDirEffect], benign.} =
-  ## Removes the directory `dir`. By default, it will delete all subdirectories
-  ## and files in `dir`, then `dir` itself, recursively. If `recursive` is
-  ## `false`, then the directory will only be deleted if it is empty and is not
-  ## a file path. If `recursive` is `true` (the default), then `dir` will be
-  ## deleted even if it is a file path and not a directory path.
+  ## Removes the directory ``dir``. Additionally removes all subdirectories and files recursively
+  ## if ``recursive`` is ``true`` (default behavior is recursive).
   ##
   ## If this fails, `OSError` is raised. This does not fail if the directory never
   ## existed in the first place.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -944,32 +944,21 @@ proc rawRemoveDir(dir: string) =
   else:
     if rmdir(dir) != 0'i32 and errno != ENOENT: raiseOSError(osLastError())
 
-proc removeDir*(dir: string, recursive: bool = true) {.raises: [IOError, OSError], rtl, extern: "nos$1", tags: [
+proc removeDir*(dir: string, recursive = true) {.raises: [OSError], rtl, extern: "nos$1", tags: [
   WriteDirEffect, ReadDirEffect], benign.} =
   ## Removes the directory `dir`. By default, it will delete all subdirectories
-  ## and files in `dir` recursively. If `recursive` is `false`, then the
-  ## directory will only be deleted if it is empty and is not a file path. If
-  ##`recursive` is `true` (the default), then `dir` will be deleted even if it
-  ## is a file path and not a directory path.
+  ## and files in `dir`, then `dir` itself, recursively. If `recursive` is
+  ## `false`, then the directory will only be deleted if it is empty and is not
+  ## a file path. If `recursive` is `true` (the default), then `dir` will be
+  ## deleted even if it is a file path and not a directory path.
   ##
-  ## If this fails because `recursive` is `false` and the path `dir` is a file,
-  ## doesn't exist, or is not empty, `IOError` is raised. If this fails for any
-  ## other reason, `OSError` is raised. This does not fail if the directory never
+  ## If this fails, `OSError` is raised. This does not fail if the directory never
   ## existed in the first place.
   if recursive:
     for kind, path in walkDir(dir):
       case kind
       of pcFile, pcLinkToFile, pcLinkToDir: removeFile(path)
       of pcDir: removeDir(path, recursive)
-  else:
-    if (not dirExists(dir)) and fileExists(dir):
-      raise newException(IOError, "The path '" & dir & "' is a file.")
-    var dirIsEmpty: bool = true
-    for _ in walkDir(dir):
-      dirIsEmpty = false
-      break
-    if not dirIsEmpty:
-      raise newException(IOError, "The directory '" & dir & "' is not empty.")
   rawRemoveDir(dir)
 
 proc rawCreateDir(dir: string): bool =

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -944,7 +944,7 @@ proc rawRemoveDir(dir: string) =
   else:
     if rmdir(dir) != 0'i32 and errno != ENOENT: raiseOSError(osLastError())
 
-proc removeDir*(dir: string, recursive: bool = true) {.raises: [IOError], rtl, extern: "nos$1", tags: [
+proc removeDir*(dir: string, recursive: bool = true) {.raises: [IOError, OSError], rtl, extern: "nos$1", tags: [
   WriteDirEffect, ReadDirEffect], benign.} =
   ## Removes the directory `dir`. By default, it will delete all subdirectories
   ## and files in `dir` recursively. If `recursive` is `false`, then the

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -947,7 +947,7 @@ proc rawRemoveDir(dir: string) =
 proc removeDir*(dir: string, recursive = true) {.raises: [OSError], rtl, extern: "nos$1", tags: [
   WriteDirEffect, ReadDirEffect], benign.} =
   ## Removes the directory ``dir``. Additionally removes all subdirectories and files recursively
-  ## if ``recursive`` is ``true`` (default behavior is recursive).
+  ## if ``recursive`` is ``true``.
   ##
   ## If this fails, `OSError` is raised. This does not fail if the directory never
   ## existed in the first place.

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -27,6 +27,8 @@ __really_obscure_dir_name/created
 __really_obscure_dir_name/dirs
 __really_obscure_dir_name/some
 __really_obscure_dir_name/test
+RaisesNonEmptyDir
+RaisesFile
 false
 false
 false
@@ -87,6 +89,17 @@ echo "Dirs:"
 
 for path in walkDirs(dname/"*"):
   echo path.norm
+
+# Test that the `recursive = false` argument doesn't remove non-empty dirs or files
+try:
+  removeDir(dname, recursive = false)
+except OSError:
+  echo "RaisesNonEmptyDir"
+
+try:
+  removeDir(dname/files[0], recursive = false)
+except OSError:
+  echo "RaisesFile"
 
 # Test removal of files dirs
 for dir in dirs:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -27,8 +27,7 @@ __really_obscure_dir_name/created
 __really_obscure_dir_name/dirs
 __really_obscure_dir_name/some
 __really_obscure_dir_name/test
-RaisesNonEmptyDir
-RaisesFile
+Raises
 false
 false
 false
@@ -90,16 +89,11 @@ echo "Dirs:"
 for path in walkDirs(dname/"*"):
   echo path.norm
 
-# Test that the `recursive = false` argument doesn't remove non-empty dirs or files
+# Test that the `recursive = false` argument doesn't remove non-empty dirs
 try:
   removeDir(dname, recursive = false)
 except OSError:
-  echo "RaisesNonEmptyDir"
-
-try:
-  removeDir(dname/files[0], recursive = false)
-except OSError:
-  echo "RaisesFile"
+  echo "Raises"
 
 # Test removal of files dirs
 for dir in dirs:


### PR DESCRIPTION
This PR adds additional functionality as requested in #9200, but does not fix #9200.

This PR adds a `recursive` boolean argument to `removeDir`. If `recursive` is `true` (default) then the behavior is exactly as before. If it is `false`, then we check to ensure the path provided is truly an empty directory (i.e.: not a file).