### PR TITLE
os: use unlink() to remove file

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -33,8 +33,6 @@ else:
 import ospaths
 export ospaths
 
-proc c_remove(filename: cstring): cint {.
-  importc: "remove", header: "<stdio.h>".}
 proc c_rename(oldname, newname: cstring): cint {.
   importc: "rename", header: "<stdio.h>".}
 proc c_system(cmd: cstring): cint {.
@@ -652,7 +650,7 @@ proc tryRemoveFile*(file: string): bool {.rtl, extern: "nos$1", tags: [WriteDirE
          deleteFile(f) != 0:
         result = true
   else:
-    if c_remove(file) != 0'i32 and errno != ENOENT:
+    if unlink(file) != 0'i32 and errno != ENOENT:
       result = false
 
 proc removeFile*(file: string) {.rtl, extern: "nos$1", tags: [WriteDirEffect].} =

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -39,6 +39,7 @@ false
 true
 true
 Raises
+Raises
 true
 true
 true
@@ -118,6 +119,14 @@ try:
 except IOError:
   echo "Raises"
 removeFile(dname)
+
+# removeFile should not remove directory
+createDir(dname)
+try:
+  removeFile(dname)
+except OSError:
+  echo "Raises"
+removeDir(dname)
 
 # test copyDir:
 createDir("a/b")


### PR DESCRIPTION
`removeFile()` behavior should now be consistant between Windows and POSIX

Fixes #9200