### PR TITLE
Fixes #9222, link time error when multiple dynlib pragmas with function calls used

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -567,7 +567,12 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
       var p = newProc(nil, m)
       p.options = p.options - {optStackTrace, optEndb}
       var dest: TLoc
-      initLocExpr(p, lib.path, dest)
+      initLoc(dest, locTemp, lib.path, OnStack)
+      dest.r = getTempName(m)
+      appcg(m, m.s[cfsDynLibInit],"$1 $2;$n",
+           [getTypeDesc(m, lib.path.typ), rdLoc(dest)])
+      expr(p, lib.path, dest)
+
       add(m.s[cfsVars], p.s(cpsLocals))
       add(m.s[cfsDynLibInit], p.s(cpsInit))
       add(m.s[cfsDynLibInit], p.s(cpsStmts))

--- a/tests/cpp/amodule.nim
+++ b/tests/cpp/amodule.nim
@@ -1,0 +1,10 @@
+import os
+
+proc findlib: string =
+  let path = getEnv("MYLIB_DOES_NOT_EXIST_PATH")
+  if path.len > 0 and dirExists(path):
+    path / "alib_does_not_matter.dll"
+  else:
+    "alib_does_not_matter.dll"
+
+proc imported_func*(a: cint): cstring {.importc, dynlib: findlib().}

--- a/tests/cpp/t8241.nim
+++ b/tests/cpp/t8241.nim
@@ -5,3 +5,19 @@ discard """
 
 proc foo(): cstring {.importcpp: "", dynlib: "".}
 echo foo()
+
+
+## bug #9222
+import os
+import amodule
+proc findlib2: string =
+  let path = getEnv("MYLIB2_DOES_NOT_EXIST_PATH")
+  if path.len > 0 and dirExists(path):
+    path / "alib_does_not_matter.dll"
+  else:
+    "alib_does_not_matter.dll"
+
+proc imported_func2*(a: cint): cstring {.importc, dynlib: findlib2().}
+
+echo imported_func(1)
+echo imported_func2(1)


### PR DESCRIPTION
The fix is to use a local stack variable instead of global variable to avoid global variable redefinition problem:

```
Hint:  [Link]
C:\nim-devel\nimcache\tests\cpp\t8241.nim\compiler_amodule.cpp.o:compiler_amodule.cpp:(.bss+0x0): multiple definition of `T1_'
C:\nim-devel\nimcache\tests\cpp\t8241.nim\compiler_t8241.cpp.o:compiler_t8241.cpp:(.bss+0x8): first defined here collect2.exe: error: ld returned 1 exit status
```