### PR TITLE
Acknowledge nimscripts not ending in '.nims'

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -69,8 +69,9 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
     let scriptFile = conf.projectFull.changeFileExt("nims")
     if not self.suggestMode:
       runNimScriptIfExists(scriptFile)
-      # 'nim foo.nims' means to just run the NimScript file and do nothing more:
-      if fileExists(scriptFile) and scriptFile == conf.projectFull:
+      # 'nim foo.nims', 'nim task foo' means to just run the NimScript file
+      # and do nothing more:
+      if fileExists(scriptFile) and conf.command in ["nop", "e"]:
         return false
     else:
       if scriptFile != conf.projectFull:


### PR DESCRIPTION
Acknowledge when a script file is executed without the '.nims' extension. Previously it would execute it and pretend it wasn't one.

Fixes https://github.com/nim-lang/Nim/issues/9246