### PR TITLE
Fix typo in an algorithm runnableExamples

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -272,7 +272,7 @@ func sort*[T](a: var openArray[T], order = SortOrder.Ascending) =
   runnableExamples:
     var s = @[1,3,2,5,4]
     s.sort
-    doAssert a == @[1,2,3,4,5]
+    doAssert s == @[1,2,3,4,5]
   sort(a, system.cmp, order)
 
 func sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.},


### PR DESCRIPTION
Fixes the 'koch docs' build failure.

Ref:
https://github.com/nim-lang/Nim/commit/b90b45b01bba1f3fc241a96abd4ae5c8c314bb92