### PR TITLE
 Add procs to retrieve project name, directory and full path from nimscript

### DIFF
--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -96,6 +96,12 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
   cbconf fileExists:
     setResult(a, os.fileExists(a.getString 0))
 
+  cbconf projectName:
+    setResult(a, conf.projectName)
+  cbconf projectDir:
+    setResult(a, conf.projectPath.string)
+  cbconf projectPath:
+    setResult(a, conf.projectFull.string)
   cbconf thisDir:
     setResult(a, vthisDir)
   cbconf put:

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -269,6 +269,18 @@ proc nimcacheDir*(): string =
   ## Retrieves the location of 'nimcache'.
   builtin
 
+proc projectName*(): string =
+  ## Retrieves the name of the current project
+  builtin
+
+proc projectDir*(): string =
+  ## Retrieves the absolute directory of the current project
+  builtin
+
+proc projectPath*(): string =
+  ## Retrieves the absolute path of the current project
+  builtin
+
 proc thisDir*(): string =
   ## Retrieves the location of the current ``nims`` script file.
   builtin


### PR DESCRIPTION
Mirrors some functionality of `nim.cfg`. Distinction between `Path` and `Full` seemed a bit vague to me so i switched the names. Don't know if this is appropriate solution, but it allows me to use only `config.nims` for global configuration.