### PR TITLE
Fix tests on NixOS

### DIFF
--- a/tests/async/tioselectors.nim
+++ b/tests/async/tioselectors.nim
@@ -163,9 +163,9 @@ elif not defined(windows):
 
     proc process_notification_test(): bool =
       var selector = newSelector[int]()
-      var process2 = startProcess("/bin/sleep", "", ["2"], nil,
+      var process2 = startProcess("sleep", "", ["2"], nil,
                            {poStdErrToStdOut, poUsePath})
-      discard startProcess("/bin/sleep", "", ["1"], nil,
+      discard startProcess("sleep", "", ["1"], nil,
                            {poStdErrToStdOut, poUsePath})
 
       selector.registerProcess(process2.processID, 0)

--- a/tests/async/tupcoming_async.nim
+++ b/tests/async/tupcoming_async.nim
@@ -100,7 +100,7 @@ when defined(upcoming):
                                    {poStdErrToStdOut, poUsePath, poInteractive,
                                    poDemon})
       else:
-        var process = startProcess("/bin/sleep", "", ["1"], nil,
+        var process = startProcess("sleep", "", ["1"], nil,
                                    {poStdErrToStdOut, poUsePath})
       var fut = waitProcess(process)
       waitFor(fut or waitTimer(2000))

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -114,7 +114,7 @@ suite "ttimes":
   # Generate tests for multiple timezone files where available
   # Set the TZ env var for each test
   when defined(linux) or defined(macosx):
-    const tz_dir = "/usr/share/zoneinfo"
+    let tz_dir = getEnv("TZDIR", "/usr/share/zoneinfo")
     const f = "yyyy-MM-dd HH:mm zzz"
     
     let orig_tz = getEnv("TZ")


### PR DESCRIPTION
#9209

* Replace `/bin/sleep` with just `sleep`, i.e. use environment variable `$PATH` to locate binary.
* Replace `/usr/share/zoneinfo` with `$TZDIR` when it is defined, fallback to hardcoded path otherwise. This is the same behavior that Glibc2 normally have, see [man 3 tzset].

[man 3 tzset]: https://linux.die.net/man/3/tzset