### PR TITLE
Fix wrong heuristic in codegen

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -771,7 +771,13 @@ proc allPathsAsgnResult(n: PNode): InitResultEnum =
       result = InitRequired
   of nkReturnStmt:
     if n.len > 0:
-      result = allPathsAsgnResult(n[0])
+      if n[0].kind == nkEmpty and result != InitSkippable:
+        # This is a bare `return` statement, if `result` was not initialized
+        # anywhere else (or if we're not sure about this) let's require it to be
+        # initialized. This avoids cases like #9286 where this heuristic lead to
+        # wrong code being generated.
+        result = InitRequired
+      else: result = allPathsAsgnResult(n[0])
   of nkIfStmt, nkIfExpr:
     var exhaustive = false
     result = InitSkippable

--- a/tests/ccgbugs/t9286.nim
+++ b/tests/ccgbugs/t9286.nim
@@ -1,0 +1,22 @@
+discard """
+  action: run
+"""
+
+import options
+type Foo  = ref object
+  i:      int
+
+proc next(foo: Foo): Option[Foo] =
+  try:    assert(foo.i == 0)
+  except: return      # 2º: none
+  return some(foo)    # 1º: some
+
+proc test =
+  let foo = Foo()
+  var opt = next(foo) # 1º Some
+  while isSome(opt) and foo.i < 10:
+    inc(foo.i)
+    opt = next(foo)   # 2º None
+  assert foo.i == 1, $foo.i
+
+test()


### PR DESCRIPTION
@Araq your heuristic was a bit too eager and removed the reset even though it was needed. The fix should be correct since it uses the informations gathered from all the previous nodes so that if nothing had initialized `result` before the point where the return is we insert a zeroing operation in the function prologue.