### PR TITLE
recv avoid 'Resource temporarily unavailable'

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1194,6 +1194,7 @@ proc recv*(socket: Socket, data: var string, size: int, timeout = -1,
     data.setLen(0)
     let lastError = getSocketError(socket)
     if flags.isDisconnectionError(lastError): return
+    if lastError == OSErrorCode(EAGAIN): return 0
     socket.socketError(result, lastError = lastError)
   data.setLen(result)
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1194,7 +1194,10 @@ proc recv*(socket: Socket, data: var string, size: int, timeout = -1,
     data.setLen(0)
     let lastError = getSocketError(socket)
     if flags.isDisconnectionError(lastError): return
-    if cint(lastError) in [EAGAIN, EWOULDBLOCK]: return 0
+    when useWinVersion:
+      if cint(lastError) == WSAEWOULDBLOCK: return 0
+    else:
+      if cint(lastError) in [EAGAIN, EWOULDBLOCK]: return 0
     socket.socketError(result, lastError = lastError)
   data.setLen(result)
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1194,7 +1194,7 @@ proc recv*(socket: Socket, data: var string, size: int, timeout = -1,
     data.setLen(0)
     let lastError = getSocketError(socket)
     if flags.isDisconnectionError(lastError): return
-    if lastError == OSErrorCode(EAGAIN): return 0
+    if cint(lastError) in [EAGAIN, EWOULDBLOCK]: return 0
     socket.socketError(result, lastError = lastError)
   data.setLen(result)
 


### PR DESCRIPTION
Fix https://github.com/nim-lang/Nim/issues/9292

https://linux.die.net/man/2/recv
> EAGAIN or EWOULDBLOCK
>> The socket is marked nonblocking and the receive operation would block, or a receive timeout had been set and the timeout expired before data was received. POSIX.1-2001 allows either error to be returned for this case, and does not require these constants to have the same value, so a portable application should check for both possibilities.

The timeout passed as an arg is not affected by this change.