### PR TITLE
Add `toOpenArray[T](ptr UncheckedArray[T])` for clarity.

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -106,7 +106,7 @@ proc openArrayLoc(p: BProc, n: PNode): Rope =
         result = "($1)+($2), ($3)-($2)+1" % [rdLoc(a), rdLoc(b), rdLoc(c)]
       else:
         result = "($1)+(($2)-($4)), ($3)-($2)+1" % [rdLoc(a), rdLoc(b), rdLoc(c), intLiteral(first)]
-    of tyOpenArray, tyVarargs:
+    of tyOpenArray, tyVarargs, tyUncheckedArray:
       result = "($1)+($2), ($3)-($2)+1" % [rdLoc(a), rdLoc(b), rdLoc(c)]
     of tyString, tySequence:
       if skipTypes(n.typ, abstractInst).kind == tyVar and

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4338,6 +4338,8 @@ when not defined(js):
     magic: "Slice".}
   proc toOpenArray*[T](x: openarray[T]; first, last: int): openarray[T] {.
     magic: "Slice".}
+  proc toOpenArray*[T](x: ptr UncheckedArray[T]; first, last: int): openarray[T] {.
+    magic: "Slice".}
   proc toOpenArray*[I, T](x: array[I, T]; first, last: I): openarray[T] {.
     magic: "Slice".}
   proc toOpenArray*(x: string; first, last: int): openarray[char] {.

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -15,6 +15,7 @@ discard """
 1
 2
 3
+2
 48
 49
 50
@@ -96,6 +97,10 @@ doAssertRaises(IndexError):
   foo(toOpenArray(arrNeg, -1, 0))
 doAssertRaises(IndexError):
   foo(toOpenArray(arrNeg, -1, -3))
+
+type seqqType = ptr UncheckedArray[int]
+let qData = cast[seqqType](addr seqq[0])
+oaFirstElm(toOpenArray(qData, 1, 3))
 
 proc foo(a: openArray[byte]) =
   for x in a: echo x


### PR DESCRIPTION
This pull request would let users replace code like this:
```Nim
type MyTypes* {.unchecked.} = ptr array[0, MyType]
get(toOpenArray(myObs[], 0, n), 0).somefield[1]
```
with code like this:
```Nim
type MyTypes* = ptr UncheckedArray[MyType]
echo get(toOpenArray(myObs, 0, n), 0).somefield[1]
```
In both cases, `get` is just some `proc get*[T](x: openArray[T], i: int): T`, `myObs` is some instance of `MyTypes`, and `n` is some length computed at run-time.  I elided those to more starkly show the difference.
 
I don't know if that improves the ergonomics enough to close https://github.com/nim-lang/Nim/issues/9001, but it is a pretty simple change maybe worth consideration.