### PR TITLE
Avoid memory allocation during dynlib loading

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -20,7 +20,7 @@ const
 proc c_fwrite(buf: pointer, size, n: csize, f: File): cint {.
   importc: "fwrite", header: "<stdio.h>".}
 
-proc rawWrite(f: File, s: string) =
+proc rawWrite(f: File, s: string|cstring) =
   # we cannot throw an exception here!
   discard c_fwrite(cstring(s), 1, s.len, f)
 
@@ -43,7 +43,7 @@ proc nimLoadLibraryError(path: string) =
 proc procAddrError(name: cstring) {.noinline.} =
   # carefully written to avoid memory allocation:
   stderr.rawWrite("could not import: ")
-  stderr.write(name)
+  stderr.rawWrite(name)
   stderr.rawWrite("\n")
   quit(1)
 
@@ -86,7 +86,7 @@ when defined(posix):
     when defined(nimDebugDlOpen):
       let error = dlerror()
       if error != nil:
-        stderr.write(error)
+        stderr.rawWrite(error)
         stderr.rawWrite("\n")
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
@@ -181,7 +181,7 @@ elif defined(nintendoswitch):
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
     stderr.rawWrite("nimGetProAddr not implemented")
-    stderr.write(name)
+    stderr.rawWrite(name)
     stderr.rawWrite("\n")
     quit(1)
 


### PR DESCRIPTION
By using `write` instead of `rawWrite` we'd end up asking the compiler
to generate the GC dynlib _while_ we were already generating another
dynlib!

Fixes #9123

@Araq: I think you'd like this better than #9124 :)