### PR TITLE
check to make sure `loadDynamicLib` is not re-entrant to avoid bugs like #9123 in future

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -11,6 +11,9 @@
 # It is not possible to do this in a platform independent way, unfortunately.
 # However, the interface has been designed to take platform differences into
 # account and been ported to all major platforms.
+# Subtle bugs can occur if trying to dlopen a GC and the code below calls the GC,
+# see https://github.com/nim-lang/Nim/issues/9123, so we should avoid calling the
+# GC in the procs here.
 
 {.push stack_trace: off.}
 


### PR DESCRIPTION
~~just found out https://github.com/nim-lang/Nim/pull/9320 ended up with the same fix! closing this...~~
**EDIT**  reopening this; 
this introduces a check that makes sure loadDynamicLib is not re-entrant to avoid bugs such as #9123 in the future
it'll give this error if code changes make `loadDynamicLib` reentrant:

`Error: internal error: loadDynamicLib should not be re-entrant; see https://github.com/nim-lang/Nim/issues/9123`

you can trigger this via changing back `stderr.rawWrite(error)` to `stderr.write(error)`

