### PR TITLE
doc: stmt was an alias for untyped, not typed (+ expr also was flipped)

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5036,8 +5036,8 @@ an ``immediate`` pragma and then these templates do not take part in
 overloading resolution and the parameters' types are *ignored* by the
 compiler. Explicit immediate templates are now deprecated.
 
-**Note**: For historical reasons ``stmt`` was an alias for ``typed`` and
-``expr`` was an alias for ``untyped``, but they are removed.
+**Note**: For historical reasons ``stmt`` was an alias for ``untyped`` and
+``expr`` was an alias for ``typed``, but they are removed.
 
 
 Passing a code block to a template


### PR DESCRIPTION
/cc @Araq @demotomohiro  ; noticed docs has a typo after reading https://github.com/nim-lang/Nim/pull/9321

eg:
see
git diff 75345ad1aacf8e2a4d43e4e89f16f6a641d6a9c3 -- lib/deprecated/pure/sockets.nim
```
-  template addNLIfEmpty(): stmt =
+  template addNLIfEmpty(): untyped =
```