### PR TITLE
fixes #8916 by fixing typeinfo and marshal.

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -246,8 +246,8 @@ proc base*(x: Any): Any =
 
 
 proc isNil*(x: Any): bool =
-  ## `isNil` for an any `x` that represents a sequence, string, cstring,
-  ## proc or some pointer type.
+  ## `isNil` for an any `x` that represents a cstring, proc or
+  ## some pointer type.
   assert x.rawType.kind in {tyCString, tyRef, tyPtr, tyPointer, tyProc}
   result = isNil(cast[ppointer](x.value)[])
 

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -228,8 +228,14 @@ proc `[]=`*(x: Any, i: int, y: Any) =
 proc len*(x: Any): int =
   ## len for an any `x` that represents an array or a sequence.
   case x.rawType.kind
-  of tyArray: result = x.rawType.size div x.rawType.base.size
-  of tySequence: result = cast[PGenSeq](cast[ppointer](x.value)[]).len
+  of tyArray:
+    result = x.rawType.size div x.rawType.base.size
+  of tySequence:
+    let pgenSeq = cast[PGenSeq](cast[ppointer](x.value)[])
+    if isNil(pgenSeq):
+      result = 0
+    else:
+      result = pgenSeq.len
   else: assert false
 
 
@@ -242,8 +248,7 @@ proc base*(x: Any): Any =
 proc isNil*(x: Any): bool =
   ## `isNil` for an any `x` that represents a sequence, string, cstring,
   ## proc or some pointer type.
-  assert x.rawType.kind in {tyString, tyCString, tyRef, tyPtr, tyPointer,
-                            tySequence, tyProc}
+  assert x.rawType.kind in {tyCString, tyRef, tyPtr, tyPointer, tyProc}
   result = isNil(cast[ppointer](x.value)[])
 
 proc getPointer*(x: Any): pointer =
@@ -716,5 +721,3 @@ when isMainModule:
     for i in 0 .. m.len-1:
       for j in 0 .. m[i].len-1:
         echo getString(m[i][j])
-
-

--- a/lib/pure/marshal.nim
+++ b/lib/pure/marshal.nim
@@ -54,13 +54,11 @@ proc storeAny(s: Stream, a: Any, stored: var IntSet) =
     else:
       s.write($int(ch))
   of akArray, akSequence:
-    if a.kind == akSequence and isNil(a): s.write("null")
-    else:
-      s.write("[")
-      for i in 0 .. a.len-1:
-        if i > 0: s.write(", ")
-        storeAny(s, a[i], stored)
-      s.write("]")
+    s.write("[")
+    for i in 0 .. a.len-1:
+      if i > 0: s.write(", ")
+      storeAny(s, a[i], stored)
+    s.write("]")
   of akObject, akTuple:
     s.write("{")
     var i = 0

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -105,3 +105,16 @@ r = to[Something](data2)
 
 echo r.x, " ", r.y
 
+
+type
+  Foo = object
+    a1: string
+    a2: string
+    a3: seq[string]
+    a4: seq[int]
+    a5: seq[int]
+    a6: seq[int]
+var foo = Foo(a2: "", a4: @[], a6: @[1])
+foo.a6.setLen 0
+doAssert $$foo == """{"a1": "", "a2": "", "a3": [], "a4": [], "a5": [], "a6": []}"""
+testit(foo)


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/8916.

This PR is partially based on @timotheecour's https://github.com/nim-lang/Nim/pull/8942, but fixes the issue seen in his example.

In `marshal.nim` we must not check for `isNil` of `tySequence` anymore and then in addition make sure we return the length of a sequence in `typeinfo` correctly. If the latter can be done differently, let me know.