### PR TITLE
add strutils. stripLineEnd: removes (at most 1) newline-like suffix

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2392,6 +2392,29 @@ proc removePrefix*(s: var string, prefix: string) {.
   if s.startsWith(prefix):
     s.delete(0, prefix.len - 1)
 
+proc stripLineEnd*(s: var string) =
+  ## Returns ``s`` stripped from one of these suffixes:
+  ## ``\r, \n, \r\n, \f, \v`` (at most once instance).
+  ## For example, can be useful in conjunction with ``osproc.execCmdEx``.
+  runnableExamples:
+    var s = "foo\n\n"
+    s.stripLineEnd
+    doAssert s == "foo\n"
+    s = "foo\r\n"
+    s.stripLineEnd
+    doAssert s == "foo"
+  if s.len > 0:
+    case s[^1]
+    of '\n':
+      if s.len > 1 and s[^2] == '\r':
+        s.setLen s.len-2
+      else:
+        s.setLen s.len-1
+    of '\r', '\v', '\f':
+      s.setLen s.len-1
+    else:
+      discard
+
 when isMainModule:
   proc nonStaticTests =
     doAssert formatBiggestFloat(1234.567, ffDecimal, -1) == "1234.567000"


### PR DESCRIPTION
useful in conjunction with things like osproc.execCmdEx, or readline lines of text file (that could've been produced on another platform) for example.

in other languages:
* D: chomp https://dlang.org/library/std/string/chomp.html
* java: chomp https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringUtils.html
* perl: chomp https://perldoc.perl.org/functions/chomp.html
* ruby: chomp https://ruby-doc.org/core-2.2.0/String.html
* scala: stripLineEnd https://www.scala-lang.org/api/2.7.7/scala/runtime/RichString.html
* node: newline-remove https://www.npmjs.com/package/newline-remove

it's easy to get wrong and common enough to be in stdlib (alongside `removeSuffix`)

Note: as in all (most?) of the above languages, the implementation of `stripLineEnd ` is not OS specific, so it'll remove a trailing `\r, \n, \r\n, \f, \v` regardless of platform, this is useful eg to operate on input that could've come from another platform.

EDIT: s/chomp/stripLineEnd/ after feedback