### PR TITLE
Don't use echo if the TLS size check fails

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3070,6 +3070,10 @@ when not defined(JS): #and not defined(nimscript):
   include "system/ansi_c"
   include "system/memory"
 
+  proc rawWrite(f: File, s: string|cstring) {.inline.} =
+    # Writes `s` to `f` without allocating memory nor raising exceptions
+    discard c_fwrite(cstring(s), 1, s.len, f)
+
   proc zeroMem(p: pointer, size: Natural) =
     nimZeroMem(p, size)
     when declared(memTrackerOp):

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -119,6 +119,9 @@ proc c_sprintf(buf, frmt: cstring): cint {.
   importc: "sprintf", header: "<stdio.h>", varargs, noSideEffect.}
   # we use it only in a way that cannot lead to security issues
 
+proc c_fwrite(buf: pointer, size, n: csize, f: File): cint {.
+  importc: "fwrite", header: "<stdio.h>".}
+
 when defined(windows):
   proc c_fileno(f: File): cint {.
       importc: "_fileno", header: "<stdio.h>".}

--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -17,13 +17,6 @@
 const
   NilLibHandle: LibHandle = nil
 
-proc c_fwrite(buf: pointer, size, n: csize, f: File): cint {.
-  importc: "fwrite", header: "<stdio.h>".}
-
-proc rawWrite(f: File, s: string|cstring) =
-  # we cannot throw an exception here!
-  discard c_fwrite(cstring(s), 1, s.len, f)
-
 proc nimLoadLibraryError(path: string) =
   # carefully written to avoid memory allocation:
   stderr.rawWrite("could not load: ")

--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -40,10 +40,6 @@ proc c_clearerr(f: File) {.
 proc c_feof(f: File): cint {.
   importc: "feof", header: "<stdio.h>".}
 
-when not declared(c_fwrite):
-  proc c_fwrite(buf: pointer, size, n: csize, f: File): cint {.
-    importc: "fwrite", header: "<stdio.h>".}
-
 # C routine that is used here:
 proc c_fread(buf: pointer, size, n: csize, f: File): csize {.
   importc: "fread", header: "<stdio.h>", tags: [ReadIOEffect].}

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -329,10 +329,12 @@ when not defined(useNimRtl):
 
   when emulatedThreadVars:
     if nimThreadVarsSize() > sizeof(ThreadLocalStorage):
-      echo "too large thread local storage size requested ",
-           "(", nimThreadVarsSize(), "/", sizeof(ThreadLocalStorage), "). ",
-           "Use -d:\"nimTlsSize=", nimThreadVarsSize(),
-           "\" to preallocate sufficient storage."
+      stderr.rawWrite "too large thread local storage size requested ("
+      stderr.rawWrite $nimThreadVarsSize()
+      stderr.rawWrite "/" & $sizeof(ThreadLocalStorage) & "). "
+      stderr.rawWrite "Use -d:\"nimTlsSize="
+      stderr.rawWrite $nimThreadVarsSize()
+      stderr.rawWrite "\" to preallocate sufficient storage.\n"
 
       quit 1
 


### PR DESCRIPTION
On windows the echoBinSafe procedure uses a global lock that's not
initialized yet when we reach the check.

Some code has been shuffled around in order to use the same trick both
in the `threads` module and in `dyncalls`.

Fixes #9314

CC @kayabaNerve 