### PR TITLE
Unicode escape in string literals

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -285,6 +285,11 @@ contain the following `escape sequences`:idx:\ :
   ``\e``                   `escape`:idx: `[ESC]`:idx:
   ``\x`` HH                `character with hex value HH`:idx:;
                            exactly two hex digits are allowed
+  ``\u`` HHHH              `unicode codepoint with hex value HHHH`:idx:;
+                           exactly four hex digits are allowed
+  ``\u`` {H+}              `unicode codepoint`:idx:;
+                           all hex digits enclosed in ``{}`` are used for
+                           the codepoint
 ==================         ===================================================
 
 

--- a/tests/lexer/tstrlits.nim
+++ b/tests/lexer/tstrlits.nim
@@ -1,6 +1,6 @@
 discard """
   file: "tstrlits.nim"
-  output: "a\"\"long string\"\"\"\"\"abc\"def_'2'●"
+  output: "a\"\"long string\"\"\"\"\"abc\"def_'2'●𝌆𝌆A"
 """
 # Test the new different string literals
 
@@ -11,14 +11,14 @@ const
 
   raw = r"abc""def"
 
-  escaped = "\x5f'\50'\u25cf"
+  escaped = "\x5f'\50'\u25cf\u{1D306}\u{1d306}\u{41}"
 
 
 stdout.write(rawQuote)
 stdout.write(tripleEmpty)
 stdout.write(raw)
 stdout.write(escaped)
-#OUT a""long string"""""abc"def
+#OUT a""long string"""""abc"def_'2'●𝌆𝌆A
 
 
 


### PR DESCRIPTION
Changes:
- `\uHHHH` and `\xHH` must now use exactly four/two hex digits (already documented in the spec)
- `\uHHHH` is no longer allowed in char literals
- Added `\u{H+}`, which is used to escape an arbitrary unicode codepoint

Fixes #7068