### PR TITLE
fix module graph

### DIFF
--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -107,6 +107,7 @@ proc newModuleGraph*(cache: IdentCache; config: ConfigRef): ModuleGraph =
   result.cacheSeqs = initTable[string, PNode]()
   result.cacheCounters = initTable[string, BiggestInt]()
   result.cacheTables = initTable[string, BTree[string, PNode]]()
+  result.passes = @[]
 
 proc resetAllModules*(g: ModuleGraph) =
   initStrTable(g.packageSyms)


### PR DESCRIPTION
Getting this error while executing ` koch boot`
nim revision: afd9d8dd8d99391500ef91085b76b34d77a37648

Looks like passes in ModuleGraph never be allocated.

compiler\nim1.exe c  --nimcache:nimcache/d_windows_amd64 compiler\nim.nim
Hint: used config file 'J:\devel\nim\config\nim.cfg' [Conf]
Hint: used config file 'J:\devel\nim\compiler\nim.cfg' [Conf]
Traceback (most recent call last)
nim.nim(108)             nim
nim.nim(72)              handleCmdLine
cmdlinehelper.nim(91)    loadConfigsAndRunMainCommand
main.nim(155)            mainCommand
passes.nim(48)           clearPasses
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
FAILURE
