### PR TITLE
Nimpretty source code filter abort

### DIFF
--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -73,7 +73,7 @@ proc main =
   if not fs.isNil:
     let prefix = fs.readStr(2)
     if prefix == "#?":
-      echo "Nimpretty currently doesn't support source code filters"
+      echo "Nothing changed, nimpretty currently doesn't support source code filters"
       fs.close()
       return
     fs.close()


### PR DESCRIPTION
As requested by @Araq in issue #9384 .
Reads the first 2 characters of the input file, abort `nimpretty` if they are `#?`.