### PR TITLE
Minor fixes for 32bit compatibility

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -944,11 +944,11 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     c.freeTemp(tmp)
     c.freeTemp(tmp2)
 
-  of mShlI: genBinaryABCnarrowU(c, n, dest, opcShlInt)
+  of mShlI: genBinaryABCnarrow(c, n, dest, opcShlInt)
   of mAshrI: genBinaryABCnarrow(c, n, dest, opcAshrInt)
-  of mBitandI: genBinaryABCnarrowU(c, n, dest, opcBitandInt)
-  of mBitorI: genBinaryABCnarrowU(c, n, dest, opcBitorInt)
-  of mBitxorI: genBinaryABCnarrowU(c, n, dest, opcBitxorInt)
+  of mBitandI: genBinaryABCnarrow(c, n, dest, opcBitandInt)
+  of mBitorI: genBinaryABCnarrow(c, n, dest, opcBitorInt)
+  of mBitxorI: genBinaryABCnarrow(c, n, dest, opcBitxorInt)
   of mAddU: genBinaryABCnarrowU(c, n, dest, opcAddu)
   of mSubU: genBinaryABCnarrowU(c, n, dest, opcSubu)
   of mMulU: genBinaryABCnarrowU(c, n, dest, opcMulu)
@@ -974,9 +974,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
     genNarrow(c, n, dest)
   of mUnaryMinusF64: genUnaryABC(c, n, dest, opcUnaryMinusFloat)
   of mUnaryPlusI, mUnaryPlusF64: gen(c, n.sons[1], dest)
-  of mBitnotI:
-    genUnaryABC(c, n, dest, opcBitnotInt)
-    genNarrowU(c, n, dest)
+  of mBitnotI: genBinaryABCnarrow(c, n, dest, opcBitnotInt)
   of mToFloat, mToBiggestFloat, mToInt,
      mToBiggestInt, mCharToStr, mBoolToStr, mIntToStr, mInt64ToStr,
      mFloatToStr, mCStrToStr, mStrToStr, mEnumToStr:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -915,13 +915,13 @@ when not defined(JS):
     ## unsigned. Does nothing if the size of an ``int`` is the same as ``int64``.
     ## (This is the case on 64 bit processors.)
 
-  proc toU8*(x: int): int8 {.magic: "ToU8", noSideEffect.}
+  proc toU8*(x: int|int8|int16|int32|int64): int8 {.magic: "ToU8", noSideEffect.}
     ## treats `x` as unsigned and converts it to a byte by taking the last 8 bits
     ## from `x`.
-  proc toU16*(x: int): int16 {.magic: "ToU16", noSideEffect.}
+  proc toU16*(x: int|int16|int32|int64): int16 {.magic: "ToU16", noSideEffect.}
     ## treats `x` as unsigned and converts it to an ``int16`` by taking the last
     ## 16 bits from `x`.
-  proc toU32*(x: int64): int32 {.magic: "ToU32", noSideEffect.}
+  proc toU32*(x: int32|int64): int32 {.magic: "ToU32", noSideEffect.}
     ## treats `x` as unsigned and converts it to an ``int32`` by taking the
     ## last 32 bits from `x`.
 

--- a/tests/system/talloc2.nim
+++ b/tests/system/talloc2.nim
@@ -1,10 +1,12 @@
 discard """
 """
 
-const
-  nmax = 2*1024*1024*1024
+when sizeOf(int) < 8:
+  const nmax = 1'i64*1024*1024*1024
+else:
+  const nmax = 2'i64*1024*1024*1024
 
-proc test(n: int) =
+proc test(n: int64) =
   var a = alloc0(9999)
   var t = cast[ptr UncheckedArray[int8]](alloc(n))
   var b = alloc0(9999)
@@ -18,7 +20,7 @@ proc test(n: int) =
 
 # allocator adds 48 bytes to BigChunk
 # BigChunk allocator edges at 2^n * (1 - s) for s = [1..32]/64
-proc test2(n: int) =
+proc test2(n: int64) =
   let d = n div 256  # cover edges and more
   for i in countdown(128,1):
     for j in [-4096, -64, -49, -48, -47, -32, 0, 4096]:
@@ -28,7 +30,7 @@ proc test2(n: int) =
         #echo b, ": ", getTotalMem(), " ", getOccupiedMem(), " ", getFreeMem()
 
 proc test3 =
-  var n = 1
+  var n = 1'i64
   while n <= nmax:
     test2(n)
     n *= 2

--- a/tests/vm/tzero_extend.nim
+++ b/tests/vm/tzero_extend.nim
@@ -13,9 +13,9 @@ proc get_values(): (seq[int8], seq[int16], seq[int32]) =
   result[0] = @[]; result[1] = @[]; result[2] = @[]
 
   for offset in RANGE:
-    let i8 = -(1 shl 9) + offset
-    let i16 = -(1 shl 17) + offset
-    let i32 = -(1 shl 33) + offset
+    let i8 = -(1'i64 shl 9) + offset
+    let i16 = -(1'i64 shl 17) + offset
+    let i32 = -(1'i64 shl 33) + offset
 
     # higher bits are masked. these should be exactly equal to offset.
     result[0].add i8.toU8


### PR DESCRIPTION
The only notable change here is in the VM: the bitwise OPs preserve the
input type signedness.

Addresses part of #9138

Let's see if this patchset breaks on 64bit platforms...