### PR TITLE
make some tests faster

### DIFF
--- a/tests/async/tfuturestream.nim
+++ b/tests/async/tfuturestream.nim
@@ -19,7 +19,7 @@ var fs = newFutureStream[int]()
 proc alpha() {.async.} =
   for i in 0 .. 5:
     await fs.write(i)
-    await sleepAsync(1000)
+    await sleepAsync(200)
 
   echo("Done")
   fs.complete()

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -3,10 +3,9 @@ discard """
   output: '''
 done
 And we get here
-true
-true
-true
-true
+1
+2
+3
 '''
 """
 import hashes, sequtils, tables
@@ -119,8 +118,7 @@ block thashes:
       newTable[uint32, string](),
       newTable[uint64, string](),
     )
-
-  echo "true"
+  echo "1"
 
 
 block tindexby:
@@ -188,7 +186,7 @@ block ttables2:
 
 
   run1()
-  echo "true"
+  echo "2"
 
 
 block tablesref:
@@ -355,21 +353,4 @@ block tablesref:
     assert t.len() == 0
 
   orderedTableSortTest()
-  echo "true"
-
-
-block tablesref2:
-  proc TestHashIntInt() =
-    var tab = newTable[int,int]()
-    for i in 1..1_000_000:
-      tab[i] = i
-    for i in 1..1_000_000:
-      var x = tab[i]
-      if x != i : echo "not found ", i
-
-  proc run1() =         # occupied Memory stays constant, but
-    for i in 1 .. 50:   # aborts at run: 44 on win32 with 3.2GB with out of memory
-      TestHashIntInt()
-
-  run1()
-  echo "true"
+  echo "3"

--- a/tests/generics/trtree.nim
+++ b/tests/generics/trtree.nim
@@ -67,7 +67,7 @@ proc center(r: Box): auto =#BoxCenter[r.len, type(r[0].a)] =
   for i in 0 .. r.high:
     when r[0].a is SomeInteger:
       result[i] = (r[i].a + r[i].b) div 2
-    elif r[0].a is SomeReal:
+    elif r[0].a is SomeFloat:
       result[i] = (r[i].a + r[i].b) / 2
     else: assert false
   return result
@@ -81,7 +81,7 @@ proc distance(c1, c2: BoxCenter): auto =
 proc overlap(r1, r2: Box): auto =
   result = type(r1[0].a)(1)
   for i in 0 .. r1.high:
-    result *=  (min(r1[i]. b, r2[i]. b) - max(r1[i]. a, r2[i]. a))
+    result *= (min(r1[i]. b, r2[i]. b) - max(r1[i]. a, r2[i]. a))
     if result <= 0: return 0
 
 proc union(r1, r2: Box): Box =
@@ -278,7 +278,7 @@ proc rstarSplit[M, D: Dim; RT, LT](t: RStarTree[M, D, RT, LT]; n: var Node[M, D,
   for i in i0 .. n.a.high:
     result.a[i - i0] = nbest.a[i]
   n.numEntries = i0 + 1
-  result.numEntries = M  - i0
+  result.numEntries = M - i0
   when n is Node[M, D, RT, LT]:
     for i in 0 ..< result.numEntries:
       result.a[i].n.parent = result
@@ -302,7 +302,7 @@ proc quadraticSplit[M, D: Dim; RT, LT](t: RTree[M, D, RT, LT]; n: var Node[M, D,
   else:
     n1.a[0] = n.a[s1]
     dec(n.numEntries)
-    if s2 ==  n.numEntries: # important fix
+    if s2 == n.numEntries: # important fix
       s2 = s1
     n.a[s1] = n.a[n.numEntries]
   inc(n1.numEntries)
@@ -651,7 +651,7 @@ when isMainModule:
         assert r.len == r2.len
         assert r.sorted(system.cmp) == r2.sorted(system.cmp)
 
-  test(5500)
+  test(1500)
 
   # 651 lines
 

--- a/tests/parallel/tconvexhull.nim
+++ b/tests/parallel/tconvexhull.nim
@@ -1,10 +1,6 @@
 discard """
-  output: '''true
-true
-true
-true
-true
-true'''
+  output: '''
+'''
 
 ccodeCheck: "\\i ! @'deepCopy(' .*"
 """
@@ -55,10 +51,10 @@ proc convex_hull[T](points: var seq[T], cmp: proc(x, y: T): int {.closure.}) : s
       ul[k] = spawn half[T](points, k == 0)
   result = concat(^ul[0], ^ul[1])
 
-var s = map(toSeq(0..999999), proc(x: int): Point = (float(x div 1000), float(x mod 1000)))
+var s = map(toSeq(0..99999), proc(x: int): Point = (float(x div 1000), float(x mod 1000)))
 setMaxPoolSize 2
 
 #echo convex_hull[Point](s, cmpPoint)
 for i in 0..5:
-  echo convex_hull[Point](s, cmpPoint) ==
-      @[(0.0, 0.0), (999.0, 0.0), (999.0, 999.0), (0.0, 999.0)]
+  doAssert convex_hull[Point](s, cmpPoint) ==
+      @[(0.0, 0.0), (99.0, 0.0), (99.0, 999.0), (0.0, 999.0)]

--- a/tests/parallel/twaitany.nim
+++ b/tests/parallel/twaitany.nim
@@ -11,7 +11,7 @@ proc timer(d: int): int =
   #echo fmt"done {d}"
   return d
 
-var durations = [1000, 2000, 3000, 4000, 5000]
+var durations = [1000, 1500, 2000, 2500, 3000]
 var tasks: seq[FlowVarBase] = @[]
 var results: seq[int] = @[]
 
@@ -27,9 +27,9 @@ while index != -1:
 
 doAssert results.len == 5
 doAssert 1000 in results
+doAssert 1500 in results
 doAssert 2000 in results
+doAssert 2500 in results
 doAssert 3000 in results
-doAssert 4000 in results
-doAssert 5000 in results
 sync()
 echo "true"


### PR DESCRIPTION
I've checked the slowest tests on appveyor and tried to see if there is anything that can be improved.

* in `ttables.nim` there was a slow test which was duplicated. I've removed the duplicate, but didn't touch [the original number of iterations](https://github.com/nim-lang/Nim/blob/06a3b63e77a79297a8d91b117d0f6c39d9868f46/tests/collections/ttables.nim#L165)
* changes in other files include decreasing the number of iterations or less `sleep`

I've tried to do the same for the slowest tests on TravisCI, but the results seem very erratic (e.g. tests that should be fast taking more than a minute).
