### PR TITLE
[doc] start of best practices section in contributing.rst

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -303,8 +303,8 @@ Use ``doAssert`` (or ``require``, etc), not ``assert`` in all tests.
 
 .. code-block:: nim
 
-  runnableExamples: assert foo()
-  runnableExamples: doAssert foo()
+  runnableExamples: assert foo() # bad
+  runnableExamples: doAssert foo() # preferred
 
 .. _delegate_printing:
 Delegate printing to caller: return ``string`` instead of calling ``echo``
@@ -313,7 +313,7 @@ including prepending location info, writing to log files, etc).
 
 .. code-block:: nim
 
-  proc foo() = echo "bar"
+  proc foo() = echo "bar" # bad
   proc foo(): string = "bar" # preferred (usually)
 
 .. _use_Option:
@@ -322,7 +322,7 @@ allocation is needed (eg for efficiency).
 
 .. code-block:: nim
 
-  proc foo(a: var Bar): bool
+  proc foo(a: var Bar): bool # bad
   proc foo(): Option[Bar] # preferred
 
 .. _use_doAssert_not_echo:

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -251,7 +251,7 @@ the first is preferred.
 Best practices
 =============
 
-Note: these are gneral guidelines, not hard rules; there are always exceptions.
+Note: these are general guidelines, not hard rules; there are always exceptions.
 Code reviews can just point to a specific section here to save time and
 propagate best practices.
 
@@ -263,14 +263,6 @@ Take advantage of no implicit bool conversion
   doAssert isValid() == true
   doAssert isValid() # preferred
 
-.. _noimplicitbool:
-Reduce parenthesis nesting
-
-.. code-block:: nim
-
-  doAssert (not 1 == 2)
-  doAssert: not 1 == 2  # preferred
-
 .. _immediately_invoked_lambdas:
 Immediately invoked lambdas (https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
 
@@ -280,8 +272,8 @@ Immediately invoked lambdas (https://en.wikipedia.org/wiki/Immediately-invoked_f
   let a = block:  # preferred
     getFoo()
 
-.. _design_for_ufcs:
-Design with UFCS (method call syntax) chaining in mind
+.. _design_for_mcs:
+Design with method call syntax (UFCS in other languages) chaining in mind
 
 .. code-block:: nim
 
@@ -317,8 +309,8 @@ including prepending location info, writing to log files, etc).
   proc foo(): string = "bar" # preferred (usually)
 
 .. _use_Option:
-Genreally, use Option instead of return bool + var argument, unless stack
-allocation is needed (eg for efficiency).
+[Ongoing debate] Consider using Option instead of return bool + var argument,
+unless stack allocation is needed (eg for efficiency).
 
 .. code-block:: nim
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -248,6 +248,94 @@ or
 
 the first is preferred.
 
+Best practices
+=============
+
+Note: these are gneral guidelines, not hard rules; there are always exceptions.
+Code reviews can just point to a specific section here to save time and
+propagate best practices.
+
+.. _noimplicitbool:
+Take advantage of no implicit bool conversion
+
+.. code-block:: nim
+
+  doAssert isValid() == true
+  doAssert isValid() # preferred
+
+.. _noimplicitbool:
+Reduce parenthesis nesting
+
+.. code-block:: nim
+
+  doAssert (not 1 == 2)
+  doAssert: not 1 == 2  # preferred
+
+.. _immediately_invoked_lambdas:
+Immediately invoked lambdas (https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
+
+.. code-block:: nim
+
+  let a = (proc (): auto = getFoo())()
+  let a = block:  # preferred
+    getFoo()
+
+.. _design_for_ufcs:
+Design with UFCS (method call syntax) chaining in mind
+
+.. code-block:: nim
+
+  proc foo(cond: bool, lines: seq[string]) # bad
+  proc foo(lines: seq[string], cond: bool) # preferred
+  # can be called as: `getLines().foo(false)`
+
+.. _avoid_quit:
+Use exceptions (including assert / doAssert) instead of ``quit``
+rationale: https://forum.nim-lang.org/t/4089
+
+.. code-block:: nim
+
+  quit() # bad in almost all cases
+  doAssert() # preferred
+
+.. _tests_use_doAssert:
+Use ``doAssert`` (or ``require``, etc), not ``assert`` in all tests.
+
+.. code-block:: nim
+
+  runnableExamples: assert foo()
+  runnableExamples: doAssert foo()
+
+.. _delegate_printing:
+Delegate printing to caller: return ``string`` instead of calling ``echo``
+rationale: it's more flexible (eg allows caller to call custom printing,
+including prepending location info, writing to log files, etc).
+
+.. code-block:: nim
+
+  proc foo() = echo "bar"
+  proc foo(): string = "bar" # preferred (usually)
+
+.. _use_Option:
+Genreally, use Option instead of return bool + var argument, unless stack
+allocation is needed (eg for efficiency).
+
+.. code-block:: nim
+
+  proc foo(a: var Bar): bool
+  proc foo(): Option[Bar] # preferred
+
+.. _use_doAssert_not_echo:
+Tests (including in testament) should always prefer assertions over ``echo``,
+except when that's not possible. It's more precise, easier for readers and
+maintaners to where expected values refer to. See for example
+https://github.com/nim-lang/Nim/pull/9335 and https://forum.nim-lang.org/t/4089
+
+.. code-block:: nim
+
+  echo foo() # adds a line in testament `discard` block.
+  doAssert foo() == [1, 2] # preferred, except when not possible to do so.
+
 The Git stuff
 =============
 

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -314,8 +314,8 @@ unless stack allocation is needed (eg for efficiency).
 
 .. code-block:: nim
 
-  proc foo(a: var Bar): bool # bad
-  proc foo(): Option[Bar] # preferred
+  proc foo(a: var Bar): bool
+  proc foo(): Option[Bar]
 
 .. _use_doAssert_not_echo:
 Tests (including in testament) should always prefer assertions over ``echo``,


### PR DESCRIPTION
/cc @Araq @mratsim @narimiran @dom96 

I always wished there was a "best practices" section; let's start one and grow it over time, keeping it up to date with language improvements. It saves times for both PR authors and reviewers, we can just refer to this doc in code reviews, using anchors to the specific paragraph. 

There are plenty of posts on forum requesting such best practices section:

* [Lessons learned/idioms - Nim forum](https://forum.nim-lang.org/t/4124#25693)
* https://forum.nim-lang.org/t/4099#25496 "How should I handle testing these examples? ..."
* https://forum.nim-lang.org/t/1978#13958 "what are the best practices?"
* [Zen for NIM? - Nim forum](https://forum.nim-lang.org/t/1377#8593) "What are the recommended Practices between soo many choices? ..."
* https://forum.nim-lang.org/t/871#5177 "And are there other best practices in Nim for adding..."
* https://forum.nim-lang.org/t/608#3347 "As with the rest of Nim, some more docs and 'best practices' would be helpful."

## note
* I don't mind other guides containing such best practices (eg "external links" below), but it's desirable to have such a "best practices" section in Nim repo, version controlled along the rest of doc/code, so that it's always in sync with compiler/language, are updated when newer idioms become preferred, and agreed upon for code reviews (aka: no endless debates in each indivudual PR)
* if a rule is too controversial, let's skip it (or mark it as "controversial")

## external links
* https://scripter.co/notes/nim
* Nim in Action
* https://github.com/status-im
* https://github.com/nim-lang/Nim/wiki/Style-Guide-for-Nim-Code
* https://nim-lang.org/docs/nep1.html seems to cover mostly style (eg whitespace, naming) rather than semantics. This "best practices" is not intended to duplicate what's in there.  One possibility is to move the paragraph "Coding Conventions" to this "best practices" page so that the split is even clearer (style vs semantics)


