### PR TITLE
fix #9394 by replacing `fmt` with `strutils.%`

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -18,7 +18,7 @@
 
 import macros
 import strformat
-from strutils import toLowerAscii
+from strutils import toLowerAscii, `%`
 import colors, tables
 
 when defined(windows):
@@ -636,7 +636,7 @@ proc ansiForegroundColorCode*(color: Color): string =
 template ansiForegroundColorCode*(color: static[Color]): string =
   const rgb = extractRGB(color)
   # no usage of `fmt`, see issue #7632
-  (static($fgPrefix & $(rgb.r) & ";" & $(rgb.g) & ";" & $(rgb.b) & "m"))
+  (static("$1$2;$3;$4m" % [$fgPrefix, $(rgb.r), $(rgb.g), $(rgb.b)]))
 
 proc ansiBackgroundColorCode*(color: Color): string =
   let rgb = extractRGB(color)
@@ -645,7 +645,7 @@ proc ansiBackgroundColorCode*(color: Color): string =
 template ansiBackgroundColorCode*(color: static[Color]): string =
   const rgb = extractRGB(color)
   # no usage of `fmt`, see issue #7632
-  (static($bgPrefix & $(rgb.r) & ";" & $(rgb.g) & ";" & $(rgb.b) & "m"))
+  (static("$1$2;$3;$4m" % [$bgPrefix, $(rgb.r), $(rgb.g), $(rgb.b)]))
 
 proc setForegroundColor*(f: File, color: Color) =
   ## Sets the terminal's foreground true color.

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -635,7 +635,8 @@ proc ansiForegroundColorCode*(color: Color): string =
 
 template ansiForegroundColorCode*(color: static[Color]): string =
   const rgb = extractRGB(color)
-  (static(fmt"{fgPrefix}{rgb.r};{rgb.g};{rgb.b}m"))
+  # no usage of `fmt`, see issue #7632
+  (static($fgPrefix & $(rgb.r) & ";" & $(rgb.g) & ";" & $(rgb.b) & "m"))
 
 proc ansiBackgroundColorCode*(color: Color): string =
   let rgb = extractRGB(color)
@@ -643,7 +644,8 @@ proc ansiBackgroundColorCode*(color: Color): string =
 
 template ansiBackgroundColorCode*(color: static[Color]): string =
   const rgb = extractRGB(color)
-  (static(fmt"{bgPrefix}{rgb.r};{rgb.g};{rgb.b}m"))
+  # no usage of `fmt`, see issue #7632
+  (static($bgPrefix & $(rgb.r) & ";" & $(rgb.g) & ";" & $(rgb.b) & "m"))
 
 proc setForegroundColor*(f: File, color: Color) =
   ## Sets the terminal's foreground true color.

--- a/tests/stdlib/t9394.nim
+++ b/tests/stdlib/t9394.nim
@@ -1,0 +1,7 @@
+import terminal, colors
+
+let codeFg = ansiForegroundColorCode(colAliceBlue)
+let codeBg = ansiBackgroundColorCode(colAliceBlue)
+
+doAssert codeFg == "\27[38;2;240;248;255m"
+doAssert codeBg == "\27[48;2;240;248;255m"


### PR DESCRIPTION
Fixes #9394.

Until issue #7632 is fixed, use string append.