### PR TITLE
Fix 6544

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1826,8 +1826,12 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
     let srca = typeRel(m, src, a)
     if srca notin {isEqual, isGeneric, isSubtype}: continue
 
+    # What's done below matches the logic in ``matchesAux``
     let constraint = c.converters[i].typ.n[1].sym.constraint
+    # let constraint = src.sym.constraint
     if not constraint.isNil and not matchNodeKinds(constraint, arg):
+      continue
+    if src.kind in {tyVar, tyLent} and not arg.isLValue:
       continue
 
     let destIsGeneric = containsGenericType(dest)
@@ -1841,9 +1845,16 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       s.info = arg.info
       result = newNodeIT(nkHiddenCallConv, arg.info, dest)
       addSon(result, s)
+      # We build the call expression by ourselves in order to avoid passing this
+      # expression trough the semantic check phase once again so let's make sure
+      # it is correct
       var param: PNode = nil
       if srca == isSubtype:
         param = implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
+      elif s.typ[1].kind in {tyVar, tyLent}:
+        # Analyse the converter return type
+        param = newNodeIT(nkHiddenAddr, arg.info, s.typ[1])
+        param.addSon(copyTree(arg))
       else:
         param = copyTree(arg)
       addSon(result, param)

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1828,7 +1828,6 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
 
     # What's done below matches the logic in ``matchesAux``
     let constraint = c.converters[i].typ.n[1].sym.constraint
-    # let constraint = src.sym.constraint
     if not constraint.isNil and not matchNodeKinds(constraint, arg):
       continue
     if src.kind in {tyVar, tyLent} and not arg.isLValue:
@@ -1851,7 +1850,7 @@ proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
       var param: PNode = nil
       if srca == isSubtype:
         param = implicitConv(nkHiddenSubConv, src, copyTree(arg), m, c)
-      elif s.typ[1].kind in {tyVar, tyLent}:
+      elif src.kind == tyVar:
         # Analyse the converter return type
         param = newNodeIT(nkHiddenAddr, arg.info, s.typ[1])
         param.addSon(copyTree(arg))

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -571,7 +571,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
         if i < sonsLen(t) - 1: add(result, ", ")
       result.add ']'
     else:
-      result.add typeToString(t.sons[0])
+      result.add " " & typeToString(t.sons[0])
   of tyRange:
     result = "range "
     if t.n != nil and t.n.kind == nkRange:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -397,7 +397,7 @@ const
     "float", "float32", "float64", "float128",
     "uint", "uint8", "uint16", "uint32", "uint64",
     "opt", "sink",
-    "lent", "varargs[$1]", "UncheckedArray[$1]", "Error Type",
+    "lent ", "varargs[$1]", "UncheckedArray[$1]", "Error Type",
     "BuiltInTypeClass", "UserTypeClass",
     "UserTypeClassInst", "CompositeTypeClass", "inferred",
     "and", "or", "not", "any", "static", "TypeFromExpr", "FieldAccessor",
@@ -571,7 +571,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
         if i < sonsLen(t) - 1: add(result, ", ")
       result.add ']'
     else:
-      result.add " " & typeToString(t.sons[0])
+      result.add typeToString(t.sons[0])
   of tyRange:
     result = "range "
     if t.n != nil and t.n.kind == nkRange:
@@ -1176,6 +1176,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
   case t.kind
   of tyVar, tyLent:
     if kind in {skProc, skFunc, skConst}: return t
+    elif t.kind == tyLent and kind != skResult: return t
     var t2 = skipTypes(t.sons[0], abstractInst-{tyTypeDesc})
     case t2.kind
     of tyVar, tyLent:

--- a/tests/converter/tconvert.nim
+++ b/tests/converter/tconvert.nim
@@ -18,3 +18,16 @@ converter toPtr*(some: var TFoo): ptr TFoo = (addr some)
 proc zoot(x: ptr TFoo) = discard
 var x: Tfoo
 zoot(x)
+
+# issue #6544
+converter withLent(b: lent bool): int = ord(b)
+converter withVar(b: var string): int = ord(b[1])
+
+block:
+  var x = true
+  var y: int = x # instantiate withLent
+  doAssert(y == 1)
+block:
+  var x = "101"
+  var y: int = x # instantiate withVar
+  doAssert(y == ord('0'))

--- a/tests/converter/tconvert.nim
+++ b/tests/converter/tconvert.nim
@@ -20,13 +20,8 @@ var x: Tfoo
 zoot(x)
 
 # issue #6544
-converter withLent(b: lent bool): int = ord(b)
 converter withVar(b: var string): int = ord(b[1])
 
-block:
-  var x = true
-  var y: int = x # instantiate withLent
-  doAssert(y == 1)
 block:
   var x = "101"
   var y: int = x # instantiate withVar


### PR DESCRIPTION
The second commit fixes a sigmatch error that leads to bad C code being generated, I've included it in this PR because I'm too lazy to open another one.

The first commit on the other hand addresses #6544 by making the call expression correct in presence of `var`/`lent` arguments.
It's not that clean but I've figured we don't want to run the call trough `semExpr`/`semOverloadedCall` because that may introduce more converters and that's against the specified (and expected?) behaviour of the (already surprising) converters.

What we really want is to call `afterCallActions` but that's not possible from `sigmatch`...