### PR TITLE
Move cpp exception handler from system to excpt next to the signal handler

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4166,26 +4166,6 @@ template doAssertRaises*(exception: typedesc, code: untyped): typed =
   if wrong:
     raiseAssert(astToStr(exception) & " wasn't raised by:\n" & astToStr(code))
 
-when defined(cpp) and appType != "lib" and
-    not defined(js) and not defined(nimscript) and
-    hostOS != "standalone" and not defined(noCppExceptions):
-  proc setTerminate(handler: proc() {.noconv.})
-    {.importc: "std::set_terminate", header: "<exception>".}
-  setTerminate proc() {.noconv.} =
-    # Remove ourself as a handler, reinstalling the default handler.
-    setTerminate(nil)
-
-    let ex = getCurrentException()
-    let trace = ex.getStackTrace()
-    when defined(genode):
-      # stderr not available by default, use the LOG session
-      echo trace & "Error: unhandled exception: " & ex.msg &
-                   " [" & $ex.name & "]\n"
-    else:
-      cstderr.rawWrite trace & "Error: unhandled exception: " & ex.msg &
-                   " [" & $ex.name & "]\n"
-    quit 1
-
 when not defined(js):
   proc toOpenArray*[T](x: seq[T]; first, last: int): openarray[T] {.
     magic: "Slice".}

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -469,6 +469,26 @@ when defined(endb):
   var
     dbgAborting: bool # whether the debugger wants to abort
 
+when defined(cpp) and appType != "lib" and
+    not defined(js) and not defined(nimscript) and
+    hostOS != "standalone" and not defined(noCppExceptions):
+  proc setTerminate(handler: proc() {.noconv.})
+    {.importc: "std::set_terminate", header: "<exception>".}
+  setTerminate proc() {.noconv.} =
+    # Remove ourself as a handler, reinstalling the default handler.
+    setTerminate(nil)
+
+    let ex = getCurrentException()
+    let trace = ex.getStackTrace()
+    when defined(genode):
+      # stderr not available by default, use the LOG session
+      echo trace & "Error: unhandled exception: " & ex.msg &
+                   " [" & $ex.name & "]\n"
+    else:
+      stderr.write trace & "Error: unhandled exception: " & ex.msg &
+                   " [" & $ex.name & "]\n"
+    quit 1
+
 when not defined(noSignalHandler) and not defined(useNimRtl):
   proc signalHandler(sign: cint) {.exportc: "signalHandler", noconv.} =
     template processSignal(s, action: untyped) {.dirty.} =

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -478,15 +478,13 @@ when defined(cpp) and appType != "lib" and
     # Remove ourself as a handler, reinstalling the default handler.
     setTerminate(nil)
 
-    let ex = getCurrentException()
-    let trace = ex.getStackTrace()
     when defined(genode):
       # stderr not available by default, use the LOG session
-      echo trace & "Error: unhandled exception: " & ex.msg &
-                   " [" & $ex.name & "]\n"
+      echo currException.trace & "Error: unhandled exception: " & 
+              currException.msg & " [" & $currException.name & "]\n"
     else:
-      stderr.write trace & "Error: unhandled exception: " & ex.msg &
-                   " [" & $ex.name & "]\n"
+      stderr.write currException.trace & "Error: unhandled exception: " & 
+              currException.msg & " [" & $currException.name & "]\n"
     quit 1
 
 when not defined(noSignalHandler) and not defined(useNimRtl):

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -480,10 +480,10 @@ when defined(cpp) and appType != "lib" and
 
     when defined(genode):
       # stderr not available by default, use the LOG session
-      echo currException.trace & "Error: unhandled exception: " & 
+      echo currException.getStackTrace() & "Error: unhandled exception: " & 
               currException.msg & " [" & $currException.name & "]\n"
     else:
-      stderr.write currException.trace & "Error: unhandled exception: " & 
+      stderr.write currException.getStackTrace() & "Error: unhandled exception: " & 
               currException.msg & " [" & $currException.name & "]\n"
     quit 1
 

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -480,10 +480,10 @@ when defined(cpp) and appType != "lib" and
 
     when defined(genode):
       # stderr not available by default, use the LOG session
-      echo currException.getStackTrace() & "Error: unhandled exception: " & 
+      echo currException.getStackTrace() & "Error: unhandled exception: " &
               currException.msg & " [" & $currException.name & "]\n"
     else:
-      stderr.write currException.getStackTrace() & "Error: unhandled exception: " & 
+      writeToStdErr currException.getStackTrace() & "Error: unhandled exception: " &
               currException.msg & " [" & $currException.name & "]\n"
     quit 1
 


### PR DESCRIPTION
Just keep system.nim cleaner. Excpt already contains other excption , signal handlers