### PR TITLE
Fix infinite loop with `nim check`

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -636,6 +636,8 @@ proc handleHexChar(L: var TLexer, xi: var int) =
   else:
     lexMessage(L, errGenerated,
       "expected a hex digit, but found: " & L.buf[L.bufpos])
+    # Need to progress for `nim check`
+    inc(L.bufpos)
 
 proc handleDecChars(L: var TLexer, xi: var int) =
   while L.buf[L.bufpos] in {'0'..'9'}:


### PR DESCRIPTION
Turns out that #9390 causes infinite loops with `nim check`.