### PR TITLE
fixes #9474

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1101,7 +1101,7 @@ proc ConvertThreadToFiber*(param: pointer): pointer {.stdcall, discardable, dynl
 proc ConvertThreadToFiberEx*(param: pointer, flags: int32): pointer {.stdcall, discardable, dynlib: "kernel32", importc.}
 proc DeleteFiber*(fiber: pointer): void {.stdcall, discardable, dynlib: "kernel32", importc.}
 proc SwitchToFiber*(fiber: pointer): void {.stdcall, discardable, dynlib: "kernel32", importc.}
-proc GetCurrentFiber*(): pointer {.stdcall, importc, header: "Windows.h".}
+proc GetCurrentFiber*(): pointer {.stdcall, importc, header: "windows.h".}
 
 proc toFILETIME*(t: int64): FILETIME =
   ## Convert the Windows file time timestamp ``t`` to ``FILETIME``.


### PR DESCRIPTION
Mingw always comes with a lower case "windows.h".
So I think it would be better to use #include "windows.h", since it works on both linux and windows.