### PR TITLE
Add 'order' argument to CountTable.sort and OrderedTable.sort

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -115,6 +115,10 @@
 import
   hashes, math
 
+# selective import from algorithm, we only need SortOrder (for CountTable.sort)
+from algorithm import SortOrder
+export algorithm.SortOrder
+
 include "system/inclrtl"
 
 type
@@ -1068,17 +1072,20 @@ proc largest*[A](t: CountTable[A]): tuple[key: A, val: int] =
   result.key = t.data[maxIdx].key
   result.val = t.data[maxIdx].val
 
-proc sort*[A](t: var CountTable[A], descending: bool = true) =
+proc sort*[A](t: var CountTable[A], order: SortOrder = SortOrder.Descending) =
   ## sorts the count table so that the entry with the highest counter comes
-  ## first. Set `descending` to `false` to reverse the order.
-  ## This is destructive! You must not modify `t` afterwards!
-  ## You can use the iterators `pairs`,  `keys`, and `values` to iterate over
-  ## `t` in the sorted order.
+  ## first. Set `order` to ``SortOrder.Ascending`` to reverse the order.
+  ## (Note that ``SortOrder`` is defined in ``algorithm``, and is re-exported by
+  ## ``tables`` for convenience.)
+  ##
+  ## This operation is destructive! You must not modify `t` afterwards! You can
+  ## use the iterators `pairs`, `keys`, and `values` to iterate over `t` in the
+  ## sorted order.
 
   # we use shellsort here; fast enough and simple
   var h = 1
-  # desc_factor reverses the comparison on ascending sorts.
-  let desc_factor = (if descending: 1 else: -1)
+  # order_factor reverses the comparison on ascending sorts.
+  let order_factor = (if order == SortOrder.Descending: 1 else: -1)
   while true:
     h = 3 * h + 1
     if h >= high(t.data): break
@@ -1086,7 +1093,7 @@ proc sort*[A](t: var CountTable[A], descending: bool = true) =
     h = h div 3
     for i in countup(h, high(t.data)):
       var j = i
-      while cmp(t.data[j-h].val, t.data[j].val) * desc_factor <= 0:
+      while cmp(t.data[j-h].val, t.data[j].val) * order_factor <= 0:
         swap(t.data[j], t.data[j-h])
         j = j-h
         if j < h: break

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1068,14 +1068,17 @@ proc largest*[A](t: CountTable[A]): tuple[key: A, val: int] =
   result.key = t.data[maxIdx].key
   result.val = t.data[maxIdx].val
 
-proc sort*[A](t: var CountTable[A]) =
+proc sort*[A](t: var CountTable[A], descending: bool = true) =
   ## sorts the count table so that the entry with the highest counter comes
-  ## first. This is destructive! You must not modify ``t`` afterwards!
-  ## You can use the iterators ``pairs``, ``keys``, and ``values`` to iterate over
-  ## ``t`` in the sorted order.
+  ## first. Set `descending` to `false` to reverse the order.
+  ## This is destructive! You must not modify `t` afterwards!
+  ## You can use the iterators `pairs`,  `keys`, and `values` to iterate over
+  ## `t` in the sorted order.
 
   # we use shellsort here; fast enough and simple
   var h = 1
+  # desc_factor reverses the comparison on ascending sorts.
+  let desc_factor = (if descending: 1 else: -1)
   while true:
     h = 3 * h + 1
     if h >= high(t.data): break
@@ -1083,7 +1086,7 @@ proc sort*[A](t: var CountTable[A]) =
     h = h div 3
     for i in countup(h, high(t.data)):
       var j = i
-      while t.data[j-h].val <= t.data[j].val:
+      while cmp(t.data[j-h].val, t.data[j].val) * desc_factor <= 0:
         swap(t.data[j], t.data[j-h])
         j = j-h
         if j < h: break

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -45,8 +45,8 @@ block tcounttable_asc_desc:
     tbl_desc.inc(w)
     tbl_asc.inc(w)
   # sort the tables
-  tbl_desc.sort(true)           # default (descending)
-  tbl_asc.sort(false)
+  tbl_desc.sort()           # default (SortOrder.Descending)
+  tbl_asc.sort(SortOrder.Ascending)
   # check the orders
   var n = 3
   for v in tbl_desc.values:

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -35,6 +35,27 @@ block tcounttable:
 
   echo "And we get here"
 
+block tcounttable_asc_desc:
+  # Test both descending (default) and ascending sort.
+  var
+    tbl_desc = initCountTable[string]()
+    tbl_asc = initCountTable[string]()
+    words = @["three", "three", "three", "two", "two", "one"]
+  for w in words:
+    tbl_desc.inc(w)
+    tbl_asc.inc(w)
+  # sort the tables
+  tbl_desc.sort(true)           # default (descending)
+  tbl_asc.sort(false)
+  # check the orders
+  var n = 3
+  for v in tbl_desc.values:
+    doAssert v == n
+    dec n
+  n = 1
+  for v in tbl_asc.values:
+    doAssert v == n
+    inc n
 
 block thashes:
   # Test with int


### PR DESCRIPTION
Descending is still the default for CountTable, and ascending for OrderedTable; these changes will not break existing code.
