### PR TITLE
Make Windows cross-compilation simpler

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -73,6 +73,19 @@ path="$lib/pure"
   opt:speed
 @end
 
+@if unix and mingw:
+  # Cross compile for Windows from Linux/OSX using MinGW
+  os = windows
+
+  i386.windows.gcc.path = "/usr/bin"
+  i386.windows.gcc.exe = "i686-w64-mingw32-gcc"
+  i386.windows.gcc.linkerexe = "i686-w64-mingw32-gcc"
+
+  amd64.windows.gcc.path = "/usr/bin"
+  amd64.windows.gcc.exe = "x86_64-w64-mingw32-gcc"
+  amd64.windows.gcc.linkerexe = "x86_64-w64-mingw32-gcc"
+@end
+
 @if unix:
   @if not bsd or haiku:
     # -fopenmp

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -261,6 +261,21 @@ configuration file should contain something like::
   arm.linux.gcc.exe = "arm-linux-gcc"
   arm.linux.gcc.linkerexe = "arm-linux-gcc"
 
+Cross compilation for Windows
+=============================
+
+To cross compile for Windows from Linux or OSX using the MinGW-w64 toolchain::
+
+  nim c -d:mingw myproject.nim
+
+Use ``--cpu:i386`` or ``--cpu:amd64`` to switch the cpu arch.
+
+The MinGW-w64 toolchain can be installed as follows::
+
+  Ubuntu: apt install mingw-w64
+  CentOS: yum install mingw32-gcc | mingw64-gcc - requires EPEL
+  OSX: brew install mingw-w64
+
 Cross compilation for Nintendo Switch
 =====================================
 


### PR DESCRIPTION
- Added a `-d:mingw` flag to enable cross compilation for Windows from Linux/OSX
- Added section to cross-compilation documentation