### PR TITLE
[WIP] [not ready for formal review] RST to markdown for Nim repo

### DIFF
--- a/tools/rsttomd.nim
+++ b/tools/rsttomd.nim
@@ -1,0 +1,74 @@
+import std/[
+  os,
+  osproc,
+  strformat,
+  nre,
+  algorithm,
+]
+
+type LineMap = object
+  offsets: seq[int]
+
+proc initialize(lineMap: var LineMap, s: string) =
+  lineMap.offsets.setLen 0
+  for i in 0..<s.len:
+    if s[i] == '\n':
+      lineMap.offsets.add i
+
+proc initLineMap(s: string): LineMap =
+  initialize(result, s)
+
+proc findLine(lineMap: LineMap, offset: int): int =
+  result = upperBound(lineMap.offsets, offset)
+
+proc testFindLine()=
+  block:
+    var lineMap: LineMap
+    let s = "abc\ndef\n"
+    lineMap.initialize(s)
+    let lines = [0,0,0,1,1,1,1,2]
+    for i in 0..<s.len:
+      doAssert lineMap.findLine(i) == lines[i]
+
+  block:
+    let s = "\nabc\ndef"
+    let lineMap = initLineMap(s)
+    let lines = [1,1,1,1,2,2,2,2]
+    for i in 0..<s.len:
+      doAssert lineMap.findLine(i) == lines[i]
+
+proc lintRstOK(path: string): bool=
+  echo path
+  let code = path.readFile
+  let reg = re"(-{2,}\s+-{2,})"
+  let m = code.find(reg)
+
+  if m.isSome:
+    let lineMap = initLineMap(code)
+    let offset = m.get.captureBounds[0].get.a
+    let line = lineMap.findLine(offset)
+    const humanOffset = 1
+    let msg = fmt"{path}:{line+humanOffset} potential table detected: {m.get.captures[0]}"
+    echo msg
+    return false
+  return true
+
+proc process(path: string, doLint = true, doPandoc = true)=
+  let path2 = path.changeFileExt "md"
+  if doLint:
+    if not lintRstOK(path):
+      return
+  if doPandoc:
+    let pandoc = "$HOME/Downloads/pandoc-2.3.1/bin/pandoc"
+    let cmd = fmt"{pandoc} {path} -f rst -t markdown -o {path2} --columns=80 --atx-headers"
+    let (output, exitCode) = osproc.execCmdEx(cmd)
+    doAssert exitCode == 0
+    echo output
+
+proc convertRstToMdNim()=
+  let pattern = "doc/*.rst"
+  for path in walkPattern(pattern):
+    process(path)
+
+when isMainModule:
+  convertRstToMdNim()

--- a/tools/rsttomd.nim
+++ b/tools/rsttomd.nim
@@ -58,12 +58,21 @@ proc process(path: string, doLint = true, doPandoc = true)=
   if doLint:
     if not lintRstOK(path):
       return
-  if doPandoc:
-    let pandoc = "$HOME/Downloads/pandoc-2.3.1/bin/pandoc"
-    let cmd = fmt"{pandoc} {path} -f rst -t markdown -o {path2} --columns=80 --atx-headers"
-    let (output, exitCode) = osproc.execCmdEx(cmd)
-    doAssert exitCode == 0
-    echo output
+
+  if not doPandoc:
+    return
+
+  let pandoc = "$HOME/Downloads/pandoc-2.3.1/bin/pandoc"
+  let cmd = fmt"{pandoc} {path} -f rst -t markdown -o {path2} --columns=80 --atx-headers"
+  let (output, exitCode) = osproc.execCmdEx(cmd)
+  doAssert exitCode == 0
+  echo output
+
+  ## postprocess
+  let code = readFile(path2)
+  let reg = "``` {.sourceCode .nim}".escapeRe
+  let code2 = code.replace(re("(?m)^" & reg), "```nim")
+  writeFile(path2, code2)
 
 proc convertRstToMdNim()=
   let pattern = "doc/*.rst"


### PR DESCRIPTION
/cc @soasme if you have early feedback

work in progress for automating process of converting RST in Nim repo (files in  doc/*.rst) to markdown

goal:
* references: https://github.com/nim-lang/Nim/issues/9291
* automate process as much as possible
* provide linter that tells you when it can't convert something (eg tables from RST are currently not properly converted; other example: include)

## try for yourself
```
nim c -r ./tools/rsttomd.nim
```
this will populate doc/ with md files

## see output (may be from an older version of this PR)
see files under doc in:
https://github.com/timotheecour/Nim/blob/pr_rst_to_markdown_contributing2_output2/doc/contributing.md

## TODO
- [ ] delete corresponding rst files
- [ ] improve linter that tells when a RST file can't be faithfully converted
- [ ] figure out what to do with RST `include`
- [ ] html generation must make use of the new markdown files
- [ ] some RST sources must be manually adjusted where linter complains

- [ ] use nim-markdown for markdown=>html generation in `./koch web` (this is discussed here: https://github.com/soasme/nim-markdown/issues/10)
