### PR TITLE
fix #9502 : nimpretty: allow overriding indentation spaces via via --indentSpaces:2

### DIFF
--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -41,9 +41,12 @@ type
 proc openEmitter*(em: var Emitter, cache: IdentCache;
                   config: ConfigRef, fileIdx: FileIndex) =
   let fullPath = Absolutefile config.toFullPath(fileIdx)
-  em.indWidth = getIndentWidth(fileIdx, llStreamOpen(fullPath, fmRead),
+  if config.nimprettyOpt.indentSpaces > 0:
+    em.indWidth = config.nimprettyOpt.indentSpaces
+  else:
+    em.indWidth = getIndentWidth(fileIdx, llStreamOpen(fullPath, fmRead),
                                cache, config)
-  if em.indWidth == 0: em.indWidth = 2
+    if em.indWidth == 0: em.indWidth = 2
   em.config = config
   em.fid = fileIdx
   em.lastTok = tkInvalid

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -161,6 +161,9 @@ type
     version*: int
   Suggestions* = seq[Suggest]
 
+  NimprettyOpt* = object
+    indentSpaces*: int ## number of spaces for indents; 0=infer from 1st indent
+
   ConfigRef* = ref object ## every global configuration
                           ## fields marked with '*' are subject to
                           ## the incremental compilation mechanisms
@@ -244,6 +247,9 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure.}
     cppCustomNamespace*: string
+    
+    when defined(nimpretty):
+      nimprettyOpt*: NimprettyOpt
 
 template depConfigFields*(fn) {.dirty.} =
   fn(target)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -247,7 +247,7 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure.}
     cppCustomNamespace*: string
-    
+
     when defined(nimpretty):
       nimprettyOpt*: NimprettyOpt
 

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -26,6 +26,7 @@ Usage:
 Options:
   --backup:on|off     create a backup file before overwritting (default: ON)
   --output:file       set the output file (default: overwrite the .nim file)
+  --indentSpaces:n    indents use `n` spaces (default: 0=infer from 1st indent)
   --version           show the version
   --help              show this help
 """
@@ -40,8 +41,7 @@ proc writeVersion() =
   stdout.flushFile()
   quit(0)
 
-proc prettyPrint(infile, outfile: string) =
-  var conf = newConfigRef()
+proc prettyPrint(infile, outfile: string, conf: ConfigRef) =
   let fileIdx = fileInfoIdx(conf, AbsoluteFile infile)
   conf.outFile = AbsoluteFile outfile
   when defined(nimpretty2):
@@ -51,6 +51,7 @@ proc prettyPrint(infile, outfile: string) =
     renderModule(tree, infile, outfile, {}, fileIdx, conf)
 
 proc main =
+  var conf = newConfigRef()
   var infile, outfile: string
   var backup = true
   for kind, key, val in getopt():
@@ -62,6 +63,7 @@ proc main =
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
       of "backup": backup = parseBool(val)
+      of "indentspaces": conf.nimprettyOpt.indentSpaces = parseInt(val)
       of "output", "o": outfile = val
       else: writeHelp()
     of cmdEnd: assert(false) # cannot happen
@@ -70,6 +72,6 @@ proc main =
   if backup:
     os.copyFile(source=infile, dest=changeFileExt(infile, ".nim.backup"))
   if outfile.len == 0: outfile = infile
-  prettyPrint(infile, outfile)
+  prettyPrint(infile, outfile, conf)
 
 main()

--- a/nimpretty/tester.nim
+++ b/nimpretty/tester.nim
@@ -16,10 +16,19 @@ else:
   const nimp = "nimpretty"
 
 proc test(infile, ext: string) =
-  if execShellCmd("$# -o:$# --backup:off $#" % [nimp, infile.changeFileExt(ext), infile]) != 0:
+  var extraArg = ""
+
+  case infile.splitFile.name:
+    # can hardcode custom options here
+    of "simple4": extraArg = "--indentSpaces:4"
+    else: discard
+
+  let cmd = "$# -o:$# --backup:off $# $#" % [nimp, infile.changeFileExt(ext), extraArg, infile]
+  if execShellCmd(cmd) != 0:
     echo "FAILURE: nimpretty cannot prettify ", infile
     failures += 1
     return
+
   let nimFile = splitFile(infile).name
   let expected = dir / "expected" / nimFile & ".nim"
   let produced = dir / nimFile.changeFileExt(ext)

--- a/nimpretty/tests/expected/simple4.nim
+++ b/nimpretty/tests/expected/simple4.nim
@@ -1,0 +1,6 @@
+proc fun() =
+    echo "ok1"
+
+proc fun2() =
+    for i in 0..<2:
+        echo "ok2"

--- a/nimpretty/tests/simple4.nim
+++ b/nimpretty/tests/simple4.nim
@@ -1,0 +1,6 @@
+proc fun() =
+ echo "ok1"
+
+proc fun2() =
+  for i in 0..<2:
+    echo "ok2"


### PR DESCRIPTION
/cc @Araq 

* fixes #9502

## side question (unrelated to this PR, but saw it while writing it...)
why `strip` in `strip in if strip(readFile(expected)) != strip(readFile(produced)):` in nimpretty tester? isnt’ that loosening the test ?