### PR TITLE
Improve dumpLisp macro

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,9 @@
 
 ### Library changes
 
+- The string output of `macros.lispRepr` proc has been tweaked
+  slightly. The `dumpLisp` macro in this module now outputs an
+  indented proper Lisp, devoid of commas.
 
 ### Language additions
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -736,13 +736,13 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
   if level > 0:
     if indented:
       res.add("\n")
-      if level > 1:
-        for i in 1 .. level-1:
-          if isLisp:
-            res.add " "
-          else:
-            res.add "  "
-    res.add(" ")
+      for i in 0 .. level-1:
+        if isLisp:
+          res.add(" ")          # dumpLisp indentation
+        else:
+          res.add("  ")         # dumpTree indentation
+    else:
+      res.add(" ")
 
   if isLisp:
     res.add("(")

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -732,14 +732,17 @@ proc nestList*(theProc: NimIdent, x: NimNode): NimNode {.compileTime, deprecated
   for i in countdown(L-3, 0):
     result = newCall(theProc, x[i], result)
 
-proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false) {.benign.} =
+proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indented = false) {.benign.} =
   if level > 0:
-    res.add("\n")
-    for i in 0 .. level-1:
-      if isLisp:
-        res.add " "
-      else:
-        res.add "  "
+    if indented:
+      res.add("\n")
+      if level > 1:
+        for i in 1 .. level-1:
+          if isLisp:
+            res.add " "
+          else:
+            res.add "  "
+    res.add(" ")
 
   if isLisp:
     res.add("(")
@@ -758,7 +761,7 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false) {.beni
     assert false
   else:
     for j in 0 .. n.len-1:
-      n[j].treeTraverse(res, level+1, isLisp)
+      n[j].treeTraverse(res, level+1, isLisp, indented)
 
   if isLisp:
     res.add(")")
@@ -767,13 +770,13 @@ proc treeRepr*(n: NimNode): string {.compileTime, benign.} =
   ## Convert the AST `n` to a human-readable tree-like string.
   ##
   ## See also `repr`, `lispRepr`, and `astGenRepr`.
-  n.treeTraverse(result, isLisp = false)
+  n.treeTraverse(result, isLisp = false, indented = true)
 
-proc lispRepr*(n: NimNode): string {.compileTime, benign.} =
+proc lispRepr*(n: NimNode; indented = false): string {.compileTime, benign.} =
   ## Convert the AST ``n`` to a human-readable lisp-like string.
   ##
   ## See also ``repr``, ``treeRepr``, and ``astGenRepr``.
-  n.treeTraverse(result, isLisp = true)
+  n.treeTraverse(result, isLisp = true, indented = indented)
 
 proc astGenRepr*(n: NimNode): string {.compileTime, benign.} =
   ## Convert the AST ``n`` to the code required to generate that AST.
@@ -845,7 +848,7 @@ macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ##
   ## Also see ``dumpAstGen`` and ``dumpLisp``.
 
-macro dumpLisp*(s: untyped): untyped = echo s.lispRepr
+macro dumpLisp*(s: untyped): untyped = echo s.lispRepr(indented = true)
   ## Accepts a block of nim code and prints the parsed abstract syntax
   ## tree using the ``lispRepr`` proc. Printing is done *at compile time*.
   ##

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -776,23 +776,9 @@ proc lispRepr*(n: NimNode): string {.compileTime, benign.} =
   n.treeTraverse(result, isLisp = true)
 
 proc astGenRepr*(n: NimNode): string {.compileTime, benign.} =
-  ## Convert the AST `n` to the code required to generate that AST. So for example
+  ## Convert the AST ``n`` to the code required to generate that AST.
   ##
-  ## .. code-block:: nim
-  ##   astGenRepr:
-  ##     echo "Hello world"
-  ##
-  ## Would output:
-  ##
-  ## .. code-block:: nim
-  ##   nnkStmtList.newTree(
-  ##     nnkCommand.newTree(
-  ##       newIdentNode("echo"),
-  ##       newLit("Hello world")
-  ##     )
-  ##   )
-  ##
-  ## See also `repr`, `treeRepr`, and `lispRepr`.
+  ## See also ``repr``, ``treeRepr``, and ``lispRepr``.
 
   const
     NodeKinds = {nnkEmpty, nnkIdent, nnkSym, nnkNone, nnkCommentStmt}
@@ -846,7 +832,7 @@ macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ## For example:
   ##
   ## .. code-block:: nim
-  ##    dumpLisp:
+  ##    dumpTree:
   ##      echo "Hello, World!"
   ##
   ## Outputs:
@@ -857,7 +843,7 @@ macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ##        Ident "echo"
   ##        StrLit "Hello, World!"
   ##
-  ## Also see ``dumpLisp``.
+  ## Also see ``dumpAstGen`` and ``dumpLisp``.
 
 macro dumpLisp*(s: untyped): untyped = echo s.lispRepr
   ## Accepts a block of nim code and prints the parsed abstract syntax
@@ -881,16 +867,32 @@ macro dumpLisp*(s: untyped): untyped = echo s.lispRepr
   ##      (Ident "echo")
   ##      (StrLit "Hello, World!")))
   ##
-  ## Also see ``dumpTree``.
+  ## Also see ``dumpAstGen`` and ``dumpTree``.
 
 macro dumpAstGen*(s: untyped): untyped = echo s.astGenRepr
   ## Accepts a block of nim code and prints the parsed abstract syntax
-  ## tree using the `astGenRepr` function. Printing is done *at compile time*.
+  ## tree using the ``astGenRepr`` proc. Printing is done *at compile time*.
   ##
   ## You can use this as a tool to write macros quicker by writing example
   ## outputs and then copying the snippets into the macro for modification.
   ##
-  ## See `dumpTree`.
+  ## For example:
+  ##
+  ## .. code-block:: nim
+  ##    dumpAstGen:
+  ##      echo "Hello, World!"
+  ##
+  ## Outputs:
+  ##
+  ## .. code-block:: nim
+  ##    nnkStmtList.newTree(
+  ##      nnkCommand.newTree(
+  ##        newIdentNode("echo"),
+  ##        newLit("Hello, World!")
+  ##      )
+  ##    )
+  ##
+  ## Also see ``dumpTree`` and ``dumpLisp``.
 
 macro dumpTreeImm*(s: untyped): untyped {.deprecated.} = echo s.treeRepr
   ## Deprecated. Use `dumpTree` instead.

--- a/tests/vm/tnimnode.nim
+++ b/tests/vm/tnimnode.nim
@@ -14,7 +14,7 @@ var nodeSeq {.compileTime.} = newSeq[NimNode](2)
 proc checkNode(arg: NimNode; name: string): void {. compileTime .} =
   echo "checking ", name
 
-  assertEq arg.lispRepr , "StmtList(DiscardStmt(Empty()))"
+  assertEq arg.lispRepr, """(StmtList (DiscardStmt (Empty)))"""
 
   node = arg
   nodeArray = [arg]
@@ -24,12 +24,12 @@ proc checkNode(arg: NimNode; name: string): void {. compileTime .} =
   seqAppend.add(arg)   # bit this creates a copy
   arg.add newCall(ident"echo", newLit("Hello World"))
 
-  assertEq arg.lispRepr          , """StmtList(DiscardStmt(Empty()), Call(Ident("echo"), StrLit("Hello World")))"""
-  assertEq node.lispRepr         , """StmtList(DiscardStmt(Empty()), Call(Ident("echo"), StrLit("Hello World")))"""
-  assertEq nodeArray[0].lispRepr , """StmtList(DiscardStmt(Empty()), Call(Ident("echo"), StrLit("Hello World")))"""
-  assertEq nodeSeq[0].lispRepr   , """StmtList(DiscardStmt(Empty()), Call(Ident("echo"), StrLit("Hello World")))"""
-  assertEq seqAppend[0].lispRepr , """StmtList(DiscardStmt(Empty()), Call(Ident("echo"), StrLit("Hello World")))"""
-  assertEq seqAppend[1].lispRepr , """StmtList(DiscardStmt(Empty()), Call(Ident("echo"), StrLit("Hello World")))"""
+  assertEq arg.lispRepr,          """(StmtList (DiscardStmt (Empty)) (Call (Ident "echo") (StrLit "Hello World")))"""
+  assertEq node.lispRepr,         """(StmtList (DiscardStmt (Empty)) (Call (Ident "echo") (StrLit "Hello World")))"""
+  assertEq nodeArray[0].lispRepr, """(StmtList (DiscardStmt (Empty)) (Call (Ident "echo") (StrLit "Hello World")))"""
+  assertEq nodeSeq[0].lispRepr,   """(StmtList (DiscardStmt (Empty)) (Call (Ident "echo") (StrLit "Hello World")))"""
+  assertEq seqAppend[0].lispRepr, """(StmtList (DiscardStmt (Empty)) (Call (Ident "echo") (StrLit "Hello World")))"""
+  assertEq seqAppend[1].lispRepr, """(StmtList (DiscardStmt (Empty)) (Call (Ident "echo") (StrLit "Hello World")))"""
 
   echo "OK"
 


### PR DESCRIPTION
- Remove commas from the lisp representation of the AST.
- Make the dumpLisp output "pretty" and indented.
- Improve docs of `dumpTree` and `dumpLisp` macros.

---

### Changes

- `lispRepr` outputs unindented lisp representation by default (the `indented` arg is `false` by default) as before, but with a comma-less lisp form.
- `dumpLisp` macro now outputs an indented lisp representation, just like `dumpTree` does.

---


With:

    dumpLisp:
      echo "Hello, World!"

Output before this commit:

    StmtList(Command(Ident("echo"), StrLit("Hello, World!")))

Output after this commit:

    (StmtList
     (Command
      (Ident "echo")
      (StrLit "Hello, World!")))

`dumpTree` output for reference:

    StmtList
      Command
        Ident "echo"
        StrLit "Hello, World!"

Another example: https://irclogs.nim-lang.org/25-10-2018.html#15:01:12, https://gitter.im/nim-lang/Nim?at=5bd1dab882893a2f3b3abbef

**Advantage**: If your editor supports parentheses based navigation, navigation a huge dumpLisp AST representation after this commit becomes a breeze.

---

/cc @Araq 

/cc @zah (original author of this macro, from b72480ec88fa2826853b281a0c14054b51bd6c3b)

Also copying few people I know who might use/appreciate this `dumpLisp` change: @Vindaar @krux02 