### PR TITLE
Fix normalizedPath for absolute paths on Windows

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -377,7 +377,10 @@ proc normalizePath*(path: var string) {.rtl, extern: "nos$1", tags: [].} =
       stack.add(p)
 
   if isAbs:
-    path = DirSep & join(stack, $DirSep)
+    when defined(doslikeFileSystem):
+      path = join(stack, $DirSep) # Absolute dos-like paths start with a drive letter
+    else:
+      path = DirSep & join(stack, $DirSep)
   elif stack.len > 0:
     path = join(stack, $DirSep)
   else:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -226,6 +226,8 @@ block normalizedPath:
       doAssert normalizedPath("\\a\\\\\\b") == "\\a\\b"
       doAssert normalizedPath("\\a\\b\\c\\..") == "\\a\\b"
       doAssert normalizedPath("\\a\\b\\c\\..\\") == "\\a\\b"
+      doAssert normalizedPath("C:\\a\\b") == "C:\\a\\b"
+      doAssert normalizedPath("C:\\a\\b\\..\\") == "C:\\a"
 
 block isHidden:
   when defined(posix):


### PR DESCRIPTION
There's a bug in `normalizedPath` for Windows.  It prefixes absolute paths with a `\\` making `"C:\\foo".normalizedPath` into `"\\C:\\foo"`