### PR TITLE
Eliminate floating point arithmatic in nre

### DIFF
--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -469,7 +469,8 @@ proc matchImpl(str: string, pattern: Regex, start, endpos: int, flags: int): Opt
   # 1x capture count as slack space for PCRE
   let vecsize = (pattern.captureCount() + 1) * 3
   # div 2 because each element is 2 cints long
-  myResult.pcreMatchBounds = newSeq[HSlice[cint, cint]](ceil(vecsize / 2).int)
+  # plus 1 because we need the ceiling, not the floor
+  myResult.pcreMatchBounds = newSeq[HSlice[cint, cint]]((vecsize div 2) + 1)
   myResult.pcreMatchBounds.setLen(vecsize div 3)
 
   let strlen = if endpos == int.high: str.len else: endpos+1

--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -470,7 +470,7 @@ proc matchImpl(str: string, pattern: Regex, start, endpos: int, flags: int): Opt
   let vecsize = (pattern.captureCount() + 1) * 3
   # div 2 because each element is 2 cints long
   # plus 1 because we need the ceiling, not the floor
-  myResult.pcreMatchBounds = newSeq[HSlice[cint, cint]]((vecsize div 2) + 1)
+  myResult.pcreMatchBounds = newSeq[HSlice[cint, cint]]((vecsize + 1) div 2)
   myResult.pcreMatchBounds.setLen(vecsize div 3)
 
   let strlen = if endpos == int.high: str.len else: endpos+1


### PR DESCRIPTION
Integer division is already hard enough on your CPU, using floating
point here is WAY slower and can just as effectively be done using
integers. This is important because matchImpl tends to be in the center
of very hot loops (like split()).