### PR TITLE
write logs to stderr instead of stdout fixes #9547

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -150,11 +150,8 @@ method log*(logger: ConsoleLogger, level: Level, args: varargs[string, `$`]) =
       {.emit: "console.log(`cln`);".}
     else:
       try:
-        if level in {lvlError, lvlFatal, lvlWarn}:
-          writeLine(stderr, ln)
-        else:
-          writeLine(stdout, ln)
-        if level in {lvlError, lvlFatal, lvlWarn}: flushFile(stderr)
+        writeLine(stderr, ln)
+        if level in {lvlError, lvlFatal}: flushFile(stderr)
       except IOError:
         discard
 

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -150,8 +150,11 @@ method log*(logger: ConsoleLogger, level: Level, args: varargs[string, `$`]) =
       {.emit: "console.log(`cln`);".}
     else:
       try:
-        writeLine(stdout, ln)
-        if level in {lvlError, lvlFatal}: flushFile(stdout)
+        if level in {lvlError, lvlFatal, lvlWarn}:
+          writeLine(stderr, ln)
+        else:
+          writeLine(stdout, ln)
+        if level in {lvlError, lvlFatal, lvlWarn}: flushFile(stderr)
       except IOError:
         discard
 

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -80,6 +80,7 @@ type
 
   ConsoleLogger* = ref object of Logger ## logger that writes the messages to the
                                         ## console
+    useStderr*: bool ## will send logs into Stderr if set 
 
 when not defined(js):
   type
@@ -150,16 +151,20 @@ method log*(logger: ConsoleLogger, level: Level, args: varargs[string, `$`]) =
       {.emit: "console.log(`cln`);".}
     else:
       try:
-        writeLine(stderr, ln)
-        if level in {lvlError, lvlFatal}: flushFile(stderr)
+        var handle = stdout
+        if logger.useStderr:
+          handle = stderr 
+        writeLine(handle, ln)
+        if level in {lvlError, lvlFatal}: flushFile(handle)
       except IOError:
         discard
 
-proc newConsoleLogger*(levelThreshold = lvlAll, fmtStr = defaultFmtStr): ConsoleLogger =
+proc newConsoleLogger*(levelThreshold = lvlAll, fmtStr = defaultFmtStr, useStderr=false): ConsoleLogger =
   ## Creates a new console logger. This logger logs to the console.
   new result
   result.fmtStr = fmtStr
   result.levelThreshold = levelThreshold
+  result.useStderr = useStderr
 
 when not defined(js):
   method log*(logger: FileLogger, level: Level, args: varargs[string, `$`]) =


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/9547

write all logs to stderr

```nim
import logging

var L* = newConsoleLogger()
addHandler(L)

error("err should go to stderr")
fatal("fatal sholud go to stderr")
warn("warn sholud go to stderr")
info("should go to stderr")
```

```bash
~> bin/nim -r c /tmp/testlogging.nim > stdoutfile.txt 2> stderr.txt
~> cat stdoutfile.txt  
~> cat stderr.txt
Hint: used config file '/home/ahmed/wspace/Nim/config/nim.cfg' [Conf]
Hint: system [Processing]
Hint: testlogging [Processing]
Hint: logging [Processing]
Hint: strutils [Processing]
Hint: parseutils [Processing]
Hint: math [Processing]
Hint: bitops [Processing]
Hint: algorithm [Processing]
Hint: unicode [Processing]
Hint: times [Processing]
Hint: options [Processing]
Hint: typetraits [Processing]
Hint: strformat [Processing]
Hint: macros [Processing]
Hint: posix [Processing]
Hint: os [Processing]
Hint: ospaths [Processing]
Hint:  [Link]
Hint: operation successful (33727 lines compiled; 0.688 sec total; 48.273MiB peakmem; Debug Build) [SuccessX]
Hint: /tmp/testlogging  [Exec]
ERROR err should go to stderr
FATAL fatal sholud go to stderr
WARN warn sholud go to stderr
INFO should go to stderr
```
