### PR TITLE
Add C++ Keywords

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -283,3 +283,4 @@ tcc.options.always = "-w"
 # C++ keywords that need to be mangled by the codegen
 cppDefine = "compl"
 cppDefine = "typeof"
+cppDefine = "restrict"

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -279,3 +279,6 @@ tcc.options.always = "-w"
     gcc.cpp.exe = "genode-arm-g++"
   @end
 @end
+
+# C++ keywords that need to be mangled by the codegen
+cppDefine = "compl"

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -282,3 +282,4 @@ tcc.options.always = "-w"
 
 # C++ keywords that need to be mangled by the codegen
 cppDefine = "compl"
+cppDefine = "typeof"


### PR DESCRIPTION
PR https://github.com/nim-lang/Nim/pull/9226 can be closed if this is merged.
  
This adds `compl`, `typeof`, and `restrict` as C++ keywords.
  
`cppDefine` has a bug which is tracked here - https://github.com/nim-lang/Nim/issues/9575 **[And due to this BUG, this PR does not actually fix the issues mentioned in the commits]**
  
I did not add a test because I don't think a test is required for each keyword that is added. IMO it would be better to add test case for the bug linked above, as it would cover this PR and other keywords as well.
