### PR TITLE
helper to convert tests to doAssert instead of echo

### DIFF
--- a/lib/pure/testhelpers.nim
+++ b/lib/pure/testhelpers.nim
@@ -1,0 +1,6 @@
+template echoToResult*(args: varargs[string, `$`]): untyped =
+  ## in tests, replace ``echo a, b, c`` by ``echoToResult a, b, c`` and 
+  ## ``proc mytest()`` to ``proc mytest(): string``
+  for a in args:
+    result.add $a
+  result.add "\n"

--- a/tests/casestmt/tcomputedgoto.nim
+++ b/tests/casestmt/tcomputedgoto.nim
@@ -1,5 +1,41 @@
-discard """
-  output: '''
+import testhelpers
+
+type
+  MyEnum = enum
+    enumA, enumB, enumC, enumD, enumE, enumLast
+
+proc vm(): string =
+  var instructions: array[0..100, MyEnum]
+  instructions[2] = enumC
+  instructions[3] = enumD
+  instructions[4] = enumA
+  instructions[5] = enumD
+  instructions[6] = enumC
+  instructions[7] = enumA
+  instructions[8] = enumB
+
+  instructions[12] = enumE
+  var pc = 0
+  while true:
+    {.computedGoto.}
+    let instr = instructions[pc]
+    let ra = instr.succ # instr.regA
+    case instr
+    of enumA:
+      echoToResult "yeah A ", ra
+    of enumC, enumD:
+      echoToResult "yeah CD ", ra
+    of enumB:
+      echoToResult "yeah B ", ra
+    of enumE:
+      break
+    of enumLast: discard
+    inc(pc)
+
+    if pc mod 2 == 1:
+      echoToResult "uneven"
+
+doAssert vm() == """
 yeah A enumB
 uneven
 yeah A enumB
@@ -18,42 +54,4 @@ yeah A enumB
 yeah A enumB
 uneven
 yeah A enumB
-'''
 """
-
-type
-  MyEnum = enum
-    enumA, enumB, enumC, enumD, enumE, enumLast
-
-proc vm() =
-  var instructions: array[0..100, MyEnum]
-  instructions[2] = enumC
-  instructions[3] = enumD
-  instructions[4] = enumA
-  instructions[5] = enumD
-  instructions[6] = enumC
-  instructions[7] = enumA
-  instructions[8] = enumB
-
-  instructions[12] = enumE
-  var pc = 0
-  while true:
-    {.computedGoto.}
-    let instr = instructions[pc]
-    let ra = instr.succ # instr.regA
-    case instr
-    of enumA:
-      echo "yeah A ", ra
-    of enumC, enumD:
-      echo "yeah CD ", ra
-    of enumB:
-      echo "yeah B ", ra
-    of enumE:
-      break
-    of enumLast: discard
-    inc(pc)
-
-    if pc mod 2 == 1:
-      echo "uneven"
-
-vm()


### PR DESCRIPTION
/cc @narimiran @Araq 

This will make it easier to simplify a number of tests run by testament, replacing `echo` + `discard` magic by `doAssert`'s 
I picked `tcomputedgoto.nim` as an example of resulting transformed test in reply to https://github.com/nim-lang/Nim/issues/9581#issuecomment-434990987

This will also enable applying the optimization https://github.com/nim-lang/Nim/issues/9581 to more tests.

* I put the helper module in `lib/pure/testhelpers.nim` but happy to move it somewhere else; the requirement is that it should be importable by tests without adding dependencies that would prevent using it in many tests

* happy to change name `echoToResult` to some other name
