### PR TITLE
Use value-initialization in C++ to gracefully handle non-POD types

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1308,15 +1308,13 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
   var tmp: TLoc
   var r: Rope
   if useTemp:
-    getTemp(p, t, tmp)
+    getTemp(p, t, tmp, not isRef)
     r = rdLoc(tmp)
     if isRef:
       rawGenNew(p, tmp, nil)
       t = t.lastSon.skipTypes(abstractInst)
       r = "(*$1)" % [r]
       gcUsage(p.config, e)
-    else:
-      constructLoc(p, tmp)
   else:
     resetLoc(p, d)
     r = rdLoc(d)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -326,8 +326,12 @@ proc resetLoc(p: BProc, loc: var TLoc) =
     else:
       # array passed as argument decayed into pointer, bug #7332
       # so we use getTypeDesc here rather than rdLoc(loc)
-      linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",
-              addrLoc(p.config, loc), getTypeDesc(p.module, loc.t))
+      let typeName = getTypeDesc(p.module, loc.t)
+      if p.module.compileToCpp:
+        linefmt(p, cpsStmts, "$1 = $2{};$n", rdLoc(loc), typeName)
+      else:
+        linefmt(p, cpsStmts, "#nimZeroMem((void*)$1, sizeof($2));$n",
+                addrLoc(p.config, loc), typeName)
       # XXX: We can be extra clever here and call memset only
       # on the bytes following the m_type field?
       genObjectInit(p, cpsStmts, loc.t, loc, true)

--- a/tests/cpp/tvalue_initialization.nim
+++ b/tests/cpp/tvalue_initialization.nim
@@ -1,0 +1,39 @@
+discard """
+  targets: "cpp"
+"""
+
+{.emit: """/*TYPESECTION*/
+struct Foo
+{
+  bool isConstructed = true;
+};
+""".}
+
+type
+  Foo {.importc.} = object
+
+  Bar = object
+    impl: Foo
+
+proc isConstructed(self: Foo): bool {.importcpp: "#.$1".}
+
+proc test_init_locals(): Bar =
+  var
+    x: Bar
+    y: (Foo, Bar)
+    z = Bar()
+
+  doAssert result.impl.isConstructed
+  doAssert x.impl.isConstructed
+  doAssert y[0].isConstructed
+  doAssert y[1].impl.isConstructed
+  doAssert z.impl.isConstructed
+
+proc test_reset(): Bar =
+  if true:
+    result = Bar()
+
+  doAssert result.impl.isConstructed
+
+discard test_init_locals()
+discard test_reset()


### PR DESCRIPTION
Locals of types containing imported non-POD members currently get zeroed, leaving them in an invalid state. This replaces zeroing with value-initialization when in C++ mode.