### PR TITLE
Fixes #9556

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -190,10 +190,13 @@ template toFullPath*(conf: ConfigRef; info: TLineInfo): string =
 proc toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
   if info.fileIndex.int32 < 0:
     result = "???"
-  elif optListFullPaths in conf.globalOptions:
-    result = conf.m.fileInfos[info.fileIndex.int32].fullPath.string
+    return  
+  let absPath = conf.m.fileInfos[info.fileIndex.int32].fullPath.string
+  let relPath = conf.m.fileInfos[info.fileIndex.int32].projPath.string
+  if optListFullPaths in conf.globalOptions:
+    result = absPath
   else:
-    result = conf.m.fileInfos[info.fileIndex.int32].projPath.string
+    result = if absPath.len < relPath.len: absPath else: relPath
 
 proc toLinenumber*(info: TLineInfo): int {.inline.} =
   result = int info.line

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -87,7 +87,7 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
     isKnownFile = false
     result = conf.m.fileInfos.len.FileIndex
     conf.m.fileInfos.add(newFileInfo(canon, if pseudoPath: RelativeFile filename
-                                            else: relativeTo(canon, conf.projectPath)))
+                                            else: shortenDir(conf, canon)))
     conf.m.filenameToIndexTbl[canon.string] = result
 
 proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile): FileIndex =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -87,7 +87,7 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
     isKnownFile = false
     result = conf.m.fileInfos.len.FileIndex
     conf.m.fileInfos.add(newFileInfo(canon, if pseudoPath: RelativeFile filename
-                                            else: shortenDir(conf, canon)))
+                                            else: relativeTo(canon, conf.projectPath)))
     conf.m.filenameToIndexTbl[canon.string] = result
 
 proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile): FileIndex =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -492,7 +492,7 @@ proc canonicalizePath*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
     result = AbsoluteFile path.string.expandFilename
 
 proc shortenDir*(conf: ConfigRef; dir: string): string {.
-    deprecated: "use 'shortenDir(ConfigRef, AbsoluteFile)' instead".} =
+    deprecated: "use 'relativeTo' instead".} =
   ## returns the interesting part of a dir
   var prefix = conf.projectPath.string & DirSep
   if startsWith(dir, prefix):
@@ -501,16 +501,6 @@ proc shortenDir*(conf: ConfigRef; dir: string): string {.
   if startsWith(dir, prefix):
     return substr(dir, len(prefix))
   result = dir
-
-proc shortenDir*(conf: ConfigRef; dir: AbsoluteFile): RelativeFile =
-  ## returns the interesting part of a dir
-  var prefix = conf.projectPath.string & DirSep
-  if startsWith(dir.string, prefix):
-    return RelativeFile substr(dir.string, len(prefix))
-  prefix = getPrefixDir(conf).string & DirSep
-  if startsWith(dir.string, prefix):
-    return RelativeFile substr(dir.string, len(prefix))
-  result = RelativeFile dir
 
 proc removeTrailingDirSep*(path: string): string =
   if (len(path) > 0) and (path[len(path) - 1] == DirSep):

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -492,7 +492,7 @@ proc canonicalizePath*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
     result = AbsoluteFile path.string.expandFilename
 
 proc shortenDir*(conf: ConfigRef; dir: string): string {.
-    deprecated: "use 'relativeTo' instead".} =
+    deprecated: "use 'shortenDir(ConfigRef, AbsoluteFile)' instead".} =
   ## returns the interesting part of a dir
   var prefix = conf.projectPath.string & DirSep
   if startsWith(dir, prefix):
@@ -501,6 +501,16 @@ proc shortenDir*(conf: ConfigRef; dir: string): string {.
   if startsWith(dir, prefix):
     return substr(dir, len(prefix))
   result = dir
+
+proc shortenDir*(conf: ConfigRef; dir: AbsoluteFile): RelativeFile =
+  ## returns the interesting part of a dir
+  var prefix = conf.projectPath.string & DirSep
+  if startsWith(dir.string, prefix):
+    return RelativeFile substr(dir.string, len(prefix))
+  prefix = getPrefixDir(conf).string & DirSep
+  if startsWith(dir.string, prefix):
+    return RelativeFile substr(dir.string, len(prefix))
+  result = RelativeFile dir
 
 proc removeTrailingDirSep*(path: string): string =
   if (len(path) > 0) and (path[len(path) - 1] == DirSep):


### PR DESCRIPTION
IDK why `shortenDir` was changed to `relativeTo` in a previous commit - https://github.com/nim-lang/Nim/commit/86556ebfdbbd4b8e9edc9d3085ea21d6c0bae2e2#diff-ec1eedfc292fc296265be60cf35f5188L90, but that was the reason for https://github.com/nim-lang/Nim/issues/9556