### PR TITLE
remove redundant `-p:compiler` from koch.nim ; the compiler files are already imported via `import compiler/foo`

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -141,12 +141,12 @@ proc buildNimble(latest: bool) =
       else:
         exec("git checkout -f stable")
       exec("git pull")
-  nimexec("c --noNimblePath -p:compiler --nilseqs:on -d:release " & installDir / "src/nimble.nim")
+  nimexec("c --noNimblePath --nilseqs:on -d:release " & installDir / "src/nimble.nim")
   copyExe(installDir / "src/nimble".exe, "bin/nimble".exe)
 
 proc bundleNimsuggest(buildExe: bool) =
   if buildExe:
-    nimexec("c --noNimblePath -d:release -p:compiler nimsuggest/nimsuggest.nim")
+    nimexec("c --noNimblePath -d:release nimsuggest/nimsuggest.nim")
     copyExe("nimsuggest/nimsuggest".exe, "bin/nimsuggest".exe)
     removeFile("nimsuggest/nimsuggest".exe)
 
@@ -195,7 +195,7 @@ proc buildTool(toolname, args: string) =
   copyFile(dest="bin" / splitFile(toolname).name.exe, source=toolname.exe)
 
 proc buildTools(latest: bool) =
-  nimexec "c --noNimblePath -p:compiler -d:release -o:" & ("bin/nimsuggest".exe) &
+  nimexec "c --noNimblePath -d:release -o:" & ("bin/nimsuggest".exe) &
       " nimsuggest/nimsuggest.nim"
 
   nimexec "c -d:release -o:" & ("bin/nimgrep".exe) & " tools/nimgrep.nim"

--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -23,4 +23,3 @@ define:nimcore
 --path:"$nim"
 --threads:on
 --noNimblePath
---path:"../compiler"


### PR DESCRIPTION
this removes redundant `-p:compiler` from koch.nim ; the compiler files are already imported via `import compiler/foo` instead of `import foo` (the latter being bad style since it can lead to name clashes)

furthermore, having `-p:compiler` led to issues when modules with same name could clash, such as options:
compiler/options.nim
lib/pure/options.nim
(eg, nre has `import options`; so wasn't usable inside for example nimsuggest because that would point to the wrong options module)
(which I ran into while debugging another PR)
