### PR TITLE
keep the order of the callbacks

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -123,11 +123,17 @@ proc add(callbacks: var CallbackList, function: CallbackFunc) =
     callbacks.function = function
     assert callbacks.next == nil
   else:
-    let newNext = new(ref CallbackList)
-    newNext.function = callbacks.function
-    newNext.next = callbacks.next
-    callbacks.next = newNext
-    callbacks.function = function
+    let newCallback = new(ref CallbackList)
+    newCallback.function = function
+    newCallback.next = nil
+
+    if callbacks.next == nil:
+      callbacks.next = newCallback
+    else:
+      var last = callbacks.next
+      while last.next != nil:
+        last = last.next
+      last.next = newCallback
 
 proc complete*[T](future: Future[T], val: T) =
   ## Completes ``future`` with value ``val``.

--- a/tests/async/tcallbacks.nim
+++ b/tests/async/tcallbacks.nim
@@ -1,8 +1,9 @@
 discard """
   exitcode: 0
-  output: '''3
-2
+  output: '''
 1
+2
+3
 5
 '''
 """


### PR DESCRIPTION
Put new callbacks at the end of the `CallbackList`, not in front, so the order of callbacks is not reversed.

Fixes #7197.