### PR TITLE
change dir when koch starts

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -79,6 +79,8 @@ template withDir(dir, body) =
   finally:
     setCurrentdir(old)
 
+setCurrentDir(getAppDir())
+
 proc tryExec(cmd: string): bool =
   echo(cmd)
   result = execShellCmd(cmd) == 0


### PR DESCRIPTION
Up until now koch fails when it is started from another directory because it contains relative paths to its own location. Now it won't crash anymore.