### PR TITLE
WIP sem checking

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1189,10 +1189,11 @@ proc semTypeSection(c: PContext, n: PNode): PNode =
   result = n
 
 proc semParamList(c: PContext, n, genericParams: PNode, s: PSym) =
+  # echo "semProcTypeNode of: ", s.name.s
   s.typ = semProcTypeNode(c, n, genericParams, nil, s.kind)
-  if s.kind notin {skMacro, skTemplate}:
-    if s.typ.sons[0] != nil and s.typ.sons[0].kind == tyStmt:
-      localError(c.config, n.info, "invalid return type: 'stmt'")
+  #if s.kind notin {skMacro, skTemplate}:
+  #  if s.typ.sons[0] != nil and s.typ.sons[0].kind == tyStmt:
+  #    localError(c.config, n.info, "invalid return type: 'stmt'")
 
 proc addParams(c: PContext, n: PNode, kind: TSymKind) =
   for i in countup(1, sonsLen(n)-1):
@@ -1588,6 +1589,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
     gp = newNodeI(nkGenericParams, n.info)
   # process parameters:
   if n.sons[paramsPos].kind != nkEmpty:
+    #echo s.name.s, " -- ", n.sons[paramsPos], " -- ", s.kind
     semParamList(c, n.sons[paramsPos], gp, s)
     if sonsLen(gp) > 0:
       if n.sons[genericParamsPos].kind == nkEmpty:

--- a/tests/errmsgs/t1154.nim
+++ b/tests/errmsgs/t1154.nim
@@ -9,3 +9,20 @@ proc foo(a:varargs[untyped]) =
   echo a[0].type.name
 
 foo(1)
+
+proc fool(): typed =
+  discard
+
+proc bar(): untyped =
+  discard
+
+proc foobar(x:typed) =
+  discard
+
+proc baz(y:untyped) =
+  discard
+
+proc barfaz(x: auto) =
+  echo x
+
+barfaz(123)


### PR DESCRIPTION
this causes problems, but the goal is to disallow usage of ``[un]typed`` in procedure declaration.