### PR TITLE
add vs2017 support when run from developer command prompt.

### DIFF
--- a/tools/vccenv/vccenv.nim
+++ b/tools/vccenv/vccenv.nim
@@ -3,6 +3,7 @@ import strtabs, os, osproc, streams, strutils
 const
   comSpecEnvKey = "ComSpec"
   vsComnToolsEnvKeys = [
+    "VS150COMNTOOLS",
     "VS140COMNTOOLS",
     "VS130COMNTOOLS",
     "VS120COMNTOOLS",


### PR DESCRIPTION
I have tested this on Windows. Fix for #6540 