### PR TITLE
Empty check in shallow [backport]

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4019,7 +4019,7 @@ proc shallow*[T](s: var seq[T]) {.noSideEffect, inline.} =
   ## marks a sequence `s` as `shallow`:idx:. Subsequent assignments will not
   ## perform deep copies of `s`. This is only useful for optimization
   ## purposes.
-  if s == @[]: return
+  if s.len == 0: return
   when not defined(JS) and not defined(nimscript):
     var s = cast[PGenericSeq](s)
     s.reserved = s.reserved or seqShallowFlag

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4019,6 +4019,7 @@ proc shallow*[T](s: var seq[T]) {.noSideEffect, inline.} =
   ## marks a sequence `s` as `shallow`:idx:. Subsequent assignments will not
   ## perform deep copies of `s`. This is only useful for optimization
   ## purposes.
+  if s == @[]: return
   when not defined(JS) and not defined(nimscript):
     var s = cast[PGenericSeq](s)
     s.reserved = s.reserved or seqShallowFlag

--- a/tests/seq/tseq.nim
+++ b/tests/seq/tseq.nim
@@ -170,6 +170,30 @@ block tshallowseq:
   xxx()
 
 
+block tshallowemptyseq:
+  proc test() =
+    var nilSeq: seq[int] = @[]
+    var emptySeq: seq[int] = newSeq[int]()
+    block:
+      var t = @[1,2,3]
+      shallow(nilSeq)
+      t = nilSeq
+      doAssert t == @[]
+    block:
+      var t = @[1,2,3]
+      shallow(emptySeq)
+      t = emptySeq
+      doAssert t == @[]
+    block:
+      var t = @[1,2,3]
+      shallowCopy(t, nilSeq)
+      doAssert t == @[]
+    block:
+      var t = @[1,2,3]
+      shallowCopy(t, emptySeq)
+      doAssert t == @[]
+  test()
+
 
 import strutils
 block ttoseq:


### PR DESCRIPTION
Before this change, this code was crashing by SEGV.
So I had append empty check in `shallow`.
```nim
block:
  var a: seq[int] = @[]
  var b: seq[int]
  shallowCopy(b,a) # ok

block:
  var a: seq[int] = @[]
  var b: seq[int]
  shallow(a) # crash here
  b = a
```
```
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```