### PR TITLE
nimsuggest: fix nimsuggest#96 ; nimsuggest can handle files not yet known

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -186,7 +186,7 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
   if conf.suggestVersion == 1:
     graph.usageSym = nil
   if not isKnownFile:
-    graph.compileProject()
+    graph.compileProject(dirtyIdx)
   if conf.suggestVersion == 0 and conf.ideCmd in {ideUse, ideDus} and
       dirtyfile.isEmpty:
     discard "no need to recompile anything"
@@ -195,7 +195,8 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
     graph.markDirty dirtyIdx
     graph.markClientsDirty dirtyIdx
     if conf.ideCmd != ideMod:
-      graph.compileProject(modIdx)
+      if isKnownFile:
+        graph.compileProject(modIdx)
   if conf.ideCmd in {ideUse, ideDus}:
     let u = if conf.suggestVersion != 1: graph.symFromInfo(conf.m.trackPos) else: graph.usageSym
     if u != nil:


### PR DESCRIPTION
/cc @PMunch @Araq @krux02

* fixes https://github.com/nim-lang/nimsuggest/issues/96
docs say https://nim-lang.github.io/Nim/nimsuggest.html
> There is some support so that you can throw random .nim files which are not part of myproject at Nimsuggest too, but usually the query refer to modules/files that are part of myproject.

this wasn't true until this PR
it's a very useful feature that allows you to handle nim files not covered by your initial project.nim

* refs https://github.com/nim-lang/nimsuggest/issues/66
* refs https://github.com/PMunch/nimlsp/issues/8

