### PR TITLE
refs nim-lang/nimsuggest#91 ; nimsuggest can be built anywhere

### DIFF
--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -89,11 +89,16 @@ proc findNimStdLib*(): string =
   except OSError, ValueError:
     return ""
 
+proc findNimRootCompileTime*(): string =
+  ## returns Nim path (that contains koch.nim)
+  const sourcePath = currentSourcePath()
+  result = sourcePath.parentDir.parentDir
+  doAssert fileExists(result / "koch.nim"), "result:" & result
+
 proc findNimStdLibCompileTime*(): string =
   ## Same as ``findNimStdLib`` but uses source files used at compile time,
   ## and asserts on error.
-  const sourcePath = currentSourcePath()
-  result = sourcePath.parentDir.parentDir / "lib"
+  result = findNimRootCompileTime() / "lib"
   doAssert fileExists(result / "system.nim"), "result:" & result
 
 proc createInterpreter*(scriptName: string;

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -21,6 +21,7 @@ import compiler / [options, commands, modules, sem,
   extccomp, condsyms,
   sigmatch, ast, scriptconfig,
   idents, modulegraphs, vm, prefixmatches, lineinfos, cmdlinehelper,
+  nimeval,
   pathutils]
 
 when defined(windows):
@@ -599,14 +600,8 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
 
   if gMode != mstdin:
     conf.writelnHook = proc (msg: string) = discard
-  # Find Nim's prefix dir.
-  let binaryPath = findExe("nim")
-  if binaryPath == "":
-    raise newException(IOError,
-        "Cannot find Nim standard library: Nim compiler not in PATH")
-  conf.prefixDir = AbsoluteDir binaryPath.splitPath().head.parentDir()
-  if not dirExists(conf.prefixDir / RelativeDir"lib"):
-    conf.prefixDir = AbsoluteDir""
+
+  conf.prefixDir = AbsoluteDir(findNimRootCompileTime())
 
   #msgs.writelnHook = proc (line: string) = log(line)
   myLog("START " & conf.projectFull.string)


### PR DESCRIPTION
* refs nim-lang/nimsuggest#91 ; specifically fixes this comment: https://github.com/nim-lang/nimsuggest/issues/91#issuecomment-435548683
* nimsuggest can be built anywhere

nimsuggest does't work if it's compiled somewhere else than default location
eg: this won't work
$nimc_D/bin/nim c -o:/tmp/nimsuggest_dbg --debugger:native nimsuggest/nimsuggest.nim

after running /tmp/nimsuggest_dbg you'd get:

Error: cannot open '/private/lib/system.nim'

this fixes this building upon findNimStdLibCompileTime introduced here nim-lang/Nim#9181

