### PR TITLE
Make getEnv case insensitive on Windows

### DIFF
--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -3,6 +3,8 @@
 when not declared(os):
   {.error: "This is an include file for os.nim!".}
 
+from parseutils import skipIgnoreCase
+
 proc c_getenv(env: cstring): cstring {.
   importc: "getenv", header: "<stdlib.h>".}
 proc c_putenv(env: cstring): cint {.
@@ -91,7 +93,10 @@ proc findEnvVar(key: string): int =
   getEnvVarsC()
   var temp = key & '='
   for i in 0..high(environment):
-    if startsWith(environment[i], temp): return i
+    when defined(windows):
+      if skipIgnoreCase(environment[i], temp) == len(temp): return i
+    else:
+      if startsWith(environment[i], temp): return i
   return -1
 
 proc getEnv*(key: string, default = ""): TaintedString {.tags: [ReadEnvEffect].} =


### PR DESCRIPTION
The `getEnv` proc calls `findEnvVar`, which tries to find an environment variable's key using case-sensitive search, and, if it is not found, tries to use `c_getenv`.

On Windows, where the environment variable keys are case insensitive, `c_getenv` returns ANSI-encoded string - the returned value is incorrect if it originally contained Unicode characters.

This changes the behavior such that `findEnvVar` proc tries to match the key using case-insensitive search on Windows.