### PR TITLE
Add isInstanceOf for generic procs to the macros module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,10 @@ proc enumToString*(enums: openArray[enum]): string =
 - Added `system.typeof` for more control over how `type` expressions
   can be deduced.
 
+- Added `macros.isInstanceOf` for checking if the proc symbol is instance of
+  generic proc symbol.
+
+
 ### Library changes
 
 - The string output of `macros.lispRepr` proc has been tweaked

--- a/changelog.md
+++ b/changelog.md
@@ -61,8 +61,8 @@ proc enumToString*(enums: openArray[enum]): string =
 - Added `system.typeof` for more control over how `type` expressions
   can be deduced.
 
-- Added `macros.isInstanceOf` for checking if the proc symbol is instance of
-  generic proc symbol.
+- Added `macros.isGenericProcInstanceOf` for checking if the proc symbol 
+  is instance of generic proc symbol.
 
 
 ### Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -61,8 +61,8 @@ proc enumToString*(enums: openArray[enum]): string =
 - Added `system.typeof` for more control over how `type` expressions
   can be deduced.
 
-- Added `macros.isGenericProcInstanceOf` for checking if the proc symbol 
-  is instance of generic proc symbol.
+- Added `macros.isInstantiationOf` for checking if the proc symbol 
+  is instantiation of generic proc symbol.
 
 
 ### Library changes

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -656,7 +656,8 @@ type
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo,
     mNimvm, mIntDefine, mStrDefine, mRunnableExamples,
-    mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf
+    mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
+    mSymIsIntanceOf
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -657,7 +657,7 @@ type
     mInstantiationInfo, mGetTypeInfo,
     mNimvm, mIntDefine, mStrDefine, mRunnableExamples,
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
-    mSymIsIntanceOf
+    mSymIsInstantiationOf
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -86,8 +86,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")
   defineSymbol("nimErrorProcCanHaveBody")
-  defineSymbol("nimHasInstanceOfInMacro")
-
+  defineSymbol("nimHasInstantiationOfInMacro")
   defineSymbol("nimHasNilSeqs")
   for f in low(Feature)..high(Feature):
     defineSymbol("nimHas" & $f)

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -86,6 +86,9 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")
   defineSymbol("nimErrorProcCanHaveBody")
+  defineSymbol("nimHasInstanceOfInMacro")
+
+ 
 
   defineSymbol("nimHasNilSeqs")
   for f in low(Feature)..high(Feature):

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -88,8 +88,6 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimErrorProcCanHaveBody")
   defineSymbol("nimHasInstanceOfInMacro")
 
- 
-
   defineSymbol("nimHasNilSeqs")
   for f in low(Feature)..high(Feature):
     defineSymbol("nimHas" & $f)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -959,7 +959,18 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                         else: newSymNode(a.sym.skipGenericOwner)
         regs[ra].node.flags.incl nfIsRef
       else:
-        stackTrace(c, tos, pc, "node is not a symbol")
+        stackTrace(c, tos, pc, "node is not a symbol")#
+    of opcSymIsInstanceOf:
+      decodeBC(rkInt)
+      let a = regs[rb].node
+      let b = regs[rc].node
+      if a.kind == nkSym and a.sym.kind in skProcKinds and 
+         b.kind == nkSym and b.sym.kind in skProcKinds:
+        regs[ra].intVal =
+          if sfFromGeneric in a.sym.flags and a.sym.owner == b.sym: 1
+          else: 0
+      else:    
+        stackTrace(c, tos, pc, "node is not a proc symbol") 
     of opcEcho:
       let rb = instr.regB
       if rb == 1:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -959,7 +959,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
                         else: newSymNode(a.sym.skipGenericOwner)
         regs[ra].node.flags.incl nfIsRef
       else:
-        stackTrace(c, tos, pc, "node is not a symbol")#
+        stackTrace(c, tos, pc, "node is not a symbol")
     of opcSymIsInstantiationOf:
       decodeBC(rkInt)
       let a = regs[rb].node

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -960,7 +960,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         regs[ra].node.flags.incl nfIsRef
       else:
         stackTrace(c, tos, pc, "node is not a symbol")#
-    of opcSymIsInstanceOf:
+    of opcSymIsInstantiationOf:
       decodeBC(rkInt)
       let a = regs[rb].node
       let b = regs[rc].node

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -148,7 +148,7 @@ type
     opcMarshalLoad, opcMarshalStore,
     opcToNarrowInt,
     opcSymOwner,
-    opcSymIsInstanceOf
+    opcSymIsInstantiationOf
 
   TBlock* = object
     label*: PSym

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -147,7 +147,8 @@ type
     opcTypeTrait,
     opcMarshalLoad, opcMarshalStore,
     opcToNarrowInt,
-    opcSymOwner
+    opcSymOwner,
+    opcSymIsInstanceOf
 
   TBlock* = object
     label*: PSym

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1148,6 +1148,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mGetImpl: genUnaryABC(c, n, dest, opcGetImpl)
   of mGetImplTransf: genUnaryABC(c, n, dest, opcGetImplTransf)
   of mSymOwner: genUnaryABC(c, n, dest, opcSymOwner)
+  of mSymIsIntanceOf: genBinaryABC(c, n, dest, opcSymIsInstanceOf)
   of mNChild: genBinaryABC(c, n, dest, opcNChild)
   of mNSetChild: genVoidABC(c, n, dest, opcNSetChild)
   of mNDel: genVoidABC(c, n, dest, opcNDel)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1148,7 +1148,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mGetImpl: genUnaryABC(c, n, dest, opcGetImpl)
   of mGetImplTransf: genUnaryABC(c, n, dest, opcGetImplTransf)
   of mSymOwner: genUnaryABC(c, n, dest, opcSymOwner)
-  of mSymIsIntanceOf: genBinaryABC(c, n, dest, opcSymIsInstanceOf)
+  of mSymIsInstantiationOf: genBinaryABC(c, n, dest, opcSymIsInstantiationOf)
   of mNChild: genBinaryABC(c, n, dest, opcNChild)
   of mNSetChild: genVoidABC(c, n, dest, opcNSetChild)
   of mNDel: genVoidABC(c, n, dest, opcNDel)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -274,8 +274,8 @@ when defined(nimHasSymOwnerInMacro):
     ## result is also mnde of kind nnkSym if owner exists otherwise
     ## nnkNilLit is returned
 
-when defined(nimHasInstanceOfInMacro):
-  proc isGenericProcInstanceOf*(instanceProcSym, genProcSym: NimNode): bool {.magic: "SymIsIntanceOf", noSideEffect.}
+when defined(nimHasInstantiationOfInMacro):
+  proc isInstantiationOf*(instanceProcSym, genProcSym: NimNode): bool {.magic: "SymIsInstantiationOf", noSideEffect.}
     ## check if proc symbol is instance of the generic proc symbol
     ## useful to check proc symbols against generic symbols 
     ## returned by `bindSym`

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -274,13 +274,11 @@ when defined(nimHasSymOwnerInMacro):
     ## result is also mnde of kind nnkSym if owner exists otherwise
     ## nnkNilLit is returned
 
-
 when defined(nimHasInstanceOfInMacro):
   proc isInstanceOf*(instanceProcSym, genProcSym: NimNode): bool {.magic: "SymIsIntanceOf", noSideEffect.}
     ## check if proc symbol is instance of the generic proc symbol
     ## useful to check proc symbols against generic symbols 
-    ## returned by `bindSym` 
-
+    ## returned by `bindSym`
  
 proc getType*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
   ## with 'getType' you can access the node's `type`:idx:. A Nim type is

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -275,7 +275,7 @@ when defined(nimHasSymOwnerInMacro):
     ## nnkNilLit is returned
 
 when defined(nimHasInstanceOfInMacro):
-  proc isInstanceOf*(instanceProcSym, genProcSym: NimNode): bool {.magic: "SymIsIntanceOf", noSideEffect.}
+  proc isGenericProcInstanceOf*(instanceProcSym, genProcSym: NimNode): bool {.magic: "SymIsIntanceOf", noSideEffect.}
     ## check if proc symbol is instance of the generic proc symbol
     ## useful to check proc symbols against generic symbols 
     ## returned by `bindSym`

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -274,6 +274,14 @@ when defined(nimHasSymOwnerInMacro):
     ## result is also mnde of kind nnkSym if owner exists otherwise
     ## nnkNilLit is returned
 
+
+when defined(nimHasInstanceOfInMacro):
+  proc isInstanceOf*(instanceProcSym, genProcSym: NimNode): bool {.magic: "SymIsIntanceOf", noSideEffect.}
+    ## check if proc symbol is instance of the generic proc symbol
+    ## useful to check proc symbols against generic symbols 
+    ## returned by `bindSym` 
+
+ 
 proc getType*(n: NimNode): NimNode {.magic: "NGetType", noSideEffect.}
   ## with 'getType' you can access the node's `type`:idx:. A Nim type is
   ## mapped to a Nim AST too, so it's slightly confusing but it means the same

--- a/tests/macros/tgetimpl.nim
+++ b/tests/macros/tgetimpl.nim
@@ -57,7 +57,7 @@ macro check_gen_proc(ex: typed): (bool, bool) =
     if not is_equal:
       is_equal = ex[0] == child
     if not is_instance_of:
-      is_instance_of = isInstanceOf(ex[0], child)
+      is_instance_of = isGenericProcInstanceOf(ex[0], child)
          
   result = nnkTupleConstr.newTree(newLit(is_equal), newLit(is_instance_of))
 

--- a/tests/macros/tgetimpl.nim
+++ b/tests/macros/tgetimpl.nim
@@ -57,7 +57,7 @@ macro check_gen_proc(ex: typed): (bool, bool) =
     if not is_equal:
       is_equal = ex[0] == child
     if not is_instance_of:
-      is_instance_of = isGenericProcInstanceOf(ex[0], child)
+      is_instance_of = isInstantiationOf(ex[0], child)
          
   result = nnkTupleConstr.newTree(newLit(is_equal), newLit(is_instance_of))
 

--- a/tests/macros/tgetimpl.nim
+++ b/tests/macros/tgetimpl.nim
@@ -46,3 +46,22 @@ static:
   doAssert isSameOwner(foo, poo)
   doAssert isSameOwner(foo, echo) == false
   doAssert isSameOwner(poo, len) == false
+
+#---------------------------------------------------------------
+
+macro check_gen_proc(ex: typed): (bool, bool) =
+  let lenChoice = bindsym"len"
+  var is_equal = false 
+  var is_instance_of = false 
+  for child in lenChoice:
+    if not is_equal:
+      is_equal = ex[0] == child
+    if not is_instance_of:
+      is_instance_of = isInstanceOf(ex[0], child)
+         
+  result = nnkTupleConstr.newTree(newLit(is_equal), newLit(is_instance_of))
+
+# check that len(seq[int]) is not equal to bindSym"len", but is instance of it
+let a = @[1,2,3]
+assert: check_gen_proc(len(a)) == (false, true)
+


### PR DESCRIPTION
In typed macros we often compare symbols. Comparison often made with the `bindSym` output. However this comparison does not work if a symbol belongs to the generic proc. In the proc bodies we are analysing, we encounter only already resolved instances of generic procs while `bindSym` returns generic proc symbols. These are understandably are different symbols and comparison returns `false`. AFAIK, there is no way at the moment check if proc symbol is the instance of a particular generic proc. This PR adds this functionality.