### PR TITLE
More converter fixes

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1818,7 +1818,6 @@ proc implicitConv(kind: TNodeKind, f: PType, arg: PNode, m: TCandidate,
 proc userConvMatch(c: PContext, m: var TCandidate, f, a: PType,
                    arg: PNode): PNode =
   result = nil
-  m.converterRetType = nil
   for i in countup(0, len(c.converters) - 1):
     var src = c.converters[i].typ.sons[1]
     var dest = c.converters[i].typ.sons[0]
@@ -1917,6 +1916,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     a = a
     c = m.c
 
+  m.converterRetType = nil
   if tfHasStatic in fMaybeStatic.flags:
     # XXX: When implicit statics are the default
     # this will be done earlier - we just have to

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2237,8 +2237,12 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
         m.state = csNoMatch
         return
     if formal.typ.kind == tyVar:
-      if m.converterRetType != nil and m.converterRetType.kind != tyVar and 
-         not n.isLValue:
+      if m.converterRetType != nil:
+        if m.converterRetType.kind != tyVar:
+          m.state = csNoMatch
+          m.mutabilityProblem = uint8(f-1)
+          return  
+      elif not n.isLValue:
         m.state = csNoMatch
         m.mutabilityProblem = uint8(f-1)
         return

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -51,7 +51,7 @@ type
                              # of error or wildcard (unknown) types.
                              # this is used to prevent instantiations.
     genericConverter*: bool  # true if a generic converter needs to
-                             # be instantiated         
+                             # be instantiated
     coerceDistincts*: bool   # this is an explicit coercion that can strip away
                              # a distrinct type
     typedescMatched*: bool

--- a/tests/converter/tconvert.nim
+++ b/tests/converter/tconvert.nim
@@ -26,3 +26,19 @@ block:
   var x = "101"
   var y: int = x # instantiate withVar
   doAssert(y == ord('0'))
+
+
+######################
+# bug #3503
+type Foo = object
+  r: float
+
+converter toFoo(r: float): Foo =
+  result.r = r
+
+proc `+=`*(x: var Foo, r: float) =
+  x.r += r
+
+var a: Foo
+a.r += 3.0
+

--- a/tests/converter/tconverter_unique_ptr.nim
+++ b/tests/converter/tconverter_unique_ptr.nim
@@ -115,7 +115,8 @@ doAssert: pu2[0] == 2.0
 ## Bugs #9735 and #9736 
 type
   ConstPtr*[T] = object
-    ## non copyable pointer to object T, exclusive ownership of the object is assumed
+    ## This pointer makes it impossible to change underlying value
+    ## as it returns only `lent T`
     val: ptr T
 
 proc `=destroy`*[T](p: var ConstPtr[T]) =

--- a/tests/converter/tconverter_unique_ptr.nim
+++ b/tests/converter/tconverter_unique_ptr.nim
@@ -2,9 +2,7 @@
 discard """
   file: "tconverter_unique_ptr.nim"
   targets: "c cpp"
-  output: '''5
-2.0 5
-'''
+  output: ""
 """
 
 ## Bugs 9698 and 9699
@@ -22,6 +20,8 @@ type
     data: ptr UncheckedArray[float]
 
 proc `$`(x: MyLen): string {.borrow.}
+proc `==`(x1, x2: MyLen): bool {.borrow.}
+
 
 proc `=destroy`*(m: var MySeq) {.inline.} =
   if m.data != nil:
@@ -50,8 +50,10 @@ proc len*(m: MySeq): MyLen {.inline.} = m.len
 
 proc lenx*(m: var MySeq): MyLen {.inline.} = m.len
 
-
 proc `[]`*(m: MySeq; i: MyLen): float {.inline.} =
+  m.data[i.int]
+
+proc `[]`*(m: var MySeq; i: MyLen): var float {.inline.} =
   m.data[i.int]
 
 proc `[]=`*(m: var MySeq; i: MyLen, val: float) {.inline.} =
@@ -97,11 +99,54 @@ proc newUniquePtr*[T](val: sink T): UniquePtr[T] =
 converter convertPtrToObj*[T](p: UniquePtr[T]): var T =
   result = p.val[]
 
-
 var pu = newUniquePtr(newMySeq(5, 1.0))
-echo pu.len
+let pu2 = newUniquePtr(newMySeq(5, 1.0))
+doAssert: pu.len == 5
+doAssert: pu2.len == 5
+doAssert: pu.lenx == 5
+doAssert: pu2.lenx == 5
 
 pu[0] = 2.0
-echo pu[0], " ", pu.lenx
+pu2[0] = 2.0
+doAssert pu[0] == 2.0
+doAssert: pu2[0] == 2.0
 
+##-----------------------------------------------------------------------------------------
+## Bugs #9735 and #9736 
+type
+  ConstPtr*[T] = object
+    ## non copyable pointer to object T, exclusive ownership of the object is assumed
+    val: ptr T
 
+proc `=destroy`*[T](p: var ConstPtr[T]) =
+  if p.val != nil:
+    `=destroy`(p.val[])
+    dealloc(p.val)
+    p.val = nil
+
+proc `=`*[T](dest: var ConstPtr[T], src: ConstPtr[T]) {.error.}
+
+proc `=sink`*[T](dest: var ConstPtr[T], src: ConstPtr[T]) {.inline.} =
+  if dest.val != nil and dest.val != src.val:
+    `=destroy`(dest)
+  dest.val = src.val
+
+proc newConstPtr*[T](val: sink T): ConstPtr[T] =
+  result.val = cast[type(result.val)](alloc(sizeof(result.val[])))
+  reset(result.val[])
+  result.val[] = val
+
+converter convertConstPtrToObj*[T](p: ConstPtr[T]): lent T =
+  result = p.val[]
+
+var pc = newConstPtr(newMySeq(3, 1.0))
+let pc2 = newConstPtr(newMySeq(3, 1.0))
+doAssert: pc.len == 3
+doAssert: pc.len == 3
+doAssert: compiles(pc.lenx == 2) == false
+doAssert: compiles(pc2.lenx == 2) == false
+doAssert: compiles(pc[0] = 2.0) == false
+doAssert: compiles(pc2[0] = 2.0) == false
+
+doAssert: pc[0] == 1.0
+doAssert: pc2[0] == 1.0


### PR DESCRIPTION
I am working on smart pointers using new Nim destructors and they require top quality converter support. I have stumbled upon two more issues:

Fixes #9735  (Converter bug: if converter returns `lent T` it is still possible to pass it as `var T` argument)
Fixes #9736  (Converter bug: if converter returns `var T` and argument expects `var T`,  it may still be rejected if original variable is `let`)


I haven't provided examples in the issue description, but the PR contains extensive test case

P.S.
I guess I can contribute the smart pointer library to stdlib if there is an interest.