### PR TITLE
add: proc deepCopy*[T](y: T): T

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4206,6 +4206,10 @@ when hasAlloc and not defined(nimscript) and not defined(JS) and
     ## for the implementation of ``spawn``.
     discard
 
+  proc deepCopy*[T](y: T): T =
+    ## Convenience wrapper around `deepCopy` overload.
+    deepCopy(result, y)
+
   include "system/deepcopy"
 
 proc procCall*(x: untyped) {.magic: "ProcCall", compileTime.} =


### PR DESCRIPTION
/cc @Araq 
this form is often more convenient eg:

```nim
# nimongo.mongo.insert modifies its argument in-place, we can protect against it via `deepCopy`:
let ai = mc.insert(doc.deepCopy)

# alternative is cumbersome, and also pollutes scope
var doc2: type(doc)
deepCopy(doc2, doc)
let ai = mc.insert(doc2)
```
