### PR TITLE
Fixes discard bug in cpp codegen [backport]

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2437,19 +2437,12 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
       # See tests/run/tcnstseq3 for an example that would fail otherwise.
       genAsgn(p, n, fastAsgn=p.prc != nil)
   of nkDiscardStmt:
-    let ex = n[0]
+    var ex = n[0]
     if ex.kind != nkEmpty:
       genLineDir(p, n)
       var a: TLoc
-      if ex.kind in nkCallKinds and (ex[0].kind != nkSym or
-                                     ex[0].sym.magic == mNone):
-        # bug #6037: do not assign to a temp in C++ mode:
-        incl a.flags, lfSingleUse
-        genCall(p, ex, a)
-        if lfSingleUse notin a.flags:
-          line(p, cpsStmts, a.r & ";\L")
-      else:
-        initLocExpr(p, ex, a)
+      initLocExprSingleUse(p, ex, a)
+      line(p, cpsStmts, "(void)(" & a.r & ");\L")
   of nkAsmStmt: genAsmStmt(p, n)
   of nkTryStmt:
     if p.module.compileToCpp and optNoCppExceptions notin p.config.globalOptions:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2437,7 +2437,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
       # See tests/run/tcnstseq3 for an example that would fail otherwise.
       genAsgn(p, n, fastAsgn=p.prc != nil)
   of nkDiscardStmt:
-    var ex = n[0]
+    let ex = n[0]
     if ex.kind != nkEmpty:
       genLineDir(p, n)
       var a: TLoc

--- a/tests/cpp/tcasts.nim
+++ b/tests/cpp/tcasts.nim
@@ -1,6 +1,6 @@
 discard """
   cmd: "nim cpp $file"
-  output: ""
+  output: '''{"vas": "kas", "123": "123"}'''
   targets: "cpp"
 """
 
@@ -9,3 +9,13 @@ block: #5979
   var p: pointer = cast[pointer](a)
   var c = cast[char](p)
   doAssert(c == 'a')
+
+
+#----------------------------------------------------
+# bug #9739
+import tables
+
+var t = initTable[string, string]()
+discard t.hasKeyOrPut("123", "123")
+discard t.mgetOrPut("vas", "kas")
+echo t


### PR DESCRIPTION
Fixes #9739. Codegen for discard is greatly simplified.
