### PR TITLE
nimsuggest: fix #96 ; enabled via `--partialRecompilation` since some cases cause crashes

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -186,7 +186,7 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
   if conf.suggestVersion == 1:
     graph.usageSym = nil
   if not isKnownFile:
-    graph.compileProject()
+    graph.compileProject(dirtyIdx)
   if conf.suggestVersion == 0 and conf.ideCmd in {ideUse, ideDus} and
       dirtyfile.isEmpty:
     discard "no need to recompile anything"
@@ -195,7 +195,8 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
     graph.markDirty dirtyIdx
     graph.markClientsDirty dirtyIdx
     if conf.ideCmd != ideMod:
-      graph.compileProject(modIdx)
+      if isKnownFile:
+        graph.compileProject(modIdx)
   if conf.ideCmd in {ideUse, ideDus}:
     let u = if conf.suggestVersion != 1: graph.symFromInfo(conf.m.trackPos) else: graph.usageSym
     if u != nil:

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -41,8 +41,6 @@ Options:
                           stdout instead of using sockets
   --epc                   use emacs epc mode
   --debug                 enable debug output
-  --partialRecompilation  [experimental] partial recompilation to enable
-                          speedy handling of yet unknown files; sometimes crashes
   --log                   enable verbose logging to nimsuggest.log file
   --v1                    use version 1 of the protocol; for backwards compatibility
   --refresh               perform automatic refreshes to keep the analysis precise
@@ -70,7 +68,6 @@ var
   gEmitEof: bool # whether we write '!EOF!' dummy lines
   gLogging = defined(logging)
   gRefresh: bool
-  gPartialRecompilation: bool
 
   requests: Channel[string]
   results: Channel[Suggest]
@@ -189,10 +186,7 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
   if conf.suggestVersion == 1:
     graph.usageSym = nil
   if not isKnownFile:
-    if gPartialRecompilation:
-      graph.compileProject(dirtyIdx)
-    else:
-      graph.compileProject()
+    graph.compileProject(dirtyIdx)
   if conf.suggestVersion == 0 and conf.ideCmd in {ideUse, ideDus} and
       dirtyfile.isEmpty:
     discard "no need to recompile anything"
@@ -201,7 +195,7 @@ proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
     graph.markDirty dirtyIdx
     graph.markClientsDirty dirtyIdx
     if conf.ideCmd != ideMod:
-      if not gPartialRecompilation or isKnownFile:
+      if isKnownFile:
         graph.compileProject(modIdx)
   if conf.ideCmd in {ideUse, ideDus}:
     let u = if conf.suggestVersion != 1: graph.symFromInfo(conf.m.trackPos) else: graph.usageSym
@@ -572,8 +566,6 @@ proc processCmdLine*(pass: TCmdLinePass, cmd: string; conf: ConfigRef) =
         gEmitEof = true
         gRefresh = false
       of "log": gLogging = true
-      of "partialrecompilation":
-        gPartialRecompilation = true
       of "refresh":
         if p.val.len > 0:
           gRefresh = parseBool(p.val)


### PR DESCRIPTION
/cc @Araq 
this reopens https://github.com/nim-lang/Nim/pull/9715 as requested by @araq but hides the feature under `--partialRecompilation` so only it's only enabled for users who want to try it out
reference:
this comment from @Araq https://github.com/nim-lang/Nim/pull/9721#issuecomment-439016793

> I liked your previous solution much better and the crashes could have been fixed, I think. The ModuleGraph can have multiple entry points, in theory there is not much to it.

## description

* fixes https://github.com/nim-lang/nimsuggest/issues/96
docs say https://nim-lang.github.io/Nim/nimsuggest.html
> There is some support so that you can throw random .nim files which are not part of myproject at Nimsuggest too, but usually the query refer to modules/files that are part of myproject.

this wasn't true until this PR
it's a very useful feature that allows you to handle nim files not covered by your initial project.nim

* refs https://github.com/nim-lang/nimsuggest/issues/66
* refs https://github.com/PMunch/nimlsp/issues/8

## caveat
same caveat as mentioned in https://github.com/nim-lang/Nim/pull/9715#issuecomment-438935200 applies

## note
tried to reopen https://github.com/nim-lang/Nim/pull/9715 using instructions in https://gist.github.com/robertpainsi/2c42c15f1ce6dab03a0675348edd4e2c but `git push -f origin 70aa9613371081d52dfaba90fa12d5532b3e1ae1:pr_nimsuggest_fix_96` failed because I don't have credentials it seems

