### PR TITLE
Destructors: move into nkTupleConstr and move on tuple unpacking

### DIFF
--- a/compiler/destroyer.nim
+++ b/compiler/destroyer.nim
@@ -496,8 +496,6 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
 proc p(n: PNode; c: var Con): PNode =
   case n.kind
   of nkVarSection, nkLetSection:
-    echo "n ", $n
-    echo "---------------"
     discard "transform; var x = y to  var x; x op y  where op is a move or copy"
     result = newNodeI(nkStmtList, n.info)
 

--- a/compiler/destroyer.nim
+++ b/compiler/destroyer.nim
@@ -435,7 +435,7 @@ proc pArg(arg: PNode; c: var Con; isSink: bool): PNode =
 
 proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
   case ri.kind
-  of nkCallKinds:
+  of nkCallKinds, nkBracketExpr:
     result = genSink(c, dest.typ, dest, ri)
     # watch out and no not transform 'ri' twice if it's a call:
     let ri2 = copyNode(ri)
@@ -446,7 +446,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
       ri2.add pArg(ri[i], c, i < L and parameters[i].kind == tySink)
     #recurse(ri, ri2)
     result.add ri2
-  of nkObjConstr:
+  of nkObjConstr, nkTupleConstr:
     result = genSink(c, dest.typ, dest, ri)
     let ri2 = copyTree(ri)
     for i in 1..<ri.len:

--- a/tests/destructor/t6434.nim
+++ b/tests/destructor/t6434.nim
@@ -1,21 +1,26 @@
 discard """
   exitcode: 0
-  output: '''assingment
-assingment
-assingment
-assingment
-'''
+  output: ""
 """
 
 type
   Foo* = object
     boo: int
 
+var sink_counter = 0
+var assign_counter = 0
+
+proc `=sink`(dest: var Foo, src: Foo) =
+  sink_counter.inc
+
 proc `=`(dest: var Foo, src: Foo) =
-  debugEcho "assingment"
+  assign_counter.inc
 
 proc test(): auto =
   var a,b : Foo
   return (a, b, Foo(boo: 5))
 
 var (a, b, _) = test()
+
+doAssert: assign_counter == 0
+doAssert: sink_counter == 9

--- a/tests/destructor/t6434.nim
+++ b/tests/destructor/t6434.nim
@@ -16,6 +16,6 @@ proc `=`(dest: var Foo, src: Foo) =
 
 proc test(): auto =
   var a,b : Foo
-  return (a, b)
+  return (a, b, Foo(boo: 5))
 
-var (a, b) = test()
+var (a, b, _) = test()

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -108,8 +108,15 @@ proc newMySeq*(size: int, initial_value = 0.0): MySeqNonCopyable =
 proc myfunc(x, y: int): (MySeqNonCopyable, MySeqNonCopyable) =
   result = (newMySeq(x, 1.0), newMySeq(y, 5.0))
 
+proc myfunc2(x, y: int): tuple[a: MySeqNonCopyable, b:int, c:MySeqNonCopyable] =
+  (a: newMySeq(x, 1.0), b:0, c:newMySeq(y, 5.0))
+
 let (seq1, seq2) = myfunc(2, 3)
 doAssert seq1.len == 2
 doAssert seq1[0] == 1.0
 doAssert seq2.len == 3
 doAssert seq2[0] == 5.0
+
+var (seq3, i, _) = myfunc2(2, 3)
+doAssert seq3.len == 2
+doAssert seq3[0] == 1.0

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -97,8 +97,7 @@ proc setTo(s: var MySeqNonCopyable, val: float) =
   for i in 0..<s.len.int:
     s.data[i] = val
 
-proc newMySeq*(size: int, initial_value = 0.0): MySeqNonCopyable =
-  echo " MySeq destructor is created"
+proc newMySeq*(size: int, initial_value = 0.0): MySeqNonCopyable =#
   result.len = size
   if size > 0:
     result.data = cast[ptr UncheckedArray[float]](createShared(float, size))

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -62,9 +62,9 @@ for x in getPony():
 #echo "Pony is dying!"
 
 
-#-------------------------------------------------------
-#--- Move into tuple const and move in tuple unpacking
-#-------------------------------------------------------
+#------------------------------------------------------------
+#-- Move into tuple constructor and move on tuple unpacking
+#------------------------------------------------------------
 
 type
   MySeqNonCopyable* = object

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -60,3 +60,56 @@ for x in getPony():
 # XXX this needs to be enabled once top level statements
 # produce destructor calls again.
 #echo "Pony is dying!"
+
+
+#-------------------------------------------------------
+#--- Move into tuple const and move in tuple unpacking
+#-------------------------------------------------------
+
+type
+  MySeqNonCopyable* = object
+    len: int 
+    data: ptr UncheckedArray[float]
+
+proc `=destroy`*(m: var MySeqNonCopyable) {.inline.} =
+  if m.data != nil:
+    deallocShared(m.data)
+    m.data = nil
+
+proc `=`*(m: var MySeqNonCopyable, m2: MySeqNonCopyable) {.error.}
+
+proc `=sink`*(m: var MySeqNonCopyable, m2: MySeqNonCopyable) {.inline.} =
+  if m.data != m2.data:
+    if m.data != nil:
+      `=destroy`(m)
+    m.len = m2.len
+    m.data = m2.data
+
+proc len*(m: MySeqNonCopyable): int {.inline.} = m.len
+
+proc `[]`*(m: MySeqNonCopyable; i: int): float {.inline.} =
+  m.data[i.int]
+
+proc `[]=`*(m: var MySeqNonCopyable; i, val: float) {.inline.} =
+  m.data[i.int] = val
+
+proc setTo(s: var MySeqNonCopyable, val: float) = 
+  for i in 0..<s.len.int:
+    s.data[i] = val
+
+proc newMySeq*(size: int, initial_value = 0.0): MySeqNonCopyable =
+  echo " MySeq destructor is created"
+  result.len = size
+  if size > 0:
+    result.data = cast[ptr UncheckedArray[float]](createShared(float, size))
+
+  result.setTo(initial_value)
+
+proc myfunc(x, y: int): (MySeqNonCopyable, MySeqNonCopyable) =
+  result = (newMySeq(x, 1.0), newMySeq(y, 5.0))
+
+let (seq1, seq2) = myfunc(2, 3)
+doAssert seq1.len == 2
+doAssert seq1[0] == 1.0
+doAssert seq2.len == 3
+doAssert seq2[0] == 5.0


### PR DESCRIPTION
Destructors are getting more mature. On tuple construction we now move objects into tuple just like for object construction and we move objects out of the tuple during tuple unpacking.

