### PR TITLE
Show lineinfo of for in yield

### DIFF
--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -368,6 +368,11 @@ proc transformYield(c: PTransf, n: PNode): PTransNode =
   else:
     # we need to introduce new local variables:
     add(result, introduceNewLocalVars(c, c.transCon.forLoopBody.PNode))
+  if result.len > 0:
+    var changeNode = PNode(result[0])
+    changeNode.info = c.transCon.forStmt.info
+    for i, child in changeNode:
+      child.info = changeNode.info
 
 proc transformAddrDeref(c: PTransf, n: PNode, a, b: TNodeKind): PTransNode =
   result = transformSons(c, n)


### PR DESCRIPTION
This way we can have correct debug flow loops.


It changes the behavior in a debugger from 
```
iterator code..
code1
code2
iterator code ..
code1

# now
for
iterator code ..
code1 
code2
for
```
I think adding a noop line after yield might be best, as maybe yield needs the iterator lineinfo. I am not sure how to add such a line: I tried and codegen seems to optimize it.

Do I need to add a test?