### PR TITLE
fix segfault when calling shallow() on an empty string

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4028,6 +4028,8 @@ proc shallow*(s: var string) {.noSideEffect, inline.} =
   ## purposes.
   when not defined(JS) and not defined(nimscript) and not defined(gcDestructors):
     var s = cast[PGenericSeq](s)
+    if s == nil:
+      s = cast[PGenericSeq](newString(0))
     # string literals cannot become 'shallow':
     if (s.reserved and strlitFlag) == 0:
       s.reserved = s.reserved or seqShallowFlag

--- a/tests/system/tnilconcats.nim
+++ b/tests/system/tnilconcats.nim
@@ -23,3 +23,10 @@ when true:
   doAssert s == "fooabc"
 
   echo x
+
+  # casting an empty string as sequence with shallow() should not segfault
+  var s2: string
+  shallow(s2)
+  s2 &= "foo"
+  doAssert s2 == "foo"
+


### PR DESCRIPTION
shallow() casts its string argument to a seq and then tries to access
its fields. Guess what happens when that string is nil, which seems to
be the representation of an empty string (both the default value and an
explicitly assigned "").

Segfault encountered when running "ntags -R ." on a large project. The relevant line:
https://bitbucket.org/nimcontrib/ntags/src/a1c62c38e539877c105fbe4e08d06b76232f8017/ntags.nim#lines-125