### PR TITLE
Made nimsuggest importable as a library and add Nim-path override option

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -707,7 +707,6 @@ else:
       retval.add(Suggest(section: ideMsg, doc: line))
     conf.suggestionResultHook = proc (s: Suggest) =
       retval.add(s)
-    echo conf.ideCmd
     if conf.ideCmd == ideKnown:
       retval.add(Suggest(section: ideKnown, quality: ord(fileInfoKnown(conf, file))))
     else:


### PR DESCRIPTION
This makes it possible to import nimsuggest as a library to make it easier to use in Nim based plug-ins (like nimlsp). It still has to be imported by a direct path, but I'm not entirely sure what to do to make the importing smoother.