### PR TITLE
fixes #9794: sizeof tuple is incorrect if contains imported object

### DIFF
--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -310,9 +310,9 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
     for i in countup(0, sonsLen(typ) - 1):
       let child = typ.sons[i]
       computeSizeAlign(conf, child)
-      if child.size == szIllegalRecursion:
-        typ.size = szIllegalRecursion
-        typ.align = szIllegalRecursion
+      if child.size < 0:
+        typ.size = child.size
+        typ.align = child.align
         return
       maxAlign = max(maxAlign, child.align)
       sizeAccum = align(sizeAccum, child.align) + child.size

--- a/tests/types/tfinalobj.nim
+++ b/tests/types/tfinalobj.nim
@@ -1,6 +1,6 @@
 discard """
   output: '''abc
-64 == 64'''
+16 == 16'''
 """
 
 type
@@ -19,13 +19,13 @@ echo a.x
 # bug #9794
 ##########################################
 type
-  m256 {.importc: "__m256" , header: "immintrin.h".} = object
+  imported_double {.importc: "double".} = object
 
   Pod = object
-    v* : m256
+    v* : imported_double
     seed*: int32
 
-  Pod2 = tuple[v: m256, seed: int32]
+  Pod2 = tuple[v: imported_double, seed: int32]
 
 proc test() =
   echo sizeof(Pod), " == ",sizeof(Pod2)

--- a/tests/types/tfinalobj.nim
+++ b/tests/types/tfinalobj.nim
@@ -1,5 +1,6 @@
 discard """
-  output: "abc"
+  output: '''abc
+64 == 64'''
 """
 
 type
@@ -14,3 +15,19 @@ doAssert TA.sizeof == string.sizeof
 
 echo a.x
 
+##########################################
+# bug #9794
+##########################################
+type
+  m256 {.importc: "__m256" , header: "immintrin.h".} = object
+
+  Pod = object
+    v* : m256
+    seed*: int32
+
+  Pod2 = tuple[v: m256, seed: int32]
+
+proc test() =
+  echo sizeof(Pod), " == ",sizeof(Pod2)
+
+test()


### PR DESCRIPTION
Bug is rather critical and fix should be backported