### PR TITLE
"let" vars and guarded vars are considered GC safe

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -8038,9 +8038,13 @@ indirectly; so the ``thread`` pragma implies ``procvar``.
 GC safety
 ---------
 
-We call a proc ``p`` `GC safe`:idx: when it doesn't access any global variable
-that contains GC'ed memory (``string``, ``seq``, ``ref`` or a closure) either
+We call a proc ``p`` `GC safe`:idx: when it doesn't access global variables
+that contain GC'ed memory (``string``, ``seq``, ``ref`` or a closure) either
 directly or indirectly through a call to a GC unsafe proc.
+
+An exception is made for access to `let variables
+<#statements-and-expressions-let-statement>`_ and `guarded variables
+<#guards-and-locks>`_ which is considered GC safe.
 
 The `gcsafe`:idx: annotation can be used to mark a proc to be gcsafe,
 otherwise this property is inferred by the compiler. Note that ``noSideEffect``

--- a/tests/parallel/tgcsafe_global_access.nim
+++ b/tests/parallel/tgcsafe_global_access.nim
@@ -1,0 +1,40 @@
+import locks, threadpool, os
+
+# read-only global access
+let g1 = @[42]
+
+proc f1() {.gcsafe.} =
+  discard g1[0]
+
+spawn f1()
+
+# guarded global access
+var
+  l2: Lock
+  g2 {.guard: l2.} = @[42]
+
+initLock(l2)
+
+proc f2() {.gcsafe.} =
+  sleep(100)
+  l2.acquire()
+  {.locks: [l2].}:
+    if g2[0] == 42:
+      g2[0] = 2
+  l2.release()
+
+proc f3() {.gcsafe.} =
+  sleep(100)
+  l2.acquire()
+  {.locks: [l2].}:
+    if g2[0] == 42:
+      g2[0] = 3
+  l2.release()
+
+spawn f2()
+spawn f3()
+
+sync()
+doAssert(g2[0] != 42)
+# echo "the winner is f", g2[0]
+


### PR DESCRIPTION
Rationale:
- "let" variables are read-only and parallel read-only access to
  shared memory is safe
- guarded variables are protected by locks - here we rely on the
  programmer to do the actual lock acquisition and release around the
  {.locks: [...].} block that the compiler checks for, but once that's
  done, shared memory access from different threads becomes safe