### PR TITLE
Destructors: more moves for tuples

### DIFF
--- a/compiler/destroyer.nim
+++ b/compiler/destroyer.nim
@@ -459,7 +459,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
       result = genCopy(c, dest.typ, dest, ri)
     result.add p(ri, c)
   of nkStmtListExpr:
-    result = newNWdeI(nkStmtList, ri.info)
+    result = newNodeI(nkStmtList, ri.info)
     for i in 0..ri.len-2:
       result.add p(ri[i], c)
     result.add moveOrCopy(dest, ri[^1], c)

--- a/compiler/destroyer.nim
+++ b/compiler/destroyer.nim
@@ -457,9 +457,9 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
       result = genSink(c, dest.typ, dest, ri)
     else:
       result = genCopy(c, dest.typ, dest, ri)
-    result.add p(ri, c)  
+    result.add p(ri, c)
   of nkStmtListExpr:
-    result = newNodeI(nkStmtList, ri.info)
+    result = newNWdeI(nkStmtList, ri.info)
     for i in 0..ri.len-2:
       result.add p(ri[i], c)
     result.add moveOrCopy(dest, ri[^1], c)

--- a/compiler/destroyer.nim
+++ b/compiler/destroyer.nim
@@ -457,7 +457,12 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
       result = genSink(c, dest.typ, dest, ri)
     else:
       result = genCopy(c, dest.typ, dest, ri)
-    result.add p(ri, c)
+    result.add p(ri, c)  
+  of nkStmtListExpr:
+    result = newNodeI(nkStmtList, ri.info)
+    for i in 0..ri.len-2:
+      result.add p(ri[i], c)
+    result.add moveOrCopy(dest, ri[^1], c)
   of nkObjConstr:
     result = genSink(c, dest.typ, dest, ri)
     let ri2 = copyTree(ri)

--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -78,7 +78,7 @@ proc lowerTupleUnpackingForAsgn*(g: ModuleGraph; n: PNode; owner: PSym): PNode =
   let value = n.lastSon
   result = newNodeI(nkStmtList, n.info)
 
-  var temp = newSym(skLet, getIdent(g.cache, "_"), owner, value.info, owner.options)
+  var temp = newSym(skTemp, getIdent(g.cache, "_"), owner, value.info, owner.options)
   var v = newNodeI(nkLetSection, value.info)
   let tempAsNode = newSymNode(temp) #newIdentNode(getIdent(genPrefix & $temp.id), value.info)
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -204,7 +204,7 @@ proc newSymG*(kind: TSymKind, n: PNode, c: PContext): PSym =
   if n.kind == nkSym:
     # and sfGenSym in n.sym.flags:
     result = n.sym
-    if result.kind != kind:
+    if result.kind notin {kind, skTemp}:
       localError(c.config, n.info, "cannot use symbol of kind '" &
                  $result.kind & "' as a '" & $kind & "'")
     if sfGenSym in result.flags and result.kind notin {skTemplate, skMacro, skParam}:

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -108,7 +108,8 @@ proc myfunc(x, y: int): (MySeqNonCopyable, MySeqNonCopyable) =
   result = (newMySeq(x, 1.0), newMySeq(y, 5.0))
 
 proc myfunc2(x, y: int): tuple[a: MySeqNonCopyable, b:int, c:MySeqNonCopyable] =
-  (a: newMySeq(x, 1.0), b:0, c:newMySeq(y, 5.0))
+  var cc = newMySeq(y, 5.0)
+  (a: newMySeq(x, 1.0), b:0, c: cc)
 
 let (seq1, seq2) = myfunc(2, 3)
 doAssert seq1.len == 2
@@ -119,3 +120,6 @@ doAssert seq2[0] == 5.0
 var (seq3, i, _) = myfunc2(2, 3)
 doAssert seq3.len == 2
 doAssert seq3[0] == 1.0
+
+var seq4, seq5: MySeqNonCopyable
+(seq4, i, seq5) = myfunc2(2, 3)


### PR DESCRIPTION
I have found a couple more use cases where sink is not happening for tuples.
nkStmtListExpr in moveOrCopy is likely going to help not only tuples.
