### PR TITLE
Moved some code around in nimsuggest to avoid crash when run as library

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -200,7 +200,7 @@ proc executeNoHooks(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
 
 proc execute(cmd: IdeCmd, file, dirtyfile: AbsoluteFile, line, col: int;
              graph: ModuleGraph) =
-  if graph.config.ideCmd == ideChk:
+  if cmd == ideChk:
     graph.config.structuredErrorHook = errorHook
     graph.config.writelnHook = myLog
   else:


### PR DESCRIPTION
One of the hooks were set inside the execute procedure which caused nimsuggest to crash when it tried to send something over the uninitialised channel.