### PR TITLE
[WIP] `assert` enforced if condition known at CT, regardless of --assertions:off

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3952,6 +3952,11 @@ template assert*(cond: untyped, msg = "") =
   const expr = astToStr(cond)
   assertImpl(cond, msg, expr, compileOption("assertions"))
 
+template assert*(cond: static untyped, msg = "") =
+  ## overload that makes the assert valid when `cond` known at CT.
+  const expr = astToStr(cond)
+  assertImpl(cond, msg, expr, true)
+
 template doAssert*(cond: untyped, msg = "") =
   ## same as ``assert`` but is always turned on regardless of ``--assertions``
   const expr = astToStr(cond)


### PR DESCRIPTION
/cc @Araq 
this PR makes code with `--assertions:off` (eg, `-d:release`) safer, with zero performance impact in terms of evaluating the condition at runtime
Note: inspired by D, where `assert(foo)` is enforced if `foo` is known at CT


## note 1
adding `WIP` as I need to think how code like this should be handled:

pegs.nim
```nim
  if match("abcdefg", peg"c {d} ef {g}", matches, 2):
    assert matches[0] == "d"
    assert matches[1] == "g"
  else:
    assert false
```

this would transform to (with -d:release):
```nim
  if match("abcdefg", peg"c {d} ef {g}", matches, 2):
    discard
  else:
    assert false
```
ie, the condition `match("abcdefg", peg"c {d} ef {g}", matches, 2)` can't be optimized away with -d:release after this PR

maybe this justifies another flag `--assertionsCT:on|off` to give users finer grain control over safety/performance

## note 2: blocked by a bug
hmm this exhibits what seems to be a bug: here's a reduced case:
after this PR, following code gives a internal error:
```nim
import json
assert parseJson("null").kind == JNull
assert parseJson("true").kind == JBool
```

```
/Users/timothee/git_clone/nim/timn/config.nims [config.nims used]
/Users/timothee/git_clone/nim/Nim/compiler/nim.nim(109) nim
/Users/timothee/git_clone/nim/Nim/compiler/nim.nim(73) handleCmdLine
/Users/timothee/git_clone/nim/Nim/compiler/cmdlinehelper.nim(91) loadConfigsAndRunMainCommand
/Users/timothee/git_clone/nim/Nim/compiler/main.nim(168) mainCommand
/Users/timothee/git_clone/nim/Nim/compiler/main.nim(78) commandCompileToC
/Users/timothee/git_clone/nim/Nim/compiler/modules.nim(127) compileProject
/Users/timothee/git_clone/nim/Nim/compiler/modules.nim(72) compileModule
/Users/timothee/git_clone/nim/Nim/compiler/passes.nim(194) processModule
/Users/timothee/git_clone/nim/Nim/compiler/passes.nim(86) processTopLevelStmt
/Users/timothee/git_clone/nim/Nim/compiler/sem.nim(603) myProcess
/Users/timothee/git_clone/nim/Nim/compiler/sem.nim(571) semStmtAndGenerateGenerics
/Users/timothee/git_clone/nim/Nim/compiler/semstmts.nim(1986) semStmt
/Users/timothee/git_clone/nim/Nim/compiler/semexprs.nim(915) semExprNoType
/Users/timothee/git_clone/nim/Nim/compiler/semexprs.nim(2548) semExpr
/Users/timothee/git_clone/nim/Nim/compiler/semstmts.nim(1927) semStmtList
/Users/timothee/git_clone/nim/Nim/compiler/semexprs.nim(2441) semExpr
/Users/timothee/git_clone/nim/Nim/compiler/semexprs.nim(896) semDirectOp
/Users/timothee/git_clone/nim/Nim/compiler/semexprs.nim(746) semOverloadedCallAnalyseEffects
/Users/timothee/git_clone/nim/Nim/compiler/semcall.nim(504) semOverloadedCall
/Users/timothee/git_clone/nim/Nim/compiler/semcall.nim(312) resolveOverloads
/Users/timothee/git_clone/nim/Nim/compiler/semcall.nim(93) pickBestCandidate
/Users/timothee/git_clone/nim/Nim/compiler/sigmatch.nim(2438) matches
/Users/timothee/git_clone/nim/Nim/compiler/sigmatch.nim(2379) matchesAux
/Users/timothee/git_clone/nim/Nim/compiler/sigmatch.nim(2098) paramTypesMatch
/Users/timothee/git_clone/nim/Nim/compiler/sigmatch.nim(1933) paramTypesMatchAux
/Users/timothee/git_clone/nim/Nim/compiler/sem.nim(329) tryConstExpr
/Users/timothee/git_clone/nim/Nim/compiler/vm.nim(1908) evalConstExpr
/Users/timothee/git_clone/nim/Nim/compiler/vm.nim(1904) evalConstExprAux
/Users/timothee/git_clone/nim/Nim/compiler/vm.nim(1051) rawExecute
/Users/timothee/git_clone/nim/Nim/lib/system.nim(2974) sysFatal
Error: unhandled exception: value out of range: -1 [RangeError]
```

## note 3
one issue with this approach is it'd force to evaluate at CT an expression that would otherwise be evaluated at RT (when feasible); this could potentially slow down compilation if the `cond` expression is costly;
maybe a better idea would be to restrict this "enforced" assert to the case where `cond` is the bool literal `false`; the `note 1` caveat mentioned above, could be handled by `--assertionsFalseEnabled:on|off`

