### PR TITLE
add os.getCurrentProcessId()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -91,6 +91,7 @@ proc enumToString*(enums: openArray[enum]): string =
 - Vm suport for float32<->int32 and float64<->int64 casts was added.
 - There is a new pragma block `noSideEffect` that works like
   the `gcsafe` pragma block.
+- added os.processID()
 
 ### Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -91,7 +91,7 @@ proc enumToString*(enums: openArray[enum]): string =
 - Vm suport for float32<->int32 and float64<->int64 casts was added.
 - There is a new pragma block `noSideEffect` that works like
   the `gcsafe` pragma block.
-- added os.processID()
+- added os.getCurrentProcessId()
 
 ### Language changes
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2419,6 +2419,15 @@ proc isHidden*(path: string): bool {.noNimScript.} =
     let fileName = lastPathPart(path)
     result = len(fileName) >= 2 and fileName[0] == '.' and fileName != ".."
 
+proc processID*(): int =
+  ## return current process ID. See also ``osproc.processID(p: Process)``.
+  when defined(windows):
+    proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",
+                                        importc: "GetCurrentProcessId".}
+    result = GetCurrentProcessId().int
+  else:
+    result = getpid()
+
 {.pop.}
 
 proc setLastModificationTime*(file: string, t: times.Time) {.noNimScript.} =

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2419,7 +2419,7 @@ proc isHidden*(path: string): bool {.noNimScript.} =
     let fileName = lastPathPart(path)
     result = len(fileName) >= 2 and fileName[0] == '.' and fileName != ".."
 
-proc processID*(): int {.noNimScript.} =
+proc getCurrentProcessId*(): int {.noNimScript.} =
   ## return current process ID. See also ``osproc.processID(p: Process)``.
   when defined(windows):
     proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2419,7 +2419,7 @@ proc isHidden*(path: string): bool {.noNimScript.} =
     let fileName = lastPathPart(path)
     result = len(fileName) >= 2 and fileName[0] == '.' and fileName != ".."
 
-proc processID*(): int =
+proc processID*(): int {.noNimScript.} =
   ## return current process ID. See also ``osproc.processID(p: Process)``.
   when defined(windows):
     proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -164,7 +164,7 @@ proc processID*(): int =
     type DWORD = uint32
     proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",
                                         importc: "GetCurrentProcessId".}
-    result = GetCurrentProcessId()
+    result = GetCurrentProcessId().int
   else:
     result = getpid()
 

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -155,7 +155,7 @@ proc running*(p: Process): bool {.rtl, extern: "nosp$1", tags: [].}
   ## Returns true iff the process `p` is still running. Returns immediately.
 
 proc processID*(p: Process): int {.rtl, extern: "nosp$1".} =
-  ## returns `p`'s process ID. See also ``os.processID()``.
+  ## returns `p`'s process ID. See also ``os.getCurrentProcessId()``.
   return p.id
 
 proc waitForExit*(p: Process, timeout: int = -1): int {.rtl,

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -158,6 +158,15 @@ proc processID*(p: Process): int {.rtl, extern: "nosp$1".} =
   ## returns `p`'s process ID.
   return p.id
 
+proc processID*(): int =
+  ## return current process ID
+  when defined(windows):
+    proc GetCurrentProcessId(): int32 {.stdcall, dynlib: "kernel32",
+                                        importc: "GetCurrentProcessId".}
+    result = GetCurrentProcessId()
+  else:
+    result = getpid()
+
 proc waitForExit*(p: Process, timeout: int = -1): int {.rtl,
   extern: "nosp$1", tags: [].}
   ## waits for the process to finish and returns `p`'s error code.
@@ -1341,3 +1350,4 @@ proc execCmdEx*(command: string, options: set[ProcessOption] = {
       result[1] = peekExitCode(p)
       if result[1] != -1: break
   close(p)
+

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -15,7 +15,7 @@ include "system/inclrtl"
 import
   strutils, os, strtabs, streams, cpuinfo
 
-export quoteShell, quoteShellWindows, quoteShellPosix
+export quoteShell, quoteShellWindows, quoteShellPosix, processID
 
 when defined(windows):
   import winlean
@@ -155,18 +155,8 @@ proc running*(p: Process): bool {.rtl, extern: "nosp$1", tags: [].}
   ## Returns true iff the process `p` is still running. Returns immediately.
 
 proc processID*(p: Process): int {.rtl, extern: "nosp$1".} =
-  ## returns `p`'s process ID.
+  ## returns `p`'s process ID. See also ``os.processID()``.
   return p.id
-
-proc processID*(): int =
-  ## return current process ID
-  when defined(windows):
-    type DWORD = uint32
-    proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",
-                                        importc: "GetCurrentProcessId".}
-    result = GetCurrentProcessId().int
-  else:
-    result = getpid()
 
 proc waitForExit*(p: Process, timeout: int = -1): int {.rtl,
   extern: "nosp$1", tags: [].}

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -161,7 +161,8 @@ proc processID*(p: Process): int {.rtl, extern: "nosp$1".} =
 proc processID*(): int =
   ## return current process ID
   when defined(windows):
-    proc GetCurrentProcessId(): int32 {.stdcall, dynlib: "kernel32",
+    type DWORD = uint32
+    proc GetCurrentProcessId(): DWORD {.stdcall, dynlib: "kernel32",
                                         importc: "GetCurrentProcessId".}
     result = GetCurrentProcessId()
   else:

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -15,7 +15,7 @@ include "system/inclrtl"
 import
   strutils, os, strtabs, streams, cpuinfo
 
-export quoteShell, quoteShellWindows, quoteShellPosix, processID
+export quoteShell, quoteShellWindows, quoteShellPosix
 
 when defined(windows):
   import winlean


### PR DESCRIPTION
/cc @Araq 
surprising it didn't exist yet

after this is merged maybe nimble/src/nimblepkg/tools.nim can be refactored use that  /cc @dom96 

## links
* [How do I get the process ID of the current program? - Nim forum](https://forum.nim-lang.org/t/946)