### PR TITLE
Support distinct JsAssoc keys

### DIFF
--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -115,6 +115,13 @@ type
   JsTypeError* {.importc: "TypeError".} = object of JsError
   JsURIError* {.importc: "URIError".} = object of JsError
 
+type
+  DistinctInt = concept a
+    a is distinct
+    a.int
+
+proc toJsKey*[T: DistinctInt](text: cstring, t: type T): T {.importcpp: "parseInt(#)".}
+
 # New
 proc newJsObject*: JsObject {. importcpp: "{@}" .}
   ## Creates a new empty JsObject

--- a/tests/js/tjsffi.nim
+++ b/tests/js/tjsffi.nim
@@ -16,6 +16,7 @@ true
 true
 true
 true
+true
 3
 2
 12
@@ -180,6 +181,17 @@ block:
     obj.a = proc(e: int): int = e * e
     let call = obj["a"]
     call(10) == 100
+  echo test()
+
+# Test JsAssoc distinct
+type
+  A = distinct int
+
+block:
+  proc test(): bool =
+    let obj = newJsAssoc[A, int]()
+    obj[0.A] = 0
+    obj[0.A] == 0
   echo test()
 
 # Test JsAssoc Iterators


### PR DESCRIPTION
After fixing the JsKey type safety, distinct ints are not supported by default currently: it makes sense to add default support.

I couldn't make `T: distinct int` work, that's why I used `DistinctInt`: is there a better way?
