### PR TITLE
Remove compiler's ctags command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -107,6 +107,6 @@ proc enumToString*(enums: openArray[enum]): string =
 
 ### Compiler changes
 - The deprecated `fmod` proc is now unavailable on the VM'.
-- The compiler's command `ctags` has been deprecated.
+- The compiler's command `ctags` has been removed.
 
 ### Bugfixes

--- a/changelog.md
+++ b/changelog.md
@@ -107,5 +107,6 @@ proc enumToString*(enums: openArray[enum]): string =
 
 ### Compiler changes
 - The deprecated `fmod` proc is now unavailable on the VM'.
+- The compiler's command `ctags` has been deprecated.
 
 ### Bugfixes

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1016,27 +1016,6 @@ proc commandJson*(cache: IdentCache, conf: ConfigRef) =
     if not writeRope(content, filename):
       rawMessage(conf, errCannotOpenFile, filename.string)
 
-proc commandTags*(cache: IdentCache, conf: ConfigRef) =
-  var ast = parseFile(conf.projectMainIdx, cache, conf)
-  if ast == nil: return
-  var d = newDocumentor(conf.projectFull, cache, conf)
-  d.onTestSnippet = proc (d: var RstGenerator; filename, cmd: string;
-                          status: int; content: string) =
-    localError(conf, newLineInfo(conf, AbsoluteFile d.filename, -1, -1),
-               warnUser, "the ':test:' attribute is not supported by this backend")
-  d.hasToc = true
-  var
-    content: Rope
-  generateTags(d, ast, content)
-
-  if optStdout in d.conf.globalOptions:
-    writeRope(stdout, content)
-  else:
-    #echo getOutFile(gProjectFull, TagsExt)
-    let filename = getOutFile(conf, RelativeFile conf.projectName, TagsExt)
-    if not writeRope(content, filename):
-      rawMessage(conf, errCannotOpenFile, filename.string)
-
 proc commandBuildIndex*(cache: IdentCache, conf: ConfigRef) =
   var content = mergeIndexes(conf.projectFull.string).rope
 

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -236,15 +236,6 @@ proc mainCommand*(graph: ModuleGraph) =
       wantMainModule(conf)
       defineSymbol(conf.symbols, "nimdoc")
       commandDoc2(graph, true)
-  of "ctags":
-    when defined(leanCompiler):
-      quit "compiler wasn't built with documentation generator"
-    else:
-      wantMainModule(conf)
-      conf.cmd = cmdDoc
-      loadConfigs(DocConfig, cache, conf)
-      defineSymbol(conf.symbols, "nimdoc")
-      commandTags(cache, conf)
   of "buildindex":
     when defined(leanCompiler):
       quit "compiler wasn't built with documentation generator"

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -7,7 +7,6 @@ Advanced commands:
   //rst2html                convert a reStructuredText file to HTML
   //rst2tex                 convert a reStructuredText file to TeX
   //jsondoc                 extract the documentation to a json file
-  //ctags                   create a tags file
   //buildIndex              build an index for the whole documentation
   //run                     run the project (with Tiny C backend; buggy!)
   //genDepend               generate a DOT file containing the


### PR DESCRIPTION
It's useless and now we have `nimfind` tool.