### PR TITLE
gens: match ast handle to node kind name better

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -671,7 +671,7 @@ proc isCppRef(p: BProc; typ: PType): bool {.inline.} =
       skipTypes(typ, abstractInst).kind == tyVar and
       tfVarIsPtr notin skipTypes(typ, abstractInst).flags
 
-proc genDeref(p: BProc, e: PNode, d: var TLoc; enforceDeref=false) =
+proc generateDeref(p: BProc, e: PNode, d: var TLoc; enforceDeref=false) =
   let mt = mapType(p.config, e.sons[0].typ)
   if mt in {ctArray, ctPtrToArray} and not enforceDeref:
     # XXX the amount of hacks for C's arrays is incredible, maybe we should
@@ -708,7 +708,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc; enforceDeref=false) =
       of tyPtr:
         d.storage = OnUnknown         # BUGFIX!
       else:
-        internalError(p.config, e.info, "genDeref " & $typ.kind)
+        internalError(p.config, e.info, "generateDeref " & $typ.kind)
     elif p.module.compileToCpp:
       if typ.kind == tyVar and tfVarIsPtr notin typ.flags and
            e.kind == nkHiddenDeref:
@@ -724,7 +724,7 @@ proc genDeref(p: BProc, e: PNode, d: var TLoc; enforceDeref=false) =
     else:
       putIntoDest(p, d, e, "(*$1)" % [rdLoc(a)], a.storage)
 
-proc genAddr(p: BProc, e: PNode, d: var TLoc) =
+proc generateAddr(p: BProc, e: PNode, d: var TLoc) =
   # careful  'addr(myptrToArray)' needs to get the ampersand:
   if e.sons[0].typ.skipTypes(abstractInst).kind in {tyRef, tyPtr}:
     var a: TLoc
@@ -776,7 +776,7 @@ proc lookupFieldAgain(p: BProc, ty: PType; field: PSym; r: var Rope;
       break
     if not p.module.compileToCpp: add(r, ".Sup")
     ty = ty.sons[0]
-  if result == nil: internalError(p.config, field.info, "genCheckedRecordField")
+  if result == nil: internalError(p.config, field.info, "generateCheckedFieldExpr")
 
 proc genRecordField(p: BProc, e: PNode, d: var TLoc) =
   var a: TLoc
@@ -829,7 +829,7 @@ proc genFieldCheck(p: BProc, e: PNode, obj: Rope, field: PSym) =
               "if (!($1)) #raiseFieldError($2);$n",
               rdLoc(test), genStringLiteralFromData(p.module, strLit, e.info))
 
-proc genCheckedRecordField(p: BProc, e: PNode, d: var TLoc) =
+proc generateCheckedFieldExpr(p: BProc, e: PNode, d: var TLoc) =
   if optFieldCheck in p.options:
     var a: TLoc
     genRecordFieldAux(p, e.sons[0], d, a)
@@ -839,7 +839,7 @@ proc genCheckedRecordField(p: BProc, e: PNode, d: var TLoc) =
     let field = lookupFieldAgain(p, ty, f, r)
     if field.loc.r == nil: fillObjectFields(p.module, ty)
     if field.loc.r == nil:
-      internalError(p.config, e.info, "genCheckedRecordField") # generate the checks:
+      internalError(p.config, e.info, "generateCheckedFieldExpr") # generate the checks:
     genFieldCheck(p, e, r, field)
     add(r, ropecg(p.module, ".$1", field.loc.r))
     putIntoDest(p, d, e.sons[0], r, a.storage)
@@ -943,7 +943,7 @@ proc genSeqElem(p: BProc, n, x, y: PNode, d: var TLoc) =
   putIntoDest(p, d, n,
               ropecg(p.module, "$1$3[$2]", rdLoc(a), rdCharLoc(b), dataField(p)), a.storage)
 
-proc genBracketExpr(p: BProc; n: PNode; d: var TLoc) =
+proc generateBracketExpr(p: BProc; n: PNode; d: var TLoc) =
   var ty = skipTypes(n.sons[0].typ, abstractVarRange + tyUserTypeClasses)
   if ty.kind in {tyRef, tyPtr}: ty = skipTypes(ty.lastSon, abstractVarRange)
   case ty.kind
@@ -1279,7 +1279,7 @@ proc handleConstExpr(p: BProc, n: PNode, d: var TLoc): bool =
   else:
     result = false
 
-proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
+proc generateObjConstr(p: BProc, e: PNode, d: var TLoc) =
   #echo rendertree e, " ", e.isDeepConstExpr
   # inheritance in C++ does not allow struct initialization so
   # we skip this step here:
@@ -1317,7 +1317,7 @@ proc genObjConstr(p: BProc, e: PNode, d: var TLoc) =
     tmp2.r = r
     let field = lookupFieldAgain(p, ty, it.sons[0].sym, tmp2.r)
     if field.loc.r == nil: fillObjectFields(p.module, ty)
-    if field.loc.r == nil: internalError(p.config, e.info, "genObjConstr")
+    if field.loc.r == nil: internalError(p.config, e.info, "generateObjConstr")
     if it.len == 3 and optFieldCheck in p.options:
       genFieldCheck(p, it.sons[2], r, field)
     add(tmp2.r, ".")
@@ -1812,7 +1812,7 @@ proc genSomeCast(p: BProc, e: PNode, d: var TLoc) =
       putIntoDest(p, d, e, "(($1) ($2))" %
           [getTypeDesc(p.module, e.typ), rdCharLoc(a)], a.storage)
 
-proc genCast(p: BProc, e: PNode, d: var TLoc) =
+proc generateCast(p: BProc, e: PNode, d: var TLoc) =
   const ValueTypes = {tyFloat..tyFloat128, tyTuple, tyObject, tyArray}
   let
     destt = skipTypes(e.typ, abstractRange)
@@ -1836,7 +1836,7 @@ proc genCast(p: BProc, e: PNode, d: var TLoc) =
     # C code; plus it's the right thing to do for closures:
     genSomeCast(p, e, d)
 
-proc genRangeChck(p: BProc, n: PNode, d: var TLoc, magic: string) =
+proc generateChckRange(p: BProc, n: PNode, d: var TLoc, magic: string) =
   var a: TLoc
   var dest = skipTypes(n.typ, abstractVar)
   # range checks for unsigned turned out to be buggy and annoying:
@@ -1852,7 +1852,7 @@ proc genRangeChck(p: BProc, n: PNode, d: var TLoc, magic: string) =
         genLiteral(p, n.sons[1], dest), genLiteral(p, n.sons[2], dest),
         rope(magic)]), a.storage)
 
-proc genConv(p: BProc, e: PNode, d: var TLoc) =
+proc generateConv(p: BProc, e: PNode, d: var TLoc) =
   let destType = e.typ.skipTypes({tyVar, tyLent, tyGenericInst, tyAlias, tySink})
   if sameBackendType(destType, e.sons[1].typ):
     expr(p, e.sons[1], d)
@@ -2130,7 +2130,7 @@ proc isConstClosure(n: PNode): bool {.inline.} =
   result = n.sons[0].kind == nkSym and isRoutine(n.sons[0].sym) and
       n.sons[1].kind == nkNilLit
 
-proc genClosure(p: BProc, n: PNode, d: var TLoc) =
+proc generateClosure(p: BProc, n: PNode, d: var TLoc) =
   assert n.kind in {nkPar, nkTupleConstr, nkClosure}
 
   if isConstClosure(n):
@@ -2170,7 +2170,7 @@ proc genComplexConst(p: BProc, sym: PSym, d: var TLoc) =
   assert((sym.loc.r != nil) and (sym.loc.t != nil))
   putLocIntoDest(p, d, sym.loc)
 
-template genStmtListExprImpl(exprOrStmt) {.dirty.} =
+template genStmtListExpr(exprOrStmt) {.dirty.} =
   #let hasNimFrame = magicsys.getCompilerProc("nimFrame") != nil
   let hasNimFrame = p.prc != nil and
       sfSystemModule notin p.module.module.flags and
@@ -2192,12 +2192,12 @@ template genStmtListExprImpl(exprOrStmt) {.dirty.} =
   if frameName != nil:
     add p.s(cpsStmts), deinitFrameNoDebug(p, frameName)
 
-proc genStmtListExpr(p: BProc, n: PNode, d: var TLoc) =
-  genStmtListExprImpl:
+proc generateStmtListExpr(p: BProc, n: PNode, d: var TLoc) =
+  genStmtListExpr:
     expr(p, n[n.len - 1], d)
 
-proc genStmtList(p: BProc, n: PNode) =
-  genStmtListExprImpl:
+proc generateStmtList(p: BProc, n: PNode) =
+  genStmtListExpr:
     genStmts(p, n[n.len - 1])
 
 proc upConv(p: BProc, n: PNode, d: var TLoc) =
@@ -2288,200 +2288,237 @@ proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
     if t.kind notin {tySequence, tyString}:
       d.storage = OnStatic
 
-proc expr(p: BProc, n: PNode, d: var TLoc) =
-  p.currLineInfo = n.info
-  case n.kind
-  of nkSym:
-    var sym = n.sym
-    case sym.kind
-    of skMethod:
-      if {sfDispatcher, sfForward} * sym.flags != {}:
-        # we cannot produce code for the dispatcher yet:
-        fillProcLoc(p.module, n)
-        genProcPrototype(p.module, sym)
-      else:
-        genProc(p.module, sym)
-      putLocIntoDest(p, d, sym.loc)
-    of skProc, skConverter, skIterator, skFunc:
-      #if sym.kind == skIterator:
-      #  echo renderTree(sym.getBody, {renderIds})
-      if sfCompileTime in sym.flags:
-        localError(p.config, n.info, "request to generate code for .compileTime proc: " &
-           sym.name.s)
+proc generateSym(p: BProc, n: PNode, d: var TLoc) =
+  var sym = n.sym
+  case sym.kind
+  of skMethod:
+    if {sfDispatcher, sfForward} * sym.flags != {}:
+      # we cannot produce code for the dispatcher yet:
+      fillProcLoc(p.module, n)
+      genProcPrototype(p.module, sym)
+    else:
       genProc(p.module, sym)
-      if sym.loc.r == nil or sym.loc.lode == nil:
-        internalError(p.config, n.info, "expr: proc not init " & sym.name.s)
-      putLocIntoDest(p, d, sym.loc)
-    of skConst:
-      if isSimpleConst(sym.typ):
-        putIntoDest(p, d, n, genLiteral(p, sym.ast, sym.typ), OnStatic)
-      else:
-        genComplexConst(p, sym, d)
-    of skEnumField:
-      # we never reach this case - as of the time of this comment,
-      # skEnumField is folded to an int in semfold.nim, but this code
-      # remains for robustness
-      putIntoDest(p, d, n, rope(sym.position))
-    of skVar, skForVar, skResult, skLet:
-      if {sfGlobal, sfThread} * sym.flags != {}:
-        genVarPrototype(p.module, n)
-      if sym.loc.r == nil or sym.loc.t == nil:
-        #echo "FAILED FOR PRCO ", p.prc.name.s
-        #echo renderTree(p.prc.ast, {renderIds})
-        internalError p.config, n.info, "expr: var not init " & sym.name.s & "_" & $sym.id
-      if sfThread in sym.flags:
-        accessThreadLocalVar(p, sym)
-        if emulatedThreadVars(p.config):
-          putIntoDest(p, d, sym.loc.lode, "NimTV_->" & sym.loc.r)
-        else:
-          putLocIntoDest(p, d, sym.loc)
-      else:
-        putLocIntoDest(p, d, sym.loc)
-    of skTemp:
-      if sym.loc.r == nil or sym.loc.t == nil:
-        #echo "FAILED FOR PRCO ", p.prc.name.s
-        #echo renderTree(p.prc.ast, {renderIds})
-        internalError(p.config, n.info, "expr: temp not init " & sym.name.s & "_" & $sym.id)
-      putLocIntoDest(p, d, sym.loc)
-    of skParam:
-      if sym.loc.r == nil or sym.loc.t == nil:
-        # echo "FAILED FOR PRCO ", p.prc.name.s
-        # debug p.prc.typ.n
-        # echo renderTree(p.prc.ast, {renderIds})
-        internalError(p.config, n.info, "expr: param not init " & sym.name.s & "_" & $sym.id)
-      putLocIntoDest(p, d, sym.loc)
-    else: internalError(p.config, n.info, "expr(" & $sym.kind & "); unknown symbol")
-  of nkNilLit:
-    if not isEmptyType(n.typ):
-      putIntoDest(p, d, n, genLiteral(p, n))
-  of nkStrLit..nkTripleStrLit:
-    putDataIntoDest(p, d, n, genLiteral(p, n))
-  of nkIntLit..nkUInt64Lit,
-     nkFloatLit..nkFloat128Lit, nkCharLit:
-    putIntoDest(p, d, n, genLiteral(p, n))
-  of nkCall, nkHiddenCallConv, nkInfix, nkPrefix, nkPostfix, nkCommand,
-     nkCallStrLit:
-    genLineDir(p, n)
-    let op = n.sons[0]
-    if n.typ.isNil:
-      # discard the value:
-      var a: TLoc
-      if op.kind == nkSym and op.sym.magic != mNone:
-        genMagicExpr(p, n, a, op.sym.magic)
-      else:
-        genCall(p, n, a)
-    else:
-      # load it into 'd':
-      if op.kind == nkSym and op.sym.magic != mNone:
-        genMagicExpr(p, n, d, op.sym.magic)
-      else:
-        genCall(p, n, d)
-  of nkCurly:
-    if isDeepConstExpr(n) and n.len != 0:
-      putIntoDest(p, d, n, genSetNode(p, n))
-    else:
-      genSetConstr(p, n, d)
-  of nkBracket:
-    if isDeepConstExpr(n) and n.len != 0:
-      exprComplexConst(p, n, d)
-    elif skipTypes(n.typ, abstractVarRange).kind == tySequence:
-      genSeqConstr(p, n, d)
-    else:
-      genArrayConstr(p, n, d)
-  of nkPar, nkTupleConstr:
-    if n.typ != nil and n.typ.kind == tyProc and n.len == 2:
-      genClosure(p, n, d)
-    elif isDeepConstExpr(n) and n.len != 0:
-      exprComplexConst(p, n, d)
-    else:
-      genTupleConstr(p, n, d)
-  of nkObjConstr: genObjConstr(p, n, d)
-  of nkCast: genCast(p, n, d)
-  of nkHiddenStdConv, nkHiddenSubConv, nkConv: genConv(p, n, d)
-  of nkHiddenAddr, nkAddr: genAddr(p, n, d)
-  of nkBracketExpr: genBracketExpr(p, n, d)
-  of nkDerefExpr, nkHiddenDeref: genDeref(p, n, d)
-  of nkDotExpr: genRecordField(p, n, d)
-  of nkCheckedFieldExpr: genCheckedRecordField(p, n, d)
-  of nkBlockExpr, nkBlockStmt: genBlock(p, n, d)
-  of nkStmtListExpr: genStmtListExpr(p, n, d)
-  of nkStmtList: genStmtList(p, n)
-  of nkIfExpr, nkIfStmt: genIf(p, n, d)
-  of nkWhen:
-    # This should be a "when nimvm" node.
-    expr(p, n.sons[1].sons[0], d)
-  of nkObjDownConv: downConv(p, n, d)
-  of nkObjUpConv: upConv(p, n, d)
-  of nkChckRangeF: genRangeChck(p, n, d, "chckRangeF")
-  of nkChckRange64: genRangeChck(p, n, d, "chckRange64")
-  of nkChckRange: genRangeChck(p, n, d, "chckRange")
-  of nkStringToCString: convStrToCStr(p, n, d)
-  of nkCStringToString: convCStrToStr(p, n, d)
-  of nkLambdaKinds:
-    var sym = n.sons[namePos].sym
+    putLocIntoDest(p, d, sym.loc)
+  of skProc, skConverter, skIterator, skFunc:
+    #if sym.kind == skIterator:
+    #  echo renderTree(sym.getBody, {renderIds})
+    if sfCompileTime in sym.flags:
+      localError(p.config, n.info, "request to generate code for .compileTime proc: " &
+          sym.name.s)
     genProc(p.module, sym)
     if sym.loc.r == nil or sym.loc.lode == nil:
       internalError(p.config, n.info, "expr: proc not init " & sym.name.s)
     putLocIntoDest(p, d, sym.loc)
-  of nkClosure: genClosure(p, n, d)
+  of skConst:
+    if isSimpleConst(sym.typ):
+      putIntoDest(p, d, n, genLiteral(p, sym.ast, sym.typ), OnStatic)
+    else:
+      genComplexConst(p, sym, d)
+  of skEnumField:
+    # we never reach this case - as of the time of this comment,
+    # skEnumField is folded to an int in semfold.nim, but this code
+    # remains for robustness
+    putIntoDest(p, d, n, rope(sym.position))
+  of skVar, skForVar, skResult, skLet:
+    if {sfGlobal, sfThread} * sym.flags != {}:
+      genVarPrototype(p.module, n)
+    if sym.loc.r == nil or sym.loc.t == nil:
+      #echo "FAILED FOR PRCO ", p.prc.name.s
+      #echo renderTree(p.prc.ast, {renderIds})
+      internalError p.config, n.info, "expr: var not init " & sym.name.s & "_" & $sym.id
+    if sfThread in sym.flags:
+      accessThreadLocalVar(p, sym)
+      if emulatedThreadVars(p.config):
+        putIntoDest(p, d, sym.loc.lode, "NimTV_->" & sym.loc.r)
+      else:
+        putLocIntoDest(p, d, sym.loc)
+    else:
+      putLocIntoDest(p, d, sym.loc)
+  of skTemp:
+    if sym.loc.r == nil or sym.loc.t == nil:
+      #echo "FAILED FOR PRCO ", p.prc.name.s
+      #echo renderTree(p.prc.ast, {renderIds})
+      internalError(p.config, n.info, "expr: temp not init " & sym.name.s & "_" & $sym.id)
+    putLocIntoDest(p, d, sym.loc)
+  of skParam:
+    if sym.loc.r == nil or sym.loc.t == nil:
+      # echo "FAILED FOR PRCO ", p.prc.name.s
+      # debug p.prc.typ.n
+      # echo renderTree(p.prc.ast, {renderIds})
+      internalError(p.config, n.info, "expr: param not init " & sym.name.s & "_" & $sym.id)
+    putLocIntoDest(p, d, sym.loc)
+  else: internalError(p.config, n.info, "expr(" & $sym.kind & "); unknown symbol")
 
+proc generateNilLit(p: BProc, n: PNode, d: var TLoc) =
+  if not isEmptyType(n.typ):
+    putIntoDest(p, d, n, genLiteral(p, n))
+
+proc generateCall(p: BProc, n: PNode, d: var TLoc) =
+  genLineDir(p, n)
+  let op = n.sons[0]
+  if n.typ.isNil:
+    # discard the value:
+    var a: TLoc
+    if op.kind == nkSym and op.sym.magic != mNone:
+      genMagicExpr(p, n, a, op.sym.magic)
+    else:
+      genCall(p, n, a)
+  else:
+    # load it into 'd':
+    if op.kind == nkSym and op.sym.magic != mNone:
+      genMagicExpr(p, n, d, op.sym.magic)
+    else:
+      genCall(p, n, d)
+
+proc generateCurly(p: BProc, n: PNode, d: var TLoc) =
+  if isDeepConstExpr(n) and n.len != 0:
+    putIntoDest(p, d, n, genSetNode(p, n))
+  else:
+    genSetConstr(p, n, d)
+
+proc generateBracket(p: BProc, n: PNode, d: var TLoc) =
+  if isDeepConstExpr(n) and n.len != 0:
+    exprComplexConst(p, n, d)
+  elif skipTypes(n.typ, abstractVarRange).kind == tySequence:
+    genSeqConstr(p, n, d)
+  else:
+    genArrayConstr(p, n, d)
+
+proc generatePar(p: BProc, n: PNode, d: var TLoc) =
+  if n.typ != nil and n.typ.kind == tyProc and n.len == 2:
+    generateClosure(p, n, d)
+  elif isDeepConstExpr(n) and n.len != 0:
+    exprComplexConst(p, n, d)
+  else:
+    genTupleConstr(p, n, d)
+
+proc generateTupleConstr(p: BProc, n: PNode, d: var TLoc) =
+  generatePar(p, n, d)
+
+proc generateLit(p: BProc, n: PNode, d: var TLoc) =
+  putDataIntoDest(p, d, n, genLiteral(p, n))
+
+proc generateDotExpr(p: BProc, n: PNode, d: var TLoc) =
+  genRecordField(p, n, d)
+
+proc generateObjDownConv(p: BProc, n: PNode, d: var TLoc) =
+  downConv(p, n, d)
+
+proc generateObjUpConv(p: BProc, n: PNode, d: var TLoc) =
+  upConv(p, n, d)
+
+proc generateLambda(p: BProc, n: PNode, d: var TLoc) =
+  var sym = n.sons[namePos].sym
+  genProc(p.module, sym)
+  if sym.loc.r == nil or sym.loc.lode == nil:
+    internalError(p.config, n.info, "expr: proc not init " & sym.name.s)
+  putLocIntoDest(p, d, sym.loc)
+
+proc generateAsgn(p: BProc, n: PNode, d: var TLoc) =
+  if nfPreventCg notin n.flags:
+    genAsgn(p, n, fastAsgn=false)
+
+proc generateFastAsgn(p: BProc, n: PNode, d: var TLoc) =
+  if nfPreventCg notin n.flags:
+    # transf is overly aggressive with 'nkFastAsgn', so we work around here.
+    # See tests/run/tcnstseq3 for an example that would fail otherwise.
+    genAsgn(p, n, fastAsgn=p.prc != nil)
+
+proc generateDiscardStmt(p: BProc, n: PNode, d: var TLoc) =
+  let ex = n[0]
+  if ex.kind != nkEmpty:
+    genLineDir(p, n)
+    var a: TLoc
+    initLocExprSingleUse(p, ex, a)
+    line(p, cpsStmts, "(void)(" & a.r & ");\L")
+
+proc generateTryStmt(p: BProc, n: PNode, d: var TLoc) =
+  if p.module.compileToCpp and optNoCppExceptions notin p.config.globalOptions:
+    genTryCpp(p, n, d)
+  else:
+    genTry(p, n, d)
+
+proc generateProcDef(p: BProc, n: PNode, d: var TLoc) =
+  if n.sons[genericParamsPos].kind == nkEmpty:
+    var prc = n.sons[namePos].sym
+    # due to a bug/limitation in the lambda lifting, unused inner procs
+    # are not transformed correctly. We work around this issue (#411) here
+    # by ensuring it's no inner proc (owner is a module):
+    if prc.skipGenericOwner.kind == skModule and sfCompileTime notin prc.flags:
+      if ({sfExportc, sfCompilerProc} * prc.flags == {sfExportc}) or
+          (sfExportc in prc.flags and lfExportLib in prc.loc.flags) or
+          (prc.kind == skMethod):
+        # we have not only the header:
+        if prc.getBody.kind != nkEmpty or lfDynamicLib in prc.loc.flags:
+          genProc(p.module, prc)
+
+proc expr(p: BProc, n: PNode, d: var TLoc) =
+  p.currLineInfo = n.info
+  case n.kind
+  of nkSym: generateSym(p, n, d)
+  of nkNilLit: generateNilLit(p, n, d)
+  of nkStrLit..nkTripleStrLit: generateLit(p, n, d)
+  of nkIntLit..nkUInt64Lit,
+     nkFloatLit..nkFloat128Lit, nkCharLit: generateLit(p, n, d)
+  of nkCall, nkHiddenCallConv, nkInfix, nkPrefix, nkPostfix, nkCommand,
+     nkCallStrLit: generateCall(p, n, d)
+  of nkCurly: generateCurly(p, n, d)
+  of nkBracket: generateBracket(p, n, d)
+  of nkPar: generatePar(p, n, d)
+  of nkTupleConstr: generateTupleConstr(p, n, d)
+  of nkObjConstr: generateObjConstr(p, n, d)
+  of nkCast: generateCast(p, n, d)
+  of nkHiddenStdConv, nkHiddenSubConv, nkConv: generateConv(p, n, d)
+  of nkHiddenAddr, nkAddr: generateAddr(p, n, d)
+  of nkBracketExpr: generateBracketExpr(p, n, d)
+  of nkDerefExpr, nkHiddenDeref: generateDeref(p, n, d)
+  of nkDotExpr: generateDotExpr(p, n, d)
+  of nkCheckedFieldExpr: generateCheckedFieldExpr(p, n, d)
+  of nkBlockExpr, nkBlockStmt: generateBlock(p, n, d)
+  of nkStmtListExpr: generateStmtListExpr(p, n, d)
+  of nkStmtList: generateStmtList(p, n)
+  of nkIfExpr, nkIfStmt: generateIf(p, n, d)
+  of nkWhen:
+    # This should be a "when nimvm" node.
+    expr(p, n.sons[1].sons[0], d)
+  of nkObjDownConv: generateObjDownConv(p, n, d)
+  of nkObjUpConv: generateObjUpConv(p, n, d)
+  of nkChckRangeF: generateChckRange(p, n, d, "chckRangeF")
+  of nkChckRange64: generateChckRange(p, n, d, "chckRange64")
+  of nkChckRange: generateChckRange(p, n, d, "chckRange")
+  of nkStringToCString: convStrToCStr(p, n, d)
+  of nkCStringToString: convCStrToStr(p, n, d)
+  of nkLambdaKinds: generateLambda(p, n, d)
+  of nkClosure: generateClosure(p, n, d)
   of nkEmpty: discard
-  of nkWhileStmt: genWhileStmt(p, n)
+  of nkWhileStmt: generateWhileStmt(p, n)
   of nkVarSection, nkLetSection: genVarStmt(p, n)
   of nkConstSection: discard  # consts generated lazily on use
   of nkForStmt: internalError(p.config, n.info, "for statement not eliminated")
-  of nkCaseStmt: genCase(p, n, d)
-  of nkReturnStmt: genReturnStmt(p, n)
-  of nkBreakStmt: genBreakStmt(p, n)
-  of nkAsgn:
-    if nfPreventCg notin n.flags:
-      genAsgn(p, n, fastAsgn=false)
-  of nkFastAsgn:
-    if nfPreventCg notin n.flags:
-      # transf is overly aggressive with 'nkFastAsgn', so we work around here.
-      # See tests/run/tcnstseq3 for an example that would fail otherwise.
-      genAsgn(p, n, fastAsgn=p.prc != nil)
-  of nkDiscardStmt:
-    let ex = n[0]
-    if ex.kind != nkEmpty:
-      genLineDir(p, n)
-      var a: TLoc
-      initLocExprSingleUse(p, ex, a)
-      line(p, cpsStmts, "(void)(" & a.r & ");\L")
-  of nkAsmStmt: genAsmStmt(p, n)
-  of nkTryStmt:
-    if p.module.compileToCpp and optNoCppExceptions notin p.config.globalOptions:
-      genTryCpp(p, n, d)
-    else:
-      genTry(p, n, d)
-  of nkRaiseStmt: genRaiseStmt(p, n)
+  of nkCaseStmt: generateCaseStmt(p, n, d)
+  of nkReturnStmt: generateReturnStmt(p, n)
+  of nkBreakStmt: generateBreakStmt(p, n)
+  of nkAsgn: generateAsgn(p, n, d)
+  of nkFastAsgn: generateFastAsgn(p, n, d)
+  of nkDiscardStmt: generateDiscardStmt(p, n, d)
+  of nkAsmStmt: generateAsmStmt(p, n)
+  of nkTryStmt: generateTryStmt(p, n, d)
+  of nkRaiseStmt: generateRaiseStmt(p, n)
   of nkTypeSection:
     # we have to emit the type information for object types here to support
     # separate compilation:
-    genTypeSection(p.module, n)
+    generateTypeSection(p.module, n)
   of nkCommentStmt, nkIteratorDef, nkIncludeStmt,
      nkImportStmt, nkImportExceptStmt, nkExportStmt, nkExportExceptStmt,
      nkFromStmt, nkTemplateDef, nkMacroDef, nkStaticStmt:
     discard
-  of nkPragma: genPragma(p, n)
+  of nkPragma: generatePragma(p, n)
   of nkPragmaBlock: expr(p, n.lastSon, d)
-  of nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef:
-    if n.sons[genericParamsPos].kind == nkEmpty:
-      var prc = n.sons[namePos].sym
-      # due to a bug/limitation in the lambda lifting, unused inner procs
-      # are not transformed correctly. We work around this issue (#411) here
-      # by ensuring it's no inner proc (owner is a module):
-      if prc.skipGenericOwner.kind == skModule and sfCompileTime notin prc.flags:
-        if ({sfExportc, sfCompilerProc} * prc.flags == {sfExportc}) or
-            (sfExportc in prc.flags and lfExportLib in prc.loc.flags) or
-            (prc.kind == skMethod):
-          # we have not only the header:
-          if prc.getBody.kind != nkEmpty or lfDynamicLib in prc.loc.flags:
-            genProc(p.module, prc)
-  of nkParForStmt: genParForStmt(p, n)
-  of nkState: genState(p, n)
-  of nkGotoState: genGotoState(p, n)
-  of nkBreakState: genBreakState(p, n, d)
+  of nkProcDef, nkFuncDef, nkMethodDef, nkConverterDef: generateProcDef(p, n, d)
+  of nkParForStmt: generateParForStmt(p, n)
+  of nkState: generateState(p, n)
+  of nkGotoState: generateGotoState(p, n)
+  of nkBreakState: generateBreakState(p, n, d)
   else: internalError(p.config, n.info, "expr(" & $n.kind & "); unknown node kind")
 
 proc genNamedConstExpr(p: BProc, n: PNode): Rope =

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -74,7 +74,7 @@ proc genVarTuple(p: BProc, n: PNode) =
       field.r = "$1.$2" % [rdLoc(tup), mangleRecFieldName(p.module, t.n.sons[i].sym)]
     putLocIntoDest(p, v.loc, field)
 
-proc genDeref(p: BProc, e: PNode, d: var TLoc; enforceDeref=false)
+proc generateDeref(p: BProc, e: PNode, d: var TLoc; enforceDeref=false)
 
 proc loadInto(p: BProc, le, ri: PNode, a: var TLoc) {.inline.} =
   if ri.kind in nkCallKinds and (ri.sons[0].kind != nkSym or
@@ -88,7 +88,7 @@ proc loadInto(p: BProc, le, ri: PNode, a: var TLoc) {.inline.} =
     # However, fixing this properly really requires modelling 'array' as
     # a 'struct' in C to preserve dereferencing semantics completely. Not
     # worth the effort until version 1.0 is out.
-    genDeref(p, ri, a, enforceDeref=true)
+    generateDeref(p, ri, a, enforceDeref=true)
   else:
     expr(p, ri, a)
 
@@ -148,7 +148,7 @@ template preserveBreakIdx(body: untyped): untyped =
   body
   p.breakIdx = oldBreakIdx
 
-proc genState(p: BProc, n: PNode) =
+proc generateState(p: BProc, n: PNode) =
   internalAssert p.config, n.len == 1
   let n0 = n[0]
   if n0.kind == nkIntLit:
@@ -190,7 +190,7 @@ proc blockLeaveActions(p: BProc, howManyTrys, howManyExcepts: int) =
     for i in countdown(howManyExcepts-1, 0):
       linefmt(p, cpsStmts, "#popCurrentException();$n")
 
-proc genGotoState(p: BProc, n: PNode) =
+proc generateGotoState(p: BProc, n: PNode) =
   # we resist the temptation to translate it into duff's device as it later
   # will be translated into computed gotos anyway for GCC at least:
   # switch (x.state) {
@@ -214,7 +214,7 @@ proc genGotoState(p: BProc, n: PNode) =
     lineF(p, cpsStmts, "case $2: goto $1$2;$n", [prefix, rope(i)])
   lineF(p, cpsStmts, "}$n", [])
 
-proc genBreakState(p: BProc, n: PNode, d: var TLoc) =
+proc generateBreakState(p: BProc, n: PNode, d: var TLoc) =
   var a: TLoc
   initLoc(d, locExpr, n, OnUnknown)
 
@@ -327,7 +327,7 @@ proc genVarStmt(p: BProc, n: PNode) =
     else:
       genVarTuple(p, it)
 
-proc genIf(p: BProc, n: PNode, d: var TLoc) =
+proc generateIf(p: BProc, n: PNode, d: var TLoc) =
   #
   #  { if (!expr1) goto L1;
   #   thenPart }
@@ -371,10 +371,10 @@ proc genIf(p: BProc, n: PNode, d: var TLoc) =
       startBlock(p)
       expr(p, it.sons[0], d)
       endBlock(p)
-    else: internalError(p.config, n.info, "genIf()")
+    else: internalError(p.config, n.info, "generateIf()")
   if sonsLen(n) > 1: fixLabel(p, lend)
 
-proc genReturnStmt(p: BProc, t: PNode) =
+proc generateReturnStmt(p: BProc, t: PNode) =
   if nfPreventCg in t.flags: return
   p.beforeRetNeeded = true
   genLineDir(p, t)
@@ -495,7 +495,7 @@ proc genComputedGoto(p: BProc; n: PNode) =
     genStmts(p, n.sons[j])
 
 
-proc genWhileStmt(p: BProc, t: PNode) =
+proc generateWhileStmt(p: BProc, t: PNode) =
   # we don't generate labels here as for example GCC would produce
   # significantly worse code
   var
@@ -528,7 +528,7 @@ proc genWhileStmt(p: BProc, t: PNode) =
 
   dec(p.withinLoop)
 
-proc genBlock(p: BProc, n: PNode, d: var TLoc) =
+proc generateBlock(p: BProc, n: PNode, d: var TLoc) =
   # bug #4505: allocate the temp in the outer scope
   # so that it can escape the generated {}:
   if not isEmptyType(n.typ) and d.k == locNone:
@@ -544,7 +544,7 @@ proc genBlock(p: BProc, n: PNode, d: var TLoc) =
     expr(p, n.sons[1], d)
     endBlock(p)
 
-proc genParForStmt(p: BProc, t: PNode) =
+proc generateParForStmt(p: BProc, t: PNode) =
   assert(sonsLen(t) == 3)
   inc(p.withinLoop)
   genLineDir(p, t)
@@ -572,7 +572,7 @@ proc genParForStmt(p: BProc, t: PNode) =
 
   dec(p.withinLoop)
 
-proc genBreakStmt(p: BProc, t: PNode) =
+proc generateBreakStmt(p: BProc, t: PNode) =
   var idx = p.breakIdx
   if t.sons[0].kind != nkEmpty:
     # named break?
@@ -592,7 +592,7 @@ proc genBreakStmt(p: BProc, t: PNode) =
   genLineDir(p, t)
   lineF(p, cpsStmts, "goto $1;$n", [label])
 
-proc genRaiseStmt(p: BProc, t: PNode) =
+proc generateRaiseStmt(p: BProc, t: PNode) =
   if p.module.compileToCpp:
     discard cgsym(p.module, "popCurrentExceptionEx")
   if p.nestedTryStmts.len > 0 and p.nestedTryStmts[^1].inExcept:
@@ -652,7 +652,7 @@ proc genCaseSecondPass(p: BProc, t: PNode, d: var TLoc,
       exprBlock(p, t.sons[i].sons[0], d)
   result = lend
 
-proc genIfForCaseUntil(p: BProc, t: PNode, d: var TLoc,
+proc generateIfForCaseUntil(p: BProc, t: PNode, d: var TLoc,
                        rangeFormat, eqFormat: FormatStr,
                        until: int, a: TLoc): TLabel =
   # generate a C-if statement for a Nim case statement
@@ -677,7 +677,7 @@ proc genCaseGeneric(p: BProc, t: PNode, d: var TLoc,
                     rangeFormat, eqFormat: FormatStr) =
   var a: TLoc
   initLocExpr(p, t.sons[0], a)
-  var lend = genIfForCaseUntil(p, t, d, rangeFormat, eqFormat, sonsLen(t)-1, a)
+  var lend = generateIfForCaseUntil(p, t, d, rangeFormat, eqFormat, sonsLen(t)-1, a)
   fixLabel(p, lend)
 
 proc genCaseStringBranch(p: BProc, b: PNode, e: TLoc, labl: TLabel,
@@ -768,7 +768,7 @@ proc genOrdinalCase(p: BProc, n: PNode, d: var TLoc) =
   # generate if part (might be empty):
   var a: TLoc
   initLocExpr(p, n.sons[0], a)
-  var lend = if splitPoint > 0: genIfForCaseUntil(p, n, d,
+  var lend = if splitPoint > 0: generateIfForCaseUntil(p, n, d,
                     rangeFormat = "if ($1 >= $2 && $1 <= $3) goto $4;$n",
                     eqFormat = "if ($1 == $2) goto $3;$n",
                     splitPoint, a) else: nil
@@ -794,7 +794,7 @@ proc genOrdinalCase(p: BProc, n: PNode, d: var TLoc) =
     lineF(p, cpsStmts, "}$n", [])
   if lend != nil: fixLabel(p, lend)
 
-proc genCase(p: BProc, t: PNode, d: var TLoc) =
+proc generateCaseStmt(p: BProc, t: PNode, d: var TLoc) =
   genLineDir(p, t)
   if not isEmptyType(t.typ) and d.k == locNone:
     getTemp(p, t.typ, d)
@@ -1029,7 +1029,7 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
     res.add("\L")
     result = res.rope
 
-proc genAsmStmt(p: BProc, t: PNode) =
+proc generateAsmStmt(p: BProc, t: PNode) =
   assert(t.kind == nkAsmStmt)
   genLineDir(p, t)
   var s = genAsmOrEmitStmt(p, t, isAsmStmt=true)
@@ -1085,7 +1085,7 @@ proc genWatchpoint(p: BProc, n: PNode) =
         [addrLoc(p.config, a), makeCString(renderTree(n.sons[1])),
         genTypeInfo(p.module, typ, n.info)])
 
-proc genPragma(p: BProc, n: PNode) =
+proc generatePragma(p: BProc, n: PNode) =
   for it in n.sons:
     case whichPragma(it)
     of wEmit: genEmit(p, it)
@@ -1167,7 +1167,7 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
     var a: TLoc
     discard getTypeDesc(p.module, le.typ.skipTypes(skipPtrs))
     if le.kind in {nkDerefExpr, nkHiddenDeref}:
-      genDeref(p, le, a, enforceDeref=true)
+      generateDeref(p, le, a, enforceDeref=true)
     else:
       initLocExpr(p, le, a)
     if fastAsgn: incl(a.flags, lfNoDeepCopy)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1240,5 +1240,5 @@ proc genTypeInfo(m: BModule, t: PType; info: TLineInfo): Rope =
     genDeepCopyProc(m, origType.deepCopy, result)
   result = "(&".rope & result & ")".rope
 
-proc genTypeSection(m: BModule, n: PNode) =
+proc generateTypeSection(m: BModule, n: PNode) =
   discard

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -13,7 +13,7 @@ import
   intsets, options, ast, astalgo, msgs, idents, renderer, types, magicsys,
   sempass2, strutils, modulegraphs, lineinfos
 
-proc genConv(n: PNode, d: PType, downcast: bool; conf: ConfigRef): PNode =
+proc generateConv(n: PNode, d: PType, downcast: bool; conf: ConfigRef): PNode =
   var dest = skipTypes(d, abstractPtrs)
   var source = skipTypes(n.typ, abstractPtrs)
   if (source.kind == tyObject) and (dest.kind == tyObject):
@@ -24,12 +24,12 @@ proc genConv(n: PNode, d: PType, downcast: bool; conf: ConfigRef): PNode =
     elif diff < 0:
       result = newNodeIT(nkObjUpConv, n.info, d)
       addSon(result, n)
-      if downcast: internalError(conf, n.info, "cgmeth.genConv: no upcast allowed")
+      if downcast: internalError(conf, n.info, "cgmeth.generateConv: no upcast allowed")
     elif diff > 0:
       result = newNodeIT(nkObjDownConv, n.info, d)
       addSon(result, n)
       if not downcast:
-        internalError(conf, n.info, "cgmeth.genConv: no downcast allowed")
+        internalError(conf, n.info, "cgmeth.generateConv: no downcast allowed")
     else:
       result = n
   else:
@@ -50,7 +50,7 @@ proc methodCall*(n: PNode; conf: ConfigRef): PNode =
     result.sons[0].sym = disp
     # change the arguments to up/downcasts to fit the dispatcher's parameters:
     for i in countup(1, sonsLen(result)-1):
-      result.sons[i] = genConv(result.sons[i], disp.typ.sons[i], true, conf)
+      result.sons[i] = generateConv(result.sons[i], disp.typ.sons[i], true, conf)
   else:
     localError(conf, n.info, "'" & $result.sons[0] & "' lacks a dispatcher")
 
@@ -262,7 +262,7 @@ proc genDispatcher(g: ModuleGraph; methods: TSymSeq, relevantCols: IntSet): PSym
     let call = newNodeIT(nkCall, base.info, retTyp)
     addSon(call, newSymNode(curr))
     for col in countup(1, paramLen - 1):
-      addSon(call, genConv(newSymNode(base.typ.n.sons[col].sym),
+      addSon(call, generateConv(newSymNode(base.typ.n.sons[col].sym),
                            curr.typ.sons[col], false, g.config))
     var ret: PNode
     if retTyp != nil:


### PR DESCRIPTION
Alternative to #9836 using `generate` (that's trivial now.. `sed s/genNode/generate/g -i *.nim`)