### PR TITLE
Added basic AF_UNIX support to asyncnet.

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -622,6 +622,59 @@ proc bindAddr*(socket: AsyncSocket, port = Port(0), address = "") {.
     raiseOSError(osLastError())
   freeAddrInfo(aiList)
 
+when defined(posix):
+
+  proc connectUnix*(socket: AsyncSocket, path: string): Future[void] =
+    ## Binds Unix socket to `path`.
+    ## This only works on Unix-style systems: Mac OS X, BSD and Linux
+    let retFuture = newFuture[void]("connectUnix")
+    result = retFuture
+
+    proc cb(fd: AsyncFD): bool =
+      let ret = SocketHandle(fd).getSockOptInt(cint(SOL_SOCKET), cint(SO_ERROR))
+      if ret == 0:
+        retFuture.complete()
+        return true
+      elif ret == EINTR:
+        return false
+      else:
+        retFuture.fail(newException(OSError, osErrorMsg(OSErrorCode(ret))))
+        return true
+
+    var socketAddr = makeUnixAddr(path)
+    let ret = socket.fd.connect(cast[ptr SockAddr](addr socketAddr),
+                     (sizeof(socketAddr.sun_family) + path.len).Socklen)
+    if ret == 0:
+      # Request to connect completed immediately.
+      retFuture.complete()
+    else:
+      let lastError = osLastError()
+      if lastError.int32 == EINTR or lastError.int32 == EINPROGRESS:
+        addWrite(AsyncFD(socket.fd), cb)
+      else:
+        retFuture.fail(newException(OSError, osErrorMsg(lastError)))
+
+  proc bindUnix*(socket: AsyncSocket, path: string)  {.
+    tags: [ReadIOEffect].} =
+    ## Binds Unix socket to `path`.
+    ## This only works on Unix-style systems: Mac OS X, BSD and Linux
+    var socketAddr = makeUnixAddr(path)
+    if socket.fd.bindAddr(cast[ptr SockAddr](addr socketAddr),
+                          (sizeof(socketAddr.sun_family) + path.len).Socklen) != 0'i32:
+      raiseOSError(osLastError())
+
+elif defined(nimdoc):
+
+  proc connectUnix*(socket: AsyncSocket, path: string): Future[void] =
+    ## Binds Unix socket to `path`.
+    ## This only works on Unix-style systems: Mac OS X, BSD and Linux
+    discard
+  
+  proc bindUnix*(socket: AsyncSocket, path: string) =
+    ## Binds Unix socket to `path`.
+    ## This only works on Unix-style systems: Mac OS X, BSD and Linux
+    discard
+
 proc close*(socket: AsyncSocket) =
   ## Closes the socket.
   defer:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -947,13 +947,6 @@ proc setSockOpt*(socket: Socket, opt: SOBool, value: bool, level = SOL_SOCKET) {
   var valuei = cint(if value: 1 else: 0)
   setSockOptInt(socket.fd, cint(level), toCInt(opt), valuei)
 
-when defined(posix) and not defined(nimdoc):
-  proc makeUnixAddr(path: string): Sockaddr_un =
-    result.sun_family = AF_UNIX.uint16
-    if path.len >= Sockaddr_un_path_length:
-      raise newException(ValueError, "socket path too long")
-    copyMem(addr result.sun_path, path.cstring, path.len + 1)
-
 when defined(posix) or defined(nimdoc):
   proc connectUnix*(socket: Socket, path: string) =
     ## Connects to Unix socket on `path`.


### PR DESCRIPTION
 Unfortunately this required some code duplication because the doConnect() from asynccommon.nim only works with addrInfo which does not make sense for AF_UNIX.

Also needed to export makeUnixAddr() from net.nim.