### PR TITLE
Make options.UnpackError inherit from system.Defect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,8 @@
 
 - `osproc.execProcess` now also takes a `workingDir` parameter.
 
+- `options.UnpackError` is no longer a ref type and inherits from `System.Defect` instead of `System.ValueError`.
+
 #### Breaking changes in the compiler
 
 - The compiler now implements the "generic symbol prepass" for `when` statements


### PR DESCRIPTION
- Removed `ref` from UnpackError
- UnpackError inherits from Defect instead of ValueError

I also removed the examples using `try/except`, since UnpackError should not be catched.

Fixes #9856