### PR TITLE
refs #9906; --errorMax:10 allows stopping after 10 errors (more robust than nim check)

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -618,10 +618,14 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectNoArg(conf, switch, arg, pass, info)
     incl(conf.globalOptions, optRun)
   of "errormax":
-    # Note: `nim check` (etc) can overwrite this;
-    # `0` is meaningless and has same effect as `1`
     expectArg(conf, switch, arg, pass, info)
-    conf.errorMax = parseInt(arg)
+    conf.errorMax = block:
+      # Note: `nim check` (etc) can overwrite this.
+      # `0` is meaningless, give it a useful meaning as in clang's -ferror-limit
+      # If user doesn't set this flag and the code doesn't either, it'd
+      # have the same effect as errorMax = 1
+      let ret = parseInt(arg)
+      if ret == 0: high(int) else: ret
   of "verbosity":
     expectArg(conf, switch, arg, pass, info)
     let verbosity = parseInt(arg)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -617,6 +617,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "run", "r":
     expectNoArg(conf, switch, arg, pass, info)
     incl(conf.globalOptions, optRun)
+  of "errormax":
+    # Note: `nim check` (etc) can overwrite this;
+    # `0` is meaningless and has same effect as `1`
+    expectArg(conf, switch, arg, pass, info)
+    conf.errorMax = parseInt(arg)
   of "verbosity":
     expectArg(conf, switch, arg, pass, info)
     let verbosity = parseInt(arg)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -103,6 +103,7 @@ Advanced options:
                             value = number of processors (0 for auto-detect)
   --incremental:on|off      only recompile the changed modules (experimental!)
   --verbosity:0|1|2|3       set Nim's verbosity level (1 is default)
+  --errorMax:int            stop after n (>=1) errors in semantic pass
   --experimental:$1
                             enable experimental language feature
   -v, --version             show detailed version information

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -103,7 +103,7 @@ Advanced options:
                             value = number of processors (0 for auto-detect)
   --incremental:on|off      only recompile the changed modules (experimental!)
   --verbosity:0|1|2|3       set Nim's verbosity level (1 is default)
-  --errorMax:int            stop after n (>=1) errors in semantic pass
+  --errorMax:int            stop after n errors in semantic pass; 0 means unlimited
   --experimental:$1
                             enable experimental language feature
   -v, --version             show detailed version information


### PR DESCRIPTION
/cc @Araq  @citycide 

* refs #9906

editor integrations (eg NimLime /cc @Varriount ) often use `nim check` to report whether input file has any errors; unfortunately `nim check` has inherent limitations (see https://github.com/nim-lang/Nim/issues/9906) in that it's limited to semantic pass and won't report some errors.
Oftentimes what user wants is just "tell me whether this file has any errors" regardless of whether it's in semantic pass or in backend, or in subsequent stages (eg linking).

This PR fixes this problem by adding a flag , eg `--errorMax:10` will stop after 10 errors instead of the usual 1 error 

## note
* the default is actually 0 but 0 is rather meaningless and 0 will have exact same effect as 1; in fact:
```
--errorMax:0 # stops after 1 error
--errorMax:1 # stops after 1 error
--errorMax:2 # stops after 2 errors and so on
```

* tools (eg nimfind etc) which reset errorMax will override user specified `--errorMax`; this was made for simplicity and because the most useful use of `--errorMax` is in code paths which doesn't modify `errorMax` from its default value (0); we can revisit this aspect in future PR if needed

* if there are any error in semantic phase, subsequent phase won't run ; this is a bit of a limitation but is probably more sane behavior

## usage
after this PR we have greater control over what errors are reported
```
nim check main.nim # report up to high(int) errors in semantic phase (will miss errors like in #9906 with array overflow)
nim c --errorMax:10 --compileOnly main.nim # report up to 10 errors in semantic+backend phase (will miss errors in `{.emit:"asdf".}`)
nim c --errorMax:10 --noLinking main.nim # report up to 10 errors in semantic+backend phase (will miss link erros)
nim c --errorMax:10 -o:/dev/null main.nim # report up to 10 errors (should catch everything)
```

so editor intergrations might choose to use something like: `nim c --errorMax:10000 -o:/dev/null main.nim` instead of `nim check`
