### PR TITLE
enhance `dump --dump.format:json` : report `out`, `hints`, `warnings`, document it ; closes #9513

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -266,11 +266,27 @@ proc mainCommand*(graph: ModuleGraph) =
       var libpaths = newJArray()
       for dir in conf.searchPaths: libpaths.elems.add(%dir.string)
 
+      var hints = block: # consider factoring with `listHints`
+        var ret = newJObject()
+        for a in hintMin..hintMax:
+          let key = lineinfos.HintsToStr[ord(a) - ord(hintMin)]
+          ret[key] = % (a in conf.notes)
+        ret
+      var warnings = block: # consider factoring with `listWarnings`
+        var ret = newJObject()
+        for a in warnMin..warnMax:
+          let key = lineinfos.WarningsToStr[ord(a) - ord(warnMin)]
+          ret[key] = % (a in conf.notes)
+        ret
+
       var dumpdata = % [
         (key: "version", val: %VersionAsString),
         (key: "project_path", val: %conf.projectFull.string),
         (key: "defined_symbols", val: definedSymbols),
-        (key: "lib_paths", val: libpaths)
+        (key: "lib_paths", val: %libpaths),
+        (key: "out", val: %conf.outFile.string),
+        (key: "hints", val: hints),
+        (key: "warnings", val: warnings),
       ]
 
       msgWriteln(conf, $dumpdata, {msgStdout, msgSkipHook})

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -13,6 +13,7 @@ Advanced commands:
   //genDepend               generate a DOT file containing the
                             module dependency graph
   //dump                    dump all defined conditionals and search paths
+                            see also: --dump.format:json (useful with: ` | jq`)
   //check                   checks the project for syntax and semantic
 
 Advanced options:


### PR DESCRIPTION
* documents `--dump.format:json`
* adds `out` to json dump, see use cases [1]
* closes https://github.com/nim-lang/Nim/issues/8196  since with this PR we have a more systematic way to access these (hints, warnings) that's both human-readable and machine-readable, via json instead of custom "cute" format in --hints:list and --warnings:list

`dump --dump.format:json` more generally is useful, because it may not always be clear what the compiler sees (eg flags can come from several config files + command line) (eg, could be useful in some bug reports)

## example usage
one can use `jq` (eg after `brew install jq`) or any other tool to access the json dump, eg:
* pretty print json dump:
`nim dump --dump.format:json main.nim|jq`

or we can postprocess the json dump from cmd line:
* show all the warnings:
`|jq '.warnings'
```js
{
  "CannotOpenFile": false,
  "OctalEscape": false,
  ...
}
```

* show `out` file (the -r is for raw output, to remove quotes):
`|jq -r '.out'`

* show all hints that are `on`:
```
`|jq -cr '.hints | to_entries[] | select(.value == true) | .key'
QuitCalled
Source
StackTrace
ExtendedContext
```

## notes
[1] eg use case for outputting out in json:
* when calling `nim c $flags` where it's not clear what the --out param is 
* once https://github.com/nim-lang/Nim/issues/9513 is implemented, `out` will be inferred by compiler instead of explicitly given so this provides a way to get that information

## links
* https://github.com/stedolan/jq/wiki/Cookbook#filter-objects-based-on-the-contents-of-a-key
* https://stedolan.github.io/jq/manual/
