### PR TITLE
Let handles be seen outside of `memfiles` module so that "updating"

### DIFF
--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -36,11 +36,26 @@ type
     size*: int       ## size of the memory mapped file
 
     when defined(windows):
-      fHandle*: Handle
-      mapHandle*: Handle
-      wasOpened*: bool   ## only close if wasOpened
+      fHandle: Handle
+      mapHandle: Handle
+      wasOpened: bool   ## only close if wasOpened
     else:
-      handle*: cint
+      handle: cint
+
+when defined(windows):
+  proc fHandle*(m: MemFile): Handle = m.fHandle
+  proc mapHandle*(m: MemFile): Handle = m.mapHandle
+  proc wasOpened*(m: MemFile): bool = m.wasOpened
+  proc `fHandle=`*(m: var MemFile, fHandle: Handle) =
+    m.fHandle = fHandle
+  proc `mapHandle=`*(m: var MemFile, mapHandle: Handle) =
+    m.mapHandle = mapHandle
+  proc `wasOpened=`*(m: var MemFile, wasOpened: bool) =
+    m.wasOpened = wasOpened
+else:
+  proc handle*(m: MemFile): cint = m.handle
+  proc `handle=`*(m: var MemFile, handle: cint) =
+    m.handle = handle
 
 proc mapMem*(m: var MemFile, mode: FileMode = fmRead,
              mappedSize = -1, offset = 0): pointer =

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -36,11 +36,11 @@ type
     size*: int       ## size of the memory mapped file
 
     when defined(windows):
-      fHandle: Handle
-      mapHandle: Handle
-      wasOpened: bool   ## only close if wasOpened
+      fHandle*: Handle
+      mapHandle*: Handle
+      wasOpened*: bool   ## only close if wasOpened
     else:
-      handle: cint
+      handle*: cint
 
 proc mapMem*(m: var MemFile, mode: FileMode = fmRead,
              mappedSize = -1, offset = 0): pointer =

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -42,21 +42,6 @@ type
     else:
       handle: cint
 
-when defined(windows):
-  proc fHandle*(m: MemFile): Handle = m.fHandle
-  proc mapHandle*(m: MemFile): Handle = m.mapHandle
-  proc wasOpened*(m: MemFile): bool = m.wasOpened
-  proc `fHandle=`*(m: var MemFile, fHandle: Handle) =
-    m.fHandle = fHandle
-  proc `mapHandle=`*(m: var MemFile, mapHandle: Handle) =
-    m.mapHandle = mapHandle
-  proc `wasOpened=`*(m: var MemFile, wasOpened: bool) =
-    m.wasOpened = wasOpened
-else:
-  proc handle*(m: MemFile): cint = m.handle
-  proc `handle=`*(m: var MemFile, handle: cint) =
-    m.handle = handle
-
 proc mapMem*(m: var MemFile, mode: FileMode = fmRead,
              mappedSize = -1, offset = 0): pointer =
   ## returns a pointer to a mapped portion of MemFile `m`
@@ -295,6 +280,35 @@ proc flush*(f: var MemFile; attempts: Natural = 3) =
       lastErr = osLastError()
       if lastErr != EBUSY.OSErrorCode:
         raiseOSError(lastErr, "error flushing mapping")
+
+proc resize*(f: var MemFile, newFileSize: int) =
+  ## resize and re-map the file underlying an ``allowRemap MemFile``.  NOTE:
+  ## this assumes the entire file is mapped read-write at offset zero.  Also,
+  ## the value of ``.mem`` will probably change.
+  when defined(windows):
+    discard #TODO This needs to be implemented.
+  else:
+    if f.handle == -1:
+      raise newException(IOError,
+                         "Cannot resize MemFile opened with allowRemap=false")
+    if ftruncate(f.handle, newFileSize) == -1:
+      raiseOSError(osLastError())
+    when defined(linux):                          #Maybe NetBSD, too?
+      #On Linux this can be over 100 times faster than a munmap,mmap cycle.
+      proc mremap(old: pointer; oldSize,newSize: csize; flags: cint): pointer {.
+        importc: "mremap", header: "<sys/mman.h>" .}
+      let newAddr = mremap(f.mem, csize(f.size), csize(newFileSize), cint(1))
+      if newAddr == cast[pointer](MAP_FAILED):
+        raiseOSError(osLastError())
+    else:
+      if munmap(f.mem, f.size) != 0:
+        raiseOSError(osLastError())
+      let newAddr = mmap(nil, newFileSize, PROT_READ or PROT_WRITE,
+                         MAP_SHARED or MAP_POPULATE, f.handle, 0)
+      if newAddr == cast[pointer](MAP_FAILED):
+        raiseOSError(osLastError())
+    f.mem = newAddr
+    f.size = newFileSize
 
 proc close*(f: var MemFile) =
   ## closes the memory mapped file `f`. All changes are written back to the


### PR DESCRIPTION
Let handles be seen outside of `memfiles` module so that "updating" operations (like eg., resizing a file and re-mapping) do not need
to worry about race conditions of re-opened paths, renamed parent
directories and that sort of thing.  Operating directly on already
open handles is both safer and more efficient than relying upon the
stability of filesystem paths.

For example, I have a little routine to resize a writable map that was opened with `allowRemap=true` that makes it very easy to work with growing output files in a memory mapped setting:
```Nim
import posix
proc remap*(f: var MemFile, newFileSize: int) =
  when defined(windows): error("Not yet supported for windows.")
  else:                     #XXX if mremap unavail need to munmap,ftrunc,mmap
    proc mremap(old: pointer; oldSize, newSize: csize; flags: cint): pointer {.
      importc: "mremap", header: "<sys/mman.h>" .}
    if ftruncate(f.handle, newFileSize) == -1:
      raiseOSError(osLastError())
    let newAddr = mremap(f.mem, csize(f.size), csize(newFileSize), cint(1))
    if cast[int](newAddr) == -1:
      raiseOSError(osLastError())
    f.mem = newAddr
    f.size = newFileSize
```
I happen to use that for a persistent hash table/non-transactional key-value store, but there are obviously many uses of a growable persistent memory.

While we can and perhaps should also just include that above `remap` in `memfiles` which would side-step this particular need for an export marker, there could be _other_ updating operations like permission or ownership changes where the file handle itself is just a better thing to use than a path name.  (I.e., the POSIX `fchown` and `fchmod`).  Other such calls/uses could also exist/come to pass.  So, the handles should probably be kept visible regardless of such further API expansion.