### PR TITLE
add `getCurrentCompilerExe` to vmops (eg allows to get nim compiler at CT); add tests for vmops

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -95,6 +95,9 @@ proc enumToString*(enums: openArray[enum]): string =
 
 - Added `os.relativePath`.
 - Added `parseopt.remainingArgs`.
+- Added `os.staticGetAppFilename`, which is `getAppFilename` at CT;
+  can be used to retrive the currently executing nim compiler.
+
 
 ### Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -95,8 +95,8 @@ proc enumToString*(enums: openArray[enum]): string =
 
 - Added `os.relativePath`.
 - Added `parseopt.remainingArgs`.
-- Added `os.getCurrentNimExe` (implmented as `getAppFilename` at CT),
-  can be used to retrive the currently executing nim compiler.
+- Added `os.getCurrentCompilerExe` (implmented as `getAppFilename` at CT),
+  can be used to retrive the currently executing compiler.
 
 
 ### Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -95,7 +95,7 @@ proc enumToString*(enums: openArray[enum]): string =
 
 - Added `os.relativePath`.
 - Added `parseopt.remainingArgs`.
-- Added `os.staticGetAppFilename`, which is `getAppFilename` at CT;
+- Added `os.getCurrentNimExe` (implmented as `getAppFilename` at CT),
   can be used to retrive the currently executing nim compiler.
 
 

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -13,7 +13,7 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,
   floor, ceil, `mod`
 
-from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir
+from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -113,6 +113,7 @@ proc registerAdditionalOps*(c: PCtx) =
     wrap2svoid(putEnv, osop)
     wrap1s(dirExists, osop)
     wrap1s(fileExists, osop)
+    wrap0(getAppFilename, osop)
     wrap2svoid(writeFile, systemop)
     wrap1s(readFile, systemop)
     systemop getCurrentExceptionMsg

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -113,7 +113,6 @@ proc registerAdditionalOps*(c: PCtx) =
     wrap2svoid(putEnv, osop)
     wrap1s(dirExists, osop)
     wrap1s(fileExists, osop)
-    wrap0(getAppFilename, osop)
     wrap2svoid(writeFile, systemop)
     wrap1s(readFile, systemop)
     systemop getCurrentExceptionMsg
@@ -121,3 +120,6 @@ proc registerAdditionalOps*(c: PCtx) =
       setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
     systemop gorgeEx
   macrosop getProjectPath
+
+  registerCallback c, "stdlib.os.staticGetAppFilename", proc (a: VmArgs) {.nimcall.} =
+    setResult(a, getAppFilename())

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -121,5 +121,5 @@ proc registerAdditionalOps*(c: PCtx) =
     systemop gorgeEx
   macrosop getProjectPath
 
-  registerCallback c, "stdlib.os.staticGetAppFilename", proc (a: VmArgs) {.nimcall.} =
+  registerCallback c, "stdlib.os.getCurrentNimExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -121,5 +121,5 @@ proc registerAdditionalOps*(c: PCtx) =
     systemop gorgeEx
   macrosop getProjectPath
 
-  registerCallback c, "stdlib.os.getCurrentNimExe", proc (a: VmArgs) {.nimcall.} =
+  registerCallback c, "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1419,6 +1419,10 @@ type
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
 
+proc staticGetAppFilename*(): string {.compileTime.} = discard
+  ## `getAppFilename` at CT; can be used to retrive the currently executing
+  ## nim compiler.
+
 when defined(posix) and not defined(nimscript):
   proc getSymlinkFileKind(path: string): PathComponent =
     # Helper function.
@@ -2118,7 +2122,8 @@ when defined(haiku):
       result = ""
 
 proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noNimScript.} =
-  ## Returns the filename of the application's executable.
+  ## Returns the filename of the application's executable. See also
+  ## `staticGetAppFilename`.
   ##
   ## This procedure will resolve symlinks.
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1419,7 +1419,7 @@ type
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
 
-proc staticGetAppFilename*(): string {.compileTime.} = discard
+proc getCurrentNimExe*(): string {.compileTime.} = discard
   ## `getAppFilename` at CT; can be used to retrive the currently executing
   ## nim compiler.
 
@@ -2123,7 +2123,7 @@ when defined(haiku):
 
 proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noNimScript.} =
   ## Returns the filename of the application's executable. See also
-  ## `staticGetAppFilename`.
+  ## `getCurrentNimExe`.
   ##
   ## This procedure will resolve symlinks.
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1419,9 +1419,11 @@ type
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
 
-proc getCurrentNimExe*(): string {.compileTime.} = discard
+proc getCurrentCompilerExe*(): string {.compileTime.} = discard
   ## `getAppFilename` at CT; can be used to retrive the currently executing
-  ## nim compiler.
+  ## Nim compiler from a Nim or nimscript program, or the nimble binary
+  ## inside a nimble program (likewise with other binaries built from
+  ## compiler API).
 
 when defined(posix) and not defined(nimscript):
   proc getSymlinkFileKind(path: string): PathComponent =
@@ -2123,7 +2125,7 @@ when defined(haiku):
 
 proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noNimScript.} =
   ## Returns the filename of the application's executable. See also
-  ## `getCurrentNimExe`.
+  ## `getCurrentCompilerExe`.
   ##
   ## This procedure will resolve symlinks.
 

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -143,7 +143,7 @@ proc existsDir*(dir: string): bool =
 
 proc selfExe*(): string =
   ## Returns the currently running nim or nimble executable.
-  # TODO: consider making this as deprecated alias of `getCurrentNimExe`
+  # TODO: consider making this as deprecated alias of `getCurrentCompilerExe`
   builtin
 
 proc toExe*(filename: string): string =

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -143,6 +143,7 @@ proc existsDir*(dir: string): bool =
 
 proc selfExe*(): string =
   ## Returns the currently running nim or nimble executable.
+  # TODO: consider making this as deprecated alias of `getCurrentNimExe`
   builtin
 
 proc toExe*(filename: string): string =

--- a/tests/vm/tgorge.nim
+++ b/tests/vm/tgorge.nim
@@ -10,6 +10,8 @@ import os
 template getScriptDir(): string =
   parentDir(instantiationInfo(-1, true).filename)
 
+# See also simpler test in Nim/tests/vm/tvmops.nim for a simpler
+# cross platform way.
 block gorge:
   const
     execName = when defined(windows): "tgorge.bat" else: "./tgorge.sh"

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -5,12 +5,20 @@ import os
 import math
 import strutils
 
-# proc forceCT()
+template forceConst(a: untyped): untyped =
+  ## Force evaluation at CT, useful for example here:
+  ## `callFoo(forceConst(getBar1()), getBar2())`
+  ## instead of:
+  ##  block:
+  ##    const a = getBar1()
+  ##    `callFoo(a, getBar2())`
+  const ret = a
+  ret
 
 static:
   # TODO: add more tests
   block: #getAppFilename, gorgeEx, gorge
-    let nim = getAppFilename()
+    const nim = staticGetAppFilename()
     let ret = gorgeEx(nim & " --version")
     doAssert ret.exitCode == 0
     doAssert ret.output.contains "Nim Compiler"
@@ -31,3 +39,9 @@ static:
     const a1 = arcsin 0.3
     let a2 = arcsin 0.3
     doAssert a1 == a2
+
+block:
+  # Check against bugs like #9176
+  doAssert staticGetAppFilename() == forceConst(staticGetAppFilename())
+  if false: #pending #9176
+    doAssert gorgeEx("unexistant") == forceConst(gorgeEx("unexistant"))

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -18,7 +18,7 @@ template forceConst(a: untyped): untyped =
 static:
   # TODO: add more tests
   block: #getAppFilename, gorgeEx, gorge
-    const nim = staticGetAppFilename()
+    const nim = getCurrentNimExe()
     let ret = gorgeEx(nim & " --version")
     doAssert ret.exitCode == 0
     doAssert ret.output.contains "Nim Compiler"
@@ -42,6 +42,6 @@ static:
 
 block:
   # Check against bugs like #9176
-  doAssert staticGetAppFilename() == forceConst(staticGetAppFilename())
+  doAssert getCurrentNimExe() == forceConst(getCurrentNimExe())
   if false: #pending #9176
     doAssert gorgeEx("unexistant") == forceConst(gorgeEx("unexistant"))

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -1,0 +1,33 @@
+#[
+test for vmops.nim
+]#
+import os
+import math
+import strutils
+
+# proc forceCT()
+
+static:
+  # TODO: add more tests
+  block: #getAppFilename, gorgeEx, gorge
+    let nim = getAppFilename()
+    let ret = gorgeEx(nim & " --version")
+    doAssert ret.exitCode == 0
+    doAssert ret.output.contains "Nim Compiler"
+    let ret2 = gorgeEx(nim & " --unexistant")
+    doAssert ret2.exitCode != 0
+    let output3 = gorge(nim & " --version")
+    doAssert output3.contains "Nim Compiler"
+
+  block:
+    const key = "D20181210T175037"
+    const val = "foo"
+    putEnv(key, val)
+    doAssert existsEnv(key)
+    doAssert getEnv(key) == val
+
+  block:
+    # sanity check (we probably don't need to test for all ops)
+    const a1 = arcsin 0.3
+    let a2 = arcsin 0.3
+    doAssert a1 == a2

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -18,7 +18,7 @@ template forceConst(a: untyped): untyped =
 static:
   # TODO: add more tests
   block: #getAppFilename, gorgeEx, gorge
-    const nim = getCurrentNimExe()
+    const nim = getCurrentCompilerExe()
     let ret = gorgeEx(nim & " --version")
     doAssert ret.exitCode == 0
     doAssert ret.output.contains "Nim Compiler"
@@ -42,6 +42,6 @@ static:
 
 block:
   # Check against bugs like #9176
-  doAssert getCurrentNimExe() == forceConst(getCurrentNimExe())
+  doAssert getCurrentCompilerExe() == forceConst(getCurrentCompilerExe())
   if false: #pending #9176
     doAssert gorgeEx("unexistant") == forceConst(gorgeEx("unexistant"))


### PR DESCRIPTION
/cc @Araq 
* adds `getCurrentNimExe` support at CT
eg use case: allowing a nim file to get access to the exact same nim compiler that was used to compile it (without needing environment variables etc), which can be useful in some testing scenarios
there are other use cases obviously

* adds a test file for vmops (`getCurrentNimExe` now provides a simple way to test gorge, gorgeEx for example)

[EDIT] notes
* WAS: `getAppFilename`