### PR TITLE
parseStmt,parseExpr: on error, show correct lineinfo; and show code that was attempted to parse

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -13,7 +13,7 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,
   floor, ceil, `mod`
 
-from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir
+from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -113,6 +113,7 @@ proc registerAdditionalOps*(c: PCtx) =
     wrap2svoid(putEnv, osop)
     wrap1s(dirExists, osop)
     wrap1s(fileExists, osop)
+    wrap0(getAppFilename, osop)
     wrap2svoid(writeFile, systemop)
     wrap1s(readFile, systemop)
     systemop getCurrentExceptionMsg

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -497,19 +497,21 @@ proc internalErrorFlag*(): string {.magic: "NError", noSideEffect.}
   ## Some builtins set an error flag. This is then turned into a proper
   ## exception. **Note**: Ordinary application code should not call this.
 
-proc parseExpr*(s: string): NimNode {.noSideEffect, compileTime.} =
+template parseExpr*(s: string): untyped =
   ## Compiles the passed string to its AST representation.
   ## Expects a single expression. Raises ``ValueError`` for parsing errors.
-  result = internalParseExpr(s)
+  let result = internalParseExpr(s)
   let x = internalErrorFlag()
   if x.len > 0: raise newException(ValueError, x)
+  result
 
-proc parseStmt*(s: string): NimNode {.noSideEffect, compileTime.} =
+template parseStmt*(s: string): untyped =
   ## Compiles the passed string to its AST representation.
   ## Expects one or more statements. Raises ``ValueError`` for parsing errors.
-  result = internalParseStmt(s)
+  let result = internalParseStmt(s)
   let x = internalErrorFlag()
   if x.len > 0: raise newException(ValueError, x)
+  result
 
 proc getAst*(macroOrTemplate: untyped): NimNode {.magic: "ExpandToAst", noSideEffect.}
   ## Obtains the AST nodes returned from a macro or template invocation.

--- a/tests/macros/tparsestmt.nim
+++ b/tests/macros/tparsestmt.nim
@@ -117,12 +117,10 @@ let a3=1
   fun()
 
 
-else: # main driver
-
-  import os, strutils, osproc, nre
-
+when not defined(case_any_testcase): # main driver
+  import os, strutils, osproc, nre, strformat
   proc sanitizeOutput(s: string): string =
-    ## sanitize external location information to keep the test flexible, 
+    ## sanitize external location information to keep the test flexible,
     ## eg `../../lib/core/macros.nim(505))` => <replaced_file>
     result = s.replace(re"(?m)^../../[^\)]+\)", "<replaced_file>")
 
@@ -140,7 +138,7 @@ tparsestmt.nim(89, 6) template/generic instantiation of `fun` from here"""
     let cases_ok = @["-d:case_ok1", "-d:case_ok2"]
     let cases_err = @["-d:case1", "-d:case2", "-d:case3"]
     for opt in cases_ok & cases_err:
-      let cmd = nim & " c --compileOnly --colors:off --hints:off " & opt & " " & self
+      let cmd = fmt"{nim} c --compileOnly --colors:off --hints:off -d:case_any_testcase {opt} {self}"
       echo "test case: " & opt & "--------------------"
       let ret = execCmdEx(cmd, {poStdErrToStdOut, poEvalCommand})
       echo ret.output.sanitizeOutput

--- a/tests/macros/tparsestmt.nim
+++ b/tests/macros/tparsestmt.nim
@@ -1,0 +1,150 @@
+discard """
+  output: '''
+test case: -d:case_ok1--------------------
+
+
+test case: -d:case_ok2--------------------
+
+
+test case: -d:case1--------------------
+stack trace: (most recent call last)
+<replaced_file> fun
+tparsestmt.nim(67, 6) template/generic instantiation of `fun` from here
+tparsestmt.nim(61, 5) template/generic instantiation of `implicit_file_for_parseStmt.nim:
+>>let a0=1
+>>let a1=1
+>>let a2=1) # inserting an error here
+>>let a3=1
+>>` from here
+<replaced_file> Error: unhandled exception: implicit_file_for_parseStmt.nim(3, 9) Error: invalid indentation
+
+
+test case: -d:case2--------------------
+tparsestmt.nim(79, 6) template/generic instantiation of `fun` from here
+tparsestmt.nim(72, 5) template/generic instantiation of `implicit_file_for_parseStmt.nim:
+>>let a0=1
+>>let a1=1
+>>let a2=1
+>>let a1=1  # inserting a redefinition error
+>>
+>>` from here
+implicit_file_for_parseStmt.nim(4, 5) Error: redefinition of 'a1'; previous declaration here: implicit_file_for_parseStmt.nim(4, 4)
+
+
+test case: -d:case3--------------------
+stack trace: (most recent call last)
+<replaced_file> fun
+tparsestmt.nim(88, 6) template/generic instantiation of `fun` from here
+tparsestmt.nim(84, 5) template/generic instantiation of `implicit_file_for_parseStmt.nim:
+>>let a0=1
+>>let a1=1 # inserting a 2nd statement should given an error
+>>` from here
+<replaced_file> Error: unhandled exception: tparsestmt.nim(84, 5) Error: expected expression, but got multiple statements
+
+
+done
+'''
+  exitcode: "0"
+"""
+
+## this is at line 50
+
+#[
+See also: ttryparseexpr.nim;
+
+
+]#
+
+when defined(case1):  # simple example where code given as string litteral
+  import macros
+  macro fun(): untyped =
+    parseStmt("""
+let a0=1
+let a1=1
+let a2=1) # inserting an error here
+let a3=1
+""")
+  fun()
+
+when defined(case2): # more complex example where code is generated
+  import macros
+  macro fun(): untyped =
+    proc genCode(): string =
+      result.add "let a0=1\n"
+      result.add "let a1=1\n"
+      result.add "let a2=1\n"
+      result.add "let a1=1  # inserting a redefinition error\n"
+    const code = genCode()
+    parseStmt(code & "\n")
+  fun()
+
+when defined(case3): # example with parseExpr
+  import macros
+  macro fun(): untyped =
+    parseExpr("""
+let a0=1
+let a1=1 # inserting a 2nd statement should given an error
+""")
+  fun()
+
+when defined(case_ok1): # example with parseExpr that should compile
+  import macros
+  macro fun(): untyped =
+    parseExpr("""
+let a0=1 # this should work
+""")
+  fun()
+
+when defined(case_ok2): # example with parseStmt that should compile
+  import macros
+  macro fun(): untyped =
+    parseStmt("""
+let a0=1
+let a1=1
+""")
+  fun()
+
+when defined(case_bug): # BUG: TODO: probably got to do with not calling `popInfoContext(p.config)` in `opcParseStmtToAst` block
+  import macros
+  import times
+  macro fun(): untyped =
+    parseStmt("""
+let a0=1
+let a1=1
+let a2=1) # inserting an error here
+let a3=1
+""")
+  fun()
+
+
+else: # main driver
+
+  import os, strutils, osproc, nre
+
+  proc sanitizeOutput(s: string): string =
+    ## sanitize external location information to keep the test flexible, 
+    ## eg `../../lib/core/macros.nim(505))` => <replaced_file>
+    result = s.replace(re"(?m)^../../[^\)]+\)", "<replaced_file>")
+
+  doAssert sanitizeOutput("""
+stack trace: (most recent call last)
+../../lib/core/macros.nim(505) fun
+tparsestmt.nim(89, 6) template/generic instantiation of `fun` from here""") == """
+stack trace: (most recent call last)
+<replaced_file> fun
+tparsestmt.nim(89, 6) template/generic instantiation of `fun` from here"""
+
+  proc main()=
+    const nim = getAppFilename()
+    const self = currentSourcePath
+    let cases_ok = @["-d:case_ok1", "-d:case_ok2"]
+    let cases_err = @["-d:case1", "-d:case2", "-d:case3"]
+    for opt in cases_ok & cases_err:
+      let cmd = nim & " c --compileOnly --colors:off --hints:off " & opt & " " & self
+      echo "test case: " & opt & "--------------------"
+      let ret = execCmdEx(cmd, {poStdErrToStdOut, poEvalCommand})
+      echo ret.output.sanitizeOutput
+      doAssert (ret.exitCode == 0) == (opt in cases_ok), $(ret.exitCode, opt)
+      echo ""
+    echo "done"
+  main()


### PR DESCRIPTION
before this PR, upon error, parseStmt,parseExpr give very unhelpful messages:
* line context is wrong(doesn't point to where parseStmt is called)
* it's unclear what the code given to `parseStmt` looked like (can be complex when that code is generated)

* after this PR, we fix both of these issues; it looks like this:

```
tparsestmt.nim(67, 6) template/generic instantiation of `fun` from here
tparsestmt.nim(61, 5) template/generic instantiation of `implicit_file_for_parseStmt.nim:
>>let a0=1
>>let a1=1
>>let a2=1) # inserting an error here
>>let a3=1
>>` from here
../../lib/core/macros.nim(505) Error: unhandled exception: implicit_file_for_parseStmt.nim(3, 9) Error: invalid indentation
```

## note
* supersedes https://github.com/nim-lang/Nim/pull/9853 (github doesn't allow to reopen a closed PR that was force pushed)
* depends on https://github.com/nim-lang/Nim/pull/9925 (ignore the diff for `compiler/vmops.nim`)
* the testing pattern I'm using (which requires #9925) makes it easy to write a number of tests that are self contained in a single file:
  * updating the test is as simple as running locally, copy pasting all the output into discard `output`
  * the test output is sanitized to avoid overly rigid entries: `../../lib/core/macros.nim(505) foobar` => `<replaced_file> foobar`
  * `nim check`(which @araq had suggested for the use case of running multiple tests that can fail in a single file (discussed on gitter as an alternative to  https://github.com/nim-lang/Nim/issues/8803)) just isn't good enough for that:
    * it doesn't report a number of errors: https://github.com/nim-lang/Nim/issues/9906
    * it actually stops early in many use cases, including the ones I'm addressing in this PR; as you can see with `nim -d:case1 -d:case2 tests/macros/tparsestmt.nim` which stops on 1st error)
    * it doesn't allow processing the output (eg to sanitize overly specific line numbers)

This pattern could be reused in many other contexts and would greatly simplify writing tests.

## TODO
- [ ] fix https://github.com/nim-lang/Nim/pull/9927#issuecomment-446537506 before merging