### PR TITLE
Undefine some symbols and globalOptions when processing nimscript

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -88,6 +88,9 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
         # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
         discard
 
+  # Reload configuration from .cfg file
+  loadConfigs(DefaultConfig, cache, conf)
+
   # now process command line arguments again, because some options in the
   # command line can overwite the config file's settings
   extccomp.initVars(conf)

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -50,9 +50,9 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
 
   # These defines/options should not be enabled while processing nimscript
   # bug #4446, #9420, #8991, #9589, #9153
-  var symsToUndef = ["profiler", "memProfiler", "nodejs"]
-  for sym in symsToUndef:
-    undefSymbol(conf.symbols, sym)
+  undefSymbol(conf.symbols, "profiler")
+  undefSymbol(conf.symbols, "memProfiler")
+  undefSymbol(conf.symbols, "nodejs")
 
   # bug #9120
   conf.globalOptions.excl(optTaintMode)

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -48,6 +48,12 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
   if self.suggestMode:
     conf.command = "nimsuggest"
 
+  # These defines/options should not be enabled while processing nimscript
+  # bug #4446, #9420, #8991, #9589, #9153
+  var symsToUndef = ["profiler", "memProfiler", "nodejs"]
+  for sym in symsToUndef:
+    undefSymbol(conf.symbols, sym)
+
   proc runNimScriptIfExists(path: AbsoluteFile)=
     if fileExists(path):
       runNimScript(cache, path, freshDefines = false, conf)

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -54,6 +54,9 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
   for sym in symsToUndef:
     undefSymbol(conf.symbols, sym)
 
+  # bug #9120
+  conf.globalOptions.excl(optTaintMode)
+
   proc runNimScriptIfExists(path: AbsoluteFile)=
     if fileExists(path):
       runNimScript(cache, path, freshDefines = false, conf)


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/4446
Fixes https://github.com/nim-lang/Nim/issues/8991
Fixes https://github.com/nim-lang/Nim/issues/9420
Fixes https://github.com/nim-lang/Nim/issues/9589
Fixes https://github.com/nim-lang/Nim/issues/9153
Fixes https://github.com/nim-lang/Nim/issues/9120

Note that there is no need to re-enable these symbols because a few lines later we already re-process the command line argumesnts -
https://github.com/nim-lang/Nim/blob/b104f77444beb3a19732ad5d7728ce2109325be9/compiler/cmdlinehelper.nim#L91