### PR TITLE
[sysio] `checkErr` now shows actual system error msg instead of unknown error

### DIFF
--- a/lib/system/sysio.nim
+++ b/lib/system/sysio.nim
@@ -76,32 +76,19 @@ proc raiseEOF() {.noinline, noreturn.} =
 
 proc strerror(errnum: cint): cstring {.importc, header: "<string.h>".}
 
-proc c_getErrno*(): cint {.importc:"$1".}
-
-# TODO: this is useful, expose somewhere more public
-const defineExternC = """
-#ifndef NIM_EXTERN_C
-#ifdef __cplusplus
-#define NIM_EXTERN_C extern "C"
-#else
-#define NIM_EXTERN_C
-#endif
-#endif
-"""
-
-{.emit: defineExternC & """
-#include <errno.h>
-NIM_EXTERN_C
-int c_getErrno() {
-  return errno;
-}
-""".}
+when not defined(NimScript):
+  var
+    errno {.importc, header: "<errno.h>".}: cint ## error variable
 
 proc checkErr(f: File) =
-  if c_ferror(f) != 0:
-    let msg = "strerror: `" & $strerror(c_getErrno()) & "`"
-    c_clearerr(f)
-    raiseEIO(msg)
+  when not defined(NimScript):
+    if c_ferror(f) != 0:
+      let msg = "errno: " & $errno & " `" & $strerror(errno) & "`"
+      c_clearerr(f)
+      raiseEIO(msg)
+  else:
+    # shouldn't happen
+    quit(1)
 
 {.push stackTrace:off, profiler:off.}
 proc readBuffer(f: File, buffer: pointer, len: Natural): int =


### PR DESCRIPTION
* `checkErr` now returns the actual system error msg instead of unknown error
eg, for https://github.com/nim-lang/Nim/issues/9634 it now shows:
```
Error: unhandled exception: strerror: `Interrupted system call` [IOError]
```
instead of:
```
Error: unhandled exception: Unknown IO Error [IOError]
```


* ~~introduces an easy / flexible way to deal with problem raised in https://github.com/nim-lang/Nim/pull/4010, ie, allowing `emit` to link correctly regardless of `nim c` or `nim cpp`~~ 
EDIT: just saw we already have `NIM_EXTERNC` available, defined in `lib/nimbase.h`

## note
* ~~I couldn't use: `var errno* {.importc, header: "<errno.h>".}: cint ## error variable` since it gave `Error: cannot 'importc' variable at compile time`
and besides, accessing `errno` through a proc as I did sounds through `c_getErrno` sounds cleaner than exposing a global variable (even if the variable is already global in C)~~
EDIT: `when not defined(NimScript)` works

* I'm not super happy about fact that `proc strerror(errnum: cint): cstring {.importc, header: "<string.h>".}` is defined in multiple locations but doing otherwise would introduce dependency issues; please let me know if you have a better way to avoid this duplication
```
lib/posix/posix.nim:738:1:proc strerror*(errnum: cint): cstring {.importc, header: "<string.h>".}
lib/system/sysio.nim:77:1:proc strerror(errnum: cint): cstring {.importc, header: "<string.h>".}
lib/pure/includes/oserr.nim:9:3:  proc c_strerror(errnum: cint): cstring {....
```

* likewise, we have:
```
lib/posix/posix_linux_amd64.nim:565:3:  errno* {.importc, header: "<errno.h>".}: cint ## error variable
lib/posix/posix_nintendoswitch.nim:490:3:  errno* {.importc, header: "<errno.h>".}: cint ## error variable
lib/posix/posix_other.nim:530:3:  errno* {.importc, header: "<errno.h>".}: cint ## error variable
```
perhaps this could be more DRY in subsequent PR

- [ ] TODO in subsequent PR: also show the symbolic code (casting as enum), eg: `$errno.OSErrorCode`