### PR TITLE
Pragma syntax is now consistent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -136,6 +136,12 @@ proc enumToString*(enums: openArray[enum]): string =
   it's more recognizable and allows tools like github to recognize it as Nim,
   see [#9647](https://github.com/nim-lang/Nim/issues/9647).
   The previous extension will continue to work.
+- Pragma syntax is now consistent. Previous syntax where type pragmas did not 
+  follow the type name is now deprecated. Also pragma before generic parameter
+  list is deprecated to be consistent with how pragmas are used with a proc. See
+  [#8514](https://github.com/nim-lang/Nim/issues/8514) and 
+  [#1872](https://github.com/nim-lang/Nim/issues/1872) for further details.
+
 
 ### Tool changes
 - `jsondoc` now include a `moduleDescription` field with the module

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -2024,7 +2024,7 @@ proc parseTypeDef(p: var TParser): PNode =
       addSon(identPragma, identifier)
       addSon(identPragma, pragma)
   elif p.tok.tokType == tkCurlyDotLe:
-    parMessage(p, errUser, "pragma already present")
+    parMessage(p, errGenerated, "pragma already present")
 
   addSon(result, identPragma)
   addSon(result, genericParam)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1920,7 +1920,7 @@ proc parseObject(p: var TParser): PNode =
   result = newNodeP(nkObjectTy, p)
   getTok(p)
   if p.tok.tokType == tkCurlyDotLe and p.validInd:
-    # Deprecated since v0.19.9
+    # Deprecated since v0.20.0
     parMessage(p, warnDeprecated, "type pragmas follow the type name; this form of writing pragmas")
     addSon(result, parsePragma(p))
   else:
@@ -2003,6 +2003,7 @@ proc parseTypeDef(p: var TParser): PNode =
   var noPragmaYet = true
 
   if p.tok.tokType == tkCurlyDotLe:
+    # Deprecated since v0.20.0
     parMessage(p, warnDeprecated, "pragma before generic parameter list")
     pragma = optPragmas(p)
     identPragma = newNodeP(nkPragmaExpr, p)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -2003,8 +2003,6 @@ proc parseTypeDef(p: var TParser): PNode =
   var noPragmaYet = true
 
   if p.tok.tokType == tkCurlyDotLe:
-    # Deprecated since v0.20.0
-    parMessage(p, warnDeprecated, "pragma before generic parameter list")
     pragma = optPragmas(p)
     identPragma = newNodeP(nkPragmaExpr, p)
     addSon(identPragma, identifier)
@@ -2012,6 +2010,9 @@ proc parseTypeDef(p: var TParser): PNode =
     noPragmaYet = false
 
   if p.tok.tokType == tkBracketLe and p.validInd:
+    if not noPragmaYet:
+      # Deprecated since v0.20.0
+      parMessage(p, warnDeprecated, "pragma before generic parameter list")
     genericParam = parseGenericParamList(p)
   else:
     genericParam = p.emptyNode

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1994,6 +1994,7 @@ proc parseTypeClass(p: var TParser): PNode =
 proc parseTypeDef(p: var TParser): PNode =
   #|
   #| typeDef = identWithPragmaDot genericParamList? '=' optInd typeDefAux
+  #|             indAndComment? / identVisDot genericParamList? pragma '=' optInd typeDefAux
   #|             indAndComment?
   result = newNodeP(nkTypeDef, p)
   var identifier = identVis(p, allowDot=true)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -2019,7 +2019,7 @@ proc parseTypeDef(p: var TParser): PNode =
 
   if noPragmaYet:
     pragma = optPragmas(p)
-    if not pragma.isNil:
+    if pragma.kind != nkEmpty:
       identPragma = newNodeP(nkPragmaExpr, p)
       addSon(identPragma, identifier)
       addSon(identPragma, pragma)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1920,6 +1920,8 @@ proc parseObject(p: var TParser): PNode =
   result = newNodeP(nkObjectTy, p)
   getTok(p)
   if p.tok.tokType == tkCurlyDotLe and p.validInd:
+    # Deprecated since v0.19.9
+    parMessage(p, warnDeprecated, "type pragmas follow the type name; this form of writing pragmas")
     addSon(result, parsePragma(p))
   else:
     addSon(result, p.emptyNode)


### PR DESCRIPTION
Closes https://github.com/nim-lang/Nim/issues/8514
Closes https://github.com/nim-lang/Nim/issues/1872

<details><summary><b>Deprecated Syntax</b></summary>
<p>

```nim
type B = object {.pragma.}
```

```nim
type T {.shallow.} [X] = void
```

</p>
</details>

<details><summary><b>And, the syntax that has to be used now</b></summary>
<p>

```nim
type A {.pragma.} = object
```

```nim
type T[X] {.shallow.} = void
```

</p>
</details>