### PR TITLE
Fix module resolution inside parseStmt

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1455,7 +1455,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeB(rkNode)
       var error: string
       let ast = parseString(regs[rb].node.strVal, c.cache, c.config,
-                            toFullPath(c.config, c.debug[pc]), c.debug[pc].line.int,
+                            toFullPath(c.config, c.debug[pc-2]), c.debug[pc].line.int,
                             proc (conf: ConfigRef; info: TLineInfo; msg: TMsgKind; arg: string) =
                               if error.len == 0 and msg <= errMax:
                                 error = formatMsg(conf, info, msg, arg))


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/7466
  
Note: I am not familiar with macros at all, so I don't know if this change would break anything else.