### PR TITLE
[json] document fact that key ordering is preserved

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -134,6 +134,13 @@
 ##    j2["details"] = %* {"age":35, "pi":3.1415}
 ##    echo j2
 
+runnableExamples:
+  ## Note: for JObject, key ordering is preserved, unlike in some languages,
+  ## this is convenient for some use cases. Example:
+  type Foo = object
+    a1, a2, a0, a3, a4: int
+  doAssert $(%* Foo()) == """{"a1":0,"a2":0,"a0":0,"a3":0,"a4":0}"""
+
 import
   hashes, tables, strutils, lexbase, streams, unicode, macros, parsejson
 


### PR DESCRIPTION
document (with a `runnableExamples` unittest) fact that key ordering is preserved

This property is useful in some cases (eg when dumping some value as json string, it's nice to preserve source ordering of keys)

## note
the "purist" approach is that json key ordering is unspecified and shouldn't matter (eg see https://stackoverflow.com/questions/4515676/keep-the-order-of-the-json-keys-during-json-conversion-to-csv) however it's and often recurring pain point, and since we're already preserving key ordering, might as well document that it works within Nim's stdlib.

same as in python, where they realized it can be useful:
https://stackoverflow.com/questions/10844064/items-in-json-object-are-out-of-order-using-json-dumps
> Since Python 3.6, the keyword argument order is preserved and the above can be rewritten using a nicer syntax:

```py
import json
from collections import OrderedDict
json.dumps(OrderedDict(a1=0, a2=0, a0=0, a3=0, a4=0))
'{"a1": 0, "a2": 0, "a0": 0, "a3": 0, "a4": 0}'
```
