### PR TITLE
document NIM_EXTERNC for `emit` that avoids link errors with `nim cpp`

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7365,6 +7365,17 @@ Example:
 
   embedsC()
 
+``nimbase.h`` defines ``NIM_EXTERNC`` C macro that can be used for
+``extern "C"`` code to work with both ``nim c`` and ``nim cpp``, eg:
+
+.. code-block:: Nim
+  proc foobar() {.importc:"$1".}
+  {.emit: """
+  #include <stdio.h>
+  NIM_EXTERNC
+  void fun(){}
+  """.}
+
 For backwards compatibility, if the argument to the ``emit`` statement
 is a single string literal, Nim symbols can be referred to via backticks.
 This usage is however deprecated.


### PR DESCRIPTION
* document NIM_EXTERNC for `emit`
* refs https://github.com/nim-lang/Nim/pull/4010
