### PR TITLE
Testament fixes

### DIFF
--- a/testament/htmlgen.nim
+++ b/testament/htmlgen.nim
@@ -35,12 +35,12 @@ proc generateTestResultPanelPartial(outfile: File, testResultRow: JsonNode) =
     bgCtxClass = "success"
     resultSign = "ok"
     resultDescription = "PASS"
-  of "reIgnored":
+  of "reDisabled", "reJoined":
     panelCtxClass = "info"
     textCtxClass = "info"
     bgCtxClass = "info"
     resultSign = "question"
-    resultDescription = "SKIP"
+    resultDescription = if result != "reJoined": "SKIP" else: "JOINED"
   else:
     panelCtxClass = "danger"
     textCtxClass = "danger"
@@ -78,7 +78,8 @@ proc allTestResults(onlyFailing = false): AllTests =
         let state = elem["result"].str
         inc result.totalCount
         if state.contains("reSuccess"): inc result.successCount
-        elif state.contains("reIgnored"): inc result.ignoredCount
+        elif state.contains("reDisabled") or state.contains("reJoined"):
+          inc result.ignoredCount
         if not onlyFailing or not(state.contains("reSuccess")):
           result.data.add elem
   result.successPercentage = 100 *

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -68,7 +68,7 @@ let
   pegSuccess = peg"'Hint: operation successful'.*"
   pegOfInterest = pegLineError / pegOtherError
 
-var targets = {low(TTarget)..high(TTarget)}
+var gTargets = {low(TTarget)..high(TTarget)}
 
 proc normalizeMsg(s: string): string =
   result = newStringOfCap(s.len+1)
@@ -372,6 +372,10 @@ proc testSpec(r: var TResults, test: TTest, targets: set[TTarget] = {}) =
       expected.targets = {targetC}
   for target in expected.targets:
     inc(r.total)
+    if target notin gTargets:
+      r.addResult(test, target, "", "", reDisabled)
+      inc(r.skipped)
+      continue
     case expected.action
     of actionCompile:
       var given = callCompiler(expected.getCmd, test.name, test.options, target,
@@ -504,7 +508,7 @@ proc main() =
     of "pedantic": discard "now always enabled"
     of "targets":
       targetsStr = p.val.string
-      targets = parseTargets(targetsStr)
+      gTargets = parseTargets(targetsStr)
     of "nim":
       compilerPrefix = addFileExt(p.val.string, ExeExt)
     of "directory":


### PR DESCRIPTION
Fix several testament regressions:

- `testresults.html` now correctly classify skipped tests
- `--targets` is now (again) respected by `testament` to limit backends tested.