### PR TITLE
allow implicit strings for keys in `json.%*` macro

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -430,7 +430,7 @@ macro `%*`*(x: untyped): untyped =
   ## `%` for every element.
   result = toJson(x)
 
-macro `%*$`*(x: untyped): untyped =
+macro buildJson*(x: untyped): untyped =
   ## Convert an expression to a JsonNode directly, without having to specify
   ## `%` for every element. Raw Nim identifiers for ``JObject`` keys will be
   ## taken as string literals. Variable quoting is achieved by surrounding the
@@ -447,11 +447,6 @@ macro `%*$`*(x: untyped): untyped =
   ## doAssert j["myKey"].getInt == 1
   ## doAssert j["another"].getInt == 2
   ## doAssert j["someKey"].getInt == 3
-  result = toJson(x, identAsKey = true)
-
-macro asJson*(x: untyped): untyped =
-  ## Convert an expression to a JsonNode directly, without having to specify
-  ## `%` for every element.
   result = toJson(x, identAsKey = true)
 
 proc `==`* (a, b: JsonNode): bool =

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -520,17 +520,17 @@ when true:
   # implicit string keys for JObjects
   block:
     block allImplicit:
-      let res = %*$ {
+      let res = buildJson({
         xy: {rows: 1, columns: 2, pattern: "independent"},
         abc: 10
-      }
+      })
       doAssert res["xy"]["rows"].getInt == 1
       doAssert res["xy"]["columns"].getInt == 2
       doAssert res["xy"]["pattern"].getStr == "independent"
       doAssert res["abc"].getInt == 10
 
     block someImplicit:
-      let res = asJson({
+      let res = buildJson({
         xy: {rows: 1, "columns": 2, "pattern": "independent"},
         abc: 10
       })
@@ -539,10 +539,10 @@ when true:
       doAssert res["xy"]["pattern"].getStr == "independent"
       doAssert res["abc"].getInt == 10
     block noneImplicit:
-      let res = %*$ {
+      let res = buildJson({
         "xy": {"rows": 1, "columns": 2, "pattern": "independent"},
         "abc": 10
-      }
+      })
       doAssert res["xy"]["rows"].getInt == 1
       doAssert res["xy"]["columns"].getInt == 2
       doAssert res["xy"]["pattern"].getStr == "independent"
@@ -551,10 +551,10 @@ when true:
     block keyVars:
       let xyKey = "xy"
       let colKey = "columns"
-      let res = %*$ {
+      let res = buildJson({
         [xyKey]: {"rows": 1, [colKey]: 2, pattern: "independent"},
         "abc": 10
-      }
+      })
       doAssert res["xy"]["rows"].getInt == 1
       doAssert res["xy"]["columns"].getInt == 2
       doAssert res["xy"]["pattern"].getStr == "independent"
@@ -563,17 +563,17 @@ when true:
     block invalidIdent:
       # the following two contain invalid identifiers
       when compiles((
-        let res = %*$ {
+        let res = buildJson({
           xy-abc: "test",
           "abc": 10
-        }
+        })
       )):
         echo "FAIL"
 
       when compiles((
-        let res = %*$ {
+        let res = buildJson({
           xy(abc): "test",
           "abc": 10
-        }
+        })
       )):
         echo "FAIL"

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -516,3 +516,64 @@ when true:
       var w = u.to(MyDistRef)
       doAssert v.name == "smith"
       doAssert MyRef(w).name == "smith"
+
+  # implicit string keys for JObjects
+  block:
+    block allImplicit:
+      let res = %* {
+        xy: {rows: 1, columns: 2, pattern: "independent"},
+        abc: 10
+      }
+      doAssert res["xy"]["rows"].getInt == 1
+      doAssert res["xy"]["columns"].getInt == 2
+      doAssert res["xy"]["pattern"].getStr == "independent"
+      doAssert res["abc"].getInt == 10
+
+    block someImplicit:
+      let res = %* {
+        xy: {rows: 1, "columns": 2, "pattern": "independent"},
+        abc: 10
+      }
+      doAssert res["xy"]["rows"].getInt == 1
+      doAssert res["xy"]["columns"].getInt == 2
+      doAssert res["xy"]["pattern"].getStr == "independent"
+      doAssert res["abc"].getInt == 10
+    block noneImplicit:
+      let res = %* {
+        "xy": {"rows": 1, "columns": 2, "pattern": "independent"},
+        "abc": 10
+      }
+      doAssert res["xy"]["rows"].getInt == 1
+      doAssert res["xy"]["columns"].getInt == 2
+      doAssert res["xy"]["pattern"].getStr == "independent"
+      doAssert res["abc"].getInt == 10
+
+    block keyVars:
+      let xyKey = "xy"
+      let colKey = "columns"
+      let res = %* {
+        xyKey: {"rows": 1, colKey: 2, pattern: "independent"},
+        "abc": 10
+      }
+      doAssert res["xy"]["rows"].getInt == 1
+      doAssert res["xy"]["columns"].getInt == 2
+      doAssert res["xy"]["pattern"].getStr == "independent"
+      doAssert res["abc"].getInt == 10
+
+    block invalidIdent:
+      # the following two contain invalid identifiers
+      when compiles((
+        let res = %* {
+          xy-abc: "test",
+          "abc": 10
+        }
+      )):
+        echo "FAIL"
+
+      when compiles((
+        let res = %* {
+          xy(abc): "test",
+          "abc": 10
+        }
+      )):
+        echo "FAIL"

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -520,7 +520,7 @@ when true:
   # implicit string keys for JObjects
   block:
     block allImplicit:
-      let res = %* {
+      let res = %*$ {
         xy: {rows: 1, columns: 2, pattern: "independent"},
         abc: 10
       }
@@ -530,16 +530,16 @@ when true:
       doAssert res["abc"].getInt == 10
 
     block someImplicit:
-      let res = %* {
+      let res = asJson({
         xy: {rows: 1, "columns": 2, "pattern": "independent"},
         abc: 10
-      }
+      })
       doAssert res["xy"]["rows"].getInt == 1
       doAssert res["xy"]["columns"].getInt == 2
       doAssert res["xy"]["pattern"].getStr == "independent"
       doAssert res["abc"].getInt == 10
     block noneImplicit:
-      let res = %* {
+      let res = %*$ {
         "xy": {"rows": 1, "columns": 2, "pattern": "independent"},
         "abc": 10
       }
@@ -551,8 +551,8 @@ when true:
     block keyVars:
       let xyKey = "xy"
       let colKey = "columns"
-      let res = %* {
-        xyKey: {"rows": 1, colKey: 2, pattern: "independent"},
+      let res = %*$ {
+        [xyKey]: {"rows": 1, [colKey]: 2, pattern: "independent"},
         "abc": 10
       }
       doAssert res["xy"]["rows"].getInt == 1
@@ -563,7 +563,7 @@ when true:
     block invalidIdent:
       # the following two contain invalid identifiers
       when compiles((
-        let res = %* {
+        let res = %*$ {
           xy-abc: "test",
           "abc": 10
         }
@@ -571,7 +571,7 @@ when true:
         echo "FAIL"
 
       when compiles((
-        let res = %* {
+        let res = %*$ {
           xy(abc): "test",
           "abc": 10
         }


### PR DESCRIPTION
Since keys of `JObjects` are strings anyway, I thought it might be nice to allow implicit string conversion of keys in the `%*` macro. This now allows e.g.:

```nim
let j = %* {a: "value"}
doAssert j["a"].getStr == "value"
```
(note `a` is not an explicit string). The macro fails if an identifier for a key is not a valid Nim identifier. If the identifier already refers to a variable in the calling scope, that variables string value is used instead:
```nim
let x = "key"
let j = %* {x: "value"}
doAssert j["key"].getStr == "value"
```