### PR TITLE
lots of testament bug fixes and improvements:

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -584,7 +584,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =
 
   echo "joinable specs: ", specs.len
 
-  if dryrun:
+  if simulate:
     var s = "runJoinedTest: "
     for a in specs: s.add a.file & " "
     echo s

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -546,6 +546,8 @@ proc isJoinableSpec(spec: TSpec): bool =
     spec.action == actionRun and
     not fileExists(spec.file.changeFileExt("cfg")) and
     not fileExists(spec.file.changeFileExt("nims")) and
+    not fileExists(parentDir(spec.file) / "nim.cfg") and
+    not fileExists(parentDir(spec.file) / "config.nims") and
     spec.cmd.len == 0 and
     spec.err != reDisabled and
     not spec.unjoinable and
@@ -555,10 +557,6 @@ proc isJoinableSpec(spec: TSpec): bool =
     spec.outputCheck != ocSubstr and
     spec.ccodeCheck.len == 0 and
     (spec.targets == {} or spec.targets == {targetC})
-  if result:
-    for dir in parentDirs(spec.file, inclusive=false):
-      if fileExists(dir / "nim.cfg") or fileExists(dir / "config.nims"):
-        result = false
 
 proc norm(s: var string) =
   while true:

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -587,7 +587,9 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =
   echo "joinable specs: ", specs.len
 
   if dryrun:
-    echo "runJoinedTest: ", specs.mapIt(it.file).join(" ")
+    var s = "runJoinedTest: "
+    for a in specs: s.add a.file & " "
+    echo s
     return
 
   var megatest: string

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -12,7 +12,7 @@
 import
   parseutils, strutils, pegs, os, osproc, streams, parsecfg, json,
   marshal, backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, compiler/nodejs, times, sets, md5, sequtils
+  algorithm, compiler/nodejs, times, sets, md5
 
 var useColors = true
 var backendLogging = true

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -16,7 +16,7 @@ import
 
 var useColors = true
 var backendLogging = true
-var dryrun = false
+var simulate = false
 
 const
   resultsFile = "testresults.html"
@@ -34,6 +34,7 @@ Arguments:
   arguments are passed to the compiler
 Options:
   --print                   also print results to the console
+  --simulate                see what tests would be run but don't run them (for debugging)
   --failing                 only show failing/ignored tests
   --targets:"c c++ js objc" run tests for specified targets (default: all)
   --nim:path                use a particular nim executable (default: compiler/nim)
@@ -379,7 +380,7 @@ proc testSpec(r: var TResults, test: TTest, targets: set[TTarget] = {}) =
       inc(r.skipped)
       continue
 
-    if dryrun:
+    if simulate:
       var count {.global.} = 0
       count.inc
       echo "testSpec count: ", count, " expected: ", expected
@@ -546,8 +547,8 @@ proc main() =
         useColors = false
       else:
         quit Usage
-    of "dryrun":
-      dryrun = true
+    of "simulate":
+      simulate = true
     of "backendlogging":
       case p.val.string:
       of "on":
@@ -590,7 +591,7 @@ proc main() =
     proc progressStatus(idx: int) =
       echo "progress[all]: i: " & $idx & " / " & $cats.len & " cat: " & cats[idx]
 
-    if dryrun:
+    if simulate:
       for i, cati in cats:
         progressStatus(i)
         processCategory(r, Category(cati), p.cmdLineRest.string, testsDir, runJoinableTests = false)

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -222,7 +222,10 @@ proc `$`(x: TResults): string =
 proc addResult(r: var TResults, test: TTest, target: TTarget,
                expected, given: string, success: TResultEnum) =
   # test.name is easier to find than test.name.extractFilename
-  let name = test.name & " " & $target & test.options
+  # A bit hacky but simple and works with tests/testament/tshouldfail.nim
+  var name = test.name.replace(DirSep, '/')
+  name.add " " & $target & test.options
+
   let duration = epochTime() - test.startTime
   let durationStr = duration.formatFloat(ffDecimal, precision = 8).align(11)
   if backendLogging:

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -12,10 +12,11 @@
 import
   parseutils, strutils, pegs, os, osproc, streams, parsecfg, json,
   marshal, backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, compiler/nodejs, times, sets, md5
+  algorithm, compiler/nodejs, times, sets, md5, sequtils
 
 var useColors = true
 var backendLogging = true
+var dryrun = false
 
 const
   resultsFile = "testresults.html"
@@ -219,7 +220,8 @@ proc `$`(x: TResults): string =
 
 proc addResult(r: var TResults, test: TTest, target: TTarget,
                expected, given: string, success: TResultEnum) =
-  let name = test.name.extractFilename & " " & $target & test.options
+  # test.name is easier to find than test.name.extractFilename
+  let name = test.name & " " & $target & test.options
   let duration = epochTime() - test.startTime
   let durationStr = duration.formatFloat(ffDecimal, precision = 8).align(11)
   if backendLogging:
@@ -376,6 +378,13 @@ proc testSpec(r: var TResults, test: TTest, targets: set[TTarget] = {}) =
       r.addResult(test, target, "", "", reDisabled)
       inc(r.skipped)
       continue
+
+    if dryrun:
+      var count {.global.} = 0
+      count.inc
+      echo "testSpec count: ", count, " expected: ", expected
+      continue
+
     case expected.action
     of actionCompile:
       var given = callCompiler(expected.getCmd, test.name, test.options, target,
@@ -477,14 +486,30 @@ proc makeTest(test, options: string, cat: Category): TTest =
   result.spec = parseSpec(addFileExt(test, ".nim"))
   result.startTime = epochTime()
 
+# TODO: fix these files
+const disabledFilesDefault = @[
+  "LockFreeHash.nim",
+  "sharedstrings.nim",
+  "tableimpl.nim",
+
+  # Error: undeclared identifier: 'hasThreadSupport'
+  "ioselectors_epoll.nim",
+  "ioselectors_kqueue.nim",
+  "ioselectors_poll.nim",
+
+  # Error: undeclared identifier: 'Timeval'
+  "ioselectors_select.nim",
+]
+
 when defined(windows):
   const
     # array of modules disabled from compilation test of stdlib.
-    disabledFiles = ["coro.nim"]
+    disabledFiles = disabledFilesDefault & @["coro.nim"]
 else:
   const
     # array of modules disabled from compilation test of stdlib.
-    disabledFiles = ["-"]
+    # TODO: why the ["-"]? (previous code should've prob used seq[string] = @[] instead)
+    disabledFiles = disabledFilesDefault & @["-"]
 
 include categories
 
@@ -521,6 +546,8 @@ proc main() =
         useColors = false
       else:
         quit Usage
+    of "dryrun":
+      dryrun = true
     of "backendlogging":
       case p.val.string:
       of "on":
@@ -547,16 +574,28 @@ proc main() =
 
     myself &= " " & quoteShell("--nim:" & compilerPrefix)
 
-    var cmds: seq[string] = @[]
+    var cats: seq[string]
     let rest = if p.cmdLineRest.string.len > 0: " " & p.cmdLineRest.string else: ""
     for kind, dir in walkDir(testsDir):
       assert testsDir.startsWith(testsDir)
       let cat = dir[testsDir.len .. ^1]
       if kind == pcDir and cat notin ["testdata", "nimcache"]:
-        cmds.add(myself & " pcat " & quoteShell(cat) & rest)
-    for cat in AdditionalCategories:
+        cats.add cat
+    cats.add AdditionalCategories
+
+    var cmds: seq[string]
+    for cat in cats:
       cmds.add(myself & " pcat " & quoteShell(cat) & rest)
-    quit osproc.execProcesses(cmds, {poEchoCmd, poStdErrToStdOut, poUsePath, poParentStreams})
+
+    proc progressStatus(idx: int) =
+      echo "progress[all]: i: " & $idx & " / " & $cats.len & " cat: " & cats[idx]
+
+    if dryrun:
+      for i, cati in cats:
+        progressStatus(i)
+        processCategory(r, Category(cati), p.cmdLineRest.string, testsDir, runJoinableTests = false)
+    else:
+      quit osproc.execProcesses(cmds, {poEchoCmd, poStdErrToStdOut, poUsePath, poParentStreams}, beforeRunEvent = progressStatus)
   of "c", "cat", "category":
     var cat = Category(p.key)
     p.next

--- a/tests/testament/tshouldfail.nim
+++ b/tests/testament/tshouldfail.nim
@@ -2,30 +2,30 @@ discard """
 cmd: "testament/tester --directory:testament --colors:off --backendLogging:off --nim:../compiler/nim category shouldfail"
 action: compile
 nimout: '''
-FAIL: tccodecheck.nim C
+FAIL: tests/shouldfail/tccodecheck.nim C
 Failure: reCodegenFailure
 Expected:
 baz
-FAIL: tcolumn.nim C
+FAIL: tests/shouldfail/tcolumn.nim C
 Failure: reLinesDiffer
-FAIL: terrormsg.nim C
+FAIL: tests/shouldfail/terrormsg.nim C
 Failure: reMsgsDiffer
-FAIL: texitcode1.nim C
+FAIL: tests/shouldfail/texitcode1.nim C
 Failure: reExitcodesDiffer
-FAIL: tfile.nim C
+FAIL: tests/shouldfail/tfile.nim C
 Failure: reFilesDiffer
-FAIL: tline.nim C
+FAIL: tests/shouldfail/tline.nim C
 Failure: reLinesDiffer
-FAIL: tmaxcodesize.nim C
+FAIL: tests/shouldfail/tmaxcodesize.nim C
 Failure: reCodegenFailure
 max allowed size: 1
-FAIL: tnimout.nim C
+FAIL: tests/shouldfail/tnimout.nim C
 Failure: reMsgsDiffer
-FAIL: toutput.nim C
+FAIL: tests/shouldfail/toutput.nim C
 Failure: reOutputsDiffer
-FAIL: toutputsub.nim C
+FAIL: tests/shouldfail/toutputsub.nim C
 Failure: reOutputsDiffer
-FAIL: tsortoutput.nim C
+FAIL: tests/shouldfail/tsortoutput.nim C
 Failure: reOutputsDiffer
 '''
 """


### PR DESCRIPTION
/cc @Araq @krux02 

* fix #9328 testsuite silently ignores a number of tests
* all stdlib modules are now compiled (and run when appropriate), except an explicit blacklist that fails
  (previously it ignored deeper nested modules, eg lib/pure/foo/bar.nim)
* that exposed a number of failing tests that were never previously run under CI, see disabledFilesDefault
* ditto with files under tests/
* ditto with identifying modules suitable for megatest

* isJoinableSpec now returns false if there's a nims file
* isJoinableSpec now searches deeper for a nim.cfg (and config.nims) file, since that's how config files work

* show absolute progress (eg: category 10 / 120)
* new --dryrun mode that just completes in ~5 seconds and prints out all the testSpec that would be run; helpful for debugging
* files are now processed in sorted order, making test run order more deterministic and easier to follow
* testament now doesn't strip dir component, making it easier to follow, eg:
  PASS: cyclecollector C -d:release
  =>
  PASS: tests/gc/cyclecollector C -d:release
