### PR TITLE
Add call to hostnamectl in detectOsImpl

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -133,8 +133,8 @@ const
   LacksDevPackages* = {Distribution.Gentoo, Distribution.Slackware,
     Distribution.ArchLinux}
 
-var unameRes, releaseRes: string ## we cache the result of the 'uname -a'
-                                 ## execution for faster platform detections.
+var unameRes, releaseRes, hostnamectlRes: string ## we cache the result of the 'uname -a'
+                                                 ## execution for faster platform detections.
 
 template unameRelease(cmd, cache): untyped =
   if cache.len == 0:
@@ -143,6 +143,7 @@ template unameRelease(cmd, cache): untyped =
 
 template uname(): untyped = unameRelease("uname -a", unameRes)
 template release(): untyped = unameRelease("lsb_release -a", releaseRes)
+template hostnamectl(): untyped = unameRelease("hostnamectl", hostnamectlRes)
 
 proc detectOsImpl(d: Distribution): bool =
   case d
@@ -172,7 +173,7 @@ proc detectOsImpl(d: Distribution): bool =
     result = defined(haiku)
   else:
     let dd = toLowerAscii($d)
-    result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release())
+    result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release()) or dd in toLowerAscii(hostnamectl())
 
 template detectOs*(d: untyped): bool =
   ## Distro/OS detection. For convenience the


### PR DESCRIPTION
`detectOs` from `distros.nim` won't detect the OS properly if `uname` or `lsb_release -a` do not contain the OS name. I don't know about any other OS's, but I know for a fact that since at least Fedora 27, `uname` reports the OS name as `GNU/Linux` and `lsb_release` is not installed by default.

This commit adds a third `execProcess` call to the necessary `detectOsImpl` code, this time the call executes `hostnamectl`, which contains the OS name. Sample output of `hostnamectl` from my Fedora 29 machine is as follows:
```
   Static hostname: anarchy
         Icon name: computer-laptop
           Chassis: laptop
        Machine ID: [redacted for opsec]
           Boot ID: [redacted for opsec]
  Operating System: Fedora 29 (Workstation Edition)
       CPE OS Name: cpe:/o:fedoraproject:fedora:29
            Kernel: Linux 4.19.8-300.fc29.x86_64
      Architecture: x86-64
```
This commit fixes bug report #10036

The code currently only checks if the distribution name is in the output. However, this might cause issues if someone's machine is running say Ubuntu and happens to be named `Arch` for some reason. To fix that edge case, I think checking for `Operating System: [distribution name]` might be best, but I thought it would be good to check with the maintainers on that.