### PR TITLE
Stop false positives in distros.detectOs

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -141,8 +141,8 @@ template unameRelease(cmd, cache): untyped =
     cache = (when defined(nimscript): gorge(cmd) else: execProcess(cmd))
   cache
 
-template uname(): untyped = unameRelease("uname -a", unameRes)
-template release(): untyped = unameRelease("lsb_release -a", releaseRes)
+template uname(): untyped = unameRelease("uname -o", unameRes)
+template release(): untyped = unameRelease("lsb_release -d", releaseRes)
 template hostnamectl(): untyped = unameRelease("hostnamectl", hostnamectlRes)
 
 proc detectOsImpl(d: Distribution): bool =
@@ -173,7 +173,7 @@ proc detectOsImpl(d: Distribution): bool =
     result = defined(haiku)
   else:
     let dd = toLowerAscii($d)
-    result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release()) or dd in toLowerAscii(hostnamectl())
+    result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release()) or dd in toLowerAscii("Operating System: " & hostnamectl())
 
 template detectOs*(d: untyped): bool =
   ## Distro/OS detection. For convenience the

--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -173,7 +173,7 @@ proc detectOsImpl(d: Distribution): bool =
     result = defined(haiku)
   else:
     let dd = toLowerAscii($d)
-    result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release()) or dd in toLowerAscii("Operating System: " & hostnamectl())
+    result = dd in toLowerAscii(uname()) or dd in toLowerAscii(release()) or ("operating system: " & dd) in toLowerAscii(hostnamectl())
 
 template detectOs*(d: untyped): bool =
   ## Distro/OS detection. For convenience the


### PR DESCRIPTION
Calling `uname -a`, `lsb_release -a`, and only checking the distro name against the entirety of `hostnamectl` can cause false positives in distro detection due to the machine name.

For instance, my machine has been named "anarchy" for quite some time. `uname -a`, `lsb_release -a`, and `hostnamectl` all output the hostname, so `detectOs ArchLinux` returns `true` as `anarchy` contains the substring `arch`.

Changing `uname -a` to `uname -o` fixes the problem for uname, as the `-o` switch only outputs the OS name (`GNU/Linux` on my Fedora machine, but most distros output the actual distro name). The `-d` switch for `lsb_release` outputs only the description, which is `Description:	Fedora release 29 (Twenty Nine)` on my Fedora machine.

`hostnamectl` is different, because you can't use a command line switch to output specific lines. On my Fedora machine, the relevant line is `Operating System: Fedora 29 (Twenty Nine)`, so checking for `toLowerAscii("Operating System: " & <distribution name>)` narrows down the search to only that line.

Before these changes, my machine would return `true` for `detectOs ArchLinux`, and with these changes, Nim now correctly reports that I'm not using Arch.

If needed, I can add comments to lines 144 and 145 explaining the use of the command line switches.