### PR TITLE
simplify code that handles hints/warnings

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -27,7 +27,7 @@ bootSwitch(usedNoGC, defined(nogc), "--gc:none")
 import
   os, msgs, options, nversion, condsyms, strutils, extccomp, platform,
   wordrecg, parseutils, nimblecmd, idents, parseopt, sequtils, lineinfos,
-  pathutils
+  pathutils, tables
 
 # but some have deps to imported modules. Yay.
 bootSwitch(usedTinyC, hasTinyCBackend, "-d:tinyc")
@@ -188,14 +188,11 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
 
   if i < len(arg) and (arg[i] in {':', '='}): inc(i)
   else: invalidCmdLineOption(conf, pass, orig, info)
-  if state == wHint:
-    let x = findStr(lineinfos.HintsToStr, id)
-    if x >= 0: n = TNoteKind(x + ord(hintMin))
-    else: localError(conf, info, "unknown hint: " & id)
-  else:
-    let x = findStr(lineinfos.WarningsToStr, id)
-    if x >= 0: n = TNoteKind(x + ord(warnMin))
-    else: localError(conf, info, "unknown warning: " & id)
+
+  let ret = humanStrToMsg(id)
+  if ret[0]: n = ret[1]
+  else: localError(conf, info, "unknown hint/warning: " & id)
+
   case substr(arg, i).normalize
   of "on":
     incl(conf.notes, n)

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -13,7 +13,7 @@ import
   strtabs, platform, strutils, idents
 
 from options import Feature
-from lineinfos import HintsToStr, WarningsToStr
+from lineinfos import warnMin, warnMax, hintMin, hintMax, msgToHumanStr
 
 const
   catNone = "false"
@@ -91,7 +91,5 @@ proc initDefines*(symbols: StringTableRef) =
   for f in low(Feature)..high(Feature):
     defineSymbol("nimHas" & $f)
 
-  for s in WarningsToStr:
-    defineSymbol("nimHasWarning" & s)
-  for s in HintsToStr:
-    defineSymbol("nimHasHint" & s)
+  for s in warnMin..warnMax: defineSymbol("nimHasWarning" & msgToHumanStr(s))
+  for s in hintMin..hintMax: defineSymbol("nimHasHint" & msgToHumanStr(s))

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -737,6 +737,7 @@ template tryExceptOSErrorMessage(conf: ConfigRef; errorPrefix: string = "", body
     raise
 
 proc execLinkCmd(conf: ConfigRef; linkCmd: string) =
+  rawMessage(conf, hintLinkingVerbose, linkCmd)
   tryExceptOSErrorMessage(conf, "invocation of external linker program failed."):
     execExternalProgram(conf, linkCmd,
       if optListCmd in conf.globalOptions or conf.verbosity > 1: hintExecuting else: hintLinking)

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -141,22 +141,17 @@ type
   TNoteKinds* = set[TNoteKind]
 
 proc msgToHumanStr*(a: TMsgKind): string =
-  case a
-  # of errMin..errMax: result = ($a)["err".len .. ^1]
-  of warnMin..warnMax: result = ($a)["warn".len .. ^1]
-  of hintMin..hintMax: result = ($a)["hint".len .. ^1]
-  else:
-    doAssert false
-
-  # handle special cases to match old code behavior; consider removing these
-  # special cases
-  case a
+  case a # handle exceptions here
   of warnInconsistentSpacing: result = "Spacing"
   of hintConditionAlwaysTrue: result = "CondTrue"
   of hintConditionAlwaysFalse: result = "CondFalse"
   of hintExecuting: result = "Exec"
   of hintLinking: result = "Link"
-  else: discard
+  else: # general case
+    case a
+    of warnMin..warnMax: result = ($a)["warn".len .. ^1]
+    of hintMin..hintMax: result = ($a)["hint".len .. ^1]
+    else: doAssert false
 
 proc humanStrToMsg*(a: string): (bool,TMsgKind) =
   # Consider using `Option[TMsgKind]` if we're ok depending on options.nim

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -270,12 +270,10 @@ proc mainCommand*(graph: ModuleGraph) =
 
       var hints = newJObject() # consider factoring with `listHints`
       for a in hintMin..hintMax:
-        let key = lineinfos.HintsToStr[ord(a) - ord(hintMin)]
-        hints[key] = %(a in conf.notes)
+        hints[lineinfos.msgToHumanStr(a)] = %(a in conf.notes)
       var warnings = newJObject()
       for a in warnMin..warnMax:
-        let key = lineinfos.WarningsToStr[ord(a) - ord(warnMin)]
-        warnings[key] = %(a in conf.notes)
+        warnings[lineinfos.msgToHumanStr(a)] = %(a in conf.notes)
 
       var dumpdata = %[
         (key: "version", val: %VersionAsString),

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -386,7 +386,7 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     writeContext(conf, unknownLineInfo())
     title = WarningTitle
     color = WarningColor
-    kind = WarningsToStr[ord(msg) - ord(warnMin)]
+    kind = msgToHumanStr(msg)
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint
@@ -394,7 +394,7 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     if msg notin conf.notes: return
     title = HintTitle
     color = HintColor
-    if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]
+    if msg != hintUserRaw: kind = msgToHumanStr(msg)
     inc(conf.hintCounter)
   let s = msgKindToString(msg) % args
 
@@ -474,14 +474,14 @@ proc liMessage(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
     if not ignoreMsg: writeContext(conf, info)
     title = WarningTitle
     color = WarningColor
-    kind = WarningsToStr[ord(msg) - ord(warnMin)]
+    kind = msgToHumanStr(msg)
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint
     ignoreMsg = optHints notin conf.options or msg notin conf.notes
     title = HintTitle
     color = HintColor
-    if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]
+    if msg != hintUserRaw: kind = msgToHumanStr(msg)
     inc(conf.hintCounter)
   # NOTE: currently line info line numbers start with 1,
   # but column numbers start with 0, however most editors expect
@@ -556,7 +556,7 @@ proc listWarnings*(conf: ConfigRef) =
   for warn in warnMin..warnMax:
     msgWriteln(conf, "  [$1] $2" % [
       if warn in conf.notes: "x" else: " ",
-      lineinfos.WarningsToStr[ord(warn) - ord(warnMin)]
+      lineinfos.msgToHumanStr(warn)
     ])
 
 proc listHints*(conf: ConfigRef) =
@@ -564,5 +564,5 @@ proc listHints*(conf: ConfigRef) =
   for hint in hintMin..hintMax:
     msgWriteln(conf, "  [$1] $2" % [
       if hint in conf.notes: "x" else: " ",
-      lineinfos.HintsToStr[ord(hint) - ord(hintMin)]
+      lineinfos.msgToHumanStr(hint)
     ])

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -12,7 +12,7 @@
 import
   os, platform, condsyms, ast, astalgo, idents, semdata, msgs, renderer,
   wordrecg, ropes, options, strutils, extccomp, math, magicsys, trees,
-  types, lookups, lineinfos, pathutils
+  types, lookups, lineinfos, pathutils, tables
 
 const
   FirstCallConv* = wNimcall
@@ -306,13 +306,9 @@ proc processNote(c: PContext, n: PNode) =
       n[0][1].kind == nkIdent and n[0][0].kind == nkIdent:
     var nk: TNoteKind
     case whichKeyword(n[0][0].ident)
-    of wHint:
-      var x = findStr(HintsToStr, n[0][1].ident.s)
-      if x >= 0: nk = TNoteKind(x + ord(hintMin))
-      else: invalidPragma(c, n); return
-    of wWarning:
-      var x = findStr(WarningsToStr, n[0][1].ident.s)
-      if x >= 0: nk = TNoteKind(x + ord(warnMin))
+    of wHint,wWarning:
+      let ret = humanStrToMsg(n[0][1].ident.s)
+      if ret[0]: nk = ret[1]
       else: invalidPragma(c, n); return
     else:
       invalidPragma(c, n)


### PR DESCRIPTION
* WarningsToStr, HintsToStr hardcoded tables wasn't DRY; I removed it in favor of `proc msgToHumanStr*(a: TMsgKind): string`. This simplifies a bunch of code related to hints/warnings
* added `hintLinkingVerbose` to always show link command; happy to make that the new meaning for `hintLink` if we don't want to create a new hint for that (the existing `hintLink` isn't very useful as it doesn't show anything except "Link")

## note
I could also use an inverted index table, eg:
```
const humanStrToMsg* = block: ## Inverted index of `proc humanStrToMsg`
  var ret = initTable[string, TMsgKind]()
  for a in TNoteKind:
    let str = a.msgToHumanStr.normalizeStyle
    ret[str] = a
  ret

proc normalizeStyle(a: string): string=
  # normalizes: _Foo_Bar => Foobar so that `cmpIgnoreStyle` doesn't need to be used
```
however, `humanStrToMsg` is only used in non performance critical places so I went for simplicity instead (with same time complexity as before PR)