### PR TITLE
Implement range[0..5] support in json.to.

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1235,6 +1235,25 @@ proc processType(typeName: NimNode, obj: NimNode,
           )
       else:
         doAssert false, "Unable to process nnkSym " & $typeName
+  of nnkBracketExpr:
+    if obj[0].kind == nnkSym and $obj[0] == "range":
+      case obj[1].kind
+      of nnkIntLit:
+        result = quote do:
+          (
+            verifyJsonKind(`jsonNode`, {JInt}, astToStr(`jsonNode`));
+            `typeName`(`jsonNode`.num)
+          )
+      of nnkFloatLit:
+        result = quote do:
+          (
+            verifyJsonKind(`jsonNode`, {JInt, JFloat}, astToStr(`jsonNode`));
+            if `jsonNode`.kind == JFloat: `typeName`(`jsonNode`.fnum) else: `typeName`(`jsonNode`.num)
+          )
+      else:
+        doAssert false, "Unable to process range with " & $obj[1].kind
+    else:
+      doAssert false, "Unable to process nnkBracketExpr"
   else:
     doAssert false, "Unable to process type: " & $obj.kind
 

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -516,3 +516,19 @@ when true:
       var w = u.to(MyDistRef)
       doAssert v.name == "smith"
       doAssert MyRef(w).name == "smith"
+
+  block:
+    # Support for `range[0 .. 5]`
+    type
+      RangeTest = object
+        x: range[0 .. 5]
+        y: range[0.0 .. 12.23]
+
+    let data = """
+      {"x": 2, "y": 0.1}
+    """
+
+    let dataParsed = parseJson(data)
+    let dataDeser = to(dataParsed, RangeTest)
+    doAssert dataDeser.x == 2
+    doAssert dataDeser.y == 0.1


### PR DESCRIPTION
Was hoping to use this in my project but it seems Nim is randomly more strict when initialising objects that have `range`(?):

```
protocol.nim(95, 12) template/generic instantiation of `to` from here
../nim/lib/pure/json.nim(1477, 33) Error: fields not initialized: size.
```

I couldn't reproduce it and didn't want to spend more time chasing it, but this seems to work in a small test case at the very least so it's a worthy addition I think.