### PR TITLE
testament megatest: we can now tell which test failed; helps debugging and prevents certain bugs, plus other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ test.txt
 tweeter.db
 tweeter_test.db
 megatest.nim
+
+/outputExpected.txt
+/outputGotten.txt
+

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -599,7 +599,7 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =
 
   var megatest: string
   #[
-  TODO(MINOR):
+  TODO(minor):
   get from Nim cmd
   put outputGotten.txt, outputGotten.txt, megatest.nim there too
   delete upon completion, maybe
@@ -610,10 +610,8 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =
   for i, runSpec in specs:
     let file = runSpec.file
     let file2 = outDir / ("megatest_" & $i & ".nim")
-    var code = ""
     # `include` didn't work with `trecmod2.nim`, so using `import`
-    code.add "echo \"" & marker & "\", " & quoted(file) & "\n"
-
+    let code = "echo \"" & marker & "\", " & quoted(file) & "\n"
     createDir(file2.parentDir)
     writeFile(file2, code)
     megatest.add "import " & quoted(file2) & "\n"

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -425,15 +425,12 @@ proc testStdlib(r: var TResults, pattern, options: string, cat: Category) =
     let contents = readFile(testFile).string
     var testObj = makeTest(testFile, options, cat)
     #[
-    TODO:
+    todo:
     this logic is fragile:
     false positives (if appears in a comment), or false negatives, eg
     `when defined(osx) and isMainModule`.
-    Instead of fixing this, a much better way, is to extend
-    https://github.com/nim-lang/Nim/issues/9581 to stdlib modules as follows:
-    * add these to megatest
-    * patch compiler so `isMainModule` is true when -d:isMainModuleIsAlwaysTrue
-    That'll give speedup benefit, and we don't have to patch stdlib files.
+    Instead of fixing this, see https://github.com/nim-lang/Nim/issues/10045
+    for a much better way.
     ]#
     if "when isMainModule" notin contents:
       testObj.spec.action = actionCompile
@@ -571,7 +568,7 @@ proc isTestFile*(file: string): bool =
   result = ext == ".nim" and name.startsWith("t")
 
 proc quoted(a: string): string =
-  # TODO: consider moving to system.nim
+  # todo: consider moving to system.nim
   result.addQuoted(a)
 
 proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -83,7 +83,7 @@ proc getFileDir(filename: string): string =
   if not result.isAbsolute():
     result = getCurrentDir() / result
 
-proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOption], input: string): tuple[
+proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOption], input: string, logFile: File = nil): tuple[
                 output: TaintedString,
                 exitCode: int] {.tags:
                 [ExecIOEffect, ReadIOEffect, RootEffect], gcsafe.} =
@@ -103,6 +103,10 @@ proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOp
     if outp.readLine(line):
       result[0].string.add(line.string)
       result[0].string.add("\n")
+      if logFile != nil:
+        logFile.write line.string
+        logFile.write "\n"
+        logFile.flushFile
     else:
       result[1] = peekExitCode(p)
       if result[1] != -1: break

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -17,8 +17,10 @@ import
 var useColors = true
 var backendLogging = true
 var simulate = false
+var verboseMegatest = false # very verbose but can be useful
 
 const
+  testsDir = "tests" & DirSep
   resultsFile = "testresults.html"
   #jsonFile = "testresults.json" # not used
   Usage = """Usage:
@@ -34,6 +36,7 @@ Arguments:
   arguments are passed to the compiler
 Options:
   --print                   also print results to the console
+  --verboseMegatest         log to stdout megatetest compilation
   --simulate                see what tests would be run but don't run them (for debugging)
   --failing                 only show failing/ignored tests
   --targets:"c c++ js objc" run tests for specified targets (default: all)
@@ -83,7 +86,7 @@ proc getFileDir(filename: string): string =
   if not result.isAbsolute():
     result = getCurrentDir() / result
 
-proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOption], input: string, logFile: File = nil): tuple[
+proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOption], input: string, onStdout: proc(line: string) = nil): tuple[
                 output: TaintedString,
                 exitCode: int] {.tags:
                 [ExecIOEffect, ReadIOEffect, RootEffect], gcsafe.} =
@@ -103,10 +106,7 @@ proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOp
     if outp.readLine(line):
       result[0].string.add(line.string)
       result[0].string.add("\n")
-      if logFile != nil:
-        logFile.write line.string
-        logFile.write "\n"
-        logFile.flushFile
+      if onStdout != nil: onStdout(line.string)
     else:
       result[1] = peekExitCode(p)
       if result[1] != -1: break
@@ -521,8 +521,6 @@ else:
 
 include categories
 
-const testsDir = "tests" & DirSep
-
 proc main() =
   os.putenv "NIMTEST_COLOR", "never"
   os.putenv "NIMTEST_OUTPUT_LVL", "PRINT_FAILURES"
@@ -537,6 +535,7 @@ proc main() =
   while p.kind == cmdLongoption:
     case p.key.string.normalize
     of "print", "verbose": optPrintResults = true
+    of "verbosemegatest": verboseMegatest = true
     of "failing": optFailing = true
     of "pedantic": discard "now always enabled"
     of "targets":


### PR DESCRIPTION
* sort megatest files for reproducibility / ease of debugging
* output of file `foo.nim` will now be preceded by `megatest:processing: foo.nim` with 2 benefits:
  * prevents pathological cases where wrong test output is not detected [1]
  * helps debugging when there are test failures (including expected/actual mismatch) as you can now tell where the test failure came from; previously it was pretty bad as you'd have no idea and would have to try to figure it out using grep, which in some cases would be impossibly ambiguous

[1] example:
```
test1.nim: expected to print foo
test2.nim: expected to print bar
```

if test1 produces nothing and test2 produces foo\nbar, a bug would previously go un-detected; after this PR, it will be detected since the output is now:
```
processing test1.nim
foo
processing test2.nim
bar
```

EDIT:
* megatest compilation is now logged to stdout (with `--verboseMegatest`) which helps with debugging, it'll display:

EDIT:
* replace "tests" by testsDir

EDIT:
* megatest's nimcache is now in same dir as other tests to avoid clobbering (eg when running tests from multiple Nim repos)

## note
I had originally suggested this here https://github.com/nim-lang/Nim/issues/9581#issuecomment-439785885 ; this PR is a simplified version of that