### PR TITLE
config/nim.cfg: disable tlsEmulation on Haiku

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -102,9 +102,6 @@ path="$lib/pure"
     tlsEmulation:on
   @end
   @if haiku:
-    # Haiku currently have problems with TLS
-    # https://dev.haiku-os.org/ticket/14342
-    tlsEmulation:on
     gcc.options.linker = "-Wl,--as-needed -lnetwork"
     gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork"
     clang.options.linker = "-Wl,--as-needed -lnetwork"


### PR DESCRIPTION
As of [hrev52662](https://git.haiku-os.org/haiku/commit/?id=df3de4792e9b20d073d16acccc20c37f1114ea37), TLS support in Haiku is usable again. This has since been backported to R1/Beta1, so we can flip the switch upstream.

Can we have this commit backported? Thanks!