### PR TITLE
document --profiler:on

### DIFF
--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -108,3 +108,6 @@ Advanced options:
   --experimental:$1
                             enable experimental language feature
   -v, --version             show detailed version information
+  --profiler:on|off         Enable profiling; requires `import nimprof`, and
+                            works better with `--stackTrace:on`
+                            see also https://nim-lang.github.io/Nim/estp.html


### PR DESCRIPTION
documenting this flag to increase its discoverability and increasing likelihood corresponding bugs (eg https://github.com/nim-lang/Nim/issues/10106) will get fixed; furthermore that flag requires other flags and setup (import nimprof) so needs to be documented to avoid user frustration when they try `--profiler:on` and `profile_results.txt` doesn't get written

