### PR TITLE
profiler improvements

### DIFF
--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -39,6 +39,15 @@ type
     st: StackTrace
   ProfileData = array[0..64*1024-1, ptr ProfileEntry]
 
+proc `==`(x, y: cstring): bool {.noSideEffect, inline.} =
+  ## Checks for equality between two `cstring` variables.
+  # copied over from system.nim as workaround for #10106
+  proc strcmp(a, b: cstring): cint {.noSideEffect,
+    importc, header: "<string.h>".}
+  if pointer(x) == pointer(y): result = true
+  elif x.isNil or y.isNil: result = false
+  else: result = strcmp(x, y) == 0
+
 proc `==`(a, b: StackTrace): bool =
   for i in 0 .. high(a.lines):
     if a[i] != b[i]: return false
@@ -146,7 +155,7 @@ else:
       dec gTicker
 
   proc hook(st: StackTrace) {.nimcall, locks: 0.} =
-    #echo "profiling! ", interval
+    # echo "profiling! ", interval
     if interval == 0:
       hookAux(st, 1)
     else:
@@ -167,7 +176,7 @@ proc writeProfile() {.noconv.} =
   when declared(system.StackTrace):
     system.profilerHook = nil
   const filename = "profile_results.txt"
-  echo "writing " & filename & "..."
+  echo "writing " & filename & " ..."
   var f: File
   if open(f, filename, fmWrite):
     sort(profileData, cmpEntries)

--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -197,7 +197,7 @@ proc writeProfile() {.noconv.} =
 
     var sum = 0
     # only write the first 100 entries:
-    for i in 0..min(100, entries-1):
+    for i in 0..<min(100, entries):
       if profileData[i].total > 1:
         inc sum, profileData[i].total
         writeLine(f, "Entry: ", i+1, "/", entries, " Calls: ",

--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -26,12 +26,6 @@ const
   withThreads = compileOption("threads")
   tickCountCorrection = 50_000
 
-when not declared(system.StackTrace):
-  type StackTrace = object
-    lines: array[0..20, cstring]
-    files: array[0..20, cstring]
-  proc `[]`*(st: StackTrace, i: int): cstring = st.lines[i]
-
 # We use a simple hash table of bounded size to keep track of the stack traces:
 type
   ProfileEntry = object
@@ -206,8 +200,9 @@ proc writeProfile() {.noconv.} =
         for ii in 0..high(StackTrace.lines):
           let procname = profileData[i].st[ii]
           let filename = profileData[i].st.files[ii]
+          let line = profileData[i].st.locLines[ii]
           if isNil(procname): break
-          writeLine(f, "  ", $filename & ": " & $procname, " ", perProc[$procname] // totalCalls)
+          writeLine(f, "  ", $filename & ":" & $line & " " & $procname, " ", perProc[$procname] // totalCalls)
     close(f)
     echo "... done"
   else:

--- a/lib/system/profiler.nim
+++ b/lib/system/profiler.nim
@@ -11,7 +11,7 @@
 # code generator. The idea is to inject the instruction stream
 # with 'nimProfile()' calls. These calls are injected at every loop end
 # (except perhaps loops that have no side-effects). At every Nth call a
-# stack trace is taken. A stack tace is a list of cstrings.
+# stack trace is taken. A stack trace is a list of cstrings.
 
 when defined(profiler) and defined(memProfiler):
   {.error: "profiler and memProfiler cannot be defined at the same time (See Embedded Stack Trace Profiler (ESTP) User Guide) for more details".}
@@ -26,7 +26,7 @@ type
     lines*: array[0..MaxTraceLen-1, cstring]
     files*: array[0..MaxTraceLen-1, cstring]
     #[
-    TODO(minor):
+    todo(minor):
     * rename to loc after renaming `lines` to procnames
     * make StackTrace = object: entry: array[0..MaxTraceLen-1, StackTraceEntry]
       with some StackTraceEntry object


### PR DESCRIPTION
/cc @Araq @zah

* add line to stacktrace in profiler results

* fixes #10106

* remove duplicate `type StackTrace = object` definition
note to reviewer: not sure where/when this was used, maybe I overlook some use case?

* minor bugfix in "for i in 0..<min(100, entries)" (previously printed 101 entries unlike what comment suggested)

Note: the fix for #10106 works but leads to code duplication; alternatives would be:
* move this to include (yuk...):
```
proc `==`(x, y: cstring): bool {.noSideEffect, inline.} 
```
* use `{.pushAcrossModuleBoundary profiler: off.}` as proposed here: https://github.com/nim-lang/Nim/issues/10120
