### PR TITLE
refs #10121

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -163,7 +163,8 @@ when defined(posix):
 
   when not defined(freebsd) and not defined(netbsd) and not defined(openbsd):
     var timezone {.importc, header: "<time.h>".}: int
-    tzset()
+    when not defined(valgrind_workaround_10121):
+      tzset()
 
 elif defined(windows):
   import winlean


### PR DESCRIPTION
* workaround for https://github.com/nim-lang/Nim/issues/10121#issuecomment-450453369
* allows profiling nim compiler itself with valgrind's callgrind, eg:
```
nim c -d:release -d:valgrind_workaround_10121 --passC:-g compiler/nim.nim
valgrind --tool=callgrind --fullpath-after= compiler/nim c compiler/nim.nim
callgrind_annotate callgrind.out.$pid
```

## note
this workaround is needed until upstream valgrind fixes this, just filed https://bugs.kde.org/show_bug.cgi?id=402696
