### PR TITLE
`nim c` now allows: when defined(c)

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -167,6 +167,7 @@ proc mainCommand*(graph: ModuleGraph) =
   of "c", "cc", "compile", "compiletoc":
     # compile means compileToC currently
     conf.cmd = cmdCompileToC
+    defineSymbol(graph.config.symbols, "c")
     commandCompileToC(graph)
   of "cpp", "compiletocpp":
     conf.cmd = cmdCompileToCpp


### PR DESCRIPTION
```
nim cpp allows: when defined(cpp)
nim objc allows: when defined(objc)
nim js allows: when defined(js)
```
and now, with this PR,
```
nim c allows: when defined(c)
```
