### PR TITLE
Fix when in generic objects

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -660,25 +660,14 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
       case it.kind
       of nkElifBranch:
         checkSonsLen(it, 2, c.config)
-        if c.inGenericContext == 0:
-          var e = semConstBoolExpr(c, it.sons[0])
-          if e.kind != nkIntLit: internalError(c.config, e.info, "semRecordNodeAux")
-          elif e.intVal != 0 and branch == nil: branch = it.sons[1]
-        else:
-          it.sons[0] = forceBool(c, semExprWithType(c, it.sons[0]))
+        var e = semConstBoolExpr(c, it.sons[0])
+        if e.kind != nkIntLit: internalError(c.config, e.info, "semRecordNodeAux")
+        elif e.intVal != 0 and branch == nil: branch = it.sons[1]
       of nkElse:
         checkSonsLen(it, 1, c.config)
         if branch == nil: branch = it.sons[0]
         idx = 0
       else: illFormedAst(n, c.config)
-      if c.inGenericContext > 0:
-        # use a new check intset here for each branch:
-        var newCheck: IntSet
-        assign(newCheck, check)
-        var newPos = pos
-        var newf = newNodeI(nkRecList, n.info)
-        semRecordNodeAux(c, it.sons[idx], newCheck, newPos, newf, rectype)
-        it.sons[idx] = if newf.len == 1: newf[0] else: newf
     if c.inGenericContext > 0:
       addSon(father, n)
     elif branch != nil:

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -106,9 +106,6 @@ when defineSsl:
       serverGetPskFunc: SslServerGetPskFunc
       clientGetPskFunc: SslClientGetPskFunc
 
-else:
-  type
-    SslContext* = void # TODO: Workaround #4797.
 
 const
   BufferSize*: int = 4000 ## size of a buffered socket's buffer


### PR DESCRIPTION
I don't think semantics of `when` change in a generic context.
But in case they do, then this fix is probably wrong.

The code for generic context was originally introduced in https://github.com/nim-lang/Nim/commit/72651de7103a85f68b6e86353960daf6e62b37df (No idea which bug it fixed though.)

Closes https://github.com/nim-lang/Nim/issues/4774