### PR TITLE
Show field not initialized warning only when `notnil` used

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -141,7 +141,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     if isPure and (let conflict = strTableInclReportConflict(symbols, e); conflict != nil):
       wrongRedefinition(c, e.info, e.name.s, conflict.info)
     inc(counter)
-  if not hasNull: incl(result.flags, tfNeedsInit)
+  if tfNotNil in e.typ.flags and not hasNull: incl(result.flags, tfNeedsInit)
 
 proc semSet(c: PContext, n: PNode, prev: PType): PType =
   result = newOrPrevType(tySet, prev, c)


### PR DESCRIPTION
Closes https://github.com/nim-lang/Nim/issues/5635

Also allows (because a similar code `var x: ExplicitEnum` compiles)
```
import tables
type
  ExplicitEnum = enum
    Val1 = 1 

  MyObj = ref object
    table: ExplicitEnum

let obj = MyObj()
echo obj.table
```
which currently gives ` Error: field not initialized: table` 