### PR TITLE
fix system.nim documentations

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2767,8 +2767,8 @@ when not defined(nimscript) and hasAlloc:
 
     when not defined(JS) and not defined(nimscript) and hasAlloc:
       proc nimGC_setStackBottom*(theStackBottom: pointer) {.compilerRtl, noinline, benign.}
-      ## Expands operating GC stack range to `theStackBottom`. Does nothing
-      ## if current stack bottom is already lower than `theStackBottom`.
+        ## Expands operating GC stack range to `theStackBottom`. Does nothing
+        ## if current stack bottom is already lower than `theStackBottom`.
 
   else:
     template GC_disable* =

--- a/lib/system/helpers.nim
+++ b/lib/system/helpers.nim
@@ -1,5 +1,5 @@
-## helpers used system.nim and other modules, avoids code duplication while
-## also minimizing symbols exposed in system.nim
+# helpers used system.nim and other modules, avoids code duplication while
+# also minimizing symbols exposed in system.nim
 #
 # TODO: move other things here that should not be exposed in system.nim
 


### PR DESCRIPTION
Some unrelated documentations have leaked into the top-level of system.nim. This PR fixes that.