### PR TITLE
add test case for #7976

### DIFF
--- a/tests/helper_testament.nim
+++ b/tests/helper_testament.nim
@@ -1,0 +1,10 @@
+# note: not merging with tests/assert/testhelper.nim as this pulls less
+# dependencies so is more generally applicable
+
+proc assertEquals*[T](lhs: T, rhs: T) =
+  ## Simplified version of `unittest.require` that satisfies a common use case,
+  ## while avoiding pulling too many dependencies. The `{}` are useful to
+  ## spot whitespace issues.
+  if lhs!=rhs:
+    echo "lhs:{\n", lhs, "}\nrhs:{\n", rhs, "}"
+    doAssert false

--- a/tests/issues/readme.md
+++ b/tests/issues/readme.md
@@ -1,0 +1,5 @@
+This directory can be used for adding a test case to a github issue, eg:
+issue `#7976` would have test case named `t7976.nim`
+It makes it easier to find which issue corresponds to a test caes, or vice
+versa, and removes the guesswork of trying to figure out an appropriate
+directory/filename by being more systematic.

--- a/tests/issues/t7976.nim
+++ b/tests/issues/t7976.nim
@@ -45,19 +45,14 @@ when defined(case5):
 
 when not defined(case_any_testcase): # main driver
   import os, strutils, osproc, strformat
-  proc assertEquals[T](lhs: T, rhs: T) =
-    if lhs!=rhs:
-      echo "lhs:{\n", lhs, "}\nrhs:{", rhs, "}"
-      echo "lhs:\n", lhs, "\nrhs:", rhs
-      doAssert false
-
-  var output = ""
+  from "../helper_testament" import assertEquals
   proc main() =
     const nim = getCurrentCompilerExe()
     const self = currentSourcePath
     let cases = "case1 case2 case3 case4 case5".split
+    var output = ""
     for opt in cases:
-      let cmd = fmt"{nim} c -r --colors:off --hints:off -d:case_any_testcase -d:{opt} {self}"
+      let cmd = fmt"{nim} c -r --verbosity:0 --colors:off --hints:off -d:case_any_testcase -d:{opt} {self}"
       output.add "test case: " & opt & "\n"
       let ret = execCmdEx(cmd, {poStdErrToStdOut, poEvalCommand})
       doAssert ret.exitCode == 0

--- a/tests/issues/t7976.nim
+++ b/tests/issues/t7976.nim
@@ -1,0 +1,83 @@
+when defined(case1):
+  import strformat, typetraits
+  type Person = tuple[name: string, age: int]
+  let
+    person1: Person = ("Peter", 30)
+    person2 = (name: "Peter", age: 30)
+  echo fmt"Tuple person1 of type {$person1.type} = {person1}"
+  echo fmt"Tuple person2 of type {$person2.type} = {person2}"
+
+when defined(case2):
+  import strformat, typetraits
+  type Person = tuple[name: string, age: int]
+  let
+    person1 = (name: "Peter", age: 30)
+    person2: Person = ("Peter", 30)
+  echo fmt"Tuple person1 of type {$person1.type} = {person1}"
+  echo fmt"Tuple person2 of type {$person2.type} = {person2}"
+
+when defined(case3):
+  import strformat, typetraits
+  type Person = tuple[name: string, age: int]
+  let
+    person1: Person = ("Peter", 30)
+    person2 = (name: "Peter", age: 30)
+  echo fmt"Tuple person1 of type {$person1.type} = {person1}"
+  echo fmt"Tuple person2 of type {$person2.type} = {person2}"
+
+when defined(case4):
+  import strformat, typetraits
+  type Person = tuple[name: string, age: int]
+  let
+    person1: Person = ("Peter", 30)
+    person2 = (name: "Peter", age: 30)
+  echo fmt"Tuple person1 of type {$person2.type} = {person2}" # simply moved up
+  echo fmt"Tuple person2 of type {$person1.type} = {person1}"
+
+when defined(case5):
+  import strformat, typetraits
+  type Person = tuple[name: string, age: int]
+  let
+    person1: Person = ("Peter", 30)
+    person2 = (name: "Peter", age: 30)
+  echo fmt"Tuple person1 of type {name(person1.type)} = {person1}"
+  echo fmt"Tuple person2 of type {name(person2.type)} = {person2}"
+
+when not defined(case_any_testcase): # main driver
+  import os, strutils, osproc, strformat
+  proc assertEquals[T](lhs: T, rhs: T) =
+    if lhs!=rhs:
+      echo "lhs:{\n", lhs, "}\nrhs:{", rhs, "}"
+      echo "lhs:\n", lhs, "\nrhs:", rhs
+      doAssert false
+
+  var output = ""
+  proc main() =
+    const nim = getCurrentCompilerExe()
+    const self = currentSourcePath
+    let cases = "case1 case2 case3 case4 case5".split
+    for opt in cases:
+      let cmd = fmt"{nim} c -r --colors:off --hints:off -d:case_any_testcase -d:{opt} {self}"
+      output.add "test case: " & opt & "\n"
+      let ret = execCmdEx(cmd, {poStdErrToStdOut, poEvalCommand})
+      doAssert ret.exitCode == 0
+      output.add ret.output
+    let expected = """
+test case: case1
+Tuple person1 of type Person = (name: "Peter", age: 30)
+Tuple person2 of type tuple[name: string, age: int] = (name: "Peter", age: 30)
+test case: case2
+Tuple person1 of type tuple[name: string, age: int] = (name: "Peter", age: 30)
+Tuple person2 of type Person = (name: "Peter", age: 30)
+test case: case3
+Tuple person1 of type Person = (name: "Peter", age: 30)
+Tuple person2 of type tuple[name: string, age: int] = (name: "Peter", age: 30)
+test case: case4
+Tuple person1 of type tuple[name: string, age: int] = (name: "Peter", age: 30)
+Tuple person2 of type Person = (name: "Peter", age: 30)
+test case: case5
+Tuple person1 of type Person = (name: "Peter", age: 30)
+Tuple person2 of type tuple[name: string, age: int] = (name: "Peter", age: 30)
+"""
+    assertEquals(output, expected)
+  main()


### PR DESCRIPTION
* closes #7976 by adding test case
* in reply to https://github.com/nim-lang/Nim/issues/7976#issuecomment-450895141 from @@kaushalmodi , I verified that 083129286349ba440018cff1ed20172b675b84fe is the commit that fixed #7976 (see my corresponding PR #10071)

## note1
I'm using the same technique here as I had introduced here https://github.com/nim-lang/Nim/pull/9927 
it allows grouping tests in a single self contained file instead of splitting in multiple files (see also rationale here: see rationale here: https://github.com/nim-lang/Nim/pull/9927#issue-237544090)

I've read this comment https://github.com/nim-lang/Nim/pull/9927#issuecomment-446547353 but testament doesn't support this, and the pattern is simple and gives fine grained control to test writer.

## note2:
see tests/issues/readme.md for rationale why I'm adding this directory; my intent is to also use it for https://github.com/nim-lang/Nim/issues/10170