### PR TITLE
fix #10166: loadLib now throws on error (and shows dlerror()) instead of silently ignoring error 

### DIFF
--- a/tests/issues/t10166.nim
+++ b/tests/issues/t10166.nim
@@ -1,17 +1,7 @@
-discard """
-disabled:true
-"""
-
 import dynlib
-
-proc dlclose(lib: LibHandle):cint {.importc, header: "<dlfcn.h>".}
-proc dlerror(): cstring {.importc, header: "<dlfcn.h>".}
 
 proc main()=
   var libHandle: LibHandle
-  doAssertRaises(LibraryError):
-    if dlclose(libHandle) != 0:
-      raise newException(LibraryError, $dlerror())
   doAssertRaises(LibraryError):
     unloadLib(libHandle)
 main()

--- a/tests/issues/t10166.nim
+++ b/tests/issues/t10166.nim
@@ -1,0 +1,17 @@
+discard """
+disabled:true
+"""
+
+import dynlib
+
+proc dlclose(lib: LibHandle):cint {.importc, header: "<dlfcn.h>".}
+proc dlerror(): cstring {.importc, header: "<dlfcn.h>".}
+
+proc main()=
+  var libHandle: LibHandle
+  doAssertRaises(LibraryError):
+    if dlclose(libHandle) != 0:
+      raise newException(LibraryError, $dlerror())
+  doAssertRaises(LibraryError):
+    unloadLib(libHandle)
+main()


### PR DESCRIPTION
* fix #10166 (on both posix and windows)
* throw on error (and show `dlerror()` msg, for posix) instead of silently ignoring
* use `WINBOOL = distinct int32` as well as type-safe `template isOK(success: WINBOOL)` in lib/pure/dynlib.nim with this note:
```
     # todo: merge with winlean.WINBOOL after making it `distinct` there too.
     # `WINBOOL` as a raw `int32` is error-prone since its meaning is opposite
     # from posix status codes (in which 0 means success).
```

## todo for future PR's
`proc loadLib*(): LibHandle {.gcsafe.}` + friends could similarly get "safe" overloads that throw (and show informative msg from `dlerror()`) instead of silently ignoring errors, eg:
```
proc loadLib*(throws=false): LibHandle {.gcsafe.}
or:
proc checkedLoadLib*(): LibHandle {.gcsafe.}
```
