### PR TITLE
os.walkDir: correctly evaluate paths when relative = true [0.19]

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -875,8 +875,9 @@ iterator walkDir*(dir: string; relative=false): tuple[kind: PathComponent, path:
             var y = $x.d_name.cstring
           if y != "." and y != "..":
             var s: Stat
+            let path = dir / y
             if not relative:
-              y = dir / y
+              y = path
             var k = pcFile
 
             when defined(linux) or defined(macosx) or
@@ -884,16 +885,16 @@ iterator walkDir*(dir: string; relative=false): tuple[kind: PathComponent, path:
               if x.d_type != DT_UNKNOWN:
                 if x.d_type == DT_DIR: k = pcDir
                 if x.d_type == DT_LNK:
-                  if dirExists(y): k = pcLinkToDir
+                  if dirExists(path): k = pcLinkToDir
                   else: k = pcLinkToFile
                 yield (k, y)
                 continue
 
-            if lstat(y, s) < 0'i32: break
+            if lstat(path, s) < 0'i32: break
             if S_ISDIR(s.st_mode):
               k = pcDir
             elif S_ISLNK(s.st_mode):
-              k = getSymlinkFileKind(y)
+              k = getSymlinkFileKind(path)
             yield (k, y)
 
 iterator walkDirRec*(dir: string, yieldFilter = {pcFile},

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -189,6 +189,13 @@ when defined(posix):
       doAssert normalizedPath("/a/b/c/..") == "/a/b"
       doAssert normalizedPath("/a/b/c/../") == "/a/b"
 
+  block walkDirRelative:
+    createDir("walkdir_test")
+    createSymlink(".", "walkdir_test/c")
+    for k, p in walkDir("walkdir_test", true):
+      doAssert k == pcLinkToDir
+    removeDir("walkdir_test")
+
 else:
 
   block normalizedPath:


### PR DESCRIPTION
A port of b6257f3f212036216fb4aeb521a3d120222b237c for version-0-19 branch

/cc @Araq 