### PR TITLE
[backport] correctly document `toInt`, fixes #2764 [ci skip]

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1799,14 +1799,16 @@ proc toBiggestFloat*(i: BiggestInt): BiggestFloat {.
 proc toInt*(f: float): int {.
   magic: "ToInt", noSideEffect, importc: "toInt".}
   ## converts a floating point number `f` into an ``int``. Conversion
-  ## rounds `f` if it does not contain an integer value. If the conversion
-  ## fails (because `f` is infinite for example), `ValueError` is raised.
+  ## rounds `f` if it does not contain an integer value.
+  ## Note that some floating point numbers (e.g. infinty) cannot be
+  ## accurately converted.
 
 proc toBiggestInt*(f: BiggestFloat): BiggestInt {.
   magic: "ToBiggestInt", noSideEffect, importc: "toBiggestInt".}
   ## converts a biggestfloat `f` into a ``biggestint``. Conversion
-  ## rounds `f` if it does not contain an integer value. If the conversion
-  ## fails (because `f` is infinite for example), `ValueError` is raised.
+  ## rounds `f` if it does not contain an integer value.
+  ## Note that some floating point numbers (e.g. infinty) cannot be
+  ## accurately converted.
 
 proc addQuitProc*(quitProc: proc() {.noconv.}) {.
   importc: "atexit", header: "<stdlib.h>".}


### PR DESCRIPTION
Only documentation fixes — skipping CI.