### PR TITLE
add `alignTable`, `parseTableCells` to align/format a tab(etc) delimited table

### DIFF
--- a/compiler/asciitables.nim
+++ b/compiler/asciitables.nim
@@ -1,0 +1,83 @@
+#[
+move to std/asciitables.nim once stable, or to a nimble paackage
+once compiler can depend on nimble
+]#
+
+type Cell* = object
+  text*: string
+  width*, row*, col*, ncols*, nrows*: int
+
+iterator parseTableCells*(s: string, delim = '\t'): Cell =
+  ## iterates over all cells in a `delim`-delimited `s`, after a 1st
+  ## pass that computes number of rows, columns, and width of each column.
+  var widths: seq[int]
+  var cell: Cell
+  template update() =
+    if widths.len<=cell.col:
+      widths.setLen cell.col+1
+      widths[cell.col] = cell.width
+    else:
+      widths[cell.col] = max(widths[cell.col], cell.width)
+    cell.width = 0
+
+  for a in s:
+    case a
+    of '\n':
+      update()
+      cell.col = 0
+      cell.row.inc
+    elif a == delim:
+      update()
+      cell.col.inc
+    else:
+      # todo: consider multi-width chars when porting to non-ascii implementation
+      cell.width.inc
+  if s.len > 0 and s[^1] != '\n':
+    update()
+
+  cell.ncols = widths.len
+  cell.nrows = cell.row + 1
+  cell.row = 0
+  cell.col = 0
+  cell.width = 0
+
+  template update2() =
+    cell.width = widths[cell.col]
+    yield cell
+    cell.text = ""
+    cell.width = 0
+    cell.col.inc
+
+  template finishRow() =
+    for col in cell.col..<cell.ncols:
+      cell.col = col
+      update2()
+    cell.col = 0
+
+  for a in s:
+    case a
+    of '\n':
+      finishRow()
+      cell.row.inc
+    elif a == delim:
+      update2()
+    else:
+      cell.width.inc
+      cell.text.add a
+
+  if s.len > 0 and s[^1] != '\n':
+    finishRow()
+
+proc alignTable*(s: string, delim = '\t', fill = ' ', sep = " "): string =
+  ## formats a `delim`-delimited `s` representing a table; each cell is aligned
+  ## to a width that's computed for each column; consecutive columns are
+  ## delimted by `sep`, and alignment space is filled using `fill`.
+  ## More customized formatting can be done by calling `parseTableCells` directly.
+  for cell in parseTableCells(s, delim):
+    result.add cell.text
+    for i in cell.text.len..<cell.width:
+      result.add fill
+    if cell.col < cell.ncols-1:
+      result.add sep
+    if cell.col == cell.ncols-1 and cell.row < cell.nrows - 1:
+      result.add '\n'

--- a/compiler/unittest_light.nim
+++ b/compiler/unittest_light.nim
@@ -1,0 +1,37 @@
+# note: consider merging tests/assert/testhelper.nim here.
+
+proc mismatch*[T](lhs: T, rhs: T): string =
+  ## Simplified version of `unittest.require` that satisfies a common use case,
+  ## while avoiding pulling too many dependencies. On failure, diagnostic
+  ## information is provided that in particular makes it easy to spot
+  ## whitespace mismatches and where the mismatch is.
+  proc replaceInvisible(s: string): string =
+    for a in s:
+      case a
+      of '\n': result.add "\\n\n"
+      else: result.add a
+
+  proc quoted(s: string): string = result.addQuoted s
+
+  result.add "\n"
+  result.add "lhs:{\n" & replaceInvisible(
+      $lhs) & "}\nrhs:{\n" & replaceInvisible($rhs) & "}\n"
+  when compiles(lhs.len):
+    if lhs.len != rhs.len:
+      result.add "lhs.len: " & $lhs.len & " rhs.len: " & $rhs.len & "\n"
+    when compiles(lhs[0]):
+      var i = 0
+      while i<lhs.len and i<rhs.len:
+        if lhs[i] != rhs[i]: break
+        i.inc
+      result.add "first mismatch index: " & $i & "\n"
+      if i < lhs.len and i<rhs.len:
+        result.add "lhs[i]: {" & quoted($lhs[i]) & "} rhs[i]: {" & quoted(
+            $rhs[i]) & "}"
+      result.add "lhs[0..<i]:{\n" & replaceInvisible($lhs[
+          0..<i]) & "}\nrhs[0..<i]:{\n" & replaceInvisible($rhs[0..<i]) & "}"
+
+proc assertEquals*[T](lhs: T, rhs: T) =
+  when false: # can be useful for debugging to see all that's fed to this.
+    echo "----" & $lhs
+  doAssert lhs==rhs, mismatch(lhs, rhs)

--- a/compiler/unittest_light.nim
+++ b/compiler/unittest_light.nim
@@ -21,11 +21,11 @@ proc mismatch*[T](lhs: T, rhs: T): string =
       result.add "lhs.len: " & $lhs.len & " rhs.len: " & $rhs.len & "\n"
     when compiles(lhs[0]):
       var i = 0
-      while i<lhs.len and i<rhs.len:
+      while i < lhs.len and i < rhs.len:
         if lhs[i] != rhs[i]: break
         i.inc
       result.add "first mismatch index: " & $i & "\n"
-      if i < lhs.len and i<rhs.len:
+      if i < lhs.len and i < rhs.len:
         result.add "lhs[i]: {" & quoted($lhs[i]) & "} rhs[i]: {" & quoted(
             $rhs[i]) & "}"
       result.add "lhs[0..<i]:{\n" & replaceInvisible($lhs[

--- a/tests/compiler/nim.cfg
+++ b/tests/compiler/nim.cfg
@@ -1,0 +1,7 @@
+# note: consider moving tests/compilerapi/ to tests/compiler/ since
+# that's more predictable.
+
+# note: without this, tests may succeed locally but fail on CI (it can succeed
+# locally even when compiling via `./bin/nim` because `$HOME/.nimble` is being
+# used).
+--path:"../../" # so we can `import compiler/foo` in this dir

--- a/tests/compiler/tasciitables.nim
+++ b/tests/compiler/tasciitables.nim
@@ -1,0 +1,109 @@
+import compiler/unittest_light
+import compiler/asciitables
+
+import strformat
+
+proc alignTableCustom(s: string, delim = '\t', sep = ","): string =
+  for cell in parseTableCells(s, delim):
+    result.add fmt"({cell.row},{cell.col}): "
+    for i in cell.text.len..<cell.width:
+      result.add " "
+    result.add cell.text
+    if cell.col < cell.ncols-1:
+      result.add sep
+    if cell.col == cell.ncols-1 and cell.row < cell.nrows - 1:
+      result.add '\n'
+
+proc testAlignTable() =
+  block: # test with variable width columns
+    var ret = ""
+    ret.add "12\t143\tbcdef\n"
+    ret.add "2\t14394852020\tbcdef\n"
+    ret.add "45342\t1\tbf\n"
+    ret.add "45342\t1\tbsadfasdfasfdasdff\n"
+    ret.add "453232323232342\t1\tbsadfasdfasfdasdff\n"
+    ret.add "45342\t1\tbf\n"
+    ret.add "45342\t1\tb afasf a ff\n"
+    ret.add "4\t1\tbf\n"
+
+    assertEquals alignTable(ret),
+      """
+12              143         bcdef             
+2               14394852020 bcdef             
+45342           1           bf                
+45342           1           bsadfasdfasfdasdff
+453232323232342 1           bsadfasdfasfdasdff
+45342           1           bf                
+45342           1           b afasf a ff      
+4               1           bf                
+"""
+
+    assertEquals alignTable(ret, fill = '.', sep = ","),
+      """
+12.............,143........,bcdef.............
+2..............,14394852020,bcdef.............
+45342..........,1..........,bf................
+45342..........,1..........,bsadfasdfasfdasdff
+453232323232342,1..........,bsadfasdfasfdasdff
+45342..........,1..........,bf................
+45342..........,1..........,b afasf a ff......
+4..............,1..........,bf................
+"""
+
+    assertEquals alignTableCustom(ret, sep = "  "),
+      """
+(0,0):              12  (0,1):         143  (0,2):              bcdef
+(1,0):               2  (1,1): 14394852020  (1,2):              bcdef
+(2,0):           45342  (2,1):           1  (2,2):                 bf
+(3,0):           45342  (3,1):           1  (3,2): bsadfasdfasfdasdff
+(4,0): 453232323232342  (4,1):           1  (4,2): bsadfasdfasfdasdff
+(5,0):           45342  (5,1):           1  (5,2):                 bf
+(6,0):           45342  (6,1):           1  (6,2):       b afasf a ff
+(7,0):               4  (7,1):           1  (7,2):                 bf
+"""
+
+  block: # test with 1 column
+    var ret = "12\nasdfa\nadf"
+    assertEquals alignTable(ret), """
+12   
+asdfa
+adf  """
+
+  block: # test with empty input
+    var ret = ""
+    assertEquals alignTable(ret), ""
+
+  block: # test with 1 row
+    var ret = "abc\tdef"
+    assertEquals alignTable(ret), """
+abc def"""
+
+  block: # test with 1 row ending in \t
+    var ret = "abc\tdef\t"
+    assertEquals alignTable(ret), """
+abc def """
+
+  block: # test with 1 row starting with \t
+    var ret = "\tabc\tdef\t"
+    assertEquals alignTable(ret), """
+ abc def """
+
+
+  block: # test with variable number of cols per row
+    var ret = """
+a1,a2,a3
+
+b1
+c1,c2
+,d1
+"""
+    assertEquals alignTableCustom(ret, delim = ',', sep = ","),
+      """
+(0,0): a1,(0,1): a2,(0,2): a3
+(1,0):   ,(1,1):   ,(1,2):   
+(2,0): b1,(2,1):   ,(2,2):   
+(3,0): c1,(3,1): c2,(3,2):   
+(4,0):   ,(4,1): d1,(4,2):   
+"""
+
+testAlignTable()

--- a/tests/compiler/tunittest_light.nim
+++ b/tests/compiler/tunittest_light.nim
@@ -1,0 +1,55 @@
+import compiler/unittest_light
+
+proc test_assertEquals() =
+  assertEquals("foo", "foo")
+  doAssertRaises(AssertionError):
+    assertEquals("foo", "foo ")
+
+proc test_mismatch() =
+  assertEquals(1+1, 2*1)
+
+  let a = """
+  some test with space at the end of lines    
+
+  can be hard to spot differences when diffing in a terminal   
+  without this helper function
+
+"""
+
+  let b = """
+  some test with space at the end of lines    
+
+  can be hard to spot differences when diffing in a terminal  
+  without this helper function
+
+"""
+
+  doAssert mismatch(a, b) == """
+
+lhs:{
+  some test with space at the end of lines    \n
+\n
+  can be hard to spot differences when diffing in a terminal   \n
+  without this helper function\n
+\n
+}
+rhs:{
+  some test with space at the end of lines    \n
+\n
+  can be hard to spot differences when diffing in a terminal  \n
+  without this helper function\n
+\n
+}
+lhs.len: 144 rhs.len: 143
+first mismatch index: 110
+lhs[i]: {" "} rhs[i]: {"\n"}lhs[0..<i]:{
+  some test with space at the end of lines    \n
+\n
+  can be hard to spot differences when diffing in a terminal  }
+rhs[0..<i]:{
+  some test with space at the end of lines    \n
+\n
+  can be hard to spot differences when diffing in a terminal  }"""
+
+test_mismatch()
+test_assertEquals()

--- a/tests/compiler/tunittest_light.nim
+++ b/tests/compiler/tunittest_light.nim
@@ -1,11 +1,11 @@
 import compiler/unittest_light
 
-proc test_assertEquals() =
+proc testAssertEquals() =
   assertEquals("foo", "foo")
   doAssertRaises(AssertionError):
     assertEquals("foo", "foo ")
 
-proc test_mismatch() =
+proc testMismatch() =
   assertEquals(1+1, 2*1)
 
   let a = """
@@ -51,5 +51,5 @@ rhs[0..<i]:{
 \n
   can be hard to spot differences when diffing in a terminal  }"""
 
-test_mismatch()
-test_assertEquals()
+testMismatch()
+testAssertEquals()


### PR DESCRIPTION
* depends on https://github.com/nim-lang/Nim/pull/10181 when viewing the diff
* useful for easy pretty-printing of tables, see ./tests/compiler/tasciitables.nim
* automatically infers number of rows, cols, and width of each cell
* can be either used with the provided `alignTable(ret)` or arbitrarily customized by calling the iterator `for cell in parseTableCells(s, delim):` directly

after this PR is merged, I'll update `vmgen.codeListing` to use that instead ; it'll generate nicer looking listings (aligned) which are easier to follow, eg:
```
code listing:
103           AsgnStr   r5, r1, r0          #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:3
104           LdConst   r6, "(" (9)         #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:10
105           Conv      r7, r2, string, int #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:16
108           LdConst   r8, ", " (10)       #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:24
109           Conv      r9, r3, string, int #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:31
112           LdConst   r10, ")" (11)       #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:41
113           ConcatStr r4, r5, r6          #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:39
114           AsgnStr   r0, r4, r1          #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:6:1
115           Ret       r0, r0, r0          #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:3
116           Eof       r0, r0, r0          #/Users/timothee/git_clone/nim/Nim/lib/system/helpers.nim:7:3

```

(some other irrelevant changes done in above listing, but the point is alignment is now working)