### PR TITLE
[CI] fix #10041 move bulk of `travis` and `appveyor` logic to koch.nim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,26 +40,11 @@ before_script:
   - sh build.sh
   - cd ..
   - export PATH=$(pwd)/bin${PATH:+:$PATH}
+  - echo PATH:${PATH}
+
 script:
   - nim c koch
-  - env NIM_COMPILE_TO_CPP=false ./koch boot
-  - ./koch boot -d:release
-  - ./koch nimble
-  - nim e tests/test_nimscript.nims
-  #- nimble install zip -y
-  #- nimble install opengl
-  #- nimble install sdl1
-  #- nimble install jester@#head -y
-  #- nimble install niminst
-  - nim c -d:nimCoroutines testament/tester
-  - testament/tester --pedantic all -d:nimCoroutines
-  - nim c -o:bin/nimpretty nimpretty/nimpretty.nim
-  - nim c -r nimpretty/tester.nim
-  - ./koch docs --git.commit:devel
-  - ./koch csource
-  - ./koch nimsuggest
-  - nim c -r nimsuggest/tester
-  - nim c -r nimdoc/tester
+  - ./koch runCI
 
 before_deploy:
   # Make https://nim-lang.github.io/Nim work the same as https://nim-lang.github.io/Nim/overview.html

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,22 +44,6 @@ install:
 
 build_script:
   - bin\nim c koch
-  - koch boot -d:release
-  - koch nimble
-  - nim e tests/test_nimscript.nims
-  - nim c -o:bin/nimpretty.exe nimpretty/nimpretty.nim
-  - nim c -r nimpretty/tester.nim
-#  - nimble install zip -y
-#  - nimble install opengl -y
-#  - nimble install sdl1 -y
-#  - nimble install jester@#head -y
-  - nim c -d:nimCoroutines --os:genode -d:posix --compileOnly testament/tester
-  - nim c -d:nimCoroutines testament/tester
-
-test_script:
-  - testament\tester --pedantic all -d:nimCoroutines
-  - nim c -r nimdoc\tester
-#  - koch csource
-#  - koch zip
+  - koch runCI
 
 deploy: off

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -34,6 +34,9 @@ proc exec*(cmd: string, errorcode: int = QuitFailure, additionalPath = "") =
       absolute = getCurrentDir() / absolute
     echo("Adding to $PATH: ", absolute)
     putEnv("PATH", (if prevPath.len > 0: prevPath & PathSep else: "") & absolute)
+  when defined(windows):
+    var cmd = cmd
+    if cmd.startsWith "./": cmd = cmd[2..^1]
   echo(cmd)
   if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
   putEnv("PATH", prevPath)

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -51,9 +51,8 @@ proc execCleanPath*(cmd: string,
   if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
   putEnv("PATH", prevPath)
 
-let kochExe* = "koch".absolutePath
-  # designed so that it also means ./koch on windows, as opposed to another one
-  # in PATH (otherwise would be inconsistent with posix).
+let kochExe* = os.getAppFilename()
+  # note: assumes `kochdocs` is only used by koch.nim
 
 proc kochExec*(cmd: string) =
   exec kochExe.quoteShell & " " & cmd

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -34,9 +34,6 @@ proc exec*(cmd: string, errorcode: int = QuitFailure, additionalPath = "") =
       absolute = getCurrentDir() / absolute
     echo("Adding to $PATH: ", absolute)
     putEnv("PATH", (if prevPath.len > 0: prevPath & PathSep else: "") & absolute)
-  when defined(windows):
-    var cmd = cmd
-    if cmd.startsWith "./": cmd = cmd[2..^1]
   echo(cmd)
   if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
   putEnv("PATH", prevPath)
@@ -53,6 +50,13 @@ proc execCleanPath*(cmd: string,
   echo(cmd)
   if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
   putEnv("PATH", prevPath)
+
+let kochExe* = "koch".absolutePath
+  # designed so that it also means ./koch on windows, as opposed to another one
+  # in PATH (otherwise would be inconsistent with posix).
+
+proc kochExec*(cmd: string) =
+  exec kochExe.quoteShell & " " & cmd
 
 proc nimexec*(cmd: string) =
   # Consider using `nimCompile` instead


### PR DESCRIPTION
* fix #10041
## TODO left for subsequent PRs:
- [ ] time each `exec` command (so we know the bottlenecks)
- [ ] add a smoke test (eg `smoke_test.nim`) that runs as early as possible (before other tests) and whose job is to fail fast to reject PR's in a bad state (eg after a typo) and avoid wasting CI time for these; it shall import as many modules as possible (without running into known limitations) and just try to compile it (maybe via `nim --errrormax:0 smoke_test.nim`) ; code can be reused with megatest maybe

