### PR TITLE
Fix the tuple returned by `os.splitFile()` in documentation

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -336,7 +336,7 @@ proc searchExtPos*(path: string): int =
 
 proc splitFile*(path: string): tuple[dir, name, ext: string] {.
   noSideEffect, rtl, extern: "nos$1".} =
-  ## Splits a filename into (dir, filename, extension).
+  ## Splits a filename into (dir, name, extension).
   ## `dir` does not end in `DirSep`.
   ## `extension` includes the leading dot.
   ##


### PR DESCRIPTION
The tuple returns `name` instead of `filename` as seen here: https://github.com/nim-lang/Nim/blob/be0a4d1342b05815e25f9a51bda0cf199a6d439e/lib/pure/os.nim#L378