### PR TITLE
Fix ODBC SQL Error string decoding

### DIFF
--- a/lib/impure/db_odbc.nim
+++ b/lib/impure/db_odbc.nim
@@ -131,7 +131,7 @@ proc getErrInfo(db: var DbConn): tuple[res: int, ss, ne, msg: string] {.
               511.TSqlSmallInt, retSz.addr.PSQLSMALLINT)
   except:
     discard
-  return (res.int, $sqlState, $nativeErr, $errMsg)
+  return (res.int, $(addr sqlState), $(addr nativeErr), $(addr errMsg))
 
 proc dbError*(db: var DbConn) {.
           tags: [ReadDbEffect, WriteDbEffect], raises: [DbError] .} =


### PR DESCRIPTION
ODBC Errors were presented to the users as a sequence of characters.
I.e.:

    >test_oracle.exe

    Error: ['H', 'Y', '0', '0', '0', '\x00', '\x00', ...]

    test_oracle.nim(15)      test_oracle
    test_oracle.nim(8)       test_oracle
    db_odbc.nim(534)         open
    db_odbc.nim(168)         dbError
    Error: unhandled exception: ODBC Error [DbError]

This patch fix the string decoding, creating a real string:

    >test_oracle.exe

    Error: HY000 [Oracle][ODBC][Ora]ORA-12541: TNS:no listener

    test_oracle.nim(15)      test_oracle
    test_oracle.nim(8)       test_oracle
    db_odbc.nim(534)         open
    db_odbc.nim(168)         dbError
    Error: unhandled exception: ODBC Error [DbError]