### PR TITLE
os.execShellCmd: use WEXITSTATUS to retrieve exit code

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1298,7 +1298,7 @@ proc execShellCmd*(command: string): int {.rtl, extern: "nos$1",
   ## shell involved, use the `execProcess` proc of the `osproc`
   ## module.
   when defined(posix):
-    result = c_system(command) shr 8
+    result = WEXITSTATUS(c_system(command))
   else:
     result = c_system(command)
 


### PR DESCRIPTION
According to POSIX, `system()` shall returns the termination status in the
format specified by `waitpid()`, which means `WEXITSTATUS` should be used to
retrieve the exit code portably.

This fixes execShellCmd on Haiku.

Can we have this backported as well?