### PR TITLE
[WIP] CountTable now returns 0 instead of 'key not found' for immutable get…

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -963,7 +963,7 @@ proc mget*[A](t: var CountTable[A], key: A): var int {.deprecated.} =
   ctget(t, key)
 
 proc getOrDefault*[A](t: CountTable[A], key: A): int =
-  ## retrieves the value at ``t[key]`` if ``key`` is in ``t``. Otherwise, 0 (the
+  ## retrieves the value at ``t[key]`` iff ``key`` is in ``t``. Otherwise, 0 (the
   ## default initialization value of ``int``), is returned.
   ctgetOrDefault(t, key)
 


### PR DESCRIPTION
Fixes #10065. 
~~I left the mutable get requests raise Key Error because I did not know what the proper response would be there.~~
Now is possible to do
```
  var tbl = toCountTable("abracadabra")
  doAssert tbl['z'] == 0
  tbl['z'] = 1
  doAssert tbl['z'] == 1
```
