### PR TITLE
Change the search order of libSSL libs from newest to oldest.

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -38,7 +38,7 @@ when useWinVersion:
 
   from winlean import SocketHandle
 else:
-  const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
+  const versions = "(.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.1.1|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
   when defined(macosx):
     const


### PR DESCRIPTION
fixes #9419

It currently searches for libSSL versions in random order:
`.1.1|.38|.39|.41|.43|.44|.45|.46|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|`
Its a mystery which one it will pick up. Newest version 1.0.2 is some where in the middle, so its highly likely it will not pick it up.

A better system is to search in order of new -> old:
`.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.1.1|.38|.39|.41|.43|.44|.45|.46|.10`


