### PR TITLE
os.execShellCmd: fixes #10231

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1297,7 +1297,9 @@ proc execShellCmd*(command: string): int {.rtl, extern: "nos$1",
   ## the process has finished. To execute a program without having a
   ## shell involved, use the `execProcess` proc of the `osproc`
   ## module.
-  when defined(posix):
+  when defined(macosx):
+    result = c_system(command) shr 8
+  elif defined(posix):
     result = WEXITSTATUS(c_system(command))
   else:
     result = c_system(command)

--- a/tests/stdlib/t10231.nim
+++ b/tests/stdlib/t10231.nim
@@ -1,0 +1,13 @@
+discard """
+  target: cpp
+  action: run
+  exitcode: 0
+"""
+
+import os
+
+if paramCount() == 0:
+  # main process
+  doAssert execShellCmd(getAppFilename().quoteShell & " test") == 1
+else:
+  quit 1


### PR DESCRIPTION
Darwin has long deprecated the wait `union`, but their macros still assume
it unless you define `_POSIX_C_SOURCE`. This trips up C++ compilers.

This commit duplicates the behavior of `WEXITSTATUS` when `_POSIX_C_SOURCE`
is defined.