### PR TITLE
{.deprecated: msg.} now works for vars and lets

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -881,7 +881,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wExplain:
         sym.flags.incl sfExplain
       of wDeprecated:
-        if sym != nil and sym.kind in routineKinds + {skType}:
+        if sym != nil and sym.kind in routineKinds + {skType, skVar, skLet}:
           if it.kind in nkPragmaCallKinds: discard getStrLitNode(c, it)
           incl(sym.flags, sfDeprecated)
         elif sym != nil and sym.kind != skModule:

--- a/tests/deprecated/tannot.nim
+++ b/tests/deprecated/tannot.nim
@@ -1,0 +1,9 @@
+discard """
+  nimout: '''tannot.nim(9, 1) Warning: efgh; foo1 is deprecated [Deprecated]
+tannot.nim(9, 8) Warning: abcd; foo is deprecated [Deprecated]
+'''
+"""
+
+let foo* {.deprecated: "abcd".} = 42
+var foo1* {.deprecated: "efgh".} = 42
+foo1 = foo

--- a/tests/deprecated/tnoannot.nim
+++ b/tests/deprecated/tnoannot.nim
@@ -1,7 +1,0 @@
-discard """
-  errormsg: "annotation to deprecated not supported here"
-  line: 7
-"""
-
-var foo* {.deprecated.} = 42
-var foo1* {.deprecated: "no".} = 42


### PR DESCRIPTION
Works now because of https://github.com/nim-lang/Nim/pull/9582
Refs https://github.com/nim-lang/Nim/issues/9331

