### PR TITLE
fix #10039 : CI now runs buildTools (eg, nimfind wasn't being compiled before); refactoring

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -46,6 +46,8 @@ Possible Commands:
   boot [options]           bootstraps with given command line options
   distrohelper [bindir]    helper for distro packagers
   tools                    builds Nim related tools
+  toolsNoNimble            builds Nim related tools (except nimble)
+                           doesn't require network connectivity
   nimble                   builds the Nimble tool
 Boot options:
   -d:release               produce a release version of the compiler
@@ -448,7 +450,7 @@ proc runCI(cmd: string) =
     for pkg in "zip opengl sdl1 jester@#head niminst".split:
       exec "nimble install -y" & pkg
 
-  buildTools() # altenatively, kochExec "tools --skipNimble"
+  buildTools() # altenatively, kochExec "tools --toolsNoNimble"
 
   ## run tests
   exec "nim e tests/test_nimscript.nims"
@@ -592,9 +594,11 @@ when isMainModule:
       of "wintools": bundleWinTools()
       of "nimble": buildNimble(isLatest())
       of "nimsuggest": bundleNimsuggest()
-      of "tools":
-        buildNimble(isLatest())
+      of "toolsnonimble":
         buildTools()
+      of "tools":
+        buildTools()
+        buildNimble(isLatest())
       of "pushcsource", "pushcsources": pushCsources()
       of "valgrind": valgrind(op.cmdLineRest)
       else: showHelp()

--- a/koch.nim
+++ b/koch.nim
@@ -73,6 +73,11 @@ Web options:
                            build the official docs, use UA-48159761-1
 """
 
+let kochExe* = os.getAppFilename()
+
+proc kochExec*(cmd: string) =
+  exec kochExe.quoteShell & " " & cmd
+
 template withDir(dir, body) =
   let old = getCurrentDir()
   try:

--- a/koch.nim
+++ b/koch.nim
@@ -128,9 +128,6 @@ proc bundleNimbleExe(latest: bool) =
   # installer.ini expects it under $nim/bin
   nimCompile("dist/nimble/src/nimble.nim", options = "-d:release --nilseqs:on")
 
-proc buildNimfind() =
-  nimCompile("tools/nimfind.nim", options = "-d:release")
-
 proc buildNimble(latest: bool) =
   # old installations created nim/nimblepkg/*.nim files. We remove these
   # here so that it cannot cause problems (nimble bug #306):
@@ -204,13 +201,12 @@ proc buildTool(toolname, args: string) =
   nimexec("cc $# $#" % [args, toolname])
   copyFile(dest="bin" / splitFile(toolname).name.exe, source=toolname.exe)
 
-proc buildTools(latest: bool) =
+proc buildTools() =
   bundleNimsuggest()
   nimCompile("tools/nimgrep.nim", options = "-d:release")
   when defined(windows): buildVccTool()
   nimCompile("nimpretty/nimpretty.nim", options = "-d:release")
-  buildNimble(latest)
-  buildNimfind()
+  nimCompile("tools/nimfind.nim", options = "-d:release")
 
 proc nsis(latest: bool; args: string) =
   bundleNimbleExe(latest)
@@ -445,32 +441,38 @@ proc runCI(cmd: string) =
     # todo: implement `execWithEnv`
     exec("env NIM_COMPILE_TO_CPP=false $1 boot" % kochExe.quoteShell)
   kochExec "boot -d:release"
+
+  ## build nimble early on to enable remainder to depend on it if needed
   kochExec "nimble"
-  exec "nim e tests/test_nimscript.nims"
 
   when false:
     for pkg in "zip opengl sdl1 jester@#head niminst".split:
       exec "nimble install -y" & pkg
 
+  buildTools() # altenatively, kochExec "tools --skipNimble"
+
+  ## run tests
+  exec "nim e tests/test_nimscript.nims"
   when defined(windows):
     # note: will be over-written below
     exec "nim c -d:nimCoroutines --os:genode -d:posix --compileOnly testament/tester"
-    when false:
-      kochExec "csource"
-      kochExec "zip"
 
-  # main bottleneck: runs all main tests
+  # main bottleneck here
   exec "nim c -r -d:nimCoroutines testament/tester --pedantic all -d:nimCoroutines"
+
   exec "nim c -r nimdoc/tester"
-
-  nimCompile "nimpretty/nimpretty.nim"
   exec "nim c -r nimpretty/tester.nim"
+  when defined(posix):
+    exec "nim c -r nimsuggest/tester"
 
+  ## remaining actions
   when defined(posix):
     kochExec "docs --git.commit:devel"
     kochExec "csource"
-    kochExec "nimsuggest"
-    exec "nim c -r nimsuggest/tester"
+  elif defined(windows):
+    when false:
+      kochExec "csource"
+      kochExec "zip"
 
 proc pushCsources() =
   if not dirExists("../csources/.git"):
@@ -555,6 +557,10 @@ when isMainModule:
   var op = initOptParser()
   var latest = false
   var stable = false
+  template isLatest(): bool =
+    if stable: false
+    else:
+      existsDir(".git") or latest
   while true:
     op.next()
     case op.kind
@@ -585,13 +591,11 @@ when isMainModule:
       of "temp": temp(op.cmdLineRest)
       of "xtemp": xtemp(op.cmdLineRest)
       of "wintools": bundleWinTools()
-      of "nimble":
-        if stable: buildNimble(false)
-        else: buildNimble(existsDir(".git") or latest)
+      of "nimble": buildNimble(isLatest())
       of "nimsuggest": bundleNimsuggest()
       of "tools":
-        if stable: buildTools(false)
-        else: buildTools(existsDir(".git") or latest)
+        buildNimble(isLatest())
+        buildTools()
       of "pushcsource", "pushcsources": pushCsources()
       of "valgrind": valgrind(op.cmdLineRest)
       else: showHelp()

--- a/koch.nim
+++ b/koch.nim
@@ -26,7 +26,6 @@ import
 import tools / kochdocs
 
 const VersionAsString = system.NimVersion
-const env_NIM_COMPILE_TO_CPP = "NIM_COMPILE_TO_CPP"
 
 const
   HelpText = """
@@ -275,7 +274,7 @@ proc boot(args: string) =
   var output = "compiler" / "nim".exe
   var finalDest = "bin" / "nim".exe
   # default to use the 'c' command:
-  let defaultCommand = if getEnv(env_NIM_COMPILE_TO_CPP, "false") == "true": "cpp" else: "c"
+  let defaultCommand = if getEnv("NIM_COMPILE_TO_CPP", "false") == "true": "cpp" else: "c"
   let bootOptions = if args.len == 0 or args.startsWith("-"): defaultCommand else: ""
   echo "boot: defaultCommand: ", defaultCommand, " bootOptions: ", bootOptions
   let smartNimcache = (if "release" in args: "nimcache/r_" else: "nimcache/d_") &

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -51,12 +51,6 @@ proc execCleanPath*(cmd: string,
   if execShellCmd(cmd) != 0: quit("FAILURE", errorcode)
   putEnv("PATH", prevPath)
 
-let kochExe* = os.getAppFilename()
-  # note: assumes `kochdocs` is only used by koch.nim
-
-proc kochExec*(cmd: string) =
-  exec kochExe.quoteShell & " " & cmd
-
 proc nimexec*(cmd: string) =
   # Consider using `nimCompile` instead
   exec findNim() & " " & cmd


### PR DESCRIPTION
* fix #10039 : CI now runs buildTools

* refactoring / simplification
  appveyor now a bit more consistent with travis than before PR: previously, some tools were not compiled on appveyor, which could've been due to bitrot

* fix remaining comment from https://github.com/nim-lang/Nim/pull/10183#discussion_r245972871 
> You can easily move kochExe and kochExec to koch.nim btw, but I'm merging this now.


* closes #10250 /cc @cooldome 
    * humans can use ./koch tools in most cases (it'll work if no network failure; it'll work up to nimble if there is network failure, and then crash but at least non-nimble tools would be built)
    * humans can also use ./koch toolsNoNimble if they don't need to rebuild nimble (which is actually what I'd want in most cases since nimble is hosted / maintaned elsewhere, unlike tools bundled with nim repo) and/or 
      don't want it to crash in scripts when no network connectivity
    * CI runs ./koch toolsNoNimble
