### PR TITLE
ValueError now inherits from CatchableError

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,9 @@
 
 - `osproc.execProcess` now also takes a `workingDir` parameter.
 
-- `options.UnpackError` is no longer a ref type and inherits from `System.Defect` instead of `System.ValueError`.
+- `options.UnpackError` is no longer a ref type and inherits from `system.Defect` instead of `system.ValueError`.
+
+- `system.ValueError` now inherits from `system.CatchableError` instead of `system.Defect`.
 
 - nre's `RegexMatch.{captureBounds,captures}[]`  no longer return `Option` or
   `nil`/`""`, respectivly. Use the newly added `n in p.captures` method to

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -590,7 +590,7 @@ type
     ## Raised when assertion is proved wrong.
     ##
     ## Usually the result of using the `assert() template <#assert>`_.
-  ValueError* = object of Defect ## \
+  ValueError* = object of CatchableError ## \
     ## Raised for string and object conversion errors.
   KeyError* = object of ValueError ## \
     ## Raised if a key cannot be found in a table.


### PR DESCRIPTION
See https://github.com/nim-lang/Nim/issues/9857#issuecomment-452601891

`KeyError` inherits from `ValueError`, but it should probably inherit from `Defect` instead so it's not treated as catchable after this change?