### PR TITLE
refs #8638 nimble-wide CI: first pass

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -431,7 +431,7 @@ proc xtemp(cmd: string) =
 
 proc runCIPackages(cmd: string) =
   doAssert cmd.len == 0, cmd # avoid silently ignoring
-  runCIPackages()
+  runCIPackages(dirOutput = kochExe.parentDir / "build_nimbleci")
 
 proc runCI(cmd: string) =
   doAssert cmd.len == 0, cmd # avoid silently ignoring

--- a/tools/nimbleci.nim
+++ b/tools/nimbleci.nim
@@ -1,0 +1,125 @@
+#[
+nimble wide CI
+]#
+
+import os, strutils
+
+template withDir*(dir, body) =
+  let old = getCurrentDir()
+  try:
+    setCurrentDir(dir)
+    body
+  finally:
+    setCurrentdir(old)
+
+proc execEcho(cmd: string): bool =
+  echo "running:", cmd
+  let status = execShellCmd(cmd)
+  if status != 0:
+    echo "failed: cmd: ", cmd, " status:", status
+  result = status == 0
+
+type TestResult = ref object
+  # we can add further test fields here (eg running time, mem usage etc)
+  pkg: string
+  installOK: bool
+  developOK: bool
+  buildOK: bool
+  testOK: bool
+
+proc runCIPackage(data: var TestResult) =
+  let pkg = data.pkg
+  echo "runCIPackage:", pkg
+  let pkgInstall = "nimbleRoot"
+  let pkgClone = "nimbleRoot"
+
+  let cmd = "nimble install --nimbleDir:$# -y $# " % [pkgInstall, pkg]
+  if not execEcho(cmd):
+    echo "FAILURE: runCIPackage:", pkg
+    return
+  data.installOK = true
+
+  withDir pkgClone:
+    if not execEcho("nimble develop -y $#" % [pkg]):
+      return
+    data.developOK = true
+
+  withDir pkgClone / pkg:
+    data.buildOK = execEcho "nimble build"
+    # note: see caveat https://github.com/nim-lang/nimble/issues/558
+    # where `nimble test` suceeds even if no tests are defined.
+    data.testOK = execEcho "nimble test"
+
+proc runCIPackages*() =
+  echo "runCIPackages"
+
+  var data: TestResult
+  let pkgs0 = """
+# add more packages here; lines starting with `#` are skipped
+
+#TODO: jester@#head or jester? etc
+jester
+
+cligen
+
+# CT failures
+libffi
+
+glob
+nimongo
+nimx
+karax
+freeimage
+regex
+nimpy
+zero_functional
+arraymancer
+inim
+c2nim
+sdl1
+iterutils
+gnuplot
+nimpb
+lazy
+choosenim
+"""
+
+  var pkgs: seq[string]
+  for a in pkgs0.splitLines:
+    var a = a.strip
+    if a.len == 0: continue
+    if a.startsWith '#': continue
+    pkgs.add a
+
+  echo (pkgs: pkgs)
+
+  var tests: seq[TestResult]
+  type Stats = object
+    num: int
+    installOK: int
+    developOK: int
+    buildOK: int
+    testOK: int
+
+  var stats: Stats
+  proc toStr(a: Stats): string =
+    result = $a # consider human formatting if needed
+
+  for i,pkg in pkgs:
+    var data = TestResult(pkg:pkg)
+    runCIPackage(data)
+    tests.add data
+    stats.num.inc
+    stats.installOK+=data.installOK.ord
+    if not data.testOK: echo "FAILURE:CI"
+    echo (count:i, n: pkgs.len, stats:stats.toStr, pkg: pkg, testOK: data.testOK)
+  
+  var failures: seq[string]
+  for a in tests:
+    if not a.testOK:
+      failures.add a.pkg
+  echo (finalStats:stats.toStr, failures:failures)
+  # consider sending a notification, gather stats on failed packages
+
+when isMainModule:
+  runCIPackages()


### PR DESCRIPTION
* refs #8638 nimble-wide CI: first pass
* [EDIT] the extra computation time spent seems ok for 20 packages; we could scale up

~~TODO: need to figure how to run `nimble test`~~ DONE

## example output
see from https://travis-ci.com/timotheecour/Nim/jobs/169254994
```
TestResultAll:
i:    0  pkg: jester          seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 4.386720180511475
i:    1  pkg: cligen          seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 1.467899084091187
i:    2  pkg: libffi          seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 0.9745161533355713
i:    3  pkg: glob            seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 5.504637002944946
i:    4  pkg: nimongo         seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 15.49166083335876
i:    5  pkg: nimx            seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 5.231872081756592
i:    6  pkg: karax           seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 1 testOK: 1  totalTime: 18.29054808616638
i:    7  pkg: freeimage       seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 1.256640911102295
i:    8  pkg: regex           seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 4.114385843276978
i:    9  pkg: nimpy           seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 4.289348840713501
i:    10 pkg: zero_functional seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 1.651534080505371
i:    11 pkg: arraymancer     seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 8.910984039306641
i:    12 pkg: inim            seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 1 testOK: 1  totalTime: 8.552016973495483
i:    13 pkg: c2nim           seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 1 testOK: 0  totalTime: 13.97467684745789
i:    14 pkg: sdl1            seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 0.9655599594116211
i:    15 pkg: iterutils       seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 2.912926912307739
i:    16 pkg: gnuplot         seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 1  totalTime: 2.922753095626831
i:    17 pkg: nimpb           seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 1 testOK: 1  totalTime: 10.72133898735046
i:    18 pkg: lazy            seenOK: 1  foundOK: 1  cloneOK: 1  installOK: 1  developOK: 0 buildOK: 0 testOK: 0  totalTime: 0.9004640579223633
i:    19 pkg: choosenim       seenOK: 1  foundOK: 0  cloneOK: 0  installOK: 0  developOK: 0 buildOK: 0 testOK: 0  totalTime: 5.960464477539062e-06
TOTAL 20                      seenOK: 20 foundOK: 19 cloneOK: 19 installOK: 19 developOK: 0 buildOK: 4 testOK: 10 totalTime: 112.5204899311066
```

## for future PR's
- [ ] TOOD: figure out a better way to notify about test results (shouldn't be blocking a PR so shouldn't make travis fail, yet should be visible easily), and especially if previously succeeding tests are now failing



## [EDIT] potential concerns to think about down the line
( this makes appveyor timeout, but travis is fine; maybe we can have a when `defined(windows)` block to have a shorter list of pkgs to test on appveyor
see  https://ci.appveyor.com/project/Araq/nim/builds/21497722/messages
`Build execution time has reached the maximum allowed time for your plan (90 minutes).`
it went up to 3/20 packages

* not clear whether order in which packages are tested matters, eg if they have side effects
