### PR TITLE
Compile nimfind before nimble

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -204,8 +204,8 @@ proc buildTools(latest: bool) =
   nimCompile("tools/nimgrep.nim", options = "-d:release")
   when defined(windows): buildVccTool()
   nimCompile("nimpretty/nimpretty.nim", options = "-d:release")
-  buildNimble(latest)
   buildNimfind()
+  buildNimble(latest)
 
 proc nsis(latest: bool; args: string) =
   bundleNimbleExe(latest)


### PR DESCRIPTION
Nimble requires `git` and `github` access.  You can't compile nimble when you don't have external network access. `nimfind` does not require anything to build. With this change I able to get `nimfind` with `koch tools` in restricted environment.