### PR TITLE
Fixes 10065

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -963,7 +963,7 @@ proc mget*[A](t: var CountTable[A], key: A): var int {.deprecated.} =
   ctget(t, key)
 
 proc getOrDefault*[A](t: CountTable[A], key: A): int =
-  ## retrieves the value at ``t[key]`` if ``key`` is in ``t``. Otherwise, 0 (the
+  ## retrieves the value at ``t[key]`` iff ``key`` is in ``t``. Otherwise, 0 (the
   ## default initialization value of ``int``), is returned.
   ctgetOrDefault(t, key)
 

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -157,8 +157,7 @@ template get(t, key): untyped =
   mixin rawGet
   var hc: Hash
   var index = rawGet(t, key, hc)
-  if index >= 0:
-    return t.data[index].val
+  if index >= 0: result = t.data[index].val
   else:
     when compiles($key):
       raise newException(KeyError, "key not found: " & $key)
@@ -1376,11 +1375,13 @@ when isMainModule:
     let t = toCountTable("abracadabra")
     doAssert t['z'] == 0
 
-  block: #10065
     var t_mut = toCountTable("abracadabra")
     doAssert t_mut['z'] == 0
+    # the previous read may not have modified the table.
+    doAssert t_mut.hasKey('z') == false
     t_mut['z'] = 1
     doAssert t_mut['z'] == 1
+    doAssert t_mut.hasKey('z') == true
 
   block:
     var tp: Table[string, string] = initTable[string, string]()

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -947,7 +947,7 @@ proc enlarge[A](t: var CountTable[A]) =
   newSeq(n, len(t.data) * growthFactor)
   for i in countup(0, high(t.data)):
     if t.data[i].val != 0: rawInsert(t, n, t.data[i].key, t.data[i].val)
-    swap(t.data, n)
+  swap(t.data, n)
 
 proc ctInsert[A](t: var CountTable[A], key: A, val: int): Hash {.discardable.}=
   ## puts a ``(key, value)`` pair into ``t``.

--- a/tests/stdlib/tmget.nim
+++ b/tests/stdlib/tmget.nim
@@ -11,10 +11,10 @@ Can't access 6
 Can't access 6
 10
 11
-Can't access 6
+0
 10
 11
-Can't access 6
+0
 10
 11
 Can't access 6
@@ -85,7 +85,7 @@ block:
   except KeyError:
     echo "Can't access 6"
   echo x[5]
-  x[5] += 1
+  x.inc 5, 1
   var c = x[5]
   echo c
 
@@ -97,7 +97,7 @@ block:
   except KeyError:
     echo "Can't access 6"
   echo x[5]
-  x[5] += 1
+  x.inc 5, 1
   var c = x[5]
   echo c
 


### PR DESCRIPTION
I base this work on top of @BontaVlads work here: #10226. This still needs to be reviewed. I did this because I saw some time ago a C++ conference talk about the design problems in c++ where reading from a table causes changes in the table. I don't use count table on my own, but I saw how the decisions were heading towards the exact same problems that were talked about in the talk. I am sorry it was really a long time ago so I can't provide a link to it.

What I did, I removed `proc `[]`*[A](t: var CountTable[A], key: A): var int`, because that either has to raise an error when the key is not found or modify the table. Neither is desireable and in nim there is a nice alternative, the `[]=` procedure. This coveres almost all practical use cases of returning a reference, it is syntactically identical. So code that compiled earlier should still compile.

I don't know what the `deprecatedget` pragma is for. I just removed it.

But for some use case you really want a referece to the object in the table. For that use case I revived the `mget` procedure. It was deprecated, now it isn't anymore. It is a rare use case, so it is not that bad if it looks a bit ugly. I also discourage people from using it. Reviving the `mget` procedure shouldn't cause any problems, because it behaves exactly how it always behaved.
