### PR TITLE
refs #10249 ; more debug info to diagnose failures

### DIFF
--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -104,15 +104,19 @@ proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOp
   var line = newStringOfCap(120).TaintedString
   while true:
     if outp.readLine(line):
-      result[0].string.add(line.string)
-      result[0].string.add("\n")
+      result.output.string.add(line.string)
+      result.output.string.add("\n")
       if onStdout != nil: onStdout(line.string)
     else:
-      result[1] = peekExitCode(p)
-      if result[1] != -1: break
+      result.exitCode = peekExitCode(p)
+      if result.exitCode != -1: break
   close(p)
-
-
+  if result.exitCode != 0:
+    var command2 = command
+    if args.len > 0: command2.add " " & args.quoteShellCommand
+    echo (msg: "execCmdEx2 failed",
+      command: command2,
+      options: options)
 
 proc nimcacheDir(filename, options: string, target: TTarget): string =
   ## Give each test a private nimcache dir so they don't clobber each other's.


### PR DESCRIPTION
* refs #10249

addresses this comment from @cooldome 
> Megatest should display what nim command was executed with all the arguments and the file path in verbose mode

and shows things like:
```
(msg: "execCmdEx2", command: "compiler/nim c --nimCache:nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257 -d:testing --listCmd megatest.nim", options: {poUsePath, poStdErrToStdOut})
```

the root cause of #10249 is different though, and I will explain later what's going on
