### PR TITLE
fix #10273 execShellCmd now returns nonzero when child killed with signal + other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ doc/*.html
 doc/*.pdf
 doc/*.idx
 /web/upload
-build/*
+/build/*
 bin/*
 
 # iOS specific wildcards.

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -724,13 +724,6 @@ elif not defined(useNimRtl):
   proc isExitStatus(status: cint): bool =
     WIFEXITED(status) or WIFSIGNALED(status)
 
-  proc exitStatusLikeShell(status: cint): cint =
-    if WIFSIGNALED(status):
-      # like the shell!
-      128 + WTERMSIG(status)
-    else:
-      WEXITSTATUS(status)
-
   proc envToCStringArray(t: StringTableRef): cstringArray =
     result = cast[cstringArray](alloc0((t.len + 1) * sizeof(cstring)))
     var i = 0

--- a/lib/std/special_paths.nim
+++ b/lib/std/special_paths.nim
@@ -1,0 +1,29 @@
+#[
+todo: move findNimStdLibCompileTime, findNimStdLib here
+]#
+
+import os
+
+# Note: all the const paths defined here are known at compile time and valid
+# so long Nim repo isn't relocated after compilation.
+
+const sourcePath = currentSourcePath()
+  # robust way to derive other paths here
+  # We don't depend on PATH so this is robust to having multiple nim
+  # binaries
+
+const nimRootDir* = sourcePath.parentDir.parentDir.parentDir
+  ## root of Nim repo
+
+const stdlibDir* = nimRootDir / "lib"
+  # todo: make nimeval.findNimStdLibCompileTime use this
+
+const systemPath* = stdlibDir / "system.nim"
+
+const buildDir* = nimRootDir / "build"
+  ## refs #10268: all testament generated files should go here to avoid
+  ## polluting .gitignore
+
+static:
+  # sanity check
+  doAssert fileExists(systemPath)

--- a/testament/lib/stdtest/specialpaths.nim
+++ b/testament/lib/stdtest/specialpaths.nim
@@ -6,13 +6,15 @@ import os
 
 # Note: all the const paths defined here are known at compile time and valid
 # so long Nim repo isn't relocated after compilation.
+# This means the binaries they produce will embed hardcoded paths, which
+# isn't appropriate for some applications that need to be relocatable.
 
 const sourcePath = currentSourcePath()
   # robust way to derive other paths here
   # We don't depend on PATH so this is robust to having multiple nim
   # binaries
 
-const nimRootDir* = sourcePath.parentDir.parentDir.parentDir
+const nimRootDir* = sourcePath.parentDir.parentDir.parentDir.parentDir
   ## root of Nim repo
 
 const stdlibDir* = nimRootDir / "lib"

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,0 +1,1 @@
+--path:"../testament/lib" # so we can `import stdtest/foo` in this dir

--- a/tests/stdlib/t10231.nim
+++ b/tests/stdlib/t10231.nim
@@ -6,6 +6,8 @@ discard """
 
 import os
 
+# consider moving this inside tosproc (taking care that it's for cpp mode)
+
 if paramCount() == 0:
   # main process
   doAssert execShellCmd(getAppFilename().quoteShell & " test") == 1

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -263,3 +263,5 @@ block splitFile:
   doAssert splitFile("abc/.") == ("abc", ".", "")
   doAssert splitFile("..") == ("", "..", "")
   doAssert splitFile("a/..") == ("a", "..", "")
+
+# execShellCmd is tested in tosproc

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -1,10 +1,7 @@
-discard """
-  output: ""
-"""
 # test the osproc module
 
-import compiler/unittest_light
-import std/special_paths
+import stdtest/specialpaths
+import "../.." / compiler/unittest_light
 
 when defined(case_testfile): # compiled test file for child process
   from posix import exitnow
@@ -75,9 +72,9 @@ else:
     runTest("c_exit2_139", 139)
     runTest("quit_139", 139)
     runTest("exit_array", 1)
-    runTest("exit_recursion", SIGSEGV.int + 128) # bug #10273: was returning 0
-
-    assertEquals exitStatusLikeShell(SIGSEGV), SIGSEGV + 128.cint
+    when defined(posix): # on windows, -1073741571
+      runTest("exit_recursion", SIGSEGV.int + 128) # bug #10273: was returning 0
+      assertEquals exitStatusLikeShell(SIGSEGV), SIGSEGV + 128.cint
 
   block execProcessTest:
     let dir = parentDir(currentSourcePath())

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -3,21 +3,93 @@ discard """
 """
 # test the osproc module
 
-import os, osproc
+import compiler/unittest_light
+import std/special_paths
 
-block execProcessTest:
-  let dir = parentDir(currentSourcePath())
-  let (outp, err) = execCmdEx("nim c " & quoteShell(dir / "osproctest.nim"))
-  doAssert err == 0
-  let exePath = dir / addFileExt("osproctest", ExeExt)
-  let outStr1 = execProcess(exePath, workingDir=dir, args=["foo", "b A r"], options={})
-  doAssert outStr1 == dir & "\nfoo\nb A r\n"
+when defined(case_testfile): # compiled test file for child process
+  from posix import exitnow
+  proc c_exit2(code: c_int): void {.importc: "_exit", header: "<unistd.h>".}
+  import os
+  var a = 0
+  proc fun(b = 0) =
+    a.inc
+    # if a mod 100000 == 0:
+    if a mod 10000000 == 0:
+      echo a
+      discard
+    fun(b+1)
 
-  const testDir = "t e st"
-  createDir(testDir)
-  doAssert dirExists(testDir)
-  let outStr2 = execProcess(exePath, workingDir=testDir, args=["x yz"], options={})
-  doAssert outStr2 == absolutePath(testDir) & "\nx yz\n"
+  proc main() =
+    let args = commandLineParams()
+    # echo "ok1"
+    echo (msg: "child binary", pid: getCurrentProcessId())
+    let arg = args[0]
+    echo (arg: arg)
+    case arg
+    of "exit_0":
+      if true: quit(0)
+    of "exitnow_139":
+      if true: exitnow(139)
+    of "c_exit2_139":
+      if true: c_exit2(139)
+    of "quit_139":
+      #[
+      139-128=11=SIGSEGV
+      ]#
+      if true: quit(139)
+    of "exit_recursion": # stack overflow by infinite recursion
+      fun()
+      echo a
+    of "exit_array": # bad array access
+      echo args[1]
+  main()
 
-  removeDir(testDir)
-  removeFile(exePath)
+else:
+
+  import os, osproc, strutils, posix
+
+  block execShellCmdTest:
+    ## first, compile child program
+    const nim = getCurrentCompilerExe()
+    const sourcePath = currentSourcePath()
+    let output = buildDir / "D20190111T024543".addFileExt(ExeExt)
+    let cmd = "$# c -o:$# -d:release -d:case_testfile $#" % [nim, output,
+        sourcePath]
+    # we're testing `execShellCmd` so don't rely on it to compile test file
+    # note: this should be exported in posix.nim
+    proc c_system(cmd: cstring): cint {.importc: "system",
+      header: "<stdlib.h>".}
+    assertEquals c_system(cmd), 0
+
+    ## use it
+    template runTest(arg: string, expected: int) =
+      echo (arg2: arg, expected2: expected)
+      assertEquals execShellCmd(output & " " & arg), expected
+
+    runTest("exit_0", 0)
+    runTest("exitnow_139", 139)
+    runTest("c_exit2_139", 139)
+    runTest("quit_139", 139)
+    runTest("exit_array", 1)
+    runTest("exit_recursion", SIGSEGV.int + 128)
+
+    assertEquals exitStatusLikeShell(SIGSEGV), SIGSEGV + 128.cint
+
+  block execProcessTest:
+    let dir = parentDir(currentSourcePath())
+    let (outp, err) = execCmdEx("nim c " & quoteShell(dir / "osproctest.nim"))
+    doAssert err == 0
+    let exePath = dir / addFileExt("osproctest", ExeExt)
+    let outStr1 = execProcess(exePath, workingDir = dir, args = ["foo",
+        "b A r"], options = {})
+    doAssert outStr1 == dir & "\nfoo\nb A r\n"
+
+    const testDir = "t e st"
+    createDir(testDir)
+    doAssert dirExists(testDir)
+    let outStr2 = execProcess(exePath, workingDir = testDir, args = ["x yz"],
+        options = {})
+    doAssert outStr2 == absolutePath(testDir) & "\nx yz\n"
+
+    removeDir(testDir)
+    removeFile(exePath)


### PR DESCRIPTION
* fix #10273 : execShellCmd now returns nonzero (instead of 0) when child killed with signal
  * this is a serious bug as ignoring errors can have bad consequences
  * this could happen when child dies because of SIGSEGV, eg due to infinite recursion causing stack overflow
  * execShellCmd(cmd) now returns the same exit code as if you ran `cmd` in your shell, instead of 0
* add tests for this in tests/stdlib/tosproc.nim
* rename exitStatus() to exitStatusLikeShell() to make its meaning clear and distinguish from exitStatus variables which aren't necessarily referring to shell exit status
* fix minor bug in .gitignore
* properly fixes this https://github.com/nim-lang/Nim/issues/10231#issuecomment-452190306:
> Looks like POSIX compat is a mess on Darwin. I guess this could just be fixed with a special when branch.

* properly fixes these: #10231 #10231

* adds a test case for https://github.com/nim-lang/Nim/issues/10249 and explanation for the bug: `megatest compilation failure gives no useful information, hence hard to investigate`

* add lib/std/special_paths.nim 
  * makes it easy for files (eg in testament) to refer to specific dirs/files, which are guaranteed to be correct at compile time (and don't depend on environment eg PATH)
  * refs #10268 by allowing testament tests to simply call: `let output = buildDir / "D20190111T024543".addFileExt(ExeExt)` ; `tests/stdlib/tosproc.nim` has an example of that

## note
* the bug was pre-existant to https://github.com/nim-lang/Nim/pull/10222 so dates back since probably forever /cc @alaviss
`c_system(command) shr 8` was wrong, as was `WEXITSTATUS(c_system(command))` since these could return 0 even when child exited with a signal that killed it (eg SIGSEGV)

