### PR TITLE
fix #10281 (workaround) `OpenSSL error` breaking nimble and every package

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -38,7 +38,11 @@ when useWinVersion:
 
   from winlean import SocketHandle
 else:
-  const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.46|.45|.44|.43|.41|.39|.38|.10|)"
+  when defined(osx):
+    # todo: find a better workaround for #10281 (caused by #10230)
+    const versions = "(.1.1|.38|.39|.41|.43|.44|.45|.46|.10|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|)"
+  else:
+    const versions = "(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.46|.45|.44|.43|.41|.39|.38|.10|)"
 
   when defined(macosx):
     const


### PR DESCRIPTION
* fix #10281 (workaround) `OpenSSL error` breaking nimble and every package #10282

this reverts the recent changes made for #10230, but only for OSX, which is where things started breaking badly; a future PR can find a better fix  /cc @treeform @alaviss @dom96 

after this PR  `./nimble test` works again

if anyone has an idea for a test please help