### PR TITLE
Improve exception usage in parseutils

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,8 @@
 
 - `system.ValueError` now inherits from `system.CatchableError` instead of `system.Defect`.
 
+- The procs `parseutils.parseBiggsetInt`, `parseutils.parseInt`, `parseutils.parseBiggestUInt` and `parseutils.parseUInt` now raise a `ValueError` when the parsed integer is outside of the valid range. Previously they sometimes raised a `OverflowError` and sometimes returned `0`.
+
 - nre's `RegexMatch.{captureBounds,captures}[]`  no longer return `Option` or
   `nil`/`""`, respectivly. Use the newly added `n in p.captures` method to
   check if a group is captured, otherwise you'll recieve an exception.


### PR DESCRIPTION
Fixes #9857.

For the procs that only parse positive numbers, no exception was previously raised for negative numbers. I've changed this so that all inputs that are outside of the valid range result in a `ValueError`.

I haven't touched `parseSaturatedNatural`, because I'm guessing the whole point of that procedure is that it doesn't raise any exception, so I don't know what it should do when it encounters a negative number.

I also haven't touched `parseHex`,  `parseOct` or `parseBin`, so those procs still use `OverflowError`.