### PR TITLE
Fix csize and add cssize

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1490,7 +1490,7 @@ proc find*(s: string, sub: char, start: Natural = 0, last = 0): int {.noSideEffe
     when hasCStringBuiltin:
       let L = last-start+1
       if L > 0:
-        let found = c_memchr(s[start].unsafeAddr, sub, L)
+        let found = c_memchr(s[start].unsafeAddr, sub, L.csize)
         if not found.isNil:
           return cast[ByteAddress](found) -% cast[ByteAddress](s.cstring)
     else:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1769,8 +1769,10 @@ type # these work for most platforms:
     ## This is the same as the type ``short`` in *C*.
   cint* {.importc: "int", nodecl.} = int32
     ## This is the same as the type ``int`` in *C*.
-  csize* {.importc: "size_t", nodecl.} = int
+  csize* {.importc: "size_t", nodecl.} = culong
     ## This is the same as the type ``size_t`` in *C*.
+  cssize* {.importc: "ssize_t", nodecl.} = clong
+    ## This is the same as the type ``ssize_t`` in *C*.
   clonglong* {.importc: "long long", nodecl.} = int64
     ## This is the same as the type ``long long`` in *C*.
   cfloat* {.importc: "float", nodecl.} = float32

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -22,7 +22,7 @@ proc c_fwrite(buf: pointer, size, n: csize, f: File): cint {.
 
 proc rawWrite(f: File, s: string|cstring) =
   # we cannot throw an exception here!
-  discard c_fwrite(cstring(s), 1, s.len, f)
+  discard c_fwrite(cstring(s), 1, s.len.csize, f)
 
 when not defined(windows) or not defined(guiapp):
   proc writeToStdErr(msg: cstring) = rawWrite(stdmsg, msg)

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -221,18 +221,18 @@ elif defined(posix):
   proc munmap(adr: pointer, len: csize): cint {.header: "<sys/mman.h>".}
 
   proc osAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, PROT_READ or PROT_WRITE,
+    result = mmap(nil, size.csize, PROT_READ or PROT_WRITE,
                              MAP_PRIVATE or MAP_ANONYMOUS, -1, 0)
     if result == nil or result == cast[pointer](-1):
       raiseOutOfMem()
 
   proc osTryAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, PROT_READ or PROT_WRITE,
+    result = mmap(nil, size.csize, PROT_READ or PROT_WRITE,
                              MAP_PRIVATE or MAP_ANONYMOUS, -1, 0)
     if result == cast[pointer](-1): result = nil
 
   proc osDeallocPages(p: pointer, size: int) {.inline.} =
-    when reallyOsDealloc: discard munmap(p, size)
+    when reallyOsDealloc: discard munmap(p, size.csize)
 
 elif defined(windows):
   const


### PR DESCRIPTION
csize is incorrectly defined as signed - should be unsigned and cssize should be signed.

On Linux:
```c
typedef long int __ssize_t;
typedef __ssize_t ssize_t;
typedef long unsigned int size_t;
```

On Windows:
```c
typedef unsigned int size_t;
typedef int ssize_t;
```
