### PR TITLE
parseopt2.cmdLineRest is now correct too

### DIFF
--- a/lib/pure/parseopt2.nim
+++ b/lib/pure/parseopt2.nim
@@ -112,10 +112,10 @@ proc next(p: var OptParser) =
     p.key = token
     p.val = ""
 
-proc cmdLineRest*(p: OptParser): TaintedString {.rtl, extern: "npo2$1", deprecated.} =
-  ## Returns part of command line string that has not been parsed yet.
-  ## Do not use - does not correctly handle whitespace.
-  return p.cmd[p.pos..p.cmd.len-1].join(" ")
+proc cmdLineRest*(p: OptParser): TaintedString {.rtl, extern: "npo2$1".} =
+  ## Returns the part of command line string that has not been parsed yet,
+  ## properly quoted.
+  return p.cmd[p.pos..p.cmd.len-1].quoteShellCommand
 
 type
   GetoptResult* = tuple[kind: CmdLineKind, key, val: TaintedString]

--- a/tests/misc/tparseopt.nim
+++ b/tests/misc/tparseopt.nim
@@ -97,24 +97,27 @@ else:
   from stdtest/specialpaths import buildDir
   import "../.." / compiler/unittest_light
 
-  block: # fix #9951
-    var p = parseopt.initOptParser(@["echo \"quoted\""])
-    let expected = when defined(windows):
-      """"echo \"quoted\"""""
-    else:
-      """'echo "quoted"'"""
-    assertEquals parseopt.cmdLineRest(p), expected
+  block: # fix #9951 (and make it work for parseopt and parseopt2)
+    template runTest(parseoptCustom) =
+      var p = parseoptCustom.initOptParser(@["echo \"quoted\""])
+      let expected = when defined(windows):
+        """"echo \"quoted\"""""
+      else:
+        """'echo "quoted"'"""
+      assertEquals parseoptCustom.cmdLineRest(p), expected
 
-    doAssert "a5'b" == "a5\'b"
+      doAssert "a5'b" == "a5\'b"
 
-    let args = @["a1b", "a2 b", "", "a4\"b", "a5'b", r"a6\b", "a7\'b"]
-    var p2 = parseopt.initOptParser(args)
-    let expected2 = when defined(windows):
-      """a1b "a2 b" "" a4\"b a5'b a6\b a7'b"""
-    else:
-      """a1b 'a2 b' '' 'a4"b' 'a5'"'"'b' 'a6\b' 'a7'"'"'b'"""
-    doAssert "a5'b" == "a5\'b"
-    assertEquals parseopt.cmdLineRest(p2), expected2
+      let args = @["a1b", "a2 b", "", "a4\"b", "a5'b", r"a6\b", "a7\'b"]
+      var p2 = parseoptCustom.initOptParser(args)
+      let expected2 = when defined(windows):
+        """a1b "a2 b" "" a4\"b a5'b a6\b a7'b"""
+      else:
+        """a1b 'a2 b' '' 'a4"b' 'a5'"'"'b' 'a6\b' 'a7'"'"'b'"""
+      doAssert "a5'b" == "a5\'b"
+      assertEquals parseoptCustom.cmdLineRest(p2), expected2
+    runTest(parseopt)
+    runTest(parseopt2)
 
   block: # fix #9842
     let exe = buildDir / "D20190112T145450".addFileExt(ExeExt)


### PR DESCRIPTION
* same fix as https://github.com/nim-lang/Nim/pull/10291 but applied to parseopt2 instead of parseopt
* see tests that verify this (the added tests failed before this PR)

## note: justification for `properly quoted` (see discussion here https://github.com/nim-lang/Nim/pull/10304#pullrequestreview-192509988)
> No it is not "properly quoted", that is impossible because the quoting rules depend on the used shell on Unix.

it works for all the ones I've tried: fish, bash, sh, zsh, so  `properly quoted` seems a valid statement


```
fish
Welcome to fish, the friendly interactive shell
timothee@timotheecourmbp17 /p/t/d08> /tmp/nim//app 'a1 a2' '' 'a3"b' "a4'b"
@["a1 a2", "", "a3\"b", "a4\'b"]
```

```
bash
bash-3.2$ /tmp/nim//app 'a1 a2' '' 'a3"b' "a4'b"
@["a1 a2", "", "a3\"b", "a4\'b"]
bash-3.2$
```

```
sh
sh-3.2$ /tmp/nim//app 'a1 a2' '' 'a3"b' "a4'b"
@["a1 a2", "", "a3\"b", "a4\'b"]
```


```
zsh
/tmp/d08  0.000 $ /tmp/nim//app 'a1 a2' '' 'a3"b' "a4'b"
@["a1 a2", "", "a3\"b", "a4\'b"]
```

```
nim c -r -o:/tmp/nim//app main.nim
```

main.nim:
```nim
import os
proc main()=
  let args=commandLineParams()
  echo args
main()
```

 