### PR TITLE
improve vmgen.codeListing formatting

### DIFF
--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -86,7 +86,7 @@ proc codeListing(c: ControlFlowGraph, result: var string, start=0; last = -1) =
     result.add("\n")
     inc i
   if i in jumpTargets: result.add("L" & $i & ": End\n")
-
+  # consider calling `asciitables.alignTable`
 
 proc echoCfg*(c: ControlFlowGraph; start=0; last = -1) {.deprecated.} =
   ## echos the ControlFlowGraph for debugging purposes.

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -10,10 +10,6 @@
 ## This file implements the new evaluation engine for Nim code.
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
-const
-  debugEchoCode = defined(nimVMDebug)
-  traceCode = debugEchoCode
-
 import ast except getstr
 
 import
@@ -25,6 +21,9 @@ from semfold import leValueConv, ordinalValToString
 from evaltempl import evalTemplate
 
 from modulegraphs import ModuleGraph, PPassContext
+
+const
+  traceCode = debugEchoCode
 
 when hasFFI:
   import evalffi

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -11,7 +11,7 @@
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
 const
-  debugEchoCode = false
+  debugEchoCode = defined(nimVMDebug)
   traceCode = debugEchoCode
 
 import ast except getstr

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -29,7 +29,7 @@
 
 import
   strutils, ast, astalgo, types, msgs, renderer, vmdef,
-  trees, intsets, magicsys, options, lowerings, lineinfos, transf
+  trees, intsets, magicsys, options, lowerings, lineinfos, transf, asciitables
 import platform
 from os import splitFile
 
@@ -43,9 +43,12 @@ type
   TGenFlags = set[TGenFlag]
 
 proc debugInfo(c: PCtx; info: TLineInfo): string =
-  result = toFilename(c.config, info).splitFile.name & ":" & $info.line
+  result = toFileLineCol(c.config, info)
 
 proc codeListing(c: PCtx, result: var string, start=0; last = -1) =
+  ## for debugging purposes
+
+
   # first iteration: compute all necessary labels:
   var jumpTargets = initIntSet()
   let last = if last < 0: c.code.len-1 else: min(last, c.code.len-1)
@@ -54,7 +57,9 @@ proc codeListing(c: PCtx, result: var string, start=0; last = -1) =
     if x.opcode in relativeJumps:
       jumpTargets.incl(i+x.regBx-wordExcess)
 
-  # for debugging purposes
+  template toStr(opc: TOpcode): string = ($opc).substr(3)
+
+  result.add "code listing:\n"
   var i = start
   while i <= last:
     if i in jumpTargets: result.addf("L$1:\n", i)
@@ -62,34 +67,38 @@ proc codeListing(c: PCtx, result: var string, start=0; last = -1) =
 
     result.add($i)
     let opc = opcode(x)
-    if opc in {opcConv, opcCast}:
+    if opc in {opcIndCall, opcIndCallAsgn}:
+      result.addf("\t$#\tr$#, r$#, nargs:$#", opc.toStr, x.regA,
+                  x.regB, x.regC)
+    elif opc in {opcConv, opcCast}:
       let y = c.code[i+1]
       let z = c.code[i+2]
-      result.addf("\t$#\tr$#, r$#, $#, $#", ($opc).substr(3), x.regA, x.regB,
+      result.addf("\t$#\tr$#, r$#, $#, $#", opc.toStr, x.regA, x.regB,
         c.types[y.regBx-wordExcess].typeToString,
         c.types[z.regBx-wordExcess].typeToString)
       inc i, 2
     elif opc < firstABxInstr:
-      result.addf("\t$#\tr$#, r$#, r$#", ($opc).substr(3), x.regA,
+      result.addf("\t$#\tr$#, r$#, r$#", opc.toStr, x.regA,
                   x.regB, x.regC)
     elif opc in relativeJumps:
-      result.addf("\t$#\tr$#, L$#", ($opc).substr(3), x.regA,
+      result.addf("\t$#\tr$#, L$#", opc.toStr, x.regA,
                   i+x.regBx-wordExcess)
     elif opc in {opcLdConst, opcAsgnConst}:
       let idx = x.regBx-wordExcess
-      result.addf("\t$#\tr$#, $# ($#)", ($opc).substr(3), x.regA,
+      result.addf("\t$#\tr$#, $# ($#)", opc.toStr, x.regA,
         c.constants[idx].renderTree, $idx)
     elif opc in {opcMarshalLoad, opcMarshalStore}:
       let y = c.code[i+1]
-      result.addf("\t$#\tr$#, r$#, $#", ($opc).substr(3), x.regA, x.regB,
+      result.addf("\t$#\tr$#, r$#, $#", opc.toStr, x.regA, x.regB,
         c.types[y.regBx-wordExcess].typeToString)
       inc i
     else:
-      result.addf("\t$#\tr$#, $#", ($opc).substr(3), x.regA, x.regBx-wordExcess)
+      result.addf("\t$#\tr$#, $#", opc.toStr, x.regA, x.regBx-wordExcess)
     result.add("\t#")
     result.add(debugInfo(c, c.debug[i]))
     result.add("\n")
     inc i
+  result = result.alignTable
 
 proc echoCode*(c: PCtx; start=0; last = -1) {.deprecated.} =
   var buf = ""

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -29,10 +29,15 @@
 
 import
   strutils, ast, astalgo, types, msgs, renderer, vmdef,
-  trees, intsets, magicsys, options, lowerings, lineinfos, transf, asciitables
+  trees, intsets, magicsys, options, lowerings, lineinfos, transf
 import platform
 from os import splitFile
 
+const
+  debugEchoCode* = defined(nimVMDebug)
+
+when debugEchoCode:
+  import asciitables
 when hasFFI:
   import evalffi
 
@@ -47,8 +52,6 @@ proc debugInfo(c: PCtx; info: TLineInfo): string =
 
 proc codeListing(c: PCtx, result: var string, start=0; last = -1) =
   ## for debugging purposes
-
-
   # first iteration: compute all necessary labels:
   var jumpTargets = initIntSet()
   let last = if last < 0: c.code.len-1 else: min(last, c.code.len-1)
@@ -98,7 +101,8 @@ proc codeListing(c: PCtx, result: var string, start=0; last = -1) =
     result.add(debugInfo(c, c.debug[i]))
     result.add("\n")
     inc i
-  result = result.alignTable
+  when debugEchoCode:
+    result = result.alignTable
 
 proc echoCode*(c: PCtx; start=0; last = -1) {.deprecated.} =
   var buf = ""


### PR DESCRIPTION
when investigating VM bugs codeListing is very useful. This PR improves formatting a bit:
* table is now aligned thanks to alignTable (from #10182)
* `--listFullPaths` is now honored if present inside code listing
* `opcIndCall, opcIndCallAsgn` opcodes are now more useful/easier to interpret, eg:
```
64            IndCallAsgn r2, r3, r4
=>
64            IndCallAsgn r2, r3, nargs:4
```

which helps ppl looking at the listings by better reflecting meaning of `4` here (note: nargs include 1 for the output; plus 3 for input params)

* minor code refactoring
* debugging enabled via `-d:nimVMDebug`; it's sufficiently useful to enable via a `defined`

I found these useful when debugging for FFI at CT PR

## sample results

with `--listFullPaths -d:nimVMDebug` 
```
PC 101 opcLdConst ra 0 rb 8 rc 128
PC 102 opcIndCall ra 0 rb 0 rc 1
code listing:
104           LdImmInt r1, 1               #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(6, 11)
105           LdImmInt r3, 2               #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(7, 11)
106           AddInt   r2, r3, r1          #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(7, 13)
107           Conv     r4, r2, string, int #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(8, 8)
110           Echo     r4, r1, r0          #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(8, 8)
111           Ret      r0, r0, r0          #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(6, 3)
112           Eof      r0, r0, r0          #/Users/timothee/git_clone/nim/timn/tests/nim/all/t0102.nim(6, 3)

PC 104 opcLdImmInt ra 1 rb 1 rc 128
PC 105 opcLdImmInt ra 3 rb 2 rc 128
```
