### PR TITLE
fix #10305 nim cpp is now nan-correct at CT

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -63,8 +63,8 @@ compiler gcc:
   result = (
     name: "gcc",
     objExt: "o",
-    optSpeed: " -O3 -ffast-math ",
-    optSize: " -Os -ffast-math ",
+    optSpeed: " -O3 ",
+    optSize: " -Os ",
     compilerExe: "gcc",
     cppCompiler: "g++",
     compileTmpl: "-c $options $include -o $objfile $file",
@@ -88,8 +88,8 @@ compiler nintendoSwitchGCC:
   result = (
     name: "switch_gcc",
     objExt: "o",
-    optSpeed: " -O3 -ffast-math ",
-    optSize: " -Os -ffast-math ",
+    optSpeed: " -O3 ",
+    optSize: " -Os ",
     compilerExe: "aarch64-none-elf-gcc",
     cppCompiler: "aarch64-none-elf-g++",
     compileTmpl: "-w -MMD -MP -MF $dfile -c $options $include -o $objfile $file",

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -347,6 +347,9 @@ complete list.
 Define                   Effect
 ======================   =========================================================
 ``release``              Turns off runtime checks and turns on the optimizer.
+                         More aggressive optimizations are possible, eg:
+                         ``--passC:-ffast-math`` (but see issue #10305)
+                         ``--stacktrace:off``
 ``useWinAnsi``           Modules like ``os`` and ``osproc`` use the Ansi versions
                          of the Windows API. The default build uses the Unicode
                          version.

--- a/tests/float/tfloatnan.nim
+++ b/tests/float/tfloatnan.nim
@@ -14,3 +14,19 @@ echo "Nim: ", f32, " (float)"
 
 let f64: float64 = NaN
 echo "Nim: ", f64, " (double)"
+
+
+proc fun() =
+  # issue #10305
+  # with `-O3 -ffast-math`, generated C/C++ code is not nan compliant
+  # user can pass `--passC:-ffast-math` if he doesn't care.
+  let a1 = 0.0
+  let a = 0.0/a1
+  let b1 = a == 0.0
+  let b2 = a == a
+  doAssert not b1
+  doAssert not b2
+
+static: fun()
+fun()
+

--- a/tests/float/tfloatnan.nim
+++ b/tests/float/tfloatnan.nim
@@ -15,18 +15,30 @@ echo "Nim: ", f32, " (float)"
 let f64: float64 = NaN
 echo "Nim: ", f64, " (double)"
 
-
-proc fun() =
-  # issue #10305
+block: # issue #10305
   # with `-O3 -ffast-math`, generated C/C++ code is not nan compliant
   # user can pass `--passC:-ffast-math` if he doesn't care.
-  let a1 = 0.0
-  let a = 0.0/a1
-  let b1 = a == 0.0
-  let b2 = a == a
-  doAssert not b1
-  doAssert not b2
+  proc fun() =
+    # this was previously failing at compile time with a nim compiler
+    # that was compiled with `nim cpp -d:release`
+    let a1 = 0.0
+    let a = 0.0/a1
+    let b1 = a == 0.0
+    let b2 = a == a
+    doAssert not b1
+    doAssert not b2
 
-static: fun()
-fun()
+  proc fun2(i: int) =
+    # this was previously failing simply with `nim cpp -d:release`; the
+    # difference with above example is that optimization (const folding) can't
+    # take place in this example to hide the non-compliant nan bug.
+    let a = 0.0/(i.float)
+    let b1 = a == 0.0
+    let b2 = a == a
+    doAssert not b1
+    doAssert not b2
+
+  static: fun()
+  fun()
+  fun2(0)
 


### PR DESCRIPTION
* fix #10305 nim cpp is now nan-correct at CT #10310 and added a test that would fail before PR
* should fix these failing tests in CI (with nim cpp)
  * tests/float/tfloatnan.nim
  * lib/pure/math.nim
  * tests/float/tfloatmod.nim

I finally figured out root cause of #10305, but it was a rather painful debug session

Here's a minimal test case to explain what's going on:
```cpp
#include <stdio.h>

#define CASE_VOLATILE // otherwise const folding optimizer kicks in
int main (int argc, char *argv[]) {
  #ifdef CASE_VOLATILE
    volatile double a1 = 0.0;
  #else
    double a1 = 0.0;
  #endif
  double a2 = 0.0;
  double a3 = a1 / a2;
  int t = a3 == 0.0;
  int t2 = a3 == a3;
  int t3 = a3 != a3;
  printf("a3=%g,t=%d,t2=%d,t3=%d\n", a3, t, t2, t3);
  return 0;
}
```

```
clang++ -o /tmp/D20181107T193702 -ffast-math -O3 $timn_D/tests/nim/all/t0103.cpp
/tmp/D20181107T193702
a3=nan,t=1,t2=1,t3=0 # BUG

without  -ffast-math
a3=nan,t=0,t2=0,t3=1
```

so `-ffast-math` affects Nan correctness;
note that :

`$nimc_D/config/nim.cfg` contains
```
clang.options.speed = "-O3"
```
so that explains why this issue was only affecting `nim cpp` (since $nimc_D/compiler/extccomp.nim defined `optSpeed: " -O3 -ffast-math "` for both c and cpp, but `c` was overridden by `$nimc_D/config/nim.cfg`)


## note
there's a tradeoff between speed and accuracy at play here; but `-d:release` should be correct by default; but I added a note in doc/nimc.rst regarding more aggressive options for speed, including `--passC:-ffast-math`
