### PR TITLE
[CI] runCI runs `kochExec "boot"` regardless of nim mode

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -444,8 +444,7 @@ proc runCI(cmd: string) =
   # note(@araq): Do not replace these commands with direct calls (eg boot())
   # as that would weaken our testing efforts.
   when defined(posix): # appveyor (on windows) didn't run this
-    # todo: implement `execWithEnv`
-    exec("env NIM_COMPILE_TO_CPP=false $1 boot" % kochExe.quoteShell)
+    kochExec "boot"
   kochExec "boot -d:release"
 
   ## build nimble early on to enable remainder to depend on it if needed


### PR DESCRIPTION
seems like
```
exec("env NIM_COMPILE_TO_CPP=false $1 boot" % kochExe.quoteShell)
```
will be run twice identically when travis runs the 2 top-level tests
```
    - os: osx
      env: NIM_COMPILE_TO_CPP=false

    - os: osx
      env: NIM_COMPILE_TO_CPP=true
```
whereas  `./koch boot`  in c++ mode will never be run; this PR fixes that so that `./koch boot`  will run once in c mode, once in C++ mode

## note
when i converted travis code to nim code (`runCI`), `exec("env NIM_COMPILE_TO_CPP=false $1 boot" % kochExe.quoteShell)` was directly translation of what the travis code did
