### PR TITLE
fix twrong_refcounts in nim cpp mode

### DIFF
--- a/tests/parallel/twrong_refcounts.nim
+++ b/tests/parallel/twrong_refcounts.nim
@@ -1,7 +1,10 @@
 discard """
   output: "Success"
+  target: "c"
 """
 
+# Note: target: "cpp" fails because we can't yet have `extern "C"` mangling in
+# `exportc` procs.
 import math, random, threadPool
 
 # ---


### PR DESCRIPTION
twrong_refcounts was failing in cpp mode because `getRefcount` from
```
lib/system/gc.nim:131:50:proc internRefcount(p: pointer): int {.exportc: "getRefcount".} =
```
gets mangled as C++ in `nim cpp`:
```
nm stdlib_system.cpp.o|grep getRefcount
000000000000d140 T __Z11getRefcountPv
```
whereas on the import side:
```
proc getRefcount*[T](x: ref T): int {.importc: "getRefcount", noSideEffect,
  deprecated: "the refcount never was reliable, the GC does not use traditional refcounting".}
```
gets the declaration mangled as `extern C`, not `extern C++`, which points to a limitation we should address soon, such as ability to have `extern C` exportc procs in `nim cpp` ( a few syntaxes were discussed; will be addressed in future PR's)

So this PR introduces a workaround until we get ability to have `extern C` exportc procs in `nim cpp`

after this PR and https://github.com/nim-lang/Nim/pull/10310 there'll be ~~1~~ 2 last failing tests before we can enable remove `allow_failures` for `env: NIM_COMPILE_TO_CPP=true`:
* tests/niminaction/Chapter8/sdl/sdl_test.nim
* tests/objects/tobjcov.nim
