### PR TITLE
[CI] now enables `NIM_COMPILE_TO_CPP=true` to run without allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
     - os: osx
       env: NIM_COMPILE_TO_CPP=true
 
-  allow_failures:
-    - env: NIM_COMPILE_TO_CPP=true
+# To allow failures for a failing configuration, use something like:
+#  allow_failures:
+#    - env: NIM_COMPILE_TO_CPP=true
 #    - os: osx
 
 addons:

--- a/koch.nim
+++ b/koch.nim
@@ -281,7 +281,8 @@ proc boot(args: string) =
   let smartNimcache = (if "release" in args: "nimcache/r_" else: "nimcache/d_") &
                       hostOs & "_" & hostCpu
 
-  copyExe(findStartNim(), 0.thVersion)
+  let nimStart = findStartNim()
+  copyExe(nimStart, 0.thVersion)
   for i in 0..2:
     let defaultCommand = if useCpp: "cpp" else: "c"
     let bootOptions = if args.len == 0 or args.startsWith("-"): defaultCommand else: ""
@@ -292,7 +293,11 @@ proc boot(args: string) =
         # Note(D20190115T162028:here): the configs are skipped for bootstrap
         # (1st iteration) to prevent newer flags from breaking bootstrap phase.
         # fixes #10030.
-      extraOption.add " -d:nimBoostrapCsources0_19_0"
+      let ret = execCmdEx(nimStart & " --version")
+      doAssert ret.exitCode == 0
+      let version = ret.output.splitLines[0]
+      if version.startsWith "Nim Compiler Version 0.19.0":
+        extraOption.add " -d:nimBoostrapCsources0_19_0"
         # remove this when csources get updated
     exec i.thVersion & " $# $# $# --nimcache:$# compiler" / "nim.nim" %
       [bootOptions, extraOption, args, smartNimcache]

--- a/koch.nim
+++ b/koch.nim
@@ -282,18 +282,18 @@ proc boot(args: string) =
                       hostOs & "_" & hostCpu
 
   copyExe(findStartNim(), 0.thVersion)
-  for i in 0..2+ord(useCpp):
-    # do the first iteration in C mode in order to avoid problem #10315:
-    let defaultCommand = if useCpp and i > 0: "cpp" else: "c"
+  for i in 0..2:
+    let defaultCommand = if useCpp: "cpp" else: "c"
     let bootOptions = if args.len == 0 or args.startsWith("-"): defaultCommand else: ""
-
     echo "iteration: ", i+1
-    let extraOption = if i == 0:
-      "--skipUserCfg --skipParentCfg"
+    var extraOption = ""
+    if i == 0:
+      extraOption.add " --skipUserCfg --skipParentCfg"
         # Note(D20190115T162028:here): the configs are skipped for bootstrap
         # (1st iteration) to prevent newer flags from breaking bootstrap phase.
         # fixes #10030.
-    else: ""
+      extraOption.add " -d:nimBoostrapCsources0_19_0"
+        # remove this when csources get updated
     exec i.thVersion & " $# $# $# --nimcache:$# compiler" / "nim.nim" %
       [bootOptions, extraOption, args, smartNimcache]
     if sameFileContent(output, i.thVersion):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -569,7 +569,12 @@ type
       trace: string
     else:
       trace: seq[StackTraceEntry]
-    raiseId: uint # set when exception is raised
+    when defined(nimBoostrapCsources0_19_0):
+      # see #10315, bootstrap with `nim cpp` from csources gave error:
+      # error: no member named 'raise_id' in 'Exception'
+      raise_id: uint # set when exception is raised
+    else:
+      raiseId: uint # set when exception is raised
     up: ref Exception # used for stacking exceptions. Not exported!
 
   Defect* = object of Exception ## \

--- a/tests/exception/t9657.nim
+++ b/tests/exception/t9657.nim
@@ -1,6 +1,8 @@
 discard """
   action: run
   exitcode: 1
+  target: "c"
 """
+# todo: remove `target: "c"` workaround once #10343 is properly fixed
 close stdmsg
 writeLine stdmsg, "exception!"


### PR DESCRIPTION
* [CI] now enables `NIM_COMPILE_TO_CPP=true` to run without allow_failures
* adds workaround for https://github.com/nim-lang/Nim/issues/10343
* fixes bug caused by `csources` being built assuming `raise_id` even though stdlib was updated in meantime to use `raiseId` ; this workaround can be removed after the next release of csources (but nothing will break if it's not removed)

* requires these other PR's the be merged first: EDIT: DONE!
  * https://github.com/nim-lang/Nim/pull/10314 sdl_test (MERGED)
  * https://github.com/nim-lang/Nim/pull/10313 twrong_refcounts (MERGED)
  * https://github.com/nim-lang/Nim/pull/10310 (MERGED)
    * tests/float/tfloatnan.nim
    * lib/pure/math.nim
    * tests/float/tfloatmod.nim
