### PR TITLE
Disable interior pointer checking by default for the Boehm GC.

### DIFF
--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -72,6 +72,8 @@ when defined(boehmgc):
   proc boehmGCincremental {.
     importc: "GC_enable_incremental", boehmGC.}
   proc boehmGCfullCollect {.importc: "GC_gcollect", boehmGC.}
+  proc boehmGC_set_all_interior_pointers(flag: cint) {.
+    importc: "GC_set_all_interior_pointers", boehmGC.}
   proc boehmAlloc(size: int): pointer {.importc: "GC_malloc", boehmGC.}
   proc boehmAllocAtomic(size: int): pointer {.
     importc: "GC_malloc_atomic", boehmGC.}
@@ -148,6 +150,7 @@ when defined(boehmgc):
     proc nimGC_setStackBottom(theStackBottom: pointer) = discard
 
   proc initGC() =
+    boehmGC_set_all_interior_pointers(0)
     boehmGCinit()
     when hasThreadSupport:
       boehmGC_allow_register_threads()


### PR DESCRIPTION
The Boehm GC only needs interior pointer checking if pointers in global
variables or on the heap point to the interior of an object rather than
the beginning. If this does not happen, then checking for interior
pointers causes additional overhead, in particular because any objects
whose sizes are an exact multiple of two words gain another two words of
padding, wasting memory.

If checking of interior pointers is still desired, this can be achieved
by setting the environment variable GC_ALL_INTERIOR_POINTERS.

Pointers on the stack will always be treated as potential interior
pointers, as compiler optimizations may advance the only live reference
to a point past the beginning of an object.