### PR TITLE
Revert export of times.CTime; add std/time_t instead.

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -217,7 +217,7 @@ when defined(JS):
 elif defined(posix):
   import posix
 
-  type CTime* = posix.Time
+  type CTime = posix.Time
 
   var
     realTimeClockId {.importc: "CLOCK_REALTIME", header: "<time.h>".}: Clockid
@@ -236,10 +236,10 @@ elif defined(windows):
   import winlean
 
   when defined(i386) and defined(gcc):
-    type CTime* {.importc: "time_t", header: "<time.h>".} = distinct int32
+    type CTime {.importc: "time_t", header: "<time.h>".} = distinct int32
   else:
     # newest version of Visual C++ defines time_t to be of 64 bits
-    type CTime* {.importc: "time_t", header: "<time.h>".} = distinct int64
+    type CTime {.importc: "time_t", header: "<time.h>".} = distinct int64
   # visual c's c runtime exposes these under a different name
   var timezone {.importc: "_timezone", header: "<time.h>".}: int
 

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -233,13 +233,10 @@ elif defined(posix):
       tzset()
 
 elif defined(windows):
-  import winlean
+  import winlean, std/time_t
 
-  when defined(i386) and defined(gcc):
-    type CTime {.importc: "time_t", header: "<time.h>".} = distinct int32
-  else:
-    # newest version of Visual C++ defines time_t to be of 64 bits
-    type CTime {.importc: "time_t", header: "<time.h>".} = distinct int64
+  type CTime = time_t.Time
+
   # visual c's c runtime exposes these under a different name
   var timezone {.importc: "_timezone", header: "<time.h>".}: int
 

--- a/lib/std/time_t.nim
+++ b/lib/std/time_t.nim
@@ -1,0 +1,23 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2019 Nim contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+when defined(nimdoc):
+  type
+    impl = distinct int64
+    Time* = impl ## \
+      ## Wrapper for ``time_t``. On posix, this is an alias to ``posix.Time``.
+elif defined(windows):
+  when defined(i386) and defined(gcc):
+    type Time* {.importc: "time_t", header: "<time.h>".} = distinct int32
+  else:
+    # newest version of Visual C++ defines time_t to be of 64 bits
+    type Time* {.importc: "time_t", header: "<time.h>".} = distinct int64
+elif defined(posix):
+  import posix
+  export posix.Time

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -219,6 +219,7 @@ lib/pure/collections/heapqueue.nim
 lib/pure/fenv.nim
 lib/std/sha1.nim
 lib/std/varints.nim
+lib/std/time_t.nim
 lib/impure/rdstdin.nim
 lib/wrappers/linenoise/linenoise.nim
 lib/pure/strformat.nim


### PR DESCRIPTION
As explained in https://github.com/nim-lang/Nim/pull/10301#issuecomment-454280263, I think it's a bad idea to export this symbol. The `times` module is not a wrapper module, and the fact that it wraps `time_t` on Windows is just an implementation detail that might not be true in the future.

If we want to wrap C runtime library stuff for Windows it should be done as a separate module.

cc @genotrance