### PR TITLE
properly fix #10030 by skipping all external configs

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -27,9 +27,8 @@ build_nim_csources(){
 [ -f $nim_csources ] || echo_run build_nim_csources
 
 # Note: if fails, may need to `cd csources && git pull`
-# Note: --skipUserCfg is to prevent newer flags from
-# breaking bootstrap phase
-echo_run bin/nim c --skipUserCfg koch
+# see D20190115T162028
+echo_run bin/nim c --skipCfg --skipUserCfg --skipParentCfg koch
 
 echo_run ./koch boot -d:release
 echo_run ./koch tools # Compile Nimble and other tools.

--- a/build_all.sh
+++ b/build_all.sh
@@ -28,7 +28,7 @@ build_nim_csources(){
 
 # Note: if fails, may need to `cd csources && git pull`
 # see D20190115T162028
-echo_run bin/nim c --skipCfg --skipUserCfg --skipParentCfg koch
+echo_run bin/nim c --skipUserCfg --skipParentCfg koch
 
 echo_run ./koch boot -d:release
 echo_run ./koch tools # Compile Nimble and other tools.

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -77,7 +77,7 @@ Advanced options:
   --nilseqs:on|off          allow 'nil' for strings/seqs for
                             backwards compatibility
   --oldast:on|off           use old AST for backwards compatibility
-  --skipCfg                 do not read the general configuration file
+  --skipCfg                 do not read the nim installation's configuration file
   --skipUserCfg             do not read the user's configuration file
   --skipParentCfg           do not read the parent dirs' configuration files
   --skipProjCfg             do not read the project's configuration file

--- a/koch.nim
+++ b/koch.nim
@@ -287,9 +287,10 @@ proc boot(args: string) =
   for i in 0..2:
     echo "iteration: ", i+1
     let extraOption = if i == 0:
-      "--skipUserCfg"
-        # forward compatibility: for bootstrap (1st iteration), avoid user flags
-        # that could break things, see #10030
+      "--skipCfg --skipUserCfg --skipParentCfg"
+        # Note(D20190115T162028:here): the configs are skipped for bootstrap
+        # (1st iteration) to prevent newer flags from breaking bootstrap phase.
+        # fixes #10030.
     else: ""
     exec i.thVersion & " $# $# $# --nimcache:$# compiler" / "nim.nim" %
       [bootOptions, extraOption, args, smartNimcache]

--- a/koch.nim
+++ b/koch.nim
@@ -287,7 +287,7 @@ proc boot(args: string) =
   for i in 0..2:
     echo "iteration: ", i+1
     let extraOption = if i == 0:
-      "--skipCfg --skipUserCfg --skipParentCfg"
+      "--skipUserCfg --skipParentCfg"
         # Note(D20190115T162028:here): the configs are skipped for bootstrap
         # (1st iteration) to prevent newer flags from breaking bootstrap phase.
         # fixes #10030.


### PR DESCRIPTION
* fix #10030 /cc @kaushalmodi 
* this prevents a user's config.nims to mess with bootstrap when he uses features not yet known by older nim  (older = one that's bootstrapped from c sources)

minimized example that failed before this PR and works after this PR:
```
mkdir foo && cd foo
```

cat config.nims
```
echo "should be used during boostrap"
import os
```

```
git clone https://github.com/nim-lang/Nim
cd Nim
sh build_all.sh
```

