### PR TITLE
remove verboseCommands switch for tester

### DIFF
--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -18,7 +18,6 @@ var useColors = true
 var backendLogging = true
 var simulate = false
 var verboseMegatest = false # very verbose but can be useful
-var verboseCommands = false
 
 const
   testsDir = "tests" & DirSep
@@ -38,7 +37,6 @@ Arguments:
 Options:
   --print                   also print results to the console
   --verboseMegatest         log to stdout megatetest compilation
-  --verboseCommands         log to stdout info about commands being run
   --simulate                see what tests would be run but don't run them (for debugging)
   --failing                 only show failing/ignored tests
   --targets:"c c++ js objc" run tests for specified targets (default: all)
@@ -113,14 +111,6 @@ proc execCmdEx2(command: string, args: openarray[string], options: set[ProcessOp
       result.exitCode = peekExitCode(p)
       if result.exitCode != -1: break
   close(p)
-
-  if verboseCommands:
-    var command2 = command
-    if args.len > 0: command2.add " " & args.quoteShellCommand
-    echo (msg: "execCmdEx2",
-      command: command2,
-      options: options,
-      exitCode: result.exitCode)
 
 proc nimcacheDir(filename, options: string, target: TTarget): string =
   ## Give each test a private nimcache dir so they don't clobber each other's.
@@ -544,7 +534,6 @@ proc main() =
     case p.key.string.normalize
     of "print", "verbose": optPrintResults = true
     of "verbosemegatest": verboseMegatest = true
-    of "verbosecommands": verboseCommands = true
     of "failing": optFailing = true
     of "pedantic": discard "now always enabled"
     of "targets":


### PR DESCRIPTION
This switch is unnecessary

- It bloats the documentation for no reason
- The implementation is lazy at best.
- It is not a general solution just a very specific switch to enable a single debug echo in the tester.
- typing ``--verboseCommands:on`` is actually longer than typing ``echo command, args``
- If every debug eche I ever wrote would be a new compiler switch, we would drown in non-important compiler switches.
