### PR TITLE
[testament] add tests/{stdlib,osproc}/** to megatest (minus a blacklist)

### DIFF
--- a/compiler/unittest_light.nim
+++ b/compiler/unittest_light.nim
@@ -31,8 +31,11 @@ proc mismatch*[T](lhs: T, rhs: T): string =
       result.add "lhs[0..<i]:{" & replaceInvisible($lhs[
           0..<i]) & "}"
 
-proc assertEquals*[T](lhs: T, rhs: T) =
+proc assertEquals*[T](lhs: T, rhs: T, msg = "") =
   when false: # can be useful for debugging to see all that's fed to this.
     echo "----" & $lhs
   if lhs!=rhs:
-    doAssert false, mismatch(lhs, rhs)
+    var msg2 = ""
+    if msg.len > 0: msg2.add "msg: `" & msg & "` "
+    msg2.add "mismatch:" & mismatch(lhs, rhs)
+    doAssert false, msg2

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -34,7 +34,6 @@ const
     "testdata",
     "nimcache",
     "coroutines",
-    "osproc",
     "shouldfail",
     "dir with space"
   ]

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -517,6 +517,15 @@ const disabledFilesDefault = @[
   "ioselectors_select.nim",
 ]
 
+# TODO: fix these files.
+# note: some tests use `write(stdout, "foo")`; this will break when joining
+# megatest because of lack of trailing newline; either these tests need
+# adjustement (see modification to tests/stdlib/tstrutil.nim) or logic in
+# megatest needs minor adjustment to deal with that.
+const joinableBlacklist = @[
+  "tests/stdlib/tmarshal.nim", # see #9754
+]
+
 when defined(windows):
   const
     # array of modules disabled from compilation test of stdlib.

--- a/testament/tester.nim
+++ b/testament/tester.nim
@@ -524,6 +524,7 @@ const disabledFilesDefault = @[
 # megatest needs minor adjustment to deal with that.
 const joinableBlacklist = @[
   "tests/stdlib/tmarshal.nim", # see #9754
+  "tests/osproc/texecps.nim", # tests/osproc/texecps.nim(23, 13) `gResults == checks`  [AssertionError]
 ]
 
 when defined(windows):

--- a/tests/stdlib/tcgi.nim
+++ b/tests/stdlib/tcgi.nim
@@ -1,3 +1,9 @@
+discard """
+  output: '''
+[Suite] Test cgi module
+'''
+"""
+
 import unittest
 import cgi, strtabs
 

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -66,7 +66,7 @@ else:
     const nim = getCurrentCompilerExe()
     const sourcePath = currentSourcePath()
     let output = buildDir / "D20190111T024543".addFileExt(ExeExt)
-    let cmd = "$# c -o:$# --verbosity:0 --colors:off -d:release -d:case_testfile $#" %
+    let cmd = "$# c -o:$# --verbosity:0 --hints:off --colors:off -d:release -d:case_testfile $#" %
       [nim, output, sourcePath]
     # we're testing `execShellCmd` so don't rely on it to compile test file
     # note: this should be exported in posix.nim

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -1,6 +1,3 @@
-discard """
-  output: "ha/home/a1xyz/usr/bin"
-"""
 # test the new strutils module
 
 import
@@ -15,7 +12,7 @@ template rejectParse(e) =
   except ValueError: discard
 
 proc testStrip() =
-  write(stdout, strip("  ha  "))
+  doAssert strip("  ha  ") == "ha"
 
 proc testRemoveSuffix =
   var s = "hello\n\r"
@@ -143,8 +140,9 @@ proc main() =
   testStrip()
   testRemoveSuffix()
   testRemovePrefix()
-  for p in split("/home/a1:xyz:/usr/bin", {':'}):
-    write(stdout, p)
+  var ret: seq[string]
+  for p in split("/home/a1:xyz:/usr/bin", {':'}): ret.add p
+  doAssert ret == @["/home/a1", "xyz", "/usr/bin"]
 
 proc testDelete =
   var s = "0123456789ABCDEFGH"


### PR DESCRIPTION
* refs #9581

EDIT:
this seems to fail probably because cmd line is too large or gcc is running out of memory on travis; maybe we should split megatest in N (=2?) pieces
```
Error: execution of an external program failed: 'gcc   -o /home/travis/build/nim-lang/Nim/megatest  /home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/stdlib_system.c.o /home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/compiler_megatest_0.c.o /home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/stdlib_parseutils.c.o /home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/stdlib_math.c.o /home/travis/build/nim-
...
/home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/compiler_megatest_517.c.o /home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/compiler_tzero_extend.c.o /home/travis/build/nim-lang/Nim/nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257/compiler_megatest.c.o  -lm -lrt -lm   -ldl'

megatest compilation failed: compiler/nim c --nimCache:nimcache/tests/megatest_0d61f8370cad1d412f80b84d143e1257 -d:testing --listCmd '--path:$nim/testament/lib' megatest.nim

```
