### PR TITLE
Fix unhandled exception that raised when `nim c --cc:vcc`

### DIFF
--- a/tools/vccexe/vccenv.nim
+++ b/tools/vccexe/vccenv.nim
@@ -44,4 +44,4 @@ proc vccEnvVcVarsAllPath*(version: VccEnvVersion = vsUndefined): string =
     let key = $version
     let val = getEnv key
     if val.len > 0:
-      result = expandFilename(val & vcvarsallRelativePath)
+      result = try: expandFilename(val & vcvarsallRelativePath) except OSError: ""


### PR DESCRIPTION
I got following error when I try to compile testvcc.nim.
This commit changed `expandFilename` so that if `filename` doesn't exist, it raise OSError.
But tools/vccexe/vccenv.nim was not fixed.
https://github.com/nim-lang/Nim/commit/e9a192c36fb62331db0bbd308433e56fc771c352#diff-2fd1cb6fa2de35053b75e69dcddfd419
This PR fix unhandled exception but still I cannot compile a testvcc.nim with --cc:vcc option.
I will make an issue about it later.

testvcc.nim:
```nim
echo "foo"
```

testvcc.nims:
```nim
--cc:vcc
```

Log:
f:\temp>nim c -r testvcc.nim
Hint: used config file 'f:\temp\nim-0.19.9\config\nim.cfg' [Conf]
Hint: used config file 'f:\temp\testvcc.nims' [Conf]
Hint: system [Processing]
Hint: testvcc [Processing]
CC: stdlib_system
CC: testvcc
Error: execution of an external compiler program 'vccexe.exe /c --platform:amd64 /nologo  /If:\temp\nim-0.19.9\lib /If:\temp /
Fof:\temp\nimcache\testvcc\debug\stdlib_system.c.obj f:\temp\nimcache\testvcc\debug\stdlib_system.c' failed with exit code: 1

vccexe.nim(159)          vccexe
vccexe.nim(25)           discoverVccVcVarsAllPath
vccenv.nim(40)           vccEnvVcVarsAllPath
vccenv.nim(47)           vccEnvVcVarsAllPath
os.nim(1430)             expandFilename
Error: unhandled exception: file does not exist [OSError]
