### PR TITLE
fix #1994 gorge, staticExec now error at CT on exitCode !=0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -67,7 +67,10 @@
 - two poorly documented and not used modules (`subexes`, `scgi`) were moved to
   graveyard (they are available as Nimble packages)
 
-
+- `gorge`, `staticExec` now give compile time error if exitCode is not 0 instead of
+  silently ignoring errors. See https://github.com/nim-lang/Nim/issues/1994#issuecomment-327904129
+  Use `--experimental:gorgeIgnoreExitCodeDeprecated` to get old behavior, or use
+  `gorgeEx` to get `tuple[output: string, exitCode: int]`.
 
 #### Breaking changes in the compiler
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -127,6 +127,8 @@ type
     forLoopMacros,
     caseStmtMacros,
     codeReordering,
+    # deprecated behavior `foo` is named: `fooDeprecated`
+    gorgeIgnoreExitCodeDeprecated,
 
   SymbolFilesOption* = enum
     disabledSf, writeOnlySf, readOnlySf, v2Sf

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -5,6 +5,8 @@ import os
 import math
 import strutils
 
+const nonexistant = "D20190116T211842"
+
 template forceConst(a: untyped): untyped =
   ## Force evaluation at CT, useful for example here:
   ## `callFoo(forceConst(getBar1()), getBar2())`
@@ -22,7 +24,7 @@ static:
     let ret = gorgeEx(nim & " --version")
     doAssert ret.exitCode == 0
     doAssert ret.output.contains "Nim Compiler"
-    let ret2 = gorgeEx(nim & " --unexistant")
+    let ret2 = gorgeEx(nim & " --" & nonexistant)
     doAssert ret2.exitCode != 0
     let output3 = gorge(nim & " --version")
     doAssert output3.contains "Nim Compiler"
@@ -44,4 +46,5 @@ block:
   # Check against bugs like #9176
   doAssert getCurrentCompilerExe() == forceConst(getCurrentCompilerExe())
   if false: #pending #9176
-    doAssert gorgeEx("unexistant") == forceConst(gorgeEx("unexistant"))
+    doAssert gorgeEx(nonexistant) == forceConst(gorgeEx(nonexistant))
+

--- a/tests/vm/tvmops_fail.nim
+++ b/tests/vm/tvmops_fail.nim
@@ -1,0 +1,15 @@
+discard """
+  errormsg: '''gorge failed: (exitCode: 127, cmd: "D20190116T211842", input: "")'''
+"""
+
+# issue #1994
+
+#[
+This doesn't work as VM error isn't catchable
+block:
+  static:
+    doAssertRaises(AssertionError):
+]#
+
+const nonexistant = "D20190116T211842"
+const a = gorge(nonexistant)


### PR DESCRIPTION
* fix #1994
* uses a different approach than https://github.com/nim-lang/Nim/pull/10345 because I couldn't figure out how to address technical difficulty mentioned here https://github.com/nim-lang/Nim/pull/10345#issuecomment-455470972
* Use `--experimental:gorgeIgnoreExitCodeDeprecated` to get old behavior, or use `gorgeEx` to get `tuple[output: string, exitCode: int]`

an altenative would be:`--experimental:gorgeHonorsExitCode`  and if this flag isn't passed, show a deprecation notice when `gorge` is used

## note
* in this PR the VM errors (with stacktrace) when gorge fails, it doesn't raise doAssert and error can't be caught:
```
block:
  static:
    doAssertRaises(AssertionError): const a = gorge("nonexistant") # doesn't work
```
unlike in previous PR which allowed that: https://github.com/nim-lang/Nim/pull/10345/files#diff-353c91db729fe1f641027ea2a4e781b2
if someone has an idea (that they tested to work) for allowing that (or even allowing raising `OSError`), please let me know; otherwise the workaround mentioned above should cover all usability cases

