### PR TITLE
produce better lineinfo for qualified symbols

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -450,17 +450,21 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode =
   pushInfoContext(c.config, nOrig.info, sym.detailedInfo)
 
-  markUsed(c.config, n.info, sym, c.graph.usageSym)
-  onUse(n.info, sym)
+  let info = if n.kind in {nkCall,nkCommand}:
+               n.sons[0].info
+             else:
+               n.info
+  markUsed(c.config, info, sym, c.graph.usageSym)
+  onUse(info, sym)
   if sym == c.p.owner:
-    globalError(c.config, n.info, "recursive dependency: '$1'" % sym.name.s)
+    globalError(c.config, info, "recursive dependency: '$1'" % sym.name.s)
 
   let genericParams = if sfImmediate in sym.flags: 0
                       else: sym.ast[genericParamsPos].len
   let suppliedParams = max(n.safeLen - 1, 0)
 
   if suppliedParams < genericParams:
-    globalError(c.config, n.info, errMissingGenericParamsForTemplate % n.renderTree)
+    globalError(c.config, info, errMissingGenericParamsForTemplate % n.renderTree)
 
   #if c.evalContext == nil:
   #  c.evalContext = c.createEvalContext(emStatic)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -500,7 +500,11 @@ proc semResolvedCall(c: PContext, x: TCandidate,
 
   result = x.call
   instGenericConvertersSons(c, result, x)
-  result[0] = newSymNode(finalCallee, result[0].info)
+  let xinfo = if result[0].kind == nkDotExpr:
+                result[0][1].info
+              else:
+                result[0].info
+  result[0] = newSymNode(finalCallee, xinfo)
   result.typ = finalCallee.typ.sons[0]
   updateDefaultParams(result)
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -466,7 +466,11 @@ proc semResolvedCall(c: PContext, x: TCandidate,
                      n: PNode, flags: TExprFlags): PNode =
   assert x.state == csMatch
   var finalCallee = x.calleeSym
-  markUsed(c.config, n.sons[0].info, finalCallee, c.graph.usageSym)
+  let info = if n.sons[0].kind == nkDotExpr:
+               n.sons[0].sons[1].info
+             else:
+               n.sons[0].info
+  markUsed(c.config, info, finalCallee, c.graph.usageSym)
   onUse(n.sons[0].info, finalCallee)
   assert finalCallee.ast != nil
   if x.hasFauxMatch:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1077,8 +1077,12 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
   of skMacro:
     if efNoEvaluateGeneric in flags and s.ast[genericParamsPos].len > 0 or
        (n.kind notin nkCallKinds and s.requiredParams > 0):
-      markUsed(c.config, n.info, s, c.graph.usageSym)
-      onUse(n.info, s)
+      let info = if n.kind == nkDotExpr:
+                   n.sons[1].info
+                 else:
+                   n.info
+      markUsed(c.config, info, s, c.graph.usageSym)
+      onUse(info, s)
       result = symChoice(c, n, s, scClosed)
     else:
       result = semMacroExpr(c, n, n, s, flags)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -24,15 +24,19 @@ const
 
 proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
                      flags: TExprFlags = {}): PNode =
-  markUsed(c.config, n.info, s, c.graph.usageSym)
-  onUse(n.info, s)
-  pushInfoContext(c.config, n.info, s.detailedInfo)
+  let info = if n.kind == nkCall:
+               n.sons[0].info
+             else:
+               n.info
+  markUsed(c.config, info, s, c.graph.usageSym)
+  onUse(info, s)
+  pushInfoContext(c.config, info, s.detailedInfo)
   result = evalTemplate(n, s, getCurrOwner(c), c.config, efFromHlo in flags)
   if efNoSemCheck notin flags: result = semAfterMacroCall(c, n, result, s, flags)
   popInfoContext(c.config)
 
   # XXX: A more elaborate line info rewrite might be needed
-  result.info = n.info
+  result.info = info
 
 proc semFieldAccess(c: PContext, n: PNode, flags: TExprFlags = {}): PNode
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -24,7 +24,7 @@ const
 
 proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
                      flags: TExprFlags = {}): PNode =
-  let info = if n.kind == nkCall:
+  let info = if n.kind in {nkCall,nkCommand}:
                n.sons[0].info
              else:
                n.info
@@ -1090,8 +1090,12 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
     if efNoEvaluateGeneric in flags and s.ast[genericParamsPos].len > 0 or
        (n.kind notin nkCallKinds and s.requiredParams > 0) or
        sfCustomPragma in sym.flags:
-      markUsed(c.config, n.info, s, c.graph.usageSym)
-      onUse(n.info, s)
+      let info = if n.kind == nkDotExpr:
+                   n.sons[1].info
+                 else:
+                   n.info
+      markUsed(c.config, info, s, c.graph.usageSym)
+      onUse(info, s)
       result = symChoice(c, n, s, scClosed)
     else:
       result = semTemplateExpr(c, n, s, flags)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -62,9 +62,13 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule): PNode =
     # XXX this makes more sense but breaks bootstrapping for now:
     # (s.kind notin routineKinds or s.magic != mNone):
     # for instance 'nextTry' is both in tables.nim and astalgo.nim ...
-    result = newSymNode(s, n.info)
-    markUsed(c.config, n.info, s, c.graph.usageSym)
-    onUse(n.info, s)
+    let info = if n.kind == nkDotExpr:
+                 n.sons[1].info
+               else:
+                 n.info
+    result = newSymNode(s, info)
+    markUsed(c.config, info, s, c.graph.usageSym)
+    onUse(info, s)
   else:
     # semantic checking requires a type; ``fitNode`` deals with it
     # appropriately

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3983,13 +3983,13 @@ proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
   Hide(raiseAssert)(msg)
 
 template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]) =
-  const loc = $instantiationInfo(-1, true)
+  const loc = $instantiationInfo(-2, true)
   bind instantiationInfo
   mixin failedAssertImpl
   when enabled:
     # for stacktrace; fixes #8928 ; Note: `fullPaths = true` is correct
     # here, regardless of --excessiveStackTrace
-    {.line: instantiationInfo(fullPaths = true).}:
+    {.line: instantiationInfo(-2, fullPaths = true).}:
       if not cond:
         failedAssertImpl(loc & " `" & expr & "` " & msg)
 
@@ -4059,7 +4059,7 @@ template onFailedAssert*(msg, code: untyped): untyped {.dirty.} =
   ##  onFailedAssert(msg):
   ##    var e = new(TMyError)
   ##    e.msg = msg
-  ##    e.lineinfo = instantiationInfo(-2)
+  ##    e.lineinfo = instantiationInfo(-3)
   ##    raise e
   ##
   template failedAssertImpl(msgIMPL: string): untyped {.dirty.} =

--- a/nimsuggest/tests/tqualified_highlight.nim
+++ b/nimsuggest/tests/tqualified_highlight.nim
@@ -1,0 +1,16 @@
+import macros
+system.once: system.echo()
+macros.dumpTree#[!]#
+
+discard """
+disabled:true
+$nimsuggest --tester $file
+>highlight $1
+highlight;;skModule;;1;;7;;6
+highlight;;skTemplate;;2;;7;;4
+highlight;;skTemplate;;2;;7;;4
+highlight;;skProc;;2;;20;;4
+highlight;;skMacro;;3;;7;;8
+highlight;;skMacro;;3;;7;;8
+highlight;;skMacro;;3;;7;;8
+"""

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -34,12 +34,12 @@ except AssertionError as e:
 try:
   assert false, "msg2"  # assert test
 except AssertionError as e:
-  checkMsg(e.msg, "tfailedassert.nim(35, 10) `false` msg2", "test2")
+  checkMsg(e.msg, "tfailedassert.nim(35, 3) `false` msg2", "test2")
 
 try:
   assert false # assert test with no msg
 except AssertionError as e:
-  checkMsg(e.msg, "tfailedassert.nim(40, 10) `false` ", "test3")
+  checkMsg(e.msg, "tfailedassert.nim(40, 3) `false` ", "test3")
 
 try:
   let a = 1
@@ -109,14 +109,14 @@ block: ## checks for issue https://github.com/nim-lang/Nim/issues/8518
     doAssert fun("foo1") == fun("foo2"), "mymsg"
   except AssertionError as e:
     # used to expand out the template instantiaiton, sometimes filling hundreds of lines
-    checkMsg(e.msg, """tfailedassert.nim(109, 14) `fun("foo1") == fun("foo2")` mymsg""", "test9")
+    checkMsg(e.msg, """tfailedassert.nim(109, 5) `fun("foo1") == fun("foo2")` mymsg""", "test9")
 
 block: ## checks for issue https://github.com/nim-lang/Nim/issues/9301
   try:
     doAssert 1 + 1 == 3
   except AssertionError as e:
     # used to const fold as false
-    checkMsg(e.msg, "tfailedassert.nim(116, 14) `1 + 1 == 3` ", "test10")
+    checkMsg(e.msg, "tfailedassert.nim(116, 5) `1 + 1 == 3` ", "test10")
 
 block: ## checks AST isnt' transformed as it used to
   let a = 1
@@ -124,4 +124,4 @@ block: ## checks AST isnt' transformed as it used to
     doAssert a > 1
   except AssertionError as e:
     # used to rewrite as `1 < a`
-    checkMsg(e.msg, "tfailedassert.nim(124, 14) `a > 1` ", "test11")
+    checkMsg(e.msg, "tfailedassert.nim(124, 5) `a > 1` ", "test11")

--- a/tests/assert/tfailedassert.nim
+++ b/tests/assert/tfailedassert.nim
@@ -29,7 +29,7 @@ echo("")
 try:
   doAssert(false, "msg1") # doAssert test
 except AssertionError as e:
-  checkMsg(e.msg, "tfailedassert.nim(30, 11) `false` msg1", "test1")
+  checkMsg(e.msg, "tfailedassert.nim(30, 3) `false` msg1", "test1")
 
 try:
   assert false, "msg2"  # assert test
@@ -70,7 +70,7 @@ block:
   onFailedAssert(msg):
     var e = new(TMyError)
     e.msg = msg
-    e.lineinfo = instantiationInfo(-2)
+    e.lineinfo = instantiationInfo(-3)
     raise e
 
   proc foo =
@@ -80,12 +80,12 @@ block:
   proc bar: int =
     # local overrides that are active only in this proc
     onFailedAssert(msg):
-      checkMsg(msg, "tfailedassert.nim(85, 11) `false` first assertion from bar", "test6")
+      checkMsg(msg, "tfailedassert.nim(85, 5) `false` first assertion from bar", "test6")
 
     assert(false, "first assertion from bar")
 
     onFailedAssert(msg):
-      checkMsg(msg, "tfailedassert.nim(91, 11) `false` second assertion from bar", "test7")
+      checkMsg(msg, "tfailedassert.nim(91, 5) `false` second assertion from bar", "test7")
       return -1
 
     assert(false, "second assertion from bar")
@@ -98,7 +98,7 @@ block:
   except:
     let e = EMyError(getCurrentException())
     echo e.lineinfo.filename
-    checkMsg(e.msg, "tfailedassert.nim(77, 11) `false` assertion from foo", "test8")
+    checkMsg(e.msg, "tfailedassert.nim(77, 5) `false` assertion from foo", "test8")
 
 block: ## checks for issue https://github.com/nim-lang/Nim/issues/8518
   template fun(a: string): string =

--- a/tests/assert/tfaileddoassert.nim
+++ b/tests/assert/tfaileddoassert.nim
@@ -9,12 +9,12 @@ test2:ok
 import testhelper
 
 onFailedAssert(msg):
-  checkMsg(msg, "tfaileddoassert.nim(15, 9) `a == 2` foo", "test1")
+  checkMsg(msg, "tfaileddoassert.nim(15, 1) `a == 2` foo", "test1")
 
 var a = 1
 doAssert(a == 2, "foo")
 
 onFailedAssert(msg):
-  checkMsg(msg, "tfaileddoassert.nim(20, 10) `a == 3` ", "test2")
+  checkMsg(msg, "tfaileddoassert.nim(20, 1) `a == 3` ", "test2")
 
 doAssert a == 3

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -30,7 +30,7 @@ texplain.nim(84, 5) ExplainedConcept: concept predicate failed
 texplain.nim(128, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
 proc e(o: ExplainedConcept): int
-texplain.nim(128, 9) template/generic instantiation of `assert` from here
+texplain.nim(128, 3) template/generic instantiation of `assert` from here
 texplain.nim(84, 5) ExplainedConcept: concept predicate failed
 proc e(i: int): int
 
@@ -38,7 +38,7 @@ expression: e(n)
 texplain.nim(129, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
 proc r(o: RegularConcept): int
-texplain.nim(129, 9) template/generic instantiation of `assert` from here
+texplain.nim(129, 3) template/generic instantiation of `assert` from here
 texplain.nim(88, 5) RegularConcept: concept predicate failed
 proc r[T](a: SomeNumber; b: T; c: auto)
 proc r(i: string): int


### PR DESCRIPTION
Previously, nimsuggest highlighter will erronously highlight qualified
symbols starting from the dot like this (the highlighted part is marked
below):

```
system.echo()
      ^~~~
```

This commit fixes that.