### PR TITLE
fix #10339 by returning type attached to nkEmpty

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1066,12 +1066,8 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
       else: result = newSymNode(s, n.info)
     of tyStatic:
       if typ.n != nil:
-        case typ.n.kind
-        of nkObjConstr:
-          result = newSymNode(s, n.info)
-        else:
-          result = typ.n
-          result.typ = typ.base
+        result = typ.n
+        result.typ = typ.base
       else:
         result = newSymNode(s, n.info)
     else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1066,8 +1066,12 @@ proc semSym(c: PContext, n: PNode, sym: PSym, flags: TExprFlags): PNode =
       else: result = newSymNode(s, n.info)
     of tyStatic:
       if typ.n != nil:
-        result = typ.n
-        result.typ = typ.base
+        case typ.n.kind
+        of nkObjConstr:
+          result = newSymNode(s, n.info)
+        else:
+          result = typ.n
+          result.typ = typ.base
       else:
         result = newSymNode(s, n.info)
     else:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1474,7 +1474,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
 
   if c.config.cmd == cmdIdeTools: suggestExpr(c, n)
   case n.kind
-  of nkEmpty: discard
+  of nkEmpty:
+    if n.typ != nil: result = n.typ
+    else: discard
   of nkTypeOfExpr:
     # for ``type(countup(1,3))``, see ``tests/ttoseq``.
     checkSonsLen(n, 1, c.config)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1474,9 +1474,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
 
   if c.config.cmd == cmdIdeTools: suggestExpr(c, n)
   case n.kind
-  of nkEmpty:
-    if n.typ != nil: result = n.typ
-    else: discard
+  of nkEmpty: result = n.typ
   of nkTypeOfExpr:
     # for ``type(countup(1,3))``, see ``tests/ttoseq``.
     checkSonsLen(n, 1, c.config)

--- a/tests/macros/tquotedo.nim
+++ b/tests/macros/tquotedo.nim
@@ -4,6 +4,7 @@ output: '''
 Hallo Welt
 Hallo Welt
 1
+()
 '''
 """
 
@@ -34,3 +35,17 @@ macro t(): untyped =
 t()
 
 echo tp()
+
+
+# https://github.com/nim-lang/Nim/issues/9866
+type
+  # Foo = int # works
+  Foo = object # fails
+
+macro dispatchGen(): untyped =
+  var shOpt: Foo
+  result = quote do:
+    let baz = `shOpt`
+    echo `shOpt`
+
+dispatchGen()

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -137,3 +137,20 @@ block:
   type
     Coord[N: static[int]] = tuple[col, row: range[0'i8 .. (N.int8-1)]]
     Point[N: static[int]] = range[0'i16 .. N.int16 * N.int16 - 1]
+
+# https://github.com/nim-lang/Nim/issues/10339
+block:
+  type
+    MicroKernel = object
+      a: float
+      b: int
+
+  macro extractA(ukernel: static MicroKernel): untyped =
+    result = newLit ukernel.a
+
+  proc tFunc[ukernel: static MicroKernel]() =
+    const x = ukernel.extractA
+    doAssert x == 5.5
+
+  const uk = MicroKernel(a: 5.5, b: 1)
+  tFunc[uk]()


### PR DESCRIPTION
I'm not sure if this is actually a fix or more of a hack. :)

The test case at least reproduces the same error as @mratsim's laser code.

The problem without this PR seems to be that we end up in `semObjConstr` with a `nkEmpty` node as the first child. I assume that's because `typ.base` in `semSym` extracts the node we need as a child later on in `semObjConstr`. 

If there's a better fix for this, feel free to close. 