### PR TITLE
Object downconversion in VM should not copy

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -399,6 +399,11 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
         dest.floatVal = toBiggestFloat(src.intVal)
       else:
         dest.floatVal = src.floatVal
+    of tyObject:
+      if srctyp.skipTypes(abstractRange).kind != tyObject:
+        internalError(c.config, "invalid object-to-object conversion")
+      # A object-to-object conversion is essentially a no-op
+      moveConst(dest, src)
     else:
       asgnComplex(dest, src)
 

--- a/tests/vm/tconstobj.nim
+++ b/tests/vm/tconstobj.nim
@@ -48,3 +48,20 @@ let people = {
 }.toTable()
 
 echo people["001"]
+
+# Object downconversion should not copy
+
+type
+  SomeBaseObj  {.inheritable.} = object of RootObj
+    txt : string
+  InheritedFromBase = object of SomeBaseObj
+    other : string
+
+proc initBase(sbo: var SomeBaseObj) =
+  sbo.txt = "Initialized string from base"
+
+static:
+  var ifb2: InheritedFromBase
+  initBase(SomeBaseObj(ifb2))
+  echo repr(ifb2)
+  doAssert(ifb2.txt == "Initialized string from base")


### PR DESCRIPTION
Hopefully the type-check phase already rejected all the invalid conversions by the time we execute the VM bytecode.

Am I too optimistic?

Problem reported by chrisheller on the Nim Forum, there's no associated ticket.