### PR TITLE
Proper check for tyStatic[T] -> U conversions

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -108,6 +108,8 @@ const
 
 proc checkConvertible(c: PContext, castDest, src: PType): TConvStatus =
   result = convOK
+  # We're interested in the inner type and not in the static tag
+  var src = src.skipTypes({tyStatic})
   if sameType(castDest, src) and castDest.sym == src.sym:
     # don't annoy conversions that may be needed on another processor:
     if castDest.kind notin IntegralTypes+{tyRange}:

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -132,3 +132,8 @@ block:
   var x = foo(y, 10, 15, [1, 2, 3])
   doAssert x == (20, 10, 15, 3)
 
+# #7609
+block:
+  type
+    Coord[N: static[int]] = tuple[col, row: range[0'i8 .. (N.int8-1)]]
+    Point[N: static[int]] = range[0'i16 .. N.int16 * N.int16 - 1]


### PR DESCRIPTION
Drop the outer tyStatic shell then perform the check.

Fixes #7609