### PR TITLE
fix json bug `[]=` misplaced, causing: Error: type mismatch: got <JsonNode, string, JsonNode>

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -357,6 +357,11 @@ when false:
     assert false notin elements, "usage error: only empty sets allowed"
     assert true notin elements, "usage error: only empty sets allowed"
 
+proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
+  ## Sets a field from a `JObject`.
+  assert(obj.kind == JObject)
+  obj.fields[key] = val
+
 #[
 Note: could use simply:
 proc `%`*(o: object|tuple): JsonNode
@@ -521,11 +526,6 @@ proc contains*(node: JsonNode, val: JsonNode): bool =
 
 proc existsKey*(node: JsonNode, key: string): bool {.deprecated: "use hasKey instead".} = node.hasKey(key)
   ## **Deprecated:** use `hasKey` instead.
-
-proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
-  ## Sets a field from a `JObject`.
-  assert(obj.kind == JObject)
-  obj.fields[key] = val
 
 proc `{}`*(node: JsonNode, keys: varargs[string]): JsonNode =
   ## Traverses the node and gets the given value. If any of the


### PR DESCRIPTION
before PR:
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0118.nim(34, 1) template/generic instantiation from here
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0118.nim(36, 6) template/generic instantiation of `foo` from here
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0118b.nim(4, 17) template/generic instantiation of `%` from here
/Users/timothee/git_clone/nim/Nim/lib/pure/json.nim(369, 41) Error: type mismatch: got <JsonNode, string, JsonNode>
but expected one of:
proc `[]=`[T, U](s: var string; x: HSlice[T, U]; b: string)
proc `[]=`[T](s: var openArray[T]; i: BackwardsIndex; x: T)
template `[]=`(s: string; i: int; val: char)
proc `[]=`[Idx, T](a: var array[Idx, T]; i: BackwardsIndex; x: T)
proc `[]=`[I: Ordinal; T, S](a: T; i: I; x: S)
proc `[]=`[T, U, V](s: var seq[T]; x: HSlice[U, V]; b: openArray[T])
proc `[]=`[Idx, T, U, V](a: var array[Idx, T]; x: HSlice[U, V]; b: openArray[T])
proc `[]=`(s: var string; i: BackwardsIndex; x: char)

expression: []=(result, "file", %o[0])
      for k, v in o.fieldPairs: result[k] = %v
                                          ^
```

after PR: works

this simply moves `proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =` right before it's being used


t0118.nim:
```nim
import t0118b
proc main()=
  let a = (file:"asdf", line: 21)
  foo("asdf", a)

main()
```

t0118b.nim:
```nim
import json
proc foo*[T](cmd: string, args: T) =
  let args2 = $(%* args)
  echo args2
```
