### PR TITLE
Correct lineinfo for accent quoted symbols in proc definition

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -332,12 +332,15 @@ proc parseSymbol(p: var TParser, mode = smNormal): PNode =
           parMessage(p, errIdentifierExpected, p.tok)
         break
       of tkOpr, tkDot, tkDotDot, tkEquals, tkParLe..tkParDotRi:
+        let lineinfo = parLineinfo(p)
         var accm = ""
         while p.tok.tokType in {tkOpr, tkDot, tkDotDot, tkEquals,
                                 tkParLe..tkParDotRi}:
           accm.add(tokToStr(p.tok))
           getTok(p)
-        result.add(newIdentNodeP(p.lex.cache.getIdent(accm), p))
+        let node = newNodeI(nkIdent, lineinfo)
+        node.ident = p.lex.cache.getIdent(accm)
+        result.add(node)
       of tokKeywordLow..tokKeywordHigh, tkSymbol, tkIntLit..tkCharLit:
         result.add(newIdentNodeP(p.lex.cache.getIdent(tokToStr(p.tok)), p))
         getTok(p)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -318,16 +318,16 @@ proc semIdentDef(c: PContext, n: PNode, kind: TSymKind): PSym =
     result = semIdentWithPragma(c, kind, n, {})
     if result.owner.kind == skModule:
       incl(result.flags, sfGlobal)
-  let info = case n.kind
-             of nkPostfix:
-               n.sons[1].info
-             of nkPragmaExpr:
-               if n.sons[0].kind == nkPostfix:
-                 n.sons[0].sons[1].info
-               else:
-                 n.sons[0].info
-             else:
-               n.info
+
+  proc getLineInfo(n: PNode): TLineInfo =
+    case n.kind
+    of nkPostfix:
+      getLineInfo(n.sons[1])
+    of nkAccQuoted, nkPragmaExpr:
+      getLineInfo(n.sons[0])
+    else:
+      n.info
+  let info = getLineInfo(n)
   suggestSym(c.config, info, result, c.graph.usageSym)
 
 proc checkNilable(c: PContext; v: PSym) =

--- a/nimsuggest/tests/taccent_highlight.nim
+++ b/nimsuggest/tests/taccent_highlight.nim
@@ -1,0 +1,8 @@
+proc `$$$`#[!]#
+
+discard """
+disabled:true
+$nimsuggest --tester $file
+>highlight $1
+highlight;;skProc;;1;;6;;3
+"""


### PR DESCRIPTION
Previously nimsuggest would highlight the following as:

```
proc `$$$`
     ^~~
```

This fixes it into:

```
proc `$$$`
      ^~~
```