### PR TITLE
Fix subtype conversion w/ varargs arguments

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2071,6 +2071,7 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
     # constructor in a call:
     if result == nil and f.kind == tyVarargs:
       if f.n != nil:
+        # Forward to the varargs converter
         result = localConvMatch(c, m, f, a, arg)
       else:
         r = typeRel(m, base(f), a)
@@ -2083,10 +2084,10 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
         # bug #4799, varargs accepting subtype relation object
         elif r == isSubtype:
           inc(m.subtypeMatches)
-          if f.kind == tyTypeDesc:
+          if base(f).kind == tyTypeDesc:
             result = arg
           else:
-            result = implicitConv(nkHiddenSubConv, f, arg, m, c)
+            result = implicitConv(nkHiddenSubConv, base(f), arg, m, c)
           m.baseTypeMatch = true
         else:
           result = userConvMatch(c, m, base(f), a, arg)

--- a/tests/typerel/t4799.nim
+++ b/tests/typerel/t4799.nim
@@ -1,4 +1,5 @@
 discard """
+  targets: "c cpp"
   output: "OK"
 """
 

--- a/tests/typerel/t4799_1.nim
+++ b/tests/typerel/t4799_1.nim
@@ -1,4 +1,5 @@
 discard """
+  targets: "c cpp"
   outputsub: '''ObjectAssignmentError'''
   exitcode: "1"
 """

--- a/tests/typerel/t4799_2.nim
+++ b/tests/typerel/t4799_2.nim
@@ -1,4 +1,5 @@
 discard """
+  targets: "c cpp"
   outputsub: '''ObjectAssignmentError'''
   exitcode: "1"
 """

--- a/tests/typerel/t4799_3.nim
+++ b/tests/typerel/t4799_3.nim
@@ -1,4 +1,5 @@
 discard """
+  targets: "c cpp"
   outputsub: '''ObjectAssignmentError'''
   exitcode: "1"
 """


### PR DESCRIPTION
The type matching is done on the `T` of the `varargs[T]` so the
conversion must be performed to `T` and not to the whole type.

This problem is only noticeable with the cpp backend since C doesn't
give a damn shit about your fucking (wrong) types.

Fixes #9845