### PR TITLE
nimsuggest/tester: disable highlight tests for epc

### DIFF
--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -240,6 +240,10 @@ proc skipDisabledTest(test: Test): bool =
 proc runEpcTest(filename: string): int =
   let s = parseTest(filename, true)
   if s.skipDisabledTest: return 0
+  for req, _ in items(s.script):
+    if req.startsWith("highlight"):
+      echo "disabled epc: " & s.filename
+      return 0
   for cmd in s.startup:
     if not runCmd(cmd, s.dest):
       quit "invalid command: " & cmd

--- a/nimsuggest/tests/taccent_highlight.nim
+++ b/nimsuggest/tests/taccent_highlight.nim
@@ -1,7 +1,6 @@
 proc `$$$`#[!]#
 
 discard """
-disabled:true
 $nimsuggest --tester $file
 >highlight $1
 highlight;;skProc;;1;;6;;3

--- a/nimsuggest/tests/ttype_highlight.nim
+++ b/nimsuggest/tests/ttype_highlight.nim
@@ -6,7 +6,6 @@ type
   TypeE* {.unchecked.} = array[0, int]#[!]#
 
 discard """
-disabled:true
 $nimsuggest --tester $file
 >highlight $1
 highlight;;skType;;2;;2;;5


### PR DESCRIPTION
The EPC backend of nimsuggest currently doesn't support nimsuggest
highlighter, see nim-lang/nim-mode#140

Re-enable disabled highlighting tests.