### PR TITLE
fix #9556 [backport]

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -203,7 +203,7 @@ proc toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
     result = absPath
   else:
     let relPath = conf.m.fileInfos[info.fileIndex.int32].projPath.string
-    result = if absPath.len < relPath.len: absPath else: relPath
+    result = if relPath.count("..") > 2: absPath else: relPath
 
 proc toLinenumber*(info: TLineInfo): int {.inline.} =
   result = int info.line


### PR DESCRIPTION
The old logic wasn't very useful because
`relPath` is almost always shorter than `absPath`,
e.g. `../../../../../` is shorter than `C:\Program Files`.

This way allows the usage of a relative path for
at most two levels deep, e.g. `../../relPath`,
otherwise the absolute path is used.