### PR TITLE
object private field lookup fix for hygienic templates, issue is dead hard to reproduce

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1291,7 +1291,11 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
       if ty.sons[0] == nil: break
       ty = skipTypes(ty.sons[0], skipPtrs)
     if f != nil:
-      if fieldVisible(c, f):
+      let visibilityCheckNeeded =
+        if n[1].kind == nkSym and n[1].sym == f:
+          false # field lookup was done already, likely by hygienic template or bindSym
+        else: true
+      if not visibilityCheckNeeded or fieldVisible(c, f):
         # is the access to a public field or in the same module or in a friend?
         markUsed(c.config, n.sons[1].info, f, c.graph.usageSym)
         onUse(n.sons[1].info, f)


### PR DESCRIPTION
I have faced this field lookup issue in my project.

I have spent 2 days trying to create a test to replicate this issue in isolation. I couldn't reproduce it outside of the full code base. Therefore, no test I am afraid;(. I can only describe the symptoms:

By the looks of it `builtinFieldAccess` is executed twice. Once from the module were hygienic template getter is defined and it is successful and second time from the module where field is not visible.
Compilation fails with error that field can't be accessed.

In debugger I see that `builtinFieldAccess`  second time gets `nkDotExpr` node `n` produced by hygienic template , `n[0]` is already a symbol and `n[1]` is also already resolved field symbol. However  `builtinFieldAccess` does its work second time and this time, the field is not visible because we are in a different module.

I have no idea what could cause `builtinFieldAccess`  to be run twice (usually it is done once) and why in the second run n[0] and n[1] are properly looked up symbols, but `n.typ` is not yet populated.

Please review. 

