### PR TITLE
Fix exception tracking in try blocks

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -353,6 +353,8 @@ proc trackTryStmt(tracked: PEffects, n: PNode) =
 
   var branches = 1
   var hasFinally = false
+
+  # Collect the exceptions caught by the except branches
   for i in 1 ..< n.len:
     let b = n.sons[i]
     let blen = sonsLen(b)
@@ -368,12 +370,18 @@ proc trackTryStmt(tracked: PEffects, n: PNode) =
           else:
             assert(b.sons[j].kind == nkType)
             catches(tracked, b.sons[j].typ)
+    else:
+      assert b.kind == nkFinally
+  # Add any other exception raised in the except bodies
+  for i in 1 ..< n.len:
+    let b = n.sons[i]
+    let blen = sonsLen(b)
+    if b.kind == nkExceptBranch:
       setLen(tracked.init, oldState)
       track(tracked, b.sons[blen-1])
       for i in oldState..<tracked.init.len:
         addToIntersection(inter, tracked.init[i])
     else:
-      assert b.kind == nkFinally
       setLen(tracked.init, oldState)
       track(tracked, b.sons[blen-1])
       hasFinally = true

--- a/tests/effects/teffects7.nim
+++ b/tests/effects/teffects7.nim
@@ -1,0 +1,14 @@
+discard """
+  errormsg: "can raise an unlisted exception: ref FloatingPointError"
+  line: 10
+"""
+
+proc foo() {.raises: [].} =
+  try:
+    discard
+  except KeyError:
+    raise newException(FloatingPointError, "foo")
+  except Exception:
+    discard
+
+foo()


### PR DESCRIPTION
Exceptions raised inside a nkFinally/nkExcept block are not caught by
the block itself.

Fixes #3886