### PR TITLE
isLastRead regression fix

### DIFF
--- a/compiler/destroyer.nim
+++ b/compiler/destroyer.nim
@@ -139,7 +139,7 @@ proc isLastRead(s: PSym; c: var Con; pc, comesFrom: int): int =
     of def:
       if c.g[pc].sym == s:
         # the path lead to a redefinition of 's' --> abandon it.
-        return pc
+        return high(int) 
       inc pc
     of use:
       if c.g[pc].sym == s:
@@ -150,14 +150,16 @@ proc isLastRead(s: PSym; c: var Con; pc, comesFrom: int): int =
       pc = pc + c.g[pc].dest
     of fork:
       # every branch must lead to the last read of the location:
-      let variantA = isLastRead(s, c, pc+1, pc)
+      var variantA = isLastRead(s, c, pc+1, pc)
       if variantA < 0: return -1
       let variantB = isLastRead(s, c, pc + c.g[pc].dest, pc)
       if variantB < 0: return -1
-      pc = variantA+1
+      elif variantA == high(int): 
+        variantA = variantB
+      pc = variantA
     of InstrKind.join:
       let dest = pc + c.g[pc].dest
-      if dest == comesFrom: return pc
+      if dest == comesFrom: return pc + 1
       inc pc
   return pc
 

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -166,3 +166,12 @@ seq4 =
 var ii = 1
 let arr2 = [newMySeq(2, 5.0), if i > 1: newMySeq(3, 1.0) else: newMySeq(0, 0.0)]
 var seqOfSeq2 = @[newMySeq(2, 5.0), newMySeq(3, 1.0)]
+
+
+## issue #10462
+proc myfuncLoop(x: int): MySeqNonCopyable =
+  for i in 0..<x:
+    var cc = newMySeq(i, 5.0)
+    result = cc
+
+discard myfuncLoop(3)


### PR DESCRIPTION
I have also noticed is that new `isLastRead` can crash with integer overflow because `fork` did `variantA+1` without checking if `variant(A) == high(int)` which does happen due to `goto high(int)` instructions.

Fixes #10462