### PR TITLE
uri: Update documentation typo

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -342,9 +342,9 @@ proc combine*(uris: varargs[Uri]): Uri =
   ## **See also:**
   ## * `/ proc <#/,Uri,string>`_ for building URIs
   runnableExamples:
-    let foo = combine([parseUri("https://nim-lang.org/blog.html"), parseUri("/install.html")])
+    let foo = combine(parseUri("https://nim-lang.org/"), parseUri("docs/"), parseUri("manual.html"))
     assert foo.hostname == "nim-lang.org"
-    assert foo.path == "/install.html"
+    assert foo.path == "/docs/manual.html"
   result = uris[0]
   for i in 1 ..< uris.len:
     result = combine(result, uris[i])

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -33,8 +33,7 @@
 ##    import uri
 ##    let res = parseUri("sftp://127.0.0.1:4343")
 ##    if isAbsolute(res):
-##      echo "Connect to port: " & res.port
-##      # --> Connect to port: 4343
+##      assert res.port == "4343"
 ##    else:
 ##      echo "Wrong format"
 
@@ -343,7 +342,7 @@ proc combine*(uris: varargs[Uri]): Uri =
   ## **See also:**
   ## * `/ proc <#/,Uri,string>`_ for building URIs
   runnableExamples:
-    let foo = combine(parseUri("https://nim-lang.org/blog.html"), parseUri("/install.html"))
+    let foo = combine([parseUri("https://nim-lang.org/blog.html"), parseUri("/install.html")])
     assert foo.hostname == "nim-lang.org"
     assert foo.path == "/install.html"
   result = uris[0]


### PR DESCRIPTION
1) Use `assert` in code sample.
2) Updated wrong runnableExample in `combine()`.