### PR TITLE
lines(f: File) defaults to stdin if no file given.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3566,7 +3566,7 @@ when not defined(JS): #and not defined(nimscript):
       var res = TaintedString(newStringOfCap(80))
       while f.readLine(res): yield res
 
-    iterator lines*(f: File): TaintedString {.tags: [ReadIOEffect].} =
+    iterator lines*(f: File = stdin): TaintedString {.tags: [ReadIOEffect].} =
       ## Iterate over any line in the file `f`.
       ##
       ## The trailing newline character(s) are removed from the iterated lines.


### PR DESCRIPTION

Not sure if it is just me, but 90% of the times I use lines() it is for ad-hoc scripts and tools which do stdin/stdout transforms. I think using ``stdin`` by default makese sense here?