### PR TITLE
Genode fixes

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -290,13 +290,16 @@ tcc.options.always = "-w"
 
 # Configuration for the Genode toolchain
 @if genode:
+  noCppExceptions # avoid std C++
+  tlsEmulation:on # no TLS segment register magic
   gcc.path = "/usr/local/genode-gcc/bin"
-  gcc.cpp.options.always = "-D__GENODE__ -fno-stack-protector"
   @if i386 or amd64:
     gcc.exe = "genode-x86-gcc"
     gcc.cpp.exe = "genode-x86-g++"
+    gcc.cpp.linkerexe = "genode-x86-ld"
   @elif arm:
     gcc.exe = "genode-arm-gcc"
     gcc.cpp.exe = "genode-arm-g++"
+    gcc.cpp.linkerexe = "genode-arm-ld"
   @end
 @end

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -73,6 +73,15 @@ when defined(Windows):
          discard readConsoleInputW(hStdin, irInputRecord, 1, dwEventsRead)
          return result
 
+elif defined(genode):
+  proc readLineFromStdin*(prompt: string): TaintedString {.
+                          tags: [ReadIOEffect, WriteIOEffect].} =
+    stdin.readLine()
+
+  proc readLineFromStdin*(prompt: string, line: var TaintedString): bool {.
+                          tags: [ReadIOEffect, WriteIOEffect].} =
+    stdin.readLine(line)
+
 else:
   import linenoise, termios
 

--- a/lib/pure/fenv.nim
+++ b/lib/pure/fenv.nim
@@ -12,7 +12,7 @@
 
 {.deadCodeElim: on.}  # dce option deprecated
 
-when defined(Posix):
+when defined(Posix) and not defined(genode):
   {.passl: "-lm".}
 
 var

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -95,7 +95,7 @@ proc fac*(n: int): int =
 
 {.push checks:off, line_dir:off, stack_trace:off.}
 
-when defined(Posix):
+when defined(Posix) and not defined(genode):
   {.passl: "-lm".}
 
 const


### PR DESCRIPTION
Readline pasthru, add linker to config, do not pass -lm to linker.