### PR TITLE
Misc fixes

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -246,7 +246,7 @@ proc genComment(d: PDoc, n: PNode): string =
   result = ""
   var dummyHasToc: bool
   if n.comment.len > 0:
-    renderRstToOut(d[], parseRst(n.comment, toFilename(d.conf, n.info),
+    renderRstToOut(d[], parseRst(n.comment, toFullPath(d.conf, n.info),
                                toLinenumber(n.info), toColumn(n.info),
                                dummyHasToc, d.options, d.conf), result)
 

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -149,14 +149,16 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
       if filename.len == 0:
         inc(d.id)
         let nameOnly = splitFile(d.filename).name
-        let subdir = getNimcacheDir(conf) / RelativeDir(nameOnly)
-        createDir(subdir)
-        outp = subdir / RelativeFile(nameOnly & "_snippet_" & $d.id & ".nim")
+        outp = getNimcacheDir(conf) / RelativeDir(nameOnly) /
+               RelativeFile(nameOnly & "_snippet_" & $d.id & ".nim")
       elif isAbsolute(filename):
-        outp = AbsoluteFile filename
+        outp = AbsoluteFile(filename)
       else:
         # Nim's convention: every path is relative to the file it was written in:
-        outp = splitFile(d.filename).dir.AbsoluteDir / RelativeFile(filename)
+        let nameOnly = splitFile(d.filename).name
+        outp = AbsoluteDir(nameOnly) / RelativeFile(filename)
+      # Make sure the destination directory exists
+      createDir(outp.splitFile.dir)
       # Include the current file if we're parsing a nim file
       let importStmt = if d.isPureRst: "" else: "import \"$1\"\n" % [d.filename]
       writeFile(outp, importStmt & content)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4405,7 +4405,7 @@ template doAssertRaises*(exception: typedesc, code: untyped): typed =
       wrong = true
     except exception:
       discard
-    except Exception as exc:
+    except Exception:
       raiseAssert(astToStr(exception) &
                   " wasn't raised, another error was raised instead by:\n"&
                   astToStr(code))


### PR DESCRIPTION
The important commit is the second one, right now the Nim Convention :tm: is not respected by `code-block` `:file:`.

One more nit, if one specifies a `:file:` directive the file it points to gets `importStmt` prepended to it and that's IMO bad behaviour if you want to do something like I do [here](https://github.com/LemonBoy/cassette/blob/0d727bae8a387629e4fe0f4b8632db1b179740fc/src/cassette.nim#L20,L22). I think the snippet should always be written to its own file or compiled&run from the specified location instead.

[1] `Nim's convention: every path is relative to the file it was written in`