### PR TITLE
fix #9471 (re quantifier `{` under-documented)

### DIFF
--- a/doc/regexprs.txt
+++ b/doc/regexprs.txt
@@ -80,13 +80,13 @@ meta character     meaning
 ``|``              start of alternative branch
 ``(``              start subpattern
 ``)``              end subpattern
-``?``              extends the meaning of ``(``
-                   also 0 or 1 quantifier
-                   also quantifier minimizer
-``*``              0 or more quantifier
-``+``              1 or more quantifier
-                   also "possessive quantifier"
 ``{``              start min/max quantifier
+``?``              extends the meaning of ``(``
+                   | also 0 or 1 quantifier (equal to ``{0,1}``)
+                   | also quantifier minimizer
+``*``              0 or more quantifier (equal to ``{0,}``)
+``+``              1 or more quantifier (equal to ``{1,}``)
+                   | also "possessive quantifier"
 ==============     ============================================================
 
 


### PR DESCRIPTION
`re` `{` is now more documented by providing usage examples in `?`, `*` and `+` rows.

Anything more than that would just raise hundred new questions "why is `{` documented in detail, and X isn't?".
For those who would like to learn more, the documentation already provides links to http://www.pcre.org/ and http://perldoc.perl.org/perlre.html


This also fixes wrong table formatting:
![before-after](https://i.imgur.com/FftM5rR.png)