### PR TITLE
fix #10042 (allow spaces in import)

### DIFF
--- a/compiler/modulepaths.nim
+++ b/compiler/modulepaths.nim
@@ -114,7 +114,6 @@ proc getModuleName*(conf: ConfigRef; n: PNode): string =
     try:
       result =
         pathSubs(conf, n.strVal, toFullPath(conf, n.info).splitFile().dir)
-          .replace(" ")
     except ValueError:
       localError(conf, n.info, "invalid path: " & n.strVal)
       result = n.strVal

--- a/tests/dir with space/more spaces/mspace.nim
+++ b/tests/dir with space/more spaces/mspace.nim
@@ -1,0 +1,1 @@
+proc tenTimes*(x: int): int = 10*x

--- a/tests/dir with space/tspace.nim
+++ b/tests/dir with space/tspace.nim
@@ -2,5 +2,9 @@ discard """
 output: "Successful"
 """
 # Test for the compiler to be able to compile a Nim file with spaces in the directory name.
+# Also test if import of a directory with a space works.
 
+import "more spaces" / mspace
+
+assert tenTimes(5) == 50
 echo("Successful")


### PR DESCRIPTION
This allows spaces in imports, by using the following syntax:
* `import "directory with spaces" / subdir / file`, or
* `import "directory with spaces/subdir/file"`