### PR TITLE
Fix evaluation of const expression w/ converters

### DIFF
--- a/tests/vm/teval1.nim
+++ b/tests/vm/teval1.nim
@@ -25,3 +25,18 @@ doAssert x == ""
 static:
   var i, j: set[int8] = {}
   var k = i + j
+
+type
+  Obj = object
+    x: int
+
+converter toObj(x: int): Obj = Obj(x: x)
+
+# bug #10514
+block:
+  const
+    b: Obj = 42
+    bar = [b]
+
+  let i_runtime = 0
+  doAssert bar[i_runtime] == b


### PR DESCRIPTION
Fixes #10514 by splitting the type checking phase from the evaluation phase.
`semConstExpr` ends up sem-checking the `def` node again but I've left that since it's better be safe than sorry.