### PR TITLE
Deprecate the times.countX procs

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2369,26 +2369,38 @@ proc `$`*(time: Time): string {.tags: [], raises: [], benign.} =
     doAssert $tm == "1970-01-01T00:00:00" & format(dt, "zzz")
   $time.local
 
-proc countLeapYears*(yearSpan: int): int =
+proc countLeapYears*(yearSpan: int): int
+    {.deprecated.} =
   ## Returns the number of leap years spanned by a given number of years.
   ##
   ## **Note:** For leap years, start date is assumed to be 1 AD.
   ## counts the number of leap years up to January 1st of a given year.
   ## Keep in mind that if specified year is a leap year, the leap day
   ## has not happened before January 1st of that year.
+  ##
+  ## **Deprecated since v0.20.0**.
   (yearSpan - 1) div 4 - (yearSpan - 1) div 100 + (yearSpan - 1) div 400
 
-proc countDays*(yearSpan: int): int =
+proc countDays*(yearSpan: int): int
+    {.deprecated.} =
   ## Returns the number of days spanned by a given number of years.
+  ##
+  ## **Deprecated since v0.20.0**.
   (yearSpan - 1) * 365 + countLeapYears(yearSpan)
 
-proc countYears*(daySpan: int): int =
+proc countYears*(daySpan: int): int
+    {.deprecated.} =
   ## Returns the number of years spanned by a given number of days.
+  ##
+  ## **Deprecated since v0.20.0**.
   ((daySpan - countLeapYears(daySpan div 365)) div 365)
 
-proc countYearsAndDays*(daySpan: int): tuple[years: int, days: int] =
+proc countYearsAndDays*(daySpan: int): tuple[years: int, days: int]
+    {.deprecated.} =
   ## Returns the number of years spanned by a given number of days and the
   ## remainder as days.
+  ##
+  ## **Deprecated since v0.20.0**.
   let days = daySpan - countLeapYears(daySpan div 365)
   result.years = days div 365
   result.days = days mod 365


### PR DESCRIPTION
These procs should have been deprecated a long time ago. I think their original purpose was to implement a conversion for `Time` to `DateTime`. However, that conversion was rewritten a long time ago and doesn't use these procs anymore. They are extremely niche and it's unlikely that anyone uses them, so they are just api bloat that should be removed.
