### PR TITLE
brew (almost?) never requires sudo

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -232,7 +232,7 @@ proc foreignDepInstallCmd*(foreignPackageName: string): (string, bool) =
   elif defined(haiku):
     result = ("pkgman install " & p, true)
   else:
-    result = ("brew install " & p, true)
+    result = ("brew install " & p, false)
 
 proc foreignDep*(foreignPackageName: string) =
   ## Registers 'foreignPackageName' to the internal list of foreign deps.


### PR DESCRIPTION
/cc @dom96 because of https://github.com/nim-lang/nimble/pull/607#issuecomment-459850375
@Araq I don't understand your commit 0ecec83 `distros.nim: brew usually requires 'sudo'` ; where did you get this information from?

I've been using brew for years and never needed `sudo` when running `brew install foo` (there may be exceptions in rare corner cases, eg `brew cask install`, but i'm not even sure of that)

while installing brew itself **may** require `sudo` (or may have, in the past), (eg to agree to xcode license agreement), using sudo for `brew install` is not only not required but also probably not even allowed, see official docs:

* https://docs.brew.sh/Installation 
> This script installs Homebrew to /usr/local so that you don’t need sudo when you brew install

* see also: https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad
> Homebrew refuses to work using sudo.

