### PR TITLE
Flexible import syntax

### DIFF
--- a/tests/macros/tmacros_importinterp.nim
+++ b/tests/macros/tmacros_importinterp.nim
@@ -1,0 +1,55 @@
+when not defined(case_custom):
+  import strutils, strformat, os
+  for a in "caseExpr caseSymbol casePaths caseRename caseFrom caseMultiNil".split:
+    let path = currentSourcePath
+    let cmd = fmt"nim c -r -d:{a} -d:case_custom {path}"
+    doAssert execShellCmd(cmd) == 0, cmd
+else:
+  from macros import importInterp
+  when defined(caseExpr):
+    importInterp("std/" & "strutils")
+    static: doAssert declared strutils
+
+  when defined(caseSymbol):
+    const path = "std/" & "strutils"
+    importInterp path
+    static: doAssert declared strutils
+
+  when defined(casePaths):
+    const path = ["os", "strutils"]
+    importInterp path
+    static:
+      doAssert declared os
+      doAssert declared strutils
+
+  when defined(caseRename):
+    importInterp("std/" & "strutils", strutils_temp)
+    static: doAssert declared strutils_temp
+    doAssert strutils_temp.splitLines("a") == @["a"] # sanity check
+
+  when defined(caseFrom):
+    importInterp "std/os": [ExeExt, DirSep]
+    static:
+      doAssert declared ExeExt
+      doAssert declared DirSep
+      doAssert not declared AltSep
+      doAssert declared os.AltSep
+
+  when defined(caseMultiNil):
+    importInterp ["os", "strutils"]: nil
+    static:
+      doAssert not declared ExeExt
+      doAssert declared os.ExeExt
+
+  when defined(caseMegatestLike):
+    # not enabling this one to avoid slowdowns, just for illustration.
+    import sequtils, os, strformat
+    const nimLibPure = fmt"{currentSourcePath}".parentDir
+    const paths = block:
+      var ret: seq[string]
+      for kind, path in walkDir(nimLibPure):
+        if kind != pcFile: continue
+        if ret.len > 10: break
+        ret.add path
+      ret
+    importInterp paths: nil


### PR DESCRIPTION
Flexible import syntax, allowing to import a path (or multiple paths) computed at compile time from an expression, instead of standard import which requires a litteral.
  
```nim
  # import from a path expression:
  const path = getSomePath()
  importInterp path

   # same as above:
  importInterp getSomePath()

   # same, but with alias syntax (`pathAlias` is a symbol, not a string):
  importInterp path, pathAlias

   # same, but with partial import:
  importInterp path: [foo1, foo2]

   # import from multiple paths at once (can be any compile time expression):
  importInterp ["os", "strutils"]

   # same but requiring qualified imports:
  importInterp ["os", "strutils"]: nil
```


* additional example use case, using `getCurrentPkgDir` from https://github.com/nim-lang/Nim/pull/10530:
```nim
# import relative to root of current nimble package:
importInterp getCurrentPkgDir() / "foo/bar"

# provides an alternative  to current approach where you have to know how many `..` to add:
import "../../foo/bar"
```
