### PR TITLE
getCurrentPkgDir: Returns the path to the closest enclosing nimble package dir

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3015,6 +3015,16 @@ proc setLastModificationTime*(file: string, t: times.Time) {.noNimScript.} =
     discard h.closeHandle
     if res == 0'i32: raiseOSError(osLastError())
 
+proc getCurrentPkgDirImpl(dir: string): string =
+  for dir2 in parentDirs(dir, fromRoot = false, inclusive = false):
+    for kind, path in walkDir(dir2, relative = true):
+      if kind == pcFile and path.endsWith ".nimble":
+        when defined(nimscript): return dir2
+        else: return normalizedPath dir2
+
+template getCurrentPkgDir*(dir = instantiationInfo(-1, true).filename): string =
+  ## Returns the path to the closest enclosing nimble package dir
+  getCurrentPkgDirImpl(dir)
 
 when isMainModule:
   assert quoteShellWindows("aaa") == "aaa"

--- a/tests/stdlib/nimblepkg/baz/tbaz.nim
+++ b/tests/stdlib/nimblepkg/baz/tbaz.nim
@@ -1,0 +1,3 @@
+import os
+block getCurrentPkgDir:
+  static: doAssert getCurrentPkgDir() == currentSourcePath.parentDir.parentDir

--- a/tests/stdlib/nimblepkg/foo.nimble
+++ b/tests/stdlib/nimblepkg/foo.nimble
@@ -1,0 +1,1 @@
+# for tbaz.nim

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -26,6 +26,7 @@ Raises
 # test os path creation, iteration, and deletion
 
 import os, strutils, pathnorm
+import "$nim/compiler/unittest_light"
 
 block fileOperations:
   let files = @["these.txt", "are.x", "testing.r", "files.q"]
@@ -333,3 +334,9 @@ block ospaths:
   doAssert joinPath("", "lib") == "lib"
   doAssert joinPath("", "/lib") == unixToNativePath"/lib"
   doAssert joinPath("usr/", "/lib") == unixToNativePath"usr/lib"
+
+block getCurrentPkgDir:
+  const dir = currentSourcePath.parentDir / "nimblepkg"
+  static:
+    assertEquals getCurrentPkgDir(dir / "baz/tbaz.nim"), dir
+    assertEquals getCurrentPkgDir(dir / "baz"), dir


### PR DESCRIPTION
`getCurrentPkgDir(dir)`, `getCurrentPkgDir()`: Returns the path to the closest enclosing nimble package dir.

This enables referring to current nimble package without interference from potential other nimble packages already installed with same name (eg a different version).

Suppose we have a nimble package (ie containing `/pathto/nim-myjester/jester.nimble`)
in /pathto/nim-myjester/bar/baz.nim:
```nim
import os
proc main()=
  static: doAssert getCurrentPkgDir() == "/pathto/nim-myjester"
  static: doAssert getCurrentPkgDir("/pathto/nim-myjester/bar/baz.nim") == "/pathto/nim-myjester"
main()
```


## example use cases
```nim
# reliable way to access a specific file inside a nimble package regardless of where calling module is located inside nimble pkg
const file = getCurrentPkgDir() / "foo.txt"
# in combination with https://github.com/nim-lang/Nim/pull/10527:
importInterp getCurrentPkgDir() / "foo/bar"
```

## note:
added `[backport]` as I'd like to have this in next release (19.6) in case there's such a release
