### PR TITLE
Change strtabs.nextTry to match the assumption in strtabs.del

### DIFF
--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -117,7 +117,7 @@ proc mustRehash(length, counter: int): bool =
   result = (length * 2 < counter * 3) or (length - counter < 4)
 
 proc nextTry(h, maxHash: Hash): Hash {.inline.} =
-  result = ((5 * h) + 1) and maxHash
+  result = (h + 1) and maxHash
 
 proc rawGet(t: StringTableRef, key: string): int =
   var h: Hash = myhash(t, key) and high(t.data) # start with real hash value


### PR DESCRIPTION
I forgot to push this before #10533 was merged... Since the strtabs.del implementation is based on the one for tables the strtabs.nextTry implementation must match the one for tables.