### PR TITLE
Fix regression in AsyncHttpServer (plus other niceties)

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -309,10 +309,8 @@ proc serve*(server: AsyncHttpServer, port: Port,
   server.socket.listen()
 
   while true:
-    # TODO: Causes compiler crash.
-    #var (address, client) = await server.socket.acceptAddr()
-    var fut = await server.socket.acceptAddr()
-    asyncCheck processClient(server, fut.client, fut.address, callback)
+    var (address, client) = await server.socket.acceptAddr()
+    asyncCheck processClient(server, client, address, callback)
     #echo(f.isNil)
     #echo(f.repr)
 

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -264,6 +264,9 @@ proc processRequest(
   if "upgrade" in request.headers.getOrDefault("connection"):
     return false
 
+  # The request has been served, from this point on returning `true` means the
+  # connection will not be closed and will be kept in the connection pool.
+
   # Persistent connections
   if (request.protocol == HttpVer11 and
       cmpIgnoreCase(request.headers.getOrDefault("connection"), "close") != 0) or
@@ -273,7 +276,7 @@ proc processRequest(
     # header states otherwise.
     # In HTTP 1.0 we assume that the connection should not be persistent.
     # Unless the connection header states otherwise.
-    discard
+    return true
   else:
     request.client.close()
     return false

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -154,13 +154,13 @@ proc processBody(node, retFutureSym: NimNode,
                 newCommand, node)
 
   of nnkVarSection, nnkLetSection:
-    case node[0][2].kind
+    case node[0][^1].kind
     of nnkCommand:
-      if node[0][2][0].kind == nnkIdent and node[0][2][0].eqIdent("await"):
+      if node[0][^1][0].kind == nnkIdent and node[0][^1][0].eqIdent("await"):
         # var x = await y
         var newVarSection = node # TODO: Should this use copyNimNode?
-        result.createVar("future" & node[0][0].strVal, node[0][2][1],
-          newVarSection[0][2], newVarSection, node)
+        result.createVar("future" & node[0][0].strVal, node[0][^1][1],
+          newVarSection[0][^1], newVarSection, node)
     else: discard
   of nnkAsgn:
     case node[1].kind
@@ -367,11 +367,11 @@ proc stripAwait(node: NimNode): NimNode =
       # foo await x
       node[1][0] = emptyNoopSym
   of nnkVarSection, nnkLetSection:
-    case node[0][2].kind
+    case node[0][^1].kind
     of nnkCommand:
-      if node[0][2][0].kind == nnkIdent and node[0][2][0].eqIdent("await"):
+      if node[0][^1][0].kind == nnkIdent and node[0][^1][0].eqIdent("await"):
         # var x = await y
-        node[0][2][0] = emptyNoopSym
+        node[0][^1][0] = emptyNoopSym
     else: discard
   of nnkAsgn:
     case node[1].kind


### PR DESCRIPTION
The keep-alive handling is very rough, there's no support for `Keep-Alive` directives nor a way to specify a timeout/limit of the connections in the pool.