### PR TITLE
[superseded] [os] fix #8734, #8353: parentDir, parentDirs now work reliably

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,9 @@
 - `getImpl` on a `var` or `let` symbol will now return the full `IdentDefs`
   tree from the symbol declaration instead of just the initializer portion.
 
+- ``os.parentDir`` and ``os.parentDirs`` had bugs that were fixed in #10545, see details there
+
+
 
 #### Breaking changes in the standard library
 

--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -7,21 +7,13 @@
 #    distribution, for details about the copyright.
 #
 
-iterator myParentDirs(p: string): string =
-  # XXX os's parentDirs is stupid (multiple yields) and triggers an old bug...
-  var current = p
-  while true:
-    current = current.parentDir
-    if current.len == 0: break
-    yield current
-
 proc resetPackageCache*(conf: ConfigRef) =
   conf.packageCache = newPackageCache()
 
 proc getPackageName*(conf: ConfigRef; path: string): string =
   var parents = 0
   block packageSearch:
-    for d in myParentDirs(path):
+    for d in parentDirs(path, inclusive=false):
       if conf.packageCache.hasKey(d):
         #echo "from cache ", d, " |", packageCache[d], "|", path.splitFile.name
         return conf.packageCache[d]
@@ -35,7 +27,7 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
   # we also store if we didn't find anything:
   when not defined(nimNoNilSeqs):
     if result.isNil: result = ""
-  for d in myParentDirs(path):
+  for d in parentDirs(path, inclusive=false):
     #echo "set cache ", d, " |", result, "|", parents
     conf.packageCache[d] = result
     dec parents

--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -7,13 +7,21 @@
 #    distribution, for details about the copyright.
 #
 
+iterator myParentDirs(p: string): string =
+  # XXX os's parentDirs is stupid (multiple yields) and triggers an old bug...
+  var current = p
+  while true:
+    current = current.parentDir
+    if current.len == 0: break
+    yield current
+
 proc resetPackageCache*(conf: ConfigRef) =
   conf.packageCache = newPackageCache()
 
 proc getPackageName*(conf: ConfigRef; path: string): string =
   var parents = 0
   block packageSearch:
-    for d in parentDirs(path, inclusive=false):
+    for d in myParentDirs(path):
       if conf.packageCache.hasKey(d):
         #echo "from cache ", d, " |", packageCache[d], "|", path.splitFile.name
         return conf.packageCache[d]
@@ -27,7 +35,7 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
   # we also store if we didn't find anything:
   when not defined(nimNoNilSeqs):
     if result.isNil: result = ""
-  for d in parentDirs(path, inclusive=false):
+  for d in myParentDirs(path):
     #echo "set cache ", d, " |", result, "|", parents
     conf.packageCache[d] = result
     dec parents

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -594,10 +594,9 @@ proc parentDir*(path: string): string {.
   ## Returns the parent directory of `path`.
   ##
   ## Conventions below derive from analogy with the shell:
-  ##   * an absolute path remains absolute
   ##   * trailing ``.`` and ``/`` are resolved before taking the parent dir
   ## It returns empty when attempting to take parent of ``.`` or ``..``
-  ## to indicate it is invalid and distinguish from ``.``
+  ## to indicate it is invalid (and different from ``.``)
   ##
   ## The remainder can be obtained with `lastPathPart(path) proc
   ## <#lastPathPart,string>`_.
@@ -615,11 +614,15 @@ proc parentDir*(path: string): string {.
       assert parentDir("foo") == "."
       assert parentDir("/foo") == "/"
       assert parentDir(".") == ""
+  const parentDirOfRootIsEmpty = true # still controversial
   if path == "": return ""
   result = path
   while true:
     normalizePathEnd(result)
     let (dir, name, ext) = splitFile(result)
+    when parentDirOfRootIsEmpty:
+      if name == ".." or (name.len == 0 and ext.len == 0): return ""
+
     if name == "..":
       if isAbsolute(dir):
         return dir

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -644,29 +644,14 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ##
   ## See also:
   ## * `parentDir proc <#parentDir,string>`_
-  ##
-  ## **Examples:**
-  ##
-  ## .. code-block::
-  ##   let g = "a/b/c"
-  ##
-  ##   for p in g.parentDirs:
-  ##     echo p
-  ##   # a/b/c
-  ##   # a/b
-  ##   # a
-  ##
-  ##   for p in g.parentDirs(fromRoot=true):
-  ##     echo p
-  ##   # a/
-  ##   # a/b/
-  ##   # a/b/c
-  ##
-  ##   for p in g.parentDirs(inclusive=false):
-  ##     echo p
-  ##   # a/b
-  ##   # a
-
+  runnableExamples:
+    import sequtils
+    let g = "a/b/c"
+    when defined(posix):
+      assert toSeq(g.parentDirs) == @["a/b/c", "a/b", "a"]
+      assert toSeq(g.parentDirs(fromRoot=true)) == @["a", "a/b", "a/b/c"]
+      assert toSeq(g.parentDirs(inclusive=false)) == @["a/b", "a"]
+      assert toSeq("/a//b/".parentDirs) == @["/a//b", "/a", "/"]
   var path = path.normalizePathEnd
   if not fromRoot:
     if inclusive: yield path

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -644,6 +644,7 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ##
   ## Relative paths won't be expanded by this iterator. Instead, it will traverse
   ## only the directories appearing in the relative path.
+  ## Caveat: current implementation involves multiple yields, causing code bloat.
   ##
   ## See also:
   ## * `parentDir proc <#parentDir,string>`_

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -593,10 +593,8 @@ proc parentDir*(path: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Returns the parent directory of `path`.
   ##
-  ## Conventions below derive from analogy with the shell:
-  ##   * trailing ``.`` and ``/`` are resolved before taking the parent dir
-  ## It returns empty when attempting to take parent of ``.`` or ``..``
-  ## to indicate it is invalid (and different from ``.``)
+  ## Trailing ``.`` and ``/`` are resolved before taking the parent dir, see
+  ## examples below for corner cases.
   ##
   ## The remainder can be obtained with `lastPathPart(path) proc
   ## <#lastPathPart,string>`_.
@@ -610,23 +608,17 @@ proc parentDir*(path: string): string {.
     assert parentDir("") == ""
     when defined(posix):
       assert parentDir("/usr/local/bin") == "/usr/local"
-      assert parentDir("foo//bar/") == "foo"
+      assert parentDir("foo//bar//.") == "foo"
       assert parentDir("foo") == "."
       assert parentDir("/foo") == "/"
       assert parentDir(".") == ""
-  const parentDirOfRootIsEmpty = true # still controversial
+      assert parentDir("/") == ""
   if path == "": return ""
   result = path
   while true:
     normalizePathEnd(result)
     let (dir, name, ext) = splitFile(result)
-    when parentDirOfRootIsEmpty:
-      if name == ".." or (name.len == 0 and ext.len == 0): return ""
-
-    if name == "..":
-      if isAbsolute(dir):
-        return dir
-      return ""
+    if name == ".." or (name.len == 0 and ext.len == 0): return ""
     if name == ".":
       result = dir
       continue

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -388,7 +388,7 @@ proc splitFile*(path: string): tuple[dir, name, ext: string] {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Splits a filename into `(dir, name, extension)` tuple.
   ##
-  ## `dir` does not end in `DirSep <#DirSep>`_ unless it is absolute.
+  ## `dir` does not end in `DirSep <#DirSep>`_ unless it is the root directory.
   ## `extension` includes the leading dot.
   ##
   ## If `path` has no extension, `ext` is the empty string.

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -249,13 +249,13 @@ block absolutePath:
 block splitFile:
   doAssert splitFile("") == ("", "", "")
   doAssert splitFile("abc/") == ("abc", "", "")
-  doAssert splitFile("/") == ("/", "", "")
+  doAssert splitFile("/") == ("/".unixToNativePath, "", "")
   doAssert splitFile("./abc") == (".", "abc", "")
   doAssert splitFile(".txt") == ("", ".txt", "")
   doAssert splitFile("abc/.txt") == ("abc", ".txt", "")
   doAssert splitFile("abc") == ("", "abc", "")
   doAssert splitFile("abc.txt") == ("", "abc", ".txt")
-  doAssert splitFile("/abc.txt") == ("/", "abc", ".txt")
+  doAssert splitFile("/abc.txt") == ("/".unixToNativePath, "abc", ".txt")
   doAssert splitFile("/foo/abc.txt") == ("/foo", "abc", ".txt")
   doAssert splitFile("/foo/abc.txt.gz") == ("/foo", "abc.txt", ".gz")
   doAssert splitFile(".") == ("", ".", "")
@@ -426,7 +426,8 @@ block tailDir:
   let examples = [
     ("/usr/local/bin", "usr/local/bin"),
     ("usr/local/bin", "local/bin"),
-    # todo: fix
+
+    # issue #8395; todo: fix
     # ("//usr//local//bin//", "usr//local//bin//"),
     # ("usr//local//bin//", "local/bin//"),
   ]

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -26,13 +26,13 @@ Raises
 # test os path creation, iteration, and deletion
 
 import os, strutils, pathnorm
-import "$nim/compiler/unittest_light"
 
 template runTestCases*(msg: string, examples, body: untyped): bool =
   ##[
   Runs body on each example (input, expected).
   Takes care of calling unixToNativePath.
   Returns true on success.
+  An empty `msg` will disable printing the debug message.
   ]##
   block:
     var numErrors = 0
@@ -428,7 +428,7 @@ block parentDirs:
   template test(iter: untyped, expected: seq[string]): untyped =
     let lhs = toSeq(iter)
     let rhs = expected.mapIt(it.unixToNativePath)
-    assertEquals lhs, rhs
+    doAssert lhs == rhs, $(lhs: lhs, rhs: rhs)
 
   # fromRoot=false, inclusive=true
   test parentDirs("a/b/c".unixToNativePath), @["a/b/c", "a/b", "a"]
@@ -458,4 +458,4 @@ block parentDirs:
 block runTestCasesTest:
   const examples = [("foo", "foobar"), ("foo2", "foo2bar")]
   doAssert runTestCases("identity", examples, it & "bar")
-  doAssert not runTestCases("intentional failure", examples, it & "baz")
+  doAssert not runTestCases("", examples, it & "baz")

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -362,6 +362,12 @@ block ospaths:
   doAssert joinPath("usr/", "/lib") == unixToNativePath"usr/lib"
 
 block parentDir:
+  # list of test cases for `parentDir` with format: `(input, expected)`.
+  # `runTestCases` takes each test case prints helpful debug info for all
+  # violations of:
+  # `parentDir(unixToNativePath(input)) == unixToNativePath(expected)`
+  # and returns true if no violation occurs. This allows seeing errors on
+  # all test cases at once instead of just the 1st error, saving debugging time.
   let examples = [
     ("/usr/local/bin", "/usr/local"),
     ("foo/bar.nim", "foo"),
@@ -413,6 +419,7 @@ block parentDir:
 import sequtils
 
 block tailDir:
+  # list of test cases for `tailDir` with format: `(input, expected)`.
   let examples = [
     ("/usr/local/bin", "usr/local/bin"),
     ("usr/local/bin", "local/bin"),

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -382,23 +382,8 @@ block parentDir:
     ("./bar", "."),
     (".//bar", "."),
     ("bar", "."),
-
     (".git", "."),
     (".git.bak1", "."),
-
-    # with parentDirOfRootIsEmpty=false
-    # ("/", "/"),
-    # ("/.", "/"),
-    # ("/..", "/"),
-    # ("/./", "/"),
-    # fix #8734 (bug 3)
-    # ("/", "/"),
-
-    # with parentDirOfRootIsEmpty=true
-    ("/", ""),
-    ("/.", ""),
-    ("/..", ""),
-    ("/./", ""),
 
     # return empty when no parent possible
     ("", ""),
@@ -407,13 +392,17 @@ block parentDir:
     ("..", ""),
     ("../", ""),
     ("../..", ""),
+    # parent of root is empty
+    ("/", ""),
+    ("/.", ""),
+    ("/..", ""),
+    ("/./", ""),
 
     # regression tests
 
     # fix #8734 (bug 2)
     ("a/b//", "a"),
     ("a/b/", "a"),
-
 
     # fix #8734 (bug 4)
     ("/a.txt", "/"),

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -391,11 +391,19 @@ block parentDir:
     (".git", "."),
     (".git.bak1", "."),
 
-    # absolute remains absolute
-    ("/", "/"),
-    ("/.", "/"),
-    ("/..", "/"),
-    ("/./", "/"),
+    # with parentDirOfRootIsEmpty=false
+    # ("/", "/"),
+    # ("/.", "/"),
+    # ("/..", "/"),
+    # ("/./", "/"),
+    # fix #8734 (bug 3)
+    # ("/", "/"),
+
+    # with parentDirOfRootIsEmpty=true
+    ("/", ""),
+    ("/.", ""),
+    ("/..", ""),
+    ("/./", ""),
 
     # return empty when no parent possible
     ("", ""),
@@ -411,8 +419,6 @@ block parentDir:
     ("a/b//", "a"),
     ("a/b/", "a"),
 
-    # fix #8734 (bug 3)
-    ("/", "/"),
 
     # fix #8734 (bug 4)
     ("/a.txt", "/"),

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -34,11 +34,6 @@ template runTestCases*(msg: string, examples, body: untyped): bool =
   Takes care of calling unixToNativePath.
   Returns true on success.
   ]##
-  runnableExamples:
-    const examples = [("foo", "foobar"), ("foo2", "foo2bar")]
-    doAssert runTestCases("identity", examples, it & "bar")
-    doAssert not runTestCases("intentional failure", examples, it & "baz")
-
   block:
     var numErrors = 0
     for i, a in examples:
@@ -470,3 +465,8 @@ block parentDirs:
   # regression test
   # fix #8353
   test parentDirs("/a/b".unixToNativePath), @["/a/b", "/a", "/"]
+
+block runTestCasesTest:
+  const examples = [("foo", "foobar"), ("foo2", "foo2bar")]
+  doAssert runTestCases("identity", examples, it & "bar")
+  doAssert not runTestCases("intentional failure", examples, it & "baz")


### PR DESCRIPTION
parentDir, parentDirs now work reliably

* fix #8734
* fix #8353
* removes workaround in ./compiler/packagehandling.nim
> `XXX os's parentDirs is stupid (multiple yields) and triggers an old bug...`

+ many other issues I saw while working on the fix.

I also added extensive unittests so you can now see exactly what `parentDir` and `parentDirs` return

to view the diff and not get confused by code that was only moved, see instructions here https://github.com/nim-lang/Nim/pull/10435/files

## note
the `# todo: fix` is a (commented out) test case for a pre-existing failure from https://github.com/nim-lang/Nim/issues/8395 which i can fix after this PR