### PR TITLE
[ci skip] document that multiple `yield` in inline iterator cause code bloat

### DIFF
--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -67,8 +67,8 @@ Coding Guidelines
 * Max line length is 80 characters.
 * Provide spaces around binary operators if that enhances readability.
 * Use a space after a colon, but not before it.
-* Start types with a capital ``T``, unless they are pointers/references which
-  start with ``P``.
+* [deprecated] Start types with a capital ``T``, unless they are
+  pointers/references which start with ``P``.
 
 See also the `API naming design <apis.html>`_ document.
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3870,7 +3870,14 @@ First class iterators
 There are 2 kinds of iterators in Nim: *inline* and *closure* iterators.
 An `inline iterator`:idx: is an iterator that's always inlined by the compiler
 leading to zero overhead for the abstraction, but may result in a heavy
-increase in code size. Inline iterators are second class citizens;
+increase in code size.
+
+Caution: the body of a for loop over an inline iterator is inlined into
+each ``yield`` statement appearing in the iterator code,
+so ideally the code should be refactored to contain a single yield when possible
+to avoid code bloat.
+
+Inline iterators are second class citizens;
 They can be passed as parameters only to other inlining code facilities like
 templates, macros and other inline iterators.
 


### PR DESCRIPTION
* this documents that multiple `yield` in inline iterator cause code bloat

it's probably by design and not a bug but should be documented as it's a gotcha; see example below:



/cc @Araq 

```nim
iterator myiter(): int =
  yield 10
  yield 11

proc main()=
  for a in myiter():
    echo "done"
main()
```

generates with `--embedsrc -d:release`:
```
N_LIB_PRIVATE N_NIMCALL(void, main_audQMEKlkQTCwd9cxcZvVCg)(void) {
	{
		NI a;
		a = (NI)0;
//    for a in myiter():
		a = ((NI) 10);
//      echo "done"
		echoBinSafe(TM_12xtM2ZmWTyc1IoNCQwzsA_2, 1);
//    for a in myiter():
		a = ((NI) 11);
//      echo "done"
		echoBinSafe(TM_12xtM2ZmWTyc1IoNCQwzsA_2, 1);
	}
}

```

## links
* see also https://github.com/nim-lang/Nim/pull/10545#discussion_r253651739 for relevant discussion, where `os.parentDirs` was deemed unsuitable in compiler/packagehandling.nim which had to roll it's own version:

```nim
iterator myParentDirs(p: string): string =
  # XXX os's parentDirs is stupid (multiple yields) and triggers an old bug...
```
* for an example of how to switch from multiple `yield` to a single `yield`, see this PR: https://github.com/nim-lang/Nim/pull/10557

## note
* D ranges would have the benefit of `inline` iterator in terms of having 0 overhead, while avoiding the code bloat associated with it (hence would likely be faster when instruction cache starts becoming a bottleneck because of resulting code bloat)
* the only tradeoff is that writing a range is sometimes a bit more complex than writing an iterator because it requires the iteration state to be explicit as opposed to implicit; but that's only for callee (the caller sees no difference); see https://github.com/timotheecour/vitanim/blob/master/drange/src/drange/drange_algorithms.nim for an experiment with this idea in Nim  (note newest yet-to-be-pushed version doesn't use `concept` to avoid its bugs, see https://github.com/nim-lang/Nim/issues/9422#issuecomment-430964740)

