### PR TITLE
cgen can now generate pretty-printed C/C++ files

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -568,6 +568,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "passl", "l":
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd2, passPP}: extccomp.addLinkOptionCmd(conf, arg)
+  of "cgenpostprocesscmd":
+    expectArg(conf, switch, arg, pass, info)
+    conf.cgenPostprocessCmd = arg
   of "cincludes":
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd2, passPP}: conf.cIncludes.add processPath(conf, arg, info)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -236,6 +236,7 @@ type
                                   # we compiled (*)
     linkOptionsCmd*: string
     compileOptionsCmd*: seq[string]
+    cgenPostprocessCmd*: string   # postprocess generated C/C++ files
     linkOptions*: string          # (*)
     compileOptions*: string       # (*)
     ccompilerpath*: string

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -62,6 +62,8 @@ Advanced options:
   --lineDir:on|off          generation of #line directive on|off
   --embedsrc:on|off         embeds the original source code as comments
                             in the generated output
+  --cgenPostprocessCmd:cmd  if nonempty, run a post-process command on generated files
+                            for example: `clang-format -i $#`
   --threadanalysis:on|off   turn thread analysis on|off
   --tlsEmulation:on|off     turn thread local storage emulation on|off
   --taintMode:on|off        turn taint mode on|off


### PR DESCRIPTION
after this PR, simply add:
```
--cgenPostprocessCmd:"clang-format -i $#"
```
to your config files and the generated C/C++ files will look more readable; makes it easier when you need to look at generated C/C++ files


before: https://gist.github.com/timotheecour/ff834261e8f8e5e03aeec12871aab18d
after: https://gist.github.com/timotheecour/5d615ea453e177fb2d6f85ab395f44ae

note: users can customize the cmd to their liking, avoids any flame war on what's more readable.
It defaults to empty (= no re-formatting)
