### PR TITLE
 os.parentDirs now uses a single yield to avoid code bloat; refs #10553

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,9 @@
 - `getImpl` on a `var` or `let` symbol will now return the full `IdentDefs`
   tree from the symbol declaration instead of just the initializer portion.
 
+- ``os.parentDir`` and ``os.parentDirs`` had bugs that were fixed in #10545, see details there
+
+
 
 #### Breaking changes in the standard library
 

--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -7,21 +7,13 @@
 #    distribution, for details about the copyright.
 #
 
-iterator myParentDirs(p: string): string =
-  # XXX os's parentDirs is stupid (multiple yields) and triggers an old bug...
-  var current = p
-  while true:
-    current = current.parentDir
-    if current.len == 0: break
-    yield current
-
 proc resetPackageCache*(conf: ConfigRef) =
   conf.packageCache = newPackageCache()
 
 proc getPackageName*(conf: ConfigRef; path: string): string =
   var parents = 0
   block packageSearch:
-    for d in myParentDirs(path):
+    for d in parentDirs(path, inclusive=false):
       if conf.packageCache.hasKey(d):
         #echo "from cache ", d, " |", packageCache[d], "|", path.splitFile.name
         return conf.packageCache[d]
@@ -35,7 +27,7 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
   # we also store if we didn't find anything:
   when not defined(nimNoNilSeqs):
     if result.isNil: result = ""
-  for d in myParentDirs(path):
+  for d in parentDirs(path, inclusive=false):
     #echo "set cache ", d, " |", result, "|", parents
     conf.packageCache[d] = result
     dec parents

--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -7,13 +7,21 @@
 #    distribution, for details about the copyright.
 #
 
+iterator myParentDirs(p: string): string =
+  # XXX os's parentDirs is stupid (multiple yields) and triggers an old bug...
+  var current = p
+  while true:
+    current = current.parentDir
+    if current.len == 0: break
+    yield current
+
 proc resetPackageCache*(conf: ConfigRef) =
   conf.packageCache = newPackageCache()
 
 proc getPackageName*(conf: ConfigRef; path: string): string =
   var parents = 0
   block packageSearch:
-    for d in parentDirs(path, inclusive=false):
+    for d in myParentDirs(path):
       if conf.packageCache.hasKey(d):
         #echo "from cache ", d, " |", packageCache[d], "|", path.splitFile.name
         return conf.packageCache[d]
@@ -27,7 +35,7 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
   # we also store if we didn't find anything:
   when not defined(nimNoNilSeqs):
     if result.isNil: result = ""
-  for d in parentDirs(path, inclusive=false):
+  for d in myParentDirs(path):
     #echo "set cache ", d, " |", result, "|", parents
     conf.packageCache[d] = result
     dec parents

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -634,6 +634,22 @@ proc parentDir*(path: string): string {.
       return "."
     return dir
 
+type Queue[T] = object
+  ## a simple priority queue implementation
+  data: seq[T]
+  first: int
+
+proc empty[T](q: Queue[T]): bool = q.first >= q.data.len
+
+proc pushBack[T](q: var Queue[T], a: T) =
+  q.data.add a
+
+proc popFront[T](q: var Queue[T]): T =
+  # TODO: use a resizable ring buffer if performance is needed
+  assert q.first < q.data.len
+  result = q.data[q.first]
+  q.first.inc
+
 iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ## Walks over all parent directories of a given `path`.
   ##
@@ -644,7 +660,6 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ##
   ## Relative paths won't be expanded by this iterator. Instead, it will traverse
   ## only the directories appearing in the relative path.
-  ## Caveat: current implementation involves multiple yields, causing code bloat.
   ##
   ## See also:
   ## * `parentDir proc <#parentDir,string>`_
@@ -657,21 +672,28 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
       assert toSeq(g.parentDirs(inclusive=false)) == @["a/b", "a"]
       assert toSeq("/a//b/".parentDirs) == @["/a//b", "/a", "/"]
   var path = path.normalizePathEnd
-  if not fromRoot:
-    if inclusive: yield path
-    var current = path
-    while true:
-      if current.isRootDir: break
-      current = current.parentDir
-      yield current
-  else:
-    for i in countup(0, path.len - 2): # ignore the last /
-      # deal with non-normalized paths such as /foo//bar//baz
-      if path[i] in {DirSep, AltSep} and
-          (i == 0 or path[i-1] notin {DirSep, AltSep}):
-        yield path.substr(0, i).normalizePathEnd
-
-    if inclusive: yield path
+  var queue: Queue[string]
+  if not fromRoot and inclusive: queue.pushBack path
+  var i = 0
+  while true:
+    if not queue.empty:
+      yield popFront(queue)
+    if not fromRoot:
+      if path.isRootDir: break
+      path = path.parentDir
+      queue.pushBack path
+    else:
+      while i < path.len - 1: # ignore the last /
+        # deal with non-normalized paths such as /foo//bar//baz
+        if path[i] in {DirSep, AltSep} and (i == 0 or path[i-1] notin {DirSep, AltSep}):
+          queue.pushBack path.substr(0, i).normalizePathEnd
+          i.inc
+          break
+        i.inc
+      if i == path.len - 1 and inclusive:
+        queue.pushBack path
+        i.inc
+      elif queue.empty: break # no work remaining
 
 proc unixToNativePath*(path: string, drive=""): string {.
   noSideEffect, rtl, extern: "nos$1".} =
@@ -3056,3 +3078,13 @@ when isMainModule:
       doAssert r"D:\".normalizePathEnd == r"D:"
       doAssert r"E:/".normalizePathEnd(trailingSep = true) == r"E:\"
       doAssert "/".normalizePathEnd == r"\"
+
+  block queueTest:
+    var queue: Queue[int]
+    var ret: seq[int]
+    queue.pushBack 3
+    ret.add queue.popFront
+    for a in 10..13: queue.pushBack a
+    while not queue.empty:
+      ret.add queue.popFront
+    doAssert ret == @[3, 10, 11, 12, 13]

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -594,10 +594,9 @@ proc parentDir*(path: string): string {.
   ## Returns the parent directory of `path`.
   ##
   ## Conventions below derive from analogy with the shell:
-  ##   * an absolute path remains absolute
   ##   * trailing ``.`` and ``/`` are resolved before taking the parent dir
   ## It returns empty when attempting to take parent of ``.`` or ``..``
-  ## to indicate it is invalid and distinguish from ``.``
+  ## to indicate it is invalid (and different from ``.``)
   ##
   ## The remainder can be obtained with `lastPathPart(path) proc
   ## <#lastPathPart,string>`_.
@@ -615,11 +614,15 @@ proc parentDir*(path: string): string {.
       assert parentDir("foo") == "."
       assert parentDir("/foo") == "/"
       assert parentDir(".") == ""
+  const parentDirOfRootIsEmpty = true # still controversial
   if path == "": return ""
   result = path
   while true:
     normalizePathEnd(result)
     let (dir, name, ext) = splitFile(result)
+    when parentDirOfRootIsEmpty:
+      if name == ".." or (name.len == 0 and ext.len == 0): return ""
+
     if name == "..":
       if isAbsolute(dir):
         return dir

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -644,29 +644,14 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ##
   ## See also:
   ## * `parentDir proc <#parentDir,string>`_
-  ##
-  ## **Examples:**
-  ##
-  ## .. code-block::
-  ##   let g = "a/b/c"
-  ##
-  ##   for p in g.parentDirs:
-  ##     echo p
-  ##   # a/b/c
-  ##   # a/b
-  ##   # a
-  ##
-  ##   for p in g.parentDirs(fromRoot=true):
-  ##     echo p
-  ##   # a/
-  ##   # a/b/
-  ##   # a/b/c
-  ##
-  ##   for p in g.parentDirs(inclusive=false):
-  ##     echo p
-  ##   # a/b
-  ##   # a
-
+  runnableExamples:
+    import sequtils
+    let g = "a/b/c"
+    when defined(posix):
+      assert toSeq(g.parentDirs) == @["a/b/c", "a/b", "a"]
+      assert toSeq(g.parentDirs(fromRoot=true)) == @["a", "a/b", "a/b/c"]
+      assert toSeq(g.parentDirs(inclusive=false)) == @["a/b", "a"]
+      assert toSeq("/a//b/".parentDirs) == @["/a//b", "/a", "/"]
   var path = path.normalizePathEnd
   if not fromRoot:
     if inclusive: yield path

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -644,6 +644,7 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ##
   ## Relative paths won't be expanded by this iterator. Instead, it will traverse
   ## only the directories appearing in the relative path.
+  ## Caveat: current implementation involves multiple yields, causing code bloat.
   ##
   ## See also:
   ## * `parentDir proc <#parentDir,string>`_

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -249,13 +249,13 @@ block absolutePath:
 block splitFile:
   doAssert splitFile("") == ("", "", "")
   doAssert splitFile("abc/") == ("abc", "", "")
-  doAssert splitFile("/") == ("/", "", "")
+  doAssert splitFile("/") == ("/".unixToNativePath, "", "")
   doAssert splitFile("./abc") == (".", "abc", "")
   doAssert splitFile(".txt") == ("", ".txt", "")
   doAssert splitFile("abc/.txt") == ("abc", ".txt", "")
   doAssert splitFile("abc") == ("", "abc", "")
   doAssert splitFile("abc.txt") == ("", "abc", ".txt")
-  doAssert splitFile("/abc.txt") == ("/", "abc", ".txt")
+  doAssert splitFile("/abc.txt") == ("/".unixToNativePath, "abc", ".txt")
   doAssert splitFile("/foo/abc.txt") == ("/foo", "abc", ".txt")
   doAssert splitFile("/foo/abc.txt.gz") == ("/foo", "abc.txt", ".gz")
   doAssert splitFile(".") == ("", ".", "")
@@ -426,7 +426,8 @@ block tailDir:
   let examples = [
     ("/usr/local/bin", "usr/local/bin"),
     ("usr/local/bin", "local/bin"),
-    # todo: fix
+
+    # issue #8395; todo: fix
     # ("//usr//local//bin//", "usr//local//bin//"),
     # ("usr//local//bin//", "local/bin//"),
   ]

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -391,11 +391,19 @@ block parentDir:
     (".git", "."),
     (".git.bak1", "."),
 
-    # absolute remains absolute
-    ("/", "/"),
-    ("/.", "/"),
-    ("/..", "/"),
-    ("/./", "/"),
+    # with parentDirOfRootIsEmpty=false
+    # ("/", "/"),
+    # ("/.", "/"),
+    # ("/..", "/"),
+    # ("/./", "/"),
+    # fix #8734 (bug 3)
+    # ("/", "/"),
+
+    # with parentDirOfRootIsEmpty=true
+    ("/", ""),
+    ("/.", ""),
+    ("/..", ""),
+    ("/./", ""),
 
     # return empty when no parent possible
     ("", ""),
@@ -411,8 +419,6 @@ block parentDir:
     ("a/b//", "a"),
     ("a/b/", "a"),
 
-    # fix #8734 (bug 3)
-    ("/", "/"),
 
     # fix #8734 (bug 4)
     ("/a.txt", "/"),

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -470,3 +470,4 @@ block parentDirs:
   # regression test
   # fix #8353
   test parentDirs("/a/b".unixToNativePath), @["/a/b", "/a", "/"]
+


### PR DESCRIPTION
[DO NOT MERGE until #10545]

https://github.com/nim-lang/Nim/pull/10545 should be merged first to view the diff

* os.parentDirs now uses a single yield to avoid code bloat (as explained in #10553)
* remove parentDirs workaround in compiler/packagehandling.nim as this addresses the concerns from https://github.com/nim-lang/Nim/pull/10545#discussion_r253408586

parentDirs has extensive unittests to prevent regressions since https://github.com/nim-lang/Nim/pull/10545



