### PR TITLE
unittest: add optional msg to check, require

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -663,17 +663,17 @@ macro check*(conditions: untyped, msg = ""): untyped =
       if node.kind != nnkCommentStmt:
         result.add(newCall(!"check", node))
 
-  of nnkPar:
-    doAssert checked.len == 2, repr(checked)
-    result = newCall(!"check", checked[0], checked[1])
   else:
-    let lineinfo = newStrLitNode(checked.lineinfo)
-    let callLit = checked.toStrLit
+    if checked.kind == nnkPar and checked.len == 2:
+      result = newCall(!"check", checked[0], checked[1])
+    else:
+      let lineinfo = newStrLitNode(checked.lineinfo)
+      let callLit = checked.toStrLit
 
-    result = quote do:
-      if not `checked`:
-        formatCheckpoint(`lineinfo`, `callLit`, `msg`)
-        fail()
+      result = quote do:
+        if not `checked`:
+          formatCheckpoint(`lineinfo`, `callLit`, `msg`)
+          fail()
 
 template require*(conditions: untyped, msg = "") =
   ## Same as `check` except any failed test causes the program to quit

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -15,6 +15,8 @@ discard """
 
 [Suite] test suite
 
+[Suite] check with msg
+
 [Suite] test name filtering
 
 '''
@@ -45,6 +47,10 @@ test "unittest typedescs":
 test "unittest multiple requires":
   require(true)
   require(true)
+  require true, "foo"
+  require:
+    (true, "foo")
+    true
 
 
 import math, random
@@ -140,6 +146,16 @@ suite "test suite":
         let b = SomeType(value: 10)
 
         check(a == b)
+
+suite "check with msg":
+    test "test":
+        check true
+        check(1 == 1, "foo1")
+        check 2 == 1+1, "foo2"
+        check:
+          true
+          (int is int, "foo3")
+          ([1][0] == 1, "foo4")
 
 when defined(testing):
   suite "test name filtering":

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -150,6 +150,8 @@ suite "test suite":
 suite "check with msg":
     test "test":
         check true
+        check(true)
+        check (true)
         check(1 == 1, "foo1")
         check 2 == 1+1, "foo2"
         check:


### PR DESCRIPTION
oftentimes I wished I could show additional runtime context in error msgs generated by  `require`, `check`
this PR allows doing that, eg:
```nim
import unittest

proc main()=
  check true
  check true, "foo"
  check:
    true
    (true, "foo")

  require true
  require true, "foo"
  require:
    true
    (true, "foo")

main()
```
typical use case is: `require foo(x) == bar, $(otherVar, otherContext)`