### PR TITLE
./koch tests now does not rebuild nim

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -412,7 +412,7 @@ proc tests(args: string) =
   ## This can also be used:
   ## `nim c -r testament/tester --nim:pathto/nim_temp pcat megatest`
   let tester = "testament/tester".exe
-  let success = tryExec("nim c -d:release -r testament/tester " & (args|"all"))
+  let success = tryExec(findNim() & " c -d:release -r testament/tester " & (args|"all"))
   if not existsEnv("TRAVIS") and not existsEnv("APPVEYOR"):
     doAssert tryExec(tester & " html")
   doAssert success, "tests failed"

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -9,7 +9,7 @@
 
 import parseutils, strutils, os, osproc, streams, parsecfg
 
-var compilerPrefix* = "compiler" / "nim"  # XXX Change this, it's wrong.
+var compilerPrefix* = "nim"
 
 let isTravis* = existsEnv("TRAVIS")
 let isAppVeyor* = existsEnv("APPVEYOR")


### PR DESCRIPTION
note to reviewer:
i also changed:
```
echo "Version check: failure"
```
to use a `doAssert`, as `echo` didn't seem to make sense

