### PR TITLE
prevent common user config to interfere with testament

### DIFF
--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,0 +1,6 @@
+switch("path", "$nim/testament/lib") # so we can `import stdtest/foo` in this dir
+
+## prevent common user config settings to interfere with testament expectations
+## Indifidual tests can override this if needed to test for these options.
+switch("colors", "off")
+switch("listFullPaths", "off")

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,1 +1,0 @@
---path:"../testament/lib" # so we can `import stdtest/foo` in this dir


### PR DESCRIPTION
I ran ``./koch tests r tests/ccgbugs/twrongrefcounting.nim` on https://github.com/nim-lang/Nim/pull/10559 and got the very unhelpful:
```
FAIL: tests/ccgbugs/twrongrefcounting.nim C
Test "tests/ccgbugs/twrongrefcounting.nim" in category "tests"
Failure: reNimcCrash
Expected:


Gotten:


```

ie, empty `Gotten` instead of:
```
Gotten:
system module needs: echoBinSafe
```

The root casue is `switch("colors", "on")` in my `~/.config/config.nims` which messes with how testament verifies outputs;
note, this is a reasonable thing to put in a user config (I even had it under `when not defined(testing):` but that still didn't work; perhaps because not every call to `nim` inside testament has `-d:testing`

plus, might as well make it simple and working for everyone without requiring them to edit their user config

This PR fixes that robustly.

## note
that would happen in other situations; eg with `./koch tests`  on a PR that has failures

