### PR TITLE
`system module needs` now shows a stacktrace (with debug nim)

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -668,7 +668,7 @@ proc cgsym(m: BModule, name: string): Rope =
     # we used to exclude the system module from this check, but for DLL
     # generation support this sloppyness leads to hard to detect bugs, so
     # we're picky here for the system module too:
-    rawMessage(m.config, errGenerated, "system module needs: " & name)
+    internalError(m.config, "system module needs: " & name)
   result = sym.loc.r
 
 proc generateHeaders(m: BModule) =

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -668,7 +668,7 @@ proc cgsym(m: BModule, name: string): Rope =
     # we used to exclude the system module from this check, but for DLL
     # generation support this sloppyness leads to hard to detect bugs, so
     # we're picky here for the system module too:
-    internalError(m.config, "system module needs: " & name)
+    rawMessage(m.config, errGenerated, "system module needs: " & name)
   result = sym.loc.r
 
 proc generateHeaders(m: BModule) =

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -201,6 +201,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     incl(conf.notes, n)
     incl(conf.mainPackageNotes, n)
     incl(conf.enableNotes, n)
+    incl(conf.foreignPackageNotes, n)
   of "off":
     excl(conf.notes, n)
     excl(conf.mainPackageNotes, n)


### PR DESCRIPTION
* before this PR, all you get is a cryptic `Error: system module needs: echoBinSafe` with no backtrace (even with debug version of nim)
as well as a wide choice of places where to look at:
```
compiler/cgen.nim:671:30:    internalError(m.config, "system module needs: " & name)
compiler/jsgen.nim:303:42:      globalError(p.config, p.prc.info, "system module needs: " & name)
compiler/jsgen.nim:305:43:      rawMessage(p.config, errGenerated, "system module needs: " & name)
compiler/lowerings.nim:290:33:    localError(g.config, info, "system module needs: " & name)
compiler/magicsys.nim:31:33:    localError(g.config, info, "system module needs: " & name)
compiler/magicsys.nim:47:31:  localError(g.config, info, "system module needs: " & name)
```

* after this PR, you get a backtrace (with debug version of nim)

This type of error can for example occur when refactoring system.nim; it's happening in  https://github.com/nim-lang/Nim/pull/10559 but it also happened to me before (in my PR for `{.nosystem.}`)

https://travis-ci.org/nim-lang/Nim/jobs/489276424
```
FAIL: tests/ccgbugs/twrongrefcounting.nim C
Test "tests/ccgbugs/twrongrefcounting.nim" in category "ccgbugs"
Failure: reNimcCrash
Expected:
Gotten:
system module needs: echoBinSafe
```

## question to reviewer
besides what's fixed here, the only other place where a `rawMessage` is used with `system module needs` is:
```
    if p.prc != nil:
      globalError(p.config, p.prc.info, "system module needs: " & name)
    else:
      rawMessage(p.config, errGenerated, "system module needs: " & name)
```
seems like this should be changed to `internalError` as well, so as to get a backtrace?