### PR TITLE
Fix handling of reraise in effect tracking

### DIFF
--- a/tests/effects/teffects8.nim
+++ b/tests/effects/teffects8.nim
@@ -1,0 +1,12 @@
+discard """
+  errormsg: "can raise an unlisted exception: Exception"
+  line: 10
+"""
+
+proc foo() {.raises: [].} =
+  try:
+    discard
+  except ValueError:
+    raise
+
+foo()


### PR DESCRIPTION
This is the MVP in order not to get a completely useless error message
from the compiler.

Fixes #10579 

Please note that this won't make NimYAML compile unless the `raises:` tags are removed.
This "regression" is more of a "progression" since before #10455 we'd just cover up the issue and, as it's common wisdom, a hidden exception raised at runtime is worse than an error at compile time.

Of course we could always improve the current algorithm (and make `raise` illegal outside of `except` bodies ?) but that's something for another day.