### PR TITLE
fix #10585 regression: `static: writeFile` doesnt work anymore since `system refactorings`

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -13,13 +13,10 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,
   floor, ceil, `mod`
 
-from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename, removeFile
+from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
 
-#[
-todo:
-give a CT error if `registerCallback` is called on something that doesn't exit,
-to avoid regressions like #10588
-]#
+# caution: no error given if `registerCallback` is called on something that
+# doesn't exit; this can cause regressions like #10588
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -119,7 +116,6 @@ proc registerAdditionalOps*(c: PCtx) =
   when defined(nimcore):
     wrap2s(getEnv, osop)
     wrap1s(existsEnv, osop)
-    wrap1svoid(removeFile, osop)
     wrap2svoid(putEnv, osop)
     wrap1s(dirExists, osop)
     wrap1s(fileExists, osop)

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -4,7 +4,7 @@ test for vmops.nim
 import os
 import math
 import strutils
-import stdtest/specialpaths
+import "$nim/testament/lib/stdtest/specialpaths"
 
 template forceConst(a: untyped): untyped =
   ## Force evaluation at CT, useful for example here:
@@ -15,6 +15,8 @@ template forceConst(a: untyped): untyped =
   ##    `callFoo(a, getBar2())`
   const ret = a
   ret
+
+const tempFile = buildDir / "D20190206T151011.txt"
 
 static:
   # TODO: add more tests
@@ -36,12 +38,10 @@ static:
     doAssert getEnv(key) == val
 
   block: # std/io, std/os
-    let file = buildDir / "D20190206T151011.txt"
-    let content = "this is " & file
-    writeFile file, content
-    let content2 = readFile file
-    doAssert content == content2, $(content, content2)
-    removeFile file
+    let content = "this is " & tempFile
+    writeFile tempFile, content
+    let content2 = readFile tempFile
+    doAssert content == content2, $(tempFile, content, content2)
 
   block: # arcsin
     # sanity check (we probably don't need to test for all ops)
@@ -54,3 +54,6 @@ block:
   doAssert getCurrentCompilerExe() == forceConst(getCurrentCompilerExe())
   if false: #pending #9176
     doAssert gorgeEx("unexistant") == forceConst(gorgeEx("unexistant"))
+
+block: # cleanup
+  if existsFile tempFile: removeFile tempFile

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -4,6 +4,7 @@ test for vmops.nim
 import os
 import math
 import strutils
+import stdtest/specialpaths
 
 template forceConst(a: untyped): untyped =
   ## Force evaluation at CT, useful for example here:
@@ -27,14 +28,22 @@ static:
     let output3 = gorge(nim & " --version")
     doAssert output3.contains "Nim Compiler"
 
-  block:
+  block: # putEnv, existsEnv, getEnv
     const key = "D20181210T175037"
     const val = "foo"
     putEnv(key, val)
     doAssert existsEnv(key)
     doAssert getEnv(key) == val
 
-  block:
+  block: # std/io, std/os
+    let file = buildDir / "D20190206T151011.txt"
+    let content = "this is " & file
+    writeFile file, content
+    let content2 = readFile file
+    doAssert content == content2, $(content, content2)
+    removeFile file
+
+  block: # arcsin
     # sanity check (we probably don't need to test for all ops)
     const a1 = arcsin 0.3
     let a2 = arcsin 0.3


### PR DESCRIPTION
* fix #10585 regression: `static: writeFile` doesnt work anymore since `system refactorings`
* ditto w readFile
~~* adds removeFile; avoids yet-more-error-prone workarounds (using shell) in client code that need it at CT (eg nimterop)~~ (delayed to another PR)
* adds tests

