### PR TITLE
followup on #10573: prevent common user config to interfere with testament (excessiveStackTrace)

### DIFF
--- a/tests/config.nims
+++ b/tests/config.nims
@@ -4,3 +4,4 @@ switch("path", "$nim/testament/lib") # so we can `import stdtest/foo` in this di
 ## Indifidual tests can override this if needed to test for these options.
 switch("colors", "off")
 switch("listFullPaths", "off")
+switch("excessiveStackTrace", "off")


### PR DESCRIPTION
* followup on #10573
* among other tests, helps `tests/errmsgs/tproper_stacktrace.nim` pass in a user config that contains `--excessiveStackTrace:on`, and also now `megatest` passes too
