### PR TITLE
Disable sink/= operators for Atomic[T] types

### DIFF
--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -375,4 +375,7 @@ proc `+=`*[T: SomeInteger](location: var Atomic[T]; value: T) {.inline.} =
 proc `-=`*[T: SomeInteger](location: var Atomic[T]; value: T) {.inline.} =
   ## Atomically decrements the atomic integer by some `value`.
   discard location.fetchSub(value)
-  
+
+proc `=`*[T](to: var Atomic[T]; rhs: Atomic[T]) {.error.}
+
+proc `=sink`*[T](to: var Atomic[T]; rhs: Atomic[T]) {.error.}


### PR DESCRIPTION
Implicit assignment/copy are forbidden for such types.

CC @jwollen 
CC @narimiran, The rationale for this choice and its consequences should be explained in the documentation