### PR TITLE
sets: avoid calling countBits32 for 0

### DIFF
--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -22,7 +22,7 @@ proc countBits64(n: int64): int {.compilerproc.} =
   result = countBits32(toU32(n and 0xffffffff'i64)) +
            countBits32(toU32(n shr 32'i64))
 
-proc cardSet(s: NimSet, len: int): int {.compilerproc.} =
-  result = 0
-  for i in countup(0, len-1):
+proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
+  for i in 0..<len:
+    if likely(s[i] == 0): continue
     inc(result, countBits32(int32(s[i])))


### PR DESCRIPTION
for: https://gist.github.com/brentp/7d440560968c3ac97c40de17200e404a
this speeds up the system.sets time from ~0.2 to ~0.06
in release mode. This is still slower than intsets and
tables (which both are ~0.01).

This assumes that most sets will be sparse.

fixes #10617