### PR TITLE
Prevent endless loop in generic instantiation

### DIFF
--- a/compiler/semtypinst.nim
+++ b/compiler/semtypinst.nim
@@ -300,7 +300,6 @@ proc instCopyType*(cl: var TReplTypeVars, t: PType): PType =
 proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   # tyGenericInvocation[A, tyGenericInvocation[A, B]]
   # is difficult to handle:
-  const eqFlags = eqTypeFlags + {tfGcSafe}
   var body = t.sons[0]
   if body.kind != tyGenericBody:
     internalError(cl.c.config, cl.info, "no generic body")
@@ -311,7 +310,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   else:
     result = searchInstTypes(t)
 
-  if result != nil and eqFlags*result.flags == eqFlags*t.flags:
+  if result != nil and sameFlags(result, t):
     when defined(reportCacheHits):
       echo "Generic instantiation cached ", typeToString(result), " for ", typeToString(t)
     return
@@ -329,7 +328,7 @@ proc handleGenericInvocation(cl: var TReplTypeVars, t: PType): PType =
   if header != t:
     # search again after first pass:
     result = searchInstTypes(header)
-    if result != nil and eqFlags*result.flags == eqFlags*t.flags:
+    if result != nil and sameFlags(result, t):
       when defined(reportCacheHits):
         echo "Generic instantiation cached ", typeToString(result), " for ",
           typeToString(t), " header ", typeToString(header)

--- a/tests/generics/tgenerics_various.nim
+++ b/tests/generics/tgenerics_various.nim
@@ -242,3 +242,14 @@ block tvarargs_vs_generics:
   withDirectType "string"
   withOpenArray "string"
   withVarargs "string"
+
+block:
+  type
+    Que[T] {.gcsafe.} = object
+      x: T
+
+  proc `=`[T](q: var Que[T]; x: Que[T]) =
+    discard
+
+  var x: Que[int]
+  doAssert(x.x == 0)


### PR DESCRIPTION
If one marks a generic type with `gcsafe` that tag is not propagated to the parent `tyGenericInvocation` and `handleGenericInvocation` becomes a lovely endless loop due to the flag mismatch.

Now, the use of `gcsafe` for types is not documented in the manual and is only used by the `Channel` type (I suppose that's needed in order to be able to use them in gcsafe code), and I'm not sure if removing it altogether is correct. 

Git blame shows that this special flag-matching rule was introduced in 4033929127 in order to make the lookup over the instantiated types sensible to the presence of such a flag **for procedures**.