### PR TITLE
fix travis: add set -e in script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,12 @@ before_script:
   - set +e   # prevents breaking after_failure
 
 script:
+  - set -e
   - echo "travis_fold:start:nim_c_koch"
   - nim c koch
   - echo "travis_fold:end:nim_c_koch"
   - ./koch runCI
+  - set +e
 
 before_deploy:
   # Make https://nim-lang.github.io/Nim work the same as https://nim-lang.github.io/Nim/overview.html


### PR DESCRIPTION
no point in running `./koch runCI` if `nim c koch` fails (avoids a weird looking error when `nim c koch` fails)