### PR TITLE
randomize: added doAssert(seed!=0) to avoid invalid (non-random) behavior

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -513,6 +513,7 @@ proc initRand*(seed: int64): Rand =
 
     let now = getTime()
     var r2 = initRand(now.toUnix * 1_000_000_000 + now.nanosecond)
+  doAssert seed != 0 # 0 causes `rand(int)` to always return 0 for example.
   result.a0 = ui(seed shr 16)
   result.a1 = ui(seed and 0xffff)
   discard next(result)


### PR DESCRIPTION
/cc @demotomohiro
> State of xoroshiro128+ must not be 0 or it generates 0 forever.

I ran into this gotcha before: after calling `randomize(0)`, `rand(int)` generates 0 forever; this PR enforces that seed is nonzero to avoid puzzling behavior.

https://github.com/nim-lang/Nim/pull/10546#issuecomment-462204717 added a documentation for the fact that `seed` needs to be nonzero but this PR enforces this with a `doAssert`.
I'm not sure there's any valid use case for `randomize(0)` (which generates constant, non-random data) but if there is one, IMO it'd be better via a different API, eg `initNonRandom()` or another name, otherwise it's error prone (easy to miss this point in docs)


