### PR TITLE
[WIP] allow parsing of JSON at compile time

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -880,8 +880,12 @@ when not defined(js):
 
   proc parseFile*(filename: static string): JsonNode =
     ## Parses `filename` into a `JsonNode` at compile time.
-    const data = staticRead(filename)
-    result = parseJson(data)
+    when nimvm:
+      const data = staticRead(filename)
+      result = parseJson(data)
+    else:
+      let fname = filename
+      result = parseFile(fname)
 
   proc parseJson*(buffer: string): JsonNode =
     ## Parses JSON from `buffer`. Either `buffer` is a string at runtime or

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -879,7 +879,9 @@ when not defined(js):
     result = parseJson(stream, filename)
 
   proc parseFile*(filename: static string): JsonNode =
-    ## Parses `filename` into a `JsonNode` at compile time.
+    ## Parses `filename` into a `JsonNode` at compile time if called in
+    ## a static context, otherwise defaults to `parseFile` above using
+    ## a FileStream at runtime.
     when nimvm:
       const data = staticRead(filename)
       result = parseJson(data)

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -62,7 +62,7 @@ type
     stateEof, stateStart, stateObject, stateArray, stateExpectArrayComma,
     stateExpectObjectComma, stateExpectColon, stateExpectValue
 
-  JsonParser* = object of BaseLexerRT ## the parser object.
+  JsonParser* = object of BaseLexer ## the parser object.
     a*: string
     tok*: TokKind
     kind: JsonEventKind
@@ -71,8 +71,7 @@ type
     filename: string
     rawStringLiterals: bool
 
-  # equivalent to JsonParser, but usable at compile time
-  JsonParserCT* = object of BaseLexerCT ## the parser object.
+  JsonParserCT* = object of BaseLexerCT
     a*: string
     tok*: TokKind
     kind: JsonEventKind
@@ -113,7 +112,7 @@ const
     "{", "}", "[", "]", ":", ","
   ]
 
-proc open*(my: var JsonParser, input: Stream, filename: string;
+proc open*(my: var AnyJsonParser, input: Stream | string, filename: string;
            rawStringLiterals = false) =
   ## initializes the parser with an input stream. `Filename` is only used
   ## for nice error messages. If `rawStringLiterals` is true, string literals
@@ -126,22 +125,9 @@ proc open*(my: var JsonParser, input: Stream, filename: string;
   my.a = ""
   my.rawStringLiterals = rawStringLiterals
 
-proc open*(my: var JsonParserCT, input: string, filename: string;
-           rawStringLiterals = false) =
-  ## initializes the parser with an input string. `Filename` is only used
-  ## for nice error messages. If `rawStringLiterals` is true, string literals
-  ## are kepts with their surrounding quotes and escape sequences in them are
-  ## left untouched too.
-  lexbase.open(my, input)
-  my.filename = filename
-  my.state = @[stateStart]
-  my.kind = jsonError
-  my.a = ""
-  my.rawStringLiterals = rawStringLiterals
-
 proc close*(my: var AnyJsonParser) {.inline.} =
   ## closes the parser `my` and its associated input stream.
-  when AnyJsonParser is JsonParser:
+  when type(AnyJsonParser) is JsonParser:
     lexbase.close(my)
 
 proc str*(my: AnyJsonParser): string {.inline.} =

--- a/tests/stdlib/tjsonct.nim
+++ b/tests/stdlib/tjsonct.nim
@@ -1,0 +1,16 @@
+import json
+
+const jj = """
+{
+ "name" : "Peter",
+ "age" : 35
+}
+"""
+
+var jData {.compileTime.} = staticParseJson(jj)
+#const jdata = staticParseJson(jj) # <- does *not* work!
+
+static:
+  echo jData
+  doAssert jData["name"].getStr == "Peter"
+  doAssert jData["age"].getInt == 35

--- a/tests/stdlib/tjsonct.nim
+++ b/tests/stdlib/tjsonct.nim
@@ -2,8 +2,11 @@ import json
 
 const jj = """
 {
- "name" : "Peter",
- "age" : 35
+  "name" : "Peter",
+  "age" : 35,
+  "data" : [1, 2, 3, 4],
+  "nested" : { "low" : 0,
+               "high" : 1 }
 }
 """
 
@@ -14,3 +17,7 @@ static:
   echo jData
   doAssert jData["name"].getStr == "Peter"
   doAssert jData["age"].getInt == 35
+  doAssert jData["data"] == % [1, 2, 3, 4]
+  doAssert jData["nested"].kind == JObject
+  doAssert jData["nested"]["low"].getInt == 0
+  doAssert jData["nested"]["high"].getInt == 1

--- a/tests/stdlib/tjsonct.nim
+++ b/tests/stdlib/tjsonct.nim
@@ -10,7 +10,7 @@ const jj = """
 }
 """
 
-var jData {.compileTime.} = staticParseJson(jj)
+var jData {.compileTime.} = parseJson(jj)
 #const jdata = staticParseJson(jj) # <- does *not* work!
 
 static:


### PR DESCRIPTION
This PR prototypes support for parsing JSON at compile time as a `.compileTime.` variable. 
**Note:** it explicitly does *not* support storing a parsed `JsonNode` in a `const` and using it at runtime, since `JsonNode` is a ref type.

It introduces `staticParseJson` and `staticParseFile` (please provide better names :P) for this, so that
```nim
var jData {.compileTime.} = staticParseJson("{"name" : "Araq"}")
static:
  doAssert jData["name"].getStr == "Araq"
```
is possible. 

Regarding the implementation, I just cleaned up my hacky code somewhat I mentioned on IRC. If we consider merging this, I'm happy improve it. 
I wrote it some time ago to try to check some JSON at compile time. 

Related discussion on IRC yesterday: https://irclogs.nim-lang.org/10-02-2019.html#14:30:29 