### PR TITLE
Fix codegen problem with strict C++ compilers

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -465,7 +465,7 @@ proc foldConv(n, a: PNode; g: ModuleGraph; check = false): PNode =
     else:
       result = a
       result.typ = n.typ
-  of tyOpenArray, tyVarargs, tyProc:
+  of tyOpenArray, tyVarargs, tyProc, tyPointer:
     discard
   else:
     result = a


### PR DESCRIPTION
Since tyCString is convertible to a tyPointer we must be extra careful
to emit a cast to (void*) in order to appease clang++.

Reported by masnagam on the Nim forum.