### PR TITLE
travis:upgrade to xenial (trusty end of life is april 2019)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: c
 
-dist: trusty
+dist: xenial
 
 matrix:
   include:


### PR DESCRIPTION
EDIT: CI failure un-related since it's appveyor failure and I'm only changing .travis.yml