### PR TITLE
Open a new scope for `static:` expr blocks

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -735,7 +735,11 @@ proc evalAtCompileTime(c: PContext, n: PNode): PNode =
     #  echo "SUCCESS evaluated at compile time: ", call.renderTree
 
 proc semStaticExpr(c: PContext, n: PNode): PNode =
-  let a = semExpr(c, n)
+  inc c.inStaticContext
+  openScope(c)
+  let a = semExprWithType(c, n)
+  closeScope(c)
+  dec c.inStaticContext
   if a.findUnresolvedStatic != nil: return a
   result = evalStaticExpr(c.module, c.graph, a, c.p.owner)
   if result.isNil:

--- a/tests/errmsgs/tstaticexprnotype.nim
+++ b/tests/errmsgs/tstaticexprnotype.nim
@@ -1,0 +1,5 @@
+discard """
+  action: reject
+"""
+
+let x = static: discard

--- a/tests/errmsgs/tstaticexprscope.nim
+++ b/tests/errmsgs/tstaticexprscope.nim
@@ -1,0 +1,11 @@
+discard """
+  errmsg: "undeclared identifier: 'z'"
+  line: 11
+"""
+
+# Open a new scope for static expr blocks
+block:
+  let a = static:
+    var z = 123
+    33
+  echo z


### PR DESCRIPTION
Bring this in line with how plain blocks are analysed and avoids codegen
errors if one references variables defined in such a block.

@mratsim 
WRT #10628, this PR lets you do something like this `let a = static: input(bindSym"x")`