### PR TITLE
compiler/types: correctly generates signature for non-proc types

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -588,7 +588,15 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
     if prefer != preferExported:
       result.add("(" & typeToString(t.sons[0]) & ")")
   of tyProc:
-    result = if tfIterator in t.flags: "iterator " else: "proc "
+    result = if tfIterator in t.flags: "iterator "
+             elif t.owner != nil:
+               case t.owner.kind
+               of skTemplate: "template "
+               of skMacro: "macro "
+               of skConverter: "converter "
+               else: "proc "
+            else:
+              "proc "
     if tfUnresolved in t.flags: result.add "[*missing parameters*]"
     result.add "("
     for i in countup(1, sonsLen(t) - 1):

--- a/nimsuggest/tests/tsug_template.nim
+++ b/nimsuggest/tests/tsug_template.nim
@@ -1,0 +1,12 @@
+template tmpa() = discard
+macro tmpb() = discard
+converter tmpc() = discard
+tmp#[!]#
+
+discard """
+$nimsuggest --tester $file
+>sug $1
+sug;;skMacro;;tsug_template.tmpb;;macro (){.noSideEffect, gcsafe, locks: 0.};;$file;;2;;6;;"";;0;;Prefix
+sug;;skConverter;;tsug_template.tmpc;;converter ();;$file;;3;;10;;"";;0;;Prefix
+sug;;skTemplate;;tsug_template.tmpa;;template (): typed;;$file;;1;;9;;"";;0;;Prefix
+"""


### PR DESCRIPTION
This makes signatures generated for nimsuggest correctly distinguish
template/macro/converter from proc.