### PR TITLE
Httpclient improvements

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -474,7 +474,7 @@ proc format(p: MultipartData): tuple[contentType, body: string] =
   result.body.add("--" & bound & "--\c\L")
 
 proc redirection(status: string): bool =
-  const redirectionNRs = ["301", "302", "303", "307"]
+  const redirectionNRs = ["301", "302", "303", "307", "308"]
   for i in items(redirectionNRs):
     if status.startsWith(i):
       return true

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -988,6 +988,7 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
         # Delete any header value associated with the body
         headers.del("Content-Length")
         headers.del("Content-Type")
+        headers.del("Transfer-Encoding")
       of Http307, Http308:
         # The method and the body are unchanged
         redirectMethod = httpMethod

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -473,12 +473,6 @@ proc format(p: MultipartData): tuple[contentType, body: string] =
     result.body.add("--" & bound & "\c\L" & s)
   result.body.add("--" & bound & "--\c\L")
 
-proc redirection(status: string): bool =
-  const redirectionNRs = ["301", "302", "303", "307", "308"]
-  for i in items(redirectionNRs):
-    if status.startsWith(i):
-      return true
-
 proc getNewLocation(lastURL: Uri, headers: HttpHeaders): Uri =
   let newLocation = headers.getOrDefault"Location"
   if newLocation == "": httpError("location header expected")

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -486,10 +486,10 @@ proc getNewLocation(lastURL: Uri, headers: HttpHeaders): Uri =
   else:
     result = parsedLocation
 
-proc generateHeaders(requestUrl: Uri, httpMethod: HttpMethod,
+proc generateHeaders(requestUrl: Uri, httpMethod: string,
                      headers: HttpHeaders, body: string, proxy: Proxy): string =
   # GET
-  result = $httpMethod
+  result = httpMethod
   result.add ' '
 
   if proxy.isNil or requestUrl.scheme == "https":
@@ -518,7 +518,7 @@ proc generateHeaders(requestUrl: Uri, httpMethod: HttpMethod,
     add(result, "Connection: Keep-Alive\c\L")
 
   # Content length header.
-  const requiresBody = {HttpPost, HttpPut, HttpPatch}
+  const requiresBody = ["POST", "PUT", "PATCH"]
   let needsContentLength = body.len > 0 or httpMethod in requiresBody
   if needsContentLength and not headers.hasKey("Content-Length"):
     add(result, "Content-Length: " & $body.len & "\c\L")
@@ -879,7 +879,7 @@ proc newConnection(client: HttpClient | AsyncHttpClient,
         connectUrl.hostname = url.hostname
         connectUrl.port = if url.port != "": url.port else: "443"
 
-        let proxyHeaderString = generateHeaders(connectUrl, HttpConnect, newHttpHeaders(), "", client.proxy)
+        let proxyHeaderString = generateHeaders(connectUrl, $HttpConnect, newHttpHeaders(), "", client.proxy)
         await client.socket.send(proxyHeaderString)
         let proxyResp = await parseResponse(client, false)
 
@@ -909,7 +909,7 @@ proc override(fallback, override: HttpHeaders): HttpHeaders =
     result[k] = vs
 
 proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
-                httpMethod: HttpMethod, body = "",
+                httpMethod: string, body = "",
                 headers: HttpHeaders = nil): Future[Response | AsyncResponse]
                 {.multisync.} =
   # Helper that actually makes the request. Does not handle redirects.
@@ -936,12 +936,12 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   if body != "":
     await client.socket.send(body)
 
-  let getBody = httpMethod notin {HttpHead, HttpConnect} and
+  let getBody = httpMethod notin ["HEAD", "CONNECT"] and
                 client.getBody
   result = await parseResponse(client, getBody)
 
 proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
-              httpMethod = HttpGET, body = "",
+              httpMethod: HttpMethod | string, body = "",
               headers: HttpHeaders = nil): Future[Response | AsyncResponse]
               {.multisync.} =
   ## Connects to the hostname specified by the URL and performs a request
@@ -957,6 +957,9 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
     let parsedUrl = parseUri(url)
   else:
     let parsedUrl = url
+  # Make the method name uppercase
+  let httpMethod = ($httpMethod).toUpperAscii()
+
   result = await client.requestAux(parsedUrl, httpMethod, body, headers)
 
   var lastURL = parsedUrl
@@ -967,15 +970,14 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
       break
 
     let redirectTo = getNewLocation(lastURL, result.headers)
-    var redirectMethod: HttpMethod
-    var redirectBody: string
+    var redirectMethod, redirectBody: string
 
     # For more informations about the redirect methods see:
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections
     case statusCode
     of Http301, Http302, Http303:
       # The method is changed to GET unless it is GET or HEAD (RFC2616)
-      if httpMethod notin {HttpGet, HttpHead}:
+      if httpMethod notin ["GET", "HEAD"]:
         redirectMethod = HttpGet
       else:
         redirectMethod = httpMethod
@@ -1008,14 +1010,6 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
     result = await client.requestAux(redirectTo, redirectMethod, redirectBody,
                                      headers)
     lastURL = redirectTo
-
-proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
-              httpMethod: string, body = "",
-              headers: HttpHeaders = nil): Future[Response | AsyncResponse]
-              {.multisync, deprecated.} =
-  ## Deprecated version of ``request`` where ``httpMethod`` is a string.
-  result = await client.request(url, parseEnum[HttpMethod](httpMethod), body,
-                                headers)
 
 proc responseContent(resp: Response | AsyncResponse): Future[string] {.multisync.} =
   ## Returns the content of a response as a string.
@@ -1080,7 +1074,7 @@ proc post*(client: HttpClient | AsyncHttpClient, url: string, body = "",
   ## Connects to the hostname specified by the URL and performs a POST request.
   ## This procedure uses httpClient values such as ``client.maxRedirects``.
   var (xb, headers) = makeRequestContent(body, multipart)
-  result = await client.request(url, $HttpPOST, xb, headers)
+  result = await client.request(url, HttpPOST, xb, headers)
 
 proc postContent*(client: HttpClient | AsyncHttpClient, url: string,
                   body = "",
@@ -1096,7 +1090,7 @@ proc put*(client: HttpClient | AsyncHttpClient, url: string, body = "",
   ## Connects to the hostname specified by the URL and performs a PUT request.
   ## This procedure uses httpClient values such as ``client.maxRedirects``.
   var (xb, headers) = makeRequestContent(body, multipart)
-  result = await client.request(url, $HttpPUT, xb, headers)
+  result = await client.request(url, HttpPUT, xb, headers)
 
 proc putContent*(client: HttpClient | AsyncHttpClient, url: string,
                   body = "",
@@ -1112,7 +1106,7 @@ proc patch*(client: HttpClient | AsyncHttpClient, url: string, body = "",
   ## Connects to the hostname specified by the URL and performs a PATCH request.
   ## This procedure uses httpClient values such as ``client.maxRedirects``.
   var (xb, headers) = makeRequestContent(body, multipart)
-  result = await client.request(url, $HttpPATCH, xb, headers)
+  result = await client.request(url, HttpPATCH, xb, headers)
 
 proc patchContent*(client: HttpClient | AsyncHttpClient, url: string,
                   body = "",

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -26,24 +26,26 @@ type
     HttpVer11,
     HttpVer10
 
-  HttpMethod* = enum  ## the requested HttpMethod
-    HttpHead,         ## Asks for the response identical to the one that would
-                      ## correspond to a GET request, but without the response
-                      ## body.
-    HttpGet,          ## Retrieves the specified resource.
-    HttpPost,         ## Submits data to be processed to the identified
-                      ## resource. The data is included in the body of the
-                      ## request.
-    HttpPut,          ## Uploads a representation of the specified resource.
-    HttpDelete,       ## Deletes the specified resource.
-    HttpTrace,        ## Echoes back the received request, so that a client
-                      ## can see what intermediate servers are adding or
-                      ## changing in the request.
-    HttpOptions,      ## Returns the HTTP methods that the server supports
-                      ## for specified address.
-    HttpConnect,      ## Converts the request connection to a transparent
-                      ## TCP/IP tunnel, usually used for proxies.
-    HttpPatch         ## Applies partial modifications to a resource.
+  HttpMethod* = enum         ## the requested HttpMethod
+    HttpHead = "HEAD"        ## Asks for the response identical to the one that
+                             ## would correspond to a GET request, but without
+                             ## the response body.
+    HttpGet = "GET"          ## Retrieves the specified resource.
+    HttpPost = "POST"        ## Submits data to be processed to the identified
+                             ## resource. The data is included in the body of
+                             ## the request.
+    HttpPut = "PUT",         ## Uploads a representation of the specified
+                             ## resource.
+    HttpDelete = "DELETE"    ## Deletes the specified resource.
+    HttpTrace = "TRACE"      ## Echoes back the received request, so that a
+                             ## client
+                             ## can see what intermediate servers are adding or
+                             ## changing in the request.
+    HttpOptions = "OPTIONS"  ## Returns the HTTP methods that the server
+                             ## supports for specified address.
+    HttpConnect = "CONNECT"  ## Converts the request connection to a transparent
+                             ## TCP/IP tunnel, usually used for proxies.
+    HttpPatch = "PATCH"      ## Applies partial modifications to a resource.
 
 
 const
@@ -303,9 +305,6 @@ proc is4xx*(code: HttpCode): bool =
 proc is5xx*(code: HttpCode): bool =
   ## Determines whether ``code`` is a 5xx HTTP status code.
   return code.int in {500 .. 599}
-
-proc `$`*(httpMethod: HttpMethod): string =
-  return (system.`$`(httpMethod))[4 .. ^1].toUpperAscii()
 
 when isMainModule:
   var test = newHttpHeaders()

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -63,6 +63,7 @@ const
   Http304* = HttpCode(304)
   Http305* = HttpCode(305)
   Http307* = HttpCode(307)
+  Http308* = HttpCode(308)
   Http400* = HttpCode(400)
   Http401* = HttpCode(401)
   Http403* = HttpCode(403)
@@ -248,6 +249,7 @@ proc `$`*(code: HttpCode): string =
   of 304: "304 Not Modified"
   of 305: "305 Use Proxy"
   of 307: "307 Temporary Redirect"
+  of 308: "308 Permanent Redirect"
   of 400: "400 Bad Request"
   of 401: "401 Unauthorized"
   of 403: "403 Forbidden"

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -15,7 +15,7 @@ const manualTests = false
 
 proc asyncTest() {.async.} =
   var client = newAsyncHttpClient()
-  var resp = await client.request("http://example.com/")
+  var resp = await client.request("http://example.com/", "GET")
   doAssert(resp.code.is2xx)
   var body = await resp.body
   body = await resp.body # Test caching
@@ -68,7 +68,7 @@ proc asyncTest() {.async.} =
 
 proc syncTest() =
   var client = newHttpClient()
-  var resp = client.request("http://example.com/")
+  var resp = client.request("http://example.com/", "GET")
   doAssert(resp.code.is2xx)
   doAssert("<title>Example Domain</title>" in resp.body)
 


### PR DESCRIPTION
- Teach httpclient that `308` is just another `302`
- Let me pass a damn `Uri` without having to convert it into a string only to convert it back to a `Uri`
- Use `HttpMethod` enum in more places
- Secure by default, do not send `Authorization` on redirection to a new domain