### PR TITLE
pathnorm fix

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -570,7 +570,10 @@ proc getCompileCFileCmd*(conf: ConfigRef; cfile: Cfile): string =
     for includeDir in items(conf.cIncludes):
       includeCmd.add(join([CC[c].includeCmd, includeDir.quoteShell]))
 
-    compilePattern = joinPath(conf.ccompilerpath, exe)
+    if conf.ccompilerpath != "":
+      compilePattern = joinPath(conf.ccompilerpath, exe)
+    else:
+      compilePattern = exe
   else:
     includeCmd = ""
     compilePattern = getCompilerExe(conf, c, cfile.cname)
@@ -678,7 +681,7 @@ proc getLinkCmd(conf: ConfigRef; projectfile: AbsoluteFile, objfiles: string): s
     if len(linkerExe) == 0: linkerExe = getLinkerExe(conf, conf.cCompiler)
     # bug #6452: We must not use ``quoteShell`` here for ``linkerExe``
     if needsExeExt(conf): linkerExe = addFileExt(linkerExe, "exe")
-    if noAbsolutePaths(conf): result = linkerExe
+    if noAbsolutePaths(conf) or conf.cCompilerpath == "": result = linkerExe
     else: result = joinPath(conf.cCompilerpath, linkerExe)
     let buildgui = if optGenGuiApp in conf.globalOptions and conf.target.targetOS == osWindows:
                      CC[conf.cCompiler].buildGui

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -86,7 +86,11 @@ proc addNormalizePath*(x: string; result: var string; state: var int; dirSep = D
         result.add dirSep
       result.add substr(x, b[0], b[1])
       inc state, 2
-  if result == "" and x != "": result = "."
+  if result == "":
+    if x == "":
+      result = "/"
+    else:
+      result = "."
 
 proc normalizePath*(path: string; dirSep = DirSep): string =
   ## Example:


### PR DESCRIPTION
``normalizePath("")`` is now ``"/"``, it was ``""``.

This will make ``check("/a" /../ "d" == "/d")`` work without touching the implementation. 

## additional information

https://github.com/nim-lang/Nim/blob/d2b3046c7073bc3316127258212a5fb140de8f06/lib/pure/os.nim#L359