### PR TITLE
add more nimble packages for testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
   MINGW_DIR: mingw64
   MINGW_URL: https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-win32/seh/x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z/download
   MINGW_ARCHIVE: x86_64-4.9.2-release-win32-seh-rt_v4-rev4.7z
+  OPENBLAS_URL: https://sourceforge.net/projects/openblas/files/v0.3.5/OpenBLAS%200.3.5%20version.zip/download
+  OPENBLAS_ARCHIVE: OpenBLAS-0.3.5.zip
   SQLITE_URL: http://www.sqlite.org/2017/sqlite-dll-win64-x64-3160200.zip
   SQLITE_ARCHIVE: sqlite-dll-win64-x64-3160200.zip
   platform: x64
@@ -31,6 +33,8 @@ install:
   - 7z x -y "%SQLITE_ARCHIVE%" -o"%CD%\DIST"> nul
   - IF not exist "%MINGW_ARCHIVE%" appveyor DownloadFile "%MINGW_URL%" -FileName "%MINGW_ARCHIVE%"
   - 7z x -y "%MINGW_ARCHIVE%" -o"%CD%\DIST"> nul
+  - IF not exist "%OPENBLAS_ARCHIVE%" appveyor DownloadFile "%OPENBLAS_URL%" -FileName "%OPENBLAS_ARCHIVE%"
+  - 7z x -y "%OPENBLAS_ARCHIVE%" -o"%CD%\DIST"> nul
   - SET PATH=%CD%\DIST\%MINGW_DIR%\BIN;%CD%\BIN;%PATH%
   - IF "%PLATFORM%" == "x64" ( copy C:\OpenSSL-Win64\libeay32.dll %CD%\BIN\libeay64.dll & copy C:\OpenSSL-Win64\libeay32.dll %CD%\BIN\libeay32.dll & copy C:\OpenSSL-Win64\libssl32.dll %CD%\BIN\libssl64.dll & copy C:\OpenSSL-Win64\libssl32.dll %CD%\BIN\libssl32.dll )
     ELSE ( copy C:\OpenSSL-Win32\libeay32.dll %CD%\BIN\libeay32.dll & copy C:\OpenSSL-Win32\libssl32.dll %CD%\BIN\libssl32.dll )

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -471,7 +471,8 @@ proc getPackageDir(package: string): string =
   else:
     result = commandOutput[0].string
 
-iterator listPackages(filter: PackageFilter): tuple[name, url, cmd: string] =
+iterator listPackages(filter: PackageFilter):
+                      tuple[name, url, cmd: string, hasDeps: bool] =
   const defaultCmd = "nimble test"
   let packageList = parseFile(packageIndex)
   for package in packageList.items:
@@ -482,12 +483,12 @@ iterator listPackages(filter: PackageFilter): tuple[name, url, cmd: string] =
         case filter
         of pfCoreOnly:
           if "nim-lang" in normalize(url):
-            yield (name, url, defaultCmd)
+            yield (name, url, defaultCmd, false)
         of pfExtraOnly:
-          for n, cmd, commit in important_packages.packages.items:
-            if name == n: yield (name, url, cmd)
+          for n, cmd, commit, hasDeps in important_packages.packages.items:
+            if name == n: yield (name, url, cmd, hasDeps)
         of pfAll:
-          yield (name, url, defaultCmd)
+          yield (name, url, defaultCmd, false)
 
 proc makeSupTest(test, options: string, cat: Category): TTest =
   result.cat = cat
@@ -506,32 +507,47 @@ proc testNimblePackages(r: var TResults, cat: Category, filter: PackageFilter) =
 
   let packageFileTest = makeSupTest("PackageFileParsed", "", cat)
   var keepDir = false
+  var packagesDir = "pkgstemp"
   try:
-    for name, url, cmd in listPackages(filter):
+    for name, url, cmd, hasDep in listPackages(filter):
       var test = makeSupTest(url, "", cat)
-      let buildPath = "pkgstemp" / name
-      let installProcess = startProcess("git", "", ["clone", url, buildPath])
-      let installStatus = waitForExitEx(installProcess)
-      installProcess.close
-      if installStatus != QuitSuccess:
-        r.addResult(test, targetC, "", "", reInstallFailed)
+      let buildPath = packagesDir / name
+      if not existsDir(buildPath):
+        if hasDep:
+          let nimbleProcess = startProcess("nimble", "", ["install", "-y", name],
+                                           options = {poUsePath, poStdErrToStdOut})
+          let nimbleStatus = waitForExitEx(nimbleProcess)
+          nimbleProcess.close
+          if nimbleStatus != QuitSuccess:
+            r.addResult(test, targetC, "", "", reInstallFailed)
+            keepDir = true
+            continue
+
+        let installProcess = startProcess("git", "", ["clone", url, buildPath],
+                                          options = {poUsePath, poStdErrToStdOut})
+        let installStatus = waitForExitEx(installProcess)
+        installProcess.close
+        if installStatus != QuitSuccess:
+          r.addResult(test, targetC, "", "", reInstallFailed)
+          keepDir = true
+          continue
+
+      let cmdArgs = parseCmdLine(cmd)
+      let buildProcess = startProcess(cmdArgs[0], buildPath, cmdArgs[1..^1],
+                                      options = {poUsePath, poStdErrToStdOut})
+      let buildStatus = waitForExitEx(buildProcess)
+      buildProcess.close
+      if buildStatus != QuitSuccess:
+        r.addResult(test, targetC, "", "", reBuildFailed)
         keepDir = true
       else:
-        let cmdArgs = parseCmdLine(cmd)
-        let buildProcess = startProcess(cmdArgs[0], buildPath, cmdArgs[1..^1])
-        let buildStatus = waitForExitEx(buildProcess)
-        buildProcess.close
-        if buildStatus != QuitSuccess:
-          r.addResult(test, targetC, "", "", reBuildFailed)
-          keepDir = true
-        else:
-          r.addResult(test, targetC, "", "", reSuccess)
+        r.addResult(test, targetC, "", "", reSuccess)
     r.addResult(packageFileTest, targetC, "", "", reSuccess)
   except JsonParsingError:
     echo("[Warning] - Cannot run nimble tests: Invalid package file.")
     r.addResult(packageFileTest, targetC, "", "", reBuildFailed)
   finally:
-    if not keepDir: removeDir("pkgstemp")
+    if not keepDir: removeDir(packagesDir)
 
 
 # ----------------------------------------------------------------------------

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -1,28 +1,44 @@
 import strutils
 
-template pkg(name: string; cmd = "nimble test"; version = ""): untyped =
-  packages.add((name, cmd, version))
+template pkg(name: string; cmd = "nimble test"; version = ""; hasDeps = false): untyped =
+  packages.add((name, cmd, version, hasDeps))
 
-var packages*: seq[tuple[name, cmd, version: string]] = @[]
+var packages*: seq[tuple[name, cmd, version: string; hasDeps: bool]] = @[]
 
-pkg "karax"
-pkg "cligen"
-pkg "glob"
-#pkg "regex"
-pkg "freeimage", "nim c freeimage.nim"
-pkg "zero_functional"
-pkg "nimpy", "nim c nimpy.nim"
-#pkg "nimongo", "nimble test_ci"
-pkg "inim"
 
-pkg "sdl1", "nim c src/sdl.nim"
-pkg "iterutils"
-pkg "gnuplot"
+pkg "arraymancer", "nim c src/arraymancer.nim", "", true
+pkg "ast_pattern_matching", "nim c tests/test1.nim"
 pkg "c2nim"
-
-#[
-    arraymancer
-    nimpb
-    jester
-    nimx
-]#
+pkg "cligen", "nim c -o:cligenn cligen.nim"
+pkg "compactdict", "nim c tests/test1.nim"
+pkg "criterion"
+pkg "docopt"
+pkg "gara", "nim c tests/test_gara.nim"
+pkg "glob"
+pkg "gnuplot"
+pkg "hts", "nim c tests/all.nim"
+pkg "inim"
+pkg "itertools", "nim doc src/itertools.nim"
+pkg "iterutils"
+pkg "karax", "nim c tests/tester.nim"
+pkg "loopfusion"
+pkg "nake", "nim c nakefile.nim"
+pkg "neo", "nim c -d:blas=openblas tests/all.nim", "", true
+pkg "nigui", "nim c -o:niguii src/nigui.nim"
+pkg "NimData", "nim c -o:nimdataa src/nimdata.nim", "", true
+pkg "nimes", "nim c src/nimes.nim", "", true
+pkg "nimgame2", "nim c nimgame2/nimgame.nim", "", true
+pkg "nimongo", "nimble test_ci", "", true
+pkg "nimpy", "nim c -o:nimpyy nimpy.nim"
+pkg "nimsl", "nim c test.nim"
+pkg "nimx", "nim c --threads:on test/main.nim", "", true
+pkg "parsetoml"
+pkg "patty"
+pkg "plotly", "nim c examples/all.nim", "", true
+pkg "protobuf", "nim c -o:protobuff src/protobuf.nim", "", true
+pkg "regex", "nim c src/regex"
+pkg "rosencrantz", "nim c -o:rsncntz rosencrantz.nim"
+pkg "sdl1", "nim c src/sdl.nim"
+pkg "sdl2_nim", "nim c sdl2/sdl.nim"
+pkg "stint", "nim c -o:stintt stint.nim"
+pkg "zero_functional", "nim c test.nim"


### PR DESCRIPTION
This adds more nimble packages to our testing. 37 packages are now tested.

Some of the packages have dependencies. For those packages, we first do `nimble install` so the dependencies are installed before we clone the repo and run the tests.
This means that the iterator `listPackages` now returns one more field: `tuple[name, url, cmd: string, hasDeps: bool]`.

Two packages (Arraymancer and Neo) are dependent on BLAS, so OpenBLAS is added to Appveyor environment.
