### PR TITLE
Fix for the EOF issue when reading asynchronous text file line by line

### DIFF
--- a/lib/pure/asyncfile.nim
+++ b/lib/pure/asyncfile.nim
@@ -296,18 +296,27 @@ proc read*(f: AsyncFile, size: int): Future[string] =
 
   return retFuture
 
+## proc readLine*(f: AsyncFile): Future[string] {.async.} =
+##   ## Reads a single line from the specified file asynchronously.
+##   result = ""
+##   while true:
+##     var c = await read(f, 1)
+##     if c[0] == '\c':
+##       c = await read(f, 1)
+##       break
+##     if c[0] == '\L' or c == "":
+##       break
+##     else:
+##       result.add(c)
+
 proc readLine*(f: AsyncFile): Future[string] {.async.} =
-  ## Reads a single line from the specified file asynchronously.
+  ## Reads a single line from the specified file asynchronously and
+  ## let the user deal with the carriage return and new line.
   result = ""
-  while true:
-    var c = await read(f, 1)
-    if c[0] == '\c':
-      c = await read(f, 1)
+  while (let c = await read(f, 1); c.len) > 0:
+    result.add(c)
+    if c[0] == '\L':
       break
-    if c[0] == '\L' or c == "":
-      break
-    else:
-      result.add(c)
 
 proc getFilePos*(f: AsyncFile): int64 =
   ## Retrieves the current position of the file pointer that is

--- a/lib/pure/asyncfile.nim
+++ b/lib/pure/asyncfile.nim
@@ -296,20 +296,20 @@ proc read*(f: AsyncFile, size: int): Future[string] =
 
   return retFuture
 
-## proc readLine*(f: AsyncFile): Future[string] {.async.} =
-##   ## Reads a single line from the specified file asynchronously.
-##   result = ""
-##   while true:
-##     var c = await read(f, 1)
-##     if c[0] == '\c':
-##       c = await read(f, 1)
-##       break
-##     if c[0] == '\L' or c == "":
-##       break
-##     else:
-##       result.add(c)
-
 proc readLine*(f: AsyncFile): Future[string] {.async.} =
+   ## Reads a single line from the specified file asynchronously.
+   result = ""
+   while true:
+     var c = await read(f, 1)
+     if c[0] == '\c':
+       c = await read(f, 1)
+       break
+     if c[0] == '\L' or c == "":
+       break
+     else:
+       result.add(c)
+
+proc readLn*(f: AsyncFile): Future[string] {.async.} =
   ## Reads a single line from the specified file asynchronously and
   ## let the user deal with the carriage return and new line.
   result = ""


### PR DESCRIPTION
Why not simplify and do the same thing that Python does?
The user then does what he understands with the new line.

Text File Example: test.txt
```
test1
test2

test3

```
Example in python:
```python
f = open("test.txt")
for line in f:
    print(line)
f.close()
```
Python output:
```
test1

test2


test3

```
My sugestion for readLine in Nim:
```nim
import asyncdispatch, asyncfile, os

proc readLine*(f: AsyncFile): Future[string] {.async.} =
    result = ""
    while (let c = await read(f, 1); c.len) > 0:
        result.add(c)
        if c[0] == '\L':
            break

proc main() {.async.} =
    var fh = openAsync("test.txt", fmRead)
    while (let line = await fh.readLine(); line.len) > 0:
        echo line
    fh.close()

waitFor main()
```
Nim output:
```
test1

test2


test3

```
If you want to remove the newline:
```nim
import asyncdispatch, asyncfile, os
import strutils

proc readLine*(f: AsyncFile): Future[string] {.async.} =
    result = ""
    while (let c = await read(f, 1); c.len) > 0:
        result.add(c)
        if c[0] == '\L':
            break

proc main() {.async.} =
    var fh = openAsync("test.txt", fmRead)
    while (let line = await fh.readLine(); line) != "":
        echo line.strip(leading = false)
    fh.close()

waitFor main()
```
Nim output without newline:
```
test1
test2

test3
```