### PR TITLE
Return result when found on mimetypes

### DIFF
--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1906,6 +1906,7 @@ func getExt*(mimedb: MimeDB, mimetype: string, default = "txt"): string =
   for e, m in mimedb.mimes:
     if m == mimeLowered:
       result = e
+      break
 
 func register*(mimedb: var MimeDB, ext: string, mimetype: string) =
   ## Adds ``mimetype`` to the ``mimedb``.


### PR DESCRIPTION
Return result when found. Sorry for the huge Diff.

**Before:**
- Search a mime.
- Result found.
- Wont return result, keeps iterating the whole `mimedb` for no reason whatsoever.
- Return result.

**After:**
- Search a mime.
- Result found.
- Return result.

:cat: 
