### PR TITLE
faster sequtils.filter, fixes #3958

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -388,10 +388,17 @@ proc filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
     assert f1 == @["red", "black"]
     assert f2 == @["yellow"]
 
-  result = newSeq[T]()
+  var size = s.len div 4 + 1
+  var cnt = 0
+  result = newSeq[T](size)
   for i in 0 ..< s.len:
     if pred(s[i]):
-      result.add(s[i])
+      result[cnt] = s[i]
+      inc cnt
+      if cnt == size:
+        size = 2 * size
+        result.setLen(size)
+  result.setLen(cnt)
 
 proc keepIf*[T](s: var seq[T], pred: proc(x: T): bool {.closure.})
                                                                 {.inline.} =


### PR DESCRIPTION
I've tested it on the sequences of random integers of various lengths (from 10 to 100_000) and with different amount of filtered results (from 5% to 95% of original size) and usually it is **between 10 and 30% faster** than the original version.

Q: Why is 1/4 of original size the initial guess?
A: It is the result of trial and error with different sizes, while keeping it reasonably simple.