### PR TITLE
add links to every document, fixes #5515

### DIFF
--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -77,7 +77,20 @@ $content
 doc.body_toc = """
 <div class="row">
   <div class="three columns">
-  <div>
+  <div id="global-links">
+    <ul class="simple-boot">
+      <li>
+        <a href="manual.html">Manual</a>
+      </li>
+      <li>
+        <a href="lib.html">Standard library</a>
+      </li>
+      <li>
+        <a href="theindex.html">Index</a>
+      </li>
+    </ul>
+  </div>
+  <div id="searchInputDiv">
     Search: <input type="text" id="searchInput"
       onkeyup="search()" />
   </div>


### PR DESCRIPTION
Currently only modules (i.e. `*.nim` files) had links to "Manual", "Standard library" and "Index". Now also documents (i.e. `*.rst` files) have those links at the top of the left column.