### PR TITLE
document proper imports, fixes #8164

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -336,23 +336,23 @@ Parsers
   This is a low level module that implements an extremely efficient buffering
   scheme for lexers and parsers. This is used by the diverse parsing modules.
 
-* `highlite <highlite.html>`_
+* `packages/docutils/highlite <highlite.html>`_
   Source highlighter for programming or markup languages.  Currently
   only few languages are supported, other languages may be added.
   The interface supports one language nested in another.
 
-* `rst <rst.html>`_
+* `packages/docutils/rst <rst.html>`_
   This module implements a reStructuredText parser. A large subset
   is implemented. Some features of the markdown wiki syntax are
   also supported.
 
-* `rstast <rstast.html>`_
+* `packages/docutils/rstast <rstast.html>`_
   This module implements an AST for the reStructuredText parser.
 
-* `rstgen <rstgen.html>`_
+* `packages/docutils/rstgen <rstgen.html>`_
   This module implements a generator of HTML/Latex from reStructuredText.
 
-* `sexp <sexp.html>`_
+* `packages/docutils/sexp <sexp.html>`_
   High performance sexp parser and generator, mainly for communication
   with emacs.
 
@@ -388,7 +388,7 @@ Cryptography and Hashing
 * `base64 <base64.html>`_
   This module implements a base64 encoder and decoder.
 
-* `sha1 <sha1.html>`_
+* `std/sha1 <sha1.html>`_
   This module implements a sha1 encoder and decoder.
 
 

--- a/lib/packages/docutils/highlite.nim
+++ b/lib/packages/docutils/highlite.nim
@@ -10,6 +10,8 @@
 ## Source highlighter for programming or markup languages.
 ## Currently only few languages are supported, other languages may be added.
 ## The interface supports one language nested in another.
+##
+## **Note:** Import ``packages/docutils/highlite`` to use this module
 
 import
   strutils

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -10,6 +10,8 @@
 ## This module implements a `reStructuredText`:idx: parser. A large
 ## subset is implemented. Some features of the `markdown`:idx: wiki syntax are
 ## also supported.
+##
+## **Note:** Import ``packages/docutils/rst`` to use this module
 
 import
   os, strutils, rstast

--- a/lib/packages/docutils/rstast.nim
+++ b/lib/packages/docutils/rstast.nim
@@ -8,6 +8,8 @@
 #
 
 ## This module implements an AST for the `reStructuredText`:idx: parser.
+##
+## **Note:** Import ``packages/docutils/rstast`` to use this module
 
 import strutils, json
 

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -22,6 +22,8 @@
 ## other lower level methods to finally build complete documents. This requires
 ## many options and tweaking, but you are not limited to snippets and can
 ## generate `LaTeX documents <https://en.wikipedia.org/wiki/LaTeX>`_ too.
+##
+## **Note:** Import ``packages/docutils/rstgen`` to use this module
 
 import strutils, os, hashes, strtabs, rstast, rst, highlite, tables, sequtils,
   algorithm, parseutils

--- a/nimsuggest/sexp.nim
+++ b/nimsuggest/sexp.nim
@@ -7,6 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
+## **Note:** Import ``nimsuggest/sexp`` to use this module
+
 import
   hashes, strutils, lexbase, streams, unicode, macros
 


### PR DESCRIPTION
Until #8164 is properly fixed (i.e. when you'll be able to do `import highlite` instead of `import packages/docutils/highlite`), document the correct way to import those files.
(The same has already been done for `std/sha1`, for example)