### PR TITLE
better docs: osproc

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -33,21 +33,21 @@ when defined(linux):
 type
   ProcessOption* = enum ## Options that can be passed to `startProcess proc
     ## <#startProcess,string,string,openArray[string],StringTableRef,set[ProcessOption]>`_.
-    poEchoCmd,           ## Echo the command before execution.
-    poUsePath,           ## Asks system to search for executable using PATH environment
-                         ## variable.
-                         ## On Windows, this is the default.
-    poEvalCommand,       ## Pass `command` directly to the shell, without quoting.
-                         ## Use it only if `command` comes from trusted source.
-    poStdErrToStdOut,    ## Merge stdout and stderr to the stdout stream.
-    poParentStreams,     ## Use the parent's streams.
-    poInteractive,       ## Optimize the buffer handling for responsiveness for
-                         ## UI applications. Currently this only affects
-                         ## Windows: Named pipes are used so that you can peek
-                         ## at the process' output streams.
-    poDaemon             ## Windows: The program creates no Window.
-                         ## Unix: Start the program as a demon. This is still
-                         ## work in progress!
+    poEchoCmd,              ## Echo the command before execution.
+    poUsePath,              ## Asks system to search for executable using PATH environment
+                            ## variable.
+                            ## On Windows, this is the default.
+    poEvalCommand,          ## Pass `command` directly to the shell, without quoting.
+                            ## Use it only if `command` comes from trusted source.
+    poStdErrToStdOut,       ## Merge stdout and stderr to the stdout stream.
+    poParentStreams,        ## Use the parent's streams.
+    poInteractive,          ## Optimize the buffer handling for responsiveness for
+                            ## UI applications. Currently this only affects
+                            ## Windows: Named pipes are used so that you can peek
+                            ## at the process' output streams.
+    poDaemon                ## Windows: The program creates no Window.
+                            ## Unix: Start the program as a daemon. This is still
+                            ## work in progress!
 
   ProcessObj = object of RootObj
     when defined(windows):
@@ -64,6 +64,11 @@ type
     options: set[ProcessOption]
 
   Process* = ref ProcessObj ## Represents an operating system process.
+
+const poDemon* {.deprecated.} = poDaemon ## Nim versions before 0.20
+  ## used the wrong spelling ("demon").
+  ## Now `ProcessOption` uses the correct spelling ("daemon"),
+  ## and this is needed just for backward compatibility.
 
 
 proc execProcess*(command: string,

--- a/nimsuggest/crashtester.nim
+++ b/nimsuggest/crashtester.nim
@@ -20,7 +20,7 @@ proc callNimsuggest() =
   let cl = parseCmdLine("nimsuggest --tester temp000.nim")
   var p = startProcess(command=cl[0], args=cl[1 .. ^1],
                        options={poStdErrToStdOut, poUsePath,
-                       poInteractive, poDemon})
+                       poInteractive, poDaemon})
   let outp = p.outputStream
   let inp = p.inputStream
   var report = ""

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -251,7 +251,7 @@ proc runEpcTest(filename: string): int =
   let cl = parseCmdLine(epccmd)
   var p = startProcess(command=cl[0], args=cl[1 .. ^1],
                        options={poStdErrToStdOut, poUsePath,
-                       poInteractive, poDemon})
+                       poInteractive, poDaemon})
   let outp = p.outputStream
   let inp = p.inputStream
   var report = ""
@@ -293,7 +293,7 @@ proc runTest(filename: string): int =
   let cl = parseCmdLine(s.cmd)
   var p = startProcess(command=cl[0], args=cl[1 .. ^1],
                        options={poStdErrToStdOut, poUsePath,
-                       poInteractive, poDemon})
+                       poInteractive, poDaemon})
   let outp = p.outputStream
   let inp = p.inputStream
   var report = ""

--- a/tests/async/tupcoming_async.nim
+++ b/tests/async/tupcoming_async.nim
@@ -98,7 +98,7 @@ when defined(upcoming):
         var process = startProcess("ping.exe", "",
                                    ["127.0.0.1", "-n", "2", "-w", "100"], nil,
                                    {poStdErrToStdOut, poUsePath, poInteractive,
-                                   poDemon})
+                                   poDaemon})
       else:
         var process = startProcess("sleep", "", ["1"], nil,
                                    {poStdErrToStdOut, poUsePath})

--- a/tools/vccexe/vcvarsall.nim
+++ b/tools/vccexe/vcvarsall.nim
@@ -80,7 +80,7 @@ proc vccVarsAll*(path: string, arch: VccArch = vccarchUnspecified, platform_type
   # Execute vcvarsall with its command-line arguments
   # and then execute the SET command to list all environment variables
   let comSpecExec = "\"$1\" /C \"$2 && SET\"" % [comSpecCmd, vcvarsExec]
-  var comSpecOpts = {poEvalCommand, poDemon, poStdErrToStdOut}
+  var comSpecOpts = {poEvalCommand, poDaemon, poStdErrToStdOut}
   if verbose:
     comSpecOpts.incl poEchoCmd
   let comSpecOut = execProcess(comSpecExec, options = comSpecOpts)


### PR DESCRIPTION
Other than more informative docs, fixes typo in the name `poDemon` to `poDaemon`.