### PR TITLE
Replace the duration conversion procs with new improved ones

### DIFF
--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -588,3 +588,12 @@ suite "ttimes":
       let y = initDateTime(10, mMar, 1995, 00, 00, 00, utc())
       doAssert x + between(x, y) == y
       doAssert between(x, y) == 1.months + 1.weeks
+
+  test "inX procs":
+    doAssert initDuration(seconds = 1).inSeconds == 1
+    doAssert initDuration(seconds = -1).inSeconds == -1
+    doAssert initDuration(seconds = -1, nanoseconds = 1).inSeconds == 0
+    doAssert initDuration(nanoseconds = -1).inSeconds == 0
+    doAssert initDuration(milliseconds = 500).inMilliseconds == 500
+    doAssert initDuration(milliseconds = -500).inMilliseconds == -500
+    doAssert initDuration(nanoseconds = -999999999).inMilliseconds == -999


### PR DESCRIPTION
As suggested in #10679, I've implement procs for converting a duration to some specific unit: `inHours`, `inMilliseconds` and so on. The old versions named `hours`, `milliseconds`, etc have been deprecated. I've also deprecated the proc `fractional`, as it mostly existed to justify the stupid behavior of the `milliseconds`/`microseconds`/`nanoseconds` procs. After this PR, the details of how a `Duration` is normalized is just an implementation detail, as all the procs that exposes it have been deprecated. 

I discovered an off-by-one error for the procs `weeks`/`days`/`hours`/`minutes`/`seconds` when used with negative durations, which is also fixed in this PR.

Closes #10679