### PR TITLE
Const named tuple unpacking: add tests

### DIFF
--- a/tests/tuples/ttuples_various.nim
+++ b/tests/tuples/ttuples_various.nim
@@ -75,10 +75,26 @@ block unpack_const:
   doAssert c == 3
 
   # bug #10098
-  const (x, y, z) = (4, 5, 6)
-  doAssert x == 4
-  doAssert y == 5
-  doAssert z == 6
+  const (d, e, f) = (4, 5, 6)
+  doAssert d == 4
+  doAssert e == 5
+  doAssert f == 6
+
+
+
+# bug #10724
+block unpack_const_named:
+  const (a, ) = (x: 1, )
+  doAssert a == 1
+
+  const (b, c) = (x: 2, y: 3)
+  doAssert b == 2
+  doAssert c == 3
+
+  const (d, e, f) = (x: 4, y: 5, z: 6)
+  doAssert d == 4
+  doAssert e == 5
+  doAssert f == 6
 
 
 


### PR DESCRIPTION
I don't know how to address https://github.com/nim-lang/Nim/issues/10724, but here's some failing tests that might save somebody a little time.

(The tests fail on Nim 0.19.9, latest `devel` commit https://github.com/nim-lang/Nim/commit/28a83a838821cbe3efc8ddd412db966ca164ef5c, so I added `[ci skip]` for now).