### PR TITLE
StringStream and parseJson in vm

### DIFF
--- a/compiler/ccgmerge.nim
+++ b/compiler/ccgmerge.nim
@@ -31,7 +31,7 @@ const
     cfsData: "NIM_merge_DATA",
     cfsProcs: "NIM_merge_PROCS",
     cfsInitProc: "NIM_merge_INIT_PROC",
-    cfsDatInitProc: "NIM_merge_DATINIT_PROC",    
+    cfsDatInitProc: "NIM_merge_DATINIT_PROC",
     cfsTypeInit1: "NIM_merge_TYPE_INIT1",
     cfsTypeInit2: "NIM_merge_TYPE_INIT2",
     cfsTypeInit3: "NIM_merge_TYPE_INIT3",
@@ -145,38 +145,34 @@ proc atEndMark(buf: cstring, pos: int): bool =
 
 proc readVerbatimSection(L: var TBaseLexer): Rope =
   var pos = L.bufpos
-  var buf = L.buf
   var r = newStringOfCap(30_000)
   while true:
-    case buf[pos]
+    case L.buf[pos]
     of CR:
       pos = nimlexbase.handleCR(L, pos)
-      buf = L.buf
       r.add('\L')
     of LF:
       pos = nimlexbase.handleLF(L, pos)
-      buf = L.buf
       r.add('\L')
     of '\0':
       doAssert(false, "ccgmerge: expected: " & NimMergeEndMark)
       break
     else:
-      if atEndMark(buf, pos):
+      if atEndMark(L.buf, pos):
         inc pos, NimMergeEndMark.len
         break
-      r.add(buf[pos])
+      r.add(L.buf[pos])
       inc pos
   L.bufpos = pos
   result = r.rope
 
 proc readKey(L: var TBaseLexer, result: var string) =
   var pos = L.bufpos
-  var buf = L.buf
   setLen(result, 0)
-  while buf[pos] in IdentChars:
-    result.add(buf[pos])
+  while L.buf[pos] in IdentChars:
+    result.add(L.buf[pos])
     inc pos
-  if buf[pos] != ':': doAssert(false, "ccgmerge: ':' expected")
+  if L.buf[pos] != ':': doAssert(false, "ccgmerge: ':' expected")
   L.bufpos = pos + 1 # skip ':'
 
 proc newFakeType(id: int): PType =

--- a/compiler/nimlexbase.nim
+++ b/compiler/nimlexbase.nim
@@ -81,8 +81,7 @@ proc fillBuffer(L: var TBaseLexer) =
   if toCopy > 0:
     moveMem(addr L.buf[0], addr L.buf[L.sentinel + 1], toCopy)
     # "moveMem" handles overlapping regions
-  charsRead = llStreamRead(L.stream, addr(L.buf[toCopy]),
-                           (L.sentinel + 1))
+  charsRead = llStreamRead(L.stream, addr L.buf[toCopy], L.sentinel + 1)
   s = toCopy + charsRead
   if charsRead < L.sentinel + 1:
     L.buf[s] = EndOfFile      # set end marker

--- a/compiler/nimlexbase.nim
+++ b/compiler/nimlexbase.nim
@@ -39,8 +39,7 @@ const
 type
   TBaseLexer* = object of RootObj
     bufpos*: int
-    buf*: cstring
-    bufLen*: int              # length of buffer in characters
+    buf*: string
     stream*: PLLStream        # we read from this stream
     lineNumber*: int          # the current line number
                               # private data:
@@ -65,11 +64,7 @@ proc handleLF*(L: var TBaseLexer, pos: int): int
   # of the LF.
 # implementation
 
-const
-  chrSize = sizeof(char)
-
 proc closeBaseLexer(L: var TBaseLexer) =
-  dealloc(L.buf)
   llStreamClose(L.stream)
 
 proc fillBuffer(L: var TBaseLexer) =
@@ -80,14 +75,14 @@ proc fillBuffer(L: var TBaseLexer) =
     oldBufLen: int
   # we know here that pos == L.sentinel, but not if this proc
   # is called the first time by initBaseLexer()
-  assert(L.sentinel < L.bufLen)
-  toCopy = L.bufLen - L.sentinel - 1
+  assert(L.sentinel < L.buf.len)
+  toCopy = L.buf.len - L.sentinel - 1
   assert(toCopy >= 0)
   if toCopy > 0:
-    moveMem(L.buf, addr(L.buf[L.sentinel + 1]), toCopy * chrSize)
+    moveMem(addr L.buf[0], addr L.buf[L.sentinel + 1], toCopy)
     # "moveMem" handles overlapping regions
   charsRead = llStreamRead(L.stream, addr(L.buf[toCopy]),
-                           (L.sentinel + 1) * chrSize) div chrSize
+                           (L.sentinel + 1))
   s = toCopy + charsRead
   if charsRead < L.sentinel + 1:
     L.buf[s] = EndOfFile      # set end marker
@@ -96,7 +91,7 @@ proc fillBuffer(L: var TBaseLexer) =
     # compute sentinel:
     dec(s)                    # BUGFIX (valgrind)
     while true:
-      assert(s < L.bufLen)
+      assert(s < L.buf.len)
       while (s >= 0) and not (L.buf[s] in NewLines): dec(s)
       if s >= 0:
         # we found an appropriate character for a sentinel:
@@ -105,17 +100,16 @@ proc fillBuffer(L: var TBaseLexer) =
       else:
         # rather than to give up here because the line is too long,
         # double the buffer's size and try again:
-        oldBufLen = L.bufLen
-        L.bufLen = L.bufLen * 2
-        L.buf = cast[cstring](realloc(L.buf, L.bufLen * chrSize))
-        assert(L.bufLen - oldBufLen == oldBufLen)
+        oldBufLen = L.buf.len
+        L.buf.setLen(L.buf.len * 2)
+        assert(L.buf.len - oldBufLen == oldBufLen)
         charsRead = llStreamRead(L.stream, addr(L.buf[oldBufLen]),
-                                 oldBufLen * chrSize) div chrSize
+                                 oldBufLen)
         if charsRead < oldBufLen:
           L.buf[oldBufLen + charsRead] = EndOfFile
           L.sentinel = oldBufLen + charsRead
           break
-        s = L.bufLen - 1
+        s = L.buf.len - 1
 
 proc fillBaseLexer(L: var TBaseLexer, pos: int): int =
   assert(pos <= L.sentinel)
@@ -149,8 +143,7 @@ proc openBaseLexer(L: var TBaseLexer, inputstream: PLLStream, bufLen = 8192) =
   assert(bufLen > 0)
   L.bufpos = 0
   L.offsetBase = 0
-  L.bufLen = bufLen
-  L.buf = cast[cstring](alloc(bufLen * chrSize))
+  L.buf = newString(bufLen)
   L.sentinel = bufLen - 1
   L.lineStart = 0
   L.lineNumber = 1            # lines start at 1

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2038,6 +2038,8 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
     genConv(c, n, n.sons[1], dest)
   of nkObjDownConv:
     genConv(c, n, n.sons[0], dest)
+  of nkObjUpConv:
+    genConv(c, n, n.sons[0], dest)
   of nkVarSection, nkLetSection:
     unused(c, n, dest)
     genVarSection(c, n)
@@ -2079,6 +2081,7 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   of nkComesFrom:
     discard "XXX to implement for better stack traces"
   else:
+    debug(n)
     globalError(c.config, n.info, "cannot generate VM code for " & $n)
 
 proc removeLastEof(c: PCtx) =

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -2081,7 +2081,6 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
   of nkComesFrom:
     discard "XXX to implement for better stack traces"
   else:
-    debug(n)
     globalError(c.config, n.info, "cannot generate VM code for " & $n)
 
 proc removeLastEof(c: PCtx) =

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -155,18 +155,17 @@ proc getAdornment(L: var Lexer, tok: var Token) =
 
 proc getIndentAux(L: var Lexer, start: int): int =
   var pos = start
-  var buf = L.buf
   # skip the newline (but include it in the token!)
-  if buf[pos] == '\x0D':
-    if buf[pos + 1] == '\x0A': inc(pos, 2)
+  if L.buf[pos] == '\x0D':
+    if L.buf[pos + 1] == '\x0A': inc(pos, 2)
     else: inc(pos)
-  elif buf[pos] == '\x0A':
+  elif L.buf[pos] == '\x0A':
     inc(pos)
   if L.skipPounds:
-    if buf[pos] == '#': inc(pos)
-    if buf[pos] == '#': inc(pos)
+    if L.buf[pos] == '#': inc(pos)
+    if L.buf[pos] == '#': inc(pos)
   while true:
-    case buf[pos]
+    case L.buf[pos]
     of ' ', '\x0B', '\x0C':
       inc(pos)
       inc(result)
@@ -175,9 +174,9 @@ proc getIndentAux(L: var Lexer, start: int): int =
       result = result - (result mod 8) + 8
     else:
       break                   # EndOfFile also leaves the loop
-  if buf[pos] == '\0':
+  if L.buf[pos] == '\0':
     result = 0
-  elif (buf[pos] == '\x0A') or (buf[pos] == '\x0D'):
+  elif (L.buf[pos] == '\x0A') or (L.buf[pos] == '\x0D'):
     # look at the next line for proper indentation:
     result = getIndentAux(L, pos)
   L.bufpos = pos              # no need to set back buf

--- a/lib/pure/lexbase.nim
+++ b/lib/pure/lexbase.nim
@@ -53,10 +53,15 @@ proc fillBuffer(L: var BaseLexer) =
   assert(toCopy >= 0)
   if toCopy > 0:
     when defined(js):
-      for i in 0 ..< toCopy: L.buf[i] = L.buf[L.sentinel + 1 + i]
+      for i in 0 ..< toCopy:
+        L.buf[i] = L.buf[L.sentinel + 1 + i]
     else:
-      # "moveMem" handles overlapping regions
-      moveMem(addr L.buf[0], addr L.buf[L.sentinel + 1], toCopy)
+      when nimvm:
+        for i in 0 ..< toCopy:
+          L.buf[i] = L.buf[L.sentinel + 1 + i]
+      else:
+        # "moveMem" handles overlapping regions
+        moveMem(addr L.buf[0], addr L.buf[L.sentinel + 1], toCopy)
   charsRead = L.input.readDataStr(L.buf, toCopy ..< toCopy + L.sentinel + 1)
   s = toCopy + charsRead
   if charsRead < L.sentinel + 1:

--- a/lib/pure/lexbase.nim
+++ b/lib/pure/lexbase.nim
@@ -51,17 +51,13 @@ proc fillBuffer(L: var BaseLexer) =
   assert(L.sentinel + 1 <= L.buf.len)
   toCopy = L.buf.len - (L.sentinel + 1)
   assert(toCopy >= 0)
-
   if toCopy > 0:
     when defined(js):
       for i in 0 ..< toCopy: L.buf[i] = L.buf[L.sentinel + 1 + i]
     else:
       # "moveMem" handles overlapping regions
       moveMem(addr L.buf[0], addr L.buf[L.sentinel + 1], toCopy)
-
-  # test
   charsRead = L.input.readDataStr(L.buf, toCopy ..< toCopy + L.sentinel + 1)
-
   s = toCopy + charsRead
   if charsRead < L.sentinel + 1:
     L.buf[s] = EndOfFile      # set end marker
@@ -81,7 +77,6 @@ proc fillBuffer(L: var BaseLexer) =
         # double the buffer's size and try again:
         oldBufLen = L.buf.len
         L.buf.setLen(L.buf.len * 2)
-
         charsRead = readDataStr(L.input, L.buf, oldBufLen ..< L.buf.len)
         if charsRead < oldBufLen:
           L.buf[oldBufLen + charsRead] = EndOfFile

--- a/lib/pure/lexbase.nim
+++ b/lib/pure/lexbase.nim
@@ -28,10 +28,7 @@ type
   BaseLexer* = object of RootObj ## the base lexer. Inherit your lexer from
                                  ## this object.
     bufpos*: int              ## the current position within the buffer
-    when defined(js):         ## the buffer itself
-      buf*: string
-    else:
-      buf*: cstring
+    buf*: string           ## the buffer itself
     bufLen*: int              ## length of buffer in characters
     input: Stream            ## the input stream
     lineNumber*: int          ## the current line number
@@ -45,8 +42,6 @@ const
 
 proc close*(L: var BaseLexer) =
   ## closes the base lexer. This closes `L`'s associated stream too.
-  when not defined(js):
-    dealloc(L.buf)
   close(L.input)
 
 proc fillBuffer(L: var BaseLexer) =
@@ -65,7 +60,9 @@ proc fillBuffer(L: var BaseLexer) =
       for i in 0 ..< toCopy: L.buf[i] = L.buf[L.sentinel + 1 + i]
     else:
       # "moveMem" handles overlapping regions
-      moveMem(L.buf, addr L.buf[L.sentinel + 1], toCopy * chrSize)
+      moveMem(addr L.buf[0], addr L.buf[L.sentinel + 1], toCopy * chrSize)
+
+  # test
   charsRead = readData(L.input, addr(L.buf[toCopy]),
                        (L.sentinel + 1) * chrSize) div chrSize
   s = toCopy + charsRead
@@ -87,10 +84,7 @@ proc fillBuffer(L: var BaseLexer) =
         # double the buffer's size and try again:
         oldBufLen = L.bufLen
         L.bufLen = L.bufLen * 2
-        when defined(js):
-          L.buf.setLen(L.bufLen)
-        else:
-          L.buf = cast[cstring](realloc(L.buf, L.bufLen * chrSize))
+        L.buf.setLen(L.bufLen)
         assert(L.bufLen - oldBufLen == oldBufLen)
         charsRead = readData(L.input, addr(L.buf[oldBufLen]),
                              oldBufLen * chrSize) div chrSize
@@ -150,10 +144,7 @@ proc open*(L: var BaseLexer, input: Stream, bufLen: int = 8192;
   L.offsetBase = 0
   L.bufLen = bufLen
   L.refillChars = refillChars
-  when defined(js):
-    L.buf = newString(bufLen)
-  else:
-    L.buf = cast[cstring](alloc(bufLen * chrSize))
+  L.buf = newString(bufLen)
   L.sentinel = bufLen - 1
   L.lineStart = 0
   L.lineNumber = 1            # lines start at 1

--- a/lib/pure/parsecsv.nim
+++ b/lib/pure/parsecsv.nim
@@ -156,44 +156,41 @@ proc open*(my: var CsvParser, filename: string,
 
 proc parseField(my: var CsvParser, a: var string) =
   var pos = my.bufpos
-  var buf = my.buf
   if my.skipWhite:
-    while buf[pos] in {' ', '\t'}: inc(pos)
+    while my.buf[pos] in {' ', '\t'}: inc(pos)
   setLen(a, 0) # reuse memory
-  if buf[pos] == my.quote and my.quote != '\0':
+  if my.buf[pos] == my.quote and my.quote != '\0':
     inc(pos)
     while true:
-      let c = buf[pos]
+      let c = my.buf[pos]
       if c == '\0':
         my.bufpos = pos # can continue after exception?
         error(my, pos, my.quote & " expected")
         break
       elif c == my.quote:
-        if my.esc == '\0' and buf[pos+1] == my.quote:
+        if my.esc == '\0' and my.buf[pos+1] == my.quote:
           add(a, my.quote)
           inc(pos, 2)
         else:
           inc(pos)
           break
       elif c == my.esc:
-        add(a, buf[pos+1])
+        add(a, my.buf[pos+1])
         inc(pos, 2)
       else:
         case c
         of '\c':
           pos = handleCR(my, pos)
-          buf = my.buf
           add(a, "\n")
         of '\l':
           pos = handleLF(my, pos)
-          buf = my.buf
           add(a, "\n")
         else:
           add(a, c)
           inc(pos)
   else:
     while true:
-      let c = buf[pos]
+      let c = my.buf[pos]
       if c == my.sep: break
       if c in {'\c', '\l', '\0'}: break
       add(a, c)

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -94,7 +94,11 @@ proc readData*(s: Stream, buffer: pointer, bufLen: int): int =
 
 proc readDataStr*(s: Stream, buffer: var string, slice: Slice[int]): int =
   ## low level proc that reads data into a string ``buffer`` at ``slice``.
-  result = s.readDataStrImpl(s, buffer, slice)
+  if s.readDataStrImpl != nil:
+    result = s.readDataStrImpl(s, buffer, slice)
+  else:
+    # fallback
+    result = s.readData(addr buffer[0], buffer.len)
 
 when not defined(js):
   proc readAll*(s: Stream): string =

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -350,20 +350,15 @@ when not defined(js):
     s.pos = clamp(pos, 0, s.data.len)
 
   proc ssGetPosition(s: Stream): int =
-    var s = (StringStream)s
+    var s = StringStream(s)
     return s.pos
 
   proc ssReadDataStr(s: Stream, buffer: var string, slice: Slice[int]): int =
-    echo "string stream read data str: "
-    echo "buflen: ", buffer.len
-    echo "slice: ", slice
     var s = StringStream(s)
     result = min(slice.b + 1 - slice.a, s.data.len - s.pos)
-    echo "result: ", result
     if result > 0:
       when nimvm:
-        # sorry, but there is no fast array string splicing on the vm.
-        for i in 0 ..< result:
+        for i in 0 ..< result: # sorry, but no fast string splicing on the vm.
           buffer[slice.a + i] = s.data[s.pos + i]
       else:
         copyMem(unsafeAddr buffer[slice.a], addr s.data[s.pos], result)
@@ -396,9 +391,6 @@ when not defined(js):
       setLen(s.data, s.pos + bufLen)
     copyMem(addr(s.data[s.pos]), buffer, bufLen)
     inc(s.pos, bufLen)
-
-
-
 
   proc ssClose(s: Stream) =
     var s = StringStream(s)

--- a/nimsuggest/sexp.nim
+++ b/nimsuggest/sexp.nim
@@ -124,9 +124,8 @@ proc handleHexChar(c: char, x: var int): bool =
 proc parseString(my: var SexpParser): TTokKind =
   result = tkString
   var pos = my.bufpos + 1
-  var buf = my.buf
   while true:
-    case buf[pos]
+    case my.buf[pos]
     of '\0':
       my.err = errQuoteExpected
       result = tkError
@@ -135,9 +134,9 @@ proc parseString(my: var SexpParser): TTokKind =
       inc(pos)
       break
     of '\\':
-      case buf[pos+1]
+      case my.buf[pos+1]
       of '\\', '"', '\'', '/':
-        add(my.a, buf[pos+1])
+        add(my.a, my.buf[pos+1])
         inc(pos, 2)
       of 'b':
         add(my.a, '\b')
@@ -157,65 +156,61 @@ proc parseString(my: var SexpParser): TTokKind =
       of 'u':
         inc(pos, 2)
         var r: int
-        if handleHexChar(buf[pos], r): inc(pos)
-        if handleHexChar(buf[pos], r): inc(pos)
-        if handleHexChar(buf[pos], r): inc(pos)
-        if handleHexChar(buf[pos], r): inc(pos)
+        if handleHexChar(my.buf[pos], r): inc(pos)
+        if handleHexChar(my.buf[pos], r): inc(pos)
+        if handleHexChar(my.buf[pos], r): inc(pos)
+        if handleHexChar(my.buf[pos], r): inc(pos)
         add(my.a, toUTF8(Rune(r)))
       else:
         # don't bother with the error
-        add(my.a, buf[pos])
+        add(my.a, my.buf[pos])
         inc(pos)
     of '\c':
       pos = lexbase.handleCR(my, pos)
-      buf = my.buf
       add(my.a, '\c')
     of '\L':
       pos = lexbase.handleLF(my, pos)
-      buf = my.buf
       add(my.a, '\L')
     else:
-      add(my.a, buf[pos])
+      add(my.a, my.buf[pos])
       inc(pos)
   my.bufpos = pos # store back
 
 proc parseNumber(my: var SexpParser) =
   var pos = my.bufpos
-  var buf = my.buf
-  if buf[pos] == '-':
+  if my.buf[pos] == '-':
     add(my.a, '-')
     inc(pos)
-  if buf[pos] == '.':
+  if my.buf[pos] == '.':
     add(my.a, "0.")
     inc(pos)
   else:
-    while buf[pos] in Digits:
-      add(my.a, buf[pos])
+    while my.buf[pos] in Digits:
+      add(my.a, my.buf[pos])
       inc(pos)
-    if buf[pos] == '.':
+    if my.buf[pos] == '.':
       add(my.a, '.')
       inc(pos)
   # digits after the dot:
-  while buf[pos] in Digits:
-    add(my.a, buf[pos])
+  while my.buf[pos] in Digits:
+    add(my.a, my.buf[pos])
     inc(pos)
-  if buf[pos] in {'E', 'e'}:
-    add(my.a, buf[pos])
+  if my.buf[pos] in {'E', 'e'}:
+    add(my.a, my.buf[pos])
     inc(pos)
-    if buf[pos] in {'+', '-'}:
-      add(my.a, buf[pos])
+    if my.buf[pos] in {'+', '-'}:
+      add(my.a, my.buf[pos])
       inc(pos)
-    while buf[pos] in Digits:
-      add(my.a, buf[pos])
+    while my.buf[pos] in Digits:
+      add(my.a, my.buf[pos])
       inc(pos)
   my.bufpos = pos
 
 proc parseSymbol(my: var SexpParser) =
   var pos = my.bufpos
-  var buf = my.buf
-  if buf[pos] in IdentStartChars:
-    while buf[pos] in IdentChars:
-      add(my.a, buf[pos])
+  if my.buf[pos] in IdentStartChars:
+    while my.buf[pos] in IdentChars:
+      add(my.a, my.buf[pos])
       inc(pos)
   my.bufpos = pos
 

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -520,3 +520,43 @@ when true:
     block test_tuple:
       doAssert $(%* (a1: 10, a2: "foo")) == """{"a1":10,"a2":"foo"}"""
       doAssert $(%* (10, "foo")) == """[10,"foo"]"""
+
+# TODO: when the issue with the limeted vm registers is solved, the
+# exact same test as above should be evaluated at compile time as
+# well, to ensure that the vm functionality won't diverge from the
+# runtime functionality. Until then, the following test should do it.
+
+static:
+  var t = parseJson("""
+    {
+      "name":"Bongo",
+      "email":"bongo@bingo.com",
+      "list": [11,7,15],
+      "year": 1975,
+      "dict": {"a": 1, "b": 2},
+      "arr": [1.0, 2.0, 7.0],
+      "person": {"name": "boney"},
+      "dog": {"name": "honey"},
+      "fruit": {"color": 10},
+      "distfruit": {"color": 11},
+      "emails": ["abc", "123"]
+    }
+  """)
+
+  doAssert t["name"].getStr == "Bongo"
+  doAssert t["email"].getStr == "bongo@bingo.com"
+  doAssert t["list"][0].getInt == 11
+  doAssert t["list"][1].getInt == 7
+  doAssert t["list"][2].getInt == 15
+  doAssert t["year"].getInt == 1975
+  doAssert t["dict"]["a"].getInt == 1
+  doAssert t["dict"]["b"].getInt == 2
+  doAssert t["arr"][0].getFloat == 1.0
+  doAssert t["arr"][1].getFloat == 2.0
+  doAssert t["arr"][2].getFloat == 7.0
+  doAssert t["person"]["name"].getStr == "boney"
+  doAssert t["distfruit"]["color"].getInt == 11
+  doAssert t["dog"]["name"].getStr == "honey"
+  doAssert t["fruit"]["color"].getInt == 10
+  doAssert t["emails"][0].getStr == "abc"
+  doAssert t["emails"][1].getStr == "123"


### PR DESCRIPTION
enable parsing of json at compile time (without even touching the json module). The implementation is done and locally it works, it just needs a test.

minor side effects:
 * kill ``chrSize`` constant. It is always 1.
 * kill a few ``when defined(js)`` branches (simpler code)
 * support down casting in the vm (``nkObjUpConv`` ¯\\\_(ツ)\_/¯)
 * the stream interface has one more proc: ``proc readDataStr*(s: Stream, buffer: var string, slice: Slice[int]): int``. This is needed because I could not find a way to implement the pointer based interface on the vm.
 * the pattern ``var buf = arg.buf`` to put the buffer of the parser into a local variable is now slow (breaking performance change).
 * parsers have been refactored to not use ``var buf = arg.buf`` anymore (js target will benefit from this).
 * even though I added a test, the total code size has been reduced by almost 50 lines.
 * other parsers should work now at compile time, too:
    - xml
    - csv
    - sql
    - rst
    - sexpr
    - pegs
    - parsecfg


This is the snippet I used for local testing (I am just posting it here to not loose it):

```nim
import json

static:
  var t = parseJson("""
    {
      "name":"Bongo",
      "email":"bongo@bingo.com",
      "list": [11,7,15],
      "year": 1975,
      "dict": {"a": 1, "b": 2},
      "arr": [1.0, 2.0, 7.0],
      "person": {"name": "boney"},
      "dog": {"name": "honey"},
      "fruit": {"color": 10},
      "distfruit": {"color": 11},
      "emails": ["abc", "123"]
    }
  """)

  doAssert t["name"].getStr == "Bongo"
  doAssert t["email"].getStr == "bongo@bingo.com"
  doAssert t["list"][0].getInt == 11
  doAssert t["list"][1].getInt == 7
  doAssert t["list"][2].getInt == 15
  doAssert t["year"].getInt == 1975
  doAssert t["dict"]["a"].getInt == 1
  doAssert t["dict"]["b"].getInt == 2
  doAssert t["arr"][0].getFloat == 1.0
  doAssert t["arr"][1].getFloat == 2.0
  doAssert t["arr"][2].getFloat == 7.0
  doAssert t["person"]["name"].getStr == "boney"
  doAssert t["distfruit"]["color"].getInt == 11
  doAssert t["dog"]["name"].getStr == "honey"
  doAssert t["fruit"]["color"].getInt == 10
  doAssert t["emails"][0].getStr == "abc"
  doAssert t["emails"][1].getStr == "123"
```

for performance testing I used [this 189,9 MB json file](https://github.com/zemirco/sf-city-lots-json/raw/master/citylots.json). The performance difference for ``parseJson`` is not measurable here (it should be mentioned though that most performance cost is to construct the tree data structure with all the pointer indirections, not actually parsing the input file).

