### PR TITLE
compiler/[main,docgen]: don't put generated doc in subfolder

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -992,7 +992,6 @@ proc writeOutputJson*(d: PDoc, useWarning = false) =
                  "\" for writing")
 
 proc commandDoc*(cache: IdentCache, conf: ConfigRef) =
-  conf.outDir = AbsoluteDir(conf.outDir / conf.outFile)
   var ast = parseFile(conf.projectMainIdx, cache, conf)
   if ast == nil: return
   var d = newDocumentor(conf.projectFull, cache, conf)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -992,6 +992,9 @@ proc writeOutputJson*(d: PDoc, useWarning = false) =
                  "\" for writing")
 
 proc commandDoc*(cache: IdentCache, conf: ConfigRef) =
+  if optWholeProject in conf.globalOptions:
+    # Backward compatibility with previous versions
+    conf.outDir = AbsoluteDir(conf.outDir / conf.outFile)
   var ast = parseFile(conf.projectMainIdx, cache, conf)
   if ast == nil: return
   var d = newDocumentor(conf.projectFull, cache, conf)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -63,6 +63,9 @@ proc commandCheck(graph: ModuleGraph) =
 
 when not defined(leanCompiler):
   proc commandDoc2(graph: ModuleGraph; json: bool) =
+    if optWholeProject in graph.config.globalOptions:
+      # Backward compatibility with previous versions
+      graph.config.outDir = AbsoluteDir(graph.config.outDir / graph.config.outFile)
     graph.config.errorMax = high(int)  # do not stop after first error
     semanticPasses(graph)
     if json: registerPass(graph, docgen2JsonPass)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -63,7 +63,6 @@ proc commandCheck(graph: ModuleGraph) =
 
 when not defined(leanCompiler):
   proc commandDoc2(graph: ModuleGraph; json: bool) =
-    graph.config.outDir = AbsoluteDir(graph.config.outDir / graph.config.outFile)
     graph.config.errorMax = high(int)  # do not stop after first error
     semanticPasses(graph)
     if json: registerPass(graph, docgen2JsonPass)


### PR DESCRIPTION
Fixes regression caused by ca4b971bc81b2e751e0388d80896fde7079b1679.

`nim doc foo.nim` will now generates `foo.html` instead of `foo/foo.html`