### PR TITLE
compiler/options: fix typo(?) in getOutFile()

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -454,7 +454,7 @@ proc setConfigVar*(conf: ConfigRef; key, val: string) =
   conf.configVars[key] = val
 
 proc getOutFile*(conf: ConfigRef; filename: RelativeFile, ext: string): AbsoluteFile =
-  result = (if conf.outFile.isEmpty: conf.projectPath else: conf.outDir) /
+  result = (if conf.outDir.isEmpty: conf.projectPath else: conf.outDir) /
             changeFileExt(filename, ext)
 
 proc absOutFile*(conf: ConfigRef): AbsoluteFile =


### PR DESCRIPTION
    nim doc --outdir:$PWD some/place/far/away/foo.nim

Should now place the resulting `foo.html` in the current folder.

/cc @zah: I'm not sure if this is correct.