### PR TITLE
Make doku of os.moveFile() more precise.

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1648,6 +1648,7 @@ proc moveFile*(source, dest: string) {.rtl, extern: "nos$1",
   ## Moves a file from `source` to `dest`.
   ##
   ## If this fails, `OSError` is raised.
+  ## If `dest` already exists, it will be overwritten.
   ##
   ## Can be used to `rename files`:idx:.
   ##


### PR DESCRIPTION
This information can prevent unintentional data loss.