### PR TITLE
Prevent certain compilation errors with `macros.newLit`

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -703,6 +703,17 @@ when compiles(float128):
     result = newNimNode(nnkFloat128Lit)
     result.floatVal = f
 
+proc newLit*(arg: enum): NimNode {.compileTime.} =
+  result = newCall(
+    arg.type.getTypeInst[1],
+    newLit(int(arg))
+  )
+
+proc newLit*[N,T](arg: array[N,T]): NimNode {.compileTime.}
+proc newLit*[T](arg: seq[T]): NimNode {.compileTime.}
+proc newLit*[T](s: set[T]): NimNode {.compileTime.}
+proc newLit*(arg: tuple): NimNode {.compileTime.}
+
 proc newLit*(arg: object): NimNode {.compileTime.} =
   result = nnkObjConstr.newTree(arg.type.getTypeInst[1])
   for a, b in arg.fieldPairs:
@@ -724,11 +735,6 @@ proc newLit*[T](arg: seq[T]): NimNode {.compileTime.} =
       getTypeInst( bindSym"T" )
     ),
     bracket
-  )
-proc newLit*(arg: enum): NimNode {.compileTime.} =
-  result = newCall(
-    arg.type.getTypeInst[1],
-    newLit(int(arg))
   )
 
 proc newLit*[T](s: set[T]): NimNode {.compileTime.} =


### PR DESCRIPTION
Unfortunately, I don't have a simple test case that demonstrates the issue, but it's easy to explain.

Notice how some of the `newLit` overloads are both generic and recursive. When you instantiate the overload for `object` for example, this may also instantiate the overload for `seq` (because a `seq` can appear as field inside an object). But notice how the opposite is also true (a `seq` will often contain objects). This leads to a compilation errors when `newLit` is used with certain complicated types. I've discovered the issue during the development of our [confutils library](https://github.com/status-im/nim-confutils).

Luckily, the the issue is easy to fix with the forward declarations I'm adding here.