### PR TITLE
Matching actual proc name

### DIFF
--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -39,7 +39,7 @@
 ##   import strutils # To use cmpIgnoreCase
 ##
 ##   proc transformHyperlinks() =
-##     let html = loadHTML("input.html")
+##     let html = loadHtml("input.html")
 ##
 ##     for a in html.findAll("a"):
 ##       if a.attrs.hasKey "href":


### PR DESCRIPTION
Not sure if this is necessary, but I think it is better to have the identifiers in examples match the actual identifiers used in the source instead of something that works but doesn't exactly match

(If this gets rejected, I'll get the message and not propose these kind of changes in the future).