### PR TITLE
compiler/extccomp: use getNimcacheDir for writing build instruction

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -969,7 +969,7 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
 
   var buf = newStringOfCap(50)
 
-  let jsonFile = conf.nimcacheDir / RelativeFile(conf.projectName & ".json")
+  let jsonFile = conf.getNimcacheDir / RelativeFile(conf.projectName & ".json")
 
   var f: File
   if open(f, jsonFile.string, fmWrite):


### PR DESCRIPTION
`conf.nimcacheDir` might be empty during build, which results in the
json build instructions being generated in the current directory. This
commit fixes the problem by using `getNimcacheDir`, which generates a
valid `nimcacheDir` should it be empty.

Fixes #10768

/cc @zah: This regression was introduced by ca4b971bc81b2e751e0388d80896fde7079b1679.
I suspect that there are more places in the compiler where the same
issue might apply.