### PR TITLE
More depth debug proc

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -415,7 +415,7 @@ proc value(this: var DebugPrinter; value: BiggestInt) =
   this.res.add value
 
 proc value[T: enum](this: var DebugPrinter; value: T) =
-  this.res.add $value
+  this.value $value
 
 proc value[T: enum](this: var DebugPrinter; value: set[T]) =
   this.openBracket


### PR DESCRIPTION
Since the ``debug`` proc is the default way for me to inspect nodes in the compiler for my debugging work, I was very frustrated with how unintuitive and inconsisted it printed out the information. So I put some effort to redesign it. The output should be understandable for someone who did not write the debug proc and does not have a lot of knowledge to use the ast.

 * Indentation is now properly fixed. Children are now always indented more than the parent.
 * consistently json (except where it can't)
 * vertical and horizontal space is used efficient.
 * no recursion depth limit anymore
 * relative line numbers on detected cycles

Last but not least, the code is now written in a consistent style so that it should be easy to modify it for custom needs. There is no one size fits all debug proc, it needs to be customizable for specific use cases.


This PR superseeds https://github.com/nim-lang/Nim/pull/10763


example output
```json
{
  "kind": "tyObject",
  "sym": {
    "kind": "skType",
    "name": "OBJECT",
    "id": 156012,
    "flags": ["sfGlobal"],
    "typ": <defined 7 lines upwards>
  },
  "flags": ["tfFinal"],
  "sons": [null],
  "n": {
    "kind": "nkRecList",
    "sons": [{
      "kind": "nkSym",
      "sym": {
        "kind": "skField",
        "name": "u",
        "id": 156016,
        "position": 0,
        "flags": ["sfExported"],
        "typ": {
          "kind": "tyObject",
          "sym": {
            "kind": "skType",
            "name": "UNION",
            "id": 156010,
            "flags": ["sfUsed", "sfGlobal"],
            "typ": <defined 7 lines upwards>
          },
          "flags": ["tfNoSideEffect", "tfFinal", "tfPacked"],
          "sons": [null],
          "n": {
            "kind": "nkRecList",
            "sons": [{
              "kind": "nkSym",
              "sym": {
                "kind": "skField",
                "name": "dwReserved1",
                "id": 156014,
                "position": 0,
                "flags": ["sfExported"],
                "typ": {
                  "kind": "tyInt",
                  "sym": {
                    "kind": "skType",
                    "name": "clong",
                    "id": 46401,
                    "flags": ["sfUsed", "sfExported", "sfGlobal", "sfImportc"],
                    "typ": <defined 7 lines upwards>
                  }
                }
              }
            }, {
              "kind": "nkSym",
              "sym": {
                "kind": "skField",
                "name": "dwReserved2",
                "id": 156015,
                "position": 1,
                "flags": ["sfExported"],
                "typ": <defined 19 lines upwards>
              }
            }]
          }
        }
      }
    }]
  }
}
```