### PR TITLE
callsite lineinfe for stackTrace template

### DIFF
--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -559,9 +559,11 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   else:
     s = semIdentVis(c, skTemplate, n.sons[0], {})
 
-  if s.owner != nil and sfSystemModule in s.owner.flags and
-      s.name.s in ["!=", ">=", ">", "incl", "excl", "in", "notin", "isnot"]:
-    incl(s.flags, sfCallsite)
+  if s.owner != nil:
+    const names = ["!=", ">=", ">", "incl", "excl", "in", "notin", "isnot"]
+    if sfSystemModule in s.owner.flags and s.name.s in names or
+       s.owner.name.s == "vm" and s.name.s == "stackTrace":
+      incl(s.flags, sfCallsite)
 
   styleCheckDef(c.config, s)
   onDef(n[0].info, s)


### PR DESCRIPTION
whenever "stackTrace" is in the stack trace, it's lineinfo was not helpful.