### PR TITLE
Make HWND a pointer instead of a cint and fix MSVC compiler warning

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -30,7 +30,7 @@ proc nimLoadLibraryError(path: string) =
     var msg: array[1000, char]
     copyMem(msg[0].addr, prefix.cstring, prefix.len)
     copyMem(msg[prefix.len].addr, path.cstring, min(path.len + 1, 1000 - prefix.len))
-    discard MessageBoxA(0, msg[0].addr, nil, 0)
+    discard MessageBoxA(nil, msg[0].addr, nil, 0)
   quit(1)
 
 proc procAddrError(name: cstring) {.compilerproc, nonReloadable, hcrInline.} =

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -28,11 +28,11 @@ when not defined(windows) or not defined(guiapp):
   proc writeToStdErr(msg: cstring) = rawWrite(cstderr, msg)
 
 else:
-  proc MessageBoxA(hWnd: cint, lpText, lpCaption: cstring, uType: int): int32 {.
+  proc MessageBoxA(hWnd: pointer, lpText, lpCaption: cstring, uType: int): int32 {.
     header: "<windows.h>", nodecl.}
 
   proc writeToStdErr(msg: cstring) =
-    discard MessageBoxA(0, msg, nil, 0)
+    discard MessageBoxA(nil, msg, nil, 0)
 
 proc showErrorMessage(data: cstring) {.gcsafe.} =
   if errorMessageWriter != nil:


### PR DESCRIPTION
In Windows, a HWND is a HANDLE which is a PVOID so a pointer in Nim: [source](https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types)

Otherwise, the MSVC compiler will complain:

```
nim\lib\system\excpt.nim(35): warning C4047: 'function': 'HWND' differs in levels of indirection from 'int'
nim\lib\system\excpt.nim(35): warning C4024: 'MessageBoxA': different types for formal and actual parameter 1
nim\lib\system\dyncalls.nim(33): warning C4047: 'function': 'HWND' differs in levels of indirection from 'int'
nim\lib\system\dyncalls.nim(33): warning C4024: 'MessageBoxA': different types for formal and actual parameter 1
```