### PR TITLE
Unuse deprecated

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -95,17 +95,8 @@ proc genLiteral(p: BProc, n: PNode): Rope =
 
 proc bitSetToWord(s: TBitSet, size: int): BiggestInt =
   result = 0
-  when true:
-    for j in countup(0, size - 1):
-      if j < len(s): result = result or `shl`(ze64(s[j]), j * 8)
-  else:
-    # not needed, too complex thinking:
-    if CPU[platform.hostCPU].endian == CPU[targetCPU].endian:
-      for j in countup(0, size - 1):
-        if j < len(s): result = result or `shl`(Ze64(s[j]), j * 8)
-    else:
-      for j in countup(0, size - 1):
-        if j < len(s): result = result or `shl`(Ze64(s[j]), (Size - 1 - j) * 8)
+  for j in 0 ..< size:
+    if j < len(s): result = result or (ze64(s[j]) shl j * 8)
 
 proc genRawSetData(cs: TBitSet, size: int): Rope =
   var frmt: FormatStr

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -96,7 +96,7 @@ proc genLiteral(p: BProc, n: PNode): Rope =
 proc bitSetToWord(s: TBitSet, size: int): BiggestInt =
   result = 0
   for j in 0 ..< size:
-    if j < len(s): result = result or (ze64(s[j]) shl j * 8)
+    if j < len(s): result = result or (ze64(s[j]) shl (j * 8))
 
 proc genRawSetData(cs: TBitSet, size: int): Rope =
   var frmt: FormatStr

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -46,9 +46,6 @@ template forwardImpl(impl, arg) {.dirty.} =
       impl(x.uint64)
 
 when defined(nimHasalignOf):
-
-  import macros
-
   type BitsRange*[T] = range[0..sizeof(T)*8-1]
     ## Returns a range with all bit positions for type ``T``
 
@@ -76,26 +73,32 @@ when defined(nimHasalignOf):
     ## Returns ``v``, with the bit at position ``bit`` flipped
     v.flipMask(1.T shl bit)
 
-  macro setBits*(v: typed, bits: varargs[typed]): untyped =
+  template setBits*(v: typed): untyped =
     ## Returns ``v``, with the bits at positions ``bits`` set to 1
-    bits.expectKind(nnkBracket)
-    result = newStmtList()
-    for bit in bits:
-      result.add newCall("setBit", v, bit)
+    discard
 
-  macro clearBits*(v: typed, bits: varargs[typed]): untyped =
-    ## Returns ``v``, with the bits at positions ``bits`` set to 0
-    bits.expectKind(nnkBracket)
-    result = newStmtList()
-    for bit in bits:
-      result.add newCall("clearBit", v, bit)
+  template setBits*(v: typed, bit: typed, bits: varargs[typed]): untyped =
+    ## Returns ``v``, with the bits at positions ``bits`` set to 1
+    setBit(v, bit)
+    setBits(v, bits)
 
-  macro flipBits*(v: typed, bits: varargs[typed]): untyped =
+  template clearBits(v: typed): untyped =
     ## Returns ``v``, with the bits at positions ``bits`` set to 0
-    bits.expectKind(nnkBracket)
-    result = newStmtList()
-    for bit in bits:
-      result.add newCall("flipBit", v, bit)
+    discard
+
+  template clearBits(v: typed; bit: typed, bits: varargs[typed]): untyped =
+    ## Returns ``v``, with the bits at positions ``bits`` set to 0
+    clearBit(v, bit)
+    clearBits(v, bits)
+
+  template flipBits(v: typed): untyped =
+    ## Returns ``v``, with the bits at positions ``bits`` set to 0
+    discard
+
+  template flipBits(v: typed; bit: typed, bits: varargs[typed]): untyped =
+    ## Returns ``v``, with the bits at positions ``bits`` set to 0
+    flipBit(v, bit)
+    flipBits(v, bits)
 
   proc testBit*[T: SomeInteger](v: T, bit: BitsRange[T]): bool {.inline.} =
     ## Returns true if the bit in ``v`` at positions ``bit`` is set to 1
@@ -121,7 +124,7 @@ proc firstSetBit_nim(x: uint64): int {.inline, nosideeffect.} =
   if k == 0:
     k = uint32(v shr 32'u32) and 0xFFFFFFFF'u32
     result = 32
-  result += firstSetBit_nim(k)
+  result = result + firstSetBit_nim(k)
 
 proc fastlog2_nim(x: uint32): int {.inline, nosideeffect.} =
   ## Quickly find the log base 2 of a 32-bit or less integer.

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -188,18 +188,16 @@ proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
   result = result or (result shr 1)
   result += 1 + ord(x<=0)
 
-proc countBits32*(n: int32): int {.noSideEffect.} =
-  ## Counts the set bits in ``n``.
+proc countBits32*(n: int32): int {.noSideEffect, deprecated.} =
+  ## **Deprecated since version v0.20.0**: Use ``bitops.countSetBits`` instead.
   runnableExamples:
     doAssert countBits32(7) == 3
     doAssert countBits32(8) == 1
     doAssert countBits32(15) == 4
     doAssert countBits32(16) == 1
     doAssert countBits32(17) == 2
-  var v = n
-  v = v -% ((v shr 1'i32) and 0x55555555'i32)
-  v = (v and 0x33333333'i32) +% ((v shr 2'i32) and 0x33333333'i32)
-  result = ((v +% (v shr 4'i32) and 0xF0F0F0F'i32) *% 0x1010101'i32) shr 24'i32
+
+  bitops.countSetBits(n)
 
 proc sum*[T](x: openArray[T]): T {.noSideEffect.} =
   ## Computes the sum of the elements in ``x``.

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -97,9 +97,9 @@ proc reprSetAux(result: var string, p: pointer, typ: PNimType) =
   add result, "{"
   var u: int64
   case typ.size
-  of 1: u = ze64(cast[ptr int8](p)[])
-  of 2: u = ze64(cast[ptr int16](p)[])
-  of 4: u = ze64(cast[ptr int32](p)[])
+  of 1: u = cast[ptr int8](p)[]
+  of 2: u = cast[ptr int16](p)[]
+  of 4: u = cast[ptr int32](p)[]
   of 8: u = cast[ptr int64](p)[]
   else:
     var a = cast[PByteArray](p)

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -95,12 +95,12 @@ proc reprSetAux(result: var string, p: pointer, typ: PNimType) =
   var elemCounter = 0  # we need this flag for adding the comma at
                        # the right places
   add result, "{"
-  var u: int64
+  var u: uint64
   case typ.size
-  of 1: u = cast[ptr int8](p)[]
-  of 2: u = cast[ptr int16](p)[]
-  of 4: u = cast[ptr int32](p)[]
-  of 8: u = cast[ptr int64](p)[]
+  of 1: u = cast[ptr uint8](p)[]
+  of 2: u = cast[ptr uint16](p)[]
+  of 4: u = cast[ptr uint32](p)[]
+  of 8: u = cast[ptr uint64](p)[]
   else:
     var a = cast[PByteArray](p)
     for i in 0 .. typ.size*8-1:
@@ -110,7 +110,7 @@ proc reprSetAux(result: var string, p: pointer, typ: PNimType) =
         inc(elemCounter)
   if typ.size <= 8:
     for i in 0..sizeof(int64)*8-1:
-      if (u and (1'i64 shl int64(i))) != 0'i64:
+      if (u and (1'u64 shl uint64(i))) != 0'u64:
         if elemCounter > 0: add result, ", "
         addSetElem(result, i+typ.node.len, typ.base)
         inc(elemCounter)

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -12,17 +12,17 @@
 type
   NimSet = array[0..4*2048-1, uint8]
 
-proc countBits32(n: int32): int {.compilerproc.} =
+proc countBits32(n: uint32): int {.compilerproc.} =
   var v = n
-  v = v -% ((v shr 1'i32) and 0x55555555'i32)
-  v = (v and 0x33333333'i32) +% ((v shr 2'i32) and 0x33333333'i32)
-  result = ((v +% (v shr 4'i32) and 0xF0F0F0F'i32) *% 0x1010101'i32) shr 24'i32
+  v = v - ((v shr 1'u32) and 0x55555555'u32)
+  v = (v and 0x33333333'u32) + ((v shr 2'u32) and 0x33333333'u32)
+  result = int(((v + (v shr 4'u32) and 0xF0F0F0F'u32) * 0x1010101'u32) shr 24'u32)
 
-proc countBits64(n: int64): int {.compilerproc.} =
-  result = countBits32(toU32(n and 0xffffffff'i64)) +
-           countBits32(toU32(n shr 32'i64))
+proc countBits64(n: uint64): int {.compilerproc.} =
+  result = countBits32(uint32(n and 0xffffffff'u64)) +
+           countBits32(uint32(n shr 32))
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
   for i in 0..<len:
     if likely(s[i] == 0): continue
-    inc(result, countBits32(int32(s[i])))
+    inc(result, countBits32(s[i]))

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -12,17 +12,15 @@
 type
   NimSet = array[0..4*2048-1, uint8]
 
-proc countBits32(n: uint32): int {.compilerproc.} =
-  var v = n
-  v = v - ((v shr 1'u32) and 0x55555555'u32)
-  v = (v and 0x33333333'u32) + ((v shr 2'u32) and 0x33333333'u32)
-  result = int(((v + (v shr 4'u32) and 0xF0F0F0F'u32) * 0x1010101'u32) shr 24'u32)
+import bitops
 
-proc countBits64(n: uint64): int {.compilerproc.} =
-  result = countBits32(uint32(n and 0xffffffff'u64)) +
-           countBits32(uint32(n shr 32))
+proc countBits32(n: int32): int {.compilerproc.} =
+  countSetBits(n)
+
+proc countBits64(n: int64): int {.compilerproc.} =
+  countSetBits(n)
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
   for i in 0..<len:
     if likely(s[i] == 0): continue
-    inc(result, countBits32(s[i]))
+    inc(result, countBits32(int32(s[i])))

--- a/lib/system/widestrs.nim
+++ b/lib/system/widestrs.nim
@@ -17,6 +17,8 @@ type
   Utf16Char* = distinct int16
   WideCString* = ref UncheckedArray[Utf16Char]
 
+proc ord*(arg: Utf16Char): int = int(cast[uint16](arg))
+
 proc len*(w: WideCString): int =
   ## returns the length of a widestring. This traverses the whole string to
   ## find the binary zero end marker!
@@ -46,7 +48,7 @@ template fastRuneAt(s: cstring, i, L: int, result: untyped, doInc = true) =
   ## `i` is incremented by the number of bytes that have been processed.
   bind ones
 
-  if ord(s[i]) <=% 127:
+  if ord(s[i]) <= 127:
     result = ord(s[i])
     when doInc: inc(i)
   elif ord(s[i]) shr 5 == 0b110:
@@ -98,20 +100,21 @@ proc newWideCString*(source: cstring, L: int): WideCString =
   #result = cast[wideCString](alloc(L * 4 + 2))
   var d = 0
   for ch in runes(source, L):
-    if ch <=% UNI_MAX_BMP:
-      if ch >=% UNI_SUR_HIGH_START and ch <=% UNI_SUR_LOW_END:
+
+    if ch <= UNI_MAX_BMP:
+      if ch >= UNI_SUR_HIGH_START and ch <= UNI_SUR_LOW_END:
         result[d] = UNI_REPLACEMENT_CHAR
       else:
-        result[d] = Utf16Char(toU16(ch))
-    elif ch >% UNI_MAX_UTF16:
+        result[d] = cast[Utf16Char](uint16(ch))
+    elif ch > UNI_MAX_UTF16:
       result[d] = UNI_REPLACEMENT_CHAR
     else:
-      let ch = ch -% halfBase
-      result[d] = Utf16Char(toU16((ch shr halfShift) +% UNI_SUR_HIGH_START))
+      let ch = ch - halfBase
+      result[d] = cast[Utf16Char](uint16((ch shr halfShift) + UNI_SUR_HIGH_START))
       inc d
-      result[d] = Utf16Char(toU16((ch and halfMask) +% UNI_SUR_LOW_START))
+      result[d] = cast[Utf16Char](uint16((ch and halfMask) + UNI_SUR_LOW_START))
     inc d
-  result[d] = Utf16Char(0'i16)
+  result[d] = Utf16Char(0)
 
 proc newWideCString*(s: cstring): WideCString =
   if s.isNil: return nil
@@ -126,11 +129,11 @@ proc `$`*(w: WideCString, estimate: int, replacement: int = 0xFFFD): string =
 
   var i = 0
   while w[i].int16 != 0'i16:
-    var ch = int(cast[uint16](w[i]))
+    var ch = ord(w[i])
     inc i
     if ch >= UNI_SUR_HIGH_START and ch <= UNI_SUR_HIGH_END:
       # If the 16 bits following the high surrogate are in the source buffer...
-      let ch2 = int(cast[uint16](w[i]))
+      let ch2 = ord(w[i])
 
       # If it's a low surrogate, convert to UTF32:
       if ch2 >= UNI_SUR_LOW_START and ch2 <= UNI_SUR_LOW_END:

--- a/lib/system/widestrs.nim
+++ b/lib/system/widestrs.nim
@@ -17,7 +17,7 @@ type
   Utf16Char* = distinct int16
   WideCString* = ref UncheckedArray[Utf16Char]
 
-proc ord*(arg: Utf16Char): int = int(cast[uint16](arg))
+proc ord(arg: Utf16Char): int = int(cast[uint16](arg))
 
 proc len*(w: WideCString): int =
   ## returns the length of a widestring. This traverses the whole string to


### PR DESCRIPTION
``Utf16Char`` should really be ``uint16``, not ``int16``. Then the casts can disappear.

I tried to remove ``ze64`` from ccgexpr, but it is currently still the "cleanest solution". The proper way to fix it would be to convert ``TBitSet`` from ``seq[int8]`` to ``seq[byte]`` ([like the comment actually says](https://github.com/nim-lang/Nim/blob/aed8766e84364360e0ed1e1e667ee735afd99e81/compiler/bitsets.nim#L14)). But that would change too much for now.

I added ```proc ord*(arg: Utf16Char): int = int(cast[uint16](arg))```, because that is used for ``char`` as well. For consistency it only makes sense to provide it. If you don't want it, I can also unexport it and leave it private.

I also normalized the declaration of ``countSetBits``. It is now declared only once.