### PR TITLE
Follow the documentation's recommendation

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -97,7 +97,8 @@ proc execProcess*(command: string,
   ## Example:
   ##
   ## .. code-block:: Nim
-  ##  let outp = execProcess("nim c -r mytestfile.nim")
+  ##  let outp = execProcess("/usr/bin/env", ["nim", "c", "-r", "mytestfile.nim"], option={})
+  ##  let outp_shell = execProcess("nim c -r mytestfile.nim")
   ##  # Note: outp may have an interleave of text from the nim compile
   ##  # and any output from mytestfile when it runs
 


### PR DESCRIPTION
The doc states "Make sure to pass options explicitly.", but the example didn't. 
Since constructing a string for the shell with appropriate quotes is non-trivial, the first example should be how to use `execProcess`  including `args`