### PR TITLE
fixes  #10807

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -1001,3 +1001,11 @@ proc iiTablePut(t: var TIITable, key, val: int) =
       swap(t.data, n)
     iiTableRawInsert(t.data, key, val)
     inc(t.counter)
+
+proc isAddrNode*(n: PNode): bool = 
+  case n.kind
+    of nkAddr, nkHiddenAddr: true
+    of nkCallKinds:
+      if n[0].kind == nkSym and n[0].sym.magic == mAddr: true
+      else: false
+    else: false

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2034,7 +2034,9 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
   case s.magic # magics that need special treatment
   of mAddr:
     checkSonsLen(n, 2, c.config)
-    result = semAddr(c, n.sons[1], s.name.s == "unsafeAddr")
+    result[0] = newSymNode(s, n[0].info)
+    result[1] = semAddrArg(c, n.sons[1], s.name.s == "unsafeAddr")
+    result.typ = makePtrType(c, result[1].typ)
   of mTypeOf:
     result = semTypeOf(c, n)
   #of mArrGet: result = semArrGet(c, n, flags)
@@ -2579,7 +2581,8 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkAddr:
     result = n
     checkSonsLen(n, 1, c.config)
-    result = semAddr(c, n.sons[0])
+    result[0] = semAddrArg(c, n.sons[0])
+    result.typ = makePtrType(c, result[0].typ)
   of nkHiddenAddr, nkHiddenDeref:
     checkSonsLen(n, 1, c.config)
     n.sons[0] = semExpr(c, n.sons[0], flags)

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -538,7 +538,7 @@ proc notNilCheck(tracked: PEffects, n: PNode, paramType: PType) =
   let paramType = paramType.skipTypesOrNil(abstractInst)
   if paramType != nil and tfNotNil in paramType.flags and
       n.typ != nil and tfNotNil notin n.typ.flags:
-    if n.kind == nkAddr:
+    if isAddrNode(n):
       # addr(x[]) can't be proven, but addr(x) can:
       if not containsNode(n, {nkDerefExpr, nkHiddenDeref}): return
     elif (n.kind == nkSym and n.sym.kind in routineKinds) or

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -763,7 +763,7 @@ proc transformCall(c: PTransf, n: PNode): PTransNode =
       add(result, a.PTransNode)
     if len(result) == 2: result = result[1]
   elif magic == mAddr:
-    result = newTransNode(nkHiddenAddr, n, 1)
+    result = newTransNode(nkAddr, n, 1)
     result[0] = n[1].PTransNode
     result = transformAddrDeref(c, result.PNode, nkDerefExpr, nkHiddenDeref)
   elif magic in {mNBindSym, mTypeOf, mRunnableExamples}:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -762,6 +762,10 @@ proc transformCall(c: PTransf, n: PNode): PTransNode =
           inc(j)
       add(result, a.PTransNode)
     if len(result) == 2: result = result[1]
+  elif magic == mAddr:
+    result = newTransNode(nkHiddenAddr, n, 1)
+    result[0] = n[1].PTransNode
+    result = transformAddrDeref(c, result.PNode, nkDerefExpr, nkHiddenDeref)
   elif magic in {mNBindSym, mTypeOf, mRunnableExamples}:
     # for bindSym(myconst) we MUST NOT perform constant folding:
     result = n.PTransNode

--- a/tests/macros/tmacrostmt.nim
+++ b/tests/macros/tmacrostmt.nim
@@ -91,14 +91,24 @@ proc fn2(x, y: float): float =
 
 proc fn3(x, y: int): bool =
   (((x and 3) div 4) or (x mod (y xor -1))) == 0 or y notin [1,2]
-  
+
+
+#------------------------------------
+# bug #10807
+proc fn_unsafeaddr(x: int): int = 
+  cast[int](unsafeAddr(x))
+
 static:
+  echo fn_unsafeaddr.repr_to_string 
   let fn1s = "proc fn1(x, y: int): int =\n  result = 2 * (x + y)\n"
   let fn2s = "proc fn2(x, y: float): float =\n  result = (y + 2 * x) / (x - y)\n"
   let fn3s = "proc fn3(x, y: int): bool =\n  result = ((x and 3) div 4 or x mod (y xor -1)) == 0 or not contains([1, 2], y)\n"
+  let fnAddr = "proc fn_unsafeaddr(x: int): int =\n  result = cast[int](unsafeAddr(x))\n"
+  
   doAssert fn1.repr_to_string == fn1s
   doAssert fn2.repr_to_string == fn2s
   doAssert fn3.repr_to_string == fn3s
+  doAssert fn_unsafeaddr.repr_to_string == fnAddr
 
 #------------------------------------
 # bug #8763


### PR DESCRIPTION
magic call to `mAddr` is now preserved till transformation stage where it is rewritten into `nkHiddenAddr`.

It is now possible to delete `nkAddr` node kind completely, let me know if you are interested in this kind of breaking change.