### PR TITLE
WIP: use a pragma to mark a function as exported (test)

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2205,7 +2205,17 @@ proc genProc(oldProc: PProc, prc: PSym): Rope =
       result.add("function $#() { return $#.apply(this, arguments); }$n" %
                  [thunkName, name])
 
-    def = "function $#($#) {$n$#$#$#$#$#" %
+    if sfDeprecated in prc.flags:
+      def = "export function $#($#) {$n$#$#$#$#$#" %
+            [ name,
+              header,
+              optionalLine(p.globals),
+              optionalLine(p.locals),
+              optionalLine(resultAsgn),
+              optionalLine(genProcBody(p, prc)),
+              optionalLine(p.indentLine(returnStmt))]
+    else:
+      def = "function $#($#) {$n$#$#$#$#$#" %
             [ name,
               header,
               optionalLine(p.globals),


### PR DESCRIPTION
I would like to use ES6 export syntax to be able to create javascript libraries 100% with Nim. I'm testing here to set the function as "export function" when marking it with a pragma, but as I'm not experienced with the nim compiler, I didn't found how to create a new pragma so I reused `{.deprecated.}`.

Could someone guide me on how to create pragmas for `export function` and `export default function`, or a hint about how to do it by other way?