### PR TITLE
Support for stmtListExpr in parser after major keywords

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,8 @@
 - it is now possible to use statement list expressions after keywords with
   indentation: raise, return, discard, yield, if, elif, case. This helps 
   parsing code produced by Nim template expansion where stmtListExpr can
-  appear in place of any expression. Example:
+  appear in place of any expression. Feature needs to be enabled with
+  switch `--experimental:exprStmtListExtensions`. Example of usage:
 ```nim
   raise 
     var e = new(Exception)

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,16 @@
   ``assert not isFalse(3)`` compiles.
 - `getImpl` on a `var` or `let` symbol will now return the full `IdentDefs`
   tree from the symbol declaration instead of just the initializer portion.
+- it is now possible to use statement list expressions after keywords with
+  indentation: raise, return, discard, yield, if, elif, case. This helps 
+  parsing code produced by Nim template expansion where stmtListExpr can
+  appear in place of any expression. Example:
+```nim
+  raise 
+    var e = new(Exception)
+    e.msg = "My Exception msg"
+    e
+```
 
 
 #### Breaking changes in the standard library

--- a/compiler/bitsets.nim
+++ b/compiler/bitsets.nim
@@ -76,7 +76,7 @@ const populationCount: array[low(int8)..high(int8), int8] = block:
     var arr: array[low(int8)..high(int8), int8]
 
     proc countSetBits(x: int8): int8 =
-      return 
+      return
         ( x and 0b00000001'i8) +
         ((x and 0b00000010'i8) shr 1) +
         ((x and 0b00000100'i8) shr 2) +

--- a/compiler/bitsets.nim
+++ b/compiler/bitsets.nim
@@ -76,8 +76,7 @@ const populationCount: array[low(int8)..high(int8), int8] = block:
     var arr: array[low(int8)..high(int8), int8]
 
     proc countSetBits(x: int8): int8 =
-      return
-        ( x and 0b00000001'i8) +
+      return ( x and 0b00000001'i8) +
         ((x and 0b00000010'i8) shr 1) +
         ((x and 0b00000100'i8) shr 2) +
         ((x and 0b00001000'i8) shr 3) +

--- a/compiler/bitsets.nim
+++ b/compiler/bitsets.nim
@@ -76,7 +76,8 @@ const populationCount: array[low(int8)..high(int8), int8] = block:
     var arr: array[low(int8)..high(int8), int8]
 
     proc countSetBits(x: int8): int8 =
-      return ( x and 0b00000001'i8) +
+      return 
+        ( x and 0b00000001'i8) +
         ((x and 0b00000010'i8) shr 1) +
         ((x and 0b00000100'i8) shr 2) +
         ((x and 0b00001000'i8) shr 3) +

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -129,6 +129,7 @@ type
     forLoopMacros,
     caseStmtMacros,
     codeReordering,
+    exprStmtListExtensions,
     compiletimeFFI,
       ## This requires building nim with `-d:nimHasLibFFI`
       ## which itself requires `nimble install libffi`, see #10150

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1301,7 +1301,7 @@ proc makeCall(n: PNode): PNode =
 proc postExprBlocks(p: var TParser, x: PNode, mode = emNormal): PNode =
   #| postExprBlocks = ':' stmt? ( IND{=} doBlock
   #|                            | IND{=} 'of' exprList ':' stmt
-  #|                            | IND{=} 'elif' expr ':' stmt
+  #|                            | IND{=} 'elif' stmtListExpr ':' stmt
   #|                            | IND{=} 'except' exprList ':' stmt
   #|                            | IND{=} 'else' ':' stmt )*
   result = x
@@ -1502,8 +1502,8 @@ proc parseReturnOrRaise(p: var TParser, kind: TNodeKind, mode = emNormal): PNode
     addSon(result, parseStmtListExpr(p, mode))
 
 proc parseIfOrWhen(p: var TParser, kind: TNodeKind): PNode =
-  #| condStmt = expr colcom stmt COMMENT?
-  #|            (IND{=} 'elif' expr colcom stmt)*
+  #| condStmt = stmtListExpr colcom stmt COMMENT?
+  #|            (IND{=} 'elif' stmtListExpr colcom stmt)*
   #|            (IND{=} 'else' colcom stmt)?
   #| ifStmt = 'if' condStmt
   #| whenStmt = 'when' condStmt
@@ -1537,9 +1537,9 @@ proc parseWhile(p: var TParser): PNode =
 proc parseCase(p: var TParser): PNode =
   #| ofBranch = 'of' exprList colcom stmt
   #| ofBranches = ofBranch (IND{=} ofBranch)*
-  #|                       (IND{=} 'elif' expr colcom stmt)*
+  #|                       (IND{=} 'elif' stmtListExpr colcom stmt)*
   #|                       (IND{=} 'else' colcom stmt)?
-  #| caseStmt = 'case' expr ':'? COMMENT?
+  #| caseStmt = 'case' stmtListExpr ':'? COMMENT?
   #|             (IND{>} ofBranches DED
   #|             | IND{=} ofBranches)
   var

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1483,7 +1483,7 @@ proc parseFromStmt(p: var TParser): PNode =
     optInd(p, a)
   #expectNl(p)
 
-proc parseReturnOrRaise(p: var TParser, kind: TNodeKind): PNode =
+proc parseReturnOrRaise(p: var TParser, kind: TNodeKind, mode = emNormal): PNode =
   #| returnStmt = 'return' optInd expr?
   #| raiseStmt = 'raise' optInd expr?
   #| yieldStmt = 'yield' optInd expr?
@@ -1499,7 +1499,7 @@ proc parseReturnOrRaise(p: var TParser, kind: TNodeKind): PNode =
     # NL terminates:
     addSon(result, p.emptyNode)
   else:
-    addSon(result, parseStmtListExpr(p))
+    addSon(result, parseStmtListExpr(p, mode))
 
 proc parseIfOrWhen(p: var TParser, kind: TNodeKind): PNode =
   #| condStmt = expr colcom stmt COMMENT?
@@ -2123,12 +2123,12 @@ proc simpleStmt(p: var TParser, mode = emNormal): PNode =
   #|            | includeStmt | commentStmt) / exprStmt) COMMENT?
   #|
   case p.tok.tokType
-  of tkReturn: result = parseReturnOrRaise(p, nkReturnStmt)
-  of tkRaise: result = parseReturnOrRaise(p, nkRaiseStmt)
-  of tkYield: result = parseReturnOrRaise(p, nkYieldStmt)
-  of tkDiscard: result = parseReturnOrRaise(p, nkDiscardStmt)
-  of tkBreak: result = parseReturnOrRaise(p, nkBreakStmt)
-  of tkContinue: result = parseReturnOrRaise(p, nkContinueStmt)
+  of tkReturn: result = parseReturnOrRaise(p, nkReturnStmt, mode)
+  of tkRaise: result = parseReturnOrRaise(p, nkRaiseStmt, mode)
+  of tkYield: result = parseReturnOrRaise(p, nkYieldStmt, mode)
+  of tkDiscard: result = parseReturnOrRaise(p, nkDiscardStmt, mode)
+  of tkBreak: result = parseReturnOrRaise(p, nkBreakStmt, mode)
+  of tkContinue: result = parseReturnOrRaise(p, nkContinueStmt, mode)
   of tkCurlyDotLe: result = parseStmtPragma(p)
   of tkImport: result = parseImport(p, nkImportStmt)
   of tkExport: result = parseImport(p, nkExportStmt)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -810,7 +810,8 @@ proc parseOperators(p: var TParser, headNode: PNode,
     var a = newNodeP(nkInfix, p)
     var opNode = newIdentNodeP(p.tok.ident, p) # skip operator:
     getTok(p)
-    optInd(p, a)
+    flexComment(p, a)
+    optPar(p)
     # read sub-expression with higher priority:
     var b = simpleExprAux(p, opPrec + leftAssoc, modeB)
     addSon(a, opNode)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1484,12 +1484,12 @@ proc parseFromStmt(p: var TParser): PNode =
   #expectNl(p)
 
 proc parseReturnOrRaise(p: var TParser, kind: TNodeKind, mode = emNormal): PNode =
-  #| returnStmt = 'return' optInd expr?
-  #| raiseStmt = 'raise' optInd expr?
-  #| yieldStmt = 'yield' optInd expr?
-  #| discardStmt = 'discard' optInd expr?
-  #| breakStmt = 'break' optInd expr?
-  #| continueStmt = 'break' optInd expr?
+  #| returnStmt = 'return' stmtListExpr?
+  #| raiseStmt = 'raise' stmtListExpr?
+  #| yieldStmt = 'yield' stmtListExpr?
+  #| discardStmt = 'discard' stmtListExpr?
+  #| breakStmt = 'break' stmtListExpr?
+  #| continueStmt = 'break' stmtListExpr?
   result = newNodeP(kind, p)
   getTok(p)
   if p.tok.tokType == tkComment:
@@ -2253,6 +2253,7 @@ proc parseStmt(p: var TParser, mode = emNormal): PNode =
           if err and p.tok.tokType == tkEof: break
 
 proc parseStmtListExpr(p: var TParser, mode = emNormal): PNode =
+  #| stmtListExpr = (IND{>} stmt) / expr
   if p.tok.indent > p.currInd:
     result = parseStmt(p, mode)
     result.kind = nkStmtListExpr

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -2254,7 +2254,8 @@ proc parseStmt(p: var TParser, mode = emNormal): PNode =
 
 proc parseStmtListExpr(p: var TParser, mode = emNormal): PNode =
   #| stmtListExpr = (IND{>} stmt) / expr
-  if p.tok.indent > p.currInd:
+  if exprStmtListExtensions in p.lex.config.features and 
+       p.tok.indent > p.currInd:
     result = parseStmt(p, mode)
     result.kind = nkStmtListExpr
     if result.len == 1:

--- a/tests/macros/ttryparseexpr.nim
+++ b/tests/macros/ttryparseexpr.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: '''Error: invalid indentation 45'''
+  outputsub: '''Error: expression expected, but found '[EOF]' -- 45'''
 """
 
 # feature request #1473
@@ -9,6 +9,7 @@ macro test(text: string): untyped =
   try:
     result = parseExpr(text.strVal)
   except ValueError:
+    echo text
     result = newLit getCurrentExceptionMsg()
 
 const
@@ -17,4 +18,4 @@ const
   b = test("valid")
   c = test("\"") # bug #2504
 
-echo a, " ", b
+echo a, " -- ", b

--- a/tests/parser/tstmtlist_expr.nim
+++ b/tests/parser/tstmtlist_expr.nim
@@ -40,4 +40,6 @@ proc d(x: int): int =
     y > 0:
       return y
 
-  
+##issue 4035
+echo(5 +
+5)

--- a/tests/parser/tstmtlist_expr.nim
+++ b/tests/parser/tstmtlist_expr.nim
@@ -1,0 +1,43 @@
+proc xx(a: int): int = 
+  let y = 0
+  return
+    var x = 0
+    x + y
+
+proc b(x: int): int = 
+  raise 
+    var e: ref Exception
+    new(e)
+    e.msg = "My Exception msg"
+    e
+
+proc c(x: int): int = 
+  if 
+    ## "a comment, this block mimics the template expansion"
+    let y = x + 2
+    y > 0:
+      return y
+  elif    
+    ## "a comment, this block mimics the template expansion"
+    let y = x + 2
+    y > 0:
+      return y
+  
+
+proc d(x: int): int = 
+  case 
+    ## "a comment, this block mimics the template expansion"
+    let y = x + 2
+    y > 0:
+  
+  of true: result = 2 # comment
+  of false:
+    let z = x - 2 
+    result = z
+  elif    
+    ## "a comment, this block mimics the template expansion"
+    let y = x + 2
+    y > 0:
+      return y
+
+  

--- a/tests/parser/tstmtlist_expr.nim
+++ b/tests/parser/tstmtlist_expr.nim
@@ -1,3 +1,7 @@
+discard """
+  output: '''10'''
+"""
+
 proc xx(a: int): int = 
   let y = 0
   return

--- a/tests/parser/tstmtlist_expr.nims
+++ b/tests/parser/tstmtlist_expr.nims
@@ -1,0 +1,2 @@
+
+switch("experimental", "exprStmtListExtensions")

--- a/tests/parser/tstmtlist_expr.nims
+++ b/tests/parser/tstmtlist_expr.nims
@@ -1,2 +1,1 @@
-
-#switch("experimental", "exprStmtListExtensions")
+switch("experimental", "exprStmtListExtensions")

--- a/tests/parser/tstmtlist_expr.nims
+++ b/tests/parser/tstmtlist_expr.nims
@@ -1,2 +1,2 @@
 
-switch("experimental", "exprStmtListExtensions")
+#switch("experimental", "exprStmtListExtensions")


### PR DESCRIPTION
Support for stmtListExpr in parser after keywords. Makes parser and renderer closer to each other. Allows parsing code rendered after template expansion that produces nkStmtListExpr 

~~The change is not 100% backwards compatible, but is 99.9% compatible ;).~~
With added fix for #4035 managed to get full compatibility.
