### PR TITLE
fixes #10838

### DIFF
--- a/tests/proc/tfunc_type.nim
+++ b/tests/proc/tfunc_type.nim
@@ -1,6 +1,6 @@
 
 discard """
-  errmsg: "type mismatch: got <proc (a: int): int{.gcsafe, locks: 0.}> but expected 'proc (a: int): int{.closure, noSideEffect.}"
+  errmsg: "func keyword is not allowed in type descriptions, use proc with {.noSideEffect.} pragma instead"
 """
 
 type

--- a/tests/proc/tfunc_type.nim
+++ b/tests/proc/tfunc_type.nim
@@ -1,0 +1,14 @@
+
+discard """
+  errmsg: "type mismatch: got <proc (a: int): int{.gcsafe, locks: 0.}> but expected 'proc (a: int): int{.closure, noSideEffect.}"
+"""
+
+type
+  MyObject = object
+    fn: func(a: int): int
+
+proc myproc(a: int): int =
+  echo "bla"
+  result = a
+
+var x = MyObject(fn: myproc)


### PR DESCRIPTION
The node `nkFuncTy` does not exist hence it can be used here. As far as I got, it is intentional not to have `nkFuncTy`. The solution is to add `{.noSideEffect.}` pragma in this case.
