### PR TITLE
fixes #10857 invisible span had width

### DIFF
--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -50,7 +50,7 @@ $seeSrc
 # See doc.item for available substitution variables.
 doc.item.toc = """
   <li><a class="reference" href="#$itemSymOrIDEnc"
-    title="$header_plain">$name<span class="attachedType" style="visibility:hidden">$attype</span></a></li>
+    title="$header_plain">$name<span class="attachedType">$attype</span></a></li>
 """
 
 # HTML rendered for doc.item's seeSrc variable. Note that this will render to
@@ -949,6 +949,10 @@ span.pragmawrap {
   display: none;
 }
 
+span.attachedType {
+  display: none;
+  visibility: hidden;
+}
 </style>
 
 <script type="text/javascript" src="dochack.js"></script>

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.html
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.html
@@ -761,6 +761,10 @@ span.pragmawrap {
   display: none;
 }
 
+span.attachedType {
+  display: none;
+  visibility: hidden;
+}
 </style>
 
 <script type="text/javascript" src="dochack.js"></script>
@@ -812,7 +816,7 @@ function main() {
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#SomeType"
     title="SomeType = enum
-  enumValueA, enumValueB, enumValueC"><wbr />Some<wbr />Type<span class="attachedType" style="visibility:hidden"></span></a></li>
+  enumValueA, enumValueB, enumValueC"><wbr />Some<wbr />Type<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -820,7 +824,7 @@ function main() {
   <a class="reference reference-toplevel" href="#12" id="62">Procs</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#someType_2"
-    title="someType(): SomeType"><wbr />some<wbr />Type<span class="attachedType" style="visibility:hidden">SomeType</span></a></li>
+    title="someType(): SomeType"><wbr />some<wbr />Type<span class="attachedType">SomeType</span></a></li>
 
   </ul>
 </li>
@@ -828,9 +832,9 @@ function main() {
   <a class="reference reference-toplevel" href="#18" id="68">Templates</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#aEnum.t"
-    title="aEnum(): untyped"><wbr />a<wbr />Enum<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="aEnum(): untyped"><wbr />a<wbr />Enum<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#bEnum.t"
-    title="bEnum(): untyped"><wbr />b<wbr />Enum<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="bEnum(): untyped"><wbr />b<wbr />Enum<span class="attachedType"></span></a></li>
 
   </ul>
 </li>

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -761,6 +761,10 @@ span.pragmawrap {
   display: none;
 }
 
+span.attachedType {
+  display: none;
+  visibility: hidden;
+}
 </style>
 
 <script type="text/javascript" src="dochack.js"></script>
@@ -813,10 +817,10 @@ function main() {
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#A"
     title="A {.inject.} = enum
-  aA"><wbr />A<span class="attachedType" style="visibility:hidden"></span></a></li>
+  aA"><wbr />A<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#B"
     title="B {.inject.} = enum
-  bB"><wbr />B<span class="attachedType" style="visibility:hidden"></span></a></li>
+  bB"><wbr />B<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -824,7 +828,7 @@ function main() {
   <a class="reference reference-toplevel" href="#8" id="58">Vars</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#aVariable"
-    title="aVariable: array[1, int]"><wbr />a<wbr />Variable<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="aVariable: array[1, int]"><wbr />a<wbr />Variable<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -832,9 +836,9 @@ function main() {
   <a class="reference reference-toplevel" href="#12" id="62">Procs</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#bar%2CT%2CT"
-    title="bar[T](a, b: T): T"><wbr />bar<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="bar[T](a, b: T): T"><wbr />bar<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#isValid%2CT"
-    title="isValid[T](x: T): bool"><wbr />is<wbr />Valid<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="isValid[T](x: T): bool"><wbr />is<wbr />Valid<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -842,7 +846,7 @@ function main() {
   <a class="reference reference-toplevel" href="#13" id="63">Funcs</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#someFunc"
-    title="someFunc()"><wbr />some<wbr />Func<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="someFunc()"><wbr />some<wbr />Func<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -850,7 +854,7 @@ function main() {
   <a class="reference reference-toplevel" href="#17" id="67">Macros</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#bar.m"
-    title="bar(): untyped"><wbr />bar<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="bar(): untyped"><wbr />bar<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -858,7 +862,7 @@ function main() {
   <a class="reference reference-toplevel" href="#18" id="68">Templates</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#foo.t%2CSomeType%2CSomeType"
-    title="foo(a, b: SomeType)"><wbr />foo<span class="attachedType" style="visibility:hidden"></span></a></li>
+    title="foo(a, b: SomeType)"><wbr />foo<span class="attachedType"></span></a></li>
 
   </ul>
 </li>

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -761,6 +761,10 @@ span.pragmawrap {
   display: none;
 }
 
+span.attachedType {
+  display: none;
+  visibility: hidden;
+}
 </style>
 
 <script type="text/javascript" src="dochack.js"></script>


### PR DESCRIPTION
The explicit style on the span.attachedType used in the toc was
removed. The included style sheet extended for this tag+class
with both the original visibility:hidden as well as display:none
to solve the issue.

Expected output files were update to reflect this change.