### PR TITLE
Snippet fix

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -159,7 +159,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
       # Make sure the destination directory exists
       createDir(outp.splitFile.dir)
       # Include the current file if we're parsing a nim file
-      let importStmt = if d.isPureRst: "" else: "import \"$1\"\n" % [d.filename]
+      let importStmt = if d.isPureRst: "" else: "import \"$1\"\n" % [d.filename.replace("\\", "/")]
       writeFile(outp, importStmt & content)
       let c = if cmd.startsWith("nim "): os.getAppFilename() & cmd.substr(3)
               else: cmd


### PR DESCRIPTION
Nightlies have been failing due to an issue with `:test:` in `code-block`.

On Windows, it fails because the import path contains `\`.

```nim
import "C:\Users\gt\Desktop\DL\programming\nimdevel\lib\pure\htmlparser.nim"
```

`htmlparsers.nim` is the only one using `:test:` since the last commit.