### PR TITLE
docgen: generate pragma after generic, fixes #10792

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1217,8 +1217,14 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     else:
       put(g, tkDistinct, "distinct")
   of nkTypeDef:
-    gsub(g, n, 0)
-    gsub(g, n, 1)
+    if n.sons[0].kind == nkPragmaExpr:
+      # generate pragma after generic
+      gsub(g, n.sons[0], 0)
+      gsub(g, n, 1)
+      gsub(g, n.sons[0], 1)
+    else:
+      gsub(g, n, 0)
+      gsub(g, n, 1)
     put(g, tkSpaces, Space)
     if n.len > 2 and n.sons[2].kind != nkEmpty:
       putWithSpace(g, tkEquals, "=")


### PR DESCRIPTION
Types which have pragmas have the following AST so it is necessary to break the first son in two parts:

```
  TypeSection
    TypeDef
      PragmaExpr
        Postfix
          Ident "*"
          Ident "Foo"
        Pragma
          Ident "bycopy"
      GenericParams
        IdentDefs
          Ident "T"
          Ident "U"
          Empty
          Empty
      ObjectTy
        Empty
        Empty
        RecList
          IdentDefs
            Ident "x"
            Ident "int"
            Empty
```