### PR TITLE
increase VM limit

### DIFF
--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -17,7 +17,7 @@ const
   byteExcess* = 128 # we use excess-K for immediates
   wordExcess* = 32768
 
-  MaxLoopIterations* = 3_000_000 # max iterations of all loops
+  MaxLoopIterations* = 10_000_000 # max iterations of all loops
 
 
 type


### PR DESCRIPTION
Updated to the latest Nim and started to hit this limit.  No changes in macros.
I couldn't find any regressions. Our macros analyse the full function call tree all the way to magic primitives, looks like internals of stdlib became more complicated hence deeper levels of recursion are required for our macros.