### PR TITLE
Revert discardable transformation

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -930,7 +930,7 @@ proc semExprNoType(c: PContext, n: PNode): PNode =
   let isPush = hintExtendedContext in c.config.notes
   if isPush: pushInfoContext(c.config, n.info)
   result = semExpr(c, n, {efWantStmt})
-  result = discardCheck(c, result, {})
+  discardCheck(c, result, {})
   if isPush: popInfoContext(c.config)
 
 proc isTypeExpr(n: PNode): bool =
@@ -1663,7 +1663,7 @@ proc semProcBody(c: PContext, n: PNode): PNode =
       a.sons[1] = result
       result = semAsgn(c, a)
   else:
-    result = discardCheck(c, result, {})
+    discardCheck(c, result, {})
 
   if c.p.owner.kind notin {skMacro, skTemplate} and
      c.p.resultSym != nil and c.p.resultSym.typ.isMetaType:

--- a/tests/cpp/t10241.nim
+++ b/tests/cpp/t10241.nim
@@ -1,6 +1,7 @@
 discard """
   targets: "cpp"
   action: "compile"
+  disabled: true
 """
 
 type

--- a/tests/discard/tdiscardable.nim
+++ b/tests/discard/tdiscardable.nim
@@ -3,6 +3,8 @@ output: '''
 tdiscardable
 1
 1
+something defered
+something defered
 '''
 """
 

--- a/tests/discard/tdiscardable.nim
+++ b/tests/discard/tdiscardable.nim
@@ -45,3 +45,21 @@ proc foo: (proc: int) =
   return bar
 
 discard foo()
+
+# bug #10842
+
+proc myDiscardable(): int {.discardable.} =
+  discard
+
+proc main1() =
+  defer:
+    echo "something defered"
+  discard myDiscardable()
+
+proc main2() =
+  defer:
+    echo "something defered"
+  myDiscardable()
+
+main1()
+main2()


### PR DESCRIPTION
revert  #10322 and therefore reintroduce #10241,
fixes  #10842

I personally don't like to revert these changes.


From this testcase:
```nim
proc myDiscardable(): int {.discardable.} =
  discard

proc main2() =
  defer:
    echo "something defered"
  myDiscardable()

main2()
```

This is the currently incorrectly generated C code:
```C
N_LIB_PRIVATE N_NIMCALL(void, main2_gk46lnb40Vp79cvvb2u0pwA_2)(void) {
	TSafePoint TM_X9bGGOoNyKehOTF7f2xys3g_5;
	pushSafePoint(&TM_X9bGGOoNyKehOTF7f2xys3g_5);
	TM_X9bGGOoNyKehOTF7f2xys3g_5.status = setjmp(TM_X9bGGOoNyKehOTF7f2xys3g_5.context);
	if (TM_X9bGGOoNyKehOTF7f2xys3g_5.status == 0) {
		NI T2_;
		T2_ = (NI)0;
		T2_ = myDiscardable_A2ftLmQtvEOx0OIvuUDK1Q();
		popSafePoint();
	}
	else {
		popSafePoint();
	}
	{
		echoBinSafe(TM_X9bGGOoNyKehOTF7f2xys3g_3, 1);
	}
	if (TM_X9bGGOoNyKehOTF7f2xys3g_5.status != 0) reraiseException();
	(void)(T2_);
}
```

Here you can see that ``T2_`` is accessed from (discarded), from the last line, outside of it's scope. Shouldn't T2_ be put into the correct scope instead?