### PR TITLE
Add OpenMP overload with stepping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,8 @@
   the change is transparent, if you used annotations you will have to prefix
   your previous annotations with `parallel for`.
 
+  Furthermore, an overload with positive stepping is available.
+
 - The `unchecked` pragma was removed, instead use `system.UncheckedArray`.
 
 - The undocumented ``#? strongSpaces`` parsing mode has been removed.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2681,6 +2681,24 @@ iterator `||`*[S, T](a: S, b: T, annotation: static string = "parallel for"): T 
   ## and GC.
   discard
 
+iterator `||`*[S, T](a: S, b: T, step: Positive, annotation: static string = "parallel for"): T {.
+  inline, magic: "OmpParFor", sideEffect.} =
+  ## OpenMP parallel loop iterator with stepping.
+  ## Same as `countup` but the loop may run in parallel.
+  ##
+  ## `annotation` is an additional annotation for the code generator to use.
+  ## The default annotation is `parallel for`.
+  ## Please refer to the `OpenMP Syntax Reference
+  ## <https://www.openmp.org/wp-content/uploads/OpenMP-4.5-1115-CPP-web.pdf>`_
+  ## for further information.
+  ##
+  ## Note that the compiler maps that to
+  ## the ``#pragma omp parallel for`` construct of `OpenMP`:idx: and as
+  ## such isn't aware of the parallelism in your code! Be careful! Later
+  ## versions of ``||`` will get proper support by Nim's code generator
+  ## and GC.
+  discard
+
 {.push stackTrace:off.}
 proc min*(x, y: int): int {.magic: "MinI", noSideEffect.} =
   if x <= y: x else: y


### PR DESCRIPTION
Following our discussion on IRC, this adds an overload with parallel `countup` functionality using OpenMP.

Unfortunately testing OpenMP is tricky due to:
  - non-deterministic behaviour
  - stacktraces/string allocation in OpenMP threads will crash the program

Though we can probably test that the serial version compiles and gives the proper output, we just need to not pass `--passC:-fopenmp --passL:-fopenmp` to the compiler.

Example program:

```Nim
const str = [
  "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"
]

for i in `||`(0, 9):
  echo str[i]

for i in `||`(0, 9, 3):
  echo str[i]
```

Compile with
```
../Nim/bin/nim c -r -d:release --passC:-fopenmp --passL:-fopenmp -o:build/omp_block build/omp_block.nim
```

C code
```C
N_LIB_PRIVATE N_NIMCALL(void, NimMainModule)(void) {
{
	NI i;
	NI i_2;
	
#pragma omp parallel for
for (i = ((NI) 0); i <= ((NI) 9); ++i)	{
		tyArray_nHXaesL0DJZHyVS07ARPRA T2_;
		nimZeroMem((void*)T2_, sizeof(tyArray_nHXaesL0DJZHyVS07ARPRA));
		T2_[0] = copyString(str_gwp5UYlaLWqTtc0to5ZByA[(i)- 0]);
		echoBinSafe(T2_, 1);
	}
	
#pragma omp parallel for
for (i_2 = ((NI) 0); i_2 <= ((NI) 9); i_2 += ((NI) 3))	{
		tyArray_nHXaesL0DJZHyVS07ARPRA T4_;
		nimZeroMem((void*)T4_, sizeof(tyArray_nHXaesL0DJZHyVS07ARPRA));
		T4_[0] = copyString(str_gwp5UYlaLWqTtc0to5ZByA[(i_2)- 0]);
		echoBinSafe(T4_, 1);
	}
}
}
```
