### PR TITLE
improvements on the hot code reloading support

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -187,10 +187,11 @@ proc genPrefixCall(p: BProc, le, ri: PNode, d: var TLoc) =
   for i in countup(1, length - 1):
     genParamLoop(params)
   var callee = rdLoc(op)
-  let s = ri.sons[0].sym
-  if p.hcrOn and s.flags * {sfImportc, sfNonReloadable} == {} and
-      (s.typ.callConv == ccInline or s.owner.id == p.module.module.id):
-    callee = callee & "_actual"
+  if p.hcrOn and ri.sons[0].kind == nkSym:
+    let s = ri.sons[0].sym
+    if s.flags * {sfImportc, sfNonReloadable} == {} and
+        (s.typ.callConv == ccInline or s.owner.id == p.module.module.id):
+      callee = callee & "_actual"
   fixupCall(p, le, ri, d, callee, params)
 
 proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -186,7 +186,12 @@ proc genPrefixCall(p: BProc, le, ri: PNode, d: var TLoc) =
   var length = sonsLen(ri)
   for i in countup(1, length - 1):
     genParamLoop(params)
-  fixupCall(p, le, ri, d, rdLoc(op), params)
+  var callee = rdLoc(op)
+  let s = ri.sons[0].sym
+  if p.hcrOn and s.flags * {sfImportc, sfNonReloadable} == {} and
+      (s.typ.callConv == ccInline or s.owner.id == p.module.module.id):
+    callee = callee & "_actual"
+  fixupCall(p, le, ri, d, callee, params)
 
 proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -706,6 +706,8 @@ proc cgsym(m: BModule, name: string): Rope =
     # we're picky here for the system module too:
     rawMessage(m.config, errGenerated, "system module needs: " & name)
   result = sym.loc.r
+  if m.hcrOn and sym != nil and sym.kind in skProc..skIterator:
+    result.addActualPrefixForHCR(m.module, sym)
 
 proc generateHeaders(m: BModule) =
   add(m.s[cfsHeaders], "\L#include \"nimbase.h\"\L")

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -494,6 +494,10 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if conf.hcrOn:
       defineSymbol(conf.symbols, "hotcodereloading")
       defineSymbol(conf.symbols, "useNimRtl")
+      # hardcoded linking with dynamic runtime for MSVC for smaller binaries
+      # should do the same for all compilers (wherever applicable)
+      if conf.cCompiler == ccVcc:
+        extccomp.addCompileOptionCmd(conf, "/MD")
     else:
       undefSymbol(conf.symbols, "hotcodereloading")
       undefSymbol(conf.symbols, "useNimRtl")

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -496,7 +496,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       defineSymbol(conf.symbols, "useNimRtl")
       # hardcoded linking with dynamic runtime for MSVC for smaller binaries
       # should do the same for all compilers (wherever applicable)
-      if conf.cCompiler == ccVcc:
+      if isVSCompatible(conf):
         extccomp.addCompileOptionCmd(conf, "/MD")
     else:
       undefSymbol(conf.symbols, "hotcodereloading")

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -843,7 +843,7 @@ proc hcrLinkTargetName(conf: ConfigRef, objFile: string, isMain = false): Absolu
   let basename = splitFile(objFile).name
   let targetName = if isMain: basename & ".exe"
                    else: platform.OS[conf.target.targetOS].dllFrmt % basename
-  result = conf.nimcacheDir / RelativeFile(targetName)
+  result = conf.getNimcacheDir / RelativeFile(targetName)
 
 proc callCCompiler*(conf: ConfigRef) =
   var

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -734,8 +734,9 @@ proc getLinkCmd(conf: ConfigRef; output: AbsoluteFile,
     # way of being able to debug and rebuild the program at the same time. This
     # is accomplished using the /PDB:<filename> flag (there also exists the
     # /PDBALTPATH:<filename> flag). The only downside is that the .pdb files are
-    # atleast 5-10mb big and will quickly accumulate. There is a hacky solution:
-    # we could try to delete all .pdb files with a pattern and swallow exceptions.
+    # atleast 300kb big (when linking statically to the runtime - or else 5mb+) 
+    # and will quickly accumulate. There is a hacky solution: we could try to
+    # delete all .pdb files with a pattern and swallow exceptions.
     #
     # links about .pdb files and hot code reloading:
     # https://ourmachinery.com/post/dll-hot-reloading-in-theory-and-practice/

--- a/lib/nimhcr.nim
+++ b/lib/nimhcr.nim
@@ -105,13 +105,12 @@
 #   - the handlers for a reloaded module are always removed when reloading and then
 #     registered when the top-level scope is executed (thanks to `executeOnReload`)
 #
-# TODO - after first merge in upstream Nim:
+# TODO next:
 #
-# - profile
-#   - build speed with and without hot code reloading - difference should be small
-#   - runtime degradation of HCR-enabled code - important!!!
+# - implement the before/after handlers and hasModuleChanged for the javascript target
 # - ARM support for the trampolines
 # - investigate:
+#   - soon the system module might be importing other modules - the init order...?
 #   - rethink the closure iterators
 #     - ability to keep old versions of dynamic libraries alive
 #       - because of async server code
@@ -132,7 +131,7 @@
 #     - currently building with useNimRtl is problematic - lots of problems...
 #     - how to supply the nimrtl/nimhcr shared objects to all test binaries...?
 #     - think about building to C++ instead of only to C - added type safety
-#   - run tests through valgrind and the sanitizers! of HUGE importance!
+#   - run tests through valgrind and the sanitizers!
 #
 # TODO - nice to have cool stuff:
 #
@@ -148,7 +147,6 @@
 # - pragma annotations for files - to be excluded from dll shenanigans
 #   - for such file-global pragmas look at codeReordering or injectStmt
 #   - how would the initialization order be kept? messy...
-#   - per function exclude pragmas would be TOO messy and hard...
 # - C code calling stable exportc interface of nim code (for bindings)
 #   - generate proxy functions with the stable names
 #     - in a non-reloadable part (the main binary) that call the function pointers
@@ -160,9 +158,18 @@
 #   - issue an error
 #     - or let the user handle this by transferring the state properly
 #       - perhaps in the before/afterCodeReload handlers
-# - optimization: calls to procs within a module (+inlined) to use the _actual versions
 # - implement executeOnReload for global vars too - not just statements (and document!)
 # - cleanup at shutdown - freeing all globals
+# - fallback mechanism if the program crashes (the program should detect crashes
+#   by itself using SEH/signals on Windows/Unix) - should be able to revert to
+#   previous versions of the .dlls by calling some function from HCR
+# - improve runtime performance - possibilities
+#   - implement a way for multiple .nim files to be bundled into the same dll
+#     and have all calls within that domain to use the "_actual" versions of
+#     procs so there are no indirections (or the ability to just bundle everything
+#     except for a few unreloadable modules into a single mega reloadable dll)
+#   - try to load the .dlls at specific addresses of memory (close to each other)
+#     allocated with execution flags - check this: https://github.com/fancycode/MemoryModule
 #
 # TODO - unimportant:
 #

--- a/lib/system/timers.nim
+++ b/lib/system/timers.nim
@@ -8,7 +8,7 @@
 #
 
 ## Timer support for the realtime GC. Based on
-## `<https://github.com/jckarter/clay/blob/master/compiler/src/hirestimer.cpp>`_
+## `<https://github.com/jckarter/clay/blob/master/compiler/hirestimer.cpp>`_
 
 type
   Ticks = distinct int64

--- a/tests/dll/nimhcr_integration.nim
+++ b/tests/dll/nimhcr_integration.nim
@@ -72,7 +72,7 @@ done
 ## executing:
 ##   <this_file>.exe nim c --hotCodeReloading:on --nimCache:<folder> <this_file>.nim
 
-import os, osproc, times, strutils, hotcodereloading
+import os, osproc, strutils, hotcodereloading
 
 import nimhcr_0 # getInt() - the only thing we continually call from the main module
 


### PR DESCRIPTION
there are 3 things in this PR:
- within a module the "_actual" functions are called directly instead of going through an indirection through a function pointer & a trampoline - this increases runtime performance by at least 20% or much more - depending on the software/platform
- dynamically linking to the Visual Studio runtime so each .dll for each module does not contain a statically linked runtime - .pdb files drop in size from 6mb to 300kb and the .dll files drop significantly to well below 100kb as well
- fixed a bug with the output directories for the .dll files when HCR is on