### PR TITLE
Btree

### DIFF
--- a/compiler/btrees.nim
+++ b/compiler/btrees.nim
@@ -134,6 +134,13 @@ proc contains*[Key, Val](n: BTree[Key, Val], key: Key): bool =
   assert(not x.isInternal)
   return findValue(x.keys, x.entries, key) >= 0
 
+
+# for bootstrapping it can happen that ``default`` doesn't exist yet.
+when not defined(nimHasDefault):
+  template default(T: typedesc): untyped =
+    var tmp: T
+    tmp
+
 proc split[Key, Val](h: Node[Key, Val]): Node[Key, Val] =
   ## modifiy h, to be half the size. Returns a node with the other half.
   result = Node[Key, Val](entries: Mhalf, isInternal: h.isInternal)

--- a/compiler/btrees.nim
+++ b/compiler/btrees.nim
@@ -330,7 +330,7 @@ when isMainModule:
       var t2 = initTable[int, string]()
       var keys: seq[int]
 
-      for i in 0 ..< 1_000_000:
+      for i in 0 ..< 100_000:
         var x = rand(high(int))
         while t2.hasKey(x):
           x = rand(high(int))

--- a/compiler/btrees.nim
+++ b/compiler/btrees.nim
@@ -11,7 +11,7 @@
 ## Nim compiler's needs.
 
 const
-  M = 32    # max children per B-tree node = M-1
+  M = 512   # max children per B-tree node = M-1
             # (must be even and greater than 2)
   Mhalf = M div 2
 
@@ -30,6 +30,24 @@ type
     root: Node[Key, Val]
     entries: int      ## number of key-value pairs
 
+proc toString[Key, Val](h: Node[Key, Val], indent: string; result: var string) =
+  if not h.isInternal:
+    for j in 0..<h.entries:
+      result.add(indent)
+      result.add($h.keys[j] & " " & $h.vals[j] & "\n")
+  else:
+    for j in 0..<h.entries:
+      result.add(indent & "(" & $h.keys[j] & ")\n")
+      toString(h.links[j], indent & "   ", result)
+
+proc `$`[Key, Val](n: Node[Key, Val]): string =
+  result = ""
+  toString(n, "", result)
+
+proc `$`[Key, Val](b: BTree[Key, Val]): string =
+  result = ""
+  toString(b.root, "", result)
+
 proc newlineAndIndent(result: var string, indentation: int) =
   result.add "\n"
   for i in 0 ..< indentation:
@@ -47,45 +65,44 @@ proc indexFormat(arg: int): string =
   result.setLen(5)
   discard c_snprintf(cstring(result[0].addr), 6, "[%3d]", int32(arg))
 
-proc debugWrite[Key, Val](result: var string; n: Node[Key, Val], indentation: int) =
-  result.addNamedValue("entries", n.entries, indentation)
-  result.newlineAndIndent(indentation)
-  result.add "keys: "
-  for i in 0 ..< n.entries:
-    result.addNamedValue(indexFormat(i), n.keys[i], indentation + 1)
-  result.newlineAndIndent(indentation)
-  if n.isInternal:
-    result.add "links:"
-    for i in 0 ..< n.entries:
-      result.debugWrite(n.links[i], indentation + 1)
-  else:
-    result.add "vals:"
-    for i in 0 ..< n.entries:
-
-      result.addNamedValue(indexFormat(i), n.vals[i], indentation + 1)
-
-proc debug(b: BTree): string =
-  result.add "entries: "
-  result.add b.entries
-  result.add "root:"
-  debugWrite(result, b.root, 1)
-
 proc initBTree*[Key, Val](): BTree[Key, Val] =
   discard
 
 template less(a, b): bool = cmp(a, b) < 0
 template eq(a, b): bool = cmp(a, b) == 0
 
-proc findWithCmp[T](arg: openarray[T]; entries: int; value: T): int =
+proc findLinearWithCmp[T](arg: openarray[T]; entries: int; value: T): int =
   for i in 0 ..< entries:
     if eq(arg[i], value):
       return i
   return -1
 
-proc myDebug(): void {.exportc.} =
-  discard
+proc findValue[T](values: openarray[T]; entries: int; value: T): int =
+  # let expected = findLinearWithCmp(values, entries, value)
 
-proc findKey[T](keys: openarray[T]; entries: int; key: T): int =
+  if less(value, values[0]):
+    #doAssert expected == -1
+    return -1
+  if less(values[entries-1], value):
+    #doAssert expected == -1
+    return -1
+
+  var a = 0
+  var b = entries-1
+  while a != b:
+    let mid = (a + b) div 2
+    if cmp(value, values[mid]) <= 0:
+      b = mid
+    else:
+      a = mid + 1
+  if eq(values[a], value):
+    result = a
+  else:
+    result = -1
+
+  #doAssert result == expected
+
+proc findKeyLinear[T](keys: openarray[T]; entries: int; key: T): int =
   if entries == 0 or less(key, keys[0]):
     return -1
   var i = 1
@@ -94,6 +111,19 @@ proc findKey[T](keys: openarray[T]; entries: int; key: T): int =
       return i - 1
     inc i
   return entries-1
+
+proc findKey[T](keys: openarray[T]; entries: int; key: T): int =
+  if entries == 0 or less(key, keys[0]):
+    return -1
+  var a = 1
+  var b = entries
+  while a != b:
+    let mid = (a + b) div 2
+    if less(key, keys[mid]):
+      b = mid
+    else:
+      a = mid + 1
+  return a - 1
 
 proc getOrDefault*[Key, Val](b: BTree[Key, Val], key: Key): Val =
   if b.root == nil:
@@ -119,8 +149,7 @@ proc contains*[Key, Val](n: BTree[Key, Val], key: Key): bool =
       return false
     x = x.links[idx]
   assert(not x.isInternal)
-  for j in 0 ..< x.entries:
-    if eq(key, x.keys[j]): return true
+  return findValue(x.keys, x.entries, key) >= 0
 
 proc split[Key, Val](h: Node[Key, Val]): Node[Key, Val] =
   ## modifiy h, to be half the size. Returns a node with the other half.
@@ -154,31 +183,21 @@ proc insert[Key, Val](h: Node[Key, Val], key: Key, val: Val): Node[Key, Val] =
   if h.isInternal:
     let idx = findKey(h.keys, h.entries, key)
     let newLink: Node[Key, Val] = insert(h.links[max(0, idx)], key, val)
+
     if idx < 0: # insertion to the very beginning
       h.keys[0] = h.links[0].keys[0]
 
     if newLink != nil:
       let newKey = newLink.keys[0]
-      let newIdx = idx + 1
+      let newIdx = max(0, idx) + 1
+
       inc h.entries
       rotateLeft(h.links, newIdx ..< h.entries, -1) # rotate right
       h.links[newIdx] = newLink
       rotateLeft(h.keys, newIdx ..< h.entries, -1) # rotate right
       h.keys[newIdx] = newKey
   else:
-
-    var j = 0
-    while j < h.entries:
-      if less(key, h.keys[j]): break
-      inc j
     let idx = findKey(h.keys, h.entries, key) + 1
-
-    if idx != j:
-      echo h.keys[0 ..< h.entries]
-      echo idx, "  ", j
-      echo key
-
-    # doAssert j == idx
     inc h.entries
     rotateLeft(h.vals, idx ..< h.entries, -1) # rotate right
     h.vals[idx] = val
@@ -201,7 +220,7 @@ proc delete[Key, Val](n: Node[Key, Val]; key: Key): bool =
           n.keys[j] = link.keys[0]
         return
   else:
-    var idx = findWithCmp(n.keys, n.entries, key)
+    var idx = findValue(n.keys, n.entries, key)
     if idx >= 0:
       result = true
       n.keys[idx] = default(Key)
@@ -210,7 +229,7 @@ proc delete[Key, Val](n: Node[Key, Val]; key: Key): bool =
       rotateLeft(n.vals, idx ..< n.entries, 1)
       dec n.entries
 
-proc delete[Key, Val](self: var BTree[Key, Val]; key: Key): bool =
+proc delete*[Key, Val](self: var BTree[Key, Val]; key: Key): bool =
   if self.root == nil:
     return false
   else:
@@ -235,20 +254,6 @@ proc add*[Key, Val](b: var BTree[Key, Val]; key: Key; val: Val) =
   t.keys[1] = u.keys[0]
   t.links[1] = u
   b.root = t
-
-proc toString[Key, Val](h: Node[Key, Val], indent: string; result: var string) =
-  if not h.isInternal:
-    for j in 0..<h.entries:
-      result.add(indent)
-      result.add($h.keys[j] & " " & $h.vals[j] & "\n")
-  else:
-    for j in 0..<h.entries:
-      if j > 0: result.add(indent & "(" & $h.keys[j] & ")\n")
-      toString(h.links[j], indent & "   ", result)
-
-proc `$`[Key, Val](b: BTree[Key, Val]): string =
-  result = ""
-  toString(b.root, "", result)
 
 proc hasNext*[Key, Val](b: BTree[Key, Val]; index: int): bool =
   result = index < b.entries
@@ -290,41 +295,42 @@ when isMainModule:
   import random, tables
 
   proc main() =
-    var st = initBTree[string, string]()
-    st.add("www.cs.princeton.edu", "abc")
-    st.add("www.princeton.edu",    "128.112.128.15")
-    st.add("www.yale.edu",         "130.132.143.21")
-    st.add("www.simpsons.com",     "209.052.165.60")
-    st.add("www.apple.com",        "17.112.152.32")
-    st.add("www.amazon.com",       "207.171.182.16")
-    st.add("www.ebay.com",         "66.135.192.87")
-    st.add("www.cnn.com",          "64.236.16.20")
-    st.add("www.google.com",       "216.239.41.99")
-    st.add("www.nytimes.com",      "199.239.136.200")
-    st.add("www.microsoft.com",    "207.126.99.140")
-    st.add("www.dell.com",         "143.166.224.230")
-    st.add("www.slashdot.org",     "66.35.250.151")
-    st.add("www.espn.com",         "199.181.135.201")
-    st.add("www.weather.com",      "63.111.66.11")
-    st.add("www.yahoo.com",        "216.109.118.65")
+    block test1:
+      var st = initBTree[string, string]()
+      st.add("www.cs.princeton.edu", "abc")
+      st.add("www.princeton.edu",    "128.112.128.15")
+      st.add("www.yale.edu",         "130.132.143.21")
+      st.add("www.simpsons.com",     "209.052.165.60")
+      st.add("www.apple.com",        "17.112.152.32")
+      st.add("www.amazon.com",       "207.171.182.16")
+      st.add("www.ebay.com",         "66.135.192.87")
+      st.add("www.cnn.com",          "64.236.16.20")
+      st.add("www.google.com",       "216.239.41.99")
+      st.add("www.nytimes.com",      "199.239.136.200")
+      st.add("www.microsoft.com",    "207.126.99.140")
+      st.add("www.dell.com",         "143.166.224.230")
+      st.add("www.slashdot.org",     "66.35.250.151")
+      st.add("www.espn.com",         "199.181.135.201")
+      st.add("www.weather.com",      "63.111.66.11")
+      st.add("www.yahoo.com",        "216.109.118.65")
 
-    assert st.getOrDefault("www.cs.princeton.edu") == "abc"
-    assert st.getOrDefault("www.harvardsucks.com") == ""
+      assert st.getOrDefault("www.cs.princeton.edu") == "abc"
+      assert st.getOrDefault("www.harvardsucks.com") == ""
 
-    assert st.getOrDefault("www.simpsons.com") == "209.052.165.60"
-    assert st.getOrDefault("www.apple.com") == "17.112.152.32"
-    assert st.getOrDefault("www.ebay.com") == "66.135.192.87"
-    assert st.getOrDefault("www.dell.com") == "143.166.224.230"
-    assert(st.entries == 16)
+      assert st.getOrDefault("www.simpsons.com") == "209.052.165.60"
+      assert st.getOrDefault("www.apple.com") == "17.112.152.32"
+      assert st.getOrDefault("www.ebay.com") == "66.135.192.87"
+      assert st.getOrDefault("www.dell.com") == "143.166.224.230"
+      assert(st.entries == 16)
 
-    var keys: seq[string]
+      var keys: seq[string]
 
-    for k, v in st:
-      echo k, ": ", v
-      keys.add k
+      for k, v in st:
+        echo k, ": ", v
+        keys.add k
 
-    for key in keys:
-      discard st.delete(key)
+      for key in keys:
+        discard st.delete(key)
 
     when false:
       var b2 = initBTree[string, string]()
@@ -338,38 +344,39 @@ when isMainModule:
       echo b2.entries
 
     when true:
-      const iters = 100_000
-
-      var b2 = initBTree[int, string]()
       var t2 = initTable[int, string]()
-      var keys2: seq[int]
-      for i in 1..iters:
-        let x = rand(high(int))
-        if not t2.hasKey(x):
-          doAssert b2.getOrDefault(x) == "", " what, tree has this element " & $x
-          t2[x] = $x
-          b2.add(x, $x)
-          keys2.add x
-          doAssert b2.getOrDefault(x) == $x
+      var keys: seq[int]
 
-      doAssert b2.entries == t2.len
-      echo "unique entries ", b2.entries
-      for k, v in t2:
-        doAssert $k == v
-        doAssert b2.getOrDefault(k) == $k, "\"" & b2.getOrDefault(k) & "\" != \"" & $k & "\""
+      for i in 0 ..< 1_000_000:
+        var x = rand(high(int))
+        while t2.hasKey(x):
+          x = rand(high(int))
+        t2[x] = $x
+        keys.add x
 
-      shuffle keys2 # just make it a different order than insertion order
+      echo "Hash map initialized with ", keys.len, " entries."
 
-      for key in keys2:
-        doAssert key in b2
-        doAssert b2.delete(key) == true
-        doAssert key notin b2
+      var tree = initBTree[int, string]()
+      for key, value in t2:
+        doAssert tree.getOrDefault(key) == "", " what, tree has this element " & $key
+        tree.add(key, value)
+        doAssert tree.getOrDefault(key) == value
 
-      doAssert b2.entries == 0
-      shuffle keys2
+      doAssert tree.entries == t2.len
+      for key, value in t2:
+        doAssert tree.getOrDefault(key) == value, "\"" & $tree.getOrDefault(key) & "\" != \"" & $value & "\""
 
-      for key in keys2:
-        b2.add(key, $key)
+      shuffle keys # just make it a different order than insertion order
 
+      for key in keys:
+        doAssert key in tree
+        doAssert tree.delete(key)
+        doAssert key notin tree
+
+      doAssert tree.entries == 0
+      shuffle keys
+
+      for key in keys:
+        tree.add(key, $key)
 
   main()

--- a/compiler/btrees.nim
+++ b/compiler/btrees.nim
@@ -150,23 +150,20 @@ proc insert[Key, Val](h: Node[Key, Val], key: Key, val: Val): Node[Key, Val] =
     inc h.entries
     rotateLeft(h.vals, j ..< h.entries, -1) # rotate right
     h.vals[j] = val
+    rotateLeft(h.keys, j ..< h.entries, -1) # rotate right
+    h.keys[j] = newKey
   else:
-    var newLink: Node[Key, Val] = nil
-    while j < h.entries:
-      if j+1 == h.entries or less(key, h.keys[j+1]):
-        let u = insert(h.links[j], key, val)
-        inc j
-        if u == nil: return nil
-        newKey = u.keys[0]
-        newLink = u
-        break
-      inc j
-    inc h.entries
-    rotateLeft(h.links, j ..< h.entries, -1) # rotate right
-    h.links[j] = newLink
-
-  rotateLeft(h.keys, j ..< h.entries, -1) # rotate right
-  h.keys[j] = newKey
+    let idx = findKey(h.keys, h.entries, key)
+    doAssert idx >= 0
+    let newLink = insert(h.links[idx], key, val)
+    if newLink != nil:
+      let newKey = newLink.keys[0]
+      let newIdx = idx + 1
+      inc h.entries
+      rotateLeft(h.links, newIdx ..< h.entries, -1) # rotate right
+      h.links[newIdx] = newLink
+      rotateLeft(h.keys, newIdx ..< h.entries, -1) # rotate right
+      h.keys[newIdx] = newKey
 
 proc delete[Key, Val](n: Node[Key, Val]; key: Key): bool =
   if n.isInternal:

--- a/compiler/btrees.nim
+++ b/compiler/btrees.nim
@@ -48,23 +48,6 @@ proc `$`[Key, Val](b: BTree[Key, Val]): string =
   result = ""
   toString(b.root, "", result)
 
-proc newlineAndIndent(result: var string, indentation: int) =
-  result.add "\n"
-  for i in 0 ..< indentation:
-    result.add "  "
-
-proc addNamedValue[T](result: var string; name: string; value: T; indentation: int) =
-  result.newlineAndIndent(indentation)
-  result.add name
-  result.add ": "
-  result.add $value
-
-proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
-
-proc indexFormat(arg: int): string =
-  result.setLen(5)
-  discard c_snprintf(cstring(result[0].addr), 6, "[%3d]", int32(arg))
-
 proc initBTree*[Key, Val](): BTree[Key, Val] =
   discard
 

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -560,7 +560,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     s = semIdentVis(c, skTemplate, n.sons[0], {})
 
   if s.owner != nil and sfSystemModule in s.owner.flags and
-      s.name.s in ["!=", ">=", ">", "incl", "excl", "in", "notin", "isnot"]:
+      s.name.s in ["!=", ">=", ">", "incl", "excl", "in", "notin", "isnot", "..<"]:
     incl(s.flags, sfCallsite)
 
   styleCheckDef(c.config, s)


### PR DESCRIPTION
  * performance improvements: binary search within nodes in the BTree
  * code refactoring:
    - use rotateLeft from algorithm where possible (replaces loops)
    - search for nodes is now binary
  * delte operation for BTree, non balancing, but empty nodes get removed.
 

I did some performance tests. The binary search does help, but the BTree is much slower than I expected. The biggest improvement that I measured is when the node size is reduced from 512 to 32.


  