### PR TITLE
add a compiler argument to debug a macro

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -760,6 +760,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     processOnOffSwitchG(conf, {optDocInternal}, arg, pass, info)
   of "multimethods":
     processOnOffSwitchG(conf, {optMultiMethods}, arg, pass, info)
+  of "expandmacro":
+    conf.expandMacro = arg
   else:
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)

--- a/compiler/idents.nim
+++ b/compiler/idents.nim
@@ -52,6 +52,9 @@ proc cmpIgnoreStyle*(a, b: cstring, blen: int): int =
   if result == 0:
     if a[i] != '\0': result = 1
 
+proc eqIdent*(a,b: string): bool =
+  cmpIgnoreStyle(a.cstring, b.cstring, high(int)) == 0
+
 proc cmpExact(a, b: cstring, blen: int): int =
   var i = 0
   var j = 0

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -254,6 +254,7 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+    expandMacro*: string          # The name of the symbol that should be debugged.
 
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -471,6 +471,10 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
   result = wrapInComesFrom(nOrig.info, sym, result)
   popInfoContext(c.config)
 
+  if eqIdent(c.config.expandMacro, sym.name.s):
+    echo c.config $ nOrig.info, " expansion of macro ", c.config.expandMacro
+    echo result
+
 proc forceBool(c: PContext, n: PNode): PNode =
   result = fitNode(c, getSysType(c.graph, n.info, tyBool), n, n.info)
   if result == nil: result = n

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -37,6 +37,11 @@ proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
   # XXX: A more elaborate line info rewrite might be needed
   result.info = info
 
+  if eqIdent(c.config.expandMacro, s.name.s):
+    echo c.config $ info, " expansion of template ", s.name.s
+    echo result
+
+
 proc semFieldAccess(c: PContext, n: PNode, flags: TExprFlags = {}): PNode
 
 template rejectEmptyNode(n: PNode) =

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -124,3 +124,4 @@ Advanced options:
   --profiler:on|off         Enable profiling; requires `import nimprof`, and
                             works better with `--stackTrace:on`
                             see also https://nim-lang.github.io/Nim/estp.html
+  --expandMacro:MACRO       Dump the generated syntax tree of MACRO.


### PR DESCRIPTION
It is not specified what should happen when expandMacro is passed several times to nim? Currently the last expandMacro argument overrides every previous one. No error no warning.

When a macro expansion is wanted for debugging, these are the things that I can imagine to be useful to specify what macros or temples should be selected:

 * the name of the macro
 * the name of the module where the macro is declared
 * the name of the module where the macro is invoked
 * the file where the macro is invoked (thanks to includes, this is not the same as the above)
 * the line of the file where the macro is invoked

With this PR only the name of the macro can be specified. If the other features are wanted, what should the syntax be for those features be? And last but not least: Regular expressions?