### PR TITLE
change the order of appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
   platform: x64
 
   matrix:
-    - NIM_TEST_PACKAGES: true
     - NIM_TEST_PACKAGES: false
+    - NIM_TEST_PACKAGES: true
 
 cache:
     - '%MINGW_ARCHIVE%'


### PR DESCRIPTION
Testing packages sometimes randomly fails because of some
reason not connected to Nim (e.g. github is down).
Currently, that would prevent "regular" appveyor tests
from running.

Changing the order will allow "regular tests" to run
regardless of the outside problems with packages.