### PR TITLE
Strformat symbol binding

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -95,7 +95,8 @@
 - two poorly documented and not used modules (`subexes`, `scgi`) were moved to
   graveyard (they are available as Nimble packages)
 
-
+- Custom types that should be supported by `strformat` (&) now need an
+  explicit overload of `formatValue`.
 
 #### Breaking changes in the compiler
 

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -503,19 +503,17 @@ macro `&`*(pattern: string): untyped =
           let msg = getCurrentExceptionMsg()
           error("could not parse ``" & subexpr & "``.\n" & msg, pattern)
         let formatSym = bindSym("formatValue", brOpen)
+        var options = ""
         if f[i] == ':':
           inc i
-          var options = ""
           while i < f.len and f[i] != '}':
             options.add f[i]
             inc i
-          result.add newCall(formatSym, x, newLit(options), res)
-        else:
-          result.add newCall(formatSym, x, newLit(""), res)
         if f[i] == '}':
           inc i
         else:
           doAssert false, "invalid format string: missing '}'"
+        result.add newCall(formatSym, x, newLit(options), res)
     elif f[i] == '}':
       if f[i+1] == '}':
         strlit.add '}'

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -472,6 +472,14 @@ template formatValue(result: var string; value: char; specifier: string) =
 template formatValue(result: var string; value: cstring; specifier: string) =
   result.add value
 
+proc formatValue[T](result: var string; value: openarray[T]; specifier: string) =
+  result.add "["
+  for i, it in value:
+    if i != 0:
+      result.add ", "
+    result.formatValue(it, specifier)
+  result.add "]"
+
 macro `&`*(pattern: string): untyped =
   ## For a specification of the ``&`` macro, see the module level documentation.
   if pattern.kind notin {nnkStrLit..nnkTripleStrLit}:

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -102,7 +102,7 @@ of ``formatValue`` procs. The required signature for a type ``T`` that supports
 formatting is usually ``proc formatValue(result: var string; x: T; specifier: string)``.
 
 The subexpression after the colon
-(``arg`` in ``&"{key} is {value:arg} {{z}}"``) is optional. It will be passed as the second argument to ``formatValue``. When it is left out, the default value is the empty string.
+(``arg`` in ``&"{key} is {value:arg} {{z}}"``) is optional. It will be passed as the last argument to ``formatValue``. When the colon with the subexpression it is left out, an empty string will be taken instead.
 
 For strings and numeric types the optional argument is a so-called
 "standard format specifier".
@@ -215,7 +215,7 @@ Future directions
 =================
 
 A curly expression with commas in it like ``{x, argA, argB}`` could be
-transformed to ``format(x, argA, argB, res)`` in order to support
+transformed to ``formatValue(result, x, argA, argB)`` in order to support
 formatters that do not need to parse a custom language within a custom
 language but instead prefer to use Nim's existing syntax. This also
 helps in readability since there is only so much you can cram into

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2330,6 +2330,10 @@ proc format*(dt: DateTime, f: static[string]): string {.raises: [].} =
   const f2 = initTimeFormat(f)
   result = dt.format(f2)
 
+template formatValue*(value: DateTime, specifier: string, res: var string) =
+  ## adapter for strformat. Not intended to be called directly.
+  res.add format(value, specifier)
+
 proc format*(time: Time, f: string, zone: Timezone = local()): string
     {.raises: [TimeFormatParseError].} =
   ## Shorthand for constructing a ``TimeFormat`` and using it to format
@@ -2348,6 +2352,10 @@ proc format*(time: Time, f: static[string], zone: Timezone = local()): string
   ## Overload that validates ``f`` at compile time.
   const f2 = initTimeFormat(f)
   result = time.inZone(zone).format(f2)
+
+template formatValue*(value: Time, specifier: string, res: var string) =
+  ## adapter for strformat. Not intended to be called directly.
+  res.add format(value, specifier)
 
 proc parse*(input: string, f: TimeFormat, zone: Timezone = local()): DateTime
     {.raises: [TimeParseError, Defect].} =

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2330,9 +2330,9 @@ proc format*(dt: DateTime, f: static[string]): string {.raises: [].} =
   const f2 = initTimeFormat(f)
   result = dt.format(f2)
 
-template formatValue*(value: DateTime, specifier: string, res: var string) =
+template formatValue*(result: var string; value: DateTime, specifier: string) =
   ## adapter for strformat. Not intended to be called directly.
-  res.add format(value, specifier)
+  result.add format(value, specifier)
 
 proc format*(time: Time, f: string, zone: Timezone = local()): string
     {.raises: [TimeFormatParseError].} =
@@ -2353,9 +2353,9 @@ proc format*(time: Time, f: static[string], zone: Timezone = local()): string
   const f2 = initTimeFormat(f)
   result = time.inZone(zone).format(f2)
 
-template formatValue*(value: Time, specifier: string, res: var string) =
+template formatValue*(result: var string; value: Time, specifier: string) =
   ## adapter for strformat. Not intended to be called directly.
-  res.add format(value, specifier)
+  result.add format(value, specifier)
 
 proc parse*(input: string, f: TimeFormat, zone: Timezone = local()): DateTime
     {.raises: [TimeParseError, Defect].} =

--- a/tests/stdlib/genericstrformat.nim
+++ b/tests/stdlib/genericstrformat.nim
@@ -1,0 +1,16 @@
+# from issue #7632
+# imported and used in tstrformat
+
+import strformat
+
+proc fails*(a: static[int]): string =
+  &"formatted {a:2}"
+
+proc fails2*[N: static[int]](a: int): string =
+  &"formatted {a:2}"
+
+proc works*(a: int): string =
+  &"formatted {a:2}"
+
+proc fails0*(a: int or uint): string =
+  &"formatted {a:2}"

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,5 +1,5 @@
 discard """
-    action: "run"
+action: "run"
 """
 
 import strformat
@@ -7,6 +7,10 @@ import strformat
 type Obj = object
 
 proc `$`(o: Obj): string = "foobar"
+
+# for custom types, formatValue needs to be overloaded.
+template formatValue(value: Obj; specifier: string; res: var string) =
+  formatValue($value, specifier, res)
 
 var o: Obj
 doAssert fmt"{o}" == "foobar"
@@ -42,7 +46,7 @@ doAssert fmt"^7.9 :: {str:^7.9}" == "^7.9 :: äöüe\u0309\u0319o\u0307\u0359"
 doAssert fmt"{15:08}" == "00000015" # int, works
 doAssert fmt"{1.5:08}" == "000001.5" # float, works
 doAssert fmt"{1.5:0>8}" == "000001.5" # workaround using fill char works for positive floats
-doAssert fmt"{-1.5:0>8}" == "0000-1.5" # even that does not work for negative floats  
+doAssert fmt"{-1.5:0>8}" == "0000-1.5" # even that does not work for negative floats
 doAssert fmt"{-1.5:08}" == "-00001.5" # works
 doAssert fmt"{1.5:+08}" == "+00001.5" # works
 doAssert fmt"{1.5: 08}" == " 00001.5" # works
@@ -54,3 +58,26 @@ doassert fmt"{-0.0: g}" == "-0"
 doAssert fmt"{0.0:g}" == "0"
 doAssert fmt"{0.0:+g}" == "+0"
 doAssert fmt"{0.0: g}" == " 0"
+
+# issue #7632
+
+
+type
+  Vec2f = object
+    x,y: float32
+
+proc formatValue(value: Vec2f; specifier: string; res: var string) =
+  res.add '['
+  formatValue value.x, specifier, res
+  res.add ", "
+  formatValue value.y, specifier, res
+  res.add "]"
+
+doAssert fmt"v: {Vec2f(x:1.0, y: 2.0):+08}" == "v: [+0000001, +0000002]"
+
+import genericstrformat
+
+doAssert works(5) == "formatted  5"
+doAssert fails0(6) == "formatted  6"
+doAssert fails(7) == "formatted  7"
+doAssert fails2[0](8) == "formatted  8"

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -59,21 +59,26 @@ doAssert fmt"{0.0:g}" == "0"
 doAssert fmt"{0.0:+g}" == "+0"
 doAssert fmt"{0.0: g}" == " 0"
 
-# issue #7632
-
+# custom format Value
 
 type
-  Vec2f = object
-    x,y: float32
+  Vec2[T] = object
+    x,y: T
+  Vec2f = Vec2[float32]
+  Vec2i = Vec2[int32]
 
-proc formatValue(value: Vec2f; specifier: string; res: var string) =
+proc formatValue[T](value: Vec2[T]; specifier: string; res: var string) =
   res.add '['
   formatValue value.x, specifier, res
   res.add ", "
   formatValue value.y, specifier, res
   res.add "]"
 
-doAssert fmt"v: {Vec2f(x:1.0, y: 2.0):+08}" == "v: [+0000001, +0000002]"
+let v1 = Vec2f(x:1.0, y: 2.0)
+let v2 = Vec2i(x:1, y: 1337)
+doAssert fmt"v1: {v1:+08}  v2: {v2:>4}" == "v1: [+0000001, +0000002]  v2: [   1, 1337]"
+
+# issue #7632
 
 import genericstrformat
 

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -61,11 +61,11 @@ doAssert fmt"{0.0: g}" == " 0"
 
 # seq format
 
-let data1 = [1'i64, 1000'i64, 10000000'i64]
-let data2 = [10000000'i64, 1000'i64, 1'i64]
+let data1 = [1'i64, 10000'i64, 10000000'i64]
+let data2 = [10000000'i64, 100'i64, 1'i64]
 
-doAssert fmt"data1: {data1:8} ∨" == "data1: [       1,     1000, 10000000] ∨"
-doAssert fmt"data2: {data2:8} ∧" == "data2: [10000000,     1000,        1] ∧"
+doAssert fmt"data1: {data1:8} ∨" == "data1: [       1,    10000, 10000000] ∨"
+doAssert fmt"data2: {data2:8} ∧" == "data2: [10000000,      100,        1] ∧"
 
 # custom format Value
 

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -9,8 +9,8 @@ type Obj = object
 proc `$`(o: Obj): string = "foobar"
 
 # for custom types, formatValue needs to be overloaded.
-template formatValue(value: Obj; specifier: string; res: var string) =
-  formatValue($value, specifier, res)
+template formatValue(result: var string; value: Obj; specifier: string) =
+  result.formatValue($value, specifier)
 
 var o: Obj
 doAssert fmt"{o}" == "foobar"
@@ -59,6 +59,14 @@ doAssert fmt"{0.0:g}" == "0"
 doAssert fmt"{0.0:+g}" == "+0"
 doAssert fmt"{0.0: g}" == " 0"
 
+# seq format
+
+let data1 = [1'i64, 1000'i64, 10000000'i64]
+let data2 = [10000000'i64, 1000'i64, 1'i64]
+
+doAssert fmt"data1: {data1:8} ∨" == "data1: [       1,     1000, 10000000] ∨"
+doAssert fmt"data2: {data2:8} ∧" == "data2: [10000000,     1000,        1] ∧"
+
 # custom format Value
 
 type
@@ -67,12 +75,12 @@ type
   Vec2f = Vec2[float32]
   Vec2i = Vec2[int32]
 
-proc formatValue[T](value: Vec2[T]; specifier: string; res: var string) =
-  res.add '['
-  formatValue value.x, specifier, res
-  res.add ", "
-  formatValue value.y, specifier, res
-  res.add "]"
+proc formatValue[T](result: var string; value: Vec2[T]; specifier: string) =
+  result.add '['
+  result.formatValue value.x, specifier
+  result.add ", "
+  result.formatValue value.y, specifier
+  result.add "]"
 
 let v1 = Vec2f(x:1.0, y: 2.0)
 let v2 = Vec2i(x:1, y: 1337)

--- a/tests/stdlib/tstrformatMissingFormatValue.nim
+++ b/tests/stdlib/tstrformatMissingFormatValue.nim
@@ -1,0 +1,16 @@
+discard """
+errormsg: '''type mismatch: got <Obj, string, string>'''
+nimout: '''proc formatValue'''
+"""
+
+# This test is here to make sure that there is a clean error that
+# that indicates ``formatValue`` needs to be overloaded with the custom type.
+
+import strformat
+
+type Obj = object
+
+proc `$`(o: Obj): string = "foobar"
+
+var o: Obj
+doAssert fmt"{o}" == "foobar"

--- a/tests/stdlib/tstrformatMissingFormatValue.nim
+++ b/tests/stdlib/tstrformatMissingFormatValue.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: '''type mismatch: got <Obj, string, string>'''
+errormsg: '''type mismatch: got <string, Obj, string>'''
 nimout: '''proc formatValue'''
 """
 


### PR DESCRIPTION
 * ``strformat.format`` is renamed to ``strformat.formatValue``, so it does not clash with ``strutils.format``.
 * The (in my opinion complicated and weird logic) in the ``callFormat`` templates is removed entirely. ``formatValue`` has to follow the interface ``formatValue*(value: T; specifier: string; res: var string)``. Hacks to support alternative interfaces are removed.
 * Libraries can overload ``formatValue`` to enable custom types within to be used in the ``&`` macro.
 * Libraries have full control over the meaning of the ``specifier`` string for their own types. 
 * The changes above enable an implementation for the ``nim_glm`` types to be used in the ``&`` macro.
 * fixes https://github.com/nim-lang/Nim/issues/7632
 * the macro ``&`` is moved below the definition of ``formatValue``, so that ``bindSym`` gets them all. Sorry that makes the diff harder to read, but it is important.

breaking change:

Custom types now need to overload ``formatValue`` explicity. It would be possible to provide a generic ``formatValue`` that is based on ``$``, but I decided against it. Most importantly, when the generic ``formatValue`` does not exist, there is a really nice error message that tells the developer that there is a missing ``formatValue`` that should be implemented. I also did it, because it is not clear to me what to do with the ``specifier`` argument.
