### PR TITLE
`parsecfg.nim` module supports annotation statements, does not delete comment statements and redundant blank characters, leaving the original style and you can specify annotation delimiters.

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -233,8 +233,9 @@ proc parseSpec*(filename: string): TSpec =
             result.targets.incl(targetJS)
           else:
             result.parseErrors.addLine "cannot interpret as a target: ", e.value
+      of "": discard  
       else:
-        result.parseErrors.addLine "invalid key for test spec: ", e.key
+        result.parseErrors.addLine "invalid key for test spec: ", e.key & ":" & e.value
 
     of cfgSectionStart:
       result.parseErrors.addLine "section ignored: ", e.section

--- a/tests/stdlib/tparscfg.nim
+++ b/tests/stdlib/tparscfg.nim
@@ -7,45 +7,45 @@ lihf8515
 10214028
 lihaifeng@wxm.com
 ===
-charset=utf-8
+charset="utf-8"
 [Package]
-name=hello
---threads:on
+name="hello"
+--threads:"on"
 [Author]
-name=lhf
-qq=10214028
+name="lhf"
+qq="10214028"
 email="lihaifeng@wxm.com"
 ===
-charset=utf-8
+charset="utf-8"
 [Package]
-name=hello
---threads:on
+name="hello"
+--threads:"on"
 [Author]
-name=lihf8515
-qq=10214028
+name="lihf8515"
+qq="10214028"
 '''
 """
 import parsecfg, streams
 
 ## Creating a configuration file.
 var dict1=newConfig()
-dict1.setSectionKey("","charset","utf-8")
-dict1.setSectionKey("Package","name","hello")
-dict1.setSectionKey("Package","--threads","on")
-dict1.setSectionKey("Author","name","lihf8515")
-dict1.setSectionKey("Author","qq","10214028")
-dict1.setSectionKey("Author","email","lihaifeng@wxm.com")
+dict1.set("","charset","utf-8")
+dict1.set("Package","name","hello")
+dict1.set("Package","--threads","on")
+dict1.set("Author","name","lihf8515")
+dict1.set("Author","qq","10214028")
+dict1.set("Author","email","lihaifeng@wxm.com")
 var ss = newStringStream()
-dict1.writeConfig(ss)
+dict1.write(ss)
 
 ## Reading a configuration file.
 var dict2 = loadConfig(newStringStream(ss.data))
-var charset = dict2.getSectionValue("","charset")
-var threads = dict2.getSectionValue("Package","--threads")
-var pname = dict2.getSectionValue("Package","name")
-var name = dict2.getSectionValue("Author","name")
-var qq = dict2.getSectionValue("Author","qq")
-var email = dict2.getSectionValue("Author","email")
+var charset = dict2.get("","charset")
+var threads = dict2.get("Package","--threads")
+var pname = dict2.get("Package","name")
+var name = dict2.get("Author","name")
+var qq = dict2.get("Author","qq")
+var email = dict2.get("Author","email")
 echo charset
 echo threads
 echo pname
@@ -57,13 +57,13 @@ echo "==="
 
 ## Modifying a configuration file.
 var dict3 = loadConfig(newStringStream(ss.data))
-dict3.setSectionKey("Author","name","lhf")
+dict3.set("Author","name","lhf")
 write(stdout, $dict3)
 
 echo "==="
 
 ## Deleting a section key in a configuration file.
 var dict4 = loadConfig(newStringStream(ss.data))
-dict4.delSectionKey("Author","email")
+dict4.del("Author","email")
 write(stdout, $dict4)
 

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -268,11 +268,13 @@ proc pathFlags(p: var CfgParser, k, v: string,
   case normalize(k)
   of "path": t.path = v
   of "flags": t.flags = v
+  of "": discard
   else: quit(errorStr(p, "unknown variable: " & k))
 
 proc filesOnly(p: var CfgParser, k, v: string, dest: var seq[string]) =
   case normalize(k)
   of "files": addFiles(dest, split(v, {';'}))
+  of "": discard
   else: quit(errorStr(p, "unknown variable: " & k))
 
 proc yesno(p: var CfgParser, v: string): bool =
@@ -317,7 +319,6 @@ proc parseIniFile(c: var ConfigData) =
       of cfgKeyValuePair:
         var v = `%`(k.value, c.vars, {useEnvironment, useEmpty})
         c.vars[k.key] = v
-
         case section
         of "project":
           case normalize(k.key)
@@ -347,6 +348,7 @@ proc parseIniFile(c: var ConfigData) =
             of "gui": c.app = appGUI
             else: quit(errorStr(p, "expected: console or gui"))
           of "license": c.license = unixToNativePath(k.value)
+          of "": discard
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "var": discard
         of "winbin": filesOnly(p, k.key, v, c.cat[fcWinBin])
@@ -356,6 +358,7 @@ proc parseIniFile(c: var ConfigData) =
           case normalize(k.key)
           of "files": addFiles(c.cat[fcDoc], split(v, {';'}))
           of "start": addFiles(c.cat[fcDocStart], split(v, {';'}))
+          of "": discard
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "lib": filesOnly(p, k.key, v, c.cat[fcLib])
         of "other": filesOnly(p, k.key, v, c.cat[fcOther])
@@ -365,12 +368,14 @@ proc parseIniFile(c: var ConfigData) =
           of "binpath": c.binPaths = split(v, {';'})
           of "innosetup": c.innoSetupFlag = yesno(p, v)
           of "download": c.downloads.add(v)
+          of "": discard
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "unix":
           case normalize(k.key)
           of "files": addFiles(c.cat[fcUnix], split(v, {';'}))
           of "installscript": c.installScript = yesno(p, v)
           of "uninstallscript": c.uninstallScript = yesno(p, v)
+          of "": discard
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "unixbin": filesOnly(p, k.key, v, c.cat[fcUnixBin])
         of "innosetup": pathFlags(p, k.key, v, c.innosetup)
@@ -406,6 +411,7 @@ proc parseIniFile(c: var ConfigData) =
                 if afterComma: license.add(v[i])
                 else: file.add(v[i])
               inc(i)
+          of "": discard
           else: quit(errorStr(p, "unknown variable: " & k.key))
         of "nimble":
           case normalize(k.key)
@@ -413,8 +419,10 @@ proc parseIniFile(c: var ConfigData) =
             c.nimblePkgName = v
           of "pkgfiles":
             addFiles(c.cat[fcNimble], split(v, {';'}))
+          of "": discard
           else:
             quit(errorStr(p, "invalid key: " & k.key))
+        of "": discard
         else: quit(errorStr(p, "invalid section: " & section))
 
       of cfgOption: quit(errorStr(p, "syntax error"))


### PR DESCRIPTION
`parsecfg.nim` module supports annotation statements, does not delete comment statements and redundant blank characters, leaving the original style and you can specify annotation delimiters.