### PR TITLE
fixes #10942. Lent T bug

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -136,7 +136,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode): Rope =
   elif skipTypes(param.typ, abstractVar).kind in {tyOpenArray, tyVarargs}:
     var n = if n.kind != nkHiddenAddr: n else: n.sons[0]
     result = openArrayLoc(p, n)
-  elif ccgIntroducedPtr(p.config, param, call[0].typ[0], call[0].info):
+  elif ccgIntroducedPtr(p.config, param, call[0].typ[0]):
     initLocExpr(p, n, a)
     result = addrLoc(p.config, a)
   elif p.module.compileToCpp and param.typ.kind == tyVar and

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -136,7 +136,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode): Rope =
   elif skipTypes(param.typ, abstractVar).kind in {tyOpenArray, tyVarargs}:
     var n = if n.kind != nkHiddenAddr: n else: n.sons[0]
     result = openArrayLoc(p, n)
-  elif ccgIntroducedPtr(p.config, param):
+  elif ccgIntroducedPtr(p.config, param, call[0].typ[0], call[0].info):
     initLocExpr(p, n, a)
     result = addrLoc(p.config, a)
   elif p.module.compileToCpp and param.typ.kind == tyVar and

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -249,11 +249,9 @@ proc addAbiCheck(m: BModule, t: PType, name: Rope) =
   if isDefined(m.config, "checkabi") and (let size = getSize(m.config, t); size != szUnknownSize):
     addf(m.s[cfsTypeInfo], "NIM_CHECK_SIZE($1, $2);$n", [name, rope(size)])
 
-proc ccgIntroducedPtr(conf: ConfigRef; s: PSym, retType: PType, info: TLineInfo): bool =
+proc ccgIntroducedPtr(conf: ConfigRef; s: PSym, retType: PType): bool =
   var pt = skipTypes(s.typ, typedescInst)
   assert skResult != s.kind
-  if tfByCopy in pt.flags and retType != nil and retType.kind == tyLent:
-    localError(conf, info, typeToString(pt) & " type is {.bycopy.}, but pass by reference is required to return lent value")
 
   if tfByRef in pt.flags: return true
   elif tfByCopy in pt.flags: return false
@@ -412,7 +410,7 @@ proc genProcParams(m: BModule, t: PType, rettype, params: var Rope,
     if params != nil: add(params, ~", ")
     fillLoc(param.loc, locParam, t.n.sons[i], mangleParamName(m, param),
             param.paramStorageLoc)
-    if ccgIntroducedPtr(m.config, param, t.sons[0], t.n.sons[i].info):
+    if ccgIntroducedPtr(m.config, param, t.sons[0]):
       add(params, getTypeDescWeak(m, param.typ, check))
       add(params, ~"*")
       incl(param.loc.flags, lfIndirect)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -249,9 +249,12 @@ proc addAbiCheck(m: BModule, t: PType, name: Rope) =
   if isDefined(m.config, "checkabi") and (let size = getSize(m.config, t); size != szUnknownSize):
     addf(m.s[cfsTypeInfo], "NIM_CHECK_SIZE($1, $2);$n", [name, rope(size)])
 
-proc ccgIntroducedPtr(conf: ConfigRef; s: PSym): bool =
+proc ccgIntroducedPtr(conf: ConfigRef; s: PSym, retType: PType, info: TLineInfo): bool =
   var pt = skipTypes(s.typ, typedescInst)
   assert skResult != s.kind
+  if tfByCopy in pt.flags and retType != nil and retType.kind == tyLent:
+    localError(conf, info, typeToString(pt) & " type is {.bycopy.}, but pass by reference is required to return lent value")
+
   if tfByRef in pt.flags: return true
   elif tfByCopy in pt.flags: return false
   case pt.kind
@@ -261,13 +264,18 @@ proc ccgIntroducedPtr(conf: ConfigRef; s: PSym): bool =
       result = true
     elif (optByRef in s.options) or (getSize(conf, pt) > conf.target.floatSize * 3):
       result = true           # requested anyway
+    elif retType != nil and retType.kind == tyLent:
+      result = true
     elif (tfFinal in pt.flags) and (pt.sons[0] == nil):
       result = false          # no need, because no subtyping possible
     else:
       result = true           # ordinary objects are always passed by reference,
                               # otherwise casting doesn't work
   of tyTuple:
-    result = (getSize(conf, pt) > conf.target.floatSize*3) or (optByRef in s.options)
+    if retType != nil and retType.kind == tyLent:
+      result = true
+    else:
+      result = (getSize(conf, pt) > conf.target.floatSize*3) or (optByRef in s.options)
   else: result = false
 
 proc fillResult(conf: ConfigRef; param: PNode) =
@@ -404,7 +412,7 @@ proc genProcParams(m: BModule, t: PType, rettype, params: var Rope,
     if params != nil: add(params, ~", ")
     fillLoc(param.loc, locParam, t.n.sons[i], mangleParamName(m, param),
             param.paramStorageLoc)
-    if ccgIntroducedPtr(m.config, param):
+    if ccgIntroducedPtr(m.config, param, t.sons[0], t.n.sons[i].info):
       add(params, getTypeDescWeak(m, param.typ, check))
       add(params, ~"*")
       incl(param.loc.flags, lfIndirect)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -416,7 +416,7 @@ proc localDebugInfo(p: BProc, s: PSym, retType: PType) =
   # XXX work around a bug: No type information for open arrays possible:
   if skipTypes(s.typ, abstractVar).kind in {tyOpenArray, tyVarargs}: return
   var a = "&" & s.loc.r
-  if s.kind == skParam and ccgIntroducedPtr(p.config, s, retType, s.ast.info): a = s.loc.r
+  if s.kind == skParam and ccgIntroducedPtr(p.config, s, retType): a = s.loc.r
   lineF(p, cpsInit,
        "FR_.s[$1].address = (void*)$3; FR_.s[$1].typ = $4; FR_.s[$1].name = $2;$n",
        [p.maxFrameLen.rope, makeCString(normalize(s.name.s)), a,

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -259,6 +259,7 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
       result = isAssignable(owner, n.sons[1], isUnsafeAddr)
   of nkHiddenDeref:
     if isUnsafeAddr and n[0].typ.kind == tyLent: result = arLValue
+    elif n[0].typ.kind == tyLent: result = arDiscriminant
     else: result = arLValue
   of nkDerefExpr, nkHiddenAddr:
     result = arLValue

--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -230,8 +230,10 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
       let t = n.sym.typ.skipTypes({tyTypeDesc})
       if t.kind == tyVar: result = arStrange
   of nkDotExpr:
-    if skipTypes(n.sons[0].typ, abstractInst-{tyTypeDesc}).kind in
-        {tyVar, tyPtr, tyRef}:
+    let t = skipTypes(n.sons[0].typ, abstractInst-{tyTypeDesc})
+    if t.kind in {tyVar, tyPtr, tyRef}:
+      result = arLValue
+    elif isUnsafeAddr and t.kind == tyLent:
       result = arLValue
     else:
       result = isAssignable(owner, n.sons[0], isUnsafeAddr)
@@ -239,8 +241,10 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
         sfDiscriminant in n[1].sym.flags:
       result = arDiscriminant
   of nkBracketExpr:
-    if skipTypes(n.sons[0].typ, abstractInst-{tyTypeDesc}).kind in
-        {tyVar, tyPtr, tyRef}:
+    let t = skipTypes(n.sons[0].typ, abstractInst-{tyTypeDesc})
+    if t.kind in {tyVar, tyPtr, tyRef}:
+      result = arLValue
+    elif isUnsafeAddr and t.kind == tyLent:
       result = arLValue
     else:
       result = isAssignable(owner, n.sons[0], isUnsafeAddr)
@@ -254,7 +258,7 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
       # types that are equal modulo distinction preserve l-value:
       result = isAssignable(owner, n.sons[1], isUnsafeAddr)
   of nkHiddenDeref:
-    if n[0].typ.kind == tyLent: result = arDiscriminant
+    if isUnsafeAddr and n[0].typ.kind == tyLent: result = arLValue
     else: result = arLValue
   of nkDerefExpr, nkHiddenAddr:
     result = arLValue
@@ -265,6 +269,8 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
     if getMagic(n) in {mArrGet, mSlice}:
       result = isAssignable(owner, n.sons[1], isUnsafeAddr)
     elif n.typ != nil and n.typ.kind == tyVar:
+      result = arLValue
+    elif isUnsafeAddr and n.typ != nil and n.typ.kind == tyLent:
       result = arLValue
   of nkStmtList, nkStmtListExpr:
     if n.typ != nil:

--- a/tests/types/tlent_var.nim
+++ b/tests/types/tlent_var.nim
@@ -1,0 +1,19 @@
+discard """
+  output: ''''''
+"""
+
+type
+  MyObj = object
+    a: int
+
+proc test_lent(x: MyObj): lent int =
+  x.a
+
+proc test_var(x: var MyObj): var int =
+  x.a
+
+var x = MyObj(a: 5)
+
+doAssert: test_var(x).addr == x.a.addr
+doAssert: test_lent(x).unsafeAddr == x.a.addr
+

--- a/tests/types/tlent_var.nim
+++ b/tests/types/tlent_var.nim
@@ -17,3 +17,9 @@ var x = MyObj(a: 5)
 doAssert: test_var(x).addr == x.a.addr
 doAssert: test_lent(x).unsafeAddr == x.a.addr
 
+proc varProc(x: var int) =
+  x = 100
+
+doAssert: not compiles(test_lent(x) = 1)
+doAssert: not compiles(varProc(test_lent(x)))
+


### PR DESCRIPTION
adds support for unsafeAddr for `lent T` returned type.
fixes #10942 by passing by reference object and tuples if `lent T` is returned