### PR TITLE
fixes cpp codegen regression #10948

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -540,7 +540,7 @@ proc initLocExprSingleUse(p: BProc, e: PNode, result: var TLoc) =
     discard "bug #8202; enforce evaluation order for nested calls for C++ too"
     # We may need to consider that 'f(g())' cannot be rewritten to 'tmp = g(); f(tmp)'
     # if 'tmp' lacks a move/assignment operator.
-    if e[0].kind == nkSym and sfConstructor in e[0].sym.flags:
+    if e[0].kind == nkSym and sfCompileToCpp in e[0].sym.flags:
       result.flags.incl lfSingleUse
   else:
     result.flags.incl lfSingleUse

--- a/tests/cpp/tretvar.nim
+++ b/tests/cpp/tretvar.nim
@@ -1,0 +1,39 @@
+discard """
+  targets: "cpp"
+  output: '''test1
+xest1
+'''
+"""
+{.passC: "-std=c++14".}
+
+{.experimental: "dotOperators".}
+
+import macros
+
+type
+  stdString {.importcpp: "std::string", header: "<string>".} = object
+  stdUniquePtr[T] {.importcpp: "std::unique_ptr", header: "<memory>".} = object
+
+proc c_str(a: stdString): cstring {.importcpp: "(char *)(#.c_str())", header: "<string>".}
+
+proc len(a: stdString): csize {.importcpp: "(#.length())", header: "<string>".}
+
+proc setChar(a: var stdString, i: csize, c: char) {.importcpp: "(#[#] = #)", header: "<string>".}
+
+proc `*`*[T](this: stdUniquePtr[T]): var T {.noSideEffect, importcpp: "(* #)", header: "<memory>".}
+
+proc make_unique_str(a: cstring): stdUniquePtr[stdString] {.importcpp: "std::make_unique<std::string>(#)", header: "<string>".}
+
+macro `.()`*[T](this: stdUniquePtr[T], name: untyped, args: varargs[untyped]): untyped =
+  result = nnkCall.newTree(
+    nnkDotExpr.newTree(
+      newNimNode(nnkPar).add(prefix(this, "*")),
+      name
+    )
+  )
+  copyChildrenTo(args, result)
+
+var val = make_unique_str("test1")
+echo val.c_str()
+val.setChar(0, 'x')
+echo val.c_str()


### PR DESCRIPTION
I managed to fix it without fully reverting 0cc6e124254a2222e04d1226fe9c362d20f38cd5.
Just light increase in single use scope for cpp imported procs not just constructors. 