### PR TITLE
Pure ref object

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1203,6 +1203,8 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       incl st.flags, tfRefsAnonObj
       let obj = newSym(skType, getIdent(c.cache, s.name.s & ":ObjectType"),
                               getCurrOwner(c), s.info)
+      if sfPure in s.flags:
+        obj.flags.incl sfPure
       obj.typ = st.lastSon
       st.lastSon.sym = obj
 

--- a/tests/types/tinheritref.nim
+++ b/tests/types/tinheritref.nim
@@ -1,9 +1,3 @@
-discard """
-  output: '''23
-1.5
-'''
-"""
-
 # bug #554, #179
 
 type T[E] =

--- a/tests/types/tinheritref.nim
+++ b/tests/types/tinheritref.nim
@@ -13,7 +13,8 @@ type T[E] =
 var ob: T[int]
 
 ob = T[int](elem: 23)
-echo ob.elem
+
+doAssert ob.elem == 23
 
 type
   TTreeIteratorA* = ref object {.inheritable.}
@@ -47,4 +48,42 @@ type
 
 var x = Apple(kind: Smooth, skin: 1.5)
 var u = x.skin
-echo u
+
+doAssert u == 1.5
+
+type
+  BaseRef {.inheritable, pure.} = ref object
+    baseRef: int
+
+  SubRef = ref object of BaseRef
+
+  BasePtr {.inheritable, pure.} = ptr object
+    basePtr: int
+  SubPtr = ptr object of BasePtr
+
+  BaseObj {.inheritable, pure.} = object
+    baseObj: int
+
+  SubObj = object of BaseObj
+
+template baseObj[T](t: ptr T): untyped = T
+
+proc something123(): int =
+  var r : SubRef
+  r.new
+  var p : SubPtr
+  p = create(baseObj(p))
+  var r2 : ref BaseObj
+  r2.new
+
+  var accu = 0
+  # trigger code generation
+  accu += r.baseRef
+  accu += p.basePtr
+  accu += r2.baseObj
+
+  doAssert sizeof(r[]) == sizeof(int)
+  doAssert sizeof(baseObj(p)) == sizeof(int)
+  doAssert sizeof(r2[]) == sizeof(int)
+
+discard something123()


### PR DESCRIPTION
fix for #10721 

This fix is tiny. But in my opinion this is code smell. Why does sfPure nead spcial treatment? Do other flags need this treatment as well?