### PR TITLE
fixes #9811

### DIFF
--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -26,7 +26,8 @@ Usage:
   nimpretty [options] file.nim
 Options:
   --output:file         set the output file (default: overwrite the input file)
-  --indent:N[=2]        set the number of spaces that is used for indentation
+  --indent:N[=0]        set the number of spaces that is used for indentation
+                        --indent:0 means autodetection (default behaviour)
   --version             show the version
   --help                show this help
 """
@@ -67,7 +68,6 @@ proc main =
     # if input is not actually over-written, when nimpretty is a noop).
     # --backup was un-documented (rely on git instead).
   var opt: PrettyOptions
-  opt.indWidth = 2
   for kind, key, val in getopt():
     case kind
     of cmdArgument:

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -67,6 +67,7 @@ proc main =
     # if input is not actually over-written, when nimpretty is a noop).
     # --backup was un-documented (rely on git instead).
   var opt: PrettyOptions
+  opt.indWidth = 2
   for kind, key, val in getopt():
     case kind
     of cmdArgument:


### PR DESCRIPTION
Although `nimpretty --help` says `--indent:N[=2]`, the default value of indent was 0.
I thought implementation is wrong, so I set the default value of `opt.indWidth` to 2.

As a side effect, #9811 is fixed.
The bug is because `getIndentWidth` in `compiler/layouter.nim` is called whenever `--indent=N` option is not set.