### PR TITLE
Improved docs around exec, staticExec, gorgeEx, etc.

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3924,7 +3924,8 @@ proc gorge*(command: string, input = "", cache = ""): string {.
 
 proc staticExec*(command: string, input = "", cache = ""): string {.
   magic: "StaticExec".} = discard
-  ## Executes an external process at compile-time.
+  ## Executes an external process at compile-time and returns its text output
+  ## (stdout + stderr).
   ##
   ## If `input` is not an empty string, it will be passed as a standard input
   ## to the executed program.

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -239,19 +239,24 @@ proc exec*(command: string) {.
   raises: [OSError], tags: [ExecIOEffect].} =
   ## Executes an external process. If the external process terminates with
   ## a non-zero exit code, an OSError exception is raised.
-  ## Note: If you need a version of ``exec`` that returns the exit code
-  ## and text output of the command, you can use ``gorgeEx`` from the
-  ## system module.
+  ##
+  ## **Note:** If you need a version of ``exec`` that returns the exit code
+  ## and text output of the command, you can use `system.gorgeEx
+  ## <system.html#gorgeEx,string,string,string>`_.
   log "exec: " & command:
     if rawExec(command) != 0:
       raise newException(OSError, "FAILED: " & command)
     checkOsError()
 
-proc exec*(command: string, input: string, cache = "") =
-  ## Executes an external process. Non-zero exit codes of the external process
-  ## are ignored.
+proc exec*(command: string, input: string, cache = "") {.
+  raises: [OSError], tags: [ExecIOEffect].} =
+  ## Executes an external process. If the external process terminates with
+  ## a non-zero exit code, an OSError exception is raised.
   log "exec: " & command:
-    echo staticExec(command, input, cache)
+    let (output, exitCode) = gorgeEx(command, input, cache)
+    if exitCode != 0:
+      raise newException(OSError, "FAILED: " & command)
+    echo output
 
 proc selfExec*(command: string) {.
   raises: [OSError], tags: [ExecIOEffect].} =

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -235,20 +235,26 @@ proc cpDir*(`from`, to: string) {.raises: [OSError].} =
     copyDir `from`, to
     checkOsError()
 
-proc exec*(command: string) =
-  ## Executes an external process.
+proc exec*(command: string) {.
+  raises: [OSError], tags: [ExecIOEffect].} =
+  ## Executes an external process. If the external process terminates with
+  ## a non-zero exit code, an OSError exception is raised.
+  ## Note: If you need a version of ``exec`` that returns the exit code
+  ## and text output of the command, you can use ``gorgeEx`` from the
+  ## system module.
   log "exec: " & command:
     if rawExec(command) != 0:
       raise newException(OSError, "FAILED: " & command)
     checkOsError()
 
-proc exec*(command: string, input: string, cache = "") {.
-  raises: [OSError], tags: [ExecIOEffect].} =
-  ## Executes an external process.
+proc exec*(command: string, input: string, cache = "") =
+  ## Executes an external process. Non-zero exit codes of the external process
+  ## are ignored.
   log "exec: " & command:
     echo staticExec(command, input, cache)
 
-proc selfExec*(command: string) =
+proc selfExec*(command: string) {.
+  raises: [OSError], tags: [ExecIOEffect].} =
   ## Executes an external command with the current nim/nimble executable.
   ## ``Command`` must not contain the "nim " part.
   let c = selfExe() & " " & command


### PR DESCRIPTION
Yesterday I sat down to implement `execEx` (returning exit code + output) for NimScript because it looked like it was missing. In the end, I discovered that it is actually available, just under the unexpected name `gorgeEx`. I missed it because:

- looking only at the nimscript module the functionality seems missing => added a mention of `gorgeEx` there.
- `gorgeEx` and `staticExec` actually never mentioned what they return => added.

It was also not clear the me what the `exec` functions do on non-zero exit codes, and I think one of the `raises` annotations were wrong, because `staticExec` swallows non-zero exit codes.

In general, it's quite confusing that process handling is split into three modules system, nimscript, osproc and that they using different naming schemes (exec, gorge, staticExec, runCmd).