### PR TITLE
relax warning about inconsistent spacing

### DIFF
--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -266,7 +266,7 @@ proc checkBinary(p: TParser) {.inline.} =
   ## Check if the current parser token is a binary operator.
   # we don't check '..' here as that's too annoying
   if p.tok.tokType == tkOpr:
-    if p.tok.strongSpaceB > 0 and p.tok.strongSpaceA != p.tok.strongSpaceB:
+    if p.tok.strongSpaceB > 0 and p.tok.strongSpaceA == 0:
       parMessage(p, warnInconsistentSpacing, prettyTok(p.tok))
 
 #| module = stmt ^* (';' / IND{=})


### PR DESCRIPTION
Now the warning is raised only in the cases when there is an
inconsistency in the style (spacing vs no spacing):
* `if a>_b`      --> warning
* `if a_>___b`   --> no warning