### PR TITLE
Add items() over closure iterator

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -313,6 +313,14 @@ iterator filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): T =
     if pred(s[i]):
       yield s[i]
 
+iterator items*[T](xs: iterator: T): T =
+  ## iterates over each element yielded by a closure iterator. This may
+  ## not seem particularly useful on its own, but this allows closure
+  ## iterators to be used by the the mapIt, filterIt, allIt, anyIt, etc.
+  ## templates.
+  for x in xs:
+    yield x
+
 proc filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
                                                                   {.inline.} =
   ## Returns a new sequence with all the items that fulfilled the predicate.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2315,6 +2315,14 @@ iterator items*[T](s: HSlice[T, T]): T =
   for x in s.a..s.b:
     yield x
 
+iterator items*[T](xs: iterator: T): T =
+  ## iterates over each element yielded by a closure iterator. This may
+  ## not seem particularly useful on its own, but this allows closure
+  ## iterators to be used by the the mapIt, filterIt, allIt, anyIt, etc.
+  ## templates implemented in sequtils.
+  for x in xs:
+    yield x
+
 iterator pairs*[T](a: openArray[T]): tuple[key: int, val: T] {.inline.} =
   ## iterates over each item of `a`. Yields ``(index, a[index])`` pairs.
   var i = 0


### PR DESCRIPTION
A very simple, very tiny addition, but this PR adds a little bit of code to system.nim that I've always found to be helpful:

```Nim
iterator items*[T](xs: iterator: T): T =
  for x in xs():
    yield x
```

All it does is iterate over the items yielded by a closure iterator. This sounds redundant and stupid, but it allows the `mapIt`, `allIt`, `filterIt`, etc. templates in sequtils to be used with closure iterators

I was originally going to put this snippet in sequtils, since AFAIK the only time it's helpful is with the sequtils templates, but found that the other `items` implementations are all in system.nim, so I figured I'd keep that consistent.