### PR TITLE
Make `secureHash` accept any `openArray[char]`, not only `string`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,9 @@
 
 - `osproc.execProcess` now also takes a `workingDir` parameter.
 
+- `std/sha1.secureHash` now accepts `openArray[char]`, not `string`. (Former
+   successful matches should keep working, though former failures will not.)
+
 - `options.UnpackError` is no longer a ref type and inherits from `system.Defect`
   instead of `system.ValueError`.
 

--- a/lib/std/sha1.nim
+++ b/lib/std/sha1.nim
@@ -194,7 +194,7 @@ proc finalize(ctx: var Sha1State): Sha1Digest =
 
 # Public API
 
-proc secureHash*(str: string): SecureHash =
+proc secureHash*(str: openArray[char]): SecureHash =
   ## Generates a ``SecureHash`` from a ``str``.
   ##
   ## **See also:**


### PR DESCRIPTION
Enough said?  I needed to hash just a sub-range of a `MemFile` via `toOpenArray[char]`, but other slice contexts can presumably benefit from this, too.