### PR TITLE
faster CountTable sort(), optional SortOrder

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1475,6 +1475,7 @@ proc sort*[A, B](t: var OrderedTable[A, B], cmp: proc (x,y: (A, B)): int, order 
   ## call but key lookup and insertions remain possible after ``sort`` (in
   ## contrast to the `sort proc<#sort,CountTable[A]>`_ for count tables).
   runnableExamples:
+    import algorithm
     var a = initOrderedTable[char, int]()
     for i, c in "cab":
       a[c] = 10*i
@@ -1885,6 +1886,7 @@ proc sort*[A, B](t: OrderedTableRef[A, B], cmp: proc (x,y: (A, B)): int, order =
   ## call but key lookup and insertions remain possible after ``sort`` (in
   ## contrast to the `sort proc<#sort,CountTableRef[A]>`_ for count tables).
   runnableExamples:
+    import algorithm
     var a = newOrderedTable[char, int]()
     for i, c in "cab":
       a[c] = 10*i
@@ -2216,6 +2218,7 @@ proc sort*[A](t: var CountTable[A], order = SortOrder.Descending) =
   ## `keys<#keys.i,CountTable[A]>`_, and `values<#values.i,CountTable[A]>`_
   ## to iterate over ``t`` in the sorted order.
   runnableExamples:
+    import algorithm, sequtils
     var a = toCountTable("abracadabra")
     doAssert a == "aaaaabbrrcd".toCountTable
     a.sort()

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -8,7 +8,7 @@ And we get here
 '''
 joinable: false
 """
-import hashes, sequtils, tables
+import hashes, sequtils, tables, algorithm
 
 # test should not be joined because it takes too long.
 block tableadds:
@@ -274,22 +274,30 @@ block tablesref:
   block countTableTest1:
     var s = data.toTable
     var t = newCountTable[string]()
-    for k in s.keys: t.inc(k)
-    for k in t.keys: assert t[k] == 1
-    t.inc("90", 3)
-    t.inc("12", 2)
-    t.inc("34", 1)
+    var r = newCountTable[string]()
+    for x in [t, r]:
+      for k in s.keys:
+        x.inc(k)
+        assert x[k] == 1
+      x.inc("90", 3)
+      x.inc("12", 2)
+      x.inc("34", 1)
     assert t.largest()[0] == "90"
 
     t.sort()
-    var i = 0
-    for k, v in t.pairs:
-      case i
-      of 0: assert k == "90" and v == 4
-      of 1: assert k == "12" and v == 3
-      of 2: assert k == "34" and v == 2
-      else: break
-      inc i
+    r.sort(SortOrder.Ascending)
+    var ps1 = toSeq t.pairs
+    var ps2 = toSeq r.pairs
+    ps2.reverse()
+    for ps in [ps1, ps2]:
+      var i = 0
+      for (k, v) in ps:
+        case i
+        of 0: assert k == "90" and v == 4
+        of 1: assert k == "12" and v == 3
+        of 2: assert k == "34" and v == 2
+        else: break
+        inc i
 
   block SyntaxTest:
     var x = newTable[int, string]({:})
@@ -308,12 +316,19 @@ block tablesref:
     var t = newOrderedTable[string, int](2)
     for key, val in items(data): t[key] = val
     for key, val in items(data): assert t[key] == val
-    t.sort(proc (x, y: tuple[key: string, val: int]): int = cmp(x.key, y.key))
+    proc cmper(x, y: tuple[key: string, val: int]): int = cmp(x.key, y.key)
+    t.sort(cmper)
     var i = 0
     # `pairs` needs to yield in sorted order:
     for key, val in pairs(t):
       doAssert key == sorteddata[i][0]
       doAssert val == sorteddata[i][1]
+      inc(i)
+    t.sort(cmper, order=SortOrder.Descending)
+    i = 0
+    for key, val in pairs(t):
+      doAssert key == sorteddata[high(data)-i][0]
+      doAssert val == sorteddata[high(data)-i][1]
       inc(i)
 
     # check that lookup still works:


### PR DESCRIPTION
As long as we are importing algorithm, it seemed reasonable to let the user override the sort order without redefining cmp.  The defaults have not changed.  I'd like to add a test or two for this functionality, but first...

Attempts to modify a CountTable after a sort() don't go well.  In my experiment, with many items, my program appeared to hang.  What about adding an `unsafe` boolean or similar and raising a runtime error in the event of a misbehaving mutate?