### PR TITLE
add algorithm.fillWith, closes #3857

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -85,6 +85,9 @@ proc fill*[T](a: var openArray[T], first, last: Natural, value: T) =
 
 proc fill*[T](a: var openArray[T], value: T) =
   ## Fills the container ``a`` with ``value``.
+  ##
+  ## See also:
+  ## * `fillWith template <#fillWith.t,openArray[T],untyped>`_
   runnableExamples:
     var a: array[6, int]
     a.fill(9)
@@ -93,6 +96,13 @@ proc fill*[T](a: var openArray[T], value: T) =
     assert a == [4, 4, 4, 4, 4, 4]
   fillImpl(a, 0, a.high, value)
 
+template fillWith*[T](a: var openArray[T], f: untyped) =
+  ## Fills the container ``a`` with ``f``.
+  runnableExamples:
+    import random
+    var a: array[6, int]
+    a.fillWith(rand(10))
+  fillImpl(a, 0, a.high, f)
 
 proc reverse*[T](a: var openArray[T], first, last: Natural) =
   ## Reverses the slice ``a[first..last]``.

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -97,11 +97,19 @@ proc fill*[T](a: var openArray[T], value: T) =
   fillImpl(a, 0, a.high, value)
 
 template fillWith*[T](a: var openArray[T], f: untyped) =
-  ## Fills the container ``a`` with ``f``.
+  ## Fills the container ``a`` by calling ``f`` for every element of ``a``.
+  ##
+  ## This is similar to `sequtils.newSeqWith <sequtils.html#newSeqWith.t,int,untyped>`_
+  ## but it is more memory efficient since it doesn't copy its result.
   runnableExamples:
     import random
     var a: array[6, int]
     a.fillWith(rand(10))
+    ## a = [7, 8, 4, 0, 2, 10]  <- `rand` was called for every element
+    ##
+    ## in contrast with:
+    a.fill(rand(10))
+    ## a = [7, 7, 7, 7, 7, 7]   <- `rand` was called only once
   fillImpl(a, 0, a.high, f)
 
 proc reverse*[T](a: var openArray[T], first, last: Natural) =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -883,6 +883,8 @@ template newSeqWith*(len: int, init: untyped): untyped =
   ## Useful for creating "2D" sequences - sequences containing other sequences
   ## or to populate fields of the created sequence.
   ##
+  ## For a more memory-efficient variant, see
+  ## `algorithm.fillWith <algorithm.html#fillWith.t,openArray[T],untyped>`_.
   runnableExamples:
     ## Creates a seqence containing 5 bool sequences, each of length of 3.
     var seq2D = newSeqWith(5, newSeq[bool](3))
@@ -892,7 +894,7 @@ template newSeqWith*(len: int, init: untyped): untyped =
 
     ## Creates a sequence of 20 random numbers from 1 to 10
     import random
-    var seqRand = newSeqWith(20, random(10))
+    var seqRand = newSeqWith(20, rand(10))
 
   var result = newSeq[type(init)](len)
   for i in 0 ..< len:


### PR DESCRIPTION
This is a more memory-efficient version of `newSeqWith`, which doesn't copy its result.

----

Using `newSeqWith`:

```nim
import sequtils, random, algorithm

const N = 50_000_000
var a = newSeqWith(N, rand(100))
```

```--> 1.302s, 681724 KB```

----

Using `fillWith`:

```nim
import sequtils, random, algorithm

const N = 50_000_000
var b = newSeq[int](N)
b.fillWith(rand(100))
```

```--> 1.078s, 392364 KB```

...and with the uninitialized seq:
```nim
import sequtils, random, algorithm

const N = 50_000_000
var b = newSeqUninitialized[int](N)
b.fillWith(rand(100))
```

```--> 1.083s, 366124 KB```
