### PR TITLE
Add len check for newIfStmt to avoid segfault

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1105,6 +1105,8 @@ proc newIfStmt*(branches: varargs[tuple[cond, body: NimNode]]):
   ##    )
   ##
   result = newNimNode(nnkIfStmt)
+  if len(branches) < 1:
+    error("If statement must have at least one branch")
   for i in branches:
     result.add(newTree(nnkElifBranch, i.cond, i.body))
 


### PR DESCRIPTION
`macros.newIfStmt` segfaults on empty/invalid input. Makes it an error message instead.