### PR TITLE
Fix unexpected result of rand on a range #11015

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -362,7 +362,7 @@ proc rand*[T](r: var Rand; a: openArray[T]): T {.deprecated.} =
   ## Use `sample[T](Rand, openArray[T])<#sample,Rand,openArray[T]>`_ instead.
   result = a[rand(r, a.low..a.high)]
 
-proc rand*[T: SomeInteger|range](t: typedesc[T]): T =
+proc rand*[T: SomeInteger](t: typedesc[T]): T =
   ## Returns a random integer in the range `low(T)..high(T)`.
   ##
   ## If `randomize<#randomize>`_ has not been called, the sequence of random


### PR DESCRIPTION
The proc description is unchanged because the code is almost verbatim of the current description. This is one possible fix. Other ideas: Make another proc with just signature `T: range`. When T is range, error out with a suggestion to use the `HSlice` rand instead. Also: Is there anywhere I should add tests?