### PR TITLE
tables: better error message for uninitialized table, fixes #10716

### DIFF
--- a/tests/niminaction/Chapter3/ChatApp/src/protocol.nim
+++ b/tests/niminaction/Chapter3/ChatApp/src/protocol.nim
@@ -7,7 +7,8 @@ type
 
   MessageParsingError* = object of Exception
 
-proc parseMessage*(data: string): Message {.raises: [MessageParsingError, KeyError].} =
+proc parseMessage*(data: string): Message {.raises: [MessageParsingError,
+                                           KeyError, AccessViolationError].} =
   var dataJson: JsonNode
   try:
     dataJson = parseJson(data)


### PR DESCRIPTION
Similar logic to how it is done for `deques`.