### PR TITLE
Fix varargs int32

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2092,14 +2092,21 @@ proc paramTypesMatchAux(m: var TCandidate, f, a: PType,
         result = localConvMatch(c, m, f, a, arg)
       else:
         r = typeRel(m, base(f), a)
-        if r >= isGeneric:
+        case r
+        of isGeneric:
           inc(m.convMatches)
           result = copyTree(arg)
-          if r == isGeneric:
-            result.typ = getInstantiatedType(c, arg, m, base(f))
+          result.typ = getInstantiatedType(c, arg, m, base(f))
           m.baseTypeMatch = true
-        # bug #4799, varargs accepting subtype relation object
-        elif r == isSubtype:
+        of isFromIntLit:
+          inc(m.intConvMatches, 256)
+          result = implicitConv(nkHiddenStdConv, f[0], arg, m, c)
+          m.baseTypeMatch = true
+        of isEqual:
+          inc(m.convMatches)
+          result = copyTree(arg)
+          m.baseTypeMatch = true
+        of isSubtype: # bug #4799, varargs accepting subtype relation object
           inc(m.subtypeMatches)
           if base(f).kind == tyTypeDesc:
             result = arg

--- a/tests/ccgbugs/t5701.nim
+++ b/tests/ccgbugs/t5701.nim
@@ -2,6 +2,7 @@ discard """
   output: '''(1, 1)
 (2, 2)
 (3, 3)
+@[1, 2, 3, 4]
 '''
 """
 
@@ -15,3 +16,12 @@ proc foo(args: varargs[int]) =
     discard
 
 foo(1,2,3)
+
+# 10999
+
+proc varargsToSeq(vals: varargs[int32]): seq[int32] =
+  result = newSeqOfCap[int32](vals.len)
+  for v in vals:
+    result.add v
+
+echo varargsToSeq(1, 2, 3, 4)


### PR DESCRIPTION
Simply a missing injection of ``nkHiddenStdConv`` for varargs. There are probably other problems with varargs yet that have been solved for normal parameter passing already, simply because varargs doesn't share the code with normal parameter passing.