### PR TITLE
Avoid sigsev parsing float out of empty string.

### DIFF
--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -135,6 +135,9 @@ proc nimParseBiggestFloat(s: string, number: var BiggestFloat,
   #  INTEGER * 10 ^ exponent and leave the work to standard `strtod()`.
   # This avoid the problems of decimal character portability.
   # see: http://www.exploringbinary.com/fast-path-decimal-to-floating-point-conversion/
+  if s.len < 1:
+    return 0
+
   var
     i = start
     sign = 1.0


### PR DESCRIPTION
```
$ cat test.nim 
import strutils
var a: string = ""
echo a.parse_float
$ nim c -r test
Hint: used config file '/Users/gradha/.choosenim/toolchains/nim-#devel/config/nim.cfg' [Conf]
Hint: used config file '/Users/gradha/.choosenim/toolchains/nim-#devel/config/config.nims' [Conf]
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: test [Processing]
Hint: strutils [Processing]
Hint: parseutils [Processing]
Hint: math [Processing]
Hint: bitops [Processing]
Hint: macros [Processing]
Hint: algorithm [Processing]
Hint: unicode [Processing]
Hint:  [Link]
Hint: operation successful (31531 lines compiled; 0.490 sec total; 38.18MiB peakmem; Debug Build) [SuccessX]
Hint: /private/tmp/t/test  [Exec]
Traceback (most recent call last)
test.nim(3)              test
strutils.nim(1065)       parseFloat
parseutils.nim(521)      parseFloat
strmantle.nim(150)       nimParseBiggestFloat
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
Error: execution of an external program failed: '/private/tmp/t/test '
```
