### PR TITLE
Make parseutils.parseBin|Oct|Hex generic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,10 +47,16 @@
 
 - `system.ValueError` now inherits from `system.CatchableError` instead of `system.Defect`.
 
-- The procs `parseutils.parseBiggsetInt`, `parseutils.parseInt`,
+- The procs `parseutils.parseBiggestInt`, `parseutils.parseInt`,
   `parseutils.parseBiggestUInt` and `parseutils.parseUInt` now raise a
   `ValueError` when the parsed integer is outside of the valid range.
   Previously they sometimes raised a `OverflowError` and sometimes returned `0`.
+
+- The procs `parseutils.parseBin`, `parseutils.parseOct` and `parseutils.parseHex`
+  were not clearing their `var` parameter `number` and used to push its value to
+  the left when storing the parsed string into it. Now they always set the value
+  of the parameter to `0` before storing the result of the parsing, unless the
+  string to parse is not valid and then the value of `number` is not changed.
 
 - `streams.StreamObject` now restricts its fields to only raise `system.Defect`,
   `system.IOError` and `system.OSError`.

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -136,7 +136,7 @@ proc parseOct*(s: string, number: var int, start = 0, maxLen = 0): int  {.
     inc(i)
   if foundDigit: result = i-start
 
-proc parseBin*(s: string, number: var int, start = 0, maxLen = 0): int {.
+proc parseBin*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0): int {.
   rtl, extern: "npuParseBin", noSideEffect.} =
   ## Parses an binary number and stores its value in ``number``. Returns
   ## the number of the parsed characters or 0 in case of an error.
@@ -145,9 +145,25 @@ proc parseBin*(s: string, number: var int, start = 0, maxLen = 0): int {.
   ## Else no more than ``start + maxLen`` characters are parsed, up to the
   ## length of the string.
   runnableExamples:
-    var res: int
-    doAssert parseBin("010011100110100101101101", res) == 24
-    doAssert parseBin("3", res) == 0
+    var num: int
+    doAssert parseBin("010011100110100111101101", num) == 24
+    doAssert num == 5138925
+    doAssert parseBin("3", num) == 0
+    
+    var num8: int8
+    doAssert parseBin("010011100110100111101101", num8) == 24
+    doAssert num8 == -19
+    doAssert parseBin("010011100110100111101101", num8, 0, 8) == 8
+    doAssert num8 == 78
+    
+    var num8u: uint8
+    doAssert parseBin("010011100110100111101101", num8u) == 24
+    doAssert num8u == 237
+    
+    var num64: int64
+    doAssert parseBin("010011100110100111101101010011100110100111101101", num64) == 48
+    doAssert num64 == 86216859871725
+    
   var i = start
   var foundDigit = false
   # get last index based on minimum `start + maxLen` or `s.len`
@@ -157,7 +173,7 @@ proc parseBin*(s: string, number: var int, start = 0, maxLen = 0): int {.
     case s[i]
     of '_': discard
     of '0'..'1':
-      number = number shl 1 or (ord(s[i]) - ord('0'))
+      number = number shl 1 or cast[T](ord(s[i]) - ord('0'))
       foundDigit = true
     else: break
     inc(i)


### PR DESCRIPTION
Reimplemented parseutils.parseBin|Oct|Hex using template and made them generic that var argument could be of any SomeInteger type. This is the basis to make templates for parseBinInt32, parseBinUint64 and siblings in strutils. Refer to issue #11063.