### PR TITLE
(docs) fix unidecode.unidecode example input string

### DIFF
--- a/lib/pure/unidecode/unidecode.nim
+++ b/lib/pure/unidecode/unidecode.nim
@@ -57,7 +57,7 @@ proc unidecode*(s: string): string =
   ##
   ## ..code-block:: nim
   ##
-  ##   unidecode("\x53\x17\x4E\xB0")
+  ##   unidecode("北京")
   ##
   ## Results in: "Bei Jing"
   ##


### PR DESCRIPTION
The existing example doesn't actually have the intended output:

```
nim> echo unidecode("\x53\x17\x4E\xB0")
SNdeg

nim> echo unidecode("\xe5\x8c\x97\xe4\xba\xac")
Bei Jing
```

moreover, it's misrendered in the HTML as `unidecode("x53x17x4ExB0")` with backlashes stripped.

When replaced with the Chinese, the produced HTML looks good and it actually unidecods into "Bei Jing" as intended.