### PR TITLE
tables: fix link

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -19,7 +19,7 @@
 ## For consistency with every other data type in Nim these have **value**
 ## semantics, this means that ``=`` performs a copy of the hash table.
 ##
-## For `ref semantics<manual.html#types-ref-and-pointer-types>`_
+## For `ref semantics<manual.html#types-reference-and-pointer-types>`_
 ## use their ``Ref`` variants: `TableRef<#TableRef>`_,
 ## `OrderedTableRef<#OrderedTableRef>`_, and `CountTableRef<#CountTableRef>`_.
 ##


### PR DESCRIPTION
It didn't match with the corresponding section in the manual.

Edit: gah I forget that [ci skip] exists; sorry about that