### PR TITLE
Fix ..< iterator

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2641,6 +2641,20 @@ when defined(nimNewRoof):
       yield i
       inc i
 
+  template dotdotLessImpl(t) {.dirty.} =
+    iterator `..<`*(a, b: t): t {.inline.} =
+      ## A type specialized version of ``..<`` for convenience so that
+      ## mixing integer types works better.
+      var res = a
+      while res < b:
+        yield res
+        inc(res)
+
+  dotdotLessImpl(int64)
+  dotdotLessImpl(int32)
+  dotdotLessImpl(uint64)
+  dotdotLessImpl(uint32)
+
 else:
   iterator countup*[S, T](a: S, b: T, step = 1): T {.inline.} =
     ## Counts from ordinal value `a` up to `b` (inclusive) with the given

--- a/tests/iter/tcountup.nim
+++ b/tests/iter/tcountup.nim
@@ -1,9 +1,25 @@
 discard """
-  output: "0123456789"
+  output: '''
+0123456789
+0.0
+'''
 """
 
 # Test new countup
 
 for i in 0 ..< 10'i64:
   stdout.write(i)
-echo "\n"
+
+echo()
+
+# 11099
+
+var
+  x: uint32
+  y: float
+
+for i in 0 ..< x:
+  if i == 1: echo i
+  y += 1
+
+echo y


### PR DESCRIPTION
fix #11099 

#### The problem

The `..<` iterator did not have the same overloads as the `..` iterator. Then the generic template ``..<`` was expanded which eventually caused the bug.

#### The solution

 * The generic `..<` template is now restricted to not match the general untyped ast anymore.
 * Provide the exact same overloads to `..<` as `..`.