### PR TITLE
[experiment] ropes on alloc

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -438,8 +438,7 @@ proc genInfixCall(p: BProc, le, ri: PNode, d: var TLoc) =
   assert(typ.kind == tyProc)
   var length = sonsLen(ri)
   assert(sonsLen(typ) == sonsLen(typ.n))
-  # don't call '$' here for efficiency:
-  let pat = ri.sons[0].sym.loc.r.data
+  let pat = $ri.sons[0].sym.loc.r
   internalAssert p.config, pat.len > 0
   if pat.contains({'#', '(', '@', '\''}):
     var pl = genPatternCall(p, ri, pat, typ)
@@ -487,8 +486,7 @@ proc genNamedParamCall(p: BProc, ri: PNode, d: var TLoc) =
   var length = sonsLen(ri)
   assert(sonsLen(typ) == sonsLen(typ.n))
 
-  # don't call '$' here for efficiency:
-  let pat = ri.sons[0].sym.loc.r.data
+  let pat = $ri.sons[0].sym.loc.r
   internalAssert p.config, pat.len > 0
   var start = 3
   if ' ' in pat:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -785,7 +785,7 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
     else: addAbiCheck(m, t, result)
   of tyObject, tyTuple:
     if isImportedCppType(t) and origTyp.kind == tyGenericInst:
-      let cppName = getTypeName(m, t, sig)
+      let cppName: string = $getTypeName(m, t, sig)
       var i = 0
       var chunkStart = 0
 
@@ -798,12 +798,12 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
         else:
           result.add getTypeDescAux(m, ty, check)
 
-      while i < cppName.data.len:
-        if cppName.data[i] == '\'':
+      while i < cppName.len:
+        if cppName[i] == '\'':
           var chunkEnd = i-1
           var idx, stars: int
-          if scanCppGenericSlot(cppName.data, i, idx, stars):
-            result.add cppName.data.substr(chunkStart, chunkEnd)
+          if scanCppGenericSlot(cppName, i, idx, stars):
+            result.add cppName.substr(chunkStart, chunkEnd)
             chunkStart = i
 
             let typeInSlot = resolveStarsInCppType(origTyp, idx + 1, stars)
@@ -812,9 +812,9 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
           inc i
 
       if chunkStart != 0:
-        result.add cppName.data.substr(chunkStart)
+        result.add cppName.substr(chunkStart)
       else:
-        result = cppName & "<"
+        result = rope(cppName & "<")
         for i in 1 .. origTyp.len-2:
           if i > 1: result.add(" COMMA ")
           addResultType(origTyp.sons[i])

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1520,7 +1520,7 @@ proc genInfixCall(p: PProc, n: PNode, r: var TCompRes) =
   let f = n[0].sym
   if f.loc.r == nil: f.loc.r = mangleName(p.module, f)
   if sfInfixCall in f.flags:
-    let pat = n.sons[0].sym.loc.r.data
+    let pat = $n.sons[0].sym.loc.r
     internalAssert p.config, pat.len > 0
     if pat.contains({'#', '(', '@'}):
       var typ = skipTypes(n.sons[0].typ, abstractInst)


### PR DESCRIPTION
This is an experiment to allocate the compiler internal ropes with ``alloc`` and make them a pointer. As ropes are will never change their content, I moved the data directly at the end of the rope object to avoid additional pointer indirection, allocations and the overhead of storing the string length and capacity. Since ropes are not collected at all anymore it is expected that the memory usage increases. These are my performance measurements:

```
$ koch boot -d:release --gc:markAndSweep # on branch devel
$ nim c --compileOnly compiler/nim.nim # (4 times)
Hint: operation successful (144299 lines compiled; 4.591 sec total; 424.773MiB peakmem; Debug Build)
Hint: operation successful (144299 lines compiled; 4.598 sec total; 424.770MiB peakmem; Debug Build)
Hint: operation successful (144299 lines compiled; 4.559 sec total; 424.777MiB peakmem; Debug Build)
Hint: operation successful (144299 lines compiled; 4.594 sec total; 424.773MiB peakmem; Debug Build)
$ koch boot -d:release --gc:markAndSweep # on branch ropes-experiment
$ nim c --compileOnly compiler/nim.nim (6 times)
Hint: operation successful (144299 lines compiled; 4.398 sec total; 530.812MiB peakmem; Debug Build)
Hint: operation successful (144299 lines compiled; 4.413 sec total; 530.824MiB peakmem; Debug Build)
Hint: operation successful (144299 lines compiled; 4.420 sec total; 530.824MiB peakmem; Debug Build)
Hint: operation successful (144327 lines compiled; 4.428 sec total; 530.906MiB peakmem; Debug Build)
Hint: operation successful (144327 lines compiled; 4.415 sec total; 530.867MiB peakmem; Debug Build)
Hint: operation successful (144327 lines compiled; 4.405 sec total; 530.902MiB peakmem; Debug Build)
```

Well, it is measurably faster. 