### PR TITLE
better error message for metatypes, fixes #8654

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -439,8 +439,11 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
     var length = sonsLen(a)
 
     var typ: PType = nil
-    if a.sons[length-2].kind != nkEmpty:
-      typ = semTypeNode(c, a.sons[length-2], nil)
+    let n = a.sons[length-2]
+    if n.kind != nkEmpty:
+      typ = semTypeNode(c, n, nil)
+      if typ.isMetaType:
+        localError(c.config, n.info, errTIsNotAConcreteType % typ.typeToString)
 
     var def: PNode = c.graph.emptyNode
     if a.sons[length-1].kind != nkEmpty:

--- a/tests/errmsgs/t8654.nim
+++ b/tests/errmsgs/t8654.nim
@@ -1,0 +1,6 @@
+discard """
+  errmsg: "'typedesc' is not a concrete type"
+  line: 6
+"""
+## issue #8654
+var a: typedesc


### PR DESCRIPTION
The other example from the same issue (`const a: typedesc = typedesc[int]`) is already fixed and it throws `Error: 'typedesc' metatype is not valid here; typed '=' instead of ':'?`.