### PR TITLE
Fix #11111 nkIdentsDef left in vmgen

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1585,8 +1585,8 @@ proc genGlobalInit(c: PCtx; n: PNode; s: PSym) =
   #   var decls{.compileTime.}: seq[NimNode] = @[]
   let dest = c.getTemp(s.typ)
   c.gABx(n, opcLdGlobal, dest, s.position)
-  if s.ast != nil:
-    let tmp = c.genx(s.ast)
+  if s.astdef != nil:
+    let tmp = c.genx(s.astdef)
     c.genAdditionalCopy(n, opcWrDeref, dest, 0, tmp)
     c.freeTemp(dest)
     c.freeTemp(tmp)


### PR DESCRIPTION
See #11111, cc @cooldome.

This fix a corner case where nkIdentDefs can be left in the AST at the codegen stage.

Unfortunately I don't have a small testcase, I'm also not sure what the difference between ast and astdef is.