### PR TITLE
fix #11133, error on runtime use of compile-time procs in JS target

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1268,6 +1268,9 @@ proc genSym(p: PProc, n: PNode, r: var TCompRes) =
       internalError(p.config, n.info, "symbol has no generated name: " & s.name.s)
     r.res = s.loc.r
   of skProc, skFunc, skConverter, skMethod:
+    if sfCompileTime in s.flags:
+      localError(p.config, n.info, "request to generate code for .compileTime proc: " &
+          s.name.s)
     discard mangleName(p.module, s)
     r.res = s.loc.r
     if lfNoDecl in s.loc.flags or s.magic != mNone or


### PR DESCRIPTION
fix for #11133

given (invalid) jscomp.nim and (valid) jscomp2.nim:
```nim
proc test() {.compileTime.} =
  echo "can only be called at compile time?"

test()
```

```nim
proc test() {.compileTime.} =
  echo "can only be called at compile time?"

const x = block:
  test()
  42

echo "ok"
```

### current output
Nim compiles the invalid code without complaint, and then JS dies at runtime:
```
$ nim js --run jscomp.nim
Hint: used config file '/usr/local/Cellar/nim/0.19.4/nim/config/nim.cfg' [Conf]
Hint: system [Processing]
Hint: jscomp [Processing]
Hint: operation successful (5883 lines compiled; 0.037 sec total; 4.547MiB peakmem; Debug Build) [SuccessX]
Hint: /usr/local/bin/../Cellar/node/11.14.0_1/bin/node /Users/jfondren/nim/learn/nimcache/jscomp.js  [Exec]
/Users/jfondren/nim/learn/nimcache/jscomp.js:28
test_25003();
^

ReferenceError: test_25003 is not defined
    at Object.<anonymous> (/Users/jfondren/nim/learn/nimcache/jscomp.js:28:1)
    at Module._compile (internal/modules/cjs/loader.js:816:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:877:12)
    at internal/main/run_main_module.js:21:11

$ nim js --run jscomp2.nim
Hint: used config file '/usr/local/Cellar/nim/0.19.4/nim/config/nim.cfg' [Conf]
Hint: system [Processing]
Hint: jscomp2 [Processing]
can only be called at compile time?
Hint: operation successful (5887 lines compiled; 0.037 sec total; 4.547MiB peakmem; Debug Build) [SuccessX]
Hint: /usr/local/bin/../Cellar/node/11.14.0_1/bin/node /Users/jfondren/nim/learn/nimcache/jscomp2.js  [Exec]
ok
```

### patched output
With this PR, Nim complains about the compile-time use, with code taken from compiler/ccgexprs.nim
```
$ ../Nim/bin/nim js --run jscomp.nim
Hint: used config file '/Users/jfondren/nim/Nim/config/nim.cfg' [Conf]
Hint: used config file '/Users/jfondren/nim/Nim/config/config.nims' [Conf]
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: jscomp [Processing]
jscomp.nim(4, 1) Error: request to generate code for .compileTime proc: test

$ ../Nim/bin/nim js --run jscomp2.nim
Hint: used config file '/Users/jfondren/nim/Nim/config/nim.cfg' [Conf]
Hint: used config file '/Users/jfondren/nim/Nim/config/config.nims' [Conf]
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: jscomp2 [Processing]
can only be called at compile time?
jscomp2.nim(4, 7) Hint: 'x' is declared but not used [XDeclaredButNotUsed]
Hint: operation successful (15194 lines compiled; 0.052 sec total; 10.559MiB peakmem; Debug Build) [SuccessX]
Hint: /usr/local/Cellar/node/11.14.0_1/bin/node /Users/jfondren/nim/learn/jscomp2.js  [Exec]
ok
```