### PR TITLE
Better empty seq and array parameter error messages

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1133,6 +1133,10 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
 
       if typ == nil:
         typ = def.typ
+        if typ.kind == tySequence and def.typ[0].kind == tyEmpty or
+            typ.kind == tyArray and def.typ[1].kind == tyEmpty:
+          localError(c.config, a.info, "cannot infer the type of parameter '" & a[0].ident.s & "'")
+
         if typ.kind == tyTypeDesc:
           # consider a proc such as:
           # proc takesType(T = int)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1133,8 +1133,8 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
 
       if typ == nil:
         typ = def.typ
-        if typ.kind == tySequence and def.typ[0].kind == tyEmpty or
-            typ.kind == tyArray and def.typ[1].kind == tyEmpty:
+        if typ.kind == tySequence and typ[0].kind == tyEmpty or
+            typ.kind == tyArray and typ[1].kind == tyEmpty:
           localError(c.config, a.info, "cannot infer the type of parameter '" & a[0].ident.s & "'")
 
         if typ.kind == tyTypeDesc:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1133,8 +1133,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
 
       if typ == nil:
         typ = def.typ
-        if typ.kind == tySequence and typ[0].kind == tyEmpty or
-            typ.kind == tyArray and typ[1].kind == tyEmpty:
+        if isEmptyContainer(typ):
           localError(c.config, a.info, "cannot infer the type of parameter '" & a[0].ident.s & "'")
 
         if typ.kind == tyTypeDesc:

--- a/tests/proc/temptyarray.nim
+++ b/tests/proc/temptyarray.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "cannot infer the type of parameter 'x'"
+  line: 6
+"""
+
+proc foo(x = []) = discard

--- a/tests/proc/temptyseq.nim
+++ b/tests/proc/temptyseq.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "cannot infer the type of parameter 'y'"
+  line: 6
+"""
+
+proc bar(y = @[]) = discard


### PR DESCRIPTION
These currently fail in unhelpful ways.
```nim
proc a(x = []) = discard
proc b(y = @[]) = discard
proc c(z = []) = echo z
proc d(w = @[]) = echo w
a() # fails in c gen
b() # fails in the c compiler
c() # fails with type mismatch: got empty
d() # fails with closest overload being collectionToString
```
With this pr, they fail with `cannot infer the type of parameter 'paramName'`.