### PR TITLE
Destructor lifting fixes #11149

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -325,7 +325,7 @@ proc genOp(c: Con; t: PType; kind: TTypeAttachedOp; dest, ri: PNode): PNode =
 
   if op == nil:
     # give up and find the canonical type instead:
-    let h = sighashes.hashType(t, {CoType, CoConsiderOwned})
+    let h = sighashes.hashType(t, {CoType, CoConsiderOwned, CoDistinct})
     let canon = c.graph.canonTypes.getOrDefault(h)
     if canon != nil:
       op = canon.attachedOps[kind]

--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -36,6 +36,7 @@ type
     CoOwnerSig
     CoIgnoreRange
     CoConsiderOwned
+    CoDistinct
 
 proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag])
 
@@ -97,7 +98,11 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
     for i in countup(0, sonsLen(t) - 1):
       c.hashType t.sons[i], flags
   of tyDistinct:
-    if {CoType, CoConsiderOwned} * flags == {CoType} or t.sym == nil:
+    if CoDistinct in flags:
+      if t.sym != nil: c.hashSym(t.sym)
+      if t.sym == nil or tfFromGeneric in t.flags:
+        c.hashType t.lastSon, flags
+    elif CoType in flags or t.sym == nil:
       c.hashType t.lastSon, flags
     else:
       c.hashSym(t.sym)

--- a/tests/destructor/topt.nim
+++ b/tests/destructor/topt.nim
@@ -1,0 +1,61 @@
+
+discard """
+  output: '''5
+vseq destroy
+'''
+"""
+type
+  opt*[T] = object
+    case exists: bool
+      of true: val: T
+      of false: discard
+
+proc some*[T](val: sink T): opt[T] {.inline.} =
+  ## Returns an ``opt`` that has the value.
+  ## nil is considered as none for reference types
+  result.exists = true
+  result.val = val
+
+proc none*(T: typedesc): opt[T] {.inline.} =
+  ## Returns an ``opt`` for this type that has no value.
+  # the default is the none type
+  discard
+
+proc none*[T]: opt[T] {.inline.} =
+  ## Alias for ``none(T)``.
+  none(T)
+
+proc unsafeGet*[T](self: opt[T]): lent T {.inline.} =
+  ## Returns the value of a ``some``. Behavior is undefined for ``none``.
+  self.val
+
+type
+  VSeq*[T] = object
+    len: int 
+    data: ptr UncheckedArray[T]
+
+proc `=destroy`*[T](m: var VSeq[T]) {.inline.} =
+  if m.data != nil:
+    echo "vseq destroy"
+    dealloc(m.data)
+    m.data = nil
+
+proc `=`*[T](m: var VSeq[T], m2: VSeq[T]) {.error.}
+
+proc `=sink`*[T](m: var VSeq[T], m2: VSeq[T]) {.inline.} =
+  if m.data != m2.data:
+    `=destroy`(m)
+  m.len = m2.len
+  m.data = m2.data
+
+proc newVSeq*[T](len: int): VSeq[T] =
+  ## Only support sequence creation from scalar size because creation from
+  ## vetorized size can't reproduce the original scalar size
+  result.len = len
+  if len > 0:
+    result.data = cast[ptr UncheckedArray[T]](alloc(sizeof(T) * len))
+
+let x = some newVSeq[float](5)
+echo x.unsafeGet.len
+let y = none(VSeq[float])
+


### PR DESCRIPTION
Fixes destructor regressions I have encountered in the last 2 weeks.
One was related to generic distinct: for destructor lifting we allow distinct types to ahve its own destructor, hence hash needs to be different. But it is not enough to hash distinct sym if type instantiation is involved.

 Other one: destructor was not found because it was tyAlias, tyGenericInst away.
