### PR TITLE
Fix `nim doc` ignoring doc comments with implicit returns and implicit conversions

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -254,7 +254,7 @@ proc genRecCommentAux(d: PDoc, n: PNode): Rope =
   result = genComment(d, n).rope
   if result == nil:
     if n.kind in {nkStmtList, nkStmtListExpr, nkTypeDef, nkConstDef,
-                  nkObjectTy, nkRefTy, nkPtrTy, nkAsgn, nkFastAsgn}:
+                  nkObjectTy, nkRefTy, nkPtrTy, nkAsgn, nkFastAsgn, nkHiddenStdConv}:
       # notin {nkEmpty..nkNilLit, nkEnumTy, nkTupleTy}:
       for i in countup(0, len(n)-1):
         result = genRecCommentAux(d, n.sons[i])


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/10687