### PR TITLE
Empty macro assignment error

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -452,6 +452,9 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
         # prevent the all too common 'var x = int' bug:
         localError(c.config, def.info, "'typedesc' metatype is not valid here; typed '=' instead of ':'?")
         def.typ = errorType(c)
+      elif def.typ.kind == tyError:
+        localError(c.config, def.info, "cannot assign '$1' to variable. Is this an empty macro?" %
+          renderTree(a.sons[length-1], {renderNoComments}))
 
       if typ != nil:
         if typ.isMetaType:

--- a/tests/errmsgs/t10090.nim
+++ b/tests/errmsgs/t10090.nim
@@ -1,0 +1,7 @@
+discard """
+  errormsg: "cannot assign 'placeholderMacro()' to variable. Is this an empty macro?"
+  line: 7
+"""
+
+macro placeholderMacro: untyped = discard
+var a = placeholderMacro()


### PR DESCRIPTION
This fixes #10090, and half of #8145
Unfortunately, this is only a 2/3 fix. This doesn't work for `const x = emptyMacro()`