### PR TITLE
Pass command line arguments from build_all.sh to build.sh

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -17,14 +17,14 @@ build_nim_csources(){
   ## avoid changing dir in case of failure
   (
     echo_run cd csources
-    echo_run sh build.sh
+    echo_run sh build.sh $@
   )
   # keep $nim_csources in case needed to investigate bootstrap issues
   # without having to rebuild from csources
   echo_run cp bin/nim $nim_csources
 }
 
-[ -f $nim_csources ] || echo_run build_nim_csources
+[ -f $nim_csources ] || echo_run build_nim_csources $@
 
 # Note: if fails, may need to `cd csources && git pull`
 echo_run bin/nim c --skipUserCfg --skipParentCfg koch


### PR DESCRIPTION
This allows running things such as `./build_all.sh --cpu i386` instead of manually having to run `./csources/build.sh --cpu i386` and continuing to manually run the rest of `build_all.sh`.