### PR TITLE
manual: fix typo in inImplicitlyConvertible

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2144,7 +2144,7 @@ algorithm returns true:
     of array:
       result = b == openArray and typeEquals(a.baseType, b.baseType)
       if a.baseType == char and a.indexType.rangeA == 0:
-        result = b = cstring
+        result = b == cstring
     of cstring, ptr:
       result = b == pointer
     of string:


### PR DESCRIPTION
Just a typo I found while reading this part of the manual...

`[ci skip]` is used since this code isn't tested (there is no `:test:` role before it) because it is most likely pseudo-code, based on the algorithms prior to this one.