### PR TITLE
Fix #9844

### DIFF
--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -181,14 +181,14 @@ proc isPartOf*(a, b: PNode): TAnalysisResult =
       else: discard
     of nkObjConstr:
       result = arNo
-      for i in 1 .. <b.len:
+      for i in 1 ..< b.len:
         let res = isPartOf(a, b[i][1])
         if res != arNo:
           result = res
           if res == arYes: break
     of nkCall:
       result = arNo
-      for i in 1 .. <b.len:
+      for i in 1 ..< b.len:
         let res = isPartOf(a, b[i])
         if res != arNo:
           result = res

--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -181,8 +181,15 @@ proc isPartOf*(a, b: PNode): TAnalysisResult =
       else: discard
     of nkObjConstr:
       result = arNo
-      for i in 1..<b.len:
+      for i in 1 .. <b.len:
         let res = isPartOf(a, b[i][1])
+        if res != arNo:
+          result = res
+          if res == arYes: break
+    of nkCall:
+      result = arNo
+      for i in 1 .. <b.len:
+        let res = isPartOf(a, b[i])
         if res != arNo:
           result = res
           if res == arYes: break

--- a/tests/ccgbugs/tobjconstr_bad_aliasing.nim
+++ b/tests/ccgbugs/tobjconstr_bad_aliasing.nim
@@ -1,5 +1,6 @@
 discard """
-  output: '''(10, (20, ))'''
+  output: '''(10, (20, ))
+42'''
 """
 
 import strutils, sequtils
@@ -23,3 +24,16 @@ proc dosomething(): seq[TThing] =
   result = @[TThing(data: 10, children: result)]
 
 echo($dosomething()[0])
+
+
+# bug #9844
+
+proc f(v: int): int = v
+
+type X = object
+  v: int
+
+var x = X(v: 42)
+
+x = X(v: f(x.v))
+echo x.v


### PR DESCRIPTION
It should probably check for all accessed global symbols in the proc too?
Is there a helper proc that could give me a list of those symbols?