### PR TITLE
repr on seq now outputs @[]

### DIFF
--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -181,7 +181,7 @@ when not defined(useNimRtl):
       add result, "[]"
       return
     result.add(reprPointer(p))
-    result.add '['
+    result.add "@["
     var bs = typ.base.size
     for i in 0..cast[PGenericSeq](p).len-1:
       if i > 0: add result, ", "


### PR DESCRIPTION
Not a big deal, but adding the at sign might be a bit less surprising output. Arrays are `[]`, seqs are `@[]`