### PR TITLE
rename tyExpr/tyStmt to tyUntyped/tyTyped

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -347,7 +347,7 @@ type
                      # (apparently something with bootstrapping)
                      # if you need to add a type, they can apparently be reused
     tyNone, tyBool, tyChar,
-    tyEmpty, tyAlias, tyNil, tyExpr, tyStmt, tyTypeDesc,
+    tyEmpty, tyAlias, tyNil, tyUntyped, tyTyped, tyTypeDesc,
     tyGenericInvocation, # ``T[a, b]`` for types to invoke
     tyGenericBody,       # ``T[a, b, body]`` last parameter is the body
     tyGenericInst,       # ``T[a, b, realInstance]`` instantiated generic type
@@ -448,7 +448,7 @@ const
                     tyUserTypeClass, tyUserTypeClassInst,
                     tyAnd, tyOr, tyNot, tyAnything}
 
-  tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyExpr} + tyTypeClasses
+  tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyUntyped} + tyTypeClasses
   tyUserTypeClasses* = {tyUserTypeClass, tyUserTypeClassInst}
 
 type
@@ -1714,7 +1714,7 @@ proc isAtom*(n: PNode): bool {.inline.} =
 
 proc isEmptyType*(t: PType): bool {.inline.} =
   ## 'void' and 'stmt' types are often equivalent to 'nil' these days:
-  result = t == nil or t.kind in {tyVoid, tyStmt}
+  result = t == nil or t.kind in {tyVoid, tyTyped}
 
 proc makeStmtList*(n: PNode): PNode =
   if n.kind == nkStmtList:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2720,8 +2720,8 @@ proc getDefaultValue(p: BProc; typ: PType; info: TLineInfo): Rope =
   of tyBool: result = rope"NIM_FALSE"
   of tyEnum, tyChar, tyInt..tyInt64, tyUInt..tyUInt64: result = rope"0"
   of tyFloat..tyFloat128: result = rope"0.0"
-  of tyCString, tyString, tyVar, tyLent, tyPointer, tyPtr, tySequence, tyExpr,
-     tyStmt, tyTypeDesc, tyStatic, tyRef, tyNil:
+  of tyCString, tyString, tyVar, tyLent, tyPointer, tyPtr, tySequence, tyUntyped,
+     tyTyped, tyTypeDesc, tyStatic, tyRef, tyNil:
     result = rope"NIM_NIL"
   of tyProc:
     if t.callConv != ccClosure:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -152,7 +152,7 @@ proc mapSetType(conf: ConfigRef; typ: PType): TCTypeKind =
 proc mapType(conf: ConfigRef; typ: PType): TCTypeKind =
   ## Maps a Nim type to a C type
   case typ.kind
-  of tyNone, tyStmt: result = ctVoid
+  of tyNone, tyTyped: result = ctVoid
   of tyBool: result = ctBool
   of tyChar: result = ctChar
   of tySet: result = mapSetType(conf, typ)

--- a/compiler/cgmeth.nim
+++ b/compiler/cgmeth.nim
@@ -91,7 +91,7 @@ proc sameMethodBucket(a, b: PSym): MethodResult =
   if result == Yes:
     # check for return type:
     if not sameTypeOrNil(a.typ.sons[0], b.typ.sons[0]):
-      if b.typ.sons[0] != nil and b.typ.sons[0].kind == tyExpr:
+      if b.typ.sons[0] != nil and b.typ.sons[0].kind == tyUntyped:
         # infer 'auto' from the base to make it consistent:
         b.typ.sons[0] = a.typ.sons[0]
       else:

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -90,8 +90,8 @@ proc mapType(conf: ConfigRef, t: ast.PType): ptr libffi.TType =
     else: result = nil
   of tyFloat, tyFloat64: result = addr libffi.type_double
   of tyFloat32: result = addr libffi.type_float
-  of tyVar, tyLent, tyPointer, tyPtr, tyRef, tyCString, tySequence, tyString, tyExpr,
-     tyStmt, tyTypeDesc, tyProc, tyArray, tyStatic, tyNil:
+  of tyVar, tyLent, tyPointer, tyPtr, tyRef, tyCString, tySequence, tyString, tyUntyped,
+     tyTyped, tyTypeDesc, tyProc, tyArray, tyStatic, tyNil:
     result = addr libffi.type_pointer
   of tyDistinct, tyAlias, tySink:
     result = mapType(conf, t.sons[0])
@@ -498,4 +498,3 @@ proc callForeignFunction*(conf: ConfigRef, fn: PNode, fntyp: PType,
     let t = args[i+start].typ
     args[i+start] = unpack(conf, cargs[i], t, args[i+start])
     dealloc cargs[i]
-

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -190,7 +190,7 @@ proc mapType(typ: PType): TJSTypeKind =
   of tyNil: result = etyNull
   of tyGenericParam, tyGenericBody, tyGenericInvocation,
      tyNone, tyFromExpr, tyForward, tyEmpty,
-     tyExpr, tyStmt, tyTypeDesc, tyBuiltInTypeClass, tyCompositeTypeClass,
+     tyUntyped, tyTyped, tyTypeDesc, tyBuiltInTypeClass, tyCompositeTypeClass,
      tyAnd, tyOr, tyNot, tyAnything, tyVoid:
     result = etyNone
   of tyGenericInst, tyInferred, tyAlias, tyUserTypeClass, tyUserTypeClassInst,

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -487,7 +487,7 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
     localError(c.graph.config, c.info, "cannot copy openArray")
   of tyFromExpr, tyProxy, tyBuiltInTypeClass, tyUserTypeClass,
      tyUserTypeClassInst, tyCompositeTypeClass, tyAnd, tyOr, tyNot, tyAnything,
-     tyGenericParam, tyGenericBody, tyNil, tyExpr, tyStmt,
+     tyGenericParam, tyGenericBody, tyNil, tyUntyped, tyTyped,
      tyTypeDesc, tyGenericInvocation, tyForward:
     #internalError(c.graph.config, c.info, "assignment requested for type: " & typeToString(t))
     discard

--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -204,7 +204,7 @@ proc addField*(obj: PType; s: PSym; cache: IdentCache) =
   field.id = -s.id
   let t = skipIntLit(s.typ)
   field.typ = t
-  assert t.kind != tyStmt
+  assert t.kind != tyTyped
   field.position = sonsLen(obj.n)
   addSon(obj.n, newSymNode(field))
 
@@ -216,7 +216,7 @@ proc addUniqueField*(obj: PType; s: PSym; cache: IdentCache): PSym {.discardable
     field.id = -s.id
     let t = skipIntLit(s.typ)
     field.typ = t
-    assert t.kind != tyStmt
+    assert t.kind != tyTyped
     field.position = sonsLen(obj.n)
     addSon(obj.n, newSymNode(field))
     result = field

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -78,7 +78,7 @@ proc checkTypes(c: PPatternContext, p: PSym, n: PNode): bool =
     result = matchNodeKinds(p.constraint, n)
     if not result: return
   if isNil(n.typ):
-    result = p.typ.kind in {tyVoid, tyStmt}
+    result = p.typ.kind in {tyVoid, tyTyped}
   else:
     result = sigmatch.argtypeMatches(c.c, p.typ, n.typ, fromHlo = true)
 
@@ -241,7 +241,7 @@ proc aliasAnalysisRequested(params: PNode): bool =
       if whichAlias(param) != aqNone: return true
 
 proc addToArgList(result, n: PNode) =
-  if n.typ != nil and n.typ.kind != tyStmt:
+  if n.typ != nil and n.typ.kind != tyTyped:
     if n.kind != nkArgList: result.add(n)
     else:
       for i in 0 ..< n.len: result.add(n.sons[i])

--- a/compiler/plugins/locals.nim
+++ b/compiler/plugins/locals.nim
@@ -26,7 +26,7 @@ proc semLocals*(c: PContext, n: PNode): PNode =
       #if it.owner != c.p.owner: return result
       if it.kind in skLocalVars and
           it.typ.skipTypes({tyGenericInst, tyVar}).kind notin
-            {tyVarargs, tyOpenArray, tyTypeDesc, tyStatic, tyExpr, tyStmt, tyEmpty}:
+            {tyVarargs, tyOpenArray, tyTypeDesc, tyStatic, tyUntyped, tyTyped, tyEmpty}:
 
         var field = newSym(skField, it.name, getCurrOwner(c), n.info)
         field.typ = it.typ.skipTypes({tyVar})

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -213,7 +213,7 @@ proc newOptionEntry*(conf: ConfigRef): POptionEntry =
 
 proc newContext*(graph: ModuleGraph; module: PSym): PContext =
   new(result)
-  result.enforceVoidContext = PType(kind: tyStmt)
+  result.enforceVoidContext = PType(kind: tyTyped)
   result.ambiguousSymbols = initIntSet()
   result.optionStack = @[]
   result.libs = @[]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -552,7 +552,7 @@ proc fixAbstractType(c: PContext, n: PNode) =
       if skipTypes(it.sons[1].typ, abstractVar).kind in
             {tyNil, tyTuple, tySet} or it[1].isArrayConstr:
         var s = skipTypes(it.typ, abstractVar)
-        if s.kind != tyExpr:
+        if s.kind != tyUntyped:
           changeType(c, it.sons[1], s, check=true)
         n.sons[i] = it.sons[1]
 
@@ -1758,7 +1758,7 @@ proc semYield(c: PContext, n: PNode): PNode =
     var iterType = c.p.owner.typ
     let restype = iterType.sons[0]
     if restype != nil:
-      if restype.kind != tyExpr:
+      if restype.kind != tyUntyped:
         n.sons[0] = fitNode(c, restype, n.sons[0], n.info)
       if n.sons[0].typ == nil: internalError(c.config, n.info, "semYield")
 
@@ -1857,7 +1857,7 @@ proc semExpandToAst(c: PContext, n: PNode): PNode =
 
   if isCallExpr(macroCall):
     for i in 1 ..< macroCall.len:
-      #if macroCall.sons[0].typ.sons[i].kind != tyExpr:
+      #if macroCall.sons[0].typ.sons[i].kind != tyUntyped:
       macroCall.sons[i] = semExprWithType(c, macroCall[i], {})
     # performing overloading resolution here produces too serious regressions:
     let headSymbol = macroCall[0]

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -595,21 +595,21 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
     for i in 1 .. s.typ.n.len-1:
       let param = s.typ.n.sons[i].sym
       param.flags.excl sfGenSym
-      if param.typ.kind != tyExpr: allUntyped = false
+      if param.typ.kind != tyUntyped: allUntyped = false
     if sonsLen(gp) > 0:
       if n.sons[genericParamsPos].kind == nkEmpty:
         # we have a list of implicit type parameters:
         n.sons[genericParamsPos] = gp
-    # no explicit return type? -> use tyStmt
+    # no explicit return type? -> use tyTyped
     if n.sons[paramsPos].sons[0].kind == nkEmpty:
       # use ``stmt`` as implicit result type
-      s.typ.sons[0] = newTypeS(tyStmt, c)
+      s.typ.sons[0] = newTypeS(tyTyped, c)
       s.typ.n.sons[0] = newNodeIT(nkType, n.info, s.typ.sons[0])
   else:
     s.typ = newTypeS(tyProc, c)
-    # XXX why do we need tyStmt as a return type again?
+    # XXX why do we need tyTyped as a return type again?
     s.typ.n = newNodeI(nkFormalParams, n.info)
-    rawAddSon(s.typ, newTypeS(tyStmt, c))
+    rawAddSon(s.typ, newTypeS(tyTyped, c))
     addSon(s.typ.n, newNodeIT(nkType, n.info, s.typ.sons[0]))
   if allUntyped: incl(s.flags, sfAllUntyped)
   if n.sons[patternPos].kind != nkEmpty:

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -258,7 +258,7 @@ proc getQuality(s: PSym): range[0..100] =
   if s.typ != nil and s.typ.len > 1:
     var exp = s.typ.sons[1].skipTypes({tyGenericInst, tyVar, tyLent, tyAlias, tySink})
     if exp.kind == tyVarargs: exp = elemType(exp)
-    if exp.kind in {tyExpr, tyStmt, tyGenericParam, tyAnything}: return 50
+    if exp.kind in {tyUntyped, tyTyped, tyGenericParam, tyAnything}: return 50
   return 100
 
 template wholeSymTab(cond, section: untyped) =
@@ -319,7 +319,7 @@ proc suggestCall(c: PContext, n, nOrig: PNode, outputs: var Suggestions) =
 
 proc typeFits(c: PContext, s: PSym, firstArg: PType): bool {.inline.} =
   if s.typ != nil and sonsLen(s.typ) > 1 and s.typ.sons[1] != nil:
-    # special rule: if system and some weird generic match via 'tyExpr'
+    # special rule: if system and some weird generic match via 'tyUntyped'
     # or 'tyGenericParam' we won't list it either to reduce the noise (nobody
     # wants 'system.`-|` as suggestion
     let m = s.getModule()
@@ -327,7 +327,7 @@ proc typeFits(c: PContext, s: PSym, firstArg: PType): bool {.inline.} =
       if s.kind == skType: return
       var exp = s.typ.sons[1].skipTypes({tyGenericInst, tyVar, tyLent, tyAlias, tySink})
       if exp.kind == tyVarargs: exp = elemType(exp)
-      if exp.kind in {tyExpr, tyStmt, tyGenericParam, tyAnything}: return
+      if exp.kind in {tyUntyped, tyTyped, tyGenericParam, tyAnything}: return
     result = sigmatch.argtypeMatches(c, s.typ.sons[1], firstArg)
 
 proc suggestOperations(c: PContext, n, f: PNode, typ: PType, outputs: var Suggestions) =

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -522,7 +522,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
         result.add(" or ")
   of tyNot:
     result = "not " & typeToString(t.sons[0])
-  of tyExpr:
+  of tyUntyped:
     #internalAssert t.len == 0
     result = "untyped"
   of tyFromExpr:
@@ -1017,7 +1017,7 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
 
   case a.kind
   of tyEmpty, tyChar, tyBool, tyNil, tyPointer, tyString, tyCString,
-     tyInt..tyUInt64, tyStmt, tyExpr, tyVoid:
+     tyInt..tyUInt64, tyTyped, tyUntyped, tyVoid:
     result = sameFlags(a, b)
   of tyStatic, tyFromExpr:
     result = exprStructuralEquivalent(a.n, b.n) and sameFlags(a, b)
@@ -1215,7 +1215,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
   of tyTypeDesc:
     # XXX: This is still a horrible idea...
     result = nil
-  of tyExpr, tyStmt, tyStatic:
+  of tyUntyped, tyTyped, tyStatic:
     if kind notin {skParam, skResult}: result = t
   of tyVoid:
     if taField notin flags: result = t
@@ -1459,7 +1459,7 @@ proc skipConvTakeType*(n: PNode): PNode =
 
 proc isEmptyContainer*(t: PType): bool =
   case t.kind
-  of tyExpr, tyNil: result = true
+  of tyUntyped, tyNil: result = true
   of tyArray: result = t.sons[1].kind == tyEmpty
   of tySet, tySequence, tyOpenArray, tyVarargs:
     result = t.sons[0].kind == tyEmpty
@@ -1490,7 +1490,7 @@ proc skipHiddenSubConv*(n: PNode): PNode =
     result = n.sons[1]
     let arg = result.typ
     let dest = takeType(formal, arg)
-    if dest == arg and formal.kind != tyExpr:
+    if dest == arg and formal.kind != tyUntyped:
       #echo n.info, " came here for ", formal.typeToString
       result = n
     else:

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -91,8 +91,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyBool: result = atomicType("bool", mBool)
   of tyChar: result = atomicType("char", mChar)
   of tyNil: result = atomicType("nil", mNil)
-  of tyExpr: result = atomicType("expr", mExpr)
-  of tyStmt: result = atomicType("stmt", mStmt)
+  of tyUntyped: result = atomicType("expr", mExpr)
+  of tyTyped: result = atomicType("stmt", mStmt)
   of tyVoid: result = atomicType("void", mVoid)
   of tyEmpty: result = atomicType("empty", mNone)
   of tyUncheckedArray:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1378,7 +1378,7 @@ proc genMarshalStore(c: PCtx, n: PNode, dest: var TDest) =
 
 const
   atomicTypes = {tyBool, tyChar,
-    tyExpr, tyStmt, tyTypeDesc, tyStatic,
+    tyUntyped, tyTyped, tyTypeDesc, tyStatic,
     tyEnum,
     tyOrdinal,
     tyRange,
@@ -1763,8 +1763,8 @@ proc getNullValue(typ: PType, info: TLineInfo; conf: ConfigRef): PNode =
   of tyCString, tyString:
     result = newNodeIT(nkStrLit, info, t)
     result.strVal = ""
-  of tyVar, tyLent, tyPointer, tyPtr, tyExpr,
-     tyStmt, tyTypeDesc, tyRef, tyNil:
+  of tyVar, tyLent, tyPointer, tyPtr, tyUntyped,
+     tyTyped, tyTypeDesc, tyRef, tyNil:
     result = newNodeIT(nkNilLit, info, t)
   of tyProc:
     if t.callConv != ccClosure:

--- a/lib/system/hti.nim
+++ b/lib/system/hti.nim
@@ -17,8 +17,8 @@ type
     tyEmpty,
     tyArrayConstr,
     tyNil,
-    tyExpr,
-    tyStmt,
+    tyUntyped,
+    tyTyped,
     tyTypeDesc,
     tyGenericInvocation, # ``T[a, b]`` for types to invoke
     tyGenericBody,       # ``T[a, b, body]`` last parameter is the body


### PR DESCRIPTION
I don't know why this hasn't been done before. I enconter tyExpr and tyStmt and it recularly confuses me which one of them is untyped and which one is typed. This gets rid of the legacy once and for all.