### PR TITLE
fix conflicting file names in error messages attempt 2

### DIFF
--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -13,5 +13,7 @@ define:nimcore
 
 define:useStdoutAsStdmsg
 
+listFullPaths:on
+excessiveStackTrace:on
 #define:useNodeIds
 #gc:markAndSweep

--- a/nimdoc/tester.nim.cfg
+++ b/nimdoc/tester.nim.cfg
@@ -1,3 +1,2 @@
-path = "$nim" # For compiler/nodejs
 listFullPaths:on
 excessiveStackTrace:on

--- a/nimpretty/tester.nim.cfg
+++ b/nimpretty/tester.nim.cfg
@@ -1,3 +1,2 @@
-path = "$nim" # For compiler/nodejs
 listFullPaths:on
 excessiveStackTrace:on

--- a/nimsuggest/tester.nim.cfg
+++ b/nimsuggest/tester.nim.cfg
@@ -1,3 +1,2 @@
-path = "$nim" # For compiler/nodejs
 listFullPaths:on
 excessiveStackTrace:on


### PR DESCRIPTION
This is new my second attempt to reduce the probability of conflicting file names in Nim error messages. This time I used the suggestion from @Araq to use the compiler flags ``--listFullPaths:on`` and ``--excessiveStackTrace:on`` that he mention [here](https://github.com/nim-lang/Nim/pull/11223#issuecomment-491490220).


Original PR to reduce the amount of conflicting file names that was not merged: https://github.com/nim-lang/Nim/pull/11223