### PR TITLE
Fix destructor injections for global variables

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1963,6 +1963,8 @@ proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
   result = n
   if b == nil: return
   var m = BModule(b)
+  if sfMainModule in m.module.flags and not graph.globalDestructors.isNil:
+    n.add graph.globalDestructors
   if passes.skipCodegen(m.config, n): return
   # if the module is cached, we don't regenerate the main proc
   # nor the dispatchers? But if the dispatchers changed?

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1963,8 +1963,9 @@ proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
   result = n
   if b == nil: return
   var m = BModule(b)
-  if sfMainModule in m.module.flags and not graph.globalDestructors.isNil:
-    n.add graph.globalDestructors
+  if sfMainModule in m.module.flags:
+    for destructorCall in graph.globalDestructors:
+      n.add destructorCall
   if passes.skipCodegen(m.config, n): return
   # if the module is cached, we don't regenerate the main proc
   # nor the dispatchers? But if the dispatchers changed?

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -832,8 +832,6 @@ proc injectDestructorCalls*(g: ModuleGraph; owner: PSym; n: PNode): PNode =
   if c.destroys.len > 0:
     if owner.kind == skModule:
       result.add body
-      if g.globalDestructors.isNil:
-        g.globalDestructors = newNodeI(nkStmtList, n.info)
       g.globalDestructors.add c.destroys
     else:
       result.add newTryFinally(body, c.destroys)

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -316,10 +316,6 @@ proc makePtrType(c: Con, baseType: PType): PType =
   result = newType(tyPtr, c.owner)
   addSonSkipIntLit(result, baseType)
 
-proc addDestroy(c: var Con; n: PNode) =
-  # append to front:
-  c.destroys = newTree(nkStmtList, n, c.destroys)
-
 proc genOp(c: Con; t: PType; kind: TTypeAttachedOp; dest, ri: PNode): PNode =
   var op = t.attachedOps[kind]
 
@@ -738,7 +734,7 @@ proc p(n: PNode; c: var Con): PNode =
             c.addTopVar v
             # make sure it's destroyed at the end of the proc:
             if not isUnpackedTuple(it[0].sym):
-              c.addDestroy genDestroy(c, v.typ, v)
+              c.destroys.add genDestroy(c, v.typ, v)
           if ri.kind != nkEmpty:
             let r = moveOrCopy(v, ri, c)
             result.add r
@@ -757,7 +753,7 @@ proc p(n: PNode; c: var Con): PNode =
       sinkExpr.add n
       result.add sinkExpr
       result.add tmp
-      c.addDestroy genDestroy(c, n.typ, tmp)
+      c.destroys.add genDestroy(c, n.typ, tmp)
     else:
       result = n
   of nkAsgn, nkFastAsgn:
@@ -799,6 +795,19 @@ proc p(n: PNode; c: var Con): PNode =
     result = copyNode(n)
     recurse(n, result)
 
+proc extractDestroysForTemporaries(c: Con, destroys: PNode): PNode =
+  result = newNodeI(nkStmtList, destroys.info)
+  for i in 0 ..< destroys.len:
+    if destroys[i][1][0].sym.kind == skTemp:
+      result.add destroys[i]
+      destroys[i] = c.emptyNode
+
+proc reverseDestroys(destroys: PNode) =
+  var reversed: seq[PNode]
+  for i in countdown(destroys.len - 1, 0):
+    reversed.add(destroys[i])
+  destroys.sons = reversed
+
 proc injectDestructorCalls*(g: ModuleGraph; owner: PSym; n: PNode): PNode =
   if sfGeneratedOp in owner.flags or isInlineIterator(owner): return n
   var c: Con
@@ -821,7 +830,7 @@ proc injectDestructorCalls*(g: ModuleGraph; owner: PSym; n: PNode): PNode =
     for i in 1 ..< params.len:
       let param = params[i].sym
       if isSinkTypeForParam(param.typ) and hasDestructor(param.typ.skipTypes({tySink})):
-        c.addDestroy genDestroy(c, param.typ.skipTypes({tyGenericInst, tyAlias, tySink}), params[i])
+        c.destroys.add genDestroy(c, param.typ.skipTypes({tyGenericInst, tyAlias, tySink}), params[i])
 
   #if optNimV2 in c.graph.config.globalOptions:
   #  injectDefaultCalls(n, c)
@@ -830,8 +839,9 @@ proc injectDestructorCalls*(g: ModuleGraph; owner: PSym; n: PNode): PNode =
   if c.topLevelVars.len > 0:
     result.add c.topLevelVars
   if c.destroys.len > 0:
+    reverseDestroys(c.destroys)
     if owner.kind == skModule:
-      result.add body
+      result.add newTryFinally(body, extractDestroysForTemporaries(c, c.destroys))
       g.globalDestructors.add c.destroys
     else:
       result.add newTryFinally(body, c.destroys)

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -830,7 +830,13 @@ proc injectDestructorCalls*(g: ModuleGraph; owner: PSym; n: PNode): PNode =
   if c.topLevelVars.len > 0:
     result.add c.topLevelVars
   if c.destroys.len > 0:
-    result.add newTryFinally(body, c.destroys)
+    if owner.kind == skModule:
+      result.add body
+      if g.globalDestructors.isNil:
+        g.globalDestructors = newNodeI(nkStmtList, n.info)
+      g.globalDestructors.add c.destroys
+    else:
+      result.add newTryFinally(body, c.destroys)
   else:
     result.add body
 

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -71,7 +71,7 @@ type
     onDefinition*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
     onDefinitionResolveForward*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
     onUsage*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
-    globalDestructors*: PNode
+    globalDestructors*: seq[PNode]
 
   TPassContext* = object of RootObj # the pass's context
   PPassContext* = ref TPassContext

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -71,6 +71,7 @@ type
     onDefinition*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
     onDefinitionResolveForward*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
     onUsage*: proc (graph: ModuleGraph; s: PSym; info: TLineInfo) {.nimcall.}
+    globalDestructors*: PNode
 
   TPassContext* = object of RootObj # the pass's context
   PPassContext* = ref TPassContext

--- a/tests/destructor/objFile.nim
+++ b/tests/destructor/objFile.nim
@@ -1,0 +1,8 @@
+type Obj* = object
+  v*: int
+
+proc `=destroy`(this: var Obj) =
+  echo "igotdestroyed"
+  this.v = -1
+
+var test* = Obj(v: 42)

--- a/tests/destructor/texplicit_move.nim
+++ b/tests/destructor/texplicit_move.nim
@@ -6,6 +6,7 @@ discard """
 10
 destroyed!
 '''
+joinable: false
 """
 
 type

--- a/tests/destructor/tglobaldestructor.nim
+++ b/tests/destructor/tglobaldestructor.nim
@@ -1,0 +1,9 @@
+discard """
+  cmd: '''nim c --newruntime $file'''
+  output: '''(v: 42)
+igotdestroyed'''
+"""
+
+import objFile
+
+echo test

--- a/tests/destructor/topt.nim
+++ b/tests/destructor/topt.nim
@@ -3,6 +3,7 @@ discard """
   output: '''5
 vseq destroy
 '''
+joinable: false
 """
 type
   opt*[T] = object


### PR DESCRIPTION
Fixes #9799
Refs #11217
I consider this a WIP as
- I don't know if this should really belong in ModuleGraph or in myClose
- ~generated temporaries for globals leak into topLevelVars such as in https://github.com/nim-lang/Nim/blob/devel/tests/ccgbugs/tsequence_outoforder.nim and thus only get destroyed at the end of the mainModule or cause generating invalid C. EDIT: This also the reason the tests currently fail...~
  EDIT: Fixed!
- It is not yet implemented for the other backends