### PR TITLE
make global variables static when possible

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -536,7 +536,7 @@ proc assignGlobalVar(p: BProc, n: PNode) =
       var decl: Rope = nil
       var td = getTypeDesc(p.module, s.loc.t)
       if s.constraint.isNil:
-        if {sfExported, sfCompilerProc} * s.flags == {} or p.hcrOn: add(decl, "static ")
+        if {sfImportc, sfExported, sfCompilerProc} * s.flags == {} or p.hcrOn: add(decl, "static ")
         elif sfImportc in s.flags: add(decl, "extern ")
         add(decl, td)
         if p.hcrOn: add(decl, "*")

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -536,7 +536,7 @@ proc assignGlobalVar(p: BProc, n: PNode) =
       var decl: Rope = nil
       var td = getTypeDesc(p.module, s.loc.t)
       if s.constraint.isNil:
-        if p.hcrOn: add(decl, "static ")
+        if {sfExported, sfCompilerProc} * s.flags == {} or p.hcrOn: add(decl, "static ")
         elif sfImportc in s.flags: add(decl, "extern ")
         add(decl, td)
         if p.hcrOn: add(decl, "*")

--- a/lib/core/refs.nim
+++ b/lib/core/refs.nim
@@ -42,7 +42,7 @@ type
     greyStack: seq[Cell]
 
 var
-  gch {.threadvar.}: GcHeap
+  gch {.threadvar, compilerProc.}: GcHeap
 
 proc `=trace`[T](a: ref T) =
   if not marked(a):

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -96,7 +96,7 @@ type
     gcThreadId: int
 
 var
-  gch {.rtlThreadVar.}: GcHeap
+  gch {.rtlThreadVar, compilerProc.}: GcHeap
 
 when not defined(useNimRtl):
   instantiateForRegion(gch.region)

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -107,7 +107,7 @@ type
     gcThreadId: int
 
 var
-  gch {.rtlThreadVar.}: GcHeap
+  gch {.rtlThreadVar, compilerProc.}: GcHeap
 
 when not defined(useNimRtl):
   instantiateForRegion(gch.region)

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -80,7 +80,7 @@ type
       indentation: int
 
 var
-  gch {.rtlThreadVar.}: GcHeap
+  gch {.rtlThreadVar, compilerProc.}: GcHeap
 
 when not defined(useNimRtl):
   instantiateForRegion(gch.region)

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -217,10 +217,10 @@ type
       nil
 
 when emulatedThreadVars:
-  var globalsSlot: ThreadVarSlot
+  var globalsSlot {.compilerProc.}: ThreadVarSlot
 
   when not defined(useNimRtl):
-    var mainThread: GcThread
+    var mainThread {.compilerProc.}: GcThread
 
   proc GetThreadLocalVars(): pointer {.compilerRtl, inl.} =
     result = addr(cast[PGcThread](threadVarGetValue(globalsSlot)).tls)


### PR DESCRIPTION
Attempt to address multiple complains that top level code is significantly slower then the same code put in proc