### PR TITLE
fix #11194

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1695,13 +1695,12 @@ proc genModule(m: BModule, cfile: Cfile): Rope =
   result = getFileHeader(m.config, cfile)
   result.add(genMergeInfo(m))
 
-  if m.config.cppCustomNamespace.len > 0:
-    result.add openNamespaceNim(m.config.cppCustomNamespace)
-
   generateThreadLocalStorage(m)
   generateHeaders(m)
   add(result, genSectionStart(cfsHeaders, m.config))
   add(result, m.s[cfsHeaders])
+  if m.config.cppCustomNamespace.len > 0:
+    result.add openNamespaceNim(m.config.cppCustomNamespace)
   add(result, genSectionEnd(cfsHeaders, m.config))
   add(result, genSectionStart(cfsFrameDefines, m.config))
   if m.s[cfsFrameDefines].len > 0:

--- a/tests/compiler/tcppCompileToNamespace.nim
+++ b/tests/compiler/tcppCompileToNamespace.nim
@@ -1,0 +1,12 @@
+discard """
+cmd: "nim cpp --cppCompileToNamespace:foo $options -r $file"
+target: cpp
+"""
+
+# Theoretically nim could just ignore the flag cppCompileToNamespace
+# and this test would pass.  Setting ``ccodeCheck`` for a c++ target
+# doesn't work.
+
+import os
+
+echo "a" / "b"


### PR DESCRIPTION
There was not a single test case for ``cppCompileToNamespace`` in the entire test suite. How was this accepted into Nim? And btw `ccodeCheck` can't be used to ensure that ``cppCompileToNamespace`` generates the correct code, because it only works with C and javascript?!

Anyway, this should fix #11194