### PR TITLE
cas(): use an "__atomic" builtin instead of the legacy "__sync" one

### DIFF
--- a/lib/system/atomics.nim
+++ b/lib/system/atomics.nim
@@ -285,6 +285,9 @@ static int __tcc_cas(int *ptr, int oldVal, int newVal)
     {.importc: "__tcc_cas", nodecl.}
   proc cas*[T: bool|int|ptr](p: ptr T; oldValue, newValue: T): bool =
     tcc_cas(cast[ptr int](p), cast[int](oldValue), cast[int](newValue))
+elif declared(atomicCompareExchangeN):
+  proc cas*[T: bool|int|ptr](p: ptr T; oldValue, newValue: T): bool =
+    atomicCompareExchangeN(p, oldValue.unsafeAddr, newValue, false, ATOMIC_SEQ_CST, ATOMIC_SEQ_CST)
 else:
   # this is valid for GCC and Intel C++
   proc cas*[T: bool|int|ptr](p: ptr T; oldValue, newValue: T): bool


### PR DESCRIPTION
"New code should always use the ‘__atomic’ builtins rather than the ‘__sync’ builtins." - https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html