### PR TITLE
Expose api to disable autoinitializing OpenSSL.

### DIFF
--- a/lib/wrappers/postgres.nim
+++ b/lib/wrappers/postgres.nim
@@ -153,6 +153,8 @@ type
     isint*: int32
     p*: pointer
 
+proc pqinitOpenSSL*(do_ssl: int32, do_crypto: int32) {.cdecl, dynlib: dllName,
+    importc: "PQinitOpenSSL".}
 proc pqconnectStart*(conninfo: cstring): PPGconn{.cdecl, dynlib: dllName,
     importc: "PQconnectStart".}
 proc pqconnectPoll*(conn: PPGconn): PostgresPollingStatusType{.cdecl,


### PR DESCRIPTION
Expose `PQinitOpenSSL` so we can disable libpq from initializing OpenSSL if it's already done by someone else.  Will help to address some problems in #9419.