### PR TITLE
Workaround "move not found" exception in JS when using tables.

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -274,7 +274,10 @@ proc enlarge[A, B](t: var Table[A, B]) =
       var j: Hash = eh and maxHash(t)
       while isFilled(t.data[j].hcode):
         j = nextTry(j, maxHash(t))
-      rawInsert(t, t.data, move n[i].key, move n[i].val, eh, j)
+      when defined(js):
+        rawInsert(t, t.data, n[i].key, n[i].val, eh, j)
+      else:
+        rawInsert(t, t.data, move n[i].key, move n[i].val, eh, j)
 
 
 


### PR DESCRIPTION
I don't have time to dig into the compiler to fix this, so I'm offering this quick fix in case it's useful.

TL;DR: e1515b53d1992aa8 breaks JS target because the Nim compiler outputs a function call which does not exist for the `move` (odd that the Nim compiler didn't complain about this function not existing...)