### PR TITLE
range/case fixes

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -878,10 +878,14 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
   var covered: BiggestInt = 0
   var typ = commonTypeBegin
   var hasElse = false
-  let caseTyp = skipTypes(n.sons[0].typ, abstractVarRange-{tyTypeDesc})
+  let caseTyp = skipTypes(n.sons[0].typ, abstractVar-{tyTypeDesc})
+  const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool}
   case caseTyp.kind
-  of tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool:
+  of shouldChckCovered:
     chckCovered = true
+  of tyRange:
+    if skipTypes(caseTyp.sons[0], abstractInst).kind in shouldChckCovered:
+      chckCovered = true
   of tyFloat..tyFloat128, tyString, tyError:
     discard
   else:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -893,7 +893,7 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
       result = handleCaseStmtMacro(c, n)
       if result != nil: return result
 
-    localError(c.config, n.info, errSelectorMustBeOfCertainTypes)
+    localError(c.config, n.sons[0].info, errSelectorMustBeOfCertainTypes)
     return
   for i in 1 ..< sonsLen(n):
     var x = n.sons[i]

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -605,11 +605,15 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
   var covered: BiggestInt = 0
   var chckCovered = false
   var typ = skipTypes(a.sons[0].typ, abstractVar-{tyTypeDesc})
+  const shouldChckCovered = {tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool}
   case typ.kind
-  of tyInt..tyInt64, tyChar, tyEnum, tyUInt..tyUInt32, tyBool, tyRange:
+  of shouldChckCovered:
     chckCovered = true
   of tyFloat..tyFloat128, tyString, tyError:
     discard
+  of tyRange:
+    if skipTypes(typ.sons[0], abstractInst).kind in shouldChckCovered:
+      chckCovered = true
   of tyForward:
     errorUndeclaredIdentifier(c, n.sons[0].info, typ.sym.name.s)
   elif not isOrdinalType(typ):

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -223,7 +223,8 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
   if not hasUnknownTypes:
     if not sameType(rangeT[0].skipTypes({tyRange}), rangeT[1].skipTypes({tyRange})):
       localError(c.config, n.info, "type mismatch")
-    elif not rangeT[0].isOrdinalType and rangeT[0].kind notin tyFloat..tyFloat128:
+    elif not rangeT[0].isOrdinalType and rangeT[0].kind notin tyFloat..tyFloat128 or
+        rangeT[0].kind == tyBool:
       localError(c.config, n.info, "ordinal or float type expected")
     elif enumHasHoles(rangeT[0]):
       localError(c.config, n.info, "enum '$1' has holes" % typeToString(rangeT[0]))

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1255,8 +1255,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     result = typeAllowedAux(marker, lastSon(t), kind, flags)
   of tyRange:
     if skipTypes(t.sons[0], abstractInst-{tyTypeDesc}).kind notin
-        {tyBool, tyChar, tyEnum, tyInt..tyFloat128, tyUInt8..tyUInt32}:
-      result = t
+      {tyChar, tyEnum, tyInt..tyFloat128, tyUInt8..tyUInt32}: result = t
   of tyOpenArray, tyVarargs, tySink:
     if kind != skParam:
       result = t

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1255,7 +1255,8 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     result = typeAllowedAux(marker, lastSon(t), kind, flags)
   of tyRange:
     if skipTypes(t.sons[0], abstractInst-{tyTypeDesc}).kind notin
-        {tyChar, tyEnum, tyInt..tyFloat128, tyUInt8..tyUInt32}: result = t
+        {tyBool, tyChar, tyEnum, tyInt..tyFloat128, tyUInt8..tyUInt32}:
+      result = t
   of tyOpenArray, tyVarargs, tySink:
     if kind != skParam:
       result = t

--- a/tests/objvariant/tfloatrangeobj.nim
+++ b/tests/objvariant/tfloatrangeobj.nim
@@ -1,0 +1,13 @@
+discard """
+  output: '''(kind: 2.0, twoStr: "TWO STR")
+(kind: 1.0)
+'''
+"""
+type
+  FloatRange = range[1.0..3.0]
+  VariantObj = object
+    case kind: FloatRange
+    of 2.0: twoStr: string
+
+echo VariantObj(kind: 2.0, twoStr: "TWO STR")
+echo VariantObj(kind: 1.0)

--- a/tests/range/trange.nim
+++ b/tests/range/trange.nim
@@ -2,9 +2,6 @@ discard """
   output: '''
 TSubRange: 5 from 1 to 10
 #FF3722
-TRUE
-FALSE
-TRUE
 '''
 """
 

--- a/tests/range/trange.nim
+++ b/tests/range/trange.nim
@@ -121,24 +121,3 @@ block:
     x3 = R32(4)
 
   doAssert $x1 & $x2 & $x3 == "444"
-
-block:
-  type
-    BoolRange = range[false..true]
-    JustFalse = range[false..false]
-    JustTrue = range[true..true]
-  
-  let
-    a = BoolRange(true)
-    b = JustFalse(false)
-    c = JustTrue(true)
-
-  case a:
-  of true: echo "TRUE"
-  of false: echo "FALSE"
-
-  case b:
-  of false: echo "FALSE"
-
-  case c:
-  of true: echo "TRUE"

--- a/tests/range/trange.nim
+++ b/tests/range/trange.nim
@@ -2,6 +2,9 @@ discard """
   output: '''
 TSubRange: 5 from 1 to 10
 #FF3722
+TRUE
+FALSE
+TRUE
 '''
 """
 
@@ -118,3 +121,24 @@ block:
     x3 = R32(4)
 
   doAssert $x1 & $x2 & $x3 == "444"
+
+block:
+  type
+    BoolRange = range[false..true]
+    JustFalse = range[false..false]
+    JustTrue = range[true..true]
+  
+  let
+    a = BoolRange(true)
+    b = JustFalse(false)
+    c = JustTrue(true)
+
+  case a:
+  of true: echo "TRUE"
+  of false: echo "FALSE"
+
+  case b:
+  of false: echo "FALSE"
+
+  case c:
+  of true: echo "TRUE"


### PR DESCRIPTION
Couple small things I found while working on smarter variant construction.
1. Fix bool range assignment. Right now, bool ranges give a not very helpful error on assignment.
2. Make coverage checking in cases more consistent between type sections and stmts. Right now, coverage is checked for float ranges in type sections which of course doesn't work.
3. Make the selector error highlight the selector, which I had already changed for type sections earlier.