### PR TITLE
fix #11139 (re.nim memory leak)

### DIFF
--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -440,7 +440,6 @@ proc extractOptions(pattern: string): tuple[pattern: string, flags: int, study: 
 
 proc destroyRegex(pattern: Regex) =
   pcre.free_substring(cast[cstring](pattern.pcreObj))
-  pattern.pcreObj = nil
   if pattern.pcreExtra != nil:
     pcre.free_study(pattern.pcreExtra)
 

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -65,7 +65,7 @@ proc finalizeRegEx(x: Regex) =
   # Fortunately the implementation is unlikely to change.
   pcre.free_substring(cast[cstring](x.h))
   if not isNil(x.e):
-    pcre.free_substring(cast[cstring](x.e))
+    pcre.free_study(x.e)
 
 proc re*(s: string, flags = {reStudy}): Regex =
   ## Constructor of regular expressions.


### PR DESCRIPTION
Use the same PCRE function for freeing up the memory as nre.nim does.