### PR TITLE
db_sqlite: Update documentation (#10330)

### DIFF
--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -21,8 +21,8 @@
 ##
 ##    sql"INSERT INTO my_table (colA, colB, colC) VALUES (?, ?, ?)"
 ##
-## Examples
-## ========
+## Basic usage
+## ===========
 ##
 ## Opening a connection to a database
 ## ----------------------------------
@@ -105,7 +105,7 @@ export db_common
 type
   DbConn* = PSqlite3  ## Encapsulates a database connection.
   Row* = seq[string]  ## A row of a dataset. NULL database values will be
-                       ## converted to nil.
+                      ## converted to nil.
   InstantRow* = Pstmt  ## A handle that can be used to get a row's column
                        ## text on demand.
 
@@ -170,7 +170,7 @@ proc tryExec*(db: DbConn, query: SqlQuery,
 
 proc exec*(db: DbConn, query: SqlQuery, args: varargs[string, `$`])  {.
   tags: [ReadDbEffect, WriteDbEffect].} =
-  ## Executes the query and raises DbError if not successful.
+  ## Executes the query and raises a DbError exception if not successful.
   ##
   ## **Examples:**
   ##
@@ -450,8 +450,8 @@ proc tryInsertID*(db: DbConn, query: SqlQuery,
 proc insertID*(db: DbConn, query: SqlQuery,
                args: varargs[string, `$`]): int64 {.tags: [WriteDbEffect].} =
   ## Executes the query (typically "INSERT") and returns the
-  ## generated ID for the row. Raise DBError when failed to insert row.
-  ## For Postgre this adds ``RETURNING id`` to the query, so it only works
+  ## generated ID for the row. Raise a DbError exception when failed to insert
+  ## row. For Postgre this adds ``RETURNING id`` to the query, so it only works
   ## if your primary key is named ``id``.
   ##
   ## **Examples:**
@@ -511,8 +511,8 @@ proc close*(db: DbConn) {.tags: [DbEffect].} =
 
 proc open*(connection, user, password, database: string): DbConn {.
   tags: [DbEffect].} =
-  ## Opens a database connection. Raises `EDb` if the connection could not
-  ## be established.
+  ## Opens a database connection. Raises a DbError exception if the connection
+  ## could not be established.
   ##
   ## **Note:** Only the ``connection`` parameter is used for ``sqlite``.
   ##
@@ -535,14 +535,13 @@ proc open*(connection, user, password, database: string): DbConn {.
 
 proc setEncoding*(connection: DbConn, encoding: string): bool {.
   tags: [DbEffect].} =
-  ## Sets the encoding of a database connection, returns true for
-  ## success, false for failure.
+  ## Sets the encoding of a database connection, returns `true` for
+  ## success, `false` for failure.
   ##
   ## **Note:** that the encoding cannot be changed once it's been set.
   ## According to SQLite3 documentation, any attempt to change
   ## the encoding after the database is created will be silently
   ## ignored.
-  ## TODO example
   exec(connection, sql"PRAGMA encoding = ?", [encoding])
   result = connection.getValue(sql"PRAGMA encoding") == encoding
 

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -290,20 +290,13 @@ proc getRow*(db: DbConn, query: SqlQuery,
   ## .. code-block:: Nim
   ##
   ##    let db = open("mytest.db", "", "", "")
-  ##    # setup datas
-  ##    db.exec(sql"DROP TABLE IF EXISTS my_table")
-  ##    db.exec(sql"""CREATE TABLE my_table (
-  ##                     id   INTEGER,
-  ##                     name VARCHAR(50) NOT NULL
-  ##                  )""")
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (1, 'item#1')
-  ##                  """)
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (2, 'item#2')
-  ##                  """)
   ##
-  ##    # get rows
+  ##    # Records of my_table:
+  ##    # | id | name     |
+  ##    # |----|----------|
+  ##    # |  1 | 'item#1' |
+  ##    # |  2 | 'item#2' |
+  ##
   ##    doAssert db.getRow(sql"SELECT id, name FROM my_table") == Row(@["1", "item#1"])
   ##    doAssert db.getRow(sql"SELECT id, name FROM my_table WHERE id = 2") == Row(@["2", "item#2"])
   ##    db.close()
@@ -323,18 +316,12 @@ proc getAllRows*(db: DbConn, query: SqlQuery,
   ## .. code-block:: Nim
   ##
   ##    let db = open("mytest.db", "", "", "")
-  ##    # setup datas
-  ##    db.exec(sql"DROP TABLE IF EXISTS my_table")
-  ##    db.exec(sql"""CREATE TABLE my_table (
-  ##                     id   INTEGER,
-  ##                     name VARCHAR(50) NOT NULL
-  ##                  )""")
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (1, 'item#1')
-  ##                  """)
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (2, 'item#2')
-  ##                  """)
+  ##
+  ##    # Records of my_table:
+  ##    # | id | name     |
+  ##    # |----|----------|
+  ##    # |  1 | 'item#1' |
+  ##    # |  2 | 'item#2' |
   ##
   ##    doAssert db.getAllRows(sql"SELECT id, name FROM my_table") == @[Row(@["1", "item#1"]), Row(@["2", "item#2"])]
   ##    db.close()
@@ -351,21 +338,16 @@ iterator rows*(db: DbConn, query: SqlQuery,
   ## .. code-block:: Nim
   ##
   ##    let db = open("mytest.db", "", "", "")
-  ##    # setup datas
-  ##    db.exec(sql"DROP TABLE IF EXISTS my_table")
-  ##    db.exec(sql"""CREATE TABLE my_table (
-  ##                     id   INTEGER,
-  ##                     name VARCHAR(50) NOT NULL
-  ##                  )""")
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (1, 'item#1')
-  ##                  """)
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (2, 'item#2')
-  ##                  """)
+  ##
+  ##    # Records of my_table:
+  ##    # | id | name     |
+  ##    # |----|----------|
+  ##    # |  1 | 'item#1' |
+  ##    # |  2 | 'item#2' |
   ##
   ##    for row in db.rows(sql"SELECT id, name FROM my_table"):
   ##      echo row
+  ##
   ##    ## Output:
   ##    ## @["1", "item#1"]
   ##    ## @["2", "item#2"]
@@ -384,18 +366,12 @@ proc getValue*(db: DbConn, query: SqlQuery,
   ## .. code-block:: Nim
   ##
   ##    let db = open("mytest.db", "", "", "")
-  ##    # setup datas
-  ##    db.exec(sql"DROP TABLE IF EXISTS my_table")
-  ##    db.exec(sql"""CREATE TABLE my_table (
-  ##                     id   INTEGER,
-  ##                     name VARCHAR(50) NOT NULL
-  ##                  )""")
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (1, 'item#1')
-  ##                  """)
-  ##    db.exec(sql"""INSERT INTO my_table (id, name)
-  ##                  VALUES (2, 'item#2')
-  ##                  """)
+  ##
+  ##    # Records of my_table:
+  ##    # | id | name     |
+  ##    # |----|----------|
+  ##    # |  1 | 'item#1' |
+  ##    # |  2 | 'item#2' |
   ##
   ##    doAssert db.getValue(sql"SELECT name FROM my_table WHERE id = 2") == "item#2"
   ##    doAssert db.getValue(sql"SELECT id, name FROM my_table") == "1"

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -10,9 +10,6 @@
 ## A higher level `SQLite`:idx: database wrapper. This interface
 ## is implemented for other databases too.
 ##
-## See also: `db_odbc <db_odbc.html>`_, `db_postgres <db_postgres.html>`_,
-## `db_mysql <db_mysql.html>`_.
-##
 ## Parameter substitution
 ## ======================
 ##
@@ -21,7 +18,8 @@
 ## value should be placed. For example:
 ##
 ## .. code-block:: Nim
-##     sql"INSERT INTO myTable (colA, colB, colC) VALUES (?, ?, ?)"
+##
+##    sql"INSERT INTO my_table (colA, colB, colC) VALUES (?, ?, ?)"
 ##
 ## Examples
 ## ========
@@ -30,61 +28,72 @@
 ## ----------------------------------
 ##
 ## .. code-block:: Nim
-##     import db_sqlite
-##     let db = open("mytest.db", "", "", "")  # user, password, database name can be empty
-##     db.close()
+##
+##    import db_sqlite
+##
+##    # user, password, database name can be empty.
+##    # These params are not used on db_sqlite module.
+##    let db = open("mytest.db", "", "", "")
+##    db.close()
 ##
 ## Creating a table
 ## ----------------
 ##
 ## .. code-block:: Nim
-##      db.exec(sql"DROP TABLE IF EXISTS myTable")
-##      db.exec(sql("""CREATE TABLE myTable (
-##                       id integer,
-##                       name varchar(50) not null)"""))
+##
+##    db.exec(sql"DROP TABLE IF EXISTS my_table")
+##    db.exec(sql("""CREATE TABLE my_table (
+##                     id   INTEGER,
+##                     name VARCHAR(50) NOT NULL
+##                   )"""))
 ##
 ## Inserting data
 ## --------------
 ##
 ## .. code-block:: Nim
-##     db.exec(sql"INSERT INTO myTable (id, name) VALUES (0, ?)",
-##             "Jack")
+##
+##    db.exec(sql"INSERT INTO my_table (id, name) VALUES (0, ?)",
+##            "Jack")
 ##
 ## Larger example
 ## --------------
 ##
 ## .. code-block:: nim
 ##
-##  import db_sqlite, math
+##    import db_sqlite, math
 ##
-##  let theDb = open("mytest.db", "", "", "")
+##    let db = open("mytest.db", "", "", "")
 ##
-##  theDb.exec(sql"Drop table if exists myTestTbl")
-##  theDb.exec(sql("""create table myTestTbl (
-##       Id    INTEGER PRIMARY KEY,
-##       Name  VARCHAR(50) NOT NULL,
-##       i     INT(11),
-##       f     DECIMAL(18,10))"""))
+##    db.exec(sql"DROP TABLE IF EXISTS my_table")
+##    db.exec(sql("""CREATE TABLE my_table (
+##                     id    INTEGER PRIMARY KEY,
+##                     name  VARCHAR(50) NOT NULL,
+##                     i     INT(11),
+##                     f     DECIMAL(18, 10)
+##                   )"""))
 ##
-##  theDb.exec(sql"BEGIN")
-##  for i in 1..1000:
-##    theDb.exec(sql"INSERT INTO myTestTbl (name,i,f) VALUES (?,?,?)",
-##          "Item#" & $i, i, sqrt(i.float))
-##  theDb.exec(sql"COMMIT")
+##    db.exec(sql"BEGIN")
+##    for i in 1..1000:
+##      db.exec(sql"INSERT INTO my_table (name, i, f) VALUES (?, ?, ?)",
+##              "Item#" & $i, i, sqrt(i.float))
+##    db.exec(sql"COMMIT")
 ##
-##  for x in theDb.fastRows(sql"select * from myTestTbl"):
-##    echo x
+##    for x in db.fastRows(sql"SELECT * FROM my_table"):
+##      echo x
 ##
-##  let id = theDb.tryInsertId(sql"INSERT INTO myTestTbl (name,i,f) VALUES (?,?,?)",
-##        "Item#1001", 1001, sqrt(1001.0))
-##  echo "Inserted item: ", theDb.getValue(sql"SELECT name FROM myTestTbl WHERE id=?", id)
+##    let id = db.tryInsertId(sql"""INSERT INTO my_table (name, i, f)
+##                                  VALUES (?, ?, ?)""",
+##                            "Item#1001", 1001, sqrt(1001.0))
+##    echo "Inserted item: ", db.getValue(sql"SELECT name FROM my_table WHERE id=?", id)
 ##
-##  theDb.close()
+##    db.close()
 ##
 ## See also
 ## ========
 ##
-## * TODO
+## * `db_odbc module <db_odbc.html>`_ for ODBC database wrapper
+## * `db_mysql <db_mysql.html>`_ for MySQL database wrapper
+## * `db_postgres <db_postgres.html>`_ for PostgreSQL database wrapper
 
 {.deadCodeElim: on.}  # dce option deprecated
 
@@ -328,8 +337,10 @@ proc close*(db: DbConn) {.tags: [DbEffect].} =
 
 proc open*(connection, user, password, database: string): DbConn {.
   tags: [DbEffect].} =
-  ## opens a database connection. Raises `EDb` if the connection could not
-  ## be established. Only the ``connection`` parameter is used for ``sqlite``.
+  ## Opens a database connection. Raises `EDb` if the connection could not
+  ## be established.
+  ##
+  ## **Note:** Only the ``connection`` parameter is used for ``sqlite``.
   ## TODO example
   var db: DbConn
   if sqlite3.open(connection, db) == SQLITE_OK:
@@ -339,10 +350,10 @@ proc open*(connection, user, password, database: string): DbConn {.
 
 proc setEncoding*(connection: DbConn, encoding: string): bool {.
   tags: [DbEffect].} =
-  ## sets the encoding of a database connection, returns true for
+  ## Sets the encoding of a database connection, returns true for
   ## success, false for failure.
   ##
-  ## Note that the encoding cannot be changed once it's been set.
+  ## **Note:** that the encoding cannot be changed once it's been set.
   ## According to SQLite3 documentation, any attempt to change
   ## the encoding after the database is created will be silently
   ## ignored.

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -10,17 +10,6 @@
 ## A higher level `SQLite`:idx: database wrapper. This interface
 ## is implemented for other databases too.
 ##
-## Parameter substitution
-## ======================
-##
-## All ``db_*`` modules support the same form of parameter substitution.
-## That is, using the ``?`` (question mark) to signify the place where a
-## value should be placed. For example:
-##
-## .. code-block:: Nim
-##
-##    sql"INSERT INTO my_table (colA, colB, colC) VALUES (?, ?, ?)"
-##
 ## Basic usage
 ## ===========
 ##
@@ -29,6 +18,17 @@
 ## 1. Open database connection
 ## 2. Execute SQL query
 ## 3. Close database connection
+##
+## Parameter substitution
+## ----------------------
+##
+## All ``db_*`` modules support the same form of parameter substitution.
+## That is, using the ``?`` (question mark) to signify the place where a
+## value should be placed. For example:
+##
+## .. code-block:: Nim
+##
+##    sql"INSERT INTO my_table (colA, colB, colC) VALUES (?, ?, ?)"
 ##
 ## Opening a connection to a database
 ## ----------------------------------
@@ -110,13 +110,13 @@ export db_common
 
 type
   DbConn* = PSqlite3  ## Encapsulates a database connection.
-  Row* = seq[string]  ## A row of a dataset. NULL database values will be
-                      ## converted to nil.
-  InstantRow* = Pstmt  ## A handle that can be used to get a row's column
-                       ## text on demand.
+  Row* = seq[string]  ## A row of a dataset. `NULL` database values will be
+                      ## converted to an empty string.
+  InstantRow* = Pstmt ## A handle that can be used to get a row's column
+                      ## text on demand.
 
 proc dbError*(db: DbConn) {.noreturn.} =
-  ## Raises a DbError exception.
+  ## Raises a `DbError` exception.
   ##
   ## **Examples:**
   ##
@@ -132,8 +132,8 @@ proc dbError*(db: DbConn) {.noreturn.} =
   raise e
 
 proc dbQuote*(s: string): string =
-  ## Escapes the `'`(single quote) char to `''`.
-  ## Because single quote is used for defining VARCHAR in SQL.
+  ## Escapes the `'` (single quote) char to `''`.
+  ## Because single quote is used for defining `VARCHAR` in SQL.
   runnableExamples:
     doAssert dbQuote("'") == "''''"
     doAssert dbQuote("A Foobar's pen.") == "'A Foobar''s pen.'"
@@ -157,7 +157,7 @@ proc dbFormat(formatstr: SqlQuery, args: varargs[string]): string =
 proc tryExec*(db: DbConn, query: SqlQuery,
               args: varargs[string, `$`]): bool {.
               tags: [ReadDbEffect, WriteDbEffect].} =
-  ## Tries to execute the query and returns true if successful, false otherwise.
+  ## Tries to execute the query and returns `true` if successful, `false` otherwise.
   ##
   ## **Examples:**
   ##
@@ -177,7 +177,7 @@ proc tryExec*(db: DbConn, query: SqlQuery,
 
 proc exec*(db: DbConn, query: SqlQuery, args: varargs[string, `$`])  {.
   tags: [ReadDbEffect, WriteDbEffect].} =
-  ## Executes the query and raises a DbError exception if not successful.
+  ## Executes the query and raises a `DbError` exception if not successful.
   ##
   ## **Examples:**
   ##
@@ -214,11 +214,11 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
                    args: varargs[string, `$`]): Row {.tags: [ReadDbEffect].} =
   ## Executes the query and iterates over the result dataset.
   ##
-  ## This is very fast, but potentially dangerous.  Use this iterator only
+  ## This is very fast, but potentially dangerous. Use this iterator only
   ## if you require **ALL** the rows.
   ##
-  ## **Note:** Breaking the fastRows() iterator during a loop will cause the
-  ## next database query to raise a DbError exception ``unable to close due
+  ## **Note:** Breaking the `fastRows()` iterator during a loop will cause the
+  ## next database query to raise a `DbError` exception ``unable to close due
   ## to ...``.
   ##
   ## **Examples:**
@@ -254,9 +254,9 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
 iterator instantRows*(db: DbConn, query: SqlQuery,
                       args: varargs[string, `$`]): InstantRow
                       {.tags: [ReadDbEffect].} =
-  ## Same as `fastRows iterator <#fastRows.i,DbConn,SqlQuery,varargs[string,]>`_
+  ## Similar to `fastRows iterator <#fastRows.i,DbConn,SqlQuery,varargs[string,]>`_
   ## but returns a handle that can be used to get column text
-  ## on demand using []. Returned handle is valid only within the iterator body.
+  ## on demand using `[]`. Returned handle is valid only within the iterator body.
   ##
   ## **Examples:**
   ##
@@ -316,8 +316,8 @@ proc setColumns(columns: var DbColumns; x: PStmt) =
 iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery,
                       args: varargs[string, `$`]): InstantRow
                       {.tags: [ReadDbEffect].} =
-  ## Same as `instantRows iterator <#instantRows.i,DbConn,SqlQuery,varargs[string,]>`_.
-  ## And sets information of columns to `columns`.
+  ## Similar to `instantRows iterator <#instantRows.i,DbConn,SqlQuery,varargs[string,]>`_,
+  ## but sets information about columns to `columns`.
   ##
   ## **Examples:**
   ##
@@ -360,7 +360,7 @@ proc `[]`*(row: InstantRow, col: int32): string {.inline.} =
   $column_text(row, col)
 
 proc len*(row: InstantRow): int32 {.inline.} =
-  ## Returns number of columns in the row.
+  ## Returns number of columns in a row.
   ##
   ## See also:
   ## * `instantRows iterator <#instantRows.i,DbConn,SqlQuery,varargs[string,]>`_
@@ -370,7 +370,7 @@ proc len*(row: InstantRow): int32 {.inline.} =
 proc getRow*(db: DbConn, query: SqlQuery,
              args: varargs[string, `$`]): Row {.tags: [ReadDbEffect].} =
   ## Retrieves a single row. If the query doesn't return any rows, this proc
-  ## will return a Row with empty strings for each column.
+  ## will return a `Row` with empty strings for each column.
   ##
   ## **Examples:**
   ##
@@ -427,7 +427,7 @@ proc getAllRows*(db: DbConn, query: SqlQuery,
 
 iterator rows*(db: DbConn, query: SqlQuery,
                args: varargs[string, `$`]): Row {.tags: [ReadDbEffect].} =
-  ## Same as `fastRows iterator <#fastRows.i,DbConn,SqlQuery,varargs[string,]>`_,
+  ## Similar to `fastRows iterator <#fastRows.i,DbConn,SqlQuery,varargs[string,]>`_,
   ## but slower and safe.
   ##
   ## **Examples:**
@@ -455,8 +455,8 @@ iterator rows*(db: DbConn, query: SqlQuery,
 proc getValue*(db: DbConn, query: SqlQuery,
                args: varargs[string, `$`]): string {.tags: [ReadDbEffect].} =
   ## Executes the query and returns the first column of the first row of the
-  ## result dataset. Returns "" if the dataset contains no rows or the database
-  ## value is NULL.
+  ## result dataset. Returns `""` if the dataset contains no rows or the database
+  ## value is `NULL`.
   ##
   ## **Examples:**
   ##
@@ -517,8 +517,10 @@ proc tryInsertID*(db: DbConn, query: SqlQuery,
 proc insertID*(db: DbConn, query: SqlQuery,
                args: varargs[string, `$`]): int64 {.tags: [WriteDbEffect].} =
   ## Executes the query (typically "INSERT") and returns the
-  ## generated ID for the row. Raise a DbError exception when failed to insert
-  ## row. For Postgre this adds ``RETURNING id`` to the query, so it only works
+  ## generated ID for the row.
+  ##
+  ## Raises a `DbError` exception when failed to insert row.
+  ## For Postgre this adds ``RETURNING id`` to the query, so it only works
   ## if your primary key is named ``id``.
   ##
   ## **Examples:**
@@ -578,7 +580,7 @@ proc close*(db: DbConn) {.tags: [DbEffect].} =
 
 proc open*(connection, user, password, database: string): DbConn {.
   tags: [DbEffect].} =
-  ## Opens a database connection. Raises a DbError exception if the connection
+  ## Opens a database connection. Raises a `DbError` exception if the connection
   ## could not be established.
   ##
   ## **Note:** Only the ``connection`` parameter is used for ``sqlite``.
@@ -605,7 +607,7 @@ proc setEncoding*(connection: DbConn, encoding: string): bool {.
   ## Sets the encoding of a database connection, returns `true` for
   ## success, `false` for failure.
   ##
-  ## **Note:** that the encoding cannot be changed once it's been set.
+  ## **Note:** The encoding cannot be changed once it's been set.
   ## According to SQLite3 documentation, any attempt to change
   ## the encoding after the database is created will be silently
   ## ignored.

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -129,7 +129,7 @@ proc dbQuote*(s: string): string =
   ## Escape the `'` char to `''`.
   runnableExamples:
     doAssert dbQuote("'") == "''''"
-    doAssert dbQuote("This is a Bob's pen.") == "'This is a Bob''s pen.'"
+    doAssert dbQuote("A Foobar's pen.") == "'A Foobar''s pen.'"
 
   result = "'"
   for c in items(s):
@@ -219,8 +219,8 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
   ##    # Records of my_table:
   ##    # | id | name     |
   ##    # |----|----------|
-  ##    # |  1 | 'item#1' |
-  ##    # |  2 | 'item#2' |
+  ##    # |  1 | item#1   |
+  ##    # |  2 | item#2   |
   ##
   ##    for row in db.fastRows(sql"SELECT id, name FROM my_table"):
   ##      echo row
@@ -315,8 +315,8 @@ proc getRow*(db: DbConn, query: SqlQuery,
   ##    # Records of my_table:
   ##    # | id | name     |
   ##    # |----|----------|
-  ##    # |  1 | 'item#1' |
-  ##    # |  2 | 'item#2' |
+  ##    # |  1 | item#1   |
+  ##    # |  2 | item#2   |
   ##
   ##    doAssert db.getRow(sql"SELECT id, name FROM my_table"
   ##                       ) == Row(@["1", "item#1"])
@@ -350,8 +350,8 @@ proc getAllRows*(db: DbConn, query: SqlQuery,
   ##    # Records of my_table:
   ##    # | id | name     |
   ##    # |----|----------|
-  ##    # |  1 | 'item#1' |
-  ##    # |  2 | 'item#2' |
+  ##    # |  1 | item#1   |
+  ##    # |  2 | item#2   |
   ##
   ##    doAssert db.getAllRows(sql"SELECT id, name FROM my_table") == @[Row(@["1", "item#1"]), Row(@["2", "item#2"])]
   ##    db.close()
@@ -372,8 +372,8 @@ iterator rows*(db: DbConn, query: SqlQuery,
   ##    # Records of my_table:
   ##    # | id | name     |
   ##    # |----|----------|
-  ##    # |  1 | 'item#1' |
-  ##    # |  2 | 'item#2' |
+  ##    # |  1 | item#1   |
+  ##    # |  2 | item#2   |
   ##
   ##    for row in db.rows(sql"SELECT id, name FROM my_table"):
   ##      echo row
@@ -400,8 +400,8 @@ proc getValue*(db: DbConn, query: SqlQuery,
   ##    # Records of my_table:
   ##    # | id | name     |
   ##    # |----|----------|
-  ##    # |  1 | 'item#1' |
-  ##    # |  2 | 'item#2' |
+  ##    # |  1 | item#1   |
+  ##    # |  2 | item#2   |
   ##
   ##    doAssert db.getValue(sql"SELECT name FROM my_table WHERE id = ?",
   ##                         2) == "item#2"
@@ -479,7 +479,22 @@ proc execAffectedRows*(db: DbConn, query: SqlQuery,
                        tags: [ReadDbEffect, WriteDbEffect].} =
   ## Executes the query (typically "UPDATE") and returns the
   ## number of affected rows.
-  ## TODO example
+  ##
+  ## **Examples:**
+  ##
+  ## .. code-block:: Nim
+  ##
+  ##    let db = open("mytest.db", "", "", "")
+  ##
+  ##    # Records of my_table:
+  ##    # | id | name     |
+  ##    # |----|----------|
+  ##    # |  1 | item#1   |
+  ##    # |  2 | item#2   |
+  ##
+  ##    doAssert db.execAffectedRows(sql"UPDATE my_table SET name = 'TEST'") == 2
+  ##
+  ##    db.close()
   exec(db, query, args)
   result = changes(db)
 
@@ -508,7 +523,7 @@ proc open*(connection, user, password, database: string): DbConn {.
   ##    try:
   ##      let db = open("mytest.db", "", "", "")
   ##      ## do something...
-  ##      ## db.exec(sql"SELECT * FROM my_table")
+  ##      ## db.getAllRows(sql"SELECT * FROM my_table")
   ##      db.close()
   ##    except:
   ##      stderr.writeLine(getCurrentExceptionMsg())

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -80,6 +80,11 @@
 ##  echo "Inserted item: ", theDb.getValue(sql"SELECT name FROM myTestTbl WHERE id=?", id)
 ##
 ##  theDb.close()
+##
+## See also
+## ========
+##
+## * TODO
 
 {.deadCodeElim: on.}  # dce option deprecated
 
@@ -97,6 +102,7 @@ type
 
 proc dbError*(db: DbConn) {.noreturn.} =
   ## Raises a DbError exception.
+  ## TODO example
   var e: ref DbError
   new(e)
   e.msg = $sqlite3.errmsg(db)
@@ -104,6 +110,7 @@ proc dbError*(db: DbConn) {.noreturn.} =
 
 proc dbQuote*(s: string): string =
   ## DB quotes the string.
+  ## TODO example
   result = "'"
   for c in items(s):
     if c == '\'': add(result, "''")
@@ -124,6 +131,7 @@ proc tryExec*(db: DbConn, query: SqlQuery,
               args: varargs[string, `$`]): bool {.
               tags: [ReadDbEffect, WriteDbEffect].} =
   ## Tries to execute the query and returns true if successful, false otherwise.
+  ## TODO example
   assert(not db.isNil, "Database not connected.")
   var q = dbFormat(query, args)
   var stmt: sqlite3.Pstmt
@@ -135,6 +143,7 @@ proc tryExec*(db: DbConn, query: SqlQuery,
 proc exec*(db: DbConn, query: SqlQuery, args: varargs[string, `$`])  {.
   tags: [ReadDbEffect, WriteDbEffect].} =
   ## Executes the query and raises DbError if not successful.
+  ## TODO example
   if not tryExec(db, query, args): dbError(db)
 
 proc newRow(L: int): Row =
@@ -163,6 +172,7 @@ iterator fastRows*(db: DbConn, query: SqlQuery,
   ##
   ## Breaking the fastRows() iterator during a loop will cause the next
   ## database query to raise a DbError exception ``unable to close due to ...``.
+  ## TODO example
   var stmt = setupQuery(db, query, args)
   var L = (column_count(stmt))
   var result = newRow(L)
@@ -178,6 +188,7 @@ iterator instantRows*(db: DbConn, query: SqlQuery,
                       {.tags: [ReadDbEffect].} =
   ## Same as fastRows but returns a handle that can be used to get column text
   ## on demand using []. Returned handle is valid only within the iterator body.
+  ## TODO example
   var stmt = setupQuery(db, query, args)
   try:
     while step(stmt) == SQLITE_ROW:
@@ -212,6 +223,7 @@ iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery,
                       {.tags: [ReadDbEffect].} =
   ## Same as fastRows but returns a handle that can be used to get column text
   ## on demand using []. Returned handle is valid only within the iterator body.
+  ## TODO example
   var stmt = setupQuery(db, query, args)
   setColumns(columns, stmt)
   try:
@@ -222,16 +234,19 @@ iterator instantRows*(db: DbConn; columns: var DbColumns; query: SqlQuery,
 
 proc `[]`*(row: InstantRow, col: int32): string {.inline.} =
   ## Returns text for given column of the row.
+  ## TODO example
   $column_text(row, col)
 
 proc len*(row: InstantRow): int32 {.inline.} =
   ## Returns number of columns in the row.
+  ## TODO example
   column_count(row)
 
 proc getRow*(db: DbConn, query: SqlQuery,
              args: varargs[string, `$`]): Row {.tags: [ReadDbEffect].} =
   ## Retrieves a single row. If the query doesn't return any rows, this proc
   ## will return a Row with empty strings for each column.
+  ## TODO example
   var stmt = setupQuery(db, query, args)
   var L = (column_count(stmt))
   result = newRow(L)
@@ -242,6 +257,7 @@ proc getRow*(db: DbConn, query: SqlQuery,
 proc getAllRows*(db: DbConn, query: SqlQuery,
                  args: varargs[string, `$`]): seq[Row] {.tags: [ReadDbEffect].} =
   ## Executes the query and returns the whole result dataset.
+  ## TODO example
   result = @[]
   for r in fastRows(db, query, args):
     result.add(r)
@@ -249,6 +265,7 @@ proc getAllRows*(db: DbConn, query: SqlQuery,
 iterator rows*(db: DbConn, query: SqlQuery,
                args: varargs[string, `$`]): Row {.tags: [ReadDbEffect].} =
   ## Same as `FastRows`, but slower and safe.
+  ## TODO example
   for r in fastRows(db, query, args): yield r
 
 proc getValue*(db: DbConn, query: SqlQuery,
@@ -256,6 +273,7 @@ proc getValue*(db: DbConn, query: SqlQuery,
   ## Executes the query and returns the first column of the first row of the
   ## result dataset. Returns "" if the dataset contains no rows or the database
   ## value is NULL.
+  ## TODO example
   var stmt = setupQuery(db, query, args)
   if step(stmt) == SQLITE_ROW:
     let cb = column_bytes(stmt, 0)
@@ -273,6 +291,7 @@ proc tryInsertID*(db: DbConn, query: SqlQuery,
                   {.tags: [WriteDbEffect], raises: [].} =
   ## Executes the query (typically "INSERT") and returns the
   ## generated ID for the row or -1 in case of an error.
+  ## TODO example
   assert(not db.isNil, "Database not connected.")
   var q = dbFormat(query, args)
   var stmt: sqlite3.Pstmt
@@ -289,6 +308,7 @@ proc insertID*(db: DbConn, query: SqlQuery,
   ## generated ID for the row. For Postgre this adds
   ## ``RETURNING id`` to the query, so it only works if your primary key is
   ## named ``id``.
+  ## TODO example
   result = tryInsertID(db, query, args)
   if result < 0: dbError(db)
 
@@ -297,17 +317,20 @@ proc execAffectedRows*(db: DbConn, query: SqlQuery,
                        tags: [ReadDbEffect, WriteDbEffect].} =
   ## Executes the query (typically "UPDATE") and returns the
   ## number of affected rows.
+  ## TODO example
   exec(db, query, args)
   result = changes(db)
 
 proc close*(db: DbConn) {.tags: [DbEffect].} =
   ## Closes the database connection.
+  ## TODO example
   if sqlite3.close(db) != SQLITE_OK: dbError(db)
 
 proc open*(connection, user, password, database: string): DbConn {.
   tags: [DbEffect].} =
   ## opens a database connection. Raises `EDb` if the connection could not
   ## be established. Only the ``connection`` parameter is used for ``sqlite``.
+  ## TODO example
   var db: DbConn
   if sqlite3.open(connection, db) == SQLITE_OK:
     result = db
@@ -323,6 +346,7 @@ proc setEncoding*(connection: DbConn, encoding: string): bool {.
   ## According to SQLite3 documentation, any attempt to change
   ## the encoding after the database is created will be silently
   ## ignored.
+  ## TODO example
   exec(connection, sql"PRAGMA encoding = ?", [encoding])
   result = connection.getValue(sql"PRAGMA encoding") == encoding
 


### PR DESCRIPTION
Updated documentation for db_sqlite module.

- See also links
- Example codes

db_sqlite is impure module and need to be installed sqlite3.
Therefore I wrote example codes by `code-block` documentation comment, not `runnableExamples`.

My english is not perfect.
Please fix or tell me if english sentence was wrong.

ref #10330