### PR TITLE
More specific error message for unsupported recursion in iterators

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -804,7 +804,7 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode, nOrig: PNode,
     of skMacro, skTemplate: discard
     else:
       if callee.kind == skIterator and callee.id == c.p.owner.id:
-        localError(c.config, n.info, errRecursiveDependencyX % callee.name.s)
+        localError(c.config, n.info, errRecursiveDependencyIteratorX % callee.name.s)
         # error correction, prevents endless for loop elimination in transf.
         # See bug #2051:
         result.sons[0] = newSymNode(errorSym(c, n))

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -34,6 +34,7 @@ const
   errThreadvarCannotInit = "a thread var cannot be initialized explicitly; this would only run for the main thread"
   errImplOfXexpected = "implementation of '$1' expected"
   errRecursiveDependencyX = "recursive dependency: '$1'"
+  errRecursiveDependencyIteratorX = "recursion is not supported in iterators: '$1'"
   errPragmaOnlyInHeaderOfProcX = "pragmas are only allowed in the header of a proc; redefinition of $1"
   errCannotAssignMacroSymbol = "cannot assign macro symbol to $1 here. Forgot to invoke the macro with '()'?"
   errInvalidTypeDescAssign = "'typedesc' metatype is not valid here; typed '=' instead of ':'?"

--- a/tests/iter/treciter.nim
+++ b/tests/iter/treciter.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "recursive dependency: \'myrec\'"
+  errormsg: "recursion is not supported in iterators: 'myrec'"
   file: "treciter.nim"
   line: 9
 """


### PR DESCRIPTION
Instead of

```
t.nim(6, 18) Error: recursive dependency: 'all'
```

the message is now a bit more informative:

```
t.nim(6, 18) Error: recursion is not supported in iterators: 'all'
```