### PR TITLE
Allow void macro result

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -36,8 +36,12 @@
 
 - Compile time checks for integer and float conversions are now stricter. For example, `const x = uint32(-1)` now gives a compile time error instead of being equivalent to `const x = 0xFFFFFFFF'u32`.
 
-- A bug allowed ``macro foo(): int = 123`` to compile even though a
-  macros has to return a ``NimNode``. This has been fixed.
+- Using `typed` as the result type in templates/macros now means
+  "expression with a type". The old meaning of `typed` is preserved
+  as `void` or no result type at all.
+
+- A bug allowed `macro foo(): int = 123` to compile even though a
+  macros has to return a `NimNode`. This has been fixed.
 
 #### Breaking changes in the standard library
 

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -759,7 +759,7 @@ proc getLinkCmd(conf: ConfigRef; output: AbsoluteFile,
 template getLinkCmd(conf: ConfigRef; output: AbsoluteFile, objfiles: string): string =
   getLinkCmd(conf, output, objfiles, optGenDynLib in conf.globalOptions)
 
-template tryExceptOSErrorMessage(conf: ConfigRef; errorPrefix: string = "", body: untyped): typed =
+template tryExceptOSErrorMessage(conf: ConfigRef; errorPrefix: string = "", body: untyped) =
   try:
     body
   except OSError:

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -407,12 +407,11 @@ proc semAfterMacroCall(c: PContext, call, macroResult: PNode,
   else:
     case s.typ.sons[0].kind
     of tyUntyped:
-      # BUGFIX: we cannot expect a type here, because module aliases would not
-      # work then (see the ``tmodulealias`` test)
-      # semExprWithType(c, result)
+      # Not expecting a type here allows templates like in ``tmodulealias.in``.
       result = semExpr(c, result, flags)
     of tyTyped:
-      result = semStmt(c, result, flags)
+      # More restrictive version.
+      result = semExprWithType(c, result, flags)
     of tyTypeDesc:
       if result.kind == nkStmtList: result.kind = nkStmtListType
       var typ = semTypeNode(c, result, nil)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1985,7 +1985,7 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
 
   if ids.len > 0:
     dummyTemplate.sons[paramsPos] = newNodeI(nkFormalParams, n.info)
-    dummyTemplate[paramsPos].add getSysSym(c.graph, n.info, "typed").newSymNode # return type
+    dummyTemplate[paramsPos].add getSysSym(c.graph, n.info, "untyped").newSymNode # return type
     ids.add getSysSym(c.graph, n.info, "untyped").newSymNode # params type
     ids.add c.graph.emptyNode # no default value
     dummyTemplate[paramsPos].add newNode(nkIdentDefs, n.info, ids)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -606,11 +606,6 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
       if n.sons[genericParamsPos].kind == nkEmpty:
         # we have a list of implicit type parameters:
         n.sons[genericParamsPos] = gp
-    # no explicit return type? -> use tyTyped
-    if n.sons[paramsPos].sons[0].kind == nkEmpty:
-      # use ``stmt`` as implicit result type
-      s.typ.sons[0] = newTypeS(tyTyped, c)
-      s.typ.n.sons[0] = newNodeIT(nkType, n.info, s.typ.sons[0])
   else:
     s.typ = newTypeS(tyProc, c)
     # XXX why do we need tyTyped as a return type again?

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1104,7 +1104,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         #echo "new pc ", newPc, " calling: ", prc.name.s
         var newFrame = PStackFrame(prc: prc, comesFrom: pc, next: tos)
         newSeq(newFrame.slots, prc.offset+ord(isClosure))
-        if not isEmptyType(prc.typ.sons[0]) or prc.kind == skMacro:
+        if not isEmptyType(prc.typ.sons[0]):
           putIntoReg(newFrame.slots[0], getNullValue(prc.typ.sons[0], prc.info, c.config))
         for i in 1 .. rc-1:
           newFrame.slots[i] = regs[rb+i]

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -567,7 +567,7 @@ proc quote*(bl: typed, op = "``"): NimNode {.magic: "QuoteAst", noSideEffect.}
   ##
   ## .. code-block:: nim
   ##
-  ##   macro check(ex: untyped): typed =
+  ##   macro check(ex: untyped) =
   ##     # this is a simplified version of the check macro from the
   ##     # unittest module.
   ##

--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -572,7 +572,7 @@ when not useUnicode:
   proc isTitle(a: char): bool {.inline.} = return false
   proc isWhiteSpace(a: char): bool {.inline.} = return a in {' ', '\9'..'\13'}
 
-template matchOrParse(mopProc: untyped): typed =
+template matchOrParse(mopProc: untyped) =
   # Used to make the main matcher proc *rawMatch* as well as event parser
   # procs. For the former, *enter* and *leave* event handler code generators
   # are provided which just return *discard*.

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -71,7 +71,7 @@ template onFailedAssert*(msg, code: untyped): untyped {.dirty.} =
     let msg = msgIMPL
     code
 
-template doAssertRaises*(exception: typedesc, code: untyped): typed =
+template doAssertRaises*(exception: typedesc, code: untyped) =
   ## Raises ``AssertionError`` if specified ``code`` does not raise the
   ## specified exception. Example:
   ##

--- a/nimsuggest/tests/tsug_template.nim
+++ b/nimsuggest/tests/tsug_template.nim
@@ -8,5 +8,5 @@ $nimsuggest --tester $file
 >sug $1
 sug;;skMacro;;tsug_template.tmpb;;macro (){.noSideEffect, gcsafe, locks: 0.};;$file;;2;;6;;"";;0;;Prefix
 sug;;skConverter;;tsug_template.tmpc;;converter ();;$file;;3;;10;;"";;0;;Prefix
-sug;;skTemplate;;tsug_template.tmpa;;template (): typed;;$file;;1;;9;;"";;0;;Prefix
+sug;;skTemplate;;tsug_template.tmpa;;template ();;$file;;1;;9;;"";;0;;Prefix
 """

--- a/tests/ccgbugs/tnocodegen_for_compiletime.nim
+++ b/tests/ccgbugs/tnocodegen_for_compiletime.nim
@@ -1,7 +1,7 @@
 # bug #1679
 import macros, tables, hashes
 proc hash(v: NimNode): Hash = 4  # performance is for suckers
-macro test(body: untyped): typed =
+macro test(body: untyped) =
   var a = initCountTable[NimNode]()
   a.inc(body)
 

--- a/tests/fields/tfields.nim
+++ b/tests/fields/tfields.nim
@@ -46,7 +46,7 @@ block ttemplate:
   for name, value in (n: "v").fieldPairs:
     echo name
 
-  template wrapper: typed =
+  template wrapper(): void =
     for name, value in (n: "v").fieldPairs:
       echo name
   wrapper()

--- a/tests/lookups/test.nim
+++ b/tests/lookups/test.nim
@@ -12,7 +12,7 @@ import unittest, macros
 
 # bug #4555
 
-macro memo(n: untyped): typed =
+macro memo(n: untyped) =
   result = n
 
 proc fastFib(n: int): int {.memo.} = 40

--- a/tests/macros/tcomplexecho.nim
+++ b/tests/macros/tcomplexecho.nim
@@ -32,7 +32,7 @@ proc foo(): seq[NimNode] {.compiletime.} =
   result.add test()
   result.add parseExpr("echo(5+56)")
 
-macro bar(): typed =
+macro bar() =
   result = newNimNode(nnkStmtList)
   let x = foo()
   for xx in x:

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -22,7 +22,7 @@ proc symToIdent(x: NimNode): NimNode =
         result.add symToIdent(c)
 
 # check getTypeInst and getTypeImpl for given symbol x
-macro testX(x,inst0: typed; recurse: static[bool]; implX: typed): typed =
+macro testX(x,inst0: typed; recurse: static[bool]; implX: typed) =
   # check that getTypeInst(x) equals inst0
   let inst = x.getTypeInst
   let instr = inst.symToIdent.treeRepr

--- a/tests/macros/tmacro5.nim
+++ b/tests/macros/tmacro5.nim
@@ -38,7 +38,7 @@ macro importImpl_forward(name, returns: untyped): untyped =
   decls.add res
   echo(repr(res))
 
-macro importImpl(name, returns, body: untyped): typed =
+macro importImpl(name, returns, body: untyped) =
   #var res = getAST(importImpl_forward(name, returns))
   discard getAST(importImpl_forward(name, returns))
   var res = copyNimTree(decls[decls.high])
@@ -46,7 +46,7 @@ macro importImpl(name, returns, body: untyped): typed =
   echo repr(res)
   impls.add res
 
-macro okayy: typed =
+macro okayy() =
   result = newNimNode(nnkStmtList)
   for node in decls: result.add node
   for node in impls: result.add node

--- a/tests/macros/tmacro6.nim
+++ b/tests/macros/tmacro6.nim
@@ -1,19 +1,9 @@
-# this is the Nim scratch file
-# feel free to try out things
-# when done try to run it with `compile'
+discard """
+errormsg: "expression '123' is of type 'int literal(123)' and has to be discarded"
+line: 71
+"""
 
 import macros
-# import math
-# import strutils
-# import sugar
-# import sequtils
-
-#var unittestResult = 0
-
-#proc unittestFinalizer(): void {.noconv.} =
-#  echo("abc")
-
-#addQuitProc(unittestFinalizer)
 
 proc foo(a,b,c: int): int =
   result += a
@@ -26,8 +16,6 @@ macro bar(a,b,c: int): int =
   result.add b
   result.add c
 
-# this is an already existing bug
-
 macro baz(a,b,c: int): int =
   let stmt = nnkStmtListExpr.newTree()
   stmt.add newCall(ident"echo", a)
@@ -36,14 +24,52 @@ macro baz(a,b,c: int): int =
   stmt.add newLit(123)
   return c
 
-proc bar(a: int, b,d: float): void =
-  discard
+# test no result type with explicit return
+
+macro baz2(a,b,c: int) =
+  let stmt = nnkStmtListExpr.newTree()
+  stmt.add newCall(ident"echo", a)
+  stmt.add newCall(ident"echo", b)
+  stmt.add newCall(ident"echo", c)
+  return stmt
+
+# test explicit void type with explicit return
+
+macro baz3(a,b,c: int): void =
+  let stmt = nnkStmtListExpr.newTree()
+  stmt.add newCall(ident"echo", a)
+  stmt.add newCall(ident"echo", b)
+  stmt.add newCall(ident"echo", c)
+  return stmt
+
+# test no result type with result variable
+
+macro baz4(a,b,c: int) =
+  result = nnkStmtListExpr.newTree()
+  result.add newCall(ident"echo", a)
+  result.add newCall(ident"echo", b)
+  result.add newCall(ident"echo", c)
+
+# test explicit void type with result variable
+
+macro baz5(a,b,c: int): void =
+  let result = nnkStmtListExpr.newTree()
+  result.add newCall(ident"echo", a)
+  result.add newCall(ident"echo", b)
+  result.add newCall(ident"echo", c)
+
+macro foobar1(): int =
+  result = quote do:
+    echo "Hello World"
+    1337
+
+echo foobar1()
 
 # this should create an error message, because 123 has to be discarded.
 
-macro foobar() =
+macro foobar2() =
   result = quote do:
     echo "Hello World"
     123
 
-foobar()
+echo foobar2()

--- a/tests/macros/tmacro6.nim
+++ b/tests/macros/tmacro6.nim
@@ -1,0 +1,49 @@
+# this is the Nim scratch file
+# feel free to try out things
+# when done try to run it with `compile'
+
+import macros
+# import math
+# import strutils
+# import sugar
+# import sequtils
+
+#var unittestResult = 0
+
+#proc unittestFinalizer(): void {.noconv.} =
+#  echo("abc")
+
+#addQuitProc(unittestFinalizer)
+
+proc foo(a,b,c: int): int =
+  result += a
+  result += b
+  result += c
+
+macro bar(a,b,c: int): int =
+  result = newCall(ident"echo")
+  result.add a
+  result.add b
+  result.add c
+
+# this is an already existing bug
+
+macro baz(a,b,c: int): int =
+  let stmt = nnkStmtListExpr.newTree()
+  stmt.add newCall(ident"echo", a)
+  stmt.add newCall(ident"echo", b)
+  stmt.add newCall(ident"echo", c)
+  stmt.add newLit(123)
+  return c
+
+proc bar(a: int, b,d: float): void =
+  discard
+
+# this should create an error message, because 123 has to be discarded.
+
+macro foobar() =
+  result = quote do:
+    echo "Hello World"
+    123
+
+foobar()

--- a/tests/macros/tmacrostmt.nim
+++ b/tests/macros/tmacrostmt.nim
@@ -18,15 +18,16 @@ case_token: inc i
 
 #bug #488
 
-macro foo: typed =
+macro foo() =
   var exp = newCall("whatwhat", newIntLitNode(1))
-  if compiles(getAst(exp)): return exp
+  if compiles(getAst(exp)):
+    return exp
   else: echo "Does not compute! (test OK)"
 
 foo()
 
 #------------------------------------
-# bug #8287 
+# bug #8287
 type MyString = distinct string
 
 proc `$` (c: MyString): string {.borrow.}
@@ -37,7 +38,7 @@ proc `!!` (c: cstring): int =
 proc f(name: MyString): int =
   !! $ name
 
-macro repr_and_parse(fn: typed): typed =
+macro repr_and_parse(fn: typed) =
   let fn_impl = fn.getImpl
   fn_impl.name = genSym(nskProc, $fn_impl.name)
   echo fn_impl.repr
@@ -51,7 +52,7 @@ repr_and_parse(f)
 
 
 #------------------------------------
-# bugs #8343 and #8344 
+# bugs #8343 and #8344
 proc one_if_proc(x, y : int): int =
   if x < y: result = x
   else: result = y
@@ -76,7 +77,7 @@ proc test_cond_stmtlist(x, y: int): int =
 
 #------------------------------------
 # bug #8762
-proc t2(a, b: int): int =  
+proc t2(a, b: int): int =
   `+`(a, b)
 
 
@@ -92,23 +93,23 @@ proc fn2(x, y: float): float =
 proc fn3(x, y: int): bool =
   (((x and 3) div 4) or (x mod (y xor -1))) == 0 or y notin [1,2]
 
-proc fn4(x: int): int = 
+proc fn4(x: int): int =
   if x mod 2 == 0: return x + 2
   else: return 0
 
 #------------------------------------
 # bug #10807
-proc fn_unsafeaddr(x: int): int = 
+proc fn_unsafeaddr(x: int): int =
   cast[int](unsafeAddr(x))
 
 static:
-  echo fn_unsafeaddr.repr_to_string 
+  echo fn_unsafeaddr.repr_to_string
   let fn1s = "proc fn1(x, y: int): int =\n  result = 2 * (x + y)\n"
   let fn2s = "proc fn2(x, y: float): float =\n  result = (y + 2 * x) / (x - y)\n"
   let fn3s = "proc fn3(x, y: int): bool =\n  result = ((x and 3) div 4 or x mod (y xor -1)) == 0 or not contains([1, 2], y)\n"
   let fn4s = "proc fn4(x: int): int =\n  if x mod 2 == 0:\n    return x + 2\n  else:\n    return 0\n"
   let fnAddr = "proc fn_unsafeaddr(x: int): int =\n  result = cast[int](unsafeAddr(x))\n"
-  
+
   doAssert fn1.repr_to_string == fn1s
   doAssert fn2.repr_to_string == fn2s
   doAssert fn3.repr_to_string == fn3s
@@ -134,4 +135,3 @@ repr_and_parse(test_block)
 repr_and_parse(test_cond_stmtlist)
 repr_and_parse(t2)
 repr_and_parse(test_pure_enums)
-

--- a/tests/metatype/tmetatype_issues.nim
+++ b/tests/metatype/tmetatype_issues.nim
@@ -34,7 +34,7 @@ block t898:
 
 
 block t7528:
-  macro bar(n: untyped): typed =
+  macro bar(n: untyped) =
     result = newNimNode(nnkStmtList, n)
     result.add(newCall("write", newIdentNode("stdout"), n))
 

--- a/tests/template/template_various.nim
+++ b/tests/template/template_various.nim
@@ -77,7 +77,7 @@ block generic_templates:
 block tgetast_typeliar:
   proc error(s: string) = quit s
 
-  macro assertOrReturn(condition: bool; message: string): typed =
+  macro assertOrReturn2(condition: bool; message: string) =
     var line = condition.lineInfo()
     result = quote do:
       block:
@@ -86,8 +86,10 @@ block tgetast_typeliar:
           return
 
   macro assertOrReturn(condition: bool): typed =
-    var message = condition.toStrLit()
-    result = getAst assertOrReturn(condition, message)
+    var message : NimNode = newLit(condition.repr)
+    # echo message
+    result = getAst assertOrReturn2(condition, message)
+    echo result.repr
 
   proc point(size: int16): tuple[x, y: int16] =
     # returns random point in square area with given `size`
@@ -245,7 +247,3 @@ block ttempl5:
 block templreturntype:
   template `=~` (a: int, b: int): bool = false
   var foo = 2 =~ 3
-
-
-
-

--- a/tests/vm/texcl.nim
+++ b/tests/vm/texcl.nim
@@ -18,7 +18,7 @@ proc initOpts(): set[nlOptions] =
 
 const cOpts = initOpts()
 
-macro nlo(): typed =
+macro nlo() =
   nlOpts.incl(nloNone)
   nlOpts.excl(nloDebug)
   result = newEmptyNode()

--- a/tests/vm/tstaticprintseq.nim
+++ b/tests/vm/tstaticprintseq.nim
@@ -24,7 +24,7 @@ bb
 
 const s = @[1,2,3]
 
-macro foo: typed =
+macro foo() =
   for e in s:
     echo e
 
@@ -55,7 +55,7 @@ static:
   var m2: TData = data
   for x in m2.numbers: echo x
 
-macro ff(d: static[TData]): typed =
+macro ff(d: static[TData]) =
   for x in d.letters:
     echo x
 

--- a/tests/vm/ttouintconv.nim
+++ b/tests/vm/ttouintconv.nim
@@ -20,7 +20,7 @@ nimout: '''
 
 #bug #2514
 
-macro foo(): typed =
+macro foo() =
   var x = 8'u8
   var y = 9'u16
   var z = 17'u32
@@ -58,7 +58,7 @@ macro foo(): typed =
   var zz = 0x7FFFFFFF'u32
   echo zz
 
-macro foo2(): typed =
+macro foo2() =
   var xx = 0x7FFFFFFFFFFFFFFF
   echo xx
 


### PR DESCRIPTION
This PR aims to clean up some leftovers from the expr/stmt distinction. ``stmt`` has been renamed to ``typed``, but it still means "statement", so basically an expression of type void. But I don't think that the name really makes a lot of senes here. I have decided to actually use the type void here from now on, because that is what is used everywhere else in the compiler as well.

 * ``macro foo() = ...`` and ``macro foo(): void = ...`` is now allowed. It doesn't mean that the macro has no result, it means that the macro generates an expression of type ``void`` (a statement).
 * ``macro foo(): typed = ...`` triggers now a deprecation warning. You should use ``void`` or no return type declaration at all, as has the exact same semantic meaning of ``typed`` until now.
 * As macros now use the void type (nil), the ``tyTyped`` type for macro results became basically free. This means at some point ``typed`` might be repurposed for something else, where the name actually matters.
 * since ``macro foo() = ...`` is now allowed, it is now consistent with procs and templates, where the default result type is void as well.

Edit: Pleas don't get bothered with all the changes where I remove ``: typed`` in the tests. In my first attempt I changed the meaning of ``: typed`` but I quickly saw that it really was too disruptive of a change. So I reverted that part and made the use of ``: typed`` emit a deprecation warning.

