### PR TITLE
nimsuggest: lower its memory limit

### DIFF
--- a/nimsuggest/nimsuggest.nim.cfg
+++ b/nimsuggest/nimsuggest.nim.cfg
@@ -10,12 +10,8 @@ define:useStdoutAsStdmsg
 define:nimsuggest
 define:nimcore
 
-# die when nimsuggest uses more than 4GB:
-@if cpu32:
-  define:"nimMaxHeap=2000"
-@else:
-  define:"nimMaxHeap=4000"
-@end
+# die when nimsuggest uses more than 1GB:
+define:"nimMaxHeap=1000"
 
 #define:useNodeIds
 #define:booting


### PR DESCRIPTION
It is still leaking as before, but now at least it is killed at less embarrassing value.