### PR TITLE
Fixed #9762

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3834,36 +3834,35 @@ template `^^`(s, i: untyped): untyped =
 template `[]`*(s: string; i: int): char = arrGet(s, i)
 template `[]=`*(s: string; i: int; val: char) = arrPut(s, i, val)
 
-when hasAlloc or defined(nimscript):
-  proc `[]`*[T, U](s: string, x: HSlice[T, U]): string {.inline.} =
-    ## Slice operation for strings.
-    ## Returns the inclusive range `[s[x.a], s[x.b]]`:
-    ##
-    ## .. code-block:: Nim
-    ##    var s = "abcdef"
-    ##    assert s[1..3] == "bcd"
-    let a = s ^^ x.a
-    let L = (s ^^ x.b) - a + 1
-    result = newString(L)
-    for i in 0 ..< L: result[i] = s[i + a]
+proc `[]`*[T, U](s: string, x: HSlice[T, U]): string {.inline.} =
+  ## Slice operation for strings.
+  ## Returns the inclusive range `[s[x.a], s[x.b]]`:
+  ##
+  ## .. code-block:: Nim
+  ##    var s = "abcdef"
+  ##    assert s[1..3] == "bcd"
+  let a = s ^^ x.a
+  let L = (s ^^ x.b) - a + 1
+  result = newString(L)
+  for i in 0 ..< L: result[i] = s[i + a]
 
-  proc `[]=`*[T, U](s: var string, x: HSlice[T, U], b: string) =
-    ## Slice assignment for strings.
-    ##
-    ## If ``b.len`` is not exactly the number of elements that are referred to
-    ## by `x`, a `splice`:idx: is performed:
-    ##
-    runnableExamples:
-      var s = "abcdefgh"
-      s[1 .. ^2] = "xyz"
-      assert s == "axyzh"
+proc `[]=`*[T, U](s: var string, x: HSlice[T, U], b: string) =
+  ## Slice assignment for strings.
+  ##
+  ## If ``b.len`` is not exactly the number of elements that are referred to
+  ## by `x`, a `splice`:idx: is performed:
+  ##
+  runnableExamples:
+    var s = "abcdefgh"
+    s[1 .. ^2] = "xyz"
+    assert s == "axyzh"
 
-    var a = s ^^ x.a
-    var L = (s ^^ x.b) - a + 1
-    if L == b.len:
-      for i in 0..<L: s[i+a] = b[i]
-    else:
-      spliceImpl(s, a, L, b)
+  var a = s ^^ x.a
+  var L = (s ^^ x.b) - a + 1
+  if L == b.len:
+    for i in 0..<L: s[i+a] = b[i]
+  else:
+    spliceImpl(s, a, L, b)
 
 proc `[]`*[Idx, T, U, V](a: array[Idx, T], x: HSlice[U, V]): seq[T] =
   ## Slice operation for arrays.

--- a/tests/manyloc/standalone/barebone.nim
+++ b/tests/manyloc/standalone/barebone.nim
@@ -11,3 +11,6 @@ proc printf(frmt: cstring) {.varargs, header: "<stdio.h>", cdecl.}
 var x = 0
 inc x
 printf("hi %ld\n", x+4777)
+
+proc substr(a: string): string = a[0 .. 3] # This should compile. See #9762
+const a = substr("foobar")


### PR DESCRIPTION
Unconditionally enabled operators `[]` and `[]=` for strings. I don't see much sense in disabling just those operators, since there still remain seq counterparts, and they "require" GC just as well.