### PR TITLE
extends {}= proc of stdlib.json , removes exceptions

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -61,8 +61,6 @@
 ##
 ##   doAssert jsonNode["key"].getFloat() == 3.14
 ##
-## **Important:** The ``[]`` operator will raise an exception when the
-## specified field does not exist.
 ##
 ## Handling optional keys
 ## ----------------------
@@ -299,12 +297,12 @@ proc getElems*(n: JsonNode, default: seq[JsonNode] = @[]): seq[JsonNode] =
 
 proc add*(father, child: JsonNode) =
   ## Adds `child` to a JArray node `father`.
-  assert father.kind == JArray
+  if father.kind != JObject: discard
   father.elems.add(child)
 
 proc add*(obj: JsonNode, key: string, val: JsonNode) =
   ## Sets a field from a `JObject`.
-  assert obj.kind == JObject
+  if obj.kind != JObject: discard
   obj.fields[key] = val
 
 proc `%`*(s: string): JsonNode =
@@ -371,249 +369,6 @@ proc `%`*[T](opt: Option[T]): JsonNode =
   ## Generic constructor for JSON data. Creates a new ``JNull JsonNode``
   ## if ``opt`` is empty, otherwise it delegates to the underlying value.
   if opt.isSome: %opt.get else: newJNull()
-
-when false:
-  # For 'consistency' we could do this, but that only pushes people further
-  # into that evil comfort zone where they can use Nim without understanding it
-  # causing problems later on.
-  proc `%`*(elements: set[bool]): JsonNode =
-    ## Generic constructor for JSON data. Creates a new `JObject JsonNode`.
-    ## This can only be used with the empty set ``{}`` and is supported
-    ## to prevent the gotcha ``%*{}`` which used to produce an empty
-    ## JSON array.
-    result = newJObject()
-    assert false notin elements, "usage error: only empty sets allowed"
-    assert true notin elements, "usage error: only empty sets allowed"
-
-proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
-  ## Sets a field from a `JObject`.
-  assert(obj.kind == JObject)
-  obj.fields[key] = val
-
-proc `%`*[T: object](o: T): JsonNode =
-  ## Construct JsonNode from tuples and objects.
-  result = newJObject()
-  for k, v in o.fieldPairs: result[k] = %v
-
-proc `%`*(o: ref object): JsonNode =
-  ## Generic constructor for JSON data. Creates a new `JObject JsonNode`
-  if o.isNil:
-    result = newJNull()
-  else:
-    result = %(o[])
-
-proc `%`*(o: enum): JsonNode =
-  ## Construct a JsonNode that represents the specified enum value as a
-  ## string. Creates a new ``JString JsonNode``.
-  result = %($o)
-
-proc toJson(x: NimNode): NimNode {.compiletime.} =
-  case x.kind
-  of nnkBracket: # array
-    if x.len == 0: return newCall(bindSym"newJArray")
-    result = newNimNode(nnkBracket)
-    for i in 0 ..< x.len:
-      result.add(toJson(x[i]))
-    result = newCall(bindSym("%", brOpen), result)
-  of nnkTableConstr: # object
-    if x.len == 0: return newCall(bindSym"newJObject")
-    result = newNimNode(nnkTableConstr)
-    for i in 0 ..< x.len:
-      x[i].expectKind nnkExprColonExpr
-      result.add newTree(nnkExprColonExpr, x[i][0], toJson(x[i][1]))
-    result = newCall(bindSym("%", brOpen), result)
-  of nnkCurly: # empty object
-    x.expectLen(0)
-    result = newCall(bindSym"newJObject")
-  of nnkNilLit:
-    result = newCall(bindSym"newJNull")
-  of nnkPar:
-    if x.len == 1: result = toJson(x[0])
-    else: result = newCall(bindSym("%", brOpen), x)
-  else:
-    result = newCall(bindSym("%", brOpen), x)
-
-macro `%*`*(x: untyped): untyped =
-  ## Convert an expression to a JsonNode directly, without having to specify
-  ## `%` for every element.
-  result = toJson(x)
-
-proc `==`* (a, b: JsonNode): bool =
-  ## Check two nodes for equality
-  if a.isNil:
-    if b.isNil: return true
-    return false
-  elif b.isNil or a.kind != b.kind:
-    return false
-  else:
-    case a.kind
-    of JString:
-      result = a.str == b.str
-    of JInt:
-      result = a.num == b.num
-    of JFloat:
-      result = a.fnum == b.fnum
-    of JBool:
-      result = a.bval == b.bval
-    of JNull:
-      result = true
-    of JArray:
-      result = a.elems == b.elems
-    of JObject:
-     # we cannot use OrderedTable's equality here as
-     # the order does not matter for equality here.
-     if a.fields.len != b.fields.len: return false
-     for key, val in a.fields:
-       if not b.fields.hasKey(key): return false
-       if b.fields[key] != val: return false
-     result = true
-
-proc hash*(n: OrderedTable[string, JsonNode]): Hash {.noSideEffect.}
-
-proc hash*(n: JsonNode): Hash =
-  ## Compute the hash for a JSON node
-  case n.kind
-  of JArray:
-    result = hash(n.elems)
-  of JObject:
-    result = hash(n.fields)
-  of JInt:
-    result = hash(n.num)
-  of JFloat:
-    result = hash(n.fnum)
-  of JBool:
-    result = hash(n.bval.int)
-  of JString:
-    result = hash(n.str)
-  of JNull:
-    result = Hash(0)
-
-proc hash*(n: OrderedTable[string, JsonNode]): Hash =
-  for key, val in n:
-    result = result xor (hash(key) !& hash(val))
-  result = !$result
-
-proc len*(n: JsonNode): int =
-  ## If `n` is a `JArray`, it returns the number of elements.
-  ## If `n` is a `JObject`, it returns the number of pairs.
-  ## Else it returns 0.
-  case n.kind
-  of JArray: result = n.elems.len
-  of JObject: result = n.fields.len
-  else: discard
-
-proc `[]`*(node: JsonNode, name: string): JsonNode {.inline, deprecatedGet.} =
-  ## Gets a field from a `JObject`, which must not be nil.
-  ## If the value at `name` does not exist, raises KeyError.
-  ##
-  ## **Note:** The behaviour of this procedure changed in version 0.14.0. To
-  ## get a list of usages and to restore the old behaviour of this procedure,
-  ## compile with the ``-d:nimJsonGet`` flag.
-  assert(not isNil(node))
-  assert(node.kind == JObject)
-  when defined(nimJsonGet):
-    if not node.fields.hasKey(name): return nil
-  result = node.fields[name]
-
-proc `[]`*(node: JsonNode, index: int): JsonNode {.inline.} =
-  ## Gets the node at `index` in an Array. Result is undefined if `index`
-  ## is out of bounds, but as long as array bound checks are enabled it will
-  ## result in an exception.
-  assert(not isNil(node))
-  assert(node.kind == JArray)
-  return node.elems[index]
-
-proc hasKey*(node: JsonNode, key: string): bool =
-  ## Checks if `key` exists in `node`.
-  assert(node.kind == JObject)
-  result = node.fields.hasKey(key)
-
-proc contains*(node: JsonNode, key: string): bool =
-  ## Checks if `key` exists in `node`.
-  assert(node.kind == JObject)
-  node.fields.hasKey(key)
-
-proc contains*(node: JsonNode, val: JsonNode): bool =
-  ## Checks if `val` exists in array `node`.
-  assert(node.kind == JArray)
-  find(node.elems, val) >= 0
-
-proc existsKey*(node: JsonNode, key: string): bool {.deprecated: "use hasKey instead".} = node.hasKey(key)
-  ## **Deprecated:** use `hasKey` instead.
-
-proc `{}`*(node: JsonNode, keys: varargs[string]): JsonNode =
-  ## Traverses the node and gets the given value. If any of the
-  ## keys do not exist, returns ``nil``. Also returns ``nil`` if one of the
-  ## intermediate data structures is not an object.
-  ##
-  ## This proc can be used to create tree structures on the
-  ## fly (sometimes called `autovivification`:idx:):
-  ##
-  ## .. code-block:: nim
-  ##   myjson{"parent", "child", "grandchild"} = newJInt(1)
-  ##
-  result = node
-  for key in keys:
-    if isNil(result) or result.kind != JObject:
-      return nil
-    result = result.fields.getOrDefault(key)
-
-proc `{}`*(node: JsonNode, index: varargs[int]): JsonNode =
-  ## Traverses the node and gets the given value. If any of the
-  ## indexes do not exist, returns ``nil``. Also returns ``nil`` if one of the
-  ## intermediate data structures is not an array.
-  result = node
-  for i in index:
-    if isNil(result) or result.kind != JArray or i >= node.len:
-      return nil
-    result = result.elems[i]
-
-proc getOrDefault*(node: JsonNode, key: string): JsonNode =
-  ## Gets a field from a `node`. If `node` is nil or not an object or
-  ## value at `key` does not exist, returns nil
-  if not isNil(node) and node.kind == JObject:
-    result = node.fields.getOrDefault(key)
-
-template simpleGetOrDefault*{`{}`(node, [key])}(node: JsonNode, key: string): JsonNode = node.getOrDefault(key)
-
-proc `{}=`*(node: JsonNode, keys: varargs[string], value: JsonNode) =
-  ## Traverses the node and tries to set the value at the given location
-  ## to ``value``. If any of the keys are missing, they are added.
-  var node = node
-  for i in 0..(keys.len-2):
-    if not node.hasKey(keys[i]):
-      node[keys[i]] = newJObject()
-    node = node[keys[i]]
-  node[keys[keys.len-1]] = value
-
-proc delete*(obj: JsonNode, key: string) =
-  ## Deletes ``obj[key]``.
-  assert(obj.kind == JObject)
-  if not obj.fields.hasKey(key):
-    raise newException(KeyError, "key not in object")
-  obj.fields.del(key)
-
-proc copy*(p: JsonNode): JsonNode =
-  ## Performs a deep copy of `a`.
-  case p.kind
-  of JString:
-    result = newJString(p.str)
-  of JInt:
-    result = newJInt(p.num)
-  of JFloat:
-    result = newJFloat(p.fnum)
-  of JBool:
-    result = newJBool(p.bval)
-  of JNull:
-    result = newJNull()
-  of JObject:
-    result = newJObject()
-    for key, val in pairs(p.fields):
-      result.fields[key] = copy(val)
-  of JArray:
-    result = newJArray()
-    for i in items(p.elems):
-      result.elems.add(copy(i))
 
 # ------------- pretty printing ----------------------------------------------
 
@@ -782,34 +537,261 @@ proc toUgly*(result: var string, node: JsonNode) =
   of JNull:
     result.add "null"
 
+proc len*(n: JsonNode): int =
+  ## If `n` is a `JArray`, it returns the number of elements.
+  ## If `n` is a `JObject`, it returns the number of pairs.
+  ## Else it returns 0.
+  case n.kind
+  of JArray: result = n.elems.len
+  of JObject: result = n.fields.len
+  else: discard
+
 proc `$`*(node: JsonNode): string =
   ## Converts `node` to its JSON Representation on one line.
   result = newStringOfCap(node.len shl 1)
   toUgly(result, node)
 
+proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
+  ## Sets a field from a `JObject`.
+  obj.fields[key] = val
+
+proc `%`*[T: object](o: T): JsonNode =
+  ## Construct JsonNode from tuples and objects.
+  result = newJObject()
+  for k, v in o.fieldPairs: result[k] = %v
+
+proc `%`*(o: ref object): JsonNode =
+  ## Generic constructor for JSON data. Creates a new `JObject JsonNode`
+  if o.isNil:
+    result = newJNull()
+  else:
+    result = %(o[])
+
+proc `%`*(o: enum): JsonNode =
+  ## Construct a JsonNode that represents the specified enum value as a
+  ## string. Creates a new ``JString JsonNode``.
+  result = %($o)
+
+proc toJson(x: NimNode): NimNode {.compiletime.} =
+  case x.kind
+  of nnkBracket: # array
+    if x.len == 0: return newCall(bindSym"newJArray")
+    result = newNimNode(nnkBracket)
+    for i in 0 ..< x.len:
+      result.add(toJson(x[i]))
+    result = newCall(bindSym("%", brOpen), result)
+  of nnkTableConstr: # object
+    if x.len == 0: return newCall(bindSym"newJObject")
+    result = newNimNode(nnkTableConstr)
+    for i in 0 ..< x.len:
+      x[i].expectKind nnkExprColonExpr
+      result.add newTree(nnkExprColonExpr, x[i][0], toJson(x[i][1]))
+    result = newCall(bindSym("%", brOpen), result)
+  of nnkCurly: # empty object
+    x.expectLen(0)
+    result = newCall(bindSym"newJObject")
+  of nnkNilLit:
+    result = newCall(bindSym"newJNull")
+  of nnkPar:
+    if x.len == 1: result = toJson(x[0])
+    else: result = newCall(bindSym("%", brOpen), x)
+  else:
+    result = newCall(bindSym("%", brOpen), x)
+
+macro `%*`*(x: untyped): untyped =
+  ## Convert an expression to a JsonNode directly, without having to specify
+  ## `%` for every element.
+  result = toJson(x)
+
+proc `==`* (a, b: JsonNode): bool =
+  ## Check two nodes for equality
+  if a.isNil:
+    if b.isNil: return true
+    return false
+  elif b.isNil or a.kind != b.kind:
+    return false
+  else:
+    case a.kind
+    of JString:
+      result = a.str == b.str
+    of JInt:
+      result = a.num == b.num
+    of JFloat:
+      result = a.fnum == b.fnum
+    of JBool:
+      result = a.bval == b.bval
+    of JNull:
+      result = true
+    of JArray:
+      result = a.elems == b.elems
+    of JObject:
+     # we cannot use OrderedTable's equality here as
+     # the order does not matter for equality here.
+     if a.fields.len != b.fields.len: return false
+     for key, val in a.fields:
+       if not b.fields.hasKey(key): return false
+       if b.fields[key] != val: return false
+     result = true
+
+proc hash*(n: OrderedTable[string, JsonNode]): Hash {.noSideEffect.}
+
+proc hash*(n: JsonNode): Hash =
+  ## Compute the hash for a JSON node
+  case n.kind
+  of JArray:
+    result = hash(n.elems)
+  of JObject:
+    result = hash(n.fields)
+  of JInt:
+    result = hash(n.num)
+  of JFloat:
+    result = hash(n.fnum)
+  of JBool:
+    result = hash(n.bval.int)
+  of JString:
+    result = hash(n.str)
+  of JNull:
+    result = Hash(0)
+
+proc hash*(n: OrderedTable[string, JsonNode]): Hash =
+  for key, val in n:
+    result = result xor (hash(key) !& hash(val))
+  result = !$result
+
+
+proc `[]`*(node: JsonNode, name: string): JsonNode {.inline, deprecatedGet.} =
+  ## Gets a field from a `JObject`, which must not be nil.
+  ## If the value at `name` does not exist, raises KeyError.
+  ##
+  ## **Note:** The behaviour of this procedure changed in version 0.14.0. To
+  ## get a list of usages and to restore the old behaviour of this procedure,
+  ## compile with the ``-d:nimJsonGet`` flag.
+  if node.isNil or node.kind != JObject: return newJNull()
+  when defined(nimJsonGet):
+    if not node.fields.hasKey(name): return nil
+  result = node.fields[name]
+
+proc `[]`*(node: JsonNode, index: int): JsonNode {.inline.} =
+  ## Gets the node at `index` in an Array. Result is undefined if `index`
+  ## is out of bounds, but as long as array bound checks are enabled it will
+  ## result in an exception.
+  if node.isNil or node.kind != JArray: return newJNull()
+  return node.elems[index]
+
+proc hasKey*(node: JsonNode, key: string): bool =
+  ## Checks if `key` exists in `node`.
+  if node.kind != JObject: return false
+  result = node.fields.hasKey(key)
+
+proc contains*(node: JsonNode, key: string): bool =
+  ## Checks if `key` exists in `node`.
+  if node.kind != JObject: return false
+  node.fields.hasKey(key)
+
+proc contains*(node: JsonNode, val: JsonNode): bool =
+  ## Checks if `val` exists in array `node`.
+  if node.kind != JArray: return false
+  find(node.elems, val) >= 0
+
+proc existsKey*(node: JsonNode, key: string): bool {.deprecated: "use hasKey instead".} = node.hasKey(key)
+  ## **Deprecated:** use `hasKey` instead.
+
+proc `{}`*(node: JsonNode, keys: varargs[string]): JsonNode =
+  ## Traverses the node and gets the given value. If any of the
+  ## keys do not exist, returns ``nil``. Also returns ``nil`` if one of the
+  ## intermediate data structures is not an object.
+  ##
+  ## This proc can be used to create tree structures on the
+  ## fly (sometimes called `autovivification`:idx:):
+  ##
+  ## .. code-block:: nim
+  ##   myjson{"parent", "child", "grandchild"} = newJInt(1)
+  ##
+  result = node
+  for key in keys:
+    if isNil(result) or result.kind != JObject:
+      return nil
+    result = result.fields.getOrDefault(key)
+
+proc `{}`*(node: JsonNode, index: varargs[int]): JsonNode =
+  ## Traverses the node and gets the given value. If any of the
+  ## indexes do not exist, returns ``nil``. Also returns ``nil`` if one of the
+  ## intermediate data structures is not an array.
+  result = node
+  for i in index:
+    if isNil(result) or result.kind != JArray or i >= node.len:
+      return nil
+    result = result.elems[i]
+
+proc getOrDefault*(node: JsonNode, key: string): JsonNode =
+  ## Gets a field from a `node`. If `node` is nil or not an object or
+  ## value at `key` does not exist, returns nil
+  if not isNil(node) and node.kind == JObject:
+    result = node.fields.getOrDefault(key)
+
+template simpleGetOrDefault*{`{}`(node, [key])}(node: JsonNode, key: string): JsonNode = node.getOrDefault(key)
+
+proc `{}=`*(node: JsonNode, keys: varargs[string], value: JsonNode) =
+  ## Traverses the node and tries to set the value at the given location
+  ## to ``value``. If any of the keys are missing, they are added.
+  var node = node
+  for i in 0..(keys.high-1):
+    if not node.hasKey(keys[i]) or node[keys[i]].kind != JObject:
+      node[keys[i]] = newJObject()
+    node = node[keys[i]]
+  node[keys[keys.high]] = value
+
+proc delete*(obj: JsonNode, key: string) =
+  ## Deletes ``obj[key]``.
+  if obj.kind != JObject: discard
+  obj.fields.del(key)
+
+proc copy*(p: JsonNode): JsonNode =
+  ## Performs a deep copy of `a`.
+  case p.kind
+  of JString:
+    result = newJString(p.str)
+  of JInt:
+    result = newJInt(p.num)
+  of JFloat:
+    result = newJFloat(p.fnum)
+  of JBool:
+    result = newJBool(p.bval)
+  of JNull:
+    result = newJNull()
+  of JObject:
+    result = newJObject()
+    for key, val in pairs(p.fields):
+      result.fields[key] = copy(val)
+  of JArray:
+    result = newJArray()
+    for i in items(p.elems):
+      result.elems.add(copy(i))
+
+
 iterator items*(node: JsonNode): JsonNode =
   ## Iterator for the items of `node`. `node` has to be a JArray.
-  assert node.kind == JArray
+  if node.kind != JArray: discard
   for i in items(node.elems):
     yield i
 
 iterator mitems*(node: var JsonNode): var JsonNode =
   ## Iterator for the items of `node`. `node` has to be a JArray. Items can be
   ## modified.
-  assert node.kind == JArray
+  if node.kind != JArray: discard
   for i in mitems(node.elems):
     yield i
 
 iterator pairs*(node: JsonNode): tuple[key: string, val: JsonNode] =
   ## Iterator for the child elements of `node`. `node` has to be a JObject.
-  assert node.kind == JObject
+  if node.kind != JObject: discard
   for key, val in pairs(node.fields):
     yield (key, val)
 
 iterator mpairs*(node: var JsonNode): tuple[key: string, val: var JsonNode] =
   ## Iterator for the child elements of `node`. `node` has to be a JObject.
   ## Values can be modified
-  assert node.kind == JObject
+  if node.kind != JObject: discard
   for key, val in mpairs(node.fields):
     yield (key, val)
 
@@ -833,7 +815,7 @@ proc parseJson(p: var JsonParser): JsonNode =
   of tkFalse:
     result = newJBool(false)
     discard getTok(p)
-  of tkNull:
+  of tkNull, tkError, tkCurlyRi, tkBracketRi, tkColon, tkComma, tkEof:
     result = newJNull()
     discard getTok(p)
   of tkCurlyLe:
@@ -858,14 +840,13 @@ proc parseJson(p: var JsonParser): JsonNode =
       if p.tok != tkComma: break
       discard getTok(p)
     eat(p, tkBracketRi)
-  of tkError, tkCurlyRi, tkBracketRi, tkColon, tkComma, tkEof:
-    raiseParseErr(p, "{")
+  # of tkError, tkCurlyRi, tkBracketRi, tkColon, tkComma, tkEof:
+  #   raiseParseErr(p, "{")
 
 when not defined(js):
   proc parseJson*(s: Stream, filename: string = ""): JsonNode =
     ## Parses from a stream `s` into a `JsonNode`. `filename` is only needed
     ## for nice error messages.
-    ## If `s` contains extra data, it will raise `JsonParsingError`.
     var p: JsonParser
     p.open(s, filename)
     try:
@@ -877,15 +858,11 @@ when not defined(js):
 
   proc parseJson*(buffer: string): JsonNode =
     ## Parses JSON from `buffer`.
-    ## If `buffer` contains extra data, it will raise `JsonParsingError`.
     result = parseJson(newStringStream(buffer), "input")
 
   proc parseFile*(filename: string): JsonNode =
     ## Parses `file` into a `JsonNode`.
-    ## If `file` contains extra data, it will raise `JsonParsingError`.
     var stream = newFileStream(filename, fmRead)
-    if stream == nil:
-      raise newException(IOError, "cannot read from file: " & filename)
     result = parseJson(stream, filename)
 else:
   from math import `mod`
@@ -994,7 +971,7 @@ template verifyJsonKind(node: JsonNode, kinds: set[JsonNodeKind],
       ast,
       $node.kind
     ]
-    raise newException(JsonKindError, msg)
+    echo msg
 
 proc getEnum(node: JsonNode, ast: string, T: typedesc): T =
   when T is SomeInteger:
@@ -1601,7 +1578,22 @@ when false:
 
 when isMainModule:
   # Note: Macro tests are in tests/stdlib/tjsonmacro.nim
+  var cost = newJObject()
+  var rows = [["AWS","compute","cost"],
+              ["Alibaba","compute","monthly"],
+              ["Alibaba","network","monthly"],
+              ["Tencent","compute","monthly"],
+              ["AWS","network","cost"],
+              ["Tencent","network","monthly"]]
 
+  for row in rows:
+    cost{row[0..2]} = %(cost{row[0..2]}.getFloat + 1)
+  echo cost
+  cost{"AWS", "yearly"} = %""
+  cost{"AWS","compute","cost","monthly"} = %1
+  cost{"AWS","compute","cost","yearly"} = %1
+  cost{"IBM"} = %""
+  echo cost
   let testJson = parseJson"""{ "a": [1, 2, 3, 4], "b": "asd", "c": "\ud83c\udf83", "d": "\u00E6"}"""
   # nil passthrough
   doAssert(testJson{"doesnt_exist"}{"anything"}.isNil)
@@ -1708,14 +1700,14 @@ when isMainModule:
 
   # Test loading of file.
   when not defined(js):
-    var parsed = parseFile("tests/testdata/jsontest.json")
+    var parsed = parseFile("../../tests/testdata/jsontest.json")
 
     try:
       discard parsed["key2"][12123]
       doAssert(false)
     except IndexError: doAssert(true)
 
-    var parsed2 = parseFile("tests/testdata/jsontest2.json")
+    var parsed2 = parseFile("../../tests/testdata/jsontest2.json")
     doAssert(parsed2{"repository", "description"}.str=="IRC Library for Haskell", "Couldn't fetch via multiply nested key using {}")
 
   doAssert escapeJsonUnquoted("\10Foo🎃barÄ") == "\\nFoo🎃barÄ"
@@ -1732,7 +1724,7 @@ when isMainModule:
       doAssert getCurrentExceptionMsg().contains(errorMessages[errEofExpected])
 
     try:
-      discard parseFile("tests/testdata/jsonwithextradata.json")
+      discard parseFile("../../tests/testdata/jsonwithextradata.json")
       doAssert(false)
     except JsonParsingError:
       doAssert getCurrentExceptionMsg().contains(errorMessages[errEofExpected])

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1280,15 +1280,17 @@ proc `-`*(ti1, ti2: TimeInterval): TimeInterval =
 
   result = ti1 + (-ti2)
 
-proc getDateStr*(): string {.rtl, extern: "nt$1", tags: [TimeEffect].} =
+proc getDateStr*(dt = now()): string {.rtl, extern: "nt$1", tags: [TimeEffect].} =
   ## Gets the current local date as a string of the format ``YYYY-MM-DD``.
-  var dt = now()
+  runnableExamples:
+    echo getDateStr(now() - 1.months)
   result = $dt.year & '-' & intToStr(ord(dt.month), 2) &
     '-' & intToStr(dt.monthday, 2)
 
-proc getClockStr*(): string {.rtl, extern: "nt$1", tags: [TimeEffect].} =
+proc getClockStr*(dt = now()): string {.rtl, extern: "nt$1", tags: [TimeEffect].} =
   ## Gets the current local clock time as a string of the format ``HH:MM:SS``.
-  var dt = now()
+  runnableExamples:
+    echo getClockStr(now() - 1.hours)
   result = intToStr(dt.hour, 2) & ':' & intToStr(dt.minute, 2) &
     ':' & intToStr(dt.second, 2)
 


### PR DESCRIPTION
```
  var cost = newJObject()
  var rows = [["AWS","compute","cost"],
              ["Alibaba","compute","monthly"],
              ["Alibaba","network","monthly"],
              ["Tencent","compute","monthly"],
              ["AWS","network","cost"],
              ["Tencent","network","monthly"]]

  for row in rows:
    cost{row[0..2]} = %(cost{row[0..2]}.getFloat + 1)
  echo cost
  cost{"AWS", "yearly"} = %""
  cost{"AWS","compute","cost","monthly"} = %1
  cost{"AWS","compute","cost","yearly"} = %1
  cost{"IBM"} = %""
  echo cost
```
it scales as expected in a more complex context, and passes unittests. This makes json the most convinient container for string key and multiple kinds type value pairs.
Exceptions of iterators are unnecessary,  others neither , after dealing with many json exceptions, it leads me to think about exception machenism, which I call the boundary of exception. In simple context as json inputting , adding or getting, just fallback to default if it's not a expected result. This helps to avoid overhead of defending or cathcing exception and performance downgrade in high level application case. As for low level system operations ,exceptions exist for some reason.