### PR TITLE
finish #11292: fix `addQuoted` and add changelog entry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,7 +34,9 @@
 
 - To use multi-methods, explicit `--multimethods:on` is now needed.
 
-- Compile time checks for integer and float conversions are now stricter. For example, `const x = uint32(-1)` now gives a compile time error instead of being equivalent to `const x = 0xFFFFFFFF'u32`.
+- Compile time checks for integer and float conversions are now stricter.
+  For example, `const x = uint32(-1)` now gives a compile time error instead
+  of being equivalent to `const x = 0xFFFFFFFF'u32`.
 
 - Using `typed` as the result type in templates/macros now means
   "expression with a type". The old meaning of `typed` is preserved
@@ -42,6 +44,7 @@
 
 - A bug allowed `macro foo(): int = 123` to compile even though a
   macros has to return a `NimNode`. This has been fixed.
+
 
 #### Breaking changes in the standard library
 
@@ -104,6 +107,10 @@
 
 - Custom types that should be supported by `strformat` (&) now need an
   explicit overload of `formatValue`.
+
+- procs `string.add(int)` and `string.add(float)` which implicitly convert
+  ints and floats to string have been deprecated.
+  Use `string.addInt(int)` and `string.addFloat(float)` instead.
 
 
 #### Breaking changes in the compiler
@@ -201,7 +208,8 @@ proc enumToString*(enums: openArray[enum]): string =
 
 - The switch ``-d:useWinAnsi`` is not supported anymore.
 
-- In `times` module, procs `format` and `parse` accept a new optional `DateTimeLocale` argument for formatting/parsing dates in other languages.
+- In `times` module, procs `format` and `parse` accept a new optional
+  `DateTimeLocale` argument for formatting/parsing dates in other languages.
 
 
 ### Language additions

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4202,6 +4202,10 @@ proc addQuoted*[T](s: var string, x: T) =
     s.addEscapedChar(x)
     s.add("'")
   # prevent temporary string allocation
+  elif T is int:
+    s.addInt(x)
+  elif T is float:
+    s.addFloat(x)
   elif compiles(s.add(x)):
     s.add(x)
   else:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4202,9 +4202,9 @@ proc addQuoted*[T](s: var string, x: T) =
     s.addEscapedChar(x)
     s.add("'")
   # prevent temporary string allocation
-  elif T is int:
+  elif T is int and not defined(JS):
     s.addInt(x)
-  elif T is float:
+  elif T is float and not defined(JS):
     s.addFloat(x)
   elif compiles(s.add(x)):
     s.add(x)


### PR DESCRIPTION
Don't let `addQuoted` use now-deprecated `add` for ints and floats (see PR #11292).

Add changelog entry about this deprecation.