### PR TITLE
Add TLS to net module, deprecate everything else

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -245,6 +245,8 @@ when compileOption("dynlibOverride", "ssl"):
     proc SSL_library_init*(): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_load_error_strings*() {.cdecl, dynlib: DLLSSLName, importc.}
     proc SSLv23_method*(): PSSL_METHOD {.cdecl, dynlib: DLLSSLName, importc.}
+    proc TLS_method*(): PSSL_METHOD =
+      SSLv23_method()
   else:
     proc OPENSSL_init_ssl*(opts: uint64, settings: uint8): cint {.cdecl, dynlib: DLLSSLName, importc, discardable.}
     proc SSL_library_init*(): cint {.discardable.} =


### PR DESCRIPTION
Changes:

* Adds `protTLS` to `net` module. This is the option recommended by OpenSSL[0]
* Deprecates all `protX`

Notes:

* TLS_method supports `SSLv3, TLSv1, TLSv1.1, TLSv1.2 and TLSv1.3` in OpenSSL 1.1.1 and only `SSLv3, TLSv1` in OpenSSL 1.0.0. `SSLv3` is not secure, so ideally we would set `TLSv1` as min version (as OpenSSL docs recommend), however that function requires a backport for v1.0.0. I may add it later.

[0] https://www.openssl.org/docs/man1.1.1/man3/TLS_method.html