### PR TITLE
travis: minor opimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
   homebrew:
     packages:
     - boehmgc
+    - make
     - sfml
 
 before_script:
@@ -39,7 +40,7 @@ before_script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shell_session_update() { :; }; fi
   - git clone --depth 1 https://github.com/nim-lang/csources.git
   - cd csources
-  - sh build.sh
+  - make -j 2 LD=$CC
   - cd ..
   - export PATH=$(pwd)/bin${PATH:+:$PATH}
   - echo PATH:${PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,10 @@ addons:
     - libsdl1.2-dev
     - libgc-dev
     - libsfml-dev
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install boehmgc; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install sfml; fi
+  homebrew:
+    packages:
+    - boehmgc
+    - sfml
 
 before_script:
   - set -e


### PR DESCRIPTION
- Use Travis `homebrew` addon instead of installing by hand. This skips the `update` phase that took a lot of time (300s+).
- Parallelize csources building, which shaved half the build time (42s -> 20s) for OSX, doesn't seem to affect Linux.