### PR TITLE
list available options for --cpu: or --os: if the passed option is not found

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -615,14 +615,18 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd1, passPP}:
       let theOS = platform.nameToOS(arg)
-      if theOS == osNone: localError(conf, info, "unknown OS: '$1'" % arg)
+      if theOS == osNone:
+        let osList = platform.listOSnames().join(", ")
+        localError(conf, info, "unknown OS: '$1'. Available options are: $2" % [arg, $osList])
       elif theOS != conf.target.hostOS:
         setTarget(conf.target, theOS, conf.target.targetCPU)
   of "cpu":
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd1, passPP}:
       let cpu = platform.nameToCPU(arg)
-      if cpu == cpuNone: localError(conf, info, "unknown CPU: '$1'" % arg)
+      if cpu == cpuNone:
+        let cpuList = platform.listCPUnames().join(", ")
+        localError(conf, info, "unknown CPU: '$1'. Available options are: $2" % [ arg, cpuList])
       elif cpu != conf.target.hostCPU:
         setTarget(conf.target, conf.target.targetOS, cpu)
   of "run", "r":

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -375,6 +375,10 @@ proc nameToCC*(name: string): TSystemCC =
       return i
   result = ccNone
 
+proc listCCnames(): seq[string] =
+  for i in succ(ccNone) .. high(TSystemCC):
+    result.add CC[i].name
+
 proc isVSCompatible*(conf: ConfigRef): bool =
   return conf.cCompiler == ccVcc or
           conf.cCompiler == ccClangCl or
@@ -408,7 +412,8 @@ proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
 proc setCC*(conf: ConfigRef; ccname: string; info: TLineInfo) =
   conf.cCompiler = nameToCC(ccname)
   if conf.cCompiler == ccNone:
-    localError(conf, info, "unknown C compiler: '$1'" % ccname)
+    let ccList = listCCnames().join(", ")
+    localError(conf, info, "unknown C compiler: '$1'. Available options are: $2" % [ccname, ccList])
   conf.compileOptions = getConfigVar(conf, conf.cCompiler, ".options.always")
   conf.linkOptions = ""
   conf.ccompilerpath = getConfigVar(conf, conf.cCompiler, ".path")

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -242,11 +242,19 @@ proc nameToOS*(name: string): TSystemOS =
       return i
   result = osNone
 
+proc listOSnames*(): seq[string] =
+  for i in succ(osNone) .. high(TSystemOS):
+    result.add OS[i].name
+
 proc nameToCPU*(name: string): TSystemCPU =
   for i in succ(cpuNone) .. high(TSystemCPU):
     if cmpIgnoreStyle(name, CPU[i].name) == 0:
       return i
   result = cpuNone
+
+proc listCPUnames*(): seq[string] =
+  for i in succ(cpuNone) .. high(TSystemCPU):
+    result.add CPU[i].name
 
 proc setTargetFromSystem*(t: var Target) =
   t.hostOS = nameToOS(system.hostOS)


### PR DESCRIPTION
More helpful then having to look in the source:

```
command line(1, 2) Error: unknown CPU: 'amd6'. Available options are: i386, m68k, alpha, powerpc, 
powerpc64, powerpc64el, sparc, vm, ia64, amd64, mips, mipsel, arm, arm64, js, nimvm, avr, msp430, 
sparc64, mips64, mips64el, riscv64, wasm32
```

```
command line(1, 2) Error: unknown OS: 'wndows'. Available options are: DOS, Windows, OS2, Linux, 
MorphOS, SkyOS, Solaris, Irix, NetBSD, FreeBSD, OpenBSD, DragonFly, AIX, PalmOS, QNX, Amiga, 
Atari, Netware, MacOS, MacOSX, Haiku, Android, VxWorks, Genode, JS, NimVM, Standalone, 
NintendoSwitch
```

```
command line(1, 2) Error: unknown C compiler: 'help'. Available options are: gcc, switch_gcc,
 llvm_gcc, clang, lcc, bcc, dmc, wcc, vcc, tcc, pcc, ucc, icl, icc, clang_cl
```