### PR TITLE
travis: cleanup & add 32-bit Linux testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,7 @@ addons:
 
 before_script:
   - git clone --depth 1 https://github.com/nim-lang/csources.git
-  - cd csources
-  - make -j 2 LD=$CC
-  - cd ..
+  - make -C csources -j 2 LD=$CC
   - export PATH=$(pwd)/bin${PATH:+:$PATH}
   - echo PATH:${PATH}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ before_script:
   - git clone --depth 1 https://github.com/nim-lang/csources.git
   - make -C csources -j 2 LD=$CC
   - export PATH=$(pwd)/bin${PATH:+:$PATH}
-  - echo PATH:${PATH}
 
 script:
   - echo "travis_fold:start:nim_c_koch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ addons:
     - sfml
 
 before_script:
-  - set -e
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unset -f cd; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shell_session_update() { :; }; fi
   - git clone --depth 1 https://github.com/nim-lang/csources.git
@@ -44,15 +43,12 @@ before_script:
   - cd ..
   - export PATH=$(pwd)/bin${PATH:+:$PATH}
   - echo PATH:${PATH}
-  - set +e   # prevents breaking after_failure
 
 script:
-  - set -e
   - echo "travis_fold:start:nim_c_koch"
   - nim c koch
   - echo "travis_fold:end:nim_c_koch"
   - ./koch runCI
-  - set +e
 
 before_deploy:
   # Make https://nim-lang.github.io/Nim work the same as https://nim-lang.github.io/Nim/overview.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,35 @@ matrix:
 
   include:
     - os: linux
-      env: NIM_COMPILE_TO_CPP=false
+      env:
+        - NIM_COMPILE_TO_CPP=false
+        - CPU=amd64
+
+    - os: linux
+      env:
+        - NIM_COMPILE_TO_CPP=false
+        - CPU=i386
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - g++-multilib
+            - libcurl4-openssl-dev:i386
+            - libgc-dev:i386
+            - libglib2.0-dev:i386
+            - libpulse-dev:i386
+            - libsdl1.2-dev:i386
+            - libsfml-dev:i386
 
     - os: osx
-      env: NIM_COMPILE_TO_CPP=false
+      env:
+        - NIM_COMPILE_TO_CPP=false
+        - CPU=amd64
 
     - os: osx
-      env: NIM_COMPILE_TO_CPP=true
+      env:
+        - NIM_COMPILE_TO_CPP=true
+        - CPU=amd64
 
 # To allow failures for a failing configuration, use something like:
 #  allow_failures:
@@ -23,6 +45,7 @@ matrix:
 
 addons:
   apt:
+    # update the list above if more deps are introduced
     packages:
     - libcurl4-openssl-dev
     - libsdl1.2-dev
@@ -34,10 +57,16 @@ addons:
     - make
     - sfml
 
+install:
+  - if [[ $CPU = i386 ]]; then echo -e "#!/bin/bash\n$(which gcc) -m32 \"\$@\"" > bin/gcc; fi
+  - if [[ $CPU = i386 ]]; then chmod 755 bin/gcc; fi
+  - if [[ $CPU = i386 ]]; then echo -e "#!/bin/bash\n$(which g++) -m32 \"\$@\"" > bin/g++; fi
+  - if [[ $CPU = i386 ]]; then chmod 755 bin/g++; fi
+
 before_script:
   - git clone --depth 1 https://github.com/nim-lang/csources.git
-  - make -C csources -j 2 LD=$CC
-  - export PATH=$(pwd)/bin${PATH:+:$PATH}
+  - export PATH="$PWD/bin${PATH:+:$PATH}"
+  - make -C csources -j 2 LD=$CC ucpu=$CPU
 
 script:
   - echo "travis_fold:start:nim_c_koch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ addons:
     - sfml
 
 before_script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unset -f cd; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then shell_session_update() { :; }; fi
   - git clone --depth 1 https://github.com/nim-lang/csources.git
   - cd csources
   - make -j 2 LD=$CC

--- a/koch.nim
+++ b/koch.nim
@@ -165,7 +165,7 @@ proc buildNimble(latest: bool) =
   nimCompile(installDir / "src/nimble.nim", options = "--noNimblePath --nilseqs:on -d:release")
 
 proc bundleNimsuggest() =
-  nimCompile("nimsuggest/nimsuggest.nim", options = "-d:release")
+  nimCompileFold("Compile nimsuggest", "nimsuggest/nimsuggest.nim", options = "-d:release")
 
 proc buildVccTool() =
   nimCompileFold("Compile Vcc", "tools/vccexe/vccexe.nim")

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -1,8 +1,8 @@
 discard """
 errormsg: "type mismatch: got <array[0..0, type int]>"
-line: 15
+line: 16
 nimout: '''
-twrong_at_operator.nim(15, 30) Error: type mismatch: got <array[0..0, type int]>
+twrong_at_operator.nim(16, 30) Error: type mismatch: got <array[0..0, type int]>
 but expected one of:
 proc `@`[T](a: openArray[T]): seq[T]
 proc `@`[IDX, T](a: array[IDX, T]): seq[T]

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -9,7 +9,7 @@ proc `@`[IDX, T](a: array[IDX, T]): seq[T]
 
 expression: @[int]
 '''
-disabled: 32bit
+disabled: "32bit"
 """
 
 # bug #7331

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -9,6 +9,7 @@ proc `@`[IDX, T](a: array[IDX, T]): seq[T]
 
 expression: @[int]
 '''
+disabled: 32bit
 """
 
 # bug #7331

--- a/tests/gc/closureleak.nim
+++ b/tests/gc/closureleak.nim
@@ -1,6 +1,6 @@
 discard """
   outputsub: "true"
-  disabled: 32bit
+  disabled: "32bit"
 """
 
 from strutils import join

--- a/tests/gc/closureleak.nim
+++ b/tests/gc/closureleak.nim
@@ -1,5 +1,6 @@
 discard """
   outputsub: "true"
+  disabled: 32bit
 """
 
 from strutils import join


### PR DESCRIPTION
~~Currently 32-bit Linux doesn't bootstrap. I don't know if it's my fault or `devel` got a regression.~~

**EDIT:** Tested with a known good config, this is a `devel` regression caused by 3a06022071d3ecf62c8e2f4812062e2e2fe71954

Bonus goodies:
- `after_failure` is now triggered correctly and will print out a nice summary of failed tests.

/cc @Araq