### PR TITLE
Tuple assignments

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1643,13 +1643,14 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     add(result, n[1])
     return semExprNoType(c, result)
   of nkPar, nkTupleConstr:
+    a = semExprWithType(c, a, {efLValue})
     if a.len >= 2:
       # unfortunately we need to rewrite ``(x, y) = foo()`` already here so
       # that overloading of the assignment operator still works. Usually we
       # prefer to do these rewritings in transf.nim:
+      var rhs = semExprWithType(c, n.sons[1])
+      n.sons[1] = fitNode(c, a.typ, rhs, rhs.info)
       return semStmt(c, lowerTupleUnpackingForAsgn(c.graph, n, c.p.owner), {})
-    else:
-      a = semExprWithType(c, a, {efLValue})
   else:
     a = semExprWithType(c, a, {efLValue})
   n.sons[0] = a

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1648,7 +1648,7 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
       # unfortunately we need to rewrite ``(x, y) = foo()`` already here so
       # that overloading of the assignment operator still works. Usually we
       # prefer to do these rewritings in transf.nim:
-      var rhs = semExprWithType(c, n.sons[1])
+      let rhs = semExprWithType(c, n.sons[1])
       n.sons[1] = fitNode(c, a.typ, rhs, rhs.info)
       return semStmt(c, lowerTupleUnpackingForAsgn(c.graph, n, c.p.owner), {})
   else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1643,14 +1643,16 @@ proc semAsgn(c: PContext, n: PNode; mode=asgnNormal): PNode =
     add(result, n[1])
     return semExprNoType(c, result)
   of nkPar, nkTupleConstr:
-    a = semExprWithType(c, a, {efLValue})
     if a.len >= 2:
       # unfortunately we need to rewrite ``(x, y) = foo()`` already here so
       # that overloading of the assignment operator still works. Usually we
       # prefer to do these rewritings in transf.nim:
+      a = semExprWithType(c, a)
       let rhs = semExprWithType(c, n.sons[1])
       n.sons[1] = fitNode(c, a.typ, rhs, rhs.info)
       return semStmt(c, lowerTupleUnpackingForAsgn(c.graph, n, c.p.owner), {})
+    else:
+      a = semExprWithType(c, a, {efLValue})
   else:
     a = semExprWithType(c, a, {efLValue})
   n.sons[0] = a

--- a/tests/tuples/ttuple_asgn_err.nim
+++ b/tests/tuples/ttuple_asgn_err.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "type mismatch: got <seq[int]> but expected 'tuple of (int, int)'"
+  line: 8
+"""
+var
+  a = 1
+  b = 2
+(a, b) = @[3, 4]

--- a/tests/types/tassignemptytuple.nim
+++ b/tests/types/tassignemptytuple.nim
@@ -1,7 +1,7 @@
 discard """
-  errormsg: "cannot infer the type of the tuple"
-  file: "tassignemptytuple.nim"
-  line: 11
+  output: '''@[]
+(a: @[], b: {})
+'''
 """
 
 var
@@ -9,3 +9,5 @@ var
   bar: tuple[a: seq[int], b: set[char]]
 
 (foo, bar) = (@[], (@[], {}))
+echo foo
+echo bar


### PR DESCRIPTION
refs #10853
```nim
# These become type mismatch.
var a, b = 1
(a, b) = 3 # weird error message
(a, b) = @[4, 5] # works, but shouldn't
(a, b) = (1, 2, 3) # works, but shouldn't (at least not implicitly).
```
decisions:
- Supporting discarding tuple elements on assignment: `(a, b, _) = (1, 2, 3)`
- Supporting named tuple on lhs: `(x: a, y: b, z: c) = (1, 2, 3)` Currently gives: `invalid expression: x: a`