### PR TITLE
Make net module compile with --taintMode:on

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1263,7 +1263,7 @@ proc recvLine*(socket: Socket, timeout = -1,
   ## that can be read. The result is truncated after that.
   ##
   ## **Warning**: Only the ``SafeDisconn`` flag is currently supported.
-  result = ""
+  result = "".TaintedString
   readLine(socket, result, timeout, flags, maxLength)
 
 proc recvFrom*(socket: Socket, data: var string, length: int,


### PR DESCRIPTION
Currently the net module doesn't compile when the ``--taintMode:on`` flag is passed to the compiler. Not well tested, I've only tried it by patching my local stdlib files.