### PR TITLE
Add build support for Linux/sparc64

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -6,7 +6,7 @@ Name: "Nim"
 Version: "$version"
 Platforms: """
   windows: i386;amd64
-  linux: i386;amd64;powerpc64;arm;sparc;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
+  linux: i386;amd64;powerpc64;arm;sparc;sparc64;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
   macosx: i386;amd64;powerpc64
   solaris: i386;amd64;sparc;sparc64
   freebsd: i386;amd64

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -140,8 +140,12 @@ case $ucpu in
     mycpu="amd64" ;;
   *sparc*|*sun* )
     mycpu="sparc"
-    if [ "$(isainfo -b)" = "64" ]; then
-      mycpu="sparc64"
+    if [ "$myos" = "linux" ] ; then
+      if [ "$(getconf LONG_BIT)" = "64" ]; then
+        mycpu="sparc64"
+      elif [ "$(isainfo -b)" = "64" ]; then
+        mycpu="sparc64"
+      fi
     fi
     ;;
   *ppc64le* )


### PR DESCRIPTION
Nim currently fails to build on Debian/sparc64. The two changes in this PR should fix that.