### PR TITLE
Add build support for Linux/m68k

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -6,7 +6,7 @@ Name: "Nim"
 Version: "$version"
 Platforms: """
   windows: i386;amd64
-  linux: i386;amd64;powerpc64;arm;sparc;sparc64;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
+  linux: i386;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
   macosx: i386;amd64;powerpc64
   solaris: i386;amd64;sparc;sparc64
   freebsd: i386;amd64

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -158,6 +158,8 @@ case $ucpu in
     mycpu="powerpc64" ;;
   *power*|*ppc* )
     mycpu="powerpc" ;;
+  *m68k*)
+    mycpu="m68k" ;;
   *mips* )
     mycpu="$("$CC" -dumpmachine | sed 's/-.*//')"
     case $mycpu in


### PR DESCRIPTION
Nim currently fails to build on Debian/m68k. The two changes in this PR should fix that.

Note: This PR will need to be rebased once #11365 has been merged.