### PR TITLE
niminst: get rid of LINKER / LD

### DIFF
--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -40,7 +40,7 @@ do
 done
 
 CC="${CC:-gcc}"
-LINKER="${LD:-gcc}"
+LINKER="${CCLD:-gcc}"
 COMP_FLAGS="${CPPFLAGS:-} ${CFLAGS:-} ?{c.ccompiler.flags}$extraBuildArgs"
 LINK_FLAGS="${LDFLAGS:-} ?{c.linker.flags}"
 PS4=""

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -40,7 +40,6 @@ do
 done
 
 CC="${CC:-gcc}"
-LINKER="${CCLD:-gcc}"
 COMP_FLAGS="${CPPFLAGS:-} ${CFLAGS:-} ?{c.ccompiler.flags}$extraBuildArgs"
 LINK_FLAGS="${LDFLAGS:-} ?{c.linker.flags}"
 PS4=""
@@ -60,7 +59,7 @@ if [ ! -d $binDir ]; then
 fi
 
 #  add(result, "# override OS, CPU and OS Name with command-line arguments\n")
-if [ -n "$optos" ]; then 
+if [ -n "$optos" ]; then
   uos="$optos"
 fi
 if [ -n "$optcpu" ]; then
@@ -87,7 +86,6 @@ case $uos in
   *freebsd* )
     myos="freebsd"
     CC="clang"
-    LINKER="clang"
     LINK_FLAGS="$LINK_FLAGS -lm"
     ;;
   *openbsd* )
@@ -101,7 +99,6 @@ case $uos in
   *darwin* )
     myos="macosx"
     CC="clang"
-    LINKER="clang"
     LINK_FLAGS="$LINK_FLAGS -ldl -lm"
     if [ "$HOSTTYPE" = "x86_64" ] ; then
       ucpu="amd64"
@@ -207,7 +204,7 @@ case $myos in
     $CC $COMP_FLAGS -Ic_code -c ?{f} -o ?{changeFileExt(f, "o")}
 #        add(linkCmd, " \\\n" & changeFileExt(f, "o"))
 #      end for
-    $LINKER -o ?{"$binDir/" & toLowerAscii(c.name)} ?linkCmd $LINK_FLAGS
+    $CC -o ?{"$binDir/" & toLowerAscii(c.name)} ?linkCmd $LINK_FLAGS
     ;;
 #    end for
   *)

--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -5,7 +5,7 @@
 #           "# To regenerate run ``niminst csource`` or ``koch csource``\n"
 
 CC ??= gcc
-LD ??= gcc
+CCLD ??= gcc
 CFLAGS += -Ic_code ?{c.ccompiler.flags}
 LDFLAGS += ?{c.linker.flags}
 binDir = ?{firstBinPath(c).toUnix}
@@ -29,7 +29,7 @@ endif
 ifeq ($(uos),freebsd)
   myos= freebsd
   CC = clang
-  LD = clang
+  CCLD = clang
   LDFLAGS += -lm
 endif
 ifeq ($(uos),openbsd)
@@ -43,7 +43,7 @@ endif
 ifeq ($(uos),darwin)
   myos = macosx
   CC = clang
-  LD = clang
+  CCLD = clang
   LDFLAGS += -ldl -lm
   ifeq ($(HOSTTYPE),x86_64)
     ucpu = amd64
@@ -171,7 +171,7 @@ endif
 
 ?{"$(binDir)/" & toLowerAscii(c.name)}: $(oFiles)
 	@mkdir -p $(binDir)
-	$(LD) -o $@ $^ $(LDFLAGS)
+	$(CCLD) -o $@ $^ $(LDFLAGS)
 	@echo "SUCCESS"
 
 .PHONY: clean

--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -5,7 +5,6 @@
 #           "# To regenerate run ``niminst csource`` or ``koch csource``\n"
 
 CC ??= gcc
-CCLD ??= gcc
 CFLAGS += -Ic_code ?{c.ccompiler.flags}
 LDFLAGS += ?{c.linker.flags}
 binDir = ?{firstBinPath(c).toUnix}
@@ -29,7 +28,6 @@ endif
 ifeq ($(uos),freebsd)
   myos= freebsd
   CC = clang
-  CCLD = clang
   LDFLAGS += -lm
 endif
 ifeq ($(uos),openbsd)
@@ -43,7 +41,6 @@ endif
 ifeq ($(uos),darwin)
   myos = macosx
   CC = clang
-  CCLD = clang
   LDFLAGS += -ldl -lm
   ifeq ($(HOSTTYPE),x86_64)
     ucpu = amd64
@@ -171,7 +168,7 @@ endif
 
 ?{"$(binDir)/" & toLowerAscii(c.name)}: $(oFiles)
 	@mkdir -p $(binDir)
-	$(CCLD) -o $@ $^ $(LDFLAGS)
+	$(CC) -o $@ $^ $(LDFLAGS)
 	@echo "SUCCESS"
 
 .PHONY: clean


### PR DESCRIPTION
LD is used to specify the linker (in most cases, `ld`). However, Nim
wants the C compiler for linking, so we switch this to CCLD instead,
which should lighten the burden on confused packagers.