### PR TITLE
Genode compiler configuration for arm64 and riscv64

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -262,7 +262,6 @@ tcc.options.always = "-w"
 @if genode:
   noCppExceptions # avoid std C++
   tlsEmulation:on # no TLS segment register magic
-  gcc.path = "/usr/local/genode-gcc/bin"
   @if i386 or amd64:
     gcc.exe = "genode-x86-gcc"
     gcc.cpp.exe = "genode-x86-g++"
@@ -271,6 +270,14 @@ tcc.options.always = "-w"
     gcc.exe = "genode-arm-gcc"
     gcc.cpp.exe = "genode-arm-g++"
     gcc.cpp.linkerexe = "genode-arm-ld"
+  @elif arm64:
+    gcc.exe = "genode-aarch64-gcc"
+    gcc.cpp.exe = "genode-aarch64-g++"
+    gcc.cpp.linkerexe = "genode-aarch64-ld"
+  @elif riscv64:
+    gcc.exe = "genode-riscv-gcc"
+    gcc.cpp.exe = "genode-riscv-g++"
+    gcc.cpp.linkerexe = "genode-riscv-ld"
   @end
 @end
 


### PR DESCRIPTION
Add compiler for arm64 and riscv64, remove path to compiler binaries.