### PR TITLE
Fixed "is not GC-safe as it calls 'createThread'" when creating a thread in a thread

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -146,7 +146,7 @@ proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) =
   when defined(boehmgc):
     boehmGC_call_with_stack_base(threadProcWrapDispatch[TArg], thrd)
   elif not defined(nogc) and not defined(gogc) and not defined(gcRegions) and not defined(gcDestructors):
-    var p {.volatile.}: proc(a: ptr Thread[TArg]) {.nimcall.} =
+    var p {.volatile.}: proc(a: ptr Thread[TArg]) {.nimcall, gcsafe.} =
       threadProcWrapDispatch[TArg]
     # init the GC for refc/markandsweep
     nimGC_setStackBottom(addr(p))


### PR DESCRIPTION
When creating a thread in a thread like in this code example:
```Nim
import os

proc threadInThreadProc() {.thread.}=
  echo("Hello from thread in a thread.")

proc threadProc() {.thread.} =
  var thread: Thread[void]
  createThread(thread, threadInThreadProc)
  thread.joinThread()

when isMainModule:
  var thread: Thread[void]
  createThread(thread, threadProc)
  thread.joinThread()
```
The expected behaviour/output should be:
```
Hello from thread in a thread.
```
But it fails with:
```
/opt/Nim/lib/system/threads.nim(145, 6) Warning: 'threadProcWrapStackFrame' is not GC-safe as it accesses 'p' which is a global using GC'ed memory [GcUnsafe2]
/opt/Nim/lib/system/threads.nim(186, 8) Warning: 'threadProcWrapper' is not GC-safe as it calls 'threadProcWrapStackFrame' [GcUnsafe2]
/opt/Nim/lib/system/threads.nim(299, 8) Warning: 'createThread' is not GC-safe as it calls 'threadProcWrapper' [GcUnsafe2]
/opt/Nim/lib/system/threads.nim(329, 6) Warning: 'createThread' is not GC-safe as it calls 'createThread' [GcUnsafe2]
threadbug.nim(6, 6) Error: 'threadProc' is not GC-safe as it calls 'createThread'
```
Fixed this bug by setting the p variable in the threadProcWrapStackFrame proc to gcsafe.

Signed-off-by: Dankrad <Dankrad>