### PR TITLE
Disallow {.global.} variables at compile time

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1484,7 +1484,10 @@ proc checkCanEval(c: PCtx; n: PNode) =
   # we need to ensure that we don't evaluate 'x' here:
   # proc foo() = var x ...
   let s = n.sym
-  if {sfCompileTime, sfGlobal} <= s.flags: return
+  if {sfCompileTime} <= s.flags: return
+  if {sfGlobal} <= s.flags:
+    localError(c.config, n.info,
+               "'global' variables not allowed at compile time; " & s.name.s)
   if s.kind in {skVar, skTemp, skLet, skParam, skResult} and
       not s.isOwnedBy(c.prc.sym) and s.owner != c.module and c.mode != emRepl:
     cannotEval(c, n)

--- a/tests/vm/tglobalerror.nim
+++ b/tests/vm/tglobalerror.nim
@@ -1,0 +1,13 @@
+discard """
+  errormsg: "'global' variables not allowed at compile time; id"
+  line: 7
+"""
+
+proc unique: int =
+  var id {.global.} = 0
+  result = id
+  id += 1
+
+const x = unique()
+
+echo x


### PR DESCRIPTION
fixes #11285

Dont know if right solution, relying on tests to see if it works