### PR TITLE
parameter runtime discriminators

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -236,7 +236,7 @@ proc enumToString*(enums: openArray[enum]): string =
   pragmas for further analysis by macros
 - Custom pragmas are now supported for `var` and `let` symbols.
 - Tuple unpacking is now supported for constants and for loop variables.
-- Case object branchs can be initialized with a runtime discriminator if
+- Case object branches can be initialized with a runtime discriminator if
   possible discriminator values are constrained within a case statement.
 
 ### Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -236,7 +236,8 @@ proc enumToString*(enums: openArray[enum]): string =
   pragmas for further analysis by macros
 - Custom pragmas are now supported for `var` and `let` symbols.
 - Tuple unpacking is now supported for constants and for loop variables.
-
+- Case object branchs can be initialized with a runtime discriminator if
+  possible discriminator values are constrained within a case statement.
 
 ### Language changes
 

--- a/tests/objvariant/trt_discrim.nim
+++ b/tests/objvariant/trt_discrim.nim
@@ -136,3 +136,15 @@ reject: # not immutable.
   of k1, k2, k3: discard KindObj(varkind: kind, i32: 1)
   of k4: discard KindObj(varkind: kind, f32: 2.0)
   else: discard KindObj(varkind: kind, str: "3")
+
+accept:
+  proc kindProc(kind: Kind): KindObj =
+    case kind:
+    of k1: result = KindObj(kind: kind, i32: 1)
+    else: discard
+
+reject:
+  proc varKindProc(kind: var Kind): KindObj =
+    case kind:
+    of k1: result = KindObj(kind: kind, i32: 1)
+    else: discard


### PR DESCRIPTION
Immutable parameters should be fine for runtime discriminator construction.