### PR TITLE
pass typedesc as NimNode to macros

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,8 @@
   `NimNode` like every other type. Use either `typed` or
   `static[typedesc]` for a behavior that is identical in new and old
   Nim.
-
+  RFC: `Pass typedesc as NimNode to macros
+  <https://github.com/nim-lang/RFCs/issues/148>`_.
 
 #### Breaking changes in the standard library
 

--- a/changelog.md
+++ b/changelog.md
@@ -52,6 +52,11 @@
 - With the exception of `uint` and `uint64`, conversion to unsigned types
   are now range checked during runtime.
 
+- Macro arguments of type `typedesc` are now passed in to the macro as
+  `NimNode` like every other type. Use either `typed` or
+  `static[typedesc]` for a behavior that is identical in new and old
+  Nim.
+
 
 #### Breaking changes in the standard library
 

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1554,11 +1554,7 @@ proc activate(c: PContext, n: PNode) =
 
 proc maybeAddResult(c: PContext, s: PSym, n: PNode) =
   if s.kind == skMacro:
-    let resultType =
-      if s.typ.sons[0] != nil and s.typ.sons[0].kind == tyTypeDesc:
-        s.typ.sons[0]
-      else:
-        sysTypeFromName(c.graph, n.info, "NimNode")
+    let resultType = sysTypeFromName(c.graph, n.info, "NimNode")
     addResult(c, resultType, n.info, s.kind)
     addResultNode(c, n)
   elif s.typ.sons[0] != nil and not isInlineIterator(s):

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -869,8 +869,8 @@ proc addParamOrResult(c: PContext, param: PSym, kind: TSymKind) =
       var a = copySym(param)
       a.typ = staticType.base
       addDecl(c, a)
-    elif param.typ != nil and param.typ.kind == tyTypeDesc:
-      addDecl(c, param)
+      #elif param.typ != nil and param.typ.kind == tyTypeDesc:
+      #  addDecl(c, param)
     else:
       # within a macro, every param has the type NimNode!
       let nn = getSysSym(c.graph, param.info, "NimNode")

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2028,8 +2028,8 @@ proc setupMacroParam(x: PNode, typ: PType): TFullReg =
   case typ.kind
   of tyStatic:
     putIntoReg(result, x)
-  of tyTypeDesc:
-    putIntoReg(result, x)
+  #of tyTypeDesc:
+  #  putIntoReg(result, x)
   else:
     result.kind = rkNode
     var n = x

--- a/tests/metatype/ttypeselectors.nim
+++ b/tests/metatype/ttypeselectors.nim
@@ -14,7 +14,7 @@ template selectType(x: int): type =
 template simpleTypeTempl: type =
   string
 
-macro typeFromMacro: type = string
+macro typeFromMacro: type = bindSym"string"
 
 # The tests below check that the result variable of the
 # selected type matches the literal types in the code:


### PR DESCRIPTION
superseeds https://github.com/nim-lang/Nim/pull/11393

implements this RFC: https://github.com/nim-lang/RFCs/issues/148