### PR TITLE
stdlib case transitions

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -700,7 +700,7 @@ when isMainModule:
 
   var test3: TestObj
   test3.test = 42
-  test3.test2 = blah2
+  test3 = TestObj(test2: blah2)
   var x3 = toAny(test3)
   i = 0
   for n, a in fields(x3):

--- a/lib/pure/marshal.nim
+++ b/lib/pure/marshal.nim
@@ -375,7 +375,7 @@ when not defined(testing) and isMainModule:
 
   var test3: TestObj
   test3.test = 42
-  test3.test2 = blah
+  test3 = TestObj(test2: blah)
   testit(test3)
 
   var test4: ref tuple[a, b: string]

--- a/lib/pure/parsecfg.nim
+++ b/lib/pure/parsecfg.nim
@@ -391,8 +391,10 @@ proc ignoreMsg*(c: CfgParser, e: CfgEvent): string {.rtl, extern: "npc$1".} =
 
 proc getKeyValPair(c: var CfgParser, kind: CfgEventKind): CfgEvent =
   if c.tok.kind == tkSymbol:
-    result = CfgEvent(kind: cfgKeyValuePair, key: c.tok.literal, value: "")
-    result.kind = kind
+    case kind
+    of cfgOption, cfgKeyValuePair:
+      result = CfgEvent(kind: kind, key: c.tok.literal, value: "")
+    else: discard
     rawGetTok(c, c.tok)
     if c.tok.kind in {tkEquals, tkColon}:
       rawGetTok(c, c.tok)


### PR DESCRIPTION
Removes old style case object transitions I could find in the stdlib.
fixes #11395