### PR TITLE
Ignore dochack.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ xcuserdata/
 /compiler/nim.dot
 /reject.json
 /run.json
+/tools/dochack/dochack.js
 *.json
 /pkgstemp/**/*
 # for `nim doc foo.nim`


### PR DESCRIPTION
Add to `.gitignore` rule for `/tools/dochack/dochack.js`.

After building locally Nim and running `koch docs`, the `dochack.js`
file was showing up in Git working tree as a new untracked file.

Closes #11374.