### PR TITLE
Bit operator names

### DIFF
--- a/compiler/bitsets.nim
+++ b/compiler/bitsets.nim
@@ -41,23 +41,24 @@ proc bitSetIncl(x: var TBitSet, elem: BiggestInt) =
       toU8(int(1 shl (elem mod ElemSize)))
 
 proc bitSetExcl(x: var TBitSet, elem: BiggestInt) =
-  x[int(elem div ElemSize)] = x[int(elem div ElemSize)] and
-      not toU8(int(1 shl (elem mod ElemSize)))
+  x[int(elem div ElemSize)] = bitand(
+    x[int(elem div ElemSize)],
+    bitnot(toU8(int(1 shl (elem mod ElemSize))))
 
 proc bitSetInit(b: var TBitSet, length: int) =
   newSeq(b, length)
 
 proc bitSetUnion(x: var TBitSet, y: TBitSet) =
-  for i in 0 .. high(x): x[i] = x[i] or y[i]
+  for i in 0 .. high(x): x[i] = bitor(x[i], y[i])
 
 proc bitSetDiff(x: var TBitSet, y: TBitSet) =
-  for i in 0 .. high(x): x[i] = x[i] and not y[i]
+  for i in 0 .. high(x): x[i] = bitand(x[i], bitnot(y[i]))
 
 proc bitSetSymDiff(x: var TBitSet, y: TBitSet) =
-  for i in 0 .. high(x): x[i] = x[i] xor y[i]
+  for i in 0 .. high(x): x[i] = bitxor(x[i], y[i])
 
 proc bitSetIntersect(x: var TBitSet, y: TBitSet) =
-  for i in 0 .. high(x): x[i] = x[i] and y[i]
+  for i in 0 .. high(x): x[i] = bitand(x[i], y[i])
 
 proc bitSetEquals(x, y: TBitSet): bool =
   for i in 0 .. high(x):
@@ -67,7 +68,7 @@ proc bitSetEquals(x, y: TBitSet): bool =
 
 proc bitSetContains(x, y: TBitSet): bool =
   for i in 0 .. high(x):
-    if (x[i] and not y[i]) != int8(0):
+    if bitand(x[i], bitnot(y[i])) != int8(0):
       return false
   result = true
 
@@ -77,14 +78,14 @@ const populationCount: array[low(int8)..high(int8), int8] = block:
 
     proc countSetBits(x: uint8): uint8 =
       return
-        ( x and 0b00000001'u8) +
-        ((x and 0b00000010'u8) shr 1) +
-        ((x and 0b00000100'u8) shr 2) +
-        ((x and 0b00001000'u8) shr 3) +
-        ((x and 0b00010000'u8) shr 4) +
-        ((x and 0b00100000'u8) shr 5) +
-        ((x and 0b01000000'u8) shr 6) +
-        ((x and 0b10000000'u8) shr 7)
+         bitant(x, 0b00000001'u8) +
+        (bitand(x, 0b00000010'u8) shr 1) +
+        (bitand(x, 0b00000100'u8) shr 2) +
+        (bitand(x, 0b00001000'u8) shr 3) +
+        (bitand(x, 0b00010000'u8) shr 4) +
+        (bitand(x, 0b00100000'u8) shr 5) +
+        (bitand(x, 0b01000000'u8) shr 6) +
+        (bitand(x, 0b10000000'u8) shr 7)
 
 
     for it in low(int8)..high(int8):

--- a/compiler/bitsets.nim
+++ b/compiler/bitsets.nim
@@ -10,6 +10,8 @@
 # this unit handles Nim sets; it implements bit sets
 # the code here should be reused in the Nim standard library
 
+import bitops
+
 type
   TBitSet* = seq[int8]        # we use byte here to avoid issues with
                               # cross-compiling; uint would be more efficient
@@ -43,7 +45,7 @@ proc bitSetIncl(x: var TBitSet, elem: BiggestInt) =
 proc bitSetExcl(x: var TBitSet, elem: BiggestInt) =
   x[int(elem div ElemSize)] = bitand(
     x[int(elem div ElemSize)],
-    bitnot(toU8(int(1 shl (elem mod ElemSize))))
+    bitnot(toU8(int(1 shl (elem mod ElemSize)))))
 
 proc bitSetInit(b: var TBitSet, length: int) =
   newSeq(b, length)
@@ -78,7 +80,7 @@ const populationCount: array[low(int8)..high(int8), int8] = block:
 
     proc countSetBits(x: uint8): uint8 =
       return
-         bitant(x, 0b00000001'u8) +
+         bitand(x, 0b00000001'u8) +
         (bitand(x, 0b00000010'u8) shr 1) +
         (bitand(x, 0b00000100'u8) shr 2) +
         (bitand(x, 0b00001000'u8) shr 3) +

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -503,14 +503,14 @@ proc getNumber(L: var TLexer, result: var TToken) =
         result.base = base2
         while pos < endpos:
           if L.buf[pos] != '_':
-            xi = `shl`(xi, 1) or (ord(L.buf[pos]) - ord('0'))
+            xi = bitor(`shl`(xi, 1), ord(L.buf[pos]) - ord('0'))
           inc(pos)
       # 'c', 'C' is deprecated
       of 'o', 'c', 'C':
         result.base = base8
         while pos < endpos:
           if L.buf[pos] != '_':
-            xi = `shl`(xi, 3) or (ord(L.buf[pos]) - ord('0'))
+            xi = bitor(`shl`(xi, 3), ord(L.buf[pos]) - ord('0'))
           inc(pos)
       of 'x', 'X':
         result.base = base16
@@ -519,13 +519,13 @@ proc getNumber(L: var TLexer, result: var TToken) =
           of '_':
             inc(pos)
           of '0'..'9':
-            xi = `shl`(xi, 4) or (ord(L.buf[pos]) - ord('0'))
+            xi = bitor(`shl`(xi, 4), ord(L.buf[pos]) - ord('0'))
             inc(pos)
           of 'a'..'f':
-            xi = `shl`(xi, 4) or (ord(L.buf[pos]) - ord('a') + 10)
+            xi = bitor(`shl`(xi, 4), ord(L.buf[pos]) - ord('a') + 10)
             inc(pos)
           of 'A'..'F':
-            xi = `shl`(xi, 4) or (ord(L.buf[pos]) - ord('A') + 10)
+            xi = bitor(`shl`(xi, 4), ord(L.buf[pos]) - ord('A') + 10)
             inc(pos)
           else:
             break
@@ -624,13 +624,13 @@ proc handleHexChar(L: var TLexer, xi: var int; position: range[0..4]) =
 
   case L.buf[L.bufpos]
   of '0'..'9':
-    xi = (xi shl 4) or (ord(L.buf[L.bufpos]) - ord('0'))
+    xi = bitor(xi shl 4, ord(L.buf[L.bufpos]) - ord('0'))
     inc(L.bufpos)
   of 'a'..'f':
-    xi = (xi shl 4) or (ord(L.buf[L.bufpos]) - ord('a') + 10)
+    xi = bitor(xi shl 4, ord(L.buf[L.bufpos]) - ord('a') + 10)
     inc(L.bufpos)
   of 'A'..'F':
-    xi = (xi shl 4) or (ord(L.buf[L.bufpos]) - ord('A') + 10)
+    xi = bitor(xi shl 4, ord(L.buf[L.bufpos]) - ord('A') + 10)
     inc(L.bufpos)
   of '"', '\'':
     if position <= 1: invalid()
@@ -655,34 +655,34 @@ proc addUnicodeCodePoint(s: var string, i: int) =
     s[pos+0] = chr(i)
   elif i <= 0x07FF:
     s.setLen(pos+2)
-    s[pos+0] = chr((i shr 6) or 0b110_00000)
-    s[pos+1] = chr((i and ones(6)) or 0b10_0000_00)
+    s[pos+0] = chr(bitor(i shr 6, 0b110_00000))
+    s[pos+1] = chr(bitor(bitand(i, ones(6)), 0b10_0000_00))
   elif i <= 0xFFFF:
     s.setLen(pos+3)
-    s[pos+0] = chr(i shr 12 or 0b1110_0000)
-    s[pos+1] = chr(i shr 6 and ones(6) or 0b10_0000_00)
-    s[pos+2] = chr(i and ones(6) or 0b10_0000_00)
+    s[pos+0] = chr(bitor(i shr 12, 0b1110_0000))
+    s[pos+1] = chr(bitand(i shr 6, ones(6)).bitor(0b10_0000_00))
+    s[pos+2] = chr(bitand(i, ones(6)).bitor(0b10_0000_00))
   elif i <= 0x001FFFFF:
     s.setLen(pos+4)
-    s[pos+0] = chr(i shr 18 or 0b1111_0000)
-    s[pos+1] = chr(i shr 12 and ones(6) or 0b10_0000_00)
-    s[pos+2] = chr(i shr 6 and ones(6) or 0b10_0000_00)
-    s[pos+3] = chr(i and ones(6) or 0b10_0000_00)
+    s[pos+0] = chr(bitor(i shr 18, 0b1111_0000))
+    s[pos+1] = chr(bitand(i shr 12, ones(6)).bitor(0b10_0000_00))
+    s[pos+2] = chr(bitand(i shr 6, ones(6)).bitor(0b10_0000_00))
+    s[pos+3] = chr(bitand(i, ones(6)).bitor(0b10_0000_00))
   elif i <= 0x03FFFFFF:
     s.setLen(pos+5)
-    s[pos+0] = chr(i shr 24 or 0b111110_00)
-    s[pos+1] = chr(i shr 18 and ones(6) or 0b10_0000_00)
-    s[pos+2] = chr(i shr 12 and ones(6) or 0b10_0000_00)
-    s[pos+3] = chr(i shr 6 and ones(6) or 0b10_0000_00)
-    s[pos+4] = chr(i and ones(6) or 0b10_0000_00)
+    s[pos+0] = chr(bitor(i shr 24, 0b111110_00))
+    s[pos+1] = chr(bitand(i shr 18, ones(6)).bitor(0b10_0000_00))
+    s[pos+2] = chr(bitand(i shr 12, ones(6)).bitor(0b10_0000_00))
+    s[pos+3] = chr(bitand(i shr 6, ones(6)).bitor(0b10_0000_00))
+    s[pos+4] = chr(bitand(i, ones(6)).bitor(0b10_0000_00))
   elif i <= 0x7FFFFFFF:
     s.setLen(pos+6)
-    s[pos+0] = chr(i shr 30 or 0b1111110_0)
-    s[pos+1] = chr(i shr 24 and ones(6) or 0b10_0000_00)
-    s[pos+2] = chr(i shr 18 and ones(6) or 0b10_0000_00)
-    s[pos+3] = chr(i shr 12 and ones(6) or 0b10_0000_00)
-    s[pos+4] = chr(i shr 6 and ones(6) or 0b10_0000_00)
-    s[pos+5] = chr(i and ones(6) or 0b10_0000_00)
+    s[pos+0] = chr(bitor(i shr 30, 0b1111110_0))
+    s[pos+1] = chr(bitand(i shr 24, ones(6)).bitor(0b10_0000_00))
+    s[pos+2] = chr(bitand(i shr 18, ones(6)).bitor(0b10_0000_00))
+    s[pos+3] = chr(bitand(i shr 12, ones(6)).bitor(0b10_0000_00))
+    s[pos+4] = chr(bitand(i shr 6, ones(6)).bitor(0b10_0000_00))
+    s[pos+5] = chr(bitand(i , ones(6)).bitor(0b10_0000_00))
 
 proc getEscapedChar(L: var TLexer, tok: var TToken) =
   inc(L.bufpos)               # skip '\'

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -17,7 +17,7 @@
 
 import
   hashes, options, msgs, strutils, platform, idents, nimlexbase, llstream,
-  wordrecg, lineinfos, pathutils, parseutils
+  wordrecg, lineinfos, pathutils, parseutils, bitops
 
 const
   MaxLineLength* = 80         # lines longer than this lead to a warning

--- a/compiler/nimsets.nim
+++ b/compiler/nimsets.nim
@@ -11,7 +11,7 @@
 
 import
   ast, astalgo, trees, nversion, lineinfos, platform, bitsets, types, renderer,
-  options
+  options, bitops
 
 proc inSet*(s: PNode, elem: PNode): bool =
   assert s.kind == nkCurly

--- a/compiler/nimsets.nim
+++ b/compiler/nimsets.nim
@@ -133,7 +133,7 @@ proc equalSets*(conf: ConfigRef; a, b: PNode): bool =
 proc complement*(conf: ConfigRef; a: PNode): PNode =
   var x: TBitSet
   toBitSet(conf, a, x)
-  for i in 0 .. high(x): x[i] = not x[i]
+  for i in 0 .. high(x): x[i] = bitnot(x[i])
   result = toTreeSet(conf, x, a.typ, a.info)
 
 proc deduplicate*(conf: ConfigRef; a: PNode): PNode =

--- a/compiler/saturate.nim
+++ b/compiler/saturate.nim
@@ -9,6 +9,8 @@
 
 ## Saturated arithmetic routines. XXX Make part of the stdlib?
 
+import bitops
+
 proc `|+|`*(a, b: BiggestInt): BiggestInt =
   ## saturated addition.
   result = a +% b

--- a/compiler/saturate.nim
+++ b/compiler/saturate.nim
@@ -12,7 +12,7 @@
 proc `|+|`*(a, b: BiggestInt): BiggestInt =
   ## saturated addition.
   result = a +% b
-  if (result xor a) >= 0'i64 or (result xor b) >= 0'i64:
+  if bitxor(result, a) >= 0'i64 or bitxor(result, b) >= 0'i64:
     return result
   if a < 0 or b < 0:
     result = low(result)
@@ -21,7 +21,7 @@ proc `|+|`*(a, b: BiggestInt): BiggestInt =
 
 proc `|-|`*(a, b: BiggestInt): BiggestInt =
   result = a -% b
-  if (result xor a) >= 0'i64 or (result xor not b) >= 0'i64:
+  if bitxor(result, a) >= 0'i64 or bitxor(result, bitnot(b)) >= 0'i64:
     return result
   if b > 0:
     result = low(result)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2197,6 +2197,16 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
     else:
       result = c.graph.emptyNode
   of mSizeOf: result = semSizeof(c, setMs(n, s))
+  # of mBitandI, mBitorI, mBitxorI, mBitnotI:
+  #   result = semDirectOp(c, n, flags)
+  #   if result.typ.kind != tyBool and n.kind in {nkInfix, nkPrefix}:
+  #     echo "bitop: ", result
+  #     echo "typ: ", result.typ
+  #   else:
+  #     echo "hä!? "
+  #     debug(result)
+  #     debug(result.typ)
+  #     quit()
   else:
     result = semDirectOp(c, n, flags)
 

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -13,7 +13,7 @@
 import
   strutils, options, ast, astalgo, trees, treetab, nimsets,
   nversion, platform, math, msgs, os, condsyms, idents, renderer, types,
-  commands, magicsys, modulegraphs, strtabs, lineinfos
+  commands, magicsys, modulegraphs, strtabs, lineinfos, bitops
 
 proc newIntNodeT*(intVal: BiggestInt, n: PNode; g: ModuleGraph): PNode =
   case skipTypes(n.typ, abstractVarRange).kind

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -713,7 +713,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         bVal = regs[rb].intVal
         cVal = regs[rc].intVal
         sum = bVal +% cVal
-      if (sum xor bVal) >= 0 or (sum xor cVal) >= 0:
+      if bitxor(sum, bVal) >= 0 or bitxor(sum, cVal) >= 0:
         regs[ra].intVal = sum
       else:
         stackTrace(c, tos, pc, errOverOrUnderflow)
@@ -725,7 +725,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         bVal = regs[rb].intVal
         cVal = imm
         sum = bVal +% cVal
-      if (sum xor bVal) >= 0 or (sum xor cVal) >= 0:
+      if bitxor(sum, bVal) >= 0 or bitxor(sum, cVal) >= 0:
         regs[ra].intVal = sum
       else:
         stackTrace(c, tos, pc, errOverOrUnderflow)
@@ -735,7 +735,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         bVal = regs[rb].intVal
         cVal = regs[rc].intVal
         diff = bVal -% cVal
-      if (diff xor bVal) >= 0 or (diff xor not cVal) >= 0:
+      if bitxor(diff, bVal) >= 0 or bitxor(diff, bitnot(cVal)) >= 0:
         regs[ra].intVal = diff
       else:
         stackTrace(c, tos, pc, errOverOrUnderflow)
@@ -745,7 +745,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         bVal = regs[rb].intVal
         cVal = imm
         diff = bVal -% cVal
-      if (diff xor bVal) >= 0 or (diff xor not cVal) >= 0:
+      if bitxor(diff, bVal) >= 0 or bitxor(diff, bitnot(cVal)) >= 0:
         regs[ra].intVal = diff
       else:
         stackTrace(c, tos, pc, errOverOrUnderflow)
@@ -833,13 +833,13 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       regs[ra].intVal = ashr(regs[rb].intVal, regs[rc].intVal)
     of opcBitandInt:
       decodeBC(rkInt)
-      regs[ra].intVal = regs[rb].intVal and regs[rc].intVal
+      regs[ra].intVal = bitand(regs[rb].intVal, regs[rc].intVal)
     of opcBitorInt:
       decodeBC(rkInt)
-      regs[ra].intVal = regs[rb].intVal or regs[rc].intVal
+      regs[ra].intVal = bitor(regs[rb].intVal, regs[rc].intVal)
     of opcBitxorInt:
       decodeBC(rkInt)
-      regs[ra].intVal = regs[rb].intVal xor regs[rc].intVal
+      regs[ra].intVal = bitxor(regs[rb].intVal, regs[rc].intVal)
     of opcAddu:
       decodeBC(rkInt)
       regs[ra].intVal = regs[rb].intVal +% regs[rc].intVal
@@ -926,7 +926,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcBitnotInt:
       decodeB(rkInt)
       assert regs[rb].kind == rkInt
-      regs[ra].intVal = not regs[rb].intVal
+      regs[ra].intVal = bitnot(regs[rb].intVal)
     of opcEqStr:
       decodeBC(rkInt)
       regs[ra].intVal = ord(regs[rb].node.strVal == regs[rc].node.strVal)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -16,7 +16,7 @@ import
   strutils, astalgo, msgs, vmdef, vmgen, nimsets, types, passes,
   parser, vmdeps, idents, trees, renderer, options, transf, parseutils,
   vmmarshal, gorgeimpl, lineinfos, tables, btrees, macrocacheimpl,
-  modulegraphs, sighashes
+  modulegraphs, sighashes, bitops
 
 from semfold import leValueConv, ordinalValToString
 from evaltempl import evalTemplate

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -254,10 +254,10 @@ const
 # flag is used to signal opcSeqLen if node is NimNode.
 const nimNodeFlag* = 16
 
-template opcode*(x: TInstr): TOpcode = TOpcode(x.uint32 and 0xff'u32)
-template regA*(x: TInstr): TRegister = TRegister(x.uint32 shr 8'u32 and 0xff'u32)
-template regB*(x: TInstr): TRegister = TRegister(x.uint32 shr 16'u32 and 0xff'u32)
+template opcode*(x: TInstr): TOpcode = TOpcode(bitand(x.uint32, 0xff'u32))
+template regA*(x: TInstr): TRegister = TRegister(bitand(x.uint32 shr 8'u32, 0xff'u32))
+template regB*(x: TInstr): TRegister = TRegister(bitand(x.uint32 shr 16'u32, 0xff'u32))
 template regC*(x: TInstr): TRegister = TRegister(x.uint32 shr 24'u32)
-template regBx*(x: TInstr): int = (x.uint32 shr 16'u32).int
+template regBx*(x: TInstr): int = int(x.uint32 shr 16'u32)
 
 template jmpDiff*(x: TInstr): int = regBx(x) - wordExcess

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -11,7 +11,7 @@
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
 import ast, passes, msgs, idents, intsets, options, modulegraphs, lineinfos,
-  tables, btrees
+  tables, btrees, bitops
 
 const
   byteExcess* = 128 # we use excess-K for immediates

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -29,7 +29,7 @@
 
 import
   strutils, ast, astalgo, types, msgs, renderer, vmdef,
-  trees, intsets, magicsys, options, lowerings, lineinfos, transf
+  trees, intsets, magicsys, options, lowerings, lineinfos, transf, bitops
 import platform
 from os import splitFile
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1418,7 +1418,7 @@ proc boolVal*(n: NimNode): bool {.compileTime, noSideEffect.} =
   if n.kind == nnkIntLit: n.intVal != 0
   else: n == bindSym"true" # hacky solution for now
 
-macro expandMacros*(body: typed): typed =
+macro expandMacros*(body: typed): untyped =
   ## Expands one level of macro - useful for debugging.
   ## Can be used to inspect what happens when a macro call is expanded,
   ## without altering its result.

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -190,7 +190,7 @@ proc binarySearch*[T, K](a: openArray[T], key: K,
     var step = len shr 1
     var cmpRes: int
     while step > 0:
-      let i = result or step
+      let i = bitor(result, step)
       cmpRes = cmp(a[i], key)
       if cmpRes == 0:
         return i

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -44,6 +44,8 @@
 ## * `sequtils module<sequtils.html>`_ for working with the built-in seq type
 ## * `tables module<tables.html>`_ for sorting tables
 
+import bitops
+
 type
   SortOrder* = enum
     Descending, Ascending

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -39,6 +39,18 @@ template toUnsigned(x: int32): uint32 = cast[uint32](x)
 template toUnsigned(x: int64): uint64 = cast[uint64](x)
 template toUnsigned(x: int): uint = cast[uint](x)
 
+proc bitnot*[T: SomeInteger](x: T): T {.magic: "BitnotI", noSideEffect.}
+  ## Computes the `bitwise complement` of the integer `x`.
+
+proc bitand*[T: SomeInteger](x, y: T): T {.magic: "BitandI", noSideEffect.}
+  ## Computes the `bitwise and` of numbers `x` and `y`.
+
+proc bitor*[T: SomeInteger](x, y: T): T {.magic: "BitorI", noSideEffect.}
+  ## Computes the `bitwise or` of numbers `x` and `y`.
+
+proc bitxor*[T: SomeInteger](x, y: T): T {.magic: "BitxorI", noSideEffect.}
+  ## Computes the `bitwise xor` of numbers `x` and `y`.
+
 template forwardImpl(impl, arg) {.dirty.} =
   when sizeof(x) <= 4:
     when x is SomeSignedInt:

--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -29,7 +29,7 @@
 ##    writeLine(stdout, "your password: " & myData["password"])
 ##    writeLine(stdout, "</body></html>")
 
-import strutils, os, strtabs, cookies, uri
+import strutils, os, strtabs, cookies, uri, bitops
 export uri.encodeUrl, uri.decodeUrl
 
 proc handleHexChar(c: char, x: var int) {.inline.} =

--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -34,9 +34,9 @@ export uri.encodeUrl, uri.decodeUrl
 
 proc handleHexChar(c: char, x: var int) {.inline.} =
   case c
-  of '0'..'9': x = (x shl 4) or (ord(c) - ord('0'))
-  of 'a'..'f': x = (x shl 4) or (ord(c) - ord('a') + 10)
-  of 'A'..'F': x = (x shl 4) or (ord(c) - ord('A') + 10)
+  of '0'..'9': x = bitor(x shl 4, ord(c) - ord('0'))
+  of 'a'..'f': x = bitor(x shl 4, ord(c) - ord('a') + 10)
+  of 'A'..'F': x = bitor(x shl 4, ord(c) - ord('A') + 10)
   else: assert(false)
 
 proc addXmlChar(dest: var string, c: char) {.inline.} =

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -61,7 +61,7 @@ when not defined(nimhygiene):
 type
   KeyValuePair[A] = tuple[hcode: Hash, key: A]
   KeyValuePairSeq[A] = seq[KeyValuePair[A]]
-  HashSet* {.myShallow.} [A] = object ## \
+  HashSet*[A] {.myShallow.} = object ## \
     ## A generic hash set.
     ##
     ## Use `init proc <#init,HashSet[A],int>`_ or `initHashSet proc <#initHashSet,int>`_
@@ -73,7 +73,7 @@ type
   OrderedKeyValuePair[A] = tuple[
     hcode: Hash, next: int, key: A]
   OrderedKeyValuePairSeq[A] = seq[OrderedKeyValuePair[A]]
-  OrderedSet* {.myShallow.} [A] = object ## \
+  OrderedSet*[A] {.myShallow.} = object ## \
     ## A generic hash set that remembers insertion order.
     ##
     ## Use `init proc <#init,OrderedSet[A],int>`_ or `initOrderedSet proc

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -149,7 +149,7 @@ template dollarImpl(): untyped {.dirty.} =
       result.addQuoted(val)
     result.add("}")
 
-template equalsImpl(s, t: typed) =
+template equalsImpl(s, t: typed): untyped =
   if s.counter == t.counter:
     # different insertion orders mean different 'data' seqs, so we have
     # to use the slow route here:

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1252,7 +1252,7 @@ proc enlarge[A, B](t: var OrderedTable[A, B]) =
       rawInsert(t, t.data, n[h].key, n[h].val, n[h].hcode, j)
     h = nxt
 
-template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
+template forAllOrderedPairs(yieldStmt: untyped): untyped {.dirty.} =
   var h = t.first
   while h >= 0:
     var nxt = t.data[h].next

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -9,7 +9,7 @@
 ## This module implements color handling for Nim. It is used by
 ## the ``graphics`` module.
 
-import strutils
+import strutils, bitops
 from algorithm import binarySearch
 
 type

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -32,7 +32,7 @@ template extract(a: Color, r, g, b: untyped) =
   var b = a.int and 0xff
 
 template rawRGB(r, g, b: int): Color =
-  Color(r shl 16 or g shl 8 or b)
+  Color(bitor(bitor(r shl 16, g shl 8), b))
 
 template colorOp(op): Color =
   extract(a, ar, ag, ab)

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -64,7 +64,7 @@ proc `!&`*(h: Hash, val: int): Hash {.inline.} =
   let val = cast[uint](val)
   var res = h + val
   res = res + res shl 10
-  res = res xor (res shr 6)
+  res = bitxor(res, res shr 6)
   result = cast[Hash](res)
 
 proc `!$`*(h: Hash): Hash {.inline.} =
@@ -73,7 +73,7 @@ proc `!$`*(h: Hash): Hash {.inline.} =
   ## This is only needed if you need to implement a hash proc for a new datatype.
   let h = cast[uint](h) # Hash is practically unsigned.
   var res = h + h shl 3
-  res = res xor (res shr 11)
+  res = bitxor(res, res shr 11)
   res = res + res shl 15
   result = cast[Hash](res)
 
@@ -164,7 +164,7 @@ template hashImpl(result: Hash, x: typed, start, stop: int) =
     when nimvm:
       # we cannot cast in VM, so we do it manually
       for j in countdown(stepsize-1, 0):
-        n = (n shl (8*elementSize)) or ord(x[i+j])
+        n = bitor(n shl (8*elementSize), ord(x[i+j]))
     else:
       n = cast[ptr Hash](unsafeAddr x[i])[]
     result = result !& n

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -46,7 +46,7 @@
 
 
 import
-  strutils
+  strutils, bitops
 
 type
   Hash* = int  ## A hash value. Hash tables using these values should

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -143,7 +143,7 @@ runnableExamples:
 
 import
   hashes, tables, strutils, lexbase, streams, unicode, macros, parsejson,
-  typetraits, options
+  typetraits, options, bitops
 
 export
   tables.`$`

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -463,7 +463,7 @@ proc hash*(n: JsonNode): Hash =
 
 proc hash*(n: OrderedTable[string, JsonNode]): Hash =
   for key, val in n:
-    result = result xor (hash(key) !& hash(val))
+    result = bitxor(result, hash(key) !& hash(val))
   result = !$result
 
 proc len*(n: JsonNode): int =

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -178,14 +178,14 @@ proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
     doAssert nextPowerOfTwo(-16) == 1
   result = x - 1
   when defined(cpu64):
-    result = result or (result shr 32)
+    result = bitor(result, result shr 32)
   when sizeof(int) > 2:
-    result = result or (result shr 16)
+    result = bitor(result, (result shr 16))
   when sizeof(int) > 1:
-    result = result or (result shr 8)
-  result = result or (result shr 4)
-  result = result or (result shr 2)
-  result = result or (result shr 1)
+    result = bitor(result, result shr 8)
+  result = bitor(result, result shr 4)
+  result = bitor(result, result shr 2)
+  result = bitor(result, result shr 1)
   result += 1 + ord(x<=0)
 
 proc countBits32*(n: int32): int {.noSideEffect, deprecated:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -48,7 +48,7 @@
 include "system/inclrtl"
 
 import
-  strutils, pathnorm
+  strutils, pathnorm, bitops
 
 const weirdTarget = defined(nimscript) or defined(js)
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1440,17 +1440,17 @@ proc getFilePermissions*(filename: string): set[FilePermission] {.
     var a: Stat
     if stat(filename, a) < 0'i32: raiseOSError(osLastError())
     result = {}
-    if (a.st_mode and S_IRUSR) != 0'i32: result.incl(fpUserRead)
-    if (a.st_mode and S_IWUSR) != 0'i32: result.incl(fpUserWrite)
-    if (a.st_mode and S_IXUSR) != 0'i32: result.incl(fpUserExec)
+    if bitand(a.st_mode, S_IRUSR) != 0'i32: result.incl(fpUserRead)
+    if bitand(a.st_mode, S_IWUSR) != 0'i32: result.incl(fpUserWrite)
+    if bitand(a.st_mode, S_IXUSR) != 0'i32: result.incl(fpUserExec)
 
-    if (a.st_mode and S_IRGRP) != 0'i32: result.incl(fpGroupRead)
-    if (a.st_mode and S_IWGRP) != 0'i32: result.incl(fpGroupWrite)
-    if (a.st_mode and S_IXGRP) != 0'i32: result.incl(fpGroupExec)
+    if bitand(a.st_mode, S_IRGRP) != 0'i32: result.incl(fpGroupRead)
+    if bitand(a.st_mode, S_IWGRP) != 0'i32: result.incl(fpGroupWrite)
+    if bitand(a.st_mode, S_IXGRP) != 0'i32: result.incl(fpGroupExec)
 
-    if (a.st_mode and S_IROTH) != 0'i32: result.incl(fpOthersRead)
-    if (a.st_mode and S_IWOTH) != 0'i32: result.incl(fpOthersWrite)
-    if (a.st_mode and S_IXOTH) != 0'i32: result.incl(fpOthersExec)
+    if bitand(a.st_mode, S_IROTH) != 0'i32: result.incl(fpOthersRead)
+    if bitand(a.st_mode, S_IWOTH) != 0'i32: result.incl(fpOthersWrite)
+    if bitand(a.st_mode, S_IXOTH) != 0'i32: result.incl(fpOthersExec)
   else:
     when useWinUnicode:
       wrapUnary(res, getFileAttributesW, filename)
@@ -1476,17 +1476,17 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
   ## * `FilePermission enum <#FilePermission>`_
   when defined(posix):
     var p = 0'i32
-    if fpUserRead in permissions: p = p or S_IRUSR
-    if fpUserWrite in permissions: p = p or S_IWUSR
-    if fpUserExec in permissions: p = p or S_IXUSR
+    if fpUserRead in permissions: p = bitor(p, S_IRUSR)
+    if fpUserWrite in permissions: p = bitor(p, S_IWUSR)
+    if fpUserExec in permissions: p = bitor(p, S_IXUSR)
 
-    if fpGroupRead in permissions: p = p or S_IRGRP
-    if fpGroupWrite in permissions: p = p or S_IWGRP
-    if fpGroupExec in permissions: p = p or S_IXGRP
+    if fpGroupRead in permissions: p = bitor(p, S_IRGRP)
+    if fpGroupWrite in permissions: p = bitor(p, S_IWGRP)
+    if fpGroupExec in permissions: p = bitor(p, S_IXGRP)
 
-    if fpOthersRead in permissions: p = p or S_IROTH
-    if fpOthersWrite in permissions: p = p or S_IWOTH
-    if fpOthersExec in permissions: p = p or S_IXOTH
+    if fpOthersRead in permissions: p = bitor(p, S_IROTH)
+    if fpOthersWrite in permissions: p = bitor(p, S_IWOTH)
+    if fpOthersExec in permissions: p = bitor(p, S_IXOTH)
 
     if chmod(filename, p) != 0: raiseOSError(osLastError())
   else:
@@ -2859,7 +2859,7 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
 
   else:
     template checkAndIncludeMode(rawMode, formalMode: untyped) =
-      if (rawInfo.st_mode and rawMode) != 0'i32:
+      if bitand(rawInfo.st_mode, rawMode) != 0'i32:
         formalInfo.permissions.incl(formalMode)
     formalInfo.id = (rawInfo.st_dev, rawInfo.st_ino)
     formalInfo.size = rawInfo.st_size

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -12,7 +12,7 @@
 ## module, but can also be used in its own right.
 
 import
-  strutils, lexbase, streams, unicode
+  strutils, lexbase, streams, unicode, bitops
 
 type
   JsonEventKind* = enum  ## enumeration of all events that may occur when parsing

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -165,9 +165,9 @@ proc errorMsgExpected*(my: JsonParser, e: string): string =
 proc handleHexChar(c: char, x: var int): bool =
   result = true # Success
   case c
-  of '0'..'9': x = (x shl 4) or (ord(c) - ord('0'))
-  of 'a'..'f': x = (x shl 4) or (ord(c) - ord('a') + 10)
-  of 'A'..'F': x = (x shl 4) or (ord(c) - ord('A') + 10)
+  of '0'..'9': x = bitor(x shl 4, ord(c) - ord('0'))
+  of 'a'..'f': x = bitor(x shl 4, ord(c) - ord('a') + 10)
+  of 'A'..'F': x = bitor(x shl 4, ord(c) - ord('A') + 10)
   else: result = false # error
 
 proc parseEscapedUTF16*(buf: cstring, pos: var int): int =
@@ -237,7 +237,7 @@ proc parseString(my: var JsonParser): TokKind =
           inc(pos, 2)
           var s = parseEscapedUTF16(my.buf, pos)
           if (s and 0xfc00) == 0xdc00 and s > 0:
-            r = 0x10000 + (((r - 0xd800) shl 10) or (s - 0xdc00))
+            r = 0x10000 + bitor((r - 0xd800) shl 10, s - 0xdc00)
           else:
             my.err = errInvalidToken
             break

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -55,6 +55,8 @@
 
 include "system/inclrtl"
 
+import bitops
+
 const
   Whitespace = {' ', '\t', '\v', '\r', '\l', '\f'}
   IdentChars = {'a'..'z', 'A'..'Z', '0'..'9', '_'}

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -74,7 +74,7 @@ proc parseBin*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0):
   ## If ``maxLen == 0``, the parsing continues until the first non-bin character
   ## or to the end of the string. Otherwise, no more than ``maxLen`` characters
   ## are parsed starting from the ``start`` position.
-  ## 
+  ##
   ## It does not check for overflow. If the value represented by the string is
   ## too big to fit into ``number``, only the value of last fitting characters
   ## will be stored in ``number`` without producing an error.
@@ -103,7 +103,7 @@ proc parseBin*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0):
     case s[i]
     of '_': discard
     of '0'..'1':
-      output = output shl 1 or T(ord(s[i]) - ord('0'))
+      output = bitor(output shl 1, T(ord(s[i]) - ord('0')))
       foundDigit = true
     else: break
     inc(i)
@@ -121,7 +121,7 @@ proc parseOct*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0):
   ## If ``maxLen == 0``, the parsing continues until the first non-oct character
   ## or to the end of the string. Otherwise, no more than ``maxLen`` characters
   ## are parsed starting from the ``start`` position.
-  ## 
+  ##
   ## It does not check for overflow. If the value represented by the string is
   ## too big to fit into ``number``, only the value of last fitting characters
   ## will be stored in ``number`` without producing an error.
@@ -150,7 +150,7 @@ proc parseOct*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0):
     case s[i]
     of '_': discard
     of '0'..'7':
-      output = output shl 3 or T(ord(s[i]) - ord('0'))
+      output = bitor(output shl 3, T(ord(s[i]) - ord('0')))
       foundDigit = true
     else: break
     inc(i)
@@ -168,7 +168,7 @@ proc parseHex*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0):
   ## If ``maxLen == 0``, the parsing continues until the first non-hex character
   ## or to the end of the string. Otherwise, no more than ``maxLen`` characters
   ## are parsed starting from the ``start`` position.
-  ## 
+  ##
   ## It does not check for overflow. If the value represented by the string is
   ## too big to fit into ``number``, only the value of last fitting characters
   ## will be stored in ``number`` without producing an error.
@@ -199,13 +199,13 @@ proc parseHex*[T: SomeInteger](s: string, number: var T, start = 0, maxLen = 0):
     case s[i]
     of '_': discard
     of '0'..'9':
-      output = output shl 4 or T(ord(s[i]) - ord('0'))
+      output = bitor(output shl 4, T(ord(s[i]) - ord('0')))
       foundDigit = true
     of 'a'..'f':
-      output = output shl 4 or T(ord(s[i]) - ord('a') + 10)
+      output = bitor(output shl 4, T(ord(s[i]) - ord('a') + 10))
       foundDigit = true
     of 'A'..'F':
-      output = output shl 4 or T(ord(s[i]) - ord('A') + 10)
+      output = bitor(output shl 4, T(ord(s[i]) - ord('A') + 10))
       foundDigit = true
     else: break
     inc(i)

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -68,7 +68,7 @@ proc addNormalizePath*(x: string; result: var string; state: var int; dirSep = D
     let b = next(it, x)
     if (state shr 1 == 0) and isSlash(x, b):
       result.add dirSep
-      state = state or 1
+      state = bitor(state, 1)
     elif isDotDot(x, b):
       if (state shr 1) >= 1:
         var d = result.len

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -13,7 +13,7 @@
 
 # Yes, this uses import here, not include so that
 # we don't end up exporting these symbols from pathnorm and os:
-import "includes/osseps"
+import "includes/osseps", bitops
 
 type
   PathIter* = object

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -897,7 +897,7 @@ proc toBin*(x: BiggestInt, len: Positive): string {.noSideEffect,
   assert(len > 0)
   result = newString(len)
   for j in countdown(len-1, 0):
-    result[j] = chr(int((BiggestUInt(x) and mask) shr shift) + ord('0'))
+    result[j] = chr(int(bitand(BiggestUInt(x), mask) shr shift) + ord('0'))
     inc shift
     mask = mask shl BiggestUInt(1)
 
@@ -922,7 +922,7 @@ proc toOct*(x: BiggestInt, len: Positive): string {.noSideEffect,
   assert(len > 0)
   result = newString(len)
   for j in countdown(len-1, 0):
-    result[j] = chr(int((BiggestUInt(x) and mask) shr shift) + ord('0'))
+    result[j] = chr(int(bitand(BiggestUInt(x), mask) shr shift) + ord('0'))
     inc shift, 3
     mask = mask shl BiggestUInt(3)
 
@@ -945,7 +945,7 @@ proc toHex*(x: BiggestInt, len: Positive): string {.noSideEffect,
     n = x
   result = newString(len)
   for j in countdown(len-1, 0):
-    result[j] = HexChars[int(n and 0xF)]
+    result[j] = HexChars[int(bitand(n, 0xF))]
     n = n shr 4
     # handle negative overflow
     if n == 0 and x < 0: n = -1

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -72,7 +72,7 @@
 ##   easier substring extraction than regular expressions
 
 
-import parseutils
+import parseutils, bitops
 from math import pow, floor, log10
 from algorithm import reverse
 

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -16,7 +16,7 @@
 ## Similarly, if you hide the cursor, make sure to unhide it with
 ## ``showCursor`` before quitting.
 
-import macros
+import macros, bitops
 import strformat
 from strutils import toLowerAscii, `%`
 import colors, tables

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -93,9 +93,9 @@ proc decodeUrl*(s: string, decodePlus=true): string =
     assert decodeUrl("https%3A%2F%2Fnim-lang.org%2Fthis%20is%20a%20test", false) == "https://nim-lang.org/this is a test"
   proc handleHexChar(c: char, x: var int) {.inline.} =
     case c
-    of '0'..'9': x = (x shl 4) or (ord(c) - ord('0'))
-    of 'a'..'f': x = (x shl 4) or (ord(c) - ord('a') + 10)
-    of 'A'..'F': x = (x shl 4) or (ord(c) - ord('A') + 10)
+    of '0'..'9': x = bitor(x shl 4, ord(c) - ord('0'))
+    of 'a'..'f': x = bitor(x shl 4, ord(c) - ord('a') + 10)
+    of 'A'..'F': x = bitor(x shl 4, ord(c) - ord('A') + 10)
     else: assert(false)
 
   result = newString(s.len)

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -37,7 +37,7 @@
 ##    else:
 ##      echo "Wrong format"
 
-import strutils, parseutils
+import strutils, parseutils, bitops
 type
   Url* = distinct string
 

--- a/lib/std/sha1.nim
+++ b/lib/std/sha1.nim
@@ -60,9 +60,9 @@ proc newSha1State(): Sha1State =
   result.state[3] = 0x10325476'u32
   result.state[4] = 0xC3D2E1F0'u32
 
-template ror27(val: uint32): uint32 = (val shr 27) or (val shl  5)
-template ror2 (val: uint32): uint32 = (val shr  2) or (val shl 30)
-template ror31(val: uint32): uint32 = (val shr 31) or (val shl  1)
+template ror27(val: uint32): uint32 = bitor(val shr 27, val shl  5)
+template ror2 (val: uint32): uint32 = bitor(val shr  2, val shl 30)
+template ror31(val: uint32): uint32 = bitor(val shr 31, val shl  1)
 
 proc transform(ctx: var Sha1State) =
   var W: array[80, uint32]
@@ -77,7 +77,7 @@ proc transform(ctx: var Sha1State) =
 
   template SHA_F1(A, B, C, D, E, t: untyped) =
     bigEndian32(addr W[t], addr ctx.buf[t * 4])
-    E += ror27(A) + W[t] + (D xor (B and (C xor D))) + 0x5A827999'u32
+    E += ror27(A) + W[t] + bitxor(D, bitand(B, bitxor(C, D))) + 0x5A827999'u32
     B = ror2(B)
 
   while t < 15:
@@ -90,8 +90,8 @@ proc transform(ctx: var Sha1State) =
   SHA_F1(A, B, C, D, E, t + 0) # 16th one, t == 15
 
   template SHA_F11(A, B, C, D, E, t: untyped) =
-    W[t] = ror31(W[t-3] xor W[t-8] xor W[t-14] xor W[t-16])
-    E += ror27(A) + W[t] + (D xor (B and (C xor D))) + 0x5A827999'u32
+    W[t] = ror31(W[t-3].bitxor(W[t-8]).bitxor(W[t-14]).bitxor(W[t-16]))
+    E += ror27(A) + W[t] + bitxor(D, bitand(B, bitxor(C, D))) + 0x5A827999'u32
     B = ror2(B)
 
   SHA_F11(E, A, B, C, D, t + 1)
@@ -100,8 +100,8 @@ proc transform(ctx: var Sha1State) =
   SHA_F11(B, C, D, E, A, t + 4)
 
   template SHA_F2(A, B, C, D, E, t: untyped) =
-    W[t] = ror31(W[t-3] xor W[t-8] xor W[t-14] xor W[t-16])
-    E += ror27(A) + W[t] + (B xor C xor D) + 0x6ED9EBA1'u32
+    W[t] = ror31(W[t-3].bitxor(W[t-8]).bitxor(W[t-14]).bitxor(W[t-16]))
+    E += ror27(A) + W[t] + bitxor(B, C).bitxor(D) + 0x6ED9EBA1'u32
     B = ror2(B)
 
   t = 20
@@ -114,8 +114,8 @@ proc transform(ctx: var Sha1State) =
     t += 5
 
   template SHA_F3(A, B, C, D, E, t: untyped) =
-    W[t] = ror31(W[t-3] xor W[t-8] xor W[t-14] xor W[t-16])
-    E += ror27(A) + W[t] + ((B and C) or (D and (B or C))) + 0x8F1BBCDC'u32
+    W[t] = ror31(W[t-3].bitxor(W[t-8]).bitxor(W[t-14]).bitxor(W[t-16]))
+    E += ror27(A) + W[t] + bitor(bitand(B, C), bitand(D, bitor(B, C))) + 0x8F1BBCDC'u32
     B = ror2(B)
 
   while t < 60:
@@ -127,8 +127,8 @@ proc transform(ctx: var Sha1State) =
     t += 5
 
   template SHA_F4(A, B, C, D, E, t: untyped) =
-    W[t] = ror31(W[t-3] xor W[t-8] xor W[t-14] xor W[t-16])
-    E += ror27(A) + W[t] + (B xor C xor D) + 0xCA62C1D6'u32
+    W[t] = ror31(W[t-3].bitxor(W[t-8]).bitxor(W[t-14]).bitxor(W[t-16]))
+    E += ror27(A) + W[t] + bitxor(B, C).bitxor(D) + 0xCA62C1D6'u32
     B = ror2(B)
 
   while t < 80:

--- a/lib/std/sha1.nim
+++ b/lib/std/sha1.nim
@@ -34,7 +34,7 @@
 ## * `hashes module<hashes.html>`_ for efficient computations of hash values for diverse Nim types
 ## * `md5 module<md5.html>`_ implements the MD5 checksum algorithm
 
-import strutils
+import strutils, bitops
 from endians import bigEndian32, bigEndian64
 
 const Sha1DigestSize = 20

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1178,7 +1178,7 @@ proc `-`*(x: int16): int16 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int32): int32 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int64): int64 {.magic: "UnaryMinusI64", noSideEffect.}
 
-proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect.}
+proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
   ## Computes the `bitwise complement` of the integer `x`.
   ##
   ## .. code-block:: Nim
@@ -1192,13 +1192,35 @@ proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect.}
   ##   echo not b # => -1
   ##   echo not c # => 64535
   ##   echo not d # => -1001
-proc `not`*(x: int8): int8 {.magic: "BitnotI", noSideEffect.}
-proc `not`*(x: int16): int16 {.magic: "BitnotI", noSideEffect.}
-proc `not`*(x: int32): int32 {.magic: "BitnotI", noSideEffect.}
+proc `not`*(x: int8): int8 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+proc `not`*(x: int16): int16 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+proc `not`*(x: int32): int32 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
 when defined(nimnomagic64):
-  proc `not`*(x: int64): int64 {.magic: "BitnotI", noSideEffect.}
+  proc `not`*(x: int64): int64 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
 else:
-  proc `not`*(x: int64): int64 {.magic: "BitnotI64", noSideEffect.}
+  proc `not`*(x: int64): int64 {.magic: "BitnotI64", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+
+proc bitnot*(x: int): int {.magic: "BitnotI", noSideEffect.}
+  ## Computes the `bitwise complement` of the integer `x`.
+  ##
+  ## .. code-block:: Nim
+  ##   var
+  ##     a = 0'u8
+  ##     b = 0'i8
+  ##     c = 1000'u16
+  ##     d = 1000'i16
+  ##
+  ##   echo not a # => 255
+  ##   echo not b # => -1
+  ##   echo not c # => 64535
+  ##   echo not d # => -1001
+proc bitnot*(x: int8): int8 {.magic: "BitnotI", noSideEffect.}
+proc bitnot*(x: int16): int16 {.magic: "BitnotI", noSideEffect.}
+proc bitnot*(x: int32): int32 {.magic: "BitnotI", noSideEffect.}
+when defined(nimnomagic64):
+  proc bitnot*(x: int64): int64 {.magic: "BitnotI", noSideEffect.}
+else:
+  proc bitnot*(x: int64): int64 {.magic: "BitnotI64", noSideEffect.}
 
 proc `+`*(x, y: int): int {.magic: "AddI", noSideEffect.}
   ## Binary `+` operator for an integer.
@@ -1358,32 +1380,65 @@ proc `and`*(x, y: int): int {.magic: "BitandI", noSideEffect.}
   ## .. code-block:: Nim
   ##   (0b0011 and 0b0101) == 0b0001
   ##   (0b0111 and 0b1100) == 0b0100
-proc `and`*(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}
-proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
-proc `and`*(x, y: int32): int32 {.magic: "BitandI", noSideEffect.}
-proc `and`*(x, y: int64): int64 {.magic: "BitandI", noSideEffect.}
+proc `and`*(x, y: int8): int8 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
+proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
+proc `and`*(x, y: int32): int32 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
+proc `and`*(x, y: int64): int64 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
 
-proc `or`*(x, y: int): int {.magic: "BitorI", noSideEffect.}
+proc bitand*(x, y: int): int {.magic: "BitandI", noSideEffect.}
+  ## Computes the `bitwise and` of numbers `x` and `y`.
+  ##
+  ## .. code-block:: Nim
+  ##   (0b0011 and 0b0101) == 0b0001
+  ##   (0b0111 and 0b1100) == 0b0100
+proc bitand*(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}
+proc bitand*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
+proc bitand*(x, y: int32): int32 {.magic: "BitandI", noSideEffect.}
+proc bitand*(x, y: int64): int64 {.magic: "BitandI", noSideEffect.}
+
+proc `or`*(x, y: int): int {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
   ## Computes the `bitwise or` of numbers `x` and `y`.
   ##
   ## .. code-block:: Nim
   ##   (0b0011 or 0b0101) == 0b0111
   ##   (0b0111 or 0b1100) == 0b1111
-proc `or`*(x, y: int8): int8 {.magic: "BitorI", noSideEffect.}
-proc `or`*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
-proc `or`*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
-proc `or`*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
+proc `or`*(x, y: int8): int8 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
+proc `or`*(x, y: int16): int16 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
+proc `or`*(x, y: int32): int32 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
+proc `or`*(x, y: int64): int64 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
 
-proc `xor`*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
+proc bitor*(x, y: int): int {.magic: "BitorI", noSideEffect.}
+  ## Computes the `bitwise or` of numbers `x` and `y`.
+  ##
+  ## .. code-block:: Nim
+  ##   (0b0011 or 0b0101) == 0b0111
+  ##   (0b0111 or 0b1100) == 0b1111
+proc bitor*(x, y: int8): int8 {.magic: "BitorI", noSideEffect.}
+proc bitor*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
+proc bitor*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
+proc bitor*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
+
+proc `xor`*(x, y: int): int {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
   ##
   ## .. code-block:: Nim
   ##   (0b0011 xor 0b0101) == 0b0110
   ##   (0b0111 xor 0b1100) == 0b1011
-proc `xor`*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect.}
-proc `xor`*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect.}
-proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
-proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
+proc `xor`*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+proc `xor`*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+
+proc bitxor*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
+  ## Computes the `bitwise xor` of numbers `x` and `y`.
+  ##
+  ## .. code-block:: Nim
+  ##   (0b0011 xor 0b0101) == 0b0110
+  ##   (0b0111 xor 0b1100) == 0b1011
+proc bitxor*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect.}
+proc bitxor*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect.}
+proc bitxor*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
+proc bitxor*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
 
 proc `==`*(x, y: int): bool {.magic: "EqI", noSideEffect.}
   ## Compares two integers for equality.
@@ -1464,7 +1519,10 @@ template `>%`*(x, y: untyped): untyped = y <% x
 
 
 # unsigned integer operations:
-proc `not`*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect.}
+proc `not`*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+  ## Computes the `bitwise complement` of the integer `x`.
+
+proc bitnot*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect.}
   ## Computes the `bitwise complement` of the integer `x`.
 
 when defined(nimNewShiftOps):
@@ -1478,13 +1536,22 @@ else:
   proc `shl`*[T: SomeUnsignedInt](x, y: T): T {.magic: "ShlI", noSideEffect.}
     ## Computes the `shift left` operation of `x` and `y`.
 
-proc `and`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect.}
+proc `and`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
   ## Computes the `bitwise and` of numbers `x` and `y`.
 
-proc `or`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect.}
+proc bitand*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect.}
+  ## Computes the `bitwise and` of numbers `x` and `y`.
+
+proc `or`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
   ## Computes the `bitwise or` of numbers `x` and `y`.
 
-proc `xor`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect.}
+proc bitor*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect.}
+  ## Computes the `bitwise or` of numbers `x` and `y`.
+
+proc `xor`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+  ## Computes the `bitwise xor` of numbers `x` and `y`.
+
+proc bitxor*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect.}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
 
 proc `==`*[T: SomeUnsignedInt](x, y: T): bool {.magic: "EqI", noSideEffect.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1192,13 +1192,13 @@ proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bi
   ##   echo not b # => -1
   ##   echo not c # => 64535
   ##   echo not d # => -1001
-proc `not`*(x: int8): int8 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
-proc `not`*(x: int16): int16 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
-proc `not`*(x: int32): int32 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+proc `not`*(x: int8): int8 {.magic: "BitnotI", noSideEffect.}
+proc `not`*(x: int16): int16 {.magic: "BitnotI", noSideEffect.}
+proc `not`*(x: int32): int32 {.magic: "BitnotI", noSideEffect.}
 when defined(nimnomagic64):
-  proc `not`*(x: int64): int64 {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+  proc `not`*(x: int64): int64 {.magic: "BitnotI", noSideEffect.}
 else:
-  proc `not`*(x: int64): int64 {.magic: "BitnotI64", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+  proc `not`*(x: int64): int64 {.magic: "BitnotI64", noSideEffect.}
 
 proc bitnot*(x: int): int {.magic: "BitnotI", noSideEffect.}
   ## Computes the `bitwise complement` of the integer `x`.
@@ -1380,10 +1380,10 @@ proc `and`*(x, y: int): int {.magic: "BitandI", noSideEffect.}
   ## .. code-block:: Nim
   ##   (0b0011 and 0b0101) == 0b0001
   ##   (0b0111 and 0b1100) == 0b0100
-proc `and`*(x, y: int8): int8 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
-proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
-proc `and`*(x, y: int32): int32 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
-proc `and`*(x, y: int64): int64 {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
+proc `and`*(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}
+proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
+proc `and`*(x, y: int32): int32 {.magic: "BitandI", noSideEffect.}
+proc `and`*(x, y: int64): int64 {.magic: "BitandI", noSideEffect.}
 
 proc bitand*(x, y: int): int {.magic: "BitandI", noSideEffect.}
   ## Computes the `bitwise and` of numbers `x` and `y`.
@@ -1402,10 +1402,10 @@ proc `or`*(x, y: int): int {.magic: "BitorI", noSideEffect, deprecated: "Use ``b
   ## .. code-block:: Nim
   ##   (0b0011 or 0b0101) == 0b0111
   ##   (0b0111 or 0b1100) == 0b1111
-proc `or`*(x, y: int8): int8 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
-proc `or`*(x, y: int16): int16 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
-proc `or`*(x, y: int32): int32 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
-proc `or`*(x, y: int64): int64 {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
+proc `or`*(x, y: int8): int8 {.magic: "BitorI", noSideEffect.}
+proc `or`*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
+proc `or`*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
+proc `or`*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
 
 proc bitor*(x, y: int): int {.magic: "BitorI", noSideEffect.}
   ## Computes the `bitwise or` of numbers `x` and `y`.
@@ -1418,16 +1418,16 @@ proc bitor*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
 proc bitor*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
 proc bitor*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
 
-proc `xor`*(x, y: int): int {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+proc `xor`*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
   ##
   ## .. code-block:: Nim
   ##   (0b0011 xor 0b0101) == 0b0110
   ##   (0b0111 xor 0b1100) == 0b1011
-proc `xor`*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
-proc `xor`*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
-proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
-proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+proc `xor`*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect.}
+proc `xor`*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect.}
+proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
+proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
 
 proc bitxor*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
@@ -1519,7 +1519,7 @@ template `>%`*(x, y: untyped): untyped = y <% x
 
 
 # unsigned integer operations:
-proc `not`*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+proc `not`*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect.}
   ## Computes the `bitwise complement` of the integer `x`.
 
 proc bitnot*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect.}
@@ -1536,19 +1536,19 @@ else:
   proc `shl`*[T: SomeUnsignedInt](x, y: T): T {.magic: "ShlI", noSideEffect.}
     ## Computes the `shift left` operation of `x` and `y`.
 
-proc `and`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect, deprecated: "Use ``bitand`` proc instead.".}
+proc `and`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect.}
   ## Computes the `bitwise and` of numbers `x` and `y`.
 
 proc bitand*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect.}
   ## Computes the `bitwise and` of numbers `x` and `y`.
 
-proc `or`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
+proc `or`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect.}
   ## Computes the `bitwise or` of numbers `x` and `y`.
 
 proc bitor*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect.}
   ## Computes the `bitwise or` of numbers `x` and `y`.
 
-proc `xor`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect, deprecated: "Use ``bitxor`` proc instead.".}
+proc `xor`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect.}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
 
 proc bitxor*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -676,7 +676,7 @@ when not defined(JS) and not defined(gcDestructors):
 when not defined(JS) and not defined(nimscript):
   when not defined(gcDestructors):
     template space(s: PGenericSeq): int {.dirty.} =
-      bitand(s.reserved, bitnot(bitor(seqShallowFlag, strlitFlag)))
+      `and`(s.reserved, not(`or`(seqShallowFlag, strlitFlag)))
   when not defined(nimV2):
     include "system/hti"
 
@@ -1178,7 +1178,7 @@ proc `-`*(x: int16): int16 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int32): int32 {.magic: "UnaryMinusI", noSideEffect.}
 proc `-`*(x: int64): int64 {.magic: "UnaryMinusI64", noSideEffect.}
 
-proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect, deprecated: "Use ``bitnot`` proc instead.".}
+proc `not`*(x: int): int {.magic: "BitnotI", noSideEffect.}
   ## Computes the `bitwise complement` of the integer `x`.
   ##
   ## .. code-block:: Nim
@@ -1199,28 +1199,6 @@ when defined(nimnomagic64):
   proc `not`*(x: int64): int64 {.magic: "BitnotI", noSideEffect.}
 else:
   proc `not`*(x: int64): int64 {.magic: "BitnotI64", noSideEffect.}
-
-proc bitnot*(x: int): int {.magic: "BitnotI", noSideEffect.}
-  ## Computes the `bitwise complement` of the integer `x`.
-  ##
-  ## .. code-block:: Nim
-  ##   var
-  ##     a = 0'u8
-  ##     b = 0'i8
-  ##     c = 1000'u16
-  ##     d = 1000'i16
-  ##
-  ##   echo not a # => 255
-  ##   echo not b # => -1
-  ##   echo not c # => 64535
-  ##   echo not d # => -1001
-proc bitnot*(x: int8): int8 {.magic: "BitnotI", noSideEffect.}
-proc bitnot*(x: int16): int16 {.magic: "BitnotI", noSideEffect.}
-proc bitnot*(x: int32): int32 {.magic: "BitnotI", noSideEffect.}
-when defined(nimnomagic64):
-  proc bitnot*(x: int64): int64 {.magic: "BitnotI", noSideEffect.}
-else:
-  proc bitnot*(x: int64): int64 {.magic: "BitnotI64", noSideEffect.}
 
 proc `+`*(x, y: int): int {.magic: "AddI", noSideEffect.}
   ## Binary `+` operator for an integer.
@@ -1385,18 +1363,7 @@ proc `and`*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: int32): int32 {.magic: "BitandI", noSideEffect.}
 proc `and`*(x, y: int64): int64 {.magic: "BitandI", noSideEffect.}
 
-proc bitand*(x, y: int): int {.magic: "BitandI", noSideEffect.}
-  ## Computes the `bitwise and` of numbers `x` and `y`.
-  ##
-  ## .. code-block:: Nim
-  ##   (0b0011 and 0b0101) == 0b0001
-  ##   (0b0111 and 0b1100) == 0b0100
-proc bitand*(x, y: int8): int8 {.magic: "BitandI", noSideEffect.}
-proc bitand*(x, y: int16): int16 {.magic: "BitandI", noSideEffect.}
-proc bitand*(x, y: int32): int32 {.magic: "BitandI", noSideEffect.}
-proc bitand*(x, y: int64): int64 {.magic: "BitandI", noSideEffect.}
-
-proc `or`*(x, y: int): int {.magic: "BitorI", noSideEffect, deprecated: "Use ``bitor`` proc instead.".}
+proc `or`*(x, y: int): int {.magic: "BitorI", noSideEffect.}
   ## Computes the `bitwise or` of numbers `x` and `y`.
   ##
   ## .. code-block:: Nim
@@ -1406,17 +1373,6 @@ proc `or`*(x, y: int8): int8 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
 proc `or`*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
-
-proc bitor*(x, y: int): int {.magic: "BitorI", noSideEffect.}
-  ## Computes the `bitwise or` of numbers `x` and `y`.
-  ##
-  ## .. code-block:: Nim
-  ##   (0b0011 or 0b0101) == 0b0111
-  ##   (0b0111 or 0b1100) == 0b1111
-proc bitor*(x, y: int8): int8 {.magic: "BitorI", noSideEffect.}
-proc bitor*(x, y: int16): int16 {.magic: "BitorI", noSideEffect.}
-proc bitor*(x, y: int32): int32 {.magic: "BitorI", noSideEffect.}
-proc bitor*(x, y: int64): int64 {.magic: "BitorI", noSideEffect.}
 
 proc `xor`*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
@@ -1428,17 +1384,6 @@ proc `xor`*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
-
-proc bitxor*(x, y: int): int {.magic: "BitxorI", noSideEffect.}
-  ## Computes the `bitwise xor` of numbers `x` and `y`.
-  ##
-  ## .. code-block:: Nim
-  ##   (0b0011 xor 0b0101) == 0b0110
-  ##   (0b0111 xor 0b1100) == 0b1011
-proc bitxor*(x, y: int8): int8 {.magic: "BitxorI", noSideEffect.}
-proc bitxor*(x, y: int16): int16 {.magic: "BitxorI", noSideEffect.}
-proc bitxor*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
-proc bitxor*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
 
 proc `==`*(x, y: int): bool {.magic: "EqI", noSideEffect.}
   ## Compares two integers for equality.
@@ -1522,9 +1467,6 @@ template `>%`*(x, y: untyped): untyped = y <% x
 proc `not`*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect.}
   ## Computes the `bitwise complement` of the integer `x`.
 
-proc bitnot*[T: SomeUnsignedInt](x: T): T {.magic: "BitnotI", noSideEffect.}
-  ## Computes the `bitwise complement` of the integer `x`.
-
 when defined(nimNewShiftOps):
   proc `shr`*[T: SomeUnsignedInt](x: T, y: SomeInteger): T {.magic: "ShrI", noSideEffect.}
     ## Computes the `shift right` operation of `x` and `y`.
@@ -1539,19 +1481,10 @@ else:
 proc `and`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect.}
   ## Computes the `bitwise and` of numbers `x` and `y`.
 
-proc bitand*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitandI", noSideEffect.}
-  ## Computes the `bitwise and` of numbers `x` and `y`.
-
 proc `or`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect.}
   ## Computes the `bitwise or` of numbers `x` and `y`.
 
-proc bitor*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitorI", noSideEffect.}
-  ## Computes the `bitwise or` of numbers `x` and `y`.
-
 proc `xor`*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect.}
-  ## Computes the `bitwise xor` of numbers `x` and `y`.
-
-proc bitxor*[T: SomeUnsignedInt](x, y: T): T {.magic: "BitxorI", noSideEffect.}
   ## Computes the `bitwise xor` of numbers `x` and `y`.
 
 proc `==`*[T: SomeUnsignedInt](x, y: T): bool {.magic: "EqI", noSideEffect.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -676,7 +676,7 @@ when not defined(JS) and not defined(gcDestructors):
 when not defined(JS) and not defined(nimscript):
   when not defined(gcDestructors):
     template space(s: PGenericSeq): int {.dirty.} =
-      s.reserved and not (seqShallowFlag or strlitFlag)
+      bitand(s.reserved, bitnot(bitor(seqShallowFlag, strlitFlag)))
   when not defined(nimV2):
     include "system/hti"
 

--- a/lib/system/arithm.nim
+++ b/lib/system/arithm.nim
@@ -73,13 +73,13 @@ when defined(builtinOverflow):
 else:
   proc addInt64(a, b: int64): int64 {.compilerProc, inline.} =
     result = a +% b
-    if bitxor(result, a) >= int64(0) or bitxor(result, b) >= int64(0):
+    if `xor`(result, a) >= int64(0) or `xor`(result, b) >= int64(0):
       return result
     raiseOverflow()
 
   proc subInt64(a, b: int64): int64 {.compilerProc, inline.} =
     result = a -% b
-    if bitxor(result, a) >= int64(0) or bitxor(result, bitnot(b)) >= int64(0):
+    if `xor`(result, a) >= int64(0) or `xor`(result, not(b)) >= int64(0):
       return result
     raiseOverflow()
 
@@ -332,14 +332,14 @@ when not declared(mulInt) and defined(builtinOverflow):
 when not declared(addInt):
   proc addInt(a, b: int): int {.compilerProc, inline.} =
     result = a +% b
-    if bitxor(result, a) >= 0 or bitxor(result, b) >= 0:
+    if `xor`(result, a) >= 0 or `xor`(result, b) >= 0:
       return result
     raiseOverflow()
 
 when not declared(subInt):
   proc subInt(a, b: int): int {.compilerProc, inline.} =
     result = a -% b
-    if bitxor(result, a) >= 0 or bitxor(result, bitnot(b)) >= 0:
+    if `xor`(result, a) >= 0 or `xor`(result, not(b)) >= 0:
       return result
     raiseOverflow()
 

--- a/lib/system/arithm.nim
+++ b/lib/system/arithm.nim
@@ -73,13 +73,13 @@ when defined(builtinOverflow):
 else:
   proc addInt64(a, b: int64): int64 {.compilerProc, inline.} =
     result = a +% b
-    if (result xor a) >= int64(0) or (result xor b) >= int64(0):
+    if bitxor(result, a) >= int64(0) or bitxor(result, b) >= int64(0):
       return result
     raiseOverflow()
 
   proc subInt64(a, b: int64): int64 {.compilerProc, inline.} =
     result = a -% b
-    if (result xor a) >= int64(0) or (result xor not b) >= int64(0):
+    if bitxor(result, a) >= int64(0) or bitxor(result, bitnot(b)) >= int64(0):
       return result
     raiseOverflow()
 
@@ -332,14 +332,14 @@ when not declared(mulInt) and defined(builtinOverflow):
 when not declared(addInt):
   proc addInt(a, b: int): int {.compilerProc, inline.} =
     result = a +% b
-    if (result xor a) >= 0 or (result xor b) >= 0:
+    if bitxor(result, a) >= 0 or bitxor(result, b) >= 0:
       return result
     raiseOverflow()
 
 when not declared(subInt):
   proc subInt(a, b: int): int {.compilerProc, inline.} =
     result = a -% b
-    if (result xor a) >= 0 or (result xor not b) >= 0:
+    if bitxor(result, a) >= 0 or bitxor(result, bitnot(b)) >= 0:
       return result
     raiseOverflow()
 

--- a/lib/system/cellsets.nim
+++ b/lib/system/cellsets.nim
@@ -150,7 +150,7 @@ proc contains(s: CellSet, cell: PCell): bool =
   var t = cellSetGet(s, u shr PageShift)
   if t != nil:
     u = (u mod PageSize) div MemAlign
-    result = bitand(t.bits[u shr IntShift], 1 shl bitand(u, IntMask)) != 0
+    result = `and`(t.bits[u shr IntShift], 1 shl `and`(u, IntMask)) != 0
   else:
     result = false
 
@@ -158,7 +158,7 @@ proc incl(s: var CellSet, cell: PCell) {.noinline.} =
   var u = cast[uint](cell)
   var t = cellSetPut(s, u shr PageShift)
   u = (u mod PageSize) div MemAlign
-  t.bits[u shr IntShift] = bitor(t.bits[u shr IntShift], 1 shl bitand(u, IntMask))
+  t.bits[u shr IntShift] = `or`(t.bits[u shr IntShift], 1 shl `and`(u, IntMask))
 
 proc excl(s: var CellSet, cell: PCell) =
   var u = cast[uint](cell)
@@ -166,18 +166,18 @@ proc excl(s: var CellSet, cell: PCell) =
   if t != nil:
     u = (u mod PageSize) div MemAlign
     t.bits[u shr IntShift] = (t.bits[u shr IntShift] and
-                              bitnot(1 shl bitand(u, IntMask)))
+                              not(1 shl `and`(u, IntMask)))
 
 proc containsOrIncl(s: var CellSet, cell: PCell): bool =
   var u = cast[uint](cell)
   var t = cellSetGet(s, u shr PageShift)
   if t != nil:
     u = (u mod PageSize) div MemAlign
-    result = bitand(t.bits[u shr IntShift], 1 shl bitand(u, IntMask)) != 0
+    result = `and`(t.bits[u shr IntShift], 1 shl `and`(u, IntMask)) != 0
     if not result:
-      t.bits[u shr IntShift] = bitor(
+      t.bits[u shr IntShift] = `or`(
         t.bits[u shr IntShift],
-        1 shl bitand(u, IntMask))
+        1 shl `and`(u, IntMask))
   else:
     incl(s, cell)
     result = false
@@ -193,7 +193,7 @@ iterator elements(t: CellSet): PCell {.inline.} =
       var j: uint = 0
       while w != 0:         # test all remaining bits for zero
         if (w and 1) != 0:  # the bit is set!
-          yield cast[PCell](bitor(r.key shl PageShift,(i shl IntShift + j) * MemAlign))
+          yield cast[PCell](`or`(r.key shl PageShift,(i shl IntShift + j) * MemAlign))
         inc(j)
         w = w shr 1
       inc(i)
@@ -242,11 +242,11 @@ iterator elementsExcept(t, s: CellSet): PCell {.inline.} =
     while int(i) <= high(r.bits):
       var w = r.bits[i]
       if ss != nil:
-        w = bitand(w, bitnot(ss.bits[i]))
+        w = `and`(w, not(ss.bits[i]))
       var j:uint = 0
       while w != 0:
         if (w and 1) != 0:
-          yield cast[PCell](bitor(r.key shl PageShift, (i shl IntShift + j) * MemAlign))
+          yield cast[PCell](`or`(r.key shl PageShift, (i shl IntShift + j) * MemAlign))
         inc(j)
         w = w shr 1
       inc(i)

--- a/lib/system/cellsets.nim
+++ b/lib/system/cellsets.nim
@@ -150,7 +150,7 @@ proc contains(s: CellSet, cell: PCell): bool =
   var t = cellSetGet(s, u shr PageShift)
   if t != nil:
     u = (u mod PageSize) div MemAlign
-    result = (t.bits[u shr IntShift] and (1 shl (u and IntMask))) != 0
+    result = bitand(t.bits[u shr IntShift], 1 shl bitand(u, IntMask)) != 0
   else:
     result = false
 
@@ -158,7 +158,7 @@ proc incl(s: var CellSet, cell: PCell) {.noinline.} =
   var u = cast[uint](cell)
   var t = cellSetPut(s, u shr PageShift)
   u = (u mod PageSize) div MemAlign
-  t.bits[u shr IntShift] = t.bits[u shr IntShift] or (1 shl (u and IntMask))
+  t.bits[u shr IntShift] = bitor(t.bits[u shr IntShift], 1 shl bitand(u, IntMask))
 
 proc excl(s: var CellSet, cell: PCell) =
   var u = cast[uint](cell)
@@ -166,17 +166,18 @@ proc excl(s: var CellSet, cell: PCell) =
   if t != nil:
     u = (u mod PageSize) div MemAlign
     t.bits[u shr IntShift] = (t.bits[u shr IntShift] and
-                              not (1 shl (u and IntMask)))
+                              bitnot(1 shl bitand(u, IntMask)))
 
 proc containsOrIncl(s: var CellSet, cell: PCell): bool =
   var u = cast[uint](cell)
   var t = cellSetGet(s, u shr PageShift)
   if t != nil:
     u = (u mod PageSize) div MemAlign
-    result = (t.bits[u shr IntShift] and (1 shl (u and IntMask))) != 0
+    result = bitand(t.bits[u shr IntShift], 1 shl bitand(u, IntMask)) != 0
     if not result:
-      t.bits[u shr IntShift] = t.bits[u shr IntShift] or
-          (1 shl (u and IntMask))
+      t.bits[u shr IntShift] = bitor(
+        t.bits[u shr IntShift],
+        1 shl bitand(u, IntMask))
   else:
     incl(s, cell)
     result = false
@@ -192,8 +193,7 @@ iterator elements(t: CellSet): PCell {.inline.} =
       var j: uint = 0
       while w != 0:         # test all remaining bits for zero
         if (w and 1) != 0:  # the bit is set!
-          yield cast[PCell]((r.key shl PageShift) or
-                              (i shl IntShift + j) * MemAlign)
+          yield cast[PCell](bitor(r.key shl PageShift,(i shl IntShift + j) * MemAlign))
         inc(j)
         w = w shr 1
       inc(i)
@@ -242,12 +242,11 @@ iterator elementsExcept(t, s: CellSet): PCell {.inline.} =
     while int(i) <= high(r.bits):
       var w = r.bits[i]
       if ss != nil:
-        w = w and not ss.bits[i]
+        w = bitand(w, bitnot(ss.bits[i]))
       var j:uint = 0
       while w != 0:
         if (w and 1) != 0:
-          yield cast[PCell]((r.key shl PageShift) or
-                              (i shl IntShift + j) * MemAlign)
+          yield cast[PCell](bitor(r.key shl PageShift, (i shl IntShift + j) * MemAlign))
         inc(j)
         w = w shr 1
       inc(i)

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -117,7 +117,7 @@ template gcAssert(cond: bool, msg: string) =
 
 proc addZCT(s: var CellSeq, c: PCell) {.noinline.} =
   if (c.refcount and ZctFlag) == 0:
-    c.refcount = c.refcount or ZctFlag
+    c.refcount = bitor(c.refcount, ZctFlag)
     add(s, c)
 
 proc cellToUsr(cell: PCell): pointer {.inline.} =
@@ -360,7 +360,7 @@ proc addNewObjToZCT(res: PCell, gch: var GcHeap) {.inline.} =
     template replaceZctEntry(i: untyped) =
       c = d[i]
       if c.refcount >=% rcIncrement:
-        c.refcount = c.refcount and not ZctFlag
+        c.refcount = bitand(c.refcount, bitnot(ZctFlag))
         d[i] = res
         return
     if L > 8:
@@ -701,7 +701,7 @@ proc collectZCT(gch: var GcHeap): bool =
     # remove from ZCT:
     gcAssert((c.refcount and ZctFlag) == ZctFlag, "collectZCT")
 
-    c.refcount = c.refcount and not ZctFlag
+    c.refcount = bitand(c.refcount, bitnot(ZctFlag))
     gch.zct.d[0] = gch.zct.d[L[] - 1]
     dec(L[])
     when withRealTime: dec steps

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -117,7 +117,7 @@ template gcAssert(cond: bool, msg: string) =
 
 proc addZCT(s: var CellSeq, c: PCell) {.noinline.} =
   if (c.refcount and ZctFlag) == 0:
-    c.refcount = bitor(c.refcount, ZctFlag)
+    c.refcount = `or`(c.refcount, ZctFlag)
     add(s, c)
 
 proc cellToUsr(cell: PCell): pointer {.inline.} =
@@ -360,7 +360,7 @@ proc addNewObjToZCT(res: PCell, gch: var GcHeap) {.inline.} =
     template replaceZctEntry(i: untyped) =
       c = d[i]
       if c.refcount >=% rcIncrement:
-        c.refcount = bitand(c.refcount, bitnot(ZctFlag))
+        c.refcount = `and`(c.refcount, not(ZctFlag))
         d[i] = res
         return
     if L > 8:
@@ -701,7 +701,7 @@ proc collectZCT(gch: var GcHeap): bool =
     # remove from ZCT:
     gcAssert((c.refcount and ZctFlag) == ZctFlag, "collectZCT")
 
-    c.refcount = bitand(c.refcount, bitnot(ZctFlag))
+    c.refcount = `and`(c.refcount, not(ZctFlag))
     gch.zct.d[0] = gch.zct.d[L[] - 1]
     dec(L[])
     when withRealTime: dec steps

--- a/lib/system/gc_common.nim
+++ b/lib/system/gc_common.nim
@@ -378,7 +378,7 @@ else:
               gcMark(gch, cast[PPointer](sp +% sizeof(pointer) div 2)[])
               sp = sp +% sizeof(pointer)
         # Make sure sp is word-aligned
-        sp = bitand(sp, bitnot(sizeof(pointer) - 1))
+        sp = `and`(sp, not(sizeof(pointer) - 1))
         # loop unrolled:
         while sp <% max - 8*sizeof(pointer):
           gcMark(gch, cast[PStackSlice](sp)[0])

--- a/lib/system/gc_common.nim
+++ b/lib/system/gc_common.nim
@@ -378,7 +378,7 @@ else:
               gcMark(gch, cast[PPointer](sp +% sizeof(pointer) div 2)[])
               sp = sp +% sizeof(pointer)
         # Make sure sp is word-aligned
-        sp = sp and not (sizeof(pointer) - 1)
+        sp = bitand(sp, bitnot(sizeof(pointer) - 1))
         # loop unrolled:
         while sp <% max - 8*sizeof(pointer):
           gcMark(gch, cast[PStackSlice](sp)[0])

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -8,7 +8,7 @@
 #
 
 proc roundup(x, v: int): int {.inline.} =
-  result = (x + (v-1)) and not (v-1)
+  result = (x + (v-1)) and bitnot(v-1)
   sysAssert(result >= x, "roundup: result < x")
   #return ((-x) and (v-1)) +% x
 
@@ -221,14 +221,14 @@ elif defined(posix):
   proc munmap(adr: pointer, len: csize): cint {.header: "<sys/mman.h>".}
 
   proc osAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, PROT_READ or PROT_WRITE,
-                             MAP_PRIVATE or MAP_ANONYMOUS, -1, 0)
+    result = mmap(nil, size, bitor(PROT_READ, PROT_WRITE),
+                             bitor(MAP_PRIVATE, MAP_ANONYMOUS), -1, 0)
     if result == nil or result == cast[pointer](-1):
       raiseOutOfMem()
 
   proc osTryAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, PROT_READ or PROT_WRITE,
-                             MAP_PRIVATE or MAP_ANONYMOUS, -1, 0)
+    result = mmap(nil, size, bitor(PROT_READ, PROT_WRITE),
+                             bitor(MAP_PRIVATE, MAP_ANONYMOUS), -1, 0)
     if result == cast[pointer](-1): result = nil
 
   proc osDeallocPages(p: pointer, size: int) {.inline.} =

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -8,7 +8,7 @@
 #
 
 proc roundup(x, v: int): int {.inline.} =
-  result = (x + (v-1)) and bitnot(v-1)
+  result = (x + (v-1)) and not(v-1)
   sysAssert(result >= x, "roundup: result < x")
   #return ((-x) and (v-1)) +% x
 
@@ -221,14 +221,14 @@ elif defined(posix):
   proc munmap(adr: pointer, len: csize): cint {.header: "<sys/mman.h>".}
 
   proc osAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, bitor(PROT_READ, PROT_WRITE),
-                             bitor(MAP_PRIVATE, MAP_ANONYMOUS), -1, 0)
+    result = mmap(nil, size, `or`(PROT_READ, PROT_WRITE),
+                             `or`(MAP_PRIVATE, MAP_ANONYMOUS), -1, 0)
     if result == nil or result == cast[pointer](-1):
       raiseOutOfMem()
 
   proc osTryAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, bitor(PROT_READ, PROT_WRITE),
-                             bitor(MAP_PRIVATE, MAP_ANONYMOUS), -1, 0)
+    result = mmap(nil, size, `or`(PROT_READ, PROT_WRITE),
+                             `or`(MAP_PRIVATE, MAP_ANONYMOUS), -1, 0)
     if result == cast[pointer](-1): result = nil
 
   proc osDeallocPages(p: pointer, size: int) {.inline.} =

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -104,13 +104,13 @@ proc reprSetAux(result: var string, p: pointer, typ: PNimType) =
   else:
     var a = cast[PByteArray](p)
     for i in 0 .. typ.size*8-1:
-      if bitand(ze(a[i div 8]), 1 shl (i mod 8)) != 0:
+      if `and`(ze(a[i div 8]), 1 shl (i mod 8)) != 0:
         if elemCounter > 0: add result, ", "
         addSetElem(result, i+typ.node.len, typ.base)
         inc(elemCounter)
   if typ.size <= 8:
     for i in 0..sizeof(int64)*8-1:
-      if bitand(u, 1'u64 shl uint64(i)) != 0'u64:
+      if `and`(u, 1'u64 shl uint64(i)) != 0'u64:
         if elemCounter > 0: add result, ", "
         addSetElem(result, i+typ.node.len, typ.base)
         inc(elemCounter)

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -104,13 +104,13 @@ proc reprSetAux(result: var string, p: pointer, typ: PNimType) =
   else:
     var a = cast[PByteArray](p)
     for i in 0 .. typ.size*8-1:
-      if (ze(a[i div 8]) and (1 shl (i mod 8))) != 0:
+      if bitand(ze(a[i div 8]), 1 shl (i mod 8)) != 0:
         if elemCounter > 0: add result, ", "
         addSetElem(result, i+typ.node.len, typ.base)
         inc(elemCounter)
   if typ.size <= 8:
     for i in 0..sizeof(int64)*8-1:
-      if (u and (1'u64 shl uint64(i))) != 0'u64:
+      if bitand(u, 1'u64 shl uint64(i)) != 0'u64:
         if elemCounter > 0: add result, ", "
         addSetElem(result, i+typ.node.len, typ.base)
         inc(elemCounter)

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -17,17 +17,17 @@ type
 proc countBits32(n: uint32): int {.compilerproc.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint32(n)
-  v = v - ((v shr 1) and 0x55555555)
-  v = (v and 0x33333333) + ((v shr 2) and 0x33333333)
-  result = (((v + (v shr 4) and 0xF0F0F0F) * 0x1010101) shr 24).int
+  v = v - bitand(v shr 1, 0x55555555)
+  v = bitand(v, 0x33333333) + bitand(v shr 2, 0x33333333)
+  result = int((bitand(v + v shr 4, 0xF0F0F0F) * 0x1010101) shr 24)
 
 proc countBits64(n: uint64): int {.compilerproc.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint64(n)
-  v = v - ((v shr 1'u64) and 0x5555555555555555'u64)
-  v = (v and 0x3333333333333333'u64) + ((v shr 2'u64) and 0x3333333333333333'u64)
-  v = (v + (v shr 4'u64) and 0x0F0F0F0F0F0F0F0F'u64)
-  result = ((v * 0x0101010101010101'u64) shr 56'u64).int
+  v = v - bitand(v shr 1'u64, 0x5555555555555555'u64)
+  v = bitand(v, 0x3333333333333333'u64) + bitand(v shr 2'u64, 0x3333333333333333'u64)
+  v = bitand(v + (v shr 4'u64), 0x0F0F0F0F0F0F0F0F'u64)
+  result = int((v * 0x0101010101010101'u64) shr 56'u64)
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
   for i in 0..<len:

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -17,16 +17,16 @@ type
 proc countBits32(n: uint32): int {.compilerproc.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint32(n)
-  v = v - bitand(v shr 1, 0x55555555)
-  v = bitand(v, 0x33333333) + bitand(v shr 2, 0x33333333)
-  result = int((bitand(v + v shr 4, 0xF0F0F0F) * 0x1010101) shr 24)
+  v = v - `and`(v shr 1, 0x55555555)
+  v = `and`(v, 0x33333333) + `and`(v shr 2, 0x33333333)
+  result = int((`and`(v + v shr 4, 0xF0F0F0F) * 0x1010101) shr 24)
 
 proc countBits64(n: uint64): int {.compilerproc.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint64(n)
-  v = v - bitand(v shr 1'u64, 0x5555555555555555'u64)
-  v = bitand(v, 0x3333333333333333'u64) + bitand(v shr 2'u64, 0x3333333333333333'u64)
-  v = bitand(v + (v shr 4'u64), 0x0F0F0F0F0F0F0F0F'u64)
+  v = v - `and`(v shr 1'u64, 0x5555555555555555'u64)
+  v = `and`(v, 0x3333333333333333'u64) + `and`(v shr 2'u64, 0x3333333333333333'u64)
+  v = `and`(v + (v shr 4'u64), 0x0F0F0F0F0F0F0F0F'u64)
   result = int((v * 0x0101010101010101'u64) shr 56'u64)
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -34,9 +34,9 @@ proc hashString(s: string): int {.compilerproc.} =
   for i in 0..len(s)-1:
     h = h + uint(s[i])
     h = h + h shl 10
-    h = h xor (h shr 6)
+    h = bitxor(h, h shr 6)
   h = h + h shl 3
-  h = h xor (h shr 11)
+  h = bitxor(h, h shr 11)
   h = h + h shl 15
   result = cast[int](h)
 

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -34,9 +34,9 @@ proc hashString(s: string): int {.compilerproc.} =
   for i in 0..len(s)-1:
     h = h + uint(s[i])
     h = h + h shl 10
-    h = bitxor(h, h shr 6)
+    h = `xor`(h, h shr 6)
   h = h + h shl 3
-  h = bitxor(h, h shr 11)
+  h = `xor`(h, h shr 11)
   h = h + h shl 15
   result = cast[int](h)
 


### PR DESCRIPTION
bitand and family, because it was requested.

overloads of operators are nice in the beginning. But when you realize that the operator precedence isn't made for bit operations and that you have to put braces everywhere, you really wish for the function call syntax.

```nim
a shr b and c  # operator precedence is not clear for everybody
(a and b) != 0 and (c and d) != 0 # everything is just ``and``. Which one is the bitand?
not savedPC < 0  # this is a bitnot, who whould have thought so. It is a real bug.
```


