### PR TITLE
`doNotSerialize`, `jsonName` pragmas for JSON serialization closes #8104, #10718, also fixes #11415

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1472,7 +1472,12 @@ proc customPragmaNode(n: NimNode): NimNode =
   if n.kind in {nnkDotExpr, nnkCheckedFieldExpr}:
     let name = $(if n.kind == nnkCheckedFieldExpr: n[0][1] else: n[1])
     let typInst = getTypeInst(if n.kind == nnkCheckedFieldExpr or n[0].kind == nnkHiddenDeref: n[0][0] else: n[0])
-    var typDef = getImpl(if typInst.kind == nnkVarTy: typInst[0] else: typInst)
+    var typDef = getImpl(
+      if typInst.kind == nnkVarTy or
+         typInst.kind == nnkBracketExpr:
+        typInst[0]
+      else: typInst
+    )
     while typDef != nil:
       typDef.expectKind(nnkTypeDef)
       let typ = typDef[2]

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1493,12 +1493,12 @@ proc customPragmaNode(n: NimNode): NimNode =
               let varNode = identDefs[i]
               # if it is and empty branch, skip
               if varNode[0].kind == nnkNilLit: continue
-              if varNode[1].kind == nnkIdentDefs:
-                identDefsStack.add(varNode[1])
-              else: # nnkRecList
-                for j in 0 ..< varNode[1].len:
-                  identDefsStack.add(varNode[1][j])
-
+              for j in 1 ..< varNode.len:
+                if varNode[j].kind == nnkIdentDefs:
+                  identDefsStack.add(varNode[j])
+                else: # nnkRecList
+                  for m in 0 ..< varNode[j].len:
+                    identDefsStack.add(varNode[j][m])
           else:
             for i in 0 .. identDefs.len - 3:
               let varNode = identDefs[i]

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -128,7 +128,7 @@
 ##   doAssert numJson.kind == JInt
 ##
 ## For objects it may be desirable to avoid serialization of one or more object
-## fields. This can be achieved by using the ``{.noSerialize.}`` pragma.
+## fields. This can be achieved by using the ``{.doNotSerialize.}`` pragma.
 ##
 ## .. code-block:: nim
 ##   import json
@@ -137,7 +137,7 @@
 ##     User = object
 ##       name: string
 ##       age: int
-##       uid {.noSerialize.}: int
+##       uid {.doNotSerialize.}: int
 ##
 ##    let user = User(name: "Siri", age: 7, uid: 1234)
 ##    let uJson = % user
@@ -391,28 +391,28 @@ proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
   assert(obj.kind == JObject)
   obj.fields[key] = val
 
-template noSerialize*() {.pragma.}
-  ## The `{.noSerialize.}` pragma can be attached to a field of an object to avoid
+template doNotSerialize*() {.pragma.}
+  ## The `{.doNotSerialize.}` pragma can be attached to a field of an object to avoid
   ## serialization of said field to a `JsonNode` via `%`. See the `%` proc for
   ## objects below for an example.
 
 proc `%`*[T: object](o: T): JsonNode =
   ## Construct JsonNode from tuples and objects.
   ##
-  ## An object field annotated with the `{.noSerialize.}` pragma will not appear
+  ## An object field annotated with the `{.doNotSerialize.}` pragma will not appear
   ## in the serialized JsonNode.
   runnableExamples:
     type
       User = object
         name: string
         age: int
-        uid {.noSerialize.}: int
+        uid {.doNotSerialize.}: int
     let user = User(name: "Siri", age: 7, uid: 1234)
     let uJson = % user
     doAssert not uJson.hasKey("uid")
   result = newJObject()
   for k, v in o.fieldPairs:
-    when not hasCustomPragma(v, noSerialize):
+    when not hasCustomPragma(v, doNotSerialize):
       result[k] = %v
 
 proc `%`*(o: ref object): JsonNode =

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -142,7 +142,7 @@
 ##
 ##    let user = User(name: "Siri", age: 7, uid: 1234)
 ##    let uJson = % user
-##    doAssert not uJson.hasKey(uid)
+##    doAssert not uJson.hasKey("uid")
 ##    echo uJson
 ##
 ## This module can also be used to comfortably create JSON using the ``%*``
@@ -406,7 +406,7 @@ proc `%`*[T: object](o: T): JsonNode =
         uid {.noserialize.}: int
     let user = User(name: "Siri", age: 7, uid: 1234)
     let uJson = % user
-    doAssert not uJson.hasKey(uid)
+    doAssert not uJson.hasKey("uid")
   result = newJObject()
   for k, v in o.fieldPairs:
     when not hasCustomPragma(v, noserialize):

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -124,12 +124,11 @@
 ##
 ## .. code-block:: nim
 ##   import json
-##   let number = 10
-##   let numJson = % number
+##   let numJson = %10
 ##   doAssert numJson.kind == JInt
 ##
 ## For objects it may be desirable to avoid serialization of one or more object
-## fields. This can be achieved by using the ``{.noserialize.}`` pragma.
+## fields. This can be achieved by using the ``{.noSerialize.}`` pragma.
 ##
 ## .. code-block:: nim
 ##   import json
@@ -138,7 +137,7 @@
 ##     User = object
 ##       name: string
 ##       age: int
-##       uid {.noserialize.}: int
+##       uid {.noSerialize.}: int
 ##
 ##    let user = User(name: "Siri", age: 7, uid: 1234)
 ##    let uJson = % user
@@ -392,24 +391,28 @@ proc `[]=`*(obj: JsonNode, key: string, val: JsonNode) {.inline.} =
   assert(obj.kind == JObject)
   obj.fields[key] = val
 
-template noserialize*() {.pragma.}
+template noSerialize*() {.pragma.}
+  ## The `{.noSerialize.}` pragma can be attached to a field of an object to avoid
+  ## serialization of said field to a `JsonNode` via `%`. See the `%` proc for
+  ## objects below for an example.
 
 proc `%`*[T: object](o: T): JsonNode =
   ## Construct JsonNode from tuples and objects.
-  ## An object field annotated with the `{.noserialize.}` pragma will not appear
+  ##
+  ## An object field annotated with the `{.noSerialize.}` pragma will not appear
   ## in the serialized JsonNode.
   runnableExamples:
     type
       User = object
         name: string
         age: int
-        uid {.noserialize.}: int
+        uid {.noSerialize.}: int
     let user = User(name: "Siri", age: 7, uid: 1234)
     let uJson = % user
     doAssert not uJson.hasKey("uid")
   result = newJObject()
   for k, v in o.fieldPairs:
-    when not hasCustomPragma(v, noserialize):
+    when not hasCustomPragma(v, noSerialize):
       result[k] = %v
 
 proc `%`*(o: ref object): JsonNode =

--- a/tests/macros/tcprag.nim
+++ b/tests/macros/tcprag.nim
@@ -2,6 +2,9 @@ discard """
   output: '''true
 true
 true
+true
+true
+true
 '''
 """
 
@@ -30,3 +33,56 @@ macro m2(T: typedesc): untyped =
   result = quote do:
     `T`.hasCustomPragma(table)
 echo m2(User)
+
+
+
+block:
+  template noserialize() {.pragma.}
+
+  type
+    Point[T] = object
+      x, y: T
+
+    ReplayEventKind = enum
+      FoodAppeared, FoodEaten, DirectionChanged
+
+  # ref #11415
+  # this works, since `foodPos` is inside of a variant kind with a
+  # single `of` element
+  block:
+    type
+      ReplayEvent = object
+        time: float
+        pos {.noserialize.}: Point[float] # works before fix
+        case kind: ReplayEventKind
+        of FoodEaten:
+          foodPos {.noserialize.}: Point[float] # also works, only in one branch
+        of DirectionChanged, FoodAppeared:
+          playerPos: float
+
+    let ev = ReplayEvent(
+        pos: Point[float](x: 5.0, y: 1.0),
+        time: 1.2345,
+        kind: FoodEaten,
+        foodPos: Point[float](x: 5.0, y: 1.0)
+      )
+    echo ev.pos.hasCustomPragma(noserialize)
+    echo ev.foodPos.hasCustomPragma(noserialize)
+
+  # ref 11415
+  # this did not work, since `foodPos` is inside of a variant kind with a
+  # two `of` elements
+  block:
+    type
+      ReplayEvent = object
+        case kind: ReplayEventKind
+        of FoodEaten, FoodAppeared:
+          foodPos {.noserialize.}: Point[float] # did not work, because in two branches
+        of DirectionChanged:
+          playerPos: float
+
+    let ev = ReplayEvent(
+        kind: FoodEaten,
+        foodPos: Point[float](x: 5.0, y: 1.0)
+      )
+    echo ev.foodPos.hasCustomPragma(noserialize)

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -563,7 +563,6 @@ block:
 
     let user = User(name: "Siri", age: 7, uid: 1234)
     let uJson = % user
-    echo uJson
     doAssert uJson["name"].getStr == "Siri"
     doAssert uJson["age"].getInt == 7
     doAssert not uJson.hasKey("uid")

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -559,7 +559,7 @@ block:
       User = object
         name: string
         age: int
-        uid {.noserialize.}: int
+        uid {.doNotSerialize.}: int
 
     let user = User(name: "Siri", age: 7, uid: 1234)
     let uJson = % user
@@ -573,10 +573,10 @@ block:
     type
       ReplayEvent2 = object
         time: float
-        anotherPos {.noserialize.}: Point[float]
+        anotherPos {.doNotSerialize.}: Point[float]
         case kind: ReplayEventKind
         of FoodEaten, FoodAppeared:
-          foodPos {.noserialize.}: Point[float]
+          foodPos {.doNotSerialize.}: Point[float]
         of DirectionChanged:
           playerPos: float
 


### PR DESCRIPTION
This PR adds the ability to exclude certain object fields from JSON serialization via `%`, by annotating the field with the `{.noserialize.}` pragma.

```nim
type
  User = object
    name: string
    age: int
    uid {.noserialize.}: int
let user = User(name: "Siri", age: 7, uid: 1234)
let uJson = % user
doAssert not uJson.hasKey("uid")
```

After discussion on IRC:
https://irclogs.nim-lang.org/05-06-2019.html#19:15:24
@dom96 asked me to create a PR for this.

While working on it I stumbled upon an issue with custom pragmas on variant objects: #11415.

However, to not break things, I also had to extend how `typDef` is determined in `customPragmaNode` (see https://github.com/nim-lang/Nim/pull/11416/commits/5da931fe811717a45f2dd272ea6281979c3e8f0b). This is a problem for the first test case in `tjsonmacro.nim`:
https://github.com/nim-lang/Nim/blob/devel/tests/stdlib/tjsonmacro.nim#L9-L45
Line 45 will fail with `node is not a symbol`. I couldn't really reproduce this without the `%` proc change, which is why I didn't open an issue for this as well.

#### Update: add `jsonName`

I also added a `jsonName` pragma, to customize the (de)serialization name of an object field. 

```nim
type
  User = object
    name: string
    age {.jsonName: "userAge".}: int
let user = User(name: "Siri", age: 7)
let uJson = % user
doAssert uJson["userAge"].num == 7
```

This pragma closes #10718.