### PR TITLE
fix `koch docs` failing at io.nim with `import os` in config.nims

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4450,9 +4450,8 @@ when defined(genode):
 import system/widestrs
 export widestrs
 
-when not defined(nimnoio):
-  import system/io
-  export io
+import system/io
+export io
 
 when not defined(createNimHcr):
   include nimhcr

--- a/lib/system/io.nim.cfg
+++ b/lib/system/io.nim.cfg
@@ -1,1 +1,0 @@
---define: nimnoio


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/10800

The code which has been deleted in this PR was added by @Araq here https://github.com/nim-lang/Nim/commit/1d1be03d81a380d6d2e15bd1e4a0873fe64ada5f with the message `make 'doc io.nim' work`. Apparently, removing those changes makes it work. But I dunno if it breaks something. So lets wait for the CIs to do their work.