### PR TITLE
literal array indices

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -530,6 +530,7 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
   var
     firstIndex, lastIndex: BiggestInt = 0
     indexType = getSysType(c.graph, n.info, tyInt)
+    lastInt = lastOrd(c.config, indexType)
   if sonsLen(n) == 0:
     rawAddSon(result.typ, newTypeS(tyEmpty, c)) # needs an empty basetype!
     lastIndex = -1
@@ -546,7 +547,7 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       x = x.sons[1]
 
     template unlessOverflows(body: untyped): untyped =
-      if lastIndex == high(BiggestInt):
+      if lastIndex == lastInt:
         localError(c.config, x.info, "array index too large")
       body
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -569,8 +569,10 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       result.sons[i] = fitNode(c, typ, result.sons[i], result.sons[i].info)
   let extraElems = lastIndex - lastOrd(c.config, indexType)
   if extraElems > 0:
+    let validRange = makeRangeType(c, firstIndex, lastOrd(c.config, indexType),
+                                   n.info, indexType)
     localError(c.config, n.info, "size of array exceeds range of index " &
-      "type '$1' by $2 elements" % [typeToString(indexType), $extraElems])
+      "type '$1' by $2 elements" % [typeToString(validRange), $extraElems])
   result.typ.sons[0] = makeRangeType(c, firstIndex, lastIndex, n.info,
                                      indexType)
 

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -548,3 +548,12 @@ block t3899:
     x.a[i]
   const c = O(a: [1.0,2.0])
   echo c[2]
+
+block arrayLiterals:
+  type ABC = enum A, B, C
+  template Idx[IdxT, ElemT](arr: array[IdxT, ElemT]): untyped = IdxT
+  doAssert [A: 0, B: 1].Idx is range[A..B]
+  doAssert [A: 0, 1, 3].Idx is ABC
+  doAssert [1: 2][1] == 2
+  doAssert [-1'i8: 2][-1] == 2
+  doAssert [-1'i8: 2, 3, 4, 5].Idx is range[-1'i8..2'i8]

--- a/tests/array/tidx_lit_err1.nim
+++ b/tests/array/tidx_lit_err1.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "size of array exceeds range of index type 'Color' by 3 elements"
+  line: 6
+"""
+type Color = enum Red, Green, Blue
+let y = [Green: 0, 1, 2, 3, 4]

--- a/tests/array/tidx_lit_err1.nim
+++ b/tests/array/tidx_lit_err1.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "size of array exceeds range of index type 'Color' by 3 elements"
+  errormsg: "size of array exceeds range of index type 'range 1..2(Color)' by 3 elements"
   line: 6
 """
 type Color = enum Red, Green, Blue

--- a/tests/array/tidx_lit_err2.nim
+++ b/tests/array/tidx_lit_err2.nim
@@ -1,0 +1,5 @@
+discard """
+  errormsg: "expected ordinal value for array index, got '\"string\"'"
+  line: 5
+"""
+let x = ["string": 0, "index": 1]

--- a/tests/array/tidx_lit_err3.nim
+++ b/tests/array/tidx_lit_err3.nim
@@ -1,0 +1,5 @@
+discard """
+  errormsg: "array index too large"
+  line: 5
+"""
+echo [high(int)-1: 1, 2, 3]

--- a/tests/array/tidx_lit_err3.nim
+++ b/tests/array/tidx_lit_err3.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "array index too large"
+  errormsg: "size of array exceeds range of index type 'range 9223372036854775806..9223372036854775807(int)' by 1 elements"
   line: 5
 """
 echo [high(int)-1: 1, 2, 3]

--- a/tests/array/tidx_lit_err3.nim
+++ b/tests/array/tidx_lit_err3.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "size of array exceeds range of index type 'range 9223372036854775806..9223372036854775807(int)' by 1 elements"
+  errormsg: "size of array exceeds range of index type 'range 2147483646..2147483647(int32)' by 1 elements"
   line: 5
 """
-echo [high(int)-1: 1, 2, 3]
+echo [high(int32)-1: 1, 2, 3]


### PR DESCRIPTION
```nim
# bug 1: compiler overflow on invalid indices
let x = [int: 1, int: 2]

# bug 2: literal indices don't change the index type (which is kinda the point?).
#        This may be a breaking change.
echo [bigEndian: 1][bigEndian] # type mismatch 
```