### PR TITLE
streams: change error message of `openFileStream`

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -1241,7 +1241,7 @@ when not defined(js):
     if open(f, filename, mode, bufSize):
       return newFileStream(f)
     else:
-      raise newEIO("cannot open file\n")
+      raise newEIO("cannot open file stream: " & filename)
 
 when false:
   type


### PR DESCRIPTION
```nim
import streams

var strm = openFileStream("somefile.txt")
echo strm.readLine()
strm.close()
```

Current exception message is below.

> Error: unhandled exception: cannot open file [IOError]

I think that error message needs file name.
I changed exception message to below.

> Error: unhandled exception: cannot open file stream: somefile.txt [IOError]

