### PR TITLE
Ensure that koch-built nim exe has +x perm for u/g/others [bugfix]

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -111,7 +111,7 @@ proc overwriteFile(source, dest: string) =
 proc copyExe(source, dest: string) =
   safeRemove(dest)
   copyFile(dest=dest, source=source)
-  inclFilePermissions(dest, {fpUserExec})
+  inclFilePermissions(dest, {fpUserExec, fpGroupExec, fpOthersExec})
 
 const
   compileNimInst = "tools/niminst/niminst"


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/11427.