### PR TITLE
[bugfix] fix nimpretty for absolute paths

### DIFF
--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -49,7 +49,9 @@ type
 proc prettyPrint(infile, outfile: string, opt: PrettyOptions) =
   var conf = newConfigRef()
   let fileIdx = fileInfoIdx(conf, AbsoluteFile infile)
-  conf.outFile = RelativeFile outfile
+  let f = splitFile(outfile.expandTilde)
+  conf.outFile = RelativeFile f.name & f.ext
+  conf.outDir = toAbsoluteDir f.dir
   var p: TParsers
   p.parser.em.indWidth = opt.indWidth
   if setupParsers(p, fileIdx, newIdentCache(), conf):


### PR DESCRIPTION
Nimpretty doesn't work anymore for absolute paths, which is how the vscode uses nimpretty. I just used the same code from the nim `--out` option.