### PR TITLE
azure-pipelines: add pipelines for linux, mac and win & integrate with testament

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,148 @@
+strategy:
+  matrix:
+    Linux_amd64:
+      vmImage: 'ubuntu-16.04'
+      CPU: amd64
+    Linux_i386:
+      vmImage: 'ubuntu-16.04'
+      CPU: i386
+    OSX_amd64:
+      vmImage: 'macOS-10.14'
+      CPU: amd64
+    OSX_amd64_cpp:
+      vmImage: 'macOS-10.14'
+      CPU: amd64
+      NIM_COMPILE_TO_CPP: true
+    Windows_amd64:
+      vmImage: 'windows-2019'
+      CPU: amd64
+    Windows_amd64_pkg:
+      vmImage: 'windows-2019'
+      CPU: amd64
+      NIM_TEST_PACKAGES: true
+
+pool:
+  vmImage: $(vmImage)
+
+workspace:
+  clean: all
+
+steps:
+  - bash: git config --global core.autocrlf false
+    displayName: 'Disable auto conversion to CRLF by git (Windows-only)'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+  - checkout: self
+
+  - bash: git clone --depth 1 https://github.com/nim-lang/csources.git
+    displayName: 'Checkout csources'
+
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.x'
+    displayName: 'Install node.js 8.x'
+
+  - bash: |
+      sudo apt-fast update -qq
+      DEBIAN_FRONTEND='noninteractive' \
+        sudo apt-fast install --no-install-recommends -yq \
+          libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev
+    displayName: 'Install dependencies (amd64 Linux)'
+    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
+
+  - bash: |
+      sudo dpkg --add-architecture i386
+
+      # Downgrade llvm, libgcc and libstdc++:
+      # - llvm has to be downgraded to have 32bit version installed for sfml.
+      # - libgcc and libstdc++ have to be downgraded as an optimization to
+      #   prevent the use of the toolchain ppa, which has a terrible download
+      #   speed.
+      cat << EOF | sudo tee /etc/apt/preferences.d/pin-to-rel
+      Package: libllvm6.0 libgcc1 libstdc++6
+      Pin: origin "azure.archive.ubuntu.com"
+      Pin-Priority: 1001
+
+      Package: *
+      Pin: release o=LP-PPA-ubuntu-toolchain-r-test
+      Pin-Priority: 100
+      EOF
+
+      sudo apt-fast update -qq
+      DEBIAN_FRONTEND='noninteractive' \
+        sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
+          g++-multilib gcc-multilib libcurl4-openssl-dev:i386 libgc-dev:i386 \
+          libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386
+
+      cat << EOF > bin/gcc
+      #!/bin/bash
+
+      exec $(which gcc) -m32 "\$@"
+      EOF
+      cat << EOF > bin/g++
+      #!/bin/bash
+
+      exec $(which g++) -m32 "\$@"
+      EOF
+
+      chmod 755 bin/gcc
+      chmod 755 bin/g++
+
+    displayName: 'Install dependencies (i386 Linux)'
+    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
+
+  - bash: brew install boehmgc make sfml
+    displayName: 'Install dependencies (OSX)'
+    condition: eq(variables['Agent.OS'], 'Darwin')
+
+  - bash: |
+      mkdir dist
+      curl -L https://nim-lang.org/download/mingw64-6.3.0.7z -o dist/mingw64.7z
+      curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
+      7z x dist/mingw64.7z -odist
+      7z x dist/dlls.zip -obin
+      echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
+
+    displayName: 'Install dependencies (Windows)'
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+  - bash: echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/bin'
+    displayName: 'Add build binaries to PATH'
+
+  - bash: |
+      echo 'PATH:' "$PATH"
+      echo '##[section]gcc version'
+      gcc -v
+      echo '##[section]nodejs version'
+      node -v
+      echo '##[section]make version'
+      make -v
+    displayName: 'System information'
+
+  - bash: |
+      ncpu=
+      case '$(Agent.OS)' in
+      'Linux')
+        ncpu=$(nproc)
+        ;;
+      'Darwin')
+        ncpu=$(sysctl -n hw.ncpu)
+        ;;
+      'Windows_NT')
+        ncpu=$NUMBER_OF_PROCESSORS
+        ;;
+      esac
+      [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
+
+      make -C csources -j $ncpu CC=gcc ucpu=$(CPU)
+    displayName: 'Build csources'
+
+  - bash: nim c koch
+    displayName: 'Build koch'
+
+    # set result to omit the "bash exited with error code '1'" message
+  - bash: |
+      ./koch runCI || echo '##vso[task.complete result=Failed]'
+    displayName: 'Run CI'
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/testament/azure.nim
+++ b/testament/azure.nim
@@ -1,0 +1,95 @@
+#
+#
+#              The Nim Tester
+#        (c) Copyright 2019 Leorize
+#
+#    Look at license.txt for more info.
+#    All rights reserved.
+
+import base64, json, httpclient, os, strutils
+import specs
+
+const
+  ApiRuns = "/_apis/test/runs"
+  ApiVersion = "?api-version=5.0"
+  ApiResults = ApiRuns & "/$1/results"
+
+var runId* = -1
+
+proc getAzureEnv(env: string): string =
+  # Conversion rule at:
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables#set-variables-in-pipeline
+  env.toUpperAscii().replace('.', '_').getEnv
+
+proc invokeRest(httpMethod: HttpMethod; api: string; body = ""): Response =
+  let http = newHttpClient()
+  defer: close http
+  result = http.request(getAzureEnv("System.TeamFoundationCollectionUri") &
+                        getAzureEnv("System.TeamProjectId") & api & ApiVersion,
+                        httpMethod,
+                        $body,
+                        newHttpHeaders {
+                          "Accept": "application/json",
+                          "Authorization": "Basic " & encode(':' & getAzureEnv("System.AccessToken")),
+                          "Content-Type": "application/json"
+                        })
+  if not result.code.is2xx:
+    raise newException(HttpRequestError, "Server returned: " & result.body)
+
+proc finish*() {.noconv.} =
+  if not isAzure or runId < 0:
+    return
+
+  try:
+    discard invokeRest(HttpPatch,
+                       ApiRuns & "/" & $runId,
+                       $ %* { "state": "Completed" })
+  except:
+    stderr.writeLine "##vso[task.logissue type=warning;]Unable to finalize Azure backend"
+    stderr.writeLine getCurrentExceptionMsg()
+
+  runId = -1
+
+# TODO: Only obtain a run id if tests are run
+# NOTE: We can't delete test runs with Azure's access token
+proc start*() =
+  if not isAzure:
+    return
+  try:
+    if runId < 0:
+      runId = invokeRest(HttpPost,
+                         ApiRuns,
+                         $ %* {
+                           "automated": true,
+                           "build": { "id": getAzureEnv("Build.BuildId") },
+                           "buildPlatform": hostCPU,
+                           "controller": "nim-testament",
+                           "name": getAzureEnv("Agent.JobName")
+                         }).body.parseJson["id"].getInt(-1)
+  except:
+    stderr.writeLine "##vso[task.logissue type=warning;]Unable to initialize Azure backend"
+    stderr.writeLine getCurrentExceptionMsg()
+
+proc addTestResult*(name, category: string; durationInMs: int; errorMsg: string;
+                    outcome: TResultEnum) =
+  if not isAzure or runId < 0:
+    return
+  let outcome = case outcome
+                of reSuccess: "Passed"
+                of reDisabled, reJoined: "NotExecuted"
+                else: "Failed"
+  try:
+    discard invokeRest(HttpPost,
+                       ApiResults % [$runId],
+                       $ %* [{
+                         "automatedTestName": name,
+                         "automatedTestStorage": category,
+                         "durationInMs": durationInMs,
+                         "errorMessage": errorMsg,
+                         "outcome": outcome,
+                         "testCaseTitle": name
+                       }])
+  except:
+    stderr.writeLine "##vso[task.logissue type=warning;]Unable to log test case: ",
+                     name, ", outcome: ", outcome
+    stderr.writeLine getCurrentExceptionMsg()

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -13,6 +13,7 @@ var compilerPrefix* = findExe("nim")
 
 let isTravis* = existsEnv("TRAVIS")
 let isAppVeyor* = existsEnv("APPVEYOR")
+let isAzure* = existsEnv("TF_BUILD")
 
 var skips*: seq[string]
 
@@ -211,6 +212,8 @@ proc parseSpec*(filename: string): TSpec =
           if isTravis: result.err = reDisabled
         of "appveyor":
           if isAppVeyor: result.err = reDisabled
+        of "azure":
+          if isAzure: result.err = reDisabled
         of "32bit":
           if sizeof(int) == 4:
             result.err = reDisabled

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -12,7 +12,7 @@
 import
   strutils, pegs, os, osproc, streams, json,
   backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, times, md5, sequtils
+  algorithm, times, md5, sequtils, azure
 
 include compiler/nodejs
 
@@ -281,7 +281,7 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
       maybeStyledEcho styleBright, given, "\n"
 
 
-  if backendLogging and existsEnv("APPVEYOR"):
+  if backendLogging and (isAppVeyor or isAzure):
     let (outcome, msg) =
       case success
       of reSuccess:
@@ -292,14 +292,17 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
         ("Failed", "Failure: " & $success & "\n" & given)
       else:
         ("Failed", "Failure: " & $success & "\nExpected:\n" & expected & "\n\n" & "Gotten:\n" & given)
-    var p = startProcess("appveyor", args=["AddTest", test.name.replace("\\", "/") & test.options,
-                         "-Framework", "nim-testament", "-FileName",
-                         test.cat.string,
-                         "-Outcome", outcome, "-ErrorMessage", msg,
-                         "-Duration", $(duration*1000).int],
-                         options={poStdErrToStdOut, poUsePath, poParentStreams})
-    discard waitForExit(p)
-    close(p)
+    if isAzure:
+      azure.addTestResult(name, test.cat.string, int(duration * 1000), msg, success)
+    else:
+      var p = startProcess("appveyor", args=["AddTest", test.name.replace("\\", "/") & test.options,
+                           "-Framework", "nim-testament", "-FileName",
+                           test.cat.string,
+                           "-Outcome", outcome, "-ErrorMessage", msg,
+                           "-Duration", $(duration*1000).int],
+                           options={poStdErrToStdOut, poUsePath, poParentStreams})
+      discard waitForExit(p)
+      close(p)
 
 proc cmpMsgs(r: var TResults, expected, given: TSpec, test: TTest, target: TTarget) =
   if strip(expected.msg) notin strip(given.msg):
@@ -638,6 +641,8 @@ proc main() =
         quit Usage
     of "skipfrom":
       skipFrom = p.val.string
+    of "azurerunid":
+      runId = p.val.parseInt
     else:
       quit Usage
     p.next()
@@ -650,6 +655,8 @@ proc main() =
   of "all":
     #processCategory(r, Category"megatest", p.cmdLineRest.string, testsDir, runJoinableTests = false)
 
+    azure.start()
+
     var myself = quoteShell(findExe("testament" / "testament"))
     if targetsStr.len > 0:
       myself &= " " & quoteShell("--targets:" & targetsStr)
@@ -658,6 +665,8 @@ proc main() =
 
     if skipFrom.len > 0:
       myself &= " " & quoteShell("--skipFrom:" & skipFrom)
+    if isAzure:
+      myself &= " " & quoteShell("--azureRunId:" & $runId)
 
     var cats: seq[string]
     let rest = if p.cmdLineRest.string.len > 0: " " & p.cmdLineRest.string else: ""
@@ -683,13 +692,16 @@ proc main() =
         progressStatus(i)
         processCategory(r, Category(cati), p.cmdLineRest.string, testsDir, runJoinableTests = false)
     else:
+      addQuitProc azure.finish
       quit osproc.execProcesses(cmds, {poEchoCmd, poStdErrToStdOut, poUsePath, poParentStreams}, beforeRunEvent = progressStatus)
   of "c", "cat", "category":
+    azure.start()
     skips = loadSkipFrom(skipFrom)
     var cat = Category(p.key)
     p.next
     processCategory(r, cat, p.cmdLineRest.string, testsDir, runJoinableTests = true)
   of "pcat":
+    azure.start()
     skips = loadSkipFrom(skipFrom)
     # 'pcat' is used for running a category in parallel. Currently the only
     # difference is that we don't want to run joinable tests here as they
@@ -704,6 +716,7 @@ proc main() =
     p.next
     processPattern(r, pattern, p.cmdLineRest.string, simulate)
   of "r", "run":
+    azure.start()
     # at least one directory is required in the path, to use as a category name
     let pathParts = split(p.key.string, {DirSep, AltSep})
     # "stdlib/nre/captures.nim" -> "stdlib" + "nre/captures.nim"
@@ -719,6 +732,7 @@ proc main() =
     if action == "html": openDefaultBrowser(resultsFile)
     else: echo r, r.data
   backend.close()
+  if isMainProcess: azure.finish()
   var failed = r.total - r.passed - r.skipped
   if failed != 0:
     echo "FAILURE! total: ", r.total, " passed: ", r.passed, " skipped: ",

--- a/testament/testament.nim.cfg
+++ b/testament/testament.nim.cfg
@@ -1,1 +1,2 @@
 path = "$nim" # For compiler/nodejs
+-d:ssl # For azure

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -4,6 +4,7 @@ discard """
   output: "OK"
   disabled: "travis"
   disabled: "appveyor"
+  disabled: "azure"
 """
 
 import strutils

--- a/tests/system/t7894.nim
+++ b/tests/system/t7894.nim
@@ -1,6 +1,7 @@
 discard """
 disabled: "travis"
 disabled: "appveyor"
+disabled: "azure"
 joinable: false
 disabled: 32bit
 """


### PR DESCRIPTION
Preferably be rebase-and-merged.

This PR introduces:
- An Azure Pipelines configuration that covers both AppVeyor + Travis CI (except for github pages deployment).
- Integration of Azure Pipelines' "Tests" view with testament.

Known issues:
- There will be empty test runs produced by `testament`, not harmful in anyway as it's hidden by Azure Pipelines UI (only affects test runs count).
- Some tests might be flaky (OSX's hot code reloading test, `tests/float/tfloatrange.nim` on Windows).
- Test run duration might be longer than the duration of the job that produces it.

Test runs can be seen here: https://dev.azure.com/alaviss/Nim/_build?definitionId=1&_a=summary