### PR TITLE
Update tut1: -d:release does not turn off *all* runtime checks anymore

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -56,7 +56,7 @@ To compile a release version use::
   nim c -d:release greetings.nim
 
 By default the Nim compiler generates a large amount of runtime checks
-aiming for your debugging pleasure. With ``-d:release`` these checks are
+aiming for your debugging pleasure. With ``-d:release`` some checks are
 `turned off and optimizations are turned on
 <nimc.html#compiler-usage-compile-time-symbols>`_.
 


### PR DESCRIPTION
Does -d:release still turn off *some* checks or should the sentence changed more?