### PR TITLE
[other] test c2nim again

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -12,7 +12,7 @@ pkg "ast_pattern_matching", "nim c -r tests/test1.nim"
 pkg "binaryheap", "nim c -r binaryheap.nim"
 pkg "blscurve", "", true
 pkg "bncurve", "", true
-pkg "c2nim", "nim c -r testsuite/tester.nim"
+pkg "c2nim", "nim c -r testsuite/tester.nim", true
 pkg "cascade"
 pkg "chroma"
 pkg "chronicles", "nim c -o:chr -r chronicles.nim", true

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -12,7 +12,7 @@ pkg "ast_pattern_matching", "nim c -r tests/test1.nim"
 pkg "binaryheap", "nim c -r binaryheap.nim"
 pkg "blscurve", "", true
 pkg "bncurve", "", true
-pkg "c2nim", "nim c testsuite/tester.nim"
+pkg "c2nim", "nim c -r testsuite/tester.nim"
 pkg "cascade"
 pkg "chroma"
 pkg "chronicles", "nim c -o:chr -r chronicles.nim", true


### PR DESCRIPTION
c2nim doesn't work on 0.20.0 because of case objects transition changes. Run the tests so it doesn't break again. This will fail until https://github.com/nim-lang/c2nim/pull/155 or a similiar PR is merged.