### PR TITLE
Fix the link to "For Loop Macro" section

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4427,7 +4427,7 @@ when not defined(js):
 type
   ForLoopStmt* {.compilerProc.} = object ## \
     ## A special type that marks a macro as a `for-loop macro`:idx:.
-    ## See `"For loop macros" <manual.html#macros-for-loop-macros>`_.
+    ## See `"For Loop Macro" <manual.html#macros-for-loop-macro>`_.
 
 when defined(genode):
   var componentConstructHook*: proc (env: GenodeEnv) {.nimcall.}


### PR DESCRIPTION
Right now, the <See "For loop macros"> link in https://nim-lang.github.io/Nim/system.html#ForLoopStmt points to https://nim-lang.github.io/Nim/manual.html#macros-for-loop-macros.

It should point to https://nim-lang.github.io/Nim/manual.html#macros-for-loop-macro. (note the removal of 's' at the end)