### PR TITLE
[bugfix] fix #11482, fix nimsuggest range error

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -445,8 +445,8 @@ proc execCmd(cmd: string; graph: ModuleGraph; cachedMsgs: CachedMsgs) =
     if i < cmd.len and cmd[i] == ';':
       i = parseQuoted(cmd, dirtyfile, i+1)
     i += skipWhile(cmd, seps, i)
-  var line = -1
-  var col = 0
+  var line = 0
+  var col = -1
   i += parseInt(cmd, line, i)
   i += skipWhile(cmd, seps, i)
   i += parseInt(cmd, col, i)


### PR DESCRIPTION
The default starting parameters for `line` and `col` were switched.

See line 141: "line starts at 1, column at 0, dirtyfile is optional".
Also, in `TLineInfo` object, `line` is uint16, `col` is int16.