### PR TITLE
[bugfix] fix #11450, random.initRand crashes in JS backend

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -321,7 +321,7 @@ proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
   ## Allowed input types are:
   ## * Integer
   ## * Floats
-  ## * Enums without holes 
+  ## * Enums without holes
   ##
   ## See also:
   ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice and uses the
@@ -407,7 +407,7 @@ proc sample*[T](r: var Rand; s: set[T]): T =
   for e in s:
     if i == 0: return e
     dec(i)
-    
+
 proc sample*[T](s: set[T]): T =
   ## returns a random element from a set
   sample(state, s)
@@ -607,8 +607,8 @@ when not defined(nimscript):
     ## See also:
     ## * `randomize proc<#randomize,int64>`_ that accepts a seed
     ## * `initRand proc<#initRand,int64>`_
-    when defined(js):
-      let time = int64(times.epochTime() * 1_000_000_000)
+    when defined(JS):
+      let time = int64(times.epochTime() * 100_000)
       randomize(time)
     else:
       let now = times.getTime()


### PR DESCRIPTION
The original example which fails:

```nim
import random
proc onLoad() {.exportC.} =
  let r = initRand(1560090106546000100)

when isMainModule and defined(c):
  onLoad()
```

----

The error is triggered here: 

```nim
result.a0 = ui(seed shr 16)
```
(inside of `initRand` proc) because `1560090106546000100 shr 16` is larger than `uint32.high`, which is what `ui` is in JS backend. (It is `uint64` in C backend).

> The value that I used above was generated by `randomize`

Here is what `randomize` does for JS backend:

```nim
let time = int64(times.epochTime() * 1_000_000_000)
```

and then `time` is used as `seed` parameter in the above code, which, even after the shift-right, produces numbers larger than `uint32.high`.