### PR TITLE
Add `cbrt()` bindings for the JS Target

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -298,6 +298,9 @@ else: # JS
   proc sqrt*(x: float32): float32 {.importc: "Math.sqrt", nodecl.}
   proc sqrt*(x: float64): float64 {.importc: "Math.sqrt", nodecl.}
 
+  proc cbrt*(x: float32): float32 {.importc: "Math.cbrt", nodecl.}
+  proc cbrt*(x: float64): float64 {.importc: "Math.cbrt", nodecl.}
+
   proc ln*(x: float32): float32 {.importc: "Math.log", nodecl.}
   proc ln*(x: float64): float64 {.importc: "Math.log", nodecl.}
 


### PR DESCRIPTION
`Math.cbrt()` exists:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt

The binding was missing for the JavaScript backend.