### PR TITLE
[bugfix] fix OrderedTable default initialization

### DIFF
--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -118,6 +118,9 @@ template initImpl(result: typed, size: int) =
   assert isPowerOfTwo(size)
   result.counter = 0
   newSeq(result.data, size)
+  when compiles(result.first):
+    result.first = -1
+    result.last = -1
 
 template insertImpl() = # for CountTable
   if t.dataLen == 0: initImpl(t, defaultInitialSize)

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1282,8 +1282,6 @@ proc initOrderedTable*[A, B](initialsize = defaultInitialSize): OrderedTable[A, 
       a = initOrderedTable[int, string]()
       b = initOrderedTable[char, seq[int]]()
   initImpl(result, initialSize)
-  result.first = -1
-  result.last = -1
 
 proc toOrderedTable*[A, B](pairs: openArray[(A, B)]): OrderedTable[A, B] =
   ## Creates a new ordered hash table that contains the given ``pairs``.


### PR DESCRIPTION
This was reported on IRC, see the [reported example](https://play.nim-lang.org/#ix=1Mhr).