### PR TITLE
[bugfix] fix OrderedTable iterators

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1253,11 +1253,13 @@ proc enlarge[A, B](t: var OrderedTable[A, B]) =
     h = nxt
 
 template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
-  var h = t.first
-  while h >= 0:
-    var nxt = t.data[h].next
-    if isFilled(t.data[h].hcode): yieldStmt
-    h = nxt
+  if t.counter > 0:
+    var h = t.first
+    while h >= 0:
+      var nxt = t.data[h].next
+      if isFilled(t.data[h].hcode):
+        yieldStmt
+      h = nxt
 
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
This solves the bug reported on IRC:

```nim
import tables

# You can for loop over an auto initialized sequence of "Table"
var test = newSeq[Table[string, string]](1)
for key, table in test:
  for k, v in table:
    discard

# So I suppose it should work for "OrderedTable" too, but that crashes
var test2 = newSeq[OrderedTable[string, string]](1)
for key, table in test2:
  for k, v in table:
    discard
```