### PR TITLE
[bugfix] assertions: make assert follow excessiveStackTrace

### DIFF
--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -31,9 +31,7 @@ template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]
   bind instantiationInfo
   mixin failedAssertImpl
   when enabled:
-    # for stacktrace; fixes #8928 ; Note: `fullPaths = true` is correct
-    # here, regardless of --excessiveStackTrace
-    {.line: instantiationInfo(fullPaths = true).}:
+    {.line: instantiationInfo(fullPaths = compileOption("excessiveStackTrace")).}:
       if not cond:
         failedAssertImpl(loc & " `" & expr & "` " & msg)
 


### PR DESCRIPTION
Fixes #11545.

Currently `--listFullPaths:off` is also needed to get rid of the full path as well, thanks to this
https://github.com/nim-lang/Nim/blob/436f57065197bee86c9539b75de3a73e5bda3f10/compiler/msgs.nim#L158-L165

I'll probably try to patch around this later...