### PR TITLE
[other] nim.cfg: disable excessiveStackTrace on release

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -71,6 +71,7 @@ path="$lib/pure"
 
 @if release or danger:
   stacktrace:off
+  excessiveStackTrace:off
   linetrace:off
   debugger:off
   line_dir:off


### PR DESCRIPTION
As discussed on IRC: https://irclogs.nim-lang.org/24-06-2019.html#18:13:02

This will not disable full paths in stacktrace atm, you'd need to have `--listFullPaths:off` also. I'm pretty sure I've figured out the culprit, and will send a PR for that soon.