### PR TITLE
Always return relative path when listFullPaths is off

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -206,8 +206,7 @@ proc toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
   if optListFullPaths in conf.globalOptions:
     result = absPath
   else:
-    let relPath = conf.m.fileInfos[info.fileIndex.int32].projPath.string
-    result = if relPath.count("..") > 2: absPath else: relPath
+    result = conf.m.fileInfos[info.fileIndex.int32].projPath.string
 
 proc toLinenumber*(info: TLineInfo): int {.inline.} =
   result = int info.line


### PR DESCRIPTION
A fix for #11572 that helps respect the privacy of the user by **never** including the absolute path of imported files in the compiled binary when the listFullPaths flag is off.