### PR TITLE
compiler/[msgs, options]: confine --listFullPaths to compiler messages

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -217,7 +217,7 @@ proc toFileLine*(conf: ConfigRef; info: TLineInfo): string {.inline.} =
 
 proc toFileLineCol*(conf: ConfigRef; info: TLineInfo): string {.inline.} =
   # consider calling `helpers.lineInfoToString` instead
-  result = toFilename(conf, info) & "(" & $info.line & ", " &
+  result = toMsgFilename(conf, info) & "(" & $info.line & ", " &
     $(info.col + ColOffset) & ")"
 
 proc `$`*(conf: ConfigRef; info: TLineInfo): string = toFileLineCol(conf, info)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -159,10 +159,7 @@ template toFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:
     "???"
   else:
-    if optListFullPaths in conf.globalOptions:
-      conf.m.fileInfos[fileIdx.int32].fullPath.string
-    else:
-      conf.m.fileInfos[fileIdx.int32].projPath.string
+    conf.m.fileInfos[fileIdx.int32].projPath.string
 
 proc toFullPath*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil: result = "???"

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -197,14 +197,16 @@ template toFullPathConsiderDirty*(conf: ConfigRef; info: TLineInfo): string =
 
 proc toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
   if info.fileIndex.int32 < 0:
-    result = "???"
-    return
-  let absPath = conf.m.fileInfos[info.fileIndex.int32].fullPath.string
-  if optListFullPaths in conf.globalOptions:
-    result = absPath
-  else:
-    let relPath = conf.m.fileInfos[info.fileIndex.int32].projPath.string
-    result = if relPath.count("..") > 2: absPath else: relPath
+    return "???"
+  let
+    absPath = conf.m.fileInfos[info.fileIndex.int32].fullPath.string
+    relPath = conf.m.fileInfos[info.fileIndex.int32].projPath.string
+  result = if (optListFullPaths in conf.globalOptions) or
+              (relPath.len > absPath.len) or
+              (relPath.count("..") > 2):
+             absPath
+           else:
+             relPath
 
 proc toLinenumber*(info: TLineInfo): int {.inline.} =
   result = int info.line

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -212,9 +212,6 @@ proc toLinenumber*(info: TLineInfo): int {.inline.} =
 proc toColumn*(info: TLineInfo): int {.inline.} =
   result = info.col
 
-proc toFileLine*(conf: ConfigRef; info: TLineInfo): string {.inline.} =
-  result = toFilename(conf, info) & ":" & $info.line
-
 proc toFileLineCol*(conf: ConfigRef; info: TLineInfo): string {.inline.} =
   # consider calling `helpers.lineInfoToString` instead
   result = toMsgFilename(conf, info) & "(" & $info.line & ", " &

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -78,7 +78,7 @@ type                          # please make sure we have under 32 options
     optWholeProject           # for 'doc2': output any dependency
     optDocInternal            # generate documentation for non-exported symbols
     optMixedMode              # true if some module triggered C++ codegen
-    optListFullPaths          # use full paths in toMsgFilename, toFilename
+    optListFullPaths          # use full paths in toMsgFilename
     optNoNimblePath
     optHotCodeReloading
     optDynlibOverrideAll


### PR DESCRIPTION
This PR introduce the following changes:
- Confine `--listFullPaths` to only affect compiler messages (as designed). All test cases from #9766 have been tested to ensure nothing broke.
- Minor cleanup to `toMsgFilename`, should now prefer `/home/test.nim` over `../home/test.nim`

Potential problems:
- Since `toFilename` could have been used for compiler messages also, this change may cause certain compiler messages to stop respecting `--listFullPaths` (haven't found any). Patching those ocurrances to `toMsgFilename` should be enough however.