### PR TITLE
[feature] Enable net types to be used in hashed collections

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -95,10 +95,7 @@
 ##   runForever()
 ##
 
-import asyncdispatch
-import nativesockets
-import net
-import os
+import asyncdispatch, nativesockets, net, os, hashes
 
 export SOBool
 
@@ -129,6 +126,14 @@ type
     sockType: SockType
     protocol: Protocol
   AsyncSocket* = ref AsyncSocketDesc
+
+proc hash*(x: AsyncSocket): Hash =
+  var h: Hash = 0
+  h = h !& hash(x.fd)
+  h = h !& hash(x.domain)
+  h = h !& hash(x.sockType)
+  h = h !& hash(x.protocol)
+  result = !$h
 
 proc newAsyncSocket*(fd: AsyncFD, domain: Domain = AF_INET,
     sockType: SockType = SOCK_STREAM,

--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -128,12 +128,21 @@ type
   AsyncSocket* = ref AsyncSocketDesc
 
 proc hash*(x: AsyncSocket): Hash =
+  ## Generates a hash using only a subset of the fields.  The ones
+  ## used are considered to provide identity.
   var h: Hash = 0
   h = h !& hash(x.fd)
   h = h !& hash(x.domain)
   h = h !& hash(x.sockType)
   h = h !& hash(x.protocol)
   result = !$h
+
+proc `==`*(a, b: AsyncSocket): bool =
+  ## Comparison using only a subset of the fields.  The ones used are
+  ## considered to provide identity.
+  not isNil(a) and not isNil(b) and
+  a.fd == b.fd and a.domain == b.domain and a.sockType == b.sockType and
+  a.protocol == b.protocol
 
 proc newAsyncSocket*(fd: AsyncFD, domain: Domain = AF_INET,
     sockType: SockType = SOCK_STREAM,

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -142,6 +142,9 @@ proc hash*(x: char): Hash {.inline.} =
 
 proc hash*[T: Ordinal | enum](x: T): Hash {.inline.} =
   ## Efficient hashing of other ordinal types (e.g. enums).
+  ##
+  ## NOTE: An enum type will only match the system.Ordinal type if it
+  ## has no holes.
   result = ord(x)
 
 proc hash*(x: float): Hash {.inline.} =

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -140,7 +140,7 @@ proc hash*(x: char): Hash {.inline.} =
   ## Efficient hashing of characters.
   result = ord(x)
 
-proc hash*[T: Ordinal](x: T): Hash {.inline.} =
+proc hash*[T: Ordinal | enum](x: T): Hash {.inline.} =
   ## Efficient hashing of other ordinal types (e.g. enums).
   result = ord(x)
 

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -12,7 +12,7 @@
 
 # TODO: Clean up the exports a bit and everything else in general.
 
-import os, options
+import os, options, hashes
 
 when hostOS == "solaris":
   {.passl: "-lsocket -lnsl".}
@@ -183,6 +183,23 @@ proc toSockType*(protocol: Protocol): SockType =
     SOCK_DGRAM
   of IPPROTO_IP, IPPROTO_IPV6, IPPROTO_RAW, IPPROTO_ICMP, IPPROTO_ICMPV6:
     SOCK_RAW
+
+proc hash*(x: Servent): Hash =
+  var h: Hash = 0
+  h = h !& hash(x.name)
+  h = h !& hash(x.aliases)
+  h = h !& hash(x.port)
+  h = h !& hash(x.proto)
+  result = !$h
+
+proc hash*(x: Hostent): Hash =
+  var h: Hash = 0
+  h = h !& hash(x.name)
+  h = h !& hash(x.aliases)
+  h = h !& hash(x.addrtype)
+  h = h !& hash(x.length)
+  h = h !& hash(x.addrList)
+  result = !$h
 
 proc createNativeSocket*(domain: Domain = AF_INET,
                       sockType: SockType = SOCK_STREAM,

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -192,6 +192,10 @@ proc hash*(x: Servent): Hash =
   h = h !& hash(x.proto)
   result = !$h
 
+proc `==`*(a, b: Servent): bool =
+  a.name == b.name and a.aliases == b.aliases and a.port == b.port and
+  a.proto == b.proto
+
 proc hash*(x: Hostent): Hash =
   var h: Hash = 0
   h = h !& hash(x.name)
@@ -200,6 +204,10 @@ proc hash*(x: Hostent): Hash =
   h = h !& hash(x.length)
   h = h !& hash(x.addrList)
   result = !$h
+
+proc `==`*(a, b: Hostent): bool =
+  a.name == b.name and a.aliases == b.aliases and a.addrtype == b.addrtype and
+  a.length == b.length and a.addrList == b.addrList
 
 proc createNativeSocket*(domain: Domain = AF_INET,
                       sockType: SockType = SOCK_STREAM,


### PR DESCRIPTION
I wanted to use AsyncSockets in a set and ran into missing hash functions.

Some notes for reviewers:

* Only a subset of fields are being hashed on `AsyncSocket`.
  * The fields were chosen based on how much they represented the identity of the object.
  * The thinking is that if the `SocketHandle` or `Domain` were to change, then it is an entirely different object.  But if the `currPos` in the buffer were to change, then it's not important from an identity point of view.
* Are `enum`s a type of `Ordinal`?
  * Some documentation says they are and then some code says they are not.  For example, `system.ord` has a type signature that accepts either one.
  * `nativesockets.nim:199` failed to compile until `enum` was added to the type signature for `hash*[T: Ordinal](x: T)`.  The compiler didn't know how to generate a hash for the `Domain` enum.
  * Is there a better way to solve this problem?
