### PR TITLE
[bugfix] fix #11590: c compiler warnings silently ignored, giving undefined behavior

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,8 @@
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.
+- new warning `--warning:backendWarning:on` to enable default backend warnings;
+  the defaults can be customized with additional flags eg: `--passc:-Wwritable-strings`
 - The `define` and `undef` pragmas have been de-deprecated.
 
 ## Tool changes

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -174,15 +174,6 @@ proc expectNoArg(conf: ConfigRef; switch, arg: string, pass: TCmdLinePass, info:
   if arg != "":
     localError(conf, info, "invalid argument for command line option: '$1'" % addPrefix(switch))
 
-proc handleSpecialNotes(conf: ConfigRef, pass: TCmdLinePass, note: TNoteKind) =
-  ## some notes require special handling so that cmdline flags overrides work
-  ## as expected.
-  case note
-  of warnBackendWarning:
-    if pass in {passCmd2, passPP}:
-       extccomp.addCompileOptionCmd(conf, warningsOff, isRemove = conf.hasWarn(note))
-  else: discard
-
 proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
                          info: TLineInfo; orig: string; conf: ConfigRef) =
   var id = ""  # arg = key:val or [key]:val;  with val=on|off
@@ -230,7 +221,6 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
         excl(conf.notes, n)
         excl(conf.mainPackageNotes, n)
         excl(conf.foreignPackageNotes, n)
-  handleSpecialNotes(conf, pass, n)
 
 proc processCompile(conf: ConfigRef; filename: string) =
   var found = findFile(conf, filename)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -567,7 +567,6 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
   block: # warnings
     # must occur before `compileOptionsCmd` so user config/cmdline can override
     let key = nimname & ".warnings"
-    echo0b key
     if existsConfigVar(conf, key): addOpt(result, getConfigVar(conf, key))
     else: addOpt(result, getWarnings(conf, conf.cCompiler))
 

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -873,7 +873,8 @@ proc execCmdsInParallel(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx:
           cmds[i])
   else:
     tryExceptOSErrorMessage(conf, "invocation of external compiler program failed."):
-      res = execProcesses(cmds, {poStdErrToStdOut, poUsePath, poParentStreams},
+      # keep writing errors/warnings to stderr
+      res = execProcesses(cmds, {poUsePath, poParentStreams},
                             conf.numberOfProcessors, prettyCb, afterRunEvent=runCb)
   if res != 0:
     if conf.numberOfProcessors <= 1:

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -62,7 +62,6 @@ template compiler(name, settings: untyped): untyped =
 
 const
   gnuAsmListing = "-Wa,-acdl=$asmfile -g -fverbose-asm -masm=intel"
-  warningsOff* = "-w" # if needed, can be compiler specific
 
 # GNU C and C++ Compiler
 compiler gcc:
@@ -100,7 +99,7 @@ compiler nintendoSwitchGCC:
     optSize: " -Os ",
     compilerExe: "aarch64-none-elf-gcc",
     cppCompiler: "aarch64-none-elf-g++",
-    compileTmpl: "-w -MMD -MP -MF $dfile -c $options $include -o $objfile $file",
+    compileTmpl: "-MMD -MP -MF $dfile -c $options $include -o $objfile $file",
     buildGui: " -mwindows",
     buildDll: " -shared",
     buildLib: "aarch64-none-elf-gcc-ar rcs $libfile $objfiles",
@@ -550,6 +549,9 @@ proc getOptSize(conf: ConfigRef; c: TSystemCC): string =
 
 proc getWarnings(conf: ConfigRef; c: TSystemCC): string =
   result = getConfigVar(conf, c, ".options.warnings")
+  if not conf.hasWarn(warnBackendWarning):
+    # TODO: /w for vcc?
+    result.add " -w"
   # if result == "":
   #   result = CC[c].optSize    # use default settings from this file
 

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -549,15 +549,10 @@ proc getOptSize(conf: ConfigRef; c: TSystemCC): string =
 
 proc getWarnings(conf: ConfigRef; c: TSystemCC): string =
   result = getConfigVar(conf, c, ".options.warnings")
-  if not conf.hasWarn(warnBackendWarning):
-    # TODO: /w for vcc?
-    result.add " -w"
-  # if result == "":
-  #   result = CC[c].optSize    # use default settings from this file
-
-  # case c
-  # of ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccZig, ccLcc, ccBcc, ccDmc, ccWcc, ccVcc, ccTcc, ccPcc, ccUcc, ccIcl, ccIcc, ccClangCl
-  # # ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccZig, ccLcc, ccBcc, ccDmc, ccWcc, ccVcc, ccTcc, ccPcc, ccUcc, ccIcl, ccIcc, ccClangCl
+  if not conf.hasWarn(warnBackendWarning): # disable all warnings
+    case c
+    of ccVcc: result.add " /w"
+    else: result.add " -w"
 
 proc noAbsolutePaths(conf: ConfigRef): bool {.inline.} =
   # We used to check current OS != specified OS, but this makes no sense
@@ -570,8 +565,9 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
   result = conf.compileOptions
 
   block: # warnings
-    # must occur before `compileOptionsCmd` so cmdline can override
+    # must occur before `compileOptionsCmd` so user config/cmdline can override
     let key = nimname & ".warnings"
+    echo0b key
     if existsConfigVar(conf, key): addOpt(result, getConfigVar(conf, key))
     else: addOpt(result, getWarnings(conf, conf.cCompiler))
 

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -588,8 +588,6 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
     let key = nimname & ".size"
     if existsConfigVar(conf, key): addOpt(result, getConfigVar(conf, key))
     else: addOpt(result, getOptSize(conf, conf.cCompiler))
-
-
   let key = nimname & ".always"
   if existsConfigVar(conf, key): addOpt(result, getConfigVar(conf, key))
 

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -62,6 +62,7 @@ template compiler(name, settings: untyped): untyped =
 
 const
   gnuAsmListing = "-Wa,-acdl=$asmfile -g -fverbose-asm -masm=intel"
+  warningsOff* = "-w" # if needed, can be compiler specific
 
 # GNU C and C++ Compiler
 compiler gcc:
@@ -471,8 +472,12 @@ proc addCompileOption*(conf: ConfigRef; option: string) =
 proc addLinkOptionCmd*(conf: ConfigRef; option: string) =
   addOpt(conf.linkOptionsCmd, option)
 
-proc addCompileOptionCmd*(conf: ConfigRef; option: string) =
-  conf.compileOptionsCmd.add(option)
+proc addCompileOptionCmd*(conf: ConfigRef; option: string, isRemove = false) =
+  if isRemove:
+    if (var index = conf.compileOptionsCmd.find(option); index >= 0):
+      conf.compileOptionsCmd.delete(index)
+  else:
+    conf.compileOptionsCmd.add(option)
 
 proc initVars*(conf: ConfigRef) =
   # we need to define the symbol here, because ``CC`` may have never been set!

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -547,12 +547,17 @@ proc getOptSize(conf: ConfigRef; c: TSystemCC): string =
   if result == "":
     result = CC[c].optSize    # use default settings from this file
 
+proc flagsToNative(flags: string, c: TSystemCC): string =
+  ## replaces ' -X' by ' /X' for VCC; works ok for some common flags.
+  if c == ccVcc: result = flags.replace(" -", " /")
+  else: result = flags
+
 proc getWarnings(conf: ConfigRef; c: TSystemCC): string =
   result = getConfigVar(conf, c, ".options.warnings")
-  if not conf.hasWarn(warnBackendWarning): # disable all warnings
-    case c
-    of ccVcc: result.add " /w"
-    else: result.add " -w"
+  if not conf.hasWarn(warnBackendWarning):
+    result.add " -w".flagsToNative(c) # disable all warnings
+  else:
+    result.add " -DNIM_UNIGNORE_DEFAULT_BACKEND_WARNINGS".flagsToNative(c)
 
 proc noAbsolutePaths(conf: ConfigRef): bool {.inline.} =
   # We used to check current OS != specified OS, but this makes no sense

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -17,6 +17,7 @@ const
 
 type
   TMsgKind* = enum
+    # errors
     errUnknown, errInternal, errIllFormedAstX, errCannotOpenFile,
     errXExpected,
     errGridTableNotImplemented,
@@ -26,6 +27,7 @@ type
     errProveInit,
     errGenerated,
     errUser,
+    # warnings
     warnCannotOpenFile,
     warnOctalEscape, warnXIsNeverRead, warnXmightNotBeenInit,
     warnDeprecated, warnConfigDeprecated,
@@ -42,7 +44,9 @@ type
     warnProveInit, warnProveField, warnProveIndex,
     warnStaticIndexCheck, warnGcUnsafe, warnGcUnsafe2,
     warnUninit, warnGcMem, warnDestructor, warnLockLevel, warnResultShadowed,
-    warnInconsistentSpacing, warnCaseTransition, warnCycleCreated, warnUser,
+    warnInconsistentSpacing, warnCaseTransition, warnCycleCreated,
+    warnBackendWarning, warnUser,
+    # hints
     hintSuccess, hintSuccessX, hintCC,
     hintLineTooLong, hintXDeclaredButNotUsed,
     hintConvToBaseNotNeeded,
@@ -106,6 +110,7 @@ const
     warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
     warnCaseTransition: "Potential object case transition, instantiate new object instead",
     warnCycleCreated: "$1",
+    warnBackendWarning: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`
@@ -155,7 +160,7 @@ const
     "ProveInit", "ProveField", "ProveIndex",
     "IndexCheck", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed",
-    "Spacing", "CaseTransition", "CycleCreated", "User"]
+    "Spacing", "CaseTransition", "CycleCreated", "BackendWarning", "User"]
 
   HintsToStr* = [
     "Success", "SuccessX", "CC", "LineTooLong",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -194,7 +194,7 @@ proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result[3] = {low(TNoteKind)..high(TNoteKind)} - {}
   result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext}
   result[1] = result[2] - {warnProveField, warnProveIndex,
-    warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
+    warnGcUnsafe, warnBackendWarning, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats}
   result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,
     hintProcessing, hintPattern, hintExecuting, hintLinking, hintCC}

--- a/config/config.nims
+++ b/config/config.nims
@@ -3,3 +3,36 @@
 when defined(nimHasCppDefine):
   cppDefine "errno"
   cppDefine "unix"
+
+block: # warnings
+  #[
+  ## ignore typical warnings in Nim-generated files
+
+  ## reference:
+  https://clang.llvm.org/docs/DiagnosticsReference.html
+
+  ## useful warnings:
+    -Wunknown-warning-option
+    -Weverything
+
+  ## To pass the test suite, `-Werror` would require the following adjustments:
+  -Werror -Wno-error=parentheses -Wno-error=deprecated-declarations -Wno-error=int-to-void-pointer-cast -Wno-error=ignored-attributes -Wno-error=incompatible-pointer-types -Wno-error=compare-distinct-pointer-types -Wno-error=incompatible-library-redeclaration
+
+  ## suspicious warnings for which we should fix code instead of ignoring warning:
+  -Wno-tautological-constant-out-of-range-compare
+  -Wswitch-bool: occurs for object variants with bool switch, eg btrees.Node
+  ]#
+
+  let clangWarningsCommon = "-Wno-logical-op-parentheses -Wno-invalid-noreturn -Wno-tautological-constant-out-of-range-compare -Wno-switch-bool"
+
+  let clangWarningsC = clangWarningsCommon & " -Wno-incompatible-pointer-types-discards-qualifiers"
+
+  let clangWarningsCpp = clangWarningsCommon & " -Wno-writable-strings -Wno-invalid-offsetof"
+
+  let vccWarnings = "4005 4100 4101 4189 4191 4200 4244 4293 4296 4309 4310 4365 4456 4477 4514 4574 4611 4668 4702 4706 4710 4711 4774 4800 4809 4820 4996 4090 4297"
+
+  switch("vcc.options.warnings", vccWarnings)
+
+  for cc in ["clang", "gcc"]:
+    switch(cc & ".options.warnings", clangWarningsC)
+    switch(cc & ".cpp.options.warnings", clangWarningsCpp)

--- a/config/config.nims
+++ b/config/config.nims
@@ -20,7 +20,10 @@ block: # warnings
 
   ## suspicious warnings for which we should fix code instead of ignoring warning:
   -Wno-tautological-constant-out-of-range-compare
-  -Wswitch-bool: occurs for object variants with bool switch, eg btrees.Node
+  -Wno-switch-bool: occurs for object variants with bool switch, eg btrees.Node
+  -Wno-incompatible-pointer-types-discards-qualifiers: will prevent 
+    `--passC:-Wwrite-strings` from giving warning for `char*s = "foo"
+    which can indicate a real bug, but cgen also generates a lot of these
   ]#
 
   let clangWarningsCommon = "-Wno-logical-op-parentheses -Wno-invalid-noreturn -Wno-tautological-constant-out-of-range-compare -Wno-switch-bool"

--- a/config/config.nims
+++ b/config/config.nims
@@ -4,7 +4,8 @@ when defined(nimHasCppDefine):
   cppDefine "errno"
   cppDefine "unix"
 
-block: # warnings
+when false:
+ block: # warnings
   #[
   ## ignore typical warnings in Nim-generated files
 
@@ -32,10 +33,17 @@ block: # warnings
 
   let clangWarningsCpp = clangWarningsCommon & " -Wno-writable-strings -Wno-invalid-offsetof"
 
-  let vccWarnings = "4005 4100 4101 4189 4191 4200 4244 4293 4296 4309 4310 4365 4456 4477 4514 4574 4611 4668 4702 4706 4710 4711 4774 4800 4809 4820 4996 4090 4297"
+  let gccWarnings = " "
 
-  switch("vcc.options.warnings", vccWarnings)
-
-  for cc in ["clang", "gcc"]:
+  for cc in ["clang"]:
     switch(cc & ".options.warnings", clangWarningsC)
     switch(cc & ".cpp.options.warnings", clangWarningsCpp)
+
+  block: # vcc
+    let vccWarnings = "/wd4005 /wd4100 /wd4101 /wd4189 /wd4191 /wd4200 /wd4244 /wd4293 /wd4296 /wd4309 /wd4310 /wd4365 /wd4456 /wd4477 /wd4514 /wd4574 /wd4611 /wd4668 /wd4702 /wd4706 /wd4710 /wd4711 /wd4774 /wd4800 /wd4809 /wd4820 /wd4996 /wd4090 /wd4297"
+    switch("vcc.options.warnings", vccWarnings)
+
+    when defined(vcc):
+      switch("passc", "/w")
+    else:
+      switch("passc", "-w")

--- a/config/config.nims
+++ b/config/config.nims
@@ -4,8 +4,7 @@ when defined(nimHasCppDefine):
   cppDefine "errno"
   cppDefine "unix"
 
-when false:
- block: # warnings
+block: # warnings
   #[
   ## ignore typical warnings in Nim-generated files
 
@@ -28,22 +27,7 @@ when false:
   ]#
 
   let clangWarningsCommon = "-Wno-logical-op-parentheses -Wno-invalid-noreturn -Wno-tautological-constant-out-of-range-compare -Wno-switch-bool"
-
   let clangWarningsC = clangWarningsCommon & " -Wno-incompatible-pointer-types-discards-qualifiers"
-
   let clangWarningsCpp = clangWarningsCommon & " -Wno-writable-strings -Wno-invalid-offsetof"
-
-  let gccWarnings = " "
-
-  for cc in ["clang"]:
-    switch(cc & ".options.warnings", clangWarningsC)
-    switch(cc & ".cpp.options.warnings", clangWarningsCpp)
-
-  block: # vcc
-    let vccWarnings = "/wd4005 /wd4100 /wd4101 /wd4189 /wd4191 /wd4200 /wd4244 /wd4293 /wd4296 /wd4309 /wd4310 /wd4365 /wd4456 /wd4477 /wd4514 /wd4574 /wd4611 /wd4668 /wd4702 /wd4706 /wd4710 /wd4711 /wd4774 /wd4800 /wd4809 /wd4820 /wd4996 /wd4090 /wd4297"
-    switch("vcc.options.warnings", vccWarnings)
-
-    when defined(vcc):
-      switch("passc", "/w")
-    else:
-      switch("passc", "-w")
+  switch("clang.options.warnings", clangWarningsC)
+  switch("clang.cpp.options.warnings", clangWarningsCpp)

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -242,9 +242,7 @@ llvm_gcc.options.size = "-Os"
 # Configuration for the LLVM CLang compiler:
 clang.options.debug = "-g"
 clang.cpp.options.debug = "-g"
-# To pass the test suite, `-Werror` would require the following adjustments:
-# -Werror -Wno-error=parentheses -Wno-error=deprecated-declarations -Wno-error=int-to-void-pointer-cast -Wno-error=ignored-attributes -Wno-error=incompatible-pointer-types -Wno-error=compare-distinct-pointer-types -Wno-error=incompatible-library-redeclaration
-clang.options.always = ""
+
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -242,9 +242,9 @@ llvm_gcc.options.size = "-Os"
 # Configuration for the LLVM CLang compiler:
 clang.options.debug = "-g"
 clang.cpp.options.debug = "-g"
-# We whitelist some warnings so test suite passes; warnings will be generated
-# but will not error for these, so we can fix these later if needed.
-clang.options.always = "-Werror -Wno-error=parentheses -Wno-error=deprecated-declarations -Wno-error=int-to-void-pointer-cast -Wno-error=ignored-attributes -Wno-error=incompatible-pointer-types -Wno-error=compare-distinct-pointer-types -Wno-error=incompatible-library-redeclaration"
+# To pass the test suite, `-Werror` would require the following adjustments:
+# -Werror -Wno-error=parentheses -Wno-error=deprecated-declarations -Wno-error=int-to-void-pointer-cast -Wno-error=ignored-attributes -Wno-error=incompatible-pointer-types -Wno-error=compare-distinct-pointer-types -Wno-error=incompatible-library-redeclaration
+clang.options.always = ""
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -170,14 +170,14 @@ path="$lib/pure"
 @if macosx or freebsd:
   cc = clang
   tlsEmulation:on
-  gcc.options.always = "-w"
-  gcc.cpp.options.always = "-w -fpermissive"
+  gcc.options.always = ""
+  gcc.cpp.options.always = "-fpermissive"
 @elif windows:
-  gcc.options.always = "-w -mno-ms-bitfields"
-  gcc.cpp.options.always = "-w -fpermissive -mno-ms-bitfields"
+  gcc.options.always = "-mno-ms-bitfields"
+  gcc.cpp.options.always = "-fpermissive -mno-ms-bitfields"
 @else:
-  gcc.options.always = "-w"
-  gcc.cpp.options.always = "-w -fpermissive"
+  gcc.options.always = ""
+  gcc.cpp.options.always = "-fpermissive"
 @end
 
 # Configuration for Objective-C compiler:
@@ -235,7 +235,7 @@ gcc.cpp.options.debug = "-g3 -Og"
 
 # Configuration for the LLVM GCC compiler:
 llvm_gcc.options.debug = "-g"
-llvm_gcc.options.always = "-w"
+llvm_gcc.options.always = ""
 llvm_gcc.options.speed = "-O2"
 llvm_gcc.options.size = "-Os"
 
@@ -282,7 +282,7 @@ vcc.options.size = "/O1"
 vcc.cpp.options.size = "/O1"
 
 # Configuration for the Tiny C Compiler:
-tcc.options.always = "-w"
+tcc.options.always = ""
 
 # Configuration for the Genode toolchain
 @if genode:

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -242,9 +242,9 @@ llvm_gcc.options.size = "-Os"
 # Configuration for the LLVM CLang compiler:
 clang.options.debug = "-g"
 clang.cpp.options.debug = "-g"
-# pending fixing `sem.nim.c:16829:37: error: & has lower precedence than ==`
-# when compiling nim, we can remove `-Wno-error=parentheses`
-clang.options.always = "-Werror -Wno-error=parentheses"
+# We whitelist some warnings so test suite passes; warnings will be generated
+# but will not error for these, so we can fix these later if needed.
+clang.options.always = "-Werror -Wno-error=parentheses -Wno-error=deprecated-declarations -Wno-error=int-to-void-pointer-cast -Wno-error=ignored-attributes -Wno-error=incompatible-pointer-types -Wno-error=compare-distinct-pointer-types -Wno-error=incompatible-library-redeclaration"
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -242,7 +242,9 @@ llvm_gcc.options.size = "-Os"
 # Configuration for the LLVM CLang compiler:
 clang.options.debug = "-g"
 clang.cpp.options.debug = "-g"
-clang.options.always = "-w"
+# pending fixing `sem.nim.c:16829:37: error: & has lower precedence than ==`
+# when compiling nim, we can remove `-Wno-error=parentheses`
+clang.options.always = "-Werror -Wno-error=parentheses"
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -47,48 +47,6 @@ __AVR__
 #  endif
 #endif
 
-
-/* ------------ ignore typical warnings in Nim-generated files ------------- */
-#ifndef NIM_ENABLE_BACKEND_WARNING
-#  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
-#  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
-#  pragma GCC diagnostic ignored "-Winvalid-noreturn"
-
-// for C++:
-// -Winvalid-offsetof
-
-#if defined(__GNUC__) || defined(__clang__)
-// note:
-
-#  pragma GCC diagnostic ignored "-Wpragmas"
-#  pragma GCC diagnostic ignored "-Wwritable-strings"
-#  pragma GCC diagnostic ignored "-Winvalid-noreturn"
-// #  pragma GCC diagnostic ignored "-Wformat" // this warning is always useful
-#  pragma GCC diagnostic ignored "-Wlogical-not-parentheses"
-#  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
-#  pragma GCC diagnostic ignored "-Wshadow"
-#  pragma GCC diagnostic ignored "-Wunused-function"
-#  pragma GCC diagnostic ignored "-Wunused-variable"
-#  pragma GCC diagnostic ignored "-Winvalid-offsetof"
-#  pragma GCC diagnostic ignored "-Wtautological-compare"
-#  pragma GCC diagnostic ignored "-Wswitch-bool"
-#  pragma GCC diagnostic ignored "-Wmacro-redefined"
-// this will prevent `--passC:-Wwrite-strings` from warning for char*s = "foo"
-// which can indicate serious bugs but cgen also generates a lot of these
-#  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
-#  pragma GCC diagnostic ignored "-Wpointer-bool-conversion"
-#  pragma GCC diagnostic ignored "-Wconstant-conversion"
-#endif
-
-#if defined(_MSC_VER)
-#  pragma warning(disable: 4005 4100 4101 4189 4191 4200 4244 4293 4296 4309)
-#  pragma warning(disable: 4310 4365 4456 4477 4514 4574 4611 4668 4702 4706)
-#  pragma warning(disable: 4710 4711 4774 4800 4809 4820 4996 4090 4297)
-#endif
-#endif // NIM_ENABLE_BACKEND_WARNING
-/* ------------------------------------------------------------------------- */
-
-
 #if defined(__GNUC__)
 #  define _GNU_SOURCE 1
 #endif

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -47,6 +47,36 @@ __AVR__
 #  endif
 #endif
 
+
+/* ------------ ignore typical warnings in Nim-generated files ------------- */
+#ifndef NIM_UNIGNORE_DEFAULT_BACKEND_WARNINGS
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic ignored "-Wpragmas"
+#  pragma GCC diagnostic ignored "-Wwritable-strings"
+#  pragma GCC diagnostic ignored "-Winvalid-noreturn"
+#  pragma GCC diagnostic ignored "-Wformat"
+#  pragma GCC diagnostic ignored "-Wlogical-not-parentheses"
+#  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
+#  pragma GCC diagnostic ignored "-Wshadow"
+#  pragma GCC diagnostic ignored "-Wunused-function"
+#  pragma GCC diagnostic ignored "-Wunused-variable"
+#  pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#  pragma GCC diagnostic ignored "-Wtautological-compare"
+#  pragma GCC diagnostic ignored "-Wswitch-bool"
+#  pragma GCC diagnostic ignored "-Wmacro-redefined"
+#  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#  pragma GCC diagnostic ignored "-Wpointer-bool-conversion"
+#  pragma GCC diagnostic ignored "-Wconstant-conversion"
+#endif
+
+#if defined(_MSC_VER)
+#  pragma warning(disable: 4005 4100 4101 4189 4191 4200 4244 4293 4296 4309)
+#  pragma warning(disable: 4310 4365 4456 4477 4514 4574 4611 4668 4702 4706)
+#  pragma warning(disable: 4710 4711 4774 4800 4809 4820 4996 4090 4297)
+#endif
+#endif
+/* ------------------------------------------------------------------------- */
+
 #if defined(__GNUC__)
 #  define _GNU_SOURCE 1
 #endif

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -49,6 +49,7 @@ __AVR__
 
 
 /* ------------ ignore typical warnings in Nim-generated files ------------- */
+#ifndef NIM_ENABLE_BACKEND_WARNING
 #  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
 #  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
 #  pragma GCC diagnostic ignored "-Winvalid-noreturn"
@@ -56,7 +57,6 @@ __AVR__
 // for C++:
 // -Winvalid-offsetof
 
-#ifndef NIM_ENABLE_BACKEND_WARNING
 #if defined(__GNUC__) || defined(__clang__)
 // note:
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -49,11 +49,21 @@ __AVR__
 
 
 /* ------------ ignore typical warnings in Nim-generated files ------------- */
+#  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
+#  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
+#  pragma GCC diagnostic ignored "-Winvalid-noreturn"
+
+// for C++:
+// -Winvalid-offsetof
+
+#ifndef NIM_ENABLE_BACKEND_WARNING
 #if defined(__GNUC__) || defined(__clang__)
+// note:
+
 #  pragma GCC diagnostic ignored "-Wpragmas"
 #  pragma GCC diagnostic ignored "-Wwritable-strings"
 #  pragma GCC diagnostic ignored "-Winvalid-noreturn"
-// #  pragma GCC diagnostic ignored "-Wformat"
+// #  pragma GCC diagnostic ignored "-Wformat" // this warning is always useful
 #  pragma GCC diagnostic ignored "-Wlogical-not-parentheses"
 #  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
 #  pragma GCC diagnostic ignored "-Wshadow"
@@ -63,6 +73,8 @@ __AVR__
 #  pragma GCC diagnostic ignored "-Wtautological-compare"
 #  pragma GCC diagnostic ignored "-Wswitch-bool"
 #  pragma GCC diagnostic ignored "-Wmacro-redefined"
+// this will prevent `--passC:-Wwrite-strings` from warning for char*s = "foo"
+// which can indicate serious bugs but cgen also generates a lot of these
 #  pragma GCC diagnostic ignored "-Wincompatible-pointer-types-discards-qualifiers"
 #  pragma GCC diagnostic ignored "-Wpointer-bool-conversion"
 #  pragma GCC diagnostic ignored "-Wconstant-conversion"
@@ -73,7 +85,9 @@ __AVR__
 #  pragma warning(disable: 4310 4365 4456 4477 4514 4574 4611 4668 4702 4706)
 #  pragma warning(disable: 4710 4711 4774 4800 4809 4820 4996 4090 4297)
 #endif
+#endif // NIM_ENABLE_BACKEND_WARNING
 /* ------------------------------------------------------------------------- */
+
 
 #if defined(__GNUC__)
 #  define _GNU_SOURCE 1

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -53,7 +53,7 @@ __AVR__
 #  pragma GCC diagnostic ignored "-Wpragmas"
 #  pragma GCC diagnostic ignored "-Wwritable-strings"
 #  pragma GCC diagnostic ignored "-Winvalid-noreturn"
-#  pragma GCC diagnostic ignored "-Wformat"
+// #  pragma GCC diagnostic ignored "-Wformat"
 #  pragma GCC diagnostic ignored "-Wlogical-not-parentheses"
 #  pragma GCC diagnostic ignored "-Wlogical-op-parentheses"
 #  pragma GCC diagnostic ignored "-Wshadow"

--- a/tests/misc/mbackendwarnings.nim
+++ b/tests/misc/mbackendwarnings.nim
@@ -1,13 +1,7 @@
 ## tests cgen warnings, see trunner
 
-{.localpassc:"-Wwritable-strings".}
-
 proc c_printf(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.}
 
 c_printf("warning_1: %d\n", 1.2) # -Wformat
 c_printf("a: %d, warning_2: %s\n", 1.cint) # -Wformat
 c_printf("a: %d, no_warning: %s\n", 1.cint, "foo".cstring) # no warning
-
-var s: cstring = "warning_3" # -Wwritable-strings
-# s[0] = 'a' # warning useful for user code because this would cause SIGBUS
-echo s

--- a/tests/misc/mbackendwarnings.nim
+++ b/tests/misc/mbackendwarnings.nim
@@ -1,0 +1,13 @@
+## tests cgen warnings, see trunner
+
+{.localpassc:"-Wwritable-strings".}
+
+proc c_printf(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.}
+
+c_printf("warning_1: %d\n", 1.2) # -Wformat
+c_printf("a: %d, warning_2: %s\n", 1.cint) # -Wformat
+c_printf("a: %d, no_warning: %s\n", 1.cint, "foo".cstring) # no warning
+
+var s: cstring = "warning_3" # -Wwritable-strings
+# s[0] = 'a' # warning useful for user code because this would cause SIGBUS
+echo s

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -25,14 +25,13 @@ proc testCodegenStaticAssert() =
   doAssert "sizeof(bool) == 2" in output
   doAssert exitCode != 0
 
-proc testCmdline() =
-  let (output, exitCode) = runCmd("misc/mbackendwarnings.nim", "-f --warning:backendWarning:on --stacktrace:off")
-  doAssert r"warning_1" in output, output
-  doAssert r"warning_2" in output, output
-  if mode == "cpp":
-    doAssert r"warning_3" in output, output
-  doAssert r"no_warning" notin output, output  # sanity check
-  doAssert exitCode == 0, output
+proc testBackendWarnings() =
+  when defined clang:
+    let (output, exitCode) = runCmd("misc/mbackendwarnings.nim", "-f --warning:backendWarning:on --stacktrace:off")
+    doAssert r"warning_1" in output, output
+    doAssert r"warning_2" in output, output
+    doAssert r"no_warning" notin output, output  # sanity check
+    doAssert exitCode == 0, output
 
 proc testCTFFI() =
   let (output, exitCode) = runCmd("vm/mevalffi.nim", "--experimental:compiletimeFFI")
@@ -53,4 +52,4 @@ when defined(nimHasLibFFIEnabled):
   testCTFFI()
 else: # don't run twice the same test
   testCodegenStaticAssert()
-  testCmdline()
+  testBackendWarnings()

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -29,13 +29,12 @@ proc testCTFFI() =
   let expected = """
 hello world stderr
 hi stderr
-foo
-foo:100
-foo:101
-foo:102:103
-foo:102:103:104
-foo:0.03:asdf:103:105
-ret={s1:foobar s2:foobar age:25 pi:3.14}
+foo0
+foo1:101
+foo2:102:103
+foo3:102:103:104
+foo4:0.03:asdf:103:105
+foo5:{s1:foobar s2:foobar age:25 pi:3.14}
 """
   doAssert output == expected, output
   doAssert exitCode == 0

--- a/tests/vm/mevalffi.nim
+++ b/tests/vm/mevalffi.nim
@@ -24,14 +24,13 @@ proc fun() =
     doAssert c_exp(x2) == c_exp(x)
 
   block: # c_printf
-    c_printf("foo\n")
-    c_printf("foo:%d\n", 100)
-    c_printf("foo:%d\n", 101.cint)
-    c_printf("foo:%d:%d\n", 102.cint, 103.cint)
+    c_printf("foo0\n")
+    c_printf("foo1:%d\n", 101.cint)
+    c_printf("foo2:%d:%d\n", 102.cint, 103.cint)
     let temp = 104.cint
-    c_printf("foo:%d:%d:%d\n", 102.cint, 103.cint, temp)
+    c_printf("foo3:%d:%d:%d\n", 102.cint, 103.cint, temp)
     var temp2 = 105.cint
-    c_printf("foo:%g:%s:%d:%d\n", 0.03, "asdf", 103.cint, temp2)
+    c_printf("foo4:%g:%s:%d:%d\n", 0.03, "asdf", 103.cint, temp2)
 
   block: # c_snprintf, c_malloc, c_free
     let n: uint = 50
@@ -39,19 +38,18 @@ proc fun() =
     var s: cstring = "foobar"
     var age: cint = 25
     discard c_snprintf(buffer2, n, "s1:%s s2:%s age:%d pi:%g", s, s, age, 3.14)
-    c_printf("ret={%s}\n", buffer2)
+    c_printf("foo5:{%s}\n", buffer2)
     c_free(buffer2) # not sure it has an effect
 
-  block: # c_printf bug
-    var a = 123
+  block: # c_printf bug with `var` {.varargs.} params
+    var a = 123.cint
     var a2 = a.addr
-    #[
-    bug: different behavior between CT RT in this case:
-    at CT, shows foo2:a=123
-    at RT, shows foo2:a=<address as int>
-    ]#
-    if false:
-      c_printf("foo2:a=%d\n", a2)
+    when false:
+      # BUG: CT FFI currently does not handle this edge case correctly,
+      # passing `a2` as `cint` instead of as `ptr cint` for a {.varargs.} param:
+      # at CT, shows foo6:a2=0x7b
+      # at RT, shows foo2:a2=<address>
+      c_printf("foo6:a2=%p\n", a2)
 
 
 static:


### PR DESCRIPTION
* fix #11590
other compilers besides `clang` can be fixed in followup PR's

After this PR, compiling the example from #11590 gives:
```nim
/tmp/nim/tmp.d02/t04377.nim.c:149:8: warning: implicit declaration of function 'mach_absolute_time' is invalid in C99 [-Wimplicit-function-declaration]
        T2_ = mach_absolute_time();
              ^
```
instead of silently accepting and giving undefined behavior without any warning

as a side benefit, since warnings (and errors) are now printed to stderr (instead of capturing sdout + stderr as it was before PR), clang will honor colors (since it's a tty) so we get colored clang errors/warnings.

## Note: whether to treat errors as warnings
in a previous version of this PR I was passing ` -Werror` + a minimal whitelist of warnings to ignore so that it would pass the test suite. This would be a more breaking change so should be done in subsequent PR if at all.
These were:
```
-Werror -Wno-error=parentheses -Wno-error=deprecated-declarations -Wno-error=int-to-void-pointer-cast -Wno-error=ignored-attributes -Wno-error=incompatible-pointer-types -Wno-error=compare-distinct-pointer-types -Wno-error=incompatible-library-redeclaration
```

note that after this PR, recompiling nim only generates 1 warning: `-Wparentheses` (but test running test suite may generate more), so we don't generate a ton of noise, but the benefit is we do now show warnings which could indicate a bug (as was case in #11590)


## note:
appveyor failures seem unrelated, see https://ci.appveyor.com/project/Araq/nim/builds/25543607/job/lfumr9dh3qogtjpm/tests