### PR TITLE
[bugfix] fix mach_absolute_time header; refs #11591

### DIFF
--- a/lib/system/timers.nim
+++ b/lib/system/timers.nim
@@ -36,9 +36,9 @@ elif defined(macosx):
     MachTimebaseInfoData {.pure, final,
         importc: "mach_timebase_info_data_t",
         header: "<mach/mach_time.h>".} = object
-      numer, denom: int32
+      numer, denom: int32 # note: `uint32` in sources
 
-  proc mach_absolute_time(): int64 {.importc, header: "<mach/mach.h>".}
+  proc mach_absolute_time(): uint64 {.importc, header: "<mach/mach_time.h>".}
   proc mach_timebase_info(info: var MachTimebaseInfoData) {.importc,
     header: "<mach/mach_time.h>".}
 


### PR DESCRIPTION
* refs #11591

wrong header was used, which was one of the issues mentioned in https://github.com/nim-lang/Nim/issues/11590

I also fixed uint64 to uint64 (cf https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time) for correctness in case user includes `sytem/timers` and wants to use `mach_absolute_time` ; this'll get converted to int64 (`Ticks`) anyways, but header should IMO reflect the real type whenever possible.
I didn't fix numer/denom but added a note (would require cast or conver to int32 otherwise compiler error)


## note
https://nim-lang.github.io/Nim/times.html mentions this:
```
proc getTime(): Time {...}
Gets the current time as a Time with up to nanosecond resolution.
```
while technically correct, this doesn't mention the fact that on OSX (and maybe in other cases), the resolution is limited to microseconds; for precise benchmarking requiring higher precision, `system/timers` can be used instead, giving highest available resolution (in nanoseconds) and also causes less overhead (also important for some benchmarks). Doc could either mention system/timers or code could wrap the API inside `std/times`
