### PR TITLE
compiler/[msgs, reorder, semstmts]: use toMsgFilename where appropriate

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -195,18 +195,19 @@ template toFullPath*(conf: ConfigRef; info: TLineInfo): string =
 template toFullPathConsiderDirty*(conf: ConfigRef; info: TLineInfo): string =
   string toFullPathConsiderDirty(conf, info.fileIndex)
 
-proc toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
-  if info.fileIndex.int32 < 0:
-    return "???"
+proc toMsgFilename*(conf: ConfigRef; info: FileIndex): string =
   let
-    absPath = conf.m.fileInfos[info.fileIndex.int32].fullPath.string
-    relPath = conf.m.fileInfos[info.fileIndex.int32].projPath.string
+    absPath = toFullPath(conf, info)
+    relPath = toFilename(conf, info)
   result = if (optListFullPaths in conf.globalOptions) or
               (relPath.len > absPath.len) or
               (relPath.count("..") > 2):
              absPath
            else:
              relPath
+
+template toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
+  toMsgFilename(conf, info.fileIndex)
 
 proc toLinenumber*(info: TLineInfo): int {.inline.} =
   result = int info.line

--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -154,7 +154,7 @@ proc expandIncludes(graph: ModuleGraph, module: PSym, n: PNode,
         if f != InvalidFileIDX:
           if containsOrIncl(includedFiles, f.int):
             localError(graph.config, a.info, "recursive dependency: '$1'" %
-              toFilename(graph.config, f))
+              toMsgFilename(graph.config, f))
           else:
             let nn = includeModule(graph, module, f)
             let nnn = expandIncludes(graph, module, nn, modulePath,

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1288,7 +1288,7 @@ proc semAllTypeSections(c: PContext; n: PNode): PNode =
         var f = checkModuleName(c.config, n.sons[i])
         if f != InvalidFileIDX:
           if containsOrIncl(c.includedFiles, f.int):
-            localError(c.config, n.info, errRecursiveDependencyX % toFilename(c.config, f))
+            localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
           else:
             let code = c.graph.includeFileCallback(c.graph, c.module, f)
             gatherStmts c, code, result
@@ -2023,7 +2023,7 @@ proc incMod(c: PContext, n: PNode, it: PNode, includeStmtResult: PNode) =
   var f = checkModuleName(c.config, it)
   if f != InvalidFileIDX:
     if containsOrIncl(c.includedFiles, f.int):
-      localError(c.config, n.info, errRecursiveDependencyX % toFilename(c.config, f))
+      localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
     else:
       addSon(includeStmtResult, semStmt(c, c.graph.includeFileCallback(c.graph, c.module, f), {}))
       excl(c.includedFiles, f.int)


### PR DESCRIPTION
This is a follow up of #11583 covering cases of `toFilename` used for compiler messages that I've missed.

/cc @timotheecour 