### PR TITLE
Make repr print 'ptr' for ptr types instead of 'ref'

### DIFF
--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -230,7 +230,8 @@ when not defined(useNimRtl):
         var cell = cast[PCell](p)
       else:
         var cell = usrToCell(p)
-      add result, "ref " & reprPointer(p)
+      add result, if typ.kind == tyPtr: "ptr " else: "ref "
+      add result, reprPointer(p)
       if cell notin cl.marked:
         # only the address is shown:
         incl(cl.marked, cell)


### PR DESCRIPTION


```
import typetraits

var a:int

var b = a.addr
echo b.type.name
echo b.repr
                  
var c = new int   
echo c.type.name
echo c.repr
```

```
ptr int
ptr 0x557736e5aca0 --> 0

ref int
ref 0x7f697999c048 --> 0
```