### PR TITLE
fix #8405: -d:useNimRtl now works even when {.rtl.} procs are used at compile time; CTFFI now works with {dynlib}

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1881,12 +1881,11 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
 
         c.p.wasForwarded = proto != nil
         maybeAddResult(c, s, n)
-        if lfDynamicLib notin s.loc.flags or n.sons[bodyPos] != nil:
-          # semantic checking for importc needed in case used in VM
-          s.ast[bodyPos] = hloBody(c, semProcBody(c, n.sons[bodyPos]))
-          # unfortunately we cannot skip this step when in 'system.compiles'
-          # context as it may even be evaluated in 'system.compiles':
-          trackProc(c, s, s.ast[bodyPos])
+        # semantic checking also needed with importc in case used in VM
+        s.ast[bodyPos] = hloBody(c, semProcBody(c, n.sons[bodyPos]))
+        # unfortunately we cannot skip this step when in 'system.compiles'
+        # context as it may even be evaluated in 'system.compiles':
+        trackProc(c, s, s.ast[bodyPos])
         if s.kind == skMethod: semMethodPrototype(c, s, n)
       else:
         if (s.typ.sons[0] != nil and kind != skIterator) or kind == skMacro:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1082,12 +1082,15 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[pointer](regs),
                  currentException: c.currentExceptionA,
                  currentLineInfo: c.debug[pc]))
-      elif sfImportc in prc.flags:
+      elif shouldImportcSymbol(prc):
         if compiletimeFFI notin c.config.features:
           globalError(c.config, c.debug[pc], "VM not allowed to do FFI, see `compiletimeFFI`")
         # we pass 'tos.slots' instead of 'regs' so that the compiler can keep
         # 'regs' in a register:
         when hasFFI:
+          if prc.position - 1 < 0:
+            globalError(c.config, c.debug[pc],
+              "VM call invalid: prc.position: " & $prc.position)
           let prcValue = c.globals.sons[prc.position-1]
           if prcValue.kind == nkEmpty:
             globalError(c.config, c.debug[pc], "cannot run " & prc.name.s)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1082,7 +1082,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[pointer](regs),
                  currentException: c.currentExceptionA,
                  currentLineInfo: c.debug[pc]))
-      elif shouldImportcSymbol(prc):
+      elif importcCond(prc):
         if compiletimeFFI notin c.config.features:
           globalError(c.config, c.debug[pc], "VM not allowed to do FFI, see `compiletimeFFI`")
         # we pass 'tos.slots' instead of 'regs' so that the compiler can keep

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1547,6 +1547,12 @@ proc genTypeLit(c: PCtx; t: PType; dest: var TDest) =
 proc importcCond(s: PSym): bool {.inline.} =
   sfImportc in s.flags and (lfDynamicLib notin s.loc.flags or s.ast == nil)
 
+proc shouldImportcSymbol*(s: PSym): bool =
+  ## return true to importc `s`, false to execute its body instead (refs #8405)
+  if sfImportc in s.flags:
+    assert s.kind == skProc
+    return s.ast.sons[bodyPos].kind == nkEmpty
+
 proc importcSym(c: PCtx; info: TLineInfo; s: PSym) =
   when hasFFI:
     if compiletimeFFI in c.config.features:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1547,7 +1547,7 @@ proc genTypeLit(c: PCtx; t: PType; dest: var TDest) =
 proc importcCond*(s: PSym): bool {.inline.} =
   ## return true to importc `s`, false to execute its body instead (refs #8405)
   if sfImportc in s.flags:
-    if s.kind == skProc:
+    if s.kind in routineKinds:
       return s.ast.sons[bodyPos].kind == nkEmpty
 
 proc importcSym(c: PCtx; info: TLineInfo; s: PSym) =

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1544,14 +1544,11 @@ proc genTypeLit(c: PCtx; t: PType; dest: var TDest) =
   n.typ = t
   genLit(c, n, dest)
 
-proc importcCond(s: PSym): bool {.inline.} =
-  sfImportc in s.flags and (lfDynamicLib notin s.loc.flags or s.ast == nil)
-
-proc shouldImportcSymbol*(s: PSym): bool =
+proc importcCond*(s: PSym): bool {.inline.} =
   ## return true to importc `s`, false to execute its body instead (refs #8405)
   if sfImportc in s.flags:
-    assert s.kind == skProc
-    return s.ast.sons[bodyPos].kind == nkEmpty
+    if s.kind == skProc:
+      return s.ast.sons[bodyPos].kind == nkEmpty
 
 proc importcSym(c: PCtx; info: TLineInfo; s: PSym) =
   when hasFFI:
@@ -1559,7 +1556,8 @@ proc importcSym(c: PCtx; info: TLineInfo; s: PSym) =
       c.globals.add(importcSymbol(c.config, s))
       s.position = c.globals.len
     else:
-      localError(c.config, info, "VM is not allowed to 'importc'")
+      localError(c.config, info,
+        "VM is not allowed to 'importc' without --experimental:compiletimeFFI")
   else:
     localError(c.config, info,
                "cannot 'importc' variable at compile time; " & s.name.s)

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -366,43 +366,42 @@ proc next*(p: var OptParser) {.rtl, extern: "npo$1".} =
     inc p.idx
     p.pos = 0
 
-when declared(os.paramCount):
-  proc cmdLineRest*(p: OptParser): TaintedString {.rtl, extern: "npo$1".} =
-    ## Retrieves the rest of the command line that has not been parsed yet.
-    ##
-    ## See also:
-    ## * `remainingArgs proc<#remainingArgs,OptParser>`_
-    ##
-    ## **Examples:**
-    ##
-    ## .. code-block::
-    ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
-    ##   while true:
-    ##     p.next()
-    ##     if p.kind == cmdLongOption and p.key == "":  # Look for "--"
-    ##       break
-    ##     else: continue
-    ##   doAssert p.cmdLineRest == "foo.txt bar.txt"
-    result = p.cmds[p.idx .. ^1].quoteShellCommand.TaintedString
+proc cmdLineRest*(p: OptParser): TaintedString {.rtl, extern: "npo$1".} =
+  ## Retrieves the rest of the command line that has not been parsed yet.
+  ##
+  ## See also:
+  ## * `remainingArgs proc<#remainingArgs,OptParser>`_
+  ##
+  ## **Examples:**
+  ##
+  ## .. code-block::
+  ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
+  ##   while true:
+  ##     p.next()
+  ##     if p.kind == cmdLongOption and p.key == "":  # Look for "--"
+  ##       break
+  ##     else: continue
+  ##   doAssert p.cmdLineRest == "foo.txt bar.txt"
+  result = p.cmds[p.idx .. ^1].quoteShellCommand.TaintedString
 
-  proc remainingArgs*(p: OptParser): seq[TaintedString] {.rtl, extern: "npo$1".} =
-    ## Retrieves a sequence of the arguments that have not been parsed yet.
-    ##
-    ## See also:
-    ## * `cmdLineRest proc<#cmdLineRest,OptParser>`_
-    ##
-    ## **Examples:**
-    ##
-    ## .. code-block::
-    ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
-    ##   while true:
-    ##     p.next()
-    ##     if p.kind == cmdLongOption and p.key == "":  # Look for "--"
-    ##       break
-    ##     else: continue
-    ##   doAssert p.remainingArgs == @["foo.txt", "bar.txt"]
-    result = @[]
-    for i in p.idx..<p.cmds.len: result.add TaintedString(p.cmds[i])
+proc remainingArgs*(p: OptParser): seq[TaintedString] {.rtl, extern: "npo$1".} =
+  ## Retrieves a sequence of the arguments that have not been parsed yet.
+  ##
+  ## See also:
+  ## * `cmdLineRest proc<#cmdLineRest,OptParser>`_
+  ##
+  ## **Examples:**
+  ##
+  ## .. code-block::
+  ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
+  ##   while true:
+  ##     p.next()
+  ##     if p.kind == cmdLongOption and p.key == "":  # Look for "--"
+  ##       break
+  ##     else: continue
+  ##   doAssert p.remainingArgs == @["foo.txt", "bar.txt"]
+  result = @[]
+  for i in p.idx..<p.cmds.len: result.add TaintedString(p.cmds[i])
 
 iterator getopt*(p: var OptParser): tuple[kind: CmdLineKind, key, val: TaintedString] =
   ## Convenience iterator for iterating over the given

--- a/lib/system/repr.nim
+++ b/lib/system/repr.nim
@@ -299,18 +299,19 @@ when not defined(useNimRtl):
       add result, "(invalid data!)"
     inc(cl.recdepth)
 
-proc reprOpenArray(p: pointer, length: int, elemtyp: PNimType): string {.
-                   compilerRtl.} =
-  var
-    cl: ReprClosure
-  initReprClosure(cl)
-  result = "["
-  var bs = elemtyp.size
-  for i in 0..length - 1:
-    if i > 0: add result, ", "
-    reprAux(result, cast[pointer](cast[ByteAddress](p) + i*bs), elemtyp, cl)
-  add result, "]"
-  deinitReprClosure(cl)
+when not defined(useNimRtl):
+  proc reprOpenArray(p: pointer, length: int, elemtyp: PNimType): string {.
+                     compilerRtl.} =
+    var
+      cl: ReprClosure
+    initReprClosure(cl)
+    result = "["
+    var bs = elemtyp.size
+    for i in 0..length - 1:
+      if i > 0: add result, ", "
+      reprAux(result, cast[pointer](cast[ByteAddress](p) + i*bs), elemtyp, cl)
+    add result, "]"
+    deinitReprClosure(cl)
 
 when not defined(useNimRtl):
   proc reprAny(p: pointer, typ: PNimType): string =


### PR DESCRIPTION
* nim now allows using dynamic shared libraries at compile time when compiled with `-d:nimHasLibFFI`, extending the scope of #10150 to cover `{.dynlib:mylib.}`, not just `{.importc.}` which was only for symbols dlsym'd from the main running executable

this is especially useful as we can now call arbitrary compiled user code at CT imported as a shared library (eg regex, or access global variables via wrappers, or to speedup CT operations by avoiding the VM interpretation, or writing to stderr at compile time)

* fixes #8405 (issue was marked as closed but wasn't actually fixed AFAIK, see https://github.com/nim-lang/Nim/issues/8405#issuecomment-507422748) 
/cc @awr1 @ccll 
/cc @zah because you asked about that bug here https://github.com/nim-lang/Nim/pull/10150#issuecomment-451903510

#8405 has been a major blocker for writing shared libraries / plugins: it prevented using any proc marked as `{.rtl.}` at compile time (more generally, any proc with `{.importc.}`); for example simply importing pkg/regex would fail with `-d:useNimRtl` because somewhere in the code, `strutils.repeat` is used at CT. (note that #10150 mitigates but doesn't fix this as explained here: https://github.com/nim-lang/Nim/issues/8405#issuecomment-507422748)

After this PR, `importc` procs with a body are executed in the VM as if `importc` wasn't specified: the body is compiled when used at compile time, and symbol is dynamically loaded when used at runtime.

nim can now be compiled with `-d:useNimRtl`, eg:
```
./bin/nim c -d:useNimRtl --skipUserCfg --skipParentCfg -o:bin/nim_temp1 -d:leanCompiler --passL:-Wl,-rpath,lib compiler/nim.nim
```
(whether the produced binary is a fully working nim compiler is a separate issue that can be addressed later)

whereas this would give errors before this PR.

## example usage: CT FFI, dynlib, importc; with and without VM override
```nim
# t0464b.nim dynlib compiled with: `nim c -o:/tmp/libt0464b.dylib t0464b.nim`
proc fun1() {.exportc.} =
  echo "in fun1 v1"

proc fun2() {.exportc.} =
  echo "in fun2 v1"

var myvar {.exportc.}: int = 1234

proc set_myvar(a: int) {.exportc.} =
  myvar = a

proc get_myvar(): int {.exportc.} =
  myvar
```

```nim
# main.nim
proc c_exp1(a: float64): float64 {.importc: "exp", header: "<math.h>".}
proc c_exp2(a: float64): float64 {.importc: "exp", header: "<math.h>".} =
  echo "override exp"
  return 1234.0


proc c_printf1(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.}
proc c_printf2(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.} =
  echo "override printf"
  return 0

{.push importc, dynlib: "/tmp/libt0464b.dylib".}
proc fun1()
proc fun2() = echo "override fun1"
proc set_myvar(a: int)
proc get_myvar(): int
{.pop.}


proc main()=
  when defined(case_nim_has_ffi):
    echo c_exp1(1.0)
    c_printf1("hello world1\n")
    fun1()
    set_myvar(123)
    doAssert get_myvar() == 123

  echo c_exp2(1.0)
  c_printf2("hello world2\n")
  fun2()

static: main()
main()
```

### output with nim c -r main.nim
```
override exp
1234.0
override printf
override fun1
Hint: operation successful (51925 lines compiled; 0.377 sec total; 58.875MiB peakmem; Debug Build) [SuccessX]
2.718281828459045
hello world2
in fun2 v1
```
### output with nim c -r --experimental:compiletimeFFI -d: case_nim_has_ffi  main.nim
(and nim built with -d:nimHasLibFFI)
```
2.718281828459045
hello world1
in fun1 v1
override exp
1234.0
override printf
override fun1
Hint: operation successful (51925 lines compiled; 0.480 sec total; 58.879MiB peakmem; Debug Build) [SuccessX]
2.718281828459045
hello world1
in fun1 v1
2.718281828459045
hello world2
in fun2 v1
```

## note
* without `-d:leanCompiler` the above command gives: I get: docutils/highlite.nim(401, 15) Error: type mismatch: got <openarray[string], string, proc (a: string, b: string): int{.cdecl, noSideEffect, gcsafe, locks: 0.}>
* without the change to `lib/pure/parseopt.nim` , after recompiling `./bin/nim c lib/nimrtl.nim`, and recompiling `bin/nim_temp1` as above, running `bin/nim_temp1` would error with: `could not import: npocmdLineRest`
* `lib/system/repr.nim` was also needed to prevent: `lib/system/repr.nim(306, 3) Error: undeclared identifier: 'initReprClosure'`
