### PR TITLE
Fixed the broken link to the strformat module in math.nim

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -47,7 +47,7 @@
 ## * `random module<random.html>`_ for fast and tiny random number generator
 ## * `mersenne module<mersenne.html>`_ for Mersenne twister random number generator
 ## * `stats module<stats.html>`_ for statistical analysis
-## * `strformat module<strformat>`_ for formatting floats for print
+## * `strformat module<strformat.html>`_ for formatting floats for print
 
 
 include "system/inclrtl"


### PR DESCRIPTION
In the documentation for math.nim, the link to the strformat module in the "See also" section at the top of the documentation is broken so it takes you to https://nim-lang.org/documentation.html instead of https://nim-lang.org/docs/strformat.html. This patch fixes that.