### PR TITLE
fix #11651 exportc symbol not exported, leading to link error

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2669,9 +2669,8 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         if ({sfExportc, sfCompilerProc} * prc.flags == {sfExportc}) or
             (sfExportc in prc.flags and lfExportLib in prc.loc.flags) or
             (prc.kind == skMethod):
-          # we have not only the header:
-          if prc.getBody.kind != nkEmpty or lfDynamicLib in prc.loc.flags:
-            genProc(p.module, prc)
+          # Generate proc even if empty body, bugfix #11651.
+          genProc(p.module, prc)
   of nkParForStmt: genParForStmt(p, n)
   of nkState: genState(p, n)
   of nkGotoState:


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/issues/11651

note that this PR doesn't introduce spurious symbols in binary, eg:

```nim
proc foo1() = when false: discard
proc foo2() {.exportc.} = when false: discard
# rest of code...
```

if `foo1` wasn't generated before PR in binary (eg not referenced), it won't be generated after PR
but `foo2` will get generated after PR as it's marked `exportc`

Note that:
`proc foo {.exportc.}` without body is still generating CT error (unless an implementation follows somewhere in module), nothing changes here