### PR TITLE
nimpretty: improved detection of commas and semicolons

### DIFF
--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -509,12 +509,9 @@ proc endsWith(em: Emitter; k: varargs[string]): bool =
   return true
 
 proc rfind(em: Emitter, t: string): int =
-  var i = em.tokens.high
-  while i >= 0:
-    if em.tokens[i] == t:
+  for i in 1 .. 5:
+    if em.tokens[^i] == t:
       return i
-    dec i
-  return -1
 
 proc starWasExportMarker*(em: var Emitter) =
   if em.endsWith(" ", "*", " "):
@@ -526,11 +523,11 @@ proc starWasExportMarker*(em: var Emitter) =
 
 proc commaWasSemicolon*(em: var Emitter) =
   if em.semicolons == detectSemicolonKind:
-    em.semicolons = if em.rfind(";") >= 0: useSemicolon else: dontTouch
+    em.semicolons = if em.rfind(";") > 0: useSemicolon else: dontTouch
   if em.semicolons == useSemicolon:
     let commaPos = em.rfind(",")
-    if commaPos >= em.tokens.len - 3:
-      em.tokens[commaPos] = ";"
+    if commaPos > 0:
+      em.tokens[^commaPos] = ";"
 
 proc curlyRiWasPragma*(em: var Emitter) =
   if em.endsWith("}"):

--- a/nimpretty/tests/expected/simple4.nim
+++ b/nimpretty/tests/expected/simple4.nim
@@ -1,0 +1,2 @@
+proc readBuffer*(f: AsyncFile, buf: pointer, size: int): Future[int] =
+  discard

--- a/nimpretty/tests/simple4.nim
+++ b/nimpretty/tests/simple4.nim
@@ -1,0 +1,2 @@
+proc readBuffer*(f: AsyncFile, buf: pointer, size: int): Future[int] =
+  discard


### PR DESCRIPTION
This bug has been spotted by @dom96 when nimpretty was run on stdlib ([link](https://github.com/nim-lang/Nim/pull/11646#discussion_r300143128)).

The problem was that `","` was **not** guaranteed to be the semi-last token (`em.endsWith(",", " ")`) because of `optionalNewline`, and if that was the case — nimpretty would use semicolon as the default separator.

...only to fail again when a similar situation (comma, followed by `optionalNewline` token, followed by the space) arose and then it failed to convert comma to semicolon.

E.g.:

```nim
proc readBuffer*(f: AsyncFile; buf: pointer, size: int): Future[int] =
#                            ^             ^
#                            |             |
#                      wrong change     ignoring
```

```