### PR TITLE
nimpretty: don't touch formatted multiline comments

### DIFF
--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -300,29 +300,37 @@ proc emitMultilineComment(em: var Emitter, lit: string, col: int) =
   var i = 0
   var lastIndent = em.indentStack[^1]
   var b = 0
+  var dontIndent = false
   for commentLine in splitLines(lit):
-    let stripped = commentLine.strip()
-    var a = 0
-    while a < commentLine.len and commentLine[a] == ' ': inc a
-    if i == 0:
-      if em.kinds.len > 0 and em.kinds[^1] != ltTab:
-        wr(em, "", ltTab)
-    elif stripped.len == 0:
+    if i == 0 and (commentLine.endsWith("\\") or commentLine.endsWith("[")):
+      dontIndent = true
+      wr em, commentLine, ltComment
+    elif dontIndent:
       wrNewline em
+      wr em, commentLine, ltComment
     else:
-      if a > lastIndent:
-        b += em.indWidth
-        lastIndent = a
-      elif a < lastIndent:
-        b -= em.indWidth
-        lastIndent = a
-      wrNewline em
-      #wrSpaces em, col + b
-      if col + b > 0:
-        wr(em, repeat(' ', col+b), ltTab)
+      let stripped = commentLine.strip()
+      var a = 0
+      while a < commentLine.len and commentLine[a] == ' ': inc a
+      if i == 0:
+        if em.kinds.len > 0 and em.kinds[^1] != ltTab:
+          wr(em, "", ltTab)
+      elif stripped.len == 0:
+        wrNewline em
       else:
-        wr(em, "", ltTab)
-    wr em, stripped, ltComment
+        if a > lastIndent:
+          b += em.indWidth
+          lastIndent = a
+        elif a < lastIndent:
+          b -= em.indWidth
+          lastIndent = a
+        wrNewline em
+        #wrSpaces em, col + b
+        if col + b > 0:
+          wr(em, repeat(' ', col+b), ltTab)
+        else:
+          wr(em, "", ltTab)
+      wr em, stripped, ltComment
     inc i
 
 proc lastChar(s: string): char =

--- a/nimpretty/tests/exhaustive.nim
+++ b/nimpretty/tests/exhaustive.nim
@@ -689,6 +689,34 @@ proc newRecordGen(ctx: Context; typ: TypRef): PNode =
         typ.recFields.map(newRecFieldGen))))
 
 
+##[
+String `interpolation`:idx: / `format`:idx: inspired by
+Python's ``f``-strings.
+
+.. code-block:: nim
+
+    import strformat
+    let msg = "hello"
+    doAssert fmt"{msg}\n" == "hello\\n"
+
+Because the literal is a raw string literal, the ``\n`` is not interpreted as
+an escape sequence.
+
+
+=================        ====================================================
+  Sign                   Meaning
+=================        ====================================================
+``+``                    Indicates that a sign should be used for both
+                         positive as well as negative numbers.
+``-``                    Indicates that a sign should be used only for
+                         negative numbers (this is the default behavior).
+(space)                  Indicates that a leading space should be used on
+                         positive numbers.
+=================        ====================================================
+
+]##
+
+
 let
   lla = 42394219 - 42429849 + 1293293 - 13918391 + 424242 # this here is an okayish comment
   llb = 42394219 - 42429849 + 1293293 - 13918391 + 424242 # this here is a very long comment which should be split

--- a/nimpretty/tests/expected/exhaustive.nim
+++ b/nimpretty/tests/expected/exhaustive.nim
@@ -631,10 +631,10 @@ type
     cmdLongOption,    ## A long option such as --option
     cmdShortOption    ## A short option such as -c
   OptParser* = object of RootObj ## \
-                                 ## Implementation of the command line parser. Here is even more text yad.
-                                 ##
-                                 ## To initialize it, use the
-                                 ## `initOptParser proc<#initOptParser,string,set[char],seq[string]>`_.
+    ## Implementation of the command line parser. Here is even more text yad.
+    ##
+    ## To initialize it, use the
+    ## `initOptParser proc<#initOptParser,string,set[char],seq[string]>`_.
     pos*: int
     inShortState: bool
     allowWhitespaceAfterColon: bool
@@ -693,6 +693,34 @@ proc newRecordGen(ctx: Context; typ: TypRef): PNode =
       empty(),
       nkRecList.t(
         typ.recFields.map(newRecFieldGen))))
+
+
+##[
+String `interpolation`:idx: / `format`:idx: inspired by
+Python's ``f``-strings.
+
+.. code-block:: nim
+
+    import strformat
+    let msg = "hello"
+    doAssert fmt"{msg}\n" == "hello\\n"
+
+Because the literal is a raw string literal, the ``\n`` is not interpreted as
+an escape sequence.
+
+
+=================        ====================================================
+  Sign                   Meaning
+=================        ====================================================
+``+``                    Indicates that a sign should be used for both
+                         positive as well as negative numbers.
+``-``                    Indicates that a sign should be used only for
+                         negative numbers (this is the default behavior).
+(space)                  Indicates that a leading space should be used on
+                         positive numbers.
+=================        ====================================================
+
+]##
 
 
 let


### PR DESCRIPTION
Because of the change in indentation, the diff looks larger than it really is. Here is the added logic:

```nim
  var dontIndent = false
  for commentLine in splitLines(lit):
    if i == 0 and (commentLine.endsWith("\\") or commentLine.endsWith("[")):
      dontIndent = true
      wr em, commentLine, ltComment
    elif dontIndent:
      wrNewline em
      wr em, commentLine, ltComment
    else:
       # the same as before
```

-----

Before this PR, nimpretty change the formatting and would produce stuff like these:

```nim
=================        ====================================================
  Sign                   Meaning
=================        ====================================================
``+``                    Indicates that a sign should be used for both
  positive as well as negative numbers.
``-``                    Indicates that a sign should be used only for
  negative numbers (this is the default behavior).
(space)                  Indicates that a leading space should be used on
  positive numbers.
=================        ====================================================
```

```nim
type
  RuneImpl = int32 # underlying type of Rune
  Rune* = distinct RuneImpl ## \
                            ## Type that can hold a single Unicode code point.
                            ##
                            ## A Rune may be composed with other Runes to a character on the screen.
  Rune16* = distinct int16 ## \
                           ## Type that can hold a single UTF-16 encoded character.
                           ##
                           ## A single Rune16 may not be enough to hold an arbitrary Unicode code point.
```