### PR TITLE
Fix #9009

### DIFF
--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -1657,6 +1657,11 @@ proc getTok(c: var PegLexer, tok: var Token) =
   setLen(tok.literal, 0)
   skip(c)
 
+  if c.bufpos >= c.buf.len:
+    tok.kind = tkEof
+    tok.literal = "[EOF]"
+    return
+
   case c.buf[c.bufpos]
   of '{':
     inc(c.bufpos)
@@ -1754,9 +1759,6 @@ proc getTok(c: var PegLexer, tok: var Token) =
     inc(c.bufpos)
     add(tok.literal, '^')
   else:
-    if c.bufpos >= c.buf.len:
-      tok.kind = tkEof
-      tok.literal = "[EOF]"
     add(tok.literal, c.buf[c.bufpos])
     inc(c.bufpos)
 

--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -1416,7 +1416,7 @@ type
 
   PegLexer {.inheritable.} = object          ## the lexer object.
     bufpos: int               ## the current position within the buffer
-    buf: cstring              ## the buffer itself
+    buf: string               ## the buffer itself
     lineNumber: int           ## the current line number
     lineStart: int            ## index of last line start in buffer
     colOffset: int            ## column to add
@@ -1567,7 +1567,7 @@ proc getString(c: var PegLexer, tok: var Token) =
 
 proc getDollar(c: var PegLexer, tok: var Token) =
   var pos = c.bufpos + 1
-  if c.buf[pos] in {'0'..'9'}:
+  if pos < c.buf.len and c.buf[pos] in {'0'..'9'}:
     tok.kind = tkBackref
     tok.index = 0
     while pos < c.buf.len and c.buf[pos] in {'0'..'9'}:
@@ -1701,9 +1701,10 @@ proc getTok(c: var PegLexer, tok: var Token) =
   of '$': getDollar(c, tok)
   of 'a'..'z', 'A'..'Z', '\128'..'\255':
     getSymbol(c, tok)
-    if c.buf[c.bufpos] in {'\'', '"'} or
+    if c.bufpos < c.buf.len and (
+        c.buf[c.bufpos] in {'\'', '"'} or
         c.buf[c.bufpos] == '$' and c.bufpos+1 < c.buf.len and
-        c.buf[c.bufpos+1] in {'0'..'9'}:
+        c.buf[c.bufpos+1] in {'0'..'9'}):
       case tok.literal
       of "i": tok.modifier = modIgnoreCase
       of "y": tok.modifier = modIgnoreStyle
@@ -1766,7 +1767,7 @@ proc arrowIsNextTok(c: PegLexer): bool =
   # the only look ahead we need
   var pos = c.bufpos
   while pos < c.buf.len and c.buf[pos] in {'\t', ' '}: inc(pos)
-  result = c.buf[pos] == '<' and (pos+1 < c.buf.len) and c.buf[pos+1] == '-'
+  result = (pos+1 < c.buf.len) and c.buf[pos] == '<' and c.buf[pos+1] == '-'
 
 # ----------------------------- parser ----------------------------------------
 

--- a/tests/stdlib/tpegs.nim
+++ b/tests/stdlib/tpegs.nim
@@ -146,3 +146,14 @@ block:
   echo "-------------------"
   let pLen = parseArithExpr(txt)
   assert txt.len == pLen
+
+block:
+  # Issue #9009
+  const f = find("xyz", peg"'xyz'")
+  doAssert f == 0
+  const r = "var1=key; var2=key2".replacef(peg"{\ident}'='{\ident}", "$1<-$2$2")
+  doAssert r == "var1<-keykey; var2<-key2key2"
+  static:
+    doAssert "w_h_IlE" =~ peg" y'while'"
+    doAssert not ("w" =~ peg" y'while'")
+


### PR DESCRIPTION
pegs module has code that relys on terminating zero.
Type of ``PegLexer.buf`` is ``cstring``.
No bounds checking for ``cstring`` is performed at runtime but VM do bounds check.
This PR change type of ``PegLexer.buf`` to ``string`` and fix out of bounds errors.
