### PR TITLE
typeToString can now show (recursively) resolved type aliases; fixes  #8569 #8083  #8570

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -141,6 +141,14 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     return typeWithSonsResult(tyAnd, @[operand, operand2])
   of "not":
     return typeWithSonsResult(tyNot, @[operand])
+  of "typeToString":
+    var prefer = preferTypeName
+    if traitCall.sons.len >= 2:
+      let preferStr = traitCall.sons[2].strVal
+      prefer = parseEnum[TPreferedDesc](preferStr)
+    result = newStrNode(nkStrLit, operand.typeToString(prefer))
+    result.typ = newType(tyString, context)
+    result.info = traitCall.info
   of "name", "$":
     result = newStrNode(nkStrLit, operand.typeToString(preferTypeName))
     result.typ = newType(tyString, context)

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -36,7 +36,7 @@ tsigmatch.nim(143, 13) Error: type mismatch: got <array[0..0, proc (x: int){.gcs
 but expected one of:
 proc takesFuncs(fs: openArray[proc (x: int) {.gcsafe, locks: 0.}])
   first type mismatch at position: 1
-  required type for fs: openarray[proc (x: int){.closure, gcsafe, locks: 0.}]
+  required type for fs: openArray[proc (x: int){.closure, gcsafe, locks: 0.}]
   but expression '[proc (x: int) {.gcsafe, locks: 0.} = echo [x]]' is of type: array[0..0, proc (x: int){.gcsafe, locks: 0.}]
 
 expression: takesFuncs([proc (x: int) {.gcsafe, locks: 0.} = echo [x]])

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -6,7 +6,7 @@ twrong_at_operator.nim(22, 30) Error: type mismatch: got <array[0..0, type int]>
 but expected one of:
 proc `@`[T](a: openArray[T]): seq[T]
   first type mismatch at position: 1
-  required type for a: openarray[T]
+  required type for a: openArray[T]
   but expression '[int]' is of type: array[0..0, type int]
 proc `@`[IDX, T](a: array[IDX, T]): seq[T]
   first type mismatch at position: 1

--- a/tests/metatype/ttypetraits2.nim
+++ b/tests/metatype/ttypetraits2.nim
@@ -14,3 +14,26 @@ block: # isNamedTuple
   doAssert not Foo3.isNamedTuple
   doAssert not Foo4.isNamedTuple
   doAssert not (1,).type.isNamedTuple
+
+proc typeToString*(t: typedesc, prefer = "preferTypeName"): string {.magic: "TypeTrait".}
+  ## Returns the name of the given type, with more flexibility than `name`,
+  ## and avoiding the potential clash with a variable named `name`.
+  ## prefer = "preferResolved" will resolve type aliases recursively.
+  # Move to typetraits.nim once api stabilized.
+
+block: # typeToString
+  type MyInt = int
+  type
+    C[T0, T1] = object
+  type C2=C # alias => will resolve as C
+  type C2b=C # alias => will resolve as C (recursively)
+  type C3[U,V] = C[V,U]
+  type C4[X] = C[X,X]
+  template name2(T): string = typeToString(T, "preferResolved")
+  doAssert MyInt.name2 == "int"
+  doAssert C3[MyInt, C2b].name2 == "C3[int, C]"
+    # C3 doesn't get resolved to C, not an alias (nor does C4)
+  doAssert C2b[MyInt, C4[cstring]].name2 == "C[int, C4[cstring]]"
+  doAssert C4[MyInt].name2 == "C4[int]"
+  when BiggestFloat is float and cint is int:
+    doAssert C2b[cint, BiggestFloat].name2 == "C3[int, C3[float, int32]]"

--- a/tests/metatype/ttypetraits2.nim
+++ b/tests/metatype/ttypetraits2.nim
@@ -37,3 +37,9 @@ block: # typeToString
   doAssert C4[MyInt].name2 == "C4[int]"
   when BiggestFloat is float and cint is int:
     doAssert C2b[cint, BiggestFloat].name2 == "C3[int, C3[float, int32]]"
+
+  template name3(T): string = typeToString(T, "preferMixed")
+  doAssert MyInt.name3 == "MyInt{int}"
+  doAssert (tuple[a: MyInt, b: float]).name3 == "tuple[a: MyInt{int}, b: float]"
+  doAssert (tuple[a: C2b[MyInt, C4[cstring]], b: cint, c: float]).name3 ==
+    "tuple[a: C2b{C}[MyInt{int}, C4[cstring]], b: cint{int32}, c: float]"

--- a/tests/openarray/t8259.nim
+++ b/tests/openarray/t8259.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "invalid type: 'openarray[int]' for result"
+  errormsg: "invalid type: 'openArray[int]' for result"
   line: 6
 """
 


### PR DESCRIPTION
* fix #8569
* fix #8083
* fix #8570
* fixed typename case: fixed `CString` => `cstring` and `Char`=>`char`, `openarray`=>`openArray` (more consistent with all other types, see `typeToStr`)
(also related to #7976)

## details
typeToString gets 2 new options (and typeToString gets exposed as a magic), which in future PRs could replace all existing `TPreferedDesc` options: 

* `preferResolved` to show (recursively) resolved type aliases (`tuple[a: MyInt]` shows as `tuple[a: int]`) (note that `preferDesc` doesn't do that reliably)
* `preferMixed` to show (recursively) resolved type aliases + their aliases when they differ (at the place where they differ): (`tuple[a: MyInt]` shows as `tuple[a: MyInt{int}]`)
this fixes above mentioned bugs and also makes it clear to user what a type resolves to, while also showing original type if using `preferMixed` (eg `cint`), in a way more compact than current (unreliable) way of showing both `preferName`+`preferDesc`; it helps notably in **type mismatch/sigmatch errors**.

See unittest in tests/metatype/ttypetraits2.nim for detailed behavior; here's a snippet:
```nim
 template name3(T): string = typeToString(T, "preferMixed")
  doAssert name3(tuple[a: MyInt, b: float]) == "tuple[a: MyInt{int}, b: float]"
  doAssert name3(tuple[a: C2b[MyInt, C4[cstring]], b: cint, c: float]) ==
    "tuple[a: C2b{C}[MyInt{int}, C4[cstring]], b: cint{int32}, c: float]"
```



**Existing code is unaffected** except for the fixed typename case (such as `CString` => `cstring`)

in future PR we can use the `preferMixed` (eg to replace `preferDesc`  and expose it in typetraits.typeToString)

I kept `proc typeToString*(t: typedesc, prefer = "preferTypeName"): string {.magic: "TypeTrait".}` out of typetraits.nim for now until we're sure of API; as for the public name for the new proc, using `typeToString` as I did instead of overloading `name` seems like a good choice (named just like the proc in compiler/types.nim), because `name` is such a common word it keeps causing issues (as noted by @kaushalmodi here https://github.com/nim-lang/Nim/issues/7975#issuecomment-508946612) 

* could be adapted to also fix #8704 by printing `int literal(10)` instead of `int` with the option `preferResolved`
* could be used for sigmatch errors, to avoid confusing error messages where signatures don't match, leaving the user clueless as to why they don't
* should probably replace the existing `preferDesc` (in which case i can just remove the newly added preferResolved and make preferDesc use its implementation); but I'd rather do this in a separate PR

## implementation notes
maybe easier to view the diff in a terminal with `git diff -w` to view the diff without getting confused by re-indentation; the 1st commit doesn't change semantics but just re-indents `typeToString` (hence seemingly large diff), adding a nested `typeToString(typ: PType)` inside top-level `proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string` ; this makes implementation much easier.

the remaining commits do the actual semantic changes

## note:
CI failure seems unrelated (caused by https://github.com/nim-lang/Nim/issues/11708)