### PR TITLE
Stacktraces with Column Information

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -270,8 +270,12 @@ proc genLineDir(p: BProc, t: PNode) =
       {optLineTrace, optStackTrace}) and
       (p.prc == nil or sfPure notin p.prc.flags) and t.info.fileIndex != InvalidFileIDX:
     if freshLineInfo(p, t.info):
-      linefmt(p, cpsStmts, "nimln_($1, $2);$n",
-              [line, quotedFilename(p.config, t.info)])
+      # abuses the `filename` field to be the formatted location for simplicity
+      # `line` not used and could be removed
+      var msg = ""
+      msg.addQuoted toFileLineCol(p.config, t.info) & " `" & sourceLine(p.config, t.info).strip & "`"
+      linefmt(p, cpsStmts, "nimln_($1, $2);$n", [0, msg])
+
 
 proc postStmtActions(p: BProc) {.inline.} =
   add(p.s(cpsStmts), p.module.injectStmt)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -270,12 +270,15 @@ proc genLineDir(p: BProc, t: PNode) =
       {optLineTrace, optStackTrace}) and
       (p.prc == nil or sfPure notin p.prc.flags) and t.info.fileIndex != InvalidFileIDX:
     if freshLineInfo(p, t.info):
-      # abuses the `filename` field to be the formatted location for simplicity
-      # `line` not used and could be removed
-      var msg = ""
-      msg.addQuoted toFileLineCol(p.config, t.info) & " `" & sourceLine(p.config, t.info).strip & "`"
-      linefmt(p, cpsStmts, "nimln_($1, $2);$n", [0, msg])
-
+      if optExcessiveStackTrace in p.config.globalOptions:
+        var msg = ""
+        msg.addQuoted toFileLineCol(p.config, t.info) &
+          " `" & sourceLine(p.config, t.info).strip & "`"
+        # abuses the `filename` field to be the formatted location for simplicity
+        linefmt(p, cpsStmts, "nimln_($1, $2);$n", [0, msg])
+      else:
+        linefmt(p, cpsStmts, "nimln_($1, $2);$n",
+          [line, quotedFilename(p.config, t.info)])
 
 proc postStmtActions(p: BProc) {.inline.} =
   add(p.s(cpsStmts), p.module.injectStmt)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -250,8 +250,8 @@ proc genCLineDir(r: var Rope, info: TLineInfo; conf: ConfigRef) =
 
 proc freshLineInfo(p: BProc; info: TLineInfo): bool =
   if p.lastLineInfo.line != info.line or
-     p.lastLineInfo.col != info.col or
-     p.lastLineInfo.fileIndex != info.fileIndex:
+      (optExcessiveStackTrace in p.config.globalOptions and p.lastLineInfo.col != info.col) or
+      p.lastLineInfo.fileIndex != info.fileIndex:
     p.lastLineInfo.line = info.line
     p.lastLineInfo.col = info.col
     p.lastLineInfo.fileIndex = info.fileIndex
@@ -274,8 +274,7 @@ proc genLineDir(p: BProc, t: PNode) =
     if freshLineInfo(p, t.info):
       if optExcessiveStackTrace in p.config.globalOptions:
         var msg = ""
-        msg.addQuoted toFileLineCol(p.config, t.info) &
-          " `" & sourceLine(p.config, t.info).strip & "`"
+        msg.addQuoted toFileLineCol(p.config, t.info)
         # abuses the `filename` field to be the formatted location for simplicity
         linefmt(p, cpsStmts, "nimln_($1, $2);$n", [0, msg])
       else:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -250,8 +250,10 @@ proc genCLineDir(r: var Rope, info: TLineInfo; conf: ConfigRef) =
 
 proc freshLineInfo(p: BProc; info: TLineInfo): bool =
   if p.lastLineInfo.line != info.line or
+     p.lastLineInfo.col != info.col or
      p.lastLineInfo.fileIndex != info.fileIndex:
     p.lastLineInfo.line = info.line
+    p.lastLineInfo.col = info.col
     p.lastLineInfo.fileIndex = info.fileIndex
     result = true
 

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -81,8 +81,8 @@ Advanced options:
   --hotCodeReloading:on|off
                             turn support for hot code reloading on|off
   --excessiveStackTrace:on|off
-                            stack traces show col + source line; can be combined
-                            with --listFullPaths
+                            stack traces show column info; can be combined
+                            with --listFullPaths to get full paths
   --oldNewlines:on|off      turn on|off the old behaviour of "\n"
   --laxStrings:on|off       when turned on, accessing the zero terminator in
                             strings is allowed; only for backwards compatibility

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -81,7 +81,8 @@ Advanced options:
   --hotCodeReloading:on|off
                             turn support for hot code reloading on|off
   --excessiveStackTrace:on|off
-                            stack traces use full file paths
+                            stack traces show col + source line; can be combined
+                            with --listFullPaths
   --oldNewlines:on|off      turn on|off the old behaviour of "\n"
   --laxStrings:on|off       when turned on, accessing the zero terminator in
                             strings is allowed; only for backwards compatibility


### PR DESCRIPTION
* fix #10137
* supersedes https://github.com/nim-lang/Nim/pull/10141
much simpler (3 lines of code only) and avoids introducing an extra `col` field, so avoids any extra runtime cost
* additionally we add source line info

this gives for much more useful stacktraces, eg, when nim itself is compiled with `--stacktrace:on` here's the before/after comparison (see below):
we get at a glance what's going on without having to open corresponding files; we also get the column info which disambiguates where we are for cases like this:
```
# without col info, not clear where we are eg when we got a SIGSEGV
echo2 ai.kind, info=toFileLineCol2(cl.c.config, ai.n.info)
```



```
nim c -r main.nim
```

```nim
  proc fun(a: int)=
    doAssert a == b
  proc main() = fun(12)
  main()
```
## before PR
```
Traceback (most recent call last)
/Users/timothee/git_clone/nim/Nim_devel/compiler/nim.nim(98) nim
/Users/timothee/git_clone/nim/Nim_devel/compiler/nim.nim(75) handleCmdLine
/Users/timothee/git_clone/nim/Nim_devel/compiler/cmdlinehelper.nim(92) loadConfigsAndRunMainCommand
/Users/timothee/git_clone/nim/Nim_devel/compiler/main.nim(194) mainCommand
/Users/timothee/git_clone/nim/Nim_devel/compiler/main.nim(90) commandCompileToC
/Users/timothee/git_clone/nim/Nim_devel/compiler/modules.nim(147) compileProject
/Users/timothee/git_clone/nim/Nim_devel/compiler/modules.nim(88) compileModule
/Users/timothee/git_clone/nim/Nim_devel/compiler/passes.nim(197) processModule
/Users/timothee/git_clone/nim/Nim_devel/compiler/passes.nim(86) processTopLevelStmt
/Users/timothee/git_clone/nim/Nim_devel/compiler/sem.nim(603) myProcess
/Users/timothee/git_clone/nim/Nim_devel/compiler/sem.nim(571) semStmtAndGenerateGenerics
/Users/timothee/git_clone/nim/Nim_devel/compiler/semstmts.nim(2184) semStmt
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(980) semExprNoType
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2712) semExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/semstmts.nim(2124) semStmtList
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2639) semExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2228) semWhen
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2712) semExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/semstmts.nim(2124) semStmtList
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2730) semExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/semstmts.nim(1961) semProc
/Users/timothee/git_clone/nim/Nim_devel/compiler/semstmts.nim(1885) semProcAux
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(1737) semProcBody
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2712) semExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/semstmts.nim(2124) semStmtList
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(2609) semExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(962) semDirectOp
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(855) afterCallActions
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(34) semTemplateExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/sem.nim(406) semAfterMacroCall
```

## after PR
```
Traceback (most recent call last)
/Users/timothee/git_clone/nim/Nim_prs/compiler/nim.nim(98, 16) `handleCmdLine(newIdentCache(), conf)` nim
/Users/timothee/git_clone/nim/Nim_prs/compiler/nim.nim(75, 3) `if not self.loadConfigsAndRunMainCommand(cache, conf): return` handleCmdLine
/Users/timothee/git_clone/nim/Nim_prs/compiler/cmdlinehelper.nim(92, 19) `self.mainCommand(graph)` loadConfigsAndRunMainCommand
/Users/timothee/git_clone/nim/Nim_prs/compiler/main.nim(194, 22) `commandCompileToC(graph)` mainCommand
/Users/timothee/git_clone/nim/Nim_prs/compiler/main.nim(90, 17) `compileProject(graph)` commandCompileToC
/Users/timothee/git_clone/nim/Nim_prs/compiler/modules.nim(147, 5) `discard graph.compileModule(projectFile, {sfMainModule})` compileProject
/Users/timothee/git_clone/nim/Nim_prs/compiler/modules.nim(88, 26) `discard processModule(graph, result,` compileModule
/Users/timothee/git_clone/nim/Nim_prs/compiler/passes.nim(197, 11) `if not processTopLevelStmt(graph, sl, a): break` processModule
/Users/timothee/git_clone/nim/Nim_prs/compiler/passes.nim(86, 34) `m = graph.passes[i].process(a[i], m)` processTopLevelStmt
/Users/timothee/git_clone/nim/Nim_prs/compiler/sem.nim(603, 40) `result = semStmtAndGenerateGenerics(c, n)` myProcess
/Users/timothee/git_clone/nim/Nim_prs/compiler/sem.nim(571, 19) `result = semStmt(c, result, {})` semStmtAndGenerateGenerics
/Users/timothee/git_clone/nim/Nim_prs/compiler/semstmts.nim(2184, 27) `result = semExprNoType(c, n)` semStmt
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(980, 19) `result = semExpr(c, n, {efWantStmt})` semExprNoType
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2712, 54) `of nkStmtList, nkStmtListExpr: result = semStmtList(c, n, flags)` semExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/semstmts.nim(2124, 9) `var expr = semExpr(c, n.sons[i], flags)` semStmtList
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2639, 23) `result = semWhen(c, n, true)` semExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2228, 34) `if semCheck: result = semExpr(c, e) # do not open a new scope!` semWhen
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2712, 54) `of nkStmtList, nkStmtListExpr: result = semStmtList(c, n, flags)` semExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/semstmts.nim(2124, 9) `var expr = semExpr(c, n.sons[i], flags)` semStmtList
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2730, 33) `of nkProcDef: result = semProc(c, n)` semExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/semstmts.nim(1961, 22) `result = semProcAux(c, n, skProc, procPragmas)` semProc
/Users/timothee/git_clone/nim/Nim_prs/compiler/semstmts.nim(1885, 33) `s.ast[bodyPos] = hloBody(c, semProcBody(c, n.sons[bodyPos]))` semProcAux
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(1737, 19) `result = semExpr(c, n)` semProcBody
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2712, 54) `of nkStmtList, nkStmtListExpr: result = semStmtList(c, n, flags)` semExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/semstmts.nim(2124, 9) `var expr = semExpr(c, n.sons[i], flags)` semStmtList
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(2609, 29) `result = semDirectOp(c, n, flags)` semExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(962, 3) `if result != nil: result = afterCallActions(c, result, nOrig, flags)` semDirectOp
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(855, 42) `of skTemplate: result = semTemplateExpr(c, result, callee, flags)` afterCallActions
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(34, 3) `if efNoSemCheck notin flags: result = semAfterMacroCall(c, n, result, s, flags)` semTemplateExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/sem.nim(406, 21) `result = semStmt(c, result, flags)` semAfterMacroCall
```


## note: 
* latest commit only enables this behavior (addde col + source line) for `--excessiveStacktrace:on` ; `--excessiveStacktrace:off` will work same as before PR
* with latest commit, `--excessiveStacktrace:on` can be used with `--listFullPaths:on` or `--listFullPaths:off` producing either full paths or project paths according to logic in `toMsgFilename`; this makes the flags more orthogonal; I could change PR to make `--excessiveStacktrace:on` enforce full paths (like before PR) but IMO its better to keep flags as orthogonal as possible; I've updated the docs for `--excessiveStacktrace`

