### PR TITLE
Alias sugar

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -238,3 +238,22 @@ macro distinctBase*(T: typedesc): untyped =
   while typeSym.typeKind == ntyDistinct:
     typeSym = getTypeImpl(typeSym)[0]
   typeSym.freshIdentNodes
+
+template alias*(name: untyped, bodyOrExpr: untyped): untyped =
+  ## Syntax sugar to create aliases.
+  ##
+  ## Notes:
+  ##   Contrary to `let`, aliases are not allocated in memory.
+  ##   This is useful to access deep nested object fields
+  ##   without incurring the cost of allocation.
+  runnableExamples:
+    type Node = ref object
+      left, right: Node
+      val: int
+
+    let t = Node(left: Node(left: Node(left: Node(val: 10))))
+    alias(t3, t.left.left.left)
+
+    doAssert t3.val == 10
+
+  template name(): untyped {.dirty.} = bodyOrExpr


### PR DESCRIPTION
The `alias` sugar is a popular demand:
  - https://irclogs.nim-lang.org/21-03-2018.html#10:59:16
  - https://irclogs.nim-lang.org/05-05-2019.html#19:19:44 (cc @dom96)
  - https://irclogs.nim-lang.org/08-07-2019.html#01:43:32 (cc @kaushalmodi)

This creates an alias template defined and used the following way.

```Nim
template alias*(name: untyped, bodyOrExpr: untyped): untyped =
  template name(): untyped {.dirty.} = bodyOrExpr

type Node = ref object
  left, right: Node
  val: int

let t = Node(left: Node(left: Node(left: Node(val: 10))))
alias(t3, t.left.left.left)
# or
# alias t3, t.left.left.left
# or
# alias t3:
#   t.left.left.left

doAssert t3.val == 10
```

I can also introduce a scoped alias similar to `with` statements in Python.

```Nim
template withAlias(alias: untyped, to_be_aliased: untyped, body: untyped) =
  template alias(): untyped = to_be_aliased
  body

withAlias pos, game.renderer.ball[ix].pos:
  coolStuffHappenHere(pos)
```
