### PR TITLE
Offsetof fixes

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2119,14 +2119,7 @@ proc semSizeof(c: PContext, n: PNode): PNode =
     n.sons[1] = semExprWithType(c, n.sons[1], {efDetermineType})
     #restoreOldStyleType(n.sons[1])
   n.typ = getSysType(c.graph, n.info, tyInt)
-
-  let size = getSize(c.config, n[1].typ)
-  if size >= 0:
-    result = newIntNode(nkIntLit, size)
-    result.info = n.info
-    result.typ = n.typ
-  else:
-    result = n
+  result = foldSizeOf(c.config, n, n)
 
 proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
   # this is a hotspot in the compiler!
@@ -2215,7 +2208,8 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
       result = setMs(n, s)
     else:
       result = c.graph.emptyNode
-  of mSizeOf: result = semSizeof(c, setMs(n, s))
+  of mSizeOf: result =
+    semSizeof(c, setMs(n, s))
   else:
     result = semDirectOp(c, n, flags)
 

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -648,13 +648,11 @@ proc getConstExpr(m: PSym, n: PNode; g: ModuleGraph): PNode =
         # This fixes bug #544.
         result = newIntNodeT(lengthOrd(g.config, n.sons[1].typ), n, g)
       of mSizeOf:
-        let size = getSize(g.config, n[1].typ)
-        if size >= 0:
-          result = newIntNode(nkIntLit, size)
-          result.info = n.info
-          result.typ = getSysType(g, n.info, tyInt)
-        else:
-          result = nil
+        result = foldSizeOf(g.config, n, nil)
+      of mAlignOf:
+        result = foldAlignOf(g.config, n, nil)
+      of mOffsetOf:
+        result = foldOffsetOf(g.config, n, nil)
       of mAstToStr:
         result = newStrNodeT(renderTree(n[1], {renderNoComments}), n, g)
       of mConStrStr:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -375,55 +375,11 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
   of mTypeOf:
     result = semTypeOf(c, n)
   of mSizeOf:
-    let size = getSize(c.config, n[1].typ)
-    # We just assume here that the type might come from the c backend
-    if size == szUnknownSize:
-      # Forward to the c code generation to emit a `sizeof` in the C code.
-      result = n
-    elif size >= 0:
-      result = newIntNode(nkIntLit, size)
-      result.info = n.info
-      result.typ = n.typ
-    else:
-      localError(c.config, n.info, "cannot evaluate 'sizeof' because its type is not defined completely, type: " & n[1].typ.typeToString)
-      result = n
+    result = foldSizeOf(c.config, n, n)
   of mAlignOf:
-    # this is 100% analog to mSizeOf, could be made more dry.
-    let align = getAlign(c.config, n[1].typ)
-    if align == szUnknownSize:
-      result = n
-    elif align >= 0:
-      result = newIntNode(nkIntLit, align)
-      result.info = n.info
-      result.typ = n.typ
-    else:
-      localError(c.config, n.info, "cannot evaluate 'alignof' because its type is not defined completely, type: " & n[1].typ.typeToString)
-      result = n
+    result = foldAlignOf(c.config, n, n)
   of mOffsetOf:
-    var dotExpr: PNode
-    block findDotExpr:
-      if n[1].kind == nkDotExpr:
-        dotExpr = n[1]
-      elif n[1].kind == nkCheckedFieldExpr:
-        dotExpr = n[1][0]
-      else:
-        illFormedAst(n, c.config)
-
-    assert dotExpr != nil
-
-    let value = dotExpr[0]
-    let member = dotExpr[1]
-
-    discard computeSize(c.config, value.typ)
-
-    let offset = member.sym.offset
-
-    if offset == szUnknownSize:
-      result = n
-    else:
-      result = newIntNode(nkIntLit, offset)
-      result.info = n.info
-      result.typ = n.typ
+    result = foldOffsetOf(c.config, n, n)
   of mArrGet:
     result = semArrGet(c, n, flags)
   of mArrPut:

--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -11,12 +11,48 @@
 proc align(address, alignment: BiggestInt): BiggestInt =
   result = (address + (alignment - 1)) and not (alignment - 1)
 
+proc align(address, alignment: int): int =
+  result = (address + (alignment - 1)) and not (alignment - 1)
+
+
 const
   ## a size is concidered "unknown" when it is an imported type from C
   ## or C++.
   szUnknownSize* = -3
   szIllegalRecursion* = -2
   szUncomputedSize* = -1
+
+type IllegalTypeRecursionError = object of Exception
+
+proc raiseIllegalTypeRecursion() =
+  raise newException(IllegalTypeRecursionError, "illegal type recursion")
+
+type
+  OffsetAccum = object
+    maxAlign: int
+    offset: int
+
+proc inc(arg: var OffsetAccum; value: int) =
+  if unlikely(value == szIllegalRecursion):  raiseIllegalTypeRecursion()
+  if value == szUnknownSize or arg.offset == szUnknownSize:
+    arg.offset = szUnknownSize
+  else:
+    arg.offset += value
+
+proc align(arg: var OffsetAccum; value: int) =
+  if unlikely(value == szIllegalRecursion):  raiseIllegalTypeRecursion()
+  if value == szUnknownSize or arg.maxAlign == szUnknownSize or arg.offset == szUnknownSize:
+    arg.maxAlign = szUnknownSize
+    arg.offset = szUnknownSize
+  else:
+    arg.maxAlign = max(value, arg.maxAlign)
+    arg.offset = align(arg.offset, value)
+
+proc finish(arg: var OffsetAccum) =
+  if arg.maxAlign == szUnknownSize or arg.offset == szUnknownSize:
+    arg.offset = szUnknownSize
+  else:
+    arg.offset = align(arg.offset, arg.maxAlign)
 
 proc computeSizeAlign(conf: ConfigRef; typ: PType)
 
@@ -335,19 +371,22 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
     typ.size = typ.sons[0].size
     typ.align = typ.sons[0].align
   of tyTuple:
-    maxAlign = 1
-    sizeAccum = 0
-    for i in 0 ..< sonsLen(typ):
-      let child = typ.sons[i]
-      computeSizeAlign(conf, child)
-      if child.size < 0:
-        typ.size = child.size
-        typ.align = child.align
-        return
-      maxAlign = max(maxAlign, child.align)
-      sizeAccum = align(sizeAccum, child.align) + child.size
-    typ.size = align(sizeAccum, maxAlign)
-    typ.align = int16(maxAlign)
+    try:
+      var accum = OffsetAccum(maxAlign: 1)
+      for i in 0 ..< sonsLen(typ):
+        let child = typ.sons[i]
+        computeSizeAlign(conf, child)
+        accum.align(child.align)
+        if typ.n != nil: # is named tuple (has field symbols)?
+          let sym = typ.n[i].sym
+          sym.offset = accum.offset
+        accum.inc(int(child.size))
+      accum.finish
+      typ.size = accum.offset
+      typ.align = int16(accum.maxAlign)
+    except IllegalTypeRecursionError:
+      typ.size = szIllegalRecursion
+      typ.align = szIllegalRecursion
   of tyObject:
     var headerSize: BiggestInt
     var headerAlign: int16
@@ -448,3 +487,58 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
   else:
     typ.size = szUncomputedSize
     typ.align = szUncomputedSize
+
+template foldSizeOf*(conf: ConfigRef; n: PNode; fallback: PNode): PNode =
+  let config = conf
+  let node = n
+  let typ = node[1].typ
+  computeSizeAlign(config, typ)
+  let size = typ.size
+  if size >= 0:
+    let res = newIntNode(nkIntLit, size)
+    res.info = node.info
+    res.typ = node.typ
+    res
+  else:
+    fallback
+
+template foldAlignOf*(conf: ConfigRef; n: PNode; fallback: PNode): PNode =
+  let config = conf
+  let node = n
+  let typ = node[1].typ
+  computeSizeAlign(config, typ)
+  let align = typ.align
+  if align >= 0:
+    let res = newIntNode(nkIntLit, align)
+    res.info = node.info
+    res.typ = node.typ
+    res
+  else:
+    fallback
+
+template foldOffsetOf*(conf: ConfigRef; n: PNode; fallback: PNode): PNode =
+  ## Returns an int literal node of the given offsetof expression in `n`.
+  ## Falls back to `fallback`, if the `offsetof` expression can't be processed.
+  let config = conf
+  let node : PNode = n
+  var dotExpr: PNode
+  block findDotExpr:
+    if node[1].kind == nkDotExpr:
+      dotExpr = node[1]
+    elif node[1].kind == nkCheckedFieldExpr:
+      dotExpr = node[1][0]
+    else:
+      localError(config, node.info, "can't compute offsetof on this ast")
+
+  assert dotExpr != nil
+  let value = dotExpr[0]
+  let member = dotExpr[1]
+  computeSizeAlign(config, value.typ)
+  let offset = member.sym.offset
+  if offset >= 0:
+    let tmp = newIntNode(nkIntLit, offset)
+    tmp.info = node.info
+    tmp.typ = node.typ
+    tmp
+  else:
+    fallback

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1310,7 +1310,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
       # produces a value
     else:
       globalError(c.config, n.info, "expandToAst requires a call expression")
-  of mSizeOf, mAlignOf:
+  of mSizeOf, mAlignOf, mOffsetOf:
     globalError(c.config, n.info, "cannot evaluate 'sizeof/alignof' because its type is not defined completely")
   of mRunnableExamples:
     discard "just ignore any call to runnableExamples"

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1310,8 +1310,12 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
       # produces a value
     else:
       globalError(c.config, n.info, "expandToAst requires a call expression")
-  of mSizeOf, mAlignOf, mOffsetOf:
-    globalError(c.config, n.info, "cannot evaluate 'sizeof/alignof' because its type is not defined completely")
+  of mSizeOf:
+    globalError(c.config, n.info, "cannot evaluate 'sizeof' because its type is not defined completely")
+  of mAlignOf:
+    globalError(c.config, n.info, "cannot evaluate 'alignof' because its type is not defined completely")
+  of mOffsetOf:
+    globalError(c.config, n.info, "cannot evaluate 'offsetof' because its type is not defined completely")
   of mRunnableExamples:
     discard "just ignore any call to runnableExamples"
   of mDestroy: discard "ignore calls to the default destructor"

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -582,12 +582,12 @@ doAssert offsetof(MyOtherTupleType, b) == 8
 # properly forwarded for the C code generator.
 doAssert offsetof(MyOtherTupleType, c) == 16
 doAssert offsetof(Bar, foo) == 4
-echo offsetof(MyCaseObject, val2)
-echo offsetof(MyCaseObject, val5)
-#doAssert offsetof(MyCaseObject, val2) == 12
-#doAssert offsetof(MyCaseObject, val3) == 16
-#doAssert offsetof(MyCaseObject, val4) == 12
-#doAssert offsetof(MyCaseObject, val5) == 16
+doAssert offsetof(MyCaseObject, val1) == 0
+doAssert offsetof(MyCaseObject, kind) == 8
+doAssert offsetof(MyCaseObject, val2) == 12
+doAssert offsetof(MyCaseObject, val3) == 16
+doAssert offsetof(MyCaseObject, val4) == 12
+doAssert offsetof(MyCaseObject, val5) == 16
 
 template reject(e) =
   static: assert(not compiles(e))
@@ -598,5 +598,38 @@ reject:
 reject:
   const off2 = offsetof(MyOtherTupleType, b)
 
+reject:
+  const off3 = offsetof(MyCaseObject, kind)
 
-#Foo
+
+type
+  MyPackedCaseObject {.packed.} = object
+    val1: imported_double
+    case kind: bool
+    of true:
+      val2,val3: float32
+    else:
+      val4,val5: int32
+
+# packed case object
+
+doAssert offsetof(MyPackedCaseObject, val1) == 0
+doAssert offsetof(MyPackedCaseObject, val2) == 9
+doAssert offsetof(MyPackedCaseObject, val3) == 13
+doAssert offsetof(MyPackedCaseObject, val4) == 9
+doAssert offsetof(MyPackedCaseObject, val5) == 13
+
+reject:
+  const off4 = offsetof(MyPackedCaseObject, val1)
+
+reject:
+  const off5 = offsetof(MyPackedCaseObject, val2)
+
+reject:
+  const off6 = offsetof(MyPackedCaseObject, val3)
+
+reject:
+  const off7 = offsetof(MyPackedCaseObject, val4)
+
+reject:
+  const off8 = offsetof(MyPackedCaseObject, val5)

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -549,3 +549,54 @@ proc payloadCheck() =
   doAssert sizeOf(Payload) == 4
 
 payloadCheck()
+
+# offsetof tuple types
+
+type
+  MyTupleType = tuple
+    a: float64
+    b: float64
+    c: float64
+
+  MyOtherTupleType = tuple
+    a: float64
+    b: imported_double
+    c: float64
+
+  MyCaseObject = object
+    val1: imported_double
+    case kind: bool
+    of true:
+      val2,val3: float32
+    else:
+      val4,val5: int32
+
+doAssert offsetof(MyTupleType, a) == 0
+doAssert offsetof(MyTupleType, b) == 8
+doAssert offsetof(MyTupleType, c) == 16
+
+doAssert offsetof(MyOtherTupleType, a) == 0
+doAssert offsetof(MyOtherTupleType, b) == 8
+
+# The following expression can only work if the offsetof expression is
+# properly forwarded for the C code generator.
+doAssert offsetof(MyOtherTupleType, c) == 16
+doAssert offsetof(Bar, foo) == 4
+echo offsetof(MyCaseObject, val2)
+echo offsetof(MyCaseObject, val5)
+#doAssert offsetof(MyCaseObject, val2) == 12
+#doAssert offsetof(MyCaseObject, val3) == 16
+#doAssert offsetof(MyCaseObject, val4) == 12
+#doAssert offsetof(MyCaseObject, val5) == 16
+
+template reject(e) =
+  static: assert(not compiles(e))
+
+reject:
+  const off1 = offsetof(MyOtherTupleType, c)
+
+reject:
+  const off2 = offsetof(MyOtherTupleType, b)
+
+
+#Foo

--- a/tests/misc/tsizeof2.nim
+++ b/tests/misc/tsizeof2.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "cannot evaluate 'sizeof/alignof' because its type is not defined completely"
+errormsg: "cannot evaluate 'sizeof' because its type is not defined completely"
 line: 9
 """
 


### PR DESCRIPTION
* `offsetof` did not work on tuples with named fields before. This has been fixed.
* Make `offsetof` fallback to `offsetof` from C/C++, similar to `sizeof` `alignof` fall back to their C/C++ counterparts. 
* Fix a few bugs where the field offset was set to ``szUncomputedSize`` instead of ``szUnknownSize``.
* Add test that ensure that the fallback to the C/C++ backend actually works.
* Reduce code redundancy a little bit.
* Finally introduce the `OffsetAccum` type, even though it isn't used much yet.