### PR TITLE
Make public additional types from sha1 module [feature]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@
 
 - Enable Oid usage in hashtables. (#11472)
 
+- Make public `Sha1Digest` and `Sha1State` types and `newSha1State`, `update` and `finalize` procedures from `sha1` module. (#11694)
 
 ## Language additions
 

--- a/lib/std/sha1.nim
+++ b/lib/std/sha1.nim
@@ -40,11 +40,11 @@ from endians import bigEndian32, bigEndian64
 const Sha1DigestSize = 20
 
 type
-  Sha1Digest = array[0 .. Sha1DigestSize-1, uint8]
+  Sha1Digest* = array[0 .. Sha1DigestSize-1, uint8]
   SecureHash* = distinct Sha1Digest
 
 type
-  Sha1State = object
+  Sha1State* = object
     count: int
     state: array[5, uint32]
     buf:   array[64, byte]


### PR DESCRIPTION
After making public `newSha1State`, `update` and `finalize` methods from the `sha1` module was forgotten to be made public `Sha1Digest` and `Sha1State` types used by the new public methods.