### PR TITLE
Added `%` operator for table construction

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -322,6 +322,16 @@ proc toTable*[A, B](pairs: openArray[(A, B)]): Table[A, B] =
 
   result = initTable[A, B](rightSize(pairs.len))
   for key, val in items(pairs): result[key] = val
+  
+proc `%`*[A, B](pairs: openArray[(A, B)]) : Table[A, B] =
+  ## Creates a new hash table that contains the given ``pairs``.
+  ##
+  ## ``pairs`` is a container consisting of ``(key, value)`` tuples.
+  ##
+  ## See also:
+  ## * `initTable proc<#initTable,int>`_
+  ## * `newTable proc<#newTable,openArray[]>`_ for a `TableRef` version
+  pairs.toTable()
 
 proc `[]`*[A, B](t: Table[A, B], key: A): B =
   ## Retrieves the value at ``t[key]``.


### PR DESCRIPTION
`%` is essentially the same thing as `toTable`, but allows for a more concise notation:

```
var a = %{"key_1": "value_1", "key_2": "value_2"}
```

I don't expect this PR to go through as-is because the `%` operator might be confused with the Json constructor, although it does not actually clash.