### PR TITLE
strformat: add 2 'fmt' macros that use specified characters instead of '{}'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,9 @@
 
 ### Tool changes
 
+- The Nim compiler now does not recompile the Nim project via ``nim c -r`` if
+  no dependent Nim file changed. This feature can be overridden by
+  the ``--forceBuild`` command line option.
 
 ### Compiler changes
 

--- a/changelog_v020.md
+++ b/changelog_v020.md
@@ -26,6 +26,7 @@
 
 ## Library additions
 
+- `toOpenArray` is now available for the JS target.
 
 ## Library changes
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -784,7 +784,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)
 
-template gCmdLineInfo*(): untyped = newLineInfo(config, AbsoluteFile"command line", 1, 1)
+template gCmdLineInfo*(): untyped = newLineInfo(commandLineIdx, 1, 1)
 
 proc processCommand*(switch: string, pass: TCmdLinePass; config: ConfigRef) =
   var cmd, arg: string

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1023,7 +1023,7 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
     lit "],\L\"linkcmd\": "
     str getLinkCmd(conf, conf.absOutFile, objfiles)
 
-    if optRun in conf.globalOptions:
+    if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
       lit ",\L\"nimfiles\":[\L"
       nimfiles(conf, f)
       lit "]\L"

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -947,7 +947,7 @@ proc callCCompiler*(conf: ConfigRef) =
     generateScript(conf, script)
 
 #from json import escapeJson
-import json
+import json, std / sha1
 
 proc writeJsonBuildInstructions*(conf: ConfigRef) =
   template lit(x: untyped) = f.write x
@@ -960,17 +960,17 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
       f.write escapeJson(x)
 
   proc cfiles(conf: ConfigRef; f: File; buf: var string; clist: CfileList, isExternal: bool) =
-    var pastStart = false
+    var i = 0
     for it in clist:
       if CfileFlag.Cached in it.flags: continue
       let compileCmd = getCompileCFileCmd(conf, it)
-      if pastStart: lit "],\L"
+      if i > 0: lit ",\L"
       lit "["
       str it.cname.string
       lit ", "
       str compileCmd
-      pastStart = true
-    lit "]\L"
+      lit "]"
+      inc i
 
   proc linkfiles(conf: ConfigRef; f: File; buf, objfiles: var string; clist: CfileList;
                  llist: seq[string]) =
@@ -994,6 +994,19 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
       pastStart = true
     lit "\L"
 
+  proc nimfiles(conf: ConfigRef; f: File) =
+    var i = 0
+    for it in conf.m.fileInfos:
+      if isAbsolute(it.fullPath.string):
+        if i > 0: lit "],\L"
+        lit "["
+        str it.fullPath.string
+        lit ", "
+        str $secureHashFile(it.fullPath.string)
+        inc i
+    lit "]\L"
+
+
   var buf = newStringOfCap(50)
 
   let jsonFile = conf.getNimcacheDir / RelativeFile(conf.projectName & ".json")
@@ -1009,8 +1022,36 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
 
     lit "],\L\"linkcmd\": "
     str getLinkCmd(conf, conf.absOutFile, objfiles)
+
+    if optRun in conf.globalOptions:
+      lit ",\L\"nimfiles\":[\L"
+      nimfiles(conf, f)
+      lit "]\L"
+
     lit "\L}\L"
     close(f)
+
+proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; projectfile: AbsoluteFile): bool =
+  let jsonFile = toGeneratedFile(conf, projectfile, "json")
+  if not fileExists(jsonFile): return true
+  if not fileExists(conf.absOutFile): return true
+  result = false
+  try:
+    let data = json.parseFile(jsonFile.string)
+    let nimfilesPairs = data["nimfiles"]
+    doAssert nimfilesPairs.kind == JArray
+    for p in nimfilesPairs:
+      doAssert p.kind == JArray
+      # >= 2 for forwards compatibility with potential later .json files:
+      doAssert p.len >= 2
+      let nimFilename = p[0].getStr
+      let oldHashValue = p[1].getStr
+      let newHashValue = $secureHashFile(nimFilename)
+      if oldHashValue != newHashValue:
+        result = true
+  except IOError, OSError, ValueError:
+    echo "Warning: JSON processing failed: ", getCurrentExceptionMsg()
+    result = true
 
 proc runJsonBuildInstructions*(conf: ConfigRef; projectfile: AbsoluteFile) =
   let jsonFile = toGeneratedFile(conf, projectfile, "json")

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -482,7 +482,7 @@ template binaryExpr(p: PProc, n: PNode, r: var TCompRes, magic, frmt: string) =
     a, tmp = x.rdLoc
     b, tmp2 = y.rdLoc
   when "$3" in frmt: (a, tmp) = maybeMakeTemp(p, n[1], x)
-  when "$4" in frmt: (a, tmp) = maybeMakeTemp(p, n[1], x)
+  when "$4" in frmt: (b, tmp2) = maybeMakeTemp(p, n[2], y)
 
   r.res = frmt % [a, b, tmp, tmp2]
   r.kind = resExpr
@@ -2040,8 +2040,14 @@ proc genMagic(p: PProc, n: PNode, r: var TCompRes) =
   of mParseBiggestFloat:
     useMagic(p, "nimParseBiggestFloat")
     genCall(p, n, r)
-  of mArray:
-    genCall(p, n, r)
+  of mSlice:
+    # arr.slice([begin[, end]]): 'end' is exclusive
+    var x, y, z: TCompRes
+    gen(p, n.sons[1], x)
+    gen(p, n.sons[2], y)
+    gen(p, n.sons[3], z)
+    r.res = "($1.slice($2, $3+1))" % [x.rdLoc, y.rdLoc, z.rdLoc]
+    r.kind = resExpr
   else:
     genCall(p, n, r)
     #else internalError(p.config, e.info, 'genMagic: ' + magicToStr[op]);

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -240,8 +240,10 @@ type
   Severity* {.pure.} = enum ## VS Code only supports these three
     Hint, Warning, Error
 
-const trackPosInvalidFileIdx* = FileIndex(-2) # special marker so that no suggestions
-                                   # are produced within comments and string literals
+const
+  trackPosInvalidFileIdx* = FileIndex(-2) # special marker so that no suggestions
+                                          # are produced within comments and string literals
+  commandLineIdx* = FileIndex(-3)
 
 type
   MsgConfig* = object ## does not need to be stored in the incremental cache

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -87,7 +87,7 @@ proc commandCompileToC(graph: ModuleGraph) =
   semanticPasses(graph)
   registerPass(graph, cgenPass)
 
-  if {optRun, optForceFullMake} * conf.globalOptions == {optRun}:
+  if {optRun, optForceFullMake} * conf.globalOptions == {optRun} or isDefined(conf, "nimBetterRun"):
     let proj = changeFileExt(conf.projectFull, "")
     if not changeDetectedViaJsonBuildInstructions(conf, proj):
       # nothing changed

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -87,6 +87,15 @@ proc commandCompileToC(graph: ModuleGraph) =
   semanticPasses(graph)
   registerPass(graph, cgenPass)
 
+  if {optRun, optForceFullMake} * conf.globalOptions == {optRun}:
+    let proj = changeFileExt(conf.projectFull, "")
+    if not changeDetectedViaJsonBuildInstructions(conf, proj):
+      # nothing changed
+      # Little hack here in order to not lose our precious
+      # hintSuccessX message:
+      conf.notes.incl hintSuccessX
+      return
+
   compileProject(graph)
   if graph.config.errorCounter > 0:
     return # issue #9933

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -160,19 +160,25 @@ proc getInfoContext*(conf: ConfigRef; index: int): TLineInfo =
   if i >=% L: result = unknownLineInfo()
   else: result = conf.m.msgContext[i].info
 
+const
+  commandLineDesc = "command line"
+
 template toFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:
-    "???"
+    (if fileIdx == commandLineIdx: commandLineDesc else: "???")
   else:
     conf.m.fileInfos[fileIdx.int32].shortName
 
 proc toProjPath*(conf: ConfigRef; fileIdx: FileIndex): string =
-  if fileIdx.int32 < 0 or conf == nil: "???"
+  if fileIdx.int32 < 0 or conf == nil:
+    (if fileIdx == commandLineIdx: commandLineDesc else: "???")
   else: conf.m.fileInfos[fileIdx.int32].projPath.string
 
 proc toFullPath*(conf: ConfigRef; fileIdx: FileIndex): string =
-  if fileIdx.int32 < 0 or conf == nil: result = "???"
-  else: result = conf.m.fileInfos[fileIdx.int32].fullPath.string
+  if fileIdx.int32 < 0 or conf == nil:
+    result = (if fileIdx == commandLineIdx: commandLineDesc else: "???")
+  else:
+    result = conf.m.fileInfos[fileIdx.int32].fullPath.string
 
 proc setDirtyFile*(conf: ConfigRef; fileIdx: FileIndex; filename: AbsoluteFile) =
   assert fileIdx.int32 >= 0
@@ -189,7 +195,7 @@ proc getHash*(conf: ConfigRef; fileIdx: FileIndex): string =
 
 proc toFullPathConsiderDirty*(conf: ConfigRef; fileIdx: FileIndex): AbsoluteFile =
   if fileIdx.int32 < 0:
-    result = AbsoluteFile"???"
+    result = AbsoluteFile(if fileIdx == commandLineIdx: commandLineDesc else: "???")
   elif not conf.m.fileInfos[fileIdx.int32].dirtyFile.isEmpty:
     result = conf.m.fileInfos[fileIdx.int32].dirtyFile
   else:

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -97,7 +97,6 @@ proc resolveMod(conf: ConfigRef; module, relativeTo: string): FileIndex =
 proc processImplicits(graph: ModuleGraph; implicits: seq[string], nodeKind: TNodeKind,
                       a: var TPassContextArray; m: PSym) =
   # XXX fixme this should actually be relative to the config file!
-  let gCmdLineInfo = newLineInfo(FileIndex(0), 1, 1)
   let relativeTo = toFullPath(graph.config, m.info)
   for module in items(implicits):
     # implicit imports should not lead to a module importing itself

--- a/compiler/rodimpl.nim
+++ b/compiler/rodimpl.nim
@@ -427,12 +427,8 @@ proc storeRemaining*(g: ModuleGraph; module: PSym) =
       stillForwarded.add s
   swap w.forwardedSyms, stillForwarded
   transitiveClosure(g)
-  var nimid = 0
   for x in items(g.config.m.fileInfos):
-    # don't store the "command line" entry:
-    if nimid != 0:
-      storeFilename(g, x.fullPath, FileIndex(nimid))
-    inc nimid
+    storeFilename(g, x.fullPath, FileIndex(nimid))
 
 # ---------------- decoder -----------------------------------
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5149,57 +5149,6 @@ Currently for loop macros must be enabled explicitly
 via ``{.experimental: "forLoopMacros".}``.
 
 
-Case statement macros
----------------------
-
-A macro that needs to be called `match`:idx: can be used to rewrite
-``case`` statements in order to implement `pattern matching`:idx: for
-certain types. The following example implements a simplistic form of
-pattern matching for tuples, leveraging the existing equality operator
-for tuples (as provided in ``system.==``):
-
-.. code-block:: nim
-    :test: "nim c $1"
-
-  {.experimental: "caseStmtMacros".}
-
-  import macros
-
-  macro match(n: tuple): untyped =
-    result = newTree(nnkIfStmt)
-    let selector = n[0]
-    for i in 1 ..< n.len:
-      let it = n[i]
-      case it.kind
-      of nnkElse, nnkElifBranch, nnkElifExpr, nnkElseExpr:
-        result.add it
-      of nnkOfBranch:
-        for j in 0..it.len-2:
-          let cond = newCall("==", selector, it[j])
-          result.add newTree(nnkElifBranch, cond, it[^1])
-      else:
-        error "'match' cannot handle this node", it
-    echo repr result
-
-  case ("foo", 78)
-  of ("foo", 78): echo "yes"
-  of ("bar", 88): echo "no"
-  else: discard
-
-
-Currently case statement macros must be enabled explicitly
-via ``{.experimental: "caseStmtMacros".}``.
-
-``match`` macros are subject to overload resolution. First the
-``case``'s selector expression is used to determine which ``match``
-macro to call. To this macro is then passed the complete ``case``
-statement body and the macro is evaluated.
-
-In other words, the macro needs to transform the full ``case`` statement
-but only the statement's selector expression is used to determine which
-macro to call.
-
-
 Special Types
 =============
 

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -886,6 +886,57 @@ The builtin ``deepCopy`` can even clone closures and their environments. See
 the documentation of `spawn`_ for details.
 
 
+Case statement macros
+=====================
+
+A macro that needs to be called `match`:idx: can be used to rewrite
+``case`` statements in order to implement `pattern matching`:idx: for
+certain types. The following example implements a simplistic form of
+pattern matching for tuples, leveraging the existing equality operator
+for tuples (as provided in ``system.==``):
+
+.. code-block:: nim
+    :test: "nim c $1"
+
+  {.experimental: "caseStmtMacros".}
+
+  import macros
+
+  macro match(n: tuple): untyped =
+    result = newTree(nnkIfStmt)
+    let selector = n[0]
+    for i in 1 ..< n.len:
+      let it = n[i]
+      case it.kind
+      of nnkElse, nnkElifBranch, nnkElifExpr, nnkElseExpr:
+        result.add it
+      of nnkOfBranch:
+        for j in 0..it.len-2:
+          let cond = newCall("==", selector, it[j])
+          result.add newTree(nnkElifBranch, cond, it[^1])
+      else:
+        error "'match' cannot handle this node", it
+    echo repr result
+
+  case ("foo", 78)
+  of ("foo", 78): echo "yes"
+  of ("bar", 88): echo "no"
+  else: discard
+
+
+Currently case statement macros must be enabled explicitly
+via ``{.experimental: "caseStmtMacros".}``.
+
+``match`` macros are subject to overload resolution. First the
+``case``'s selector expression is used to determine which ``match``
+macro to call. To this macro is then passed the complete ``case``
+statement body and the macro is evaluated.
+
+In other words, the macro needs to transform the full ``case`` statement
+but only the statement's selector expression is used to determine which
+macro to call.
+
+
 Term rewriting macros
 =====================
 

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -144,6 +144,9 @@ to override symbols during build time.
 Compile time symbols are completely **case insensitive** and underscores are
 ignored too. ``--define:FOO`` and ``--define:foo`` are identical.
 
+Compile time symbols starting with the ``nim`` prefix are reserved for the
+implementation and should not be used elsewhere.
+
 
 Configuration files
 -------------------

--- a/koch.nim
+++ b/koch.nim
@@ -443,10 +443,12 @@ proc temp(args: string) =
   var finalDest = d / "bin" / "nim_temp".exe
   # 125 is the magic number to tell git bisect to skip the current commit.
   var (bootArgs, programArgs) = splitArgs(args)
-  if "doc" notin programArgs and "threads" notin programArgs and "js" notin programArgs:
+  if "doc" notin programArgs and
+      "threads" notin programArgs and
+      "js" notin programArgs:
     bootArgs.add " -d:leanCompiler"
   let nimexec = findNim()
-  exec(nimexec & " c -d:debug --debugger:native " & bootArgs & " " & (d / "compiler" / "nim"), 125)
+  exec(nimexec & " c -d:debug --debugger:native -d:nimBetterRun " & bootArgs & " " & (d / "compiler" / "nim"), 125)
   copyExe(output, finalDest)
   setCurrentDir(origDir)
   if programArgs.len > 0: exec(finalDest & " " & programArgs)

--- a/koch.nim
+++ b/koch.nim
@@ -441,10 +441,9 @@ proc temp(args: string) =
   let d = getAppDir()
   var output = d / "compiler" / "nim".exe
   var finalDest = d / "bin" / "nim_temp".exe
-  # 125 is the magic number to tell git bisect to skip the current
-  # commit.
+  # 125 is the magic number to tell git bisect to skip the current commit.
   var (bootArgs, programArgs) = splitArgs(args)
-  if "doc" notin programArgs and "threads" notin programArgs:
+  if "doc" notin programArgs and "threads" notin programArgs and "js" notin programArgs:
     bootArgs.add " -d:leanCompiler"
   let nimexec = findNim()
   exec(nimexec & " c -d:debug --debugger:native " & bootArgs & " " & (d / "compiler" / "nim"), 125)

--- a/koch.nim
+++ b/koch.nim
@@ -308,8 +308,14 @@ proc boot(args: string) =
         extraOption.add " -d:nimBoostrapCsources0_19_0"
         # remove this when csources get updated
 
-    exec "$# $# $# $# --nimcache:$# compiler" / "nim.nim" %
+    # in order to use less memory, we split the build into two steps:
+    # --compileOnly produces a $project.json file and does not run GCC/Clang.
+    # jsonbuild then uses the $project.json file to build the Nim binary.
+    exec "$# $# $# $# --nimcache:$# --compileOnly compiler" / "nim.nim" %
       [nimi, bootOptions, extraOption, args, smartNimcache]
+    exec "$# jsonscript --nimcache:$# compiler" / "nim.nim" %
+      [nimi, smartNimcache]
+
     if sameFileContent(output, i.thVersion):
       copyExe(output, finalDest)
       echo "executables are equal: SUCCESS!"

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -31,6 +31,10 @@ when not defined(release):
   var currentID = 0
 
 const isFutureLoggingEnabled* = defined(futureLogging)
+
+const
+  NimAsyncContinueSuffix* = "NimAsyncContinue" ## For internal usage. Do not use.
+
 when isFutureLoggingEnabled:
   import hashes
   type
@@ -294,7 +298,7 @@ proc getHint(entry: StackTraceEntry): string =
     if cmpIgnoreStyle(entry.filename, "asyncdispatch.nim") == 0:
       return "Processes asynchronous completion events"
 
-  if entry.procname.endsWith("_continue"):
+  if entry.procname.endsWith(NimAsyncContinueSuffix):
     if cmpIgnoreStyle(entry.filename, "asyncmacro.nim") == 0:
       return "Resumes an async procedure"
 

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -308,9 +308,9 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
     outerProcBody.add(closureIterator)
 
     # -> createCb(retFuture)
-    # NOTE: The "_continue" suffix is checked for in asyncfutures.nim to produce
+    # NOTE: The NimAsyncContinueSuffix is checked for in asyncfutures.nim to produce
     # friendlier stack traces:
-    var cbName = genSym(nskProc, prcName & "Continue")
+    var cbName = genSym(nskProc, prcName & NimAsyncContinueSuffix)
     var procCb = getAst createCb(retFutureSym, iteratorNameSym,
                          newStrLitNode(prcName),
                          cbName,

--- a/lib/pure/segfaults.nim
+++ b/lib/pure/segfaults.nim
@@ -17,7 +17,7 @@
 var se: ref NilAccessError
 new(se)
 se.name = "NilAccessError"
-se.msg = ""
+se.msg = "Could not access value because it is nil."
 
 when defined(windows):
   include "../system/ansi_c"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4484,18 +4484,19 @@ when defined(windows) and appType == "console" and defined(nimSetUtf8CodePage) a
   discard setConsoleOutputCP(65001) # 65001 - utf-8 codepage
 
 when not defined(js):
-  proc toOpenArray*[T](x: seq[T]; first, last: int): openArray[T] {.
-    magic: "Slice".}
-  proc toOpenArray*[T](x: openArray[T]; first, last: int): openArray[T] {.
-    magic: "Slice".}
   proc toOpenArray*[T](x: ptr UncheckedArray[T]; first, last: int): openArray[T] {.
     magic: "Slice".}
-  proc toOpenArray*[I, T](x: array[I, T]; first, last: I): openArray[T] {.
-    magic: "Slice".}
-  proc toOpenArray*(x: string; first, last: int): openArray[char] {.
-    magic: "Slice".}
-  proc toOpenArrayByte*(x: string; first, last: int): openArray[byte] {.
-    magic: "Slice".}
+
+proc toOpenArray*[T](x: seq[T]; first, last: int): openArray[T] {.
+  magic: "Slice".}
+proc toOpenArray*[T](x: openArray[T]; first, last: int): openArray[T] {.
+  magic: "Slice".}
+proc toOpenArray*[I, T](x: array[I, T]; first, last: I): openArray[T] {.
+  magic: "Slice".}
+proc toOpenArray*(x: string; first, last: int): openArray[char] {.
+  magic: "Slice".}
+proc toOpenArrayByte*(x: string; first, last: int): openArray[byte] {.
+  magic: "Slice".}
 
 type
   ForLoopStmt* {.compilerproc.} = object ## \

--- a/nimdoc/tester.nim
+++ b/nimdoc/tester.nim
@@ -14,6 +14,10 @@ type
     doc: seq[string]
     buildIndex: seq[string]
 
+proc exec(cmd: string) =
+  if execShellCmd(cmd) != 0:
+    quit("FAILURE: " & cmd)
+
 proc testNimDoc(prjDir, docsDir: string; switches: NimSwitches; fixup = false) =
   let
     nimDocSwitches = switches.doc.join(" ")
@@ -22,12 +26,10 @@ proc testNimDoc(prjDir, docsDir: string; switches: NimSwitches; fixup = false) =
   putEnv("SOURCE_DATE_EPOCH", "100000")
 
   if nimDocSwitches != "":
-    if execShellCmd("nim doc $1" % [nimDocSwitches]) != 0:
-      quit("FAILURE: nim doc failed")
+    exec("nim doc $1" % [nimDocSwitches])
 
   if nimBuildIndexSwitches != "":
-    if execShellCmd("nim buildIndex $1" % [nimBuildIndexSwitches]) != 0:
-      quit("FAILURE: nim buildIndex failed")
+    exec("nim buildIndex $1" % [nimBuildIndexSwitches])
 
   for expected in walkDirRec(prjDir / "expected/"):
     let produced = expected.replace('\\', '/').replace("/expected/", "/$1/" % [docsDir])

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -18,7 +18,7 @@ import ../compiler / [idents, msgs, ast, syntaxes, renderer, options,
 import parseopt, strutils, os
 
 const
-  Version = "0.1"
+  Version = "0.2"
   Usage = "nimpretty - Nim Pretty Printer Version " & Version & """
 
   (c) 2017 Andreas Rumpf
@@ -28,6 +28,7 @@ Options:
   --output:file         set the output file (default: overwrite the input file)
   --indent:N[=0]        set the number of spaces that is used for indentation
                         --indent:0 means autodetection (default behaviour)
+  --maxLineLen:N        set the desired maximum line length (default: 80)
   --version             show the version
   --help                show this help
 """
@@ -45,6 +46,7 @@ proc writeVersion() =
 type
   PrettyOptions = object
     indWidth: int
+    maxLineLen: int
 
 proc prettyPrint(infile, outfile: string, opt: PrettyOptions) =
   var conf = newConfigRef()
@@ -55,6 +57,7 @@ proc prettyPrint(infile, outfile: string, opt: PrettyOptions) =
   var p: TParsers
   p.parser.em.indWidth = opt.indWidth
   if setupParsers(p, fileIdx, newIdentCache(), conf):
+    p.parser.em.maxLineLen = opt.maxLineLen
     discard parseAll(p)
     closeParsers(p)
 
@@ -66,6 +69,7 @@ proc main =
     # if input is not actually over-written, when nimpretty is a noop).
     # --backup was un-documented (rely on git instead).
   var opt: PrettyOptions
+  opt.maxLineLen = 80
   for kind, key, val in getopt():
     case kind
     of cmdArgument:
@@ -77,6 +81,7 @@ proc main =
       of "backup": backup = parseBool(val)
       of "output", "o": outfile = val
       of "indent": opt.indWidth = parseInt(val)
+      of "maxlinelen": opt.maxLineLen = parseInt(val)
       else: writeHelp()
     of cmdEnd: assert(false) # cannot happen
   if infile.len == 0:

--- a/nimpretty/tests/exhaustive.nim
+++ b/nimpretty/tests/exhaustive.nim
@@ -741,3 +741,23 @@ proc `==` *(a, b: Color): bool
 proc `==` *(a, b: Color): bool {.borrow.}
   ## Compares two colors.
   ##
+
+
+var rows1 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffff
+  """,
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)
+
+var rows2 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffffgggggggggggggggggggggggggghhhhhhhhhhhhhhhheeeeeeiiiijklm""",
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)

--- a/nimpretty/tests/expected/exhaustive.nim
+++ b/nimpretty/tests/expected/exhaustive.nim
@@ -749,3 +749,23 @@ proc `==` *(a, b: Color): bool
 proc `==` *(a, b: Color): bool {.borrow.}
   ## Compares two colors.
   ##
+
+
+var rows1 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffff
+  """,
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)
+
+var rows2 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffffgggggggggggggggggggggggggghhhhhhhhhhhhhhhheeeeeeiiiijklm""",
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)

--- a/tests/async/tasync_traceback.nim
+++ b/tests/async/tasync_traceback.nim
@@ -70,17 +70,17 @@ b failure
 Async traceback:
   tasync_traceback\.nim\(\d+?\)\s+?tasync_traceback
   asyncmacro\.nim\(\d+?\)\s+?a
-  asyncmacro\.nim\(\d+?\)\s+?aContinue
+  asyncmacro\.nim\(\d+?\)\s+?aNimAsyncContinue
     ## Resumes an async procedure
   tasync_traceback\.nim\(\d+?\)\s+?aIter
   asyncmacro\.nim\(\d+?\)\s+?b
-  asyncmacro\.nim\(\d+?\)\s+?bContinue
+  asyncmacro\.nim\(\d+?\)\s+?bNimAsyncContinue
     ## Resumes an async procedure
   tasync_traceback\.nim\(\d+?\)\s+?bIter
   #\[
     tasync_traceback\.nim\(\d+?\)\s+?tasync_traceback
     asyncmacro\.nim\(\d+?\)\s+?a
-    asyncmacro\.nim\(\d+?\)\s+?aContinue
+    asyncmacro\.nim\(\d+?\)\s+?aNimAsyncContinue
       ## Resumes an async procedure
     tasync_traceback\.nim\(\d+?\)\s+?aIter
     asyncfutures\.nim\(\d+?\)\s+?read
@@ -97,7 +97,7 @@ Async traceback:
   asyncdispatch\.nim\(\d+?\)\s+?runOnce
   asyncdispatch\.nim\(\d+?\)\s+?processPendingCallbacks
     ## Executes pending callbacks
-  asyncmacro\.nim\(\d+?\)\s+?barContinue
+  asyncmacro\.nim\(\d+?\)\s+?barNimAsyncContinue
     ## Resumes an async procedure
   tasync_traceback\.nim\(\d+?\)\s+?barIter
   #\[
@@ -108,7 +108,7 @@ Async traceback:
     asyncdispatch\.nim\(\d+?\)\s+?runOnce
     asyncdispatch\.nim\(\d+?\)\s+?processPendingCallbacks
       ## Executes pending callbacks
-    asyncmacro\.nim\(\d+?\)\s+?fooContinue
+    asyncmacro\.nim\(\d+?\)\s+?fooNimAsyncContinue
       ## Resumes an async procedure
     tasync_traceback\.nim\(\d+?\)\s+?fooIter
     asyncfutures\.nim\(\d+?\)\s+?read

--- a/tests/js/tstringitems.nim
+++ b/tests/js/tstringitems.nim
@@ -1,6 +1,9 @@
 discard """
   output: '''Hello
-Hello'''
+Hello
+c
+d
+e'''
 """
 
 block: # bug #2581
@@ -85,3 +88,8 @@ block: # String cmp
   doAssert(cmp("foo", "foobar") == -3)
   doAssert(cmp("fooz", "foog") == 19)
   doAssert(cmp("foog", "fooz") == -19)
+
+proc main(x: openArray[char]) =
+  for c in x: echo c
+
+main(toOpenArray(['a', 'b', 'c', 'd', 'e'], 2, 4))

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -115,3 +115,32 @@ proc print_object(animalAddr: AnimalRef) =
   echo fmt"Received {animalAddr[]}"
 
 print_object(AnimalRef(name: "Foo", species: "Bar"))
+
+block:
+  let
+    testInt = 123
+    testStr = "foobar"
+    testFlt = 3.141592
+  doAssert ">><<".fmt('<', '>') == "><"
+  doAssert " >> << ".fmt('<', '>') == " > < "
+  doAssert "<<>>".fmt('<', '>') == "<>"
+  doAssert " << >> ".fmt('<', '>') == " < > "
+  doAssert "''".fmt('\'') == "'"
+  doAssert "''''".fmt('\'') == "''"
+  doAssert "'' ''".fmt('\'') == "' '"
+  doAssert "<testInt>".fmt('<', '>') == "123"
+  doAssert "<testInt>".fmt('<', '>') == "123"
+  doAssert "'testFlt:1.2f'".fmt('\'') == "3.14"
+  doAssert "<testInt><testStr>".fmt('<', '>') == "123foobar"
+  doAssert """ ""{"123+123"}"" """.fmt('"') == " \"{246}\" "
+  doAssert "(((testFlt:1.2f)))((111))".fmt('(', ')') == "(3.14)(111)"
+  doAssert """(()"foo" & "bar"())""".fmt(')', '(') == "(foobar)"
+  doAssert "{}abc`testStr' `testFlt:1.2f' `1+1' ``".fmt('`', '\'') == "{}abcfoobar 3.14 2 `"
+  doAssert """x = '"foo" & "bar"'
+              y = '123 + 111'
+              z = '3 in {2..7}'
+           """.fmt('\'') ==
+           """x = foobar
+              y = 234
+              z = true
+           """

--- a/tests/vm/tinheritance.nim
+++ b/tests/vm/tinheritance.nim
@@ -1,6 +1,7 @@
 discard """
-  nimout: '''Hello fred , managed by sally
-Hello sally , managed by bob'''
+  nimout: '''Hello fred, managed by sally
+Hello sally, managed by bob
+0'''
 """
 # bug #3973
 
@@ -10,20 +11,20 @@ type
     ecCode2
 
   Person* = object of RootObj
-    name* : string
+    name*: string
     last_name*: string
 
   Employee* = object of Person
-    empl_code* : EmployeeCode
-    mgr_name* : string
+    empl_code*: EmployeeCode
+    mgr_name*: string
 
 proc test() =
   var
     empl1 = Employee(name: "fred", last_name: "smith", mgr_name: "sally", empl_code: ecCode1)
     empl2 = Employee(name: "sally", last_name: "jones", mgr_name: "bob", empl_code: ecCode2)
 
-  echo "Hello ", empl1.name, " , managed by ", empl1.mgr_name
-  echo "Hello ", empl2.name, " , managed by ", empl2.mgr_name
+  echo "Hello ", empl1.name, ", managed by ", empl1.mgr_name
+  echo "Hello ", empl2.name, ", managed by ", empl2.mgr_name
 
 static:
   test()
@@ -50,13 +51,13 @@ template check_templ(n: Base, k: MyKind) =
   if k == kA: doAssert(n of A) else: doAssert(not (n of A))
   if k in {kB, kC}: doAssert(n of B) else: doAssert(not (n of B))
   if k == kC: doAssert(n of C) else: doAssert(not (n of C))
-  doAssert(n of Base) 
+  doAssert(n of Base)
 
 proc check_proc(n: Base, k: MyKind) =
   if k == kA: doAssert(n of A) else: doAssert(not (n of A))
   if k in {kB, kC}: doAssert(n of B) else: doAssert(not (n of B))
   if k == kC: doAssert(n of C) else: doAssert(not (n of C))
-  doAssert(n of Base) 
+  doAssert(n of Base)
 
 static:
   let aa = new(A)
@@ -68,7 +69,7 @@ static:
   let cc = new(C)
   check_templ(cc, kC)
   check_proc(cc, kC)
-    
+
 let aa = new(A)
 check_templ(aa, kA)
 check_proc(aa, kA)
@@ -78,3 +79,16 @@ check_proc(bb, kB)
 let cc = new(C)
 check_templ(cc, kC)
 check_proc(cc, kC)
+
+type
+  BBar = object of RootObj
+    bbarField: set[char]
+    xbarField: string
+    d, e: int
+  FooBar = object of BBar
+    a: int
+    b: string
+
+static:
+  var fb: FooBar
+  echo fb.a


### PR DESCRIPTION
I want to use ``strformat.fmt`` to put Nim variables in GLSL code that are embed as string literal in Nim code.
But GLSL code have many ``{`` and ``}`` characters and I don't want to escape them.
So I added 2 ``fmt`` macros that use specified characters instead of ``{`` and ``}``.