### PR TITLE
nimpretty: fix #11700, no extra newlines

### DIFF
--- a/nimpretty/tests/exhaustive.nim
+++ b/nimpretty/tests/exhaustive.nim
@@ -741,3 +741,23 @@ proc `==` *(a, b: Color): bool
 proc `==` *(a, b: Color): bool {.borrow.}
   ## Compares two colors.
   ##
+
+
+var rows1 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffff
+  """,
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)
+
+var rows2 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffffgggggggggggggggggggggggggghhhhhhhhhhhhhhhheeeeeeiiiijklm""",
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)

--- a/nimpretty/tests/expected/exhaustive.nim
+++ b/nimpretty/tests/expected/exhaustive.nim
@@ -749,3 +749,23 @@ proc `==` *(a, b: Color): bool
 proc `==` *(a, b: Color): bool {.borrow.}
   ## Compares two colors.
   ##
+
+
+var rows1 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffff
+  """,
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)
+
+var rows2 = await pool.rows(sql"""
+    SELECT STUFF
+    WHERE fffffffffffffffffffffffffffffffgggggggggggggggggggggggggghhhhhhhhhhhhhhhheeeeeeiiiijklm""",
+  @[
+    "AAAA",
+    "BBBB"
+  ]
+)


### PR DESCRIPTION
The problem was that `lineLen` was not being calculated correctly for multiline strings. E.g. `123\n123\n123` would have `lineLen = 11` instead of `3`.