### PR TITLE
new `macros.genAst`: sidesteps issues with `quote do`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,8 @@
 
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 
+- Added `macros.genAst` that fixes all issues with `quote do` (#11722)
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`
@@ -74,7 +76,6 @@
 - `httpclient.newHttpClient` and `httpclient.newAsyncHttpClient` added `headers` argument to set initial HTTP Headers,
   instead of a hardcoded empty `newHttpHeader()`.
 
-
 ## Language additions
 
 - An `align` pragma can now be used for variables and object fields, similar
@@ -82,7 +83,6 @@
 
 - `=sink` type bound operator is now optional. Compiler can now use combination
   of `=destroy` and `copyMem` to move objects efficiently.
-
 
 ## Language changes
 
@@ -106,6 +106,11 @@
   pass specific compiler options to the C(++) backend for the C(++) file
   that was produced from the current Nim module.
 
+- VM FFI now works with {.importc, dynlib.}, when using -d:nimHasLibFFI (#11635)
+
+- importc procs with a body are now executed in the VM as if importc wasn't specified,
+  this allows using {.rtl.} procs at CT, making -d:useNimRtl work in more cases,
+  e.g. compiling nim itself (#11635)
 
 ## Bugfixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,8 @@
 - `httpclient.maxredirects` changed from `int` to `Natural`, because negative values serve no purpose whatsoever.
 - `httpclient.newHttpClient` and `httpclient.newAsyncHttpClient` added `headers` argument to set initial HTTP Headers,
   instead of a hardcoded empty `newHttpHeader()`.
+- Added `macros.genAst` that avoids the problems inherent with `quote do` and can
+  be used as a replacement (#11722)
 
 ## Language additions
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1460,7 +1460,7 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
     else: error("invalid argument kind: " & $a.kind, a)
     if kNoAutoNewLit notin options: varVal = newCall(bindSym"newLitMaybe", varVal)
 
-    params.add newTree(nnkIdentDefs, [varName, newEmptyNode(), newEmptyNode()])
+    params.add newTree(nnkIdentDefs, varName, newEmptyNode(), newEmptyNode())
     call.add varVal
 
   result = newStmtList()

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1381,12 +1381,11 @@ proc copy*(node: NimNode): NimNode {.compileTime.} =
 
 type GenAstOpt* = enum
   kDirtyTemplate,
-    # when unset, inject'd symbols (including implicit ones such as local procs
-    # in scope) are exposed implicitly;
-    # gensym'd symbols will generate a CT internal error: `environment misses:`
-    # when set, local symbols are not exposed unless captured explicitly in
-    # `genAst` argument list. The default is unset, to avoid surprising hijacking
-    # of local symbols by symbols in caller scope.
+    # When set, uses a dirty template in implementation of `genAst`. This
+    # is occasionally useful as workaround for issues such as #8220, see
+    # `strformat limitations <strformat.html#limitations>`_ for details.
+    # Default is unset, to avoid surprising hijacking of local symbols by
+    # symbols in caller scope.
   kNoAutoNewLit,
     # don't call call newLit automatically in `genAst` capture parameters
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1380,7 +1380,7 @@ proc copy*(node: NimNode): NimNode {.compileTime.} =
   return node.copyNimTree()
 
 type GenAstOpt* = enum
-  kNoExposeLocalInjects,
+  kDirtyTemplate,
     # when unset, inject'd symbols (including implicit ones such as local procs
     # in scope) are exposed implicitly;
     # gensym'd symbols will generate a CT internal error: `environment misses:`
@@ -1393,7 +1393,7 @@ type GenAstOpt* = enum
 macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untyped =
   ## Accepts a list of captured `variables = value` and a block and returns the
   ## AST that represents it. Local `{.inject.}` symbols are captured (eg
-  ## local procs) unless `kNoExposeLocalInjects in options`; additional variables
+  ## local procs) unless `kDirtyTemplate in options`; additional variables
   ## are captured as subsequent parameters.
   runnableExamples:
     type Foo = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4
@@ -1415,7 +1415,7 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
       let s1 = "not captured!" ## does not override `s1=2`
       let xignoredLocal = kfoo4
       let x3 = newLit kfoo4
-      result = genAstOpt({kNoExposeLocalInjects}, s1=true, s2="asdf", x0, x1=x1, x2, x3):
+      result = genAstOpt({kDirtyTemplate}, s1=true, s2="asdf", x0, x1=x1, x2, x3):
         ## only captures variables from `genAst` argument list
         ## uncaptured variables will be set from caller scope (Eg `s0`)
         ## `x2` is shortcut for the common `x2=x2`
@@ -1435,7 +1435,7 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
 
   let params = newTree(nnkFormalParams, newEmptyNode())
   let pragmas =
-    if kNoExposeLocalInjects in options:
+    if kDirtyTemplate in options:
       nnkPragma.newTree(ident"dirty")
     else:
       newEmptyNode()

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1390,7 +1390,7 @@ type GenAstOpt* = enum
   kNoAutoNewLit,
     # don't call call newLit automatically in `genAst` capture parameters
 
-macro genAst*(options: static set[GenAstOpt] = {}, args: varargs[untyped]): untyped =
+macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untyped =
   ## Accepts a list of captured `variables = value` and a block and returns the
   ## AST that represents it. Local `{.inject.}` symbols are captured (eg
   ## local procs) unless `kNoExposeLocalInjects in options`; additional variables
@@ -1404,7 +1404,7 @@ macro genAst*(options: static set[GenAstOpt] = {}, args: varargs[untyped]): unty
       let s1 = "not captured!" ## does not override `s1=2`
       let xignoredLocal = kfoo4
       proc localExposed(): auto = kfoo4 # implicitly captured
-      result = genAst({}, s1=true, s2="asdf", x0, x1):
+      result = genAst(s1=true, s2="asdf", x0, x1):
         # echo xignored # would give: Error: undeclared identifier
         # echo s0 # would give: Error: internal error: expr: var not init s0_237159
         (s1, s2, x0, x1, localExposed())
@@ -1415,7 +1415,7 @@ macro genAst*(options: static set[GenAstOpt] = {}, args: varargs[untyped]): unty
       let s1 = "not captured!" ## does not override `s1=2`
       let xignoredLocal = kfoo4
       let x3 = newLit kfoo4
-      result = genAst({kNoExposeLocalInjects}, s1=true, s2="asdf", x0, x1=x1, x2, x3):
+      result = genAstOpt({kNoExposeLocalInjects}, s1=true, s2="asdf", x0, x1=x1, x2, x3):
         ## only captures variables from `genAst` argument list
         ## uncaptured variables will be set from caller scope (Eg `s0`)
         ## `x2` is shortcut for the common `x2=x2`
@@ -1473,6 +1473,10 @@ macro genAst*(options: static set[GenAstOpt] = {}, args: varargs[untyped]): unty
       newEmptyNode(),
       args[^1])
   result.add newCall(bindSym"getAst", call)
+
+template genAst*(args: varargs[untyped]): untyped =
+  ## convenience wrapper around `genAstOpt`
+  genAstOpt({}, args)
 
 when defined(nimVmEqIdent):
   proc eqIdent*(a: string; b: string): bool {.magic: "EqIdent", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1410,8 +1410,9 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
     else:
       newEmptyNode()
 
-  proc newLitMaybe[T](a: T): auto =
-    when compiles(newLit(a)): newLit(a)
+  template newLitMaybe(a): untyped =
+    when type(a) is NimNode: a
+    elif compiles(newLit(a)): newLit(a)
     else: a
 
   # using `_` as workaround, see https://github.com/nim-lang/Nim/issues/2465#issuecomment-511076669

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1402,7 +1402,7 @@ macro genAst*(options: static set[GenAstOpt] = {}, args: varargs[untyped]): unty
       let xignoredLocal = kfoo4
       proc localExposed(): auto = kfoo4 # implicitly captured
       let x3 = newLit kfoo4
-      result = genAst({}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
+      result = genAst({}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3):
         # echo xignored # would give: Error: undeclared identifier
         # echo s0 # would give: Error: internal error: expr: var not init s0_237159
         (s1, s2, x0, x1, x2, x3, localExposed())
@@ -1412,7 +1412,7 @@ macro genAst*(options: static set[GenAstOpt] = {}, args: varargs[untyped]): unty
       let s1 = "not captured!" ## does not override `s1=2`
       let xignoredLocal = kfoo4
       let x3 = newLit kfoo4
-      result = genAst({kNoExposeLocalInjects}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
+      result = genAst({kNoExposeLocalInjects}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3):
         ## only captures variables from `genAst` argument list
         ## uncaptured variables will be set from caller scope (Eg `s0`)
         ## `x2` is shortcut for the common `x2=x2`

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1411,9 +1411,9 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
       newEmptyNode()
 
   template newLitMaybe(a): untyped =
-    when type(a) is NimNode: a
-    elif compiles(newLit(a)): newLit(a)
-    else: a
+    when (a is type) or (typeof(a) is (proc | iterator | func | NimNode)):
+      a # `proc` actually also covers template, macro
+    else: newLit(a)
 
   # using `_` as workaround, see https://github.com/nim-lang/Nim/issues/2465#issuecomment-511076669
   let name = genSym(nskTemplate, "_fun")

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1402,7 +1402,8 @@ macro genAst*(args: varargs[untyped]): untyped =
       (2, "asdf", "caller scope!", kfoo1, kfoo2, kfoo3, kfoo4)
 
   let params = newTree(nnkFormalParams, newEmptyNode())
-  let name = genSym(nskTemplate, "fun")
+  # using `_` as workaround, see https://github.com/nim-lang/Nim/issues/2465#issuecomment-511076669
+  let name = genSym(nskTemplate, "_fun")
   let call = newCall(name)
   for a in args[0..^2]:
     var varName: NimNode

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1386,7 +1386,7 @@ type GenAstOpt* = enum
     # `strformat limitations <strformat.html#limitations>`_ for details.
     # Default is unset, to avoid hijacking of uncaptured local symbols by
     # symbols in caller scope.
-  kNoAutoNewLit,
+  kNoNewLit,
     # don't call call newLit automatically in `genAst` capture parameters
 
 macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untyped =
@@ -1428,7 +1428,7 @@ macro genAstOpt*(options: static set[GenAstOpt], args: varargs[untyped]): untype
       varName = a
       varVal = a
     else: error("invalid argument kind: " & $a.kind, a)
-    if kNoAutoNewLit notin options: varVal = newCall(bindSym"newLitMaybe", varVal)
+    if kNoNewLit notin options: varVal = newCall(bindSym"newLitMaybe", varVal)
 
     params.add newTree(nnkIdentDefs, varName, newEmptyNode(), newEmptyNode())
     call.add varVal

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1389,6 +1389,7 @@ macro genAst*(args: varargs[untyped]): untyped =
       let s1 = "not captured!" ## does not override `s1=2`
       let xignoredLocal = kfoo4
       let x3 = newLit kfoo4
+      ## use `result = genAst do` if there are 0 captures
       result = genAst(s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
         ## only captures variables from `genAst` argument list
         ## uncaptured variables will be set from caller scope (Eg `s0`)

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -1,8 +1,42 @@
-from std/streams import newStringStream, readData, writeData
 import std/macros
 
-macro bindme*(): untyped =
-  genAst(newStringStream, writeData, readData) do:
+## using a enum instead of, say, int, to make apparent potential bugs related to
+## forgetting converting to NimNode via newLit, see https://github.com/nim-lang/Nim/issues/9607
+
+type Foo* = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4
+
+proc myLocalPriv(): auto = kfoo1
+proc myLocalPriv2(): auto = kfoo1
+macro bindme2*(): untyped =
+  genAst({}) do: myLocalPriv()
+macro bindme3*(): untyped =
+  ## myLocalPriv must be captured explicitly
+  genAst({kNoExposeLocalInjects}, myLocalPriv) do: myLocalPriv()
+
+macro bindme4*(): untyped =
+  ## calling this won't compile because `myLocalPriv` isn't captured
+  genAst({kNoExposeLocalInjects}) do: myLocalPriv()
+
+macro bindme5UseExpose*(): untyped =
+  genAst({}) do: myLocalPriv2()
+
+macro bindme5UseExposeFalse*(): untyped =
+  genAst({kNoExposeLocalInjects}) do: myLocalPriv2()
+
+## example from https://github.com/nim-lang/Nim/issues/7889
+from std/streams import newStringStream, readData, writeData
+
+macro bindme6UseExpose*(): untyped =
+  genAst({}) do:
+    var tst = "sometext"
+    var ss = newStringStream("anothertext")
+    writeData(ss, tst[0].addr, 2)
+    discard readData(ss, tst[0].addr, 2)
+
+macro bindme6UseExposeFalse*(): untyped =
+  ## without kexposeLocalInjects, requires passing all referenced symbols
+  ## which can be tedious
+  genAst({kNoExposeLocalInjects}, newStringStream, writeData, readData) do:
     var tst = "sometext"
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -1,6 +1,6 @@
 import std/macros
 
-## using a enum instead of, say, int, to make apparent potential bugs related to
+## Using a enum instead of, say, int, to make apparent potential bugs related to
 ## forgetting converting to NimNode via newLit, see https://github.com/nim-lang/Nim/issues/9607
 
 type Foo* = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -8,26 +8,26 @@ type Foo* = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4
 proc myLocalPriv(): auto = kfoo1
 proc myLocalPriv2(): auto = kfoo1
 macro bindme2*(): untyped =
-  genAst({}): myLocalPriv()
+  genAst: myLocalPriv()
 macro bindme3*(): untyped =
   ## myLocalPriv must be captured explicitly
-  genAst({kNoExposeLocalInjects}, myLocalPriv): myLocalPriv()
+  genAstOpt({kNoExposeLocalInjects}, myLocalPriv): myLocalPriv()
 
 macro bindme4*(): untyped =
   ## calling this won't compile because `myLocalPriv` isn't captured
-  genAst({kNoExposeLocalInjects}): myLocalPriv()
+  genAstOpt({kNoExposeLocalInjects}): myLocalPriv()
 
 macro bindme5UseExpose*(): untyped =
-  genAst({}): myLocalPriv2()
+  genAst: myLocalPriv2()
 
 macro bindme5UseExposeFalse*(): untyped =
-  genAst({kNoExposeLocalInjects}): myLocalPriv2()
+  genAstOpt({kNoExposeLocalInjects}): myLocalPriv2()
 
 ## example from https://github.com/nim-lang/Nim/issues/7889
 from std/streams import newStringStream, readData, writeData
 
 macro bindme6UseExpose*(): untyped =
-  genAst({}):
+  genAst:
     var tst = "sometext"
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)
@@ -36,7 +36,7 @@ macro bindme6UseExpose*(): untyped =
 macro bindme6UseExposeFalse*(): untyped =
   ## without kexposeLocalInjects, requires passing all referenced symbols
   ## which can be tedious
-  genAst({kNoExposeLocalInjects}, newStringStream, writeData, readData):
+  genAstOpt({kNoExposeLocalInjects}, newStringStream, writeData, readData):
     var tst = "sometext"
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -34,7 +34,7 @@ macro bindme6UseExpose*(): untyped =
     discard readData(ss, tst[0].addr, 2)
 
 macro bindme6UseExposeFalse*(): untyped =
-  ## without kexposeLocalInjects, requires passing all referenced symbols
+  ## with `kDirtyTemplate`, requires passing all referenced symbols
   ## which can be tedious
   genAstOpt({kDirtyTemplate}, newStringStream, writeData, readData):
     var tst = "sometext"

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -1,0 +1,9 @@
+from std/streams import newStringStream, readData, writeData
+import std/macros
+
+macro bindme*(): untyped =
+  genAst(newStringStream, writeData, readData) do:
+    var tst = "sometext"
+    var ss = newStringStream("anothertext")
+    writeData(ss, tst[0].addr, 2)
+    discard readData(ss, tst[0].addr, 2)

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -8,26 +8,26 @@ type Foo* = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4
 proc myLocalPriv(): auto = kfoo1
 proc myLocalPriv2(): auto = kfoo1
 macro bindme2*(): untyped =
-  genAst({}) do: myLocalPriv()
+  genAst({}): myLocalPriv()
 macro bindme3*(): untyped =
   ## myLocalPriv must be captured explicitly
-  genAst({kNoExposeLocalInjects}, myLocalPriv) do: myLocalPriv()
+  genAst({kNoExposeLocalInjects}, myLocalPriv): myLocalPriv()
 
 macro bindme4*(): untyped =
   ## calling this won't compile because `myLocalPriv` isn't captured
-  genAst({kNoExposeLocalInjects}) do: myLocalPriv()
+  genAst({kNoExposeLocalInjects}): myLocalPriv()
 
 macro bindme5UseExpose*(): untyped =
-  genAst({}) do: myLocalPriv2()
+  genAst({}): myLocalPriv2()
 
 macro bindme5UseExposeFalse*(): untyped =
-  genAst({kNoExposeLocalInjects}) do: myLocalPriv2()
+  genAst({kNoExposeLocalInjects}): myLocalPriv2()
 
 ## example from https://github.com/nim-lang/Nim/issues/7889
 from std/streams import newStringStream, readData, writeData
 
 macro bindme6UseExpose*(): untyped =
-  genAst({}) do:
+  genAst({}):
     var tst = "sometext"
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)
@@ -36,7 +36,7 @@ macro bindme6UseExpose*(): untyped =
 macro bindme6UseExposeFalse*(): untyped =
   ## without kexposeLocalInjects, requires passing all referenced symbols
   ## which can be tedious
-  genAst({kNoExposeLocalInjects}, newStringStream, writeData, readData) do:
+  genAst({kNoExposeLocalInjects}, newStringStream, writeData, readData):
     var tst = "sometext"
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -41,3 +41,12 @@ macro bindme6UseExposeFalse*(): untyped =
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)
     discard readData(ss, tst[0].addr, 2)
+
+
+proc locafun1(): auto = "in locafun1"
+proc locafun2(): auto = "in locafun2"
+# locafun3 in caller scope only
+macro mixinExample*(): untyped =
+  genAst:
+    mixin locafun1
+    (locafun1(), locafun2(), locafun3())

--- a/tests/macros/mgenast.nim
+++ b/tests/macros/mgenast.nim
@@ -11,17 +11,17 @@ macro bindme2*(): untyped =
   genAst: myLocalPriv()
 macro bindme3*(): untyped =
   ## myLocalPriv must be captured explicitly
-  genAstOpt({kNoExposeLocalInjects}, myLocalPriv): myLocalPriv()
+  genAstOpt({kDirtyTemplate}, myLocalPriv): myLocalPriv()
 
 macro bindme4*(): untyped =
   ## calling this won't compile because `myLocalPriv` isn't captured
-  genAstOpt({kNoExposeLocalInjects}): myLocalPriv()
+  genAstOpt({kDirtyTemplate}): myLocalPriv()
 
 macro bindme5UseExpose*(): untyped =
   genAst: myLocalPriv2()
 
 macro bindme5UseExposeFalse*(): untyped =
-  genAstOpt({kNoExposeLocalInjects}): myLocalPriv2()
+  genAstOpt({kDirtyTemplate}): myLocalPriv2()
 
 ## example from https://github.com/nim-lang/Nim/issues/7889
 from std/streams import newStringStream, readData, writeData
@@ -36,7 +36,7 @@ macro bindme6UseExpose*(): untyped =
 macro bindme6UseExposeFalse*(): untyped =
   ## without kexposeLocalInjects, requires passing all referenced symbols
   ## which can be tedious
-  genAstOpt({kNoExposeLocalInjects}, newStringStream, writeData, readData):
+  genAstOpt({kDirtyTemplate}, newStringStream, writeData, readData):
     var tst = "sometext"
     var ss = newStringStream("anothertext")
     writeData(ss, tst[0].addr, 2)

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -197,3 +197,22 @@ block: # sanity check: check passing `{}` also works
   macro bar(): untyped =
     result = genAstOpt({}, s1=true): s1
   doAssert bar() == true
+
+block: # test passing function and type symbols
+  proc z1(): auto = 41
+  type Z4 = type(1'i8)
+  macro bar(Z1: typedesc): untyped =
+    proc z2(): auto = 42
+    proc z3[T](a: T): auto = 43
+    let Z2 = genAst():
+      type(true)
+    let z4 = genAst():
+      proc myfun(): auto = 44
+      myfun
+    type Z3 = type(1'u8)
+    result = genAst(z4, Z1, Z2):
+      # z1, z2, z3, Z3, Z4 are captured automatically
+      # z1, z2, z3 can optionally be specified in capture list
+      (z1(), z2(), z3('a'), z4(), $Z1, $Z2, $Z3, $Z4)
+  type Z1 = type('c')
+  doAssert bar(Z1) == (41, 42, 43, 44, "char", "bool", "uint8", "int8")

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -1,14 +1,14 @@
 import std/macros
+from std/strformat import `&`
+import ./mgenast
 
 block:
-  type Foo = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4
-
   macro bar(x0: static Foo, x1: Foo, x2: Foo, xignored: Foo): untyped =
     let s0 = "not captured!"
     let s1 = "not captured!"
     let xignoredLocal = kfoo4
     let x3 = newLit kfoo4
-    result = genAst(s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
+    result = genAst({kNoExposeLocalInjects}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
       doAssert not declared(xignored)
       doAssert not declared(xignoredLocal)
       (s1, s2, s0, x0, x1, x2, x3)
@@ -21,21 +21,11 @@ block:
 block:
   # doesn't have limitation mentioned in https://github.com/nim-lang/RFCs/issues/122#issue-401636535
   macro abc(name: untyped): untyped =
-    result = genAst(name):
+    result = genAst({}, name):
       type name = object
 
   abc(Bar)
   doAssert Bar.default == Bar()
-
-import std/strformat
-
-block:
-  # fix https://github.com/nim-lang/Nim/issues/8220
-  macro foo(): untyped =
-    result = genAst do:
-      let bar = "Hello, World"
-      &"Let's interpolate {bar} in the string"
-  doAssert foo() == "Let's interpolate Hello, World in the string"
 
 block:
   # backticks parser limitations / ambiguities not an issue with `genAst`:
@@ -46,7 +36,7 @@ block:
 
   macro m1(): untyped =
     # result = quote do: # Error: undeclared identifier: 'a1'
-    result = genAst do:
+    result = genAst({}) do:
       template `a1=`(x: var Foo, val: int) =
         x.a = val
 
@@ -61,22 +51,17 @@ block:
     result = newStmtList()
   macro foo(c: bool): untyped =
     var b = false
-    result = genAst(b = newLit b, c) do:
+    result = genAst({}, b = newLit b, c) do:
       fun(b, c)
 
   foo(true)
-
-when true:
-  # fix https://github.com/nim-lang/Nim/issues/7889
-  from mgenast import bindme
-  bindme()
 
 block:
   # fix https://github.com/nim-lang/Nim/issues/7589
   # since `==` works with genAst, the problem goes away
   macro foo2(): untyped =
     # result = quote do: # Error: '==' cannot be passed to a procvar
-    result = genAst do:
+    result = genAst({}) do:
       `==`(3,4)
   doAssert not foo2()
 
@@ -84,7 +69,7 @@ block:
   # fix https://github.com/nim-lang/Nim/issues/7726
   macro foo(): untyped =
     let a = @[1, 2, 3, 4, 5]
-    result = genAst(a, b = a.len) do: # shows 2 ways to get a.len
+    result = genAst({}, a, b = a.len) do: # shows 2 ways to get a.len
       (a.len, b)
   doAssert foo() == (5, 5)
 
@@ -92,12 +77,79 @@ block:
   # fix https://github.com/nim-lang/Nim/issues/9607
   proc fun1(info:LineInfo): string = "bar1"
   proc fun2(info:int): string = "bar2"
+
+  macro bar2(args: varargs[untyped]): untyped =
+    let info = args.lineInfoObj
+    let fun1 = bindSym"fun1" # optional; we can remove this and also the
+    # capture of fun1
+    result = genAst({}, info = newLit info, fun1) do:
+      (fun1(info), fun2(info.line))
+  doAssert bar2() == ("bar1", "bar2")
+
   macro bar(args: varargs[untyped]): untyped =
     let info = args.lineInfoObj
     let fun1 = bindSym"fun1"
     let fun2 = bindSym"fun2"
-    result = genAst(info = newLit info) do:
+    result = genAst({kNoExposeLocalInjects}, info = newLit info) do:
       (fun1(info), fun2(info.line))
   doAssert bar() == ("bar1", "bar2")
 
+block:
+  # fix https://github.com/nim-lang/Nim/issues/7889
+  doAssert bindme2() == kfoo1
+  doAssert bindme3() == kfoo1
+  doAssert not compiles(bindme4()) # correctly gives Error: undeclared identifier: 'myLocalPriv'
+  proc myLocalPriv2(): auto = kfoo2
 
+  doAssert bindme5UseExpose() == kfoo1
+  doAssert bindme5UseExposeFalse() == kfoo2
+    # local `myLocalPriv2` hijacks symbol, probably not what user wants
+    # by default as it's surprising for the macro writer
+
+  bindme6UseExpose()
+  bindme6UseExposeFalse()
+
+block:
+  macro mbar(x3: Foo, x3b: static Foo): untyped =
+    var x1=kfoo3
+    var x2=newLit kfoo3
+    var x4=kfoo3
+    var xLocal=kfoo3
+
+    proc funLocal(): auto = kfoo4
+
+    result = genAst({}, x1=newLit x1, x2, x3, x4 = newLit x4) do:
+      # local x1 overrides remote x1
+      when false:
+        # one advantage of using `kNoExposeLocalInjects` is that these would hold:
+        doAssert not declared xLocal
+        doAssert not compiles(echo xLocal)
+        # however, even without it, we at least correctly generate CT error
+        # if trying to use un-captured symbol; this correctly gives:
+        # Error: internal error: environment misses: xLocal
+        echo xLocal
+
+      proc foo1(): auto =
+        # note that `funLocal` is captured implicitly, according to hygienic
+        # template rules; with `kNoExposeLocalInjects` it would not unless
+        # captured in `genAst` capture list explicitly
+        (a0: xRemote, a1: x1, a2: x2, a3: x3, a4: x4, a5: funLocal())
+
+    return result
+
+  proc main()=
+    var xRemote=kfoo1
+    var x1=kfoo2
+    mbar(kfoo4, kfoo4)
+    doAssert foo1() == (a0: kfoo1, a1: kfoo3, a2: kfoo3, a3: kfoo4, a4: kfoo3, a5: kfoo4)
+
+  main()
+
+block:
+  # fix https://github.com/nim-lang/Nim/issues/8220
+  macro foo(): untyped =
+    # kNoExposeLocalInjects needed here
+    result = genAst({kNoExposeLocalInjects}) do:
+      let bar = "Hello, World"
+      &"Let's interpolate {bar} in the string"
+  doAssert foo() == "Let's interpolate Hello, World in the string"

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -8,7 +8,7 @@ block:
     let s1 = "not captured!"
     let xignoredLocal = kfoo4
     let x3 = newLit kfoo4
-    result = genAst({kNoExposeLocalInjects}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
+    result = genAst({kNoExposeLocalInjects}, s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3):
       doAssert not declared(xignored)
       doAssert not declared(xignoredLocal)
       (s1, s2, s0, x0, x1, x2, x3)
@@ -36,7 +36,7 @@ block:
 
   macro m1(): untyped =
     # result = quote do: # Error: undeclared identifier: 'a1'
-    result = genAst({}) do:
+    result = genAst({}):
       template `a1=`(x: var Foo, val: int) =
         x.a = val
 
@@ -51,7 +51,7 @@ block:
     result = newStmtList()
   macro foo(c: bool): untyped =
     var b = false
-    result = genAst({}, b = newLit b, c) do:
+    result = genAst({}, b = newLit b, c):
       fun(b, c)
 
   foo(true)
@@ -61,7 +61,7 @@ block:
   # since `==` works with genAst, the problem goes away
   macro foo2(): untyped =
     # result = quote do: # Error: '==' cannot be passed to a procvar
-    result = genAst({}) do:
+    result = genAst({}):
       `==`(3,4)
   doAssert not foo2()
 
@@ -69,7 +69,7 @@ block:
   # fix https://github.com/nim-lang/Nim/issues/7726
   macro foo(): untyped =
     let a = @[1, 2, 3, 4, 5]
-    result = genAst({}, a, b = a.len) do: # shows 2 ways to get a.len
+    result = genAst({}, a, b = a.len): # shows 2 ways to get a.len
       (a.len, b)
   doAssert foo() == (5, 5)
 
@@ -82,7 +82,7 @@ block:
     let info = args.lineInfoObj
     let fun1 = bindSym"fun1" # optional; we can remove this and also the
     # capture of fun1
-    result = genAst({}, info = newLit info, fun1) do:
+    result = genAst({}, info = newLit info, fun1):
       (fun1(info), fun2(info.line))
   doAssert bar2() == ("bar1", "bar2")
 
@@ -90,7 +90,7 @@ block:
     let info = args.lineInfoObj
     let fun1 = bindSym"fun1"
     let fun2 = bindSym"fun2"
-    result = genAst({kNoExposeLocalInjects}, info = newLit info) do:
+    result = genAst({kNoExposeLocalInjects}, info = newLit info):
       (fun1(info), fun2(info.line))
   doAssert bar() == ("bar1", "bar2")
 
@@ -118,7 +118,7 @@ block:
 
     proc funLocal(): auto = kfoo4
 
-    result = genAst({}, x1=newLit x1, x2, x3, x4 = newLit x4) do:
+    result = genAst({}, x1=newLit x1, x2, x3, x4 = newLit x4):
       # local x1 overrides remote x1
       when false:
         # one advantage of using `kNoExposeLocalInjects` is that these would hold:
@@ -149,7 +149,7 @@ block:
   # fix https://github.com/nim-lang/Nim/issues/8220
   macro foo(): untyped =
     # kNoExposeLocalInjects needed here
-    result = genAst({kNoExposeLocalInjects}) do:
+    result = genAst({kNoExposeLocalInjects}):
       let bar = "Hello, World"
       &"Let's interpolate {bar} in the string"
   doAssert foo() == "Let's interpolate Hello, World in the string"

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -12,7 +12,7 @@ block:
     let x3 = newLit kfoo4
     let x3b = kfoo4
 
-    result = genAstOpt({kNoExposeLocalInjects}, s1=true, s2="asdf", x0, x1=x1, x2, x3, x3b):
+    result = genAstOpt({kDirtyTemplate}, s1=true, s2="asdf", x0, x1=x1, x2, x3, x3b):
       doAssert not declared(xignored)
       doAssert not declared(xignoredLocal)
       (s1, s2, s0, x0, x1, x2, x3, x3b)
@@ -94,7 +94,7 @@ block:
     let info = args.lineInfoObj
     let fun1 = bindSym"fun1"
     let fun2 = bindSym"fun2"
-    result = genAstOpt({kNoExposeLocalInjects}, info):
+    result = genAstOpt({kDirtyTemplate}, info):
       (fun1(info), fun2(info.line))
   doAssert bar() == ("bar1", "bar2")
 
@@ -125,7 +125,7 @@ block:
     result = genAst(x1, x2, x3, x4):
       # local x1 overrides remote x1
       when false:
-        # one advantage of using `kNoExposeLocalInjects` is that these would hold:
+        # one advantage of using `kDirtyTemplate` is that these would hold:
         doAssert not declared xLocal
         doAssert not compiles(echo xLocal)
         # however, even without it, we at least correctly generate CT error
@@ -135,7 +135,7 @@ block:
 
       proc foo1(): auto =
         # note that `funLocal` is captured implicitly, according to hygienic
-        # template rules; with `kNoExposeLocalInjects` it would not unless
+        # template rules; with `kDirtyTemplate` it would not unless
         # captured in `genAst` capture list explicitly
         (a0: xRemote, a1: x1, a2: x2, a3: x3, a4: x4, a5: funLocal())
 
@@ -152,8 +152,8 @@ block:
 block:
   # fix https://github.com/nim-lang/Nim/issues/8220
   macro foo(): untyped =
-    # kNoExposeLocalInjects needed here
-    result = genAstOpt({kNoExposeLocalInjects}):
+    # kDirtyTemplate needed here
+    result = genAstOpt({kDirtyTemplate}):
       let bar = "Hello, World"
       &"Let's interpolate {bar} in the string"
   doAssert foo() == "Let's interpolate Hello, World in the string"

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -185,12 +185,12 @@ block: # nested application of genAst
   createMacro foo, x, len
   doAssert (foo 20) == (3, "len", 10, 20)
 
-block: # test with kNoAutoNewLit
+block: # test with kNoNewLit
   macro bar(): untyped =
     let s1 = true
     template boo(x): untyped =
       fun(x)
-    result = genAstOpt({kNoAutoNewLit}, s1=newLit(s1), s1b=s1): (s1, s1b)
+    result = genAstOpt({kNoNewLit}, s1=newLit(s1), s1b=s1): (s1, s1b)
   doAssert bar() == (true, 1)
 
 block: # sanity check: check passing `{}` also works

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -235,3 +235,25 @@ block: # also from #11986
       let t = s
       $typeof(t)
   doAssert foo() == "set[char]"
+
+block:
+  macro foo(): untyped =
+    type Foo = object
+    template baz2(a: int): untyped = a*10
+    macro baz3(a: int): untyped = newLit 13
+    result = newStmtList()
+
+    result.add genAst(Foo, baz2, baz3) do: # shows you can pass types, templates etc
+      var x: Foo
+      $($typeof(x), baz2(3), baz3(4))
+
+    let ret = genAst() do: # shows you don't have to, since they're inject'd
+      var x: Foo
+      $($typeof(x), baz2(3), baz3(4))
+  doAssert foo() == """("Foo", 30, 13)"""
+
+block: # illustrates how symbol visiblity can be controlled precisely using `mixin`
+  proc locafun1(): auto = "in locafun1 (caller scope)" # this will be used because of `mixin locafun1` => explicit hijacking is ok
+  proc locafun2(): auto = "in locafun2 (caller scope)" # this won't be used => no hijacking
+  proc locafun3(): auto = "in locafun3 (caller scope)"
+  doAssert mixinExample() == ("in locafun1 (caller scope)", "in locafun2", "in locafun3 (caller scope)")

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -152,7 +152,7 @@ block:
 block:
   # fix https://github.com/nim-lang/Nim/issues/8220
   macro foo(): untyped =
-    # kDirtyTemplate needed here
+    # kDirtyTemplate needed here, see https://nim-lang.github.io/Nim/strformat.html#limitations
     result = genAstOpt({kDirtyTemplate}):
       let bar = "Hello, World"
       &"Let's interpolate {bar} in the string"

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -87,3 +87,17 @@ block:
     result = genAst(a, b = a.len) do: # shows 2 ways to get a.len
       (a.len, b)
   doAssert foo() == (5, 5)
+
+block:
+  # fix https://github.com/nim-lang/Nim/issues/9607
+  proc fun1(info:LineInfo): string = "bar1"
+  proc fun2(info:int): string = "bar2"
+  macro bar(args: varargs[untyped]): untyped =
+    let info = args.lineInfoObj
+    let fun1 = bindSym"fun1"
+    let fun2 = bindSym"fun2"
+    result = genAst(info = newLit info) do:
+      (fun1(info), fun2(info.line))
+  doAssert bar() == ("bar1", "bar2")
+
+

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -153,3 +153,16 @@ block:
       let bar = "Hello, World"
       &"Let's interpolate {bar} in the string"
   doAssert foo() == "Let's interpolate Hello, World in the string"
+
+
+block: # nested application of genAst
+  macro createMacro(name, obj, field: untyped): untyped =
+    result = genAst({}, obj = newDotExpr(obj, field), lit = newLit(10), name, field):
+      # can't reuse `result` here, would clash
+      macro name(arg: untyped): untyped =
+        genAst({}, arg2=arg): # somehow `arg2` rename is needed
+          (obj, astToStr(field), lit, arg2)
+
+  var x = @[1, 2, 3]
+  createMacro foo, x, len
+  doAssert (foo 20) == (3, "len", 10, 20)

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -50,7 +50,7 @@ block:
   doAssert x0 == Foo(a: 10)
 
 block:
-  # fix https://github.com/nim-lang/Nim/issues/7375
+  # avoids https://github.com/nim-lang/Nim/issues/7375
   macro fun(b: static[bool], b2: bool): untyped =
     result = newStmtList()
   macro foo(c: bool): untyped =
@@ -61,7 +61,7 @@ block:
   foo(true)
 
 block:
-  # fix https://github.com/nim-lang/Nim/issues/7589
+  # avoids https://github.com/nim-lang/Nim/issues/7589
   # since `==` works with genAst, the problem goes away
   macro foo2(): untyped =
     # result = quote do: # Error: '==' cannot be passed to a procvar
@@ -70,7 +70,7 @@ block:
   doAssert not foo2()
 
 block:
-  # fix https://github.com/nim-lang/Nim/issues/7726
+  # avoids https://github.com/nim-lang/Nim/issues/7726
   # expressions such as `a.len` are just passed as arguments to `genAst`, and
   # caller scope is not polluted with definitions such as `let b = newLit a.len`
   macro foo(): untyped =
@@ -80,7 +80,7 @@ block:
   doAssert foo() == (5, 5)
 
 block:
-  # fix https://github.com/nim-lang/Nim/issues/9607
+  # avoids https://github.com/nim-lang/Nim/issues/9607
   proc fun1(info:LineInfo): string = "bar1"
   proc fun2(info:int): string = "bar2"
 

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -216,3 +216,22 @@ block: # test passing function and type symbols
       (z1(), z2(), z3('a'), z4(), $Z1, $Z2, $Z3, $Z4)
   type Z1 = type('c')
   doAssert bar(Z1) == (41, 42, 43, 44, "char", "bool", "uint8", "int8")
+
+block: # fix https://github.com/nim-lang/Nim/issues/11986
+  proc foo(): auto =
+    var s = { 'a', 'b' }
+    # var n = quote do: `s` # would print {97, 98}
+    var n = genAst(s): s
+    n.repr
+  static: doAssert foo() == "{'a', 'b'}"
+
+block: # also from #11986
+  macro foo(): untyped =
+    var s = { 'a', 'b' }
+    # quote do:
+    #   let t = `s`
+    #   $typeof(t) # set[range 0..65535(int)]
+    genAst(s):
+      let t = s
+      $typeof(t)
+  doAssert foo() == "set[char]"

--- a/tests/macros/tgenast.nim
+++ b/tests/macros/tgenast.nim
@@ -1,0 +1,89 @@
+import std/macros
+
+block:
+  type Foo = enum kfoo0, kfoo1, kfoo2, kfoo3, kfoo4
+
+  macro bar(x0: static Foo, x1: Foo, x2: Foo, xignored: Foo): untyped =
+    let s0 = "not captured!"
+    let s1 = "not captured!"
+    let xignoredLocal = kfoo4
+    let x3 = newLit kfoo4
+    result = genAst(s1=2, s2="asdf", x0=newLit x0, x1=x1, x2, x3) do:
+      doAssert not declared(xignored)
+      doAssert not declared(xignoredLocal)
+      (s1, s2, s0, x0, x1, x2, x3)
+
+  let s0 = "caller scope!"
+
+  doAssert bar(kfoo1, kfoo2, kfoo3, kfoo4) ==
+    (2, "asdf", "caller scope!", kfoo1, kfoo2, kfoo3, kfoo4)
+
+block:
+  # doesn't have limitation mentioned in https://github.com/nim-lang/RFCs/issues/122#issue-401636535
+  macro abc(name: untyped): untyped =
+    result = genAst(name):
+      type name = object
+
+  abc(Bar)
+  doAssert Bar.default == Bar()
+
+import std/strformat
+
+block:
+  # fix https://github.com/nim-lang/Nim/issues/8220
+  macro foo(): untyped =
+    result = genAst do:
+      let bar = "Hello, World"
+      &"Let's interpolate {bar} in the string"
+  doAssert foo() == "Let's interpolate Hello, World in the string"
+
+block:
+  # backticks parser limitations / ambiguities not an issue with `genAst`:
+  # fix https://github.com/nim-lang/Nim/issues/10326
+  # fix https://github.com/nim-lang/Nim/issues/9745
+  type Foo = object
+    a: int
+
+  macro m1(): untyped =
+    # result = quote do: # Error: undeclared identifier: 'a1'
+    result = genAst do:
+      template `a1=`(x: var Foo, val: int) =
+        x.a = val
+
+  m1()
+  var x0: Foo
+  x0.a1 = 10
+  doAssert x0 == Foo(a: 10)
+
+block:
+  # fix https://github.com/nim-lang/Nim/issues/7375
+  macro fun(b: static[bool], b2: bool): untyped =
+    result = newStmtList()
+  macro foo(c: bool): untyped =
+    var b = false
+    result = genAst(b = newLit b, c) do:
+      fun(b, c)
+
+  foo(true)
+
+when true:
+  # fix https://github.com/nim-lang/Nim/issues/7889
+  from mgenast import bindme
+  bindme()
+
+block:
+  # fix https://github.com/nim-lang/Nim/issues/7589
+  # since `==` works with genAst, the problem goes away
+  macro foo2(): untyped =
+    # result = quote do: # Error: '==' cannot be passed to a procvar
+    result = genAst do:
+      `==`(3,4)
+  doAssert not foo2()
+
+block:
+  # fix https://github.com/nim-lang/Nim/issues/7726
+  macro foo(): untyped =
+    let a = @[1, 2, 3, 4, 5]
+    result = genAst(a, b = a.len) do: # shows 2 ways to get a.len
+      (a.len, b)
+  doAssert foo() == (5, 5)


### PR DESCRIPTION
provides a solution for https://github.com/nim-lang/RFCs/issues/122

a new `macros.genAst` is introduced; it sidesteps virtually all issues inherent with `quote do` and can be used as a replacement for it
```nim
macro fun(a: bool, b: static bool): untyped =
  let b2 = newLit b
  let c = newLit true
  quote do: echo (`a`, `b2`, `c`)

# can be replaced by:
macro fun(a: bool, b: static bool): untyped =
  genAst(a, b, c = true): echo (a, b, c)
```

## sidesteps these (see unittests tests/macros/tgenast.nim)
* #7375
* #8220 via `getAstOpt({kDirtyTemplate})` see unittests
* #7589
* #7726
* #9607
* #11986
* EDIT: plus other issues, eg recursive use, ambiguity with backticks (eg operators that need backticks don't work with `quote`)

for #7889, see unittests showing this is fixed (for both `quote do` and `genAst`) by using regular call syntax instead of method call syntax; can be therefore closed as dup of https://github.com/nim-lang/Nim/issues/7085

## comparison to `quoteAst` proposal
this PR doesn't have limitations of the other `quoteAst` proposal mentioned in https://github.com/nim-lang/RFCs/issues/122#issue-401636535 : see unittest `tests/macros/tgenast.nim` (`macro abc(name: untyped)` test case)
> As it seems, the uq(...) expression is not allowed everywhere. The following example does not pass the parsing step of Nim, because an unquote expression is now allowed as the name of a new type

it doesn't require any parser change unlike what's mentioned in https://github.com/nim-lang/RFCs/issues/122 
> To fix this problem the parser needs to be changes.

it's also much simpler than https://github.com/nim-lang/Nim/pull/10446 (no compiler change needed, just 1 new proc in macros.nim)

so I think this PR also closes https://github.com/nim-lang/RFCs/issues/122 and https://github.com/nim-lang/Nim/pull/10446 

## note
* the only issue with `quote do` that is not fixed by this PR is https://github.com/nim-lang/Nim/issues/10430 `Comments are removed in quote do expressions` , however this is in fact a pre-existing problem with `getAst` that can be easily fixed independently of this PR (possibly via an extra argument to `getAst`)

* there are use cases for when `dirty` pragma is desirable, so there is an option to control that:`getAstOpt({kDirtyTemplate}, ...)` , see unittests. However, this leads to more verbose code (each symbol used must be in capture list) and potentially surprising hijacking behavior in case some symbols are not captured (see unittests), therefore the default is `not dirty`. See nim docs for what symbols are gensym'd vs inject'd: https://nim-lang.github.io/Nim/manual.html#templates-hygiene-in-templates
