### PR TITLE
allow runnableExamples(topLevel=true)

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -431,7 +431,7 @@ proc prepareExamples(d: PDoc; n: PNode) =
       newTree(nkImportStmt, newStrNode(nkStrLit, d.filename)))
   runnableExamples.info = n.info
 
-  var topLevel = false
+  var topLevel = true
   if n.len > 2:
     let arg = n[1]
     doAssert arg.kind == nkExprEqExpr

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -430,11 +430,25 @@ proc prepareExamples(d: PDoc; n: PNode) =
       docComment,
       newTree(nkImportStmt, newStrNode(nkStrLit, d.filename)))
   runnableExamples.info = n.info
-  let imports = newTree(nkStmtList)
-  var savedLastSon = copyTree n.lastSon
-  extractImports(savedLastSon, imports)
-  for imp in imports: runnableExamples.add imp
-  runnableExamples.add newTree(nkBlockStmt, newNode(nkEmpty), copyTree savedLastSon)
+
+  var topLevel = false
+  if n.len > 2:
+    let arg = n[1]
+    doAssert arg.kind == nkExprEqExpr
+    doAssert arg[0].ident.s == "topLevel"
+    let val = $arg[1]
+    case val
+    of "true": topLevel  = true
+    of "false": topLevel  = false
+    else: doAssert(false, val)
+  if topLevel:
+    for a in n.lastSon: runnableExamples.add a
+  else:
+    let imports = newTree(nkStmtList)
+    var savedLastSon = copyTree n.lastSon
+    extractImports(savedLastSon, imports)
+    for imp in imports: runnableExamples.add imp
+    runnableExamples.add newTree(nkBlockStmt, newNode(nkEmpty), copyTree savedLastSon)
   testExample(d, runnableExamples)
 
 proc getAllRunnableExamplesRec(d: PDoc; n, orig: PNode; dest: var Rope) =

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -198,8 +198,8 @@ proc initUri*(): Uri =
   ## **See also:**
   ## * `Uri type <#Uri>`_ for available fields in the URI type
   runnableExamples:
-    var uri: Uri
-    assert initUri() == uri
+    var uri2: Uri
+    assert initUri() == uri2
   result = Uri(scheme: "", username: "", password: "", hostname: "", port: "",
                 path: "", query: "", anchor: "")
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -121,7 +121,7 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ##   # Put here the normal code
 
 when defined(nimHasRunnableExamples):
-  proc runnableExamples*(body: untyped) {.magic: "RunnableExamples".}
+  proc runnableExamples*(topLevel = false, body: untyped) {.magic: "RunnableExamples".}
     ## A section you should use to mark `runnable example`:idx: code with.
     ##
     ## - In normal debug and release builds code within
@@ -143,6 +143,15 @@ when defined(nimHasRunnableExamples):
     ##       assert double(21) == 42
     ##
     ##     result = 2 * x
+    ##
+    ##   proc fun2*(): auto =
+    ##     runnableExamples(topLevel=true):
+    ##       # `topLevel=true` will put the generated code at module scope
+    ##       proc fun0*() = discard
+    ##       fun0()
+    ##
+    ##     discard
+    ##
 else:
   template runnableExamples*(body: untyped) =
     discard

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -121,17 +121,19 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ##   # Put here the normal code
 
 when defined(nimHasRunnableExamples):
-  proc runnableExamples*(topLevel = false, body: untyped) {.magic: "RunnableExamples".}
+  proc runnableExamples*(body: untyped) {.magic: "RunnableExamples".}
+  proc runnableExamples*(topLevel: bool, body: untyped) {.magic: "RunnableExamples".}
     ## A section you should use to mark `runnable example`:idx: code with.
     ##
     ## - In normal debug and release builds code within
     ##   a ``runnableExamples`` section is ignored.
     ## - The documentation generator is aware of these examples and considers them
     ##   part of the ``##`` doc comment. As the last step of documentation
-    ##   generation the examples are put into an ``$file_example.nim`` file,
+    ##   generation each runnableExample is put in its own file ``$file_examples$i.nim``,
     ##   compiled and tested. The collected examples are
     ##   put into their own module to ensure the examples do not refer to
-    ##   non-exported symbols.
+    ##   non-exported symbols. By default `body` is at module scope, but `topLevel=false`
+    ##   will put it inside a `block:`.
     ##
     ## Usage:
     ##
@@ -145,15 +147,15 @@ when defined(nimHasRunnableExamples):
     ##     result = 2 * x
     ##
     ##   proc fun2*(): auto =
-    ##     runnableExamples(topLevel=true):
-    ##       # `topLevel=true` will put the generated code at module scope
-    ##       proc fun0*() = discard
-    ##       fun0()
+    ##     runnableExamples(topLevel=false):
+    ##       defer: echo "done" # cannot be at module scope
     ##
     ##     discard
     ##
 else:
   template runnableExamples*(body: untyped) =
+    discard
+  template runnableExamples*(topLevel: bool, body: untyped) =
     discard
 
 proc declared*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -121,7 +121,7 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ##   # Put here the normal code
 
 when defined(nimHasRunnableExamples):
-  proc runnableExamples*(topLevel = true, body: untyped) {.magic: "RunnableExamples".}
+  proc runnableExamples*(body: untyped) {.magic: "RunnableExamples".}
     ## A section you should use to mark `runnable example`:idx: code with.
     ##
     ## - In normal debug and release builds code within
@@ -131,30 +131,22 @@ when defined(nimHasRunnableExamples):
     ##   generation each runnableExample is put in its own file ``$file_examples$i.nim``,
     ##   compiled and tested. The collected examples are
     ##   put into their own module to ensure the examples do not refer to
-    ##   non-exported symbols. By default `body` is at module scope, but `topLevel=false`
-    ##   will put it inside a `block:`.
+    ##   non-exported symbols.
     ##
     ## Usage:
     ##
     ## .. code-block:: Nim
-    ##   proc double(x: int): int =
+    ##   proc double*(x: int): int =
     ##     ## This proc doubles a number.
     ##     runnableExamples:
+    ##       ## at module scope
     ##       assert double(5) == 10
-    ##       assert double(21) == 42
-    ##
+    ##       block: ## at block scope
+    ##         defer: echo "done"
+    ##   
     ##     result = 2 * x
-    ##
-    ##   proc fun2*(): auto =
-    ##     runnableExamples(topLevel=false):
-    ##       defer: echo "done" # cannot be at module scope
-    ##
-    ##     discard
-    ##
 else:
   template runnableExamples*(body: untyped) =
-    discard
-  template runnableExamples*(topLevel: bool, body: untyped) =
     discard
 
 proc declared*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -121,8 +121,7 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ##   # Put here the normal code
 
 when defined(nimHasRunnableExamples):
-  proc runnableExamples*(body: untyped) {.magic: "RunnableExamples".}
-  proc runnableExamples*(topLevel: bool, body: untyped) {.magic: "RunnableExamples".}
+  proc runnableExamples*(topLevel = true, body: untyped) {.magic: "RunnableExamples".}
     ## A section you should use to mark `runnable example`:idx: code with.
     ##
     ## - In normal debug and release builds code within

--- a/tests/magics/trunnableexamples.nim
+++ b/tests/magics/trunnableexamples.nim
@@ -10,6 +10,7 @@ foo5
 foo6
 foo7
 foo8
+foo9
 '''
 joinable: false
 """
@@ -17,30 +18,30 @@ joinable: false
 proc fun*() =
   runnableExamples(topLevel=false):
     # `defer` only allowed inside a block
-    defer: echo "foo2"
+    defer: echo "foo1"
 
   runnableExamples(topLevel=true):
     # `fun*` only allowed at top level
-    proc fun*()=echo "foo3"
+    proc fun*()=echo "foo2"
     fun()
     block:
-      defer: echo "foo4"
+      defer: echo "foo3"
 
   runnableExamples:
     # implicitly uses topLevel=true
-    proc fun*()=echo "foo3"
+    proc fun*()=echo "foo4"
     fun()
 
   runnableExamples():
     # ditto
-    proc fun*()=echo "foo3"
+    proc fun*()=echo "foo5"
     fun()
 
   runnableExamples:
     # `codeReordering` only allowed at top level
     {.experimental: "codeReordering".}
     proc fun1() = fun2()
-    proc fun2() = echo "foo5"
+    proc fun2() = echo "foo6"
     fun1()
 
   runnableExamples:
@@ -50,14 +51,14 @@ proc fun*() =
       newTree(nnkImportStmt, [newLit a])
     myImport "str" & "utils"
     doAssert declared(isAlphaAscii)
-    echo "foo6"
+    echo "foo7"
 
 # also check for runnableExamples at module scope
 runnableExamples(topLevel=false):
-  defer: echo "foo7"
+  defer: echo "foo8"
 
 runnableExamples:
-  proc fun*()=echo "foo8"
+  proc fun*()=echo "foo9"
   fun()
 
 # note: there are yet other examples where `topLevel=true` is needed,

--- a/tests/magics/trunnableexamples.nim
+++ b/tests/magics/trunnableexamples.nim
@@ -1,0 +1,62 @@
+discard """
+cmd: "nim doc $file"
+nimout: '''
+foo1
+foo2
+foo3
+foo4
+foo5
+foo6
+foo7
+foo8
+'''
+joinable: false
+"""
+
+proc fun*() =
+  runnableExamples:
+    # `defer` only allowed inside a block
+    defer: echo "foo1"
+
+  runnableExamples(topLevel=false):
+    defer: echo "foo2"
+
+  runnableExamples(topLevel=true):
+    # `fun*` only allowed at top level
+    proc fun*()=echo "foo3"
+    fun()
+    block:
+      defer: echo "foo4"
+
+  runnableExamples(topLevel=true):
+    # `codeReordering` only allowed at top level
+    {.experimental: "codeReordering".}
+    proc fun1() = fun2()
+    proc fun2() = echo "foo5"
+    fun1()
+
+  runnableExamples(topLevel=true):
+    # only works at top level
+    import std/macros
+    macro myImport(a: static string): untyped =
+      newTree(nnkImportStmt, [newLit a])
+    myImport "str" & "utils"
+    doAssert declared(isAlphaAscii)
+    echo "foo6"
+
+proc fun2*(): auto =
+  runnableExamples(topLevel=true):
+    proc fun0*() = discard
+    fun0()
+  discard
+
+# also check for runnableExamples at module scope
+runnableExamples:
+  defer: echo "foo7"
+
+runnableExamples(topLevel=true):
+  proc fun*()=echo "foo8"
+  fun()
+
+# note: there are yet other examples where `topLevel=true` is needed,
+# for example when using an `include` before an `import`, etc.

--- a/tests/magics/trunnableexamples.nim
+++ b/tests/magics/trunnableexamples.nim
@@ -15,11 +15,8 @@ joinable: false
 """
 
 proc fun*() =
-  runnableExamples:
-    # `defer` only allowed inside a block
-    defer: echo "foo1"
-
   runnableExamples(topLevel=false):
+    # `defer` only allowed inside a block
     defer: echo "foo2"
 
   runnableExamples(topLevel=true):
@@ -29,14 +26,24 @@ proc fun*() =
     block:
       defer: echo "foo4"
 
-  runnableExamples(topLevel=true):
+  runnableExamples:
+    # implicitly uses topLevel=true
+    proc fun*()=echo "foo3"
+    fun()
+
+  runnableExamples():
+    # ditto
+    proc fun*()=echo "foo3"
+    fun()
+
+  runnableExamples:
     # `codeReordering` only allowed at top level
     {.experimental: "codeReordering".}
     proc fun1() = fun2()
     proc fun2() = echo "foo5"
     fun1()
 
-  runnableExamples(topLevel=true):
+  runnableExamples:
     # only works at top level
     import std/macros
     macro myImport(a: static string): untyped =
@@ -46,10 +53,10 @@ proc fun*() =
     echo "foo6"
 
 # also check for runnableExamples at module scope
-runnableExamples:
+runnableExamples(topLevel=false):
   defer: echo "foo7"
 
-runnableExamples(topLevel=true):
+runnableExamples:
   proc fun*()=echo "foo8"
   fun()
 

--- a/tests/magics/trunnableexamples.nim
+++ b/tests/magics/trunnableexamples.nim
@@ -1,5 +1,6 @@
 discard """
 cmd: "nim doc $file"
+action: "compile"
 nimout: '''
 foo1
 foo2

--- a/tests/magics/trunnableexamples.nim
+++ b/tests/magics/trunnableexamples.nim
@@ -44,12 +44,6 @@ proc fun*() =
     doAssert declared(isAlphaAscii)
     echo "foo6"
 
-proc fun2*(): auto =
-  runnableExamples(topLevel=true):
-    proc fun0*() = discard
-    fun0()
-  discard
-
 # also check for runnableExamples at module scope
 runnableExamples:
   defer: echo "foo7"

--- a/tests/magics/trunnableexamples.nim
+++ b/tests/magics/trunnableexamples.nim
@@ -5,7 +5,6 @@ nimout: '''
 foo1
 foo2
 foo3
-foo4
 foo5
 foo6
 foo7
@@ -16,11 +15,11 @@ joinable: false
 """
 
 proc fun*() =
-  runnableExamples(topLevel=false):
-    # `defer` only allowed inside a block
-    defer: echo "foo1"
+  runnableExamples:
+    block: # `defer` only allowed inside a block
+      defer: echo "foo1"
 
-  runnableExamples(topLevel=true):
+  runnableExamples:
     # `fun*` only allowed at top level
     proc fun*()=echo "foo2"
     fun()
@@ -28,11 +27,6 @@ proc fun*() =
       defer: echo "foo3"
 
   runnableExamples:
-    # implicitly uses topLevel=true
-    proc fun*()=echo "foo4"
-    fun()
-
-  runnableExamples():
     # ditto
     proc fun*()=echo "foo5"
     fun()
@@ -54,12 +48,13 @@ proc fun*() =
     echo "foo7"
 
 # also check for runnableExamples at module scope
-runnableExamples(topLevel=false):
-  defer: echo "foo8"
+runnableExamples:
+  block:
+    defer: echo "foo8"
 
 runnableExamples:
   proc fun*()=echo "foo9"
   fun()
 
-# note: there are yet other examples where `topLevel=true` is needed,
-# for example when using an `include` before an `import`, etc.
+# note: there are yet other examples where putting runnableExamples at module
+# scope is needed, for example when using an `include` before an `import`, etc.


### PR DESCRIPTION
this PR allows `runnableExamples` to generate code at module scope, which is needed in some cases where code inside a block would not work. The option is opt-in so no existing code is affected.

See `tests/magics/trunnableexamples.nim` for unittests, it also shows some examples where module scope is needed