### PR TITLE
Fix Typos in Internal Docs

### DIFF
--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -220,7 +220,7 @@ Source URLs are generated as `href="${url}/tree/${commit}/${path}#L${line}"` by 
 You can edit ``config/nimdoc.cfg`` and modify the ``doc.item.seesrc`` value with a hyperlink to your own code repository.
 
 In the case of Nim's own documentation, the ``commit`` value is just a commit
-hash to append to a formatted URL to https://github.com/Araq/Nim. The
+hash to append to a formatted URL to https://github.com/nim-lang/Nim. The
 ``tools/nimweb.nim`` helper queries the current git commit hash during doc
 generation, but since you might be working on an unpublished repository, it
 also allows specifying a ``githash`` value in ``web/website.ini`` to force a

--- a/doc/filelist.txt
+++ b/doc/filelist.txt
@@ -37,8 +37,8 @@ pragmas         semantic checking of pragmas
 
 idents          implements a general mapping from identifiers to an internal
                 representation (``PIdent``) that is used so that a simple
-                id-comparison suffices to say whether two Nim identifiers
-                are equivalent
+                id-comparison suffices to establish whether two Nim
+                identifiers are equivalent
 ropes           implements long strings represented as trees for
                 lazy evaluation; used mainly by the code generators
 

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -184,7 +184,7 @@ How the RTL is compiled
 
 The ``system`` module contains the part of the RTL which needs support by
 compiler magic (and the stuff that needs to be in it because the spec
-says so). The C code generator generates the C code for it just like any other
+says so). The C code generator generates the C code for it's just like any other
 module. However, calls to some procedures like ``addInt`` are inserted by
 the CCG. Therefore the module ``magicsys`` contains a table (``compilerprocs``)
 with all symbols that are marked as ``compilerproc``. ``compilerprocs`` are
@@ -246,14 +246,14 @@ The symbol's ``ast`` field is loaded lazily, on demand. This is where most
 savings come from, only the shallow outer AST is reconstructed immediately.
 
 It is also important that the replay involves the ``import`` statement so
-that the dependencies are resolved properly.
+that dependencies are resolved properly.
 
 
 Shared global compiletime state
 -------------------------------
 
 Nim allows ``.global, compiletime`` variables that can be filled by macro
-invokations across different modules. This feature breaks modularity in a
+invocations across different modules. This feature breaks modularity in a
 severe way. Plenty of different solutions have been proposed:
 
 - Restrict the types of global compiletime variables to ``Set[T]`` or
@@ -286,7 +286,7 @@ We only know the root is ``someGlobal`` but the concrete path to the data
 is unknown as is the value that is added. We could compute a "diff" between
 the global states and use that to compute a symbol patchset, but this is
 quite some work, expensive to do at runtime (it would need to run after
-every module has been compiled) and also would break for hash tables.
+every module has been compiled) and would also break for hash tables.
 
 We need an API that hides the complex aliasing problems by not relying
 on Nim's global variables. The obvious solution is to use string keys

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -184,7 +184,7 @@ How the RTL is compiled
 
 The ``system`` module contains the part of the RTL which needs support by
 compiler magic (and the stuff that needs to be in it because the spec
-says so). The C code generator generates the C code for it's just like any other
+says so). The C code generator generates the C code for it, just like any other
 module. However, calls to some procedures like ``addInt`` are inserted by
 the CCG. Therefore the module ``magicsys`` contains a table (``compilerprocs``)
 with all symbols that are marked as ``compilerproc``. ``compilerprocs`` are


### PR DESCRIPTION
A couple of typos-fixes and polishes from reading over the _[Internals of the Nim Compiler](https://nim-lang.org/docs/intern.html)_ document.

Also (second commit), amend in _[Nim DocGen Tools Guide](https://nim-lang.org/docs/docgen.html)_ (`docs/docgen.html`) the Nim repository
URL from `Araq/Nim` to `/nim-lang/Nim`:

  * https://github.com/Araq/Nim
  * https://github.com/nim-lang/Nim