### PR TITLE
`getCurrentScope`, `bindSym` with custom scope

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -681,7 +681,7 @@ type
     mNimvm, mIntDefine, mStrDefine, mBoolDefine, mRunnableExamples,
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
     mSymIsInstantiationOf, mNodeId
-
+    mGetCurrentScope,
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -86,9 +86,10 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimMacrosSizealignof")
   defineSymbol("nimNoZeroExtendMagic")
   defineSymbol("nimMacrosGetNodeId")
+  defineSymbol("nimHasGetCurrentScope")
+
   for f in low(Feature)..high(Feature):
     defineSymbol("nimHas" & $f)
-
   for s in WarningsToStr:
     defineSymbol("nimHasWarning" & s)
   for s in HintsToStr:

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -284,7 +284,7 @@ proc opBindSym(c: PContext, scope: PScope, n: PNode, isMixin: int, info: PNode):
 
 proc semGetCurrentScope(c: PContext, n: PNode): PNode =
   let val = cast[ByteAddress](c.currentScope)
-  result = newIntTypeNode(nkIntLit, val, n.typ)
+  result = newIntTypeNode(val, n.typ)
   result.info = n.info
 
 proc semDynamicBindSym(c: PContext, n: PNode): PNode =

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -478,14 +478,13 @@ type
 
   NimScope* = distinct ByteAddress ## scope in which to resolve `bindSym`
 
-proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.magic: "NBindSym", noSideEffect.}
-
 when defined(nimHasGetCurrentScope):
   proc getCurrentScope*(): NimScope {. magic: "GetCurrentScope", noSideEffect.}
     ## return opaque pointer to current scope, allowing `bindSym` to
     ## resolve relatively to it
-  proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed, scope: NimScope): NimNode {.magic: "NBindSym", noSideEffect.}
-    ## Ceates a node that binds `ident` to a symbol node. The bound symbol
+
+  proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed, scope: NimScope = 0.NimScope): NimNode {.magic: "NBindSym", noSideEffect.}
+    ## Creates a node that binds `ident` to a symbol node. The bound symbol
     ## may be an overloaded symbol.
     ## if `ident` is a NimNode, it must have ``nnkIdent`` kind.
     ## If ``rule == brClosed`` either an ``nnkClosedSymChoice`` tree is
@@ -502,8 +501,10 @@ when defined(nimHasGetCurrentScope):
     ## If called from macros / compile time procs / static blocks,
     ## `ident` and `rule` can be VM computed value.
     ##
-    ## `scope` can be obtained via `getCurrentScope` to bind to another scope
+    ## `scope` can be obtained via `getCurrentScope` to bind to another scope,
+    ## use 0 for current scope.
 else:
+  proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.magic: "NBindSym", noSideEffect.}
   proc getCurrentScope*(): NimScope = NimScope.default
 
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.

--- a/tests/macros/mbindsym.nim
+++ b/tests/macros/mbindsym.nim
@@ -1,0 +1,35 @@
+import std/macros
+
+{.experimental: "dynamicBindSym".}
+
+macro dispatchImpl(scope: static NimScope, fun: untyped, args: varargs[untyped]): untyped =
+  let sym = bindSym(fun.repr, scope=scope).getImpl
+  let bodyParam = sym[3][^1][0]
+  result = newCall(fun)
+  for i, a in args:
+    result.add:
+      if a.kind == nnkStmtList:
+        doAssert i == args.len-1
+        newTree(nnkExprEqExpr, bodyParam, a)
+      else:
+        a
+
+template dispatch*(fun: untyped, args: varargs[untyped]): untyped =
+  dispatchImpl(getCurrentScope(), fun, args)
+
+macro inspectImpl(scope: static NimScope, fun: untyped): untyped =
+  let sym = bindSym(fun.repr, scope=scope).getImpl
+  newLit sym.repr
+
+template inspect*(fun: untyped): untyped = inspectImpl(getCurrentScope(), fun)
+
+macro inspectWithoutScope*(fun: typed): untyped =
+  let sym = fun.getImpl
+  newLit sym.repr
+
+macro arityImpl(scope: static NimScope, fun: untyped): untyped =
+  let sym = bindSym(fun.repr, scope=scope).getImpl
+  newLit sym[3].len - 1
+
+template arity*(fun: untyped): untyped = arityImpl(getCurrentScope(), fun)
+

--- a/tests/macros/tbindsym.nim
+++ b/tests/macros/tbindsym.nim
@@ -143,3 +143,11 @@ block:
     template fun5(a1: int, a2: int): untyped = discard
     doAssert arity(fun5) == 2
 
+block:
+  # example from [optional params before `untyped` body - Nim forum](https://forum.nim-lang.org/t/4970)
+  template foo(a1 = 10, a2 = "ba", body: untyped): untyped = (a1, a2, astToStr(body))
+  let ret = dispatch foo:
+    for a in 0..<3:
+      echo a
+    echo 10
+  doAssert ret == (10, "ba", "\nfor a in 0 ..< 3:\n  echo a\necho 10")

--- a/tests/macros/tbindsym.nim
+++ b/tests/macros/tbindsym.nim
@@ -65,3 +65,81 @@ macro mixer(): untyped =
   echo getType(x).repr
 
 mixer()
+
+import ./mbindsym
+
+block:
+  # `getCurrentScope` allows passing templates and macros to another macro even when all
+  # parameters are optional or untyped, by passing them as `untyped` and accessing them
+  # via `bindSym(ident, scope)` in the callee
+  # Example use case: debugging / introspection
+  proc fun1(): auto = 1
+  template fun2(): untyped = (1,2)
+  template fun3(a1: int): untyped = discard
+  template fun4(a1: int, a2: int): untyped = discard
+  template fun4b(a1 = 1, a2 = "bac"): untyped = discard
+  macro fun5(a1 = 1, a2 = "bac"): untyped = discard
+  macro fun6(a1: int): untyped = discard
+  # macro fun7(a1: int = 12, body: untyped): untyped = discard
+  macro fun7(a0 = 1, body: untyped): untyped = discard
+
+  const a = 1+2
+  type Foo = object
+    v1, v2: int
+
+  # echo inspect(fun1) # to print
+  discard inspect(fun1)
+  discard inspect(fun2)
+  discard inspect(a)
+  discard inspect(Foo)
+  discard inspect(fun4b)
+  discard inspect(fun5)
+  discard inspect(fun6)
+  discard inspect(fun7)
+
+  when false:
+    # this would not be possible without `getCurrentScope` as it would require
+    # passing `fun` as a `typed` param, but then the compiler would error
+    # after trying to call the template/macro directly:
+    discard inspectWithoutScope(fun2) # Error: node is not a symbol
+    discard inspectWithoutScope(a) # ditto
+    discard inspectWithoutScope(fun4b) # ditto
+    discard inspectWithoutScope(fun5) # Error: in call 'fun5' got -1, but expected 2 argument(s)
+    discard inspectWithoutScope(fun7) # ditto
+  # these work with `inspectWithoutScope`:
+  discard inspectWithoutScope(fun1) # ok
+  discard inspectWithoutScope(fun4) # ok
+  discard inspectWithoutScope(fun6) # ok
+
+  # example use case: type traits
+  doAssert arity(fun2) == 0
+  doAssert arity(fun3) == 1
+  doAssert arity(fun4) == 2
+
+block:
+  # As another application, this can be used to implement a workaround for this:
+  # [optional params before `untyped` body - Nim forum](https://forum.nim-lang.org/t/4970)
+  proc getA1Def(): auto = 12
+
+  macro foo(a0: bool, a1 = getA1Def(), a2 = "ba", body: untyped): untyped =
+    result = newStmtList()
+    result.add body
+    result.add nnkTupleConstr.newTree [a0, a1, a2]
+
+  var count = 0
+  let ret = foo.dispatch(true, a2 = "bo"):
+    count.inc
+
+  doAssert count == 1
+  doAssert ret == (true, 12, "bo")
+
+  macro foo2(body: untyped): untyped = newLit body.repr
+  let ret2 = dispatch(foo2, (echo 12))
+  doAssert ret2 == "(echo 12)"
+
+block:
+  proc main() =
+    # also works inside a proc
+    template fun5(a1: int, a2: int): untyped = discard
+    doAssert arity(fun5) == 2
+


### PR DESCRIPTION
this PR allows to pass around the current scope as an opaque pointer to `bindSym`, allowing one to resolve symbols relative to current caller scope instead of callee scope.
This opens many new possibilities:

* reduce the need for `{.dirty.}` annotations, making symbol resolution scope more precise

* allows passing around templates or macros (as untyped parameters or as string) to another macro, and that other macro can then resolve these back to a symbol using the caller's scope

* this can be used to implement a workaround for calling a macro with optional params + untyped body /cc @zah:
 [optional params before `untyped` body - Nim forum](https://forum.nim-lang.org/t/4970):
```nim
macro foo(a0: bool, a1 = getA1Def(), a2 = "ba", body: untyped): untyped = ...
foo.dispatch(true, a2 = "boo"): some code
```
this would not be possible before this PR, see detailed unittests `tests/macros/tbindsym.nim`


* runtime dispatch, eg:
```nim
# runtimedispatcher.nim: library code, can be implemented using this PR
template runtimeDispatch(cmdline: seq[string], funs: static seq[string])=...

# main.nim: user code 
import runtimedispatcher
proc fun1(a: string, b: float) = discard
proc fun2(x: int) = discard
template fun3(y = 0, y1 = 10) = discard
runtimeDispatch(cmdline = commandLineParams(), @["fun1", "fun2", "fun3"])
```
./main fun1 hello 0.2 # calls fun1("hello", 0,2)
./main fun2 123 # calls fun2(123)

