### PR TITLE
Different Hashing to avoid Collisions.

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -16,6 +16,7 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
 from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
 from md5 import getMD5
 from sighashes import symBodyDigest
+from std/hashes import hashBiggestInt
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -144,3 +145,6 @@ proc registerAdditionalOps*(c: PCtx) =
     let n = getNode(a, 0)
     if n.kind != nkSym: raise newException(ValueError, "node is not a symbol")
     setResult(a, $symBodyDigest(c.graph, n.sym))
+
+  registerCallback c, "stdlib.hashes.hashBiggestIntVM", proc (a: VmArgs) {.nimcall.} =
+    a.setResult hashBiggestInt(getInt(a, 0))

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -130,8 +130,9 @@ proc hash*(x: pointer): Hash {.inline.} =
       }
     """
   else:
-    # bugfix #11764: s/cast[Hash]/hash/
-    result = hash(cast[uint](x) shr 3) # skip the alignment
+    # 2 bug fixes: s/cast[Hash]()/hash()/ (#11764); and also s/uint/BiggestInt/
+    # note that we can't use unsigned because nimscript doesn't have `$`(uint)
+    result = hash(cast[ByteAddress](x) shr 3) # skip the alignment
       # CHECKME: why? isn't that responsability of caller if he needs this behavior?
 
 when not defined(booting):

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -165,9 +165,10 @@ block tableconstr:
 block ttables2:
   proc TestHashIntInt() =
     var tab = initTable[int,int]()
-    for i in 1..1_000_000:
+    const n = 1_000_000 # bottleneck: 50 seconds on OSX in debug mode
+    for i in 1..n:
       tab[i] = i
-    for i in 1..1_000_000:
+    for i in 1..n:
       var x = tab[i]
       if x != i : echo "not found ", i
 
@@ -233,7 +234,7 @@ block tablesref:
       for y in 0..1:
         assert t[(x,y)] == $x & $y
     assert($t ==
-      "{(x: 0, y: 1): \"01\", (x: 0, y: 0): \"00\", (x: 1, y: 0): \"10\", (x: 1, y: 1): \"11\"}")
+      """{(x: 0, y: 1): "01", (x: 1, y: 0): "10", (x: 0, y: 0): "00", (x: 1, y: 1): "11"}""")
 
   block tableTest2:
     var t = newTable[string, float]()

--- a/tests/collections/ttablesthreads.nim
+++ b/tests/collections/ttablesthreads.nim
@@ -48,7 +48,7 @@ block tableTest1:
     for y in 0..1:
       assert t[(x,y)] == $x & $y
   assert($t ==
-    "{(x: 0, y: 1): \"01\", (x: 0, y: 0): \"00\", (x: 1, y: 0): \"10\", (x: 1, y: 1): \"11\"}")
+    """{(x: 0, y: 0): "00", (x: 1, y: 0): "10", (x: 0, y: 1): "01", (x: 1, y: 1): "11"}""")
 
 block tableTest2:
   var t = initTable[string, float]()

--- a/tests/vm/tcompiletimetable.nim
+++ b/tests/vm/tcompiletimetable.nim
@@ -47,3 +47,29 @@ addStuff("Hey"): echo "Hey"
 addStuff("Hi"): echo "Hi"
 dump()
 
+import std/hashes
+block:
+  # check CT vs RT produces same results for Table
+  template callFun(T) =
+    block:
+      proc fun(): string =
+        var t: Table[T, string]
+        let n = 10
+        for i in 0..<n:
+          let i2 = when T.sizeof == type(i).sizeof: i else: i.int32
+          let k = cast[T](i2)
+            # cast intentional for regression testing,
+            # producing small values
+          doAssert k notin t
+          t[k] = $(i, k)
+          doAssert k in t
+        $t
+      const s1 = fun()
+      let s2 = fun()
+      # echo s1 # for debugging
+      doAssert s1 == s2
+      doAssert s1 == s2
+      doAssert hash(0.0) == hash(-0.0)
+  callFun(float)
+  callFun(float32)
+  callFun(int64)


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/issues/11764

* it turns out all primitive types of size >= 4 bytes (eg int32, pointer, uint, float etc) are affected by the bug, resulting in 100 to 1000 slowdown depending on conditions
for eg for pointer, the 3rd case is 1K slower; float also is similar; this PR fixes that

* also fixes another bug that would cause hash collisions for small floats (previous code was using `x+1.0` which leads to 0 for small floats)

see test cases here to reproduce:
results: see https://github.com/timotheecour/vitanim/blob/master/testcases/tests/t0129b.nim

## note
as I also observed (see test case), the `faster hashing` PR https://github.com/nim-lang/Nim/pull/11203 introduced a 5X slowdown 2.229572/0.424859 in some cases, eg using `uint64` or `uint32` and more (for 3rd case, with `let n = 100_000 * 10`), even after my PR #11767 is applied (ie after hash input as as a string): in other words, `bytewiseHashing` and `murmur3` are 5X faster compared to the multibyte hash introduced in #11203

this is related to what I had observed in https://github.com/nim-lang/Nim/issues/11581 but introduces the new observation that the multibyte extension to the jenkins hash is also affected for smaller inputs than oids, such as `uint64` or even `uint32`. The same conclusion as #11581 follow: we should adopt murmur3 (or at least reconsider implementation of #11203) which always comes out the fastest ; I have provided a pure nim implementation and suggested how to make it work at CT (via vm register callback)

[EDIT] that 2nd point won't be observable after latest commit since code now uses `hashData(cast[pointer](unsafeAddr x), T.sizeof)` which for some reason is implemented differently than `hash*[A](aBuf: openArray[A], sPos, ePos: int)`, ie doesn't use multibyte jenkins anymore, but the point remains that multibyte jenkins can still result in 5x slowdown even for small (4B) inputs