### PR TITLE
Fix the range of destroyed elements when shrinking a seq

### DIFF
--- a/lib/core/seqs.nim
+++ b/lib/core/seqs.nim
@@ -138,7 +138,7 @@ proc shrink*[T](x: var seq[T]; newLen: Natural) =
   mixin `=destroy`
   sysAssert newLen <= x.len, "invalid newLen parameter for 'shrink'"
   when not supportsCopyMem(T):
-    for i in countdown(x.len - 1, newLen - 1):
+    for i in countdown(x.len - 1, newLen):
       `=destroy`(x[i])
   # XXX This is wrong for const seqs that were moved into 'x'!
   cast[ptr NimSeqV2[T]](addr x).len = newLen


### PR DESCRIPTION
With `--newruntime`, shrinking a `seq` destroyed one too many elements/iterated out of bounds. E.g. this crashed
```nim
var x = newSeq[string](1)
x.setLen(0)
```