### PR TITLE
fixes #11792

### DIFF
--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -169,7 +169,7 @@ proc computeObjectOffsetsFoldFunction(conf: ConfigRef; n: PNode,
       align = n.sym.typ.align.int
 
     result.align = align
-    if initialOffset == szUnknownSize or size == szUnknownSize:
+    if initialOffset == szUnknownSize or size == szUnknownSize or align == szUnknownSize:
       n.sym.offset = szUnknownSize
       result.offset = szUnknownSize
     else:

--- a/tests/misc/tsizeof3.nim
+++ b/tests/misc/tsizeof3.nim
@@ -17,3 +17,33 @@ proc toByteArrayBE*[T: SomeInteger](num: T): ByteArrayBE[sizeof(T)]=
 
 let a = 12345.toByteArrayBE
 echo a[^2 .. ^1] # to make it work on both 32-bit and 64-bit
+
+
+#-----------------------------------------------------------------
+
+# bug #11792
+type
+  m256d {.importc: "__m256d", header: "immintrin.h".} = object
+
+  MyKind = enum
+    k1, k2, k3
+
+  MyTypeObj = object
+    kind: MyKind
+    x: int
+    amount: UncheckedArray[m256d]
+
+
+# The sizeof(MyTypeObj) is not equal to (sizeof(int) + sizeof(MyKind)) due to
+# alignment requirement of m256d, make sure Nim understands that
+doAssert(sizeof(MyTypeObj) > sizeof(int) + sizeof(MyKind))
+
+#---------------------------------------------------------------------
+
+type
+  Payload = object
+    something: int
+    vals: UncheckedArray[int]
+
+static:
+  doAssert(compiles(offsetOf(Payload, vals)))


### PR DESCRIPTION
test case is included.

Description.
It is not possible to compute the size of the following object without knowing the alignment of `MyImportedType` even if size of `UncheckArray[MyImportedType]` is zero:
```nim
  MyType = object
    a: int
    b: UncheckeyArray[MyImportedType]
```
Alignment of `b` needs to be included to sizeof `MyType` even if size of `b` is zero.
In this case sizeof needs to be delegated back to c/cpp


