### PR TITLE
compiler/suggest: highlight squashed operators

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -106,11 +106,15 @@ proc getTokenLenFromSource(conf: ConfigRef; ident: string; info: TLineInfo): int
     if cmpIgnoreStyle(line[column..column + result - 1], ident) != 0:
       result = 0
   else:
-    result = skipWhile(line, OpChars + {'[', '(', '{', ']', ')', '}'}, column)
+    var sourceIdent: string
+    result = parseWhile(line, sourceIdent,
+                        OpChars + {'[', '(', '{', ']', ')', '}'}, column)
     if ident[^1] == '=' and ident[0] in linter.Letters:
-      if line[column..column + result - 1] != "=":
+      if sourceIdent != "=":
         result = 0
-    elif line[column..column + result - 1] != ident:
+    elif sourceIdent.len > ident.len and sourceIdent[..ident.high] == ident:
+      result = ident.len
+    elif sourceIdent != ident:
       result = 0
 
 proc symToSuggest(conf: ConfigRef; s: PSym, isLocal: bool, section: IdeCmd, info: TLineInfo;

--- a/nimsuggest/tests/top_highlight.nim
+++ b/nimsuggest/tests/top_highlight.nim
@@ -1,0 +1,11 @@
+import json
+
+%*{}#[!]#
+
+discard """
+$nimsuggest --tester $file
+>highlight $1
+highlight;;skModule;;1;;7;;4
+highlight;;skMacro;;3;;0;;2
+highlight;;skMacro;;3;;0;;2
+"""


### PR DESCRIPTION
The operator fetching proc is greedy, so operators such as `%*` in
expression `%*{}` can't be highlighted.

This commit fixes that.