### PR TITLE
Add `opacity` to JS `Style`

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -408,6 +408,7 @@ type
     maxWidth*: cstring
     minHeight*: cstring
     minWidth*: cstring
+    opacity*: cstring
     overflow*: cstring
     padding*: cstring
     paddingBottom*: cstring
@@ -416,6 +417,7 @@ type
     paddingTop*: cstring
     pageBreakAfter*: cstring
     pageBreakBefore*: cstring
+    opacity*: cstring
     pointerEvents*: cstring
     position*: cstring
     right*: cstring


### PR DESCRIPTION
I noticed this was missing.  It has cross browser support: https://developer.mozilla.org/en-US/docs/Web/CSS/opacity#Browser_compatibility