### PR TITLE
Removal Deprecation Warnings on export except Statement

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2453,8 +2453,8 @@ proc semExportExcept(c: PContext, n: PNode): PNode =
        s.name.id notin exceptSet and sfError notin s.flags:
       strTableAdd(c.module.tab, s)
       result.add newSymNode(s, n.info)
-      markUsed(c, n.info, s, c.graph.usageSym)
     s = nextIter(i, exported.tab)
+  markUsed(c, n.info, exported, c.graph.usageSym)
 
 proc semExport(c: PContext, n: PNode): PNode =
   result = newNodeI(nkExportStmt, n.info)


### PR DESCRIPTION
This produces a warning for all deprecated symbols in macros.
```nim
import macros
export macros except `$`
```

## Current  Output

```
$ nim c -r scratch.nim
Hint: used config file '/home/arne/proj/nim/Nim/config/nim.cfg' [Conf]
Hint: used config file '/home/arne/.config/nim/nim.cfg' [Conf]
Hint: used config file '/home/arne/proj/nim/Nim/config/config.nims' [Conf]
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: scratch [Processing]
Hint: macros [Processing]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.1; Use '==' on 'NimNode' instead.; == is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since v0.18.1; use varargs[untyped] in the macro prototype instead; callsite is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.1; Use '==(NimNode, NimNode)' instead.; == is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: dumpTreeImm is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since v0.18.1; use 'newCall(string, ...)' or 'newCall(NimNode, ...)' instead; newCall is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: TNimTypeKinds is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.1; Generate a new 'NimNode' with 'ident(string)' instead.; ident= is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.1; All functionality is defined on 'NimNode'.; symbol is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.; toNimIdent is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.1; Generate a new 'NimNode' with 'genSym' instead.; symbol= is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.1; All functionality is defined on 'NimNode'.; ident is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: NimSym is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: dumpLispImm is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: TNimSymKinds is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: newIdentNode is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: use `getImpl: NimNode -> NimNode` instead; getImpl is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: emit is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.; ! is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: Deprecated since v0.18.1; use one of 'nestList(NimNode, ...)' instead.; nestList is deprecated [Deprecated]
/tmp/scratch.nim(12, 1) Warning: NimIdent is deprecated [Deprecated]
CC: stdlib_system.nim
CC: scratch.nim
Hint:  [Link]
Hint: operation successful (23090 lines compiled; 0.589 sec total; 24.695MiB peakmem; Debug Build) [SuccessX]
Hint: /tmp/scratch  [Exec]
```

## Solution

Mark the module used instead for export except.