### PR TITLE
fix #11772, JS random seed was too large

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -608,7 +608,7 @@ when not defined(nimscript):
     ## * `randomize proc<#randomize,int64>`_ that accepts a seed
     ## * `initRand proc<#initRand,int64>`_
     when defined(JS):
-      let time = int64(times.epochTime() * 100_000)
+      let time = int64(times.epochTime() * 1000)
       randomize(time)
     else:
       let now = times.getTime()


### PR DESCRIPTION
In the JS backend `times.epochTime()` gives only millisecond resolution, so there's no point in multiplying by anything larger than `1000`.
The previous larger values were producing `Error: unhandled exception: value out of range [RangeError]`.