### PR TITLE
[superseded] `alias: myecho=echo`  to alias any symbol

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -571,7 +571,9 @@ type
                           # file (it is loaded on demand, which may
                           # mean: never)
     skPackage,            # symbol is a package (used for canonicalization)
-    skAlias               # an alias (needs to be resolved immediately)
+    skAlias,              # an alias (needs to be resolved immediately)
+    skAliasDeprecated,    # an skAlias for a deprecated symbol
+
   TSymKinds* = set[TSymKind]
 
 const
@@ -665,7 +667,8 @@ type
     mInstantiationInfo, mGetTypeInfo,
     mNimvm, mIntDefine, mStrDefine, mBoolDefine, mRunnableExamples,
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
-    mSymIsInstantiationOf
+    mSymIsInstantiationOf,
+    mAlias,
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const
@@ -977,8 +980,8 @@ const
   NilableTypes*: TTypeKinds = {tyPointer, tyCString, tyRef, tyPtr,
     tyProc, tyError}
   ExportableSymKinds* = {skVar, skConst, skProc, skFunc, skMethod, skType,
-    skIterator,
-    skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias}
+    skIterator, skMacro, skTemplate, skConverter, skEnumField, skLet, skStub,
+    skAlias, skAliasDeprecated}
   PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
                                       nfDotSetter, nfDotField,
                                       nfIsRef, nfPreventCg, nfLL,

--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -992,3 +992,10 @@ proc isAddrNode*(n: PNode): bool =
       if n[0].kind == nkSym and n[0].sym.magic == mAddr: true
       else: false
     else: false
+
+proc skipAliasAux*(s: PSym): PSym =
+  ## similar to `skipAlias` without extra error message processing
+  result = s
+  while true:
+    if result.kind in {skAlias, skAliasDeprecated}: result=result.owner
+    else: return result

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -87,6 +87,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasDefault")
   defineSymbol("nimMacrosSizealignof")
   defineSymbol("nimNoZeroExtendMagic")
+  defineSymbol("nimHasAlias")
   for f in low(Feature)..high(Feature):
     defineSymbol("nimHas" & $f)
 

--- a/compiler/magicsys.nim
+++ b/compiler/magicsys.nim
@@ -31,7 +31,7 @@ proc getSysSym*(g: ModuleGraph; info: TLineInfo; name: string): PSym =
     localError(g.config, info, "system module needs: " & name)
     result = newSym(skError, getIdent(g.cache, name), g.systemModule, g.systemModule.info, {})
     result.typ = newType(tyError, g.systemModule)
-  if result.kind == skAlias: result = result.owner
+  result = skipAliasAux(result)
 
 proc getSysMagic*(g: ModuleGraph; info: TLineInfo; name: string, m: TMagic): PSym =
   var ti: TIdentIter

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -134,6 +134,8 @@ type
       ## This requires building nim with `-d:nimHasLibFFI`
       ## which itself requires `nimble install libffi`, see #10150
       ## Note: this feature can't be localized with {.push.}
+    aliasSym,
+      ## enable `Alias` magic to alias symbols
 
   SymbolFilesOption* = enum
     disabledSf, writeOnlySf, readOnlySf, v2Sf

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -696,7 +696,7 @@ proc deprecatedStmt(c: PContext; outerPragma: PNode) =
       if dest == nil or dest.kind in routineKinds:
         localError(c.config, n.info, warnUser, "the .deprecated pragma is unreliable for routines")
       let src = considerQuotedIdent(c, n[0])
-      let alias = newSym(skAlias, src, dest, n[0].info, c.config.options)
+      let alias = newSym(skAliasDeprecated, src, dest, n[0].info, c.config.options)
       incl(alias.flags, sfExported)
       if sfCompilerProc in dest.flags: markCompilerProc(c, alias)
       addInterfaceDecl(c, alias)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2244,7 +2244,10 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
   of mSizeOf: result =
     semSizeof(c, setMs(n, s))
   of mAlias:
-    result = semAlias(c, n, s, flags)
+    if aliasSym in c.features:
+      result = semAlias(c, n, s, flags)
+    else:
+      globalError(c.config, n.info, "requires --experimental:aliasSym")
   else:
     result = semDirectOp(c, n, flags)
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2138,14 +2138,14 @@ proc semAlias(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
   of nkAsgn:
     nodeAlias = def[0]
     nodeOrigin = def[1]
-  of nkInFix:
+  of nkInfix:
     if def[0].ident.s != "*=":
       globalError(c.config, n.info, errUser, "expected `*=`, got " & renderTree(def))
     nodeAlias = def[1]
     nodeOrigin = def[2]
     exported = true
   else:
-    globalError(c.config, n.info, errUser, "expected " & ${nkAsgn, nkInFix} &  ", got " & $def.kind)
+    globalError(c.config, n.info, errUser, "expected " & ${nkAsgn, nkInfix} &  ", got " & $def.kind)
 
   template maybeExport(alias) =
     if exported: alias.flags.incl sfExported

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -240,15 +240,14 @@ macro distinctBase*(T: typedesc): untyped =
   typeSym.freshIdentNodes
 
 when defined(nimHasAlias):
-  proc aliasImpl[T1, T2](name: T1, expr: T2) {.magic: "Alias".}
-
-  template `:=`*(name, expr) =
+  proc alias*(aliasDef: untyped) {.magic: "Alias".} =
     ## Declares `name` as alias of `expr`, which must resolve to a symbol.
     ## Works with any symbol, e.g. iterator, template, macro, module, proc etc.
     runnableExamples:
       {.push experimental: "aliasSym".}
-      echo2:=echo
+      alias: echo2=echo
       echo2 "hello"
-      declared2:=system.declared
+      alias: declared2=system.declared
       doAssert declared2(echo2)
-    aliasImpl(name, expr)
+      alias: echoPub*=echo # would export `echoPub`
+    discard

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -238,3 +238,15 @@ macro distinctBase*(T: typedesc): untyped =
   while typeSym.typeKind == ntyDistinct:
     typeSym = getTypeImpl(typeSym)[0]
   typeSym.freshIdentNodes
+
+when defined(nimHasAlias):
+  proc aliasImpl[T1, T2](name: T1, expr: T2) {.magic: "Alias".}
+
+  template `:=`*(name, expr) =
+    ## Declares `a` as alias of `expr`, which must resolve to a symbol.
+    runnableExamples:
+      echo2:=system.echo
+      echo2 "hello"
+      declared2:=system.declared
+      doAssert declared2(echo2)
+    aliasImpl(name, expr)

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -243,9 +243,11 @@ when defined(nimHasAlias):
   proc aliasImpl[T1, T2](name: T1, expr: T2) {.magic: "Alias".}
 
   template `:=`*(name, expr) =
-    ## Declares `a` as alias of `expr`, which must resolve to a symbol.
+    ## Declares `name` as alias of `expr`, which must resolve to a symbol.
+    ## Works with any symbol, e.g. iterator, template, macro, module, proc etc.
     runnableExamples:
-      echo2:=system.echo
+      {.push experimental: "aliasSym".}
+      echo2:=echo
       echo2 "hello"
       declared2:=system.declared
       doAssert declared2(echo2)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -149,18 +149,6 @@ else:
   template runnableExamples*(body: untyped) =
     discard
 
-when defined(nimHasAlias):
-  proc aliasImpl[T1, T2](name: T1, expr: T2) {.magic: "Alias".}
-
-  template `:=`*(name, expr) =
-    ## Declares `a` as alias of `expr`, which must resolve to a symbol.
-    runnableExamples:
-      echo2:=system.echo
-      echo2 "hello"
-      declared2:=system.declared
-      doAssert declared2(echo2)
-    aliasImpl(name, expr)
-
 proc declared*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## Special compile-time procedure that checks whether `x` is
   ## declared. `x` has to be an identifier or a qualified identifier.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -149,6 +149,18 @@ else:
   template runnableExamples*(body: untyped) =
     discard
 
+when defined(nimHasAlias):
+  proc aliasImpl[T1, T2](name: T1, expr: T2) {.magic: "Alias".}
+
+  template `:=`*(name, expr) =
+    ## Declares `a` as alias of `expr`, which must resolve to a symbol.
+    runnableExamples:
+      echo2:=system.echo
+      echo2 "hello"
+      declared2:=system.declared
+      doAssert declared2(echo2)
+    aliasImpl(name, expr)
+
 proc declared*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## Special compile-time procedure that checks whether `x` is
   ## declared. `x` has to be an identifier or a qualified identifier.

--- a/tests/magics/malias2.nim
+++ b/tests/magics/malias2.nim
@@ -1,0 +1,6 @@
+import std/sugar
+
+template fun6(): untyped = 42
+
+{.push experimental: "aliasSym".}
+alias: fun6a*=fun6 # alias with export

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -13,7 +13,7 @@ proc main1() =
 
   block: # works with macros, even with all optional parameters
     macro fun2(a = 10, b = 11): untyped = quote do: (`a`,`b`)
-    fun2a:=fun2
+    alias: fun2a=fun2
     doAssert fun2a() == (10, 11)
     doAssert fun2a(12) == (12, 11)
     block:
@@ -21,66 +21,65 @@ proc main1() =
 
   block: # ditto with templates
     template fun2(a = 10, b = 11): untyped = (a,b)
-    fun2a:=fun2
+    alias:fun2a=fun2
     doAssert fun2a(12) == (12, 11)
     doAssert fun2a() == (10, 11)
 
   block: # works with types
-    int2:=system.int
+    alias:int2=system.int
     doAssert int2 is int
 
   block: # ditto
-    int2:=int
+    alias:int2=int
     doAssert int2 is int
 
   block: # works with modules
-    system2:=system
+    alias:system2=system
     doAssert system2.int is int
-    int2:=system2.int
+    alias:int2=system2.int
     doAssert int2 is int
 
   block: # usage of alias is identical to usage of aliased symbol
-    currentSourcePath2:=system.currentSourcePath
+    alias:currentSourcePath2=system.currentSourcePath
     doAssert currentSourcePath2 == currentSourcePath
     doAssert currentSourcePath2() == currentSourcePath()
 
   block: # works with overloaded symbols
-    toStr:=`$`
+    alias:toStr=`$`
     doAssert 12.toStr == "12"
     doAssert true.toStr == "true"
 
   block: # CT error if symbol does not exist in scope
-    doAssert compiles(echo2:=echo)
-    doAssert not compiles(echo2:=echo_nonexistant)
-    echo2:=echo
+    doAssert compiles(block: alias: echo2=echo)
+    doAssert not compiles(block: alias: echo2=echoNonexistant)
+    alias: echo2=echo
     doAssert compiles(echo2())
   doAssert not compiles(echo2()) # echo2 not in scope anymore
 
   block: # works with variables
     var x = @[1,2,3]
-    xa:=x
+    alias: xa=x
     xa[1] = 10
     doAssert x == @[1,10,3]
-    doAssert not compiles(xa2:=x[1])
+    doAssert not compiles(block: alias: xa2=x[1])
     when false:
-      xa:=x # correctly would give: Error: redefinition of 'xa'
-      # doAssert not compiles(xa:=x) # we can't test that using `compiles` though
+      alias: xa=x # correctly would give: Error: redefinition of 'xa'
 
   block: # works with const
     const L = 12
-    L2:=L
+    alias: L2=L
     const L3 = L2
     doAssert L3 == L
 
   block: # works with overloaded symbols, including local overloads, including generics
     proc fun0[T](a: T, b: float): auto = $(a,b)
-    fun0a:=fun0
+    alias: fun0a=fun0
     doAssert fun0a(true) == "true"
     doAssert fun0a(1.2) == "1.2"
     doAssert fun0a(1, 2.0) == "(1, 2.0)"
 
   block: # works with overloaded templates
-    fun3a:=fun3
+    alias: fun3a=fun3
     doAssert fun3a(12.1) == "12.1"
     doAssert fun3a() == "1.2"
 
@@ -88,27 +87,27 @@ proc main1() =
     iterator fun4(): auto =
       yield 10
       yield 3
-    fun4a := fun4
+    alias: fun4a = fun4
     var s: seq[int]
     for ai in fun4a(): s.add ai
     doAssert s == [10,3]
 
   block: # works with generics
     proc fun5[T](a: T): auto = a
-    fun5a := fun5
+    alias: fun5a = fun5
     doAssert fun5a(3.2) == 3.2
 
-proc main2() = # using `:=` alias avoids all issues mentioned in #8935
+proc main2() = # using `alias` avoids all issues mentioned in #8935
   # const myPrint = echo # Error: invalid type for const: proc
   # let myPuts = system.echo # Error: invalid type: 'typed'
-  myPrint:=echo # works
+  alias: myPrint=echo # works
   # myPrint (1,2)
   doAssert compiles(myPrint (1,2))
   when false:
     const testForMe = assert
     testForMe(1 + 1 == 2)  # Error: VM problem: dest register is not set
 
-  testForMe:=assert
+  alias: testForMe=assert
   testForMe(1 + 1 == 2)
   doAssertRaises(AssertionError): testForMe(1 + 1 == 3)
 
@@ -117,7 +116,7 @@ block: # somewhat related to #11047
   # var f {.compileTime.} = foo # would give: Undefined symbols error
   # let f {.compileTime.} = foo # would give: Undefined symbols error
   # const f = foo # this would work
-  f:=foo
+  alias: f=foo
   doAssert f() == 100
   static: doAssert f() == 100
 
@@ -125,16 +124,19 @@ block: # fix https://forum.nim-lang.org/t/5015
   proc getLength(i: int): int = sizeof(i)
   proc getLength(s: string): int = s.len
   # const length = getLength # Error: cannot generate VM code for getLength
-  length := getLength # works
+  alias: length = getLength # works
   doAssert length("alias") == 5
 
 block: # works with `result` variable too, as asked here:
        # https://forum.nim-lang.org/t/5015#31650
   proc foo(): string =
-    r:=result
+    alias: r=result
     r.add "ba"
     r.add "bo"
   doAssert foo() == "babo"
+
+import ./malias2
+doAssert fun6a() == 42
 
 main1()
 main2()

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -98,7 +98,7 @@ proc main1() =
     fun5a := fun5
     doAssert fun5a(3.2) == 3.2
 
-proc main2() = # fixes #8935
+proc main2() = # using `:=` alias avoids all issues mentioned in #8935
   # const myPrint = echo # Error: invalid type for const: proc
   # let myPuts = system.echo # Error: invalid type: 'typed'
   myPrint:=echo # works

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -1,0 +1,93 @@
+import std/macros
+
+proc fun0(a: int): auto = $a
+template fun3(a: int): untyped = $a
+template fun3(a = 1.2): untyped = $a
+
+proc main() =
+  proc fun0(a: float): auto = $a
+  proc fun0(a: bool): auto = $a
+
+  block: # works with macros, even with all optional parameters
+    macro fun2(a = 10, b = 11): untyped = quote do: (`a`,`b`)
+    fun2a:=fun2
+    doAssert fun2a() == (10, 11)
+    doAssert fun2a(12) == (12, 11)
+    block:
+      doAssert fun2a(12) == (12, 11)
+
+  block: # ditto with templates
+    template fun2(a = 10, b = 11): untyped = (a,b)
+    fun2a:=fun2
+    doAssert fun2a(12) == (12, 11)
+    doAssert fun2a() == (10, 11)
+
+  block: # works with types
+    int2:=system.int
+    doAssert int2 is int
+
+  block: # ditto
+    int2:=int
+    doAssert int2 is int
+
+  block: # works with modules
+    system2:=system
+    doAssert system2.int is int
+    int2:=system2.int
+    doAssert int2 is int
+
+  block: # usage of alias is identical to usage of aliased symbol
+    currentSourcePath2:=system.currentSourcePath
+    doAssert currentSourcePath2 == currentSourcePath
+    doAssert currentSourcePath2() == currentSourcePath()
+
+  block: # works with overloaded symbols
+    toStr:=`$`
+    doAssert 12.toStr == "12"
+    doAssert true.toStr == "true"
+
+  block: # CT error if symbol does not exist in scope
+    doAssert compiles(echo2:=echo)
+    doAssert not compiles(echo2:=echo_nonexistant)
+    echo2:=echo
+    doAssert compiles(echo2())
+  doAssert not compiles(echo2()) # echo2 not in scope anymore
+
+  block: # works with variables
+    var x = @[1,2,3]
+    xa:=x
+    xa[1] = 10
+    doAssert x == @[1,10,3]
+    doAssert not compiles(xa2:=x[1])
+    when false:
+      xa:=x # correctly would give: Error: redefinition of 'xa'
+      # doAssert not compiles(xa:=x) # we can't test that using `compiles` though
+
+  block: # works with const
+    const L = 12
+    L2:=L
+    const L3 = L2
+    doAssert L3 == L
+
+  block: # works with overloaded symbols, including local overloads, including generics
+    proc fun0[T](a: T, b: float): auto = $(a,b)
+    fun0a:=fun0
+    doAssert fun0a(true) == "true"
+    doAssert fun0a(1.2) == "1.2"
+    doAssert fun0a(1, 2.0) == "(1, 2.0)"
+
+  block: # works with overloaded templates
+    fun3a:=fun3
+    doAssert fun3a(12.1) == "12.1"
+    doAssert fun3a() == "1.2"
+
+  block: # works with iterator
+    iterator fun4(): auto =
+      yield 10
+      yield 3
+    fun4a := fun4
+    var s: seq[int]
+    for ai in fun4a(): s.add ai
+    doAssert s == [10,3]
+
+main()

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -1,4 +1,7 @@
 import std/macros
+import std/sugar
+
+{.push experimental: "aliasSym".}
 
 proc fun0(a: int): auto = $a
 template fun3(a: int): untyped = $a

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -4,7 +4,7 @@ proc fun0(a: int): auto = $a
 template fun3(a: int): untyped = $a
 template fun3(a = 1.2): untyped = $a
 
-proc main() =
+proc main1() =
   proc fun0(a: float): auto = $a
   proc fun0(a: bool): auto = $a
 
@@ -108,5 +108,14 @@ proc main2() = # fixes #8935
   testForMe(1 + 1 == 2)
   doAssertRaises(AssertionError): testForMe(1 + 1 == 3)
 
-main()
+block:# somewhat related to #11047
+  proc foo(): int {.compileTime.} = 100
+  # var f {.compileTime.} = foo # would give: Undefined symbols error
+  # let f {.compileTime.} = foo # would give: Undefined symbols error
+  # const f = foo # this would work
+  f:=foo
+  doAssert f() == 100
+  static: doAssert f() == 100
+
+main1()
 main2()

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -128,5 +128,13 @@ block: # fix https://forum.nim-lang.org/t/5015
   length := getLength # works
   doAssert length("alias") == 5
 
+block: # works with `result` variable too, as asked here:
+       # https://forum.nim-lang.org/t/5015#31650
+  proc foo(): string =
+    r:=result
+    r.add "ba"
+    r.add "bo"
+  doAssert foo() == "babo"
+
 main1()
 main2()

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -97,7 +97,7 @@ proc main1() =
     alias: fun5a = fun5
     doAssert fun5a(3.2) == 3.2
 
-proc main2() = # using `alias` avoids all issues mentioned in #8935
+proc main2() = # using `alias` avoids the issues mentioned in #8935
   # const myPrint = echo # Error: invalid type for const: proc
   # let myPuts = system.echo # Error: invalid type: 'typed'
   alias: myPrint=echo # works

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -99,7 +99,8 @@ proc main2() = # fixes #8935
   # const myPrint = echo # Error: invalid type for const: proc
   # let myPuts = system.echo # Error: invalid type: 'typed'
   myPrint:=echo # works
-  myPrint (1,2)
+  # myPrint (1,2)
+  doAssert compiles(myPrint (1,2))
   when false:
     const testForMe = assert
     testForMe(1 + 1 == 2)  # Error: VM problem: dest register is not set
@@ -108,7 +109,7 @@ proc main2() = # fixes #8935
   testForMe(1 + 1 == 2)
   doAssertRaises(AssertionError): testForMe(1 + 1 == 3)
 
-block:# somewhat related to #11047
+block: # somewhat related to #11047
   proc foo(): int {.compileTime.} = 100
   # var f {.compileTime.} = foo # would give: Undefined symbols error
   # let f {.compileTime.} = foo # would give: Undefined symbols error
@@ -116,6 +117,13 @@ block:# somewhat related to #11047
   f:=foo
   doAssert f() == 100
   static: doAssert f() == 100
+
+block: # fix https://forum.nim-lang.org/t/5015
+  proc getLength(i: int): int = sizeof(i)
+  proc getLength(s: string): int = s.len
+  # const length = getLength # Error: cannot generate VM code for getLength
+  length := getLength # works
+  doAssert length("alias") == 5
 
 main1()
 main2()

--- a/tests/magics/talias2.nim
+++ b/tests/magics/talias2.nim
@@ -90,4 +90,23 @@ proc main() =
     for ai in fun4a(): s.add ai
     doAssert s == [10,3]
 
+  block: # works with generics
+    proc fun5[T](a: T): auto = a
+    fun5a := fun5
+    doAssert fun5a(3.2) == 3.2
+
+proc main2() = # fixes #8935
+  # const myPrint = echo # Error: invalid type for const: proc
+  # let myPuts = system.echo # Error: invalid type: 'typed'
+  myPrint:=echo # works
+  myPrint (1,2)
+  when false:
+    const testForMe = assert
+    testForMe(1 + 1 == 2)  # Error: VM problem: dest register is not set
+
+  testForMe:=assert
+  testForMe(1 + 1 == 2)
+  doAssertRaises(AssertionError): testForMe(1 + 1 == 3)
+
 main()
+main2()


### PR DESCRIPTION
[EDIT] nim now has a way to alias any **symbol** (for **lvalue expressions**, see https://github.com/nim-lang/Nim/pull/11824 instead), for example `alias: myecho=echo`.
This has been an often requested feature, found in other languages eg D's `alias` (or to some extend C's `define`)

see extensive unittests in tests/magics/talias.nim

* the alias only works by design with expressions that resolve to symbols, and gives sane CT error if it can't
* the alias works fine with overloaded symbols
* it works with any symbol: module, template, macro, type, const, var, proc, iterator etc (EDIT: eg `alias:r=result` works just fine)
* the usage of the alias is identical to the usage of the symbol being aliased

## fixes
* using `alias` avoids the issues mentioned in #8935: `alias:testForMe=assert` works, `alias:myPuts=system.echo` works, generic/template/macro aliases work etc
* fixes #11731: `alias:my_echo=system.echo` works
* fixes #7090 ; this was wrongly closed: the workarounds didn't work in many cases, see test suite; eg
  - templates / macros/ iterators with all optional params didn't work
  - a macro with varargs; eg:  `template myalias(args: varargs[untyped]): untyped = echo(args)` didn't work with `myalias()`
  - module didn't work (requires a different syntax, `import foo as bar`)
  - would require different syntaxes for different symbols (eg proc vs let, or depending on whether template/macro being aliased has some argument or not)

## this feature request keeps popping up
* https://forum.nim-lang.org/t/5015 Alias for proc names -- any progress?
```nim
proc getLength(i: int): int = sizeof(i)
proc getLength(s: string): int = s.len
# const length = getLength # Error: cannot generate VM code for getLength
alias:length = getLength # works
echo length("alias")
```

* https://forum.nim-lang.org/t/1515 Best way for function aliases
* https://github.com/btbytes/nim-cookbook/issues/21 Syntax for aliasing
> This is my biggest annoyance with nim right now

* https://www.reddit.com/r/nim/comments/5v2rgw/alias_echo_to_print/ 
* https://forum.nim-lang.org/t/1810 Macro Aliases

## examples  (see more in tests/magics/talias.nim)
```nim
alias:echoa=echo
echoa (1,2)

template fun(a = 10, b = 11): untyped = (a,b)
alias:funa=fun
doAssert funa() == (10, 11)
doAssert funa == (10, 11)
doAssert funa(3) == (3, 11)

alias:toStr=`$` # works fine with overloads
doAssert toStr(true) == "true"

alias:system2=system # works fine with module aliasing
alias:toStr2=system2.`$` # that works too
doAssert toStr2(true) == "true"
```

## could it have been done without patching the compiler ?
no.
There are many issues making that impossible without this PR, if you're not convinced, try out the test suite I have (for example, aliasing a template/macro with all optional params, iterator, module etc). Using things like `template myalias(args: varargs[untyped]): untyped = myexpr(args)` or more elaborate variants just doesn't work in many situations; eg: `template myalias(args: varargs[untyped]): untyped = echo(args); myalias() # fails`; 

Furthermore, the patch is small and straightforward (essentially just introduces a new magic), and results in essentially no compile time overhead; it really boils down to adding `addInterfaceDecl(c, alias)`, see `semAlias`

## note
see also https://github.com/nim-lang/Nim/pull/11824 which defines ref for lvalues instead of alias for symbols. Lvalues and symbols should not be conflated as it would lead to ambiguities, hence the 2 different syntax:
```nim
alias: sym2=sym # a symbol (this PR)
byRef: myref=sym[2].bar.baz # an lvalue (pure library solution, see https://github.com/nim-lang/Nim/pull/11824)
```

## use cases
the main use case for `alias` is as described in https://dlang.org/spec/declaration.html: a way to redirect references from one symbol to another

* conditionally override a symbol, eg:
```nim
when defined(overrideEcho):
  alias: myecho = myechoImpl # also logs, adds file/line numbers etc
else:
  alias: myecho = echo # myecho un-distinguishable from echo
```
(note that `template myecho(args: varargs[untyped]) = echo(args)` won't work, as noted above)

* conditionally enable a symbol, eg: `assert / doAssert` could've been implemented in a simpler way:
```nim
template doAssert*(cond: untyped, msg = "") = ...
when compileOption("assertions"):
  alias: assert*=doAssert
else:
  template assert*(cond: untyped, msg = "") = discard
```

this would've avoided the complications due to `instantiationInfo` being affected by intermediate template definition, which `alias` avoids.

Another similar scenario is conditional definition, eg `os.quoteShell` which could've been implemented with `alias` and avoid intermediate proc + non DRY code

* avoid a symbol clash:
```nim
  import logging
  alias: debug2 = debug # suppose `debug` clashes
  var logger = newConsoleLogger()
  addHandler(logger)
  debug2 (12, 13)
  debug2()
```
note that `template debug2(args: varargs[untyped]): untyped = debug(args)` would not work, giving CT error. 
Also note that when implementing an alias via an intermediate template in cases where it does work, it doesn't quite fit as a 1-1 replacement, eg reflection using `macros.owner, macros.getImpl` will produce different results, unlike with `alias` (see also note regarding `instantiationInfo`)

other use cases:
* `alias` also allows to avoid symbol clashes while keeping method call syntax, eg when doing
```nim
from foo import nil # to avoid putting too many clashing symbols in scope
alias: bar2 = foo.bar # bar2 still usable with method call syntax
```
* turn a regular proc into an operator / special name so that a generic code works, eg:
```nim
# mylib.nim
proc toStr*(a: Foo): string = ...
# main.nim
import mylib
alias: `$` = toStr
echo Bar # somewhere inside Bar, `toStr(Foo)` will be used automatically thanks to `$`
```
ditto with turning regular third party procs into operators, eg matrix operations: 
```nim
proc matMul(a, b: Mat): Mat = ...
alias: `*` = matMult
echo mat1 * mat2 * mat3
```

## how frequent are aliases?
pretty frequent, search in nim code base for `alias`. 
eg:
```nim
proc contains*[T](c: CritBitTree[T], key: string): bool {.inline.} =
  ## returns true iff `c` contains the given `key`.
  result = rawGet(c, key) != nil

proc hasKey*[T](c: CritBitTree[T], key: string): bool {.inline.} =
  ## alias for `contains`.
  result = rawGet(c, key) != nil
```
this could be rewritten as:
```nim
# more declarative, more obvious it's just an alias
alias: hasKey*=contains # critbits.nim 
alias: fmt *= `&` # strformat.nim
alias: `$` *= renderSQL # parsesql.nim
```

there are many examples of that in nim code, and even more in third party libs.

## alias in other languages
(not restricted to types)
* dlang: `alias fooa = bar.foo`
* rust: `use bar::foo as fooa;`
* C: `#define fooa foo`
* C++: via `perfect forwarding`, see https://stackoverflow.com/questions/9864125/c11-how-to-alias-a-function
* swift: `let fooa = foo`
* most dynamic languages (eg python, ruby, javascript etc)
