### PR TITLE
Fixes subtle SSL recvInto bug.

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -257,6 +257,7 @@ when defineSsl:
         if not fut.read():
           # Socket disconnected.
           if SocketFlag.SafeDisconn in flags:
+            opResult = 0.cint
             break
           else:
             raiseSSLError("Socket has been disconnected")


### PR DESCRIPTION
This resulted in a "value out of range: -1" exception inside `recvInto`
(on the `copyMem` line). Basically readIntoBuf was returning `-1`.