### PR TITLE
Allow IO override (for standalone) and remove use of stderr when there is a panicoverride

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4534,9 +4534,9 @@ when defined(genode):
 import system/widestrs
 export widestrs
 
-when defined(ioverride):
-  include "$projectpath/iooverride"
-  export ioverride as io
+when defined(iooverride):
+  include "$projectpath/iooverride" as io
+  export io
 else:
   import system/io
   export io

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2356,7 +2356,7 @@ when not defined(nimscript) and not defined(JS):
 
 when not defined(nimscript):
   when hasAlloc:
-    proc alloc*(size: Natural): pointer {.noconv, rtl, tags: [], benign, raises: [].}
+    proc alloc*(size: Natural): pointer {.noconv, rtl, benign, raises: [].}
       ## Allocates a new memory block with at least ``size`` bytes.
       ##
       ## The block has to be freed with `realloc(block, 0) <#realloc,pointer,Natural>`_
@@ -2384,7 +2384,7 @@ when not defined(nimscript):
       ## * `create <#create,typedesc>`_
       cast[ptr T](alloc(T.sizeof * size))
 
-    proc alloc0*(size: Natural): pointer {.noconv, rtl, tags: [], benign, raises: [].}
+    proc alloc0*(size: Natural): pointer {.noconv, rtl, benign, raises: [].}
       ## Allocates a new memory block with at least ``size`` bytes.
       ##
       ## The block has to be freed with `realloc(block, 0) <#realloc,pointer,Natural>`_
@@ -2406,7 +2406,7 @@ when not defined(nimscript):
       ## Use `createShared <#createShared,typedesc>`_ to allocate from a shared heap.
       cast[ptr T](alloc0(sizeof(T) * size))
 
-    proc realloc*(p: pointer, newSize: Natural): pointer {.noconv, rtl, tags: [],
+    proc realloc*(p: pointer, newSize: Natural): pointer {.noconv, rtl,
                                                            benign, raises: [].}
       ## Grows or shrinks a given memory block.
       ##
@@ -2432,7 +2432,7 @@ when not defined(nimscript):
       ## from a shared heap.
       cast[ptr T](realloc(p, T.sizeof * newSize))
 
-    proc dealloc*(p: pointer) {.noconv, rtl, tags: [], benign, raises: [].}
+    proc dealloc*(p: pointer) {.noconv, rtl, benign, raises: [].}
       ## Frees the memory allocated with ``alloc``, ``alloc0`` or
       ## ``realloc``.
       ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4535,11 +4535,10 @@ import system/widestrs
 export widestrs
 
 when defined(iooverride):
-  include "$projectpath/iooverride" as io
-  export io
+  import "$projectpath/iooverride" as io
 else:
   import system/io
-  export io
+export io
 
 when not defined(createNimHcr):
   include nimhcr

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4534,8 +4534,12 @@ when defined(genode):
 import system/widestrs
 export widestrs
 
-import system/io
-export io
+when defined(ioverride):
+  include "$projectpath/iooverride"
+  export ioverride as io
+else:
+  import system/io
+  export io
 
 when not defined(createNimHcr):
   include nimhcr

--- a/lib/system/fatal.nim
+++ b/lib/system/fatal.nim
@@ -1,5 +1,5 @@
 {.push profiler: off.}
-when hostOS == "standalone":
+when hostOS == "standalone" or defined(panicoverride):
   include "$projectpath/panicoverride"
 
   proc sysFatal(exceptn: typedesc, message: string) {.inline.} =

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -14,7 +14,7 @@
 {.push checks:off.}
 
 when hostOS == "standalone" or defined(panicoverride):
-  include "$projectpath/panicoverride"
+  import "$projectpath/panicoverride"
 
 const
   debugGC = false # we wish to debug the GC...

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -13,6 +13,9 @@
 #{.push checks:on, assertions:on.}
 {.push checks:off.}
 
+when hostOS == "standalone" or defined(panicoverride):
+  include "$projectpath/panicoverride"
+
 const
   debugGC = false # we wish to debug the GC...
   logGC = false
@@ -62,8 +65,11 @@ const
 
 proc raiseOutOfMem() {.noinline.} =
   if outOfMemHook != nil: outOfMemHook()
-  cstderr.rawWrite("out of memory")
-  quit(1)
+  when hostOS == "standalone" or defined(panicoverride):
+    panic("out of memory")
+  else:
+    cstderr.rawWrite("out of memory")
+    quit(1)
 
 when defined(boehmgc):
   proc boehmGCinit {.importc: "GC_init", boehmGC.}


### PR DESCRIPTION
[As I said in the forum](https://forum.nim-lang.org/t/5041), the possibility of overriding the IO of the standard library is very useful when compile to standalone. Also, I think using of **stderr** in the Nim high-level memory manager for _out of memory_ error should be only on not standalone platforms. Instead, I use the proc _panic_ from panicoverride on standalone platforms.

By the way, I was also trying to use compile time define pragmas for specify the include path of the overrides, but I don't know how to do it.