### PR TITLE
VM exception fixes [bugfix]

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -79,6 +79,9 @@ proc getCurrentExceptionMsgWrapper(a: VmArgs) {.nimcall.} =
   setResult(a, if a.currentException.isNil: ""
                else: a.currentException.sons[3].skipColon.strVal)
 
+proc getCurrentExceptionWrapper(a: VmArgs) {.nimcall.} =
+  setResult(a, a.currentException)
+
 proc staticWalkDirImpl(path: string, relative: bool): PNode =
   result = newNode(nkBracket)
   for k, f in walkDir(path, relative):
@@ -132,6 +135,7 @@ proc registerAdditionalOps*(c: PCtx) =
     wrap1s(readFile, ioop)
     wrap2si(readLines, ioop)
     systemop getCurrentExceptionMsg
+    systemop getCurrentException
     registerCallback c, "stdlib.*.staticWalkDir", proc (a: VmArgs) {.nimcall.} =
       setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
     systemop gorgeEx

--- a/tests/vm/texception.nim
+++ b/tests/vm/texception.nim
@@ -1,0 +1,14 @@
+proc someFunc() =
+  try:
+    raise newException(ValueError, "message")
+  except ValueError as err:
+    doAssert err.name == "ValueError"
+    doAssert err.msg == "message"
+    raise
+
+static:
+  try:
+    someFunc()
+  except:
+    discard
+  


### PR DESCRIPTION
This PR fixes a few issues with exceptions in the VM:

- `getCurrentException` was not available (fixes #9920, fixes #11802)
- empty `raise` statement did not work
- the name of the exception was not included in the stack trace, unlike stack traces from the runtime