### PR TITLE
Allow typeof(nil) as generic parameter

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -340,8 +340,6 @@ proc typeRel*(c: var TCandidate, f, aOrig: PType,
 
 proc concreteType(c: TCandidate, t: PType; f: PType = nil): PType =
   case t.kind
-  of tyNil:
-    result = nil              # what should it be?
   of tyTypeDesc:
     if c.isNoCall: result = t
     else: result = nil

--- a/tests/ccgbugs/tnil_type.nim
+++ b/tests/ccgbugs/tnil_type.nim
@@ -2,5 +2,14 @@ discard """
   targets: "c cpp"
 """
 
-proc foo(v: type(nil)) = discard
-foo nil
+proc f1(v: typeof(nil)) = discard
+f1(nil)
+
+proc f2[T]() = discard
+f2[typeof(nil)]()
+
+proc f3(_: typedesc) = discard
+f3(typeof(nil))
+
+proc f4[T](_: T) = discard
+f4(nil)


### PR DESCRIPTION
`type(nil)` is already allowed for concrete parameters, this PR enables `type(nil)` for generic parameters as well.