### PR TITLE
Remove float overloads for io.write

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -309,10 +309,6 @@ proc write*(f: File, i: BiggestInt) {.tags: [WriteIOEffect], benign.} =
 proc write*(f: File, b: bool) {.tags: [WriteIOEffect], benign.} =
   if b: write(f, "true")
   else: write(f, "false")
-proc write*(f: File, r: float32) {.tags: [WriteIOEffect], benign.} =
-  if c_fprintf(f, "%.16g", r) < 0: checkErr(f)
-proc write*(f: File, r: BiggestFloat) {.tags: [WriteIOEffect], benign.} =
-  if c_fprintf(f, "%.16g", r) < 0: checkErr(f)
 
 proc write*(f: File, c: char) {.tags: [WriteIOEffect], benign.} =
   discard c_putc(cint(c), f)


### PR DESCRIPTION
It was reported on IRC/Gitter that `write(f, 1.0)` and `write(f, $1.0)` gives different result (the first one writes `1`, the second one `1.0`). This happens due to overloads of `io.write` with their own logic for the float->string conversion. So I removed the overloads, now floats use the ``varargs[string, `$`]`` overload which gives the expected result.