### PR TITLE
Fixes handling of nkBracketExpr nodes in opcGetImpl.

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1472,7 +1472,8 @@ proc customPragmaNode(n: NimNode): NimNode =
   if n.kind in {nnkDotExpr, nnkCheckedFieldExpr}:
     let name = $(if n.kind == nnkCheckedFieldExpr: n[0][1] else: n[1])
     let typInst = getTypeInst(if n.kind == nnkCheckedFieldExpr or n[0].kind == nnkHiddenDeref: n[0][0] else: n[0])
-    var typDef = getImpl(if typInst.kind == nnkVarTy: typInst[0] else: typInst)
+    # XXX: look into this further (see #11879)
+    var typDef = getImpl(if typInst.kind in {nnkVarTy, nnkBracketExpr}: typInst[0] else: typInst)
     while typDef != nil:
       typDef.expectKind(nnkTypeDef)
       let typ = typDef[2]


### PR DESCRIPTION
This fixes a problem that is similar to #8484. I attempted to
reproduce it via:

```nim
import macros

template custom {.pragma.}

type
  Vec[T] = object
    x, y: T
  Entry = object
    c: Vec[float]
    a {.custom.}: int
    b: float

proc foo(o: object) =
  for name, value in o.fieldPairs:
    when value.hasCustomPragma(custom):
      echo(name, " has {.custom.}")

var x: Entry
foo(x)
```

But was not able to do so, possibly just a case of my code having
nesting of templates/generics. But this simple patch fixes the
compilation of my code.