### PR TITLE
Add build support for Linux/ia64

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -6,7 +6,7 @@ Name: "Nim"
 Version: "$version"
 Platforms: """
   windows: i386;amd64
-  linux: i386;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
+  linux: i386;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
   macosx: i386;amd64;powerpc64
   solaris: i386;amd64;sparc;sparc64
   freebsd: i386;amd64

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -155,6 +155,8 @@ case $ucpu in
     mycpu="powerpc64" ;;
   *power*|*ppc* )
     mycpu="powerpc" ;;
+  *ia64*)
+    mycpu="ia64" ;;
   *m68k*)
     mycpu="m68k" ;;
   *mips* )


### PR DESCRIPTION
Nim currently fails to build on Debian/ia64. The two changes in this PR should fix that.