### PR TITLE
Lock semchecked ast for macros

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -48,17 +48,16 @@ const
       "Compiled at $4\n" &
       "Copyright (c) 2006-" & copyrightYear & " by Andreas Rumpf\n"
 
-proc genFeatureDesc(obsolete: bool): string {.compileTime.} =
+proc genFeatureDesc[T: enum](t: typedesc[T]): string {.compileTime.} =
   var x = ""
-  for f in low(Feature)..high(Feature):
-    if obsolete == (f in ObsoleteFeatures):
-      if x.len > 0: x.add "|"
-      x.add $f
+  for f in low(T)..high(T):
+    if x.len > 0: x.add "|"
+    x.add $f
   x
 
 const
   Usage = slurp"../doc/basicopt.txt".replace(" //", " ")
-  AdvancedUsage = slurp"../doc/advopt.txt".replace(" //", " ") % [genFeatureDesc(false), genFeatureDesc(true)]
+  AdvancedUsage = slurp"../doc/advopt.txt".replace(" //", " ") % [genFeatureDesc(Feature), genFeatureDesc(LegacyFeature)]
 
 proc getCommandLineDesc(conf: ConfigRef): string =
   result = (HelpMessage % [VersionAsString, platform.OS[conf.target.hostOS].name,
@@ -741,21 +740,12 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       conf.features.incl oldExperimentalFeatures
     else:
       try:
-        let feature = parseEnum[Feature](arg)
-        if feature in ObsoleteFeatures:
-          localError(conf, info, "use --enableObsolete:" & $feature)
-        else:
-          conf.features.incl feature
         conf.features.incl parseEnum[Feature](arg)
       except ValueError:
         localError(conf, info, "unknown experimental feature")
-  of "enableobsolete":
+  of "legacy":
     try:
-      let feature = parseEnum[Feature](arg)
-      if feature in ObsoleteFeatures:
-        conf.features.incl feature
-      else:
-        localError(conf, info, "use --experimental:" & $feature)
+      conf.legacyFeatures.incl parseEnum[LegacyFeature](arg)
     except ValueError:
       localError(conf, info, "unknown obsolete feature")
   of "nocppexceptions":

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -134,8 +134,12 @@ type
       ## This requires building nim with `-d:nimHasLibFFI`
       ## which itself requires `nimble install libffi`, see #10150
       ## Note: this feature can't be localized with {.push.}
-    allowSemcheckedAstModification,
 
+  LegacyFeature* = enum
+    allowSemcheckedAstModification,
+      ## Allows to modify a NimNode where the type has already been
+      ## flaged with nfSem. If you actually do this, it will cause
+      ## bugs.
 
   SymbolFilesOption* = enum
     disabledSf, writeOnlySf, readOnlySf, v2Sf
@@ -198,6 +202,7 @@ type
     cppDefines*: HashSet[string] # (*)
     headerFile*: string
     features*: set[Feature]
+    legacyFeatures*: set[LegacyFeature]
     arguments*: string ## the arguments to be passed to the program that
                        ## should be run
     ideCmd*: IdeCmd
@@ -260,9 +265,6 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
 
-
-const ObsoleteFeatures* = {allowSemcheckedAstModification} ## Features that are only to support legacy code.
-
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 
 template depConfigFields*(fn) {.dirty.} =
@@ -320,7 +322,7 @@ proc newConfigRef*(): ConfigRef =
     m: initMsgConfig(),
     evalExpr: "",
     cppDefines: initHashSet[string](),
-    headerFile: "", features: {}, foreignPackageNotes: {hintProcessing, warnUnknownMagic,
+    headerFile: "", features: {}, legacyFeatures: {}, foreignPackageNotes: {hintProcessing, warnUnknownMagic,
     hintQuitCalled, hintExecuting},
     notes: NotesVerbosity[1], mainPackageNotes: NotesVerbosity[1],
     configVars: newStringTable(modeStyleInsensitive),

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -134,6 +134,8 @@ type
       ## This requires building nim with `-d:nimHasLibFFI`
       ## which itself requires `nimble install libffi`, see #10150
       ## Note: this feature can't be localized with {.push.}
+    allowSemcheckedAstModification,
+
 
   SymbolFilesOption* = enum
     disabledSf, writeOnlySf, readOnlySf, v2Sf
@@ -257,6 +259,9 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+
+
+const ObsoleteFeatures* = {allowSemcheckedAstModification} ## Features that are only to support legacy code.
 
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1392,7 +1392,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       let idx = regs[rb].intVal.int
       var dest = regs[ra].node
-      if nfSem in dest.flags and allowSemcheckedAstModification notin c.config.features:
+      if nfSem in dest.flags and allowSemcheckedAstModification notin c.config.legacyFeatures:
         stackTrace(c, tos, pc, "typechecked nodes may not be modified")
       elif dest.kind in {nkEmpty..nkNilLit} or idx >=% dest.len:
         stackTrace(c, tos, pc, formatErrorIndexBound(idx, dest.len-1))
@@ -1401,7 +1401,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNAdd:
       decodeBC(rkNode)
       var u = regs[rb].node
-      if nfSem in u.flags and allowSemcheckedAstModification notin c.config.features:
+      if nfSem in u.flags and allowSemcheckedAstModification notin c.config.legacyFeatures:
         stackTrace(c, tos, pc, "typechecked nodes may not be modified")
       elif u.kind in {nkEmpty..nkNilLit}:
         stackTrace(c, tos, pc, "cannot add to node kind: " & $u.kind)
@@ -1412,7 +1412,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       let x = regs[rc].node
       var u = regs[rb].node
-      if nfSem in u.flags and allowSemcheckedAstModification notin c.config.features:
+      if nfSem in u.flags and allowSemcheckedAstModification notin c.config.legacyFeatures:
         stackTrace(c, tos, pc, "typechecked nodes may not be modified")
       elif u.kind in {nkEmpty..nkNilLit}:
         stackTrace(c, tos, pc, "cannot add to node kind: " & $u.kind)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1392,27 +1392,32 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       let idx = regs[rb].intVal.int
       var dest = regs[ra].node
-      if dest.kind notin {nkEmpty..nkNilLit} and idx <% dest.len:
-        dest.sons[idx] = regs[rc].node
-      else:
+      if nfSem in dest.flags:
+        stackTrace(c, tos, pc, "typechecked nodes may not be modified")
+      elif dest.kind in {nkEmpty..nkNilLit} or idx >=% dest.len:
         stackTrace(c, tos, pc, formatErrorIndexBound(idx, dest.len-1))
+      else:
+        dest.sons[idx] = regs[rc].node
     of opcNAdd:
       decodeBC(rkNode)
       var u = regs[rb].node
-      if u.kind notin {nkEmpty..nkNilLit}:
-        u.add(regs[rc].node)
-      else:
+      if nfSem in u.flags:
+        stackTrace(c, tos, pc, "typechecked nodes may not be modified")
+      elif u.kind in {nkEmpty..nkNilLit}:
         stackTrace(c, tos, pc, "cannot add to node kind: " & $u.kind)
+      else:
+        u.add(regs[rc].node)
       regs[ra].node = u
     of opcNAddMultiple:
       decodeBC(rkNode)
       let x = regs[rc].node
       var u = regs[rb].node
-      if u.kind notin {nkEmpty..nkNilLit}:
-        # XXX can be optimized:
-        for i in 0..<x.len: u.add(x.sons[i])
-      else:
+      if nfSem in u.flags:
+        stackTrace(c, tos, pc, "typechecked nodes may not be modified")
+      elif u.kind in {nkEmpty..nkNilLit}:
         stackTrace(c, tos, pc, "cannot add to node kind: " & $u.kind)
+      else:
+        for i in 0 ..< x.len: u.add(x.sons[i])
       regs[ra].node = u
     of opcNKind:
       decodeB(rkInt)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1392,7 +1392,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       let idx = regs[rb].intVal.int
       var dest = regs[ra].node
-      if nfSem in dest.flags:
+      if nfSem in dest.flags and allowSemcheckedAstModification notin c.config.features:
         stackTrace(c, tos, pc, "typechecked nodes may not be modified")
       elif dest.kind in {nkEmpty..nkNilLit} or idx >=% dest.len:
         stackTrace(c, tos, pc, formatErrorIndexBound(idx, dest.len-1))
@@ -1401,7 +1401,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNAdd:
       decodeBC(rkNode)
       var u = regs[rb].node
-      if nfSem in u.flags:
+      if nfSem in u.flags and allowSemcheckedAstModification notin c.config.features:
         stackTrace(c, tos, pc, "typechecked nodes may not be modified")
       elif u.kind in {nkEmpty..nkNilLit}:
         stackTrace(c, tos, pc, "cannot add to node kind: " & $u.kind)
@@ -1412,7 +1412,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       decodeBC(rkNode)
       let x = regs[rc].node
       var u = regs[rb].node
-      if nfSem in u.flags:
+      if nfSem in u.flags and allowSemcheckedAstModification notin c.config.features:
         stackTrace(c, tos, pc, "typechecked nodes may not be modified")
       elif u.kind in {nkEmpty..nkNilLit}:
         stackTrace(c, tos, pc, "cannot add to node kind: " & $u.kind)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -120,7 +120,7 @@ Advanced options:
   --errorMax:N              stop compilation after N errors; 0 means unlimited
   --experimental:$1
                             enable experimental language feature
-  --enableObsolete:$2
+  --legacy:$2
                             enable obsolete/legacy language feature
                             legacy code.
   --newruntime              use an alternative runtime that uses destructors

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -120,6 +120,9 @@ Advanced options:
   --errorMax:N              stop compilation after N errors; 0 means unlimited
   --experimental:$1
                             enable experimental language feature
+  --enableObsolete:$2
+                            enable obsolete/legacy language feature
+                            legacy code.
   --newruntime              use an alternative runtime that uses destructors
                             and that uses a shared heap via -d:useMalloc
   --profiler:on|off         enable profiling; requires `import nimprof`, and

--- a/tests/macros/tlocktypednode1.nim
+++ b/tests/macros/tlocktypednode1.nim
@@ -1,0 +1,12 @@
+discard """
+errormsg: "typechecked nodes may not be modified"
+"""
+
+import macros
+
+macro doSomething(arg: typed): untyped =
+  echo arg.treeREpr
+  result = arg
+  result.add newCall(bindSym"echo", newLit(1))
+
+doSomething((echo(1); echo(2)))

--- a/tests/macros/tlocktypednode2.nim
+++ b/tests/macros/tlocktypednode2.nim
@@ -1,0 +1,12 @@
+discard """
+errormsg: "typechecked nodes may not be modified"
+"""
+
+import macros
+
+macro doSomething(arg: typed): untyped =
+  echo arg.treeREpr
+  result = arg
+  result[0] = newCall(bindSym"echo", newLit(1))
+
+doSomething((echo(1); echo(2)))

--- a/tests/macros/tlocktypednode3.nim
+++ b/tests/macros/tlocktypednode3.nim
@@ -1,0 +1,15 @@
+discard """
+errormsg: "typechecked nodes may not be modified"
+"""
+
+import macros
+
+macro doSomething(arg: typed): untyped =
+  echo arg.treeREpr
+  result = arg
+  result.add(
+    newCall(bindSym"echo", newLit(3)),
+    newCall(bindSym"echo", newLit(1))
+  )
+
+doSomething((echo(1); echo(2)))

--- a/tests/macros/tmacro7.nim
+++ b/tests/macros/tmacro7.nim
@@ -1,18 +1,19 @@
 discard """
-  output: '''calling!stuff
+output: '''
+calling!stuff
 calling!stuff
 '''
-  joinable: false
+disabled: true
 """
 
+# this test modifies an already semchecked ast (bad things happen)
+# this test relies on the bug #4547
 # issue #7792
 
 import macros
 
-
 proc callProc(str: string) =
   echo "calling!" & str
-
 
 macro testMacro(code: typed): untyped =
   let stmtList = newNimNode(nnkStmtList)
@@ -27,11 +28,9 @@ macro testMacro(code: typed): untyped =
 
   result = newEmptyNode()
 
-
 proc main() {.testMacro.} =
   echo "test"
   echo "test2"
-
 
 when isMainModule:
   main()


### PR DESCRIPTION
This will emit a proper error message ``typechecked nodes may not be modified`` for code like https://github.com/nim-lang/Nim/issues/11877. Not sure if that can be called a fix though. This check should prevent a lot of crashes due to illegal AST going through the semchecker. It should also prevent a lot of head scratching for programming that actually do modify a typechecked AST and wonder about the weird results and behavior.

