### PR TITLE
Fix effect error in pure/logging.nim

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -320,7 +320,7 @@ proc substituteLog*(frmt: string, level: Level, args: varargs[string, `$`]): str
 
 method log*(logger: Logger, level: Level, args: varargs[string, `$`]) {.
             raises: [Exception], gcsafe,
-            tags: [TimeEffect, WriteIOEffect, ReadIOEffect, RootEffect], base.} =
+            tags: [RootEffect], base.} =
   ## Override this method in custom loggers. The default implementation does
   ## nothing.
   ##

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -320,7 +320,7 @@ proc substituteLog*(frmt: string, level: Level, args: varargs[string, `$`]): str
 
 method log*(logger: Logger, level: Level, args: varargs[string, `$`]) {.
             raises: [Exception], gcsafe,
-            tags: [TimeEffect, WriteIOEffect, ReadIOEffect], base.} =
+            tags: [TimeEffect, WriteIOEffect, ReadIOEffect, RootEffect], base.} =
   ## Override this method in custom loggers. The default implementation does
   ## nothing.
   ##


### PR DESCRIPTION
If you are using the `terminal` module with the `logging` module and call `resetAttributes()` within your log method override, this error will be prdocued:

`Error: can have an unlisted effect: RootEffect`

Here is an example to reproduce - 

```nim
import logging, terminal

type  
  CustomLogger = ref object of Logger

proc logPrefix*(level: Level): tuple[msg: string, color: ForegroundColor] =
    case level:
    of lvlDebug:
        return ("---", fgMagenta)
    of lvlInfo:
        return ("(i)", fgCyan)
    of lvlNotice:
        return ("   ", fgWhite)
    of lvlWarn:
        return ("(!)", fgYellow)
    of lvlError:
        return ("(!)", fgRed)
    of lvlFatal:
        return ("(x)", fgRed)
    else:
        return ("   ", fgWhite)

method log(logger: CustomLogger; level: Level; args: varargs[string, `$`]) =
  var f = stdout
  if level >= getLogFilter() and level >= logger.levelThreshold:
    if level >= lvlWarn: 
      f = stderr
    let ln = substituteLog(logger.fmtStr, level, args)
    let prefix = level.logPrefix()
    f.setForegroundColor(prefix.color)
    f.write(prefix.msg)
    f.write(ln)
    resetAttributes()
    f.write("\n")
    if level in {lvlError, lvlFatal}: flushFile(f)

proc newCustomLogger(levelThreshold = lvlAll; fmtStr = " "): CustomLogger =
    new result
    result.fmtStr = fmtStr
    result.levelThreshold = levelThreshold

let logger = newCustomLogger()

logger.log(lvlInfo, "Hello custom")
```

This PR adds `RootEffect` to the list of tags in the `tags` pragma for logging.log