### PR TITLE
fix #11903

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2102,9 +2102,9 @@ proc evalMacroCall*(module: PSym; g: ModuleGraph;
 
   setupGlobalCtx(module, g)
   var c = PCtx g.vm
+  let oldMode = c.mode
   c.mode = emStaticStmt
   c.comesFromHeuristic.line = 0'u16
-
   c.callsite = nOrig
   let start = genProc(c, sym)
 
@@ -2143,3 +2143,4 @@ proc evalMacroCall*(module: PSym; g: ModuleGraph;
   if cyclicTree(result): globalError(c.config, n.info, "macro produced a cyclic tree")
   dec(g.config.evalMacroCounter)
   c.callsite = nil
+  c.mode = oldMode

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2102,6 +2102,7 @@ proc evalMacroCall*(module: PSym; g: ModuleGraph;
 
   setupGlobalCtx(module, g)
   var c = PCtx g.vm
+  c.mode = emStaticStmt
   c.comesFromHeuristic.line = 0'u16
 
   c.callsite = nOrig

--- a/tests/tools/tnimscriptwithmacro.nims
+++ b/tests/tools/tnimscriptwithmacro.nims
@@ -1,0 +1,22 @@
+discard """
+cmd: "nim e $file"
+output: '''
+foobar
+nothing
+hallo
+"""
+
+# this test ensures that the mode is resetted correctly to repr
+
+import macros
+
+macro foobar(): void =
+  result = newCall(bindSym"echo", newLit("nothing"))
+
+echo "foobar"
+
+let x = 123
+
+foobar()
+
+exec "echo hallo"

--- a/tests/vm/tgloballetfrommacro.nim
+++ b/tests/vm/tgloballetfrommacro.nim
@@ -1,0 +1,13 @@
+discard """
+errormsg: "cannot evaluate at compile time: BUILTIN_NAMES"
+line: 11
+"""
+
+import sets
+
+let BUILTIN_NAMES = toSet(["int8", "int16", "int32", "int64"])
+
+macro test*(): bool =
+  echo "int64" notin BUILTIN_NAMES
+
+echo test()


### PR DESCRIPTION
By default the global context was in mode ``emRepl``. In repl accessing a global ``let`` variable is explicitly allowed. That is why the compiler didn't complain to read from the global let from the macro. This is a bug that I could fix by setting the mode to something else, like ``emStaticStmt``, which seems most reasonable to me.