### PR TITLE
delete expensive call

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2325,7 +2325,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
   m.call = newNodeI(n.kind, n.info)
   m.call.typ = base(m.callee) # may be nil
   var formalLen = m.callee.n.len
-  addSon(m.call, copyTree(n.sons[0]))
+  addSon(m.call, n.sons[0])
   var container: PNode = nil # constructed container
   formal = if formalLen > 1: m.callee.n.sons[1].sym else: nil
 


### PR DESCRIPTION
I did an analysis to find out where most of the copyTree calls come from. This location is by far the location with the most usage call. A small 10 line program had over 100000 copyTree invocations from this location alone. So I just removed it, let's see if it will fail some tests.

I also did a benchmark to compile the compiler with this change. The difference is, even though not as big as I would have hoped, measurable:

```
147922 lines compiled; 5.491 sec total; 514.445MiB peakmem;
147923 lines compiled; 5.298 sec total; 514.43MiB peakmem
```

0.2 seconds difference to compile the compiler. I would have expected to have a bigger impact on peakmem though.


Here are the other copy tree calls hidden (all locations above 1000, identity by stack frame):
```
----------------------------------------
count: 79251

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1349) builtinFieldAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1007) lookupInRecordAndBuildCheck
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1022) lookupInRecordAndBuildCheck

----------------------------------------
count: 32147

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/evaltempl.nim(81) evalTemplateAux
/home/arne/proj/nim/Nim/compiler/evaltempl.nim(81) evalTemplateAux
/home/arne/proj/nim/Nim/compiler/evaltempl.nim(34) evalTemplateAux

----------------------------------------
count: 27953

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2628) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2222) semMagic
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 23438

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semcall.nim(493) semResolvedCall
/home/arne/proj/nim/Nim/compiler/seminst.nim(365) generateInstance
/home/arne/proj/nim/Nim/compiler/seminst.nim(312) instantiateProcType

----------------------------------------
count: 23420

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semcall.nim(532) semOverloadedCall
/home/arne/proj/nim/Nim/compiler/semcall.nim(493) semResolvedCall
/home/arne/proj/nim/Nim/compiler/seminst.nim(334) generateInstance

----------------------------------------
count: 16015

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/evaltempl.nim(192) evalTemplate
/home/arne/proj/nim/Nim/compiler/evaltempl.nim(81) evalTemplateAux
/home/arne/proj/nim/Nim/compiler/evaltempl.nim(34) evalTemplateAux

----------------------------------------
count: 13481

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 11572

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2639) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 11152

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(49) semOperand
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2639) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 9844

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(64) semExprWithType
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 8393

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(49) semOperand
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 8198

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/sem.nim(466) semMacroExpr
/home/arne/proj/nim/Nim/compiler/vm.nim(2135) evalMacroCall
/home/arne/proj/nim/Nim/compiler/vm.nim(778) rawExecute

----------------------------------------
count: 7489

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2586) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1403) semFieldAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1396) dotTransformation

----------------------------------------
count: 6917

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semcall.nim(326) resolveOverloads
/home/arne/proj/nim/Nim/compiler/semcall.nim(93) pickBestCandidate
/home/arne/proj/nim/Nim/compiler/sigmatch.nim(2548) matches

----------------------------------------
count: 6318

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(64) semExprWithType
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2639) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 5696

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1349) builtinFieldAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1007) lookupInRecordAndBuildCheck
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1045) lookupInRecordAndBuildCheck

----------------------------------------
count: 5533

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2680) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2639) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 5387

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2719) semExpr
/home/arne/proj/nim/Nim/compiler/semstmts.nim(564) semVarOrLet

----------------------------------------
count: 5385

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2719) semExpr
/home/arne/proj/nim/Nim/compiler/semstmts.nim(548) semVarOrLet

----------------------------------------
count: 5109

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2721) semExpr
/home/arne/proj/nim/Nim/compiler/semstmts.nim(654) semConst

----------------------------------------
count: 5070

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2614) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 4980

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(881) semIndirectOp
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1403) semFieldAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1396) dotTransformation

----------------------------------------
count: 4603

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(64) semExprWithType
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2614) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 4469

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(49) semOperand
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2614) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 4457

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2715) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1637) semAsgn

----------------------------------------
count: 3671

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(888) semIndirectOp
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 3530

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2720) semExpr
/home/arne/proj/nim/Nim/compiler/semstmts.nim(564) semVarOrLet

----------------------------------------
count: 3529

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semstmts.nim(2125) semStmtList
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2720) semExpr
/home/arne/proj/nim/Nim/compiler/semstmts.nim(548) semVarOrLet

----------------------------------------
count: 2832

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(873) afterCallActions
/home/arne/proj/nim/Nim/compiler/semexprs.nim(726) evalAtCompileTime
/home/arne/proj/nim/Nim/compiler/semfold.nim(590) getConstExpr

----------------------------------------
count: 2793

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2589) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 2561

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2544) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1115) semSym
/home/arne/proj/nim/Nim/compiler/semexprs.nim(90) inlineConst

----------------------------------------
count: 2549

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/sem.nim(466) semMacroExpr
/home/arne/proj/nim/Nim/compiler/vm.nim(2135) evalMacroCall
/home/arne/proj/nim/Nim/compiler/vm.nim(772) rawExecute

----------------------------------------
count: 2472

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2548) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1115) semSym
/home/arne/proj/nim/Nim/compiler/semexprs.nim(90) inlineConst

----------------------------------------
count: 2465

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1349) builtinFieldAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1007) lookupInRecordAndBuildCheck
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1028) lookupInRecordAndBuildCheck

----------------------------------------
count: 2382

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semcall.nim(493) semResolvedCall
/home/arne/proj/nim/Nim/compiler/seminst.nim(365) generateInstance
/home/arne/proj/nim/Nim/compiler/seminst.nim(281) instantiateProcType

----------------------------------------
count: 2318

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1349) builtinFieldAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1007) lookupInRecordAndBuildCheck
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1032) lookupInRecordAndBuildCheck

----------------------------------------
count: 2061

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2589) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2614) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 2055

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(1523) semArrayAccess
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 1602

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(77) semExprNoDeref
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2627) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(963) semDirectOp

----------------------------------------
count: 1561

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(64) semExprWithType
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2619) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(264) semConv

----------------------------------------
count: 1409

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/transf.nim(123) transformSons
/home/arne/proj/nim/Nim/compiler/transf.nim(945) transform
/home/arne/proj/nim/Nim/compiler/transf.nim(634) transformFor

----------------------------------------
count: 1194

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2589) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2619) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(264) semConv

----------------------------------------
count: 1074

Traceback (most recent call last)
/home/arne/proj/nim/Nim/compiler/semexprs.nim(49) semOperand
/home/arne/proj/nim/Nim/compiler/semexprs.nim(2619) semExpr
/home/arne/proj/nim/Nim/compiler/semexprs.nim(264) semConv
```
``semDirectOp`` is what I fixed [here](https://github.com/nim-lang/Nim/pull/11864)