### PR TITLE
fix crash on sigmatch, improve error msg

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -196,6 +196,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
       case err.firstMismatch.kind
       of kUnknownNamedParam: candidates.add("\n  unknown named parameter: " & $nArg[0])
       of kAlreadyGiven: candidates.add("\n  named param already provided: " & $nArg[0])
+      of kPositionalAlreadyGiven: candidates.add("\n  positional param was already given as named param")
       of kExtraArg: candidates.add("\n  extra argument given")
       of kMissingParam: candidates.add("\n  missing parameter: " & nameParam)
       of kTypeMismatch, kVarNeeded:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -21,7 +21,7 @@ when (defined(booting) or defined(nimsuggest)) and not defined(leanCompiler):
 type
   MismatchKind* = enum
     kUnknown, kAlreadyGiven, kUnknownNamedParam, kTypeMismatch, kVarNeeded,
-    kMissingParam, kExtraArg
+    kMissingParam, kExtraArg, kPositionalAlreadyGiven
 
   MismatchInfo* = object
     kind*: MismatchKind # reason for mismatch
@@ -2432,8 +2432,8 @@ proc matchesAux(c: PContext, n, nOrig: PNode,
         formal = m.callee.n.sons[f].sym
         m.firstMismatch.kind = kTypeMismatch
         if containsOrIncl(marker, formal.position) and container.isNil:
-          m.firstMismatch.kind = kAlreadyGiven
-          # already in namedParams: (see above remark)
+          m.firstMismatch.kind = kPositionalAlreadyGiven
+          # positional param already in namedParams: (see above remark)
           when false: localError(n.sons[a].info, errCannotBindXTwice, formal.name.s)
           noMatch()
           return


### PR DESCRIPTION
```nim
  template fun2(a2 = ""; a3: int = 10; a4 = "") = discard
  fun2(a3 = 30, "asdf")
```
before PR:
```
/Users/timothee/git_clone/nim/Nim_devel/lib/system/fatal.nim(48) sysFatal
Error: unhandled exception: sons is not accessible [FieldError]
```

after PR:
```nim
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0611.nim(40, 7) Error: type mismatch: got <a3: int literal(30), string>
but expected one of:
template fun2(a2 = ""; a3: int = 10; a4 = "")
  first type mismatch at position: 2
  positional param was already given as named param

expression: fun2(a3 = 30, "asdf")
    fun2(a3 = 30, "asdf")
        ^
```

