### PR TITLE
Fix splitfile

### DIFF
--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -237,6 +237,7 @@ block splitFile:
   doAssert splitFile("abc/.") == ("abc", ".", "")
   doAssert splitFile("..") == ("", "..", "")
   doAssert splitFile("a/..") == ("a", "..", "")
+  doAssert splitFile("/foo/abc....txt") == ("/foo", "abc...", ".txt")
 
 # execShellCmd is tested in tosproc
 


### PR DESCRIPTION
This PR improves the implementation of os.splitFile so it correctly splits when the input path has multiple dots before the extension, e.g. `splitFile("/foo/abc....txt") == ("/foo", "abc...", ".txt")`.