### PR TITLE
gc_regions: cleanup & fixes for deallocation

### DIFF
--- a/lib/system/gc_regions.nim
+++ b/lib/system/gc_regions.nim
@@ -102,13 +102,13 @@ var
   tlRegion {.threadVar.}: MemRegion
 #  tempStrRegion {.threadVar.}: MemRegion  # not yet used
 
-template withRegion*(r: MemRegion; body: untyped) =
+template withRegion*(r: var MemRegion; body: untyped) =
   let oldRegion = tlRegion
   tlRegion = r
   try:
     body
   finally:
-    #r = tlRegion
+    r = tlRegion
     tlRegion = oldRegion
 
 template inc(p: pointer, s: int) =

--- a/lib/system/gc_regions.nim
+++ b/lib/system/gc_regions.nim
@@ -277,14 +277,13 @@ when false:
     setObstackPtr(obs)
 
 template withScratchRegion*(body: untyped) =
-  var scratch: MemRegion
   let oldRegion = tlRegion
-  tlRegion = scratch
+  tlRegion = MemRegion()
   try:
     body
   finally:
+    deallocAll()
     tlRegion = oldRegion
-    deallocAll(scratch)
 
 when false:
   proc joinRegion*(dest: var MemRegion; src: MemRegion) =

--- a/tests/gc/tregionleak.nim
+++ b/tests/gc/tregionleak.nim
@@ -1,0 +1,23 @@
+discard """
+  cmd: '''nim c --gc:regions $file'''
+  output: '''
+finalized
+finalized
+'''
+"""
+
+proc finish(o: RootRef) =
+  echo "finalized"
+
+withScratchRegion:
+  var test: RootRef
+  new(test, finish)
+
+var
+  mr: MemRegion
+  test: RootRef
+
+withRegion(mr):
+  new(test, finish)
+
+deallocAll(mr)


### PR DESCRIPTION
This PR introduces these changes:
- `withRegion` now returns the modified `MemRegion`. The signature has also been changed to account for this.
- `withScratchRegion` now correctly deallocate the scratch region