### PR TITLE
Update documentation on `xmltree.items`/`mitems`

### DIFF
--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -392,7 +392,7 @@ proc clear*(n: var XmlNode) =
 
 
 iterator items*(n: XmlNode): XmlNode {.inline.} =
-  ## Iterates over any child of `n`.
+  ## Iterates over all immediate children of `n`.
   ##
   ## **Examples:**
   ##
@@ -417,7 +417,7 @@ iterator items*(n: XmlNode): XmlNode {.inline.} =
   for i in 0 .. n.len-1: yield n[i]
 
 iterator mitems*(n: var XmlNode): var XmlNode {.inline.} =
-  ## Iterates over any child of `n` so that it can be modified.
+  ## Iterates over all immediate children of `n` so that they can be modified.
   assert n.k == xnElement
   for i in 0 .. n.len-1: yield n[i]
 

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -392,7 +392,7 @@ proc clear*(n: var XmlNode) =
 
 
 iterator items*(n: XmlNode): XmlNode {.inline.} =
-  ## Iterates over all immediate children of `n`.
+  ## Iterates over all direct children of `n`.
   ##
   ## **Examples:**
   ##
@@ -417,7 +417,7 @@ iterator items*(n: XmlNode): XmlNode {.inline.} =
   for i in 0 .. n.len-1: yield n[i]
 
 iterator mitems*(n: var XmlNode): var XmlNode {.inline.} =
-  ## Iterates over all immediate children of `n` so that they can be modified.
+  ## Iterates over all direct children of `n` so that they can be modified.
   assert n.k == xnElement
   for i in 0 .. n.len-1: yield n[i]
 


### PR DESCRIPTION
So far the documentation on `items` and `mitems` wasn't explicit about whether the iteration recurses down the node's children or not. I had assumed recursion, which turned out to be wrong.