### PR TITLE
newruntime for vcc fixes

### DIFF
--- a/lib/core/allocators.nim
+++ b/lib/core/allocators.nim
@@ -13,10 +13,10 @@ type
     ZerosMem    ## the allocator always zeros the memory on an allocation
   Allocator* = ptr AllocatorObj
   AllocatorObj* {.inheritable, compilerproc.} = object
-    alloc*: proc (a: Allocator; size: int; alignment: int = 8): pointer {.nimcall, raises: [], tags: [].}
-    dealloc*: proc (a: Allocator; p: pointer; size: int) {.nimcall, raises: [], tags: [].}
-    realloc*: proc (a: Allocator; p: pointer; oldSize, newSize: int): pointer {.nimcall, raises: [], tags: [].}
-    deallocAll*: proc (a: Allocator) {.nimcall, raises: [], tags: [].}
+    alloc*: proc (a: Allocator; size: int; alignment: int = 8): pointer {.nimcall, raises: [], tags: [], gcsafe.}
+    dealloc*: proc (a: Allocator; p: pointer; size: int) {.nimcall, raises: [], tags: [], gcsafe.}
+    realloc*: proc (a: Allocator; p: pointer; oldSize, newSize: int): pointer {.nimcall, raises: [], tags: [], gcsafe.}
+    deallocAll*: proc (a: Allocator) {.nimcall, raises: [], tags: [], gcsafe.}
     flags*: set[AllocatorFlag]
     name*: cstring
     allocCount: int


### PR DESCRIPTION
Simple programs doesn't compile with newruntimea and vcc.
```nim
echo "hello"`
```
fails with ` Error: 'open' is not GC-safe` because widechars are used and they call allocator.alloc() which is not marked as gcsafe.

with `threads:on` fails because `atomicLoadN` is used in owned references implementation but is not available in `atomics.nim` for vcc.