### PR TITLE
Refactor sizealignoffset, new improvements

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -903,6 +903,7 @@ type
     size*: BiggestInt         # the size of the type in bytes
                               # -1 means that the size is unkwown
     align*: int16             # the type's alignment requirements
+    paddingAtEnd*: int16      #
     lockLevel*: TLockLevel    # lock level as required for deadlock checking
     loc*: TLoc
     typeInst*: PType          # for generic instantiations the tyGenericInst that led to this

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -718,3 +718,13 @@ proc `$`*(c: IdeCmd): string =
   of ideOutline: "outline"
   of ideKnown: "known"
   of ideMsg: "msg"
+
+proc floatInt64Align*(conf: ConfigRef): int =
+  ## Returns either 4 or 8 depending on reasons.
+  if conf.target.targetCPU == cpuI386:
+    #on Linux/BSD i386, double are aligned to 4bytes (except with -malign-double)
+    if conf.target.targetOS != osWindows:
+      # on i386 for all known POSIX systems, 64bits ints are aligned
+      # to 4bytes (except with -malign-double)
+      return 4
+  return 8

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1813,13 +1813,8 @@ proc setMagicType(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
 
   # FIXME: proper support for clongdouble should be added.
   # long double size can be 8, 10, 12, 16 bytes depending on platform & compiler
-  if conf.target.targetCPU == cpuI386 and size == 8:
-    #on Linux/BSD i386, double are aligned to 4bytes (except with -malign-double)
-    if conf.target.targetOS != osWindows:
-      if kind in {tyFloat64, tyFloat, tyInt, tyUInt, tyInt64, tyUInt64}:
-        # on i386 for all known POSIX systems, 64bits ints are aligned
-        # to 4bytes (except with -malign-double)
-        m.typ.align = 4
+  if kind in {tyFloat64, tyFloat, tyInt, tyUInt, tyInt64, tyUInt64} and size == 8:
+    m.typ.align = int16(conf.floatInt64Align)
 
 proc setMagicIntegral(conf: ConfigRef; m: PSym, kind: TTypeKind, size: int) =
   setMagicType(conf, m, kind, size)

--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -409,10 +409,9 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
       typ.align = typ.lastSon.align
       typ.paddingAtEnd = typ.lastSon.paddingAtEnd
     else:
-      # XXX should be szUnknownsize
-      typ.size = szUncomputedSize
-      typ.align = szUncomputedSize
-      typ.paddingAtEnd = szUncomputedSize
+      typ.size = szUnknownSize
+      typ.align = szUnknownSize
+      typ.paddingAtEnd = szUnknownSize
 
   of tyTypeDesc:
     computeSizeAlign(conf, typ.base)
@@ -433,15 +432,13 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
       typ.align = typ.lastSon.align
       typ.paddingAtEnd = typ.lastSon.paddingAtEnd
     else:
-      # XXX should be szUnknownsize
-      typ.size = szUncomputedSize
-      typ.align = szUncomputedSize
-      typ.paddingAtEnd = szUncomputedSize
+      typ.size = szUnknownSize
+      typ.align = szUnknownSize
+      typ.paddingAtEnd = szUnknownSize
   else:
-    # XXX should be szUnknownsizea
-    typ.size = szUncomputedSize
-    typ.align = szUncomputedSize
-    typ.paddingAtEnd = szUncomputedSize
+    typ.size = szUnknownSize
+    typ.align = szUnknownSize
+    typ.paddingAtEnd = szUnknownSize
 
 template foldSizeOf*(conf: ConfigRef; n: PNode; fallback: PNode): PNode =
   let config = conf

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -620,9 +620,6 @@ doAssert offsetof(MyPackedCaseObject, val4) == 9
 doAssert offsetof(MyPackedCaseObject, val5) == 13
 
 reject:
-  const off4 = offsetof(MyPackedCaseObject, val1)
-
-reject:
   const off5 = offsetof(MyPackedCaseObject, val2)
 
 reject:

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -8,6 +8,11 @@ macros api OK
 '''
 """
 
+# This is for travis. The keyword ``alignof`` only exists in ``c++11``
+# and newer. On travis gcc does not default to c++11 yet.
+when defined(cpp) and not defined(windows):
+  {.passC: "-std=c++11".}
+
 # Object offsets are different for inheritance objects when compiling
 # to c++.
 

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -1,4 +1,5 @@
 discard """
+  targets: "c cpp"
   output: '''
 body executed
 body executed
@@ -6,6 +7,9 @@ OK
 macros api OK
 '''
 """
+
+# Object offsets are different for inheritance objects when compiling
+# to c++.
 
 type
   TMyEnum = enum
@@ -348,14 +352,13 @@ testinstance:
 
     testSizeAlignOf(t,a,b,c,d,e,f,g,ro,go, e1, e2, e4, e8, eoa, eob)
 
-    when not defined(cpp):
-      type
-        WithBitsize {.objectconfig.} = object
-          bitfieldA {.bitsize: 16.}: uint32
-          bitfieldB {.bitsize: 16.}: uint32
+    type
+      WithBitsize {.objectconfig.} = object
+        bitfieldA {.bitsize: 16.}: uint32
+        bitfieldB {.bitsize: 16.}: uint32
 
-      var wbs: WithBitsize
-      testSize(wbs)
+    var wbs: WithBitsize
+    testSize(wbs)
 
     testOffsetOf(TrivialType, x)
     testOffsetOf(TrivialType, y)
@@ -383,11 +386,10 @@ testinstance:
 
     testOffsetOf(Foobar, c)
 
-    when not defined(cpp):
-      testOffsetOf(Bazing, a)
-      testOffsetOf(InheritanceA, a)
-      testOffsetOf(InheritanceB, b)
-      testOffsetOf(InheritanceC, c)
+    testOffsetOf(Bazing, a)
+    testOffsetOf(InheritanceA, a)
+    testOffsetOf(InheritanceB, b)
+    testOffsetOf(InheritanceC, c)
 
     testOffsetOf(EnumObjectA, a)
     testOffsetOf(EnumObjectA, b)

--- a/tests/misc/tsizeof.nim
+++ b/tests/misc/tsizeof.nim
@@ -147,6 +147,14 @@ type
     ValueA
     ValueB
 
+  # Must have more than 32 elements so that set[MyEnum33] will become compile to an int64.
+  MyEnum33 {.pure.} = enum
+    Value1, Value2, Value3, Value4, Value5, Value6,
+    Value7, Value8, Value9, Value10, Value11, Value12,
+    Value13, Value14, Value15, Value16, Value17, Value18,
+    Value19, Value20, Value21, Value22, Value23, Value24,
+    Value25, Value26, Value27, Value28, Value29, Value30,
+    Value31, Value32, Value33
 
 proc transformObjectconfigPacked(arg: NimNode): NimNode =
   let debug = arg.kind == nnkPragmaExpr
@@ -300,6 +308,10 @@ testinstance:
         b: int8
       c: int8
 
+    PaddingOfSetEnum33 = object
+      cause: int8
+      theSet: set[MyEnum33]
+
     Bazing {.objectconfig.} = object of RootObj
       a: int64
       # TODO test on 32 bit system
@@ -332,6 +344,7 @@ testinstance:
     var g : RecursiveStuff
     var ro : RootObj
     var go : GenericObject[int64]
+    var po : PaddingOfSetEnum33
 
     var
       e1: Enum1
@@ -350,7 +363,8 @@ testinstance:
     else:
       doAssert sizeof(SimpleAlignment) > 10
 
-    testSizeAlignOf(t,a,b,c,d,e,f,g,ro,go, e1, e2, e4, e8, eoa, eob)
+    testSizeAlignOf(t,a,b,c,d,e,f,g,ro,go,po, e1, e2, e4, e8, eoa, eob)
+
 
     type
       WithBitsize {.objectconfig.} = object
@@ -385,6 +399,9 @@ testinstance:
     testOffsetOf(PaddingAfterBranch, cause)
 
     testOffsetOf(Foobar, c)
+
+    testOffsetOf(PaddingOfSetEnum33, cause)
+    testOffsetOf(PaddingOfSetEnum33, theSet)
 
     testOffsetOf(Bazing, a)
     testOffsetOf(InheritanceA, a)


### PR DESCRIPTION
* ``computePackedObjectOffsetsFoldFunction`` and ``computeObjectOffsetsFoldFunction`` has been merged into one function (code normalization).
* The folding object ``OffsetAccum`` is now used more extensively (Simpler to read, less error prone to write).
* tsizeof is now enabled for c++ testing
* offset values for objects with inheritance now also works when compiling to c++ at compile time.
* fixed a bug that would cause problems with big enum sets on 32 bit platforms