### PR TITLE
fix #11947 : generics can safely call macros

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -282,7 +282,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     # in threads.nim: the subtle preprocessing here binds 'globalsSlot' which
     # is not exported and yet the generic 'threadProcWrapper' works correctly.
     let flags = if mixinContext: flags+{withinMixin} else: flags
-    for i in first ..< sonsLen(result):
+    for i in first ..< safeLen(result):
       result.sons[i] = semGenericStmt(c, result.sons[i], flags, ctx)
   of nkCurlyExpr:
     result = newNodeI(nkCall, n.info)


### PR DESCRIPTION
fixes Example1 from https://github.com/nim-lang/Nim/issues/11947
the problem was that a macro can return an atom (eg via `newLit 134`), so `sonsLen` was incorrect.

the 2nd half of that issue is still there (so it was a separate problem)
