### PR TITLE
fix #10053: FieldError exception messages now show discriminant + type

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -825,7 +825,8 @@ proc genFieldCheck(p: BProc, e: PNode, obj: Rope, field: PSym) =
     v.r.add(".")
     v.r.add(disc.sym.loc.r)
     genInExprAux(p, it, u, v, test)
-    let strLit = genStringLiteral(p.module, newStrNode(nkStrLit, field.name.s))
+    let msg = genFieldError(field, disc.sym)
+    let strLit = genStringLiteral(p.module, newStrNode(nkStrLit, msg))
     if op.magic == mNot:
       linefmt(p, cpsStmts,
               "if ($1) #raiseFieldError($2);$n",

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1157,9 +1157,10 @@ proc genCheckedFieldOp(p: PProc, n: PNode, addrTyp: PType, r: var TCompRes) =
 
   useMagic(p, "raiseFieldError")
   useMagic(p, "makeNimstrLit")
+  let msg = genFieldError(field, disc)
   lineF(p, "if ($1[$2.$3]$4undefined) { raiseFieldError(makeNimstrLit($5)); }$n",
     setx.res, tmp, disc.loc.r, if negCheck: ~"!==" else: ~"===",
-    makeJSString(field.name.s))
+    makeJSString(msg))
 
   if addrTyp != nil and mapType(p, addrTyp) == etyBaseIndex:
     r.typ = etyBaseIndex

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1575,3 +1575,15 @@ proc getTokSym*(r: TSrcGen): PSym =
     result = r.tokens[r.idx-1].sym
   else:
     result = nil
+
+proc quoteExpr*(a: string): string {.inline.} =
+  ## can be used for quoting expressions in error msgs.
+  "'" & a & "'"
+
+proc genFieldError*(field: PSym, disc: PSym): string =
+  ## this needs to be in a module accessible by jsgen, ccgexprs, and vm to
+  ## provide this error msg FieldError; msgs would be better but it does not
+  ## import ast
+  result = field.name.s.quoteExpr & " is not accessible using discriminant " &
+    disc.name.s.quoteExpr & " of type " &
+    disc.owner.name.s.quoteExpr

--- a/lib/system/chcks.nim
+++ b/lib/system/chcks.nim
@@ -26,7 +26,7 @@ proc raiseIndexError() {.compilerproc, noinline.} =
   sysFatal(IndexError, "index out of bounds")
 
 proc raiseFieldError(f: string) {.compilerproc, noinline.} =
-  sysFatal(FieldError, f, " is not accessible")
+  sysFatal(FieldError, f)
 
 proc chckIndx(i, a, b: int): int =
   if i >= a and i <= b:

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -163,7 +163,7 @@ proc raiseIndexError(i, a, b: int) {.compilerproc, noreturn.} =
   raise newException(IndexError, formatErrorIndexBound(int(i), int(a), int(b)))
 
 proc raiseFieldError(f: string) {.compilerproc, noreturn.} =
-  raise newException(FieldError, f & " is not accessible")
+  raise newException(FieldError, f)
 
 proc setConstr() {.varargs, asmNoStackFrame, compilerproc.} =
   asm """


### PR DESCRIPTION
* fix #10053

```nim
type Kind = enum k1, k2

type Foo = object
  case kind: Kind
  of k1:
    f1: int
  of k2:
    f2: int

proc main()=
  var foo = Foo()
  echo foo.f2
main()
```

before PR:
Error: unhandled exception: f2 [FieldError]

in most cases (eg see error msg i got from https://github.com/nim-lang/Nim/issues/11947) this is not very helpful

after PR:
Error: unhandled exception: 'f2' is not accessible using discriminant 'kind' of type 'Foo' [FieldError]

works with `nim js` and `nim c`

## note
I have another PR to fix the VM case, but it depends on this PR so i'll wait until this is merged
