### PR TITLE
restrict usage of typedesc, improve error messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,9 +9,7 @@
 
 ### Breaking changes in the compiler
 
-- `typeDesc` handling is now stricter. This means procedures such as
-  `proc foo(T: typedesc): T` have to be written as
-  `proc foo[T](t: typedesc[T]): T`
+- `typeDesc` handling is now stricter.
 
 ## Library additions
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@
 
 ### Breaking changes in the compiler
 
+- `typeDesc` handling is now stricter. This means procedures such as
+  `proc foo(T: typedesc): T` have to be written as
+  `proc foo[T](t: typedesc[T]): T`
 
 ## Library additions
 

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1185,7 +1185,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     putWithSpace(g, tkColon, ":")
     gsub(g, n, 0)
   of nkTypeOfExpr:
-    put(g, tkType, "type")
+    put(g, tkType, "typeof")
     put(g, tkParLe, "(")
     if n.len > 0: gsub(g, n.sons[0])
     put(g, tkParRi, ")")

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -387,8 +387,9 @@ proc generateInstance(c: PContext, fn: PSym, pt: TIdTable,
     if c.inGenericContext == 0:
       instantiateBody(c, n, fn.typ.n, result, fn)
     sideEffectsCheck(c, result)
-    if result.magic != mSlice:
-      # 'toOpenArray' is special and it is allowed to return 'openArray':
+    if result.magic notin {mSlice, mTypeTrait}:
+      # 'toOpenArray' is special and it is allowed to return `openArray`.
+      # typetrait procs are special as they are allowed to return `typedesc`
       paramsTypeCheck(c, result.typ)
   else:
     result = oldPrc

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1222,10 +1222,10 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
     # turn explicit 'void' return type into 'nil' because the rest of the
     # compiler only checks for 'nil':
     if skipTypes(r, {tyGenericInst, tyAlias, tySink}).kind != tyVoid:
-      if kind notin {skMacro, skTemplate} and r.kind in {tyTyped, tyUntyped}:
+      if kind notin {skMacro, skTemplate} and r.kind in {tyTyped, tyUntyped, tyTypeDesc} and
+         (let owner = getCurrOwner(c).owner; owner.kind != skModule or owner.owner.name.s != "stdlib"):
         localError(c.config, n.sons[0].info, "return type '" & typeToString(r) &
-            "' is only valid for macros and templates")
-      # 'auto' as a return type does not imply a generic:
+          "' is only valid for macros and templates")
       elif r.kind == tyAnything:
         # 'p(): auto' and 'p(): expr' are equivalent, but the rest of the
         # compiler is hardly aware of 'auto':

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -493,8 +493,11 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
       add(result, typeToString(t.sons[i], preferTypeName))
     add(result, ']')
   of tyTypeDesc:
-    if t.sons[0].kind == tyNone: result = "typedesc"
-    else: result = "type " & typeToString(t.sons[0])
+    result = "typedesc"
+    if t.sons[0].kind != tyNone:
+      result.add '['
+      result.add typeToString(t.sons[0])
+      result.add ']'
   of tyStatic:
     if prefer == preferGenericArg and t.n != nil:
       result = t.n.renderTree
@@ -1255,8 +1258,12 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
       if result.isNil and t.sons[0] != nil:
         result = typeAllowedAux(marker, t.sons[0], skResult, flags)
   of tyTypeDesc:
-    # XXX: This is still a horrible idea...
-    result = nil
+    if kind != skParam:
+      if taConcept in flags:
+        # XXX: This is still a horrible idea...
+        result = nil
+      else:
+        result = typ
   of tyStatic:
     if kind notin {skParam}: result = t
   of tyUntyped, tyTyped:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -493,11 +493,9 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
       add(result, typeToString(t.sons[i], preferTypeName))
     add(result, ']')
   of tyTypeDesc:
-    result = "typedesc"
-    if t.sons[0].kind != tyNone:
-      result.add '['
-      result.add typeToString(t.sons[0])
-      result.add ']'
+    result = "typedesc["
+    result.add typeToString(t.sons[0])
+    result.add ']'
   of tyStatic:
     if prefer == preferGenericArg and t.n != nil:
       result = t.n.renderTree

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -357,7 +357,8 @@ proc high*[I, T](x: array[I, T]): I {.magic: "High", noSideEffect.}
   ##  for i in low(arr)..high(arr):
   ##    echo arr[i]
 
-proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
+proc high*[T: array](x: typedesc[T]): auto {.magic: "High", noSideEffect.}
+  #proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of an array type.
   ##
   ## See also:
@@ -882,7 +883,7 @@ proc sizeof*[T](x: T): int {.magic: "SizeOf", noSideEffect.}
 
 when defined(nimHasalignOf):
   proc alignof*[T](x: T): int {.magic: "AlignOf", noSideEffect.}
-  proc alignof*(x: typedesc): int {.magic: "AlignOf", noSideEffect.}
+  proc alignof*[T](x: typedesc[T]): int {.magic: "AlignOf", noSideEffect.}
 
   proc offsetOfDotExpr(typeAccess: typed): int {.magic: "OffsetOf", noSideEffect, compileTime.}
 
@@ -896,7 +897,7 @@ when defined(nimHasalignOf):
   #proc offsetOf*(memberaccess: typed): int {.magic: "OffsetOf", noSideEffect.}
 
 when defined(nimtypedescfixed):
-  proc sizeof*(x: typedesc): int {.magic: "SizeOf", noSideEffect.}
+  proc sizeof*[T](x: typedesc[T]): int {.magic: "SizeOf", noSideEffect.}
 
 proc `<`*[T](x: Ordinal[T]): T {.magic: "UnaryLt", noSideEffect, deprecated.}
   ## **Deprecated since version 0.18.0**. For the common excluding range
@@ -1712,16 +1713,16 @@ when defined(nimV2) and not defined(nimscript):
     ## Creates a new object of type ``T`` and returns a safe (traced)
     ## reference to it in ``a``.
 
-  proc new*(t: typedesc): auto =
+  proc new*[T](t: typedesc[T]): auto =
     ## Creates a new object of type ``T`` and returns a safe (traced)
     ## reference to it as result value.
     ##
     ## When ``T`` is a ref type then the resulting type will be ``T``,
     ## otherwise it will be ``ref T``.
-    when (t is ref):
-      var r: owned t
+    when (T is ref):
+      var r: owned T
     else:
-      var r: owned(ref t)
+      var r: owned(ref T)
     new(r)
     return r
 
@@ -1738,16 +1739,16 @@ else:
     ## Creates a new object of type ``T`` and returns a safe (traced)
     ## reference to it in ``a``.
 
-  proc new*(t: typedesc): auto =
+  proc new*[T](t: typedesc[T]): auto =
     ## Creates a new object of type ``T`` and returns a safe (traced)
     ## reference to it as result value.
     ##
     ## When ``T`` is a ref type then the resulting type will be ``T``,
     ## otherwise it will be ``ref T``.
-    when (t is ref):
-      var r: t
+    when (T is ref):
+      var r: T
     else:
-      var r: ref t
+      var r: ref T
     new(r)
     return r
 
@@ -1811,7 +1812,7 @@ proc `@`* [IDX, T](a: array[IDX, T]): seq[T] {.
   ##   echo @b # => @['f', 'o', 'o']
 
 when defined(nimHasDefault):
-  proc default*(T: typedesc): T {.magic: "Default", noSideEffect.}
+  proc default*[T](t: typedesc[T]): T {.magic: "Default", noSideEffect.}
     ## returns the default value of the type ``T``.
 
 proc setLen*[T](s: var seq[T], newlen: Natural) {.
@@ -2885,8 +2886,8 @@ proc max*[T](x, y: T): T {.inline.}=
   if y <= x: x else: y
 {.pop.}
 
-proc high*(T: typedesc[SomeFloat]): T = Inf
-proc low*(T: typedesc[SomeFloat]): T = NegInf
+proc high*[T: SomeFloat](t: typedesc[T]): T = Inf
+proc low*[T: SomeFloat](t: typedesc[T]): T = NegInf
 
 proc clamp*[T](x, a, b: T): T =
   ## Limits the value ``x`` within the interval [a, b].

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1812,7 +1812,7 @@ proc `@`* [IDX, T](a: array[IDX, T]): seq[T] {.
   ##   echo @b # => @['f', 'o', 'o']
 
 when defined(nimHasDefault):
-  proc default*[T](t: typedesc[T]): T {.magic: "Default", noSideEffect.}
+  proc default*(T: typedesc): T {.magic: "Default", noSideEffect.}
     ## returns the default value of the type ``T``.
 
 proc setLen*[T](s: var seq[T], newlen: Natural) {.

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -593,7 +593,7 @@ proc readFile*(filename: string): TaintedString {.tags: [ReadIOEffect], benign.}
   var f: File
   if open(f, filename):
     try:
-      result = readAll(f).TaintedString
+      result = readAll(f)
     finally:
       close(f)
   else:

--- a/tests/async/tgeneric_async.nim
+++ b/tests/async/tgeneric_async.nim
@@ -20,7 +20,7 @@ template msgId(M: type SomeMsg): int = 1
 proc recvMsg(): Future[tuple[msgId: int, msgData: string]] {.async.} =
   return (1, "message")
 
-proc read(data: string, T: type SomeMsg, maxBytes: int): T =
+proc read(data: string, t: typedesc[SomeMsg], maxBytes: int): SomeMsg =
   result.data = data[0 ..< min(data.len, maxBytes)]
 
 proc nextMsg*(MsgType: typedesc,
@@ -37,4 +37,3 @@ proc main {.async.} =
   echo msg.data
 
 asyncCheck main()
-

--- a/tests/bind/tinvalidbindtypedesc.nim
+++ b/tests/bind/tinvalidbindtypedesc.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <type float, string>"
+  errormsg: "type mismatch: got <typedesc[float], string>"
   line: 10
 """
 

--- a/tests/ccgbugs/tmissingbracket.nim
+++ b/tests/ccgbugs/tmissingbracket.nim
@@ -28,7 +28,7 @@ proc initialize*(self: TObj) =
   self.class = addr ClassOfTObj
   # this generates wrong C code: && instead of &
 
-proc newInstance(T: typedesc): T =
+proc newInstance[T](t: typedesc[T]): T =
   mixin initialize
   new(result)
   initialize(result)

--- a/tests/ccgbugs/twrongrefcounting.nim
+++ b/tests/ccgbugs/twrongrefcounting.nim
@@ -4,7 +4,7 @@ discard """
 """
 
 # bug #9825
-func empty(T: typedesc): T = discard
+func empty[T](t: typedesc[T]): T = discard
 const emptyChunk = @(empty(array[10, byte]))
 
 var lst: seq[seq[byte]]

--- a/tests/concepts/tvectorspace.nim
+++ b/tests/concepts/tvectorspace.nim
@@ -10,10 +10,9 @@ type VectorSpace[K] = concept x, y
   var k: K
   k * x is type(x)
 
-proc zero(T: typedesc): T = 0
+proc zero[T](t: typedesc[T]): T = 0
 
 static:
   assert float is VectorSpace[float]
   # assert float is VectorSpace[int]
   # assert int is VectorSpace
-

--- a/tests/errmsgs/tconceptconstraint.nim
+++ b/tests/errmsgs/tconceptconstraint.nim
@@ -2,7 +2,7 @@ discard """
   errormsg: "cannot instantiate B"
   line: 20
   nimout: '''
-got: <type string>
+got: <typedesc[string]>
 but expected: <T: A>
 '''
 """
@@ -18,4 +18,3 @@ proc advance(x: int): int = x + 1
 
 var a: B[int]
 var b: B[string]
-

--- a/tests/errmsgs/tgenericconstraint.nim
+++ b/tests/errmsgs/tgenericconstraint.nim
@@ -2,7 +2,7 @@ discard """
   errormsg: "cannot instantiate B"
   line: 14
   nimout: '''
-got: <type int>
+got: <typedesc[int]>
 but expected: <T: string or float>
 '''
 """
@@ -12,4 +12,3 @@ type
     child: ref B[T]
 
 var b: B[int]
-

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -1,17 +1,17 @@
 discard """
-errormsg: "type mismatch: got <array[0..0, type int]>"
+errormsg: "type mismatch: got <array[0..0, typedesc[int]]>"
 line: 22
 nimout: '''
-twrong_at_operator.nim(22, 30) Error: type mismatch: got <array[0..0, type int]>
+twrong_at_operator.nim(22, 30) Error: type mismatch: got <array[0..0, typedesc[int]]>
 but expected one of:
 proc `@`[T](a: openArray[T]): seq[T]
   first type mismatch at position: 1
   required type for a: openarray[T]
-  but expression '[int]' is of type: array[0..0, type int]
+  but expression '[int]' is of type: array[0..0, typedesc[int]]
 proc `@`[IDX, T](a: array[IDX, T]): seq[T]
   first type mismatch at position: 1
   required type for a: array[IDX, T]
-  but expression '[int]' is of type: array[0..0, type int]
+  but expression '[int]' is of type: array[0..0, typedesc[int]]
 
 expression: @[int]
 '''

--- a/tests/generics/tgenerics_issues.nim
+++ b/tests/generics/tgenerics_issues.nim
@@ -242,7 +242,7 @@ block t7794:
 
 
 block t8403:
-  proc sum[T](s: seq[T], R: typedesc): R =
+  proc sum[T,R](s: seq[T], t: typedesc[R]): R =
     var sum: R = 0
     for x in s:
       sum += R(x)

--- a/tests/generics/tlateboundgenericparams.nim
+++ b/tests/generics/tlateboundgenericparams.nim
@@ -16,7 +16,7 @@ proc defaultInt: int = 1
 proc defaultTInt(T: type): int = 2
 proc defaultTFoo[T](x: typedesc[T]): Foo = discard
 proc defaultTOldSchool[T](x: typedesc[T]): T = discard
-proc defaultTModern(T: type): T = discard
+proc defaultTModern[T](t: typedesc[T]): T = discard
 
 proc specializedDefault(T: type int): int = 10
 proc specializedDefault(T: type string): string = "default"
@@ -142,4 +142,3 @@ when true:
     foo(10)
     foo(1)
     foo(10)
-

--- a/tests/js/test2.nim
+++ b/tests/js/test2.nim
@@ -31,7 +31,7 @@ echo foo(3.14)
 # #2495
 type C = concept x
 
-proc test(x: C, T: typedesc): T =
+proc test[T](x: C, t: typedesc[T]): T =
   cast[T](x)
 
 echo 7.test(int8)

--- a/tests/metatype/ttypeselectors.nim
+++ b/tests/metatype/ttypeselectors.nim
@@ -103,7 +103,7 @@ echo sizeof(c)
 # Instead of type mismatch for macro, proc just failed with internal error: getTypeDescAux(tyNone)
 # https://github.com/nim-lang/Nim/issues/7231
 
-proc getBase2*(bits: static[int]): typedesc =
+proc getBase2*(bits: static[int]): NimNode =
   if bits == 128:
     result = newTree(nnkBracketExpr, ident("MpUintBase"), ident("uint64"))
   else:

--- a/tests/metatype/twildtypedesc.nim
+++ b/tests/metatype/twildtypedesc.nim
@@ -33,11 +33,10 @@ echo s as string
 
 # bug #4534
 
-proc unit(t: typedesc[int]): t = 0
-proc unit(t: typedesc[string]): t = ""
-proc unit(t: typedesc[float]): t = 0.0
+proc unit(t: typedesc[int]): int = 0
+proc unit(t: typedesc[string]): string = ""
+proc unit(t: typedesc[float]): float = 0.0
 
 assert unit(int) == 0
 assert unit(string) == ""
 assert unit(float) == 0.0
-

--- a/tests/proc/tillegalreturntype.nim
+++ b/tests/proc/tillegalreturntype.nim
@@ -1,8 +1,11 @@
 discard """
   cmd: "nim check $file"
   errmsg: ""
-  nimout: '''tillegalreturntype.nim(8, 11) Error: return type 'typed' is only valid for macros and templates
-tillegalreturntype.nim(11, 11) Error: return type 'untyped' is only valid for macros and templates'''
+  nimout: '''
+tillegalreturntype.nim(11, 11) Error: return type 'typed' is only valid for macros and templates
+tillegalreturntype.nim(14, 11) Error: return type 'untyped' is only valid for macros and templates
+tillegalreturntype.nim(17, 21) Error: return type 'typedesc' is only valid for macros and templates
+'''
 """
 
 proc x(): typed =
@@ -10,3 +13,8 @@ proc x(): typed =
 
 proc y(): untyped =
   discard
+
+proc foo(arg: int): typedesc =
+  return float
+
+foo(1)

--- a/tests/typerel/ttypedesc_as_genericparam1.nim
+++ b/tests/typerel/ttypedesc_as_genericparam1.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <type int>"
+  errormsg: "type mismatch: got <typedesc[int]>"
   line: 6
 """
 # bug #3079, #1146

--- a/tests/typerel/ttypenoval.nim
+++ b/tests/typerel/ttypenoval.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <type int> but expected 'int'"
+  errormsg: "type mismatch: got <typedesc[int]> but expected 'int'"
   file: "ttypenoval.nim"
   line: 38
 """

--- a/tests/types/testnewwarnings.nim
+++ b/tests/types/testnewwarnings.nim
@@ -1,0 +1,25 @@
+discard """
+nimout: '''
+testnewwarnings.nim(12, 14) Warning: implicit generics typedesc proc parameters are discouraged. Please use explicit generic parameters, for example:
+proc foo3*[T, T1, T2](a: T; arg: typedesc[T1]; b: int; c: int; arg2: typedesc[T2]): T1 [Deprecated]
+testnewwarnings.nim(15, 10) Warning: implicit generics typedesc proc parameters are discouraged. Please use explicit generic parameters, for example:
+proc foo2[T1: SomeFloat](T: typedesc[T1]): T1 [Deprecated]
+testnewwarnings.nim(18, 10) Warning: implicit generics typedesc proc parameters are discouraged. Please use explicit generic parameters, for example:
+proc foo1[T1: SomeFloat](t: typedesc[T1]): T [Deprecated]
+'''
+"""
+
+proc foo3*[T](a: T; arg: typedesc; b,c: int, arg2: typedesc): arg =
+  discard
+
+proc foo2(T: typedesc[SomeFloat]): T =
+  discard
+
+proc foo1(t: typedesc[SomeFloat]): int =
+  discard
+
+proc foo0[T](t: typedesc[T]): T =
+  discard
+
+proc baz(s: seq) =
+  discard


### PR DESCRIPTION
Restrict the usage of ``typedesc`` for parameters only. 

code like this won't compile anymore:
```nim
proc foo(arg: int): typedesc =
  return float
```

This PR will also introduce a warning that encourages to rewrite code like ``proc foo(T: typedesc): T`` as ``proc foo[T](t: typedesc[T]): T``. This way of passing type parameters to procedures has been proven to be the most reliable way to do it.
