### PR TITLE
`include` now gives a proper error message for all invalid infix operators

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2035,8 +2035,8 @@ proc evalInclude(c: PContext, n: PNode): PNode =
   for i in 0 ..< sonsLen(n):
     var imp: PNode
     let it = n.sons[i]
-    if it.kind == nkInfix and it.len == 3 and it[0].ident.s == "as":
-      localError(c.config, it.info, "Cannot use 'as' in 'include'.")
+    if it.kind == nkInfix and it.len == 3 and it[0].ident.s != "/":
+      localError(c.config, it.info, "Cannot use '" & it[0].ident.s & "' in 'include'.")
     if it.kind == nkInfix and it.len == 3 and it[2].kind == nkBracket:
       let sep = it[0]
       let dir = it[1]

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2035,6 +2035,8 @@ proc evalInclude(c: PContext, n: PNode): PNode =
   for i in 0 ..< sonsLen(n):
     var imp: PNode
     let it = n.sons[i]
+    if it.kind == nkInfix and it.len == 3 and it[0].ident.s == "as":
+      localError(c.config, it.info, "Cannot use 'as' in 'include'.")
     if it.kind == nkInfix and it.len == 3 and it[2].kind == nkBracket:
       let sep = it[0]
       let dir = it[1]

--- a/tests/modules/tincludeas.nim
+++ b/tests/modules/tincludeas.nim
@@ -1,0 +1,6 @@
+discard """
+  errormsg: "Cannot use 'as' in 'include'."
+  line: 6
+"""
+
+include foobar as foo


### PR DESCRIPTION
Closes https://github.com/nim-lang/Nim/issues/11872