### PR TITLE
Improve handling of invalid UTF-8

### DIFF
--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -1888,7 +1888,7 @@ proc entityToUtf8*(entity: string): string =
     doAssert entityToUtf8("#X3a3") == sigma
   let rune = entityToRune(entity)
   if rune.ord <= 0: result = ""
-  else: result = toUTF8(rune)
+  else: result = toUtf8(rune)
 
 proc addNode(father, son: XmlNode) =
   if son != nil: add(father, son)

--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -367,7 +367,6 @@ proc runeToEntity*(rune: Rune): string =
   runnableExamples:
     import unicode
     doAssert runeToEntity(Rune(0)) == ""
-    doAssert runeToEntity(Rune(-1)) == ""
     doAssert runeToEntity("Ü".runeAt(0)) == "#220"
     doAssert runeToEntity("∈".runeAt(0)) == "#8712"
   if rune.ord <= 0: result = ""

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -250,7 +250,7 @@ proc parseString(my: var JsonParser): TokKind =
             else:
               break
         else:
-          add(my.a, toUTF8(Rune(r)))
+          add(my.a, toUtf8(Rune(r)))
       else:
         # don't bother with the error
         add(my.a, my.buf[pos])

--- a/lib/pure/parsexml.nim
+++ b/lib/pure/parsexml.nim
@@ -451,7 +451,7 @@ proc parseEntity(my: var XmlParser, dest: var string) =
       while my.buf[pos] in {'0'..'9'}:
         r = r * 10 + (ord(my.buf[pos]) - ord('0'))
         inc(pos)
-    add(dest, toUTF8(Rune(r)))
+    add(dest, toUtf8(Rune(r)))
   elif my.buf[pos] == 'l' and my.buf[pos+1] == 't' and my.buf[pos+2] == ';':
     add(dest, '<')
     inc(pos, 2)

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -765,7 +765,7 @@ proc getch*(): char =
     discard fd.tcSetAttr(TCSADRAIN, addr oldMode)
 
 when defined(windows):
-  from unicode import toUTF8, Rune, runeLenAt
+  from unicode import toUtf8, Rune, runeLenAt
 
   proc readPasswordFromStdin*(prompt: string, password: var TaintedString):
                               bool {.tags: [ReadIOEffect, WriteIOEffect].} =
@@ -792,7 +792,7 @@ when defined(windows):
         # https://github.com/nim-lang/Nim/issues/7764
         continue
       else:
-        password.string.add(toUTF8(c.Rune))
+        password.string.add(toUtf8(c.Rune))
     stdout.write "\n"
 
 else:

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -218,6 +218,14 @@ proc `$`*(rune: Rune): string =
   ## * `add proc<#add,string,Rune>`_
   rune.toUtf8
 
+proc sanitizeUtf8*(s: string): string =
+  result = newStringOfCap(s.len)
+  var i = 0
+  while i < s.len:
+    let (rune, size) = runeAndSizeAt(s, i)
+    i.inc size
+    result.add rune
+
 proc `$`*(runes: seq[Rune]): string =
   ## Converts a sequence of Runes to a string.
   ##

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -1217,6 +1217,12 @@ template fastToUtf8Copy*(c: Rune, s: var string, pos: int, doInc = true)
   else:
     discard # error, exception?
 
+proc `<%`*(a, b: Rune): bool {.deprecated: "use < instead".} =
+  a < b
+
+proc `<=%`*(a, b: Rune): bool {.deprecated: "use <= instead".} =
+  a <= b
+
 when isMainModule:
 
   proc asRune(s: static[string]): Rune =

--- a/nimsuggest/sexp.nim
+++ b/nimsuggest/sexp.nim
@@ -160,7 +160,7 @@ proc parseString(my: var SexpParser): TTokKind =
         if handleHexChar(my.buf[pos], r): inc(pos)
         if handleHexChar(my.buf[pos], r): inc(pos)
         if handleHexChar(my.buf[pos], r): inc(pos)
-        add(my.a, toUTF8(Rune(r)))
+        add(my.a, toUtf8(Rune(r)))
       else:
         # don't bother with the error
         add(my.a, my.buf[pos])

--- a/tests/manyloc/argument_parser/argument_parser.nim
+++ b/tests/manyloc/argument_parser/argument_parser.nim
@@ -417,7 +417,7 @@ proc parse*(expected: seq[Tparameter_specification] = @[],
 
 proc toString(runes: seq[Rune]): string =
   result = ""
-  for rune in runes: result.add(rune.toUTF8)
+  for rune in runes: result.add(rune.toUtf8)
 
 
 proc ascii_cmp(a, b: string): int =

--- a/tests/tuples/tuple_with_nil.nim
+++ b/tests/tuples/tuple_with_nil.nim
@@ -267,7 +267,7 @@ proc writeformat(o: var Writer; c: Rune; fmt: Format) =
   # compute alignment
   var alg = getalign(fmt, faLeft, 1)
   writefill(o, fmt, alg.left)
-  let s = c.toUTF8
+  let s = c.toUtf8
   for c in s: write(o, c)
   writefill(o, fmt, alg.right)
 


### PR DESCRIPTION
The primary goal of this PR is to fix the handling of invalid UTF-8 in the unicode module, but it also contains some other minor changes. The diff is pretty big so I've tried to list the changes in the PR description. Although this PR contains breaking changes, the behavior will be the same for most cases. All the old tests for the unicode module still pass. I still need to write some tests and documentation, but I'm opening a draft PR early so I don't forget about this and in case someone wants to do a review.

### Breaking changes:

- `Rune` is now `distinct range[0..0x10FFFF]`
- Invalid UTF-8 input is now properly handled, with every invalid byte being
  treated as the replacement rune (0xFFFD). This change affect every proc
  in the unicode module that takes a string as input.
- Invalid UTF-8 is never generated anymore. However, procs like align
  and strip that doesn't process the entire string will still output
  invalid UTF-8 if they received it.

### New exported symbols:
- `` `<`(Rune, Rune): bool``
- `` `<=`(Rune, Rune): bool``
- `runeAndSizeAt(string, Natural): (Rune, int)`
- `const ReplacementRune* = Rune(0xFFFD)`
- `runeSizeAt`

### Deprecated symbols:
- `Rune16`
- `` `<%`(Rune, Rune)`` (replaced by `<`)
- `` `<=%`(Rune, Rune)`` (replaced by `<=`)
- `fastRuneAt` (replaced by `runeAndSizeAt`)
- `fastToUtf8Copy` (replaced by `add`)
- `runeLenAt` (replaced by `runeSizeAt`)

### TODO

- [ ] Tests for invalid UTF-8
- [ ] Documentation

Fixes https://github.com/nim-lang/RFCs/issues/151
Fixes #10750