### PR TITLE
Fix HCR crash because certain procs were hcrGetProc'ed before being hcrRegisterProc'ed

### DIFF
--- a/lib/nimhcr.nim
+++ b/lib/nimhcr.nim
@@ -347,7 +347,7 @@ when defined(createNimHcr):
 
   proc hcrGetProc*(module: cstring, name: cstring): pointer {.nimhcr.} =
     trace "  get proc: ", module.sanitize, " ", name
-    return modules[$module].procs[$name].jump
+    return modules[$module].procs.getOrDefault($name, ProcSym()).jump
 
   proc hcrRegisterGlobal*(module: cstring,
                           name: cstring,


### PR DESCRIPTION
Closes https://github.com/nim-lang/Nim/issues/11718

This issue was occuring because `system always gets fully inited before any other module (including when reloading)`  but system.nim imports many modules whose procs are not yet registered with hcr, so now we ignore such procs till later when they get registered.