### PR TITLE
Implement string block literals.

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -834,13 +834,15 @@ proc getString(L: var Lexer, tok: var Token, mode: StringMode) =
           inc(emptyLines)
           pos = handleCRLF(L, pos)
           needIndent = indent
+        elif c == ')':
+          add(tok.literal, '\n'.repeat(emptyLines))
+          break
         else:
           break
         continue
       # string block content
-      while emptyLines > 0:
-        add(tok.literal, "\n")
-        dec(emptyLines)
+      add(tok.literal, '\n'.repeat(emptyLines))
+      emptyLines = 0
       if c in {CR, LF, nimlexbase.EndOfFile}:
         add(tok.literal, "\n")
         pos = handleCRLF(L, pos)


### PR DESCRIPTION
````nim
let str = ":
    formatted
        text
         is
      possible
echo str

echo(
  r":
    def foo():
        """Generated Python function without any escaping"""
        print("".join(["foo", "bar"]))
        print("Hello\nWorld!")
)

echo ":
  <pre>\
  lines split only in source code, \
  no newlines in output\
  </pre>\
````
Discussion in https://github.com/nim-lang/RFCs/issues/161