### PR TITLE
nim check, fix #11927, no more empty strings

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -864,7 +864,9 @@ proc getCharacter(L: var TLexer, tok: var TToken) =
   inc(L.bufpos)               # skip '
   var c = L.buf[L.bufpos]
   case c
-  of '\0'..pred(' '), '\'': lexMessage(L, errGenerated, "invalid character literal")
+  of '\0'..pred(' '), '\'':
+    lexMessage(L, errGenerated, "invalid character literal")
+    tok.literal = $c
   of '\\': getEscapedChar(L, tok)
   else:
     tok.literal = $c


### PR DESCRIPTION
Before
```nim
# compiler/parser.nim:691
  of tkCharLit:
    result = newIntNodeP(nkCharLit, ord(p.tok.literal[0]), p)
    getTok(p)
```
had `IndexError` because `p.tok.literal` was empty.