### PR TITLE
fix compiletimeFFI bitrot

### DIFF
--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -289,7 +289,7 @@ proc unpackArray(conf: ConfigRef, x: pointer, typ: PType, n: PNode): PNode =
   if n.isNil:
     result = newNode(nkBracket)
     result.typ = typ
-    newSeq(result.sons, lengthOrd(conf, typ).int)
+    newSeq(result.sons, lengthOrd(conf, typ).toInt)
   else:
     result = n
     if result.kind != nkBracket:


### PR DESCRIPTION
https://github.com/nim-lang/Nim/pull/10150 has started to bitrot (after in128 changes) because testing it in testament was disabled in c5dbb0379fc431a01220224097f00323df6c9ced
this PR fixes that bitrot, so that 
```
nimble install libffi
nim c -d:nimHasLibFFI compiler/nim.nim # note: requires --styleCheck:hint currently
compiler/nim c --experimental:compiletimeFFI -r tests/vm/tevalffi.nim
```
will work.

But could we revert c5dbb0379fc431a01220224097f00323df6c9ced so that `compiletimeFFI` keeps working ?
I'm heavily relying on that, it enables a lot of things that would otherwise be impossible


