### PR TITLE
HCR - fix for #11608 and #11996

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -184,8 +184,8 @@ template genParamLoop(params) {.dirty.} =
     if params != nil: add(params, ~", ")
     add(params, genArgNoParam(p, ri.sons[i]))
 
-proc addActualPrefixForHCR(res: var Rope, module: PSym, sym: PSym) =
-  if sym.flags * {sfImportc, sfNonReloadable} == {} and
+proc addActualSuffixForHCR(res: var Rope, module: PSym, sym: PSym) =
+  if sym.flags * {sfImportc, sfNonReloadable} == {} and sym.loc.k == locProc and
       (sym.typ.callConv == ccInline or sym.owner.id == module.id):
     res = res & "_actual".rope
 
@@ -203,7 +203,7 @@ proc genPrefixCall(p: BProc, le, ri: PNode, d: var TLoc) =
     genParamLoop(params)
   var callee = rdLoc(op)
   if p.hcrOn and ri.sons[0].kind == nkSym:
-    callee.addActualPrefixForHCR(p.module.module, ri.sons[0].sym)
+    callee.addActualSuffixForHCR(p.module.module, ri.sons[0].sym)
   fixupCall(p, le, ri, d, callee, params)
 
 proc genClosureCall(p: BProc, le, ri: PNode, d: var TLoc) =

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -956,7 +956,7 @@ proc genProcHeader(m: BModule, prc: PSym, asPtr: bool = false): Rope =
   fillLoc(prc.loc, locProc, prc.ast[namePos], mangleName(m, prc), OnUnknown)
   genProcParams(m, prc.typ, rettype, params, check)
   # handle the 2 options for hotcodereloading codegen - function pointer
-  # (instead of forward declaration) or header for function budy with "_actual" postfix
+  # (instead of forward declaration) or header for function body with "_actual" postfix
   let asPtrStr = rope(if asPtr: "_PTR" else: "")
   var name = prc.loc.r
   if isReloadable(m, prc) and not asPtr:

--- a/lib/nimhcr.nim
+++ b/lib/nimhcr.nim
@@ -421,7 +421,7 @@ when defined(createNimHcr):
       modules.add(name, newModuleDesc())
 
     let copiedName = name & ".copy." & dllExt
-    copyFile(name, copiedName)
+    copyFileWithPermissions(name, copiedName)
 
     let lib = loadLib(copiedName)
     assert lib != nil


### PR DESCRIPTION
- adding _actual as a suffix only for calls to an actual proc and not through a global function pointer - fixes #11996
- adding forward declarations for reloadable functions within a module - fix compilation errors when 2 such functions reference each other (+ fixes codegen when methods are used) - fixes #11608
- preserve permissions of copied executable binaries