### PR TITLE
fixes #12015 by also checking kind of `typeNode`

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1384,9 +1384,12 @@ proc createConstructor(typeSym, jsonNode: NimNode): NimNode =
     let typeNode = getTypeImpl(typeSym)
     if typeNode.typeKind == ntyDistinct:
       result = createConstructor(typeNode, jsonNode)
-    elif obj.kind == nnkBracketExpr:
-      # When `Sym "Foo"` turns out to be a `ref object`.
+    elif obj.kind == nnkBracketExpr and typeNode.kind == nnkRefTy:
+      # When `Sym "Foo"` turns out to be a `ref object`
       result = createConstructor(obj, jsonNode)
+    elif obj.kind == nnkBracketExpr and typeNode.kind == nnkTupleTy:
+      # when "Sym "Foo" turns out to be a `tuple`
+      result = processType(typeSym, typeNode, jsonNode, false)
     else:
       result = processType(typeSym, obj, jsonNode, false)
   of nnkTupleTy:

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -517,9 +517,9 @@ when true:
       doAssert v.name == "smith"
       doAssert MyRef(w).name == "smith"
 
-# the type definition for `Pix` and the `%` proc are global, due to
-# #12017
 # bug #12015
+# The definition of the `%` proc needs to be here, since the `% c` calls below
+# can only find our custom `%` proc for `Pix` if defined in global scope.
 type
   Pix = tuple[x, y: uint8, ch: uint16]
 proc `%`(p: Pix): JsonNode =

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -517,23 +517,41 @@ when true:
       doAssert v.name == "smith"
       doAssert MyRef(w).name == "smith"
 
-  block:
-    # bug #12015
-    type
-      Pix = tuple[x, y: uint8, ch: uint16]
-      Cluster = object
-        works: tuple[x, y: uint8, ch: uint16] # working
-        fails: Pix # previously broken
+# the type definition for `Pix` and the `%` proc are global, due to
+# #12017
+# bug #12015
+type
+  Pix = tuple[x, y: uint8, ch: uint16]
+proc `%`(p: Pix): JsonNode =
+  result = %* { "x" : % p.x,
+                "y" : % p.y,
+                "ch" : % p.ch }
+block:
+  type
+    Cluster = object
+      works: tuple[x, y: uint8, ch: uint16] # working
+      fails: Pix # previously broken
 
-    proc `%`(p: Pix): JsonNode =
-      result = %* { "x" : % p.x,
-                    "y" : % p.y,
-                    "ch" : % p.ch }
+  let data = (x: 123'u8, y: 53'u8, ch: 1231'u16)
+  let c = Cluster(works: data, fails: data)
+  let cFromJson = (% c).to(Cluster)
+  doAssert c == cFromJson
 
-    let data = (x: 123'u8, y: 53'u8, ch: 1231'u16)
-    let c = Cluster(works: data, fails: data)
-    let cFromJson = (% c).to(Cluster)
-    doAssert c == cFromJson
+block:
+  # bug related to #12015
+  type
+    PixInt = tuple[x, y, ch: int]
+    SomePix = Pix | PixInt
+    Cluster[T: SomePix] = seq[T]
+    ClusterObject[T: SomePix] = object
+      data: Cluster[T]
+    RecoEvent[T: SomePix] = object
+      cluster: seq[ClusterObject[T]]
+
+  let data = @[(x: 123'u8, y: 53'u8, ch: 1231'u16)]
+  var c = RecoEvent[Pix](cluster: @[ClusterObject[Pix](data: data)])
+  let cFromJson = (% c).to(RecoEvent[Pix])
+  doAssert c == cFromJson
 
 # TODO: when the issue with the limeted vm registers is solved, the
 # exact same test as above should be evaluated at compile time as

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -517,6 +517,24 @@ when true:
       doAssert v.name == "smith"
       doAssert MyRef(w).name == "smith"
 
+  block:
+    # bug #12015
+    type
+      Pix = tuple[x, y: uint8, ch: uint16]
+      Cluster = object
+        works: tuple[x, y: uint8, ch: uint16] # working
+        fails: Pix # previously broken
+
+    proc `%`(p: Pix): JsonNode =
+      result = %* { "x" : % p.x,
+                    "y" : % p.y,
+                    "ch" : % p.ch }
+
+    let data = (x: 123'u8, y: 53'u8, ch: 1231'u16)
+    let c = Cluster(works: data, fails: data)
+    let cFromJson = (% c).to(Cluster)
+    doAssert c == cFromJson
+
 # TODO: when the issue with the limeted vm registers is solved, the
 # exact same test as above should be evaluated at compile time as
 # well, to ensure that the vm functionality won't diverge from the


### PR DESCRIPTION
Fixes #12015. 

If anyone sees a cleaner way to fix this, let me know. :)

edit: 
Just noticed that this does not solve my actual problem. I thought my test case reproduced the same problem, but it seems if generics are involved there are more cases for this to break. I'll reopen once I fix this.

edit2: I fixed it differently after all. The previous fix would fail if a generic was involved.
For some reason the this branch here:
https://github.com/nim-lang/Nim/pull/12016/files#diff-e00d77321d9bf30eaf8e4be863d9b565R1379-R1382
only seems to happen for aliases of `seq[T]`. At least that's the only case I could reproduce that branch. 

I decided to add an `of "tuple"` after all, even though the above mentioned branch would also catch that for clarity.