### PR TITLE
enableif: simpler and more powerful alternative to `concepts`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -868,6 +868,7 @@ type
                               # it won't cause problems
                               # for skModule the string literal to output for
                               # deprecated modules.
+    enableIf*: PNode          # consider reusing `constraint` instead
     when defined(nimsuggest):
       allUsages*: seq[TLineInfo]
 

--- a/compiler/procfind.nim
+++ b/compiler/procfind.nim
@@ -68,16 +68,27 @@ proc searchForProcNew(c: PContext, scope: PScope, fn: PSym): PSym =
   result = initIdentIter(it, scope.symbols, fn.name)
   while result != nil:
     if result.kind == fn.kind: #and sameType(result.typ, fn.typ, flags):
-      case equalParams(result.typ.n, fn.typ.n)
+      var status = equalParams(result.typ.n, fn.typ.n)
+      template msgAux(): untyped = [getProcHeader(c.config, result, getDeclarationPath = false), c.config$result.info]
+      template msgAux2(): untyped = [c.config$result.info]
+      if status in {paramsEqual,paramsIncompatible}:
+        if exprStructuralEquivalent(result.enableIf, fn.enableIf):
+          discard
+        elif result.enableIf == nil or fn.enableIf == nil:
+          localError(c.config, fn.info, "enableIf constraint required for each overload with matching types, see overload '$1' " %  msgAux2())
+        else:
+          # different (non-nil) enableIf constraints is ok
+          status = paramsNotEqual
+
+      case status
       of paramsEqual:
         if (sfExported notin result.flags) and (sfExported in fn.flags):
           let message = ("public implementation '$1' has non-public " &
-                         "forward declaration at $2") %
-                        [getProcHeader(c.config, result, getDeclarationPath = false), c.config$result.info]
+                         "forward declaration at $2") %  msgAux()
           localError(c.config, fn.info, message)
         return
       of paramsIncompatible:
-        localError(c.config, fn.info, "overloaded '$1' leads to ambiguous calls" % fn.name.s)
+        localError(c.config, fn.info, "overload '$1' with incompatible types leads to ambiguous calls" % msgAux2())
         return
       of paramsNotEqual:
         discard

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -44,7 +44,7 @@ proc semOpAux(c: PContext, n: PNode)
 proc semParamList(c: PContext, n, genericParams: PNode, s: PSym)
 proc addParams(c: PContext, n: PNode, kind: TSymKind)
 proc maybeAddResult(c: PContext, s: PSym, n: PNode)
-proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode
+proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}, isSemConstExpr = false): PNode
 proc activate(c: PContext, n: PNode)
 proc semQuoteAst(c: PContext, n: PNode): PNode
 proc finishMethod(c: PContext, s: PSym)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -191,7 +191,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
       candidates.add(getProcHeader(c.config, err.sym, prefer))
     candidates.add("\n")
     if err.firstMismatch.kind == kEnableIfFail:
-      let nCond = getEnableIfExpr(err.sym)
+      let nCond = err.sym.enableIf
       candidates.add("  enableIf condition failed: " & quoteExpr(renderTree(nCond)) & "\n")
     else:
       let nArg = if err.firstMismatch.arg < n.len: n[err.firstMismatch.arg] else: nil

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -101,7 +101,7 @@ type
     libs*: seq[PLib]           # all libs used by this module
     semConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # for the pragmas
     semExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
-    semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
+    semTryExpr*: proc (c: PContext, n: PNode, flags: TExprFlags = {}, isSemConstExpr = false): PNode {.nimcall.}
     semTryConstExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.}
     semOperand*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
     semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2040,7 +2040,7 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
     newNode(nkCall, n.info, quotes)])
   result = semExpandToAst(c, result)
 
-proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
+proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}, isSemConstExpr = false): PNode =
   # watch out, hacks ahead:
   let oldErrorCount = c.config.errorCounter
   let oldErrorMax = c.config.errorMax
@@ -2070,7 +2070,8 @@ proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   c.generics = @[]
   var err: string
   try:
-    result = semExpr(c, n, flags)
+    if isSemConstExpr: result = semConstExpr(c, n)
+    else: result = semExpr(c, n, flags)
     if c.config.errorCounter != oldErrorCount: result = nil
   except ERecoverableError:
     discard

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -319,6 +319,7 @@ proc instantiateProcType(c: PContext, pt: TIdTable,
   prc.typ = result
   popInfoContext(c.config)
 
+{.emit: "NIM_EXTERNC".} # for bootstrapping; remove after 0.21, refs #12144
 proc generateInstanceEnableIf*(c: PContext, fn: PSym, pt: TIdTable, info: TLineInfo, nCond: PNode, tryCompiles: bool): PNode {.exportc.} =
   let nCond = nCond.copyTree # needed, otherwise subsequent instantiations will
     # use stale data

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -319,7 +319,6 @@ proc instantiateProcType(c: PContext, pt: TIdTable,
   prc.typ = result
   popInfoContext(c.config)
 
-{.emit: "NIM_EXTERNC".}
 proc generateInstanceEnableIf*(c: PContext, fn: PSym, pt: TIdTable, info: TLineInfo, nCond: PNode, tryCompiles: bool): PNode {.exportc.} =
   let nCond = nCond.copyTree # needed, otherwise subsequent instantiations will
     # use stale data

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -82,7 +82,8 @@ type
     wStdIn, wStdOut, wStdErr,
 
     wInOut, wByCopy, wByRef, wOneWay,
-    wBitsize
+    wBitsize,
+    wEnableIf,
 
   TSpecialWords* = set[TSpecialWord]
 
@@ -170,7 +171,7 @@ const
     "stdin", "stdout", "stderr",
 
     "inout", "bycopy", "byref", "oneway",
-    "bitsize"
+    "bitsize", "enableif"
     ]
 
 proc findStr*(a: openArray[string], s: string): int =
@@ -210,4 +211,5 @@ proc canonPragmaSpelling*(w: TSpecialWord): string =
   of wCodegenDecl: "codegenDecl"
   of wLiftLocals: "liftLocals"
   of wLocalPassc: "localPassc"
+  of wEnableIf: "enableIf"
   else: specialWords[w]

--- a/tests/errmsgs/tcant_overload_by_return_type.nim
+++ b/tests/errmsgs/tcant_overload_by_return_type.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "overloaded 'x' leads to ambiguous calls"
+errormsg: "overload 'tcant_overload_by_return_type.nim(8, 6) ' with incompatible types leads to ambiguous calls"
 line: 9
 """
 

--- a/tests/errmsgs/tcant_overload_by_return_type.nim
+++ b/tests/errmsgs/tcant_overload_by_return_type.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "overload 'tcant_overload_by_return_type.nim(8, 6) ' with incompatible types leads to ambiguous calls"
+errormsg: "overload 'tcant_overload_by_return_type.nim(8, 6)' with incompatible types leads to ambiguous calls"
 line: 9
 """
 

--- a/tests/magics/tenableif.nim
+++ b/tests/magics/tenableif.nim
@@ -1,0 +1,104 @@
+proc test1() =
+  # test with constraints on static value, and multi argument constraint
+  proc baz(Ta, Tb, Tc: typedesc, d: static string): bool =
+    if d[0] == 'f': false
+    else:
+      Ta is Tb and Tc is float
+
+  proc fun[T1, T2, T3](a: T1, b: T2, c: T3, d: static string): auto
+    {.enableif: baz(T1, T2, type(a), d) and T3 is string and type(a) is float.} =
+    let ret = (a,b)
+    # echo ret
+    ret
+
+  template baz2(a: untyped): bool =
+    type(a) is string
+
+  proc fun2(a: auto): auto {.enableif: baz2(a).} = (a,)
+  proc fun3(a: string): auto {.enableif: false.} = discard
+  proc fun3[T](a: ptr T): auto {.enableif: false.} = discard
+  proc fun3(a: auto): auto {.enableif: false.} = discard
+  proc fun3[T](a: T): auto {.enableif: 3 == 5.} = discard
+  proc fun3[T](b: T): auto {.enableif: false.} = discard
+  proc fun3(a: char|float|int): auto {.enableif: type(a).sizeof == 3.} = discard
+  proc fun3(a: int): auto {.enableif: type(a) is float.} = (a,)
+  proc fun3(a: ptr int16): auto {.enableif: false.} = discard
+  proc fun3[T](c: T): auto {.enableif: false.} = "asdf"
+  proc fun3(a: ptr int8): auto {.enableif: false.} = discard
+
+  proc main()=
+    doAssert not compiles(fun2(12.3))
+    doAssert fun(1.1, 3.4, "asdf", "goobar") == (1.1, 3.4)
+    doAssert fun2("foobar") == ("foobar",)
+  main()
+
+proc test2() =
+  proc fun3[T](a: T): auto {.enableif: false.} = discard
+  proc fun3[T](b: T): auto {.enableif: false.} = discard
+  proc fun3(a: auto): auto {.enableif: typeof(a) is string .} = discard
+  proc fun3(a: int): auto {.enableif: false.} = discard
+  fun3("asdf")
+
+proc test3() =
+  proc fun() =
+    template gooz(a): untyped =
+      type(a) is int
+    proc fun3[T](a: T): auto {.enableif: gooz(a).} = a
+    doAssert fun3(1) == 1
+    doAssert not compiles(fun3("asdf"))
+  fun()
+
+proc test4() =
+  proc fun3[T](a: T): auto {.enableif: 3 == 3.} = (a,"ok1")
+  proc fun() =
+    proc fun3[T](a: T): auto {.enableif: false.} = (a,"ok1b")
+    proc fun3[T](a: T): auto {.enableif: 1 == 2.} = (a,"ok1b")
+    doAssert fun3("asdf") == ("asdf", "ok1")
+  fun()
+
+proc test5() =
+  proc fun3[T](a: T): string {.enableif: false.}
+  proc fun3[T](a: T): string {.enableif: true.}
+  proc bar(): auto =
+    fun3(12)
+  proc fun3[T](a: T): string {.enableif: false.} = $(a,)
+  proc fun3[T](a: T): string {.enableif: true.} = $(a,)
+  doAssert bar() == "(12,)"
+
+proc test6() =
+  # templates are allowed to redefine with the same enableif constraint
+  template fun3[T](a: T): int {.enableif: true.} = 41
+  template fun3[T](a: T): int {.enableif: true.} = 42
+  doAssert fun3("asdf") == 42
+
+proc test7() =
+  # different ways to specify `enableif`: from `a`, `T`, via an auxiliary template
+  template fun3(a: auto): auto {.enableif: type(a) is int.} = (a,"ok1")
+  template fun3[T](a: T): auto {.enableif: T is string.} = (a,"ok2")
+  template baz(T): untyped = T is int8
+  proc fun3[T](a: T): auto {.enableif: baz(T).} = (a, "ok3")
+  doAssert fun3(13) == (13, "ok1")
+  doAssert fun3("asdf") == ("asdf", "ok2")
+  doAssert fun3(1'i8) == (1'i8, "ok3")
+  doAssert not compiles fun3(1'u8)
+
+import std/sugar
+
+proc test8() =
+  # test with `compiles`
+  proc fun[T](a: T): auto {.enableif: compiles(a(1)).} = a(8)
+  proc fun[T](a: T): auto {.enableif: compiles(a("b")).} = a("b")
+  doAssert fun((x:int)=>x*2) == 8*2
+  doAssert fun((x:string)=>x & "ba") == "bba"
+
+proc testAll()=
+  test1()
+  test2()
+  test3()
+  test4()
+  test5()
+  test6()
+  test7()
+  test8()
+
+testAll()

--- a/tests/magics/tenableif.nim
+++ b/tests/magics/tenableif.nim
@@ -91,6 +91,21 @@ proc test8() =
   doAssert fun((x:int)=>x*2) == 8*2
   doAssert fun((x:string)=>x & "ba") == "bba"
 
+
+template isEmpty*[T: object|seq|string|set](a: T): bool {.enableif: a.len is int .} =
+  ## see https://github.com/nim-lang/Nim/pull/13526#issuecomment-596857722
+  a.len == 0
+
+proc testIsEmpty() =
+  type Foo = object
+    x: int
+  type Foo2 = object
+    x: int
+  proc len(a: Foo2): int = a.x
+  doAssert isEmpty(Foo2())
+  doAssert not isEmpty(Foo2(x: 1))
+  doAssert not compiles(isEmpty(Foo()))
+
 proc testAll()=
   test1()
   test2()

--- a/tests/magics/tenableif_failures.nim
+++ b/tests/magics/tenableif_failures.nim
@@ -1,0 +1,19 @@
+discard """
+cmd: "nim check $file"
+errormsg: "type mismatch"
+nimout: '''
+Error: type mismatch: got <int literal(1), uint8>
+but expected one of:
+proc fun3[T1, T2](a: T1; b: T2): int
+  enableIf condition failed: 'T1.sizeof == T2.sizeof'
+'''
+"""
+
+
+
+
+## line 15
+
+block:
+  proc fun3[T1, T2](a: T1, b: T2): int {.enableif: T1.sizeof == T2.sizeof.} = 41
+  fun3(1, 1'u8)


### PR DESCRIPTION
this PR implements `enableif` for routine (generic proc/template/etc) specialization, known in other languages as:
* C++: SFINAE/enable_if (with caveat that `enable_if` can be hard to use in C++)
* [EDIT] clang attribute (different from c++ enable_if): https://releases.llvm.org/3.7.0/tools/clang/docs/AttributeReference.html#id18 eg:
```
int isdigit(int c) __attribute__((enable_if(c <= -1 || c > 255, "chosen when 'c' is out of range"))) __attribute__((unavailable("'c' must have the value of an unsigned char or EOF")));
```

* D: template constraints (https://dlang.org/concepts.html) (easy to use in D).

eg usage:
```nim
proc fun[T1, T2](a1: T1, a2: T2): auto {.enableif: T1.sizeof == T2.sizeof .} = discard
template isFoo(a): untyped = type(s.a) is int and type(s.b) is float
proc fun[T](a: T, b: static string): auto {.enableif: isFoo(a) and b.len <2 .} = discard
```

Benefits compared to concepts / alternatives:
* **much simpler implementation**. The core of this PR is to test whether `enableif` expression returns true right after sigmatch
* [EDIT] replaces {.since.} which doesn't work with templates (as mentioned in https://github.com/nim-lang/Nim/pull/13016#issuecomment-592402835 and https://github.com/timotheecour/Nim/issues/42) (I need to double check this point) :
```nim
proc addInt(a, b: int): int {.since: (1, 1).} =
=>
proc addInt(a, b: int): int {.enableif: since(1, 1).} =
```

* [EDIT] can be used to reduce indentation eg:
```nim
when not declared(addInt) and defined(builtinOverflow):
  proc addInt(a, b: int): int {.compilerproc, inline.} =
=>
proc addInt(a, b: int): int {.compilerproc, inline, enableif: not declared(addInt) and defined(builtinOverflow).} =
```
* [EDIT] likewise, can be used do comment out a proc without modifying indentation, which shows large diffs in github UI and in cmdline git diff:
```nim
when false:
  proc addInt(a, b: int): int = ...
=>
proc addInt(a, b: int): int {.enableif: false.} = ...
```
* allows writing arbitrary constraint on the whole proc signature. By contrast, `concepts` can only model single argument constraints
* allows accessing compile time value of static params
* simpler to read/write for one-off constraints: instead of having to write a concept just for a constraint that appears once, you just write the expression in enableif; for constraints that are reused, you can just use a template (eg `{.enableif: isFoo(T).}`)
* nothing special (eg `{.explain.}`) is needed to debug a enableif expression: you can just insert `echo` statements inside the enableif expression, it'll execute as regular compile time code during sigmatch
* does not mess argument types, eg:
```nim
  type Foo = concept a
    a.x
  proc fun(a: Foo) = echo type(a) # `Foo` instead of `B`
  type B = object
    x: int
  fun(B())
```
(and it gets worse when `Foo[T]` is needed, giving `Foo[inferred[T], Foo]`)
wheres `enableif: compiles(a.x)` will just show `B`

## `concept` issues avoided by `enableif`
There are many issues with concepts, see https://github.com/nim-lang/Nim/labels/Concepts
These issues have prevented using concepts in the compiler source code. Eg see comments like this https://github.com/nim-lang/Nim/issues/9733#issuecomment-439425517:
> My personal opinion is, don't use concepts, they currently cause more problems than they solve. But yes, this is bad.

I believe using `enableif` will solve most of those issues, while also enable use cases that aren't possible with concepts.

I tried porting a few examples from concept to enableif and the problem disappeared with enableif in every case.
Would be interesting to try other issues and see which are fixed and which are not.  /cc @dawkot

* would close https://github.com/nim-lang/Nim/issues/9006 (generic parameter access via Foo.T doesn't work with concepts )
this works: `proc fun[U](s: U) {.enableif: U is Foo[U.T] .} = type T2 = s.type.T`
* would close https://github.com/nim-lang/Nim/issues/10079 (`type(foo)` interpreted as `foo` inside concept)
the straightforward porting to enableif works. There is no `type(x) vs x` conflation with enableif that causes ambiguities
* would close https://github.com/nim-lang/Nim/issues/8197 (Converter + concept results in an endless (or very long) compiler loop)
the straightforward porting works fine:
`converter toBool*(arg: auto): bool {.enableif: type(len(arg)) is int.}  = arg.len > 0`
* would close https://github.com/nim-lang/Nim/issues/9733 (concept cannot be overloaded with var concept)
* would close https://github.com/nim-lang/Nim/issues/10506 (Concepts with inheritance)
`proc conceptf(f : auto): string {.enableif: type(f(f)) is string .} = f(f)` works
* would close https://github.com/nim-lang/Nim/issues/9732 (`type` proc used on a concept-constrained variable return void)
`func foo(a: auto): type(a) {.enableif: true.} = discard` works

* would close https://github.com/nim-lang/Nim/issues/9573 Error when a concept-bound generic function argument is a tuple
```nim
  func foo(x: auto) {.enableif: type(x[0]) is type and type(x[1]) is type .} = discard
  foo((0, 'a'))
```

* would close https://github.com/nim-lang/Nim/issues/9550 Concept related crash only when compiling to JS
```nim
  template isFoo(c): untyped =
    for v in default(type(c)): (doAssert v is char)
    true
  func foo(c: auto) {.enableif: isFoo(c) .} =
    (for v in c: discard)
  foo @['a', 'b' ,'c']
```

* etc, probably a lot more


## notes
* I say `would close` for those issues because, while merging this PR wouldn't fix the problem with concepts, i would provide a suitable alternative via enableif, and there's no point in keeping unfixable issues open forever if suitable workaround is made available.

* bikeshedding: I could rename `enableif` to `where`: `enableif` is used in C++ but `where` is what's used in `C#`, `swift`, `rust`, `haskell` for the closest semantic thing; and a bit easier to type (and no guesswork enableif vs enableIf); on the other hand `enableif` is more unique/easier to search
* ~~add tests~~ done

* [EDIT]: see also [Having problems with concepts that won't finish compiling - Nim forum : Having problems with concepts that won't finish compiling - Nim forum](https://forum.nim-lang.org/t/6159)