### PR TITLE
Fixes #12044

### DIFF
--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -27,12 +27,12 @@ proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
   Hide(raiseAssert)(msg)
 
 template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]) =
-  const
-    loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
-    ploc = $loc
-  bind instantiationInfo
-  mixin failedAssertImpl
   when enabled:
+    const
+      loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
+      ploc = $loc
+    bind instantiationInfo
+    mixin failedAssertImpl
     {.line: loc.}:
       if not cond:
         failedAssertImpl(ploc & " `" & expr & "` " & msg)


### PR DESCRIPTION
Moves 'when enabled' up in `assertImpl()` to avoid `ploc` to be defined but not used.

As a side effect this also seems to slightly speed up compilation.