### PR TITLE
lift destructor for openarray 

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1496,14 +1496,14 @@ proc propagateToOwner*(owner, elem: PType) =
   if tfHasAsgn in elem.flags:
     let o2 = owner.skipTypes({tyGenericInst, tyAlias, tySink})
     if o2.kind in {tyTuple, tyObject, tyArray,
-                   tySequence, tyOpt, tySet, tyDistinct}:
+                   tySequence, tyOpt, tySet, tyDistinct, tyOpenArray, tyVarargs}:
       o2.flags.incl tfHasAsgn
       owner.flags.incl tfHasAsgn
 
   if tfHasOwned in elem.flags:
     let o2 = owner.skipTypes({tyGenericInst, tyAlias, tySink})
     if o2.kind in {tyTuple, tyObject, tyArray,
-                   tySequence, tyOpt, tySet, tyDistinct}:
+                   tySequence, tyOpt, tySet, tyDistinct, tyOpenArray, tyVarargs}:
       o2.flags.incl tfHasOwned
       owner.flags.incl tfHasOwned
 

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -469,7 +469,7 @@ proc genProcParams(m: BModule, t: PType, rettype, params: var Rope,
     add(params, param.loc.r)
     # declare the len field for open arrays:
     var arr = param.typ
-    if arr.kind in {tyVar, tyLent}: arr = arr.lastSon
+    if arr.kind in {tyVar, tyLent, tySink}: arr = arr.lastSon
     var j = 0
     while arr.kind in {tyOpenArray, tyVarargs}:
       # this fixes the 'sort' bug:
@@ -477,7 +477,7 @@ proc genProcParams(m: BModule, t: PType, rettype, params: var Rope,
       # need to pass hidden parameter:
       addf(params, ", NI $1Len_$2", [param.loc.r, j.rope])
       inc(j)
-      arr = arr.sons[0]
+      arr = arr.sons[0].skipTypes({tySink})
   if t.sons[0] != nil and isInvalidReturnType(m.config, t.sons[0]):
     var arr = t.sons[0]
     if params != nil: add(params, ", ")

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -13,7 +13,7 @@
 # Todo:
 # - use openArray instead of array to avoid over-specializations
 
-import modulegraphs, lineinfos, idents, ast, astalgo, renderer, semdata,
+import modulegraphs, lineinfos, idents, ast, renderer, semdata,
   sighashes, lowerings, options, types, msgs, magicsys, tables
 
 type

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -13,7 +13,7 @@
 # Todo:
 # - use openArray instead of array to avoid over-specializations
 
-import modulegraphs, lineinfos, idents, ast, renderer, semdata,
+import modulegraphs, lineinfos, idents, ast, astalgo, renderer, semdata,
   sighashes, lowerings, options, types, msgs, magicsys, tables
 
 type
@@ -506,7 +506,11 @@ proc fillBody(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   of tyTuple:
     fillBodyTup(c, t, body, x, y)
   of tyVarargs, tyOpenArray:
-    localError(c.g.config, c.info, "cannot copy openArray")
+    if c.kind == attachedDestructor:
+      forallElements(c, t, body, x, y)
+    else:
+      discard "cannot copy openArray"
+
   of tyFromExpr, tyProxy, tyBuiltInTypeClass, tyUserTypeClass,
      tyUserTypeClassInst, tyCompositeTypeClass, tyAnd, tyOr, tyNot, tyAnything,
      tyGenericParam, tyGenericBody, tyNil, tyUntyped, tyTyped,
@@ -626,7 +630,7 @@ proc createTypeBoundOps(g: ModuleGraph; c: PContext; orig: PType; info: TLineInf
   var canon = g.canonTypes.getOrDefault(h)
   var overwrite = false
   if canon == nil:
-    let typ = orig.skipTypes({tyGenericInst, tyAlias})
+    let typ = orig.skipTypes({tyGenericInst, tyAlias, tySink})
     g.canonTypes[h] = typ
     canon = typ
   elif canon != orig:

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -77,14 +77,12 @@ template semIdeForTemplateOrGeneric(c: PContext; n: PNode;
       discard safeSemExpr(c, n)
 
 proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
-  result = arg
-  let x = result.skipConv
+  let x = arg.skipConv
   if x.kind in {nkPar, nkTupleConstr, nkCurly} and formal.kind != tyUntyped:
     changeType(c, x, formal, check=true)
-  else:
-    result = skipHiddenSubConv(result)
-    #result.typ = takeType(formal, arg.typ)
-    #echo arg.info, " picked ", result.typ.typeToString
+  result = arg
+  result = skipHiddenSubConv(result)
+
 
 proc fitNode(c: PContext, formal: PType, arg: PNode; info: TLineInfo): PNode =
   if arg.typ.isNil:

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -176,3 +176,18 @@ proc myfuncLoop(x: int): MySeqNonCopyable =
     result = cc
 
 discard myfuncLoop(3)
+
+#------------------------------------------------------------
+# Move into table via openarray
+#------------------------------------------------------------
+
+type
+  TableNonCopyable = object
+    x: seq[(string, MySeqNonCopyable)]
+
+proc toTable(pairs: sink openArray[(string, MySeqNonCopyable)]): TableNonCopyable =
+  discard
+
+
+let mytable = {"a": newMySeq(2, 5.0)}.toTable
+


### PR DESCRIPTION
I had to change `fitNodePostMatch` to make the following compile in newruntime: `[(new(int),)]`. 
Otherwise, nkHiddenSubConv node is in the way for tuple elements of array and inject destructor tries to copy non copyable tuple `(new(int),)`