### PR TITLE
strop rendered keyword identifiers

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -845,6 +845,8 @@ proc gident(g: var TSrcGen, n: PNode) =
         t = tkSymbol
       else:
         t = TTokType(n.ident.id + ord(tkSymbol))
+        if not g.inGenericParams:
+          s = "`" & s & "`"
     else:
       t = tkSymbol
   else:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -38,7 +38,7 @@ const
     "because the parameter '$1' has a generic type"
   errIllegalRecursionInTypeX = "illegal recursion in type '$1'"
   errNoGenericParamsAllowedForX = "no generic parameters allowed for $1"
-  errInOutFlagNotExtern = "the '$1' modifier can be used only with imported types"
+  errInOutFlagNotExtern = "the $1 modifier can be used only with imported types"
 
 proc newOrPrevType(kind: TTypeKind, prev: PType, c: PContext): PType =
   if prev == nil:

--- a/tests/errmsgs/tinvalidinout.nim
+++ b/tests/errmsgs/tinvalidinout.nim
@@ -1,10 +1,10 @@
 discard """
 cmd: "nim check $file"
-errormsg: "the 'in' modifier can be used only with imported types"
+errormsg: "the `in` modifier can be used only with imported types"
 nimout: '''
-tinvalidinout.nim(14, 7) Error: the 'out' modifier can be used only with imported types
-tinvalidinout.nim(17, 9) Error: the 'in' modifier can be used only with imported types
-tinvalidinout.nim(18, 9) Error: the 'in' modifier can be used only with imported types
+tinvalidinout.nim(14, 7) Error: the `out` modifier can be used only with imported types
+tinvalidinout.nim(17, 9) Error: the `in` modifier can be used only with imported types
+tinvalidinout.nim(18, 9) Error: the `in` modifier can be used only with imported types
 '''
 """
 


### PR DESCRIPTION
This strops identifier names in the renderer when they would otherwise clash with keywords.

I took liberty with the changed test output; it is arguably more correct now, though.