### PR TITLE
`resolveSymbol(foo(args))` and `overloadExists(foo(args))` to return symbol after overload resolution

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -484,6 +484,7 @@ type
     nfDefaultRefsParam # a default param value references another parameter
                        # the flag is applied to proc default values and to calls
     nfExecuteOnReload  # A top-level statement that will be executed during reloads
+    nfOverloadResolve # return resolved `foo` in `foo(args)`
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   # keep below 32 for efficiency reasons (now: ~40)
@@ -673,8 +674,7 @@ type
     mInstantiationInfo, mGetTypeInfo,
     mNimvm, mIntDefine, mStrDefine, mBoolDefine, mRunnableExamples,
     mException, mBuiltinType, mSymOwner, mUncheckedArray, mGetImplTransf,
-    mSymIsInstantiationOf, mNodeId
-
+    mSymIsInstantiationOf, mNodeId, mOverloadResolve,
 
 # things that we can evaluate safely at compile time, even if not asked for it:
 const

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -484,7 +484,6 @@ type
     nfDefaultRefsParam # a default param value references another parameter
                        # the flag is applied to proc default values and to calls
     nfExecuteOnReload  # A top-level statement that will be executed during reloads
-    nfOverloadResolve # return resolved `foo` in `foo(args)`
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   # keep below 32 for efficiency reasons (now: ~40)

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -114,3 +114,4 @@ proc initDefines*(symbols: StringTableRef) =
 
   defineSymbol("nimHasSinkInference")
   defineSymbol("nimNewIntegerOps")
+  defineSymbol("himHasOverloadResolve")

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -338,7 +338,7 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
           result = strTableGet(c.topLevelScope.symbols, ident).skipAlias(n, c.config)
         else:
           result = strTableGet(m.tab, ident).skipAlias(n, c.config)
-        if result == nil and checkUndeclared in flags:
+        if result == nil and checkUndeclared in flags and nfOverloadResolve notin n.flags:
           fixSpelling(n[1], ident, searchInScopes)
           errorUndeclaredIdentifier(c, n[1].info, ident.s)
           result = errorSym(c, n[1])

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -313,7 +313,6 @@ proc qualifiedLookUp*(c: PContext, n: PNode, flags: set[TLookupFlag]): PSym =
       result = searchInScopes(c, ident, allExceptModule).skipAlias(n, c.config)
     if result == nil and checkPureEnumFields in flags:
       result = strTableGet(c.pureEnumFields, ident)
-    # if result == nil and checkUndeclared in flags:
     if result == nil and checkUndeclared in flags and checkOverloadResolve notin flags:
       fixSpelling(n, ident, searchInScopes)
       errorUndeclaredIdentifier(c, n.info, ident.s)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -537,7 +537,6 @@ proc tryDeref(n: PNode): PNode =
 proc semOverloadedCall(c: PContext, n, nOrig: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode =
   var errors: CandidateErrors = @[] # if efExplain in flags: @[] else: nil
-  echo0b (flags, n.flags, nOrig.flags, n.kind)
   var r = resolveOverloads(c, n, nOrig, filter, flags, errors, efExplain in flags)
   template canError(): bool =
     efNoUndeclared notin flags and nfOverloadResolve notin n.flags

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -384,7 +384,8 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       pickBest(callOp)
 
     if overloadsState == csEmpty and result.state == csEmpty:
-      if efNoUndeclared notin flags: # for tests/pragmas/tcustom_pragma.nim
+      if {efNoUndeclared, efOverloadResolve} * flags == {}:
+        # for tests/pragmas/tcustom_pragma.nim
         localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
       return
     elif result.state != csMatch:
@@ -488,7 +489,7 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   markUsed(c, info, finalCallee)
   onUse(info, finalCallee)
   assert finalCallee.ast != nil
-  if nfOverloadResolve in n.flags: return newSymNode(finalCallee, info)
+  if efOverloadResolve in flags: return newSymNode(finalCallee, info)
   if x.hasFauxMatch:
     result = x.call
     result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))
@@ -534,8 +535,7 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode =
   var errors: CandidateErrors = @[] # if efExplain in flags: @[] else: nil
   var r = resolveOverloads(c, n, nOrig, filter, flags, errors, efExplain in flags)
-  template canError(): bool =
-    efNoUndeclared notin flags and nfOverloadResolve notin n.flags
+  template canError(): bool = {efNoUndeclared, efOverloadResolve} * flags == {}
   if r.state == csMatch:
     # this may be triggered, when the explain pragma is used
     if errors.len > 0:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -384,8 +384,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       pickBest(callOp)
 
     if overloadsState == csEmpty and result.state == csEmpty:
-      if {efNoUndeclared, efOverloadResolve} * flags == {}:
-        # for tests/pragmas/tcustom_pragma.nim
+      if {efNoUndeclared, efOverloadResolve} * flags == {}: # for tests/pragmas/tcustom_pragma.nim
         localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
       return
     elif result.state != csMatch:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -537,6 +537,7 @@ proc tryDeref(n: PNode): PNode =
 proc semOverloadedCall(c: PContext, n, nOrig: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode =
   var errors: CandidateErrors = @[] # if efExplain in flags: @[] else: nil
+  echo0b (flags, n.flags, nOrig.flags, n.kind)
   var r = resolveOverloads(c, n, nOrig, filter, flags, errors, efExplain in flags)
   template canError(): bool =
     efNoUndeclared notin flags and nfOverloadResolve notin n.flags

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -488,11 +488,7 @@ proc semResolvedCall(c: PContext, x: TCandidate,
   markUsed(c, info, finalCallee)
   onUse(info, finalCallee)
   assert finalCallee.ast != nil
-  if nfOverloadResolve in n.flags:
-    # CHECKME: see if handling of `hasFauxMatch` is correct
-    let info2 = info
-    return newSymNode(finalCallee, info2)
-
+  if nfOverloadResolve in n.flags: return newSymNode(finalCallee, info)
   if x.hasFauxMatch:
     result = x.call
     result[0] = newSymNode(finalCallee, getCallLineInfo(result[0]))

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -64,9 +64,12 @@ type
     efWantStmt, efAllowStmt, efDetermineType, efExplain,
     efAllowDestructor, efWantValue, efOperand, efNoSemCheck,
     efNoEvaluateGeneric, efInCall, efFromHlo,
-    efNoUndeclared
+    efNoUndeclared,
       # Use this if undeclared identifiers should not raise an error during
       # overload resolution.
+    efOverloadResolve,
+      # for `mOverloadResolve` evaluation
+      # return resolved `foo` in `foo(args)`
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -68,8 +68,7 @@ type
       # Use this if undeclared identifiers should not raise an error during
       # overload resolution.
     efOverloadResolve,
-      # for `mOverloadResolve` evaluation
-      # return resolved `foo` in `foo(args)`
+      # for `mOverloadResolve` evaluation, resolves `foo` in `foo(args)`
 
   TExprFlags* = set[TExprFlag]
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1285,9 +1285,25 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
       if exactEquals(c.config.m.trackPos, n[1].info): suggestExprNoCheck(c, n)
 
   echo0b (n.flags, n.kind, n.renderTree, flags)
+
   var flags2 = {checkAmbiguity, checkUndeclared, checkModule}
   # if  nfOverloadResolve in n.flags: flags2.excl checkUndeclared
   var s = qualifiedLookUp(c, n, flags2)
+
+  if nfOverloadResolve in n.flags and n.kind == nkDotExpr:
+    var m = qualifiedLookUp(c, n[0], (flags2*{checkUndeclared})+{checkModule})
+    if m != nil and m.kind == skModule:
+      # it's mymodule.someident
+      if s == nil:
+        return nil
+      else:
+        # PRTEMP
+        return symChoice(c, n, s, scClosed)
+        # return s
+
+  # if s == nil and nfOverloadResolve in n.flags: # could be nil for somobj.somefield
+
+
   echo0b (n.flags, s == nil)
   # if nfOverloadResolve in n.flags:
   if false and nfOverloadResolve in n.flags: # could be nil for somobj.somefield

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2110,10 +2110,9 @@ proc semCompiles(c: PContext, n: PNode, flags: TExprFlags): PNode =
   result.typ = getSysType(c.graph, n.info, tyBool)
 
 proc semOverloadResolve(c: PContext, n: PNode, flags: TExprFlags): PNode =
-  if sonsLen(n) != 2:
-    localError(c.config, n.info, "semOverloadResolve: got" & $sonsLen(n))
+  if n.len != 2:
+    localError(c.config, n.info, "semOverloadResolve: got" & $n.len)
     return
-  doAssert sonsLen(n) == 2, $sonsLen(n)
   let n1 = n[1]
   n1.flags.incl nfOverloadResolve
   case n1.kind
@@ -2132,7 +2131,7 @@ proc semOverloadResolve(c: PContext, n: PNode, flags: TExprFlags): PNode =
     let typ = newTypeS(tyTuple, c)
     let result0 = result
     result = newNodeIT(nkTupleConstr, n.info, typ)
-    addSon(result, result0)
+    result.add result0
 
 proc semShallowCopy(c: PContext, n: PNode, flags: TExprFlags): PNode =
   if n.len == 3:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1279,16 +1279,11 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
   var flags2 = {checkAmbiguity, checkUndeclared, checkModule}
   var s = qualifiedLookUp(c, n, flags2)
-
   if nfOverloadResolve in n.flags and n.kind == nkDotExpr:
     var m = qualifiedLookUp(c, n[0], (flags2*{checkUndeclared})+{checkModule})
-    if m != nil and m.kind == skModule:
-      # it's mymodule.someident
-      if s == nil:
-        return nil
-      else:
-        return symChoice(c, n, s, scClosed)
-
+    if m != nil and m.kind == skModule: # got `mymodule.someident`
+      if s == nil: return nil
+      else: return symChoice(c, n, s, scClosed)
   if s != nil:
     if s.kind in OverloadableSyms:
       result = symChoice(c, n, s, scClosed)
@@ -2115,7 +2110,7 @@ proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
 
 proc semCompiles(c: PContext, n: PNode, flags: TExprFlags): PNode =
   # we replace this node by a 'true' or 'false' node:
-  if n.len != 2: return semDirectOp(c, n, flags) # why needed?
+  if n.len != 2: return semDirectOp(c, n, flags)
   result = newIntNode(nkIntLit, ord(tryExpr(c, n[1], flags) != nil))
   result.info = n.info
   result.typ = getSysType(c.graph, n.info, tyBool)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -10,8 +10,6 @@
 # this module does the semantic checking for expressions
 # included from sem.nim
 
-import std/wrapnils
-
 const
   errExprXHasNoType = "expression '$1' has no type (or is ambiguous)"
   errXExpectsTypeOrValue = "'$1' expects a type or value"

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1112,7 +1112,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       var a = regs[rb].node
       if a.kind == nkVarTy: a = a[0]
       if a.kind == nkSym:
-        regs[ra].node = if a.sym.ast.isNil: newNodeI(nkNilLit, a.sym.info) # preserve `info`, eg for module symbols
+        regs[ra].node = if a.sym.ast.isNil: newNode(nkNilLit)
                         else: copyTree(a.sym.ast)
         regs[ra].node.flags.incl nfIsRef
       else:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1112,7 +1112,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       var a = regs[rb].node
       if a.kind == nkVarTy: a = a[0]
       if a.kind == nkSym:
-        regs[ra].node = if a.sym.ast.isNil: newNode(nkNilLit)
+        regs[ra].node = if a.sym.ast.isNil: newNodeI(nkNilLit, a.sym.info) # preserve `info`, eg for module symbols
                         else: copyTree(a.sym.ast)
         regs[ra].node.flags.incl nfIsRef
       else:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2681,7 +2681,6 @@ when defined(himHasOverloadResolve):
     ## without calling it. Unlike `compiles(foo(args))`, the body is not analyzed.
     ## Also works with `compiles(mymod.mysym)` to return the symChoice overload
     ## set.
-    discard
 
 when defined(nimV2):
   import system/repr_v2

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2674,6 +2674,14 @@ type
   NimNode* {.magic: "PNimrodNode".} = ref NimNodeObj
     ## Represents a Nim AST node. Macros operate on this type.
 
+proc resolveSymbol*(x: untyped): NimNode {.magic: "OverloadResolve", noSideEffect, compileTime.} =
+  ## resolves a symbol given an expression, eg: in `resolveSymbol(foo(args))`
+  ## it will find the symbol that would be called after overload resolution,
+  ## without calling it. Unlike `compiles(foo(args))`, the body is not analyzed.
+  ## Also works with `compiles(mymod.mysym)` to return the symChoice overload
+  ## set.
+  discard
+
 when defined(nimV2):
   import system/repr_v2
   export repr_v2

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2674,13 +2674,14 @@ type
   NimNode* {.magic: "PNimrodNode".} = ref NimNodeObj
     ## Represents a Nim AST node. Macros operate on this type.
 
-proc resolveSymbol*(x: untyped): NimNode {.magic: "OverloadResolve", noSideEffect, compileTime.} =
-  ## resolves a symbol given an expression, eg: in `resolveSymbol(foo(args))`
-  ## it will find the symbol that would be called after overload resolution,
-  ## without calling it. Unlike `compiles(foo(args))`, the body is not analyzed.
-  ## Also works with `compiles(mymod.mysym)` to return the symChoice overload
-  ## set.
-  discard
+when defined(himHasOverloadResolve):
+  proc resolveSymbol*(x: untyped): NimNode {.magic: "OverloadResolve", noSideEffect, compileTime.} =
+    ## resolves a symbol given an expression, eg: in `resolveSymbol(foo(args))`
+    ## it will find the symbol that would be called after overload resolution,
+    ## without calling it. Unlike `compiles(foo(args))`, the body is not analyzed.
+    ## Also works with `compiles(mymod.mysym)` to return the symChoice overload
+    ## set.
+    discard
 
 when defined(nimV2):
   import system/repr_v2

--- a/tests/magics/mresolve_overloads.nim
+++ b/tests/magics/mresolve_overloads.nim
@@ -1,6 +1,6 @@
-let foo1* = [1,2] ## c1
-var foo2* = "asdf" ## c2
-const foo3* = 'a' ## c3
+let mfoo1* = [1,2] ## c1
+var mfoo2* = "asdf" ## c2
+const mfoo3* = 'a' ## c3
 
 proc `@@@`*(a: int) = discard
 proc `@@@`*(a: float) = discard

--- a/tests/magics/mresolve_overloads.nim
+++ b/tests/magics/mresolve_overloads.nim
@@ -1,0 +1,8 @@
+let foo1* = [1,2] ## c1
+var foo2* = "asdf" ## c2
+const foo3* = 'a' ## c3
+
+proc `@@@`*(a: int) = discard
+proc `@@@`*(a: float) = discard
+proc `@@@`*[T: Ordinal](a: T) = discard
+

--- a/tests/magics/mresolves.nim
+++ b/tests/magics/mresolves.nim
@@ -1,6 +1,6 @@
 import std/macros
 
-macro overloadExistsImpl(x: typed): bool = 
+macro overloadExistsImpl(x: typed): bool =
   newLit(x != nil)
 
 template overloadExists*(a: untyped): bool =

--- a/tests/magics/mresolves.nim
+++ b/tests/magics/mresolves.nim
@@ -42,4 +42,5 @@ macro inspect*(a: typed, resolveLet: static bool = false): untyped =
   s.add a.lineInfoObj.toStr & ": "
   s.add a.repr & " = "
   inspectImpl(s, a, resolveLet)
-  echo s
+  when defined(nimTestsResolvesDebug):
+    echo s

--- a/tests/magics/mresolves.nim
+++ b/tests/magics/mresolves.nim
@@ -1,0 +1,45 @@
+import std/macros
+
+macro overloadExistsImpl(x: typed): bool = 
+  newLit(x != nil)
+
+template overloadExists*(a: untyped): bool =
+  overloadExistsImpl(resolveSymbol(a))
+
+type InstantiationInfo = type(instantiationInfo())
+
+proc toStr(info: InstantiationInfo | LineInfo): string =
+  const offset = 1
+  result = info.filename & ":" & $info.line & ":" & $(info.column + offset)
+
+proc inspectImpl*(s: var string, a: NimNode, resolveLet: bool) =
+  var a = a
+  if resolveLet:
+    a = a.getImpl
+    a = a[2]
+  case a.kind
+  of nnkClosedSymChoice:
+    s.add "closedSymChoice:"
+    for ai in a:
+      s.add "\n  "
+      inspectImpl(s, ai, false)
+  of nnkSym:
+    var a2 = a.getImpl
+    const callables = {nnkProcDef, nnkMethodDef, nnkConverterDef, nnkMacroDef, nnkTemplateDef, nnkIteratorDef}
+    if a2.kind in callables:
+      let a20=a2
+      a2 = newTree(a20.kind)
+      for i, ai in a20:
+        a2.add if i notin [6]: ai else: newEmptyNode()
+    s.add a2.lineInfoObj.toStr & " " & a2.repr
+  else: error($a.kind, a)
+
+macro inspect*(a: typed, resolveLet: static bool = false): untyped =
+  var a = a
+  if a.kind == nnkTupleConstr:
+    a = a[0]
+  var s: string
+  s.add a.lineInfoObj.toStr & ": "
+  s.add a.repr & " = "
+  inspectImpl(s, a, resolveLet)
+  echo s

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -43,6 +43,10 @@ macro fun8(c: static bool): untyped = discard
 
 proc fun8(d: var int) = d.inc
 
+proc fun10[T: seq](a: T): auto = (a,)
+proc fun10[T: int|float](a: T): auto = (a,)
+template fun11(a: untyped): auto = (a,)
+
 proc main()=
   block: # overloadExists with nkCall
     doAssert overloadExists(fun4(1))
@@ -79,6 +83,26 @@ proc main()=
     doAssert not overloadExists(fun6(1 + 'a', 2))
     doAssert overloadExists(fun7(1))
     doAssert not overloadExists(fun7())
+
+    # generics
+    doAssert overloadExists(fun10(@[1]))
+    doAssert overloadExists(fun10(1.2))
+    doAssert not overloadExists(fun10("foo"))
+    doAssert not overloadExists(fun10('a'))
+    template fun10(a: char): auto = (a,)
+    doAssert overloadExists(fun10('a'))
+    doAssert not overloadExists(fun11())
+    doAssert overloadExists(fun11(1 + 'a'))
+
+    # $
+    doAssert overloadExists($12)
+    doAssert not overloadExists($main)
+    # echo
+    doAssert overloadExists(echo 12)
+    doAssert overloadExists(echo ())
+    doAssert overloadExists(echo())
+    doAssert not overloadExists(echo main)
+    doAssert not overloadExists(echo(main))
 
   block: # overloadExists with nkCall dot accesors
     type Foo = object

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -1,5 +1,13 @@
 #[
-D20190825T173945
+use -d:nimTestsResolvesDebug to make the `inspect` macro print debug info showing
+resolved symbol locations, for example:
+
+`inspect resolveSymbol(`$`)` would print:
+
+Nim/tests/magics/tresolve_overloads.nim:133:28: $ = closedSymChoice:
+  Nim/lib/system/dollars.nim:124:1 proc `$`[T](x: set[T]): string
+  Nim/lib/system/dollars.nim:140:1 proc `$`[T; U](x: HSlice[T, U]): string
+  Nim/lib/system/dollars.nim:14:1 proc `$`(x: bool): string {.magic: "BoolToStr", noSideEffect.}
 ]#
 
 import ./mresolves

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -122,12 +122,23 @@ proc main()=
     doAssert not compiles(nonexistant.bar1)
     doAssert not compiles overloadExists(nonexistant.bar1)
     doAssert not compiles overloadExists(nonexistant().mfoo1)
-    
     doAssert not compiles overloadExists(nonexistant1().nonexistant2)
     doAssert not compiles overloadExists(nonexistant().bar2)
     doAssert not compiles overloadExists(nonexistant().bar1)
 
-    # doAssert not overloadExists(nonexistant) # PRTEMP
+    doAssert declared(mresolve_overloads)
+    doAssert declared(fun7)
+    doAssert declared(foo)
+    doAssert declared(`bar5`)
+    doAssert declared(bar5)
+    doAssert declared(`system`)
+    doAssert not declared(nonexistant)
+    doAssert not overloadExists(nonexistant)
+    doAssert not overloadExists(`nonexistant`)
+    doAssert overloadExists(system)
+    doAssert overloadExists(`system`)
+    doAssert overloadExists(`bar5`)
+    doAssert overloadExists(bar5)
 
   block: # resolveSymbol
     doAssert resolveSymbol(fun8(1))(3) == fun8(3)
@@ -196,7 +207,7 @@ proc main2()=
     doAssert compiles resolveSymbol(system.compiles)
     inspect resolveSymbol(system.compiles)
     doAssert resolveSymbol(system.nonexistant) == nil
-    # doAssert resolveSymbol(nonexistant) == nil
+    doAssert resolveSymbol(nonexistant) == nil
 
   block:
     template bar1(): untyped = 12

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -50,7 +50,9 @@ proc main()=
     doAssert overloadExists(fun4(1))
     doAssert overloadExists(fun4(1.2))
     doAssert not overloadExists(fun4())
-    # doAssert not overloadExists(nonexistant(1)) # should we error with `Error: undeclared identifier: 'nonexistant'` ? A: probly should just return false, eg: imagine for: ` 1 @ 2`
+    doAssert not overloadExists(1 @@@ 2)
+    doAssert overloadExists(1 + 2)
+    doAssert not overloadExists('a' + 2.0)
 
     doAssert overloadExists(funDecl1(1))
     doAssert not overloadExists(funDecl1(1.0))
@@ -92,12 +94,14 @@ proc main()=
     template bar5(a: Foo) = discard
 
     doAssert not declared(mresolve_overloads.nonexistant)
-    doAssert declared(mresolve_overloads.foo3)
+    doAssert declared(mresolve_overloads.mfoo3)
     doAssert not declared(foo.bar1)
     doAssert not overloadExists(mresolve_overloads.nonexistant)
-    doAssert overloadExists(mresolve_overloads.foo3)
+    doAssert overloadExists(mresolve_overloads.mfoo3)
 
     doAssert not overloadExists(nonexistant(foo))
+    doAssert not overloadExists(nonexistant())
+
     doAssert not overloadExists(foo.nonexistant)
     doAssert compiles(Foo().bar1)
     doAssert compiles(Foo().bar1)
@@ -116,8 +120,14 @@ proc main()=
     doAssert overloadExists(Foo().bar1)
 
     doAssert not compiles(nonexistant.bar1)
-    doAssert not compiles(overloadExists(nonexistant.bar1))
-    doAssert not compiles(overloadExists(nonexistant().bar1))
+    doAssert not compiles overloadExists(nonexistant.bar1)
+    doAssert not compiles overloadExists(nonexistant().mfoo1)
+    
+    doAssert not compiles overloadExists(nonexistant1().nonexistant2)
+    doAssert not compiles overloadExists(nonexistant().bar2)
+    doAssert not compiles overloadExists(nonexistant().bar1)
+
+    # doAssert not overloadExists(nonexistant) # PRTEMP
 
   block: # resolveSymbol
     doAssert resolveSymbol(fun8(1))(3) == fun8(3)
@@ -186,7 +196,7 @@ proc main2()=
     doAssert compiles resolveSymbol(system.compiles)
     inspect resolveSymbol(system.compiles)
     doAssert resolveSymbol(system.nonexistant) == nil
-    doAssert resolveSymbol(nonexistant) == nil
+    # doAssert resolveSymbol(nonexistant) == nil
 
   block:
     template bar1(): untyped = 12
@@ -199,10 +209,10 @@ proc main2()=
     inspect resolveSymbol(cint)
     inspect resolveSymbol(system.off)
     inspect resolveSymbol(newLit(true))
-    inspect resolveSymbol(foo1)
-    inspect resolveSymbol(foo2)
-    inspect resolveSymbol(foo3)
-    inspect resolveSymbol(mresolve_overloads.foo3)
+    inspect resolveSymbol(mfoo1)
+    inspect resolveSymbol(mfoo2)
+    inspect resolveSymbol(mfoo3)
+    inspect resolveSymbol(mresolve_overloads.mfoo3)
     inspect resolveSymbol(macros.nnkCallKinds)
 
     ## module

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -77,6 +77,19 @@ proc main()=
     doAssert overloadExists(fun7(1))
     doAssert not overloadExists(fun7())
 
+    block: # dot accesors
+      type Foo = object
+        bar1: int
+      template bar2(a: Foo) = discard
+      template bar3[T](a: T) = discard
+      doAssert compiles(Foo().bar1)
+      doAssert overloadExists(Foo().bar1)
+      var foo: Foo
+      doAssert overloadExists(foo.bar1)
+      doAssert overloadExists(foo.bar2)
+      doAssert overloadExists(foo.bar3)
+      doAssert not overloadExists(foo.bar4)
+
     doAssert resolveSymbol(fun8(1))(3) == fun8(3)
     inspect resolveSymbol(fun8)
 

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -1,0 +1,165 @@
+#[
+D20190825T173945
+]#
+
+import ./mresolves
+
+template bail() = static: doAssert false
+
+proc funDecl1(a: int) {.importc.}
+proc funDecl2(a: int)
+
+proc fun(a: int) = discard
+
+template fun2(a = 0) = bail()
+template fun3() = bail()
+
+proc fun4(a: float) = discard
+
+proc fun4[T](a: T) =
+  static: echo "in fun4"
+  bail()
+
+macro fun5(a: typed): untyped = discard
+macro fun6(a: untyped): untyped = discard
+iterator fun7(a: int): auto = yield 1
+
+proc fun8(a: int): auto = (a, "int")
+proc fun8(a: float): tuple = (a,"float")
+template fun8(a: string) = discard
+template fun8(a: char = 'x') = discard
+template fun8() = discard
+macro fun8(b = 1'u8): untyped = discard
+macro fun8(c: static bool): untyped = discard
+
+proc fun8(d: var int) = d.inc
+
+proc main()=
+  static:
+    doAssert overloadExists(fun4(1))
+    doAssert not compiles(fun4(1))
+    doAssert overloadExists(fun4(1))
+    doAssert overloadExists(fun4(1.2))
+    doAssert not overloadExists(fun4())
+    # doAssert not overloadExists(nonexistant(1)) # should we error with `Error: undeclared identifier: 'nonexistant'` ? A: probly should just return false, eg: imagine for: ` 1 @ 2`
+
+    doAssert overloadExists(funDecl1(1))
+    doAssert not overloadExists(funDecl1(1.0))
+    doAssert overloadExists(funDecl2(1))
+
+    doAssert overloadExists(fun(1))
+    doAssert overloadExists(1+1)
+    doAssert not overloadExists('a'+1.2)
+
+    doAssert not overloadExists(fun(1.1))
+    doAssert not overloadExists(fun(1, 2))
+    doAssert overloadExists(fun2())
+    doAssert overloadExists(fun2(1))
+    doAssert overloadExists(fun3())
+    doAssert not overloadExists(fun3(1))
+
+    # subtlety: if arguments for a `typed` formal param are not well typed,
+    # we error instead of return false
+    doAssert not compiles overloadExists(fun5(1 + 'a'))
+
+    doAssert overloadExists(fun5(1 + 1))
+    doAssert not overloadExists(fun5(1 + 1, 2))
+    doAssert overloadExists(fun6(1 + 'a'))
+    doAssert not overloadExists(fun6(1 + 'a', 2))
+    doAssert overloadExists(fun7(1))
+    doAssert not overloadExists(fun7())
+
+    doAssert resolveSymbol(fun8(1))(3) == fun8(3)
+    inspect resolveSymbol(fun8)
+
+    inspect resolveSymbol(fun7)
+    inspect resolveSymbol(fun8(1))
+    inspect resolveSymbol(fun8(1.2))
+    inspect resolveSymbol(fun8("asdf"))
+    inspect resolveSymbol(fun8('a'))
+    doAssert compiles(resolveSymbol(fun8('a')))
+    doAssert not compiles(resolveSymbol(fun8())) # correctly would give ambiguous error
+    inspect resolveSymbol(fun8(b = 1))
+    inspect resolveSymbol(fun8(c = false))
+    inspect resolveSymbol(1.1 / 2.0)
+
+  block:
+    var c1 = false
+    doAssert not overloadExists(fun8(c = c1))
+    const c2 = false
+    doAssert overloadExists(fun8(c = c2))
+    var c3 = 10
+    doAssert overloadExists(fun8(d = c3))
+    doAssert c3 == 10
+    resolveSymbol(fun8(d = c3))(d = c3)
+    doAssert c3 == 11
+    let t = resolveSymbol(fun8(d = c3))
+    doAssert type(t) is proc
+    t(d = c3)
+    doAssert c3 == 12
+
+  block:
+    var z = 10
+    proc fun9(z0: int) = z+=z0
+    proc fun9(z0: float) = doAssert false
+    let t = resolveSymbol(fun9(12))
+    # can't work with `const t = fun9`: invalid type for const
+    doAssert type(t) is proc
+    t(3)
+    doAssert z == 10+3
+    inspect resolveSymbol(fun9(12))
+    inspect(resolveSymbol(t), resolveLet=true)
+
+import std/strutils
+import std/macros
+import std/macros as macrosAlias
+import ./mresolve_overloads
+
+proc main2()=
+  block:
+    inspect resolveSymbol(`@@@`)
+
+    let t = resolveSymbol toUpper("asdf")
+    inspect resolveSymbol(t), resolveLet=true
+    doAssert t("asdf") == "ASDF"
+    let t2 = resolveSymbol strutils.toUpper("asdf")
+    inspect resolveSymbol(t2), resolveLet=true
+    doAssert t2("asdf") == "ASDF"
+
+    inspect resolveSymbol(strutils.toUpper)
+    inspect resolveSymbol(strutils.`toUpper`)
+    inspect resolveSymbol(`toUpper`)
+    # overloaded
+    inspect resolveSymbol(`$`)
+    inspect resolveSymbol(system.`$`)
+
+    doAssert compiles resolveSymbol(system.compiles)
+    inspect resolveSymbol(system.compiles)
+    doAssert not compiles resolveSymbol(system.nonexistant)
+    doAssert not compiles resolveSymbol(nonexistant)
+
+  block:
+    template bar1(): untyped = 12
+    inspect resolveSymbol(bar1)
+    inspect resolveSymbol(currentSourcePath)
+    inspect resolveSymbol(system.currentSourcePath)
+    doAssert resolveSymbol(system.currentSourcePath)() == currentSourcePath()
+    inspect resolveSymbol(system.uint16)
+    inspect resolveSymbol(system.cint)
+    inspect resolveSymbol(cint)
+    inspect resolveSymbol(system.off)
+    inspect resolveSymbol(newLit(true))
+    inspect resolveSymbol(foo1)
+    inspect resolveSymbol(foo2)
+    inspect resolveSymbol(foo3)
+    inspect resolveSymbol(mresolve_overloads.foo3)
+    inspect resolveSymbol(macros.nnkCallKinds)
+
+    ## module
+    inspect resolveSymbol(macros)
+    inspect resolveSymbol(macrosAlias)
+
+proc funDecl2(a: int) = discard
+
+main()
+main2()

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -84,7 +84,7 @@ proc main()=
       template bar3[T](a: T) = discard
       doAssert compiles(Foo().bar1)
       doAssert overloadExists(Foo().bar1)
-      var foo: Foo
+      const foo = Foo()
       doAssert overloadExists(foo.bar1)
       doAssert overloadExists(foo.bar2)
       doAssert overloadExists(foo.bar3)
@@ -157,14 +157,14 @@ proc main2()=
     doAssert compiles resolveSymbol(system.compiles)
     inspect resolveSymbol(system.compiles)
     doAssert not compiles resolveSymbol(system.nonexistant)
-    doAssert not compiles resolveSymbol(nonexistant)
+    # doAssert not compiles resolveSymbol(nonexistant) # PRTEMP
 
   block:
     template bar1(): untyped = 12
     inspect resolveSymbol(bar1)
     inspect resolveSymbol(currentSourcePath)
     inspect resolveSymbol(system.currentSourcePath)
-    doAssert resolveSymbol(system.currentSourcePath)() == currentSourcePath()
+    # doAssert resolveSymbol(system.currentSourcePath)() == currentSourcePath() # PRTEMP
     inspect resolveSymbol(system.uint16)
     inspect resolveSymbol(system.cint)
     inspect resolveSymbol(cint)
@@ -173,8 +173,8 @@ proc main2()=
     inspect resolveSymbol(foo1)
     inspect resolveSymbol(foo2)
     inspect resolveSymbol(foo3)
-    inspect resolveSymbol(mresolve_overloads.foo3)
-    inspect resolveSymbol(macros.nnkCallKinds)
+    # inspect resolveSymbol(mresolve_overloads.foo3) # PRTEMP
+    # inspect resolveSymbol(macros.nnkCallKinds) # PRTEMP
 
     ## module
     inspect resolveSymbol(macros)

--- a/tests/magics/tresolve_overloads.nim
+++ b/tests/magics/tresolve_overloads.nim
@@ -156,15 +156,15 @@ proc main2()=
 
     doAssert compiles resolveSymbol(system.compiles)
     inspect resolveSymbol(system.compiles)
-    doAssert not compiles resolveSymbol(system.nonexistant)
-    # doAssert not compiles resolveSymbol(nonexistant) # PRTEMP
+    doAssert resolveSymbol(system.nonexistant) == nil
+    doAssert resolveSymbol(nonexistant) == nil
 
   block:
     template bar1(): untyped = 12
     inspect resolveSymbol(bar1)
     inspect resolveSymbol(currentSourcePath)
     inspect resolveSymbol(system.currentSourcePath)
-    # doAssert resolveSymbol(system.currentSourcePath)() == currentSourcePath() # PRTEMP
+    doAssert resolveSymbol(system.currentSourcePath)() == currentSourcePath()
     inspect resolveSymbol(system.uint16)
     inspect resolveSymbol(system.cint)
     inspect resolveSymbol(cint)
@@ -173,8 +173,8 @@ proc main2()=
     inspect resolveSymbol(foo1)
     inspect resolveSymbol(foo2)
     inspect resolveSymbol(foo3)
-    # inspect resolveSymbol(mresolve_overloads.foo3) # PRTEMP
-    # inspect resolveSymbol(macros.nnkCallKinds) # PRTEMP
+    inspect resolveSymbol(mresolve_overloads.foo3)
+    inspect resolveSymbol(macros.nnkCallKinds)
 
     ## module
     inspect resolveSymbol(macros)


### PR DESCRIPTION
* fixes https://github.com/nim-lang/RFCs/issues/164 (both proposal1 and proposal2)
* a single magic is added `resolveSymbol` that performs symbol resolution (in particular overload resolution for call-like expressions) and returns either nil if not such overload was found, or the symbol after overload resolution is done, or the symchoice if a symbol is ambiguous.
* `overloadExists(foo(args))` is a library proc built on top of `resolveSymbol`  to tell whether a proper overload exists
* extensive tests are provided in `tests/magics/tresolve_overloads.nim`

As an example use case, see library defined `inspect` macro that inspects the sym/symchoice returned by `resolveSymbol`:
```nim
inspect resolveSymbol(`$`)
/Users/timothee/git_clone/nim/Nim_prs/tests/magics/tresolve_overloads.nim:134:35: $ = closedSymChoice:
  /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim:10:1 proc `$`(x: float): string {.magic: "FloatToStr", noSideEffect.}
  /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim:128:1 proc `$`[T](x: seq[T]): string
  /Users/timothee/git_clone/nim/Nim_prs/lib/system/strmantle.nim:307:1 proc `$`(x: uint64): string {.noSideEffect, raises: [].}
  /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim:152:1 proc `$`[T](x: openArray[T]): string
  /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim:34:1 proc `$`[Enum](x: Enum): string {.magic: "EnumToStr", noSideEffect.}
  /Users/timothee/git_clone/nim/Nim_prs/lib/system/widestrs.nim:172:1 proc `$`(w: WideCString; estimate: int; replacement: int = 0x0000FFFD): string
etc...
```

* you can also resolve a proc overload via its arguments, this is quite useful when you don't know which overload is used in some piece of code. eg:
```nim
inspect resolveSymbol(newLit(true))
/Users/timothee/git_clone/nim/Nim_prs/tests/magics/tresolve_overloads.nim:151:27: newLit = /Users/timothee/git_clone/nim/Nim_prs/lib/core/macros.nim:702:1 proc newLit(b: bool): NimNode {.compileTime.}

let t = resolveSymbol toUpper("asdf")
inspect resolveSymbol(t), resolveLet=true
echo t("foo")
```

`inspect` is a bit similar to what `nimsuggest` binary provides but it's a pure library solution, ie easier to integrate with custom user needs. It can resolve things that aren't possible with nimsuggest, eg:
```nim
proc fun[T](a: T) =
  inspect resolveSymbol(fun(a))
```

* it works with any symbol (const,let,var,iterator,macro,template,proc,types etc)

## note
* unlike `compiles`, this does not do any analysis of routine body, hence is more efficient and solves issues related to `compiles` (eg when proc body has an error for input args but signature matches, compiles returns false, unlike `resolveSymbol` and `overloadExists`)
See also https://github.com/nim-lang/Nim/pull/11722#discussion_r317373944 where this came up /cc @krux02 

## note2
will allow doings something more targeted than this:
```nim
# in typetraits.nim
export system.`$`
```
which results in re-exporting all the `system.$` overloads instead of just `$(typedesc)`
(currently, it shows in https://nim-lang.github.io/Nim/typetraits.html#elementType.t%2Cuntyped:
```
Exports
$, $, $, $, $, $, $, $, $, $, $, $, $, $, $, $, $, $
```)