### PR TITLE
strutils.validIdentifier accurate wrt '_'

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2275,8 +2275,10 @@ proc validIdentifier*(s: string): bool {.noSideEffect,
     doAssert "abc_def08".validIdentifier
 
   if s.len > 0 and s[0] in IdentStartChars:
+    if s.len > 1 and '_' in [s[0], s[^1]]: return false
     for i in 1..s.len-1:
       if s[i] notin IdentChars: return false
+      if s[i] == '_' and s[i-1] == '_': return false
     return true
 
 

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -315,6 +315,12 @@ assert(' '.repeat(0) == "")
 assert(" ".repeat(0) == "")
 assert(spaces(0) == "")
 
+assert "_".validIdentifier
+assert not "x_".validIdentifier
+assert not "_x".validIdentifier
+assert "x_x".validIdentifier
+assert not "x__x".validIdentifier
+
 # bug #11369
 
 var num: int64 = -1


### PR DESCRIPTION
The compiler disagreed with the stdlib when it comes to validating a potential identifier name; now handling of `_`, `foo_`, `_foo`, and `foo__bar` match.

This probably needs a changelog entry, eh?