### PR TITLE
Return typeof(nil)

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -155,6 +155,7 @@ proc mapType(conf: ConfigRef; typ: PType): TCTypeKind =
   of tyNone, tyTyped: result = ctVoid
   of tyBool: result = ctBool
   of tyChar: result = ctChar
+  of tyNil: result = ctPtr
   of tySet: result = mapSetType(conf, typ)
   of tyOpenArray, tyArray, tyVarargs, tyUncheckedArray: result = ctArray
   of tyObject, tyTuple: result = ctStruct

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1600,6 +1600,8 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
     result = putToSeq("{}", indirect)
   of tyBool:
     result = putToSeq("false", indirect)
+  of tyNil:
+    result = putToSeq("null", indirect)
   of tyArray:
     let length = toInt(lengthOrd(p.config, t))
     let e = elemType(t)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1310,7 +1310,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
      tyNone, tyForward, tyFromExpr:
     result = t
   of tyNil:
-    if kind != skConst and kind != skParam: result = t
+    if kind != skConst and kind != skParam and kind != skResult: result = t
   of tyString, tyBool, tyChar, tyEnum, tyInt..tyUInt64, tyCString, tyPointer:
     result = nil
   of tyOrdinal:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -423,7 +423,7 @@ proc rangeToStr(n: PNode): string =
 
 const
   typeToStr: array[TTypeKind, string] = ["None", "bool", "char", "empty",
-    "Alias", "nil", "untyped", "typed", "typeDesc",
+    "Alias", "typeof(nil)", "untyped", "typed", "typeDesc",
     "GenericInvocation", "GenericBody", "GenericInst", "GenericParam",
     "distinct $1", "enum", "ordinal[$1]", "array[$1, $2]", "object", "tuple",
     "set[$1]", "range[$1]", "ptr ", "ref ", "var ", "seq[$1]", "proc",

--- a/tests/ccgbugs/tnil_type.nim
+++ b/tests/ccgbugs/tnil_type.nim
@@ -13,3 +13,6 @@ f3(typeof(nil))
 
 proc f4[T](_: T) = discard
 f4(nil)
+
+proc f5(): typeof(nil) = nil
+discard f5()


### PR DESCRIPTION
* Allow `typeof(nil)` as a return type.
* `typeToStr`: `$typeof(nil)` is now `"typeof(nil)"`, not `"nil"`.
  Especially makes sense e.g. when `typeof(nil)` is used inside proc type:
  ```nim
  proc foo(a: typeof(nil)) = discard
  echo typeof(foo)
  # Was: proc (a: nil){.noSideEffect, gcsafe, locks: 0.}
  # Now: proc (a: typeof(nil)){.noSideEffect, gcsafe, locks: 0.}
  ```