### PR TITLE
(disregard)

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3641,7 +3641,7 @@ when not defined(JS): #and not defined(nimscript):
         let minlen = min(x.len, y.len)
         result = int(nimCmpMem(x.cstring, y.cstring, minlen.csize))
         if result == 0:
-          result = x.len - y.len
+          result = cmp(x.len, y.len)
 
   when declared(newSeq):
     proc cstringArrayToSeq*(a: cstringArray, len: Natural): seq[string] =

--- a/tests/stdlib/tstring.nim
+++ b/tests/stdlib/tstring.nim
@@ -60,6 +60,7 @@ proc test_string_cmp() =
   let earth = "hello\0earth"
   let short = "hello\0"
   let hello = "hello"
+  let hello1 = "hello1"
   let goodbye = "goodbye"
 
   doAssert world == world
@@ -72,6 +73,7 @@ proc test_string_cmp() =
   doAssert cmp(world, earth) > 0
   doAssert cmp(world, short) > 0
   doAssert cmp(world, hello) > 0
+  doAssert cmp(hello1, hello) > 0
   doAssert cmp(world, goodbye) > 0
 
 test_string_slice()


### PR DESCRIPTION
It is still system-dependent, but shorter strings should come sooner.

See #8930 and #10559

(I have not checked whether any unit-tests need to be updated, but if so, they would only be updated to their values _before_ #10559 back in February.)