### PR TITLE
Fix #12119 - use os.setFilePermissions in tioselectors

### DIFF
--- a/tests/async/tioselectors.nim
+++ b/tests/async/tioselectors.nim
@@ -321,7 +321,7 @@ elif not defined(windows):
       discard selector.select(0)
 
       # chmod testDirectory to 0777
-      chmodPath(testDirectory, 0x1FF)
+      chmodPath(testDirectory, 0777)
       res = selector.select(0)
       doAssert(len(res) == 1)
       doAssert(len(selector.select(0)) == 0)
@@ -378,7 +378,7 @@ elif not defined(windows):
       doAssert(len(selector.select(0)) == 0)
 
       # chmod test file with 0666
-      chmodPath(testDirectory & "/testfile", 0x1B6)
+      chmodPath(testDirectory & "/testfile", 0666)
       doAssert(len(selector.select(0)) == 0)
 
       testfd = openWatch(testDirectory & "/testfile")

--- a/tests/async/tioselectors.nim
+++ b/tests/async/tioselectors.nim
@@ -260,8 +260,8 @@ elif not defined(windows):
       if err == -1:
         raiseOsError(osLastError())
 
-    proc chmodPath(name: string, mode: cint) =
-      let err = posix.chmod(cstring(name), Mode(mode))
+    proc chmodPath(name: string, mode: Mode) =
+      let err = posix.chmod(cstring(name), mode)
       if err == -1:
         raiseOsError(osLastError())
 
@@ -321,7 +321,7 @@ elif not defined(windows):
       discard selector.select(0)
 
       # chmod testDirectory to 0777
-      chmodPath(testDirectory, 0777)
+      chmodPath(testDirectory, Mode(0x1FF))
       res = selector.select(0)
       doAssert(len(res) == 1)
       doAssert(len(selector.select(0)) == 0)
@@ -378,7 +378,7 @@ elif not defined(windows):
       doAssert(len(selector.select(0)) == 0)
 
       # chmod test file with 0666
-      chmodPath(testDirectory & "/testfile", 0666)
+      chmodPath(testDirectory & "/testfile", Mode(0x1B6))
       doAssert(len(selector.select(0)) == 0)
 
       testfd = openWatch(testDirectory & "/testfile")

--- a/tests/async/tioselectors.nim
+++ b/tests/async/tioselectors.nim
@@ -260,11 +260,6 @@ elif not defined(windows):
       if err == -1:
         raiseOsError(osLastError())
 
-    proc chmodPath(name: string, mode: Mode) =
-      let err = posix.chmod(cstring(name), mode)
-      if err == -1:
-        raiseOsError(osLastError())
-
     proc renameFile(names: string, named: string) =
       let err = rename(cstring(names), cstring(named))
       if err == -1:
@@ -321,7 +316,8 @@ elif not defined(windows):
       discard selector.select(0)
 
       # chmod testDirectory to 0777
-      chmodPath(testDirectory, Mode(0x1FF))
+      os.setFilePermissions(testDirectory, {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec,
+        fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead})
       res = selector.select(0)
       doAssert(len(res) == 1)
       doAssert(len(selector.select(0)) == 0)
@@ -378,7 +374,8 @@ elif not defined(windows):
       doAssert(len(selector.select(0)) == 0)
 
       # chmod test file with 0666
-      chmodPath(testDirectory & "/testfile", Mode(0x1B6))
+      os.setFilePermissions(testDirectory & "/testfile", {fpUserWrite, fpUserRead, fpGroupWrite,
+        fpGroupRead, fpOthersWrite, fpOthersRead})
       doAssert(len(selector.select(0)) == 0)
 
       testfd = openWatch(testDirectory & "/testfile")


### PR DESCRIPTION
Fixes #12119 by using the commented CHMOD values as decimal values.