### PR TITLE
Add mathconstants to std lib

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -114,6 +114,7 @@ const
                                            ## after the decimal point
                                            ## for Nim's ``float`` type.
   RadPerDeg = PI / 180.0 ## Number of radians per degree
+include mathconstants  # File containing only mathematical constants.
 
 type
   FloatClass* = enum ## Describes the class a floating point value belongs to.

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -114,7 +114,6 @@ const
                                            ## after the decimal point
                                            ## for Nim's ``float`` type.
   RadPerDeg = PI / 180.0 ## Number of radians per degree
-include mathconstants  # File containing only mathematical constants.
 
 type
   FloatClass* = enum ## Describes the class a floating point value belongs to.

--- a/lib/pure/mathconstants.nim
+++ b/lib/pure/mathconstants.nim
@@ -1,0 +1,351 @@
+## Mathematical constants
+## ======================
+##
+## Mathematical numerical named standard constants useful for several disciplines
+## (math, physics, chemistry, biology, engineering, science, IT, hobby, etc),
+## Links to Wikipedia and The OnLine Enciclopedia of Integer Sequences provided.
+##
+## Sources
+## -------
+##
+## - http://wikipedia.org/wiki/List_of_mathematical_constants
+## - http://wikipedia.org/wiki/Astronomical_constant#Table_of_astronomical_constants
+## - http://wikipedia.org/wiki/Physical_constant#Table_of_physical_constants
+## - http://oeis.org (Foundation that *standarizes* mathematical constants).
+
+
+const
+  piSquared* = 9.8696044010893586188                            ## \
+  ## `Pi Squared constant <https://oeis.org/A002388>`_
+  gauss* = 0.83462684167407318628                               ## \
+  ## `Gauss <http://wikipedia.org/wiki/Gauss%27s_constant>`_
+  ## `constant <https://oeis.org/A014549>`_
+  eulerTotient* = 1.94359643682075920505                        ## \
+  ## `Euler's Totient <https://wikipedia.org/wiki/Euler%27s_totient_function>`_
+  ## `constant <https://oeis.org/A082695>`_
+  eulerMascheroni* = 0.57721566490153286060651209               ## \
+  ## `Euler–Mascheroni <http://wikipedia.org/wiki/Euler%E2%80%93Mascheroni_constant>`_
+  ## `constant <http://oeis.org/A001620>`_
+  meisselMertens* = 0.26149721284764278375542683                ## \
+  ## `Meissel-Mertens <http://wikipedia.org/wiki/Meissel%E2%80%93Mertens_constant>`_
+  ## `constant <https://oeis.org/A077761>`_
+  bernstein* = 0.28016949902386913303                           ## \
+  ## `Bernstein's <http://wikipedia.org/wiki/Bernstein%27s_constant>`_
+  ## `constant <http://oeis.org/A073001>`_
+  gaussKuzminWirsing* = 0.30366300289873265859744812            ## \
+  ## `Gauss–Kuzmin–Wirsing <http://wikipedia.org/w/index.php?title=Gauss%E2%80%93Kuzmin%E2%80%93Wirsing_constant>`_
+  ## `constant <https://oeis.org/A038517>`_
+  hafnerSarnakMcCurley* = 0.35323637185499598454351655          ## \
+  ## `Hafner–Sarnak–McCurley <https://wikipedia.org/wiki/Hafner%E2%80%93Sarnak%E2%80%93McCurley_constant>`_
+  ## `constant <https://oeis.org/A085849>`_
+  omega* = 0.56714329040978387299996866                         ## \
+  ## `Omega <http://wikipedia.org/wiki/Omega_constant>`_
+  ## `constant <https://oeis.org/A030178>`_
+  golombDickman* = 0.62432998854355087099293638                 ## \
+  ## `Golomb-Dickman <http://wikipedia.org/wiki/Golomb%E2%80%93Dickman_constant>`_
+  ## `constant <https://oeis.org/A084945>`_
+  cahen* = 0.6434105462                                         ## \
+  ## `Cahen's <http://wikipedia.org/wiki/Cahen%27s_constant>`_
+  ## `constant <https://oeis.org/A006279>`_
+  twinPrime* = 0.66016181584686957392781211                     ## \
+  ## `Twin Prime <http://wikipedia.org/wiki/Twin_prime>`_
+  ## `constant <https://oeis.org/A077800>`_
+  laplaceLimit* = 0.66274341934918158097474209                  ## \
+  ## `Laplace Limit <http://wikipedia.org/wiki/Laplace_limit>`_
+  ## `constant <https://oeis.org/A033259>`_
+  embreeTrefethen* = 0.70258                                    ## \
+  ## `Embree-Trefethen <http://wikipedia.org/wiki/Embree%E2%80%93Trefethen_constant>`_
+  ## `constant <https://oeis.org/A118288>`_
+  landauRamanujan* = 0.76422365358922066299069873               ## \
+  ## `Landau-Ramanujan <http://wikipedia.org/wiki/Landau%E2%80%93Ramanujan_constant>`_
+  ## `constant <https://oeis.org/A064533>`_
+  brun* = 0.87058838                                            ## \
+  ## `Brun's <https://wikipedia.org/wiki/Brun%27s_constant>`_
+  ## `constant <https://oeis.org/A065421>`_
+  catalan* = 0.91596559417721901505460351                       ## \
+  ## `Catalan's <https://wikipedia.org/wiki/Catalan%27s_constant>`_
+  ## `constant <https://oeis.org/A006752>`_
+  viswanath* = 1.13198824                                       ## \
+  ## `Viswanath's <https://wikipedia.org/wiki/Viswanath%27s_constant>`_
+  ## `constant <https://oeis.org/A078416>`_
+  apery* = 1.20205690315959428539973816                         ## \
+  ## `Apery's <https://wikipedia.org/wiki/Ap%C3%A9ry%27s_constant>`_
+  ## `constant <https://oeis.org/A002117>`_
+  conway* = 1.30357726903429639125709911                        ## \
+  ## `Conway's <http://wikipedia.org/wiki/Conway%27s_constant>`_
+  ## `constant <https://oeis.org/A014715>`_
+  mill* = 1.30637788386308069046861449                          ## \
+  ## `Mill's <https://wikipedia.org/wiki/Mills%27_constant>`_
+  ## `constant <https://oeis.org/A051021>`_
+  plastic* = 1.32471795724474602596090885                       ## \
+  ## `Plastic's <https://wikipedia.org/wiki/Plastic_constant>`_
+  ## `constant <https://oeis.org/A060006>`_
+  ramanujanSoldner* = 1.45136923488338105028396848              ## \
+  ## `Ramanujan-Soldner <https://wikipedia.org/wiki/Ramanujan%E2%80%93Soldner_constant>`_
+  ## `constant <https://oeis.org/A070769>`_
+  backhouse* = 1.45607494858268967139959535                     ## \
+  ## `Backhouse's <http://wikipedia.org/wiki/Backhouse%27s_constant>`_
+  ## `constant <https://oeis.org/A072508>`_
+  porter* = 1.4670780794                                        ## \
+  ## `Porter's <https://wikipedia.org/wiki/Porter%27s_constant>`_
+  ## `constant <https://oeis.org/A086237>`_
+  liebsSquareIce* = 1.5396007178                                ## \
+  ## `Lieb's square ice  <https://wikipedia.org/wiki/Lieb%27s_square_ice_constant>`_
+  ## `constant <https://oeis.org/A118273>`_
+  erdosBorwein* = 1.60669515241529176378330152                  ## \
+  ## `Erdos-Borwein <https://wikipedia.org/wiki/Erd%C5%91s%E2%80%93Borwein_constant>`_
+  ## `constant <https://oeis.org/A065442>`_
+  niven* = 1.70521114010536776428855145                         ## \
+  ## `Niven's <https://wikipedia.org/wiki/Niven%27s_constant>`_
+  ## `constant <https://oeis.org/A033150>`_
+  universalParabolic* = 2.29558714939263807403429804            ## \
+  ## `Universal Parabolic <https://wikipedia.org/wiki/Universal_parabolic_constant>`_
+  ## `constant <https://oeis.org/A103710>`_
+  feigenbaumReductionParameter* = 2.50290787509589282228390287  ## \
+  ## `Feigenbaum's Reduction Parameter <https://wikipedia.org/wiki/Feigenbaum_constants#The_second_constant>`_
+  ## `constant <https://oeis.org/A006891>`_
+  sierpinski* = 2.58498175957925321706589358                    ## \
+  ## `Sierpinski's <https://wikipedia.org/wiki/Sierpi%C5%84ski%27s_constant>`_
+  ## `constant <https://oeis.org/A062089>`_
+  khinchin* = 2.68545200106530644530971483                      ## \
+  ## `Khinchin's <https://wikipedia.org/wiki/Khinchin%27s_constant>`_
+  ## `constant <https://oeis.org/A002210>`_
+  fransenRobinson* = 2.80777024202851936522150118               ## \
+  ## `Fransen-Robinson <https://wikipedia.org/wiki/Frans%C3%A9n%E2%80%93Robinson_constant>`_
+  ## `constant <https://oeis.org/A058655>`_
+  levy* = 3.27582291872181115978768188                          ## \
+  ## `Levy's <https://wikipedia.org/wiki/L%C3%A9vy%27s_constant>`_
+  ## `constant <https://oeis.org/A086702>`_
+  reciprocalFibonacci* = 3.35988566624317755317201130           ## \
+  ## `Reciprocal Fibonacci <https://wikipedia.org/wiki/Reciprocal_Fibonacci_constant>`_
+  ## `constant <https://oeis.org/A079586>`_
+  feigenbaumBifurcationVelocity* = 4.66920160910299067185320382 ## \
+  ## `Feigenbaum's Bifurcation Velocity <https://wikipedia.org/wiki/Feigenbaum_constants#The_first_constant>`_
+  ## `constant <https://oeis.org/A006890>`_
+  buffon* = 0.63661977236758134307                              ## \
+  ## `Buffon's <https://oeis.org/wiki/Buffon%27s_constant>`_
+  ## `constant <https://oeis.org/A060294>`_
+  hermite* = 0.74048048969306104116                             ## \
+  ## `Hermite's constant <https://oeis.org/A093825>`_
+  wallis* = 2.09455148154232659148                              ## \
+  ## `Wallis constant <https://oeis.org/A007493>`_
+  favard* = 1.57079632679489661923                              ## \
+  ## `Favard constant <https://oeis.org/A069196>`_
+  sophomoreDream* = 0.78343051071213440705                      ## \
+  ## `Sophomore's Dream <http://wikipedia.org/wiki/Sophomore%27s_dream>`_
+  ## `constant <https://oeis.org/A083648>`_
+  lemniscate* = 2.62205755429211981046                          ## \
+  ## `Lemniscate <https://wikipedia.org/wiki/Lemniscate_constant>`_
+  ## `constant <https://oeis.org/A062539>`_
+  riemannZeta* = 1.64493406684822643647                         ## \
+  ## `Riemann Zeta constant <https://oeis.org/A013661>`_
+  liouville* = 0.110001000000000000000001                       ## \
+  ## `Liouville constant <https://oeis.org/A012245>`_
+  dottie* = 0.73908513321516064165                              ## \
+  ## `Dottie <https://wikipedia.org/wiki/Dottie_number>`_
+  ## `constant <https://oeis.org/A003957>`_
+  weierstrass* = 0.47494937998792065033                         ## \
+  ## `Weierstrass <https://wikipedia.org/wiki/Karl_Weierstrass#Mathematical_contributions>`_
+  ## `constant <https://oeis.org/A094692>`_
+  kasner* = 1.75793275661800453270                              ## \
+  ## `Kasner constant <https://oeis.org/A072449>`_
+  gelfond* = 23.1406926327792690057                             ## \
+  ## `Gelfond <https://wikipedia.org/wiki/Gelfond%27s_constant>`_
+  ## `constant <https://oeis.org/A039661>`_
+  lebesgue* = 1.43599112417691743235                            ## \
+  ## `Lebesgue <https://wikipedia.org/wiki/Lebesgue_constant_(interpolation)>`_
+  ## `constant <https://oeis.org/A226654>`_
+  goldenAngle* = 2.39996322972865332223                         ## \
+  ## `Golden Angle <https://wikipedia.org/wiki/Golden_angle>`_
+  ## `constant <https://oeis.org/A131988>`_
+  nielsenRamanujan* = 0.82246703342411321823                    ## \
+  ## `Nielsen Ramanujan constant <https://oeis.org/A072691>`_
+  gieseking* = 1.01494160640965362502                           ## \
+  ## `Gieseking <https://de.wikipedia.org/wiki/Gieseking-Konstante>`_
+  ## `constant <https://oeis.org/A143298>`_
+  reuleauxTriangle* = 0.98770039073605346013                    ## \
+  ## `Reuleaux Triangle <https://wikipedia.org/wiki/Reuleaux_triangle>`_
+  ## `constant <https://oeis.org/A066666>`_
+  spiralOfTheodorus* = 1.86002507922119030718                   ## \
+  ## `Spiral Of Theodorus <https://wikipedia.org/wiki/Spiral_of_Theodorus>`_
+  ## `constant <https://oeis.org/A226317>`_
+  blochLandau* = 0.54325896534297670695                         ## \
+  ## `Bloch-Landau <https://de.wikipedia.org/wiki/Satz_von_Bloch#Landausche_Konstante>`_
+  ## `constant <https://oeis.org/A081760>`_
+  fellerTornier* = 0.66131704946962233528                       ## \
+  ## `Feller-Tornier <https://wikipedia.org/wiki/Feller%E2%80%93Tornier_constant>`_
+  ## `constant <https://oeis.org/A065493>`_
+  champernowne* = 0.12345678910111213141                        ## \
+  ## `Champernowne <https://wikipedia.org/wiki/Champernowne_constant>`_
+  ## `constant <https://oeis.org/A033307>`_
+  gelfondSchneider* = 2.66514414269022518865                    ## \
+  ## `Gelfond-Schneider <https://wikipedia.org/wiki/Gelfond%E2%80%93Schneider_constant>`_
+  ## `constant <https://oeis.org/A007507>`_
+  khinchinLevy* = 1.18656911041562545282                        ## \
+  ## `Khinchin-Levy <https://wikipedia.org/wiki/Khinchin%E2%80%93L%C3%A9vy_constant>`_
+  ## `constant <https://oeis.org/A100199>`_
+  calabiTriangle* = 1.55138752454832039226                      ## \
+  ## `Calabi Triangle <https://wikipedia.org/wiki/Calabi_triangle>`_
+  ## `constant <https://oeis.org/A046095>`_
+  eulerGompertz* = 0.59634736232319407434                       ## \
+  ## `Euler-Gompertz <https://wikipedia.org/wiki/Gompertz_constant>`_
+  ## `constant <https://oeis.org/A073003>`_
+  vanDerPauw* = 4.53236014182719380962                          ## \
+  ## `Van Der Pauw <https://wikipedia.org/wiki/Van_der_Pauw_method>`_
+  ## `constant <https://oeis.org/A163973>`_
+  kneserMahler* = 1.38135644451849779337                        ## \
+  ## `Kneser-Mahler polynomial constant <https://oeis.org/A242710>`_
+  loch* = 0.97027011439203392574                                ## \
+  ## `Loch's <https://wikipedia.org/wiki/Lochs%27_theorem>`_
+  ## `constant <https://oeis.org/A086819>`_
+  hyperbolicTangent* = 0.76159415595576488811                   ## \
+  ## `Hyperbolic Tangent <https://wikipedia.org/wiki/Hyperbolic_function#Hyperbolic_tangent>`_
+  ## `constant <https://oeis.org/A073744>`_
+  baker* = 0.83564884826472105333                               ## \
+  ## `Baker constant <https://oeis.org/A113476>`_
+  baxterFourColoring* = 1.46099848620631835815                  ## \
+  ## `Baxter's Four Coloring constant <https://oeis.org/A224273>`_
+  alladiGrinstead* = 0.80939402054063913071                     ## \
+  ## `Alladi–Grinstead constant <https://oeis.org/A085291>`_
+  robbins* = 0.66170718226717623515                             ## \
+  ## `Robbins <https://wikipedia.org/wiki/Robbins_constant>`_
+  ## `constant <https://oeis.org/A073012>`_
+  connective* = 1.84775906502257351225                          ## \
+  ## `Connective <https://wikipedia.org/wiki/Connective_constant>`_
+  ## `constant <https://oeis.org/A179260>`_
+  vardi* = 1.26408473530530111307                               ## \
+  ## `Vardi constant <https://oeis.org/A076393>`_
+  flajoletRichmond* = 0.28878809508660242127                    ## \
+  ## `Flajolet-Richmond constant <https://oeis.org/A048651>`_
+  grothendieck* = 1.78221397819136911177                        ## \
+  ## `Grothendieck constant <https://oeis.org/A088367>`_
+  murata* = 2.82641999706759157554                              ## \
+  ## `Murata constant <https://oeis.org/A065485>`_
+  smarandache* = 1.09317045919549089396                         ## \
+  ## `Smarandache <https://de.wikipedia.org/wiki/Smarandache-Konstanten>`_
+  ## `constant <https://oeis.org/A048799>`_
+  komornikLoreti* = 1.78723165018296593301                      ## \
+  ## `Komornik-Loreti <https://wikipedia.org/wiki/Komornik%E2%80%93Loreti_constant>`_
+  ## `constant <https://oeis.org/A055060>`_
+  madelung* = 5.97798681217834912266                            ## \
+  ## `Madelung constant <https://oeis.org/A086055>`_
+  artin* = 0.37395581361920228805                               ## \
+  ## `Artin's conjecture on primitive roots <https://wikipedia.org/wiki/Artin%27s_conjecture_on_primitive_roots>`_
+  ## `constant <https://oeis.org/A005596>`_
+  mRB* = 0.18785964246206712024                                 ## \
+  ## `MRB <https://wikipedia.org/wiki/MRB_constant>`_
+  ## `constant <https://oeis.org/A037077>`_
+  hallMontgomery* = 0.17150049314153606586                      ## \
+  ## `Hall-Montgomery constant <https://oeis.org/A143301>`_
+  somosQuadraticRecurrence* = 1.66168794963359412129            ## \
+  ## `Somos Quadratic Recurrence <https://wikipedia.org/wiki/Somos%27_quadratic_recurrence_constant>`_
+  ## `constant <https://oeis.org/A065481>`_
+  steiner* = 1.44466786100976613365                             ## \
+  ## `Steiner constant <https://oeis.org/A073229>`_
+  plouffe* = 0.15915494309189533576                             ## \
+  ## `Plouffe's constant <https://oeis.org/A086201>`_
+  gaussLemniscate* = 1.85407467730137191843                     ## \
+  ## `Gauss-Lemniscate constant <https://oeis.org/A093341>`_
+  foiasAlpha* = 1.18745235112650105459                          ## \
+  ## `Foias Alpha <https://wikipedia.org/wiki/Foias_constant>`_
+  ## `constant <https://oeis.org/A085848>`_
+  foiasBeta* = 2.29316628741186103150                           ## \
+  ## `Foias Beta <https://wikipedia.org/wiki/Foias_constant>`_
+  ## `constant <https://oeis.org/A085846>`_
+  gohSchmutz* = 1.11786415118994497314                          ## \
+  ## `Goh-Schmutz constant <https://oeis.org/A143300>`_
+  pell* = 0.58057755820489240229                                ## \
+  ## `Pell constant <https://oeis.org/A141848>`_
+  carefree* = 0.70444220099916559273                            ## \
+  ## `Carefree constant <https://oeis.org/A065463>`_
+  fibonacciFactorial* = 1.22674201072035324441                  ## \
+  ## `Fibonacci-Factorial constant <https://oeis.org/A062073>`_
+  doubleFactorial* = 3.05940740534257614453                     ## \
+  ## `Double Factorial <https://wikipedia.org/wiki/Double_factorial>`_
+  ## `constant <https://oeis.org/A143280>`_
+  volumeOfReuleauxTetrahedron* = 0.42215773311582662702         ## \
+  ## `Volume of Reuleaux Tetrahedron <https://wikipedia.org/wiki/Reuleaux_tetrahedron>`_
+  ## `constant <https://oeis.org/A102888>`_
+  raabe* = 0.91893853320467274178                               ## \
+  ## `Raabe's <https://wikipedia.org/wiki/Gamma_function#Raabe's_formula>`_
+  ## `constant <https://oeis.org/A075700>`_
+  silverman* = 1.78657645936592246345                           ## \
+  ## `Silverman constant <https://oeis.org/A093827>`_
+  keplerBouwkamp* = 0.11494204485329620070                      ## \
+  ## `Kepler-Bouwkamp <https://wikipedia.org/wiki/Kepler%E2%80%93Bouwkamp_constant>`_
+  ## `constant <https://oeis.org/A085365>`_
+  prouhetThueMorse* = 0.41245403364010759778                    ## \
+  ## `Prouhet-Thue-Morse <https://wikipedia.org/wiki/Prouhet%E2%80%93Thue%E2%80%93Morse_constant>`_
+  ## `constant <https://oeis.org/A014571>`_
+  heathBrownMoroz* = 0.00131764115485317810                     ## \
+  ## `Heath-Brown–Moroz <https://wikipedia.org/wiki/Heath-Brown%E2%80%93Moroz_constant>`_
+  ## `constant <https://oeis.org/A118228>`_
+  kempnerReihe* = 23.1034479094205416160                        ## \
+  ## `Kempner-Reihe <https://de.wikipedia.org/wiki/Kempner-Reihe>`_
+  ## `constant <https://oeis.org/A082839>`_
+  boisReymond* = 0.19452804946532511361                         ## \
+  ## `Bois-Reymond <https://es.wikipedia.org/wiki/Constante_Du_Bois_Reymond>`_
+  ## `constant <https://oeis.org/A062546>`_
+  luroth* = 0.78853056591150896106                              ## \
+  ## `Luroth constant <https://oeis.org/A085361>`_
+  stephens* = 0.57595996889294543964                            ## \
+  ## `Stephens <https://wikipedia.org/wiki/Euler_product#Notable_constants>`_
+  ## `constant <https://oeis.org/A065478>`_
+  taniguchi* = 0.67823449191739197803                           ## \
+  ## `Taniguchi <https://wikipedia.org/wiki/Euler_product#Notable_constants>`_
+  ## `constant <https://oeis.org/A175639>`_
+  tutteBeraha* = 3.24697960371746706105                         ## \
+  ## `Tutte–Beraha constant (Silver Root) <https://oeis.org/A116425>`_
+  areaOfFordCircle* = 0.87228404106562797617                    ## \
+  ## `Area of Ford Circle constant <https://wikipedia.org/wiki/Ford_circle>`_
+  cubicRecurrence* = 1.15636268433226971685                     ## \
+  ## `Cubic Recurrence constant <https://oeis.org/A123852>`_
+  masserGramain* = 6.58088599101792097085                       ## \
+  ## `Masser–Gramain constant <https://oeis.org/A086057>`_
+  gibbs* = 1.85193705198246617036                               ## \
+  ## `Gibbs constant <https://oeis.org/A036792>`_
+  copelandErdos* = 0.23571113171923293137                       ## \
+  ## `Copeland–Erdos <https://wikipedia.org/wiki/Copeland%E2%80%93Erd%C5%91s_constant>`_
+  ## `constant <https://oeis.org/A033308>`_
+  carlsonLevin* = 1.77245385090551602729                        ## \
+  ## `Carlson–Levin constant <https://oeis.org/A002161>`_
+  stronglyCarefree* = 0.28674742843447873410                    ## \
+  ## `Strongly Carefree constant <https://oeis.org/A065473>`_
+  magicAngle* = 0.955316618124509278163                         ## \
+  ## `Magic Angle <https://wikipedia.org/wiki/Magic_angle>`_
+  ## `constant <https://oeis.org/A195696>`_
+  polya* = 0.34053732955099914282                               ## \
+  ## `Polya <https://wikipedia.org/wiki/Random_walk>`_
+  ## `constant <https://oeis.org/A086230>`_
+  wright* = 1.9287800                                           ## \
+  ## `Wright constant <https://oeis.org/A086238>`_
+  chebyshev* = 0.59017029950804811302                           ## \
+  ## `Chebyshev <https://wikipedia.org/wiki/Conformal_radius#The_Fekete.2C_Chebyshev_and_modified_Chebyshev_constants>`_
+  ## `constant <https://oeis.org/A249205>`_
+  bronzeRatio* = 3.30277563773199464655                         ## \
+  ## `Bronze Ratio constant <https://oeis.org/A098316>`_
+  deVicciTesseract* = 1.00743475688427937609                    ## \
+  ## `DeVicci's tesseract <https://wikipedia.org/wiki/Prince_Rupert%27s_cube#Generalizations>`_
+  ## `constant <https://oeis.org/A243309>`_
+  plouffeGamma* = 0.14758361765043327417                        ## \
+  ## `Plouffe's Gamma (Bailey–Borwein–Plouffe) <https://wikipedia.org/wiki/Bailey%E2%80%93Borwein%E2%80%93Plouffe_formula#The_BBP_formula_for_%CF%80>`_
+  ## `constant <https://oeis.org/A086203>`_
+  sarnak* = 0.72364840229820000940                              ## \
+  ## `Sarnak constant <https://oeis.org/A065476>`_
+  renyiParking* = 0.74759792025341143517                        ## \
+  ## `Renyi's Parking constant <https://oeis.org/A050996>`_
+  ## `constant <>`_
+  paris* = 1.09864196439415648573                               ## \
+  ## `Paris constant <https://oeis.org/A105415>`_
+  glaisherKinkelin* = 1.28242712910062263687                    ## \
+  ## `Glaisher–Kinkelin <https://wikipedia.org/wiki/Glaisher%E2%80%93Kinkelin_constant>`_
+  ## `constant <https://oeis.org/A074962>`_
+  trott* = 0.10841015122311136151                               ## \
+  ## `Trott constant <https://oeis.org/A039662>`_
+  tribonacci* = 1.83928675521416113255                          ## \
+  ## `Tribonacci constant <https://oeis.org/A058265>`_
+  ioachimescu* = 0.53964549119041318711                         ## \
+  ## `Ioachimescu constant <https://oeis.org/A059750>`_
+  goldenSpiral* = 1.35845627418298843520                        ## \
+  ## `Golden Spiral <https://wikipedia.org/wiki/Golden_spiral>`_
+  ## `constant <https://oeis.org/A212224>`_


### PR DESCRIPTION
- Improve Mathematical constants of `math` module.
- All static `const` with documentation and links to Wikipedia and oeis.org, NEP1 Ok.

Mathematical constants are values that are never going to change and can be static on std lib,
and [the `math` module already have a few,](https://github.com/nim-lang/Nim/blob/devel/lib/pure/math.nim#L101-L116) so I try to improve them, with Docs and Links.

:slightly_smiling_face: 
