### PR TITLE
#12141 Define SDL lib name for OpenBSD and FreeBSD

### DIFF
--- a/tests/niminaction/Chapter8/sdl/sdl.nim
+++ b/tests/niminaction/Chapter8/sdl/sdl.nim
@@ -4,6 +4,12 @@ elif defined(Linux):
   const libName* = "libSDL2.so"
 elif defined(MacOsX):
   const libName* = "libSDL2.dylib"
+elif defined(openbsd):
+  const libName* = "libSDL.so.8.0"
+elif defined(freebsd):
+  const libName* = "libSDL.so"
+else:
+  {.error: "SDL library name not set for this platform".}
 
 type
   SdlWindow = object

--- a/tests/niminaction/Chapter8/sdl/sdl.nim
+++ b/tests/niminaction/Chapter8/sdl/sdl.nim
@@ -1,13 +1,11 @@
 when defined(Windows):
   const libName* = "SDL2.dll"
-elif defined(Linux):
+elif defined(Linux) or defined(freebsd):
   const libName* = "libSDL2.so"
 elif defined(MacOsX):
   const libName* = "libSDL2.dylib"
 elif defined(openbsd):
-  const libName* = "libSDL.so.8.0"
-elif defined(freebsd):
-  const libName* = "libSDL.so"
+  const libName* = "libSDL2.so.0.6"
 else:
   {.error: "SDL library name not set for this platform".}
 


### PR DESCRIPTION
Partly fixes #12141 - define SDL lib name for OpenBSD and FreeBSD. Other architectures now get a compile error.