### PR TITLE
fix #12130 ; improve naming scheme in fakePackageName

### DIFF
--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -39,13 +39,11 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
     if parents <= 0: break
 
 proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
-  # foo/../bar becomes foo7_7bar
-  result = relativeTo(path, conf.projectPath, '/').string.multiReplace(
-    {"/": "7", "..": "_", "7": "77", "_": "__", ":": "8", "8": "88"})
+  # foo/../bar becomes foo@..@bar
+  result = relativeTo(path, conf.projectPath, '/').string.multiReplace({"/": "@", "@": "@@"})
 
 proc demanglePackageName*(path: string): string =
-  result = path.multiReplace(
-    {"88": "8", "8": ":", "77": "7", "__": "_", "_7": "../", "7": "/"})
+  result = path.multiReplace({"@@": "@", "@": "/"})
 
 proc withPackageName*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
   let x = getPackageName(conf, path.string)

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -332,8 +332,7 @@ proc generatedFile(test: TTest, target: TTarget): string =
   else:
     let (_, name, _) = test.name.splitFile
     let ext = targetToExt[target]
-    result = nimcacheDir(test.name, test.options, target) /
-              name.replace("_", "__").changeFileExt(ext)
+    result = nimcacheDir(test.name, test.options, target) / name.changeFileExt(ext)
 
 proc needsCodegenCheck(spec: TSpec): bool =
   result = spec.maxCodeSize > 0 or spec.ccodeCheck.len > 0


### PR DESCRIPTION
* `7` `8` are more common (especially in tests) than `@` so `@` seems more appropriate mangling character
* should work on windows as had been mentioned in https://github.com/nim-lang/Nim/pull/8614#issuecomment-413031385 
* should fix https://github.com/nim-lang/Nim/issues/12130 although I wasn't able to reproduce that issue on OSX (might affect linux only)
* /cc @qqtop @juancarlospaco does that fix the problem for you?

```
../bam@bax/cab.nim
=>
..@bam@@bax@cab.nim.c

../bam/bax/cab.nim
=>
..@bam@bax@cab.nim.c
```
the leading `..` could be avoided but IMO is more readable and should be legal anyway

## note
this PR does not try to make the `fakePackageName` a valid nim identifier (shouldn't be needed IIUC); note that this also wasn't the case before this PR, eg:
`nimcache/_7bar.baz7gaz77.nim.c` doesn't give a valid identifier (for `../bar.baz/gaz7.nim`); ditto with starting with `_7` or containing `__`)