### PR TITLE
fix range.getType crash

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -242,7 +242,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyRange:
     result = newNodeIT(nkBracketExpr, if t.n.isNil: info else: t.n.info, t)
     result.add atomicType("range", mRange)
-    if inst:
+    if inst and t.n.len == 2:
       let rng = newNodeX(nkInfix)
       rng.add newIdentNode(getIdent(cache, ".."), info)
       rng.add t.n.sons[0].copyTree
@@ -250,7 +250,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
       result.add rng
     else:
       result.add t.n.sons[0].copyTree
-      result.add t.n.sons[1].copyTree
+      if t.n.len > 1:
+        result.add t.n.sons[1].copyTree
   of tyPointer: result = atomicType("pointer", mPointer)
   of tyString: result = atomicType("string", mString)
   of tyCString: result = atomicType("cstring", mCstring)

--- a/tests/macros/tmacrotypes.nim
+++ b/tests/macros/tmacrotypes.nim
@@ -3,12 +3,14 @@ discard """
 void; ntyVoid; void; void
 int; ntyInt; int; int
 proc (); ntyProc; proc[void]; proc ()
-voidProc; ntyProc; proc[void]; proc ()'''
+voidProc; ntyProc; proc[void]; proc ()
+typeDesc[range[1 .. 5]]; ntyTypeDesc; typeDesc[range[1, 5]]; typeDesc[range[1 .. 5]]
+typeDesc[range]; ntyTypeDesc; typeDesc[range[T]]; typeDesc[range]'''
 """
 
 import macros
 
-macro checkType(ex: typed; expected: string): untyped =
+macro checkType(ex: typed): untyped =
   echo ex.getTypeInst.repr, "; ", ex.typeKind, "; ", ex.getType.repr, "; ", ex.getTypeImpl.repr
 
 macro checkProcType(fn: typed): untyped =
@@ -19,9 +21,9 @@ macro checkProcType(fn: typed): untyped =
 proc voidProc = echo "hello"
 proc intProc(a: int, b: float): int {.checkProcType.} = 10
 
-checkType(voidProc(), "void")
-checkType(intProc(10, 20.0), "int")
-checkType(voidProc, "procTy")
+checkType(voidProc())
+checkType(intProc(10, 20.0))
+checkType(voidProc)
 checkProcType(voidProc)
 
 # bug #10548
@@ -68,3 +70,6 @@ macro foobar(arg: typed): untyped =
 var x: Vec2f
 
 foobar(x)
+
+checkType(range[1..5])
+checkType(range)


### PR DESCRIPTION
```nim
import macros
macro t(): untyped =
  getType(range) # crash / segfault
t()
```