### PR TITLE
error for indexing atom NimNode kinds

### DIFF
--- a/tests/errmsgs/tnnodeadd.nim
+++ b/tests/errmsgs/tnnodeadd.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "cannot add to node kind: nnkInt8Lit"
+  line: 7
+"""
+import macros
+macro t(x: untyped): untyped =
+  x.add(newEmptyNode())
+t(38'i8)

--- a/tests/errmsgs/tnnodeindex.nim
+++ b/tests/errmsgs/tnnodeindex.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "index 5 not in 0 .. 2"
+  line: 7
+"""
+import macros
+macro t(x: untyped): untyped =
+  result = x[5]
+t([1, 2, 3])

--- a/tests/errmsgs/tnnodeindexkind.nim
+++ b/tests/errmsgs/tnnodeindexkind.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "cannot set child of node kind: nnkStrLit"
+  line: 7
+"""
+import macros
+macro t(x: untyped): untyped =
+  x[0] = newEmptyNode()
+t("abc")


### PR DESCRIPTION
Indexing atom NimNode now gives a stacktrace/avoids segfault.
```nim
import macros
macro foo(x: untyped): untyped =
  x[0] = newEmptyNode()
# -d:release
foo(38'i8) # 'sons' is not accessible using discriminant 'kind' of type 'TNode' [FieldError]
# -d:danger
foo(38'i8) # segfault
foo("abc") # index 0 not in 0 .. 2
```