### PR TITLE
count 64 bits at a time instead of 8

### DIFF
--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -30,11 +30,12 @@ proc countBits64(n: uint64): int {.compilerproc, inline.} =
   result = ((v * 0x0101010101010101'u64) shr 56'u64).int
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
-  var j = -1
+  var i = 0
   when defined(x86) or defined(amd64):
-    for i in countup(0, len - 8, 8):
+    while i < len - 8:
       inc(result, countBits64((cast[ptr uint64](s[i].unsafeAddr))[]))
-      j = i + 7
+      inc(i, 8)
 
-  for i in (j + 1) ..< len:
+  while i < len:
     inc(result, countBits32(uint32(s[i])))
+    inc(i, 1)

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -31,7 +31,7 @@ proc countBits64(n: uint64): int {.compilerproc, inline.} =
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
   var j = -1
-  when defined(x86):
+  when defined(x86) or defined(amd64):
     for i in countup(0, len - 8, 8):
       inc(result, countBits64((cast[ptr uint64](s[i].unsafeAddr))[]))
       j = i + 7

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -21,7 +21,7 @@ proc countBits32(n: uint32): int {.compilerproc.} =
   v = (v and 0x33333333) + ((v shr 2) and 0x33333333)
   result = (((v + (v shr 4) and 0xF0F0F0F) * 0x1010101) shr 24).int
 
-proc countBits64(n: uint64): int {.compilerproc.} =
+proc countBits64(n: uint64): int {.compilerproc, inline.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint64(n)
   v = v - ((v shr 1'u64) and 0x5555555555555555'u64)
@@ -30,6 +30,10 @@ proc countBits64(n: uint64): int {.compilerproc.} =
   result = ((v * 0x0101010101010101'u64) shr 56'u64).int
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
-  for i in 0..<len:
-    if likely(s[i] == 0): continue
+  var j = -1
+  for i in countup(0, len - 8, 8):
+    inc(result, countBits64((cast[ptr uint64](s[i].unsafeAddr))[]))
+    j = i + 7
+
+  for i in (j+1)..<len:
     inc(result, countBits32(uint32(s[i])))

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -31,9 +31,10 @@ proc countBits64(n: uint64): int {.compilerproc, inline.} =
 
 proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
   var j = -1
-  for i in countup(0, len - 8, 8):
-    inc(result, countBits64((cast[ptr uint64](s[i].unsafeAddr))[]))
-    j = i + 7
+  when defined(x86):
+    for i in countup(0, len - 8, 8):
+      inc(result, countBits64((cast[ptr uint64](s[i].unsafeAddr))[]))
+      j = i + 7
 
   for i in (j + 1) ..< len:
     inc(result, countBits32(uint32(s[i])))

--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -35,5 +35,5 @@ proc cardSet(s: NimSet, len: int): int {.compilerproc, inline.} =
     inc(result, countBits64((cast[ptr uint64](s[i].unsafeAddr))[]))
     j = i + 7
 
-  for i in (j+1)..<len:
+  for i in (j + 1) ..< len:
     inc(result, countBits32(uint32(s[i])))


### PR DESCRIPTION
I'm not sure if `unsafeAddr` is OK here or if there's another way. Processing 64 bits at a time makes the following code 8X faster for the first timing and 2X faster for the 2nd.

```Nim
import times


var s : set[uint16]
var t0 = cpuTime()

for i in 0'u16..uint16.high.uint16:
  s.incl(i)
  doAssert s.card == i.int + 1
echo cpuTime() - t0


s = {2'u16, 12, 32}
t0 = cpuTime()
for i in 0'u16..uint16.high.uint16:
  doAssert s.card == 3
echo cpuTime() - t0
```