### PR TITLE
Fixed c filenames mangling

### DIFF
--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -39,11 +39,11 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
     if parents <= 0: break
 
 proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
-  # foo/../bar becomes foo@..@bar
-  result = relativeTo(path, conf.projectPath, '/').string.multiReplace({"/": "@", "@": "@@"})
+  # foo-#head/../bar becomes @foo-@hhead@s..@sbar
+  result = "@" & relativeTo(path, conf.projectPath, '/').string.multiReplace({"/": "@s", "#": "@h", "@": "@@"})
 
 proc demanglePackageName*(path: string): string =
-  result = path.multiReplace({"@@": "@", "@": "/"})
+  result = path[1 .. ^1].multiReplace({"@@": "@", "@h": "#", "@s": "/"})
 
 proc withPackageName*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
   let x = getPackageName(conf, path.string)

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -332,7 +332,7 @@ proc generatedFile(test: TTest, target: TTarget): string =
   else:
     let (_, name, _) = test.name.splitFile
     let ext = targetToExt[target]
-    result = nimcacheDir(test.name, test.options, target) / name.changeFileExt(ext)
+    result = nimcacheDir(test.name, test.options, target) / "@" & name.changeFileExt(ext)
 
 proc needsCodegenCheck(spec: TSpec): bool =
   result = spec.maxCodeSize > 0 or spec.ccodeCheck.len > 0


### PR DESCRIPTION
- Prepend filenames with `@` to avoid leading `.`
- Mangle `/` to `@s`, `#` to `@h`.