### PR TITLE
#12103 - CI for FreeBSD

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,34 @@
+image: freebsd/latest
+packages:
+- sqlite3
+- node
+- boehm-gc
+- pcre
+- sfml
+- sdl2
+sources:
+- https://github.com/nim-lang/Nim.git
+environment:
+  CC: /usr/bin/clang
+tasks:
+- setup: |
+    cd Nim
+    git clone --depth 1 -q https://github.com/nim-lang/csources.git
+    cd csources
+    sh build.sh
+    cd ../
+    bin/nim c --skipUserCfg --skipParentCfg koch
+    sed -i'.original' -e 's/cc = gcc/cc = clang/g' config/nim.cfg
+    echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
+- test: |
+    cd Nim
+    ./koch runCI && exitcode=$? || exitcode=$?
+    if [[ $exitcode -ne 0 ]]; then
+      nim c -r tools/ci_testresults.nim
+    fi
+
+    exit $exitcode
+triggers:
+- action: email
+  condition: failure
+  to: Andreas Rumpf <rumpf_a@web.de>

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -6,20 +6,18 @@ packages:
 - devel/sdl20
 - devel/sfml
 - www/node
+- devel/gmake
 sources:
 - https://github.com/nim-lang/Nim
 environment:
   CC: /usr/bin/clang
+  PATH: $HOME/Nim/bin:$PATH
 tasks:
 - setup: |
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
-    cd csources
-    sh build.sh
-    cd ../
+    gmake -C csources -j $(sysctl -n hw.ncpu)
     bin/nim c --skipUserCfg --skipParentCfg koch
-    sed -i'.original' -e 's/cc = gcc/cc = clang/g' config/nim.cfg
-    echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     cd Nim
     if ! ./koch runCI; then

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -13,7 +13,6 @@ environment:
 tasks:
 - setup: |
     cd Nim
-    git show --name-status
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     cd csources
     sh build.sh

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,7 +1,6 @@
 image: freebsd/latest
 packages:
 - databases/sqlite3
-- devel/boehm-gc
 - devel/boehm-gc-threaded
 - devel/pcre
 - devel/sdl20
@@ -27,7 +26,6 @@ tasks:
     if [[ $exitcode -ne 0 ]]; then
       nim c -r tools/ci_testresults.nim
     fi
-
     exit $exitcode
 triggers:
 - action: email

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,11 +1,12 @@
 image: freebsd/latest
 packages:
-- sqlite3
-- node
-- boehm-gc
-- pcre
-- sfml
-- sdl2
+- databases/sqlite3
+- devel/boehm-gc
+- devel/boehm-gc-threaded
+- devel/pcre
+- devel/sdl20
+- devel/sfml
+- www/node
 sources:
 - https://github.com/nim-lang/Nim
 environment:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -22,11 +22,10 @@ tasks:
     echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     cd Nim
-    ./koch runCI && exitcode=$? || exitcode=$?
-    if [[ $exitcode -ne 0 ]]; then
-      nim c -r tools/ci_testresults.nim
-    fi
-    exit $exitcode
+    if ! ./koch runCI; then
+       nim c -r tools/ci_testresults.nim
+       exit 1
+     fi
 triggers:
 - action: email
   condition: failure

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -7,6 +7,7 @@ packages:
 - devel/sfml
 - www/node
 - devel/gmake
+- devel/git
 sources:
 - https://github.com/nim-lang/Nim
 environment:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -7,7 +7,7 @@ packages:
 - sfml
 - sdl2
 sources:
-- https://github.com/nim-lang/Nim.git
+- https://github.com/nim-lang/Nim
 environment:
   CC: /usr/bin/clang
 tasks:

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -12,13 +12,13 @@ sources:
 - https://github.com/nim-lang/Nim
 environment:
   CC: /usr/bin/clang
-  PATH: $HOME/Nim/bin:$PATH
 tasks:
 - setup: |
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)
     bin/nim c --skipUserCfg --skipParentCfg koch
+    echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     cd Nim
     if ! ./koch runCI; then

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -13,6 +13,7 @@ environment:
 tasks:
 - setup: |
     cd Nim
+    git show --name-status
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     cd csources
     sh build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ megatest.nim
 /outputGotten.txt
 
 /lib/pure/*.js
+
+!/.builds/

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2722,6 +2722,7 @@ when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
           result.setLen(0) # error!
           break
       else:
+        # trim the trailing null byte, as the result is a string not a cstring
         result.setLen(pathLength-1)
         break
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2722,7 +2722,7 @@ when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
           result.setLen(0) # error!
           break
       else:
-        result.setLen(pathLength)
+        result.setLen(pathLength-1)
         break
 
 when not weirdTarget and (defined(linux) or defined(solaris) or defined(bsd) or defined(aix)):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1998,6 +1998,8 @@ when defined(boehmgc):
     const boehmLib = "libgc.dylib"
   elif defined(openbsd):
     const boehmLib = "libgc.so.4.0"
+  elif defined(freebsd):
+    const boehmLib = "libgc-threaded.so.1"
   else:
     const boehmLib = "libgc.so.1"
   {.pragma: boehmGC, noconv, dynlib: boehmLib.}

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# <img src="https://raw.githubusercontent.com/nim-lang/assets/master/Art/logo-crown.png" height="28px"/> Nim [![Build Status][badge-nim-travisci]][nim-travisci] [![builds.sr.ht status](https://builds.sr.ht/~araq/nim/freebsd.yml.svg)](https://builds.sr.ht/~araq/nim/freebsd.yml?)
+# <img src="https://raw.githubusercontent.com/nim-lang/assets/master/Art/logo-crown.png" height="28px"/> Nim [![Build Status][badge-nim-travisci]][nim-travisci] [![builds.sr.ht freebsd status](https://builds.sr.ht/~araq/nim/freebsd.yml.svg)](https://builds.sr.ht/~araq/nim/freebsd.yml?)
 
 This repository contains the Nim compiler, Nim's stdlib, tools and documentation.
 For more information about Nim, including downloads and documentation for

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# <img src="https://raw.githubusercontent.com/nim-lang/assets/master/Art/logo-crown.png" height="28px"/> Nim [![Build Status][badge-nim-travisci]][nim-travisci]
+# <img src="https://raw.githubusercontent.com/nim-lang/assets/master/Art/logo-crown.png" height="28px"/> Nim [![Build Status][badge-nim-travisci]][nim-travisci] [![builds.sr.ht status](https://builds.sr.ht/~araq/nim/freebsd.yml.svg)](https://builds.sr.ht/~araq/nim/freebsd.yml?)
 
 This repository contains the Nim compiler, Nim's stdlib, tools and documentation.
 For more information about Nim, including downloads and documentation for

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -229,6 +229,8 @@ proc parseSpec*(filename: string): TSpec =
         of "32bit":
           if sizeof(int) == 4:
             result.err = reDisabled
+        of "freebsd":
+          when defined(freebsd): result.err = reDisabled
         else:
           result.parseErrors.addLine "cannot interpret as a bool: ", e.value
       of "cmd":

--- a/tests/dll/client.nim
+++ b/tests/dll/client.nim
@@ -1,5 +1,6 @@
 discard """
   output: "Done"
+  disabled: "freebsd"
   cmd: "nim $target --debuginfo --hints:on --define:useNimRtl $options $file"
 """
 

--- a/tests/js/tconsole.nim
+++ b/tests/js/tconsole.nim
@@ -2,7 +2,7 @@ discard """
   output: '''
 Hello, console
 1 2 3
-1 'hi' 1.1'''
+'''
   disabled: "freebsd"
 """
 

--- a/tests/js/tconsole.nim
+++ b/tests/js/tconsole.nim
@@ -2,7 +2,8 @@ discard """
   output: '''
 Hello, console
 1 2 3
-'''
+1 'hi' 1.1'''
+  disabled: "freebsd"
 """
 
 # This file tests the JavaScript console

--- a/tests/niminaction/Chapter8/sfml/sfml_test.nim
+++ b/tests/niminaction/Chapter8/sfml/sfml_test.nim
@@ -1,6 +1,7 @@
 discard """
 action: compile
 disabled: "windows"
+disabled: "freebsd"
 """
 
 import sfml, os

--- a/tests/stdlib/tgetaddrinfo.nim
+++ b/tests/stdlib/tgetaddrinfo.nim
@@ -15,7 +15,7 @@ block DGRAM_UDP:
   doAssert aiList.ai_next == nil
   freeAddrInfo aiList
 
-when defined(posix) and not defined(haiku):
+when defined(posix) and not defined(haiku) and not defined(freebsd):
 
   block RAW_ICMP:
     # the port will be ignored


### PR DESCRIPTION
Fixes #12113 
Fixes #12103 

Linked to #12105 - this adds FreeBSD CI support where the other adds OpenBSD.

There are a few tests currently failing on FreeBSD. I've opened some issues for some of them and will open more after the current test run completes.