### PR TITLE
no commas for empty `importcpp: "foo(@)"` params

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -394,11 +394,14 @@ proc genPatternCall(p: BProc; ri: PNode; pat: string; typ: PType): Rope =
   while i < pat.len:
     case pat[i]
     of '@':
-      if j < ri.len:
-        result.add genOtherArg(p, ri, j, typ)
-        for k in j+1 ..< ri.len:
-          result.add(~", ")
-          result.add genOtherArg(p, ri, k, typ)
+      var first = true
+      for k in j ..< ri.len:
+        let arg = genOtherArg(p, ri, k, typ)
+        if arg.len > 0:
+          if not first:
+            result.add(~", ")
+          first = false
+          result.add arg
       inc i
     of '#':
       if i+1 < pat.len and pat[i+1] in {'+', '@'}:

--- a/tests/cpp/tempty_generic_obj.nim
+++ b/tests/cpp/tempty_generic_obj.nim
@@ -8,7 +8,7 @@ import typetraits
 
 # bug #4625
 type
-  Vector {.importcpp: "std::vector<'0 >", header: "vector".} [T] = object
+  Vector[T] {.importcpp: "std::vector<'0 >", header: "vector".} = object
 
 proc initVector[T](): Vector[T] {.importcpp: "'0(@)", header: "vector", constructor.}
 
@@ -24,7 +24,7 @@ vf.doSomething() # Nim uses doSomething[int] here in C++
 # Alternative definition:
 # https://github.com/nim-lang/Nim/issues/7653
 
-type VectorAlt* {.importcpp: "std::vector", header: "<vector>", nodecl.} [T] = object
+type VectorAlt*[T] {.importcpp: "std::vector", header: "<vector>", nodecl.} = object
 proc mkVector*[T]: VectorAlt[T] {.importcpp: "std::vector<'*0>()", header: "<vector>", constructor, nodecl.}
 
 proc foo(): VectorAlt[cint] =
@@ -36,3 +36,10 @@ proc bar(): VectorAlt[cstring] =
 var x = foo()
 var y = bar()
 
+proc init[T; Self: Vector[T]](_: typedesc[Self], n: csize): Vector[T]
+  {.importcpp: "std::vector<'*0>(@)", header: "<vector>", constructor, nodecl.}
+proc size[T](x: Vector[T]): csize
+  {.importcpp: "#.size()", header: "<vector>", nodecl.}
+
+var z = Vector[int16].init(32)
+assert z.size == 32


### PR DESCRIPTION
`importcpp` references types of real params, so extra `typedesc` params are needed to inject types not in the params/return type of the function. This PR is a QOL improvement for this workaround.

`proc foo[T0; T1](PT0: typedesc[T0], PT1: typedesc[T1], x, y, z, w: csize)`
`foo<'1, '2>(@)` produces `foo<T0, T1>(, , x, y, z, w)`
workaround: `foo<'1, '2>(###, #, #, #)` but param modifications require changes in two places + more verbose.
I'm not aware of any valid usage, but `foo<'1, '2>(#, #, #, #, #, #)` can be used for the old behavior.

This is how the JS backend works too.
