### PR TITLE
fix #12200, wrong behaviour of CountTable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,18 +25,19 @@
   piece of code to your project:
 
 ```nim
-
 type
   Rune16* = distinct int16
-
 ```
 
-- `exportc` now uses C instead of C++ mangling with `nim cpp`, matching behavior of `importc`, see #10578
-  Use the new `exportcpp` to mangle as C++ when using `nim cpp`.
+- `exportc` now uses C instead of C++ mangling with `nim cpp`, matching behavior
+  of `importc`, see #10578. Use the new `exportcpp` to mangle as C++ when using
+  `nim cpp`.
+
 
 ### Breaking changes in the compiler
 
-- A bug allowing `int` to be implicitly converted to range types of smaller size (e.g `range[0'i8..10'i8]`) has been fixed.
+- A bug allowing `int` to be implicitly converted to range types of smaller size
+  (e.g `range[0'i8..10'i8]`) has been fixed.
 
 
 ## Library additions
@@ -67,13 +68,19 @@ type
 
 - Consistent error handling of two `exec` overloads. (#10967)
 
+- Fixed bug in `CountTable` which, in some special cases, might cause erroneous
+  zero values for keys with non-zero values.
+
+
 ## Language additions
 
-- Inline iterators returning `lent T` types are now supported, similarly to iterators returning `var T`:
+- Inline iterators returning `lent T` types are now supported, similarly to
+  iterators returning `var T`:
 ```nim
 iterator myitems[T](x: openarray[T]): lent T
 iterator mypairs[T](x: openarray[T]): tuple[idx: int, val: lent T]
 ```
+
 
 ## Language changes
 

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2172,9 +2172,11 @@ proc rawGet[A](t: CountTable[A], key: A): int =
   if t.data.len == 0:
     return -1
   var h: Hash = hash(key) and high(t.data) # start with real hash value
-  while t.data[h].val != 0:
+  let fh = h
+  while true:
     if t.data[h].key == key: return h
     h = nextTry(h, high(t.data))
+    if h == fh: break
   result = -1 - h # < 0 => MISSING; insert idx = -1 - result
 
 template ctget(t, key, default: untyped): untyped =


### PR DESCRIPTION
We cannot use `while t.data[h].val != 0:` in `rawGet` because zero can be a valid value for an existing key.