### PR TITLE
Add -d:androidNDK to fix echo on Android NDK builds.

### DIFF
--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -284,14 +284,14 @@ The MinGW-w64 toolchain can be installed as follows::
 Cross compilation for Android
 =============================
 
-There are two ways to compile for Android. Terminal programs (Termux) and with NDK (Android Native Development Kit).
+There are two ways to compile for Android: terminal programs (Termux) and with the NDK (Android Native Development Kit).
 
-First one is to treat Android as a simple linux and use https://wiki.termux.com to connect and run the nim compiler directly on android as if it was linux. These programs are console only apps
+First one is to treat Android as a simple linux and use `Termux <https://wiki.termux.com>`_ to connect and run the nim compiler directly on android as if it was linux. These programs are console only apps
 that can’t be distributed in the Play Store.
 
 Use regular ``nim c`` inside termux to make Android terminal apps.
 
-Android apps are written in Java, to use Nim inside an android app you need a small Java shim that calls out to a native library written in Nim using the NDK (https://developer.android.com/ndk). You can also use native-acitivty to have the Java shim be auto generated for you.
+Android apps are written in Java, to use Nim inside an Android app you need a small Java stub that calls out to a native library written in Nim using the `NDK <https://developer.android.com/ndk>`_. You can also use `native-acitivty <https://developer.android.com/ndk/samples/sample_na>`_ to have the Java stub be auto generated for you.
 
 Use ``nim c -c --cpu:arm --os:android -d:androidNDK`` to generate the C source files you need to include in your Android Studio project. Add the generated C files to CMake build script. Then do the final compile with Android Studio which uses gradle to call CMake to compile the project.
 

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -281,6 +281,20 @@ The MinGW-w64 toolchain can be installed as follows::
   CentOS: yum install mingw32-gcc | mingw64-gcc - requires EPEL
   OSX: brew install mingw-w64
 
+Cross compilation for Android
+=============================
+
+There are two ways to compile for Android. Terminal programs (Termux) and with NDK (Android Native Development Kit).
+
+First one is to treat Android as a simple linux and use https://wiki.termux.com to connect and run the nim compiler directly on android as if it was linux. These programs are console only apps
+that can’t be distributed in the Play Store.
+
+Use regular ``nim c`` inside termux to make Android terminal apps.
+
+Android apps are written in Java, to use Nim inside an android app you need a small Java shim that calls out to a native library written in Nim using the NDK (https://developer.android.com/ndk). You can also use native-acitivty to have the Java shim be auto generated for you.
+
+Use ``nim c -c --cpu:arm --os:android -d:androidNDK`` to generate the C source files you need to include in your Android Studio project. Add the generated C files to CMake build script. Then do the final compile with Android Studio which uses gradle to call CMake to compile the project.
+
 Cross compilation for Nintendo Switch
 =====================================
 

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -113,8 +113,8 @@ proc c_fprintf(f: File, frmt: cstring): cint {.
   importc: "fprintf", header: "<stdio.h>", varargs, discardable.}
 
 ## When running nim in android app stdout goes no where, so echo gets ignored
-## To redreict echo to the android logcat use -d:echoToAndroidLog
-when defined(echoToAndroidLog):
+## To redreict echo to the android logcat use -d:androidNDK
+when defined(androidNDK):
   const ANDROID_LOG_VERBOSE = 2.cint
   proc android_log_print(prio: cint, tag: cstring, fmt: cstring): cint
     {.importc: "__android_log_print", header: "<android/log.h>", varargs, discardable.}
@@ -592,7 +592,7 @@ when declared(stdout):
     initSysLock echoLock
 
   proc echoBinSafe(args: openArray[string]) {.compilerproc.} =
-    when defined(echoToAndroidLog):
+    when defined(androidNDK):
       var s = ""
       for arg in args:
         s.add arg


### PR DESCRIPTION
When running nim in android app stdout goes no where, so echo gets ignored.
To redirect echo to the android logcat I added the `-d:echoToAndroidLog` parameter.

I am not sure how to override echo correctly on android. But this worked for me.