### PR TITLE
fix #12202 parseHtml now correctly handles <script> jscode </script>

### DIFF
--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -1909,7 +1909,19 @@ proc untilElementEnd(x: var XmlParser, result: XmlNode,
   if result.htmlTag in SingleTags:
     if x.kind != xmlElementEnd or cmpIgnoreCase(x.elemName, result.tag) != 0:
       return
+
+  # if result.htmlTag in {tagScript}:
+  #   while true:
+  #     case x.kind
+  #     of xmlElementEnd:
+  #       case result.htmlTag
+  #       of tagScript:
+  #       else: next(x)
+  #     else: next(x)
+  #   return
+
   while true:
+    echo ("untilElementEnd", x.kind)
     case x.kind
     of xmlElementStart, xmlElementOpen:
       case result.htmlTag
@@ -1957,9 +1969,14 @@ proc untilElementEnd(x: var XmlParser, result: XmlNode,
       result.addNode(parse(x, errors))
 
 proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
+  echo ("parse.1", x.kind, x.elemName, x.a, x.b, x.c)
   case x.kind
   of xmlComment:
     result = newComment(x.rawData)
+    next(x)
+  of xmlScriptLike:
+    echo ("parse.2", x.rawData)
+    result = newText(x.rawData) # CHECKME
     next(x)
   of xmlCharData, xmlWhitespace:
     result = newText(x.rawData)
@@ -1981,6 +1998,8 @@ proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
     next(x)
     result.attrs = newStringTable()
     while true:
+      echo ("parse.3", x.kind)
+
       case x.kind
       of xmlAttribute:
         result.attrs[x.rawData] = x.rawData2
@@ -1988,11 +2007,16 @@ proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
       of xmlElementClose:
         next(x)
         break
+      of xmlScriptLike:
+        result.addNode(newText(x.rawData))
+        next(x)
+        break
       of xmlError:
         adderr(errorMsg(x))
         next(x)
         break
       else:
+        echo ("parse.4")
         adderr(errorMsg(x, "'>' expected"))
         next(x)
         break

--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -1909,19 +1909,7 @@ proc untilElementEnd(x: var XmlParser, result: XmlNode,
   if result.htmlTag in SingleTags:
     if x.kind != xmlElementEnd or cmpIgnoreCase(x.elemName, result.tag) != 0:
       return
-
-  # if result.htmlTag in {tagScript}:
-  #   while true:
-  #     case x.kind
-  #     of xmlElementEnd:
-  #       case result.htmlTag
-  #       of tagScript:
-  #       else: next(x)
-  #     else: next(x)
-  #   return
-
   while true:
-    echo ("untilElementEnd", x.kind)
     case x.kind
     of xmlElementStart, xmlElementOpen:
       case result.htmlTag
@@ -1969,14 +1957,12 @@ proc untilElementEnd(x: var XmlParser, result: XmlNode,
       result.addNode(parse(x, errors))
 
 proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
-  echo ("parse.1", x.kind, x.elemName, x.a, x.b, x.c)
   case x.kind
   of xmlComment:
     result = newComment(x.rawData)
     next(x)
   of xmlScriptLike:
-    echo ("parse.2", x.rawData)
-    result = newText(x.rawData) # CHECKME
+    adderr(errorMsg(x, "unexpected script like tag: " & x.elemName))
     next(x)
   of xmlCharData, xmlWhitespace:
     result = newText(x.rawData)
@@ -1998,8 +1984,6 @@ proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
     next(x)
     result.attrs = newStringTable()
     while true:
-      echo ("parse.3", x.kind)
-
       case x.kind
       of xmlAttribute:
         result.attrs[x.rawData] = x.rawData2
@@ -2016,7 +2000,6 @@ proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
         next(x)
         break
       else:
-        echo ("parse.4")
         adderr(errorMsg(x, "'>' expected"))
         next(x)
         break

--- a/lib/pure/lexbase.nim
+++ b/lib/pure/lexbase.nim
@@ -34,7 +34,7 @@ type
     sentinel: int
     lineStart: int            # index of last line start in buffer
     offsetBase*: int          # use ``offsetBase + bufpos`` to get the offset
-    refillChars: set[char]
+    refillChars*: set[char]
 
 proc close*(L: var BaseLexer) =
   ## closes the base lexer. This closes `L`'s associated stream too.

--- a/lib/pure/xmlparser.nim
+++ b/lib/pure/xmlparser.nim
@@ -82,7 +82,6 @@ proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
         next(x)
         break
       else:
-        echo ("xmlparser.parse.1")
         errors.add(errorMsg(x, "'>' expected"))
         next(x)
         break

--- a/lib/pure/xmlparser.nim
+++ b/lib/pure/xmlparser.nim
@@ -82,6 +82,7 @@ proc parse(x: var XmlParser, errors: var seq[string]): XmlNode =
         next(x)
         break
       else:
+        echo ("xmlparser.parse.1")
         errors.add(errorMsg(x, "'>' expected"))
         next(x)
         break

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -558,7 +558,7 @@ proc noWhitespace(n: XmlNode): bool =
     if n[i].kind in {xnText, xnEntity}: return true
 
 proc add*(result: var string, n: XmlNode, indent = 0, indWidth = 2,
-          addNewLines=true) =
+          addNewLines=true, doEscape = true) =
   ## Adds the textual representation of `n` to string `result`.
   runnableExamples:
     var
@@ -570,10 +570,18 @@ proc add*(result: var string, n: XmlNode, indent = 0, indWidth = 2,
     s.add(a)
     s.add(b)
     assert s == "<!-- my comment --><firstTag />my text"
+  proc addEscaped2(result: var string, s: string) =
+    if not doEscape:
+      result.add s
+    else:
+      addEscaped(result, s)
 
   proc addEscapedAttr(result: var string, s: string) =
     # `addEscaped` alternative with less escaped characters.
     # Only to be used for escaping attribute values enclosed in double quotes!
+    if not doEscape:
+      result.add s
+      return
     for c in items(s):
       case c
       of '<': result.add("&lt;")
@@ -583,6 +591,8 @@ proc add*(result: var string, n: XmlNode, indent = 0, indWidth = 2,
       else: result.add(c)
 
   if n == nil: return
+  # echo ("xmltree.add", n.k)
+  # result.add("{" & $n.k & "}")
   case n.k
   of xnElement:
     result.add('<')
@@ -602,24 +612,24 @@ proc add*(result: var string, n: XmlNode, indent = 0, indWidth = 2,
           # because this would be wrong. For example: ``a<b>b</b>`` is
           # different from ``a <b>b</b>``.
           for i in 0..n.len-1:
-            result.add(n[i], indent+indWidth, indWidth, addNewLines)
+            result.add(n[i], indent+indWidth, indWidth, addNewLines, doEscape)
         else:
           for i in 0..n.len-1:
             result.addIndent(indent+indWidth, addNewLines)
-            result.add(n[i], indent+indWidth, indWidth, addNewLines)
+            result.add(n[i], indent+indWidth, indWidth, addNewLines, doEscape)
           result.addIndent(indent, addNewLines)
       else:
-        result.add(n[0], indent+indWidth, indWidth, addNewLines)
+        result.add(n[0], indent+indWidth, indWidth, addNewLines, doEscape)
       result.add("</")
       result.add(n.fTag)
       result.add(">")
     else:
       result.add(" />")
   of xnText:
-    result.addEscaped(n.fText)
+    result.addEscaped2(n.fText) # TODO: why escaped? ditto w xnComment
   of xnComment:
     result.add("<!-- ")
-    result.addEscaped(n.fText)
+    result.addEscaped2(n.fText)
     result.add(" -->")
   of xnCData:
     result.add("<![CDATA[")

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -591,8 +591,6 @@ proc add*(result: var string, n: XmlNode, indent = 0, indWidth = 2,
       else: result.add(c)
 
   if n == nil: return
-  # echo ("xmltree.add", n.k)
-  # result.add("{" & $n.k & "}")
   case n.k
   of xnElement:
     result.add('<')
@@ -626,7 +624,7 @@ proc add*(result: var string, n: XmlNode, indent = 0, indWidth = 2,
     else:
       result.add(" />")
   of xnText:
-    result.addEscaped2(n.fText) # TODO: why escaped? ditto w xnComment
+    result.addEscaped2(n.fText)
   of xnComment:
     result.add("<!-- ")
     result.addEscaped2(n.fText)


### PR DESCRIPTION
* fixes #12202

parseHtml now can deal with <script> jscode </script>, making `parseHtml` usable for parsing / web scraping, in a way similar to python's `BeautifulSoup`

* for now just `<script>` is handled; `<style>` would be easy to add in a future PR based on this, ditto with other tags that do not contain html inside the opening/closing tags

* added `openConsumeAll`, a greedy version of `open` that simplifies code by avoiding having to do any buffer handling; buffer optimization doesn't make sense in the case of `parseHtml` since the cost of `parseHtml` dwarfs the cost of `readAll`, and the output size is larger than the input size; not having to deal with buffer management greatly simplifies the code

* added an option to skip escaping when rendering the output of `parseHtml`, so that user can show the parse output in a more human friendly way that matches output of python's `BeautifulSoup`

## correctness note
this PR simply tries to find a `</script>` closing tag; this may have corner cases (eg if that's inside a js string) however these are probably rare if not adversarial; in any case this is a clear improvement over current situation and future PR's can improve correctness

## performance note
one of my motivations for this PR was that `BeautifulSoup` was correct but painfully slow, while parseHtml was fast but incorrect / unusable in presence of script tags which easily occur in the wild; 
`parseHtml` shows a 30X speedup for the example from https://github.com/nim-lang/Nim/issues/12202
* python3 `BeatifulSoup`: 15 seconds
* parseHtml: 0.5 seconds (excluding compile time; using -d:danger; after applying this PR)
