### PR TITLE
importjs symbol

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,10 +75,13 @@ iterator myitems[T](x: openarray[T]): lent T
 iterator mypairs[T](x: openarray[T]): tuple[idx: int, val: lent T]
 ```
 
+- `importjs` can now be used to import for ffi on the JS target
+
 ## Language changes
 
 - `uint64` is now finally a regular ordinal type. This means `high(uint64)` compiles
   and yields the correct value.
+
 
 
 ### Tool changes

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -19,7 +19,7 @@ const
   LastCallConv* = wNoconv
 
 const
-  declPragmas = {wImportc, wImportObjC, wImportCpp, wExportc, wExportCpp,
+  declPragmas = {wImportc, wImportObjC, wImportCpp, wImportJs, wExportc, wExportCpp,
     wExportNims, wExtern, wDeprecated, wNodecl, wError, wUsed}
     ## common pragmas for declarations, to a good approximation
   procPragmas* = declPragmas + {FirstCallConv..LastCallConv,
@@ -157,6 +157,12 @@ proc processImportCpp(c: PContext; s: PSym, extname: string, info: TLineInfo) =
     let m = s.getModule()
     incl(m.flags, sfCompileToCpp)
   incl c.config.globalOptions, optMixedMode
+
+proc processImportJs(c: PContext; s: PSym, pattern: string, info: TLineInfo) =
+  setExternName(c, s, pattern, info)
+  incl(s.flags, sfImportc)
+  if c.config.cmd != cmdCompileToJS:
+    localError(c.config, info, "importjs pragma only supported when compiling to js.")
 
 proc processImportObjC(c: PContext; s: PSym, extname: string, info: TLineInfo) =
   setExternName(c, s, extname, info)
@@ -803,6 +809,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         else: invalidPragma(c, it)
       of wImportCpp:
         processImportCpp(c, sym, getOptionalStr(c, it, "$1"), it.info)
+      of wImportJs:
+        processImportJs(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wImportObjC:
         processImportObjC(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wAlign:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -805,20 +805,20 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         processImportCpp(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wImportJs:
         if c.config.cmd != cmdCompileToJS:
-          localError(c.config, info, "importjs pragma only supported when compiling to js.")
-        var strArg: NimNode = nil
-        if n.kind in nkPragmaCallKinds:
-          strArg = n[1]
+          localError(c.config, it.info, "importjs pragma only supported when compiling to js.")
+        var strArg: PNode = nil
+        if it.kind in nkPragmaCallKinds:
+          strArg = it[1]
           if strArg.kind notin {nkStrLit..nkTripleStrLit}:
-            localError(c.config, n.info, errStringLiteralExpected)
+            localError(c.config, it.info, errStringLiteralExpected)
         incl(sym.flags, sfImportc)
         incl(sym.flags, sfInfixCall)
         if strArg == nil:
-          if s.kind in skProcKinds:
-            message(c.config, info, warnDeprecated, "procedure import should have an import pattern")
-          setExternName(c, s, s.name.s, info)
+          if sym.kind in skProcKinds:
+            message(c.config, n.info, warnDeprecated, "procedure import should have an import pattern")
+          setExternName(c, sym, sym.name.s, it.info)
         else:
-          setExternName(c, s, strArg.strVal, info)
+          setExternName(c, sym, strArg.strVal, it.info)
       of wImportObjC:
         processImportObjC(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wAlign:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -161,6 +161,7 @@ proc processImportCpp(c: PContext; s: PSym, extname: string, info: TLineInfo) =
 proc processImportJs(c: PContext; s: PSym, pattern: string, info: TLineInfo) =
   setExternName(c, s, pattern, info)
   incl(s.flags, sfImportc)
+  incl(s.flags, sfInfixCall)
   if c.config.cmd != cmdCompileToJS:
     localError(c.config, info, "importjs pragma only supported when compiling to js.")
 

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -42,7 +42,7 @@ type
     wImmediate, wConstructor, wDestructor, wDelegator, wOverride,
     wImportCpp, wImportObjC,
     wImportCompilerProc,
-    wImportc, wExportc, wExportCpp, wExportNims, wIncompleteStruct, wRequiresInit,
+    wImportc, wImportJs, wExportc, wExportCpp, wExportNims, wIncompleteStruct, wRequiresInit,
     wAlign, wNodecl, wPure, wSideEffect, wHeader,
     wNoSideEffect, wGcSafe, wNoreturn, wMerge, wLib, wDynlib,
     wCompilerProc, wCore, wProcVar, wBase, wUsed,
@@ -129,7 +129,7 @@ const
 
     "immediate", "constructor", "destructor", "delegator", "override",
     "importcpp", "importobjc",
-    "importcompilerproc", "importc", "exportc", "exportcpp", "exportnims",
+    "importcompilerproc", "importc", "importjs", "exportc", "exportcpp", "exportnims",
     "incompletestruct",
     "requiresinit", "align", "nodecl", "pure", "sideeffect",
     "header", "nosideeffect", "gcsafe", "noreturn", "merge", "lib", "dynlib",

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6596,6 +6596,14 @@ this to work. The conditional symbol ``cpp`` is defined when the compiler
 emits C++ code.
 
 
+ImportJs pragma
+---------------
+
+Similar to the `importcpp pragma for C++ <#foreign-function-interface-importc-pragma>`_,
+the ``importjs`` pragma can be used to import Javascript methods or
+symbols in general. The generated code then uses the Javascript method
+calling syntax: ``obj.method(arg)``.
+
 Namespaces
 ~~~~~~~~~~
 
@@ -6993,13 +7001,14 @@ spelled*:
 .. code-block::
   proc printf(formatstr: cstring) {.header: "<stdio.h>", importc: "printf", varargs.}
 
-Note that this pragma is somewhat of a misnomer: Other backends do provide
-the same feature under the same name. Also, if one is interfacing with C++
-the `ImportCpp pragma <manual.html#implementation-specific-pragmas-importcpp-pragma>`_ and
-interfacing with Objective-C the `ImportObjC pragma
-<manual.html#implementation-specific-pragmas-importobjc-pragma>`_ can be used.
+Note that this pragma has been abused in the past to also work in the
+js backand for js objects and functions. : Other backends do provide
+the same feature under the same name. Also, when the target language
+is not set to C, other pragmas are available:
 
-The string literal passed to ``importc`` can be a format string:
+ * `importcpp <manual.html#implementation-specific-pragmas-importcpp-pragma>`_
+ * `importobjc <manual.html#implementation-specific-pragmas-importobjc-pragma>`_
+ * `importjs <manul.html#implementation-specific-pragmas-importjs-pragma>`_
 
 .. code-block:: Nim
   proc p(s: cstring) {.importc: "prefix$1".}

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -292,8 +292,8 @@ macro `.()`*(obj: JsObject,
       {.importcpp: `importString`, gensym, discardable.}
     helper(`obj`)
   for idx in 0 ..< args.len:
-    let paramName = newIdentNode(!("param" & $idx))
-    result[0][3].add newIdentDefs(paramName, newIdentNode(!"JsObject"))
+    let paramName = newIdentNode("param" & $idx)
+    result[0][3].add newIdentDefs(paramName, newIdentNode("JsObject"))
     result[1].add args[idx].copyNimTree
 
 macro `.`*[K: cstring, V](obj: JsAssoc[K, V],
@@ -425,7 +425,7 @@ macro `{}`*(typ: typedesc, xs: varargs[untyped]): auto =
   ##  # This generates roughly the same JavaScript as:
   ##  {.emit: "var obj = {a: 1, k: "foo", d: 42};".}
   ##
-  let a = !"a"
+  let a = ident"a"
   var body = quote do:
     var `a` {.noinit.}: `typ`
     {.emit: "`a` = {};".}
@@ -488,7 +488,7 @@ macro bindMethod*(procedure: typed): auto =
     error("Argument has to be a proc or a symbol corresponding to a proc.")
   var
     rawProc = if procedure.kind == nnkSym:
-        getImpl(procedure.symbol)
+        getImpl(procedure)
       else:
         procedure
     args = rawProc[3]

--- a/tests/js/tjsffi.nim
+++ b/tests/js/tjsffi.nim
@@ -32,7 +32,7 @@ true
 '''
 """
 
-import macros, jsffi, jsconsole
+import jsffi, jsconsole
 
 # Tests for JsObject
 # Test JsObject []= and []
@@ -283,7 +283,7 @@ block:
 
 block:
   {.emit: "function jsProc(n) { return n; }" .}
-  proc jsProc(x: int32): JsObject {.importjs: "jsProc".}
+  proc jsProc(x: int32): JsObject {.importjs: "jsProc(#)".}
 
   proc test() =
     var x = jsProc(1)
@@ -295,8 +295,6 @@ block:
     console.log x
 
   test()
-
-import macros
 
 block:
   {.emit:
@@ -310,7 +308,7 @@ block:
   type Event = object
     name: cstring
 
-  proc on(event: cstring, handler: proc) {.importjs: "on".}
+  proc on(event: cstring, handler: proc) {.importjs: "on(#,#)".}
   var jslib {.importjs: "jslib", nodecl.}: JsObject
 
   on("click") do (e: Event):

--- a/tests/js/tjsffi_old.nim
+++ b/tests/js/tjsffi_old.nim
@@ -32,6 +32,9 @@ true
 '''
 """
 
+## same as tjsffi, but this test uses the old names: importc and
+## importcpp. This test is for backwards compatibility.
+
 import macros, jsffi, jsconsole
 
 # Tests for JsObject
@@ -127,7 +130,7 @@ block:
 block:
   proc test(): bool =
     {. emit: "var comparison = {a: 22, b: 'test'};" .}
-    var comparison {. importjs, nodecl .}: JsObject
+    var comparison {. importc, nodecl .}: JsObject
     let obj = newJsObject()
     obj.a = 22
     obj.b = "test".cstring
@@ -138,7 +141,7 @@ block:
 block:
   proc test(): bool =
     {. emit: "var comparison = {a: 22, b: 'test'};" .}
-    var comparison {. importjs, nodecl .}: JsObject
+    var comparison {. importc, nodecl .}: JsObject
     let obj = JsObject{ a: 22, b: "test".cstring }
     obj.a == comparison.a and obj.b == comparison.b
   echo test()
@@ -233,7 +236,7 @@ block:
 block:
   proc test(): bool =
     {. emit: "var comparison = {a: 22, b: 55};" .}
-    var comparison {. importjs, nodecl .}: JsAssoc[cstring, int]
+    var comparison {. importcpp, nodecl .}: JsAssoc[cstring, int]
     let obj = newJsAssoc[cstring, int]()
     obj.a = 22
     obj.b = 55
@@ -244,7 +247,7 @@ block:
 block:
   proc test(): bool =
     {. emit: "var comparison = {a: 22, b: 55};" .}
-    var comparison {. importjs, nodecl .}: JsAssoc[cstring, int]
+    var comparison {. importcpp, nodecl .}: JsAssoc[cstring, int]
     let obj = JsAssoc[cstring, int]{ a: 22, b: 55 }
     var working = true
     working = working and
@@ -264,7 +267,7 @@ block:
     b: cstring
   proc test(): bool =
     {. emit: "var comparison = {a: 1};" .}
-    var comparison {. importjs, nodecl .}: TestObject
+    var comparison {. importc, nodecl .}: TestObject
     let obj = TestObject{ a: 1 }
     obj == comparison
   echo test()
@@ -283,7 +286,7 @@ block:
 
 block:
   {.emit: "function jsProc(n) { return n; }" .}
-  proc jsProc(x: int32): JsObject {.importjs: "jsProc".}
+  proc jsProc(x: int32): JsObject {.importc: "jsProc".}
 
   proc test() =
     var x = jsProc(1)
@@ -310,8 +313,8 @@ block:
   type Event = object
     name: cstring
 
-  proc on(event: cstring, handler: proc) {.importjs: "on".}
-  var jslib {.importjs: "jslib", nodecl.}: JsObject
+  proc on(event: cstring, handler: proc) {.importc: "on".}
+  var jslib {.importc: "jslib", nodecl.}: JsObject
 
   on("click") do (e: Event):
     console.log e


### PR DESCRIPTION
Introduce the importjs pragma. This does the same think that importcpp does when used in js, but with the difference that importjs isn't a misnomer.