### PR TITLE
Fix issue with long wait for passed timer [bugfix]

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -198,6 +198,9 @@ proc processTimers(
     dec count
     didSomeWork = true
 
+  # Ensure that an awaited timer that's been completed is promptly handled
+  if didSomeWork: return some(0)
+
   # Return the number of miliseconds in which the next timer will expire.
   if p.timers.len == 0: return
 

--- a/tests/async/t12221.nim
+++ b/tests/async/t12221.nim
@@ -1,0 +1,37 @@
+import asyncdispatch, os, times
+
+proc doubleSleep(hardSleep: int) {.async.} =
+  await sleepAsync(100)
+  sleep(hardSleep)
+
+template assertTime(target, timeTook: float): untyped {.dirty.} =
+  assert(timeTook*1000 > target - 5, "Took too short, should've taken " &
+    $target & "ms, but took " & $(timeTook*1000) & "ms")
+  assert(timeTook*1000 < target + 5, "Took too long, should've taken " &
+    $target & "ms, but took " & $(timeTook*1000) & "ms")
+
+var start: float
+
+start = epochTime()
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40)
+assertTime(150, epochTime() - start)
+
+start = epochTime()
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(60)
+assertTime(160, epochTime() - start)
+
+start = epochTime()
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40) and sleepAsync(200)
+assertTime(200, epochTime() - start)
+
+start = epochTime()
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(60) and sleepAsync(200)
+assertTime(200, epochTime() - start)
+
+start = epochTime()
+waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(40)) or sleepAsync(700)
+assertTime(150, epochTime() - start)
+
+start = epochTime()
+waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(60)) or sleepAsync(700)
+assertTime(160, epochTime() - start)

--- a/tests/async/t12221.nim
+++ b/tests/async/t12221.nim
@@ -1,37 +1,37 @@
 import asyncdispatch, os, times
 
 proc doubleSleep(hardSleep: int) {.async.} =
-  await sleepAsync(200)
+  await sleepAsync(100)
   sleep(hardSleep)
 
 template assertTime(target, timeTook: float): untyped {.dirty.} =
-  assert(timeTook*1000 > target - 10, "Took too short, should've taken " &
+  assert(timeTook*1000 > target - 50, "Took too short, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
-  assert(timeTook*1000 < target + 10, "Took too long, should've taken " &
+  assert(timeTook*1000 < target + 50, "Took too long, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
 
 var start: float
 
 start = epochTime()
-waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(80)
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40)
+assertTime(150, epochTime() - start)
+
+start = epochTime()
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(100)
+assertTime(200, epochTime() - start)
+
+start = epochTime()
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40) and sleepAsync(300)
 assertTime(300, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(120)
-assertTime(320, epochTime() - start)
-
-start = epochTime()
-waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(80) and sleepAsync(400)
-assertTime(400, epochTime() - start)
-
-start = epochTime()
-waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(120) and sleepAsync(400)
-assertTime(400, epochTime() - start)
-
-start = epochTime()
-waitFor (sleepAsync(100) and sleepAsync(300) and doubleSleep(80)) or sleepAsync(1400)
+waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(100) and sleepAsync(300)
 assertTime(300, epochTime() - start)
 
 start = epochTime()
-waitFor (sleepAsync(100) and sleepAsync(300) and doubleSleep(120)) or sleepAsync(1400)
-assertTime(320, epochTime() - start)
+waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(40)) or sleepAsync(700)
+assertTime(150, epochTime() - start)
+
+start = epochTime()
+waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(100)) or sleepAsync(700)
+assertTime(200, epochTime() - start)

--- a/tests/async/t12221.nim
+++ b/tests/async/t12221.nim
@@ -5,33 +5,48 @@ proc doubleSleep(hardSleep: int) {.async.} =
   sleep(hardSleep)
 
 template assertTime(target, timeTook: float): untyped {.dirty.} =
-  assert(timeTook*1000 > target - 150, "Took too short, should've taken " &
+  assert(timeTook*1000 > target - 1000, "Took too short, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
-  assert(timeTook*1000 < target + 150, "Took too long, should've taken " &
+  assert(timeTook*1000 < target + 1000, "Took too long, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
 
-var start: float
+var
+  start: float
+  fut: Future[void]
 
+# NOTE: this uses poll(3000) to limit timing error potential.
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40)
+fut = sleepAsync(50) and sleepAsync(150) and doubleSleep(40)
+while not fut.finished:
+  poll(3000)
 assertTime(150, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(100)
+fut = sleepAsync(50) and sleepAsync(150) and doubleSleep(100)
+while not fut.finished:
+  poll(3000)
 assertTime(200, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40) and sleepAsync(300)
+fut = sleepAsync(50) and sleepAsync(150) and doubleSleep(40) and sleepAsync(300)
+while not fut.finished:
+  poll(3000)
 assertTime(300, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(100) and sleepAsync(300)
+fut = sleepAsync(50) and sleepAsync(150) and doubleSleep(100) and sleepAsync(300)
+while not fut.finished:
+  poll(3000)
 assertTime(300, epochTime() - start)
 
 start = epochTime()
-waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(40)) or sleepAsync(700)
+fut = (sleepAsync(50) and sleepAsync(150) and doubleSleep(40)) or sleepAsync(700)
+while not fut.finished:
+  poll(3000)
 assertTime(150, epochTime() - start)
 
 start = epochTime()
-waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(100)) or sleepAsync(700)
+fut = (sleepAsync(50) and sleepAsync(150) and doubleSleep(100)) or sleepAsync(700)
+while not fut.finished:
+  poll(3000)
 assertTime(200, epochTime() - start)

--- a/tests/async/t12221.nim
+++ b/tests/async/t12221.nim
@@ -1,37 +1,37 @@
 import asyncdispatch, os, times
 
 proc doubleSleep(hardSleep: int) {.async.} =
-  await sleepAsync(100)
+  await sleepAsync(200)
   sleep(hardSleep)
 
 template assertTime(target, timeTook: float): untyped {.dirty.} =
-  assert(timeTook*1000 > target - 5, "Took too short, should've taken " &
+  assert(timeTook*1000 > target - 10, "Took too short, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
-  assert(timeTook*1000 < target + 5, "Took too long, should've taken " &
+  assert(timeTook*1000 < target + 10, "Took too long, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
 
 var start: float
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40)
-assertTime(150, epochTime() - start)
+waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(80)
+assertTime(300, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(60)
-assertTime(160, epochTime() - start)
+waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(120)
+assertTime(320, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(40) and sleepAsync(200)
-assertTime(200, epochTime() - start)
+waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(80) and sleepAsync(400)
+assertTime(400, epochTime() - start)
 
 start = epochTime()
-waitFor sleepAsync(50) and sleepAsync(150) and doubleSleep(60) and sleepAsync(200)
-assertTime(200, epochTime() - start)
+waitFor sleepAsync(100) and sleepAsync(300) and doubleSleep(120) and sleepAsync(400)
+assertTime(400, epochTime() - start)
 
 start = epochTime()
-waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(40)) or sleepAsync(700)
-assertTime(150, epochTime() - start)
+waitFor (sleepAsync(100) and sleepAsync(300) and doubleSleep(80)) or sleepAsync(1400)
+assertTime(300, epochTime() - start)
 
 start = epochTime()
-waitFor (sleepAsync(50) and sleepAsync(150) and doubleSleep(60)) or sleepAsync(700)
-assertTime(160, epochTime() - start)
+waitFor (sleepAsync(100) and sleepAsync(300) and doubleSleep(120)) or sleepAsync(1400)
+assertTime(320, epochTime() - start)

--- a/tests/async/t12221.nim
+++ b/tests/async/t12221.nim
@@ -5,9 +5,9 @@ proc doubleSleep(hardSleep: int) {.async.} =
   sleep(hardSleep)
 
 template assertTime(target, timeTook: float): untyped {.dirty.} =
-  assert(timeTook*1000 > target - 50, "Took too short, should've taken " &
+  assert(timeTook*1000 > target - 150, "Took too short, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
-  assert(timeTook*1000 < target + 50, "Took too long, should've taken " &
+  assert(timeTook*1000 < target + 150, "Took too long, should've taken " &
     $target & "ms, but took " & $(timeTook*1000) & "ms")
 
 var start: float


### PR DESCRIPTION
This fixes a small issue where a timer that had been completed while
code executed would still wait for more events before being considered
completed. This would in some scenarios incur a 500ms delay to the
completion of a timer.