### PR TITLE
fixes #12224

### DIFF
--- a/compiler/parampatterns.nim
+++ b/compiler/parampatterns.nim
@@ -218,14 +218,16 @@ proc isAssignable*(owner: PSym, n: PNode; isUnsafeAddr=false): TAssignableResult
   of nkSym:
     let kinds = if isUnsafeAddr: {skVar, skResult, skTemp, skParam, skLet, skForVar}
                 else: {skVar, skResult, skTemp}
-    if n.sym.kind in kinds:
+    if n.sym.kind == skParam and n.sym.typ.kind in {tyVar, tySink}:
+      result = arLValue
+    elif isUnsafeAddr and n.sym.kind == skParam:
+      result = arLValue
+    elif n.sym.kind in kinds:
       if owner != nil and owner == n.sym.owner and
           sfGlobal notin n.sym.flags:
         result = arLocalLValue
       else:
         result = arLValue
-    elif n.sym.kind == skParam and n.sym.typ.kind in {tyVar, tySink}:
-      result = arLValue
     elif n.sym.kind == skType:
       let t = n.sym.typ.skipTypes({tyTypeDesc})
       if t.kind == tyVar: result = arStrange

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1561,11 +1561,11 @@ proc takeImplicitAddr(c: PContext, n: PNode; isLent: bool): PNode =
   of nkBracketExpr:
     if len(n) == 1: return n.sons[0]
   else: discard
-  let valid = isAssignable(c, n)
+  let valid = isAssignable(c, n, isLent)
   if valid != arLValue:
     if valid == arLocalLValue:
       localError(c.config, n.info, errXStackEscape % renderTree(n, {renderNoComments}))
-    elif not isLent:
+    else:
       localError(c.config, n.info, errExprHasNoAddress)
   result = newNodeIT(nkHiddenAddr, n.info, makePtrType(c, n.typ))
   result.add(n)

--- a/tests/lent/tnot_allowed_lent.nim
+++ b/tests/lent/tnot_allowed_lent.nim
@@ -1,0 +1,16 @@
+discard """
+  errmsg: "expression has no address"
+"""
+type
+  MyObject = object
+    x: seq[string]
+
+proc mytest2(s: MyObject, i: int): lent string =
+  if i < s.x.len - 1 and s.x[i] != "": s.x[i]
+  else: raise newException(KeyError, "err1")
+
+for i in 1..5:
+  var x = MyObject(x: @["1", "2", "3"])
+  echo mytest2(x, 1)
+
+

--- a/tests/lent/tnot_allowed_lent.nim
+++ b/tests/lent/tnot_allowed_lent.nim
@@ -5,12 +5,20 @@ type
   MyObject = object
     x: seq[string]
 
+proc mytest1(s: MyObject, i: int): lent string =
+  ## works fine
+  if i < s.x.len - 1 and s.x[i] != "": 
+    result = s.x[i]
+  else: raise newException(KeyError, "err1")
+  
 proc mytest2(s: MyObject, i: int): lent string =
+  ## reject due to if expr
   if i < s.x.len - 1 and s.x[i] != "": s.x[i]
   else: raise newException(KeyError, "err1")
 
 for i in 1..5:
   var x = MyObject(x: @["1", "2", "3"])
+  echo mytest1(x, 1)
   echo mytest2(x, 1)
 
 


### PR DESCRIPTION
For now I am rejecting this code in sempass.
Then it is possible to lower if/case expression into statement in transf:
```nim
x = 
  if  b > 0: stmtList1
  else: stmtList2
```
Into:
```nim
  if  b > 0: 
     stmtList1MinusLastExpr
     x = LastExprInStmtList1
  else:
     stmtList2MinusLastExpr
     x = LastExprInStmtList2
```
and add support for ifExpr/CaseExpr in isAssignable.

This would also simplify codegen, vmgen, injectdestructors and would decrease number of temporary variables used.

