### PR TITLE
Locks modules should give a compile error when threads are not enabled.

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -9,6 +9,10 @@
 
 ## This module contains Nim's support for locks and condition vars.
 
+
+when not compileOption("threads"):
+  {.error: "Locks requires --threads:on option.".}
+
 const insideRLocksModule = false
 include "system/syslocks"
 

--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -10,7 +10,7 @@
 ## This module contains Nim's support for locks and condition vars.
 
 
-when not compileOption("threads"):
+when not compileOption("threads") and not defined(nimdoc):
   {.error: "Locks requires --threads:on option.".}
 
 const insideRLocksModule = false

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -10,7 +10,7 @@
 ## This module contains Nim's support for reentrant locks.
 
 
-when not compileOption("threads"):
+when not compileOption("threads") and not defined(nimdoc):
   {.error: "Rlocks requires --threads:on option.".}
 
 const insideRLocksModule = true

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -9,6 +9,10 @@
 
 ## This module contains Nim's support for reentrant locks.
 
+
+when not compileOption("threads"):
+  {.error: "Rlocks requires --threads:on option.".}
+
 const insideRLocksModule = true
 include "system/syslocks"
 

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -558,6 +558,10 @@ const disabledFilesDefault = @[
   "setimpl.nim",
   "hashcommon.nim",
 
+  # Requires compiling with '--threads:on`
+  "sharedlist.nim",
+  "sharedtables.nim",
+
   # Error: undeclared identifier: 'hasThreadSupport'
   "ioselectors_epoll.nim",
   "ioselectors_kqueue.nim",

--- a/tests/stdlib/tsharedtable.nim
+++ b/tests/stdlib/tsharedtable.nim
@@ -1,4 +1,5 @@
 discard """
+cmd: "nim $target --threads:on $options $file"
 output: '''
 '''
 """


### PR DESCRIPTION
Before, it would let you compile, and then throw a linker error with no threads.
This make Locks module work like Threads and Threadpool.
Just a small Quality of Life fix.