### PR TITLE
Make HttpHeader's getOrDefault case insensitive

### DIFF
--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -184,7 +184,8 @@ proc getOrDefault*(headers: HttpHeaders, key: string,
     default = @[""].HttpHeaderValues): HttpHeaderValues =
   ## Returns the values associated with the given ``key``. If there are no
   ## values associated with the key, then ``default`` is returned.
-  result = HttpHeaderValues(HeadersImpl(headers).getOrDefault(key, seq[string](default)))
+  result = HttpHeaderValues(HeadersImpl(headers).getOrDefault(
+    key.toLowerAscii, seq[string](default)))
 
 proc len*(headers: HttpHeaders): int = result = HeadersImpl(headers).len
 


### PR DESCRIPTION
Headers are stored lower case, but httpclient tries to get "Content-Length" via `getOrDefault` causing requests to stall in parseBody.