### PR TITLE
Explicitly state that trailing underscores are banned

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -249,8 +249,11 @@ Identifiers & Keywords
 ----------------------
 
 Identifiers in Nim can be any string of letters, digits
-and underscores, beginning with a letter. Two immediate following
-underscores ``__`` are not allowed::
+and underscores, with the following restrictions:
+
+* begins with a letter
+* does not end with an underscore ``_``
+* two immediate following underscores ``__`` are not allowed::
 
   letter ::= 'A'..'Z' | 'a'..'z' | '\x80'..'\xff'
   digit ::= '0'..'9'


### PR DESCRIPTION
It was explicit in the BNF, but the English text implied it was allowed. I'm not married to this wording, but it seemed worth stating in the prose since it isn't a common restriction in other languages.

PS- congrats on 1.0!