### PR TITLE
threadpool: fix link in docs [ci skip]

### DIFF
--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-## Implements Nim's `spawn <manual.html#parallel-amp-spawn>`_.
+## Implements Nim's `spawn <manual_experimental.html#parallel-amp-spawn>`_.
 ##
 ## **See also:**
 ## * `threads module <threads.html>`_


### PR DESCRIPTION
Just another small documentation fix...

By the way, congrats on releasing 1.0!