### PR TITLE
Fix #12242, replacing ":" with "@c" in packages.

### DIFF
--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -40,10 +40,10 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
 
 proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
   # foo-#head/../bar becomes @foo-@hhead@s..@sbar
-  result = "@m" & relativeTo(path, conf.projectPath, '/').string.multiReplace({"/": "@s", "#": "@h", "@": "@@"})
+  result = "@m" & relativeTo(path, conf.projectPath, '/').string.multiReplace({"/": "@s", "#": "@h", "@": "@@", ":": "@c"})
 
 proc demanglePackageName*(path: string): string =
-  result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": ""})
+  result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})
 
 proc withPackageName*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
   let x = getPackageName(conf, path.string)


### PR DESCRIPTION
Replacing colon seem to do the trick. I didn't find unit tests for these procs, so none are updated.