### PR TITLE
Revert VC++ to previous working (non always segfault) exception behavior.

### DIFF
--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -100,6 +100,8 @@ Advanced options:
   --NimblePath:PATH         add a path for Nimble support
   --noNimblePath            deactivate the Nimble path
   --noCppExceptions         use default exception handling with C++ backend
+  --noCppNativeExceptions   don't attempt to catch C++ native exceptions from
+                            C++ code
   --cppCompileToNamespace:namespace
                             use the provided namespace for the generated C++ code,
                             if no namespace is provided "Nim" will be used

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -483,15 +483,21 @@ when defined(cpp) and appType != "lib" and
     setTerminate(nil)
 
     var msg = "Unknown error in unexpected exception handler"
-    try:
-      raise
-    except Exception:
+    when defined(vcc):
+      # disable C++ Native (not caused by nim) exceptions for MS Visual C++
       msg = currException.getStackTrace() & "Error: unhandled exception: " &
         currException.msg & " [" & $currException.name & "]"
-    except StdException as e:
-      msg = "Error: unhandled cpp exception: " & $e.what()
-    except:
-      msg = "Error: unhandled unknown cpp exception"
+    else:
+      try:
+        # catch C++ Native (not caused by nim) exceptions with nim
+        raise
+      except Exception:
+        msg = currException.getStackTrace() & "Error: unhandled exception: " &
+          currException.msg & " [" & $currException.name & "]"
+      except StdException as e:
+        msg = "Error: unhandled cpp exception: " & $e.what()
+      except:
+        msg = "Error: unhandled unknown cpp exception"
 
     when defined(genode):
       # stderr not available by default, use the LOG session

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -483,7 +483,7 @@ when defined(cpp) and appType != "lib" and
     setTerminate(nil)
 
     var msg = "Unknown error in unexpected exception handler"
-    when defined(vcc):
+    when defined(noCppNativeExceptions):
       # disable C++ Native (not caused by nim) exceptions for MS Visual C++
       msg = currException.getStackTrace() & "Error: unhandled exception: " &
         currException.msg & " [" & $currException.name & "]"


### PR DESCRIPTION
Fix for: https://github.com/nim-lang/Nim/issues/11846

This only effects MS VC++ in C++ mode. This does not impact GCC, LLVM or if you are using C mode on MS VC++. 

Previously Nim would only catch Nim exceptions. Then @cooldome added https://github.com/nim-lang/Nim/commit/3cf038027b1df0455f5c6cd2bc47b61377c49761 a way to catch C++ exceptions not produced by nim inside nim code.

That patch caused all VC++ exceptions to segfault basically making  VC++ in cpp mode unusable.

This patch just reverts that feature for VC++ in cpp mode only and does not touch anything else. 

How often do you catch exceptions produced by C++ in nim code anyways? This is not even documented anywhere. While VC++ cpp backend is used to interface with game libraries which can only be compiled with VC++. 
 
