### PR TITLE
Easier build instructions for windows - just run `build_all.bat`.

### DIFF
--- a/build_all.bat
+++ b/build_all.bat
@@ -1,13 +1,16 @@
 @echo off
 rem build development version of the compiler; can be rerun safely
-rmdir csources /S /Q
-git clone --depth 1 https://github.com/nim-lang/csources.git
-cd csources
-if PROCESSOR_ARCHITECTURE == AMD64 (
-  SET ARCH=64
+if not exist csources (
+  git clone --depth 1 https://github.com/nim-lang/csources.git
 )
-CALL build.bat
-cd ..
-bin\nim c koch
-koch boot -d:release
-koch tools
+if not exist bin\nim.exe (
+  cd csources
+  if PROCESSOR_ARCHITECTURE == AMD64 (
+    SET ARCH=64
+  )
+  CALL build.bat
+  cd ..
+)
+bin\nim.exe c --skipUserCfg --skipParentCfg koch
+koch.exe boot -d:release
+koch.exe tools

--- a/build_all.bat
+++ b/build_all.bat
@@ -1,0 +1,13 @@
+@echo off
+rem build development version of the compiler; can be rerun safely
+rmdir csources /S /Q
+git clone --depth 1 https://github.com/nim-lang/csources.git
+cd csources
+if PROCESSOR_ARCHITECTURE == AMD64 (
+  SET ARCH=64
+)
+CALL build.bat
+cd ..
+bin\nim c koch
+koch boot -d:release
+koch tools

--- a/readme.md
+++ b/readme.md
@@ -60,28 +60,19 @@ the installation instructions on the website to do so: https://nim-lang.org/inst
 
 For package maintainers: see [packaging guidelines](https://nim-lang.github.io/Nim/packaging.html).
 
+
+First get nim from github:
+
 ```
-# step 1:
 git clone https://github.com/nim-lang/Nim.git
 cd Nim
-
-# step 2 (posix) clones `csources.git`, bootstraps Nim compiler and compiles tools
-sh build_all.sh
-
-# step 2 (windows)
-git clone --depth 1 https://github.com/nim-lang/csources.git
-
-cd csources
-# requires `gcc` in your PATH, see also https://nim-lang.org/install_windows.html
-build.bat # x86 Windows
-build64.bat # x86_64 Windows
-cd ..
-
-bin\nim c koch
-koch boot -d:release
-koch tools # Compile Nimble and other tools
-# end of step 2 (windows)
 ```
+
+Next run the appropriate build shell script for your platform:
+
+* `build_all.sh` (Linux, Mac)
+* `build_all.bat` (Windows)
+
 
 Finally, once you have finished the build steps (on Windows, Mac or Linux) you
 should add the ``bin`` directory to your PATH.

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ the installation instructions on the website to do so: https://nim-lang.org/inst
 For package maintainers: see [packaging guidelines](https://nim-lang.github.io/Nim/packaging.html).
 
 
-First get nim from github:
+First get Nim from github:
 
 ```
 git clone https://github.com/nim-lang/Nim.git


### PR DESCRIPTION
Create `build_all.bat` and make the build instructions same as for `build_all.sh`.
