### PR TITLE
Fix how os.relativePath handle case sensitiviy

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -232,9 +232,9 @@ proc splitPath*(path: string): tuple[head, tail: string] {.
     result.tail = path
 
 when FileSystemCaseSensitive:
-  template `!=?`(a, b: char): bool = toLowerAscii(a) != toLowerAscii(b)
-else:
   template `!=?`(a, b: char): bool = a != b
+else:
+  template `!=?`(a, b: char): bool = toLowerAscii(a) != toLowerAscii(b)
 
 proc relativePath*(path, base: string; sep = DirSep): string {.
   noSideEffect, rtl, extern: "nos$1", raises: [].} =

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -329,6 +329,10 @@ block ospaths:
   doAssert relativePath("/Users/me/bar/z.nim", "/Users/me", '/') == "bar/z.nim"
   doAssert relativePath("", "/users/moo", '/') == ""
   doAssert relativePath("foo", "", '/') == "foo"
+  doAssert relativePath("/foo", "/Foo", '/') == (when FileSystemCaseSensitive: "../foo" else: "")
+  doAssert relativePath("/Foo", "/foo", '/') == (when FileSystemCaseSensitive: "../Foo" else: "")
+  doAssert relativePath("/foo", "/fOO", '/') == (when FileSystemCaseSensitive: "../foo" else: "")
+  doAssert relativePath("/foO", "/foo", '/') == (when FileSystemCaseSensitive: "../foO" else: "")
 
   doAssert joinPath("usr", "") == unixToNativePath"usr/"
   doAssert joinPath("", "lib") == "lib"


### PR DESCRIPTION
I tested following code on both windows and linux before making this PR.
```nim
import os

echo relativePath("/foo", "/foo/bar")
echo relativePath("/foo", "/Foo/bar")
echo relativePath("/foo/a", "/foo")
echo relativePath("/foo/a", "/Foo")
echo relativePath("/foo/a", "/bar")
```

Output on windows:
```
..
..\..\foo
a
..\foo\a
..\foo\a
```

Output on linux:
```
..
..
a
a
../foo/a
```

`relativePath` compared characters in a path in wrong way.