### PR TITLE
On windows, os.relativePath returns path as is when roots are different

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -238,9 +238,9 @@ else:
   template `!=?`(a, b: char): bool = toLowerAscii(a) != toLowerAscii(b)
 
 
-proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raises: [].}
-
 when doslikeFileSystem:
+  proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raises: [].}
+
   proc isAbsFromCurrentDrive(path: string): bool {.noSideEffect, raises: []} =
     ## An absolute path from the root of the current drive (e.g. "\foo")
     path.len > 0 and

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1111,5 +1111,14 @@ proc setFileTime*(hFile: Handle, lpCreationTime: LPFILETIME,
                  lpLastAccessTime: LPFILETIME, lpLastWriteTime: LPFILETIME): WINBOOL
      {.stdcall, dynlib: "kernel32", importc: "SetFileTime".}
 
+when useWinUnicode:
+  proc PathIsSameRootW*(pszPath1: WideCString,
+                        pszPath2: WideCString): WINBOOL {.
+       stdcall, dynlib: "Shlwapi", importc: "PathIsSameRootW".}
+else:
+  proc PathIsSameRootA*(pszPath1: cstring,
+                        pszPath2: cstring): WINBOOL {.
+       stdcall, dynlib: "Shlwapi", importc: "PathIsSameRootA".}
+
 when defined(nimHasStyleChecks):
   {.pop.} # {.push styleChecks: off.}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1111,14 +1111,5 @@ proc setFileTime*(hFile: Handle, lpCreationTime: LPFILETIME,
                  lpLastAccessTime: LPFILETIME, lpLastWriteTime: LPFILETIME): WINBOOL
      {.stdcall, dynlib: "kernel32", importc: "SetFileTime".}
 
-when useWinUnicode:
-  proc PathIsSameRootW*(pszPath1: WideCString,
-                        pszPath2: WideCString): WINBOOL {.
-       stdcall, dynlib: "Shlwapi", importc: "PathIsSameRootW".}
-else:
-  proc PathIsSameRootA*(pszPath1: cstring,
-                        pszPath2: cstring): WINBOOL {.
-       stdcall, dynlib: "Shlwapi", importc: "PathIsSameRootA".}
-
 when defined(nimHasStyleChecks):
   {.pop.} # {.push styleChecks: off.}

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -334,8 +334,7 @@ block ospaths:
   doAssert relativePath("/foo", "/fOO", '/') == (when FileSystemCaseSensitive: "../foo" else: "")
   doAssert relativePath("/foO", "/foo", '/') == (when FileSystemCaseSensitive: "../foO" else: "")
 
-  when defined(windows):
-    echo relativePath(r"c:\foo.nim", r"C:\")
+  when doslikeFileSystem:
     doAssert relativePath(r"c:\foo.nim", r"C:\") == r"foo.nim"
     doAssert relativePath(r"c:\foo\bar\baz.nim", r"c:\foo") == r"bar\baz.nim"
     doAssert relativePath(r"c:\foo\bar\baz.nim", r"d:\foo") == r"c:\foo\bar\baz.nim"
@@ -346,6 +345,9 @@ block ospaths:
     doAssert relativePath(r"\\foo\bar\baz.nim", r"\\bar\bar") == r"\\foo\bar\baz.nim"
     doAssert relativePath(r"\\foo\bar\baz.nim", r"\\foo\car") == r"\\foo\bar\baz.nim"
     doAssert relativePath(r"\\foo\bar\baz.nim", r"\\goo\bar") == r"\\foo\bar\baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"c:\") == r"\\foo\bar\baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"\foo") == r"\\foo\bar\baz.nim"
+    doAssert relativePath(r"c:\foo.nim", r"\foo") == r"c:\foo.nim"
 
   doAssert joinPath("usr", "") == unixToNativePath"usr/"
   doAssert joinPath("", "lib") == "lib"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -334,6 +334,19 @@ block ospaths:
   doAssert relativePath("/foo", "/fOO", '/') == (when FileSystemCaseSensitive: "../foo" else: "")
   doAssert relativePath("/foO", "/foo", '/') == (when FileSystemCaseSensitive: "../foO" else: "")
 
+  when defined(windows):
+    echo relativePath(r"c:\foo.nim", r"C:\")
+    doAssert relativePath(r"c:\foo.nim", r"C:\") == r"foo.nim"
+    doAssert relativePath(r"c:\foo\bar\baz.nim", r"c:\foo") == r"bar\baz.nim"
+    doAssert relativePath(r"c:\foo\bar\baz.nim", r"d:\foo") == r"c:\foo\bar\baz.nim"
+    doAssert relativePath(r"\foo\baz.nim", r"\foo") == r"baz.nim"
+    doAssert relativePath(r"\foo\bar\baz.nim", r"\bar") == r"..\foo\bar\baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"\\foo\bar") == r"baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"\\foO\bar") == r"baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"\\bar\bar") == r"\\foo\bar\baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"\\foo\car") == r"\\foo\bar\baz.nim"
+    doAssert relativePath(r"\\foo\bar\baz.nim", r"\\goo\bar") == r"\\foo\bar\baz.nim"
+
   doAssert joinPath("usr", "") == unixToNativePath"usr/"
   doAssert joinPath("", "lib") == "lib"
   doAssert joinPath("", "/lib") == unixToNativePath"/lib"


### PR DESCRIPTION
Before making this PR, `os.relativePath` returns wrong path when a root of `path` and a root of `base` are different.
```nim
import os

echo relativePath(r"c:\foo", r"d:\bar")
echo relativePath(r"\\foo\bar\x", r"\\foo\baz\")
```

output:
```
..\..\c:\foo
..\bar\x
```

This PR uses `PathIsSameRootW` or `PathIsSameRootA` windows API to compare roots of input paths.
If they were not same root, returns `path` as is.
But `PathIsSameRootW` or `PathIsSameRootA` seems don't support [DOS device paths](https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths).

This code test `PathIsSameRootW`.
https://gist.github.com/demotomohiro/81702d8a0bf951d6a46b9954093d69bb

APIs in pathcch.h header supports DOS device paths but there is not API to compare root of paths and they are only available on windows 8 or newer.

Implementing `PathIsSameRoot` that supports DOS device paths can be larger code than this PR.