### PR TITLE
renderer letAux fix only for octal literal

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -314,6 +314,7 @@ proc litAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
     while result != nil and result.kind in {tyGenericInst, tyRange, tyVar, tyLent, tyDistinct,
                           tyOrdinal, tyAlias, tySink}:
       result = lastSon(result)
+
   let typ = n.typ.skip
   if typ != nil and typ.kind in {tyBool, tyEnum}:
     if sfPure in typ.sym.flags:
@@ -324,11 +325,13 @@ proc litAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
       if e.sym.position == x:
         result &= e.sym.name.s
         return
-
-  let y = x and ((1 shl (size*8)) - 1)
-  if nfBase2 in n.flags: result = "0b" & toBin(y, size * 8)
-  elif nfBase8 in n.flags: result = "0o" & toOct(y, size * 3)
-  elif nfBase16 in n.flags: result = "0x" & toHex(y, size * 2)
+  
+  if nfBase2 in n.flags: result = "0b" & toBin(x, size * 8)
+  elif nfBase8 in n.flags:
+    var y = x
+    if x < 0: y = x and ((1 shl (size*8)) - 1)
+    result = "0o" & toOct(y, size * 3)
+  elif nfBase16 in n.flags: result = "0x" & toHex(x, size * 2)
   else: result = $x
 
 proc ulitAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -328,8 +328,8 @@ proc litAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
   
   if nfBase2 in n.flags: result = "0b" & toBin(x, size * 8)
   elif nfBase8 in n.flags:
-    var y = x
-    if x < 0: y = x and ((1 shl (size*8)) - 1)
+    var y = if size < sizeof(BiggestInt): x and ((1 shl (size*8)) - 1)
+            else: x
     result = "0o" & toOct(y, size * 3)
   elif nfBase16 in n.flags: result = "0x" & toHex(x, size * 2)
   else: result = $x

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -850,6 +850,20 @@ function main() {
   </ul>
 </li>
 <li>
+  <a class="reference reference-toplevel" href="#10" id="60">Consts</a>
+  <ul class="simple simple-toc-section">
+      <li><a class="reference" href="#C_A"
+    title="C_A = 0x7FF0000000000000&apos;f64"><wbr />C_<wbr />A<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#C_B"
+    title="C_B = 0o377&apos;i8"><wbr />C_<wbr />B<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#C_C"
+    title="C_C = 0o277&apos;i8"><wbr />C_<wbr />C<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#C_D"
+    title="C_D = 0o177777&apos;i16"><wbr />C_<wbr />D<span class="attachedType"></span></a></li>
+
+  </ul>
+</li>
+<li>
   <a class="reference reference-toplevel" href="#12" id="62">Procs</a>
   <ul class="simple simple-toc-section">
       <li><a class="reference" href="#bar%2CT%2CT"
@@ -934,6 +948,39 @@ The enum B.
 <dl class="item">
 <a id="aVariable"></a>
 <dt><pre><a href="testproject.html#aVariable"><span class="Identifier">aVariable</span></a><span class="Other">:</span> <span class="Identifier">array</span><span class="Other">[</span><span class="DecNumber">1</span><span class="Other">,</span> <span class="Identifier">int</span><span class="Other">]</span></pre></dt>
+<dd>
+
+
+
+</dd>
+
+</dl></div>
+<div class="section" id="10">
+<h1><a class="toc-backref" href="#10">Consts</a></h1>
+<dl class="item">
+<a id="C_A"></a>
+<dt><pre><a href="testproject.html#C_A"><span class="Identifier">C_A</span></a> <span class="Other">=</span> <span class="FloatNumber">0x7FF0000000000000'f64</span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="C_B"></a>
+<dt><pre><a href="testproject.html#C_B"><span class="Identifier">C_B</span></a> <span class="Other">=</span> <span class="DecNumber">0o377'i8</span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="C_C"></a>
+<dt><pre><a href="testproject.html#C_C"><span class="Identifier">C_C</span></a> <span class="Other">=</span> <span class="DecNumber">0o277'i8</span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="C_D"></a>
+<dt><pre><a href="testproject.html#C_D"><span class="Identifier">C_D</span></a> <span class="Other">=</span> <span class="DecNumber">0o177777'i16</span></pre></dt>
 <dd>
 
 

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -840,6 +840,22 @@ function main() {
 <li><a class="reference external"
           data-doc-search-tag="testproject: buzz[T](a, b: T): T" href="testproject.html#buzz%2CT%2CT">testproject: buzz[T](a, b: T): T</a></li>
           </ul></dd>
+<dt><a name="C_A" href="#C_A"><span>C_A:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: C_A" href="testproject.html#C_A">testproject: C_A</a></li>
+          </ul></dd>
+<dt><a name="C_B" href="#C_B"><span>C_B:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: C_B" href="testproject.html#C_B">testproject: C_B</a></li>
+          </ul></dd>
+<dt><a name="C_C" href="#C_C"><span>C_C:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: C_C" href="testproject.html#C_C">testproject: C_C</a></li>
+          </ul></dd>
+<dt><a name="C_D" href="#C_D"><span>C_D:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: C_D" href="testproject.html#C_D">testproject: C_D</a></li>
+          </ul></dd>
 <dt><a name="enumValueA" href="#enumValueA"><span>enumValueA:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="SomeType.enumValueA" href="subdir/subdir_b/utils.html#enumValueA">SomeType.enumValueA</a></li>

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -9,6 +9,11 @@ runnableExamples:
   # bug #11078
   for x in "xx": discard
 
+const
+  C_A* = 0x7FF0000000000000'f64
+  C_B* = 0o377'i8
+  C_C* = 0o277'i8
+  C_D* = 0o177777'i16
 
 template foo*(a, b: SomeType) =
   ## This does nothing
@@ -31,7 +36,7 @@ import std/macros
 macro bar*(): untyped =
   result = newStmtList()
 
-var aVariable*: array[1,int]
+var aVariable*: array[1, int]
 
 aEnum()
 bEnum()


### PR DESCRIPTION
Only uses the special fix from 69658ad for negative octal literals, fixes #11131 and #12287