### PR TITLE
Virtual async events 2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@
 - `macros.newLit` now works for ref object types.
 - `system.writeFile` has been overloaded to also support `openarray[byte]`.
 - Added overloaded `strformat.fmt` macro that use specified characters as delimiter instead of '{' and '}'.
+- Added a new Async Event implementation: `asyncdispatch.VirtualAsyncEvent`.
+  - The implementation is designed to enable efficient coordination of async code across threads.
 
 ## Library changes
 

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -295,6 +295,7 @@ when defined(windows) or defined(nimdoc):
     VirtualAsyncEvent* = ptr VirtualAsyncEventImpl
 
     Callback = proc (fd: AsyncFD): bool {.closure, gcsafe.}
+    NativeCallback = proc(fd: AsyncFD, bytesCount: DWORD, errcode: OSErrorCode) {.closure,gcsafe.}
 
   proc hash(x: AsyncFD): Hash {.borrow.}
   proc `==`*(x: AsyncFD, y: AsyncFD): bool {.borrow.}

--- a/tests/async/testasyncevent.nim
+++ b/tests/async/testasyncevent.nim
@@ -1,0 +1,13 @@
+discard """
+output: '''
+event triggered!
+'''
+"""
+
+import asyncDispatch
+
+let ev = newAsyncEvent()
+addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe.} = echo "event triggered!"; true)
+ev.trigger()
+
+drain()

--- a/tests/async/testmanyasynceventsovertime.nim
+++ b/tests/async/testmanyasynceventsovertime.nim
@@ -1,6 +1,5 @@
 discard """
 output: '''
-runForever should throw ValueError, this is expected
 triggerCount: 10
 '''
 """
@@ -21,9 +20,6 @@ proc main() {.async.} =
     await sleepAsync(10)
     ev.close
 
-try:
-  asyncCheck main()
-  runForever()
-except ValueError:
-  echo "runForever should throw ValueError, this is expected"
-  echo "triggerCount: ", triggerCount
+asyncCheck main()
+drain()
+echo "triggerCount: ", triggerCount

--- a/tests/async/testmanyasynceventsovertime.nim
+++ b/tests/async/testmanyasynceventsovertime.nim
@@ -1,0 +1,29 @@
+discard """
+output: '''
+runForever should throw ValueError, this is expected
+triggerCount: 10
+'''
+"""
+
+import asyncDispatch
+
+var triggerCount = 0
+var evs = newSeq[AsyncEvent]()
+
+for i in 0 ..< 10:
+  var ev = newAsyncEvent()
+  evs.add(ev)
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
+
+proc main() {.async.} =
+  for ev in evs:
+    ev.trigger()
+    await sleepAsync(10)
+    ev.close
+
+try:
+  asyncCheck main()
+  runForever()
+except ValueError:
+  echo "runForever should throw ValueError, this is expected"
+  echo "triggerCount: ", triggerCount

--- a/tests/async/testmanyvirtualasyncevents.nim
+++ b/tests/async/testmanyvirtualasyncevents.nim
@@ -1,0 +1,21 @@
+discard """
+output: '''
+triggerCount: 8000
+'''
+"""
+
+import asyncDispatch
+
+var triggerCount = 0
+var evs = newSeq[VirtualAsyncEvent]()
+
+for i in 0 ..< 8000: # some number way higher than the typical physical fd limit
+  var ev = newVirtualAsyncEvent()
+  evs.add(ev)
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
+
+for ev in evs:
+  ev.trigger()
+
+drain()
+echo "triggerCount: ", triggerCount

--- a/tests/async/testmanyvirtualasynceventsovertime.nim
+++ b/tests/async/testmanyvirtualasynceventsovertime.nim
@@ -1,0 +1,28 @@
+discard """
+output: '''
+runForever should throw ValueError, this is expected
+triggerCount: 100
+'''
+"""
+
+import asyncDispatch
+
+var triggerCount = 0
+var evs = newSeq[VirtualAsyncEvent]()
+
+for i in 0 ..< 100:
+  var ev = newVirtualAsyncEvent()
+  evs.add(ev)
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
+
+proc main() {.async.} =
+  for ev in evs:
+    await sleepAsync(10)
+    ev.trigger()
+
+try:
+  asyncCheck main()
+  runForever()
+except ValueError:
+  echo "runForever should throw ValueError, this is expected"
+  echo "triggerCount: ", triggerCount

--- a/tests/async/testvirtualasyncevent.nim
+++ b/tests/async/testvirtualasyncevent.nim
@@ -1,0 +1,13 @@
+discard """
+output: '''
+event triggered!
+'''
+"""
+
+import asyncDispatch
+
+let ev = newVirtualAsyncEvent()
+addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe.} = echo "event triggered!"; true)
+ev.trigger()
+
+drain()

--- a/tests/threads/testVirtualAsyncThreadCoordination.nim
+++ b/tests/threads/testVirtualAsyncThreadCoordination.nim
@@ -1,0 +1,171 @@
+discard """
+output:'''
+Thread 1: iteration 0
+Thread 2: iteration 0
+Thread 1: iteration 1
+Thread 2: iteration 1
+Thread 1: iteration 2
+Thread 2: iteration 2
+Thread 1: iteration 3
+Thread 2: iteration 3
+Thread 1: iteration 4
+Thread 2: iteration 4
+Thread 1: iteration 5
+Thread 2: iteration 5
+Thread 1: iteration 6
+Thread 2: iteration 6
+Thread 1: iteration 7
+Thread 2: iteration 7
+Thread 1: iteration 8
+Thread 2: iteration 8
+Thread 1: iteration 9
+Thread 2: iteration 9
+Thread 1: iteration 10
+Thread 2: iteration 10
+Thread 1: iteration 11
+Thread 2: iteration 11
+Thread 1: iteration 12
+Thread 2: iteration 12
+Thread 1: iteration 13
+Thread 2: iteration 13
+Thread 1: iteration 14
+Thread 2: iteration 14
+Thread 1: iteration 15
+Thread 2: iteration 15
+Thread 1: iteration 16
+Thread 2: iteration 16
+Thread 1: iteration 17
+Thread 2: iteration 17
+Thread 1: iteration 18
+Thread 2: iteration 18
+Thread 1: iteration 19
+Thread 2: iteration 19
+Thread 1: iteration 20
+Thread 2: iteration 20
+Thread 1: iteration 21
+Thread 2: iteration 21
+Thread 1: iteration 22
+Thread 2: iteration 22
+Thread 1: iteration 23
+Thread 2: iteration 23
+Thread 1: iteration 24
+Thread 2: iteration 24
+Thread 1: iteration 25
+Thread 2: iteration 25
+Thread 1: iteration 26
+Thread 2: iteration 26
+Thread 1: iteration 27
+Thread 2: iteration 27
+Thread 1: iteration 28
+Thread 2: iteration 28
+Thread 1: iteration 29
+Thread 2: iteration 29
+Thread 1: iteration 30
+Thread 2: iteration 30
+Thread 1: iteration 31
+Thread 2: iteration 31
+Thread 1: iteration 32
+Thread 2: iteration 32
+Thread 1: iteration 33
+Thread 2: iteration 33
+Thread 1: iteration 34
+Thread 2: iteration 34
+Thread 1: iteration 35
+Thread 2: iteration 35
+Thread 1: iteration 36
+Thread 2: iteration 36
+Thread 1: iteration 37
+Thread 2: iteration 37
+Thread 1: iteration 38
+Thread 2: iteration 38
+Thread 1: iteration 39
+Thread 2: iteration 39
+Thread 1: iteration 40
+Thread 2: iteration 40
+Thread 1: iteration 41
+Thread 2: iteration 41
+Thread 1: iteration 42
+Thread 2: iteration 42
+Thread 1: iteration 43
+Thread 2: iteration 43
+Thread 1: iteration 44
+Thread 2: iteration 44
+Thread 1: iteration 45
+Thread 2: iteration 45
+Thread 1: iteration 46
+Thread 2: iteration 46
+Thread 1: iteration 47
+Thread 2: iteration 47
+Thread 1: iteration 48
+Thread 2: iteration 48
+Thread 1: iteration 49
+Thread 2: iteration 49
+Thread 1: iteration 50
+Thread 2: iteration 50
+'''
+"""
+
+import os, asyncdispatch
+
+type
+  ThreadArg = object
+    event1: VirtualAsyncEvent
+    event2: VirtualAsyncEvent
+
+when not(compileOption("threads")):
+  {.fatal: "Please, compile this program with the --threads:on option!".}
+
+proc wait(event: VirtualAsyncEvent): Future[void] =
+  var retFuture = newFuture[void]("AsyncEvent.wait")
+  proc continuation(fd: AsyncFD): bool {.gcsafe.} =
+    if not retFuture.finished:
+      retFuture.complete()
+    result = true
+  addEvent(event, continuation)
+  return retFuture
+
+proc asyncProc1(args: ThreadArg) {.async.} =
+  for i in 0 .. 50:
+    # why 50 iterations? It's arbitrary. We can't run forever, but we want to run long enough
+    # to sanity check against a race condition or deadlock.
+    let waiting = args.event1.wait()
+    args.event2.trigger()
+    await waiting
+    # Why echoes and not just a count? Because this test is about coordination of threads.
+    # We need to make sure the threads get properly synchronized on each iteration.
+    echo "Thread 1: iteration ", i
+  args.event2.trigger()
+
+proc asyncProc2(args: ThreadArg) {.async.} =
+  for i in 0 .. 50:
+    let waiting = args.event2.wait()
+    args.event1.trigger()
+    await waiting
+    echo "Thread 2: iteration ", i
+  args.event1.trigger()
+
+proc threadProc1(args: ThreadArg) {.thread.} =
+  ## We create new dispatcher explicitly to avoid bugs.
+  let loop = getGlobalDispatcher()
+  waitFor asyncProc1(args)
+
+proc threadProc2(args: ThreadArg) {.thread.} =
+  ## We create new dispatcher explicitly avoid bugs.
+  let loop = getGlobalDispatcher()
+  waitFor asyncProc2(args)
+
+proc main() =
+  var
+    args: ThreadArg
+    thread1: Thread[ThreadArg]
+    thread2: Thread[ThreadArg]
+
+  args.event1 = newVirtualAsyncEvent()
+  args.event2 = newVirtualAsyncEvent()
+  thread1.createThread(threadProc1, args)
+  sleep(100)
+  thread2.createThread(threadProc2, args)
+  joinThreads(thread1, thread2)
+
+when isMainModule:
+  main()

--- a/tests/threads/testasynceventwiththreads.nim
+++ b/tests/threads/testasynceventwiththreads.nim
@@ -1,0 +1,27 @@
+discard """
+output: '''
+runForever should throw ValueError, this is expected
+triggerCount: 1000
+'''
+"""
+
+import asyncDispatch, threadpool, os, random
+
+var triggerCount = 0
+var evs = newSeq[AsyncEvent]()
+
+proc threadTask(ev: AsyncEvent) =
+  sleep(rand(1000))
+  ev.trigger()
+
+for i in 0 ..< 1000:
+  var ev = newAsyncEvent()
+  evs.add ev
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
+  spawn(threadTask(ev))
+
+try:
+  runForever()
+except ValueError:
+  echo "runForever should throw ValueError, this is expected"
+  echo "triggerCount: ", triggerCount

--- a/tests/threads/testasynceventwiththreads.nim
+++ b/tests/threads/testasynceventwiththreads.nim
@@ -14,10 +14,9 @@ proc threadTask(ev: AsyncEvent) =
   ev.trigger()
 
 for i in 0 ..< 1000:
-  echo "i: ", i
   var ev = newAsyncEvent()
   evs.add ev
-  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; echo "triggerCount: ", triggerCount; true)
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
   spawn(threadTask(ev))
 
 drain()

--- a/tests/threads/testasynceventwiththreads.nim
+++ b/tests/threads/testasynceventwiththreads.nim
@@ -1,6 +1,5 @@
 discard """
 output: '''
-runForever should throw ValueError, this is expected
 triggerCount: 1000
 '''
 """
@@ -15,13 +14,11 @@ proc threadTask(ev: AsyncEvent) =
   ev.trigger()
 
 for i in 0 ..< 1000:
+  echo "i: ", i
   var ev = newAsyncEvent()
   evs.add ev
-  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; echo "triggerCount: ", triggerCount; true)
   spawn(threadTask(ev))
 
-try:
-  runForever()
-except ValueError:
-  echo "runForever should throw ValueError, this is expected"
-  echo "triggerCount: ", triggerCount
+drain()
+echo "triggerCount: ", triggerCount

--- a/tests/threads/testvirtualasynceventwiththreads.nim
+++ b/tests/threads/testvirtualasynceventwiththreads.nim
@@ -1,0 +1,27 @@
+discard """
+output: '''
+runForever should throw ValueError, this is expected
+triggerCount: 1000
+'''
+"""
+
+import asyncDispatch, threadpool, os, random
+
+var triggerCount = 0
+var evs = newSeq[VirtualAsyncEvent]()
+
+proc threadTask(ev: VirtualAsyncEvent) =
+  sleep(rand(1000))
+  ev.trigger()
+
+for i in 0 ..< 1000:
+  var ev = newVirtualAsyncEvent()
+  evs.add ev
+  addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
+  spawn(threadTask(ev))
+
+try:
+  runForever()
+except ValueError:
+  echo "runForever should throw ValueError, this is expected"
+  echo "triggerCount: ", triggerCount

--- a/tests/threads/testvirtualasynceventwiththreads.nim
+++ b/tests/threads/testvirtualasynceventwiththreads.nim
@@ -1,6 +1,5 @@
 discard """
 output: '''
-runForever should throw ValueError, this is expected
 triggerCount: 1000
 '''
 """
@@ -20,8 +19,5 @@ for i in 0 ..< 1000:
   addEvent(ev, proc(fd: AsyncFD): bool {.gcsafe,closure.} = triggerCount += 1; true)
   spawn(threadTask(ev))
 
-try:
-  runForever()
-except ValueError:
-  echo "runForever should throw ValueError, this is expected"
-  echo "triggerCount: ", triggerCount
+drain()
+echo "triggerCount: ", triggerCount


### PR DESCRIPTION
Implemented VirtualAsyncEvent separate from AysncEvent

As suggested by @dom96. This leaves the original AsyncEvent API intact.
This also includes a small test suite for both AsyncEvent and VirtualAsyncEvent.

The code is mostly the same as #12232 except that it uses a single AsyncEvent as the multiplexer, instead of reaching into the global ioselector directly.

Pros:
- This makes the code simpler and more modular

Cons:
- This relies on the correctness and performance of the old AsyncEvent
- There may be a small performance penalty from piggybacking off AsyncEvent instead of using the ioselector directly (likely very small though)

A Few Notes:
- I still think the original AsyncEvent is inefficient and has some issues.
  - But this PR is much more conservative and may be easier to accept. (It is non-breaking and additive only)

- A very rough performance measure of the test suite shows that VirtualAsyncEvent is much faster than the old AsyncEvent, as well as being able to handle an order of magnitude more events than the old AsyncEvent. 😛 

- Knowledgeable users will be able decide which version they want to use.
  - I have a TODO: to document the differences between the two types of AsyncEvent.

- Unlike the previous version, #11724 will no longer transparently work.
  - It will need a small rewrite to use this new VirtualAsyncEvent API.

Calling @zevv, @dom96, @Araq, @cheatfate for code review and thoughts.