### PR TITLE
External file compilation improvement

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -662,6 +662,10 @@ proc addExternalFileToCompile*(conf: ConfigRef; c: var Cfile) =
   if optForceFullMake notin conf.globalOptions and fileExists(c.obj) and
       not externalFileChanged(conf, c):
     c.flags.incl CfileFlag.Cached
+  else:
+    # make sure Nim keeps recompiling the external file on reruns
+    # if compilation is not successful  
+    discard tryRemoveFile(c.obj.string)
   conf.toCompile.add(c)
 
 proc addExternalFileToCompile*(conf: ConfigRef; filename: AbsoluteFile) =


### PR DESCRIPTION
This PR helps in the following use case:

You have compiled external file using `{.compile.}` pragma  once. Now you changed the file but there is a mistake and file no longer compiles. You rerun Nim to see error message once again, but Nim no longer compiles the file because it is cached and Nim not recompile until file change again.

By removing stale obj file we make sure that only successful compilations get cached.