### PR TITLE
nimsuggest: fix tcp socket leak for epc backend

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -353,7 +353,7 @@ proc replEpc(x: ThreadParams) {.thread.} =
   echo port
   stdout.flushFile()
 
-  var client = newSocket()
+  var client: Socket
   # Wait for connection
   accept(server, client)
   while true:


### PR DESCRIPTION
Same as e9fa4c9b9c8e2926449399a69a02676936bb842c, but for the epc backend which is used by emacs and
vscode plugin.

Since the EPC backend only deal with one connection per nimsuggest
instance, only one socket is leaked, thus not as servere as with the tcp
backend.