### PR TITLE
fix #11764, faster hashing of (u)int

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -1019,9 +1019,9 @@ when isMainModule and not defined(release):
       # --> {1, 3, 5}
 
     block toSeqAndString:
-      var a = toHashSet([2, 4, 5])
+      var a = toHashSet([2, 7, 5])
       var b = initHashSet[int]()
-      for x in [2, 4, 5]: b.incl(x)
+      for x in [2, 7, 5]: b.incl(x)
       assert($a == $b)
       #echo a
       #echo toHashSet(["no", "esc'aping", "is \" provided"])

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -112,29 +112,32 @@ proc hash*[T: proc](x: T): Hash {.inline.} =
   else:
     result = hash(pointer(x))
 
+const
+  prime = 31
+
 proc hash*(x: int): Hash {.inline.} =
   ## Efficient hashing of integers.
-  result = x
+  result = x * prime
 
 proc hash*(x: int64): Hash {.inline.} =
   ## Efficient hashing of `int64` integers.
-  result = cast[int](x)
+  result = cast[int](x) * prime
 
 proc hash*(x: uint): Hash {.inline.} =
   ## Efficient hashing of unsigned integers.
-  result = cast[int](x)
+  result = cast[int](x) * prime
 
 proc hash*(x: uint64): Hash {.inline.} =
   ## Efficient hashing of `uint64` integers.
-  result = cast[int](x)
+  result = cast[int](x) * prime
 
 proc hash*(x: char): Hash {.inline.} =
   ## Efficient hashing of characters.
-  result = ord(x)
+  result = ord(x) * prime
 
 proc hash*[T: Ordinal](x: T): Hash {.inline.} =
   ## Efficient hashing of other ordinal types (e.g. enums).
-  result = ord(x)
+  result = ord(x) * prime
 
 proc hash*(x: float): Hash {.inline.} =
   ## Efficient hashing of floats.

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -113,31 +113,31 @@ proc hash*[T: proc](x: T): Hash {.inline.} =
     result = hash(pointer(x))
 
 const
-  prime = 31
+  prime = uint(11)
 
 proc hash*(x: int): Hash {.inline.} =
   ## Efficient hashing of integers.
-  result = x * prime
+  result = cast[Hash](cast[uint](x) * prime)
 
 proc hash*(x: int64): Hash {.inline.} =
   ## Efficient hashing of `int64` integers.
-  result = cast[int](x) * prime
+  result = cast[Hash](cast[uint](x) * prime)
 
 proc hash*(x: uint): Hash {.inline.} =
   ## Efficient hashing of unsigned integers.
-  result = cast[int](x) * prime
+  result = cast[Hash](x * prime)
 
 proc hash*(x: uint64): Hash {.inline.} =
   ## Efficient hashing of `uint64` integers.
-  result = cast[int](x) * prime
+  result = cast[Hash](cast[uint](x) * prime)
 
 proc hash*(x: char): Hash {.inline.} =
   ## Efficient hashing of characters.
-  result = ord(x) * prime
+  result = cast[Hash](cast[uint](ord(x)) * prime)
 
 proc hash*[T: Ordinal](x: T): Hash {.inline.} =
   ## Efficient hashing of other ordinal types (e.g. enums).
-  result = ord(x) * prime
+  result = cast[Hash](cast[uint](ord(x)) * prime)
 
 proc hash*(x: float): Hash {.inline.} =
   ## Efficient hashing of floats.

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -233,7 +233,7 @@ block tablesref:
       for y in 0..1:
         assert t[(x,y)] == $x & $y
     assert($t ==
-      "{(x: 0, y: 1): \"01\", (x: 0, y: 0): \"00\", (x: 1, y: 0): \"10\", (x: 1, y: 1): \"11\"}")
+      "{(x: 1, y: 1): \"11\", (x: 0, y: 0): \"00\", (x: 0, y: 1): \"01\", (x: 1, y: 0): \"10\"}")
 
   block tableTest2:
     var t = newTable[string, float]()
@@ -340,7 +340,7 @@ block tablesref:
   block anonZipTest:
     let keys = @['a','b','c']
     let values = @[1, 2, 3]
-    doAssert "{'a': 1, 'b': 2, 'c': 3}" == $ toTable zip(keys, values)
+    doAssert "{'c': 3, 'a': 1, 'b': 2}" == $ toTable zip(keys, values)
 
   block clearTableTest:
     var t = newTable[string, float]()

--- a/tests/collections/ttablesthreads.nim
+++ b/tests/collections/ttablesthreads.nim
@@ -48,7 +48,7 @@ block tableTest1:
     for y in 0..1:
       assert t[(x,y)] == $x & $y
   assert($t ==
-    "{(x: 0, y: 1): \"01\", (x: 0, y: 0): \"00\", (x: 1, y: 0): \"10\", (x: 1, y: 1): \"11\"}")
+    "{(x: 1, y: 1): \"11\", (x: 0, y: 0): \"00\", (x: 0, y: 1): \"01\", (x: 1, y: 0): \"10\"}")
 
 block tableTest2:
   var t = initTable[string, float]()


### PR DESCRIPTION
Running https://github.com/cwpearson/nim-issue-11764/blob/master/slow_set.nim on my machine, which is the test case for https://github.com/nim-lang/Nim/issues/11764 produces the following before/after results:

Before this PR:
```
(1) time 0.017153174
(2) time 1.512243921
(3) time 18.05979435
(4) time 17.861573436
(5) time 11.350780583
(6) time 0.003636462999999424
(7) time 16.871593051
(8) time 0.002521137000002227
```

After this PR:
```
(1) time 0.022618518
(2) time 0.02331171199999999
(3) time 0.01813793399999999
(4) time 0.01471349299999999
(5) time 0.008311381999999992
(6) time 0.01135809600000001
(7) time 0.02215919299999999
(8) time 0.002485686000000015
```

Summary: this PR makes HashSets and HashTables about **three orders of magnitude faster** for large amounts of (u)int keys, because it prevents huge amounts of collisions happening with the old algorithm (where the hash of an int was that int) for consecutive ints.