### PR TITLE
fix #12319 - finish.exe add dupliate nimble path

### DIFF
--- a/tools/finish.nim
+++ b/tools/finish.nim
@@ -225,6 +225,8 @@ proc main() =
       if x.len == 0: continue
       let y = try: expandFilename(if x[0] == '"' and x[^1] == '"':
                                     substr(x, 1, x.len-2) else: x)
+              except OSError: 
+                if getCurrentExceptionMsg().endsWith("does not exist"): x else: ""
               except: ""
       if y.cmpIgnoreCase(nimDesiredPath) == 0:
         nimAlreadyInPath = true


### PR DESCRIPTION
finish.exe add duplicate nimblepath when run 2nd time because exception occur.

the exeption is OSError "..... ./nimble/bin does not exist" which raise because when expandFile proc expand nimble path in environment variable, actual nimble path does not exist yet

this fix will return nimpath instead of blank string when this exception was raised