### PR TITLE
fix #11863

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -297,6 +297,16 @@ proc newMultipartData*: MultipartData =
   ## Constructs a new ``MultipartData`` object.
   MultipartData(content: @[])
 
+
+proc `$`*(data: MultipartData): string =
+  ## convert MultipartData to string so it's human readable when echo
+  ## see https://github.com/nim-lang/Nim/issues/11863
+  for pos, item in data.content:
+    result &= "------------------------------  " 
+    result &= pos 
+    result &= "  ------------------------------\n"
+    result &= item[32 .. item.high]
+
 proc add*(p: var MultipartData, name, content: string, filename: string = "",
           contentType: string = "") =
   ## Add a value to the multipart data. Raises a `ValueError` exception if


### PR DESCRIPTION
I saw #11990 comment that we should not use split() to parse multipartData but I also not familiar with using strscan
So to close this issue I propose another way to display multipartData. For this code
```nim
var data = newMultipartData()
data["output"] = "soap12"
data["uploaded_file"] = ("test.html", "text/html",
"<html><head></head><body><p>test</p></body></html>")
```
Instead of `echo data` and get error
or  `echo data.repr` and get
```nim
ref 0x7f317993a048 --> [content = 0x7f317993d078@[0x7f317993f058"Content-Disposition: form-data; name=\"output\"\13\10"
"\13\10"
"soap12\13\10"
"", 0x7f3179945058"Content-Disposition: form-data; name=\"uploaded_file\"; filename=\"test.html\"\13\10"
"Content-Type: text/html\13\10"
"\13\10"
"<html><head></head><body><p>test</p></body></html>\13\10"
""]]
```
we can `echo data` and get
```
------------------------------  0  ------------------------------
name="output"

soap12
------------------------------  1  ------------------------------
name="uploaded_file"; filename="test.html"
Content-Type: text/html

<html><head></head><body><p>test</p></body></html>
```