### PR TITLE
Fix vcc linker option name in config/nim.cfg

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -257,7 +257,8 @@ vcc.linkerexe = "vccexe.exe"
 vcc.cpp.linkerexe = "vccexe.exe"
 
 vcc.cpp.options.always = "/EHsc"
-vcc.options.linker.always = "/F33554432" # set the stack size to 32 MiB
+vcc.options.linker = "/F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker = "/F33554432"
 vcc.options.debug = "/Zi /FS /Od"
 vcc.cpp.options.debug = "/Zi /FS /Od"
 vcc.options.speed = "/O2"


### PR DESCRIPTION
`vcc.options.linker.always` in `config/nim.cfg` was ignored when Nim call `vccexe`.
This PR fix the option name so that `/F33554432` is passed to `vccexe`.