### PR TITLE
[backport] fix type's case in random.nim

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -84,11 +84,11 @@ include "system/inclrtl"
 {.push debugger: off.}
 
 when defined(JS):
-  type ui = uint32
+  type Ui = uint32
 
   const randMax = 4_294_967_295u32
 else:
-  type ui = uint64
+  type Ui = uint64
 
   const randMax = 18_446_744_073_709_551_615u64
 
@@ -106,7 +106,7 @@ type
                  ## Many procs have two variations: one that takes in a Rand parameter and
                  ## another that uses the default generator. The procs that use the default
                  ## generator are **not** thread-safe!
-    a0, a1: ui
+    a0, a1: Ui
 
 when defined(JS):
   var state = Rand(
@@ -118,8 +118,8 @@ else:
     a0: 0x69B4C98CB8530805u64,
     a1: 0xFED1DD3004688D67CAu64) # global for backwards compatibility
 
-proc rotl(x, k: ui): ui =
-  result = (x shl k) or (x shr (ui(64) - k))
+proc rotl(x, k: Ui): Ui =
+  result = (x shl k) or (x shr (Ui(64) - k))
 
 proc next*(r: var Rand): uint64 =
   ## Computes a random ``uint64`` number using the given state.
@@ -195,11 +195,11 @@ proc skipRandomNumbers*(s: var Rand) =
   else:
     const helper = [0xbeac0467eba5facbu64, 0xd86b048b86aa9922u64]
   var
-    s0 = ui 0
-    s1 = ui 0
+    s0 = Ui 0
+    s1 = Ui 0
   for i in 0..high(helper):
     for b in 0 ..< 64:
-      if (helper[i] and (ui(1) shl ui(b))) != 0:
+      if (helper[i] and (Ui(1) shl Ui(b))) != 0:
         s0 = s0 xor s.a0
         s1 = s1 xor s.a1
       discard next(s)
@@ -210,7 +210,7 @@ proc random*(max: int): int {.benign, deprecated:
   "Deprecated since v0.18.0; use 'rand' instead".} =
   while true:
     let x = next(state)
-    if x < randMax - (randMax mod ui(max)):
+    if x < randMax - (randMax mod Ui(max)):
       return int(x mod uint64(max))
 
 proc random*(max: float): float {.benign, deprecated:
@@ -247,7 +247,7 @@ proc rand*(r: var Rand; max: Natural): int {.benign.} =
   if max == 0: return
   while true:
     let x = next(r)
-    if x <= randMax - (randMax mod ui(max)):
+    if x <= randMax - (randMax mod Ui(max)):
       return int(x mod (uint64(max)+1u64))
 
 proc rand*(max: int): int {.benign.} =
@@ -570,8 +570,8 @@ proc initRand*(seed: int64): Rand =
     let now = getTime()
     var r2 = initRand(now.toUnix * 1_000_000_000 + now.nanosecond)
   doAssert seed != 0 # 0 causes `rand(int)` to always return 0 for example.
-  result.a0 = ui(seed shr 16)
-  result.a1 = ui(seed and 0xffff)
+  result.a0 = Ui(seed shr 16)
+  result.a1 = Ui(seed and 0xffff)
   discard next(result)
 
 proc randomize*(seed: int64) {.benign.} =


### PR DESCRIPTION
Before this change an error was raised:
`Error: 'ui' should be: 'Ui'`