### PR TITLE
Add no-ident for GCC when build for Release

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -63,8 +63,8 @@ compiler gcc:
   result = (
     name: "gcc",
     objExt: "o",
-    optSpeed: " -O3 ",
-    optSize: " -Os ",
+    optSpeed: " -O3 -fno-ident",
+    optSize: " -Os -fno-ident",
     compilerExe: "gcc",
     cppCompiler: "g++",
     compileTmpl: "-c $options $include -o $objfile $file",
@@ -664,7 +664,7 @@ proc addExternalFileToCompile*(conf: ConfigRef; c: var Cfile) =
     c.flags.incl CfileFlag.Cached
   else:
     # make sure Nim keeps recompiling the external file on reruns
-    # if compilation is not successful  
+    # if compilation is not successful
     discard tryRemoveFile(c.obj.string)
   conf.toCompile.add(c)
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -207,15 +207,15 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
   gcc.options.linker %= "-L $WIND_BASE/target/lib/usr/lib/ppc/PPC32/common -mrtp -fno-strict-aliasing -D_C99 -D_HAS_C9X -std=c99 -fasm -Wall -Wno-write-strings"
 @end
 
-gcc.options.speed = "-O3 -fno-strict-aliasing"
-gcc.options.size = "-Os"
+gcc.options.speed = "-O3 -fno-strict-aliasing -fno-ident"
+gcc.options.size = "-Os -fno-ident"
 @if windows:
   gcc.options.debug = "-g3 -Og -gdwarf-3"
 @else:
   gcc.options.debug = "-g3 -Og"
 @end
-gcc.cpp.options.speed = "-O3 -fno-strict-aliasing"
-gcc.cpp.options.size = "-Os"
+gcc.cpp.options.speed = "-O3 -fno-strict-aliasing -fno-ident"
+gcc.cpp.options.size = "-Os -fno-ident"
 gcc.cpp.options.debug = "-g3 -Og"
 #passl = "-pg"
 


### PR DESCRIPTION
- Add [`-no-ident`](https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fno-ident) for GCC when build for Release.

**TLDR:** 
GCC likes to [spamm](https://github.com/msys2/MINGW-packages/issues/21) a string about timestamps, versions, and RedHat(?) on the binaries, this removes that string from the binaries when build for release.

```console
$ echo "echo 42" > hello.nim

$ nim c -d:release --listCmd hello.nim
gcc -c  -w -O3 -fno-strict-aliasing -fno-ident  -I/home/juan/code/Nim/lib -I/home/juan/code/temp4 -o /home/juan/.cache/nim/hello_r/stdlib_io.nim.c.o /home/juan/.cache/nim/hello_r/stdlib_io.nim.c
gcc -c  -w -O3 -fno-strict-aliasing -fno-ident  -I/home/juan/code/Nim/lib -I/home/juan/code/temp4 -o /home/juan/.cache/nim/hello_r/stdlib_system.nim.c.o /home/juan/.cache/nim/hello_r/stdlib_system.nim.c
gcc -c  -w -O3 -fno-strict-aliasing -fno-ident  -I/home/juan/code/Nim/lib -I/home/juan/code/temp4 -o /home/juan/.cache/nim/hello_r/hello.nim.c.o /home/juan/.cache/nim/hello_r/hello.nim.c

$ nim c --listCmd hello.nim
gcc -c  -w  -I/home/juan/code/Nim/lib -I/home/juan/code/temp4 -o /home/juan/.cache/nim/hello_d/stdlib_io.nim.c.o /home/juan/.cache/nim/hello_d/stdlib_io.nim.c
gcc -c  -w  -I/home/juan/code/Nim/lib -I/home/juan/code/temp4 -o /home/juan/.cache/nim/hello_d/stdlib_system.nim.c.o /home/juan/.cache/nim/hello_d/stdlib_system.nim.c
gcc -c  -w  -I/home/juan/code/Nim/lib -I/home/juan/code/temp4 -o /home/juan/.cache/nim/hello_d/hello.nim.c.o /home/juan/.cache/nim/hello_d/hello.nim.c

```

**Before:**
```console
$ objdump --section=.comment --full-contents hello

Contenido de la sección .comment:
 0000 4743433a 2028474e 55292034 2e342e37  GCC: (GNU) 4.4.7
 0010 20323031 32303331 33202852 65642048   20120313 (Red Hat 4.4.7 - 23). 
 0020 61742034 2e342e37 2d323329 00        

```

**After:**
```console
$ objdump --section=.comment --full-contents hello

Contenido de la sección .comment:
 0000 4743433a 2028474e 55292039 2e322e30  GCC
```

You can use the command to test for yourself: `objdump --section=.comment --full-contents `

Makes Binary smaller some bytes, the string changes from distro to distro, some distros have longer strings there.
I been using this for several months without any problem on any OS/Hardware.