### PR TITLE
Documentation Math module 

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -48,6 +48,8 @@
 ## * `mersenne module<mersenne.html>`_ for Mersenne twister random number generator
 ## * `stats module<stats.html>`_ for statistical analysis
 ## * `strformat module<strformat.html>`_ for formatting floats for print
+## * `system module<system.html>`_ Some very basic and trivial math operators
+## are on system directly, to name a few ``shr``, ``shl``, ``xor``, ``clamp``, etc.
 
 
 include "system/inclrtl"

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -49,7 +49,7 @@
 ## * `stats module<stats.html>`_ for statistical analysis
 ## * `strformat module<strformat.html>`_ for formatting floats for print
 ## * `system module<system.html>`_ Some very basic and trivial math operators
-## are on system directly, to name a few ``shr``, ``shl``, ``xor``, ``clamp``, etc.
+##   are on system directly, to name a few ``shr``, ``shl``, ``xor``, ``clamp``, etc.
 
 
 include "system/inclrtl"


### PR DESCRIPTION
- Improve `math` module documentation.
- I see new users search for stuff like `xor` and `clamp` on `math` but they cant find it, because its on `system`.