### PR TITLE
[backport] Fix #12466 , make sameTree() handle uint literals correctly

### DIFF
--- a/compiler/guards.nim
+++ b/compiler/guards.nim
@@ -436,7 +436,7 @@ proc sameTree*(a, b: PNode): bool =
       if not result and a.sym.magic != mNone:
         result = a.sym.magic == b.sym.magic or sameOpr(a.sym, b.sym)
     of nkIdent: result = a.ident.id == b.ident.id
-    of nkCharLit..nkInt64Lit: result = a.intVal == b.intVal
+    of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
     of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkType: result = a.typ == b.typ

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -582,3 +582,11 @@ template append2*(args: varargs[string, myAppend]): string =
 
 let foo = append2("1", "2", "3")
 echo foo
+
+block t12466:
+  # https://github.com/nim-lang/Nim/issues/12466
+  var a: array[288, uint16]
+  for i in 0'u16 ..< 144'u16:
+    a[0'u16 + i] = i
+  for i in 0'u16 ..< 8'u16:
+    a[0'u16 + i] = i


### PR DESCRIPTION
Fix #12466 