### PR TITLE
compiler/semcall: return the correct lineinfo for nkCallStrLit

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -474,7 +474,8 @@ proc updateDefaultParams(call: PNode) =
 
 proc getCallLineInfo(n: PNode): TLineInfo =
   case n.kind
-  of nkAccQuoted, nkBracketExpr, nkCall, nkCommand: getCallLineInfo(n.sons[0])
+  of nkAccQuoted, nkBracketExpr, nkCall, nkCallStrLit, nkCommand:
+    getCallLineInfo(n.sons[0])
   of nkDotExpr: getCallLineInfo(n.sons[1])
   else: n.info
 

--- a/nimsuggest/tests/tcallstrlit_highlight.nim
+++ b/nimsuggest/tests/tcallstrlit_highlight.nim
@@ -1,0 +1,11 @@
+func foo(s: string) = discard
+
+foo"string"#[!]#
+
+discard """
+$nimsuggest --tester $file
+>highlight $1
+highlight;;skFunc;;1;;5;;3
+highlight;;skType;;1;;12;;6
+highlight;;skFunc;;3;;0;;3
+"""


### PR DESCRIPTION
nimsuggest should now be able to highlight functions in generalized raw string literals correctly.