### PR TITLE
Fix Nim specify wrong option to vccexe when vcc.options.always is set

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -138,7 +138,7 @@ compiler vcc:
     optSize: " /O1 /G7 ",
     compilerExe: "cl",
     cppCompiler: "cl",
-    compileTmpl: "/c$vccplatform$options $include /Fo$objfile $file",
+    compileTmpl: "/c$vccplatform $options $include /Fo$objfile $file",
     buildGui: " /link /SUBSYSTEM:WINDOWS ",
     buildDll: " /LD",
     buildLib: "lib /OUT:$libfile $objfiles",


### PR DESCRIPTION
When I create `nim.cfg` with `vcc.options.always = "/nologo"` and run `nim c --cc:vcc test.nim`, Nim called vccexe.exe like
`vccexe.exe /c --platform:amd64/nologo ...`.
Then I got error because there is no space between `--platform:amd64` and `/nologo`.