### PR TITLE
compiler/semtypes: improve lineinfo for exported object fields

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -729,7 +729,11 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
                      else: rectype.sym
     for i in 0 .. len(n)-3:
       var f = semIdentWithPragma(c, skField, n.sons[i], {sfExported})
-      suggestSym(c.config, n.sons[i].info, f, c.graph.usageSym)
+      let info = if n.sons[i].kind == nkPostfix:
+                   n.sons[i].sons[1].info
+                 else:
+                   n.sons[i].info
+      suggestSym(c.config, info, f, c.graph.usageSym)
       f.typ = typ
       f.position = pos
       f.options = c.config.options
@@ -740,7 +744,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
         f.flags = f.flags + ({sfImportc, sfExportc} * fieldOwner.flags)
       inc(pos)
       if containsOrIncl(check, f.name.id):
-        localError(c.config, n.sons[i].info, "attempt to redefine: '" & f.name.s & "'")
+        localError(c.config, info, "attempt to redefine: '" & f.name.s & "'")
       if a.kind == nkEmpty: addSon(father, newSymNode(f))
       else: addSon(a, newSymNode(f))
       styleCheckDef(c.config, f)

--- a/nimsuggest/tests/tobj_highlight.nim
+++ b/nimsuggest/tests/tobj_highlight.nim
@@ -1,0 +1,11 @@
+type
+  O = object
+    a*: int#[!]#
+
+discard """
+$nimsuggest --tester $file
+>highlight $1
+highlight;;skType;;2;;2;;1
+highlight;;skType;;3;;8;;3
+highlight;;skField;;3;;4;;1
+"""


### PR DESCRIPTION
The line info should now points to the `a`, not the `*`, like this:

    a*: string
    ^

Additionally this fixes nimsuggest's highlighting of exported object
fields.

/cc @narimiran

Also, there are two `proc`s around that does this "unwrapping" in the compiler. I'm thinking of unifying them into one `proc`, but I don't know how should I name it. Any suggestions?

Those two `proc`s are: `getCallLineInfo()` in `semcall` and `getLineInfo()` in `semstmts.semIdentDef()`.