### PR TITLE
introduce csize_t instead of fixing csize

### DIFF
--- a/compiler/linter.nim
+++ b/compiler/linter.nim
@@ -37,7 +37,7 @@ proc beautifyName(s: string, k: TSymKind): string =
     # Types should start with a capital unless builtins like 'int' etc.:
     if s =~ ["int", "uint", "cint", "cuint", "clong", "cstring", "string",
              "char", "byte", "bool", "openArray", "seq", "array", "void",
-             "pointer", "float", "csize", "cdouble", "cchar", "cschar",
+             "pointer", "float", "csize", "csize_t", "cdouble", "cchar", "cschar",
              "cshort", "cu", "nil", "typedesc", "auto", "any",
              "range", "openarray", "varargs", "set", "cfloat", "ref", "ptr",
              "untyped", "typed", "static", "sink", "lent", "type", "owned"]:

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -870,9 +870,15 @@ proc CMSG_FIRSTHDR*(mhdr: ptr Tmsghdr): ptr Tcmsghdr {.
   importc, header: "<sys/socket.h>".}
 
 proc CMSG_SPACE*(len: csize): csize {.
+  importc, header: "<sys/socket.h>", deprecated: "argument `len` should be of type `csize_t`".}
+
+proc CMSG_SPACE*(len: csize_t): csize_t {.
   importc, header: "<sys/socket.h>".}
 
 proc CMSG_LEN*(len: csize): csize {.
+  importc, header: "<sys/socket.h>", deprecated: "argument `len` should be of type `csize_t`".}
+
+proc CMSG_LEN*(len: csize_t): csize_t {.
   importc, header: "<sys/socket.h>".}
 
 const

--- a/lib/posix/posix_linux_amd64.nim
+++ b/lib/posix/posix_linux_amd64.nim
@@ -66,9 +66,9 @@ type
 
   Glob* {.importc: "glob_t", header: "<glob.h>",
            final, pure.} = object ## glob_t
-    gl_pathc*: csize          ## Count of paths matched by pattern.
-    gl_pathv*: cstringArray ## Pointer to a list of matched pathnames.
-    gl_offs*: csize           ## Slots to reserve at the beginning of gl_pathv.
+    gl_pathc*: csize_t            ## Count of paths matched by pattern.
+    gl_pathv*: cstringArray       ## Pointer to a list of matched pathnames.
+    gl_offs*: csize_t             ## Slots to reserve at the beginning of gl_pathv.
     gl_flags*: cint
     gl_closedir*: pointer
     gl_readdir*: pointer
@@ -382,7 +382,7 @@ type
     aio_lio_opcode*: cint     ## Operation to be performed.
     aio_reqprio*: cint        ## Request priority offset.
     aio_buf*: pointer         ## Location of buffer.
-    aio_nbytes*: csize        ## Length of transfer.
+    aio_nbytes*: csize_t        ## Length of transfer.
     aio_sigevent*: SigEvent   ## Signal number and value.
     next_prio: pointer
     abs_prio: cint
@@ -445,22 +445,22 @@ type
   IOVec* {.importc: "struct iovec", pure, final,
             header: "<sys/uio.h>".} = object ## struct iovec
     iov_base*: pointer ## Base address of a memory region for input or output.
-    iov_len*: csize    ## The size of the memory pointed to by iov_base.
+    iov_len*: csize_t    ## The size of the memory pointed to by iov_base.
 
   Tmsghdr* {.importc: "struct msghdr", pure, final,
              header: "<sys/socket.h>".} = object  ## struct msghdr
     msg_name*: pointer  ## Optional address.
     msg_namelen*: SockLen  ## Size of address.
     msg_iov*: ptr IOVec    ## Scatter/gather array.
-    msg_iovlen*: csize   ## Members in msg_iov.
+    msg_iovlen*: csize_t   ## Members in msg_iov.
     msg_control*: pointer  ## Ancillary data; see below.
-    msg_controllen*: csize ## Ancillary data buffer len.
+    msg_controllen*: csize_t ## Ancillary data buffer len.
     msg_flags*: cint ## Flags on received message.
 
 
   Tcmsghdr* {.importc: "struct cmsghdr", pure, final,
               header: "<sys/socket.h>".} = object ## struct cmsghdr
-    cmsg_len*: csize ## Data byte count, including the cmsghdr.
+    cmsg_len*: csize_t ## Data byte count, including the cmsghdr.
     cmsg_level*: cint   ## Originating protocol.
     cmsg_type*: cint    ## Protocol-specific type.
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1846,7 +1846,7 @@ proc find*(a: SkipTable, s, sub: string, start: Natural = 0, last = 0): int
   return -1
 
 when not (defined(js) or defined(nimdoc) or defined(nimscript)):
-  proc c_memchr(cstr: pointer, c: char, n: csize): pointer {.
+  proc c_memchr(cstr: pointer, c: char, n: csize_t): pointer {.
                 importc: "memchr", header: "<string.h>".}
   const hasCStringBuiltin = true
 else:
@@ -1872,7 +1872,7 @@ proc find*(s: string, sub: char, start: Natural = 0, last = 0): int {.noSideEffe
     when hasCStringBuiltin:
       let L = last-start+1
       if L > 0:
-        let found = c_memchr(s[start].unsafeAddr, sub, L)
+        let found = c_memchr(s[start].unsafeAddr, sub, cast[csize_t](L))
         if not found.isNil:
           return cast[ByteAddress](found) -% cast[ByteAddress](s.cstring)
     else:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2270,7 +2270,9 @@ type # these work for most platforms:
     ## This is the same as the type ``short`` in *C*.
   cint* {.importc: "int", nodecl.} = int32
     ## This is the same as the type ``int`` in *C*.
-  csize* {.importc: "size_t", nodecl.} = int
+  csize* {.importc: "size_t", nodecl, deprecated: "use `csize_t` instead".} = int
+    ## This isn't the same as ``size_t`` in *C*. Don't use it.
+  csize_t* {.importc: "size_t", nodecl.} = uint
     ## This is the same as the type ``size_t`` in *C*.
   clonglong* {.importc: "long long", nodecl.} = int64
     ## This is the same as the type ``long long`` in *C*.
@@ -3634,7 +3636,7 @@ when not defined(JS): #and not defined(nimscript):
       when declared(memTrackerOp):
         memTrackerOp("copyMem", dest, size)
     proc moveMem(dest, source: pointer, size: Natural) =
-      c_memmove(dest, source, size)
+      c_memmove(dest, source, csize_t(size))
       when declared(memTrackerOp):
         memTrackerOp("moveMem", dest, size)
     proc equalMem(a, b: pointer, size: Natural): bool =
@@ -3652,7 +3654,7 @@ when not defined(JS): #and not defined(nimscript):
         else: result = 0
       else:
         let minlen = min(x.len, y.len)
-        result = int(nimCmpMem(x.cstring, y.cstring, minlen.csize))
+        result = int(nimCmpMem(x.cstring, y.cstring, cast[csize_t](minlen)))
         if result == 0:
           result = x.len - y.len
 

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -16,18 +16,28 @@ when not defined(nimHasHotCodeReloading):
   {.pragma: nonReloadable.}
 
 proc c_memchr*(s: pointer, c: cint, n: csize): pointer {.
+  importc: "memchr", header: "<string.h>", deprecated: "argument `n` should be of type `csize_t`".}
+proc c_memchr*(s: pointer, c: cint, n: csize_t): pointer {.
   importc: "memchr", header: "<string.h>".}
 proc c_memcmp*(a, b: pointer, size: csize): cint {.
+  importc: "memcmp", header: "<string.h>", noSideEffect, deprecated: "argument `size` should be of type `csize_t`".}
+proc c_memcmp*(a, b: pointer, size: csize_t): cint {.
   importc: "memcmp", header: "<string.h>", noSideEffect.}
 proc c_memcpy*(a, b: pointer, size: csize): pointer {.
+  importc: "memcpy", header: "<string.h>", discardable, deprecated: "argument `size` should be of type `csize_t`".}
+proc c_memcpy*(a, b: pointer, size: csize_t): pointer {.
   importc: "memcpy", header: "<string.h>", discardable.}
 proc c_memmove*(a, b: pointer, size: csize): pointer {.
+  importc: "memmove", header: "<string.h>",discardable, deprecated: "argument `size` should be of type `csize_t`".}
+proc c_memmove*(a, b: pointer, size: csize_t): pointer {.
   importc: "memmove", header: "<string.h>",discardable.}
 proc c_memset*(p: pointer, value: cint, size: csize): pointer {.
+  importc: "memset", header: "<string.h>", discardable, deprecated: "argument `size` should be of type `csize_t`".}
+proc c_memset*(p: pointer, value: cint, size: csize_t): pointer {.
   importc: "memset", header: "<string.h>", discardable.}
 proc c_strcmp*(a, b: cstring): cint {.
   importc: "strcmp", header: "<string.h>", noSideEffect.}
-proc c_strlen*(a: cstring): csize {.
+proc c_strlen*(a: cstring): csize_t {.
   importc: "strlen", header: "<string.h>", noSideEffect.}
 proc c_abort*() {.
   importc: "abort", header: "<stdlib.h>", noSideEffect, noreturn.}
@@ -132,18 +142,18 @@ proc c_sprintf*(buf, frmt: cstring): cint {.
   importc: "sprintf", header: "<stdio.h>", varargs, noSideEffect.}
   # we use it only in a way that cannot lead to security issues
 
-proc c_malloc*(size: csize): pointer {.
+proc c_malloc*(size: csize_t): pointer {.
   importc: "malloc", header: "<stdlib.h>".}
 proc c_free*(p: pointer) {.
   importc: "free", header: "<stdlib.h>".}
-proc c_realloc*(p: pointer, newsize: csize): pointer {.
+proc c_realloc*(p: pointer, newsize: csize_t): pointer {.
   importc: "realloc", header: "<stdlib.h>".}
 
-proc c_fwrite*(buf: pointer, size, n: csize, f: CFilePtr): cint {.
+proc c_fwrite*(buf: pointer, size, n: csize_t, f: CFilePtr): cint {.
   importc: "fwrite", header: "<stdio.h>".}
 
 proc rawWrite*(f: CFilePtr, s: cstring) {.compilerproc, nonReloadable, inline.} =
   # we cannot throw an exception here!
-  discard c_fwrite(s, 1, s.len, f)
+  discard c_fwrite(s, 1, cast[csize_t](s.len), f)
 
 {.pop.}

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -15,24 +15,14 @@
 when not defined(nimHasHotCodeReloading):
   {.pragma: nonReloadable.}
 
-proc c_memchr*(s: pointer, c: cint, n: csize): pointer {.
-  importc: "memchr", header: "<string.h>", deprecated: "argument `n` should be of type `csize_t`".}
 proc c_memchr*(s: pointer, c: cint, n: csize_t): pointer {.
   importc: "memchr", header: "<string.h>".}
-proc c_memcmp*(a, b: pointer, size: csize): cint {.
-  importc: "memcmp", header: "<string.h>", noSideEffect, deprecated: "argument `size` should be of type `csize_t`".}
 proc c_memcmp*(a, b: pointer, size: csize_t): cint {.
   importc: "memcmp", header: "<string.h>", noSideEffect.}
-proc c_memcpy*(a, b: pointer, size: csize): pointer {.
-  importc: "memcpy", header: "<string.h>", discardable, deprecated: "argument `size` should be of type `csize_t`".}
 proc c_memcpy*(a, b: pointer, size: csize_t): pointer {.
   importc: "memcpy", header: "<string.h>", discardable.}
-proc c_memmove*(a, b: pointer, size: csize): pointer {.
-  importc: "memmove", header: "<string.h>",discardable, deprecated: "argument `size` should be of type `csize_t`".}
 proc c_memmove*(a, b: pointer, size: csize_t): pointer {.
   importc: "memmove", header: "<string.h>",discardable.}
-proc c_memset*(p: pointer, value: cint, size: csize): pointer {.
-  importc: "memset", header: "<string.h>", discardable, deprecated: "argument `size` should be of type `csize_t`".}
 proc c_memset*(p: pointer, value: cint, size: csize_t): pointer {.
   importc: "memset", header: "<string.h>", discardable.}
 proc c_strcmp*(a, b: cstring): cint {.

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -83,11 +83,11 @@ proc c_feof(f: File): cint {.
   importc: "feof", header: "<stdio.h>".}
 
 when not declared(c_fwrite):
-  proc c_fwrite(buf: pointer, size, n: csize, f: File): cint {.
+  proc c_fwrite(buf: pointer, size, n: csize_t, f: File): cint {.
     importc: "fwrite", header: "<stdio.h>".}
 
 # C routine that is used here:
-proc c_fread(buf: pointer, size, n: csize, f: File): csize {.
+proc c_fread(buf: pointer, size, n: csize_t, f: File): csize_t {.
   importc: "fread", header: "<stdio.h>", tags: [ReadIOEffect].}
 when defined(windows):
   when not defined(amd64):
@@ -107,7 +107,7 @@ else:
     importc: "ftello", header: "<stdio.h>", tags: [].}
 proc c_ferror(f: File): cint {.
   importc: "ferror", header: "<stdio.h>", tags: [].}
-proc c_setvbuf(f: File, buf: pointer, mode: cint, size: csize): cint {.
+proc c_setvbuf(f: File, buf: pointer, mode: cint, size: csize_t): cint {.
   importc: "setvbuf", header: "<stdio.h>", tags: [].}
 
 proc c_fprintf(f: File, frmt: cstring): cint {.
@@ -153,7 +153,7 @@ proc readBuffer*(f: File, buffer: pointer, len: Natural): int {.
   ## reads `len` bytes into the buffer pointed to by `buffer`. Returns
   ## the actual number of bytes that have been read which may be less than
   ## `len` (if not as many bytes are remaining), but not greater.
-  result = c_fread(buffer, 1, len, f)
+  result = cast[int](c_fread(buffer, 1, cast[csize_t](len), f))
   if result != len: checkErr(f)
 
 proc readBytes*(f: File, a: var openArray[int8|uint8], start, len: Natural): int {.
@@ -185,7 +185,7 @@ proc writeBuffer*(f: File, buffer: pointer, len: Natural): int {.
   ## writes the bytes of buffer pointed to by the parameter `buffer` to the
   ## file `f`. Returns the number of actual written bytes, which may be less
   ## than `len` in case of an error.
-  result = c_fwrite(buffer, 1, len, f)
+  result = cast[int](c_fwrite(buffer, 1, cast[csize_t](len), f))
   checkErr(f)
 
 proc writeBytes*(f: File, a: openArray[int8|uint8], start, len: Natural): int {.
@@ -296,7 +296,7 @@ proc readLine*(f: File, line: var TaintedString): bool {.tags: [ReadIOEffect],
   ## character(s) are not part of the returned string. Returns ``false``
   ## if the end of the file has been reached, ``true`` otherwise. If
   ## ``false`` is returned `line` contains no new data.
-  proc c_memchr(s: pointer, c: cint, n: csize): pointer {.
+  proc c_memchr(s: pointer, c: cint, n: csize_t): pointer {.
     importc: "memchr", header: "<string.h>".}
 
   var pos = 0
@@ -312,7 +312,7 @@ proc readLine*(f: File, line: var TaintedString): bool {.tags: [ReadIOEffect],
 
     var fgetsSuccess = c_fgets(addr line.string[pos], sp.cint, f) != nil
     if not fgetsSuccess: checkErr(f)
-    let m = c_memchr(addr line.string[pos], '\L'.ord, sp)
+    let m = c_memchr(addr line.string[pos], '\L'.ord, cast[csize_t](sp))
     if m != nil:
       # \l found: Could be our own or the one by fgets, in any case, we're done
       var last = cast[ByteAddress](m) - cast[ByteAddress](addr line.string[0])
@@ -536,7 +536,7 @@ proc open*(f: var File, filename: string,
     result = true
     f = cast[File](p)
     if bufSize > 0 and bufSize <= high(cint).int:
-      discard c_setvbuf(f, nil, IOFBF, bufSize.cint)
+      discard c_setvbuf(f, nil, IOFBF, cast[csize_t](bufSize))
     elif bufSize == 0:
       discard c_setvbuf(f, nil, IONBF, 0)
 
@@ -622,7 +622,7 @@ when declared(stdout):
         when defined(windows):
           writeWindows(stdout, s)
         else:
-          discard c_fwrite(s.cstring, s.len, 1, stdout)
+          discard c_fwrite(s.cstring, cast[csize_t](s.len), 1, stdout)
       const linefeed = "\n"
       discard c_fwrite(linefeed.cstring, linefeed.len, 1, stdout)
       discard c_fflush(stdout)
@@ -666,7 +666,7 @@ proc readFile*(filename: string): TaintedString {.tags: [ReadIOEffect], benign.}
   var f: File
   if open(f, filename):
     try:
-      result = readAll(f).TaintedString
+      result = readAll(f)
     finally:
       close(f)
   else:

--- a/lib/system/memory.nim
+++ b/lib/system/memory.nim
@@ -10,7 +10,7 @@ when useLibC:
 
 proc nimCopyMem*(dest, source: pointer, size: Natural) {.nonReloadable, compilerproc, inline.} =
   when useLibC:
-    c_memcpy(dest, source, size)
+    c_memcpy(dest, source, cast[csize_t](size))
   else:
     let d = cast[ptr UncheckedArray[byte]](dest)
     let s = cast[ptr UncheckedArray[byte]](source)
@@ -21,7 +21,7 @@ proc nimCopyMem*(dest, source: pointer, size: Natural) {.nonReloadable, compiler
 
 proc nimSetMem*(a: pointer, v: cint, size: Natural) {.nonReloadable, inline.} =
   when useLibC:
-    c_memset(a, v, size)
+    c_memset(a, v, cast[csize_t](size))
   else:
     let a = cast[ptr UncheckedArray[byte]](a)
     var i = 0
@@ -35,7 +35,7 @@ proc nimZeroMem*(p: pointer, size: Natural) {.compilerproc, nonReloadable, inlin
 
 proc nimCmpMem*(a, b: pointer, size: Natural): cint {.compilerproc, nonReloadable, inline.} =
   when useLibC:
-    c_memcmp(a, b, size)
+    c_memcmp(a, b, cast[csize_t](size))
   else:
     let a = cast[ptr UncheckedArray[byte]](a)
     let b = cast[ptr UncheckedArray[byte]](b)
@@ -45,7 +45,7 @@ proc nimCmpMem*(a, b: pointer, size: Natural): cint {.compilerproc, nonReloadabl
       if d != 0: return d
       inc i
 
-proc nimCStrLen*(a: cstring): csize {.compilerproc, nonReloadable, inline.} =
+proc nimCStrLen*(a: cstring): csize_t {.compilerproc, nonReloadable, inline.} =
   when useLibC:
     c_strlen(a)
   else:

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -215,24 +215,24 @@ elif defined(posix):
       MAP_ANONYMOUS {.importc: "MAP_ANONYMOUS", header: "<sys/mman.h>".}: cint
       MAP_PRIVATE {.importc: "MAP_PRIVATE", header: "<sys/mman.h>".}: cint
 
-  proc mmap(adr: pointer, len: csize, prot, flags, fildes: cint,
+  proc mmap(adr: pointer, len: csize_t, prot, flags, fildes: cint,
             off: int): pointer {.header: "<sys/mman.h>".}
 
-  proc munmap(adr: pointer, len: csize): cint {.header: "<sys/mman.h>".}
+  proc munmap(adr: pointer, len: csize_t): cint {.header: "<sys/mman.h>".}
 
   proc osAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, PROT_READ or PROT_WRITE,
+    result = mmap(nil, cast[csize_t](size), PROT_READ or PROT_WRITE,
                              MAP_PRIVATE or MAP_ANONYMOUS, -1, 0)
     if result == nil or result == cast[pointer](-1):
       raiseOutOfMem()
 
   proc osTryAllocPages(size: int): pointer {.inline.} =
-    result = mmap(nil, size, PROT_READ or PROT_WRITE,
+    result = mmap(nil, cast[csize_t](size), PROT_READ or PROT_WRITE,
                              MAP_PRIVATE or MAP_ANONYMOUS, -1, 0)
     if result == cast[pointer](-1): result = nil
 
   proc osDeallocPages(p: pointer, size: int) {.inline.} =
-    when reallyOsDealloc: discard munmap(p, size)
+    when reallyOsDealloc: discard munmap(p, cast[csize_t](size))
 
 elif defined(windows):
   const

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -14,7 +14,7 @@ proc cmpStrings(a, b: string): int {.inline, compilerproc.} =
   let blen = b.len
   let minlen = min(alen, blen)
   if minlen > 0:
-    result = c_memcmp(unsafeAddr a[0], unsafeAddr b[0], minlen.csize)
+    result = c_memcmp(unsafeAddr a[0], unsafeAddr b[0], cast[csize_t](minlen))
     if result == 0:
       result = alen - blen
   else:

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -185,7 +185,7 @@ else:
   proc cpusetIncl(cpu: cint; s: var CpuSet) {.
     importc: "CPU_SET", header: schedh.}
 
-  proc setAffinity(thread: SysThread; setsize: csize; s: var CpuSet) {.
+  proc setAffinity(thread: SysThread; setsize: csize_t; s: var CpuSet) {.
     importc: "pthread_setaffinity_np", header: pthreadh.}
 
 

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -517,7 +517,7 @@ type
     ai_family*: cint        ## Address family of socket.
     ai_socktype*: cint      ## Socket type.
     ai_protocol*: cint      ## Protocol of socket.
-    ai_addrlen*: csize        ## Length of socket address.
+    ai_addrlen*: csize_t        ## Length of socket address.
     ai_canonname*: cstring  ## Canonical name of service location.
     ai_addr*: ptr SockAddr ## Socket address of socket.
     ai_next*: ptr AddrInfo ## Pointer to next in list.

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -685,9 +685,9 @@ type
 
 {.push callconv:cdecl, dynlib:DLLUtilName.}
 proc md5_Init*(c: var MD5_CTX): cint{.importc: "MD5_Init".}
-proc md5_Update*(c: var MD5_CTX; data: pointer; len: csize): cint{.importc: "MD5_Update".}
+proc md5_Update*(c: var MD5_CTX; data: pointer; len: csize_t): cint{.importc: "MD5_Update".}
 proc md5_Final*(md: cstring; c: var MD5_CTX): cint{.importc: "MD5_Final".}
-proc md5*(d: ptr cuchar; n: csize; md: ptr cuchar): ptr cuchar{.importc: "MD5".}
+proc md5*(d: ptr cuchar; n: csize_t; md: ptr cuchar): ptr cuchar{.importc: "MD5".}
 proc md5_Transform*(c: var MD5_CTX; b: ptr cuchar){.importc: "MD5_Transform".}
 {.pop.}
 
@@ -712,7 +712,7 @@ proc md5_File*(file: string): string {.raises: [IOError,Exception].} =
 
   discard md5_Init(ctx)
   while(let bytes = f.readChars(buf, 0, sz); bytes > 0):
-    discard md5_Update(ctx, buf[0].addr, bytes)
+    discard md5_Update(ctx, buf[0].addr, cast[csize_t](bytes))
 
   discard md5_Final(buf[0].addr, ctx)
   f.close
@@ -731,7 +731,7 @@ proc md5_Str*(str: string): string =
   var i = 0
   while i < str.len:
     let L = min(str.len - i, 512)
-    discard md5_Update(ctx, input[i].addr, L)
+    discard md5_Update(ctx, input[i].addr, cast[csize_t](L))
     i += L
 
   discard md5_Final(addr res, ctx)

--- a/tests/cpp/temitlist.nim
+++ b/tests/cpp/temitlist.nim
@@ -27,9 +27,9 @@ main()
 #bug #6837
 type StdString {.importCpp: "std::string", header: "<string>", byref.} = object
 proc initString(): StdString {.constructor, importCpp: "std::string(@)", header: "<string>".}
-proc size(this: var StdString): csize {.importCpp: "size", header: "<string>".}
+proc size(this: var StdString): csize_t {.importCpp: "size", header: "<string>".}
 
-proc f(): csize =
+proc f(): csize_t =
   var myString: StdString = initString()
   return myString.size()
 

--- a/tests/cpp/tempty_generic_obj.nim
+++ b/tests/cpp/tempty_generic_obj.nim
@@ -36,9 +36,9 @@ proc bar(): VectorAlt[cstring] =
 var x = foo()
 var y = bar()
 
-proc init[T; Self: Vector[T]](_: typedesc[Self], n: csize): Vector[T]
+proc init[T; Self: Vector[T]](_: typedesc[Self], n: csize_t): Vector[T]
   {.importcpp: "std::vector<'*0>(@)", header: "<vector>", constructor, nodecl.}
-proc size[T](x: Vector[T]): csize
+proc size[T](x: Vector[T]): csize_t
   {.importcpp: "#.size()", header: "<vector>", nodecl.}
 
 var z = Vector[int16].init(32)

--- a/tests/manyloc/keineschweine/dependencies/enet/enet.nim
+++ b/tests/manyloc/keineschweine/dependencies/enet/enet.nim
@@ -79,10 +79,10 @@ type
 
   PPacket* = ptr TPacket
   TPacket*{.pure, final.} = object
-    referenceCount: csize
+    referenceCount: csize_t
     flags*: cint
     data*: cstring#ptr cuchar
-    dataLength*: csize
+    dataLength*: csize_t
     freeCallback*: TPacketFreeCallback
 
   PAcknowledgement* = ptr TAcknowledgement
@@ -274,7 +274,7 @@ when defined(Linux) or true:
     PEnetBuffer* = ptr object
     TENetBuffer*{.pure, final.} = object
       data*: pointer
-      dataLength*: csize
+      dataLength*: csize_t
     TENetSocketSet* = Tfd_set
   ## see if these are different on win32, if not then get rid of these
   template ENET_HOST_TO_NET_16*(value: untyped): untyped =
@@ -324,7 +324,7 @@ type
     data*: pointer
     state*: TPeerState
     channels*: PChannel
-    channelCount*: csize
+    channelCount*: csize_t
     incomingBandwidth*: cuint
     outgoingBandwidth*: cuint
     incomingBandwidthThrottleEpoch*: cuint
@@ -374,13 +374,13 @@ type
   TCompressor*{.pure, final.} = object
     context*: pointer
     compress*: proc (context: pointer; inBuffers: ptr TEnetBuffer;
-                     inBufferCount: csize; inLimit: csize;
-                     outData: ptr cuchar; outLimit: csize): csize{.cdecl.}
-    decompress*: proc (context: pointer; inData: ptr cuchar; inLimit: csize;
-                       outData: ptr cuchar; outLimit: csize): csize{.cdecl.}
+                     inBufferCount: csize_t; inLimit: csize_t;
+                     outData: ptr cuchar; outLimit: csize_t): csize_t{.cdecl.}
+    decompress*: proc (context: pointer; inData: ptr cuchar; inLimit: csize_t;
+                       outData: ptr cuchar; outLimit: csize_t): csize_t{.cdecl.}
     destroy*: proc (context: pointer){.cdecl.}
 
-  TChecksumCallback* = proc (buffers: ptr TEnetBuffer; bufferCount: csize): cuint{.
+  TChecksumCallback* = proc (buffers: ptr TEnetBuffer; bufferCount: csize_t): cuint{.
       cdecl.}
 
   PHost* = ptr THost
@@ -394,25 +394,25 @@ type
     randomSeed*: cuint
     recalculateBandwidthLimits*: cint
     peers*: ptr TPeer
-    peerCount*: csize
-    channelLimit*: csize
+    peerCount*: csize_t
+    channelLimit*: csize_t
     serviceTime*: cuint
     dispatchQueue*: TEnetList
     continueSending*: cint
-    packetSize*: csize
+    packetSize*: csize_t
     headerFlags*: cushort
     commands*: array[0..ENET_PROTOCOL_MAXIMUM_PACKET_COMMANDS - 1,
                      TEnetProtocol]
-    commandCount*: csize
+    commandCount*: csize_t
     buffers*: array[0..ENET_BUFFER_MAXIMUM - 1, TEnetBuffer]
-    bufferCount*: csize
+    bufferCount*: csize_t
     checksum*: TChecksumCallback
     compressor*: TCompressor
     packetData*: array[0..ENET_PROTOCOL_MAXIMUM_MTU - 1,
                        array[0..2 - 1, cuchar]]
     receivedAddress*: TAddress
     receivedData*: ptr cuchar
-    receivedDataLength*: csize
+    receivedDataLength*: csize_t
     totalSentData*: cuint
     totalSentPackets*: cuint
     totalReceivedData*: cuint
@@ -430,12 +430,12 @@ type
     packet*: ptr TPacket
 
   TENetCallbacks*{.pure, final.} = object
-    malloc*: proc (size: csize): pointer{.cdecl.}
+    malloc*: proc (size: csize_t): pointer{.cdecl.}
     free*: proc (memory: pointer){.cdecl.}
     no_memory*: proc (){.cdecl.}
 
 {.push callConv:cdecl.}
-proc enet_malloc*(a2: csize): pointer{.
+proc enet_malloc*(a2: csize_t): pointer{.
   importc: "enet_malloc", dynlib: Lib.}
 proc enet_free*(a2: pointer){.
   importc: "enet_free", dynlib: Lib.}
@@ -468,15 +468,15 @@ proc connect*(socket: TEnetSocket; address: var TAddress): cint{.
   importc: "enet_socket_connect", dynlib: Lib.}
 proc connect*(socket: TEnetSocket; address: ptr TAddress): cint{.
   importc: "enet_socket_connect", dynlib: Lib.}
-proc send*(socket: TEnetSocket; address: var TAddress; buffer: ptr TEnetBuffer; size: csize): cint{.
+proc send*(socket: TEnetSocket; address: var TAddress; buffer: ptr TEnetBuffer; size: csize_t): cint{.
   importc: "enet_socket_send", dynlib: Lib.}
-proc send*(socket: TEnetSocket; address: ptr TAddress; buffer: ptr TEnetBuffer; size: csize): cint{.
+proc send*(socket: TEnetSocket; address: ptr TAddress; buffer: ptr TEnetBuffer; size: csize_t): cint{.
   importc: "enet_socket_send", dynlib: Lib.}
 proc receive*(socket: TEnetSocket; address: var TAddress;
-               buffer: ptr TEnetBuffer; size: csize): cint{.
+               buffer: ptr TEnetBuffer; size: csize_t): cint{.
   importc: "enet_socket_receive", dynlib: Lib.}
 proc receive*(socket: TEnetSocket; address: ptr TAddress;
-               buffer: ptr TEnetBuffer; size: csize): cint{.
+               buffer: ptr TEnetBuffer; size: csize_t): cint{.
   importc: "enet_socket_receive", dynlib: Lib.}
 proc wait*(socket: TEnetSocket; a3: ptr cuint; a4: cuint): cint{.
   importc: "enet_socket_wait", dynlib: Lib.}
@@ -492,42 +492,42 @@ proc setHost*(address: PAddress; hostName: cstring): cint{.
   importc: "enet_address_set_host", dynlib: Lib.}
 proc setHost*(address: var TAddress; hostName: cstring): cint{.
   importc: "enet_address_set_host", dynlib: Lib.}
-proc getHostIP*(address: var TAddress; hostName: cstring; nameLength: csize): cint{.
+proc getHostIP*(address: var TAddress; hostName: cstring; nameLength: csize_t): cint{.
   importc: "enet_address_get_host_ip", dynlib: Lib.}
-proc getHost*(address: var TAddress; hostName: cstring; nameLength: csize): cint{.
+proc getHost*(address: var TAddress; hostName: cstring; nameLength: csize_t): cint{.
   importc: "enet_address_get_host", dynlib: Lib.}
 
 ## Call the above two funcs but trim the result string
-proc getHostIP*(address: var TAddress; hostName: var string; nameLength: csize): cint{.inline.} =
+proc getHostIP*(address: var TAddress; hostName: var string; nameLength: csize_t): cint{.inline.} =
   hostName.setLen nameLength
   result = getHostIP(address, cstring(hostName), nameLength)
   if result == 0:
     hostName.setLen(len(cstring(hostName)))
-proc getHost*(address: var TAddress; hostName: var string; nameLength: csize): cint{.inline.} =
+proc getHost*(address: var TAddress; hostName: var string; nameLength: csize_t): cint{.inline.} =
   hostName.setLen nameLength
   result = getHost(address, cstring(hostName), nameLength)
   if result == 0:
     hostName.setLen(len(cstring(hostName)))
 
-proc createPacket*(data: pointer; len: csize; flag: TPacketFlag): PPacket{.
+proc createPacket*(data: pointer; len: csize_t; flag: TPacketFlag): PPacket{.
   importc: "enet_packet_create", dynlib: Lib.}
 proc destroy*(packet: PPacket){.
   importc: "enet_packet_destroy", dynlib: Lib.}
-proc resize*(packet: PPacket; dataLength: csize): cint{.
+proc resize*(packet: PPacket; dataLength: csize_t): cint{.
   importc: "enet_packet_resize", dynlib: Lib.}
 
-proc crc32*(buffers: ptr TEnetBuffer; bufferCount: csize): cuint{.
+proc crc32*(buffers: ptr TEnetBuffer; bufferCount: csize_t): cuint{.
   importc: "enet_crc32", dynlib: Lib.}
 
-proc createHost*(address: ptr TAddress; maxConnections, maxChannels: csize; downSpeed, upSpeed: cuint): PHost{.
+proc createHost*(address: ptr TAddress; maxConnections, maxChannels: csize_t; downSpeed, upSpeed: cuint): PHost{.
   importc: "enet_host_create", dynlib: Lib.}
-proc createHost*(address: var TAddress; maxConnections, maxChannels: csize; downSpeed, upSpeed: cuint): PHost{.
+proc createHost*(address: var TAddress; maxConnections, maxChannels: csize_t; downSpeed, upSpeed: cuint): PHost{.
   importc: "enet_host_create", dynlib: Lib.}
 proc destroy*(host: PHost){.
   importc: "enet_host_destroy", dynlib: Lib.}
-proc connect*(host: PHost; address: ptr TAddress; channelCount: csize; data: cuint): PPeer{.
+proc connect*(host: PHost; address: ptr TAddress; channelCount: csize_t; data: cuint): PPeer{.
   importc: "enet_host_connect", dynlib: Lib.}
-proc connect*(host: PHost; address: var TAddress; channelCount: csize; data: cuint): PPeer{.
+proc connect*(host: PHost; address: var TAddress; channelCount: csize_t; data: cuint): PPeer{.
   importc: "enet_host_connect", dynlib: Lib.}
 
 proc checkEvents*(host: PHost; event: var TEvent): cint{.
@@ -546,7 +546,7 @@ proc compress*(host: PHost; compressor: PCompressor){.
   importc: "enet_host_compress", dynlib: Lib.}
 proc compressWithRangeCoder*(host: PHost): cint{.
   importc: "enet_host_compress_with_range_coder", dynlib: Lib.}
-proc channelLimit*(host: PHost; channelLimit: csize){.
+proc channelLimit*(host: PHost; channelLimit: csize_t){.
   importc: "enet_host_channel_limit", dynlib: Lib.}
 proc bandwidthLimit*(host: PHost; incoming, outgoing: cuint){.
   importc: "enet_host_bandwidth_limit", dynlib: Lib.}
@@ -596,12 +596,12 @@ proc createRangeCoder*(): pointer{.
 proc rangeCoderDestroy*(context: pointer){.
   importc: "enet_range_coder_destroy", dynlib: Lib.}
 proc rangeCoderCompress*(context: pointer; inBuffers: PEnetBuffer; inLimit,
-               bufferCount: csize; outData: cstring; outLimit: csize): csize{.
+               bufferCount: csize_t; outData: cstring; outLimit: csize_t): csize_t{.
   importc: "enet_range_coder_compress", dynlib: Lib.}
-proc rangeCoderDecompress*(context: pointer; inData: cstring; inLimit: csize;
-                            outData: cstring; outLimit: csize): csize{.
+proc rangeCoderDecompress*(context: pointer; inData: cstring; inLimit: csize_t;
+                            outData: cstring; outLimit: csize_t): csize_t{.
   importc: "enet_range_coder_decompress", dynlib: Lib.}
-proc protocolCommandSize*(commandNumber: cuchar): csize{.
+proc protocolCommandSize*(commandNumber: cuchar): csize_t{.
   importc: "enet_protocol_command_size", dynlib: Lib.}
 
 {.pop.}
@@ -609,4 +609,3 @@ proc protocolCommandSize*(commandNumber: cuchar): csize{.
 from hashes import `!$`, `!&`, Hash, hash
 proc hash*(x: TAddress): Hash {.nimcall, noSideEffect.} =
   result = !$(hash(x.host.int32) !& hash(x.port.int16))
-

--- a/tests/manyloc/keineschweine/lib/estreams.nim
+++ b/tests/manyloc/keineschweine/lib/estreams.nim
@@ -26,7 +26,7 @@ proc newBuffer*(pkt: PPacket): PBuffer =
   copyMem(addr result.data[0], pkt.data, pkt.dataLength)
 proc toPacket*(buffer: PBuffer; flags: TPacketFlag): PPacket =
   buffer.data.setLen buffer.pos
-  result = createPacket(cstring(buffer.data), buffer.pos, flags)
+  result = createPacket(cstring(buffer.data), cast[csize_t](buffer.pos), flags)
 
 proc isDirty*(buffer: PBuffer): bool {.inline.} =
   result = (buffer.pos != 0)
@@ -118,5 +118,3 @@ when false:
   echo "flushed"
   b.writeC([1,2,3])
   echo(repr(b))
-
-

--- a/tests/misc/tidentconcatenations.nim
+++ b/tests/misc/tidentconcatenations.nim
@@ -13,10 +13,10 @@ void keccak_512(void* input, int input_len, void* output, int output_len) {}
 """.}
 
 template defineKeccak(bits: untyped) =
-  proc `extKeccak bits`(output: pointer, outSize: csize, input: pointer, inputSize: csize) {.nodecl, importc: "keccak_" & astToStr(bits).}
+  proc `extKeccak bits`(output: pointer, outSize: csize_t, input: pointer, inputSize: csize_t) {.nodecl, importc: "keccak_" & astToStr(bits).}
 
 template defineSha(bits: static[int]) =
-  proc `extSha bits`(output: pointer, outSize: csize, input: pointer, inputSize: csize) {.nodecl, importc: "sha_" & astToStr(bits).}
+  proc `extSha bits`(output: pointer, outSize: csize_t, input: pointer, inputSize: csize_t) {.nodecl, importc: "sha_" & astToStr(bits).}
 
 template defineHashProcs(bits) =
   defineSha(bits)
@@ -29,4 +29,3 @@ extSha256(nil, 0, nil, 0)
 extSha512(nil, 0, nil, 0)
 extKeccak256(nil, 0, nil, 0)
 extKeccak512(nil, 0, nil, 0)
-


### PR DESCRIPTION
Implement the proposal by @Araq in https://github.com/nim-lang/Nim/pull/12447#issuecomment-543135658_

It is actually harder to maintain backwards compatibility with this change instead of https://github.com/nim-lang/Nim/pull/12321. Explicit conversions like `csize(x)` or `cast[csize](x)` would work no matter if `csize` is defined as `int` or `uint`. The new type `csize_t` and deprecating `csize` forces user of `csize` into one of these options:

 * Ignore deprecation warnings
 * Drop support for Nim versions that don't provide `csize_t`
 * Copy the definition of `csize_t` into the project with some `when declared` condition.
 * Avoid using `csize`/`csize_t` all together and use `int`/`uint` directly.

This still does break backwards compatibility, since I did change functions that return `csize` to return `csize_t` now. The alternative would be to introduce new names, for example: `proc c_strlen*(a: cstring): csize` and `proc c_strlen2*(a: cstring): csize_t`. I also didn't introduce a new type `Glob2` next to `Glob` where the members `gl_pathc` and `gl_offs` stay `cint`, because then I would also need to duplicate `posix.glob` and `posix.globfree`. This basically means that every module that uses `csize` anywhere in the exposed symbols needs to duplicate those symbols now with another version that uses `csize_t` instead of `csize` to fix the deprecationd and also stay backwards compatible.

The alternative is to remerge #12321, but with a switch that allows `csize` to stay the old way.
