### PR TITLE
sequtils: replace deprecated 'random' call within example

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -903,7 +903,7 @@ template newSeqWith*(len: int, init: untyped): untyped =
 
     ## Creates a sequence of 20 random numbers from 1 to 10
     import random
-    var seqRand = newSeqWith(20, random(10))
+    var seqRand = newSeqWith(20, rand(10))
 
   var result = newSeq[type(init)](len)
   for i in 0 ..< len:


### PR DESCRIPTION
Just a tiny bit of cleanup; nothing much to see here.