### PR TITLE
Remove sentences referring to the graphics module

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -441,8 +441,7 @@ Miscellaneous
   browser.
 
 * `colors <colors.html>`_
-  This module implements color handling for Nim. It is used by
-  the ``graphics`` module.
+  This module implements color handling for Nim.
 
 * `coro <coro.html>`_
   This module implements experimental coroutines in Nim.

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -6,8 +6,7 @@
 #    distribution, for details about the copyright.
 #
 
-## This module implements color handling for Nim. It is used by
-## the ``graphics`` module.
+## This module implements color handling for Nim.
 
 import strutils
 from algorithm import binarySearch


### PR DESCRIPTION
...because the `graphics` module was removed from the standard library in 2015.