### PR TITLE
Add /nologo option when nim call cl.exe

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -256,9 +256,10 @@ vcc.cpp.exe = "vccexe.exe"
 vcc.linkerexe = "vccexe.exe"
 vcc.cpp.linkerexe = "vccexe.exe"
 
+vcc.options.always =  "/nologo"
 vcc.cpp.options.always = "/EHsc"
-vcc.options.linker = "/F33554432" # set the stack size to 32 MiB
-vcc.cpp.options.linker = "/F33554432"
+vcc.options.linker = "/nologo /F33554432" # set the stack size to 32 MiB
+vcc.cpp.options.linker = "/nologo /F33554432"
 vcc.options.debug = "/Zi /FS /Od"
 vcc.cpp.options.debug = "/Zi /FS /Od"
 vcc.options.speed = "/O2"


### PR DESCRIPTION
When I run nim with `--cc:vcc` option and nim call vccexe to link object files, cl.exe output following message:
```
Microsoft(R) C/C++ Optimizing Compiler Version 19.00.24210 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

Microsoft (R) Incremental Linker Version 14.00.24210.0
Copyright (C) Microsoft Corporation.  All rights reserved.
```

And when I got error message from cl.exe, it output following message:
```
Microsoft(R) C/C++ Optimizing Compiler Version 19.00.24210 for x64
Copyright (C) Microsoft Corporation.  All rights reserved.
```

I don't think these messages are needed to be displayed.
So I added `/nologo` option to config\nim.cfg to suppress these message.

`/nologo` option was used in config\nim.cfg before but following commit removed it.
https://github.com/nim-lang/Nim/commit/d67a9f024eeeb2bc26fb38a98be9a53956003290#diff-43962e0b84a4e84c2e3872ce29d3e0a2

In case want to know whether Nim calling cl.exe or which version of cl.exe is called by Nim,
use `--listcmd` option or run following code:

```nim
# _MSC_VER is version number of cl.exe
var mscVer {.importc: "_MSC_VER", noDecl.}: int
echo mscVer
```