### PR TITLE
colors: fix 'mix' template and make most examples runnable

### DIFF
--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -132,7 +132,6 @@ template mix*(a, b: Color, fn: untyped): untyped =
         y = if y < 0: 0 else: 255
       y
 
-  var ar, ag, ab, br, bg, bb: int
   extract(a, ar, ag, ab)
   extract(b, br, bg, bb)
   rawRGB(><fn(ar, br), ><fn(ag, bg), ><fn(ab, bb))

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -52,12 +52,12 @@ proc `+`*(a, b: Color): Color =
   ## This uses saturated artithmetic, so that each color
   ## component cannot overflow (255 is used as a maximum).
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = Color(0xaa_00_ff)
-  ##     b = Color(0x11_cc_cc)
-  ##   assert a + b == Color(0xbb_cc_ff)
-  ##
+  runnableExamples:
+    var
+      a = Color(0xaa_00_ff)
+      b = Color(0x11_cc_cc)
+    assert a + b == Color(0xbb_cc_ff)
+
   colorOp(satPlus)
 
 proc `-`*(a, b: Color): Color =
@@ -66,24 +66,26 @@ proc `-`*(a, b: Color): Color =
   ## This uses saturated artithmetic, so that each color
   ## component cannot underflow (0 is used as a minimum).
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = Color(0xff_33_ff)
-  ##     b = Color(0x11_ff_cc)
-  ##   assert a - b == Color(0xee_00_33)
-  ##
+  runnableExamples:
+    var
+      a = Color(0xff_33_ff)
+      b = Color(0x11_ff_cc)
+    assert a - b == Color(0xee_00_33)
+
   colorOp(satMinus)
 
 proc extractRGB*(a: Color): tuple[r, g, b: range[0..255]] =
   ## Extracts the red/green/blue components of the color `a`.
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = Color(0xff_00_ff)
-  ##     b = Color(0x00_ff_cc)
-  ##   echo extractRGB(a) # => (r: 255, g: 0, b: 255)
-  ##   echo extractRGB(b) # => (r: 0, g: 255, b: 204)
-  ##
+  runnableExamples:
+    var
+      a = Color(0xff_00_ff)
+      b = Color(0x00_ff_cc)
+    type
+      col = range[0..255]
+    assert extractRGB(a) == (r: 255.col, g: 0.col, b: 255.col)
+    assert extractRGB(b) == (r: 0.col, g: 255.col, b: 204.col)
+
   result.r = a.int shr 16 and 0xff
   result.g = a.int shr 8 and 0xff
   result.b = a.int and 0xff
@@ -92,13 +94,13 @@ proc intensity*(a: Color, f: float): Color =
   ## Returns `a` with intensity `f`. `f` should be a float from 0.0 (completely
   ## dark) to 1.0 (full color intensity).
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = Color(0xff_00_ff)
-  ##     b = Color(0x00_42_cc)
-  ##   assert a.intensity(0.5) == Color(0x80_00_80)
-  ##   assert b.intensity(0.5) == Color(0x00_21_66)
-  ##
+  runnableExamples:
+    var
+      a = Color(0xff_00_ff)
+      b = Color(0x00_42_cc)
+    assert a.intensity(0.5) == Color(0x80_00_80)
+    assert b.intensity(0.5) == Color(0x00_21_66)
+
   var r = toInt(toFloat(a.int shr 16 and 0xff) * f)
   var g = toInt(toFloat(a.int shr 8 and 0xff) * f)
   var b = toInt(toFloat(a.int and 0xff) * f)
@@ -114,16 +116,16 @@ template mix*(a, b: Color, fn: untyped): untyped =
   ## If `fn`'s result is not in the `range[0..255]`,
   ## it will be saturated to be so.
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = Color(0x0a2814)
-  ##     b = Color(0x050a03)
-  ##
-  ##   proc myMix(x, y: int): int =
-  ##     2 * x - 3 * y
-  ##
-  ##   assert mix(a, b, myMix) == Color(0x05_32_1f)
-  ##
+  runnableExamples:
+    var
+      a = Color(0x0a2814)
+      b = Color(0x050a03)
+
+    proc myMix(x, y: int): int =
+      2 * x - 3 * y
+
+    assert mix(a, b, myMix) == Color(0x05_32_1f)
+
   template `><` (x: untyped): untyped =
     # keep it in the range 0..255
     block:
@@ -424,9 +426,8 @@ const
 proc `$`*(c: Color): string =
   ## Converts a color into its textual representation.
   ##
-  ## .. code-block::
-  ##   assert $colFuchsia == "#FF00FF"
-  ##
+  runnableExamples:
+    assert $colFuchsia == "#FF00FF"
   result = '#' & toHex(int(c), 6)
 
 proc colorNameCmp(x: tuple[name: string, col: Color], y: string): int =
@@ -438,15 +439,15 @@ proc parseColor*(name: string): Color =
   ## If no valid color could be parsed ``ValueError`` is raised.
   ## Case insensitive.
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = "silver"
-  ##     b = "#0179fc"
-  ##     c = "#zzmmtt"
-  ##   assert parseColor(a) == Color(0xc0_c0_c0)
-  ##   assert parseColor(b) == Color(0x01_79_fc)
-  ##   doAssertRaises(ValueError): discard parseColor(c)
-  ##
+  runnableExamples:
+    var
+      a = "silver"
+      b = "#0179fc"
+      c = "#zzmmtt"
+    assert parseColor(a) == Color(0xc0_c0_c0)
+    assert parseColor(b) == Color(0x01_79_fc)
+    doAssertRaises(ValueError): discard parseColor(c)
+
   if name[0] == '#':
     result = Color(parseHexInt(name))
   else:
@@ -458,15 +459,15 @@ proc isColor*(name: string): bool =
   ## Returns true if `name` is a known color name or a hexadecimal color
   ## prefixed with ``#``. Case insensitive.
   ##
-  ## .. code-block::
-  ##   var
-  ##     a = "silver"
-  ##     b = "#0179fc"
-  ##     c = "#zzmmtt"
-  ##   assert a.isColor
-  ##   assert b.isColor
-  ##   assert not c.isColor
-  ##
+  runnableExamples:
+    var
+      a = "silver"
+      b = "#0179fc"
+      c = "#zzmmtt"
+    assert a.isColor
+    assert b.isColor
+    assert not c.isColor
+
   if name[0] == '#':
     for i in 1 .. name.len-1:
       if name[i] notin {'0'..'9', 'a'..'f', 'A'..'F'}: return false
@@ -477,7 +478,7 @@ proc isColor*(name: string): bool =
 proc rgb*(r, g, b: range[0..255]): Color =
   ## Constructs a color from RGB values.
   ##
-  ## .. code-block::
-  ##   assert rgb(0, 255, 128) == Color(0x00_ff_80)
-  ##
+  runnableExamples:
+    assert rgb(0, 255, 128) == Color(0x00_ff_80)
+
   result = rawRGB(r, g, b)


### PR DESCRIPTION
This pull request has two commits for the two parts that ended up being related anyway.

First, for some reason, the `mix` template somewhat works in 0.20.2, but using it in 1.0+ causes this error:
```
/home/jjp/code/nim/color_test1.nim(9, 8) template/generic instantiation of `assert` from here
/opt/nim/lib/pure/colors.nim(137, 14) Error: redefinition of 'ar`gensym250057'; previous declaration here: /opt/nim/lib/pure/colors.nim(136, 7)
```
The first commit fixes that. It also fixes #11339; the second example mentioned in that issue spews out C compiler errors in 0.20.2 and produces the above error with 1.0+. With this change, both examples within that issue produce the expected output.

After that, I converted `mix`'s example into a runnable one to help catch regressions, and I decided to convert most of the other examples as well.

There's a few notes about the second commit since it wasn't as straightforward as I thought:
* The `==` operator uses `{.borrow.}`, so I'm unsure how to handle that, but I guess it might be okay as-is since it'll just use the `==` operator for ints.
* I don't know if there's a better way to write `extractRGB`'s example.