### PR TITLE
[backport] fix broken link to non-existing c2nim manual html, fixes #12537 [ci skip]

### DIFF
--- a/doc/backends.rst
+++ b/doc/backends.rst
@@ -136,7 +136,7 @@ there are few sources or providing them along the Nim code is easier than using
 a system library. Libraries installed on the host system can be linked in with
 the `PassL pragma <manual.html#implementation-specific-pragmas-passl-pragma>`_.
 
-To wrap native code, take a look at the `c2nim tool <https://nim-lang.org/docs/c2nim.html>`_ which helps
+To wrap native code, take a look at the `c2nim tool <https://github.com/nim-lang/c2nim/blob/master/doc/c2nim.rst>`_ which helps
 with the process of scanning and transforming header files into a Nim
 interface.
 


### PR DESCRIPTION
instead show c2nim users manual directly from github.

this fixes issue #12537