### PR TITLE
#12543 to add non-destructive procedure `shuffled` 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,6 @@
 - `macros.newLit` now works for ref object types.
 - `system.writeFile` has been overloaded to also support `openarray[byte]`.
 - Added overloaded `strformat.fmt` macro that use specified characters as delimiter instead of '{' and '}'.
-- `random.shuffled` is array/seq shuffle not-in-place.
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 - `macros.newLit` now works for ref object types.
 - `system.writeFile` has been overloaded to also support `openarray[byte]`.
 - Added overloaded `strformat.fmt` macro that use specified characters as delimiter instead of '{' and '}'.
+- `random.shuffled` is array/seq shuffle not-in-place.
 
 ## Library changes
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -689,7 +689,7 @@ when isMainModule:
     doAssert c[1] == 0
 
     const d = [0, 1]
-    let e = shuffled(b)
+    let e = shuffled(d)
     doAssert d[0] == 0
     doAssert d[1] == 1
     doAssert e[0] == 1

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -625,25 +625,7 @@ proc shuffle*[T](x: var openArray[T]) =
     doAssert cards == ["King", "Ace", "Queen", "Ten", "Jack"]
   shuffle(state, x)
 
-proc shuffled*[T](r: var Rand; x: seq[T]): seq[T] {.inline.} =
-  ## Shuffled a array of elements not-in-place using the given state.
-  ##
-  ## See also:
-  ## * `shuffled proc<#shuffled, seq[T]>`_ that uses the default
-  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`_ that return array
-  result = x
-  shuffle(r, result)
-
-proc shuffled*[I, T](r: var Rand; x: array[I, T]): array[I, T] {.inline.} =
-  ## Shuffled a seq of elements not-in-place using the given state.
-  ##
-  ## See also:
-  ## * `shuffled proc<#shuffled, array[I, T]>`_ that uses the default
-  ## * `shuffled proc<#shuffled, Rand, seq[T]>`_ that return seq
-  result = x
-  shuffle(r, result)
-
-proc shuffled*[T](x: seq[T]): seq[T] {.inline.} =
+proc shuffled*[T: seq | array](x: T; r: var Rand = state): T {.inline.} =
   ## Shuffled a seq of elements not-in-place.
   ##
   ## If `randomize<#randomize>`_ has not been called, the order of outcomes
@@ -652,24 +634,8 @@ proc shuffled*[T](x: seq[T]): seq[T] {.inline.} =
   ## This proc uses the default random number generator. Thus, it is **not**
   ## thread-safe.
   ##
-  ## See also:
-  ## * `shuffled proc<#shuffled, Rand, seq[T]>`_ that uses a provided state
-  ## * `shuffled proc<#shuffled, array[I, T]>`_ that return array
-  shuffled(state, x)
-
-proc shuffled*[I, T](x: array[I, T]): array[I, T] {.inline.} =
-  ## Shuffled a array of elements not-in-place.
-  ##
-  ## If `randomize<#randomize>`_ has not been called, the order of outcomes
-  ## from this proc will always be the same.
-  ##
-  ## This proc uses the default random number generator. Thus, it is **not**
-  ## thread-safe.
-  ##
-  ## See also:
-  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`_ that uses a provided state
-  ## * `shuffled proc<#shuffled, seq[T]>`_ that return seq
-  shuffled(state, x)
+  result = x
+  shuffle(r, result)
 
 when not defined(nimscript):
   import times
@@ -722,7 +688,7 @@ when isMainModule:
     doAssert c[0] == 1
     doAssert c[1] == 0
 
-    const d = @[0, 1]
+    const d = [0, 1]
     let e = shuffled(b)
     doAssert d[0] == 0
     doAssert d[1] == 1

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -722,6 +722,13 @@ when isMainModule:
     doAssert c[0] == 1
     doAssert c[1] == 0
 
+    const d = @[0, 1]
+    let e = shuffled(b)
+    doAssert d[0] == 0
+    doAssert d[1] == 1
+    doAssert e[0] == 1
+    doAssert e[1] == 0
+
     doAssert rand(0) == 0
     doAssert rand("a") == 'a'
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -625,7 +625,7 @@ proc shuffle*[T](x: var openArray[T]) =
     doAssert cards == ["King", "Ace", "Queen", "Ten", "Jack"]
   shuffle(state, x)
 
-proc shuffled*[T: seq | array](x: T; r: var Rand = state): T {.inline.} =
+proc shuffled*[T: openArray](x: T; r: var Rand = state): T {.inline.} =
   ## Shuffled a seq of elements not-in-place.
   ##
   ## If `randomize<#randomize>`_ has not been called, the order of outcomes

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -625,6 +625,20 @@ proc shuffle*[T](x: var openArray[T]) =
     doAssert cards == ["King", "Ace", "Queen", "Ten", "Jack"]
   shuffle(state, x)
 
+proc shuffled[T](x: seq[T]): seq[T] =
+  ## Shuffled a sequence of elements not-in-place.
+  ##
+  ## If `randomize<#randomize>`_ has not been called, the order of outcomes
+  ## from this proc will always be the same.
+  ##
+  ## This proc uses the default random number generator. Thus, it is **not**
+  ## thread-safe.
+  ##
+  ## See also:
+  ## * `shuffle proc<#shuffle,openArray[T]>`_ that shuffles elements in-place.
+  result = x
+  shuffle(result)
+
 when not defined(nimscript):
   import times
 
@@ -668,6 +682,13 @@ when isMainModule:
     shuffle(a)
     doAssert a[0] == 1
     doAssert a[1] == 0
+
+    const b = @[0, 1]
+    let c = shuffled(b) 
+    doAssert b[0] == 0
+    doAssert b[1] == 1
+    doAssert c[0] == 1
+    doAssert c[1] == 0
 
     doAssert rand(0) == 0
     doAssert rand("a") == 'a'

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -629,8 +629,8 @@ proc shuffled*[T](r: var Rand; x: seq[T]): seq[T] {.inline.} =
   ## Shuffled a array of elements not-in-place using the given state.
   ##
   ## See also:
-  ## * `shuffled proc<#shuffled, seq[T]>`seq[T] that uses the default
-  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`array[I, T] that return array
+  ## * `shuffled proc<#shuffled, seq[T]>`_ that uses the default
+  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`_ that return array
   result = x
   shuffle(r, result)
 
@@ -638,8 +638,8 @@ proc shuffled*[I, T](r: var Rand; x: array[I, T]): array[I, T] {.inline.} =
   ## Shuffled a seq of elements not-in-place using the given state.
   ##
   ## See also:
-  ## * `shuffled proc<#shuffled, array[I, T]>`array[I, T] that uses the default
-  ## * `shuffled proc<#shuffled, Rand, seq[I, T]>`seq[I, T] that return seq
+  ## * `shuffled proc<#shuffled, array[I, T]>`_ that uses the default
+  ## * `shuffled proc<#shuffled, Rand, seq[T]>`_ that return seq
   result = x
   shuffle(r, result)
 
@@ -653,8 +653,8 @@ proc shuffled*[T](x: seq[T]): seq[T] {.inline.} =
   ## thread-safe.
   ##
   ## See also:
-  ## * `shuffled proc<#shuffled, Rand, seq[T]>`seq[T] that uses a provided state
-  ## * `shuffled proc<#shuffled, array[I, T]>`array[I, T] that return array
+  ## * `shuffled proc<#shuffled, Rand, seq[T]>`_ that uses a provided state
+  ## * `shuffled proc<#shuffled, array[I, T]>`_ that return array
   shuffled(state, x)
 
 proc shuffled*[I, T](x: array[I, T]): array[I, T] {.inline.} =
@@ -667,8 +667,8 @@ proc shuffled*[I, T](x: array[I, T]): array[I, T] {.inline.} =
   ## thread-safe.
   ##
   ## See also:
-  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`array[I, T] that uses a provided state
-  ## * `shuffled proc<#shuffled, seq[I, T]>`seq[I, T] that return seq
+  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`_ that uses a provided state
+  ## * `shuffled proc<#shuffled, seq[T]>`_ that return seq
   shuffled(state, x)
 
 when not defined(nimscript):

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -625,8 +625,26 @@ proc shuffle*[T](x: var openArray[T]) =
     doAssert cards == ["King", "Ace", "Queen", "Ten", "Jack"]
   shuffle(state, x)
 
-proc shuffled[T](x: seq[T]): seq[T] =
-  ## Shuffled a sequence of elements not-in-place.
+proc shuffled*[T](r: var Rand; x: seq[T]): seq[T] {.inline.} =
+  ## Shuffled a array of elements not-in-place using the given state.
+  ##
+  ## See also:
+  ## * `shuffled proc<#shuffled, seq[T]>`seq[T] that uses the default
+  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`array[I, T] that return array
+  result = x
+  shuffle(r, result)
+
+proc shuffled*[I, T](r: var Rand; x: array[I, T]): array[I, T] {.inline.} =
+  ## Shuffled a seq of elements not-in-place using the given state.
+  ##
+  ## See also:
+  ## * `shuffled proc<#shuffled, array[I, T]>`array[I, T] that uses the default
+  ## * `shuffled proc<#shuffled, Rand, seq[I, T]>`seq[I, T] that return seq
+  result = x
+  shuffle(r, result)
+
+proc shuffled*[T](x: seq[T]): seq[T] {.inline.} =
+  ## Shuffled a seq of elements not-in-place.
   ##
   ## If `randomize<#randomize>`_ has not been called, the order of outcomes
   ## from this proc will always be the same.
@@ -635,9 +653,23 @@ proc shuffled[T](x: seq[T]): seq[T] =
   ## thread-safe.
   ##
   ## See also:
-  ## * `shuffle proc<#shuffle,openArray[T]>`_ that shuffles elements in-place.
-  result = x
-  shuffle(result)
+  ## * `shuffled proc<#shuffled, Rand, seq[T]>`seq[T] that uses a provided state
+  ## * `shuffled proc<#shuffled, array[I, T]>`array[I, T] that return array
+  shuffled(state, x)
+
+proc shuffled*[I, T](x: array[I, T]): array[I, T] {.inline.} =
+  ## Shuffled a array of elements not-in-place.
+  ##
+  ## If `randomize<#randomize>`_ has not been called, the order of outcomes
+  ## from this proc will always be the same.
+  ##
+  ## This proc uses the default random number generator. Thus, it is **not**
+  ## thread-safe.
+  ##
+  ## See also:
+  ## * `shuffled proc<#shuffled, Rand, array[I, T]>`array[I, T] that uses a provided state
+  ## * `shuffled proc<#shuffled, seq[I, T]>`seq[I, T] that return seq
+  shuffled(state, x)
 
 when not defined(nimscript):
   import times
@@ -684,7 +716,7 @@ when isMainModule:
     doAssert a[1] == 0
 
     const b = @[0, 1]
-    let c = shuffled(b) 
+    let c = shuffled(b)
     doAssert b[0] == 0
     doAssert b[1] == 1
     doAssert c[0] == 1


### PR DESCRIPTION
## summary
add `shuffled` procedure that shuffle not-in-place.

example)
input
```
echo shuffled(@[1, 2, 3, 4, 5, 6, 7])
```
output
```
@[1, 4, 7, 5, 2, 6, 3]
```

closed #12543 