### PR TITLE
Fix for vm var param

### DIFF
--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -41,10 +41,11 @@ type
     opcFastAsgnComplex,
     opcNodeToReg,
 
-    opcLdArr,  # a = b[c]
-    opcWrArr,  # a[b] = c
-    opcLdObj,  # a = b.c
-    opcWrObj,  # a.b = c
+    opcLdArr,     # a = b[c]
+    opcWrArr,     # a[b] = c
+    opcLdObj,     # a = b.c
+    opcLdObjAddr, # a = addr(b.c)
+    opcWrObj,     # a.b = c
     opcAddrReg,
     opcAddrNode,
     opcLdDeref,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1689,6 +1689,7 @@ proc genCheckedObjAccessAux(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags
   let setLit = c.genx(checkExpr[1])
   var rs = c.getTemp(getSysType(c.graph, n.info, tyBool))
   c.gABC(n, opcContainsSet, rs, setLit, discVal)
+  c.freeTemp(discVal)
   c.freeTemp(setLit)
   # If the check fails let the user know
   let lab1 = c.xjmp(n, if negCheck: opcFJmp else: opcTJmp, rs)
@@ -1719,7 +1720,6 @@ proc genCheckedObjAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
     c.gABC(n, opcLdObj, dest, objR, fieldPos)
 
   c.freeTemp(objR)
-  c.freeTemp(fieldPos)
 
 proc genArrAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
   let arrayType = n.sons[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1719,6 +1719,7 @@ proc genCheckedObjAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
     c.gABC(n, opcLdObj, dest, objR, fieldPos)
 
   c.freeTemp(objR)
+  c.freeTemp(fieldPos)
 
 proc genArrAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
   let arrayType = n.sons[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind

--- a/tests/vm/tvarparam.nim
+++ b/tests/vm/tvarparam.nim
@@ -1,0 +1,92 @@
+discard """
+nimout: '''
+true
+true
+[nil, nil, nil, nil]
+[MyObjectRef(123, 321), nil, nil, nil]
+['A', '\x00', '\x00', '\x00']
+MyObjectRef(123, 321)
+'''
+output: '''
+true
+true
+[nil, nil, nil, nil]
+[MyObjectRef(123, 321), nil, nil, nil]
+['A', '\x00', '\x00', '\x00']
+MyObjectRef(123, 321)
+'''
+"""
+
+type
+  MyObjectRef = ref object
+    a,b: int
+
+  MyContainerObject = ref object
+    member: MyObjectRef
+
+  MySuperContainerObject = ref object
+    member: MyContainerObject
+    arr: array[4, MyObjectRef]
+
+  MyOtherObject = ref object
+    case kind: bool
+    of true:
+      member: MyObjectRef
+    else:
+      discard
+
+proc `$`(arg: MyObjectRef): string =
+  result = "MyObjectRef("
+  result.addInt arg.a
+  result.add ", "
+  result.addInt arg.b
+  result.add ")"
+
+proc foobar(dst: var MyObjectRef) =
+  dst = new(MyObjectRef)
+  dst.a = 123
+  dst.b = 321
+
+proc changeChar(c: var char) =
+  c = 'A'
+
+proc test() =
+  # when it comes from a var, it works
+  var y: MyObjectRef
+  foobar(y)
+  echo y != nil
+  # when it comes from a member, it fails on VM
+  var x = new(MyContainerObject)
+  foobar(x.member)
+  echo x.member != nil
+
+  # when it comes from an array, it fails on VM
+  var arr: array[4, MyObjectRef]
+  echo arr
+  foobar(arr[0])
+  echo arr
+
+  var arr2: array[4, char]
+  changeChar(arr2[0])
+  echo arr2
+
+
+  var z = MyOtherObject(kind: true)
+  foobar(z.member)
+  echo z.member
+
+  # this still doesn't work
+  # var sc = new(MySuperContainerObject)
+  # sc.member = new(MyContainerObject)
+  # foobar(sc.member.member)
+  # echo sc.member.member
+  # foobar(sc.arr[1])
+  # echo sc.arr
+
+  #var str = "---"
+  #changeChar(str[1])
+  #echo str
+
+test()
+static:
+  test()


### PR DESCRIPTION
fixes #12489

Status: 

I am currently blocked in this PR. 

I have a I broke some logic. At the linked code, the value of `regs[ra].node` is `nil` and the compiler crasehs. I have no idea how that happened or how to debug the VM in a way to find this out. I need some help for this.

https://github.com/nim-lang/Nim/blob/fix-for-vm-var-param/compiler/vm.nim#L668

Here are the two stack traces

nimvm:
```
tjsonmacro.nim(640, 11)  tjsonmacro
tjsonmacro.nim(63, 14)   testJson
json.nim(371, 14)        %
json.nim(364, 41)        %
json.nim(331, 36)        %
json.nim(364, 39)        %
json.nim(359, 13)        []=
tableimpl.nim(52, 12)    []=
tableimpl.nim(22, 10)    rawInsert
```
compiler:
```
compiler/nim.nim(106) nim
compiler/nim.nim(83) handleCmdLine
compiler/cmdlinehelper.nim(98) loadConfigsAndRunMainCommand
compiler/main.nim(188) mainCommand
compiler/main.nim(92) commandCompileToC
compiler/modules.nim(144) compileProject
compiler/modules.nim(85) compileModule
compiler/passes.nim(210) processModule
compiler/passes.nim(86) processTopLevelStmt
compiler/sem.nim(601) myProcess
compiler/sem.nim(569) semStmtAndGenerateGenerics
compiler/semstmts.nim(2216) semStmt
compiler/semexprs.nim(987) semExprNoType
compiler/semexprs.nim(2742) semExpr
compiler/semstmts.nim(2156) semStmtList
compiler/semexprs.nim(2794) semExpr
compiler/semstmts.nim(2108) semStaticStmt
compiler/vm.nim(2075) evalStaticStmt
compiler/vm.nim(2065) evalConstExprAux
compiler/vm.nim(668) rawExecute
```
