### PR TITLE
Switch mingw links

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,8 @@ environment:
   DLLS_URL: https://nim-lang.org/download/dlls.zip
   DLLS_ARCHIVE: dlls.zip
   MINGW_DIR: mingw64
-  MINGW_URL: https://nim-lang.org/download/mingw64-6.3.0.7z
-  MINGW_ARCHIVE: mingw64-6.3.0.7z
+  MINGW_URL: https://nim-lang.org/download/mingw64.7z
+  MINGW_ARCHIVE: mingw64.7z
 
   matrix:
     - NIM_TEST_PACKAGES: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ steps:
 
   - bash: |
       mkdir dist
-      curl -L https://nim-lang.org/download/mingw64-6.3.0.7z -o dist/mingw64.7z
+      curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
       curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
       7z x dist/mingw64.7z -odist
       7z x dist/dlls.zip -obin

--- a/tools/downloader.nim
+++ b/tools/downloader.nim
@@ -45,7 +45,7 @@ proc download(pkg: string; c: Controls) {.async.} =
 
 proc apply(a: Actions; c: Controls) {.async.} =
   if a.mingw:
-    await download("mingw" & arch & "-6.3.0", c)
+    await download("mingw" & arch, c)
   if a.aporia:
     await download("aporia-0.4.0", c)
 

--- a/tools/finish.nim
+++ b/tools/finish.nim
@@ -5,7 +5,7 @@ import strutils, os, osproc, streams, browsers
 
 const
   arch = $(sizeof(int)*8)
-  mingw = "mingw$1-6.3.0.7z" % arch
+  mingw = "mingw$1.7z" % arch
   url = r"https://nim-lang.org/download/" & mingw
 
 var

--- a/tools/urldownloader.nim
+++ b/tools/urldownloader.nim
@@ -427,5 +427,5 @@ when isMainModule:
     else:
       echo "Status [" & $status & "] message = [" & $message & "]"
 
-  downloadToFile("https://nim-lang.org/download/mingw64-6.3.0.7z",
+  downloadToFile("https://nim-lang.org/download/mingw64.7z",
                  "test.zip", {optUseCache}, progress)


### PR DESCRIPTION
@dom96 has updated the mingw32.7z and mingw64.7z links to point to the 6.3.0 version which is currently being used in our CI tests. Updating all references to that so that updating mingw going forward will simply require updating the symlinks on nim-lang.org.

Choosenim will [also](https://github.com/dom96/choosenim/pull/143) use these links going forward.

I'll make a separate PR for the nim-lang.org website.