### PR TITLE
foldl supports default value when sequence is empty.

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -730,9 +730,9 @@ template foldl*(sequence, operation: untyped): untyped =
     assert concatenation == "nimiscool"
 
   let s = sequence
-  assert s.len > 0, "Can't fold empty sequences"
+  # assert s.len > 0, "Can't fold empty sequences"
   var result: type(s[0])
-  result = s[0]
+  if s.len > 0: result = s[0]
   for i in 1..<s.len:
     let
       a {.inject.} = result


### PR DESCRIPTION
```nim
import sequtils,strutils

while true:
    readLine(stdin).splitWhitespace.filterIt(it in "0".."9").mapIt(parseFloat it).foldl(a+b).echo
```