### PR TITLE
Fixes compilation of many stdlib modules with `-d:ios`.

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -97,7 +97,7 @@ const StatHasNanoseconds* = defined(linux) or defined(freebsd) or
 
 when (defined(linux) and not defined(android)) and defined(amd64):
   include posix_linux_amd64
-elif (defined(macos) or defined(macosx) or defined(bsd)) and defined(cpu64):
+elif (defined(macos) or defined(macosx) or defined(bsd) or defined(ios)) and defined(cpu64):
   include posix_macos_amd64
 elif defined(nintendoswitch):
   include posix_nintendoswitch

--- a/lib/posix/posix_macos_amd64.nim
+++ b/lib/posix/posix_macos_amd64.nim
@@ -554,7 +554,7 @@ when defined(linux) or defined(nimdoc):
 else:
   var SO_REUSEPORT* {.importc, header: "<sys/socket.h>".}: cint
 
-when defined(macosx):
+when defined(macosx) or defined(ios):
   # We can't use the NOSIGNAL flag in the ``send`` function, it has no effect
   # Instead we should use SO_NOSIGPIPE in setsockopt
   const

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -230,7 +230,7 @@ elif defined(posix):
     when not defined(valgrind_workaround_10121):
       tzset()
 
-  when defined(macosx):
+  when defined(macosx) or defined(ios):
     proc gettimeofday(tp: var Timeval, unused: pointer = nil)
       {.importc: "gettimeofday", header: "<sys/time.h>".}
 
@@ -1200,7 +1200,7 @@ proc getTime*(): Time {.tags: [TimeEffect], benign.} =
     let nanos = convert(Milliseconds, Nanoseconds,
       millis mod convert(Seconds, Milliseconds, 1).int)
     result = initTime(seconds, nanos)
-  elif defined(macosx):
+  elif defined(macosx) or defined(ios):
     var a: Timeval
     gettimeofday(a)
     result = initTime(a.tv_sec.int64,
@@ -2511,7 +2511,7 @@ when not defined(JS):
         fib.add(fib[^1] + fib[^2])
       echo "CPU time [s] ", cpuTime() - t0
       echo "Fib is [s] ", fib
-    when defined(posix) and not defined(osx) and declared(CLOCK_THREAD_CPUTIME_ID):
+    when defined(posix) and not defined(osx) and declared(CLOCK_THREAD_CPUTIME_ID) and not defined(ios):
       # 'clocksPerSec' is a compile-time constant, possibly a
       # rather awful one, so use clock_gettime instead
       var ts: Timespec
@@ -2527,7 +2527,7 @@ when not defined(JS):
     ## on the hardware/OS).
     ##
     ## ``getTime`` should generally be preferred over this proc.
-    when defined(macosx):
+    when defined(macosx) or defined(ios):
       var a: Timeval
       gettimeofday(a)
       result = toBiggestFloat(a.tv_sec.int64) + toBiggestFloat(a.tv_usec)*0.00_0001

--- a/lib/std/monotimes.nim
+++ b/lib/std/monotimes.nim
@@ -41,7 +41,7 @@ type
   MonoTime* = object ## Represents a monotonic timestamp.
     ticks: int64
 
-when defined(macosx):
+when defined(macosx) or defined(ios):
   type
     MachTimebaseInfoData {.pure, final, importc: "mach_timebase_info_data_t",
         header: "<mach/mach_time.h>".} = object
@@ -102,7 +102,7 @@ proc getMonoTime*(): MonoTime {.tags: [TimeEffect].} =
   when defined(JS):
     let ticks = getJsTicks()
     result = MonoTime(ticks: (ticks * 1_000_000_000).int64)
-  elif defined(macosx):
+  elif defined(macosx) or defined(ios):
     let ticks = mach_absolute_time()
     result = MonoTime(ticks: ticks * machAbsoluteTimeFreq.numer div
       machAbsoluteTimeFreq.denom)


### PR DESCRIPTION
We might want to make `ios` imply `macosx` instead. But this is my quick hack to get this to compile for me.