### PR TITLE
Fix crash in terminate handler

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -484,7 +484,9 @@ when defined(cpp) and appType != "lib" and
 
     var msg = "Unknown error in unexpected exception handler"
     try:
+      {.emit"#if !defined(_MSC_VER) || (_MSC_VER >= 1923)".}
       raise
+      {.emit"#endif".}
     except Exception:
       msg = currException.getStackTrace() & "Error: unhandled exception: " &
         currException.msg & " [" & $currException.name & "]"
@@ -492,6 +494,10 @@ when defined(cpp) and appType != "lib" and
       msg = "Error: unhandled cpp exception: " & $e.what()
     except:
       msg = "Error: unhandled unknown cpp exception"
+
+    {.emit"#if defined(_MSC_VER) && (_MSC_VER < 1923)".}
+    msg = "Error: unhandled unknown cpp exception"
+    {.emit"#endif".}
 
     when defined(genode):
       # stderr not available by default, use the LOG session

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -470,28 +470,38 @@ when defined(cpp) and appType != "lib" and
     not defined(js) and not defined(nimscript) and
     hostOS != "standalone" and not defined(noCppExceptions):
 
-  type
-    StdException {.importcpp: "std::exception", header: "<exception>".} = object
-
-  proc what(ex: StdException): cstring {.importcpp: "((char *)#.what())".}
-
   proc setTerminate(handler: proc() {.noconv.})
     {.importc: "std::set_terminate", header: "<exception>".}
+
+  when someGcc:
+    type
+      TypeInfoObject {.header: "<typeinfo>", importcpp: "std::type_info".} = object
+      TypeInfo = ptr TypeInfoObject
+
+    proc name(self: TypeInfo): cstring {.header: "<typeinfo>", importcpp: "#.name()".}
+
+    proc cxaDemangle(mangled_name: cstring, output_buffer: cstring,
+                     length: ptr csize, status: var cint): cstring
+      {.importc: "abi::__cxa_demangle", header: "<cxxabi.h>".}
+
+    proc cxaCurrentExceptionType(): TypeInfo
+      {.importc: "abi::__cxa_current_exception_type", header: "<cxxabi.h>".}
 
   setTerminate proc() {.noconv.} =
     # Remove ourself as a handler, reinstalling the default handler.
     setTerminate(nil)
 
     var msg = "Unknown error in unexpected exception handler"
-    try:
-      raise
-    except Exception:
+    if currException != nil:
       msg = currException.getStackTrace() & "Error: unhandled exception: " &
         currException.msg & " [" & $currException.name & "]"
-    except StdException as e:
-      msg = "Error: unhandled cpp exception: " & $e.what()
-    except:
-      msg = "Error: unhandled unknown cpp exception"
+    else:
+      when someGcc: # defined in lib/system/atomics.nim
+        var demangleStatus: cint
+        let currCppExceptionName = cxaDemangle(cxaCurrentExceptionType().name(), nil, nil, demangleStatus)
+        msg = "Error: unhandled cpp exception: [" & $currCppExceptionName & "]"
+      else:
+        msg = "Error: unhandled unknown cpp exception"
 
     when defined(genode):
       # stderr not available by default, use the LOG session

--- a/tests/cpp/tterminate_handler.nim
+++ b/tests/cpp/tterminate_handler.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "cpp"
-  outputsub: "Error: unhandled cpp exception: [int]"
+  outputsub: "Error: unhandled unknown cpp exception"
   exitcode: 1
 """
 type Crap {.importcpp: "int".} = object

--- a/tests/cpp/tterminate_handler.nim
+++ b/tests/cpp/tterminate_handler.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "cpp"
-  outputsub: "Error: unhandled unknown cpp exception"
+  outputsub: "Error: unhandled cpp exception: [int]"
   exitcode: 1
 """
 type Crap {.importcpp: "int".} = object


### PR DESCRIPTION
Calling `throw` inside terminate handler causes undefined behavior. It is mitigated by trying to deduce exception type without rethrowing.