### PR TITLE
backtick and export marker handling in `eqIdent`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,9 @@
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations` and only returns once all pending async operations are guaranteed to have completed.
 - `asyncdispatch.drain` now consistently uses the passed timeout value for all iterations of the event loop, and not just the first iteration. This is more consistent with the other asyncdispatch apis, and allows `asyncdispatch.drain` to be more efficient.
 - `base64.encode` and `base64.decode` was made faster by about 50%.
-- `htmlgen` adds [MathML](https://wikipedia.org/wiki/MathML) support (ISO 40314).
+- `htmlgen` adds [MathML](https://wikipedia.org/wiki/MathML) support
+  (ISO 40314).
+- `macros.eqIdent` is now invariant to export markers and backtick quotes.
 
 ## Language additions
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1378,16 +1378,22 @@ when defined(nimVmEqIdent):
     ## Style insensitive comparison.
 
   proc eqIdent*(a: NimNode; b: string): bool {.magic: "EqIdent", noSideEffect.}
-    ## Style insensitive comparison.
-    ## ``a`` can be an identifier or a symbol.
+    ## Style insensitive comparison.  ``a`` can be an identifier or a
+    ## symbol. ``a`` may be wrapped in an export marker
+    ## (``nnkPostfix``) or quoted with backticks (``nnkAccQuoted``),
+    ## these nodes will be unwrapped.
 
   proc eqIdent*(a: string; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
-    ## Style insensitive comparison.
-    ## ``b`` can be an identifier or a symbol.
+    ## Style insensitive comparison.  ``b`` can be an identifier or a
+    ## symbol. ``b`` may be wrapped in an export marker
+    ## (``nnkPostfix``) or quoted with backticks (``nnkAccQuoted``),
+    ## these nodes will be unwrapped.
 
   proc eqIdent*(a: NimNode; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
-    ## Style insensitive comparison.
-    ## ``a`` and ``b`` can be an identifier or a symbol.
+    ## Style insensitive comparison.  ``a`` and ``b`` can be an
+    ## identifier or a symbol. Both may be wrapped in an export marker
+    ## (``nnkPostfix``) or quoted with backticks (``nnkAccQuoted``),
+    ## these nodes will be unwrapped.
 
 else:
   # this procedure is optimized for native code, it should not be compiled to nimVM bytecode.

--- a/tests/macros/tmacro1.nim
+++ b/tests/macros/tmacro1.nim
@@ -80,6 +80,22 @@ static:
   assert    fooSym.eqIdent("fOO")
   assertNot fooSym.eqIdent("bar")
 
+  # eqIdent on exported and backtick quoted identifiers
+  let procName = ident("proc")
+  let quoted = nnkAccQuoted.newTree(procName)
+  let exported = nnkPostfix.newTree(ident"*", procName)
+  let exportedQuoted = nnkPostfix.newTree(ident"*", quoted)
+
+  let nodes = @[procName, quoted, exported, exportedQuoted]
+
+  for i in 0 ..< nodes.len:
+    for j in 0 ..< nodes.len:
+      doAssert eqIdent(nodes[i], nodes[j])
+
+  for node in nodes:
+    doAssert eqIdent(node, "proc")
+
+
   var empty: NimNode
   var myLit = newLit("str")
 


### PR DESCRIPTION

The reason for this is that it is pretty annoying in macros to unwrap all these backtick and export markers. Almost everywhere in the language an identifier is equivalent to the same identifier but quoted. 
When writing macros, the macro usually doesn't handle the backtick initially and then it doesn't work and you wonder why and then you realize: "ah backticks, this special snowflake, I love it". In this PR I made `eqIdent` just skip this node internally it it doesn't care if any of it's arguments is backticked or Not. The same is true for the export marker in proc names.

But what made me actually implement this PR is this line of code that I stubled upon:
https://github.com/status-im/nim-stew/blob/master/stew/shims/macros.nim#L149
Aparently it is not just me who wants this behavior changed.

This PR implements the behavior change. 
