### PR TITLE
JS improve indent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,7 +45,7 @@
 
 ### Compiler changes
 
-
+- JS target indent is all spaces, instead of mixed spaces and tabs, for generated JavaScript.
 
 
 ## Bugfixes

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -110,7 +110,7 @@ proc indentLine(p: PProc, r: Rope): Rope =
   var p = p
   while true:
     for i in 0 ..< p.blocks.len + p.extraIndent:
-      prepend(result, "\t".rope)
+      prepend(result, rope"  ")
     if p.up == nil or p.up.prc != p.prc.owner:
       break
     p = p.up


### PR DESCRIPTION
- JSGen Indent be all spaces, instead of randomly mixed spaces and tabs, for generated JavaScript.
