### PR TITLE
[backport] fix #12395

### DIFF
--- a/lib/system/sets.nim
+++ b/lib/system/sets.nim
@@ -17,9 +17,9 @@ type
 proc countBits32(n: uint32): int {.compilerproc.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
   var v = uint32(n)
-  v = v - ((v shr 1) and 0x55555555)
-  v = (v and 0x33333333) + ((v shr 2) and 0x33333333)
-  result = (((v + (v shr 4) and 0xF0F0F0F) * 0x1010101) shr 24).int
+  v = v - ((v shr 1'u32) and 0x55555555'u32)
+  v = (v and 0x33333333'u32) + ((v shr 2'u32) and 0x33333333'u32)
+  result = (((v + (v shr 4'u32) and 0xF0F0F0F'u32) * 0x1010101) shr 24'u32).int
 
 proc countBits64(n: uint64): int {.compilerproc, inline.} =
   # generic formula is from: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel


### PR DESCRIPTION
`countBits32` is now fixed in the same way that `countBits64` was already patched earlier (by adding `'u32` where needed).