### PR TITLE
export nim.cfg parser for use by other tools

### DIFF
--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -201,7 +201,7 @@ proc parseAssignment(L: var TLexer, tok: var TToken;
   else:
     processSwitch(s, val, passPP, info, config)
 
-proc readConfigFile(filename: AbsoluteFile; cache: IdentCache;
+proc readConfigFile*(filename: AbsoluteFile; cache: IdentCache;
                     config: ConfigRef): bool =
   var
     L: TLexer


### PR DESCRIPTION
I'd like to use this for a package manager.