### PR TITLE
Alternative fix for #5050 and #11826 

### DIFF
--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -153,7 +153,11 @@ proc myImportModule(c: PContext, n: PNode; importStmtResult: PNode): PSym =
         err.add toFullPath(c.config, c.graph.importStack[i]) & " imports " &
                 toFullPath(c.config, c.graph.importStack[i+1])
       c.recursiveDep = err
+
+    discard pushOptionEntry(c)
     result = importModuleAs(c, n, c.graph.importModuleCallback(c.graph, c.module, f))
+    popOptionEntry(c)
+
     #echo "set back to ", L
     c.graph.importStack.setLen(L)
     # we cannot perform this check reliably because of

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -418,14 +418,7 @@ proc processOption(c: PContext, n: PNode, resOptions: var TOptions) =
 proc processPush(c: PContext, n: PNode, start: int) =
   if n.sons[start-1].kind in nkPragmaCallKinds:
     localError(c.config, n.info, "'push' cannot have arguments")
-  var x = newOptionEntry(c.config)
-  var y = c.optionStack[^1]
-  x.options = c.config.options
-  x.defaultCC = y.defaultCC
-  x.dynlib = y.dynlib
-  x.notes = c.config.notes
-  x.features = c.features
-  c.optionStack.add(x)
+  var x = pushOptionEntry(c)
   for i in start ..< len(n):
     if not tryProcessOption(c, n.sons[i], c.config.options):
       # simply store it somewhere:
@@ -444,10 +437,7 @@ proc processPop(c: PContext, n: PNode) =
   if c.optionStack.len <= 1:
     localError(c.config, n.info, "{.pop.} without a corresponding {.push.}")
   else:
-    c.config.options = c.optionStack[^1].options
-    c.config.notes = c.optionStack[^1].notes
-    c.features = c.optionStack[^1].features
-    c.optionStack.setLen(c.optionStack.len - 1)
+    popOptionEntry(c)
   when defined(debugOptions):
     echo c.config $ n.info, " POP config is now ", c.config.options
 

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -212,13 +212,28 @@ proc newOptionEntry*(conf: ConfigRef): POptionEntry =
   result.dynlib = nil
   result.notes = conf.notes
 
+proc pushOptionEntry*(c: PContext): POptionEntry =
+  new(result)
+  var prev = c.optionStack[^1]
+  result.options = c.config.options
+  result.defaultCC = prev.defaultCC
+  result.dynlib = prev.dynlib
+  result.notes = c.config.notes
+  result.features = c.features
+  c.optionStack.add(result)
+
+proc popOptionEntry*(c: PContext) =
+  c.config.options = c.optionStack[^1].options
+  c.config.notes = c.optionStack[^1].notes
+  c.features = c.optionStack[^1].features
+  c.optionStack.setLen(c.optionStack.len - 1)
+
 proc newContext*(graph: ModuleGraph; module: PSym): PContext =
   new(result)
   result.enforceVoidContext = PType(kind: tyTyped)
   result.ambiguousSymbols = initIntSet()
-  result.optionStack = @[]
+  result.optionStack = @[newOptionEntry(graph.config)]
   result.libs = @[]
-  result.optionStack.add(newOptionEntry(graph.config))
   result.module = module
   result.friendModules = @[module]
   result.converters = @[]

--- a/tests/pragmas/twarning_off.nim
+++ b/tests/pragmas/twarning_off.nim
@@ -1,0 +1,17 @@
+discard """
+  nimout: '''
+compile start
+Hint: warn_module [Processing]
+Hint: hashes [Processing]
+warn_module.nim(4, 6) Hint: 'test' is declared but not used [XDeclaredButNotUsed]
+compile end
+'''
+"""
+
+static:
+  echo "compile start"
+
+import warn_module
+
+static:
+  echo "compile end"

--- a/tests/pragmas/twarning_off.nim
+++ b/tests/pragmas/twarning_off.nim
@@ -3,7 +3,7 @@ discard """
 compile start
 Hint: warn_module [Processing]
 Hint: hashes [Processing]
-warn_module.nim(4, 6) Hint: 'test' is declared but not used [XDeclaredButNotUsed]
+warn_module.nim(6, 6) Hint: 'test' is declared but not used [XDeclaredButNotUsed]
 compile end
 '''
 """

--- a/tests/pragmas/warn_module.nim
+++ b/tests/pragmas/warn_module.nim
@@ -1,0 +1,7 @@
+
+{.warning[UnusedImport]: off.}
+
+import hashes
+
+proc test(a: float): float =
+  a


### PR DESCRIPTION
Fixes  #11826 
Fixes  #5050

Importing of a module changes ConfigRef, it needs to be preserved and then restored.