### PR TITLE
add --clearNimblePath; fixes #12601

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -381,6 +381,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "nonimblepath", "nobabelpath":
     expectNoArg(conf, switch, arg, pass, info)
     disableNimblePath(conf)
+  of "clearnimblepath":
+    expectNoArg(conf, switch, arg, pass, info)
+    clearNimblePath(conf)
   of "excludepath":
     expectArg(conf, switch, arg, pass, info)
     let path = processPath(conf, arg, info)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -546,6 +546,9 @@ proc disableNimblePath*(conf: ConfigRef) =
   incl conf.globalOptions, optNoNimblePath
   conf.lazyPaths.setLen(0)
 
+proc clearNimblePath*(conf: ConfigRef) =
+  conf.lazyPaths.setLen(0)
+
 include packagehandling
 
 proc getOsCacheDir(): string =

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -102,6 +102,7 @@ Advanced options:
   --putenv:key=value        set an environment variable
   --NimblePath:PATH         add a path for Nimble support
   --noNimblePath            deactivate the Nimble path
+  --clearNimblePath         empty the list of Nimble package search paths
   --noCppExceptions         use default exception handling with C++ backend
   --cppCompileToNamespace:namespace
                             use the provided namespace for the generated C++ code,


### PR DESCRIPTION
Per title; resets the list of Nimble search paths so that they may subsequently be manipulated by further `nimblePath` options.