### PR TITLE
Remove unused imports

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -15,7 +15,7 @@
 
 
 import
-  intsets, ast, astalgo, msgs, renderer, magicsys, types, idents,
+  intsets, ast, msgs, renderer, magicsys, types, idents,
   strutils, options, dfa, lowerings, tables, modulegraphs, msgs,
   lineinfos, parampatterns, sighashes
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -10,7 +10,7 @@
 # This module implements semantic checking for pragmas
 
 import
-  os, platform, condsyms, ast, astalgo, idents, semdata, msgs, renderer,
+  os, condsyms, ast, astalgo, idents, semdata, msgs, renderer,
   wordrecg, ropes, options, strutils, extccomp, math, magicsys, trees,
   types, lookups, lineinfos, pathutils, linter
 

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -12,9 +12,6 @@ import
   wordrecg, strutils, options, guards, lineinfos, semfold, semdata,
   modulegraphs
 
-when not defined(leanCompiler):
-  import writetracking
-
 when defined(useDfa):
   import dfa
 

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -15,9 +15,6 @@ import
   magicsys, idents, lexer, options, parampatterns, strutils, trees,
   linter, lineinfos, lowerings, modulegraphs
 
-when (defined(booting) or defined(nimsuggest)) and not defined(leanCompiler):
-  import docgen
-
 type
   MismatchKind* = enum
     kUnknown, kAlreadyGiven, kUnknownNamedParam, kTypeMismatch, kVarNeeded,

--- a/lib/pure/concurrency/cpuinfo.nim
+++ b/lib/pure/concurrency/cpuinfo.nim
@@ -12,10 +12,7 @@
 include "system/inclrtl"
 
 when not defined(windows):
-  import strutils, posix, os
-
-when defined(linux):
-  import linux
+  import posix
 
 when defined(freebsd) or defined(macosx):
   {.emit:"#include <sys/types.h>".}

--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -3,7 +3,8 @@
 when not declared(os) and not declared(ospaths):
   {.error: "This is an include file for os.nim!".}
 
-from parseutils import skipIgnoreCase
+when defined(windows):
+  from parseutils import skipIgnoreCase
 
 proc c_getenv(env: cstring): cstring {.
   importc: "getenv", header: "<stdlib.h>".}

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -27,9 +27,6 @@ when defined(windows):
 else:
   import posix
 
-when defined(linux):
-  import linux
-
 type
   ProcessOption* = enum ## Options that can be passed to `startProcess proc
                         ## <#startProcess,string,string,openArray[string],StringTableRef,set[ProcessOption]>`_.

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -151,8 +151,7 @@
 
 include "system/inclrtl"
 
-import
-  os, strutils
+import os
 
 type
   CmdLineKind* = enum ## The detected command line token.

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -17,10 +17,9 @@ import strutils, os, parseopt, parseutils, sequtils, net, rdstdin, sexp
 # suggestionResultHook, because suggest.nim is included by sigmatch.
 # So we import that one instead.
 import compiler / [options, commands, modules, sem,
-  passes, passaux, msgs, nimconf,
-  extccomp, condsyms,
-  sigmatch, ast, scriptconfig,
-  idents, modulegraphs, vm, prefixmatches, lineinfos, cmdlinehelper,
+  passes, passaux, msgs,
+  sigmatch, ast,
+  idents, modulegraphs, prefixmatches, lineinfos, cmdlinehelper,
   pathutils]
 
 when defined(windows):

--- a/tests/ccgbugs/tmissingderef2.nim
+++ b/tests/ccgbugs/tmissingderef2.nim
@@ -4,7 +4,7 @@ discard """
 
 # bug #5079
 
-import tables, strutils
+import tables
 
 type Test = ref object
   s: string

--- a/tests/ccgbugs/tuple_canon.nim
+++ b/tests/ccgbugs/tuple_canon.nim
@@ -12,8 +12,7 @@ foo = bar                     # No error if assigned directly
 
 # bug #2250
 
-import
-    math, strutils
+import math
 
 type
     Meters = float

--- a/tests/float/tfloat4.nim
+++ b/tests/float/tfloat4.nim
@@ -2,7 +2,7 @@ discard """
   output: "passed all tests."
 """
 
-import math, strutils
+import strutils
 
 proc c_sprintf(buf, fmt: cstring) {.importc:"sprintf", header: "<stdio.h>", varargs.}
 

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -22,7 +22,7 @@ end
 """
 
 
-import algorithm, math, sequtils, strutils
+import sequtils, strutils
 
 
 block t338:

--- a/tests/macros/tgettype.nim
+++ b/tests/macros/tgettype.nim
@@ -4,7 +4,7 @@ output: '''
 (BracketExpr (Sym "typeDesc") (Sym "User"))
 '''
 """
-import strutils, macros
+import macros
 
 type
   Model = object of RootObj

--- a/tests/macros/tgettypeinst.nim
+++ b/tests/macros/tgettypeinst.nim
@@ -1,7 +1,7 @@
 discard """
 """
 
-import macros, strUtils
+import macros
 
 proc symToIdent(x: NimNode): NimNode =
   case x.kind:

--- a/tests/macros/tmacro1.nim
+++ b/tests/macros/tmacro1.nim
@@ -1,7 +1,5 @@
 import  macros
 
-from uri import `/`
-
 macro test*(a: untyped): untyped =
   var nodes: tuple[a, b: int]
   nodes.a = 4
@@ -22,7 +20,6 @@ macro test*(a: untyped): untyped =
 test:
   "hi"
 
-import strutils
 
 template assertNot(arg: untyped): untyped =
   assert(not(arg))

--- a/tests/macros/tmacro4.nim
+++ b/tests/macros/tmacro4.nim
@@ -2,8 +2,7 @@ discard """
   output: "after"
 """
 
-import
-  macros, strutils
+import macros
 
 macro test_macro*(s: string, n: untyped): untyped =
   result = newNimNode(nnkStmtList)

--- a/tests/macros/tmacros1.nim
+++ b/tests/macros/tmacros1.nim
@@ -5,8 +5,7 @@ discard """
 {a, b}'''
 """
 
-import
-  macros, strutils
+import macros
 
 macro outterMacro*(n, blck: untyped): untyped =
   let n = callsite()

--- a/tests/metatype/tymatrix.nim
+++ b/tests/metatype/tymatrix.nim
@@ -1,5 +1,3 @@
-import typetraits
-
 template reject(e) =
   static: assert(not compiles(e))
 

--- a/tests/misc/tbug511622.nim
+++ b/tests/misc/tbug511622.nim
@@ -1,7 +1,7 @@
 discard """
   output: "3"
 """
-import StrUtils, Math
+import math
 
 proc FibonacciA(n: int): int64 =
   var fn = float64(n)

--- a/tools/dochack/fuzzysearch.nim
+++ b/tools/dochack/fuzzysearch.nim
@@ -5,7 +5,6 @@
 #
 import strutils
 import math
-import macros
 
 
 const

--- a/tools/nimfind.nim
+++ b/tools/nimfind.nim
@@ -28,13 +28,11 @@ In addition, all command line options of Nim that do not affect code generation
 are supported.
 """
 
-import strutils, os, parseopt, parseutils
+import strutils, os, parseopt
 
 import "../compiler" / [options, commands, modules, sem,
-  passes, passaux, msgs, nimconf,
-  extccomp, condsyms,
-  ast, scriptconfig,
-  idents, modulegraphs, vm, prefixmatches, lineinfos, cmdlinehelper,
+  passes, passaux, msgs, ast,
+  idents, modulegraphs, lineinfos, cmdlinehelper,
   pathutils]
 
 import db_sqlite

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -14,7 +14,7 @@ when haveZipLib:
   import zipfiles
 
 import
-  os, osproc, strutils, parseopt, parsecfg, strtabs, streams, debcreation,
+  os, strutils, parseopt, parsecfg, strtabs, streams, debcreation,
   std / sha1
 
 const


### PR DESCRIPTION
Removed unused imports, as reported by our CI/nightlies logs.
I got annoyed by having **560+** `Warning: imported and not used` messages there.

Please double-check all the changes in the first commit, because our CIs might not hit every branch of the code where some imports might be used, or there might be some other usage of those files.