### PR TITLE
allow `random` module to be used in standalone:

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -625,7 +625,7 @@ proc shuffle*[T](x: var openArray[T]) =
     doAssert cards == ["King", "Ace", "Queen", "Ten", "Jack"]
   shuffle(state, x)
 
-when not defined(nimscript):
+when not defined(nimscript) and not defined(standalone):
   import times
 
   proc randomize*() {.benign.} =


### PR DESCRIPTION
proc randomized*() uses time releated function which is not available on
standalone, so disable this function for standalone.