### PR TITLE
Version of trimZeros without temp strings

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2401,13 +2401,13 @@ proc trimZeros*(x: var string; decimalSep = '.') {.noSideEffect.} =
     x.trimZeros()
     doAssert x == "123.456"
 
-  var last = find(x, 'e')
-  last = if last >= 0: last - 1 else: high(x)
-  let sPos = find(x, decimalSep, last = last)
+  let sPos = find(x, decimalSep)
   if sPos >= 0:
+    var last = find(x, 'e', start = sPos)
+    last = if last >= 0: last - 1 else: high(x)
     var pos = last
     while pos >= 0 and x[pos] == '0': dec(pos)
-    if x[pos] != decimalSep: inc(pos)
+    if pos > sPos: inc(pos)
     x.delete(pos, last)
 
 type

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2400,17 +2400,13 @@ proc trimZeros*(x: var string) {.noSideEffect.} =
     var x = "123.456000000"
     x.trimZeros()
     doAssert x == "123.456"
-  var spl: seq[string]
-  if x.contains('.') or x.contains(','):
-    if x.contains('e'):
-      spl = x.split('e')
-      x = spl[0]
-    while x[x.high] == '0':
-      x.setLen(x.len-1)
-    if x[x.high] in [',', '.']:
-      x.setLen(x.len-1)
-    if spl.len > 0:
-      x &= "e" & spl[1]
+  if x.contains({'.', ','}):
+    let fE = x.find('e')
+    let last = if fE >= 0: fE-1 else: x.high
+    var first = last
+    while first >= 0 and x[first] == '0': dec(first)
+    if x[first] in {',', '.'}: dec(first)
+    x.delete(first+1, last)
 
 type
   BinaryPrefixMode* = enum ## the different names for binary prefixes

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -200,6 +200,27 @@ proc testTrimZeros() =
   x = "1.0e2"
   x.trimZeros()
   assert x == "1e2"
+  x = "78.90"
+  x.trimZeros()
+  assert x == "78.9"
+  x = "1.23e4"
+  x.trimZeros()
+  assert x == "1.23e4"
+  x = "1.01"
+  x.trimZeros()
+  assert x == "1.01"
+  x = "1.1001"
+  x.trimZeros()
+  assert x == "1.1001"
+  x = "0.0"
+  x.trimZeros()
+  assert x == "0"
+  x = "0.01"
+  x.trimZeros()
+  assert x == "0.01"
+  x = "1e0"
+  x.trimZeros()
+  assert x == "1e0"
 
 proc testSplitLines() =
   let fixture = "a\nb\rc\r\nd"

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -187,6 +187,20 @@ proc testRFind =
   assert "0123456789ABCDEFGAH".rfind({'0'..'9'}, start=5) == 9
   assert "0123456789ABCDEFGAH".rfind({'0'..'9'}, start=10) == -1
 
+proc testTrimZeros() =
+  var x = "1200"
+  x.trimZeros()
+  assert x == "1200"
+  x = "120.0"
+  x.trimZeros()
+  assert x == "120"
+  x = "0."
+  x.trimZeros()
+  assert x == "0"
+  x = "1.0e2"
+  x.trimZeros()
+  assert x == "1e2"
+
 proc testSplitLines() =
   let fixture = "a\nb\rc\r\nd"
   assert len(fixture.splitLines) == 4
@@ -246,6 +260,7 @@ proc testParseInts =
 testDelete()
 testFind()
 testRFind()
+testTrimZeros()
 testSplitLines()
 testCountLines()
 testParseInts()


### PR DESCRIPTION
* removed usage of split

Also I think it should accept parameter ``decimalSep`` instead of guessing the separator.