### PR TITLE
Add rdstdin.readBoolFromStdin template

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,7 +34,8 @@
   delimiter instead of '{' and '}'.
 - introduced new procs in `tables.nim`: `OrderedTable.take`, `CountTable.del`,
   `CountTable.take`
-
+- Added `rdstdin.ask` convenience template for `readLineFromStdin` and `parseBool` inside a `try` block,
+  to ask a question to the user on the terminal and return a boolean value.
 
 - Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into
   operations that work on a copy of the data and return the mutated copy. As the existing

--- a/changelog.md
+++ b/changelog.md
@@ -34,7 +34,7 @@
   delimiter instead of '{' and '}'.
 - introduced new procs in `tables.nim`: `OrderedTable.take`, `CountTable.del`,
   `CountTable.take`
-- Added `rdstdin.ask` convenience template for `readLineFromStdin` and `parseBool` inside a `try` block,
+- Added `rdstdin.readBoolFromStdin` convenience template for `readLineFromStdin` inside a `try` block,
   to ask a question to the user on the terminal and return a boolean value.
 
 - Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -76,7 +76,7 @@ template readBoolFromStdin*(question: string, default: bool, verbose = false): b
   ## If verbose is ``true`` the response will be printed to the terminal.
   ##
   ## .. code-block:: nim
-  ##   assert ask("Is Nim awesome?. (y/n)", false) == true
+  ##   assert readBoolFromStdin("Is Nim awesome?. (y/n)", default = true) == true
   ##
   var choice: bool
   try:

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -67,8 +67,8 @@ else:
     linenoise.free(buffer)
     result = true
 
-template ask*(question: string, default: bool): bool =
-  ## Convenience template for ``readLineFromStdin`` and ``parseBool`` inside a ``try`` block,
+template ask*(question: string, default: bool, verbose = false): bool =
+  ## Convenience template for ``readLineFromStdin`` inside a ``try`` block,
   ## to ask a question to the user on the terminal and return a boolean value.
   ## You can provide a default boolean value that will be returned when ``parseBool``
   ## can not parse the user input, this template does not raise ``ValueError`` by itself.
@@ -83,4 +83,7 @@ template ask*(question: string, default: bool): bool =
     choice = readLineFromStdin(question) in ["y", "yes", "true", "1", "on"]
   except:
     choice = default
+  finally:
+    if verbose:
+      echo choice
   choice

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -12,8 +12,6 @@
 ## (e.g. you can navigate with the arrow keys). On Windows ``system.readLine``
 ## is used. This suffices because Windows' console already provides the
 ## wanted functionality.
-from strutils import parseBool
-export parseBool
 
 {.deadCodeElim: on.}  # dce option deprecated
 
@@ -69,7 +67,7 @@ else:
     linenoise.free(buffer)
     result = true
 
-template ask*(question: string, postfix = "?. (y/n): ", verbose = false, default = false): bool =
+template ask*(question: string, default: bool): bool =
   ## Convenience template for ``readLineFromStdin`` and ``parseBool`` inside a ``try`` block,
   ## to ask a question to the user on the terminal and return a boolean value.
   ## You can provide a default boolean value that will be returned when ``parseBool``
@@ -78,14 +76,11 @@ template ask*(question: string, postfix = "?. (y/n): ", verbose = false, default
   ## If verbose is ``true`` the response will be printed to the terminal.
   ##
   ## .. code-block:: nim
-  ##   assert ask"Is Nim awesome" == true
+  ##   assert ask("Is Nim awesome?. (y/n)", false) == true
   ##
   var choice: bool
   try:
-    choice = readLineFromStdin(question & postfix).string.parseBool
-  except ValueError:
+    choice = readLineFromStdin(question) in ["y", "yes", "true", "1", "on"]
+  except:
     choice = default
-  finally:
-    if verbose:
-      echo choice
   choice

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -12,6 +12,8 @@
 ## (e.g. you can navigate with the arrow keys). On Windows ``system.readLine``
 ## is used. This suffices because Windows' console already provides the
 ## wanted functionality.
+from strutils import parseBool
+export parseBool
 
 {.deadCodeElim: on.}  # dce option deprecated
 
@@ -67,3 +69,23 @@ else:
     linenoise.free(buffer)
     result = true
 
+template ask*(question: string, postfix = "?. (y/n): ", verbose = false, default = false): bool =
+  ## Convenience template for ``readLineFromStdin`` and ``parseBool`` inside a ``try`` block,
+  ## to ask a question to the user on the terminal and return a boolean value.
+  ## You can provide a default boolean value that will be returned when ``parseBool``
+  ## can not parse the user input, this template does not raise ``ValueError`` by itself.
+  ## A postfix string can be appended at the end of the question.
+  ## If verbose is ``true`` the response will be printed to the terminal.
+  ##
+  ## .. code-block:: nim
+  ##   assert ask"Is Nim awesome" == true
+  ##
+  var choice: bool
+  try:
+    choice = readLineFromStdin(question & postfix).string.parseBool
+  except ValueError:
+    choice = default
+  finally:
+    if verbose:
+      echo choice
+  choice

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -67,7 +67,7 @@ else:
     linenoise.free(buffer)
     result = true
 
-template ask*(question: string, default: bool, verbose = false): bool =
+template readBoolFromStdin*(question: string, default: bool, verbose = false): bool =
   ## Convenience template for ``readLineFromStdin`` inside a ``try`` block,
   ## to ask a question to the user on the terminal and return a boolean value.
   ## You can provide a default boolean value that will be returned when ``parseBool``

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -70,9 +70,7 @@ else:
 template readBoolFromStdin*(question: string, default: bool, verbose = false): bool =
   ## Convenience template for ``readLineFromStdin`` inside a ``try`` block,
   ## to ask a question to the user on the terminal and return a boolean value.
-  ## You can provide a default boolean value that will be returned when ``parseBool``
-  ## can not parse the user input, this template does not raise ``ValueError`` by itself.
-  ## A postfix string can be appended at the end of the question.
+  ## You can provide a default boolean value that will be returned when user input can not be parsed.
   ## If verbose is ``true`` the response will be printed to the terminal.
   ##
   ## .. code-block:: nim


### PR DESCRIPTION
- Add `ask("question")` convenience template for `readLineFromStdin` and `parseBool`, to ask a question to the user on the terminal and return a boolean value.
- Documentation and examples.

Very frequently you may want to use `readLineFromStdin` to ask something to the user, 
this can save a lot of typing and DRY. Just 1 small `template`.

:slightly_smiling_face: 
