### PR TITLE
Make type renderable from AST renderer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,9 @@
   `const SOMECONST = 0.int; procThatTakesInt32(SOMECONST)` will be illegal now.
   Simply write `const SOMECONST = 0` instead.
 
+- The object type names behind ref object and ptr object types have changed in order to 
+  make rendered code compilable. Previously, `Matrix = ref object` had type name
+  `Matrix:ObjectType` now it is simply `Matrix`.
 
 
 ## Library additions

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -10,7 +10,7 @@
 # This module implements lookup helpers.
 
 import
-  intsets, ast, astalgo, idents, semdata, types, msgs, options,
+  intsets, ast, astalgo, idents, semdata, msgs, options,
   renderer, nimfix/prettybase, lineinfos, strutils
 
 proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope)

--- a/compiler/procfind.nim
+++ b/compiler/procfind.nim
@@ -11,7 +11,7 @@
 # This is needed for proper handling of forward declarations.
 
 import
-  ast, astalgo, msgs, semdata, types, trees, strutils
+  ast, astalgo, msgs, semdata, types, trees, strutils, renderer
 
 proc equalGenericParams(procA, procB: PNode): bool =
   if len(procA) != len(procB): return false

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -15,9 +15,20 @@ when defined(nimHasUsed):
   {.used.}
 
 import
-  lexer, options, idents, strutils, ast, msgs, lineinfos
+  lexer, options, idents, strutils, ast, msgs, lineinfos, types
 
 type
+  TPreferedDesc* = enum
+    preferName, # default
+    preferDesc, # probably should become what preferResolved is
+    preferExported,
+    preferModuleInfo, # fully qualified
+    preferGenericArg,
+    preferTypeName,
+    preferResolved, # fully resolved symbols
+    preferMixed, # show symbol + resolved symbols if it differs, eg: seq[cint{int32}, float]
+
+
   TRenderFlag* = enum
     renderNone, renderNoBody, renderNoComments, renderDocComments,
     renderNoPragmas, renderIds, renderNoProcDefs, renderSyms
@@ -47,6 +58,8 @@ type
       pendingNewlineCount: int
     fid*: FileIndex
     config*: ConfigRef
+
+proc renderTree*(n: PNode, renderFlags: TRenderFlags = {}): string
 
 # We render the source code in a two phases: The first
 # determines how long the subtree will likely be, the second
@@ -307,6 +320,328 @@ proc gcoms(g: var TSrcGen) =
   for i in 0 .. high(g.comStack): gcom(g, g.comStack[i])
   popAllComs(g)
 
+
+
+#------------------------------------------------------------------------------
+
+proc typeToString*(typ: PType; prefer: TPreferedDesc = preferName): string
+template `$`*(typ: PType): string = typeToString(typ)
+
+const preferToResolveSymbols = {preferName, preferTypeName, preferModuleInfo,
+  preferGenericArg, preferResolved, preferMixed}
+
+
+proc valueToString(a: PNode): string =
+  case a.kind
+  of nkCharLit..nkUInt64Lit: result = $a.intVal
+  of nkFloatLit..nkFloat128Lit: result = $a.floatVal
+  of nkStrLit..nkTripleStrLit: result = a.strVal
+  else: result = "<invalid value>"
+
+proc rangeToStr(n: PNode): string =
+  assert(n.kind == nkRange)
+  result = valueToString(n.sons[0]) & ".." & valueToString(n.sons[1])
+
+const
+  typeToStr: array[TTypeKind, string] = ["None", "bool", "char", "empty",
+    "Alias", "typeof(nil)", "untyped", "typed", "typeDesc",
+    "GenericInvocation", "GenericBody", "GenericInst", "GenericParam",
+    "distinct $1", "enum", "ordinal[$1]", "array[$1, $2]", "object", "tuple",
+    "set[$1]", "range[$1]", "ptr ", "ref ", "var ", "seq[$1]", "proc",
+    "pointer", "OpenArray[$1]", "string", "cstring", "Forward",
+    "int", "int8", "int16", "int32", "int64",
+    "float", "float32", "float64", "float128",
+    "uint", "uint8", "uint16", "uint32", "uint64",
+    "owned", "sink",
+    "lent ", "varargs[$1]", "UncheckedArray[$1]", "Error Type",
+    "BuiltInTypeClass", "UserTypeClass",
+    "UserTypeClassInst", "CompositeTypeClass", "inferred",
+    "and", "or", "not", "any", "static", "TypeFromExpr", "FieldAccessor",
+    "void"]
+
+proc getProcHeader*(conf: ConfigRef; sym: PSym; prefer: TPreferedDesc = preferName; getDeclarationPath = true): string =
+  assert sym != nil
+  # consider using `skipGenericOwner` to avoid fun2.fun2 when fun2 is generic
+  result = sym.owner.name.s & '.' & sym.name.s
+  if sym.kind in routineKinds:
+    result.add '('
+    var n = sym.typ.n
+    for i in 1 ..< len(n):
+      let p = n.sons[i]
+      if p.kind == nkSym:
+        add(result, p.sym.name.s)
+        add(result, ": ")
+        add(result, typeToString(p.sym.typ, prefer))
+        if i != len(n)-1: add(result, ", ")
+      else:
+        result.add renderTree(p)
+    add(result, ')')
+    if n.sons[0].typ != nil:
+      result.add(": " & typeToString(n.sons[0].typ, prefer))
+  if getDeclarationPath:
+    result.add " [declared in "
+    result.add(conf$sym.info)
+    result.add "]"
+
+
+proc addTypeFlags(name: var string, typ: PType) {.inline.} =
+  if tfNotNil in typ.flags: name.add(" not nil")
+
+proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
+  let preferToplevel = prefer
+  proc getPrefer(prefer: TPreferedDesc): TPreferedDesc =
+    if preferToplevel in {preferResolved, preferMixed}:
+      preferToplevel # sticky option
+    else:
+      prefer
+
+  proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
+    let prefer = getPrefer(prefer)
+    let t = typ
+    result = ""
+    if t == nil: return
+    if prefer in preferToResolveSymbols and t.sym != nil and
+          sfAnon notin t.sym.flags and t.kind != tySequence:
+      if t.kind == tyInt and isIntLit(t):
+        result = t.sym.name.s & " literal(" & $t.n.intVal & ")"
+      elif t.kind == tyAlias and t.sons[0].kind != tyAlias:
+        result = typeToString(t.sons[0])
+      elif prefer in {preferResolved, preferMixed}:
+        case t.kind
+        of IntegralTypes + {tyFloat..tyFloat128} + {tyString, tyCString}:
+          result = typeToStr[t.kind]
+        of tyGenericBody:
+          result = typeToString(t.lastSon)
+        of tyCompositeTypeClass:
+          # avoids showing `A[any]` in `proc fun(a: A)` with `A = object[T]`
+          result = typeToString(t.lastSon.lastSon)
+        else:
+          result = t.sym.name.s
+        if prefer == preferMixed and result != t.sym.name.s:
+          result = t.sym.name.s & "{" & result & "}"
+      elif prefer in {preferName, preferTypeName} or t.sym.owner.isNil:
+        # note: should probably be: {preferName, preferTypeName, preferGenericArg}
+        result = t.sym.name.s
+        if t.kind == tyGenericParam and t.len > 0:
+          result.add ": "
+          var first = true
+          for son in t.sons:
+            if not first: result.add " or "
+            result.add son.typeToString
+            first = false
+      else:
+        result = t.sym.owner.name.s & '.' & t.sym.name.s
+      result.addTypeFlags(t)
+      return
+    case t.kind
+    of tyInt:
+      if not isIntLit(t) or prefer == preferExported:
+        result = typeToStr[t.kind]
+      else:
+        if prefer == preferGenericArg:
+          result = $t.n.intVal
+        else:
+          result = "int literal(" & $t.n.intVal & ")"
+    of tyGenericInst, tyGenericInvocation:
+      result = typeToString(t.sons[0]) & '['
+      for i in 1 ..< len(t)-ord(t.kind != tyGenericInvocation):
+        if i > 1: add(result, ", ")
+        add(result, typeToString(t.sons[i], preferGenericArg))
+      add(result, ']')
+    of tyGenericBody:
+      result = typeToString(t.lastSon) & '['
+      for i in 0 .. len(t)-2:
+        if i > 0: add(result, ", ")
+        add(result, typeToString(t.sons[i], preferTypeName))
+      add(result, ']')
+    of tyTypeDesc:
+      if t.sons[0].kind == tyNone: result = "typedesc"
+      else: result = "type " & typeToString(t.sons[0])
+    of tyStatic:
+      if prefer == preferGenericArg and t.n != nil:
+        result = t.n.renderTree
+      else:
+        result = "static[" & (if t.len > 0: typeToString(t.sons[0]) else: "") & "]"
+        if t.n != nil: result.add "(" & renderTree(t.n) & ")"
+    of tyUserTypeClass:
+      if t.sym != nil and t.sym.owner != nil:
+        if t.isResolvedUserTypeClass: return typeToString(t.lastSon)
+        return t.sym.owner.name.s
+      else:
+        result = "<invalid tyUserTypeClass>"
+    of tyBuiltInTypeClass:
+      result = case t.base.kind:
+        of tyVar: "var"
+        of tyRef: "ref"
+        of tyPtr: "ptr"
+        of tySequence: "seq"
+        of tyArray: "array"
+        of tySet: "set"
+        of tyRange: "range"
+        of tyDistinct: "distinct"
+        of tyProc: "proc"
+        of tyObject: "object"
+        of tyTuple: "tuple"
+        of tyOpenArray: "openArray"
+        else: typeToStr[t.base.kind]
+    of tyInferred:
+      let concrete = t.previouslyInferred
+      if concrete != nil: result = typeToString(concrete)
+      else: result = "inferred[" & typeToString(t.base) & "]"
+    of tyUserTypeClassInst:
+      let body = t.base
+      result = body.sym.name.s & "["
+      for i in 1 .. len(t) - 2:
+        if i > 1: add(result, ", ")
+        add(result, typeToString(t.sons[i]))
+      result.add "]"
+    of tyAnd:
+      for i, son in t.sons:
+        result.add(typeToString(son))
+        if i < t.sons.high:
+          result.add(" and ")
+    of tyOr:
+      for i, son in t.sons:
+        result.add(typeToString(son))
+        if i < t.sons.high:
+          result.add(" or ")
+    of tyNot:
+      result = "not " & typeToString(t.sons[0])
+    of tyUntyped:
+      #internalAssert t.len == 0
+      result = "untyped"
+    of tyFromExpr:
+      if t.n == nil:
+        result = "unknown"
+      else:
+        result = "type(" & renderTree(t.n) & ")"
+    of tyArray:
+      if t.sons[0].kind == tyRange:
+        result = "array[" & rangeToStr(t.sons[0].n) & ", " &
+            typeToString(t.sons[1]) & ']'
+      else:
+        result = "array[" & typeToString(t.sons[0]) & ", " &
+            typeToString(t.sons[1]) & ']'
+    of tyUncheckedArray:
+      result = "UncheckedArray[" & typeToString(t.sons[0]) & ']'
+    of tySequence:
+      result = "seq[" & typeToString(t.sons[0]) & ']'
+    of tyOpt:
+      result = "opt[" & typeToString(t.sons[0]) & ']'
+    of tyOrdinal:
+      result = "ordinal[" & typeToString(t.sons[0]) & ']'
+    of tySet:
+      result = "set[" & typeToString(t.sons[0]) & ']'
+    of tyOpenArray:
+      result = "openArray[" & typeToString(t.sons[0]) & ']'
+    of tyDistinct:
+      result = "distinct " & typeToString(t.sons[0],
+        if prefer == preferModuleInfo: preferModuleInfo else: preferTypeName)
+    of tyTuple:
+      # we iterate over t.sons here, because t.n may be nil
+      if t.n != nil:
+        result = "tuple["
+        assert(len(t.n) == len(t))
+        for i in 0 ..< len(t.n):
+          assert(t.n.sons[i].kind == nkSym)
+          add(result, t.n.sons[i].sym.name.s & ": " & typeToString(t.sons[i]))
+          if i < len(t.n) - 1: add(result, ", ")
+        add(result, ']')
+      elif len(t) == 0:
+        result = "tuple[]"
+      else:
+        if prefer == preferTypeName: result = "("
+        else: result = "tuple of ("
+        for i in 0 ..< len(t):
+          add(result, typeToString(t.sons[i]))
+          if i < len(t) - 1: add(result, ", ")
+        add(result, ')')
+    of tyPtr, tyRef, tyVar, tyLent:
+      result = typeToStr[t.kind]
+      if t.len >= 2:
+        setLen(result, result.len-1)
+        result.add '['
+        for i in 0 ..< len(t):
+          add(result, typeToString(t.sons[i]))
+          if i < len(t) - 1: add(result, ", ")
+        result.add ']'
+      else:
+        result.add typeToString(t.sons[0])
+    of tyRange:
+      result = "range "
+      if t.n != nil and t.n.kind == nkRange:
+        result.add rangeToStr(t.n)
+      if prefer != preferExported:
+        result.add("(" & typeToString(t.sons[0]) & ")")
+    of tyProc:
+      result = if tfIterator in t.flags: "iterator "
+                elif t.owner != nil:
+                  case t.owner.kind
+                  of skTemplate: "template "
+                  of skMacro: "macro "
+                  of skConverter: "converter "
+                  else: "proc "
+              else:
+                "proc "
+      if tfUnresolved in t.flags: result.add "[*missing parameters*]"
+      result.add "("
+      for i in 1 ..< len(t):
+        if t.n != nil and i < t.n.len and t.n[i].kind == nkSym:
+          add(result, t.n[i].sym.name.s)
+          add(result, ": ")
+        add(result, typeToString(t.sons[i]))
+        if i < len(t) - 1: add(result, ", ")
+      add(result, ')')
+      if t.len > 0 and t.sons[0] != nil: add(result, ": " & typeToString(t.sons[0]))
+      var prag = if t.callConv == ccDefault: "" else: CallingConvToStr[t.callConv]
+      if tfNoSideEffect in t.flags:
+        addSep(prag)
+        add(prag, "noSideEffect")
+      if tfThread in t.flags:
+        addSep(prag)
+        add(prag, "gcsafe")
+      if t.lockLevel.ord != UnspecifiedLockLevel.ord:
+        addSep(prag)
+        add(prag, "locks: " & $t.lockLevel)
+      if len(prag) != 0: add(result, "{." & prag & ".}")
+    of tyVarargs:
+      result = typeToStr[t.kind] % typeToString(t.sons[0])
+    of tySink:
+      result = "sink " & typeToString(t.sons[0])
+    of tyOwned:
+      result = "owned " & typeToString(t.sons[0])
+    else:
+      result = typeToStr[t.kind]
+    result.addTypeFlags(t)
+  result = typeToString(typ, prefer)
+
+
+proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType) =
+  if formal.kind != tyError and actual.kind != tyError:
+    let named = typeToString(formal)
+    let desc = typeToString(formal, preferDesc)
+    let x = if named == desc: named else: named & " = " & desc
+    var msg = "type mismatch: got <" &
+              typeToString(actual) & "> " &
+              "but expected '" & x & "'"
+
+    if formal.kind == tyProc and actual.kind == tyProc:
+      case compatibleEffects(formal, actual)
+      of efCompat: discard
+      of efRaisesDiffer:
+        msg.add "\n.raise effects differ"
+      of efRaisesUnknown:
+        msg.add "\n.raise effect is 'can raise any'"
+      of efTagsDiffer:
+        msg.add "\n.tag effects differ"
+      of efTagsUnknown:
+        msg.add "\n.tag effect is 'any tag allowed'"
+      of efLockLevelsDiffer:
+        msg.add "\nlock levels differ"
+    localError(conf, info, msg)
+
+#------------------------------------------------------------------------------
+
 proc lsub(g: TSrcGen; n: PNode): int
 proc litAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
   proc skip(t: PType): PType =
@@ -354,8 +689,8 @@ proc atom(g: TSrcGen; n: PNode): string =
   var f: float32
   case n.kind
   of nkEmpty: result = ""
-  of nkIdent: result = n.ident.s
-  of nkSym: result = n.sym.name.s
+  of nkIdent: result = replace(n.ident.s, '`', '_')
+  of nkSym: result = replace(n.sym.name.s, '`', '_')
   of nkStrLit: result = ""; result.addQuoted(n.strVal)
   of nkRStrLit: result = "r\"" & replace(n.strVal, "\"", "\"\"") & '\"'
   of nkTripleStrLit: result = "\"\"\"" & n.strVal & "\"\"\""
@@ -389,7 +724,7 @@ proc atom(g: TSrcGen; n: PNode): string =
       result = litAux(g, n, (cast[PInt64](addr(n.floatVal)))[], 8) & "\'f64"
   of nkNilLit: result = "nil"
   of nkType:
-    if (n.typ != nil) and (n.typ.sym != nil): result = n.typ.sym.name.s
+    if n.typ != nil: result = typeToString(n.typ)
     else: result = "[type node]"
   else:
     internalError(g.config, "rnimsyn.atom " & $n.kind)
@@ -935,7 +1270,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
   case n.kind                 # atoms:
   of nkTripleStrLit: put(g, tkTripleStrLit, atom(g, n))
   of nkEmpty: discard
-  of nkType: put(g, tkInvalid, atom(g, n))
+  of nkType: put(g, tkSymbol, typeToString(n.typ))
   of nkSym, nkIdent: gident(g, n)
   of nkIntLit: put(g, tkIntLit, atom(g, n))
   of nkInt8Lit: put(g, tkInt8Lit, atom(g, n))

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1231,7 +1231,7 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
       internalAssert c.config, st.kind in {tyPtr, tyRef}
       internalAssert c.config, st.lastSon.sym == nil
       incl st.flags, tfRefsAnonObj
-      let obj = newSym(skType, getIdent(c.cache, s.name.s & ":ObjectType"),
+      let obj = newSym(skType, getIdent(c.cache, s.name.s),
                               getCurrOwner(c), s.info)
       if sfPure in s.flags:
         obj.flags.incl sfPure

--- a/compiler/spawn.nim
+++ b/compiler/spawn.nim
@@ -10,7 +10,7 @@
 ## This module implements threadpool's ``spawn``.
 
 import ast, types, idents, magicsys, msgs, options, modulegraphs,
-  lowerings
+  lowerings, renderer
 from trees import getMagic
 
 proc callProc(a: PNode): PNode =

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -10,22 +10,8 @@
 # this module contains routines for accessing and iterating over types
 
 import
-  intsets, ast, astalgo, trees, msgs, strutils, platform, renderer, options,
+  intsets, ast, astalgo, trees, msgs, strutils, platform, options,
   lineinfos, int128
-
-type
-  TPreferedDesc* = enum
-    preferName, # default
-    preferDesc, # probably should become what preferResolved is
-    preferExported,
-    preferModuleInfo, # fully qualified
-    preferGenericArg,
-    preferTypeName,
-    preferResolved, # fully resolved symbols
-    preferMixed, # show symbol + resolved symbols if it differs, eg: seq[cint{int32}, float]
-
-proc typeToString*(typ: PType; prefer: TPreferedDesc = preferName): string
-template `$`*(typ: PType): string = typeToString(typ)
 
 proc base*(t: PType): PType =
   result = t.sons[0]
@@ -124,30 +110,6 @@ proc isIntLit*(t: PType): bool {.inline.} =
 
 proc isFloatLit*(t: PType): bool {.inline.} =
   result = t.kind == tyFloat and t.n != nil and t.n.kind == nkFloatLit
-
-proc getProcHeader*(conf: ConfigRef; sym: PSym; prefer: TPreferedDesc = preferName; getDeclarationPath = true): string =
-  assert sym != nil
-  # consider using `skipGenericOwner` to avoid fun2.fun2 when fun2 is generic
-  result = sym.owner.name.s & '.' & sym.name.s
-  if sym.kind in routineKinds:
-    result.add '('
-    var n = sym.typ.n
-    for i in 1 ..< len(n):
-      let p = n.sons[i]
-      if p.kind == nkSym:
-        add(result, p.sym.name.s)
-        add(result, ": ")
-        add(result, typeToString(p.sym.typ, prefer))
-        if i != len(n)-1: add(result, ", ")
-      else:
-        result.add renderTree(p)
-    add(result, ')')
-    if n.sons[0].typ != nil:
-      result.add(": " & typeToString(n.sons[0].typ, prefer))
-  if getDeclarationPath:
-    result.add " [declared in "
-    result.add(conf$sym.info)
-    result.add "]"
 
 proc elemType*(t: PType): PType =
   assert(t != nil)
@@ -409,37 +371,6 @@ proc mutateType(t: PType, iter: TTypeMutator, closure: RootRef): PType =
   var marker = initIntSet()
   result = mutateTypeAux(marker, t, iter, closure)
 
-proc valueToString(a: PNode): string =
-  case a.kind
-  of nkCharLit..nkUInt64Lit: result = $a.intVal
-  of nkFloatLit..nkFloat128Lit: result = $a.floatVal
-  of nkStrLit..nkTripleStrLit: result = a.strVal
-  else: result = "<invalid value>"
-
-proc rangeToStr(n: PNode): string =
-  assert(n.kind == nkRange)
-  result = valueToString(n.sons[0]) & ".." & valueToString(n.sons[1])
-
-const
-  typeToStr: array[TTypeKind, string] = ["None", "bool", "char", "empty",
-    "Alias", "typeof(nil)", "untyped", "typed", "typeDesc",
-    "GenericInvocation", "GenericBody", "GenericInst", "GenericParam",
-    "distinct $1", "enum", "ordinal[$1]", "array[$1, $2]", "object", "tuple",
-    "set[$1]", "range[$1]", "ptr ", "ref ", "var ", "seq[$1]", "proc",
-    "pointer", "OpenArray[$1]", "string", "cstring", "Forward",
-    "int", "int8", "int16", "int32", "int64",
-    "float", "float32", "float64", "float128",
-    "uint", "uint8", "uint16", "uint32", "uint64",
-    "owned", "sink",
-    "lent ", "varargs[$1]", "UncheckedArray[$1]", "Error Type",
-    "BuiltInTypeClass", "UserTypeClass",
-    "UserTypeClassInst", "CompositeTypeClass", "inferred",
-    "and", "or", "not", "any", "static", "TypeFromExpr", "FieldAccessor",
-    "void"]
-
-const preferToResolveSymbols = {preferName, preferTypeName, preferModuleInfo,
-  preferGenericArg, preferResolved, preferMixed}
-
 template bindConcreteTypeToUserTypeClass*(tc, concrete: PType) =
   tc.sons.add concrete
   tc.flags.incl tfResolved
@@ -452,237 +383,6 @@ template bindConcreteTypeToUserTypeClass*(tc, concrete: PType) =
 # consts and types stored within the concept.
 template isResolvedUserTypeClass*(t: PType): bool =
   tfResolved in t.flags
-
-proc addTypeFlags(name: var string, typ: PType) {.inline.} =
-  if tfNotNil in typ.flags: name.add(" not nil")
-
-proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
-  let preferToplevel = prefer
-  proc getPrefer(prefer: TPreferedDesc): TPreferedDesc =
-    if preferToplevel in {preferResolved, preferMixed}:
-      preferToplevel # sticky option
-    else:
-      prefer
-
-  proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
-    let prefer = getPrefer(prefer)
-    let t = typ
-    result = ""
-    if t == nil: return
-    if prefer in preferToResolveSymbols and t.sym != nil and
-         sfAnon notin t.sym.flags and t.kind != tySequence:
-      if t.kind == tyInt and isIntLit(t):
-        result = t.sym.name.s & " literal(" & $t.n.intVal & ")"
-      elif t.kind == tyAlias and t.sons[0].kind != tyAlias:
-        result = typeToString(t.sons[0])
-      elif prefer in {preferResolved, preferMixed}:
-        case t.kind
-        of IntegralTypes + {tyFloat..tyFloat128} + {tyString, tyCString}:
-          result = typeToStr[t.kind]
-        of tyGenericBody:
-          result = typeToString(t.lastSon)
-        of tyCompositeTypeClass:
-          # avoids showing `A[any]` in `proc fun(a: A)` with `A = object[T]`
-          result = typeToString(t.lastSon.lastSon)
-        else:
-          result = t.sym.name.s
-        if prefer == preferMixed and result != t.sym.name.s:
-          result = t.sym.name.s & "{" & result & "}"
-      elif prefer in {preferName, preferTypeName} or t.sym.owner.isNil:
-        # note: should probably be: {preferName, preferTypeName, preferGenericArg}
-        result = t.sym.name.s
-        if t.kind == tyGenericParam and t.len > 0:
-          result.add ": "
-          var first = true
-          for son in t.sons:
-            if not first: result.add " or "
-            result.add son.typeToString
-            first = false
-      else:
-        result = t.sym.owner.name.s & '.' & t.sym.name.s
-      result.addTypeFlags(t)
-      return
-    case t.kind
-    of tyInt:
-      if not isIntLit(t) or prefer == preferExported:
-        result = typeToStr[t.kind]
-      else:
-        if prefer == preferGenericArg:
-          result = $t.n.intVal
-        else:
-          result = "int literal(" & $t.n.intVal & ")"
-    of tyGenericInst, tyGenericInvocation:
-      result = typeToString(t.sons[0]) & '['
-      for i in 1 ..< len(t)-ord(t.kind != tyGenericInvocation):
-        if i > 1: add(result, ", ")
-        add(result, typeToString(t.sons[i], preferGenericArg))
-      add(result, ']')
-    of tyGenericBody:
-      result = typeToString(t.lastSon) & '['
-      for i in 0 .. len(t)-2:
-        if i > 0: add(result, ", ")
-        add(result, typeToString(t.sons[i], preferTypeName))
-      add(result, ']')
-    of tyTypeDesc:
-      if t.sons[0].kind == tyNone: result = "typedesc"
-      else: result = "type " & typeToString(t.sons[0])
-    of tyStatic:
-      if prefer == preferGenericArg and t.n != nil:
-        result = t.n.renderTree
-      else:
-        result = "static[" & (if t.len > 0: typeToString(t.sons[0]) else: "") & "]"
-        if t.n != nil: result.add "(" & renderTree(t.n) & ")"
-    of tyUserTypeClass:
-      if t.sym != nil and t.sym.owner != nil:
-        if t.isResolvedUserTypeClass: return typeToString(t.lastSon)
-        return t.sym.owner.name.s
-      else:
-        result = "<invalid tyUserTypeClass>"
-    of tyBuiltInTypeClass:
-      result = case t.base.kind:
-        of tyVar: "var"
-        of tyRef: "ref"
-        of tyPtr: "ptr"
-        of tySequence: "seq"
-        of tyArray: "array"
-        of tySet: "set"
-        of tyRange: "range"
-        of tyDistinct: "distinct"
-        of tyProc: "proc"
-        of tyObject: "object"
-        of tyTuple: "tuple"
-        of tyOpenArray: "openArray"
-        else: typeToStr[t.base.kind]
-    of tyInferred:
-      let concrete = t.previouslyInferred
-      if concrete != nil: result = typeToString(concrete)
-      else: result = "inferred[" & typeToString(t.base) & "]"
-    of tyUserTypeClassInst:
-      let body = t.base
-      result = body.sym.name.s & "["
-      for i in 1 .. len(t) - 2:
-        if i > 1: add(result, ", ")
-        add(result, typeToString(t.sons[i]))
-      result.add "]"
-    of tyAnd:
-      for i, son in t.sons:
-        result.add(typeToString(son))
-        if i < t.sons.high:
-          result.add(" and ")
-    of tyOr:
-      for i, son in t.sons:
-        result.add(typeToString(son))
-        if i < t.sons.high:
-          result.add(" or ")
-    of tyNot:
-      result = "not " & typeToString(t.sons[0])
-    of tyUntyped:
-      #internalAssert t.len == 0
-      result = "untyped"
-    of tyFromExpr:
-      if t.n == nil:
-        result = "unknown"
-      else:
-        result = "type(" & renderTree(t.n) & ")"
-    of tyArray:
-      if t.sons[0].kind == tyRange:
-        result = "array[" & rangeToStr(t.sons[0].n) & ", " &
-            typeToString(t.sons[1]) & ']'
-      else:
-        result = "array[" & typeToString(t.sons[0]) & ", " &
-            typeToString(t.sons[1]) & ']'
-    of tyUncheckedArray:
-      result = "UncheckedArray[" & typeToString(t.sons[0]) & ']'
-    of tySequence:
-      result = "seq[" & typeToString(t.sons[0]) & ']'
-    of tyOpt:
-      result = "opt[" & typeToString(t.sons[0]) & ']'
-    of tyOrdinal:
-      result = "ordinal[" & typeToString(t.sons[0]) & ']'
-    of tySet:
-      result = "set[" & typeToString(t.sons[0]) & ']'
-    of tyOpenArray:
-      result = "openArray[" & typeToString(t.sons[0]) & ']'
-    of tyDistinct:
-      result = "distinct " & typeToString(t.sons[0],
-        if prefer == preferModuleInfo: preferModuleInfo else: preferTypeName)
-    of tyTuple:
-      # we iterate over t.sons here, because t.n may be nil
-      if t.n != nil:
-        result = "tuple["
-        assert(len(t.n) == len(t))
-        for i in 0 ..< len(t.n):
-          assert(t.n.sons[i].kind == nkSym)
-          add(result, t.n.sons[i].sym.name.s & ": " & typeToString(t.sons[i]))
-          if i < len(t.n) - 1: add(result, ", ")
-        add(result, ']')
-      elif len(t) == 0:
-        result = "tuple[]"
-      else:
-        if prefer == preferTypeName: result = "("
-        else: result = "tuple of ("
-        for i in 0 ..< len(t):
-          add(result, typeToString(t.sons[i]))
-          if i < len(t) - 1: add(result, ", ")
-        add(result, ')')
-    of tyPtr, tyRef, tyVar, tyLent:
-      result = typeToStr[t.kind]
-      if t.len >= 2:
-        setLen(result, result.len-1)
-        result.add '['
-        for i in 0 ..< len(t):
-          add(result, typeToString(t.sons[i]))
-          if i < len(t) - 1: add(result, ", ")
-        result.add ']'
-      else:
-        result.add typeToString(t.sons[0])
-    of tyRange:
-      result = "range "
-      if t.n != nil and t.n.kind == nkRange:
-        result.add rangeToStr(t.n)
-      if prefer != preferExported:
-        result.add("(" & typeToString(t.sons[0]) & ")")
-    of tyProc:
-      result = if tfIterator in t.flags: "iterator "
-               elif t.owner != nil:
-                 case t.owner.kind
-                 of skTemplate: "template "
-                 of skMacro: "macro "
-                 of skConverter: "converter "
-                 else: "proc "
-              else:
-                "proc "
-      if tfUnresolved in t.flags: result.add "[*missing parameters*]"
-      result.add "("
-      for i in 1 ..< len(t):
-        if t.n != nil and i < t.n.len and t.n[i].kind == nkSym:
-          add(result, t.n[i].sym.name.s)
-          add(result, ": ")
-        add(result, typeToString(t.sons[i]))
-        if i < len(t) - 1: add(result, ", ")
-      add(result, ')')
-      if t.len > 0 and t.sons[0] != nil: add(result, ": " & typeToString(t.sons[0]))
-      var prag = if t.callConv == ccDefault: "" else: CallingConvToStr[t.callConv]
-      if tfNoSideEffect in t.flags:
-        addSep(prag)
-        add(prag, "noSideEffect")
-      if tfThread in t.flags:
-        addSep(prag)
-        add(prag, "gcsafe")
-      if t.lockLevel.ord != UnspecifiedLockLevel.ord:
-        addSep(prag)
-        add(prag, "locks: " & $t.lockLevel)
-      if len(prag) != 0: add(result, "{." & prag & ".}")
-    of tyVarargs:
-      result = typeToStr[t.kind] % typeToString(t.sons[0])
-    of tySink:
-      result = "sink " & typeToString(t.sons[0])
-    of tyOwned:
-      result = "owned " & typeToString(t.sons[0])
-    else:
-      result = typeToStr[t.kind]
-    result.addTypeFlags(t)
-  result = typeToString(typ, prefer)
 
 proc firstOrd*(conf: ConfigRef; t: PType): Int128 =
   case t.kind
@@ -1587,30 +1287,6 @@ proc skipHiddenSubConv*(n: PNode): PNode =
       result.typ = dest
   else:
     result = n
-
-proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType) =
-  if formal.kind != tyError and actual.kind != tyError:
-    let named = typeToString(formal)
-    let desc = typeToString(formal, preferDesc)
-    let x = if named == desc: named else: named & " = " & desc
-    var msg = "type mismatch: got <" &
-              typeToString(actual) & "> " &
-              "but expected '" & x & "'"
-
-    if formal.kind == tyProc and actual.kind == tyProc:
-      case compatibleEffects(formal, actual)
-      of efCompat: discard
-      of efRaisesDiffer:
-        msg.add "\n.raise effects differ"
-      of efRaisesUnknown:
-        msg.add "\n.raise effect is 'can raise any'"
-      of efTagsDiffer:
-        msg.add "\n.tag effects differ"
-      of efTagsUnknown:
-        msg.add "\n.tag effect is 'any tag allowed'"
-      of efLockLevelsDiffer:
-        msg.add "\nlock levels differ"
-    localError(conf, info, msg)
 
 proc isTupleRecursive(t: PType, cycleDetector: var IntSet): bool =
   if t == nil:

--- a/compiler/vmmarshal.nim
+++ b/compiler/vmmarshal.nim
@@ -10,7 +10,7 @@
 ## Implements marshaling for the VM.
 
 import streams, json, intsets, tables, ast, astalgo, idents, types, msgs,
-  options, lineinfos
+  options, lineinfos, renderer
 
 proc ptrToInt(x: PNode): int {.inline.} =
   result = cast[int](x) # don't skip alignment

--- a/tests/macros/tmacrostmt.nim
+++ b/tests/macros/tmacrostmt.nim
@@ -105,6 +105,20 @@ proc fn5(a, b: float): float =
 proc fn_unsafeaddr(x: int): int =
   cast[int](unsafeAddr(x))
 
+
+type
+  NotImplementedError* = ref object of system.Exception
+
+proc fn_except =
+  try:
+    echo "a"
+  except IndexError:
+    echo getCurrentExceptionMsg()
+  except ValueError as ex:
+    echo ex.msg
+  except NotImplementedError as ex:
+    echo ex.msg
+
 static:
   echo fn_unsafeaddr.repr_to_string
   let fn1s = "proc fn1(x, y: int): int =\n  result = 2 * (x + y)\n"
@@ -120,7 +134,16 @@ static:
   doAssert fn4.repr_to_string == fn4s
   doAssert fn5.repr_to_string == fn5s
   doAssert fn_unsafeaddr.repr_to_string == fnAddr
-
+  doAssert fn_except.repr_to_string == """proc fn_except() =
+  try:
+    echo ["a"]
+  except IndexError:
+    echo [getCurrentExceptionMsg()]
+  except ValueError as ex:
+    echo [ex.msg]
+  except NotImplementedError as ex:
+    echo [ex.msg]
+"""
 #------------------------------------
 # bug #8763
 


### PR DESCRIPTION
Currently, AST renderer can render type node only of it is a sym otherwise it puts a dummy string `[type node]` instead.

I have changed AST render to call `typeToString` instead. This change made type and AST renderers dependent on each other. Hence I had to move them into single module to resolve recursive dependency. All renderers are now in `renderer.nim`

Note:
I had to remove  ":ObjectType" from object name in order to make renderable the following:
```nim
type
  NotImplementedError* = ref object of system.Exception
try:
    ...
except NotImplementedError as ex:
    ...
```
Otherwise `except NotImplementedError` gets rendered as `except NotImplementedError:ObjectType`.

However, in this you case you argue that it is `semTry` logic is wrong instead, `toObject` shouldn't be used. 

We need to spec out the the following:
```
nkExceptBranch:
  nkType,   <- is it a ref type here or object type
  nkStmtList
```
Currently it is object type and if we want to keep it this way then removal of   ":ObjectType" is justified.



