### PR TITLE
fix for asm statement

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1113,19 +1113,7 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
       res.add($a.rdLoc)
 
   if isAsmStmt and hasGnuAsm in CC[p.config.cCompiler].props:
-    for x in splitLines(res):
-      var j = 0
-      while j < x.len and x[j] in {' ', '\t'}: inc(j)
-      if j < x.len:
-        if x[j] in {'"', ':'}:
-          # don't modify the line if already in quotes or
-          # some clobber register list:
-          add(result, x); add(result, "\L")
-        else:
-          # ignore empty lines
-          add(result, "\"")
-          add(result, x)
-          add(result, "\\n\"\n")
+    result = makeCString(res)
   else:
     res.add("\L")
     result = res.rope

--- a/tests/misc/tasm.nim
+++ b/tests/misc/tasm.nim
@@ -1,0 +1,16 @@
+discard """
+disabled: "windows"
+"""
+
+# This tests an asm statement that contains quote characters.
+# MSVC does not have inline assembly, therefore it is diabled there.
+asm """
+string_txt:
+    .incbin "../testdata/string.txt"
+"""
+
+# Ensure the asm statement isn't ignored or optimized away.
+const data = slurp("../testdata/string.txt")
+var string_txt {.importc: "string_txt".}: array[len(data), char]
+for i in 0 ..< data.len:
+  doAssert(data[i] == string_txt[i])

--- a/tests/misc/tasm.nim
+++ b/tests/misc/tasm.nim
@@ -1,9 +1,13 @@
 discard """
-disabled: "windows"
+disabled: windows
+disabled: macosx
+joinable: false
+targets: "c cpp"
 """
 
 # This tests an asm statement that contains quote characters.
 # MSVC does not have inline assembly, therefore it is diabled there.
+# The directives are different for Apple branded compilers.
 asm """
 string_txt:
     .incbin "../testdata/string.txt"


### PR DESCRIPTION
Content of `asm` statements is not properly quoted. To verify the bug, Try to compile the following code sample to verify the bug (not with MSVC compiler backend as there is no inline assembler there):

```nim
asm """
string_txt:
    .incbin "../testdata/string.txt"
"""
```

This PR fixes it.