### PR TITLE
stdalign.h is required only in C

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -256,7 +256,9 @@ __clang__
 
 #include <limits.h>
 #include <stddef.h>
+#ifndef __cplusplus
 #include <stdalign.h>
+#endif
 
 /* C99 compiler? */
 #if (defined(__STD_VERSION__) && (__STD_VERSION__ >= 199901))

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -257,7 +257,7 @@ __clang__
 #include <limits.h>
 #include <stddef.h>
 #ifndef __cplusplus
-#include <stdalign.h>
+#  include <stdalign.h>
 #endif
 
 /* C99 compiler? */


### PR DESCRIPTION
helps visual studio where `stdalign.h` is not available.

Issue #12656