### PR TITLE
render statement list expr

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -354,8 +354,8 @@ proc atom(g: TSrcGen; n: PNode): string =
   var f: float32
   case n.kind
   of nkEmpty: result = ""
-  of nkIdent: result = n.ident.s
-  of nkSym: result = n.sym.name.s
+  of nkIdent: result = replace(n.ident.s, '`', '_')
+  of nkSym: result = replace(n.sym.name.s, '`', '_')
   of nkStrLit: result = ""; result.addQuoted(n.strVal)
   of nkRStrLit: result = "r\"" & replace(n.strVal, "\"", "\"\"") & '\"'
   of nkTripleStrLit: result = "\"\"\"" & n.strVal & "\"\"\""

--- a/tests/errmsgs/twrongcolon.nim
+++ b/tests/errmsgs/twrongcolon.nim
@@ -1,10 +1,8 @@
 discard """
 errormsg: "in expression '("
 nimout: '''
-Error: in expression '(
-  890)': identifier expected, but found ''
+Error: in expression '((890))': identifier expected, but found ''
 '''
-
 line: 11
 """
 

--- a/tests/macros/tmacrostmt.nim
+++ b/tests/macros/tmacrostmt.nim
@@ -74,6 +74,8 @@ proc test_cond_stmtlist(x, y: int): int =
   if x > y:
     result = x
 
+proc test_raise =
+  raise newException(ValueError, "Test")
 
 #------------------------------------
 # bug #8762
@@ -140,3 +142,4 @@ repr_and_parse(test_block)
 repr_and_parse(test_cond_stmtlist)
 repr_and_parse(t2)
 repr_and_parse(test_pure_enums)
+repr_and_parse(test_raise)


### PR DESCRIPTION
statement list expression is rendered as (x1; x2; x3) with indentation.
This makes ` raise newException(XXX)` renderable as newException is template producing statement list expression