### PR TITLE
Fixes ambiguity errors when evaluating Nimble files.

### DIFF
--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -226,9 +226,9 @@ when declared(os.paramCount):
     if cmdline != "":
       result.cmds = parseCmdLine(cmdline)
     else:
-      result.cmds = newSeq[string](paramCount())
-      for i in countup(1, paramCount()):
-        result.cmds[i-1] = paramStr(i).string
+      result.cmds = newSeq[string](os.paramCount())
+      for i in countup(1, os.paramCount()):
+        result.cmds[i-1] = os.paramStr(i).string
 
     result.kind = cmdEnd
     result.key = TaintedString""
@@ -263,9 +263,9 @@ when declared(os.paramCount):
       for i in 0..<cmdline.len:
         result.cmds[i] = cmdline[i].string
     else:
-      result.cmds = newSeq[string](paramCount())
-      for i in countup(1, paramCount()):
-        result.cmds[i-1] = paramStr(i).string
+      result.cmds = newSeq[string](os.paramCount())
+      for i in countup(1, os.paramCount()):
+        result.cmds[i-1] = os.paramStr(i).string
     result.kind = cmdEnd
     result.key = TaintedString""
     result.val = TaintedString""


### PR DESCRIPTION
When trying to evaluate a Nimble file which imports a Nim module
I was getting the following errors for some reason:

```
/Users/dom/projects/nim/lib/pure/parseopt.nim(229, 46) Error: ambiguous call; both system.paramCount() [declared in /Users/dom/projects/nim/lib/system/nimscript.nim(65, 6)] and os.paramCount() [declared in /Users/dom/projects/nim/lib/pure/os.nim(2613, 8)] match for: ()
```

I didn't look too closely at the cause and just fixed this code.