### PR TITLE
fix regression in align

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -550,7 +550,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
     let sname = mangleRecFieldName(m, field)
     fillLoc(field.loc, locField, n, sname, OnUnknown)
     if field.alignment > 0:
-      result.addf "alignas($1) ", [rope(field.alignment)]
+      result.addf "NIM_ALIGN($1) ", [rope(field.alignment)]
     # for importcpp'ed objects, we only need to set field.loc, but don't
     # have to recurse via 'getTypeDescAux'. And not doing so prevents problems
     # with heavily templatized C++ code:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1766,8 +1766,11 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       onUse(n.info, n.sym)
     else:
       if s.kind != skError:
-        localError(c.config, n.info, "type expected, but got symbol '$1' of kind '$2'" %
-          [s.name.s, substr($s.kind, 2)])
+        if s.typ == nil:
+          localError(c.config, n.info, "type expected, but symbol '$1' has no type." % [s.name.s])
+        else:
+          localError(c.config, n.info, "type expected, but got symbol '$1' of kind '$2'" %
+            [s.name.s, substr($s.kind, 2)])
       result = newOrPrevType(tyError, prev, c)
   of nkObjectTy: result = semObjectNode(c, n, prev, isInheritable=false)
   of nkTupleTy: result = semTuple(c, n, prev)

--- a/tests/macros/tinvalidtypesym.nim
+++ b/tests/macros/tinvalidtypesym.nim
@@ -1,0 +1,14 @@
+discard """
+errormsg: "type expected, but symbol 'MyType' has no type."
+"""
+
+import macros
+
+macro foobar(name) =
+  let sym = genSym(nskType, "MyType")
+
+  result = quote do:
+    type
+      `name` = `sym`
+
+foobar(MyAlias)

--- a/tests/misc/talignas.nim
+++ b/tests/misc/talignas.nim
@@ -6,8 +6,6 @@ output: "align ok"
 
 # This is for Azure. The keyword ``alignof`` only exists in ``c++11``
 # and newer. On Azure gcc does not default to c++11 yet.
-when defined(cpp) and not defined(windows):
-  {.passC: "-std=c++11".}
 
 import globalalignas
 


### PR DESCRIPTION
This problem isn't caught in `tsizeof`, because that test case include `stdalign.h` from using `alignof` already.

The fix in the error message is an unrelated to alignof. I fixed it because I think that ``"type expected, but got symbol 'MyType' of kind 'Type'"`` isn't that useful.