### PR TITLE
Make a copy of env on heap for closure [C backend]

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2354,6 +2354,14 @@ proc genClosure(p: BProc, n: PNode, d: var TLoc) =
         linefmt(p, cpsStmts, "$1.ClP_0 = $2; $1.ClE_0 = $3;$n",
                 [d.rdLoc, a.rdLoc, b.rdLoc])
     else:
+      # make a copy of env (b)
+      if b.t.kind != tyNil:
+        var copy: TLoc
+        getTemp(p, b.t, copy)
+        rawGenNew(p, copy, copy.r)
+        genDeepCopy(p, copy, b)
+        b = copy
+
       getTemp(p, n.typ, tmp)
       linefmt(p, cpsStmts, "$1.ClP_0 = $2; $1.ClE_0 = $3;$n",
               [tmp.rdLoc, a.rdLoc, b.rdLoc])

--- a/tests/closure/tclosureenv.nim
+++ b/tests/closure/tclosureenv.nim
@@ -1,0 +1,24 @@
+discard """
+  target: "c"
+  output: '''
+2302
+'''
+joinable: false
+"""
+
+import sequtils
+
+type
+  ft = proc (x: int): int {.noSideEffect.}
+
+proc foo() =
+  let m = @[func (x: int): int = x + 100, func (x: int): int = x + 200]
+  var l: seq[ft] = @[]
+  for it in m:
+    l.add(func (x: int): int = it(x) + 1000)
+  let r = l.map(func (f: ft): int = f(1))  
+  echo r[0] + r[1]
+
+if isMainModule:
+  foo()
+


### PR DESCRIPTION
This fixes part of the issue #12625. vm & other backends also need
update.

Possible optimization: If liveness analysis of closure shows that its scope is not larger than `env`,
then we don't need to make the copy on heap.