### PR TITLE
fix in tests/js/tconsole

### DIFF
--- a/tests/js/tconsole.nim
+++ b/tests/js/tconsole.nim
@@ -1,7 +1,8 @@
 discard """
-  output: '''Hello, console
+  output: '''
+Hello, console
 1 2 3
-1 'hi' 1.1'''
+'''
 """
 
 # This file tests the JavaScript console
@@ -10,4 +11,3 @@ import jsconsole
 
 console.log("Hello, console")
 console.log(1, 2, 3)
-console.log(1, "hi", 1.1)


### PR DESCRIPTION
whenever I test locally the test suite fails with the following error:
```
FAIL: tests/js/tconsole.nim JS -d:nodejs
Test "tests/js/tconsole.nim" in category "js"
Failure: reOutputsDiffer
Expected:
Hello, console
1 2 3
1 'hi' 1.1

Gotten:
Hello, console
1 2 3
1 hi 1.1

FAIL: tests/js/tconsole.nim JS -d:nodejs -d:release
Test "tests/js/tconsole.nim" in category "js"
Failure: reOutputsDiffer
Expected:
Hello, console
1 2 3
1 'hi' 1.1

Gotten:
Hello, console
1 2 3
1 hi 1.1
```

The problem is, console.log is underspecified stuff that does things sometimes differently. [Here is a related question about that on stack overflow](https://stackoverflow.com/questions/53746913/why-does-console-log-log-strings-with-quotes-in-some-cases). I guess it is just a matter of time until nodejs might be updated on the testing servers and CI will also fail there. This removes the test failure.
