### PR TITLE
introduce capture macro

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,9 @@
   `sorted` does.
 - Added `sugar.collect` that does comprehension for seq/set/table collections.
 
+- Added `sugar.capture` for capturing some local loop variables when creating a closure.
+  This is an enhanced version of `closureScope`.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1675,30 +1675,3 @@ when defined(nimMacrosSizealignof):
 
 proc isExported*(n: NimNode): bool {.noSideEffect.} =
   ## Returns whether the symbol is exported or not.
-
-macro capture*(locals: openArray[typed], body: untyped): untyped =
-  ## Useful when creating a closure in a loop to capture some local loop variables 
-  ## by their current iteration values. Example:
-  ##
-  ## .. code-block:: Nim
-  ##   import strformat
-  ##   var myClosure : proc()
-  ##   # without capture:
-  ##   for i in 5..7:
-  ##     for j in 7..9:      
-  ##       if i * j == 42:         
-  ##         myClosure = proc () = echo fmt"{i} * {j} = 42"
-  ##   myClosure() # outputs 7 * 9 == 42. `i` & `j` are changed after closure creation
-  ##   # with capture:
-  ##   for i in 5..7:
-  ##     for j in 7..9:      
-  ##       if i * j == 42:         
-  ##         capture [i, j]:
-  ##           myClosure = proc () = echo fmt"{i} * {j} = 42"
-  ##   myClosure() # output 6 * 7 == 42
-  var params = @[newEmptyNode()]
-  for arg in locals:
-    params.add(newIdentDefs(ident(arg.strVal), getTypeImpl(arg)))
-  result = newNimNode(nnkCall)
-  result.add(newProc(newEmptyNode(), params, body, nnkProcDef))
-  for arg in locals:  result.add(arg)

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -182,30 +182,29 @@ macro distinctBase*(T: typedesc): untyped =
     typeSym = getTypeImpl(typeSym)[0]
   typeSym.freshIdentNodes
 
-since (1, 1):
-  macro capture*(locals: openArray[typed], body: untyped): untyped =
-    ## Useful when creating a closure in a loop to capture some local loop variables
-    ## by their current iteration values. Example:
-    ##
-    ## .. code-block:: Nim
-    ##   import strformat, sequtils, sugar
-    ##   var myClosure : proc()
-    ##   for i in 5..7:
-    ##     for j in 7..9:
-    ##       if i * j == 42:
-    ##         capture [i, j]:
-    ##           myClosure = proc () = echo fmt"{i} * {j} = 42"
-    ##   myClosure() # output: 6 * 7 == 42
-    ##   let m = @[proc (s: string): string = "to " & s, proc (s: string): string = "not to " & s]
-    ##   var l = m.mapIt(capture([it], proc (s: string): string = it(s)))
-    ##   let r = l.mapIt(it("be"))
-    ##   echo r[0] & ", or " & r[1] # output: to be, or not to be
-    var params = @[newIdentNode("auto")]
-    for arg in locals:
-      params.add(newIdentDefs(ident(arg.strVal), freshIdentNodes getTypeImpl arg))
-    result = newNimNode(nnkCall)
-    result.add(newProc(newEmptyNode(), params, body, nnkProcDef))
-    for arg in locals: result.add(arg)
+macro capture*(locals: openArray[typed], body: untyped): untyped {.since: (1, 1).} =
+  ## Useful when creating a closure in a loop to capture some local loop variables
+  ## by their current iteration values. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   import strformat, sequtils, sugar
+  ##   var myClosure : proc()
+  ##   for i in 5..7:
+  ##     for j in 7..9:
+  ##       if i * j == 42:
+  ##         capture [i, j]:
+  ##           myClosure = proc () = echo fmt"{i} * {j} = 42"
+  ##   myClosure() # output: 6 * 7 == 42
+  ##   let m = @[proc (s: string): string = "to " & s, proc (s: string): string = "not to " & s]
+  ##   var l = m.mapIt(capture([it], proc (s: string): string = it(s)))
+  ##   let r = l.mapIt(it("be"))
+  ##   echo r[0] & ", or " & r[1] # output: to be, or not to be
+  var params = @[newIdentNode("auto")]
+  for arg in locals:
+    params.add(newIdentDefs(ident(arg.strVal), freshIdentNodes getTypeImpl arg))
+  result = newNimNode(nnkCall)
+  result.add(newProc(newEmptyNode(), params, body, nnkProcDef))
+  for arg in locals: result.add(arg)
 
 when (NimMajor, NimMinor) >= (1, 1):
   macro outplace*[T](arg: T, call: untyped; inplaceArgPosition: static[int] = 1): T =

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -180,6 +180,33 @@ macro distinctBase*(T: typedesc): untyped =
     typeSym = getTypeImpl(typeSym)[0]
   typeSym.freshIdentNodes
 
+macro capture*(locals: openArray[typed], body: untyped): untyped {.since: (1, 1).} =
+  ## Useful when creating a closure in a loop to capture some local loop variables
+  ## by their current iteration values. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   import strformat
+  ##   var myClosure : proc()
+  ##   # without capture:
+  ##   for i in 5..7:
+  ##     for j in 7..9:
+  ##       if i * j == 42:
+  ##         myClosure = proc () = echo fmt"{i} * {j} = 42"
+  ##   myClosure() # outputs 7 * 9 == 42. `i` & `j` are changed after closure creation
+  ##   # with capture:
+  ##   for i in 5..7:
+  ##     for j in 7..9:
+  ##       if i * j == 42:
+  ##         capture [i, j]:
+  ##           myClosure = proc () = echo fmt"{i} * {j} = 42"
+  ##   myClosure() # output 6 * 7 == 42
+  var params = @[newEmptyNode()]
+  for arg in locals:
+    params.add(newIdentDefs(ident(arg.strVal), freshIdentNodes getTypeImpl arg))
+  result = newNimNode(nnkCall)
+  result.add(newProc(newEmptyNode(), params, body, nnkProcDef))
+  for arg in locals:  result.add(arg)
+
 when (NimMajor, NimMinor) >= (1, 1):
   macro outplace*[T](arg: T, call: untyped; inplaceArgPosition: static[int] = 1): T =
     ## Turns an `in-place`:idx: algorithm into one that works on
@@ -289,33 +316,6 @@ when (NimMajor, NimMinor) >= (1, 1):
       for i in 1 ..< init.len:
         call.add init[i]
     result = newTree(nnkStmtListExpr, newVarStmt(res, call), resBody, res)
-
-  macro capture*(locals: openArray[typed], body: untyped): untyped =
-    ## Useful when creating a closure in a loop to capture some local loop variables
-    ## by their current iteration values. Example:
-    ##
-    ## .. code-block:: Nim
-    ##   import strformat
-    ##   var myClosure : proc()
-    ##   # without capture:
-    ##   for i in 5..7:
-    ##     for j in 7..9:
-    ##       if i * j == 42:
-    ##         myClosure = proc () = echo fmt"{i} * {j} = 42"
-    ##   myClosure() # outputs 7 * 9 == 42. `i` & `j` are changed after closure creation
-    ##   # with capture:
-    ##   for i in 5..7:
-    ##     for j in 7..9:
-    ##       if i * j == 42:
-    ##         capture [i, j]:
-    ##           myClosure = proc () = echo fmt"{i} * {j} = 42"
-    ##   myClosure() # output 6 * 7 == 42
-    var params = @[newEmptyNode()]
-    for arg in locals:
-      params.add(newIdentDefs(ident(arg.strVal), freshIdentNodes getTypeImpl arg))
-    result = newNimNode(nnkCall)
-    result.add(newProc(newEmptyNode(), params, body, nnkProcDef))
-    for arg in locals:  result.add(arg)
 
   when isMainModule:
     import algorithm

--- a/tests/closure/tcapture.nim
+++ b/tests/closure/tcapture.nim
@@ -1,0 +1,12 @@
+discard """
+  output: '''
+to be, or not to be'''
+  joinable: false
+"""
+
+import sequtils, sugar
+
+let m = @[proc (s: string): string = "to " & s, proc (s: string): string = "not to " & s]
+var l = m.mapIt(capture([it], proc (s: string): string = it(s)))
+let r = l.mapIt(it("be"))
+echo r[0] & ", or " & r[1]


### PR DESCRIPTION
This `capture` macro works for more cases than `closureScope`. See examples below.

__UPDATE__: move to `sugar` module, and `freshIdentNodes` is used (dependency on
 #12705 is eliminated)

~~Note: this macro depends on PR #12705.~~

## Example 1. Capture a closure

```nim
import macros, sequtils, strformat, sugar
proc t1_1() =
  let m = @[proc (s: string): string = "TO " & s, proc (s: string): string = "NOT TO " & s]
  var l: seq[proc (s: string): string] = @[]
  for it in m:
    capture [it]:
      l.add(proc (s: string): string = it(s))
  let r = l.mapIt(it("merge #12705"))
  echo r[0] & ", or " & r[1]
```
### Output

`TO merge #12705, or NOT TO merge #12705`

### Using `closureScope`

```nim
proc t1_0() =
  let m = @[proc (s: string): string = "TO " & s, proc (s: string): string = "NOT TO " & s]
  var l: seq[proc (s: string): string] = @[]
  for it in m:
    closureScope:
      l.add(proc (s: string): string = it(s))
  let r = l.mapIt(it("merge #12705"))
  echo r[0] & ", or " & r[1]
```

#### Output

`NOT TO merge #12705, or NOT TO merge #12705`

## Example 2: Flexible Multiple Capture

```nim
proc t2_1() =
  var myClosure: proc()
  for i in 5..7:
    for j in 7..9:      
      if i * j == 42:         
        capture [i, j]:
          myClosure = proc () = echo fmt"{i} * {j} = 42"
  myClosure()
```
### Output

`6 * 7 = 42`

### Using `closureScope`

```nim
proc t2_0() =
  var myClosure: proc()
  for i in 5..7:
    closureScope:
      for j in 7..9:
        closureScope:
          if i * j == 42:
            myClosure = proc () = echo fmt"{i} * {j} = 42"
  myClosure()
```
#### Output

`7 * 9 = 42`