### PR TITLE
docgen.nim: copy source nims file when test runnableExamples

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -401,6 +401,10 @@ proc runAllExamples(d: PDoc) =
   let outp = outputDir / RelativeFile(extractFilename(d.filename.changeFileExt"" &
       "_examples.nim"))
   writeFile(outp, d.examples)
+  let nimsFilename = d.filename.changeFileExt"" & ".nims"
+  if fileExists(nimsFilename):
+    let outputNims = outputDir / RelativeFile(extractFilename(d.filename.changeFileExt"" & "_examples.nims"))
+    writeFile(outputNims, readFile(nimsFilename))
   let backend = if isDefined(d.conf, "js"): "js"
                 elif isDefined(d.conf, "cpp"): "cpp"
                 elif isDefined(d.conf, "objc"): "objc"


### PR DESCRIPTION
otherwise httpclient code will failed when generate documentation:
```
  runnableExamples:
    var client = newHttpClient()
    echo client.getContent("https://www.w3.org/")
```
