### PR TITLE
replace some runtime repr in stdlib for gc:arc

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -190,8 +190,8 @@ proc decode*(s: string): string =
     inc inputIndex
     if x == invalidChar:
       raise newException(ValueError,
-        "Invalid base64 format character " & repr(s[inputIndex]) &
-        " at location " & $inputIndex & ".")
+        "Invalid base64 format character `" & s[inputIndex] &
+        "` (ord " & $s[inputIndex].ord & ") at location " & $inputIndex & ".")
 
   template outputChar(x: untyped) =
     result[outputIndex] = char(x and 255)

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -747,7 +747,7 @@ proc parseResponse(client: HttpClient | AsyncHttpClient,
       # Parse HTTP version info and status code.
       var le = skipIgnoreCase(line, "HTTP/", linei)
       if le <= 0:
-        httpError("invalid http version, " & line.repr)
+        httpError("invalid http version, `" & line & "`")
       inc(linei, le)
       le = skipIgnoreCase(line, "1.1", linei)
       if le > 0: result.version = "1.1"

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1206,7 +1206,8 @@ proc parseHexStr*(s: string): string {.noSideEffect, procvar,
   for pos, c in s:
     let val = hexCharToValueMap[ord(c)].ord
     if val == 17:
-      raise newException(ValueError, "Invalid hex char " & repr(c))
+      raise newException(ValueError, "Invalid hex char `" &
+                         c & "` (ord " & $c.ord & ")")
     if pos mod 2 == 0:
       buf = val
     else:


### PR DESCRIPTION
Per title, rewrite some error messages to remove runtime `repr` calls, enabling use with newruntime.