### PR TITLE
Fix wrong section hierarchy in the manual

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6706,15 +6706,6 @@ The compiler needs to be told to generate C++ (command ``cpp``) for
 this to work. The conditional symbol ``cpp`` is defined when the compiler
 emits C++ code.
 
-
-ImportJs pragma
----------------
-
-Similar to the `importcpp pragma for C++ <#foreign-function-interface-importc-pragma>`_,
-the ``importjs`` pragma can be used to import Javascript methods or
-symbols in general. The generated code then uses the Javascript method
-calling syntax: ``obj.method(arg)``.
-
 Namespaces
 ~~~~~~~~~~
 
@@ -6895,6 +6886,15 @@ Produces:
 .. code-block:: C
 
   std::vector<int>::iterator x;
+
+
+ImportJs pragma
+---------------
+
+Similar to the `importcpp pragma for C++ <#foreign-function-interface-importc-pragma>`_,
+the ``importjs`` pragma can be used to import Javascript methods or
+symbols in general. The generated code then uses the Javascript method
+calling syntax: ``obj.method(arg)``.
 
 
 ImportObjC pragma


### PR DESCRIPTION
I think that subsections `Namespaces`..`Importcpp for objects` following `ImportJs pragma` section are actually subsections of `ImportCpp pragma` section.