### PR TITLE
fix #12663 staticRead now creates a dependency for rebuilds

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1039,7 +1039,8 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
 
   proc depfiles(conf: ConfigRef; f: File) =
     var i = 0
-    template process(path) =
+    for it in conf.m.fileInfos:
+      let path = it.fullPath.string
       if isAbsolute(path): # TODO: else?
         if i > 0: lit "],\L"
         lit "["
@@ -1047,10 +1048,6 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
         lit ", "
         str $secureHashFile(path)
         inc i
-    for it in conf.m.fileInfos:
-      process(it.fullPath.string)
-    for it in conf.m.extraFileDeps:
-      process(it)
     lit "]\L"
 
 

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1037,16 +1037,20 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
       pastStart = true
     lit "\L"
 
-  proc nimfiles(conf: ConfigRef; f: File) =
+  proc depfiles(conf: ConfigRef; f: File) =
     var i = 0
-    for it in conf.m.fileInfos:
-      if isAbsolute(it.fullPath.string):
+    template process(path) =
+      if isAbsolute(path): # TODO: else?
         if i > 0: lit "],\L"
         lit "["
-        str it.fullPath.string
+        str path
         lit ", "
-        str $secureHashFile(it.fullPath.string)
+        str $secureHashFile(path)
         inc i
+    for it in conf.m.fileInfos:
+      process(it.fullPath.string)
+    for it in conf.m.extraFileDeps:
+      process(it)
     lit "]\L"
 
 
@@ -1069,8 +1073,8 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
     if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
       lit ",\L\"cmdline\": "
       str conf.commandLine
-      lit ",\L\"nimfiles\":[\L"
-      nimfiles(conf, f)
+      lit ",\L\"depfiles\":[\L"
+      depfiles(conf, f)
       lit "],\L\"nimexe\": \L"
       str hashNimExe()
       lit "\L"
@@ -1085,22 +1089,22 @@ proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; projectfile: Absol
   result = false
   try:
     let data = json.parseFile(jsonFile.string)
-    if not data.hasKey("nimfiles") or not data.hasKey("cmdline"):
+    if not data.hasKey("depfiles") or not data.hasKey("cmdline"):
       return true
     let oldCmdLine = data["cmdline"].getStr
     if conf.commandLine != oldCmdLine:
       return true
     if hashNimExe() != data["nimexe"].getStr:
       return true
-    let nimfilesPairs = data["nimfiles"]
-    doAssert nimfilesPairs.kind == JArray
-    for p in nimfilesPairs:
+    let depfilesPairs = data["depfiles"]
+    doAssert depfilesPairs.kind == JArray
+    for p in depfilesPairs:
       doAssert p.kind == JArray
       # >= 2 for forwards compatibility with potential later .json files:
       doAssert p.len >= 2
-      let nimFilename = p[0].getStr
+      let depFilename = p[0].getStr
       let oldHashValue = p[1].getStr
-      let newHashValue = $secureHashFile(nimFilename)
+      let newHashValue = $secureHashFile(depFilename)
       if oldHashValue != newHashValue:
         return true
   except IOError, OSError, ValueError:

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -261,7 +261,6 @@ type
     filenameToIndexTbl*: Table[string, FileIndex]
     fileInfos*: seq[TFileInfo]
     systemFileIdx*: FileIndex
-    extraFileDeps*: seq[string]
 
 
 proc initMsgConfig*(): MsgConfig =

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -261,6 +261,7 @@ type
     filenameToIndexTbl*: Table[string, FileIndex]
     fileInfos*: seq[TFileInfo]
     systemFileIdx*: FileIndex
+    extraFileDeps*: seq[string]
 
 
 proc initMsgConfig*(): MsgConfig =

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -8,6 +8,7 @@
 #
 
 import ast, types, msgs, os, options, idents, lineinfos
+from pathutils import AbsoluteFile
 
 proc opSlurp*(file: string, info: TLineInfo, module: PSym; conf: ConfigRef): string =
   try:
@@ -17,7 +18,7 @@ proc opSlurp*(file: string, info: TLineInfo, module: PSym; conf: ConfigRef): str
     result = readFile(filename)
     # we produce a fake include statement for every slurped filename, so that
     # the module dependencies are accurate:
-    conf.m.extraFileDeps.add filename
+    discard conf.fileInfoIdx(AbsoluteFile filename)
     appendToModule(module, newNode(nkIncludeStmt, info, @[
       newStrNode(nkStrLit, filename)]))
   except IOError:

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -17,6 +17,7 @@ proc opSlurp*(file: string, info: TLineInfo, module: PSym; conf: ConfigRef): str
     result = readFile(filename)
     # we produce a fake include statement for every slurped filename, so that
     # the module dependencies are accurate:
+    conf.m.extraFileDeps.add filename
     appendToModule(module, newNode(nkIncludeStmt, info, @[
       newStrNode(nkStrLit, filename)]))
   except IOError:


### PR DESCRIPTION
* fixes #12663  /cc @treeform /cc @araq

## before PR
`nim c -r main.nim` would not recompile in case `test.txt` changes in `staticRead("test.txt")`
(it would recompile in case `-r` was not provided though)

## after PR
`nim c -r main.nim` would recompile in case `test.txt` changes in `staticRead("test.txt")`

## implementation details
this simply keeps track of files used inside staticRead in a new `conf.m.extraFileDeps` field; it renames `nimfiles` to `depfiles` to keep track of any dependency (nim files + files in extraFileDeps)

## future work
* one could expose a `proc addDependency(file: string)` that would put file inside `conf.m.extraFileDeps` that'd work with other files known by user to be a dependency (not via staticRead but via some other indirect way the user knows about, eg indirectly called via`staticExec` but there could be other scenarios)
* we could also add a `conf.m.extraFileTimeDeps` that would be like `conf.m.extraFileDeps` but instead of using a hash on file content (potentially expensive for large files, perhaps binaries), it'd use a timestamp
