### PR TITLE
[backport] increase the timeout for 'tasyncclosestall'

### DIFF
--- a/tests/async/tasyncclosestall.nim
+++ b/tests/async/tasyncclosestall.nim
@@ -14,7 +14,7 @@ else:
 # even when the socket is closed.
 const
   port = Port(50726)
-  timeout = 5000
+  timeout = 8000
 
 var sent = 0
 


### PR DESCRIPTION
This test is very flaky, this change might help reducing the
number of failings (usually solved by restarting the test suite).

Refs https://github.com/nim-lang/Nim/pull/12694#issuecomment-557583790