### PR TITLE
Substitute $nimbleDir in --path flags

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -367,8 +367,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   case switch.normalize
   of "path", "p":
     expectArg(conf, switch, arg, pass, info)
-    addPath(conf, if pass == passPP: processCfgPath(conf, arg, info)
-                  else: processPath(conf, arg, info), info)
+    for path in nimbleSubs(conf, arg):
+      addPath(conf, if pass == passPP: processCfgPath(conf, path, info)
+                    else: processPath(conf, path, info), info)
   of "nimblepath", "babelpath":
     # keep the old name for compat
     if pass in {passCmd2, passPP} and optNoNimblePath notin conf.globalOptions:

--- a/compiler/nimblecmd.nim
+++ b/compiler/nimblecmd.nim
@@ -129,7 +129,10 @@ proc addPathRec(conf: ConfigRef; dir: string, info: TLineInfo) =
 proc nimblePath*(conf: ConfigRef; path: AbsoluteDir, info: TLineInfo) =
   addPathRec(conf, path.string, info)
   addNimblePath(conf, path.string, info)
-  conf.nimblePaths.insert(AbsoluteDir path, 0)
+  let i = conf.nimblePaths.find(path)
+  if i != -1:
+    conf.nimblePaths.delete(i)
+  conf.nimblePaths.add(path)
 
 when isMainModule:
   proc v(s: string): Version = s.newVersion

--- a/compiler/nimblecmd.nim
+++ b/compiler/nimblecmd.nim
@@ -129,6 +129,7 @@ proc addPathRec(conf: ConfigRef; dir: string, info: TLineInfo) =
 proc nimblePath*(conf: ConfigRef; path: AbsoluteDir, info: TLineInfo) =
   addPathRec(conf, path.string, info)
   addNimblePath(conf, path.string, info)
+  conf.nimblePaths.insert(AbsoluteDir path, 0)
 
 when isMainModule:
   proc v(s: string): Version = s.newVersion

--- a/compiler/nimblecmd.nim
+++ b/compiler/nimblecmd.nim
@@ -132,7 +132,7 @@ proc nimblePath*(conf: ConfigRef; path: AbsoluteDir, info: TLineInfo) =
   let i = conf.nimblePaths.find(path)
   if i != -1:
     conf.nimblePaths.delete(i)
-  conf.nimblePaths.add(path)
+  conf.nimblePaths.insert(path, 0)
 
 when isMainModule:
   proc v(s: string): Version = s.newVersion

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -9,7 +9,7 @@
 
 import
   os, strutils, strtabs, sets, lineinfos, platform,
-  prefixmatches, pathutils, sequtils
+  prefixmatches, pathutils
 
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
@@ -591,11 +591,11 @@ proc pathSubs*(conf: ConfigRef; p, config: string): string =
 proc nimbleSubs*(conf: ConfigRef; p: string): seq[string] =
   let pl = p.toLowerAscii
   if "$nimblepath" in pl or "$nimbledir" in pl:
-    var res: OrderedSet[string]
-    for np in conf.nimblePaths:
-      let np = removeTrailingDirSep(np.string)
-      res.incl(p % ["nimblepath", np, "nimbledir", np])
-    result = toSeq(res.items)
+    for nimblePath in conf.nimblePaths:
+      let nimblePath = removeTrailingDirSep(nimblePath.string)
+      let p = p % ["nimblepath", nimblePath, "nimbledir", nimblePath]
+      if p notin result:
+        result.add p
   else:
     result.add p
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -588,16 +588,14 @@ proc pathSubs*(conf: ConfigRef; p, config: string): string =
   if "~/" in result:
     result = result.replace("~/", home & '/')
 
-proc nimbleSubs*(conf: ConfigRef; p: string): seq[string] =
+iterator nimbleSubs*(conf: ConfigRef; p: string): string =
   let pl = p.toLowerAscii
   if "$nimblepath" in pl or "$nimbledir" in pl:
-    for nimblePath in conf.nimblePaths:
-      let nimblePath = removeTrailingDirSep(nimblePath.string)
-      let p = p % ["nimblepath", nimblePath, "nimbledir", nimblePath]
-      if p notin result:
-        result.insert(p, 0)
+    for i in countdown(conf.nimblePaths.len-1, 0):
+      let nimblePath = removeTrailingDirSep(conf.nimblePaths[i].string)
+      yield p % ["nimblepath", nimblePath, "nimbledir", nimblePath]
   else:
-    result.add p
+    yield p
 
 proc toGeneratedFile*(conf: ConfigRef; path: AbsoluteFile,
                       ext: string): AbsoluteFile =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -595,7 +595,7 @@ proc nimbleSubs*(conf: ConfigRef; p: string): seq[string] =
       let nimblePath = removeTrailingDirSep(nimblePath.string)
       let p = p % ["nimblepath", nimblePath, "nimbledir", nimblePath]
       if p notin result:
-        result.add p
+        result.insert(p, 0)
   else:
     result.add p
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -44,12 +44,12 @@ path="$lib/core"
 path="$lib/pure"
 
 @if nimbabel:
-  nimblepath="$home/.nimble/pkgs/"
   @if not windows:
     nimblepath="/opt/nimble/pkgs/"
   @else:
     # TODO:
   @end
+  nimblepath="$home/.nimble/pkgs/"
 @end
 
 @if danger or quick:

--- a/tests/nimble/tnimblepathdollar.nim
+++ b/tests/nimble/tnimblepathdollar.nim
@@ -1,0 +1,7 @@
+import pkgA/module as A
+import pkgB/module as B
+import pkgC/module as C
+
+doAssert pkgATest() == 1, "Simple pkgA-0.1.0 wasn't added to path correctly."
+doAssert pkgBTest() == 0xDEADBEEF, "pkgB-#head wasn't picked over pkgB-0.1.0"
+doAssert pkgCTest() == 0xDEADBEEF, "pkgC-#head wasn't picked over pkgC-#aa11"

--- a/tests/nimble/tnimblepathdollar.nims
+++ b/tests/nimble/tnimblepathdollar.nims
@@ -1,0 +1,5 @@
+switch("nimblePath", "$projectdir/nimbleDir/simplePkgs")
+switch("path", "$nimblepath/pkgA-0.1.0")
+switch("path", "$nimblepath/pkgB-#head")
+switch("path", "$nimblepath/pkgC-#head")
+switch("noNimblePath")


### PR DESCRIPTION
Per discussions in https://gist.github.com/genotrance/35504ed532f9cb836f11fd02b5bf1145.

Adding Nim capability to handle `$nimbleDir` substitution in `--path` flags

- `$nimblePath` and `$nimbleDir` both are supported
- Handled differently than other $ substitutions since it is one to many
- Every `$nimbleDir` added to Nim will be added to `searchPaths`
	- If `$nimbleDir = ["$home/.nimble/pkgs", "$projectpath/nimbledeps/pkgs"]`
	- `--path:"$nimbleDir/pkg-0.1.0"` will `searchPaths.add(["$projectpath/nimbledeps/pkgs/pkg-0.1.0", "$home/.nimble/pkgs/pkg-0.1.0"])`

Cc @Araq @dom96 @disruptek