### PR TITLE
Fix spelling typos

### DIFF
--- a/changelogs/changelog_0_18_1.md
+++ b/changelogs/changelog_0_18_1.md
@@ -100,7 +100,7 @@
 
 - We changed how array accesses "from backwards" like ``a[^1]`` or ``a[0..^1]`` are
   implemented. These are now implemented purely in ``system.nim`` without compiler
-  support. There is a new "heterogenous" slice type ``system.HSlice`` that takes 2
+  support. There is a new "heterogeneous" slice type ``system.HSlice`` that takes 2
   generic parameters which can be ``BackwardsIndex`` indices. ``BackwardsIndex`` is
   produced by ``system.^``.
   This means if you overload ``[]`` or ``[]=`` you need to ensure they also work

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -477,7 +477,7 @@ proc ownedRefOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
 
 proc closureOp(c: var TLiftCtx; t: PType; body, x, y: PNode) =
   if c.kind == attachedDeepCopy:
-    # a big problem is that we don't know the enviroment's type here, so we
+    # a big problem is that we don't know the environment's type here, so we
     # have to go through some indirection; we delegate this to the codegen:
     let call = newNodeI(nkCall, c.info, 2)
     call.typ = t

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -304,7 +304,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
       # in a concept, eg:
       #   ExplainedConcept {.explain.} = concept x
       #     x.foo is int
-      # We coudl use: `(c.config $ n.sons[1].info)` to get more context.
+      # We could use: `(c.config $ n.sons[1].info)` to get more context.
       discard
     else:
       typeHint = " for type " & getProcHeader(c.config, sym)

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -216,7 +216,7 @@ The solution is to **re-play** the module's top level statements.
 This solves the problem without having to special case the logic
 that fills the internal seqs which are affected by the pragmas.
 
-In fact, this decribes how the AST should be stored in the database,
+In fact, this describes how the AST should be stored in the database,
 as a "shallow" tree. Let's assume we compile module ``m`` with the
 following contents:
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1644,7 +1644,7 @@ object branch, the initialization is considered valid. This analysis only works
 for immutable discriminators of an ordinal type and disregards ``elif``
 branches. For discriminator values with a ``range`` type, the compiler
 checks if the entire range of possible values for the discriminator value is
-valid for the choosen object branch.
+valid for the chosen object branch.
 
 A small example:
 
@@ -3440,14 +3440,14 @@ different; for this a special setter syntax is needed:
     ## setter of hostAddr.
     ## This accesses the 'host' field and is not a recursive call to
     ## ``host=`` because the builtin dot access is preferred if it is
-    ## avaliable:
+    ## available:
     s.host = value
 
   proc host*(s: Socket): int {.inline.} =
     ## getter of hostAddr
     ## This accesses the 'host' field and is not a recursive call to
     ## ``host`` because the builtin dot access is preferred if it is
-    ## avaliable:
+    ## available:
     s.host
 
 .. code-block:: nim
@@ -5409,7 +5409,7 @@ expression by coercing it to a corresponding ``static`` type:
 
   echo static(fac(5)), " ", static[bool](16.isPowerOfTwo)
 
-The complier will report any failure to evaluate the expression or a
+The compiler will report any failure to evaluate the expression or a
 possible type mismatch error.
 
 typedesc[T]
@@ -5421,7 +5421,7 @@ all values must have a type, ``typedesc`` is considered their special type.
 
 ``typedesc`` acts like a generic type. For instance, the type of the symbol
 ``int`` is ``typedesc[int]``. Just like with regular generic types, when the
-generic param is ommited, ``typedesc`` denotes the type class of all types.
+generic param is omitted, ``typedesc`` denotes the type class of all types.
 As a syntactic convenience, you can also use ``typedesc`` as a modifier.
 
 Procs featuring ``typedesc`` params are considered implicitly generic.

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -27,7 +27,7 @@ Package level objects
 Every Nim module resides in a (nimble) package. An object type can be attached
 to the package it resides in. If that is done, the type can be referenced from
 other modules as an `incomplete`:idx: object type. This feature allows to
-break up recursive type dependencies accross module boundaries. Incomplete
+break up recursive type dependencies across module boundaries. Incomplete
 object types are always passed ``byref`` and can only be used in pointer like
 contexts (``var/ref/ptr IncompleteObject``) in general since the compiler does
 not yet know the size of the object. To complete an incomplete object
@@ -267,7 +267,7 @@ calls can use the ``do`` keyword:
 ``do`` is written after the parentheses enclosing the regular proc params.
 The proc expression represented by the do block is appended to them.
 In calls using the command syntax, the do block will bind to the immediately
-preceeding expression, transforming it in a call.
+preceding expression, transforming it in a call.
 
 ``do`` with parentheses is an anonymous ``proc``; however a ``do`` without
 parentheses is just a block of code. The ``do`` notation can be used to
@@ -1618,7 +1618,7 @@ Aliasing restrictions in parameter passing
 ==========================================
 
 **Note**: The aliasing restrictions are currently not enforced by the
-implementation and need to be fleshed out futher.
+implementation and need to be fleshed out further.
 
 "Aliasing" here means that the underlying storage locations overlap in memory
 at runtime. An "output parameter" is a parameter of type ``var T``, an input

--- a/lib/wrappers/linenoise/linenoise.c
+++ b/lib/wrappers/linenoise/linenoise.c
@@ -600,7 +600,7 @@ static void refreshMultiLine(struct linenoiseState *l) {
     rpos2 = (plen+l->pos+l->cols)/l->cols; /* current cursor relative row. */
     lndebug("rpos2 %d", rpos2);
 
-    /* Go up till we reach the expected positon. */
+    /* Go up till we reach the expected position. */
     if (rows-rpos2 > 0) {
         lndebug("go-up %d", rows-rpos2);
         snprintf(seq,64,"\x1b[%dA", rows-rpos2);

--- a/tests/assert/tassert2.nim
+++ b/tests/assert/tassert2.nim
@@ -118,7 +118,7 @@ block: ## checks for issue https://github.com/nim-lang/Nim/issues/9301
     # used to const fold as false
     checkMsg(e.msg, "tassert2.nim(116, 14) `1 + 1 == 3` ", "test10")
 
-block: ## checks AST isnt' transformed as it used to
+block: ## checks AST isn't transformed as it used to
   let a = 1
   try:
     doAssert a > 1

--- a/tests/deps/x11-1.0/xkb.nim
+++ b/tests/deps/x11-1.0/xkb.nim
@@ -40,7 +40,7 @@
 #         while translating this code. ;)
 #
 #         I want to thanks #fpc channel in freenode irc, for helping me, and to put up with my
-#         wierd questions ;)
+#         weird questions ;)
 #
 #         Thanks for mmc in #xlib on freenode irc And so for the channel itself for the helping me to
 #         understanding some of the problems I had converting this headers and pointing me to resources
@@ -62,7 +62,7 @@
 #        2004/10/03           - Joined xkbstr.pas into xkb.pas because of the circular calls problems.
 #                             - Added the history of xkbstr.pas above this addition.
 #
-#        2004/09/17           - Fixed a wrong convertion number of XkbPerKeyBitArraySize, insted
+#        2004/09/17           - Fixed a wrong convertion number of XkbPerKeyBitArraySize, instead
 #                               of float, it's now converted into integer (as it should have been).
 #
 #        2004/09/15 - 16      - Convertion from the c header of XKB.h.

--- a/tests/deps/x11-1.0/xkblib.nim
+++ b/tests/deps/x11-1.0/xkblib.nim
@@ -33,7 +33,7 @@
 #         while translating this code. ;)
 #
 #         I want to thanks #fpc channel in freenode irc, for helping me, and to put up with my
-#         wierd questions ;)
+#         weird questions ;)
 #
 #         Thanks for mmc in #xlib on freenode irc And so for the channel itself for the helping me to
 #         understanding some of the problems I had converting this headers and pointing me to resources


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.