### PR TITLE
Fix for 16 bit platforms

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -87,7 +87,9 @@ proc fac*(n: int): int =
     doAssert fac(4) == 24
     doAssert fac(10) == 3628800
   const factTable =
-    when sizeof(int) == 4:
+    when sizeof(int) == 2:
+      createFactTable[5]()
+    elif sizeof(int) == 4:
       createFactTable[13]()
     else:
       createFactTable[21]()

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -914,12 +914,12 @@ proc size*(r: Rune): int {.noSideEffect.} =
     doAssert size(a[1]) == 2
 
   let v = r.uint32
-  if v <= 0x007F: result = 1
-  elif v <= 0x07FF: result = 2
-  elif v <= 0xFFFF: result = 3
-  elif v <= 0x1FFFFF: result = 4
-  elif v <= 0x3FFFFFF: result = 5
-  elif v <= 0x7FFFFFFF: result = 6
+  if v <= 0x007F'u32: result = 1
+  elif v <= 0x07FF'u32: result = 2
+  elif v <= 0xFFFF'u32: result = 3
+  elif v <= 0x1FFFFF'u32: result = 4
+  elif v <= 0x3FFFFFF'u32: result = 5
+  elif v <= 0x7FFFFFFF'u32: result = 6
   else: result = 1
 
 # --------- Private templates for different split separators -----------


### PR DESCRIPTION
This fixes some tiny issues with using Nim on 16-bit platforms. Not
entirely sure why the AVR chip I was compiling for with "cpu = avr" was
detected as 16-bit, but that's probably another issue..