### PR TITLE
Always set fileInfoIdx's isKnownFile

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -81,6 +81,7 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
     pseudoPath = true
 
   if conf.m.filenameToIndexTbl.hasKey(canon.string):
+    isKnownFile = true
     result = conf.m.filenameToIndexTbl[canon.string]
   else:
     isKnownFile = false


### PR DESCRIPTION
`fileInfoIdx` assumed `isKnownFile` was set to true. Wasted a bit of time before realizing this.