### PR TITLE
Increased TInstr field sizes: allow long jumps and 65535 VM registers

### DIFF
--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -12,14 +12,14 @@
 
 import ast, idents, options, modulegraphs, lineinfos
 
-type TInstrType* = uint32
+type TInstrType* = uint64
 
 const
   regOBits = 8 # Opcode
   regABits = 8
   regBBits = 8
   regCBits = 8
-  regBxBits = 16
+  regBxBits = 24
 
   byteExcess* = 128 # we use excess-K for immediates
 

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -16,9 +16,9 @@ type TInstrType* = uint64
 
 const
   regOBits = 8 # Opcode
-  regABits = 8
-  regBBits = 8
-  regCBits = 8
+  regABits = 16
+  regBBits = 16
+  regCBits = 16
   regBxBits = 24
 
   byteExcess* = 128 # we use excess-K for immediates

--- a/tests/vm/tfarjump.nim
+++ b/tests/vm/tfarjump.nim
@@ -1,0 +1,14 @@
+# Test a VM relative jump with an offset larger then 32767 instructions.
+
+import macros
+
+static:
+  var a = 0
+  macro foo(): untyped =
+    let s = newStmtList()
+    for i in 1..6554:
+      s.add nnkCommand.newTree(ident("inc"), ident("a"))
+    quote do:
+      if true:
+        `s`
+  foo()

--- a/tests/vm/tmanyregs.nim
+++ b/tests/vm/tmanyregs.nim
@@ -1,0 +1,16 @@
+import macros
+
+# Generate a proc with more then 255 registers. Should not generate an error at
+# compile time
+
+static:
+  macro mkFoo() =
+    let ss = newStmtList()
+    for i in 1..256:
+      ss.add parseStmt "var x" & $i & " = " & $i
+      ss.add parseStmt "inc x" & $i
+    quote do:
+      proc foo() =
+        `ss`
+  mkFoo()
+  foo()


### PR DESCRIPTION
Increases range from from 32K to 8M instructions. Leaves plenty of space in `TInstr` that can later be used for other purposes.

Fixes #12727, supersedes #12742