### PR TITLE
Fix #12734

### DIFF
--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -39,8 +39,11 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
     if parents <= 0: break
 
 proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
+  # Convert `path` so that 2 modules with same name
+  # in different directory get different name and they can be
+  # placed in a directory.
   # foo-#head/../bar becomes @foo-@hhead@s..@sbar
-  result = "@m" & relativeTo(path, conf.projectPath, '/').string.multiReplace({"/": "@s", "#": "@h", "@": "@@", ":": "@c"})
+  result = "@m" & relativeTo(path, conf.projectPath).string.multiReplace({$os.DirSep: "@s", $os.AltSep: "@s", "#": "@h", "@": "@@", ":": "@c"})
 
 proc demanglePackageName*(path: string): string =
   result = path.multiReplace({"@@": "@", "@h": "#", "@s": "/", "@m": "", "@c": ":"})


### PR DESCRIPTION
Unlike Unix, Windows is multiple root file system. I cannot create a relative path from 2 absolute paths with different drive.
When `relativeTo` cannot create a relative path, it returns absolute path as is.
This fix replace all `os.DirSep` and `os.AltSep` in the path returned from `relativeTo`.
