### PR TITLE
Fix external file recompilation 2

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -641,7 +641,7 @@ proc footprint(conf: ConfigRef; cfile: Cfile): SecureHash =
     getCompileCFileCmd(conf, cfile))
 
 proc externalFileChanged(conf: ConfigRef; cfile: Cfile): bool =
-  if conf.cmd notin {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToLLVM}:
+  if conf.cmd notin {cmdCompileToC, cmdCompileToCpp, cmdCompileToOC, cmdCompileToLLVM, cmdNone}:
     return false
 
   var hashFile = toGeneratedFile(conf, conf.withPackageName(cfile.cname), "sha1")


### PR DESCRIPTION
This change is very similar to PR https://github.com/nim-lang/Nim/pull/12380.
Except PR https://github.com/nim-lang/Nim/pull/12380 helps for external c/cpp files introduced with `{.compile.}` pragma while this PR makes sure it also recompiles external file listed on the command line (or cfg/nimscript) with `--compile` command line option. During command line processing the conf.cmd is not yet set causing incorrect behavior in `externalFileChanged`.