### PR TITLE
fix db_mysql getRow() when column is null error raised

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -307,7 +307,10 @@ proc getRow*(db: DbConn, query: SqlQuery,
     if row != nil:
       for i in 0..L-1:
         setLen(result[i], 0)
-        add(result[i], $row[i])
+        if row[i] == nil:
+          add(result[i], cstring(""))
+        else:
+          add(result[i], row[i])
     properFreeResult(sqlres, row)
 
 proc getAllRows*(db: DbConn, query: SqlQuery,

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -307,10 +307,7 @@ proc getRow*(db: DbConn, query: SqlQuery,
     if row != nil:
       for i in 0..L-1:
         setLen(result[i], 0)
-        if row[i] == nil:
-          add(result[i], cstring(""))
-        else:
-          add(result[i], row[i])
+        add(result[i], row[i])
     properFreeResult(sqlres, row)
 
 proc getAllRows*(db: DbConn, query: SqlQuery,

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -307,7 +307,7 @@ proc getRow*(db: DbConn, query: SqlQuery,
     if row != nil:
       for i in 0..L-1:
         setLen(result[i], 0)
-        add(result[i], row[i])
+        add(result[i], $row[i])
     properFreeResult(sqlres, row)
 
 proc getAllRows*(db: DbConn, query: SqlQuery,

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3413,7 +3413,10 @@ elif hasAlloc:
   proc add*(x: var string, y: cstring) =
     var i = 0
     while y[i] != '\0':
-      add(x, y[i])
+      if y[i] == nil:
+        add(x, cstring(""))
+      else:
+        add(x, y[i])
       inc(i)
   {.pop.}
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3412,9 +3412,7 @@ elif hasAlloc:
   {.push stack_trace:off, profiler:off.}
   proc add*(x: var string, y: cstring) =
     var i = 0
-    if y == nil:
-      add(x, "")
-    else:
+    if y != nil:
       while y[i] != '\0':
         add(x, y[i])
         inc(i)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3412,12 +3412,12 @@ elif hasAlloc:
   {.push stack_trace:off, profiler:off.}
   proc add*(x: var string, y: cstring) =
     var i = 0
-    while y[i] != '\0':
-      if y[i] == nil:
-        add(x, cstring(""))
-      else:
+    if y == nil:
+      add(x, "")
+    else:
+      while y[i] != '\0':
         add(x, y[i])
-      inc(i)
+        inc(i)
   {.pop.}
 
 when defined(nimvarargstyped):


### PR DESCRIPTION
If we have following users table in mysql and "email" column have null data

|id|name|email|
|---|---|---|
|1|John|null|

```
echo db.getRow(sql"SELECT * FROM users")
```
expects
```
@["1", "John", ""]
```

However we get an error

```
/nim/lib/impure/db_mysql.nim(310) getRow
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```