### PR TITLE
Fix AVR target to define ints properly

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -269,8 +269,16 @@ __AVR__
 #  define HAVE_STDINT_H
 #endif
 
+#if (!defined(HAVE_STDINT_H) && defined(__cplusplus) && (__cplusplus >= 201103))
+#  define HAVE_CSTDINT
+#endif
+
+
 /* wrap all Nim typedefs into namespace Nim */
 #ifdef USE_NIM_NAMESPACE
+#ifdef HAVE_CSTDINT
+#include <cstdint>
+#endif
 namespace USE_NIM_NAMESPACE {
 #endif
 
@@ -306,38 +314,40 @@ namespace USE_NIM_NAMESPACE {
                               the generated code does not rely on it anymore */
 #endif
 
-//#if defined(__BORLANDC__) || defined(__DMC__) \
-//   || defined(__WATCOMC__) || defined(_MSC_VER)
-//typedef signed char NI8;
-//typedef signed short int NI16;
-//typedef signed int NI32;
-//typedef __int64 NI64;
-///* XXX: Float128? */
-//typedef unsigned char NU8;
-//typedef unsigned short int NU16;
-//typedef unsigned int NU32;
-//typedef unsigned __int64 NU64;
-//#elif defined(HAVE_STDINT_H)
-//#  include <stdint.h>
-//typedef int8_t NI8;
-//typedef int16_t NI16;
-//typedef int32_t NI32;
-//typedef int64_t NI64;
-//typedef uint8_t NU8;
-//typedef uint16_t NU16;
-//typedef uint32_t NU32;
-//typedef uint64_t NU64;
-//#elif (defined(__cplusplus) && (__cplusplus >= 201103))
-//#  include <cstdint>
-//typedef std::int8_t NI8;
-//typedef std::int16_t NI16;
-//typedef std::int32_t NI32;
-//typedef std::int64_t NI64;
-//typedef std::uint8_t NU8;
-//typedef std::uint16_t NU16;
-//typedef std::uint32_t NU32;
-//typedef std::uint64_t NU64;
-//#else
+#if defined(__BORLANDC__) || defined(__DMC__) \
+   || defined(__WATCOMC__) || defined(_MSC_VER)
+typedef signed char NI8;
+typedef signed short int NI16;
+typedef signed int NI32;
+typedef __int64 NI64;
+/* XXX: Float128? */
+typedef unsigned char NU8;
+typedef unsigned short int NU16;
+typedef unsigned int NU32;
+typedef unsigned __int64 NU64;
+#elif defined(HAVE_STDINT_H)
+#  include <stdint.h>
+typedef int8_t NI8;
+typedef int16_t NI16;
+typedef int32_t NI32;
+typedef int64_t NI64;
+typedef uint8_t NU8;
+typedef uint16_t NU16;
+typedef uint32_t NU32;
+typedef uint64_t NU64;
+#elif defined(HAVE_CSTDINT)
+#ifndef USE_NIM_NAMESPACE
+#  include <cstdint>
+#endif
+typedef std::int8_t NI8;
+typedef std::int16_t NI16;
+typedef std::int32_t NI32;
+typedef std::int64_t NI64;
+typedef std::uint8_t NU8;
+typedef std::uint16_t NU16;
+typedef std::uint32_t NU32;
+typedef std::uint64_t NU64;
+#else
 /* Unknown compiler/version, do our best */
 #ifdef __INT8_TYPE__
 typedef __INT8_TYPE__ NI8;
@@ -380,7 +390,7 @@ typedef __UINT64_TYPE__ NU64;
 #else
 typedef unsigned long long int NU64;
 #endif
-//#endif
+#endif
 
 #ifdef NIM_INTBITS
 #  if NIM_INTBITS == 64

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -306,38 +306,38 @@ namespace USE_NIM_NAMESPACE {
                               the generated code does not rely on it anymore */
 #endif
 
-#if defined(__BORLANDC__) || defined(__DMC__) \
-   || defined(__WATCOMC__) || defined(_MSC_VER)
-typedef signed char NI8;
-typedef signed short int NI16;
-typedef signed int NI32;
-typedef __int64 NI64;
-/* XXX: Float128? */
-typedef unsigned char NU8;
-typedef unsigned short int NU16;
-typedef unsigned int NU32;
-typedef unsigned __int64 NU64;
-#elif defined(HAVE_STDINT_H)
-#  include <stdint.h>
-typedef int8_t NI8;
-typedef int16_t NI16;
-typedef int32_t NI32;
-typedef int64_t NI64;
-typedef uint8_t NU8;
-typedef uint16_t NU16;
-typedef uint32_t NU32;
-typedef uint64_t NU64;
-#elif (defined(__cplusplus) && (__cplusplus >= 201103))
-#  include <cstdint>
-typedef std::int8_t NI8;
-typedef std::int16_t NI16;
-typedef std::int32_t NI32;
-typedef std::int64_t NI64;
-typedef std::uint8_t NU8;
-typedef std::uint16_t NU16;
-typedef std::uint32_t NU32;
-typedef std::uint64_t NU64;
-#else
+//#if defined(__BORLANDC__) || defined(__DMC__) \
+//   || defined(__WATCOMC__) || defined(_MSC_VER)
+//typedef signed char NI8;
+//typedef signed short int NI16;
+//typedef signed int NI32;
+//typedef __int64 NI64;
+///* XXX: Float128? */
+//typedef unsigned char NU8;
+//typedef unsigned short int NU16;
+//typedef unsigned int NU32;
+//typedef unsigned __int64 NU64;
+//#elif defined(HAVE_STDINT_H)
+//#  include <stdint.h>
+//typedef int8_t NI8;
+//typedef int16_t NI16;
+//typedef int32_t NI32;
+//typedef int64_t NI64;
+//typedef uint8_t NU8;
+//typedef uint16_t NU16;
+//typedef uint32_t NU32;
+//typedef uint64_t NU64;
+//#elif (defined(__cplusplus) && (__cplusplus >= 201103))
+//#  include <cstdint>
+//typedef std::int8_t NI8;
+//typedef std::int16_t NI16;
+//typedef std::int32_t NI32;
+//typedef std::int64_t NI64;
+//typedef std::uint8_t NU8;
+//typedef std::uint16_t NU16;
+//typedef std::uint32_t NU32;
+//typedef std::uint64_t NU64;
+//#else
 /* Unknown compiler/version, do our best */
 #ifdef __INT8_TYPE__
 typedef __INT8_TYPE__ NI8;
@@ -380,7 +380,7 @@ typedef __UINT64_TYPE__ NU64;
 #else
 typedef unsigned long long int NU64;
 #endif
-#endif
+//#endif
 
 #ifdef NIM_INTBITS
 #  if NIM_INTBITS == 64

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -17,6 +17,7 @@ __DMC__
 __POCC__
 __TINYC__
 __clang__
+__AVR
 */
 
 
@@ -262,7 +263,7 @@ __clang__
 #  define HAVE_STDINT_H
 #endif
 
-#if defined(__LCC__) || defined(__DMC__) || defined(__POCC__)
+#if defined(__LCC__) || defined(__DMC__) || defined(__POCC__) || defined(__AVR)
 #  define HAVE_STDINT_H
 #endif
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -278,6 +278,8 @@ __AVR__
 #ifdef USE_NIM_NAMESPACE
 #ifdef HAVE_CSTDINT
 #include <cstdint>
+#else
+#include <stdint.h>
 #endif
 namespace USE_NIM_NAMESPACE {
 #endif
@@ -326,7 +328,9 @@ typedef unsigned short int NU16;
 typedef unsigned int NU32;
 typedef unsigned __int64 NU64;
 #elif defined(HAVE_STDINT_H)
+#ifndef USE_NIM_NAMESPACE
 #  include <stdint.h>
+#endif
 typedef int8_t NI8;
 typedef int16_t NI16;
 typedef int32_t NI32;

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -17,7 +17,7 @@ __DMC__
 __POCC__
 __TINYC__
 __clang__
-__AVR
+__AVR__
 */
 
 
@@ -259,11 +259,13 @@ __AVR
 #include <stddef.h>
 
 /* C99 compiler? */
-#if (defined(__STD_VERSION__) && (__STD_VERSION__ >= 199901))
+#if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901))
 #  define HAVE_STDINT_H
 #endif
 
-#if defined(__LCC__) || defined(__DMC__) || defined(__POCC__) || defined(__AVR)
+/* Known compiler with stdint.h that doesn't fit the general pattern? */
+#if defined(__LCC__) || defined(__DMC__) || defined(__POCC__) || \
+  defined(__AVR__) || (defined(__cplusplus) && (__cplusplus < 201103))
 #  define HAVE_STDINT_H
 #endif
 
@@ -309,32 +311,75 @@ namespace USE_NIM_NAMESPACE {
 typedef signed char NI8;
 typedef signed short int NI16;
 typedef signed int NI32;
+typedef __int64 NI64;
 /* XXX: Float128? */
 typedef unsigned char NU8;
 typedef unsigned short int NU16;
-typedef unsigned __int64 NU64;
-typedef __int64 NI64;
 typedef unsigned int NU32;
+typedef unsigned __int64 NU64;
 #elif defined(HAVE_STDINT_H)
 #  include <stdint.h>
 typedef int8_t NI8;
 typedef int16_t NI16;
 typedef int32_t NI32;
 typedef int64_t NI64;
-typedef uint64_t NU64;
 typedef uint8_t NU8;
 typedef uint16_t NU16;
 typedef uint32_t NU32;
+typedef uint64_t NU64;
+#elif (defined(__cplusplus) && (__cplusplus >= 201103))
+#  include <cstdint>
+typedef std::int8_t NI8;
+typedef std::int16_t NI16;
+typedef std::int32_t NI32;
+typedef std::int64_t NI64;
+typedef std::uint8_t NU8;
+typedef std::uint16_t NU16;
+typedef std::uint32_t NU32;
+typedef std::uint64_t NU64;
+#else
+/* Unknown compiler/version, do our best */
+#ifdef __INT8_TYPE__
+typedef __INT8_TYPE__ NI8;
 #else
 typedef signed char NI8;
+#endif
+#ifdef __INT16_TYPE__
+typedef __INT16_TYPE__ NI16;
+#else
 typedef signed short int NI16;
+#endif
+#ifdef __INT32_TYPE__
+typedef __INT32_TYPE__ NI32;
+#else
 typedef signed int NI32;
-/* XXX: Float128? */
-typedef unsigned char NU8;
-typedef unsigned short int NU16;
-typedef unsigned long long int NU64;
+#endif
+#ifdef __INT64_TYPE__
+typedef __INT64_TYPE__ NI64;
+#else
 typedef long long int NI64;
+#endif
+/* XXX: Float128? */
+#ifdef __UINT8_TYPE__
+typedef __UINT8_TYPE__ NU8;
+#else
+typedef unsigned char NU8;
+#endif
+#ifdef __UINT16_TYPE__
+typedef __UINT16_TYPE__ NU16;
+#else
+typedef unsigned short int NU16;
+#endif
+#ifdef __UINT32_TYPE__
+typedef __UINT32_TYPE__ NU32;
+#else
 typedef unsigned int NU32;
+#endif
+#ifdef __UINT64_TYPE__
+typedef __UINT64_TYPE__ NU64;
+#else
+typedef unsigned long long int NU64;
+#endif
 #endif
 
 #ifdef NIM_INTBITS


### PR DESCRIPTION
`HAVE_STDINT_H` wasn't defined for the AVR compiler so the `NU32` integer type was typedef'ed to an `unsigned int`. On the AVR platform however an `unsigned int` is 16 bits in size. This would lead to weird behaviour when trying to use these types. This check fixes the issue by defining `HAVE_STDINT_H` when the AVR compiler sets the `__AVR` flag.