### PR TITLE
VM: allow setting ptr/pointer fields at CT

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -231,7 +231,11 @@ proc fastAsgnComplex(x: var TFullReg, y: TFullReg) =
 proc writeField(n: var PNode, x: TFullReg) =
   case x.kind
   of rkNone: discard
-  of rkInt: n.intVal = x.intVal
+  of rkInt:
+    if n.kind == nkNilLit:
+      n[].reset
+      n.kind = nkIntLit # ideally, `nkPtrLit`
+    n.intVal = x.intVal
   of rkFloat: n.floatVal = x.floatVal
   of rkNode: n = copyValue(x.node)
   of rkRegisterAddr: writeField(n, x.regAddr[])


### PR DESCRIPTION
/cc @Araq 

before PR:
Error: unhandled exception: intVal [FieldError]
whenever setting a ptr or pointer field (assigning a ptr variable at CT already works)

after PR:
setting a ptr or pointer field works

## examples
there are many use cases, here's a simple one (example1 with pointer field) and a more elaborate one (example2 with ptr field)
example below requires building nim with -d:nimHasLibFFI and compiling with --experimental:compiletimeFFI for importc at CT
```
nim c -d:timn_D20191206T095533 --app:lib --outdir:$build_D/lib/ t0816b.nim # only needed for example2
nim c -r --experimental:compiletimeFFI t0816.nim 
```

t0816.nim:
```nim
import system/ansi_c
import ./t0816b

proc c_malloc*(size: csize_t): pointer {.importc: "malloc", header: "<stdlib.h>".}
proc c_fprintf*(f: CFilePtr, frmt: cstring): cint {.importc: "fprintf", header: "<stdio.h>", varargs, discardable.}

type Foo = object
  a: pointer
  b: CFilePtr

proc main()=
  var f: Foo

  ## example 1: pointer
  f.a = c_malloc(1234)

  ## example 2: ptr (CFilePtr = ptr CFile)
  f.b = getStderr()
  # c_fprintf(cstderr, "hello world\n") # doesn't work yet, so we need an intermediate library, see t0816b.nim
  c_fprintf(getStderr(), "hello world 1\n")
  c_fprintf(f.b, "hello world 2\n")
  ## re-assignment works
  f.b = getStdout()
  c_fprintf(f.b, "hello world 3\n")
  ## re-assignment to nil works
  f.b = nil

static: main()
main()
```

t0816b.nim:
```nim
when defined(timn_D20191206T095533):
  {.emit:"""
  #include <stdlib.h>
  #include <stdio.h>
  NIM_EXTERNC
  FILE* getStderr(){ return stderr;}
  FILE* getStdout(){ return stdout;}
  """.}

else:
  from system/ansi_c import CFilePtr
  const libF = "libt0816b.dylib"
  {.push importc, dynlib: libF.}
  proc getStderr*(): CFilePtr
  proc getStdout*(): CFilePtr
  {.pop.}
```

## note
I added a comment regarding `nkPtrLit`, which is what compiler/evalffi.nim uses:
```
const
  nkPtrLit = nkIntLit # hopefully we can get rid of this hack soon
```
ideally, nkPtrLit could be a new member of TNodeKind to avoid conflation; but this could be done in future PR
