### PR TITLE
Fixes classify function to detect subnormal floating points

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -135,7 +135,7 @@ type
     fcInf,           ## value is positive infinity
     fcNegInf         ## value is negative infinity
 
-proc classify[T: float32|float64](x: T): FloatClass =
+proc classify*[T: float32|float64](x: T): FloatClass =
   ## Classifies a floating point value.
   ##
   ## Returns ``x``'s class as specified by `FloatClass enum<#FloatClass>`_.

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -135,7 +135,7 @@ type
     fcInf,           ## value is positive infinity
     fcNegInf         ## value is negative infinity
 
-proc classify*[T: float32|float64](x: T): FloatClass =
+proc classify*(x: float): FloatClass =
   ## Classifies a floating point value.
   ##
   ## Returns ``x``'s class as specified by `FloatClass enum<#FloatClass>`_.
@@ -156,10 +156,10 @@ proc classify*[T: float32|float64](x: T): FloatClass =
     if x > 0.0: return fcInf
     else: return fcNegInf
   if x != x: return fcNan
-  when T is float32:
+  when sizeof(x) == 4:
     if abs(x) < MinFloat32Normal:
       return fcSubnormal
-  when T is float64:
+  when sizeof(x) == 8:
     if abs(x) < MinFloat64Normal:
       return fcSubnormal
   return fcNormal

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -156,11 +156,11 @@ proc classify*(x: float): FloatClass =
     if x > 0.0: return fcInf
     else: return fcNegInf
   if x != x: return fcNan
-  when sizeof(x) == 4:
-    if abs(x) < MinFloat32Normal:
-      return fcSubnormal
-  when sizeof(x) == 8:
+  when sizeof(float) == 8:
     if abs(x) < MinFloat64Normal:
+      return fcSubnormal
+  else:
+    if abs(x) < MinFloat32Normal:
       return fcSubnormal
   return fcNormal
 

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -117,10 +117,8 @@ const
                                              ## meaningful digits
                                              ## after the decimal point
                                              ## for Nim's ``float`` type.
-  MinFloat64Normal* = 2.225073858507201e-308 ## Smallest normal number for Nim's
-                                             ## ``float64`` type. (= 2^-1022).
-  MinFloat32Normal* = 1.175494350822288e-38  ## Smallest normal number for Nim's
-                                             ## ``float32`` type. (= 2^-126).
+  MinFloatNormal* = 2.225073858507201e-308   ## Smallest normal number for Nim's
+                                             ## ``float`` type. (= 2^-1022).
   RadPerDeg = PI / 180.0                     ## Number of radians per degree
 
 type
@@ -156,12 +154,8 @@ proc classify*(x: float): FloatClass =
     if x > 0.0: return fcInf
     else: return fcNegInf
   if x != x: return fcNan
-  when sizeof(float) == 8:
-    if abs(x) < MinFloat64Normal:
-      return fcSubnormal
-  else:
-    if abs(x) < MinFloat32Normal:
-      return fcSubnormal
+  if abs(x) < MinFloatNormal:
+    return fcSubnormal
   return fcNormal
 
 proc isPowerOfTwo*(x: int): bool {.noSideEffect.} =


### PR DESCRIPTION
Added minor change to check for floating point subnormality, both for float32 and float64. It seems this was anticipated but never implemented, hence the note "XXX: fcSubnormal is not detected!"