### PR TITLE
add a StringTable.clear that requires no mode specification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
   delimiter instead of '{' and '}'.
 - introduced new procs in `tables.nim`: `OrderedTable.pop`, `CountTable.del`,
   `CountTable.pop`, `Table.pop`
+- To `strtabs.nim`, added `StringTable.clear` overload that reuses the existing mode.
 
 
 - Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into

--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -324,7 +324,7 @@ proc clear*(s: StringTableRef, mode: StringTableMode) {.
   for i in 0..<s.data.len:
     s.data[i].hasValue = false
 
-proc clear*(s: StringTableRef) =
+proc clear*(s: StringTableRef) {.since: (1, 1).} =
   ## Resets a string table to be empty again without changing the mode.
   s.clear(s.mode)
 

--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -308,7 +308,7 @@ proc getValue(t: StringTableRef, flags: set[FormatFlag], key: string): string =
 
 proc clear*(s: StringTableRef, mode: StringTableMode) {.
   rtlFunc, extern: "nst$1".} =
-  ## Resets a string table to be empty again.
+  ## Resets a string table to be empty again, perhaps altering the mode.
   ##
   ## See also:
   ## * `del proc <#del,StringTableRef,string>`_ for removing a key from the table
@@ -323,6 +323,10 @@ proc clear*(s: StringTableRef, mode: StringTableMode) {.
   s.data.setLen(startSize)
   for i in 0..<s.data.len:
     s.data[i].hasValue = false
+
+proc clear*(s: StringTableRef) =
+  ## Resets a string table to be empty again without changing the mode.
+  s.clear(s.mode)
 
 proc del*(t: StringTableRef, key: string) =
   ## Removes `key` from `t`.

--- a/tests/stdlib/tstrtabs.nim
+++ b/tests/stdlib/tstrtabs.nim
@@ -82,6 +82,7 @@ key_7: value7
 key_80: value80
 key_8: value8
 key_9: value9
+length of table 0
 length of table 81
 value1 = value2
 '''
@@ -99,3 +100,5 @@ for key, val in pairs(tab):
 writeLine(stdout, "length of table ", $tab.len)
 
 writeLine(stdout, `%`("$key1 = $key2", tab, {useEnvironment}))
+tab.clear
+writeLine(stdout, "length of table ", $tab.len)


### PR DESCRIPTION
The `mode` field is not exported.  This works around that, as well as providing more succinct typical usage.