### PR TITLE
VM: support importc var, ptr/pointer types, cast int <=> ptr/pointer

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -857,6 +857,8 @@ type
     loc*: TLoc
     annex*: PLib              # additional fields (seldom used, so we use a
                               # reference to another object to save space)
+    cname*: string            # resolved C declaration name in importc decl, eg:
+                              # {.importc: "foo".} => cname = foo
     constraint*: PNode        # additional constraints like 'lit|result'; also
                               # misused for the codegenDecl pragma in the hope
                               # it won't cause problems

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -857,8 +857,9 @@ type
     loc*: TLoc
     annex*: PLib              # additional fields (seldom used, so we use a
                               # reference to another object to save space)
-    cname*: string            # resolved C declaration name in importc decl, eg:
-                              # {.importc: "foo".} => cname = foo
+    when hasFFI:
+      cname*: string          # resolved C declaration name in importc decl, eg:
+                              # proc fun() {.importc: "$1aux".} => cname = funaux
     constraint*: PNode        # additional constraints like 'lit|result'; also
                               # misused for the codegenDecl pragma in the hope
                               # it won't cause problems

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -469,6 +469,7 @@ type
     nfExplicitCall # x.y() was used instead of x.y
     nfExprCall  # this is an attempt to call a regular expression
     nfIsRef     # this node is a 'ref' node; used for the VM
+    nfIsPtr     # this node is a 'ptr' node; used for the VM
     nfPreventCg # this node should be ignored by the codegen
     nfBlockArg  # this a stmtlist appearing in a call (e.g. a do block)
     nfFromTemplate # a top-level node returned from a template
@@ -983,7 +984,7 @@ const
     skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias}
   PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
                                       nfDotSetter, nfDotField,
-                                      nfIsRef, nfPreventCg, nfLL,
+                                      nfIsRef, nfIsPtr, nfPreventCg, nfLL,
                                       nfFromTemplate, nfDefaultRefsParam,
                                       nfExecuteOnReload}
   namePos* = 0

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -979,6 +979,7 @@ const
                                     tyTuple, tySequence}
   NilableTypes*: TTypeKinds = {tyPointer, tyCString, tyRef, tyPtr,
     tyProc, tyError}
+  PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
   ExportableSymKinds* = {skVar, skConst, skProc, skFunc, skMethod, skType,
     skIterator,
     skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias}

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -701,11 +701,14 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
 proc mangleDynLibProc(sym: PSym): Rope =
   # we have to build this as a single rope in order not to trip the
   # optimization in genInfixCall, see test tests/cpp/t8241.nim
-  if sym.loc.r != nil:
-    if sym.loc.r.data.len > 0:
-      return sym.loc.r
-    else:
-      return rope($sym.loc.r)
+  when not defined(windows):
+    # mysterious bug that only affects windows, causing SIGSEGV in
+    # stdlib_winleanDatInit000 () at generated_not_to_break_here
+    if sym.loc.r != nil:
+      if sym.loc.r.data.len > 0:
+        return sym.loc.r
+      else:
+        return rope($sym.loc.r)
   if sfCompilerProc in sym.flags:
     # NOTE: sym.loc.r is the external name!
     result = rope(sym.name.s)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -701,10 +701,6 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
 proc mangleDynLibProc(sym: PSym): Rope =
   # we have to build this as a single rope in order not to trip the
   # optimization in genInfixCall, see test tests/cpp/t8241.nim
-  if sym.loc.r != nil:
-    # `return rope($sym.loc.r)` would cause on windows a SIGSEGV in
-    # stdlib_winleanDatInit000 () at generated_not_to_break_here
-    if sym.cname.len == 0: sym.cname = $sym.loc.r
   if sfCompilerProc in sym.flags:
     # NOTE: sym.loc.r is the external name!
     result = rope(sym.name.s)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -699,6 +699,8 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
   if lib.name == nil: internalError(m.config, "loadDynamicLib")
 
 proc mangleDynLibProc(sym: PSym): Rope =
+  if sym.loc.r != nil:
+    return sym.loc.r # should that be `rope($sym.loc.r)`? (see comment below)
   # we have to build this as a single rope in order not to trip the
   # optimization in genInfixCall
   if sfCompilerProc in sym.flags:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -701,14 +701,10 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
 proc mangleDynLibProc(sym: PSym): Rope =
   # we have to build this as a single rope in order not to trip the
   # optimization in genInfixCall, see test tests/cpp/t8241.nim
-  when not defined(windows):
-    # mysterious bug that only affects windows, causing SIGSEGV in
+  if sym.loc.r != nil:
+    # `return rope($sym.loc.r)` would cause on windows a SIGSEGV in
     # stdlib_winleanDatInit000 () at generated_not_to_break_here
-    if sym.loc.r != nil:
-      if sym.loc.r.data.len > 0:
-        return sym.loc.r
-      else:
-        return rope($sym.loc.r)
+    if sym.cname.len == 0: sym.cname = $sym.loc.r
   if sfCompilerProc in sym.flags:
     # NOTE: sym.loc.r is the external name!
     result = rope(sym.name.s)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -699,10 +699,13 @@ proc loadDynamicLib(m: BModule, lib: PLib) =
   if lib.name == nil: internalError(m.config, "loadDynamicLib")
 
 proc mangleDynLibProc(sym: PSym): Rope =
-  if sym.loc.r != nil:
-    return sym.loc.r # should that be `rope($sym.loc.r)`? (see comment below)
   # we have to build this as a single rope in order not to trip the
-  # optimization in genInfixCall
+  # optimization in genInfixCall, see test tests/cpp/t8241.nim
+  if sym.loc.r != nil:
+    if sym.loc.r.data.len > 0:
+      return sym.loc.r
+    else:
+      return rope($sym.loc.r)
   if sfCompilerProc in sym.flags:
     # NOTE: sym.loc.r is the external name!
     result = rope(sym.name.s)

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -46,19 +46,12 @@ proc getDll(conf: ConfigRef, cache: var TDllCache; dll: string; info: TLineInfo)
 const
   nkPtrLit = nkIntLit # hopefully we can get rid of this hack soon
 
-var myerrno {.importc: "errno", header: "<errno.h>".}: cint ## error variable
-
 proc importcSymbol*(conf: ConfigRef, sym: PSym): PNode =
   let name = $sym.loc.r
   # the AST does not support untyped pointers directly, so we use an nkIntLit
   # that contains the address instead:
   result = newNodeIT(nkPtrLit, sym.info, sym.typ)
-  case name
-  of "stdin":  result.intVal = cast[ByteAddress](system.stdin)
-  of "stdout": result.intVal = cast[ByteAddress](system.stdout)
-  of "stderr": result.intVal = cast[ByteAddress](system.stderr)
-  of "vmErrnoWrapper": result.intVal = cast[ByteAddress](myerrno)
-  else:
+  when true:
     let lib = sym.annex
     if lib != nil and lib.path.kind notin {nkStrLit..nkTripleStrLit}:
       globalError(conf, sym.info, "dynlib needs to be a string lit")
@@ -74,7 +67,7 @@ proc importcSymbol*(conf: ConfigRef, sym: PSym): PNode =
       let dll = if lib.kind == libHeader: libcDll else: lib.path.strVal
       let dllhandle = getDll(conf, gDllCache, dll, sym.info)
       theAddr = dllhandle.symAddr(name)
-    if theAddr.isNil: globalError(conf, sym.info, "cannot import: " & sym.name.s)
+    if theAddr.isNil: globalError(conf, sym.info, "cannot import: " & name)
     result.intVal = cast[ByteAddress](theAddr)
 
 proc mapType(conf: ConfigRef, t: ast.PType): ptr libffi.TType =

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -47,7 +47,8 @@ const
   nkPtrLit = nkIntLit # hopefully we can get rid of this hack soon
 
 proc importcSymbol*(conf: ConfigRef, sym: PSym): PNode =
-  let name = $sym.loc.r
+  var name = $sym.cname
+  if name.len == 0: name = $sym.loc.r
   # the AST does not support untyped pointers directly, so we use an nkIntLit
   # that contains the address instead:
   result = newNodeIT(nkPtrLit, sym.info, sym.typ)

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -47,8 +47,7 @@ const
   nkPtrLit = nkIntLit # hopefully we can get rid of this hack soon
 
 proc importcSymbol*(conf: ConfigRef, sym: PSym): PNode =
-  var name = $sym.cname
-  if name.len == 0: name = $sym.loc.r
+  let name = sym.cname # $sym.loc.r would point to internal name
   # the AST does not support untyped pointers directly, so we use an nkIntLit
   # that contains the address instead:
   result = newNodeIT(nkPtrLit, sym.info, sym.typ)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -129,6 +129,8 @@ proc setExternName(c: PContext; s: PSym, extname: string, info: TLineInfo) =
       s.loc.r = rope(extname % s.name.s)
     except ValueError:
       localError(c.config, info, "invalid extern name: '" & extname & "'. (Forgot to escape '$'?)")
+  when hasFFI:
+    s.cname = $s.loc.r
   if c.config.cmd == cmdPretty and '$' notin extname:
     # note that '{.importc.}' is transformed into '{.importc: "$1".}'
     s.loc.flags.incl(lfFullExternalName)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -793,6 +793,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           # see also `nfIsPtr`
           if node.kind == nkIntLit:
             var typ2 = typ
+            doAssert typ != nil
             if typ.kind == tyPtr:
               typ2 = typ2[0]
             if not derefPtrToReg(node.intVal, typ2, regs[ra], isAssign = false):
@@ -826,7 +827,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           stackTrace(c, tos, pc, errNilAccess)
         let node = regs[ra].node
         let typ = node.typ
-        if nfIsPtr in node.flags or typ.kind == tyPtr:
+        if nfIsPtr in node.flags or (typ != nil and typ.kind == tyPtr):
           assert node.kind == nkIntLit, $(node.kind)
           var typ2 = typ
           if typ.kind == tyPtr:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1448,7 +1448,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       let rb = instr.regBx - wordExcess - 1
       ensureKind(rkNode)
       regs[ra].node = c.globals[rb]
-    of opcLdGlobalDeref:
+    of opcLdGlobalDerefFFI:
       let rb = instr.regBx - wordExcess - 1
       let node = c.globals[rb]
       let typ = node.typ
@@ -1462,7 +1462,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         regs[ra].node = node2
       elif not derefPtrToReg(node.intVal, typ, regs[ra], isAssign = false):
         stackTrace(c, tos, pc, "opcLdDeref unsupported type: " & $(typeToString(typ), typ[0].kind))
-    of opcLdGlobalAddrDeref:
+    of opcLdGlobalAddrDerefFFI:
       let rb = instr.regBx - wordExcess - 1
       let node = c.globals[rb]
       let typ = node.typ

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1008,7 +1008,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         let nc = regs[rc].node
         regs[ra].intVal = ord(
           (nb.kind == nkNilLit and nc.kind == nkNilLit) or
-          (nb.typ.kind in {tyPtr, tyPointer} and nb.typ.kind == nc.typ.kind and nb.intVal == nc.intVal) or
+          (nb.typ.kind in PtrLikeKinds and nb.typ.kind == nc.typ.kind and nb.intVal == nc.intVal) or
           nb == nc)
     of opcEqNimNode:
       decodeBC(rkInt)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1004,9 +1004,12 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         # we know these cannot be equal
         regs[ra].intVal = ord(false)
       else:
-        regs[ra].intVal = ord((regs[rb].node.kind == nkNilLit and
-                              regs[rc].node.kind == nkNilLit) or
-                              regs[rb].node == regs[rc].node)
+        let nb = regs[rb].node
+        let nc = regs[rc].node
+        regs[ra].intVal = ord(
+          (nb.kind == nkNilLit and nc.kind == nkNilLit) or
+          (nb.typ.kind in {tyPtr, tyPointer} and nb.typ.kind == nc.typ.kind and nb.intVal == nc.intVal) or
+          nb == nc)
     of opcEqNimNode:
       decodeBC(rkInt)
       regs[ra].intVal =

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -281,7 +281,7 @@ proc putIntoReg(dest: var TFullReg; n: PNode) =
     if dest.kind == rkNode:
       dest.node = n
       return
-    elif n.typ.kind == tyPtr:
+    elif n.typ != nil and n.typ.kind == tyPtr:
       dest = TFullReg(kind: rkNode, node: n)
       return
 

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -64,6 +64,7 @@ type
     opcCastFloatToInt32,    # int and float must be of the same byte size
     opcCastFloatToInt64,    # int and float must be of the same byte size
     opcCastPtrToInt,
+    opcCastIntToPtr,
     opcFastAsgnComplex,
     opcNodeToReg,
 

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -63,6 +63,7 @@ type
     opcCastIntToFloat64,    # int and float must be of the same byte size
     opcCastFloatToInt32,    # int and float must be of the same byte size
     opcCastFloatToInt64,    # int and float must be of the same byte size
+    opcCastPtrToInt,
     opcFastAsgnComplex,
     opcNodeToReg,
 
@@ -169,6 +170,8 @@ type
     opcAsgnConst, # dest = copy(constants[Bx])
     opcLdGlobal,  # dest = globals[Bx]
     opcLdGlobalAddr, # dest = addr(globals[Bx])
+    opcLdGlobalDeref, # dest = globals[Bx][]
+    opcLdGlobalAddrDeref, # globals[Bx][] = ...
 
     opcLdImmInt,  # dest = immediate value
     opcNBindSym, opcNDynBindSym,

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -171,8 +171,8 @@ type
     opcAsgnConst, # dest = copy(constants[Bx])
     opcLdGlobal,  # dest = globals[Bx]
     opcLdGlobalAddr, # dest = addr(globals[Bx])
-    opcLdGlobalDeref, # dest = globals[Bx][]
-    opcLdGlobalAddrDeref, # globals[Bx][] = ...
+    opcLdGlobalDerefFFI, # dest = globals[Bx][]
+    opcLdGlobalAddrDerefFFI, # globals[Bx][] = ...
 
     opcLdImmInt,  # dest = immediate value
     opcNBindSym, opcNDynBindSym,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1650,11 +1650,11 @@ proc genRdVar(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
 
     if gfNodeAddr in flags:
       if isImportcVar:
-        c.gABx(n, opcLdGlobalAddrDeref, dest, s.position)
+        c.gABx(n, opcLdGlobalAddrDerefFFI, dest, s.position)
       else:
         c.gABx(n, opcLdGlobalAddr, dest, s.position)
     elif isImportcVar:
-      c.gABx(n, opcLdGlobalDeref, dest, s.position)
+      c.gABx(n, opcLdGlobalDerefFFI, dest, s.position)
     elif fitsRegister(s.typ) and gfNode notin flags:
       var cc = c.getTemp(n.typ)
       c.gABx(n, opcLdGlobal, cc, s.position)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -885,13 +885,13 @@ proc genCastIntFloat(c: PCtx; n: PNode; dest: var TDest) =
       c.gABC(n, opcCastFloatToInt64, dest, tmp)
       # narrowing for 64 bits not needed (no extended sign bits available).
     c.freeTemp(tmp)
-  elif src.kind == tyPtr and dst.kind == tyInt:
+  elif src.kind in PtrLikeKinds and dst.kind == tyInt:
     let tmp = c.genx(n[1])
     if dest < 0: dest = c.getTemp(n[0].typ)
     c.gABC(n, opcCastPtrToInt, dest, tmp)
     c.freeTemp(tmp)
   else:
-    globalError(c.config, n.info, "VM is only allowed to 'cast' between integers and/or floats of same size " & $(src.kind, dst.kind))
+    globalError(c.config, n.info, "VM is only allowed to 'cast' between integers and/or floats of same size or PtrLikeKinds => int " & $(src.kind, dst.kind))
 
 proc genVoidABC(c: PCtx, n: PNode, dest: TDest, opcode: TOpcode) =
   unused(c, n, dest)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -890,8 +890,14 @@ proc genCastIntFloat(c: PCtx; n: PNode; dest: var TDest) =
     if dest < 0: dest = c.getTemp(n[0].typ)
     c.gABC(n, opcCastPtrToInt, dest, tmp)
     c.freeTemp(tmp)
+  elif src.kind in PtrLikeKinds + {tyInt} and dst.kind in PtrLikeKinds:
+    let tmp = c.genx(n[1])
+    if dest < 0: dest = c.getTemp(n[0].typ)
+    c.gABx(n, opcSetType, dest, c.genType(dst))
+    c.gABC(n, opcCastIntToPtr, dest, tmp)
+    c.freeTemp(tmp)
   else:
-    globalError(c.config, n.info, "VM is only allowed to 'cast' between integers and/or floats of same size or PtrLikeKinds => int " & $(src.kind, dst.kind))
+    globalError(c.config, n.info, "VM is only allowed to 'cast' between integers and/or floats of same size or PtrLikeKinds <=> PtrLikeKinds / int " & $(src.kind, dst.kind))
 
 proc genVoidABC(c: PCtx, n: PNode, dest: TDest, opcode: TOpcode) =
   unused(c, n, dest)


### PR DESCRIPTION
/cc @Araq 

* VM now supports `importc var`
in particular, it does work with ptr types (eg `CFilePtr = ptr CFile`) or primitive (eg float32 etc), and with either header or dynlib pragma

```nim
  var
    mystderr2* {.importc: "mystderr", dynlib: libF.}: CFilePtr # with C: FILE* mystderr;
    myc_float32* {.importc, dynlib: libF.}: float32 # with C: `float myb_float32; `
    myerrno2* {.importc: "errno", header: "<errno.h>".}: cint
```

the resulting code works as expected, in particular works same as with non-VM code, eg: see example1

* bugfix: importc procs returing ptr types (eg ptr float32, pointer etc) are now handled correctly

* remove hardcoded values stdin/stdout/stderr/vmErrnoWrapper in importcSymbol: the compiler is now able to correctly importc these symbols without any hack
furthermore, vmErrnoWrapper (and errno) didn't actually work prior to this PR; in this PR, errno now works in VM

* `cannot import` error msg now shows the source symbol (say, imported from a library) instead of the renamed symbol; this makes it easier to debug (eg using `nm mylib.dylib | grep symbol_name`)

* bugfix: `mangleDynLibProc` was returning a mangled symbol even if a name was already assigned (eg via `importc`), this bugfix is needed to support importc var

* VM now supports cast int <=>ptr/pointer types; among other things, it makes it easier to debug ptr types in VM, or allows to store pointers as int, make more code work as-is at CT etc

* supersedes https://github.com/nim-lang/Nim/pull/12840

## example 1
illustrates various features from this PR, in particular shows how code works un-modified at CT and RT

build nim with -d:nimHasLibFFI, compile with --experimental:compiletimeFFI
D20191211T022413
```nim
var myerrno2* {.importc: "errno", header: "<errno.h>".}: cint
from system/ansi_c import CFilePtr, c_fprintf
const stderr_name = when defined(osx): "__stderrp" else: "stderr"
var cstderr {.importc: stderr_name, header: "<stdio.h>".}: CFilePtr

proc main() =
  c_fprintf(cstderr, "hello world stderr v2\n")
  echo cast[int](cstderr)
  myerrno2 = 0
  myerrno2 += 2
  doAssert myerrno2 == 2
static: main()
main()

```

## further examples
see https://github.com/timotheecour/vitanim/blob/master/testcases/tests/test_vm_var_importc.nim which contains instructions to build, and shows the different features from this PR

## note
/cc @krux02 
hopefully this addresses comments from https://github.com/nim-lang/Nim/pull/12840#issuecomment-563483971
> But saying that importc var now works seamlessly at CT is also a pretty bold claim that I just don't believe.

this new PR should make importc var work; see example1 and especially `further examples` for extensive testing

> A var has mutability, how is that reflected here in your PR? 

see `myerrno2` example shown in top post

> You change the state at compile time, what will the value be after compilation at runtime

there is no interaction between the `importc var` at RT vs CT; after this PR, regular code work that depends on some importc var can now also work at CT without any modification, see example 1

> Regarding your future plans with let and const, am totally on your side with let. But const? I have my doubts that your plan that you are suggesting will work. But that isn't criticism on this PR though.

this could use some sugar but works:
```nim
when defined(timn_D20191211T161306):
  {.emit:"""
  NIM_EXTERNC
  // static const int foo2 = 456; // won't work
  const int foo2 = 456;
  int get_foo(){ return 1234; }
  """.}

else:
  import std/[strformat,os]
  const libF = "/tmp/libD20191211T161306.dylib"
  const nim = getCurrentCompilerExe()
  const file = currentSourcePath()
  static:
    let cmd = fmt"{nim} c -d:timn_D20191211T161306 --app:lib -o:{libF} {file}"
    echo cmd
    let (output, exitCode) = gorgeEx cmd
    doAssert exitCode == 0, output

  proc get_foo(): cint {.importc, dynlib: libF.}
  var foo2Impl {.importc: "foo2", dynlib: libF.}: cint
  const foo2 = foo2Impl

  proc main()=
    const foo = get_foo()
    echo ("foo", foo, foo2)

  static: main()
  main()
```

## TODO for future PR's
- [ ] simplify some logic by adding `nkPtrLit` node kind
