### PR TITLE
update document for `closureScope` and `capture`

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3520,8 +3520,8 @@ Creating closures in loops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since closures capture local variables by reference it is often not wanted
-behavior inside loop bodies. See `closureScope
-<system.html#closureScope.t,untyped>`_ for details on how to change this behavior.
+behavior inside loop bodies. See `capture
+<sugar.html#capture.m,openArray[typed],untyped>`_ for details on how to change this behavior.
 
 Anonymous Procs
 ---------------

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3520,7 +3520,8 @@ Creating closures in loops
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Since closures capture local variables by reference it is often not wanted
-behavior inside loop bodies. See `capture
+behavior inside loop bodies. See `closureScope
+<system.html#closureScope.t,untyped>`_ and `capture
 <sugar.html#capture.m,openArray[typed],untyped>`_ for details on how to change this behavior.
 
 Anonymous Procs

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4393,7 +4393,8 @@ when defined(nimNoNilSeqs2):
       proc `==`*(x: string; y: type(nil) | type(nil)): bool {.error.} = discard
       proc `==`*(x: type(nil) | type(nil); y: string): bool {.error.} = discard
 
-template closureScope*(body: untyped): untyped =
+template closureScope*(body: untyped): untyped {.deprecated:
+                                                "1.1.0, use `sugar.capture` instead".} =
   ## Useful when creating a closure in a loop to capture local loop variables by
   ## their current iteration values. Example:
   ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4393,10 +4393,14 @@ when defined(nimNoNilSeqs2):
       proc `==`*(x: string; y: type(nil) | type(nil)): bool {.error.} = discard
       proc `==`*(x: type(nil) | type(nil); y: string): bool {.error.} = discard
 
-template closureScope*(body: untyped): untyped {.deprecated:
-                                                "1.1.0, use `sugar.capture` instead".} =
+template closureScope*(body: untyped): untyped =
   ## Useful when creating a closure in a loop to capture local loop variables by
-  ## their current iteration values. Example:
+  ## their current iteration values.
+  ##
+  ## Note: This template may not work in some cases, use
+  ## `capture <sugar.html#capture.m,openArray[typed],untyped>`_ instead.
+  ##
+  ## Example:
   ##
   ## .. code-block:: Nim
   ##   var myClosure : proc()


### PR DESCRIPTION
1. mark closureScope as deprecated in code;
2. update manual to use `sugar.capture`.