### PR TITLE
add more utilities to `sequtils`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,8 +45,8 @@
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
 
-- Added `count` (a new version), `countIt`, `lengthWhile`, `takeWhile`, `dropWhile`, `nest`,
-  `zipWith`, and `findFirst` to `sequtils` module to enrich its functionalities.
+- Added `count` (a new version), `countIt`, `lenWhile`, `takeWhile`, `dropWhile`, `nest`,
+  `zipWith`, `findFirst`, etc, to `sequtils` module to enrich its functionalities.
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,9 @@
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
 
+- Added `count`, `countIt`, `lengthWhile`, `takeWhile`, `dropWhile`, `nest`, `zipwith`,
+  and `findFirst` to `sequtils` module to enrich its functionalities.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/changelog.md
+++ b/changelog.md
@@ -45,8 +45,8 @@
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
 
-- Added `count`, `countIt`, `lengthWhile`, `takeWhile`, `dropWhile`, `nest`, `zipwith`,
-  and `findFirst` to `sequtils` module to enrich its functionalities.
+- Added `count` (a new version), `countIt`, `lengthWhile`, `takeWhile`, `dropWhile`, `nest`,
+  `zipWith`, and `findFirst` to `sequtils` module to enrich its functionalities.
 
 ## Library changes
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -38,7 +38,7 @@
 ## * Iteratively applying operations
 ##   * `nest<#nest,proc(T),T,Natural>`_
 ##   * `foldl<#foldl.t,,,>`_ · `foldr<#foldr.t,untyped,untyped>`_ · `nestIt<#nestIt.t,untyped,typed,Natural>`_
-## * Creating a container
+## * Creating containers
 ##   * `circle<#cycle,openArray[T],Natural>`_ · `repeat<#repeat,T,Natural>`_ ·
 ##     `deduplicate<#deduplicate,openArray[T],bool>`_ · `zip<#zip,,>`_ ·
 ##     `concat<#concat,varargs[seq[T][T]]>`_ · `distribute<#distribute,seq[T][T],Positive>`_ ·
@@ -1451,17 +1451,19 @@ since (1, 1):
     block:
       evalOnceAs(ss1, s1, compiles((let _ = s1)))
       evalOnceAs(ss2, s2, compiles((let _ = s2)))
-      var
-        it {.inject.}: typeof(items(ss1), typeOfIter)
-        jt {.inject.}: typeof(items(ss2), typeOfIter)
+
       type
-        OutType = typeof(op, typeOfProc)
+        OutType = typeof((block:
+          var
+            it {.inject.}: typeof(items(ss1), typeOfIter)
+            jt {.inject.}: typeof(items(ss2), typeOfIter)
+          op), typeOfProc)
 
       let m = min(ss1.len, ss2.len)
       var result = newSeq[OutType](m)
       for i in 0 ..< m:
-        it = ss1[i]
-        jt = ss2[i]
+        let it {.inject.} = ss1[i]
+        let jt {.inject.} = ss2[i]
         result[i] = op
       result
 
@@ -1488,19 +1490,21 @@ since (1, 1):
       evalOnceAs(ss1, s1, compiles((let _ = s1)))
       evalOnceAs(ss2, s2, compiles((let _ = s2)))
       evalOnceAs(ss3, s3, compiles((let _ = s3)))
-      var
-        it {.inject.}: typeof(items(ss1), typeOfIter)
-        jt {.inject.}: typeof(items(ss2), typeOfIter)
-        kt {.inject.}: typeof(items(ss3), typeOfIter)
+
       type
-        OutType = typeof(op, typeOfProc)
+        OutType = typeof((block:
+          var
+            it {.inject.}: typeof(items(ss1), typeOfIter)
+            jt {.inject.}: typeof(items(ss2), typeOfIter)
+            kt {.inject.}: typeof(items(ss3), typeOfIter)
+          op), typeOfProc)
 
       let m = min(min(ss1.len, ss2.len), ss3.len)
       var result = newSeq[OutType](m)
       for i in 0 ..< m:
-        it = ss1[i]
-        jt = ss2[i]
-        kt = ss3[i]
+        let it {.inject.} = ss1[i]
+        let jt {.inject.} = ss2[i]
+        let kt {.inject.} = ss3[i]
         result[i] = op
       result
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -24,7 +24,39 @@
 ##
 ## This module builds upon that, providing additional functionality in form of
 ## procs, iterators and templates inspired by functional programming
-## languages.
+## languages, such as:
+## * Applying operations to a single container
+##   * `map<#map,openArray[T],proc(T)>`_ · `apply<#apply,openArray[T],proc(T)>`_ ·
+##     `mapIndexed<#mapIndexed,openArray[T],proc(int,T)>`_ ·
+##     `scan<#scan,openArray[T],proc(T)>`_ · `scanIndexed<#scanIndexed,openArray[T],proc(int,T)>`_
+##   * `mapIt<#mapIt.t,typed,untyped>`_ · `applyIt<#applyIt.t,untyped,untyped>`_ ·
+##     `scanIt<#scanIt.t,typed,untyped>`_ ·  `mapLiterals<#mapLiterals.m,untyped,untyped>`_
+## * Applying operations to two or three containers
+##   * `zipWith<#zipWith,openArray[T1],openArray[T2],proc(T1,T2)>`_ ·
+##     `zippedScan<#zippedScan,openArray[T1],openArray[T2],proc(T1,T2)>`_
+##   * `zipThem<#zipThem.t,typed,typed,untyped>`_ · `scanThem<#scanThem.t,typed,typed,untyped>`_
+## * Iteratively applying operations
+##   * `nest<#nest,proc(T),T,Natural>`_
+##   * `foldl<#foldl.t,,,>`_ · `foldr<#foldr.t,untyped,untyped>`_ · `nestIt<#nestIt.t,untyped,typed,Natural>`_
+## * Creating a container
+##   * `circle<#cycle,openArray[T],Natural>`_ · `repeat<#repeat,T,Natural>`_ ·
+##     `deduplicate<#deduplicate,openArray[T],bool>`_ · `zip<#zip,,>`_ ·
+##     `concat<#concat,varargs[seq[T][T]]>`_ · `distribute<#distribute,seq[T][T],Positive>`_ ·
+##     `partition<#partition,seq[T][T],Positive>`_ · `insert<#insert,seq[T][T],openArray[T],int>`_
+##   * `items<#items.i>`_ · `newSeqWith<#newSeqWith.t,int,untyped>`_
+## * Inspecting a container
+##   * `count<#count,openArray[T],proc(T)>`_ · `all<#all,openArray[T],proc(T)>`_ ·
+##     `any<#any,openArray[T],proc(T)>`_ · `lengthWhile<#lengthWhile,openArray[T],proc(T)>`_ ·
+##     `indexOf<#indexOf,openArray[T],proc(T)>`_ · `findFirst<#findFirst,openArray[T],proc(T),T>`_
+##   * `countIt<#countIt.t,typed,untyped>`_ ·  `allIt<#allIt.t,untyped,untyped>`_ ·
+##     `anyIt<#anyIt.t,untyped,untyped>`_ · `lengthWhileIt<#lengthWhileIt.t,typed,untyped>`_ ·
+##     `indexOfIt<#indexOfIt.t,typed,untyped>`_ · `findItFirst<#findItFirst.t,typed,untyped>`_
+## * Selecting items
+##   * `filter<#filter,openArray[T],proc(T)>`_ · `delete<#delete,seq[T][T],Natural,Natural>`_  ·
+##     `takeWhile<#takeWhile,openArray[T],proc(T)>`_ · `dropWhile<#dropWhile,openArray[T],proc(T)>`_ ·
+##     `keepIf<#keepIf,seq[T][T],proc(T)>`_
+##   * `takeItWhile<#takeItWhile.t,typed,untyped>`_ · `dropItWhile<#dropItWhile.t,typed,untyped>`_ ·
+##     `keepItIf<#keepItIf.t,seq[T],untyped>`_ · `filterIt<#filterIt.t,untyped,untyped>`_
 ##
 ## For functional style programming you have different options at your disposal:
 ## * pass `anonymous proc<manual.html#procedures-anonymous-procs>`_
@@ -145,7 +177,7 @@ proc count*[T](s: openArray[T], x: T): int =
 
 proc count*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
                                                          {.since: (1, 1).} =
-  ## Returns the number of items in the container `s` that fullfills
+  ## Returns the number of items in the container `s` that fulfills
   ## the predicate `pred` (function that returns a `bool`).
   ##
   runnableExamples:
@@ -155,34 +187,9 @@ proc count*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
     if pred(itm):
       inc result
 
-since (1, 1):
-  template countIt*(s: typed, op: untyped): untyped =
-    ## Returns a new sequence with the results of `op` proc applied to every
-    ## item in the container `s`.
-    ##
-    ## Since the input is not modified you can use it to
-    ## transform the type of the elements in the input container.
-    ##
-    ## The template injects the ``it`` variable which you can use directly in an
-    ## expression.
-    ##
-    ## See also:
-    ## * `map proc<#map,openArray[T],proc(T)>`_
-    ## * `applyIt template<#applyIt.t,untyped,untyped>`_ for the in-place version
-    ##
-    runnableExamples:
-      assert countIt("abracadabra", it in {'a', 'r'}) == 7
-
-    var
-      result: int = 0
-    for it {.inject.} in s:
-      if op:
-        inc result
-    result
-
 proc lengthWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
                                                             {.since: (1, 1).} =
-  ## Returns the number of items in the container `s` that keep fullfilling
+  ## Returns the number of items in the container `s` that keep fulfilling
   ## the predicate `pred` (function that returns a `bool`) from the beginning.
   ##
   runnableExamples:
@@ -196,34 +203,29 @@ proc lengthWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
 
 proc takeWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
                                                             {.since: (1, 1).} =
-  ## Returns a sequence of items in the container `s` that keep fullfilling
+  ## Returns a sequence of items in the container `s` that keep fulfilling
   ## the predicate `pred` (function that returns a `bool`) from the beginning.
   ##
   runnableExamples:
     assert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[1, 2, 3]
 
-  let len = lengthWhile(s, pred)
-  result = newSeq[T](len)
-  for i in 0 ..< len:
-    result[i] = s[i]
+  s[0 ..< lengthWhile(s, pred)]
 
 proc dropWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
                                                             {.since: (1, 1).} =
   ## Returns a sequence of items in the container `s` without items that
-  ## keep fullfilling the predicate `pred` (function that returns a `bool`)
+  ## keep fulfilling the predicate `pred` (function that returns a `bool`)
   ## from the beginning, i.e. those items are dropped.
   ##
   runnableExamples:
     assert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[4, 5]
 
-  let len = lengthWhile(s, pred)
-  result = newSeq[T](s.len - len)
-  for i in len ..< s.len:
-    result[i - len] = s[i]
+  s[lengthWhile(s, pred) ..< s.len]
 
 proc nest*[T](f: proc(x: T): T, x: T, n: Natural): seq[T] {.since: (1, 1).} =
   ## Returns a new sequence of the results of applying `f` to `x` 0 .. `n`
   ## times, i.e. `@[x, f(x), f(f(x)), ...]`.
+  ## `n` must be a non-negative number (zero or more).
   ##
   runnableExamples:
     assert nest(func (x: int): int = x * 2, 1, 4) == @[1, 2, 4, 8, 16]
@@ -339,8 +341,8 @@ else:
 proc zipWith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
             op: proc (x: T1, y: T2): R {.closure.}): seq[R]
                                                           {.since: (1, 1).} =
-  ## Returns a new sequence with a transformation on each elememnt from
-  ## two input containers.
+  ## Returns a new sequence with a transformation on each pair of elements
+  ## from the two input containers.
   ##
   ## The input containers can be of different types.
   ## If one container is shorter, the remaining items in the longer container
@@ -353,7 +355,7 @@ proc zipWith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
       zip1 = zipWith(s1, s2, func (x, y: int): int = x * y)
     assert zip1 == @[4, 10, 18]
 
-  var m = min(s1.len, s2.len)
+  let m = min(s1.len, s2.len)
   newSeq(result, m)
   for i in 0 ..< m:
     result[i] = op(s1[i], s2[i])
@@ -362,8 +364,8 @@ proc zipWith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
                              s3: openArray[T3],
                              op: proc (x: T1, y: T2, Z: T3): R {.closure.}):
                                                    seq[R] {.since: (1, 1).} =
-  ## Returns a new sequence with a transformation on each pair of elememnts
-  ## from two input containers.
+  ## Returns a new sequence with a transformation on each triple of elements
+  ## from three input containers.
   ##
   ## The input containers can be of different types.
   ## If one container is shorter, the remaining items in the longer container
@@ -377,10 +379,112 @@ proc zipWith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
       zip1 = zipWith(s1, s2, s3, func (x, y, z: int): bool = x + y == z)
     assert zip1 == @[true, true, true]
 
-  var m = min(min(s1.len, s2.len), s3.len)
+  let m = min(min(s1.len, s2.len), s3.len)
   newSeq(result, m)
   for i in 0 ..< m:
     result[i] = op(s1[i], s2[i], s3[i])
+
+proc zippedScan*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
+            op: proc (x: T1, y: T2): R {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc on each pair of elements from the two input containers,
+  ## discarding results.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6, 7]
+    zippedScan(s1, s2, proc (x, y: int): int = x * y)
+
+  let m = min(s1.len, s2.len)
+  for i in 0 ..< m:
+    discard op(s1[i], s2[i])
+
+proc zippedScan*[T1, T2](s1: openArray[T1], s2: openArray[T2],
+            op: proc (x: T1, y: T2) {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc on each pair of elements from the two input containers.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6, 7]
+    zippedScan(s1, s2, proc (x, y: int) = echo x * y)
+
+  let m = min(s1.len, s2.len)
+  for i in 0 ..< m:
+    op(s1[i], s2[i])
+
+proc zippedScan*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
+                             s3: openArray[T3],
+                             op: proc (x: T1, y: T2, Z: T3): R {.closure.})
+                                                          {.since: (1, 1).} =
+  ## Apply `op` proc on each triple of elements from the three input containers,
+  ## discarding results.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+    zippedScan(s1, s2, s3, proc (x, y, z: int): bool = x + y == z)
+
+  let m = min(min(s1.len, s2.len), s3.len)
+  for i in 0 ..< m:
+    discard op(s1[i], s2[i], s3[i])
+
+proc zippedScan*[T1, T2, T3](s1: openArray[T1], s2: openArray[T2],
+                             s3: openArray[T3],
+                             op: proc (x: T1, y: T2, Z: T3) {.closure.})
+                                                          {.since: (1, 1).} =
+  ## Apply `op` proc on each triple of elements from the three input containers.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+    zippedScan(s1, s2, s3, proc (x, y, z: int) = echo x + y == z)
+
+  let m = min(min(s1.len, s2.len), s3.len)
+  for i in 0 ..< m:
+    op(s1[i], s2[i], s3[i])
+
+proc partition*[T](s: seq[T], len: Positive): seq[seq[T]] {.since: (1, 1).} =
+  ## Splits a sequence `s` into sub-sequences of length `len`.
+  ##
+  ## Number of sequences in result is `s.len div len`. If length of `s`
+  ## is not a multiple of `len`, the last `s.len mod len` items are
+  ## discarded.
+  ##
+  runnableExamples:
+    let numbers = @[1, 2, 3, 4, 5, 6, 7]
+    assert numbers.partition(3) == @[@[1, 2, 3], @[4, 5, 6]]
+
+  let num = s.len div len
+
+  result = newSeq[seq[T]](num)
+  var first = 0
+
+  for i in 0 ..< num:
+    result[i] = newSeq[T](len)
+    for g in first ..< first + len:
+      result[i][g - first] = s[g]
+    first += len
 
 proc distribute*[T](s: seq[T], num: Positive, spread = true): seq[seq[T]] =
   ## Splits and distributes a sequence `s` into `num` sub-sequences.
@@ -461,6 +565,94 @@ proc map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
   for i in 0 ..< s.len:
     result[i] = op(s[i])
 
+proc mapIndexed*[T, S](s: openArray[T], op:
+                       proc (i: int, x: T): S {.closure.}): seq[S]{.inline.} =
+  ## Returns a new sequence with the results of `op` proc applied to every
+  ## item together with its index in the container `s`.
+  ##
+  ## Since the input is not modified you can use it to
+  ## transform the type of the elements in the input container.
+  ##
+  ## See also:
+  ## * `mapIt template<#mapIt.t,typed,untyped>`_
+  ## * `apply proc<#apply,openArray[T],proc(T)_2>`_ for the in-place version
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+      b = mapIndexed(a, proc(i: int, x: int): int = x - i)
+    assert b == @[1, 1, 1, 1]
+
+  newSeq(result, s.len)
+  for i, v in s:
+    result[i] = op(i, s[i])
+
+proc scan*[T](s: openArray[T], op: proc (x: T) {.closure.})
+                                                {.since: (1, 1).} =
+  ## Apply `op` proc to every item in the container `s`.
+  ##
+  ## See also:
+  ## * `scanIt template<#scanIt.t,typed,untyped>`_
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+    scan(a, proc(x: int) = echo x)
+
+  for i in low(s) .. high(s):
+    op(s[i])
+
+proc scan*[T, S](s: openArray[T], op: proc (x: T): S {.closure.})
+                                                {.since: (1, 1).} =
+  ## Apply `op` proc to every item in the container `s`. Results
+  ## of `op` proc are discarded.
+  ##
+  ## See also:
+  ## * `scanIt template<#scanIt.t,typed,untyped>`_
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+    scan(a, proc(x: int): string =
+      echo x
+      return $x)
+
+  for i in low(s) .. high(s):
+    discard op(s[i])
+
+proc scanIndexed*[T](s: openArray[T],
+                     op: proc (i: int, x: T) {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc to every item in the container `s`.
+  ##
+  ## See also:
+  ## * `scanIt template<#scanIt.t,typed,untyped>`_
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+    scan(a, proc(x: int) = echo x)
+
+  for i, v in s:
+    op(i, v)
+
+proc scanIndexed*[T, S](s: openArray[T],
+                        op: proc (i: int, x: T): S {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc to every item in the container `s`. Results
+  ## of `op` proc are discarded.
+  ##
+  ## See also:
+  ## * `scanIt template<#scanIt.t,typed,untyped>`_
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+    scan(a, proc(x: int): string =
+      echo x
+      return $x)
+
+  for i, v in s:
+    discard op(i, v)
+
 proc apply*[T](s: var openArray[T], op: proc (x: var T) {.closure.})
                                                               {.inline.} =
   ## Applies `op` to every item in `s` modifying it directly.
@@ -506,7 +698,7 @@ iterator filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): T =
   ## predicate `pred` (function that returns a `bool`).
   ##
   ## See also:
-  ## * `fliter proc<#filter,openArray[T],proc(T)>`_
+  ## * `filter proc<#filter,openArray[T],proc(T)>`_
   ## * `filterIt template<#filterIt.t,untyped,untyped>`_
   ##
   runnableExamples:
@@ -544,9 +736,9 @@ proc filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
       result.add(s[i])
 
 proc findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.},
-                                    def: T): T {.since: (1, 1).} =
-  ## Search for the first element in `s` that fulfilled the
-  ## predicate `pred` (function that returns a `bool`). If such element
+                                          def: T): T {.since: (1, 1).} =
+  ## Find the first element in `s` that fulfilled the predicate
+  ## `pred` (function that returns a `bool`). If such element
   ## is not found is `s`, `def` is returned.
   ##
   runnableExamples:
@@ -555,20 +747,50 @@ proc findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.},
       x = findFirst(l, proc(x: int): bool = x mod 2 == 1, -1)
     assert x == 7
 
-  for i in 0 ..< s.len:
+  for i in low(s) .. high(s):
     if pred(s[i]):
       return s[i]
   return def
 
-since (1,1):
-  when defined(nimHasDefault):
-    func findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): T
-                                                                  {.inline.}  =
-      ## Search for the first element in `s` that fulfilled the
-      ## predicate `pred` (function that returns a `bool`). If such element
-      ## is not found is `s`, `default(T)` is returned.
-      ##
-      return findFirst(s, pred, default(T))
+proc findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): T
+                                                       {.since: (1, 1).}  =
+  ## Find the first element in `s` that fulfilled the predicate
+  ## `pred` (function that returns a `bool`). If such element
+  ## is not found is `s`, `default(T)` is returned.
+  ##
+  return findFirst(s, pred, default(T))
+
+proc indexOf*[T](s: openArray[T], v: T): int {.since: (1, 1).} =
+  ## Get the index of the first element in `s` that equals to `v`.
+  ## If such element is not found is `s`, `low(s) - 1` is returned.
+  ##
+  runnableExamples:
+    let
+      l = @[2, 4, 6, 7, 9]
+      x = indexOf(l, 7)
+    assert x == 3
+
+  for i in low(s) .. high(s):
+    if s[i] == v:
+      return i
+  return low(s) - 1
+
+proc indexOf*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): int
+                                                        {.since: (1, 1).} =
+  ## Get the index of the first element in `s` that fulfilled the predicate
+  ## `pred` (function that returns a `bool`). If such element
+  ## is not found is `s`, `low(s) - 1` is returned.
+  ##
+  runnableExamples:
+    let
+      l = @[2, 4, 6, 7, 9]
+      x = indexOf(l, proc(x: int): bool = x mod 2 == 1)
+    assert x == 3
+
+  for i in low(s) .. high(s):
+    if pred(s[i]):
+      return i
+  return low(s) - 1
 
 proc keepIf*[T](s: var seq[T], pred: proc(x: T): bool {.closure.})
                                                                 {.inline.} =
@@ -656,7 +878,6 @@ proc insert*[T](dest: var seq[T], src: openArray[T], pos = 0) =
   for item in src:
     dest[j] = item
     inc(j)
-
 
 template filterIt*(s, pred: untyped): untyped =
   ## Returns a new sequence with all the items of `s` that fulfilled the
@@ -1057,7 +1278,6 @@ template applyIt*(varSeq, op: untyped) =
     let it {.inject.} = varSeq[i]
     varSeq[i] = op
 
-
 template newSeqWith*(len: int, init: untyped): untyped =
   ## Creates a new sequence of length `len`, calling `init` to initialize
   ## each value of the sequence.
@@ -1080,6 +1300,266 @@ template newSeqWith*(len: int, init: untyped): untyped =
   for i in 0 ..< len:
     result[i] = init
   result
+
+since (1, 1):
+  template countIt*(s: typed, op: untyped): int =
+    ## Returns the number of items in the container `s` that the results of `op`
+    ## applied to are `true`.
+    ##
+    ## The template injects the ``it`` variable which you can use directly in an
+    ## expression.
+    ##
+    runnableExamples:
+      assert countIt("abracadabra", it in {'a', 'r'}) == 7
+
+    block:
+      var result: int = 0
+      for it {.inject.} in s:
+        if op:
+          inc result
+      result
+
+  template lengthWhileIt*(s: typed, op: untyped): int =
+    ## Returns the number of items in the container `s` that keep fulfilling
+    ## `op` (an expression resulting in a `bool`) from the beginning.
+    ##
+    ## The template injects the ``it`` variable which you can use directly in an
+    ## expression.
+    ##
+    runnableExamples:
+      assert lengthWhileIt(@[1, 2, 3, 4, 5], it < 4) == 3
+
+    block:
+      var result = 0
+      for it {.inject.} in s:
+        if op: inc result
+        else: break
+      result
+
+  template takeItWhile*(s: typed, op: untyped): untyped =
+    ## Returns a sequence of items in the container `s` that keep fulfilling
+    ## `op` (an expression resulting in a `bool`) from the beginning.
+    ##
+    ## The template injects the ``it`` variable which you can use directly in an
+    ## expression.
+    ##
+    block:
+      evalOnceAs(s1, s, compiles((let _ = s)))
+      s1[low(s1) ..< low(s1) + lengthWhileIt(s1, op)]
+
+  template dropItWhile*(s: typed, op: untyped): untyped =
+    ## Returns a sequence of items in the container `s` without items that
+    ## keep fulfilling `op` (an expression resulting in a `bool`) from the beginning,
+    ## i.e. those items are dropped.
+    ##
+    ## The template injects the ``it`` variable which you can use directly in an
+    ## expression.
+    ##
+    block:
+      evalOnceAs(s1, s, compiles((let _ = s)))
+      s1[low(s1) + lengthWhileIt(s1, op) ..< s1.len]
+
+  template nestIt*(op: untyped, x: typed, n: Natural): untyped =
+    ## Returns a new sequence of the results of evaluating `op` on previous value for `n`
+    ## times. The 0th item of the result is `x`.
+    ## `n` must be a non-negative number (zero or more).
+    ##
+    ## The template injects the ``it`` variable representing the previous value which
+    ## you can use directly in an expression.
+    ##
+    block:
+      var result = newSeq[typeof(x)](n + 1)
+      result[0] = x
+      for i in 1 .. n:
+        let it {.inject.} = result[i - 1]
+        result[i] = op
+      result
+
+  template findItFirst*(s: typed, op: untyped, def: typed): untyped =
+    ## Find the first element in `s` on which `op` evaluated to `true`. If such
+    ## element is not found is `s`, `def` is returned.
+    ##
+    ## The template injects the ``it`` variable representing the previous value which
+    ## you can use directly in an expression.
+    ##
+    block:
+      var result: typeof(def) = def
+      for it {.inject.} in s:
+        if op:
+          result = it
+          break
+      result
+
+  template findItFirst*(s: typed, op: untyped): untyped =
+    ## Find the first element in `s` on which `op` evaluated to `true`. If such
+    ## element is not found is `s`, `default(T)` is returned, where `T` is the
+    ## type of items in `s`.
+    ##
+    ## The template injects the ``it`` variable representing the previous value which
+    ## you can use directly in an expression.
+    ##
+    findItFirst(s, op, default(typeof(items(s), typeOfIter)))
+
+  template indexOfIt*(s: typed, op: untyped): int =
+    ## ## Get the index of the first element in `s` that fulfilled the predicate
+    ## `op` (a `bool` expression). If such element is not found is `s`,
+    ##  `low(s) - 1` is returned.
+    ##
+    ## The template injects the ``it`` variable representing the previous value which
+    ## you can use directly in an expression.
+    ##
+    block:
+      evalOnceAs(s1, s, compiles((let _ = s)))
+      var result = low(s1) - 1
+      for i in low(s1) .. high(s1):
+        let it {.inject.} = s1[i]
+        if op:
+          result = i
+          break
+      result
+
+  template scanIt*(s: typed, op: untyped) =
+    ## Evaluate `op` on every item in the container `s`.
+    ##
+    ## The template injects the ``it`` variable representing the previous value which
+    ## you can use directly in an expression.
+    ##
+    runnableExamples:
+      @[1, 2, 3, 4].scanIt(echo it)
+
+    for it {.inject.} in s:
+      op
+
+  template zipThem*(s1, s2: typed; op: untyped): untyped =
+    ## Returns a new sequence with a transformation (`op`) on each pair of
+    ## elements from the two input containers.
+    ##
+    ## The template injects the ``it`` and ``jt`` variables representing the
+    ## previous values from ``s1`` and ``s2`` respectively which you can use
+    ## directly in an expression.
+    ##
+    ## The input containers can be of different types.
+    ## If one container is shorter, the remaining items in the longer container
+    ## are discarded.
+    ##
+    runnableExamples:
+      let
+        s1 = @[1, 2, 3]
+        s2 = @["I", "II", "III", "IV"]
+      assert zipThem(s1, s2, $it & ":" & jt) == @["1:I", "2:II", "3:III"]
+
+    block:
+      evalOnceAs(ss1, s1, compiles((let _ = s1)))
+      evalOnceAs(ss2, s2, compiles((let _ = s2)))
+      var
+        it {.inject.}: typeof(items(ss1), typeOfIter)
+        jt {.inject.}: typeof(items(ss2), typeOfIter)
+      type
+        OutType = typeof(op, typeOfProc)
+
+      let m = min(ss1.len, ss2.len)
+      var result = newSeq[OutType](m)
+      for i in 0 ..< m:
+        it = ss1[i]
+        jt = ss2[i]
+        result[i] = op
+      result
+
+  template zipThem*(s1, s2: typed, s3: untyped, op: untyped): untyped =
+    ## Returns a new sequence with a transformation (`op`) on each pair of
+    ## elements from the two input containers.
+    ##
+    ## The template injects the ``it``, ``jt`` and ``kt`` variables representing
+    ## the previous values from ``s1``, ``s2`` and ``s3`` respectively which you
+    ## can use directly in an expression.
+    ##
+    ## The input containers can be of different types.
+    ## If one container is shorter, the remaining items in the longer container
+    ## are discarded.
+    ##
+    runnableExamples:
+      let
+        s1 = @[1, 2, 3]
+        s2 = @[4, 5, 6]
+        s3 = @[5, 7, 9, 9]
+      doAssert zipThem(s1, s2, s3, it + jt == kt) ==  @[true, true, true]
+
+    block:
+      evalOnceAs(ss1, s1, compiles((let _ = s1)))
+      evalOnceAs(ss2, s2, compiles((let _ = s2)))
+      evalOnceAs(ss3, s3, compiles((let _ = s3)))
+      var
+        it {.inject.}: typeof(items(ss1), typeOfIter)
+        jt {.inject.}: typeof(items(ss2), typeOfIter)
+        kt {.inject.}: typeof(items(ss3), typeofIter)
+      type
+        OutType = typeof(op, typeOfProc)
+
+      let m = min(min(ss1.len, ss2.len), ss3.len)
+      var result = newSeq[OutType](m)
+      for i in 0 ..< m:
+        it = ss1[i]
+        jt = ss2[i]
+        kt = ss3[i]
+        result[i] = op
+      result
+
+  template scanThem*(s1, s2: typed, op: untyped) =
+    ## Apply `op` on each pair of elements from the two input containers.
+    ##
+    ## The template injects the ``it`` and ``jt`` variables representing the
+    ## previous values from ``s1`` and ``s2`` respectively which you can use
+    ## directly in an expression.
+    ##
+    ## The input containers can be of different types.
+    ## If one container is shorter, the remaining items in the longer container
+    ## are discarded.
+    ##
+    runnableExamples:
+      let
+        s1 = @[1, 2, 3]
+        s2 = @[4, 5, 6]
+      scanThem(s1, s2, echo it + jt)
+
+    block:
+      evalOnceAs(ss1, s1, compiles((let _ = s1)))
+      evalOnceAs(ss2, s2, compiles((let _ = s2)))
+
+      let m = min(ss1.len, ss2.len)
+      for i in 0 ..< m:
+        let it {.inject.} = ss1[i]
+        let jt {.inject.} = ss2[i]
+        op
+
+  template scanThem*(s1, s2: typed; s3: untyped; op: untyped) =
+    ## Apply `op` on each triple of elements from the three input containers.
+    ##
+    ## The template injects the ``it``, ``jt`` and ``kt`` variables representing
+    ## the previous values from ``s1``, ``s2`` and ``s3`` respectively which you
+    ## can use directly in an expression.
+    ##
+    ## The input containers can be of different types.
+    ## If one container is shorter, the remaining items in the longer container
+    ## are discarded.
+    ##
+    runnableExamples:
+      let
+        s1 = @[1, 2, 3]
+        s2 = @[4, 5, 6]
+        s3 = @[5, 7, 9, 9]
+      scanThem(s1, s2, s3, echo it + jt == kt)
+
+    block:
+      evalOnceAs(ss1, s1, compiles((let _ = s1)))
+      evalOnceAs(ss2, s2, compiles((let _ = s2)))
+      evalOnceAs(ss3, s3, compiles((let _ = s3)))
+
+      let m = min(min(ss1.len, ss2.len), ss3.len)
+      for i in 0 ..< m:
+        let it {.inject.} = ss1[i]
+        let jt {.inject.} = ss2[i]
+        let kt {.inject.} = ss3[i]
+        op
 
 proc mapLitsImpl(constructor: NimNode; op: NimNode; nested: bool;
                  filter = nnkLiterals): NimNode =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -26,37 +26,36 @@
 ## procs, iterators and templates inspired by functional programming
 ## languages, such as:
 ## * Applying operations to a single container
-##   * `map<#map,openArray[T],proc(T)>`_ · `apply<#apply,openArray[T],proc(T)>`_ ·
+##   * `apply<#apply,openArray[T],proc(T)>`_ · `map<#map,openArray[T],proc(T)>`_ ·
 ##     `mapIndexed<#mapIndexed,openArray[T],proc(int,T)>`_ ·
 ##     `scan<#scan,openArray[T],proc(T)>`_ · `scanIndexed<#scanIndexed,openArray[T],proc(int,T)>`_
-##   * `mapIt<#mapIt.t,typed,untyped>`_ · `applyIt<#applyIt.t,untyped,untyped>`_ ·
-##     `scanIt<#scanIt.t,typed,untyped>`_ ·  `mapLiterals<#mapLiterals.m,untyped,untyped>`_
+##   * `applyIt<#applyIt.t,untyped,untyped>`_ · `mapIt<#mapIt.t,typed,untyped>`_ ·
+##     `mapLiterals<#mapLiterals.m,untyped,untyped>`_ · `scanIt<#scanIt.t,typed,untyped>`_
 ## * Applying operations to two or three containers
-##   * `zipWith<#zipWith,openArray[T1],openArray[T2],proc(T1,T2)>`_ ·
-##     `zippedScan<#zippedScan,openArray[T1],openArray[T2],proc(T1,T2)>`_
-##   * `zipThem<#zipThem.t,typed,typed,untyped>`_ · `scanThem<#scanThem.t,typed,typed,untyped>`_
+##   * `zippedScan<#zippedScan,openArray[T1],openArray[T2],proc(T1,T2)>`_ ·
+##     `zipWith<#zipWith,openArray[T1],openArray[T2],proc(T1,T2)>`_
+##   * `scanThem<#scanThem.t,typed,typed,untyped>`_ · `zipThem<#zipThem.t,typed,typed,untyped>`_
 ## * Iteratively applying operations
-##   * `nest<#nest,proc(T),T,Natural>`_
-##   * `foldl<#foldl.t,,,>`_ · `foldr<#foldr.t,untyped,untyped>`_ · `nestIt<#nestIt.t,untyped,typed,Natural>`_
+##   * `foldl<#foldl.t,,,>`_ · `foldr<#foldr.t,untyped,untyped>`_
 ## * Creating containers
-##   * `circle<#cycle,openArray[T],Natural>`_ · `repeat<#repeat,T,Natural>`_ ·
-##     `deduplicate<#deduplicate,openArray[T],bool>`_ · `zip<#zip,,>`_ ·
-##     `concat<#concat,varargs[seq[T][T]]>`_ · `distribute<#distribute,seq[T][T],Positive>`_ ·
-##     `partition<#partition,seq[T][T],Positive>`_ · `insert<#insert,seq[T][T],openArray[T],int>`_
-##   * `items<#items.i>`_ · `newSeqWith<#newSeqWith.t,int,untyped>`_
+##   * `circle<#cycle,openArray[T],Natural>`_ · `concat<#concat,varargs[seq[T][T]]>`_ ·
+##     `deduplicate<#deduplicate,openArray[T],bool>`_ · `distribute<#distribute,seq[T][T],Positive>`_ ·
+##     `insert<#insert,seq[T][T],openArray[T],int>`_ · `nest<#nest,proc(T),T,Natural>`_ ·
+##     `partition<#partition,seq[T][T],Positive>`_ · `repeat<#repeat,T,Natural>`_ · `zip<#zip,,>`_
+##   * `items<#items.i>`_ · `nestIt<#nestIt.t,untyped,typed,Natural>`_ · `newSeqWith<#newSeqWith.t,int,untyped>`_
 ## * Inspecting a container
-##   * `count<#count,openArray[T],proc(T)>`_ · `all<#all,openArray[T],proc(T)>`_ ·
-##     `any<#any,openArray[T],proc(T)>`_ · `lenWhile<#lenWhile,openArray[T],proc(T)>`_ ·
-##     `indexOf<#indexOf,openArray[T],proc(T)>`_ · `findFirst<#findFirst,openArray[T],proc(T),T>`_
-##   * `countIt<#countIt.t,typed,untyped>`_ ·  `allIt<#allIt.t,untyped,untyped>`_ ·
-##     `anyIt<#anyIt.t,untyped,untyped>`_ · `lenWhileIt<#lenWhileIt.t,typed,untyped>`_ ·
-##     `indexOfIt<#indexOfIt.t,typed,untyped>`_ · `findItFirst<#findItFirst.t,typed,untyped>`_
+##   * `all<#all,openArray[T],proc(T)>`_ · `any<#any,openArray[T],proc(T)>`_ ·
+##     `count<#count,openArray[T],proc(T)>`_ · `findFirst<#findFirst,openArray[T],proc(T),T>`_ ·
+##     `indexOf<#indexOf,openArray[T],proc(T)>`_ · `lenWhile<#lenWhile,openArray[T],proc(T)>`_
+##   * `allIt<#allIt.t,untyped,untyped>`_ · `anyIt<#anyIt.t,untyped,untyped>`_ ·
+##     `countIt<#countIt.t,typed,untyped>`_ · `findItFirst<#findItFirst.t,typed,untyped>`_ ·
+##     `indexOfIt<#indexOfIt.t,typed,untyped>`_ · `lenWhileIt<#lenWhileIt.t,typed,untyped>`_
 ## * Selecting items
-##   * `filter<#filter,openArray[T],proc(T)>`_ · `delete<#delete,seq[T][T],Natural,Natural>`_  ·
-##     `takeWhile<#takeWhile,openArray[T],proc(T)>`_ · `dropWhile<#dropWhile,openArray[T],proc(T)>`_ ·
-##     `keepIf<#keepIf,seq[T][T],proc(T)>`_
-##   * `takeItWhile<#takeItWhile.t,typed,untyped>`_ · `dropItWhile<#dropItWhile.t,typed,untyped>`_ ·
-##     `keepItIf<#keepItIf.t,seq[T],untyped>`_ · `filterIt<#filterIt.t,untyped,untyped>`_
+##   * `delete<#delete,seq[T][T],Natural,Natural>`_ · `dropWhile<#dropWhile,openArray[T],proc(T)>`_ ·
+##     `filter<#filter,openArray[T],proc(T)>`_ · `keepIf<#keepIf,seq[T][T],proc(T)>`_ ·
+##     `takeWhile<#takeWhile,openArray[T],proc(T)>`_
+##   * `dropItWhile<#dropItWhile.t,typed,untyped>`_ · `filterIt<#filterIt.t,untyped,untyped>`_ ·
+##     `keepItIf<#keepItIf.t,seq[T],untyped>`_ · `takeItWhile<#takeItWhile.t,typed,untyped>`_
 ##
 ## For functional style programming you have different options at your disposal:
 ## * pass `anonymous proc<manual.html#procedures-anonymous-procs>`_
@@ -175,66 +174,6 @@ proc count*[T](s: openArray[T], x: T): int =
     if itm == x:
       inc result
 
-proc count*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
-                                                         {.since: (1, 1).} =
-  ## Returns the number of items in the container `s` that fulfills
-  ## the predicate `pred` (function that returns a `bool`).
-  ##
-  runnableExamples:
-    assert count("abracadabra", func (c: char): bool = c in {'a', 'r'}) == 7
-
-  for itm in items(s):
-    if pred(itm):
-      inc result
-
-proc lenWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
-                                                            {.since: (1, 1).} =
-  ## Returns the number of items in the container `s` that keep fulfilling
-  ## the predicate `pred` (function that returns a `bool`) from the beginning.
-  ##
-  runnableExamples:
-    assert lenWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
-
-  for itm in items(s):
-    if pred(itm):
-      inc result
-    else:
-      break
-
-proc takeWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
-                                                            {.since: (1, 1).} =
-  ## Returns a sequence of items in the container `s` that keep fulfilling
-  ## the predicate `pred` (function that returns a `bool`) from the beginning.
-  ##
-  runnableExamples:
-    assert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[1, 2, 3]
-
-  s[0 ..< lenWhile(s, pred)]
-
-proc dropWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
-                                                            {.since: (1, 1).} =
-  ## Returns a sequence of items in the container `s` without items that
-  ## keep fulfilling the predicate `pred` (function that returns a `bool`)
-  ## from the beginning, i.e. those items are dropped.
-  ##
-  runnableExamples:
-    assert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[4, 5]
-
-  s[lenWhile(s, pred) ..< s.len]
-
-proc nest*[T](f: proc(x: T): T, x: T, n: Natural): seq[T] {.since: (1, 1).} =
-  ## Returns a new sequence of the results of applying `f` to `x` 0 .. `n`
-  ## times, i.e. `@[x, f(x), f(f(x)), ...]`.
-  ## `n` must be a non-negative number (zero or more).
-  ##
-  runnableExamples:
-    assert nest(func (x: int): int = x * 2, 1, 4) == @[1, 2, 4, 8, 16]
-
-  result = newSeq[T](n + 1)
-  result[0] = x
-  for i in 1 .. n:
-    result[i] = f(result[i - 1])
-
 proc cycle*[T](s: openArray[T], n: Natural): seq[T] =
   ## Returns a new sequence with the items of the container `s` repeated
   ## `n` times.
@@ -338,132 +277,6 @@ when (NimMajor, NimMinor) <= (1, 0):
 else:
   zipImpl(s1, s2, seq[(S, T)])
 
-proc zipWith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
-            op: proc (x: T1, y: T2): R {.closure.}): seq[R]
-                                                          {.since: (1, 1).} =
-  ## Returns a new sequence with a transformation on each pair of elements
-  ## from the two input containers.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6, 7]
-      zip1 = zipWith(s1, s2, func (x, y: int): int = x * y)
-    assert zip1 == @[4, 10, 18]
-
-  let m = min(s1.len, s2.len)
-  newSeq(result, m)
-  for i in 0 ..< m:
-    result[i] = op(s1[i], s2[i])
-
-proc zipWith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
-                             s3: openArray[T3],
-                             op: proc (x: T1, y: T2, Z: T3): R {.closure.}):
-                                                   seq[R] {.since: (1, 1).} =
-  ## Returns a new sequence with a transformation on each triple of elements
-  ## from three input containers.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6]
-      s3 = @[5, 7, 9, 9]
-      zip1 = zipWith(s1, s2, s3, func (x, y, z: int): bool = x + y == z)
-    assert zip1 == @[true, true, true]
-
-  let m = min(min(s1.len, s2.len), s3.len)
-  newSeq(result, m)
-  for i in 0 ..< m:
-    result[i] = op(s1[i], s2[i], s3[i])
-
-proc zippedScan*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
-            op: proc (x: T1, y: T2): R {.closure.}) {.since: (1, 1).} =
-  ## Apply `op` proc on each pair of elements from the two input containers,
-  ## discarding results.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6, 7]
-    zippedScan(s1, s2, proc (x, y: int): int = x * y)
-
-  let m = min(s1.len, s2.len)
-  for i in 0 ..< m:
-    discard op(s1[i], s2[i])
-
-proc zippedScan*[T1, T2](s1: openArray[T1], s2: openArray[T2],
-            op: proc (x: T1, y: T2) {.closure.}) {.since: (1, 1).} =
-  ## Apply `op` proc on each pair of elements from the two input containers.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6, 7]
-    zippedScan(s1, s2, proc (x, y: int) = echo x * y)
-
-  let m = min(s1.len, s2.len)
-  for i in 0 ..< m:
-    op(s1[i], s2[i])
-
-proc zippedScan*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
-                             s3: openArray[T3],
-                             op: proc (x: T1, y: T2, Z: T3): R {.closure.})
-                                                          {.since: (1, 1).} =
-  ## Apply `op` proc on each triple of elements from the three input containers,
-  ## discarding results.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6]
-      s3 = @[5, 7, 9, 9]
-    zippedScan(s1, s2, s3, proc (x, y, z: int): bool = x + y == z)
-
-  let m = min(min(s1.len, s2.len), s3.len)
-  for i in 0 ..< m:
-    discard op(s1[i], s2[i], s3[i])
-
-proc zippedScan*[T1, T2, T3](s1: openArray[T1], s2: openArray[T2],
-                             s3: openArray[T3],
-                             op: proc (x: T1, y: T2, Z: T3) {.closure.})
-                                                          {.since: (1, 1).} =
-  ## Apply `op` proc on each triple of elements from the three input containers.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6]
-      s3 = @[5, 7, 9, 9]
-    zippedScan(s1, s2, s3, proc (x, y, z: int) = echo x + y == z)
-
-  let m = min(min(s1.len, s2.len), s3.len)
-  for i in 0 ..< m:
-    op(s1[i], s2[i], s3[i])
-
 proc partition*[T](s: seq[T], len: Positive): seq[seq[T]] {.since: (1, 1).} =
   ## Splits a sequence `s` into sub-sequences of length `len`.
   ##
@@ -565,8 +378,8 @@ proc map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
   for i in 0 ..< s.len:
     result[i] = op(s[i])
 
-proc mapIndexed*[T, S](s: openArray[T], op:
-                       proc (i: int, x: T): S {.closure.}): seq[S]{.inline.} =
+proc mapIndexed*[T, S](s: openArray[T],
+                       op: proc (i: int, x: T): S {.closure.}): seq[S]{.inline.} =
   ## Returns a new sequence with the results of `op` proc applied to every
   ## item together with its index in the container `s`.
   ##
@@ -586,39 +399,6 @@ proc mapIndexed*[T, S](s: openArray[T], op:
   newSeq(result, s.len)
   for i, v in s:
     result[i] = op(i, s[i])
-
-proc scan*[T](s: openArray[T], op: proc (x: T) {.closure.})
-                                                {.since: (1, 1).} =
-  ## Apply `op` proc to every item in the container `s`.
-  ##
-  ## See also:
-  ## * `scanIt template<#scanIt.t,typed,untyped>`_
-  ##
-  runnableExamples:
-    let
-      a = @[1, 2, 3, 4]
-    scan(a, proc(x: int) = echo x)
-
-  for i in low(s) .. high(s):
-    op(s[i])
-
-proc scan*[T, S](s: openArray[T], op: proc (x: T): S {.closure.})
-                                                {.since: (1, 1).} =
-  ## Apply `op` proc to every item in the container `s`. Results
-  ## of `op` proc are discarded.
-  ##
-  ## See also:
-  ## * `scanIt template<#scanIt.t,typed,untyped>`_
-  ##
-  runnableExamples:
-    let
-      a = @[1, 2, 3, 4]
-    scan(a, proc(x: int): string =
-      echo x
-      return $x)
-
-  for i in low(s) .. high(s):
-    discard op(s[i])
 
 proc scanIndexed*[T](s: openArray[T],
                      op: proc (i: int, x: T) {.closure.}) {.since: (1, 1).} =
@@ -734,63 +514,6 @@ proc filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
   for i in 0 ..< s.len:
     if pred(s[i]):
       result.add(s[i])
-
-proc findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.},
-                                          def: T): T {.since: (1, 1).} =
-  ## Find the first element in `s` that fulfilled the predicate
-  ## `pred` (function that returns a `bool`). If such element
-  ## is not found is `s`, `def` is returned.
-  ##
-  runnableExamples:
-    let
-      l = @[2, 4, 6, 7, 9]
-      x = findFirst(l, proc(x: int): bool = x mod 2 == 1, -1)
-    assert x == 7
-
-  for i in low(s) .. high(s):
-    if pred(s[i]):
-      return s[i]
-  return def
-
-proc findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): T
-                                                       {.since: (1, 1).}  =
-  ## Find the first element in `s` that fulfilled the predicate
-  ## `pred` (function that returns a `bool`). If such element
-  ## is not found is `s`, `default(T)` is returned.
-  ##
-  return findFirst(s, pred, default(T))
-
-proc indexOf*[T](s: openArray[T], v: T): int {.since: (1, 1).} =
-  ## Get the index of the first element in `s` that equals to `v`.
-  ## If such element is not found is `s`, `low(s) - 1` is returned.
-  ##
-  runnableExamples:
-    let
-      l = @[2, 4, 6, 7, 9]
-      x = indexOf(l, 7)
-    assert x == 3
-
-  for i in low(s) .. high(s):
-    if s[i] == v:
-      return i
-  return low(s) - 1
-
-proc indexOf*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): int
-                                                        {.since: (1, 1).} =
-  ## Get the index of the first element in `s` that fulfilled the predicate
-  ## `pred` (function that returns a `bool`). If such element
-  ## is not found is `s`, `low(s) - 1` is returned.
-  ##
-  runnableExamples:
-    let
-      l = @[2, 4, 6, 7, 9]
-      x = indexOf(l, proc(x: int): bool = x mod 2 == 1)
-    assert x == 3
-
-  for i in low(s) .. high(s):
-    if pred(s[i]):
-      return i
-  return low(s) - 1
 
 proc keepIf*[T](s: var seq[T], pred: proc(x: T): bool {.closure.})
                                                                 {.inline.} =
@@ -1564,6 +1287,236 @@ since (1, 1):
         let jt {.inject.} = ss2[i]
         let kt {.inject.} = ss3[i]
         op
+
+proc count*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int {.since: (1, 1).} =
+  ## Returns the number of items in the container `s` that fulfills
+  ## the predicate `pred` (function that returns a `bool`).
+  ##
+  runnableExamples:
+    assert count("abracadabra", func (c: char): bool = c in {'a', 'r'}) == 7
+
+  countIt(s, pred(it))
+
+proc lenWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int {.since: (1, 1).} =
+  ## Returns the number of items in the container `s` that keep fulfilling
+  ## the predicate `pred` (function that returns a `bool`) from the beginning.
+  ##
+  runnableExamples:
+    assert lenWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
+
+  lenWhileIt(s, pred(it))
+
+proc takeWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T] {.since: (1, 1).} =
+  ## Returns a sequence of items in the container `s` that keep fulfilling
+  ## the predicate `pred` (function that returns a `bool`) from the beginning.
+  ##
+  runnableExamples:
+    assert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[1, 2, 3]
+
+  s[0 ..< lenWhile(s, pred)]
+
+proc dropWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T] {.since: (1, 1).} =
+  ## Returns a sequence of items in the container `s` without items that
+  ## keep fulfilling the predicate `pred` (function that returns a `bool`)
+  ## from the beginning, i.e. those items are dropped.
+  ##
+  runnableExamples:
+    assert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[4, 5]
+
+  s[lenWhile(s, pred) ..< s.len]
+
+proc nest*[T](f: proc(x: T): T, x: T, n: Natural): seq[T] {.since: (1, 1).} =
+  ## Returns a new sequence of the results of applying `f` to `x` 0 .. `n`
+  ## times, i.e. `@[x, f(x), f(f(x)), ...]`.
+  ## `n` must be a non-negative number (zero or more).
+  ##
+  runnableExamples:
+    assert nest(func (x: int): int = x * 2, 1, 4) == @[1, 2, 4, 8, 16]
+
+  nestIt(f(it), x, n)
+
+proc zipWith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
+                         op: proc (x: T1, y: T2): R {.closure.}): seq[R] {.since: (1, 1).} =
+  ## Returns a new sequence with a transformation on each pair of elements
+  ## from the two input containers.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6, 7]
+      zip1 = zipWith(s1, s2, func (x, y: int): int = x * y)
+    assert zip1 == @[4, 10, 18]
+
+  zipThem(s1, s2, op(it, jt))
+
+proc zipWith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
+                             s3: openArray[T3],
+                             op: proc (x: T1, y: T2, Z: T3): R {.closure.}): seq[R] {.since: (1, 1).} =
+  ## Returns a new sequence with a transformation on each triple of elements
+  ## from three input containers.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+      zip1 = zipWith(s1, s2, s3, func (x, y, z: int): bool = x + y == z)
+    assert zip1 == @[true, true, true]
+
+  zipThem(s1, s2, s3, op(it, jt, kt))
+
+proc zippedScan*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
+                            op: proc (x: T1, y: T2): R {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc on each pair of elements from the two input containers,
+  ## discarding results.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6, 7]
+    zippedScan(s1, s2, proc (x, y: int): int = x * y)
+
+  scanThem(s1, s2, (discard op(it, jt)))
+
+proc zippedScan*[T1, T2](s1: openArray[T1], s2: openArray[T2],
+                         op: proc (x: T1, y: T2) {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc on each pair of elements from the two input containers.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6, 7]
+    zippedScan(s1, s2, proc (x, y: int) = echo x * y)
+
+  scanThem(s1, s2, op(it, jt))
+
+proc zippedScan*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
+                             s3: openArray[T3],
+                             op: proc (x: T1, y: T2, Z: T3): R {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc on each triple of elements from the three input containers,
+  ## discarding results.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+    zippedScan(s1, s2, s3, proc (x, y, z: int): bool = x + y == z)
+
+  scanThem(s1, s2, s3, (discard op(it, jt, kt)))
+
+proc zippedScan*[T1, T2, T3](s1: openArray[T1], s2: openArray[T2],
+                             s3: openArray[T3],
+                             op: proc (x: T1, y: T2, Z: T3) {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc on each triple of elements from the three input containers.
+  ##
+  ## The input containers can be of different types.
+  ## If one container is shorter, the remaining items in the longer container
+  ## are discarded.
+  ##
+  runnableExamples:
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+    zippedScan(s1, s2, s3, proc (x, y, z: int) = echo x + y == z)
+
+  scanThem(s1, s2, s3, op(it, jt, kt))
+
+proc scan*[T](s: openArray[T], op: proc (x: T) {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc to every item in the container `s`.
+  ##
+  ## See also:
+  ## * `scanIt template<#scanIt.t,typed,untyped>`_
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+    scan(a, proc(x: int) = echo x)
+
+  scanIt(s, op(it))
+
+proc scan*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}) {.since: (1, 1).} =
+  ## Apply `op` proc to every item in the container `s`. Results
+  ## of `op` proc are discarded.
+  ##
+  ## See also:
+  ## * `scanIt template<#scanIt.t,typed,untyped>`_
+  ##
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+    scan(a, proc(x: int): string =
+      echo x
+      return $x)
+
+  scanIt(s, (discard op(it)))
+
+proc findFirst*[T](s: openArray[T],
+                   pred: proc (x: T): bool {.closure.}, def: T): T {.since: (1, 1).} =
+  ## Find the first element in `s` that fulfilled the predicate
+  ## `pred` (function that returns a `bool`). If such element
+  ## is not found is `s`, `def` is returned.
+  ##
+  runnableExamples:
+    let
+      l = @[2, 4, 6, 7, 9]
+      x = findFirst(l, proc(x: int): bool = x mod 2 == 1, -1)
+    assert x == 7
+
+  findItFirst(s, pred(it), def)
+
+proc findFirst*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): T {.since: (1, 1).}  =
+  ## Find the first element in `s` that fulfilled the predicate
+  ## `pred` (function that returns a `bool`). If such element
+  ## is not found is `s`, `default(T)` is returned.
+  ##
+  findFirst(s, pred, default(T))
+
+proc indexOf*[T](s: openArray[T], v: T): int {.since: (1, 1).} =
+  ## Get the index of the first element in `s` that equals to `v`.
+  ## If such element is not found is `s`, `low(s) - 1` is returned.
+  ##
+  runnableExamples:
+    let
+      l = @[2, 4, 6, 7, 9]
+      x = indexOf(l, 7)
+    assert x == 3
+
+  indexOfIt(s, it == v)
+
+proc indexOf*[T](s: openArray[T], pred: proc (x: T): bool {.closure.}): int {.since: (1, 1).} =
+  ## Get the index of the first element in `s` that fulfilled the predicate
+  ## `pred` (function that returns a `bool`). If such element
+  ## is not found is `s`, `low(s) - 1` is returned.
+  ##
+  runnableExamples:
+    let
+      l = @[2, 4, 6, 7, 9]
+      x = indexOf(l, proc(x: int): bool = x mod 2 == 1)
+    assert x == 3
+
+  indexOfIt(s, pred(it))
 
 proc mapLitsImpl(constructor: NimNode; op: NimNode; nested: bool;
                  filter = nnkLiterals): NimNode =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1401,7 +1401,7 @@ since (1, 1):
     findItFirst(s, op, default(typeof(items(s), typeOfIter)))
 
   template indexOfIt*(s: typed, op: untyped): int =
-    ## ## Get the index of the first element in `s` that fulfilled the predicate
+    ## Get the index of the first element in `s` that fulfilled the predicate
     ## `op` (a `bool` expression). If such element is not found is `s`,
     ##  `low(s) - 1` is returned.
     ##

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1491,7 +1491,7 @@ since (1, 1):
       var
         it {.inject.}: typeof(items(ss1), typeOfIter)
         jt {.inject.}: typeof(items(ss2), typeOfIter)
-        kt {.inject.}: typeof(items(ss3), typeofIter)
+        kt {.inject.}: typeof(items(ss3), typeOfIter)
       type
         OutType = typeof(op, typeOfProc)
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -46,10 +46,10 @@
 ##   * `items<#items.i>`_ · `newSeqWith<#newSeqWith.t,int,untyped>`_
 ## * Inspecting a container
 ##   * `count<#count,openArray[T],proc(T)>`_ · `all<#all,openArray[T],proc(T)>`_ ·
-##     `any<#any,openArray[T],proc(T)>`_ · `lengthWhile<#lengthWhile,openArray[T],proc(T)>`_ ·
+##     `any<#any,openArray[T],proc(T)>`_ · `lenWhile<#lenWhile,openArray[T],proc(T)>`_ ·
 ##     `indexOf<#indexOf,openArray[T],proc(T)>`_ · `findFirst<#findFirst,openArray[T],proc(T),T>`_
 ##   * `countIt<#countIt.t,typed,untyped>`_ ·  `allIt<#allIt.t,untyped,untyped>`_ ·
-##     `anyIt<#anyIt.t,untyped,untyped>`_ · `lengthWhileIt<#lengthWhileIt.t,typed,untyped>`_ ·
+##     `anyIt<#anyIt.t,untyped,untyped>`_ · `lenWhileIt<#lenWhileIt.t,typed,untyped>`_ ·
 ##     `indexOfIt<#indexOfIt.t,typed,untyped>`_ · `findItFirst<#findItFirst.t,typed,untyped>`_
 ## * Selecting items
 ##   * `filter<#filter,openArray[T],proc(T)>`_ · `delete<#delete,seq[T][T],Natural,Natural>`_  ·
@@ -187,13 +187,13 @@ proc count*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
     if pred(itm):
       inc result
 
-proc lengthWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
+proc lenWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): int
                                                             {.since: (1, 1).} =
   ## Returns the number of items in the container `s` that keep fulfilling
   ## the predicate `pred` (function that returns a `bool`) from the beginning.
   ##
   runnableExamples:
-    assert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
+    assert lenWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
 
   for itm in items(s):
     if pred(itm):
@@ -209,7 +209,7 @@ proc takeWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
   runnableExamples:
     assert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[1, 2, 3]
 
-  s[0 ..< lengthWhile(s, pred)]
+  s[0 ..< lenWhile(s, pred)]
 
 proc dropWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
                                                             {.since: (1, 1).} =
@@ -220,7 +220,7 @@ proc dropWhile*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
   runnableExamples:
     assert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[4, 5]
 
-  s[lengthWhile(s, pred) ..< s.len]
+  s[lenWhile(s, pred) ..< s.len]
 
 proc nest*[T](f: proc(x: T): T, x: T, n: Natural): seq[T] {.since: (1, 1).} =
   ## Returns a new sequence of the results of applying `f` to `x` 0 .. `n`
@@ -1319,7 +1319,7 @@ since (1, 1):
           inc result
       result
 
-  template lengthWhileIt*(s: typed, op: untyped): int =
+  template lenWhileIt*(s: typed, op: untyped): int =
     ## Returns the number of items in the container `s` that keep fulfilling
     ## `op` (an expression resulting in a `bool`) from the beginning.
     ##
@@ -1327,7 +1327,7 @@ since (1, 1):
     ## expression.
     ##
     runnableExamples:
-      assert lengthWhileIt(@[1, 2, 3, 4, 5], it < 4) == 3
+      assert lenWhileIt(@[1, 2, 3, 4, 5], it < 4) == 3
 
     block:
       var result = 0
@@ -1345,7 +1345,7 @@ since (1, 1):
     ##
     block:
       evalOnceAs(s1, s, compiles((let _ = s)))
-      s1[low(s1) ..< low(s1) + lengthWhileIt(s1, op)]
+      s1[low(s1) ..< low(s1) + lenWhileIt(s1, op)]
 
   template dropItWhile*(s: typed, op: untyped): untyped =
     ## Returns a sequence of items in the container `s` without items that
@@ -1357,7 +1357,7 @@ since (1, 1):
     ##
     block:
       evalOnceAs(s1, s, compiles((let _ = s)))
-      s1[low(s1) + lengthWhileIt(s1, op) ..< s1.len]
+      s1[low(s1) + lenWhileIt(s1, op) ..< s1.len]
 
   template nestIt*(op: untyped, x: typed, n: Natural): untyped =
     ## Returns a new sequence of the results of evaluating `op` on previous value for `n`

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -336,7 +336,7 @@ when (NimMajor, NimMinor) <= (1, 0):
 else:
   zipImpl(s1, s2, seq[(S, T)])
 
-proc zipwith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
+proc zipWith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
             op: proc (x: T1, y: T2): R {.closure.}): seq[R]
                                                           {.since: (1, 1).} =
   ## Returns a new sequence with a transformation on each elememnt from
@@ -350,7 +350,7 @@ proc zipwith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
     let
       s1 = @[1, 2, 3]
       s2 = @[4, 5, 6, 7]
-      zip1 = zipwith(s1, s2, func (x, y: int): int = x * y)
+      zip1 = zipWith(s1, s2, func (x, y: int): int = x * y)
     assert zip1 == @[4, 10, 18]
 
   var m = min(s1.len, s2.len)
@@ -358,7 +358,7 @@ proc zipwith*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
   for i in 0 ..< m:
     result[i] = op(s1[i], s2[i])
 
-proc zipwith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
+proc zipWith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
                              s3: openArray[T3],
                              op: proc (x: T1, y: T2, Z: T3): R {.closure.}):
                                                    seq[R] {.since: (1, 1).} =
@@ -374,7 +374,7 @@ proc zipwith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
       s1 = @[1, 2, 3]
       s2 = @[4, 5, 6]
       s3 = @[5, 7, 9, 9]
-      zip1 = zipwith(s1, s2, s3, func (x, y, z: int): bool = x + y == z)
+      zip1 = zipWith(s1, s2, s3, func (x, y, z: int): bool = x + y == z)
     assert zip1 == @[true, true, true]
 
   var m = min(min(s1.len, s2.len), s3.len)

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -415,24 +415,6 @@ proc scanIndexed*[T](s: openArray[T],
   for i, v in s:
     op(i, v)
 
-proc scanIndexed*[T, S](s: openArray[T],
-                        op: proc (i: int, x: T): S {.closure.}) {.since: (1, 1).} =
-  ## Apply `op` proc to every item in the container `s`. Results
-  ## of `op` proc are discarded.
-  ##
-  ## See also:
-  ## * `scanIt template<#scanIt.t,typed,untyped>`_
-  ##
-  runnableExamples:
-    let
-      a = @[1, 2, 3, 4]
-    scan(a, proc(x: int): string =
-      echo x
-      return $x)
-
-  for i, v in s:
-    discard op(i, v)
-
 proc apply*[T](s: var openArray[T], op: proc (x: var T) {.closure.})
                                                               {.inline.} =
   ## Applies `op` to every item in `s` modifying it directly.
@@ -1373,23 +1355,6 @@ proc zipWith*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
 
   zipThem(s1, s2, s3, op(it, jt, kt))
 
-proc zippedScan*[T1, T2, R](s1: openArray[T1], s2: openArray[T2],
-                            op: proc (x: T1, y: T2): R {.closure.}) {.since: (1, 1).} =
-  ## Apply `op` proc on each pair of elements from the two input containers,
-  ## discarding results.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6, 7]
-    zippedScan(s1, s2, proc (x, y: int): int = x * y)
-
-  scanThem(s1, s2, (discard op(it, jt)))
-
 proc zippedScan*[T1, T2](s1: openArray[T1], s2: openArray[T2],
                          op: proc (x: T1, y: T2) {.closure.}) {.since: (1, 1).} =
   ## Apply `op` proc on each pair of elements from the two input containers.
@@ -1405,25 +1370,6 @@ proc zippedScan*[T1, T2](s1: openArray[T1], s2: openArray[T2],
     zippedScan(s1, s2, proc (x, y: int) = echo x * y)
 
   scanThem(s1, s2, op(it, jt))
-
-proc zippedScan*[T1, T2, T3, R](s1: openArray[T1], s2: openArray[T2],
-                             s3: openArray[T3],
-                             op: proc (x: T1, y: T2, Z: T3): R {.closure.}) {.since: (1, 1).} =
-  ## Apply `op` proc on each triple of elements from the three input containers,
-  ## discarding results.
-  ##
-  ## The input containers can be of different types.
-  ## If one container is shorter, the remaining items in the longer container
-  ## are discarded.
-  ##
-  runnableExamples:
-    let
-      s1 = @[1, 2, 3]
-      s2 = @[4, 5, 6]
-      s3 = @[5, 7, 9, 9]
-    zippedScan(s1, s2, s3, proc (x, y, z: int): bool = x + y == z)
-
-  scanThem(s1, s2, s3, (discard op(it, jt, kt)))
 
 proc zippedScan*[T1, T2, T3](s1: openArray[T1], s2: openArray[T2],
                              s3: openArray[T3],
@@ -1455,22 +1401,6 @@ proc scan*[T](s: openArray[T], op: proc (x: T) {.closure.}) {.since: (1, 1).} =
     scan(a, proc(x: int) = echo x)
 
   scanIt(s, op(it))
-
-proc scan*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}) {.since: (1, 1).} =
-  ## Apply `op` proc to every item in the container `s`. Results
-  ## of `op` proc are discarded.
-  ##
-  ## See also:
-  ## * `scanIt template<#scanIt.t,typed,untyped>`_
-  ##
-  runnableExamples:
-    let
-      a = @[1, 2, 3, 4]
-    scan(a, proc(x: int): string =
-      echo x
-      return $x)
-
-  scanIt(s, (discard op(it)))
 
 proc findFirst*[T](s: openArray[T],
                    pred: proc (x: T): bool {.closure.}, def: T): T {.since: (1, 1).} =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -277,7 +277,7 @@ when (NimMajor, NimMinor) <= (1, 0):
 else:
   zipImpl(s1, s2, seq[(S, T)])
 
-proc partition*[T](s: seq[T], len: Positive): seq[seq[T]] {.since: (1, 1).} =
+proc partition*[T](s: openArray[T], len: Positive): seq[seq[T]] {.since: (1, 1).} =
   ## Splits a sequence `s` into sub-sequences of length `len`.
   ##
   ## Number of sequences in result is `s.len div len`. If length of `s`

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -46,11 +46,6 @@ template test() =
     var r: string
     s1.scan(proc (it: int) = r = r & $it)
     doAssert r == "123"
-    r = ""
-    s1.scan(proc (it: int): int = 
-      r = r & $it
-      it)
-    doAssert r == "123"
 
   block: # zippedScan
     let
@@ -65,17 +60,6 @@ template test() =
     doAssert zip1 == @[true, true, true]
     doAssert zip2 == @[5, 7, 9]
 
-    zip1 = @[]
-    zip2 = @[]
-    zippedScan(s1, s2, s3, proc (x, y, z: int): int =
-      zip1.add(x + y == z)
-      x + y)
-    zippedScan(s1, s2, proc (x, y: int): int =
-      zip2.add(x + y)
-      x + y)
-    doAssert zip1 == @[true, true, true]
-    doAssert zip2 == @[5, 7, 9]
-
   block: # scanIt
     let s1 = @[1, 2, 3]
     var r: seq[string] = @[]
@@ -86,12 +70,6 @@ template test() =
     var r: seq[string]
     @["I", "II", "III"].scanIndexed(
               proc (i: int, x: string) = r.add($(i + 1) & ":" & x))          
-    doAssert r == @["1:I", "2:II", "3:III"]
-    r = @[]
-    @["I", "II", "III"].scanIndexed(
-              proc (i: int, x: string): int = 
-                r.add($(i + 1) & ":" & x)
-                i)
     doAssert r == @["1:I", "2:II", "3:III"]
 
   block: # scanThem

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -133,26 +133,26 @@ template test() =
     doAssert nestIt("1" & it, "1", 4) == @["1", "11", "111", "1111", "11111"]
     
   block: # while
-    doAssert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
+    doAssert lenWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
     doAssert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[1, 2, 3]
     doAssert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[4, 5]
     
-    doAssert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == 0
+    doAssert lenWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == 0
     doAssert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == @[]
     doAssert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == @[1, 2, 3, 4, 5]
 
-    doAssert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == 5
+    doAssert lenWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == 5
     doAssert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == @[1, 2, 3, 4, 5]
     doAssert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == @[]
 
     let
       s: seq[int] = @[]
-    doAssert lengthWhile(s, func (x: int): bool = x < 10) == 0
+    doAssert lenWhile(s, func (x: int): bool = x < 10) == 0
     doAssert takeWhile(s, func (x: int): bool = x < 10) == @[]
     doAssert dropWhile(s, func (x: int): bool = x < 10) == @[]
   
   block: # whileIt
-    doAssert lengthWhileIt(@[1, 2, 3, 4, 5], it < 4) == 3
+    doAssert lenWhileIt(@[1, 2, 3, 4, 5], it < 4) == 3
     doAssert takeItWhile(@[1, 2, 3, 4, 5], it < 4) == @[1, 2, 3]
     doAssert dropItWhile(@[1, 2, 3, 4, 5], it < 4) == @[4, 5]
 
@@ -164,7 +164,7 @@ template test() =
 
     let
       s: seq[int] = @[]
-    doAssert lengthWhileIt(s, it < 10) == 0
+    doAssert lenWhileIt(s, it < 10) == 0
     doAssert takeItWhile(s, it < 10) == @[]
     doAssert dropItWhile(s, it < 10) == @[]
   

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -1,0 +1,175 @@
+discard """
+  output: "OK"
+"""
+import sequtils, sugar, math
+
+template test() =
+  block: # partition
+    let numbers = @[1, 2, 3, 4, 5, 6, 7]
+    assert numbers.partition(3) == @[@[1, 2, 3], @[4, 5, 6]]
+    assert numbers.partition(10) == @[]
+
+  block: # count & countIt
+    let
+      b = "abracadabra"
+    doAssert count(b, func (c: char): bool = c in {'a', 'r'}) == 7
+    doAssert countIt(b, it in {'a', 'r'}) == 7
+    doAssert countIt(b, it == 'z') == 0
+
+  block: # mapIndexed
+    doAssert @["I", "II", "III"].mapIndexed(
+              proc (i: int, x: string): string = $(i + 1) & ":" & x) == @["1:I", "2:II", "3:III"]
+
+  block: # zipWith
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+      zip1 = zipWith(s1, s2, s3, func (x, y, z: int): bool = x + y == z)
+      zip2 = zipWith(s1, s2, (x, y) => x + y)
+    doAssert zip1 == @[true, true, true]
+    doAssert zip2 == @[5, 7, 9]
+
+  block: # zipThem
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+      zip1 = zipThem(s1, s2, s3, it + jt == kt)
+      zip2 = zipThem(s1, s2, it + jt)
+    doAssert zip1 == @[true, true, true]
+    doAssert zip2 == @[5, 7, 9]
+    doAssert zipThem(@[1, 2, 3], @["I", "II", "III", "IV"], $it & ":" & jt) == @["1:I", "2:II", "3:III"]
+
+  block: # scan
+    let s1 = @[1, 2, 3]
+    var r: string
+    s1.scan(proc (it: int) = r = r & $it)
+    doAssert r == "123"
+    r = ""
+    s1.scan(proc (it: int): int = 
+      r = r & $it
+      it)
+    doAssert r == "123"
+
+  block: # zippedScan
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+    var
+      zip1: seq[bool] = @[]
+      zip2: seq[int] = @[]
+    zippedScan(s1, s2, s3, proc (x, y, z: int) = zip1.add(x + y == z))
+    zippedScan(s1, s2, proc (x, y: int) = zip2.add(x + y))
+    doAssert zip1 == @[true, true, true]
+    doAssert zip2 == @[5, 7, 9]
+
+    zip1 = @[]
+    zip2 = @[]
+    zippedScan(s1, s2, s3, proc (x, y, z: int): int =
+      zip1.add(x + y == z)
+      x + y)
+    zippedScan(s1, s2, proc (x, y: int): int =
+      zip2.add(x + y)
+      x + y)
+    doAssert zip1 == @[true, true, true]
+    doAssert zip2 == @[5, 7, 9]
+
+  block: # scanIt
+    let s1 = @[1, 2, 3]
+    var r: seq[string] = @[]
+    s1.scanIt(r.add($it))
+    doAssert r == @["1", "2", "3"]
+
+  block: # scanIndexed
+    var r: seq[string]
+    @["I", "II", "III"].scanIndexed(
+              proc (i: int, x: string) = r.add($(i + 1) & ":" & x))          
+    doAssert r == @["1:I", "2:II", "3:III"]
+    r = @[]
+    @["I", "II", "III"].scanIndexed(
+              proc (i: int, x: string): int = 
+                r.add($(i + 1) & ":" & x)
+                i)
+    doAssert r == @["1:I", "2:II", "3:III"]
+
+  block: # scanThem
+    let
+      s1 = @[1, 2, 3]
+      s2 = @[4, 5, 6]
+      s3 = @[5, 7, 9, 9]
+    var r: seq[bool] = @[]
+    var zip2: seq[int]
+    scanThem(s1, s2, s3, r.add(it + jt == kt))
+    scanThem(s1, s2, zip2.add(it + jt))
+    doAssert r == @[true, true, true]
+    doAssert zip2 == [5, 7, 9]
+
+  block: # findFirst  
+    let
+      l = @[2, 4, 6, 7, 9]
+      x = findFirst(l, pred = proc(x: int): bool = x mod 2 == 1)
+    doAssert x == 7
+    doAssert findItFirst(l, it mod 2 == 1) == 7
+    doAssert findItFirst(l, it == 100) == default(int)
+
+  block: # indexOf
+    let
+      l = @["one", "two", "three"]
+    doAssert l.indexOf("one") == 0
+    doAssert l.indexOf(proc (x: string): bool = x == "one") == 0
+    doAssert l.indexOf("four") == -1
+    doAssert l.indexOf(proc (x: string): bool = x == "four") == -1
+    doAssert l.indexOfIt(it == "one") == 0
+    doAssert l.indexOfIt(it == "four") == -1
+
+  block: # nest
+    doAssert nest(func (x: int): int = x * 2, 1, 3) == [1, 2, 4, 8]
+    doAssert nest(func (x: int): int = x * 2, 1, 0) == [1]
+  
+    doAssert nestIt(it * 2, 1, 3) == [1, 2, 4, 8]
+    doAssert nestIt(it * 2, 1, 0) == [1]
+    doAssert nestIt("1" & it, "1", 4) == @["1", "11", "111", "1111", "11111"]
+    
+  block: # while
+    doAssert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == 3
+    doAssert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[1, 2, 3]
+    doAssert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 4) == @[4, 5]
+    
+    doAssert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == 0
+    doAssert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == @[]
+    doAssert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x > 10) == @[1, 2, 3, 4, 5]
+
+    doAssert lengthWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == 5
+    doAssert takeWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == @[1, 2, 3, 4, 5]
+    doAssert dropWhile(@[1, 2, 3, 4, 5], func (x: int): bool = x < 10) == @[]
+
+    let
+      s: seq[int] = @[]
+    doAssert lengthWhile(s, func (x: int): bool = x < 10) == 0
+    doAssert takeWhile(s, func (x: int): bool = x < 10) == @[]
+    doAssert dropWhile(s, func (x: int): bool = x < 10) == @[]
+  
+  block: # whileIt
+    doAssert lengthWhileIt(@[1, 2, 3, 4, 5], it < 4) == 3
+    doAssert takeItWhile(@[1, 2, 3, 4, 5], it < 4) == @[1, 2, 3]
+    doAssert dropItWhile(@[1, 2, 3, 4, 5], it < 4) == @[4, 5]
+
+    doAssert takeItWhile(@[1, 2, 3, 4, 5], it > 10) == @[]
+    doAssert dropItWhile(@[1, 2, 3, 4, 5], it < 10) == @[]
+
+    doAssert takeItWhile(@[1, 2, 3, 4, 5], it < 10) == @[1, 2, 3, 4, 5]
+    doAssert dropItWhile(@[1, 2, 3, 4, 5], it > 10) == @[1, 2, 3, 4, 5]
+
+    let
+      s: seq[int] = @[]
+    doAssert lengthWhileIt(s, it < 10) == 0
+    doAssert takeItWhile(s, it < 10) == @[]
+    doAssert dropItWhile(s, it < 10) == @[]
+  
+static:
+  test()
+
+test()
+echo "OK"


### PR DESCRIPTION
Based on experiences on Erlang, Mathematica, Haskell, C#/LINQ, I propose to add `count` (another
version), `countIt`, `lengthWhile`, `takeWhile`, `dropWhile`, `nest`, `zipwith`, and `findFirst` to `seqtuils`.

Usage of these functions are straight forward, except `nest`, maybe. It is similar to Mathematica's
`NestList`. Since it is in `sequtils`, the `List` can be omitted. A quick example on `nest`,
to show how we are approaching the solution of `cos(x) == x` by pressing [COS] over and over again on a scientific calculator: 

```nim
echo nest[float64](cos, 1.0, 100)
```