### PR TITLE
fix json regression

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1055,6 +1055,7 @@ when defined(nimFixedForwardGeneric):
       jsonPath.setLen originalJsonPathLen
 
   proc initFromJson[T](dst: var ref T; jsonNode: JsonNode; jsonPath: var string) =
+    verifyJsonKind(jsonNode, {JObject, JNull}, jsonPath)
     if jsonNode.kind == JNull:
       dst = nil
     else:


### PR DESCRIPTION
D20191212T144944
fixes regressions introduced in 21cbfd72ec9fce04fab98326376651806c8adf0b /cc @krux02 

## regression1: SIGSEGV
```nim
  import std/json
  type
    Foo* = ref object # no bug with `object`
      z1*: string
    Baz* = ref object
      foo2*: Foo # bug
  proc testAll*()=
    let s = """{"foo": {"z1": "hi"}}"""
    let j = parseJson(s)
    discard j.to(Baz)
  # static: testAll()
  testAll()
```

before 21cbfd72ec9fce04fab98326376651806c8adf0b
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0832.nim(64) t0832
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/json.nim(1216) testAll
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/json.nim(480) []
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/collections/tables.nim(263) []
Error: unhandled exception: key not found: foo2 [KeyError]
```
after 21cbfd72ec9fce04fab98326376651806c8adf0b
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0832.nim(63) t0832
/Users/timothee/git_clone/nim/timn/tests/nim/all/t0832.nim(61) testAll
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/json.nim(1194) to
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/json.nim(1052) initFromJson
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/json.nim(1156) initFromJson
/Users/timothee/git_clone/nim/Nim_temp/lib/pure/json.nim(1048) initFromJson
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

after this PR
...
Error: unhandled exception: key not found: .foo2 [KeyError]

## regression2: accepts invalid code
```nim
  import std/json
  type
    Foo* = ref object
    Baz* = ref object
      foo*: Foo
  proc testAll*()=
    let s = """{"foo": [1,2]}"""
    let j = parseJson(s)
    discard j.to(Baz)
  # static: testAll()
  testAll()
```

before 21cbfd72ec9fce04fab98326376651806c8adf0b
Error: unhandled exception: Incorrect JSON kind. Wanted '{JNull, JObject}' in 'temp_547030["foo"]' but got 'JArray'. [JsonKindError]


after 21cbfd72ec9fce04fab98326376651806c8adf0b
no error at runtime even though there should be

after this PR
Error: unhandled exception: Incorrect JSON kind. Wanted '{JNull, JObject}' in '.foo' but got 'JArray'. [JsonKindError]
