### PR TITLE
[WIP] fix #12884 VM handles float32 correctly for declarations

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -252,7 +252,10 @@ proc putIntoReg(dest: var TFullReg; n: PNode) =
     dest.intVal = n.intVal
   of nkFloatLit..nkFloat128Lit:
     dest.kind = rkFloat
-    dest.floatVal = n.floatVal
+    case n.typ.kind
+    of tyFloat32: dest.floatVal = n.floatVal.float32
+    of tyFloat: dest.floatVal = n.floatVal.float # handles 32bit float on 32 bit platforms
+    else: dest.floatVal = n.floatVal
   else:
     dest.kind = rkNode
     dest.node = n

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -451,7 +451,8 @@ proc sameConstant*(a, b: PNode): bool =
     of nkSym: result = a.sym == b.sym
     of nkIdent: result = a.ident.id == b.ident.id
     of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = a.floatVal == b.floatVal
+    of nkFloatLit..nkFloat64Lit:
+      result = a.floatVal == b.floatVal and a.typ.kind == b.typ.kind
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkType, nkNilLit: result = a.typ == b.typ
     of nkEmpty: result = true
@@ -462,7 +463,7 @@ proc sameConstant*(a, b: PNode): bool =
         result = true
 
 proc genLiteral(c: PCtx; n: PNode): int =
-  # types do not matter here:
+  # types do not matter here except for special cases eg float32, see #12884
   for i in 0..<c.constants.len:
     if sameConstant(c.constants[i], n): return i
   result = rawGenLiteral(c, n)

--- a/tests/vm/tfloat32.nim
+++ b/tests/vm/tfloat32.nim
@@ -1,0 +1,25 @@
+proc main(): string =
+  let x0 = float32(1.32)
+  let x1: float32 = 1.32
+  let x3 = 1.32'f32
+  let x4 = 1.32
+  let x2 = x1
+  let x5 = x3*x3 # will differ here
+  let x6 = 1.32'f64
+  let x7: float = 1.32
+  $(x0, x1, x2, x3, x4, x5, x6, x7, x3*x3,
+    x3 * 2.0,  # will differ here
+     $type(x4), $type(x5))
+
+const a1 = main()
+let a2 = main()
+
+#[
+CT (a1) and RT (a2) values differ when float operations are involved (eg x3*x3),
+but otherwise are the same
+]#
+doAssert a1 == """
+(1.320000052452087, 1.320000052452087, 1.320000052452087, 1.320000052452087, 1.32, 1.742400138473513, 1.32, 1.32, 1.742400138473513, 2.640000104904175, "float64", "float32")"""
+
+doAssert a2 == """
+(1.320000052452087, 1.320000052452087, 1.320000052452087, 1.320000052452087, 1.32, 1.742400169372559, 1.32, 1.32, 1.742400169372559, 2.640000104904175, "float64", "float32")"""


### PR DESCRIPTION
EDIT: do not review: marking as `WIP` because of failing tests... tests/stdlib/tjsonmacro.nim in particular seems tricky, maybe this can't be done easily

## fixes #12884

see tests/vm/tfloat32.nim

this PR makes VM correctly handle float32 declarations (eg float32 litterals or conversions to float32); eg `1.32'f32` will be 1.320000052452087 instead of 1.32. The internal representation is still float64, but at least the litteral is first cast to the requested type float32. This makes VM code more compatible with RT code when float32 are involved.

Caveat: float32 operations (eg a*b) are still calculated using float64 precision instead of float32 precision (see tests/vm/tfloat32.nim), so the VM gives identical results to RT code only when declarations (float32 litterals + explicit float32 conversions) are involved, but results can differ (as before this PR) when float32 operations are involved.

see tests/vm/tfloat32.nim:
runtime value:
echo a2
(1.320000052452087, 1.320000052452087, 1.320000052452087, 1.320000052452087, 1.32, 1.742400169372559, 1.32, 1.32, 1.742400169372559, 2.640000104904175, "float64", "float32")

CT value:
before PR:
echo a1
(1.32, 1.32, 1.32, 1.32, 1.32, 1.7424, 1.32, 1.32, 1.7424, 2.64, "float64", "float32")

after PR:
echo a1
(1.320000052452087, 1.320000052452087, 1.320000052452087, 1.320000052452087, 1.32, 1.742400138473513, 1.32, 1.32, 1.742400138473513, 2.640000104904175, "float64", "float32")

