### PR TITLE
lenVarargs: number of varargs elements

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4198,10 +4198,9 @@ type
   NimNode* {.magic: "PNimrodNode".} = ref NimNodeObj
     ## Represents a Nim AST node. Macros operate on this type.
 
-proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
-
 macro lenVarargs*(x: varargs[untyped]): int =
   ## returns number of variadic arguments in `x`
+  proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
   lenVarargsImpl(x)
 
 when false:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4198,11 +4198,10 @@ type
   NimNode* {.magic: "PNimrodNode".} = ref NimNodeObj
     ## Represents a Nim AST node. Macros operate on this type.
 
-when (NimMajor, NimMinor) >= (1, 1):
-  macro lenVarargs*(x: varargs[untyped]): int =
-    ## returns number of variadic arguments in `x`
-    proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
-    lenVarargsImpl(x)
+macro lenVarargs*(x: varargs[untyped]): int {.since: (1, 1).} =
+  ## returns number of variadic arguments in `x`
+  proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
+  lenVarargsImpl(x)
 
 when false:
   template eval*(blk: typed): typed =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4198,6 +4198,12 @@ type
   NimNode* {.magic: "PNimrodNode".} = ref NimNodeObj
     ## Represents a Nim AST node. Macros operate on this type.
 
+proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
+
+macro lenVarargs*(x: varargs[untyped]): int {.magic: "LengthOpenArray", noSideEffect.} =
+  ## returns number of variadic arguments in `x`
+  lenVarargsImpl(x)
+
 when false:
   template eval*(blk: typed): typed =
     ## Executes a block of code at compile time just as if it was a macro.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4200,7 +4200,7 @@ type
 
 proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
 
-macro lenVarargs*(x: varargs[untyped]): int {.magic: "LengthOpenArray", noSideEffect.} =
+macro lenVarargs*(x: varargs[untyped]): int =
   ## returns number of variadic arguments in `x`
   lenVarargsImpl(x)
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -4198,10 +4198,11 @@ type
   NimNode* {.magic: "PNimrodNode".} = ref NimNodeObj
     ## Represents a Nim AST node. Macros operate on this type.
 
-macro lenVarargs*(x: varargs[untyped]): int =
-  ## returns number of variadic arguments in `x`
-  proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
-  lenVarargsImpl(x)
+when (NimMajor, NimMinor) >= (1, 1):
+  macro lenVarargs*(x: varargs[untyped]): int =
+    ## returns number of variadic arguments in `x`
+    proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
+    lenVarargsImpl(x)
 
 when false:
   template eval*(blk: typed): typed =

--- a/tests/system/tlenvarargs.nim
+++ b/tests/system/tlenvarargs.nim
@@ -1,0 +1,55 @@
+discard """
+  output: '''
+tlenvarargs.nim:35:9 (1, 2)
+tlenvarargs.nim:36:9 12
+tlenvarargs.nim:37:9 1
+tlenvarargs.nim:38:8'''
+"""
+
+
+## line 10
+
+template myecho*(a: varargs[untyped]) =
+  ## shows a useful debugging echo-like proc that is dependency-free (no dependency
+  ## on macros.nim) so can be used in more contexts
+  const info = instantiationInfo(-1, false)
+  const loc = info.filename & ":" & $info.line & ":" & $info.column & " "
+  when lenVarargs(a) > 0:
+    echo(loc, a)
+  else:
+    echo(loc)
+
+template fun*(a: varargs[untyped]): untyped =
+  lenVarargs(a)
+
+template fun2*(a: varargs[typed]): untyped =
+  a.lenVarargs
+
+template fun3*(a: varargs[int]): untyped =
+  a.lenVarargs
+
+template fun4*(a: varargs[untyped]): untyped =
+  len(a)
+
+proc main()=
+  myecho (1, 2)
+  myecho 1, 2
+  myecho 1
+  myecho()
+
+  doAssert fun() == 0
+  doAssert fun('a') == 1
+  doAssert fun("asdf", 1) == 2
+
+  doAssert fun2() == 0
+  doAssert fun2('a') == 1
+  doAssert fun2("asdf", 1) == 2
+
+  doAssert fun3() == 0
+  doAssert fun3(10) == 1
+  doAssert fun3(10, 11) == 2
+
+  ## shows why `lenVarargs` can't be named `len`
+  doAssert fun4("abcdef") == len("abcdef")
+
+main()

--- a/tests/system/tlenvarargs.nim
+++ b/tests/system/tlenvarargs.nim
@@ -3,10 +3,10 @@ discard """
 tlenvarargs.nim:35:9 (1, 2)
 tlenvarargs.nim:36:9 12
 tlenvarargs.nim:37:9 1
-tlenvarargs.nim:38:8'''
-  joinable: "false"
+tlenvarargs.nim:38:8 
+done
+'''
 """
-
 ## line 10
 
 template myecho*(a: varargs[untyped]) =
@@ -52,4 +52,8 @@ proc main()=
   ## shows why `lenVarargs` can't be named `len`
   doAssert fun4("abcdef") == len("abcdef")
 
+  ## workaround for BUG:D20191218T171447 whereby if testament expected output ends
+  ## in space, testament strips it from expected output but not actual output,
+  ## which leads to a mismatch when running test via megatest
+  echo "done"
 main()

--- a/tests/system/tlenvarargs.nim
+++ b/tests/system/tlenvarargs.nim
@@ -4,8 +4,8 @@ tlenvarargs.nim:35:9 (1, 2)
 tlenvarargs.nim:36:9 12
 tlenvarargs.nim:37:9 1
 tlenvarargs.nim:38:8'''
+  joinable: "false"
 """
-
 
 ## line 10
 


### PR DESCRIPTION
* fixes https://forum.nim-lang.org/t/3717#23156 How to count varargs[untyped] inside of template?
* fixes https://github.com/nim-lang/Nim/issues/11117 varargs[T].len as const expression

## note
`lenVarargs` can actually be implemented as follows:
```nim
macro lenVarargs*(a: varargs[untyped]): untyped = newLit len(a)
```
but that requires a dependency on macros.nim, so is unsuitable for "low-level" code that can't have such dependency, eg:
* see myecho in provided test file tests/system/tlenvarargs.nim: it defines a simple yet useful alternative to echo that also prints file:line:col before printing its arguments (to makes it obvious in printouts where the echo came from); it is useful (in particular for debugging) even in cases where a depdency on macros.nim would otherwise cause circular dependency (eg for debugging code inside system.nim or one of its includes/imported files)

* defining `lenVarargs` in another module than system.nim (eg macros.nim or sugar.nim etc) would defeat this purpose, so IMO in this particular case it's ok to add this proc to system.nim
