### PR TITLE
NaN floatFormat with clang_cl 

### DIFF
--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -44,10 +44,10 @@ proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat): int =
     result = n + 2
   else:
     result = n
-  # On Windows nice numbers like '1.#INF', '-1.#INF' or '1.#NAN'
+  # On Windows nice numbers like '1.#INF', '-1.#INF' or '1.#NAN' or nan(ind)
   # of '-1.#IND' are produced.
   # We want to get rid of these here:
-  if buf[n-1] in {'n', 'N', 'D', 'd'}:
+  if buf[n-1] in {'n', 'N', 'D', 'd', ')'}:
     writeToBuffer(buf, "nan")
     result = 3
   elif buf[n-1] == 'F':

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -44,7 +44,7 @@ proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat): int =
     result = n + 2
   else:
     result = n
-  # On Windows nice numbers like '1.#INF', '-1.#INF' or '1.#NAN' or nan(ind)
+  # On Windows nice numbers like '1.#INF', '-1.#INF' or '1.#NAN' or 'nan(ind)'
   # of '-1.#IND' are produced.
   # We want to get rid of these here:
   if buf[n-1] in {'n', 'N', 'D', 'd', ')'}:


### PR DESCRIPTION
I have been trying out clang_cl compiler from LLVM 9.0 with Nim. Found it prints out nan differently than vcc on windows. NaNs are printed as `nan(ind)`.


