### PR TITLE
allow typed/untyped params in magic procs (even if not in stdlib)

### DIFF
--- a/tests/proc/untyped.nim
+++ b/tests/proc/untyped.nim
@@ -1,7 +1,15 @@
 discard """
-  errormsg: "'untyped' is only allowed in templates and macros"
-  line: 6
+  errormsg: "'untyped' is only allowed in templates and macros or magic procs"
+  line: 14
 """
 
+# magic procs are allowed with `untyped`
+proc declaredInScope2*(x: untyped): bool {.magic: "DefinedInScope", noSideEffect, compileTime.}
+proc bar(): bool =
+  var x = 1
+  declaredInScope2(x)
+static: doAssert bar()
+
+# but not non-magic procs
 proc fun(x:untyped)=discard
 fun(10)


### PR DESCRIPTION
* this PR removes a stdlib special case and makes typed/untyped params in magic procs explicitly allowed (even in non-stdlib modules).
It makes it easier to define magic procs in user defined modules (eg for customizing the compiler)
* a test case is included