### PR TITLE
followup #12911 typed/untyped params only allowed in magic procs

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1157,8 +1157,7 @@ proc semProcTypeNode(c: PContext, n, genericParams: PNode,
       # TODO: Disallow typed/untyped in procs in the compiler/stdlib
       if kind == skProc and (typ.kind == tyTyped or typ.kind == tyUntyped):
         if not isMagic(sym):
-          if (owner.kind != skModule or (owner.owner.name.s != "stdlib")):
-            localError(c.config, a[^2].info, "'" & typ.sym.name.s & "' is only allowed in templates and macros or magic procs")
+          localError(c.config, a[^2].info, "'" & typ.sym.name.s & "' is only allowed in templates and macros or magic procs")
 
     if hasDefault:
       def = a[^1]


### PR DESCRIPTION
followup after https://github.com/nim-lang/Nim/pull/12911 thanks to comment from @Clyybber
> This can be removed now afaict

(somehow i thought this wouldn't work, but maybe it does work)