### PR TITLE
generic stack trace overriding mechanism

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -33,6 +33,9 @@ when defined(profiler) or defined(memProfiler):
   {.hint: "Profiling support is turned on!".}
   import nimprof
 
+when defined(libbacktrace):
+  import libbacktrace
+
 proc prependCurDir(f: AbsoluteFile): AbsoluteFile =
   when defined(unix):
     if os.isAbsolute(f.string): result = f

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -33,9 +33,6 @@ when defined(profiler) or defined(memProfiler):
   {.hint: "Profiling support is turned on!".}
   import nimprof
 
-when defined(libbacktrace):
-  import libbacktrace
-
 proc prependCurDir(f: AbsoluteFile): AbsoluteFile =
   when defined(unix):
     if os.isAbsolute(f.string): result = f

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -144,10 +144,10 @@ const
     (defined(nativeStackTrace) and nativeStackTraceSupported)
 
 when defined(nimStackTraceOverride):
-  type StackTraceOverrideProc* = proc (): string {.nimcall, benign, raises: [], tags: [].}
+  type StackTraceOverrideProc* = proc (): string {.nimcall, noinline, benign, raises: [], tags: [].}
     ## Procedure type for overriding the default stack trace.
 
-  var stackTraceOverrideGetTraceback: StackTraceOverrideProc = proc(): string =
+  var stackTraceOverrideGetTraceback: StackTraceOverrideProc = proc(): string {.noinline.} =
     result = "Stack trace override procedure not registered.\n"
 
   proc registerStackTraceOverride*(overrideProc: StackTraceOverrideProc) =


### PR DESCRIPTION
Lightweight stack traces using an external libbacktrace wrapper: https://github.com/status-im/nim-libbacktrace

This addresses https://github.com/nim-lang/Nim/issues/12702 and will be helped by https://github.com/nim-lang/Nim/issues/12735 (on macOS)

These stack traces require `--debuger:native` for debugging symbols and look the same as Nim's default ones: https://travis-ci.org/status-im/nim-libbacktrace/jobs/626489399

This small PR adds support for libbacktrace both in the compiler itself (try it with `./koch boot -d:libbacktrace --debugger:native -d:release`) and in external programs that `import libbacktrace`.

This last requirement is unfortunate. Is there some stdlib module, besides "system", where I can plug this instead of asking users to import it?

Also, any elegant way of showing an error message if the external Nim package is not installed on the system?