### PR TITLE
[WIP] Aligned allocation

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2538,7 +2538,7 @@ when not defined(nimscript):
       ## Grows or shrinks a given memory block on the heap.
       ##
       ## If `p` is **nil** then a new memory block is returned with alignment `align`
-      ## In either way the block has at least ``newSize`` bytes. align` must be a power
+      ## In either way the block has at least ``newSize`` bytes. `align` must be a power
       ## of two. If ``newSize == 0`` and `p` is not **nil** ``reallocShared`` calls
       ## ``deallocShared(p)``.
       ## In other cases the block has to be freed with

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2493,7 +2493,7 @@ when not defined(nimscript):
     proc createSharedU*(T: typedesc, size = 1.Positive): ptr T {.inline,
                                                                  benign, raises: [].} =
       ## Allocates a new memory block on the shared heap with at
-      ## least ``T.sizeof * size`` bytes
+      ## least ``T.sizeof * size`` bytes.
       ##
       ## The block has to be freed with
       ## `resizeShared(block, 0) <#resizeShared,ptr.T,Natural>`_ or

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2386,7 +2386,9 @@ when not defined(nimscript):
     const MemAlign = 8 # also minimal allocatable memory block
 
     proc alloc*(size: Natural, align = MemAlign): pointer {.noconv, rtl, tags: [], benign, raises: [].}
-      ## Allocates a new memory block with at least ``size`` bytes.
+      ## Allocates a new memory block with at least ``size`` bytes and alignment `align`.
+      ## `align` must be power of two. It is adviced to use `createU` instead as
+      ## it handles alignment automatically.
       ##
       ## The block has to be freed with `realloc(block, 0) <#realloc,pointer,Natural>`_
       ## or `dealloc(block) <#dealloc,pointer>`_.
@@ -2414,7 +2416,9 @@ when not defined(nimscript):
       cast[ptr T](alloc(T.sizeof * size, alignOf(T)))
 
     proc alloc0*(size: Natural, align = MemAlign): pointer {.noconv, rtl, tags: [], benign, raises: [].}
-      ## Allocates a new memory block with at least ``size`` bytes.
+      ## Allocates a new memory block with at least ``size`` bytes and alignment `align`.
+      ## `align` must be power of two. It is adviced to use `create` instead as
+      ## it handles alignment automatically.
       ##
       ## The block has to be freed with `realloc(block, 0) <#realloc,pointer,Natural>`_
       ## or `dealloc(block) <#dealloc,pointer>`_.
@@ -2439,11 +2443,10 @@ when not defined(nimscript):
                                                            benign, raises: [].}
       ## Grows or shrinks a given memory block.
       ##
-      ## If `p` is **nil** then a new memory block is returned if alignment `align`.
-      ## In either way the block has at least ``newSize`` bytes.
-      ## If ``newSize == 0`` and `p` is not **nil** ``realloc`` calls ``dealloc(p)``.
-      ## In other cases the block has to be freed with
-      ## `dealloc(block) <#dealloc,pointer>`_.
+      ## If `p` is **nil** then a new memory block is returned with alignment `align`.
+      ## In either way the block has at least ``newSize`` bytes. `align` must be a power
+      ## of two. If ``newSize == 0`` and `p` is not **nil** ``realloc`` calls ``dealloc(p)``.
+      ## In other cases the block has to be freed with `dealloc(block) <#dealloc,pointer>`_.
       ##
       ## The allocated memory belongs to its allocating thread!
       ## Use `reallocShared <#reallocShared,pointer,Natural>`_ to reallocate
@@ -2475,7 +2478,8 @@ when not defined(nimscript):
 
     proc allocShared*(size: Natural, align = MemAlign): pointer {.noconv, rtl, benign, raises: [].}
       ## Allocates a new memory block on the shared heap with at
-      ## least ``size`` bytes.
+      ## least ``size`` bytes and alignment `align`. `align` must be power of two.
+      ## It is adviced to use `createSharedU` instead as it handles alignment automatically.
       ##
       ## The block has to be freed with
       ## `reallocShared(block, 0) <#reallocShared,pointer,Natural>`_
@@ -2489,7 +2493,7 @@ when not defined(nimscript):
     proc createSharedU*(T: typedesc, size = 1.Positive): ptr T {.inline,
                                                                  benign, raises: [].} =
       ## Allocates a new memory block on the shared heap with at
-      ## least ``T.sizeof * size`` bytes.
+      ## least ``T.sizeof * size`` bytes
       ##
       ## The block has to be freed with
       ## `resizeShared(block, 0) <#resizeShared,ptr.T,Natural>`_ or
@@ -2504,7 +2508,9 @@ when not defined(nimscript):
 
     proc allocShared0*(size: Natural, align = MemAlign): pointer {.noconv, rtl, benign, raises: [].}
       ## Allocates a new memory block on the shared heap with at
-      ## least ``size`` bytes.
+      ## least ``size`` byte  and alignment `align`. `align` must be power of two.
+      ## It is adviced to use `createSharedU` instead as it handles alignment
+      ## automatically.
       ##
       ## The block has to be freed with
       ## `reallocShared(block, 0) <#reallocShared,pointer,Natural>`_
@@ -2513,7 +2519,7 @@ when not defined(nimscript):
       ## The block is initialized with all bytes
       ## containing zero, so it is somewhat safer than
       ## `allocShared <#allocShared,Natural>`_.
-    proc createShared*(T: typedesc, size = 1.Positive, align = MemAlign): ptr T {.inline.} =
+    proc createShared*(T: typedesc, size = 1.Positive): ptr T {.inline.} =
       ## Allocates a new memory block on the shared heap with at
       ## least ``T.sizeof * size`` bytes.
       ##
@@ -2524,15 +2530,15 @@ when not defined(nimscript):
       ## The block is initialized with all bytes
       ## containing zero, so it is somewhat safer than
       ## `createSharedU <#createSharedU,typedesc>`_.
-      cast[ptr T](allocShared0(T.sizeof * size))
+      cast[ptr T](allocShared0(T.sizeof * size, T.alignOf))
 
     proc reallocShared*(p: pointer, newSize: Natural, align = MemAlign): pointer {.noconv, rtl,
                                                                  benign, raises: [].}
       ## Grows or shrinks a given memory block on the heap.
       ##
       ## If `p` is **nil** then a new memory block is returned with alignment `align`
-      ## In either way the block has at least ``newSize`` bytes.
-      ## If ``newSize == 0`` and `p` is not **nil** ``reallocShared`` calls
+      ## In either way the block has at least ``newSize`` bytes. align` must be a power
+      ## of two. If ``newSize == 0`` and `p` is not **nil** ``reallocShared`` calls
       ## ``deallocShared(p)``.
       ## In other cases the block has to be freed with
       ## `deallocShared <#deallocShared,pointer>`_.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2387,8 +2387,8 @@ when not defined(nimscript):
 
     proc alloc*(size: Natural, align = MemAlign): pointer {.noconv, rtl, tags: [], benign, raises: [].}
       ## Allocates a new memory block with at least ``size`` bytes and alignment `align`.
-      ## `align` must be power of two. It is adviced to use `createU` instead as
-      ## it handles alignment automatically.
+      ## `align` must be power of two. It is adviced to use `createU` as it handles 
+      ## alignment automatically.
       ##
       ## The block has to be freed with `realloc(block, 0) <#realloc,pointer,Natural>`_
       ## or `dealloc(block) <#dealloc,pointer>`_.
@@ -2417,8 +2417,8 @@ when not defined(nimscript):
 
     proc alloc0*(size: Natural, align = MemAlign): pointer {.noconv, rtl, tags: [], benign, raises: [].}
       ## Allocates a new memory block with at least ``size`` bytes and alignment `align`.
-      ## `align` must be power of two. It is adviced to use `create` instead as
-      ## it handles alignment automatically.
+      ## `align` must be power of two. It is adviced to use `create` as it handles 
+      ## alignment automatically.
       ##
       ## The block has to be freed with `realloc(block, 0) <#realloc,pointer,Natural>`_
       ## or `dealloc(block) <#dealloc,pointer>`_.
@@ -2447,6 +2447,7 @@ when not defined(nimscript):
       ## In either way the block has at least ``newSize`` bytes. `align` must be a power
       ## of two. If ``newSize == 0`` and `p` is not **nil** ``realloc`` calls ``dealloc(p)``.
       ## In other cases the block has to be freed with `dealloc(block) <#dealloc,pointer>`_.
+      ## It is adviced to use `resize` as it handles alignment automatically. 
       ##
       ## The allocated memory belongs to its allocating thread!
       ## Use `reallocShared <#reallocShared,pointer,Natural>`_ to reallocate
@@ -2479,7 +2480,7 @@ when not defined(nimscript):
     proc allocShared*(size: Natural, align = MemAlign): pointer {.noconv, rtl, benign, raises: [].}
       ## Allocates a new memory block on the shared heap with at
       ## least ``size`` bytes and alignment `align`. `align` must be power of two.
-      ## It is adviced to use `createSharedU` instead as it handles alignment automatically.
+      ## It is adviced to use `createSharedU` as it handles alignment automatically.
       ##
       ## The block has to be freed with
       ## `reallocShared(block, 0) <#reallocShared,pointer,Natural>`_
@@ -2509,7 +2510,7 @@ when not defined(nimscript):
     proc allocShared0*(size: Natural, align = MemAlign): pointer {.noconv, rtl, benign, raises: [].}
       ## Allocates a new memory block on the shared heap with at
       ## least ``size`` byte  and alignment `align`. `align` must be power of two.
-      ## It is adviced to use `createSharedU` instead as it handles alignment
+      ## It is adviced to use `createShared` as it handles alignment
       ## automatically.
       ##
       ## The block has to be freed with

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -426,7 +426,7 @@ proc isCell(p: pointer): bool {.inline.} =
 
 proc smallChunkIndex(size, alignment: int): int {.inline.} =
   const baseShift = msbit(MinAlignment)
-  size div MinAlignment + msbit((alignment shr baseShift).uint32)
+  (size div MinAlignment) * Alignments + msbit((alignment shr baseShift).uint32)
 
 # ------------- chunk management ----------------------------------------------
 proc pageIndex(c: PChunk): int {.inline.} =
@@ -907,7 +907,7 @@ proc interiorAllocatedPtr(a: MemRegion, p: pointer): pointer =
       if avlNode != nil:
         var k = cast[pointer](avlNode.key)
         var c = cast[PBigChunk](pageAddr(k))
-        sysAssert(addr(c.data) == k, " k is not the same as addr(c.data)!")
+        sysAssert(align(addr c.data, c.alignment) == k, " k is not the same as addr(c.data)!")
         if cast[ptr FreeCell](k).zeroField >% 1:
           result = k
           sysAssert isAllocatedPtr(a, result), " result wrong pointer! 1"

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -409,7 +409,7 @@ proc rawNewObj(typ: PNimType, size: int, gch: var GcHeap): pointer =
   sysAssert(allocInv(gch.region), "rawNewObj begin")
   gcAssert(typ.kind in {tyRef, tyString, tySequence}, "newObj: 1")
   collectCT(gch)
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell)))
+  var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, size + sizeof(Cell), MemAlign, sizeof(Cell)))
   #gcAssert typ.kind in {tyString, tySequence} or size >= typ.base.size, "size too small"
   gcAssert((cast[ByteAddress](res) and (MemAlign-1)) == 0, "newObj: 2")
   # now it is buffered in the ZCT
@@ -457,7 +457,7 @@ proc newObjRC1(typ: PNimType, size: int): pointer {.compilerRtl.} =
   collectCT(gch)
   sysAssert(allocInv(gch.region), "newObjRC1 after collectCT")
 
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell)))
+  var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, size + sizeof(Cell), MemAlign, sizeof(Cell)))
   sysAssert(allocInv(gch.region), "newObjRC1 after rawAlloc")
   sysAssert((cast[ByteAddress](res) and (MemAlign-1)) == 0, "newObj: 2")
   # now it is buffered in the ZCT
@@ -490,7 +490,7 @@ proc growObj(old: pointer, newsize: int, gch: var GcHeap): pointer =
   gcAssert(ol.typ.kind in {tyString, tySequence}, "growObj: 2")
   sysAssert(allocInv(gch.region), "growObj begin")
 
-  var res = cast[PCell](rawAlloc(gch.region, newsize + sizeof(Cell)))
+  var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, newsize + sizeof(Cell), MemAlign, sizeof(Cell)))
   var elemSize = 1
   if ol.typ.kind != tyString: elemSize = ol.typ.base.size
   incTypeSize ol.typ, newsize

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -327,7 +327,7 @@ proc rawNewObj(typ: PNimType, size: int, gch: var GcHeap): pointer =
   sysAssert(allocInv(gch.region), "rawNewObj begin")
   gcAssert(typ.kind in {tyRef, tyString, tySequence}, "newObj: 1")
   collectCT(gch)
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell)))
+  var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, size + sizeof(Cell), MemAlign, sizeof(Cell)))
   gcAssert((cast[ByteAddress](res) and (MemAlign-1)) == 0, "newObj: 2")
   # now it is buffered in the ZCT
   res.typ = typ
@@ -377,7 +377,7 @@ proc growObj(old: pointer, newsize: int, gch: var GcHeap): pointer =
   sysAssert(ol.typ != nil, "growObj: 1")
   gcAssert(ol.typ.kind in {tyString, tySequence}, "growObj: 2")
 
-  var res = cast[PCell](rawAlloc(gch.region, newsize + sizeof(Cell)))
+  var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, newsize + sizeof(Cell), MemAlign, sizeof(Cell)))
   var elemSize = 1
   if ol.typ.kind != tyString: elemSize = ol.typ.base.size
   incTypeSize ol.typ, newsize

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -268,7 +268,7 @@ proc rawNewObj(typ: PNimType, size: int, gch: var GcHeap): pointer =
   incTypeSize typ, size
   gcAssert(typ.kind in {tyRef, tyString, tySequence}, "newObj: 1")
   collectCT(gch, size + sizeof(Cell))
-  var res = cast[PCell](rawAlloc(gch.region, size + sizeof(Cell)))
+  var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, size + sizeof(Cell), MemAlign, sizeof(Cell)))
   gcAssert((cast[ByteAddress](res) and (MemAlign-1)) == 0, "newObj: 2")
   # now it is buffered in the ZCT
   res.typ = typ
@@ -326,7 +326,7 @@ when not defined(nimSeqsV2):
     sysAssert(ol.typ != nil, "growObj: 1")
     gcAssert(ol.typ.kind in {tyString, tySequence}, "growObj: 2")
 
-    var res = cast[PCell](rawAlloc(gch.region, newsize + sizeof(Cell)))
+    var res = cast[PCell](rawAllocAlignedAtOffset(gch.region, newsize + sizeof(Cell), MemAlign, sizeof(Cell)))
     var elemSize = 1
     if ol.typ.kind != tyString: elemSize = ol.typ.base.size
     incTypeSize ol.typ, newsize

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -46,8 +46,6 @@ const
   PageSize = 1 shl PageShift
   PageMask = PageSize-1
 
-  MemAlign = 8 # also minimal allocatable memory block
-
   BitsPerPage = PageSize div MemAlign
   UnitsPerPage = BitsPerPage div (sizeof(int)*8)
     # how many ints do we need to describe a page:

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -205,9 +205,9 @@ when emulatedThreadVars:
   proc nimThreadVarsSize(): int {.noconv, importc: "NimThreadVarsSize".}
 
 # we preallocate a fixed size for thread local storage, so that no heap
-# allocations are needed. Currently less than 16K are used on a 64bit machine.
+# allocations are needed. Currently less than 24K are used on a 64bit machine.
 # We use ``float`` for proper alignment:
-const nimTlsSize {.intdefine.} = 16000
+const nimTlsSize {.intdefine.} = 24000
 type
   ThreadLocalStorage = array[0..(nimTlsSize div sizeof(float)), float]
   PGcThread = ptr GcThread


### PR DESCRIPTION
Alignment is no longer a fixed number. MinAlignment is now 4 bytes.
`create(int32)` now allocates 25% less memory than `create(int64)` thanks to the alignment information. It is not 50% less because of `FreeCell` overhead which hasn't changed.
We can go to 1 byte MinAlignment if someone find it useful, but at expense of larger `MemRegion`  object.

This PR on its own is not very useful because user have to provide alignment information.
This is where PR https://github.com/nim-lang/Nim/pull/12430 comes to play. It provides automatic flow of alignment information so we will always allocate the right amount. You safe memory if your alignment requirement is lower than 8 bytes and don't crash if your alignment requirement is higher than 8 bytes.
