### PR TITLE
Fix #12785

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -490,12 +490,12 @@ iterator fieldValuePairs(n: PNode): tuple[memberSym, valueSym: PNode] =
         let memberSym = identDefs[i]
         yield((memberSym: memberSym, valueSym: valueSym))
 
-proc genComputedGoto(p: BProc; nAsIs: PNode) =
+proc genComputedGoto(p: BProc; n: PNode) =
   # first pass: Generate array of computed labels:
 
   # flatten the loop body because otherwise let and var sections
   # wrapped inside stmt lists by inject destructors won't be recognised
-  let n = nAsIs.flattenStmts()
+  let n = n.flattenStmts()
   var casePos = -1
   var arraySize: int
   for i in 0..<n.len:

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -490,8 +490,12 @@ iterator fieldValuePairs(n: PNode): tuple[memberSym, valueSym: PNode] =
         let memberSym = identDefs[i]
         yield((memberSym: memberSym, valueSym: valueSym))
 
-proc genComputedGoto(p: BProc; n: PNode) =
+proc genComputedGoto(p: BProc; nAsIs: PNode) =
   # first pass: Generate array of computed labels:
+
+  # flatten the loop body because otherwise let and var sections
+  # wrapped inside stmt lists by inject destructors won't be recognised
+  let n = nAsIs.flattenStmts()
   var casePos = -1
   var arraySize: int
   for i in 0..<n.len:

--- a/tests/casestmt/t12785.nim
+++ b/tests/casestmt/t12785.nim
@@ -1,0 +1,47 @@
+discard """
+  cmd: '''nim c --newruntime $file'''
+  output: '''copied
+copied
+2
+copied
+copied
+2
+destroyed
+destroyed'''
+"""
+
+type
+  ObjWithDestructor = object
+    a: int
+proc `=destroy`(self: var ObjWithDestructor) =
+  echo "destroyed"
+
+proc `=`(self: var ObjWithDestructor, other: ObjWithDestructor) =
+  echo "copied"
+
+proc test(a: range[0..1], arg: ObjWithDestructor) =
+  var iteration = 0
+  while true:
+    {.computedGoto.}
+
+    let
+      b = int(a) * 2
+      c = a
+      d = arg
+      e = arg
+
+    discard c
+    discard d
+    discard e
+
+    inc iteration
+
+    case a
+    of 0:  
+        assert false
+    of 1:      
+      echo b
+      if iteration == 2:
+        break
+
+test(1, ObjWithDestructor())


### PR DESCRIPTION
As discussed on IRC, all let and var sections processed by inject destructors are put into stmt lists, which the [code generating computedGoto can't handle](https://github.com/nim-lang/Nim/blob/devel/compiler/ccgstmts.nim#L555), leading to #12785 
It's not super clean, but the least invasive solution I came up with.