### PR TITLE
case coverage error message for `char`

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -953,7 +953,7 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
   if chckCovered:
     if covered == toCover(c, n[0].typ):
       hasElse = true
-    elif n[0].typ.skipTypes(abstractRange).kind == tyEnum:
+    elif n[0].typ.skipTypes(abstractRange).kind in {tyEnum, tyChar}:
       localError(c.config, n.info, "not all cases are covered; missing: $1" %
                  formatMissingEnums(c, n))
     else:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -607,7 +607,7 @@ iterator processBranchVals(b: PNode): int =
   assert b.kind in {nkOfBranch, nkElifBranch, nkElse}
   if b.kind == nkOfBranch:
     for i in 0..<b.len-1:
-      if b[i].kind == nkIntLit:
+      if b[i].kind in {nkIntLit, nkCharLit}:
         yield b[i].intVal.int
       elif b[i].kind == nkRange:
         for i in b[i][0].intVal..b[i][1].intVal:
@@ -621,9 +621,12 @@ proc renderAsType(vals: IntSet, t: PType): string =
   for val in vals:
     if result.len > 1:
       result &= ", "
-    if t.kind in {tyEnum, tyBool}:
+    case t.kind:
+    of tyEnum, tyBool:
       while t.n[enumSymOffset].sym.position < val: inc(enumSymOffset)
       result &= t.n[enumSymOffset].sym.name.s
+    of tyChar:
+      result.addQuoted(char(val))
     else:
       if i == 64:
         result &= "omitted $1 values..." % $(vals.len - i)

--- a/tests/casestmt/tincompletecaseobject2.nim
+++ b/tests/casestmt/tincompletecaseobject2.nim
@@ -2,9 +2,10 @@ discard """
 cmd: "nim check $file"
 errormsg: "not all cases are covered; missing: {A, B}"
 nimout: '''
-tincompletecaseobject2.nim(16, 1) Error: not all cases are covered; missing: {B, C, D}
-tincompletecaseobject2.nim(19, 1) Error: not all cases are covered; missing: {A, C}
-tincompletecaseobject2.nim(22, 1) Error: not all cases are covered; missing: {A, B}
+tincompletecaseobject2.nim(18, 1) Error: not all cases are covered; missing: {' ', '!', '\"', '#', '$', '%', '&', '\'', '*', '+', ',', '-', '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '^', '_', '`', '{', '|', '}', '~'}
+tincompletecaseobject2.nim(22, 1) Error: not all cases are covered; missing: {B, C, D}
+tincompletecaseobject2.nim(25, 1) Error: not all cases are covered; missing: {A, C}
+tincompletecaseobject2.nim(28, 1) Error: not all cases are covered; missing: {A, B}
 '''
 """
 type
@@ -12,6 +13,11 @@ type
   AliasABCD = ABCD
   RangeABC = range[A .. C]
   AliasRangeABC = RangeABC
+  PrintableChars = range[' ' .. '~']
+
+case PrintableChars 'x':
+of '0'..'9', 'A'..'Z', 'a'..'z': discard
+of '(', ')': discard
 
 case AliasABCD A:
 of A: discard


### PR DESCRIPTION
I find this useful but may be too verbose for others given that half `char` values are represented as hex literals.
opinions?