### PR TITLE
Added fix for handling TaintedStrings in streams and httpclient

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -367,7 +367,7 @@ proc addFiles*(p: var MultipartData, xs: openArray[tuple[name, file: string]]):
     let (_, fName, ext) = splitFile(file)
     if ext.len > 0:
       contentType = m.getMimetype(ext[1..ext.high], "")
-    p.add(name, readFile(file), fName & ext, contentType)
+    p.add(name, readFile(file).string, fName & ext, contentType)
   result = p
 
 proc `[]=`*(p: var MultipartData, name, content: string) =
@@ -633,7 +633,7 @@ proc parseChunks(client: HttpClient | AsyncHttpClient): Future[void]
                  {.multisync.} =
   while true:
     var chunkSize = 0
-    var chunkSizeStr = await client.socket.recvLine()
+    var chunkSizeStr = (await client.socket.recvLine()).string
     var i = 0
     if chunkSizeStr == "":
       httpError("Server terminated connection prematurely")
@@ -733,9 +733,9 @@ proc parseResponse(client: HttpClient | AsyncHttpClient,
   while true:
     linei = 0
     when client is HttpClient:
-      line = await client.socket.recvLine(client.timeout)
+      line = (await client.socket.recvLine(client.timeout)).string
     else:
-      line = await client.socket.recvLine()
+      line = (await client.socket.recvLine()).string
     if line == "":
       # We've been disconnected.
       client.close()

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -901,7 +901,10 @@ proc readLine*(s: Stream, line: var TaintedString): bool =
   else:
     # fallback
     when nimvm: #Bug #12282
-      line.setLen(0)
+      when taintMode:
+        line.string.setLen(0)
+      else:
+        line.setLen(0)
     else:
       line.string.setLen(0)
     while true:
@@ -914,7 +917,10 @@ proc readLine*(s: Stream, line: var TaintedString): bool =
         if line.len > 0: break
         else: return false
       when nimvm: #Bug #12282
-        line.add(c)
+        when taintMode:
+          line.string.add(c)
+        else:
+          line.add(c)
       else:
         line.string.add(c)
     result = true

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -96,6 +96,8 @@
 
 include "system/inclrtl"
 
+const taintMode = compileOption("taintmode")
+
 proc newEIO(msg: string): owned(ref IOError) =
   new(result)
   result.msg = msg

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1979,7 +1979,7 @@ proc compileOption*(option, arg: string): bool {.
 const
   hasThreadSupport = compileOption("threads") and not defined(nimscript)
   hasSharedHeap = defined(boehmgc) or defined(gogc) # don't share heaps; every thread has its own
-  taintMode = compileOption("taintmode")
+  taintMode* = compileOption("taintmode")
   nimEnableCovariance* = defined(nimEnableCovariance) # or true
 
 when hasThreadSupport and defined(tcc) and not compileOption("tlsEmulation"):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1979,7 +1979,7 @@ proc compileOption*(option, arg: string): bool {.
 const
   hasThreadSupport = compileOption("threads") and not defined(nimscript)
   hasSharedHeap = defined(boehmgc) or defined(gogc) # don't share heaps; every thread has its own
-  taintMode* = compileOption("taintmode")
+  taintMode = compileOption("taintmode")
   nimEnableCovariance* = defined(nimEnableCovariance) # or true
 
 when hasThreadSupport and defined(tcc) and not compileOption("tlsEmulation"):


### PR DESCRIPTION
Also addresses (or attempts to address) #12968, but I'm not sure if splitting the `nimvm` branch further with `taintMode` is the correct way to go. I'd appreciate feedback on this. Thanks in advance!