### PR TITLE
Allow customize Host header in httpclient

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -450,10 +450,11 @@ proc generateHeaders(requestUrl: Uri, httpMethod: string,
   result.add(" HTTP/1.1\c\L")
 
   # Host header.
-  if requestUrl.port == "":
-    add(result, "Host: " & requestUrl.hostname & "\c\L")
-  else:
-    add(result, "Host: " & requestUrl.hostname & ":" & requestUrl.port & "\c\L")
+  if not headers.hasKey("Host"):
+    if requestUrl.port == "":
+      add(result, "Host: " & requestUrl.hostname & "\c\L")
+    else:
+      add(result, "Host: " & requestUrl.hostname & ":" & requestUrl.port & "\c\L")
 
   # Connection header.
   if not headers.hasKey("Connection"):


### PR DESCRIPTION
The request hostname do not necessarily equal to Host http header. Current logic do not allow customzie Host header, but always append another, even there is one supplied.