### PR TITLE
fix #12985 {.push.} now does not apply to generic instantiations

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1168,7 +1168,7 @@ proc implicitPragmas*(c: PContext, sym: PSym, n: PNode,
   if sym != nil and sym.kind != skModule:
     for it in c.optionStack:
       let o = it.otherPragmas
-      if not o.isNil:
+      if not o.isNil and sfFromGeneric notin sym.flags: # see issue #12985
         pushInfoContext(c.config, n.info)
         var i = 0
         while i < o.len:


### PR DESCRIPTION
* fix #12985