### PR TITLE
c_fflush() the rawWrite() buffer

### DIFF
--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -142,8 +142,12 @@ proc c_realloc*(p: pointer, newsize: csize_t): pointer {.
 proc c_fwrite*(buf: pointer, size, n: csize_t, f: CFilePtr): cint {.
   importc: "fwrite", header: "<stdio.h>".}
 
+proc c_fflush(f: CFilePtr): cint {.
+  importc: "fflush", header: "<stdio.h>".}
+
 proc rawWrite*(f: CFilePtr, s: cstring) {.compilerproc, nonReloadable, inline.} =
   # we cannot throw an exception here!
   discard c_fwrite(s, 1, cast[csize_t](s.len), f)
+  discard c_fflush(f)
 
 {.pop.}


### PR DESCRIPTION
Stack traces on an unbuffered stderr get out of sync with line-buffered
stdout - usually on Windows terminals or CI logs. This fixes it by
calling C's fflush() on the output buffer in the procedure used for
printing stack traces.