### PR TITLE
fix #12996

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3562,6 +3562,13 @@ const
   NimVersion*: string = $NimMajor & "." & $NimMinor & "." & $NimPatch
     ## is the version of Nim as a string.
 
+template since*(version, body: untyped) {.dirty.} =
+  ## Enable `body` when nim >= `version`
+  ##
+  ## .. code-block:: Nim
+  ##   proc foo*() {.since: (1, 1).} = discard
+  when version <= (NimMajor, NimMinor):
+    body
 
 type
   FileSeekPos* = enum ## Position relative to which seek should happen.

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -48,7 +48,3 @@ when defined(nimlocks):
   {.pragma: benign, gcsafe, locks: 0.}
 else:
   {.pragma: benign, gcsafe.}
-
-template since(version, body: untyped) {.dirty.} =
-  when version <= (NimMajor, NimMinor):
-    body


### PR DESCRIPTION
* fix #12996
* the alternative is to add `include "system/inclrtl"` (even for nim js) to strtabs.nim but IMO since does not belong in inclrtl:
```
# Pragmas for RTL generation. Has to be an include, because user-defined
# pragmas cannot be exported.
```
