### PR TITLE
Sink to MemMove optimization in injectdestructors

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -612,11 +612,8 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
 proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
   case ri.kind
   of nkCallKinds:
-    if isUnpackedTuple(dest):
-      result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
-    else:
-      result = genSink(c, dest, ri)
-      result.add p(ri, c, consumed)
+    result = genSink(c, dest, ri)
+    result.add p(ri, c, consumed)
   of nkBracketExpr:
     if isUnpackedTuple(ri[0]):
       # unpacking of tuple: take over elements

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -212,6 +212,11 @@ proc genSink(c: Con; dest, ri: PNode): PNode =
     # we generate a fast assignment in this case:
     result = newTree(nkFastAsgn, dest)
 
+proc genSinkOrMemMove(c: Con; dest, ri: PNode, isFirstWrite: bool): PNode =
+  # optimize sink call into a bitwise mem
+  if isFirstWrite: newTree(nkFastAsgn, dest)
+  else: genSink(c, dest, ri)
+
 proc genCopyNoCheck(c: Con; dest, ri: PNode): PNode =
   let t = dest.typ.skipTypes({tyGenericInst, tyAlias, tySink})
   result = genOp(c, t, attachedAsgn, dest, ri)
@@ -284,7 +289,7 @@ type
     sinkArg
 
 proc p(n: PNode; c: var Con; mode: ProcessMode): PNode
-proc moveOrCopy(dest, ri: PNode; c: var Con): PNode
+proc moveOrCopy(dest, ri: PNode; c: var Con, isFirstWrite = false): PNode
 
 proc isClosureEnv(n: PNode): bool = n.kind == nkSym and n.sym.name.s[0] == ':'
 
@@ -547,7 +552,7 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
             if ri.kind == nkEmpty and c.inLoop > 0:
               ri = genDefaultCall(v.typ, c, v.info)
             if ri.kind != nkEmpty:
-              let r = moveOrCopy(v, ri, c)
+              let r = moveOrCopy(v, ri, c, isFirstWrite = (c.inLoop == 0))
               result.add r
         else: # keep the var but transform 'ri':
           var v = copyNode(n)
@@ -609,13 +614,13 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
       for i in 0..<n.len:
         result[i] = p(n[i], c, mode)
 
-proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
+proc moveOrCopy(dest, ri: PNode; c: var Con, isFirstWrite = false): PNode =
   case ri.kind
   of nkCallKinds:
     if isUnpackedTuple(dest):
       result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
     else:
-      result = genSink(c, dest, ri)
+      result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       result.add p(ri, c, consumed)
   of nkBracketExpr:
     if isUnpackedTuple(ri[0]):
@@ -623,7 +628,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
       result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
     elif isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c):
       # Rule 3: `=sink`(x, z); wasMoved(z)
-      var snk = genSink(c, dest, ri)
+      var snk = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       snk.add ri
       result = newTree(nkStmtList, snk, genWasMoved(ri, c))
     else:
@@ -634,22 +639,22 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
     if ri.len > 0 and isDangerousSeq(ri.typ):
       result = genCopy(c, dest, ri)
     else:
-      result = genSink(c, dest, ri)
+      result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
     result.add p(ri, c, consumed)
   of nkObjConstr, nkTupleConstr, nkClosure, nkCharLit..nkNilLit:
-    result = genSink(c, dest, ri)
+    result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
     result.add p(ri, c, consumed)
   of nkSym:
     if isSinkParam(ri.sym):
       # Rule 3: `=sink`(x, z); wasMoved(z)
       sinkParamIsLastReadCheck(c, ri)
-      var snk = genSink(c, dest, ri)
+      var snk = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       snk.add ri
       result = newTree(nkStmtList, snk, genWasMoved(ri, c))
     elif ri.sym.kind != skParam and ri.sym.owner == c.owner and
         isLastRead(ri, c) and canBeMoved(c, dest.typ):
       # Rule 3: `=sink`(x, z); wasMoved(z)
-      var snk = genSink(c, dest, ri)
+      var snk = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       snk.add ri
       result = newTree(nkStmtList, snk, genWasMoved(ri, c))
     else:
@@ -663,7 +668,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
         copyRi[1] = result[^1]
         result[^1] = copyRi
     else:
-      result = genSink(c, dest, ri)
+      result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       result.add p(ri, c, sinkArg)
   of nkObjDownConv, nkObjUpConv:
     when false:
@@ -672,7 +677,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
       copyRi[0] = result[^1]
       result[^1] = copyRi
     else:
-      result = genSink(c, dest, ri)
+      result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       result.add p(ri, c, sinkArg)
   of nkStmtListExpr, nkBlockExpr, nkIfExpr, nkCaseStmt:
     handleNested(ri): moveOrCopy(dest, node, c)
@@ -680,7 +685,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
     if isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c) and
         canBeMoved(c, dest.typ):
       # Rule 3: `=sink`(x, z); wasMoved(z)
-      var snk = genSink(c, dest, ri)
+      var snk = genSinkOrMemMove(c, dest, ri, isFirstWrite)
       snk.add ri
       result = newTree(nkStmtList, snk, genWasMoved(ri, c))
     else:

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -213,7 +213,7 @@ proc genSink(c: Con; dest, ri: PNode): PNode =
     result = newTree(nkFastAsgn, dest)
 
 proc genSinkOrMemMove(c: Con; dest, ri: PNode, isFirstWrite: bool): PNode =
-  # optimize sink call into a bitwise mem
+  # optimize sink call into a bitwise memcopy
   if isFirstWrite: newTree(nkFastAsgn, dest)
   else: genSink(c, dest, ri)
 

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -617,8 +617,11 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
 proc moveOrCopy(dest, ri: PNode; c: var Con, isFirstWrite: bool): PNode =
   case ri.kind
   of nkCallKinds:
-    result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
-    result.add p(ri, c, consumed)
+    if isUnpackedTuple(dest):
+      result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
+    else:
+      result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
+      result.add p(ri, c, consumed)
   of nkBracketExpr:
     if isUnpackedTuple(ri[0]):
       # unpacking of tuple: take over elements

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -617,11 +617,8 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
 proc moveOrCopy(dest, ri: PNode; c: var Con, isFirstWrite = false): PNode =
   case ri.kind
   of nkCallKinds:
-    if isUnpackedTuple(dest):
-      result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
-    else:
-      result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
-      result.add p(ri, c, consumed)
+    result = genSinkOrMemMove(c, dest, ri, isFirstWrite)
+    result.add p(ri, c, consumed)
   of nkBracketExpr:
     if isUnpackedTuple(ri[0]):
       # unpacking of tuple: take over elements

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -612,8 +612,11 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
 proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
   case ri.kind
   of nkCallKinds:
-    result = genSink(c, dest, ri)
-    result.add p(ri, c, consumed)
+    if isUnpackedTuple(dest):
+      result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
+    else:
+      result = genSink(c, dest, ri)
+      result.add p(ri, c, consumed)
   of nkBracketExpr:
     if isUnpackedTuple(ri[0]):
       # unpacking of tuple: take over elements

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -133,10 +133,10 @@ proc initialized(code: ControlFlowGraph; pc: int,
       inc pc
   return pc
 
-template isUnpackedTuple(s: PSym): bool =
+template isUnpackedTuple(n: PNode): bool =
   ## we move out all elements of unpacked tuples,
   ## hence unpacked tuples themselves don't need to be destroyed
-  s.kind == skTemp and s.typ.kind == tyTuple
+  n.kind == nkSym and n.sym.kind == skTemp and n.sym.typ.kind == tyTuple
 
 proc checkForErrorPragma(c: Con; t: PType; ri: PNode; opname: string) =
   var m = "'" & opname & "' is not available for type <" & typeToString(t) & ">"
@@ -542,7 +542,7 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
               # move the variable declaration to the top of the frame:
               c.addTopVar v
               # make sure it's destroyed at the end of the proc:
-              if not isUnpackedTuple(it[0].sym):
+              if not isUnpackedTuple(v):
                 c.destroys.add genDestroy(c, v)
             if ri.kind == nkEmpty and c.inLoop > 0:
               ri = genDefaultCall(v.typ, c, v.info)
@@ -612,10 +612,13 @@ proc p(n: PNode; c: var Con; mode: ProcessMode): PNode =
 proc moveOrCopy(dest, ri: PNode; c: var Con): PNode =
   case ri.kind
   of nkCallKinds:
-    result = genSink(c, dest, ri)
-    result.add p(ri, c, consumed)
+    if isUnpackedTuple(dest):
+      result = newTree(nkFastAsgn, dest, p(ri, c, consumed))
+    else:
+      result = genSink(c, dest, ri)
+      result.add p(ri, c, consumed)
   of nkBracketExpr:
-    if ri[0].kind == nkSym and isUnpackedTuple(ri[0].sym):
+    if isUnpackedTuple(ri[0]):
       # unpacking of tuple: move out the elements
       result = genSink(c, dest, ri)
       result.add p(ri, c, consumed)

--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -253,13 +253,6 @@ proc considerUserDefinedOp(c: var TLiftCtx; t: PType; body, x, y: PNode): bool =
       body.add newDeepCopyCall(op, x, y)
       result = true
 
-proc addVar(father, v, value: PNode) =
-  var vpart = newNodeI(nkIdentDefs, v.info, 3)
-  vpart[0] = v
-  vpart[1] = newNodeI(nkEmpty, v.info)
-  vpart[2] = value
-  father.add vpart
-
 proc declareCounter(c: var TLiftCtx; body: PNode; first: BiggestInt): PNode =
   var temp = newSym(skTemp, getIdent(c.g.cache, lowerings.genPrefix), c.fn, c.info)
   temp.typ = getSysType(c.g, body.info, tyInt)

--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -60,7 +60,6 @@ proc lowerTupleUnpacking*(g: ModuleGraph; n: PNode; owner: PSym): PNode =
   var temp = newSym(skTemp, getIdent(g.cache, genPrefix), owner, value.info, g.config.options)
   temp.typ = skipTypes(value.typ, abstractInst)
   incl(temp.flags, sfFromGeneric)
-  incl(temp.flags, sfCursor)
 
   var v = newNodeI(nkVarSection, value.info)
   let tempAsNode = newSymNode(temp)

--- a/compiler/lowerings.nim
+++ b/compiler/lowerings.nim
@@ -42,6 +42,13 @@ proc addVar*(father, v: PNode) =
   vpart[2] = vpart[1]
   father.add vpart
 
+proc addVar*(father, v, value: PNode) =
+  var vpart = newNodeI(nkIdentDefs, v.info, 3)
+  vpart[0] = v
+  vpart[1] = newNodeI(nkEmpty, v.info)
+  vpart[2] = value
+  father.add vpart
+
 proc newAsgnStmt*(le, ri: PNode): PNode =
   result = newNodeI(nkAsgn, le.info, 2)
   result[0] = le
@@ -63,10 +70,9 @@ proc lowerTupleUnpacking*(g: ModuleGraph; n: PNode; owner: PSym): PNode =
 
   var v = newNodeI(nkVarSection, value.info)
   let tempAsNode = newSymNode(temp)
-  v.addVar(tempAsNode)
+  v.addVar(tempAsNode, value)
   result.add(v)
 
-  result.add newAsgnStmt(tempAsNode, value)
   for i in 0..<n.len-2:
     if n[i].kind == nkSym: v.addVar(n[i])
     result.add newAsgnStmt(n[i], newTupleAccess(g, tempAsNode, i))

--- a/tests/destructor/t12037.nim
+++ b/tests/destructor/t12037.nim
@@ -23,3 +23,12 @@ test()
 import tables
 var t = initTable[string, seq[ptr int]]()
 discard t.hasKeyOrPut("f1", @[])
+
+
+#############################################
+### bug #12989
+proc bug(start: (seq[int], int)) =
+  let (s, i) = start
+
+let input = @[0]
+bug((input, 0))

--- a/tests/destructor/t12037.nim
+++ b/tests/destructor/t12037.nim
@@ -32,4 +32,3 @@ proc bug(start: (seq[int], int)) =
 
 let input = @[0]
 bug((input, 0))
-doASsert(input.len == 1)

--- a/tests/destructor/t12037.nim
+++ b/tests/destructor/t12037.nim
@@ -32,3 +32,4 @@ proc bug(start: (seq[int], int)) =
 
 let input = @[0]
 bug((input, 0))
+doASsert(input.len == 1)

--- a/tests/destructor/tmisc_destructors.nim
+++ b/tests/destructor/tmisc_destructors.nim
@@ -28,7 +28,7 @@ proc test(): auto =
 var (a, b, _) = test()
 
 doAssert assign_counter == 0
-doAssert sink_counter == 9 # XXX this is still silly and needs to be investigated
+doAssert sink_counter == 6
 
 # bug #11510
 proc main =

--- a/tests/destructor/tmisc_destructors.nim
+++ b/tests/destructor/tmisc_destructors.nim
@@ -28,7 +28,7 @@ proc test(): auto =
 var (a, b, _) = test()
 
 doAssert assign_counter == 0
-doAssert sink_counter == 6
+doAssert sink_counter == 3
 
 # bug #11510
 proc main =


### PR DESCRIPTION
While working on PR  https://github.com/nim-lang/Nim/pull/12992 I came up with idea how number of sink calls be significantly reduced. `isFirstWrite` is used to detect if it safe to optimize `=sink` calls to bitwise `memmove` calls. So far  `isFirstWrite`  is true if it is `let x = ..` or `var y = ...` outside of the loop, but further PRs can potentially use control flow graph to optimize assignments as well. In similar fashion as we have `isLastRead` we also will need `isFirstWrite` to make it happen.

This PR contains all changes of https://github.com/nim-lang/Nim/pull/12992. As I used it as a starting point.

