### PR TITLE
Add checkError parameter to os.walkDir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,9 @@
 
 - Added `os.normalizePathEnd` for additional path sanitization.
 
+- Added `checkError` parameter to `os.walkDir`. If it is true, raises `OSError`
+  when `dir` cannot be open.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/changelog.md
+++ b/changelog.md
@@ -53,8 +53,8 @@
 
 - Added `os.normalizePathEnd` for additional path sanitization.
 
-- Added `checkError` parameter to `os.walkDir`. If it is true, raises `OSError`
-  when `dir` cannot be open.
+- Added `checkError` parameter to `os.walkDir` and `os.walkDirRec`.
+  If it is true, raises `OSError` when `dir` cannot be open.
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -51,10 +51,9 @@
   and `typetraits.get` to get the ith element of a type tuple.
 - Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
 
-- Added `os.normalizePathEnd` for additional path sanitization.
-
-- Added `checkError` parameter to `os.walkDir` and `os.walkDirRec`.
-  If it is true, raises `OSError` when `dir` cannot be open.
+- Added `checkError` parameter to `os.walkPattern`, `os.walkFiles`,
+  `os.walkDirs`, `os.walkDir` and `os.walkDirRec`. If it is true, raises
+  `OSError` in case of an error.
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,8 @@
   and `typetraits.get` to get the ith element of a type tuple.
 - Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
 
+- Added `os.normalizePathEnd` for additional path sanitization.
+
 - Added `checkError` parameter to `os.walkPattern`, `os.walkFiles`,
   `os.walkDirs`, `os.walkDir` and `os.walkDirRec`. If it is true, raises
   `OSError` in case of an error.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2076,7 +2076,8 @@ iterator walkDir*(dir: string;
 
 iterator walkDirRec*(dir: string,
                      yieldFilter = {pcFile}, followFilter = {pcDir},
-                     relative = false): string {.tags: [ReadDirEffect].} =
+                     relative = false,
+                     checkError = false): string {.tags: [ReadDirEffect].} =
   ## Recursively walks over the directory `dir` and yields for each file
   ## or directory in `dir`.
   ##
@@ -2105,6 +2106,9 @@ iterator walkDirRec*(dir: string,
   ## ``pcLinkToDir``         follow symbolic links to directories
   ## ---------------------   ---------------------------------------------
   ##
+  ## When `dir` or any directory in `dir` cannot be open, raises `OSError`
+  ## if `checkError` is true, otherwise the error is ignored and yield nothing
+  ## from the directory.
   ##
   ## See also:
   ## * `walkPattern iterator <#walkPattern.i,string>`_
@@ -2115,7 +2119,7 @@ iterator walkDirRec*(dir: string,
   var stack = @[""]
   while stack.len > 0:
     let d = stack.pop()
-    for k, p in walkDir(dir / d, relative = true):
+    for k, p in walkDir(dir / d, relative = true, checkError):
       let rel = d / p
       if k in {pcDir, pcLinkToDir} and k in followFilter:
         stack.add rel

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2036,7 +2036,7 @@ iterator walkDir*(dir: string;
             if errCode == ERROR_NO_MORE_FILES: break
             else: raiseOSError(errCode.OSErrorCode)
       elif checkError:
-        raiseOSError(osLastError())
+        raiseOSError(osLastError(), dir)
     else:
       var d = opendir(dir)
       if d != nil:
@@ -2072,7 +2072,7 @@ iterator walkDir*(dir: string;
               k = getSymlinkFileKind(path)
             yield (k, y)
       elif checkError:
-        raiseOSError(osLastError())
+        raiseOSError(osLastError(), dir)
 
 iterator walkDirRec*(dir: string,
                      yieldFilter = {pcFile}, followFilter = {pcDir},


### PR DESCRIPTION
Fix #10309 without breaking change.
Related to https://forum.nim-lang.org/t/4546

I think this is a better way than #12960.

Sample code:
```nim
import os

let dir = if paramCount() > 0: paramStr(1) else: "."
for kind, path in walkDir(dir, checkError = true):
  echo kind, ": ", path
```

Output on Linux:
```console
colab@67c26b208c9e:~$ ./test aa
/home/colab/Nim/lib/pure/os.nim(2066) test
/home/colab/Nim/lib/pure/includes/oserr.nim(94) raiseOSError
Error: unhandled exception: No such file or directory [OSError]
colab@67c26b208c9e:~$ ./test /root
/home/colab/Nim/lib/pure/os.nim(2066) test
/home/colab/Nim/lib/pure/includes/oserr.nim(94) raiseOSError
Error: unhandled exception: Permission denied [OSError]
```

Output on Windows 8.1:
```console
f:\temp>test.exe c:\aaaaa
f:\project\demotomohiro\Nim\lib\pure\os.nim(2029) test
f:\project\demotomohiro\Nim\lib\pure\includes\oserr.nim(94) raiseOSError
Error: unhandled exception: 指定されたパスが見つかりません。
 [OSError]
```
"指定されたパスが見つかりません。" means "The specified path can not be found.".