### PR TITLE
[superseded] add `.?` operator for optional chaining: allows field access even with nil objects

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -381,3 +381,18 @@ when (NimMajor, NimMinor) >= (1, 1):
         of "bird": "word"
         else: d
     assert z == @["word", "word"]
+
+template `.?`*[T](a: T, b: untyped): untyped =
+  ## obj.?field returns obj.field if obj != nil, else its default value
+  runnableExamples:
+    type Foo = ref object
+      x1: float
+      x2: Foo
+    var x: Foo
+    doAssert x.?x2.?x1 == 0.0
+    doAssert Foo(x1: 1.0).?x1 == 1.0
+
+  if a == nil:
+    default(type(a.b))
+  else:
+    a.b


### PR DESCRIPTION
This PR introduces optional chaining `.?` operator, which is found in other languages (eg, it's ubiquitous in swift, see https://docs.swift.org/swift-book/LanguageGuide/OptionalChaining.html)

very often, when debugging (or other cases), we need to special case field access to make sure a ref/ptr object is not nil, leading to clumsy code, eg:
```nim
type PSym = ref TSym
proc fun(s: PSym, iter: int) =
  var msg: string
  if s != nil:
    msg.add "name:", s.name.s & "kind: " s.kind
  else:
    msg.add "s is nil"
  echo msg & "iter:" & $iter
```

this PR allows much simpler code instead, using a new operator `.?` that allows the LHS to be nil (in which case it returns `default` for the field)

```nim
type PSym = ref TSym
proc fun(s: PSym, iter: int) =
  echo (isnil: s == nil, name: s.?name.?s, kind: s.?kind, iter: iter)
```

## note
using `?.` instead of `.?` would not work as well (see for yourself by modifying this PR and running `nim doc lib/pure/sugar.nim`)

