### PR TITLE
[WIP] exportable pragmas

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -544,6 +544,7 @@ type
 
   TSymKind* = enum        # the different symbols (start with the prefix sk);
                           # order is important for the documentation generator!
+                          # keep in sync with `NimSymKind`
     skUnknown,            # unknown symbol: used for parsing assembler blocks
                           # and first phase symbol lookup in generics
     skConditional,        # symbol for the preprocessor (may become obsolete)
@@ -575,6 +576,7 @@ type
                           # mean: never)
     skPackage,            # symbol is a package (used for canonicalization)
     skAlias               # an alias (needs to be resolved immediately)
+    skPragma,             # a pragma
   TSymKinds* = set[TSymKind]
 
 const
@@ -985,7 +987,7 @@ const
   PtrLikeKinds*: TTypeKinds = {tyPointer, tyPtr} # for VM
   ExportableSymKinds* = {skVar, skConst, skProc, skFunc, skMethod, skType,
     skIterator,
-    skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias}
+    skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias, skPragma}
   PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
                                       nfDotSetter, nfDotField,
                                       nfIsRef, nfIsPtr, nfPreventCg, nfLL,

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -986,7 +986,7 @@ proc genSection(d: PDoc, kind: TSymKind) =
   const sectionNames: array[skModule..skField, string] = [
     "Imports", "Types", "Vars", "Lets", "Consts", "Vars", "Procs", "Funcs",
     "Methods", "Iterators", "Converters", "Macros", "Templates", "Exports"
-  ]
+  ] # consider adding more, eg for `skPragma`
   if d.section[kind] == nil: return
   var title = sectionNames[kind].rope
   d.section[kind] = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.section"), [

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -68,7 +68,8 @@ proc rawImportSymbol(c: PContext, s, origin: PSym) =
             importPureEnumField(c, e)
   else:
     if s.kind == skConverter: addConverter(c, s)
-    if hasPattern(s): addPattern(c, s)
+    if s.kind == skPragma: strTableAdd(c.userPragmas, s)
+    elif hasPattern(s): addPattern(c, s)
   if s.owner != origin:
     c.exportIndirections.incl((origin.id, s.id))
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -604,9 +604,10 @@ proc processPragma(c: PContext, n: PNode, i: int) =
   elif it.safeLen != 2 or it[0].kind != nkIdent or it[1].kind != nkIdent:
     invalidPragma(c, n)
 
-  var userPragma = newSym(skTemplate, it[1].ident, nil, it.info, c.config.options)
+  var userPragma = newSym(skPragma, it[1].ident, nil, it.info, c.config.options)
   userPragma.ast = newNode(nkPragma, n.info, n.sons[i+1..^1])
   strTableAdd(c.userPragmas, userPragma)
+  strTableAdd(c.currentScope.symbols, userPragma)
 
 proc pragmaRaisesOrTags(c: PContext, n: PNode) =
   proc processExc(c: PContext, x: PNode) =

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -503,7 +503,10 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       template x: untyped = n[i]
       case x.kind
       of nkExprColonExpr:
-        x[0] = semTemplBody(c, x[0])
+        when false:
+          # this would fail with things like:
+          # invalid pragma: hint[ConvFromXtoItselfNotNeeded]: off
+          x[0] = semTemplBody(c, x[0])
         x[1] = semTemplBody(c, x[1])
       of nkIdent:
         x = semTemplBody(c, x)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -498,9 +498,26 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   of nkPostfix:
     result[1] = semTemplBody(c, n[1])
   of nkPragma:
-    for x in n:
-      if x.kind == nkExprColonExpr:
+    var i=0
+    while i < n.len:
+      template x: untyped = n[i]
+      case x.kind
+      of nkExprColonExpr:
+        x[0] = semTemplBody(c, x[0])
         x[1] = semTemplBody(c, x[1])
+      of nkIdent:
+        x = semTemplBody(c, x)
+        if x.kind == nkSym:
+          if x.sym.kind == skPragma:
+            # similar to semCustomPragmaMulti
+            n.sons[i..i] = x.sym.ast.sons # expand user pragma with its content
+          else:
+            # eg: skProc
+            discard
+      else:
+        doAssert false # CHECKME
+      i.inc
+
   of nkBracketExpr:
     result = newNodeI(nkCall, n.info)
     result.add newIdentNode(getIdent(c.c.cache, "[]"), n.info)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -109,13 +109,14 @@ type
 
   TNimTypeKinds* {.deprecated.} = set[NimTypeKind]
   NimSymKind* = enum
+    # keep in sync with ast.TSymKind
     nskUnknown, nskConditional, nskDynLib, nskParam,
     nskGenericParam, nskTemp, nskModule, nskType, nskVar, nskLet,
     nskConst, nskResult,
     nskProc, nskFunc, nskMethod, nskIterator,
     nskConverter, nskMacro, nskTemplate, nskField,
     nskEnumField, nskForVar, nskLabel,
-    nskStub
+    nskStub, nskPackage, nskAlias, nskPragma
 
   TNimSymKinds* {.deprecated.} = set[NimSymKind]
 

--- a/tests/pragmas/mpragma_export.nim
+++ b/tests/pragmas/mpragma_export.nim
@@ -4,8 +4,9 @@ template myfoo4* = {.discardable, myfoo2.}
 template myfoo5 = {. .}
 
 when false:
-  # can't use classical pragma inside template pragma
+  # would require pragma export via https://github.com/nim-lang/Nim/pull/13030
   {.pragma: myfoo0, exportc: "myfoo0_in_c".}
+  export myfoo0
 elif false:
   # can't use non exported template pragma inside exported template pragma
   template myfoo0 = {.exportc: "myfoo0_in_c".}

--- a/tests/pragmas/mpragma_export.nim
+++ b/tests/pragmas/mpragma_export.nim
@@ -15,4 +15,7 @@ else:
 
 template myfoo6* = {.myfoo0, discardable.}
 
+template myfooHijacked* = {.discardable.}
+template myfoo7* = {.myfooHijacked.}
+
 export myfoo5

--- a/tests/pragmas/mpragma_export.nim
+++ b/tests/pragmas/mpragma_export.nim
@@ -1,22 +1,24 @@
+template getExportcName*(): string =
+  ## returns at runtime the exportc name; there may be a better way (that also works at CT)
+  # TODO: add to stdlib
+  block:
+    var name {.inject.}: cstring
+    {.emit: "`name` = __func__;".}
+    $name
+
 template myfoo2* = {.exportc.}
 template myfoo3* = {.exportc: "myfoo3_in_c", discardable.}
 template myfoo4* = {.discardable, myfoo2.}
 template myfoo5 = {. .}
 
-when false:
-  # would require pragma export via https://github.com/nim-lang/Nim/pull/13030
-  {.pragma: myfoo0, exportc: "myfoo0_in_c".}
-  export myfoo0
-elif false:
-  # can't use non exported template pragma inside exported template pragma
-  template myfoo0 = {.exportc: "myfoo0_in_c".}
-else:
-  # works
-  template myfoo0* = {.exportc: "myfoo0_in_c".}
+{.pragma: myfoo0a, exportc: "myfoo0_in_c".}
+# export myfoo0a # works even if not exported
+template myfoo0b* = {.cdecl.}
 
-template myfoo6* = {.myfoo0, discardable.}
+template myfoo6* = {.myfoo0a, myfoo0b, discardable.}
 
-template myfooHijacked* = {.discardable.}
-template myfoo7* = {.myfooHijacked.}
+# this won't be hijacked
+template myfooHijacked = {.exportc: "myfooHijacked_orig".}
+template myfooHijacked_wrap* = {.myfooHijacked.}
 
 export myfoo5

--- a/tests/pragmas/mpragma_export.nim
+++ b/tests/pragmas/mpragma_export.nim
@@ -1,0 +1,18 @@
+template myfoo2* = {.exportc.}
+template myfoo3* = {.exportc: "myfoo3_in_c", discardable.}
+template myfoo4* = {.discardable, myfoo2.}
+template myfoo5 = {. .}
+
+when false:
+  # can't use classical pragma inside template pragma
+  {.pragma: myfoo0, exportc: "myfoo0_in_c".}
+elif false:
+  # can't use non exported template pragma inside exported template pragma
+  template myfoo0 = {.exportc: "myfoo0_in_c".}
+else:
+  # works
+  template myfoo0* = {.exportc: "myfoo0_in_c".}
+
+template myfoo6* = {.myfoo0, discardable.}
+
+export myfoo5

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -1,3 +1,13 @@
+discard """
+  output: '''
+ok1
+ok2
+in fun4
+in fun5
+in fun6
+'''
+"""
+
 import ./mpragma_export
 
 {.pragma: myfoo, exportc.}

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -1,0 +1,24 @@
+import ./mpragma_export
+
+{.pragma: myfoo, exportc.}
+
+proc fun1() {.myfoo.} = echo "ok1"
+proc fun2() {.myfoo2.} = echo "ok2"
+proc fun3(): int {.myfoo3.} = 123
+proc fun4(): int {.myfoo4.} =
+  echo "in fun4"
+  124
+proc fun5(): int {.myfoo5.} =
+  echo "in fun5"
+  125
+proc fun6(): int {.myfoo6.} =
+  echo "in fun6"
+  125
+
+fun1()
+fun2()
+fun3()
+doAssert fun3()  == 123
+fun4()
+doAssert fun5() == 125
+fun6()

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -5,6 +5,7 @@ ok2
 in fun4
 in fun5
 in fun6
+in fun7
 '''
 """
 
@@ -25,6 +26,16 @@ proc fun6(): int {.myfoo6.} =
   echo "in fun6"
   125
 
+when false:
+  # BUG: enable this and it'll hijack `myfoo7` and fail in `fun7()`;
+  # ideally, the pragma template would to locally defined symbols, instead
+  # of to identifiers.
+  template myfooHijacked* = {. .}
+
+proc fun7(): int {.myfoo7.} =
+  echo "in fun7"
+  126
+
 fun1()
 fun2()
 fun3()
@@ -32,3 +43,4 @@ doAssert fun3()  == 123
 fun4()
 doAssert fun5() == 125
 fun6()
+fun7()

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -25,14 +25,14 @@ proc fun6(): int {.myfoo6.} =
   echo "in fun6"
   125
 
-when false:
-  # BUG: enable this and it'll hijack `myfoo7` and fail in `fun7()`;
-  # ideally, the pragma template would to locally defined symbols, instead
-  # of to identifiers.
-  template myfooHijacked* = {. .}
+block:
+  # checks that local redefinition with same name does not hijack definition of
+  # myfooHijacked_wrap
+  template myfooHijacked = {.exportc: "myfooHijacked_new".}
 
-proc funHijackExample(): int {.myfoo7.} =
-  126
+  proc funHijackExample() {.myfooHijacked_wrap.} =
+    doAssert getExportcName() == "myfooHijacked_orig"
+  funHijackExample()
 
 ## example showing a template pragma can use a local {.pragma.} pragma.
 ## Using an imported {.pragma.} pragma would require https://github.com/nim-lang/Nim/pull/13030
@@ -48,5 +48,4 @@ doAssert fun3()  == 123
 fun4()
 doAssert fun5() == 125
 fun6()
-funHijackExample()
 fun8()

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -5,7 +5,6 @@ ok2
 in fun4
 in fun5
 in fun6
-in fun7
 '''
 """
 
@@ -32,8 +31,14 @@ when false:
   # of to identifiers.
   template myfooHijacked* = {. .}
 
-proc fun7(): int {.myfoo7.} =
-  echo "in fun7"
+proc funHijackExample(): int {.myfoo7.} =
+  126
+
+## example showing a template pragma can use a local {.pragma.} pragma.
+## Using an imported {.pragma.} pragma would require https://github.com/nim-lang/Nim/pull/13030
+{.pragma: myfooLocal, discardable.}
+template myfoo8* = {.myfooLocal.}
+proc fun8(): int {.myfoo8.} =
   126
 
 fun1()
@@ -43,4 +48,5 @@ doAssert fun3()  == 123
 fun4()
 doAssert fun5() == 125
 fun6()
-fun7()
+funHijackExample()
+fun8()

--- a/tests/pragmas/tsym_as_pragma.nim
+++ b/tests/pragmas/tsym_as_pragma.nim
@@ -1,8 +1,9 @@
 
 # bug #3171
+when false:
+  # now getting: Error: invalid pragma: closure`gensym272010
+  template newDataWindow(): untyped =
+      let eventClosure = proc (closure: pointer): bool {.closure, cdecl.} =
+          discard
 
-template newDataWindow(): untyped =
-    let eventClosure = proc (closure: pointer): bool {.closure, cdecl.} =
-        discard
-
-newDataWindow()
+  newDataWindow()


### PR DESCRIPTION
see tests

small example:
```nim
# foo.nim:
template myfoo0* = {.exportc: "myfoo0_in_c".}
# main.nim
import foo
proc bar() {.myfoo0, discardable.} = 12
```

## caveats (help welcome)
~~right now this has some limitations:~~
* ~~can't use a classical user defined pragma pragma inside a template pragma~~ EDIT: actually it's possible for local pragma pragma, see tests; for non-loacl pragma pragmas, would require also https://github.com/nim-lang/Nim/pull/13030
* ~~can't use non exported template pragma inside exported template pragma~~ EDIT: works, see tests
* ~~[EDIT] ideally the pragmas would be evaluated at definition time and bind to symbols, not identifiers; see example `myfooHijacked` illustrating how a locally defined template pragma affects an imported pragma because it hijacks the identifier~~
EDIT: this now works, no hijacking happens, see tests

## note
see also https://github.com/nim-lang/Nim/pull/13030 for an alternative implementation
