### PR TITLE
exportable pragmas (v2)

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -543,6 +543,7 @@ type
 
   TSymKind* = enum        # the different symbols (start with the prefix sk);
                           # order is important for the documentation generator!
+                          # keep in sync with `NimSymKind`
     skUnknown,            # unknown symbol: used for parsing assembler blocks
                           # and first phase symbol lookup in generics
     skConditional,        # symbol for the preprocessor (may become obsolete)
@@ -563,7 +564,6 @@ type
     skIterator,           # an iterator
     skConverter,          # a type converter
     skMacro,              # a macro
-    skPragma,             # a pragma
     skTemplate,           # a template; currently also misused for user-defined
                           # pragmas
     skField,              # a field in a record or object
@@ -575,6 +575,7 @@ type
                           # mean: never)
     skPackage,            # symbol is a package (used for canonicalization)
     skAlias               # an alias (needs to be resolved immediately)
+    skPragma,             # a pragma
   TSymKinds* = set[TSymKind]
 
 const

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -563,6 +563,7 @@ type
     skIterator,           # an iterator
     skConverter,          # a type converter
     skMacro,              # a macro
+    skPragma,             # a pragma
     skTemplate,           # a template; currently also misused for user-defined
                           # pragmas
     skField,              # a field in a record or object
@@ -980,7 +981,7 @@ const
     tyProc, tyError}
   ExportableSymKinds* = {skVar, skConst, skProc, skFunc, skMethod, skType,
     skIterator,
-    skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias}
+    skMacro, skTemplate, skConverter, skEnumField, skLet, skStub, skAlias, skPragma}
   PersistentNodeFlags*: TNodeFlags = {nfBase2, nfBase8, nfBase16,
                                       nfDotSetter, nfDotField,
                                       nfIsRef, nfPreventCg, nfLL,

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -985,8 +985,8 @@ proc generateTags*(d: PDoc, n: PNode, r: var Rope) =
 proc genSection(d: PDoc, kind: TSymKind) =
   const sectionNames: array[skModule..skField, string] = [
     "Imports", "Types", "Vars", "Lets", "Consts", "Vars", "Procs", "Funcs",
-    "Methods", "Iterators", "Converters", "Macros", "Pragmas", "Templates", "Exports"
-  ]
+    "Methods", "Iterators", "Converters", "Macros", "Templates", "Exports"
+  ] # consider adding more, eg for `skPragma`
   if d.section[kind] == nil: return
   var title = sectionNames[kind].rope
   d.section[kind] = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.section"), [

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -985,7 +985,7 @@ proc generateTags*(d: PDoc, n: PNode, r: var Rope) =
 proc genSection(d: PDoc, kind: TSymKind) =
   const sectionNames: array[skModule..skField, string] = [
     "Imports", "Types", "Vars", "Lets", "Consts", "Vars", "Procs", "Funcs",
-    "Methods", "Iterators", "Converters", "Macros", "Templates", "Exports"
+    "Methods", "Iterators", "Converters", "Macros", "Pragmas", "Templates", "Exports"
   ]
   if d.section[kind] == nil: return
   var title = sectionNames[kind].rope

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -68,7 +68,8 @@ proc rawImportSymbol(c: PContext, s, origin: PSym) =
             importPureEnumField(c, e)
   else:
     if s.kind == skConverter: addConverter(c, s)
-    if hasPattern(s): addPattern(c, s)
+    if s.kind == skPragma: strTableAdd(c.userPragmas, s)
+    elif hasPattern(s): addPattern(c, s)
   if s.owner != origin:
     c.exportIndirections.incl((origin.id, s.id))
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -602,9 +602,10 @@ proc processPragma(c: PContext, n: PNode, i: int) =
   elif it.safeLen != 2 or it[0].kind != nkIdent or it[1].kind != nkIdent:
     invalidPragma(c, n)
 
-  var userPragma = newSym(skTemplate, it[1].ident, nil, it.info, c.config.options)
+  var userPragma = newSym(skPragma, it[1].ident, nil, it.info, c.config.options)
   userPragma.ast = newNode(nkPragma, n.info, n.sons[i+1..^1])
   strTableAdd(c.userPragmas, userPragma)
+  strTableAdd(c.currentScope.symbols, userPragma)
 
 proc pragmaRaisesOrTags(c: PContext, n: PNode) =
   proc processExc(c: PContext, x: PNode) =

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -109,13 +109,14 @@ type
 
   TNimTypeKinds* {.deprecated.} = set[NimTypeKind]
   NimSymKind* = enum
+    # keep in sync with ast.TSymKind
     nskUnknown, nskConditional, nskDynLib, nskParam,
     nskGenericParam, nskTemp, nskModule, nskType, nskVar, nskLet,
     nskConst, nskResult,
     nskProc, nskFunc, nskMethod, nskIterator,
     nskConverter, nskMacro, nskTemplate, nskField,
     nskEnumField, nskForVar, nskLabel,
-    nskStub
+    nskStub, nskPackage, nskAlias, nskPragma
 
   TNimSymKinds* {.deprecated.} = set[NimSymKind]
 

--- a/tests/pragmas/mpragma_export.nim
+++ b/tests/pragmas/mpragma_export.nim
@@ -1,18 +1,9 @@
-template myfoo2* = {.exportc.}
-template myfoo3* = {.exportc: "myfoo3_in_c", discardable.}
-template myfoo4* = {.discardable, myfoo2.}
-template myfoo5 = {. .}
+{.pragma: myfoo2, exportc.}
+{.pragma: myfoo3, exportc: "myfoo3_in_c", discardable.}
+{.pragma: myfoo4, discardable, myfoo2.}
+{.pragma: myfoo5.}
+{.pragma: myfoo0, exportc: "myfoo0_in_c".}
+{.pragma: myfoo6, myfoo0, discardable.}
 
-when false:
-  # can't use classical pragma inside template pragma
-  {.pragma: myfoo0, exportc: "myfoo0_in_c".}
-elif false:
-  # can't use non exported template pragma inside exported template pragma
-  template myfoo0 = {.exportc: "myfoo0_in_c".}
-else:
-  # works
-  template myfoo0* = {.exportc: "myfoo0_in_c".}
-
-template myfoo6* = {.myfoo0, discardable.}
-
-export myfoo5
+export myfoo0 # needed if appears in an exported pragma; ideally should not be needed
+export myfoo2, myfoo3, myfoo4, myfoo5, myfoo6

--- a/tests/pragmas/mpragma_export.nim
+++ b/tests/pragmas/mpragma_export.nim
@@ -1,0 +1,18 @@
+template myfoo2* = {.exportc.}
+template myfoo3* = {.exportc: "myfoo3_in_c", discardable.}
+template myfoo4* = {.discardable, myfoo2.}
+template myfoo5 = {. .}
+
+when false:
+  # can't use classical pragma inside template pragma
+  {.pragma: myfoo0, exportc: "myfoo0_in_c".}
+elif false:
+  # can't use non exported template pragma inside exported template pragma
+  template myfoo0 = {.exportc: "myfoo0_in_c".}
+else:
+  # works
+  template myfoo0* = {.exportc: "myfoo0_in_c".}
+
+template myfoo6* = {.myfoo0, discardable.}
+
+export myfoo5

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -1,3 +1,13 @@
+discard """
+  output: '''
+ok1
+ok2
+in fun4
+in fun5
+in fun6
+'''
+"""
+
 import ./mpragma_export
 
 {.pragma: myfoo, exportc.}

--- a/tests/pragmas/tpragma_export.nim
+++ b/tests/pragmas/tpragma_export.nim
@@ -1,0 +1,24 @@
+import ./mpragma_export
+
+{.pragma: myfoo, exportc.}
+
+proc fun1() {.myfoo.} = echo "ok1"
+proc fun2() {.myfoo2.} = echo "ok2"
+proc fun3(): int {.myfoo3.} = 123
+proc fun4(): int {.myfoo4.} =
+  echo "in fun4"
+  124
+proc fun5(): int {.myfoo5.} =
+  echo "in fun5"
+  125
+proc fun6(): int {.myfoo6.} =
+  echo "in fun6"
+  125
+
+fun1()
+fun2()
+fun3()
+doAssert fun3()  == 123
+fun4()
+doAssert fun5() == 125
+fun6()


### PR DESCRIPTION
same goal as https://github.com/nim-lang/Nim/pull/13016  but different implementation

```nim
# this PR:
{.pragma: foo, gcsafe, exportc: "bar".}
export foo

# PR 13016
template foo* = {.gcsafe, exportc: "bar".}
```

pros: works with existing user defined pragmas; all that's needed is `export foo`, whereas https://github.com/nim-lang/Nim/pull/13016 required all sons to be of the form `template pragma` eg:
```nim
template myfoo0* = {.exportc: "myfoo0_in_c".} # ok
# {.pragma: myfoo0, exportc: "myfoo0_in_c".} # not ok
template myfoo6* = {.myfoo0, discardable.}
```

## future work (can be done in subsequent PR's):
- [ ]  support directly:
```nim
{.pragma: foo*, gcsafe, exportc: "bar".}
```
- [ ]  allow exporting a pragma even if its sons are not exported
- [ ]  nim doc should show the exported pragmas
