### PR TITLE
nimvmRunning: alternative for nimvm; can be used in any context; fixes #12517; fixes #12518

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,10 @@
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
 
+- Added `system.nimct` which is true inside compile time evaluation context. Unlike `nimvm`,
+  it can be used in any context, however it'll evaluate to true inside a when `nimct` context
+  so can't be used to statically disable code.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1958,7 +1958,24 @@ const
 let nimvm* {.magic: "Nimvm", compileTime.}: bool = false
   ## May be used only in `when` expression.
   ## It is true in Nim VM context and false otherwise.
+  ##
+  ## .. code-block:: Nim
+  ##   when nimvm: # can't use expressions (eg `not nimvm`)
+  ##     discard # VM running
+  ##   else: # this branch must exist
+  ##     doAssert(false) # VM not running
 {.pop.}
+
+template nimvmRunning*: bool =
+  ## Wrapper around `nimvm` that can be used in any context. Note that it always
+  ## evaluates to `true` inside a when context so can't be used for statically
+  ## disabling code.
+  runnableExamples:
+    if not nimvmRunning: discard # non-static branch selection
+    when nimvmRunning: discard # this isn't useful, branch always taken
+    discard nimvmRunning
+  when nimvm: true
+  else: false
 
 proc compileOption*(option: string): bool {.
   magic: "CompileOption", noSideEffect.}

--- a/tests/vm/tnimvm.nim
+++ b/tests/vm/tnimvm.nim
@@ -1,0 +1,34 @@
+discard """
+  nimout: '''
+(true, true)
+ok1
+ok5
+done
+'''
+  output: '''
+(false, true)
+ok2
+ok4
+ok6
+done
+'''
+"""
+
+proc main()=
+  let a1 = nimvmRunning
+  const a2 = nimvmRunning
+  echo (a1, a2)
+  if nimvmRunning and true:
+    echo "ok1"
+  else:
+    echo "ok2"
+  if not nimvmRunning:
+    echo "ok4"
+  when nimvm:
+    echo "ok5"
+  else:
+    echo"ok6"
+  echo "done"
+
+static: main()
+main()


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/issues/12518 (in the sense provides a 100% workaround)
* fixes https://github.com/nim-lang/Nim/issues/12517 (ditto)

added `nimct` that is a replacement for `nimvm` which should be deprecated:
* can be used in any context (eg: `if not nimvm: foo`); 
```nim
if not nimvm:
  foo
if bar and nimvm: discard
echo (nimvm, "asdf")
```
* typically is used in `if` context; using it in `when nimct` would always imply `nimct = true`; no weird/special rules apply, unlike for nimvm

## note
* it's possible (and easy; in fact that was what I had originally written for this PR) to write `nimct` that doesn't rely on nimvm for its implementation, using a magic that gets defined differently depending on when we are in a VM environment.
that would allows removing the existing hack / special casing that is in place to support nimvm. This is left as future low priority work

* I can't reuse the name nimvm for this improved version since existing code would change semantics (because nimct follows usual nim semantics and in particular, `when nimct` implies nimct = true)

## TODO for future PR's 
- [ ] update manual