### PR TITLE
make SuccessX show project file + output file

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -97,6 +97,7 @@ const
     warnCycleCreated: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
+    # keep in sync with `pegSuccess` see testament.nim
     hintSuccessX: "LOC: $loc sec: $sec $mem build: $build proj: $project out: $output",
     hintCC: "CC: \'$1\'", # unused
     hintLineTooLong: "line too long",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -97,7 +97,7 @@ const
     warnCycleCreated: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
-    hintSuccessX: "operation successful ($# lines compiled; $# sec total; $#; $#)",
+    hintSuccessX: "operation successful ($# lines compiled; $# sec total; $#; $#) project: $# output: $#",
     hintCC: "CC: \'$1\'", # unused
     hintLineTooLong: "line too long",
     hintXDeclaredButNotUsed: "'$1' is declared but not used",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -97,7 +97,7 @@ const
     warnCycleCreated: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
-    hintSuccessX: "operation successful ($# lines compiled; $# sec total; $#; $#) project: $# output: $#",
+    hintSuccessX: "LOC: $loc sec: $sec $mem build: $build proj: $project out: $output",
     hintCC: "CC: \'$1\'", # unused
     hintLineTooLong: "line too long",
     hintXDeclaredButNotUsed: "'$1' is declared but not used",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -98,7 +98,7 @@ const
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `pegSuccess` see testament.nim
-    hintSuccessX: "LOC: $loc sec: $sec $mem build: $build proj: $project out: $output",
+    hintSuccessX: "LOC: $loc; sec: $sec; $mem; build: $build; proj: $project; out: $output",
     hintCC: "CC: \'$1\'", # unused
     hintLineTooLong: "line too long",
     hintXDeclaredButNotUsed: "'$1' is declared but not used",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -98,7 +98,7 @@ const
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `pegSuccess` see testament.nim
-    hintSuccessX: "LOC: $loc; sec: $sec; $mem; build: $build; proj: $project; out: $output",
+    hintSuccessX: "$loc LOC; $sec sec; $mem; $build build; $project proj; $output out",
     hintCC: "CC: \'$1\'", # unused
     hintLineTooLong: "line too long",
     hintXDeclaredButNotUsed: "'$1' is declared but not used",

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -356,8 +356,8 @@ proc mainCommand*(graph: ModuleGraph) =
   if conf.errorCounter == 0 and
      conf.cmd notin {cmdInterpret, cmdRun, cmdDump}:
     let mem =
-      when declared(system.getMaxMem): "peakmem: " & formatSize(getMaxMem())
-      else: "totmem: " & formatSize(getTotalMem())
+      when declared(system.getMaxMem): formatSize(getMaxMem()) & " peakmem"
+      else: formatSize(getTotalMem()) & " totmem"
     let loc = $conf.linesCompiled
     let build = if isDefined(conf, "danger"): "Dangerous Release"
                 elif isDefined(conf, "release"): "Release"

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -355,19 +355,24 @@ proc mainCommand*(graph: ModuleGraph) =
 
   if conf.errorCounter == 0 and
      conf.cmd notin {cmdInterpret, cmdRun, cmdDump}:
-    when declared(system.getMaxMem):
-      let usedMem = formatSize(getMaxMem()) & " peakmem"
-    else:
-      let usedMem = formatSize(getTotalMem())
-    rawMessage(conf, hintSuccessX, [$conf.linesCompiled,
-               formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3),
-               usedMem,
-               if isDefined(conf, "danger"): "Dangerous Release Build"
-               elif isDefined(conf, "release"): "Release Build"
-               else: "Debug Build",
-               $conf.projectFull,
-               $conf.getOutFileFull(),
-               ])
+    let mem =
+      when declared(system.getMaxMem): "peakmem: " & formatSize(getMaxMem())
+      else: "totmem: " & formatSize(getTotalMem())
+    let loc = $conf.linesCompiled
+    let build = if isDefined(conf, "danger"): "Dangerous Release"
+                elif isDefined(conf, "release"): "Release"
+                else: "Debug"
+    let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
+    let project = if optListFullPaths in conf.globalOptions: $conf.projectFull else: $conf.projectName
+    let output = if optListFullPaths in conf.globalOptions: $conf.getOutFileFull else: $conf.outFile
+    rawMessage(conf, hintSuccessX, [
+      "loc", loc,
+      "sec", sec,
+      "mem", mem,
+      "build", build,
+      "project", project,
+      "output", output,
+      ])
 
   when PrintRopeCacheStats:
     echo "rope cache stats: "

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -364,7 +364,10 @@ proc mainCommand*(graph: ModuleGraph) =
                usedMem,
                if isDefined(conf, "danger"): "Dangerous Release Build"
                elif isDefined(conf, "release"): "Release Build"
-               else: "Debug Build"])
+               else: "Debug Build",
+               $conf.projectFull,
+               $conf.getOutFileFull(),
+               ])
 
   when PrintRopeCacheStats:
     echo "rope cache stats: "

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -284,6 +284,8 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
 
+proc getOutFileFull*(a: ConfigRef): AbsoluteFile = a.outDir / a.outFile
+
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 
 template depConfigFields*(fn) {.dirty.} =

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -74,7 +74,7 @@ let
       'template/generic instantiation' ( ' of `' [^`]+ '`' )? ' from here' .*
     """
   pegOtherError = peg"'Error:' \s* {.*}"
-  pegSuccess = peg"'Hint: operation successful'.*"
+  pegSuccess = peg"'Hint: LOC: '.*" # 
   pegOfInterest = pegLineError / pegOtherError
 
 var gTargets = {low(TTarget)..high(TTarget)}
@@ -170,6 +170,7 @@ proc callCompiler(cmdTemplate, filename, options, nimcache: string,
   result.tfile = ""
   result.tline = 0
   result.tcolumn = 0
+  result.err = reNimcCrash
   if tmpl =~ pegLineTemplate:
     result.tfile = extractFilename(matches[0])
     result.tline = parseInt(matches[1])

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -74,10 +74,13 @@ let
       'template/generic instantiation' ( ' of `' [^`]+ '`' )? ' from here' .*
     """
   pegOtherError = peg"'Error:' \s* {.*}"
-  pegSuccess = peg"'Hint: LOC: '.*" # 
   pegOfInterest = pegLineError / pegOtherError
 
 var gTargets = {low(TTarget)..high(TTarget)}
+
+proc isSuccess(input: string): bool =
+  # not clear how to do the equivalent of pkg/regex's: re"FOO(.*?)BAR" in pegs
+  input.startsWith("Hint: ") and input.endsWith("[SuccessX]")
 
 proc normalizeMsg(s: string): string =
   result = newStringOfCap(s.len+1)
@@ -157,7 +160,7 @@ proc callCompiler(cmdTemplate, filename, options, nimcache: string,
       elif x =~ pegLineTemplate and err == "":
         # `tmpl` contains the last template expansion before the error
         tmpl = x
-      elif x =~ pegSuccess:
+      elif x.isSuccess:
         suc = x
     elif not running(p):
       break
@@ -182,7 +185,7 @@ proc callCompiler(cmdTemplate, filename, options, nimcache: string,
     result.msg = matches[3]
   elif err =~ pegOtherError:
     result.msg = matches[0]
-  elif suc =~ pegSuccess:
+  elif suc.isSuccess:
     result.err = reSuccess
 
 proc callCCompiler(cmdTemplate, filename, options: string,


### PR DESCRIPTION
before PR
```
Hint: operation successful (29712 lines compiled; 0.434 sec total; 24.406MiB peakmem; Debug Build) [SuccessX]
```

after PR:
```
Hint: operation successful (29712 lines compiled; 0.434 sec total; 24.406MiB peakmem; Debug Build) project: /Users/timothee/.cache/nim/manual_d/manual/manual_snippet_101.nim output: /Users/timothee/.cache/nim/manual_d/manual/manual_snippet_101 [SuccessX]
```

* useful when it's not obvious where output goes (eg could have some `--outdir` or other flags controlling where things go or their extensions etc)
* EDIT: another example is with --app:lib which generates platform specific `pathto/libfoo.dylib` 
* also especially useful when the nim cmd was run programmatically instead of directly at cmdline, eg when running `./koch docs` you'd previously had no idea what was finished compiling in `Hint: operation successful` nor was it clear where it would output things; after this PR it shows all that's needed:

```
Hint: operation successful (46428 lines compiled; 0.844 sec total; 46.758MiB peakmem; Debug Build) project: /Users/timothee/git_clone/nim/Nim_prs/lib/wrappers/openssl.nim output: /Users/timothee/git_clone/nim/Nim_prs/web/upload/1.1.1/openssl.html [SuccessX]
Hint: operation successful (29712 lines compiled; 0.434 sec total; 24.406MiB peakmem; Debug Build) project: /Users/timothee/.cache/nim/manual_d/manual/manual_snippet_101.nim output: /Users/timothee/.cache/nim/manual_d/manual/manual_snippet_101 [SuccessX]
Hint: operation successful (44081 lines compiled; 0.737 sec total; 56.832MiB peakmem; Debug Build) project: /Users/timothee/.cache/nim/strformat_d/runnableExamples/strformat_examples.nim output: /Users/timothee/.cache/nim/strformat_d/runnableExamples/strformat_examples [SuccessX]
```


## note
full path instead of relative path is intentional, makes it easier to jump to location or resolve output locations etc

