### PR TITLE
times: toUnixFloat, fromUnixFloat

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,8 @@
 
 - Added `os.normalizePathEnd` for additional path sanitization.
 
+- Added `times.fromUnixFloat,toUnixFloat`, subsecond resolution versions of `fromUnix`,`toUnixFloat`.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -112,7 +112,7 @@ proc normalizePathEnd(path: string, trailingSep = false): string =
   result = path
   result.normalizePathEnd(trailingSep)
 
-when (NimMajor, NimMinor) >= (1, 1):
+since((1, 1)):
   export normalizePathEnd
 
 proc joinPath*(head, tail: string): string {.

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -596,7 +596,7 @@ proc toUnix*(t: Time): int64 {.benign, tags: [], raises: [], noSideEffect.} =
   t.seconds
 
 proc fromUnix*(unix: float): Time
-    {.benign, tags: [], raises: [], noSideEffect.} =
+    {.benign, tags: [], raises: [], noSideEffect, since: (1, 1).} =
   ## Overload working with subsecond resolution.
   runnableExamples:
     doAssert fromUnix(123.0) == fromUnix(123)
@@ -604,7 +604,7 @@ proc fromUnix*(unix: float): Time
   let nsecs = (unix - secs) * 1e9
   initTime(secs.int64, nsecs.NanosecondRange)
 
-proc toUnixFloat*(t: Time): float {.benign, tags: [], raises: [].} =
+proc toUnixFloat*(t: Time): float {.benign, tags: [], raises: [], since: (1, 1).} =
   ## Same as `toUnix` but using subsecond resolution.
   runnableExamples:
     let t = getTime()

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -604,7 +604,7 @@ proc fromUnix*(unix: float): Time
   let nsecs = (unix - secs) * 1e9
   initTime(secs.int64, nsecs.NanosecondRange)
 
-proc toUnixFloat*(t: Time): float {.benign, tags: [], raises: [], since: (1, 1).} =
+proc toUnixFloat*(t: Time): float {.benign, tags: [], raises: [].} =
   ## Same as `toUnix` but using subsecond resolution.
   runnableExamples:
     let t = getTime()

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -590,27 +590,31 @@ proc fromUnix*(unix: int64): Time
 
 proc toUnix*(t: Time): int64 {.benign, tags: [], raises: [], noSideEffect.} =
   ## Convert ``t`` to a unix timestamp (seconds since ``1970-01-01T00:00:00Z``).
-  ## See also `toUnix`.
+  ## See also `toUnixFloat` for subsecond resolution.
   runnableExamples:
     doAssert fromUnix(0).toUnix() == 0
   t.seconds
 
-proc fromUnix*(unix: float): Time
+proc fromUnixFloat*(seconds: float): Time
     {.benign, tags: [], raises: [], noSideEffect, since: (1, 1).} =
-  ## Overload working with subsecond resolution.
+  ## Convert a unix timestamp in seconds to a `Time`; same as `fromUnix`
+  ## but with subsecond resolution.
   runnableExamples:
-    doAssert fromUnix(123.0) == fromUnix(123)
-  let secs = unix.floor
-  let nsecs = (unix - secs) * 1e9
+    doAssert fromUnixFloat(123.0) == fromUnixFloat(123)
+  let secs = seconds.floor
+  let nsecs = (seconds - secs) * 1e9
   initTime(secs.int64, nsecs.NanosecondRange)
 
-proc toUnixFloat*(t: Time): float {.benign, tags: [], raises: [].} =
+template toUnixFloatImpl(t): untyped =
+  t.seconds.float + t.nanosecond / convert(Seconds, Nanoseconds, 1)
+
+proc toUnixFloat*(t: Time): float {.benign, tags: [], raises: [], since: (1, 1).} =
   ## Same as `toUnix` but using subsecond resolution.
   runnableExamples:
     let t = getTime()
     # `<` because of rounding errors
-    doAssert abs(t.toUnixFloat().fromUnix - t) < initDuration(nanoseconds = 1000)
-  t.seconds.float + t.nanosecond / convert(Seconds, Nanoseconds, 1)
+    doAssert abs(t.toUnixFloat().fromUnixFloat - t) < initDuration(nanoseconds = 1000)
+  toUnixFloatImpl(t)
 
 proc fromWinTime*(win: int64): Time =
   ## Convert a Windows file time (100-nanosecond intervals since
@@ -2723,7 +2727,7 @@ proc fromSeconds*(since1970: int64): Time
 proc toSeconds*(time: Time): float
     {.tags: [], raises: [], benign, deprecated: "Use toUnixFloat or toUnix".} =
   ## Returns the time in seconds since the unix epoch, with subsecond resolution.
-  toUnixFloat(time)
+  toUnixFloatImpl(time)
 
 proc getLocalTime*(time: Time): DateTime
     {.tags: [], raises: [], benign, deprecated.} =


### PR DESCRIPTION
`toSeconds` is deprecated because it's badly named (ambiguous, etc) but is useful and I use it; eg times represented as float is convenient and commonly used in several applications (eg when dealing with video or other time series)

this PR adds:
* `toUnixFloat` replaces toSeconds
* `fromUnixFloat` overload, which is the reverse of toUnixFloat modulo rounding errors

## [EDIT]
* this PR also fixes a bug in deprecated `fromSeconds*(since1970: float)` which used to crash for negative input; now it uses the new implementation`fromUnixFloat` which correctly handles negative inputs 

## note
* supersedes https://github.com/nim-lang/Nim/pull/12441
* I removed `since` annotation from toUnixFloat since it was making CI fail (`toSeconds` now is implemented from it and I don't want to duplicate the implementation; not super sure why it'd fail as I'd assume nim would test CI assuming (1,1))
