### PR TITLE
testament/important_packages dont run hts

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -33,7 +33,7 @@ pkg "gara"
 pkg "glob"
 pkg "gnuplot"
 # pkg "godot", "nim c -r godot/godot.nim" # not yet compatible with Nim 0.19
-pkg "hts", "nim c -o:htss -r src/hts.nim"
+pkg "hts", "nim c -o:htss src/hts.nim"
 pkg "illwill", "nimble examples"
 pkg "inim"
 pkg "itertools", "nim doc src/itertools.nim"


### PR DESCRIPTION
and update to src/hts now requires the backing c library.