### PR TITLE
Modify the test command for nimly (nimble-package)

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -54,7 +54,7 @@ pkg "nimfp", "nim c -o:nfp -r src/fp.nim", true
 pkg "nimgame2", "nim c nimgame2/nimgame.nim", true
 pkg "nimgen", "nim c -o:nimgenn -r src/nimgen/runcfg.nim", true
 # pkg "nimlsp", "", true
-pkg "nimly", "nim c -r tests/test_nimly", true
+pkg "nimly", "", true
 # pkg "nimongo", "nimble test_ci", true
 pkg "nimpy", "nim c -r tests/nimfrompy.nim"
 pkg "nimquery"


### PR DESCRIPTION
I'm the author of package `nimly`.

The right command for full testing of nimly is `nimble test` and the module `tests/test_nimly` is a subpart of the test.

I'm sorry for there is a test with confusing name.
I will rename `tests/test_nimly` after the release of next version nim.