### PR TITLE
make --listCmd an alias to --hint:exec instead of differing subtly

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -836,7 +836,7 @@ template tryExceptOSErrorMessage(conf: ConfigRef; errorPrefix: string = "", body
 proc execLinkCmd(conf: ConfigRef; linkCmd: string) =
   tryExceptOSErrorMessage(conf, "invocation of external linker program failed."):
     execExternalProgram(conf, linkCmd,
-      if optListCmd in conf.globalOptions or conf.verbosity > 1: hintExecuting else: hintLinking)
+      if hintExecuting in conf.notes or conf.verbosity > 1: hintExecuting else: hintLinking)
 
 proc maybeRunDsymutil(conf: ConfigRef; exe: AbsoluteFile) =
   when defined(osx):
@@ -865,7 +865,7 @@ proc execCmdsInParallel(conf: ConfigRef; cmds: seq[string]; prettyCb: proc (idx:
           cmds[i])
   else:
     tryExceptOSErrorMessage(conf, "invocation of external compiler program failed."):
-      if optListCmd in conf.globalOptions or conf.verbosity > 1:
+      if hintExecuting in conf.notes or conf.verbosity > 1:
         res = execProcesses(cmds, {poEchoCmd, poStdErrToStdOut, poUsePath},
                             conf.numberOfProcessors, afterRunEvent=runCb)
       elif conf.verbosity == 1:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -45,7 +45,8 @@ type                          # please make sure we have under 32 options
   TGlobalOption* = enum       # **keep binary compatible**
     gloptNone, optForceFullMake,
     optWasNimscript,
-    optListCmd, optCompileOnly, optNoLinking,
+    optListCmd,               # DEPRECATED UNUSED
+    optCompileOnly, optNoLinking,
     optCDebug,                # turn on debugging information
     optGenDynLib,             # generate a dynamic library
     optGenStaticLib,          # generate a static library

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -118,6 +118,7 @@ Advanced options:
   --dynlibOverrideAll
                             disables the effects of the dynlib pragma
   --listCmd                 list the commands used to execute external programs
+                            (same as --hint:exec:on)
   --asm                     produce assembler code
   --parallelBuild:0|1|...   perform a parallel build
                             value = number of processors (0 for auto-detect)

--- a/tests/enum/tenum.nim
+++ b/tests/enum/tenum.nim
@@ -133,7 +133,7 @@ block toptions:
     TOption = enum
       optNone, optForceFullMake, optBoehmGC, optRefcGC, optRangeCheck,
       optBoundsCheck, optOverflowCheck, optNilCheck, optAssert, optLineDir,
-      optWarns, optHints, optListCmd, optCompileOnly,
+      optWarns, optHints, optCompileOnly,
       optSafeCode,             # only allow safe code
       optStyleCheck, optOptimizeSpeed, optOptimizeSize, optGenDynLib,
       optGenGuiApp, optStackTrace


### PR DESCRIPTION
before PR:
```
--listCmd shows a subset of executed cmds (eg 
--hint:exec:on shows another subset of executed cmds
```
after PR:
```
--listCmd is same as --hint:exec:on
```

