### PR TITLE
--listFullPaths:off now shows paths relative to cwd

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -216,7 +216,7 @@ template toFullPathConsiderDirty*(conf: ConfigRef; info: TLineInfo): string =
 proc toMsgFilename*(conf: ConfigRef; info: FileIndex): string =
   let
     absPath = toFullPath(conf, info)
-    relPath = toProjPath(conf, info)
+    relPath = absPath.relativePath(getCurrentDir())
   result = if (optListFullPaths in conf.globalOptions) or
               (relPath.len > absPath.len) or
               (relPath.count("..") > 2):

--- a/tests/modules/trecinca.nim
+++ b/tests/modules/trecinca.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "recursive dependency: 'trecincb.nim'"
+  errormsg: "recursive dependency: 'tests/modules/trecincb.nim'"
   file: "trecincb.nim"
   line: 9
 """

--- a/tests/modules/trecincb.nim
+++ b/tests/modules/trecincb.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "recursive dependency: 'trecincb.nim'"
+  errormsg: "recursive dependency: 'tests/modules/trecincb.nim'"
   file: "trecincb.nim"
   line: 9
 """


### PR DESCRIPTION
the previous behavior never made sense to me as it showed a relative path that wasn't relative to current dir (so couldn't be easily opened)
now you can easily open either via clicking on it (if your terminal supports it) or via `open somerelativepath` etc

likewise, this is especially true if nim command was run programmatically, in which case user has even less context as to how to turn project path to an actual path
