### PR TITLE
typetraits: fix #6454; genericParams; tuple len; tuple type get

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,10 @@
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
 
+- Added `typetraits.lenTuple` to get number of elements of a tuple/type tuple,
+  and `typetraits.get` to get the ith element of a type tuple.
+- Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -14,6 +14,7 @@
 
 export system.`$` # for backward compatibility
 
+include "system/inclrtl"
 
 proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ## Returns the name of the given type.
@@ -72,20 +73,21 @@ proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".}
 
 import std/macros
 
-macro lenTuple*(t: tuple): int =
+macro lenTuple*(t: tuple): int {.since: (1, 1).} =
   ## Return number of elements of `t`
   newLit t.len
 
-macro lenTuple*(t: typedesc[tuple]): int =
+macro lenTuple*(t: typedesc[tuple]): int {.since: (1, 1).} =
   ## Return number of elements of `T`
   newLit t.len
 
-template get*(T: typedesc[tuple], i: static int): untyped =
-  ## Return `i`th element of `T`
-  # Note: `[]` currently gives: `Error: no generic parameters allowed for ...`
-  type(default(T)[i])
+when (NimMajor, NimMinor) >= (1, 1):
+  template get*(T: typedesc[tuple], i: static int): untyped =
+    ## Return `i`th element of `T`
+    # Note: `[]` currently gives: `Error: no generic parameters allowed for ...`
+    type(default(T)[i])
 
-macro genericParams*(T: typedesc): untyped =
+macro genericParams*(T: typedesc): untyped {.since: (1, 1).} =
   ## return tuple of generic params for generic `T`
   runnableExamples:
     type Foo[T1, T2]=object

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -72,13 +72,13 @@ proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".}
 
 import std/macros
 
-macro len*(t: tuple): int =
+macro lenTuple*(t: tuple): int =
   ## Return number of elements of `t`
   newLit t.len
 
-template len*(T: typedesc[tuple]): untyped =
+macro lenTuple*(t: typedesc[tuple]): int =
   ## Return number of elements of `T`
-  len(default(T))
+  newLit t.len
 
 template get*(T: typedesc[tuple], i: static int): untyped =
   ## Return `i`th element of `T`

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -50,5 +50,7 @@ else:
   {.pragma: benign, gcsafe.}
 
 template since(version, body: untyped) {.dirty.} =
+  ## limitation: can't be used to annotate a template (eg typetraits.get), would
+  ## error: cannot attach a custom pragma.
   when version <= (NimMajor, NimMinor):
     body

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -44,9 +44,6 @@ block: # typeToString
   doAssert (tuple[a: C2b[MyInt, C4[cstring]], b: cint, c: float]).name3 ==
     "tuple[a: C2b{C}[MyInt{int}, C4[cstring]], b: cint{int32}, c: float]"
 
-
-#----------------------------------------------------
-
 block distinctBase:
   block:
     type
@@ -90,4 +87,17 @@ block distinctBase:
         doAssert($distinctBase(typeof(b2)) == "string")
         doAssert($distinctBase(typeof(c2)) == "int")
 
-
+block genericParams:
+  type Foo[T1, T2]=object
+  doAssert genericParams(Foo[float, string]) is (float, string)
+  type Foo1 = Foo[float, int]
+  doAssert genericParams(Foo1) is (float, int)
+  type Foo2 = Foo[float, Foo1]
+  doAssert genericParams(Foo2) is (float, Foo[float, int])
+  doAssert genericParams(Foo2) is (float, Foo1)
+  doAssert genericParams(Foo2).get(1) is Foo1
+  doAssert (int,).get(0) is int
+  doAssert (int, float).get(1) is float
+  static: doAssert (int, float).len == 2
+  static: doAssert (1, ).len == 1
+  static: doAssert ().len == 0

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -98,6 +98,6 @@ block genericParams:
   doAssert genericParams(Foo2).get(1) is Foo1
   doAssert (int,).get(0) is int
   doAssert (int, float).get(1) is float
-  static: doAssert (int, float).len == 2
-  static: doAssert (1, ).len == 1
-  static: doAssert ().len == 0
+  static: doAssert (int, float).lenTuple == 2
+  static: doAssert (1, ).lenTuple == 1
+  static: doAssert ().lenTuple == 0


### PR DESCRIPTION
* fix #6454
* typetraits: genericParams
returns a type tuple of generic params of a generic instantiation
* typetraits.len: len of a tuple or type tuple
* get: get ith element of a type tuple (without which `genericParams` is not very useful)

## example (see also tests)
```nim
type Foo[T1, T2]=object
type Foo1 = Foo[float, int]
doAssert genericParams(Foo1) is (float, int)
doAssert genericParams(Foo1).len == 2
doAssert genericParams(Foo1).get(0) is float
doAssert (int, float).get(1) is float
```

## note
* this supersedes https://github.com/nim-lang/Nim/pull/8554 providing the better API (returning a tuple instead of passing in an index, which would've required yet another api to get the generic number of args) suggested in https://github.com/nim-lang/Nim/pull/8554#issuecomment-410997964 by @zah
* there is an existing `genericHead` in typetraits, however it doesn't work at all; this can be fixed in subsequent PR; much better than to conflate both as i was doing before in extractGeneric in https://github.com/nim-lang/Nim/pull/8554


