### PR TITLE
showStats: shows statistics on number of alloc's for each unique type

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1730,9 +1730,13 @@ when defined(nimOwnedEnabled) and not defined(nimscript):
 else:
   template unown*(x: typed): untyped = x
 
-  proc new*[T](a: var ref T) {.magic: "New", noSideEffect.}
-    ## Creates a new object of type ``T`` and returns a safe (traced)
-    ## reference to it in ``a``.
+  when defined(nimWithStatsTypes):
+    from system/stats_types_new import new
+    export new
+  else:
+    proc new*[T](a: var ref T) {.magic: "New", noSideEffect.}
+      ## Creates a new object of type ``T`` and returns a safe (traced)
+      ## reference to it in ``a``.
 
   proc new*(t: typedesc): auto =
     ## Creates a new object of type ``T`` and returns a safe (traced)
@@ -4531,3 +4535,6 @@ export io
 
 when not defined(createNimHcr):
   include nimhcr
+
+when defined(nimWithStatsTypes):
+  import system/stats_types_show

--- a/lib/system/stats_types_new.nim
+++ b/lib/system/stats_types_new.nim
@@ -1,0 +1,45 @@
+proc `$`(t: typedesc): string {.magic: "TypeTrait".}
+
+proc newImpl[T](a: var ref T) {.magic: "New", noSideEffect.}
+
+type SysCounter* = object
+  name*: cstring
+  size*: int
+  nameLen*: int
+  count*: int
+
+var sysCounters*: array[1000, SysCounter]
+var sysCountersLen* = 0
+
+proc new*[T](a: var ref T) {.noSideEffect.} =
+  ## we avoid allocations, do everything on stack
+
+  # TODO: how do get a unique hash (in case of name collisions for different types T)
+  const name = $T
+  var i2 = 0
+  {.noSideEffect.}:
+    while true:
+      if i2 == sysCountersLen:
+        sysCounters[sysCountersLen] = SysCounter(name: name.cstring, nameLen: name.len, size: T.sizeof)
+        if sysCountersLen < sysCounters.len - 1:
+          sysCountersLen.inc
+        break
+
+      var ok = true
+      # TODO: strncmp ?
+      if sysCounters[i2].nameLen == name.len:
+        var j = 0
+        while true:
+          if j >= name.len:
+            break
+          if name[j] != sysCounters[i2].name[j]:
+            ok = false
+            break
+          j.inc
+        if ok:
+          break
+      i2.inc
+    if i2 < sysCounters.len:
+      sysCounters[i2].count.inc
+
+  newImpl(a)

--- a/lib/system/stats_types_new.nim
+++ b/lib/system/stats_types_new.nim
@@ -2,6 +2,10 @@ proc `$`(t: typedesc): string {.magic: "TypeTrait".}
 
 proc newImpl[T](a: var ref T) {.magic: "New", noSideEffect.}
 
+{.push profiler: off.}
+let nimvm {.magic: "Nimvm", compileTime.}: bool = false
+{.pop.}
+
 type SysCounter* = object
   name*: cstring
   size*: int
@@ -16,30 +20,35 @@ proc new*[T](a: var ref T) {.noSideEffect.} =
 
   # TODO: how do get a unique hash (in case of name collisions for different types T)
   const name = $T
-  var i2 = 0
-  {.noSideEffect.}:
-    while true:
-      if i2 == sysCountersLen:
-        sysCounters[sysCountersLen] = SysCounter(name: name.cstring, nameLen: name.len, size: T.sizeof)
-        if sysCountersLen < sysCounters.len - 1:
-          sysCountersLen.inc
-        break
 
-      var ok = true
-      # TODO: strncmp ?
-      if sysCounters[i2].nameLen == name.len:
-        var j = 0
-        while true:
-          if j >= name.len:
-            break
-          if name[j] != sysCounters[i2].name[j]:
-            ok = false
-            break
-          j.inc
-        if ok:
+  when nimvm:
+    # TODO: support
+    discard
+  else:
+    var i2 = 0
+    {.noSideEffect.}:
+      while true:
+        if i2 == sysCountersLen:
+          sysCounters[sysCountersLen] = SysCounter(name: name.cstring, nameLen: name.len, size: T.sizeof)
+          if sysCountersLen < sysCounters.len - 1:
+            sysCountersLen.inc
           break
-      i2.inc
-    if i2 < sysCounters.len:
-      sysCounters[i2].count.inc
+
+        var ok = true
+        # TODO: strncmp ?
+        if sysCounters[i2].nameLen == name.len:
+          var j = 0
+          while true:
+            if j >= name.len:
+              break
+            if name[j] != sysCounters[i2].name[j]:
+              ok = false
+              break
+            j.inc
+          if ok:
+            break
+        i2.inc
+      if i2 < sysCounters.len:
+        sysCounters[i2].count.inc
 
   newImpl(a)

--- a/lib/system/stats_types_show.nim
+++ b/lib/system/stats_types_show.nim
@@ -1,0 +1,51 @@
+#[
+Usage:
+this will print out unique types, the number of calls to new, the types size, and the total bytes for that type
+
+nim c -o:bin/nim_temp1 -d:release -d:nimWithStatsTypes compiler/nim.nim
+bin/nim_temp1 c -o:bin/nim_temp1 -d:release -d:nimWithStatsTypes compiler/nim.nim
+bin/nim_temp1 c -o:bin/nim_temp1 -d:release -d:nimWithStatsTypes compiler/nim.nim #(yes, we need to call it a 2nd time)
+]#
+
+import system/stats_types_new
+
+import std/os
+import std/strformat
+import std/algorithm
+
+import compiler/asciitables
+
+proc numBytes(a: SysCounter): int = a.size * a.count
+proc toStr(result: var string, bytesTot: var int,  a: SysCounter) =
+  let bytes = a.numBytes
+  bytesTot += bytes
+  result.add &"{$a.name}\tc: {a.count}\ts: {a.size}\tb: {bytes}"
+
+proc showStats*() {.noconv.} =
+  var bytesTot = 0
+  var ret = ""
+  var s: seq[SysCounter]
+  for i in 0..<sysCountersLen:
+    s.add sysCounters[i]
+  proc fun(a, b: SysCounter): int = b.numBytes - a.numBytes
+  s = s.sorted(fun)
+  for i in 0..<s.len:
+    ret.add "  " & $i & " "
+    ret.toStr(bytesTot, s[i])
+    ret.add "\n"
+  var pid = 0
+  when not defined(nimscript):
+    pid = getCurrentProcessId()
+  # ret = ret.alignTableCustom
+  ret = ret.alignTable
+  ret = &"stats pid: {pid}: num: {sysCountersLen} tot: {bytesTot} \n{ret}"
+  when not defined(nimscript) and not defined(js):
+    write(stderr, ret) # already ends in "\n", no need to add
+  else:
+    echo ret
+
+when nimvm:
+  discard
+  # TODO: Error: cannot 'importc' variable at compile time; addQuitProc
+else:
+  addQuitProc(showStats)


### PR DESCRIPTION
this PR allows a debug mode (`-d:nimWithStatsTypes`) which prints out stats per unique type at program exit.
it can be run on any program, but of particular interest is running it on nim compiler itself. This can help diagnose bottlenecks in the compiler, and better inform design decisions, identify performance regressions

For example:

* as expected, TNode represents the most number of bytes allocated (hence need for something like https://github.com/nim-lang/Nim/pull/10054 to reduce from 40 to 32 bytes per node)
* the total bytes allocates for `TSym` and `TType` are both < 10% of the total bytes allocated so these don't matter much

## example 1
```
nim c -o:bin/nim_temp1 -d:release -d:nimWithStatsTypes compiler/nim.nim
bin/nim_temp1 c -o:bin/nim_temp1 -d:release -d:nimWithStatsTypes compiler/nim.nim
bin/nim_temp1 c -o:bin/nim_temp1 -d:release -d:nimWithStatsTypes compiler/nim.nim #(yes, we need to call it a 2nd time)
```

the last cmd will print:
```
stats pid: 15407: num: 22 tot: 722256104
  0 TNode              c: 11353329 s: 40   b: 454133160
  1 RopeObj            c: 3463861  s: 40   b: 138554440
  2 TSym               c: 367913   s: 168  b: 61809384
  3 TType              c: 277913   s: 176  b: 48912688
  4 Trunk              c: 126863   s: 80   b: 10149040
  5 TProcCon           c: 38177    s: 88   b: 3359576
  6 TTransfContext     c: 15721    s: 72   b: 1131912
  7 TIdent             c: 24921    s: 40   b: 996840
  8 TTransCon          c: 17182    s: 56   b: 962192
  9 TCProc             c: 7239     s: 128  b: 926592
  10 TInstantiation    c: 30742    s: 24   b: 737808
  11 TContext          c: 200      s: 1392 b: 278400
  12 TCGen             c: 156      s: 1128 b: 175968
  13 TOptionEntry      c: 1480     s: 40   b: 59200
  14 TLLStream         c: 671      s: 72   b: 48312
  15 ProcessObj        c: 140      s: 56   b: 7840
  16 ERecoverableError c: 124      s: 56   b: 6944
  17 TLib              c: 110      s: 24   b: 2640
  18 OSError           c: 40       s: 64   b: 2560
  19 StringTableObj    c: 9        s: 32   b: 288
  20 ValueError        c: 4        s: 56   b: 224
  21 FileStreamObj     c: 1        s: 96   b: 96
```

## caveats (Help welcome!)
this only counts calls to `new`; to be correct it'd have to also count calls to ref object constructors eg `Foo(name: "bar")` where Foo is a ref type.
For example, when compiling and then running this test.nim we only show Foo1, not Foo2 because of that caveat:

```nim
  type Foo1 = ref object
    b1: int
    b2: string

  type Foo2 = ref object
    b1: int
    b2: string

  for i in 0..<1234:
    var xi: Foo1
    xi.new # ok: this is counted
    discard Foo2() # bug: this isn't counted
```
```
bin/nim_temp1 c -d:nimWithStatsTypes --skipParentCfg --skipUserCfg test.nim
./test
```
last cmd will show:
```
stats pid: 52473: num: 1 tot: 19744
  0 Foo1:ObjectType c: 1234 s: 16 b: 19744
```

## note
this gives different (complementary) information from `--hint:GCStats:on` which gives
```
[GC] total memory: 61120512
[GC] occupied memory: 48441984
[GC] stack scans: 4081
[GC] stack cells: 1977
[GC] cycle collections: 0
[GC] max threshold: 0
[GC] zct capacity: 2304
[GC] max cycle table size: 0
[GC] max pause time [ms]: 0
[GC] max stack size: 58496
```
