### PR TITLE
pass platform argument only if vccexe is used

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -559,7 +559,7 @@ proc vccplatform(conf: ConfigRef): string =
   # VCC specific but preferable over the config hacks people
   # had to do before, see #11306
   let exe = getConfigVar(conf, conf.cCompiler, ".exe")
-  if exe.len == 0 or "vccexe" in exe:
+  if "vccexe" in exe:
     result = case conf.target.targetCPU
       of cpuI386: " --platform:x86"
       of cpuArm: " --platform:arm"

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -558,13 +558,14 @@ proc getCompileOptions(conf: ConfigRef): string =
 proc vccplatform(conf: ConfigRef): string =
   # VCC specific but preferable over the config hacks people
   # had to do before, see #11306
-  let exe = getConfigVar(conf, conf.cCompiler, ".exe")
-  if "vccexe" in exe:
-    result = case conf.target.targetCPU
-      of cpuI386: " --platform:x86"
-      of cpuArm: " --platform:arm"
-      of cpuAmd64: " --platform:amd64"
-      else: ""
+  if conf.cCompiler == ccVcc: 
+    let exe = getConfigVar(conf, conf.cCompiler, ".exe")
+    if "vccexe.exe" == extractFilename(exe):
+      result = case conf.target.targetCPU
+        of cpuI386: " --platform:x86"
+        of cpuArm: " --platform:arm"
+        of cpuAmd64: " --platform:amd64"
+        else: ""
 
 proc getLinkOptions(conf: ConfigRef): string =
   result = conf.linkOptions & " " & conf.linkOptionsCmd & " "

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -558,15 +558,13 @@ proc getCompileOptions(conf: ConfigRef): string =
 proc vccplatform(conf: ConfigRef): string =
   # VCC specific but preferable over the config hacks people
   # had to do before, see #11306
-  case conf.target.targetCPU
-  of cpuI386:
-    result = " --platform:x86"
-  of cpuArm:
-    result = " --platform:arm"
-  of cpuAmd64:
-    result = " --platform:amd64"
-  else:
-    result = ""
+  let exe = getConfigVar(conf, conf.cCompiler, ".exe")
+  if exe.len == 0 or "vccexe" in exe:
+    result = case conf.target.targetCPU
+      of cpuI386: " --platform:x86"
+      of cpuArm: " --platform:arm"
+      of cpuAmd64: " --platform:amd64"
+      else: ""
 
 proc getLinkOptions(conf: ConfigRef): string =
   result = conf.linkOptions & " " & conf.linkOptionsCmd & " "
@@ -596,7 +594,7 @@ proc getLinkerExe(conf: ConfigRef; compiler: TSystemCC): string =
 
 proc getCompileCFileCmd*(conf: ConfigRef; cfile: Cfile,
                          isMainFile = false; produceOutput = false): string =
-  var c = conf.cCompiler
+  let c = conf.cCompiler
   # We produce files like module.nim.cpp, so the absolute Nim filename is not
   # cfile.name but `cfile.cname.changeFileExt("")`:
   var options = cFileSpecificOptions(conf, cfile.nimname, cfile.cname.changeFileExt("").string)


### PR DESCRIPTION
I am not using `vccexe` tool to run `cl` compiler so got tired of compilation and link warnings:
```
warning: unknown argument  `--platform:amd64` is ignored
```