### PR TITLE
VM: allow const ref objects

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1349,8 +1349,7 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     elif kind in {skVar, skLet}:
       result = t[1]
   of tyRef:
-    if kind == skConst: result = t
-    else: result = typeAllowedAux(marker, t.lastSon, kind, flags+{taHeap})
+    result = typeAllowedAux(marker, t.lastSon, kind, flags+{taHeap})
   of tyPtr:
     result = typeAllowedAux(marker, t.lastSon, kind, flags+{taHeap})
   of tySet:

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -1,0 +1,21 @@
+import std/json
+
+block: # case ref objects
+  const j = parseJson(""" {"x1":12,"x2":"asdf","x3":[1,2]} """)
+  const x1 = j["x1"].getInt
+  const x2 = j["x3"].to(seq[int])
+  when false:
+    # pending https://github.com/nim-lang/Nim/issues/13081
+    echo j["x1"].getInt
+
+  doAssert x1 == 12
+  doAssert x2 == @[1, 2]
+
+block: # case objects
+  type Foo = ref object
+    x1: int
+    x2: string
+    x3: seq[string]
+  const j1 = Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])
+  doAssert j1[] == Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])[]
+  doAssert $j1[] == """(x1: 12, x2: "asdf", x3: @["foo", "bar"])"""


### PR DESCRIPTION
this PR enables const ref objects.
It seems to work, and makes it usable to use more code at CT.
The pre-existing caveat (when the ref object points to a case object) is a separate, pre-existing issue (see https://github.com/nim-lang/Nim/issues/13081) that will get fixed eventually, but shouldn't block this; the problem is the `case-object` not the `ref object`

## example use case1: with ref object

```nim
type Config = ref object
  paths: seq[string]
  name: string

const j = parseFile("cfgFile.json").to(Config)
# now you can use j.paths, j.name etc at runtime; no caveats
```

## example use case2: even useful with ref case objects

```nim
import std/json
const j = parseFile("cfgFile.json")
const paths = j["paths"].to(seq[string]) # extract const field to avoid caveat mentioned in https://github.com/nim-lang/Nim/issues/13081
const name = j["name"].to(string)
# now you can use paths, name at runtime
```
