### PR TITLE
VM FFI: write(stderr, msg) and fprintf(cstderr, msg) now work at CT

### DIFF
--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -116,7 +116,11 @@ type
           incompleteStruct.} = object
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
-import system/imports_common
+# duplicated between io and ansi_c
+const stderrName* = when defined(osx): "__stderrp" else: "stderr"
+const stdoutName* = when defined(osx): "__stdoutp" else: "stdout"
+const stdinName* = when defined(osx): "__stdinp" else: "stdin"
+
 var
   cstderr* {.importc: stderrName, header: "<stdio.h>".}: CFilePtr
   cstdout* {.importc: stdoutName, header: "<stdio.h>".}: CFilePtr

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -117,9 +117,9 @@ type
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
 # duplicated between io and ansi_c
-const stderrName* = when defined(osx): "__stderrp" else: "stderr"
-const stdoutName* = when defined(osx): "__stdoutp" else: "stdout"
-const stdinName* = when defined(osx): "__stdinp" else: "stdin"
+const stderrName = when defined(osx): "__stderrp" else: "stderr"
+const stdoutName = when defined(osx): "__stdoutp" else: "stdout"
+const stdinName = when defined(osx): "__stdinp" else: "stdin"
 
 var
   cstderr* {.importc: stderrName, header: "<stdio.h>".}: CFilePtr

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -116,9 +116,11 @@ type
           incompleteStruct.} = object
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
+import system/imports_common
 var
-  cstderr* {.importc: "stderr", header: "<stdio.h>".}: CFilePtr
-  cstdout* {.importc: "stdout", header: "<stdio.h>".}: CFilePtr
+  cstderr* {.importc: stderrName, header: "<stdio.h>".}: CFilePtr
+  cstdout* {.importc: stdoutName, header: "<stdio.h>".}: CFilePtr
+  cstdin* {.importc: stdinName, header: "<stdio.h>".}: CFilePtr
 
 proc c_fprintf*(f: CFilePtr, frmt: cstring): cint {.
   importc: "fprintf", header: "<stdio.h>", varargs, discardable.}

--- a/lib/system/imports_common.nim
+++ b/lib/system/imports_common.nim
@@ -1,3 +1,0 @@
-const stderrName* = when defined(osx): "__stderrp" else: "stderr"
-const stdoutName* = when defined(osx): "__stdoutp" else: "stdout"
-const stdinName* = when defined(osx): "__stdinp" else: "stdin"

--- a/lib/system/imports_common.nim
+++ b/lib/system/imports_common.nim
@@ -1,0 +1,3 @@
+const stderrName* = when defined(osx): "__stderrp" else: "stderr"
+const stdoutName* = when defined(osx): "__stdoutp" else: "stdout"
+const stdinName* = when defined(osx): "__stdinp" else: "stdin"

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -36,9 +36,9 @@ type
 # text file handling:
 when not defined(nimscript) and not defined(js):
   # duplicated between io and ansi_c
-  const stderrName* = when defined(osx): "__stderrp" else: "stderr"
-  const stdoutName* = when defined(osx): "__stdoutp" else: "stdout"
-  const stdinName* = when defined(osx): "__stdinp" else: "stdin"
+  const stderrName = when defined(osx): "__stderrp" else: "stderr"
+  const stdoutName = when defined(osx): "__stdoutp" else: "stdout"
+  const stdinName = when defined(osx): "__stdinp" else: "stdin"
 
   var
     stdin* {.importc: stdinName, header: "<stdio.h>".}: File

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -35,12 +35,13 @@ type
 
 # text file handling:
 when not defined(nimscript) and not defined(js):
+  import system/imports_common
   var
-    stdin* {.importc: "stdin", header: "<stdio.h>".}: File
+    stdin* {.importc: stdinName, header: "<stdio.h>".}: File
       ## The standard input stream.
-    stdout* {.importc: "stdout", header: "<stdio.h>".}: File
+    stdout* {.importc: stdoutName, header: "<stdio.h>".}: File
       ## The standard output stream.
-    stderr* {.importc: "stderr", header: "<stdio.h>".}: File
+    stderr* {.importc: stderrName, header: "<stdio.h>".}: File
       ## The standard error stream.
 
 when defined(useStdoutAsStdmsg):

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -35,7 +35,11 @@ type
 
 # text file handling:
 when not defined(nimscript) and not defined(js):
-  import system/imports_common
+  # duplicated between io and ansi_c
+  const stderrName* = when defined(osx): "__stderrp" else: "stderr"
+  const stdoutName* = when defined(osx): "__stdoutp" else: "stdout"
+  const stdinName* = when defined(osx): "__stdinp" else: "stdin"
+
   var
     stdin* {.importc: stdinName, header: "<stdio.h>".}: File
       ## The standard input stream.

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -8,6 +8,8 @@ foo:102:103
 foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
+hello world stderr
+hi stderr
 '''
   output: '''
 foo
@@ -17,6 +19,8 @@ foo:102:103
 foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
+hello world stderr
+hi stderr
 '''
   disabled: "true"
 """
@@ -76,6 +80,15 @@ proc fun() =
     if false:
       c_printf("foo2:a=%d\n", a2)
 
+
 static:
   fun()
 fun()
+
+when true:
+  import system/ansi_c
+  proc fun2()=
+    c_fprintf(cstderr, "hello world stderr\n")
+    write(stderr, "hi stderr\n")
+  static: fun2()
+  fun2()


### PR DESCRIPTION
follow-up now that https://github.com/nim-lang/Nim/pull/12877 got merged. This enables the use case from https://github.com/nim-lang/Nim/pull/12840
`fprintf(cstderr, msg)` + friends now works at CT (with -d:nimHasLibFFI / --experimental:compiletimeFFI as usual)
```nim
  import system/ansi_c
  proc main()=
    c_fprintf(cstderr, "hello world stderr\n")
    write(stderr, "hi\n")
  static: main()
  main()
```
