### PR TITLE
remove all remaining warnings when build nim (with -d:nimHasLibFFI)

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -24,7 +24,7 @@ when defined(nimfix):
   import nimfix/prettybase
 
 when not defined(leanCompiler):
-  import spawn, semparallel
+  import spawn
 
 # implementation
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -106,13 +106,6 @@ proc getOrdValue*(n: PNode; onError = high(Int128)): Int128 =
     # should therefore really be revisited.
     onError
 
-proc getOrdValue64*(n: PNode): BiggestInt {.deprecated: "use getOrdvalue".} =
-  case n.kind
-  of nkCharLit..nkUInt64Lit: n.intVal
-  of nkNilLit: 0
-  of nkHiddenStdConv: getOrdValue64(n[1])
-  else: high(BiggestInt)
-
 proc getFloatValue*(n: PNode): BiggestFloat =
   case n.kind
   of nkFloatLiterals: n.floatVal


### PR DESCRIPTION
* remove all remaining warnings when build nim (with -d:nimHasLibFFI)
* remove dead code
