### PR TITLE
Deleted misplaced separator

### DIFF
--- a/lib/pure/includes/osseps.nim
+++ b/lib/pure/includes/osseps.nim
@@ -35,7 +35,6 @@ const
 
   AltSep* =
     when doslikeFileSystem: '/'
-    elif defined(haiku): ':'
     else: DirSep
     ## An alternative character used by the operating system to separate
     ## pathname components, or the same as `DirSep <#DirSep>`_ if only one separator


### PR DESCRIPTION
Misplaced separator, which was constantly breaking compilation on Haiku OS, was deleted.

Fixed #13017.