### PR TITLE
Added 'ansic' os support for minimal (embedded) targets

### DIFF
--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -22,7 +22,7 @@ type
     osNone, osDos, osWindows, osOs2, osLinux, osMorphos, osSkyos, osSolaris,
     osIrix, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osAix, osPalmos, osQnx,
     osAmiga, osAtari, osNetware, osMacos, osMacosx, osIos, osHaiku, osAndroid, osVxWorks
-    osGenode, osJS, osNimVM, osStandalone, osNintendoSwitch, osAnsiC
+    osGenode, osJS, osNimVM, osStandalone, osNintendoSwitch, osAny
 
 type
   TInfoOSProp* = enum
@@ -177,7 +177,7 @@ const
       objExt: ".o", newLine: "\x0A", pathSep: ":", dirSep: "/",
       scriptExt: ".sh", curDir: ".", exeExt: ".elf", extSep: ".",
       props: {ospNeedsPIC, ospPosix}),
-     (name: "AnsiC", parDir: "..", dllFrmt: "lib$1.so", altDirSep: "/",
+     (name: "Any", parDir: "..", dllFrmt: "lib$1.so", altDirSep: "/",
       objExt: ".o", newLine: "\x0A", pathSep: ":", dirSep: "/",
       scriptExt: ".sh", curDir: ".", exeExt: "", extSep: ".",
       props: {}),

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -22,7 +22,7 @@ type
     osNone, osDos, osWindows, osOs2, osLinux, osMorphos, osSkyos, osSolaris,
     osIrix, osNetbsd, osFreebsd, osOpenbsd, osDragonfly, osAix, osPalmos, osQnx,
     osAmiga, osAtari, osNetware, osMacos, osMacosx, osIos, osHaiku, osAndroid, osVxWorks
-    osGenode, osJS, osNimVM, osStandalone, osNintendoSwitch
+    osGenode, osJS, osNimVM, osStandalone, osNintendoSwitch, osAnsiC
 
 type
   TInfoOSProp* = enum
@@ -177,6 +177,10 @@ const
       objExt: ".o", newLine: "\x0A", pathSep: ":", dirSep: "/",
       scriptExt: ".sh", curDir: ".", exeExt: ".elf", extSep: ".",
       props: {ospNeedsPIC, ospPosix}),
+     (name: "AnsiC", parDir: "..", dllFrmt: "lib$1.so", altDirSep: "/",
+      objExt: ".o", newLine: "\x0A", pathSep: ":", dirSep: "/",
+      scriptExt: ".sh", curDir: ".", exeExt: "", extSep: ".",
+      props: {}),
      ]
 
 type

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2096,7 +2096,7 @@ template sysAssert(cond: bool, msg: string) =
 
 const hasAlloc = (hostOS != "standalone" or not defined(nogc)) and not defined(nimscript)
 
-when notJSnotNims and hostOS != "standalone":
+when notJSnotNims and hostOS != "standalone" and hostOS != "ansic":
   include "system/cgprocs"
 when notJSnotNims and hasAlloc and not defined(nimSeqsV2):
   proc addChar(s: NimString, c: char): NimString {.compilerproc, benign.}
@@ -3741,7 +3741,7 @@ when not defined(JS):
 
 
 when notJSnotNims:
-  when hostOS != "standalone":
+  when hostOS != "standalone" and hostOS != "ansic":
     include "system/dyncalls"
 
   include "system/sets"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2096,7 +2096,7 @@ template sysAssert(cond: bool, msg: string) =
 
 const hasAlloc = (hostOS != "standalone" or not defined(nogc)) and not defined(nimscript)
 
-when notJSnotNims and hostOS != "standalone" and hostOS != "ansic":
+when notJSnotNims and hostOS != "standalone" and hostOS != "any":
   include "system/cgprocs"
 when notJSnotNims and hasAlloc and not defined(nimSeqsV2):
   proc addChar(s: NimString, c: char): NimString {.compilerproc, benign.}
@@ -3741,7 +3741,7 @@ when not defined(JS):
 
 
 when notJSnotNims:
-  when hostOS != "standalone" and hostOS != "ansic":
+  when hostOS != "standalone" and hostOS != "any":
     include "system/dyncalls"
 
   include "system/sets"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3394,6 +3394,11 @@ var
     ##
     ## If the handler does not raise an exception, ordinary control flow
     ## continues and the program is terminated.
+  unhandledExceptionHook*: proc (e: ref Exception) {.nimcall, tags: [], benign, raises: [].}
+    ## Set this variable to provide a procedure that should be called
+    ## in case of an `unhandle exception` event. The standard handler
+    ## writes an error message and terminates the program, except when
+    ## using `--os:any`
 
 type
   PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -210,7 +210,7 @@ when defined(nativeStacktrace) and nativeStackTraceSupported:
           # interested in
           enabled = true
 
-when not hasThreadSupport:
+when hasSomeStackTrace and not hasThreadSupport:
   var
     tempFrames: array[0..127, PFrame] # should not be alloc'd on stack
 
@@ -261,52 +261,53 @@ proc `$`(s: seq[StackTraceEntry]): string =
     elif s[i].line == reraisedFromEnd: result.add "]]\n"
     else: addFrameEntry(result, s[i])
 
-proc auxWriteStackTrace(f: PFrame, s: var string) =
-  when hasThreadSupport:
-    var
-      tempFrames: array[0..127, PFrame] # but better than a threadvar
-  const
-    firstCalls = 32
-  var
-    it = f
-    i = 0
-    total = 0
-  # setup long head:
-  while it != nil and i <= high(tempFrames)-firstCalls:
-    tempFrames[i] = it
-    inc(i)
-    inc(total)
-    it = it.prev
-  # go up the stack to count 'total':
-  var b = it
-  while it != nil:
-    inc(total)
-    it = it.prev
-  var skipped = 0
-  if total > len(tempFrames):
-    # skip N
-    skipped = total-i-firstCalls+1
-    for j in 1..skipped:
-      if b != nil: b = b.prev
-    # create '...' entry:
-    tempFrames[i] = nil
-    inc(i)
-  # setup short tail:
-  while b != nil and i <= high(tempFrames):
-    tempFrames[i] = b
-    inc(i)
-    b = b.prev
-  for j in countdown(i-1, 0):
-    if tempFrames[j] == nil:
-      add(s, "(")
-      add(s, $skipped)
-      add(s, " calls omitted) ...\n")
-    else:
-      addFrameEntry(s, tempFrames[j])
-
-proc stackTraceAvailable*(): bool
-
 when hasSomeStackTrace:
+
+  proc auxWriteStackTrace(f: PFrame, s: var string) =
+    when hasThreadSupport:
+      var
+        tempFrames: array[0..127, PFrame] # but better than a threadvar
+    const
+      firstCalls = 32
+    var
+      it = f
+      i = 0
+      total = 0
+    # setup long head:
+    while it != nil and i <= high(tempFrames)-firstCalls:
+      tempFrames[i] = it
+      inc(i)
+      inc(total)
+      it = it.prev
+    # go up the stack to count 'total':
+    var b = it
+    while it != nil:
+      inc(total)
+      it = it.prev
+    var skipped = 0
+    if total > len(tempFrames):
+      # skip N
+      skipped = total-i-firstCalls+1
+      for j in 1..skipped:
+        if b != nil: b = b.prev
+      # create '...' entry:
+      tempFrames[i] = nil
+      inc(i)
+    # setup short tail:
+    while b != nil and i <= high(tempFrames):
+      tempFrames[i] = b
+      inc(i)
+      b = b.prev
+    for j in countdown(i-1, 0):
+      if tempFrames[j] == nil:
+        add(s, "(")
+        add(s, $skipped)
+        add(s, " calls omitted) ...\n")
+      else:
+        addFrameEntry(s, tempFrames[j])
+
+  proc stackTraceAvailable*(): bool
+
   proc rawWriteStackTrace(s: var string) =
     when defined(nimStackTraceOverride):
       add(s, "Traceback (most recent call last, using override)\n")
@@ -424,14 +425,6 @@ when gotoBasedExceptions:
       reportUnhandledError(currException)
       currException = nil
       quit(1)
-
-  addQuitProc(proc () {.noconv.} =
-    if currException != nil:
-      reportUnhandledError(currException)
-      # emulate: ``programResult = 1`` via abort() and a nop signal handler.
-      c_signal(SIGABRT, (proc (sign: cint) {.noconv, benign.} = discard))
-      c_abort()
-  )
 
 proc raiseExceptionAux(e: sink(ref Exception)) {.nodestroy.} =
   if localRaiseHook != nil:

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -610,7 +610,7 @@ when declared(stdout):
       android_log_print(ANDROID_LOG_VERBOSE, "nim", s)
     else:
       # flockfile deadlocks some versions of Android 5.x.x
-      when not defined(windows) and not defined(android) and not defined(nintendoswitch):
+      when not defined(windows) and not defined(android) and not defined(nintendoswitch) and hostOS != "ansic":
         proc flockfile(f: File) {.importc, nodecl.}
         proc funlockfile(f: File) {.importc, nodecl.}
         flockfile(stdout)
@@ -624,7 +624,7 @@ when declared(stdout):
       const linefeed = "\n"
       discard c_fwrite(linefeed.cstring, linefeed.len, 1, stdout)
       discard c_fflush(stdout)
-      when not defined(windows) and not defined(android) and not defined(nintendoswitch):
+      when not defined(windows) and not defined(android) and not defined(nintendoswitch) and hostOS != "ansic":
         funlockfile(stdout)
       when defined(windows) and compileOption("threads"):
         releaseSys echoLock

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -610,7 +610,7 @@ when declared(stdout):
       android_log_print(ANDROID_LOG_VERBOSE, "nim", s)
     else:
       # flockfile deadlocks some versions of Android 5.x.x
-      when not defined(windows) and not defined(android) and not defined(nintendoswitch) and hostOS != "ansic":
+      when not defined(windows) and not defined(android) and not defined(nintendoswitch) and hostOS != "any":
         proc flockfile(f: File) {.importc, nodecl.}
         proc funlockfile(f: File) {.importc, nodecl.}
         flockfile(stdout)
@@ -624,7 +624,7 @@ when declared(stdout):
       const linefeed = "\n"
       discard c_fwrite(linefeed.cstring, linefeed.len, 1, stdout)
       discard c_fflush(stdout)
-      when not defined(windows) and not defined(android) and not defined(nintendoswitch) and hostOS != "ansic":
+      when not defined(windows) and not defined(android) and not defined(nintendoswitch) and hostOS != "any":
         funlockfile(stdout)
       when defined(windows) and compileOption("threads"):
         releaseSys echoLock

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -295,5 +295,16 @@ elif hostOS == "standalone" or defined(StandaloneHeapSize):
   proc osDeallocPages(p: pointer, size: int) {.inline.} =
     if bumpPointer-size == cast[int](p):
       dec bumpPointer, size
+
+elif hostOS == "ansic":
+  proc osAllocPages(size: int): pointer {.inline.} =
+    result = c_malloc(size.csize_t)
+
+  proc osTryAllocPages(size: int): pointer {.inline.} =
+    result = c_malloc(size.csize_t)
+
+  proc osDeallocPages(p: pointer, size: int) {.inline.} =
+    c_free(p)
+
 else:
   {.error: "Port memory manager to your platform".}

--- a/lib/system/osalloc.nim
+++ b/lib/system/osalloc.nim
@@ -296,7 +296,7 @@ elif hostOS == "standalone" or defined(StandaloneHeapSize):
     if bumpPointer-size == cast[int](p):
       dec bumpPointer, size
 
-elif hostOS == "ansic":
+elif hostOS == "any":
   proc osAllocPages(size: int): pointer {.inline.} =
     result = c_malloc(size.csize_t)
 


### PR DESCRIPTION
Note: draft only.

Added a new OS target for running Nim on embedded targets with very basic OS support, the goal is to require only ANSI C features and nothing else. This new `--os:ansic` is ideally used together with `--useMalloc` and `--gc:arc` and might replace `--os:standalone` one day.

This solves:

- The creation of a static RAM area for heap management, now we rely on `malloc()` and `free()` only
- Prevents creation of stack trace info in RAM when stack traces are disabled
- Disabled SIGABRT hack for `gotoBasedExecptions`