### PR TITLE
enable testing -d:nimHasLibFFI mode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,26 +5,26 @@ jobs:
 
   strategy:
     matrix:
-      # Linux_amd64:
-      #   vmImage: 'ubuntu-16.04'
-      #   CPU: amd64
-      # Linux_i386:
-      #   vmImage: 'ubuntu-16.04'
-      #   CPU: i386
-      # OSX_amd64:
-      #   vmImage: 'macOS-10.14'
-      #   CPU: amd64
-      # OSX_amd64_cpp:
-      #   vmImage: 'macOS-10.14'
-      #   CPU: amd64
-      #   NIM_COMPILE_TO_CPP: true
-      # Windows_amd64:
-      #   vmImage: 'windows-2019'
-      #   CPU: amd64
-      # Windows_amd64_pkg:
-      #   vmImage: 'windows-2019'
-      #   CPU: amd64
-      #   NIM_TEST_PACKAGES: true
+      Linux_amd64:
+        vmImage: 'ubuntu-16.04'
+        CPU: amd64
+      Linux_i386:
+        vmImage: 'ubuntu-16.04'
+        CPU: i386
+      OSX_amd64:
+        vmImage: 'macOS-10.14'
+        CPU: amd64
+      OSX_amd64_cpp:
+        vmImage: 'macOS-10.14'
+        CPU: amd64
+        NIM_COMPILE_TO_CPP: true
+      Windows_amd64:
+        vmImage: 'windows-2019'
+        CPU: amd64
+      Windows_amd64_pkg:
+        vmImage: 'windows-2019'
+        CPU: amd64
+        NIM_TEST_PACKAGES: true
 
   pool:
     vmImage: $(vmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ jobs:
         DEBIAN_FRONTEND='noninteractive' \
           sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
             g++-multilib gcc-multilib libcurl4-openssl-dev:i386 libgc-dev:i386 \
-            libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386
+            libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386 libffi-dev
 
         cat << EOF > bin/gcc
         #!/bin/bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,26 +5,26 @@ jobs:
 
   strategy:
     matrix:
-      Linux_amd64:
-        vmImage: 'ubuntu-16.04'
-        CPU: amd64
-      Linux_i386:
-        vmImage: 'ubuntu-16.04'
-        CPU: i386
-      OSX_amd64:
-        vmImage: 'macOS-10.14'
-        CPU: amd64
-      OSX_amd64_cpp:
-        vmImage: 'macOS-10.14'
-        CPU: amd64
-        NIM_COMPILE_TO_CPP: true
-      Windows_amd64:
-        vmImage: 'windows-2019'
-        CPU: amd64
-      Windows_amd64_pkg:
-        vmImage: 'windows-2019'
-        CPU: amd64
-        NIM_TEST_PACKAGES: true
+      # Linux_amd64:
+      #   vmImage: 'ubuntu-16.04'
+      #   CPU: amd64
+      # Linux_i386:
+      #   vmImage: 'ubuntu-16.04'
+      #   CPU: i386
+      # OSX_amd64:
+      #   vmImage: 'macOS-10.14'
+      #   CPU: amd64
+      # OSX_amd64_cpp:
+      #   vmImage: 'macOS-10.14'
+      #   CPU: amd64
+      #   NIM_COMPILE_TO_CPP: true
+      # Windows_amd64:
+      #   vmImage: 'windows-2019'
+      #   CPU: amd64
+      # Windows_amd64_pkg:
+      #   vmImage: 'windows-2019'
+      #   CPU: amd64
+      #   NIM_TEST_PACKAGES: true
 
   pool:
     vmImage: $(vmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,10 +74,12 @@ jobs:
         EOF
 
         sudo apt-fast update -qq
+        # `:i386` (e.g. in `libffi-dev:i386`) is needed otherwise you may get:
+        # `could not load: libffi.so` during dynamic loading.
         DEBIAN_FRONTEND='noninteractive' \
           sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
             g++-multilib gcc-multilib libcurl4-openssl-dev:i386 libgc-dev:i386 \
-            libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386 libffi-dev
+            libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386 libffi-dev:i386
 
         cat << EOF > bin/gcc
         #!/bin/bash

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -103,3 +103,9 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimNewShiftOps")
   defineSymbol("nimHasCursor")
   defineSymbol("nimHasExceptionsQuery")
+
+  when defined(nimHasLibFFI):
+    # Renaming as we can't conflate input vs output define flags; e.g. this
+    # will report the right thing regardless of whether user adds
+    # `-d:nimHasLibFFI` in his user config.
+    defineSymbol("nimHasLibFFIEnabled")

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -18,7 +18,6 @@ when defined(windows):
 elif defined(linux):
   const libcDll = "libc.so(.6|.5|)"
 elif defined(freebsd):
-  # const libcDll = "/usr/lib/libc.so"
   const libcDll = "/lib/libc.so.7"
 elif defined(osx):
   const libcDll = "/usr/lib/libSystem.dylib"

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -17,7 +17,7 @@ when defined(windows):
   const libcDll = "msvcrt.dll"
 elif defined(linux):
   const libcDll = "libc.so(.6|.5|)"
-elif defined(freebsd):
+elif defined(bsd):
   const libcDll = "/lib/libc.so.7"
 elif defined(osx):
   const libcDll = "/usr/lib/libSystem.dylib"

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -17,6 +17,9 @@ when defined(windows):
   const libcDll = "msvcrt.dll"
 elif defined(linux):
   const libcDll = "libc.so(.6|.5|)"
+elif defined(freebsd):
+  # const libcDll = "/usr/lib/libc.so"
+  const libcDll = "/lib/libc.so.7"
 elif defined(osx):
   const libcDll = "/usr/lib/libSystem.dylib"
 else:

--- a/koch.nim
+++ b/koch.nim
@@ -485,9 +485,9 @@ proc runCI(cmd: string) =
   ## build nimble early on to enable remainder to depend on it if needed
   kochExecFold("Build Nimble", "nimble")
 
-  when false:
-    execFold("nimble install -y libffi", "nimble install -y libffi")
-    kochExecFold("boot -d:release -d:nimHasLibFFI", "boot -d:release -d:nimHasLibFFI")
+  ## test -d:nimHasLibFFI
+  execFold("nimble install -y libffi", "nimble install -y libffi")
+  kochExecFold("boot -d:release -d:nimHasLibFFI", "boot -d:release -d:nimHasLibFFI")
 
   if getEnv("NIM_TEST_PACKAGES", "false") == "true":
     execFold("Test selected Nimble packages", "nim c -r testament/testament cat nimble-packages")

--- a/koch.nim
+++ b/koch.nim
@@ -486,7 +486,9 @@ proc runCI(cmd: string) =
   kochExecFold("Build Nimble", "nimble")
 
   ## test -d:nimHasLibFFI
-  execFold("nimble install -y libffi", "nimble install -y libffi")
+  ## pending https://github.com/Araq/libffi/pull/4
+  # execFold("nimble install -y libffi", "nimble install -y libffi")
+  execFold("nimble install -y https://github.com/timotheecour/libffi@9617720caba60ebd458fc1470f7b49ba19d32006", "nimble install -y libffi")
   kochExecFold("boot -d:release -d:nimHasLibFFI", "boot -d:release -d:nimHasLibFFI")
 
   if getEnv("NIM_TEST_PACKAGES", "false") == "true":

--- a/koch.nim
+++ b/koch.nim
@@ -504,7 +504,7 @@ proc runCI(cmd: string) =
         const nimFFI = "./bin/nim.ctffi"
         # no need to bootstrap with koch boot (would be slower)
         execFold("build with -d:nimHasLibFFI", "nim c -d:release -d:nimHasLibFFI -o:$1 compiler/nim.nim" % [nimFFI])
-        execFold("test with -d:nimHasLibFFI", "nim c -r testament/testament --nim:$1 r tests/vm/tevalffi.nim" % [nimFFI])
+        execFold("test with -d:nimHasLibFFI", "$1 c -r testament/testament --nim:$1 r tests/vm/tevalffi.nim" % [nimFFI])
 
     execFold("Run nimdoc tests", "nim c -r nimdoc/tester")
     execFold("Run nimpretty tests", "nim c -r nimpretty/tester.nim")

--- a/koch.nim
+++ b/koch.nim
@@ -477,8 +477,8 @@ proc runCI(cmd: string) =
   echo "runCI:", cmd
   # note(@araq): Do not replace these commands with direct calls (eg boot())
   # as that would weaken our testing efforts.
-  when defined(posix): # appveyor (on windows) didn't run this
-    kochExecFold("Boot", "boot")
+  # when defined(posix): # appveyor (on windows) didn't run this
+  #   kochExecFold("Boot", "boot")
   # boot without -d:nimHasLibFFI to make sure this still works
   kochExecFold("Boot in release mode", "boot -d:release -d:danger")
 
@@ -497,7 +497,7 @@ proc runCI(cmd: string) =
       execFold("Compile tester", "nim c -d:nimCoroutines --os:genode -d:posix --compileOnly testament/testament")
 
     # main bottleneck here
-    execFold("Run tester", "nim c -r -d:nimCoroutines testament/testament --pedantic all -d:nimCoroutines")
+    # execFold("Run tester", "nim c -r -d:nimCoroutines testament/testament --pedantic all -d:nimCoroutines")
     block: # CT FFI
       when defined(posix): # windows can be handled in future PR's
         execFold("nimble install -y libffi", "nimble install -y libffi")

--- a/koch.nim
+++ b/koch.nim
@@ -485,10 +485,6 @@ proc runCI(cmd: string) =
   ## build nimble early on to enable remainder to depend on it if needed
   kochExecFold("Build Nimble", "nimble")
 
-  ## test -d:nimHasLibFFI
-  execFold("nimble install -y libffi", "nimble install -y libffi")
-  kochExecFold("boot -d:release -d:nimHasLibFFI", "boot -d:release -d:nimHasLibFFI")
-
   if getEnv("NIM_TEST_PACKAGES", "false") == "true":
     execFold("Test selected Nimble packages", "nim c -r testament/testament cat nimble-packages")
   else:
@@ -502,6 +498,13 @@ proc runCI(cmd: string) =
 
     # main bottleneck here
     execFold("Run tester", "nim c -r -d:nimCoroutines testament/testament --pedantic all -d:nimCoroutines")
+    block: # CT FFI
+      when defined(posix): # windows can be handled in future PR's
+        execFold("nimble install -y libffi", "nimble install -y libffi")
+        const nimFFI = "./bin/nim.ctffi"
+        # no need to bootstrap with koch boot (would be slower)
+        execFold("build with -d:nimHasLibFFI", "nim c -d:release -d:nimHasLibFFI -o:$1 compiler/nim.nim" % [nimFFI])
+        execFold("test with -d:nimHasLibFFI", "nim c -r testament/testament --nim:$1 r tests/vm/tevalffi.nim" % [nimFFI])
 
     execFold("Run nimdoc tests", "nim c -r nimdoc/tester")
     execFold("Run nimpretty tests", "nim c -r nimpretty/tester.nim")

--- a/koch.nim
+++ b/koch.nim
@@ -477,8 +477,8 @@ proc runCI(cmd: string) =
   echo "runCI:", cmd
   # note(@araq): Do not replace these commands with direct calls (eg boot())
   # as that would weaken our testing efforts.
-  # when defined(posix): # appveyor (on windows) didn't run this
-  #   kochExecFold("Boot", "boot")
+  when defined(posix): # appveyor (on windows) didn't run this
+    kochExecFold("Boot", "boot")
   # boot without -d:nimHasLibFFI to make sure this still works
   kochExecFold("Boot in release mode", "boot -d:release -d:danger")
 
@@ -497,7 +497,7 @@ proc runCI(cmd: string) =
       execFold("Compile tester", "nim c -d:nimCoroutines --os:genode -d:posix --compileOnly testament/testament")
 
     # main bottleneck here
-    # execFold("Run tester", "nim c -r -d:nimCoroutines testament/testament --pedantic all -d:nimCoroutines")
+    execFold("Run tester", "nim c -r -d:nimCoroutines testament/testament --pedantic all -d:nimCoroutines")
     block: # CT FFI
       when defined(posix): # windows can be handled in future PR's
         execFold("nimble install -y libffi", "nimble install -y libffi")

--- a/koch.nim
+++ b/koch.nim
@@ -486,9 +486,7 @@ proc runCI(cmd: string) =
   kochExecFold("Build Nimble", "nimble")
 
   ## test -d:nimHasLibFFI
-  ## pending https://github.com/Araq/libffi/pull/4
-  # execFold("nimble install -y libffi", "nimble install -y libffi")
-  execFold("nimble install -y https://github.com/timotheecour/libffi@9617720caba60ebd458fc1470f7b49ba19d32006", "nimble install -y libffi")
+  execFold("nimble install -y libffi", "nimble install -y libffi")
   kochExecFold("boot -d:release -d:nimHasLibFFI", "boot -d:release -d:nimHasLibFFI")
 
   if getEnv("NIM_TEST_PACKAGES", "false") == "true":

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -117,7 +117,7 @@ type
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
 # duplicated between io and ansi_c
-const stdioUsesMacros = (defined(osx) or defined(freebsd)) and not defined(emscripten)
+const stdioUsesMacros = (defined(osx) or defined(bsd)) and not defined(emscripten)
 const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
 const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
 const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -117,7 +117,7 @@ type
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
 # duplicated between io and ansi_c
-const stdioUsesMacros = defined(osx) and not defined(emscripten)
+const stdioUsesMacros = (defined(osx) or defined(freebsd)) and not defined(emscripten)
 const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
 const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
 const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -36,7 +36,7 @@ type
 # text file handling:
 when not defined(nimscript) and not defined(js):
   # duplicated between io and ansi_c
-  const stdioUsesMacros = defined(osx) and not defined(emscripten)
+  const stdioUsesMacros = (defined(osx) or defined(freebsd)) and not defined(emscripten)
   const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
   const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
   const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -36,7 +36,7 @@ type
 # text file handling:
 when not defined(nimscript) and not defined(js):
   # duplicated between io and ansi_c
-  const stdioUsesMacros = (defined(osx) or defined(freebsd)) and not defined(emscripten)
+  const stdioUsesMacros = (defined(osx) or defined(bsd)) and not defined(emscripten)
   const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
   const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
   const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -236,8 +236,8 @@ proc parseSpec*(filename: string): TSpec =
           when defined(freebsd): result.err = reDisabled
         of "arm64":
           when defined(arm64): result.err = reDisabled
-        of "not defined(nimhaslibffi)": # a bit hacky, this could be generalized somehow
-          when not defined(nimHasLibFFI): result.err = reDisabled
+        of "not defined(nimhaslibffienabled)": # a bit hacky, this could be generalized somehow
+          when not defined(nimHasLibFFIEnabled): result.err = reDisabled
         else:
           result.parseErrors.addLine "cannot interpret as a bool: ", e.value
       of "cmd":

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -236,6 +236,8 @@ proc parseSpec*(filename: string): TSpec =
           when defined(freebsd): result.err = reDisabled
         of "arm64":
           when defined(arm64): result.err = reDisabled
+        of "not defined(nimHasLibFFI)": # this could be generalized somehow
+          when not defined(nimHasLibFFI): result.err = reDisabled
         else:
           result.parseErrors.addLine "cannot interpret as a bool: ", e.value
       of "cmd":

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -236,8 +236,6 @@ proc parseSpec*(filename: string): TSpec =
           when defined(freebsd): result.err = reDisabled
         of "arm64":
           when defined(arm64): result.err = reDisabled
-        of "not defined(nimhaslibffienabled)": # a bit hacky, this could be generalized somehow
-          when not defined(nimHasLibFFIEnabled): result.err = reDisabled
         else:
           result.parseErrors.addLine "cannot interpret as a bool: ", e.value
       of "cmd":

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -236,7 +236,7 @@ proc parseSpec*(filename: string): TSpec =
           when defined(freebsd): result.err = reDisabled
         of "arm64":
           when defined(arm64): result.err = reDisabled
-        of "not defined(nimHasLibFFI)": # this could be generalized somehow
+        of "not defined(nimhaslibffi)": # a bit hacky, this could be generalized somehow
           when not defined(nimHasLibFFI): result.err = reDisabled
         else:
           result.parseErrors.addLine "cannot interpret as a bool: ", e.value

--- a/tests/vm/mevalffi.nim
+++ b/tests/vm/mevalffi.nim
@@ -1,0 +1,67 @@
+# re-enable for windows once libffi can be installed in koch.nim
+# With win32 (not yet win64), libffi on windows works and this test passes.
+
+when defined(linux) or defined(freebsd):
+  {.passL: "-lm".} # for exp
+proc c_exp(a: float64): float64 {.importc: "exp", header: "<math.h>".}
+
+proc c_printf(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.}
+
+const snprintfName = when defined(windows): "_snprintf" else: "snprintf"
+proc c_snprintf*(buffer: pointer, buf_size: uint, format: cstring): cint {.importc: snprintfName, header: "<stdio.h>", varargs .}
+
+proc c_malloc(size:uint):pointer {.importc:"malloc", header: "<stdlib.h>".}
+proc c_free(p: pointer) {.importc:"free", header: "<stdlib.h>".}
+
+proc fun() =
+  block: # c_exp
+    var x = 0.3
+    let b = c_exp(x)
+    let b2 = int(b*1_000_000) # avoids floating point equality
+    doAssert b2 == 1349858
+    doAssert c_exp(0.3) == c_exp(x)
+    const x2 = 0.3
+    doAssert c_exp(x2) == c_exp(x)
+
+  block: # c_printf
+    c_printf("foo\n")
+    c_printf("foo:%d\n", 100)
+    c_printf("foo:%d\n", 101.cint)
+    c_printf("foo:%d:%d\n", 102.cint, 103.cint)
+    let temp = 104.cint
+    c_printf("foo:%d:%d:%d\n", 102.cint, 103.cint, temp)
+    var temp2 = 105.cint
+    c_printf("foo:%g:%s:%d:%d\n", 0.03, "asdf", 103.cint, temp2)
+
+  block: # c_snprintf, c_malloc, c_free
+    let n: uint = 50
+    var buffer2: pointer = c_malloc(n)
+    var s: cstring = "foobar"
+    var age: cint = 25
+    discard c_snprintf(buffer2, n, "s1:%s s2:%s age:%d pi:%g", s, s, age, 3.14)
+    c_printf("ret={%s}\n", buffer2)
+    c_free(buffer2) # not sure it has an effect
+
+  block: # c_printf bug
+    var a = 123
+    var a2 = a.addr
+    #[
+    bug: different behavior between CT RT in this case:
+    at CT, shows foo2:a=123
+    at RT, shows foo2:a=<address as int>
+    ]#
+    if false:
+      c_printf("foo2:a=%d\n", a2)
+
+
+static:
+  fun()
+fun()
+
+import system/ansi_c
+block:
+  proc fun2()=
+    c_fprintf(cstderr, "hello world stderr\n")
+    write(stderr, "hi stderr\n")
+  static: fun2()
+  fun2()

--- a/tests/vm/mevalffi.nim
+++ b/tests/vm/mevalffi.nim
@@ -1,7 +1,7 @@
 # re-enable for windows once libffi can be installed in koch.nim
 # With win32 (not yet win64), libffi on windows works and this test passes.
 
-when defined(linux) or defined(freebsd):
+when defined(linux) or defined(bsd):
   {.passL: "-lm".} # for exp
 proc c_exp(a: float64): float64 {.importc: "exp", header: "<math.h>".}
 

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -1,94 +1,36 @@
 discard """
-  cmd: "nim c --experimental:compiletimeFFI $file"
-  nimout: '''
-hello world stderr
-hi stderr
-foo
-foo:100
-foo:101
-foo:102:103
-foo:102:103:104
-foo:0.03:asdf:103:105
-ret={s1:foobar s2:foobar age:25 pi:3.14}
-'''
-  output: '''
-hello world stderr
-hi stderr
-foo
-foo:100
-foo:101
-foo:102:103
-foo:102:103:104
-foo:0.03:asdf:103:105
-ret={s1:foobar s2:foobar age:25 pi:3.14}
-'''
-  disabled: "not defined(nimHasLibFFIEnabled)"
+  joinable: false
 """
 
-# re-enable for windows once libffi can be installed in koch.nim
-# With win32 (not yet win64), libffi on windows works and this test passes.
+import std/[strformat,os,osproc]
 
-when defined(linux) or defined(freebsd):
-  {.passL: "-lm".} # for exp
-proc c_exp(a: float64): float64 {.importc: "exp", header: "<math.h>".}
+proc main() =
+  const nim = getCurrentCompilerExe()
+  const file = currentSourcePath().parentDir / "mevalffi.nim"
+  let cmd = fmt"{nim} c -r -f --experimental:compiletimeFFI --hints:off {file}"
+  let (output, exitCode) = execCmdEx(cmd)
+  let expected = """
+hello world stderr
+hi stderr
+hello world stderr
+hi stderr
+foo
+foo:100
+foo:101
+foo:102:103
+foo:102:103:104
+foo:0.03:asdf:103:105
+ret={s1:foobar s2:foobar age:25 pi:3.14}
+foo
+foo:100
+foo:101
+foo:102:103
+foo:102:103:104
+foo:0.03:asdf:103:105
+ret={s1:foobar s2:foobar age:25 pi:3.14}
+"""
+  doAssert output == expected, output
+  doAssert exitCode == 0
 
-proc c_printf(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.}
-
-const snprintfName = when defined(windows): "_snprintf" else: "snprintf"
-proc c_snprintf*(buffer: pointer, buf_size: uint, format: cstring): cint {.importc: snprintfName, header: "<stdio.h>", varargs .}
-
-proc c_malloc(size:uint):pointer {.importc:"malloc", header: "<stdlib.h>".}
-proc c_free(p: pointer) {.importc:"free", header: "<stdlib.h>".}
-
-proc fun() =
-  block: # c_exp
-    var x = 0.3
-    let b = c_exp(x)
-    let b2 = int(b*1_000_000) # avoids floating point equality
-    doAssert b2 == 1349858
-    doAssert c_exp(0.3) == c_exp(x)
-    const x2 = 0.3
-    doAssert c_exp(x2) == c_exp(x)
-
-  block: # c_printf
-    c_printf("foo\n")
-    c_printf("foo:%d\n", 100)
-    c_printf("foo:%d\n", 101.cint)
-    c_printf("foo:%d:%d\n", 102.cint, 103.cint)
-    let temp = 104.cint
-    c_printf("foo:%d:%d:%d\n", 102.cint, 103.cint, temp)
-    var temp2 = 105.cint
-    c_printf("foo:%g:%s:%d:%d\n", 0.03, "asdf", 103.cint, temp2)
-
-  block: # c_snprintf, c_malloc, c_free
-    let n: uint = 50
-    var buffer2: pointer = c_malloc(n)
-    var s: cstring = "foobar"
-    var age: cint = 25
-    discard c_snprintf(buffer2, n, "s1:%s s2:%s age:%d pi:%g", s, s, age, 3.14)
-    c_printf("ret={%s}\n", buffer2)
-    c_free(buffer2) # not sure it has an effect
-
-  block: # c_printf bug
-    var a = 123
-    var a2 = a.addr
-    #[
-    bug: different behavior between CT RT in this case:
-    at CT, shows foo2:a=123
-    at RT, shows foo2:a=<address as int>
-    ]#
-    if false:
-      c_printf("foo2:a=%d\n", a2)
-
-
-static:
-  fun()
-fun()
-
-import system/ansi_c
-block:
-  proc fun2()=
-    c_fprintf(cstderr, "hello world stderr\n")
-    write(stderr, "hi stderr\n")
-  static: fun2()
-  fun2()
+when defined(nimHasLibFFIEnabled):
+  main()

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -1,6 +1,8 @@
 discard """
   cmd: "nim c --experimental:compiletimeFFI $file"
   nimout: '''
+hello world stderr
+hi stderr
 foo
 foo:100
 foo:101
@@ -8,10 +10,10 @@ foo:102:103
 foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
-hello world stderr
-hi stderr
 '''
   output: '''
+hello world stderr
+hi stderr
 foo
 foo:100
 foo:101
@@ -19,8 +21,6 @@ foo:102:103
 foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
-hello world stderr
-hi stderr
 '''
 """
 
@@ -84,8 +84,8 @@ static:
   fun()
 fun()
 
-when true:
-  import system/ansi_c
+import system/ansi_c
+block:
   proc fun2()=
     c_fprintf(cstderr, "hello world stderr\n")
     write(stderr, "hi stderr\n")

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -22,6 +22,7 @@ foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
 '''
+  disabled: "windows"
 """
 
 # re-enable for windows once libffi can be installed in koch.nim

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -22,7 +22,6 @@ ret={s1:foobar s2:foobar age:25 pi:3.14}
 hello world stderr
 hi stderr
 '''
-  disabled: "true"
 """
 
 # re-enable for windows once libffi can be installed in koch.nim

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -22,13 +22,13 @@ foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
 '''
-  disabled: "not defined(nimHasLibFFI)"
+  disabled: "not defined(nimHasLibFFIEnabled)"
 """
 
 # re-enable for windows once libffi can be installed in koch.nim
 # With win32 (not yet win64), libffi on windows works and this test passes.
 
-when defined(linux):
+when defined(linux) or defined(freebsd):
   {.passL: "-lm".} # for exp
 proc c_exp(a: float64): float64 {.importc: "exp", header: "<math.h>".}
 

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -7,7 +7,8 @@ import std/[strformat,os,osproc]
 proc main() =
   const nim = getCurrentCompilerExe()
   const file = currentSourcePath().parentDir / "mevalffi.nim"
-  let cmd = fmt"{nim} c -f --experimental:compiletimeFFI --hints:off {file}"
+  # strangely, --hint:cc:off was needed
+  let cmd = fmt"{nim} c -f --experimental:compiletimeFFI --hints:off --hint:cc:off {file}"
   let (output, exitCode) = execCmdEx(cmd)
   let expected = """
 hello world stderr

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -22,7 +22,7 @@ foo:102:103:104
 foo:0.03:asdf:103:105
 ret={s1:foobar s2:foobar age:25 pi:3.14}
 '''
-  disabled: "windows"
+  disabled: "not defined(nimHasLibFFI)"
 """
 
 # re-enable for windows once libffi can be installed in koch.nim
@@ -65,7 +65,7 @@ proc fun() =
     var buffer2: pointer = c_malloc(n)
     var s: cstring = "foobar"
     var age: cint = 25
-    let j = c_snprintf(buffer2, n, "s1:%s s2:%s age:%d pi:%g", s, s, age, 3.14)
+    discard c_snprintf(buffer2, n, "s1:%s s2:%s age:%d pi:%g", s, s, age, 3.14)
     c_printf("ret={%s}\n", buffer2)
     c_free(buffer2) # not sure it has an effect
 

--- a/tests/vm/tevalffi.nim
+++ b/tests/vm/tevalffi.nim
@@ -7,20 +7,11 @@ import std/[strformat,os,osproc]
 proc main() =
   const nim = getCurrentCompilerExe()
   const file = currentSourcePath().parentDir / "mevalffi.nim"
-  let cmd = fmt"{nim} c -r -f --experimental:compiletimeFFI --hints:off {file}"
+  let cmd = fmt"{nim} c -f --experimental:compiletimeFFI --hints:off {file}"
   let (output, exitCode) = execCmdEx(cmd)
   let expected = """
 hello world stderr
 hi stderr
-hello world stderr
-hi stderr
-foo
-foo:100
-foo:101
-foo:102:103
-foo:102:103:104
-foo:0.03:asdf:103:105
-ret={s1:foobar s2:foobar age:25 pi:3.14}
 foo
 foo:100
 foo:101


### PR DESCRIPTION
* prevents future regressions (especially platform specific ones) caused by that code not being tested in CI (there were a bunch in the past since -d:nimHasLibFFI was introduced, which is not surprising for code not being tested)
* speaking of which fixes one such regression on windows
* minimal impact on CI runtime, as I'm only compiling nim with -d:nimHasLibFFI once (no bootstrapping via koch boot), and running a single test (./tests/vm/tevalffi.nim)


* [EDIT] -d:nimHasLibFFI now works for freebsd and i386, so that it now works on all posix platforms in CI (freebsd, linux i386, amd64, osx)
* [EDIT] `nimHasLibFFIEnabled` is now defined when nim itself was compiled with -d:nimHasLibFFI; `nimHasLibFFIEnabled` is named differently from `nimHasLibFFI` on purpose to avoid confusion between what nim was compiled with and what's the resulting `defined(..)` that nim programs can use to query whether FFICT was enabled (this distinction matters, eg in case user has a --defined:nimHasLibFFI in their config.nims)

* [EDIT] requested here https://forum.nim-lang.org/t/5881

## future PRs
* add testing for windows platform (in particular win64, win32 should work already)
