### PR TITLE
Add Percentage type

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,7 @@
 - introduced new procs in `tables.nim`: `OrderedTable.pop`, `CountTable.del`,
   `CountTable.pop`, `Table.pop`
 - To `strtabs.nim`, added `StringTable.clear` overload that reuses the existing mode.
-
+- Added `Percentage` an `int` type ranging from 0 to 100. This type is often useful for Percentages, without off-by-one errors.
 
 - Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into
   operations that work on a copy of the data and return the mutated copy. As the existing

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -691,6 +691,8 @@ type
     ## is an `int` type ranging from one to the maximum value
     ## of an `int`. This type is often useful for documentation and debugging.
 
+  Percentage* = range[0..100] ## `int` type ranging from 0 to 100. Useful for Percentages, without off-by-one errors.
+
   RootObj* {.compilerproc, inheritable.} =
     object ## The root of Nim's object hierarchy.
            ##

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -59,6 +59,8 @@ doAssert high(float) > low(float)
 doAssert high(float32) > low(float32)
 doAssert high(float64) > low(float64)
 
+for i in 0..100: doAssert i.Percentage == i
+
 # bug #6710
 var s = @[1]
 s.delete(0)


### PR DESCRIPTION
- Add `Percentage` subrange `int` type ranging from `0` to `100`. This is often useful for percentages, without off-by-one errors. Similar to `Positive` and `Natural`.
- Includes unitttests. Single line so should be easy to merge.

No more *101% complete* :laughing: 
