### PR TITLE
[CI] fix timeout errors: increase timeout from 60m (default) to 90m

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,148 +1,153 @@
-strategy:
-  matrix:
-    Linux_amd64:
-      vmImage: 'ubuntu-16.04'
-      CPU: amd64
-    Linux_i386:
-      vmImage: 'ubuntu-16.04'
-      CPU: i386
-    OSX_amd64:
-      vmImage: 'macOS-10.14'
-      CPU: amd64
-    OSX_amd64_cpp:
-      vmImage: 'macOS-10.14'
-      CPU: amd64
-      NIM_COMPILE_TO_CPP: true
-    Windows_amd64:
-      vmImage: 'windows-2019'
-      CPU: amd64
-    Windows_amd64_pkg:
-      vmImage: 'windows-2019'
-      CPU: amd64
-      NIM_TEST_PACKAGES: true
+jobs:
+- job: packages
 
-pool:
-  vmImage: $(vmImage)
+  timeoutInMinutes: 90 # default `60` led to lots of cancelled jobs; use 0 for unlimited (may be undesirable)
 
-workspace:
-  clean: all
+  strategy:
+    matrix:
+      Linux_amd64:
+        vmImage: 'ubuntu-16.04'
+        CPU: amd64
+      Linux_i386:
+        vmImage: 'ubuntu-16.04'
+        CPU: i386
+      OSX_amd64:
+        vmImage: 'macOS-10.14'
+        CPU: amd64
+      OSX_amd64_cpp:
+        vmImage: 'macOS-10.14'
+        CPU: amd64
+        NIM_COMPILE_TO_CPP: true
+      Windows_amd64:
+        vmImage: 'windows-2019'
+        CPU: amd64
+      Windows_amd64_pkg:
+        vmImage: 'windows-2019'
+        CPU: amd64
+        NIM_TEST_PACKAGES: true
 
-steps:
-  - bash: git config --global core.autocrlf false
-    displayName: 'Disable auto conversion to CRLF by git (Windows-only)'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
+  pool:
+    vmImage: $(vmImage)
 
-  - checkout: self
+  workspace:
+    clean: all
 
-  - bash: git clone --depth 1 https://github.com/nim-lang/csources.git
-    displayName: 'Checkout csources'
+  steps:
+    - bash: git config --global core.autocrlf false
+      displayName: 'Disable auto conversion to CRLF by git (Windows-only)'
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
 
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.x'
-    displayName: 'Install node.js 8.x'
+    - checkout: self
 
-  - bash: |
-      sudo apt-fast update -qq
-      DEBIAN_FRONTEND='noninteractive' \
-        sudo apt-fast install --no-install-recommends -yq \
-          libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
-    displayName: 'Install dependencies (amd64 Linux)'
-    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
+    - bash: git clone --depth 1 https://github.com/nim-lang/csources.git
+      displayName: 'Checkout csources'
 
-  - bash: |
-      sudo dpkg --add-architecture i386
+    - task: NodeTool@0
+      inputs:
+        versionSpec: '8.x'
+      displayName: 'Install node.js 8.x'
 
-      # Downgrade llvm, libgcc and libstdc++:
-      # - llvm has to be downgraded to have 32bit version installed for sfml.
-      # - libgcc and libstdc++ have to be downgraded as an optimization to
-      #   prevent the use of the toolchain ppa, which has a terrible download
-      #   speed.
-      cat << EOF | sudo tee /etc/apt/preferences.d/pin-to-rel
-      Package: libllvm6.0 libgcc1 libstdc++6
-      Pin: origin "azure.archive.ubuntu.com"
-      Pin-Priority: 1001
+    - bash: |
+        sudo apt-fast update -qq
+        DEBIAN_FRONTEND='noninteractive' \
+          sudo apt-fast install --no-install-recommends -yq \
+            libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
+      displayName: 'Install dependencies (amd64 Linux)'
+      condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 
-      Package: *
-      Pin: release o=LP-PPA-ubuntu-toolchain-r-test
-      Pin-Priority: 100
-      EOF
+    - bash: |
+        sudo dpkg --add-architecture i386
 
-      sudo apt-fast update -qq
-      DEBIAN_FRONTEND='noninteractive' \
-        sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
-          g++-multilib gcc-multilib libcurl4-openssl-dev:i386 libgc-dev:i386 \
-          libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386
+        # Downgrade llvm, libgcc and libstdc++:
+        # - llvm has to be downgraded to have 32bit version installed for sfml.
+        # - libgcc and libstdc++ have to be downgraded as an optimization to
+        #   prevent the use of the toolchain ppa, which has a terrible download
+        #   speed.
+        cat << EOF | sudo tee /etc/apt/preferences.d/pin-to-rel
+        Package: libllvm6.0 libgcc1 libstdc++6
+        Pin: origin "azure.archive.ubuntu.com"
+        Pin-Priority: 1001
 
-      cat << EOF > bin/gcc
-      #!/bin/bash
+        Package: *
+        Pin: release o=LP-PPA-ubuntu-toolchain-r-test
+        Pin-Priority: 100
+        EOF
 
-      exec $(which gcc) -m32 "\$@"
-      EOF
-      cat << EOF > bin/g++
-      #!/bin/bash
+        sudo apt-fast update -qq
+        DEBIAN_FRONTEND='noninteractive' \
+          sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
+            g++-multilib gcc-multilib libcurl4-openssl-dev:i386 libgc-dev:i386 \
+            libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386
 
-      exec $(which g++) -m32 "\$@"
-      EOF
+        cat << EOF > bin/gcc
+        #!/bin/bash
 
-      chmod 755 bin/gcc
-      chmod 755 bin/g++
+        exec $(which gcc) -m32 "\$@"
+        EOF
+        cat << EOF > bin/g++
+        #!/bin/bash
 
-    displayName: 'Install dependencies (i386 Linux)'
-    condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
+        exec $(which g++) -m32 "\$@"
+        EOF
 
-  - bash: brew install boehmgc make sfml
-    displayName: 'Install dependencies (OSX)'
-    condition: eq(variables['Agent.OS'], 'Darwin')
+        chmod 755 bin/gcc
+        chmod 755 bin/g++
 
-  - bash: |
-      mkdir dist
-      curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
-      curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
-      7z x dist/mingw64.7z -odist
-      7z x dist/dlls.zip -obin
-      echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
+      displayName: 'Install dependencies (i386 Linux)'
+      condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
-    displayName: 'Install dependencies (Windows)'
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    - bash: brew install boehmgc make sfml
+      displayName: 'Install dependencies (OSX)'
+      condition: eq(variables['Agent.OS'], 'Darwin')
 
-  - bash: echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/bin'
-    displayName: 'Add build binaries to PATH'
+    - bash: |
+        mkdir dist
+        curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
+        curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
+        7z x dist/mingw64.7z -odist
+        7z x dist/dlls.zip -obin
+        echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
 
-  - bash: |
-      echo 'PATH:' "$PATH"
-      echo '##[section]gcc version'
-      gcc -v
-      echo '##[section]nodejs version'
-      node -v
-      echo '##[section]make version'
-      make -v
-    displayName: 'System information'
+      displayName: 'Install dependencies (Windows)'
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
 
-  - bash: |
-      ncpu=
-      case '$(Agent.OS)' in
-      'Linux')
-        ncpu=$(nproc)
-        ;;
-      'Darwin')
-        ncpu=$(sysctl -n hw.ncpu)
-        ;;
-      'Windows_NT')
-        ncpu=$NUMBER_OF_PROCESSORS
-        ;;
-      esac
-      [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
+    - bash: echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/bin'
+      displayName: 'Add build binaries to PATH'
 
-      make -C csources -j $ncpu CC=gcc ucpu=$(CPU)
-    displayName: 'Build csources'
+    - bash: |
+        echo 'PATH:' "$PATH"
+        echo '##[section]gcc version'
+        gcc -v
+        echo '##[section]nodejs version'
+        node -v
+        echo '##[section]make version'
+        make -v
+      displayName: 'System information'
 
-  - bash: nim c koch
-    displayName: 'Build koch'
+    - bash: |
+        ncpu=
+        case '$(Agent.OS)' in
+        'Linux')
+          ncpu=$(nproc)
+          ;;
+        'Darwin')
+          ncpu=$(sysctl -n hw.ncpu)
+          ;;
+        'Windows_NT')
+          ncpu=$NUMBER_OF_PROCESSORS
+          ;;
+        esac
+        [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
 
-    # set result to omit the "bash exited with error code '1'" message
-  - bash: |
-      ./koch runCI || echo '##vso[task.complete result=Failed]'
-    displayName: 'Run CI'
-    env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        make -C csources -j $ncpu CC=gcc ucpu=$(CPU)
+      displayName: 'Build csources'
+
+    - bash: nim c koch
+      displayName: 'Build koch'
+
+      # set result to omit the "bash exited with error code '1'" message
+    - bash: |
+        ./koch runCI || echo '##vso[task.complete result=Failed]'
+      displayName: 'Run CI'
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
I often run into CI timeouts, which causes more wasted time (both on PR author and on CI resources since whole CI needs to be re-run, even though most pipelines in the matrix finished except maybe 1 or 2 that timed out)

* this should fix most CI timeout errors, I didn't want to use a too high value (or 0 = max) in case some bad PR would run for a very long time, affecting other PR's; note that 80m wasn't enough (I still got timeout after 80m = 1h20 on this very PR)
* the diff is mostly re-indentation as you can see by running `git diff` locally
* this was the simplest change that actually works; modeled after https://github.com/kata-containers/packaging/commit/b58c6a4682346f821a9f0c23e5c4fe15ab492d4e ; see also https://github.com/microsoft/azure-pipelines-yaml/issues/48#issuecomment-525093222 which (as i verified) shows you can't simply put timeout under pool
* you can verify this timeout is taken into effect by replacing it by a small value (eg 2) and seeing the jobs cancelled after 2 minutes, which I did

