### PR TITLE
refs #13054 correctly handle {.exportc,dynlib.} and {.exportcpp,dynlib.} 

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -208,11 +208,7 @@ __AVR__
 #    define N_FASTCALL_PTR(rettype, name) rettype (*name)
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
-#  ifdef __cplusplus
-#    define N_LIB_EXPORT  extern "C"
-#  else
-#    define N_LIB_EXPORT  extern
-#  endif
+#  define N_LIB_EXPORT __attribute__((visibility("default")))
 #  define N_LIB_IMPORT  extern
 #endif
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -159,7 +159,13 @@ __AVR__
 #  define NIM_CAST(type, ptr) ((type)(ptr))
 #endif
 
+
 /* ------------------------------------------------------------------- */
+#ifdef  __cplusplus
+#  define NIM_EXTERNC extern "C"
+#else
+#  define NIM_EXTERNC
+#endif
 
 #if defined(WIN32) || defined(_WIN32) /* only Windows has this mess... */
 #  define N_LIB_PRIVATE
@@ -208,7 +214,7 @@ __AVR__
 #    define N_FASTCALL_PTR(rettype, name) rettype (*name)
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
-#  define N_LIB_EXPORT __attribute__((visibility("default")))
+#  define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
 #  define N_LIB_IMPORT  extern
 #endif
 
@@ -514,12 +520,6 @@ typedef int Nim_and_C_compiler_disagree_on_target_architecture[sizeof(NI) == siz
 
 #ifdef USE_NIM_NAMESPACE
 }
-#endif
-
-#ifdef  __cplusplus
-#  define NIM_EXTERNC extern "C"
-#else
-#  define NIM_EXTERNC
 #endif
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
/cc @alaviss 

* references https://github.com/nim-lang/Nim/issues/13054 (but doesn't solve it)
* addresses this specific point: https://github.com/nim-lang/Nim/issues/13054#issuecomment-573962723

```nim
  # D20200113T190938
  proc fun1() {.exportc, dynlib.} = discard
  proc fun1_aux() {.exportc.} = discard
  proc local_fun1() {.exportc, dynlib.} = discard
  proc global_fun1() {.exportc, dynlib.} = discard
  proc fun1_other() = discard
  when defined(cpp):
    proc fun1_cpp1() {.exportcpp, dynlib.} = discard
    proc fun1_cpp2() {.exportcpp.} = discard
  if false: fun1_other()
```

## before PR
* if we pass `--passc:-fvisibility=hidden`, `nm -gU libmain.dylib` would show nothing (no exported symbol)
* if we don't pass `--passc:-fvisibility=hidden` (or if we pass `--passc:-fvisibility=default`), `nm -gU libmain.dylib` shows 78 symbols including a lot of internal nim symbols such as `_raiseOverflow` etc
* in addition to that, when using `nim cpp`, `proc fun1_cpp1() {.exportcpp, dynlib.} ` was incorrectly mangled as C (`_fun1_cpp1`) instead of C++ (`__Z9fun1_cpp1v`)

## after PR
with `--passc:-fvisibility=hidden` we only export `{.exportc, dynlib.} ` 

~~and `{.exportcpp, dynlib.} ` symbols and don't mangle as C  `{.exportcpp, dynlib.} ` symbols~~ EDIT: I've removed a fix for that specific point in this PR

```
./bin/nim cpp --app:lib --passc:-fvisibility=hidden main.nim
nm -gU libmain.dylib | c++filt
```
000000000000e110 T ~~NimMain()~~ _NimMain
000000000000df70 T ~~fun1_cpp1()~~ _fun1_cpp1
000000000000ddb0 T _fun1
000000000000df30 T _global_fun1
000000000000def0 T _local_fun1

```
./bin/nim c --app:lib -d:case2 --passc:-fvisibility=hidden main.nim
nm -gU libmain.dylib | c++filt
```
000000000000e0e0 T _NimMain
000000000000de00 T _fun1
000000000000df80 T _global_fun1
000000000000df40 T _local_fun1

## note
* user can still do explicit override of exported symbols (the goal of https://github.com/nim-lang/Nim/issues/13054):
on OSX :
` --passl:-Wl,-exported_symbols_list,/dev/null ` will export 0 symbols (likely not very useful but still good that this works)
`--passl:-Wl,-exported_symbol,_fun1` will export only `_fun` and unexport all the others


## note (for future PR's)
* I don't know whether it's desirable to have `NimMain` exported (see above); the current implementation uses `N_LIB_EXPORT " & NimMainProc` which explains why; but not sure we want that
* would be nice to make --app:lib imply `--passc:-fvisibility=hidden` but no idea how to do that (help welcome); note that it must be still be over-rideable if user sets on cmdline `--passc:-fvisibility=default`
