### PR TITLE
fixes #13144

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -779,7 +779,7 @@ proc cgsym(m: BModule, name: string): Rope =
     result.addActualSuffixForHCR(m.module, sym)
 
 proc generateHeaders(m: BModule) =
-  m.s[cfsHeaders].add("\L#include \"nimbase.h\"\L")
+  m.s[cfsHeaders].add("\L#include <nimbase.h>\L") # see #13144
 
   for it in m.headerFiles:
     if it[0] == '#':

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -779,7 +779,7 @@ proc cgsym(m: BModule, name: string): Rope =
     result.addActualSuffixForHCR(m.module, sym)
 
 proc generateHeaders(m: BModule) =
-  m.s[cfsHeaders].add("\L#include <nimbase.h>\L") # see #13144
+  m.s[cfsHeaders].add("\L#include \"nimbase.h\"\L")
 
   for it in m.headerFiles:
     if it[0] == '#':


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/issues/13144
* adds `-I$nim/lib` absolute include to make it all work, instead of copying nimbase.h
* note that there already are absolute includes generated inside compile_foo.sh prior to this PR so this seems fine
```
nim c --genscript --nimcache:/tmp/d01 main.nim
cd /tmp/d01
nim jsonscript --nimcache:. main.json # works
sh compile_main.sh # also works
```

