### PR TITLE
Option to allow the request body to be processed outside the asynchttpserver library.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,7 @@
 
 ## Library changes
 
+- `asynchttpserver` now the request body is a FutureStream.
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`
   and only returns once all pending async operations are guaranteed to have completed.
 - `asyncdispatch.drain` now consistently uses the passed timeout value for all

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -256,7 +256,9 @@ proc processRequest(
 
       var remainder = contentLength
       while remainder > 0:
-        let read_size = if remainder < chunkSize: remainder else: chunkSize
+
+        let readSize = min(remainder, chunkSize)
+
         let data = await client.recv(read_size)
         if data.len != read_size:
           await request.respond(Http500, "Internal Server Error. An error occurred while reading the request body.")

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -52,7 +52,6 @@ type
     url*: Uri
     hostname*: string    ## The hostname of the client that made the request.
     body*: string
-    contentLength*: int
 
   AsyncHttpServer* = ref object
     socket: AsyncSocket
@@ -149,7 +148,6 @@ proc processRequest(
   # \n
   request.headers.clear()
   request.body = ""
-  request.contentLength = 0
   request.hostname.shallowCopy(address)
   assert client != nil
   request.client = client
@@ -244,7 +242,6 @@ proc processRequest(
       await request.respond(Http400, "Bad Request. Invalid Content-Length.")
       return true
     else:
-      request.contentLength = contentLength
       if contentLength > server.maxBody:
         await request.respondError(Http413)
         return false

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -30,6 +30,8 @@
 ##
 ##    waitFor server.serve(Port(8080), cb)
 
+include "system/inclrtl"
+
 import tables, asyncnet, asyncdispatch, parseutils, uri, strutils
 import httpcore
 

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -130,19 +130,30 @@ proc parseProtocol(protocol: string): tuple[orig: string, major, minor: int] =
 proc sendStatus(client: AsyncSocket, status: string): Future[void] =
   client.send("HTTP/1.1 " & status & "\c\L\c\L")
 
-proc parseUppercaseMethod(name: string): HttpMethod =
-  result =
-    case name
-    of "GET": HttpGet
-    of "POST": HttpPost
-    of "HEAD": HttpHead
-    of "PUT": HttpPut
-    of "DELETE": HttpDelete
-    of "PATCH": HttpPatch
-    of "OPTIONS": HttpOptions
-    of "CONNECT": HttpConnect
-    of "TRACE": HttpTrace
-    else: raise newException(ValueError, "Invalid HTTP method " & name)
+proc readBody(
+  req: FutureVar[Request],
+  contentLength: int
+): Future[bool] {.since: (1, 1), async.} =
+
+  var remainder = contentLength
+  while remainder > 0:
+    let readSize = min(remainder, chunkSize)
+    let data = await req.mget().client.recv(read_size)
+    if data.len != read_size:
+      return true
+    await req.mget().bodyStream.write(data)
+    remainder -= data.len
+
+  req.mget().bodyStream.complete()
+  return false
+
+proc readBody(
+  req: FutureVar[Request],
+  contentLength: int
+): Future[bool] {.async.} =
+
+  req.mget().body = await req.mget().client.recv(contentLength)
+  return if req.mget().body.len == contentLength: false else: true
 
 proc processRequest(
   server: AsyncHttpServer,
@@ -190,9 +201,17 @@ proc processRequest(
   for linePart in lineFut.mget.split(' '):
     case i
     of 0:
-      try:
-        request.reqMethod = parseUppercaseMethod(linePart)
-      except ValueError:
+      case linePart
+      of "GET": request.reqMethod = HttpGet
+      of "POST": request.reqMethod = HttpPost
+      of "HEAD": request.reqMethod = HttpHead
+      of "PUT": request.reqMethod = HttpPut
+      of "DELETE": request.reqMethod = HttpDelete
+      of "PATCH": request.reqMethod = HttpPatch
+      of "OPTIONS": request.reqMethod = HttpOptions
+      of "CONNECT": request.reqMethod = HttpConnect
+      of "TRACE": request.reqMethod = HttpTrace
+      else:
         asyncCheck request.respondError(Http400)
         return true # Retry processing of request
     of 1:
@@ -245,32 +264,22 @@ proc processRequest(
   # - Check for Content-length header
   if request.headers.hasKey("Content-Length"):
     var contentLength = 0
-    if parseSaturatedNatural(request.headers["Content-Length"],
-        contentLength) == 0:
+    if parseSaturatedNatural(request.headers["Content-Length"], contentLength) == 0:
       await request.respond(Http400, "Bad Request. Invalid Content-Length.")
       return true
     else:
       if contentLength > server.maxBody:
         await request.respondError(Http413)
         return false
-
-      var remainder = contentLength
-      while remainder > 0:
-        let readSize = min(remainder, chunkSize)
-        let data = await client.recv(read_size)
-        if data.len != read_size:
-          await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
-          return true
-        await request.bodyStream.write(data)
-        remainder -= data.len
-
-      request.bodyStream.complete()
-
+        
+      if await req.readBody(contentLength):
+        await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
+        return true
+      
       ## request.body = await client.recv(contentLength)
       ## if request.body.len != contentLength:
-      ##  await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
+      ##   await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
       ##   return true
-  
   elif request.reqMethod == HttpPost:
     await request.respond(Http411, "Content-Length required.")
     return true

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -52,20 +52,23 @@ type
     url*: Uri
     hostname*: string    ## The hostname of the client that made the request.
     body*: string
+    contentLength*: int
 
   AsyncHttpServer* = ref object
     socket: AsyncSocket
     reuseAddr: bool
     reusePort: bool
     maxBody: int ## The maximum content-length that will be read for the body.
+    handleBody: bool ## if false leave the body for the developer to do whatever he wants with it.
 
 proc newAsyncHttpServer*(reuseAddr = true, reusePort = false,
-                         maxBody = 8388608): AsyncHttpServer =
+                         maxBody = 8388608, handleBody = true): AsyncHttpServer =
   ## Creates a new ``AsyncHttpServer`` instance.
   new result
   result.reuseAddr = reuseAddr
   result.reusePort = reusePort
   result.maxBody = maxBody
+  result.handleBody = handleBody
 
 proc addHeaders(msg: var string, headers: HttpHeaders) =
   for k, v in headers:
@@ -146,6 +149,7 @@ proc processRequest(
   # \n
   request.headers.clear()
   request.body = ""
+  request.contentLength = 0
   request.hostname.shallowCopy(address)
   assert client != nil
   request.client = client
@@ -243,10 +247,14 @@ proc processRequest(
       if contentLength > server.maxBody:
         await request.respondError(Http413)
         return false
-      request.body = await client.recv(contentLength)
-      if request.body.len != contentLength:
-        await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
-        return true
+
+      request.contentLength = contentLength
+      if server.handleBody == true: # if false leave the body for the developer to do whatever he wants with it.
+        request.body = await client.recv(contentLength)
+        if request.body.len != contentLength:
+          await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
+          return true
+
   elif request.reqMethod == HttpPost:
     await request.respond(Http411, "Content-Length required.")
     return true

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -41,10 +41,12 @@ export httpcore except parseHeader
 # Also, maybe move `client` out of `Request` object and into the args for
 # the proc.
 
+const
+  maxLine = 8*1024
+
 when (NimMajor, NimMinor) >= (1, 1):
   const
-    maxLine = 8*1024
-    chunkSize = 1048
+    chunkSize = 8*1048 ## This seems perfectly reasonable for default chunkSize.
 
   type
     Request* = object
@@ -57,9 +59,6 @@ when (NimMajor, NimMinor) >= (1, 1):
       body*: string
       bodyStream*: FutureStream[string]
 else:
-  const
-    maxLine = 8*1024
-
   type
     Request* = object
       client*: AsyncSocket # TODO: Separate this into a Response object?

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -30,8 +30,6 @@
 ##
 ##    waitFor server.serve(Port(8080), cb)
 
-include "system/inclrtl"
-
 import tables, asyncnet, asyncdispatch, parseutils, uri, strutils
 import httpcore
 
@@ -135,7 +133,7 @@ proc sendStatus(client: AsyncSocket, status: string): Future[void] =
 proc readBody(
   req: FutureVar[Request],
   contentLength: int
-): Future[bool] {.since: (1, 1), async.} =
+): Future[bool] {.async.} =
 
   var remainder = contentLength
   while remainder > 0:
@@ -148,14 +146,6 @@ proc readBody(
 
   req.mget().bodyStream.complete()
   return false
-
-proc readBody(
-  req: FutureVar[Request],
-  contentLength: int
-): Future[bool] {.async.} =
-
-  req.mget().body = await req.mget().client.recv(contentLength)
-  return if req.mget().body.len == contentLength: false else: true
 
 proc processRequest(
   server: AsyncHttpServer,

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -256,19 +256,13 @@ proc processRequest(
 
       var remainder = contentLength
       while remainder > 0:
-
         let readSize = min(remainder, chunkSize)
-
         let data = await client.recv(read_size)
         if data.len != read_size:
-          await request.respond(Http500, "Internal Server Error. An error occurred while reading the request body.")
+          await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
           return true
         await request.bodyStream.write(data)
         remainder -= data.len
-
-      if remainder > 0:
-        await request.respond(Http400, "Bad Request. Content-Length does not match actual.")
-        return true
 
       request.bodyStream.complete()
 

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -244,12 +244,12 @@ proc processRequest(
       await request.respond(Http400, "Bad Request. Invalid Content-Length.")
       return true
     else:
+      request.contentLength = contentLength
       if contentLength > server.maxBody:
         await request.respondError(Http413)
         return false
 
-      request.contentLength = contentLength
-      if server.handleBody == true: # if false leave the body for the developer to do whatever he wants with it.
+      if server.handleBody: # if false leave the body for the developer to do whatever he wants with it.
         request.body = await client.recv(contentLength)
         if request.body.len != contentLength:
           await request.respond(Http400, "Bad Request. Content-Length does not match actual.")


### PR DESCRIPTION
Option to allow the request body to be processed outside the asynchttpserver library to break big files into chunks of data.
This change does not break anything.

Example:
```nim
import asyncnet, asynchttpserver, asyncdispatch

proc test_page(): string =
  return """
<!Doctype html>
<html lang="en">
<head>
<meta charset="utf-8"/>
</head>
<body>
<form action="/test" method="post">
  Test: <input type="text" name="test" value="post test"><br/>
  <input type="submit">
</form>
</body>
</html>
"""

const chunkSize = 1024

var server = newAsyncHttpServer(maxBody=102400, handleBody=false)
proc cb(req: Request) {.async.} =
  if req.reqMethod == HttpPost:
    var body = ""
    var remainder = req.content_length
    while remainder > 0:
      let data = await req.client.recv(if remainder < chunkSize: remainder else: chunkSize)
      if data.len == 0:
        break
      body.add(data)
      remainder -= data.len

    if body.len != req.contentLength:
      await req.respond(Http400, "Bad Request. Content-Length does not match actual.")
    else:
      await req.respond(Http200, body)
    # req.client.close()
  else:
    await req.respond(Http200, test_page())

waitFor server.serve(Port(8080), cb)
```