### PR TITLE
export normalizePathEnd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,8 @@
   and `typetraits.get` to get the ith element of a type tuple.
 - Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
 
+- Added `os.normalizePathEnd` for additional path sanitization.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -103,8 +103,17 @@ proc normalizePathEnd(path: var string, trailingSep = false) =
     path = $DirSep
 
 proc normalizePathEnd(path: string, trailingSep = false): string =
+  ## outplace overload
+  runnableExamples:
+    when defined(posix):
+      assert normalizePathEnd("/lib//", trailingSep = true) == "/lib/"
+      assert normalizePathEnd("lib//", trailingSep = false) == "lib"
+      assert normalizePathEnd("", trailingSep = true) == "" # not / !
   result = path
   result.normalizePathEnd(trailingSep)
+
+when (NimMajor, NimMinor) >= (1, 1):
+  export normalizePathEnd
 
 proc joinPath*(head, tail: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =


### PR DESCRIPTION
supersedes https://github.com/nim-lang/Nim/pull/13000 /cc @disruptek @Araq 

made possible by recently merged https://github.com/nim-lang/Nim/pull/13123 which correctly shows doc/doc comments/runnableExamples for the `export normalizePathEnd` symbol