### PR TITLE
[WIP, TODO] turn some include => import in system.nim

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -466,8 +466,15 @@ let nimvm* {.magic: "Nimvm", compileTime.}: bool = false
 
 import system/arithmetics
 export arithmetics except IntMax32
-import system/comparisons
-export comparisons
+
+when false:
+  # these mess with stack traces, see tests/enum/tenummix.nim, and also fails with:
+  # system/comparisons.nim(291, 40) Error: undeclared field: 'p'
+  # because NimSeqV2.p is private
+  import system/comparisons
+  export comparisons
+else:
+  include "system/comparisons"
 
 const
   appType* {.magic: "AppType"}: string = ""

--- a/lib/system/arithmetics.nim
+++ b/lib/system/arithmetics.nim
@@ -343,7 +343,7 @@ proc `xor`*(x, y: int32): int32 {.magic: "BitxorI", noSideEffect.}
 proc `xor`*(x, y: int64): int64 {.magic: "BitxorI", noSideEffect.}
 
 type
-  IntMax32 = int|int8|int16|int32
+  IntMax32* = int|int8|int16|int32
 
 proc `+%`*(x, y: IntMax32): IntMax32 {.magic: "AddU", noSideEffect.}
 proc `+%`*(x, y: int64): int64 {.magic: "AddU", noSideEffect.}

--- a/lib/system/comparisons.nim
+++ b/lib/system/comparisons.nim
@@ -1,3 +1,5 @@
+import system/arithmetics
+
 # comparison operators:
 proc `==`*[Enum: enum](x, y: Enum): bool {.magic: "EqEnum", noSideEffect.}
   ## Checks whether values within the *same enum* have the same underlying value.

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -10,37 +10,6 @@ type
   WriteIOEffect* = object of IOEffect  ## Effect describing a write IO operation.
   ExecIOEffect* = object of IOEffect   ## Effect describing an executing IO operation.
 
-  StackTraceEntry* = object ## In debug mode exceptions store the stack trace that led
-                            ## to them. A `StackTraceEntry` is a single entry of the
-                            ## stack trace.
-    procname*: cstring      ## Name of the proc that is currently executing.
-    line*: int              ## Line number of the proc that is currently executing.
-    filename*: cstring      ## Filename of the proc that is currently executing.
-
-  Exception* {.compilerproc, magic: "Exception".} = object of RootObj ## \
-    ## Base exception class.
-    ##
-    ## Each exception has to inherit from `Exception`. See the full `exception
-    ## hierarchy <manual.html#exception-handling-exception-hierarchy>`_.
-    parent*: ref Exception ## Parent exception (can be used as a stack).
-    name*: cstring         ## The exception's name is its Nim identifier.
-                           ## This field is filled automatically in the
-                           ## ``raise`` statement.
-    msg* {.exportc: "message".}: string ## The exception's message. Not
-                                        ## providing an exception message
-                                        ## is bad style.
-    when defined(js):
-      trace: string
-    else:
-      trace: seq[StackTraceEntry]
-    when defined(nimBoostrapCsources0_19_0):
-      # see #10315, bootstrap with `nim cpp` from csources gave error:
-      # error: no member named 'raise_id' in 'Exception'
-      raise_id: uint # set when exception is raised
-    else:
-      raiseId: uint # set when exception is raised
-    up: ref Exception # used for stacking exceptions. Not exported!
-
   Defect* = object of Exception ## \
     ## Abstract base class for all exceptions that Nim's runtime raises
     ## but that are strictly uncatchable as they can also be mapped to

--- a/lib/system/gc_interface.nim
+++ b/lib/system/gc_interface.nim
@@ -1,6 +1,7 @@
+# import system/privatedefs
+# include "system/inclrtl"
+
 # ----------------- GC interface ---------------------------------------------
-const
-  usesDestructors = defined(gcDestructors) or defined(gcHooks)
 
 when not usesDestructors:
   {.pragma: nodestroy.}

--- a/lib/system/memalloc.nim
+++ b/lib/system/memalloc.nim
@@ -1,3 +1,7 @@
+## uncomment these when this turns into an import module
+# import system/privatedefs
+# include "system/inclrtl"
+
 when notJSnotNims:
   proc zeroMem*(p: pointer, size: Natural) {.inline, noSideEffect,
     tags: [], locks: 0, raises: [].}

--- a/lib/system/privatedefs.nim
+++ b/lib/system/privatedefs.nim
@@ -1,0 +1,27 @@
+proc compileOption*(option: string): bool {.
+  magic: "CompileOption", noSideEffect.}
+  ## Can be used to determine an `on|off` compile-time option. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   when compileOption("floatchecks"):
+  ##     echo "compiled with floating point NaN and Inf checks"
+
+proc compileOption*(option, arg: string): bool {.
+  magic: "CompileOptionArg", noSideEffect.}
+  ## Can be used to determine an enum compile-time option. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
+  ##     echo "compiled with optimization for size and uses Boehm's GC"
+
+const
+  notJSnotNims* = not defined(js) and not defined(nimscript)
+  hostOS* {.magic: "HostOS".}: string = ""
+    ## A string that describes the host operating system.
+    ##
+    ## Possible values:
+    ## `"windows"`, `"macosx"`, `"linux"`, `"netbsd"`, `"freebsd"`,
+    ## `"openbsd"`, `"solaris"`, `"aix"`, `"haiku"`, `"standalone"`.
+  hasAlloc* = (hostOS != "standalone" or not defined(nogc)) and not defined(nimscript)
+  hasThreadSupport* = compileOption("threads") and not defined(nimscript)
+  usesDestructors* = defined(gcDestructors) or defined(gcHooks)

--- a/lib/system_overview.rst
+++ b/lib/system_overview.rst
@@ -1,12 +1,17 @@
 The System module imports several separate modules, and their documentation
 is in separate files:
 
-* `iterators <iterators.html>`_
+* `arithmetics <arithmetics.html>`_
 * `assertions <assertions.html>`_
+* `comparisons <comparisons.html>`_
 * `dollars <dollars.html>`_
+* `exceptions <exceptions.html>`_
 * `io <io.html>`_
+* `iterators <iterators.html>`_
+* `iterators_1 <iterators_1.html>`_
+* `privatedefs <privatedefs.html>`_
+* `setops <setops.html>`_
 * `widestrs <widestrs.html>`_
-
 
 Here is a short overview of the most commonly used functions from the
 `system` module. Function names in the tables below are clickable and

--- a/lib/system_overview.rst
+++ b/lib/system_overview.rst
@@ -3,7 +3,6 @@ is in separate files:
 
 * `arithmetics <arithmetics.html>`_
 * `assertions <assertions.html>`_
-* `comparisons <comparisons.html>`_
 * `dollars <dollars.html>`_
 * `exceptions <exceptions.html>`_
 * `io <io.html>`_

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -132,7 +132,6 @@ lib/system/iterators.nim
 lib/system/dollars.nim
 lib/system/widestrs.nim
 lib/system/arithmetics.nim
-lib/system/comparisons.nim
 lib/system/exceptions.nim
 lib/system/iterators_1.nim
 lib/system/privatedefs.nim

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -131,6 +131,12 @@ lib/system/assertions.nim
 lib/system/iterators.nim
 lib/system/dollars.nim
 lib/system/widestrs.nim
+lib/system/arithmetics.nim
+lib/system/comparisons.nim
+lib/system/exceptions.nim
+lib/system/iterators_1.nim
+lib/system/privatedefs.nim
+lib/system/setops.nim
 lib/deprecated/pure/ospaths.nim
 lib/pure/parsejson.nim
 lib/pure/cstrutils.nim


### PR DESCRIPTION
* refs https://github.com/nim-lang/Nim/issues/10385
followup on https://github.com/nim-lang/Nim/pull/13155 see https://github.com/nim-lang/Nim/pull/13155#issuecomment-574546679

## what changed:
* turned to import:
system/arithmetics
system/exceptions
system/setops
system/iterators_1
system/arithmetics
* new import:
system/privatedefs


* kept as include:
system/comparisons


same could be done for remaining includes in future PR's

## note
I had to keep the following include's:
* system/basic_types
because of: `Error: system module needs: int`
* system/gc_interface
because they define public procs but no implementation
maybe this could be dealt with using `importc/exportc` ; but should be in future PR's
* system/memalloc
ditto

## note
* also related: `{.nosystem.} ` (see https://github.com/nim-lang/Nim/issues/10385#issuecomment-457023533) which would allow a user to skip importing all of what system imports and instead choose what he wants
* `import foo {.privateImport.}` (https://github.com/nim-lang/Nim/pull/11865) would simplify a number of things, eg it'd allow to put back `StackTraceEntry` and `Exception` inside exceptions.nim; right now i had to re-move it inside system.nim because of some private fields (`up`, `trace`, `raiseId`); with https://github.com/nim-lang/Nim/pull/11865 you'd instead have:
```
# in system/excpt.nim:
{.push experimental: "allowPrivateImport".}
import system/exceptions {.privateImport.} # => gives access to private fields Exception.trace etc just inside this module
```

* likewise, it'd allow to make system/comparisons an import, right now it'd fail for ` ./bin/nim c --newruntime -d:useMalloc --listfullpaths tests/destructor/tnewruntime_strutils.nim` because `NimSeqV2.p` is private
(plus some mysterious change of stacktrace, see ` ./bin/nim c -r testament/testament --nim:bin/nim r tests/enum/tenummix.nim`, which I don't understand)



