### PR TITLE
followup on #10435 : should be diff, not show

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -428,7 +428,7 @@ Code reviews
    .. code-block:: sh
 
       git fetch origin pull/10431/head && git checkout FETCH_HEAD
-      git show --color-moved-ws=allow-indentation-change --color-moved=blocks HEAD^
+      git diff --color-moved-ws=allow-indentation-change --color-moved=blocks HEAD^
 
 3. In addition, you can view github-like diffs locally to identify what was changed
    within a code block using `diff-highlight` or `diff-so-fancy`, e.g.:


### PR DESCRIPTION
the cmd i had written in #10435 would show the wrong diff; you can verify this works by trying on this large-diff PR with a tiny actual change:
```
git fetch origin pull/13134/head && git checkout FETCH_HEAD
git diff --color-moved-ws=allow-indentation-change --color-moved=blocks HEAD^
```
as mentioned in https://github.com/nim-lang/Nim/pull/13134#issuecomment-574871318