### PR TITLE
add error-checked version of walkDir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -80,6 +80,7 @@
 - `htmlgen` adds [MathML](https://wikipedia.org/wiki/MathML) support
   (ISO 40314).
 - `macros.eqIdent` is now invariant to export markers and backtick quotes.
+- Added `os.tryWalkDir` iterator to traverse directories with error checking. 
 - `htmlgen.html` allows `lang` on the `<html>` tag and common valid attributes.
 - `macros.basename` and `basename=` got support for `PragmaExpr`,
   so that an expression like `MyEnum {.pure.}` is handled correctly.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2021,7 +2021,7 @@ type WalkStep = ref object
     discard
 
 iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
-  tags: [ReadDirEffect], raises: [].} =
+  tags: [ReadDirEffect], raises: [], noNimScript .} =
   ## The same as `walkDir iterator <#walkDir.i,string>`_ but with full error
   ## checking: when an error at getting information about some path happened
   ## then yields the path and the error code (`kind` may be wrong in this case).

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2128,17 +2128,17 @@ proc `$`*(s: WalkStep): string =
   of wsInterrupted: "(wsInterrupted | '$1'$2)"  % [s.path, err]
 
 iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
-  tags: [ReadDirEffect], raises: [], noNimScript.} =
-  ## Walks over the directory `dir` and yields for each directory or file
-  ## in `dir`, non-recursively. It's a version of
+  tags: [ReadDirEffect], raises: [], noNimScript, since: (1, 1).} =
+  ## Walks over the directory `dir` and yields *steps* for each
+  ## directory or file in `dir`, non-recursively. It's a version of
   ## `walkDir iterator <#walkDir.i,string>`_  with more thorough error
-  ## checking. It never raises an exception.
+  ## checking. Never raises an exception.
   ##
-  ## Yields *steps* of walking through `dir`, each step contains
-  ## its path ``path``, OS error code ``code`` and additional tag ``kind``:
+  ## Each step is object variant ``WalkStep``, which  contains corresponding
+  ## path ``path``, OS error code ``code`` and discriminator ``kind``:
   ## 
-  ## - ``kind=wsOpenDir``: yielded once after opening, contains ``openStatus``
-  ##                       of type ``OpenDirStatus``
+  ## - ``kind=wsOpenDir`` is yielded once after opening, contains ``openStatus``
+  ##                      of type ``OpenDirStatus``
   ## - then it yields zero or more entries, each can be of the following kind:
   ##    - ``kind=wsEntryOk``: signifies normal entries with
   ##                          path component ``entryType``
@@ -2146,7 +2146,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
   ##    - ``kind=wsInterrupted``: signifies that a rare OS error happenned and
   ##                              the walking was terminated
   ##
-  ## An example of usage with full error checking:
+  ## An example of usage with full error logging:
   ## .. code-block:: Nim
   ##   for step in tryWalkDir("dirA"):
   ##     let err = " (" & $step.code & " - " & osErrorMsg(step.code) & ")"
@@ -2172,7 +2172,6 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
   ##       of wsEntryOk: yield (step.entryType, step.path)
   ##       of wsEntryBad: yield (pcLinkToFile, step.path)
   ##       of wsInterrupted: raiseOSError(step.code)
-
 
   var step: WalkStep
   var skip = false

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2139,6 +2139,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
   ## 
   ## - ``kind=wsOpenDir`` is yielded once after opening, contains ``openStatus``
   ##                      of type ``OpenDirStatus``
+  ##                      (when `relative=true` the path is '.')
   ## - then it yields zero or more entries, each can be of the following kind:
   ##    - ``kind=wsEntryOk``: signifies normal entries with
   ##                          path component ``entryType``
@@ -2207,7 +2208,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
         of ERROR_ACCESS_DENIED: odAccessDenied
         else: odUnknownError
       else: odOpenOk
-    step = sOpenDir(status, dir)
+    step = sOpenDir(status, if relative: "." else: dir)
 
     var firstStep = true
     while true:
@@ -2278,7 +2279,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
           elif errno == EACCES: odAccessDenied
           else: odUnknownError
       else: odOpenOk
-    step = sOpenDir(status, dir)
+    step = sOpenDir(status, if relative: "." else: dir)
 
     while true:
       if not skip:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2021,7 +2021,7 @@ type WalkStep = ref object
     discard
 
 iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
-  tags: [ReadDirEffect], raises: [], noNimScript.} =
+  tags: [ReadDirEffect], raises: [].} =
   ## An analogue of `walkDir iterator <#walkDir.i,string>`_ with full error
   ## checking. Yields "steps" of walking through `dir`, each step contains its path `path`, OS error code `code` and additional info. At first step yields info with the status of opening `dir` as a directory, tag `wsOpenDir`. If it's OK,
   ## the subsequent steps will yield the directory entries with file/directory type as info, tag `wsEntryOk`. Dangling symlinks on posix are reported as wsEntryBad. If (rarely) walking terminates with an error, tag is `wsInterrupted`.
@@ -2173,7 +2173,7 @@ iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
         discard closedir(d)
 
 proc tryOpenDir*(dir: string): OpenDirStatus {.
-  tags: [ReadDirEffect], raises: [], since:(1,1) .} =
+  tags: [ReadDirEffect], raises: [], since:(1,1).} =
   # TODO
   for step in tryWalkDir(dir):
     case step.kind

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2127,7 +2127,8 @@ proc `$`*(s: WalkStep): string =
   of wsEntryBad: "(wsEntryBad | '$1'$2)" % [s.path, err]
   of wsInterrupted: "(wsInterrupted | '$1'$2)"  % [s.path, err]
 
-iterator tryWalkDir*(dir: string, relative=false): WalkStep =
+iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
+  tags: [ReadDirEffect], raises: [], noNimScript.} =
   ## Walks over the directory `dir` and yields for each directory or file
   ## in `dir`, non-recursively. It's a version of
   ## `walkDir iterator <#walkDir.i,string>`_  with more thorough error
@@ -2138,11 +2139,12 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep =
   ## 
   ## - ``kind=wsOpenDir``: yielded once after opening, contains ``openStatus``
   ##                       of type ``OpenDirStatus``
-  ## - ``kind=wsEntryOk``: signifies normal entries with
-  ##                       path component ``entryType``
-  ## - ``kind=wsEntryBad``: broken symlink on posix without path component
-  ## - ``kind=wsInterrupted``: signifies that a rare OS error happenned and
-  ##                           the walking was terminated
+  ## - then it yields zero or more entries, each can be of the following kind:
+  ##    - ``kind=wsEntryOk``: signifies normal entries with
+  ##                          path component ``entryType``
+  ##    - ``kind=wsEntryBad``: broken symlink (without path component)
+  ##    - ``kind=wsInterrupted``: signifies that a rare OS error happenned and
+  ##                              the walking was terminated
   ##
   ## An example of usage with full error checking:
   ## .. code-block:: Nim

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2107,7 +2107,7 @@ type
     wsEntryBad     ## a broken symlink on posix, where it's unclear if it
                    ## points to a file or directory
     wsInterrupted  ## the directory handle got invalidated during reading
-  WalkStep = object  ## step of walking through directory
+  WalkStep* = object  ## step of walking through directory
     path*: string                ## the path that this step applies to
     code*: OSErrorCode           ## OS error code for the step
     case kind*: WalkStepKind     ## discriminator

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2035,11 +2035,11 @@ iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
   ##   of wiEntryBad: echo "bad symlink " & path & " with error " &
   ##                       osErrorMsg(info.code)
 
-  proc noErrors(pc: PathComponent, path: string): WalkStep =
+  proc noErrors(pc: PathComponent, path: string): owned(WalkStep) =
     WalkStep(kind: wiEntryOk, entryType: pc, code: OSErrorCode(0), path: path)
-  proc openDir(s: openDirStatus, path: string): WalkStep =
+  proc openDir(s: openDirStatus, path: string): owned(WalkStep) =
     WalkStep(kind: wiOpenDir, openStatus: s, code: osLastError(), path: path)
-  proc getError(k: WalkStepKind, path: string): WalkStep =
+  proc getError(k: WalkStepKind, path: string): owned(WalkStep) =
     WalkStep(kind: k, code: osLastError(), path: path)
 
   when nimvm:
@@ -2184,7 +2184,7 @@ iterator walkDir*(dir: string; relative=false): tuple[kind: PathComponent, path:
     of wiOpenDir:
       if step.openStatus == odUnknownError: raiseOSError(step.code)
       else: discard
-    of wiEntryOk: yield (step.entryType, step.path)
+    of wiEntryOk: yield (step.entryType, move(step.path))
     of wiEntryBad: discard
     of wiInterrupted: raiseOSError(step.code)
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2085,15 +2085,12 @@ iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
             else: yield sGetError(wsInterrupted, dir)
     else:
       var init = false
-      #while true:
-      #  if not init
 
       var d = opendir(dir)
       if d == nil:
-        case errno
-        of ENOENT: yield sOpenDir(odNotFound, dir)
-        of ENOTDIR: yield sOpenDir(odNotDir, dir)
-        of EACCES: yield sOpenDir(odAccessDenied, dir)
+        if errno == ENOENT: yield sOpenDir(odNotFound, dir)
+        elif errno == ENOTDIR: yield sOpenDir(odNotDir, dir)
+        elif errno == EACCES: yield sOpenDir(odAccessDenied, dir)
         else: yield sOpenDir(odUnknownError, dir)
       else:
         defer: discard closedir(d)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2176,6 +2176,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
 
   var step: WalkStep
   var skip = false
+  let outDir = if relative: "." else: dir
   proc sOpenDir(s: OpenDirStatus, path: string): WalkStep =
     let code = if s == odOpenOk: OSErrorCode(0) else: osLastError()
     result = WalkStep(kind: wsOpenDir, openStatus: s, code: code, path: path)
@@ -2208,7 +2209,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
         of ERROR_ACCESS_DENIED: odAccessDenied
         else: odUnknownError
       else: odOpenOk
-    step = sOpenDir(status, if relative: "." else: dir)
+    step = sOpenDir(status, outDir)
 
     var firstStep = true
     while true:
@@ -2225,7 +2226,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
             break  # normal end, yielding nothing
           else:
             skip = false
-            step = sGetError(wsInterrupted, dir)
+            step = sGetError(wsInterrupted, outDir)
             continue
       skip = skipFindData(f)
       if not skip:
@@ -2279,7 +2280,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
           elif errno == EACCES: odAccessDenied
           else: odUnknownError
       else: odOpenOk
-    step = sOpenDir(status, if relative: "." else: dir)
+    step = sOpenDir(status, outDir)
 
     while true:
       if not skip:
@@ -2295,7 +2296,7 @@ iterator tryWalkDir*(dir: string, relative=false): WalkStep {.
           break  # normal end, yielding nothing
         else:
           skip = false
-          step = sGetError(wsInterrupted, dir)
+          step = sGetError(wsInterrupted, outDir)
           continue
       when defined(nimNoArrayToCstringConversion):
         var y = $cstring(addr x.d_name)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1995,7 +1995,7 @@ proc staticWalkDir(dir: string; relative: bool): seq[
                   tuple[kind: PathComponent, path: string]] =
   discard
 
-type openDirStatus* = enum
+type OpenDirStatus* = enum
   odOpenOk,
   odNotDir,
   odAccessDenied,
@@ -2014,7 +2014,7 @@ type WalkStep = ref object
   path*: string
   case kind*: WalkStepKind
   of wsOpenDir:
-    openStatus*: openDirStatus
+    openStatus*: OpenDirStatus
   of wsEntryOk:
     entryType*: PathComponent
   of wsEntryBad, wsInterrupted:
@@ -2044,7 +2044,7 @@ iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
 
   proc sNoErrors(pc: PathComponent, path: string): owned(WalkStep) =
     WalkStep(kind: wsEntryOk, entryType: pc, code: OSErrorCode(0), path: path)
-  proc sOpenDir(s: openDirStatus, path: string): owned(WalkStep) =
+  proc sOpenDir(s: OpenDirStatus, path: string): owned(WalkStep) =
     WalkStep(kind: wsOpenDir, openStatus: s, code: osLastError(), path: path)
   proc sGetError(k: WalkStepKind, path: string): owned(WalkStep) =
     WalkStep(kind: k, code: osLastError(), path: path)
@@ -2172,7 +2172,7 @@ iterator tryWalkDir*(dir: string; relative=false): WalkStep {.
       if d != nil:
         discard closedir(d)
 
-proc tryOpenDir*(dir: string): openDirStatus {.
+proc tryOpenDir*(dir: string): OpenDirStatus {.
   tags: [ReadDirEffect], raises: [], since:(1,1) .} =
   # TODO
   for step in tryWalkDir(dir):

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -704,6 +704,7 @@ const
   ERROR_LOCK_VIOLATION* = 33
   ERROR_HANDLE_EOF* = 38
   ERROR_BAD_ARGUMENTS* = 165
+  ERROR_DIRECTORY* = 267
 
 proc duplicateHandle*(hSourceProcessHandle: Handle, hSourceHandle: Handle,
                       hTargetProcessHandle: Handle,

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -312,6 +312,7 @@ const
   MOVEFILE_FAIL_IF_NOT_TRACKABLE* = 0x20'i32
   MOVEFILE_REPLACE_EXISTING* = 0x1'i32
   MOVEFILE_WRITE_THROUGH* = 0x8'i32
+  REPARSE_TAG_NAME_SURROGATE* = 0x20000000'u32
 
 type
   WIN32_FIND_DATA* {.pure.} = object
@@ -321,7 +322,7 @@ type
     ftLastWriteTime*: FILETIME
     nFileSizeHigh*: int32
     nFileSizeLow*: int32
-    dwReserved0: int32
+    dwReserved0*: uint32
     dwReserved1: int32
     cFileName*: array[0..(MAX_PATH) - 1, WinChar]
     cAlternateFileName*: array[0..13, WinChar]
@@ -703,6 +704,7 @@ const
   ERROR_NO_MORE_FILES* = 18
   ERROR_LOCK_VIOLATION* = 33
   ERROR_HANDLE_EOF* = 38
+  ERROR_INVALID_NAME* = 123
   ERROR_BAD_ARGUMENTS* = 165
   ERROR_DIRECTORY* = 267
 


### PR DESCRIPTION
Alternative solution w.r.t. #13011, #12960.
New iterator `walkDirErr` with error-checking, use like this:
```nim
for kind, path, error in walkDirErr("dirA"):
  if error == OSErrorCode(0):
    echo path & " of kind " & $kind
  else:
    echo path & " GET INFO FAILED: " & osErrorMsg(error)
```
Other iterators remain unchecked.
Tested manually on Linux & Windows.
