### PR TITLE
fix #13164 CI disable -r for package norm

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -62,7 +62,7 @@ pkg "nimsl", "", true
 pkg "nimsvg"
 # pkg "nimterop", "", true
 pkg "nimx", "nim c --threads:on test/main.nim", true
-pkg "norm", "nim c -r tests/tsqlite.nim", true
+pkg "norm", "nim c tests/tsqlite.nim", true # bug #13164 breaks with -r
 pkg "npeg"
 pkg "ormin", "nim c -o:orminn ormin.nim", true
 pkg "parsetoml"


### PR DESCRIPTION
/cc @moigagoo @Araq 

## note:
super weird, I tried closing and reopening this PR because of https://github.com/nim-lang/Nim/issues/13166 (another flaky test) but it did not restart this job:
`builds.sr.ht: freebsd.yml Pending — builds.sr.ht job is running`
instead I had to force CI running again by making a git change (in my case `git pull --rebase original devel`)
maybe there's something funky about freebsd.yml
