### PR TITLE
[do not merge] assessing overhead caused by azure pipelines integration

### DIFF
--- a/testament/azure.nim
+++ b/testament/azure.nim
@@ -42,6 +42,7 @@ proc invokeRest(httpMethod: HttpMethod; api: string; body = ""): Response =
     raise newException(HttpRequestError, "Server returned: " & result.body)
 
 proc finish*() {.noconv.} =
+  stderr.writeLine "##vso[task.logissue type=warning;]Recorded overhead was ", overhead, " seconds"
   if not isAzure or runId < 0:
     return
 
@@ -53,7 +54,6 @@ proc finish*() {.noconv.} =
     stderr.writeLine "##vso[task.logissue type=warning;]Unable to finalize Azure backend"
     stderr.writeLine getCurrentExceptionMsg()
 
-  stderr.writeLine "##vso[task.logissue type=warning;]Recorded overhead was ", overhead, " seconds"
   runId = -1
 
 # TODO: Only obtain a run id if tests are run

--- a/testament/azure.nim
+++ b/testament/azure.nim
@@ -16,7 +16,7 @@ const
 
 var
   runId* = -1
-  overhead = 0.0
+  overhead* = 0.0
 
 proc getAzureEnv(env: string): string =
   # Conversion rule at:
@@ -42,7 +42,6 @@ proc invokeRest(httpMethod: HttpMethod; api: string; body = ""): Response =
     raise newException(HttpRequestError, "Server returned: " & result.body)
 
 proc finish*() {.noconv.} =
-  stderr.writeLine "##vso[task.logissue type=warning;]Recorded overhead was ", overhead, " seconds"
   if not isAzure or runId < 0:
     return
 

--- a/testament/azure.nim
+++ b/testament/azure.nim
@@ -59,23 +59,22 @@ proc finish*() {.noconv.} =
 # TODO: Only obtain a run id if tests are run
 # NOTE: We can't delete test runs with Azure's access token
 proc start*() =
-  when false:
-    if not isAzure:
-      return
-    try:
-      if runId < 0:
-        runId = invokeRest(HttpPost,
-                           ApiRuns,
-                           $ %* {
-                             "automated": true,
-                             "build": { "id": getAzureEnv("Build.BuildId") },
-                             "buildPlatform": hostCPU,
-                             "controller": "nim-testament",
-                             "name": getAzureEnv("Agent.JobName")
-                           }).body.parseJson["id"].getInt(-1)
-    except:
-      stderr.writeLine "##vso[task.logissue type=warning;]Unable to initialize Azure backend"
-      stderr.writeLine getCurrentExceptionMsg()
+  if not isAzure:
+    return
+  try:
+    if runId < 0:
+      runId = invokeRest(HttpPost,
+                         ApiRuns,
+                         $ %* {
+                           "automated": true,
+                           "build": { "id": getAzureEnv("Build.BuildId") },
+                           "buildPlatform": hostCPU,
+                           "controller": "nim-testament",
+                           "name": getAzureEnv("Agent.JobName")
+                         }).body.parseJson["id"].getInt(-1)
+  except:
+    stderr.writeLine "##vso[task.logissue type=warning;]Unable to initialize Azure backend"
+    stderr.writeLine getCurrentExceptionMsg()
 
 proc addTestResult*(name, category: string; durationInMs: int; errorMsg: string;
                     outcome: TResultEnum) =

--- a/testament/azure.nim
+++ b/testament/azure.nim
@@ -53,22 +53,23 @@ proc finish*() {.noconv.} =
 # TODO: Only obtain a run id if tests are run
 # NOTE: We can't delete test runs with Azure's access token
 proc start*() =
-  if not isAzure:
-    return
-  try:
-    if runId < 0:
-      runId = invokeRest(HttpPost,
-                         ApiRuns,
-                         $ %* {
-                           "automated": true,
-                           "build": { "id": getAzureEnv("Build.BuildId") },
-                           "buildPlatform": hostCPU,
-                           "controller": "nim-testament",
-                           "name": getAzureEnv("Agent.JobName")
-                         }).body.parseJson["id"].getInt(-1)
-  except:
-    stderr.writeLine "##vso[task.logissue type=warning;]Unable to initialize Azure backend"
-    stderr.writeLine getCurrentExceptionMsg()
+  when false:
+    if not isAzure:
+      return
+    try:
+      if runId < 0:
+        runId = invokeRest(HttpPost,
+                           ApiRuns,
+                           $ %* {
+                             "automated": true,
+                             "build": { "id": getAzureEnv("Build.BuildId") },
+                             "buildPlatform": hostCPU,
+                             "controller": "nim-testament",
+                             "name": getAzureEnv("Agent.JobName")
+                           }).body.parseJson["id"].getInt(-1)
+    except:
+      stderr.writeLine "##vso[task.logissue type=warning;]Unable to initialize Azure backend"
+      stderr.writeLine getCurrentExceptionMsg()
 
 proc addTestResult*(name, category: string; durationInMs: int; errorMsg: string;
                     outcome: TResultEnum) =

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -747,6 +747,7 @@ proc main() =
     else: echo r, r.data
   backend.close()
   if isMainProcess: azure.finish()
+  stderr.writeLine "##vso[task.logissue type=warning;]Recorded overhead was ", overhead, " seconds"
   var failed = r.total - r.passed - r.skipped
   if failed != 0:
     echo "FAILURE! total: ", r.total, " passed: ", r.passed, " skipped: ",


### PR DESCRIPTION
I've noted occasions where testament couldn't upload result due to azure pipelines' REST API stopped working, thus got a suspicion that the workload done by Nim's CI might have overloaded their servers.

Furthermore, since test result reporting is a synchronous process, any slowness experienced by azure pipelines' servers will be reflected to us.

Please do not merge this PR, this is only for profiling purposes.