### PR TITLE
more on arc codegen

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2811,15 +2811,17 @@ proc getNullValueAux(p: BProc; t: PType; obj, constOrNil: PNode,
     
     result.add "{"
     var countB = 0
+    let b = lastSon(obj[selectedBranch])
     # designated initilization is the only way to init non first element of unions
-    if lastSon(obj[selectedBranch]).kind != nkSym:
+    # branches are allowed to have no members (b.len == 0), in this case they don't need initializer
+    if  b.kind == nkRecList and b.len > 0:
       result.add "._i" & $selectedBranch & " = {"
-      getNullValueAux(p, t, lastSon(obj[selectedBranch]), constOrNil, result, countB, isConst, info)
+      getNullValueAux(p, t,  b, constOrNil, result, countB, isConst, info)
       result.add "}"
-    else:
+    elif b.kind == nkSym:
       result.add "." & lastSon(obj[selectedBranch]).sym.loc.r & " = "
-      getNullValueAux(p, t, lastSon(obj[selectedBranch]), constOrNil, result, countB, isConst, info)
-      result.add "}"
+      getNullValueAux(p, t,  b, constOrNil, result, countB, isConst, info)
+    result.add "}"
     
   of nkSym:
     if count > 0: result.add ", "

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2201,11 +2201,12 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
       else:
         internalError(p.config, e.info, "unknown ast")
     let t = dotExpr[0].typ.skipTypes({tyTypeDesc})
+    let tname = getTypeDesc(p.module, t)
     let member =
       if t.kind == tyTuple:
         "Field" & rope(dotExpr[1].sym.position)
       else: dotExpr[1].sym.loc.r
-    putIntoDest(p,d,e, "((NI)offsetof($1, $2))" % [getTypeDesc(p.module, t), member])
+    putIntoDest(p,d,e, "((NI)offsetof($1, $2))" % [tname, member])
   of mChr: genSomeCast(p, e, d)
   of mOrd: genOrd(p, e, d)
   of mLengthArray, mHigh, mLengthStr, mLengthSeq, mLengthOpenArray:

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2204,8 +2204,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
     let member =
       if t.kind == tyTuple:
         "Field" & rope(dotExpr[1].sym.position)
-      else:
-        rope(dotExpr[1].sym.name.s)
+      else: dotExpr[1].sym.loc.r
     putIntoDest(p,d,e, "((NI)offsetof($1, $2))" % [getTypeDesc(p.module, t), member])
   of mChr: genSomeCast(p, e, d)
   of mOrd: genOrd(p, e, d)

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -508,15 +508,15 @@ proc mangleRecFieldName(m: BModule; field: PSym): Rope =
 
 proc genRecordFieldsAux(m: BModule, n: PNode,
                         rectype: PType,
-                        check: var IntSet): Rope =
+                        check: var IntSet, union_prefix = ""): Rope =
   result = nil
   case n.kind
   of nkRecList:
     for i in 0..<n.len:
-      result.add(genRecordFieldsAux(m, n[i], rectype, check))
+      result.add(genRecordFieldsAux(m, n[i], rectype, check, union_prefix))
   of nkRecCase:
     if n[0].kind != nkSym: internalError(m.config, n.info, "genRecordFieldsAux")
-    result.add(genRecordFieldsAux(m, n[0], rectype, check))
+    result.add(genRecordFieldsAux(m, n[0], rectype, check, union_prefix))
     # prefix mangled name with "_U" to avoid clashes with other field names,
     # since identifiers are not allowed to start with '_'
     var unionBody: Rope = nil
@@ -525,7 +525,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
       of nkOfBranch, nkElse:
         let k = lastSon(n[i])
         if k.kind != nkSym:
-          let a = genRecordFieldsAux(m, k, rectype, check)
+          let a = genRecordFieldsAux(m, k, rectype, check, union_prefix = union_prefix & "_i" & $i & ".")
           if a != nil:
             if tfPacked notin rectype.flags:
               unionBody.add("struct {")
@@ -535,11 +535,11 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
               else:
                 unionBody.addf("#pragma pack(push, 1)$nstruct{", [])
             unionBody.add(a)
-            unionBody.addf("};$n", [])
+            unionBody.addf("} _i$1;$n", [rope($i)])
             if tfPacked in rectype.flags and hasAttribute notin CC[m.config.cCompiler].props:
               unionBody.addf("#pragma pack(pop)$n", [])
         else:
-          unionBody.add(genRecordFieldsAux(m, k, rectype, check))
+          unionBody.add(genRecordFieldsAux(m, k, rectype, check, union_prefix))
       else: internalError(m.config, "genRecordFieldsAux(record case branch)")
     if unionBody != nil:
       result.addf("union{$n$1};$n", [unionBody])
@@ -548,7 +548,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
     if field.typ.kind == tyVoid: return
     #assert(field.ast == nil)
     let sname = mangleRecFieldName(m, field)
-    fillLoc(field.loc, locField, n, sname, OnUnknown)
+    fillLoc(field.loc, locField, n, union_prefix & sname, OnUnknown)
     if field.alignment > 0:
       result.addf "NIM_ALIGN($1) ", [rope(field.alignment)]
     # for importcpp'ed objects, we only need to set field.loc, but don't

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -508,15 +508,15 @@ proc mangleRecFieldName(m: BModule; field: PSym): Rope =
 
 proc genRecordFieldsAux(m: BModule, n: PNode,
                         rectype: PType,
-                        check: var IntSet, union_prefix = ""): Rope =
+                        check: var IntSet, unionPrefix = ""): Rope =
   result = nil
   case n.kind
   of nkRecList:
     for i in 0..<n.len:
-      result.add(genRecordFieldsAux(m, n[i], rectype, check, union_prefix))
+      result.add(genRecordFieldsAux(m, n[i], rectype, check, unionPrefix))
   of nkRecCase:
     if n[0].kind != nkSym: internalError(m.config, n.info, "genRecordFieldsAux")
-    result.add(genRecordFieldsAux(m, n[0], rectype, check, union_prefix))
+    result.add(genRecordFieldsAux(m, n[0], rectype, check, unionPrefix))
     # prefix mangled name with "_U" to avoid clashes with other field names,
     # since identifiers are not allowed to start with '_'
     var unionBody: Rope = nil
@@ -525,7 +525,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
       of nkOfBranch, nkElse:
         let k = lastSon(n[i])
         if k.kind != nkSym:
-          let a = genRecordFieldsAux(m, k, rectype, check, union_prefix = union_prefix & "_i" & $i & ".")
+          let a = genRecordFieldsAux(m, k, rectype, check, unionPrefix & "_i" & $i & ".")
           if a != nil:
             if tfPacked notin rectype.flags:
               unionBody.add("struct {")
@@ -539,7 +539,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
             if tfPacked in rectype.flags and hasAttribute notin CC[m.config.cCompiler].props:
               unionBody.addf("#pragma pack(pop)$n", [])
         else:
-          unionBody.add(genRecordFieldsAux(m, k, rectype, check, union_prefix))
+          unionBody.add(genRecordFieldsAux(m, k, rectype, check, unionPrefix))
       else: internalError(m.config, "genRecordFieldsAux(record case branch)")
     if unionBody != nil:
       result.addf("union{$n$1};$n", [unionBody])
@@ -548,7 +548,7 @@ proc genRecordFieldsAux(m: BModule, n: PNode,
     if field.typ.kind == tyVoid: return
     #assert(field.ast == nil)
     let sname = mangleRecFieldName(m, field)
-    fillLoc(field.loc, locField, n, union_prefix & sname, OnUnknown)
+    fillLoc(field.loc, locField, n, unionPrefix & sname, OnUnknown)
     if field.alignment > 0:
       result.addf "NIM_ALIGN($1) ", [rope(field.alignment)]
     # for importcpp'ed objects, we only need to set field.loc, but don't

--- a/tests/destructor/tarc3.nim
+++ b/tests/destructor/tarc3.nim
@@ -4,7 +4,7 @@ discard """
 """
 
 when defined(cpp):
-  {.passC: "-std=gnu++17".}
+  {.passC: "-std=gnu++2a".}
 
 type
   TokenKind* = enum
@@ -24,6 +24,23 @@ type
     else: discard
     pos*: Natural
 
+
+  Token2* = object
+    case kind*: TokenKind
+    of tkString: strVal*: string
+    of tkNumber: numVal*: float
+    of tkInt64, tkColon..tkComma:
+      str1*: array[2, string]
+      float: float
+    else: discard
+    pos*: Natural
+
+  Token3* = object
+    case kind*: TokenKind
+    of tkNumber: numVal*: float
+    of tkInt64, tkComma..tkString: ff: seq[float]
+    else: str1*: string
+  
   BaseLexer* = object of RootObj
     input*: string
     pos*: Natural
@@ -39,6 +56,8 @@ type
   Parser[T: Lexer] = object
     l: T
     tok: Token
+    tok2: Token2
+    tok3: Token3
     allowTrailingComma: bool
     allowIdentifierObjectKey: bool
 


### PR DESCRIPTION
Unions are now properly initialised in constants. 
Designated initialisers is the only way to init non first member of the union.
Such syntax requires C11 and C++2020, very latest GCC/VCC/Clang cpp compilers do support this feature.
I had to give anonymous structs in unions names, so I can refer to them in designated initializers.
