### PR TITLE
compiler/ccgtypes: hide exportc proc unless it has dynlib

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -953,7 +953,7 @@ proc genProcHeader(m: BModule, prc: PSym, asPtr: bool = false): Rope =
       result.add "N_LIB_EXPORT "
   elif prc.typ.callConv == ccInline or asPtr or isNonReloadable(m, prc):
     result.add "static "
-  elif {sfImportc, sfExportc} * prc.flags == {}:
+  elif sfImportc notin prc.flags:
     result.add "N_LIB_PRIVATE "
   var check = initIntSet()
   fillLoc(prc.loc, locProc, prc.ast[namePos], mangleName(m, prc), OnUnknown)

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -128,6 +128,9 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string) =
   var test3 = makeTest("lib/nimhcr.nim", options & " --outdir:tests/dll" & rpath, cat)
   test3.spec.action = actionCompile
   testSpec c, test3
+  var test4 = makeTest("tests/dll/visibility.nim", options & " --app:lib" & rpath, cat)
+  test4.spec.action = actionCompile
+  testSpec c, test4
 
   # windows looks in the dir of the exe (yay!):
   when not defined(Windows):
@@ -141,6 +144,7 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string) =
 
   testSpec r, makeTest("tests/dll/client.nim", options & " --threads:on" & rpath, cat)
   testSpec r, makeTest("tests/dll/nimhcr_unit.nim", options & rpath, cat)
+  testSpec r, makeTest("tests/dll/visibility.nim", options & rpath, cat)
 
   if "boehm" notin options:
     # force build required - see the comments in the .nim file for more details

--- a/tests/dll/visibility.nim
+++ b/tests/dll/visibility.nim
@@ -1,0 +1,19 @@
+discard """
+  output: "could not import: foo"
+  exitcode: 1
+"""
+
+const LibName {.used.} =
+  when defined(windows):
+    "visibility.dll"
+  elif defined(macosx):
+    "libvisibility.dylib"
+  else:
+    "libvisibility.so"
+
+when compileOption("app", "lib"):
+  proc foo() {.exportc.} =
+    echo "failed"
+elif isMainModule:
+  proc foo() {.importc, dynlib: LibName.}
+  foo()


### PR DESCRIPTION
This hides most of stdlib's internal functions from resulting binaries/libraries, where they aren't needed on *nix. Static libraries are not affected by this change (visibility doesn't apply to them).

This change reduced the amount of exported symbols drastically, from 83 exported symbols in `libvisibility.so` (the newly added test):

<details>

```
0000000000020860 B NTI__77mFvmsOLKik79ci2hXkHEg_
0000000000020720 B NTI__9bTGS9b5gqA3m1IgV71Csl0Q_
0000000000027c40 B NTI__DsOOBcxCUeVlNUDRmn9afcA_
00000000000207a0 B NTI__G9cUlLvU4AFC26wbFxLFkFA_
00000000000208c0 B NTI__K39aEGuwNdydKn2WFEpUygg_
0000000000020760 B NTI__LbeSGvgPzGzXnW9caIkJqMA_
0000000000027c00 B NTI__Pjt0MQjoA6TAHAHOFNel9cg_
0000000000020de0 B NTI__S9agCYBinaYZnGWcjTdxclg_
0000000000020620 B NTI__ShBqCFAISBSH2YqBfe6zjg_
00000000000207e0 B NTI__Ss6DFlX5iSZpHRZDmP74bg_
00000000000206e0 B NTI__Wyd9avMRCq0gsOu9adFoIjCA_
0000000000020900 B NTI__XEycrCsme5C8CVWAYEcdBQ_
00000000000206a0 B NTI__XIT9aewsXycM2U5B437NUDA_
0000000000020820 B NTI__hMQEc0FMry7Up7EoPki79aA_
0000000000020660 B NTI__oLyohQ7O2XOvGnflOss8EA_
0000000000020d60 B NTI__rR5Bzr1D5krxoo1NcNyeMA_
0000000000027bc0 B NTI__uB9b75OUPRENsBAu4AnoePA_
00000000000205e0 B NTI__vU9aO9cTqOMn6CBzhV8rX7Sw_
0000000000020da0 B NTI__ytyiCJqK439aF9cIibuRVpAg_
0000000000010b04 T NimMain
0000000000010b54 T NimMainInit
0000000000010af8 T NimMainInner
0000000000010aa3 T PreMain
0000000000010a9c T PreMainInner
0000000000011270 R TM__Q5wkpxktOdTGvlSRo9bzt9aw_11
0000000000011290 R TM__Q5wkpxktOdTGvlSRo9bzt9aw_12
0000000000015b70 D TM__tb6ebwjQ7RC9bgAFf10ee6w_2
0000000000010bb4 T _fini
0000000000002000 T _init
000000000000cc49 T addChar
0000000000027c78 B cmdCount
0000000000027c88 B cmdLine
0000000000010042 T copyString
000000000000d8ca T copyStringRC1
000000000000d448 T cstrToNimstr
0000000000020898 B currException__9bVPeDJlYTi9bQApZpfH8wjg
00000000000025db T echoBinSafe
00000000000205c0 B errorMessageWriter__ZXnv0JyrWe3HTd07wpSr7A
00000000000208a0 B excHandler__rqLlY5bs9atDw2OXYqJEn5g
000000000000e061 T extGetCellType
00000000000109f7 T foo
0000000000020e18 B framePtr__HRfVMH3jYeBJz6Q6X9b6Ptw
0000000000011080 R fsLookupTable__Gn52IZvqY4slyBTOYwGNRQ
0000000000027c80 B gEnv
0000000000019850 B gHeapidGenerator__hd54mEUTGcVuZLChYgtR9bg
0000000000027bf8 B gcFramePtr__ot48iojqko9aFxGhyjjjVaA
0000000000016480 B gch__IcYaEuuWivYAS86vFMTS3Q
000000000000fde0 T getRefcount
0000000000020e40 B globalMarkers
0000000000020d98 B globalMarkersLen
0000000000020618 B globalRaiseHook__JbO1ti4ULxrw54m4zNPbpA
000000000000e525 T incrSeqV3
0000000000027ba0 B localRaiseHook__EIvMhANBvB9cp2Ezvt29cADg
0000000000008e93 T markStackAndRegisters__U6T7JWtDLrWhtmhXSoy9a6g
000000000000c605 T mnewString
000000000000dd6e T mulInt
000000000000c4bf T newObj
000000000000bf77 T newObjNoInit
000000000000d76a T newObjRC1
000000000000de97 T newSeq
000000000000f3ee T nimGC_setStackBottom
000000000000d635 T nimGCvisit
000000000000cb90 T nimIntToStr
000000000000f8a6 T nimRegisterThreadLocalMarker
0000000000027ba8 B nim_program_result
0000000000020e20 B onUnhandledException__bFrawQlTKZhLweDD36j9b8g
0000000000020d40 B outOfMemHook__kZNaA7u1MfSW5ZeoGvw8xg
000000000000ed1c T raiseExceptionEx
00000000000100c5 T raiseIndexError2
000000000000dc10 T raiseOverflow
000000000000c58c T rawNewString
000000000000c01e T rawNewStringNoInit
000000000000f06b T reraiseException
000000000000c0f5 T resizeString
000000000000e10a T setLengthSeqV2
000000000000c63a T setLengthStr
000000000000fb5e T signalHandler
0000000000016020 D strDesc__D0UzA4zsDu5tgpJQ9a9clXPg
0000000000020940 B tempFrames__7nBYIr2UsDREpYylZK4fug
0000000000019860 B threadLocalMarkers
0000000000020e28 B threadLocalMarkersLen
000000000000d3f0 T toNimStr
000000000000c376 T unsureAsgnRef
```
</details>

down to 53 exported symbols:
<details>

```
0000000000020860 B NTI__77mFvmsOLKik79ci2hXkHEg_
0000000000020720 B NTI__9bTGS9b5gqA3m1IgV71Csl0Q_
0000000000027c40 B NTI__DsOOBcxCUeVlNUDRmn9afcA_
00000000000207a0 B NTI__G9cUlLvU4AFC26wbFxLFkFA_
00000000000208c0 B NTI__K39aEGuwNdydKn2WFEpUygg_
0000000000020760 B NTI__LbeSGvgPzGzXnW9caIkJqMA_
0000000000027c00 B NTI__Pjt0MQjoA6TAHAHOFNel9cg_
0000000000020de0 B NTI__S9agCYBinaYZnGWcjTdxclg_
0000000000020620 B NTI__ShBqCFAISBSH2YqBfe6zjg_
00000000000207e0 B NTI__Ss6DFlX5iSZpHRZDmP74bg_
00000000000206e0 B NTI__Wyd9avMRCq0gsOu9adFoIjCA_
0000000000020900 B NTI__XEycrCsme5C8CVWAYEcdBQ_
00000000000206a0 B NTI__XIT9aewsXycM2U5B437NUDA_
0000000000020820 B NTI__hMQEc0FMry7Up7EoPki79aA_
0000000000020660 B NTI__oLyohQ7O2XOvGnflOss8EA_
0000000000020d60 B NTI__rR5Bzr1D5krxoo1NcNyeMA_
0000000000027bc0 B NTI__uB9b75OUPRENsBAu4AnoePA_
00000000000205e0 B NTI__vU9aO9cTqOMn6CBzhV8rX7Sw_
0000000000020da0 B NTI__ytyiCJqK439aF9cIibuRVpAg_
0000000000010972 T NimMain
00000000000109c2 T NimMainInit
0000000000010966 T NimMainInner
0000000000010911 T PreMain
000000000001090a T PreMainInner
0000000000011270 R TM__Q5wkpxktOdTGvlSRo9bzt9aw_11
0000000000011290 R TM__Q5wkpxktOdTGvlSRo9bzt9aw_12
0000000000015c50 D TM__tb6ebwjQ7RC9bgAFf10ee6w_2
0000000000010a24 T _fini
0000000000002000 T _init
0000000000027c78 B cmdCount
0000000000027c88 B cmdLine
0000000000020898 B currException__9bVPeDJlYTi9bQApZpfH8wjg
00000000000205c0 B errorMessageWriter__ZXnv0JyrWe3HTd07wpSr7A
00000000000208a0 B excHandler__rqLlY5bs9atDw2OXYqJEn5g
0000000000020e18 B framePtr__HRfVMH3jYeBJz6Q6X9b6Ptw
0000000000011080 R fsLookupTable__Gn52IZvqY4slyBTOYwGNRQ
0000000000027c80 B gEnv
0000000000019858 B gHeapidGenerator__hd54mEUTGcVuZLChYgtR9bg
0000000000027bf8 B gcFramePtr__ot48iojqko9aFxGhyjjjVaA
0000000000016480 B gch__IcYaEuuWivYAS86vFMTS3Q
0000000000020e40 B globalMarkers
0000000000020d98 B globalMarkersLen
0000000000020618 B globalRaiseHook__JbO1ti4ULxrw54m4zNPbpA
0000000000027ba0 B localRaiseHook__EIvMhANBvB9cp2Ezvt29cADg
0000000000008cd3 T markStackAndRegisters__U6T7JWtDLrWhtmhXSoy9a6g
0000000000027ba8 B nim_program_result
0000000000020e20 B onUnhandledException__bFrawQlTKZhLweDD36j9b8g
0000000000020d40 B outOfMemHook__kZNaA7u1MfSW5ZeoGvw8xg
0000000000016020 D strDesc__D0UzA4zsDu5tgpJQ9a9clXPg
0000000000020940 B tempFrames__7nBYIr2UsDREpYylZK4fug
0000000000019860 B threadLocalMarkers
0000000000020e28 B threadLocalMarkersLen
0000000000019850 B unhandledExceptionHook__RJpSsXsRUH8ochbXTEhRIw
```
</details>

/cc @timotheecour