### PR TITLE
Idxmin & idxmax, continuation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,27 +37,21 @@
 - introduced new procs in `tables.nim`: `OrderedTable.pop`, `CountTable.del`,
   `CountTable.pop`, `Table.pop`
 - To `strtabs.nim`, added `StringTable.clear` overload that reuses the existing mode.
-
-
 - Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into
   operations that work on a copy of the data and return the mutated copy. As the existing
   `sorted` does.
 - Added `sugar.collect` that does comprehension for seq/set/table collections.
-
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
-
 - Added `typetraits.lenTuple` to get number of elements of a tuple/type tuple,
   and `typetraits.get` to get the ith element of a type tuple.
 - Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
-
 - Added `os.normalizePathEnd` for additional path sanitization.
-
 - Added `times.fromUnixFloat,toUnixFloat`, subsecond resolution versions of `fromUnix`,`toUnixFloat`.
-
 - Added `wrapnils` module for chains of field-access and indexing where the LHS can be nil.
   This simplifies code by reducing need for if-else branches around intermediate maybe nil values.
   Eg: `echo ?.n.typ.kind`
+- Added `minIndex` and `maxIndex` to the `sequtils` module
 
 ## Library changes
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -231,7 +231,7 @@ proc idxmin*[T, U](s: array[T, U]): auto =
 
     type Count = enum First, Second, Third
     let d: array[Count, int] = [0, 1, 2]
-    assert idxmin(d) = First
+    assert idxmin(d) == Count.First
 
   result = low(s)
   for i in result.succ..high(s):
@@ -267,7 +267,7 @@ proc idxmax*[T, U](s: array[T, U]): auto =
 
     type Count = enum First, Second, Third
     let d: array[Count, int] = [0, 1, 2]
-    assert idxmax(d) = Third
+    assert idxmax(d) == Count.Third
 
   result = low(s)
   for i in result.succ..high(s):

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -205,6 +205,15 @@ proc deduplicate*[T](s: openArray[T], isSorted: bool = false): seq[T] =
 proc idxmin*[T](s: openArray[T]): Natural =
   ## Returns the index of the minimum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+      b = @[6, 5, 4, 3]
+      c = @[2, -7, 8, -5]
+    assert idxmin(a) == 0
+    assert idxmin(b) == 3
+    assert idxmin(c) == 1
+
   result = 0
   for i in 1..high(s):
     if s[i] < s[result]: result = i

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -214,7 +214,6 @@ proc idxmin*[T](s: openArray[T]): Natural =
     assert idxmin(b) == 3
     assert idxmin(c) == 1
 
-  result = 0
   for i in 1..high(s):
     if s[i] < s[result]: result = i
 
@@ -230,7 +229,6 @@ proc idxmax*[T](s: openArray[T]): Natural =
     assert idxmax(b) == 0
     assert idxmax(c) == 2
 
-  result = 0
   for i in 1..high(s):
     if s[result] < s[i]: result = i
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -217,6 +217,23 @@ proc idxmin*[T](s: openArray[T]): Natural =
   for i in 1..high(s):
     if s[i] < s[result]: result = i
 
+proc idxmin*[T, U](s: array[T, U]): int =
+  ## Returns the index of the minimum value of `s`.
+  ## ``T`` needs to have a ``<`` operator.
+  runnableExamples:
+    let
+      a: array[3, int] = [0, 1, 2]
+      b: array[2..4, int] = [0, 1, 2]
+      c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
+    assert idxmin(a) == 0
+    assert idxmin(b) == 2
+    assert idxmin(c) == -1
+
+  result = low(s)
+  for i in result.succ..high(s):
+    if s[i] < s[result]:
+      result = i
+
 proc idxmax*[T](s: openArray[T]): Natural =
   ## Returns the index of the maximum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
@@ -231,6 +248,23 @@ proc idxmax*[T](s: openArray[T]): Natural =
 
   for i in 1..high(s):
     if s[result] < s[i]: result = i
+
+proc idxmax*[T, U](s: array[T, U]): int =
+  ## Returns the index of the maximum value of `s`.
+  ## ``T`` needs to have a ``<`` operator.
+  runnableExamples:
+    let
+      a: array[3, int] = [0, 1, 2]
+      b: array[2..4, int] = [0, 1, 2]
+      c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
+    assert idxmin(a) == 2
+    assert idxmin(b) == 4
+    assert idxmin(c) == -2
+
+  result = low(s)
+  for i in result.succ..high(s):
+    if s[result] < s[i]:
+      result = i
 
 template zipImpl(s1, s2, retType: untyped): untyped =
   proc zip*[S, T](s1: openArray[S], s2: openArray[T]): retType =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -209,6 +209,13 @@ proc idxmin*[T](s: openArray[T]): Natural =
   for i in 1..high(s):
     if s[i] < s[result]: result = i
 
+proc idxmax*[T](s: openArray[T]): Natural =
+  ## Returns the index of the maximum value of `s`.
+  ## ``T`` needs to have a ``<`` operator.
+  result = 0
+  for i in 1..high(s):
+    if s[result] < s[i]: result = i
+
 template zipImpl(s1, s2, retType: untyped): untyped =
   proc zip*[S, T](s1: openArray[S], s2: openArray[T]): retType =
     ## Returns a new sequence with a combination of the two input containers.

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -217,7 +217,7 @@ proc idxmin*[T](s: openArray[T]): Natural =
   for i in 1..high(s):
     if s[i] < s[result]: result = i
 
-proc idxmin*[T, U](s: array[T, U]): int =
+proc idxmin*[T, U](s: array[T, U]): auto =
   ## Returns the index of the minimum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
@@ -228,6 +228,10 @@ proc idxmin*[T, U](s: array[T, U]): int =
     assert idxmin(a) == 0
     assert idxmin(b) == 2
     assert idxmin(c) == -1
+
+    type Count = enum First, Second, Third
+    let d: array[Count, int] = [0, 1, 2]
+    assert idxmin(d) = First
 
   result = low(s)
   for i in result.succ..high(s):
@@ -249,7 +253,7 @@ proc idxmax*[T](s: openArray[T]): Natural =
   for i in 1..high(s):
     if s[result] < s[i]: result = i
 
-proc idxmax*[T, U](s: array[T, U]): int =
+proc idxmax*[T, U](s: array[T, U]): auto =
   ## Returns the index of the maximum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
@@ -260,6 +264,10 @@ proc idxmax*[T, U](s: array[T, U]): int =
     assert idxmin(a) == 2
     assert idxmin(b) == 4
     assert idxmin(c) == -2
+
+    type Count = enum First, Second, Third
+    let d: array[Count, int] = [0, 1, 2]
+    assert idxmax(d) = Third
 
   result = low(s)
   for i in result.succ..high(s):

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -202,77 +202,40 @@ proc deduplicate*[T](s: openArray[T], isSorted: bool = false): seq[T] =
       for itm in items(s):
         if not result.contains(itm): result.add(itm)
 
-proc minIndex*[T](s: openArray[T]): Natural =
+proc minIndex*[T](s: openArray[T]): int {.since: (1, 1).} =
   ## Returns the index of the minimum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
     let
       a = @[1, 2, 3, 4]
       b = @[6, 5, 4, 3]
-      c = @[2, -7, 8, -5]
+      c = [2, -7, 8, -5]
+      d = "ziggy"
     assert minIndex(a) == 0
     assert minIndex(b) == 3
     assert minIndex(c) == 1
+    assert minIndex(d) == 2
 
   for i in 1..high(s):
     if s[i] < s[result]: result = i
 
-proc minIndex*[T, U](s: array[T, U]): auto =
-  ## Returns the index of the minimum value of `s`.
-  ## ``T`` needs to have a ``<`` operator.
-  runnableExamples:
-    let
-      a: array[3, int] = [0, 1, 2]
-      b: array[2..4, int] = [0, 1, 2]
-      c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
-    assert minIndex(a) == 0
-    assert minIndex(b) == 2
-    assert minIndex(c) == -1
-
-    type Count = enum First, Second, Third
-    let d: array[Count, int] = [0, 1, 2]
-    assert minIndex(d) == Count.First
-
-  result = low(s)
-  for i in result.succ..high(s):
-    if s[i] < s[result]:
-      result = i
-
-proc maxIndex*[T](s: openArray[T]): Natural =
+proc maxIndex*[T](s: openArray[T]): int {.since: (1, 1).} =
   ## Returns the index of the maximum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
     let
       a = @[1, 2, 3, 4]
       b = @[6, 5, 4, 3]
-      c = @[2, -7, 8, -5]
+      c = [2, -7, 8, -5]
+      d = "ziggy"
     assert maxIndex(a) == 3
     assert maxIndex(b) == 0
     assert maxIndex(c) == 2
+    assert maxIndex(d) == 0
 
   for i in 1..high(s):
-    if s[result] < s[i]: result = i
+    if s[i] > s[result]: result = i
 
-proc maxIndex*[T, U](s: array[T, U]): auto =
-  ## Returns the index of the maximum value of `s`.
-  ## ``T`` needs to have a ``<`` operator.
-  runnableExamples:
-    let
-      a: array[3, int] = [0, 1, 2]
-      b: array[2..4, int] = [0, 1, 2]
-      c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
-    assert maxIndex(a) == 2
-    assert maxIndex(b) == 4
-    assert maxIndex(c) == -2
-
-    type Count = enum First, Second, Third
-    let d: array[Count, int] = [0, 1, 2]
-    assert maxIndex(d) == Count.Third
-
-  result = low(s)
-  for i in result.succ..high(s):
-    if s[result] < s[i]:
-      result = i
 
 template zipImpl(s1, s2, retType: untyped): untyped =
   proc zip*[S, T](s1: openArray[S], s2: openArray[T]): retType =

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -202,6 +202,13 @@ proc deduplicate*[T](s: openArray[T], isSorted: bool = false): seq[T] =
       for itm in items(s):
         if not result.contains(itm): result.add(itm)
 
+proc idxmin*[T](s: openArray[T]): Natural =
+  ## Returns the index of the minimum value of `s`.
+  ## ``T`` needs to have a ``<`` operator.
+  result = 0
+  for i in 1..high(s):
+    if s[i] < s[result]: result = i
+
 template zipImpl(s1, s2, retType: untyped): untyped =
   proc zip*[S, T](s1: openArray[S], s2: openArray[T]): retType =
     ## Returns a new sequence with a combination of the two input containers.

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -202,7 +202,7 @@ proc deduplicate*[T](s: openArray[T], isSorted: bool = false): seq[T] =
       for itm in items(s):
         if not result.contains(itm): result.add(itm)
 
-proc idxmin*[T](s: openArray[T]): Natural =
+proc minIndex*[T](s: openArray[T]): Natural =
   ## Returns the index of the minimum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
@@ -210,14 +210,14 @@ proc idxmin*[T](s: openArray[T]): Natural =
       a = @[1, 2, 3, 4]
       b = @[6, 5, 4, 3]
       c = @[2, -7, 8, -5]
-    assert idxmin(a) == 0
-    assert idxmin(b) == 3
-    assert idxmin(c) == 1
+    assert minIndex(a) == 0
+    assert minIndex(b) == 3
+    assert minIndex(c) == 1
 
   for i in 1..high(s):
     if s[i] < s[result]: result = i
 
-proc idxmin*[T, U](s: array[T, U]): auto =
+proc minIndex*[T, U](s: array[T, U]): auto =
   ## Returns the index of the minimum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
@@ -225,20 +225,20 @@ proc idxmin*[T, U](s: array[T, U]): auto =
       a: array[3, int] = [0, 1, 2]
       b: array[2..4, int] = [0, 1, 2]
       c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
-    assert idxmin(a) == 0
-    assert idxmin(b) == 2
-    assert idxmin(c) == -1
+    assert minIndex(a) == 0
+    assert minIndex(b) == 2
+    assert minIndex(c) == -1
 
     type Count = enum First, Second, Third
     let d: array[Count, int] = [0, 1, 2]
-    assert idxmin(d) == Count.First
+    assert minIndex(d) == Count.First
 
   result = low(s)
   for i in result.succ..high(s):
     if s[i] < s[result]:
       result = i
 
-proc idxmax*[T](s: openArray[T]): Natural =
+proc maxIndex*[T](s: openArray[T]): Natural =
   ## Returns the index of the maximum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
@@ -246,14 +246,14 @@ proc idxmax*[T](s: openArray[T]): Natural =
       a = @[1, 2, 3, 4]
       b = @[6, 5, 4, 3]
       c = @[2, -7, 8, -5]
-    assert idxmax(a) == 3
-    assert idxmax(b) == 0
-    assert idxmax(c) == 2
+    assert maxIndex(a) == 3
+    assert maxIndex(b) == 0
+    assert maxIndex(c) == 2
 
   for i in 1..high(s):
     if s[result] < s[i]: result = i
 
-proc idxmax*[T, U](s: array[T, U]): auto =
+proc maxIndex*[T, U](s: array[T, U]): auto =
   ## Returns the index of the maximum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
   runnableExamples:
@@ -261,13 +261,13 @@ proc idxmax*[T, U](s: array[T, U]): auto =
       a: array[3, int] = [0, 1, 2]
       b: array[2..4, int] = [0, 1, 2]
       c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
-    assert idxmax(a) == 2
-    assert idxmax(b) == 4
-    assert idxmax(c) == -2
+    assert maxIndex(a) == 2
+    assert maxIndex(b) == 4
+    assert maxIndex(c) == -2
 
     type Count = enum First, Second, Third
     let d: array[Count, int] = [0, 1, 2]
-    assert idxmax(d) == Count.Third
+    assert maxIndex(d) == Count.Third
 
   result = low(s)
   for i in result.succ..high(s):

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -221,6 +221,15 @@ proc idxmin*[T](s: openArray[T]): Natural =
 proc idxmax*[T](s: openArray[T]): Natural =
   ## Returns the index of the maximum value of `s`.
   ## ``T`` needs to have a ``<`` operator.
+  runnableExamples:
+    let
+      a = @[1, 2, 3, 4]
+      b = @[6, 5, 4, 3]
+      c = @[2, -7, 8, -5]
+    assert idxmax(a) == 3
+    assert idxmax(b) == 0
+    assert idxmax(c) == 2
+
   result = 0
   for i in 1..high(s):
     if s[result] < s[i]: result = i

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -261,9 +261,9 @@ proc idxmax*[T, U](s: array[T, U]): auto =
       a: array[3, int] = [0, 1, 2]
       b: array[2..4, int] = [0, 1, 2]
       c: array[-2..4, int] = [4, -5, 1, 3, 0, 1, 2]
-    assert idxmin(a) == 2
-    assert idxmin(b) == 4
-    assert idxmin(c) == -2
+    assert idxmax(a) == 2
+    assert idxmax(b) == 4
+    assert idxmax(c) == -2
 
     type Count = enum First, Second, Third
     let d: array[Count, int] = [0, 1, 2]


### PR DESCRIPTION
This is a continuation from PR #12993, making that one obsolete, based on @Araq's comments:

- remove 'array' versions
- add .since pragma
- return 'int' instead of 'Natural'
- add changelog entry