### PR TITLE
new os.isRelativeTo

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,8 @@
   Eg: `echo ?.n.typ.kind`
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 
+- Added `os.isRelativeTo` to tell whether a path is relative to another
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -406,6 +406,19 @@ proc relativePath*(path, base: string; sep = DirSep): string {.
     if not f.hasNext(path): break
     ff = f.next(path)
 
+proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
+  ## returns true if `path` is rooted under or equal to `base` modulo path
+  ## normalization.
+  runnableExamples:
+    doAssert isRelativeTo("./foo//bar", "foo")
+    # doAssert isRelativeTo("foo/bar", ".") # pending #13211
+    doAssert isRelativeTo("/foo/bar.nim", "/foo/bar.nim")
+    doAssert not isRelativeTo("foo/bar.nims", "foo/bar.nim")
+  let path = path.normalizePath
+  let base = base.normalizePath
+  let ret = relativePath(path, base)
+  result = path.len > 0 and not ret.startsWith ".."
+
 proc parentDirPos(path: string): int =
   var q = 1
   if len(path) >= 1 and path[len(path)-1] in {DirSep, AltSep}: q = 2

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -407,8 +407,7 @@ proc relativePath*(path, base: string; sep = DirSep): string {.
     ff = f.next(path)
 
 proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
-  ## returns true if `path` is rooted under or equal to `base` modulo path
-  ## normalization.
+  ## Returns true if `path` is relative to `base`.
   runnableExamples:
     doAssert isRelativeTo("./foo//bar", "foo")
     # doAssert isRelativeTo("foo/bar", ".") # pending #13211

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -410,7 +410,7 @@ proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
   ## Returns true if `path` is relative to `base`.
   runnableExamples:
     doAssert isRelativeTo("./foo//bar", "foo")
-    # doAssert isRelativeTo("foo/bar", ".") # pending #13211
+    doAssert isRelativeTo("foo/bar", ".")
     doAssert isRelativeTo("/foo/bar.nim", "/foo/bar.nim")
     doAssert not isRelativeTo("foo/bar.nims", "foo/bar.nim")
   let path = path.normalizePath

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -382,3 +382,13 @@ block osenv:
     doAssert existsEnv(dummyEnvVar) == false
     delEnv(dummyEnvVar)         # deleting an already deleted env var
     doAssert existsEnv(dummyEnvVar) == false
+
+block isRelativeTo:
+  doAssert isRelativeTo("foo/bar", "foo")
+  doAssert isRelativeTo("/foo/bar.nim", "/foo/bar.nim")
+  doAssert isRelativeTo("./foo/", "foo")
+  doAssert isRelativeTo("foo", "./foo/")
+  doAssert isRelativeTo(".", ".")
+  # doAssert isRelativeTo("foo/bar", ".") # pending #13211
+  doAssert not isRelativeTo("foo/bar.nims", "foo/bar.nim")
+  doAssert not isRelativeTo("/foo2", "/foo")

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -384,6 +384,8 @@ block osenv:
     doAssert existsEnv(dummyEnvVar) == false
 
 block isRelativeTo:
+  doAssert isRelativeTo("/foo", "/")
+  doAssert isRelativeTo("/foo/bar", "/foo")
   doAssert isRelativeTo("foo/bar", "foo")
   doAssert isRelativeTo("/foo/bar.nim", "/foo/bar.nim")
   doAssert isRelativeTo("./foo/", "foo")

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -391,6 +391,6 @@ block isRelativeTo:
   doAssert isRelativeTo("./foo/", "foo")
   doAssert isRelativeTo("foo", "./foo/")
   doAssert isRelativeTo(".", ".")
-  # doAssert isRelativeTo("foo/bar", ".") # pending #13211
+  doAssert isRelativeTo("foo/bar", ".")
   doAssert not isRelativeTo("foo/bar.nims", "foo/bar.nim")
   doAssert not isRelativeTo("/foo2", "/foo")


### PR DESCRIPTION
```nim
doAssert isRelativeTo("./foo//bar", "foo")
doAssert isRelativeTo("foo/bar", ".")
doAssert isRelativeTo("/foo/bar.nim", "/foo/bar.nim")
doAssert not isRelativeTo("foo/bar.nims", "foo/bar.nim")
```

note: different from `startsWith` which is the wrong thing to use with paths
