### PR TITLE
Unexport even more symbols

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1325,7 +1325,7 @@ proc rawConstExpr(p: BProc, n: PNode; d: var TLoc) =
   if id == p.module.labels:
     # expression not found in the cache:
     inc(p.module.labels)
-    p.module.s[cfsData].addf("NIM_CONST $1 $2 = $3;$n",
+    p.module.s[cfsData].addf("static NIM_CONST $1 $2 = $3;$n",
           [getTypeDesc(p.module, t), d.r, genBracedInit(p, n, isConst = true)])
 
 proc handleConstExpr(p: BProc, n: PNode, d: var TLoc): bool =
@@ -2508,7 +2508,7 @@ proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
   if id == p.module.labels:
     # expression not found in the cache:
     inc(p.module.labels)
-    p.module.s[cfsData].addf("NIM_CONST $1 $2 = $3;$n",
+    p.module.s[cfsData].addf("static NIM_CONST $1 $2 = $3;$n",
          [getTypeDesc(p.module, t), tmp, genBracedInit(p, n, isConst = true)])
 
   if d.k == locNone:
@@ -2896,7 +2896,7 @@ proc genConstSeq(p: BProc, n: PNode, t: PType; isConst: bool): Rope =
   let base = t.skipTypes(abstractInst)[0]
 
   appcg(p.module, cfsData,
-        "$5 struct {$n" &
+        "static $5 struct {$n" &
         "  #TGenericSeq Sup;$n" &
         "  $1 data[$2];$n" &
         "} $3 = $4;$n", [

--- a/compiler/ccgthreadvars.nim
+++ b/compiler/ccgthreadvars.nim
@@ -33,7 +33,7 @@ proc declareThreadVar(m: BModule, s: PSym, isExtern: bool) =
       m.g.nimtv.addf("$1 $2;$n", [getTypeDesc(m, s.loc.t), s.loc.r])
   else:
     if isExtern: m.s[cfsVars].add("extern ")
-    elif lfExportLib in s.loc.flags: m.s[cfsVars].add("N_LIB_EXPORT ")
+    elif lfExportLib in s.loc.flags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
     else: m.s[cfsVars].add("N_LIB_PRIVATE ")
     if optThreads in m.config.globalOptions: m.s[cfsVars].add("NIM_THREADVAR ")
     m.s[cfsVars].add(getTypeDesc(m, s.loc.t))

--- a/compiler/ccgthreadvars.nim
+++ b/compiler/ccgthreadvars.nim
@@ -33,6 +33,8 @@ proc declareThreadVar(m: BModule, s: PSym, isExtern: bool) =
       m.g.nimtv.addf("$1 $2;$n", [getTypeDesc(m, s.loc.t), s.loc.r])
   else:
     if isExtern: m.s[cfsVars].add("extern ")
+    elif lfExportLib in s.loc.flags: m.s[cfsVars].add("N_LIB_EXPORT ")
+    else: m.s[cfsVars].add("N_LIB_PRIVATE ")
     if optThreads in m.config.globalOptions: m.s[cfsVars].add("NIM_THREADVAR ")
     m.s[cfsVars].add(getTypeDesc(m, s.loc.t))
     m.s[cfsVars].addf(" $1;$n", [s.loc.r])

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1026,7 +1026,7 @@ proc genTypeInfoAuxBase(m: BModule; typ, origType: PType;
     m.hcrCreateTypeInfosProc.addf("\thcrRegisterGlobal($2, \"$1\", sizeof(TNimType), NULL, (void**)&$1);$n",
          [name, getModuleDllPath(m, m.module)])
   else:
-    m.s[cfsData].addf("TNimType $1;$n", [name])
+    m.s[cfsData].addf("N_LIB_PRIVATE TNimType $1;$n", [name])
 
 proc genTypeInfoAux(m: BModule, typ, origType: PType, name: Rope;
                     info: TLineInfo) =
@@ -1301,7 +1301,7 @@ proc genTypeInfoV2(m: BModule, t, origType: PType, name: Rope; info: TLineInfo) 
   else:
     typeName = rope("NIM_NIL")
 
-  m.s[cfsData].addf("TNimType $1;$n", [name])
+  m.s[cfsData].addf("N_LIB_PRIVATE TNimType $1;$n", [name])
   let destroyImpl = genHook(m, t, info, attachedDestructor)
   let traceImpl = genHook(m, t, info, attachedTrace)
   let disposeImpl = genHook(m, t, info, attachedDispose)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1316,19 +1316,19 @@ proc genMainProc(m: BModule) =
   const
     # not a big deal if we always compile these 3 global vars... makes the HCR code easier
     PosixCmdLine =
-      "int cmdCount;$N" &
-      "char** cmdLine;$N" &
-      "char** gEnv;$N"
+      "N_LIB_PRIVATE int cmdCount;$N" &
+      "N_LIB_PRIVATE char** cmdLine;$N" &
+      "N_LIB_PRIVATE char** gEnv;$N"
 
     # The use of a volatile function pointer to call Pre/NimMainInner
     # prevents inlining of the NimMainInner function and dependent
     # functions, which might otherwise merge their stack frames.
     PreMainBody = "$N" &
-      "void PreMainInner(void) {$N" &
+      "N_LIB_PRIVATE void PreMainInner(void) {$N" &
       "$2" &
       "}$N$N" &
       PosixCmdLine &
-      "void PreMain(void) {$N" &
+      "N_LIB_PRIVATE void PreMain(void) {$N" &
       "\tvoid (*volatile inner)(void);$N" &
       "\tinner = PreMainInner;$N" &
       "$1" &
@@ -1341,7 +1341,7 @@ proc genMainProc(m: BModule) =
     MainProcsWithResult =
       MainProcs & ("\treturn $1nim_program_result;$N")
 
-    NimMainInner = "N_CDECL(void, NimMainInner)(void) {$N" &
+    NimMainInner = "N_LIB_PRIVATE N_CDECL(void, NimMainInner)(void) {$N" &
         "$1" &
       "}$N$N"
 
@@ -1388,7 +1388,7 @@ proc genMainProc(m: BModule) =
     PosixNimDllMain = WinNimDllMain
 
     PosixCDllMain =
-      "void NIM_POSIX_INIT NimMainInit(void) {$N" &
+      "N_LIB_PRIVATE void NIM_POSIX_INIT NimMainInit(void) {$N" &
         MainProcs &
       "}$N$N"
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1177,7 +1177,7 @@ proc requestConstImpl(p: BProc, sym: PSym) =
   var q = findPendingModule(m, sym)
   if q != nil and not containsOrIncl(q.declaredThings, sym.id):
     assert q.initProc.module == q
-    q.s[cfsData].addf("NIM_CONST $1 $2 = $3;$n",
+    q.s[cfsData].addf("N_LIB_PRIVATE NIM_CONST $1 $2 = $3;$n",
         [getTypeDesc(q, sym.typ), sym.loc.r, genBracedInit(q.initProc, sym.ast, isConst = true)])
   # declare header:
   if q != m and not containsOrIncl(m.declaredThings, sym.id):

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -549,6 +549,8 @@ proc assignGlobalVar(p: BProc, n: PNode; value: Rope) =
           decl.addf "NIM_ALIGN($1) ", [rope(s.alignment)]
         if p.hcrOn: decl.add("static ")
         elif sfImportc in s.flags: decl.add("extern ")
+        elif lfExportLib in s.loc.flags: decl.add("N_LIB_EXPORT ")
+        else: decl.add("N_LIB_PRIVATE ")
         if s.kind == skLet and value != nil: decl.add("NIM_CONST ")
         decl.add(td)
         if p.hcrOn: decl.add("*")

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -549,7 +549,7 @@ proc assignGlobalVar(p: BProc, n: PNode; value: Rope) =
           decl.addf "NIM_ALIGN($1) ", [rope(s.alignment)]
         if p.hcrOn: decl.add("static ")
         elif sfImportc in s.flags: decl.add("extern ")
-        elif lfExportLib in s.loc.flags: decl.add("N_LIB_EXPORT ")
+        elif lfExportLib in s.loc.flags: decl.add("N_LIB_EXPORT_VAR ")
         else: decl.add("N_LIB_PRIVATE ")
         if s.kind == skLet and value != nil: decl.add("NIM_CONST ")
         decl.add(td)

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -186,6 +186,7 @@ __AVR__
 #  else
 #    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
 #  endif
+#  define N_LIB_EXPORT_VAR  __declspec(dllexport)
 #  define N_LIB_IMPORT  extern __declspec(dllimport)
 #else
 #  define N_LIB_PRIVATE __attribute__((visibility("hidden")))
@@ -215,6 +216,7 @@ __AVR__
 #    define N_SAFECALL_PTR(rettype, name) rettype (*name)
 #  endif
 #  define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
+#  define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
 #  define N_LIB_IMPORT  extern
 #endif
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -182,9 +182,9 @@ __AVR__
 #  define N_SAFECALL_PTR(rettype, name) rettype (__stdcall *name)
 
 #  ifdef __cplusplus
-#    define N_LIB_EXPORT  extern "C" __declspec(dllexport)
+#    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
 #  else
-#    define N_LIB_EXPORT  extern __declspec(dllexport)
+#    define N_LIB_EXPORT  NIM_EXTERNC __declspec(dllexport)
 #  endif
 #  define N_LIB_IMPORT  extern __declspec(dllimport)
 #else

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -682,7 +682,7 @@ proc gcMark(gch: var GcHeap, p: pointer) {.inline.} =
   `CLANG_NO_SANITIZE_ADDRESS` in `lib/nimbase.h`.
  ]#
 proc markStackAndRegisters(gch: var GcHeap) {.noinline, cdecl,
-    codegenDecl: "CLANG_NO_SANITIZE_ADDRESS $# $#$#".} =
+    codegenDecl: "CLANG_NO_SANITIZE_ADDRESS N_LIB_PRIVATE $# $#$#".} =
   forEachStackSlot(gch, gcMark)
 
 proc collectZCT(gch: var GcHeap): bool =

--- a/tests/dll/visibility.nim
+++ b/tests/dll/visibility.nim
@@ -14,8 +14,12 @@ when compileOption("app", "lib"):
   var
     bar {.exportc.}: int
     thr {.exportc, threadvar.}: int
-  proc foo() {.exportc.} =
-    echo "failed"
+  proc foo() {.exportc.} = discard
+
+  var
+    exported {.exportc, dynlib.}: int
+    exported_thr {.exportc, threadvar, dynlib.}: int
+  proc exported_func() {.exportc, dynlib.} = discard
 elif isMainModule:
   import dynlib
 
@@ -25,7 +29,15 @@ elif isMainModule:
     const s = astToStr(sym)
     if handle.symAddr(s) != nil:
       echo s, " is exported"
+  template checkE(sym: untyped) =
+    const s = astToStr(sym)
+    if handle.symAddr(s) == nil:
+      echo s, " is not exported"
 
   check foo
   check bar
   check thr
+
+  checkE exported
+  checkE exported_thr
+  checkE exported_func

--- a/tests/dll/visibility.nim
+++ b/tests/dll/visibility.nim
@@ -11,7 +11,9 @@ const LibName {.used.} =
     "libvisibility.so"
 
 when compileOption("app", "lib"):
-  var bar {.exportc.}: int
+  var
+    bar {.exportc.}: int
+    thr {.exportc, threadvar.}: int
   proc foo() {.exportc.} =
     echo "failed"
 elif isMainModule:
@@ -26,3 +28,4 @@ elif isMainModule:
 
   check foo
   check bar
+  check thr

--- a/tests/dll/visibility.nim
+++ b/tests/dll/visibility.nim
@@ -1,6 +1,5 @@
 discard """
-  output: "could not import: foo"
-  exitcode: 1
+  output: ""
 """
 
 const LibName {.used.} =
@@ -12,8 +11,18 @@ const LibName {.used.} =
     "libvisibility.so"
 
 when compileOption("app", "lib"):
+  var bar {.exportc.}: int
   proc foo() {.exportc.} =
     echo "failed"
 elif isMainModule:
-  proc foo() {.importc, dynlib: LibName.}
-  foo()
+  import dynlib
+
+  let handle = loadLib(LibName)
+
+  template check(sym: untyped) =
+    const s = astToStr(sym)
+    if handle.symAddr(s) != nil:
+      echo s, " is exported"
+
+  check foo
+  check bar


### PR DESCRIPTION
Hopefully I've tackled them all.

Symbols exported by an empty file created with `nim c --app:lib empty.nim`:
Before (50 exported symbols):
<details>

```
0000000000020800 B NTI__77mFvmsOLKik79ci2hXkHEg_
0000000000027ba0 B NTI__DsOOBcxCUeVlNUDRmn9afcA_
0000000000020740 B NTI__G9cUlLvU4AFC26wbFxLFkFA_
0000000000020700 B NTI__LbeSGvgPzGzXnW9caIkJqMA_
0000000000027b60 B NTI__Pjt0MQjoA6TAHAHOFNel9cg_
0000000000020d40 B NTI__S9agCYBinaYZnGWcjTdxclg_
0000000000020600 B NTI__ShBqCFAISBSH2YqBfe6zjg_
0000000000020780 B NTI__Ss6DFlX5iSZpHRZDmP74bg_
00000000000206c0 B NTI__Wyd9avMRCq0gsOu9adFoIjCA_
0000000000020860 B NTI__XEycrCsme5C8CVWAYEcdBQ_
0000000000020680 B NTI__XIT9aewsXycM2U5B437NUDA_
00000000000207c0 B NTI__hMQEc0FMry7Up7EoPki79aA_
0000000000020640 B NTI__oLyohQ7O2XOvGnflOss8EA_
0000000000020cc0 B NTI__rR5Bzr1D5krxoo1NcNyeMA_
0000000000027b20 B NTI__uB9b75OUPRENsBAu4AnoePA_
00000000000205c0 B NTI__vU9aO9cTqOMn6CBzhV8rX7Sw_
0000000000020d00 B NTI__ytyiCJqK439aF9cIibuRVpAg_
0000000000010080 T NimMain
00000000000100d0 T NimMainInit
0000000000010074 T NimMainInner
000000000001001f T PreMain
0000000000010018 T PreMainInner
0000000000011230 R TM__Q5wkpxktOdTGvlSRo9bzt9aw_11
0000000000011250 R TM__Q5wkpxktOdTGvlSRo9bzt9aw_12
0000000000010134 T _fini
0000000000002000 T _init
0000000000027bd8 B cmdCount
0000000000027be8 B cmdLine
0000000000020838 B currException__9bVPeDJlYTi9bQApZpfH8wjg
00000000000205a0 B errorMessageWriter__ZXnv0JyrWe3HTd07wpSr7A
0000000000020840 B excHandler__rqLlY5bs9atDw2OXYqJEn5g
0000000000020d78 B framePtr__HRfVMH3jYeBJz6Q6X9b6Ptw
0000000000011040 R fsLookupTable__Gn52IZvqY4slyBTOYwGNRQ
0000000000027be0 B gEnv
0000000000019838 B gHeapidGenerator__hd54mEUTGcVuZLChYgtR9bg
0000000000027b58 B gcFramePtr__ot48iojqko9aFxGhyjjjVaA
0000000000016460 B gch__IcYaEuuWivYAS86vFMTS3Q
0000000000020da0 B globalMarkers
0000000000020cf8 B globalMarkersLen
00000000000205f8 B globalRaiseHook__JbO1ti4ULxrw54m4zNPbpA
0000000000027b00 B localRaiseHook__EIvMhANBvB9cp2Ezvt29cADg
00000000000088e5 T markStackAndRegisters__U6T7JWtDLrWhtmhXSoy9a6g
0000000000027b08 B nim_program_result
0000000000020d80 B onUnhandledException__bFrawQlTKZhLweDD36j9b8g
0000000000020ca0 B outOfMemHook__kZNaA7u1MfSW5ZeoGvw8xg
0000000000016020 D strDesc__D0UzA4zsDu5tgpJQ9a9clXPg
00000000000208a0 B tempFrames__7nBYIr2UsDREpYylZK4fug
0000000000019840 B threadLocalMarkers
0000000000020d88 B threadLocalMarkersLen
0000000000019830 B unhandledExceptionHook__RJpSsXsRUH8ochbXTEhRIw
```
</details>

After (3 exported symbols):
<details>

```
000000000000ee4a T NimMain
000000000000eef4 T _fini
0000000000001000 T _init
```
</details>