### PR TITLE
kochdocs: use a glob instead of hardcoded list; generate docs for compiler/; bugfixes

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -218,12 +218,12 @@ proc sameIgnoreBacktickGensymInfo(a, b: string): bool =
 
 proc getNamedParamFromList*(list: PNode, ident: PIdent): PSym =
   ## Named parameters are special because a named parameter can be
-  ## gensym'ed and then they have '`<number>' suffix that we need to
+  ## gensym'ed and then they have '\`<number>' suffix that we need to
   ## ignore, see compiler / evaltempl.nim, snippet:
   ##
   ##..code-block:: nim
   ##
-  ##    result.add newIdentNode(getIdent(c.ic, x.name.s & "`gensym" & $x.id),
+  ##    result.add newIdentNode(getIdent(c.ic, x.name.s & "\`gensym" & $x.id),
   ##            if c.instLines: actual.info else: templ.info)
   for i in 1..<list.len:
     let it = list[i].sym

--- a/compiler/btrees.nim
+++ b/compiler/btrees.nim
@@ -191,7 +191,7 @@ when isMainModule:
     st.add("www.yahoo.com",        "216.109.118.65")
 
     assert st.getOrDefault("www.cs.princeton.edu") == "abc"
-    assert st.getOrDefault("www.harvardsucks.com") == nil
+    assert st.getOrDefault("www.harvardsucks.com") == ""
 
     assert st.getOrDefault("www.simpsons.com") == "209.052.165.60"
     assert st.getOrDefault("www.apple.com") == "17.112.152.32"

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -170,12 +170,13 @@ lib/posix/posix_openbsd_amd64.nim
   # but contain potentially valuable docs on OS-specific symbols (eg OSX) that
   # don't end up in the main docs; we ignore these for now.
 
-proc isRelativeTo(path, base: string): bool =
-  # pending #13212 use os.isRelativeTo
-  let path = path.normalizedPath
-  let base = base.normalizedPath
-  let ret = relativePath(path, base)
-  result = path.len > 0 and not ret.startsWith ".."
+when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
+  proc isRelativeTo(path, base: string): bool =
+    # pending #13212 use os.isRelativeTo
+    let path = path.normalizedPath
+    let base = base.normalizedPath
+    let ret = relativePath(path, base)
+    result = path.len > 0 and not ret.startsWith ".."
 
 proc getDocList(): seq[string] =
   var t: HashSet[string]

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -129,7 +129,19 @@ doc/manual/var_t_return.rst
   doc0 = """
 lib/system/threads.nim
 lib/system/channels.nim
-""".splitWhitespace()
+lib/pure/ioselects/ioselectors_kqueue.nim
+lib/pure/ioselects/ioselectors_select.nim
+lib/pure/ioselects/ioselectors_poll.nim
+lib/pure/ioselects/ioselectors_epoll.nim
+lib/posix/posix_macos_amd64.nim
+lib/posix/posix_other.nim
+lib/posix/posix_nintendoswitch.nim
+lib/posix/posix_nintendoswitch_consts.nim
+lib/posix/posix_linux_amd64.nim
+lib/posix/posix_linux_amd64_consts.nim
+lib/posix/posix_other_consts.nim
+lib/posix/posix_openbsd_amd64.nim
+""".splitWhitespace() # these are include files, `nim doc` would not work, but `nim doc0` does
 
   withoutIndex = """
 lib/wrappers/mysql.nim
@@ -146,147 +158,6 @@ lib/posix/termios.nim
 lib/js/jscore.nim
 """.splitWhitespace()
 
-const
-  docOld = """
-lib/system.nim
-lib/system/io.nim
-lib/system/nimscript.nim
-lib/system/assertions.nim
-lib/system/iterators.nim
-lib/system/dollars.nim
-lib/system/widestrs.nim
-lib/deprecated/pure/ospaths.nim
-lib/pure/parsejson.nim
-lib/pure/cstrutils.nim
-lib/core/macros.nim
-lib/pure/marshal.nim
-lib/core/typeinfo.nim
-lib/impure/re.nim
-lib/pure/typetraits.nim
-nimsuggest/sexp.nim
-lib/pure/concurrency/threadpool.nim
-lib/pure/concurrency/cpuinfo.nim
-lib/pure/concurrency/cpuload.nim
-lib/js/dom.nim
-lib/js/jsffi.nim
-lib/js/jsconsole.nim
-lib/js/asyncjs.nim
-lib/pure/os.nim
-lib/pure/strutils.nim
-lib/pure/math.nim
-lib/std/editdistance.nim
-lib/std/wordwrap.nim
-lib/std/wrapnils.nim
-lib/experimental/diff.nim
-lib/pure/algorithm.nim
-lib/pure/stats.nim
-lib/windows/winlean.nim
-lib/windows/registry.nim
-lib/pure/random.nim
-lib/pure/complex.nim
-lib/pure/times.nim
-lib/std/monotimes.nim
-lib/pure/osproc.nim
-lib/pure/pegs.nim
-lib/pure/dynlib.nim
-lib/pure/strscans.nim
-lib/pure/parseopt.nim
-lib/pure/hashes.nim
-lib/pure/strtabs.nim
-lib/pure/lexbase.nim
-lib/pure/parsecfg.nim
-lib/pure/parsexml.nim
-lib/pure/parsecsv.nim
-lib/pure/parsesql.nim
-lib/pure/streams.nim
-lib/pure/terminal.nim
-lib/pure/cgi.nim
-lib/pure/unicode.nim
-lib/pure/strmisc.nim
-lib/pure/htmlgen.nim
-lib/pure/parseutils.nim
-lib/pure/browsers.nim
-lib/impure/db_postgres.nim
-lib/impure/db_mysql.nim
-lib/impure/db_sqlite.nim
-lib/impure/db_odbc.nim
-lib/pure/db_common.nim
-lib/pure/httpclient.nim
-lib/pure/smtp.nim
-lib/pure/ropes.nim
-lib/pure/unidecode/unidecode.nim
-lib/pure/xmlparser.nim
-lib/pure/htmlparser.nim
-lib/pure/xmltree.nim
-lib/pure/colors.nim
-lib/pure/mimetypes.nim
-lib/pure/json.nim
-lib/pure/base64.nim
-lib/impure/nre.nim
-lib/impure/nre/private/util.nim
-lib/pure/collections/tables.nim
-lib/pure/collections/sets.nim
-lib/pure/collections/lists.nim
-lib/pure/collections/sharedlist.nim
-lib/pure/collections/sharedtables.nim
-lib/pure/collections/intsets.nim
-lib/pure/collections/deques.nim
-lib/pure/encodings.nim
-lib/pure/collections/sequtils.nim
-lib/pure/collections/rtarrays.nim
-lib/pure/cookies.nim
-lib/pure/memfiles.nim
-lib/pure/collections/critbits.nim
-lib/core/locks.nim
-lib/core/rlocks.nim
-lib/pure/oids.nim
-lib/pure/endians.nim
-lib/pure/uri.nim
-lib/pure/nimprof.nim
-lib/pure/unittest.nim
-lib/packages/docutils/highlite.nim
-lib/packages/docutils/rst.nim
-lib/packages/docutils/rstast.nim
-lib/packages/docutils/rstgen.nim
-lib/pure/logging.nim
-lib/pure/options.nim
-lib/pure/asyncdispatch.nim
-lib/pure/asyncnet.nim
-lib/pure/asyncstreams.nim
-lib/pure/asyncfutures.nim
-lib/pure/nativesockets.nim
-lib/pure/asynchttpserver.nim
-lib/pure/net.nim
-lib/pure/selectors.nim
-lib/pure/sugar.nim
-lib/pure/collections/chains.nim
-lib/pure/asyncfile.nim
-lib/pure/asyncftpclient.nim
-lib/pure/lenientops.nim
-lib/pure/md5.nim
-lib/pure/rationals.nim
-lib/pure/distros.nim
-lib/pure/oswalkdir.nim
-lib/pure/collections/heapqueue.nim
-lib/pure/fenv.nim
-lib/std/sha1.nim
-lib/std/sums.nim
-lib/std/varints.nim
-lib/std/time_t.nim
-lib/impure/rdstdin.nim
-lib/wrappers/linenoise/linenoise.nim
-lib/pure/strformat.nim
-lib/pure/segfaults.nim
-lib/pure/mersenne.nim
-lib/pure/coro.nim
-lib/pure/httpcore.nim
-lib/pure/bitops.nim
-lib/pure/nimtracker.nim
-lib/pure/punycode.nim
-lib/pure/volatile.nim
-lib/posix/posix_utils.nim
-""".splitWhitespace()
-
   ignoredModules = """
 lib/pure/future.nim
 lib/impure/osinfo_posix.nim
@@ -294,19 +165,7 @@ lib/impure/osinfo_win.nim
 lib/pure/collections/hashcommon.nim
 lib/pure/collections/tableimpl.nim
 lib/pure/collections/setimpl.nim
-lib/pure/ioselects/ioselectors_kqueue.nim
-lib/pure/ioselects/ioselectors_select.nim
-lib/pure/ioselects/ioselectors_poll.nim
-lib/pure/ioselects/ioselectors_epoll.nim
-lib/posix/posix_macos_amd64.nim
-lib/posix/posix_other.nim
-lib/posix/posix_nintendoswitch.nim
-lib/posix/posix_nintendoswitch_consts.nim
-lib/posix/posix_linux_amd64.nim
-lib/posix/posix_linux_amd64_consts.nim
-lib/posix/posix_other_consts.nim
-lib/posix/posix_openbsd_amd64.nim
-""".splitWhitespace()
+""".splitWhitespace() # these don't produce any useful info even with `nim doc0`
 
 import std/strformat
 
@@ -330,11 +189,6 @@ proc getDocList(): seq[string] =
     doAssert a notin t, a
     t.incl a
 
-  var tdocOld: HashSet[string]
-  for a in docOld:
-    doAssert a notin tdocOld
-    tdocOld.incl a
-
   var t2: HashSet[string]
   template myadd(a)=
     result.add a
@@ -354,14 +208,8 @@ proc getDocList(): seq[string] =
       result.add a
       doAssert a notin t2, a
       t2.incl a
-  myadd "nimsuggest/sexp.nim"
-  
-  for a in docOld:
-    doAssert a in t2, a
 
-  for a in result:
-    if a notin tdocOld:
-      echo a
+  myadd "nimsuggest/sexp.nim"
 
 proc runDocAsMegatest(files: seq[string])=
   proc quoted(a: string): string =
@@ -400,7 +248,6 @@ bin/nim doc --hint[Conf]:off --hint[Path]:off --hint[Processing]:off -d:boot --p
   doAssert false
 
 const doc = getDocList()
-# const doc = docOld
 # runDocAsMegatest(doc)
 
 proc sexec(cmds: openArray[string]) =

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -195,8 +195,8 @@ proc getDocList(): seq[string] =
     doAssert a notin t2, a
     t2.incl a
 
-  when false:
-   const goodSystem = """
+  # don't ignore these even though in lib/system
+  const goodSystem = """
 lib/system/io.nim
 lib/system/nimscript.nim
 lib/system/assertions.nim
@@ -205,7 +205,7 @@ lib/system/dollars.nim
 lib/system/widestrs.nim
 """.splitWhitespace()
 
-   for a in walkDirRec("lib"):
+  for a in walkDirRec("lib"):
     if a.splitFile.ext != ".nim": continue
     if a.isRelativeTo("lib/deprecated"):
       if a notin @["lib/deprecated/pure/ospaths.nim"]: # REMOVE
@@ -246,6 +246,8 @@ compiler/suggest.nim
 compiler/packagehandling.nim
 compiler/hlo.nim
 compiler/rodimpl.nim
+compiler/vmops.nim
+compiler/vmhooks.nim
 """.splitWhitespace()
 
   # not include files but doesn't work; not included/imported anywhere; dead code?
@@ -255,12 +257,16 @@ compiler/canonicalizer.nim
 compiler/forloops.nim
 """.splitWhitespace()
 
-  # these cause mysterious errors even though they're imported
+  # these cause errors even though they're imported (some of which are mysterious)
   const bad2 = """
 compiler/closureiters.nim
 compiler/tccgen.nim
 compiler/lambdalifting.nim
 compiler/layouter.nim
+compiler/evalffi.nim
+compiler/nimfix/nimfix.nim
+compiler/plugins/active.nim
+compiler/plugins/itersgen.nim
 """.splitWhitespace()
 
   for a in walkDirRec("compiler"):

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -294,14 +294,19 @@ lib/impure/osinfo_win.nim
 lib/pure/collections/hashcommon.nim
 lib/pure/collections/tableimpl.nim
 lib/pure/collections/setimpl.nim
+lib/pure/ioselects/ioselectors_kqueue.nim
+lib/pure/ioselects/ioselectors_select.nim
+lib/pure/ioselects/ioselectors_poll.nim
+lib/pure/ioselects/ioselectors_epoll.nim
+lib/posix/posix_macos_amd64.nim
+lib/posix/posix_other.nim
+lib/posix/posix_nintendoswitch.nim
+lib/posix/posix_nintendoswitch_consts.nim
+lib/posix/posix_linux_amd64.nim
+lib/posix/posix_linux_amd64_consts.nim
+lib/posix/posix_other_consts.nim
+lib/posix/posix_openbsd_amd64.nim
 """.splitWhitespace()
-# lib/deprecated/pure/securehash.nim
-
-# note: another pitfall of `include` is that `nim doc lib/std/sha1.nim` works
-# but `nim doc lib/deprecated/pure/securehash.nim` fails:
-# Error: redefinition of 'secureHash'
-
-# lib/pure/collections/hashcommon.nim # an include file; will cause CT errors by itself
 
 import std/strformat
 
@@ -337,12 +342,14 @@ proc getDocList(): seq[string] =
     t2.incl a
   for a in walkDirRec("lib"):
     if a.splitFile.ext != ".nim": continue
-    if a.isRelativeTo("lib/deprecated"): continue
+    if a.isRelativeTo("lib/deprecated"):
+      if a notin @["lib/deprecated/pure/ospaths.nim"]: # REMOVE
+        continue
     if a.isRelativeTo("lib/pure/includes"): continue
     if a.isRelativeTo("lib/genode"): continue
     if a.isRelativeTo("lib/system"):
       if a notin @["lib/system/io.nim", "lib/system/nimscript.nim", "lib/system/assertions.nim", "lib/system/iterators.nim", "lib/system/dollars.nim", "lib/system/widestrs.nim"]:
-        continue # CHECKME
+        continue
     if a notin t:
       result.add a
       doAssert a notin t2, a
@@ -350,65 +357,26 @@ proc getDocList(): seq[string] =
   myadd "nimsuggest/sexp.nim"
   
   for a in docOld:
-    if a == "lib/deprecated/pure/ospaths.nim":
-      continue
     doAssert a in t2, a
 
-  var ok = true
   for a in result:
     if a notin tdocOld:
       echo a
-      ok = false
-    # doAssert a in tdocOld, a
-  # doAssert ok
 
+proc runDocAsMegatest(files: seq[string])=
   proc quoted(a: string): string =
     result.addQuoted(a)
-
-  # let file = "/tmp/z01.nim"
-  let file = "lib/pure/alldoc.nim"
-
+  let file = "lib/pure/alldoc.nim" # has to be under same project otherwise nim doc would skip
   var msg = ""
-  # for i in result:
-  for i in docOld:
+  for i in files:
     var i = i
+    # these have special compile options, eg lib/nimrtl.nim.cfg
     if i in @["lib/nimrtl.nim"]: continue # Error: This file has to be compiled as a library!
     if i in @["lib/pure/nimprof.nim"]: continue # Profiling support is turned off
     if i in @["lib/pure/nimtracker.nim"]: continue # when not defined(memTracker) and not isMainModule:
-    if i in @["lib/pure/ioselects/ioselectors_kqueue.nim"]: continue # it's included; missing stuff
-    if i in @["lib/pure/ioselects/ioselectors_select.nim"]: continue # it's included; missing stuff
-    if i in @["lib/pure/ioselects/ioselectors_poll.nim"]: continue # it's included; missing stuff
-    if i in @["lib/pure/ioselects/ioselectors_epoll.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_macos_amd64.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_other.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_nintendoswitch.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_nintendoswitch_consts.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_linux_amd64.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_linux_amd64_consts.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_other_consts.nim"]: continue # it's included; missing stuff
-    if i in @["lib/posix/posix_openbsd_amd64.nim"]: continue # it's included; missing stuff
     if i in @["lib/pure/concurrency/threadpool.nim"]: continue #  Threadpool requires --threads:on option.
     if i in @["lib/pure/smtp.nim"]: continue #  Error: SMTP module compiled without SSL support
     if i in file: continue # it's included; missing stuff
-
-    # if i in @["lib/system/sysstr.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/seqs_v2.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/arithm.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/atomics.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/chcks.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/alloc.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/gc2.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/excpt.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/refs_v2.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/gc_ms.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/memtracker.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/avltree.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/gc.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/comparisons.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/jssys.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/repr.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/sets.nim"]: continue # it's included; missing stuff
-    # if i in @["lib/system/memalloc.nim"]: continue # it's included; missing stuff
 
     let msgi = "import $1" % i.quoted
     # let msgi = "from $1 import nil" % i.quoted
@@ -421,13 +389,9 @@ proc getDocList(): seq[string] =
   const nim = getCurrentCompilerExe()
   #[
 bin/nim doc --hint[Conf]:off --hint[Path]:off --hint[Processing]:off -d:boot --putenv:nimversion=1.1.1  --git.url:https://github.com/nim-lang/Nim -o:web/upload/1.1.1/xmltree.html --index:on lib/pure/xmltree.nim
-
-lib/pure/concurrency/threadpool.nim --threads:on
   ]#
-  # let dir = "lib/pure/timdocs"
   let dir = "/tmp/d46"
-  let options = ""
-  # let options = "-d:ssl --threads:on"
+  let options = "-d:boot"
   let cmd = fmt"cd /Users/timothee/git_clone/nim/Nim_prs && {nim} doc {options} --path:. --errorMax:1 --project --index:on --git.url:https://github.com/nim-lang/Nim --putenv:nimversion=1.1.1 --outDir:{dir} {file}"
   echo cmd
   let (output, exitCode) = gorgeEx cmd
@@ -435,10 +399,9 @@ lib/pure/concurrency/threadpool.nim --threads:on
   echo output
   doAssert false
 
-
 const doc = getDocList()
 # const doc = docOld
-# doAssert doc == docOld
+# runDocAsMegatest(doc)
 
 proc sexec(cmds: openArray[string]) =
   ## Serial queue wrapper around exec.

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -129,19 +129,7 @@ doc/manual/var_t_return.rst
   doc0 = """
 lib/system/threads.nim
 lib/system/channels.nim
-lib/pure/ioselects/ioselectors_kqueue.nim
-lib/pure/ioselects/ioselectors_select.nim
-lib/pure/ioselects/ioselectors_poll.nim
-lib/pure/ioselects/ioselectors_epoll.nim
-lib/posix/posix_macos_amd64.nim
-lib/posix/posix_other.nim
-lib/posix/posix_nintendoswitch.nim
-lib/posix/posix_nintendoswitch_consts.nim
-lib/posix/posix_linux_amd64.nim
-lib/posix/posix_linux_amd64_consts.nim
-lib/posix/posix_other_consts.nim
-lib/posix/posix_openbsd_amd64.nim
-""".splitWhitespace() # these are include files, `nim doc` would not work, but `nim doc0` does
+""".splitWhitespace() # ran by `nim doc0` instead of `nim doc`
 
   withoutIndex = """
 lib/wrappers/mysql.nim
@@ -165,7 +153,22 @@ lib/impure/osinfo_win.nim
 lib/pure/collections/hashcommon.nim
 lib/pure/collections/tableimpl.nim
 lib/pure/collections/setimpl.nim
-""".splitWhitespace() # these don't produce any useful info even with `nim doc0`
+lib/pure/ioselects/ioselectors_kqueue.nim
+lib/pure/ioselects/ioselectors_select.nim
+lib/pure/ioselects/ioselectors_poll.nim
+lib/pure/ioselects/ioselectors_epoll.nim
+lib/posix/posix_macos_amd64.nim
+lib/posix/posix_other.nim
+lib/posix/posix_nintendoswitch.nim
+lib/posix/posix_nintendoswitch_consts.nim
+lib/posix/posix_linux_amd64.nim
+lib/posix/posix_linux_amd64_consts.nim
+lib/posix/posix_other_consts.nim
+lib/posix/posix_openbsd_amd64.nim
+""".splitWhitespace()
+  # some of these (eg lib/posix/posix_macos_amd64.nim) are include files
+  # but contain potentially valuable docs on OS-specific symbols (eg OSX) that
+  # don't end up in the main docs; we ignore these for now.
 
 proc isRelativeTo(path, base: string): bool =
   # pending #13212 use os.isRelativeTo
@@ -274,7 +277,7 @@ compiler/plugins/itersgen.nim
     if a in bad2: continue
     result.add a
 
-const doc = getDocList()
+let doc = getDocList()
 
 proc sexec(cmds: openArray[string]) =
   ## Serial queue wrapper around exec.


### PR DESCRIPTION
* kochdocs use a glob instead of hardcoded list (eg mentioned here https://github.com/nim-lang/Nim/pull/13023#issuecomment-570939933) => more DRY
* these files now get docgen'd (previously were ignored):
```
lib/prelude.nim
lib/nimrtl.nim
lib/nimhcr.nim
lib/pure/async.nim
lib/pure/reservedmem.nim
lib/pure/asyncmacro.nim
lib/pure/pathnorm.nim
lib/pure/concurrency/atomics.nim
lib/nintendoswitch/switch_memory.nim
lib/core/macrocache.nim
lib/core/hotcodereloading.nim
lib/posix/kqueue.nim
lib/posix/epoll.nim
lib/posix/inotify.nim
```

* we now generate docs for compiler/ making it easier to develop compiler sources

* some include files also get docgen'ed via `nim doc0`, see kochdocs.doc0; eg: `lib/posix/posix_macos_amd64.nim`; this helps for users interested in OS-specific symbols (eg SIGKILLTHR on OSX); the title of those (eg posix_macos_amd64) makes it clear that it's OS specific so no source of confusion possible

* tiny bugfixes in files that are now docgen'd

* passing `--warning[LockLevel]:off` pending #13218

## note
* I tried a megatest-like approach but it actually is slower than current way via multithread `execProcesses` (using 8 cores); in any case `./koch docs` is actually a small part of CI (walltime: 146 s in my machine; and about 19 seconds just for running `nim doc` on the `lib` files from getDocList) so it doesn't matter
* same spirit as https://github.com/nim-lang/Nim/pull/10351 but for `nim doc`

## TODO
* lib/deprecated/pure/ospaths.nim was previously docgen'd; should I remove it from list of docgen'd modules?
* if someone wants to revive the megatest approach for nim doc, https://github.com/nim-lang/Nim/pull/13221/commits/f4ee7e190ff785ec1c832ab28b7aba56fc12c749 can be used as a starting point (see deleted lines around `runDocAsMegatest`); but, interestingly, wasn't giving a speedup
