### PR TITLE
fix #13150 `nim doc --project` now works reliably

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -823,7 +823,6 @@ type
       # check for the owner when touching 'usedGenerics'.
       usedGenerics*: seq[PInstantiation]
       tab*: TStrTable         # interface table for modules
-      nimblePkg*: PSym
     of skLet, skVar, skField, skForVar:
       guard*: PSym
       bitsize*: int
@@ -1026,6 +1025,26 @@ const
   defaultSize = -1
   defaultAlignment = -1
   defaultOffset = -1
+
+
+proc getnimblePkg*(a: PSym): PSym =
+  result = a
+  while result != nil:
+    case result.kind
+    of skModule:
+      result = result.owner
+      assert result.kind == skPackage
+    of skPackage:
+      if result.owner == nil:
+        break
+      else:
+        result = result.owner
+    else:
+      assert false, $result.kind
+
+proc getnimblePkgId*(a: PSym): int =
+  let b = a.getnimblePkg
+  result = if b == nil: -1 else: b.id
 
 var ggDebug* {.deprecated.}: bool ## convenience switch for trying out things
 #var
@@ -1392,7 +1411,6 @@ proc createModuleAlias*(s: PSym, newIdent: PIdent, info: TLineInfo;
   result.ast = s.ast
   result.id = s.id
   result.flags = s.flags
-  result.nimblePkg = s.nimblePkg
   system.shallowCopy(result.tab, s.tab)
   result.options = s.options
   result.position = s.position

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -823,6 +823,7 @@ type
       # check for the owner when touching 'usedGenerics'.
       usedGenerics*: seq[PInstantiation]
       tab*: TStrTable         # interface table for modules
+      nimblePkg*: PSym
     of skLet, skVar, skField, skForVar:
       guard*: PSym
       bitsize*: int
@@ -1391,6 +1392,7 @@ proc createModuleAlias*(s: PSym, newIdent: PIdent, info: TLineInfo;
   result.ast = s.ast
   result.id = s.id
   result.flags = s.flags
+  result.nimblePkg = s.nimblePkg
   system.shallowCopy(result.tab, s.tab)
   result.options = s.options
   result.position = s.position

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -413,6 +413,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "docseesrcurl":
     expectArg(conf, switch, arg, pass, info)
     conf.docSeeSrcUrl = arg
+  of "docroot":
+    expectArg(conf, switch, arg, pass, info)
+    conf.docRoot = processPath(conf, arg, info, notRelativeToProj=true)
   of "mainmodule", "m":
     discard "allow for backwards compatibility, but don't do anything"
   of "define", "d":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -415,7 +415,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.docSeeSrcUrl = arg
   of "docroot":
     expectArg(conf, switch, arg, pass, info)
-    conf.docRoot = processPath(conf, arg, info, notRelativeToProj=true)
+    conf.docRoot = arg
   of "mainmodule", "m":
     discard "allow for backwards compatibility, but don't do anything"
   of "define", "d":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -414,8 +414,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     expectArg(conf, switch, arg, pass, info)
     conf.docSeeSrcUrl = arg
   of "docroot":
-    expectArg(conf, switch, arg, pass, info)
-    conf.docRoot = arg
+    conf.docRoot = if arg.len == 0: "@default" else: arg
   of "mainmodule", "m":
     discard "allow for backwards compatibility, but don't do anything"
   of "define", "d":

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -318,8 +318,7 @@ proc getPlainDocstring(n: PNode): string =
       if result.len > 0: return
 
 proc belongsToPackage(conf: ConfigRef; module: PSym): bool =
-  result = module.kind == skModule and module.nimblePkg != nil and
-      module.nimblePkg.id == conf.mainPackageId
+  result = module.kind == skModule and module.getnimblePkgId == conf.mainPackageId
 
 proc externalDep(d: PDoc; module: PSym): string =
   if optWholeProject in d.conf.globalOptions:

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -330,7 +330,7 @@ proc belongsToPackage(conf: ConfigRef; module: PSym): bool =
   result = module.kind == skModule and module.getnimblePkgId == conf.mainPackageId
 
 proc externalDep(d: PDoc; module: PSym): string =
-  if optWholeProject in d.conf.globalOptions:
+  if optWholeProject in d.conf.globalOptions or d.conf.docRoot.len > 0:
     let full = AbsoluteFile toFullPath(d.conf, FileIndex module.position)
     let tmp = getOutFile2(d.conf, presentationPath(d.conf, full), HtmlExt,
                           htmldocsDir, sfMainModule notin module.flags)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -61,7 +61,7 @@ proc presentationPath*(conf: ConfigRef, file: AbsoluteFile): RelativeFile =
   of "@path":
     result = getRelativePathFromConfigPath(conf, file)
     if result.isEmpty: bail()
-  # of "@mixed": result = relativeToPkg(conf, file) # consider enabling this
+  # we could consider a @besteffort mode that would returned the "best" match among @pkg and @path
   elif conf.docRoot.len > 0:
     doAssert conf.docRoot.isAbsolute, conf.docRoot # or globalError
     doAssert conf.docRoot.existsDir, conf.docRoot

--- a/compiler/docgen2.nim
+++ b/compiler/docgen2.nim
@@ -23,7 +23,7 @@ type
   PGen = ref TGen
 
 proc shouldProcess(g: PGen): bool =
-  (g.module.nimblePkg.id == g.doc.conf.mainPackageId and optWholeProject in g.doc.conf.globalOptions) or
+  (optWholeProject in g.doc.conf.globalOptions and g.module.getnimblePkgId == g.doc.conf.mainPackageId) or
       sfMainModule in g.module.flags or g.config.projectMainIdx == g.module.info.fileIndex
 
 template closeImpl(body: untyped) {.dirty.} =

--- a/compiler/docgen2.nim
+++ b/compiler/docgen2.nim
@@ -22,8 +22,8 @@ type
     config: ConfigRef
   PGen = ref TGen
 
-template shouldProcess(g): bool =
-  (g.module.owner.id == g.doc.conf.mainPackageId and optWholeProject in g.doc.conf.globalOptions) or
+proc shouldProcess(g: PGen): bool =
+  (g.module.nimblePkg.id == g.doc.conf.mainPackageId and optWholeProject in g.doc.conf.globalOptions) or
       sfMainModule in g.module.flags or g.config.projectMainIdx == g.module.info.fileIndex
 
 template closeImpl(body: untyped) {.dirty.} =

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -293,7 +293,9 @@ proc mainCommand*(graph: ModuleGraph) =
       for s in definedSymbolNames(conf.symbols): definedSymbols.elems.add(%s)
 
       var libpaths = newJArray()
+      var lazyPaths = newJArray()
       for dir in conf.searchPaths: libpaths.elems.add(%dir.string)
+      for dir in conf.lazyPaths: lazyPaths.elems.add(%dir.string)
 
       var hints = newJObject() # consider factoring with `listHints`
       for a in hintMin..hintMax:
@@ -311,6 +313,7 @@ proc mainCommand*(graph: ModuleGraph) =
         (key: "project_path", val: %conf.projectFull.string),
         (key: "defined_symbols", val: definedSymbols),
         (key: "lib_paths", val: %libpaths),
+        (key: "lazyPaths", val: %lazyPaths),
         (key: "outdir", val: %conf.outDir.string),
         (key: "out", val: %conf.outFile.string),
         (key: "nimcache", val: %getNimcacheDir(conf).string),

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -27,9 +27,7 @@ proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; fil
     packSym = newSym(skPackage, getIdent(graph.cache, pck2), nil, result.info)
     initStrTable(packSym.tab)
     graph.packageSyms.strTableAdd(packSym)
-    result.nimblePkg = packSym
   else:
-    result.nimblePkg = packSym
     let existing = strTableGet(packSym.tab, result.name)
     if existing != nil and existing.info.fileIndex != result.info.fileIndex:
       when false:
@@ -41,7 +39,8 @@ proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; fil
         # but starting with version 0.20 we now produce a fake Nimble package instead
         # to resolve the conflicts:
         let pck3 = fakePackageName(graph.config, filename)
-        packSym = newSym(skPackage, getIdent(graph.cache, pck3), nil, result.info)
+        # this makes the new `packSym`'s owner be the original `packSym`
+        packSym = newSym(skPackage, getIdent(graph.cache, pck3), packSym, result.info)
         initStrTable(packSym.tab)
         graph.packageSyms.strTableAdd(packSym)
 

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -27,7 +27,9 @@ proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; fil
     packSym = newSym(skPackage, getIdent(graph.cache, pck2), nil, result.info)
     initStrTable(packSym.tab)
     graph.packageSyms.strTableAdd(packSym)
+    result.nimblePkg = packSym
   else:
+    result.nimblePkg = packSym
     let existing = strTableGet(packSym.tab, result.name)
     if existing != nil and existing.info.fileIndex != result.info.fileIndex:
       when false:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -263,7 +263,7 @@ type
     implicitIncludes*: seq[string] # modules that are to be implicitly included
     docSeeSrcUrl*: string # if empty, no seeSrc will be generated. \
     # The string uses the formatting variables `path` and `line`.
-    docRoot*: AbsoluteDir ## see nim --fullhelp for --docRoot
+    docRoot*: string ## see nim --fullhelp for --docRoot
 
      # the used compiler
     cIncludes*: seq[AbsoluteDir]  # directories to search for included files
@@ -500,9 +500,6 @@ proc absOutFile*(conf: ConfigRef): AbsoluteFile =
   result = conf.outDir / conf.outFile
   if dirExists(result.string):
     result.string.add ".out"
-
-proc getDocRoot*(conf: ConfigRef): AbsoluteDir =
-  if conf.docRoot.isEmpty: conf.projectPath else: conf.docRoot
 
 proc prepareToWriteOutput*(conf: ConfigRef): AbsoluteFile =
   ## Create the output directory and returns a full path to the output file

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -675,15 +675,6 @@ proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile): RelativeF
   search(conf.searchPaths)
   search(conf.lazyPaths)
 
-proc relativeToPkg*(conf: ConfigRef, file: AbsoluteFile): string =
-  let file2 = $file
-  let dir = getNimbleFile(conf, file2).parentDir
-  result = relativePath(file2, dir)
-  # take care of things like in stdlib with multiple `--path:lib/pure` etc
-  let path2 = getRelativePathFromConfigPath(conf, file).string
-  if path2.len > result.len: result = path2
-  if result.len == 0: result = file2
-
 proc findFile*(conf: ConfigRef; f: string; suppressStdlib = false): AbsoluteFile =
   if f.isAbsolute:
     result = if f.existsFile: AbsoluteFile(f) else: AbsoluteFile""

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -263,9 +263,7 @@ type
     implicitIncludes*: seq[string] # modules that are to be implicitly included
     docSeeSrcUrl*: string # if empty, no seeSrc will be generated. \
     # The string uses the formatting variables `path` and `line`.
-    docRoot*: AbsoluteDir
-      # `nim doc --docRoot:foo --project --outdir:docs foo/sub/main.nim`
-      # genrates: docs/sub/main.html
+    docRoot*: AbsoluteDir ## see nim --fullhelp for --docRoot
 
      # the used compiler
     cIncludes*: seq[AbsoluteDir]  # directories to search for included files
@@ -662,12 +660,13 @@ template patchModule(conf: ConfigRef) {.dirty.} =
       let ov = conf.moduleOverrides[key]
       if ov.len > 0: result = AbsoluteFile(ov)
 
-proc isRelativeTo(path: string, base: string): bool=
-  # PENDING #13212
-  let path = path.normalizedPath
-  let base = base.normalizedPath
-  let ret = relativePath(path, base)
-  result = path.len > 0 and not ret.startsWith ".."
+when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
+  proc isRelativeTo(path, base: string): bool =
+    # pending #13212 use os.isRelativeTo
+    let path = path.normalizedPath
+    let base = base.normalizedPath
+    let ret = relativePath(path, base)
+    result = path.len > 0 and not ret.startsWith ".."
 
 proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile): RelativeFile =
   let f = $f

--- a/compiler/packagehandling.nim
+++ b/compiler/packagehandling.nim
@@ -15,10 +15,8 @@ iterator myParentDirs(p: string): string =
     if current.len == 0: break
     yield current
 
-proc resetPackageCache*(conf: ConfigRef) =
-  conf.packageCache = newPackageCache()
-
-proc getPackageName*(conf: ConfigRef; path: string): string =
+proc getNimbleFile*(conf: ConfigRef; path: string): string =
+  ## returns absolute path to nimble file, eg: /pathto/cligen.nimble
   var parents = 0
   block packageSearch:
     for d in myParentDirs(path):
@@ -27,7 +25,7 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
         return conf.packageCache[d]
       inc parents
       for file in walkFiles(d / "*.nimble"):
-        result = file.splitFile.name
+        result = file
         break packageSearch
   # we also store if we didn't find anything:
   when not defined(nimNoNilSeqs):
@@ -37,6 +35,11 @@ proc getPackageName*(conf: ConfigRef; path: string): string =
     conf.packageCache[d] = result
     dec parents
     if parents <= 0: break
+
+proc getPackageName*(conf: ConfigRef; path: string): string =
+  ## returns nimble package name, eg: `cligen`
+  let path = getNimbleFile(conf, path)
+  result = path.splitFile.name
 
 proc fakePackageName*(conf: ConfigRef; path: AbsoluteFile): string =
   # Convert `path` so that 2 modules with same name

--- a/compiler/pathutils.nim
+++ b/compiler/pathutils.nim
@@ -67,7 +67,7 @@ when true:
 
   proc `/`*(base: AbsoluteDir; f: RelativeFile): AbsoluteFile =
     let base = postProcessBase(base)
-    assert(not isAbsolute(f.string))
+    assert(not isAbsolute(f.string), f.string)
     result = AbsoluteFile newStringOfCap(base.string.len + f.string.len)
     var state = 0
     addNormalizePath(base.string, result.string, state)
@@ -83,6 +83,7 @@ when true:
 
   proc relativeTo*(fullPath: AbsoluteFile, baseFilename: AbsoluteDir;
                    sep = DirSep): RelativeFile =
+    assert not baseFilename.isEmpty, $fullPath # else, would return an absolute file
     RelativeFile(relativePath(fullPath.string, baseFilename.string, sep))
 
   proc toAbsolute*(file: string; base: AbsoluteDir): AbsoluteFile =

--- a/compiler/pathutils.nim
+++ b/compiler/pathutils.nim
@@ -83,8 +83,10 @@ when true:
 
   proc relativeTo*(fullPath: AbsoluteFile, baseFilename: AbsoluteDir;
                    sep = DirSep): RelativeFile =
-    assert not baseFilename.isEmpty, $fullPath # else, would return an absolute file
-    RelativeFile(relativePath(fullPath.string, baseFilename.string, sep))
+    # this currently fails for `tests/compilerapi/tcompilerapi.nim`
+    # it's needed otherwise would returns an absolute path
+    # assert not baseFilename.isEmpty, $fullPath
+    result = RelativeFile(relativePath(fullPath.string, baseFilename.string, sep))
 
   proc toAbsolute*(file: string; base: AbsoluteDir): AbsoluteFile =
     if isAbsolute(file): result = AbsoluteFile(file)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -71,6 +71,8 @@ Advanced options:
                             generates: docs/sub/main.html
                             if path == @pkg, will use nimble file enclosing dir
                             if path == @path, will use first matching dir in --path
+                            if path == @default (the default and most useful), will use
+                            best match among @pkg,@path.
                             if these are nonexistant, will use project path
   --docSeeSrcUrl:url        activate 'see source' for doc and doc2 commands
                             (see doc.item.seesrc in config/nimdoc.cfg)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -67,6 +67,8 @@ Advanced options:
   --clib:LIBNAME            link an additional C library
                             (you should omit platform-specific extensions)
   --project                 document the whole project (doc2)
+  --docRoot:path            nim doc --docRoot:foo --project --outdir:docs foo/sub/main.nim
+                            generates: docs/sub/main.html
   --docSeeSrcUrl:url        activate 'see source' for doc and doc2 commands
                             (see doc.item.seesrc in config/nimdoc.cfg)
   --docInternal             also generate documentation for non-exported symbols

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -67,8 +67,11 @@ Advanced options:
   --clib:LIBNAME            link an additional C library
                             (you should omit platform-specific extensions)
   --project                 document the whole project (doc2)
-  --docRoot:path            nim doc --docRoot:foo --project --outdir:docs foo/sub/main.nim
+  --docRoot:path            nim doc --docRoot:/foo --project --outdir:docs /foo/sub/main.nim
                             generates: docs/sub/main.html
+                            if path == @pkg, will use nimble file enclosing dir
+                            if path == @path, will use first matching dir in --path
+                            if these are nonexistant, will use project path
   --docSeeSrcUrl:url        activate 'see source' for doc and doc2 commands
                             (see doc.item.seesrc in config/nimdoc.cfg)
   --docInternal             also generate documentation for non-exported symbols

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.html
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.html
@@ -17,7 +17,7 @@
 <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600' rel='stylesheet' type='text/css'/>
 
 <!-- CSS -->
-<title>utils</title>
+<title>subdir/subdir_b/utils</title>
 <link rel="stylesheet" type="text/css" href="../../nimdoc.out.css">
 
 <script type="text/javascript" src="dochack.js"></script>
@@ -71,7 +71,7 @@ function main() {
 <body onload="main()">
 <div class="document" id="documentId">
   <div class="container">
-    <h1 class="title">utils</h1>
+    <h1 class="title">subdir/subdir_b/utils</h1>
     <div class="row">
   <div class="three columns">
   <div class="theme-switch-wrapper">

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -321,7 +321,7 @@ proc buildDoc(nimArgs, destPath: string) =
   for d in items(doc):
     var nimArgs2 = nimArgs
     if d.isRelativeTo("compiler"):
-      nimArgs2.add " --docroot:@pkg"
+      nimArgs2.add " --docroot"
     commands[i] = nim & " doc $# --git.url:$# --outdir:$# --index:on $#" %
       [nimArgs2, gitUrl, destPath, d]
     i.inc

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -321,8 +321,7 @@ proc buildDoc(nimArgs, destPath: string) =
   for d in items(doc):
     var nimArgs2 = nimArgs
     if d.isRelativeTo("compiler"):
-      when false: # enable this when bugs fixed
-        nimArgs2.add " --docroot:@pkg"
+      nimArgs2.add " --docroot:@pkg"
     commands[i] = nim & " doc $# --git.url:$# --outdir:$# --index:on $#" %
       [nimArgs2, gitUrl, destPath, d]
     i.inc

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -319,9 +319,12 @@ proc buildDoc(nimArgs, destPath: string) =
       destPath / changeFileExt(splitFile(d).name, "html"), d]
     i.inc
   for d in items(doc):
-    commands[i] = nim & " doc $# --git.url:$# -o:$# --index:on $#" %
-      [nimArgs, gitUrl,
-      destPath / changeFileExt(splitFile(d).name, "html"), d]
+    var nimArgs2 = nimArgs
+    if d.isRelativeTo("compiler"):
+      when false: # enable this when bugs fixed
+        nimArgs2.add " --docroot:@pkg"
+    commands[i] = nim & " doc $# --git.url:$# --outdir:$# --index:on $#" %
+      [nimArgs2, gitUrl, destPath, d]
     i.inc
   for d in items(withoutIndex):
     commands[i] = nim & " doc2 $# --git.url:$# -o:$# $#" %


### PR DESCRIPTION
* fixes #13150 `nim doc --project` works reliably, in particular with duplicate names and with imports below main project file


* new option: `--docroot`: nim doc --project --docroot:/pathto/mypkg --outdir:htmldocs /pathto/mypkg/sub/main.nim
=> creates: `htmldocs/sub/main.nim` (ie, `outdir / relativePath(srcfile, docroot)`)
* correctly handles duplicate names (implementation uses PSym.nimblePkg since fakePackageName would be wrong); previously, a duplicate package name would be silently ignored
* `..` gets transformed to `@@` and it all works including in hrefs; turns out skipping files in case they're starting with `..` is tricky / undesirable

## semi-related or unrelated changes
* removed dead code `resetPackageCache`
* removed unused import nimconf
* added `lazyPaths` to `nim dump`
* added `getNimbleFile*(conf: ConfigRef; path: string)` to return path to nimble file corresponding to an input file
  => used to get doc files relative to this for `--docroot:@pkg`
* added `proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile): RelativeFile`
`getRelativePathFromConfigPath(conf, "/pathto/foo/bar/bar.nim")` returns `"bar/bar.nim"` if `/pathto/foo` is in the `nim --path`
  => used to get doc files relative to this for `--docroot:@path`
* [EDIT] compiler docs now under compiler/, eg: https://nim-lang.github.io/Nim/vmgen.html => https://nim-lang.github.io/Nim/compiler/vmgen.html
[EDIT]: note: this is desirable because otherwise name modules do clash, eg: pure/options vs compiler/options