### PR TITLE
added note to re constructor regarding performance

### DIFF
--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -78,7 +78,11 @@ proc re*(s: string, flags = {reStudy}): Regex =
   ##
   ## Note that Nim's
   ## extended raw string literals support the syntax ``re"[abc]"`` as
-  ## a short form for ``re(r"[abc]")``.
+  ## a short form for ``re(r"[abc]")``. Also note that since this
+  ## compiles the regular expression, which is expensive, you should
+  ## avoid putting it directly in the arguments of the functions like
+  ## the examples show below if you plan to use it a lot of times, as
+  ## this will hurt performance immensely. (e.g. outside a loop, ...)
   when defined(gcDestructors):
     result = Regex()
   else:


### PR DESCRIPTION
Since I was new to regex I did not know that there is a compilation going on with ``re"[abc]"`` constructor and so I followed the other examples in the docs blindly, that is I just put the constructor directly in the arguments of match, find, etc., which was inside a loop and then wondered why my performance was so bad. Of course putting it outside the loop made it vastly more performant. People like me would benefit from the small note I added I would think :)