### PR TITLE
document `isNil` for seq types needing nilseq

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1494,8 +1494,20 @@ else:
   {.pragma: nilError.}
 
 proc isNil*[T](x: seq[T]): bool {.noSideEffect, magic: "IsNil", nilError.}
+  ## Requires `--nilseqs:on` since 0.19.
+  ##
+  ## Seqs are no longer nil by default, but set and empty.
+  ## Check for zero length instead.
+  ##
+  ## See also:
+  ## * `isNil(string) <#isNil,string>`_
+
 proc isNil*[T](x: ref T): bool {.noSideEffect, magic: "IsNil".}
 proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
+  ## Requires `--nilseqs:on`.
+  ##
+  ## See also:
+  ## * `isNil(seq[T]) <#isNil,seq[T][T]>`_
 
 proc isNil*[T](x: ptr T): bool {.noSideEffect, magic: "IsNil".}
 proc isNil*(x: pointer): bool {.noSideEffect, magic: "IsNil".}


### PR DESCRIPTION
`isNil` are in the documentation for seq and string, with no notice about them no longer being nil, which may confuse users to believe they are and erroneously use the procs, only to find the following ambiguous error to be reported: https://github.com/nim-lang/Nim/issues/11440.

This PR hopes to at least set an understanding in the docs that to use those procs, a special flag has to be passed, but hopefully dissuades the usage by offering length check as the alternative.

This may be considered to fix https://github.com/nim-lang/Nim/issues/11440 as well, unless a more specific error message is desired.