### PR TITLE
make AbsoluteFile (etc) lie in fewer places

### DIFF
--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -181,7 +181,4 @@ proc makeModule*(graph: ModuleGraph; filename: AbsoluteFile): PSym =
   result = graph.newModule(fileInfoIdx(graph.config, filename))
   registerModule(graph, result)
 
-proc makeModule*(graph: ModuleGraph; filename: string): PSym =
-  result = makeModule(graph, AbsoluteFile filename)
-
 proc makeStdinModule*(graph: ModuleGraph): PSym = graph.makeModule(AbsoluteFile"stdin")

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -132,7 +132,11 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
         projPath = RelativeFile filename.extractFilename
       else:
         projPath = RelativeFile filename
-    else: projPath = relativeTo(canon, conf.projectPath)
+    elif conf.projectPath.isEmpty:
+      # eg happens with `nim c -r nimpretty/tester.nim` in CI
+      projPath = relativeTo(canon, getCurrentDir().AbsoluteDir)
+    else:
+      projPath = relativeTo(canon, conf.projectPath)
     conf.m.fileInfos.add(newFileInfo(canon, projPath))
     conf.m.filenameToIndexTbl[canon2] = result
 

--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -119,7 +119,7 @@ proc createInterpreter*(scriptName: string;
 
   var scriptName2 = findFile(conf, scriptName)
   if scriptName2.isEmpty:
-    scriptName2 = "/fakeroot".AbsoluteDir / scriptName.RelativeFile
+    scriptName2 =  getCurrentDir().AbsoluteDir / scriptName.RelativeFile
   conf.projectPath = scriptName2.splitFile.dir
 
   var m = graph.makeModule(scriptName2)

--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -117,7 +117,12 @@ proc createInterpreter*(scriptName: string;
     conf.searchPaths.add(AbsoluteDir p)
     if conf.libpath.isEmpty: conf.libpath = AbsoluteDir p
 
-  var m = graph.makeModule(scriptName)
+  var scriptName2 = findFile(conf, scriptName)
+  if scriptName2.isEmpty:
+    scriptName2 = "/fakeroot".AbsoluteDir / scriptName.RelativeFile
+  conf.projectPath = scriptName2.splitFile.dir
+
+  var m = graph.makeModule(scriptName2)
   incl(m.flags, sfMainModule)
   var idgen = idGeneratorFromModule(m)
   var vm = newCtx(m, cache, graph, idgen)
@@ -127,7 +132,7 @@ proc createInterpreter*(scriptName: string;
     vm.registerAdditionalOps() # Required to register parts of stdlib modules
   graph.vm = vm
   graph.compileSystemModule()
-  result = Interpreter(mainModule: m, graph: graph, scriptName: scriptName, idgen: idgen)
+  result = Interpreter(mainModule: m, graph: graph, scriptName: scriptName2.string, idgen: idgen)
 
 proc destroyInterpreter*(i: Interpreter) =
   ## destructor.

--- a/compiler/pathutils.nim
+++ b/compiler/pathutils.nim
@@ -83,9 +83,8 @@ when true:
 
   proc relativeTo*(fullPath: AbsoluteFile, baseFilename: AbsoluteDir;
                    sep = DirSep): RelativeFile =
-    # this currently fails for `tests/compilerapi/tcompilerapi.nim`
-    # it's needed otherwise would returns an absolute path
-    # assert not baseFilename.isEmpty, $fullPath
+    assert not baseFilename.isEmpty, "fullPath: " & $fullPath
+      # otherwise would return absolute path
     result = RelativeFile(relativePath(fullPath.string, baseFilename.string, sep))
 
   proc toAbsolute*(file: string; base: AbsoluteDir): AbsoluteFile =

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -625,6 +625,7 @@ proc pragmaLine(c: PContext, n: PNode) =
       elif y.kind != nkIntLit:
         localError(c.config, n.info, errIntLiteralExpected)
       else:
+        # it's a lie: x.strVal could be non-absolute
         n.info.fileIndex = fileInfoIdx(c.config, AbsoluteFile(x.strVal))
         n.info.line = uint16(y.intVal)
     else:


### PR DESCRIPTION
as mentioned in https://github.com/nim-lang/RFCs/issues/71, the guarantees offered by pathutils.AbsoluteFile + friends are rather moot because code like AbsoluteFile(file) makes 0 checking (nor can it since it's an object constructor). In practice these "guarantees" are often violated, eg see:
* relativeTo can return absolute paths if 2nd argument is empty
* nim-lang/Nim#13121
* AbsoluteFile"stdin" in modules.nim
* AbsoluteFile"command line" in modules.nim
* AbsoluteFile(x.strVal) in pragmaLine which is a lie when user uses {.loc: "file.nim".}, or uses --excessiveStackTrace:off

this PR fixes a bug whereby `relativeTo` could've returned an absolute path, as well as in a few other places
