### PR TITLE
new: sugar.chainOn, chainEval

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -55,6 +55,10 @@
 
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 
+- Added a `sugar.chainOn` macro for easy function chaining that's available
+  everywhere, there is no need to concern your APIs with returning the first argument
+  to enable "chaining" (as in the builder pattern), instead use this.
+
 ## Library changes
 
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`

--- a/changelog.md
+++ b/changelog.md
@@ -55,7 +55,7 @@
 
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 
-- Added a `sugar.chainOn` macro for easy function chaining that's available
+- Added `sugar.chainOn` and `sugar.chainEval` for easy function chaining that's available
   everywhere, there is no need to concern your APIs with returning the first argument
   to enable "chaining" (as in the builder pattern), instead use this.
 

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -426,6 +426,8 @@ since (1, 1):
     ## similar way as `chainOn`, and returns the result
     runnableExamples:
       doAssert (5+5).chainEval(*= 2, += 100) == ((5+5)*2) + 100
+      ## example showing method call syntax chain mixed with chainEval
+      doAssert 10.chainEval(*= 2).float.chainEval(*= 3.5) == float(10*2)*3.5
     block:
       var x = lhs
       chainOn(x, calls)

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -426,8 +426,10 @@ since (1, 1):
     ## similar way as `chainOn`, and returns the result
     runnableExamples:
       doAssert (5+5).chainEval(*= 2, += 100) == ((5+5)*2) + 100
-      ## example showing method call syntax chain mixed with chainEval
+      ## examples showing method call syntax chain mixed with chainEval
       doAssert 10.chainEval(*= 2).float.chainEval(*= 3.5) == float(10*2)*3.5
+      import std/[strutils, algorithm]
+      doAssert 10.chainEval(*= 2).`$`.chainEval(add("cba"), sort()) == "02abc"
     block:
       var x = lhs
       chainOn(x, calls)


### PR DESCRIPTION
* supersedes #13092 , same rationale
* all credits for original idea goes to @Araq 

## improvements over #13092
* (minor) nnkPrefix gets transformed to nnkInfix, otherwise `repr` doesn't work (and it looks like a violation of nnkPrefix?)
* (minor) renamed operateOn to chainOn
* supports both statementlist-style and varargs style: `a.chainOn(+= 10, mult2(), *= 100)` for easy one-liners

```nim
    a.chainOn: # or `chainOn a:`
      += 4
      -= 5
    # new:
    a.chainOn(+= 10, mult2(), *= 100)
```

alternatives were considered in the forum involving `;` eg:
```nim
on x: add("a"); add("b")
x.on.add("a").add("b")
```
but IMO this is better:
```nim
a.chainOn(+= 10, mult2(), *= 100)
```

* supports field accesses 
There is no ambiguity here; infix operators `x += expr` imply a field access `_.x += expr`, whereas postfix operators `+= expr` imply `_ += expr`
```nim
    type Foo = object
      x1, x2: int
    var foo: Foo
    foo.chainOn(initialize(), postprocess("foo"), x1 = 1, x1 += 3, x2 = 5)
```

## also added chainEval
this is a simpler wrapper around chainOn that is used for returning expressions; it evaluates the lhs (once), applies the chain, and returns the result.
It's a quite natural addition.

```nim
doAssert (5+5).chainEval(*= 2, += 100) == ((5+5)*2) + 100
return expressionWithSideEffect("foo", bar).chainEval(*= 2, += 100, transform())
```


