### PR TITLE
contributing docs: symbols need package prefix; changed allocStats to nimAllocStats

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -271,6 +271,20 @@ Note: these are general guidelines, not hard rules; there are always exceptions.
 Code reviews can just point to a specific section here to save time and
 propagate best practices.
 
+.. _define_needs_prefix:
+New `defined(foo)` symbols need to be prefixed by the nimble package name, or
+by `nim` for symbols in nim sources (e.g. compiler, standard library). This is
+to avoid name conflicts across packages.
+
+.. code-block:: nim
+
+  # if in nim sources
+  when defined(allocStats): discard # bad, can cause conflicts
+  when defined(nimAllocStats): discard # preferred
+  # if in a pacakge `cligen`:
+  when defined(debug): discard # bad, can cause conflicts
+  when defined(cligenDebug): discard # preferred
+
 .. _noimplicitbool:
 Take advantage of no implicit bool conversion
 

--- a/lib/system/memalloc.nim
+++ b/lib/system/memalloc.nim
@@ -65,7 +65,7 @@ when hasAlloc and not defined(js):
     let stats2 = getAllocStats()
     echo $(stats2 - stats1)
 
-  when defined(allocStats):
+  when defined(nimAllocStats):
     var stats: AllocStats
     template incStat(what: untyped) = inc stats.what
     proc getAllocStats*(): AllocStats = stats

--- a/tests/destructor/tbintree2.nim
+++ b/tests/destructor/tbintree2.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim c -d:allocStats --newruntime $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime $file'''
   output: '''0
 (allocCount: 6, deallocCount: 6)'''
 """

--- a/tests/destructor/tgcdestructors.nim
+++ b/tests/destructor/tgcdestructors.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim c -d:allocStats --newruntime $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime $file'''
   output: '''hi
 ho
 ha

--- a/tests/destructor/tnewruntime_misc.nim
+++ b/tests/destructor/tnewruntime_misc.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim cpp -d:allocStats --newruntime --threads:on $file'''
+  cmd: '''nim cpp -d:nimAllocStats --newruntime --threads:on $file'''
   output: '''(field: "value")
 Indeed
 axc

--- a/tests/destructor/tnewruntime_strutils.nim
+++ b/tests/destructor/tnewruntime_strutils.nim
@@ -1,6 +1,6 @@
 discard """
   valgrind: true
-  cmd: '''nim c -d:allocStats --newruntime -d:useMalloc $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime -d:useMalloc $file'''
   output: '''
 @[(input: @["KXSC", "BGMC"]), (input: @["PXFX"]), (input: @["WXRQ", "ZSCZD"])]'''
 """

--- a/tests/destructor/tsimpleclosure.nim
+++ b/tests/destructor/tsimpleclosure.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim c -d:allocStats --newruntime $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime $file'''
   output: '''a b
 70
 hello

--- a/tests/destructor/tv2_raise.nim
+++ b/tests/destructor/tv2_raise.nim
@@ -1,6 +1,6 @@
 discard """
   valgrind: true
-  cmd: '''nim c -d:allocStats --newruntime $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime $file'''
   output: '''OK 3
 (allocCount: 8, deallocCount: 3)'''
 """

--- a/tests/destructor/twidgets.nim
+++ b/tests/destructor/twidgets.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim c -d:allocstats --newruntime $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime $file'''
   output: '''button
 clicked!
 (allocCount: 4, deallocCount: 4)'''

--- a/tests/destructor/twidgets_unown.nim
+++ b/tests/destructor/twidgets_unown.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: '''nim c -d:allocStats --newruntime $file'''
+  cmd: '''nim c -d:nimAllocStats --newruntime $file'''
   output: '''button
 clicked!
 (allocCount: 9, deallocCount: 9)'''


### PR DESCRIPTION
/cc @zevv follow-up from #13190 which just introduced -d:allocStats

(related: #https://github.com/nim-lang/RFCs/issues/181 but not depending on this)