### PR TITLE
nim dump: add libpath

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -306,6 +306,7 @@ proc mainCommand*(graph: ModuleGraph) =
       var dumpdata = %[
         (key: "version", val: %VersionAsString),
         (key: "prefixdir", val: %conf.getPrefixDir().string),
+        (key: "libpath", val: %conf.libpath.string),
         (key: "project_path", val: %conf.projectFull.string),
         (key: "defined_symbols", val: definedSymbols),
         (key: "lib_paths", val: %libpaths),


### PR DESCRIPTION
after PR:
```
nim dump --dump.format:json . | jq -r .libpath
/Users/timothee/git_clone/nim/Nim_prs/lib
```

robust and avoids redoing compiler work like in https://scripter.co/notes/nim/#nim-stdlib-path
(see also https://forum.nim-lang.org/t/5850 which shows need for it)
