### PR TITLE
added os.nativeToUnixPath, os.absolutePrefix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,87 +16,6 @@
   type B = enum b1, b2
   doAssert not compiles(a1.B)
   doAssert compiles(a1.ord.B)
-## Standard library additions and changes
-- Add `tryInsert`,`insert` procs to db_* libs accept primary key column name.
-- Added `xmltree.newVerbatimText` support create `style`'s,`script`'s text.
-- `uri` adds Data URI Base64, implements RFC-2397.
-- Add [DOM Parser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser)
-  to the `dom` module for the JavaScript target.
-- The default hash for `Ordinal` has changed to something more bit-scrambling.
-  `import hashes; proc hash(x: myInt): Hash = hashIdentity(x)` recovers the old
-  one in an instantiation context while `-d:nimIntHash1` recovers it globally.
-- `deques.peekFirst` and `deques.peekLast` now have `var Deque[T] -> var T` overloads.
-- File handles created from high-level abstractions in the stdlib will no longer
-  be inherited by child processes. In particular, these modules are affected:
-  `asyncdispatch`, `asyncnet`, `system`, `nativesockets`, `net` and `selectors`.
-
-  For `asyncdispatch`, `asyncnet`, `net` and `nativesockets`, an `inheritable`
-  flag has been added to all `proc`s that create sockets, allowing the user to
-  control whether the resulting socket is inheritable. This flag is provided to
-  ease the writing of multi-process servers, where sockets inheritance is
-  desired.
-
-  For a transistion period, define `nimInheritHandles` to enable file handle
-  inheritance by default. This flag does **not** affect the `selectors` module
-  due to the differing semantics between operating systems.
-
-  `asyncdispatch.setInheritable`, `system.setInheritable` and
-  `nativesockets.setInheritable` is also introduced for setting file handle or
-  socket inheritance. Not all platform have these `proc`s defined.
-
-- The file descriptors created for internal bookkeeping by `ioselector_kqueue`
-  and `ioselector_epoll` will no longer be leaked to child processes.
-
-- `strutils.formatFloat` with `precision = 0` has been restored to the version
-  1 behaviour that produces a trailing dot, e.g. `formatFloat(3.14159, precision = 0)`
-  is now `3.`, not `3`.
-- `critbits` adds `commonPrefixLen`.
-
-- `relativePath(rel, abs)` and `relativePath(abs, rel)` used to silently give wrong results
-  (see #13222); instead they now use `getCurrentDir` to resolve those cases,
-  and this can now throw in edge cases where `getCurrentDir` throws.
-  `relativePath` also now works for js with `-d:nodejs`.
-
-- JavaScript and NimScript standard library changes: `streams.StringStream` is
-  now supported in JavaScript, with the limitation that any buffer `pointer`s
-  used must be castable to `ptr string`, any incompatible pointer type will not
-  work. The `lexbase` and `streams` modules used to fail to compile on
-  NimScript due to a bug, but this has been fixed.
-
-  The following modules now compile on both JS and NimScript: `parsecsv`,
-  `parsecfg`, `parsesql`, `xmlparser`, `htmlparser` and `ropes`. Additionally
-  supported for JS is `cstrutils.startsWith` and `cstrutils.endsWith`, for
-  NimScript: `json`, `parsejson`, `strtabs` and `unidecode`.
-
-- Added `streams.readStr` and `streams.peekStr` overloads to
-  accept an existing string to modify, which avoids memory
-  allocations, similar to `streams.readLine` (#13857).
-
-- Added high-level `asyncnet.sendTo` and `asyncnet.recvFrom`. UDP functionality.
-
-- `paramCount` & `paramStr` are now defined in os.nim instead of nimscript.nim for nimscript/nimble.
-- `dollars.$` now works for unsigned ints with `nim js`
-- Added `os.absolutePrefix` to return the root path component for absolute paths
-- Added `os.nativeToUnixPath` to convert a native path to a UNIX path.
-
-- Improvements to the `bitops` module, including bitslices, non-mutating versions
-  of the original masking functions, `mask`/`masked`, and varargs support for
-  `bitand`, `bitor`, and `bitxor`.
-
-- `sugar.=>` and `sugar.->` changes: Previously `(x, y: int)` was transformed
-  into `(x: auto, y: int)`, it now becomes `(x: int, y: int)` in consistency
-  with regular proc definitions (although you cannot use semicolons).
-
-  Pragmas and using a name are now allowed on the lefthand side of `=>`. Here
-  is an aggregate example of these changes:
-  ```nim
-  import sugar
-
-  foo(x, y: int) {.noSideEffect.} => x + y
-
-  # is transformed into
-
-  proc foo(x: int, y: int): auto {.noSideEffect.} = x + y
   ```
   for a transition period, use `-d:nimLegacyConvEnumEnum`.
 
@@ -263,6 +182,10 @@
   determining preferred I/O block size for this file object.
 
 - Added `os.getCacheDir()` to return platform specific cache directory.
+
+- Added `os.absolutePrefix` to return the root path component for absolute paths
+
+- Added `os.nativeToUnixPath` to convert a native path to a UNIX path.
 
 - Added a simpler to use `io.readChars` overload.
 

--- a/changelog.md
+++ b/changelog.md
@@ -76,7 +76,6 @@
 
 - `paramCount` & `paramStr` are now defined in os.nim instead of nimscript.nim for nimscript/nimble.
 - `dollars.$` now works for unsigned ints with `nim js`
-- Added `os.absolutePrefix` to return the root path component for absolute paths
 - Added `os.nativeToUnixPath` to convert a native path to a UNIX path.
 
 - Improvements to the `bitops` module, including bitslices, non-mutating versions

--- a/changelog.md
+++ b/changelog.md
@@ -76,6 +76,7 @@
 
 - `paramCount` & `paramStr` are now defined in os.nim instead of nimscript.nim for nimscript/nimble.
 - `dollars.$` now works for unsigned ints with `nim js`
+- Added `os.absolutePrefix` to return the root path component for absolute paths
 - Added `os.nativeToUnixPath` to convert a native path to a UNIX path.
 
 - Improvements to the `bitops` module, including bitslices, non-mutating versions

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -19,7 +19,6 @@ import
   pathutils, trees, tables, nimpaths, renderverbatim, osproc
 
 from uri import encodeUrl
-from std/private/globs import nativeToUnixPath
 from nodejs import findNodeJs
 
 const

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -13,7 +13,7 @@ import
 
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
-from std/private/globs import nativeToUnixPath
+
 const
   hasTinyCBackend* = defined(tinyc)
   useEffectSystem* = true

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -284,6 +284,35 @@ proc splitPath*(path: string): tuple[head, tail: string] {.
     result.head = ""
     result.tail = path
 
+proc absolutePrefix*(path: string): string {.since: (1, 1).} =
+  ## returns the root path component for absolute paths, empty for relative paths.
+  ## See also `isAbsolute`.
+  runnableExamples:
+    when defined(posix):
+      doAssert absolutePrefix("//foo") == "//"
+      doAssert absolutePrefix("foo") == ""
+    when defined(windows):
+      doAssert absolutePrefix(r"C:\\\bar") == r"C:\\\"
+  var i = 0
+  let len = len(path)
+  when doslikeFileSystem:
+    while i < len:
+      if path[i] in {DirSep, AltSep}: i.inc
+      elif i == 0 and path[0] in {'a'..'z', 'A'..'Z'} and len > 1 and path[1] == ':': i.inc
+      else: break
+  elif defined(macos):
+    # according to https://perldoc.perl.org/File/Spec/Mac.html `:a` is a relative path
+    while i < len:
+      if path[i] != ':': i.inc
+      else: break
+  elif defined(RISCOS):
+    if len > 0 and path[0] == '$': i = 1
+  elif defined(posix):
+    while i < len:
+      if path[i] == '/': i.inc
+      else: break
+  result = path[0 ..< i]
+
 proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raises: [].} =
   ## Checks whether a given `path` is absolute.
   ##
@@ -826,6 +855,21 @@ proc cmpPaths*(pathA, pathB: string): int {.
     else:
       result = cmpIgnoreCase(a, b)
 
+proc nativeToUnixPath*(path: string): string {.noSideEffect, since: (1, 1).} =
+  ## Converts a native path to a UNIX path; on windows, the drive is converted to
+  ## `/`.
+  ## See also `unixToNativePath`.
+  runnableExamples:
+    when defined(windows):
+      doAssert nativeToUnixPath(r"C:\foo\bar") == "/foo/bar"
+  when defined(posix):
+    result = path
+  else:
+    let prefix = path.absolutePrefix
+    if prefix.len > 0:
+      result.add '/'
+    result.add path.replace('\\', '/')
+
 proc unixToNativePath*(path: string, drive=""): string {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Converts an UNIX-like path to a native one.
@@ -837,6 +881,7 @@ proc unixToNativePath*(path: string, drive=""): string {.
   ## which drive label to use during absolute path conversion.
   ## `drive` defaults to the drive of the current working directory, and is
   ## ignored on systems that do not have a concept of "drives".
+  ## See also `nativeToUnixPath`.
   when defined(unix):
     result = path
   else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -284,7 +284,7 @@ proc splitPath*(path: string): tuple[head, tail: string] {.
     result.head = ""
     result.tail = path
 
-proc absolutePrefix*(path: string): string {.since: (1, 3, 7).} =
+func absolutePrefix*(path: string): string {.since: (1, 5, 1).} =
   ## returns the root path component for absolute paths, empty for relative paths.
   ## See also `isAbsolute`.
   runnableExamples:
@@ -855,7 +855,7 @@ proc cmpPaths*(pathA, pathB: string): int {.
     else:
       result = cmpIgnoreCase(a, b)
 
-proc nativeToUnixPath*(path: string, keepDrive = false): string {.noSideEffect, since: (1, 3, 7).} =
+func nativeToUnixPath*(path: string, keepDrive = false): string {.since: (1, 5, 1).} =
   ## Converts a native path to a UNIX path; on windows, the drive is converted to
   ## `/`.
   ## See also `unixToNativePath`.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -284,35 +284,6 @@ proc splitPath*(path: string): tuple[head, tail: string] {.
     result.head = ""
     result.tail = path
 
-proc absolutePrefix*(path: string): string {.since: (1, 1).} =
-  ## returns the root path component for absolute paths, empty for relative paths.
-  ## See also `isAbsolute`.
-  runnableExamples:
-    when defined(posix):
-      doAssert absolutePrefix("//foo") == "//"
-      doAssert absolutePrefix("foo") == ""
-    when defined(windows):
-      doAssert absolutePrefix(r"C:\\\bar") == r"C:\\\"
-  var i = 0
-  let len = len(path)
-  when doslikeFileSystem:
-    while i < len:
-      if path[i] in {DirSep, AltSep}: i.inc
-      elif i == 0 and path[0] in {'a'..'z', 'A'..'Z'} and len > 1 and path[1] == ':': i.inc
-      else: break
-  elif defined(macos):
-    # according to https://perldoc.perl.org/File/Spec/Mac.html `:a` is a relative path
-    while i < len:
-      if path[i] != ':': i.inc
-      else: break
-  elif defined(RISCOS):
-    if len > 0 and path[0] == '$': i = 1
-  elif defined(posix):
-    while i < len:
-      if path[i] == '/': i.inc
-      else: break
-  result = path[0 ..< i]
-
 proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raises: [].} =
   ## Checks whether a given `path` is absolute.
   ##
@@ -855,7 +826,7 @@ proc cmpPaths*(pathA, pathB: string): int {.
     else:
       result = cmpIgnoreCase(a, b)
 
-proc nativeToUnixPath*(path: string): string {.noSideEffect, since: (1, 1).} =
+proc nativeToUnixPath*(path: string, keepDrive = false): string {.noSideEffect, since: (1, 3, 5).} =
   ## Converts a native path to a UNIX path; on windows, the drive is converted to
   ## `/`.
   ## See also `unixToNativePath`.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -289,10 +289,10 @@ func absolutePrefix*(path: string): string {.since: (1, 5, 1).} =
   ## See also `isAbsolute`.
   runnableExamples:
     when defined(posix):
-      doAssert absolutePrefix("//foo") == "//"
-      doAssert absolutePrefix("foo") == ""
+      assert absolutePrefix("//foo") == "//"
+      assert absolutePrefix("foo") == ""
     when defined(windows):
-      doAssert absolutePrefix(r"C:\\\bar") == r"C:\\\"
+      assert absolutePrefix(r"C:\\\bar") == r"C:\\\"
   var i = 0
   let len = len(path)
   when doslikeFileSystem:
@@ -861,7 +861,7 @@ func nativeToUnixPath*(path: string, keepDrive = false): string {.since: (1, 5, 
   ## See also `unixToNativePath`.
   runnableExamples:
     when defined(windows):
-      doAssert nativeToUnixPath(r"C:\foo\bar") == "/foo/bar"
+      assert nativeToUnixPath(r"C:\foo\bar") == "/foo/bar"
   when defined(posix):
     result = path
   else:

--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -43,13 +43,6 @@ iterator walkDirRecFilter*(dir: string, follow: proc(entry: PathEntry): bool = n
       # permissions), it'll abort iteration and there would be no way to
       # continue iteration.
 
-proc nativeToUnixPath*(path: string): string =
-  # pending https://github.com/nim-lang/Nim/pull/13265
-  doAssert not path.isAbsolute # not implemented here; absolute files need more care for the drive
-  when DirSep == '\\':
-    result = replace(path, '\\', '/')
-  else: result = path
-
 when isMainModule:
   import sugar
   for a in walkDirRecFilter(".", follow = a=>a.path.lastPathPart notin ["nimcache", ".git", "csources_v1", "csources", "bin"]):

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -13,7 +13,6 @@ import std/[strformat,os,osproc,unittest,compilesettings]
 from std/sequtils import toSeq,mapIt
 from std/algorithm import sorted
 import stdtest/[specialpaths, unittest_light]
-from std/private/globs import nativeToUnixPath
 from strutils import startsWith, strip, removePrefix
 from std/sugar import dup
 import "$lib/../compiler/nimpaths"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -665,3 +665,10 @@ block: # isAdmin
   if isAzure and defined(windows): doAssert isAdmin()
   # In Azure on POSIX tests run as a normal user
   if isAzure and defined(posix): doAssert not isAdmin()
+
+block: # absolutePrefix
+  when defined(posix):
+    doAssert absolutePrefix("//foo") == "//"
+    doAssert absolutePrefix("foo") == ""
+  when defined(windows):
+    doAssert absolutePrefix(r"C:\\\bar") == r"C:\\\"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -667,11 +667,17 @@ block: # isAdmin
   if isAzure and defined(posix): doAssert not isAdmin()
 
 block: # absolutePrefix
-  when defined(posix):
-    doAssert absolutePrefix("//foo") == "//"
-    doAssert absolutePrefix("foo") == ""
+  check:
+    absolutePrefix("//foo") == "//"
+    absolutePrefix("foo") == ""
+  when defined(windows):
+    check:
+      nativeToUnixPath(r"C:\foo\bar") == "/foo/bar"
+      nativeToUnixPath(r"\foo\bar") == "/foo/bar"
+      # tricky case
+      nativeToUnixPath(r"C:foo\bar") == "foo/bar"
 
-block nativeToUnixPath:
+block: # nativeToUnixPath
   check:
     nativeToUnixPath("") == ""
     nativeToUnixPath("foo") == "foo"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -25,7 +25,7 @@ Raises
 """
 # test os path creation, iteration, and deletion
 
-import os, strutils, pathnorm
+import std/[os, strutils, pathnorm, unittest]
 from stdtest/specialpaths import buildDir
 
 block fileOperations:
@@ -670,5 +670,18 @@ block: # absolutePrefix
   when defined(posix):
     doAssert absolutePrefix("//foo") == "//"
     doAssert absolutePrefix("foo") == ""
+
+block nativeToUnixPath:
+  check:
+    nativeToUnixPath("") == ""
+    nativeToUnixPath("foo") == "foo"
+    nativeToUnixPath("foo/bar") == "foo/bar"
+    nativeToUnixPath("/") == "/"
+    nativeToUnixPath(".") == "."
+
   when defined(windows):
-    doAssert absolutePrefix(r"C:\\\bar") == r"C:\\\"
+    check:
+      nativeToUnixPath(r"C:\foo\bar") == "/foo/bar"
+      nativeToUnixPath(r"\foo\bar") == "/foo/bar"
+      # tricky case
+      nativeToUnixPath(r"C:foo\bar") == "foo/bar"

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -1,7 +1,7 @@
 ## Part of 'koch' responsible for the documentation generation.
 
 import os, strutils, osproc, sets, pathnorm, pegs, sequtils
-from std/private/globs import nativeToUnixPath, walkDirRecFilter, PathEntry
+from std/private/globs import walkDirRecFilter, PathEntry
 import "../compiler/nimpaths"
 
 const


### PR DESCRIPTION
* nativeToUnixPath is occasionally useful (eg in unittests as well as for some PR's) and is the best-effort reverse of unixToNativePath
* absolutePrefix does the tricky OS-specific work of figuring out the 1st path component of absolute paths (and is used for example in nativeToUnixPath; isAbsolute could also be implemented on top of it but I didn't do it in this PR), eg: 
```nim
doAssert absolutePrefix(r"C:\bar") == r"C:\"
```

note: another sensible choice would've been firstPathPart (analog to lastPathPart), instead of absolutePrefix, which would also return 1st path component for relative paths, eg `doAssert firstPathPart("foo/bar") == "foo"`