### PR TITLE
unittest add resetOutputFormatters proc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -52,8 +52,8 @@
   This simplifies code by reducing need for if-else branches around intermediate maybe nil values.
   Eg: `echo ?.n.typ.kind`
 - Added `minIndex` and `maxIndex` to the `sequtils` module
-
 - Added `os.isRelativeTo` to tell whether a path is relative to another
+- Added `resetOutputFormatters` to `unittest`
 
 ## Library changes
 

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -178,7 +178,7 @@ method testEnded*(formatter: OutputFormatter, testResult: TestResult) {.base, gc
   discard
 method suiteEnded*(formatter: OutputFormatter) {.base, gcsafe.} =
   discard
-
+  
 proc addOutputFormatter*(formatter: OutputFormatter) =
   formatters.add(formatter)
 
@@ -186,6 +186,9 @@ proc delOutputFormatter*(formatter: OutputFormatter) =
   keepIf(formatters, proc (x: OutputFormatter): bool =
     x != formatter)
 
+proc resetOutputFormatters* =
+  formatters = @[]
+    
 proc newConsoleOutputFormatter*(outputLevel: OutputLevel = OutputLevel.PRINT_ALL,
                                 colorOutput = true): <//>ConsoleOutputFormatter =
   ConsoleOutputFormatter(

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -96,6 +96,8 @@
 import
   macros, strutils, streams, times, sets, sequtils
 
+include "system/inclrtl"
+
 when declared(stdout):
   import os
 
@@ -186,7 +188,7 @@ proc delOutputFormatter*(formatter: OutputFormatter) =
   keepIf(formatters, proc (x: OutputFormatter): bool =
     x != formatter)
 
-proc resetOutputFormatters* =
+proc resetOutputFormatters* {.since: (1, 1).} =
   formatters = @[]
     
 proc newConsoleOutputFormatter*(outputLevel: OutputLevel = OutputLevel.PRINT_ALL,

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -178,7 +178,7 @@ method testEnded*(formatter: OutputFormatter, testResult: TestResult) {.base, gc
   discard
 method suiteEnded*(formatter: OutputFormatter) {.base, gcsafe.} =
   discard
-  
+
 proc addOutputFormatter*(formatter: OutputFormatter) =
   formatters.add(formatter)
 


### PR DESCRIPTION
If you use unittest with thread pool it is easy to end up with duplicate formatters. 
The most reliable way to initialise the formatter for the thread is to reset it first and then add what you need.
