### PR TITLE
Repr v2 progress

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1988,10 +1988,6 @@ template unlikely*(val: bool): bool =
 import system/dollars
 export dollars
 
-when defined(nimV2):
-  import system/repr_v2
-  export repr_v2
-
 const
   NimMajor* {.intdefine.}: int = 1
     ## is the major number of Nim's version.
@@ -2620,7 +2616,8 @@ type
     ## Represents a Nim AST node. Macros operate on this type.
 
 when defined(nimV2):
-  proc repr*(x: NimNode): string {.magic: "Repr", noSideEffect.}
+  import system/repr_v2
+  export repr_v2
 
 macro lenVarargs*(x: varargs[untyped]): int {.since: (1, 1).} =
   ## returns number of variadic arguments in `x`

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -102,11 +102,11 @@ proc repr*[T](x: ptr T): string =
   result.add repr(x[])
 
 proc repr*[T](x: ref T | ptr T): string =
-  if x == nil: return "nil"
+  if isNil(x): return "nil"
   when nimvm:
     result = "ref "
   else:
-    result = "ref "  &repr(cast[pointer](x))
+    result = "ref "  & repr(cast[pointer](x))
   result.add repr(x[])
 
 proc collectionToRepr[T](x: T, prefix, separator, suffix: string): string =

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -105,7 +105,6 @@ proc repr*[T](x: ref T | ptr T): string =
   if x == nil: return "nil"
   when nimvm:
     result = "ref "
- 
   else:
     result = "ref "  &repr(cast[pointer](x))
   result.add repr(x[])

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -1,3 +1,11 @@
+proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
+  ## imported from typetraits
+
+proc distinctBase(T: typedesc): typedesc {.magic: "TypeTrait".}
+  ## imported from typetraits
+
+proc repr*(x: NimNode): string {.magic: "Repr", noSideEffect.}
+
 proc repr*(x: int): string {.magic: "IntToStr", noSideEffect.}
   ## repr for an integer argument. Returns `x`
   ## converted to a decimal string.
@@ -37,19 +45,26 @@ proc repr*[Enum: enum](x: Enum): string {.magic: "EnumToStr", noSideEffect.}
   ## If a `repr` operator for a concrete enumeration is provided, this is
   ## used instead. (In other words: *Overwriting* is possible.)
 
-template repr(t: typedesc): string = $t
-
-proc isNamedTuple(T: typedesc): bool =
-  # Taken from typetraits.
-  when T isnot tuple: result = false
+proc repr*(p: pointer): string =
+  ## repr of pointer as its hexadecimal value
+  if p == nil: 
+    result = "nil"
   else:
-    var t: T
-    for name, _ in t.fieldPairs:
-      when name == "Field0":
-        return compiles(t.Field0)
-      else:
-        return true
-    return false
+    when nimvm:
+      result = "ptr"
+    else:
+      const HexChars = "0123456789ABCDEF"
+      const len = sizeof(pointer) * 2
+      var n = cast[uint](p)
+      result = newString(len)
+      for j in countdown(len-1, 0):
+        result[j] = HexChars[n and 0xF]
+        n = n shr 4
+
+template repr*(x: distinct): string =
+  repr(distinctBase(typeof(x))(x))
+
+template repr*(t: typedesc): string = $t
 
 proc repr*[T: tuple|object](x: T): string =
   ## Generic `repr` operator for tuples that is lifted from the components
@@ -75,42 +90,25 @@ proc repr*[T: tuple|object](x: T): string =
       result.add(": ")
     else:
       count.inc
-    when compiles($value):
-      when value isnot string and value isnot seq and compiles(value.isNil):
-        if value.isNil: result.add "nil"
-        else: result.addQuoted(value)
-      else:
-        result.addQuoted(value)
-      firstElement = false
-    else:
-      result.add("...")
-      firstElement = false
+    result.add repr(value)
+    firstElement = false
   when not isNamed:
     if count == 1:
       result.add(',') # $(1,) should print as the semantically legal (1,)
   result.add(')')
 
-proc repr*[T: (ref object)](x: T): string =
-  ## Generic `repr` operator for tuples that is lifted from the components
-  ## of `x`.
+proc repr*[T](x: ptr T): string =
+  result.add repr(pointer(x)) & " "
+  result.add repr(x[])
+
+proc repr*[T](x: ref T | ptr T): string =
   if x == nil: return "nil"
-  result = $typeof(x) & "("
-  var firstElement = true
-  for name, value in fieldPairs(x[]):
-    if not firstElement: result.add(", ")
-    result.add(name)
-    result.add(": ")
-    when compiles($value):
-      when value isnot string and value isnot seq and compiles(value.isNil):
-        if value.isNil: result.add "nil"
-        else: result.addQuoted(value)
-      else:
-        result.addQuoted(value)
-      firstElement = false
-    else:
-      result.add("...")
-      firstElement = false
-  result.add(')')
+  when nimvm:
+    result = "ref "
+ 
+  else:
+    result = "ref "  &repr(cast[pointer](x))
+  result.add repr(x[])
 
 proc collectionToRepr[T](x: T, prefix, separator, suffix: string): string =
   result = prefix
@@ -120,15 +118,7 @@ proc collectionToRepr[T](x: T, prefix, separator, suffix: string): string =
       firstElement = false
     else:
       result.add(separator)
-
-    when value isnot string and value isnot seq and compiles(value.isNil):
-      # this branch should not be necessary
-      if value.isNil:
-        result.add "nil"
-      else:
-        result.addQuoted(value)
-    else:
-      result.addQuoted(value)
+    result.add repr(value)
   result.add(suffix)
 
 proc repr*[T](x: set[T]): string =
@@ -153,9 +143,9 @@ proc repr*[T, U](x: HSlice[T, U]): string =
   ##
   ## .. code-block:: Nim
   ##  $(1 .. 5) == "1 .. 5"
-  result = $x.a
+  result = repr(x.a)
   result.add(" .. ")
-  result.add($x.b)
+  result.add(repr(x.b))
 
 proc repr*[T, IDX](x: array[IDX, T]): string =
   ## Generic `repr` operator for arrays that is lifted from the components.

--- a/tests/arc/trepr.nim
+++ b/tests/arc/trepr.nim
@@ -2,6 +2,7 @@ discard """
   cmd: "nim c --gc:arc $file"
   nimout: '''(a: true, n: doAssert)
 Table[system.string, trepr.MyType](data: @[], counter: 0)
+nil
 '''
 """
 
@@ -21,9 +22,15 @@ proc myproc2(t: MyType) =
   var x = Table[string, t]()
   echo repr(x)
 
+proc myproc3(t: MyType) =
+  var x: TableRef[string, t]
+  echo repr(x)
+
+
 macro dumpSym(a: typed) =
   myproc((a: true, n: NimSym(a)))
   myproc2((a: true, n: NimSym(a)))
+  myproc3((a: true, n: NimSym(a)))
 
 dumpSym(doAssert)
 

--- a/tests/arc/trepr.nim
+++ b/tests/arc/trepr.nim
@@ -1,6 +1,8 @@
 discard """
   cmd: "nim c --gc:arc $file"
-  nimout: "(a: true, n: doAssert)"
+  nimout: '''(a: true, n: doAssert)
+Table[system.string, trepr.MyType](data: @[], counter: 0)
+'''
 """
 
 import macros
@@ -16,11 +18,10 @@ proc myproc(t: MyType) =
   echo repr(t)
 
 proc myproc2(t: MyType) =
-  var x = TableRef[string, t]()
+  var x = Table[string, t]()
   echo repr(x)
 
 macro dumpSym(a: typed) =
-  echo repr(myproc)
   myproc((a: true, n: NimSym(a)))
   myproc2((a: true, n: NimSym(a)))
 

--- a/tests/arc/trepr.nim
+++ b/tests/arc/trepr.nim
@@ -1,0 +1,28 @@
+discard """
+  cmd: "nim c --gc:arc $file"
+  nimout: "(a: true, n: doAssert)"
+"""
+
+import macros
+import tables
+
+type
+  NimSym = distinct NimNode
+  MyType = tuple
+    a: bool
+    n: NimSym
+
+proc myproc(t: MyType) =
+  echo repr(t)
+
+proc myproc2(t: MyType) =
+  var x = TableRef[string, t]()
+  echo repr(x)
+
+macro dumpSym(a: typed) =
+  echo repr(myproc)
+  myproc((a: true, n: NimSym(a)))
+  myproc2((a: true, n: NimSym(a)))
+
+dumpSym(doAssert)
+

--- a/tests/arc/trepr.nim
+++ b/tests/arc/trepr.nim
@@ -5,8 +5,6 @@ Table[system.string, trepr.MyType](data: @[], counter: 0)
 nil
 '''
 """
-
-import macros
 import tables
 
 type

--- a/tests/destructor/tfinalizer.nim
+++ b/tests/destructor/tfinalizer.nim
@@ -1,6 +1,6 @@
 discard """
   cmd: "nim c --gc:arc $file"
-  output: '''Foo(field: "Dick Laurent", k: ka, x: 0.0)
+  output: '''Foo(field: Dick Laurent, k: ka, x: 0.0)
 Nobody is dead
 Dick Laurent is dead'''
 """


### PR DESCRIPTION
This PR doesn't solve all repr_v2 issues, but at least it is as progress and it unblocks further `--gc:arc` testing.

Progress:
-   support distinct types (RT, VM)
-   support objects with distinct types fields (addQuoted is no go for this one)  (RT, VM)
-   support ref objects  with distinct type fields  (RT, VM)
-   support raw pointer  (RT, VM)

`addQuoted` can't handle NimNodes and distinct types, hence had been abandoned. 

Still missing for later PRs:
-   proc pointers



