### PR TITLE
implementation for newLit on distinct types (fixes #13266)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -61,7 +61,7 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-
+- Added a new generic overload of `newLit` for distinct types in `macros`
 
 ## Library changes
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -725,13 +725,6 @@ proc newLit*(s: string): NimNode {.compileTime.} =
   result = newNimNode(nnkStrLit)
   result.strVal = s
 
-when false:
-  # the float type is not really a distinct type as described in https://github.com/nim-lang/Nim/issues/5875
-  proc newLit*(f: float): NimNode {.compileTime.} =
-    ## Produces a new float literal node.
-    result = newNimNode(nnkFloatLit)
-    result.floatVal = f
-
 proc newLit*(f: float32): NimNode {.compileTime.} =
   ## Produces a new float literal node.
   result = newNimNode(nnkFloat32Lit)
@@ -797,6 +790,14 @@ proc newLit*(arg: tuple): NimNode {.compileTime.} =
   result = nnkPar.newTree
   for a,b in arg.fieldPairs:
     result.add nnkExprColonExpr.newTree(newIdentNode(a), newLit(b))
+
+macro undistinct[T: distinct](arg: T): untyped =
+  ## convert and distinct value to it's base type.
+  let baseTyp = getTypeImpl(arg)[0]
+  result = newCall(baseTyp, arg)
+
+proc newLit*[T : distinct](arg: T): NimNode =
+  result = newCall(bindSym"T", newLit(undistinct(arg)))
 
 proc nestList*(op: NimNode; pack: NimNode): NimNode {.compileTime.} =
   ## Nests the list `pack` into a tree of call expressions:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -796,7 +796,7 @@ macro undistinct[T: distinct](arg: T): untyped =
   let baseTyp = getTypeImpl(arg)[0]
   result = newCall(baseTyp, arg)
 
-proc newLit*[T : distinct](arg: T): NimNode {.compileTime.} =
+proc newLit*[T : distinct](arg: T): NimNode {.compileTime, since: (1,1).} =
   result = newCall(bindSym"T", newLit(undistinct(arg)))
 
 proc nestList*(op: NimNode; pack: NimNode): NimNode {.compileTime.} =

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -792,11 +792,11 @@ proc newLit*(arg: tuple): NimNode {.compileTime.} =
     result.add nnkExprColonExpr.newTree(newIdentNode(a), newLit(b))
 
 macro undistinct[T: distinct](arg: T): untyped =
-  ## convert and distinct value to it's base type.
+  ## convert and distinct value to its base type.
   let baseTyp = getTypeImpl(arg)[0]
   result = newCall(baseTyp, arg)
 
-proc newLit*[T : distinct](arg: T): NimNode =
+proc newLit*[T : distinct](arg: T): NimNode {.compileTime.} =
   result = newCall(bindSym"T", newLit(undistinct(arg)))
 
 proc nestList*(op: NimNode; pack: NimNode): NimNode {.compileTime.} =

--- a/tests/macros/tnewlit.nim
+++ b/tests/macros/tnewlit.nim
@@ -192,3 +192,22 @@ block:
   let x = test_newLit_object_ref_alias()
   doAssert $(x[]) == "(x: 10)"
 
+
+type
+  Rune = distinct int32
+  Foo = object
+    a: Rune
+
+proc `$`(arg: Rune): string = $(int32(arg))
+
+macro test_newLit_distinct(): untyped =
+  newLit(Rune(123))
+
+macro test_newLit_distinct_in_object(): untyped =
+  newLit(Foo(a: Rune(456)))
+
+block:
+  let x1 = test_newLit_distinct()
+  let x2 = test_newLit_distinct_in_object()
+  doAssert $x1 == "123"
+  doAssert $x2 == "(a: 456)"


### PR DESCRIPTION
`newLit` should work on all types, including `distinct` types. This fixes it.

Minor change, I removed some dead code of mine.