### PR TITLE
remove ties to stringification of io.write

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -380,8 +380,40 @@ proc write*(f: File, r: BiggestFloat) {.tags: [WriteIOEffect], benign.} =
 proc write*(f: File, c: char) {.tags: [WriteIOEffect], benign.} =
   discard c_putc(cint(c), f)
 
-proc write*(f: File, a: varargs[string, `$`]) {.tags: [WriteIOEffect], benign.} =
-  for x in items(a): write(f, x)
+when defined(harmfulOverloadOfWrite):
+  proc write*(f: File, a: varargs[string, `$`]) {.tags: [WriteIOEffect], benign.} =
+    for x in items(a): write(f, x)
+else:
+  # no macros available
+  proc write*[T1,T2](f: File, arg1: T1, arg2: T2) =
+    f.write(arg1)
+    f.write(arg2)
+
+  proc write*[T1,T2,T3](f: File, arg1: T1, arg2: T2, arg3: T3) =
+    f.write(arg1)
+    f.write(arg2)
+    f.write(arg3)
+
+  proc write*[T1,T2,T3,T4](f: File, arg1: T1, arg2: T2, arg3: T3, arg4: T4) =
+    f.write(arg1)
+    f.write(arg2)
+    f.write(arg3)
+    f.write(arg4)
+
+  proc write*[T1,T2,T3,T4,T5](f: File, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) =
+    f.write(arg1)
+    f.write(arg2)
+    f.write(arg3)
+    f.write(arg4)
+    f.write(arg5)
+
+  proc write*[T1,T2,T3,T4,T5,T6](f: File, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) =
+    f.write(arg1)
+    f.write(arg2)
+    f.write(arg3)
+    f.write(arg4)
+    f.write(arg5)
+    f.write(arg6)
 
 proc readAllBuffer(file: File): string =
   # This proc is for File we want to read but don't know how many

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -427,7 +427,7 @@ proc writeQuoted[T](f: File, arg: T) =
 
 proc write*[T: tuple|object](f: File; arg: T) =
   f.write "("
-  const isNamed = isNamedTuple(T)
+  const isNamed = T is object or isNamedTuple(T)
   var count = 0
   for name, value in fieldPairs(arg):
     if count != 0:

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -438,7 +438,7 @@ proc write*[T: tuple|object](f: File; arg: T) =
 
     when compiles($value):
       when value isnot string and value isnot seq and compiles(value.isNil):
-        if value.isNil: result.add "nil"
+        if value.isNil: f.write "nil"
         else: f.writeQuoted(value)
       else:
         f.writeQuoted(value)

--- a/tests/parser/tmultiline_comments.nim
+++ b/tests/parser/tmultiline_comments.nim
@@ -43,7 +43,7 @@ proc writeln(a: auto, x: varargs[string, `$`]) =
   write a, x
   stdout.write "\n"
 
-proc write() = write(stdout)
+proc write() = discard
 proc writeln() =
   stdout.write "\n"
 


### PR DESCRIPTION
Normally I would do such an implementation with macros, but they are not available in system.nim. 

This is a breaking change. uses of `write` that rely on stringification won't work anymore. They will get an easy to fix compilation error though.

This PR is still raw. ``harmfulOverloadOfWrite`` isn't a good name, there is no test added, `writeLn` also needs to be adapted. I am just curious if a change like this could be welcome, or if I have to fight windmills again.

Personally a change like this would be really valuable to me. As you probably know I really don't link the `$` stringification with its intermediate objects, and I don't like `varargs`. `echo` has both of it. I tried to get rid of the `$` fallback in string interpolation, but I got massive negative feedback and it is back in there. `write` that works on `File` also has the `$` fallback. There is simply nothing currently in Nim that doesn't secretly inject the `$` function for printing in `Nim`. String interpolation and `echo` seems to popular to break, so I won't touch them, But `write` and `writeLn` could be non-popular enough to be used as a `$` free printing environment.

would fix #13182

Very much like https://github.com/nim-lang/RFCs/issues/191 this solution is extendable, but the extendable proc isn't a binary `$` or an ``appendStr`` proc, it is just ``write``, which we already have. But unlike that RFC ``write`` doesn't need a single intermediate string allocation, where the RFC does create one intermediate string object per call to ``echo`` or variadic ``write``.

A generic `$` could be implemented using an in memory file object, e.g. with ``FILE * open_memstream (char **ptr, size_t *sizeloc)``. But that is not very portable for all the backends.

