### PR TITLE
miscellaneous bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ megatest.nim
 *.dSYM
 
 nimdoc.out.css
+
+# for `nim c -r nimdoc/tester` etc; this can be in multiple places
+htmldocs

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -21,6 +21,7 @@ import
 
 const
   exportSection = skField
+  htmldocsDir = RelativeDir"htmldocs"
 
 type
   TSections = array[TSymKind, Rope]
@@ -175,7 +176,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
         rawMessage(conf, errGenerated, "executing of external program failed: " & c2)
   result.emitted = initIntSet()
   result.destFile = getOutFile2(conf, relativeTo(filename, conf.projectPath),
-                                outExt, RelativeDir"htmldocs", false)
+                                outExt, htmldocsDir, false)
   result.thisDir = result.destFile.splitFile.dir
 
 template dispA(conf: ConfigRef; dest: var Rope, xml, tex: string, args: openArray[Rope]) =
@@ -301,7 +302,7 @@ proc externalDep(d: PDoc; module: PSym): string =
   if optWholeProject in d.conf.globalOptions:
     let full = AbsoluteFile toFullPath(d.conf, FileIndex module.position)
     let tmp = getOutFile2(d.conf, full.relativeTo(d.conf.projectPath), HtmlExt,
-        RelativeDir"htmldocs", sfMainModule notin module.flags)
+        htmldocsDir, sfMainModule notin module.flags)
     result = relativeTo(tmp, d.thisDir, '/').string
   else:
     result = extractFilename toFullPath(d.conf, FileIndex module.position)
@@ -1057,7 +1058,7 @@ proc genOutFile(d: PDoc): Rope =
 proc generateIndex*(d: PDoc) =
   if optGenIndex in d.conf.globalOptions:
     let dir = if not d.conf.outDir.isEmpty: d.conf.outDir
-              else: d.conf.projectPath / RelativeDir"htmldocs"
+              else: d.conf.projectPath / htmldocsDir
     createDir(dir)
     let dest = dir / changeFileExt(relativeTo(AbsoluteFile d.filename,
                                               d.conf.projectPath), IndexExt)
@@ -1070,7 +1071,7 @@ proc writeOutput*(d: PDoc, useWarning = false) =
     writeRope(stdout, content)
   else:
     template outfile: untyped = d.destFile
-    #let outfile = getOutFile2(d.conf, shortenDir(d.conf, filename), outExt, "htmldocs")
+    #let outfile = getOutFile2(d.conf, shortenDir(d.conf, filename), outExt, htmldocsDir)
     createDir(outfile.splitFile.dir)
     d.conf.outFile = outfile.extractFilename.RelativeFile
     if not writeRope(content, outfile):

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -17,7 +17,7 @@ import
   packages/docutils/rst, packages/docutils/rstgen,
   json, xmltree, cgi, trees, types,
   typesrenderer, astalgo, lineinfos, intsets,
-  pathutils, trees, nimconf
+  pathutils, trees
 
 const
   exportSection = skField

--- a/lib/pure/concurrency/cpuinfo.nim
+++ b/lib/pure/concurrency/cpuinfo.nim
@@ -29,7 +29,7 @@ when defined(macosx) or defined(bsd):
     HW_AVAILCPU = 25
     HW_NCPU = 3
   proc sysctl(x: ptr array[0..3, cint], y: cint, z: pointer,
-              a: var csize, b: pointer, c: int): cint {.
+              a: var csize_t, b: pointer, c: csize_t): cint {.
               importc: "sysctl", nodecl.}
 
 when defined(genode):
@@ -73,10 +73,9 @@ proc countProcessors*(): int {.rtl, extern: "ncpi$1".} =
     var
       mib: array[0..3, cint]
       numCPU: int
-      len: csize
     mib[0] = CTL_HW
     mib[1] = HW_AVAILCPU
-    len = sizeof(numCPU)
+    var len = sizeof(numCPU).csize_t
     discard sysctl(addr(mib), 2, addr(numCPU), len, nil, 0)
     if numCPU < 1:
       mib[1] = HW_NCPU

--- a/lib/pure/ioselects/ioselectors_kqueue.nim
+++ b/lib/pure/ioselects/ioselectors_kqueue.nim
@@ -27,8 +27,8 @@ when defined(macosx) or defined(freebsd) or defined(dragonfly):
     const MAX_DESCRIPTORS_ID = 29 # KERN_MAXFILESPERPROC (MacOS)
   else:
     const MAX_DESCRIPTORS_ID = 27 # KERN_MAXFILESPERPROC (FreeBSD)
-  proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize,
-              newp: pointer, newplen: csize): cint
+  proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize_t,
+              newp: pointer, newplen: csize_t): cint
        {.importc: "sysctl",header: """#include <sys/types.h>
                                       #include <sys/sysctl.h>"""}
 elif defined(netbsd) or defined(openbsd):
@@ -36,8 +36,8 @@ elif defined(netbsd) or defined(openbsd):
   # KERN_MAXFILES, because KERN_MAXFILES is always bigger,
   # than KERN_MAXFILESPERPROC.
   const MAX_DESCRIPTORS_ID = 7 # KERN_MAXFILES
-  proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize,
-              newp: pointer, newplen: csize): cint
+  proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize_t,
+              newp: pointer, newplen: csize_t): cint
        {.importc: "sysctl",header: """#include <sys/param.h>
                                       #include <sys/sysctl.h>"""}
 
@@ -82,7 +82,7 @@ proc getUnique[T](s: Selector[T]): int {.inline.} =
 
 proc newSelector*[T](): owned(Selector[T]) =
   var maxFD = 0.cint
-  var size = csize(sizeof(cint))
+  var size = csize_t(sizeof(cint))
   var namearr = [1.cint, MAX_DESCRIPTORS_ID.cint]
   # Obtain maximum number of opened file descriptors for process
   if sysctl(addr(namearr[0]), 2, cast[pointer](addr maxFD), addr size,

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2725,8 +2725,8 @@ when declared(paramCount) or defined(nimdoc):
       result.add(paramStr(i))
 
 when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
-  proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize,
-              newp: pointer, newplen: csize): cint
+  proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize_t,
+              newp: pointer, newplen: csize_t): cint
        {.importc: "sysctl",header: """#include <sys/types.h>
                                       #include <sys/sysctl.h>"""}
   const
@@ -2740,7 +2740,7 @@ when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
     const KERN_PROC_PATHNAME = 9
 
   proc getApplFreebsd(): string =
-    var pathLength = csize(MAX_PATH)
+    var pathLength = csize_t(MAX_PATH)
     result = newString(pathLength)
     var req = [CTL_KERN.cint, KERN_PROC.cint, KERN_PROC_PATHNAME.cint, -1.cint]
     while true:

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -117,9 +117,10 @@ type
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
 # duplicated between io and ansi_c
-const stderrName = when defined(osx): "__stderrp" else: "stderr"
-const stdoutName = when defined(osx): "__stdoutp" else: "stdout"
-const stdinName = when defined(osx): "__stdinp" else: "stdin"
+const stdioUsesMacros = defined(osx) and not defined(emscripten)
+const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
+const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
+const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"
 
 var
   cstderr* {.importc: stderrName, header: "<stdio.h>".}: CFilePtr

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -36,9 +36,10 @@ type
 # text file handling:
 when not defined(nimscript) and not defined(js):
   # duplicated between io and ansi_c
-  const stderrName = when defined(osx): "__stderrp" else: "stderr"
-  const stdoutName = when defined(osx): "__stdoutp" else: "stdout"
-  const stdinName = when defined(osx): "__stdinp" else: "stdin"
+  const stdioUsesMacros = defined(osx) and not defined(emscripten)
+  const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
+  const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
+  const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"
 
   var
     stdin* {.importc: stdinName, header: "<stdio.h>".}: File


### PR DESCRIPTION
* csize => csize_t for sysctl (csize deprecated and was wrong in this context); it silences some warnings
* gitignore htmldocs, which appears when running some tests; factor htmldocs
* remove an unused import
* make stderr(+friends) work with emscripten again