### PR TITLE
fix bug discovered by #11591: `proc `<`*[T](x, y: set[T])` was wrong

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1832,7 +1832,7 @@ proc genSetOp(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
     of mCard:
       if size <= 4: unaryExprChar(p, e, d, "#countBits32($1)")
       else: unaryExprChar(p, e, d, "#countBits64($1)")
-    of mLtSet: binaryExprChar(p, e, d, "(($1 & ~ $2 ==0)&&($1 != $2))")
+    of mLtSet: binaryExprChar(p, e, d, "((($1 & ~ $2)==0)&&($1 != $2))")
     of mLeSet: binaryExprChar(p, e, d, "(($1 & ~ $2)==0)")
     of mEqSet: binaryExpr(p, e, d, "($1 == $2)")
     of mMulSet: binaryExpr(p, e, d, "($1 & $2)")


### PR DESCRIPTION
This is yet another bug (see also #11590) that I'm finding and fixing thanks to #11591; could we please merge #11591 ?

* this PR fixes the following bug:
```nim
  type Foo = enum
    k1, k2
  var
    a = {k1}
    b = {k1,k2}
  doAssert a < b
```
before PR: assert failed (and, under #11591 only, would show a cgen warning `& has lower precedence than ==`)
after PR: assert succeeds

* after this PR, compiling nim under #11591 doesn't generate any cgen warnings anymore; before it generated 1 warning, as mentioned in https://github.com/nim-lang/Nim/pull/11591#issuecomment-511539430

> /Users/timothee/.cache/nim/nim_r/sem.nim.cpp:15862:37: warning: & has lower precedence than ==; == will be evaluated first [-Wparentheses]
                                T116_ = (((*(*proto).typ).flags & ~ (*(*s).typ).flags ==0)&&((*(*proto).typ).flags != (*(*s).typ).flags));

it turns out this warning was actually hiding a real bug; so maybe the code in semstmts.nim was previously relying on incorrect behavior
```nim
      if proto.typ.callConv != s.typ.callConv or proto.typ.flags < s.typ.flags:
        localError(c.config, n[pragmasPos].info, errPragmaOnlyInHeaderOfProcX %
          ("'" & proto.name.s & "' from " & c.config$proto.info))
```


