### PR TITLE
CT FFI: fix for windows; fix case transition; error msg shows more useful context

### DIFF
--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -320,7 +320,7 @@ proc unpack(conf: ConfigRef, x: pointer, typ: PType, n: PNode): PNode =
     else:
       reset n[]
       result = n
-      result.kind = nkNilLit
+      result[] = TNode(kind: nkNilLit)
       result.typ = typ
 
   template awi(kind, v: untyped): untyped = aw(kind, v, intVal)

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -10,6 +10,7 @@
 ## This file implements the FFI part of the evaluator for Nim code.
 
 import ast, types, options, tables, dynlib, msgs, lineinfos
+from os import getAppFilename
 import pkg/libffi
 
 when defined(windows):
@@ -27,7 +28,6 @@ var
   gDllCache = initTable[string, LibHandle]()
 
 when defined(windows):
-  from os import getAppFilename
   var gExeHandle = loadLib(getAppFilename())
 else:
   var gExeHandle = loadLib()
@@ -53,11 +53,13 @@ proc importcSymbol*(conf: ConfigRef, sym: PSym): PNode =
   # that contains the address instead:
   result = newNodeIT(nkPtrLit, sym.info, sym.typ)
   when true:
+    var libPathMsg = ""
     let lib = sym.annex
     if lib != nil and lib.path.kind notin {nkStrLit..nkTripleStrLit}:
       globalError(conf, sym.info, "dynlib needs to be a string lit")
     var theAddr: pointer
     if (lib.isNil or lib.kind == libHeader) and not gExeHandle.isNil:
+      libPathMsg = "current exe: " & getAppFilename() & " nor libc: " & libcDll
       # first try this exe itself:
       theAddr = gExeHandle.symAddr(name)
       # then try libc:
@@ -66,9 +68,11 @@ proc importcSymbol*(conf: ConfigRef, sym: PSym): PNode =
         theAddr = dllhandle.symAddr(name)
     elif not lib.isNil:
       let dll = if lib.kind == libHeader: libcDll else: lib.path.strVal
+      libPathMsg = dll
       let dllhandle = getDll(conf, gDllCache, dll, sym.info)
       theAddr = dllhandle.symAddr(name)
-    if theAddr.isNil: globalError(conf, sym.info, "cannot import: " & name)
+    if theAddr.isNil: globalError(conf, sym.info,
+      "cannot import symbol: " & name & " from " & libPathMsg)
     result.intVal = cast[ByteAddress](theAddr)
 
 proc mapType(conf: ConfigRef, t: ast.PType): ptr libffi.Type =

--- a/compiler/evalffi.nim
+++ b/compiler/evalffi.nim
@@ -27,7 +27,8 @@ var
   gDllCache = initTable[string, LibHandle]()
 
 when defined(windows):
-  var gExeHandle = loadLib(os.getAppFilename())
+  from os import getAppFilename
+  var gExeHandle = loadLib(getAppFilename())
 else:
   var gExeHandle = loadLib()
 


### PR DESCRIPTION
* fix a regression for windows (hence need for https://github.com/nim-lang/Nim/pull/13091 (that PR is still a WIP at the moment))
* remove case transition warning
* improve error msg by showing which library the symbol is searched from
Error: cannot import symbol: foo
=>
Error: cannot import symbol: foo from /pathto/libmylib.dylib
or (depending on the case):
Error: cannot import symbol: foo from current exe: /Users/timothee/git_clone/nim/Nim_prs/bin/nim.ffi nor libc: /usr/lib/libSystem.dylib

these only concern `-d:nimHasLibFFI`
