### PR TITLE
Thread attributes should be destroyed using the pthread_attr_destroy()

### DIFF
--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -151,9 +151,11 @@ else:
       tv_sec: Time
       tv_nsec: clong
 
-  proc pthread_attr_init(a1: var Pthread_attr) {.
+  proc pthread_attr_init(a1: var Pthread_attr): cint {.
     importc, header: pthreadh.}
-  proc pthread_attr_setstacksize(a1: var Pthread_attr, a2: int) {.
+  proc pthread_attr_setstacksize(a1: var Pthread_attr, a2: int): cint {.
+    importc, header: pthreadh.}
+  proc pthread_attr_destroy(a1: var Pthread_attr): cint {.
     importc, header: pthreadh.}
 
   proc pthread_create(a1: var SysThread, a2: var Pthread_attr,

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -313,10 +313,11 @@ else:
     t.dataFn = tp
     when hasSharedHeap: t.core.stackSize = ThreadStackSize
     var a {.noinit.}: Pthread_attr
-    pthread_attr_init(a)
-    pthread_attr_setstacksize(a, ThreadStackSize)
+    doAssert pthread_attr_init(a) == 0
+    doAssert pthread_attr_setstacksize(a, ThreadStackSize) == 0
     if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
       raise newException(ResourceExhaustedError, "cannot create thread")
+    doAssert pthread_attr_destroy(a) == 0
 
   proc pinToCpu*[Arg](t: var Thread[Arg]; cpu: Natural) =
     ## Pins a thread to a `CPU`:idx:.


### PR DESCRIPTION
On some OSes (such as FreeBSD or Solaris), pthread_attr_init allocate memory. So it is necessary to deallocate that memory by using pthread_attr_destroy.