### PR TITLE
[DO NOT REVIEW] js: use BigInt for int64

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2429,6 +2429,8 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   of nkCharLit..nkUInt64Lit:
     if n.typ.kind == tyBool:
       r.res = if n.intVal == 0: rope"false" else: rope"true"
+    elif n.typ.kind in {tyInt64, tyUInt64}:
+      r.res = rope($n.intVal & "n")
     else:
       r.res = rope(n.intVal)
     r.kind = resExpr


### PR DESCRIPTION
starting point for experimenting with https://github.com/nim-lang/RFCs/issues/187

```nim
proc main()=
  # var a = 9007199254740991
  var a = 9007199254740990
  echo a # this works
  # this currently fails:
  # a+=1 # TypeError: Cannot mix BigInt and other types, use explicit conversions

main()
```

