### PR TITLE
build_all.sh: building csources 5X faster thanks to make -j

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 # build development version of the compiler; can be rerun safely.
-# arguments can be passed, eg `--cpu i386`
+# arguments can be passed, eg `--os freebsd`
 
 set -u # error on undefined variables
 set -e # exit on first error
@@ -14,13 +14,18 @@ echo_run(){
 [ -d csources ] || echo_run git clone -q --depth 1 https://github.com/nim-lang/csources.git
 
 nim_csources=bin/nim_csources
+
+build_nim_csources_via_script(){
+  echo_run cd csources
+  echo_run sh build.sh "$@"
+}
+
 build_nim_csources(){
   ## avoid changing dir in case of failure
   (
     if [[ $# -ne 0 ]]; then
       # some args were passed (eg: `--cpu i386`), need to call build.sh
-      echo_run cd csources
-      echo_run sh build.sh $@
+      build_nim_csources_via_script "$@"
     else
       # no args, use multhreaded (5X faster on 16 cores: 10s instead of 50s)
       makeX=make
@@ -31,7 +36,7 @@ build_nim_csources(){
       # see https://stackoverflow.com/a/53427092/1426932
       logicalCpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
       # +1: see https://unix.stackexchange.com/questions/519092/what-is-the-logic-of-using-nproc-1-in-make-command
-      echo_run $makeX -C csources -j $(($logicalCpus + 1))
+      which $makeX && echo_run $makeX -C csources -j $(($logicalCpus + 1)) || build_nim_csources_via_script
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues

--- a/build_all.sh
+++ b/build_all.sh
@@ -28,7 +28,8 @@ build_nim_csources(){
       if [ "$unamestr" = 'FreeBSD' ]; then
         makeX=gmake
       fi
-      logicalCpus=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max || nproc)
+      # see https://stackoverflow.com/a/53427092/1426932
+      logicalCpus=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null)
       # +1: see https://unix.stackexchange.com/questions/519092/what-is-the-logic-of-using-nproc-1-in-make-command
       echo_run $makeX -C csources -j $(($logicalCpus + 1))
     fi

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,6 +1,7 @@
 #! /bin/sh
 
-# build development version of the compiler; can be rerun safely
+# build development version of the compiler; can be rerun safely.
+# arguments can be passed, eg `--cpu i386`
 
 set -u # error on undefined variables
 set -e # exit on first error
@@ -10,14 +11,20 @@ echo_run(){
   "$@"
 }
 
-[ -d csources ] || echo_run git clone --depth 1 https://github.com/nim-lang/csources.git
+[ -d csources ] || echo_run git clone -q --depth 1 https://github.com/nim-lang/csources.git
 
 nim_csources=bin/nim_csources
 build_nim_csources(){
   ## avoid changing dir in case of failure
   (
-    echo_run cd csources
-    echo_run sh build.sh $@
+    if [[ $# -ne 0 ]]; then
+      # some args were passed (eg: `--cpu i386`), need to call build.sh
+      echo_run cd csources
+      echo_run sh build.sh $@
+    else
+      # no args, use multhreaded (5X faster on 16 cores: 10s instead of 50s)
+      echo_run make -C csources -j
+    fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues
   # without having to rebuild from csources

--- a/build_all.sh
+++ b/build_all.sh
@@ -23,7 +23,13 @@ build_nim_csources(){
       echo_run sh build.sh $@
     else
       # no args, use multhreaded (5X faster on 16 cores: 10s instead of 50s)
-      echo_run make -C csources -j
+      makeX=make
+      unamestr=$(uname)
+      if [ "$unamestr" = 'FreeBSD' ]; then
+        makeX=gmake
+      fi
+      # `-j` implies `-j $(sysctl -n hw.ncpu)`
+      echo_run $makeX -C csources -j
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues

--- a/build_all.sh
+++ b/build_all.sh
@@ -28,8 +28,9 @@ build_nim_csources(){
       if [ "$unamestr" = 'FreeBSD' ]; then
         makeX=gmake
       fi
-      # `-j` implies `-j $(sysctl -n hw.ncpu)`
-      echo_run $makeX -C csources -j
+      logicalCpus=$([ $(uname) = 'Darwin' ] && sysctl -n hw.logicalcpu_max || nproc)
+      # +1: see https://unix.stackexchange.com/questions/519092/what-is-the-logic-of-using-nproc-1-in-make-command
+      echo_run $makeX -C csources -j $(($logicalCpus + 1))
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues


### PR DESCRIPTION
5X faster on my machine using 16 cores: 10s instead of 50s

## notes
* original version had `make -j` (meaning: `infinite jobs `) but this can be detrimental for performance, eg see https://unix.stackexchange.com/questions/316644/is-make-j-with-no-argument-dangerous
* there's also `make -j -l X` option (load average) but it may be hard to set a value that works across the board from low powered build bots to high powered dev machines


