### PR TITLE
[superseded] new `quoted`: outplace version of `addQuoted`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,7 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
+- Added `system.quoted`
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -54,7 +54,7 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-- Added `system.quoted`
+- Added `strutils.quoted`
 
 ## Library changes
 

--- a/compiler/unittest_light.nim
+++ b/compiler/unittest_light.nim
@@ -11,6 +11,8 @@ proc mismatch*[T](lhs: T, rhs: T): string =
       of '\n': result.add "\\n\n"
       else: result.add a
 
+  proc quoted(s: string): string = result.addQuoted s
+
   result.add "\n"
   result.add "lhs:{" & replaceInvisible(
       $lhs) & "}\nrhs:{" & replaceInvisible($rhs) & "}\n"

--- a/compiler/unittest_light.nim
+++ b/compiler/unittest_light.nim
@@ -11,8 +11,6 @@ proc mismatch*[T](lhs: T, rhs: T): string =
       of '\n': result.add "\\n\n"
       else: result.add a
 
-  proc quoted(s: string): string = result.addQuoted s
-
   result.add "\n"
   result.add "lhs:{" & replaceInvisible(
       $lhs) & "}\nrhs:{" & replaceInvisible($rhs) & "}\n"

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -987,7 +987,7 @@ when defined(windows) or defined(posix) or defined(nintendoswitch):
     ## When on Windows, it calls `quoteShellWindows proc
     ## <#quoteShellWindows,string>`_. Otherwise, calls `quoteShellPosix proc
     ## <#quoteShellPosix,string>`_.
-    ## See also: `system.quoted`.
+    ## See also: `strutils.quoted`.
     when defined(windows):
       return quoteShellWindows(s)
     else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -987,6 +987,7 @@ when defined(windows) or defined(posix) or defined(nintendoswitch):
     ## When on Windows, it calls `quoteShellWindows proc
     ## <#quoteShellWindows,string>`_. Otherwise, calls `quoteShellPosix proc
     ## <#quoteShellPosix,string>`_.
+    ## See also: `system.quoted`.
     when defined(windows):
       return quoteShellWindows(s)
     else:

--- a/lib/pure/parsesql.nim
+++ b/lib/pure/parsesql.nim
@@ -1225,7 +1225,7 @@ proc addMulti(s: var SqlWriter, n: SqlNode, sep = ',', prefix, suffix: char) =
       ra(n.sons[i], s)
     s.add(suffix)
 
-proc quoted(s: string): string =
+proc quoteSQL(s: string): string =
   "\"" & replace(s, "\"", "\"\"") & "\""
 
 proc ra(n: SqlNode, s: var SqlWriter) =
@@ -1236,9 +1236,9 @@ proc ra(n: SqlNode, s: var SqlWriter) =
     if allCharsInSet(n.strVal, {'\33'..'\127'}):
       s.add(n.strVal)
     else:
-      s.add(quoted(n.strVal))
+      s.add(quoteSQL(n.strVal))
   of nkQuotedIdent:
-    s.add(quoted(n.strVal))
+    s.add(quoteSQL(n.strVal))
   of nkStringLit:
     s.add(escape(n.strVal, "'", "'"))
   of nkBitStringLit:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2860,6 +2860,14 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
   ## Alias for isEmptyOrWhitespace
   result = isEmptyOrWhitespace(s)
 
+proc quoted*[T](a: T): string {.since: (1, 1).} =
+  ## outplace version of `system.addQuoted`
+  runnableExamples:
+    doAssert quoted(1) == "1"
+    doAssert quoted("1") == "\"1\""
+    doAssert quoted('c') == "'c'"
+  addQuoted(result, a)
+
 when isMainModule:
   proc nonStaticTests =
     doAssert formatBiggestFloat(1234.567, ffDecimal, -1) == "1234.567000"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2711,14 +2711,7 @@ proc addQuoted*[T](s: var string, x: T) =
   ## Users may overload `addQuoted` for custom (string-like) types if
   ## they want to implement a customized element representation.
   ##
-  ## .. code-block:: Nim
-  ##   var tmp = ""
-  ##   tmp.addQuoted(1)
-  ##   tmp.add(", ")
-  ##   tmp.addQuoted("string")
-  ##   tmp.add(", ")
-  ##   tmp.addQuoted('c')
-  ##   assert(tmp == """1, "string", 'c'""")
+  ## See also: `quoted` (outplace version), `os.quoteShell`.
   when T is string or T is cstring:
     s.add("\"")
     for c in x:
@@ -2742,6 +2735,14 @@ proc addQuoted*[T](s: var string, x: T) =
     s.add(x)
   else:
     s.add($x)
+
+proc quoted*[T](a: T): string {.since: (1, 1).} =
+  ## outplace version of `addQuoted`
+  runnableExamples:
+    doAssert quoted(1) == "1"
+    doAssert quoted("1") == "\"1\""
+    doAssert quoted('c') == "'c'"
+  addQuoted(result, a)
 
 proc locals*(): RootObj {.magic: "Plugin", noSideEffect.} =
   ## Generates a tuple constructor expression listing all the local variables

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2711,7 +2711,16 @@ proc addQuoted*[T](s: var string, x: T) =
   ## Users may overload `addQuoted` for custom (string-like) types if
   ## they want to implement a customized element representation.
   ##
-  ## See also: `quoted` (outplace version), `os.quoteShell`.
+  ## See also: `strutils.quoted` (outplace version), `os.quoteShell`.
+  runnableExamples:
+    var tmp = ""
+    tmp.addQuoted(1)
+    tmp.add(", ")
+    tmp.addQuoted("string")
+    tmp.add(", ")
+    tmp.addQuoted('c')
+    assert tmp == """1, "string", 'c'"""
+
   when T is string or T is cstring:
     s.add("\"")
     for c in x:
@@ -2735,14 +2744,6 @@ proc addQuoted*[T](s: var string, x: T) =
     s.add(x)
   else:
     s.add($x)
-
-proc quoted*[T](a: T): string {.since: (1, 1).} =
-  ## outplace version of `addQuoted`
-  runnableExamples:
-    doAssert quoted(1) == "1"
-    doAssert quoted("1") == "\"1\""
-    doAssert quoted('c') == "'c'"
-  addQuoted(result, a)
 
 proc locals*(): RootObj {.magic: "Plugin", noSideEffect.} =
   ## Generates a tuple constructor expression listing all the local variables

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -578,10 +578,6 @@ proc norm(s: var string) =
     s = tmp
   s = s.strip
 
-proc quoted(a: string): string =
-  # todo: consider moving to system.nim
-  result.addQuoted(a)
-
 proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =
   ## returns a list of tests that have problems
   var specs: seq[TSpec] = @[]


### PR DESCRIPTION
`quoted` is what's most convenient to use most of the time (addQuoted when efficiency is needed); I'm putting it in system (yes, more bloat) because addQuoted is already there 

The alternative I considered was to put it under strutils but this seemed worse: strutils carries a bunch of dependencies, and it'd be awkward to split quoted(outplace) vs addQuoted(inplace) in different modules