### PR TITLE
fix `is` with generic types; fix `genericHead(Foo[T])`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -976,8 +976,9 @@ const
     tyPointer,
     tyOpenArray, tyString, tyCString, tyInt..tyInt64, tyFloat..tyFloat128,
     tyUInt..tyUInt64}
-  IntegralTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
+  NumberLikeTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
     tyFloat..tyFloat128, tyUInt..tyUInt64}
+  IntegralTypes* = NumberLikeTypes + {tyEnum} # weird name because it contains tyFloat
   ConstantDataTypes*: TTypeKinds = {tyArray, tySet,
                                     tyTuple, tySequence}
   NilableTypes*: TTypeKinds = {tyPointer, tyCString, tyRef, tyPtr,

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -11,6 +11,7 @@
 
 import
   lineinfos, hashes, options, ropes, idents, idgen, int128
+from strutils import toLowerAscii
 
 export int128
 
@@ -1909,3 +1910,16 @@ proc canRaise*(fn: PNode): bool =
     result = fn.typ != nil and fn.typ.n != nil and ((fn.typ.n[0].len < effectListLen) or
       (fn.typ.n[0][exceptionEffects] != nil and
       fn.typ.n[0][exceptionEffects].safeLen > 0))
+
+proc toHumanStrImpl[T](kind: T, num: static int): string =
+  result = $kind
+  result = result[num..^1]
+  result[0] = result[0].toLowerAscii
+
+proc toHumanStr*(kind: TSymKind): string =
+  ## strips leading `sk`
+  result = toHumanStrImpl(kind, 2)
+
+proc toHumanStr*(kind: TTypeKind): string =
+  ## strips leading `tk`
+  result = toHumanStrImpl(kind, 2)

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -977,9 +977,8 @@ const
     tyPointer,
     tyOpenArray, tyString, tyCString, tyInt..tyInt64, tyFloat..tyFloat128,
     tyUInt..tyUInt64}
-  NumberLikeTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
-    tyFloat..tyFloat128, tyUInt..tyUInt64}
-  IntegralTypes* = NumberLikeTypes + {tyEnum} # weird name because it contains tyFloat
+  IntegralTypes* = {tyBool, tyChar, tyEnum, tyInt..tyInt64,
+    tyFloat..tyFloat128, tyUInt..tyUInt64} # weird name because it contains tyFloat
   ConstantDataTypes*: TTypeKinds = {tyArray, tySet,
                                     tyTuple, tySequence}
   NilableTypes*: TTypeKinds = {tyPointer, tyCString, tyRef, tyPtr,

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -288,10 +288,6 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      proc toHumanStr(kind: TSymKind): string =
-        result = $kind
-        assert result.startsWith "sk"
-        result = result[2..^1].toLowerAscii
       result &= "\n  found '$1' of kind '$2'" % [getSymRepr(c.config, sym), sym.kind.toHumanStr]
       sym = nextOverloadIter(o, c, f)
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -396,12 +396,21 @@ proc isOpImpl(c: PContext, n: PNode, flags: TExprFlags): PNode =
     else:
       res = false
   else:
-    maybeLiftType(t2, c, n.info)
+    if t1.skipTypes({tyAlias}).kind != tyGenericBody:
+      maybeLiftType(t2, c, n.info)
+    else:
+      #[
+      for this case:
+      type Foo = object[T]
+      Foo is Foo
+      ]#
+      discard
     var m = newCandidate(c, t2)
     if efExplain in flags:
       m.diagnostics = @[]
       m.diagnosticsEnabled = true
     res = typeRel(m, t2, t1) >= isSubtype # isNone
+    # `res = sameType(t1, t2)` would be wrong, eg for `int is (int|float)`
 
   result = newIntNode(nkIntLit, ord(res))
   result.typ = n.typ

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -396,7 +396,7 @@ proc isOpImpl(c: PContext, n: PNode, flags: TExprFlags): PNode =
     else:
       res = false
   else:
-    if t1.skipTypes({tyAlias}).kind != tyGenericBody:
+    if t1.skipTypes({tyGenericInst, tyAlias, tySink, tyDistinct}).kind != tyGenericBody:
       maybeLiftType(t2, c, n.info)
     else:
       #[

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -173,8 +173,8 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     # of tySequence:
     #   var resType = newType(tySequence, operand.owner)
     #   result = toNode(resType, traitCall.info) # doesn't work yet
-    else: # there might be more kinds to consider, eg `tySequence` etc
-      localError(c.config, traitCall.info, "expected generic instantiation, got: " & $(arg.kind, typeToString(operand)))
+    else: # there might be more kinds we can support later, eg `tySequence` etc
+      localError(c.config, traitCall.info, "expected $1, got: $2 of type $3" % [tyGenericInst.toHumanStr, arg.kind.toHumanStr, typeToString(operand)])
       result = newType(tyError, context).toNode(traitCall.info)
   of "stripGenericParams":
     result = uninstantiate(operand).toNode(traitCall.info)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -170,11 +170,11 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     case arg.kind
     of tyGenericInst:
       result = getTypeDescNode(arg.base, operand.owner, traitCall.info)
-    # of tySequence:
+    # of tySequence: # this doesn't work
     #   var resType = newType(tySequence, operand.owner)
     #   result = toNode(resType, traitCall.info) # doesn't work yet
-    else: # there might be more kinds we can support later, eg `tySequence` etc
-      localError(c.config, traitCall.info, "expected $1, got: $2 of type $3" % [tyGenericInst.toHumanStr, arg.kind.toHumanStr, typeToString(operand)])
+    else:
+      localError(c.config, traitCall.info, "expected generic type, got: type $2 of kind $1" % [arg.kind.toHumanStr, typeToString(operand)])
       result = newType(tyError, context).toNode(traitCall.info)
   of "stripGenericParams":
     result = uninstantiate(operand).toNode(traitCall.info)

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -167,9 +167,13 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     result.info = traitCall.info
   of "genericHead":
     var arg = operand
-    if arg.kind == tyGenericInst:
+    case arg.kind
+    of tyGenericInst:
       result = getTypeDescNode(arg.base, operand.owner, traitCall.info)
-    else:
+    # of tySequence:
+    #   var resType = newType(tySequence, operand.owner)
+    #   result = toNode(resType, traitCall.info) # doesn't work yet
+    else: # there might be more kinds to consider, eg `tySequence` etc
       localError(c.config, traitCall.info, "expected generic instantiation, got: " & $(arg.kind, typeToString(operand)))
       result = newType(tyError, context).toNode(traitCall.info)
   of "stripGenericParams":

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -165,15 +165,6 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     result = newIntNode(nkIntLit, operand.len - ord(operand.kind==tyProc))
     result.typ = newType(tyInt, context)
     result.info = traitCall.info
-  of "getTypeid":
-    var arg = operand
-    if arg.kind in NumberLikeTypes:
-      # needed otherwise we could get different ids, see tests
-      arg = getSysType(c.graph, traitCall[1].info, arg.kind)
-    result = newIntNode(nkIntLit, arg.id)
-      # `id` better than cast[int](arg) so that it's reproducible across compiles
-    result.typ = getSysType(c.graph, traitCall[1].info, tyInt)
-    result.info = traitCall.info
   of "genericHead":
     var arg = operand
     if arg.kind == tyGenericInst:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1403,7 +1403,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
     # not generic.
-    localError(c.config, n.info, errNoGenericParamsAllowedForX % $(s.name.s, t.kind.toHumanStr))
+    localError(c.config, n.info, errNoGenericParamsAllowedForX % s.name.s)
     return newOrPrevType(tyError, prev, c)
   else:
     var m = newCandidate(c, t)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1403,7 +1403,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
     # not generic.
-    localError(c.config, n.info, errNoGenericParamsAllowedForX % $(s.name.s, t.kind))
+    localError(c.config, n.info, errNoGenericParamsAllowedForX % $(s.name.s, t.kind.toHumanStr))
     return newOrPrevType(tyError, prev, c)
   else:
     var m = newCandidate(c, t)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1781,7 +1781,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       else:
         assignType(prev, s.typ)
         # bugfix: keep the fresh id for aliases to integral types:
-        if s.typ.kind notin NumberLikeTypes:
+        if s.typ.kind notin {tyBool, tyChar, tyInt..tyInt64, tyFloat..tyFloat128,
+                             tyUInt..tyUInt64}:
           prev.id = s.typ.id
         result = prev
   of nkSym:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -16,16 +16,6 @@ export system.`$` # for backward compatibility
 
 include "system/inclrtl"
 
-proc getTypeid*(t: typedesc): int {.magic: "TypeTrait", since: (1, 1).} =
-  ## returns a unique id representing a type; the id is stable across
-  ## recompilations of the same program, but may differ if the program source
-  ## changes.
-  runnableExamples:
-    type Foo[T] = object
-    type Foo2 = Foo
-    doAssert Foo[int].getTypeid == Foo2[type(1)].getTypeid
-    doAssert Foo[int].getTypeid != Foo[float].getTypeid
-
 proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ## Returns the name of the given type.
   ##

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -16,6 +16,16 @@ export system.`$` # for backward compatibility
 
 include "system/inclrtl"
 
+proc getTypeid*(t: typedesc): int {.magic: "TypeTrait", since: (1, 1).} =
+  ## returns a unique id representing a type; the id is stable across
+  ## recompilations of the same program, but may differ if the program source
+  ## changes.
+  runnableExamples:
+    type Foo[T] = object
+    type Foo2 = Foo
+    doAssert Foo[int].getTypeid == Foo2[type(1)].getTypeid
+    doAssert Foo[int].getTypeid != Foo[float].getTypeid
+
 proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ## Returns the name of the given type.
   ##

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -134,6 +134,17 @@ block genericHead:
   type FooInst = Foo[int, float]
   type Foo2 = genericHead(FooInst)
   doAssert Foo2 is Foo # issue #13066
+
+  block:
+    type Goo[T] = object
+    type Moo[U] = object
+    type Hoo = Goo[Moo[float]]
+    type Koo = genericHead(Hoo)
+    doAssert Koo is Goo
+    doAssert genericParams(Hoo) is (Moo[float],)
+    doAssert genericParams(Hoo).get(0) is Moo[float]
+    doAssert genericHead(genericParams(Hoo).get(0)) is Moo
+
   type Foo2Inst = Foo2[int, float]
   doAssert FooInst.default == Foo2Inst.default
   doAssert FooInst.default.x2 == 0.0

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -143,3 +143,4 @@ block genericHead:
   doAssert not compiles(genericHead(Foo))
   type Bar = object
   doAssert not compiles(genericHead(Bar))
+  # doAssert seq[int].genericHead is seq

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -127,32 +127,6 @@ static:
   doAssert x.T is string          # true
   doAssert x.raw_buffer is seq
 
-block:
-  const c1 = getTypeid(type(12))
-  const a1 = getTypeid(type(12))
-  const a2 = getTypeid(type(12))
-  let a3 = getTypeid(type(12))
-  doAssert a1 == a2
-    # we need to check that because nim uses different id's
-    # for different instances of tyInt (etc), so we make sure implementation of
-    # `getTypeid` is robust to that
-  doAssert a1 == a3
-  doAssert getTypeid(type(12.0)) != getTypeid(type(12))
-  doAssert getTypeid(type(12.0)) == getTypeid(float)
-
-  type Foo = object
-    x1: int
-
-  type FooT[T] = object
-    x1: int
-  type Foo2 = Foo
-  type FooT2 = FooT
-  doAssert Foo.getTypeid == Foo2.getTypeid
-  doAssert FooT2.getTypeid == FooT.getTypeid
-  doAssert FooT2[float].getTypeid == FooT[type(1.2)].getTypeid
-  doAssert FooT2[float].getTypeid != FooT[type(1)].getTypeid
-  doAssert Foo.x1.type.getTypeid == int.getTypeid
-
 block genericHead:
   type Foo[T1,T2] = object
     x1: T1

--- a/tests/types/tisopr.nim
+++ b/tests/types/tisopr.nim
@@ -89,3 +89,23 @@ proc test[T](x: T) =
     echo "no"
 
 test(7)
+
+block:
+  # bug #13066
+  type Bar[T1,T2] = object
+  type Foo[T1,T2] = object
+  type Foo2 = Foo
+  doAssert Foo2 is Foo
+  doAssert Foo is Foo2
+  doAssert Foo is Foo
+  doAssert Foo2 is Foo2
+  doAssert Foo2 isnot Bar
+  doAssert Foo[int,float] is Foo2[int,float]
+
+  # other
+  doAssert Foo[int,float] isnot Foo2[float,float]
+  doAssert Foo[int,float] is Foo2
+  doAssert Foo[int,float|int] is Foo2
+  doAssert Foo2[int,float|int] is Foo
+  doAssert Foo2[int,float|int] isnot Bar
+  doAssert int is (int|float)


### PR DESCRIPTION
* fix #9855
* fix #13066 (both the regression since 0.20 as well as the long standing issue mentioned there)
* fix typetraits.genericHead (was broken since forever)
* `type Foo[T] = object; type Foo2 = Foo` (or `type Foo2 = genericHead(Foo[int])`) will now make Foo2 an alias of Foo instead of a distinct type (just like for non-generic types)

## note
support for `seq[T]` can be added in future PR's (cf #10143)
