### PR TITLE
[TODO] miscellaneous bug fixes (part 3) 

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -22,9 +22,9 @@ tasks:
 - test: |
     cd Nim
     if ! ./koch runCI; then
-       nim c -r tools/ci_testresults.nim
-       exit 1
-     fi
+      nim c -r tools/ci_testresults.nim
+      exit 1
+    fi
 triggers:
 - action: email
   condition: failure

--- a/compiler/magicsys.nim
+++ b/compiler/magicsys.nim
@@ -68,7 +68,7 @@ proc getSysType*(g: ModuleGraph; info: TLineInfo; kind: TTypeKind): PType =
     of tyUInt64: result = sysTypeFromName("uint64")
     of tyFloat: result = sysTypeFromName("float")
     of tyFloat32: result = sysTypeFromName("float32")
-    of tyFloat64: return sysTypeFromName("float64")
+    of tyFloat64: result = sysTypeFromName("float64")
     of tyFloat128: result = sysTypeFromName("float128")
     of tyBool: result = sysTypeFromName("bool")
     of tyChar: result = sysTypeFromName("char")
@@ -79,7 +79,9 @@ proc getSysType*(g: ModuleGraph; info: TLineInfo; kind: TTypeKind): PType =
     else: internalError(g.config, "request for typekind: " & $kind)
     g.sysTypes[kind] = result
   if result.kind != kind:
-    internalError(g.config, "wanted: " & $kind & " got: " & $result.kind)
+    if kind == tyFloat64 and result.kind == tyFloat: discard # because of aliasing
+    else:
+      internalError(g.config, "wanted: " & $kind & " got: " & $result.kind)
   if result == nil: internalError(g.config, "type not found: " & $kind)
 
 proc resetSysTypes*(g: ModuleGraph) =

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -134,7 +134,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     newTypeWithSons(context, kind, sons).toNode(traitCall.info)
 
   if operand.kind == tyGenericParam or (traitCall.len > 2 and operand2.kind == tyGenericParam):
-    return traitCall  ## tpo early to evaluate
+    return traitCall  ## too early to evaluate
     
   let s = trait.sym.name.s
   case s

--- a/koch.nim
+++ b/koch.nim
@@ -124,13 +124,13 @@ proc csource(args: string) =
 
 proc bundleC2nim(args: string) =
   if not dirExists("dist/c2nim/.git"):
-    exec("git clone https://github.com/nim-lang/c2nim.git dist/c2nim")
+    exec("git clone -q https://github.com/nim-lang/c2nim.git dist/c2nim")
   nimCompile("dist/c2nim/c2nim",
              options = "--noNimblePath --path:. " & args)
 
 proc bundleNimbleExe(latest: bool, args: string) =
   if not dirExists("dist/nimble/.git"):
-    exec("git clone https://github.com/nim-lang/nimble.git dist/nimble")
+    exec("git clone -q https://github.com/nim-lang/nimble.git dist/nimble")
   if not latest:
     withDir("dist/nimble"):
       exec("git fetch")
@@ -152,7 +152,7 @@ proc buildNimble(latest: bool, args: string) =
         while dirExists("dist/nimble" & $id):
           inc id
         installDir = "dist/nimble" & $id
-      exec("git clone https://github.com/nim-lang/nimble.git " & installDir)
+      exec("git clone -q https://github.com/nim-lang/nimble.git " & installDir)
     withDir(installDir):
       if latest:
         exec("git checkout -f master")

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -107,7 +107,7 @@ block genericParams:
 # bug 13095
 
 type
-  CpuStorage{.shallow.}[T] = ref object
+  CpuStorage[T] {.shallow.} = ref object
     when supportsCopyMem(T):
       raw_buffer*: ptr UncheckedArray[T] # 8 bytes
       memalloc*: pointer                 # 8 bytes

--- a/tools/ci_testresults.nim
+++ b/tools/ci_testresults.nim
@@ -2,7 +2,7 @@
 
 import os, json, sets, strformat
 
-const skip = toSet(["reDisabled", "reIgnored", "reSuccess", "reJoined"])
+const skip = toHashSet(["reDisabled", "reIgnored", "reSuccess", "reJoined"])
 
 when isMainModule:
   for fn in walkFiles("testresults/*.json"):


### PR DESCRIPTION
* bugfix: sysTypeFromName("float64") was never cached
* avoid some warnings
* git clone: use -q (avoids a lot of noise in CI etc)

## TODO after this PR
- [ ] investigate whether all 3 (tyFloat32, tyFloa64, tyFloat) are needed: see https://github.com/nim-lang/Nim/pull/13304#discussion_r373894876