### PR TITLE
new: typetraits.getTypeId

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -167,9 +167,9 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     if arg.kind in NumberLikeTypes:
       # needed otherwise we could get different ids, see tests
       arg = getSysType(c.graph, traitCall[1].info, arg.kind)
-    result = newIntNode(nkIntLit, arg.id)
+    result = newStrNode(nkStrLit, $arg.id)
       # `id` better than cast[int](arg) so that it's reproducible across compiles
-    result.typ = getSysType(c.graph, traitCall[1].info, tyInt)
+    result.typ = getSysType(c.graph, traitCall[1].info, tyString)
     result.info = traitCall.info
   of "genericHead":
     var arg = operand

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -162,7 +162,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     result = newIntNode(nkIntLit, operand.len - ord(operand.kind==tyProc))
     result.typ = newType(tyInt, nextTypeId c.idgen, context)
     result.info = traitCall.info
-  of "getTypeid":
+  of "getTypeIdImpl":
     var arg = operand
     if arg.kind in IntegralTypes - {tyEnum}:
       # needed otherwise we could get different ids, see tests

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -162,6 +162,15 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     result = newIntNode(nkIntLit, operand.len - ord(operand.kind==tyProc))
     result.typ = newType(tyInt, nextTypeId c.idgen, context)
     result.info = traitCall.info
+  of "getTypeid":
+    var arg = operand
+    if arg.kind in NumberLikeTypes:
+      # needed otherwise we could get different ids, see tests
+      arg = getSysType(c.graph, traitCall[1].info, arg.kind)
+    result = newIntNode(nkIntLit, arg.id)
+      # `id` better than cast[int](arg) so that it's reproducible across compiles
+    result.typ = getSysType(c.graph, traitCall[1].info, tyInt)
+    result.info = traitCall.info
   of "genericHead":
     var arg = operand
     case arg.kind

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -164,7 +164,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     result.info = traitCall.info
   of "getTypeid":
     var arg = operand
-    if arg.kind in NumberLikeTypes:
+    if arg.kind in IntegralTypes - {tyEnum}:
       # needed otherwise we could get different ids, see tests
       arg = getSysType(c.graph, traitCall[1].info, arg.kind)
     result = newStrNode(nkStrLit, $arg.id)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1927,7 +1927,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       else:
         assignType(prev, s.typ)
         # bugfix: keep the fresh id for aliases to integral types:
-        if s.typ.kind notin NumberLikeTypes:
+        if s.typ.kind notin IntegralTypes - {tyEnum}:
           prev.itemId = s.typ.itemId
         result = prev
   of nkSym:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1456,7 +1456,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
     # not generic.
-    localError(c.config, n.info, errNoGenericParamsAllowedForX % s.name.s)
+    localError(c.config, n.info, errNoGenericParamsAllowedForX % $(s.name.s, t.kind))
     return newOrPrevType(tyError, prev, c)
   else:
     var m = newCandidate(c, t)
@@ -1927,8 +1927,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       else:
         assignType(prev, s.typ)
         # bugfix: keep the fresh id for aliases to integral types:
-        if s.typ.kind notin {tyBool, tyChar, tyInt..tyInt64, tyFloat..tyFloat128,
-                             tyUInt..tyUInt64}:
+        if s.typ.kind notin NumberLikeTypes:
           prev.itemId = s.typ.itemId
         result = prev
   of nkSym:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1456,7 +1456,7 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   elif t.kind != tyGenericBody:
     # we likely got code of the form TypeA[TypeB] where TypeA is
     # not generic.
-    localError(c.config, n.info, errNoGenericParamsAllowedForX % $(s.name.s, t.kind))
+    localError(c.config, n.info, errNoGenericParamsAllowedForX % s.name.s)
     return newOrPrevType(tyError, prev, c)
   else:
     var m = newCandidate(c, t)
@@ -1927,7 +1927,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       else:
         assignType(prev, s.typ)
         # bugfix: keep the fresh id for aliases to integral types:
-        if s.typ.kind notin IntegralTypes - {tyEnum}:
+        # could use simply: `IntegralTypes - {tyEnum}`
+        if s.typ.kind notin {tyBool, tyChar, tyInt..tyInt64, tyFloat..tyFloat128,
+                             tyUInt..tyUInt64}:
           prev.itemId = s.typ.itemId
         result = prev
   of nkSym:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -36,9 +36,9 @@ type
 proc `==`*(x, y: TypeId): bool {.borrow.}
 proc `$`*(x: TypeId): string {.borrow.}
 
-proc getTypeIdImpl(t: typedesc): string {.magic: "TypeTrait", since: (1, 1).}
+proc getTypeIdImpl(t: typedesc): string {.magic: "TypeTrait", since: (1, 5, 1).}
 
-proc getTypeId*(t: typedesc): TypeId {.since: (1, 1).} =
+proc getTypeId*(t: typedesc): TypeId {.since: (1, 5, 1).} =
   ## Returns a unique id representing a type; the id is stable across
   ## recompilations of the same program, but may differ if the program source
   ## changes. In particular serializing it will be meaningless after source change

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -30,8 +30,8 @@ runnableExamples:
   type C[T] = enum h0 = 2, h1 = 4
   assert C[float] is HoleyEnum
 
-proc getTypeid*(t: typedesc): int {.magic: "TypeTrait", since: (1, 1).} =
-  ## returns a unique id representing a type; the id is stable across
+proc getTypeid*(t: typedesc): string {.magic: "TypeTrait", since: (1, 1).} =
+  ## returns a unique string id representing a type; the id is stable across
   ## recompilations of the same program, but may differ if the program source
   ## changes.
   runnableExamples:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -34,17 +34,26 @@ type
   TypeId* = distinct string ## opaque, used by `getTypeId`
 
 proc `==`*(x, y: TypeId): bool {.borrow.}
+proc `$`*(x: TypeId): string {.borrow.}
 
 proc getTypeIdImpl(t: typedesc): string {.magic: "TypeTrait", since: (1, 1).}
 
 proc getTypeId*(t: typedesc): TypeId {.since: (1, 1).} =
   ## Returns a unique id representing a type; the id is stable across
   ## recompilations of the same program, but may differ if the program source
-  ## changes. In particular serializing it will be meaningless after source
-  ## change + recompilation: ids are reused in an un-specified manner.
+  ## changes. In particular serializing it will be meaningless after source change
+  ## and recompilation: ids are reused in an un-specified manner.
   ##
-  ## Example use cases: using ids as keys in Tables (eg for Type hashing),  for Comparisons? Store into sets to prevent recursions during type traversal?
-  ## Example use case: passing a callback
+  ## Example use cases that are impossible / hard without such feature:
+  ## 1: using ids as keys in Tables (eg for Type hashing) or to prevent recursions during type traversal
+  ## 2: passing a callback proc that can handle multiple types to a routine
+  ## 3: defining an exportc proc that can handle multiple types, this can be used
+  ##    as workaround for lack of cyclic imports
+  ##
+  ## See examples for those use cases in ttypetraits.nim; in each case the
+  ## callback is called via:
+  ## `callbackFun(cast[pointer](a), getTypeId(type(a)), ...)`
+
   runnableExamples:
     type Foo[T] = object
     type Foo2 = Foo

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -30,7 +30,17 @@ runnableExamples:
   type C[T] = enum h0 = 2, h1 = 4
   assert C[float] is HoleyEnum
 
-proc name*(t: typedesc): string {.magic: "TypeTrait".} =
+proc getTypeid*(t: typedesc): int {.magic: "TypeTrait", since: (1, 1).} =
+  ## returns a unique id representing a type; the id is stable across
+  ## recompilations of the same program, but may differ if the program source
+  ## changes.
+  runnableExamples:
+    type Foo[T] = object
+    type Foo2 = Foo
+    doAssert Foo[int].getTypeid == Foo2[type(1)].getTypeid
+    doAssert Foo[int].getTypeid != Foo[float].getTypeid
+
+proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ## Returns the name of the given type.
   ##
   ## Alias for `system.\`$\`(t) <dollars.html#$,typedesc>`_ since Nim v0.20.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -57,11 +57,11 @@ proc getTypeId*(t: typedesc): TypeId {.since: (1, 1).} =
   runnableExamples:
     type Foo[T] = object
     type Foo2 = Foo
-    doAssert Foo[int].getTypeId == Foo2[type(1)].getTypeId
-    doAssert Foo[int].getTypeId != Foo[float].getTypeId
+    assert Foo[int].getTypeId == Foo2[type(1)].getTypeId
+    assert Foo[int].getTypeId != Foo[float].getTypeId
   TypeId(getTypeIdImpl(t))
 
-proc name*(t: typedesc): string {.magic: "TypeTrait".}
+proc name*(t: typedesc): string {.magic: "TypeTrait".} =
   ## Returns the name of the given type.
   ##
   ## Alias for `system.\`$\`(t) <dollars.html#$,typedesc>`_ since Nim v0.20.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -30,7 +30,9 @@ runnableExamples:
   type C[T] = enum h0 = 2, h1 = 4
   assert C[float] is HoleyEnum
 
-proc getTypeid*(t: typedesc): string {.magic: "TypeTrait", since: (1, 1).} =
+type
+  Typeid* = distinct string ## opaque, used by `getTypeid`
+proc getTypeid*(t: typedesc): Typeid {.magic: "TypeTrait", since: (1, 1).} =
   ## returns a unique string id representing a type; the id is stable across
   ## recompilations of the same program, but may differ if the program source
   ## changes.

--- a/tests/metatype/mtypetraits_impl.nim
+++ b/tests/metatype/mtypetraits_impl.nim
@@ -1,0 +1,14 @@
+{.used.}
+
+import std/typetraits
+import mtypetraits_types
+import ttypetraits
+
+proc callbackFun(a: pointer, id: TypeId): string {.exportc.} =
+  case id
+  of getTypeid(Foo1): $("custom1", cast[Foo1](a))
+  of getTypeid(Foo2): $("custom2", cast[Foo2](a))
+  of getTypeid(Foo3): $("custom3", cast[Foo3](a))
+  else:
+    doAssert false, $id
+    ""

--- a/tests/metatype/mtypetraits_types.nim
+++ b/tests/metatype/mtypetraits_types.nim
@@ -1,0 +1,10 @@
+type Foo1* = object
+  x1*: int
+
+type Foo2* = object
+  x2*: int
+
+import std/typetraits
+proc callbackFun(a: pointer, id: TypeId): string {.importc.}
+
+proc callbackFun*[T](a: T): string = callbackFun(cast[pointer](a), getTypeid(T))

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -379,7 +379,7 @@ block: # getTypeId
 
   doAssert int.getTypeId is TypeId
 
-block: # example use case for `getTypeId`:
+block: # example use case for `getTypeId`: passing a callback that handles multiple types
   ## this would be in a library, say prettys.nim:
   type Callback = proc(result: var string, a: pointer, id: TypeId): bool
 
@@ -433,3 +433,23 @@ block: # example use case for `getTypeId`:
     doAssert pretty(f, callback2) == """(b1: ("custom2:", 12), b2: abc, )"""
 
   main()
+
+type Foo3* = object
+  x3*: int
+
+import ./mtypetraits_types
+
+block:
+  # example use case for `getTypeId`: exportc proc that handles multiple types.
+  # This can be used in cases where we want to define implementation for a
+  # proc in a separate module (here, mtypetraits_impl), to avoid cyclic import
+  # issues or avoid dragging many dependencies for users of the proc, which can
+  # be declared in another import module (here, mtypetraits_types).
+  # This mimicks the use of headers vs source files in C.
+
+  doAssert callbackFun(Foo1(x1: 1)) == """("custom1", (x1: 1))"""
+  doAssert callbackFun(Foo2(x2: 2)) == """("custom2", (x2: 2))"""
+  doAssert callbackFun(Foo3(x3: 3)) == """("custom3", (x3: 3))"""
+
+import ./mtypetraits_impl
+  # this could be imported from any module; it defines our exportc proc

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -350,3 +350,29 @@ block: # enum.len
     doAssert MyEnum.enumLen == 4
     doAssert OtherEnum.enumLen == 3
     doAssert MyFlag.enumLen == 4
+
+block: # getTypeid
+  const c1 = getTypeid(type(12))
+  const a1 = getTypeid(type(12))
+  const a2 = getTypeid(type(12))
+  let a3 = getTypeid(type(12))
+  doAssert a1 == a2
+    # we need to check that because nim uses different id's
+    # for different instances of tyInt (etc), so we make sure implementation of
+    # `getTypeid` is robust to that
+  doAssert a1 == a3
+  doAssert getTypeid(type(12.0)) != getTypeid(type(12))
+  doAssert getTypeid(type(12.0)) == getTypeid(float)
+
+  type Foo = object
+    x1: int
+
+  type FooT[T] = object
+    x1: int
+  type Foo2 = Foo
+  type FooT2 = FooT
+  doAssert Foo.getTypeid == Foo2.getTypeid
+  doAssert FooT2.getTypeid == FooT.getTypeid
+  doAssert FooT2[float].getTypeid == FooT[type(1.2)].getTypeid
+  doAssert FooT2[float].getTypeid != FooT[type(1)].getTypeid
+  doAssert Foo.x1.type.getTypeid == int.getTypeid


### PR DESCRIPTION
new: typetraits.getTypeId: get a unique id (int) for a type (note: static, not dynamic), can be used for type equality, reliable type hashing (more reliable than via `$T`), + many other use cases that would be really hard without this 

this is much simpler and more efficient than something like getTypeId from https://github.com/yglukhov/variant/blob/master/variant.nim which relies on stringification


