### PR TITLE
new outplace operator: `doAssert @[2,1,3].>sort() == @[1,2,3]`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,7 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
+- Added new `sugar` `.@` outplace operator: `@[2,1,3].@sort()`
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -54,7 +54,7 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-- Added new `outplaces` module with `.@` outplace operator: `@[2,1,3].@sort()` to avoid duplicating API's
+- Added new `outplaces` module with `./` outplace operator: `@[2,1,3]./sort()` to avoid duplicating API's
   with inplace and outplace variants; instead only the inplace variant is needed now.
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -54,7 +54,8 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-- Added new `sugar` `.@` outplace operator: `@[2,1,3].@sort()`
+- Added new `outplaces` module with `.@` outplace operator: `@[2,1,3].@sort()` to avoid duplicating API's
+  with inplace and outplace variants; instead only the inplace variant is needed now.
 
 ## Library changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -51,7 +51,7 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-- Added new `outplaces` module with `./` outplace operator: `@[2,1,3]./sort()`.
+- Added new `outplaces` module with `.>` outplace operator: `@[2,1,3].>sort()`.
   It turn in-place algorithms like `sort` and `shuffle` into operations that work on a copy of
   the data and return the mutated copy. As the existing `sorted` does. This avoids duplicating API's with
   outplace variants.

--- a/changelog.md
+++ b/changelog.md
@@ -37,9 +37,6 @@
 - introduced new procs in `tables.nim`: `OrderedTable.pop`, `CountTable.del`,
   `CountTable.pop`, `Table.pop`
 - To `strtabs.nim`, added `StringTable.clear` overload that reuses the existing mode.
-- Added `sugar.outplace` for turning in-place algorithms like `sort` and `shuffle` into
-  operations that work on a copy of the data and return the mutated copy. As the existing
-  `sorted` does.
 - Added `sugar.collect` that does comprehension for seq/set/table collections.
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
@@ -54,8 +51,10 @@
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-- Added new `outplaces` module with `./` outplace operator: `@[2,1,3]./sort()` to avoid duplicating API's
-  with inplace and outplace variants; instead only the inplace variant is needed now.
+- Added new `outplaces` module with `./` outplace operator: `@[2,1,3]./sort()`.
+  It turn in-place algorithms like `sort` and `shuffle` into operations that work on a copy of
+  the data and return the mutated copy. As the existing `sorted` does. This avoids duplicating API's with
+  outplace variants.
 
 ## Library changes
 

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -223,7 +223,7 @@ proc replaceOutplace(lhs, n: NimNode): NimNode =
   of nnkCall:
     result = newCall(bindSym"outplace", [lhs, n])
   else:
-    doAssert false, "\n" & n.treeRepr
+    doAssert false, "unpexpected kind: " & $n.kind
 
 macro `.@`*(lhs, rhs): untyped {.since: (1,1).} =
   ## outplace operator, syntax sugar for `outplace`

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -226,16 +226,6 @@ proc transLastStmt(n, res, bracketExpr: NimNode): (NimNode, NimNode, NimNode) {.
     template adder(res, v) = res.add(v)
     result[0] = getAst(adder(res, n))
 
-macro outplace*[T](arg: T, call: untyped; inplaceArgPosition: static[int] = 1): T {.since: (1, 1), deprecated: "use outplaces.`./`".} =
-  expectKind call, nnkCallKinds
-  let tmp = genSym(nskVar, "outplaceResult")
-  var callsons = call[0..^1]
-  callsons.insert(tmp, inplaceArgPosition)
-  result = newTree(nnkStmtListExpr,
-    newVarStmt(tmp, arg),
-    copyNimNode(call).add callsons,
-    tmp)
-
 macro collect*(init, body: untyped): untyped {.since: (1, 1).} =
   ## Comprehension for seq/set/table collections. ``init`` is
   ## the init call, and so custom collections are supported.

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -226,7 +226,7 @@ proc transLastStmt(n, res, bracketExpr: NimNode): (NimNode, NimNode, NimNode) {.
     template adder(res, v) = res.add(v)
     result[0] = getAst(adder(res, n))
 
-macro outplace*[T](arg: T, call: untyped; inplaceArgPosition: static[int] = 1): T {.since: (1, 1), deprecated: "use outplaces.`.@`".} =
+macro outplace*[T](arg: T, call: untyped; inplaceArgPosition: static[int] = 1): T {.since: (1, 1), deprecated: "use outplaces.`./`".} =
   expectKind call, nnkCallKinds
   let tmp = genSym(nskVar, "outplaceResult")
   var callsons = call[0..^1]

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -223,7 +223,7 @@ proc replaceOutplace(lhs, n: NimNode): NimNode =
   of nnkCall:
     result = newCall(bindSym"outplace", [lhs, n])
   else:
-    doAssert false, "unpexpected kind: " & $n.kind
+    doAssert false, "unexpected kind: " & $n.kind
 
 macro `.@`*(lhs, rhs): untyped {.since: (1,1).} =
   ## outplace operator, syntax sugar for `outplace`

--- a/lib/std/outplaces.nim
+++ b/lib/std/outplaces.nim
@@ -1,0 +1,46 @@
+import std/macros
+include system/inclrtl
+
+proc outplaceImpl(arg, call: NimNode): NimNode =
+  expectKind call, nnkCallKinds
+  let tmp = genSym(nskVar, "outplaceResult")
+  var callsons = call[0..^1]
+  var found = false
+  for i in 1..<len(callsons):
+    if callsons[i].kind == nnkIdent and callsons[i].strVal == "_":
+      callsons[i] = tmp
+      found = true
+      break
+  if not found: callsons.insert(tmp, 1)
+  result = newTree(nnkStmtListExpr,
+    newVarStmt(tmp, arg),
+    copyNimNode(call).add callsons,
+    tmp)
+
+proc replaceOutplace(lhs, n: NimNode): NimNode =
+  case n.kind
+  of nnkDotExpr, nnkBracketExpr:
+    result = copyNimTree(n)
+    result[0] = replaceOutplace(lhs, result[0])
+  of nnkCall:
+    result = outplaceImpl(lhs, n)
+  of nnkCommand:
+    result = outplaceImpl(lhs, n)
+  else:
+    doAssert false, "unexpected kind: " & $n.kind
+
+macro `.@`*(lhs, rhs): untyped {.since: (1, 1).} =
+  ## Outplace operator: turns an `in-place`:idx: algorithm into one that works on
+  ## a copy and returns this copy. A placeholder `_` can optionally be used to
+  ## specify an output parameter of position > 0.
+  ## **Since**: Version 1.2.
+  runnableExamples:
+    import algorithm, strutils
+    doAssert @[2,1,3].@sort() == @[1,2,3]
+    doAssert "".@addQuoted("foX").toUpper == "\"FOX\""
+    doAssert "A".@addQuoted("foo").toUpper[0..1].toLower == "a\""
+    proc bar(x: int, ret: var int) = ret += x
+    doAssert 3.@bar(4, _) == 3 + 4 # use placeholder `_` to specify a position > 0
+    doAssert @[2,1,3].@sort(_) == @[1,2,3] # `_` works but unneeded in position 0
+  result = copyNimTree(rhs)
+  result = replaceOutplace(lhs, result)

--- a/lib/std/outplaces.nim
+++ b/lib/std/outplaces.nim
@@ -33,6 +33,7 @@ macro `.>`*(lhs, rhs): untyped {.since: (1, 1).} =
   ## Outplace operator: turns an `in-place`:idx: algorithm into one that works on
   ## a copy and returns this copy. A placeholder `_` can optionally be used to
   ## specify an output parameter of position > 0.
+  ##
   ## **Since**: Version 1.2.
   runnableExamples:
     import algorithm, strutils

--- a/lib/std/outplaces.nim
+++ b/lib/std/outplaces.nim
@@ -29,18 +29,18 @@ proc replaceOutplace(lhs, n: NimNode): NimNode =
   else:
     doAssert false, "unexpected kind: " & $n.kind
 
-macro `./`*(lhs, rhs): untyped {.since: (1, 1).} =
+macro `.>`*(lhs, rhs): untyped {.since: (1, 1).} =
   ## Outplace operator: turns an `in-place`:idx: algorithm into one that works on
   ## a copy and returns this copy. A placeholder `_` can optionally be used to
   ## specify an output parameter of position > 0.
   ## **Since**: Version 1.2.
   runnableExamples:
     import algorithm, strutils
-    doAssert @[2,1,3]./sort() == @[1,2,3]
-    doAssert ""./addQuoted("foX").toUpper == "\"FOX\""
-    doAssert "A"./addQuoted("foo").toUpper[0..1].toLower == "a\""
+    doAssert @[2,1,3].>sort() == @[1,2,3]
+    doAssert "".>addQuoted("foX").toUpper == "\"FOX\""
+    doAssert "A".>addQuoted("foo").toUpper[0..1].toLower == "a\""
     proc bar(x: int, ret: var int) = ret += x
-    doAssert 3./bar(4, _) == 3 + 4 # use placeholder `_` to specify a position > 0
-    doAssert @[2,1,3]./sort(_) == @[1,2,3] # `_` works but unneeded in position 0
+    doAssert 3.>bar(4, _) == 3 + 4 # use placeholder `_` to specify a position > 0
+    doAssert @[2,1,3].>sort(_) == @[1,2,3] # `_` works but unneeded in position 0
   result = copyNimTree(rhs)
   result = replaceOutplace(lhs, result)

--- a/lib/std/outplaces.nim
+++ b/lib/std/outplaces.nim
@@ -29,18 +29,18 @@ proc replaceOutplace(lhs, n: NimNode): NimNode =
   else:
     doAssert false, "unexpected kind: " & $n.kind
 
-macro `.@`*(lhs, rhs): untyped {.since: (1, 1).} =
+macro `./`*(lhs, rhs): untyped {.since: (1, 1).} =
   ## Outplace operator: turns an `in-place`:idx: algorithm into one that works on
   ## a copy and returns this copy. A placeholder `_` can optionally be used to
   ## specify an output parameter of position > 0.
   ## **Since**: Version 1.2.
   runnableExamples:
     import algorithm, strutils
-    doAssert @[2,1,3].@sort() == @[1,2,3]
-    doAssert "".@addQuoted("foX").toUpper == "\"FOX\""
-    doAssert "A".@addQuoted("foo").toUpper[0..1].toLower == "a\""
+    doAssert @[2,1,3]./sort() == @[1,2,3]
+    doAssert ""./addQuoted("foX").toUpper == "\"FOX\""
+    doAssert "A"./addQuoted("foo").toUpper[0..1].toLower == "a\""
     proc bar(x: int, ret: var int) = ret += x
-    doAssert 3.@bar(4, _) == 3 + 4 # use placeholder `_` to specify a position > 0
-    doAssert @[2,1,3].@sort(_) == @[1,2,3] # `_` works but unneeded in position 0
+    doAssert 3./bar(4, _) == 3 + 4 # use placeholder `_` to specify a position > 0
+    doAssert @[2,1,3]./sort(_) == @[1,2,3] # `_` works but unneeded in position 0
   result = copyNimTree(rhs)
   result = replaceOutplace(lhs, result)

--- a/tests/stdlib/toutplaces.nim
+++ b/tests/stdlib/toutplaces.nim
@@ -2,30 +2,30 @@ import std/[outplaces, algorithm, random, os]
 
 proc main() =
   var a = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
-  doAssert a./sort() == sorted(a)
+  doAssert a.>sort() == sorted(a)
   #Chaining:
   var aCopy = a
   aCopy.insert(10)
-  doAssert a./insert(10)./sort() == sorted(aCopy)
-  doAssert @[1,3,2]./sort()./sort(order = SortOrder.Descending) == @[3,2,1]
-    # using 2 `./` chained together
+  doAssert a.>insert(10).>sort() == sorted(aCopy)
+  doAssert @[1,3,2].>sort().>sort(order = SortOrder.Descending) == @[3,2,1]
+    # using 2 `.>` chained together
 
   proc bar(x: int, ret: var int) = ret += x
-  doAssert 3./bar(4, _) == 3 + 4
+  doAssert 3.>bar(4, _) == 3 + 4
 
   const b = @[0, 1, 2]
-  let c = b./shuffle()
+  let c = b.>shuffle()
   doAssert c[0] == 1
   doAssert c[1] == 0
 
   block:
     var a = "foo"
     var b = "bar"
-    doAssert "ab"./add("cd") == "abcd"
-    let ret = "ab"./add "cd" # example with `nnkCommand`
+    doAssert "ab".>add("cd") == "abcd"
+    let ret = "ab".>add "cd" # example with `nnkCommand`
     doAssert ret == "abcd"
 
   when defined(posix):
-    doAssert "foo./bar///"./normalizePathEnd() == "foo./bar"
+    doAssert "foo./bar///".>normalizePathEnd() == "foo./bar"
 
 main()

--- a/tests/stdlib/toutplaces.nim
+++ b/tests/stdlib/toutplaces.nim
@@ -1,8 +1,4 @@
-import std/outplaces
-import algorithm
-# import random
-# import ./random
-import "."/random
+import std/[outplaces, algorithm, random, os]
 
 proc main() =
   var a = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -28,5 +24,8 @@ proc main() =
     doAssert "ab"./add("cd") == "abcd"
     let ret = "ab"./add "cd" # example with `nnkCommand`
     doAssert ret == "abcd"
+
+  when defined(posix):
+    doAssert "foo./bar///"./normalizePathEnd() == "foo./bar"
 
 main()

--- a/tests/stdlib/toutplaces.nim
+++ b/tests/stdlib/toutplaces.nim
@@ -1,30 +1,32 @@
 import std/outplaces
 import algorithm
-import random
+# import random
+# import ./random
+import "."/random
 
 proc main() =
   var a = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
-  doAssert a.@sort() == sorted(a)
+  doAssert a./sort() == sorted(a)
   #Chaining:
   var aCopy = a
   aCopy.insert(10)
-  doAssert a.@insert(10).@sort() == sorted(aCopy)
-  doAssert @[1,3,2].@sort().@sort(order = SortOrder.Descending) == @[3,2,1]
-    # using 2 `.@` chained together
+  doAssert a./insert(10)./sort() == sorted(aCopy)
+  doAssert @[1,3,2]./sort()./sort(order = SortOrder.Descending) == @[3,2,1]
+    # using 2 `./` chained together
 
   proc bar(x: int, ret: var int) = ret += x
-  doAssert 3.@bar(4, _) == 3 + 4
+  doAssert 3./bar(4, _) == 3 + 4
 
   const b = @[0, 1, 2]
-  let c = b.@shuffle()
+  let c = b./shuffle()
   doAssert c[0] == 1
   doAssert c[1] == 0
 
   block:
     var a = "foo"
     var b = "bar"
-    doAssert "ab".@add("cd") == "abcd"
-    let ret = "ab".@add "cd" # example with `nnkCommand`
+    doAssert "ab"./add("cd") == "abcd"
+    let ret = "ab"./add "cd" # example with `nnkCommand`
     doAssert ret == "abcd"
 
 main()

--- a/tests/stdlib/toutplaces.nim
+++ b/tests/stdlib/toutplaces.nim
@@ -1,0 +1,30 @@
+import std/outplaces
+import algorithm
+import random
+
+proc main() =
+  var a = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
+  doAssert a.@sort() == sorted(a)
+  #Chaining:
+  var aCopy = a
+  aCopy.insert(10)
+  doAssert a.@insert(10).@sort() == sorted(aCopy)
+  doAssert @[1,3,2].@sort().@sort(order = SortOrder.Descending) == @[3,2,1]
+    # using 2 `.@` chained together
+
+  proc bar(x: int, ret: var int) = ret += x
+  doAssert 3.@bar(4, _) == 3 + 4
+
+  const b = @[0, 1, 2]
+  let c = b.@shuffle()
+  doAssert c[0] == 1
+  doAssert c[1] == 0
+
+  block:
+    var a = "foo"
+    var b = "bar"
+    doAssert "ab".@add("cd") == "abcd"
+    let ret = "ab".@add "cd" # example with `nnkCommand`
+    doAssert ret == "abcd"
+
+main()


### PR DESCRIPTION
* this feature has often been requested
* it avoids having to nest with parens, eg:

```nim
a.outplace(sort())
=>
a.>sort()
```

## note
i was previously using `.@`
