### PR TITLE
Quote nim executable before executing.

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -259,7 +259,7 @@ when false:
 
   proc pdf(args="") =
     exec("$# cc -r tools/nimweb.nim $# --pdf web/website.ini --putenv:nimversion=$#" %
-        [findNim(), args, VersionAsString], additionalPATH=findNim().splitFile.dir)
+        [findNim().quoteShell(), args, VersionAsString], additionalPATH=findNim().splitFile.dir)
 
 # -------------- boot ---------------------------------------------------------
 
@@ -297,7 +297,7 @@ proc boot(args: string) =
   let smartNimcache = (if "release" in args or "danger" in args: "nimcache/r_" else: "nimcache/d_") &
                       hostOS & "_" & hostCPU
 
-  let nimStart = findStartNim()
+  let nimStart = findStartNim().quoteShell()
   for i in 0..2:
     let defaultCommand = if useCpp: "cpp" else: "c"
     let bootOptions = if args.len == 0 or args.startsWith("-"): defaultCommand else: ""
@@ -455,7 +455,7 @@ proc temp(args: string) =
       "threads" notin programArgs and
       "js" notin programArgs:
     bootArgs.add " -d:leanCompiler"
-  let nimexec = findNim()
+  let nimexec = findNim().quoteShell()
   exec(nimexec & " c -d:debug --debugger:native -d:nimBetterRun " & bootArgs & " " & (d / "compiler" / "nim"), 125)
   copyExe(output, finalDest)
   setCurrentDir(origDir)

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -70,16 +70,16 @@ proc execCleanPath*(cmd: string,
 
 proc nimexec*(cmd: string) =
   # Consider using `nimCompile` instead
-  exec findNim() & " " & cmd
+  exec findNim().quoteShell() & " " & cmd
 
 proc nimCompile*(input: string, outputDir = "bin", mode = "c", options = "") =
   let output = outputDir / input.splitFile.name.exe
-  let cmd = findNim() & " " & mode & " -o:" & output & " " & options & " " & input
+  let cmd = findNim().quoteShell() & " " & mode & " -o:" & output & " " & options & " " & input
   exec cmd
 
 proc nimCompileFold*(desc, input: string, outputDir = "bin", mode = "c", options = "") =
   let output = outputDir / input.splitFile.name.exe
-  let cmd = findNim() & " " & mode & " -o:" & output & " " & options & " " & input
+  let cmd = findNim().quoteShell() & " " & mode & " -o:" & output & " " & options & " " & input
   execFold(desc, cmd)
 
 const
@@ -299,7 +299,7 @@ proc buildDocSamples(nimArgs, destPath: string) =
   ##
   ## TODO: consider integrating into the existing generic documentation builders
   ## now that we have a single `doc` command.
-  exec(findNim() & " doc $# -o:$# $#" %
+  exec(findNim().quoteShell() & " doc $# -o:$# $#" %
     [nimArgs, destPath / "docgen_sample.html", "doc" / "docgen_sample.nim"])
 
 proc buildDoc(nimArgs, destPath: string) =
@@ -307,7 +307,7 @@ proc buildDoc(nimArgs, destPath: string) =
   var
     commands = newSeq[string](rst2html.len + len(doc0) + len(doc) + withoutIndex.len)
     i = 0
-  let nim = findNim()
+  let nim = findNim().quoteShell()
   for d in items(rst2html):
     commands[i] = nim & " rst2html $# --git.url:$# -o:$# --index:on $#" %
       [nimArgs, gitUrl,
@@ -339,7 +339,7 @@ proc buildPdfDoc*(nimArgs, destPath: string) =
   else:
     const pdflatexcmd = "pdflatex -interaction=nonstopmode "
     for d in items(pdf):
-      exec(findNim() & " rst2tex $# $#" % [nimArgs, d])
+      exec(findNim().quoteShell() & " rst2tex $# $#" % [nimArgs, d])
       # call LaTeX twice to get cross references right:
       exec(pdflatexcmd & changeFileExt(d, "tex"))
       exec(pdflatexcmd & changeFileExt(d, "tex"))
@@ -356,9 +356,9 @@ proc buildPdfDoc*(nimArgs, destPath: string) =
       removeFile(changeFileExt(d, "tex"))
 
 proc buildJS() =
-  exec(findNim() & " js -d:release --out:$1 tools/nimblepkglist.nim" %
+  exec(findNim().quoteShell() & " js -d:release --out:$1 tools/nimblepkglist.nim" %
       [webUploadOutput / "nimblepkglist.js"])
-  exec(findNim() & " js " & (docHackDir / "dochack.nim"))
+  exec(findNim().quoteShell() & " js " & (docHackDir / "dochack.nim"))
 
 proc buildDocs*(args: string) =
   const


### PR DESCRIPTION
`koch` finds nim executable and the executable that is found might be located on a path that may contain spaces. This can for example happen on Windows, if you use a installed version of Nim that was installed to `C:\Program Files\Nim`.

This quotes the path to the nim executable before it is executed by koch.

fixes #13311