### PR TITLE
fix #13132 tnetdial flaky test

### DIFF
--- a/tests/stdlib/tnetdial.nim
+++ b/tests/stdlib/tnetdial.nim
@@ -2,7 +2,6 @@ discard """
   cmd: "nim c --threads:on $file"
   exitcode: 0
   output: "OK"
-  disabled: "travis"
 """
 
 import os, net, nativesockets, asyncdispatch
@@ -39,10 +38,10 @@ proc testThread() {.thread.} =
   fd.close()
 
 proc test() =
+  let serverFd = initIPv6Server("::1", port)
   var t: Thread[void]
   createThread(t, testThread)
 
-  let serverFd = initIPv6Server("::1", port)
   var done = false
 
   serverFd.accept().callback = proc(fut: Future[AsyncFD]) =
@@ -58,4 +57,5 @@ proc test() =
 
   joinThread(t)
 
+# this would cause #13132 `for i in 0..<10000: test()`
 test()


### PR DESCRIPTION
* fix #13132
* you can see this by adding `for i in 0..<10000: test()`, it always failed before this PR after a few iterations (but won't fail depending on whether you add other modifications, eg `echo i`)