### PR TITLE
build_all.sh update

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -34,7 +34,7 @@ build_nim_csources(){
         makeX=gmake
       fi
       nCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1)
-      which $makeX && echo_run $makeX -C csources -j $($nCPU + 2) -l $nCPU || build_nim_csources_via_script
+      which $makeX && echo_run $makeX -C csources -j $((nCPU + 2)) -l $nCPU || build_nim_csources_via_script
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues

--- a/build_all.sh
+++ b/build_all.sh
@@ -33,7 +33,8 @@ build_nim_csources(){
       if [ "$unamestr" = 'FreeBSD' ]; then
         makeX=gmake
       fi
-      which $makeX && echo_run $makeX -C csources -j -l $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1) || build_nim_csources_via_script
+      nCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1)
+      which $makeX && echo_run $makeX -C csources -j -l $nCPU || build_nim_csources_via_script
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues

--- a/build_all.sh
+++ b/build_all.sh
@@ -23,7 +23,7 @@ build_nim_csources_via_script(){
 build_nim_csources(){
   # avoid changing dir in case of failure
   (
-    if [[ $# -ne 0 ]]; then
+    if [ $# -ne 0 ]; then
       # some args were passed (eg: `--cpu i386`), need to call build.sh
       build_nim_csources_via_script "$@"
     else
@@ -33,7 +33,7 @@ build_nim_csources(){
       if [ "$unamestr" = 'FreeBSD' ]; then
         makeX=gmake
       fi
-      which $makeX && echo_run $makeX -C csources -j -l 80 || build_nim_csources_via_script
+      which $makeX && echo_run $makeX -C csources -j -l $(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1) || build_nim_csources_via_script
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues

--- a/build_all.sh
+++ b/build_all.sh
@@ -34,7 +34,7 @@ build_nim_csources(){
         makeX=gmake
       fi
       nCPU=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || 1)
-      which $makeX && echo_run $makeX -C csources -j -l $nCPU || build_nim_csources_via_script
+      which $makeX && echo_run $makeX -C csources -j $($nCPU + 2) -l $nCPU || build_nim_csources_via_script
     fi
   )
   # keep $nim_csources in case needed to investigate bootstrap issues


### PR DESCRIPTION
`-l 80` was a bad idea, now using nproc and co. again, but falling back to 1 when not available.
Also removed a bashism that c-blake pointed out.