### PR TITLE
koch: enable checks in the compiler when running CI

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -480,7 +480,7 @@ proc runCI(cmd: string) =
   when defined(posix): # appveyor (on windows) didn't run this
     kochExecFold("Boot", "boot")
   # boot without -d:nimHasLibFFI to make sure this still works
-  kochExecFold("Boot in release mode", "boot -d:release -d:danger")
+  kochExecFold("Boot in release mode", "boot -d:release")
 
   ## build nimble early on to enable remainder to depend on it if needed
   kochExecFold("Build Nimble", "nimble")


### PR DESCRIPTION
While this increases CI time, it will let us know if there are any bugs that can be caught with the checks in `-d:release` (I mean, what is the point of making `-d:release` check for bugs if you just switch to `-d:danger` instead?).