### PR TITLE
nim secret: support linenoise when available

### DIFF
--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -12,9 +12,9 @@
 import
   pathutils
 
-# support '-d:useGnuReadline' for backwards compatibility:
-when not defined(windows) and (defined(useGnuReadline) or defined(useLinenoise)):
-  import rdstdin
+template imp(x) = import x
+const hasRstdin = compiles(imp(rdstdin))
+when hasRstdin: import rdstdin
 
 type
   TLLRepl* = proc (s: PLLStream, buf: pointer, bufLen: int): int
@@ -67,7 +67,7 @@ proc llStreamClose*(s: PLLStream) =
   of llsFile:
     close(s.f)
 
-when not declared(readLineFromStdin):
+when not hasRstdin:
   # fallback implementation:
   proc readLineFromStdin(prompt: string, line: var string): bool =
     stderr.write(prompt)


### PR DESCRIPTION
(on OSX in my case)
before PR: `nim secret` didn't use linenoise, so bad line editing
after PR: linenoise is enabled

## example
example inspired by andrea in https://forum.nim-lang.org/t/5881#36488 to test out CTFFI
```nim
$ nim secret
>>> import system/ansi_c
>>> c_printf("foo\n")
4
>>> c_printf("foo\n") # you can use line editing here, arrow keys etc
```
