### PR TITLE
Make vccexe parse response files

### DIFF
--- a/tools/vccexe/vccexe.nim
+++ b/tools/vccexe/vccexe.nim
@@ -104,28 +104,29 @@ Microsoft (R) C/C++ Optimizing Compiler if no secondary
 command was specified
 """
 
-when isMainModule:
-  var vccversionArg: seq[string] = @[]
-  var printPathArg: bool = false
-  var vcvarsallArg: string
-  var commandArg: string
-  var noCommandArg: bool = false
-  var platformArg: VccArch
-  var sdkTypeArg: VccPlatformType
-  var sdkVersionArg: string
-  var verboseArg: bool = false
-
-  var clArgs: seq[TaintedString] = @[]
-
-  # Cannot use usual command-line argument parser here
-  # Since vccexe command-line arguments are intermingled
-  # with the secondary command-line arguments which have
-  # a syntax that is not supported by the default nim
-  # argument parser.
-  var wrapperArgs = commandLineParams()
-  for wargv in wrapperArgs:
+proc parseVccexeCmdLine(argseq: seq[TaintedString], 
+vccversionArg: var seq[string], printPathArg: var bool, 
+vcvarsallArg: var string, commandArg: var string, noCommandArg: var bool,
+platformArg: var VccArch, sdkTypeArg: var VccPlatformType,
+sdkVersionArg: var string, verboseArg: var bool,
+clArgs: var seq[TaintedString]) =
+  ## Cannot use usual command-line argument parser here
+  ## Since vccexe command-line arguments are intermingled
+  ## with the secondary command-line arguments which have
+  ## a syntax that is not supported by the default nim
+  ## argument parser.
+  for wargv in argseq:
     # Check whether the current argument contains -- prefix
-    if wargv.startsWith(vccversionPrefix): # Check for vccversion
+    if wargv.startsWith("@"): # Check for response file prefix
+      let
+        responsefilename = wargv.substr(1)
+        responsefilehandle = open(responsefilename)
+        responsecontent = responsefilehandle.readAll()
+        responseargs = parseCmdLine(responsecontent)
+      parseVccexeCmdLine(responseargs, vccversionArg, printPathArg,
+        vcvarsallArg, commandArg, noCommandArg, platformArg, sdkTypeArg,
+        sdkVersionArg, verboseArg, clArgs)
+    elif wargv.startsWith(vccversionPrefix): # Check for vccversion
       vccversionArg.add(wargv.substr(vccversionSepIdx + 1))
     elif wargv.cmpIgnoreCase(printPathPrefix) == 0: # Check for printPath
       printPathArg = true
@@ -147,6 +148,24 @@ when isMainModule:
       if (wargv.len == 2) and (wargv[1] == '?'):
         echo helpText
       clArgs.add(wargv)
+
+when isMainModule:
+  var vccversionArg: seq[string] = @[]
+  var printPathArg: bool = false
+  var vcvarsallArg: string
+  var commandArg: string
+  var noCommandArg: bool = false
+  var platformArg: VccArch
+  var sdkTypeArg: VccPlatformType
+  var sdkVersionArg: string
+  var verboseArg: bool = false
+
+  var clArgs: seq[TaintedString] = @[]
+
+  let wrapperArgs = commandLineParams()
+  parseVccexeCmdLine(wrapperArgs, vccversionArg, printPathArg, vcvarsallArg,
+    commandArg, noCommandArg, platformArg, sdkTypeArg, sdkVersionArg, verboseArg,
+    clArgs)
 
   # Support for multiple specified versions. Attempt VCC discovery for each version
   # specified, first successful discovery wins

--- a/tools/vccexe/vccexe.nim
+++ b/tools/vccexe/vccexe.nim
@@ -32,7 +32,7 @@ proc discoverVccVcVarsAllPath*(version: VccVersion = vccUndefined): string =
 
   # All attempts to discover vcc failed
 
-const 
+const
   vccversionPrefix = "--vccversion"
   printPathPrefix = "--printPath"
   vcvarsallPrefix = "--vcvarsall"
@@ -49,7 +49,7 @@ const
   platformSepIdx = platformPrefix.len
   sdktypeSepIdx = sdktypePrefix.len
   sdkversionSepIdx = sdkversionPrefix.len
-  
+
   vcvarsallDefaultPath = "vcvarsall.bat"
 
   helpText = """
@@ -104,8 +104,8 @@ Microsoft (R) C/C++ Optimizing Compiler if no secondary
 command was specified
 """
 
-proc parseVccexeCmdLine(argseq: seq[TaintedString], 
-vccversionArg: var seq[string], printPathArg: var bool, 
+proc parseVccexeCmdLine(argseq: seq[TaintedString],
+vccversionArg: var seq[string], printPathArg: var bool,
 vcvarsallArg: var string, commandArg: var string, noCommandArg: var bool,
 platformArg: var VccArch, sdkTypeArg: var VccPlatformType,
 sdkVersionArg: var string, verboseArg: var bool,
@@ -164,7 +164,8 @@ when isMainModule:
 
   let wrapperArgs = commandLineParams()
   parseVccexeCmdLine(wrapperArgs, vccversionArg, printPathArg, vcvarsallArg,
-    commandArg, noCommandArg, platformArg, sdkTypeArg, sdkVersionArg, verboseArg,
+    commandArg, noCommandArg, platformArg, sdkTypeArg, sdkVersionArg,
+    verboseArg,
     clArgs)
 
   # Support for multiple specified versions. Attempt VCC discovery for each version

--- a/tools/vccexe/vccexe.nim
+++ b/tools/vccexe/vccexe.nim
@@ -105,11 +105,11 @@ command was specified
 """
 
 proc parseVccexeCmdLine(argseq: seq[TaintedString],
-vccversionArg: var seq[string], printPathArg: var bool,
-vcvarsallArg: var string, commandArg: var string, noCommandArg: var bool,
-platformArg: var VccArch, sdkTypeArg: var VccPlatformType,
-sdkVersionArg: var string, verboseArg: var bool,
-clArgs: var seq[TaintedString]) =
+    vccversionArg: var seq[string], printPathArg: var bool,
+    vcvarsallArg: var string, commandArg: var string, noCommandArg: var bool,
+    platformArg: var VccArch, sdkTypeArg: var VccPlatformType,
+    sdkVersionArg: var string, verboseArg: var bool,
+    clArgs: var seq[TaintedString]) =
   ## Cannot use usual command-line argument parser here
   ## Since vccexe command-line arguments are intermingled
   ## with the secondary command-line arguments which have


### PR DESCRIPTION
When a response file is generated, `nim` and `koch` will emit the `vccexe` specific arguments into the response file.

This PR causes `vccexe` to intercept all arguments starting with `@` and parses them as if passed via command-line.

## Examples

When running the `koch tools` command (using the `vcc` backend), `koch` will emit a responsefile to compile `nimsuggest`. The first argument in the response file is the `vccexe`-specific `--platform:amd64` (for x64 architectures) argument that is not understood by `cl.exe` and generates a corresponding error-message.