### PR TITLE
config/nim.cfg: -d:danger now implies -d:release

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -69,7 +69,11 @@ path="$lib/pure"
   @end
 @end
 
-@if release or danger:
+@if danger:
+  define:release
+@end
+
+@if release:
   stacktrace:off
   excessiveStackTrace:off
   linetrace:off


### PR DESCRIPTION
Based on the discussion at https://forum.nim-lang.org/t/5878