### PR TITLE
[superseded] new syntax for lvalue references: `byaddr x = expr`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -157,6 +157,7 @@ type
     nkTypeSection,        # a type section (consists of type definitions)
     nkVarSection,         # a var section
     nkLetSection,         # a let section
+    nkCustomDefSection,   # a custom definition section, eg `byAddr foo = bar`
     nkConstSection,       # a const section
     nkConstDef,           # a const definition
     nkTypeDef,            # a type definition

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -157,7 +157,6 @@ type
     nkTypeSection,        # a type section (consists of type definitions)
     nkVarSection,         # a var section
     nkLetSection,         # a let section
-    nkCustomDefSection,   # a custom definition section, eg `byAddr foo = bar`
     nkConstSection,       # a const section
     nkConstDef,           # a const definition
     nkTypeDef,            # a type definition
@@ -225,6 +224,7 @@ type
     nkBreakState,         # special break statement for easier code generation
     nkFuncDef,            # a func
     nkTupleConstr         # a tuple constructor
+    nkCustomDefSection,   # a custom definition section, eg `byAddr foo = bar`
 
   TNodeKinds* = set[TNodeKind]
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -49,7 +49,7 @@ type
     tkTemplate,
     tkTry, tkTuple, tkType, tkUsing,
     tkVar, tkWhen, tkWhile, tkXor,
-    tkYield, # end of keywords
+    tkYield, tkByAddr, # end of keywords
     tkIntLit, tkInt8Lit, tkInt16Lit, tkInt32Lit, tkInt64Lit,
     tkUIntLit, tkUInt8Lit, tkUInt16Lit, tkUInt32Lit, tkUInt64Lit,
     tkFloatLit, tkFloat32Lit, tkFloat64Lit, tkFloat128Lit,
@@ -65,6 +65,8 @@ type
     tkSpaces, tkInfixOpr, tkPrefixOpr, tkPostfixOpr
 
   TTokTypes* = set[TTokType]
+
+const customDefTokens* = {tkByAddr}
 
 const
   weakTokens = {tkComma, tkSemiColon, tkColon,
@@ -90,7 +92,7 @@ const
     "template",
     "try", "tuple", "type", "using",
     "var", "when", "while", "xor",
-    "yield",
+    "yield", specialWords[wByAddr],
     "tkIntLit", "tkInt8Lit", "tkInt16Lit", "tkInt32Lit", "tkInt64Lit",
     "tkUIntLit", "tkUInt8Lit", "tkUInt16Lit", "tkUInt32Lit", "tkUInt64Lit",
     "tkFloatLit", "tkFloat32Lit", "tkFloat64Lit", "tkFloat128Lit",
@@ -1338,7 +1340,7 @@ proc getIndentWidth*(fileIdx: FileIndex, inputstream: PLLStream;
   var prevToken = tkEof
   while tok.tokType != tkEof:
     rawGetTok(lex, tok)
-    if tok.indent > 0 and prevToken in {tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing}:
+    if tok.indent > 0 and prevToken in {tkColon, tkEquals, tkType, tkConst, tkLet, tkVar, tkUsing} + customDefTokens:
       result = tok.indent
       if result > 0: break
     prevToken = tok.tokType

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2742,6 +2742,15 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkVarSection: result = semVarOrLet(c, n, skVar)
   of nkLetSection: result = semVarOrLet(c, n, skLet)
   of nkConstSection: result = semConst(c, n)
+  of nkCustomDefSection:
+    # cleaner to let user code define it than hard code via `semTemplateDef(c, n)`
+    result = newTree(nkCall)
+    result.add newIdentNode(getIdent(c.cache, "byAddrImpl"), n.info)
+    result.add n
+    result.add n[1][0]
+    result.add n[1][1]
+    result.add n[1][2]
+    result = semExpr(c, result, flags)
   of nkTypeSection: result = semTypeSection(c, n)
   of nkDiscardStmt: result = semDiscard(c, n)
   of nkWhileStmt: result = semWhile(c, n, flags)

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -30,7 +30,8 @@ type
     wMacro, wMethod, wMixin, wMod, wNil,
     wNot, wNotin, wObject, wOf, wOr, wOut, wProc, wPtr, wRaise, wRef, wReturn,
     wShl, wShr, wStatic, wTemplate, wTry, wTuple, wType, wUsing, wVar,
-    wWhen, wWhile, wXor, wYield,
+    wWhen, wWhile, wXor, wYield, wByAddr,
+    # end of keywords here
 
     wColon, wColonColon, wEquals, wDot, wDotDot,
     wStar, wMinus,
@@ -116,7 +117,7 @@ const
     "shl", "shr", "static",
     "template", "try", "tuple", "type", "using", "var",
     "when", "while", "xor",
-    "yield",
+    "yield", "byaddr",
 
     ":", "::", "=", ".", "..",
     "*", "-",

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -33,7 +33,7 @@ qualifiedIdent = symbol ('.' optInd symbol)?
 setOrTableConstr = '{' ((exprColonEqExpr comma)* | ':' ) '}'
 castExpr = 'cast' '[' optInd typeDesc optPar ']' '(' optInd expr optPar ')'
 parKeyw = 'discard' | 'include' | 'if' | 'while' | 'case' | 'try'
-        | 'finally' | 'except' | 'for' | 'block' | 'const' | 'let'
+        | 'finally' | 'except' | 'for' | 'block' | 'const' | 'let' | 'byaddr'
         | 'when' | 'var' | 'mixin'
 par = '(' optInd
           ( &parKeyw complexOrSimpleStmt ^+ ';'
@@ -200,7 +200,7 @@ complexOrSimpleStmt = (ifStmt | whenStmt | whileStmt
                     | 'converter' routine
                     | 'type' section(typeDef)
                     | 'const' section(constant)
-                    | ('let' | 'var' | 'using') section(variable)
+                    | ('let' | 'var' | 'using' | 'byaddr') section(variable)
                     | bindStmt | mixinStmt)
                     / simpleStmt
 stmt = (IND{>} complexOrSimpleStmt^+(IND{=} / ';') DED)

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -51,7 +51,7 @@ type
     nnkElifBranch, nnkExceptBranch, nnkElse,
     nnkAsmStmt, nnkPragma, nnkPragmaBlock, nnkIfStmt, nnkWhenStmt,
     nnkForStmt, nnkParForStmt, nnkWhileStmt, nnkCaseStmt,
-    nnkTypeSection, nnkVarSection, nnkLetSection, nnkConstSection,
+    nnkTypeSection, nnkVarSection, nnkLetSection, nnkCustomDefSection, nnkConstSection,
     nnkConstDef, nnkTypeDef,
     nnkYieldStmt, nnkDefer, nnkTryStmt, nnkFinally, nnkRaiseStmt,
     nnkReturnStmt, nnkBreakStmt, nnkContinueStmt, nnkBlockStmt, nnkStaticStmt,

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -51,7 +51,7 @@ type
     nnkElifBranch, nnkExceptBranch, nnkElse,
     nnkAsmStmt, nnkPragma, nnkPragmaBlock, nnkIfStmt, nnkWhenStmt,
     nnkForStmt, nnkParForStmt, nnkWhileStmt, nnkCaseStmt,
-    nnkTypeSection, nnkVarSection, nnkLetSection, nnkCustomDefSection, nnkConstSection,
+    nnkTypeSection, nnkVarSection, nnkLetSection, nnkConstSection,
     nnkConstDef, nnkTypeDef,
     nnkYieldStmt, nnkDefer, nnkTryStmt, nnkFinally, nnkRaiseStmt,
     nnkReturnStmt, nnkBreakStmt, nnkContinueStmt, nnkBlockStmt, nnkStaticStmt,
@@ -84,7 +84,8 @@ type
     nnkState,
     nnkBreakState,
     nnkFuncDef,
-    nnkTupleConstr
+    nnkTupleConstr,
+    nnkCustomDefSection,
 
   NimNodeKinds* = set[NimNodeKind]
   NimTypeKind* = enum  # some types are no longer used, see ast.nim

--- a/lib/std/references.nim
+++ b/lib/std/references.nim
@@ -1,0 +1,14 @@
+template byAddrImpl*(n, name, typ, exp): untyped =
+  ## Defines a reference syntax for lvalue expressions, analog to C++ `auto& a = expr`.
+  ## The expression is evaluated only once, and any side effects will only be
+  ## evaluated once, at declaration time.
+  ##
+  ## Note: to use this, use `byaddr x = expr` (not `byAddrImpl`), see examples.
+  runnableExamples:
+    var x = @[1,2,3]
+    let x0=x[1]
+    byaddr x1=x[1]
+    x1+=10
+    doAssert type(x1) is int and x == @[1,12,3]
+  let myAddr = addr `exp`
+  template `name`: untyped = myAddr[]

--- a/tests/stdlib/treferences.nim
+++ b/tests/stdlib/treferences.nim
@@ -1,0 +1,34 @@
+import std/references
+
+block:
+  var x = @[1,2,3]
+  let x0=x[1]
+  byaddr x1=x[1]
+  x1+=10
+  doAssert type(x1) is int and x == @[1,12,3]
+
+  byaddr
+    x2=x[1]
+  doAssert x2.addr == x1.addr
+
+  when false:
+    # this could be supported but would require a macro instead of a simple
+    # template in `byAddrImpl`
+    byaddr
+      x2=x[1]
+      x3=x[1]
+    doAssert x2.addr == x3.addr
+
+import std/macros
+
+macro dbg(a): string = newLit a.treeRepr
+let s = dbg:
+  byaddr foo = bar
+doAssert s == """
+StmtList
+  CustomDefSection
+    Ident "byaddr"
+    IdentDefs
+      Ident "foo"
+      Empty
+      Ident "bar""""

--- a/tools/grammar_nanny.nim
+++ b/tools/grammar_nanny.nim
@@ -4,7 +4,7 @@
 import std / [strutils, sets]
 
 import ".." / compiler / [
-  llstream, ast, lexer, options, msgs, idents,
+  llstream, lexer, options, msgs, idents,
   lineinfos, pathutils]
 
 proc checkGrammarFileImpl(cache: IdentCache, config: ConfigRef) =


### PR DESCRIPTION
* supersedes #11824 ; exactly same idea but with a parser change to allow the cleaner syntax `byaddr x = expr` instead of `byaddr: x = expr`
 
* see https://github.com/nim-lang/Nim/pull/11824 for rationale, examples etc

* byaddr is now a new keyword and introduces a new section nkCustomDefSection, analog to nkLetSection except it has 1 more field, placeholder for the name of the section:

`byaddr foo = bar` produces this AST:
```
  CustomDefSection
    Ident "byaddr"
    IdentDefs
      Ident "foo"
      Empty
      Ident "bar"
```

thanks to nkCustomDefSection, we can easily extend to additional keywords without changing much else in the compiler/parser/lexer, and more importantly user code, for example it'd be easy to add (if one wanted to):
`alias foo = bar`


## example
```nim
var x = @[1,2,3]
byaddr x1=x[1]
x1+=10
doAssert type(x1) is int and x == @[1,12,3]

# the expression is evaluated exactly once, which matters in case of expensive computation or side effects:
byaddr x1 = x.foo(2)[3].bar  # evaluated here
echo x1
echo x1

# unlike with:
template x1(): untyped = x.foo(2)[3].bar
echo x1 # evaluated here
echo x1 # evaluated here
```
