### PR TITLE
fix #13182: `proc fun(a: varargs[Foo, conv])` now can be overloaded

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1938,7 +1938,8 @@ proc localConvMatch(c: PContext, m: var TCandidate, f, a: PType,
   var call = newNodeI(nkCall, arg.info)
   call.add(f.n.copyTree)
   call.add(arg.copyTree)
-  result = c.semExpr(c, call)
+  result = c.semTryExpr(c, call)
+
   if result != nil:
     if result.typ == nil: return nil
     # resulting type must be consistent with the other arguments:

--- a/tests/errmsgs/tsigmatch2.nim
+++ b/tests/errmsgs/tsigmatch2.nim
@@ -1,0 +1,47 @@
+discard """
+  cmd: "nim check --showAllMismatches:on --hints:off $file"
+  nimout: '''
+tsigmatch2.nim(40, 14) Error: type mismatch: got <float64>
+but expected one of:
+proc foo(i: Foo): string
+  first type mismatch at position: 1
+  required type for i: Foo
+  but expression '1.2' is of type: float64
+proc foo(args: varargs[string, myproc]): string
+  first type mismatch at position: 1
+  required type for args: varargs[string]
+  but expression '1.2' is of type: float64
+
+expression: foo(1.2)
+tsigmatch2.nim(46, 7) Error: type mismatch: got <int literal(1)>
+but expected one of:
+proc foo(args: varargs[string, myproc])
+  first type mismatch at position: 1
+  required type for args: varargs[string]
+  but expression '1' is of type: int literal(1)
+
+expression: foo 1
+'''
+  errormsg: "type mismatch"
+"""
+
+
+
+# line 30
+
+block: # issue #13182
+  proc myproc(a: int): string = $("myproc", a)
+  proc foo(args: varargs[string, myproc]): string = $args
+  type Foo = object
+  proc foo(i: Foo): string = "in foo(i)"
+  static: doAssert foo(Foo()) == "in foo(i)"
+  static: doAssert foo(1) == """["(\"myproc\", 1)"]"""
+  doAssert not compiles(foo(1.2))
+  discard foo(1.2)
+
+block:
+  proc myproc[T](x: T): string =
+    let temp = 12.isNil
+  proc foo(args: varargs[string, myproc]) = discard
+  foo 1
+static: echo "done"


### PR DESCRIPTION
* fix #13182 by addressing the root cause (varargs[Foo, conv] was hijacking overloads) instead of the symptom (io.write using `vararsg[string,$]`)
* `proc fun(a: varargs[Foo, conv])` now can be overloaded

## example
```nim
  proc myproc(a: int): string = $("myproc", a)
  proc foo(args: varargs[string, myproc]): string = $args
  type Foo = object
  proc foo(i: Foo): string = "in foo(i)"
  static: doAssert foo(Foo()) == "in foo(i)"
  static: doAssert foo(1) == """["(\"myproc\", 1)"]"""
  doAssert not compiles(foo(1.2))
  discard foo(1.2) # this one shows a clean error, pointing to both overloads
```

```
tsigmatch2.nim(32, 14) Error: type mismatch: got <float64>
but expected one of:
proc foo(i: Foo): string
  first type mismatch at position: 1
  required type for i: Foo
  but expression '1.2' is of type: float64
proc foo(args: varargs[string, myproc]): string
  first type mismatch at position: 1
  required type for args: varargs[string]
  but expression '1.2' is of type: float64

expression: foo(1.2)
```

