### PR TITLE
adding sqlite3 backup functions

### DIFF
--- a/lib/wrappers/sqlite3.nim
+++ b/lib/wrappers/sqlite3.nim
@@ -381,7 +381,7 @@ proc backup_pagecount*(pBackup: PSqlite3_Backup): int32 {.cdecl, mylib, importc:
 
 proc backup_remaining*(pBackup: PSqlite3_Backup): int32 {.cdecl, mylib, importc: "sqlite3_backup_remaining".}
 
-proc sleep*(t: int64): int64 {.cdecl, mylib, importc: "sqlite3_sleep".}
+proc sqlite3_sleep*(t: int64): int64 {.cdecl, mylib, importc: "sqlite3_sleep".}
 
   #function sqlite3_key(db:Psqlite3; pKey:pointer; nKey:longint):longint;cdecl; external Sqlite3Lib name 'sqlite3_key';
   #function sqlite3_rekey(db:Psqlite3; pKey:pointer; nKey:longint):longint;cdecl; external Sqlite3Lib name 'sqlite3_rekey';

--- a/lib/wrappers/sqlite3.nim
+++ b/lib/wrappers/sqlite3.nim
@@ -110,6 +110,9 @@ type
   Sqlite3 {.pure, final.} = object
   PSqlite3* = ptr Sqlite3
   PPSqlite3* = ptr PSqlite3
+  Sqlite3_Backup {.pure, final.} = object
+  PSqlite3_Backup* = ptr Sqlite3_Backup
+  PPSqlite3_Backup* = ptr PSqlite3_Backup
   Context{.pure, final.} = object
   Pcontext* = ptr Context
   TStmt{.pure, final.} = object
@@ -366,6 +369,20 @@ proc version*(): cstring{.cdecl, mylib, importc: "sqlite3_libversion".}
   # Not published functions
 proc libversion_number*(): int32{.cdecl, mylib,
                                   importc: "sqlite3_libversion_number".}
+
+proc backup_init*(pDest: PSqlite3, zDestName: cstring, pSource: PSqlite3, zSourceName: cstring): PSqlite3_Backup {.
+    cdecl, mylib, importc: "sqlite3_backup_init".}
+
+proc backup_step*(pBackup: PSqlite3_Backup, nPage: int32): int32 {.cdecl, mylib, importc: "sqlite3_backup_step".}
+
+proc backup_finish*(pBackup: PSqlite3_Backup): int32 {.cdecl, mylib, importc: "sqlite3_backup_finish".}
+
+proc backup_pagecount*(pBackup: PSqlite3_Backup): int32 {.cdecl, mylib, importc: "sqlite3_backup_pagecount".}
+
+proc backup_remaining*(pBackup: PSqlite3_Backup): int32 {.cdecl, mylib, importc: "sqlite3_backup_remaining".}
+
+proc sleep*(t: int64): int64 {.cdecl, mylib, importc: "sqlite3_sleep".}
+
   #function sqlite3_key(db:Psqlite3; pKey:pointer; nKey:longint):longint;cdecl; external Sqlite3Lib name 'sqlite3_key';
   #function sqlite3_rekey(db:Psqlite3; pKey:pointer; nKey:longint):longint;cdecl; external Sqlite3Lib name 'sqlite3_rekey';
   #function sqlite3_sleep(_para1:longint):longint;cdecl; external Sqlite3Lib name 'sqlite3_sleep';


### PR DESCRIPTION
Adding sqlite3 backup functions.
working example code
```
import sqlite3
import os


type
  DbConn* = PSqlite3
  DbBackupConn* = PSqlite3_Backup
  DbError = object of IOError


proc dbError*(db: DbConn) {.noreturn.} =
  var e: ref DbError
  new(e)
  e.msg = $sqlite3.errmsg(db)
  raise e

proc open(connection, user, password, database: string): DbConn =
  var db: DbConn
  if sqlite3.open(connection, db) == SQLITE_OK:
    result = db
  else:
    dbError(db)

proc offline_test: int =
  let db_source = open("source.db", "", "", "")
  let db_target = open("target.db", "", "", "")

  var pBackup: PSqlite3_Backup = backup_init(db_target, "main", db_source, "main")
  if not isNil(pBackup):
    echo backup_step(pBackup, -1)
    echo backup_finish(pBackup)
  
  echo close(db_source)
  echo close(db_target)

proc online_test: int =
  let db_source = open("source.db", "", "", "")
  let db_target = open("target.db", "", "", "")

  var pBackup: PSqlite3_Backup = backup_init(db_target, "main", db_source, "main")
  if not isNil(pBackup):
    while true:
      var rc = backup_step(pBackup, 5)
      echo "pagecount: " & $backup_pagecount(pBackup)
      echo "remaining: " & $backup_remaining(pBackup)
      if (rc == SQLITE_OK or rc == SQLITE_BUSY or rc == SQLITE_LOCKED):
        discard sqlite3_sleep(250)
      if not (rc == SQLITE_OK or rc == SQLITE_BUSY or rc == SQLITE_LOCKED):
        break
    discard backup_finish(pBackup)
    discard close(db_source)
    discard close(db_target)


when isMainModule:
  echo offline_test()
  echo online_test()
```