### PR TITLE
stacktraces can now show custom runtime msgs per frame

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -150,6 +150,9 @@ echo f
 - `net.newContext` now performs SSL Certificate checking on Linux and OSX.
   Define `nimDisableCertificateValidation` to disable it globally.
 - new syntax for lvalue references: `var b {.byaddr.} = expr` enabled by `import pragmas`
+- new module `std/stackframes`, in particular `setFrameMsg` which enables
+  custom runtime annotation of stackframes, see #13351 for examples. Turn on/off via
+  `--stackTraceMsgs:on/off`
 
 ## Language additions
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -281,6 +281,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "hints": result = contains(conf.options, optHints)
   of "threadanalysis": result = contains(conf.globalOptions, optThreadAnalysis)
   of "stacktrace": result = contains(conf.options, optStackTrace)
+  of "stacktracemsgs": result = contains(conf.options, optStackTraceMsgs)
   of "linetrace": result = contains(conf.options, optLineTrace)
   of "debugger": result = contains(conf.globalOptions, optCDebug)
   of "profiler": result = contains(conf.options, optProfiler)
@@ -531,6 +532,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if processOnOffSwitchOrList(conf, {optHints}, arg, pass, info): listHints(conf)
   of "threadanalysis": processOnOffSwitchG(conf, {optThreadAnalysis}, arg, pass, info)
   of "stacktrace": processOnOffSwitch(conf, {optStackTrace}, arg, pass, info)
+  of "stacktracemsgs": processOnOffSwitch(conf, {optStackTraceMsgs}, arg, pass, info)
   of "excessivestacktrace": processOnOffSwitchG(conf, {optExcessiveStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch(conf, {optLineTrace}, arg, pass, info)
   of "debugger":

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -114,3 +114,4 @@ proc initDefines*(symbols: StringTableRef) =
 
   defineSymbol("nimHasSinkInference")
   defineSymbol("nimNewIntegerOps")
+  defineSymbol("nimHasStacktraceMsgs")

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -28,7 +28,9 @@ type                          # please make sure we have under 32 options
     optOverflowCheck, optNilCheck, optRefCheck,
     optNaNCheck, optInfCheck, optStaticBoundsCheck, optStyleCheck,
     optAssert, optLineDir, optWarns, optHints,
-    optOptimizeSpeed, optOptimizeSize, optStackTrace, # stack tracing support
+    optOptimizeSpeed, optOptimizeSize,
+    optStackTrace, # stack tracing support
+    optStackTraceMsgs, # enable custom runtime msgs via `setFrameMsg`
     optLineTrace,             # line tracing support (includes stack tracing)
     optByRef,                 # use pass by ref for objects
                               # (for interfacing with C)
@@ -324,7 +326,7 @@ const
 
   DefaultOptions* = {optObjCheck, optFieldCheck, optRangeCheck,
     optBoundsCheck, optOverflowCheck, optAssert, optWarns, optRefCheck,
-    optHints, optStackTrace, optLineTrace,
+    optHints, optStackTrace, optStackTraceMsgs, optLineTrace,
     optTrMacros, optNilCheck, optStyleCheck, optSinkInference}
   DefaultGlobalOptions* = {optThreadAnalysis,
     optExcessiveStackTrace, optListFullPaths}

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -326,7 +326,7 @@ const
 
   DefaultOptions* = {optObjCheck, optFieldCheck, optRangeCheck,
     optBoundsCheck, optOverflowCheck, optAssert, optWarns, optRefCheck,
-    optHints, optStackTrace, optStackTraceMsgs, optLineTrace,
+    optHints, optStackTrace, optLineTrace, # consider adding `optStackTraceMsgs`
     optTrMacros, optNilCheck, optStyleCheck, optSinkInference}
   DefaultGlobalOptions* = {optThreadAnalysis,
     optExcessiveStackTrace, optListFullPaths}

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2554,8 +2554,11 @@ proc shouldBeBracketExpr(n: PNode): bool =
           n[0] = be
           return true
 
+import std/stackframes
+
 proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   result = n
+  setFrameMsg c.config$n.info & " " & $n.kind
   if c.config.cmd == cmdIdeTools: suggestExpr(c, n)
   if nfSem in n.flags: return
   case n.kind

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2557,8 +2557,9 @@ proc shouldBeBracketExpr(n: PNode): bool =
 import std/stackframes
 
 proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
+  when defined(nimCompilerStackraceHints):
+    setFrameMsg c.config$n.info & " " & $n.kind
   result = n
-  setFrameMsg c.config$n.info & " " & $n.kind
   if c.config.cmd == cmdIdeTools: suggestExpr(c, n)
   if nfSem in n.flags: return
   case n.kind

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -10,6 +10,9 @@
 # this module does the semantic checking for expressions
 # included from sem.nim
 
+when defined(nimCompilerStackraceHints):
+  import std/stackframes
+
 const
   errExprXHasNoType = "expression '$1' has no type (or is ambiguous)"
   errXExpectsTypeOrValue = "'$1' expects a type or value"
@@ -2553,8 +2556,6 @@ proc shouldBeBracketExpr(n: PNode): bool =
           for i in 1..<a.len: be.add(a[i])
           n[0] = be
           return true
-
-import std/stackframes
 
 proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   when defined(nimCompilerStackraceHints):

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -92,6 +92,7 @@ Advanced options:
                             turn support for hot code reloading on|off
   --excessiveStackTrace:on|off
                             stack traces use full file paths
+  --stackTraceMsgs:on|off   enable user defined stack frame msgs via `setFrameMsg`
   --oldNewlines:on|off      turn on|off the old behaviour of "\n"
   --laxStrings:on|off       when turned on, accessing the zero terminator in
                             strings is allowed; only for backwards compatibility

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -489,6 +489,7 @@ struct TFrame_ {
   NCSTRING filename;
   NI16 len;
   NI16 calldepth;
+  NI frameMsgLen; // should that be int64?
 };
 
 #define NIM_POSIX_INIT  __attribute__((constructor))

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -489,7 +489,7 @@ struct TFrame_ {
   NCSTRING filename;
   NI16 len;
   NI16 calldepth;
-  NI frameMsgLen; // should that be int64?
+  NI frameMsgLen;
 };
 
 #define NIM_POSIX_INIT  __attribute__((constructor))

--- a/lib/std/stackframes.nim
+++ b/lib/std/stackframes.nim
@@ -1,18 +1,16 @@
 const NimStackTrace = compileOption("stacktrace")
 
 template procName*(): string =
-  var name {.inject.}: cstring
-  {.emit: "`name` = __func__;".}
-  $name
-  # import std/strutils
-  # ($name).rsplit('_', 1)[0]
+  ## returns current C/C++ function name
+  when defined(c) or defined(cpp):
+    var name {.inject.}: cstring
+    {.emit: "`name` = __func__;".}
+    $name
 
-# TODO:proc getFrame*(): PFrame {.compilerRtl, inl.} = framePtr
 template getPFrame*(): PFrame =
+  ## avoids a function call (unlike `getFrame()`)
   block:
-    # note: PFrame.calldepth (among other fields...) seems useful
     when NimStackTrace:
-      # IMPROVE: this does a double pointer copy (not a huge deal but still)
       var framePtr {.inject.}: PFrame
       {.emit: "`framePtr` = &FR_;".}
       framePtr
@@ -21,11 +19,12 @@ template setFrameMsg*(msg: string) =
   ## attach a msg to current PFrame. This can be called multiple times
   ## in a given PFrame.
   when NimStackTrace:
-    let fr = getPFrame()
-    # let fr = getFrame()
-    # let fr = framePtr
-    # TODO: instead realloc etc; TODO: also, js
-    # TODO: set an upper limit? maybe not needed unless stack grows large AND lots of msgs are written
-    frameMsgBuf.setLen fr.frameMsgLen
-    frameMsgBuf.add msg
-    fr.frameMsgLen += msg.len
+    block:
+      var fr {.inject.}: PFrame
+      {.emit: "`fr` = &FR_;".}
+      # consider setting a custom upper limit on size (analog to stack overflow)
+      const prefix = " " # to format properly
+      frameMsgBuf.setLen fr.frameMsgLen
+      frameMsgBuf.add prefix
+      frameMsgBuf.add msg
+      fr.frameMsgLen += prefix.len + msg.len

--- a/lib/std/stackframes.nim
+++ b/lib/std/stackframes.nim
@@ -1,4 +1,5 @@
 const NimStackTrace = compileOption("stacktrace")
+const NimStackTraceMsgs = compileOption("stacktraceMsgs")
 
 template procName*(): string =
   ## returns current C/C++ function name
@@ -16,9 +17,9 @@ template getPFrame*(): PFrame =
       framePtr
 
 template setFrameMsg*(msg: string) =
-  ## attach a msg to current PFrame. This can be called multiple times
-  ## in a given PFrame.
-  when NimStackTrace:
+  ## attach a msg to current `PFrame`. This can be called multiple times
+  ## in a given PFrame. Noop unless passing --stacktraceMsgs and --stacktrace
+  when NimStackTrace and NimStackTraceMsgs:
     block:
       var fr {.inject.}: PFrame
       {.emit: "`fr` = &FR_;".}

--- a/lib/std/stackframes.nim
+++ b/lib/std/stackframes.nim
@@ -16,7 +16,7 @@ template getPFrame*(): PFrame =
       {.emit: "`framePtr` = &FR_;".}
       framePtr
 
-template setFrameMsg*(msg: string) =
+template setFrameMsg*(msg: string, prefix = " ") =
   ## attach a msg to current `PFrame`. This can be called multiple times
   ## in a given PFrame. Noop unless passing --stacktraceMsgs and --stacktrace
   when NimStackTrace and NimStackTraceMsgs:
@@ -24,7 +24,6 @@ template setFrameMsg*(msg: string) =
       var fr {.inject.}: PFrame
       {.emit: "`fr` = &FR_;".}
       # consider setting a custom upper limit on size (analog to stack overflow)
-      const prefix = " " # to format properly
       frameMsgBuf.setLen fr.frameMsgLen
       frameMsgBuf.add prefix
       frameMsgBuf.add msg

--- a/lib/std/stackframes.nim
+++ b/lib/std/stackframes.nim
@@ -1,0 +1,31 @@
+const NimStackTrace = compileOption("stacktrace")
+
+template procName*(): string =
+  var name {.inject.}: cstring
+  {.emit: "`name` = __func__;".}
+  $name
+  # import std/strutils
+  # ($name).rsplit('_', 1)[0]
+
+# TODO:proc getFrame*(): PFrame {.compilerRtl, inl.} = framePtr
+template getPFrame*(): PFrame =
+  block:
+    # note: PFrame.calldepth (among other fields...) seems useful
+    when NimStackTrace:
+      # IMPROVE: this does a double pointer copy (not a huge deal but still)
+      var framePtr {.inject.}: PFrame
+      {.emit: "`framePtr` = &FR_;".}
+      framePtr
+
+template setFrameMsg*(msg: string) =
+  ## attach a msg to current PFrame. This can be called multiple times
+  ## in a given PFrame.
+  when NimStackTrace:
+    let fr = getPFrame()
+    # let fr = getFrame()
+    # let fr = framePtr
+    # TODO: instead realloc etc; TODO: also, js
+    # TODO: set an upper limit? maybe not needed unless stack grows large AND lots of msgs are written
+    frameMsgBuf.setLen fr.frameMsgLen
+    frameMsgBuf.add msg
+    fr.frameMsgLen += msg.len

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -54,6 +54,23 @@ type
 
 include "system/basic_types"
 
+
+proc compileOption*(option: string): bool {.
+  magic: "CompileOption", noSideEffect.}
+  ## Can be used to determine an `on|off` compile-time option. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   when compileOption("floatchecks"):
+  ##     echo "compiled with floating point NaN and Inf checks"
+
+proc compileOption*(option, arg: string): bool {.
+  magic: "CompileOptionArg", noSideEffect.}
+  ## Can be used to determine an enum compile-time option. Example:
+  ##
+  ## .. code-block:: Nim
+  ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
+  ##     echo "compiled with optimization for size and uses Boehm's GC"
+
 {.push warning[GcMem]: off, warning[Uninit]: off.}
 {.push hints: off.}
 
@@ -1040,22 +1057,6 @@ const
   # emit this flag
   # for string literals, it allows for some optimizations.
 
-proc compileOption*(option: string): bool {.
-  magic: "CompileOption", noSideEffect.}
-  ## Can be used to determine an `on|off` compile-time option. Example:
-  ##
-  ## .. code-block:: Nim
-  ##   when compileOption("floatchecks"):
-  ##     echo "compiled with floating point NaN and Inf checks"
-
-proc compileOption*(option, arg: string): bool {.
-  magic: "CompileOptionArg", noSideEffect.}
-  ## Can be used to determine an enum compile-time option. Example:
-  ##
-  ## .. code-block:: Nim
-  ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
-  ##     echo "compiled with optimization for size and uses Boehm's GC"
-
 const
   hasThreadSupport = compileOption("threads") and not defined(nimscript)
   hasSharedHeap = defined(boehmgc) or defined(gogc) # don't share heaps; every thread has its own
@@ -1899,7 +1900,8 @@ type
     filename*: cstring  ## Filename of the proc that is currently executing.
     len*: int16         ## Length of the inspectable slots.
     calldepth*: int16   ## Used for max call depth checking.
-    frameMsgLen*: int   ## end position in frameMsgBuf for this frame.
+    when NimStackTraceMsgs:
+      frameMsgLen*: int   ## end position in frameMsgBuf for this frame.
 
 when defined(js):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -530,18 +530,6 @@ type
   RootRef* = ref RootObj ## Reference to `RootObj`.
 
 
-type
-  PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;
-                        ## part of the debugger API.
-  TFrame* {.importc, nodecl, final.} = object ## The frame itself.
-    prev*: PFrame       ## Previous frame; used for chaining the call stack.
-    procname*: cstring  ## Name of the proc that is currently executing.
-    line*: int          ## Line number of the proc that is currently executing.
-    filename*: cstring  ## Filename of the proc that is currently executing.
-    len*: int16         ## Length of the inspectable slots.
-    calldepth*: int16   ## Used for max call depth checking.
-    frameMsgLen*: int
-
 include "system/exceptions"
 
 when defined(js) or defined(nimdoc):
@@ -1899,6 +1887,19 @@ var
     ## in case of an `unhandle exception` event. The standard handler
     ## writes an error message and terminates the program, except when
     ## using `--os:any`
+
+type
+  PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;
+                        ## part of the debugger API.
+  # keep in sync with nimbase.h `struct TFrame_`
+  TFrame* {.importc, nodecl, final.} = object ## The frame itself.
+    prev*: PFrame       ## Previous frame; used for chaining the call stack.
+    procname*: cstring  ## Name of the proc that is currently executing.
+    line*: int          ## Line number of the proc that is currently executing.
+    filename*: cstring  ## Filename of the proc that is currently executing.
+    len*: int16         ## Length of the inspectable slots.
+    calldepth*: int16   ## Used for max call depth checking.
+    frameMsgLen*: int   ## end position in frameMsgBuf for this frame.
 
 when defined(js):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -530,6 +530,18 @@ type
   RootRef* = ref RootObj ## Reference to `RootObj`.
 
 
+type
+  PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;
+                        ## part of the debugger API.
+  TFrame* {.importc, nodecl, final.} = object ## The frame itself.
+    prev*: PFrame       ## Previous frame; used for chaining the call stack.
+    procname*: cstring  ## Name of the proc that is currently executing.
+    line*: int          ## Line number of the proc that is currently executing.
+    filename*: cstring  ## Filename of the proc that is currently executing.
+    len*: int16         ## Length of the inspectable slots.
+    calldepth*: int16   ## Used for max call depth checking.
+    frameMsgLen*: int
+
 include "system/exceptions"
 
 when defined(js) or defined(nimdoc):
@@ -1887,17 +1899,6 @@ var
     ## in case of an `unhandle exception` event. The standard handler
     ## writes an error message and terminates the program, except when
     ## using `--os:any`
-
-type
-  PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;
-                        ## part of the debugger API.
-  TFrame* {.importc, nodecl, final.} = object ## The frame itself.
-    prev*: PFrame       ## Previous frame; used for chaining the call stack.
-    procname*: cstring  ## Name of the proc that is currently executing.
-    line*: int          ## Line number of the proc that is currently executing.
-    filename*: cstring  ## Filename of the proc that is currently executing.
-    len*: int16         ## Length of the inspectable slots.
-    calldepth*: int16   ## Used for max call depth checking.
 
 when defined(js):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -16,7 +16,10 @@ type
     procname*: cstring      ## Name of the proc that is currently executing.
     line*: int              ## Line number of the proc that is currently executing.
     filename*: cstring      ## Filename of the proc that is currently executing.
-    pframe*: PFrame
+    frameMsg*: string       ## When a stacktrace is generated in a given frame and
+                            ## rendered at a later time, we should ensure the stacktrace
+                            ## data isn't invalidated; any pointer into PFrame is
+                            ## subject to being invalidated so shouldn't be stored.
 
   Exception* {.compilerproc, magic: "Exception".} = object of RootObj ## \
     ## Base exception class.

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -16,6 +16,7 @@ type
     procname*: cstring      ## Name of the proc that is currently executing.
     line*: int              ## Line number of the proc that is currently executing.
     filename*: cstring      ## Filename of the proc that is currently executing.
+    pframe*: PFrame
 
   Exception* {.compilerproc, magic: "Exception".} = object of RootObj ## \
     ## Base exception class.

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -1,3 +1,7 @@
+const NimStackTraceMsgs =
+  when defined(nimHasStacktraceMsgs): compileOption("stacktraceMsgs")
+  else: false
+
 type
   RootEffect* {.compilerproc.} = object of RootObj ## \
     ## Base effect class.
@@ -16,7 +20,8 @@ type
     procname*: cstring      ## Name of the proc that is currently executing.
     line*: int              ## Line number of the proc that is currently executing.
     filename*: cstring      ## Filename of the proc that is currently executing.
-    frameMsg*: string       ## When a stacktrace is generated in a given frame and
+    when NimStackTraceMsgs:
+      frameMsg*: string     ## When a stacktrace is generated in a given frame and
                             ## rendered at a later time, we should ensure the stacktrace
                             ## data isn't invalidated; any pointer into PFrame is
                             ## subject to being invalidated so shouldn't be stored.

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -53,9 +53,10 @@ type
     len: int
     prev: ptr GcFrameHeader
 
+when NimStackTraceMsgs:
+  var frameMsgBuf* {.threadvar.}: string
 var
   framePtr {.threadvar.}: PFrame
-  frameMsgBuf* {.threadvar.}: string
   excHandler {.threadvar.}: PSafePoint
     # list of exception handlers
     # a global variable for the root of all try blocks
@@ -225,11 +226,13 @@ proc auxWriteStackTrace(f: PFrame; s: var seq[StackTraceEntry]) =
     s[last] = StackTraceEntry(procname: it.procname,
                               line: it.line,
                               filename: it.filename)
-    let first = if it.prev == nil: 0 else: it.prev.frameMsgLen
-    if it.frameMsgLen > first:
-      s[last].frameMsg.setLen(it.frameMsgLen - first)
-      # somehow string slicing not available here
-      for i in first .. it.frameMsgLen-1: s[last].frameMsg[i-first] = frameMsgBuf[i]
+    when NimStackTraceMsgs:
+      let first = if it.prev == nil: 0 else: it.prev.frameMsgLen
+      if it.frameMsgLen > first:
+        s[last].frameMsg.setLen(it.frameMsgLen - first)
+        # somehow string slicing not available here
+        for i in first .. it.frameMsgLen-1:
+          s[last].frameMsg[i-first] = frameMsgBuf[i]
     it = it.prev
     dec last
 
@@ -242,11 +245,12 @@ template addFrameEntry(s: var string, f: StackTraceEntry|PFrame) =
     add(s, ')')
   for k in 1..max(1, 25-(s.len-oldLen)): add(s, ' ')
   add(s, f.procname)
-  when type(f) is StackTraceEntry:
-    add(s, f.frameMsg)
-  else:
-    var first = if f.prev == nil: 0 else: f.prev.frameMsgLen
-    for i in first..<f.frameMsgLen: add(s, frameMsgBuf[i])
+  when NimStackTraceMsgs:
+    when type(f) is StackTraceEntry:
+      add(s, f.frameMsg)
+    else:
+      var first = if f.prev == nil: 0 else: f.prev.frameMsgLen
+      for i in first..<f.frameMsgLen: add(s, frameMsgBuf[i])
   add(s, "\n")
 
 proc `$`(s: seq[StackTraceEntry]): string =
@@ -532,10 +536,10 @@ proc callDepthLimitReached() {.noinline.} =
 proc nimFrame(s: PFrame) {.compilerRtl, inl, raises: [].} =
   if framePtr == nil:
     s.calldepth = 0
-    s.frameMsgLen = 0
+    when NimStackTraceMsgs: s.frameMsgLen = 0
   else:
     s.calldepth = framePtr.calldepth+1
-    s.frameMsgLen = framePtr.frameMsgLen
+    when NimStackTraceMsgs: s.frameMsgLen = framePtr.frameMsgLen
   s.prev = framePtr
   framePtr = s
   if s.calldepth == nimCallDepthLimit: callDepthLimitReached()

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -222,13 +222,12 @@ proc auxWriteStackTrace(f: PFrame; s: var seq[StackTraceEntry]) =
       s.setLen(last+1)
   it = f
   while it != nil:
-    let first = if it.prev == nil: 0 else: it.prev.frameMsgLen
     s[last] = StackTraceEntry(procname: it.procname,
                               line: it.line,
                               filename: it.filename)
-    let msgLen = it.frameMsgLen - first
-    if msgLen > 0:
-      s[last].frameMsg.setLen(msgLen)
+    let first = if it.prev == nil: 0 else: it.prev.frameMsgLen
+    if it.frameMsgLen > first:
+      s[last].frameMsg.setLen(it.frameMsgLen - first)
       # somehow string slicing not available here
       for i in first .. it.frameMsgLen-1: s[last].frameMsg[i-first] = frameMsgBuf[i]
     it = it.prev

--- a/tests/assert/tassert_c.nim
+++ b/tests/assert/tassert_c.nim
@@ -36,4 +36,4 @@ try:
 except AssertionError:
   let e = getCurrentException()
   let trace = e.getStackTrace
-  echo tmatch(trace, expected)
+  if tmatch(trace, expected): echo true else: echo "wrong trace:\n" & trace

--- a/tests/stdlib/mstackframes.nim
+++ b/tests/stdlib/mstackframes.nim
@@ -1,19 +1,8 @@
 import std/stackframes
 
-const expected = """
-tstackframes.nim(50)     tstackframes
-tstackframes.nim(41)     main ("main",)
-tstackframes.nim(35)     main2 ("main2", 5, 1)
-tstackframes.nim(35)     main2 ("main2", 4, 2)
-tstackframes.nim(35)     main2 ("main2", 3, 3)
-tstackframes.nim(34)     main2 ("main2", 2, 4)
-tstackframes.nim(33)     bar ("bar ",)
-"""
 
 
-
-
-# line 20
+# line 5
 var count = 0
 
 proc main1(n: int) =
@@ -30,9 +19,12 @@ proc main2(n: int) =
   bar()
   main2(n-1)
 
-import strutils
 proc main() =
-  setFrameMsg $("main", )
+  var z = 0
+  setFrameMsg "\n z1: " & $z
+  # multiple calls inside a frame are possible
+  z.inc
+  setFrameMsg "\n z2: " & $z
   try:
     main2(5)
   except CatchableError:
@@ -41,6 +33,6 @@ proc main() =
               # were a reference instead of a copy, this would fail.
     let e = getCurrentException()
     let trace = e.getStackTrace
-    doAssert trace.startsWith(expected), "\n" & trace
+    echo trace
 
 main()

--- a/tests/stdlib/mstackframes.nim
+++ b/tests/stdlib/mstackframes.nim
@@ -1,0 +1,46 @@
+import std/stackframes
+
+const expected = """
+tstackframes.nim(50)     tstackframes
+tstackframes.nim(41)     main ("main",)
+tstackframes.nim(35)     main2 ("main2", 5, 1)
+tstackframes.nim(35)     main2 ("main2", 4, 2)
+tstackframes.nim(35)     main2 ("main2", 3, 3)
+tstackframes.nim(34)     main2 ("main2", 2, 4)
+tstackframes.nim(33)     bar ("bar ",)
+"""
+
+
+
+
+# line 20
+var count = 0
+
+proc main1(n: int) =
+  setFrameMsg $("main1", n)
+  if n > 0:
+    main1(n-1)
+
+proc main2(n: int) =
+  count.inc
+  setFrameMsg $("main2", n, count)
+  proc bar() =
+    setFrameMsg $("bar ",)
+    if n < 3: raise newException(CatchableError, "on purpose")
+  bar()
+  main2(n-1)
+
+import strutils
+proc main() =
+  setFrameMsg $("main", )
+  try:
+    main2(5)
+  except CatchableError:
+    main1(10) # goes deep and then unwinds; sanity check to ensure `setFrameMsg` from inside
+              # `main1` won't invalidate the stacktrace; if StackTraceEntry.frameMsg
+              # were a reference instead of a copy, this would fail.
+    let e = getCurrentException()
+    let trace = e.getStackTrace
+    doAssert trace.startsWith(expected), "\n" & trace
+
+main()

--- a/tests/stdlib/mstackframes.nim
+++ b/tests/stdlib/mstackframes.nim
@@ -21,10 +21,10 @@ proc main2(n: int) =
 
 proc main() =
   var z = 0
-  setFrameMsg "\n z1: " & $z
+  setFrameMsg "\n  z: " & $z, prefix = ""
   # multiple calls inside a frame are possible
   z.inc
-  setFrameMsg "\n z2: " & $z
+  setFrameMsg "\n  z: " & $z, prefix = ""
   try:
     main2(5)
   except CatchableError:

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -12,8 +12,8 @@ tstackframes.nim(35)     main2 ("main2", 4, 2)
 tstackframes.nim(35)     main2 ("main2", 3, 3)
 tstackframes.nim(34)     main2 ("main2", 2, 4)
 tstackframes.nim(33)     bar ("bar ",)
-assertions.nim(27)       failedAssertImpl
 """
+
 
 
 
@@ -30,7 +30,7 @@ proc main2(n: int) =
   setFrameMsg $("main2", n, count)
   proc bar() =
     setFrameMsg $("bar ",)
-    doAssert n >= 3
+    if n < 3: raise newException(CatchableError, "on purpose")
   bar()
   main2(n-1)
 
@@ -39,7 +39,7 @@ proc main() =
   setFrameMsg $("main", )
   try:
     main2(5)
-  except AssertionError:
+  except CatchableError:
     main1(10) # goes deep and then unwinds; sanity check to ensure `setFrameMsg` from inside
               # `main1` won't invalidate the stacktrace; if StackTraceEntry.frameMsg
               # were a reference instead of a copy, this would fail.

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -1,16 +1,50 @@
+discard """
+  cmd: "nim $target $options --excessiveStackTrace:off $file"
+"""
+
 import std/stackframes
 
-proc main2(n: int) =
-  setFrameMsg $(n,)
-  if n > 0:
-    main2(n-1)
+const expected = """
+tstackframes.nim(50)     tstackframes
+tstackframes.nim(41)     main ("main",)
+tstackframes.nim(35)     main2 ("main2", 5, 1)
+tstackframes.nim(35)     main2 ("main2", 4, 2)
+tstackframes.nim(35)     main2 ("main2", 3, 3)
+tstackframes.nim(34)     main2 ("main2", 2, 4)
+tstackframes.nim(33)     bar ("bar ",)
+assertions.nim(27)       failedAssertImpl
+"""
 
-proc main(n: int) =
-  setFrameMsg $(n,)
+
+
+# line 20
+var count = 0
+
+proc main1(n: int) =
+  setFrameMsg $("main1", n)
+  if n > 0:
+    main1(n-1)
+
+proc main2(n: int) =
+  count.inc
+  setFrameMsg $("main2", n, count)
   proc bar() =
-    setFrameMsg "in bar "
+    setFrameMsg $("bar ",)
     doAssert n >= 3
   bar()
-  main(n-1)
+  main2(n-1)
 
-main(10)
+import strutils
+proc main() =
+  setFrameMsg $("main", )
+  try:
+    main2(5)
+  except AssertionError:
+    main1(10) # goes deep and then unwinds; sanity check to ensure `setFrameMsg` from inside
+              # `main1` won't invalidate the stacktrace; if StackTraceEntry.frameMsg
+              # were a reference instead of a copy, this would fail.
+    let e = getCurrentException()
+    let trace = e.getStackTrace
+    doAssert trace.startsWith(expected), "\n" & trace
+
+main()

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -6,9 +6,6 @@ proc main2(n: int) =
     main2(n-1)
 
 proc main(n: int) =
-  #[
-  TODO: instead, simply allow setting custom frame msg
-  ]#
   setFrameMsg $(n,)
   proc bar() =
     setFrameMsg "in bar "

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -2,49 +2,27 @@ discard """
   cmd: "nim $target $options --excessiveStackTrace:off $file"
 """
 
-import std/stackframes
+import std/[strformat,os,osproc]
 
-const expected = """
-tstackframes.nim(50)     tstackframes
-tstackframes.nim(41)     main ("main",)
-tstackframes.nim(35)     main2 ("main2", 5, 1)
-tstackframes.nim(35)     main2 ("main2", 4, 2)
-tstackframes.nim(35)     main2 ("main2", 3, 3)
-tstackframes.nim(34)     main2 ("main2", 2, 4)
-tstackframes.nim(33)     bar ("bar ",)
-"""
-
-
-
-
-# line 20
-var count = 0
-
-proc main1(n: int) =
-  setFrameMsg $("main1", n)
-  if n > 0:
-    main1(n-1)
-
-proc main2(n: int) =
-  count.inc
-  setFrameMsg $("main2", n, count)
-  proc bar() =
-    setFrameMsg $("bar ",)
-    if n < 3: raise newException(CatchableError, "on purpose")
-  bar()
-  main2(n-1)
-
-import strutils
 proc main() =
-  setFrameMsg $("main", )
-  try:
-    main2(5)
-  except CatchableError:
-    main1(10) # goes deep and then unwinds; sanity check to ensure `setFrameMsg` from inside
-              # `main1` won't invalidate the stacktrace; if StackTraceEntry.frameMsg
-              # were a reference instead of a copy, this would fail.
-    let e = getCurrentException()
-    let trace = e.getStackTrace
-    doAssert trace.startsWith(expected), "\n" & trace
+  const nim = getCurrentCompilerExe()
+  const file = currentSourcePath().parentDir / "mstackframes.nim"
+  # strangely, --hint:cc:off was needed
+  let cmd = fmt"{nim} c -f --experimental:compiletimeFFI --hints:off --hint:cc:off {file}"
+  let (output, exitCode) = execCmdEx(cmd)
+  let expected = """
+hello world stderr
+hi stderr
+foo
+foo:100
+foo:101
+foo:102:103
+foo:102:103:104
+foo:0.03:asdf:103:105
+ret={s1:foobar s2:foobar age:25 pi:3.14}
+"""
+  doAssert output == expected, output
+  doAssert exitCode == 0
 
-main()
+when defined(nimHasLibFFIEnabled):
+  main()

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -1,6 +1,5 @@
 import std/[strformat,os,osproc]
-# import "../../compiler/unittest_light"
-import pkg/compiler/unittest_light
+import "$nim/compiler/unittest_light" # works even if moved by megatest
 
 proc main(opt: string, expected: string) =
   const nim = getCurrentCompilerExe()

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -1,5 +1,6 @@
 import std/[strformat,os,osproc]
-import compiler/unittest_light
+# import "../../compiler/unittest_light"
+import pkg/compiler/unittest_light
 
 proc main(opt: string, expected: string) =
   const nim = getCurrentCompilerExe()

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -1,0 +1,19 @@
+import std/stackframes
+
+proc main2(n: int) =
+  setFrameMsg $(n,)
+  if n > 0:
+    main2(n-1)
+
+proc main(n: int) =
+  #[
+  TODO: instead, simply allow setting custom frame msg
+  ]#
+  setFrameMsg $(n,)
+  proc bar() =
+    setFrameMsg "in bar "
+    doAssert n >= 3
+  bar()
+  main(n-1)
+
+main(10)

--- a/tests/stdlib/tstackframes.nim
+++ b/tests/stdlib/tstackframes.nim
@@ -11,9 +11,9 @@ proc main(opt: string, expected: string) =
 
 main("on"): """
 mstackframes.nim(38)     mstackframes
-mstackframes.nim(29)     main 
- z1: 0 
- z2: 1
+mstackframes.nim(29)     main
+  z: 0
+  z: 1
 mstackframes.nim(20)     main2 ("main2", 5, 1)
 mstackframes.nim(20)     main2 ("main2", 4, 2)
 mstackframes.nim(20)     main2 ("main2", 3, 3)


### PR DESCRIPTION
stacktraces can now show custom runtime msgs per frame.

* useful in many cases where the stacktrace alone isn't sufficient to debug an issue; in particular for any parser / compiler (such as nim compiler), showing additional runtime info helps showing tracing program along with traced source code (+ arbitrary computed values)

* efficient implementation using a fixed string, so there is no allocation cost (amortized cost = O(1)); the only allocations happen if an exception is thrown; for stackframe entries with a nonempty custom msg, a string will be allocated before unwinding the stack so that the custom msg isn't invalidated by further calls to `setFrameMsg`

## example:
say you want to debug an internal compiler error such as https://github.com/nim-lang/Nim/issues/12263 which normally gives a regular stacktrace error (with --stacktrace:on); 

if we simply add the following line inside `proc semExpr(...)` (obviously `setFrameMsg` can be called in other places as needed) 
```nim
when defined(nimCompilerStackraceHints):
  setFrameMsg c.config$n.info & " " & $n.kind
```
it'll show that context in each stackframe corresponding to that (re-entrant) function, which helps showing the progress in the file being compiled:


stacktrace with custom runtime msgs for `nim c /pathto/t1015.nim`
shows both tracing and traced programs along side:

```
compiler/nim.nim(118) nim
compiler/nim.nim(95) handleCmdLine
compiler/cmdlinehelper.nim(105) loadConfigsAndRunMainCommand
compiler/main.nim(190) mainCommand
compiler/main.nim(92) commandCompileToC
compiler/modules.nim(143) compileProject
compiler/modules.nim(84) compileModule
compiler/passes.nim(210) processModule
compiler/passes.nim(86) processTopLevelStmt
compiler/sem.nim(600) myProcess
compiler/sem.nim(568) semStmtAndGenerateGenerics
compiler/semstmts.nim(2240) semStmt
compiler/semexprs.nim(986) semExprNoType
compiler/semexprs.nim(2743) semExpr /pathto/t1015.nim(5, 1) nkStmtList
compiler/semstmts.nim(2180) semStmtList
compiler/semexprs.nim(2670) semExpr /pathto/t1015.nim(35, 1) nkWhenStmt
compiler/semexprs.nim(2256) semWhen
compiler/semexprs.nim(2743) semExpr /pathto/t1015.nim(36, 3) nkStmtList
compiler/semstmts.nim(2180) semStmtList
compiler/semexprs.nim(2746) semExpr /pathto/t1015.nim(50, 3) nkLetSection
compiler/semstmts.nim(450) semVarOrLet
compiler/semexprs.nim(64) semExprWithType
compiler/semexprs.nim(2708) semExpr /pathto/t1015.nim(50, 33) nkBracket
compiler/semexprs.nim(557) semArrayConstr
compiler/semexprs.nim(64) semExprWithType
compiler/semexprs.nim(2654) semExpr /pathto/t1015.nim(51, 10) nkPrefix
compiler/semexprs.nim(2248) semMagic
compiler/semexprs.nim(967) semDirectOp
compiler/semexprs.nim(816) semOverloadedCallAnalyseEffects
compiler/semcall.nim(532) semOverloadedCall
compiler/semcall.nim(335) resolveOverloads
compiler/semcall.nim(93) pickBestCandidate
compiler/sigmatch.nim(2522) matches
compiler/sigmatch.nim(2459) matchesAux
compiler/sigmatch.nim(2261) prepareOperand
compiler/semexprs.nim(49) semOperand
compiler/semexprs.nim(2708) semExpr /pathto/t1015.nim(51, 11) nkBracket
compiler/semexprs.nim(557) semArrayConstr
compiler/semexprs.nim(64) semExprWithType
compiler/semexprs.nim(2704) semExpr /pathto/t1015.nim(52, 7) nkPar
compiler/semexprs.nim(2513) semTupleConstr
compiler/semexprs.nim(2435) semTuplePositionsConstr
compiler/semexprs.nim(64) semExprWithType
compiler/semexprs.nim(2615) semExpr /pathto/t1015.nim(52, 54) nkDotExpr
compiler/semexprs.nim(2645) semExpr /pathto/t1015.nim(52, 54) nkCall
compiler/semexprs.nim(272) semConv
compiler/semcall.nim(444) inferWithMetatype
compiler/sigmatch.nim(2171) paramTypesMatch
compiler/sigmatch.nim(2015) paramTypesMatchAux
compiler/sigmatch.nim(1654) typeRel
compiler/sigmatch.nim(1210) typeRel
compiler/types.nim(815) lengthOrd
compiler/types.nim(776) lastOrd
compiler/msgs.nim(565) internalError
compiler/msgs.nim(443) rawMessage
compiler/msgs.nim(440) rawMessage
compiler/msgs.nim(356) handleError
compiler/msgs.nim(346) quit
```

## unrelated changes
* added stackframes.procName
