### PR TITLE
[backport] remove 'CountTable.mget'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,9 @@
 - Global variable `lc` has been removed from sugar.nim.
 - `distinctBase` has been moved from sugar.nim to typetraits and now implemented as
   compiler type trait instead of macro. `distinctBase` in sugar module is now deprecated.
+- `CountTable.mget` has been removed from `tables.nim`. It didn't work, and it
+  was an oversight to be included in v1.0.
+
 
 ### Breaking changes in the compiler
 
@@ -50,10 +53,11 @@
 - Added `times.fromUnixFloat,toUnixFloat`, subsecond resolution versions of `fromUnix`,`toUnixFloat`.
 - Added `wrapnils` module for chains of field-access and indexing where the LHS can be nil.
   This simplifies code by reducing need for if-else branches around intermediate maybe nil values.
-  Eg: `echo ?.n.typ.kind`
+  E.g. `echo ?.n.typ.kind`
 - Added `minIndex` and `maxIndex` to the `sequtils` module
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
+
 
 ## Library changes
 
@@ -71,9 +75,10 @@
 - `htmlgen.html` allows `lang` on the `<html>` tag and common valid attributes.
 - `macros.basename` and `basename=` got support for `PragmaExpr`,
   so that an expression like `MyEnum {.pure.}` is handled correctly.
-- `httpclient.maxredirects` changed from `int` to `Natural`, because negative values serve no purpose whatsoever.
-- `httpclient.newHttpClient` and `httpclient.newAsyncHttpClient` added `headers` argument to set initial HTTP Headers,
-  instead of a hardcoded empty `newHttpHeader()`.
+- `httpclient.maxredirects` changed from `int` to `Natural`, because negative values
+  serve no purpose whatsoever.
+- `httpclient.newHttpClient` and `httpclient.newAsyncHttpClient` added `headers`
+  argument to set initial HTTP Headers, instead of a hardcoded empty `newHttpHeader()`.
 
 
 ## Language additions

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2304,13 +2304,6 @@ proc `[]`*[A](t: CountTable[A], key: A): int =
   assert(not t.isSorted, "CountTable must not be used after sorting")
   ctget(t, key, 0)
 
-proc mget*[A](t: var CountTable[A], key: A): var int =
-  ## Retrieves the value at ``t[key]``. The value can be modified.
-  ##
-  ## If ``key`` is not in ``t``, the ``KeyError`` exception is raised.
-  assert(not t.isSorted, "CountTable must not be used after sorting")
-  get(t, key)
-
 proc `[]=`*[A](t: var CountTable[A], key: A, val: int) =
   ## Inserts a ``(key, value)`` pair into ``t``.
   ##
@@ -2673,12 +2666,6 @@ proc `[]`*[A](t: CountTableRef[A], key: A): int =
   ## * `hasKey proc<#hasKey,CountTableRef[A],A>`_ for checking if a key
   ##   is in the table
   result = t[][key]
-
-proc mget*[A](t: CountTableRef[A], key: A): var int =
-  ## Retrieves the value at ``t[key]``. The value can be modified.
-  ##
-  ## If ``key`` is not in ``t``, the ``KeyError`` exception is raised.
-  mget(t[], key)
 
 proc `[]=`*[A](t: CountTableRef[A], key: A, val: int) =
   ## Inserts a ``(key, value)`` pair into ``t``.


### PR DESCRIPTION
It didn't work, and it was an oversight to be included in v1.0.