### PR TITLE
properly fix #13196: json serialization with option for lossless roundtrip

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -685,7 +685,7 @@ proc pretty*(node: JsonNode, indent = 2): string =
   ## Similar to prettyprint in Python.
   runnableExamples:
     let j = %* {"name": "Isaac", "books": ["Robot Dreams"],
-                "details": {"age": 35, "pi": 3.1415}}
+                "details": {"age": 35, "number": 3.125}}
     doAssert pretty(j) == """
 {
   "name": "Isaac",
@@ -694,7 +694,7 @@ proc pretty*(node: JsonNode, indent = 2): string =
   ],
   "details": {
     "age": 35,
-    "pi": 3.1415
+    "number": 3.125
   }
 }"""
   result = ""

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -182,7 +182,7 @@ type
       elems*: seq[JsonNode]
 
 const floatSerializationPrecision = 17
-  # must be high enought to avoid roundrip serialization issues see #13196
+  # must be high enough to avoid roundtrip serialization issues see #13196
   # this works with nextafter(1.0, Inf).
   # note that 17 seems enough, unlike what is mentioned here for D which recommended 18, quoting:
   # > ceil(log(pow(2.0, double.mant_dig - 1)) / log(10.0) + 1) == (double.dig + 2)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -184,6 +184,10 @@ type
 const floatSerializationPrecision = 17
   # must be high enought to avoid roundrip serialization issues see #13196
   # this works with nextafter(1.0, Inf).
+  # note that 17 seems enough, unlike what is mentioned here for D which recommended 18, quoting:
+  # > ceil(log(pow(2.0, double.mant_dig - 1)) / log(10.0) + 1) == (double.dig + 2)
+  # see:
+  # https://github.com/dlang/phobos/blob/b885f607e26750673aba694c46899583779d2361/std/json.d#L1644
 
 proc newJString*(s: string): JsonNode =
   ## Creates a new `JString JsonNode`.

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -181,7 +181,9 @@ type
     of JArray:
       elems*: seq[JsonNode]
 
-const floatSerializationPrecision = 18
+const floatSerializationPrecision = 17
+  # must be high enought to avoid roundrip serialization issues see #13196
+  # this works with nextafter(1.0, Inf).
 
 proc newJString*(s: string): JsonNode =
   ## Creates a new `JString JsonNode`.

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -30,10 +30,17 @@ proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat, precisio
   ##           initialized and it will be overridden.
   ##
   let precision2 = if precision == -1: 16 else: precision
-  var format = "%."
-  format.addInt(precision2)
-  format.add 'g'
-  var n: int = c_sprintf(addr buf, format, value)
+
+  var buf2 {.noinit.}: array[6, char] # 6 is just enough to hold `%.16g`
+  var n2: int = c_sprintf(addr buf2,  "%%.%dg", precision2.cint)
+  # if n2 <= 0: quit(1) # if want to be exact
+
+  # this would fail for `tests/manyloc/standalone/barebone.nim`
+  # var format = "%."
+  # format.addInt(precision2)
+  # format.add 'g'
+
+  var n: int = c_sprintf(addr buf, addr buf2, value)
   var hasDot = false
   for i in 0..n-1:
     if buf[i] == ',':

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -16,7 +16,7 @@ proc writeToBuffer(buf: var array[65, char]; value: cstring) =
     buf[i] = value[i]
     inc i
 
-proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat, precision: static int = -1): int =
+proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat, precision = -1): int =
   ## This is the implementation to format floats in the Nim
   ## programming language. The specific format for floating point
   ## numbers is not specified in the Nim programming language and
@@ -29,8 +29,10 @@ proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat, precisio
   ## * `buf` - A buffer to write into. The buffer does not need to be
   ##           initialized and it will be overridden.
   ##
-  const precision2 = if precision == -1: 16 else: precision
-  const format = "%." & $precision2 & "g"
+  let precision2 = if precision == -1: 16 else: precision
+  var format = "%."
+  format.addInt(precision2)
+  format.add 'g'
   var n: int = c_sprintf(addr buf, format, value)
   var hasDot = false
   for i in 0..n-1:

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -16,7 +16,7 @@ proc writeToBuffer(buf: var array[65, char]; value: cstring) =
     buf[i] = value[i]
     inc i
 
-proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat): int =
+proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat, precision: static int = -1): int =
   ## This is the implementation to format floats in the Nim
   ## programming language. The specific format for floating point
   ## numbers is not specified in the Nim programming language and
@@ -29,7 +29,9 @@ proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat): int =
   ## * `buf` - A buffer to write into. The buffer does not need to be
   ##           initialized and it will be overridden.
   ##
-  var n: int = c_sprintf(addr buf, "%.16g", value)
+  const precision2 = if precision == -1: 16 else: precision
+  const format = "%." & $precision2 & "g"
+  var n: int = c_sprintf(addr buf, format, value)
   var hasDot = false
   for i in 0..n-1:
     if buf[i] == ',':

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -30,17 +30,7 @@ proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat, precisio
   ##           initialized and it will be overridden.
   ##
   let precision2 = if precision == -1: 16 else: precision
-
-  var buf2 {.noinit.}: array[6, char] # 6 is just enough to hold `%.16g`
-  var n2: int = c_sprintf(addr buf2,  "%%.%dg", precision2.cint)
-  # if n2 <= 0: quit(1) # if want to be exact
-
-  # this would fail for `tests/manyloc/standalone/barebone.nim`
-  # var format = "%."
-  # format.addInt(precision2)
-  # format.add 'g'
-
-  var n: int = c_sprintf(addr buf, addr buf2, value)
+  var n: int = c_sprintf(addr buf, "%.*g", precision2.cint, value)
   var hasDot = false
   for i in 0..n-1:
     if buf[i] == ',':

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -85,7 +85,7 @@ import formatfloat
 
 proc addFloat*(result: var string; x: float, precision: static int = -1) =
   ## Converts float to its string representation and appends it to `result`.
-  ## passing `precision >=0 ` can override the default precision.
+  ## passing `precision >=0` can override the default precision.
   ##
   ## .. code-block:: Nim
   ##   var

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -83,7 +83,7 @@ proc addCstringN(result: var string, buf: cstring; buflen: int) =
 
 import formatfloat
 
-proc addFloat*(result: var string; x: float, precision: static int = -1) =
+proc addFloat*(result: var string; x: float, precision = -1) =
   ## Converts float to its string representation and appends it to `result`.
   ## passing `precision >=0` can override the default precision.
   ##

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -83,8 +83,9 @@ proc addCstringN(result: var string, buf: cstring; buflen: int) =
 
 import formatfloat
 
-proc addFloat*(result: var string; x: float) =
+proc addFloat*(result: var string; x: float, precision: static int = -1) =
   ## Converts float to its string representation and appends it to `result`.
+  ## passing `precision >=0 ` can override the default precision.
   ##
   ## .. code-block:: Nim
   ##   var
@@ -95,7 +96,7 @@ proc addFloat*(result: var string; x: float) =
     result.add $x
   else:
     var buffer: array[65, char]
-    let n = writeFloatToBuffer(buffer, x)
+    let n = writeFloatToBuffer(buffer, x, precision = precision)
     result.addCstringN(cstring(buffer[0].addr), n)
 
 proc add*(result: var string; x: float) {.deprecated:


### PR DESCRIPTION
this properly fixes #13196 without affecting how nim prints/stringifies floats, so that:
`echo 0.6` is now 0.6 again, unlike after https://github.com/nim-lang/Nim/pull/13276

```nim
echo 0.6 # 0.6
import std/json
echo(%* 0.6) # 0.59999999999999998
```

## future PR's
implement https://github.com/ulfjack/ryu to keep short representations eg for json => see https://github.com/nim-lang/Nim/issues/13365
