### PR TITLE
allow conversion of ints to enums in json

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1013,7 +1013,7 @@ when defined(nimFixedForwardGeneric):
     verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
     if jsonNode.kind == JInt:
       let i = jsonNode.getBiggestInt
-      if (i <= low(T).int or i >= high(T).int) or $i.T == $i & " (invalid data!)":
+      if (i <= low(T).BiggestInt or i >= high(T).BiggestInt) or $i.T == $i & " (invalid data!)":
         raise newException(ValueError, "invalid enum value: " & $i)
       dst = i.T
     else:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1008,26 +1008,28 @@ when defined(nimFixedForwardGeneric):
       dst = T(jsonNode.fnum)
     else:
       dst = T(jsonNode.num)
-macro intValuesSet[T: enum](arg: typedesc[T]): untyped =
-  ## Takes an enum and returns a set of integers that contains all
-  ## valid enum integer representations of that enum.
 
-  let typedescImpl = getTypeImpl(arg)
-  let impl = typedescImpl[1].getImpl[2]
-  result = newNimNode(nnkCurly)
-  var i = 0
-  for idx in 1 ..< impl.len:
-    let child = impl[idx]
-    case child.kind
-    of nnkEnumFieldDef:
-      child[1].expectKind nnkIntLit
-      result.add child[1]
-      i = int(child[1].intVal)
-    of nnkIdent:
-      result.add newLit(i)
-    else:
-      child.expectkind({nnkEnumFieldDef, nnkIdent})
-    i += 1
+  macro intValuesSet[T: enum](arg: typedesc[T]): untyped =
+    ## Takes an enum and returns a set of integers that contains all
+    ## valid enum integer representations of that enum.
+
+    let typedescImpl = getTypeImpl(arg)
+    let impl = typedescImpl[1].getImpl[2]
+    result = newNimNode(nnkCurly)
+    var i = 0
+    for idx in 1 ..< impl.len:
+      let child = impl[idx]
+      case child.kind
+      of nnkEnumFieldDef:
+        child[1].expectKind nnkIntLit
+        result.add child[1]
+        i = int(child[1].intVal)
+      of nnkIdent:
+        result.add newLit(i)
+      else:
+        child.expectkind({nnkEnumFieldDef, nnkIdent})
+      i += 1
+
   proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
     verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
     if jsonNode.kind == JInt:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1010,8 +1010,14 @@ when defined(nimFixedForwardGeneric):
       dst = T(jsonNode.num)
 
   proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
-    verifyJsonKind(jsonNode, {JString}, jsonPath)
-    dst = parseEnum[T](jsonNode.getStr)
+    verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
+    if jsonNode.kind == JInt:
+      let i = jsonNode.getBiggestInt
+      if (i <= low(T).int or i >= high(T).int) or $i.T == $i & " (invalid data!)":
+        raise newException(ValueError, "invalid enum value: " & $i)
+      dst = i.T
+    else:
+      dst = parseEnum[T](jsonNode.getStr)
 
   proc initFromJson[T](dst: var seq[T]; jsonNode: JsonNode; jsonPath: var string) =
     verifyJsonKind(jsonNode, {JArray}, jsonPath)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1027,7 +1027,7 @@ when defined(nimFixedForwardGeneric):
       of nnkIdent:
         result.add newLit(i)
       else:
-        child.expectkind({nnkEnumFieldDef, nnkIdent})
+        child.expectKind({nnkEnumFieldDef, nnkIdent})
       i += 1
 
   proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string) =

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1035,7 +1035,7 @@ when defined(nimFixedForwardGeneric):
     if jsonNode.kind == JInt:
       let i = jsonNode.getBiggestInt
       const validValues = intValuesSet(T)
-      if i in validValues:
+      if i notin validValues:
         raise newException(ValueError, "invalid enum value: " & $i)
       dst = i.T
     else:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1032,7 +1032,8 @@ macro intValuesSet[T: enum](arg: typedesc[T]): untyped =
     verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
     if jsonNode.kind == JInt:
       let i = jsonNode.getBiggestInt
-      if (i <= low(T).BiggestInt or i >= high(T).BiggestInt) or $i.T == $i & " (invalid data!)":
+      const validValues = intValuesSet(T)
+      if i in validValues:
         raise newException(ValueError, "invalid enum value: " & $i)
       dst = i.T
     else:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1008,7 +1008,26 @@ when defined(nimFixedForwardGeneric):
       dst = T(jsonNode.fnum)
     else:
       dst = T(jsonNode.num)
+macro intValuesSet[T: enum](arg: typedesc[T]): untyped =
+  ## Takes an enum and returns a set of integers that contains all
+  ## valid enum integer representations of that enum.
 
+  let typedescImpl = getTypeImpl(arg)
+  let impl = typedescImpl[1].getImpl[2]
+  result = newNimNode(nnkCurly)
+  var i = 0
+  for idx in 1 ..< impl.len:
+    let child = impl[idx]
+    case child.kind
+    of nnkEnumFieldDef:
+      child[1].expectKind nnkIntLit
+      result.add child[1]
+      i = int(child[1].intVal)
+    of nnkIdent:
+      result.add newLit(i)
+    else:
+      child.expectkind({nnkEnumFieldDef, nnkIdent})
+    i += 1
   proc initFromJson[T: enum](dst: var T; jsonNode: JsonNode; jsonPath: var string) =
     verifyJsonKind(jsonNode, {JInt, JString}, jsonPath)
     if jsonNode.kind == JInt:

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -194,12 +194,29 @@ proc testJson() =
       TestEnum = object
         field: EnumType
 
-    var node = %{
+    var strNode = %{
       "field": %"Bar"
     }
+    var intNode = %{
+      "field": %0
+    }
 
-    var result = to(node, TestEnum)
+    var invalidIntNode() = %{
+      "field": %2
+    }
+
+    var result = to(strNode, TestEnum)
     doAssert result.field == Bar
+    result = to(intNode, TestEnum)
+    doAssert result.field == Foo
+
+    try:
+      result = to(invalidIntNode, TestEnum)
+      doAssert false
+    except ValueError as exc:
+      doAssert("2" in exc.msg)
+    except:
+      doAssert false
 
   # Test ref type in field.
   block:

--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -201,7 +201,7 @@ proc testJson() =
       "field": %0
     }
 
-    var invalidIntNode() = %{
+    var invalidIntNode = %{
       "field": %2
     }
 


### PR DESCRIPTION
in the web, enums are sent as int values in json. this modification would allow for the `to` macro (i think only the `to` macro?) to convert these into their correct enum value