### PR TITLE
new cmd: `nim r main [args...]` to compile & run, saving binary under $nimcache/main

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,17 @@
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.
 - The `define` and `undef` pragmas have been de-deprecated.
+- New command: `nim r main.nim [args...]` which compiles and runs main.nim, saving
+  the binary to $nimcache/main$exeExt, using the same logic as `nim c -r` to
+  avoid recompiling when sources don't change. This is now the preferred way to
+  run tests, avoiding the usual pain of clobbering your repo with binaries or
+  using tricky gitignore rules on posix. Example:
+  ```nim
+  nim r compiler/nim.nim --help # only compiled the first time
+  echo 'import os; echo getCurrentCompilerExe()' | nim r - # this works too
+  nim r compiler/nim.nim --fullhelp # no recompilation
+  nim r --nimcache:/tmp main # binary saved to /tmp/main
+  ```
 
 ## Tool changes
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -63,7 +63,7 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
       if processArgument(pass, p, argsCount, config): break
   if pass == passCmd2:
     if {optRun, optWasNimscript} * config.globalOptions == {} and
-        config.arguments.len > 0 and config.command.normalize notin ["run", "e"]:
+        config.arguments.len > 0 and config.command.normalize notin ["run", "e", "r"]:
       rawMessage(config, errGenerated, errArgsNeedRunOption)
 
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -255,8 +255,7 @@ type
     nimblePaths*: seq[AbsoluteDir]
     searchPaths*: seq[AbsoluteDir]
     lazyPaths*: seq[AbsoluteDir]
-    outFileAbs*: AbsoluteFile
-    outFile*: RelativeFile # used if outFileAbs is empty
+    outFile*: RelativeFile
     outDir*: AbsoluteDir
     prefixDir*, libpath*, nimcacheDir*: AbsoluteDir
     dllOverrides, moduleOverrides*, cfileSpecificOptions*: StringTableRef
@@ -526,14 +525,14 @@ proc getOutFile*(conf: ConfigRef; filename: RelativeFile, ext: string): Absolute
   conf.outDir / changeFileExt(filename, ext)
 
 proc absOutFile*(conf: ConfigRef): AbsoluteFile =
-  result = conf.outFileAbs
-  if result.isEmpty:
+  if false:
     doAssert not conf.outDir.isEmpty
     doAssert not conf.outFile.isEmpty
-    result = conf.outDir / conf.outFile
-    when defined(posix):
-      if dirExists(result.string): result.string.add ".out"
-    conf.outFileAbs = result
+    # xxx: fix this pre-existing bug causing `SuccessX` error messages to lie
+    # for `jsonscript`
+  result = conf.outDir / conf.outFile
+  when defined(posix):
+    if dirExists(result.string): result.string.add ".out"
 
 proc prepareToWriteOutput*(conf: ConfigRef): AbsoluteFile =
   ## Create the output directory and returns a full path to the output file

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -4,6 +4,7 @@
 
 Command:
   //compile, c                compile project with default code generator (C)
+  //r                         compile & run $nimcach/projname [arguments]
   //doc                       generate the documentation for inputfile
 
 Arguments:


### PR DESCRIPTION
(updated description)

new cmd: `nim r main [args...]` now outputs binary under `$nimcache/main` and runs `$nimcache/main [args...]`

## examples
```
nim r compiler/nim.nim --help # only compiled the first time
echo 'import os; echo getCurrentCompilerExe()' | nim r - # this works too
nim r compiler/nim.nim --fullhelp # no recompilation
nim r --nimcache:/tmp main # binary saved to /tmp/main
```

## benefits
* don't clobber source dirs with binaries; they're hard to gitignore on posix (no extension) without jumping through some hoops, and in fact I don't know anything that works without breaking other tooling, as I explained here; https://stackoverflow.com/questions/61381438/how-to-gitignore-extension-less-files-without-breaking-a-global-gitignore
* (once `--mode:js` is added in future PRs) don't clobber source dirs with generated js files (hard to gitignore because their filename looks exactly like a regular source js file)
* adhers more to out-of-source builds principle

**This can become the new preferred way to write tests in nims/nimble files**, avoiding the problem of clobbering your repo with binaries (or fighting gitignore on posix)

## related issues
* related to https://github.com/nim-lang/RFCs/issues/29 and https://github.com/nim-lang/nimble/issues/787

## same as in some other languages
* D: `dmd -run main.d` => outputs in some temp dir
* D(rdmd): `rdmd main.d` => outputs in some temp dir hashed by all relevant options
* go: ditto
```go
package main
import ("fmt"; "os")
func main() {
    ex, err := os.Executable()
    if err != nil { panic(err) }
    fmt.Println(ex)
}
```
* C via tcc: `tcc -run test.c`
=> doesn't generate a binary (and perhaps does all in memory but that's besides the point)
* ditto with scripting languages (python, swift, node js, octave, matlab etc) which don't generate clobbering artifacts when you run `python main.py` 
* lua via `lua test.lua`

## future work
- [x] `nim r --mode:cpp main` (EDIT: this was implemented by https://github.com/nim-lang/Nim/pull/14363, via --backend)
- [x] hash-based-caching (see https://github.com/timotheecour/Nim/issues/199) => https://github.com/nim-lang/Nim/pull/17829


## links
* https://github.com/PMunch/nimcr/issues/14