### PR TITLE
lib.rst: add a link for jsconsole [ci skip]

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -472,6 +472,9 @@ Modules for JS backend
 * `dom <dom.html>`_
   Declaration of the Document Object Model for the JS backend.
 
+* `jsconsole <jsconsole.html>`_
+  Wrapper for the ``console`` object.
+
 * `jscore <jscore.html>`_
   Wrapper of core JavaScript functions. For most purposes you should be using
   the ``math``, ``json``, and ``times`` stdlib modules instead of this module.


### PR DESCRIPTION
I did not know about this module until about an hour ago...

(why is CI running? I guess it won't hurt anyway...)