### PR TITLE
fix several bugs with `repr` 

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -16,6 +16,8 @@ when defined(nimHasUsed):
 
 import
   lexer, options, idents, strutils, ast, msgs, lineinfos
+from compiler/renderer2 import nil
+template renderTree2(a): untyped = renderer2.renderTree(a)
 
 type
   TRenderFlag* = enum
@@ -437,7 +439,7 @@ proc lsub(g: TSrcGen; n: PNode): int =
   of nkTableConstr:
     result = if n.len > 0: lcomma(g, n) + 2 else: len("{:}")
   of nkClosedSymChoice, nkOpenSymChoice:
-    result = lsons(g, n) + len("()") + n.len - 1
+    if n.len > 0: result += lsub(g, n[0])
   of nkTupleTy: result = lcomma(g, n) + len("tuple[]")
   of nkTupleClassTy: result = len("tuple")
   of nkDotExpr: result = lsons(g, n) + 1
@@ -529,10 +531,12 @@ proc lsub(g: TSrcGen; n: PNode): int =
     if n[0].kind != nkEmpty: result = result + lsub(g, n[0]) + 2
   of nkExceptBranch:
     result = lcomma(g, n, 0, -2) + lsub(g, lastSon(n)) + len("except_:_")
+  of nkObjectTy:
+    result = len("object_")
   else: result = MaxLineLen + 1
 
 proc fits(g: TSrcGen, x: int): bool =
-  result = x + g.lineLen <= MaxLineLen
+  result = x <= MaxLineLen
 
 type
   TSubFlag = enum
@@ -572,7 +576,8 @@ proc gcommaAux(g: var TSrcGen, n: PNode, ind: int, start: int = 0,
   for i in start..n.len + theEnd:
     var c = i < n.len + theEnd
     var sublen = lsub(g, n[i]) + ord(c)
-    if not fits(g, sublen) and (ind + sublen < MaxLineLen): optNL(g, ind)
+    if not fits(g, g.lineLen + sublen):
+      optNL(g, ind)
     let oldLen = g.tokens.len
     gsub(g, n[i])
     if c:
@@ -1139,10 +1144,12 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     putWithSpace(g, tkColon, ":")
     gsub(g, n, 1)
   of nkInfix:
+    let oldLineLen = g.lineLen # we cache this because lineLen gets updated below
     infixArgument(g, n, 1)
     put(g, tkSpaces, Space)
     gsub(g, n, 0)        # binary operator
-    if n.len == 3 and not fits(g, lsub(g, n[2]) + lsub(g, n[0]) + 1):
+    # eg: `n1 == n2` decompses as following sum:
+    if n.len == 3 and not fits(g, oldLineLen + lsub(g, n[1]) + lsub(g, n[2]) + lsub(g, n[0]) + len("  ")):
       optNL(g, g.indent + longIndentWid)
     else:
       put(g, tkSpaces, Space)

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -574,8 +574,7 @@ proc gcommaAux(g: var TSrcGen, n: PNode, ind: int, start: int = 0,
   for i in start..n.len + theEnd:
     var c = i < n.len + theEnd
     var sublen = lsub(g, n[i]) + ord(c)
-    if not fits(g, g.lineLen + sublen):
-      optNL(g, ind)
+    if not fits(g, g.lineLen + sublen) and (ind + sublen < MaxLineLen): optNL(g, ind)
     let oldLen = g.tokens.len
     gsub(g, n[i])
     if c:

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -16,8 +16,6 @@ when defined(nimHasUsed):
 
 import
   lexer, options, idents, strutils, ast, msgs, lineinfos
-from compiler/renderer2 import nil
-template renderTree2(a): untyped = renderer2.renderTree(a)
 
 type
   TRenderFlag* = enum

--- a/tests/errmsgs/t8434.nim
+++ b/tests/errmsgs/t8434.nim
@@ -1,8 +1,7 @@
 discard """
   errormsg: "type mismatch: got <byte, int literal(0)>"
   nimout: '''but expected one of:
-proc fun0[T1: int | float |
-    object | array | seq](a1: T1; a2: int)
+proc fun0[T1: int | float | object | array | seq](a1: T1; a2: int)
   first type mismatch at position: 1
   required type for a1: T1: int or float or object or array or seq[T]
   but expression 'byte(1)' is of type: byte

--- a/tests/macros/tdumpast.nim
+++ b/tests/macros/tdumpast.nim
@@ -31,3 +31,20 @@ dumpAST:
 
   proc sub(x, y: int): int = return x - y
 
+macro fun() =
+  let n = quote do:
+    1+1 == 2
+  doAssert n.repr == "1 + 1 == 2", n.repr
+fun()
+
+macro fun2(): untyped =
+  let n = quote do:
+    1 + 2 * 3 == 1 + 6
+  doAssert n.repr == "1 + 2 * 3 == 1 + 6", n.repr
+fun2()
+
+macro fun3(): untyped =
+  let n = quote do:
+    int | float | array | seq | object | ptr | pointer | float32
+  doAssert n.repr == "int | float | array | seq | object | ptr | pointer | float32", n.repr
+fun3()

--- a/tests/stdlib/tunittesttemplate.nim
+++ b/tests/stdlib/tunittesttemplate.nim
@@ -1,12 +1,12 @@
 discard """
   exitcode: 1
   outputsub: '''
-    tunittesttemplate.nim(20, 12): Check failed: a.b ==
-    2
+    tunittesttemplate.nim(20, 12): Check failed: a.b == 2
     a.b was 0
   [FAILED] 1
 '''
 """
+
 
 # bug #6736
 


### PR DESCRIPTION
* `repr` didn't work well for infix:
before PR:
`1 + 1 == 2`
would render sometimes as:
```
1 + 1 ==
    2
```
after PR: would render as
```
1 + 1 == 2
```

there were actually a few bugs related to infix, see PR for details


* `repr` was confused by nkClosedSymChoice, nkOpenSymChoice, resulting in very large values for `lsub` because it was summing up over all the children even though this doesn't make sense for `lsub` (repr only stringifies a single child)

* `repr` was confused by nkObjectTy in `seq | object`, always adding a newline; now it correctly handles it in `lsub`

## see new tests:
tests/macros/tdumpast.nim
(all of which would fail before PR)