### PR TITLE
Fix to asynchttpserver form data/body broken with #13147

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -65,7 +65,8 @@
 
 ## Library changes
 
-- `asynchttpserver` now the request body is a FutureStream.
+- `asynchttpserver` added an iterator that allows the request body to be read in
+   chunks of data when new server "stream" option is set to true.
 - `asyncdispatch.drain` now properly takes into account `selector.hasPendingOperations`
   and only returns once all pending async operations are guaranteed to have completed.
 - `asyncdispatch.drain` now consistently uses the passed timeout value for all

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -81,7 +81,7 @@
 ##          bodyLength += req.body.len
 ##      await req.respond(Http200, htmlpage(contentLength, bodyLength))
 ##
-##    let server = newAsyncHttpServer(maxBody = 10485760, stream = true) # 10 MB
+##    let server = newAsyncHttpServer(maxBody = 10485760, stream = stream) # 10 MB
 ##    waitFor server.serve(Port(8080), cb)
 
 import tables, asyncnet, asyncdispatch, parseutils, uri, strutils

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -109,7 +109,7 @@ type
     reuseAddr: bool
     reusePort: bool
     maxBody: int ## The maximum content-length that will be read for the body.
-    stream: bool ## By default, the body of the response is readed immediately
+    stream: bool ## By default (stream = false), the body of the request is readed immediately
 
 proc newAsyncHttpServer*(reuseAddr = true, reusePort = false,
                          maxBody = 8388608, stream = false): AsyncHttpServer =


### PR DESCRIPTION
This fix add a new server option that allow the request body to be processed outside the asynchttpserver library to break big files into chunks of data. This change does not break anything and works with the jester and the rosencrantz.

The new server option "stream" when it is true uses the Future Streams otherwise all body is readed at once. The "stream" option by default is set to false.

The idea of this option I took from the python requests module (https://requests.readthedocs.io/en/v1.2.3/api/).
"When stream=True is set on the request, this avoids reading the content at once into memory for large responses. The chunk size is the number of bytes it should read into memory. This is not necessarily the length of each item returned as decoding can take place."

Example:
```nim
let server = newAsyncHttpServer(stream = true) # if true use Future Streams
waitFor server.serve(Port(8080), cb)
```