### PR TITLE
Small refactor on generic dollar for object

### DIFF
--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -85,8 +85,8 @@ proc `$`*[T: tuple|object](x: T): string =
       result.add(": ")
 
     when compiles($value):
-      when value isnot string and value isnot seq and compiles(value.isNil):
-        if value.isNil: result.add "nil"
+      when value is ptr or value is ref or value is pointer:
+        if value == nil: result.add "nil"
         else: result.addQuoted(value)
       else:
         result.addQuoted(value)

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -75,32 +75,27 @@ proc `$`*[T: tuple|object](x: T): string =
   ##   $(a: 23, b: 45) == "(a: 23, b: 45)"
   ##   $() == "()"
   result = "("
-  var firstElement = true
-  const isNamed = T is object or isNamedTuple(T)
-  when not isNamed:
-    var count = 0
+  let isNamed = isNamedTuple(T)
+  var count = 0
   for name, value in fieldPairs(x):
-    if not firstElement: result.add(", ")
-    when isNamed:
+    if count != 0:
+      result.add(", ")
+    if isNamed:
       result.add(name)
       result.add(": ")
-    else:
-      count.inc
+
     when compiles($value):
       when value isnot string and value isnot seq and compiles(value.isNil):
         if value.isNil: result.add "nil"
         else: result.addQuoted(value)
       else:
         result.addQuoted(value)
-      firstElement = false
     else:
       result.add("...")
-      firstElement = false
-  when not isNamed:
-    if count == 1:
-      result.add(",") # $(1,) should print as the semantically legal (1,)
+    inc count
+  if not isNamed and count == 1:
+    result.add(",") # $(1,) should print as the semantically legal (1,)
   result.add(")")
-
 
 proc collectionToString[T](x: T, prefix, separator, suffix: string): string =
   result = prefix

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -75,7 +75,7 @@ proc `$`*[T: tuple|object](x: T): string =
   ##   $(a: 23, b: 45) == "(a: 23, b: 45)"
   ##   $() == "()"
   result = "("
-  let isNamed = isNamedTuple(T)
+  const isNamed = x is object or isNamedTuple(T)
   var count = 0
   for name, value in fieldPairs(x):
     if count != 0:


### PR DESCRIPTION
 * `firstElement` and `count` is redundant. Only `count` is used now.
 * One instance of ``compiles`` in `system` could be avoided.