### PR TITLE
revert #13064

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -50,9 +50,6 @@
 - Added `sugar.collect` that does comprehension for seq/set/table collections.
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
-- Added `typetraits.lenTuple` to get number of elements of a tuple/type tuple,
-  and `typetraits.get` to get the ith element of a type tuple.
-- Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
 - Added `os.normalizePathEnd` for additional path sanitization.
 - Added `times.fromUnixFloat,toUnixFloat`, subsecond resolution versions of `fromUnix`,`toUnixFloat`.
 - Added `wrapnils` module for chains of field-access and indexing where the LHS can be nil.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -14,8 +14,6 @@
 
 export system.`$` # for backward compatibility
 
-include "system/inclrtl"
-
 proc name*(t: typedesc): string {.magic: "TypeTrait".}
   ## Returns the name of the given type.
   ##
@@ -70,46 +68,6 @@ proc isNamedTuple*(T: typedesc): bool {.magic: "TypeTrait".}
 proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".}
   ## Returns base type for distinct types, works only for distinct types.
   ## compile time error otherwise
-
-import std/macros
-
-macro lenTuple*(t: tuple): int {.since: (1, 1).} =
-  ## Return number of elements of `t`
-  newLit t.len
-
-macro lenTuple*(t: typedesc[tuple]): int {.since: (1, 1).} =
-  ## Return number of elements of `T`
-  newLit t.len
-
-since (1, 1):
-  template get*(T: typedesc[tuple], i: static int): untyped =
-    ## Return `i`th element of `T`
-    # Note: `[]` currently gives: `Error: no generic parameters allowed for ...`
-    type(default(T)[i])
-
-macro genericParams*(T: typedesc): untyped {.since: (1, 1).} =
-  ## return tuple of generic params for generic `T`
-  runnableExamples:
-    type Foo[T1, T2]=object
-    doAssert genericParams(Foo[float, string]) is (float, string)
-  result = newNimNode(nnkTupleConstr)
-  var impl = getTypeImpl(T)
-  expectKind(impl, nnkBracketExpr)
-  impl = impl[1]
-  while true:
-    case impl.kind
-      of nnkSym:
-        impl = impl.getImpl
-        continue
-      of nnkTypeDef:
-        impl = impl[2]
-        continue
-      of nnkBracketExpr:
-        for i in 1..<impl.len:
-          result.add impl[i]
-        break
-      else:
-        error "wrong kind: " & $impl.kind
 
 when isMainModule:
   static:

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -125,9 +125,6 @@ block genericHead:
     type Hoo = Goo[Moo[float]]
     type Koo = genericHead(Hoo)
     doAssert Koo is Goo
-    doAssert genericParams(Hoo) is (Moo[float],)
-    doAssert genericParams(Hoo).get(0) is Moo[float]
-    doAssert genericHead(genericParams(Hoo).get(0)) is Moo
 
   type Foo2Inst = Foo2[int, float]
   doAssert FooInst.default == Foo2Inst.default

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -92,22 +92,6 @@ block distinctBase:
         doAssert($distinctBase(typeof(b2)) == "string")
         doAssert($distinctBase(typeof(c2)) == "int")
 
-block genericParams:
-  type Foo[T1, T2]=object
-  doAssert genericParams(Foo[float, string]) is (float, string)
-  type Foo1 = Foo[float, int]
-  doAssert genericParams(Foo1) is (float, int)
-  type Foo2 = Foo[float, Foo1]
-  doAssert genericParams(Foo2) is (float, Foo[float, int])
-  doAssert genericParams(Foo2) is (float, Foo1)
-  doAssert genericParams(Foo2).get(1) is Foo1
-  doAssert (int,).get(0) is int
-  doAssert (int, float).get(1) is float
-  static: doAssert (int, float).lenTuple == 2
-  static: doAssert (1, ).lenTuple == 1
-  static: doAssert ().lenTuple == 0
-
-
 ##############################################
 # bug 13095
 


### PR DESCRIPTION
#13064 should not have passed quality control.

issues with `lenTuple`:

 * The name should be `tupleLen`, because a length tuple is a tuple containing dimensions like with height and depath.
 * The implementation returns the length of the AST node. That is only in rare cases the actual length of a tuple.

issues with `get`:

 * The name `get` is too universal. It is very likely to clash with symbols of other libraries that also have a `get` proc. 

issues with `genericParams`:

 * `genericParams` returns a tuple of `typedesc` values. This is exactly the type of `typedesc` usage that we agreed to drop from the language. Same with arrays of typedesc.


Edit:

from my experience with macros I can tell, that you need for every typetrait proc a variant that takes `NimNode`, because that is the way you get types within macros, both in the argument form as well as in the result of `getTypeInst`. It is not possible to call the procs operating on `typedesc` from a macro. But if you have the `NimNode` proc implemented, it is trivial to infer a version that works on `typedesc` with a macro. It is also nice if the macros api and the typetraits api have matching names.