### PR TITLE
fix pathSubs for windows: `--outdir:@projectpath/foo` works cross platform, and without quoting needed

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -309,7 +309,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
 
 proc processPath(conf: ConfigRef; path: string, info: TLineInfo,
                  notRelativeToProj = false): AbsoluteDir =
-  let p = if os.isAbsolute(path) or '$' in path:
+  let p = if os.isAbsolute(path) or path.shouldPathSubs:
             path
           elif notRelativeToProj:
             getCurrentDir() / path
@@ -325,7 +325,7 @@ proc processCfgPath(conf: ConfigRef; path: string, info: TLineInfo): AbsoluteDir
   let path = if path.len > 0 and path[0] == '"': strutils.unescape(path)
              else: path
   let basedir = toFullPath(conf, info).splitFile().dir
-  let p = if os.isAbsolute(path) or '$' in path:
+  let p = if os.isAbsolute(path) or path.shouldPathSubs:
             path
           else:
             basedir / path

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -175,7 +175,7 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
   cbconf patchFile:
     let key = a.getString(0) & "_" & a.getString(1)
     var val = a.getString(2).addFileExt(NimExt)
-    if {'$', '~'} in val:
+    if val.shouldPathSubs:
       val = pathSubs(conf, val, vthisDir)
     elif not isAbsolute(val):
       val = vthisDir / val

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2623,9 +2623,14 @@ proc findNormalized(x: string, inArray: openArray[string]): int =
 proc invalidFormatString() {.noinline.} =
   raise newException(ValueError, "invalid format string")
 
-proc addf2*(s: var string, formatstr: string, subs = {'$'}, a: varargs[string, `$`]) {.
+proc addfCustom*(s: var string, formatstr: string, subs = {'$'}, a: varargs[string, `$`]) {.
   noSideEffect, rtl, extern: "nsuAddf2".} =
   ## The same as ``add(s, formatstr % a)``, but more efficient.
+  runnableExamples:
+    var s = "start:"
+    s.addfCustom("$foo @bar $$ @@ $", subs = {'$', '@'}, ["foo", "FOO", "bar", "BAR"])
+    doAssert s == "start:FOO BAR $ @ $"
+
   const PatternChars = {'a'..'z', 'A'..'Z', '0'..'9', '\128'..'\255', '_'}
   var i = 0
   var num = 0
@@ -2689,7 +2694,8 @@ proc addf2*(s: var string, formatstr: string, subs = {'$'}, a: varargs[string, `
 
 proc addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.
   noSideEffect, rtl, extern: "nsuAddf".} =
-  addf2(s, formatstr, subs = {'$'}, a)
+  ## Wrapper around `addfCustom` with subs = {'$'}
+  addfCustom(s, formatstr, subs = {'$'}, a)
 
 proc `%` *(formatstr: string, a: openArray[string]): string {.noSideEffect,
   rtl, extern: "nsuFormatOpenArray".} =


### PR DESCRIPTION
## before PR
* `nim c --outdir:'$projectpath'/foo main.nim` works on posix, but not on windows inside exec (inside nims program) or execCmd (inside nim program) or on windows command prompt (only works on windows git bash cmd prompt)
* `nim c --outdir:$projectpath/foo main.nim` works on windows cmd prompt, but not on posix, and not on windows git bash prompt

likewise with other path substitutions supported by `pathSubs`

## after PR
`nim c --outdir:@projectpath/foo main.nim` works everywhere (posix and windows, nim or nims or on cmdline), and doesn't require any quoting

## note
* this notation is consistent with `--docroot:@pkg` introduced in https://github.com/nim-lang/Nim/pull/13223
* this is a backward compatible change; but the new format should be preferred (and perhaps we can undocument / deprecate old format with `$projectpath`)
