### PR TITLE
[WIP] fix #13404 poEvalCommand now works on windows

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -969,6 +969,7 @@ when defined(windows):
   proc quoteShellWindowsForSh*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
     ## Quote `s`, so it can be safely passed to Windows sh / bash. This handles quoting of `\`
     ## differently from `quoteShellWindows`, to support: sh -c 'echo C:\foo\bar'
+    ## This is not needed if using standard `cmd` as done via `execCmdEx("echo ok1 && echo ok2")`
     let needQuote = {' ', '\t'} in s or s.len == 0
     result = ""
     var backslashBuff = ""

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -965,37 +965,6 @@ proc quoteShellWindows*(s: string): string {.noSideEffect, rtl, extern: "nosp$1"
   if needQuote:
     result.add("\"")
 
-when defined(windows):
-  proc quoteShellWindowsForSh*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
-    ## Quote `s`, so it can be safely passed to Windows sh / bash. This handles quoting of `\`
-    ## differently from `quoteShellWindows`, to support: sh -c 'echo C:\foo\bar'
-    ## This is not needed if using standard `cmd` as done via `execCmdEx("echo ok1 && echo ok2")`
-    let needQuote = {' ', '\t'} in s or s.len == 0
-    result = ""
-    var backslashBuff = ""
-    if needQuote:
-      result.add("\"")
-
-    for c in s:
-      if c == '\\':
-        ## modification: see https://stackoverflow.com/questions/60204063/why-does-sh-exe-swallow-and-how-to-escape
-        backslashBuff.add(c)
-        backslashBuff.add(c)
-        backslashBuff.add(c)
-      elif c == '\"':
-        result.add(backslashBuff)
-        result.add(backslashBuff)
-        backslashBuff.setLen(0)
-        result.add("\\\"")
-      else:
-        if backslashBuff.len != 0:
-          result.add(backslashBuff)
-          backslashBuff.setLen(0)
-        result.add(c)
-
-    if needQuote:
-      result.add("\"")
-
 proc quoteShellPosix*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
   ## Quote ``s``, so it can be safely passed to POSIX shell.
   ## Based on Python's `pipes.quote`.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -965,6 +965,36 @@ proc quoteShellWindows*(s: string): string {.noSideEffect, rtl, extern: "nosp$1"
   if needQuote:
     result.add("\"")
 
+when defined(windows):
+  proc quoteShellWindowsForSh*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
+    ## Quote `s`, so it can be safely passed to Windows sh / bash. This handles quoting of `\`
+    ## differently from `quoteShellWindows`, to support: sh -c 'echo C:\foo\bar'
+    let needQuote = {' ', '\t'} in s or s.len == 0
+    result = ""
+    var backslashBuff = ""
+    if needQuote:
+      result.add("\"")
+
+    for c in s:
+      if c == '\\':
+        ## modification: see https://stackoverflow.com/questions/60204063/why-does-sh-exe-swallow-and-how-to-escape
+        backslashBuff.add(c)
+        backslashBuff.add(c)
+        backslashBuff.add(c)
+      elif c == '\"':
+        result.add(backslashBuff)
+        result.add(backslashBuff)
+        backslashBuff.setLen(0)
+        result.add("\\\"")
+      else:
+        if backslashBuff.len != 0:
+          result.add(backslashBuff)
+          backslashBuff.setLen(0)
+        result.add(c)
+
+    if needQuote:
+      result.add("\"")
+
 proc quoteShellPosix*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
   ## Quote ``s``, so it can be safely passed to POSIX shell.
   ## Based on Python's `pipes.quote`.

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -71,7 +71,7 @@ const poDemon* {.deprecated.} = poDaemon ## Nim versions before 0.20
                                          ## and this is needed just for backward compatibility.
 
 const useShPath {.strdefine.} =
-  when defined(windows): "sh"
+  when defined(windows): "cmd"
   elif not defined(android): "/bin/sh"
   else: "/system/bin/sh"
 
@@ -437,6 +437,9 @@ when not defined(useNimRtl):
 template streamAccess(p) =
   assert poParentStreams notin p.options, "API usage error: stream access not allowed when you use poParentStreams"
 
+template checkEmpty(args) =
+  assert args.len == 0, "`args` has to be empty when using poEvalCommand."
+
 when defined(Windows) and not defined(useNimRtl):
   # We need to implement a handle stream for Windows:
   type
@@ -608,9 +611,9 @@ when defined(Windows) and not defined(useNimRtl):
     var cmdl: cstring
     var cmdRoot: string
     if poEvalCommand in options:
-      cmdRoot = useShPath & " -c " & command.quoteShellWindowsForSh
+      cmdRoot = useShPath & " /c " & command
       cmdl = cstring(cmdRoot)
-      assert args.len == 0, "`args` has to be empty when using poEvalCommand."
+      checkEmpty(args)
     else:
       cmdRoot = buildCommandLine(command, args)
       cmdl = cstring(cmdRoot)
@@ -856,7 +859,7 @@ elif not defined(useNimRtl):
     if poEvalCommand in options:
       data.sysCommand = useShPath
       sysArgsRaw = @[data.sysCommand, "-c", command]
-      assert args.len == 0, "`args` has to be empty when using poEvalCommand."
+      checkEmpty(args)
     else:
       data.sysCommand = command
       sysArgsRaw = @[command]

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -72,8 +72,8 @@ const poDemon* {.deprecated.} = poDaemon ## Nim versions before 0.20
 
 const useShPath {.strdefine.} =
   when defined(windows): "cmd"
-  elif not defined(android): "/bin/sh"
-  else: "/system/bin/sh"
+  elif defined(android): "/system/bin/sh"
+  else: "/bin/sh"
 
 proc execProcess*(command: string, workingDir: string = "",
     args: openArray[string] = [], env: StringTableRef = nil,

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -101,7 +101,7 @@ proc flagTests(r: var TResults, cat: Category, options: string) =
   testSpec r, makeTest(filename, genopts, cat)
 
   when defined(windows):
-    testExec r, makeTest(filename, " cmd /c cd " & nimcache &
+    testExec r, makeTest(filename, " cd " & nimcache &
                          " && compile_tgenscript.bat", cat)
 
   elif defined(posix):


### PR DESCRIPTION
* fix #13404 poEvalCommand now works on windows
* added runnableExample
* `execCmdEx("echo ok1 && echo ok2")` now works on posix and windows