### PR TITLE
pseudorandom probing for hash collision

### DIFF
--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -42,7 +42,6 @@ proc mustRehash(length, counter: int): bool {.inline.} =
   result = (length * 2 < counter * 3) or (length - counter < 4) # synchronize with `rightSize`
 
 proc mustRehash2[T](t: T): bool {.inline.} =
-  # static: echo $T
   let counter2 = t.counter + t.countDeleted
   result = mustRehash(t.dataLen, counter2)
 

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -20,8 +20,15 @@ when not defined(nimHasDefault):
 
 # hcode for real keys cannot be zero.  hcode==0 signifies an empty slot.  These
 # two procs retain clarity of that encoding without the space cost of an enum.
-proc isEmpty(hcode: Hash): bool {.inline.} =
-  result = hcode == 0
+when false:
+  proc isEmpty(hcode: Hash): bool {.inline.} =
+    result = hcode == 0
+
+const freeMarker = 0
+const deletedMarker = -1
+
+proc isFilledValid(hcode: Hash): bool {.inline.} =
+  result = hcode != 0 and hcode != deletedMarker # SPEED: could improve w bit magic
 
 proc isFilled(hcode: Hash): bool {.inline.} =
   result = hcode != 0
@@ -30,29 +37,49 @@ proc isFilled(hcode: Hash): bool {.inline.} =
 proc nextTry(h, maxHash: Hash, perturb: var Hash): Hash {.inline.} =
   # TODO: shouldn't perturb be unsigned?
   const PERTURB_SHIFT = 5
-  perturb = perturb shr PERTURB_SHIFT
-  # perturb = cast[uint](perturb) shr PERTURB_SHIFT # TODO
+  # SPEED IMPROVE
+  var perturb2 = cast[uint](perturb) shr PERTURB_SHIFT
+  perturb = cast[Hash](perturb2)
   result = ((5*h) + 1 + perturb) and maxHash
 
 proc mustRehash(length, counter: int): bool {.inline.} =
   assert(length > counter)
-  result = (length * 2 < counter * 3) or (length - counter < 4)
+  result = (length * 2 < counter * 3) or (length - counter < 4) # synchronize with `rightSize`
+
+proc mustRehash2[T](t: T): bool {.inline.} =
+  let counter2 = t.counter + t.countDeleted
+  # echo (t.dataLen, t.counter, t.countDeleted, counter2)
+  result = mustRehash(t.dataLen, counter2)
+  # echo ("mustRehash2", t.dataLen, t.counter, t.countDeleted, counter2, result)
 
 template rawGetKnownHCImpl() {.dirty.} =
   if t.dataLen == 0:
     return -1
   var h: Hash = hc and maxHash(t) # start with real hash value
   var perturb = hc
-  while isFilled(t.data[h].hcode):
-    # Compare hc THEN key with boolean short circuit. This makes the common case
-    # zero ==key's for missing (e.g.inserts) and exactly one ==key for present.
-    # It does slow down succeeding lookups by one extra Hash cmp&and..usually
-    # just a few clock cycles, generally worth it for any non-integer-like A.
-    # TODO: optimize this: depending on type(key), skip hc comparison
-    if t.data[h].hcode == hc and t.data[h].key == key:
-      return h
-    h = nextTry(h, maxHash(t), perturb)
-  result = -1 - h # < 0 => MISSING; insert idx = -1 - result
+  var deletedIndex = -1
+  while true:
+    if isFilledValid(t.data[h].hcode):
+      # Compare hc THEN key with boolean short circuit. This makes the common case
+      # zero ==key's for missing (e.g.inserts) and exactly one ==key for present.
+      # It does slow down succeeding lookups by one extra Hash cmp&and..usually
+      # just a few clock cycles, generally worth it for any non-integer-like A.
+      # TODO: optimize this: depending on type(key), skip hc comparison
+      if t.data[h].hcode == hc and t.data[h].key == key:
+        return h
+      # echo (h, perturb, maxHash(t))
+      h = nextTry(h, maxHash(t), perturb)
+    elif t.data[h].hcode == deletedMarker:
+      if deletedIndex == -1:
+        deletedIndex = h
+      h = nextTry(h, maxHash(t), perturb)
+    else:
+      break
+  if deletedIndex == -1:
+    result = -1 - h # < 0 => MISSING; insert idx = -1 - result # TODO
+  else:
+    # we prefer returning a (in fact the 1st found) deleted index
+    result = -1 - deletedIndex
 
 proc rawGetKnownHC[X, A](t: X, key: A, hc: Hash): int {.inline.} =
   rawGetKnownHCImpl()
@@ -61,6 +88,8 @@ template genHashImpl(key, hc: typed) =
   hc = hash(key)
   if hc == 0: # This almost never taken branch should be very predictable.
     hc = 314159265 # Value doesn't matter; Any non-zero favorite is fine.
+  elif hc == deletedMarker:
+    hc = 214159261
 
 template genHash(key: typed): Hash =
   var res: Hash

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -46,6 +46,7 @@ proc mustRehash(length, counter: int): bool {.inline.} =
   result = (length * 2 < counter * 3) or (length - counter < 4) # synchronize with `rightSize`
 
 proc mustRehash2[T](t: T): bool {.inline.} =
+  # static: echo $T
   let counter2 = t.counter + t.countDeleted
   result = mustRehash(t.dataLen, counter2)
 
@@ -64,7 +65,6 @@ template rawGetKnownHCImpl() {.dirty.} =
       # TODO: optimize this: depending on type(key), skip hc comparison
       if t.data[h].hcode == hc and t.data[h].key == key:
         return h
-      # echo (h, perturb, maxHash(t))
       h = nextTry(h, maxHash(t), perturb)
     elif t.data[h].hcode == deletedMarker:
       if deletedIndex == -1:

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -10,12 +10,8 @@
 # An ``include`` file which contains common code for
 # hash sets and tables.
 
-# type Hash = uint
-
 const
   growthFactor = 2
-
-from bitops import fastLog2
 
 when not defined(nimHasDefault):
   template default[T](t: typedesc[T]): T =
@@ -55,8 +51,11 @@ proc mustRehash2[T](t: T): bool {.inline.} =
   let counter2 = t.counter + t.countDeleted
   result = mustRehash(t.dataLen, counter2)
 
+# from bitops import fastLog2 # PRTEMP
+
 template getPerturb*(t: typed, hc: Hash): UHash =
-  let numBitsMask=fastLog2(dataLen(t)) # TODO: cache/store in t if needed
+  # let numBitsMask = fastLog2(dataLen(t)) # TODO: cache/store in t if needed
+  let numBitsMask = 16 # PRTEMP can't use fastLog2
   # this makes a major difference for cases like #13393; it causes the bits
   # that were masked out in 1st position so they'll be masked in instead, and
   # influence the recursion in nextTry earlier rather than later.

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -27,7 +27,7 @@ when false:
 const freeMarker = 0
 const deletedMarker = -1
 
-proc isFilledValid(hcode: Hash): bool {.inline.} =
+proc isFilledAndValid(hcode: Hash): bool {.inline.} =
   result = hcode != 0 and hcode != deletedMarker # SPEED: could improve w bit magic
 
 proc isFilled(hcode: Hash): bool {.inline.} =
@@ -57,7 +57,7 @@ template rawGetKnownHCImpl() {.dirty.} =
   var perturb = hc
   var deletedIndex = -1
   while true:
-    if isFilledValid(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       # Compare hc THEN key with boolean short circuit. This makes the common case
       # zero ==key's for missing (e.g.inserts) and exactly one ==key for present.
       # It does slow down succeeding lookups by one extra Hash cmp&and..usually

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -35,9 +35,8 @@ proc isFilled(hcode: Hash): bool {.inline.} =
 
 
 proc nextTry(h, maxHash: Hash, perturb: var Hash): Hash {.inline.} =
-  # TODO: shouldn't perturb be unsigned?
   const PERTURB_SHIFT = 5
-  # SPEED IMPROVE
+  # TODO: make perturb (maybe even Hash) unsigned everywhere to avoid back and forth conversions
   var perturb2 = cast[uint](perturb) shr PERTURB_SHIFT
   perturb = cast[Hash](perturb2)
   result = ((5*h) + 1 + perturb) and maxHash
@@ -48,9 +47,7 @@ proc mustRehash(length, counter: int): bool {.inline.} =
 
 proc mustRehash2[T](t: T): bool {.inline.} =
   let counter2 = t.counter + t.countDeleted
-  # echo (t.dataLen, t.counter, t.countDeleted, counter2)
   result = mustRehash(t.dataLen, counter2)
-  # echo ("mustRehash2", t.dataLen, t.counter, t.countDeleted, counter2, result)
 
 template rawGetKnownHCImpl() {.dirty.} =
   if t.dataLen == 0:
@@ -76,7 +73,7 @@ template rawGetKnownHCImpl() {.dirty.} =
     else:
       break
   if deletedIndex == -1:
-    result = -1 - h # < 0 => MISSING; insert idx = -1 - result # TODO
+    result = -1 - h # < 0 => MISSING; insert idx = -1 - result
   else:
     # we prefer returning a (in fact the 1st found) deleted index
     result = -1 - deletedIndex

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -28,12 +28,11 @@ proc isFilled(hcode: Hash): bool {.inline.} =
 
 
 proc nextTry(h, maxHash: Hash, perturb: var Hash): Hash {.inline.} =
-  # result = ((5*h) + 1 + perturb and maxHash)
+  # TODO: shouldn't perturb be unsigned?
   const PERTURB_SHIFT = 5
   perturb = perturb shr PERTURB_SHIFT
+  # perturb = cast[uint](perturb) shr PERTURB_SHIFT # TODO
   result = ((5*h) + 1 + perturb) and maxHash
-  # echo (h, result)
-  # result = (h + 1) and maxHash
 
 proc mustRehash(length, counter: int): bool {.inline.} =
   assert(length > counter)

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -24,7 +24,8 @@ const deletedMarker = -1
 # hcode for real keys cannot be zero.  hcode==0 signifies an empty slot.  These
 # two procs retain clarity of that encoding without the space cost of an enum.
 proc isFilledAndValid(hcode: Hash): bool {.inline.} =
-  result = hcode != 0 and hcode != deletedMarker # SPEED: could improve w bit magic
+  result = hcode != 0 and hcode != deletedMarker
+    # performance: we could use bit magic if needed
 
 proc isFilled(hcode: Hash): bool {.inline.} =
   result = hcode != 0
@@ -72,7 +73,7 @@ template rawGetKnownHCImpl() {.dirty.} =
       # zero ==key's for missing (e.g.inserts) and exactly one ==key for present.
       # It does slow down succeeding lookups by one extra Hash cmp&and..usually
       # just a few clock cycles, generally worth it for any non-integer-like A.
-      # TODO: optimize this: depending on type(key), skip hc comparison
+      # performance: we optimize this: depending on type(key), skip hc comparison
       if t.data[h].hcode == hc and t.data[h].key == key:
         return h
       h = nextTry(h, maxHash(t), perturb)

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -21,6 +21,8 @@ when not defined(nimHasDefault):
 const freeMarker = 0
 const deletedMarker = -1
 
+type UHash = uint
+
 # hcode for real keys cannot be zero.  hcode==0 signifies an empty slot.  These
 # two procs retain clarity of that encoding without the space cost of an enum.
 proc isFilledAndValid(hcode: Hash): bool {.inline.} =
@@ -30,7 +32,6 @@ proc isFilledAndValid(hcode: Hash): bool {.inline.} =
 proc isFilled(hcode: Hash): bool {.inline.} =
   result = hcode != 0
 
-type UHash* = uint
 
 proc translateBits(a: UHash, numBitsMask: int): UHash {.inline.} =
   result = (a shr numBitsMask) or (a shl (UHash.sizeof * 8 - numBitsMask))

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -18,15 +18,11 @@ when not defined(nimHasDefault):
     var v: T
     v
 
-# hcode for real keys cannot be zero.  hcode==0 signifies an empty slot.  These
-# two procs retain clarity of that encoding without the space cost of an enum.
-when false:
-  proc isEmpty(hcode: Hash): bool {.inline.} =
-    result = hcode == 0
-
 const freeMarker = 0
 const deletedMarker = -1
 
+# hcode for real keys cannot be zero.  hcode==0 signifies an empty slot.  These
+# two procs retain clarity of that encoding without the space cost of an enum.
 proc isFilledAndValid(hcode: Hash): bool {.inline.} =
   result = hcode != 0 and hcode != deletedMarker # SPEED: could improve w bit magic
 

--- a/lib/pure/collections/intsets.nim
+++ b/lib/pure/collections/intsets.nim
@@ -22,8 +22,6 @@
 import
   hashes
 
-# from hashcommon import UHash
-
 type
   BitScalar = uint
 

--- a/lib/pure/collections/intsets.nim
+++ b/lib/pure/collections/intsets.nim
@@ -51,13 +51,15 @@ type
     a: array[0..33, int] # profiling shows that 34 elements are enough
 
 proc mustRehash(length, counter: int): bool {.inline.} =
+  # FACTOR with hashcommon.mustRehash
   assert(length > counter)
   result = (length * 2 < counter * 3) or (length - counter < 4)
 
-# FACTOR
 proc nextTry(h, maxHash: Hash, perturb: var Hash): Hash {.inline.} =
+  # FACTOR with hashcommon.nextTry
   const PERTURB_SHIFT = 5
-  perturb = perturb shr PERTURB_SHIFT
+  var perturb2 = cast[uint](perturb) shr PERTURB_SHIFT
+  perturb = cast[Hash](perturb2)
   result = ((5*h) + 1 + perturb) and maxHash
 
 proc intSetGet(t: IntSet, key: int): PTrunk =

--- a/lib/pure/collections/intsets.nim
+++ b/lib/pure/collections/intsets.nim
@@ -22,6 +22,8 @@
 import
   hashes
 
+# from hashcommon import UHash
+
 type
   BitScalar = uint
 

--- a/lib/pure/collections/setimpl.nim
+++ b/lib/pure/collections/setimpl.nim
@@ -48,7 +48,7 @@ template inclImpl() {.dirty.} =
   var hc: Hash
   var index = rawGet(s, key, hc)
   if index < 0:
-    if mustRehash(len(s.data), s.counter):
+    if mustRehash(s):
       enlarge(s)
       index = rawGetKnownHC(s, key, hc)
     rawInsert(s, s.data, key, hc, -1 - index)
@@ -62,7 +62,7 @@ template containsOrInclImpl() {.dirty.} =
   if index >= 0:
     result = true
   else:
-    if mustRehash(len(s.data), s.counter):
+    if mustRehash(s):
       enlarge(s)
       index = rawGetKnownHC(s, key, hc)
     rawInsert(s, s.data, key, hc, -1 - index)

--- a/lib/pure/collections/setimpl.nim
+++ b/lib/pure/collections/setimpl.nim
@@ -68,11 +68,6 @@ template containsOrInclImpl() {.dirty.} =
     rawInsert(s, s.data, key, hc, -1 - index)
     inc(s.counter)
 
-template doWhile(a, b) =
-  while true:
-    b
-    if not a: break
-
 proc exclImpl[A](s: var HashSet[A], key: A): bool {.inline.} =
   var hc: Hash
   var i = rawGet(s, key, hc)
@@ -82,17 +77,9 @@ proc exclImpl[A](s: var HashSet[A], key: A): bool {.inline.} =
   if i >= 0:
     result = false
     dec(s.counter)
-    while true: # KnuthV3 Algo6.4R adapted for i=i+1 instead of i=i-1
-      var j = i # The correctness of this depends on (h+1) in nextTry,
-      var r = j # though may be adaptable to other simple sequences.
-      s.data[i].hcode = 0 # mark current EMPTY
-      s.data[i].key = default(type(s.data[i].key))
-      doWhile((i >= r and r > j) or (r > j and j > i) or (j > i and i >= r)):
-        i = (i + 1) and msk # increment mod table size
-        if isEmpty(s.data[i].hcode): # end of collision cluster; So all done
-          return
-        r = s.data[i].hcode and msk # "home" location of key@i
-      s.data[j] = move(s.data[i]) # data[i] will be marked EMPTY next loop
+    inc(s.countDeleted)
+    s.data[i].hcode = deletedMarker
+    s.data[i].key = default(type(s.data[i].key))
 
 template dollarImpl() {.dirty.} =
   result = "{"

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -68,6 +68,7 @@ type
     ## before calling other procs on it.
     data: KeyValuePairSeq[A]
     counter: int
+    countDeleted: int
 
 type
   OrderedKeyValuePair[A] = tuple[
@@ -80,6 +81,7 @@ type
     ## <#initOrderedSet,int>`_ before calling other procs on it.
     data: OrderedKeyValuePairSeq[A]
     counter, first, last: int
+    countDeleted: int
 
 const
   defaultInitialSize* = 64

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -252,7 +252,7 @@ iterator items*[A](s: HashSet[A]): A =
   ##   echo b
   ##   # --> {(a: 1, b: 3), (a: 0, b: 4)}
   for h in 0 .. high(s.data):
-    if isFilled(s.data[h].hcode): yield s.data[h].key
+    if isFilledAndValid(s.data[h].hcode): yield s.data[h].key
 
 proc containsOrIncl*[A](s: var HashSet[A], key: A): bool =
   ## Includes `key` in the set `s` and tells if `key` was already in `s`.
@@ -344,7 +344,7 @@ proc pop*[A](s: var HashSet[A]): A =
     doAssertRaises(KeyError, echo s.pop)
 
   for h in 0 .. high(s.data):
-    if isFilled(s.data[h].hcode):
+    if isFilledAndValid(s.data[h].hcode):
       result = s.data[h].key
       excl(s, result)
       return result
@@ -636,7 +636,7 @@ template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
     var idx = 0
     while h >= 0:
       var nxt = s.data[h].next
-      if isFilled(s.data[h].hcode):
+      if isFilledAndValid(s.data[h].hcode):
         yieldStmt
         inc(idx)
       h = nxt
@@ -870,7 +870,7 @@ proc `==`*[A](s, t: OrderedSet[A]): bool =
   while h >= 0 and g >= 0:
     var nxh = s.data[h].next
     var nxg = t.data[g].next
-    if isFilled(s.data[h].hcode) and isFilled(t.data[g].hcode):
+    if isFilledAndValid(s.data[h].hcode) and isFilledAndValid(t.data[g].hcode):
       if s.data[h].key == t.data[g].key:
         inc compared
       else:

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -88,9 +88,6 @@ const
 
 include setimpl
 
-proc rightSize*(count: Natural): int {.inline.}
-
-
 # ---------------------------------------------------------------------
 # ------------------------------ HashSet ------------------------------
 # ---------------------------------------------------------------------
@@ -594,16 +591,6 @@ proc `$`*[A](s: HashSet[A]): string =
   ##   echo toHashSet(["no", "esc'aping", "is \" provided"])
   ##   # --> {no, esc'aping, is " provided}
   dollarImpl()
-
-proc rightSize*(count: Natural): int {.inline.} =
-  ## Return the value of `initialSize` to support `count` items.
-  ##
-  ## If more items are expected to be added, simply add that
-  ## expected extra amount to the parameter before calling this.
-  ##
-  ## Internally, we want `mustRehash(rightSize(x), x) == false`.
-  result = nextPowerOfTwo(count * 3 div 2 + 4)
-
 
 proc initSet*[A](initialSize = defaultInitialSize): HashSet[A] {.deprecated:
      "Deprecated since v0.20, use 'initHashSet'".} = initHashSet[A](initialSize)
@@ -1148,10 +1135,19 @@ when isMainModule and not defined(release):
       b.incl(2)
       assert b.len == 1
 
-    for i in 0 .. 32:
-      var s = rightSize(i)
-      if s <= i or mustRehash(s, i):
-        echo "performance issue: rightSize() will not elide enlarge() at ", i
+    block:
+      type FakeTable = object
+        dataLen: int
+        counter: int
+        countDeleted: int
+
+      var t: FakeTable
+      for i in 0 .. 32:
+        var s = rightSize(i)
+        t.dataLen = s
+        t.counter = i
+        doAssert s > i and not mustRehash(t),
+          "performance issue: rightSize() will not elide enlarge() at: " & $i
 
     block missingOrExcl:
       var s = toOrderedSet([2, 3, 6, 7])

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -33,7 +33,7 @@ template maxHash(t): untyped = t.dataLen-1
 include tableimpl
 
 template st_maybeRehashPutImpl(enlarge) {.dirty.} =
-  if mustRehash2(t):
+  if mustRehash(t):
     enlarge(t)
     index = rawGetKnownHC(t, key, hc)
   index = -1 - index # important to transform for mgetOrPutImpl

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -25,6 +25,7 @@ type
   SharedTable*[A, B] = object ## generic hash SharedTable
     data: KeyValuePairSeq[A, B]
     counter, dataLen: int
+    countDeleted: int
     lock: Lock
 
 template maxHash(t): untyped = t.dataLen-1
@@ -49,9 +50,10 @@ proc enlarge[A, B](t: var SharedTable[A, B]) =
   for i in 0..<oldSize:
     let eh = n[i].hcode
     if isFilled(eh):
+      var perturb = eh
       var j: Hash = eh and maxHash(t)
       while isFilled(t.data[j].hcode):
-        j = nextTry(j, maxHash(t))
+        j = nextTry(j, maxHash(t), perturb)
       rawInsert(t, t.data, n[i].key, n[i].val, eh, j)
   deallocShared(n)
 

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -50,7 +50,7 @@ proc enlarge[A, B](t: var SharedTable[A, B]) =
   for i in 0..<oldSize:
     let eh = n[i].hcode
     if isFilled(eh):
-      var perturb = eh
+      var perturb = t.getPerturb(eh)
       var j: Hash = eh and maxHash(t)
       while isFilled(t.data[j].hcode):
         j = nextTry(j, maxHash(t), perturb)

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -32,7 +32,7 @@ template maxHash(t): untyped = t.dataLen-1
 include tableimpl
 
 template st_maybeRehashPutImpl(enlarge) {.dirty.} =
-  if mustRehash(t.dataLen, t.counter):
+  if mustRehash2(t):
     enlarge(t)
     index = rawGetKnownHC(t, key, hc)
   index = -1 - index # important to transform for mgetOrPutImpl

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -14,7 +14,7 @@ include hashcommon
 template rawGetDeepImpl() {.dirty.} =   # Search algo for unconditional add
   genHashImpl(key, hc)
   var h: Hash = hc and maxHash(t)
-  var perturb = hc
+  var perturb = t.getPerturb(hc)
   while true:
     let hcode = t.data[h].hcode
     if hcode == deletedMarker or hcode == freeMarker:

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -44,14 +44,14 @@ template checkIfInitialized() =
 
 template addImpl(enlarge) {.dirty.} =
   checkIfInitialized()
-  if mustRehash2(t): enlarge(t)
+  if mustRehash(t): enlarge(t)
   var hc: Hash
   var j = rawGetDeep(t, key, hc)
   rawInsert(t, t.data, key, val, hc, j)
   inc(t.counter)
 
 template maybeRehashPutImpl(enlarge) {.dirty.} =
-  if mustRehash2(t):
+  if mustRehash(t):
     enlarge(t)
     index = rawGetKnownHC(t, key, hc)
   index = -1 - index                  # important to transform for mgetOrPutImpl
@@ -92,7 +92,7 @@ template delImplIdx(t, i) =
     t.data[i].hcode = deletedMarker
     t.data[i].key = default(type(t.data[i].key))
     t.data[i].val = default(type(t.data[i].val))
-    # mustRehash2 + enlarge not needed because counter+countDeleted doesn't change
+    # mustRehash + enlarge not needed because counter+countDeleted doesn't change
 
 template delImpl() {.dirty.} =
   var hc: Hash
@@ -117,7 +117,7 @@ template initImpl(result: typed, size: int) =
 
 template insertImpl() = # for CountTable
   checkIfInitialized()
-  if mustRehash2(t): enlarge(t)
+  if mustRehash(t): enlarge(t)
   ctRawInsert(t, t.data, key, val)
   inc(t.counter)
 

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -92,10 +92,7 @@ template delImplIdx(t, i) =
     t.data[i].hcode = deletedMarker
     t.data[i].key = default(type(t.data[i].key))
     t.data[i].val = default(type(t.data[i].val))
-    # maybe not needed because counter+countDeleted doesn't change, unless formula is not a simple +
-    # if mustRehash2(t):
-    #   enlarge(t) # RENAME enlarge...
-      # i = rawGetKnownHC(t, key, hc) # TODO
+    # mustRehash2 + enlarge not needed because counter+countDeleted doesn't change
 
 template delImpl() {.dirty.} =
   var hc: Hash

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -89,34 +89,13 @@ template delImplIdx(t, i) =
   if i >= 0:
     dec(t.counter)
     inc(t.countDeleted)
-    when true:
-      t.data[i].hcode = deletedMarker
-      t.data[i].key = default(type(t.data[i].key))
-      t.data[i].val = default(type(t.data[i].val))
-      # maybe not needed because counter+countDeleted doesn't change, unless formula is not a simple +
-      # if mustRehash2(t):
-      #   enlarge(t) # RENAME enlarge...
-        # i = rawGetKnownHC(t, key, hc) # TODO
-    else:
-      block outer:
-        while true:         # KnuthV3 Algo6.4R adapted for i=i+1 instead of i=i-1
-          var j = i         # The correctness of this depends on (h+1) in nextTry,
-                            # though may be adaptable to other simple sequences.
-          t.data[i].hcode = 0              # mark current EMPTY
-          t.data[i].key = default(type(t.data[i].key))
-          t.data[i].val = default(type(t.data[i].val))
-          while true:
-            i = (i + 1) and msk            # increment mod table size
-            if isEmpty(t.data[i].hcode):   # end of collision cluster; So all done
-              break outer
-            var r = t.data[i].hcode and msk    # "home" location of key@i
-            if not ((i >= r and r > j) or (r > j and j > i) or (j > i and i >= r)):
-              break
-          # TODO: can we instead just move the last in the chain?
-          when defined(js):
-            t.data[j] = t.data[i]
-          else:
-            t.data[j] = move(t.data[i]) # data[i] will be marked EMPTY next loop
+    t.data[i].hcode = deletedMarker
+    t.data[i].key = default(type(t.data[i].key))
+    t.data[i].val = default(type(t.data[i].val))
+    # maybe not needed because counter+countDeleted doesn't change, unless formula is not a simple +
+    # if mustRehash2(t):
+    #   enlarge(t) # RENAME enlarge...
+      # i = rawGetKnownHC(t, key, hc) # TODO
 
 template delImpl() {.dirty.} =
   var hc: Hash

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2248,8 +2248,9 @@ type
 
 proc ctRawInsert[A](t: CountTable[A], data: var seq[tuple[key: A, val: int]],
                   key: A, val: int) =
-  var perturb = t.getPerturb(hash(key))
-  var h: Hash = perturb and high(data)
+  let hc = hash(key)
+  var perturb = t.getPerturb(hc)
+  var h: Hash = hc and high(data)
   while data[h].val != 0: h = nextTry(h, high(data), perturb) # TODO: handle deletedMarker
   data[h].key = key
   data[h].val = val
@@ -2277,8 +2278,9 @@ proc remove[A](t: var CountTable[A], key: A) =
 proc rawGet[A](t: CountTable[A], key: A): int =
   if t.data.len == 0:
     return -1
-  var perturb = t.getPerturb(hash(key))
-  var h: Hash = perturb and high(t.data) # start with real hash value
+  let hc = hash(key)
+  var perturb = t.getPerturb(hc)
+  var h: Hash = hc and high(t.data) # start with real hash value
   while t.data[h].val != 0: # TODO: may need to handle t.data[h].hcode == deletedMarker?
     if t.data[h].key == key: return h
     h = nextTry(h, high(t.data), perturb)

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2250,7 +2250,7 @@ proc ctRawInsert[A](t: CountTable[A], data: var seq[tuple[key: A, val: int]],
                   key: A, val: int) =
   var perturb = hash(key)
   var h: Hash = perturb and high(data)
-  while data[h].val != 0: h = nextTry(h, high(data), perturb) # TODO: hadnle deletedMarker
+  while data[h].val != 0: h = nextTry(h, high(data), perturb) # TODO: handle deletedMarker
   data[h].key = key
   data[h].val = val
 

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -251,8 +251,6 @@ template dataLen(t): untyped = len(t.data)
 
 include tableimpl
 
-proc rightSize*(count: Natural): int {.inline.}
-
 template get(t, key): untyped =
   ## retrieves the value at ``t[key]``. The value can be modified.
   ## If ``key`` is not in ``t``, the ``KeyError`` exception is raised.
@@ -581,15 +579,6 @@ proc `==`*[A, B](s, t: Table[A, B]): bool =
     doAssert a == b
 
   equalsImpl(s, t)
-
-proc rightSize*(count: Natural): int {.inline.} =
-  ## Return the value of ``initialSize`` to support ``count`` items.
-  ##
-  ## If more items are expected to be added, simply add that
-  ## expected extra amount to the parameter before calling this.
-  ##
-  ## Internally, we want mustRehash(rightSize(x), x) == false.
-  result = nextPowerOfTwo(count * 3 div 2 + 4)
 
 proc indexBy*[A, B, C](collection: A, index: proc(x: B): C): Table[C, B] =
   ## Index the collection with the proc provided.

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -273,7 +273,7 @@ proc enlarge[A, B](t: var Table[A, B]) =
   t.countDeleted = 0
   for i in countup(0, high(n)):
     let eh = n[i].hcode
-    if isFilledValid(eh):
+    if isFilledAndValid(eh):
       var j: Hash = eh and maxHash(t)
       var perturb = eh
       while isFilled(t.data[j].hcode):
@@ -673,7 +673,7 @@ iterator pairs*[A, B](t: Table[A, B]): (A, B) =
   ##   # value: [1, 5, 7, 9]
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilledValid(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield (t.data[h].key, t.data[h].val)
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -695,7 +695,7 @@ iterator mpairs*[A, B](t: var Table[A, B]): (A, var B) =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilledValid(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield (t.data[h].key, t.data[h].val)
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -716,7 +716,7 @@ iterator keys*[A, B](t: Table[A, B]): A =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilledValid(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield t.data[h].key
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -737,7 +737,7 @@ iterator values*[A, B](t: Table[A, B]): B =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilledValid(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -759,7 +759,7 @@ iterator mvalues*[A, B](t: var Table[A, B]): var B =
 
   let L = len(t)
   for h in 0 .. high(t.data):
-    if isFilledValid(t.data[h].hcode):
+    if isFilledAndValid(t.data[h].hcode):
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
 
@@ -824,7 +824,7 @@ iterator allValues*[A, B](t: Table[A, B]; key: A): B =
   # const N = 20000 # can optimize this
   var cache1 {.noinit.}: array[N, Hash]
   var cache2: IntSet
-  while isFilled(t.data[h].hcode): # CHECKME isFilledValid ??
+  while isFilled(t.data[h].hcode): # CHECKME isFilledAndValid ??
     if t.data[h].key == key:
       if not inCache():
         yield t.data[h].val
@@ -1303,7 +1303,7 @@ proc enlarge[A, B](t: var OrderedTable[A, B]) =
   while h >= 0:
     var nxt = n[h].next
     let eh = n[h].hcode
-    if isFilledValid(eh):
+    if isFilledAndValid(eh):
       var j: Hash = eh and maxHash(t)
       var perturb = eh
       while isFilled(t.data[j].hcode):

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -786,19 +786,13 @@ iterator allValues*[A, B](t: Table[A, B]; key: A): B =
   ## Used if you have a table with duplicate keys (as a result of using
   ## `add proc<#add,Table[A,B],A,B>`_).
   ##
-  ## **Examples:**
-  ##
-  ## .. code-block::
-  ##   var a = {'a': 3, 'b': 5}.toTable
-  ##   for i in 1..3:
-  ##     a.add('z', 10*i)
-  ##   echo a # {'a': 3, 'b': 5, 'z': 10, 'z': 20, 'z': 30}
-  ##
-  ##   for v in a.allValues('z'):
-  ##     echo v
-  ##   # 10
-  ##   # 20
-  ##   # 30
+  runnableExamples:
+    import testutils
+    var a = {'a': 3, 'b': 5}.toTable
+    for i in 1..3: a.add('z', 10*i)
+    doAssert a.sortedPairs == @[('a', 3), ('b', 5), ('z', 10), ('z', 20), ('z', 30)]
+    doAssert sortedItems(a.allValues('z')) == @[10, 20, 30]
+
   let hc = genHash(key)
   var h: Hash = hc and high(t.data)
   let L = len(t)
@@ -806,8 +800,8 @@ iterator allValues*[A, B](t: Table[A, B]; key: A): B =
 
   var num = 0
   var cache: seq[Hash]
-  while isFilled(t.data[h].hcode): # CHECKME isFilledAndValid ??
-    if t.data[h].key == key:
+  while isFilled(t.data[h].hcode): # `isFilledAndValid` would be incorrect, see test for `allValues`
+    if t.data[h].hcode == hc and t.data[h].key == key:
       if not hasKeyOrPutCache(cache, h):
         yield t.data[h].val
         assert(len(t) == L, "the length of the table changed while iterating over it")

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -273,8 +273,9 @@ proc enlarge[A, B](t: var Table[A, B]) =
     let eh = n[i].hcode
     if isFilled(eh):
       var j: Hash = eh and maxHash(t)
+      var perturb = eh
       while isFilled(t.data[j].hcode):
-        j = nextTry(j, maxHash(t))
+        j = nextTry(j, maxHash(t), perturb)
       when defined(js):
         rawInsert(t, t.data, n[i].key, n[i].val, eh, j)
       else:

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -275,7 +275,7 @@ proc enlarge[A, B](t: var Table[A, B]) =
     let eh = n[i].hcode
     if isFilledAndValid(eh):
       var j: Hash = eh and maxHash(t)
-      var perturb = eh
+      var perturb = t.getPerturb(eh)
       while isFilled(t.data[j].hcode):
         j = nextTry(j, maxHash(t), perturb)
       when defined(js):
@@ -796,7 +796,7 @@ iterator allValues*[A, B](t: Table[A, B]; key: A): B =
   let hc = genHash(key)
   var h: Hash = hc and high(t.data)
   let L = len(t)
-  var perturb = hc
+  var perturb = t.getPerturb(hc)
 
   var num = 0
   var cache: seq[Hash]
@@ -1281,7 +1281,7 @@ proc enlarge[A, B](t: var OrderedTable[A, B]) =
     let eh = n[h].hcode
     if isFilledAndValid(eh):
       var j: Hash = eh and maxHash(t)
-      var perturb = eh
+      var perturb = t.getPerturb(eh)
       while isFilled(t.data[j].hcode):
         j = nextTry(j, maxHash(t), perturb)
       rawInsert(t, t.data, n[h].key, n[h].val, n[h].hcode, j)
@@ -2248,7 +2248,7 @@ type
 
 proc ctRawInsert[A](t: CountTable[A], data: var seq[tuple[key: A, val: int]],
                   key: A, val: int) =
-  var perturb = hash(key)
+  var perturb = t.getPerturb(hash(key))
   var h: Hash = perturb and high(data)
   while data[h].val != 0: h = nextTry(h, high(data), perturb) # TODO: handle deletedMarker
   data[h].key = key
@@ -2277,7 +2277,7 @@ proc remove[A](t: var CountTable[A], key: A) =
 proc rawGet[A](t: CountTable[A], key: A): int =
   if t.data.len == 0:
     return -1
-  var perturb = hash(key)
+  var perturb = t.getPerturb(hash(key))
   var h: Hash = perturb and high(t.data) # start with real hash value
   while t.data[h].val != 0: # TODO: may need to handle t.data[h].hcode == deletedMarker?
     if t.data[h].key == key: return h

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -112,30 +112,13 @@ proc hash*[T: proc](x: T): Hash {.inline.} =
   else:
     result = hash(pointer(x))
 
-proc hashUInt32*(x: uint32): Hash {.inline.} =
-  ## for internal use; user code should prefer `hash` overloads
-  # calling `hashUInt64(x)` would perform 1.736 worse, see thashes_perf toInt32
-  when nimvm: # in vmops
-    doAssert false
-  else:
-    # inspired from https://gist.github.com/badboy/6267743
-    var x = x xor ((x shr 20) xor (x shr 12))
-    result = cast[Hash](x xor (x shr 7) xor (x shr 4))
-
-const prime = uint(11)
 proc hash*(x: int|int64|uint|uint64|char|Ordinal): Hash {.inline.} =
   ## Efficient hashing of integers.
-  when sizeof(x) < 4:
-    cast[Hash](x)
-  elif sizeof(x) == 4:
-    cast[Hash](cast[uint](x) * prime)
-    # hashUInt32(x)
-  else:
-    cast[Hash](cast[uint](x) * prime)
+  cast[Hash](ord(x))
 
 proc hash*(x: float): Hash {.inline.} =
   ## Efficient hashing of floats.
-  var y = x + 0.0
+  var y = x + 0.0 # for denormalization
   result = hash(cast[ptr Hash](addr(y))[])
 
 # Forward declarations before methods that hash containers. This allows

--- a/lib/pure/testutils.nim
+++ b/lib/pure/testutils.nim
@@ -1,0 +1,8 @@
+## utilities to help writing tests
+
+import std/[sequtils, algorithm]
+
+proc sortedPairs*[T](t: T): auto =
+  ## helps when writing tests involving tables in a way that's robust to
+  ## changes in hashing functions / table implementation.
+  toSeq(t.pairs).sorted

--- a/lib/pure/testutils.nim
+++ b/lib/pure/testutils.nim
@@ -1,4 +1,6 @@
-## utilities to help writing tests
+## Utilities to help writing tests
+##
+## Unstable, experimental API.
 
 import std/[sequtils, algorithm]
 

--- a/lib/pure/testutils.nim
+++ b/lib/pure/testutils.nim
@@ -6,3 +6,8 @@ proc sortedPairs*[T](t: T): auto =
   ## helps when writing tests involving tables in a way that's robust to
   ## changes in hashing functions / table implementation.
   toSeq(t.pairs).sorted
+
+template sortedItems*(t: untyped): untyped =
+  ## helps when writing tests involving tables in a way that's robust to
+  ## changes in hashing functions / table implementation.
+  sorted(toSeq(t))

--- a/tests/arc/trepr.nim
+++ b/tests/arc/trepr.nim
@@ -1,7 +1,7 @@
 discard """
   cmd: "nim c --gc:arc $file"
   nimout: '''(a: true, n: doAssert)
-Table[system.string, trepr.MyType](data: @[], counter: 0)
+Table[system.string, trepr.MyType](data: @[], counter: 0, countDeleted: 0)
 nil
 '''
 """

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -8,7 +8,12 @@ And we get here
 '''
 joinable: false
 """
-import hashes, sequtils, tables, algorithm
+import hashes, sequtils, tables, algorithm, testutils
+
+block tableDollar:
+  # other tests should use `sortedPairs` to be robust to future table/hash
+  # implementation changes
+  doAssert ${1: 'a', 2: 'b'}.toTable in ["{1: 'a', 2: 'b'}", "{2: 'b', 1: 'a'}"]
 
 # test should not be joined because it takes too long.
 block tableadds:
@@ -232,8 +237,8 @@ block tablesref:
     for x in 0..1:
       for y in 0..1:
         assert t[(x,y)] == $x & $y
-    assert($t ==
-      "{(x: 1, y: 1): \"11\", (x: 0, y: 0): \"00\", (x: 0, y: 1): \"01\", (x: 1, y: 0): \"10\"}")
+    assert t.sortedPairs ==
+      @[((x: 0, y: 0), "00"), ((x: 0, y: 1), "01"), ((x: 1, y: 0), "10"), ((x: 1, y: 1), "11")]
 
   block tableTest2:
     var t = newTable[string, float]()
@@ -340,7 +345,7 @@ block tablesref:
   block anonZipTest:
     let keys = @['a','b','c']
     let values = @[1, 2, 3]
-    doAssert "{'c': 3, 'a': 1, 'b': 2}" == $ toTable zip(keys, values)
+    doAssert zip(keys, values).toTable.sortedPairs == @[('a', 1), ('b', 2), ('c', 3)]
 
   block clearTableTest:
     var t = newTable[string, float]()

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -193,6 +193,23 @@ block ttables2:
   run1()
   echo "2"
 
+block allValues:
+  var t: Table[int, string]
+  var key = 0
+  let n = 1000
+  for i in 0..<n: t.add(i, $i)
+  const keys = [0, -1, 12]
+  for i in 0..1:
+    for key in keys:
+      t.add(key, $key & ":" & $i)
+  for i in 0..<n:
+    if i notin keys:
+      t.del(i)
+  doAssert t.sortedPairs == @[(-1, "-1:0"), (-1, "-1:1"), (0, "0"), (0, "0:0"), (0, "0:1"), (12, "12"), (12, "12:0"), (12, "12:1")]
+  doAssert sortedItems(t.allValues(0)) == @["0", "0:0", "0:1"]
+  doAssert sortedItems(t.allValues(-1)) == @["-1:0", "-1:1"]
+  doAssert sortedItems(t.allValues(12)) == @["12", "12:0", "12:1"]
+  doAssert sortedItems(t.allValues(1)) == @[]
 
 block tablesref:
   const
@@ -374,3 +391,4 @@ block tablesref:
 
   orderedTableSortTest()
   echo "3"
+

--- a/tests/collections/ttablesthreads.nim
+++ b/tests/collections/ttablesthreads.nim
@@ -3,7 +3,7 @@ discard """
   output: '''true'''
 """
 
-import hashes, tables, sharedtables
+import hashes, tables, sharedtables, testutils
 
 const
   data = {
@@ -47,8 +47,7 @@ block tableTest1:
   for x in 0..1:
     for y in 0..1:
       assert t[(x,y)] == $x & $y
-  assert($t ==
-    "{(x: 1, y: 1): \"11\", (x: 0, y: 0): \"00\", (x: 0, y: 1): \"01\", (x: 1, y: 0): \"10\"}")
+  assert t.sortedPairs == @[((x: 0, y: 0), "00"), ((x: 0, y: 1), "01"), ((x: 1, y: 0), "10"), ((x: 1, y: 1), "11")]
 
 block tableTest2:
   var t = initTable[string, float]()


### PR DESCRIPTION
(EDIT: see followup https://github.com/nim-lang/Nim/pull/13440 with a "best of both worlds" approach and additional benchmarks) 

performance benchmark shows this can work, see below.

* fixes #13393
* fixes analog problem for bitsets
* fixes collisions for small floats (as explained in #13410, small floats would previously all have the same hash value, causing major slowdowns)
* completely different approach from #13410 but some parts of that PR are still relevant and useful even in combination with this PR

this investigates pseudorandom probing for hash collisions, as done in python.
The main idea is to use this recursion in `nextTry`:
```nim
perturb = perturb shr PERTURB_SHIFT # with perturb initialized to hash(key) before recursion
h = ((5*h) + 1 + perturb) and maxHash
```
instead of linear probing:
`h = (h + 1) and maxHash`


## consequences
* at least similar (within 10%) performance in all cases I tested compared to before PR (see #13410 for test cases)
* no catastrophic slowdowns (issue #13393) which were causing 100x-1000x (and likely unbounded) slowdowns
* hash key computation is now only required to produce good hash keys modulo 64 bit, not modulo n bits for n<64, since the whole hash key is used in probing sequence. That means hash key computation for primitive types can remain fast.
* for theory on justification of `((5*h) + 1 + perturb) and maxHash`, refer to python internal docs (cpython implementation of dictionaries) or other material which explains pretty well; the basic idea is that `((5*h) + 1 + perturb) and maxHash` recursion is affected by all bits of hash(key) (so that different hashkeys will not follow exactly the same path and clustering is avoided), and if a free slot still isn't found by the time perturb = 0, then the recursion becomes `h = ((5*h) + 1) and maxHash` which is guaranteed to visit each slot exactly once. The visit occurs in pseudorandom order, and that order depends on the full 64 bit hash(key).
* should be resilient to adversarial attacks (but can still be made more resilient with adding an (unguessable) fixed seed in the recursion, eg: `h = ((5*h) + 1 + perturb + seed) and maxHash` with seed initialized upoon application startup)

## consequence for deletion
* there is no way to adapt `Algorithm R (Deletion with linear probing)` from Knuth Volume 3 to our new recursion, since multiple unrelated paths can pass through a given index (unlike with linear probing `h = (h + 1) and maxHash` or even `h = (h + c) and maxHash` with c constant). So I instead keep track of deletions, and adapt the table implementation as follows:
* each cell is in 3 states: empty (hash=0), deleted(h=-1), valid(h!=0, h!=1)
* rehash when count(empty) < 1/3 numSlots

## note: 
this is a slight modification from python: I'm using `translateBits` which results in large (eg 30x) speedups in cases like #13393 at 0 extra cost; it makes the hash influence the path earlier on. python doesn't do `translateBits` and does suffer from #13393 (although not catastrophically (eg 1000x) thanks to `PERTURB_SHIFT`) as well as you can see with:
```nim
  n = 10_000_000
  t={}
  for i in range(n):
    key = i << 32 # 68 sec 
    # key = i # 3 sec
    t[key] = str(key)
```
but with this PR, this isn't the case.


## TODO for future PR's
- [ ] do same with:
strtabs
compiler/astalgo.nim
compiler/treetab.nim
system/cellsets
(I don't quite understand why we have so many Table variants; seems to me like at least some of them could be reusing existing ones)

- [ ] investigate whether following refinement would improve speed even further:
```nim
  if iteration < thres: # eg thres = 4
    result = (h + 1) and maxHash
  else:
    perturb = perturb shr PERTURB_SHIFT
    result = ((5*h) + 1 + perturb) and maxHash
  iteration.inc
```
with the idea being to improve cache locality unless we're detecting we're in a dense collision cluster, in which case we're switching to pseudo-random probing to break out of the cluster. In some benchmarks at least this led to some speedups, but it'd require a bit of code refactoring to avoid introducing code duplication. So this is left for future work.

- [ ] [EDIT] OrderedTable.del is O(n) (including before PR), because every `del` rebuilds whole table; instead, using tombstones as introduced in this PR would make it O(1)

- [ ] [EDIT] support `dec`, and having zero counts, in `CountTable` using tombstones
- [ ] SharedTable should auto-init, like other tables; it should have some iterators, and simply ask user to protect access via `withLock` instead of current API which is rather cumbersome and unlike other tables
