### PR TITLE
[ci skip] fixed examples in manual.rst:exception handling

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4106,6 +4106,8 @@ needs to fit the types of ``except`` branches, but the type of the ``finally``
 branch always has to be ``void``:
 
 .. code-block:: nim
+  from strutils import parseInt
+  
   let x = try: parseInt("133a")
           except: -1
           finally: echo "hi"
@@ -4220,7 +4222,7 @@ Raise statement
 Example:
 
 .. code-block:: nim
-  raise newEOS("operating system failed")
+  raise newException(LoadError, "Failed to load data")
 
 Apart from built-in operations like array indexing, memory allocation, etc.
 the ``raise`` statement is the only way to raise an exception.


### PR DESCRIPTION
Fixed examples in Exception Handling section of the Nim Manual which were not working due to import issues.