### PR TITLE
fix incorrect lenTuple implementation

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -187,6 +187,10 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     var operand = operand.skipTypes({tyGenericInst})
     let cond = operand.kind == tyTuple and operand.n != nil
     result = newIntNodeT(toInt128(ord(cond)), traitCall, c.graph)
+  of "lenTuple":
+    var operand = operand.skipTypes({tyGenericInst})
+    assert operand.kind == tyTuple, $operand.kind
+    result = newIntNodeT(toInt128(operand.len), traitCall, c.graph)
   of "distinctBase":
     var arg = operand.skipTypes({tyGenericInst})
     if arg.kind == tyDistinct:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -71,21 +71,22 @@ proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".}
   ## Returns base type for distinct types, works only for distinct types.
   ## compile time error otherwise
 
-import std/macros
 
-macro lenTuple*(t: tuple): int {.since: (1, 1).} =
-  ## Return number of elements of `t`
-  newLit t.len
-
-macro lenTuple*(t: typedesc[tuple]): int {.since: (1, 1).} =
+proc lenTuple*(T: typedesc[tuple]): int {.magic: "TypeTrait", since: (1, 1).}
   ## Return number of elements of `T`
-  newLit t.len
+
+since (1, 1):
+  template lenTuple*(t: tuple): int =
+    ## Return number of elements of `t`
+    lenTuple(type(t))
 
 since (1, 1):
   template get*(T: typedesc[tuple], i: static int): untyped =
     ## Return `i`th element of `T`
     # Note: `[]` currently gives: `Error: no generic parameters allowed for ...`
     type(default(T)[i])
+
+import std/macros
 
 macro genericParams*(T: typedesc): untyped {.since: (1, 1).} =
   ## return tuple of generic params for generic `T`

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -93,17 +93,12 @@ block distinctBase:
         doAssert($distinctBase(typeof(c2)) == "int")
 
 block: # lenTuple
-  type
-    VectorElementType = SomeNumber | bool
-    Vec[N : static[int], T: VectorElementType] = object
-      arr*: array[N, T]
-    Vec4[T: VectorElementType] = Vec[4,T]
-    Vec4f = Vec4[float32]
+  doAssert not compiles(lenTuple(int))
 
+  type
     MyTupleType = (int,float,string)
 
   static: doAssert MyTupleType.lenTuple == 3
-  doAssert not compiles(lenTuple(Vec4f))
 
   type
     MyGenericTuple[T] = (T,int,float)

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -92,7 +92,46 @@ block distinctBase:
         doAssert($distinctBase(typeof(b2)) == "string")
         doAssert($distinctBase(typeof(c2)) == "int")
 
+block lenTuple:
+  type
+    VectorElementType = SomeNumber | bool
+    Vec[N : static[int], T: VectorElementType] = object
+      arr*: array[N, T]
+    Vec4[T: VectorElementType] = Vec[4,T]
+    Vec4f = Vec4[float32]
+
+    MyTupleType = (int,float,string)
+  static: doAssert MyTupleType.lenTuple == 3
+
+  type
+    MyGenericTuple[T] = (T,int,float)
+    MyGenericAlias = MyGenericTuple[string]
+  static: doAssert MyGenericAlias.lenTuple == 3
+
+  type
+    MyGenericTuple2[T,U] = (T,U,string)
+    MyGenericTuple2Alias[T] =  MyGenericTuple2[T,int]
+
+    MyGenericTuple2Alias2 =   MyGenericTuple2Alias[float]
+  static: doAssert MyGenericTuple2Alias2.lenTuple == 3
+
+  static: doAssert (int, float).lenTuple == 2
+  static: doAssert (1, ).lenTuple == 1
+  static: doAssert ().lenTuple == 0
+
+  let x = (1,2,)
+  doAssert x.lenTuple == 2
+  doAssert ().lenTuple == 0
+  doAssert (1,).lenTuple == 1
+  doAssert (int,).lenTuple == 1
+  doAssert type(x).lenTuple == 2
+  doAssert type(x).default.lenTuple == 2
+  type T1 = (int,float)
+  type T2 = T1
+  doAssert T2.lenTuple == 2
+
 block genericParams:
+
   type Foo[T1, T2]=object
   doAssert genericParams(Foo[float, string]) is (float, string)
   type Foo1 = Foo[float, int]
@@ -103,10 +142,6 @@ block genericParams:
   doAssert genericParams(Foo2).get(1) is Foo1
   doAssert (int,).get(0) is int
   doAssert (int, float).get(1) is float
-  static: doAssert (int, float).lenTuple == 2
-  static: doAssert (1, ).lenTuple == 1
-  static: doAssert ().lenTuple == 0
-
 
 ##############################################
 # bug 13095

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -92,7 +92,7 @@ block distinctBase:
         doAssert($distinctBase(typeof(b2)) == "string")
         doAssert($distinctBase(typeof(c2)) == "int")
 
-block lenTuple:
+block: # lenTuple
   type
     VectorElementType = SomeNumber | bool
     Vec[N : static[int], T: VectorElementType] = object
@@ -101,7 +101,9 @@ block lenTuple:
     Vec4f = Vec4[float32]
 
     MyTupleType = (int,float,string)
+
   static: doAssert MyTupleType.lenTuple == 3
+  doAssert not compiles(lenTuple(Vec4f))
 
   type
     MyGenericTuple[T] = (T,int,float)


### PR DESCRIPTION
some of the tests I added in this PR would not pass before this PR.
`var operand = operand.skipTypes({tyGenericInst})` could maybe be `{tyGenericInst, tySink}` but I went for consistency with other typetraits; most/all of these typetraits should use the same argument in skipTypes so, if needed, that could be handled in a separate (unrelated) PR that would fix all of these
