### PR TITLE
[ci skip] Fixed non-working examples in Manual: Exception Handling

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4221,7 +4221,7 @@ Raise statement
 
 Example:
 
-.. code-block:: nim/
+.. code-block:: nim
   raise newException(IOError, "IO failed")
 
 Apart from built-in operations like array indexing, memory allocation, etc.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4106,6 +4106,8 @@ needs to fit the types of ``except`` branches, but the type of the ``finally``
 branch always has to be ``void``:
 
 .. code-block:: nim
+  from strutils import parseInt
+  
   let x = try: parseInt("133a")
           except: -1
           finally: echo "hi"
@@ -4219,8 +4221,8 @@ Raise statement
 
 Example:
 
-.. code-block:: nim
-  raise newEOS("operating system failed")
+.. code-block:: nim/
+  raise newException(IOError, "IO failed")
 
 Apart from built-in operations like array indexing, memory allocation, etc.
 the ``raise`` statement is the only way to raise an exception.


### PR DESCRIPTION
Tried to fix some examples in Exception Handling section of doc/manual.rst which were not working when copy-pasted.