### PR TITLE
hashing collision: improve performance using linear/pseudorandom probing mix

### DIFF
--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -78,24 +78,24 @@ template findCell(t: typed, hc, mustNextTry): int =
   var perturb = getPerturb(t, hc)
   var depth = 0
 
-  ## PARAM: this param can affect performance and could be exposed to users whoe
-  ## need to optimize for their specific key distribution. If clusters are to be
-  ## expected, it's better to set it low; for really random data, it's better to
-  ## set it high. We pick a sensible default that works across a range of key
-  ## distributions.
-  ##
-  ## depthThres=0 will just use pseudorandom probing
-  ## depthThres=int.high will just use linear probing
-  ## depthThres in between will switch
+  # PARAM: `depthThres` can affect performance and could be exposed to users who
+  # need to optimize for their specific key distribution. If clusters are to be
+  # expected, it's better to set it low; for really random data, it's better to
+  # set it high. We pick a sensible default that works across a range of key
+  # distributions.
+  #
+  # depthThres=0 will just use pseudorandom probing
+  # depthThres=int.high will just use linear probing
+  # depthThres in between will switch
   const depthThres = 20
 
   while mustNextTry(t.data[index], index):
     depth.inc
     if depth <= depthThres:
-      ## linear probing, cache friendly
+      # linear probing, cache friendly
       index = (index + 1) and m
     else:
-      ## pseudorandom probing, "bad" case was detected
+      # pseudorandom probing, "bad" case was detected
       index = nextTry(index, m, perturb)
   index
 

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -50,10 +50,8 @@ proc enlarge[A, B](t: var SharedTable[A, B]) =
   for i in 0..<oldSize:
     let eh = n[i].hcode
     if isFilled(eh):
-      var perturb = t.getPerturb(eh)
-      var j: Hash = eh and maxHash(t)
-      while isFilled(t.data[j].hcode):
-        j = nextTry(j, maxHash(t), perturb)
+      template mustNextTry(cell, index): bool = isFilled(cell.hcode)
+      let j = findCell(t, eh, mustNextTry)
       rawInsert(t, t.data, n[i].key, n[i].val, eh, j)
   deallocShared(n)
 

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -13,15 +13,9 @@ include hashcommon
 
 template rawGetDeepImpl() {.dirty.} =   # Search algo for unconditional add
   genHashImpl(key, hc)
-  var h: Hash = hc and maxHash(t)
-  var perturb = t.getPerturb(hc)
-  while true:
-    let hcode = t.data[h].hcode
-    if hcode == deletedMarker or hcode == freeMarker:
-      break
-    else:
-      h = nextTry(h, maxHash(t), perturb)
-  result = h
+  template mustNextTry(cell, index): bool = cell.hcode != deletedMarker and cell.hcode != freeMarker
+  result = findCell(t, hc, mustNextTry)
+
 
 template rawInsertImpl(t) {.dirty.} =
   data[h].key = key
@@ -128,7 +122,7 @@ template initImpl(result: typed, size: int) =
 template insertImpl() = # for CountTable
   checkIfInitialized()
   if mustRehash(t): enlarge(t)
-  ctRawInsert(t, t.data, key, val)
+  ctRawInsert(t, key, val)
   inc(t.counter)
 
 template getOrDefaultImpl(t, key): untyped =

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -272,10 +272,8 @@ proc enlarge[A, B](t: var Table[A, B]) =
   for i in countup(0, high(n)):
     let eh = n[i].hcode
     if isFilledAndValid(eh):
-      var j: Hash = eh and maxHash(t)
-      var perturb = t.getPerturb(eh)
-      while isFilled(t.data[j].hcode):
-        j = nextTry(j, maxHash(t), perturb)
+      template mustNextTry(cell, index): bool = isFilled(cell.hcode)
+      let j = findCell(t, eh, mustNextTry)
       when defined(js):
         rawInsert(t, t.data, n[i].key, n[i].val, eh, j)
       else:

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2226,9 +2226,10 @@ type
     counter: int
     countDeleted: int
       # using this and creating tombstones as in `Table` would make `remove`
-      # amortized O(1) instead of O(n); this requires updating remove,
-      # and changing `val != 0` to what's used in Table. Or simply make CountTable
-      # a thin wrapper around Table (which would also enable `dec`, etc)
+      # amortized O(1) instead of O(n); this requires updating `remove`,
+      # and changing `val != 0` to what's used in Table. Or we could simply make
+      # CountTable a thin wrapper around Table (which would also enable lifting
+      # restrictions on CountTable, eg lack of `dec`, allowing `0` counts, etc).
     isSorted: bool
   CountTableRef*[A] = ref CountTable[A] ## Ref version of
     ## `CountTable<#CountTable>`_.
@@ -2360,7 +2361,7 @@ proc inc*[A](t: var CountTable[A], key: A, val: Positive = 1) =
   var index = rawGet(t, key)
   if index >= 0:
     inc(t.data[index].val, val)
-    if t.data[index].val == 0: dec(t.counter) # how could this happen?
+    assert t.data[index].val != 0
   else:
     insertImpl()
 

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -436,3 +436,37 @@ block: # https://github.com/nim-lang/Nim/issues/13496
   testDel(): (let t = newOrderedTable[int, int]())
   testDel(): (var t: CountTable[int])
   testDel(): (let t = newCountTable[int]())
+
+block:
+  # check CountTable using Table as groundtruth
+  proc main() =
+    var t: CountTable[string]
+    var t0: Table[string, int]
+    let n = 1000
+    let n1 = n div 2
+    template inc2(key: string, val = 1) =
+      t.inc(key, val)
+      if key in t0: t0[key]+=val else: t0[key]=val
+
+    template del2(key) =
+      t.del(key)
+      t0.del(key)
+
+    template check() =
+      for k,v in t:
+        doAssert t0[k] == v
+      for k,v in t0:
+        doAssert t[k] == v
+
+    let m = 2
+    for j in 0..<m:
+      for i in 0..<n: inc2($i)
+    check()
+
+    for i in 0..<n1: del2($i)
+    check()
+
+    for i in 0..<n: inc2($i)
+    check()
+
+  main()

--- a/tests/stdlib/tsharedtable.nim
+++ b/tests/stdlib/tsharedtable.nim
@@ -87,3 +87,17 @@ block: # we use Table as groundtruth, it's well tested elsewhere
   var t0: Table[int, int]
   testDel(t, t0)
   deinitSharedTable(t)
+
+block: # CHECKME:redundant w above?
+  let n = 100
+  let n2 = n * 2
+  for i in 0..<n:
+    table[i] = i
+    assert table.hasKeyOrPut(i, i)
+
+  for i in n..<n2:
+    assert not table.hasKeyOrPut(i, i)
+
+  for i in 0..<n2:
+    assert table.mgetOrPut(i, i) == i
+    assert table.mget(i) == i

--- a/tests/stdlib/tsharedtable.nim
+++ b/tests/stdlib/tsharedtable.nim
@@ -66,10 +66,15 @@ block: # we use Table as groundtruth, it's well tested elsewhere
       doAssert t.mgetOrPut(i, -2) == -2
       doAssert t.mget(i) == -2
 
+    var numOK = 0
     for i in 0..<n4:
       let ok = i in t0
+      if ok:
+        numOK.inc
       if not ok: t0[i] = -i
       doAssert t.hasKeyOrPut(i, -i) == ok
+    doAssert numOK > 0
+    doAssert numOK < n4
 
     checkEquals()
 
@@ -87,17 +92,3 @@ block: # we use Table as groundtruth, it's well tested elsewhere
   var t0: Table[int, int]
   testDel(t, t0)
   deinitSharedTable(t)
-
-block: # CHECKME:redundant w above?
-  let n = 100
-  let n2 = n * 2
-  for i in 0..<n:
-    table[i] = i
-    assert table.hasKeyOrPut(i, i)
-
-  for i in n..<n2:
-    assert not table.hasKeyOrPut(i, i)
-
-  for i in 0..<n2:
-    assert table.mgetOrPut(i, i) == i
-    assert table.mget(i) == i


### PR DESCRIPTION
## TLDR
compared to right before PR:
* performance improves in almost all cases thanks to better cache locality
* performance is slightly worse (1.3X) for the edge cases (long collision chains) that were causing extreme (100X-unbounded) slowdowns before pseudorandom probing (https://github.com/nim-lang/Nim/pull/13418)

compared to right before https://github.com/nim-lang/Nim/pull/13418:
* often quite a bit faster
*  worst slowdown is `1.06` slowdown
* avoids the extreme slowdowns (100X-unbounded) for edge cases

## details
as I mentioned in https://github.com/nim-lang/Nim/pull/13418 we can refine the collision strategy to get the best of both worlds between:
* cache locality (linear probing, **make common case fast**)
* avoiding large collision clusters (pseudorandom probing, **prevents edge cases causing extreme slowdowns**)

using a threshold `depthThres` on search depth (ie number of calls to nextTry), which is a parameter to tune; in practice 20 works across a range of applications but future PR could expose this single param to users;
* depthThres=0 will just use pseudorandom probing
* depthThres=int.high will just use linear probing
* depthThres > 0 < int.high will switch dynamically for "bad cases" from linear to pseudorandom

## performance numbers
I published some easy to modify benchmarking code to compare performance of a (customizable) task involving inserting some 20 million keys in a table, retrieving keys, and searching for both existing and nonexisting keys. I tried on a number of different distributions of keys (english words, oids, various string keys, various random, high order bit keys, consecutive numbers (int32/64), explicit formulas (eg squares, multiples of K), small floats, etc

The results show that:
* with this PR, the worst ratio compared to before #13418 is `1.06` slowdown
* the best ratio is essentially unlimited (eg for cases like https://github.com/nim-lang/Nim/issues/13393, which could be 100X, 1000X or worse); in this benchmark **I added a timeout of 50s**
* many other distributions (unrelated to https://github.com/nim-lang/Nim/issues/13393) compare favorably (eg 3X speedup)
* `better hash` (https://github.com/nim-lang/Nim/pull/13410) also avoids the extreme bad cases, but is 2X slower for many simple distributions because of the hash computation overhead, and isn't as robust as pseudorandom probing against adversarial attacks
* this PR noticably improves performance over pure pseudorandom (what's currently in devel) in almost all cases, except for the pathological cases (eg `toHighOrderBits` distribution), but instead of giving an unbounded slowdown (as is case for linear probing), it just gives a 1.3X slowdown), so this is a very good tradeoff that makes the common cases faster at the expense of edge cases, for which we pay a small penalty (1.3X instead of 100X or unbounded slowdown)
* `depthThres` is a very simple heuristic that helps almost in all cases

```
git clone https://github.com/timotheecour/vitanim && cd vitanim
git checkout 06a65792d075815e718d2b6b0d31211127dcf8d1
nim c -r -d:danger testcases/tableutils/benchmain.nim
```

I'm comparing 4 algos:
* mix: this PR
* pseudorandom (as of https://github.com/nim-lang/Nim/pull/13418)
* linear  (right before https://github.com/nim-lang/Nim/pull/13418)
* better hash (https://github.com/nim-lang/Nim/pull/13410 with a small modification: `hashUInt32` just forwarding to `hashUInt64` as `hashUInt32` had at least 1 very bad case)
```
mix(this PR) | pseudorandom | linear | better hash | 1 / 3
-- | -- | -- | -- | --
24.7842 | 28.1233 | 23.3294 | 23.5042 | 1.062359083
28.4544 | 32.4396 | 26.811 | 27.3472 | 1.061295737
11.8106 | 14.9808 | 11.7898 | 12.0099 | 1.001764237
24.7805 | 28.4708 | 24.0842 | 24.5816 | 1.02891107
24.1552 | 27.9138 | 22.6895 | 23.3472 | 1.064598162
22.417 | 26.535 | 22.0931 | 22.2877 | 1.014660686
2.90124 | 2.65254 | 3.03189 | 10.906 | 0.9569080672
3.51184 | 2.7196 | 4.48502 | 11.9838 | 0.7830154604
9.6545 | 16.254 | 15.2375 | 11.3906 | 0.6336013126
9.76797 | 16.0781 | 15.7369 | 11.4528 | 0.6207048402
2.47488 | 3.93578 | 6.82566 | 11.8847 | 0.3625847171
4.06318 | 4.58738 | 8.18277 | 12.073 | 0.4965531232
8.33806 | 14.4545 | 11.2387 | 11.431 | 0.7419060923
10.2709 | 14.9484 | 11.3907 | 11.7426 | 0.901691731
11.1881 | 14.963 | 50.0003 | 11.7045 | 0.2237606574
4.51758 | 2.65223 | 50.0001 | 11.4548 | 0.0903514193
19.213 | 16.0138 | 47.0852 | 8.76856 | 0.4080475394
27.7964 | 19.6391 | 50 | 11.481 | 0.555928
```


## details performance numbers
```
mix: after current PR (mix of linear/pseudo-random probing)
runPerfAll benchmark for nim git hash: 586e7f672a50b4a4d450e8d9cb8b167b6221fa12
[ 1] name: toEnglishWords       num: 20000000 numIter: 1 runtime:              19.7674                      ex[0]: Aaron_0              ex[1]: darted_220           ex[2]: itch_440
[ 2] name: toRandFloatAsString  num: 20000000 numIter: 1 runtime:              28.4858                      ex[0]: 0.8228467011541094   ex[1]: 0.8883906930501309   ex[2]: 0.7158161478612264
[ 3] name: oidHash              num: 20000000 numIter: 1 runtime:              12.0973                      ex[0]: 5980795527476110011  ex[1]: -8770990215615663721 ex[2]: 346373246543934521
[ 4] name: oidHashAsString      num: 20000000 numIter: 1 runtime:              25.3611                      ex[0]: 5e4e013d49519734557bef48 ex[1]: 5e4e013e49519734561485c7 ex[2]: 5e4e013f4951973456ad1c46
[ 5] name: randIint32AsString   num: 20000000 numIter: 1 runtime:              24.4193                      ex[0]: 6286188681263997477  ex[1]: 5241554617367510837  ex[2]: 1048061160398310475
[ 6] name: intAsString          num: 20000000 numIter: 1 runtime:              22.7159                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 7] name: toInt32              num: 20000000 numIter: 1 runtime:              3.07487                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 8] name: toInt64              num: 20000000 numIter: 1 runtime:              3.68188                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 9] name: toSquares            num: 20000000 numIter: 1 runtime:              12.5888                      ex[0]: 1                    ex[1]: 100000000000000      ex[2]: 399999960000001
[10] name: toSquaresSigned      num: 20000000 numIter: 1 runtime:              13.1395                      ex[0]: -1                   ex[1]: 100000000000000      ex[2]: -399999960000001
[11] name: toIntTimes5          num: 20000000 numIter: 1 runtime:              2.68821                      ex[0]: 5                    ex[1]: 50000000             ex[2]: 99999995
[12] name: toIntTimes13         num: 20000000 numIter: 1 runtime:              4.79935                      ex[0]: 13                   ex[1]: 130000000            ex[2]: 259999987
[13] name: toRand               num: 20000000 numIter: 1 runtime:              11.3335                      ex[0]: 8389824593544564917  ex[1]: 1388452581874133311  ex[2]: 5738321176173495635
[14] name: toRandFloat          num: 20000000 numIter: 1 runtime:              11.6262                      ex[0]: 0.005933778906357601 ex[1]: 0.9201098173171902   ex[2]: 0.05296104548725977
[15] name: toSmallFloat         num: 20000000 numIter: 1 runtime:              11.4167                      ex[0]: 9.999999999999999e-21 ex[1]: 9.999999999999999e-14 ex[2]: 1.9999999e-13
[16] name: toHighOrderBits      num: 20000000 numIter: 1 runtime:              3.55724                      ex[0]: 4294967296           ex[1]: 42949672960000000    ex[2]: 85899341625032704
[17] name: toHighOrderBits2     num: 20000000 numIter: 1 runtime:              20.5522                      ex[0]: 2048                 ex[1]: 3300130816           ex[2]: 2305292288
[18] name: toHighOrderBits3     num: 20000000 numIter: 1 runtime:              21.6669                      ex[0]: 8192                 ex[1]: 81920000000          ex[2]: 163839991808

pseudorandom: after https://github.com/nim-lang/Nim/pull/13418 (pseudo-random probing)
runPerfAll benchmark for nim git hash: 87dd19453b9a9aeded5f85714e90e12fc8bab0bf
[ 1] name: toEnglishWords       num: 20000000 numIter: 1 runtime:              28.1233                      ex[0]: Aaron_0              ex[1]: darted_220           ex[2]: itch_440
[ 2] name: toRandFloatAsString  num: 20000000 numIter: 1 runtime:              32.4396                      ex[0]: 0.8228467011541094   ex[1]: 0.8883906930501309   ex[2]: 0.7158161478612264
[ 3] name: oidHash              num: 20000000 numIter: 1 runtime:              14.9808                      ex[0]: 2007510477909153732  ex[1]: -2712027032279094734 ex[2]: -3177538604408694653
[ 4] name: oidHashAsString      num: 20000000 numIter: 1 runtime:              28.4708                      ex[0]: 5e4dcdafb2217733483f66dd ex[1]: 5e4dcdb0b221773348d7fd5c ex[2]: 5e4dcdb0b2217733497093db
[ 5] name: randIint32AsString   num: 20000000 numIter: 1 runtime:              27.9138                      ex[0]: 6286188681263997477  ex[1]: 5241554617367510837  ex[2]: 1048061160398310475
[ 6] name: intAsString          num: 20000000 numIter: 1 runtime:               26.535                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 7] name: toInt32              num: 20000000 numIter: 1 runtime:              2.65254                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 8] name: toInt64              num: 20000000 numIter: 1 runtime:               2.7196                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 9] name: toSquares            num: 20000000 numIter: 1 runtime:               16.254                      ex[0]: 1                    ex[1]: 100000000000000      ex[2]: 399999960000001
[10] name: toSquaresSigned      num: 20000000 numIter: 1 runtime:              16.0781                      ex[0]: -1                   ex[1]: 100000000000000      ex[2]: -399999960000001
[11] name: toIntTimes5          num: 20000000 numIter: 1 runtime:              3.93578                      ex[0]: 5                    ex[1]: 50000000             ex[2]: 99999995
[12] name: toIntTimes13         num: 20000000 numIter: 1 runtime:              4.58738                      ex[0]: 13                   ex[1]: 130000000            ex[2]: 259999987
[13] name: toRand               num: 20000000 numIter: 1 runtime:              14.4545                      ex[0]: 8389824593544564917  ex[1]: 1388452581874133311  ex[2]: 5738321176173495635
[14] name: toRandFloat          num: 20000000 numIter: 1 runtime:              14.9484                      ex[0]: 0.005933778906357601 ex[1]: 0.9201098173171902   ex[2]: 0.05296104548725977
[15] name: toSmallFloat         num: 20000000 numIter: 1 runtime:               14.963                      ex[0]: 9.999999999999999e-21 ex[1]: 9.999999999999999e-14 ex[2]: 1.9999999e-13
[16] name: toHighOrderBits      num: 20000000 numIter: 1 runtime:              2.65223                      ex[0]: 4294967296           ex[1]: 42949672960000000    ex[2]: 85899341625032704
[17] name: toHighOrderBits2     num: 20000000 numIter: 1 runtime:              16.0138                      ex[0]: 2048                 ex[1]: 3300130816           ex[2]: 2305292288
[18] name: toHighOrderBits3     num: 20000000 numIter: 1 runtime:              19.6391                      ex[0]: 8192                 ex[1]: 81920000000          ex[2]: 163839991808


linear: before https://github.com/nim-lang/Nim/pull/13418 (ie, before pseudo-random probing)
runPerfAll benchmark for nim git hash: 273a93581f851d2d16d6891d7dd1d7d9edfbb4ef
[ 1] name: toEnglishWords       num: 20000000 numIter: 1 runtime:              23.3294                      ex[0]: Aaron_0              ex[1]: darted_220           ex[2]: itch_440
[ 2] name: toRandFloatAsString  num: 20000000 numIter: 1 runtime:               26.811                      ex[0]: 0.8228467011541094   ex[1]: 0.8883906930501309   ex[2]: 0.7158161478612264
[ 3] name: oidHash              num: 20000000 numIter: 1 runtime:              11.7898                      ex[0]: 6791954661837144404  ex[1]: 6737600927306182383  ex[2]: -9096880239424528216
[ 4] name: oidHashAsString      num: 20000000 numIter: 1 runtime:              24.0842                      ex[0]: 5e4dcf6da16c6e5948b6e8db ex[1]: 5e4dcf73a16c6e59494f7f5a ex[2]: 5e4dcf74a16c6e5949e815d9
[ 5] name: randIint32AsString   num: 20000000 numIter: 1 runtime:              22.6895                      ex[0]: 6286188681263997477  ex[1]: 5241554617367510837  ex[2]: 1048061160398310475
[ 6] name: intAsString          num: 20000000 numIter: 1 runtime:              22.0931                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 7] name: toInt32              num: 20000000 numIter: 1 runtime:              3.03189                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 8] name: toInt64              num: 20000000 numIter: 1 runtime:              4.48502                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 9] name: toSquares            num: 20000000 numIter: 1 runtime:              15.2375                      ex[0]: 1                    ex[1]: 100000000000000      ex[2]: 399999960000001
[10] name: toSquaresSigned      num: 20000000 numIter: 1 runtime:              15.7369                      ex[0]: -1                   ex[1]: 100000000000000      ex[2]: -399999960000001
[11] name: toIntTimes5          num: 20000000 numIter: 1 runtime:              6.82566                      ex[0]: 5                    ex[1]: 50000000             ex[2]: 99999995
[12] name: toIntTimes13         num: 20000000 numIter: 1 runtime:              8.18277                      ex[0]: 13                   ex[1]: 130000000            ex[2]: 259999987
[13] name: toRand               num: 20000000 numIter: 1 runtime:              11.2387                      ex[0]: 8389824593544564917  ex[1]: 1388452581874133311  ex[2]: 5738321176173495635
[14] name: toRandFloat          num: 20000000 numIter: 1 runtime:              11.3907                      ex[0]: 0.005933778906357601 ex[1]: 0.9201098173171902   ex[2]: 0.05296104548725977
[15] name: toSmallFloat         num: 20000000 numIter: 1 runtime:              50.0003 timeoutAtIter: 0     ex[0]: 9.999999999999999e-21 ex[1]: 9.999999999999999e-14 ex[2]: 1.9999999e-13
[16] name: toHighOrderBits      num: 20000000 numIter: 1 runtime:              50.0001 timeoutAtIter: 0     ex[0]: 4294967296           ex[1]: 42949672960000000    ex[2]: 85899341625032704
[17] name: toHighOrderBits2     num: 20000000 numIter: 1 runtime:              47.0852                      ex[0]: 2048                 ex[1]: 3300130816           ex[2]: 2305292288
[18] name: toHighOrderBits3     num: 20000000 numIter: 1 runtime:                   50 timeoutAtIter: 0     ex[0]: 8192                 ex[1]: 81920000000          ex[2]: 163839991808

better hash
runPerfAll benchmark for nim git hash: e6b517ad36ee4f053fcef8f878cd2c82201c1523
[ 1] name: toEnglishWords       num: 20000000 numIter: 1 runtime:              23.5042                      ex[0]: Aaron_0              ex[1]: darted_220           ex[2]: itch_440
[ 2] name: toRandFloatAsString  num: 20000000 numIter: 1 runtime:              27.3472                      ex[0]: 0.8228467011541094   ex[1]: 0.8883906930501309   ex[2]: 0.7158161478612264
[ 3] name: oidHash              num: 20000000 numIter: 1 runtime:              12.0099                      ex[0]: 8341231083579904102  ex[1]: 8281382965556985093  ex[2]: 2998183081495492116
[ 4] name: oidHashAsString      num: 20000000 numIter: 1 runtime:              24.5816                      ex[0]: 5e4dd45a91112c1649f98781 ex[1]: 5e4dd46091112c164a921e00 ex[2]: 5e4dd46191112c164b2ab47f
[ 5] name: randIint32AsString   num: 20000000 numIter: 1 runtime:              23.3472                      ex[0]: 6286188681263997477  ex[1]: 5241554617367510837  ex[2]: 1048061160398310475
[ 6] name: intAsString          num: 20000000 numIter: 1 runtime:              22.2877                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 7] name: toInt32              num: 20000000 numIter: 1 runtime:               10.906                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 8] name: toInt64              num: 20000000 numIter: 1 runtime:              11.9838                      ex[0]: 1                    ex[1]: 10000000             ex[2]: 19999999
[ 9] name: toSquares            num: 20000000 numIter: 1 runtime:              11.3906                      ex[0]: 1                    ex[1]: 100000000000000      ex[2]: 399999960000001
[10] name: toSquaresSigned      num: 20000000 numIter: 1 runtime:              11.4528                      ex[0]: -1                   ex[1]: 100000000000000      ex[2]: -399999960000001
[11] name: toIntTimes5          num: 20000000 numIter: 1 runtime:              11.8847                      ex[0]: 5                    ex[1]: 50000000             ex[2]: 99999995
[12] name: toIntTimes13         num: 20000000 numIter: 1 runtime:               12.073                      ex[0]: 13                   ex[1]: 130000000            ex[2]: 259999987
[13] name: toRand               num: 20000000 numIter: 1 runtime:               11.431                      ex[0]: 8389824593544564917  ex[1]: 1388452581874133311  ex[2]: 5738321176173495635
[14] name: toRandFloat          num: 20000000 numIter: 1 runtime:              11.7426                      ex[0]: 0.005933778906357601 ex[1]: 0.9201098173171902   ex[2]: 0.05296104548725977
[15] name: toSmallFloat         num: 20000000 numIter: 1 runtime:              11.7045                      ex[0]: 9.999999999999999e-21 ex[1]: 9.999999999999999e-14 ex[2]: 1.9999999e-13
[16] name: toHighOrderBits      num: 20000000 numIter: 1 runtime:              11.4548                      ex[0]: 4294967296           ex[1]: 42949672960000000    ex[2]: 85899341625032704
[17] name: toHighOrderBits2     num: 20000000 numIter: 1 runtime:              8.76856                      ex[0]: 2048                 ex[1]: 3300130816           ex[2]: 2305292288
[18] name: toHighOrderBits3     num: 20000000 numIter: 1 runtime:               11.481                      ex[0]: 8192                 ex[1]: 81920000000          ex[2]: 163839991808


```
