### PR TITLE
make unzip faster: seq[i]=val can be 7X faster than seq.add(val)

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -290,11 +290,11 @@ proc unzip*[S, T](s: openArray[(S, T)]): (seq[S], seq[T]) {.since: (1, 1).} =
       unzipped2 = @['a', 'b', 'c']
     assert zipped.unzip() == (unzipped1, unzipped2)
     assert zip(unzipped1, unzipped2).unzip() == (unzipped1, unzipped2)
-  result[0] = newSeqOfCap[S](s.len)
-  result[1] = newSeqOfCap[T](s.len)
-  for elem in s:
-    result[0].add(elem[0])
-    result[1].add(elem[1])
+  result[0] = newSeq[S](s.len)
+  result[1] = newSeq[T](s.len)
+  for i in 0..<s.len:
+    result[0][i]=s[i][0]
+    result[1][i]=s[i][1]
 
 proc distribute*[T](s: seq[T], num: Positive, spread = true): seq[seq[T]] =
   ## Splits and distributes a sequence `s` into `num` sub-sequences.

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -293,8 +293,8 @@ proc unzip*[S, T](s: openArray[(S, T)]): (seq[S], seq[T]) {.since: (1, 1).} =
   result[0] = newSeq[S](s.len)
   result[1] = newSeq[T](s.len)
   for i in 0..<s.len:
-    result[0][i]=s[i][0]
-    result[1][i]=s[i][1]
+    result[0][i] = s[i][0]
+    result[1][i] = s[i][1]
 
 proc distribute*[T](s: seq[T], num: Positive, spread = true): seq[seq[T]] =
   ## Splits and distributes a sequence `s` into `num` sub-sequences.


### PR DESCRIPTION
this PR makes unzip (https://github.com/nim-lang/Nim/pull/13429) up to 7X faster by simply using `[]=` instead of `add`

## general performance note: avoid `newSeqOfCap` anti-pattern
when the final size is known in advance, `newSeqOfCap(n) + seq.add(elem)` should not be used; it can be 7X slower than this pattern:
`newSeq(n) + seq[i]=elem`.

and it makes sense, because `add` has to do more work (both with and without `-d:danger`): to increment length, and also to compare new length against capacity. So while reallocation is avoided in both newSeq(n) and  newSeqOfCap(n) cases thanks to preallocation, the 1st pattern is a lot slower because of the extra work.


## benchmark code
```nim
import times

proc unzip1[S, T](s: openArray[(S, T)]): (seq[S], seq[T]) =
  result[0] = newSeqOfCap[S](s.len)
  result[1] = newSeqOfCap[T](s.len)
  for elem in s:
    result[0].add(elem[0])
    result[1].add(elem[1])

proc unzip2[S, T](s: openArray[(S, T)]): (seq[S], seq[T]) =
  result[0] = newSeq[S](s.len)
  result[1] = newSeq[T](s.len)
  for i in 0..<s.len:
    result[0][i]=s[i][0]
    result[1][i]=s[i][1]

var ret = 0
proc main()=
  let n = 100_000
  let numIter = 1000
  var s=newSeq[(int,int)](n)
  for i in 0..<n: s[i] = (i,i)
  var t1, t2: float
  template perf(fun): float =
    let t = epochTime()
    for j in 0..<numIter:
      let s2 = fun(s)
      ret += s2[1][^1]
      ret += s2[0][5]
    var dt = epochTime() - t
    echo (astToStr(fun), dt, ret)
    dt

  for i in 0..<5:
    t1 += perf(unzip1)
    t2 += perf(unzip2)
  echo (t1, t2)
  doAssert unzip1(s) == unzip2(s)
main()
```

## benchmark times
nim c -r main.nim
```
("unzip1", 6.597026109695435, 100004000)
("unzip2", 1.029499053955078, 200008000)
("unzip1", 6.262022018432617, 300012000)
("unzip2", 0.9490630626678467, 400016000)
("unzip1", 6.228638172149658, 500020000)
("unzip2", 0.9355859756469727, 600024000)
("unzip1", 6.221283912658691, 700028000)
("unzip2", 0.9702279567718506, 800032000)
("unzip1", 6.275908946990967, 900036000)
("unzip2", 0.9814701080322266, 1000040000)
(31.58487915992737, 4.865846157073975)
```

nim c -r -d:danger main.nim
```
("unzip1", 1.104756832122803, 100004000)
("unzip2", 0.1451900005340576, 200008000)
("unzip1", 0.9864020347595215, 300012000)
("unzip2", 0.1396539211273193, 400016000)
("unzip1", 0.9924249649047852, 500020000)
("unzip2", 0.1378440856933594, 600024000)
("unzip1", 1.028185844421387, 700028000)
("unzip2", 0.1567389965057373, 800032000)
("unzip1", 1.103832960128784, 900036000)
("unzip2", 0.1695449352264404, 1000040000)
(5.21560263633728, 0.7489719390869141)
```

## note
i haven't tried with `{.noinit.}` ; this could have potential concerns depending on the type (eg if it's a reference type and something throws in the middle); this is very related to this: https://github.com/dlang/phobos/pull/6178#discussion_r176238187 from an old D PR:

> This function has a pernicious bug: if construction throws an exception, ret will be destroyed and destructors will be called for uninitialized objects. Recall that statically-sized arrays on the stack insert one destructor call for each member.


