### PR TITLE
fix #13222: make relativePath more robust and flexible

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,12 @@
 - The file descriptors created for internal bookkeeping by `ioselector_kqueue`
   and `ioselector_epoll` will no longer be leaked to child processes.
 
+- `relativePath(rel, abs)` and `relativePath(abs, rel)` used to silently give wrong results
+  (see #13222); instead they now use `getCurrentDir` to resolve those cases,
+  and this can now throw in edge cases where `getCurrentDir` throws.
+  `relativePath` also now works for js with `-d:nodejs`.
+
+
 ## Language changes
 - In newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this: 
   ```nim

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -13,7 +13,7 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,
   floor, ceil, `mod`
 
-from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
+from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename, getCurrentDir
 from md5 import getMD5
 from sighashes import symBodyDigest
 from times import cpuTime
@@ -198,6 +198,8 @@ proc registerAdditionalOps*(c: PCtx) =
 
   registerCallback c, "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())
+  registerCallback c, "stdlib.os.getCurrentDir", proc (a: VmArgs) {.nimcall.} =
+    setResult(a, getCurrentDir())
 
   registerCallback c, "stdlib.macros.symBodyHash", proc (a: VmArgs) {.nimcall.} =
     let n = getNode(a, 0)

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -13,7 +13,7 @@ from math import sqrt, ln, log10, log2, exp, round, arccos, arcsin,
   arctan, arctan2, cos, cosh, hypot, sinh, sin, tan, tanh, pow, trunc,
   floor, ceil, `mod`
 
-from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename, getCurrentDir
+from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
 from md5 import getMD5
 from sighashes import symBodyDigest
 from times import cpuTime
@@ -198,8 +198,6 @@ proc registerAdditionalOps*(c: PCtx) =
 
   registerCallback c, "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())
-  registerCallback c, "stdlib.os.getCurrentDir", proc (a: VmArgs) {.nimcall.} =
-    setResult(a, getCurrentDir())
 
   registerCallback c, "stdlib.macros.symBodyHash", proc (a: VmArgs) {.nimcall.} =
     let n = getNode(a, 0)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1367,11 +1367,6 @@ when not defined(nimscript):
           else:
             raiseOSError(osLastError())
 
-proc relativePath*(path: string, sep = DirSep): string =
-  ## returns `path` relative to current directory
-  let base = if path.isAbsolute: getCurrentDir() else: "."
-  relativePath(path, base, sep)
-
 proc setCurrentDir*(newDir: string) {.inline, tags: [], noNimScript.} =
   ## Sets the `current working directory`:idx:; `OSError`
   ## is raised if `newDir` cannot been set.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -300,6 +300,8 @@ proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raise
   elif defined(RISCOS):
     result = path[0] == '$'
   elif defined(posix) or defined(js):
+    # `or defined(js)` wouldn't be needed pending https://github.com/nim-lang/Nim/issues/13469
+    # This works around the problem for posix, but windows is still broken with nim js -d:nodejs
     result = path[0] == '/'
   else:
     doAssert false # if ever hits here, adapt as needed

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -299,8 +299,10 @@ proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raise
     result = path[0] != ':'
   elif defined(RISCOS):
     result = path[0] == '$'
-  elif defined(posix):
+  elif defined(posix) or defined(js):
     result = path[0] == '/'
+  else:
+    doAssert false # if ever hits here, adapt as needed
 
 when FileSystemCaseSensitive:
   template `!=?`(a, b: char): bool = a != b

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -98,7 +98,7 @@ type
 
 include "includes/osseps"
 
-proc absolutePathInternal(path: string): string
+proc absolutePathInternal(path: string): string {.gcsafe.}
 
 proc normalizePathEnd(path: var string, trailingSep = false) =
   ## Ensures ``path`` has exactly 0 or 1 trailing `DirSep`, depending on

--- a/tests/js/tos.nim
+++ b/tests/js/tos.nim
@@ -9,7 +9,14 @@ block:
   doAssert not "".isAbsolute
   doAssert not ".".isAbsolute
   doAssert not "foo".isAbsolute
-  doAssert relativePath(getCurrentDir()) == "."
-  doAssert relativePath(getCurrentDir() / "foo", "bar") == "../foo"
   doAssert relativePath("", "bar") == ""
   doAssert normalizedPath(".///foo//./") == "foo"
+  let cwd = getCurrentDir()
+
+  let isWindows = '\\' in cwd
+  # defined(windows) doesn't work with -d:nodejs but should
+  # these actually break because of that (see https://github.com/nim-lang/Nim/issues/13469)
+  if not isWindows:
+    doAssert cwd.isAbsolute
+    doAssert relativePath(getCurrentDir() / "foo", "bar") == "../foo"
+    doAssert relativePath(getCurrentDir()) == "."

--- a/tests/js/tos.nim
+++ b/tests/js/tos.nim
@@ -19,4 +19,3 @@ block:
   if not isWindows:
     doAssert cwd.isAbsolute
     doAssert relativePath(getCurrentDir() / "foo", "bar") == "../foo"
-    doAssert relativePath(getCurrentDir()) == "."

--- a/tests/js/tos.nim
+++ b/tests/js/tos.nim
@@ -5,3 +5,11 @@ import os
 block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar"
   doAssert relativePath(".//foo/bar", "foo") == "bar"
+  doAssert "/".isAbsolute
+  doAssert not "".isAbsolute
+  doAssert not ".".isAbsolute
+  doAssert not "foo".isAbsolute
+  doAssert relativePath(getCurrentDir()) == "."
+  doAssert relativePath(getCurrentDir() / "foo", "bar") == "../foo"
+  doAssert relativePath("", "bar") == ""
+  doAssert normalizedPath(".///foo//./") == "foo"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -348,8 +348,6 @@ block ospaths:
   doAssert relativePath("", "foo") == ""
   doAssert relativePath("././/foo", "foo//./") == "."
 
-  doAssert relativePath(getCurrentDir()) == "."
-  doAssert relativePath(getCurrentDir() / "bar") == "bar"
   doAssert relativePath(getCurrentDir() / "bar", "foo") == "../bar".unixToNativePath
   doAssert relativePath("bar", getCurrentDir() / "foo") == "../bar".unixToNativePath
 

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -348,6 +348,7 @@ block ospaths:
   doAssert relativePath("", "foo") == ""
   doAssert relativePath("././/foo", "foo//./") == "."
 
+  doAssert relativePath(getCurrentDir()) == "."
   doAssert relativePath(getCurrentDir() / "bar") == "bar"
   doAssert relativePath(getCurrentDir() / "bar", "foo") == "../bar".unixToNativePath
   doAssert relativePath("bar", getCurrentDir() / "foo") == "../bar".unixToNativePath

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -348,6 +348,10 @@ block ospaths:
   doAssert relativePath("", "foo") == ""
   doAssert relativePath("././/foo", "foo//./") == "."
 
+  doAssert relativePath(getCurrentDir() / "bar") == "bar"
+  doAssert relativePath(getCurrentDir() / "bar", "foo") == "../bar".unixToNativePath
+  doAssert relativePath("bar", getCurrentDir() / "foo") == "../bar".unixToNativePath
+
   when doslikeFileSystem:
     doAssert relativePath(r"c:\foo.nim", r"C:\") == r"foo.nim"
     doAssert relativePath(r"c:\foo\bar\baz.nim", r"c:\foo") == r"bar\baz.nim"


### PR DESCRIPTION
* relativePath(foo) now works
* relativePath(rel, abs) and relativePath(abs, rel) now work (fixes #13222)
* relativePath, absolutePath, getCurrentDir now available in more targets (eg: ~~vm~~, nodejs etc)
* [EDIT] `isAbsolute` now works with -d:js (previously was always returning false)
see tests