### PR TITLE
relativePath("foo", "foo") is now ".", not ""

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,9 @@
   It was an oversight to be included in v1.0.
 - `options` now treats `proc` like other pointer types, meaning `nil` proc variables
   are converted to `None`.
-
+- `relativePath("foo", "foo")` is now `"."`, not `""`, as `""` means invalid path
+  and shouldn't be conflated with `"."`; use -d:nimOldRelativePathBehavior to restore the old
+  behavioe
 
 ### Breaking changes in the compiler
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -865,6 +865,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       defineSymbol(conf.symbols, "NimMinor", "0")
       # always be compatible with 1.0.2 for now:
       defineSymbol(conf.symbols, "NimPatch", "2")
+      # see also: -d:nimOldRelativePathBehavior
     else:
       localError(conf, info, "unknown Nim version; currently supported values are: {1.0}")
   of "benchmarkvm":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -865,7 +865,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       defineSymbol(conf.symbols, "NimMinor", "0")
       # always be compatible with 1.0.2 for now:
       defineSymbol(conf.symbols, "NimPatch", "2")
-      # see also: -d:nimOldRelativePathBehavior
+      # old behaviors go here:
+      defineSymbol(conf.symbols, "nimOldRelativePathBehavior")
     else:
       localError(conf, info, "unknown Nim version; currently supported values are: {1.0}")
   of "benchmarkvm":

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -65,6 +65,8 @@ when weirdTarget and defined(nimErrorProcCanHaveBody):
 else:
   {.pragma: noNimScript.}
 
+proc normalizePathAux(path: var string){.inline, raises: [], noSideEffect.}
+
 type
   ReadEnvEffect* = object of ReadIOEffect   ## Effect that denotes a read
                                             ## from an environment variable.
@@ -359,9 +361,13 @@ proc relativePath*(path, base: string; sep = DirSep): string {.
     assert relativePath("/Users/me/bar/z.nim", "/Users/me", '/') == "bar/z.nim"
     assert relativePath("", "/users/moo", '/') == ""
     assert relativePath("foo", ".", '/') == "foo"
+    assert relativePath("foo", "foo", '/') == "."
 
   if path.len == 0: return ""
-  let base = if base == ".": "" else: base
+  var base = if base == ".": "" else: base
+  var path = path
+  path.normalizePathAux
+  base.normalizePathAux
 
   when doslikeFileSystem:
     if isAbsolute(path) and isAbsolute(base):
@@ -410,6 +416,8 @@ proc relativePath*(path, base: string; sep = DirSep): string {.
         result.add path[i + ff[0]]
     if not f.hasNext(path): break
     ff = f.next(path)
+
+  if result.len == 0: result.add "."
 
 proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
   ## Returns true if `path` is relative to `base`.
@@ -1353,7 +1361,7 @@ when not weirdTarget:
         raise newException(ValueError, "The specified root is not absolute: " & root)
       joinPath(root, path)
 
-proc normalizePath*(path: var string) {.rtl, extern: "nos$1", tags: [], noNimScript.} =
+proc normalizePath*(path: var string) {.rtl, extern: "nos$1", tags: [].} =
   ## Normalize a path.
   ##
   ## Consecutive directory separators are collapsed, including an initial double slash.
@@ -1401,6 +1409,8 @@ proc normalizePath*(path: var string) {.rtl, extern: "nos$1", tags: [], noNimScr
       path = join(stack, $DirSep)
     else:
       path = "."
+
+proc normalizePathAux(path: var string) = normalizePath(path)
 
 proc normalizedPath*(path: string): string {.rtl, extern: "nos$1", tags: [], noNimScript.} =
   ## Returns a normalized path for the current OS.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -417,7 +417,8 @@ proc relativePath*(path, base: string; sep = DirSep): string {.
     if not f.hasNext(path): break
     ff = f.next(path)
 
-  if result.len == 0: result.add "."
+  when not defined(nimOldRelativePathBehavior):
+    if result.len == 0: result.add "."
 
 proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
   ## Returns true if `path` is relative to `base`.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1413,7 +1413,7 @@ proc normalizePath*(path: var string) {.rtl, extern: "nos$1", tags: [].} =
 
 proc normalizePathAux(path: var string) = normalizePath(path)
 
-proc normalizedPath*(path: string): string {.rtl, extern: "nos$1", tags: [], noNimScript.} =
+proc normalizedPath*(path: string): string {.rtl, extern: "nos$1", tags: [].} =
   ## Returns a normalized path for the current OS.
   ##
   ## See also:

--- a/tests/js/tos.nim
+++ b/tests/js/tos.nim
@@ -1,0 +1,7 @@
+static: doAssert defined(nodejs)
+
+import os
+
+block:
+  doAssert "./foo//./bar/".normalizedPath == "foo/bar"
+  doAssert relativePath(".//foo/bar", "foo") == "bar"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -329,14 +329,18 @@ block ospaths:
   doAssert relativePath("/Users/me/bar/z.nim", "/Users/me", '/') == "bar/z.nim"
   doAssert relativePath("", "/users/moo", '/') == ""
   doAssert relativePath("foo", "", '/') == "foo"
-  doAssert relativePath("/foo", "/Foo", '/') == (when FileSystemCaseSensitive: "../foo" else: "")
-  doAssert relativePath("/Foo", "/foo", '/') == (when FileSystemCaseSensitive: "../Foo" else: "")
-  doAssert relativePath("/foo", "/fOO", '/') == (when FileSystemCaseSensitive: "../foo" else: "")
-  doAssert relativePath("/foO", "/foo", '/') == (when FileSystemCaseSensitive: "../foO" else: "")
+  doAssert relativePath("/foo", "/Foo", '/') == (when FileSystemCaseSensitive: "../foo" else: ".")
+  doAssert relativePath("/Foo", "/foo", '/') == (when FileSystemCaseSensitive: "../Foo" else: ".")
+  doAssert relativePath("/foo", "/fOO", '/') == (when FileSystemCaseSensitive: "../foo" else: ".")
+  doAssert relativePath("/foO", "/foo", '/') == (when FileSystemCaseSensitive: "../foO" else: ".")
 
   doAssert relativePath("foo", ".", '/') == "foo"
   doAssert relativePath(".", ".", '/') == "."
   doAssert relativePath("..", ".", '/') == ".."
+
+  doAssert relativePath("foo", "foo") == "."
+  doAssert relativePath("", "foo") == ""
+  doAssert relativePath("././/foo", "foo//./") == "."
 
   when doslikeFileSystem:
     doAssert relativePath(r"c:\foo.nim", r"C:\") == r"foo.nim"

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -22,4 +22,7 @@ import unicode
 import uri
 import macros
 
+block:
+  doAssert "./foo//./bar/".normalizedPath == "foo/bar"
+
 echo "Nimscript imports are successful."

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -23,6 +23,6 @@ import uri
 import macros
 
 block:
-  doAssert "./foo//./bar/".normalizedPath == "foo/bar"
+  doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
 
 echo "Nimscript imports are successful."


### PR DESCRIPTION
as discussed many times already [1], empty dir shouldn't be considered as a valid dir and not conflated with `"."`, so `relativePath("foo", "foo")` is now `"."` and `relativePath("", "foo")` stays `""`.

[1] see https://github.com/nim-lang/Nim/pull/13236#issuecomment-577665921, https://github.com/nim-lang/Nim/pull/10018#issuecomment-448192956 + other places

* It is consistent with other things (eg `parentDir("foo")` is `"."`, not `""`)
* consistent with python:
```
os.path.relpath("foo","foo")
'.'
```
