### PR TITLE
Make gdb script work on mac and linux; add windows gdb script

### DIFF
--- a/bin/nim-gdb
+++ b/bin/nim-gdb
@@ -5,17 +5,25 @@ set -e
 
 which nim > /dev/null || (echo "nim not in PATH"; exit 1)
 which gdb > /dev/null || (echo "gdb not in PATH"; exit 1)
+which readlink > /dev/null || which greadlink > /dev/null || (echo "readlink not in PATH. Please install coreutils from brew if on Mac."; exit 1)
+
+nreadlink () {
+    (which greadlink > /dev/null && greadlink "$@") || (which readlink > /dev/null && readlink "$@") || echo "Readlink could not be found"
+}
 
 # Find out where the pretty printer Python module is
-NIM_SYSROOT=$(dirname $(dirname $(readlink -e $(which nim))))
+NIM_SYSROOT=$(dirname $(dirname $(nreadlink -e $(which nim))))
 GDB_PYTHON_MODULE_PATH="$NIM_SYSROOT/tools/nim-gdb.py"
 
 # Run GDB with the additional arguments that load the pretty printers
 # Set the environment variable `NIM_GDB` to overwrite the call to a
 # different/specific command (defaults to `gdb`).
 NIM_GDB="${NIM_GDB:-gdb}"
+
+# This is needed for some reason. I can't get -eval-command to work ever
+echo "source $GDB_PYTHON_MODULE_PATH" > gdbcommands.txt
 # exec replaces the new process of bash with gdb. It is always good to
 # have fewer processes.
-exec ${NIM_GDB} \
-  -eval-command "source $GDB_PYTHON_MODULE_PATH" \
-  "$@"
+exec ${NIM_GDB} --command="gdbcommands.txt" "$@"
+
+rm gdbcommands.txt

--- a/bin/nim-gdb.bat
+++ b/bin/nim-gdb.bat
@@ -1,0 +1,16 @@
+@echo off
+for %%i in (nim.exe) do (set NIM_BIN=%%~dp$PATH:i)
+
+for %%i in ("%NIM_BIN%\..\") do (set NIM_ROOT=%%~fi)
+
+set @GDB_PYTHON_MODULE_PATH=%NIM_ROOT%\tools\nim-gdb.py
+set @NIM_GDB=gdb.exe
+
+@echo source %@GDB_PYTHON_MODULE_PATH%> wingdbcommand.txt
+
+%@NIM_GDB% --command="wingdbcommand.txt" %*
+
+del wingdbcommand.txt /f /q
+
+EXIT /B %ERRORLEVEL%
+@echo on


### PR DESCRIPTION
I could never get the built in `nim-gdb` script to work with Mac or my linux box. This PR fixes it for both and adds support for windows in the form of a batch script. This is useful for getting debugging working in VSCode on all platforms.