### PR TITLE
fix 3 minor bugs in joinPath (see #13455)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -111,3 +111,5 @@
 
 - The `FD` variant of `selector.unregister` for `ioselector_epoll` and
   `ioselector_select` now properly handle the `Event.User` select event type.
+- `joinPath` path normalization when `/` is the first argument works correctly:
+  `assert "/" / "/a" == "/a"`. Fixed the edgecase: `assert "" / "" == ""`.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -147,7 +147,7 @@ proc joinPath*(head, tail: string): string {.
   result = newStringOfCap(head.len + tail.len)
   var state = 0
   addNormalizePath(head, result, state, DirSep)
-  if head.len != 0 and head[^1] notin {DirSep, AltSep} and tail.len == 0:
+  if result.len != 0 and result[^1] notin {DirSep, AltSep} and tail.len == 0:
     result.add DirSep
   else:
     addNormalizePath(tail, result, state, DirSep)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -143,6 +143,9 @@ proc joinPath*(head, tail: string): string {.
       assert joinPath("", "/lib") == "/lib"
       assert joinPath("usr/", "/lib") == "usr/lib"
       assert joinPath("usr/lib", "../bin") == "usr/bin"
+      since((1, 1)):
+        assert joinPath("", "") == ""
+        assert joinPath("/", "/usr/lib") == "/usr/lib"
 
   result = newStringOfCap(head.len + tail.len)
   var state = 0

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -147,7 +147,7 @@ proc joinPath*(head, tail: string): string {.
   result = newStringOfCap(head.len + tail.len)
   var state = 0
   addNormalizePath(head, result, state, DirSep)
-  if tail.len == 0:
+  if head.len != 0 and head[^1] notin {DirSep, AltSep} and tail.len == 0:
     result.add DirSep
   else:
     addNormalizePath(tail, result, state, DirSep)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -139,13 +139,11 @@ proc joinPath*(head, tail: string): string {.
     when defined(posix):
       assert joinPath("usr", "lib") == "usr/lib"
       assert joinPath("usr", "") == "usr/"
+      assert joinPath("", "") == ""
       assert joinPath("", "lib") == "lib"
       assert joinPath("", "/lib") == "/lib"
       assert joinPath("usr/", "/lib") == "usr/lib"
       assert joinPath("usr/lib", "../bin") == "usr/bin"
-      since((1, 1)):
-        assert joinPath("", "") == ""
-        assert joinPath("/", "/usr/lib") == "/usr/lib"
 
   result = newStringOfCap(head.len + tail.len)
   var state = 0

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -69,7 +69,8 @@ proc addNormalizePath*(x: string; result: var string; state: var int;
   while hasNext(it, x):
     let b = next(it, x)
     if (state shr 1 == 0) and isSlash(x, b):
-      result.add dirSep
+      if result.len == 0 or result[^1] notin {DirSep, AltSep}:
+        result.add dirSep
       state = state or 1
     elif isDotDot(x, b):
       if (state shr 1) >= 1:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -357,6 +357,9 @@ block ospaths:
   doAssert joinPath("", "lib") == "lib"
   doAssert joinPath("", "/lib") == unixToNativePath"/lib"
   doAssert joinPath("usr/", "/lib") == unixToNativePath"usr/lib"
+  doAssert joinPath("", "") == unixToNativePath""
+  doAssert joinPath("/" / "") == unixToNativePath"/"
+  doAssert joinPath("/", "/a/b/c") == unixToNativePath"/a/b/c"
 
 block getTempDir:
   block TMPDIR:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -360,6 +360,7 @@ block ospaths:
   doAssert joinPath("", "") == unixToNativePath""
   doAssert joinPath("/" / "") == unixToNativePath"/"
   doAssert joinPath("/", "/a/b/c") == unixToNativePath"/a/b/c"
+  doAssert joinPath("foo/","") == unixToNativePath"foo/"
 
 block getTempDir:
   block TMPDIR:


### PR DESCRIPTION
this fixes 3 wrong cases for `joinPath`:
```
"" / "" == "/", should be ""
```
```
"/" / "" == "//", should be "/"
```
```
"/" / "/a/b/c" == "//a/b/c", should be "/a/b/c"
```

I don't fix behavior like `"a" / "" == "a/"` since it's specified so in documentation hence changing it might break compatibility, though I admit @timotheecour is right in #13455 that it's strange.