### PR TITLE
Update advopt.txt to include link to nim cache docs

### DIFF
--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -49,6 +49,7 @@ Advanced options:
   --import:PATH             add an automatically imported module
   --include:PATH            add an automatically included module
   --nimcache:PATH           set the path used for generated files
+                            see also https://nim-lang.org/docs/nimc.html#compiler-usage-generated-c-code-directory 
   -c, --compileOnly:on|off  compile Nim files only; do not assemble or link
   --noLinking:on|off        compile Nim and generated files but do not link
   --noMain:on|off           do not generate a main procedure


### PR DESCRIPTION
Hi all!

Long story short, it took me way to long to find the nim cache directory for the first time the other night. I found this command entry, but didn't see the content at https://nim-lang.org/docs/nimc.html#compiler-usage-generated-c-code-directory for another hour or so...

That said, hoping this small request could help future folks be a little quicker!