### PR TITLE
fix #13455 ; joinPath(a,b) now honors trailing slashes in b (or a if b = "")

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@
   are converted to `None`.
 - `relativePath("foo", "foo")` is now `"."`, not `""`, as `""` means invalid path
   and shouldn't be conflated with `"."`; use -d:nimOldRelativePathBehavior to restore the old
-  behavioe
+  behavior
 - `joinPath(a,b)` now honors trailing slashes in `b` (or `a` if `b` = "")
 
 ### Breaking changes in the compiler

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@
 - `relativePath("foo", "foo")` is now `"."`, not `""`, as `""` means invalid path
   and shouldn't be conflated with `"."`; use -d:nimOldRelativePathBehavior to restore the old
   behavioe
+- `joinPath(a,b)` now honors trailing slashes in `b` (or `a` if `b` = "")
 
 ### Breaking changes in the compiler
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -122,14 +122,21 @@ proc normalizePathEnd(path: string, trailingSep = false): string =
 since((1, 1)):
   export normalizePathEnd
 
+template endsWith(a: string, b: set[char]): bool =
+  a.len > 0 and a[^1] in b
+
+proc joinPathImpl(result: var string, state: var int, tail: string) =
+  let trailingSep = tail.endsWith({DirSep, AltSep}) or tail.len == 0 and result.endsWith({DirSep, AltSep})
+  addNormalizePath(tail, result, state, DirSep)
+  normalizePathEnd(result, trailingSep=trailingSep)
+
 proc joinPath*(head, tail: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Joins two directory names to one.
   ##
-  ## If `head` is the empty string, `tail` is returned. If `tail` is the empty
-  ## string, `head` is returned with a trailing path separator. If `tail` starts
-  ## with a path separator it will be removed when concatenated to `head`.
-  ## Path separators will be normalized.
+  ## returns normalized path concatenation of `head` and `tail`, preserving
+  ## whether or not `tail` has a trailing slash (or, if tail if empty, whether
+  ## head has one).
   ##
   ## See also:
   ## * `joinPath(varargs) proc <#joinPath,varargs[string]>`_
@@ -149,11 +156,8 @@ proc joinPath*(head, tail: string): string {.
 
   result = newStringOfCap(head.len + tail.len)
   var state = 0
-  addNormalizePath(head, result, state, DirSep)
-  if result.len != 0 and result[^1] notin {DirSep, AltSep} and tail.len == 0:
-    result.add DirSep
-  else:
-    addNormalizePath(tail, result, state, DirSep)
+  joinPathImpl(result, state, head)
+  joinPathImpl(result, state, tail)
   when false:
     if len(head) == 0:
       result = tail
@@ -192,7 +196,7 @@ proc joinPath*(parts: varargs[string]): string {.noSideEffect,
   result = newStringOfCap(estimatedLen)
   var state = 0
   for i in 0..high(parts):
-    addNormalizePath(parts[i], result, state, DirSep)
+    joinPathImpl(result, state, parts[i])
 
 proc `/`*(head, tail: string): string {.noSideEffect.} =
   ## The same as `joinPath(head, tail) proc <#joinPath,string,string>`_.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -147,7 +147,9 @@ proc joinPath*(head, tail: string): string {.
   runnableExamples:
     when defined(posix):
       assert joinPath("usr", "lib") == "usr/lib"
-      assert joinPath("usr", "") == "usr/"
+      assert joinPath("usr", "lib/") == "usr/lib/"
+      assert joinPath("usr", "") == "usr"
+      assert joinPath("usr/", "") == "usr/"
       assert joinPath("", "") == ""
       assert joinPath("", "lib") == "lib"
       assert joinPath("", "/lib") == "/lib"
@@ -210,10 +212,10 @@ proc `/`*(head, tail: string): string {.noSideEffect.} =
   ## * `uri./ proc <uri.html#/,Uri,string>`_
   runnableExamples:
     when defined(posix):
-      assert "usr" / "" == "usr/"
+      assert "usr" / "" == "usr"
       assert "" / "lib" == "lib"
       assert "" / "/lib" == "/lib"
-      assert "usr/" / "/lib" == "usr/lib"
+      assert "usr/" / "/lib/" == "usr/lib/"
       assert "usr" / "lib" / "../bin" == "usr/bin"
 
   return joinPath(head, tail)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -357,14 +357,37 @@ block ospaths:
     doAssert relativePath(r"\\foo\bar\baz.nim", r"\foo") == r"\\foo\bar\baz.nim"
     doAssert relativePath(r"c:\foo.nim", r"\foo") == r"c:\foo.nim"
 
-  doAssert joinPath("usr", "") == unixToNativePath"usr/"
+  doAssert joinPath("usr", "") == unixToNativePath"usr"
   doAssert joinPath("", "lib") == "lib"
   doAssert joinPath("", "/lib") == unixToNativePath"/lib"
   doAssert joinPath("usr/", "/lib") == unixToNativePath"usr/lib"
-  doAssert joinPath("", "") == unixToNativePath""
-  doAssert joinPath("/" / "") == unixToNativePath"/"
+  doAssert joinPath("", "") == unixToNativePath"" # issue #13455
+  doAssert joinPath("", "/") == unixToNativePath"/"
+  doAssert joinPath("/", "/") == unixToNativePath"/"
+  doAssert joinPath("/", "") == unixToNativePath"/"
+  doAssert joinPath("/" / "") == unixToNativePath"/" # weird test case...
   doAssert joinPath("/", "/a/b/c") == unixToNativePath"/a/b/c"
   doAssert joinPath("foo/","") == unixToNativePath"foo/"
+  doAssert joinPath("foo/","abc") == unixToNativePath"foo/abc"
+  doAssert joinPath("foo//./","abc/.//") == unixToNativePath"foo/abc/"
+  doAssert joinPath("foo","abc") == unixToNativePath"foo/abc"
+  doAssert joinPath("","abc") == unixToNativePath"abc"
+
+  doAssert joinPath("gook/.","abc") == unixToNativePath"gook/abc"
+
+  # controversial: inconsistent with `joinPath("gook/.","abc")`
+  # on linux, `./foo` and `foo` are treated a bit differently for executables
+  # but not `./foo/bar` and `foo/bar`
+  doAssert joinPath(".", "/lib") == unixToNativePath"./lib"
+  doAssert joinPath(".","abc") == unixToNativePath"./abc"
+  
+  # cases related to issue #13455
+  doAssert joinPath("foo", "", "") == "foo"
+  doAssert joinPath("foo", "") == "foo"
+  doAssert joinPath("foo/", "") == "foo/"
+  doAssert joinPath("foo/", ".") == "foo"
+  doAssert joinPath("foo", "./") == "foo/"
+  doAssert joinPath("foo", "", "bar/") == "foo/bar/"
 
 block getTempDir:
   block TMPDIR:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -384,10 +384,10 @@ block ospaths:
   # cases related to issue #13455
   doAssert joinPath("foo", "", "") == "foo"
   doAssert joinPath("foo", "") == "foo"
-  doAssert joinPath("foo/", "") == "foo/"
+  doAssert joinPath("foo/", "") == unixToNativePath"foo/"
   doAssert joinPath("foo/", ".") == "foo"
-  doAssert joinPath("foo", "./") == "foo/"
-  doAssert joinPath("foo", "", "bar/") == "foo/bar/"
+  doAssert joinPath("foo", "./") == unixToNativePath"foo/"
+  doAssert joinPath("foo", "", "bar/") == unixToNativePath"foo/bar/"
 
 block getTempDir:
   block TMPDIR:


### PR DESCRIPTION
* fix #13455 (fixes remaining cases after https://github.com/nim-lang/Nim/pull/13462 was merged)
* fixed behavior for variadic `joinPath` which was previously buggy as it didn't follow the same logic as joinPath (see some cases from #13455 ); it now simply calls the same routine as in joinPath.

* behavior for joinPath is now more natural, and consistent with D, nodejs, matlab, and more consistent with how other languages honor trailing slash:

`joinPath(a,b)` now honors trailing slashes in `b` (or `a` if `b == ""`)
in the sense that it ends with a trailing slash if b ends with a trailing slash, or if b is empty and a ends in a trailing slash.

see detailed test cases in PR.

changed behaviors since #13462 :
```nim
  ## changed behaviors
  doAssert joinPath("foo", "bar") == "foo/bar" # same as before
  doAssert joinPath("foo", "bar/") == "foo/bar/" # was: foo/bar
  doAssert joinPath("foo", "./") == "foo/" # was: foo
  doAssert joinPath("foo", "", "bar/") == "foo/bar/" # was: foo/bar
  doAssert joinPath("./", ".", "/.") == "." # was: ./ (bug with variadic joinPath)
  doAssert joinPath("", "lib/") == "lib/" # was: lib
  doAssert joinPath("foo", "") == "foo" # was: foo/
```

## it's 100% consistent with how nodejs does it:
```nim
Welcome to Node.js v13.8.0.
Type ".help" for more information.
> path.join('foo', '')
'foo'
> path.join('foo', './')
'foo/'
> path.join('foo', '','bar/')
'foo/bar/'
> path.join('./','.','/.')
'.'
> path.join('usr','')
'usr'
> path.join('','lib/')
'lib/'
```

## it's 100% consistent with how matlab, octave does it:
```matlab
octave:2> fullfile('foo','bar')
ans = foo/bar
octave:3> fullfile('foo','bar/')
ans = foo/bar/
octave:4> fullfile('foo','')
ans = foo
octave:5> fullfile('foo/','')
ans = foo/
octave:6> fullfile('foo/','/bar')
ans = foo/bar
```

## it's also consistent with how D does it
(as far as honoring trailing slash)
(but D differs in some other aspect, `buildPath("foo", "/bar")` would return `"/bar"` ; that's a separate topic)
```
rdmd --eval 'writeln(buildPath("baz/", ""))'
baz/
rdmd --eval 'writeln(buildPath("baz", ""))'
baz
rdmd --eval 'writeln(buildPath("baz", "baz"))'
baz/baz
rdmd --eval 'writeln(buildPath("baz", "baz/"))'
baz/baz/
```

## python
it's now consistent with how python honors trailing slash on `tail`:
os.path.join("foo","bar")
'foo/bar'
os.path.join("foo","bar/")
'foo/bar/'
but now differs from python in behavior when tail is empty:
os.path.join("foo","")
'foo/'


## note
the only controversial aspect in this PR is the edge case of whether
`joinPath("foo", "")` should be "foo" (as in nodejs, D, go, matlab, and this PR) or "foo/" (as in python).
IMO the way I did it makes more sense, with the semantic of `""` being an invalid path (unlike `"."`), it collapses out, so that
joinPath(foo1, "", foo2, "", "", bar, "") reduces to `joinPath(foo1, foo2, bar)` for example; it's also more consistent with `joinPath("", "")` being `""`
