### PR TITLE
only enable linenoise for -d:nimUseLinenoise

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -18,7 +18,8 @@ template bootSwitch(name, expr, userString) =
 
 bootSwitch(usedRelease, defined(release), "-d:release")
 bootSwitch(usedDanger, defined(danger), "-d:danger")
-bootSwitch(usedGnuReadline, defined(useLinenoise), "-d:useLinenoise")
+# `useLinenoise` deprecated in favor of `nimUseLinenoise`, kept for backward compatibility
+bootSwitch(useLinenoise, defined(nimUseLinenoise) or defined(useLinenoise), "-d:nimUseLinenoise")
 bootSwitch(usedBoehm, defined(boehmgc), "--gc:boehm")
 bootSwitch(usedMarkAndSweep, defined(gcmarkandsweep), "--gc:markAndSweep")
 bootSwitch(usedGenerational, defined(gcgenerational), "--gc:generational")
@@ -101,7 +102,7 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
       msgWriteln(conf, "git hash: " & gitHash, {msgStdout})
 
     msgWriteln(conf, "active boot switches:" & usedRelease & usedDanger &
-      usedTinyC & usedGnuReadline & usedNativeStacktrace &
+      usedTinyC & useLinenoise & usedNativeStacktrace &
       usedFFI & usedBoehm & usedMarkAndSweep & usedGenerational & usedGoGC & usedNoGC,
                {msgStdout})
     msgQuit(0)

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -12,8 +12,10 @@
 import
   pathutils
 
-template imp(x) = import x
-const hasRstdin = compiles(imp(rdstdin))
+# support `useGnuReadline`, `useLinenoise` for backwards compatibility
+const hasRstdin = (defined(nimUseLinenoise) or defined(useLinenoise) or defined(useGnuReadline)) and
+  not defined(windows)
+
 when hasRstdin: import rdstdin
 
 type

--- a/doc/koch.rst
+++ b/doc/koch.rst
@@ -35,7 +35,7 @@ options:
   By default a debug version is created, passing this option will
   force a release build, which is much faster and should be preferred
   unless you are debugging the compiler.
--d:useLinenoise
+-d:nimUseLinenoise
   Use the linenoise library for interactive mode (not needed on Windows).
 
 After compilation is finished you will hopefully end up with the nim

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -528,7 +528,7 @@ for further information.
 
   The Nim compiler supports an interactive mode. This is also known as
   a `REPL`:idx: (*read eval print loop*). If Nim has been built with the
-  ``-d:useGnuReadline`` switch, it uses the GNU readline library for terminal
+  ``-d:nimUseLinenoise`` switch, it uses the GNU readline library for terminal
   input management. To start Nim in interactive mode use the command
   ``nim secret``. To quit use the ``quit()`` command. To determine whether an input
   line is an incomplete statement to be continued these rules are used:

--- a/koch.nim
+++ b/koch.nim
@@ -56,7 +56,7 @@ Possible Commands:
 Boot options:
   -d:release               produce a release version of the compiler
   -d:nimUseLinenoise       use the linenoise library for interactive mode
-                          `nim secret` (not needed on Windows)
+                           `nim secret` (not needed on Windows)
   -d:leanCompiler          produce a compiler without JS codegen or
                            documentation generator in order to use less RAM
                            for bootstrapping

--- a/koch.nim
+++ b/koch.nim
@@ -55,8 +55,8 @@ Possible Commands:
   nimble                   builds the Nimble tool
 Boot options:
   -d:release               produce a release version of the compiler
-  -d:useLinenoise          use the linenoise library for interactive mode
-                           (not needed on Windows)
+  -d:nimUseLinenoise       use the linenoise library for interactive mode
+                          `nim secret` (not needed on Windows)
   -d:leanCompiler          produce a compiler without JS codegen or
                            documentation generator in order to use less RAM
                            for bootstrapping

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -513,7 +513,8 @@ template gatherFiles(fun, libpath, outDir) =
       fun(src, dst)
 
     for f in walkFiles(libpath / "lib/*.h"): copySrc(f)
-    copySrc(libpath / "lib/wrappers/linenoise/linenoise.h")
+    # commenting out for now, see discussion in https://github.com/nim-lang/Nim/pull/13413
+    # copySrc(libpath / "lib/wrappers/linenoise/linenoise.h")
 
 proc srcdist(c: var ConfigData) =
   let cCodeDir = getOutputDir(c) / "c_code"


### PR DESCRIPTION
* refs: 2b368bc#commitcomment-37273026
* supersedes https://github.com/nim-lang/Nim/pull/13413
* comments out `copySrc(libpath / "lib/wrappers/linenoise/linenoise.h")` from niminst since this was causing issues
* users who need linenoise support now can't do it from a nim release (sadly...) but they can do it from a locally built nim by passing `-d:nimUseLinenoise` when building nim, eg via either:
* ./koch boot -d:release -d:nimUseLinenoise
* nim c -o:bin/nim_temp -d:release -d:nimUseLinenoise --lib:lib compiler/nim.nim

I've renamed -d:useLinenoise (which wasn't used since a few commits ago) to `-d:nimUseLinenoise` to adhere to namespace prefix rule but -d:useLinenoise will continue to work for backward compatibility

future PR's could consider something like: `-d:useLinenoise:path/to/linenoise_header` so that it could work for a nim release too, pointing to an external path