### PR TITLE
make CI tests faster (2.4X faster on local OSX), and make gcleak2 leak detection more accurate

### DIFF
--- a/tests/gc/gcleak.nim
+++ b/tests/gc/gcleak.nim
@@ -12,7 +12,14 @@ type
 proc makeObj(): TTestObj =
   result.x = "Hello"
 
-for i in 1 .. 100_000:
+const numIter =
+  # see tests/gc/gcleak2.nim
+  when defined(boehmgc):
+    1_000
+  elif defined(gcMarkAndSweep): 10_000
+  else: 100_000
+
+for i in 1 .. numIter:
   when defined(gcMarkAndSweep) or defined(boehmgc):
     GC_fullcollect()
   var obj = makeObj()

--- a/tests/gc/gcleak2.nim
+++ b/tests/gc/gcleak2.nim
@@ -14,8 +14,20 @@ proc makeObj(): TTestObj =
   result.x = "Hello"
   result.s = @[1,2,3]
 
+const numIter =
+  when defined(boehmgc):
+    # super slow because GC_fullcollect() at each iteration; especially
+    # on OSX 10.15 where it takes ~170s
+    # `getOccupiedMem` should be constant after each iteration for i >= 3
+    1_000
+  elif defined(gcMarkAndSweep):
+    # likewise, somewhat slow, 1_000_000 would run for 8s
+    # and same remark as above
+    100_000
+  else: 1_000_000
+
 proc inProc() =
-  for i in 1 .. 1_000_000:
+  for i in 1 .. numIter:
     when defined(gcMarkAndSweep) or defined(boehmgc):
       GC_fullcollect()
     var obj: TTestObj

--- a/tests/gc/gcleak2.nim
+++ b/tests/gc/gcleak2.nim
@@ -2,11 +2,6 @@ discard """
   outputsub: "no leak: "
 """
 
-## this test makes sure getOccupiedMem() is constant after a few iterations
-## for --gc:bohem, --gc:markAndSweep, --gc:arc, --gc:orc.
-## and for other gc, it consists of cycles with constant min/max after a few cycles.
-## This ensures we have no leaks.
-
 when defined(GC_setMaxPause):
   GC_setMaxPause 2_000
 
@@ -19,75 +14,13 @@ proc makeObj(): TTestObj =
   result.x = "Hello"
   result.s = @[1,2,3]
 
-const collectAlways = defined(gcMarkAndSweep) or defined(boehmgc)
-const isDeterministic = collectAlways or defined(gcArc) or defined(gcOrc)
-  ## when isDeterministic, we expect memory to reach a fixed point
-  ## after `numIterStable` iterations
-
-var memMax = 0 # peak
-
-when isDeterministic:
-  const numIterStable = 3
-    # stabilize after this many iterations
-else:
-  const numCycleStable = when defined(useRealtimeGC): 6 else: 4
-    # stabilize after this many cycles; empirically determined
-    # after running all combinations of gc's with / without -d:release
-  var memPrevious = 0
-  var memMin = int.high # right after a peak
-  var numCollections = 0
-
-let numIter = when isDeterministic: 1_000 else: 1_000_000
-  ## full collection is expensive, and the memory doesn't change after
-  ## each iteration so there's no point in a large `numIter` (this was taking
-  ## 350s for `nim c -r -d:release --gc:boehm` + `nim c -r --gc:boehm`, 50%
-  ## of running time of `testament/testament all`.
-
 proc inProc() =
-  for i in 1 .. numIter:
-    when collectAlways: GC_fullcollect()
+  for i in 1 .. 1_000_000:
+    when defined(gcMarkAndSweep) or defined(boehmgc):
+      GC_fullcollect()
     var obj: TTestObj
     obj = makeObj()
-    let mem = getOccupiedMem()
-    when isDeterministic:
-      if i <= numIterStable:
-        memMax = mem
-        doAssert memMax <= 50_000 # adjust as needed
-      else:
-        # memory shouldn't increase after 1st few iterations
-        # on linux 386 it somehow takes 3 iters to converge
-        doAssert mem <= memMax
-    else:
-      if mem < memPrevious:
-        # a collection happened, it peaked at memPrevious
-        # echo (mem, memMin, memMax, numCollections, numIter, i) # for debugging
-        numCollections.inc
-        if numCollections <= numCycleStable:
-          # this is the 1st few collections, we update the min/max
-          doAssert memPrevious < 300_000 # adjust as needed
-          if memMin < mem: # `<` intentional; the valley may increase 
-            memMin = mem
-          if memMax < memPrevious:
-            memMax = memPrevious
-        else:
-          # after a collection, we always go back to same level
-          doAssert mem <= memMin, $(mem, memMin)
-
-      if numCollections >= numCycleStable:
-        # after a few cycles, the max stabilizes
-        doAssert mem <= memMax, $(mem, memMax)
-
-      memPrevious = mem
+    if getOccupiedMem() > 300_000: quit("still a leak!")
 
 inProc()
-let mem = getOccupiedMem()
-var msg = "no leak: "
-when isDeterministic:
-  msg.add $(mem, memMax)
-  echo msg
-else:
-  msg.add $(mem, memMin, memMax, numCollections, numIter)
-  echo msg
-  # make sure some collections did happen, otherwise the previous tests
-  # are meaningless
-  doAssert numCollections > 1000 # 3999 on local OSX; leaving some slack
+echo "no leak: ", getOccupiedMem()

--- a/tests/gc/gcleak2.nim
+++ b/tests/gc/gcleak2.nim
@@ -2,6 +2,11 @@ discard """
   outputsub: "no leak: "
 """
 
+## this test makes sure getOccupiedMem() is constant after a few iterations
+## for --gc:bohem, --gc:markAndSweep, --gc:arc, --gc:orc.
+## and for other gc, it consists of cycles with constant min/max after a few cycles.
+## This ensures we have no leaks.
+
 when defined(GC_setMaxPause):
   GC_setMaxPause 2_000
 
@@ -14,13 +19,75 @@ proc makeObj(): TTestObj =
   result.x = "Hello"
   result.s = @[1,2,3]
 
+const collectAlways = defined(gcMarkAndSweep) or defined(boehmgc)
+const isDeterministic = collectAlways or defined(gcArc) or defined(gcOrc)
+  ## when isDeterministic, we expect memory to reach a fixed point
+  ## after `numIterStable` iterations
+
+var memMax = 0 # peak
+
+when isDeterministic:
+  const numIterStable = 3
+    # stabilize after this many iterations
+else:
+  const numCycleStable = when defined(useRealtimeGC): 6 else: 4
+    # stabilize after this many cycles; empirically determined
+    # after running all combinations of gc's with / without -d:release
+  var memPrevious = 0
+  var memMin = int.high # right after a peak
+  var numCollections = 0
+
+let numIter = when isDeterministic: 1_000 else: 1_000_000
+  ## full collection is expensive, and the memory doesn't change after
+  ## each iteration so there's no point in a large `numIter` (this was taking
+  ## 350s for `nim c -r -d:release --gc:boehm` + `nim c -r --gc:boehm`, 50%
+  ## of running time of `testament/testament all`.
+
 proc inProc() =
-  for i in 1 .. 1_000_000:
-    when defined(gcMarkAndSweep) or defined(boehmgc):
-      GC_fullcollect()
+  for i in 1 .. numIter:
+    when collectAlways: GC_fullcollect()
     var obj: TTestObj
     obj = makeObj()
-    if getOccupiedMem() > 300_000: quit("still a leak!")
+    let mem = getOccupiedMem()
+    when isDeterministic:
+      if i <= numIterStable:
+        memMax = mem
+        doAssert memMax <= 50_000 # adjust as needed
+      else:
+        # memory shouldn't increase after 1st few iterations
+        # on linux 386 it somehow takes 3 iters to converge
+        doAssert mem <= memMax
+    else:
+      if mem < memPrevious:
+        # a collection happened, it peaked at memPrevious
+        # echo (mem, memMin, memMax, numCollections, numIter, i) # for debugging
+        numCollections.inc
+        if numCollections <= numCycleStable:
+          # this is the 1st few collections, we update the min/max
+          doAssert memPrevious < 300_000 # adjust as needed
+          if memMin < mem: # `<` intentional; the valley may increase 
+            memMin = mem
+          if memMax < memPrevious:
+            memMax = memPrevious
+        else:
+          # after a collection, we always go back to same level
+          doAssert mem <= memMin, $(mem, memMin)
+
+      if numCollections >= numCycleStable:
+        # after a few cycles, the max stabilizes
+        doAssert mem <= memMax, $(mem, memMax)
+
+      memPrevious = mem
 
 inProc()
-echo "no leak: ", getOccupiedMem()
+let mem = getOccupiedMem()
+var msg = "no leak: "
+when isDeterministic:
+  msg.add $(mem, memMax)
+  echo msg
+else:
+  msg.add $(mem, memMin, memMax, numCollections, numIter)
+  echo msg
+  # make sure some collections did happen, otherwise the previous tests
+  # are meaningless
+  doAssert numCollections > 1000 # 3999 on local OSX; leaving some slack


### PR DESCRIPTION
## before PR

there's a single test that takes a whopping 335 seconds (on my local OSX; on other machines may be different), representing > 57% of CI tests time (585 s) (ie, all of `testament/testament all`; this excludes other things in `./koch runCI`).

on local OSX:
```
XDG_CONFIG_HOME= nim c -r testament/testament --nim:./bin/nim all
PASS: tests/gc/gcleak2 C --gc:boehm                                (165.00503802 secs)
PASS: tests/gc/gcleak2 C -d:release --gc:boehm                     (170.92052507 secs)
...
```

## after PR
* these:
./bin/nim c -r -d:release --gc:boehm tests/gc/gcleak2.nim
./bin/nim c -r --gc:boehm tests/gc/gcleak2.nim
now both run in 1 sec, by simply reducing number of iterations in this case; the test is in fact more useful than before despite smaller numIter, as we check that the occupied memory doesn't vary after few iterations; so running more iterations would make no difference.

* other deterministic gc tested (eg: --gc:orc, --gc:arc) also are tested like --gc:boehm (ie fixed point at a few iterations)

* for the other gc tested (ie `./bin/nim c -r tests/gc/gcleak2.nim` + other gc) , we also modify the test to make it more useful, by checking that occupied memory follows a set of cycles, each with identical min/max values after a few cycles. The test before this PR was more rough, and would not have detected a small leak accumulating since it just had a coarse upperbound on memory use.

and overall, `testament/testament all` now runs in 242s, a 2.4X speedup (on my local OSX)

## Note
on azure CI machines, the overall speedup is less significant compared to the speedup observed on my local OSX machine (OSX catalina 10.15, 16GB RAM 2.3 GHz 8-Core Intel Core i9); for some reason `./bin/nim c -r --gc:boehm tests/gc/gcleak2.nim` was 165s (before this PR) on my local machine but only 65s on azure OSX machines (note: azure uses 10.14 not 10.15, could be a factor)  eg:
https://dev.azure.com/nim-lang/255dfe86-e590-40bb-a8a2-3c0295ebdeb1/_apis/build/builds/2835/logs/60
```
2020-02-24T22:22:05.2156800Z [32mPASS: [36mtests/gc/gcleak2 C --gc:boehm                               [34m (65.62197399 secs)[0m
2020-02-24T22:22:05.2157710Z [32mPASS: [36mtests/gc/gcleak2 C -d:release --gc:boehm                    [34m (54.69007993 secs)[0m
```
still, this PR saves 120s on each such azure machine, and it saves 335s (a 2.4X overall speedup) on a local OSX machine, and makes the tests more accurate.