### PR TITLE
Documentation staticRead

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2525,6 +2525,9 @@ proc staticRead*(filename: string): string {.magic: "Slurp".}
   ## Compile-time `readFile <io.html#readFile,string>`_ proc for easy
   ## `resource`:idx: embedding:
   ##
+  ## The maximum file size limit that ``staticRead`` and ``slurp`` can read is
+  ## near or equal to the *free* memory of the device you are using to compile.
+  ##
   ## .. code-block:: Nim
   ##     const myResource = staticRead"mydatafile.bin"
   ##


### PR DESCRIPTION
- Documentation of `staticRead` and `slurp` maximum file size limits.
- Small change, easy merge, only doc.

Someone was trying to `staticRead` a 9 gigabytes file on a 8 gigabytes notebook,
just adds a line on the documentation explaining this for new people learning the lang.

Tested on multiple PC with different RAM and devel/stable with:
```nim
static:  # nim c -d:gigas=8 file.nim
  const gigas {.intdefine.} = 8
  doAssert gorgeEx("fallocate -l " & $gigas & "G " & $gigas).exitCode == 0
  defer: doAssert gorgeEx("rm " & $gigas).exitCode == 0
  doAssert staticRead($gigas).len > 0

```
