### PR TITLE
runCI: logs now show CPU/OS/etc info to be self contained

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -472,9 +472,14 @@ proc xtemp(cmd: string) =
   finally:
     copyExe(d / "bin" / "nim_backup".exe, d / "bin" / "nim".exe)
 
+proc hostInfo(): string =
+  "hostOS: $1, hostCPU: $2, int: $3, float: $4, cpuEndian: $5, cwd: $6" %
+    [hostOS, hostCPU, $int.sizeof, $float.sizeof, $cpuEndian, getCurrentDir()]
+
 proc runCI(cmd: string) =
   doAssert cmd.len == 0, cmd # avoid silently ignoring
   echo "runCI:", cmd
+  echo hostInfo()
   # note(@araq): Do not replace these commands with direct calls (eg boot())
   # as that would weaken our testing efforts.
   when defined(posix): # appveyor (on windows) didn't run this


### PR DESCRIPTION
## before PR
raw logs don't show any context info, it's not obvious what machine/OS it was run on, eg see:
https://dev.azure.com/nim-lang/255dfe86-e590-40bb-a8a2-3c0295ebdeb1/_apis/build/builds/2836/logs/68
```
...
runCI:
/Users/timothee/git_clone/nim/Nim_prs/koch boot
...
```
so you'd have to do some guess work or add where it came from when pasting such links (and searching for strings like macosx would provide false positives because of things like `2020-02-24T23:12:51.7719191Z nim compile -f --symbolfiles:off --compileonly --gen_mapping --cc:gcc --skipUserCfg --os:macosx --cpu:powerpc64  compiler/nim.nim`)

## after PR
raw logs now show

```
...
runCI:
hostOS: macosx, hostCPU: amd64, int: 8, float: 8, cpuEndian: littleEndian, cwd: /Users/timothee/git_clone/nim/Nim_prs
/Users/timothee/git_clone/nim/Nim_prs/koch boot
...
```
