### PR TITLE
Fix #9405 - cfg and nims run in sync; correctly honor cmdline --hint:conf:on/off ; correctly show Conf hints in order

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -10,7 +10,7 @@
 ## Helpers for binaries that use compiler passes, eg: nim, nimsuggest, nimfix
 
 import
-  options, idents, nimconf, scriptconfig, extccomp, commands, msgs,
+  options, idents, nimconf, extccomp, commands, msgs,
   lineinfos, modulegraphs, condsyms, os, pathutils
 
 from strutils import normalize
@@ -43,32 +43,13 @@ proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
     conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile getCurrentDir())
 
 proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: ConfigRef): bool =
-  loadConfigs(DefaultConfig, cache, conf) # load all config files
   if self.suggestMode:
     conf.command = "nimsuggest"
+  loadConfigs(DefaultConfig, cache, conf) # load all config files
 
-  template runNimScriptIfExists(path: AbsoluteFile) =
-    let p = path # eval once
-    if fileExists(p):
-      runNimScript(cache, p, freshDefines = false, conf)
-
-  # Caution: make sure this stays in sync with `loadConfigs`
-  if optSkipSystemConfigFile notin conf.globalOptions:
-    runNimScriptIfExists(getSystemConfigPath(conf, DefaultConfigNims))
-
-  if optSkipUserConfigFile notin conf.globalOptions:
-    runNimScriptIfExists(getUserConfigPath(DefaultConfigNims))
-
-  if optSkipParentConfigFiles notin conf.globalOptions:
-    for dir in parentDirs(conf.projectPath.string, fromRoot = true, inclusive = false):
-      runNimScriptIfExists(AbsoluteDir(dir) / DefaultConfigNims)
-
-  if optSkipProjConfigFile notin conf.globalOptions:
-    runNimScriptIfExists(conf.projectPath / DefaultConfigNims)
   block:
     let scriptFile = conf.projectFull.changeFileExt("nims")
     if not self.suggestMode:
-      runNimScriptIfExists(scriptFile)
       # 'nim foo.nims' means to just run the NimScript file and do nothing more:
       if fileExists(scriptFile) and scriptFile == conf.projectFull:
         if conf.command == "":
@@ -76,12 +57,6 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
           return false
         elif conf.command.normalize == "e":
           return false
-    else:
-      if scriptFile != conf.projectFull:
-        runNimScriptIfExists(scriptFile)
-      else:
-        # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
-        discard
 
   # now process command line arguments again, because some options in the
   # command line can overwrite the config file's settings

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -27,9 +27,7 @@ proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   defineSymbol conf.symbols, name
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
-  conf.isCmdLine = true
   self.processCmdLine(passCmd1, "", conf)
-  conf.isCmdLine = false
   if self.supportsStdinFile and conf.projectName == "-":
     handleStdinInput(conf)
   elif conf.projectName != "":

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -27,7 +27,9 @@ proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
   defineSymbol conf.symbols, name
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
+  conf.isCmdLine = true
   self.processCmdLine(passCmd1, "", conf)
+  conf.isCmdLine = false
   if self.supportsStdinFile and conf.projectName == "-":
     handleStdinInput(conf)
   elif conf.projectName != "":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -204,11 +204,17 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     incl(conf.notes, n)
     incl(conf.mainPackageNotes, n)
     incl(conf.enableNotes, n)
+    if conf.isCmdLine:
+      incl(conf.cmdLineNotes, n)
+      excl(conf.cmdLineDisabledNotes, n)
   of "off":
     excl(conf.notes, n)
     excl(conf.mainPackageNotes, n)
     incl(conf.disableNotes, n)
     excl(conf.foreignPackageNotes, n)
+    if conf.isCmdLine:
+      incl(conf.cmdLineDisabledNotes, n)
+      excl(conf.cmdLineNotes, n)
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
 
 proc processCompile(conf: ConfigRef; filename: string) =

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -204,7 +204,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     incl(conf.notes, n)
     incl(conf.mainPackageNotes, n)
     incl(conf.enableNotes, n)
-    if conf.isCmdLine:
+    if pass == passCmd1:
       incl(conf.cmdLineNotes, n)
       excl(conf.cmdLineDisabledNotes, n)
   of "off":
@@ -212,7 +212,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     excl(conf.mainPackageNotes, n)
     incl(conf.disableNotes, n)
     excl(conf.foreignPackageNotes, n)
-    if conf.isCmdLine:
+    if pass == passCmd1:
       incl(conf.cmdLineDisabledNotes, n)
       excl(conf.cmdLineNotes, n)
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -421,7 +421,7 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     if msg in conf.cmdLineDisabledNotes: return # eg: `--hints:conf:off` passed on cmdline
     # handle `--hints:off` (regardless of cmdline/cfg file)
     # handle `--hints:conf:on` on cmdline
-    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes)): return
+    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes): return
     title = HintTitle
     color = HintColor
     if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -418,7 +418,10 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint
-    if not conf.hasHint(msg): return
+    if msg in conf.cmdLineDisabledNotes: return # eg: `--hints:conf:off` passed on cmdline
+    # handle `--hints:off` (regardless of cmdline/cfg file)
+    # handle `--hints:conf:on` on cmdline
+    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes)): return
     title = HintTitle
     color = HintColor
     if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -418,10 +418,7 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, args: openArray[string]) =
     inc(conf.warnCounter)
   of hintMin..hintMax:
     sev = Severity.Hint
-    if msg in conf.cmdLineDisabledNotes: return # eg: `--hints:conf:off` passed on cmdline
-    # handle `--hints:off` (regardless of cmdline/cfg file)
-    # handle `--hints:conf:on` on cmdline
-    if not conf.hasHint(msg) and not (optHints in conf.options and msg in conf.cmdLineNotes): return
+    if not conf.hasHint(msg): return
     title = HintTitle
     color = HintColor
     if msg != hintUserRaw: kind = HintsToStr[ord(msg) - ord(hintMin)]

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -11,7 +11,7 @@
 
 import
   llstream, commands, os, strutils, msgs, lexer,
-  options, idents, wordrecg, strtabs, lineinfos, pathutils
+  options, idents, wordrecg, strtabs, lineinfos, pathutils, scriptconfig
 
 # ---------------- configuration file parser -----------------------------
 # we use Nim's scanner here to save space and work
@@ -248,16 +248,30 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef) =
     if readConfigFile(configPath, cache, conf):
       configFiles.add(configPath)
 
+  template runNimScriptIfExists(path: AbsoluteFile) =
+    let p = path # eval once
+    if fileExists(p):
+      runNimScript(cache, p, freshDefines = false, conf)
+
   if optSkipSystemConfigFile notin conf.globalOptions:
     readConfigFile(getSystemConfigPath(conf, cfg))
 
+    if cfg == DefaultConfig:
+      runNimScriptIfExists(getSystemConfigPath(conf, DefaultConfigNims))
+
   if optSkipUserConfigFile notin conf.globalOptions:
     readConfigFile(getUserConfigPath(cfg))
+
+    if cfg == DefaultConfig:
+      runNimScriptIfExists(getUserConfigPath(DefaultConfigNims))
 
   let pd = if not conf.projectPath.isEmpty: conf.projectPath else: AbsoluteDir(getCurrentDir())
   if optSkipParentConfigFiles notin conf.globalOptions:
     for dir in parentDirs(pd.string, fromRoot=true, inclusive=false):
       readConfigFile(AbsoluteDir(dir) / cfg)
+
+      if cfg == DefaultConfig:
+        runNimScriptIfExists(AbsoluteDir(dir) / DefaultConfigNims)
 
   if optSkipProjConfigFile notin conf.globalOptions:
     readConfigFile(pd / cfg)
@@ -269,6 +283,20 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef) =
         projectConfig = changeFileExt(conf.projectFull, "nim.cfg")
       readConfigFile(projectConfig)
 
+    if cfg == DefaultConfig:
+      runNimScriptIfExists(pd / DefaultConfigNims)
+
   for filename in configFiles:
     # delayed to here so that `hintConf` is honored
     rawMessage(conf, hintConf, filename.string)
+
+  block:
+    let scriptFile = conf.projectFull.changeFileExt("nims")
+    if conf.command != "nimsuggest":
+      runNimScriptIfExists(scriptFile)
+    else:
+      if scriptFile != conf.projectFull:
+        runNimScriptIfExists(scriptFile)
+      else:
+        # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
+        discard

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -251,6 +251,7 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef) =
   template runNimScriptIfExists(path: AbsoluteFile) =
     let p = path # eval once
     if fileExists(p):
+      configFiles.add(p)
       runNimScript(cache, p, freshDefines = false, conf)
 
   if optSkipSystemConfigFile notin conf.globalOptions:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -226,13 +226,11 @@ type
     ideCmd*: IdeCmd
     oldNewlines*: bool
     cCompiler*: TSystemCC
-    enableNotes*: TNoteKinds
-    disableNotes*: TNoteKinds
+    modifiedyNotes*: TNoteKinds # notes that have been set/unset from either cmdline/configs
+    cmdlineNotes*: TNoteKinds # notes that have been set/unset from cmdline
     foreignPackageNotes*: TNoteKinds
-    notes*: TNoteKinds
+    notes*: TNoteKinds # notes after resolving all logic(defaults, verbosity)/cmdline/configs
     mainPackageNotes*: TNoteKinds
-    cmdLineNotes*: TNoteKinds
-    cmdLineDisabledNotes*: TNoteKinds
     mainPackageId*: int
     errorCounter*: int
     hintCounter*: int
@@ -288,6 +286,10 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+
+proc setNote*(conf: ConfigRef, note: TNoteKind, enabled = true) =
+  if note notin conf.cmdlineNotes:
+    if enabled: incl(conf.notes, note) else: excl(conf.notes, note)
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
   optHints in conf.options and note in conf.notes

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -288,7 +288,6 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
-    isCmdLine*: bool # whether we are currently processing cmdline args, not cfg files
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
   optHints in conf.options and note in conf.notes
@@ -394,7 +393,6 @@ proc newConfigRef*(): ConfigRef =
     arguments: "",
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
-    isCmdLine: false,
   )
   setTargetFromSystem(result.target)
   # enable colors by default on terminals

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -231,6 +231,8 @@ type
     foreignPackageNotes*: TNoteKinds
     notes*: TNoteKinds
     mainPackageNotes*: TNoteKinds
+    cmdLineNotes*: TNoteKinds
+    cmdLineDisabledNotes*: TNoteKinds
     mainPackageId*: int
     errorCounter*: int
     hintCounter*: int
@@ -286,6 +288,7 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+    isCmdLine*: bool # whether we are currently processing cmdline args, not cfg files
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
   optHints in conf.options and note in conf.notes
@@ -391,6 +394,7 @@ proc newConfigRef*(): ConfigRef =
     arguments: "",
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
+    isCmdLine: false,
   )
   setTargetFromSystem(result.target)
   # enable colors by default on terminals

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -28,8 +28,8 @@ proc verboseProcess(context: PPassContext, n: PNode): PNode =
   let v = VerboseRef(context)
   if v.config.verbosity == 3:
     # system.nim deactivates all hints, for verbosity:3 we want the processing
-    # messages nonetheless, so we activate them again unconditionally:
-    incl(v.config.notes, hintProcessing)
+    # messages nonetheless, so we activate them again (but honor cmdlineNotes)
+    v.config.setNote(hintProcessing)
     message(v.config, n.info, hintProcessing, $idgen.gFrontEndId)
 
 const verbosePass* = makePass(open = verboseOpen, process = verboseProcess)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -328,6 +328,7 @@ proc processNote(c: PContext, n: PNode) =
     n[1] = x
     if x.kind == nkIntLit and x.intVal != 0: incl(c.config.notes, nk)
     else: excl(c.config.notes, nk)
+    # checkme: honor cmdlineNotes with: c.setNote(nk, x.kind == nkIntLit and x.intVal != 0)
   else:
     invalidPragma(c, n)
 

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -199,7 +199,6 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
 
 proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
                    freshDefines=true; conf: ConfigRef) =
-  rawMessage(conf, hintConf, scriptName.string)
   let oldSymbolFiles = conf.symbolFiles
   conf.symbolFiles = disabledSf
 
@@ -224,7 +223,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   incl(m.flags, sfMainModule)
   graph.vm = setupVM(m, cache, scriptName.string, graph)
 
-  graph.compileSystemModule() # TODO: see why this unsets hintConf in conf.notes
+  graph.compileSystemModule()
   discard graph.processModule(m, llStreamOpen(scriptName, fmRead))
 
   # watch out, "newruntime" can be set within NimScript itself and then we need


### PR DESCRIPTION
* fix #9405
* supersedes https://github.com/nim-lang/Nim/pull/13472 and https://github.com/nim-lang/Nim/pull/13461
* builds upon https://github.com/nim-lang/Nim/pull/13472 ; /cc @araq please don't squash so that @genotrance 's commit will appear as his

## rationale
neither #13472 nor #13461 are correct wrt hintConf; this PR correctly handles nimConf, and honors all cfg/nims/cmdline flags that contains references to `hintConf`
```
nim c -r -f --hint:conf:on main.nim
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/config.nims' [Conf]
Hint: used config file '/Users/timothee/.config/nim/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/.config/nim/config.nims' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/timn/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/timn/config.nims' [Conf]
Hint: 53772 LOC; 0.390 sec; 58.574MiB peakmem; Debug build; proj: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello.nim; out: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello [SuccessX]
hello world
```

```
nim c -r -f --hint:conf:off main.nim
Hint: 53772 LOC; 0.433 sec; 58.578MiB peakmem; Debug build; proj: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello.nim; out: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello [SuccessX]
hello world
```

```
nim c -r -f main.nim
```
outputs with or without Conf hints depending on what's in cfg/nims after **whole** processing

## output from https://github.com/nim-lang/Nim/pull/13461
* it doesn't honor --hint:conf:on/off on cmdline
* putting switch("hint", "conf:on") in ~/.config/nim/config.nims (or `--hint:conf:off`  in ~/.config/nim/nim.cfg) is now not honored, and there's no way to hide those Conf hints anymore
* output is buggy / out of order eg successX appears before some Conf hints:

```
Nim_prs/config/config.nims' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/timn/config.nims' [Conf]
Hint: 53762 LOC; 0.294 sec; 57.578MiB peakmem; Debug build; proj: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello.nim; out: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello [SuccessX]
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/.config/nim/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/timn/nim.cfg' [Conf]
hello world
```

## output from https://github.com/nim-lang/Nim/pull/13461
* it doesn't honor --hint:conf:on/off on cmdline
* putting switch("hint", "conf:on") in ~/.config/nim/config.nims (or `--hint:conf:off`  in ~/.config/nim/nim.cfg) is now not honored, and there's no way to hide those Conf hints anymore
* Conf hint file order is also buggy
```
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/config.nims' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/timn/config.nims' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/.config/nim/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/timn/nim.cfg' [Conf]
Hint: 53771 LOC; 0.262 sec; 57.523MiB peakmem; Debug build; proj: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello.nim; out: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello [SuccessX]
hello world
```
