### PR TITLE
fix #8312 --hints:off and --warnings:off now honored everywhere

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1412,7 +1412,7 @@ proc genAsgn(p: BProc, e: PNode, fastAsgn: bool) =
 proc genStmts(p: BProc, t: PNode) =
   var a: TLoc
 
-  let isPush = hintExtendedContext in p.config.notes
+  let isPush = p.config.hasHint(hintExtendedContext)
   if isPush: pushInfoContext(p.config, t.info)
   expr(p, t, a)
   if isPush: popInfoContext(p.config)

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -715,7 +715,7 @@ proc compileCFiles(conf: ConfigRef; list: CfileList, script: var Rope, cmds: var
     if optCompileOnly notin conf.globalOptions:
       cmds.add(compileCmd)
       let (_, name, _) = splitFile(it.cname)
-      prettyCmds.add(if hintCC in conf.notes: "CC: " & demanglePackageName(name) else: "")
+      prettyCmds.add(if conf.hasHint(hintCC): "CC: " & demanglePackageName(name) else: "")
     if optGenScript in conf.globalOptions:
       script.add(compileCmd)
       script.add("\n")

--- a/compiler/hlo.nim
+++ b/compiler/hlo.nim
@@ -17,7 +17,7 @@ proc evalPattern(c: PContext, n, orig: PNode): PNode =
   # awful to semcheck before macro invocation, so we don't and treat
   # templates and macros as immediate in this context.
   var rule: string
-  if optHints in c.config.options and hintPattern in c.config.notes:
+  if c.config.hasHint(hintPattern):
     rule = renderTree(n, {renderNoComments})
   let s = n[0].sym
   case s.kind
@@ -27,7 +27,7 @@ proc evalPattern(c: PContext, n, orig: PNode): PNode =
     result = semTemplateExpr(c, n, s, {efFromHlo})
   else:
     result = semDirectOp(c, n, {})
-  if optHints in c.config.options and hintPattern in c.config.notes:
+  if c.config.hasHint(hintPattern):
     message(c.config, orig.info, hintPattern, rule & " --> '" &
       renderTree(result, {renderNoComments}) & "'")
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -93,7 +93,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
 
   self.processCmdLineAndProjectPath(conf)
   if not self.loadConfigsAndRunMainCommand(cache, conf): return
-  if optHints in conf.options and hintGCStats in conf.notes: echo(GC_getStatistics())
+  if conf.hasHint(hintGCStats): echo(GC_getStatistics())
   #echo(GC_getStatistics())
   if conf.errorCounter != 0: return
   when hasTinyCBackend:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -287,6 +287,12 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
 
+proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
+  optHints in conf.options and note in conf.notes
+
+proc hasWarn*(conf: ConfigRef, note: TNoteKind): bool =
+  optWarns in conf.options and note in conf.notes
+
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 
 template depConfigFields*(fn) {.dirty.} =

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -990,7 +990,7 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   result = semExpr(c, result)
 
 proc semExprNoType(c: PContext, n: PNode): PNode =
-  let isPush = hintExtendedContext in c.config.notes
+  let isPush = c.config.hasHint(hintExtendedContext)
   if isPush: pushInfoContext(c.config, n.info)
   result = semExpr(c, n, {efWantStmt})
   discardCheck(c, result, {})

--- a/compiler/syntaxes.nim
+++ b/compiler/syntaxes.nim
@@ -120,7 +120,7 @@ proc applyFilter(p: var TParsers, n: PNode, filename: AbsoluteFile,
     result = filterReplace(p.config, stdin, filename, n)
   if f != filtNone:
     assert p.config != nil
-    if hintCodeBegin in p.config.notes:
+    if p.config.hasHint(hintCodeBegin):
       rawMessage(p.config, hintCodeBegin, [])
       msgWriteln(p.config, result.s)
       rawMessage(p.config, hintCodeEnd, [])


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/8312
* fix https://github.com/AndreiRegiani/INim/issues/16

things like `--hint:cc:on`, `--hint:source:on` and a few others were not properly cancelled by `--hints:off` ; now it works (and code simplifies a tiny bit)