### PR TITLE
Fix docgen snippet numbering

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -191,10 +191,10 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
   initStrTable result.types
   result.onTestSnippet =
     proc (gen: var RstGenerator; filename, cmd: string; status: int; content: string) =
+      inc(gen.id)
       var d = TDocumentor(gen)
       var outp: AbsoluteFile
       if filename.len == 0:
-        inc(d.id)
         let nameOnly = splitFile(d.filename).name
         outp = getNimcacheDir(conf) / RelativeDir(nameOnly) /
                RelativeFile(nameOnly & "_snippet_" & $d.id & ".nim")

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -49,7 +49,7 @@ when defined(nimlocks):
 else:
   {.pragma: benign, gcsafe.}
 
-template since(version, body: untyped) {.dirty.} =
+template since(version, body: untyped) {.dirty, used.} =
   ## limitation: can't be used to annotate a template (eg typetraits.get), would
   ## error: cannot attach a custom pragma.
   when (NimMajor, NimMinor) >= version:


### PR DESCRIPTION
- Fix snippet file name - everything was 101 - also print snippet if error
- Reduce noise in snippet and example compilation
- Reduce specific warnings, hints in koch docs