### PR TITLE
`koch --nim:pathto/nim boot` and `koch boot --hint:cc:off` now work 

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -704,6 +704,11 @@ proc addExternalFileToCompile*(conf: ConfigRef; filename: AbsoluteFile) =
     flags: {CfileFlag.External})
   addExternalFileToCompile(conf, c)
 
+proc displayProgressCC(conf: ConfigRef, path: string): string =
+  if conf.hasHint(hintCC):
+    let (_, name, _) = splitFile(path)
+    result = MsgKindToStr[hintCC] % demanglePackageName(name)
+
 proc compileCFiles(conf: ConfigRef; list: CfileList, script: var Rope, cmds: var TStringSeq,
                   prettyCmds: var TStringSeq) =
   var currIdx = 0
@@ -714,8 +719,7 @@ proc compileCFiles(conf: ConfigRef; list: CfileList, script: var Rope, cmds: var
     inc currIdx
     if optCompileOnly notin conf.globalOptions:
       cmds.add(compileCmd)
-      let (_, name, _) = splitFile(it.cname)
-      prettyCmds.add(if conf.hasHint(hintCC): "CC: " & demanglePackageName(name) else: "")
+      prettyCmds.add displayProgressCC(conf, $it.cname)
     if optGenScript in conf.globalOptions:
       script.add(compileCmd)
       script.add("\n")
@@ -907,6 +911,11 @@ proc hcrLinkTargetName(conf: ConfigRef, objFile: string, isMain = false): Absolu
                    else: platform.OS[conf.target.targetOS].dllFrmt % basename
   result = conf.getNimcacheDir / RelativeFile(targetName)
 
+template callbackPrettyCmd(cmd) =
+  when declared(echo):
+    let cmd2 = cmd
+    if cmd2.len > 0: echo cmd2
+
 proc callCCompiler*(conf: ConfigRef) =
   var
     linkCmd: string
@@ -917,10 +926,7 @@ proc callCCompiler*(conf: ConfigRef) =
   var script: Rope = nil
   var cmds: TStringSeq = @[]
   var prettyCmds: TStringSeq = @[]
-  let prettyCb = proc (idx: int) =
-    when declared(echo):
-      let cmd = prettyCmds[idx]
-      if cmd != "": echo cmd
+  let prettyCb = proc (idx: int) = callbackPrettyCmd(prettyCmds[idx])
   compileCFiles(conf, conf.toCompile, script, cmds, prettyCmds)
   if optCompileOnly notin conf.globalOptions:
     execCmdsInParallel(conf, cmds, prettyCb)
@@ -1125,12 +1131,9 @@ proc runJsonBuildInstructions*(conf: ConfigRef; projectfile: AbsoluteFile) =
       doAssert c.len >= 2
 
       cmds.add(c[1].getStr)
-      let (_, name, _) = splitFile(c[0].getStr)
-      prettyCmds.add("CC: " & demanglePackageName(name))
+      prettyCmds.add displayProgressCC(conf, c[0].getStr)
 
-    let prettyCb = proc (idx: int) =
-      when declared(echo):
-        echo prettyCmds[idx]
+    let prettyCb = proc (idx: int) = callbackPrettyCmd(prettyCmds[idx])
     execCmdsInParallel(conf, cmds, prettyCb)
 
     let linkCmd = data["linkcmd"]
@@ -1145,9 +1148,11 @@ proc runJsonBuildInstructions*(conf: ConfigRef; projectfile: AbsoluteFile) =
         execExternalProgram(conf, cmd2, hintExecuting)
 
   except:
-    when declared(echo):
-      echo getCurrentException().getStackTrace()
-    quit "error evaluating JSON file: " & jsonFile.string
+    let e = getCurrentException()
+    var msg = "\ncaught exception:n" & e.msg & "\nstacktrace:\n" &
+      getCurrentException().getStackTrace() &
+      "error evaluating JSON file: " & jsonFile.string
+    quit msg
 
 proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =
   for it in list:

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -99,7 +99,7 @@ const
     hintSuccess: "operation successful: $#",
     # keep in sync with `pegSuccess` see testament.nim
     hintSuccessX: "$loc LOC; $sec sec; $mem; $build build; proj: $project; out: $output",
-    hintCC: "CC: \'$1\'", # unused
+    hintCC: "CC: $1",
     hintLineTooLong: "line too long",
     hintXDeclaredButNotUsed: "'$1' is declared but not used",
     hintConvToBaseNotNeeded: "conversion to base object is not needed",

--- a/koch.nim
+++ b/koch.nim
@@ -265,15 +265,12 @@ when false:
 
 proc findStartNim: string =
   # we try several things before giving up:
+  # * nimExe
   # * bin/nim
   # * $PATH/nim
   # If these fail, we try to build nim with the "build.(sh|bat)" script.
-  var nim = "nim".exe
-  result = "bin" / nim
-  if existsFile(result): return
-  for dir in split(getEnv("PATH"), PathSep):
-    if existsFile(dir / nim): return dir / nim
-
+  let (nim, ok) = findNimImpl()
+  if ok: return nim
   when defined(Posix):
     const buildScript = "build.sh"
     if existsFile(buildScript):

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -18,15 +18,19 @@ proc exe*(f: string): string =
   when defined(windows):
     result = result.replace('/','\\')
 
-proc findNim*(): string =
-  if nimExe.len > 0: return nimExe
-  var nim = "nim".exe
-  result = "bin" / nim
-  if existsFile(result): return
+proc findNimImpl*(): tuple[path: string, ok: bool] =
+  if nimExe.len > 0: return (nimExe, true)
+  let nim = "nim".exe
+  result.path = "bin" / nim
+  result.ok = true
+  if existsFile(result.path): return
   for dir in split(getEnv("PATH"), PathSep):
-    if existsFile(dir / nim): return dir / nim
+    result.path = dir / nim
+    if existsFile(result.path): return
   # assume there is a symlink to the exe or something:
-  return nim
+  return (nim, false)
+
+proc findNim*(): string = findNimImpl().path
 
 proc exec*(cmd: string, errorcode: int = QuitFailure, additionalPath = "") =
   let prevPath = getEnv("PATH")


### PR DESCRIPTION
* `koch boot --hint:cc:off` now works  (previously silently ignored that option)
hintCC (the `CC: passaux.nim` lines etc)  are very verbose so it's important that user should be able to disable these.
* `koch --nim:pathto/nim boot` now works (previsouly silently ignored that option)
* code cleanup to avoid duplications in affected code

```
# will honor --hint:cc:off or --hint:processing:off or any other flag in user configs
./koch boot -d:release --skipUserCfg:off
# other example that now works:
./koch --nim:pathto/nim boot -d:release -d:nimUseLinenoise --hint:cc:off
```

- [ ] TODO for future PR
Now, in combination with https://github.com/nim-lang/Nim/pull/13488 and this PR, we can have a perfect workaround for https://github.com/nim-lang/Nim/pull/13411 (isolate the build process from external configuration files) if we allow `build_all.sh` to forward arguments to the koch build commands:
```
sh build_all.sh --skipUserCfg:off --hint:cc:off # for example
```
