### PR TITLE
[TODO] fix #13524: magics with untyped params (eg astToStr) now work inside generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -290,10 +290,9 @@ proc semGenericStmt(c: PContext, n: PNode,
     # is not exported and yet the generic 'threadProcWrapper' works correctly.
     let flags = if mixinContext: flags+{withinMixin} else: flags
     for i in first..<result.safeLen:
-      let flags = if mixinContext: flags+{withinMixin} else: flags
       # instead, would be better to only set `withinMixin` for arguments of
       # kind tyUntyped, eg `if s.typ[i].kind == tyUntyped:`, however, this
-      # currentl doesn't work
+      # currently doesn't work
       result[i] = semGenericStmt(c, result[i], flags, ctx)
   of nkCurlyExpr:
     result = newNodeI(nkCall, n.info)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1629,7 +1629,7 @@ else:
       result[i+1] = y[i]
 
 
-proc astToStr*[T](x: T): string {.magic: "AstToStr", noSideEffect.}
+proc astToStr*(x: untyped): string {.magic: "AstToStr", noSideEffect.}
   ## Converts the AST of `x` into a string representation. This is very useful
   ## for debugging.
 

--- a/tests/generics/t13525.nim
+++ b/tests/generics/t13525.nim
@@ -1,0 +1,6 @@
+# https://github.com/nim-lang/Nim/issues/13524
+template fun(field): untyped = astToStr(field)
+proc test1(): string = fun(nonexistant1)
+proc test2[T](): string = fun(nonexistant2) # used to cause: Error: undeclared identifier: 'nonexistant2'
+doAssert test1() == "nonexistant1"
+doAssert test2[int]() == "nonexistant2"


### PR DESCRIPTION
* fix #13524: magics with untyped params (eg astToStr) now work inside generics
* if the tyUntyped trick i used isn't acceptable for some reason, I can simply change the logic to:
```nim
mixinContext = s.magic in {mDefined, mDefinedInScope, mCompiles, mAstToStr}
```