### PR TITLE
[RFC] add `isDefault`; more general than isNil, isEmpty etc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,7 @@
 
 
 ```
+- Added `system.isDefault(a)` to tell whether `a` is equal to its default value
 
 
 ## Library changes

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -480,6 +480,24 @@ include "system/arithmetics"
 include "system/comparisons"
 
 const
+  NimMajor* {.intdefine.}: int = 1
+    ## is the major number of Nim's version.
+
+  NimMinor* {.intdefine.}: int = 1
+    ## is the minor number of Nim's version.
+
+  NimPatch* {.intdefine.}: int = 1
+    ## is the patch number of Nim's version.
+
+template since2(version, body: untyped) {.dirty.} =
+  ## poor-man's version of inclrtl.since without `>=` defined
+  const
+    v0 = version[0]
+    v1 = version[1]
+  when NimMajor > v0 or NimMajor == v0 and NimMinor >= v1:
+    body
+
+const
   appType* {.magic: "AppType"}: string = ""
     ## A string that describes the application type. Possible values:
     ## `"console"`, `"gui"`, `"lib"`.
@@ -909,7 +927,7 @@ else:
   else:
     proc reset*[T](obj: var T) {.magic: "Reset", noSideEffect.}
 
-when (NimMajor, NimMinor) >= (1, 1):
+since2 (1, 1):
   proc isDefault*[T](a: T): bool {.inline.} =
     ## returns whether `a` is equal to its default value
     runnableExamples:
@@ -2080,15 +2098,6 @@ import system/dollars
 export dollars
 
 const
-  NimMajor* {.intdefine.}: int = 1
-    ## is the major number of Nim's version.
-
-  NimMinor* {.intdefine.}: int = 1
-    ## is the minor number of Nim's version.
-
-  NimPatch* {.intdefine.}: int = 1
-    ## is the patch number of Nim's version.
-
   NimVersion*: string = $NimMajor & "." & $NimMinor & "." & $NimPatch
     ## is the version of Nim as a string.
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -928,7 +928,7 @@ else:
     proc reset*[T](obj: var T) {.magic: "Reset", noSideEffect.}
 
 since2 (1, 1):
-  proc isDefault*[T](a: T): bool {.inline.} =
+  template isDefault*[T](a: T): bool =
     ## returns whether `a` is equal to its default value
     runnableExamples:
       doAssert "".isDefault
@@ -949,7 +949,8 @@ since2 (1, 1):
       doAssert Foo1().notDefault
       doAssert Foo2().isDefault
 
-    a == default(T)
+    # BUG: default(T) would not work but should
+    a == default(type(a))
 
   template isDefault*(a: string): bool =
     ## overloaded for efficiency

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -946,6 +946,7 @@ since2 (1, 1):
       type Foo1 = ref object
       type Foo2 = object
       doAssert not Foo1().isDefault
+      doAssert Foo1().notDefault
       doAssert Foo2().isDefault
 
     a == default(T)
@@ -957,6 +958,10 @@ since2 (1, 1):
   template isDefault*[T](a: seq[T]): bool =
     ## overloaded for efficiency
     a.len == 0
+
+  template notDefault*(a): untyped =
+    ## negation of `isDefault`
+    not isDefault(a)
 
 proc setLen*[T](s: var seq[T], newlen: Natural) {.
   magic: "SetLengthSeq", noSideEffect.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -909,6 +909,34 @@ else:
   else:
     proc reset*[T](obj: var T) {.magic: "Reset", noSideEffect.}
 
+when defined(nimHasDefault):
+  proc isDefault*[T: not seq](a: T): bool {.inline.} =
+    ## returns whether `a` is equal to its default value
+    runnableExamples:
+      doAssert "".isDefault
+      doAssert not "a".isDefault
+      doAssert (-0.0).isDefault
+      doAssert not @[0].isDefault
+      doAssert [0].isDefault # whereas [0].len != 0
+
+      type Kind = enum kUnknown, kRed, kGreen
+      doAssert kUnknown.isDefault
+
+      type Foo1 = ref object
+      type Foo2 = object
+      doAssert not Foo1().isDefault
+      doAssert Foo2().isDefault
+
+    a == default(T)
+
+template isDefault*(a: string): bool =
+  ## overloaded for efficiency
+  a.len == 0
+
+template isDefault*(a: seq): bool =
+  ## overloaded for efficiency
+  a.len == 0
+
 proc setLen*[T](s: var seq[T], newlen: Natural) {.
   magic: "SetLengthSeq", noSideEffect.}
   ## Sets the length of seq `s` to `newlen`. ``T`` may be any sequence type.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -909,18 +909,21 @@ else:
   else:
     proc reset*[T](obj: var T) {.magic: "Reset", noSideEffect.}
 
-when defined(nimHasDefault):
+when (NimMajor, NimMinor) >= (1, 1):
   proc isDefault*[T](a: T): bool {.inline.} =
     ## returns whether `a` is equal to its default value
     runnableExamples:
       doAssert "".isDefault
       doAssert not "a".isDefault
-      doAssert (-0.0).isDefault
       doAssert not @[0].isDefault
+
+      ## semantic differences with something like isEmpty:
       doAssert [0].isDefault # whereas [0].len != 0
+      doAssert not "".cstring.isDefault # whereas "".cstring.len == 0
 
       type Kind = enum kUnknown, kRed, kGreen
       doAssert kUnknown.isDefault
+      doAssert (-0.0).isDefault
 
       type Foo1 = ref object
       type Foo2 = object
@@ -929,13 +932,13 @@ when defined(nimHasDefault):
 
     a == default(T)
 
-template isDefault*(a: string): bool =
-  ## overloaded for efficiency
-  a.len == 0
+  template isDefault*(a: string): bool =
+    ## overloaded for efficiency
+    a.len == 0
 
-template isDefault*[T](a: seq[T]): bool =
-  ## overloaded for efficiency
-  a.len == 0
+  template isDefault*[T](a: seq[T]): bool =
+    ## overloaded for efficiency
+    a.len == 0
 
 proc setLen*[T](s: var seq[T], newlen: Natural) {.
   magic: "SetLengthSeq", noSideEffect.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -910,7 +910,7 @@ else:
     proc reset*[T](obj: var T) {.magic: "Reset", noSideEffect.}
 
 when defined(nimHasDefault):
-  proc isDefault*[T: not seq](a: T): bool {.inline.} =
+  proc isDefault*[T](a: T): bool {.inline.} =
     ## returns whether `a` is equal to its default value
     runnableExamples:
       doAssert "".isDefault
@@ -933,7 +933,7 @@ template isDefault*(a: string): bool =
   ## overloaded for efficiency
   a.len == 0
 
-template isDefault*(a: seq): bool =
+template isDefault*[T](a: seq[T]): bool =
   ## overloaded for efficiency
   a.len == 0
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -949,7 +949,7 @@ since2 (1, 1):
       doAssert Foo1().notDefault
       doAssert Foo2().isDefault
 
-    # BUG: default(T) would not work but should
+    # pending https://github.com/nim-lang/Nim/issues/13527, use `default(T)`
     a == default(type(a))
 
   template isDefault*(a: string): bool =

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -4,13 +4,13 @@ line: 22
 nimout: '''
 twrong_at_operator.nim(22, 30) Error: type mismatch: got <array[0..0, type int]>
 but expected one of:
-proc `@`[IDX, T](a: sink array[IDX, T]): seq[T]
-  first type mismatch at position: 1
-  required type for a: sink array[IDX, T]
-  but expression '[int]' is of type: array[0..0, type int]
 proc `@`[T](a: openArray[T]): seq[T]
   first type mismatch at position: 1
   required type for a: openArray[T]
+  but expression '[int]' is of type: array[0..0, type int]
+proc `@`[IDX, T](a: sink array[IDX, T]): seq[T]
+  first type mismatch at position: 1
+  required type for a: sink array[IDX, T]
   but expression '[int]' is of type: array[0..0, type int]
 
 expression: @[int]


### PR DESCRIPTION
this is an often requested feature [1], the lack of which forces some packages to define their own flavors eg:
* in nimterop.globals:
```nim
template nBl(s: typed): untyped {.used.} = (s.len != 0)
template Bl(s: typed): untyped {.used.} = (s.len == 0)
```

## `isDefault` is more useful than `isEmpty` 
IMO `isDefault` is the more useful abstraction in the majority of cases, and is more general than `isNil`, or something like `isEmpty` (which has been proposed a few times) etc. 
* `isNil` and `isEmpty` don't cover important use cases, eg:
```
type Kind = enum kUnknown, kRed, kGreen
doAssert kUnknown.isDefault
```

* the following semantic differences illustrate that `isEmpty` is usually the wrong abstraction: 
```nim
      doAssert not @[0].isDefault # ok
      doAssert [0].isDefault # whereas [0].len != 0 and hence isEmpty would differ
      doAssert not "".cstring.isDefault # whereas "".cstring.len == 0, ditto
      doAssert not newTable[int,int]().isDefault # whereas newTable[int,int]().len == 0, ditto
```
  * `isEmpty ` is always false for `array[N, T]` variables (with N>0), so it's not particularly useful here.
  * for `cstring`, most algorithms I can think of care about whether a variable is nil or not, not whether it's len (c_strlen) is == 0

* `isDefault` is **automatically defined for any type that has `==` defined**
* whereas it's **much harder to define `isEmpty` generically**, let alone doing so efficiently eg many types would need a custom definition (Tables, etc)
eg: the naive 
```nim
proc isEmpty[T](a: T): bool = when compiles(a.len): a.len == 0 else: handleDifferently(a)`
```
is not efficient for some types where computing `len` is O(n) or expensive (eg linked lists, `intsets`, `packedjson`, c_strlen for cstring, etc)
* the **semantics of isEmpty aren't always clear** in particular with reference types (eg is `"".cstring` empty or not?);  **it would always give rise to debates** about what's considered `empty`, unlike `isDefault`. 

## semantics
* `isDefault` doesn't try to be too clever about what is considered "default", instead it just uses system.default(T) for that.
* However, optimizations are allowed, so long semantics are preserved, hence the overloads I added for `seq` and `string`. More overloads can be added in other modules as needed, when optimization dictates it. Note that such overloads should rarely be needed, because most types would often have effcient `==` defined
* note that `isDefault` is NOT binary equality, eg 0.0 and -0.0 aren't binary equal, but they're semantically (`==`) equal, hence `isDefault(-0.0)` is true
* likewise, `isDefault(initTable[int,int]())` is true despite `initTable[int,int]()` not being binary equal to t2 with `var t2: Table[int,int]`: what matters is **semantic** equality
* but `isDefault(newTable[int,int]())` is false and `isDefault(t3)` is true with `t3: TableRef[int,int]`

## Examples 1:
see `runnableExamples` in PR
## Example 2: enables DRY code
```nim
# main.nim
import mymod
doAssert Foo().bar.isDefault # this PR
# doAssert Foo().bar == Bar.default # doesn't compile, Bar private
doAssert Foo().bar == default(type(Foo().bar)) # not DRY

# mymod.nim
type Bar = ref object
type Foo* = ref object
  bar*: Bar
```

## [1] requests for a similar feature
I've seen it a few times already in gitter eg
* 
> I always used if str != "", but using len makes more sense in terms of performance
> Alexander Ivanov @alehander92 Apr 03 2019 08:35
> i am not sure if this is slower if it is, we should optimize it
> there was this idea of a geneirc isEmpty or something like that what happened

* 
>  Alexander Ivanov @alehander92 Nov 08 2018 02:03
> can we add isEmpty to the stdlib

> From IRC (bridge bot) @FromIRC Nov 08 2018 03:04
> Araq @alehander42: I want it too. for packedjson 'len == 0' is expensive. On the other hand, we have TR macros for that, maybe we should use them more

* 
> From IRC (bridge bot) @FromIRC Sep 22 2018 02:36
> Araq isEmpty is important for Nim's future though, should write a blog post...


## note
* I've also added `notDefault` as sugar over `not isDefault` to avoid using `not isDefault` (same rationale as `isnot` vs `is`); a few ppl have mentioned the need
> alehander92 maybe not isEmpty looks strange ? I think I prefer it compared to len > 0 still
> Araq well I don't want to write if not x.isEmpty: for y in x.unwrap():

name-wise, `notDefault` is preferable to `isAny` because it's self documenting, whereas `isAny` would be counter-intuitive for things like `doAssert not [0].isAny` (see above discussion about isEmpty)

* we could move it out of system but then please suggest which module; IMO it should be in system because that's also where `default` is defined, and it avoids having to import a heavy dependency like sugar etc for something that ought to be common
