### PR TITLE
Add posix_utils.isSsd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -69,7 +69,7 @@
 - Added `minIndex`, `maxIndex` and `unzip` to the `sequtils` module.
 - Added `os.isRelativeTo` to tell whether a path is relative to another
 - Added `resetOutputFormatters` to `unittest`
-
+- Added `posix_utils.isSsd` proc that returns `true` if disk is SSD (Solid).
 
 - Added a `with` macro for easy function chaining that's available
   everywhere, there is no need to concern your APIs with returning the first argument

--- a/lib/posix/posix_utils.nim
+++ b/lib/posix/posix_utils.nim
@@ -106,4 +106,4 @@ when defined(linux):
     ## .. code-block:: nim
     ##   echo isSsd('a') ## 'a' for /dev/sda, 'b' for /dev/sdb, ...
     ##
-    try: readFile("/sys/block/sd" & diskLetter & "/queue/rotational") == "0\n" except: false
+    try: readFile("/sys/block/sd" & $diskLetter & "/queue/rotational") == "0\n" except: false

--- a/lib/posix/posix_utils.nim
+++ b/lib/posix/posix_utils.nim
@@ -99,3 +99,11 @@ proc mkdtemp*(prefix: string): string =
     raise newException(OSError, $strerror(errno))
   return $tmpl
 
+when defined(linux):
+  proc isSsd*(diskLetter: char): bool {.inline.} =
+    ## Returns ``true`` if disk is SSD (Solid). Linux only.
+    ##
+    ## .. code-block:: nim
+    ##   echo isSsd('a') ## 'a' for /dev/sda, 'b' for /dev/sdb, ...
+    ##
+    try: readFile("/sys/block/sd" & diskLetter & "/queue/rotational") == "0\n" except: false

--- a/tests/stdlib/tposix.nim
+++ b/tests/stdlib/tposix.nim
@@ -6,7 +6,7 @@ outputsub: ""
 
 when not defined(windows):
 
-  import posix, posix_utils
+  import posix
 
   var
     u: Utsname
@@ -17,8 +17,3 @@ when not defined(windows):
   writeLine(stdout, u.nodename)
   writeLine(stdout, u.release)
   writeLine(stdout, u.machine)
-
-  when defined(linux):
-    block:
-      # lib/posix/posix_utils.nim
-      doAssert posix_utils.isSsd(diskLetter = 'a') is bool

--- a/tests/stdlib/tposix.nim
+++ b/tests/stdlib/tposix.nim
@@ -6,7 +6,7 @@ outputsub: ""
 
 when not defined(windows):
 
-  import posix
+  import posix, posix_utils
 
   var
     u: Utsname
@@ -17,3 +17,8 @@ when not defined(windows):
   writeLine(stdout, u.nodename)
   writeLine(stdout, u.release)
   writeLine(stdout, u.machine)
+
+
+  block:
+    # lib/posix/posix_utils.nim
+    doAssert posix_utils.isSsd(diskLetter = 'a') is bool

--- a/tests/stdlib/tposix.nim
+++ b/tests/stdlib/tposix.nim
@@ -18,7 +18,7 @@ when not defined(windows):
   writeLine(stdout, u.release)
   writeLine(stdout, u.machine)
 
-
-  block:
-    # lib/posix/posix_utils.nim
-    doAssert posix_utils.isSsd(diskLetter = 'a') is bool
+  when defined(linux):
+    block:
+      # lib/posix/posix_utils.nim
+      doAssert posix_utils.isSsd(diskLetter = 'a') is bool


### PR DESCRIPTION
- Add `posix_utils.isSsd()` proc that returns `true` if disk is SSD (Solid).
- Can work at compile-time, so allows to optimize for slow or fast I/O.
- Documentation with example.
- proc is single line, easy merge.
