### PR TITLE
make it possible to pass /link option to vcc link step

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -149,7 +149,7 @@ compiler vcc:
     buildDll: " /LD",
     buildLib: "lib /OUT:$libfile $objfiles",
     linkerExe: "cl",
-    linkTmpl: "$options $builddll$vccplatform /Fe$exefile $objfiles $buildgui",
+    linkTmpl: "$builddll$vccplatform /Fe$exefile $objfiles $buildgui $options",
     includeCmd: " /I",
     linkDirCmd: " /LIBPATH:",
     linkLibCmd: " $1.lib",


### PR DESCRIPTION
passing `/link` option to vcc requires it to be last in the command line, definitely after object file list. Hence, moving $options to the end of the command line. gcc also has $options for link command as the last element.