### PR TITLE
[TODO] fix #13528 nimgrep --word now works with operators

### DIFF
--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -649,7 +649,8 @@ else:
     if optIgnoreStyle in options:
       pattern = styleInsensitive(pattern)
     if optWord in options:
-      pattern = r"\b(:?" & pattern & r")\b"
+      # see https://github.com/nim-lang/Nim/issues/13528#issuecomment-592786443
+      pattern = r"(^|\W)(:?" & pattern & r")($|\W)"
     if {optIgnoreCase, optIgnoreStyle} * options != {}:
       reflags.incl reIgnoreCase
     let rep = if optRex in options: rex(pattern, reflags)


### PR DESCRIPTION
* fix #13528 nimgrep --word now works with operators
* uses same pattern as ripgrep instead of `\b` (thanks to @BurntSushi  for the idea!)

## caveat
Here's an edge case that could be considered a false positive depending on how you interpret `--word`, but it's a bit trickier o fix and definitely better than having false negatives

```
/Users/timothee/git_clone/nim/Nim_prs/tools/nimgrep --find -r --ext:nim --word '\$\$' lib
lib/pure/parseutils.nim:588:     for k, v in interpolatedFragments("  $this is ${an  example}  $$"):
lib/pure/marshal.nim:45: ## **Note**: The ``to`` and ``$$`` operations are available at compile-time!
lib/pure/marshal.nim:296: proc `$$`*[T](x: T): string =
lib/pure/strutils.nim:2709:   ## To produce a verbatim ``$``, use ``$$``.
lib/pure/strscans.nim:41: ``$$``              Matches a single dollar sign.
lib/pure/strscans.nim:693:   let xx = scanf("$abc", "$$$i", intval)
lib/pure/strscans.nim:697:   let xx2 = scanf("$1234", "$$$i", intval)
lib/pure/parsexml.nim:609:   # if we have no name, we have '<tag attr= key %&$$%':
lib/impure/nre.nim:713:   ## -  ``$$`` - literal ``$``
9 matches
```
ripgrep has same issue here:
```
echo 'let xx = scanf("$abc", "$$$i", intval)' | rg -w '\$\$'
let xx = scanf("$abc", "$$$i", intval)
```

## TODO for future PR
* `--word` should add an extra check that filters out entries `bcd` preceded by a b or succeeded by a d; this would filter out `$$$i` in this case.
* ripgrep could use a similar trick /cc @BurntSushi 