### PR TITLE
fix #13502 `a and b` now short-circuits semcheck in VM

### DIFF
--- a/lib/system/basic_types.nim
+++ b/lib/system/basic_types.nim
@@ -50,6 +50,13 @@ proc `and`*(x, y: bool): bool {.magic: "And", noSideEffect.}
   ## are true).
   ##
   ## Evaluation is lazy: if ``x`` is false, ``y`` will not even be evaluated.
+  ## Semantic check is lazy in VM, to allow `when declared(Foo) and T is Foo`
+
+template nimInternalAndVM*(x: bool, y: untyped): bool =
+  ## Internal lowering used by `and` in VM to enable shortcuiting semcheck
+  when x: y
+  else: false
+
 proc `or`*(x, y: bool): bool {.magic: "Or", noSideEffect.}
   ## Boolean ``or``; returns true if ``not (not x and not y)`` (if any of
   ## the arguments is true).

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -210,3 +210,20 @@ block: # Ordinal
   # doAssert enum is Ordinal # fails
   # doAssert Ordinal is SomeOrdinal
   # doAssert SomeOrdinal is Ordinal
+
+block: # and VM shortcircuits semcheck
+  doAssert not compiles(nonexistant)
+  const a1 = false and nonexistant
+  doAssert not a1
+  const a2 = true and false
+  doAssert not a2
+  const a3 = true and true
+  doAssert a3
+
+  static:
+    const a4 = false and nonexistant
+    doAssert not a4
+    let a5 = false and nonexistant # still works, we're inside a static context
+    doAssert not a5
+    const a6 = 2 and 3 # make sure we don't break bitwise and
+    doAssert a6 == 2


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/13502
* `when declared(Foo) and T is Foo: discard` now works, and more generally, in a static context, `a and b` now short-circuits semcheck in a static section (eg const a = false and nonexistant), meaning that b doesn't have to type-check if a is false
* see added tests

- [ ] TODO: also do short-circuit for `or`