### PR TITLE
nimsuggest: don't add CRLF to replies

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -252,10 +252,10 @@ proc toSocket(stdoutSocket: Socket) {.gcsafe.} =
     let res = results.recv()
     case res.section
     of ideNone: break
-    of ideMsg: stdoutSocket.send(res.doc & "\c\L")
-    of ideKnown: stdoutSocket.send($(res.quality == 1) & "\c\L")
-    of ideProject: stdoutSocket.send(res.filePath & "\c\L")
-    else: stdoutSocket.send($res & "\c\L")
+    of ideMsg: stdoutSocket.send(res.doc)
+    of ideKnown: stdoutSocket.send($(res.quality == 1))
+    of ideProject: stdoutSocket.send(res.filePath)
+    else: stdoutSocket.send($res)
 
 proc toEpc(client: Socket; uid: BiggestInt) {.gcsafe.} =
   var list = newSList()


### PR DESCRIPTION
This is already sent by replTcp after the message is sent.