### PR TITLE
azure-pipelines: use OSX 10.15 (was just enabled upstream)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,10 +12,10 @@ jobs:
         vmImage: 'ubuntu-16.04'
         CPU: i386
       OSX_amd64:
-        vmImage: 'macOS-10.14'
+        vmImage: 'macOS-10.15'
         CPU: amd64
       OSX_amd64_cpp:
-        vmImage: 'macOS-10.14'
+        vmImage: 'macOS-10.15'
         CPU: amd64
         NIM_COMPILE_TO_CPP: true
       Windows_amd64:


### PR DESCRIPTION
refs:
* [Add macOS 10.15 · Issue #1277 · microsoft/azure-pipelines-image-generation : Add macOS 10.15 · Issue #1277 · microsoft/azure-pipelines-image-generation](https://github.com/microsoft/azure-pipelines-image-generation/issues/1277)
* https://github.com/microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.15-Readme.md

* failure unrelated, caused by https://github.com/status-im/nim-blscurve/issues/39
* then after I fixed that by disabling blscurve, there's another unrelated failure: https://github.com/yglukhov/nimx/issues/397