### PR TITLE
[WIP] fix  #6999 (allow [nimDocOnly] in commit msg);  fix #13477 (flaky nodejs install); log PR url (+other info) in runCI logs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,15 +53,11 @@ jobs:
 
     - task: NodeTool@0
       inputs:
-        # versionSpec: '8.x'
         versionSpec: '13.x'
-        # rerunFailedTests: True # Optional
-        # rerunMaxAttempts: '10' # Optional
-      # displayName: 'Install node.js 8.x'
-      displayName: 'Install node.js 13.x v3'
+      displayName: 'Install node.js 13.x'
       # workaround flaky test https://github.com/nim-lang/Nim/issues/13477
-      continueOnError: 'true'
-      # CHECKME
+      # continueOnError: 'true' # this would cause error because system version
+      # is too old, so instead we install via `installNode` on non-windows
       condition: eq(variables['Agent.OS'], 'Windows_NT')
 
     - bash: |
@@ -69,7 +65,6 @@ jobs:
         DEBIAN_FRONTEND='noninteractive' \
           sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
-
       displayName: 'Install dependencies (amd64 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 
@@ -117,7 +112,6 @@ jobs:
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
     - bash: brew install --display-times boehmgc make sfml
-
       displayName: 'Install dependencies (OSX)'
       condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,27 +166,12 @@ jobs:
       displayName: 'Run CI'
       env:
         # see https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+        # most useful entries among the numerous defined variables
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
-        NIM_CI_PR_SourceRepositoryURI: $(System.PullRequest.SourceRepositoryURI)
-        NIM_CI_PR_PullRequestNumber: $(System.PullRequest.PullRequestNumber)
-
-        NIM_CI_TeamProject: $(System.TeamProject)
-        NIM_CI_JobAttempt: $(System.JobAttempt)
-
-        NIM_CI_Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
-        NIM_CI_Build_BuildId: $(Build.BuildId)
-        NIM_CI_Build_BuildNumber: $(Build.BuildNumber)
-        NIM_CI_Build_BuildUri: $(Build.BuildUri)
-        NIM_CI_Build_BinariesDirectory: $(Build.BinariesDirectory)
-        NIM_CI_Build_DefinitionName: $(Build.DefinitionName)
-        NIM_CI_Build_Repository_ID: $(Build.Repository.ID)
-        NIM_CI_Build_Repository_Name: $(Build.Repository.Name)
-        NIM_CI_Build_Repository_Provider: $(Build.Repository.Provider)
-        NIM_CI_Build_Repository_Uri: $(Build.Repository.Uri)
-        NIM_CI_Build_SourceBranch: $(Build.SourceBranch)
+        NIM_CI_System_PullRequest_PullRequestNumber: $(System.PullRequest.PullRequestNumber)
         NIM_CI_Build_SourceBranchName: $(Build.SourceBranchName)
-        NIM_CI_Build_SourcesDirectory: $(Build.SourcesDirectory)
+        NIM_CI_Build_Reason: $(Build.Reason)
+        NIM_CI_Build_Repository_Uri: $(Build.Repository.Uri)
         NIM_CI_Build_SourceVersion: $(Build.SourceVersion)
         NIM_CI_Build_SourceVersionMessage: $(Build.SourceVersionMessage)
-        NIM_CI_Build_Reason: $(Build.Reason)
+        NIM_CI_Build_BuildNumber: $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,10 +168,3 @@ jobs:
         # see https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
         # most useful entries among the numerous defined variables
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-        NIM_CI_System_PullRequest_PullRequestNumber: $(System.PullRequest.PullRequestNumber)
-        NIM_CI_Build_SourceBranchName: $(Build.SourceBranchName)
-        NIM_CI_Build_Reason: $(Build.Reason)
-        NIM_CI_Build_Repository_Uri: $(Build.Repository.Uri)
-        NIM_CI_Build_SourceVersion: $(Build.SourceVersion)
-        NIM_CI_Build_SourceVersionMessage: $(Build.SourceVersionMessage)
-        NIM_CI_Build_BuildNumber: $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,5 @@ jobs:
         ./koch runCI || echo '##vso[task.complete result=Failed]'
       displayName: 'Run CI'
       env:
-        # see https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
-        # most useful entries among the numerous defined variables
+        # other entries are automatically exported, see `getAzureEnv`
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,8 +53,8 @@ jobs:
 
     - task: NodeTool@0
       inputs:
-        versionSpec: '13.x'
-      displayName: 'Install node.js 13.x'
+        versionSpec: '8.x'
+      displayName: 'Install node.js 8.x'
       # workaround flaky test https://github.com/nim-lang/Nim/issues/13477
       # continueOnError: 'true' # this would cause error because system version
       # is too old, so instead we install via `installNode` on non-windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,14 +53,23 @@ jobs:
 
     - task: NodeTool@0
       inputs:
-        versionSpec: '8.x'
-      displayName: 'Install node.js 8.x'
+        # versionSpec: '8.x'
+        versionSpec: '13.x'
+        # rerunFailedTests: True # Optional
+        # rerunMaxAttempts: '10' # Optional
+      # displayName: 'Install node.js 8.x'
+      displayName: 'Install node.js 13.x v3'
+      # workaround flaky test https://github.com/nim-lang/Nim/issues/13477
+      continueOnError: 'true'
+      # CHECKME
+      condition: eq(variables['Agent.OS'], 'Windows_NT')
 
     - bash: |
         sudo apt-fast update -qq
         DEBIAN_FRONTEND='noninteractive' \
           sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
+
       displayName: 'Install dependencies (amd64 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 
@@ -107,7 +116,8 @@ jobs:
       displayName: 'Install dependencies (i386 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
-    - bash: brew install boehmgc make sfml
+    - bash: brew install --display-times boehmgc make sfml
+
       displayName: 'Install dependencies (OSX)'
       condition: eq(variables['Agent.OS'], 'Darwin')
 
@@ -161,4 +171,28 @@ jobs:
         ./koch runCI || echo '##vso[task.complete result=Failed]'
       displayName: 'Run CI'
       env:
+        # see https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
+        NIM_CI_PR_SourceRepositoryURI: $(System.PullRequest.SourceRepositoryURI)
+        NIM_CI_PR_PullRequestNumber: $(System.PullRequest.PullRequestNumber)
+
+        NIM_CI_TeamProject: $(System.TeamProject)
+        NIM_CI_JobAttempt: $(System.JobAttempt)
+
+        NIM_CI_Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
+        NIM_CI_Build_BuildId: $(Build.BuildId)
+        NIM_CI_Build_BuildNumber: $(Build.BuildNumber)
+        NIM_CI_Build_BuildUri: $(Build.BuildUri)
+        NIM_CI_Build_BinariesDirectory: $(Build.BinariesDirectory)
+        NIM_CI_Build_DefinitionName: $(Build.DefinitionName)
+        NIM_CI_Build_Repository_ID: $(Build.Repository.ID)
+        NIM_CI_Build_Repository_Name: $(Build.Repository.Name)
+        NIM_CI_Build_Repository_Provider: $(Build.Repository.Provider)
+        NIM_CI_Build_Repository_Uri: $(Build.Repository.Uri)
+        NIM_CI_Build_SourceBranch: $(Build.SourceBranch)
+        NIM_CI_Build_SourceBranchName: $(Build.SourceBranchName)
+        NIM_CI_Build_SourcesDirectory: $(Build.SourcesDirectory)
+        NIM_CI_Build_SourceVersion: $(Build.SourceVersion)
+        NIM_CI_Build_SourceVersionMessage: $(Build.SourceVersionMessage)
+        NIM_CI_Build_Reason: $(Build.Reason)

--- a/koch.nim
+++ b/koch.nim
@@ -30,8 +30,9 @@ when defined(i386) and defined(windows) and defined(vcc):
 import
   os, strutils, parseopt, osproc
 
-import tools / kochdocs
-import tools / deps
+import tools/kochdocs
+import tools/deps
+import tools/continuous_integration # could be conditional on whether we're in CI
 
 const VersionAsString = system.NimVersion
 
@@ -498,11 +499,6 @@ proc buildDrNim(args: string) =
   # always run the tests for now:
   exec("testament/testament".exe & " --nim:" & "drnim".exe & " pat drnim/tests")
 
-
-proc hostInfo(): string =
-  "hostOS: $1, hostCPU: $2, int: $3, float: $4, cpuEndian: $5, cwd: $6" %
-    [hostOS, hostCPU, $int.sizeof, $float.sizeof, $cpuEndian, getCurrentDir()]
-
 proc installDeps(dep: string, commit = "") =
   # the hashes/urls are version controlled here, so can be changed seamlessly
   # and tied to a nim release (mimicking git submodules)
@@ -518,6 +514,7 @@ proc runCI(cmd: string) =
   doAssert cmd.len == 0, cmd # avoid silently ignoring
   echo "runCI: ", cmd
   echo hostInfo()
+  installNode()
   # boot without -d:nimHasLibFFI to make sure this still works
   kochExecFold("Boot in release mode", "boot -d:release")
 

--- a/koch.nim
+++ b/koch.nim
@@ -517,13 +517,12 @@ proc runCI(cmd: string) =
   if isAzureCI(): installNode()
 
   template runDocs() =
-    when defined(posix):
-      kochExecFold("Docs", "docs --git.commit:devel")
+    echo "runDocs"
+    when defined(posix): kochExecFold("Docs", "docs --git.commit:devel")
 
   if isNimDocOnly():
-    echo "isNimDocOnly: true"
+    kochExecFold("Boot in release mode", "boot -d:release")
     runDocs()
-    echo "isNimDocOnly: done"
     return
 
   # boot without -d:nimHasLibFFI to make sure this still works

--- a/koch.nim
+++ b/koch.nim
@@ -514,7 +514,7 @@ proc runCI(cmd: string) =
   doAssert cmd.len == 0, cmd # avoid silently ignoring
   echo "runCI: ", cmd
   echo hostInfo()
-  installNode()
+  if isAzureCI():  installNode()
   # boot without -d:nimHasLibFFI to make sure this still works
   kochExecFold("Boot in release mode", "boot -d:release")
 

--- a/testament/azure.nim
+++ b/testament/azure.nim
@@ -6,18 +6,14 @@
 #    Look at license.txt for more info.
 #    All rights reserved.
 
-import base64, json, httpclient, os, strutils, uri
+import base64, json, httpclient, os, uri
 import specs
+import ".."/tools/azure_common
 
 const
   RunIdEnv = "TESTAMENT_AZURE_RUN_ID"
   CacheSize = 8 # How many results should be cached before uploading to
                 # Azure Pipelines. This prevents throttling that might arise.
-
-proc getAzureEnv(env: string): string =
-  # Conversion rule at:
-  # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables#set-variables-in-pipeline
-  env.toUpperAscii().replace('.', '_').getEnv
 
 template getRun(): string =
   ## Get the test run attached to this instance

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -8,12 +8,13 @@
 #
 
 import sequtils, parseutils, strutils, os, streams, parsecfg
+from ".."/tools/azure_common import isAzureCI
 
 var compilerPrefix* = findExe("nim")
 
 let isTravis* = existsEnv("TRAVIS")
 let isAppVeyor* = existsEnv("APPVEYOR")
-let isAzure* = existsEnv("TF_BUILD")
+let isAzure* = isAzureCI()
 
 var skips*: seq[string]
 

--- a/tools/azure_common.nim
+++ b/tools/azure_common.nim
@@ -1,0 +1,7 @@
+import strutils, os
+
+proc getAzureEnv*(env: string): string =
+  # Conversion rule at:
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables#set-variables-in-pipeline
+  env.toUpperAscii().replace('.', '_').getEnv
+

--- a/tools/azure_common.nim
+++ b/tools/azure_common.nim
@@ -3,5 +3,9 @@ import strutils, os
 proc getAzureEnv*(env: string): string =
   # Conversion rule at:
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables#set-variables-in-pipeline
+  # Predefined variables:
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
   env.toUpperAscii().replace('.', '_').getEnv
 
+proc isAzureCI*(): bool =
+  existsEnv("TF_BUILD")

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -31,7 +31,7 @@ proc installNode*() =
   elif defined(linux):
     # https://linuxize.com/post/how-to-install-node-js-on-ubuntu-18.04/
     runCmd "curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -"
-    runCmd "sudo apt install -yq nodejs"
+    runCmd "sudo apt install -yqq nodejs"
     runCmd "nodejs --version"
   elif defined(windows):
     # should've be installed via azure-pipelines.yml, but could do it here too
@@ -44,18 +44,19 @@ proc hostInfo*(): string =
   if not isAzureCI(): return
   let mode = if existsEnv("NIM_COMPILE_TO_CPP"): "cpp" else: "c"
 
-  var url = getAzureEnv("Build.Repository.Uri")
+  var urlBase = getAzureEnv("Build.Repository.Uri")
+  var urlPR = ""
 
   let isPR = isPullRequest()
   let commit = getAzureEnv("Build.SourceVersion")
   if isPR:
     let id = getAzureEnv("System.PullRequest.PullRequestNumber")
-    url = fmt"{url}/pull/{id}"
-  else:
-    url = fmt"{url}/commit/{commit}"
+    urlPR = fmt"{urlBase}/pull/{id}"
+  let urlCommit = fmt"{urlBase}/commit/{commit}"
 
   let branch = getAzureEnv("Build.SourceBranchName")
   let msg = getAzureEnv("Build.SourceVersionMessage").quoteShell
   let buildNum = getAzureEnv("Build.BuildNumber")
   let nl = "\n"
-  result.add fmt"""{nl}isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, mode: {mode}, buildNum: {buildNum}{nl}msg: {msg}{nl}"""
+  # Avoids `,` after urls since it'd prevent the link from being clickable in azure UI
+  result.add fmt"""{nl}urlPR: {urlPR}{nl}urlCommit: {urlCommit}{nl}branch: {branch}, mode: {mode}, buildNum: {buildNum}{nl}msg: {msg}{nl}"""

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -23,15 +23,12 @@ proc tryRunCmd(cmd: string): bool =
   execShellCmd(cmd) == 0
 
 proc gitLogPretty(): string =
-  ## returns last 2 entries
-  runCmd "pwd && git rev-parse --show-toplevel"
-  runCmd "git log --no-merges -1 --pretty=oneline"
-  runCmd "git log --no-merges -2 --pretty=oneline"
+  ## last commit msg excluding merge commit, so that it works both for PR's
+  ## and direct pushes to repo
   let cmd = "git log --no-merges -1 --pretty=oneline"
-  echo cmd
   let (outp, errC) = execCmdEx(cmd)
   doAssert errC == 0, $outp
-  echo ("gitLogPretty", outp, errC)
+  echo ("gitLogPretty", cmd, outp)
   outp
 
 proc isNimDocOnly*(): bool =

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -11,7 +11,7 @@ proc isPullRequest*(): bool =
   ## returns true if CI build is triggered via a PR
   ## else, it corresponds to a direct push to the repository by owners
   assert isAzureCI()
-  getEnv("Build.Reason") == "PullRequest"
+  getAzureEnv("Build.Reason") == "PullRequest"
 
 proc runCmd(cmd: string) =
   echo "runCmd: " & cmd
@@ -44,18 +44,18 @@ proc hostInfo*(): string =
   if not isAzureCI(): return
   let mode = if existsEnv("NIM_COMPILE_TO_CPP"): "cpp" else: "c"
 
-  var url = getEnv("Build.Repository.Uri")
+  var url = getAzureEnv("Build.Repository.Uri")
 
   let isPR = isPullRequest()
-  let commit = getEnv("Build.SourceVersion")
+  let commit = getAzureEnv("Build.SourceVersion")
   if isPR:
-    let id = getEnv("System.PullRequest.PullRequestNumber")
+    let id = getAzureEnv("System.PullRequest.PullRequestNumber")
     url = fmt"{url}/pull/{id}"
   else:
     url = fmt"{url}/commit/{commit}"
 
-  let branch = getEnv("Build.SourceBranchName")
-  let msg = getEnv("Build.SourceVersionMessage").quoteShell
+  let branch = getAzureEnv("Build.SourceBranchName")
+  let msg = getAzureEnv("Build.SourceVersionMessage").quoteShell
   let buildNum = getAzureEnv("Build.BuildNumber")
   let nl = "\n"
   result.add fmt"""{nl}isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, mode: {mode}, buildNum: {buildNum}{nl}msg: {msg}{nl}"""

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -1,0 +1,97 @@
+import os, osproc, strutils, strformat
+
+proc isAzureCI*(): bool =
+  getEnv("NIM_CI_Build_SourceBranchName").len > 0
+
+import macros
+
+macro fun(ret: var string, body): untyped =
+  result = newStmtList()
+  for a in body:
+    let a2 = a.strVal
+    result.add quote do:
+      `ret`.add `a2` & ": " & getEnv(`a2`) & "\n"
+
+proc isPullRequest*(): bool =
+  ## returns true if CI build is triggered via a PR
+  ## else, it corresponds to a direct push to the repository by owners
+  assert isAzureCI()
+  getEnv("NIM_CI_Build_Reason") == "PullRequest"
+
+proc runCmd(cmd: string) =
+  echo "runCmd: " & cmd
+  let status = execShellCmd(cmd)
+  doAssert status == 0, $status
+
+proc tryRunCmd(cmd: string): bool =
+  echo "tryRunCmd: " & cmd
+  execShellCmd(cmd) == 0
+
+proc installNode*() =
+  echo "installNode"
+  when defined(osx):
+    if not tryRunCmd "brew install node  > /dev/null":
+      echo " ok to ignore this: Error: The `brew link` step did not complete successfully"
+      runCmd "brew link --overwrite node"
+  elif defined(linux):
+    # https://linuxize.com/post/how-to-install-node-js-on-ubuntu-18.04/
+    runCmd "curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -"
+    runCmd "sudo apt install -yq nodejs"
+    runCmd "nodejs --version"
+    # node: v12.16.0
+    # nodejs: v10.19.0
+
+  elif defined(windows):
+    # should've be installed via azure-pipelines.yml, but could do it here too
+    # via https://nodejs.org/en/download/
+    discard
+
+  runCmd "node --version"
+
+proc hostInfo*(): string =
+  echo "D20200301T212950.v5"
+  result = "hostOS: $1, hostCPU: $2, nproc: $3, int: $4, float: $5, cpuEndian: $6, cwd: $7" %
+    [hostOS, hostCPU, $countProcessors(),
+     $int.sizeof, $float.sizeof, $cpuEndian, getCurrentDir()]
+  if not isAzureCI(): return
+  let mode = if existsEnv("NIM_COMPILE_TO_CPP"): "cpp" else: "c"
+
+  var url = getEnv("NIM_CI_Build_Repository_Uri")
+  let isPR = isPullRequest()
+  let commit = getEnv("NIM_CI_Build_SourceVersion")
+  if isPR:
+    url = "$1/pull/$2" % [url, getEnv("NIM_CI_PR_PullRequestNumber")]
+  else:
+    url = "$1/commit/$2" % [url, commit]
+
+  let branch = getEnv("NIM_CI_Build_SourceBranchName")
+  let msg = getEnv("NIM_CI_Build_SourceVersionMessage").quoteShell
+  let attempt = getEnv("NIM_CI_JobAttempt")
+  let buildNum = getEnv("NIM_CI_Build_BuildNumber")
+  # getEnv("NIM_CI_TeamProject")
+  result.add """isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, msg: {msg}, mode: {mode}, buildNum: {buildNum}"""
+  result.add "\n"
+
+  fun(result):
+    NIM_CI_PR_SourceRepositoryURI
+    NIM_CI_PR_PullRequestNumber
+    NIM_CI_TeamProject
+    NIM_CI_JobAttempt
+    NIM_CI_Build_ArtifactStagingDirectory
+    NIM_CI_Build_BuildId
+    NIM_CI_Build_BuildNumber
+    NIM_CI_Build_BuildUri
+    NIM_CI_Build_BinariesDirectory
+    NIM_CI_Build_DefinitionName
+    NIM_CI_Build_Repository_ID
+    NIM_CI_Build_Repository_Name
+    NIM_CI_Build_Repository_Provider
+    NIM_CI_Build_Repository_Uri
+    NIM_CI_Build_SourceBranch
+    NIM_CI_Build_SourceBranchName
+    NIM_CI_Build_SourcesDirectory
+    NIM_CI_Build_SourceVersion
+    NIM_CI_Build_SourceVersionMessage
+    NIM_CI_Build_Reason
+
+  result.add "\n"

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -28,7 +28,6 @@ proc gitLogPretty(): string =
   let cmd = "git log --no-merges -1 --pretty=oneline"
   let (outp, errC) = execCmdEx(cmd)
   doAssert errC == 0, $outp
-  echo ("gitLogPretty", cmd, outp)
   outp
 
 proc isNimDocOnly*(): bool =
@@ -70,7 +69,8 @@ proc hostInfo*(): string =
   let urlCommit = fmt"{urlBase}/commit/{commit}"
 
   let branch = getAzureEnv("Build.SourceBranchName")
-  let msg = getAzureEnv("Build.SourceVersionMessage").quoteShell
+  # let msg = getAzureEnv("Build.SourceVersionMessage") # not useful for merge commits
+  let msg = gitLogPretty()
   let buildNum = getAzureEnv("Build.BuildNumber")
   let nl = "\n"
   # Avoids `,` after urls since it'd prevent the link from being clickable in azure UI

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -1,16 +1,7 @@
-import os, osproc, strutils, strformat
+import os, osproc, strformat
 
 proc isAzureCI*(): bool =
   getEnv("NIM_CI_Build_SourceBranchName").len > 0
-
-import macros
-
-macro fun(ret: var string, body): untyped =
-  result = newStmtList()
-  for a in body:
-    let a2 = a.strVal
-    result.add quote do:
-      `ret`.add `a2` & ": " & getEnv(`a2`) & "\n"
 
 proc isPullRequest*(): bool =
   ## returns true if CI build is triggered via a PR
@@ -38,21 +29,14 @@ proc installNode*() =
     runCmd "curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -"
     runCmd "sudo apt install -yq nodejs"
     runCmd "nodejs --version"
-    # node: v12.16.0
-    # nodejs: v10.19.0
-
   elif defined(windows):
     # should've be installed via azure-pipelines.yml, but could do it here too
     # via https://nodejs.org/en/download/
     discard
-
   runCmd "node --version"
 
 proc hostInfo*(): string =
-  echo "D20200301T212950.v5"
-  result = "hostOS: $1, hostCPU: $2, nproc: $3, int: $4, float: $5, cpuEndian: $6, cwd: $7" %
-    [hostOS, hostCPU, $countProcessors(),
-     $int.sizeof, $float.sizeof, $cpuEndian, getCurrentDir()]
+  result = fmt"hostOS: {hostOS}, hostCPU: {hostCPU}, nproc: {countProcessors()}, int: {int.sizeof}, float: {float.sizeof}, cpuEndian: {cpuEndian}, cwd: {getCurrentDir()}"
   if not isAzureCI(): return
   let mode = if existsEnv("NIM_COMPILE_TO_CPP"): "cpp" else: "c"
 
@@ -60,38 +44,13 @@ proc hostInfo*(): string =
   let isPR = isPullRequest()
   let commit = getEnv("NIM_CI_Build_SourceVersion")
   if isPR:
-    url = "$1/pull/$2" % [url, getEnv("NIM_CI_PR_PullRequestNumber")]
+    let id = getEnv("NIM_CI_System_PullRequest_PullRequestNumber")
+    url = "{url}/pull/{id}"
   else:
-    url = "$1/commit/$2" % [url, commit]
+    url = "{url}/commit/{commit}"
 
   let branch = getEnv("NIM_CI_Build_SourceBranchName")
   let msg = getEnv("NIM_CI_Build_SourceVersionMessage").quoteShell
-  let attempt = getEnv("NIM_CI_JobAttempt")
   let buildNum = getEnv("NIM_CI_Build_BuildNumber")
-  # getEnv("NIM_CI_TeamProject")
-  result.add """isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, msg: {msg}, mode: {mode}, buildNum: {buildNum}"""
-  result.add "\n"
-
-  fun(result):
-    NIM_CI_PR_SourceRepositoryURI
-    NIM_CI_PR_PullRequestNumber
-    NIM_CI_TeamProject
-    NIM_CI_JobAttempt
-    NIM_CI_Build_ArtifactStagingDirectory
-    NIM_CI_Build_BuildId
-    NIM_CI_Build_BuildNumber
-    NIM_CI_Build_BuildUri
-    NIM_CI_Build_BinariesDirectory
-    NIM_CI_Build_DefinitionName
-    NIM_CI_Build_Repository_ID
-    NIM_CI_Build_Repository_Name
-    NIM_CI_Build_Repository_Provider
-    NIM_CI_Build_Repository_Uri
-    NIM_CI_Build_SourceBranch
-    NIM_CI_Build_SourceBranchName
-    NIM_CI_Build_SourcesDirectory
-    NIM_CI_Build_SourceVersion
-    NIM_CI_Build_SourceVersionMessage
-    NIM_CI_Build_Reason
-
+  result.add fmt"""isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, msg: {msg}, mode: {mode}, buildNum: {buildNum}"""
   result.add "\n"

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -45,12 +45,13 @@ proc hostInfo*(): string =
   let commit = getEnv("NIM_CI_Build_SourceVersion")
   if isPR:
     let id = getEnv("NIM_CI_System_PullRequest_PullRequestNumber")
-    url = "{url}/pull/{id}"
+    url = fmt"{url}/pull/{id}"
   else:
-    url = "{url}/commit/{commit}"
+    url = fmt"{url}/commit/{commit}"
 
   let branch = getEnv("NIM_CI_Build_SourceBranchName")
   let msg = getEnv("NIM_CI_Build_SourceVersionMessage").quoteShell
   let buildNum = getEnv("NIM_CI_Build_BuildNumber")
+  result.add "\n"
   result.add fmt"""isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, msg: {msg}, mode: {mode}, buildNum: {buildNum}"""
   result.add "\n"

--- a/tools/continuous_integration.nim
+++ b/tools/continuous_integration.nim
@@ -52,6 +52,5 @@ proc hostInfo*(): string =
   let branch = getEnv("NIM_CI_Build_SourceBranchName")
   let msg = getEnv("NIM_CI_Build_SourceVersionMessage").quoteShell
   let buildNum = getEnv("NIM_CI_Build_BuildNumber")
-  result.add "\n"
-  result.add fmt"""isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, msg: {msg}, mode: {mode}, buildNum: {buildNum}"""
-  result.add "\n"
+  let nl = "\n"
+  result.add fmt"""{nl}isPR:{isPR}, url: {url}, branch: {branch}, commit: {commit}, mode: {mode}, buildNum: {buildNum}{nl}msg: {msg}{nl}"""


### PR DESCRIPTION
EDIT 2020-05-13: this PR is useful but needs to be updated to reflect recent changes in how CI works; in particular can be modified to handle `[ci skip]` which isn't working in azure pipelines)

* fix https://github.com/nim-lang/Nim/pull/6999 as follows: if the **last commit msg** containing `[nimDocOnly]` will only build nim and run nim doc-related stuff
* this results in 7.5X speedups for `[nimDocOnly]`commits:  ~ 4mn per machine instead of ~30mn 
* fix #13477 `Install node.js 8.x` flaky step
#13477 keeps happening regularly (and even breaks with different error messages depending on the time) ; and it's simpler anyway to install directly from system package installers, eg `brew` on OSX ; furthermore, moving more logic into Nim code (`installNode `) is better (less dependency on CI specific logic, which makes it easier to switch as needed or work with multiple CI's)
* log a few other relevant variables that help when looking at runCI logs (the main log that contains almost all of nim CI), so they're self contained when shared
  * the PR url so it's easy to find originating PR when looking at those
  * the number of CPU's (helps when interpreting differences in timing results; some have 2, some have 4 in azure IIRC)
  * build ID + 1 or 2 more relevant info

eg for this PR, CI logs for the runCI step (eg like https://dev.azure.com/nim-lang/Nim/_build/results?buildId=2984&view=logs&j=a0440cd6-2060-5545-8b53-639e777de0c6)
will show this (and urls' are clickable):
```
...
hostOS: linux, hostCPU: amd64, nproc: 2, int: 8, float: 8, cpuEndian: littleEndian, cwd: /home/vsts/work/1/s
urlPR: https://github.com/nim-lang/Nim/pull/13556
urlCommit: https://github.com/nim-lang/Nim/commit/196c5b57f8e647a4219ba8f548fe8d4c43aaa608
branch: merge, mode: c, buildNum: 20200304.22
msg: 16c26ae4cb8f95d5694ccb57d6f3e407307e2f3d rerun without skipping tests
...
```
  * note this also works for CI logs triggered by a direct push to a branch as opposed to a PR (in which case the commit msg + url will be reflected as well, and isPR:false)

[EDIT]: that issue just happened again in https://dev.azure.com/nim-lang/Nim/_build/results?buildId=3007&view=logs&jobId=30931762-47c4-53b3-6a83-316eb5a6b9d7&j=30931762-47c4-53b3-6a83-316eb5a6b9d7&t=a385ca32-7847-5843-f526-f36e9a71a329

https://dev.azure.com/nim-lang/Nim/_build/results?buildId=3523&view=logs&jobId=1effb61f-3820-5ca5-606b-caa183b197b5&j=1effb61f-3820-5ca5-606b-caa183b197b5&t=17e5f679-7cb9-5688-0d47-09c257156869