### PR TITLE
fix #13563 freebsd CI

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,4 +1,9 @@
-image: freebsd/latest
+# see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
+# these are all broken, pending https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549
+# image: freebsd/latest 
+# image: freebsd/current
+# image: freebsd/12.x
+image: freebsd/11.x
 packages:
 - databases/sqlite3
 - devel/boehm-gc-threaded


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/issues/13563
pending https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=244549 we can revert back to using `image: freebsd/12.x` (but not revert this PR, the doc is useful)