### PR TITLE
fix #13558: toDateTime was buggy on 29th, 30th and 31th of each month (and had other quirks)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,10 @@
   and shouldn't be conflated with `"."`; use -d:nimOldRelativePathBehavior to restore the old
   behavior
 - `joinPath(a,b)` now honors trailing slashes in `b` (or `a` if `b` = "")
+- `times.parse` now only uses input to compute its result, and not `now`:
+  `parse("2020", "YYYY", utc())` is now `2020-01-01T00:00:00Z` instead of
+  `2020-03-02T00:00:00Z` if run on 03-02; it also doesn't crash anymore when
+  used on 29th, 30th, 31st of each month.
 
 ### Breaking changes in the compiler
 

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2248,19 +2248,9 @@ proc parsePattern(input: string, pattern: FormatPattern, i: var int,
 
 proc toDateTime(p: ParsedTime, zone: Timezone, f: TimeFormat,
                 input: string): DateTime =
-  var month = mJan
-  var year: int
-  var monthday: int
-  # `now()` is an expensive call, so we avoid it when possible
-  (year, month, monthday) =
-    if p.year.isNone or p.month.isNone or p.monthday.isNone:
-      let n = now()
-      (p.year.get(n.year),
-        p.month.get(n.month.int).Month,
-        p.monthday.get(n.monthday))
-    else:
-      (p.year.get(), p.month.get().Month, p.monthday.get())
-
+  var year = p.year.get(0)
+  var month = p.month.get(1).Month
+  var monthday = p.monthday.get(1)
   year =
     case p.era
     of eraUnknown:


### PR DESCRIPTION
* fix #13558: toDateTime buggy on 29th, 30th and 31th of each month
* breaking change: do not use `now` to compute result, was undocumented and non-sensical

