### PR TITLE
misc testament improvements

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -26,10 +26,7 @@ tasks:
     echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     cd Nim
-    if ! ./koch runCI; then
-      nim c -r tools/ci_testresults.nim
-      exit 1
-    fi
+    ./koch runCI
 triggers:
 - action: email
   condition: failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,3 @@ deploy:                         # https://nim-lang.github.io/Nim
   keep-history: false
   on:
     branch: devel
-
-# Extract failed tests
-after_failure: nim c -r tools/ci_testresults.nim

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -667,6 +667,8 @@ proc runJoinedTest(r: var TResults, cat: Category, testsDir: string) =
 proc processCategory(r: var TResults, cat: Category,
                      options, testsDir: string,
                      runJoinableTests: bool) =
+  doAssert r.testCat.len == 0
+  r.testCat = cat.string
   case cat.string.normalize
   of "rodfiles":
     when false:

--- a/tools/ci_testresults.nim
+++ b/tools/ci_testresults.nim
@@ -4,14 +4,15 @@ import os, json, sets, strformat
 
 const skip = toHashSet(["reDisabled", "reIgnored", "reSuccess", "reJoined"])
 
-when isMainModule:
+proc showTestResults*(): string =
+  result.add "showTestResults:\n"
   for fn in walkFiles("testresults/*.json"):
     let entries = fn.readFile().parseJson()
     for j in entries:
       let res = j["result"].getStr()
       if skip.contains(res):
         continue
-      echo fmt """
+      result.add fmt """
 Category: {j["category"].getStr()}
 Name: {j["name"].getStr()}
 Action: {j["action"].getStr()}
@@ -21,4 +22,7 @@ Result: {res}
 --------- Given  --------
 {j["given"].getStr()}
 -------------------------
-"""
+""" & "\n"
+
+when isMainModule:
+  echo showTestResults()


### PR DESCRIPTION
* run tools/ci_testresults.nim as part of runCI instead of duplicating the work (differently) in each CI pipeline (it was done in freebsd, travis, but not appveyor nor azure-pipelines, the most important); this is done by calling `./koch runCIRaw` from `./koch runCI` (direct call would not be robust to various crashes)
* after a category is done processing, we now show:
```
SUCCESS! testCat: lib total: 103 passed: 103 skipped: 0 failed: 1 duration: 76.5691397 pid: 51382
or:
FAILURE! testCat: stdlib total: 78 passed: 73 skipped: 4 failed: 1 duration: 32.12213921 pid: 51391
```
instead of the confusing:
```
FAILURE! total: 78 passed: 73 skipped: 4 failed: 1
```
which would cause you to think it's the sum-total over all the tests; it also enables showing per-category durations as shown above
