### PR TITLE
fix hintSuccess: `out` was wrong for `nim doc` without `-o` flag

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1135,8 +1135,8 @@ proc generateIndex*(d: PDoc) =
 
 proc updateOutfile(d: PDoc, outfile: AbsoluteFile) =
   if d.module == nil or sfMainModule in d.module.flags: # nil for eg for commandRst2Html
-    if d.conf.outFile.isEmpty and not d.conf.outDir.isEmpty:
-      d.conf.outFile = outfile.relativeTo(d.conf.outDir)
+    if d.conf.outDir.isEmpty: d.conf.outDir = d.conf.projectPath
+    if d.conf.outFile.isEmpty: d.conf.outFile = outfile.relativeTo(d.conf.outDir)
 
 proc writeOutput*(d: PDoc, useWarning = false) =
   runAllExamples(d)


### PR DESCRIPTION
before PR
Hint: 54137 LOC; 0.126 sec; 47.082MiB peakmem; Debug build; proj: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello2.nim; out: /Users/timothee/git_clone/nim/Nim_prs.out [SuccessX]

after PR
Hint: 54139 LOC; 0.119 sec; 47.016MiB peakmem; Debug build; proj: /Users/timothee/git_clone/nim/timn/src/timn/examples/thello2.nim; out: /Users/timothee/git_clone/nim/Nim_prs/thello2.html [SuccessX]

(nothing changes except the hintSuccessX)

works with -o or --outdir or no flag at atll