### PR TITLE
allow category nimble-packages to test a single package

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -480,7 +480,7 @@ proc makeSupTest(test, options: string, cat: Category): TTest =
   result.options = options
   result.startTime = epochTime()
 
-proc testNimblePackages(r: var TResults, cat: Category) =
+proc testNimblePackages(r: var TResults; cat: Category; packageFilter: string) =
   if nimbleExe == "":
     echo "[Warning] - Cannot run nimble tests: Nimble binary not found."
     return
@@ -493,6 +493,8 @@ proc testNimblePackages(r: var TResults, cat: Category) =
   var errors = 0
   try:
     for name, url, cmd, hasDep in listPackages():
+      if packageFilter notin name:
+        continue
       inc r.total
       var test = makeSupTest(url, "", cat)
       let buildPath = packagesDir / name
@@ -708,7 +710,7 @@ proc processCategory(r: var TResults, cat: Category,
     compileExample(r, "examples/gtk/*.nim", options, cat)
     compileExample(r, "examples/talk/*.nim", options, cat)
   of "nimble-packages":
-    testNimblePackages(r, cat)
+    testNimblePackages(r, cat, options)
   of "niminaction":
     testNimInAction(r, cat, options)
   of "untestable":

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -717,7 +717,6 @@ proc main() =
   of "c", "cat", "category":
     skips = loadSkipFrom(skipFrom)
     var cat = Category(p.key)
-    p.next
     processCategory(r, cat, p.cmdLineRest.string, testsDir, runJoinableTests = true)
   of "pcat":
     skips = loadSkipFrom(skipFrom)


### PR DESCRIPTION
After this PR, `nimble cat nimble-packages nimx` will test `nimx` only. I used it to reproduce a CI failure locally.