### PR TITLE
Nimpretty Fix negative indent breaks code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -126,6 +126,7 @@
 
 ### Tool changes
 
+- Fix Nimpretty must not accept negative indentation argument because breaks file.
 
 
 ### Compiler changes

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -44,8 +44,8 @@ proc writeVersion() =
 
 type
   PrettyOptions = object
-    indWidth: int
-    maxLineLen: int
+    indWidth: Natural
+    maxLineLen: Positive
 
 proc prettyPrint(infile, outfile: string, opt: PrettyOptions) =
   var conf = newConfigRef()


### PR DESCRIPTION

```console
$ cat example.nim 
proc f() =
    echo 42

try:
   echo 42
except:
   discard

$ nimpretty --maxLineLen:-9 --indent:-9 example.nim

$ cat example.nim 
proc f() =
echo 42

try:
echo 42
except:
discard

$ nim c -r /home/juan/code/Nim/nimpretty/nimpretty.nim --indent:-9 example.nim
Hint: nimpretty --indent:-9 example.nim [Exec]
Error: unhandled exception: value out of range: -9 [RangeError]

$
```

- 2 Line fix, easy merge, feel free to try it yourself with code above.
