### PR TITLE
[RFC] --stacktrace:noinline: up to 3X speedups with typically same stacktraces

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -764,6 +764,7 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
     genProcParams(m, t, rettype, desc, check, true, true)
     if not isImportedType(t):
       if t.callConv != ccClosure: # procedure vars may need a closure!
+        # this is where seemingly dead-code `N_INLINE_PTR` is used
         m.s[cfsTypes].addf("typedef $1_PTR($2, $3) $4;$n",
              [rope(CallingConvToStr[t.callConv]), rettype, result, desc])
       else:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -29,7 +29,7 @@ import dynlib
 
 template isGnerateNimFrame(options, sym): bool =
   optStackTrace in options and
-    (optStackTraceInline in options or sym.typ.callConv != ccInline)
+    (optStackTraceNoInline notin options or sym.typ.callConv != ccInline)
 
 when not declared(dynlib.libCandidates):
   proc libCandidates(s: string, dest: var seq[string]) =

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -281,7 +281,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "hints": result = contains(conf.options, optHints)
   of "threadanalysis": result = contains(conf.globalOptions, optThreadAnalysis)
   of "stacktrace": result = contains(conf.options, optStackTrace)
-  of "stacktraceInline": result = contains(conf.options, optStackTraceInline)
+  of "stacktraceNoInline": result = contains(conf.options, optStackTraceNoInline)
   of "linetrace": result = contains(conf.options, optLineTrace)
   of "debugger": result = contains(conf.globalOptions, optCDebug)
   of "profiler": result = contains(conf.options, optProfiler)
@@ -534,8 +534,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     case arg.normalize
     of "","on": conf.options.incl optStackTrace
     of "off": conf.options.excl optStackTrace
-    of "inline": conf.options.incl {optStackTrace, optStackTraceInline}
-    else: localError(conf, info, errExpectedButFound % ["'', 'on', 'off', 'inline'", arg])
+    of "noinline": conf.options.incl {optStackTrace, optStackTraceNoInline}
+    else: localError(conf, info, errExpectedButFound % ["'', 'on', 'off', 'noinline'", arg])
   of "excessivestacktrace": processOnOffSwitchG(conf, {optExcessiveStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch(conf, {optLineTrace}, arg, pass, info)
   of "debugger":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -119,6 +119,7 @@ const
   errOnOrOffExpectedButXFound = "'on' or 'off' expected, but '$1' found"
   errOnOffOrListExpectedButXFound = "'on', 'off' or 'list' expected, but '$1' found"
   errOffHintsError = "'off', 'hint' or 'error' expected, but '$1' found"
+  errExpectedButFound = "$1 expected, but '$2' found"
 
 proc invalidCmdLineOption(conf: ConfigRef; pass: TCmdLinePass, switch: string, info: TLineInfo) =
   if switch == " ": localError(conf, info, errInvalidCmdLineOption % "-")
@@ -280,6 +281,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
   of "hints": result = contains(conf.options, optHints)
   of "threadanalysis": result = contains(conf.globalOptions, optThreadAnalysis)
   of "stacktrace": result = contains(conf.options, optStackTrace)
+  of "stacktraceInline": result = contains(conf.options, optStackTraceInline)
   of "linetrace": result = contains(conf.options, optLineTrace)
   of "debugger": result = contains(conf.globalOptions, optCDebug)
   of "profiler": result = contains(conf.options, optProfiler)
@@ -528,7 +530,12 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "hints":
     if processOnOffSwitchOrList(conf, {optHints}, arg, pass, info): listHints(conf)
   of "threadanalysis": processOnOffSwitchG(conf, {optThreadAnalysis}, arg, pass, info)
-  of "stacktrace": processOnOffSwitch(conf, {optStackTrace}, arg, pass, info)
+  of "stacktrace":
+    case arg.normalize
+    of "","on": conf.options.incl optStackTrace
+    of "off": conf.options.excl optStackTrace
+    of "inline": conf.options.incl {optStackTrace, optStackTraceInline}
+    else: localError(conf, info, errExpectedButFound % ["'', 'on', 'off', 'inline'", arg])
   of "excessivestacktrace": processOnOffSwitchG(conf, {optExcessiveStackTrace}, arg, pass, info)
   of "linetrace": processOnOffSwitch(conf, {optLineTrace}, arg, pass, info)
   of "debugger":

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -28,7 +28,7 @@ type                          # please make sure we have under 32 options
     optOverflowCheck, optNilCheck, optRefCheck,
     optNaNCheck, optInfCheck, optStyleCheck,
     optAssert, optLineDir, optWarns, optHints,
-    optOptimizeSpeed, optOptimizeSize, optStackTrace, optStackTraceInline, # stack tracing support
+    optOptimizeSpeed, optOptimizeSize, optStackTrace, optStackTraceNoInline, # stack tracing support
     optLineTrace,             # line tracing support (includes stack tracing)
     optByRef,                 # use pass by ref for objects
                               # (for interfacing with C)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -28,7 +28,7 @@ type                          # please make sure we have under 32 options
     optOverflowCheck, optNilCheck, optRefCheck,
     optNaNCheck, optInfCheck, optStyleCheck,
     optAssert, optLineDir, optWarns, optHints,
-    optOptimizeSpeed, optOptimizeSize, optStackTrace, # stack tracing support
+    optOptimizeSpeed, optOptimizeSize, optStackTrace, optStackTraceInline, # stack tracing support
     optLineTrace,             # line tracing support (includes stack tracing)
     optByRef,                 # use pass by ref for objects
                               # (for interfacing with C)

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -17,8 +17,8 @@ Options:
                             see: "compile time define pragmas")
   -u, --undef:SYMBOL        undefine a conditional symbol
   -f, --forceBuild:on|off   force rebuilding of all modules
-  --stackTrace:on|off|inline turn stack tracing on|off; {.inline.} procs
-                            won't be traceable unless `inline` is used
+  --stackTrace:on|off|noinline turn stack tracing on|off; {.inline.} procs
+                            won't be traceable with `noinline` option
   --lineTrace:on|off        turn line tracing on|off
   --threads:on|off          turn support for multi-threading on|off
   -x, --checks:on|off       turn all runtime checks on|off

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -17,7 +17,8 @@ Options:
                             see: "compile time define pragmas")
   -u, --undef:SYMBOL        undefine a conditional symbol
   -f, --forceBuild:on|off   force rebuilding of all modules
-  --stackTrace:on|off       turn stack tracing on|off
+  --stackTrace:on|off|inline turn stack tracing on|off; {.inline.} procs
+                            won't be traceable unless `inline` is used
   --lineTrace:on|off        turn line tracing on|off
   --threads:on|off          turn support for multi-threading on|off
   -x, --checks:on|off       turn all runtime checks on|off

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -108,6 +108,8 @@ __AVR__
 #  define N_INLINE(rettype, name) rettype __inline name
 #endif
 
+#define N_INLINE_PTR(rettype, name) rettype (*name)
+
 #if defined(__POCC__)
 #  define NIM_CONST /* PCC is really picky with const modifiers */
 #  undef _MSC_VER /* Yeah, right PCC defines _MSC_VER even if it is

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -108,8 +108,6 @@ __AVR__
 #  define N_INLINE(rettype, name) rettype __inline name
 #endif
 
-#define N_INLINE_PTR(rettype, name) rettype (*name)
-
 #if defined(__POCC__)
 #  define NIM_CONST /* PCC is really picky with const modifiers */
 #  undef _MSC_VER /* Yeah, right PCC defines _MSC_VER even if it is


### PR DESCRIPTION
* refs https://github.com/nim-lang/RFCs/issues/198 (does not close because more items left)

* nim is now faster with ~~--stacktrace:on~~ the new option --stacktrace:noinline

## example 1:
see example https://github.com/nim-lang/Nim/pull/13582#issuecomment-594617950 showing **3X speedup compared to default stacktraces, while producing identical stacktraces**

## example 2:
nim compiling itself. Less drastic speedup than example 1 because it relies less on inlined procs (unlike math heavy code), but still an appreciatable speedup than anyone working on debugging compiler may benefit from.

## before PR: 
after building nim with `--stacktrace:on --opt:speed`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 26.5.s
after building nim with `--stacktrace:on`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 52.s
after building nim with `-d:release --stacktrace:on`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 18.s
after building nim with `-d:danger --stacktrace:on`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 17.7s

## after PR: 
after building nim with `--stacktrace:noinline --opt:speed`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 19.5.s (1.35X faster)
after building nim with `--stacktrace:noinline`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 46.9.s  (1.09X faster)
after building nim with `-d:release --stacktrace:noinline`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 14.7.s (1.24X faster)
after building nim with `-d:danger --stacktrace:noinline`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 14.3.s  (1.23X faster)

and for comparison (unchanged before/after this PR):
after building nim with `-d:danger --stacktrace:off`:
./bin/nim c -o:/tmp/z01 --hints:off -f compiler/nim.nim: 8.5

## links
* see also `-Og`, refs https://forum.nim-lang.org/t/7848#49991
* see also `-d:nimStackTraceOverride --import:libbacktrace --debugger:native` + `--passc:"-fno-omit-frame-pointer -fno-optimize-sibling-calls"`, refs [fix #9 stacktrace works if triggered by a signal, eg SIGSEGV by timotheecour · Pull Request #10 · status-im/nim-libbacktrace](https://github.com/status-im/nim-libbacktrace/pull/10)