### PR TITLE
fix #13579 joinPath("/foo/", "../a") is now /a

### DIFF
--- a/compiler/pathutils.nim
+++ b/compiler/pathutils.nim
@@ -102,6 +102,8 @@ when true:
 
 when isMainModule:
   doAssert AbsoluteDir"/Users/me///" / RelativeFile"z.nim" == AbsoluteFile"/Users/me/z.nim"
+  doAssert AbsoluteDir"/Users/me" / RelativeFile"../z.nim" == AbsoluteFile"/Users/z.nim"
+  doAssert AbsoluteDir"/Users/me/" / RelativeFile"../z.nim" == AbsoluteFile"/Users/z.nim"
   doAssert relativePath("/foo/bar.nim", "/foo/", '/') == "bar.nim"
   doAssert $RelativeDir"foo/bar" == "foo/bar"
   doAssert RelativeDir"foo/bar" == RelativeDir"foo/bar"

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -127,6 +127,7 @@ template endsWith(a: string, b: set[char]): bool =
 
 proc joinPathImpl(result: var string, state: var int, tail: string) =
   let trailingSep = tail.endsWith({DirSep, AltSep}) or tail.len == 0 and result.endsWith({DirSep, AltSep})
+  normalizePathEnd(result, trailingSep=false)
   addNormalizePath(tail, result, state, DirSep)
   normalizePathEnd(result, trailingSep=trailingSep)
 

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -80,7 +80,7 @@ proc addNormalizePath*(x: string; result: var string; state: var int;
         # while (d-1) > (state and 1) and result[d-1] in {DirSep, AltSep}: dec d
         # but right now we instead handle it inside os.joinPath
 
-        ## strip path component: foo/bar => foo
+        # strip path component: foo/bar => foo
         while (d-1) > (state and 1) and result[d-1] notin {DirSep, AltSep}:
           dec d
         if d > 0:

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -76,9 +76,9 @@ proc addNormalizePath*(x: string; result: var string; state: var int;
       if (state shr 1) >= 1:
         var d = result.len
         # f/..
-        ## We could handle stripping trailing sep here as well: foo// => foo
-        ## but right now we instead handle it inside os.joinPath
+        # We could handle stripping trailing sep here: foo// => foo like this:
         # while (d-1) > (state and 1) and result[d-1] in {DirSep, AltSep}: dec d
+        # but right now we instead handle it inside os.joinPath
 
         ## strip path component: foo/bar => foo
         while (d-1) > (state and 1) and result[d-1] notin {DirSep, AltSep}:

--- a/lib/pure/pathnorm.nim
+++ b/lib/pure/pathnorm.nim
@@ -76,6 +76,11 @@ proc addNormalizePath*(x: string; result: var string; state: var int;
       if (state shr 1) >= 1:
         var d = result.len
         # f/..
+        ## We could handle stripping trailing sep here as well: foo// => foo
+        ## but right now we instead handle it inside os.joinPath
+        # while (d-1) > (state and 1) and result[d-1] in {DirSep, AltSep}: dec d
+
+        ## strip path component: foo/bar => foo
         while (d-1) > (state and 1) and result[d-1] notin {DirSep, AltSep}:
           dec d
         if d > 0:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -389,7 +389,7 @@ block ospaths:
   doAssert joinPath("foo", "./") == unixToNativePath"foo/"
   doAssert joinPath("foo", "", "bar/") == unixToNativePath"foo/bar/"
 
-  ## issue #13579
+  # issue #13579
   doAssert joinPath("/foo", "../a") == unixToNativePath"/a"
   doAssert joinPath("/foo/", "../a") == unixToNativePath"/a"
   doAssert joinPath("/foo/.", "../a") == unixToNativePath"/a"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -389,6 +389,19 @@ block ospaths:
   doAssert joinPath("foo", "./") == unixToNativePath"foo/"
   doAssert joinPath("foo", "", "bar/") == unixToNativePath"foo/bar/"
 
+  ## issue #13579
+  doAssert joinPath("/foo", "../a") == unixToNativePath"/a"
+  doAssert joinPath("/foo/", "../a") == unixToNativePath"/a"
+  doAssert joinPath("/foo/.", "../a") == unixToNativePath"/a"
+  doAssert joinPath("/foo/.b", "../a") == unixToNativePath"/foo/a"
+  doAssert joinPath("/foo///", "..//a/") == unixToNativePath"/a/"
+  doAssert joinPath("foo/", "../a") == unixToNativePath"a"
+
+  when doslikeFileSystem:
+    doAssert joinPath("C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\Common7\\Tools\\", "..\\..\\VC\\vcvarsall.bat") == r"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+    doAssert joinPath("C:\\foo", "..\\a") == r"C:\a"
+    doAssert joinPath("C:\\foo\\", "..\\a") == r"C:\a"
+
 block getTempDir:
   block TMPDIR:
     # TMPDIR env var is not used if either of these are defined.


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/issues/13579
addNormalizePath doesn't work when result ends in a slash (eg foo/), all other uses assumed a path not ending in `/`; I could've fixed it inside `addNormalizePath` but decided to fix it inside `joinPathImpl` instead, and added a comment in `addNormalizePath`
