### PR TITLE
Removed simpleGetOrDefault

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -523,8 +523,10 @@ proc getOrDefault*(node: JsonNode, key: string): JsonNode =
   if not isNil(node) and node.kind == JObject:
     result = node.fields.getOrDefault(key)
 
-template simpleGetOrDefault*{`{}`(node, [key])}(node: JsonNode,
-    key: string): JsonNode = node.getOrDefault(key)
+proc `{}`*(node: JsonNode, key: string): JsonNode =
+  ## Gets a field from a `node`. If `node` is nil or not an object or
+  ## value at `key` does not exist, returns nil
+  node.getOrDefault(key)
 
 proc `{}=`*(node: JsonNode, keys: varargs[string], value: JsonNode) =
   ## Traverses the node and tries to set the value at the given location


### PR DESCRIPTION
Changed `simpleGetOrDefault` rewrite rule to `{}` single-arg overload. This removes annoying `Hint: simpleGetOrDefault` in the logs, and potentially increases compilation speed (but not sure).