### PR TITLE
Revert "Support cross compiling from host to host (#12859)"

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -411,7 +411,8 @@ proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
     else:
       suffix
 
-  if optCompileOnly notin conf.globalOptions:
+  if (conf.target.hostOS != conf.target.targetOS or conf.target.hostCPU != conf.target.targetCPU) and
+      optCompileOnly notin conf.globalOptions:
     let fullCCname = platform.CPU[conf.target.targetCPU].name & '.' &
                      platform.OS[conf.target.targetOS].name & '.' &
                      CC[c].name & fullSuffix


### PR DESCRIPTION
Original issue #8921 was fixed with #12859 by @nc-x. This attempted to fix cross compilation but ends up with always preferring `$cpu.$os.gcc.exe` even though it is not being requested.

Consider [nightlies](https://travis-ci.org/nim-lang/nightlies/jobs/658108777) which builds [csources](https://travis-ci.org/nim-lang/nightlies/jobs/658108777) with `--cpu arm` in a dockcross armv7a setup. This goes fine and the correct armv7a compiler is used since $CC is set appropriately.

Next, nim.cfg is [updated](https://github.com/nim-lang/nightlies/blob/master/dx.sh#L44) to point to $CC for `gcc.exe` so that the correct C cross-compiler is used for all following Nim calls.

Next, `nim c koch` is run and even though no cross compilation is requested in the command line or the nim.cfg, Nim [tries](https://travis-ci.org/nim-lang/nightlies/jobs/658108777#L10059) to use `arm.linux.gcc.exe` which is defined in [nim.cfg](https://github.com/nim-lang/Nim/blob/devel/config/nim.cfg#L23) as `arm-linux-gnueabihf-gcc`. This is the correct compiler on armv6 but not on armv7a or armv7 and causes those jobs to fail. arm64 passes since we do not have an `arm64.linux.gcc.exe` defined in nim.cfg.

This fails because hostCPU and targetCPU both are set as `arm` since csources was compiled with `--cpu arm`. As a result, the original if condition that was removed in #12859 does not take effect and the default `gcc.exe` is used and the correct cross-compiler is called.

With the #12859 code change, it always changes the compiler based on targetCPU which is `arm` and Nim picks the wrong default `arm.linux.gcc.exe` compiler defined in nim.cfg.

Even besides this specific case, per @alaviss, this [code change](https://irclogs.nim-lang.org/05-03-2020.html#21:33:27) no longer aligns with the documentation nor is it backwards compatible.

IRC discussion [here](https://irclogs.nim-lang.org/05-03-2020.html#20:41:01).