### PR TITLE
close #12704 by adding a test (tuple codegen error)

### DIFF
--- a/tests/metatype/ttypedesc2.nim
+++ b/tests/metatype/ttypedesc2.nim
@@ -35,8 +35,22 @@ type Point[T] = tuple[x, y: T]
 proc origin(T: typedesc): Point[T] = discard
 discard origin(int)
 
+block: # issue #12704
+  const a = $("a", "b")
+  proc fun() =
+    const str = $int
+    let b = $(str, "asdf")
+  fun()
+
 # https://github.com/nim-lang/Nim/issues/7516
 import typetraits
+
+block: #issue #12704
+  const a = $("a", "b")
+  proc fun() =
+    const str = name(int)
+    let b = $(str, "asdf")
+  fun()
 
 proc hasDefault1(T: type = int): auto = return T.name
 doAssert hasDefault1(int) == "int"

--- a/tests/tuples/ttuples_issues.nim
+++ b/tests/tuples/ttuples_issues.nim
@@ -75,18 +75,3 @@ block t1986:
     (var1: test(), var2: 100'u32),
     (var1: test(), var2: 192'u32)
   ]
-
-block t12704:
-  const a = $("a", "b")
-  proc fun() =
-    const str = $int
-    let b = $(str, "asdf")
-  fun()
-
-import std/typetraits
-block t12704_bis:
-  const a = $("a", "b")
-  proc fun() =
-    const str = name(int)
-    let b = $(str, "asdf")
-  fun()

--- a/tests/tuples/ttuples_issues.nim
+++ b/tests/tuples/ttuples_issues.nim
@@ -75,3 +75,18 @@ block t1986:
     (var1: test(), var2: 100'u32),
     (var1: test(), var2: 192'u32)
   ]
+
+block t12704:
+  const a = $("a", "b")
+  proc fun() =
+    const str = $int
+    let b = $(str, "asdf")
+  fun()
+
+import std/typetraits
+block t12704_bis:
+  const a = $("a", "b")
+  proc fun() =
+    const str = name(int)
+    let b = $(str, "asdf")
+  fun()


### PR DESCRIPTION
* close #12704 by adding a test
* git bisect shows this was fixed (by "accident") in https://github.com/nim-lang/Nim/pull/12809 , thanks @cooldome 
* I wonder if these also need fixing similarly to #12809:
```
compiler/lambdalifting.nim:136:31:  if intType.isNil: intType = newType(tyInt, iter)
compiler/semmagic.nim:166:18:    result.typ = newType(tyInt, context)
```

* failure unrelated, caused by https://github.com/nim-lang/Nim/issues/13166