### PR TITLE
Revert "nimsuggest: don't add CRLF to replies (#13545)"

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -252,10 +252,10 @@ proc toSocket(stdoutSocket: Socket) {.gcsafe.} =
     let res = results.recv()
     case res.section
     of ideNone: break
-    of ideMsg: stdoutSocket.send(res.doc)
-    of ideKnown: stdoutSocket.send($(res.quality == 1))
-    of ideProject: stdoutSocket.send(res.filePath)
-    else: stdoutSocket.send($res)
+    of ideMsg: stdoutSocket.send(res.doc & "\c\L")
+    of ideKnown: stdoutSocket.send($(res.quality == 1) & "\c\L")
+    of ideProject: stdoutSocket.send(res.filePath & "\c\L")
+    else: stdoutSocket.send($res & "\c\L")
 
 proc toEpc(client: Socket; uid: BiggestInt) {.gcsafe.} =
   var list = newSList()


### PR DESCRIPTION
This reverts commit a974684b149faa19645f1e18b7b11aa67f169997.

The CRLF was to separate between each response, and removing them causes
the responses to not be splitted correctly.

I didn't notice that it was in a loop when I made #13545.