### PR TITLE
Only print the link command when listCmd is active and fix the docs

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -489,7 +489,7 @@ proc addExternalFileToLink*(conf: ConfigRef; filename: AbsoluteFile) =
   conf.externalToLink.insert(filename.string, 0)
 
 proc execWithEcho(conf: ConfigRef; cmd: string, msg = hintExecuting): int =
-  rawMessage(conf, msg, cmd)
+  rawMessage(conf, msg, if msg == hintLinking and not(optListCmd in conf.globalOptions or conf.verbosity > 1): "" else: cmd)
   result = execCmd(cmd)
 
 proc execExternalProgram*(conf: ConfigRef; cmd: string, msg = hintExecuting) =

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -1,7 +1,6 @@
 # Special configuration file for the Nim project
 
 hint[XDeclaredButNotUsed]:off
-hint[Link]:off
 
 define:booting
 define:nimcore

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -125,8 +125,8 @@ Advanced options:
                             dynlib: "liblua.so.3"
   --dynlibOverrideAll
                             disables the effects of the dynlib pragma
-  --listCmd                 list the compilation commands; can be combined with:
-                            --hint:exec:on and --hint:link:on
+  --listCmd                 list the compilation commands; can be combined with
+                            `--hint:exec:on` and `--hint:link:on`
   --asm                     produce assembler code
   --parallelBuild:0|1|...   perform a parallel build
                             value = number of processors (0 for auto-detect)


### PR DESCRIPTION
After #13056 the link command is shown always regardless of `--listCmd`, which is really annoying.
This fixes that and it also fixes the docs, that looked like this:

![](https://i.imgur.com/FZHDQEE.png)
