### PR TITLE
Add strutils in-place

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -94,6 +94,10 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
+- Added in-place `strutils.toLowerAscii`,  `strutils.toUpperAscii`, `strutils.capitalizeAscii`,
+  with compile-time `{.linearScanEnd.}` optimizations for `string` and `char`,
+  faster than the copy versions, at least from ~1.5x to ~5x performance approx,
+  depending on how you optimize it with the `linearScanEnd` static argument.
 
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -94,10 +94,8 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
-- Added in-place `strutils.toLowerAscii`,  `strutils.toUpperAscii`, `strutils.capitalizeAscii`,
-  with compile-time `{.linearScanEnd.}` optimizations for `string` and `char`,
-  faster than the copy versions, at least from ~1.5x to ~5x performance approx,
-  depending on how you optimize it with the `linearScanEnd` static argument.
+- Added in-place `strutils.toLowerAsciiInPlace`,  `strutils.toUpperAsciiInPlace`, `strutils.capitalizeAsciiInPlace`,
+  faster than the copy versions, at least from ~1.5x to ~5x performance approx.
 
 
 ## Library changes

--- a/changelog.md
+++ b/changelog.md
@@ -94,7 +94,7 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
-- Added in-place `strutils.toLowerAsciiInPlace`,  `strutils.toUpperAsciiInPlace`, `strutils.capitalizeAsciiInPlace`,
+- Added in-place `strutils.toLowerAsciiInPlace`,  `strutils.toUpperAsciiInPlace`,
   faster than the copy versions, at least from ~1.5x to ~5x performance approx.
 
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -191,7 +191,7 @@ proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
   return c in {'A'..'Z'}
 
 
-proc toLowerAscii*(c: char): char {.inline, noSideEffect, procvar,
+proc toLowerAscii*(c: char): char {.noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiChar".} =
   ## Returns the lower case version of character ``c``.
   ##
@@ -229,7 +229,7 @@ proc toLowerAscii*(s: string): string {.inline, noSideEffect, procvar,
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
 
-proc toUpperAscii*(c: char): char {.inline, noSideEffect, procvar,
+proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiChar".} =
   ## Converts character `c` into upper case.
   ##

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,7 +2862,7 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+  template toLowerAscii*(c: var char, linearScanEnd: static[char]) =
     ## Returns the lower case version of character ``c``.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
@@ -2892,7 +2892,7 @@ since (1, 1):
       toLowerAscii(character, linearScanEnd = 'f')
       doAssert character == 'f'
       var chara = 'A'
-      toLowerAscii(chara)
+      toLowerAscii(chara, linearScanEnd = ' ')
       doAssert chara == 'a'
     c = case c
       of 'A':
@@ -2976,7 +2976,7 @@ since (1, 1):
       else: c
 
 
-  template toUpperAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+  template toUpperAscii*(c: var char, linearScanEnd: static[char]) =
     ## Converts character `c` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
@@ -3007,7 +3007,7 @@ since (1, 1):
       toUpperAscii(character, linearScanEnd = 'f')
       doAssert character == 'F'
       var chara = 'z'
-      toUpperAscii(chara)
+      toUpperAscii(chara, linearScanEnd = ' ')
       doAssert chara == 'Z'
     c = case c
       of 'a':
@@ -3091,7 +3091,7 @@ since (1, 1):
       else: c
 
 
-  func toLowerAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+  func toLowerAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
     ## Converts string `s` into lower case.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
@@ -3117,7 +3117,7 @@ since (1, 1):
       toLowerAscii(stringy, linearScanEnd = 'f')
       doAssert stringy == "abcdef"
       var strng = "NIM"
-      toLowerAscii(strng)
+      toLowerAscii(strng, linearScanEnd = 'n')
       doAssert strng == "nim"
     var i = 0
     for c in mitems(s):
@@ -3126,7 +3126,7 @@ since (1, 1):
       inc i
 
 
-  func toUpperAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+  func toUpperAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
     ## Converts string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
@@ -3154,7 +3154,7 @@ since (1, 1):
       toUpperAscii(stringo, linearScanEnd = 'f')
       doAssert stringo == "ABCDEF"
       var strng = "nim"
-      toUpperAscii(strng)
+      toUpperAscii(strng, linearScanEnd = 'n')
       doAssert strng == "NIM"
     var i = 0
     for c in mitems(s):
@@ -3163,7 +3163,7 @@ since (1, 1):
       inc i
 
 
-  func capitalizeAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+  func capitalizeAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
     ## Converts the first character of string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.
@@ -3190,7 +3190,7 @@ since (1, 1):
       capitalizeAscii(stringu, linearScanEnd = 'f')
       doAssert stringu == "Foo"
       var stringx = "-bar"
-      capitalizeAscii(stringx, linearScanEnd = 'f')
+      capitalizeAscii(stringx, linearScanEnd = 'r')
       doAssert stringx == "-bar"
     toUpperAscii(s[0], linearScanEnd)
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -191,7 +191,7 @@ proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
   return c in {'A'..'Z'}
 
 
-proc toLowerAscii*(c: char): char {.noSideEffect, procvar,
+proc toLowerAscii*(c: char): char {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiChar".} =
   ## Returns the lower case version of character ``c``.
   ##
@@ -215,7 +215,7 @@ template toImpl(call) =
   for i in 0..len(s) - 1:
     result[i] = call(s[i])
 
-proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
+proc toLowerAscii*(s: string): string {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiStr".} =
   ## Converts string `s` into lower case.
   ##
@@ -229,7 +229,7 @@ proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
 
-proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
+proc toUpperAscii*(c: char): char {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiChar".} =
   ## Converts character `c` into upper case.
   ##
@@ -249,7 +249,7 @@ proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   else:
     result = c
 
-proc toUpperAscii*(s: string): string {.noSideEffect, procvar,
+proc toUpperAscii*(s: string): string {.inline, noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiStr".} =
   ## Converts string `s` into upper case.
   ##

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,337 +2862,163 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAscii*(c: var char, linearScanEnd: static[char]) =
+  template toLowerAsciiInPlace*(c: var char) =
     ## Returns the lower case version of character ``c``.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
     ## <unicode.html#toLower,Rune>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   var character = 'F'  ## Hexadecimal
-    ##   toLowerAscii(character, linearScanEnd = 'f')
-    ##   doAssert character == 'f'
-    ##
     ## See also:
     ## * `isLowerAscii proc<#isLowerAscii,char>`_
     ## * `toLowerAscii proc<#toLowerAscii,string>`_ for converting a string
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var character = 'F'
-      toLowerAscii(character, linearScanEnd = 'f')
+      toLowerAsciiInPlace(character)
       doAssert character == 'f'
       var chara = 'A'
-      toLowerAscii(chara, linearScanEnd = ' ')
+      toLowerAsciiInPlace(chara)
       doAssert chara == 'a'
     c = case c
-      of 'A':
-        when linearScanEnd == 'a': {.linearScanEnd.}
-        'a'
-      of 'B':
-        when linearScanEnd == 'b': {.linearScanEnd.}
-        'b'
-      of 'C':
-        when linearScanEnd == 'c': {.linearScanEnd.}
-        'c'
-      of 'D':
-        when linearScanEnd == 'd': {.linearScanEnd.}
-        'd'
-      of 'E':
-        when linearScanEnd == 'e': {.linearScanEnd.}
-        'e'
-      of 'F':
-        when linearScanEnd == 'f': {.linearScanEnd.}
-        'f'
-      of 'G':
-        when linearScanEnd == 'g': {.linearScanEnd.}
-        'g'
-      of 'H':
-        when linearScanEnd == 'h': {.linearScanEnd.}
-        'h'
-      of 'I':
-        when linearScanEnd == 'i': {.linearScanEnd.}
-        'i'
-      of 'J':
-        when linearScanEnd == 'j': {.linearScanEnd.}
-        'j'
-      of 'K':
-        when linearScanEnd == 'k': {.linearScanEnd.}
-        'k'
-      of 'L':
-        when linearScanEnd == 'l': {.linearScanEnd.}
-        'l'
-      of 'M':
-        when linearScanEnd == 'm': {.linearScanEnd.}
-        'm'
-      of 'N':
-        when linearScanEnd == 'n': {.linearScanEnd.}
-        'n'
-      of 'O':
-        when linearScanEnd == 'o': {.linearScanEnd.}
-        'o'
-      of 'P':
-        when linearScanEnd == 'p': {.linearScanEnd.}
-        'p'
-      of 'Q':
-        when linearScanEnd == 'q': {.linearScanEnd.}
-        'q'
-      of 'R':
-        when linearScanEnd == 'r': {.linearScanEnd.}
-        'r'
-      of 'S':
-        when linearScanEnd == 's': {.linearScanEnd.}
-        's'
-      of 'T':
-        when linearScanEnd == 't': {.linearScanEnd.}
-        't'
-      of 'U':
-        when linearScanEnd == 'u': {.linearScanEnd.}
-        'u'
-      of 'V':
-        when linearScanEnd == 'v': {.linearScanEnd.}
-        'v'
-      of 'W':
-        when linearScanEnd == 'w': {.linearScanEnd.}
-        'w'
-      of 'X':
-        when linearScanEnd == 'x': {.linearScanEnd.}
-        'x'
-      of 'Y':
-        when linearScanEnd == 'y': {.linearScanEnd.}
-        'y'
-      of 'Z':
-        when linearScanEnd == 'z': {.linearScanEnd.}
-        'z'
+      of 'A': 'a'
+      of 'B': 'b'
+      of 'C': 'c'
+      of 'D': 'd'
+      of 'E': 'e'
+      of 'F': 'f'
+      of 'G': 'g'
+      of 'H': 'h'
+      of 'I': 'i'
+      of 'J': 'j'
+      of 'K': 'k'
+      of 'L': 'l'
+      of 'M': 'm'
+      of 'N': 'n'
+      of 'O': 'o'
+      of 'P': 'p'
+      of 'Q': 'q'
+      of 'R': 'r'
+      of 'S': 's'
+      of 'T': 't'
+      of 'U': 'u'
+      of 'V': 'v'
+      of 'W': 'w'
+      of 'X': 'x'
+      of 'Y': 'y'
+      of 'Z': 'z'
       else: c
 
 
-  template toUpperAscii*(c: var char, linearScanEnd: static[char]) =
+  template toUpperAsciiInPlace*(c: var char) =
     ## Converts character `c` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
     ## <unicode.html#toUpper,Rune>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   var character = 'F'  ## Hexadecimal
-    ##   toLowerAscii(character, linearScanEnd = 'f')
-    ##   doAssert character == 'f'
-    ##
     ## See also:
     ## * `isLowerAscii proc<#isLowerAscii,char>`_
     ## * `toUpperAscii proc<#toUpperAscii,string>`_ for converting a string
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var character = 'f'
-      toUpperAscii(character, linearScanEnd = 'f')
+      toUpperAsciiInPlace(character)
       doAssert character == 'F'
       var chara = 'z'
-      toUpperAscii(chara, linearScanEnd = ' ')
+      toUpperAsciiInPlace(chara)
       doAssert chara == 'Z'
     c = case c
-      of 'a':
-        when linearScanEnd == 'a': {.linearScanEnd.}
-        'A'
-      of 'b':
-        when linearScanEnd == 'b': {.linearScanEnd.}
-        'B'
-      of 'c':
-        when linearScanEnd == 'c': {.linearScanEnd.}
-        'C'
-      of 'd':
-        when linearScanEnd == 'd': {.linearScanEnd.}
-        'D'
-      of 'e':
-        when linearScanEnd == 'e': {.linearScanEnd.}
-        'E'
-      of 'f':
-        when linearScanEnd == 'f': {.linearScanEnd.}
-        'F'
-      of 'g':
-        when linearScanEnd == 'g': {.linearScanEnd.}
-        'G'
-      of 'h':
-        when linearScanEnd == 'h': {.linearScanEnd.}
-        'H'
-      of 'i':
-        when linearScanEnd == 'i': {.linearScanEnd.}
-        'I'
-      of 'j':
-        when linearScanEnd == 'j': {.linearScanEnd.}
-        'J'
-      of 'k':
-        when linearScanEnd == 'k': {.linearScanEnd.}
-        'K'
-      of 'l':
-        when linearScanEnd == 'l': {.linearScanEnd.}
-        'L'
-      of 'm':
-        when linearScanEnd == 'm': {.linearScanEnd.}
-        'M'
-      of 'n':
-        when linearScanEnd == 'n': {.linearScanEnd.}
-        'N'
-      of 'o':
-        when linearScanEnd == 'o': {.linearScanEnd.}
-        'O'
-      of 'p':
-        when linearScanEnd == 'p': {.linearScanEnd.}
-        'P'
-      of 'q':
-        when linearScanEnd == 'q': {.linearScanEnd.}
-        'Q'
-      of 'r':
-        when linearScanEnd == 'r': {.linearScanEnd.}
-        'R'
-      of 's':
-        when linearScanEnd == 's': {.linearScanEnd.}
-        'S'
-      of 't':
-        when linearScanEnd == 't': {.linearScanEnd.}
-        'T'
-      of 'u':
-        when linearScanEnd == 'u': {.linearScanEnd.}
-        'U'
-      of 'v':
-        when linearScanEnd == 'v': {.linearScanEnd.}
-        'V'
-      of 'w':
-        when linearScanEnd == 'w': {.linearScanEnd.}
-        'W'
-      of 'x':
-        when linearScanEnd == 'x': {.linearScanEnd.}
-        'X'
-      of 'y':
-        when linearScanEnd == 'y': {.linearScanEnd.}
-        'Y'
-      of 'z':
-        when linearScanEnd == 'z': {.linearScanEnd.}
-        'Z'
+      of 'a': 'A'
+      of 'b': 'B'
+      of 'c': 'C'
+      of 'd': 'D'
+      of 'e': 'E'
+      of 'f': 'F'
+      of 'g': 'G'
+      of 'h': 'H'
+      of 'i': 'I'
+      of 'j': 'J'
+      of 'k': 'K'
+      of 'l': 'L'
+      of 'm': 'M'
+      of 'n': 'N'
+      of 'o': 'O'
+      of 'p': 'P'
+      of 'q': 'Q'
+      of 'r': 'R'
+      of 's': 'S'
+      of 't': 'T'
+      of 'u': 'U'
+      of 'v': 'V'
+      of 'w': 'W'
+      of 'x': 'X'
+      of 'y': 'Y'
+      of 'z': 'Z'
       else: c
 
 
-  func toLowerAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
+  func toLowerAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into lower case.
     ##
     ## This works only for the letters ``A-Z``. See `unicode.toLower
     ## <unicode.html#toLower,string>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char`` argument,
-    ## if it is on range ``'a'..'z'`` then it will add ``{.linearScanEnd.}`` pragma
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``,
-    ## this is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   echo toLowerAscii("#FFFFFF", linearScanEnd = 'f') ## Hexadecimal
-    ##
     ## See also:
     ## * `normalize proc<#normalize,string>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var stringy = "ABCDEF"
-      toLowerAscii(stringy, linearScanEnd = 'f')
+      toLowerAsciiInPlace(stringy)
       doAssert stringy == "abcdef"
       var strng = "NIM"
-      toLowerAscii(strng, linearScanEnd = 'n')
+      toLowerAsciiInPlace(strng)
       doAssert strng == "nim"
     var i = 0
     for c in mitems(s):
-      toLowerAscii(c, linearScanEnd)
+      toLowerAsciiInPlace(c)
       s[i] = c
       inc i
 
 
-  func toUpperAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
+  func toUpperAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.  See `unicode.toUpper
     ## <unicode.html#toUpper,string>`_ for a version that works for any Unicode
     ## character.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   echo toUpperAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
-    ##   echo toUpperAscii("acgt", linearScanEnd = 't')    ## DNA data
-    ##
     ## See also:
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var stringo = "abcdef"
-      toUpperAscii(stringo, linearScanEnd = 'f')
+      toUpperAsciiInPlace(stringo)
       doAssert stringo == "ABCDEF"
       var strng = "nim"
-      toUpperAscii(strng, linearScanEnd = 'n')
+      toUpperAsciiInPlace(strng)
       doAssert strng == "NIM"
     var i = 0
     for c in mitems(s):
-      toUpperAscii(c, linearScanEnd)
+      toUpperAsciiInPlace(c)
       s[i] = c
       inc i
 
 
-  func capitalizeAscii*(s: var string, linearScanEnd: static[char]) {.inline.} =
+  func capitalizeAsciiInPlace*(s: var string) {.inline.} =
     ## Converts the first character of string `s` into upper case.
     ##
     ## This works only for the letters ``A-Z``.
     ## Use `Unicode module<unicode.html>`_ for UTF-8 support.
     ##
-    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
-    ## if the char is on the range ``'a'..'z'`` then it will add a
-    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
-    ## at compile-time at that char position, reducing the case switch linear scan.
-    ##
-    ## Example: Imagine that you are working with Hexadecimal strings,
-    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
-    ## This is an optional compile-time optimization, is disabled by default.
-    ##
-    ## .. code-block:: nim
-    ##   echo capitalizeAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
-    ##   echo capitalizeAscii("acgt", linearScanEnd = 't')    ## DNA data
-    ##
     ## See also:
     ## * `toUpperAscii proc<#toUpperAscii,char>`_
-    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
     runnableExamples:
       var stringu = "foo"
-      capitalizeAscii(stringu, linearScanEnd = 'f')
+      capitalizeAsciiInPlace(stringu)
       doAssert stringu == "Foo"
       var stringx = "-bar"
-      capitalizeAscii(stringx, linearScanEnd = 'r')
+      capitalizeAsciiInPlace(stringx)
       doAssert stringx == "-bar"
-    toUpperAscii(s[0], linearScanEnd)
+    toUpperAsciiInPlace(s[0])
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,44 +2862,10 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAsciiInPlace*(c: var char) =
-    ## Returns the lower case version of character ``c``.
-    ##
-    ## This works only for the letters ``A-Z``. See `unicode.toLower
-    ## <unicode.html#toLower,Rune>`_ for a version that works for any Unicode
-    ## character.
-    ##
-    ## See also:
-    ## * `isLowerAscii proc<#isLowerAscii,char>`_
-    ## * `toLowerAscii proc<#toLowerAscii,string>`_ for converting a string
-    runnableExamples:
-      var character = 'F'
-      toLowerAsciiInPlace(character)
-      doAssert character == 'f'
-      var chara = 'A'
-      toLowerAsciiInPlace(chara)
-      doAssert chara == 'a'
+  template toLowerAsciiInPlace(c: var char) =
     if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
 
-
-  template toUpperAsciiInPlace*(c: var char) =
-    ## Converts character `c` into upper case.
-    ##
-    ## This works only for the letters ``A-Z``.  See `unicode.toUpper
-    ## <unicode.html#toUpper,Rune>`_ for a version that works for any Unicode
-    ## character.
-    ##
-    ## See also:
-    ## * `isLowerAscii proc<#isLowerAscii,char>`_
-    ## * `toUpperAscii proc<#toUpperAscii,string>`_ for converting a string
-    ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
-    runnableExamples:
-      var character = 'f'
-      toUpperAsciiInPlace(character)
-      doAssert character == 'F'
-      var chara = 'z'
-      toUpperAsciiInPlace(chara)
-      doAssert chara == 'Z'
+  template toUpperAsciiInPlace(c: var char) =
     if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
 
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -215,7 +215,7 @@ template toImpl(call) =
   for i in 0..len(s) - 1:
     result[i] = call(s[i])
 
-proc toLowerAscii*(s: string): string {.inline, noSideEffect, procvar,
+proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
   rtl, extern: "nsuToLowerAsciiStr".} =
   ## Converts string `s` into lower case.
   ##
@@ -249,7 +249,7 @@ proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   else:
     result = c
 
-proc toUpperAscii*(s: string): string {.inline, noSideEffect, procvar,
+proc toUpperAscii*(s: string): string {.noSideEffect, procvar,
   rtl, extern: "nsuToUpperAsciiStr".} =
   ## Converts string `s` into upper case.
   ##

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2878,11 +2878,8 @@ since (1, 1):
       var strng = "NIM"
       toLowerAsciiInPlace(strng)
       doAssert strng == "nim"
-    var i = 0
     for c in mitems(s):
       if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
-      s[i] = c
-      inc i
 
 
   func toUpperAsciiInPlace*(s: var string) {.inline.} =
@@ -2901,11 +2898,8 @@ since (1, 1):
       var strng = "nim"
       toUpperAsciiInPlace(strng)
       doAssert strng == "NIM"
-    var i = 0
     for c in mitems(s):
       if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
-      s[i] = c
-      inc i
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2862,13 +2862,6 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
 
 
 since (1, 1):
-  template toLowerAsciiInPlace(c: var char) =
-    if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
-
-  template toUpperAsciiInPlace(c: var char) =
-    if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
-
-
   func toLowerAsciiInPlace*(s: var string) {.inline.} =
     ## Converts string `s` into lower case.
     ##
@@ -2887,7 +2880,7 @@ since (1, 1):
       doAssert strng == "nim"
     var i = 0
     for c in mitems(s):
-      toLowerAsciiInPlace(c)
+      if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
       s[i] = c
       inc i
 
@@ -2910,27 +2903,9 @@ since (1, 1):
       doAssert strng == "NIM"
     var i = 0
     for c in mitems(s):
-      toUpperAsciiInPlace(c)
+      if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
       s[i] = c
       inc i
-
-
-  func capitalizeAsciiInPlace*(s: var string) {.inline.} =
-    ## Converts the first character of string `s` into upper case.
-    ##
-    ## This works only for the letters ``A-Z``.
-    ## Use `Unicode module<unicode.html>`_ for UTF-8 support.
-    ##
-    ## See also:
-    ## * `toUpperAscii proc<#toUpperAscii,char>`_
-    runnableExamples:
-      var stringu = "foo"
-      capitalizeAsciiInPlace(stringu)
-      doAssert stringu == "Foo"
-      var stringx = "-bar"
-      capitalizeAsciiInPlace(stringx)
-      doAssert stringx == "-bar"
-    toUpperAsciiInPlace(s[0])
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2875,9 +2875,8 @@ since (1, 1):
       var x = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
       toLowerAsciiInPlace(x)
       doAssert x == "abcdefghijklmnopqrstuvwxyz01234567890abcdefghijklmnopqrstuvwxyz*+,-./:;<=>?@[]_{|}~"
-    const t = "abcdefghijklmnopqrstuvwxyz".indent(65).cstring
     for c in mitems(s):
-      if c in {'A'..'Z'}: c = t[c.ord]
+      if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
 
 
   func toUpperAsciiInPlace*(s: var string) {.inline.} =
@@ -2893,9 +2892,8 @@ since (1, 1):
       var z = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
       toUpperAsciiInPlace(z)
       doAssert z == "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
-    const t = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indent(97).cstring
     for c in mitems(s):
-      if c in {'a'..'z'}: c = t[c.ord]
+      if c in {'a'..'z'}: c = chr(ord(c) - ord('A') + ord('a'))
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2873,7 +2873,7 @@ since (1, 1):
     ## * `normalize proc<#normalize,string>`_
     runnableExamples:
       var x = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
-      toLowerAscii(x)
+      toLowerAsciiInPlace(x)
       doAssert x == "abcdefghijklmnopqrstuvwxyz01234567890abcdefghijklmnopqrstuvwxyz*+,-./:;<=>?@[]_{|}~"
     const t = "abcdefghijklmnopqrstuvwxyz".indent(65).cstring
     for c in mitems(s):
@@ -2891,7 +2891,7 @@ since (1, 1):
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
     runnableExamples:
       var z = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
-      toUpperAscii(z)
+      toUpperAsciiInPlace(z)
       doAssert z == "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
     const t = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indent(97).cstring
     for c in mitems(s):

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2872,14 +2872,12 @@ since (1, 1):
     ## See also:
     ## * `normalize proc<#normalize,string>`_
     runnableExamples:
-      var stringy = "ABCDEF"
-      toLowerAsciiInPlace(stringy)
-      doAssert stringy == "abcdef"
-      var strng = "NIM"
-      toLowerAsciiInPlace(strng)
-      doAssert strng == "nim"
+      var x = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
+      toLowerAscii(x)
+      doAssert x == "abcdefghijklmnopqrstuvwxyz01234567890abcdefghijklmnopqrstuvwxyz*+,-./:;<=>?@[]_{|}~"
+    const t = "abcdefghijklmnopqrstuvwxyz".indent(65).cstring
     for c in mitems(s):
-      if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
+      if c in {'A'..'Z'}: c = t[c.ord]
 
 
   func toUpperAsciiInPlace*(s: var string) {.inline.} =
@@ -2892,14 +2890,12 @@ since (1, 1):
     ## See also:
     ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
     runnableExamples:
-      var stringo = "abcdef"
-      toUpperAsciiInPlace(stringo)
-      doAssert stringo == "ABCDEF"
-      var strng = "nim"
-      toUpperAsciiInPlace(strng)
-      doAssert strng == "NIM"
+      var z = "abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
+      toUpperAscii(z)
+      doAssert z == "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
+    const t = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indent(97).cstring
     for c in mitems(s):
-      if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
+      if c in {'a'..'z'}: c = t[c.ord]
 
 
 when isMainModule:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2860,6 +2860,341 @@ proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
   ## Alias for isEmptyOrWhitespace
   result = isEmptyOrWhitespace(s)
 
+
+since (1, 1):
+  template toLowerAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+    ## Returns the lower case version of character ``c``.
+    ##
+    ## This works only for the letters ``A-Z``. See `unicode.toLower
+    ## <unicode.html#toLower,Rune>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   var character = 'F'  ## Hexadecimal
+    ##   toLowerAscii(character, linearScanEnd = 'f')
+    ##   doAssert character == 'f'
+    ##
+    ## See also:
+    ## * `isLowerAscii proc<#isLowerAscii,char>`_
+    ## * `toLowerAscii proc<#toLowerAscii,string>`_ for converting a string
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var character = 'F'
+      toLowerAscii(character, linearScanEnd = 'f')
+      doAssert character == 'f'
+      var chara = 'A'
+      toLowerAscii(chara)
+      doAssert chara == 'a'
+    c = case c
+      of 'A':
+        when linearScanEnd == 'a': {.linearScanEnd.}
+        'a'
+      of 'B':
+        when linearScanEnd == 'b': {.linearScanEnd.}
+        'b'
+      of 'C':
+        when linearScanEnd == 'c': {.linearScanEnd.}
+        'c'
+      of 'D':
+        when linearScanEnd == 'd': {.linearScanEnd.}
+        'd'
+      of 'E':
+        when linearScanEnd == 'e': {.linearScanEnd.}
+        'e'
+      of 'F':
+        when linearScanEnd == 'f': {.linearScanEnd.}
+        'f'
+      of 'G':
+        when linearScanEnd == 'g': {.linearScanEnd.}
+        'g'
+      of 'H':
+        when linearScanEnd == 'h': {.linearScanEnd.}
+        'h'
+      of 'I':
+        when linearScanEnd == 'i': {.linearScanEnd.}
+        'i'
+      of 'J':
+        when linearScanEnd == 'j': {.linearScanEnd.}
+        'j'
+      of 'K':
+        when linearScanEnd == 'k': {.linearScanEnd.}
+        'k'
+      of 'L':
+        when linearScanEnd == 'l': {.linearScanEnd.}
+        'l'
+      of 'M':
+        when linearScanEnd == 'm': {.linearScanEnd.}
+        'm'
+      of 'N':
+        when linearScanEnd == 'n': {.linearScanEnd.}
+        'n'
+      of 'O':
+        when linearScanEnd == 'o': {.linearScanEnd.}
+        'o'
+      of 'P':
+        when linearScanEnd == 'p': {.linearScanEnd.}
+        'p'
+      of 'Q':
+        when linearScanEnd == 'q': {.linearScanEnd.}
+        'q'
+      of 'R':
+        when linearScanEnd == 'r': {.linearScanEnd.}
+        'r'
+      of 'S':
+        when linearScanEnd == 's': {.linearScanEnd.}
+        's'
+      of 'T':
+        when linearScanEnd == 't': {.linearScanEnd.}
+        't'
+      of 'U':
+        when linearScanEnd == 'u': {.linearScanEnd.}
+        'u'
+      of 'V':
+        when linearScanEnd == 'v': {.linearScanEnd.}
+        'v'
+      of 'W':
+        when linearScanEnd == 'w': {.linearScanEnd.}
+        'w'
+      of 'X':
+        when linearScanEnd == 'x': {.linearScanEnd.}
+        'x'
+      of 'Y':
+        when linearScanEnd == 'y': {.linearScanEnd.}
+        'y'
+      of 'Z':
+        when linearScanEnd == 'z': {.linearScanEnd.}
+        'z'
+      else: c
+
+
+  template toUpperAscii*(c: var char, linearScanEnd: static[char] = ' ') =
+    ## Converts character `c` into upper case.
+    ##
+    ## This works only for the letters ``A-Z``.  See `unicode.toUpper
+    ## <unicode.html#toUpper,Rune>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   var character = 'F'  ## Hexadecimal
+    ##   toLowerAscii(character, linearScanEnd = 'f')
+    ##   doAssert character == 'f'
+    ##
+    ## See also:
+    ## * `isLowerAscii proc<#isLowerAscii,char>`_
+    ## * `toUpperAscii proc<#toUpperAscii,string>`_ for converting a string
+    ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var character = 'f'
+      toUpperAscii(character, linearScanEnd = 'f')
+      doAssert character == 'F'
+      var chara = 'z'
+      toUpperAscii(chara)
+      doAssert chara == 'Z'
+    c = case c
+      of 'a':
+        when linearScanEnd == 'a': {.linearScanEnd.}
+        'A'
+      of 'b':
+        when linearScanEnd == 'b': {.linearScanEnd.}
+        'B'
+      of 'c':
+        when linearScanEnd == 'c': {.linearScanEnd.}
+        'C'
+      of 'd':
+        when linearScanEnd == 'd': {.linearScanEnd.}
+        'D'
+      of 'e':
+        when linearScanEnd == 'e': {.linearScanEnd.}
+        'E'
+      of 'f':
+        when linearScanEnd == 'f': {.linearScanEnd.}
+        'F'
+      of 'g':
+        when linearScanEnd == 'g': {.linearScanEnd.}
+        'G'
+      of 'h':
+        when linearScanEnd == 'h': {.linearScanEnd.}
+        'H'
+      of 'i':
+        when linearScanEnd == 'i': {.linearScanEnd.}
+        'I'
+      of 'j':
+        when linearScanEnd == 'j': {.linearScanEnd.}
+        'J'
+      of 'k':
+        when linearScanEnd == 'k': {.linearScanEnd.}
+        'K'
+      of 'l':
+        when linearScanEnd == 'l': {.linearScanEnd.}
+        'L'
+      of 'm':
+        when linearScanEnd == 'm': {.linearScanEnd.}
+        'M'
+      of 'n':
+        when linearScanEnd == 'n': {.linearScanEnd.}
+        'N'
+      of 'o':
+        when linearScanEnd == 'o': {.linearScanEnd.}
+        'O'
+      of 'p':
+        when linearScanEnd == 'p': {.linearScanEnd.}
+        'P'
+      of 'q':
+        when linearScanEnd == 'q': {.linearScanEnd.}
+        'Q'
+      of 'r':
+        when linearScanEnd == 'r': {.linearScanEnd.}
+        'R'
+      of 's':
+        when linearScanEnd == 's': {.linearScanEnd.}
+        'S'
+      of 't':
+        when linearScanEnd == 't': {.linearScanEnd.}
+        'T'
+      of 'u':
+        when linearScanEnd == 'u': {.linearScanEnd.}
+        'U'
+      of 'v':
+        when linearScanEnd == 'v': {.linearScanEnd.}
+        'V'
+      of 'w':
+        when linearScanEnd == 'w': {.linearScanEnd.}
+        'W'
+      of 'x':
+        when linearScanEnd == 'x': {.linearScanEnd.}
+        'X'
+      of 'y':
+        when linearScanEnd == 'y': {.linearScanEnd.}
+        'Y'
+      of 'z':
+        when linearScanEnd == 'z': {.linearScanEnd.}
+        'Z'
+      else: c
+
+
+  func toLowerAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+    ## Converts string `s` into lower case.
+    ##
+    ## This works only for the letters ``A-Z``. See `unicode.toLower
+    ## <unicode.html#toLower,string>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char`` argument,
+    ## if it is on range ``'a'..'z'`` then it will add ``{.linearScanEnd.}`` pragma
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``,
+    ## this is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   echo toLowerAscii("#FFFFFF", linearScanEnd = 'f') ## Hexadecimal
+    ##
+    ## See also:
+    ## * `normalize proc<#normalize,string>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var stringy = "ABCDEF"
+      toLowerAscii(stringy, linearScanEnd = 'f')
+      doAssert stringy == "abcdef"
+      var strng = "NIM"
+      toLowerAscii(strng)
+      doAssert strng == "nim"
+    var i = 0
+    for c in mitems(s):
+      toLowerAscii(c, linearScanEnd)
+      s[i] = c
+      inc i
+
+
+  func toUpperAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+    ## Converts string `s` into upper case.
+    ##
+    ## This works only for the letters ``A-Z``.  See `unicode.toUpper
+    ## <unicode.html#toUpper,string>`_ for a version that works for any Unicode
+    ## character.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   echo toUpperAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
+    ##   echo toUpperAscii("acgt", linearScanEnd = 't')    ## DNA data
+    ##
+    ## See also:
+    ## * `capitalizeAscii proc<#capitalizeAscii,string>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var stringo = "abcdef"
+      toUpperAscii(stringo, linearScanEnd = 'f')
+      doAssert stringo == "ABCDEF"
+      var strng = "nim"
+      toUpperAscii(strng)
+      doAssert strng == "NIM"
+    var i = 0
+    for c in mitems(s):
+      toUpperAscii(c, linearScanEnd)
+      s[i] = c
+      inc i
+
+
+  func capitalizeAscii*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
+    ## Converts the first character of string `s` into upper case.
+    ##
+    ## This works only for the letters ``A-Z``.
+    ## Use `Unicode module<unicode.html>`_ for UTF-8 support.
+    ##
+    ## ``linearScanEnd`` is a static ``char``, must be known at compile-time,
+    ## if the char is on the range ``'a'..'z'`` then it will add a
+    ## `{. linearScanEnd .} pragma <manual.html#pragmas-linearscanend-pragma>`_
+    ## at compile-time at that char position, reducing the case switch linear scan.
+    ##
+    ## Example: Imagine that you are working with Hexadecimal strings,
+    ## you do not have letters beyond ``'F'``, you can use ``linearScanEnd = 'f'``.
+    ## This is an optional compile-time optimization, is disabled by default.
+    ##
+    ## .. code-block:: nim
+    ##   echo capitalizeAscii("#ffffff", linearScanEnd = 'f') ## Hexadecimal
+    ##   echo capitalizeAscii("acgt", linearScanEnd = 't')    ## DNA data
+    ##
+    ## See also:
+    ## * `toUpperAscii proc<#toUpperAscii,char>`_
+    ## * `linearScanEnd <manual.html#pragmas-linearscanend-pragma>`_ pragma
+    runnableExamples:
+      var stringu = "foo"
+      capitalizeAscii(stringu, linearScanEnd = 'f')
+      doAssert stringu == "Foo"
+      var stringx = "-bar"
+      capitalizeAscii(stringx, linearScanEnd = 'f')
+      doAssert stringx == "-bar"
+    toUpperAscii(s[0], linearScanEnd)
+
+
 when isMainModule:
   proc nonStaticTests =
     doAssert formatBiggestFloat(1234.567, ffDecimal, -1) == "1234.567000"

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2879,34 +2879,7 @@ since (1, 1):
       var chara = 'A'
       toLowerAsciiInPlace(chara)
       doAssert chara == 'a'
-    c = case c
-      of 'A': 'a'
-      of 'B': 'b'
-      of 'C': 'c'
-      of 'D': 'd'
-      of 'E': 'e'
-      of 'F': 'f'
-      of 'G': 'g'
-      of 'H': 'h'
-      of 'I': 'i'
-      of 'J': 'j'
-      of 'K': 'k'
-      of 'L': 'l'
-      of 'M': 'm'
-      of 'N': 'n'
-      of 'O': 'o'
-      of 'P': 'p'
-      of 'Q': 'q'
-      of 'R': 'r'
-      of 'S': 's'
-      of 'T': 't'
-      of 'U': 'u'
-      of 'V': 'v'
-      of 'W': 'w'
-      of 'X': 'x'
-      of 'Y': 'y'
-      of 'Z': 'z'
-      else: c
+    if c in {'A'..'Z'}: c = chr(ord(c) + (ord('a') - ord('A')))
 
 
   template toUpperAsciiInPlace*(c: var char) =
@@ -2927,34 +2900,7 @@ since (1, 1):
       var chara = 'z'
       toUpperAsciiInPlace(chara)
       doAssert chara == 'Z'
-    c = case c
-      of 'a': 'A'
-      of 'b': 'B'
-      of 'c': 'C'
-      of 'd': 'D'
-      of 'e': 'E'
-      of 'f': 'F'
-      of 'g': 'G'
-      of 'h': 'H'
-      of 'i': 'I'
-      of 'j': 'J'
-      of 'k': 'K'
-      of 'l': 'L'
-      of 'm': 'M'
-      of 'n': 'N'
-      of 'o': 'O'
-      of 'p': 'P'
-      of 'q': 'Q'
-      of 'r': 'R'
-      of 's': 'S'
-      of 't': 'T'
-      of 'u': 'U'
-      of 'v': 'V'
-      of 'w': 'W'
-      of 'x': 'X'
-      of 'y': 'Y'
-      of 'z': 'Z'
-      else: c
+    if c in {'a'..'z'}: c = chr(ord(c) - (ord('a') - ord('A')))
 
 
   func toLowerAsciiInPlace*(s: var string) {.inline.} =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2893,7 +2893,7 @@ since (1, 1):
       toUpperAsciiInPlace(z)
       doAssert z == "ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ*+,-./:;<=>?@[]_{|}~"
     for c in mitems(s):
-      if c in {'a'..'z'}: c = chr(ord(c) - ord('A') + ord('a'))
+      if c in {'a'..'z'}: c = chr(ord(c) - ord('A') - ord('a'))
 
 
 when isMainModule:


### PR DESCRIPTION
- Add `strutils` in-place functions.
- Documentation with links and `code-block`, `runnableExamples`, `since`, changelog.
- Speed performance improves, worse case at least ~2x.

```console
$ nim c -r -d:release -d:danger example.nim
strutils.toLowerAscii
30 microseconds and 592 nanoseconds     4.005999999999975e-05
toLowerAscii2
9 microseconds and 729 nanoseconds     1.216100000000012e-05

$ nim c -r example.nim
strutils.toLowerAscii
70 microseconds and 935 nanoseconds     9.858399999999878e-05
toLowerAscii2
25 microseconds and 743 nanoseconds     4.490400000000012e-05
```

<details>
  <summary> Bench </summary>

Try yourself if you want:

```nim
import times
from strutils import toLowerAscii

template toLowerAscii2*(c: var char, linearScanEnd: static[char] = ' ') =
  c = case c
    of 'A':
      when linearScanEnd == 'a': {.linearScanEnd.}
      'a'
    of 'B':
      when linearScanEnd == 'b': {.linearScanEnd.}
      'b'
    of 'C':
      when linearScanEnd == 'c': {.linearScanEnd.}
      'c'
    of 'D':
      when linearScanEnd == 'd': {.linearScanEnd.}
      'd'
    of 'E':
      when linearScanEnd == 'e': {.linearScanEnd.}
      'e'
    of 'F':
      when linearScanEnd == 'f': {.linearScanEnd.}
      'f'
    of 'G':
      when linearScanEnd == 'g': {.linearScanEnd.}
      'g'
    of 'H':
      when linearScanEnd == 'h': {.linearScanEnd.}
      'h'
    of 'I':
      when linearScanEnd == 'i': {.linearScanEnd.}
      'i'
    of 'J':
      when linearScanEnd == 'j': {.linearScanEnd.}
      'j'
    of 'K':
      when linearScanEnd == 'k': {.linearScanEnd.}
      'k'
    of 'L':
      when linearScanEnd == 'l': {.linearScanEnd.}
      'l'
    of 'M':
      when linearScanEnd == 'm': {.linearScanEnd.}
      'm'
    of 'N':
      when linearScanEnd == 'n': {.linearScanEnd.}
      'n'
    of 'O':
      when linearScanEnd == 'o': {.linearScanEnd.}
      'o'
    of 'P':
      when linearScanEnd == 'p': {.linearScanEnd.}
      'p'
    of 'Q':
      when linearScanEnd == 'q': {.linearScanEnd.}
      'q'
    of 'R':
      when linearScanEnd == 'r': {.linearScanEnd.}
      'r'
    of 'S':
      when linearScanEnd == 's': {.linearScanEnd.}
      's'
    of 'T':
      when linearScanEnd == 't': {.linearScanEnd.}
      't'
    of 'U':
      when linearScanEnd == 'u': {.linearScanEnd.}
      'u'
    of 'V':
      when linearScanEnd == 'v': {.linearScanEnd.}
      'v'
    of 'W':
      when linearScanEnd == 'w': {.linearScanEnd.}
      'w'
    of 'X':
      when linearScanEnd == 'x': {.linearScanEnd.}
      'x'
    of 'Y':
      when linearScanEnd == 'y': {.linearScanEnd.}
      'y'
    of 'Z':
      when linearScanEnd == 'z': {.linearScanEnd.}
      'z'
    else: c

echo "strutils.toLowerAscii"
var char1: char
let t0 = now()
let t0a = cpuTime()
for _ in 0..99:
  char1 = 'A'
  discard strutils.toLowerAscii(char1)
echo now() - t0, '\t', cpuTime() - t0a

echo "toLowerAscii2"
var char0: char
let t1 = now()
let t1a = cpuTime()
for _ in 0..99:
  char0 = 'A'
  toLowerAscii2(char0, linearScanEnd = 'b')
echo now() - t1, '\t', cpuTime() - t1a

```

```nim
import times
from strutils import toLowerAscii

template toLowerAscii2*(c: var char, linearScanEnd: static[char] = ' ') =
  c = case c
    of 'A':
      when linearScanEnd == 'a': {.linearScanEnd.}
      'a'
    of 'B':
      when linearScanEnd == 'b': {.linearScanEnd.}
      'b'
    of 'C':
      when linearScanEnd == 'c': {.linearScanEnd.}
      'c'
    of 'D':
      when linearScanEnd == 'd': {.linearScanEnd.}
      'd'
    of 'E':
      when linearScanEnd == 'e': {.linearScanEnd.}
      'e'
    of 'F':
      when linearScanEnd == 'f': {.linearScanEnd.}
      'f'
    of 'G':
      when linearScanEnd == 'g': {.linearScanEnd.}
      'g'
    of 'H':
      when linearScanEnd == 'h': {.linearScanEnd.}
      'h'
    of 'I':
      when linearScanEnd == 'i': {.linearScanEnd.}
      'i'
    of 'J':
      when linearScanEnd == 'j': {.linearScanEnd.}
      'j'
    of 'K':
      when linearScanEnd == 'k': {.linearScanEnd.}
      'k'
    of 'L':
      when linearScanEnd == 'l': {.linearScanEnd.}
      'l'
    of 'M':
      when linearScanEnd == 'm': {.linearScanEnd.}
      'm'
    of 'N':
      when linearScanEnd == 'n': {.linearScanEnd.}
      'n'
    of 'O':
      when linearScanEnd == 'o': {.linearScanEnd.}
      'o'
    of 'P':
      when linearScanEnd == 'p': {.linearScanEnd.}
      'p'
    of 'Q':
      when linearScanEnd == 'q': {.linearScanEnd.}
      'q'
    of 'R':
      when linearScanEnd == 'r': {.linearScanEnd.}
      'r'
    of 'S':
      when linearScanEnd == 's': {.linearScanEnd.}
      's'
    of 'T':
      when linearScanEnd == 't': {.linearScanEnd.}
      't'
    of 'U':
      when linearScanEnd == 'u': {.linearScanEnd.}
      'u'
    of 'V':
      when linearScanEnd == 'v': {.linearScanEnd.}
      'v'
    of 'W':
      when linearScanEnd == 'w': {.linearScanEnd.}
      'w'
    of 'X':
      when linearScanEnd == 'x': {.linearScanEnd.}
      'x'
    of 'Y':
      when linearScanEnd == 'y': {.linearScanEnd.}
      'y'
    of 'Z':
      when linearScanEnd == 'z': {.linearScanEnd.}
      'z'
    else: c

func toLowerAscii2*(s: var string, linearScanEnd: static[char] = ' ') {.inline.} =
  var i = 0
  for c in mitems(s):
    toLowerAscii2(c, linearScanEnd)
    s[i] = c
    inc i

echo "strutils.toLowerAscii"
var str0: string
let t0 = now()
let t0a = cpuTime()
for _ in 0..99:
  str0 = "ABCDEF"
  discard strutils.toLowerAscii(str0)
echo now() - t0, '\t', cpuTime() - t0a

echo "toLowerAscii2"
var str1: string
let t1 = now()
let t1a = cpuTime()
for _ in 0..99:
  str1 = "ABCDEF"
  toLowerAscii2(str1, linearScanEnd = 'f')
echo now() - t1, '\t', cpuTime() - t1a

```

</details>
