### PR TITLE
[TODO] [WIP] new std/timers module for high performance / low overhead timers and benchmarking (formerly system/timers include)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -103,6 +103,8 @@ echo f
 - Added `times.isLeapDay`
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
+- Added a new module, `std / timers` for high performance timers, more suitable
+  for benchmarking than `times.cpuTime`.
 
 ## Library changes
 

--- a/doc/gc.rst
+++ b/doc/gc.rst
@@ -85,8 +85,7 @@ disabled).
 Time measurement
 ----------------
 
-The GC's way of measuring time uses (see ``lib/system/timers.nim`` for the
-implementation):
+The GC's way of measuring time uses (see ``std/timers`` for the implementation):
 
 1) ``QueryPerformanceCounter`` and ``QueryPerformanceFrequency`` on Windows.
 2) ``mach_absolute_time`` on Mac OS X.

--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -29,7 +29,7 @@ when not nimCoroutines and not defined(nimdoc):
 
 import os
 import lists
-include system/timers
+import std/timers
 
 const defaultStackSize = 512 * 1024
 

--- a/lib/pure/nimprof.nim
+++ b/lib/pure/nimprof.nim
@@ -23,7 +23,7 @@ when defined(nimHasUsed):
 import hashes, algorithm, strutils, tables, sets
 
 when not defined(memProfiler):
-  include "system/timers"
+  import std/timers
 
 const
   withThreads = compileOption("threads")

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2537,7 +2537,8 @@ when not defined(js):
 
   proc cpuTime*(): float {.tags: [TimeEffect].} =
     ## gets time spent that the CPU spent to run the current process in
-    ## seconds. This may be more useful for benchmarking than ``epochTime``.
+    ## seconds. For benchmarking, use `timers.getTicks` instead, which has
+    ## highest resolution and least overhead.
     ## However, it may measure the real time instead (depending on the OS).
     ## The value of the result has no meaning.
     ## To generate useful timing values, take the difference between

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -24,7 +24,7 @@ const
   withRealTime = defined(useRealtimeGC)
 
 when withRealTime and not declared(getTicks):
-  include "system/timers"
+  import std/timers
 when defined(memProfiler):
   proc nimProfile(requestedSize: int) {.benign.}
 

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -28,7 +28,7 @@ const
   withRealTime = defined(useRealtimeGC)
 
 when withRealTime and not declared(getTicks):
-  include "system/timers"
+  import std/timers
 when defined(memProfiler):
   proc nimProfile(requestedSize: int) {.benign.}
 

--- a/lib/system/timers.nim
+++ b/lib/system/timers.nim
@@ -1,0 +1,3 @@
+{.deprecated: "import std/timers instead".}
+import std/timers
+export timers

--- a/tests/coroutines/titerators.nim
+++ b/tests/coroutines/titerators.nim
@@ -6,7 +6,7 @@ disabled: true
 # Timers are always flakey on the testing servers.
 
 import coro
-include system/timers
+import std/timers
 
 var
   stackCheckValue = 1100220033


### PR DESCRIPTION
This PR turns system/timers include into a new stdlib module std/timers.

`cpuTime` can be misleading for benchmarking because it adds a lot of overhead (for various reasons, including FP operations); so you get flawed conclusions unless the workload is significantly more expensive than the cost of `cpuTime`, which isn't always possible without affecting the thing you're measuring.
`getTicks` is more adequate, giving the highest timer precision and least overhead; in practice, this is what people use outside of nim (eg QueryPerformanceCounter / mach_absolute_time etc, which is wrapped by timers)

## example
on local OSX, this shows getTicks has an overhead of 16ns, vs 450ns for cpuTime, ie 27X less overhead.
`getTicks` also has the highest available precision on a given machine using platform specific API's (the benchmark below doesn't measure this)

```nim
# include system/timers
# import t10333b
import std/timers
include times
proc toSeconds(a: Nanos): float = a.float*1e-9
proc toSeconds(a: float): float = a
template test(fun)=
  block:
    proc main()=
      let n = 10_000_000
      type T = type(fun()-fun())
      var dt: T
      for i in 0..<n:
        let t = fun()
        # code to benchmark here (intentionally empty)
        let t2 = fun()
        dt += t2-t
      echo "\n" & astToStr(fun) & ":"
      echo dt.toSeconds
      echo (dt.toSeconds * 1e9 / n.float).formatEng
      echo (n.float / dt.toSeconds).formatEng
    main()
test(getTicks)
test(cpuTime)
```
prints:
```
getTicks:
0.16410692
16.410692
60.9358825332e6

cpuTime:
4.509458000001094
450.9458000001
2.2175614009e6
```


## note
I added a dummy `system/timers.nim` with a deprecation msg; the only tested package that required it was https://krux02@bitbucket.org/krux02/tensordslnim.git
code the reliied on system/timers can avoid the warning by:
```nim
template imp = import std/timers
when compiles(imp()): imp() else: include system/timers
```
or (after 1.2 release) by checking on nim version