### PR TITLE
Fix the getSelection method.

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -103,6 +103,8 @@ type
     memory*: PerformanceMemory
     timing*: PerformanceTiming
 
+  Selection* {.importc.} = ref object ## see `docs<https://developer.mozilla.org/en-US/docs/Web/API/Selection>`_
+
   LocalStorage* {.importc.} = ref object
 
   Window* = ref WindowObj
@@ -1145,7 +1147,7 @@ proc createAttribute*(d: Document, identifier: cstring): Node
 proc getElementsByName*(d: Document, name: cstring): seq[Element]
 proc getElementsByTagName*(d: Document, name: cstring): seq[Element]
 proc getElementsByClassName*(d: Document, name: cstring): seq[Element]
-proc getSelection*(d: Document): cstring
+proc getSelection*(d: Document): Selection
 proc handleEvent*(d: Document, event: Event)
 proc open*(d: Document)
 proc releaseEvents*(d: Document, eventMask: int) {.deprecated.}
@@ -1234,6 +1236,11 @@ proc slice*(e: Blob, startindex: int = 0, endindex: int = e.size, contentType: c
 
 # Performance "methods"
 proc now*(p: Performance): float
+
+# Selection "methods"
+proc removeAllRanges*(s: Selection)
+converter toString*(s: Selection): cstring
+proc `$`*(s: Selection): string = $(s.toString())
 
 # LocalStorage "methods"
 proc getItem*(ls: LocalStorage, key: cstring): cstring


### PR DESCRIPTION
document.getSelection() actually returns a Selection object, not a cstring.

In the past this HTML method did return a DOMString but has not done this in a long time.

See this for current compatibility:
https://developer.mozilla.org/en-US/docs/Web/API/Selection#Browser_compatibility
https://caniuse.com/#search=getSelection

Nim currently returns a cstring. This kind of works because the object acts like a string since it has a .toString() method in javascript. So appears to work with a cstring but it does not totally work, here is how to break it:

```js
// it does not stringify like a string
JSON.stringify(document.getSelection())
"{}"
// this is how a string should look like
JSON.stringify("")
""""
// it only stringify only works like a string if you convert it:
JSON.stringify(document.getSelection().toString())
""""
```

This means Nim’s dom API is out of sync with browsers.

A great suggestion by @dom96 we use a converter to force Selection object to behind like a string for backward compatibility.

See: https://github.com/nim-lang/Nim/pull/13483#discussion_r389200274