### PR TITLE
fix #13633 fix koch boot crashing regression

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1138,7 +1138,7 @@ proc runJsonBuildInstructions*(conf: ConfigRef; projectfile: AbsoluteFile) =
 
   except:
     let e = getCurrentException()
-    quit "\ncaught exception:n" & e.msg & "\nstacktrace:\n" & e.getStackTrace() &
+    quit "\ncaught exception:\n" & e.msg & "\nstacktrace:\n" & e.getStackTrace() &
          "error evaluating JSON file: " & jsonFile.string
 
 proc genMappingFiles(conf: ConfigRef; list: CfileList): Rope =


### PR DESCRIPTION
#13606 used the same refactoring pattern in 2 places, it turns out one introduced a regression, and one introduced by accident a bugifx to HCR IIUC:

## accidental regression
fixed by this PR:
* fixes https://github.com/nim-lang/Nim/issues/13633 

## accidental bugfix
* by accident fixed a bug that's been there probably forever

```nim
var currIdx = 0	
  for it in list:	
    # call the C compiler for the .c file:	
    if it.flags.contains(CfileFlag.Cached): continue	
    var compileCmd = getCompileCFileCmd(conf, it, currIdx == list.len - 1, produceOutput=true)

=> 

for idx, it in conf.toCompile:
    # call the C compiler for the .c file:
    if CfileFlag.Cached in it.flags: continue
    let compileCmd = getCompileCFileCmd(conf, it, idx == conf.toCompile.len - 1, produceOutput=true)
```

so before https://github.com/nim-lang/Nim/pull/13606, when at least one file was cached (`if it.flags.contains(CfileFlag.Cached): continue	`), `currIdx == list.len - 1` would be always false, so `isMainFile` would be false even for the main module in `getCompileCFileCmd`, wrongly adding `-fpic` for the main module:
```
  if (optGenDynLib in conf.globalOptions or (conf.hcrOn and not isMainFile)) and
      ospNeedsPIC in platform.OS[conf.target.targetOS].props:
    options.add(' ' & CC[c].pic)
```

