### PR TITLE
rename `lenTuple` and `lenVarargs`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -66,7 +66,7 @@
 - Added `sugar.collect` that does comprehension for seq/set/table collections.
 - Added `sugar.capture` for capturing some local loop variables when creating a closure.
   This is an enhanced version of `closureScope`.
-- Added `typetraits.lenTuple` to get number of elements of a tuple/type tuple,
+- Added `typetraits.tupleLen` to get number of elements of a tuple/type tuple,
   and `typetraits.get` to get the ith element of a type tuple.
 - Added `typetraits.genericParams` to return a tuple of generic params from a generic instantiation
 - Added `os.normalizePathEnd` for additional path sanitization.

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -187,7 +187,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     var operand = operand.skipTypes({tyGenericInst})
     let cond = operand.kind == tyTuple and operand.n != nil
     result = newIntNodeT(toInt128(ord(cond)), traitCall, c.graph)
-  of "lenTuple":
+  of "tupleLen":
     var operand = operand.skipTypes({tyGenericInst})
     assert operand.kind == tyTuple, $operand.kind
     result = newIntNodeT(toInt128(operand.len), traitCall, c.graph)

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -72,13 +72,13 @@ proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".}
   ## compile time error otherwise
 
 
-proc lenTuple*(T: typedesc[tuple]): int {.magic: "TypeTrait", since: (1, 1).}
+proc tupleLen*(T: typedesc[tuple]): int {.magic: "TypeTrait", since: (1, 1).}
   ## Return number of elements of `T`
 
 since (1, 1):
-  template lenTuple*(t: tuple): int =
+  template tupleLen*(t: tuple): int =
     ## Return number of elements of `t`
-    lenTuple(type(t))
+    tupleLen(type(t))
 
 since (1, 1):
   template get*(T: typedesc[tuple], i: static int): untyped =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2682,10 +2682,10 @@ when defined(nimV2):
   import system/repr_v2
   export repr_v2
 
-macro lenVarargs*(x: varargs[untyped]): int {.since: (1, 1).} =
+macro varargsLen*(x: varargs[untyped]): int {.since: (1, 1).} =
   ## returns number of variadic arguments in `x`
-  proc lenVarargsImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
-  lenVarargsImpl(x)
+  proc varargsLenImpl(x: NimNode): NimNode {.magic: "LengthOpenArray", noSideEffect.}
+  varargsLenImpl(x)
 
 when false:
   template eval*(blk: typed): typed =

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -92,40 +92,40 @@ block distinctBase:
         doAssert($distinctBase(typeof(b2)) == "string")
         doAssert($distinctBase(typeof(c2)) == "int")
 
-block: # lenTuple
-  doAssert not compiles(lenTuple(int))
+block: # tupleLen
+  doAssert not compiles(tupleLen(int))
 
   type
     MyTupleType = (int,float,string)
 
-  static: doAssert MyTupleType.lenTuple == 3
+  static: doAssert MyTupleType.tupleLen == 3
 
   type
     MyGenericTuple[T] = (T,int,float)
     MyGenericAlias = MyGenericTuple[string]
-  static: doAssert MyGenericAlias.lenTuple == 3
+  static: doAssert MyGenericAlias.tupleLen == 3
 
   type
     MyGenericTuple2[T,U] = (T,U,string)
     MyGenericTuple2Alias[T] =  MyGenericTuple2[T,int]
 
     MyGenericTuple2Alias2 =   MyGenericTuple2Alias[float]
-  static: doAssert MyGenericTuple2Alias2.lenTuple == 3
+  static: doAssert MyGenericTuple2Alias2.tupleLen == 3
 
-  static: doAssert (int, float).lenTuple == 2
-  static: doAssert (1, ).lenTuple == 1
-  static: doAssert ().lenTuple == 0
+  static: doAssert (int, float).tupleLen == 2
+  static: doAssert (1, ).tupleLen == 1
+  static: doAssert ().tupleLen == 0
 
   let x = (1,2,)
-  doAssert x.lenTuple == 2
-  doAssert ().lenTuple == 0
-  doAssert (1,).lenTuple == 1
-  doAssert (int,).lenTuple == 1
-  doAssert type(x).lenTuple == 2
-  doAssert type(x).default.lenTuple == 2
+  doAssert x.tupleLen == 2
+  doAssert ().tupleLen == 0
+  doAssert (1,).tupleLen == 1
+  doAssert (int,).tupleLen == 1
+  doAssert type(x).tupleLen == 2
+  doAssert type(x).default.tupleLen == 2
   type T1 = (int,float)
   type T2 = T1
-  doAssert T2.lenTuple == 2
+  doAssert T2.tupleLen == 2
 
 block genericParams:
   type Foo[T1, T2]=object

--- a/tests/system/tvarargslen.nim
+++ b/tests/system/tvarargslen.nim
@@ -1,9 +1,9 @@
 discard """
   output: '''
-tlenvarargs.nim:35:9 (1, 2)
-tlenvarargs.nim:36:9 12
-tlenvarargs.nim:37:9 1
-tlenvarargs.nim:38:8 
+tvarargslen.nim:35:9 (1, 2)
+tvarargslen.nim:36:9 12
+tvarargslen.nim:37:9 1
+tvarargslen.nim:38:8 
 done
 '''
 """
@@ -14,19 +14,19 @@ template myecho*(a: varargs[untyped]) =
   ## on macros.nim) so can be used in more contexts
   const info = instantiationInfo(-1, false)
   const loc = info.filename & ":" & $info.line & ":" & $info.column & " "
-  when lenVarargs(a) > 0:
+  when varargsLen(a) > 0:
     echo(loc, a)
   else:
     echo(loc)
 
 template fun*(a: varargs[untyped]): untyped =
-  lenVarargs(a)
+  varargsLen(a)
 
 template fun2*(a: varargs[typed]): untyped =
-  a.lenVarargs
+  a.varargsLen
 
 template fun3*(a: varargs[int]): untyped =
-  a.lenVarargs
+  a.varargsLen
 
 template fun4*(a: varargs[untyped]): untyped =
   len(a)
@@ -49,11 +49,12 @@ proc main()=
   doAssert fun3(10) == 1
   doAssert fun3(10, 11) == 2
 
-  ## shows why `lenVarargs` can't be named `len`
+  ## shows why `varargsLen` can't be named `len`
   doAssert fun4("abcdef") == len("abcdef")
 
   ## workaround for BUG:D20191218T171447 whereby if testament expected output ends
   ## in space, testament strips it from expected output but not actual output,
   ## which leads to a mismatch when running test via megatest
   echo "done"
+
 main()


### PR DESCRIPTION
Rationale:
- `lenTuple` is a tuple consisting of lengths (e.g. `(1, 5, 0)`),
- `tupleLen` is a length of a tuple (e.g. `tupleLen((1, 5, 0)) == 3`)