### PR TITLE
fix .deprecated. object typedef crash

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -497,9 +497,11 @@ proc suggestSym*(conf: ConfigRef; info: TLineInfo; s: PSym; usageSym: var PSym; 
 proc extractPragma(s: PSym): PNode =
   if s.kind in routineKinds:
     result = s.ast[pragmasPos]
-  elif s.kind in {skType, skVar, skLet} and s.ast[0].kind == nkPragmaExpr:
-    # s.ast = nkTypedef / nkPragmaExpr / [nkSym, nkPragma]
-    result = s.ast[0][1]
+  elif s.kind in {skType, skVar, skLet}:
+    if s.ast != nil and s.ast.len > 0:
+      if s.ast[0].kind == nkPragmaExpr and s.ast[0].len > 1:
+        # s.ast = nkTypedef / nkPragmaExpr / [nkSym, nkPragma]
+        result = s.ast[0][1]
   doAssert result == nil or result.kind == nkPragma
 
 proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =

--- a/nimsuggest/nimsuggest.nimble
+++ b/nimsuggest/nimsuggest.nimble
@@ -1,11 +1,8 @@
-[Package]
-name          = "nimsuggest"
 version       = "0.1.0"
 author        = "Andreas Rumpf"
 description   = "Tool for providing auto completion data for Nim source code."
 license       = "MIT"
 
-bin = "nimsuggest"
+bin = @["nimsuggest"]
 
-[Deps]
-Requires: "nim >= 0.11.2, compiler#head"
+requires "nim >= 1.1.1"

--- a/nimsuggest/tests/ttype_decl.nim
+++ b/nimsuggest/tests/ttype_decl.nim
@@ -1,5 +1,5 @@
 discard """
-disabled:false
+disabled:true
 $nimsuggest --tester --maxresults:3 $file
 >sug $1
 sug;;skType;;ttype_decl.Other;;Other;;$file;;11;;2;;"";;0;;None

--- a/nimsuggest/tests/ttype_decl.nim
+++ b/nimsuggest/tests/ttype_decl.nim
@@ -1,10 +1,10 @@
 discard """
-disabled:true
+disabled:false
 $nimsuggest --tester --maxresults:3 $file
 >sug $1
-sug;;skType;;ttype_decl.Other;;Other;;$file;;10;;2;;"";;0;;None
-sug;;skType;;system.int;;int;;$lib/system.nim;;25;;2;;"";;0;;None
-sug;;skType;;system.string;;string;;$lib/system.nim;;48;;2;;"";;0;;None
+sug;;skType;;ttype_decl.Other;;Other;;$file;;11;;2;;"";;0;;None
+sug;;skType;;system.int;;int;;$lib/system/basic_types.nim;;2;;2;;"";;0;;None
+sug;;skType;;system.string;;string;;$lib/system.nim;;34;;2;;"";;0;;None
 """
 import strutils
 type

--- a/nimsuggest/tests/ttype_decl.nim
+++ b/nimsuggest/tests/ttype_decl.nim
@@ -10,6 +10,8 @@ import strutils
 type
   Other = object ## My other object.
   Foo = #[!]#
+  OldOne {.deprecated.} = object
+    x: int
 
 proc main(f: Foo) =
 


### PR DESCRIPTION
I couldn't figure out how we're supposed to test `nimsuggest`, but at least a test does exist and the `.nimble` file works again.