### PR TITLE
fix `nim doc subdir/foo` which was generating broken css; + other fixes

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1082,6 +1082,7 @@ proc genSection(d: PDoc, kind: TSymKind) =
       ord(kind).rope, title, rope(ord(kind) + 50), d.toc[kind]])
 
 const nimdocOutCss = "nimdoc.out.css"
+  # `out` to make it easier to use with gitignore in user's repos
 
 proc cssHref(outDir: AbsoluteDir, destFile: AbsoluteFile): Rope =
   rope($relativeTo(outDir / nimdocOutCss.RelativeFile, destFile.splitFile().dir, '/'))
@@ -1149,15 +1150,15 @@ proc writeOutput*(d: PDoc, useWarning = false) =
   else:
     template outfile: untyped = d.destFile
     #let outfile = getOutFile2(d.conf, shortenDir(d.conf, filename), outExt, htmldocsDir)
-    createDir(outfile.splitFile.dir)
+    let dir = outfile.splitFile.dir
+    createDir(dir)
     updateOutfile(d, outfile)
     if not writeRope(content, outfile):
       rawMessage(d.conf, if useWarning: warnCannotOpenFile else: errCannotOpenFile,
         outfile.string)
     elif not d.wroteCss:
       let cssSource = $d.conf.getPrefixDir() / "doc" / "nimdoc.css"
-      let cssDest = $d.conf.outDir / nimdocOutCss
-        # renamed to make it easier to use with gitignore in user's repos
+      let cssDest = $dir / nimdocOutCss
       copyFile(cssSource, cssDest)
       d.wroteCss = true
 

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -54,6 +54,9 @@ proc nativeToUnix(path: string): string =
     result = replace(path, '\\', '/')
   else: result = path
 
+proc docOutDir(conf: ConfigRef, subdir: RelativeDir = RelativeDir""): AbsoluteDir =
+  if not conf.outDir.isEmpty: conf.outDir else: conf.projectPath / subdir
+
 proc presentationPath*(conf: ConfigRef, file: AbsoluteFile, isTitle = false): RelativeFile =
   ## returns a relative file that will be appended to outDir
   let file2 = $file
@@ -146,12 +149,11 @@ proc parseRst(text, filename: string,
 proc getOutFile2(conf: ConfigRef; filename: RelativeFile,
                  ext: string, dir: RelativeDir; guessTarget: bool): AbsoluteFile =
   if optWholeProject in conf.globalOptions:
-    let d = if conf.outDir.isEmpty: conf.projectPath / dir else: conf.outDir
+    let d = conf.docOutDir(dir)
     createDir(d)
     result = d / changeFileExt(filename, ext)
   elif guessTarget:
-    let d = if not conf.outDir.isEmpty: conf.outDir
-            else: conf.projectPath
+    let d = conf.docOutDir
     createDir(d)
     result = d / changeFileExt(filename, ext)
   elif not conf.outFile.isEmpty:
@@ -1079,8 +1081,10 @@ proc genSection(d: PDoc, kind: TSymKind) =
       "sectionid", "sectionTitle", "sectionTitleID", "content"], [
       ord(kind).rope, title, rope(ord(kind) + 50), d.toc[kind]])
 
+const nimdocOutCss = "nimdoc.out.css"
+
 proc cssHref(outDir: AbsoluteDir, destFile: AbsoluteFile): Rope =
-  rope($relativeTo(outDir / RelativeFile"nimdoc.out.css", destFile.splitFile().dir, '/'))
+  rope($relativeTo(outDir / nimdocOutCss.RelativeFile, destFile.splitFile().dir, '/'))
 
 proc genOutFile(d: PDoc): Rope =
   var
@@ -1127,15 +1131,14 @@ proc genOutFile(d: PDoc): Rope =
 
 proc generateIndex*(d: PDoc) =
   if optGenIndex in d.conf.globalOptions:
-    let dir = if not d.conf.outDir.isEmpty: d.conf.outDir
-              else: d.conf.projectPath / htmldocsDir
+    let dir = d.conf.docOutDir(htmldocsDir)
     createDir(dir)
     let dest = dir / changeFileExt(presentationPath(d.conf, AbsoluteFile d.filename), IndexExt)
     writeIndexFile(d[], dest.string)
 
 proc updateOutfile(d: PDoc, outfile: AbsoluteFile) =
   if d.module == nil or sfMainModule in d.module.flags: # nil for eg for commandRst2Html
-    if d.conf.outDir.isEmpty: d.conf.outDir = d.conf.projectPath
+    if d.conf.outDir.isEmpty: d.conf.outDir = d.conf.docOutDir
     if d.conf.outFile.isEmpty: d.conf.outFile = outfile.relativeTo(d.conf.outDir)
 
 proc writeOutput*(d: PDoc, useWarning = false) =
@@ -1153,7 +1156,7 @@ proc writeOutput*(d: PDoc, useWarning = false) =
         outfile.string)
     elif not d.wroteCss:
       let cssSource = $d.conf.getPrefixDir() / "doc" / "nimdoc.css"
-      let cssDest = $d.conf.outDir / "nimdoc.out.css"
+      let cssDest = $d.conf.outDir / nimdocOutCss
         # renamed to make it easier to use with gitignore in user's repos
       copyFile(cssSource, cssDest)
       d.wroteCss = true

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -12,9 +12,9 @@
 
 import
   ast, modules, idents, passes, condsyms,
-  options, sem, llstream, vm, vmdef, commands, msgs,
+  options, sem, llstream, vm, vmdef, commands,
   os, times, osproc, wordrecg, strtabs, modulegraphs,
-  lineinfos, pathutils
+  pathutils
 
 # we support 'cmpIgnoreStyle' natively for efficiency:
 from strutils import cmpIgnoreStyle, contains

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -52,7 +52,7 @@ pkg "nimcrypto", false, "nim c -r tests/testall.nim"
 pkg "NimData", true, "nim c -o:nimdataa src/nimdata.nim"
 pkg "nimes", true, "nim c src/nimes.nim"
 pkg "nimfp", true, "nim c -o:nfp -r src/fp.nim"
-#pkg "nimgame2", true, "nim c nimgame2/nimgame.nim"
+pkg "nimgame2", true, "nim c nimgame2/nimgame.nim"
 pkg "nimgen", true, "nim c -o:nimgenn -r src/nimgen/runcfg.nim"
 # pkg "nimlsp", true
 pkg "nimly", true

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -1,5 +1,5 @@
 discard """
-cmd: "nim c --nimcache:myNimCache --nimblePath:myNimblePath $file"
+cmd: "nim c --nimcache:build/myNimCache --nimblePath:myNimblePath $file"
 joinable: false
 """
 


### PR DESCRIPTION
* `nim doc subdir/foo` now doesn't generate broken css
before PR:
```
nim doc lib/js/dom.nim
```
writes css to `lib/js/nimdoc.out.css` and html to ./dom.html so the css file is at wrong place => broken css (unless user happened to have a ./nimdoc.out.css from some other prior command; keep that in mind if you're testing this PR)

after PR:
writes css to ./nimdoc.out.css, which fixes the html rendering

this also works correctly with -o, --outdir, --project, etc


* small cleanup refactoring in related code area
* unrelated: remove unused modules in compiler/scriptconfig.nim
* unrelated: tcompilesetting.nim: keep `git status` clean
before PR:
after running CI tests, it would create a `Nim/myNimCache` which makes `git status` not clean
after PR:
it gets created in `Nim/build/myNimCache` which is gitignored

* unrelated: re-enable pkg nimgame2 that got fixed upstream (see https://github.com/Vladar4/nimgame2/issues/40 if you need context)