### PR TITLE
fix `hash(HashSet)` which was incorrect; fix `hash(OrderedTable[string, JsonNode])` which was bad

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -18,7 +18,7 @@ from md5 import getMD5
 from sighashes import symBodyDigest
 from times import cpuTime
 
-from hashes import hash
+from hashes import hash, hashUInt64, hashUInt32
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -235,6 +235,11 @@ proc registerAdditionalOps*(c: PCtx) =
 
   registerCallback c, "stdlib.hashes.hashVmImplByte", hashVmImplByte
   registerCallback c, "stdlib.hashes.hashVmImplChar", hashVmImplByte
+
+  registerCallback c, "stdlib.hashes.hashUInt64", proc (a: VmArgs) {.nimcall.} =
+    a.setResult hashUInt64(cast[uint64](getInt(a, 0)))
+  registerCallback c, "stdlib.hashes.hashUInt32", proc (a: VmArgs) {.nimcall.} =
+    a.setResult hashUInt32(cast[uint32](getInt(a, 0)))
 
   if optBenchmarkVM in c.config.globalOptions:
     wrap0(cpuTime, timesop)

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -578,7 +578,7 @@ proc hash*[A](s: HashSet[A]): Hash =
   # This handles tombstones (iterating over all `s.data` would be wrong).
   # Iterating over items(s) requires a commutative hash combiner like `xor`
   # to avoid depending on order (which could differ for 2 HashSet's with different
-  # data.len but same elements, after insertions and deletions). But `xor`
+  # `data.len` but same elements, after insertions and deletions). But `xor`
   # has bad mixing properties (eg, would give 0 if HashSet contains
   # a, b such that hash(a) == hash(b) and a != b). `sort` should have low
   # overhead compared to the surrounding code.

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -571,24 +571,8 @@ proc map*[A, B](data: HashSet[A], op: proc (x: A): B {.closure.}): HashSet[B] =
   result = initHashSet[B]()
   for item in items(data): result.incl(op(item))
 
-from std/algorithm import sort
-
 proc hash*[A](s: HashSet[A]): Hash =
-  ## Hashing of HashSet.
-  # This handles tombstones (iterating over all `s.data` would be wrong).
-  # Iterating over items(s) requires a commutative hash combiner like `xor`
-  # to avoid depending on order (which could differ for 2 HashSet's with different
-  # `data.len` but same elements, after insertions and deletions), eg:
-  #   for h in s:
-  #     result = result xor hash(h)
-  # But `xor` has bad mixing properties (eg, would give 0 if HashSet contains
-  # a, b such that hash(a) == hash(b) and a != b). `sort` should have low
-  # overhead compared to the surrounding code.
-  var s2: seq[Hash]
-  for h in s: s2.add hash(h)
-  s2.sort
-  for h in s2: result = result !& hash(h)
-  result = !$result
+  hashUnordered(s)
 
 proc `$`*[A](s: HashSet[A]): string =
   ## Converts the set `s` to a string, mostly for logging and printing purposes.

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -571,11 +571,26 @@ proc map*[A, B](data: HashSet[A], op: proc (x: A): B {.closure.}): HashSet[B] =
   result = initHashSet[B]()
   for item in items(data): result.incl(op(item))
 
+from std/algorithm import sort
+
 proc hash*[A](s: HashSet[A]): Hash =
   ## Hashing of HashSet.
-  for h in 0 .. high(s.data):
-    if isFilledAndValid(s.data[h].hcode):
-      result = result xor s.data[h].hcode
+  # This handles tombstones (iterating over all `s.data` would be wrong).
+  # Iterating over items(s) requires a commutative hash combiner like `xor`
+  # to avoid depending on order (which could differ for 2 HashSet's with different
+  # data.len but same elements, after insertions and deletions). But `xor`
+  # has bad mixing properties (eg, would give 0 if HashSet contains
+  # a, b such that hash(a) == hash(b) and a != b). `sort` should have low
+  # overhead compared to the surrounding code.
+  when true:
+    var s2: seq[Hash]
+    for h in s: s2.add hash(h)
+    s2.sort
+    for h in s2: result = result !& hash(h)
+  else:
+    for h in 0 .. high(s.data):
+      if isFilledAndValid(s.data[h].hcode):
+        result = result xor s.data[h].hcode
   result = !$result
 
 proc `$`*[A](s: HashSet[A]): string =

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -578,19 +578,16 @@ proc hash*[A](s: HashSet[A]): Hash =
   # This handles tombstones (iterating over all `s.data` would be wrong).
   # Iterating over items(s) requires a commutative hash combiner like `xor`
   # to avoid depending on order (which could differ for 2 HashSet's with different
-  # `data.len` but same elements, after insertions and deletions). But `xor`
-  # has bad mixing properties (eg, would give 0 if HashSet contains
+  # `data.len` but same elements, after insertions and deletions), eg:
+  #   for h in s:
+  #     result = result xor hash(h)
+  # But `xor` has bad mixing properties (eg, would give 0 if HashSet contains
   # a, b such that hash(a) == hash(b) and a != b). `sort` should have low
   # overhead compared to the surrounding code.
-  when true:
-    var s2: seq[Hash]
-    for h in s: s2.add hash(h)
-    s2.sort
-    for h in s2: result = result !& hash(h)
-  else:
-    for h in 0 .. high(s.data):
-      if isFilledAndValid(s.data[h].hcode):
-        result = result xor s.data[h].hcode
+  var s2: seq[Hash]
+  for h in s: s2.add hash(h)
+  s2.sort
+  for h in s2: result = result !& hash(h)
   result = !$result
 
 proc `$`*[A](s: HashSet[A]): string =

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -506,6 +506,18 @@ template hashUnordered*(iter: untyped): Hash =
   result = !$ result
   result
 
+template hashOrdered*(iter: untyped): Hash =
+  ## Hashing of ordered elements. See also `hashUnordered`
+  mixin hash
+  var count = 0
+  var result: Hash
+  for ai in iter:
+    result = result !& hash(ai)
+    count.inc
+  result = result !& count # extra non-linear mixing with num elements
+  result = !$ result
+  result
+
 when isMainModule:
   block empty:
     var

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -446,7 +446,8 @@ proc hash*(n: JsonNode): Hash =
 
 proc hash*(n: OrderedTable[string, JsonNode]): Hash =
   for key, val in n:
-    result = result xor (hash(key) !& hash(val))
+    result = result !& hash(key)
+    result = result !& hash(val)
   result = !$result
 
 proc len*(n: JsonNode): int =

--- a/tests/sets/tsets_various.nim
+++ b/tests/sets/tsets_various.nim
@@ -254,3 +254,35 @@ block: # test correctness after a number of inserts/deletes
 
   testDel(): (var t: HashSet[int])
   testDel(): (var t: OrderedSet[int])
+
+block: # hash(HashSet)
+  block: # robustness to tombstones
+    var a: HashSet[int]
+    a.incl 10
+    a.excl 10
+    a.incl 11
+
+    var a2: HashSet[int]
+    a2.incl 11
+    doAssert a == a2
+    doAssert hash(a) == hash(a2)
+
+  block: # robustness to deletions, which can affect ordering
+    var a: HashSet[float]
+    var vals: seq[float]
+    for i in 0..<10:
+      let ai = i.float * 0.7
+      vals.add ai
+      a.incl ai
+    var a2: HashSet[float]
+    for ai in a: a2.incl ai
+    let n = 1000
+    for i in 0..<n:
+      let ai = i.float * 0.31
+      a2.incl ai
+    for i in 0..<n:
+      let ai = i.float * 0.31
+      if ai notin vals:
+        a2.excl ai
+    doAssert a == a2
+    doAssert hash(a) == hash(a2)


### PR DESCRIPTION
* any `hash` should satisfy:
if a == b then hash(a) == hash(b)
(the reverse being desirable but not always possible)
this PR fixes hash(HashSet), which didn't satisfy that property (see tests) because of tombstones.

* Furthermore, `xor` doesn't have good hash properties so I replaced it with `!&` (see PR content for full explanation); this was discovered while investigating this https://github.com/nim-lang/Nim/pull/13620#discussion_r391969479 /cc @PMunch

If for some reason `sort` is unacceptable, I can change to using the commented out `xor` code but keep the `!& + sort` code for documentation in case someone runs into the issue mentioned

* likewise, this PR fixes `hash*(n: OrderedTable[string, JsonNode]): Hash` which used `xor` which again has bad mixing properties: any 2 (key,val) pairs satisfying `(hash(key) !& hash(val))` having the same value would cancel each other out; instead I used the standard approach based on adding each element via `!&` (no sort needed here because `OrderedTable` is ordered).

A particular case of this type of collision is this:
```nim
import sets
import tables
import json
var a: OrderedTable[string, JsonNode]
a.add("foo", newJString("1"))
a.add("foo", newJString("1")) # this nullifies previous (key,value)
doAssert hash(a) == 0
```

## note
json spec allows duplicate keys (see https://stackoverflow.com/questions/21832701/does-json-syntax-allow-duplicate-keys-in-an-object), but std/json silently ignores duplicate keys:
```
  var b = %* {
    "foo": "1",
    "foo": "1",
    "bar": "2",
    "bar": "2",
  }
  echo b
```
```
{"foo":"1","bar":"2"}
```
that's a separate issue though