### PR TITLE
introduce getPeerCertificates, fixes #13299

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -119,6 +119,9 @@ echo f
 - Added a new module, `std / compilesettings` for querying the compiler about
   diverse configuration settings.
 - `base64` adds URL-Safe Base64, implements RFC-4648 Section-7.
+- Added `net.getPeerCertificates` and `asyncnet.getPeerCertificates` for
+  retrieving the verified certificate chain of the peer we are connected to
+  through an SSL-wrapped `Socket`/`AsyncSocket`.
 
 
 ## Library changes

--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -95,6 +95,8 @@
 ##   runForever()
 ##
 
+include "system/inclrtl"
+
 import asyncdispatch
 import nativesockets
 import net
@@ -742,6 +744,17 @@ when defineSsl:
       sslSetConnectState(socket.sslHandle)
     of handshakeAsServer:
       sslSetAcceptState(socket.sslHandle)
+
+  proc getPeerCertificates*(socket: AsyncSocket): seq[Certificate] {.since: (1, 1).} =
+    ## Returns the certificate chain received by the peer we are connected to
+    ## through the given socket.
+    ## The handshake must have been completed and the certificate chain must
+    ## have been verified successfully or else an empty sequence is returned.
+    ## The chain is ordered from leaf certificate to root certificate.
+    if not socket.isSsl:
+      result = newSeq[Certificate]()
+    else:
+      result = getPeerCertificates(socket.sslHandle)
 
 proc getSockOpt*(socket: AsyncSocket, opt: SOBool, level = SOL_SOCKET): bool {.
   tags: [ReadIOEffect].} =

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -91,6 +91,7 @@ type
   PSslPtr* = ptr SslPtr
   SslCtx* = SslPtr
   PSSL_METHOD* = SslPtr
+  PSTACK* = SslPtr
   PX509* = SslPtr
   PX509_NAME* = SslPtr
   PEVP_MD* = SslPtr
@@ -359,6 +360,8 @@ proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_get_SSL_CTX*(ssl: SslPtr): SslCtx {.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_set_SSL_CTX*(ssl: SslPtr, ctx: SslCtx): SslCtx {.cdecl, dynlib: DLLSSLName, importc.}
+proc SSL_get0_verified_chain*(ssl: SslPtr): PSTACK {.cdecl, dynlib: DLLSSLName,
+    importc.}
 proc SSL_CTX_new*(meth: PSSL_METHOD): SslCtx{.cdecl,
     dynlib: DLLSSLName, importc.}
 proc SSL_CTX_load_verify_locations*(ctx: SslCtx, CAfile: cstring,
@@ -425,6 +428,11 @@ proc ERR_get_error*(): cint{.cdecl, dynlib: DLLUtilName, importc.}
 proc ERR_peek_last_error*(): cint{.cdecl, dynlib: DLLUtilName, importc.}
 
 proc OPENSSL_config*(configName: cstring){.cdecl, dynlib: DLLSSLName, importc.}
+
+proc OPENSSL_sk_num*(stack: PSTACK): int {.cdecl, dynlib: DLLSSLName, importc.}
+
+proc OPENSSL_sk_value*(stack: PSTACK, index: int): pointer {.cdecl,
+    dynlib: DLLSSLName, importc.}
 
 proc d2i_X509*(px: ptr PX509, i: ptr ptr cuchar, len: cint): PX509 {.cdecl,
     dynlib: DLLSSLName, importc.}

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -426,6 +426,30 @@ proc ERR_peek_last_error*(): cint{.cdecl, dynlib: DLLUtilName, importc.}
 
 proc OPENSSL_config*(configName: cstring){.cdecl, dynlib: DLLSSLName, importc.}
 
+proc d2i_X509*(px: ptr PX509, i: ptr ptr cuchar, len: cint): PX509 {.cdecl,
+    dynlib: DLLSSLName, importc.}
+
+proc i2d_X509*(cert: PX509; o: ptr ptr cuchar): cint {.cdecl,
+    dynlib: DLLSSLName, importc.}
+
+proc d2i_X509*(b: string): PX509 =
+  ## decode DER/BER bytestring into X.509 certificate struct
+  var bb = b.cstring
+  let i = cast[ptr ptr cuchar](addr bb)
+  let ret = d2i_X509(addr result, i, b.len.cint)
+  if ret.isNil:
+    raise newException(Exception, "X.509 certificate decoding failed")
+
+proc i2d_X509*(cert: PX509): string =
+  ## encode `cert` to DER string
+  let encoded_length = i2d_X509(cert, nil)
+  result = newString(encoded_length)
+  var q = result.cstring
+  let o = cast[ptr ptr cuchar](addr q)
+  let length = i2d_X509(cert, o)
+  if length.int <= 0:
+    raise newException(Exception, "X.509 certificate encoding failed")
+
 when not useWinVersion and not defined(macosx) and not defined(android) and not defined(nimNoAllocForSSL):
   proc CRYPTO_set_mem_functions(a,b,c: pointer){.cdecl,
     dynlib: DLLUtilName, importc.}
@@ -688,29 +712,7 @@ when not defined(nimDisableCertificateValidation) and not defined(windows):
   proc X509_STORE_set_trust*(ctx: PX509_STORE; trust: cint): cint
   proc X509_STORE_add_cert*(ctx: PX509_STORE; x: PX509): cint
 
-  proc d2i_X509*(px: ptr PX509, i: ptr ptr cuchar, len: cint): PX509
-
-  proc i2d_X509*(cert: PX509; o: ptr ptr cuchar): cint
-
   {.pop.}
-
-  proc d2i_X509*(b: string): PX509 =
-    ## decode DER/BER bytestring into X.509 certificate struct
-    var bb = b.cstring
-    let i = cast[ptr ptr cuchar](addr bb)
-    let ret = d2i_X509(addr result, i, b.len.cint)
-    if ret.isNil:
-      raise newException(Exception, "X.509 certificate decoding failed")
-
-  proc i2d_X509*(cert: PX509): string =
-    ## encode `cert` to DER string
-    let encoded_length = i2d_X509(cert, nil)
-    result = newString(encoded_length)
-    var q = result.cstring
-    let o = cast[ptr ptr cuchar](addr q)
-    let length = i2d_X509(cert, o)
-    if length.int <= 0:
-      raise newException(Exception, "X.509 certificate encoding failed")
 
   when isMainModule:
     # A simple certificate test


### PR DESCRIPTION
getPeerCertificates retrieves the verified certificate chain of the peer
we are connected to through an SSL-wrapped Socket/AsyncSocket. This
introduces the new type ``Certificate`` which stores a DER-encoded X509 certificate.