### PR TITLE
fix #13524 astToStr now works inside generics

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -226,7 +226,7 @@ proc semGenericStmt(c: PContext, n: PNode,
     var mixinContext = false
     if s != nil:
       incl(s.flags, sfUsed)
-      mixinContext = s.magic in {mDefined, mDefinedInScope, mCompiles}
+      mixinContext = s.magic in {mDefined, mDefinedInScope, mCompiles, mAstToStr}
       let sc = symChoice(c, fn, s, if s.isMixedIn: scForceOpen else: scOpen)
       case s.kind
       of skMacro:

--- a/tests/generics/t13525.nim
+++ b/tests/generics/t13525.nim
@@ -1,0 +1,6 @@
+# https://github.com/nim-lang/Nim/issues/13524
+template fun(field): untyped = astToStr(field)
+proc test1(): string = fun(nonexistant1)
+proc test2[T](): string = fun(nonexistant2) # used to cause: Error: undeclared identifier: 'nonexistant2'
+doAssert test1() == "nonexistant1"
+doAssert test2[int]() == "nonexistant2"


### PR DESCRIPTION
* fix #13524 astToStr now works inside generics
* https://github.com/nim-lang/Nim/pull/13525 provides a different (more general) way to fix this so I'm keeping it open but at least #13524 can be fixed in the meantime