### PR TITLE
httpcore: deprecate `==`(string, HttpCode)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -35,6 +35,9 @@
   `parse("2020", "YYYY", utc())` is now `2020-01-01T00:00:00Z` instead of
   `2020-03-02T00:00:00Z` if run on 03-02; it also doesn't crash anymore when
   used on 29th, 30th, 31st of each month.
+- `httpcore.==(string, HttpCode)` is now deprecated due to lack of practical
+  usage. The `$` operator can be used to obtain the string form of `HttpCode`
+  for comparison if desired.
 
 ### Breaking changes in the compiler
 

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -290,7 +290,14 @@ proc `$`*(code: HttpCode): string =
 
 proc `==`*(a, b: HttpCode): bool {.borrow.}
 
-proc `==`*(rawCode: string, code: HttpCode): bool =
+proc `==`*(rawCode: string, code: HttpCode): bool
+          {.deprecated: "Deprecated since v1.2; use rawCode == $code instead".} =
+  ## Compare the string form of the status code with a HttpCode
+  ##
+  ## **Note**: According to HTTP/1.1 specification, the reason phrase is
+  ##           optional and should be ignored by the client, making this
+  ##           proc only suitable for comparing the ``HttpCode`` against the
+  ##           string form of itself.
   return cmpIgnoreCase(rawCode, $code) == 0
 
 proc is2xx*(code: HttpCode): bool =


### PR DESCRIPTION
According to [RFC7230], the reason phrase attached to the status line is
optional and clients should not rely on it. This in turn causes the proc
to be practically useless, as clients should only inspect the return
code.

Ref #13680.

[RFC7230]: https://tools.ietf.org/html/rfc7230#section-3.1.2