### PR TITLE
fix #11458 oswalkdir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -126,6 +126,7 @@ echo f
 - `parseutils.parseUntil` has now a different behaviour if the `until` parameter is
   empty. This was required for intuitive behaviour of the strscans module
   (see bug #13605).
+- `std/oswalkdir` was buggy, it's now deprecated and reuses `std/os` procs
 
 
 ## Language additions

--- a/lib/pure/oswalkdir.nim
+++ b/lib/pure/oswalkdir.nim
@@ -7,30 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-## Compile-time only version for walkDir if you need it at compile-time
-## for JavaScript.
-
-type
-  PathComponent* = enum ## Enumeration specifying a path component.
-    pcFile,             ## path refers to a file
-    pcLinkToFile,       ## path refers to a symbolic link to a file
-    pcDir,              ## path refers to a directory
-    pcLinkToDir         ## path refers to a symbolic link to a directory
-
-proc staticWalkDir(dir: string; relative: bool): seq[
-                  tuple[kind: PathComponent; path: string]] =
-  discard
-
-iterator walkDir*(dir: string; relative = false): tuple[kind: PathComponent;
-    path: string] =
-  for k, v in items(staticWalkDir(dir, relative)):
-    yield (k, v)
-
-iterator walkDirRec*(dir: string; filter = {pcFile, pcDir}): string =
-  var stack = @[dir]
-  while stack.len > 0:
-    for k, p in walkDir(stack.pop()):
-      if k in filter:
-        case k
-        of pcFile, pcLinkToFile: yield p
-        of pcDir, pcLinkToDir: stack.add(p)
+## This module is deprecated, ``import os`` instead.
+{.deprecated: "import os.nim instead".}
+import os
+export PathComponent, walkDir, walkDirRec


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/11458
* os.walkDir,walkDirRec already work for nims and for js at CT for a while now, and should be used instead of oswalkdir which was buggy anyway
