### PR TITLE
fix #13538 sigmatch errors are now sorted

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -10,6 +10,8 @@
 ## This module implements semantic checking for calls.
 # included from sem.nim
 
+from algorithm import sort
+
 proc sameMethodDispatcher(a, b: PSym): bool =
   result = false
   if a.kind == skMethod and b.kind == skMethod:
@@ -178,9 +180,11 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
 
   var maybeWrongSpace = false
 
+  var candidatesAll: seq[string]
   var candidates = ""
   var skipped = 0
   for err in errors:
+    candidates.setLen 0
     if filterOnlyFirst and err.firstMismatch.arg == 1:
       inc skipped
       continue
@@ -225,6 +229,9 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         maybeWrongSpace = true
     for diag in err.diagnostics:
       candidates.add(diag & "\n")
+    candidatesAll.add candidates
+  candidatesAll.sort # fix #13538
+  candidates = join(candidatesAll)
   if skipped > 0:
     candidates.add($skipped & " other mismatching symbols have been " &
         "suppressed; compile with --showAllMismatches:on to see them\n")

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -1,6 +1,5 @@
 discard """
 errormsg: "type mismatch: got <Bar[system.int]>"
-disabled: "32bit"
 nimout: '''
 t3330.nim(78, 4) Error: type mismatch: got <Bar[system.int]>
 but expected one of:
@@ -9,33 +8,33 @@ proc test(foo: Foo[int])
   required type for foo: Foo[int]
   but expression 'bar' is of type: Bar[system.int]
 t3330.nim(63, 8) Hint: Non-matching candidates for add(k, string, T)
-proc add(x: var string; y: string)
-  first type mismatch at position: 1
-  required type for x: var string
-  but expression 'k' is of type: Alias
-proc add[T](x: var seq[T]; y: openArray[T])
-  first type mismatch at position: 1
-  required type for x: var seq[T]
-  but expression 'k' is of type: Alias
 proc add(result: var string; x: float)
   first type mismatch at position: 1
   required type for result: var string
   but expression 'k' is of type: Alias
-proc add[T](x: var seq[T]; y: T)
+proc add(result: var string; x: int64)
   first type mismatch at position: 1
-  required type for x: var seq[T]
-  but expression 'k' is of type: Alias
-proc add(x: var string; y: cstring)
-  first type mismatch at position: 1
-  required type for x: var string
+  required type for result: var string
   but expression 'k' is of type: Alias
 proc add(x: var string; y: char)
   first type mismatch at position: 1
   required type for x: var string
   but expression 'k' is of type: Alias
-proc add(result: var string; x: int64)
+proc add(x: var string; y: cstring)
   first type mismatch at position: 1
-  required type for result: var string
+  required type for x: var string
+  but expression 'k' is of type: Alias
+proc add(x: var string; y: string)
+  first type mismatch at position: 1
+  required type for x: var string
+  but expression 'k' is of type: Alias
+proc add[T](x: var seq[T]; y: T)
+  first type mismatch at position: 1
+  required type for x: var seq[T]
+  but expression 'k' is of type: Alias
+proc add[T](x: var seq[T]; y: openArray[T])
+  first type mismatch at position: 1
+  required type for x: var seq[T]
   but expression 'k' is of type: Alias
 
 t3330.nim(63, 8) template/generic instantiation of `add` from here
@@ -46,10 +45,11 @@ t3330.nim(71, 6) Foo: 'bar.x' cannot be assigned to
 expression: test(bar)'''
 """
 
-# Note: currently disabled on 32bit because the candidates are presented in
-# different order on travis with `NIM_COMPILE_TO_CPP=false CPU=i386`;
-# a possible fix would be to sort the candidates by proc signature or
-# declaration location
+
+
+
+
+
 
 
 

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -37,20 +37,24 @@ texplain.nim(124, 5) ExplainedConcept: concept predicate failed
 
 texplain.nim(168, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
+proc e(i: int): int
+  first type mismatch at position: 1
+  required type for i: int
+  but expression 'n' is of type: NonMatchingType
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
   but expression 'n' is of type: NonMatchingType
 texplain.nim(168, 9) template/generic instantiation of `assert` from here
 texplain.nim(124, 5) ExplainedConcept: concept predicate failed
-proc e(i: int): int
-  first type mismatch at position: 1
-  required type for i: int
-  but expression 'n' is of type: NonMatchingType
 
 expression: e(n)
 texplain.nim(169, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
+proc r(i: string): int
+  first type mismatch at position: 1
+  required type for i: string
+  but expression 'n' is of type: NonMatchingType
 proc r(o: RegularConcept): int
   first type mismatch at position: 1
   required type for o: RegularConcept
@@ -61,20 +65,16 @@ proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
   required type for a: SomeNumber
   but expression 'n' is of type: NonMatchingType
-proc r(i: string): int
-  first type mismatch at position: 1
-  required type for i: string
-  but expression 'n' is of type: NonMatchingType
 
 expression: r(n)
 texplain.nim(170, 20) Hint: Non-matching candidates for r(y)
-proc r[T](a: SomeNumber; b: T; c: auto)
-  first type mismatch at position: 1
-  required type for a: SomeNumber
-  but expression 'y' is of type: MatchingType
 proc r(i: string): int
   first type mismatch at position: 1
   required type for i: string
+  but expression 'y' is of type: MatchingType
+proc r[T](a: SomeNumber; b: T; c: auto)
+  first type mismatch at position: 1
+  required type for a: SomeNumber
   but expression 'y' is of type: MatchingType
 
 texplain.nim(178, 2) Error: type mismatch: got <MatchingType>
@@ -97,10 +97,10 @@ expression: f(y)'''
   errormsg: "type mismatch: got <MatchingType>"
   line: 178
 
-  disabled: 32bit
 """
 
-# disabled on 32 bit, because the order of suggested alternatives ``r`` differs
+
+
 # proc r[T](a: SomeNumber; b: T; c: auto)
 # proc r(i: string): int
 # proc r(o: RegularConcept): int

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -3,13 +3,13 @@ discard """
   nimout: '''
 tsigmatch.nim(111, 4) Error: type mismatch: got <A, string>
 but expected one of:
+proc f(a: A)
+  first type mismatch at position: 2
+  extra argument given
 proc f(b: B)
   first type mismatch at position: 1
   required type for b: B
   but expression 'A()' is of type: A
-proc f(a: A)
-  first type mismatch at position: 2
-  extra argument given
 
 expression: f(A(), "extra")
 tsigmatch.nim(125, 6) Error: type mismatch: got <tuple of (string, proc (){.gcsafe, locks: 0.})>
@@ -61,14 +61,14 @@ proc f(a1: string; a2: varargs[string]; a3: float; a4: var string)
 expression: f("asdf", "1", "2", "3", "4", 2.3, "bad")
 tsigmatch.nim(164, 4) Error: type mismatch: got <string, a0: int literal(12)>
 but expected one of:
-proc f(x: string; a0: var int)
-  first type mismatch at position: 2
-  required type for a0: var int
-  but expression 'a0 = 12' is immutable, not 'var'
 proc f(x: string; a0: string)
   first type mismatch at position: 2
   required type for a0: string
   but expression 'a0 = 12' is of type: int literal(12)
+proc f(x: string; a0: var int)
+  first type mismatch at position: 2
+  required type for a0: var int
+  but expression 'a0 = 12' is immutable, not 'var'
 
 expression: f(foo, a0 = 12)
 tsigmatch.nim(171, 7) Error: type mismatch: got <Mystring, string>

--- a/tests/errmsgs/tsigmatch2.nim
+++ b/tests/errmsgs/tsigmatch2.nim
@@ -3,13 +3,13 @@ discard """
   nimout: '''
 tsigmatch2.nim(40, 14) Error: type mismatch: got <float64>
 but expected one of:
-proc foo(i: Foo): string
-  first type mismatch at position: 1
-  required type for i: Foo
-  but expression '1.2' is of type: float64
 proc foo(args: varargs[string, myproc]): string
   first type mismatch at position: 1
   required type for args: varargs[string]
+  but expression '1.2' is of type: float64
+proc foo(i: Foo): string
+  first type mismatch at position: 1
+  required type for i: Foo
   but expression '1.2' is of type: float64
 
 expression: foo(1.2)

--- a/tests/errmsgs/tunknown_named_parameter.nim
+++ b/tests/errmsgs/tunknown_named_parameter.nim
@@ -6,22 +6,22 @@ proc rsplit(s: string; sep: char; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
   required type for sep: char
   but expression '{':'}' is of type: set[char]
-proc rsplit(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[string]
-  first type mismatch at position: 3
-  unknown named parameter: maxsplits
 proc rsplit(s: string; sep: string; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
   required type for sep: string
   but expression '{':'}' is of type: set[char]
+proc rsplit(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[string]
+  first type mismatch at position: 3
+  unknown named parameter: maxsplits
 
 expression: rsplit("abc:def", {':'}, maxsplits = 1)
 '''
-disabled: 32bit
 """
+
 
 # bug #8043
 
-# disabled on 32 bit systems because the order of suggested proc alternatives is different.
+
 
 import strutils
 "abc:def".rsplit({':'}, maxsplits = 1)


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/13538
* sigmatch errors are now easier to read (eg all generics show up after all non-generics thanks to sorting)
* re-enables several tests that was disabled because of that bug:
```
tests/errmsgs/tunknown_named_parameter.nim
tests/concepts/texplain.nim
tests/concepts/t3330.nim
```
* unblocks https://github.com/nim-lang/Nim/pull/13351 which was broken because of this bug