### PR TITLE
Detect Ubuntu by checking release() and uname()

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -156,7 +156,9 @@ proc detectOsImpl(d: Distribution): bool =
   of Distribution.Posix: result = defined(posix)
   of Distribution.MacOSX: result = defined(macosx)
   of Distribution.Linux: result = defined(linux)
-  of Distribution.Ubuntu, Distribution.Gentoo, Distribution.FreeBSD,
+  of Distribution.Ubuntu:
+    result = "Ubuntu" in release() or ("-" & $d & " ") in uname()
+  of Distribution.Gentoo, Distribution.FreeBSD,
      Distribution.OpenBSD:
     result = ("-" & $d & " ") in uname()
   of Distribution.RedHat:


### PR DESCRIPTION
This will improve detection of Ubuntu when running on Ubuntu on WSL.

#13703