### PR TITLE
Revert #13658 for nim-gdb.bat. Fixes #13705

### DIFF
--- a/bin/nim-gdb.bat
+++ b/bin/nim-gdb.bat
@@ -6,7 +6,9 @@ for %%i in ("%NIM_BIN%\..\") do (set NIM_ROOT=%%~fi)
 set @GDB_PYTHON_MODULE_PATH=%NIM_ROOT%\tools\nim-gdb.py
 set @NIM_GDB=gdb.exe
 
-%@NIM_GDB% -eval-command="source  %@GDB_PYTHON_MODULE_PATH%" %*
+@echo source %@GDB_PYTHON_MODULE_PATH%> wingdbcommand.txt
+%@NIM_GDB% --command="wingdbcommand.txt" %*
+del wingdbcommand.txt /f /q
 
 EXIT /B %ERRORLEVEL%
 @echo on


### PR DESCRIPTION
This format is needed for older versions of GDB, namely 7.11, which is included in the standard Nim distribution.