### PR TITLE
[WIP] bugfixes in exception handling + remove field `up`

### DIFF
--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -33,7 +33,6 @@ type
       trace: string
     else:
       trace: seq[StackTraceEntry]
-    up: ref Exception # used for stacking exceptions. Not exported!
 
   Defect* = object of Exception ## \
     ## Abstract base class for all exceptions that Nim's runtime raises

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -110,12 +110,12 @@ proc popSafePoint {.compilerRtl, inl.} =
   excHandler = excHandler.prev
 
 proc pushCurrentException(e: sink(ref Exception)) {.compilerRtl, inl.} =
-  e.up = currException
+  e.parent = currException
   currException = e
   #showErrorMessage "A"
 
 proc popCurrentException {.compilerRtl, inl.} =
-  currException = currException.up
+  currException = currException.parent
   #showErrorMessage "B"
 
 proc popCurrentExceptionEx(id: uint) {.compilerRtl.} =

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -430,14 +430,14 @@ proc raiseExceptionAux(e: sink(ref Exception)) {.nodestroy.} =
       pushCurrentException(e)
       {.emit: "throw e;".}
   elif defined(nimQuirky) or gotoBasedExceptions:
-    # XXX This check should likely also be done in the setjmp case below.
     if e != currException:
       pushCurrentException(e)
     when gotoBasedExceptions:
       inc nimInErrorMode
   else:
     if excHandler != nil:
-      pushCurrentException(e)
+      if e != currException:
+        pushCurrentException(e)
       c_longjmp(excHandler.context, 1)
     else:
       reportUnhandledError(e)


### PR DESCRIPTION
not 100% sure this patch is correct, please double check

* `up` seemed redundant with `parent` but maybe I'm missing something
* added the `if e != currException:` check for `c` exception handling; also needs to be double checked
