### PR TITLE
add error for missing commandLineParams

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2772,7 +2772,7 @@ when declared(paramCount) or defined(nimdoc):
       result.add(paramStr(i))
 else:
   proc commandLineParams*(): seq[TaintedString] {.error:
-  "commandLineParams() unsupported by this target".} =
+  "commandLineParams() unsupported by dynamic libraries".} =
     discard
 
 when not weirdTarget and (defined(freebsd) or defined(dragonfly)):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2771,8 +2771,9 @@ when declared(paramCount) or defined(nimdoc):
     for i in 1..paramCount():
       result.add(paramStr(i))
 else:
-  proc commandLineParams*(): seq[TaintedString] =
-    {.error: "commandLineParams() unsupported by this target".}
+  proc commandLineParams*(): seq[TaintedString] {.error:
+  "commandLineParams() unsupported by this target".} =
+    discard
 
 when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
   proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize_t,

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2770,6 +2770,9 @@ when declared(paramCount) or defined(nimdoc):
     result = @[]
     for i in 1..paramCount():
       result.add(paramStr(i))
+else:
+  proc commandLineParams*(): seq[TaintedString] =
+    {.error: "commandLineParams() unsupported by this target".}
 
 when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
   proc sysctl(name: ptr cint, namelen: cuint, oldp: pointer, oldplen: ptr csize_t,


### PR DESCRIPTION
This is more of a proposal.  I wanted a better warning to explain why including other code that referenced `commandLineParams` caused my shared library build to break...