### PR TITLE
Fix #13733 - __stderrp, __stdoutp & __stdinp are only in FreeBSD

### DIFF
--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -117,7 +117,7 @@ type
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
 # duplicated between io and ansi_c
-const stdioUsesMacros = (defined(osx) or defined(bsd)) and not defined(emscripten)
+const stdioUsesMacros = (defined(osx) or defined(freebsd) or defined(dragonfly)) and not defined(emscripten)
 const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
 const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
 const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -39,7 +39,7 @@ type
 # text file handling:
 when not defined(nimscript) and not defined(js):
   # duplicated between io and ansi_c
-  const stdioUsesMacros = (defined(osx) or defined(bsd)) and not defined(emscripten)
+  const stdioUsesMacros = (defined(osx) or defined(freebsd) or defined(dragonfly)) and not defined(emscripten)
   const stderrName = when stdioUsesMacros: "__stderrp" else: "stderr"
   const stdoutName = when stdioUsesMacros: "__stdoutp" else: "stdout"
   const stdinName = when stdioUsesMacros: "__stdinp" else: "stdin"


### PR DESCRIPTION
Fixes #13733 

`__stderrp`, `__stdoutp` and `__stdinp` are only present in `stdio.h` in FreeBSD and DragonFlyBSD:

- [FreeBSD](https://github.com/freebsd/freebsd/blob/66a605b22a38094de00bac3b65cb8b6d5b68e633/include/stdio.h#L169)
- [DragonFlyBSD](https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/include/stdio.h#L119)
- [NetBSD](https://github.com/NetBSD/src/blob/trunk/include/stdio.h#L222) (no mention of `__stderrp`)
- [OpenBSD](https://github.com/openbsd/src/blob/master/include/stdio.h#L197) (no mention of `__stderrp`)