### PR TITLE
fix #13737

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -452,7 +452,8 @@ proc semLowerLetVarCustomPragma(c: PContext, a: PNode, n: PNode): PNode =
       return nil
 
     let sym = searchInScopes(c, ident)
-    if sfCustomPragma in sym.flags: return nil # skip `template myAttr() {.pragma.}`
+    if sym == nil or sfCustomPragma in sym.flags: return nil
+      # skip if not in scope; skip `template myAttr() {.pragma.}`
     let lhs = b[0]
     let clash = strTableGet(c.currentScope.symbols, lhs.ident)
     if clash != nil:


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/13737
now gives sane error just like before https://github.com/nim-lang/Nim/pull/13508:
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10396.nim(5, 1) template/generic instantiation from here
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10396.nim(6, 9) Error: invalid pragma: byaddr
  var a {.byaddr.} = s[0]
```
