### PR TITLE
Fix vm.nim for --gc:arc

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -51,16 +51,6 @@ type
                               # XXX 'break' should perform cleanup actions
                               # What does the C backend do for it?
 
-template seqToPtr(x: seq): pointer =
-  when defined(nimSeqsV2):
-    type
-      NimSeqV2 = object
-        len: int
-        p: pointer
-    cast[NimSeqV2](x).p
-  else:
-    cast[pointer](x)
-
 proc stackTraceAux(c: PCtx; x: PStackFrame; pc: int; recursionLimit=100) =
   if x != nil:
     if recursionLimit == 0:
@@ -527,6 +517,16 @@ const
   errFieldXNotFound = "node lacks field: "
 
 proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
+  template seqToPtr(x: seq): pointer =
+    when defined(nimSeqsV2):
+      type
+        NimSeqV2 = object
+          len: int
+          p: pointer
+      cast[NimSeqV2](x).p
+    else:
+      cast[pointer](x)
+
   var pc = start
   var tos = tos
   # Used to keep track of where the execution is resumed.

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1188,7 +1188,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       if prc.offset < -1:
         # it's a callback:
         c.callbacks[-prc.offset-2].value(
-          VmArgs(ra: ra, rb: rb, rc: rc, slots: regs,
+          VmArgs(ra: ra, rb: rb, rc: rc, slots: addr regs,
                  currentException: c.currentExceptionA,
                  currentLineInfo: c.debug[pc]))
       elif importcCond(prc):
@@ -1507,7 +1507,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         rc = instr.regC
         idx = int(regs[rb+rc-1].intVal)
         callback = c.callbacks[idx].value
-        args = VmArgs(ra: ra, rb: rb, rc: rc, slots: regs,
+        args = VmArgs(ra: ra, rb: rb, rc: rc, slots: addr regs,
                 currentException: c.currentExceptionA,
                 currentLineInfo: c.debug[pc])
       callback(args)

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1188,7 +1188,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       if prc.offset < -1:
         # it's a callback:
         c.callbacks[-prc.offset-2].value(
-          VmArgs(ra: ra, rb: rb, rc: rc, slots: addr regs,
+          VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
                  currentException: c.currentExceptionA,
                  currentLineInfo: c.debug[pc]))
       elif importcCond(prc):
@@ -1507,7 +1507,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         rc = instr.regC
         idx = int(regs[rb+rc-1].intVal)
         callback = c.callbacks[idx].value
-        args = VmArgs(ra: ra, rb: rb, rc: rc, slots: addr regs,
+        args = VmArgs(ra: ra, rb: rb, rc: rc, slots: cast[ptr UncheckedArray[TFullReg]](addr regs[0]),
                 currentException: c.currentExceptionA,
                 currentLineInfo: c.debug[pc])
       callback(args)

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -214,7 +214,7 @@ type
 
   TRegisterKind* = enum
     rkNone, rkNode, rkInt, rkFloat, rkRegisterAddr, rkNodeAddr
-  TFullReg* = object   # with a custom mark proc, we could use the same
+  TFullReg* = object  # with a custom mark proc, we could use the same
                       # data representation as LuaJit (tagged NaNs).
     case kind*: TRegisterKind
     of rkNone: nil
@@ -232,7 +232,7 @@ type
 
   VmArgs* = object
     ra*, rb*, rc*: Natural
-    slots*: ptr seq[TFullReg]
+    slots*: ptr UncheckedArray[TFullReg]
     currentException*: PNode
     currentLineInfo*: TLineInfo
   VmCallback* = proc (args: VmArgs) {.closure.}

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -212,6 +212,18 @@ type
     slotTempComplex,  # some complex temporary (s.node field is used)
     slotTempPerm      # slot is temporary but permanent (hack)
 
+  TRegisterKind* = enum
+    rkNone, rkNode, rkInt, rkFloat, rkRegisterAddr, rkNodeAddr
+  TFullReg* = object   # with a custom mark proc, we could use the same
+                      # data representation as LuaJit (tagged NaNs).
+    case kind*: TRegisterKind
+    of rkNone: nil
+    of rkInt: intVal*: BiggestInt
+    of rkFloat: floatVal*: BiggestFloat
+    of rkNode: node*: PNode
+    of rkRegisterAddr: regAddr*: ptr TFullReg
+    of rkNodeAddr: nodeAddr*: ptr PNode
+
   PProc* = ref object
     blocks*: seq[TBlock]    # blocks; temp data structure
     sym*: PSym
@@ -220,7 +232,7 @@ type
 
   VmArgs* = object
     ra*, rb*, rc*: Natural
-    slots*: pointer
+    slots*: seq[TFullReg]
     currentException*: PNode
     currentLineInfo*: TLineInfo
   VmCallback* = proc (args: VmArgs) {.closure.}

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -232,7 +232,7 @@ type
 
   VmArgs* = object
     ra*, rb*, rc*: Natural
-    slots*: seq[TFullReg]
+    slots*: ptr seq[TFullReg]
     currentException*: PNode
     currentLineInfo*: TLineInfo
   VmCallback* = proc (args: VmArgs) {.closure.}

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -10,10 +10,8 @@
 import pathutils
 
 template setX(k, field) {.dirty.} =
-  var s: seq[TFullReg]
-  move(s, a.slots[])
-  s[a.ra].ensureKind(k)
-  s[a.ra].field = v
+  a.slots[a.ra].ensureKind(k)
+  a.slots[a.ra].field = v
 
 proc setResult*(a: VmArgs; v: BiggestInt) = setX(rkInt, intVal)
 proc setResult*(a: VmArgs; v: BiggestFloat) = setX(rkFloat, floatVal)
@@ -22,45 +20,36 @@ proc setResult*(a: VmArgs; v: bool) =
   setX(rkInt, intVal)
 
 proc setResult*(a: VmArgs; v: string) =
-  var s: seq[TFullReg]
-  move(s, a.slots[])
-  s[a.ra].ensureKind(rkNode)
-  s[a.ra].node = newNode(nkStrLit)
-  s[a.ra].node.strVal = v
+  a.slots[a.ra].ensureKind(rkNode)
+  a.slots[a.ra].node = newNode(nkStrLit)
+  a.slots[a.ra].node.strVal = v
 
 proc setResult*(a: VmArgs; n: PNode) =
-  var s: seq[TFullReg]
-  move(s, a.slots[])
-  s[a.ra].ensureKind(rkNode)
-  s[a.ra].node = n
+  a.slots[a.ra].ensureKind(rkNode)
+  a.slots[a.ra].node = n
 
 proc setResult*(a: VmArgs; v: AbsoluteDir) = setResult(a, v.string)
 
 proc setResult*(a: VmArgs; v: seq[string]) =
-  var s: seq[TFullReg]
-  move(s, a.slots[])
-  s[a.ra].ensureKind(rkNode)
+  a.slots[a.ra].ensureKind(rkNode)
   var n = newNode(nkBracket)
   for x in v: n.add newStrNode(nkStrLit, x)
-  s[a.ra].node = n
+  a.slots[a.ra].node = n
 
 template getX(k, field) {.dirty.} =
   doAssert i < a.rc-1
-  let s = a.slots[]
-  doAssert s[i+a.rb+1].kind == k
-  result = s[i+a.rb+1].field
+  doAssert a.slots[i+a.rb+1].kind == k
+  result = a.slots[i+a.rb+1].field
 
 proc getInt*(a: VmArgs; i: Natural): BiggestInt = getX(rkInt, intVal)
 proc getBool*(a: VmArgs; i: Natural): bool = getInt(a, i) != 0
 proc getFloat*(a: VmArgs; i: Natural): BiggestFloat = getX(rkFloat, floatVal)
 proc getString*(a: VmArgs; i: Natural): string =
   doAssert i < a.rc-1
-  let s = a.slots[]
-  doAssert s[i+a.rb+1].kind == rkNode
-  result = s[i+a.rb+1].node.strVal
+  doAssert a.slots[i+a.rb+1].kind == rkNode
+  result = a.slots[i+a.rb+1].node.strVal
 
 proc getNode*(a: VmArgs; i: Natural): PNode =
   doAssert i < a.rc-1
-  let s = a.slots[]
-  doAssert s[i+a.rb+1].kind == rkNode
-  result = s[i+a.rb+1].node
+  doAssert a.slots[i+a.rb+1].kind == rkNode
+  result = a.slots[i+a.rb+1].node

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -11,7 +11,7 @@ import pathutils
 
 template setX(k, field) {.dirty.} =
   var s: seq[TFullReg]
-  move(s, cast[seq[TFullReg]](a.slots))
+  move(s, a.slots[])
   s[a.ra].ensureKind(k)
   s[a.ra].field = v
 
@@ -23,14 +23,14 @@ proc setResult*(a: VmArgs; v: bool) =
 
 proc setResult*(a: VmArgs; v: string) =
   var s: seq[TFullReg]
-  move(s, cast[seq[TFullReg]](a.slots))
+  move(s, a.slots[])
   s[a.ra].ensureKind(rkNode)
   s[a.ra].node = newNode(nkStrLit)
   s[a.ra].node.strVal = v
 
 proc setResult*(a: VmArgs; n: PNode) =
   var s: seq[TFullReg]
-  move(s, cast[seq[TFullReg]](a.slots))
+  move(s, a.slots[])
   s[a.ra].ensureKind(rkNode)
   s[a.ra].node = n
 
@@ -38,7 +38,7 @@ proc setResult*(a: VmArgs; v: AbsoluteDir) = setResult(a, v.string)
 
 proc setResult*(a: VmArgs; v: seq[string]) =
   var s: seq[TFullReg]
-  move(s, cast[seq[TFullReg]](a.slots))
+  move(s, a.slots[])
   s[a.ra].ensureKind(rkNode)
   var n = newNode(nkBracket)
   for x in v: n.add newStrNode(nkStrLit, x)
@@ -46,7 +46,7 @@ proc setResult*(a: VmArgs; v: seq[string]) =
 
 template getX(k, field) {.dirty.} =
   doAssert i < a.rc-1
-  let s = cast[seq[TFullReg]](a.slots)
+  let s = a.slots[]
   doAssert s[i+a.rb+1].kind == k
   result = s[i+a.rb+1].field
 
@@ -55,12 +55,12 @@ proc getBool*(a: VmArgs; i: Natural): bool = getInt(a, i) != 0
 proc getFloat*(a: VmArgs; i: Natural): BiggestFloat = getX(rkFloat, floatVal)
 proc getString*(a: VmArgs; i: Natural): string =
   doAssert i < a.rc-1
-  let s = cast[seq[TFullReg]](a.slots)
+  let s = a.slots[]
   doAssert s[i+a.rb+1].kind == rkNode
   result = s[i+a.rb+1].node.strVal
 
 proc getNode*(a: VmArgs; i: Natural): PNode =
   doAssert i < a.rc-1
-  let s = cast[seq[TFullReg]](a.slots)
+  let s = a.slots[]
   doAssert s[i+a.rb+1].kind == rkNode
   result = s[i+a.rb+1].node


### PR DESCRIPTION
Compiling the compiler with `--gc:arc` now passes the Nim stage, but makes the C compiler complain.