### PR TITLE
distinctBase overload for values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -122,7 +122,7 @@ echo f
 - Added `net.getPeerCertificates` and `asyncnet.getPeerCertificates` for
   retrieving the verified certificate chain of the peer we are connected to
   through an SSL-wrapped `Socket`/`AsyncSocket`.
-
+- Added `distinctBase` overload for values: `assert 12.MyInt.distinctBase == 12`
 
 ## Library changes
 

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -71,6 +71,13 @@ proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".}
   ## Returns base type for distinct types, works only for distinct types.
   ## compile time error otherwise
 
+since (1, 1):
+  template distinctBase*[T](a: T): untyped =
+    ## overload for values
+    runnableExamples:
+      type MyInt = distinct int
+      doAssert 12.MyInt.distinctBase == 12
+    distinctBase(type(a))(a)
 
 proc tupleLen*(T: typedesc[tuple]): int {.magic: "TypeTrait", since: (1, 1).}
   ## Return number of elements of `T`


### PR DESCRIPTION
the overload for values (instead of types) is the one that's needed most often, and writing it inline everywhere or define their own helper for that everywhere needed is pointless and encourages the worse alternative `getFoo(args).Bar` out of laziness, see below.

## example 1
```nim
type Foo = distinct Bar
echo distinctBase(typeof(getFoo(args))).getFoo(args) # before this PR
echo getFoo(args).Bar # bad alternative (not DRY, error prone, and not always possible if Bar is not in scope)
echo getFoo(args).distinctBase # with this PR
```

## example 2
when `$` for a distinct type is not defined in scope, you can do:
```nim
proc `$`(a: distinct): string = $a.distinctBase # match all distinct
proc `$`(a: TLineInfo): string = $a.distinctBase # or just 1 specific type
echo myvar # myvar object could contain sub-fields that are distinct
```

this provides a more flexible alternative to the ones discussed in https://github.com/nim-lang/RFCs/issues/203 since we have fine grained control over which distinct fields get shown

## note
a lot of time has passed since https://github.com/nim-lang/Nim/pull/8531#discussion_r208125648 and my experience shows this overload is indeed needed. There is no bloat since that symbol is already defined anyways.
