### PR TITLE
fixes #13744

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1941,6 +1941,8 @@ proc genSomeCast(p: BProc, e: PNode, d: var TLoc) =
     elif optSeqDestructors in p.config.globalOptions and etyp.kind in {tySequence, tyString}:
       putIntoDest(p, d, e, "(*($1*) (&$2))" %
           [getTypeDesc(p.module, e.typ), rdCharLoc(a)], a.storage)
+    elif etyp.kind == tyBool and srcTyp.kind in IntegralTypes:
+      putIntoDest(p, d, e, "(($1) != 0)" % [rdCharLoc(a)], a.storage)
     else:
       putIntoDest(p, d, e, "(($1) ($2))" %
           [getTypeDesc(p.module, e.typ), rdCharLoc(a)], a.storage)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -462,7 +462,7 @@ proc transformConv(c: PTransf, n: PNode): PNode =
   var dest = skipTypes(n.typ, abstractVarRange)
   var source = skipTypes(n[1].typ, abstractVarRange)
   case dest.kind
-  of tyInt..tyInt64, tyEnum, tyChar, tyBool, tyUInt8..tyUInt32:
+  of tyInt..tyInt64, tyEnum, tyChar, tyUInt8..tyUInt32:
     # we don't include uint and uint64 here as these are no ordinal types ;-)
     if not isOrdinalType(source):
       # float -> int conversions. ugh.

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -463,6 +463,11 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
         value = (value shl srcDist) shr srcDist
         value = (value shl destDist) shr destDist
         dest.intVal = cast[BiggestInt](value)
+    of tyBool:
+      dest.ensureKind(rkInt)
+      dest.intVal = case skipTypes(srctyp, abstractRange).kind
+      of tyFloat..tyFloat64: int(src.floatVal != 0.0)
+      else: int(src.intVal != 0)
     of tyFloat..tyFloat64:
       dest.ensureKind(rkFloat)
       case skipTypes(srctyp, abstractRange).kind

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -465,9 +465,10 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
         dest.intVal = cast[BiggestInt](value)
     of tyBool:
       dest.ensureKind(rkInt)
-      dest.intVal = case skipTypes(srctyp, abstractRange).kind
-      of tyFloat..tyFloat64: int(src.floatVal != 0.0)
-      else: int(src.intVal != 0)
+      dest.intVal = 
+        case skipTypes(srctyp, abstractRange).kind
+          of tyFloat..tyFloat64: int(src.floatVal != 0.0)
+          else: int(src.intVal != 0)
     of tyFloat..tyFloat64:
       dest.ensureKind(rkFloat)
       case skipTypes(srctyp, abstractRange).kind

--- a/tests/types/tcast1.nim
+++ b/tests/types/tcast1.nim
@@ -19,3 +19,38 @@ proc remap2[T](s: seq[int], typ: typedesc[T]): seq[T] =
 
 echo remap1(@[1,2,3], float)
 echo remap2(@[1,2,3], float)
+
+
+#--------------------------------------------------------------------
+# conversion to bool, issue #13744
+proc test_conv_to_bool = 
+  var 
+    i0 = 0
+    i1 = 1
+    ih = high(uint)
+    il = low(int)
+
+    f0 = 0.0
+    f1 = 1.0
+    fh = Inf
+    fl = -Inf
+    f_nan = NaN
+
+  doAssert(bool(i0) == false)
+  doAssert(bool(i1) == true)
+  doAssert(bool(-i1) == true)
+  doAssert(bool(il) == true)
+  doAssert(bool(ih) == true)
+
+  doAssert(bool(f0) == false)
+  doAssert(bool(-f0) == false)
+  doAssert(bool(f1) == true)
+  doAssert(bool(-f1) == true)
+  doAssert(bool(fh) == true)
+  doAssert(bool(fl) == true)
+  doAssert(bool(fnan) == true) # NaN to bool gives true according to standard
+
+
+static:
+  test_conv_to_bool()
+test_conv_to_bool()


### PR DESCRIPTION
fixes #13744, solution is not to use range checks for bool conversions
handling to bool conversion in vm and c/cpp backends.
js backend is already using `!!x` for bool conversions, no changes are required.