### PR TITLE
[WIP] evalonce: `let a {.evalonce.} = expr`: side-effect safe, avoids copies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -150,6 +150,8 @@ echo f
 - `net.newContext` now performs SSL Certificate checking on Linux and OSX.
   Define `nimDisableCertificateValidation` to disable it globally.
 - new syntax for lvalue references: `var b {.byaddr.} = expr` enabled by `import pragmas`
+- new syntax for safe evaluation: `let b {.evalonce.} = expr` enabled by `import pragmas`
+  which avoids copies for lvalues, also works with rvalues, and is side effect safe.
 
 ## Language additions
 

--- a/lib/std/pragmas.nim
+++ b/lib/std/pragmas.nim
@@ -17,3 +17,30 @@ template byaddr*(lhs, typ, expr) =
   else:
     let tmp: ptr typ = addr(expr)
   template lhs: untyped = tmp[]
+
+template evalonce*(lhs, typ, expr) =
+  ## makes sure `expr` is evaluated once, and no copy is done when using
+  ## lvalues. The only current limitation is when expr is an expression returning
+  ## an openArray and is not a symbol.
+  runnableExamples:
+    let s = @[1,2]
+    let s2 {.evalonce.} = s
+    doAssert s2[0].unsafeAddr == s[0].unsafeAddr
+  when type(expr) is openArray:
+    static: doAssert typ is type(nil) # we could support but a bit pointless
+    # caveat: that's the only case that's not sideeffect safe;
+    # it could be made safe either with 1st class openArray, or with a
+    # macro that transforms `expr` aka `(body; last)` into:
+    # `body; let tmp = unsafeAddr(last)`
+    template lhs: untyped = expr
+  elif compiles(unsafeAddr(expr)): # `unsafeAddr` is needed here!
+    when typ is type(nil):
+      let tmp = unsafeAddr(expr)
+    else:
+      let tmp: ptr typ = unsafeAddr(expr)
+    template lhs: untyped = tmp[]
+  else:
+    when typ is type(nil):
+      let lhs = expr
+    else:
+      let lhs: typ = expr


### PR DESCRIPTION
* should be able to replace sequtils.evalOnceAs with a nicer syntax
* this is almost always what you need inside templates when you want to avoid duplicate evaluation of arguments while avoiding copies
* likewise when you want to avoid duplicate evaluation of an expression yet still want to avoid copies
* builds upon new compiler feature introduced in https://github.com/nim-lang/Nim/pull/13508
* see unittests
* should help with https://github.com/nim-lang/Nim/issues/13739

## known limitation that could be lifted in future PR's
```nim
openArray inside non-symbol expressions
proc bar(s: openArray[int]) =
  template getS(): untyped =
    echo "side effect"
    s
  let a {.evalonce.} = expr
```
this limitation can be lifted in the future either by doing (recursive) code transformation
```nim
let a {.evalonce.} (body; ret)
=>
body
let a {.evalonce.} ret
```

or by making openArray 1st class
