### PR TITLE
Add support for `zig cc` as C compiler.

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -138,6 +138,16 @@ compiler clang:
   result.compilerExe = "clang"
   result.cppCompiler = "clang++"
 
+# Zig cc (Clang) C/C++ Compiler
+compiler zig:
+  result = clang() # Uses settings from llvmGcc
+
+  result.name = "zig"
+  result.compilerExe = "zig"
+  result.cppCompiler = "zig"
+  result.compileTmpl = "cc " & result.compileTmpl
+  result.linkTmpl = "cc " & result.linkTmpl
+
 # Microsoft Visual C/C++ Compiler
 compiler vcc:
   result = (
@@ -375,6 +385,7 @@ const
     nintendoSwitchGCC(),
     llvmGcc(),
     clang(),
+    zig(),
     lcc(),
     bcc(),
     dmc(),

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -157,7 +157,7 @@ type
     disabledSf, writeOnlySf, readOnlySf, v2Sf
 
   TSystemCC* = enum
-    ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccLcc, ccBcc, ccDmc, ccWcc, ccVcc,
+    ccNone, ccGcc, ccNintendoSwitch, ccLLVM_Gcc, ccCLang, ccZig, ccLcc, ccBcc, ccDmc, ccWcc, ccVcc,
     ccTcc, ccPcc, ccUcc, ccIcl, ccIcc, ccClangCl
 
   ExceptionSystem* = enum


### PR DESCRIPTION
With the upcoming release of Zig 0.6, `zig cc` can be used as a convenient and portable cross-compiler and a drop-in replacement for clang. This PR allows Nim to use Zig as its C compiler using `--cc=zig`. Further, you can easily cross-compile like so:

```sh
nim c -f --cc:zig --zig.options.linker:"-target x86_64-windows-gnu" --zig.options.always:"-target x86_64-windows-gnu"
```