### PR TITLE
Add long arrow to sugar

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -123,6 +123,8 @@ echo f
   retrieving the verified certificate chain of the peer we are connected to
   through an SSL-wrapped `Socket`/`AsyncSocket`.
 - Added `distinctBase` overload for values: `assert 12.MyInt.distinctBase == 12`
+- Added `==>` to `sugar`, same as `=>` but generates an anonymous inlined func.
+
 
 ## Library changes
 

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -49,7 +49,7 @@ proc createProcType(p, b: NimNode): NimNode {.compileTime.} =
   #echo(treeRepr(result))
   #echo(result.toStrLit())
 
-template arrowImpl(inlinedFunc: static[bool],  p, b: untyped): untyped =
+template arrowImpl(inlinedFunc: static[bool], p, b: untyped): untyped =
   var params: seq[NimNode] = @[newIdentNode("auto")]
   case p.kind
   of nnkPar, nnkTupleConstr:


### PR DESCRIPTION
- Add `==>` to `sugar`, literally the same implementation as `=>` but generates an inlined `func`.
- Documentation with examples, changelog, `since`, `runnableExamples`, etc.

I did not touch the implementation, just added a `when` with the pragmas.

```nim
import macros

static:
  expandMacros:
     let works = (a: int) ==> a + 2
     let goods = (a: int) ==> debugEcho a
```

```console
$ nim c -f example.nim
let works = proc (a: int): auto {.inline, noSideEffect.} = result = a + 2
let goods = proc (a: int): auto {.inline, noSideEffect.} = debugEcho a

```
