### PR TITLE
fix #7241

### DIFF
--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -186,6 +186,9 @@ proc tryExec*(db: DbConn, query: SqlQuery,
     let x = step(stmt)
     if x in {SQLITE_DONE, SQLITE_ROW}:
       result = finalize(stmt) == SQLITE_OK
+    else:
+      discard finalize(stmt)
+      result = false
 
 proc exec*(db: DbConn, query: SqlQuery, args: varargs[string, `$`])  {.
   tags: [ReadDbEffect, WriteDbEffect].} =
@@ -533,6 +536,8 @@ proc tryInsertID*(db: DbConn, query: SqlQuery,
       result = last_insert_rowid(db)
     if finalize(stmt) != SQLITE_OK:
       result = -1
+  else:
+    discard finalize(stmt)
 
 proc insertID*(db: DbConn, query: SqlQuery,
                args: varargs[string, `$`]): int64 {.tags: [WriteDbEffect].} =


### PR DESCRIPTION
finalize() should run in insert()

When query fail, `finalize()` doesn't run so that `db.close()` raise an error `unable to close due to unfinalized statements or unfinished backups`

close #7241 