### PR TITLE
remove unexported fields from posix

### DIFF
--- a/lib/posix/posix_linux_amd64.nim
+++ b/lib/posix/posix_linux_amd64.nim
@@ -122,7 +122,6 @@ type
     mq_maxmsg*: clong  ## Maximum number of messages.
     mq_msgsize*: clong ## Maximum message size.
     mq_curmsgs*: clong ## Number of messages currently queued.
-    pad: array[4, clong]
 
   Passwd* {.importc: "struct passwd", header: "<pwd.h>",
              final, pure.} = object ## struct passwd
@@ -153,35 +152,26 @@ type
   Pid* {.importc: "pid_t", header: "<sys/types.h>".} = cint
   Pthread_attr* {.importc: "pthread_attr_t", header: "<sys/types.h>",
                   pure, final.} = object
-    abi: array[56 div sizeof(clong), clong]
 
   Pthread_barrier* {.importc: "pthread_barrier_t",
                       header: "<sys/types.h>", pure, final.} = object
-    abi: array[32 div sizeof(clong), clong]
   Pthread_barrierattr* {.importc: "pthread_barrierattr_t",
                           header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
 
   Pthread_cond* {.importc: "pthread_cond_t", header: "<sys/types.h>",
                   pure, final.} = object
-    abi: array[48 div sizeof(clonglong), clonglong]
   Pthread_condattr* {.importc: "pthread_condattr_t",
                        header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
   Pthread_key* {.importc: "pthread_key_t", header: "<sys/types.h>".} = cuint
   Pthread_mutex* {.importc: "pthread_mutex_t", header: "<sys/types.h>",
                    pure, final.} = object
-    abi: array[48 div sizeof(clong), clong]
   Pthread_mutexattr* {.importc: "pthread_mutexattr_t",
                         header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
   Pthread_once* {.importc: "pthread_once_t", header: "<sys/types.h>".} = cint
   Pthread_rwlock* {.importc: "pthread_rwlock_t",
                      header: "<sys/types.h>", pure, final.} = object
-    abi: array[56 div sizeof(clong), clong]
   Pthread_rwlockattr* {.importc: "pthread_rwlockattr_t",
                          header: "<sys/types.h>".} = object
-    abi: array[8 div sizeof(clong), clong]
   Pthread_spinlock* {.importc: "pthread_spinlock_t",
                        header: "<sys/types.h>".} = cint
   Pthread* {.importc: "pthread_t", header: "<sys/types.h>".} = culong
@@ -204,21 +194,16 @@ type
       domainname*: array[65, char]
 
   Sem* {.importc: "sem_t", header: "<semaphore.h>", final, pure.} = object
-    abi: array[32 div sizeof(clong), clong]
 
   Ipc_perm* {.importc: "struct ipc_perm",
                header: "<sys/ipc.h>", final, pure.} = object ## struct ipc_perm
-    key: Key
-    uid*: Uid    ## Owner's user ID.
-    gid*: Gid    ## Owner's group ID.
-    cuid*: Uid   ## Creator's user ID.
-    cgid*: Gid   ## Creator's group ID.
-    mode*: cshort  ## Read/write permission.
-    pad1: cshort
-    seq1: cshort
-    pad2: cshort
-    reserved1: culong
-    reserved2: culong
+    # key: Key
+    uid*: Uid     ## Owner's user ID.
+    gid*: Gid     ## Owner's group ID.
+    cuid*: Uid    ## Creator's user ID.
+    cgid*: Gid    ## Creator's group ID.
+    mode*: cshort ## Read/write permission.
+    # seq: cushort ## slot usage sequence number
 
   Stat* {.importc: "struct stat",
            header: "<sys/stat.h>", final, pure.} = object ## struct stat
@@ -228,7 +213,6 @@ type
     st_mode*: Mode        ## Mode of file (see below).
     st_uid*: Uid          ## User ID of file.
     st_gid*: Gid          ## Group ID of file.
-    pad0: cint
     st_rdev*: Dev         ## Device ID (if file is character or block special).
     st_size*: Off         ## For regular files, the file size in bytes.
                            ## For symbolic links, the length in bytes of the
@@ -244,7 +228,6 @@ type
     st_atim*: Timespec   ## Time of last access.
     st_mtim*: Timespec   ## Time of last data modification.
     st_ctim*: Timespec   ## Time of last status change.
-    reserved: array[3, clong]
 
 
   Statvfs* {.importc: "struct statvfs", header: "<sys/statvfs.h>",
@@ -263,7 +246,6 @@ type
     f_fsid*: culong         ## File system ID.
     f_flag*: culong         ## Bit mask of f_flag values.
     f_namemax*: culong      ## Maximum filename length.
-    f_spare: array[6, cint]
 
   # No Posix_typed_mem_info
 
@@ -291,7 +273,6 @@ type
     ## accessed as an atomic entity, even in the presence of asynchronous
     ## interrupts.
   Sigset* {.importc: "sigset_t", header: "<signal.h>", final, pure.} = object
-    abi: array[1024 div (8 * sizeof(culong)), culong]
 
   SigEvent* {.importc: "struct sigevent",
                header: "<signal.h>", final, pure.} = object ## struct sigevent
@@ -300,7 +281,6 @@ type
     sigev_notify*: cint           ## Notification type.
     sigev_notify_function*: proc (x: SigVal) {.noconv.} ## Notification func.
     sigev_notify_attributes*: ptr Pthread_attr ## Notification attributes.
-    abi: array[12, int]
 
   SigVal* {.importc: "union sigval",
              header: "<signal.h>", final, pure.} = object ## struct sigval
@@ -339,7 +319,6 @@ type
     si_status*: cint   ## Exit value or signal.
     si_band*: int      ## Band event for SIGPOLL.
     si_value*: SigVal  ## Signal value.
-    pad {.importc: "_pad"}: array[128 - 56, uint8]
 
   Nl_item* {.importc: "nl_item", header: "<nl_types.h>".} = cint
   Nl_catd* {.importc: "nl_catd", header: "<nl_types.h>".} = pointer
@@ -355,13 +334,9 @@ type
     tv_usec*: Suseconds ## Microseconds.
   TFdSet* {.importc: "fd_set", header: "<sys/select.h>",
            final, pure.} = object
-    abi: array[1024 div (8 * sizeof(clong)), clong]
 
   Mcontext* {.importc: "mcontext_t", header: "<ucontext.h>",
                final, pure.} = object
-    gregs: array[23, clonglong]
-    fpregs: pointer
-    reserved1: array[8, clonglong]
 
   Ucontext* {.importc: "ucontext_t", header: "<ucontext.h>",
                final, pure.} = object ## ucontext_t
@@ -382,35 +357,18 @@ type
     aio_lio_opcode*: cint     ## Operation to be performed.
     aio_reqprio*: cint        ## Request priority offset.
     aio_buf*: pointer         ## Location of buffer.
-    aio_nbytes*: csize_t        ## Length of transfer.
+    aio_nbytes*: csize_t      ## Length of transfer.
     aio_sigevent*: SigEvent   ## Signal number and value.
-    next_prio: pointer
-    abs_prio: cint
-    policy: cint
-    error_Code: cint
-    return_value: clong
     aio_offset*: Off          ## File offset.
-    reserved: array[32, uint8]
 
 
 when hasSpawnH:
   type
     Tposix_spawnattr* {.importc: "posix_spawnattr_t",
                         header: "<spawn.h>", final, pure.} = object
-      flags: cshort
-      pgrp: Pid
-      sd: Sigset
-      ss: Sigset
-      sp: Sched_param
-      policy: cint
-      pad: array[16, cint]
 
     Tposix_spawn_file_actions* {.importc: "posix_spawn_file_actions_t",
                                  header: "<spawn.h>", final, pure.} = object
-      allocated: cint
-      used: cint
-      actions: pointer
-      pad: array[16, cint]
 
 # from sys/un.h
 const Sockaddr_un_path_length* = 108
@@ -433,8 +391,6 @@ type
                        header: "<sys/socket.h>",
                        pure, final.} = object ## struct sockaddr_storage
     ss_family*: TSa_Family ## Address family.
-    ss_padding: array[128 - sizeof(cshort) - sizeof(culong), char]
-    ss_align: clong
 
   Tif_nameindex* {.importc: "struct if_nameindex", final,
                    pure, header: "<net/if.h>".} = object ## struct if_nameindex
@@ -485,7 +441,6 @@ type
     sin_family*: TSa_Family ## AF_INET.
     sin_port*: InPort      ## Port number.
     sin_addr*: InAddr      ## IP address.
-    sin_zero: array[16 - 2 - 2 - 4, uint8]
 
   In6Addr* {.importc: "struct in6_addr", pure, final,
               header: "<netinet/in.h>".} = object ## struct in6_addr

--- a/lib/posix/posix_macos_amd64.nim
+++ b/lib/posix/posix_macos_amd64.nim
@@ -368,7 +368,7 @@ when hasAioH:
       aio_nbytes*: int          ## Length of transfer.
       aio_reqprio*: cint        ## Request priority offset.
       aio_sigevent*: SigEvent   ## Signal number and value.
-      aio_lio_opcode: cint      ## Operation to be performed.
+      # aio_lio_opcode*: cint      ## Operation to be performed.
 
 when hasSpawnH:
   type


### PR DESCRIPTION
Somebody on IRC had trouble printing these types with `$` because the unexported fields had incorrect names for the compiler.

I deleted all of the unexported fields in posix_linux_amd64 for the following reasons:

 * They are not exported, therefore they are irrelevant for the API.
 * They don't affect size and offset values, as this computation is reserved for the C compiler when the type is imported for C.
 * padding and alignment fields don't contain any data relevant for printing.
 * They cause problems with `$`.