### PR TITLE
fix regression #13730: `Foo[0.0] is Foo[-0.0]` now true again

### DIFF
--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -26,6 +26,10 @@ proc cyclicTree*(n: PNode): bool =
   var visited: seq[PNode] = @[]
   cyclicTreeAux(n, visited)
 
+proc sameFloatIgnoreNan(a, b: BiggestFloat): bool {.inline.} =
+  ## ignores NaN semantics, but ensures 0.0 == -0.0, see #13730
+  cast[uint64](a) == cast[uint64](b) or a == b
+
 proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
   if a == b:
     result = true
@@ -39,7 +43,7 @@ proc exprStructuralEquivalent*(a, b: PNode; strictSymEquality=false): bool =
         result = a.sym.name.id == b.sym.name.id
     of nkIdent: result = a.ident.id == b.ident.id
     of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = cast[uint64](a.floatVal) == cast[uint64](b.floatVal)
+    of nkFloatLit..nkFloat64Lit: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkCommentStmt: result = a.comment == b.comment
     of nkEmpty, nkNilLit, nkType: result = true
@@ -64,7 +68,7 @@ proc sameTree*(a, b: PNode): bool =
       result = a.sym.name.id == b.sym.name.id
     of nkIdent: result = a.ident.id == b.ident.id
     of nkCharLit..nkUInt64Lit: result = a.intVal == b.intVal
-    of nkFloatLit..nkFloat64Lit: result = cast[uint64](a.floatVal) == cast[uint64](b.floatVal)
+    of nkFloatLit..nkFloat64Lit: result = sameFloatIgnoreNan(a.floatVal, b.floatVal)
     of nkStrLit..nkTripleStrLit: result = a.strVal == b.strVal
     of nkEmpty, nkNilLit, nkType: result = true
     else:

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -88,6 +88,10 @@ when true:
   reject:
     var x = static(v)
 
+block: # issue #13730
+  type Foo[T: static[float]] = object
+  doAssert Foo[0.0] is Foo[-0.0]
+
 when true:
   type
     ArrayWrapper1[S: static int] = object


### PR DESCRIPTION
fix regression #13730