### PR TITLE
[CI] fix recent freebsd systematic failure

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -18,7 +18,8 @@ environment:
 tasks:
 - setup: |
     echo "D20200327T203132"
-    pkg update -f
+    # pkg update -f
+    sudo pkg update -f
     echo "D20200327T203132.2"
     pkg install devel/boehm-gc-threaded
     echo "D20200327T203132.3"

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -6,7 +6,7 @@ packages:
 - databases/sqlite3
 # - devel/boehm-gc-threaded
 - devel/pcre
-- devel/sdl20
+# - devel/sdl20
 - devel/sfml
 - www/node
 - devel/gmake
@@ -19,7 +19,7 @@ tasks:
 - setup: |
     # sudo needed
     sudo pkg update -q -f
-    sudo pkg install -q devel/boehm-gc-threaded
+    sudo pkg install -q devel/boehm-gc-threaded devel/sdl20
 
     echo "D20200327T203132.3"
     cd Nim

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -19,7 +19,7 @@ tasks:
 - setup: |
     # sudo needed
     sudo pkg update -q -f
-    sudo pkg install -q databases/sqlite3 devel/boehm-gc-threaded devel/pcre devel/sdl20 devel/sfml www/node devel/gmake
+    sudo pkg install -y -q databases/sqlite3 devel/boehm-gc-threaded devel/pcre devel/sdl20 devel/sfml www/node devel/gmake
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,10 +1,10 @@
 # see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
-# image: freebsd/latest
-image: freebsd/11.x # workaround https://github.com/timotheecour/Nim/issues/76
+image: freebsd/latest
+# image: freebsd/11.x # workaround https://github.com/timotheecour/Nim/issues/76
 
 packages:
 - databases/sqlite3
-- devel/boehm-gc-threaded
+# - devel/boehm-gc-threaded
 - devel/pcre
 - devel/sdl20
 - devel/sfml

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,6 +1,6 @@
 # see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
 # image: freebsd/latest
-image: freebsd/12.x # workaround https://github.com/timotheecour/Nim/issues/76
+image: freebsd/11.x # workaround https://github.com/timotheecour/Nim/issues/76
 
 packages:
 - databases/sqlite3

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -3,13 +3,13 @@ image: freebsd/latest
 # image: freebsd/11.x # workaround https://github.com/timotheecour/Nim/issues/76
 
 packages:
-- databases/sqlite3
+# - databases/sqlite3
 # - devel/boehm-gc-threaded
-- devel/pcre
+# - devel/pcre
 # - devel/sdl20
-- devel/sfml
-- www/node
-- devel/gmake
+# - devel/sfml
+# - www/node
+# - devel/gmake
 - devel/git
 sources:
 - https://github.com/nim-lang/Nim
@@ -19,9 +19,7 @@ tasks:
 - setup: |
     # sudo needed
     sudo pkg update -q -f
-    sudo pkg install -q devel/boehm-gc-threaded devel/sdl20
-
-    echo "D20200327T203132.3"
+    sudo pkg install -q databases/sqlite3 devel/boehm-gc-threaded devel/pcre devel/sdl20 devel/sfml www/node devel/gmake
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,5 +1,7 @@
 # see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
-image: freebsd/latest
+# image: freebsd/latest
+image: freebsd/12.x # workaround https://github.com/timotheecour/Nim/issues/76
+
 packages:
 - databases/sqlite3
 - devel/boehm-gc-threaded

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -5,11 +5,11 @@ image: freebsd/latest
 packages:
 - databases/sqlite3
 # - devel/boehm-gc-threaded
-- devel/pcre
-- devel/sdl20
-- devel/sfml
-- www/node
-- devel/gmake
+# - devel/pcre
+# - devel/sdl20
+# - devel/sfml
+# - www/node
+# - devel/gmake
 - devel/git
 sources:
 - https://github.com/nim-lang/Nim
@@ -17,6 +17,11 @@ environment:
   CC: /usr/bin/clang
 tasks:
 - setup: |
+    echo "D20200327T203132"
+    pkg update -f
+    echo "D20200327T203132.2"
+    pkg install devel/boehm-gc-threaded
+    echo "D20200327T203132.3"
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -5,11 +5,11 @@ image: freebsd/latest
 packages:
 - databases/sqlite3
 # - devel/boehm-gc-threaded
-# - devel/pcre
-# - devel/sdl20
-# - devel/sfml
-# - www/node
-# - devel/gmake
+- devel/pcre
+- devel/sdl20
+- devel/sfml
+- www/node
+- devel/gmake
 - devel/git
 sources:
 - https://github.com/nim-lang/Nim
@@ -17,11 +17,10 @@ environment:
   CC: /usr/bin/clang
 tasks:
 - setup: |
-    echo "D20200327T203132"
-    # pkg update -f
-    sudo pkg update -f
-    echo "D20200327T203132.2"
-    pkg install devel/boehm-gc-threaded
+    # sudo needed
+    sudo pkg update -q -f
+    sudo pkg install -q devel/boehm-gc-threaded
+
     echo "D20200327T203132.3"
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,8 +1,7 @@
 # see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
 image: freebsd/latest
-# image: freebsd/11.x # workaround https://github.com/timotheecour/Nim/issues/76
 
-packages:
+# packages:
 # - databases/sqlite3
 # - devel/boehm-gc-threaded
 # - devel/pcre
@@ -10,16 +9,17 @@ packages:
 # - devel/sfml
 # - www/node
 # - devel/gmake
-- devel/git
+# - devel/git
 sources:
 - https://github.com/nim-lang/Nim
 environment:
   CC: /usr/bin/clang
 tasks:
 - setup: |
-    # sudo needed
+    # workaround https://github.com/timotheecour/Nim/issues/76
     sudo pkg update -q -f
-    sudo pkg install -y -q databases/sqlite3 devel/boehm-gc-threaded devel/pcre devel/sdl20 devel/sfml www/node devel/gmake
+    sudo pkg install -y -q databases/sqlite3 devel/boehm-gc-threaded devel/pcre \
+      devel/sdl20 devel/sfml www/node devel/gmake devel/git
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)


### PR DESCRIPTION
fix https://github.com/timotheecour/Nim/issues/76 recent freebsd CI systematic failure
seems to affect a lot of PR's; it's a new problem I haven't seen before.

## scratch below
EDIT:
none of these work:
freebsd/latest
image: freebsd/11.x
image: freebsd/12.x

EDIT:
devel/boehm-gc-threaded is not the problem, if i comment it out i get:

The process will require 139 MiB more space.
29 MiB to be downloaded.
[1/40] Fetching sdl2-2.0.10_1.txz: .......... done
pkg: cached package sdl2-2.0.10_1: size mismatch, fetching from remote
[2/40] Fetching sdl2-2.0.10_1.txz: .......... done
pkg: cached package sdl2-2.0.10_1: size mismatch, cannot continue
Consider running 'pkg update -f'

EDIT: found a fix
