### PR TITLE
fix #13794 HashSet leak

### DIFF
--- a/lib/pure/collections/setimpl.nim
+++ b/lib/pure/collections/setimpl.nim
@@ -35,8 +35,9 @@ proc rawInsert[A](s: var HashSet[A], data: var KeyValuePairSeq[A], key: A,
 
 proc enlarge[A](s: var HashSet[A]) =
   var n: KeyValuePairSeq[A]
-  newSeq(n, len(s.data) * growthFactor)
+  newSeq(n, s.counter.rightSize)
   swap(s.data, n) # n is now old seq
+  s.countDeleted = 0
   for i in countup(0, high(n)):
     if isFilledAndValid(n[i].hcode):
       var j = -1 - rawGetKnownHC(s, n[i].key, n[i].hcode)


### PR DESCRIPTION
* fixes  #13794
* after PR, using repro code from #13794 and temporarily export data in HashSet, I get:
```
16
7
```
ie, the data.len doesn't keep growing.
Note that data.len is 16 and not 64 but that's not a regression, that's an implementation detail (i could cap it at `defaultInitialSize` but shouldn't be needed)

- [ ] I need to add tests to this PR to prevent future regressions

