### PR TITLE
add `--experimental:vmopsDanger`; add generic conversion for vmops

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -147,6 +147,7 @@ type
       ## This requires building nim with `-d:nimHasLibFFI`
       ## which itself requires `nimble install libffi`, see #10150
       ## Note: this feature can't be localized with {.push.}
+    vmopsDanger,
 
   LegacyFeature* = enum
     allowSemcheckedAstModification,

--- a/compiler/vmconv.nim
+++ b/compiler/vmconv.nim
@@ -1,0 +1,44 @@
+import ast
+
+template elementType*(T: typedesc): typedesc =
+  typeof(block:
+    var a: T
+    for ai in a: ai)
+
+proc fromLit*(a: PNode, T: typedesc): auto =
+  ## generic PNode => type
+  ## see also reverse operation `toLit`
+  when T is set:
+    result = default(T)
+    type Ti = elementType(T)
+    for ai in a:
+      result.incl Ti(ai.intVal)
+  else:
+    static: doAssert false, "not yet supported: " & $T # add as needed
+
+proc toLit*[T](a: T): PNode =
+  ## generic type => PNode
+  ## see also reverse operation `fromLit`
+  when T is string: result = newStrNode(nkStrLit, a)
+  elif T is Ordinal: result = newIntNode(nkIntLit, a.ord)
+  elif T is tuple:
+    result = newTree(nkTupleConstr)
+    for ai in fields(a): result.add toLit(ai)
+  elif T is (proc):
+    result = newNode(nkNilLit)
+  elif T is ref:
+    if a == nil:
+      result = newNode(nkNilLit)
+    else:
+      result = toLit(a[])
+  elif T is object:
+    result = newTree(nkObjConstr)
+    result.add(newNode(nkEmpty))
+    for k, ai in fieldPairs(a):
+      let reti = newNode(nkExprColonExpr)
+      reti.add k.toLit
+      reti.add ai.toLit
+      result.add reti
+  else:
+    static: doAssert false, "not yet supported: " & $T # add as needed
+

--- a/compiler/vmconv.nim
+++ b/compiler/vmconv.nim
@@ -19,18 +19,15 @@ proc fromLit*(a: PNode, T: typedesc): auto =
 proc toLit*[T](a: T): PNode =
   ## generic type => PNode
   ## see also reverse operation `fromLit`
-  when T is string: result = newStrNode(nkStrLit, a)
-  elif T is Ordinal: result = newIntNode(nkIntLit, a.ord)
+  when T is string: newStrNode(nkStrLit, a)
+  elif T is Ordinal: newIntNode(nkIntLit, a.ord)
+  elif T is (proc): newNode(nkNilLit)
+  elif T is ref:
+    if a == nil: newNode(nkNilLit)
+    else: toLit(a[])
   elif T is tuple:
     result = newTree(nkTupleConstr)
     for ai in fields(a): result.add toLit(ai)
-  elif T is (proc):
-    result = newNode(nkNilLit)
-  elif T is ref:
-    if a == nil:
-      result = newNode(nkNilLit)
-    else:
-      result = toLit(a[])
   elif T is object:
     result = newTree(nkObjConstr)
     result.add(newNode(nkEmpty))

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -19,6 +19,32 @@ from sighashes import symBodyDigest
 from times import cpuTime
 
 from hashes import hash
+from osproc import nil
+
+template elementType(T: typedesc): typedesc =
+  typeof(block:
+    var a: T
+    for ai in a: ai)
+
+proc fromLit*(a: PNode, T: typedesc): auto =
+  ## generic PNode => type
+  when T is set:
+    result = default(T)
+    type Ti = elementType(T)
+    for ai in a:
+      result.incl Ti(ai.intVal)
+  else:
+    static: doAssert false, "not yet supported: " & $T # add as needed
+
+proc toLit[T](a: T): PNode =
+  ## generic type => PNode
+  when T is string: result = newStrNode(nkStrLit, a)
+  elif T is Ordinal: result = newIntNode(nkIntLit, a.ord)
+  elif T is tuple:
+    result = newTree(nkTupleConstr)
+    for ai in fields(a): result.add toLit(ai)
+  else:
+    static: doAssert false, "not yet supported: " & $T # add as needed
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -99,13 +125,12 @@ proc getCurrentExceptionWrapper(a: VmArgs) {.nimcall.} =
 proc staticWalkDirImpl(path: string, relative: bool): PNode =
   result = newNode(nkBracket)
   for k, f in walkDir(path, relative):
-    result.add newTree(nkTupleConstr, newIntNode(nkIntLit, k.ord),
-                              newStrNode(nkStrLit, f))
+    result.add toLit((k, f))
 
 when defined(nimHasInvariant):
   from std / compilesettings import SingleValueSetting, MultipleValueSetting
 
-  proc querySettingImpl(a: VmArgs, conf: ConfigRef, switch: BiggestInt): string =
+  proc querySettingImpl(conf: ConfigRef, switch: BiggestInt): string =
     case SingleValueSetting(switch)
     of arguments: result = conf.arguments
     of outFile: result = conf.outFile.string
@@ -120,7 +145,7 @@ when defined(nimHasInvariant):
     of compileOptions: result = conf.compileOptions
     of ccompilerPath: result = conf.cCompilerPath
 
-  proc querySettingSeqImpl(a: VmArgs, conf: ConfigRef, switch: BiggestInt): seq[string] =
+  proc querySettingSeqImpl(conf: ConfigRef, switch: BiggestInt): seq[string] =
     template copySeq(field: untyped): untyped =
       for i in field: result.add i.string
 
@@ -134,9 +159,9 @@ when defined(nimHasInvariant):
 
 proc registerAdditionalOps*(c: PCtx) =
   proc gorgeExWrapper(a: VmArgs) =
-    let (s, e) = opGorge(getString(a, 0), getString(a, 1), getString(a, 2),
+    let ret = opGorge(getString(a, 0), getString(a, 1), getString(a, 2),
                          a.currentLineInfo, c.config)
-    setResult a, newTree(nkTupleConstr, newStrNode(nkStrLit, s), newIntNode(nkIntLit, e))
+    setResult a, ret.toLit
 
   proc getProjectPathWrapper(a: VmArgs) =
     setResult a, c.config.projectPath.string
@@ -184,9 +209,9 @@ proc registerAdditionalOps*(c: PCtx) =
       setResult(a, staticWalkDirImpl(getString(a, 0), getBool(a, 1)))
     when defined(nimHasInvariant):
       registerCallback c, "stdlib.compilesettings.querySetting", proc (a: VmArgs) {.nimcall.} =
-        setResult(a, querySettingImpl(a, c.config, getInt(a, 0)))
+        setResult(a, querySettingImpl(c.config, getInt(a, 0)))
       registerCallback c, "stdlib.compilesettings.querySettingSeq", proc (a: VmArgs) {.nimcall.} =
-        setResult(a, querySettingSeqImpl(a, c.config, getInt(a, 0)))
+        setResult(a, querySettingSeqImpl(c.config, getInt(a, 0)))
 
     if defined(nimsuggest) or c.config.cmd == cmdCheck:
       discard "don't run staticExec for 'nim suggest'"
@@ -238,8 +263,21 @@ proc registerAdditionalOps*(c: PCtx) =
   registerCallback c, "stdlib.hashes.hashVmImplByte", hashVmImplByte
   registerCallback c, "stdlib.hashes.hashVmImplChar", hashVmImplByte
 
-  if optBenchmarkVM in c.config.globalOptions:
+  if optBenchmarkVM in c.config.globalOptions or vmopsDanger in c.config.features:
     wrap0(cpuTime, timesop)
   else:
     proc cpuTime(): float = 5.391245e-44  # Randomly chosen
     wrap0(cpuTime, timesop)
+
+  if vmopsDanger in c.config.features:
+    ## useful procs but these should be opt-in because they may impact
+    ## reproducible builds. Note that `staticExec` can already do equal amount
+    ## of damage so it's more of a semantic issue than a security issue.
+    registerCallback c, "stdlib.os.getCurrentDir", proc (a: VmArgs) {.nimcall.} =
+      setResult(a, os.getCurrentDir())
+
+    proc execCmdExImpl(a: VmArgs) =
+      let options = getNode(a, 1).fromLit(set[osproc.ProcessOption])
+      a.setResult osproc.execCmdEx(getString(a, 0), options).toLit
+
+    registerCallback c, "stdlib.osproc.execCmdEx", execCmdExImpl

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -253,23 +253,8 @@ proc registerAdditionalOps*(c: PCtx) =
     ## of a semantic issue than a security issue.
     registerCallback c, "stdlib.os.getCurrentDir", proc (a: VmArgs) {.nimcall.} =
       setResult(a, os.getCurrentDir())
-
-    proc execCmdExImpl(a: VmArgs) =
+    registerCallback c, "stdlib.osproc.execCmdEx", proc (a: VmArgs) {.nimcall.} =
       let options = getNode(a, 1).fromLit(set[osproc.ProcessOption])
       a.setResult osproc.execCmdEx(getString(a, 0), options).toLit
-
-    registerCallback c, "stdlib.osproc.execCmdEx", execCmdExImpl
-# local*(): Timezone
-    registerCallback c, "stdlib.times.local", proc (a: VmArgs) {.nimcall.} =
-      setResult(a, times.local().toLit)
     registerCallback c, "stdlib.times.getTime", proc (a: VmArgs) {.nimcall.} =
-      let t = times.getTime()
-      echo "before"
-      let t2 = t.toLit
-      echo "after"
-      echo t2
-      echo "after2"
-      # setResult(a, t.toLit)
-      setResult(a, t2)
-        # newNodeIT(nkObjConstr, n.info, n[1].typ), {})
-      # setResult(a, newTree(nkObjConstr, newIntNode(nkIntLit, t.seconds), newIntNode(nkIntLit, t.nanosecond)))
+      setResult(a, times.getTime().toLit)

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1198,11 +1198,6 @@ proc utcTzInfo(time: Time): ZonedTime =
 
 var utcInstance {.threadvar.}: Timezone
 var localInstance {.threadvar.}: Timezone
-# var localInstanceRT {.threadvar.}: Timezone
-# var localInstanceVM {.compileTime.}: Timezone
-# template localInstance(): untyped =
-#   when nimvm: localInstanceVM
-#   else: localInstanceRT
 
 proc utc*(): Timezone =
   ## Get the ``Timezone`` implementation for the UTC timezone.

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1198,6 +1198,11 @@ proc utcTzInfo(time: Time): ZonedTime =
 
 var utcInstance {.threadvar.}: Timezone
 var localInstance {.threadvar.}: Timezone
+# var localInstanceRT {.threadvar.}: Timezone
+# var localInstanceVM {.compileTime.}: Timezone
+# template localInstance(): untyped =
+#   when nimvm: localInstanceVM
+#   else: localInstanceRT
 
 proc utc*(): Timezone =
   ## Get the ``Timezone`` implementation for the UTC timezone.


### PR DESCRIPTION
* this PR adds `compiler/vmconv.nim` with generic `proc toLit*[T](a: T): PNode` to convert a concrete type to a PNode (it works recursively). `fromLit` is also added for reverse direction. I only implemented the branches that were needed to support the vmops introduced, but it's easy to make it more complete in future PRs as needed. This avoids tedious manual conversion.

* it PR also adds `--experimental:vmopsDanger` to enable certain operations in VM that I and others need.
Since this is hidden behind a flag, only code that needs this feature will be able to use it.

* can close #13786 by providing a more flexible alternative

## often requested
This was also requested in several occasions, eg:
* [Times in the VM? - Nim forum : Times in the VM? - Nim forum](https://forum.nim-lang.org/t/6058#37491)
> What I'm asking is, could there ever be a staticTime proc analog to times.getTime

* https://github.com/nim-lang/Nim/pull/13451#issuecomment-590019186
> We talked about adding getCurrentDir for bump's use-case. I would use this in nimph and testutils and golden and openapi, too. I guess I'm just a bad person.

> I think you have to concede that if this isn't provided, a work-around will be developed, and that's clearly a worse option. Can you really champion NimScript as the right tool for writing build scripts when one cannot even find the current working directory in NimScript?

* nimterop also needs a lot of functions at CT (by design) and currently to resort to using `staticExec` which, I've argued in several places (eg https://forum.nim-lang.org/t/6058#37491) is often not the right tool (error prone / os specific shell commands, requires manual serialization/deserialization, inefficient, and many other drawbacks you encounter once you start using it more)

* `staticExec` is too limited (eg, no flags, and other issues), this PR provides a workaround that should close https://github.com/nim-lang/Nim/issues/13786; IMO it's better to reuse stdlib's osproc API's than re-invent another proc with different semantics that keep tripping users; caching (as done in staticExec) can always be done via a separate / orthogonal API eg `cache(execCmdEx(...), ... )` usable at both RT and CT

## example after PR:
`nim c -r --experimental:vmopsDanger t10460.nim` works

```nim
import osproc, os, times
proc main()=
  {.push experimental: "vmopsDanger".} # not yet meaningful in localized context
  echo getCurrentDir()
  let t = getTime()
  echo t.toUnixFloat
  echo cpuTime()
  let (outp, errC) = execCmdEx("echo ok1 && echo ok2 && nonexistant", {poEchoCmd,poStdErrToStdOut})
  # let (outp, errC) = gorgeEx("echo ok1 && echo ok2")
    # removes LF and has other "surprising" behavior that differs from
    # `execCmdEx`; `execCmdEx` gives you more control when needed.
  echo (outp, errC)
  {.pop.}

static: main()
main()
```

## links
* https://github.com/nim-lang/Nim/pull/16943#issuecomment-773980301 --experimental:vmSandbox