### PR TITLE
Fix browsers.openDefaultBrowser

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -25,7 +25,8 @@ const osOpenCmd* =
   ## ``"open"`` on MacOS and Windows, ``"xdg-open"`` on Linux, BSD, etc.
 
 proc openDefaultBrowser*(url: string) =
-  ## opens `url` with the user's default browser. This does not block.
+  ## Opens `url` with the user's default browser. This does not block.
+  ## The URL must not be empty string.
   ##
   ## Under Windows, ``ShellExecute`` is used. Under Mac OS X the ``open``
   ## command is used. Under Unix, it is checked if ``xdg-open`` exists and
@@ -36,6 +37,7 @@ proc openDefaultBrowser*(url: string) =
   ##
   ## .. code-block:: nim
   ##   block: openDefaultBrowser("https://nim-lang.org")
+  doAssert url.len > 0, "URL must not be empty string"
   when defined(windows):
     var o = newWideCString(osOpenCmd)
     var u = newWideCString(url)


### PR DESCRIPTION
- Tiny fix on `browsers.openDefaultBrowser()`. Easy Merge.

```nim
import browsers
openDefaultBrowser("")
```

```console
$ nim c -f -r example.nim
   xdg-open -- opens a file or URL in the user's preferred
   application

Synopsis

   xdg-open { file | URL }

   xdg-open { --help | --manual | --version }

Use 'man xdg-open' or 'xdg-open --manual' for additional info.

$ 
```
