### PR TITLE
Documentation, Fix "See XXX"

### DIFF
--- a/lib/core/macrocache.nim
+++ b/lib/core/macrocache.nim
@@ -11,8 +11,7 @@
 ## time information across module boundaries in global variables.
 ## Starting with version 0.19 of Nim this is not directly supported anymore
 ## as it breaks incremental compilations.
-## Instead the API here needs to be used. See XXX (wikipedia page) for a
-## theoretical foundation behind this.
+## Instead the API here needs to be used.
 
 type
   CacheSeq* = distinct string


### PR DESCRIPTION
- Fix a "See XXX" on documentation, clean out documentation.
- It never had a Wikipedia link whatsoever, it says "(wikipedia page)", I searched back the Git History.
- It is kinda Deprecated(?) anyway.
