### PR TITLE
Add arm/arm64 for FreeBSD

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -9,7 +9,7 @@ Platforms: """
   linux: i386;hppa;ia64;alpha;amd64;powerpc64;arm;sparc;sparc64;m68k;mips;mipsel;mips64;mips64el;powerpc;powerpc64el;arm64;riscv64
   macosx: i386;amd64;powerpc64
   solaris: i386;amd64;sparc;sparc64
-  freebsd: i386;amd64;powerpc64
+  freebsd: i386;amd64;powerpc64;arm;arm64
   netbsd: i386;amd64
   openbsd: i386;amd64
   dragonfly: i386;amd64

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -180,10 +180,10 @@ case $ucpu in
     ;;
   *alpha* )
     mycpu="alpha" ;;
+  *aarch64*|*arm64* )
+    mycpu="arm64" ;;
   *arm*|*armv6l*|*armv71* )
     mycpu="arm" ;;
-  *aarch64* )
-    mycpu="arm64" ;;
   *riscv64* )
     mycpu="riscv64" ;;
   *)


### PR DESCRIPTION
Tested on FreeBSD 13 Current with arm64.aarch64 and arm.armv6