### PR TITLE
fix "too many open files" 'leak'  when running `--debugger:native`

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1924,8 +1924,8 @@ proc shouldRecompile(m: BModule; code: Rope, cfile: Cfile): bool =
 # it would generate multiple 'main' procs, for instance.
 
 proc writeModule(m: BModule, pending: bool) =
+  template onExit() = close(m.ndi, m.config)
   let cfile = getCFile(m)
-
   if true or optForceFullMake in m.config.globalOptions:
     if moduleHasChanged(m.g.graph, m.module):
       genInitCode(m)
@@ -1943,6 +1943,7 @@ proc writeModule(m: BModule, pending: bool) =
       when hasTinyCBackend:
         if conf.cmd == cmdRun:
           tccgen.compileCCode($code)
+          onExit()
           return
 
       if not shouldRecompile(m, code, cf): cf.flags = {CfileFlag.Cached}
@@ -1966,7 +1967,7 @@ proc writeModule(m: BModule, pending: bool) =
                    obj: completeCfilePath(m.config, toObjFile(m.config, cfile)), flags: {})
     if not fileExists(cf.obj): cf.flags = {CfileFlag.Cached}
     addFileToCompile(m.config, cf)
-  close(m.ndi)
+  onExit()
 
 proc updateCachedModule(m: BModule) =
   let cfile = getCFile(m)

--- a/compiler/ndi.nim
+++ b/compiler/ndi.nim
@@ -17,6 +17,8 @@ type
     enabled: bool
     f: File
     buf: string
+    filename: AbsoluteFile
+    syms: seq[PSym]
 
 proc doWrite(f: var NdiFile; s: PSym; conf: ConfigRef) =
   f.buf.setLen 0
@@ -28,13 +30,20 @@ proc doWrite(f: var NdiFile; s: PSym; conf: ConfigRef) =
   f.f.writeLine("\t", toFullPath(conf, s.info), "\t", f.buf)
 
 template writeMangledName*(f: NdiFile; s: PSym; conf: ConfigRef) =
-  if f.enabled: doWrite(f, s, conf)
+  if f.enabled: f.syms.add s
 
 proc open*(f: var NdiFile; filename: AbsoluteFile; conf: ConfigRef) =
   f.enabled = not filename.isEmpty
   if f.enabled:
-    f.f = open(filename.string, fmWrite, 8000)
+    f.filename = filename
     f.buf = newStringOfCap(20)
 
-proc close*(f: var NdiFile) =
-  if f.enabled: close(f.f)
+proc close*(f: var NdiFile, conf: ConfigRef) =
+  if f.enabled:
+    f.f = open(f.filename.string, fmWrite, 8000)
+    doAssert f.f != nil, f.filename.string
+    for s in f.syms:
+      doWrite(f, s, conf)
+    close(f.f)
+    f.syms.reset
+    f.filename.reset


### PR DESCRIPTION
/cc @Araq 
this PR fixes a critical issue that caused nim to have too many file descriptors opened, and caused cryptic errors when passing `--debugger:native` on projects with more than ~260 file: `Error: cannot open '/valid/path/to/foo.nim` even though the path was valid.

The reason:
* `llStreamOpen` should show `errno, $strerror(errno)` on error but doesn't (that's where the `too many open files` OS error would've been shown)
* nim keeps 1 file descriptor open per module that's semchecked (for the ndi files) and only closes them later during cgen.

## before PR:
```
/private/tmp/D20200401T065629/main.nim(242, 1) template/generic instantiation from here
Error: cannot open '/private/tmp/D20200401T065629/m241.nim'
```

## after PR:
root cause fixed, and this works
## test case
```nim
import os,strformat
proc main()=
  let dir = "/tmp/D20200401T065629/"
  let dirCache = dir/"nimcache"
  createDir dir
  # let n = 240 # works
  let n = 270 # fails
  let file0 = dir / "main.nim"
  var s = ""
  for i in 0..<n:
    let file = dir / fmt"m{i}.nim"
    writeFile file, "discard"
    s.add "import "
    s.addQuoted file
    s.add "\n"
  writeFile file0, s
  const nim = getCurrentCompilerExe()
  let status = execShellCmd(fmt"{nim} c -r --stacktrace:on --debugger:native --nimcache:{dirCache} --warning:UnusedImport:off {file0}")
  doAssert status == 0

main()
```

## note
on OSX, by default processes have a limit of 256 file descriptors:
```
ulimit -n
256
```
so other OS's may have that error for different values of `n`