### PR TITLE
make `usage of foo is a user-defined error` more informative

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -523,14 +523,16 @@ proc warnAboutDeprecated(conf: ConfigRef; info: TLineInfo; s: PSym) =
 
 proc userError(conf: ConfigRef; info: TLineInfo; s: PSym) =
   let pragmaNode = extractPragma(s)
-
+  template bail(prefix: string) =
+    localError(conf, info, "$1usage of '$2' is an {.error.} defined at $3" %
+      [prefix, s.name.s, toFileLineCol(conf, s.ast.info)])
   if pragmaNode != nil:
     for it in pragmaNode:
       if whichPragma(it) == wError and it.safeLen == 2 and
           it[1].kind in {nkStrLit..nkTripleStrLit}:
-        localError(conf, info, it[1].strVal & "; usage of '$1' is a user-defined error" % s.name.s)
+        bail(it[1].strVal & "; ")
         return
-  localError(conf, info, "usage of '$1' is a user-defined error" % s.name.s)
+  bail("")
 
 proc markOwnerModuleAsUsed(c: PContext; s: PSym) =
   var module = s


### PR DESCRIPTION
/cc @Araq 
## before PR
procs marked with {.error.} give very uninformative/cryptic errors when used.

Example:
```nim
var a: seq[int]
echo a.isNil
```
t10464.nim(11, 8) Error: usage of 'isNil' is a user-defined error

totally cryptic, and we have no way to tell where this error comes from, especially in more complex cases where the type of `a` is generic, and there are many overloads. 

## after PR
we show where the symbol is defined, eg:
t10464.nim(11, 8) Error: usage of 'isNil' is an {.error.} defined at /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim(1509, 1)

now it's clear: looking up the definition there shows:
```
proc isNil*[T](x: seq[T]): bool {.noSideEffect, magic: "IsNil", nilError.}
```
(and looking up {.nilError.} shows this resolves to {.error.})

