### PR TITLE
Add browsers.openDefaultBrowser without URL, implements RFC-6694

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -123,6 +123,8 @@ echo f
   retrieving the verified certificate chain of the peer we are connected to
   through an SSL-wrapped `Socket`/`AsyncSocket`.
 - Added `distinctBase` overload for values: `assert 12.MyInt.distinctBase == 12`
+- Added `browsers.openDefaultBrowser` without URL, implements IETF RFC-6694 Section-3.
+
 
 ## Library changes
 


### PR DESCRIPTION
- Add `browsers.openDefaultBrowser()` without URL.
- Implements IETF RFC-6694 Section-3 https://tools.ietf.org/html/rfc6694#section-3
- Code is literally the same, moved into `template` to DRY.
- Can *not* use empty string because https://github.com/nim-lang/Nim/pull/13818#issue-396473868
- Documentation with example and links.
