### PR TITLE
Remove noop deprecated DCE pragmas

### DIFF
--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -113,8 +113,6 @@
 ## * `db_mysql module <db_mysql.html>`_ for MySQL database wrapper
 ## * `db_postgres module <db_postgres.html>`_ for PostgreSQL database wrapper
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 import sqlite3
 
 import db_common

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -20,7 +20,6 @@
 ##   var userResponse: string
 ##   doAssert readLineFromStdin("How are you?:", line = userResponse)
 ##   echo userResponse
-{.deadCodeElim: on.}  # dce option deprecated
 
 when defined(Windows):
   proc readLineFromStdin*(prompt: string): TaintedString {.

--- a/lib/posix/epoll.nim
+++ b/lib/posix/epoll.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 from posix import SocketHandle
 
 const

--- a/lib/posix/linux.nim
+++ b/lib/posix/linux.nim
@@ -1,5 +1,3 @@
-{.deadCodeElim: on.}  # dce option deprecated
-
 import posix
 
 const

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -33,7 +33,6 @@
 # Dead code elimination ensures that we don't accidentally generate #includes
 # for files that might not exist on a specific platform! The user will get an
 # error only if they actually try to use the missing declaration
-{.deadCodeElim: on.}  # dce option deprecated
 
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}

--- a/lib/posix/posix_macos_amd64.nim
+++ b/lib/posix/posix_macos_amd64.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 

--- a/lib/posix/posix_openbsd_amd64.nim
+++ b/lib/posix/posix_openbsd_amd64.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 

--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 

--- a/lib/posix/posix_utils.nim
+++ b/lib/posix/posix_utils.nim
@@ -11,8 +11,6 @@
 
 # Where possible, contribute OS-independent procs in `os <os.html>`_ instead.
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 import posix
 
 type Uname* = object

--- a/lib/posix/termios.nim
+++ b/lib/posix/termios.nim
@@ -7,7 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
 import posix
 
 type

--- a/lib/pure/fenv.nim
+++ b/lib/pure/fenv.nim
@@ -10,8 +10,6 @@
 ## Floating-point environment. Handling of floating-point rounding and
 ## exceptions (overflow, division by zero, etc.).
 
-{.deadCodeElim: on.} # dce option deprecated
-
 when defined(Posix) and not defined(genode):
   {.passl: "-lm".}
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -66,7 +66,6 @@
 
 include "system/inclrtl"
 
-{.deadCodeElim: on.} # dce option deprecated
 import nativesockets, os, strutils, times, sets, options, std/monotimes
 from ssl_certs import scanSSLCertificates
 export nativesockets.Port, nativesockets.`$`, nativesockets.`==`

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -45,9 +45,6 @@
 ## * `parsexml module<parsexml.html>`_ for a XML / HTML parser
 ## * `other parsers<lib.html#pure-libraries-parsers>`_ for other parsers
 
-
-{.deadCodeElim: on.} # dce option deprecated
-
 {.push debugger: off.} # the user does not want to trace a part
                        # of the standard library!
 

--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -19,8 +19,6 @@
 include "system/inclrtl"
 import streams
 
-{.deadCodeElim: on.} # dce option deprecated
-
 {.push debugger: off.} # the user does not want to trace a part
                        # of the standard library!
 

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -12,8 +12,6 @@
 
 import strutils
 
-{.deadCodeElim: on.} # dce option deprecated
-
 proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect,
   procvar.} =
   ## Expand tab characters in `s` replacing them by spaces.

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -20,9 +20,6 @@
 ## * `unidecode module <unidecode.html>`_
 ## * `encodings module <encodings.html>`_
 
-
-{.deadCodeElim: on.} # dce option deprecated
-
 include "system/inclrtl"
 
 type

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -10,8 +10,6 @@
 ## This module implements a small wrapper for some needed Win API procedures,
 ## so that the Nim compiler does not depend on the huge Windows module.
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 import dynlib
 
 when defined(nimHasStyleChecks):

--- a/lib/wrappers/iup.nim
+++ b/lib/wrappers/iup.nim
@@ -34,8 +34,6 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # ****************************************************************************
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 when defined(windows):
   const dllname = "iup(|30|27|26|25|24).dll"
 elif defined(macosx):

--- a/lib/wrappers/mysql.nim
+++ b/lib/wrappers/mysql.nim
@@ -7,7 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
 {.push, callconv: cdecl.}
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}

--- a/lib/wrappers/odbcsql.nim
+++ b/lib/wrappers/odbcsql.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 when not defined(ODBCVER):
   const
     ODBCVER = 0x0351 ## define ODBC version 3.51 by default

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -22,7 +22,6 @@
 ##   ./bin/nim c -d:ssl -p:. -r tests/untestable/tssl.nim
 ##   ./bin/nim c -d:ssl -p:. --dynlibOverride:ssl --passl:-lcrypto --passl:-lssl -r tests/untestable/tssl.nim
 
-{.deadCodeElim: on.}  # dce option deprecated
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 

--- a/lib/wrappers/pcre.nim
+++ b/lib/wrappers/pcre.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 # The current PCRE version information.
 
 const

--- a/lib/wrappers/postgres.nim
+++ b/lib/wrappers/postgres.nim
@@ -15,7 +15,6 @@
 # connection-protocol.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 

--- a/lib/wrappers/sqlite3.nim
+++ b/lib/wrappers/sqlite3.nim
@@ -7,8 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-{.deadCodeElim: on.}  # dce option deprecated
-
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 


### PR DESCRIPTION
- Remove deprecated `{.deadCodeElim: on.}`.
