### PR TITLE
fix last remaining warning when building nim (`intVal should be Int128`) + minor cleanups

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -456,6 +456,9 @@ const
 
   tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyUntyped} + tyTypeClasses
   tyUserTypeClasses* = {tyUserTypeClass, tyUserTypeClassInst}
+  # RENAME tyAbstractVarRange?
+  abstractVarRange* = {tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal,
+                       tyTypeDesc, tyAlias, tyInferred, tySink, tyOwned}
 
 type
   TTypeKinds* = set[TTypeKind]
@@ -1272,12 +1275,8 @@ proc skipTypes*(t: PType, kinds: TTypeKinds): PType =
   while result.kind in kinds: result = lastSon(result)
 
 proc newIntTypeNode*(intVal: BiggestInt, typ: PType): PNode =
-
-  # this is dirty. abstractVarRange isn't defined yet and therefore it
-  # is duplicated here.
-  const abstractVarRange = {tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal,
-                       tyTypeDesc, tyAlias, tyInferred, tySink, tyOwned}
-  case skipTypes(typ, abstractVarRange).kind
+  let kind = skipTypes(typ, abstractVarRange).kind
+  case kind
   of tyInt:     result = newNode(nkIntLit)
   of tyInt8:    result = newNode(nkInt8Lit)
   of tyInt16:   result = newNode(nkInt16Lit)
@@ -1289,9 +1288,10 @@ proc newIntTypeNode*(intVal: BiggestInt, typ: PType): PNode =
   of tyUInt16:  result = newNode(nkUInt16Lit)
   of tyUInt32:  result = newNode(nkUInt32Lit)
   of tyUInt64:  result = newNode(nkUInt64Lit)
-  else: # tyBool, tyEnum
+  of tyBool,tyEnum:
     # XXX: does this really need to be the kind nkIntLit?
     result = newNode(nkIntLit)
+  else: doAssert false, $kind
   result.intVal = intVal
   result.typ = typ
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -456,7 +456,7 @@ const
 
   tyMetaTypes* = {tyGenericParam, tyTypeDesc, tyUntyped} + tyTypeClasses
   tyUserTypeClasses* = {tyUserTypeClass, tyUserTypeClassInst}
-  # RENAME tyAbstractVarRange?
+  # consider renaming as `tyAbstractVarRange`
   abstractVarRange* = {tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal,
                        tyTypeDesc, tyAlias, tyInferred, tySink, tyOwned}
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1291,6 +1291,8 @@ proc newIntTypeNode*(intVal: BiggestInt, typ: PType): PNode =
   of tyBool,tyEnum:
     # XXX: does this really need to be the kind nkIntLit?
     result = newNode(nkIntLit)
+  of tyStatic: # that's a pre-existing bug, will fix in another PR
+    result = newNode(nkIntLit)
   else: doAssert false, $kind
   result.intVal = intVal
   result.typ = typ

--- a/compiler/int128.nim
+++ b/compiler/int128.nim
@@ -29,27 +29,27 @@ template high*(t: typedesc[Int128]): Int128 = Max
 
 proc `$`*(a: Int128): string
 
-proc toInt128*[T: SomeInteger](arg: T): Int128 =
-  when T is SomeUnsignedInt:
+proc toInt128*[T: SomeInteger | bool](arg: T): Int128 =
+  when T is bool: result.sdata(0) = int32(arg)
+  elif T is SomeUnsignedInt:
     when sizeof(arg) <= 4:
       result.udata[0] = uint32(arg)
     else:
       result.udata[0] = uint32(arg and T(0xffffffff))
       result.udata[1] = uint32(arg shr 32)
+  elif sizeof(arg) <= 4:
+    result.sdata(0) = int32(arg)
+    if arg < 0: # sign extend
+      result.sdata(1) = -1
+      result.sdata(2) = -1
+      result.sdata(3) = -1
   else:
-    when sizeof(arg) <= 4:
-      result.sdata(0) = int32(arg)
-      if arg < 0: # sign extend
-        result.sdata(1) = -1
-        result.sdata(2) = -1
-        result.sdata(3) = -1
-    else:
-      let tmp = int64(arg)
-      result.udata[0] = uint32(tmp and 0xffffffff)
-      result.sdata(1) = int32(tmp shr 32)
-      if arg < 0: # sign extend
-        result.sdata(2) = -1
-        result.sdata(3) = -1
+    let tmp = int64(arg)
+    result.udata[0] = uint32(tmp and 0xffffffff)
+    result.sdata(1) = int32(tmp shr 32)
+    if arg < 0: # sign extend
+      result.sdata(2) = -1
+      result.sdata(3) = -1
 
 template isNegative(arg: Int128): bool =
   arg.sdata(3) < 0

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -419,7 +419,7 @@ proc foldConv(n, a: PNode; g: ModuleGraph; check = false): PNode =
       result = newIntNodeT(toInt128(getFloat(a) != 0.0), n, g)
     of tyChar, tyUInt..tyUInt64, tyInt..tyInt64:
       result = newIntNodeT(toInt128(a.getOrdValue != 0), n, g)
-    of tyBool: # PRTEMP: enum?
+    of tyBool, tyEnum: # xxx shouldn't we disallow `tyEnum`?
       result = a
       result.typ = n.typ
     else: doAssert false, $srcTyp.kind

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -20,26 +20,6 @@ proc errorType*(g: ModuleGraph): PType =
   result = newType(tyError, g.owners[^1])
   result.flags.incl tfCheckedForDestructor
 
-proc newIntNodeT*(intVal: BiggestInt, n: PNode; g: ModuleGraph): PNode {.deprecated: "intVal should be Int128".} =
-  case skipTypes(n.typ, abstractVarRange).kind
-  of tyInt:
-    result = newIntNode(nkIntLit, intVal)
-    # See bug #6989. 'pred' et al only produce an int literal type if the
-    # original type was 'int', not a distinct int etc.
-    if n.typ.kind == tyInt:
-      result.typ = getIntLitType(g, result)
-    else:
-      result.typ = n.typ
-    # hrm, this is not correct: 1 + high(int) shouldn't produce tyInt64 ...
-    #setIntLitType(result)
-  of tyChar:
-    result = newIntNode(nkCharLit, intVal)
-    result.typ = n.typ
-  else:
-    result = newIntNode(nkIntLit, intVal)
-    result.typ = n.typ
-  result.info = n.info
-
 proc newIntNodeT*(intVal: Int128, n: PNode; g: ModuleGraph): PNode =
   result = newIntTypeNode(intVal, n.typ)
   # See bug #6989. 'pred' et al only produce an int literal type if the
@@ -436,12 +416,13 @@ proc foldConv(n, a: PNode; g: ModuleGraph; check = false): PNode =
   of tyBool:
     case srcTyp.kind
     of tyFloat..tyFloat64:
-      result = newIntNodeT(int(getFloat(a) != 0.0), n, g)
+      result = newIntNodeT(toInt128(getFloat(a) != 0.0), n, g)
     of tyChar, tyUInt..tyUInt64, tyInt..tyInt64:
-      result = newIntNodeT(int(a.getOrdValue != 0), n, g)
-    else:
+      result = newIntNodeT(toInt128(a.getOrdValue != 0), n, g)
+    of tyBool: # PRTEMP: enum?
       result = a
       result.typ = n.typ
+    else: doAssert false, $srcTyp.kind
   of tyInt..tyInt64, tyUInt..tyUInt64:
     case srcTyp.kind
     of tyFloat..tyFloat64:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -63,8 +63,7 @@ const
                   tyAlias, tyInferred, tySink, tyLent, tyOwned}
   abstractRange* = {tyGenericInst, tyRange, tyDistinct, tyOrdinal, tyTypeDesc,
                     tyAlias, tyInferred, tySink, tyOwned}
-  abstractVarRange* = {tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal,
-                       tyTypeDesc, tyAlias, tyInferred, tySink, tyOwned}
+  # see also ast.abstractVarRange
   abstractInst* = {tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias,
                    tyInferred, tySink, tyOwned}
   abstractInstOwned* = abstractInst + {tyOwned}


### PR DESCRIPTION
/cc @Araq 
* fix last remaining warning when building nim (`intVal should be Int128`)
* remove code duplication `abstractVarRange`
* cleanups allowing removing of deprecated proc `newIntNodeT`
* no change in semantics