### PR TITLE
fix asynchttpserver content-length header

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -99,9 +99,12 @@ proc respond*(req: Request, code: HttpCode, content: string,
 
   if headers != nil:
     msg.addHeaders(headers)
-  msg.add("Content-Length: ")
-  # this particular way saves allocations:
-  msg.add content.len
+    
+  if not headers.hasKey("Content-Length"):
+    msg.add("Content-Length: ")
+    # this particular way saves allocations:
+    msg.addInt content.len
+  
   msg.add "\c\L\c\L"
   msg.add(content)
   result = req.client.send(msg)


### PR DESCRIPTION
If user specify `content-length` in headers will cause server send duplicated `content-length` headers.
User defined `content-length` will be used to send stream response.

issues in:
https://github.com/dom96/jester/issues/241

Test Code in:
https://github.com/xflywind/test_jester

Got Error: ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_LENGTH

Because jester sends multiple content length.