### PR TITLE
fix SIGSEGV in VM in opcLdDeref

### DIFF
--- a/tests/vm/tref.nim
+++ b/tests/vm/tref.nim
@@ -60,3 +60,12 @@ static: # bug #8402
   type R = ref object
   var empty: R
   let otherEmpty = empty
+
+block:
+  # fix https://github.com/timotheecour/Nim/issues/88
+  template fun() =
+    var s = @[10,11,12]
+    var a = s[0].addr
+    a[] += 100 # was giving SIGSEGV
+    doAssert a[] == 110
+  static: fun()


### PR DESCRIPTION
* fix https://github.com/timotheecour/Nim/issues/88
* refactored code in common between opcWrDeref and opcLdDeref
* should be backported to 1.2
* see tests/vm/tref.nim
```nim
block:
  # fix https://github.com/timotheecour/Nim/issues/88
  template fun() =
    var s = @[10,11,12]
    var a = s[0].addr
    a[] += 100 # was giving SIGSEGV
    doAssert a[] == 110
  static: fun()
```

/cc @araq failure unrelated https://github.com/nitely/nim-regex/issues/60 EDIT: fixed now

