### PR TITLE
fix: `var a{.foo.} = expr` inside templates (refs #15920) (except when `foo` is overloaded)

### DIFF
--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -54,3 +54,5 @@ proc isCompilerDebug*(): bool =
       {.undef(nimCompilerDebug).}
       echo 'x'
   conf0.isDefined("nimCompilerDebug")
+
+include timn/exp/nim_compiler_debugutils

--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -54,5 +54,3 @@ proc isCompilerDebug*(): bool =
       {.undef(nimCompilerDebug).}
       echo 'x'
   conf0.isDefined("nimCompilerDebug")
-
-include timn/exp/nim_compiler_debugutils

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -447,25 +447,17 @@ proc setVarType(c: PContext; v: PSym, typ: PType) =
 
 proc semLowerLetVarCustomPragma(c: PContext, a: PNode, n: PNode): PNode =
   var b = a[0]
-  dbgIf b, b.kind
   if b.kind == nkPragmaExpr:
-    dbgIf b[1].len
     if b[1].len != 1:
       # we could in future support pragmas w args e.g.: `var foo {.bar:"goo".} = expr`
       return nil
     let nodePragma = b[1][0]
     # see: `singlePragma`
-    dbgIf nodePragma, nodePragma.kind
 
     var amb = false
     var sym: PSym = nil
     case nodePragma.kind
     of nkIdent, nkAccQuoted:
-      dbgIf nodePragma, nodePragma.kind, templatePragmas
-      if nodePragma.kind == nkIdent:
-        for a in templatePragmas: # see D20210801T100514 test
-          if nodePragma.ident == getIdent(c.cache, $a):
-            return nil
       let ident = considerQuotedIdent(c, nodePragma)
       var userPragma = strTableGet(c.userPragmas, ident)
       if userPragma != nil: return nil
@@ -480,7 +472,6 @@ proc semLowerLetVarCustomPragma(c: PContext, a: PNode, n: PNode): PNode =
       if sym == nil or sfCustomPragma in sym.flags: return nil
     of nkSym:
       sym = nodePragma.sym
-      dbgIf sym, sym.kind
     else:
       return nil
       # skip if not in scope; skip `template myAttr() {.pragma.}`

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -211,10 +211,11 @@ proc addLocalDecl(c: var TemplCtx, n: var PNode, k: TSymKind) =
         let ni = pragmaNode[i]
         # see D20210801T100514
         var found = false
-        for a in templatePragmas:
-          if ni.ident == getIdent(c.c.cache, $a):
-            found = true
-            break
+        if ni.kind == nkIdent:
+          for a in templatePragmas:
+            if ni.ident == getIdent(c.c.cache, $a):
+              found = true
+              break
         if not found:
           openScope(c)
           pragmaNode[i] = semTemplBody(c, pragmaNode[i])

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -337,6 +337,10 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
   semIdeForTemplateOrGenericCheck(c.c.config, n, c.cursorInBody)
   case n.kind
   of nkIdent:
+    # see D20210801T100514
+    for a in templatePragmas:
+      if n.ident == getIdent(c.c.cache, $a):
+        return n
     if n.ident.id in c.toInject: return n
     let s = qualifiedLookUp(c.c, n, {})
     if s != nil:

--- a/tests/pragmas/tpragmas_misc.nim
+++ b/tests/pragmas/tpragmas_misc.nim
@@ -10,3 +10,46 @@ block:
   static: doAssert defined(tpragmas_misc_def)
   {.undef(tpragmas_misc_def).}
   static: doAssert not defined(tpragmas_misc_def)
+
+block: # (partial fix) bug #15920
+  block: # var template pragmas don't work in templates
+    template foo(lhs, typ, expr) =
+      let lhs = expr
+    proc fun1()=
+      let a {.foo.} = 1
+    template fun2()=
+      let a {.foo.} = 1
+    fun1() # ok
+    fun2() # WAS bug
+
+  template foo2() = discard # distractor (template or other symbol kind)
+  block:
+    template foo2(lhs, typ, expr) =
+      let lhs = expr
+    proc fun1()=
+      let a {.foo2.} = 1
+    template fun2()=
+      let a {.foo2.} = 1
+    fun1() # ok
+    when false: # bug: Error: invalid pragma: foo2
+      fun2()
+
+  block: # proc template pragmas don't work in templates
+    # adapted from $nim/lib/std/private/since.nim
+    # case without overload
+    template since3(version: (int, int), body: untyped) {.dirty.} =
+      when (NimMajor, NimMinor) >= version:
+        body
+    when false: # bug
+      template fun3(): int {.since3: (1, 3).} = 12
+
+  block: # ditto, w
+    # case with overload
+    template since2(version: (int, int), body: untyped) {.dirty.} =
+      when (NimMajor, NimMinor) >= version:
+        body
+    template since2(version: (int, int, int), body: untyped) {.dirty.} =
+      when (NimMajor, NimMinor, NimPatch) >= version:
+        body
+    when false: # bug
+      template fun3(): int {.since2: (1, 3).} = 12

--- a/tests/pragmas/tpragmas_misc.nim
+++ b/tests/pragmas/tpragmas_misc.nim
@@ -53,3 +53,13 @@ block: # (partial fix) bug #15920
         body
     when false: # bug
       template fun3(): int {.since2: (1, 3).} = 12
+
+import macros # defines `proc genSym` symbol
+#[
+Error: undeclared identifier: 'ret`gensym0'
+]#
+block:
+  template fn() =
+    var ret {.gensym.}: int
+    discard ret
+  fn()

--- a/tests/pragmas/tpragmas_misc.nim
+++ b/tests/pragmas/tpragmas_misc.nim
@@ -54,12 +54,11 @@ block: # (partial fix) bug #15920
     when false: # bug
       template fun3(): int {.since2: (1, 3).} = 12
 
-import macros # defines `proc genSym` symbol
-#[
-Error: undeclared identifier: 'ret`gensym0'
-]#
-block:
-  template fn() =
-    var ret {.gensym.}: int
-    discard ret
-  fn()
+when true: # D20210801T100514:here
+  import macros # defines `proc genSym` symbol
+  {.define(nimCompilerDebug).}
+  block:
+    template fn() =
+      var ret {.gensym.}: int # must special case template pragmas so it doesn't get confused
+      discard ret
+    fn()

--- a/tests/pragmas/tpragmas_misc.nim
+++ b/tests/pragmas/tpragmas_misc.nim
@@ -55,10 +55,10 @@ block: # (partial fix) bug #15920
       template fun3(): int {.since2: (1, 3).} = 12
 
 when true: # D20210801T100514:here
-  import macros # defines `proc genSym` symbol
-  {.define(nimCompilerDebug).}
+  from macros import genSym
   block:
     template fn() =
       var ret {.gensym.}: int # must special case template pragmas so it doesn't get confused
       discard ret
     fn()
+    static: discard genSym()

--- a/tests/stdlib/tdecls.nim
+++ b/tests/stdlib/tdecls.nim
@@ -74,3 +74,13 @@ block: # nkAccQuoted
     let a {.`cast`.} = s[0]
     doAssert a == "foo"
     doAssert a[0].unsafeAddr == s[0][0].unsafeAddr
+
+block: # https://github.com/timotheecour/Nim/issues/89
+  template foo(lhs, typ, expr) =
+    let lhs = expr
+  proc fun1()=
+    let a {.foo.} = 1
+  template fun2()=
+    let a {.foo.} = 1
+  fun1() # ok
+  fun2() # BUG

--- a/tests/stdlib/tdecls.nim
+++ b/tests/stdlib/tdecls.nim
@@ -1,6 +1,6 @@
 import std/decls
 
-block:
+template fun() =
   var s = @[10,11,12]
   var a {.byaddr.} = s[0]
   a+=100
@@ -33,6 +33,12 @@ block:
 
   doAssert compiles(block:
     var b2 {.byaddr.}: int = s[2])
+
+proc fun2() = fun()
+fun()
+fun2()
+static: fun2()
+# static: fun() # pending https://github.com/nim-lang/Nim/pull/13865
 
 ## We can define custom pragmas in user code
 template byUnsafeAddr(lhs, typ, expr) =

--- a/tests/stdlib/tdecls.nim
+++ b/tests/stdlib/tdecls.nim
@@ -1,3 +1,7 @@
+discard """
+  targets: "c cpp js"
+"""
+
 import std/decls
 
 template fun() =
@@ -38,7 +42,8 @@ proc fun2() = fun()
 fun()
 fun2()
 static: fun2()
-# static: fun() # pending https://github.com/nim-lang/Nim/pull/13865
+when false: # pending bug #13887
+  static: fun()
 
 ## We can define custom pragmas in user code
 template byUnsafeAddr(lhs, typ, expr) =
@@ -75,7 +80,7 @@ block: # nkAccQuoted
     doAssert a == "foo"
     doAssert a[0].unsafeAddr == s[0][0].unsafeAddr
 
-block: # https://github.com/timotheecour/Nim/issues/89
+block: # bug #15920
   template foo(lhs, typ, expr) =
     let lhs = expr
   proc fun1()=

--- a/tests/stdlib/tsince.nim
+++ b/tests/stdlib/tsince.nim
@@ -27,6 +27,6 @@ since (99, 3):
   doAssert false
 
 when false:
-  # pending https://github.com/timotheecour/Nim/issues/129
+  # pending bug #15920
   # Error: cannot attach a custom pragma to 'fun3'
   template fun3(): int {.since: (1, 3).} = 12


### PR DESCRIPTION
fixes partially https://github.com/nim-lang/Nim/issues/15920

(WAS: https://github.com/timotheecour/Nim/issues/89)
```nim
template foo(lhs, typ, expr) =
  let lhs = expr
proc fun1()=
  let a {.foo.} = 1
template fun2()=
  let a {.foo.} = 1
fun1() # ok
fun2() # WAS `Error: invalid pragma: foo` here
```

## future work
- [ ] var template pragma where the template pragma is an overloaded symbol (this usually won't concern `byaddr` unless that symbol is overloaded)
- [ ] related to https://github.com/nim-lang/Nim/pull/13508#discussion_r396141917
we should handle `nkOpenSymChoice`
- [ ] proc template pragma inside template still don't work
