### PR TITLE
add nimExe to nim dump

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -315,7 +315,7 @@ proc mainCommand*(graph: ModuleGraph) =
 
       var dumpdata = %[
         (key: "version", val: %VersionAsString),
-        (key: "nimPath", val: %(getAppFilename())),
+        (key: "nimExe", val: %(getAppFilename())),
         (key: "prefixdir", val: %conf.getPrefixDir().string),
         (key: "libpath", val: %conf.libpath.string),
         (key: "project_path", val: %conf.projectFull.string),

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -13,7 +13,7 @@ when not defined(nimcore):
   {.error: "nimcore MUST be defined for Nim's core tooling".}
 
 import
-  llstream, strutils, ast, lexer, syntaxes, options, msgs,
+  llstream, strutils, os, ast, lexer, syntaxes, options, msgs,
   condsyms, times,
   sem, idents, passes, extccomp,
   cgen, json, nversion,
@@ -315,6 +315,7 @@ proc mainCommand*(graph: ModuleGraph) =
 
       var dumpdata = %[
         (key: "version", val: %VersionAsString),
+        (key: "nimPath", val: %(getAppFilename())),
         (key: "prefixdir", val: %conf.getPrefixDir().string),
         (key: "libpath", val: %conf.libpath.string),
         (key: "project_path", val: %conf.projectFull.string),


### PR DESCRIPTION
## before PR:
hard to tell which binary is nim pointing to, when installed via choosenim (eg via `choosenim pathto/Nim`):
```
which nim
/Users/timothee/.nimble//bin/nim

echo 'import os; echo getCurrentCompilerExe()' | nim c -r --hints:off -
works but inefficient, hence not suitable for use in interactive scripts
```

## after PR:
nim dump . | jq -r .nimPath
/Users/timothee/git_clone/nim/Nim_prs/bin/nim

