### PR TITLE
implement newLit on NimNode

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -798,6 +798,42 @@ proc newLit*(arg: tuple): NimNode {.compileTime.} =
   for a,b in arg.fieldPairs:
     result.add nnkExprColonExpr.newTree(newIdentNode(a), newLit(b))
 
+proc newLit*(n: NimNode): NimNode {.compileTime, benign.} =
+  ## Convert the AST ``n`` to the code required to generate that AST. Does currently not preserve line information.
+  const LitKinds = nnkLiterals-{nnkNilLit}
+  case n.kind
+  of nnkNilLit:
+    result = newCall(newIdentNode("newNimNode"), newIdentNode("nnkNilLit"))
+  of nnkEmpty:
+    result = newCall(newIdentNode("newEmptyNode"))
+  of nnkIdent:
+    result = nnkCallStrLit.newTree(newIdentNode("ident"), newLit(n.strVal))
+  of nnkSym:
+    assert false, "cannot preserve symbol binding through newLit"
+  of nnkNone:
+    result = newCall(newIdentNode("newNimNode"), newIdentNode("nnkNone"))
+  of nnkCommentStmt:
+    result = newCall("newCommentStmtNode", newLit(n.strVal))
+  of LitKinds:
+    result = newCall(bindSym"newLit", n)
+  else:
+    # some nodes kinds have constructor procs
+    case n.kind
+    of nnkStmtList:
+      result = newCall(newIdentNode"newStmtList")
+    of nnkCall:
+      result = newCall(newIdentNode"newCall")
+    of nnkAsgn:
+      result = newCall(newIdentNode"newAssignment")
+    of nnkDotExpr:
+      result = newCall(newIdentNode"newDotExpr")
+    of nnkExprColonExpr:
+      result = newCall(newIdentNode"newColonExpr")
+    else:
+      result = newCall(nnkDotExpr.newTree(newIdentNode($n.kind), newIdentNode("newTree")))
+    for i in 0 ..< n.len:
+      result.add newLit(n[i])
+
 proc nestList*(op: NimNode; pack: NimNode): NimNode {.compileTime.} =
   ## Nests the list `pack` into a tree of call expressions:
   ## ``[a, b, c]`` is transformed into ``op(a, op(c, d))``.
@@ -874,47 +910,51 @@ proc astGenRepr*(n: NimNode): string {.compileTime, benign.} =
   ## Convert the AST ``n`` to the code required to generate that AST.
   ##
   ## See also ``repr``, ``treeRepr``, and ``lispRepr``.
-
-  const
-    NodeKinds = {nnkEmpty, nnkIdent, nnkSym, nnkNone, nnkCommentStmt}
-    LitKinds = {nnkCharLit..nnkInt64Lit, nnkFloatLit..nnkFloat64Lit, nnkStrLit..nnkTripleStrLit}
-
-  proc traverse(res: var string, level: int, n: NimNode) {.benign.} =
-    for i in 0..level-1: res.add "  "
-    if n.kind in NodeKinds:
-      res.add("new" & ($n.kind).substr(3) & "Node(")
-    elif n.kind in LitKinds:
-      res.add("newLit(")
-    elif n.kind == nnkNilLit:
-      res.add("newNilLit()")
+  let tmp = repr(newLit(n))
+  # From here on, the rest of the code just rearranges whitespace in
+  # ``tmp`` to a human redable form. It would probably be not
+  # necessary, if ``repr`` would produce a better output for complex
+  # single expression code.
+  var i = 0
+  var ind = "\n"
+  let n = tmp.len
+  while i < n:
+    if tmp[i] == '\"': # east string literal
+      var j = i+1
+      while j < n and tmp[j] != '\"' and tmp[j-1] != '\\':
+        inc j
+      result.add tmp[i..j]
+      i = j
+    elif tmp[i] == '(' and tmp[i+1] != ')':
+      var j = i+1
+      while j < n and tmp[j] notin {'(', ')'}:
+        inc j
+      if tmp[j] == ')' and j - i <= 16:
+        result.add tmp[i..j]
+        i = j
+      else:
+        ind.add "  "
+        result.add tmp[i]
+        result.add ind
+        while tmp[i+1] in {'\r', '\n', ' '}:
+          inc i
+    elif tmp[i] == ')' and tmp[i-1] != '(':
+      ind.setLen(ind.len-2)
+      result.add ind
+      result.add tmp[i]
+    elif tmp[i] == ',':
+      result.add ','
+      result.add ind
+      while tmp[i+1] in {'\r', '\n', ' '}:
+        inc i
     else:
-      res.add($n.kind)
+      result.add tmp[i]
+    inc i
 
-    case n.kind
-    of nnkEmpty, nnkNilLit: discard
-    of nnkCharLit: res.add("'" & $chr(n.intVal) & "'")
-    of nnkIntLit..nnkInt64Lit: res.add($n.intVal)
-    of nnkFloatLit..nnkFloat64Lit: res.add($n.floatVal)
-    of nnkStrLit..nnkTripleStrLit, nnkCommentStmt, nnkIdent, nnkSym:
-      res.add(n.strVal.newLit.repr)
-    of nnkNone: assert false
-    else:
-      res.add(".newTree(")
-      for j in 0..<n.len:
-        res.add "\n"
-        traverse(res, level + 1, n[j])
-        if j != n.len-1:
-          res.add(",")
 
-      res.add("\n")
-      for i in 0..level-1: res.add "  "
-      res.add(")")
 
-    if n.kind in NodeKinds+LitKinds:
-      res.add(")")
 
-  result = ""
-  traverse(result, 0, n)
+
 
 macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ## Accepts a block of nim code and prints the parsed abstract syntax
@@ -980,9 +1020,10 @@ macro dumpAstGen*(s: untyped): untyped = echo s.astGenRepr
   ## Outputs:
   ##
   ## .. code-block:: nim
-  ##    nnkStmtList.newTree(
+  ##
+  ##    newStmtList(
   ##      nnkCommand.newTree(
-  ##        newIdentNode("echo"),
+  ##        ident"echo",
   ##        newLit("Hello, World!")
   ##      )
   ##    )

--- a/tests/macros/tdumpastgen.nim
+++ b/tests/macros/tdumpastgen.nim
@@ -1,20 +1,21 @@
 discard """
-nimout: '''nnkStmtList.newTree(
+nimout: '''
+newStmtList(
   nnkVarSection.newTree(
     nnkIdentDefs.newTree(
-      newIdentNode("x"),
+      ident"x",
       newEmptyNode(),
-      nnkCall.newTree(
-        nnkDotExpr.newTree(
-          newIdentNode("baz"),
-          newIdentNode("create")
+      newCall(
+        newDotExpr(
+          ident"baz",
+          ident"create"
         ),
         newLit(56)
       )
     )
   ),
   nnkProcDef.newTree(
-    newIdentNode("foo"),
+    ident"foo",
     newEmptyNode(),
     newEmptyNode(),
     nnkFormalParams.newTree(
@@ -22,24 +23,80 @@ nimout: '''nnkStmtList.newTree(
     ),
     newEmptyNode(),
     newEmptyNode(),
-    nnkStmtList.newTree(
-      newCommentStmtNode("This is a docstring"),
+    newStmtList(
+      newCommentStmtNode(
+        "This is a docstring"
+      ),
       nnkCommand.newTree(
-        newIdentNode("echo"),
-        newLit("bar")
+        ident"echo",
+        newLit("Hello, World!")
+      ),
+      nnkCommand.newTree(
+        ident"echo",
+        newLit(
+          "something \"quoted\""
+        )
+      )
+    )
+  ),
+  newCall(
+    ident"callNilLit",
+    newNimNode(nnkNilLit)
+  ),
+  newAssignment(
+    newDotExpr(
+      ident"x",
+      ident"y"
+    ),
+    nnkObjConstr.newTree(
+      ident"MyType",
+      newColonExpr(
+        ident"u1",
+        newLit(123'u64)
+      ),
+      newColonExpr(
+        ident"u2",
+        newLit(321'u32)
       )
     )
   )
-)'''
-"""
+)
 
-# disabled; can't work as the output is done by the compiler
+var x = baz.create(56)
+proc foo() =
+  ## This is a docstring
+  echo "Hello, World!"
+  echo "something \"quoted\""
+
+callNilLit(nil)
+x.y = MyType(u1: 123'u64, u2: 321'u32)
+'''
+"""
 
 import macros
 
 dumpAstGen:
   var x = baz.create(56)
-
   proc foo() =
     ## This is a docstring
-    echo "bar"
+    echo "Hello, World!"
+    echo "something \"quoted\""
+
+  callNilLit(nil)
+  x.y = MyType(u1: 123'u64, u2: 321'u32)
+
+macro myQuoteAst(arg: untyped): untyped = newLit(arg)
+
+
+static:
+  let myAst = myQuoteAst:
+    var x = baz.create(56)
+    proc foo() =
+      ## This is a docstring
+      echo "Hello, World!"
+      echo "something \"quoted\""
+
+    callNilLit(nil)
+    x.y = MyType(u1: 123'u64, u2: 321'u32)
+
+  echo myAst.repr


### PR DESCRIPTION
`newLit` on NimNode should just work. This is a first simple implementation for it. It does not yet preserve line information, as this would require a new feature in the compiler.

I found out that this proc is a missing piece that would probably have prohibited a dirty hack that I found here:
https://github.com/nigredo-tori/classy/blob/master/classy.nim#L707

@nigredo-tori since I reference your code here, your opinion on this contribution is requested.

Since newLit on NimNode and `astGenRepr` are very much related to each other, I move the implementation of `astGenRepr` to use `newLit`. This should prevent those two functions from diverging from each other.

The new astGenRepr produces now slightly different (and hopenfully shorter and more readable) output, because I instructed the generator to use some shorter notations when possible.

At the end of astGenRepr, there is some processing of whitespace. This is only becaues the whitespace indentation that comes out of vanilla ``repr`` really doesn't look very good. If at some point ``repr`` gets updatet to produce better output, that code section should be removed again without substitution.

fixes #13932