### PR TITLE
[TODO] openDefaultBrowser now works on OSX

### DIFF
--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -21,9 +21,9 @@ else:
   import os, osproc
 
 const osOpenCmd* =
-  when defined(macos) or defined(windows): "open" else: "xdg-open" ## \
+  when defined(macos) or defined(macosx) or defined(windows): "open" else: "xdg-open" ## \
   ## Alias for the operating system specific *"open"* command,
-  ## ``"open"`` on MacOS and Windows, ``"xdg-open"`` on Linux, BSD, etc.
+  ## ``"open"`` on OSX, MacOS and Windows, ``"xdg-open"`` on Linux, BSD, etc.
 
 
 template openDefaultBrowserImpl(url: string) =


### PR DESCRIPTION
* openDefaultBrowser now works on OSX
* fixes https://github.com/timotheecour/Nim/issues/6#issuecomment-606950633
* i checked, this was the only misuse of `macos` in Nim code


## TODO for future PR's
`openDefaultBrowser` is still too naive though (and not just on OSX)

examples on OSX:
* `open nimdoc.out.css` opens in your editor instead of browser
* `open -a 'Google Chrome' nimdoc.out.css` works (but see below...)
* `open ~/data/chestnut-horse-autumn_1000.jpg` will not open in the browser but in your configured image editor.
* `open -a 'Google Chrome' ~/data/chestnut-horse-autumn_1000.jpg` **doesn't even work**
* `open -a 'Safari' ~/data/chestnut-horse-autumn_1000.jpg` works
* this seems the most reliable way to get the user's browser:

https://github.com/kerma/defaultbrowser/blob/master/src/main.m (single file, could be `compile`'d in in objc mode)
see also https://stackoverflow.com/questions/17528688/set-default-web-browser-via-command-line
which we could use via `open -a $app $file`

so at least it would fix some issues like opening files in your browser instead of editor, but not sure about the jpg example

* there should be an option to not ignore error (ignoring errors is pretty much guaranteed to cause hard to find bugs; specific applications can always try/catch)

EDIT: ok this seems to be the only thing that works reliably to open a jpg on browswer:
`open -a 'Google Chrome' -n file:///Users/timothee/data/chestnut-horse-autumn_1000.jpg`
any removed option (removing file://, removing -n or removing -a 'Google Chrome') will fail

but 'Google Chrome' should be replaced by auto detection 

