### PR TITLE
fix #13902 distinct uint64 type corruption on 32-bit with borrow

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,8 +61,6 @@ jobs:
         DEBIAN_FRONTEND='noninteractive' \
           sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
-        # to test cross compilation from 64bit => 32 bit, see t13902.nim
-        sudo apt-fast install gcc-multilib g++-multilib
       displayName: 'Install dependencies (amd64 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,8 @@ jobs:
         DEBIAN_FRONTEND='noninteractive' \
           sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
+        # to test cross compilation from 64bit => 32 bit, see t13902.nim
+        sudo apt-fast install gcc-multilib g++-multilib
       displayName: 'Install dependencies (amd64 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2156,7 +2156,7 @@ proc genMagicExpr(p: BProc, e: PNode, d: var TLoc, op: TMagic) =
     const opr: array[mInc..mDec, string] = ["+=", "-="]
     const fun64: array[mInc..mDec, string] = ["nimAddInt64", "nimSubInt64"]
     const fun: array[mInc..mDec, string] = ["nimAddInt","nimSubInt"]
-    let underlying = skipTypes(e[1].typ, {tyGenericInst, tyAlias, tySink, tyVar, tyLent, tyRange})
+    let underlying = skipTypes(e[1].typ, {tyGenericInst, tyAlias, tySink, tyVar, tyLent, tyRange, tyDistinct})
     if optOverflowCheck notin p.options or underlying.kind in {tyUInt..tyUInt64}:
       binaryStmt(p, e, d, opr[op])
     else:

--- a/tests/ccgbugs/t13902.nim
+++ b/tests/ccgbugs/t13902.nim
@@ -1,29 +1,12 @@
-#issue #13902
-when defined case_t13902:
-  block:
-    type Slot = distinct uint64
-    var s = Slot(1)
-    proc `$`(x: Slot): string {.borrow.}
-    proc `+=`(x: var Slot, y: uint64) {.borrow.}
-    # test was failing with either 0 or 2 echos but not with 1 echo
-    # echo "s = ", s
-    s += 1
-    # echo "s = ", s
-    doAssert s.uint64 == 2, $s # was failing, showing 18419607611339964418
 
-else:
-  import std/[strformat,os,osproc]
-  proc main() =
-    when sizeof(int) == 4 or defined(linux):
-      const nim = getCurrentCompilerExe()
-      const file = currentSourcePath()
-      var options = ""
-      when sizeof(int) == 8:
-        when defined(linux): # other OS would need custom cross compile libs
-          options = "--cpu:i386 --passC:-m32 --passL:-m32"
-        else:
-          if true: return
-      let cmd = fmt"{nim} c -r {options} -d:case_t13902 --skipParentCfg --skipUserCfg --stacktrace:off --hints:off {file}"
-      let (output, exitCode) = execCmdEx(cmd)
-      doAssert exitCode == 0, cmd & "\n" & output
-  main()
+#issue #13902
+block:
+  type Slot = distinct uint64
+  var s = Slot(1)
+  proc `$`(x: Slot): string {.borrow.}
+  proc `+=`(x: var Slot, y: uint64) {.borrow.}
+  # test was failing with either 0 or 2 echos but not with 1 echo
+  # echo "s = ", s
+  s += 1
+  # echo "s = ", s
+  doAssert s.uint64 == 2, $s # was failing, showing 18419607611339964418

--- a/tests/ccgbugs/t13902.nim
+++ b/tests/ccgbugs/t13902.nim
@@ -1,16 +1,25 @@
-discard """
-  cmd: "nim c -r --skipParentCfg --skipUserCfg --cpu:i386 --passC:-m32 --passL:-m32 --stacktrace:off --hints:off $file"
-  action: run
-"""
-
 #issue #13902
-when defined(linux):
+when defined case_t13902:
   block:
     type Slot = distinct uint64
     var s = Slot(1)
     proc `$`(x: Slot): string {.borrow.}
     proc `+=`(x: var Slot, y: uint64) {.borrow.}
-    echo "s = ", s
+    # test was failing with either 0 or 2 echos but not with 1 echo
+    # echo "s = ", s
     s += 1
-    echo "s = ", s
+    # echo "s = ", s
     doAssert s.uint64 == 2, $s # was failing, showing 18419607611339964418
+
+else:
+  import std/[strformat,os,osproc]
+  proc main() =
+    when defined(linux):
+      # osx doesn't support 32bit and windows doesn't have the required
+      # cross compilation libraries by default
+      const nim = getCurrentCompilerExe()
+      const file = currentSourcePath()
+      let cmd = fmt"{nim} c -r -d:case_t13902 --skipParentCfg --skipUserCfg --cpu:i386 --passC:-m32 --passL:-m32 --stacktrace:off --hints:off {file}"
+      let (output, exitCode) = execCmdEx(cmd)
+      doAssert exitCode == 0, $(cmd, output)
+  main()

--- a/tests/ccgbugs/t13902.nim
+++ b/tests/ccgbugs/t13902.nim
@@ -14,12 +14,16 @@ when defined case_t13902:
 else:
   import std/[strformat,os,osproc]
   proc main() =
-    when defined(linux):
-      # osx doesn't support 32bit and windows doesn't have the required
-      # cross compilation libraries by default
+    when sizeof(int) == 4 or defined(linux):
       const nim = getCurrentCompilerExe()
       const file = currentSourcePath()
-      let cmd = fmt"{nim} c -r -d:case_t13902 --skipParentCfg --skipUserCfg --cpu:i386 --passC:-m32 --passL:-m32 --stacktrace:off --hints:off {file}"
+      var options = ""
+      when sizeof(int) == 8:
+        when defined(linux): # other OS would need custom cross compile libs
+          options = "--cpu:i386 --passC:-m32 --passL:-m32"
+        else:
+          if true: return
+      let cmd = fmt"{nim} c -r {options} -d:case_t13902 --skipParentCfg --skipUserCfg --stacktrace:off --hints:off {file}"
       let (output, exitCode) = execCmdEx(cmd)
-      doAssert exitCode == 0, $(cmd, output)
+      doAssert exitCode == 0, cmd & "\n" & output
   main()

--- a/tests/ccgbugs/t13902.nim
+++ b/tests/ccgbugs/t13902.nim
@@ -1,0 +1,16 @@
+discard """
+  cmd: "nim c -r --skipParentCfg --skipUserCfg --cpu:i386 --passC:-m32 --passL:-m32 --stacktrace:off --hints:off $file"
+  action: run
+"""
+
+#issue #13902
+when defined(linux):
+  block:
+    type Slot = distinct uint64
+    var s = Slot(1)
+    proc `$`(x: Slot): string {.borrow.}
+    proc `+=`(x: var Slot, y: uint64) {.borrow.}
+    echo "s = ", s
+    s += 1
+    echo "s = ", s
+    doAssert s.uint64 == 2, $s # was failing, showing 18419607611339964418


### PR DESCRIPTION

* fix https://github.com/nim-lang/Nim/issues/13902 (regression introduced in https://github.com/nim-lang/Nim/pull/13626)

* note: also fixes this replated cpp codegen compilation error
nim cpp -r --skipParentCfg --skipUserCfg --cpu:i386 --passC:"-m32" --passL:-m32 --stacktrace:off --hints:off -f --lib:lib tests/ccgbugs/t13902.nim

```
nimbase.h:562:67: error: cannot convert ‘NU64* {aka long long unsigned int*}’ to ‘int*’ for argument ‘3’ to ‘bool __builtin_sadd_overflow(int, int, int*)’
     #define nimAddInt(a, b, res) __builtin_sadd_overflow(a, b, res)
                                                                   ^
/home/ubuntu/.cache/nim/t13902_d/@mt13902.nim.cpp:125:7: note: in expansion of macro ‘nimAddInt’
   if (nimAddInt(s__h3z8bpua5apKtCPZQW9cs9ag, 1ULL, &TM__vd9bcdJbL6EBJYiW1bp6KQQ_3)) { raiseOverflow(); };
```

note: couldnt' figure out how to make cross compile from linux 64 to 32 on work on CI machines, so I'm just testing without cross compilation

## TODO after PR
fix other issues I raised in https://github.com/nim-lang/Nim/pull/13626#discussion_r391627793 + other comments in that PR


