### PR TITLE
Error -> Defect for defects

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -290,7 +290,7 @@ type
     sfTemplateParam   # symbol is a template parameter
     sfCursor          # variable/field is a cursor, see RFC 177 for details
     sfInjectDestructors # whether the proc needs the 'injectdestructors' transformation
-    sfNeverRaises     # proc can never raise an exception, not even OverflowError
+    sfNeverRaises     # proc can never raise an exception, not even OverflowDefect
                       # or out-of-memory
 
   TSymFlags* = set[TSymFlag]

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -821,7 +821,7 @@ proc genFieldCheck(p: BProc, e: PNode, obj: Rope, field: PSym) =
     v.r.add(".")
     v.r.add(disc.sym.loc.r)
     genInExprAux(p, it, u, v, test)
-    let msg = genFieldError(field, disc.sym)
+    let msg = genFieldDefect(field, disc.sym)
     let strLit = genStringLiteral(p.module, newStrNode(nkStrLit, msg))
     if op.magic == mNot:
       linefmt(p, cpsStmts,

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1131,7 +1131,7 @@ proc genCheckedFieldOp(p: PProc, n: PNode, addrTyp: PType, r: var TCompRes) =
 
   useMagic(p, "raiseFieldError")
   useMagic(p, "makeNimstrLit")
-  let msg = genFieldError(field, disc)
+  let msg = genFieldDefect(field, disc)
   lineF(p, "if ($1[$2.$3]$4undefined) { raiseFieldError(makeNimstrLit($5)); }$n",
     setx.res, tmp, disc.loc.r, if negCheck: ~"!==" else: ~"===",
     makeJSString(msg))
@@ -2343,7 +2343,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
   if r.kind != resCallee: r.kind = resNone
   #r.address = nil
   r.res = nil
-  
+
   case n.kind
   of nkSym:
     genSym(p, n, r)
@@ -2398,7 +2398,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
         n.len >= 1:
       genInfixCall(p, n, r)
     else:
-      genCall(p, n, r)    
+      genCall(p, n, r)
   of nkClosure: gen(p, n[0], r)
   of nkCurly: genSetConstr(p, n, r)
   of nkBracket: genArrayConstr(p, n, r)
@@ -2602,7 +2602,7 @@ proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
       (code, map) = genSourceMap($(code), outFile.string)
       writeFile(outFile.string & ".map", $(%map))
     discard writeRopeIfNotEqual(code, outFile)
-    
+
 proc myOpen(graph: ModuleGraph; s: PSym): PPassContext =
   result = newModule(graph, s)
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -571,7 +571,7 @@ proc getNumber(L: var TLexer, result: var TToken) =
         try:
           len = parseBiggestUInt(result.literal, iNumber)
         except ValueError:
-          raise newException(OverflowError, "number out of range: " & $result.literal)
+          raise newException(OverflowDefect, "number out of range: " & $result.literal)
         if len != result.literal.len:
           raise newException(ValueError, "invalid integer: " & $result.literal)
         result.iNumber = cast[int64](iNumber)
@@ -581,7 +581,7 @@ proc getNumber(L: var TLexer, result: var TToken) =
         try:
           len = parseBiggestInt(result.literal, iNumber)
         except ValueError:
-          raise newException(OverflowError, "number out of range: " & $result.literal)
+          raise newException(OverflowDefect, "number out of range: " & $result.literal)
         if len != result.literal.len:
           raise newException(ValueError, "invalid integer: " & $result.literal)
         result.iNumber = iNumber
@@ -607,7 +607,7 @@ proc getNumber(L: var TLexer, result: var TToken) =
 
   except ValueError:
     lexMessageLitNum(L, "invalid number: '$1'", startpos)
-  except OverflowError, RangeError:
+  except OverflowDefect, RangeDefect:
     lexMessageLitNum(L, "number out of range: '$1'", startpos)
   tokenEnd(result, postPos-1)
   L.bufpos = postPos

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1599,9 +1599,9 @@ proc quoteExpr*(a: string): string {.inline.} =
   ## can be used for quoting expressions in error msgs.
   "'" & a & "'"
 
-proc genFieldError*(field: PSym, disc: PSym): string =
+proc genFieldDefect*(field: PSym, disc: PSym): string =
   ## this needs to be in a module accessible by jsgen, ccgexprs, and vm to
-  ## provide this error msg FieldError; msgs would be better but it does not
+  ## provide this error msg FieldDefect; msgs would be better but it does not
   ## import ast
   result = field.name.s.quoteExpr & " is not accessible using discriminant " &
     disc.name.s.quoteExpr & " of type " &

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -645,9 +645,9 @@ proc getConstExpr(m: PSym, n: PNode; g: ModuleGraph): PNode =
         discard
       else:
         result = magicCall(m, n, g)
-    except OverflowError:
+    except OverflowDefect:
       localError(g.config, n.info, "over- or underflow")
-    except DivByZeroError:
+    except DivByZeroDefect:
       localError(g.config, n.info, "division by zero")
   of nkAddr:
     var a = getConstExpr(m, n[0], g)

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -752,7 +752,7 @@ proc track(tracked: PEffects, n: PNode) =
       createTypeBoundOps(tracked, n[0].typ, n.info)
     else:
       # A `raise` with no arguments means we're going to re-raise the exception
-      # being handled or, if outside of an `except` block, a `ReraiseError`.
+      # being handled or, if outside of an `except` block, a `ReraiseDefect`.
       # Here we add a `Exception` tag in order to cover both the cases.
       addEffect(tracked, createRaise(tracked.graph, n), nil)
   of nkCallKinds:

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -451,7 +451,7 @@ Miscellaneous
   This module implements a simple logger.
 
 * `segfaults <segfaults.html>`_
-  Turns access violations or segfaults into a ``NilAccessError`` exception.
+  Turns access violations or segfaults into a ``NilAccessDefect`` exception.
 
 * `sugar <sugar.html>`_
   This module implements nice syntactic sugar based on Nim's macro system.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -113,7 +113,7 @@ pragmas_ for details.
 
 Whether a panic results in an exception or in a fatal error is
 implementation specific. Thus the following program is invalid; even though the
-code purports to catch the `IndexError` from an out-of-bounds array access, the
+code purports to catch the `IndexDefect` from an out-of-bounds array access, the
 compiler may instead choose to allow the program to die with a fatal error.
 
 .. code-block:: nim
@@ -121,7 +121,7 @@ compiler may instead choose to allow the program to die with a fatal error.
   let i = 5
   try:
     a[i] = 'N'
-  except IndexError:
+  except IndexDefect:
     echo "invalid index"
 
 The current implementation allows to switch between these different behaviors
@@ -1033,10 +1033,10 @@ The IEEE standard defines five types of floating-point exceptions:
   precision, for example, 2.0 / 3.0, log(1.1) and 0.1 in input.
 
 The IEEE exceptions are either ignored during execution or mapped to the
-Nim exceptions: `FloatInvalidOpError`:idx:, `FloatDivByZeroError`:idx:,
-`FloatOverflowError`:idx:, `FloatUnderflowError`:idx:,
-and `FloatInexactError`:idx:.
-These exceptions inherit from the `FloatingPointError`:idx: base class.
+Nim exceptions: `FloatInvalidOpDefect`:idx:, `FloatDivByZeroDefect`:idx:,
+`FloatOverflowDefect`:idx:, `FloatUnderflowDefect`:idx:,
+and `FloatInexactDefect`:idx:.
+These exceptions inherit from the `FloatingPointDefect`:idx: base class.
 
 Nim provides the pragmas `nanChecks`:idx: and `infChecks`:idx: to control
 whether the IEEE exceptions are ignored or trap a Nim exception:
@@ -1045,12 +1045,12 @@ whether the IEEE exceptions are ignored or trap a Nim exception:
   {.nanChecks: on, infChecks: on.}
   var a = 1.0
   var b = 0.0
-  echo b / b # raises FloatInvalidOpError
-  echo a / b # raises FloatOverflowError
+  echo b / b # raises FloatInvalidOpDefect
+  echo a / b # raises FloatOverflowDefect
 
-In the current implementation ``FloatDivByZeroError`` and ``FloatInexactError``
-are never raised. ``FloatOverflowError`` is raised instead of
-``FloatDivByZeroError``.
+In the current implementation ``FloatDivByZeroDefect`` and ``FloatInexactDefect``
+are never raised. ``FloatOverflowDefect`` is raised instead of
+``FloatDivByZeroDefect``.
 There is also a `floatChecks`:idx: pragma that is a short-cut for the
 combination of ``nanChecks`` and ``infChecks`` pragmas. ``floatChecks`` are
 turned off as default.
@@ -1620,7 +1620,7 @@ An example:
   # accessing n.thenPart is valid because the ``nkIf`` branch is active:
   n.thenPart = Node(kind: nkFloat, floatVal: 2.0)
 
-  # the following statement raises an `FieldError` exception, because
+  # the following statement raises an `FieldDefect` exception, because
   # n.kind's value does not fit and the ``nkString`` branch is not active:
   n.strVal = ""
 
@@ -4063,7 +4063,7 @@ Example:
       var a = readLine(f)
       var b = readLine(f)
       echo "sum: " & $(parseInt(a) + parseInt(b))
-    except OverflowError:
+    except OverflowDefect:
       echo "overflow!"
     except ValueError:
       echo "could not convert string to integer"
@@ -4226,7 +4226,7 @@ the ``raise`` statement is the only way to raise an exception.
 .. XXX document this better!
 
 If no exception name is given, the current exception is `re-raised`:idx:. The
-`ReraiseError`:idx: exception is raised if there is no exception to
+`ReraiseDefect`:idx: exception is raised if there is no exception to
 re-raise. It follows that the ``raise`` statement *always* raises an
 exception.
 

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -126,7 +126,7 @@ The syntax for type conversions is ``destination_type(expression_to_convert)``
   proc getID(x: Person): int =
     Student(x).id
 
-The ``InvalidObjectConversionError`` exception is raised if ``x`` is not a
+The ``InvalidObjectConversionDefect`` exception is raised if ``x`` is not a
 ``Student``.
 
 
@@ -160,7 +160,7 @@ An example:
         condition, thenPart, elsePart: Node
 
   var n = Node(kind: nkFloat, floatVal: 1.0)
-  # the following statement raises an `FieldError` exception, because
+  # the following statement raises an `FieldDefect` exception, because
   # n.kind's value does not fit:
   n.strVal = ""
 
@@ -388,7 +388,7 @@ The ``try`` statement handles exceptions:
       let a = readLine(f)
       let b = readLine(f)
       echo "sum: ", parseInt(a) + parseInt(b)
-    except OverflowError:
+    except OverflowDefect:
       echo "overflow!"
     except ValueError:
       echo "could not convert string to integer"
@@ -443,7 +443,7 @@ instance, if you specify that a proc raises ``IOError``, and at some point it
 prevent that proc from compiling. Usage example:
 
 .. code-block:: nim
-  proc complexProc() {.raises: [IOError, ArithmeticError].} =
+  proc complexProc() {.raises: [IOError, ArithmeticDefect].} =
     ...
 
   proc simpleProc() {.raises: [].} =

--- a/doc/tut3.rst
+++ b/doc/tut3.rst
@@ -271,7 +271,7 @@ written.
 
     result = quote do:
       if not `arg`:
-        raise newException(AssertionError,$`lhs` & `op` & $`rhs`)
+        raise newException(AssertionDefect,$`lhs` & `op` & $`rhs`)
 
   let a = 1
   let b = 2
@@ -287,7 +287,7 @@ used to get this output.
 
 .. code-block:: nim
   if not (a != b):
-    raise newException(AssertionError, $a & " != " & $b)
+    raise newException(AssertionDefect, $a & " != " & $b)
 
 With Power Comes Responsibility
 -------------------------------

--- a/examples/tunit.nim
+++ b/examples/tunit.nim
@@ -29,7 +29,7 @@ proc foo: bool =
   return true
 
 proc err =
-  raise newException(ArithmeticError, "some exception")
+  raise newException(ArithmeticDefect, "some exception")
 
 test "final test":
   echo "inside suite-less test"
@@ -40,8 +40,8 @@ test "final test":
     d > 10
 
 test "arithmetic failure":
-  expect(ArithmeticError):
+  expect(ArithmeticDefect):
     err()
 
-  expect(ArithmeticError, CatchableError):
+  expect(ArithmeticDefect, CatchableError):
     discard foo()

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -204,14 +204,14 @@ proc `[]`*(x: Any, i: int): Any =
   of tyArray:
     var bs = x.rawType.base.size
     if i >=% x.rawType.size div bs:
-      raise newException(IndexError, formatErrorIndexBound(i, x.rawType.size div bs))
+      raise newException(IndexDefect, formatErrorIndexBound(i, x.rawType.size div bs))
     return newAny(x.value +!! i*bs, x.rawType.base)
   of tySequence:
     var s = cast[ppointer](x.value)[]
     if s == nil: raise newException(ValueError, "sequence is nil")
     var bs = x.rawType.base.size
     if i >=% cast[PGenSeq](s).len:
-      raise newException(IndexError, formatErrorIndexBound(i, cast[PGenSeq](s).len-1))
+      raise newException(IndexDefect, formatErrorIndexBound(i, cast[PGenSeq](s).len-1))
     return newAny(s +!! (align(GenericSeqSize, x.rawType.base.align)+i*bs), x.rawType.base)
   else: assert false
 
@@ -221,7 +221,7 @@ proc `[]=`*(x: Any, i: int, y: Any) =
   of tyArray:
     var bs = x.rawType.base.size
     if i >=% x.rawType.size div bs:
-      raise newException(IndexError, formatErrorIndexBound(i, x.rawType.size div bs))
+      raise newException(IndexDefect, formatErrorIndexBound(i, x.rawType.size div bs))
     assert y.rawType == x.rawType.base
     genericAssign(x.value +!! i*bs, y.value, y.rawType)
   of tySequence:
@@ -229,7 +229,7 @@ proc `[]=`*(x: Any, i: int, y: Any) =
     if s == nil: raise newException(ValueError, "sequence is nil")
     var bs = x.rawType.base.size
     if i >=% cast[PGenSeq](s).len:
-      raise newException(IndexError, formatErrorIndexBound(i, cast[PGenSeq](s).len-1))
+      raise newException(IndexDefect, formatErrorIndexBound(i, cast[PGenSeq](s).len-1))
     assert y.rawType == x.rawType.base
     genericAssign(s +!! (align(GenericSeqSize, x.rawType.base.align)+i*bs), y.value, y.rawType)
   else: assert false

--- a/lib/deprecated/pure/sharedstrings.nim
+++ b/lib/deprecated/pure/sharedstrings.nim
@@ -49,11 +49,11 @@ proc len*(s: SharedString): int = s.len
 
 proc `[]`*(s: SharedString; i: Natural): char =
   if i < s.len: result = s.buffer.data[i+s.first]
-  else: raise newException(IndexError, formatErrorIndexBound(i, s.len-1))
+  else: raise newException(IndexDefect, formatErrorIndexBound(i, s.len-1))
 
 proc `[]=`*(s: var SharedString; i: Natural; value: char) =
   if i < s.len: s.buffer.data[i+s.first] = value
-  else: raise newException(IndexError, formatErrorIndexBound(i, s.len-1))
+  else: raise newException(IndexDefect, formatErrorIndexBound(i, s.len-1))
 
 proc `[]`*(s: SharedString; ab: HSlice[int, int]): SharedString =
   #incRef(src.buffer)

--- a/lib/impure/nre.nim
+++ b/lib/impure/nre.nim
@@ -240,7 +240,7 @@ proc getinfo[T](pattern: Regex, opt: cint): T =
 
   if retcode < 0:
     # XXX Error message that doesn't expose implementation details
-    raise newException(FieldError, "Invalid getinfo for $1, errno $2" % [$opt, $retcode])
+    raise newException(FieldDefect, "Invalid getinfo for $1, errno $2" % [$opt, $retcode])
 
 proc getNameToNumberTable(pattern: Regex): Table[string, int] =
   let entryCount = getinfo[cint](pattern, pcre.INFO_NAMECOUNT)
@@ -331,7 +331,7 @@ func contains*(pattern: Captures, i: int): bool =
 func `[]`*(pattern: CaptureBounds, i: int): HSlice[int, int] =
   let pattern = RegexMatch(pattern)
   if not (i in pattern.captureBounds):
-    raise newException(IndexError, "Group '" & $i & "' was not captured")
+    raise newException(IndexDefect, "Group '" & $i & "' was not captured")
 
   let bounds = pattern.pcreMatchBounds[i + 1]
   int(bounds.a)..int(bounds.b-1)
@@ -517,7 +517,7 @@ proc matchImpl(str: string, pattern: Regex, start, endpos: int, flags: int): Opt
     of pcre.ERROR_NOMATCH:
       return none(RegexMatch)
     of pcre.ERROR_NULL:
-      raise newException(AccessViolationError, "Expected non-null parameters")
+      raise newException(AccessViolationDefect, "Expected non-null parameters")
     of pcre.ERROR_BADOPTION:
       raise RegexInternalError(msg : "Unknown pattern flag. Either a bug or " &
         "outdated PCRE.")
@@ -718,7 +718,7 @@ proc replace*(str: string, pattern: Regex,
   ## -  ``$#`` - first capture
   ## -  ``$0`` - full match
   ##
-  ## If a given capture is missing, ``IndexError`` thrown for un-named captures
+  ## If a given capture is missing, ``IndexDefect`` thrown for un-named captures
   ## and ``KeyError`` for named captures.
   replaceImpl(str, pattern, subproc(match))
 

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -75,14 +75,14 @@ template fillImpl[T](a: var openArray[T], first, last: int, value: T) =
 proc fill*[T](a: var openArray[T], first, last: Natural, value: T) =
   ## Fills the slice ``a[first..last]`` with ``value``.
   ##
-  ## If an invalid range is passed, it raises IndexError.
+  ## If an invalid range is passed, it raises IndexDefect.
   runnableExamples:
     var a: array[6, int]
     a.fill(1, 3, 9)
     assert a == [0, 9, 9, 9, 0, 0]
     a.fill(3, 5, 7)
     assert a == [0, 9, 9, 7, 7, 7]
-    doAssertRaises(IndexError, a.fill(1, 7, 9))
+    doAssertRaises(IndexDefect, a.fill(1, 7, 9))
   fillImpl(a, first, last, value)
 
 proc fill*[T](a: var openArray[T], value: T) =
@@ -99,7 +99,7 @@ proc fill*[T](a: var openArray[T], value: T) =
 proc reverse*[T](a: var openArray[T], first, last: Natural) =
   ## Reverses the slice ``a[first..last]``.
   ##
-  ## If an invalid range is passed, it raises IndexError.
+  ## If an invalid range is passed, it raises IndexDefect.
   ##
   ## **See also:**
   ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and returns a ``seq[T]``
@@ -110,7 +110,7 @@ proc reverse*[T](a: var openArray[T], first, last: Natural) =
     assert a == [1, 4, 3, 2, 5, 6]
     a.reverse(1, 3)
     assert a == [1, 2, 3, 4, 5, 6]
-    doAssertRaises(IndexError, a.reverse(1, 7))
+    doAssertRaises(IndexDefect, a.reverse(1, 7))
   var x = first
   var y = last
   while x < y:
@@ -135,7 +135,7 @@ proc reverse*[T](a: var openArray[T]) =
 proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
   ## Returns the reverse of the slice ``a[first..last]``.
   ##
-  ## If an invalid range is passed, it raises IndexError.
+  ## If an invalid range is passed, it raises IndexDefect.
   ##
   ## **See also:**
   ## * `reverse proc<#reverse,openArray[T],Natural,Natural>`_ reverse a slice
@@ -238,7 +238,7 @@ proc lowerBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.
   ## ``insert(thing, elm, lowerBound(thing, elm))``
   ## the sequence will still be sorted.
   ##
-  ## If an invalid range is passed, it raises IndexError.
+  ## If an invalid range is passed, it raises IndexDefect.
   ##
   ## The version uses ``cmp`` to compare the elements.
   ## The expected return values are the same as that of ``system.cmp``.
@@ -286,7 +286,7 @@ proc upperBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.
   ## ``insert(thing, elm, upperBound(thing, elm))``
   ## the sequence will still be sorted.
   ##
-  ## If an invalid range is passed, it raises IndexError.
+  ## If an invalid range is passed, it raises IndexDefect.
   ##
   ## The version uses ``cmp`` to compare the elements. The expected
   ## return values are the same as that of ``system.cmp``.
@@ -763,7 +763,7 @@ proc rotateLeft*[T](arg: var openArray[T]; slice: HSlice[int, int];
   ##
   ## Elements outside of ``slice`` will be left unchanged.
   ## The time complexity is linear to ``slice.b - slice.a + 1``.
-  ## If an invalid range (``HSlice``) is passed, it raises IndexError.
+  ## If an invalid range (``HSlice``) is passed, it raises IndexDefect.
   ##
   ## ``slice``
   ##   The indices of the element range that should be rotated.
@@ -783,7 +783,7 @@ proc rotateLeft*[T](arg: var openArray[T]; slice: HSlice[int, int];
     assert a == [0, 3, 4, 1, 2, 5]
     a.rotateLeft(1 .. 4, -3)
     assert a == [0, 4, 1, 2, 3, 5]
-    doAssertRaises(IndexError, a.rotateLeft(1 .. 7, 2))
+    doAssertRaises(IndexDefect, a.rotateLeft(1 .. 7, 2))
   let sliceLen = slice.b + 1 - slice.a
   let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
   arg.rotateInternal(slice.a, slice.a+distLeft, slice.b + 1)
@@ -813,7 +813,7 @@ proc rotatedLeft*[T](arg: openArray[T]; slice: HSlice[int, int],
   ## not modify the argument. It creates a new ``seq`` instead.
   ##
   ## Elements outside of ``slice`` will be left unchanged.
-  ## If an invalid range (``HSlice``) is passed, it raises IndexError.
+  ## If an invalid range (``HSlice``) is passed, it raises IndexDefect.
   ##
   ## ``slice``
   ##   The indices of the element range that should be rotated.

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -31,7 +31,7 @@ template createCb(retFutureSym, iteratorNameSym,
           if not retFutUnown.finished:
             let msg = "Async procedure ($1) yielded `nil`, are you await'ing a " &
                     "`nil` Future?"
-            raise newException(AssertionError, msg % strName)
+            raise newException(AssertionDefect, msg % strName)
         else:
           {.gcsafe.}:
             {.push hint[ConvFromXtoItselfNotNeeded]: off.}
@@ -260,7 +260,7 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
     template await(f: typed): untyped =
       static:
         error "await expects Future[T], got " & $typeof(f)
-    
+
     template await[T](f: Future[T]): auto =
       var internalTmpFuture: FutureBase = f
       yield internalTmpFuture

--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -12,7 +12,7 @@
 ##
 ## None of the procs that get an individual value from the deque can be used
 ## on an empty deque.
-## If compiled with `boundChecks` option, those procs will raise an `IndexError`
+## If compiled with `boundChecks` option, those procs will raise an `IndexDefect`
 ## on such access. This should not be relied upon, as `-d:release` will
 ## disable those checks and may return garbage or crash the program.
 ##
@@ -24,7 +24,7 @@
 ##
 ##   var a = initDeque[int]()
 ##
-##   doAssertRaises(IndexError, echo a[0])
+##   doAssertRaises(IndexDefect, echo a[0])
 ##
 ##   for i in 1 .. 5:
 ##     a.addLast(10*i)
@@ -70,7 +70,7 @@ template initImpl(result: typed, initialSize: int) =
   assert isPowerOfTwo(initialSize)
   result.mask = initialSize-1
   newSeq(result.data, initialSize)
-  
+
 template checkIfInitialized(deq: typed) =
   when compiles(defaultInitialSize):
     if deq.mask == 0:
@@ -97,16 +97,16 @@ template emptyCheck(deq) =
   # Bounds check for the regular deque access.
   when compileOption("boundChecks"):
     if unlikely(deq.count < 1):
-      raise newException(IndexError, "Empty deque.")
+      raise newException(IndexDefect, "Empty deque.")
 
 template xBoundsCheck(deq, i) =
   # Bounds check for the array like accesses.
   when compileOption("boundChecks"): # d:release should disable this.
     if unlikely(i >= deq.count): # x < deq.low is taken care by the Natural parameter
-      raise newException(IndexError,
+      raise newException(IndexDefect,
                          "Out of bounds: " & $i & " > " & $(deq.count - 1))
     if unlikely(i < 0): # when used with BackwardsIndex
-      raise newException(IndexError,
+      raise newException(IndexDefect,
                          "Out of bounds: " & $i & " < 0")
 
 proc `[]`*[T](deq: Deque[T], i: Natural): T {.inline.} =
@@ -117,7 +117,7 @@ proc `[]`*[T](deq: Deque[T], i: Natural): T {.inline.} =
       a.addLast(10*i)
     assert a[0] == 10
     assert a[3] == 40
-    doAssertRaises(IndexError, echo a[8])
+    doAssertRaises(IndexDefect, echo a[8])
 
   xBoundsCheck(deq, i)
   return deq.data[(deq.head + i) and deq.mask]
@@ -131,7 +131,7 @@ proc `[]`*[T](deq: var Deque[T], i: Natural): var T {.inline.} =
       a.addLast(10*i)
     assert a[0] == 10
     assert a[3] == 40
-    doAssertRaises(IndexError, echo a[8])
+    doAssertRaises(IndexDefect, echo a[8])
 
   xBoundsCheck(deq, i)
   return deq.data[(deq.head + i) and deq.mask]
@@ -160,7 +160,7 @@ proc `[]`*[T](deq: Deque[T], i: BackwardsIndex): T {.inline.} =
       a.addLast(10*i)
     assert a[^1] == 50
     assert a[^4] == 20
-    doAssertRaises(IndexError, echo a[^9])
+    doAssertRaises(IndexDefect, echo a[^9])
 
   xBoundsCheck(deq, deq.len - int(i))
   return deq[deq.len - int(i)]
@@ -175,7 +175,7 @@ proc `[]`*[T](deq: var Deque[T], i: BackwardsIndex): var T {.inline.} =
       a.addLast(10*i)
     assert a[^1] == 50
     assert a[^4] == 20
-    doAssertRaises(IndexError, echo a[^9])
+    doAssertRaises(IndexDefect, echo a[^9])
 
   xBoundsCheck(deq, deq.len - int(i))
   return deq[deq.len - int(i)]
@@ -569,14 +569,14 @@ when isMainModule:
     try:
       echo deq[99]
       assert false
-    except IndexError:
+    except IndexDefect:
       discard
 
     try:
       assert deq.len == 4
       for i in 0 ..< 5: deq.popFirst()
       assert false
-    except IndexError:
+    except IndexDefect:
       discard
 
   # grabs some types of resize error.

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -26,11 +26,11 @@
 ##
 ## .. code-block:: Nim
 ## import asyncdispatch, httpclient
-## 
+##
 ## proc asyncProc(): Future[string] {.async.} =
 ##   var client = newAsyncHttpClient()
 ##   return await client.getContent("http://example.com")
-## 
+##
 ## echo waitFor asyncProc()
 ##
 ## The functionality implemented by ``HttpClient`` and ``AsyncHttpClient``
@@ -225,7 +225,7 @@ type
     bodyStream*: FutureStream[string]
 
 proc code*(response: Response | AsyncResponse): HttpCode
-           {.raises: [ValueError, OverflowError].} =
+           {.raises: [ValueError, OverflowDefect].} =
   ## Retrieves the specified response's ``HttpCode``.
   ##
   ## Raises a ``ValueError`` if the response's ``status`` does not have a

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1300,18 +1300,18 @@ when isMainModule:
   when compileOption("boundChecks"):
     try:
       let a = testJson["a"][9]
-      doAssert(false, "IndexError not thrown")
-    except IndexError:
+      doAssert(false, "IndexDefect not thrown")
+    except IndexDefect:
       discard
     try:
       let a = testJson["a"][-1]
-      doAssert(false, "IndexError not thrown")
-    except IndexError:
+      doAssert(false, "IndexDefect not thrown")
+    except IndexDefect:
       discard
     try:
       doAssert(testJson["a"][0].num == 1, "Index doesn't correspond to its value")
     except:
-      doAssert(false, "IndexError thrown for valid index")
+      doAssert(false, "IndexDefect thrown for valid index")
 
   doAssert(testJson{"b"}.getStr() == "asd", "Couldn't fetch a singly nested key with {}")
   doAssert(isNil(testJson{"nonexistent"}), "Non-existent keys should return nil")
@@ -1378,7 +1378,7 @@ when isMainModule:
     try:
       discard parsed["key2"][12123]
       doAssert(false)
-    except IndexError: doAssert(true)
+    except IndexDefect: doAssert(true)
 
     var parsed2 = parseFile("tests/testdata/jsontest2.json")
     doAssert(parsed2{"repository", "description"}.str ==

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -1205,7 +1205,7 @@ when isMainModule:
   block: # fac() tests
     try:
       discard fac(-1)
-    except AssertionError:
+    except AssertionDefect:
       discard
 
     doAssert fac(0) == 1

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -457,7 +457,7 @@ proc fromSockAddrAux(sa: ptr Sockaddr_storage, sl: SockLen,
 proc fromSockAddr*(sa: Sockaddr_storage | SockAddr | Sockaddr_in | Sockaddr_in6,
     sl: SockLen, address: var IpAddress, port: var Port) {.inline.} =
   ## Converts `SockAddr` and `SockLen` to `IpAddress` and `Port`. Raises
-  ## `ObjectConversionError` in case of invalid `sa` and `sl` arguments.
+  ## `ObjectConversionDefect` in case of invalid `sa` and `sl` arguments.
   fromSockAddrAux(cast[ptr Sockaddr_storage](unsafeAddr sa), sl, address, port)
 
 when defineSsl:
@@ -488,7 +488,7 @@ when defineSsl:
   proc getExtraData*(ctx: SslContext, index: int): RootRef =
     ## Retrieves arbitrary data stored inside SslContext.
     if index notin ctx.referencedData:
-      raise newException(IndexError, "No data with that index.")
+      raise newException(IndexDefect, "No data with that index.")
     let res = ctx.context.SSL_CTX_get_ex_data(index.cint)
     if cast[int](res) == 0:
       raiseSSLError()

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -74,8 +74,8 @@ type
       val: T
       has: bool
 
-  UnpackError* = object of Defect
-
+  UnpackDefect* = object of Defect
+  UnpackError* {.deprecated: "See corresponding Defect".} = UnpackDefect
 
 proc option*[T](val: T): Option[T] =
   ## Can be used to convert a pointer type (`ptr` or `ref` or `proc`) to an option type.
@@ -486,7 +486,7 @@ when isMainModule:
 
       let tmp = option(intref)
       check(sizeof(tmp) == sizeof(ptr int))
-      
+
       var prc = proc (x: int): int = x + 1
       check(option(prc).isSome)
       prc = nil

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2678,7 +2678,7 @@ when defined(nimdoc):
   proc paramStr*(i: int): TaintedString {.tags: [ReadIOEffect].} =
     ## Returns the `i`-th `command line argument`:idx: given to the application.
     ##
-    ## `i` should be in the range `1..paramCount()`, the `IndexError`
+    ## `i` should be in the range `1..paramCount()`, the `IndexDefect`
     ## exception will be raised for invalid values.  Instead of iterating over
     ## `paramCount() <#paramCount>`_ with this proc you can call the
     ## convenience `commandLineParams() <#commandLineParams>`_.
@@ -2754,7 +2754,7 @@ elif defined(windows):
       ownArgv = parseCmdLine($getCommandLine())
       ownParsedArgv = true
     if i < ownArgv.len and i >= 0: return TaintedString(ownArgv[i])
-    raise newException(IndexError, formatErrorIndexBound(i, ownArgv.len-1))
+    raise newException(IndexDefect, formatErrorIndexBound(i, ownArgv.len-1))
 
 elif defined(genode):
   proc paramStr*(i: int): TaintedString =
@@ -2773,7 +2773,7 @@ elif not defined(createNimRtl) and
   proc paramStr*(i: int): TaintedString {.tags: [ReadIOEffect].} =
     # Docstring in nimdoc block.
     if i < cmdCount and i >= 0: return TaintedString($cmdLine[i])
-    raise newException(IndexError, formatErrorIndexBound(i, cmdCount-1))
+    raise newException(IndexDefect, formatErrorIndexBound(i, cmdCount-1))
 
   proc paramCount*(): int {.tags: [ReadIOEffect].} =
     # Docstring in nimdoc block.

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -393,7 +393,7 @@ proc captureBetween*(s: string, first: char, second = '\0', start = 0): string =
   result = ""
   discard s.parseUntil(result, if second == '\0': first else: second, i)
 
-proc integerOutOfRangeError() {.noinline.} =
+proc integerOutOfRangeDefect() {.noinline.} =
   raise newException(ValueError, "Parsed integer outside of valid range")
 
 # See #6752
@@ -416,11 +416,11 @@ proc rawParseInt(s: string, b: var BiggestInt, start = 0): int =
       if b >= (low(BiggestInt) + c) div 10:
         b = b * 10 - c
       else:
-        integerOutOfRangeError()
+        integerOutOfRangeDefect()
       inc(i)
       while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
     if sign == -1 and b == low(BiggestInt):
-      integerOutOfRangeError()
+      integerOutOfRangeDefect()
     else:
       b = b * sign
       result = i - start
@@ -459,7 +459,7 @@ proc parseInt*(s: string, number: var int, start = 0): int {.
   result = parseBiggestInt(s, res, start)
   when sizeof(int) <= 4:
     if res < low(int) or res > high(int):
-      integerOutOfRangeError()
+      integerOutOfRangeDefect()
   if result != 0:
     number = int(res)
 
@@ -493,7 +493,7 @@ proc rawParseUInt(s: string, b: var BiggestUInt, start = 0): int =
     prev = 0.BiggestUInt
     i = start
   if i < s.len - 1 and s[i] == '-' and s[i + 1] in {'0'..'9'}:
-    integerOutOfRangeError()
+    integerOutOfRangeDefect()
   if i < s.len and s[i] == '+': inc(i) # Allow
   if i < s.len and s[i] in {'0'..'9'}:
     b = 0
@@ -501,7 +501,7 @@ proc rawParseUInt(s: string, b: var BiggestUInt, start = 0): int =
       prev = res
       res = res * 10 + (ord(s[i]) - ord('0')).BiggestUInt
       if prev > res:
-        integerOutOfRangeError()
+        integerOutOfRangeDefect()
       inc(i)
       while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
     b = res
@@ -540,7 +540,7 @@ proc parseUInt*(s: string, number: var uint, start = 0): int {.
   result = parseBiggestUInt(s, res, start)
   when sizeof(BiggestUInt) > sizeof(uint) and sizeof(uint) <= 4:
     if res > 0xFFFF_FFFF'u64:
-      integerOutOfRangeError()
+      integerOutOfRangeDefect()
   if result != 0:
     number = uint(res)
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -676,13 +676,13 @@ when isMainModule:
       try:
         discard rand(-1)
         doAssert false
-      except RangeError:
+      except RangeDefect:
         discard
 
       try:
         discard rand(-1.0)
         doAssert false
-      except RangeError:
+      except RangeDefect:
         discard
 
 

--- a/lib/pure/rationals.nim
+++ b/lib/pure/rationals.nim
@@ -93,7 +93,7 @@ proc reduce*[T: SomeInteger](x: var Rational[T]) =
     x.num = -x.num div common
     x.den = -x.den div common
   else:
-    raise newException(DivByZeroError, "division by zero")
+    raise newException(DivByZeroDefect, "division by zero")
 
 proc `+` *[T](x, y: Rational[T]): Rational[T] =
   ## Add two rational numbers.
@@ -194,7 +194,7 @@ proc reciprocal*[T](x: Rational[T]): Rational[T] =
     result.num = -x.den
     result.den = -x.num
   else:
-    raise newException(DivByZeroError, "division by zero")
+    raise newException(DivByZeroDefect, "division by zero")
 
 proc `/`*[T](x, y: Rational[T]): Rational[T] =
   ## Divide rationals `x` by `y`.

--- a/lib/pure/segfaults.nim
+++ b/lib/pure/segfaults.nim
@@ -8,17 +8,17 @@
 #
 
 ## This modules registers a signal handler that turns access violations /
-## segfaults into a ``NilAccessError`` exception. To be able to catch
-## a NilAccessError all you have to do is to import this module.
+## segfaults into a ``NilAccessDefect`` exception. To be able to catch
+## a NilAccessDefect all you have to do is to import this module.
 ##
 ## Tested on these OSes: Linux, Windows, OSX
 
 {.used.}
 
 # do allocate memory upfront:
-var se: ref NilAccessError
+var se: ref NilAccessDefect
 new(se)
-se.name = "NilAccessError"
+se.name = "NilAccessDefect"
 se.msg = "Could not access value because it is nil."
 
 when defined(windows):

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -88,7 +88,7 @@
 ##
 ##     test "out of bounds error is thrown on bad access":
 ##       let v = @[1, 2, 3]  # you can do initialization here
-##       expect(IndexError):
+##       expect(IndexDefect):
 ##         discard v[4]
 ##
 ##     echo "suite teardown: run once after the tests"
@@ -190,7 +190,7 @@ proc delOutputFormatter*(formatter: OutputFormatter) =
 
 proc resetOutputFormatters* {.since: (1, 1).} =
   formatters = @[]
-    
+
 proc newConsoleOutputFormatter*(outputLevel: OutputLevel = OutputLevel.PRINT_ALL,
                                 colorOutput = true): <//>ConsoleOutputFormatter =
   ConsoleOutputFormatter(
@@ -717,7 +717,7 @@ macro expect*(exceptions: varargs[typed], body: untyped): untyped =
   ##    of 3: raise newException(IOError, "I can't do that Dave.")
   ##    else: assert 2 + 2 == 5
   ##
-  ##  expect IOError, OSError, ValueError, AssertionError:
+  ##  expect IOError, OSError, ValueError, AssertionDefect:
   ##    defectiveRobot()
   let exp = callsite()
   template expectBody(errorTypes, lineInfoLit, body): NimNode {.dirty.} =

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -64,7 +64,7 @@ template `[]`*[I](a: Wrapnil, i: I): untyped =
   ## See top-level example.
   let a1 = a # to avoid double evaluations
   if a1.validImpl:
-    # correctly will raise IndexError if a is valid but wraps an empty container
+    # correctly will raise IndexDefect if a is valid but wraps an empty container
     wrapnil(a1.valueImpl[i])
   else:
     default(Wrapnil[type(a1.valueImpl[i])])

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -868,8 +868,8 @@ proc `of`*[T, S](x: T, y: S): bool {.magic: "Of", noSideEffect.}
   ## Checks if `x` has a type of `y`.
   ##
   ## .. code-block:: Nim
-  ##   assert(FloatingPointError of Exception)
-  ##   assert(DivByZeroError of Exception)
+  ##   assert(FloatingPointDefect of Exception)
+  ##   assert(DivByZeroDefect of Exception)
 
 proc cmp*[T](x, y: T): int {.procvar.} =
   ## Generic compare proc.
@@ -1673,8 +1673,8 @@ proc instantiationInfo*(index = -1, fullPaths = false): tuple[
   ##     result = a[pos]
   ##
   ##   when isMainModule:
-  ##     testException(IndexError, tester(30))
-  ##     testException(IndexError, tester(1))
+  ##     testException(IndexDefect, tester(30))
+  ##     testException(IndexDefect, tester(1))
   ##     # --> Test failure at example.nim:20 with 'tester(1)'
 
 proc compiles*(x: untyped): bool {.magic: "Compiles", noSideEffect, compileTime.} =
@@ -2493,7 +2493,7 @@ proc `[]=`*[Idx, T, U, V](a: var array[Idx, T], x: HSlice[U, V], b: openArray[T]
   if L == b.len:
     for i in 0..<L: a[Idx(i + xa)] = b[i]
   else:
-    sysFatal(RangeError, "different lengths for slice assignment")
+    sysFatal(RangeDefect, "different lengths for slice assignment")
 
 proc `[]`*[T, U, V](s: openArray[T], x: HSlice[U, V]): seq[T] =
   ## Slice operation for sequences.
@@ -2655,7 +2655,7 @@ when compileOption("rangechecks"):
     ## Helper for performing user-defined range checks.
     ## Such checks will be performed only when the ``rangechecks``
     ## compile-time option is enabled.
-    if not cond: sysFatal(RangeError, "range check failed")
+    if not cond: sysFatal(RangeDefect, "range check failed")
 else:
   template rangeCheck*(cond) = discard
 

--- a/lib/system/arithm.nim
+++ b/lib/system/arithm.nim
@@ -12,10 +12,10 @@
 
 proc raiseOverflow {.compilerproc, noinline.} =
   # a single proc to reduce code size to a minimum
-  sysFatal(OverflowError, "over- or underflow")
+  sysFatal(OverflowDefect, "over- or underflow")
 
 proc raiseDivByZero {.compilerproc, noinline.} =
-  sysFatal(DivByZeroError, "division by zero")
+  sysFatal(DivByZeroDefect, "division by zero")
 
 when defined(builtinOverflow):
   # Builtin compiler functions for improved performance
@@ -410,16 +410,16 @@ when not declared(mulInt):
 # written in other languages.
 
 proc raiseFloatInvalidOp {.compilerproc, noinline.} =
-  sysFatal(FloatInvalidOpError, "FPU operation caused a NaN result")
+  sysFatal(FloatInvalidOpDefect, "FPU operation caused a NaN result")
 
 proc nanCheck(x: float64) {.compilerproc, inline.} =
   if x != x: raiseFloatInvalidOp()
 
 proc raiseFloatOverflow(x: float64) {.compilerproc, noinline.} =
   if x > 0.0:
-    sysFatal(FloatOverflowError, "FPU operation caused an overflow")
+    sysFatal(FloatOverflowDefect, "FPU operation caused an overflow")
   else:
-    sysFatal(FloatUnderflowError, "FPU operations caused an underflow")
+    sysFatal(FloatUnderflowDefect, "FPU operations caused an underflow")
 
 proc infCheck(x: float64) {.compilerproc, inline.} =
   if x != 0.0 and x*0.5 == x: raiseFloatOverflow(x)

--- a/lib/system/arithmetics.nim
+++ b/lib/system/arithmetics.nim
@@ -2,7 +2,7 @@ proc succ*[T: Ordinal](x: T, y = 1): T {.magic: "Succ", noSideEffect.}
   ## Returns the ``y``-th successor (default: 1) of the value ``x``.
   ## ``T`` has to be an `ordinal type <#Ordinal>`_.
   ##
-  ## If such a value does not exist, ``OverflowError`` is raised
+  ## If such a value does not exist, ``OverflowDefect`` is raised
   ## or a compile time error occurs.
   ##
   ## .. code-block:: Nim
@@ -14,7 +14,7 @@ proc pred*[T: Ordinal](x: T, y = 1): T {.magic: "Pred", noSideEffect.}
   ## Returns the ``y``-th predecessor (default: 1) of the value ``x``.
   ## ``T`` has to be an `ordinal type <#Ordinal>`_.
   ##
-  ## If such a value does not exist, ``OverflowError`` is raised
+  ## If such a value does not exist, ``OverflowDefect`` is raised
   ## or a compile time error occurs.
   ##
   ## .. code-block:: Nim
@@ -25,7 +25,7 @@ proc pred*[T: Ordinal](x: T, y = 1): T {.magic: "Pred", noSideEffect.}
 proc inc*[T: Ordinal](x: var T, y = 1) {.magic: "Inc", noSideEffect.}
   ## Increments the ordinal ``x`` by ``y``.
   ##
-  ## If such a value does not exist, ``OverflowError`` is raised or a compile
+  ## If such a value does not exist, ``OverflowDefect`` is raised or a compile
   ## time error occurs. This is a short notation for: ``x = succ(x, y)``.
   ##
   ## .. code-block:: Nim
@@ -36,7 +36,7 @@ proc inc*[T: Ordinal](x: var T, y = 1) {.magic: "Inc", noSideEffect.}
 proc dec*[T: Ordinal](x: var T, y = 1) {.magic: "Dec", noSideEffect.}
   ## Decrements the ordinal ``x`` by ``y``.
   ##
-  ## If such a value does not exist, ``OverflowError`` is raised or a compile
+  ## If such a value does not exist, ``OverflowDefect`` is raised or a compile
   ## time error occurs. This is a short notation for: ``x = pred(x, y)``.
   ##
   ## .. code-block:: Nim

--- a/lib/system/assertions.nim
+++ b/lib/system/assertions.nim
@@ -19,10 +19,10 @@ when not defined(nimHasSinkInference):
   {.pragma: nosinks.}
 
 proc raiseAssert*(msg: string) {.noinline, noreturn, nosinks.} =
-  sysFatal(AssertionError, msg)
+  sysFatal(AssertionDefect, msg)
 
 proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
-  # trick the compiler to not list ``AssertionError`` when called
+  # trick the compiler to not list ``AssertionDefect`` when called
   # by ``assert``.
   type Hide = proc (msg: string) {.noinline, raises: [], noSideEffect,
                                     tags: [].}
@@ -40,9 +40,9 @@ template assertImpl(cond: bool, msg: string, expr: string, enabled: static[bool]
         failedAssertImpl(ploc & " `" & expr & "` " & msg)
 
 template assert*(cond: untyped, msg = "") =
-  ## Raises ``AssertionError`` with `msg` if `cond` is false. Note
-  ## that ``AssertionError`` is hidden from the effect system, so it doesn't
-  ## produce ``{.raises: [AssertionError].}``. This exception is only supposed
+  ## Raises ``AssertionDefect`` with `msg` if `cond` is false. Note
+  ## that ``AssertionDefect`` is hidden from the effect system, so it doesn't
+  ## produce ``{.raises: [AssertionDefect].}``. This exception is only supposed
   ## to be caught by unit testing frameworks.
   ##
   ## The compiler may not generate any code at all for ``assert`` if it is
@@ -80,7 +80,7 @@ template onFailedAssert*(msg, code: untyped): untyped {.dirty.} =
     code
 
 template doAssertRaises*(exception: typedesc, code: untyped) =
-  ## Raises ``AssertionError`` if specified ``code`` does not raise the
+  ## Raises ``AssertionDefect`` if specified ``code`` does not raise the
   ## specified exception. Example:
   ##
   ## .. code-block:: nim

--- a/lib/system/assign.nim
+++ b/lib/system/assign.nim
@@ -233,10 +233,10 @@ proc FieldDiscriminantCheck(oldDiscVal, newDiscVal: int,
   let newBranch = selectBranch(newDiscVal, L, a)
   when defined(nimOldCaseObjects):
     if newBranch != oldBranch and oldDiscVal != 0:
-      sysFatal(FieldError, "assignment to discriminant changes object branch")
+      sysFatal(FieldDefect, "assignment to discriminant changes object branch")
   else:
     if newBranch != oldBranch:
       if oldDiscVal != 0:
-        sysFatal(FieldError, "assignment to discriminant changes object branch")
+        sysFatal(FieldDefect, "assignment to discriminant changes object branch")
       else:
-        sysFatal(FieldError, "assignment to discriminant changes object branch; compile with -d:nimOldCaseObjects for a transition period")
+        sysFatal(FieldDefect, "assignment to discriminant changes object branch; compile with -d:nimOldCaseObjects for a transition period")

--- a/lib/system/channels.nim
+++ b/lib/system/channels.nim
@@ -347,7 +347,7 @@ template lockChannel(q, action): untyped =
 
 proc sendImpl(q: PRawChannel, typ: PNimType, msg: pointer, noBlock: bool): bool =
   if q.mask == ChannelDeadMask:
-    sysFatal(DeadThreadError, "cannot send message; thread died")
+    sysFatal(DeadThreadDefect, "cannot send message; thread died")
   acquireSys(q.lock)
   if q.maxItems > 0:
     # Wait until count is less than maxItems

--- a/lib/system/chcks.nim
+++ b/lib/system/chcks.nim
@@ -12,34 +12,34 @@ include system/indexerrors
 
 proc raiseRangeError(val: BiggestInt) {.compilerproc, noinline.} =
   when hostOS == "standalone":
-    sysFatal(RangeError, "value out of range")
+    sysFatal(RangeDefect, "value out of range")
   else:
-    sysFatal(RangeError, "value out of range: ", $val)
+    sysFatal(RangeDefect, "value out of range: ", $val)
 
 proc raiseIndexError3(i, a, b: int) {.compilerproc, noinline.} =
-  sysFatal(IndexError, formatErrorIndexBound(i, a, b))
+  sysFatal(IndexDefect, formatErrorIndexBound(i, a, b))
 
 proc raiseIndexError2(i, n: int) {.compilerproc, noinline.} =
-  sysFatal(IndexError, formatErrorIndexBound(i, n))
+  sysFatal(IndexDefect, formatErrorIndexBound(i, n))
 
 proc raiseIndexError() {.compilerproc, noinline.} =
-  sysFatal(IndexError, "index out of bounds")
+  sysFatal(IndexDefect, "index out of bounds")
 
 proc raiseFieldError(f: string) {.compilerproc, noinline.} =
-  sysFatal(FieldError, f)
+  sysFatal(FieldDefect, f)
 
 proc raiseRangeErrorI(i, a, b: BiggestInt) {.compilerproc, noinline.} =
-  sysFatal(RangeError, "value out of range: " & $i & " notin " & $a & " .. " & $b)
+  sysFatal(RangeDefect, "value out of range: " & $i & " notin " & $a & " .. " & $b)
 
 proc raiseRangeErrorF(i, a, b: float) {.compilerproc, noinline.} =
-  sysFatal(RangeError, "value out of range: " & $i & " notin " & $a & " .. " & $b)
+  sysFatal(RangeDefect, "value out of range: " & $i & " notin " & $a & " .. " & $b)
 
 proc raiseRangeErrorU(i, a, b: uint64) {.compilerproc, noinline.} =
   # todo: better error reporting
-  sysFatal(RangeError, "value out of range")
+  sysFatal(RangeDefect, "value out of range")
 
 proc raiseObjectConversionError() {.compilerproc, noinline.} =
-  sysFatal(ObjectConversionError, "invalid object conversion")
+  sysFatal(ObjectConversionDefect, "invalid object conversion")
 
 proc chckIndx(i, a, b: int): int =
   if i >= a and i <= b:
@@ -63,24 +63,24 @@ proc chckRangeU(i, a, b: uint64): uint64 {.compilerproc.} =
   if i >= a and i <= b:
     return i
   else:
-    sysFatal(RangeError, "value out of range")
+    sysFatal(RangeDefect, "value out of range")
 
 proc chckRangeF(x, a, b: float): float =
   if x >= a and x <= b:
     return x
   else:
     when hostOS == "standalone":
-      sysFatal(RangeError, "value out of range")
+      sysFatal(RangeDefect, "value out of range")
     else:
-      sysFatal(RangeError, "value out of range: ", $x)
+      sysFatal(RangeDefect, "value out of range: ", $x)
 
 proc chckNil(p: pointer) =
   if p == nil:
-    sysFatal(NilAccessError, "attempt to write to a nil address")
+    sysFatal(NilAccessDefect, "attempt to write to a nil address")
 
 proc chckNilDisp(p: pointer) {.compilerproc.} =
   if p == nil:
-    sysFatal(NilAccessError, "cannot dispatch; dispatcher is nil")
+    sysFatal(NilAccessDefect, "cannot dispatch; dispatcher is nil")
 
 when not defined(nimV2):
 
@@ -90,12 +90,12 @@ when not defined(nimV2):
     if x == subclass: return # optimized fast path
     while x != subclass:
       if x == nil:
-        sysFatal(ObjectConversionError, "invalid object conversion")
+        sysFatal(ObjectConversionDefect, "invalid object conversion")
       x = x.base
 
   proc chckObjAsgn(a, b: PNimType) {.compilerproc, inline.} =
     if a != b:
-      sysFatal(ObjectAssignmentError, "invalid object assignment")
+      sysFatal(ObjectAssignmentDefect, "invalid object assignment")
 
   type ObjCheckCache = array[0..1, PNimType]
 
@@ -130,4 +130,4 @@ when not defined(nimV2):
 
 when defined(nimV2):
   proc raiseObjectCaseTransition() {.compilerproc.} =
-    sysFatal(FieldError, "assignment to discriminant changes object branch")
+    sysFatal(FieldDefect, "assignment to discriminant changes object branch")

--- a/lib/system/embedded.nim
+++ b/lib/system/embedded.nim
@@ -32,10 +32,10 @@ const
 proc quitOrDebug() {.noreturn, importc: "abort", header: "<stdlib.h>", nodecl.}
 
 proc raiseException(e: ref Exception, ename: cstring) {.compilerRtl.} =
-  sysFatal(ReraiseError, "exception handling is not available")
+  sysFatal(ReraiseDefect, "exception handling is not available")
 
 proc reraiseException() {.compilerRtl.} =
-  sysFatal(ReraiseError, "no exception to reraise")
+  sysFatal(ReraiseDefect, "no exception to reraise")
 
 proc writeStackTrace() = discard
 
@@ -43,4 +43,4 @@ proc unsetControlCHook() = discard
 proc setControlCHook(hook: proc () {.noconv.}) = discard
 
 proc closureIterSetupExc(e: ref Exception) {.compilerproc, inline.} =
-  sysFatal(ReraiseError, "exception handling is not available")
+  sysFatal(ReraiseDefect, "exception handling is not available")

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -62,19 +62,19 @@ type
     ## Raised if a dynamic library could not be loaded.
   ResourceExhaustedError* = object of CatchableError ## \
     ## Raised if a resource request could not be fulfilled.
-  ArithmeticError* = object of Defect ## \
+  ArithmeticDefect* = object of Defect ## \
     ## Raised if any kind of arithmetic error occurred.
-  DivByZeroError* = object of ArithmeticError ## \
+  DivByZeroDefect* = object of ArithmeticDefect ## \
     ## Raised for runtime integer divide-by-zero errors.
 
-  OverflowError* = object of ArithmeticError ## \
+  OverflowDefect* = object of ArithmeticDefect ## \
     ## Raised for runtime integer overflows.
     ##
     ## This happens for calculations whose results are too large to fit in the
     ## provided bits.
-  AccessViolationError* = object of Defect ## \
+  AccessViolationDefect* = object of Defect ## \
     ## Raised for invalid memory access errors
-  AssertionError* = object of Defect ## \
+  AssertionDefect* = object of Defect ## \
     ## Raised when assertion is proved wrong.
     ##
     ## Usually the result of using the `assert() template
@@ -87,54 +87,77 @@ type
     ## Mostly used by the `tables <tables.html>`_ module, it can also be raised
     ## by other collection modules like `sets <sets.html>`_ or `strtabs
     ## <strtabs.html>`_.
-  OutOfMemError* = object of Defect ## \
+  OutOfMemDefect* = object of Defect ## \
     ## Raised for unsuccessful attempts to allocate memory.
-  IndexError* = object of Defect ## \
+  IndexDefect* = object of Defect ## \
     ## Raised if an array index is out of bounds.
 
-  FieldError* = object of Defect ## \
+  FieldDefect* = object of Defect ## \
     ## Raised if a record field is not accessible because its discriminant's
     ## value does not fit.
-  RangeError* = object of Defect ## \
+  RangeDefect* = object of Defect ## \
     ## Raised if a range check error occurred.
-  StackOverflowError* = object of Defect ## \
+  StackOverflowDefect* = object of Defect ## \
     ## Raised if the hardware stack used for subroutine calls overflowed.
-  ReraiseError* = object of Defect ## \
+  ReraiseDefect* = object of Defect ## \
     ## Raised if there is no exception to reraise.
-  ObjectAssignmentError* = object of Defect ## \
+  ObjectAssignmentDefect* = object of Defect ## \
     ## Raised if an object gets assigned to its parent's object.
-  ObjectConversionError* = object of Defect ## \
+  ObjectConversionDefect* = object of Defect ## \
     ## Raised if an object is converted to an incompatible object type.
     ## You can use ``of`` operator to check if conversion will succeed.
-  FloatingPointError* = object of Defect ## \
+  FloatingPointDefect* = object of Defect ## \
     ## Base class for floating point exceptions.
-  FloatInvalidOpError* = object of FloatingPointError ## \
+  FloatInvalidOpDefect* = object of FloatingPointDefect ## \
     ## Raised by invalid operations according to IEEE.
     ##
     ## Raised by ``0.0/0.0``, for example.
-  FloatDivByZeroError* = object of FloatingPointError ## \
+  FloatDivByZeroDefect* = object of FloatingPointDefect ## \
     ## Raised by division by zero.
     ##
     ## Divisor is zero and dividend is a finite nonzero number.
-  FloatOverflowError* = object of FloatingPointError ## \
+  FloatOverflowDefect* = object of FloatingPointDefect ## \
     ## Raised for overflows.
     ##
     ## The operation produced a result that exceeds the range of the exponent.
-  FloatUnderflowError* = object of FloatingPointError ## \
+  FloatUnderflowDefect* = object of FloatingPointDefect ## \
     ## Raised for underflows.
     ##
     ## The operation produced a result that is too small to be represented as a
     ## normal number.
-  FloatInexactError* = object of FloatingPointError ## \
+  FloatInexactDefect* = object of FloatingPointDefect ## \
     ## Raised for inexact results.
     ##
     ## The operation produced a result that cannot be represented with infinite
     ## precision -- for example: ``2.0 / 3.0, log(1.1)``
     ##
     ## **Note**: Nim currently does not detect these!
-  DeadThreadError* = object of Defect ## \
+  DeadThreadDefect* = object of Defect ## \
     ## Raised if it is attempted to send a message to a dead thread.
-  NilAccessError* = object of Defect ## \
+  NilAccessDefect* = object of Defect ## \
     ## Raised on dereferences of ``nil`` pointers.
     ##
     ## This is only raised if the `segfaults module <segfaults.html>`_ was imported!
+
+  ArithmeticError* {.deprecated: "See corresponding Defect".} = ArithmeticDefect
+  DivByZeroError* {.deprecated: "See corresponding Defect".} = ArithmeticDefect
+  OverflowError* {.deprecated: "See corresponding Defect".} = OverflowDefect
+  AccessViolationError* {.deprecated: "See corresponding Defect".} = AccessViolationDefect
+  AssertionError* {.deprecated: "See corresponding Defect".} = AssertionDefect
+  OutOfMemError* {.deprecated: "See corresponding Defect".} = OutOfMemDefect
+  IndexError* {.deprecated: "See corresponding Defect".} = IndexDefect
+
+  FieldError* {.deprecated: "See corresponding Defect".} = FieldDefect
+  RangeError* {.deprecated: "See corresponding Defect".} = RangeDefect
+  StackOverflowError* {.deprecated: "See corresponding Defect".} = StackOverflowDefect
+  ReraiseError* {.deprecated: "See corresponding Defect".} = ReraiseDefect
+  ObjectAssignmentError* {.deprecated: "See corresponding Defect".} = ObjectAssignmentDefect
+  ObjectConversionError* {.deprecated: "See corresponding Defect".} = ObjectConversionDefect
+  FloatingPointError* {.deprecated: "See corresponding Defect".} = FloatingPointDefect
+  FloatInvalidOpError* {.deprecated: "See corresponding Defect".} = FloatInvalidOpDefect
+  FloatDivByZeroError* {.deprecated: "See corresponding Defect".} = FloatDivByZeroDefect
+  FloatOverflowError* {.deprecated: "See corresponding Defect".} = FloatOverflowDefect
+  FloatUnderflowError* {.deprecated: "See corresponding Defect".} = FloatUnderflowDefect
+  FloatInexactError* {.deprecated: "See corresponding Defect".} = FloatInexactDefect
+  DeadThreadError* {.deprecated: "See corresponding Defect".} = DeadThreadDefect
+  NilAccessError* {.deprecated: "See corresponding Defect".} = NilAccessDefect

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -483,7 +483,7 @@ proc raiseException(e: sink(ref Exception), ename: cstring) {.compilerRtl.} =
 
 proc reraiseException() {.compilerRtl.} =
   if currException == nil:
-    sysFatal(ReraiseError, "no exception to reraise")
+    sysFatal(ReraiseDefect, "no exception to reraise")
   else:
     when gotoBasedExceptions:
       inc nimInErrorMode

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -844,7 +844,7 @@ when not defined(useNimRtl):
     inc(gch.recGcLock)
   proc GC_enable() =
     if gch.recGcLock <= 0:
-      raise newException(AssertionError,
+      raise newException(AssertionDefect,
           "API usage error: GC_enable called but GC is already enabled")
     dec(gch.recGcLock)
 

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -496,7 +496,7 @@ when not defined(useNimRtl):
     inc(gch.recGcLock)
   proc GC_enable() =
     if gch.recGcLock <= 0:
-      raise newException(AssertionError,
+      raise newException(AssertionDefect,
           "API usage error: GC_enable called but GC is already enabled")
     dec(gch.recGcLock)
 

--- a/lib/system/integerops.nim
+++ b/lib/system/integerops.nim
@@ -12,10 +12,10 @@
 
 proc raiseOverflow {.compilerproc, noinline.} =
   # a single proc to reduce code size to a minimum
-  sysFatal(OverflowError, "over- or underflow")
+  sysFatal(OverflowDefect, "over- or underflow")
 
 proc raiseDivByZero {.compilerproc, noinline.} =
-  sysFatal(DivByZeroError, "division by zero")
+  sysFatal(DivByZeroDefect, "division by zero")
 
 {.pragma: nimbaseH, importc, nodecl, noSideEffect, compilerproc.}
 
@@ -123,10 +123,10 @@ divImplFallback(nimDivInt, int)
 divImplFallback(nimDivInt64, int64)
 
 proc raiseFloatInvalidOp {.compilerproc, noinline.} =
-  sysFatal(FloatInvalidOpError, "FPU operation caused a NaN result")
+  sysFatal(FloatInvalidOpDefect, "FPU operation caused a NaN result")
 
 proc raiseFloatOverflow(x: float64) {.compilerproc, noinline.} =
   if x > 0.0:
-    sysFatal(FloatOverflowError, "FPU operation caused an overflow")
+    sysFatal(FloatOverflowDefect, "FPU operation caused an overflow")
   else:
-    sysFatal(FloatUnderflowError, "FPU operations caused an underflow")
+    sysFatal(FloatUnderflowDefect, "FPU operations caused an underflow")

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -142,7 +142,7 @@ proc raiseException(e: ref Exception, ename: cstring) {.
 
 proc reraiseException() {.compilerproc, asmNoStackFrame.} =
   if lastJSError == nil:
-    raise newException(ReraiseError, "no exception to reraise")
+    raise newException(ReraiseDefect, "no exception to reraise")
   else:
     if excHandler == 0:
       if isNimException():
@@ -151,19 +151,19 @@ proc reraiseException() {.compilerproc, asmNoStackFrame.} =
     asm "throw lastJSError;"
 
 proc raiseOverflow {.exportc: "raiseOverflow", noreturn, compilerproc.} =
-  raise newException(OverflowError, "over- or underflow")
+  raise newException(OverflowDefect, "over- or underflow")
 
 proc raiseDivByZero {.exportc: "raiseDivByZero", noreturn, compilerproc.} =
-  raise newException(DivByZeroError, "division by zero")
+  raise newException(DivByZeroDefect, "division by zero")
 
 proc raiseRangeError() {.compilerproc, noreturn.} =
-  raise newException(RangeError, "value out of range")
+  raise newException(RangeDefect, "value out of range")
 
 proc raiseIndexError(i, a, b: int) {.compilerproc, noreturn.} =
-  raise newException(IndexError, formatErrorIndexBound(int(i), int(a), int(b)))
+  raise newException(IndexDefect, formatErrorIndexBound(int(i), int(a), int(b)))
 
 proc raiseFieldError(f: string) {.compilerproc, noreturn.} =
-  raise newException(FieldError, f)
+  raise newException(FieldDefect, f)
 
 proc setConstr() {.varargs, asmNoStackFrame, compilerproc.} =
   asm """
@@ -524,7 +524,7 @@ proc nimMax(a, b: int): int {.compilerproc.} = return if a >= b: a else: b
 
 proc chckNilDisp(p: pointer) {.compilerproc.} =
   if p == nil:
-    sysFatal(NilAccessError, "cannot dispatch; dispatcher is nil")
+    sysFatal(NilAccessDefect, "cannot dispatch; dispatcher is nil")
 
 include "system/hti"
 
@@ -663,7 +663,7 @@ proc chckObj(obj, subclass: PNimType) {.compilerproc.} =
   if x == subclass: return # optimized fast path
   while x != subclass:
     if x == nil:
-      raise newException(ObjectConversionError, "invalid object conversion")
+      raise newException(ObjectConversionDefect, "invalid object conversion")
     x = x.base
 
 proc isObj(obj, subclass: PNimType): bool {.compilerproc.} =

--- a/lib/system/refs_v2.nim
+++ b/lib/system/refs_v2.nim
@@ -191,4 +191,4 @@ proc isObj(obj: PNimType, subclass: cstring): bool {.compilerRtl, inl.} =
 
 proc chckObj(obj: PNimType, subclass: cstring) {.compilerRtl.} =
   # checks if obj is of type subclass:
-  if not isObj(obj, subclass): sysFatal(ObjectConversionError, "invalid object conversion")
+  if not isObj(obj, subclass): sysFatal(ObjectConversionDefect, "invalid object conversion")

--- a/nimpretty/tests/exhaustive.nim
+++ b/nimpretty/tests/exhaustive.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: '''ObjectAssignmentError'''
+  outputsub: '''ObjectAssignmentDefect'''
   exitcode: "1"
 """
 

--- a/nimpretty/tests/expected/exhaustive.nim
+++ b/nimpretty/tests/expected/exhaustive.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: '''ObjectAssignmentError'''
+  outputsub: '''ObjectAssignmentDefect'''
   exitcode: "1"
 """
 

--- a/tests/arc/tcaseobj.nim
+++ b/tests/arc/tcaseobj.nim
@@ -154,16 +154,16 @@ type
     x1: string
     case kind1: bool
       of false: y1: string
-      of true: 
+      of true:
           y2: seq[string]
           case kind2: bool
               of true: z1: string
-              of false: 
+              of false:
                 z2: seq[string]
                 flag: bool
     x2: string
-        
-proc test_myobject = 
+
+proc test_myobject =
   var x: MyObject
   x.x1 = "x1"
   x.x2 = "x2"
@@ -183,7 +183,7 @@ proc test_myobject =
 
   try:
     x.kind1 = x.flag # flag is not accesible
-  except FieldError:
+  except FieldDefect:
     echo "prevented"
 
   doAssert(x.x1 == "x1")

--- a/tests/assert/tassert.nim
+++ b/tests/assert/tassert.nim
@@ -10,7 +10,7 @@ proc callC() = callA()
 
 try:
   callC()
-except AssertionError:
+except AssertionDefect:
   write(stdout, "assertion failure!")
 except:
   write(stdout, "unknown exception!")

--- a/tests/assert/tassert2.nim
+++ b/tests/assert/tassert2.nim
@@ -18,12 +18,12 @@ type
 
 try:
   doAssert(false, "msg1") # doAssert test
-except AssertionError as e:
+except AssertionDefect as e:
   assert e.msg.endsWith "tassert2.nim(20, 11) `false` msg1"
 
 try:
   assert false # assert test with no msg
-except AssertionError as e:
+except AssertionDefect as e:
   assert e.msg.endsWith "tassert2.nim(25, 10) `false` "
 
 try:
@@ -31,13 +31,13 @@ try:
   doAssert(a+a==1) # assert test with Ast expression
   # BUG: const folding would make "1+1==1" appear as `false` in
   # assert message
-except AssertionError as e:
+except AssertionDefect as e:
   assert e.msg.endsWith "`a + a == 1` "
 
 try:
   let a = 1
   doAssert a+a==1 # ditto with `doAssert` and no parens
-except AssertionError as e:
+except AssertionDefect as e:
   assert e.msg.endsWith "`a + a == 1` "
 
 proc fooStatic() =
@@ -91,14 +91,14 @@ block: ## checks for issue https://github.com/nim-lang/Nim/issues/8518
 
   try:
     doAssert fun("foo1") == fun("foo2"), "mymsg"
-  except AssertionError as e:
+  except AssertionDefect as e:
     # used to expand out the template instantiaiton, sometimes filling hundreds of lines
     assert e.msg.endsWith ""
 
 block: ## checks for issue https://github.com/nim-lang/Nim/issues/9301
   try:
     doAssert 1 + 1 == 3
-  except AssertionError as e:
+  except AssertionDefect as e:
     # used to const fold as false
     assert e.msg.endsWith "tassert2.nim(100, 14) `1 + 1 == 3` "
 
@@ -106,6 +106,6 @@ block: ## checks AST isn't transformed as it used to
   let a = 1
   try:
     doAssert a > 1
-  except AssertionError as e:
+  except AssertionDefect as e:
     # used to rewrite as `1 < a`
     assert e.msg.endsWith "tassert2.nim(108, 14) `a > 1` "

--- a/tests/assert/tassert_c.nim
+++ b/tests/assert/tassert_c.nim
@@ -33,7 +33,7 @@ try:
   proc foo() =
     assert(false)
   foo()
-except AssertionError:
+except AssertionDefect:
   let e = getCurrentException()
   let trace = e.getStackTrace
   if tmatch(trace, expected): echo true else: echo "wrong trace:\n" & trace

--- a/tests/async/tasynctry.nim
+++ b/tests/async/tasynctry.nim
@@ -14,7 +14,7 @@ import asyncdispatch, strutils
 
 proc foobar() {.async.} =
   if 5 == 5:
-    raise newException(IndexError, "Test")
+    raise newException(IndexDefect, "Test")
 
 proc catch() {.async.} =
   # TODO: Create a test for when exceptions are not caught.
@@ -25,26 +25,26 @@ proc catch() {.async.} =
 
   try:
     await foobar()
-  except IndexError:
+  except IndexDefect:
     echo("Specific except")
 
   try:
     await foobar()
-  except OSError, FieldError, IndexError:
+  except OSError, FieldDefect, IndexDefect:
     echo("Multiple idents in except")
 
   try:
     await foobar()
-  except OSError, FieldError:
+  except OSError, FieldDefect:
     assert false
-  except IndexError:
+  except IndexDefect:
     echo("Multiple except branches")
 
   try:
     await foobar()
-  except IndexError:
+  except IndexDefect:
     echo("Multiple except branches 2")
-  except OSError, FieldError:
+  except OSError, FieldDefect:
     assert false
 
 waitFor catch()

--- a/tests/async/tupcoming_async.nim
+++ b/tests/async/tupcoming_async.nim
@@ -45,7 +45,7 @@ when defined(upcoming):
     poll()
 
   proc eventTest5298() =
-    # Event must raise `AssertionError` if event was unregistered twice.
+    # Event must raise `AssertionDefect` if event was unregistered twice.
     # Issue #5298.
     let e = newAsyncEvent()
     var eventReceived = false
@@ -57,7 +57,7 @@ when defined(upcoming):
       poll()
     try:
       e.unregister()
-    except AssertionError:
+    except AssertionDefect:
       discard
     e.close()
 

--- a/tests/compiler/tunittest_light.nim
+++ b/tests/compiler/tunittest_light.nim
@@ -2,7 +2,7 @@ import compiler/unittest_light
 
 proc testAssertEquals() =
   assertEquals("foo", "foo")
-  doAssertRaises(AssertionError):
+  doAssertRaises(AssertionDefect):
     assertEquals("foo", "foo ")
 
 proc testMismatch() =

--- a/tests/concepts/tmapconcept.nim
+++ b/tests/concepts/tmapconcept.nim
@@ -78,7 +78,7 @@ proc getFirstValue[K,V](m : Map[K,V]): V =
   for i in m.valuesSeq:
     return i
 
-  raise newException(RangeError, "no values")
+  raise newException(RangeDefect, "no values")
 
 proc useConceptProcInGeneric[K, V](t: Table[K, V]): V =
   return t.getFirstValue

--- a/tests/destructor/tgotoexceptions5.nim
+++ b/tests/destructor/tgotoexceptions5.nim
@@ -13,7 +13,7 @@ proc main() =
   try:
     echo "before"
     raise newException(CatchableError, "foo")
-  except AssertionError:
+  except AssertionDefect:
     echo "caught"
   echo "after"
 
@@ -27,7 +27,7 @@ proc mainB() =
     echo "before"
     raise newException(CatchableError, "foo")
   # except CatchableError: # would work
-  except AssertionError:
+  except AssertionDefect:
     echo "caught"
   except:
     raise

--- a/tests/destructor/tgotoexceptions7.nim
+++ b/tests/destructor/tgotoexceptions7.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim c --gc:arc --exceptions:goto --panics:off $file"
   output: '''prevented!
 caught
-AssertionError
+AssertionDefect
 900'''
 """
 
@@ -30,18 +30,18 @@ proc main(i: int) =
   try:
     var objA = ObjA()
     bplease(ObjB(objA))
-  except ObjectConversionError:
+  except ObjectConversionDefect:
     echo "prevented!"
 
   try:
     takeRange(i)
-  except RangeError:
+  except RangeDefect:
     echo "caught"
 
   try:
     helper()
-  except AssertionError:
-    echo "AssertionError"
+  except AssertionDefect:
+    echo "AssertionDefect"
 
   echo i * i
 

--- a/tests/destructor/tsetjmp_raise.nim
+++ b/tests/destructor/tsetjmp_raise.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "index 2 not in 0 .. 0 [IndexError]"
+  outputsub: "index 2 not in 0 .. 0 [IndexDefect]"
   exitcode: 1
   cmd: "nim c --gc:arc --exceptions:setjmp $file"
 """

--- a/tests/effects/teffects7.nim
+++ b/tests/effects/teffects7.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "can raise an unlisted exception: ref FloatingPointError"
+  errormsg: "can raise an unlisted exception: ref FloatingPointDefect"
   line: 10
 """
 
@@ -7,7 +7,7 @@ proc foo() {.raises: [].} =
   try:
     discard
   except KeyError:
-    raise newException(FloatingPointError, "foo")
+    raise newException(FloatingPointDefect, "foo")
   except Exception:
     discard
 

--- a/tests/exception/texceptions.nim
+++ b/tests/exception/texceptions.nim
@@ -89,10 +89,10 @@ block:
       result.add(1212)
     try:
       try:
-        raise newException(AssertionError, "a")
+        raise newException(AssertionDefect, "a")
       finally:
         result.add(42)
-    except AssertionError:
+    except AssertionDefect:
       result.add(99)
     finally:
       result.add(10)
@@ -104,7 +104,7 @@ block:
       result.add(-1)
     except ValueError:
       result.add(-1)
-    except IndexError:
+    except IndexDefect:
       result.add(2)
     except:
       result.add(3)

--- a/tests/exception/twrongexc.nim
+++ b/tests/exception/twrongexc.nim
@@ -4,5 +4,5 @@ discard """
 """
 try:
   raise newException(ValueError, "")
-except OverflowError:
+except OverflowDefect:
   echo("Error caught")

--- a/tests/float/tfloat1.nim
+++ b/tests/float/tfloat1.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "Error: unhandled exception: FPU operation caused an overflow [FloatOverflowError]"
+  outputsub: "Error: unhandled exception: FPU operation caused an overflow [FloatOverflowDefect]"
   exitcode: "1"
 """
 # Test new floating point exceptions

--- a/tests/float/tfloat2.nim
+++ b/tests/float/tfloat2.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "Error: unhandled exception: FPU operation caused a NaN result [FloatInvalidOpError]"
+  outputsub: "Error: unhandled exception: FPU operation caused a NaN result [FloatInvalidOpDefect]"
   exitcode: "1"
 """
 # Test new floating point exceptions

--- a/tests/js/temptyseq.nim
+++ b/tests/js/temptyseq.nim
@@ -2,7 +2,7 @@
 
 proc foo =
   var x: seq[int]
-  doAssertRaises(IndexError):
+  doAssertRaises(IndexDefect):
     inc x[0]
 
 foo()

--- a/tests/js/tfieldchecks.nim
+++ b/tests/js/tfieldchecks.nim
@@ -24,7 +24,7 @@ var obj = X(f0: "foo", f1: C, f3: 3.14)
 block:
   echo obj.f0
   echo obj.f1
-  doAssertRaises(FieldError): echo obj.f2
+  doAssertRaises(FieldDefect): echo obj.f2
   echo obj.f3
 
 block:
@@ -32,7 +32,7 @@ block:
   echo a0[]
   # let a1 = unsafeAddr(obj.f1)
   # echo a1[]
-  doAssertRaises(FieldError):
+  doAssertRaises(FieldDefect):
     let a2 = addr(obj.f2)
     echo a2[]
   let a3 = addr(obj.f3)

--- a/tests/manyloc/argument_parser/argument_parser.nim
+++ b/tests/manyloc/argument_parser/argument_parser.nim
@@ -251,8 +251,8 @@ proc parse_parameter(quit_on_failure: bool, param, value: string,
   case param_kind:
   of PK_INT:
     try: result.int_val = value.parseInt
-    except OverflowError:
-      raise_or_quit(OverflowError, ("parameter $1 requires an " &
+    except OverflowDefect:
+      raise_or_quit(OverflowDefect, ("parameter $1 requires an " &
         "integer, but $2 is too large to fit into one") % [param,
         escape(value)])
     except ValueError:

--- a/tests/metatype/tunresolved_return_type.nim
+++ b/tests/metatype/tunresolved_return_type.nim
@@ -11,7 +11,7 @@ type
 
 proc toNumber[T: int|uint|int64|uint64](v: ResultValue): T =
   if v < low(T) or v > high(T):
-    raise newException(RangeError, "protocol error")
+    raise newException(RangeDefect, "protocol error")
   return T(v)
 
 #proc toNumber[T](v: int32): T =

--- a/tests/method/tnildispatcher.nim
+++ b/tests/method/tnildispatcher.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: '''Error: unhandled exception: cannot dispatch; dispatcher is nil [NilAccessError]'''
+  outputsub: '''Error: unhandled exception: cannot dispatch; dispatcher is nil [NilAccessDefect]'''
   exitcode: 1
 """
 # bug #5599

--- a/tests/misc/trangechecks.nim
+++ b/tests/misc/trangechecks.nim
@@ -14,14 +14,14 @@ var x: range[1..10] = 10
 try:
   x += 1
   echo x
-except OverflowError, RangeError:
+except OverflowDefect, RangeDefect:
   expected += 1
   echo x
 
 try:
   inc x
   echo x
-except OverflowError, RangeError:
+except OverflowDefect, RangeDefect:
   expected += 1
   echo x
 
@@ -29,14 +29,14 @@ x = 1
 try:
   x -= 1
   echo x
-except OverflowError, RangeError:
+except OverflowDefect, RangeDefect:
   expected += 1
   echo x
 
 try:
   dec x
   echo x
-except OverflowError, RangeError:
+except OverflowDefect, RangeDefect:
   expected += 1
   echo x
 

--- a/tests/misc/tsemfold.nim
+++ b/tests/misc/tsemfold.nim
@@ -2,25 +2,25 @@ discard """
   action: run
 """
 
-doAssertRaises(OverflowError): discard low(int8) - 1'i8
-doAssertRaises(OverflowError): discard high(int8) + 1'i8
-doAssertRaises(OverflowError): discard abs(low(int8))
-doAssertRaises(DivByZeroError): discard 1 mod 0
-doAssertRaises(DivByZeroError): discard 1 div 0
-doAssertRaises(OverflowError): discard low(int8) div -1'i8
+doAssertRaises(OverflowDefect): discard low(int8) - 1'i8
+doAssertRaises(OverflowDefect): discard high(int8) + 1'i8
+doAssertRaises(OverflowDefect): discard abs(low(int8))
+doAssertRaises(DivByZeroDefect): discard 1 mod 0
+doAssertRaises(DivByZeroDefect): discard 1 div 0
+doAssertRaises(OverflowDefect): discard low(int8) div -1'i8
 
-doAssertRaises(OverflowError): discard -low(int64)
-doAssertRaises(OverflowError): discard low(int64) - 1'i64
-doAssertRaises(OverflowError): discard high(int64) + 1'i64
+doAssertRaises(OverflowDefect): discard -low(int64)
+doAssertRaises(OverflowDefect): discard low(int64) - 1'i64
+doAssertRaises(OverflowDefect): discard high(int64) + 1'i64
 
 type E = enum eA, eB
-doAssertRaises(OverflowError): discard eA.pred
-doAssertRaises(OverflowError): discard eB.succ
+doAssertRaises(OverflowDefect): discard eA.pred
+doAssertRaises(OverflowDefect): discard eB.succ
 
-doAssertRaises(OverflowError): discard low(int8) * -1
-doAssertRaises(OverflowError): discard low(int64) * -1
-doAssertRaises(OverflowError): discard high(int8) * 2
-doAssertRaises(OverflowError): discard high(int64) * 2
+doAssertRaises(OverflowDefect): discard low(int8) * -1
+doAssertRaises(OverflowDefect): discard low(int64) * -1
+doAssertRaises(OverflowDefect): discard high(int8) * 2
+doAssertRaises(OverflowDefect): discard high(int64) * 2
 
 doAssert abs(-1) == 1
 doAssert 2 div 2 == 1

--- a/tests/misc/tunsignedinc.nim
+++ b/tests/misc/tunsignedinc.nim
@@ -1,8 +1,8 @@
 
 block: # bug #2427
   var x = 0'u8
-  dec x # OverflowError
-  x -= 1 # OverflowError
+  dec x # OverflowDefect
+  x -= 1 # OverflowDefect
   x = x - 1 # No error
 
   doAssert(x == 253'u8)

--- a/tests/niminaction/Chapter2/various2.nim
+++ b/tests/niminaction/Chapter2/various2.nim
@@ -179,13 +179,13 @@ for i in list4.low .. list4.high:
   echo(list4[i])
 
 var list5: seq[int] = @[]
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   list5[0] = 1
 
 list5.add(1)
 
 assert list5[0] == 1
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   echo list5[42]
 
 # -- Errata: var list: seq[int]; echo(list[0]). This now creates an exception,

--- a/tests/niminaction/Chapter3/various3.nim
+++ b/tests/niminaction/Chapter3/various3.nim
@@ -22,7 +22,7 @@ block:
   assert obj.contents == "Hello"
 
   var obj2 = Box(empty: true)
-  doAssertRaises(FieldError):
+  doAssertRaises(FieldDefect):
     echo(obj2.contents)
 
 import json

--- a/tests/objects/tobj_asgn_dont_slice.nim
+++ b/tests/objects/tobj_asgn_dont_slice.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: '''ObjectAssignmentError'''
+  outputsub: '''ObjectAssignmentDefect'''
   exitcode: "1"
 """
 

--- a/tests/overflw/toverflw.nim
+++ b/tests/overflw/toverflw.nim
@@ -13,7 +13,7 @@ var
 
 try:
   writeLine(stdout, b - a)
-except OverflowError:
+except OverflowDefect:
   overflowDetected = true
 
 {.pop.} # overflow check
@@ -33,7 +33,7 @@ block: # Overflow checks in a proc
 
   try:
     foo()
-  except OverflowError:
+  except OverflowDefect:
     overflowDetected = true
 
   doAssert(overflowDetected)
@@ -53,7 +53,7 @@ block: # Overflow checks in a forward declared proc
 
   try:
     foo()
-  except OverflowError:
+  except OverflowDefect:
     overflowDetected = true
 
   doAssert(overflowDetected)
@@ -73,7 +73,7 @@ block: # Overflow checks doesn't affect fwd declaration
 
   try:
     foo()
-  except OverflowError:
+  except OverflowDefect:
     overflowDetected = true
 
   doAssert(not overflowDetected)

--- a/tests/overflw/toverflw2.nim
+++ b/tests/overflw/toverflw2.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "Error: unhandled exception: over- or underflow [OverflowError]"
+  outputsub: "Error: unhandled exception: over- or underflow [OverflowDefect]"
   exitcode: "1"
 """
 var a : int32 = 2147483647

--- a/tests/range/tsubrange2.nim
+++ b/tests/range/tsubrange2.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "value out of range: 50 notin 0 .. 40 [RangeError]"
+  outputsub: "value out of range: 50 notin 0 .. 40 [RangeDefect]"
   exitcode: "1"
 """
 

--- a/tests/range/tsubrange3.nim
+++ b/tests/range/tsubrange3.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "value out of range: 50 notin 0 .. 40 [RangeError]"
+  outputsub: "value out of range: 50 notin 0 .. 40 [RangeDefect]"
   exitcode: "1"
 """
 

--- a/tests/rational/trat_init.nim
+++ b/tests/rational/trat_init.nim
@@ -10,5 +10,5 @@ var
 try:
   var
     r = initRational(1, 0)  # this fails - no zero denominator
-except AssertionError:
+except AssertionDefect:
   echo "true"

--- a/tests/stdlib/nre/replace.nim
+++ b/tests/stdlib/nre/replace.nim
@@ -16,7 +16,7 @@ suite "replace":
     check("123".replace(re"(?<foo>\d)(\d)", "${foo}$#$#") == "1123")
 
   test "replacing missing captures should throw instead of segfaulting":
-    expect IndexError: discard "ab".replace(re"(a)|(b)", "$1$2")
-    expect IndexError: discard "b".replace(re"(a)?(b)", "$1$2")
+    expect IndexDefect: discard "ab".replace(re"(a)|(b)", "$1$2")
+    expect IndexDefect: discard "b".replace(re"(a)?(b)", "$1$2")
     expect KeyError: discard "b".replace(re"(a)?", "${foo}")
     expect KeyError: discard "b".replace(re"(?<foo>a)?", "${foo}")

--- a/tests/stdlib/tbitops.nim
+++ b/tests/stdlib/tbitops.nim
@@ -266,7 +266,7 @@ block: # not ready for vm because exception is compile error
     var i = 32
     v.setBit(i)
     doAssert false
-  except RangeError:
+  except RangeDefect:
     discard
   except:
     doAssert false

--- a/tests/stdlib/tstdlib_issues.nim
+++ b/tests/stdlib/tstdlib_issues.nim
@@ -43,7 +43,7 @@ block tcount:
 
   # bubble sort
   for i in low(arr)..high(arr):
-    for j in i+1..high(arr): # Error: unhandled exception: value out of range: 5 [RangeError]
+    for j in i+1..high(arr): # Error: unhandled exception: value out of range: 5 [RangeDefect]
       if arr[i] > arr[j]:
         let tmp = arr[i]
         arr[i] = arr[j]

--- a/tests/stdlib/tstdlib_various.nim
+++ b/tests/stdlib/tstdlib_various.nim
@@ -169,7 +169,7 @@ block tsegfaults:
         raise newException(ValueError, "not a crash")
       except ValueError:
         discard
-    except NilAccessError:
+    except NilAccessDefect:
       echo "caught a crash!"
   for i in 0..5:
     main()
@@ -212,7 +212,7 @@ block tsplit2:
   try:
     discard "hello".split("")
     echo "false"
-  except AssertionError:
+  except AssertionDefect:
     echo "true"
 
 

--- a/tests/stdlib/tstring.nim
+++ b/tests/stdlib/tstring.nim
@@ -52,7 +52,7 @@ proc test_string_slice() =
   doAssert s == "ab1234567890cdefghijklmnopqrstuvwxyz"
 
   # bug #6223
-  doAssertRaises(IndexError):
+  doAssertRaises(IndexDefect):
     discard s[0..999]
 
   echo("OK")

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -11,7 +11,7 @@ import macros
 template rejectParse(e) =
   try:
     discard e
-    raise newException(AssertionError, "This was supposed to fail: $#!" % astToStr(e))
+    raise newException(AssertionDefect, "This was supposed to fail: $#!" % astToStr(e))
   except ValueError: discard
 
 proc testStrip() =

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -626,8 +626,8 @@ suite "ttimes":
     doAssert a.month.Month == cast[Month](0)
     doAssert a.monthday == 0
 
-    doAssertRaises(AssertionError): discard getDayOfWeek(a.monthday, a.month, a.year)
-    doAssertRaises(AssertionError): discard a.toTime
+    doAssertRaises(AssertionDefect): discard getDayOfWeek(a.monthday, a.month, a.year)
+    doAssertRaises(AssertionDefect): discard a.toTime
 
   test "inX procs":
     doAssert initDuration(seconds = 1).inSeconds == 1

--- a/tests/stdlib/tunittest.nim
+++ b/tests/stdlib/tunittest.nim
@@ -56,7 +56,7 @@ proc defectiveRobot() =
   of 3: raise newException(IOError, "I can't do that Dave.")
   else: assert 2 + 2 == 5
 test "unittest expect":
-  expect IOError, OSError, ValueError, AssertionError:
+  expect IOError, OSError, ValueError, AssertionDefect:
     defectiveRobot()
 
 var

--- a/tests/stdlib/twrapnils.nim
+++ b/tests/stdlib/twrapnils.nim
@@ -68,8 +68,8 @@ proc main() =
   # shows that checkNotZero won't be called if a nil is found earlier in chain
   doAssert ?.a.x1.checkNotZero == 0.0
 
-  # checks that a chain without nil but with an empty seq still throws IndexError
-  doAssertRaises(IndexError): discard ?.a2.x8[3]
+  # checks that a chain without nil but with an empty seq still throws IndexDefect
+  doAssertRaises(IndexDefect): discard ?.a2.x8[3]
 
   # make sure no double evaluation bug
   doAssert witness == 0

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -81,13 +81,13 @@ foo(toOpenArray(seqq, 1, 3))
 # empty openArray issue #7904
 foo(toOpenArray(seqq, 0, -1))
 foo(toOpenArray(seqq, 1, 0))
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   foo(toOpenArray(seqq, 0, -2))
 
 foo(toOpenArray(arr, 9, 8))
 foo(toOpenArray(arr, 0, -1))
 foo(toOpenArray(arr, 1, 0))
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   foo(toOpenArray(arr, 10, 8))
 
 # test openArray of openArray
@@ -106,11 +106,11 @@ var arrNeg: array[-3 .. -1, int] = [1, 2, 3]
 foo(toOpenArray(arrNeg, -3, -1))
 foo(toOpenArray(arrNeg, 0, -1))
 foo(toOpenArray(arrNeg, -3, -4))
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   foo(toOpenArray(arrNeg, -4, -1))
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   foo(toOpenArray(arrNeg, -1, 0))
-doAssertRaises(IndexError):
+doAssertRaises(IndexDefect):
   foo(toOpenArray(arrNeg, -1, -3))
 doAssertRaises(Exception):
   raise newException(Exception, "foo")
@@ -118,9 +118,9 @@ doAssertRaises(Exception):
 block:
   var didThrow = false
   try:
-    doAssertRaises(IndexError): # should fail since it's wrong exception
-      raise newException(FieldError, "foo")
-  except AssertionError:
+    doAssertRaises(IndexDefect): # should fail since it's wrong exception
+      raise newException(FieldDefect, "foo")
+  except AssertionDefect:
     # ok, throwing was correct behavior
     didThrow = true
   doAssert didThrow

--- a/tests/typerel/t4799_1.nim
+++ b/tests/typerel/t4799_1.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp"
-  outputsub: '''ObjectAssignmentError'''
+  outputsub: '''ObjectAssignmentDefect'''
   exitcode: "1"
 """
 

--- a/tests/typerel/t4799_2.nim
+++ b/tests/typerel/t4799_2.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp"
-  outputsub: '''ObjectAssignmentError'''
+  outputsub: '''ObjectAssignmentDefect'''
   exitcode: "1"
 """
 

--- a/tests/typerel/t4799_3.nim
+++ b/tests/typerel/t4799_3.nim
@@ -1,6 +1,6 @@
 discard """
   targets: "c cpp"
-  outputsub: '''ObjectAssignmentError'''
+  outputsub: '''ObjectAssignmentDefect'''
   exitcode: "1"
 """
 


### PR DESCRIPTION
The distinction between Error and Defect is subjective,
context-dependent and somewhat arbitrary, so when looking at an
exception, it's hard to guess what it is - this happens often when
looking at a `raises` list _without_ opening the corresponding
definition and digging through layers of inheritance.

With the help of a little consistency in naming, it's at least possible
to start disentangling the two error types and the standard lib can set
a good example here.