### PR TITLE
fix #13910

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -143,8 +143,8 @@ compiler vcc:
   result = (
     name: "vcc",
     objExt: "obj",
-    optSpeed: " /Ogityb2 /G7 ",
-    optSize: " /O1 /G7 ",
+    optSpeed: " /Ogityb2 ",
+    optSize: " /O1 ",
     compilerExe: "cl",
     cppCompiler: "cl",
     compileTmpl: "/c$vccplatform $options $include /Fo$objfile $file",

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -569,7 +569,7 @@ NIM_STATIC_ASSERT(sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(NI)*8, ""
 #define nimModInt(a, b, res) (((*res) = (a) % (b)), 0)
 #define nimModInt64(a, b, res) (((*res) = (a) % (b)), 0)
 
-#if !defined(_MSC_VER) && !defined(NIM_EmulateOverflowChecks)
+#if (!defined(_MSC_VER) || defined(__clang__)) && !defined(NIM_EmulateOverflowChecks)
   /* these exist because we cannot have .compilerProcs that are importc'ed
     by a different name */
 


### PR DESCRIPTION
fix #13910
/G7 is optimise for pentium4 switch. Meaningless in current reality, save to remove.

