### PR TITLE
Test packages on Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,8 @@ jobs:
       Windows_amd64:
         vmImage: 'windows-2019'
         CPU: amd64
-      Windows_amd64_pkg:
-        vmImage: 'windows-2019'
+      Linux_amd64_pkg:
+        vmImage: 'ubuntu-16.04'
         CPU: amd64
         NIM_TEST_PACKAGES: true
 

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -17,8 +17,7 @@ pkg "c2nim", false, "nim c testsuite/tester.nim"
 pkg "cascade"
 pkg "chroma"
 pkg "chronicles", true, "nim c -o:chr -r chronicles.nim"
-# disable until my chronos fix was merged
-#pkg "chronos", true
+pkg "chronos", true
 pkg "cligen", false, "nim c -o:cligenn -r cligen.nim"
 pkg "coco", true
 pkg "combparser"


### PR DESCRIPTION
* testing packages on Linux instead of Windows makes the CI about 10-15 minutes faster than before (~25min vs ~35-40min)
* re-enabled `chronos` (which takes a couple of minutes to test)