### PR TITLE
Update code example to match new sdl2.nim syntax

### DIFF
--- a/doc/hcr.rst
+++ b/doc/hcr.rst
@@ -189,14 +189,14 @@ Native projects using the hot code reloading option will be implicitly
 compiled with the `-d:useNimRtl` option and they will depend on both
 the ``nimrtl`` library and the ``nimhcr`` library which implements the
 hot code reloading run-time. Both libraries can be found in the ``lib``
-folder of Nim and can be compiled to a ``.dylib`` file to satisfy compiling
-of the example code above. An example of compiling ``nimhcr.nim`` and
-``nimrtl.nim`` when the source dir of Nim is installed with choosenim
-follows.
+folder of Nim and can be compiled into dynamic libraries to satisfy
+runtime demands of the example code above. An example of compiling 
+``nimhcr.nim`` and ``nimrtl.nim`` when the source dir of Nim is installed
+with choosenim follows.
 
 ::
 
-  # UNIX/MacOS
+  # Unix/MacOS
   # Make sure you are in the directory containing your .nim files
   $ cd your-source-directory
 
@@ -204,9 +204,8 @@ follows.
   $ nim c --outdir:$PWD ~/.choosenim/toolchains/nim-#devel/lib/nimhcr.nim
   $ nim c --outdir:$PWD ~/.choosenim/toolchains/nim-#devel/lib/nimrtl.nim
 
-  # verify that you have two files named libnimhcr.dylib and libnimrtl.dylib
-  # in your source directory
-  $ ls libnimhcr.dylib libnimrtl.dylib
+  # verify that you have two files named libnimhcr and libnimrtl in your
+  # source directory (.dll for Windows, .so for Unix, .dylib for MacOS)
 
 All modules of the project will be compiled to separate dynamic link
 libraries placed in the ``nimcache`` directory. Please note that during

--- a/doc/hcr.rst
+++ b/doc/hcr.rst
@@ -27,58 +27,57 @@ To install SDL2 you can use ``nimble install sdl2``.
 
   # logic.nim
   import sdl2
-  
+
   #*** import the hotcodereloading stdlib module ***
   import hotcodereloading
-  
+
   var runGame*: bool = true
   var window: WindowPtr
   var renderer: RendererPtr
   var evt = sdl2.defaultEvent
-  
+
   proc init*() =
     discard sdl2.init(INIT_EVERYTHING)
     window = createWindow("testing", SDL_WINDOWPOS_UNDEFINED.cint, SDL_WINDOWPOS_UNDEFINED.cint, 640, 480, 0'u32)
     assert(window != nil, $sdl2.getError())
     renderer = createRenderer(window, -1, RENDERER_SOFTWARE)
     assert(renderer != nil, $sdl2.getError())
-  
+
   proc destroy*() =
     destroyRenderer(renderer)
     destroyWindow(window)
-  
-  var posX : cint = 1
-  var posY : cint = 0
-  var dX : cint = 1
-  var dY : cint = 1
-  
+
+  var posX: cint = 1
+  var posY: cint = 0
+  var dX: cint = 1
+  var dY: cint = 1
+
   proc update*() =
     while pollEvent(evt):
       if evt.kind == QuitEvent:
         runGame = false
         break
       if evt.kind == KeyDown:
-        if evt.key.keysym.scancode == getScancodeFromName("Escape"): runGame = false
-        elif evt.key.keysym.scancode == getScancodeFromName("F9"):
+        if evt.key.keysym.scancode == SDL_SCANCODE_ESCAPE: runGame = false
+        elif evt.key.keysym.scancode == SDL_SCANCODE_F9:
           #*** reload this logic.nim module on the F9 keypress ***
           performCodeReload()
-  
+
     # draw a bouncing rectangle:
     posX += dX
     posY += dY
-  
+
     if posX >= 640: dX = -2
     if posX <= 0: dX = +2
     if posY >= 480: dY = -2
     if posY <= 0: dY = +2
-  
+
     discard renderer.setDrawColor(0, 0, 255, 255)
     discard renderer.clear()
     discard renderer.setDrawColor(255, 128, 128, 0)
-  
-    var rect: Rect
-    rect = (x: posX - 25, y: posY - 25, w: 50.cint, h: 50.cint)
-    discard renderer.fillRect(rect.addr)
+
+    var rect: Rect = (x: posX - 25, y: posY - 25, w: 50.cint, h: 50.cint)
+    discard renderer.fillRect(rect)
     delay(16)
     renderer.present()
 
@@ -191,7 +190,23 @@ compiled with the `-d:useNimRtl` option and they will depend on both
 the ``nimrtl`` library and the ``nimhcr`` library which implements the
 hot code reloading run-time. Both libraries can be found in the ``lib``
 folder of Nim and can be compiled to a ``.dylib`` file to satisfy compiling
-of the example code above.
+of the example code above. An example of compiling ``nimhcr.nim`` and
+``nimrtl.nim`` when the source dir of Nim is installed with choosenim
+follows.
+
+::
+
+  # UNIX/MacOS
+  # Make sure you are in the directory containing your .nim files
+  $ cd your-source-directory
+
+  # Compile two required files and set their output directory to current dir
+  $ nim c --outdir:$PWD ~/.choosenim/toolchains/nim-#devel/lib/nimhcr.nim
+  $ nim c --outdir:$PWD ~/.choosenim/toolchains/nim-#devel/lib/nimrtl.nim
+
+  # verify that you have two files named libnimhcr.dylib and libnimrtl.dylib
+  # in your source directory
+  $ ls libnimhcr.dylib libnimrtl.dylib
 
 All modules of the project will be compiled to separate dynamic link
 libraries placed in the ``nimcache`` directory. Please note that during


### PR DESCRIPTION
I've updated the code example for hot-code reloading to match the new sdl2 syntax at [nim-lang/sdl2](https://github.com/nim-lang/sdl2/blob/master/src/sdl2.nim)

I've also added a reminder for people who encounter the error `dlopen(libnimhcr.dylib, 2): image not found` as I did earlier today.

Please review and tell me if anything is amiss. This is my first time doing this.

Cheers,
Hieu