### PR TITLE
[WIP] fixes in stdlib for -d:checkAbi

### DIFF
--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -140,12 +140,15 @@ type
     ## used for block sizes
   Clock* {.importc: "clock_t", header: "<sys/types.h>".} = int
   ClockId* {.importc: "clockid_t", header: "<sys/types.h>".} = int
-  Dev* {.importc: "dev_t", header: "<sys/types.h>".} = int
+  Dev* {.importc: "dev_t", header: "<sys/types.h>".} = uint64
+    # WAS: int. Probably not correct but more correct than previous definition
+    # https://lists.debian.org/debian-mips/2011/11/msg00006.html
   Fsblkcnt* {.importc: "fsblkcnt_t", header: "<sys/types.h>".} = int
   Fsfilcnt* {.importc: "fsfilcnt_t", header: "<sys/types.h>".} = int
   Gid* {.importc: "gid_t", header: "<sys/types.h>".} = int
   Id* {.importc: "id_t", header: "<sys/types.h>".} = int
-  Ino* {.importc: "ino_t", header: "<sys/types.h>".} = int
+  Ino* {.importc: "ino_t", header: "<sys/types.h>".} = cuint
+    ## BUGFIX: was int; probably still somewhat incorrect
   Key* {.importc: "key_t", header: "<sys/types.h>".} = int
   Mode* {.importc: "mode_t", header: "<sys/types.h>".} = (
     when defined(android) or defined(macos) or defined(macosx) or
@@ -155,7 +158,10 @@ type
       uint32
   )
   Nlink* {.importc: "nlink_t", header: "<sys/types.h>".} = int
-  Off* {.importc: "off_t", header: "<sys/types.h>".} = int64
+  Off* {.importc: "off_t", header: "<sys/types.h>".} = cint
+    # WAS: int64 but this broke on CI in 32bit; a but underspecified, see
+    # https://stackoverflow.com/questions/9073667/where-to-find-the-complete-definition-of-off-t-type
+    # and https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.1.0/com.ibm.zos.v2r1.cbcpx01/datatypesize64.htm
   Pid* {.importc: "pid_t", header: "<sys/types.h>".} = int32
   Pthread_attr* {.importc: "pthread_attr_t", header: "<sys/types.h>".} = int
   Pthread_barrier* {.importc: "pthread_barrier_t",

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -507,10 +507,12 @@ const
     # should not be translated.
 
 when defined(posix) and not defined(nimscript):
+  type
+    Mode {.importc: "mode_t", header: "<sys/types.h>".} = cushort
+      # BUGFIX: was cint
+
   when defined(linux) and defined(amd64):
     type
-      Mode {.importc: "mode_t", header: "<sys/types.h>".} = cint
-
       # fillers ensure correct size & offsets
       Stat {.importc: "struct stat",
               header: "<sys/stat.h>", final, pure.} = object ## struct stat
@@ -524,8 +526,6 @@ when defined(posix) and not defined(nimscript):
 
   else:
     type
-      Mode {.importc: "mode_t", header: "<sys/types.h>".} = cint
-
       Stat {.importc: "struct stat",
                header: "<sys/stat.h>", final, pure.} = object ## struct stat
         st_mode: Mode        ## Mode of file


### PR DESCRIPTION
[DO NOT REVIEW but discussion welcome]
https://github.com/nim-lang/Nim/pull/13926 needs to be merged first

## TODO
* requires fixing https://github.com/nim-lang/Nim/issues/13927
* requires fixing https://github.com/nim-lang/Nim/issues/13945
* make sure CI passes (right now linux 32bit still has issues)
* figure out what's the best way to deal with backward compatibility for the changes involved (maybe simply `.since`, not sure yet)
* some types are clearly wrong and should simply be fixed
* other types are platform specific edge cases and maybe there's a solution based on an analog of `incompleteStruct` but for primitive types, eg: `.unknownSize`:
```nim
Ino* {.importc: "ino_t", header: "<sys/types.h>", unknownSize.} = cuint
```
which would cause CT sizeof+friends to fail for these
* similar to proposal 5 (https://github.com/nim-lang/RFCs/issues/205) we could get the "real" sizeof from calling backend compiler on header files; this should work really well, but need to figure out what happens for cross compilation.

## relevant comments to address from https://github.com/nim-lang/Nim/pull/13926
* https://github.com/nim-lang/Nim/pull/13926#discussion_r405688851
* https://github.com/nim-lang/Nim/pull/13926#pullrequestreview-390233410


## distinct not handled by -d:checkAbi
```nim
type
  Time* {.importc: "time_t", header: "<time.h>".} = distinct bool
```
