### PR TITLE
Add macros |=> and |-> to create procedures and procedure types with noSideEffect pragma…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ## Standard library additions and changes
 
+- Add `|=>` and `|->` macro operators to the sugar module which behave like `=>` and `->` respectively, but guarding against side effects.
 
 ## Language changes
 
@@ -14,4 +15,3 @@
 - The `define` and `undef` pragmas have been de-deprecated.
 
 ## Tool changes
-


### PR DESCRIPTION
Resolves #13947

Reposting the small feature request:

### Summary

The `->` and `=>` macros can only be used to create procedures with possible side effects. This proposal adds the corresponding `|->` and `|=>` macros that perform a similar task, but add the `{.noSideEffect.}` pragma to enable easier functional programming capabilities.


### Description

While Nim is not a functional language, it borrows functional concepts, such as the `func` which is a `proc` that doesn't allow mutation of any global state (at least that isn't referenced in the function's parameters with a `var` or `ref`). It also supports first class functions, passing in functions as arguments and creating anonymous/lambda functions.

Using first class functions is made easier thanks to the sugar library, with the `->` and `=>` macros. However, these macros will describe a procedure that can have side effects. If you want to bridge first class functions with `func`, you cannot use the macros. Adding the `|->` and `|=>` macros bridges the functional language concepts and makes it convenient and easy to write safer and functional code.


### Alternatives

Technically no new features are introduced in this request. It is still possible to do things the verbose way, but just like `func` is convenient sugar for the `{.noSideEffect.}` pragma, so is this simply convenient sugar.


### Additional Information

For the syntax, I chose to prepend `|` to the two existing operators to create the new operators, as a sort of pun. In many functional contexts, the `|` symbol is called a "guard", so I thought that `|=>` and `|->` are like `=>` and `->` but they guard against side effects. 

As an example, say I'm working on a library that can have the user to provide a custom distance metric, for pathfinding or nearest neighbor search, etc. The distance metric should be a function that simply returns a distance, and should not have any side effects. To enforce that, I can simply write `type DistMetric = (Point, Point) |-> float`