### PR TITLE
added extended msg for failed library loads w/ incorrect DLL formats

### DIFF
--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -34,16 +34,17 @@ proc nimLoadLibraryError(path: string) =
       # message box instead:
       var
         msg: array[1000, char]
-        charsLeft = msg.len
-      copyMem(msg[msg.len - charsLeft].addr, prefix.cstring, prefix.len)
-      charsLeft -= prefix.len
-      let pathLen = min(path.len + 1, charsLeft)
-      copyMem(msg[msg.len - charsLeft].addr, path.cstring, pathLen)
-      charsLeft -= pathLen
-      if loadError == ERROR_BAD_EXE_FORMAT and charsLeft >= badExe.len + 1:
-        if msg[msg.len - charsLeft - 1] == '\0':
-          msg[msg.len - charsLeft - 1] = ' '
-        copyMem(msg[msg.len - charsLeft].addr, badExe.cstring, badExe.len + 1)
+        msgLeft = msg.len - 1 # leave (at least) one for nullchar
+        msgIdx = 0
+      copyMem(msg[msgIdx].addr, prefix.cstring, prefix.len)
+      msgLeft -= prefix.len
+      msgIdx += prefix.len
+      let pathLen = min(path.len, msgLeft)
+      copyMem(msg[msgIdx].addr, path.cstring, pathLen)
+      msgLeft -= pathLen
+      msgIdx += pathLen
+      if loadError == ERROR_BAD_EXE_FORMAT and msgLeft >= badExe.len:
+        copyMem(msg[msgIdx].addr, badExe.cstring, badExe.len)
       discard MessageBoxA(nil, msg[0].addr, nil, 0)
   cstderr.rawWrite("\n")
   quit(1)

--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -41,7 +41,8 @@ proc nimLoadLibraryError(path: string) =
       copyMem(msg[msg.len - charsLeft].addr, path.cstring, pathLen)
       charsLeft -= pathLen
       if loadError == ERROR_BAD_EXE_FORMAT and charsLeft >= badExe.len + 1:
-        msg[msg.len - charsLeft - 1] = ' '
+        if msg[msg.len - charsLeft - 1] == '\0':
+          msg[msg.len - charsLeft - 1] = ' '
         copyMem(msg[msg.len - charsLeft].addr, badExe.cstring, badExe.len + 1)
       discard MessageBoxA(nil, msg[0].addr, nil, 0)
   cstderr.rawWrite("\n")

--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -24,7 +24,7 @@ proc nimLoadLibraryError(path: string) =
   cstderr.rawWrite(path)
   when not defined(nimDebugDlOpen) and not defined(windows):
     cstderr.rawWrite("\n(compile with -d:nimDebugDlOpen for more information)")
-  when defined(windows)
+  when defined(windows):
     const badExe = "\n(bad format; library may be wrong architecture)"
     let loadError = GetLastError()
     if loadError == ERROR_BAD_EXE_FORMAT:

--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -40,8 +40,9 @@ proc nimLoadLibraryError(path: string) =
       let pathLen = min(path.len + 1, charsLeft)
       copyMem(msg[msg.len - charsLeft].addr, path.cstring, pathLen)
       charsLeft -= pathLen
-      if loadError == ERROR_BAD_EXE_FORMAT and charsLeft >= badExe.len:
-        copyMem(msg[msg.len - charsLeft].addr, badExe.cstring, badExe.len)
+      if loadError == ERROR_BAD_EXE_FORMAT and charsLeft >= badExe.len + 1:
+        msg[msg.len - charsLeft - 1] = ' '
+        copyMem(msg[msg.len - charsLeft].addr, badExe.cstring, badExe.len + 1)
       discard MessageBoxA(nil, msg[0].addr, nil, 0)
   cstderr.rawWrite("\n")
   quit(1)

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -21,8 +21,12 @@ when not defined(windows) or not defined(guiapp):
   proc writeToStdErr(msg: cstring) = rawWrite(cstderr, msg)
 
 else:
+  const ERROR_BAD_EXE_FORMAT = 193
+
   proc MessageBoxA(hWnd: pointer, lpText, lpCaption: cstring, uType: int): int32 {.
     header: "<windows.h>", nodecl.}
+
+  proc GetLastError(): int32 {.header: "<windows.h>", nodecl.}
 
   proc writeToStdErr(msg: cstring) =
     discard MessageBoxA(nil, msg, nil, 0)

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -17,17 +17,15 @@ var
     ## instead of `stdmsg.write` when printing stacktrace.
     ## Unstable API.
 
-when not defined(windows) or not defined(guiapp):
-  proc writeToStdErr(msg: cstring) = rawWrite(cstderr, msg)
-
-else:
+when defined(windows):
+  proc GetLastError(): int32 {.header: "<windows.h>", nodecl.}
   const ERROR_BAD_EXE_FORMAT = 193
 
+when not defined(windows) or not defined(guiapp):
+  proc writeToStdErr(msg: cstring) = rawWrite(cstderr, msg)
+else:
   proc MessageBoxA(hWnd: pointer, lpText, lpCaption: cstring, uType: int): int32 {.
     header: "<windows.h>", nodecl.}
-
-  proc GetLastError(): int32 {.header: "<windows.h>", nodecl.}
-
   proc writeToStdErr(msg: cstring) =
     discard MessageBoxA(nil, msg, nil, 0)
 

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -700,6 +700,7 @@ const
   ERROR_LOCK_VIOLATION* = 33
   ERROR_HANDLE_EOF* = 38
   ERROR_BAD_ARGUMENTS* = 165
+  ERROR_BAD_EXE_FORMAT* = 193
 
 proc duplicateHandle*(hSourceProcessHandle: Handle, hSourceHandle: Handle,
                       hTargetProcessHandle: Handle,

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -700,7 +700,6 @@ const
   ERROR_LOCK_VIOLATION* = 33
   ERROR_HANDLE_EOF* = 38
   ERROR_BAD_ARGUMENTS* = 165
-  ERROR_BAD_EXE_FORMAT* = 193
 
 proc duplicateHandle*(hSourceProcessHandle: Handle, hSourceHandle: Handle,
                       hTargetProcessHandle: Handle,


### PR DESCRIPTION
Common issue that I've seen in the Nim IRC is the `could not load:` error with DLLs with the wrong architecture, hopefully this pushes people in the right direction.