### PR TITLE
`emit("here"): "c code"` + other emit fixes; new module experimental/backendutils.nim

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1446,6 +1446,31 @@ proc genAsmOrEmitStmt(p: BProc, t: PNode, isAsmStmt=false): Rope =
     res.add("\L")
     result = res.rope
 
+type SectionKind = enum kUnknown, kFile, kProc
+
+proc determineSection(p: BProc, n: PNode): tuple[kind: SectionKind, filesec: TCFileSection, procsec: TCProcSection] =
+  template bail() =
+    localError(p.config, n.info, "invalid emit section")
+    return
+  template retFile(sec) = result = (kFile, sec, TCProcSection.default)
+  if n.len == 3:
+    let n1 = n[1]
+    if n1.kind != nkIdent: bail()
+    case n1.ident.s.normalize
+    of "typeSection": retFile cfsTypes
+    of "varSection": retFile cfsVars
+    of "includeSection": retFile cfsHeaders
+    of "here": result = (kProc, TCFileSection.default, cpsStmts)
+    else: bail()
+  else: # legacy syntax; no need to add new section values here
+    if n.len >= 1 and n[0].kind in {nkStrLit..nkTripleStrLit}:
+      let sec = n[0].strVal
+      if sec.startsWith("/*TYPESECTION*/"): retFile cfsTypes
+      elif sec.startsWith("/*VARSECTION*/"): retFile cfsVars
+      elif sec.startsWith("/*INCLUDESECTION*/"): retFile cfsHeaders
+    if result.kind == kUnknown:
+      result = (kUnknown, cfsProcHeaders, cpsStmts)
+
 proc genAsmStmt(p: BProc, t: PNode) =
   assert(t.kind == nkAsmStmt)
   genLineDir(p, t)
@@ -1459,24 +1484,24 @@ proc genAsmStmt(p: BProc, t: PNode) =
   else:
     p.s(cpsStmts).add indentLine(p, runtimeFormat(CC[p.config.cCompiler].asmStmtFrmt, [s]))
 
-proc determineSection(n: PNode): TCFileSection =
-  result = cfsProcHeaders
-  if n.len >= 1 and n[0].kind in {nkStrLit..nkTripleStrLit}:
-    let sec = n[0].strVal
-    if sec.startsWith("/*TYPESECTION*/"): result = cfsTypes
-    elif sec.startsWith("/*VARSECTION*/"): result = cfsVars
-    elif sec.startsWith("/*INCLUDESECTION*/"): result = cfsHeaders
+proc isModuleLevel(p: BProc): bool =
+  p.prc == nil and p.breakIdx == 0
 
 proc genEmit(p: BProc, t: PNode) =
-  var s = genAsmOrEmitStmt(p, t[1])
-  if p.prc == nil:
-    # top level emit pragma?
-    let section = determineSection(t[1])
+  var s = genAsmOrEmitStmt(p, t[^1])
+  let (status, fileSection, procSection) = determineSection(p, t)
+  template emitProcSection(section) =
+    genLineDir(p, t)
+    line(p, section, s)
+  template emitFileSection(section) =
     genCLineDir(p.module.s[section], t.info, p.config)
     p.module.s[section].add(s)
-  else:
-    genLineDir(p, t)
-    line(p, cpsStmts, s)
+
+  case status
+  of kFile: emitFileSection(fileSection)
+  of kProc: emitProcSection(procSection)
+  elif p.isModuleLevel: emitFileSection(fileSection)
+  else: emitProcSection(procSection) # could be inside a top level `block:`
 
 proc genPragma(p: BProc, n: PNode) =
   for it in n.sons:

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1457,8 +1457,11 @@ proc determineSection(p: BProc, n: PNode): tuple[kind: SectionKind, filesec: TCF
   template retFile(sec) = result = (kFile, sec, TCProcSection.default)
   if n.len == 3:
     let n1 = n[1]
-    if n1.kind != nkIdent: bail("expected: nkIdent, got $1".format n1.kind)
-    case n1.ident.s.normalize
+    if n1.kind != nkStrLit: bail("expected: 'nkStrLit', got '$1'".format n1.kind)
+    # using nkStrLit instead of nkIdent as it'll allow to pass a constant
+    # string argument to emit without ambiguity, eg:
+    # const section = "here"; emit(section): "/**/"
+    case n1.strVal.normalize
     of "typeSection".normalize: retFile cfsTypes
     of "varSection".normalize: retFile cfsVars
     of "includeSection".normalize: retFile cfsHeaders

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1467,14 +1467,15 @@ proc determineSection(p: BProc, n: PNode): tuple[kind: SectionKind, filesec: TCF
     of "includeSection".normalize: retFile cfsHeaders
     of "here".normalize: result = (kProc, TCFileSection.default, cpsStmts)
     else: bail("expected: `typeSection, varSection, includeSection, here`, got: $1".format n1.ident.s)
-  else: # legacy syntax; no need to add new section values here
+  elif n.len == 2: # legacy syntax; no need to add new section values here
+    let n = n[1]
     if n.len >= 1 and n[0].kind in {nkStrLit..nkTripleStrLit}:
       let sec = n[0].strVal
       if sec.startsWith("/*TYPESECTION*/"): retFile cfsTypes
       elif sec.startsWith("/*VARSECTION*/"): retFile cfsVars
       elif sec.startsWith("/*INCLUDESECTION*/"): retFile cfsHeaders
-    if result.kind == kUnknown:
-      result = (kUnknown, cfsProcHeaders, cpsStmts)
+    if result.kind == kUnknown: result = (kUnknown, cfsProcHeaders, cpsStmts)
+  else: doAssert false, $n.len
 
 proc genAsmStmt(p: BProc, t: PNode) =
   assert(t.kind == nkAsmStmt)

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -39,7 +39,6 @@ type
     cfsDynLibInit,            # section for init of dynamic library binding
     cfsDynLibDeinit           # section for deinitialization of dynamic
                               # libraries
-
   TCTypeKind* = enum          # describes the type kind of a C type
     ctVoid, ctChar, ctBool,
     ctInt, ctInt8, ctInt16, ctInt32, ctInt64,

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -39,6 +39,7 @@ type
     cfsDynLibInit,            # section for init of dynamic library binding
     cfsDynLibDeinit           # section for deinitialization of dynamic
                               # libraries
+
   TCTypeKind* = enum          # describes the type kind of a C type
     ctVoid, ctChar, ctBool,
     ctInt, ctInt8, ctInt16, ctInt32, ctInt64,

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -567,21 +567,20 @@ proc semAsmOrEmit*(con: PContext, n: PNode, marker: char): PNode =
     result = newNode(nkAsmStmt, n.info)
 
 proc pragmaEmit(c: PContext, n: PNode) =
-  if n.kind notin nkPragmaCallKinds:
+  if n.kind notin nkPragmaCallKinds or (n.len != 2 and n.len != 3):
     localError(c.config, n.info, errStringLiteralExpected)
   else:
-    let last = n.len-1 # easier to spot than `^1` here
-    let n1 = n[last]
+    let n1 = n[^1]
     if n1.kind == nkBracket:
       var b = newNodeI(nkBracket, n1.info, n1.len)
       for i in 0..<n1.len:
         b[i] = c.semExpr(c, n1[i])
-      n[last] = b
+      n[^1] = b
     else:
-      n[last] = c.semConstExpr(c, n1)
-      case n[last].kind
+      n[^1] = c.semConstExpr(c, n1)
+      case n[^1].kind
       of nkStrLit, nkRStrLit, nkTripleStrLit:
-        n[last] = semAsmOrEmit(c, n, '`')
+        n[^1] = semAsmOrEmit(c, n, '`')
       else:
         localError(c.config, n.info, errStringLiteralExpected)
 

--- a/lib/experimental/backendutils.nim
+++ b/lib/experimental/backendutils.nim
@@ -1,15 +1,18 @@
 ##[
 ## experimental API!
 
-Utilities to interface with generated backend (for now C/C++, later js) code
+Utilities to interface with generated backend (for now C/C++, later js) code,
+abstracting away platform differences and taking care of needy greedy details.
 ]##
 
 import macros
 
-static: doAssert defined(c) or defined(cpp)
+static: doAssert defined(c) or defined(cpp) or defined(nimdoc)
 
 macro c_astToStr*(T: typedesc): string =
-  ## returns the backend
+  ## returns the backend analog of `astToStr`
+  runnableExamples:
+    doAssert cint.c_astToStr == "int"
   result = newStmtList()
   var done {.global.}: bool
   if not done:
@@ -23,21 +26,31 @@ macro c_astToStr*(T: typedesc): string =
     $s
 
 template c_currentSourcePath*(): string =
+  ## returns the generated backend file
   var s: cstring
   {.emit("here"): [s, "= __FILE__;"].}
   $s
 
 template c_currentFunction*(): string =
+  runnableExamples:
+    proc fun(){.exportc.} = doAssert c_currentFunction == "fun"
+    fun()
   var s: cstring
-  {.emit("here"): [s, "= __FUNCTION__;"].}
+  # cast needed for C++
+  {.emit("here"): [s, "= (char*) __FUNCTION__;"].}
   $s
 
 template c_sizeof*(T: typedesc): int =
+  runnableExamples:
+    doAssert c_sizeof(cint) == cint.sizeof
   var s: int
   {.emit("here"): [s," = sizeof(", T, ");"].}
   s
 
 template cstaticIf*(cond: string, body) =
+  runnableExamples:
+    cstaticIf "defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L":
+      {.emit("HERE"): """_Static_assert(sizeof(_Bool) == 1, "bad"); """.}
   {.emit("here"): ["""#if """, cond, "\n"].}
   body
   {.emit("here"): "#endif\n".}

--- a/lib/experimental/backendutils.nim
+++ b/lib/experimental/backendutils.nim
@@ -1,0 +1,38 @@
+##[
+## experimental API!
+
+Utilities to interface with generated backend (for now C/C++, later js) code
+]##
+
+import macros
+
+static: doAssert defined(c) or defined(cpp)
+
+macro c_astToStr*(T: typedesc): string =
+  ## returns the backend
+  result = newStmtList()
+  var done {.global.}: bool
+  if not done:
+    done = true
+    result.add quote do:
+      {.emit("typeSection"): "#define c_astToStrImpl(T) #T".}
+
+  result.add quote do:
+    var s: cstring
+    {.emit("here"): [s, " = c_astToStrImpl(", `T`, ");"].}
+    $s
+
+template c_currentSourcePath*(): string =
+  var s: cstring
+  {.emit("here"): [s, "= __FILE__;"].}
+  $s
+
+template c_currentFunction*(): string =
+  var s: cstring
+  {.emit("here"): [s, "= __FUNCTION__;"].}
+  $s
+
+template c_sizeof*(T: typedesc): int =
+  var s: int
+  {.emit("here"): [s," = sizeof(", T, ");"].}
+  s

--- a/lib/experimental/backendutils.nim
+++ b/lib/experimental/backendutils.nim
@@ -36,3 +36,8 @@ template c_sizeof*(T: typedesc): int =
   var s: int
   {.emit("here"): [s," = sizeof(", T, ");"].}
   s
+
+template cstaticIf*(cond: string, body) =
+  {.emit("here"): ["""#if """, cond, "\n"].}
+  body
+  {.emit("here"): "#endif\n".}

--- a/tests/stdlib/tbackendutils.nim
+++ b/tests/stdlib/tbackendutils.nim
@@ -104,3 +104,12 @@ typedef enum FooEnum{
   when false:
     checkSize Foo1Alias # pending https://github.com/nim-lang/Nim/issues/13945
     checkSize FooEnum # pending https://github.com/nim-lang/Nim/issues/13927
+
+block: # cstaticIf
+  var a = 1
+  cstaticIf "defined(nonexistant)":
+    a = 2
+  doAssert a == 1
+  cstaticIf "defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L":
+    a = 3
+  doAssert a == 3, "really old compiler"

--- a/tests/stdlib/tbackendutils.nim
+++ b/tests/stdlib/tbackendutils.nim
@@ -1,0 +1,106 @@
+discard """
+  joinable: false
+"""
+
+import experimental/backendutils
+import macros, strutils, os
+import unittest
+
+macro test(body: untyped): untyped =
+  result = newStmtList()
+  for T in body:
+    result.add quote do:
+      let s1 = `T`.sizeof
+      let s2 = `T`.c_sizeof
+      if s1 != s2:
+        echo "$1 $2 => sizeof: $3 vs c_sizeof: $4" % [$astToStr(`T`), c_astToStr(`T`), $s1, $s2]
+
+type FooEmpty = object
+const N = 10
+type FooEmptyArr = array[N, FooEmpty]
+type Bar = object
+  x: FooEmpty
+  y: cint
+
+type BarTup = (FooEmpty, cint)
+type BarTup2 = (().type, cint)
+
+# type MyEnum = enum k1, k2
+type MyEnum {.exportc.} = enum k1, k2
+type Obj = object
+  x1: MyEnum
+  x2: cint
+
+test:
+  FooEmpty
+  FooEmptyArr
+  Bar
+  BarTup
+  BarTup2
+  MyEnum
+  Obj
+
+block: # c_currentFunction
+  proc test1(){.exportc.} =
+    doAssert c_currentFunction == "test1"
+  proc test2() =
+    doAssert c_currentFunction.startsWith "test2_", c_currentFunction
+  test1()
+  test2()
+
+block: # c_currentFunction
+  let file = c_currentSourcePath
+  let name = currentSourcePath.splitFile.name
+  doAssert file.contains name
+
+  let code = file.readFile
+  let z = "abc123"
+  doAssert code.count(z) == 1 # string generated in code
+
+block:
+  # checks `c_astToStr` generates top-level macro `c_astToStrImp` only once
+  let code = c_currentSourcePath.readFile
+  proc compose(a, b: string): string =
+    ## avoids forming a&b at CT, which could end up in cgen'd file
+    ## and affect the count
+    result = a & b
+  doAssert code.count(compose("#define ", "c_astToStrImp")) == 1
+
+block: # c_astToStr
+  doAssert c_astToStr(cint) == "int"
+  type Foo = object
+  doAssert c_astToStr(Foo).startsWith "tyObject_Foo_"
+
+block: # c_sizeof
+  doAssert char.c_sizeof == 1
+  {.emit("here"):"""
+typedef struct Foo1{
+} Foo1;
+typedef enum FooEnum{
+  k1, k2
+} FooEnum;
+""".}
+
+  # type Foo1 {.importc, completeStruct.} = object # pending https://github.com/nim-lang/Nim/pull/13926
+  type Foo1 {.importc.} = object
+  type Foo1Alias = object
+
+  type FooEnum {.importc.} = enum k1, k2
+  when defined(cpp):
+    doAssert Foo1.c_sizeof == 1
+  else:
+    doAssert Foo1.c_sizeof == 0
+
+  template checkSize(T) =
+    let s1 = T.c_sizeof
+    let s2 = T.sizeof
+    # check s1 == s2, $($T, c_astToStr(T), s1, s2) # pending https://github.com/nim-lang/Nim/pull/10558
+    if s1 != s2:
+      echo "sizeof mismatch " & $($T, c_astToStr(T), s1, s2)
+    check s1 == s2
+  checkSize cint
+  checkSize int
+  checkSize Foo1
+  when false:
+    checkSize Foo1Alias # pending https://github.com/nim-lang/Nim/issues/13945
+    checkSize FooEnum # pending https://github.com/nim-lang/Nim/issues/13927


### PR DESCRIPTION
fixes A3,A4,A5 from https://github.com/nim-lang/Nim/issues/13943, adds a sane `emit` syntax, and new experimental module `experimental/backendutils.nim`

## P1
new emit syntax: `emit("typeSection"): "some C code"`

this replaces the very hacky `emit: "/TYPESECTION*/some C code"` which continues to work but is now discouraged and will eventually be deprecated (with a warning). As mentioned by @krux02 https://github.com/nim-lang/Nim/issues/13943#issuecomment-612148639

> Unrelated to that, I would really like to have an emit prgama that has an enum argument to control the location. You know the usual problems with these magic comments. No error or warning when you mistype them. No error if the version of the compiler you are using doesn't support that value. No self explanatory API.

The new API is safe and will give CT error if section is invalid.
(also avoids silent errors like https://github.com/nim-lang/Nim/issues/15244#issuecomment-683587073 where a missing space caused obscure error)

## P2
new emit section: `emit("here"): "some C code emitted here"`

Since nim code can appear anywhere including at module scope, it makes sense to allow emitting "right here" instead of at some file section.

As an example use case, this enables writing a correct `c_sizeof`, ie, fixing Example 3 from https://github.com/nim-lang/Nim/issues/13943, so that it works regardless of where it's called from (top-level, block-level or proc-level)
See tests for more examples.

## P3
emit at block scope now uses section=here instead of being treated as module scope.
This fixes example 2 from https://github.com/nim-lang/Nim/issues/13943

## P4
new experimental module `experimental/backendutils.nim`
This experimental module enables introspecting the generated file (eg C,C++), for tests, debugging, and user code.

## P5
see tests `tests/stdlib/tbackendutils.nim` which has tests for everything

## P6
new syntax for pragmas:
`{.foo(args): baz.}` is now allowed, and rewritten as: `{.foo(args, baz).}` (where args represents 1 or more arguments).
This enables the 
```
{.emit("typeSection"): """
some code
""".}` 
```
but is generally useful and matches the way the rest of nim syntax works

## after PR
* update docs regarding emit, add c_offsetof, c_alignof and refactor with tsizeof.nim