### PR TITLE
enable important_pkg on OSX

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,10 @@ jobs:
         vmImage: 'ubuntu-16.04'
         CPU: amd64
         NIM_TEST_PACKAGES: true
+      OSX_amd64_pkg:
+        vmImage: 'macOS-10.15'
+        CPU: amd64
+        NIM_TEST_PACKAGES: true
 
   pool:
     vmImage: $(vmImage)

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -17,7 +17,8 @@ pkg "c2nim", false, "nim c testsuite/tester.nim"
 pkg "cascade"
 pkg "chroma"
 pkg "chronicles", true, "nim c -o:chr -r chronicles.nim"
-pkg "chronos", true
+when not defined(osx): # testdatagram.nim(560, 54): Check failed
+  pkg "chronos", true
 pkg "cligen", false, "nim c -o:cligenn -r cligen.nim"
 pkg "coco", true
 pkg "combparser"
@@ -46,7 +47,8 @@ pkg "nake", false, "nim c nakefile.nim"
 pkg "neo", true, "nim c -d:blas=openblas tests/all.nim"
 # pkg "nico", true
 pkg "nicy", false, "nim c src/nicy.nim"
-pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
+when not defined(osx): # could not load: libgtk-3.0.dylib
+  pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
 pkg "nimcrypto", false, "nim c -r tests/testall.nim"
 pkg "NimData", true, "nim c -o:nimdataa src/nimdata.nim"
 pkg "nimes", true, "nim c src/nimes.nim"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -1,3 +1,4 @@
+import os
 
 template pkg(name: string; hasDeps = false; cmd = "nimble test"; url = ""): untyped =
   packages.add((name, cmd, hasDeps, url))
@@ -47,8 +48,12 @@ pkg "nake", false, "nim c nakefile.nim"
 pkg "neo", true, "nim c -d:blas=openblas tests/all.nim"
 # pkg "nico", true
 pkg "nicy", false, "nim c src/nicy.nim"
-when not defined(osx): # could not load: libgtk-3.0.dylib
-  pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
+
+when defined(osx): # could not load: libgtk-3.0.dylib
+  # do this more generally by installing non-nim dependencies automatically
+  doAssert execShellCmd("brew install gtk+3") == 0
+pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
+
 pkg "nimcrypto", false, "nim c -r tests/testall.nim"
 pkg "NimData", true, "nim c -o:nimdataa src/nimdata.nim"
 pkg "nimes", true, "nim c src/nimes.nim"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -49,8 +49,9 @@ pkg "neo", true, "nim c -d:blas=openblas tests/all.nim"
 # pkg "nico", true
 pkg "nicy", false, "nim c src/nicy.nim"
 
-when defined(osx): # could not load: libgtk-3.0.dylib
+when defined(osx):
   # do this more generally by installing non-nim dependencies automatically
+  # as specified in nimble file
   doAssert execShellCmd("brew install gtk+3") == 0
 pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
 


### PR DESCRIPTION
* same as https://github.com/nim-lang/Nim/pull/13348 but only for OSX
* as https://github.com/nim-lang/Nim/pull/13921 noticed, windows was slow but CI here shows this isnt' case for OSX so won't be a bottleneck (except for taking up 1 CI spot):
```
nim-lang.Nim (packages Linux_amd64_pkg) Successful in 26m — packages Linux_amd64_pkg succeeded
nim-lang.Nim (packages OSX_amd64_pkg) Successful in 20m — packages OSX_amd64_pkg succeeded
```

## future PR
re-enable also windows in a way that doesn't slow down CI on average eg; multiple ways, eg:
* using a probabilistic test (`if rand() > 0.1: skip`)
* using pipeline schedules (see https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml)
```
- cron: "0 0 * * *"
  displayName: Daily midnight build
```
* always run for push, but not for pull_request
* run if commit msg contains `[nim_ci_all]` (using exact same logic as done in https://github.com/nim-lang/Nim/pull/13556)