### PR TITLE
Treat zig like clang/gcc wrt integer arithmetic.

### DIFF
--- a/lib/system/integerops.nim
+++ b/lib/system/integerops.nim
@@ -19,7 +19,7 @@ proc raiseDivByZero {.compilerproc, noinline.} =
 
 {.pragma: nimbaseH, importc, nodecl, noSideEffect, compilerproc.}
 
-when (defined(gcc) or defined(clang)) and not defined(nimEmulateOverflowChecks):
+when (defined(gcc) or defined(clang) or defined(zig)) and not defined(nimEmulateOverflowChecks):
   # take the #define from nimbase.h
 
   proc nimAddInt(a, b: int, res: ptr int): bool {.nimbaseH.}


### PR DESCRIPTION
Compiling Nim using `zig cc` is currently broken on nightly because gcc/clang implementation of integer arithmetic ops are not used (see https://github.com/nim-lang/Nim/pull/13757). Since `zig cc` should behave identically to clang, this PR fixes the issue by asking for the same integer code.