### PR TITLE
Improve #12920 fix

### DIFF
--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -44,7 +44,7 @@ Options:
   --color[:always]    force color even if output is redirected
   --colorTheme:THEME  select color THEME from 'simple' (default),
                       'bnw' (black and white) ,'ack', or 'gnu' (GNU grep)
-  --afterContext:N,   
+  --afterContext:N,
                -a:N   print N lines of trailing context after every match
   --beforeContext:N,
                -b:N   print N lines of leading context before every match
@@ -412,6 +412,8 @@ proc processFile(pattern; filename: string; counter: var int, errors: var int) =
       else:
         printContextBetween(si, prevMi, curMi)
       printMatch(si.fileName, curMi)
+      if t.last == buffer.len - 1:
+        stdout.write("\n")
       stdout.flushFile()
     else:
       let r = replace(curMi.match, pattern, replacement % matches)
@@ -659,8 +661,6 @@ else:
       walker(rep, f, counter, errors)
   if errors != 0:
     printError $errors & " errors"
-  if counter == 1:
-    stdout.write("\n")
   stdout.write($counter & " matches\n")
   if errors != 0:
     quit(1)


### PR DESCRIPTION
After https://github.com/nim-lang/Nim/pull/12779, nimgrep skipped newline after printing last match of each filename if  `--filenames`. Original fix in #12920 was in the wrong spot and only addressed issue if a single match. This is a better solution since it covers any number of matches.

This needs to be backported to 1.2.0, is working correctly in 1.0.6 since #12779 wasn't ported there.

Before:
```
PS C:\Users\IEUser\Desktop\DL\programming\nimbass> nimgrep --filenames --recursive --oneline ".*[\\/](lib)?bass_fx[_-]?(static)?[0-9.\-]*\.dll$" C:\Users\IEUser\nimcache\nimterop\nimbassfx
C:\Users\IEUser\nimcache\nimterop\nimbassfx\bass_fx.dll:1: C:\Users\IEUser\nimcache\nimterop\nimbassfx\bass_fx.dllC:\Users\IEUser\nimcache\nimterop\nimbassfx\x64\bass_fx.dll:1: C:\Users\IEUser\nimcache\nimterop\nimbassfx\x64\bass_fx.dll2 matches
```

After:
```
> nimgrep --filenames --recursive --oneline ".*[\\/](lib)?bass_fx[_-]?(static)?[0-9.\-]*\.dll$" C:\Users\IEUser\nimcache\nimterop\nimbassfx
C:\Users\IEUser\nimcache\nimterop\nimbassfx\bass_fx.dll:1: C:\Users\IEUser\nimcache\nimterop\nimbassfx\bass_fx.dll
C:\Users\IEUser\nimcache\nimterop\nimbassfx\x64\bass_fx.dll:1: C:\Users\IEUser\nimcache\nimterop\nimbassfx\x64\bass_fx.dll
2 matches
```