### PR TITLE
Fix semfold handling of {.str/int/bool-define.}

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -549,9 +549,13 @@ proc getConstExpr(m: PSym, n: PNode; g: ModuleGraph): PNode =
             localError(g.config, s.info,
               "{.intdefine.} const was set to an invalid integer: '" &
                 g.config.symbols[s.name.s] & "'")
+        else:
+          result = copyTree(s.ast)
       of mStrDefine:
         if isDefined(g.config, s.name.s):
           result = newStrNodeT(g.config.symbols[s.name.s], n, g)
+        else:
+          result = copyTree(s.ast)
       of mBoolDefine:
         if isDefined(g.config, s.name.s):
           try:
@@ -560,6 +564,8 @@ proc getConstExpr(m: PSym, n: PNode; g: ModuleGraph): PNode =
             localError(g.config, s.info,
               "{.booldefine.} const was set to an invalid bool: '" &
                 g.config.symbols[s.name.s] & "'")
+        else:
+          result = copyTree(s.ast)
       else:
         result = copyTree(s.ast)
     of skProc, skFunc, skMethod:

--- a/tests/misc/tdefine.nim
+++ b/tests/misc/tdefine.nim
@@ -16,3 +16,15 @@ doAssert booldef
 doAssert not booldef2
 doAssert intdef == 2
 doAssert strdef == "foobar"
+
+# Intentionally not defined from command line
+const booldef3 {.booldefine.} = true
+const intdef2 {.intdefine.} = 1
+const strdef2 {.strdefine.} = "abc"
+type T = object
+    when booldef3:
+        field1: int
+    when intdef2 == 1:
+        field2: int
+    when strdef2 == "abc":
+        field3: int


### PR DESCRIPTION
Consts with a `{.str/int/bool-define.}` pragma where only folded when there where a matching `--define`, but they can always be folded since they must be assigned a value in the code as well.

Fixes #12880
Fixes #10980