### PR TITLE
fix newDomParser

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1309,7 +1309,7 @@ proc offsetTop*(e: Node): int {.importcpp: "#.offsetTop", nodecl.}
 proc offsetLeft*(e: Node): int {.importcpp: "#.offsetLeft", nodecl.}
 
 since (1, 3):
-  func newDomParser*(): DOMParser {.importcpp: "(new DOMParser()​​)".}
+  func newDomParser*(): DOMParser {.importcpp: "new DOMParser()".}
     ## DOM Parser constructor.
 
   func parseFromString*(this: DOMParser; str: cstring; mimeType: cstring): Document {.importcpp.}


### PR DESCRIPTION
/cc @juancarlospaco my comment from https://github.com/nim-lang/Nim/pull/13920#discussion_r406222549 was not addressed

> this doesn't work, you must've pasted from a webpage and introduced an invisible symbol (see cat -e). you should make sure examples work
> also, you should remove outer parens

before PR, newDomParser will not work, giving `Uncaught SyntaxError: Unexpected identifier` in a browser
this won't show up in github UI, you can only see the difference locally using `cat -e`

CI failure unrelated and would be fixed by https://github.com/nim-lang/Nim/pull/13984
