### PR TITLE
Copy info to sym for copyLineInfo

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1769,6 +1769,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcNSetLineInfo:
       decodeB(rkNode)
       regs[ra].node.info = regs[rb].node.info
+      if regs[ra].node.kind == nkSym:
+        regs[ra].node.sym.info = regs[rb].node.info
     of opcEqIdent:
       decodeBC(rkInt)
       # aliases for shorter and easier to understand code below


### PR DESCRIPTION
Otherwise i can't change an iterator's lineinfo with `copyLineInfo` : as it seems cgen takes the sym lineinfo.

The other option is to provide a copyLineInfoToSym