### PR TITLE
make fuzzy search a bit less fuzzy

### DIFF
--- a/tools/dochack/dochack.nim
+++ b/tools/dochack/dochack.nim
@@ -303,7 +303,7 @@ proc dosearch(value: cstring): Element =
       matches.add((db[i], score))
 
   matches.sort(proc(a, b: auto): int = b[1] - a[1])
-  for i in 0 ..< min(matches.len, 19):
+  for i in 0 ..< min(matches.len, 29):
     matches[i][0].innerHTML = matches[i][0].getAttribute("data-doc-search-tag")
     ul.add(tree("LI", cast[Element](matches[i][0])))
   if ul.len == 0:

--- a/tools/dochack/fuzzysearch.nim
+++ b/tools/dochack/fuzzysearch.nim
@@ -132,6 +132,9 @@ proc fuzzyMatch*(pattern, str: cstring) : tuple[score: int, matched: bool] =
 
     strIndex += 1
 
+  if patIndex == pattern.len and (strIndex == str.len or str[strIndex] notin Letters):
+    score += 10
+
   result = (
     score:   max(0, score),
     matched: (score > 0),


### PR DESCRIPTION
Two changes here:

* `dochack.nim` - increase the number of shown matches. Self explanatory. There are some good results we didn't show earlier.
* `fuzzysearch.nim` - give a higher score to the results which match the whole word. (Why `+10` and not some other number? Trial and error until I found what works satisfactory). The improved behaviour can easily be seen for short queries such as: `add`, `not`, `of`, `abs`, `sin`, `cos`, `del`, `new` (those are the ones I have tried).

Current results:
![Imgur](https://imgur.com/2tgPPxH.jpg)

After this PR:
![Imgur](https://imgur.com/OBhZsIi.jpg)

