### PR TITLE
fix https://github.com/nim-lang/RFCs/issues/211: `var a: DateTime` compiles and is usable

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -298,7 +298,7 @@ when defined(nimHasStyleChecks):
 
 type
   MonthdayRange* = range[0..31]
-    ## 0 represents an invalid month
+    ## 0 represents an invalid day of the month
   HourRange* = range[0..23]
   MinuteRange* = range[0..59]
   SecondRange* = range[0..60]

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -260,6 +260,7 @@ type
   Month* = enum ## Represents a month. Note that the enum starts at ``1``,
                 ## so ``ord(month)`` will give the month number in the
                 ## range ``1..12``.
+    # mInvalid = (0, "Invalid") # intentionally left out so `items` works
     mJan = (1, "January")
     mFeb = "February"
     mMar = "March"
@@ -296,7 +297,8 @@ when defined(nimHasStyleChecks):
   {.pop.}
 
 type
-  MonthdayRange* = range[1..31]
+  MonthdayRange* = range[0..31]
+    ## 0 represents an invalid month
   HourRange* = range[0..23]
   MinuteRange* = range[0..59]
   SecondRange* = range[0..60]

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -672,7 +672,7 @@ proc getDaysInYear*(year: int): int =
 
 proc assertValidDate(monthday: MonthdayRange, month: Month, year: int)
     {.inline.} =
-  assert monthday <= getDaysInMonth(month, year),
+  assert monthday > 0 and monthday <= getDaysInMonth(month, year),
     $year & "-" & intToStr(ord(month), 2) & "-" & $monthday &
       " is not a valid date"
 
@@ -1578,9 +1578,14 @@ proc `<=`*(a, b: DateTime): bool =
   ## Returns true if ``a`` happened before or at the same time as ``b``.
   return a.toTime <= b.toTime
 
+proc isDefault[T](a: T): bool =
+  system.`==`(a, default(T))
+
 proc `==`*(a, b: DateTime): bool =
   ## Returns true if ``a`` and ``b`` represent the same point in time.
-  return a.toTime == b.toTime
+  if a.isDefault: b.isDefault
+  elif b.isDefault: false
+  else: a.toTime == b.toTime
 
 proc isStaticInterval(interval: TimeInterval): bool =
   interval.years == 0 and interval.months == 0 and

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -614,6 +614,16 @@ suite "ttimes":
       doAssert x + between(x, y) == y
       doAssert between(x, y) == 1.months + 1.weeks
 
+  test "default DateTime": # https://github.com/nim-lang/RFCs/issues/211
+    var a: DateTime
+    doAssert a == DateTime.default
+    doAssert ($a).len > 0 # no crash
+    doAssert a.month.Month.ord == 0
+    doAssert a.month.Month == cast[Month](0)
+    var num = 0
+    for ai in Month: num.inc
+    doAssert num == 12
+
   test "inX procs":
     doAssert initDuration(seconds = 1).inSeconds == 1
     doAssert initDuration(seconds = -1).inSeconds == -1

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -615,14 +615,19 @@ suite "ttimes":
       doAssert between(x, y) == 1.months + 1.weeks
 
   test "default DateTime": # https://github.com/nim-lang/RFCs/issues/211
+    var num = 0
+    for ai in Month: num.inc
+    doAssert num == 12
+
     var a: DateTime
     doAssert a == DateTime.default
     doAssert ($a).len > 0 # no crash
     doAssert a.month.Month.ord == 0
     doAssert a.month.Month == cast[Month](0)
-    var num = 0
-    for ai in Month: num.inc
-    doAssert num == 12
+    doAssert a.monthday == 0
+
+    doAssertRaises(AssertionError): discard getDayOfWeek(a.monthday, a.month, a.year)
+    doAssertRaises(AssertionError): discard a.toTime
 
   test "inX procs":
     doAssert initDuration(seconds = 1).inSeconds == 1


### PR DESCRIPTION
* fix https://github.com/nim-lang/RFCs/issues/211

`var a: DateTime` now compiles and is usable, eg for delayed initialization (think serialization etc)

This is the simplest approach IMO until we finally implement https://github.com/nim-lang/Nim/pull/12378 to avoid having a broken type system, see my note https://github.com/nim-lang/RFCs/issues/126#issuecomment-615014367), taking into account backward compatibility and other factors.
`var a: DateTime` now simply works, and produces a DateTime with a "sentinel" value 0 for monthday and month. `assertValidDate` will check for it so that `toTime` will fail if uninitialized

## notes
* I intentionally did not add a `proc isValid(a: DateTime): bool` because there are many ways a DateTime can be invalid, and it'd be expensive to compute if all user cares about is whether `a` was initialized.

* I intentionally did not add `isInitialized`, because we should instead use either `a != default(DateTime)` or `a.notDefault` using a new proc `notDefault` in some other module (see https://github.com/nim-lang/Nim/pull/13526 for details)

* when https://github.com/nim-lang/Nim/pull/12378 is implemented, we'll simply change this back to `MonthdayRange* = range[1..31]` and `MonthdayRange.default` would become 1 instead of 0

## alternatives considered
**There is little benefit in preventing those sentinel value at CT** because there are other ways to produce invalid DateTime objects anyways (eg: think leap years, or April 31), but I still did consider those:

All these (especially A1, and except, to some extent, A4) are **breaking changes of the worst kind**, where things sometimes produce same results, sometimes don't, depending on how it's used (eg `monthday <= 15`):
* A1 changing to `MonthdayRange* = range[0..30]`

* A2 introducing a `type MonthdayRange* = range[0.Monthday..30.Monthday]` + `type Monthday = distinct int`  + `proc to1Based*(a: Monthday): int = a.ord + 1`
still a breaking change, eg for code like `myDate.month.int`, or for serialization/deserialization routines
plus lots of work

* A3 introducing a `type Monthday* = enum d1, d2, d3, ..., d30` + `proc to1Based*(a: Monthday): int = a.ord + 1`
ditto

* A4 make `month` private and implement via getter setter
breaking change (eg object ctor would break, taking `monthday` by reference would break, serialization complications, and many other unrelated cases)

