### PR TITLE
enummaps: library based generalized typesafe enum with holes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -116,6 +116,7 @@
 - Add `random.gauss`, that uses the ratio of uniforms method of sampling from a Gaussian distribution.
 - Add `typetraits.elementType` to get element type of an iterable.
 - `typetraits.$`: `$(int,)` is now `"(int,)"`; `$tuple[]` is now `"tuple[]"`
+- Add `std/enummaps` module which enables a DRY and flexible syntax to attach metadata to enums.
 
 ## Language changes
 - In the newruntime it is now allowed to assign to the discriminator field

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -12,27 +12,28 @@
 import
   lineinfos, hashes, options, ropes, idents, idgen, int128
 from strutils import toLowerAscii
+import std/enummaps
 
 export int128
 
-type
-  TCallingConvention* = enum
-    ccDefault,                # proc has no explicit calling convention
-    ccStdCall,                # procedure is stdcall
-    ccCDecl,                  # cdecl
-    ccSafeCall,               # safecall
-    ccSysCall,                # system call
-    ccInline,                 # proc should be inlined
-    ccNoInline,               # proc should not be inlined
-    ccFastCall,               # fastcall (pass parameters in registers)
-    ccThisCall,               # thiscall (parameters are pushed right-to-left)
-    ccClosure,                # proc has a closure
-    ccNoConvention            # needed for generating proper C procs sometimes
+enumMap:
+  type TCallingConvention* = enum
+    ccDefault = (name: "", cname: "N_NIMCALL")   # proc has no explicit calling convention
+    ccStdCall  = ("stdcall", "N_STDCALL")        # procedure is stdcall
+    ccCDecl = ("cdecl", "N_CDECL")               # cdecl
+    ccSafeCall = ("safecall", "N_SAFECALL")      # safecall
+    ccSysCall = ("syscall", "N_SYSCALL")         # system call
+      # this is probably not correct for all platforms,
+      # but one can `#define` it to what one wants
+    ccInline = ("inline", "N_INLINE")            # proc should be inlined
+    ccNoInline = ("noinline", "N_NOINLINE")      # proc should not be inlined
+    ccFastCall = ("fastcall", "N_FASTCALL")      # fastcall (pass parameters in registers)
+    ccThisCall = ("thiscall", "N_THISCALL")      # thiscall (parameters are pushed right-to-left)
+    ccClosure = ("closure", "N_CLOSURE")         # proc has a closure
+    ccNoConvention = ("noconv", "N_NOCONV")      # needed for generating proper C procs sometimes
 
-const
-  CallingConvToStr*: array[TCallingConvention, string] = ["", "stdcall",
-    "cdecl", "safecall", "syscall", "inline", "noinline", "fastcall", "thiscall",
-    "closure", "noconv"]
+proc name*(a: TCallingConvention): string {.inline.} = a.val.name
+proc cname*(a: TCallingConvention): string {.inline.} = a.val.cname
 
 type
   TNodeKind* = enum # order is extremely important, because ranges are used

--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -345,7 +345,7 @@ proc typeToYamlAux(conf: ConfigRef; n: PType, marker: var IntSet, indent: int,
     result.addf("$N$1\"n\": $2",     [istr, treeToYamlAux(conf, n.n, marker, indent + 2, maxRecDepth - 1)])
     if card(n.flags) > 0:
       result.addf("$N$1\"flags\": $2", [istr, flagsToStr(n.flags)])
-    result.addf("$N$1\"callconv\": $2", [istr, makeYamlString(CallingConvToStr[n.callConv])])
+    result.addf("$N$1\"callconv\": $2", [istr, makeYamlString(n.callConv.name)])
     result.addf("$N$1\"size\": $2", [istr, rope(n.size)])
     result.addf("$N$1\"align\": $2", [istr, rope(n.align)])
     result.addf("$N$1\"sons\": $2", [istr, sonsRope])

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -295,7 +295,7 @@ proc markAsClosure(g: ModuleGraph; owner: PSym; n: PNode) =
       [s.name.s, typeToString(s.typ), g.config$s.info])
   elif owner.typ.callConv notin {ccClosure, ccDefault}:
     localError(g.config, n.info, "illegal capture '$1' because '$2' has the calling convention: <$3>" %
-      [s.name.s, owner.name.s, CallingConvToStr[owner.typ.callConv]])
+      [s.name.s, owner.name.s, owner.typ.callConv.name])
   incl(owner.typ.flags, tfCapturesEnv)
   owner.typ.callConv = ccClosure
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -680,7 +680,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
         if i < t.len - 1: result.add(", ")
       result.add(')')
       if t.len > 0 and t[0] != nil: result.add(": " & typeToString(t[0]))
-      var prag = if t.callConv == ccDefault: "" else: CallingConvToStr[t.callConv]
+      var prag = if t.callConv == ccDefault: "" else: t.callConv.name
       if tfNoSideEffect in t.flags:
         addSep(prag)
         prag.add("noSideEffect")

--- a/lib/std/enummaps.nim
+++ b/lib/std/enummaps.nim
@@ -1,0 +1,64 @@
+##[
+experimental module, unstable API
+]##
+
+import macros
+
+proc lastSon(n: NimNode): NimNode =
+  if n.len == 0: n
+  else: n[^1]
+
+proc maybeExport(n: NimNode, doExport: bool): NimNode =
+  if doExport: newTree(nnkPostfix, ident"*", n)
+  else: n
+
+macro enumMap*(body): untyped =
+  ## builds an enum with a map enum => val, allowing library implementation
+  ## of enum with holes. This lifts restrictions on enum values, so that
+  ## arbitrary types can be used as values, including non ordinal, repeated, or
+  ##  out of order values.
+  var body = body
+  doAssert body.kind == nnkStmtList and body.len == 1
+  body = body[0]
+  doAssert body.kind == nnkTypeSection and body.len == 1
+  let body2 = copyNimTree(body)
+  let isExported = body[0][0].kind == nnkPostfix and body[0][0][0].strVal == "*"
+  let name = body[0][0].lastSon
+
+  let v = nnkBracket.newTree()
+  let elems = body2[0][2]
+  for i, ai in elems:
+    if i>0:
+      v.add ai[^1]
+
+  for i, ai in elems:
+    if i>0: elems[i] = ai[0]
+
+  let valsIdent = ident"vals".maybeExport(isExported)
+  let val = ident"val".maybeExport(isExported)
+
+  result = quote do:
+    const varr = `v`
+    `body2`
+    template `val`(a: `name`): untyped = varr[ord(a)]
+    template `valsIdent`(t: type `name`): untyped = varr
+
+proc byValImpl[V](a: V, T: typedesc, vals: array): T =
+  ## can be optimized in different ways if ever needed, eg building a trie
+  ## at CT, followed by trie search at RT. Other option is a hash table
+  for ai in T:
+    if vals[ai.ord] == a:
+      return ai
+
+template byVal*(E: typedesc[enum], a: typed): E =
+  byValImpl(a, E, E.vals)
+
+template findByIt*(E: typedesc[enum], pred: untyped): E =
+  # TODO: rename; enumByIt?
+  var ret: E
+  block outer:
+    for it {.inject.} in E:
+      if pred:
+        ret = it
+        break outer
+  ret

--- a/lib/std/enummaps.nim
+++ b/lib/std/enummaps.nim
@@ -29,6 +29,11 @@ enumMap(Foo):
 
 import macros
 
+const nimHasArrayEnumIndex = compiles(block:
+  type Foo = enum foo0
+  discard [foo0: 0][foo0])
+  # for bootstrap; remove pending csources2 https://github.com/timotheecour/Nim/issues/251
+
 runnableExamples:
   ## See `tests/stdlib/tenummaps.nim` for more examples.
   enumMap:
@@ -84,11 +89,15 @@ macro enumMap*(body): untyped =
       v.add newTree(nnkExprColonExpr, elems[i], ai[^1])
   let vals = ident"vals".maybeExport(isExported)
   let val = ident"val".maybeExport(isExported)
+  let nimHasArrayEnumIndex2 = newLit nimHasArrayEnumIndex
   result = quote do:
     `body2`
     const varr = `v`
-    template `val`(a: `name`): untyped = varr[a]
     template `vals`(t: type `name`): untyped = varr
+    when `nimHasArrayEnumIndex2`:
+      template `val`(a: `name`): untyped = varr[a]
+    else:
+      template `val`(a: `name`): untyped = varr[a.ord]
 
 when false:
   # broken pending https://github.com/nim-lang/Nim/issues/13747

--- a/lib/std/enummaps.nim
+++ b/lib/std/enummaps.nim
@@ -1,8 +1,48 @@
 ##[
-experimental module, unstable API
+This module implements enum maps, which are syntax sugar for compile time
+mapping from enum members to a value type. This can be used as a type safe
+generalization of enum with holes, or any application where you have a
+compile time collection of values.
+
+Note: experimental module, unstable API
 ]##
 
+#[
+## TODO
+suport implicit consecutives when `=` not specified eg:
+enumMap:
+  type Foo = enum
+    k1 = 10
+    k2 # assumes equal to 11
+]#
+
 import macros
+
+runnableExamples:
+  ## See `tests/stdlib/tenummaps.nim` for more examples.
+  enumMap:
+    type MyHoly = enum
+      kDefault = -1 ## sentinel, when reverse lookup fails in `byVal`
+      k1 = 1 ##
+      k2 = 4 ## hole
+      k3 = 1 ## repeated and out of order is ok
+  doAssert k2.ord == 2
+  doAssert k2.val == 4 
+  doAssert k2 == MyHoly.k2
+  static: doAssert MyHoly.byVal(4) == k2 # works at CT
+  doAssert MyHoly.byVal(1) == k1 # finds 1st occurrence
+  doAssert MyHoly.byVal(17) == kDefault # catch-all, can be used
+
+  ## Any value type is valid:
+  enumMap:
+    type Color = enum
+      cDefault = (ansi: 0, name: "normal", hex: "", rgb: [0'u8,0,0]) ## default
+      cBlack = (30, "black", "#000000", [0'u8,0,0]) ## black
+      cGreen = (32, "green", "#008000", [0'u8,128,0]) ## green
+      cDarkolivegreen = (32, "dark olive green", "#556B2F", [85'u8, 107, 47]) ## red
+  static:
+    doAssert cBlack.val.name == "black"
+    doAssert Color.findByIt(it.val.name == "green") == cGreen
 
 proc lastSon(n: NimNode): NimNode =
   if n.len == 0: n
@@ -16,7 +56,7 @@ macro enumMap*(body): untyped =
   ## builds an enum with a map enum => val, allowing library implementation
   ## of enum with holes. This lifts restrictions on enum values, so that
   ## arbitrary types can be used as values, including non ordinal, repeated, or
-  ##  out of order values.
+  ## out of order values.
   var body = body
   doAssert body.kind == nnkStmtList and body.len == 1
   body = body[0]
@@ -29,30 +69,30 @@ macro enumMap*(body): untyped =
   let elems = body2[0][2]
   for i, ai in elems:
     if i>0:
-      v.add ai[^1]
       elems[i] = ai[0]
+      v.add newTree(nnkExprColonExpr, elems[i], ai[^1])
 
   let valsIdent = ident"vals".maybeExport(isExported)
   let val = ident"val".maybeExport(isExported)
 
   result = quote do:
-    const varr = `v`
     `body2`
-    template `val`(a: `name`): untyped = varr[ord(a)]
+    const varr = `v`
+    template `val`(a: `name`): untyped = varr[a]
     template `valsIdent`(t: type `name`): untyped = varr
 
 proc byValImpl[V](a: V, T: typedesc, vals: array): T =
   ## can be optimized in different ways if ever needed, eg building a trie
   ## at CT, followed by trie search at RT. Other option is a hash table
   for ai in T:
-    if vals[ai.ord] == a:
-      return ai
+    if vals[ai] == a: return ai
 
 template byVal*(E: typedesc[enum], a: typed): E =
+  ## reverse lookup by value
   byValImpl(a, E, E.vals)
 
 template findByIt*(E: typedesc[enum], pred: untyped): E =
-  # TODO: rename; enumByIt?
+  ## reverse lookup by a predicate `pred` on `it`
   var ret: E
   block outer:
     for it {.inject.} in E:

--- a/lib/std/enummaps.nim
+++ b/lib/std/enummaps.nim
@@ -71,15 +71,21 @@ macro enumMap*(body): untyped =
     if i>0:
       elems[i] = ai[0]
       v.add newTree(nnkExprColonExpr, elems[i], ai[^1])
-
-  let valsIdent = ident"vals".maybeExport(isExported)
+  let vals = ident"vals".maybeExport(isExported)
   let val = ident"val".maybeExport(isExported)
-
   result = quote do:
     `body2`
     const varr = `v`
     template `val`(a: `name`): untyped = varr[a]
-    template `valsIdent`(t: type `name`): untyped = varr
+    template `vals`(t: type `name`): untyped = varr
+
+when false:
+  # broken pending https://github.com/nim-lang/Nim/issues/13747
+  # so we use an auxiliary template as workaround
+  proc byValImpl[V](a: V, T: typedesc): T =
+    mixin vals
+    for ai in T:
+      if T.vals[ai] == a: return ai
 
 proc byValImpl[V](a: V, T: typedesc, vals: array): T =
   ## can be optimized in different ways if ever needed, eg building a trie

--- a/lib/std/enummaps.nim
+++ b/lib/std/enummaps.nim
@@ -9,11 +9,22 @@ Note: experimental module, unstable API
 
 #[
 ## TODO
-suport implicit consecutives when `=` not specified eg:
+* suport implicit consecutives when `=` not specified eg:
 enumMap:
   type Foo = enum
     k1 = 10
     k2 # assumes equal to 11
+
+* support:
+type Foo = object
+  name: string
+  baz: int
+
+enumMap(Foo):
+  type Bar* = enum
+    bar1 = (name = "", baz = 2)
+
+* support `when` which would reduce need for https://github.com/nim-lang/RFCs/issues/190
 ]#
 
 import macros

--- a/lib/std/enummaps.nim
+++ b/lib/std/enummaps.nim
@@ -30,9 +30,7 @@ macro enumMap*(body): untyped =
   for i, ai in elems:
     if i>0:
       v.add ai[^1]
-
-  for i, ai in elems:
-    if i>0: elems[i] = ai[0]
+      elems[i] = ai[0]
 
   let valsIdent = ident"vals".maybeExport(isExported)
   let val = ident"val".maybeExport(isExported)

--- a/tests/stdlib/menummaps.nim
+++ b/tests/stdlib/menummaps.nim
@@ -1,0 +1,8 @@
+import std/enummaps
+
+enumMap:
+  type Foo* = enum
+    fDefault = ""
+    f1 = "foo1"
+    f2 = "foo2"
+    f3 = "foo3"

--- a/tests/stdlib/tenummaps.nim
+++ b/tests/stdlib/tenummaps.nim
@@ -1,0 +1,92 @@
+import std/enummaps
+from sequtils import toSeq
+
+template isDefault[T](a: T): bool = a == default(type(a))
+
+when false:
+  # the current design of macro pragmas makes the following hard or impossible
+  # but the following syntax will be possible pending https://github.com/nim-lang/Nim/issues/13830
+  type MyHoly {.enumMap.} = enum
+    k1 = 1
+    k2 = 4
+
+block:
+  enumMap:
+    type MyHoly = enum
+      k1 = 1
+      k2 = 4 ## some comment
+      k3 = 1 # repeated and out of order is ok
+
+  doAssert k1.ord == 0
+  doAssert k1.val == 1
+  doAssert k2.ord == 1
+  doAssert k2.val == 4
+  doAssert k2 == MyHoly.k2
+  for ai in MyHoly: discard
+  doAssert toSeq(MyHoly) == @[k1, k2, k3]
+
+  block: # https://github.com/nim-lang/Nim/issues/13980
+    proc fun(e: MyHoly): int =
+      case e
+      of k1: 1
+      of k2: 2
+      of k3: 3
+    doAssert k2.fun == 2
+
+  doAssert MyHoly.default.val.type is int
+
+  doAssert MyHoly.byVal(4) == k2
+  doAssert MyHoly.byVal(1) == k1 # finds 1st occurrence
+  doAssert MyHoly.vals == [1,4,1]
+
+block:
+  enumMap:
+    type MyHoly2 = enum
+      k1 = (1.3, 'x', @[10]) # any type is ok
+      k2 = (1.0, 'y', @[])
+  doAssert k1.ord == 0
+  doAssert k1.val == (1.3, 'x', @[10])
+  doAssert $k1 == "k1"
+
+import menummaps
+
+block:
+  # test import
+  doAssert Foo.f1 == f1
+  doAssert f2.val == "foo2"
+
+  # test lookup
+  doAssert Foo.byVal("foo3") == f3
+  doAssert Foo.byVal("nonexistant").isDefault
+  doAssert Foo.byVal("nonexistant2").isDefault
+
+block:
+  # example: cmdline application; this minimizes boilerplate and eliminates
+  # code duplication of cmd names, and allows help messages to access command
+  # names + doc strings
+  enumMap:
+    type Cmd = enum
+      kDefault = (name: "", doc: "")
+      kRun = ("run", "perform a run")
+      kJump = ("jump", "this will do a jump")
+      kHelp = ("help", "print cmdline usage")
+      kHelpAlt = ("h", "ditto")
+
+  proc help(): string =
+    ## no code duplication: the strings (and doc msgs) appear only once
+    result = "cmdline usage:\n"
+    for ai in Cmd:
+      if ai == Cmd.default: continue
+      result.add "  " & ai.val[0] & ": " & ai.val[1] & "\n"
+
+  proc process(cmd: string): int =
+    let key = Cmd.findByIt(it.val.name == cmd)
+    case key
+    of kDefault: 0
+    of kRun: 1
+    of kJump: 2
+    of kHelp, kHelpAlt: (echo help(); 2)
+
+  doAssert "run".process == 1
+  doAssert "h".process == 2
+  doAssert "nonexistant".process == 0

--- a/tests/stdlib/tenummaps.nim
+++ b/tests/stdlib/tenummaps.nim
@@ -58,7 +58,7 @@ block:
     # this allows adding fields without beaking client code
     enumMap:
       type TCallingConvention = enum
-        ccDefault = (name: "", doc = "proc has no explicit calling convention")
+        ccDefault = (name: "", doc: "proc has no explicit calling convention")
         ccStdCall  = ("stdcall", "procedure is stdcall")
 
     template name(a: TCallingConvention): string = a.val.name

--- a/tests/stdlib/tenummaps.nim
+++ b/tests/stdlib/tenummaps.nim
@@ -41,6 +41,32 @@ block:
   doAssert MyHoly.vals == [1,4,1]
 
 block:
+  # example that could be used in compiler code
+  block: # simplest apporach: val = string
+    enumMap:
+      type TCallingConvention = enum
+        ccDefault = ""   # proc has no explicit calling convention
+        ccStdCall  = "stdcall" # procedure is stdcall
+
+    template name(a: TCallingConvention): string = a.val
+    doAssert $ccStdCall == "ccStdCall"
+    doAssert ccStdCall.val == "stdcall"
+    doAssert ccStdCall.name == "stdcall"
+
+  block:
+    # more future proof approach: val = tuple[name: string]
+    # this allows adding fields without beaking client code
+    enumMap:
+      type TCallingConvention = enum
+        ccDefault = (name: "", doc = "proc has no explicit calling convention")
+        ccStdCall  = ("stdcall", "procedure is stdcall")
+
+    template name(a: TCallingConvention): string = a.val.name
+    doAssert $ccStdCall == "ccStdCall"
+    doAssert ccStdCall.val.name == "stdcall"
+    doAssert ccStdCall.name == "stdcall"
+
+block:
   enumMap:
     type MyHoly2 = enum
       k1 = (1.3, 'x', @[10]) # any type is ok

--- a/tests/stdlib/tenummaps.nim
+++ b/tests/stdlib/tenummaps.nim
@@ -44,11 +44,11 @@ block:
   # example that could be used in compiler code
   block: # simplest apporach: val = string
     enumMap:
-      type TCallingConvention = enum
+      type TCallingConvention2 = enum
         ccDefault = ""   # proc has no explicit calling convention
         ccStdCall  = "stdcall" # procedure is stdcall
 
-    template name(a: TCallingConvention): string = a.val
+    template name(a: TCallingConvention2): string = a.val
     doAssert $ccStdCall == "ccStdCall"
     doAssert ccStdCall.val == "stdcall"
     doAssert ccStdCall.name == "stdcall"
@@ -57,11 +57,11 @@ block:
     # more future proof approach: val = tuple[name: string]
     # this allows adding fields without beaking client code
     enumMap:
-      type TCallingConvention = enum
+      type TCallingConvention2 = enum
         ccDefault = (name: "", doc: "proc has no explicit calling convention")
         ccStdCall  = ("stdcall", "procedure is stdcall")
 
-    template name(a: TCallingConvention): string = a.val.name
+    template name(a: TCallingConvention2): string = a.val.name
     doAssert $ccStdCall == "ccStdCall"
     doAssert ccStdCall.val.name == "stdcall"
     doAssert ccStdCall.name == "stdcall"
@@ -83,6 +83,40 @@ block:
 
   # checks that we can't mutate values
   doAssert not compiles(k1.val[0] = 5.2)
+
+block: # test valKind
+  type Bar = object
+    name: string
+  enumMap:
+    type Foo = enum
+      k0 = Bar()
+      k1 = Bar(name: "myk1")
+  doAssert k1.val == Bar(name: "myk1")
+
+block: # test valKind
+  var myval = 3
+  enumMapCustom(valKind="var"):
+    type Foo = enum
+      k0 = 0
+      k1 = myval*2
+      k2 = 2
+  doAssert k1.ord == 1
+  doAssert k1.val == myval*2
+  k1.val = -3
+  doAssert k1.val == -3
+
+block: # shows we can use a CT map defined by some function
+  var count {.compileTime.}: int
+  proc fun(): int =
+    result = count
+    count+=2
+
+  enumMap:
+    type Foo = enum
+      k0 = fun()
+      k1 = fun()
+      k2 = fun()
+  doAssert Foo.vals.static == [0,2,4]
 
 import menummaps
 

--- a/tests/stdlib/tenummaps.nim
+++ b/tests/stdlib/tenummaps.nim
@@ -95,7 +95,7 @@ block:
     of kDefault: 0
     of kRun: 1
     of kJump: 2
-    of kHelp, kHelpAlt: (echo help(); 2)
+    of kHelp, kHelpAlt: (if false: echo help(); 2)
 
   doAssert "run".process == 1
   doAssert "h".process == 2

--- a/tests/stdlib/tenummaps.nim
+++ b/tests/stdlib/tenummaps.nim
@@ -97,13 +97,15 @@ block: # test valKind
   var myval = 3
   enumMapCustom(valKind="var"):
     type Foo = enum
-      k0 = 0
-      k1 = myval*2
-      k2 = 2
+      k0 = (0,)
+      k1 = (myval*2,)
+      k2 = (2,)
   doAssert k1.ord == 1
-  doAssert k1.val == myval*2
-  k1.val = -3
-  doAssert k1.val == -3
+  doAssert k1.val[0] == myval*2
+  k1.val[0] = -3
+  doAssert k1.val[0] == -3
+  k1.val = (-4,)
+  doAssert k1.val == (-4,)
 
 block: # shows we can use a CT map defined by some function
   var count {.compileTime.}: int


### PR DESCRIPTION
* would close https://github.com/nim-lang/Nim/issues/13980
* would close https://github.com/nim-lang/Nim/issues/14001
* would close https://github.com/nim-lang/Nim/issues/12834
* would close other issues related to enum with holes, which can finally be deprecated
* see tests tests/stdlib/tenummaps.nim
* reverse lookup can be made as efficient as possible in future PRs (using either trie or hashtable), but this is fast enough for most applications, being cache friendly
* lots of uses cases
* clean API to handle invalid values, see examples

## example 1: vanilla example
```nim
block:
  # `type MyHoly {.enumMap.} = enum ...` pending #13830
  enumMap:
    type MyHoly = enum
      k1 = 1
      k2 = 4 ## some comment
      k3 = 1 # repeated and out of order is ok
  doAssert k2.ord == 1
  doAssert k2.val == 4
  doAssert k2 == MyHoly.k2
  doAssert toSeq(MyHoly) == @[k1, k2, k3]
  doAssert MyHoly.byVal(1) == k1 # finds 1st occurrence
```

## example 2: cmd line application, provides clean API with 0 code duplication for generating help messages

```nim
block:
  # example: cmdline application; this minimizes boilerplate and eliminates
  # code duplication of cmd names, and allows help messages to access command
  # names + doc strings
  enumMap:
    type Cmd = enum
      kDefault = (name: "", doc: "")
      kRun = ("run", "perform a run")
      kJump = ("jump", "this will do a jump")
      kHelp = ("help", "print cmdline usage")
      kHelpAlt = ("h", "ditto")

  proc help(): string =
    ## no code duplication: the strings (and doc msgs) appear only once
    result = "cmdline usage:\n"
    for ai in Cmd:
      if ai == Cmd.default: continue
      result.add "  " & ai.val[0] & ": " & ai.val[1] & "\n"

  proc process(cmd: string): int =
    let key = Cmd.findByIt(it.val.name == cmd)
    case key
    of kDefault: 0
    of kRun: 1
    of kJump: 2
    of kHelp, kHelpAlt: (echo help(); 2)

  doAssert "run".process == 1
  doAssert "h".process == 2
  doAssert "nonexistant".process == 0
```
prints:
```
cmdline usage:
  run: perform a run
  jump: this will do a jump
  help: print cmdline usage
  h: ditto
```

## note
pending https://github.com/nim-lang/Nim/issues/13830 you'll be able to write instead:
```nim
  type MyHoly {.enumMap.} = enum
    k1 = 1
    k2 = 4
```
(the current design of macro pragmas makes it either hard or impossible until https://github.com/nim-lang/Nim/issues/13830 is fixed)

* CI failure unrelated (https://github.com/timotheecour/Nim/issues/105#issue-602207590)