### PR TITLE
Fix broken async httpclient example

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -25,15 +25,19 @@
 ## ``AsyncHttpClient``:
 ##
 ## .. code-block:: Nim
-##   import httpClient
+## import asyncdispatch, httpclient
+## 
+## proc asyncProc(): Future[string] {.async.} =
 ##   var client = newAsyncHttpClient()
-##   echo await client.getContent("http://google.com")
+##   return await client.getContent("http://example.com")
+## 
+## echo waitFor asyncProc()
 ##
 ## The functionality implemented by ``HttpClient`` and ``AsyncHttpClient``
 ## is the same, so you can use whichever one suits you best in the examples
 ## shown here.
 ##
-## **Note:** You will need to run asynchronous examples in an async proc
+## **Note:** You need to run asynchronous examples in an async proc
 ## otherwise you will get an ``Undeclared identifier: 'await'`` error.
 ##
 ## Using HTTP POST


### PR DESCRIPTION
As the async httpclient is almost certainly the first async example beginners will want to try, we OWE it to them to give them a real example.

Example repeated here for clarity:

```nim
import asyncdispatch, httpclient

proc asyncProc(): Future[string] {.async.} =
  var client = newAsyncHttpClient()
  return await client.getContent("http://example.com")

echo waitFor asyncProc()
```

This is my first Nim contribution, please let me know if the code is right. (it runs on my machine, but may not be the best example)