### PR TITLE
fix mapIt issues #12625 & #12639

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -919,7 +919,7 @@ template mapIt*(s: typed, op: untyped): untyped =
       InType = typeof(items(s), typeOfIter)
       OutType = typeof((
         block:
-          var it{.inject.}: InType;
+          var it{.inject.}: typeof(items(s), typeOfIter);
           op), typeOfProc)
   else:
     type

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -916,14 +916,14 @@ template mapIt*(s: typed, op: untyped): untyped =
 
   when defined(nimHasTypeof):
     type OutType = typeof((
-        block:
-          var it{.inject.}: typeof(items(s), typeOfIter);
-          op), typeOfProc)
+      block:
+        var it{.inject.}: typeof(items(s), typeOfIter);
+        op), typeOfProc)
   else:
     type OutType = type((
-        block:
-          var it{.inject.}: type(items(s));
-          op))
+      block:
+        var it{.inject.}: type(items(s));
+        op))
   when OutType is not (proc):
     # Here, we avoid to create closures in loops.
     # This avoids https://github.com/nim-lang/Nim/issues/12625

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -915,33 +915,43 @@ template mapIt*(s: typed, op: untyped): untyped =
     assert strings == @["4", "8", "12", "16"]
 
   when defined(nimHasTypeof):
-    type OutType = typeof((
-      block:
-        var it{.inject.}: typeof(items(s), typeOfIter);
-        op), typeOfProc)
+    type
+      InType = typeof(items(s), typeOfIter)
+      OutType = typeof((
+        block:
+          var it{.inject.}: InType;
+          op), typeOfProc)
   else:
-    type OutType = type((
-      block:
-        var it{.inject.}: type(items(s));
-        op))
-  when compiles(s.len):
-    block: # using a block avoids https://github.com/nim-lang/Nim/issues/8580
+    type
+      InType = type(items(s))
+      OutType = type((
+        block:
+          var it{.inject.}: type(items(s));
+          op))
+  when OutType is not (proc):
+    when compiles(s.len):
+      block: # using a block avoids https://github.com/nim-lang/Nim/issues/8580
 
-      # BUG: `evalOnceAs(s2, s, false)` would lead to C compile errors
-      # (`error: use of undeclared identifier`) instead of Nim compile errors
-      evalOnceAs(s2, s, compiles((let _ = s)))
+        # BUG: `evalOnceAs(s2, s, false)` would lead to C compile errors
+        # (`error: use of undeclared identifier`) instead of Nim compile errors
+        evalOnceAs(s2, s, compiles((let _ = s)))
 
-      var i = 0
-      var result = newSeq[OutType](s2.len)
-      for it {.inject.} in s2:
-        result[i] = op
-        i += 1
+        var i = 0
+        var result = newSeq[OutType](s2.len)
+        for it {.inject.} in s2:
+          result[i] = op
+          i += 1
+        result
+    else:
+      var result: seq[OutType] = @[]
+      for it {.inject.} in items(s):
+        result.add(op)
       result
   else:
-    var result: seq[OutType] = @[]
-    for it {.inject.} in s:
-      result.add(op)
-    result
+    let f = proc (x: InType): OutType =
+              let it {.inject.} = x
+              op
+    map(s, f)
 
 template applyIt*(varSeq, op: untyped) =
   ## Convenience template around the mutable ``apply`` proc to reduce typing.

--- a/tests/collections/tseq.nim
+++ b/tests/collections/tseq.nim
@@ -204,3 +204,6 @@ block ttoseq:
   var y: type("a b c".split)
   y = "xzy"
   stdout.write("\n")
+
+block tseqmapitchain:
+  doAssert @[101, 102] == [1, 2].mapIt(func (x: int): int = it + x).mapIt(it(100))


### PR DESCRIPTION
1. fallback to call `map` when the result of `op` is a closure;
2. use `items(s)` in the for loop;
3. add a testcase.