### PR TITLE
`$` works for ref|ptr|pointer for all targets (c,cpp,js,vm) + other bugfixes

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -19,6 +19,7 @@ from sighashes import symBodyDigest
 from times import cpuTime
 
 from hashes import hash
+from system/dollars import toHexImpl
 from osproc import nil
 
 import vmconv
@@ -198,6 +199,9 @@ proc registerAdditionalOps*(c: PCtx) =
 
   registerCallback c, "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())
+
+  registerCallback c, "stdlib.dollars.toHexImpl", proc (a: VmArgs) {.nimcall.} =
+    setResult(a, a.getInt(0).int.toHexImpl)
 
   registerCallback c, "stdlib.macros.symBodyHash", proc (a: VmArgs) {.nimcall.} =
     let n = getNode(a, 0)

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -149,21 +149,12 @@ proc hashData*(data: pointer, size: int): Hash =
   result = !$h
 
 when defined(js):
-  var objectID = 0
+  from system/dollars import getNimJsObjectID
 
 proc hash*(x: pointer): Hash {.inline.} =
   ## Efficient hashing of pointers.
   when defined(js):
-    asm """
-      if (typeof `x` == "object") {
-        if ("_NimID" in `x`)
-          `result` = `x`["_NimID"];
-        else {
-          `result` = ++`objectID`;
-          `x`["_NimID"] = `result`;
-        }
-      }
-    """
+    result = getNimJsObjectID(x)
   else:
     result = cast[Hash](cast[uint](x) shr 3) # skip the alignment
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2051,7 +2051,7 @@ template unlikely*(val: bool): bool =
 
 
 import system/dollars
-export dollars
+export dollars except toHexImpl, getNimJsObjectID
 
 const
   NimMajor* {.intdefine.}: int = 1

--- a/tests/concepts/tconcepts_issues.nim
+++ b/tests/concepts/tconcepts_issues.nim
@@ -82,6 +82,9 @@ type
       v: T
 converter toObj1[T](t: T): Obj1[T] =
   return Obj1[T](v: t)
+
+proc echo2(a: varargs[string, mytostr]) = echo a[0]
+
 block t976:
   type
     int1 = distinct int
@@ -117,12 +120,12 @@ block t976:
       PrintAble = concept x
           $x is string
 
-  proc `$`[T](nt: Obj1[T]): string =
+  proc mytostr[T](nt: Obj1[T]): string =
       when T is PrintAble: result = "Printable"
       else: result = "Non Printable"
 
-  echo Obj2()
 
+  echo2 Obj2()
 
 
 block t1128:

--- a/tests/destructor/tdestructor3.nim
+++ b/tests/destructor/tdestructor3.nim
@@ -6,11 +6,9 @@ destroy
 123
 destroy Foo: 123
 destroy Foo: 5
-(x1: (val: ...))
 destroy
 ---------------
 app begin
-(val: ...)
 destroy
 app end
 '''
@@ -96,7 +94,7 @@ proc newObj2(x:int, y: float): MyObject2 =
 
 proc test =
   let obj2 = newObj2(1, 1.0)
-  echo obj2
+  doAssert obj2.x1.val != nil
 
 test()
 
@@ -119,7 +117,7 @@ proc createTop(): ptr TopObject =
 
 proc test2() = 
   let x = createTop()
-  echo $x.internal
+  doAssert x.internal.val != nil
   deleteTop(x)
 
 echo "---------------"  

--- a/tests/generics/tgeneric0.nim
+++ b/tests/generics/tgeneric0.nim
@@ -4,7 +4,7 @@ discard """
 0
 float32
 float32
-(name: "Resource 1", readers: ..., writers: ...)
+(name: "Resource 1", readers: @[], writers: @[])
 '''
 """
 

--- a/tests/js/trefbyvar.nim
+++ b/tests/js/trefbyvar.nim
@@ -66,4 +66,4 @@ proc initTypeA1(a: int; b: string; c: pointer = nil): TypeA1 =
   result.c_impl = c
 
 let x = initTypeA1(1, "a")
-doAssert($x == "(a_impl: 1, b_impl: \"a\", c_impl: ...)")
+doAssert($x == "(a_impl: 1, b_impl: \"a\", c_impl: nil)")

--- a/tests/statictypes/tstackmatrix.nim
+++ b/tests/statictypes/tstackmatrix.nim
@@ -1,7 +1,3 @@
-discard """
-  output: "(M: 3, N: 3, fp: ...)"
-"""
-
 # bug #6843
 
 type
@@ -26,4 +22,4 @@ var
     [7'f64, 8, 9]
   ]
   m = stackMatrix(data)
-echo m
+doAssert m.M == 3 and m.N == 3 and m.fp != nil

--- a/tests/types/tissues_types.nim
+++ b/tests/types/tissues_types.nim
@@ -6,8 +6,8 @@ true
 ptr Foo
 (member: "hello world")
 (member: 123.456)
-(member: "hello world", x: ...)
-(member: 123.456, x: ...)
+(member: "hello world", x: nil)
+(member: 123.456, x: nil)
 0
 false
 '''


### PR DESCRIPTION
* tests/system/tostring.nim now enabled for js target after doing the minimal modifications to support it; some failing tests indicate pre-existing `nim js` bugs that should be fixed
* fixes a bug for `cast` in VM which was causing a crash
* `$` now works for ref|ptr|pointer for all targets (c,cpp,js,vm),showing the address, which is useful, eg for determining whether 2 pointers/ref objects are the same (eg inside a log)

## $ for ref|ptr|pointer
for `nim js` it returns a unique object id, eg `@123`
for all other targets it returns hex address, eg `0x10d766608`

the addresses should furthermore be deterministic across re-runs if you disable ASLR, eg by passing `--passl:-Wl,-no_pie` (see example 2)

see tests in tests/system/tostring.nim

## example 1
```nim
# D20200421T000023
type
  TFoo = object
    x1: int
    x2: pointer
    x3: seq[Foo]
    x4: ptr TFoo
  Foo = ref TFoo

template fun() =
  var z = 0
  var a = Foo(x1: 1, x2: z.addr)
  a.x3 = @[nil, a, Foo()]
  a.x4 = a[].addr
  echo a[]

fun()
static: fun()

```

```
(x1: 1, x2: 0x0, x3: @[nil, 0x10afe4dc8, 0x10b03b808], x4: 0x10afe4dc8)
Hint: ... [SuccessX]
(x1: 1, x2: 0x108e80580, x3: @[nil, 0x108ed2050, 0x108ed2080], x4: 0x108ed2050)
```

instead of what's printed before this PR:
```
(x1: 1, x2: ..., x3: ..., x4: ...)
Hint: ... [SuccessX]
(x1: 1, x2: ..., x3: ..., x4: ...)
```
which doesn't tell you anything useful about reference semantics (eg which pointers are the same)

## example 2
```
git clone https://github.com/timotheecour/vitanim && cd vitanim
nim c -d:case2 --passl:-Wl,-no_pie testcases/t10595.nim
testcases/t10595
testcases/t10595 # shows same addresses
```

## note
* before PR `$` doesn't compile for ref,ptr,pointer which is not a very useful behavior, in particular for debugging (or, inside an object/tuple, would show as `...` which isn't particularly useful). The current behavior gives you no easy way to check which ref/ptr objects are identical. Showing the addresses allows exactly that, is safe, and also gives a hint as to whether an address is on the stack, heap, or data segment based on its range.

* https://github.com/nim-lang/Nim/pull/13687 attempted to make `$` recurse inside ref objects however I've explained here https://github.com/nim-lang/RFCs/issues/203#issuecomment-602534906 why this is a bad idea as a default behavior

* a more sophisticated and customizable pretty-printing (`std/prettyprint` as I suggested in https://github.com/nim-lang/RFCs/issues/203#issuecomment-602534906) doesn't remove the need for `$` to work on pointer-like types, since importing `std/prettyprint` won't work for some modules due to cyclic imports

