### PR TITLE
New runnableExample for `newAsyncHttpClient()`

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -573,6 +573,17 @@ proc newHttpClient*(userAgent = defUserAgent, maxRedirects = 5,
   ## ``TimeoutError`` is raised.
   ##
   ## ``headers`` specifies the HTTP Headers.
+  runnableExamples:
+    import asyncdispatch, httpclient, strutils
+
+    proc asyncProc(): Future[string] {.async.} =
+      var client = newAsyncHttpClient()
+      return await client.getContent("http://example.com")
+
+    let exampleHtml = waitFor asyncProc()
+    assert "Example Domain" in exampleHtml
+    assert not ("Pizza" in exampleHtml)
+
   new result
   result.headers = headers
   result.userAgent = userAgent


### PR DESCRIPTION
I've added an example that uses example.com, the contents of which are static, so it should be safe in testing.

Some context in #14037