### PR TITLE
base `parseEnum` on a case statement, fixes #14030

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -158,7 +158,7 @@ export
 export
   parsejson.JsonEventKind, parsejson.JsonError, JsonParser, JsonKindError,
   open, close, str, getInt, getFloat, kind, getColumn, getLine, getFilename,
-  errorMsg, errorMsgExpected, next, JsonParsingError, raiseParseErr
+  errorMsg, errorMsgExpected, next, JsonParsingError, raiseParseErr, normalize
 
 type
   JsonNodeKind* = enum ## possible JSON node types

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -158,7 +158,7 @@ export
 export
   parsejson.JsonEventKind, parsejson.JsonError, JsonParser, JsonKindError,
   open, close, str, getInt, getFloat, kind, getColumn, getLine, getFilename,
-  errorMsg, errorMsgExpected, next, JsonParsingError, raiseParseErr, normalize
+  errorMsg, errorMsgExpected, next, JsonParsingError, raiseParseErr, nimIdentNormalize
 
 type
   JsonNodeKind* = enum ## possible JSON node types

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -280,12 +280,12 @@ proc capitalizeAscii*(s: string): string {.noSideEffect, procvar,
   else: result = toUpperAscii(s[0]) & substr(s, 1)
 
 proc nimIdentNormalize*(s: string): string =
-  ## Normalizes the string `s`as Nim identifier.
+  ## Normalizes the string `s` as a Nim identifier.
   ##
-  ## That means to convert to lower case and remove any '_' on all characters except
-  ## first one.
+  ## That means to convert to lower case and remove any '_' on all characters
+  ## except first one.
   runnableExamples:
-    doAssert normalize("Foo_bar") == "Foobar"
+    doAssert nimIdentNormalize("Foo_bar") == "Foobar"
   result = newString(s.len)
   if s.len > 0:
     result[0] = s[0]

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -410,3 +410,28 @@ block:
   # finally using default
   let g = parseEnum[Bar]("Baz", V)
   doAssert g == V
+
+block:
+  # check ambiguous enum fails to parse
+  type
+    Ambig = enum
+      f1 = "A"
+      f2 = "B"
+      f3 = "A"
+
+  doAssert not compiles((let a = parseEnum[Ambig]("A")))
+
+block:
+  # check almost ambiguous enum
+  type
+    AlmostAmbig = enum
+      f1 = "someA"
+      f2 = "someB"
+      f3 = "SomeA"
+
+  let a = parseEnum[AlmostAmbig]("someA")
+  let b = parseEnum[AlmostAmbig]("someB")
+  let c = parseEnum[AlmostAmbig]("SomeA")
+  doAssert a == f1
+  doAssert b == f2
+  doAssert c == f3

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -348,3 +348,65 @@ when true:
 
 main()
 #OUT ha/home/a1xyz/usr/bin
+
+
+# `parseEnum`, ref issue #14030
+# check enum defined at top level
+type
+  Foo = enum
+    A
+    B = "bb"
+    C = (5, "ccc")
+    D = 15
+    E = "ee" # check that we count enum fields correctly
+
+block:
+  let a = parseEnum[Foo]("A")
+  let b = parseEnum[Foo]("bb")
+  let c = parseEnum[Foo]("ccc")
+  let d = parseEnum[Foo]("D")
+  let e = parseEnum[Foo]("ee")
+  doAssert a == A
+  doAssert b == B
+  doAssert c == C
+  doAssert d == D
+  doAssert e == E
+  try:
+    let f = parseEnum[Foo]("Bar")
+    doAssert false
+  except ValueError:
+    discard
+
+  # finally using default
+  let g = parseEnum[Foo]("Bar", A)
+  doAssert g == A
+
+block:
+  # check enum defined in block
+  type
+    Bar = enum
+      V
+      W = "ww"
+      X = (3, "xx")
+      Y = 10
+      Z = "zz" # check that we count enum fields correctly
+
+  let a = parseEnum[Bar]("V")
+  let b = parseEnum[Bar]("ww")
+  let c = parseEnum[Bar]("xx")
+  let d = parseEnum[Bar]("Y")
+  let e = parseEnum[Bar]("zz")
+  doAssert a == V
+  doAssert b == W
+  doAssert c == X
+  doAssert d == Y
+  doAssert e == Z
+  try:
+    let f = parseEnum[Bar]("Baz")
+    doAssert false
+  except ValueError:
+    discard
+
+  # finally using default
+  let g = parseEnum[Bar]("Baz", V)
+  doAssert g == V


### PR DESCRIPTION
Changes the `parseEnum` implementation to be based on a case statement comparing the given normalized string value to the normalized field of the enum.

@cooldome: I'm not quite sure what you meant with:
```nim
nnkOfBranch.newTree(normalize(str), enumVal)
```
I don't understand why this should work, nor could I get it to work.

In any case, I had to change the implementation a little bit anyways. While writing a test, I put an enum into a `block`, which broke the code, since the fields weren't known anymore. So instead I determine the correct field value and use `T(fieldValue)` instead. 