### PR TITLE
Replace enum fields idents with syms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -62,7 +62,7 @@
 
 - getImpl() on enum type symbols now returns field syms instead of idents. This helps
   with writing typed macros. Old behavior for backwards compatiblity can be restored 
-  with command line switch `--oldast`
+  with command line switch `--oldast`.
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -60,8 +60,9 @@
       x.val = nil
   ```
 
-- getImpl() on enum type symbols now return field syms instead of idents. This helps
-  with writing typed macros.
+- getImpl() on enum type symbols now returns field syms instead of idents. This helps
+  with writing typed macros. Old behavior for backwards compatiblity can be restored 
+  with command line switch `--oldast`
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -60,6 +60,9 @@
       x.val = nil
   ```
 
+- getImpl() on enum type symbols now return field syms instead of idents. This helps
+  with writing typed macros.
+
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -62,6 +62,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     counter, x: BiggestInt
     e: PSym
     base: PType
+    identToReplace: PNode
   counter = 0
   base = nil
   result = newOrPrevType(tyEnum, prev, c)
@@ -83,9 +84,11 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     of nkEnumFieldDef:
       if n[i][0].kind == nkPragmaExpr:
         e = newSymS(skEnumField, n[i][0][0], c)
+        identToReplace = n[i][0][0]
         pragma(c, e, n[i][0][1], enumFieldPragmas)
       else:
         e = newSymS(skEnumField, n[i][0], c)
+        identToReplace = n[i][0]
       var v = semConstExpr(c, n[i][1])
       var strVal: PNode = nil
       case skipTypes(v.typ, abstractInst-{tyTypeDesc}).kind
@@ -118,19 +121,24 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
       e = n[i].sym
     of nkIdent, nkAccQuoted:
       e = newSymS(skEnumField, n[i], c)
+      identToReplace = n[i]
     of nkPragmaExpr:
       e = newSymS(skEnumField, n[i][0], c)
       pragma(c, e, n[i][1], enumFieldPragmas)
+      identToReplace = n[i][0]
     else:
       illFormedAst(n[i], c.config)
     e.typ = result
     e.position = int(counter)
+    let symNode = newSymNode(e)
+    if identToReplace != nil:
+      identToReplace[] = symNode[]
     if e.position == 0: hasNull = true
     if result.sym != nil and sfExported in result.sym.flags:
       incl(e.flags, sfUsed)
       incl(e.flags, sfExported)
       if not isPure: strTableAdd(c.module.tab, e)
-    result.n.add newSymNode(e)
+    result.n.add symNode
     styleCheckDef(c.config, e)
     onDef(e.info, e)
     if sfGenSym notin e.flags:


### PR DESCRIPTION
During review of #14030 and #14046 I found there is problem with `getImpl()` for enum types.
Fields are idents and not syms. This makes hard to write typed macros. You have to generate 
`EnumType.X` everywhere instead of `X`. But  it doesn't work for bool enum type. `bool.true` is not valid.
