### PR TITLE
fix optNimV1Emulation regression breaking nim

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -131,7 +131,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     e.typ = result
     e.position = int(counter)
     let symNode = newSymNode(e)
-    if optNimV1Emulation notin c.config.options and identToReplace != nil:
+    if optNimV1Emulation notin c.config.globalOptions and identToReplace != nil:
       identToReplace[] = symNode
     if e.position == 0: hasNull = true
     if result.sym != nil and sfExported in result.sym.flags:


### PR DESCRIPTION
/cc @Araq 

I really like the new style of "move fast and break things" (within reason) I'm observing since the last few days (lots of merged PR's), IMO moving fast (after CI passes) and fixing later the occasional glitches (or leftover minor PR comments) that occur in the process is much better than moving slow and letting PR's rot forever. Obviously not applicable to controversial changes.

There is no better way to attract contributions that a PR queue that moves fast.

on this PR: oh, the dangers of pushing directly to devel without a PR... (https://github.com/nim-lang/Nim/commit/dd24004fabaf315463b89d38ac553b20080fd1cd)