### PR TITLE
implement `--warningAsError:on`  and enforce it for compiler sources; fix some bugs with `warningAsError:foo:on|off`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -74,6 +74,8 @@
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.
+- `--warningAsError:on|off` turns all enabled warnings into errors (or back to warnings),
+- `--warningAsError:on` is now enabled in compiler/config.nims
 - The `define` and `undef` pragmas have been de-deprecated.
 
 ## Tool changes

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -117,3 +117,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimNewIntegerOps")
   defineSymbol("nimHasInvariant")
   defineSymbol("nimHasStacktraceMsgs")
+  defineSymbol("nimHasWarningAsErrorAll")

--- a/compiler/config.nims
+++ b/compiler/config.nims
@@ -1,2 +1,4 @@
 when defined nimHasWarningAsErrorAll:
+  # keep this flag on to prevent future warning regressions, but if unbearable,
+  # disable specific ones via `switch("warningAsError", "foo:off")`
   switch("warningAsError", "on")

--- a/compiler/config.nims
+++ b/compiler/config.nims
@@ -1,0 +1,2 @@
+when defined nimHasWarningAsErrorAll:
+  switch("warningAsError", "on")

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -355,7 +355,7 @@ proc handleError(conf: ConfigRef; msg: TMsgKind, eh: TErrorHandling, s: string) 
     if conf.cmd == cmdIdeTools: log(s)
     quit(conf, msg)
   if msg >= errMin and msg <= errMax or
-      (msg in warnMin..warnMax and msg in conf.warningAsErrors):
+      (conf.hasWarn(msg) and msg in conf.warningAsErrors):
     inc(conf.errorCounter)
     conf.exitcode = 1'i8
     if conf.errorCounter >= conf.errorMax:

--- a/compiler/semparallel.nim
+++ b/compiler/semparallel.nim
@@ -22,7 +22,7 @@
 # - output slices need special logic (+)
 
 import
-  ast, astalgo, idents, lowerings, magicsys, guards, sempass2, msgs,
+  ast, astalgo, idents, lowerings, magicsys, guards, msgs,
   renderer, types, modulegraphs, options, spawn, lineinfos
 
 from trees import getMagic, isTrue, getRoot

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -39,6 +39,7 @@ Advanced options:
   --hint[X]:on|off          turn specific hint X on|off
   --warningAsError[X]:on|off
                             turn specific warning X into an error on|off
+  --warningAsError:on|off   turn all enabled warnings on|off (since 1.3.2)
   --styleCheck:off|hint|error
                             produce hints or errors for Nim identifiers that
                             do not adhere to Nim's official style guide

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2060,7 +2060,7 @@ const
   NimMinor* {.intdefine.}: int = 3
     ## is the minor number of Nim's version.
 
-  NimPatch* {.intdefine.}: int = 1
+  NimPatch* {.intdefine.}: int = 2
     ## is the patch number of Nim's version.
 
   NimVersion*: string = $NimMajor & "." & $NimMinor & "." & $NimPatch


### PR DESCRIPTION
## before PR:
* `warningAsError` had some bugs, for example `nim c -r --warningAsError:Deprecated:on hello.nim` would crash without any error or warning shown
* PR's keep introducing new warnings regularly and it goes un-noticed since CI doesn't check for it

## after PR
* that bug is fixed
* semantics are now as follows: 
  * `--warningAsError:foo:on` means enable warning and turn it into error
  * `--warningAsError:foo:off` means do not error for that warning but don't disable the warning
* `--warningAsError:on|off` is now implemented, with semantics:
  * `--warningAsError:on` turns all warnings into errors but doesn't enable (nor disable) any warning
  * `--warningAsError:off` turns all warnings into non-errors but doesn't enable (nor disable) any warning
* fix a pre-existing warning that was recently introduced in some recent PR
* enable `--warningAsError:on` for compiler sources; more sources could follow later. Errors can be selectively disabled:

the flags combine in the way you'd expect, so that `--warningAsError:on --warningAsError:foo:off` can be used to turn all enabled warnings into errors except for `foo`. 

## note
I'm also incrementing `NimPatch` so user code can simply branch via `when (NimMajor, NimMinor, NimPatch) >= version:`. `./compiler/config.nims` can't use that because of bootstrapping, but will be able to once `querySetting` reports the `(NimMajor, NimMinor, NimPatch)` it was compiled against
