### PR TITLE
Add critbits.commonPrefixLen

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,9 @@
 - The file descriptors created for internal bookkeeping by `ioselector_kqueue`
   and `ioselector_epoll` will no longer be leaked to child processes.
 
+- `critbits` adds `commonPrefixLen`.
+
+
 ## Language changes
 - In newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this: 
   ```nim

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -518,6 +518,22 @@ proc `$`*[T](c: CritBitTree[T]): string =
         result.addQuoted(val)
     result.add("}")
 
+proc commonPrefixLen*[T](c: CritBitTree[T]): int =
+  ## Returns longest common prefix length of all keys of `c`.
+  ## If `c` is empty, returns 0.
+  runnableExamples:
+    var c: CritBitTree[void]
+    doAssert c.commonPrefixLen == 0
+    incl(c, "key1")
+    doAssert c.commonPrefixLen == 4
+    incl(c, "key2")
+    doAssert c.commonPrefixLen == 3
+
+  if c.root != nil:
+    if c.root.isLeaf: len(c.root.key)
+    else: c.root.byte
+  else: 0
+
 
 runnableExamples:
   static:

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -518,7 +518,7 @@ proc `$`*[T](c: CritBitTree[T]): string =
         result.addQuoted(val)
     result.add("}")
 
-proc commonPrefixLen*[T](c: CritBitTree[T]): int =
+proc commonPrefixLen*[T](c: CritBitTree[T]): int {.inline, since((1, 3)).} =
   ## Returns longest common prefix length of all keys of `c`.
   ## If `c` is empty, returns 0.
   runnableExamples:


### PR DESCRIPTION
```nim
proc commonPrefixLen*[T](c: CritBitTree[T]): int
```
Returns longest common prefix length of all keys of `c`.
If `c` is empty, returns 0.

```nim
var c: CritBitTree[void]
doAssert c.commonPrefixLen == 0
incl(c, "key1")
doAssert c.commonPrefixLen == 4
incl(c, "key2")
doAssert c.commonPrefixLen == 3
```