### PR TITLE
FreeBSD: enable two currently disabled tests

### DIFF
--- a/tests/dll/client.nim
+++ b/tests/dll/client.nim
@@ -1,6 +1,5 @@
 discard """
   output: "Done"
-  disabled: "freebsd"
   cmd: "nim $target --debuginfo --hints:on --define:useNimRtl $options $file"
 """
 

--- a/tests/js/tconsole.nim
+++ b/tests/js/tconsole.nim
@@ -3,7 +3,6 @@ discard """
 Hello, console
 1 2 3
 '''
-  disabled: "freebsd"
 """
 
 # This file tests the JavaScript console


### PR DESCRIPTION
Fixes #12182

Related to #14075.

This PR enables `tests/dll/client.nim` and `tests/js/tconsole.nim` in the FreeBSD CI script. When ran locally, these tests appear to be passing. We'll see what sr.ht has to say.