### PR TITLE
testament: don't rely on Nim source structure [backport:1.2]

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -679,7 +679,7 @@ proc main() =
   of "all":
     #processCategory(r, Category"megatest", p.cmdLineRest.string, testsDir, runJoinableTests = false)
 
-    var myself = quoteShell(findExe("testament" / "testament"))
+    var myself = quoteShell(getAppFilename())
     if targetsStr.len > 0:
       myself &= " " & quoteShell("--targets:" & targetsStr)
 


### PR DESCRIPTION
It's also just faster to get the current file name instead of scanning
the PATH.