### PR TITLE
Fix #14091 and #14093 - test failures on NetBSD

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -239,6 +239,8 @@ proc parseSpec*(filename: string): TSpec =
           when defined(arm64): result.err = reDisabled
         of "openbsd":
           when defined(openbsd): result.err = reDisabled
+        of "netbsd":
+          when defined(netbsd): result.err = reDisabled
         else:
           result.parseErrors.addLine "cannot interpret as a bool: ", e.value
       of "cmd":

--- a/tests/exception/t9657.nim
+++ b/tests/exception/t9657.nim
@@ -3,6 +3,7 @@ discard """
   exitcode: 1
   target: "c"
   disabled: "openbsd"
+  disabled: "netbsd"
 """
 # todo: remove `target: "c"` workaround once #10343 is properly fixed
 close stdmsg

--- a/tests/stdlib/tgetaddrinfo.nim
+++ b/tests/stdlib/tgetaddrinfo.nim
@@ -15,7 +15,7 @@ block DGRAM_UDP:
   doAssert aiList.ai_next == nil
   freeAddrInfo aiList
 
-when defined(posix) and not defined(haiku) and not defined(freebsd) and not defined(openbsd):
+when defined(posix) and not defined(haiku) and not defined(freebsd) and not defined(openbsd) and not defined(netbsd):
 
   block RAW_ICMP:
     # the port will be ignored


### PR DESCRIPTION
Fixes #14091 
Fixes #14093 

Adds handling for disabling tests on netbsd, which was previously missing.

We don't have NetBSD CI support at the moment, so tests would need ran locally, which I have done.

For the disablement of `t9657`, see #13760 for previous discussion. 