### PR TITLE
changelog conflicts are a thing of the past .. [EDIT: in local git checkouts, not in github]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Avoids changelog conflicts by assuming additions-only, which is by far the common case.
+# In the rare case where branch b1 rebases against branch b2 and both branches
+# modified the same changelog entry, you'll end up with that changelog entry
+# duplicated, which is easily identifiable and fixable.
+/changelog.md merge=union
+


### PR DESCRIPTION
/cc @Araq 
* I've tried on a dummy repo, this works well and prevents virtually all future changelog conflicts. The only caveat is mentioned in PR content, and is a very good tradeoff.
* this PR is orthogonal to https://github.com/nim-lang/Nim/pull/14025 (only thing is that .gitattributes file will need to be updated after #14025 is merged)

CI failures unrelated

## alternatives considered
* gitatributes merge=union (this PR)
* gitlab's placeholder approach (https://about.gitlab.com/blog/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/)
* 1 file-per-changelog-entry (https://medium.com/@nettsundere/on-reducing-changelog-merge-conflicts-1eb23552630b, and IIRC git repo itself; see also http://seanwallis.com/post/resolving-changelog-merge-conflict-madness/)
* custom gitattributes merge-changelog https://github.com/isaacs/github/issues/560 (not a builtin gitattributes)

the `1 file-per-changelog-entry` can be tried if merge=union turns out bad

see also https://github.com/git/git/tree/master/Documentation/RelNotes (not quite same as 1-per-entry but git issues more frequent releases, ie patch releases, eg:
```
Documentation/RelNotes/2.25.0.txt
Documentation/RelNotes/2.25.1.txt
Documentation/RelNotes/2.25.2.txt
Documentation/RelNotes/2.25.3.txt
```

## [EDIT] works locally, but not on github UI
this avoids merge conflicts in your local git client but not in github UI, as also noted in https://github.com/isaacs/github/issues/487 (unlike gitlab which [supports it](https://gitlab.com/gitlab-org/gitlab-foss/-/issues/17325)
but whoever's merging the PR should be able to easily merge through "resolve conflict" in those cases; if not, a local rebase (which should give no conflict) + `git push -f` will fix it
