### PR TITLE
Faster readStr()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,9 @@
   and this can now throw in edge cases where `getCurrentDir` throws.
   `relativePath` also now works for js with `-d:nodejs`.
 
+- Added `streams.readStr` and `streams.peekStr` overloads to
+  accept an existing string to modify, which avoids memory
+  allocations, similar to `streams.readLine` (#13857).
 
 ## Language changes
 - In newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -841,7 +841,7 @@ proc peekFloat64*(s: Stream): float64 =
 
   peek(s, result)
 
-proc readStr*(s: Stream, length: int, str: var TaintedString) =
+proc readStr*(s: Stream, length: int, str: var TaintedString) {.since: (1, 3).} =
   ## Reads a string of length `length` from the stream `s`. Raises `IOError` if
   ## an error occurred.
 
@@ -862,7 +862,7 @@ proc readStr*(s: Stream, length: int): TaintedString =
   result = newString(length).TaintedString
   readStr(s, length, result)
 
-proc peekStr*(s: Stream, length: int, str: var TaintedString) =
+proc peekStr*(s: Stream, length: int, str: var TaintedString) {.since: (1, 3).} =
   ## Peeks a string of length `length` from the stream `s`. Raises `IOError` if
   ## an error occurred.
 

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -841,6 +841,14 @@ proc peekFloat64*(s: Stream): float64 =
 
   peek(s, result)
 
+proc readStr*(s: Stream, length: int, str: var TaintedString) =
+  ## Reads a string of length `length` from the stream `s`. Raises `IOError` if
+  ## an error occurred.
+
+  if length > len(str): setLen(str.string, length)
+  var L = readData(s, cstring(str), length)
+  if L != len(str): setLen(str.string, L)
+
 proc readStr*(s: Stream, length: int): TaintedString =
   ## Reads a string of length `length` from the stream `s`. Raises `IOError` if
   ## an error occurred.
@@ -851,10 +859,16 @@ proc readStr*(s: Stream, length: int): TaintedString =
     doAssert strm.readStr(2) == "e"
     doAssert strm.readStr(2) == ""
     strm.close()
-
   result = newString(length).TaintedString
-  var L = readData(s, cstring(result), length)
-  if L != length: setLen(result.string, L)
+  readStr(s, length, result)
+
+proc peekStr*(s: Stream, length: int, str: var TaintedString) =
+  ## Peeks a string of length `length` from the stream `s`. Raises `IOError` if
+  ## an error occurred.
+
+  if length > len(str): setLen(str.string, length)
+  var L = peekData(s, cstring(str), length)
+  if L != len(str): setLen(str.string, L)
 
 proc peekStr*(s: Stream, length: int): TaintedString =
   ## Peeks a string of length `length` from the stream `s`. Raises `IOError` if
@@ -867,10 +881,8 @@ proc peekStr*(s: Stream, length: int): TaintedString =
     doAssert strm.readStr(2) == "ab"
     doAssert strm.peekStr(2) == "cd"
     strm.close()
-
   result = newString(length).TaintedString
-  var L = peekData(s, cstring(result), length)
-  if L != length: setLen(result.string, L)
+  peekStr(s, length, result)
 
 proc readLine*(s: Stream, line: var TaintedString): bool =
   ## Reads a line of text from the stream `s` into `line`. `line` must not be


### PR DESCRIPTION
Avoid extra memory allocations, similar to existing `readLine(stream, length, str)`

resolves #13857 