### PR TITLE
fix nim CI; fix local testament

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -50,8 +50,9 @@ pkg "neo", true, "nim c -d:blas=openblas tests/all.nim"
 pkg "nicy", false, "nim c src/nicy.nim"
 
 when defined(osx):
-  # do this more generally by installing non-nim dependencies automatically
-  # as specified in nimble file
+  # xxx: do this more generally by installing non-nim dependencies automatically
+  # as specified in nimble file and calling `distros.foreignDepInstallCmd`, but
+  # it currently would fail work if a package is already installed.
   doAssert execShellCmd("brew ls --versions gtk+3 || brew install gtk+3") == 0
 pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
 

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -52,7 +52,7 @@ pkg "nicy", false, "nim c src/nicy.nim"
 when defined(osx):
   # do this more generally by installing non-nim dependencies automatically
   # as specified in nimble file
-  doAssert execShellCmd("brew install gtk+3") == 0
+  doAssert execShellCmd("brew ls --versions gtk+3 || brew install gtk+3") == 0
 pkg "nigui", false, "nim c -o:niguii -r src/nigui.nim"
 
 pkg "nimcrypto", false, "nim c -r tests/testall.nim"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -37,7 +37,7 @@ pkg "glob"
 pkg "gnuplot"
 pkg "hts", false, "nim c -o:htss src/hts.nim"
 pkg "illwill", false, "nimble examples"
-pkg "inim", true
+# pkg "inim", true # pending https://github.com/inim-repl/INim/issues/74
 pkg "itertools", false, "nim doc src/itertools.nim"
 pkg "iterutils"
 pkg "jstin"

--- a/tests/stdlib/thttpclient_ssl.nim
+++ b/tests/stdlib/thttpclient_ssl.nim
@@ -124,7 +124,8 @@ when not defined(windows):
         let msg = getCurrentExceptionMsg()
         log "client: exception: " & msg
         # SSL_shutdown:shutdown while in init
-        if not msg.contains("shutdown while in init") or msg.contains("alert number 48"):
-          # pending https://github.com/nim-lang/Nim/pull/10558 simplify as: check(msg, msg)
-          echo msg
+        if not (msg.contains("shutdown while in init") or msg.contains("alert number 48") or
+          msg.contains("routines:CONNECT_CR_CERT:certificate verify failed")):
+          # pending https://github.com/nim-lang/Nim/pull/10558 simplify as: check(condition, msg)
+          echo "CVerifyPeer exception: " & msg
           check(false)

--- a/tests/stdlib/thttpclient_ssl.nim
+++ b/tests/stdlib/thttpclient_ssl.nim
@@ -126,6 +126,5 @@ when not defined(windows):
         # SSL_shutdown:shutdown while in init
         if not (msg.contains("shutdown while in init") or msg.contains("alert number 48") or
           msg.contains("routines:CONNECT_CR_CERT:certificate verify failed")):
-          # pending https://github.com/nim-lang/Nim/pull/10558 simplify as: check(condition, msg)
           echo "CVerifyPeer exception: " & msg
           check(false)

--- a/tests/stdlib/thttpclient_ssl.nim
+++ b/tests/stdlib/thttpclient_ssl.nim
@@ -124,4 +124,7 @@ when not defined(windows):
         let msg = getCurrentExceptionMsg()
         log "client: exception: " & msg
         # SSL_shutdown:shutdown while in init
-        check(msg.contains("shutdown while in init") or msg.contains("alert number 48"))
+        if not msg.contains("shutdown while in init") or msg.contains("alert number 48"):
+          # pending https://github.com/nim-lang/Nim/pull/10558 simplify as: check(msg, msg)
+          echo msg
+          check(false)

--- a/tests/untestable/thttpclient_ssl.nim
+++ b/tests/untestable/thttpclient_ssl.nim
@@ -101,11 +101,12 @@ template evaluate(exception_msg: string, category: Category, desc: string) =
     if category in {good_broken, dubious_broken, bad_broken}:
       skip()
     if raised:
-      check exception_msg == "No SSL certificate found." or
+      # check exception_msg == "No SSL certificate found." or
+      doAssert exception_msg == "No SSL certificate found." or
         exception_msg == "SSL Certificate check failed." or
         exception_msg.contains("certificate verify failed") or
         exception_msg.contains("key too small") or
-        exception_msg.contains "shutdown while in init"
+        exception_msg.contains "shutdown while in init", exception_msg
 
   else:
     # this is unexpected


### PR DESCRIPTION
* fix running testament locally on OSX, `doAssert execShellCmd("brew install gtk+3") == 0` would fail if that package was already installed
* fix nim CI for important_packages.inim pending https://github.com/inim-repl/INim/issues/74
* fix nim CI for thttpclient_ssl.nim (https://github.com/timotheecour/Nim/issues/113#issuecomment-618770002); 
on OSX the SSL error is printed to stderr and there's no way to capture it:
`123145372754092:error:14035418:SSL routines:ACCEPT_SR_CERT:tlsv1 alert unknown ca:/BuildRoot/Library/Caches/com.apple.xbs/Sources/libressl/libressl-47.11.1/libressl-2.5/ssl/ssl_pkt.c:1205:SSL alert number 48`

none of these worked:
```
proc ERR_lib_error_string*(e: cint): cstring{.cdecl,dynlib: DLLUtilName, importc.}
proc ERR_func_error_string*(e: cint): cstring{.cdecl,dynlib: DLLUtilName, importc.}
proc ERR_reason_error_string*(e: cint): cstring{.cdecl,dynlib: DLLUtilName, importc.}
proc ERR_error_string_n*(e: cint, buf: ptr char, len: csize_t){.cdecl,dynlib: DLLUtilName, importc.}
```

but checking for `routines:CONNECT_CR_CERT:certificate verify failed` seems correct according to https://mta.openssl.org/pipermail/openssl-users/2017-December/007046.html /cc @FedericoCeratto
> SSL alert number 48 is specified in the documents that define SSL/TLS. It is the code for "unknown_ca", which means that verification failed


## note
remaining CI failures (Nim SSL CI) are pre-existing ; these pipelines only run when affected code is modified but the failure is unrelated