### PR TITLE
add badges for CI githubactions: ssl + doc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,13 @@
 # <img src="https://raw.githubusercontent.com/nim-lang/assets/master/Art/logo-crown.png" height="28px"/> Nim
 
-devel: [![Build Status](https://dev.azure.com/nim-lang/Nim/_apis/build/status/nim-lang.Nim?branchName=devel)](https://dev.azure.com/nim-lang/Nim/_build/latest?definitionId=1&branchName=devel) 1.0: [![Build Status](https://dev.azure.com/nim-lang/Nim/_apis/build/status/nim-lang.Nim?branchName=version-1-0)](https://dev.azure.com/nim-lang/Nim/_build/latest?definitionId=1&branchName=version-1-0) 1.2: [![Build Status](https://dev.azure.com/nim-lang/Nim/_apis/build/status/nim-lang.Nim?branchName=version-1-2)](https://dev.azure.com/nim-lang/Nim/_build/latest?definitionId=1&branchName=version-1-2) travis: [![Build Status][badge-nim-travisci]][nim-travisci] freebsd: [![builds.sr.ht freebsd status](https://builds.sr.ht/~araq/nim/freebsd.yml.svg)](https://builds.sr.ht/~araq/nim/freebsd.yml?) openbsd: [![builds.sr.ht openbsd status](https://builds.sr.ht/~araq/nim/openbsd.yml.svg)](https://builds.sr.ht/~araq/nim/openbsd.yml?)
+devel: [![Build Status](https://dev.azure.com/nim-lang/Nim/_apis/build/status/nim-lang.Nim?branchName=devel)](https://dev.azure.com/nim-lang/Nim/_build/latest?definitionId=1&branchName=devel)
+1.0: [![Build Status](https://dev.azure.com/nim-lang/Nim/_apis/build/status/nim-lang.Nim?branchName=version-1-0)](https://dev.azure.com/nim-lang/Nim/_build/latest?definitionId=1&branchName=version-1-0)
+1.2: [![Build Status](https://dev.azure.com/nim-lang/Nim/_apis/build/status/nim-lang.Nim?branchName=version-1-2)](https://dev.azure.com/nim-lang/Nim/_build/latest?definitionId=1&branchName=version-1-2)
+travis: [![Build Status][badge-nim-travisci]][nim-travisci]
+freebsd: [![builds.sr.ht freebsd status](https://builds.sr.ht/~araq/nim/freebsd.yml.svg)](https://builds.sr.ht/~araq/nim/freebsd.yml?)
+openbsd: [![builds.sr.ht openbsd status](https://builds.sr.ht/~araq/nim/openbsd.yml.svg)](https://builds.sr.ht/~araq/nim/openbsd.yml?)
+ssl: ![](https://github.com/nim-lang/Nim/workflows/Nim%20SSL%20CI/badge.svg)
+docs: ![](https://github.com/nim-lang/Nim/workflows/Nim%20Docs%20CI/badge.svg)
 
 This repository contains the Nim compiler, Nim's stdlib, tools and documentation.
 For more information about Nim, including downloads and documentation for


### PR DESCRIPTION
followup on https://github.com/nim-lang/Nim/pull/14101 with same rationale.

(CI for ssl only runs on some trigger so did not see it when i did that PR)

see result here: https://github.com/timotheecour/Nim/blob/pr_ci_badge_githubactions_ssl/readme.md (so we're reminded that CI SSL currently fails)