### PR TITLE
Fix #14088 and #14089 on NetBSD

### DIFF
--- a/tests/niminaction/Chapter8/sdl/sdl.nim
+++ b/tests/niminaction/Chapter8/sdl/sdl.nim
@@ -1,6 +1,6 @@
 when defined(Windows):
   const libName* = "SDL2.dll"
-elif defined(Linux) or defined(freebsd):
+elif defined(Linux) or defined(freebsd) or defined(netbsd):
   const libName* = "libSDL2.so"
 elif defined(MacOsX):
   const libName* = "libSDL2.dylib"

--- a/tests/niminaction/Chapter8/sfml/sfml_test.nim
+++ b/tests/niminaction/Chapter8/sfml/sfml_test.nim
@@ -3,6 +3,7 @@ action: compile
 disabled: "windows"
 disabled: "freebsd"
 disabled: "openbsd"
+disabled: "netbsd"
 """
 
 import sfml, os


### PR DESCRIPTION
Fixes #14088
Fixes #14089

Sets the lib name for SDL2 on NetBSD for #14088.
Disables the SFML test for #14089 - this test is already disabled for FreeBSD and OpenBSD.

We don't have NetBSD CI support at the moment, so tests would need ran locally, which I have done.