### PR TITLE
Allow vm in nkRecWhen

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -251,7 +251,7 @@ proc wordToCallConv(sw: TSpecialWord): TCallingConvention =
 
 proc isTurnedOn(c: PContext, n: PNode): bool =
   if n.kind in nkPragmaCallKinds and n.len == 2:
-    let x = c.semConstBoolExpr(c, n[1])
+    let x = forceBool(c, c.semConstExpr(c, n[1]))
     n[1] = x
     if x.kind == nkIntLit: return x.intVal != 0
   localError(c.config, n.info, "'on' or 'off' expected")
@@ -334,7 +334,8 @@ proc processNote(c: PContext, n: PNode) =
     let x = findStr(toStrArray, n[0][1].ident.s)
     if x >= 0:
       nk = TNoteKind(x + ord(msgMin))
-      let x = c.semConstBoolExpr(c, n[1])
+      let x = forceBool(c, c.semConstExpr(c, n[1]))
+      
       n[1] = x
       if x.kind == nkIntLit and x.intVal != 0: incl(notes, nk)
       else: excl(notes, nk)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -480,17 +480,6 @@ proc forceBool(c: PContext, n: PNode): PNode =
   result = fitNode(c, getSysType(c.graph, n.info, tyBool), n, n.info)
   if result == nil: result = n
 
-proc semConstBoolExpr(c: PContext, n: PNode): PNode =
-  let nn = semExprWithType(c, n)
-  result = fitNode(c, getSysType(c.graph, n.info, tyBool), nn, nn.info)
-  if result == nil:
-    localError(c.config, n.info, errConstExprExpected)
-    return nn
-  result = getConstExpr(c.module, result, c.graph)
-  if result == nil:
-    localError(c.config, n.info, errConstExprExpected)
-    result = nn
-
 proc semGenericStmt(c: PContext, n: PNode): PNode
 proc semConceptBody(c: PContext, n: PNode): PNode
 
@@ -515,7 +504,6 @@ proc myOpen(graph: ModuleGraph; module: PSym): PPassContext =
   c.semTryConstExpr = tryConstExpr
   c.computeRequiresInit = computeRequiresInit
   c.semOperand = semOperand
-  c.semConstBoolExpr = semConstBoolExpr
   c.semOverloadedCall = semOverloadedCall
   c.semInferredLambda = semInferredLambda
   c.semGenerateInstance = generateInstance

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -108,7 +108,6 @@ type
     hasUnresolvedArgs*: proc (c: PContext, n: PNode): bool
 
     semOperand*: proc (c: PContext, n: PNode, flags: TExprFlags = {}): PNode {.nimcall.}
-    semConstBoolExpr*: proc (c: PContext, n: PNode): PNode {.nimcall.} # XXX bite the bullet
     semOverloadedCall*: proc (c: PContext, n, nOrig: PNode,
                               filter: TSymKinds, flags: TExprFlags): PNode {.nimcall.}
     semTypeNode*: proc(c: PContext, n: PNode, prev: PType): PType {.nimcall.}

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -720,7 +720,7 @@ proc semRecordNodeAux(c: PContext, n: PNode, check: var IntSet, pos: var int,
       of nkElifBranch:
         checkSonsLen(it, 2, c.config)
         if c.inGenericContext == 0:
-          var e = semConstBoolExpr(c, it[0])
+          var e = forceBool(c, semConstExpr(c, it[0]))
           if e.kind != nkIntLit: internalError(c.config, e.info, "semRecordNodeAux")
           elif e.intVal != 0 and branch == nil: branch = it[1]
         else:

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1361,7 +1361,7 @@ since (1, 3):
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/error
   proc readyState*(f: FileReader): FileReaderState {.importcpp: "#.readyState", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
-  proc resultAsString*(f: FileReader): cstring {.importcpp: "(DOMString) #.result", nodecl.}
+  proc resultAsString*(f: FileReader): cstring {.importcpp: "#.result", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result
   proc abort*(f: FileReader) {.importcpp: "#.abort()".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/abort

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -39,9 +39,6 @@ type
     onselect*: proc (event: Event) {.nimcall.}
     onsubmit*: proc (event: Event) {.nimcall.}
     onunload*: proc (event: Event) {.nimcall.}
-    onloadstart*: proc (event: Event) {.nimcall.}
-    onprogress*: proc (event: Event) {.nimcall.}
-    onloadend*: proc (event: Event) {.nimcall.}
 
   DomEvent* {.pure.} = enum
     ## see `docs<https://developer.mozilla.org/en-US/docs/Web/Events>`_
@@ -991,38 +988,14 @@ type
     passive*: bool
 
 since (1, 3):
-  type 
-    DomParser* = ref object
-      ## DOM Parser object (defined on browser only, may not be on NodeJS).
-      ## * https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
-      ##
-      ## .. code-block:: nim
-      ##   let prsr = newDomParser()
-      ##   discard prsr.parseFromString("<html><marquee>Hello World</marquee></html>".cstring, "text/html".cstring)
+  type DomParser* = ref object  ## \
+    ## DOM Parser object (defined on browser only, may not be on NodeJS).
+    ## * https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
+    ##
+    ## .. code-block:: nim
+    ##   let prsr = newDomParser()
+    ##   discard prsr.parseFromString("<html><marquee>Hello World</marquee></html>".cstring, "text/html".cstring)
 
-    DomException* = ref DOMExceptionObj
-      ## The DOMException interface represents an abnormal event (called an exception) 
-      ## which occurs as a result of calling a method or accessing a property of a web API. 
-      ## Each exception has a name, which is a short "CamelCase" style string identifying 
-      ## the error or abnormal condition.
-      ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException
-
-    DOMExceptionObj {.importc.} = object 
-
-    FileReader* = ref FileReaderObj
-      ## The FileReader object lets web applications asynchronously read the contents of files 
-      ## (or raw data buffers) stored on the user's computer, using File or Blob objects to specify 
-      ## the file or data to read.
-      ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader
-
-    FileReaderObj {.importc.} = object of EventTargetObj
-
-    FileReaderState* = distinct range[0'u16..2'u16]
-
-  const 
-    fileReaderEmpty* = 0.FileReaderState
-    fileReaderLoading* = 1.FileReaderState
-    fileReaderDone* = 2.FileReaderState
 
 proc id*(n: Node): cstring {.importcpp: "#.id", nodecl.}
 proc `id=`*(n: Node; x: cstring) {.importcpp: "#.id = #", nodecl.}
@@ -1345,29 +1318,6 @@ proc offsetLeft*(e: Node): int {.importcpp: "#.offsetLeft", nodecl.}
 since (1, 3):
   func newDomParser*(): DOMParser {.importcpp: "new DOMParser()".}
     ## DOM Parser constructor.
+
   func parseFromString*(this: DOMParser; str: cstring; mimeType: cstring): Document {.importcpp.}
     ## Parse from string to `Document`.
-
-  proc newDomException*(): DomException {.importcpp: "new DomException()", constructor.}
-    ## DOM Exception constructor
-  proc message*(ex: DomException): cstring {.importcpp: "#.message", nodecl.}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException/message
-  proc name*(ex: DomException): cstring  {.importcpp: "#.name", nodecl.}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name
-
-  proc newFileReader*(): FileReader {.importcpp: "new FileReader()", constructor.}
-    ## File Reader constructor
-  proc error*(f: FileReader): DOMException {.importcpp: "#.error", nodecl.}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/error
-  proc readyState*(f: FileReader): FileReaderState {.importcpp: "#.readyState", nodecl.}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
-  proc resultAsString*(f: FileReader): cstring {.importcpp: "#.result", nodecl.}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result
-  proc abort*(f: FileReader) {.importcpp: "#.abort()".}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/abort
-  proc readAsBinaryString*(f: FileReader, b: Blob) {.importcpp: "#.readAsBinaryString(#)".}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsBinaryString
-  proc readAsDataURL*(f: FileReader, b: Blob) {.importcpp: "#.readAsDataURL(#)".}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
-  proc readAsText*(f: FileReader, b: Blob, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1362,7 +1362,7 @@ since (1, 3):
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/error
   proc readyState*(f: FileReader): FileReaderState {.importcpp: "#.readyState", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
-  proc resultAsString*(f: FileReader): cstring {.importcpp: "#.result", nodecl.}
+  proc resultAsString*(f: FileReader): cstring {.importcpp: "(DOMString) #.result", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result
   proc abort*(f: FileReader) {.importcpp: "#.abort()".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/abort

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -39,6 +39,10 @@ type
     onselect*: proc (event: Event) {.nimcall.}
     onsubmit*: proc (event: Event) {.nimcall.}
     onunload*: proc (event: Event) {.nimcall.}
+    when (NimMajor, NimMinor) >= (1, 3):
+      onloadstart*: proc (event: Event) {.nimcall.}
+      onprogress*: proc (event: Event) {.nimcall.}
+      onloadend*: proc (event: Event) {.nimcall.}
 
   DomEvent* {.pure.} = enum
     ## see `docs<https://developer.mozilla.org/en-US/docs/Web/Events>`_
@@ -988,14 +992,38 @@ type
     passive*: bool
 
 since (1, 3):
-  type DomParser* = ref object  ## \
-    ## DOM Parser object (defined on browser only, may not be on NodeJS).
-    ## * https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
-    ##
-    ## .. code-block:: nim
-    ##   let prsr = newDomParser()
-    ##   discard prsr.parseFromString("<html><marquee>Hello World</marquee></html>".cstring, "text/html".cstring)
+  type 
+    DomParser* = ref object
+      ## DOM Parser object (defined on browser only, may not be on NodeJS).
+      ## * https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
+      ##
+      ## .. code-block:: nim
+      ##   let prsr = newDomParser()
+      ##   discard prsr.parseFromString("<html><marquee>Hello World</marquee></html>".cstring, "text/html".cstring)
 
+    DomException* = ref DOMExceptionObj
+      ## The DOMException interface represents an abnormal event (called an exception) 
+      ## which occurs as a result of calling a method or accessing a property of a web API. 
+      ## Each exception has a name, which is a short "CamelCase" style string identifying 
+      ## the error or abnormal condition.
+      ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException
+
+    DOMExceptionObj {.importc.} = object 
+
+    FileReader* = ref FileReaderObj
+      ## The FileReader object lets web applications asynchronously read the contents of files 
+      ## (or raw data buffers) stored on the user's computer, using File or Blob objects to specify 
+      ## the file or data to read.
+      ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader
+
+    FileReaderObj {.importc.} = object of EventTargetObj
+
+    FileReaderState* = distinct range[0'u16..2'u16]
+
+  const 
+    fileReaderEmpty* = 0.FileReaderState
+    fileReaderLoading* = 1.FileReaderState
+    fileReaderDone* = 2.FileReaderState
 
 proc id*(n: Node): cstring {.importcpp: "#.id", nodecl.}
 proc `id=`*(n: Node; x: cstring) {.importcpp: "#.id = #", nodecl.}
@@ -1321,3 +1349,36 @@ since (1, 3):
 
   func parseFromString*(this: DOMParser; str: cstring; mimeType: cstring): Document {.importcpp.}
     ## Parse from string to `Document`.
+
+  proc newDomException*(): DomException {.importcpp: "new DomException()", constructor.}
+    ## DOM Exception constructor
+    
+  proc message*(ex: DomException): cstring {.importcpp: "#.message", nodecl.}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException/message
+  
+  proc name*(ex: DomException): cstring  {.importcpp: "#.name", nodecl.}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name
+
+  proc newFileReader*(): FileReader {.importcpp: "new FileReader()", constructor.}
+    ## File Reader constructor
+
+  proc error*(f: FileReader): DOMException {.importcpp: "#.error", nodecl.}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/error
+
+  proc readyState*(f: FileReader): FileReaderState {.importcpp: "#.readyState", nodecl.}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
+
+  proc resultAsString*(f: FileReader): cstring {.importcpp: "#.result", nodecl.}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result
+
+  proc abort*(f: FileReader) {.importcpp: "#.abort()".}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/abort
+
+  proc readAsBinaryString*(f: FileReader, b: Blob) {.importcpp: "#.readAsBinaryString(#)".}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsBinaryString
+  
+  proc readAsDataURL*(f: FileReader, b: Blob) {.importcpp: "#.readAsDataURL(#)".}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
+    
+  proc readAsText*(f: FileReader, f: File, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -39,10 +39,9 @@ type
     onselect*: proc (event: Event) {.nimcall.}
     onsubmit*: proc (event: Event) {.nimcall.}
     onunload*: proc (event: Event) {.nimcall.}
-    when (NimMajor, NimMinor) >= (1, 3):
-      onloadstart*: proc (event: Event) {.nimcall.}
-      onprogress*: proc (event: Event) {.nimcall.}
-      onloadend*: proc (event: Event) {.nimcall.}
+    onloadstart*: proc (event: Event) {.nimcall.}
+    onprogress*: proc (event: Event) {.nimcall.}
+    onloadend*: proc (event: Event) {.nimcall.}
 
   DomEvent* {.pure.} = enum
     ## see `docs<https://developer.mozilla.org/en-US/docs/Web/Events>`_
@@ -1370,5 +1369,5 @@ since (1, 3):
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsBinaryString
   proc readAsDataURL*(f: FileReader, b: Blob) {.importcpp: "#.readAsDataURL(#)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
-  proc readAsText*(f: FileReader, f: File, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
+  proc readAsText*(f: FileReader, b: Blob, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1346,39 +1346,29 @@ proc offsetLeft*(e: Node): int {.importcpp: "#.offsetLeft", nodecl.}
 since (1, 3):
   func newDomParser*(): DOMParser {.importcpp: "new DOMParser()".}
     ## DOM Parser constructor.
-
   func parseFromString*(this: DOMParser; str: cstring; mimeType: cstring): Document {.importcpp.}
     ## Parse from string to `Document`.
 
   proc newDomException*(): DomException {.importcpp: "new DomException()", constructor.}
     ## DOM Exception constructor
-    
   proc message*(ex: DomException): cstring {.importcpp: "#.message", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException/message
-  
   proc name*(ex: DomException): cstring  {.importcpp: "#.name", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name
 
   proc newFileReader*(): FileReader {.importcpp: "new FileReader()", constructor.}
     ## File Reader constructor
-
   proc error*(f: FileReader): DOMException {.importcpp: "#.error", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/error
-
   proc readyState*(f: FileReader): FileReaderState {.importcpp: "#.readyState", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState
-
   proc resultAsString*(f: FileReader): cstring {.importcpp: "#.result", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/result
-
   proc abort*(f: FileReader) {.importcpp: "#.abort()".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/abort
-
   proc readAsBinaryString*(f: FileReader, b: Blob) {.importcpp: "#.readAsBinaryString(#)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsBinaryString
-  
   proc readAsDataURL*(f: FileReader, b: Blob) {.importcpp: "#.readAsDataURL(#)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
-    
   proc readAsText*(f: FileReader, f: File, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText

--- a/tests/objects/twhen1.nim
+++ b/tests/objects/twhen1.nim
@@ -49,3 +49,10 @@ block:
 
 block:
   var x: Foo4[0]
+
+
+type
+  MyObject = object
+    x: int
+    when (NimMajor, NimMinor) >= (1, 1):
+      y: int


### PR DESCRIPTION
The fix is to use `forceBool(c, c.semConstExpr(c, n))` instead of `c.semConstBoolExpr(c, n)`.
This allows for `when (NimMajor, NimMinor) >= (1,1)` in object definitions.  

Also noticed that semConstBoolExpr is not used often so I am trying to remove it and use `semConstExpr` everywhere