### PR TITLE
Allow vm in nkRecWhen

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -481,15 +481,10 @@ proc forceBool(c: PContext, n: PNode): PNode =
   if result == nil: result = n
 
 proc semConstBoolExpr(c: PContext, n: PNode): PNode =
-  let nn = semExprWithType(c, n)
-  result = fitNode(c, getSysType(c.graph, n.info, tyBool), nn, nn.info)
-  if result == nil:
+  result = forceBool(c, semConstExpr(c, n))
+  if result.kind != nkIntLit:
     localError(c.config, n.info, errConstExprExpected)
-    return nn
-  result = getConstExpr(c.module, result, c.graph)
-  if result == nil:
-    localError(c.config, n.info, errConstExprExpected)
-    result = nn
+
 
 proc semGenericStmt(c: PContext, n: PNode): PNode
 proc semConceptBody(c: PContext, n: PNode): PNode

--- a/tests/objects/twhen1.nim
+++ b/tests/objects/twhen1.nim
@@ -49,3 +49,9 @@ block:
 
 block:
   var x: Foo4[0]
+
+type
+  MyObject = object
+    x: int
+    when (NimMajor, NimMinor) >= (1, 1):
+      y: int


### PR DESCRIPTION
The fix is to use forceBool(c, c.semConstExpr(c, n))
This allows for ``when (NimMajor, NimMinor) >= (1,1)`` in object definitions.

