### PR TITLE
HCR: properly handling complex const objects in the codegen - fixes #13915

### DIFF
--- a/tests/dll/nimhcr_0_3.nim
+++ b/tests/dll/nimhcr_0_3.nim
@@ -14,5 +14,6 @@ let c = makeCounter()
 afterCodeReload:
   echo "   0: after - closure iterator: ", c()
   echo "   0: after - closure iterator: ", c()
+  echo "   0: after - c_2 = ", c_2
 
 proc getInt*(): int = return g_1 + g_2.len

--- a/tests/dll/nimhcr_2_1.nim
+++ b/tests/dll/nimhcr_2_1.nim
@@ -7,6 +7,8 @@ type
 
 let g_2* = @[Type2(data: 2), Type2(data: 3)][1..^1] # should have a length of 1
 
+const c_2* = [1, 2, 3] # testing that a complext const object is properly exported
+
 var a: tuple[str: string, i: int]
 a.str = "   2: random string"
 echo a.str

--- a/tests/dll/nimhcr_integration.nim
+++ b/tests/dll/nimhcr_integration.nim
@@ -36,6 +36,7 @@ max mutual recursion reached!
 bar
    0: after - closure iterator: 0
    0: after - closure iterator: 1
+   0: after - c_2 = [1, 2, 3]
 main: after
               The answer is: 9
 main: hasAnyModuleChanged? true


### PR DESCRIPTION
Given this code:
```
const A1* = [1, 2, 3]
```
The C codegen looks like this for the module which defines the constant:
```C
N_LIB_PRIVATE NIM_CONST tyArray__Bd4h7Ocx9bGTvrKzPIWNlHw A1__BevQ6PNoZRbxvdSjggRx7g_const = {((NI) 1),
((NI) 2),
((NI) 3)};

static tyArray__Bd4h7Ocx9bGTvrKzPIWNlHw* A1__BevQ6PNoZRbxvdSjggRx7g;
```
and later in the `Init000` function of the module which defines it we have:
```C
	hcrRegisterGlobal("/home/onqtam/.cache/nim/b_d/lib@ma.nim.c.so", "A1__BevQ6PNoZRbxvdSjggRx7g", sizeof((*A1__BevQ6PNoZRbxvdSjggRx7g)), NULL, (void**)&A1__BevQ6PNoZRbxvdSjggRx7g);

	nimCopyMem((void*)A1__BevQ6PNoZRbxvdSjggRx7g, (NIM_CONST void*)&A1__BevQ6PNoZRbxvdSjggRx7g_const, sizeof((*A1__BevQ6PNoZRbxvdSjggRx7g)));
```
This way we can even change the constant and reload - the new contents will be memcpy-ed regardless of what `hcrRegisterGlobal` returns (not true for normal global variables - for them we check the returned boolean) and all other modules which reference the constant shouldn't need to be rebuilt/reloaded - there they just get it like this:
```C
	A1__BevQ6PNoZRbxvdSjggRx7g = (tyArray__Bd4h7Ocx9bGTvrKzPIWNlHw*)hcrGetGlobal("/home/onqtam/.cache/nim/b_d/lib@ma.nim.c.so", "A1__BevQ6PNoZRbxvdSjggRx7g");
```
And it gets used simply by being dereferenced like so: `(*A1__BevQ6PNoZRbxvdSjggRx7g)`



