### PR TITLE
`since` now takes an optional patch, eg: `since: (1, 3, 1)`

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2055,7 +2055,11 @@ export dollars
 
 const
   NimMajor* {.intdefine.}: int = 1
-    ## is the major number of Nim's version.
+    ## is the major number of Nim's version. Example:
+    ##
+    ## .. code-block:: Nim
+    ##   when (NimMajor, NimMinor, NimPatch) >=  (1, 3, 1): discard
+    # See also private symbol `since: (1, 3)` reserved for stdlib
 
   NimMinor* {.intdefine.}: int = 3
     ## is the minor number of Nim's version.

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -49,8 +49,20 @@ when defined(nimlocks):
 else:
   {.pragma: benign, gcsafe.}
 
+template isSince(version: (int, int)): bool =
+  (NimMajor, NimMinor) >= version
+template isSince(version: (int, int, int)): bool =
+  (NimMajor, NimMinor, NimPatch) >= version
+
 template since(version, body: untyped) {.dirty, used.} =
-  ## limitation: can't be used to annotate a template (eg typetraits.get), would
+  ## Usage:
+  ##
+  ## .. code-block:: Nim
+  ##   proc fun*() {since: (1, 3).}
+  ##   proc fun*() {since: (1, 3, 1).}
+  ##
+  ## Limitation: can't be used to annotate a template (eg typetraits.get), would
   ## error: cannot attach a custom pragma.
-  when (NimMajor, NimMinor) >= version:
+  # `dirty` needed because `NimMajor` may not yet be defined in caller.
+  when isSince(version):
     body

--- a/tests/stdlib/tinclrtl.nim
+++ b/tests/stdlib/tinclrtl.nim
@@ -1,0 +1,32 @@
+include system/inclrtl
+
+proc fun1(): int {.since: (1,3).} = 12
+proc fun1Bad(): int {.since: (99,3).} = 12
+proc fun2(): int {.since: (1,3,1).} = 12
+proc fun2Bad(): int {.since: (99,3,1).} = 12
+
+doAssert fun1() == 12
+doAssert declared(fun1)
+doAssert not declared(fun1Bad)
+
+doAssert fun2() == 12
+doAssert declared(fun2)
+doAssert not declared(fun2Bad)
+
+var ok = false
+since (1, 3):
+  ok = true
+doAssert ok
+
+ok = false
+since (1, 3, 1):
+  ok = true
+doAssert ok
+
+since (99,3):
+  doAssert false
+
+when false:
+  # pending https://github.com/timotheecour/Nim/issues/129
+  # Error: cannot attach a custom pragma to 'fun3'
+  template fun3(): int {.since: (1, 3).} = 12


### PR DESCRIPTION
This PR makes it a bit easier to use NimPatch by supporting both `since (1,3)` and `since (1,3,1)`.
see tests in tinclrtl.nim

NimPatch is underused (since 1.0 was release), but is useful even after 1.0 was released.

* It allows writing portable code in between "official" nim releases even if switching branches/versions/commits.
For example, I can have in my user config.nims (or regular code) conditionals like
`when (NimMajor, NimMinor, NimPatch) >= (1, 3, 3): useNewFeatureX() else: useWorkaroundForX()`
and it'll work regardless which branches/versions/commits I'm on.
note that `when declared(foo)` won't work with overloads, and `when compiles` has known caveats and won't work when inner logic changes

* it reduces (but doesn't elimitate) the need for introducing new define symbols in `compiler/condsyms.nim`

* it's self-documenting when a feature/symbol was introduced