### PR TITLE
[WIP] new module jsarrays: ArrayBuffer, DataView + typed js API's

### DIFF
--- a/lib/js/jsarrays.nim
+++ b/lib/js/jsarrays.nim
@@ -1,0 +1,78 @@
+##[
+This module provides a wrapper for ArrayBuffer, DataView and related API's such
+as `getInt8`, `setInt16`.
+]##
+
+#[
+`BigInt` could be homed here.
+]#
+
+static: doAssert defined(js)
+
+type
+  ArrayBuffer* = ref object {.importjs.}
+  DataView* = ref object {.importjs.}
+    ## https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
+
+proc newArrayBuffer*(n: int): ArrayBuffer {.importjs: "new ArrayBuffer(#)".}
+proc newDataView*(a: ArrayBuffer, offset: int): DataView {.importjs: "new DataView(#, #)".}
+proc toArrayBuffer*(a: string): ArrayBuffer =
+  let n = a.len
+  result = newArrayBuffer(n)
+  {.emit:"""
+  const view = new Uint8Array(`result`);
+  for(i=0;i<`n`;i++){
+    view[i] = `a`[i];
+  }
+  """.}
+
+template genGetSet(T, funGet, funSet): untyped =
+  proc funGet(a: DataView, byteOffset: int, littleEndian: bool): T {.importcpp.}
+  proc funSet(a: DataView, byteOffset: int, value: T, littleEndian: bool): T {.importcpp.}
+
+genGetSet int8, getInt8, setInt8
+genGetSet int16, getInt16, setInt16
+genGetSet int32, getInt32, setInt32
+
+proc getTyped*(a: DataView, T: typedesc, offset: int, littleEndian: bool): T =
+  when false: discard
+  elif T is int8: getInt8(a, offset, littleEndian)
+  elif T is int16: getInt16(a, offset, littleEndian)
+  elif T is int32: getInt32(a, offset, littleEndian)
+  else: static doAssert false, $T # add as needed
+
+when false: ## scratch below
+  # view[i] = str.charCodeAt(i); // check whether would be needed for cstring
+
+  # proc `[]=`(a: ArrayBuffer, index: int, val: char) =
+  #   {.emit: """`a`[`index`] = `val`;""".}
+
+  # DataView.prototype.getBigInt64()
+  # DataView.prototype.getBigUint64()
+  # DataView.prototype.getFloat32()
+  # DataView.prototype.getFloat64()
+  # DataView.prototype.getInt16()
+  # DataView.prototype.getInt32()
+  # DataView.prototype.getInt8()
+  # DataView.prototype.getUint16()
+  # DataView.prototype.getUint32()
+  # DataView.prototype.getUint8()
+  # DataView.prototype.setBigInt64()
+  # DataView.prototype.setBigUint64()
+  # DataView.prototype.setFloat32()
+  # DataView.prototype.setFloat64()
+  # DataView.prototype.setInt16()
+  # DataView.prototype.setInt32()
+  # DataView.prototype.setInt8()
+  # DataView.prototype.setUint16()
+  # DataView.prototype.setUint32()
+  # DataView.prototype.setUint8()
+
+  proc decode() =
+    case bufLen
+    of int32.sizeof:
+      cast[ptr int](buffer)[] = s2.getInt32(0, true)
+    of int16.sizeof:
+      cast[ptr int16](buffer)[] = s2.getInt16(0, true)
+    else:
+      doAssert false

--- a/tests/js/tstreams.nim
+++ b/tests/js/tstreams.nim
@@ -8,15 +8,39 @@ GROOT
 
 import streams
 
-var s = newStringStream("I\nAM\nGROOT")
-doAssert s.peekStr(1) == "I"
-doAssert s.peekChar() == 'I'
-for line in s.lines:
-  echo line
-s.close
+block:
+  var s = newStringStream("I\nAM\nGROOT")
+  doAssert s.peekStr(1) == "I"
+  doAssert s.peekChar() == 'I'
+  for line in s.lines:
+    echo line
+  s.close
 
-var s2 = newStringStream("abc")
-doAssert s2.readAll == "abc"
-s2.write("def")
-doAssert s2.data == "abcdef"
-s2.close
+  var s2 = newStringStream("abc")
+  doAssert s2.readAll == "abc"
+  s2.write("def")
+  doAssert s2.data == "abcdef"
+  s2.close
+
+
+block:
+  proc fun[T](x: T) =
+    # todo: this could be done via `write` on a StringStream
+    var str: string
+    str.setLen 10
+    for i in 0..<T.sizeof: # improve
+      str[i] = cast[char](255 and (x shr (i*8)))
+
+    var s = newStringStream(str)
+    var x2: T
+    s.read(x2)
+    doAssert x2 == x
+    # echo (x, x2)
+
+  fun(234_560.int32)
+  fun(234.int16)
+  fun(0.int16)
+  fun(12.uint8)
+  fun(123123.int32)
+  fun(123123.uint32)
+  fun((-123).int8)


### PR DESCRIPTION
Do not review but early feedback welcome.

This PR adds a module `jsarrays.nim`, wrapping `ArrayBuffer`, `DataView` + typed js API's, see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView
This is useful for cases where the 1-size-fits-all js type Number falls short.

This PR will allow https://github.com/nim-lang/Nim/pull/14095 to have streams.read[T] (and write[T]) with T integer or FP types
(right now https://github.com/nim-lang/Nim/pull/14095 only supports T string)

This PR will be cleaned up to remove the commits from https://github.com/nim-lang/Nim/pull/14095 and only introduce jsarrays module + tests, but right now they're included to show this works with streams, see test `tests/js/tstreams.nim`

https://github.com/nim-lang/Nim/pull/14095 (or a followup PR) can thus use `jsarrays` to support read/write[T]

BigInt (for https://github.com/nim-lang/RFCs/issues/187) could belong here (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64) or be introduced in another module and imported here. 

## note
* `ArrayBuffer` + `DataView` can be used to implement `string` in js more efficiently: right now it uses `Array` (which is dynamically typed), but with `ArrayBuffer` + `DataView` it would be backed by a strongly typed array of char.
* this should either fix or help https://github.com/nim-lang/Nim/issues/5667 once completed

## EDIT
merge with lib/std/private/jsutils.nim