### PR TITLE
[superseded] fix #14142: no more clash with: import os + use of existsDir/dirExists/existsFile/fileExists/findExe in config.nims

### DIFF
--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -77,7 +77,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasUserErrors")
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")
-  defineSymbol("nimErrorProcCanHaveBody")
+  defineSymbol("nimErrorProcCanHaveBody") # since #9665 but now unused
   defineSymbol("nimHasInstantiationOfInMacro")
   defineSymbol("nimHasHotCodeReloading")
   defineSymbol("nimHasNilSeqs")

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -76,8 +76,6 @@ else:
 
 when weirdTarget:
   template noNimScript(body): untyped = discard
-  # Adding a `disable` template and `{.pragma: noNimScript, disable.}`
-  # doesn't work pending https://github.com/timotheecour/Nim/issues/142
 else:
   {.pragma: noNimScript.}
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -74,8 +74,10 @@ elif defined(posix):
 else:
   {.error: "OS module not ported to your operating system!".}
 
-when weirdTarget and defined(nimErrorProcCanHaveBody):
-  {.pragma: noNimScript, error: "this proc is not available on the NimScript target".}
+when weirdTarget:
+  template noNimScript(body): untyped = discard
+  # Adding a `disable` template and `{.pragma: noNimScript, disable.}`
+  # doesn't work pending https://github.com/timotheecour/Nim/issues/142
 else:
   {.pragma: noNimScript.}
 

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -69,6 +69,7 @@ import std/[
   decls, compilesettings, with, wrapnils
 ]
 
+
 block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
 

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -69,8 +69,14 @@ import std/[
   decls, compilesettings, with, wrapnils
 ]
 
-
 block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
 
 echo "Nimscript imports are successful."
+
+block: # #14142
+  discard existsDir("/usr")
+  discard dirExists("/usr")
+  discard existsFile("/usr/foo")
+  discard fileExists("/usr/foo")
+  discard findExe("nim")


### PR DESCRIPTION
/cc @Araq 
* fix https://github.com/nim-lang/Nim/issues/14142

## future work
* implicitly exported symols are not good, in particular when they differ from standard `nim c` behavior
* user should `import os` for these and it'd work via vmops
* we should be able to do this without much breakage by introducing a flag `--nimsimports:off` with semantics:
`--nimsimports:off` # doesn't import anything, user has to import relevant module (eg os); will be default in some future tag 1.3.X
`--nimsimports:on` # default until 1.3.x, gives a new warning while it's on
