### PR TITLE
Fix regression: hashes module doesn't compile with vcc

### DIFF
--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -99,7 +99,10 @@ proc hiXorLo(a, b: uint64): uint64 {.inline.} =
     elif defined(gcc) or defined(llvm_gcc) or defined(clang):
       {.emit: """__uint128_t r = a; r *= b; `result` = (r >> 64) ^ r;""".}
     elif defined(windows) and not defined(tcc):
-      {.emit: """a = _umul128(a, b, &b); `result` = a ^ b;""".}
+      proc umul128(a, b: uint64, c: ptr uint64): uint64 {.importc: "_umul128", header: "intrin.h".}
+      var b = b
+      let c = umul128(a, b, addr b)
+      result = c xor b
     else:
       result = hiXorLoFallback64(a, b)
 


### PR DESCRIPTION
This is showstopper regression.
Code doesn't compile because `_umul128` is in `intrin.h` and this header file is not included.