### PR TITLE
Fix parseEnum regression: enums with negative values can't be parsed

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -99,6 +99,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
             if not isOrdinalType(v[0].typ, allowEnumWithHoles=true):
               localError(c.config, v[0].info, errOrdinalTypeExpected & "; given: " & typeToString(v[0].typ, preferDesc))
             x = toInt64(getOrdValue(v[0])) # first tuple part is the ordinal
+            n[i][1][0] = newIntTypeNode(x, getSysType(c.graph, unknownLineInfo, tyInt))
           else:
             localError(c.config, strVal.info, errStringLiteralExpected)
         else:
@@ -110,6 +111,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
         if not isOrdinalType(v.typ, allowEnumWithHoles=true):
           localError(c.config, v.info, errOrdinalTypeExpected & "; given: " & typeToString(v.typ, preferDesc))
         x = toInt64(getOrdValue(v))
+        n[i][1] = newIntTypeNode(x, getSysType(c.graph, unknownLineInfo, tyInt))
       if i != 1:
         if x != counter: incl(result.flags, tfEnumHasHoles)
         if x < counter:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -478,7 +478,7 @@ type
 
 proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
               magic: "NBindSym", noSideEffect.}
-  ## Ceates a node that binds `ident` to a symbol node. The bound symbol
+  ## Creates a node that binds `ident` to a symbol node. The bound symbol
   ## may be an overloaded symbol.
   ## if `ident` is a NimNode, it must have ``nnkIdent`` kind.
   ## If ``rule == brClosed`` either an ``nnkClosedSymChoice`` tree is

--- a/tests/stdlib/tstrutil.nim
+++ b/tests/stdlib/tstrutil.nim
@@ -354,9 +354,9 @@ main()
 # check enum defined at top level
 type
   Foo = enum
-    A
+    A = -10
     B = "bb"
-    C = (5, "ccc")
+    C = (-5, "ccc")
     D = 15
     E = "ee" # check that we count enum fields correctly
 


### PR DESCRIPTION
In ast negative values are still represented as: nkPrefix(`-`,  nkIntLit) instead of nkIntLit with negative value.
Macro in parseEnum understandably can't handle such ast.

Showstopper