### PR TITLE
Fix compilations using tcc in nim 1.2+ [backport]

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -566,7 +566,7 @@ NIM_STATIC_ASSERT(sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(NI)*8, ""
 #define nimModInt(a, b, res) (((*res) = (a) % (b)), 0)
 #define nimModInt64(a, b, res) (((*res) = (a) % (b)), 0)
 
-#if (!defined(_MSC_VER) || defined(__clang__)) && !defined(NIM_EmulateOverflowChecks)
+#if (!defined(_MSC_VER) || defined(__clang__)) && !defined(NIM_EmulateOverflowChecks) && !defined(__TINYC__)
   /* these exist because we cannot have .compilerProcs that are importc'ed
     by a different name */
 


### PR DESCRIPTION
Realistically, `tcc` is never going to grow all those gcc/clang
`__builtin_*`s.

Credit: @c-blake

Fixes https://github.com/nim-lang/Nim/issues/14171 .