### PR TITLE
Move generated tex file to doc to correct location during `koch pdf`

### DIFF
--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -271,6 +271,9 @@ proc buildPdfDoc*(nimArgs, destPath: string) =
     const pdflatexcmd = "pdflatex -interaction=nonstopmode "
     for d in items(pdf):
       exec(findNim().quoteShell() & " rst2tex $# $#" % [nimArgs, d])
+      let tex = splitFile(d).name & ".tex"
+      removeFile("doc" / tex)
+      moveFile(tex, "doc" / tex)
       # call LaTeX twice to get cross references right:
       exec(pdflatexcmd & changeFileExt(d, "tex"))
       exec(pdflatexcmd & changeFileExt(d, "tex"))


### PR DESCRIPTION
When attempting to generate the pdf documentation with `koch pdf`, Nim's `rst2tex` generates the tex file and places it in the current working directory. It turns out to be the *root of the project directory*, because that is usually where we execute `koch pdf`.

However, during the later step of the process where we call `pdflatex` to convert the tex file to pdf, it expects the tex file to be in the `doc` subdirectory. `pdflatex` of course fails, so `koch pdf` fails.

This commit fixes the issue by moving the tex file(s) into the `doc` directory after its generation.

