### PR TITLE
=> supports pragmas & names (+ changed behavior)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -74,7 +74,7 @@
 
   # is transformed into
 
-  proc foo(x, y: int): auto {.noSideEffect.} = x + y
+  proc foo(x: int, y: int): auto {.noSideEffect.} = x + y
   ```
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -61,6 +61,22 @@
 - `paramCount` & `paramStr` are now defined in os.nim instead of nimscript.nim for nimscript/nimble.
 - `dollars.$` now works for unsigned ints with `nim js`
 
+- `sugar.=>` and `sugar.->` changes: Previously `(x, y: int)` was transformed
+  into `(x: auto, y: int)`, it now becomes `(x: int, y: int)` in consistency
+  with regular proc definitions (although you cannot use semicolons).
+  
+  Pragmas and using a name are now allowed on the lefthand side of `=>`. Here
+  is an aggregate example of these changes:
+  ```nim
+  import sugar
+
+  foo(x, y: int) {.noSideEffect.} => x + y
+
+  # is transformed into
+
+  proc foo(x, y: int): auto {.noSideEffect.} = x + y
+  ```
+
 ## Language changes
 - In newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:
   ```nim

--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -64,7 +64,7 @@ proc getIdent(e: NimNode): string {.compileTime.} =
     result = getIdent(e[0])
     for i in 1 .. e.len-1:
       result.add getIdent(e[i])
-  else: error("cannot extract identifier from node: " & toStrLit(e).strVal)
+  else: error("cannot extract identifier from node: " & toStrLit(e).strVal, e)
 
 proc delete[T](s: var seq[T], attr: T): bool =
   var idx = find(s, attr)
@@ -96,14 +96,14 @@ proc xmlCheckedTag*(argsList: NimNode, tag: string, optAttr = "", reqAttr = "",
         result.add(argsList[i][1])
         result.add(newStrLitNode("\""))
       else:
-        error("invalid attribute for '" & tag & "' element: " & name)
+        error("invalid attribute for '" & tag & "' element: " & name, argsList[i])
   # check each required attribute exists:
   if req.len > 0:
-    error(req[0] & " attribute for '" & tag & "' element expected")
+    error(req[0] & " attribute for '" & tag & "' element expected", argsList)
   if isLeaf:
     for i in 0 ..< argsList.len:
       if argsList[i].kind != nnkExprEqExpr:
-        error("element " & tag & " cannot be nested")
+        error("element " & tag & " cannot be nested", argsList[i])
     result.add(newStrLitNode(" />"))
   else:
     result.add(newStrLitNode(">"))

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1295,7 +1295,7 @@ macro genEnumStmt(typ: typedesc, argSym: typed, default: typed): untyped =
       foundFields.add fStr
     else:
       error("Ambiguous enums cannot be parsed, field " & $fStr &
-        " appears multiple times!")
+        " appears multiple times!", f)
     inc fNum
   # finally add else branch to raise or use default
   if default == nil:

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -62,8 +62,10 @@ macro `=>`*(p, b: untyped): untyped =
   ##   passTwoAndTwo((x, y) => x + y) # 4
   proc checkPragma(ex, prag: var NimNode) =
     if ex.kind == nnkPragmaExpr:
-      prag = p[1]
-      if ex.kind == nnkPar and ex.len == 1:
+      prag = ex[1]
+      if ex[0].kind == nnkPar and ex[0].len == 1:
+        ex = ex[0][0]
+      else:
         ex = ex[0]
 
   var
@@ -90,6 +92,7 @@ macro `=>`*(p, b: untyped): untyped =
       newP.add(p[i])
     p = newP
 
+  echo p.treeRepr
   case p.kind
   of nnkPar, nnkTupleConstr:
     var untypedBeforeColon = 0

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -124,7 +124,7 @@ macro genericParamsImpl(T: typedesc): untyped =
           result.add ret
         break
       else:
-        error "wrong kind: " & $impl.kind
+        error "wrong kind: " & $impl.kind, impl
 
 since (1, 1):
   template genericParams*(T: typedesc): untyped =

--- a/tests/macros/tclosuremacro.nim
+++ b/tests/macros/tclosuremacro.nim
@@ -1,19 +1,16 @@
 discard """
-  output: '''10
-10
-10
-3
-3
+  output: '''
 noReturn
-6
 calling mystuff
 yes
 calling mystuff
 yes
+calling sugarWithPragma
+sugarWithPragma called
 '''
 """
 
-import future, macros
+import sugar, macros
 
 proc twoParams(x: (int, int) -> int): int =
   result = x(5, 5)
@@ -30,23 +27,23 @@ proc noReturn(x: () -> void) =
 proc doWithOneAndTwo(f: (int, int) -> int): int =
   f(1,2)
 
-echo twoParams(proc (a, b: auto): auto = a + b)
-echo twoParams((x, y) => x + y)
-
-echo oneParam(x => x+5)
-
-echo noParams(() => 3)
-
-echo doWithOneAndTwo((x, y) => x + y)
+doAssert twoParams(proc (a, b: auto): auto = a + b) == 10
+doAssert twoParams((x, y) => x + y) == 10
+doAssert oneParam(x => x+5) == 10
+doAssert noParams(() => 3) == 3
+doAssert doWithOneAndTwo((x, y) => x + y) == 3
 
 noReturn((() -> void) => echo("noReturn"))
 
 proc pass2(f: (int, int) -> int): (int) -> int =
   ((x: int) -> int) => f(2, x)
 
-echo pass2((x, y) => x + y)(4)
+doAssert pass2((x, y) => x + y)(4) == 6
 
+fun(x, y: int) {.noSideEffect.} => x + y
 
+doAssert typeof(fun) is (proc (x, y: int): int {.nimcall.})
+doAssert fun(3, 4) == 7
 
 proc register(name: string; x: proc()) =
   echo "calling ", name
@@ -72,3 +69,5 @@ macro m(x: untyped): untyped =
 m:
   proc mystuff() =
     echo "yes"
+
+sugarWithPragma() {.m.} => echo "sugarWithPragma called"


### PR DESCRIPTION
(x, y: int) is now parsed as (x: int, y: int) instead of (x: auto, y: int) inside => and ->.

I know, the "using a name" feature is kind of weird, but it's what some other languages do and might be familiar to some newcomers. Down to exclude some functionality here if people ask for it