### PR TITLE
`echo cmd | nim r - -arg1 -arg2` now works

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -52,7 +52,7 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
         config.commandLine.add ':'
         config.commandLine.add p.val.quoteShell
 
-      if p.key == " ":
+      if p.key == "": # `-` was passed to indicate main project is stdin
         p.key = "-"
         if processArgument(pass, p, argsCount, config): break
       else:

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -7,9 +7,10 @@ discard """
 
 import std/[strformat,os,osproc,strutils]
 
+const nim = getCurrentCompilerExe()
+
 proc runCmd(file, options = ""): auto =
   let mode = if existsEnv("NIM_COMPILE_TO_CPP"): "cpp" else: "c"
-  const nim = getCurrentCompilerExe()
   const testsDir = currentSourcePath().parentDir
   let fileabs = testsDir / file.unixToNativePath
   doAssert fileabs.existsFile, fileabs
@@ -60,3 +61,33 @@ else: # don't run twice the same test
       check "sizeof(Foo5) == 3"
       check "sizeof(struct Foo6) == "
       doAssert exitCode != 0
+
+  import streams
+  block: # stdin input
+    let nimcmd = fmt"{nim} r --hints:off - -firstparam '-second param'"
+    let inputcmd = "import os; echo commandLineParams()"
+    let expected = """@["-firstparam", "-second param"]"""
+    block:
+      let p = startProcess(nimcmd, options = {poStdErrToStdOut, poEvalCommand})
+      p.inputStream.write("import os; echo commandLineParams()")
+      p.inputStream.close
+      var output = p.outputStream.readAll
+      let error = p.errorStream.readAll
+      let status = p.waitForExit
+      doAssert status == 0
+      output.stripLineEnd
+      when false:
+        # bug: `^[[0m` is being inserted somehow with `-` (regarless of --run)
+        # can be seen with: `import compiler/unittest_light` and:
+        assertEquals output, expected
+      doAssert output.endsWith expected
+      p.errorStream.close
+      p.outputStream.close
+
+    block:
+      when defined(posix):
+        let cmd = fmt"echo 'import os; echo commandLineParams()' | {nimcmd}"
+        var (output, exitCode) = execCmdEx(cmd)
+        output.stripLineEnd
+        when false: assertEquals output, expected  # same bug
+        doAssert output.endsWith expected


### PR DESCRIPTION
before PR:
* `echo discard | nim r - -arg1 -arg2`
command line(1, 2) Error: invalid command line option: '-1'
* `echo 'import os; echo commandLineParams()' | nim r --hints:off - foo1 foo2`
prints `@["foo2"]`, ie the 1st argument `foo1` disappeared


after PR:
* this works (any cmdline argument after `-` is treated as a runtime argument, just like for `nim r main -arg1 -arg2`)
* added tests (I don't think `echo cmd | nim r -` was even being tested before)
* identified a new bug with stdin file, which should be fixed in subsequent PR's:
`^[[0m` (the "reset" ansi escape code) is somehow being inserted to stderr when using `-` as input file (regarless of --run), see https://github.com/timotheecour/Nim/issues/152

