### PR TITLE
`osproc.execCmdEx` now takes an optional `input` for stdin, `env`, workingDir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -92,6 +92,8 @@
 - The callback that is passed to `system.onThreadDestruction` must now be `.raises: []`.
 
 
+- `osproc.execCmdEx` now takes an optional `input` for stdin.
+
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:
 

--- a/changelog.md
+++ b/changelog.md
@@ -93,6 +93,8 @@
 
 
 - `osproc.execCmdEx` now takes an optional `input` for stdin.
+- `osproc.execCmdEx` now takes an optional `input` for stdin, `workingDir` and `env`
+  parameters.
 
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2068,8 +2068,9 @@ const
     ## is the minor number of Nim's version.
     ## Odd for devel, even for releases.
 
-  NimPatch* {.intdefine.}: int = 3
+  NimPatch* {.intdefine.}: int = 5
     ## is the patch number of Nim's version.
+    ## Odd for devel, even for releases.
 
 import system/dollars
 export dollars

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -120,7 +120,15 @@ else:
     var result = startProcessTest("nim r --hints:off -", options = {}, input = "echo 3*4")
     doAssert result == ("12\n", 0)
 
+  import std/strtabs
   block execProcessTest:
     var result = execCmdEx("nim r --hints:off -", options = {}, input = "echo 3*4")
     stripLineEnd(result[0])
     doAssert result == ("12", 0)
+    doAssert execCmdEx("ls --nonexistant").exitCode != 0
+    when false:
+      # bug: on windows, this raises; on posix, passes
+      doAssert execCmdEx("nonexistant").exitCode != 0
+    when defined(posix):
+      doAssert execCmdEx("echo $FO", env = newStringTable({"FO": "B"})) == ("B\n", 0)
+      doAssert execCmdEx("echo $PWD", workingDir = "/") == ("/\n", 0)

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -1,7 +1,7 @@
 # test the osproc module
 
 import stdtest/specialpaths
-import "../.." / compiler/unittest_light
+import "$nim" / compiler/unittest_light
 
 when defined(case_testfile): # compiled test file for child process
   from posix import exitnow
@@ -119,3 +119,8 @@ else:
 
     var result = startProcessTest("nim r --hints:off -", options = {}, input = "echo 3*4")
     doAssert result == ("12\n", 0)
+
+  block execProcessTest:
+    var result = execCmdEx("nim r --hints:off -", options = {}, input = "echo 3*4")
+    stripLineEnd(result[0])
+    doAssert result == ("12", 0)


### PR DESCRIPTION
`osproc.execCmdEx` now takes an optional `input` for stdin. This is a common use case, and avoids the bashism `input | cmd` for common cases where input is small enough to avoid blocking (eg on OSX, 140_000 does not block but 150_000 blocks)

* as noted, writing stdin by chunks (in case of large stdin) would require selectors (kqueue/epoll etc) otherwise you'll end up blocking either when writing to stdin (pipe full) or reading from stdout (output empty). This can be fixed in future work (actually I'm advocating for a osproc2 that fixes all the design issues with osproc, but that's left as future work).

* the runnableExample comment is intentionally not a doc comment but may be useful for people looking at the code (it hits https://github.com/timotheecour/Nim/issues/152 depending on your user config)

* the `when (NimMajor, NimMinor, NimPatch) < (1, 3, 3): doAssert input.len == 0` is a compromise for the sake of simplicity (avoiding to rewrite a separate template etc)

* `env`, `workingDir` are also added for more consistency with rest of osproc and to avoid more bashisms (eg `"cd $dir && cmd"` or other existing kludges)