### PR TITLE
fix https://github.com/timotheecour/Nim/issues/152: avoid writing spurious `^[[0m` to stderr when callStyledWriteLineStderr not called

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -405,5 +405,3 @@ proc mainCommand*(graph: ModuleGraph) =
     echo "  int tries: ", gCacheIntTries
     echo "  efficiency: ", formatFloat(1-(gCacheMisses.float/gCacheTries.float),
                                        ffDecimal, 3)
-
-  resetAttributes(conf)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -312,6 +312,8 @@ template styledMsgWriteln*(args: varargs[typed]) =
   else:
     if eStdErr in conf.m.errorOutputs:
       if optUseColors in conf.globalOptions:
+        # conf.options.ansiResetNeeded = true
+        conf.ansiResetNeeded = true
         callStyledWriteLineStderr(args)
       else:
         callIgnoringStyle(writeLine, stderr, args)
@@ -443,7 +445,8 @@ proc rawMessage*(conf: ConfigRef; msg: TMsgKind, arg: string) =
 
 proc resetAttributes*(conf: ConfigRef) =
   if {optUseColors, optStdout} * conf.globalOptions == {optUseColors}:
-    terminal.resetAttributes(stderr)
+    if conf.ansiResetNeeded:
+      terminal.resetAttributes(stderr)
 
 proc addSourceLine(conf: ConfigRef; fileIdx: FileIndex, line: string) =
   conf.m.fileInfos[fileIdx.int32].lines.add line

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -263,7 +263,6 @@ type
     projectPath*: AbsoluteDir # holds a path like /home/alice/projects/nim/compiler/
     projectFull*: AbsoluteFile # projectPath/projectName
     projectIsStdin*: bool # whether we're compiling from stdin
-    ansiResetNeeded*: bool # whether resetAttributes is needed
     projectMainIdx*: FileIndex # the canonical path id of the main module
     command*: string # the main command (e.g. cc, check, scan, etc)
     commandArgs*: seq[string] # any arguments after the main command

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -263,6 +263,7 @@ type
     projectPath*: AbsoluteDir # holds a path like /home/alice/projects/nim/compiler/
     projectFull*: AbsoluteFile # projectPath/projectName
     projectIsStdin*: bool # whether we're compiling from stdin
+    ansiResetNeeded*: bool # whether resetAttributes is needed
     projectMainIdx*: FileIndex # the canonical path id of the main module
     command*: string # the main command (e.g. cc, check, scan, etc)
     commandArgs*: seq[string] # any arguments after the main command

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -74,9 +74,7 @@ else: # don't run twice the same test
       var output = p.outputStream.readAll
       let error = p.errorStream.readAll
       doAssert p.waitForExit == 0
-      when false: # https://github.com/timotheecour/Nim/issues/152
-        # bug: `^[[0m` is being inserted somehow with `-` (regarless of --run)
-        doAssert error.len == 0, $(error,)
+      doAssert error.len == 0, $error
       output.stripLineEnd
       doAssert output == expected
       p.errorStream.close
@@ -85,8 +83,6 @@ else: # don't run twice the same test
     block:
       when defined(posix):
         let cmd = fmt"echo 'import os; echo commandLineParams()' | {nimcmd}"
-        # avoid https://github.com/timotheecour/Nim/issues/152 by
-        # making sure `poStdErrToStdOut` isn't passed
-        var (output, exitCode) = execCmdEx(cmd, options = {poEvalCommand})
+        var (output, exitCode) = execCmdEx(cmd)
         output.stripLineEnd
         doAssert output == expected


### PR DESCRIPTION
* fix https://github.com/timotheecour/Nim/issues/152
* thanks to this fix I can simplify the tests introduced in https://github.com/nim-lang/Nim/pull/14210