### PR TITLE
fix #14217

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1193,7 +1193,7 @@ when notJSnotNims and hasAlloc and not defined(nimSeqsV2):
   proc addChar(s: NimString, c: char): NimString {.compilerproc, benign.}
 
 when defined(nimscript) or not defined(nimSeqsV2):
-  proc add*[T](x: var seq[T], y: T) {.magic: "AppendSeqElem", noSideEffect.}
+  proc add*[T](x: var seq[T], y: sink T) {.magic: "AppendSeqElem", noSideEffect.}
     ## Generic proc for adding a data item `y` to a container `x`.
     ##
     ## For containers that have an order, `add` means *append*. New generic

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -28,11 +28,11 @@ proc add(x: var string; y: string)
   first type mismatch at position: 1
   required type for x: var string
   but expression 'k' is of type: Alias
-proc add[T](x: var seq[T]; y: T)
+proc add[T](x: var seq[T]; y: openArray[T])
   first type mismatch at position: 1
   required type for x: var seq[T]
   but expression 'k' is of type: Alias
-proc add[T](x: var seq[T]; y: openArray[T])
+proc add[T](x: var seq[T]; y: sink T)
   first type mismatch at position: 1
   required type for x: var seq[T]
   but expression 'k' is of type: Alias

--- a/tests/destructor/trecursive.nim
+++ b/tests/destructor/trecursive.nim
@@ -32,3 +32,29 @@ proc test1() =
   echo "test1 OK"
 
 test1()
+
+#------------------------------------------------------------------------------
+# issue #14217
+
+type
+  MyObject = object
+    p: ptr int
+
+proc `=destroy`(x: var MyObject) =
+  if x.p != nil:
+    deallocShared(x.p)
+
+proc `=`(x: var MyObject, y: MyObject) {.error.}
+
+proc newMyObject(i: int): MyObject = 
+  result.p = create(int)
+  result.p[] = i
+
+proc test: seq[MyObject] = 
+  for i in 0..3:
+    let x = newMyObject(i)
+    result.add x
+
+var x = test()
+for i in 0..3:
+  doAssert(x[i].p[] == i)


### PR DESCRIPTION
fix #14217. 
Old seqs also do sink (shallow copy) on `add` according to its codegen.
