### PR TITLE
[WIP] fix {.incompleteStruct.} (implied wrong typeinfo)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -126,6 +126,7 @@
   nim r compiler/nim.nim --fullhelp # no recompilation
   nim r --nimcache:/tmp main # binary saved to /tmp/main
   ```
+- `incompleteStruct` is now deprecated, use `completeStruct` instead.
 
 ## Tool changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -120,13 +120,18 @@
   avoid recompiling when sources don't change. This is now the preferred way to
   run tests, avoiding the usual pain of clobbering your repo with binaries or
   using tricky gitignore rules on posix. Example:
-  ```nim
+  ```bash
   nim r compiler/nim.nim --help # only compiled the first time
-  echo 'import os; echo getCurrentCompilerExe()' | nim r - # this works too
+  echo "import os; echo getCurrentCompilerExe()" | nim r - # this works too
   nim r compiler/nim.nim --fullhelp # no recompilation
   nim r --nimcache:/tmp main # binary saved to /tmp/main
   ```
-- `incompleteStruct` is now deprecated, use `completeStruct` instead.
+- a new pragma `completeStruct` for importc objects indicates the type is fully
+  specified in the nim declaration (including field ordering), and allows
+  `sizeof, alignof, offsetof` to be used at compile time, see
+  manual.html#implementation-specific-pragmas-completestruct-pragma.
+- `incompleteStruct` is now deprecated, see
+  manual.html#implementation-specific-pragmas-incompletestruct-pragma.
 
 ## Tool changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -129,9 +129,9 @@
 - a new pragma `completeStruct` for importc objects indicates the type is fully
   specified in the nim declaration (including field ordering), and allows
   `sizeof, alignof, offsetof` to be used at compile time, see
-  manual.html#implementation-specific-pragmas-completestruct-pragma.
+  [manual](manual.html#implementation-specific-pragmas-completestruct-pragma).
 - `incompleteStruct` is now deprecated, see
-  manual.html#implementation-specific-pragmas-incompletestruct-pragma.
+  [manual](manual.html#implementation-specific-pragmas-incompletestruct-pragma).
 
 ## Tool changes
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -552,7 +552,6 @@ type
     tfCheckedForDestructor # type was checked for having a destructor.
                            # If it has one, t.destructor is not nil.
     tfAcyclic # object type was annotated as .acyclic
-    tfIncompleteStruct # treat this type as if it had sizeof(pointer)
     tfCompleteStruct
       # (for importc types); type is fully specified, allowing to compute
       # sizeof, alignof, offsetof at CT

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -888,8 +888,6 @@ proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet): Rope =
                       else: getTupleDesc(m, t, result, check)
         if not isImportedType(t):
           m.s[cfsTypes].add(recdesc)
-        elif tfIncompleteStruct notin t.flags:
-          discard # addAbiCheck(m, t, result) # already handled elsewhere
   of tySet:
     # Don't use the imported name as it may be scoped: 'Foo::SomeKind'
     result = $t.kind & '_' & t.lastSon.typeName & $t.lastSon.hashType
@@ -1008,14 +1006,9 @@ proc genTypeInfoAuxBase(m: BModule; typ, origType: PType;
 
   let nameHcr = tiNameForHcr(m, name)
 
-  var size: Rope
-  if tfIncompleteStruct in typ.flags:
-    size = rope"void*"
-  else:
-    size = getTypeDesc(m, origType)
   m.s[cfsTypeInit3].addf(
     "$1.size = sizeof($2);$n$1.align = NIM_ALIGNOF($2);$n$1.kind = $3;$n$1.base = $4;$n",
-    [nameHcr, size, rope(nimtypeKind), base]
+    [nameHcr, getTypeDesc(m, origType), rope(nimtypeKind), base]
   )
   # compute type flags for GC optimization
   var flags = 0

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -868,6 +868,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         noVal(c, it)
         incl(sym.flags, {sfThread, sfGlobal})
       of wDeadCodeElimUnused: discard  # deprecated, dead code elim always on
+      of wIncompleteStruct: discard
+        # else: incl(sym.typ.flags, tfIncompleteStruct)
       of wNoForward: pragmaNoForward(c, it)
       of wReorder: pragmaNoForward(c, it, flag = sfReorder)
       of wMagic: processMagic(c, it, sym)
@@ -1068,10 +1070,6 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wEffects:
         # is later processed in effect analysis:
         noVal(c, it)
-      of wIncompleteStruct:
-        noVal(c, it)
-        if sym.typ == nil: invalidPragma(c, it)
-        else: incl(sym.typ.flags, tfIncompleteStruct)
       of wCompleteStruct:
         noVal(c, it)
         if sym.typ == nil: invalidPragma(c, it)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -765,6 +765,10 @@ proc semCustomPragma(c: PContext, n: PNode): PNode =
 proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
                   validPragmas: TSpecialWords,
                   comesFromPush, isStatement: bool): bool =
+
+  template deprecatedPragma(keyword, msg) =
+    localError(c.config, n.info, warnDeprecated, "pragma '$1' is deprecated: $2" % [keyword.canonPragmaSpelling, msg])
+
   var it = n[i]
   var key = if it.kind in nkPragmaCallKinds and it.len > 1: it[0] else: it
   if key.kind == nkBracketExpr:
@@ -867,9 +871,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wThreadVar:
         noVal(c, it)
         incl(sym.flags, {sfThread, sfGlobal})
-      of wDeadCodeElimUnused: discard  # deprecated, dead code elim always on
-      of wIncompleteStruct: discard
-        # else: incl(sym.typ.flags, tfIncompleteStruct)
+      of wDeadCodeElimUnused: deprecatedPragma(wDeadCodeElimUnused, "dead code elim always on")
+      of wIncompleteStruct: deprecatedPragma(wIncompleteStruct, "see '$1' instead" % wCompleteStruct.canonPragmaSpelling)
       of wNoForward: pragmaNoForward(c, it)
       of wReorder: pragmaNoForward(c, it, flag = sfReorder)
       of wMagic: processMagic(c, it, sym)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -872,7 +872,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         noVal(c, it)
         incl(sym.flags, {sfThread, sfGlobal})
       of wDeadCodeElimUnused: deprecatedPragma(wDeadCodeElimUnused, "dead code elim always on")
-      of wIncompleteStruct: deprecatedPragma(wIncompleteStruct, "see '$1' instead" % wCompleteStruct.canonPragmaSpelling)
+      of wIncompleteStruct: deprecatedPragma(wIncompleteStruct, "see https://nim-lang.github.io/Nim/manual.html#implementation-specific-pragmas-incompletestruct-pragma")
       of wNoForward: pragmaNoForward(c, it)
       of wReorder: pragmaNoForward(c, it, flag = sfReorder)
       of wMagic: processMagic(c, it, sym)

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -41,7 +41,7 @@ type
     wImportCpp, wImportObjC,
     wImportCompilerProc,
     wImportc, wImportJs, wExportc, wExportCpp, wExportNims,
-    wIncompleteStruct, # deprecated
+    wIncompleteStruct, # deprecated since 1.3.1 now that we have wCompleteStruct
     wCompleteStruct,
     wRequiresInit,
     wAlign, wNodecl, wPure, wSideEffect, wHeader,

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6412,26 +6412,27 @@ CompleteStruct pragma
 -----------------------
 By default, `importc` types are considered incomplete: they may be lacking fields
 in their nim declaration because these are unused in nim code or because of ABI
-differences across platforms, in particular for padding fields. Field reordering
+differences across platforms, in particular for padding fields. Field reorderings
 are also allowed. This prevents using `sizeof`, `alignof`, `offsetOf` at compile
 time.
-These can still be used at runtime, deferring to calling ``sizeof`` (+ friends) in the
+These can still be used at runtime, deferring to calling `sizeof` (+ friends) in the
 backend generated code. In this case, they're known at backend compile time,
 but not during nim semantic phase.
 
-This ``completeStruct`` pragma overrides this behavior by telling the compiler
-the type declaration in nim is fully specified, so that `sizeof`, `alignof`, `offsetOf`
-are available at compile time. As a sanity check, `-d:checkAbi` will insert
-cgen static checks to make sure at least sizeof is correct.
+This `completeStruct` pragma overrides this behavior by telling the compiler
+the type declaration in nim is fully specified and in correct order so that
+`sizeof`, `alignof`, `offsetOf` are available at compile time.
+As a sanity check, `-d:checkAbi` will insert backend static checks to make sure
+at least `sizeof` is correct.
 
 .. code-block:: Nim
   type
-    TFoo* {.importc: "Foo", header: "<bar.h>",
-           pure, completeStruct.} = object
-      x*: cint # only 1 field in C declaration
+    TFoo* {.importc: "struct Foo", header: "<bar.h>", completeStruct.} = object
+      s1*: cint
+      x2* {.importc: "_x2"}: pointer # renamed field
 
-See `tests <https://github.com/nim-lang/Nim/blob/devel/tests/misc/msizeof5.nim>`_
-The ``incompleteStruct`` pragma is now deprecated as it was implying the wrong
+See `additional examples <https://github.com/nim-lang/Nim/blob/devel/tests/misc/msizeof5.nim>`_.
+The `incompleteStruct` pragma is now deprecated as it was implying the wrong
 default.
 
 Compile pragma

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6432,8 +6432,17 @@ at least `sizeof` is correct.
       x2* {.importc: "_x2"}: pointer # renamed field
 
 See `additional examples <https://github.com/nim-lang/Nim/blob/devel/tests/misc/msizeof5.nim>`_.
-The `incompleteStruct` pragma is now deprecated as it was implying the wrong
-default.
+
+
+IncompleteStruct pragma
+-----------------------
+**deprecated**
+This was used for forwarded C declarations such as `DIR` on some platforms,
+but led to incorrect typeinfo (eg with `dumpNumberOfInstances`). Instead we
+simply avoid referring to such type by value on platforms where it's a forwarded
+declaration and only use it via pointer. Any disallowed use-by-value leads to a
+C codegen error, and we avoid silently wrong results for cases where
+use-by-value is allowed.
 
 Compile pragma
 --------------

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -97,10 +97,20 @@ const StatHasNanoseconds* = defined(linux) or defined(freebsd) or
 
 # Platform common stuff (avoids repetition)
 
-type
-  # DIR* {.importc: "DIR*", header: "<dirent.h>".} = ptr object
-  DIR* {.importc: "DIR12", header: "<dirent.h>".} = ptr object
-    ## A type representing a directory stream.
+when defined(nimBackendHasPosixDIR):
+  # This should be auto-detected, like NIM_EmulateOverflowChecks, by
+  # calling preprocessor, see https://github.com/nim-lang/RFCs/issues/205
+  # proposal 5.
+  type
+    DIR* {.importc: "DIR", header: "<dirent.h>".} = object
+      ## on some systems, this is a forward declared type and should only
+      ## be used via pointer, ie via `C_DIR`
+    C_DIR* = ptr DIR
+      ## A ptr type representing a directory stream.
+else:
+  type
+    C_DIR* {.importc: "DIR*", header: "<dirent.h>".} = ptr object
+      ## A ptr type representing a directory stream.
 
 # Platform specific stuff
 
@@ -173,14 +183,14 @@ proc IN6ADDR_ANY_INIT* (): In6Addr {.importc, header: "<netinet/in.h>".}
 proc IN6ADDR_LOOPBACK_INIT* (): In6Addr {.importc, header: "<netinet/in.h>".}
 
 # dirent.h
-proc closedir*(a1: DIR): cint  {.importc, header: "<dirent.h>".}
-proc opendir*(a1: cstring): DIR {.importc, header: "<dirent.h>", sideEffect.}
-proc readdir*(a1: DIR): ptr Dirent  {.importc, header: "<dirent.h>", sideEffect.}
-proc readdir_r*(a1: DIR, a2: ptr Dirent, a3: ptr ptr Dirent): cint  {.
+proc closedir*(a1: C_DIR): cint  {.importc, header: "<dirent.h>".}
+proc opendir*(a1: cstring): C_DIR {.importc, header: "<dirent.h>", sideEffect.}
+proc readdir*(a1: C_DIR): ptr Dirent  {.importc, header: "<dirent.h>", sideEffect.}
+proc readdir_r*(a1: C_DIR, a2: ptr Dirent, a3: ptr ptr Dirent): cint  {.
                 importc, header: "<dirent.h>", sideEffect.}
-proc rewinddir*(a1: DIR)  {.importc, header: "<dirent.h>".}
-proc seekdir*(a1: DIR, a2: int)  {.importc, header: "<dirent.h>".}
-proc telldir*(a1: DIR): int {.importc, header: "<dirent.h>".}
+proc rewinddir*(a1: C_DIR)  {.importc, header: "<dirent.h>".}
+proc seekdir*(a1: C_DIR, a2: int)  {.importc, header: "<dirent.h>".}
+proc telldir*(a1: C_DIR): int {.importc, header: "<dirent.h>".}
 
 # dlfcn.h
 proc dlclose*(a1: pointer): cint {.importc, header: "<dlfcn.h>", sideEffect.}

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -97,20 +97,17 @@ const StatHasNanoseconds* = defined(linux) or defined(freebsd) or
 
 # Platform common stuff (avoids repetition)
 
+type
+  DIR {.importc: "DIR", header: "<dirent.h>".} = object
+    ## on some systems, this is a forward declared type and should only
+    ## be used via pointer, ie via `C_DIR`
+  C_DIR*  = ptr DIR
+    ## A ptr type representing a directory stream.
+
 when defined(nimBackendHasPosixDIR):
   # This should be auto-detected, like NIM_EmulateOverflowChecks, by
-  # calling preprocessor, see https://github.com/nim-lang/RFCs/issues/205
-  # proposal 5.
-  type
-    DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-      ## on some systems, this is a forward declared type and should only
-      ## be used via pointer, ie via `C_DIR`
-    C_DIR* = ptr DIR
-      ## A ptr type representing a directory stream.
-else:
-  type
-    C_DIR* {.importc: "DIR*", header: "<dirent.h>".} = ptr object
-      ## A ptr type representing a directory stream.
+  # calling preprocessor, see https://github.com/nim-lang/RFCs/issues/205 prop 5
+  export DIR
 
 # Platform specific stuff
 

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -95,6 +95,13 @@ const StatHasNanoseconds* = defined(linux) or defined(freebsd) or
   ## without checking this flag, because this module defines fallback procs
   ## when they are not available.
 
+# Platform common stuff (avoids repetition)
+
+type
+  # DIR* {.importc: "DIR*", header: "<dirent.h>".} = ptr object
+  DIR* {.importc: "DIR12", header: "<dirent.h>".} = ptr object
+    ## A type representing a directory stream.
+
 # Platform specific stuff
 
 when (defined(linux) and not defined(android)) and defined(amd64):
@@ -166,14 +173,14 @@ proc IN6ADDR_ANY_INIT* (): In6Addr {.importc, header: "<netinet/in.h>".}
 proc IN6ADDR_LOOPBACK_INIT* (): In6Addr {.importc, header: "<netinet/in.h>".}
 
 # dirent.h
-proc closedir*(a1: ptr DIR): cint  {.importc, header: "<dirent.h>".}
-proc opendir*(a1: cstring): ptr DIR {.importc, header: "<dirent.h>", sideEffect.}
-proc readdir*(a1: ptr DIR): ptr Dirent  {.importc, header: "<dirent.h>", sideEffect.}
-proc readdir_r*(a1: ptr DIR, a2: ptr Dirent, a3: ptr ptr Dirent): cint  {.
+proc closedir*(a1: DIR): cint  {.importc, header: "<dirent.h>".}
+proc opendir*(a1: cstring): DIR {.importc, header: "<dirent.h>", sideEffect.}
+proc readdir*(a1: DIR): ptr Dirent  {.importc, header: "<dirent.h>", sideEffect.}
+proc readdir_r*(a1: DIR, a2: ptr Dirent, a3: ptr ptr Dirent): cint  {.
                 importc, header: "<dirent.h>", sideEffect.}
-proc rewinddir*(a1: ptr DIR)  {.importc, header: "<dirent.h>".}
-proc seekdir*(a1: ptr DIR, a2: int)  {.importc, header: "<dirent.h>".}
-proc telldir*(a1: ptr DIR): int {.importc, header: "<dirent.h>".}
+proc rewinddir*(a1: DIR)  {.importc, header: "<dirent.h>".}
+proc seekdir*(a1: DIR, a2: int)  {.importc, header: "<dirent.h>".}
+proc telldir*(a1: DIR): int {.importc, header: "<dirent.h>".}
 
 # dlfcn.h
 proc dlclose*(a1: pointer): cint {.importc, header: "<dlfcn.h>", sideEffect.}

--- a/lib/posix/posix_haiku.nim
+++ b/lib/posix/posix_haiku.nim
@@ -24,10 +24,6 @@ when defined(solaris):
   {.passl: "-lresolv".}
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-    ## A type representing a directory stream.
-
-type
   SocketHandle* = distinct cint # The type used to represent socket descriptors
 
 type

--- a/lib/posix/posix_haiku.nim
+++ b/lib/posix/posix_haiku.nim
@@ -24,8 +24,7 @@ when defined(solaris):
   {.passl: "-lresolv".}
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>",
-          incompleteStruct.} = object
+  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
     ## A type representing a directory stream.
 
 type

--- a/lib/posix/posix_linux_amd64.nim
+++ b/lib/posix/posix_linux_amd64.nim
@@ -27,10 +27,6 @@ when defined(nimHasStyleChecks):
 # Types
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-    ## A type representing a directory stream.
-
-type
   SocketHandle* = distinct cint # The type used to represent socket descriptors
 
 type

--- a/lib/posix/posix_linux_amd64.nim
+++ b/lib/posix/posix_linux_amd64.nim
@@ -27,8 +27,7 @@ when defined(nimHasStyleChecks):
 # Types
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>",
-          incompleteStruct.} = object
+  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
     ## A type representing a directory stream.
 
 type

--- a/lib/posix/posix_macos_amd64.nim
+++ b/lib/posix/posix_macos_amd64.nim
@@ -15,8 +15,7 @@ const
   hasAioH = false
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>",
-          incompleteStruct.} = object
+  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
     ## A type representing a directory stream.
 
 type

--- a/lib/posix/posix_macos_amd64.nim
+++ b/lib/posix/posix_macos_amd64.nim
@@ -15,10 +15,6 @@ const
   hasAioH = false
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-    ## A type representing a directory stream.
-
-type
   SocketHandle* = distinct cint # The type used to represent socket descriptors
 
 type

--- a/lib/posix/posix_nintendoswitch.nim
+++ b/lib/posix/posix_nintendoswitch.nim
@@ -13,9 +13,6 @@ const
   hasSpawnH = true
   hasAioH = false
 
-type
-  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-
 const SIG_HOLD* = cast[Sighandler](2)
 
 type

--- a/lib/posix/posix_nintendoswitch.nim
+++ b/lib/posix/posix_nintendoswitch.nim
@@ -14,8 +14,7 @@ const
   hasAioH = false
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>",
-          incompleteStruct.} = object
+  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
 
 const SIG_HOLD* = cast[Sighandler](2)
 

--- a/lib/posix/posix_openbsd_amd64.nim
+++ b/lib/posix/posix_openbsd_amd64.nim
@@ -15,8 +15,7 @@ const
   hasAioH = false
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>",
-          incompleteStruct.} = object
+  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
     ## A type representing a directory stream.
 
 type

--- a/lib/posix/posix_openbsd_amd64.nim
+++ b/lib/posix/posix_openbsd_amd64.nim
@@ -15,10 +15,6 @@ const
   hasAioH = false
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-    ## A type representing a directory stream.
-
-type
   SocketHandle* = distinct cint # The type used to represent socket descriptors
 
 type

--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -24,10 +24,6 @@ when defined(solaris):
   {.passl: "-lresolv".}
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
-    ## A type representing a directory stream.
-
-type
   SocketHandle* = distinct cint # The type used to represent socket descriptors
 
 type

--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -24,8 +24,7 @@ when defined(solaris):
   {.passl: "-lresolv".}
 
 type
-  DIR* {.importc: "DIR", header: "<dirent.h>",
-          incompleteStruct.} = object
+  DIR* {.importc: "DIR", header: "<dirent.h>".} = object
     ## A type representing a directory stream.
 
 type

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -112,8 +112,7 @@ proc c_signal*(sign: cint, handler: proc (a: cint) {.noconv.}): CSighandlerT {.
   importc: "signal", header: "<signal.h>", discardable.}
 
 type
-  CFile {.importc: "FILE", header: "<stdio.h>",
-          incompleteStruct.} = object
+  CFile {.importc: "FILE", header: "<stdio.h>".} = object
   CFilePtr* = ptr CFile ## The type representing a file handle.
 
 # duplicated between io and ansi_c

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -16,8 +16,7 @@ import formatfloat
 
 # ----------------- IO Part ------------------------------------------------
 type
-  CFile {.importc: "FILE", header: "<stdio.h>",
-          incompleteStruct.} = object
+  CFile {.importc: "FILE", header: "<stdio.h>".} = object
   File* = ptr CFile ## The type representing a file handle.
 
   FileMode* = enum           ## The file mode when opening a file.


### PR DESCRIPTION
EDIT: DO NOT REVIEW YET...

the meaning of `{.incompleteStruct.}` is for types like DIR (eg http://manpages.ubuntu.com/manpages/bionic/man7/dirent.h.7posix.html) which are forward declared, and hence for which sizeof (or accessing members or creating an instance on the stack etc) would result in cgen CT error on some platforms. Treating it like we used to (via `void*`) is clearly wrong though. Investigating how to best handle this... stay tuned.

THE DESCRIPTION BELOW NEEDS TO BE UPDATED


##
* followup on https://github.com/nim-lang/Nim/pull/13926 and addresses this: https://github.com/nim-lang/Nim/pull/13926#issuecomment-618288569
> needs a changelog entry and needs to be documented well

* implements proposal 2 from https://github.com/nim-lang/RFCs/issues/205 by turning {.incompleteStruct.} into a deprecated noop

incompleteStruct (only used on 2 types, DIR and FILE) is problematic because when that pragma was set but the type was in fact not forward decared, it resulted in incorrect typeinfo
```nim
when true: # D20200504T161748
  type CFile {.importc: "FILE", header: "<stdio.h>", incompleteStruct.} = object
  let a = newSeq[CFile](1000)
  dumpNumberOfInstances()
```
```
(with -d:nimTypeNames)
before PR:
[Heap] seq[CFile]: #1; bytes: 8032
[Heap] total number of bytes: 8032
[Heap] allocs/deallocs: 6/0

after PR:
[Heap] seq[CFile]: #1; bytes: 152032
[Heap] total number of bytes: 152032
[Heap] allocs/deallocs: 6/0
```
note that FILE is a struct in C, not a struct pointer, so treating it as `void*` was incorrect as can be seen with this:
```c
#include <stdio.h>
int main (int argc, char *argv[]) {
  printf("%d\n", sizeof(FILE));
  printf("%d\n", sizeof(FILE*));
  return 0;
}
```

## links
[When to use IncompleteStruct pragma? - Nim forum](https://forum.nim-lang.org/t/7180)
