### PR TITLE
make `from` an operator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -120,6 +120,8 @@
   with writing typed macros. Old behavior for backwards compatiblity can be restored
   with command line switch `--useVersion:1.0`.
 
+- The keyword `from` is now usable as an operator.
+
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.

--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -327,7 +327,7 @@ const
 
   splitters = openPars + {tkComma, tkSemiColon} # do not add 'tkColon' here!
   oprSet = {tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs,
-            tkIsnot, tkNot, tkOf, tkAs, tkDotDot, tkAnd, tkOr, tkXor}
+            tkIsnot, tkNot, tkOf, tkAs, tkFrom, tkDotDot, tkAnd, tkOr, tkXor}
 
 template goodCol(col): bool = col >= em.maxLineLen div 2
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -967,7 +967,7 @@ proc getPrecedence*(tok: TToken, strongSpaces: bool): int =
     of '?': result = 2
     else: considerAsgn(2)
   of tkDiv, tkMod, tkShl, tkShr: result = 9
-  of tkIn, tkNotin, tkIs, tkIsnot, tkOf, tkAs: result = 5
+  of tkIn, tkNotin, tkIs, tkIsnot, tkOf, tkAs, tkFrom: result = 5
   of tkDotDot: result = 6
   of tkAnd: result = 4
   of tkOr, tkXor, tkPtr, tkRef: result = 3

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -295,7 +295,7 @@ proc checkBinary(p: TParser) {.inline.} =
 #|
 #| operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9
 #|          | 'or' | 'xor' | 'and'
-#|          | 'is' | 'isnot' | 'in' | 'notin' | 'of'
+#|          | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as' | 'from'
 #|          | 'div' | 'mod' | 'shl' | 'shr' | 'not' | 'static' | '..'
 #|
 #| prefixOperator = operator
@@ -2194,6 +2194,7 @@ proc complexOrSimpleStmt(p: var TParser): PNode =
   #|                     | blockStmt | staticStmt | deferStmt | asmStmt
   #|                     | 'proc' routine
   #|                     | 'method' routine
+  #|                     | 'func' routine
   #|                     | 'iterator' routine
   #|                     | 'macro' routine
   #|                     | 'template' routine

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -269,7 +269,8 @@ proc isRightAssociative(tok: TToken): bool {.inline.} =
 proc isOperator(tok: TToken): bool =
   ## Determines if the given token is an operator type token.
   tok.tokType in {tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs,
-                  tkIsnot, tkNot, tkOf, tkAs, tkDotDot, tkAnd, tkOr, tkXor}
+                  tkIsnot, tkNot, tkOf, tkAs, tkFrom, tkDotDot, tkAnd,
+                  tkOr, tkXor}
 
 proc isUnary(p: TParser): bool =
   ## Check if the current parser token is a unary operator
@@ -555,7 +556,7 @@ proc parsePar(p: var TParser): PNode =
   optInd(p, result)
   flexComment(p, result)
   if p.tok.tokType in {tkDiscard, tkInclude, tkIf, tkWhile, tkCase,
-                       tkTry, tkDefer, tkFinally, tkExcept, tkFor, tkBlock,
+                       tkTry, tkDefer, tkFinally, tkExcept, tkBlock,
                        tkConst, tkLet, tkWhen, tkVar, tkFor,
                        tkMixin}:
     # XXX 'bind' used to be an expression, so we exclude it here;

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -6,7 +6,7 @@ colon = ':' COMMENT?
 colcom = ':' COMMENT?
 operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9
          | 'or' | 'xor' | 'and'
-         | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as'
+         | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as' | 'from' |
          | 'div' | 'mod' | 'shl' | 'shr' | 'not' | 'static' | '..'
 prefixOperator = operator
 optInd = COMMENT? IND?

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -565,7 +565,7 @@ following characters::
 defined here.)
 
 These keywords are also operators:
-``and or not xor shl shr div mod in notin is isnot of as``.
+``and or not xor shl shr div mod in notin is isnot of as from``.
 
 `.`:tok: `=`:tok:, `:`:tok:, `::`:tok: are not available as general operators; they
 are used for other notational purposes.
@@ -638,21 +638,21 @@ has the second lowest precedence.
 
 Otherwise precedence is determined by the first character.
 
-================  ==================================================  ==================  ===============
-Precedence level    Operators                                         First character     Terminal symbol
-================  ==================================================  ==================  ===============
- 10 (highest)                                                         ``$  ^``            OP10
-  9               ``*    /    div   mod   shl  shr  %``               ``*  %  \  /``      OP9
-  8               ``+    -``                                          ``+  -  ~  |``      OP8
-  7               ``&``                                               ``&``               OP7
-  6               ``..``                                              ``.``               OP6
-  5               ``==  <= < >= > !=  in notin is isnot not of as``   ``=  <  >  !``      OP5
-  4               ``and``                                                                 OP4
-  3               ``or xor``                                                              OP3
-  2                                                                   ``@  :  ?``         OP2
-  1               *assignment operator* (like ``+=``, ``*=``)                             OP1
-  0 (lowest)      *arrow like operator* (like ``->``, ``=>``)                             OP0
-================  ==================================================  ==================  ===============
+================  =======================================================  ==================  ===============
+Precedence level    Operators                                              First character     Terminal symbol
+================  =======================================================  ==================  ===============
+ 10 (highest)                                                              ``$  ^``            OP10
+  9               ``*    /    div   mod   shl  shr  %``                    ``*  %  \  /``      OP9
+  8               ``+    -``                                               ``+  -  ~  |``      OP8
+  7               ``&``                                                    ``&``               OP7
+  6               ``..``                                                   ``.``               OP6
+  5               ``==  <= < >= > !=  in notin is isnot not of as from``   ``=  <  >  !``      OP5
+  4               ``and``                                                                      OP4
+  3               ``or xor``                                                                   OP3
+  2                                                                        ``@  :  ?``         OP2
+  1               *assignment operator* (like ``+=``, ``*=``)                                  OP1
+  0 (lowest)      *arrow like operator* (like ``->``, ``=>``)                                  OP0
+================  =======================================================  ==================  ===============
 
 
 Whether an operator is used a prefix operator is also affected by preceding

--- a/tests/parser/tstatementoperators.nim
+++ b/tests/parser/tstatementoperators.nim
@@ -1,5 +1,5 @@
 discard """
-  output: '''
+  nimout: '''
 Infix
   Ident "from"
   Ident "a"

--- a/tests/parser/tstatementoperators.nim
+++ b/tests/parser/tstatementoperators.nim
@@ -1,0 +1,12 @@
+discard """
+  output: '''
+Infix
+  Ident "from"
+  Ident "a"
+  Ident "b"
+'''
+"""
+
+from macros import dumpTree
+
+dumpTree(a from b)


### PR DESCRIPTION
Just extra syntax (for DSLs and macros) to use. I don't see any downsides to this.

There are other keywords that work fine when made operators, but may be limited to infix only. `for`, `if`, `else`, `when`, `while` with precedence 1 can be used for list comprehensions (though you have to do `a if b for c in d` unlike python) or postfix conditionals, and `using` is just an English word that sounds normal when used as `a using b`. 