### PR TITLE
fixes #14244

### DIFF
--- a/compiler/liftdestructors.nim
+++ b/compiler/liftdestructors.nim
@@ -780,11 +780,11 @@ proc produceSymDistinctType(g: ModuleGraph; c: PContext; typ: PType;
   typ.attachedOps[kind] = baseType.attachedOps[kind]
   result = typ.attachedOps[kind]
 
-proc symPrototype(g: ModuleGraph; typ: PType; kind: TTypeAttachedOp;
+proc symPrototype(g: ModuleGraph; typ: PType; owner: PSym; kind: TTypeAttachedOp;
               info: TLineInfo): PSym =
 
   let procname = getIdent(g.cache, AttachedOpToStr[kind])
-  result = newSym(skProc, procname, typ.owner, info)
+  result = newSym(skProc, procname, owner, info)
   let dest = newSym(skParam, getIdent(g.cache, "dest"), result, info)
   let src = newSym(skParam, getIdent(g.cache, if kind == attachedTrace: "env" else: "src"), result, info)
   dest.typ = makeVarType(typ.owner, typ)
@@ -793,7 +793,7 @@ proc symPrototype(g: ModuleGraph; typ: PType; kind: TTypeAttachedOp;
   else:
     src.typ = typ
 
-  result.typ = newProcType(info, typ.owner)
+  result.typ = newProcType(info, owner)
   result.typ.addParam dest
   if kind notin {attachedDestructor, attachedDispose}:
     result.typ.addParam src
@@ -813,7 +813,7 @@ proc produceSym(g: ModuleGraph; c: PContext; typ: PType; kind: TTypeAttachedOp;
   if typ.kind == tyDistinct:
     return produceSymDistinctType(g, c, typ, kind, info)
 
-  result = symPrototype(g, typ, kind, info)
+  result = symPrototype(g, typ, typ.owner, kind, info)
   var a = TLiftCtx(info: info, g: g, kind: kind, c: c, asgnForType:typ)
   a.fn = result
 
@@ -847,8 +847,8 @@ proc produceSym(g: ModuleGraph; c: PContext; typ: PType; kind: TTypeAttachedOp;
 
 
 proc produceDestructorForDiscriminator*(g: ModuleGraph; typ: PType; field: PSym, info: TLineInfo): PSym =
-  assert(typ.kind == tyObject)
-  result = symPrototype(g, field.typ, attachedDestructor, info)
+  assert(typ.skipTypes({tyAlias, tyGenericInst}).kind == tyObject)
+  result = symPrototype(g, field.typ, typ.owner, attachedDestructor, info)
   var a = TLiftCtx(info: info, g: g, kind: attachedDestructor, asgnForType: typ)
   a.fn = result
   a.asgnForType = typ

--- a/tests/arc/tcaseobj.nim
+++ b/tests/arc/tcaseobj.nim
@@ -9,6 +9,7 @@ B
 begin
 end
 prevented
+(ok: true, value: "ok")
 myobj destroyed
 '''
 """
@@ -193,3 +194,21 @@ proc test_myobject =
 test_myobject()
 
 
+
+
+#------------------------------------------------
+# bug #14244
+
+type
+  RocksDBResult*[T] = object
+    case ok*: bool
+    of true:
+      value*: T
+    else:
+      error*: string
+
+proc init(): RocksDBResult[string] =
+  result.ok = true
+  result.value = "ok"
+
+echo init()


### PR DESCRIPTION
For the fix it is enough to fix assert line:
```nim
assert(typ.skipTypes({tyAlias, tyGenericInst}).kind == tyObject)
```

I also decided to fix one more issue with owner info. Generated discriminator destructor appeared in system module if discriminator type is `bool`. Now it belongs to the module where object type is defined not the discriminator type.
