### PR TITLE
Allow let to not have value when using importc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -120,6 +120,9 @@
   with writing typed macros. Old behavior for backwards compatiblity can be restored
   with command line switch `--useVersion:1.0`.
 
+- ``let`` statements can now be used without a value if declared with
+  ``importc``/``importcpp``/``importjs``/``importobjc``.
+
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -532,7 +532,16 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
             # into an unowned pointer.
             typ = typ.lastSon
     else:
-      if symkind == skLet: localError(c.config, a.info, errLetNeedsInit)
+      if symkind == skLet:
+        # check if the importc pragma is declared, if so we don't
+        # require initialisation, hopefully C has done that.
+        var importc = false
+        if n[i][0].kind == nkPragmaExpr:
+          for pragma in n[i][0][1].sons:
+            if $pragma == "importc":
+              importc = true
+        if not importc:
+          localError(c.config, a.info, errLetNeedsInit)
 
     # this can only happen for errornous var statements:
     if typ == nil: continue

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2679,6 +2679,11 @@ nor can their address be taken. They cannot be assigned new values.
 
 For let variables the same pragmas are available as for ordinary variables.
 
+As ``let`` statements are immutable after creation they need to define a value
+when they are declared. The only exception to this is if the ``{.importc.}``
+pragma (or any of the other ``importX`` pragmas) is applied, in this case the
+value is expected to come from native code, typically a C/C++ ``const``.
+
 
 Tuple unpacking
 ---------------
@@ -7066,6 +7071,16 @@ spelled*:
 
 .. code-block::
   proc printf(formatstr: cstring) {.header: "<stdio.h>", importc: "printf", varargs.}
+
+When ``importc`` is applied to a ``let`` statement it can omit its value which
+will then be expected to come from C. This can be used to import a C ``const``:
+
+.. code-block::
+  {.emit: "const int cconst = 42;".}
+
+  let cconst {.importc, nodecl.}: cint
+
+  assert cconst == 42
 
 Note that this pragma has been abused in the past to also work in the
 js backend for js objects and functions. : Other backends do provide

--- a/tests/let/timportc.nim
+++ b/tests/let/timportc.nim
@@ -4,13 +4,21 @@ targets: "c cpp js"
 
 when defined(c) or defined(cpp):
   {.emit:"""
-  const int TEST = 123;
+  const int TEST1 = 123;
+  #define TEST2 321
   """.}
 
 when defined(js):
   {.emit:"""
-  const TEST = 123;
+  const TEST1 = 123;
+  const TEST2 = 321; // JS doesn't have macros, so we just duplicate
   """.}
 
-let TEST {.importc, nodecl.}: cint
-doAssert TEST == 123
+let
+  TEST0 = 1
+  TEST1 {.importc, nodecl.}: cint
+  TEST2 {.importc, nodecl.}: cint
+
+doAssert TEST0 == 1
+doAssert TEST1 == 123
+doAssert TEST2 == 321

--- a/tests/let/timportc.nim
+++ b/tests/let/timportc.nim
@@ -1,10 +1,16 @@
 discard """
-  exitcode: 0
-  output: "42"
+targets: "c cpp js"
 """
 
-{.emit: "const int TEST = 42;".}
+when defined(c) or defined(cpp):
+  {.emit:"""
+  const int TEST = 123;
+  """.}
+
+when defined(js):
+  {.emit:"""
+  const TEST = 123;
+  """.}
 
 let TEST {.importc, nodecl.}: cint
-
-echo TEST
+doAssert TEST == 123

--- a/tests/let/timportc.nim
+++ b/tests/let/timportc.nim
@@ -1,0 +1,10 @@
+discard """
+  exitcode: 0
+  output: "42"
+"""
+
+{.emit: "const int TEST = 42;".}
+
+let TEST {.importc, nodecl.}: cint
+
+echo TEST

--- a/tests/let/timportc2.nim
+++ b/tests/let/timportc2.nim
@@ -1,0 +1,8 @@
+discard """
+  errormsg: "'let' symbol requires an initialization"
+  line: "7"
+"""
+
+# Test that this still works when not annotated with importc
+let test: cint
+echo test


### PR DESCRIPTION
This allows a let statement with the `{.importc.}` pragma to not be
initialised with a value. This allows us to declare C constants as Nim
lets without putting the value in the Nim code (which can lead to
errors, and requires us to go looking for the value). Fixes #14253