### PR TITLE
tslow_tables: wait for an additional 2 seconds

### DIFF
--- a/tests/vm/tslow_tables.nim
+++ b/tests/vm/tslow_tables.nim
@@ -1,5 +1,5 @@
 discard """
-  timeout: "5"
+  timeout: "7"
   action: "compile"
   nimout: '''create
 search


### PR DESCRIPTION
This test runtime tends to hover around the 5s mark depending on how
loaded the system currently is. This causes the test to fail a lot
during CI, per analytics:
https://dev.azure.com/nim-lang/Nim/_test/analytics?definitionId=1&contextType=build

Give the test an extra 2 seconds to account for unrelated overhead.