### PR TITLE
`nim doc --backend:js`, `nim doc --doccmd:-d:foo`, `nim r --backend:js`, `--doccmd:skip` + other improvements

### DIFF
--- a/compiler/ccgthreadvars.nim
+++ b/compiler/ccgthreadvars.nim
@@ -46,7 +46,7 @@ proc generateThreadLocalStorage(m: BModule) =
 
 proc generateThreadVarsSize(m: BModule) =
   if m.g.nimtv != nil:
-    let externc = if m.config.cmd == cmdCompileToCpp or
+    let externc = if m.config.backend == backendCpp or
                        sfCompileToCpp in m.module.flags: "extern \"C\" "
                   else: ""
     m.s[cfsProcs].addf(

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -279,7 +279,7 @@ proc genProc(m: BModule, prc: PSym)
 proc raiseInstr(p: BProc): Rope
 
 template compileToCpp(m: BModule): untyped =
-  m.config.cmd == cmdCompileToCpp or sfCompileToCpp in m.module.flags
+  m.config.backend == backendCpp or sfCompileToCpp in m.module.flags
 
 proc getTempName(m: BModule): Rope =
   result = m.tmpBase & rope(m.labels)
@@ -1066,11 +1066,11 @@ proc genProcAux(m: BModule, prc: PSym) =
 proc requiresExternC(m: BModule; sym: PSym): bool {.inline.} =
   result = (sfCompileToCpp in m.module.flags and
            sfCompileToCpp notin sym.getModule().flags and
-           m.config.cmd != cmdCompileToCpp) or (
+           m.config.backend != backendCpp) or (
            sym.flags * {sfInfixCall, sfCompilerProc, sfMangleCpp} == {} and
            sym.flags * {sfImportc, sfExportc} != {} and
            sym.magic == mNone and
-           m.config.cmd == cmdCompileToCpp)
+           m.config.backend == backendCpp)
 
 proc genProcPrototype(m: BModule, sym: PSym) =
   useHeader(m, sym)
@@ -1867,7 +1867,7 @@ proc writeHeader(m: BModule) =
 proc getCFile(m: BModule): AbsoluteFile =
   let ext =
       if m.compileToCpp: ".nim.cpp"
-      elif m.config.cmd == cmdCompileToOC or sfCompileToObjc in m.module.flags: ".nim.m"
+      elif m.config.backend == backendObjc or sfCompileToObjc in m.module.flags: ".nim.m"
       else: ".nim.c"
   result = changeFileExt(completeCfilePath(m.config, withPackageName(m.config, m.cfilename)), ext)
 

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -78,7 +78,8 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
   # XXX This is hacky. We need to find a better way.
   case conf.command
   of "cpp", "compiletocpp":
-    conf.cmd = cmdCompileToCpp
+    conf.backend = backendCpp
+    conf.cmd = cmdCompileToBackend
   else:
     discard
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -434,6 +434,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "outdir":
     expectArg(conf, switch, arg, pass, info)
     conf.outDir = processPath(conf, arg, info, notRelativeToProj=true)
+  of "usenimcache":
+    processOnOffSwitchG(conf, {optUseNimcache}, arg, pass, info)
   of "docseesrcurl":
     expectArg(conf, switch, arg, pass, info)
     conf.docSeeSrcUrl = arg

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -439,6 +439,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.docSeeSrcUrl = arg
   of "docroot":
     conf.docRoot = if arg.len == 0: "@default" else: arg
+  of "backend":
+    let backend = parseEnum(arg.normalize, TBackend.default)
+    if backend == TBackend.default: localError(conf, info, "invalid backend: '$1'" % arg)
+    conf.backend = backend
+  of "doccmd": conf.docCmd = arg
   of "mainmodule", "m":
     discard "allow for backwards compatibility, but don't do anything"
   of "define", "d":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -439,7 +439,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.docSeeSrcUrl = arg
   of "docroot":
     conf.docRoot = if arg.len == 0: "@default" else: arg
-  of "backend":
+  of "backend", "b":
     let backend = parseEnum(arg.normalize, TBackend.default)
     if backend == TBackend.default: localError(conf, info, "invalid backend: '$1'" % arg)
     conf.backend = backend

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -500,7 +500,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
         defineSymbol(conf.symbols, "gcmarkandsweep")
       of "destructors", "arc":
         conf.selectedGC = gcArc
-        if conf.cmd != cmdCompileToCpp:
+        if conf.backend != backendCpp:
           conf.exc = excGoto
         defineSymbol(conf.symbols, "gcdestructors")
         defineSymbol(conf.symbols, "gcarc")
@@ -511,7 +511,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
           defineSymbol(conf.symbols, "nimV2")
       of "orc":
         conf.selectedGC = gcOrc
-        if conf.cmd != cmdCompileToCpp:
+        if conf.backend != backendCpp:
           conf.exc = excGoto
         defineSymbol(conf.symbols, "gcdestructors")
         defineSymbol(conf.symbols, "gcorc")

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -449,19 +449,21 @@ proc runAllExamples(d: PDoc) =
   # This used to be: `let backend = if isDefined(d.conf, "js"): "js"` (etc), however
   # using `-d:js` (etc) cannot work properly, eg would fail with `importjs`
   # since semantics are affected by `config.backend`, not by isDefined(d.conf, "js")
+  echo0b docCmd, backend
   if d.examples.len == 0 or docCmd == "skip": return
   let outputDir = d.conf.getNimcacheDir / RelativeDir"runnableExamples"
   let outp = outputDir / RelativeFile(extractFilename(d.filename.changeFileExt"" &
       "_examples.nim"))
   writeFile(outp, d.examples)
-  let cmd = "$nim $backend --warning:UnusedImport:off --path:$path --nimcache:$nimcache $docCmd $file" % [
+  let cmd = "$nim $backend -r --warning:UnusedImport:off --path:$path --nimcache:$nimcache $docCmd $file" % [
     "nim", os.getAppFilename(),
-    "backend", d.conf.backend,
+    "backend", $d.conf.backend,
     "path", quoteShell(d.conf.projectPath),
     "nimcache", quoteShell(outputDir),
     "file", quoteShell(outp),
     "docCmd", docCmd,
   ]
+  echo0b cmd
   if os.execShellCmd(cmd) != 0:
     quit "[runnableExamples] failed: generated file: '$1' cmd: $2" % [outp.string, cmd]
   else:

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -446,16 +446,14 @@ proc testExample(d: PDoc; ex: PNode) =
 proc runAllExamples(d: PDoc) =
   let docCmd = d.conf.docCmd
   let backend = d.conf.backend
+  # This used to be: `let backend = if isDefined(d.conf, "js"): "js"` (etc), however
+  # using `-d:js` (etc) cannot work properly, eg would fail with `importjs`
+  # since semantics are affected by `config.backend`, not by isDefined(d.conf, "js")
   if d.examples.len == 0 or docCmd == "skip": return
   let outputDir = d.conf.getNimcacheDir / RelativeDir"runnableExamples"
   let outp = outputDir / RelativeFile(extractFilename(d.filename.changeFileExt"" &
       "_examples.nim"))
   writeFile(outp, d.examples)
-
-  # This used to be: `let backend = if isDefined(d.conf, "js"): "js"` (etc), however
-  # using `-d:js` cannot work properly and should yield a warning, eg will fail
-  # with compiler code that depends on `cmdCompileToJS` (eg for `importjs`).
-
   let cmd = "$nim $backend --warning:UnusedImport:off --path:$path --nimcache:$nimcache $docCmd $file" % [
     "nim", os.getAppFilename(),
     "backend", d.conf.backend,

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -22,6 +22,7 @@ import
 const
   exportSection = skField
   htmldocsDir = RelativeDir"htmldocs"
+  docCmdSkip = "skip"
 
 type
   TSections = array[TSymKind, Rope]
@@ -196,6 +197,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
   initStrTable result.types
   result.onTestSnippet =
     proc (gen: var RstGenerator; filename, cmd: string; status: int; content: string) =
+      if conf.docCmd == docCmdSkip: return
       inc(gen.id)
       var d = TDocumentor(gen)
       var outp: AbsoluteFile
@@ -449,7 +451,7 @@ proc runAllExamples(d: PDoc) =
   # This used to be: `let backend = if isDefined(d.conf, "js"): "js"` (etc), however
   # using `-d:js` (etc) cannot work properly, eg would fail with `importjs`
   # since semantics are affected by `config.backend`, not by isDefined(d.conf, "js")
-  if d.examples.len == 0 or docCmd == "skip": return
+  if d.examples.len == 0 or docCmd == docCmdSkip: return
   let outputDir = d.conf.getNimcacheDir / RelativeDir"runnableExamples"
   let outp = outputDir / RelativeFile(extractFilename(d.filename.changeFileExt"" &
       "_examples.nim"))

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1123,11 +1123,10 @@ proc genOutFile(d: PDoc): Rope =
   let bodyname = if d.hasToc and not d.isPureRst: "doc.body_toc_group"
                  elif d.hasToc: "doc.body_toc"
                  else: "doc.body_no_toc"
-  let gitUrl = getConfigVar(d.conf, "git.url")
   content = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, bodyname), ["title",
-      "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "url"],
+      "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg"],
       [title.rope, toc, d.modDesc, rope(getDateStr()),
-      rope(getClockStr()), code, d.modDeprecationMsg, rope gitUrl])
+      rope(getClockStr()), code, d.modDeprecationMsg])
   if optCompileOnly notin d.conf.globalOptions:
     # XXX what is this hack doing here? 'optCompileOnly' means raw output!?
     code = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.file"), [

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -449,7 +449,6 @@ proc runAllExamples(d: PDoc) =
   # This used to be: `let backend = if isDefined(d.conf, "js"): "js"` (etc), however
   # using `-d:js` (etc) cannot work properly, eg would fail with `importjs`
   # since semantics are affected by `config.backend`, not by isDefined(d.conf, "js")
-  echo0b docCmd, backend
   if d.examples.len == 0 or docCmd == "skip": return
   let outputDir = d.conf.getNimcacheDir / RelativeDir"runnableExamples"
   let outp = outputDir / RelativeFile(extractFilename(d.filename.changeFileExt"" &
@@ -463,7 +462,6 @@ proc runAllExamples(d: PDoc) =
     "file", quoteShell(outp),
     "docCmd", docCmd,
   ]
-  echo0b cmd
   if os.execShellCmd(cmd) != 0:
     quit "[runnableExamples] failed: generated file: '$1' cmd: $2" % [outp.string, cmd]
   else:

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -623,8 +623,6 @@ proc footprint(conf: ConfigRef; cfile: Cfile): SecureHash =
     getCompileCFileCmd(conf, cfile))
 
 proc externalFileChanged(conf: ConfigRef; cfile: Cfile): bool =
-  # PRTEMP nim doc?
-  echo0b (conf.backend,"D20200507T233616")
   case conf.backend
   of backendInvalid: doAssert false
   of backendJs: return false # pre-existing behavior, but not sure it's good

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -308,10 +308,11 @@ proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
   # for niminst support
   let fullSuffix =
     case conf.backend
-    of backendC, backendCpp, backendJs, backendObjc: "." & $conf.backend & suffix
+    of backendCpp, backendJs, backendObjc: "." & $conf.backend & suffix
+    of backendC: suffix
     else:
-      # CHECKME
-      suffix
+      doAssert false
+      ""
 
   if (conf.target.hostOS != conf.target.targetOS or conf.target.hostCPU != conf.target.targetCPU) and
       optCompileOnly notin conf.globalOptions:

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -308,7 +308,7 @@ proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
   # for niminst support
   let fullSuffix =
     case conf.backend
-    of backendC, backendCpp, backendJs, backendObjc: "." & conf.backend & suffix
+    of backendC, backendCpp, backendJs, backendObjc: "." & $conf.backend & suffix
     else:
       # CHECKME
       suffix
@@ -625,8 +625,10 @@ proc footprint(conf: ConfigRef; cfile: Cfile): SecureHash =
 proc externalFileChanged(conf: ConfigRef; cfile: Cfile): bool =
   # PRTEMP nim doc?
   echo0b (conf.backend,"D20200507T233616")
-  if conf.backend notin {backendC, backendCpp, backendObjc, backendLlvm}:
-    return false
+  case conf.backend
+  of backendInvalid: doAssert false
+  of backendJs: return false # pre-existing behavior, but not sure it's good
+  else: discard
 
   var hashFile = toGeneratedFile(conf, conf.withPackageName(cfile.cname), "sha1")
   var currentHash = footprint(conf, cfile)

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -235,7 +235,7 @@ template isIterator*(owner: PSym): bool =
 proc liftingHarmful(conf: ConfigRef; owner: PSym): bool {.inline.} =
   ## lambda lifting can be harmful for JS-like code generators.
   let isCompileTime = sfCompileTime in owner.flags or owner.kind == skMacro
-  result = conf.cmd == cmdCompileToJS and not isCompileTime
+  result = conf.backend == backendJs and not isCompileTime
 
 proc createTypeBoundOpsLL(g: ModuleGraph; refType: PType; info: TLineInfo; owner: PSym) =
   createTypeBoundOps(g, nil, refType.lastSon, info)
@@ -846,14 +846,14 @@ proc liftIterToProc*(g: ModuleGraph; fn: PSym; body: PNode; ptrType: PType): PNo
   fn.typ.callConv = oldCC
 
 proc liftLambdas*(g: ModuleGraph; fn: PSym, body: PNode; tooEarly: var bool): PNode =
-  # XXX gCmd == cmdCompileToJS does not suffice! The compiletime stuff needs
+  # XXX backend == backendJs does not suffice! The compiletime stuff needs
   # the transformation even when compiling to JS ...
 
   # However we can do lifting for the stuff which is *only* compiletime.
   let isCompileTime = sfCompileTime in fn.flags or fn.kind == skMacro
 
   if body.kind == nkEmpty or (
-      g.config.cmd == cmdCompileToJS and not isCompileTime) or
+      g.config.backend == backendJs and not isCompileTime) or
       fn.skipGenericOwner.kind != skModule:
 
     # ignore forward declaration:

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -189,6 +189,11 @@ proc mainCommand*(graph: ModuleGraph) =
   conf.searchPaths.add(conf.libpath)
   setId(100)
 
+  ## Calling `setOutDir(conf)` unconditionally would fix regression
+  ## https://github.com/nim-lang/Nim/issues/6583#issuecomment-625711125
+  when false: setOutDir(conf)
+  if optUseNimcache in conf.globalOptions: setOutDir(conf)
+
   template handleBackend(backend2: TBackend) =
     conf.backend = backend2
     conf.cmd = cmdCompileToBackend

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -192,7 +192,7 @@ proc mainCommand*(graph: ModuleGraph) =
   setId(100)
   template handleC() =
     conf.backend = backendC
-    conf.cmd = cmdCompileToC
+    conf.cmd = cmdCompileToBackend
     if conf.exc == excNone: conf.exc = excSetjmp
     defineSymbol(graph.config.symbols, "c")
     commandCompileToC(graph)
@@ -200,13 +200,13 @@ proc mainCommand*(graph: ModuleGraph) =
   of "c", "cc", "compile", "compiletoc": handleC() # compile means compileToC currently
   of "cpp", "compiletocpp":
     conf.backend = backendCpp
-    conf.cmd = cmdCompileToCpp
+    conf.cmd = cmdCompileToBackend
     if conf.exc == excNone: conf.exc = excCpp
     defineSymbol(graph.config.symbols, "cpp")
     commandCompileToC(graph)
   of "objc", "compiletooc":
     conf.backend = backendObjc
-    conf.cmd = cmdCompileToOC
+    conf.cmd = cmdCompileToBackend
     defineSymbol(graph.config.symbols, "objc")
     commandCompileToC(graph)
   of "r": # different from `"run"`!
@@ -224,7 +224,7 @@ proc mainCommand*(graph: ModuleGraph) =
       quit "compiler wasn't built with JS code generator"
     else:
       conf.backend = backendJs
-      conf.cmd = cmdCompileToJS
+      conf.cmd = cmdCompileToBackend
       if conf.hcrOn:
         # XXX: At the moment, system.nim cannot be compiled in JS mode
         # with "-d:useNimRtl". The HCR option has been processed earlier

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -119,8 +119,7 @@ when not defined(leanCompiler):
     let conf = graph.config
     conf.exc = excCpp
 
-    if conf.outDir.isEmpty:
-      conf.outDir = conf.projectPath
+    setOutDir(conf)
     if conf.outFile.isEmpty:
       conf.outFile = RelativeFile(conf.projectName & ".js")
 
@@ -128,7 +127,6 @@ when not defined(leanCompiler):
     setTarget(graph.config.target, osJS, cpuJS)
     #initDefines()
     defineSymbol(graph.config.symbols, "ecmascript") # For backward compatibility
-    defineSymbol(graph.config.symbols, "js")
     semanticPasses(graph)
     registerPass(graph, JSgenPass)
     compileProject(graph)
@@ -190,28 +188,41 @@ proc mainCommand*(graph: ModuleGraph) =
   conf.lastCmdTime = epochTime()
   conf.searchPaths.add(conf.libpath)
   setId(100)
-  template handleC() =
-    conf.backend = backendC
+
+  template handleBackend(backend2: TBackend) =
+    conf.backend = backend2
     conf.cmd = cmdCompileToBackend
-    if conf.exc == excNone: conf.exc = excSetjmp
-    defineSymbol(graph.config.symbols, "c")
-    commandCompileToC(graph)
+    defineSymbol(graph.config.symbols, $backend2)
+    case backend2
+    of backendC:
+      if conf.exc == excNone: conf.exc = excSetjmp
+      commandCompileToC(graph)
+    of backendCpp:
+      if conf.exc == excNone: conf.exc = excCpp
+      commandCompileToC(graph)
+    of backendObjc:
+      commandCompileToC(graph)
+    of backendJs:
+      when defined(leanCompiler):
+        globalError(conf, unknownLineInfo, "compiler wasn't built with JS code generator")
+      else:
+        if conf.hcrOn:
+          # XXX: At the moment, system.nim cannot be compiled in JS mode
+          # with "-d:useNimRtl". The HCR option has been processed earlier
+          # and it has added this define implictly, so we must undo that here.
+          # A better solution might be to fix system.nim
+          undefSymbol(conf.symbols, "useNimRtl")
+        commandCompileToJS(graph)
+    of backendInvalid: doAssert false
+
   case conf.command.normalize
-  of "c", "cc", "compile", "compiletoc": handleC() # compile means compileToC currently
-  of "cpp", "compiletocpp":
-    conf.backend = backendCpp
-    conf.cmd = cmdCompileToBackend
-    if conf.exc == excNone: conf.exc = excCpp
-    defineSymbol(graph.config.symbols, "cpp")
-    commandCompileToC(graph)
-  of "objc", "compiletooc":
-    conf.backend = backendObjc
-    conf.cmd = cmdCompileToBackend
-    defineSymbol(graph.config.symbols, "objc")
-    commandCompileToC(graph)
+  of "c", "cc", "compile", "compiletoc": handleBackend(backendC) # compile means compileToC currently
+  of "cpp", "compiletocpp": handleBackend(backendCpp)
+  of "objc", "compiletooc": handleBackend(backendObjc)
+  of "js", "compiletojs": handleBackend(backendJs)
   of "r": # different from `"run"`!
     conf.globalOptions.incl {optRun, optUseNimcache}
-    handleC()
+    handleBackend(conf.backend)
   of "run":
     conf.cmd = cmdRun
     when hasTinyCBackend:
@@ -219,19 +230,6 @@ proc mainCommand*(graph: ModuleGraph) =
       commandCompileToC(graph)
     else:
       rawMessage(conf, errGenerated, "'run' command not available; rebuild with -d:tinyc")
-  of "js", "compiletojs":
-    when defined(leanCompiler):
-      quit "compiler wasn't built with JS code generator"
-    else:
-      conf.backend = backendJs
-      conf.cmd = cmdCompileToBackend
-      if conf.hcrOn:
-        # XXX: At the moment, system.nim cannot be compiled in JS mode
-        # with "-d:useNimRtl". The HCR option has been processed earlier
-        # and it has added this define implictly, so we must undo that here.
-        # A better solution might be to fix system.nim
-        undefSymbol(conf.symbols, "useNimRtl")
-      commandCompileToJS(graph)
   of "doc0":
     when defined(leanCompiler):
       quit "compiler wasn't built with documentation generator"

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -191,6 +191,7 @@ proc mainCommand*(graph: ModuleGraph) =
   conf.searchPaths.add(conf.libpath)
   setId(100)
   template handleC() =
+    conf.backend = backendC
     conf.cmd = cmdCompileToC
     if conf.exc == excNone: conf.exc = excSetjmp
     defineSymbol(graph.config.symbols, "c")
@@ -198,11 +199,13 @@ proc mainCommand*(graph: ModuleGraph) =
   case conf.command.normalize
   of "c", "cc", "compile", "compiletoc": handleC() # compile means compileToC currently
   of "cpp", "compiletocpp":
+    conf.backend = backendCpp
     conf.cmd = cmdCompileToCpp
     if conf.exc == excNone: conf.exc = excCpp
     defineSymbol(graph.config.symbols, "cpp")
     commandCompileToC(graph)
   of "objc", "compiletooc":
+    conf.backend = backendObjc
     conf.cmd = cmdCompileToOC
     defineSymbol(graph.config.symbols, "objc")
     commandCompileToC(graph)
@@ -220,6 +223,7 @@ proc mainCommand*(graph: ModuleGraph) =
     when defined(leanCompiler):
       quit "compiler wasn't built with JS code generator"
     else:
+      conf.backend = backendJs
       conf.cmd = cmdCompileToJS
       if conf.hcrOn:
         # XXX: At the moment, system.nim cannot be compiled in JS mode

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -90,12 +90,12 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
     let output = conf.absOutFile
     case conf.cmd
     of cmdCompileToBackend:
-      var runcmd = output.quoteShell & ' ' & conf.arguments
+      var cmdPrefix = ""
       case conf.backend
-      of backendC, backendCpp, backendOC: discard
-      of backendJS: runcmd = findNodeJs() & " " & runcmd
+      of backendC, backendCpp, backendObjc: discard
+      of backendJs: cmdPrefix = findNodeJs() & " "
       else: doAssert false, $conf.backend
-      execExternalProgram(conf, runcmd)
+      execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)
     of cmdDoc, cmdRst2html:
       if conf.arguments.len > 0:
         # reserved for future use

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -88,17 +88,19 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       tccgen.run(conf, conf.arguments)
   if optRun in conf.globalOptions:
     let output = conf.absOutFile
-    let ex = quoteShell output
     case conf.cmd
-    of cmdCompileToJS:
-      execExternalProgram(conf, findNodeJs() & " " & ex & ' ' & conf.arguments)
+    of cmdCompileToBackend:
+      var runcmd = output.quoteShell & ' ' & conf.arguments
+      case conf.backend
+      of backendC, backendCpp, backendOC: discard
+      of backendJS: runcmd = findNodeJs() & " " & runcmd
+      else: doAssert false, $conf.backend
+      execExternalProgram(conf, runcmd)
     of cmdDoc, cmdRst2html:
       if conf.arguments.len > 0:
         # reserved for future use
         rawMessage(conf, errGenerated, "'$1 cannot handle arguments" % [$conf.cmd])
       openDefaultBrowser($output)
-    of cmdCompileToC, cmdCompileToCpp, cmdCompileToOC:
-      execExternalProgram(conf, ex & ' ' & conf.arguments)
     else:
       # support as needed
       rawMessage(conf, errGenerated, "'$1 cannot handle --run" % [$conf.cmd])

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -105,6 +105,14 @@ const
                       optUseColors, optStdout}
 
 type
+  TBackend* = enum
+    backendInvalid = ""
+    backendC = "c"
+    backendCpp = "cpp"
+    backendJs = "js"
+    backendObjc = "objc"
+
+type
   TCommands* = enum           # Nim's commands
                               # **keep binary compatible**
     cmdNone, cmdCompileToC, cmdCompileToCpp, cmdCompileToOC,
@@ -274,6 +282,7 @@ type
     docSeeSrcUrl*: string # if empty, no seeSrc will be generated. \
     # The string uses the formatting variables `path` and `line`.
     docRoot*: string ## see nim --fullhelp for --docRoot
+    docCmd*: string ## see nim --fullhelp for --docCmd
 
      # the used compiler
     cIncludes*: seq[AbsoluteDir]  # directories to search for included files
@@ -402,7 +411,7 @@ proc newConfigRef*(): ConfigRef =
     cIncludes: @[],   # directories to search for included files
     cLibs: @[],       # directories to search for lib files
     cLinkedLibs: @[],  # libraries to link
-
+    backend: backendC,
     externalToLink: @[],
     linkOptionsCmd: "",
     compileOptionsCmd: @[],

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -539,7 +539,10 @@ proc setConfigVar*(conf: ConfigRef; key, val: string) =
   conf.configVars[key] = val
 
 proc getOutFile*(conf: ConfigRef; filename: RelativeFile, ext: string): AbsoluteFile =
-  conf.outDir / changeFileExt(filename, ext)
+  # explains regression https://github.com/nim-lang/Nim/issues/6583#issuecomment-625711125
+  # Yet another reason why "" should not mean ".";  `""/something` should raise
+  # instead of implying "" == "." as it's bug prone.
+  result = conf.outDir / changeFileExt(filename, ext)
 
 proc absOutFile*(conf: ConfigRef): AbsoluteFile =
   if false:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -106,18 +106,24 @@ const
 
 type
   TBackend* = enum
-    backendInvalid = ""
+    backendInvalid = "" # for parseEnum
     backendC = "c"
-    backendCpp = "cpp"
-    backendJs = "js"
-    backendObjc = "objc"
+    backendCpp = "cpp"  # was cmdCompileToCpp
+    backendJs = "js" # was cmdCompileToJS
+    backendObjc = "objc" # was cmdCompileToOC
+    # backendNimscript = "nimscript" # this could actually work
+    # backendLlvm = "llvm" # probably not well supported; was cmdCompileToLLVM
 
 type
   TCommands* = enum           # Nim's commands
                               # **keep binary compatible**
-    cmdNone, cmdCompileToC, cmdCompileToCpp, cmdCompileToOC,
-    cmdCompileToJS,
-    cmdCompileToLLVM, cmdInterpret, cmdPretty, cmdDoc,
+    cmdNone,
+    cmdCompileToC,            # deadcode
+    cmdCompileToCpp,          # deadcode
+    cmdCompileToOC,           # deadcode
+    cmdCompileToJS,           # deadcode
+    cmdCompileToLLVM,         # deadcode
+    cmdInterpret, cmdPretty, cmdDoc,
     cmdGenDepend, cmdDump,
     cmdCheck,                 # semantic checking for whole project
     cmdParse,                 # parse a single file (for debugging)
@@ -129,6 +135,7 @@ type
     cmdInteractive,           # start interactive session
     cmdRun,                   # run the project via TCC backend
     cmdJsonScript             # compile a .json build file
+    cmdCompileToBackend,      # compile to backend in TBackend
   TStringSeq* = seq[string]
   TGCMode* = enum             # the selected GC
     gcUnselected, gcNone, gcBoehm, gcRegions, gcMarkAndSweep, gcArc, gcOrc,
@@ -624,7 +631,7 @@ proc getNimcacheDir*(conf: ConfigRef): AbsoluteDir =
   # XXX projectName should always be without a file extension!
   result = if not conf.nimcacheDir.isEmpty:
              conf.nimcacheDir
-           elif conf.cmd == cmdCompileToJS:
+           elif conf.backend == backendJs:
              conf.projectPath / genSubDir
            else:
             AbsoluteDir(getOsCacheDir() / splitFile(conf.projectName).name &

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -223,6 +223,7 @@ type
                           ## fields marked with '*' are subject to
                           ## the incremental compilation mechanisms
                           ## (+) means "part of the dependency"
+    backend*: TBackend
     target*: Target       # (+)
     linesCompiled*: int   # all lines that have been compiled
     options*: TOptions    # (+)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -179,7 +179,7 @@ proc processImportCpp(c: PContext; s: PSym, extname: string, info: TLineInfo) =
   incl(s.flags, sfImportc)
   incl(s.flags, sfInfixCall)
   excl(s.flags, sfForward)
-  if c.config.cmd == cmdCompileToC:
+  if c.config.backend == backendC:
     let m = s.getModule()
     incl(m.flags, sfCompileToCpp)
   incl c.config.globalOptions, optMixedMode
@@ -797,8 +797,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wExportc, wExportCpp:
         makeExternExport(c, sym, getOptionalStr(c, it, "$1"), it.info)
         if k == wExportCpp:
-          if c.config.cmd != cmdCompileToCpp:
-            localError(c.config, it.info, "exportcpp requires `nim cpp`, got " & $c.config.cmd)
+          if c.config.backend != backendCpp:
+            localError(c.config, it.info, "exportcpp requires `cpp` backend, got " & $c.config.backend)
           else:
             incl(sym.flags, sfMangleCpp)
         incl(sym.flags, sfUsed) # avoid wrong hints
@@ -819,7 +819,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wImportCpp:
         processImportCpp(c, sym, getOptionalStr(c, it, "$1"), it.info)
       of wImportJs:
-        if c.config.cmd != cmdCompileToJS:
+        if c.config.backend != backendJs:
           localError(c.config, it.info, "`importjs` pragma requires the JavaScript target")
         let name = getOptionalStr(c, it, "$1")
         incl(sym.flags, sfImportc)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -660,7 +660,7 @@ proc hasUnresolvedArgs(c: PContext, n: PNode): bool =
     return false
 
 proc newHiddenAddrTaken(c: PContext, n: PNode): PNode =
-  if n.kind == nkHiddenDeref and not (c.config.cmd == cmdCompileToCpp or
+  if n.kind == nkHiddenDeref and not (c.config.backend == backendCpp or
                                       sfCompileToCpp in c.module.flags):
     checkSonsLen(n, 1, c.config)
     result = n[0]

--- a/compiler/sizealignoffsetimpl.nim
+++ b/compiler/sizealignoffsetimpl.nim
@@ -346,7 +346,7 @@ proc computeSizeAlign(conf: ConfigRef; typ: PType) =
           while st.kind in skipPtrs:
             st = st[^1]
           computeSizeAlign(conf, st)
-          if conf.cmd == cmdCompileToCpp:
+          if conf.backend == backendCpp:
             OffsetAccum(
               offset: int(st.size) - int(st.paddingAtEnd),
               maxAlign: st.align

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -411,7 +411,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
 
 proc transformAddrDeref(c: PTransf, n: PNode, a, b: TNodeKind): PNode =
   result = transformSons(c, n)
-  if c.graph.config.cmd == cmdCompileToCpp or sfCompileToCpp in c.module.flags: return
+  if c.graph.config.backend == backendCpp or sfCompileToCpp in c.module.flags: return
   var n = result
   case n[0].kind
   of nkObjUpConv, nkObjDownConv, nkChckRange, nkChckRangeF, nkChckRange64:
@@ -447,7 +447,7 @@ proc generateThunk(c: PTransf; prc: PNode, dest: PType): PNode =
 
   # we cannot generate a proper thunk here for GC-safety reasons
   # (see internal documentation):
-  if c.graph.config.cmd == cmdCompileToJS: return prc
+  if c.graph.config.backend == backendJs: return prc
   result = newNodeIT(nkClosure, prc.info, dest)
   var conv = newNodeIT(nkHiddenSubConv, prc.info, dest)
   conv.add(newNodeI(nkEmpty, prc.info))

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -121,6 +121,7 @@ when defined(nimHasInvariant):
     of linkOptions: result = conf.linkOptions
     of compileOptions: result = conf.compileOptions
     of ccompilerPath: result = conf.cCompilerPath
+    of backend: result = $conf.backend
 
   proc querySettingSeqImpl(conf: ConfigRef, switch: BiggestInt): seq[string] =
     template copySeq(field: untyped): untyped =

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -215,7 +215,7 @@ proc registerAdditionalOps*(c: PCtx) =
 
   proc hashVmImpl(a: VmArgs) =
     var res = hashes.hash(a.getString(0), a.getInt(1).int, a.getInt(2).int)
-    if c.config.cmd == cmdCompileToJS:
+    if c.config.backend == backendJs:
       # emulate JS's terrible integers:
       res = cast[int32](res)
     setResult(a, res)
@@ -232,7 +232,7 @@ proc registerAdditionalOps*(c: PCtx) =
       bytes[i] = byte(arr[i].intVal and 0xff)
 
     var res = hashes.hash(bytes, sPos, ePos)
-    if c.config.cmd == cmdCompileToJS:
+    if c.config.backend == backendJs:
       # emulate JS's terrible integers:
       res = cast[int32](res)
     setResult(a, res)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -69,13 +69,17 @@ Advanced options:
   --clib:LIBNAME            link an additional C library
                             (you should omit platform-specific extensions)
   --project                 document the whole project (doc2)
-  --docRoot:path            nim doc --docRoot:/foo --project --outdir:docs /foo/sub/main.nim
+  --docRoot:path            `nim doc --docRoot:/foo --project --outdir:docs /foo/sub/main.nim`
                             generates: docs/sub/main.html
                             if path == @pkg, will use nimble file enclosing dir
-                            if path == @path, will use first matching dir in --path
+                            if path == @path, will use first matching dir in `--path`
                             if path == @default (the default and most useful), will use
                             best match among @pkg,@path.
                             if these are nonexistant, will use project path
+  --backend:c|cpp|js|objc   sets backend to use with commands like `nim doc`
+  --docCmd:cmd              if `cmd == skip`, skips runnableExamples
+                            else, runs runnableExamples with given options, eg:
+                            `--docCmd:"-d:foo --threads:on"`
   --docSeeSrcUrl:url        activate 'see source' for doc and doc2 commands
                             (see doc.item.seesrc in config/nimdoc.cfg)
   --docInternal             also generate documentation for non-exported symbols

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -76,7 +76,7 @@ Advanced options:
                             if path == @default (the default and most useful), will use
                             best match among @pkg,@path.
                             if these are nonexistant, will use project path
-  --backend:c|cpp|js|objc   sets backend to use with commands like `nim doc`
+  -b, --backend:c|cpp|js|objc sets backend to use with commands like `nim doc` or `nim r`
   --docCmd:cmd              if `cmd == skip`, skips runnableExamples
                             else, runs runnableExamples with given options, eg:
                             `--docCmd:"-d:foo --threads:on"`

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -5,6 +5,7 @@ Advanced commands:
   //js                      compile project to Javascript
   //e                       run a Nimscript file
   //rst2html                convert a reStructuredText file to HTML
+                            use `--docCmd:skip` to skip compiling snippets
   //rst2tex                 convert a reStructuredText file to TeX
   //jsondoc                 extract the documentation to a json file
   //ctags                   create a tags file

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -29,6 +29,8 @@ Runtime checks (see -x):
 Advanced options:
   -o:FILE, --out:FILE       set the output filename
   --outdir:DIR              set the path where the output file will be written
+  --usenimcache             will use `outdir=$$nimcache`, whichever it resolves
+                            to after all options have been processed
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths:on|off    list full paths in messages

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -4,10 +4,10 @@
 
 Command:
   //compile, c                compile project with default code generator (C)
-  //r                         compile & run $nimcach/projname [arguments] using
-                              backend specified by --backend (default: c)
+  //r                         compile to $nimcache/projname, run with [arguments]
+                              using backend specified by `--backend` (default: c)
   //doc                       generate the documentation for inputfile for
-                              backend specified by --backend (default: c)
+                              backend specified by `--backend` (default: c)
 
 Arguments:
   arguments are passed to the program being run (if --run option is selected)

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -4,8 +4,10 @@
 
 Command:
   //compile, c                compile project with default code generator (C)
-  //r                         compile & run $nimcach/projname [arguments]
-  //doc                       generate the documentation for inputfile
+  //r                         compile & run $nimcach/projname [arguments] using
+                              backend specified by --backend (default: c)
+  //doc                       generate the documentation for inputfile for
+                              backend specified by --backend (default: c)
 
 Arguments:
   arguments are passed to the program being run (if --run option is selected)

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2689,6 +2689,8 @@ proc findNormalized(x: string, inArray: openArray[string]): int =
               # security hole...
   return -1
 
+proc invalidFormatString() {.noinline.} =
+  raise newException(ValueError, "invalid format string")
 
 proc addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.
   noSideEffect, rtl, extern: "nsuAddf".} =
@@ -2697,8 +2699,6 @@ proc addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.
   var i = 0
   var num = 0
   while i < len(formatstr):
-    template invalidFormatString() =
-      raise newException(ValueError, "invalid format string: i: " & $i & "\nprefix:\n" & formatstr[0..<i] & "\nsuffix:\n" & formatstr[i..^1])
     if formatstr[i] == '$' and i+1 < len(formatstr):
       case formatstr[i+1]
       of '#':

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2689,8 +2689,6 @@ proc findNormalized(x: string, inArray: openArray[string]): int =
               # security hole...
   return -1
 
-proc invalidFormatString() {.noinline.} =
-  raise newException(ValueError, "invalid format string")
 
 proc addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.
   noSideEffect, rtl, extern: "nsuAddf".} =
@@ -2699,6 +2697,8 @@ proc addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.
   var i = 0
   var num = 0
   while i < len(formatstr):
+    template invalidFormatString() =
+      raise newException(ValueError, "invalid format string: i: " & $i & "\nprefix:\n" & formatstr[0..<i] & "\nsuffix:\n" & formatstr[i..^1])
     if formatstr[i] == '$' and i+1 < len(formatstr):
       case formatstr[i+1]
       of '#':

--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -29,6 +29,8 @@ type
     linkOptions,      ## additional options passed to the linker
     compileOptions,   ## additional options passed to the C/C++ compiler
     ccompilerPath     ## the path to the C/C++ compiler
+    backend           ## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`
+                      ## and `nim js` would imply backend=js
 
   MultipleValueSetting* {.pure.} = enum ## \
                       ## settings resulting in a seq of string values

--- a/tests/nimdoc/m13129.nim
+++ b/tests/nimdoc/m13129.nim
@@ -1,0 +1,36 @@
+when defined(cpp):
+  {.push header: "<vector>".}
+  type
+    Vector[T] {.importcpp: "std::vector".} = object
+elif defined(js):
+  proc endsWith*(s, suffix: cstring): bool {.noSideEffect,importjs: "#.endsWith(#)".}
+elif defined(c):
+  proc c_printf*(frmt: cstring): cint {.
+    importc: "printf", header: "<stdio.h>", varargs, discardable.}
+
+proc main*() =
+  runnableExamples:
+    import std/compilesettings
+    doAssert not defined(m13129Foo1)
+    doAssert defined(m13129Foo2)
+    doAssert not defined(nimdoc)
+    echo "ok2: backend: " & querySetting(backend)
+    # echo defined(c), defined(js), 
+
+import std/compilesettings
+when defined nimdoc:
+  # import std/compilesettings
+  static:
+    doAssert defined(m13129Foo1)
+    doAssert not defined(m13129Foo2)
+    echo "ok1:" & querySetting(backend)
+
+when isMainModule:
+  when not defined(js):
+    import std/os
+    let cache = querySetting(nimcacheDir)
+    doAssert cache.len > 0
+    let app = getAppFilename()
+    doAssert app.isRelativeTo(cache)
+    doAssert querySetting(projectFull) == currentSourcePath
+    echo "ok3"

--- a/tests/nimdoc/readme.md
+++ b/tests/nimdoc/readme.md
@@ -1,0 +1,2 @@
+the html validation is tested by nimdoc/tester.nim
+the runnableExamples + nim doc logic (across backend) is tested here

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -6,7 +6,7 @@ discard """
 ## tests that don't quite fit the mold and are easier to handle via `execCmdEx`
 ## A few others could be added to here to simplify code.
 
-import std/[strformat,os,osproc]
+import std/[strformat,os,osproc,unittest]
 
 const nim = getCurrentCompilerExe()
 
@@ -15,8 +15,9 @@ const mode =
   elif defined(cpp): "cpp"
   else: static: doAssert false
 
+const testsDir = currentSourcePath().parentDir
+
 proc runCmd(file, options = ""): auto =
-  const testsDir = currentSourcePath().parentDir
   let fileabs = testsDir / file.unixToNativePath
   doAssert fileabs.existsFile, fileabs
   let cmd = fmt"{nim} {mode} {options} --hints:off {fileabs}"
@@ -55,11 +56,11 @@ ret=[s1:foobar s2:foobar age:25 pi:3.14]
 
 else: # don't run twice the same test
   import std/[strutils]
-  template check(msg) = doAssert msg in output, output
+  template check2(msg) = doAssert msg in output, output
 
   block: # mstatic_assert
     let (output, exitCode) = runCmd("ccgbugs/mstatic_assert.nim", "-d:caseBad")
-    check "sizeof(bool) == 2"
+    check2 "sizeof(bool) == 2"
     doAssert exitCode != 0
 
   block: # ABI checks
@@ -72,11 +73,11 @@ else: # don't run twice the same test
       # on platforms that support _StaticAssert natively, errors will show full context, eg:
       # error: static_assert failed due to requirement 'sizeof(unsigned char) == 8'
       # "backend & Nim disagree on size for: BadImportcType{int64} [declared in mabi_check.nim(1, 6)]"
-      check "sizeof(unsigned char) == 8"
-      check "sizeof(struct Foo2) == 1"
-      check "sizeof(Foo5) == 16"
-      check "sizeof(Foo5) == 3"
-      check "sizeof(struct Foo6) == "
+      check2 "sizeof(unsigned char) == 8"
+      check2 "sizeof(struct Foo2) == 1"
+      check2 "sizeof(Foo5) == 16"
+      check2 "sizeof(Foo5) == 3"
+      check2 "sizeof(struct Foo6) == "
       doAssert exitCode != 0
 
   import streams
@@ -103,3 +104,21 @@ else: # don't run twice the same test
         var (output, exitCode) = execCmdEx(cmd)
         output.stripLineEnd
         doAssert output == expected
+
+  block: # nim doc --backend:$backend --doccmd:$cmd
+    # test for https://github.com/nim-lang/Nim/issues/13129
+    # test for https://github.com/nim-lang/Nim/issues/13891
+    const buildDir = testsDir.parentDir / "build"
+    const nimcache = buildDir / "nimcacheTrunner"
+      # `querySetting(nimcacheDir)` would also be possible, but we thus
+      # avoid stomping on other parallel tests
+    let file = testsDir / "nimdoc/m13129.nim"
+    for backend in fmt"{mode} js".split:
+      let cmd = fmt"{nim} doc -b:{backend} --nimcache:{nimcache} -d:m13129Foo1 --doccmd:'-d:m13129Foo2 --hints:off' --usenimcache --hints:off {file}"
+      check execCmdEx(cmd) == (&"ok1:{backend}\nok2: backend: {backend}\n", 0)
+    # checks that --usenimcache works with `nim doc`
+    check fileExists(nimcache / "m13129.html")
+
+    block: # mak sure --backend works with `nim r`
+      let cmd = fmt"{nim} r --backend:{mode} --hints:off --nimcache:{nimcache} {file}"
+      check execCmdEx(cmd) == ("ok3\n", 0)

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -17,3 +17,4 @@ static:
 
 doAssert "myNimCache" in nc
 doAssert "myNimblePath" in np[0]
+doAssert querySetting(backend) == "c"


### PR DESCRIPTION
flags introduced here are by design orthogonal so that they work as you'd expect when you combine them.

## `nim --backend:js|c|cpp|objc` (or -b:js etc)
* fix https://github.com/nim-lang/Nim/issues/13891 (importjs+nim doc,Error:importjs pragma requires JavaScript target)
* fix https://github.com/nim-lang/Nim/issues/13129 (Allow specifying/forcing the compilation backend in Nim for `nim doc)
* we now decouple backends from commands. Everything that worked before still works now, but we can now run things like `nim doc --backend:js` to generate js specific docs. This opens door to showing docs specific to different backends, which would be more accurate than what we have now (often wrong since it assumes c target for nim js in system.nim for example)
* `--backend` is then passed on to runnableExamples, which run the examples for the same backend backend by default. (`--doccmd:--backend:cpp` would be able to override it should user want that, see below)
* before this PR, there was no easy way to change the backend in a cmdline invocation (unless you used a separate nimscript file + setCommand); now you can simply do it by appending `--backend:js` to the command right before the $file argument, eg: `nim c -b:cpp $file` => will use cpp backend

## nim r -b:js (etc)
* likewise, `nim r` (introduced in https://github.com/nim-lang/Nim/pull/13382 just for `c` backend) now works with other backends, eg: `nim r -b:js main`
* `nim r` should now be the de facto default to run tests, regardless of backend, since it avoids polluting your sources with generated js or binaries

## `nim doc --doccmd:cmd`
* before PR, there was no way to pass options to runnableExamples command; now there is, eg: `nim doc --doccmd:'-d:foo --threads:on --lib:lib' main`
; this fixes https://github.com/nim-lang/Nim/issues/13129#issuecomment-582796434

## `nim doc --doccmd:skip`, `nim rst2html --doccmd:skip`
* before PR there was no way to skip runnableExamples or (in rst) test snippets ; now you simply pass `--doccmd:skip`; very useful when you just want to see how the generated html file looks like without waiting for all the runnableExamples to run (or snippets to compile), during development.
eg:
* `nim rst2html --outdir:doc/html doc/manual.rst` => 50s
* `nim rst2html --outdir:doc/html --doccmd:skip doc/manual.rst` => 0.9s

## `--usenimcache`
* refs https://github.com/nim-lang/Nim/issues/6583 ; now you can use `--usenimcache` and avoid polluting both $pwd and $projectdir
* `--usenimcache` was implicitly introduced in https://github.com/nim-lang/Nim/pull/13382 just for `nim r`; now it's explicitly a flag decoupled from `nim r` and works in combination with other commands, eg: `nim doc --usenimcache`  => will output html under nimcache
`--usenimcache` by design uses whatever nimcache resolves to after each command was processed, eg:
`nim doc --nimcache:foo --usenimcache --nimcache:bar main` => will output html uner `bar`, not `foo`
* it works with any command, eg: `nim c --usenimcache main` or `nim doc --usenimcache`

## note: setting `-d:js` (etc) manually is bad, hence the need for `--backend:js`
Note that simply setting `-d:js` is naive and won't work in many cases (eg importjs etc; or may end up with both defined(c) and defined(js) etc), likewise with -d:cpp; in fact future PR should probably issue warning when user code sets -d:js (+other backends) as it'd be error prone.

## tests
* tests are added for every feature

## potential future directions
* make `--usenimcache` default for `nim doc` ; IMO that's the best resolution for https://github.com/nim-lang/Nim/issues/6583; any -o or --outdir would override --usenimcache anyway 
* `nim r doc --port:1234 main` will save the html under nimcache (because `-r` implies `--usenimcache`), and setup (on 1st call) a livereload server (see https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en) so that the html opens in the same tab and auto-refreshes
* `nim r -b:js --port:1234 (-d:nimbrowser) main` will create a template html file that simply links against the generated js file so you can see it running in a browser, it will also use the livereload server to auto-refresh the same tab; this avoids setting up a server manually just to see how `nim js` code runs in a browser
