### PR TITLE
Fix move message

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -398,7 +398,7 @@ proc passCopyToSink(n: PNode; c: var Con): PNode =
     if isLValue(n) and not isClosureEnv(n) and n.typ.skipTypes(abstractInst).kind != tyRef and c.inSpawn == 0:
       message(c.graph.config, n.info, hintPerformance,
         ("passing '$1' to a sink parameter introduces an implicit copy; " &
-        "use 'move($1)' to prevent it") % $n)
+        "if possible, rearrange your program's control flow to prevent it") % $n)
   else:
     if c.graph.config.selectedGC in {gcArc, gcOrc}:
       assert(not containsGarbageCollectedRef(n.typ))

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -382,7 +382,8 @@ proc sinkParamIsLastReadCheck(c: var Con, s: PNode) =
     localError(c.graph.config, c.otherRead.info, "sink parameter `" & $s.sym.name.s &
         "` is already consumed at " & toFileLineCol(c. graph.config, s.info))
 
-proc isClosureEnv(n: PNode): bool = n.kind == nkSym and n.sym.name.s[0] == ':'
+proc isClosureEnv(n: PNode): bool =
+  n.kind == nkDotExpr and n[0].kind == nkHiddenDeref and n[0][0].typ.kind == tyRef
 
 proc passCopyToSink(n: PNode; c: var Con): PNode =
   result = newNodeIT(nkStmtListExpr, n.info, n.typ)

--- a/lib/system/mm/boehm.nim
+++ b/lib/system/mm/boehm.nim
@@ -53,14 +53,14 @@ when not defined(useNimRtl):
   proc realloc0Impl(p: pointer, oldSize, newSize: Natural): pointer =
     result = boehmRealloc(p, newSize)
     if result == nil: raiseOutOfMem()
-    if newsize > oldsize:
-      zeroMem(cast[pointer](cast[int](result) + oldsize), newsize - oldsize)
+    if newSize > oldSize:
+      zeroMem(cast[pointer](cast[int](result) + oldSize), newSize - oldSize)
   proc deallocImpl(p: pointer) = boehmDealloc(p)
 
   proc allocSharedImpl(size: Natural): pointer = allocImpl(size)
   proc allocShared0Impl(size: Natural): pointer = alloc0Impl(size)
-  proc reallocSharedImpl(p: pointer, newsize: Natural): pointer = reallocImpl(p, newsize)
-  proc reallocShared0Impl(p: pointer, oldsize, newsize: Natural): pointer = realloc0Impl(p, oldsize, newsize)
+  proc reallocSharedImpl(p: pointer, newSize: Natural): pointer = reallocImpl(p, newSize)
+  proc reallocShared0Impl(p: pointer, oldSize, newSize: Natural): pointer = realloc0Impl(p, oldSize, newSize)
   proc deallocSharedImpl(p: pointer) = deallocImpl(p)
 
   when hasThreadSupport:


### PR DESCRIPTION
The "use 'move($1)' to prevent it" part of the hint message was reworded.
See forum [thread](https://forum.nim-lang.org/t/6309)