### PR TITLE
Make --backend:cpp|js work for :test: code-blocks as well

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -216,7 +216,8 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
       # Include the current file if we're parsing a nim file
       let importStmt = if d.isPureRst: "" else: "import \"$1\"\n" % [d.filename.replace("\\", "/")]
       writeFile(outp, importStmt & content)
-      let c = if cmd.startsWith("nim "): os.getAppFilename() & cmd.substr(3)
+      let c = if cmd.startsWith("nim <backend> "): os.getAppFilename() & " " & $conf.backend & cmd.substr("nim <backend>".len)
+              elif cmd.startsWith("nim "): os.getAppFilename() & cmd.substr("nim".len)
               else: cmd
       let c2 = c % quoteShell(outp)
       rawMessage(conf, hintExecuting, c2)

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -865,7 +865,7 @@ proc parseCodeBlockField(d: PDoc, n: PRstNode, params: var CodeBlockParams) =
   of "test":
     params.testCmd = n.getFieldValue.strip
     if params.testCmd.len == 0:
-      params.testCmd = "nim c -r $1"
+      params.testCmd = "nim <backend> -r $1" # The nim backend is auto-set in docgen.nim
     else:
       params.testCmd = unescape(params.testCmd)
   of "status", "exitcode":


### PR DESCRIPTION
Continues https://github.com/nim-lang/Nim/commit/9502e39b634eea8e04f07ddc110b466387f42322

Ref:
- https://github.com/nim-lang/Nim/commit/9502e39b634eea8e04f07ddc110b466387f42322#commitcomment-39087584
- https://github.com/nim-lang/Nim/pull/14278

Fixes https://github.com/nim-lang/Nim/issues/13129 .

---

@Araq Here's another take at https://github.com/nim-lang/Nim/pull/14300

/cc @timotheecour 