### PR TITLE
`--hint:msgOrigin`: no more guessing where compiler msgs came from

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -171,6 +171,9 @@ proc mydiv(a, b): int {.raises: [].} =
   (likewise with other hints and warnings), which is consistent with all other bool flags.
   (since 1.3.3).
 - `nim doc -r main` and `nim rst2html -r main` now call openDefaultBrowser
+- new hint: `--hint:msgOrigin` will show where a compiler msg (hint|warning|error) was generated; this
+  helps in particular when it's non obvious where it came from either because multiple locations generate
+  the same message, or because the message involves runtime formatting.
 
 ## Tool changes
 

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -53,7 +53,8 @@ type
     hintSource, hintPerformance, hintStackTrace, hintGCStats,
     hintGlobalVar, hintExpandMacro,
     hintUser, hintUserRaw,
-    hintExtendedContext
+    hintExtendedContext,
+    hintMsgOrigin, # since 1.3.5
 
 const
   MsgKindToStr*: array[TMsgKind, string] = [
@@ -140,6 +141,7 @@ const
     hintUser: "$1",
     hintUserRaw: "$1",
     hintExtendedContext: "$1",
+    hintMsgOrigin: "$1",
   ]
 
 const
@@ -166,7 +168,7 @@ const
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "CondFalse", "Name", "Pattern", "Exec", "Link", "Dependency",
     "Source", "Performance", "StackTrace", "GCStats", "GlobalVar", "ExpandMacro",
-    "User", "UserRaw", "ExtendedContext",
+    "User", "UserRaw", "ExtendedContext", "MsgOrigin",
   ]
 
 const
@@ -192,7 +194,7 @@ proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext}
   result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
-    hintSource, hintGlobalVar, hintGCStats}
+    hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin}
   result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,
     hintProcessing, hintPattern, hintExecuting, hintLinking, hintCC}
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2068,7 +2068,7 @@ const
     ## is the minor number of Nim's version.
     ## Odd for devel, even for releases.
 
-  NimPatch* {.intdefine.}: int = 3
+  NimPatch* {.intdefine.}: int = 5
     ## is the patch number of Nim's version.
 
 import system/dollars


### PR DESCRIPTION
see also https://github.com/nim-lang/RFCs/issues/223

It's a small change that makes debugging easier in lots of cases. A new hint: `--hint:msgOrigin` will show where a compiler msg (hint|warning|error) was generated; this helps in particular when it's non obvious where it came from either because multiple locations generate the same message, or because the message involves runtime formatting (eg avoids arguments like https://github.com/nim-lang/Nim/pull/13926#discussion_r406714163).

it avoids having to recompile nim with `--stacktrace:on` (which would generate a slower nim) in lots of common cases. Obviously some cases will still require a full stacktrace for broader context.

## example 1
```nim
when true:
  import posix
  const s = sizeof(DIR)
```

```
nim r --hint:msgOrigin $timn_D/tests/nim/all/t10729.nim
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10729.nim(31, 19) Error: 'sizeof' requires '.importc' types to be '.completeStruct'
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(1323, 16) compiler msg initiated here [MsgOrigin]
```

## example 2
I was trying to analyze https://github.com/nim-lang/Nim/issues/14314 and was tired of detective games to figure where `warnProveInit` warning was generated from; this PR makes it easy:
```
nim doc -b:cpp --doccmd:--hint:msgOrigin $timn_D/tests/nim/all/t10729.nim
```
(or just keep `--hint:msgOrigin` in your user config)

## future PR's; EDIT: DONE
* `rawMessage` and `liMessage` are copy paste code that should've never been split and should be re-factored; after that I can make `--hint:msgOrigin` also work for `rawMessage`

## ci failure unrelated
the "recently famous" tests/async/tasyncawait.nim https://github.com/nim-lang/Nim/issues/14320