### PR TITLE
fix #14320 (tasyncawait.nim is recently very flaky) + avoid hardcoding service ports everywhere + flakyAssert

### DIFF
--- a/testament/lib/readme.md
+++ b/testament/lib/readme.md
@@ -1,0 +1,4 @@
+This directory contains helper files used by several tests, to avoid
+code duplication, akin to a std extension tailored for testament.
+
+Some of these could later migrate to stdlib.

--- a/testament/lib/stdtest/netutils.nim
+++ b/testament/lib/stdtest/netutils.nim
@@ -1,15 +1,12 @@
 import std/[nativesockets, asyncdispatch, os]
 
-proc bindAvailablePort*(port = Port(0)): (AsyncFD, Port) =
-  var server = createAsyncNativeSocket()
+proc bindAvailablePort*(handle: SocketHandle, port = Port(0)): Port =
   block:
     var name: Sockaddr_in
     name.sin_family = typeof(name.sin_family)(toInt(AF_INET))
     name.sin_port = htons(uint16(port))
     name.sin_addr.s_addr = htonl(INADDR_ANY)
-    if bindAddr(server.SocketHandle, cast[ptr SockAddr](addr(name)),
+    if bindAddr(handle, cast[ptr SockAddr](addr(name)),
                 sizeof(name).Socklen) < 0'i32:
       raiseOSError(osLastError())
-  let port = getLocalAddr(server.SocketHandle, AF_INET)[1]
-  result = (server, port)
-
+  result = getLocalAddr(handle, AF_INET)[1]

--- a/testament/lib/stdtest/netutils.nim
+++ b/testament/lib/stdtest/netutils.nim
@@ -1,0 +1,15 @@
+import std/[nativesockets, asyncdispatch, os]
+
+proc bindAvailablePort*(port = Port(0)): (AsyncFD, Port) =
+  var server = createAsyncNativeSocket()
+  block:
+    var name: Sockaddr_in
+    name.sin_family = typeof(name.sin_family)(toInt(AF_INET))
+    name.sin_port = htons(uint16(port))
+    name.sin_addr.s_addr = htonl(INADDR_ANY)
+    if bindAddr(server.SocketHandle, cast[ptr SockAddr](addr(name)),
+                sizeof(name).Socklen) < 0'i32:
+      raiseOSError(osLastError())
+  let port = getLocalAddr(server.SocketHandle, AF_INET)[1]
+  result = (server, port)
+

--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -1,0 +1,25 @@
+import std/private/miscdollars
+
+template flakyAssert*(cond: untyped, msg = "", notifySuccess = true) =
+  ## API to deal with flaky or failing tests. This avoids disabling entire tests
+  ## altogether so that at least the parts that are working are kept being
+  ## tested. This also avoids making CI fail periodically for tests known to
+  ## be flaky. Finally, for known failures, passing `notifySuccess = true` will
+  ## log that the test succeeded, which may indicate that a bug was fixed
+  ## "by accident" and should be looked into.
+  const info = instantiationInfo(-1, true)
+  const expr = astToStr(cond)
+  if cond and not notifySuccess:
+    discard # silent success
+  else:
+    var msg2 = ""
+    toLocation(msg2, info.filename, info.line, info.column)
+    if cond:
+      # a flaky test is failing, we still report it but we don't fail CI
+      msg2.add " FLAKY_SUCCESS "
+    else:
+      # a previously failing test is now passing, a pre-existing bug might've been
+      # fixed by accidend
+      msg2.add " FLAKY_FAILURE "
+    msg2.add $expr & " " & msg
+    echo msg2

--- a/tests/arc/tasyncawait.nim
+++ b/tests/arc/tasyncawait.nim
@@ -51,7 +51,8 @@ proc createServer(server: AsyncFD) {.async.} =
     asyncCheck readMessages(await accept(server))
 
 proc main =
-  let (server, port) = bindAvailablePort()
+  let server = createAsyncNativeSocket()
+  let port = bindAvailablePort(server.SocketHandle)
   asyncCheck createServer(server)
   asyncCheck launchSwarm(port)
   while true:

--- a/tests/arc/tasyncawait.nim
+++ b/tests/arc/tasyncawait.nim
@@ -3,7 +3,8 @@ discard """
   cmd: "nim c --gc:orc $file"
 """
 
-import asyncdispatch, asyncnet, nativesockets, net, strutils, os
+import asyncdispatch, asyncnet, nativesockets, net, strutils
+from stdtest/netutils import bindAvailablePort
 
 var msgCount = 0
 
@@ -44,24 +45,15 @@ proc readMessages(client: AsyncFD) {.async.} =
       else:
         doAssert false
 
-proc createServer(port: Port) {.async.} =
-  var server = createAsyncNativeSocket()
-  block:
-    var name: Sockaddr_in
-    name.sin_family = typeof(name.sin_family)(toInt(AF_INET))
-    name.sin_port = htons(uint16(port))
-    name.sin_addr.s_addr = htonl(INADDR_ANY)
-    if bindAddr(server.SocketHandle, cast[ptr SockAddr](addr(name)),
-                sizeof(name).Socklen) < 0'i32:
-      raiseOSError(osLastError())
-
+proc createServer(server: AsyncFD) {.async.} =
   discard server.SocketHandle.listen()
   while true:
     asyncCheck readMessages(await accept(server))
 
 proc main =
-  asyncCheck createServer(Port(10335))
-  asyncCheck launchSwarm(Port(10335))
+  let (server, port) = bindAvailablePort()
+  asyncCheck createServer(server)
+  asyncCheck launchSwarm(port)
   while true:
     poll()
     if clientCount == swarmSize: break

--- a/tests/async/tasyncawait.nim
+++ b/tests/async/tasyncawait.nim
@@ -1,5 +1,5 @@
-import asyncdispatch, asyncnet, nativesockets, net, strutils, os
-
+import asyncdispatch, asyncnet, nativesockets, net, strutils
+from stdtest/netutils import bindAvailablePort
 var msgCount = 0
 
 const
@@ -39,25 +39,12 @@ proc readMessages(client: AsyncFD) {.async.} =
       else:
         doAssert false
 
-proc bindAvailablePort(port: Port): (AsyncFD, Port) =
-  var server = createAsyncNativeSocket()
-  block:
-    var name: Sockaddr_in
-    name.sin_family = typeof(name.sin_family)(toInt(AF_INET))
-    name.sin_port = htons(uint16(port))
-    name.sin_addr.s_addr = htonl(INADDR_ANY)
-    if bindAddr(server.SocketHandle, cast[ptr SockAddr](addr(name)),
-                sizeof(name).Socklen) < 0'i32:
-      raiseOSError(osLastError())
-  let port = getLocalAddr(server.SocketHandle, AF_INET)[1]
-  result = (server, port)
-
 proc createServer(server: AsyncFD) {.async.} =
   discard server.SocketHandle.listen()
   while true:
     asyncCheck readMessages(await accept(server))
 
-let (server, port) = bindAvailablePort(0.Port)
+let (server, port) = bindAvailablePort()
 asyncCheck createServer(server)
 asyncCheck launchSwarm(port)
 while true:

--- a/tests/async/tasyncawait.nim
+++ b/tests/async/tasyncawait.nim
@@ -57,8 +57,15 @@ proc createServer(port: Port) {.async.} =
   while true:
     asyncCheck readMessages(await accept(server))
 
-asyncCheck createServer(Port(10335))
-asyncCheck launchSwarm(Port(10335))
+# refs https://github.com/nim-lang/Nim/issues/14320
+# tests/arc/tasyncawait.nim uses 10335 and probably explains
+# `Address already in use` errro so we use a different port. This is
+# just a workaround while waiting for a cleaner fix that would wait
+# (with deadline) for a port to become available.
+# Note that this port is already used in other tests.
+let port = 10335 + 1
+asyncCheck createServer(Port(port))
+asyncCheck launchSwarm(Port(port))
 while true:
   poll()
   if clientCount == swarmSize: break

--- a/tests/async/tasyncawait.nim
+++ b/tests/async/tasyncawait.nim
@@ -44,7 +44,8 @@ proc createServer(server: AsyncFD) {.async.} =
   while true:
     asyncCheck readMessages(await accept(server))
 
-let (server, port) = bindAvailablePort()
+let server = createAsyncNativeSocket()
+let port = bindAvailablePort(server.SocketHandle)
 asyncCheck createServer(server)
 asyncCheck launchSwarm(port)
 while true:

--- a/tests/async/tasyncawait_cyclebreaker.nim
+++ b/tests/async/tasyncawait_cyclebreaker.nim
@@ -49,7 +49,8 @@ proc createServer(server: AsyncFD) {.async.} =
   while true:
     asyncCheck readMessages(await accept(server))
 
-let (server, port) = bindAvailablePort()
+let server = createAsyncNativeSocket()
+let port = bindAvailablePort(server.SocketHandle)
 asyncCheck createServer(server)
 asyncCheck launchSwarm(port)
 while true:

--- a/tests/async/tasyncawait_cyclebreaker.nim
+++ b/tests/async/tasyncawait_cyclebreaker.nim
@@ -2,7 +2,8 @@ discard """
   output: "20000"
   cmd: "nim c -d:nimTypeNames -d:nimCycleBreaker $file"
 """
-import asyncdispatch, asyncnet, nativesockets, net, strutils, os
+import asyncdispatch, asyncnet, nativesockets, net, strutils
+from stdtest/netutils import bindAvailablePort
 
 var msgCount = 0
 
@@ -43,23 +44,14 @@ proc readMessages(client: AsyncFD) {.async.} =
       else:
         doAssert false
 
-proc createServer(port: Port) {.async.} =
-  var server = createAsyncNativeSocket()
-  block:
-    var name: Sockaddr_in
-    name.sin_family = typeof(name.sin_family)(toInt(AF_INET))
-    name.sin_port = htons(uint16(port))
-    name.sin_addr.s_addr = htonl(INADDR_ANY)
-    if bindAddr(server.SocketHandle, cast[ptr SockAddr](addr(name)),
-                sizeof(name).Socklen) < 0'i32:
-      raiseOSError(osLastError())
-
+proc createServer(server: AsyncFD) {.async.} =
   discard server.SocketHandle.listen()
   while true:
     asyncCheck readMessages(await accept(server))
 
-asyncCheck createServer(Port(10335))
-asyncCheck launchSwarm(Port(10335))
+let (server, port) = bindAvailablePort()
+asyncCheck createServer(server)
+asyncCheck launchSwarm(port)
 while true:
   poll()
   GC_collectZct()

--- a/tests/async/tasyncsend4757.nim
+++ b/tests/async/tasyncsend4757.nim
@@ -4,20 +4,22 @@ output: "Finished"
 
 import asyncdispatch, asyncnet
 
-proc createServer(port: Port) {.async.} =
+var port: Port
+proc createServer() {.async.} =
   var server = newAsyncSocket()
   server.setSockOpt(OptReuseAddr, true)
-  bindAddr(server, port)
+  bindAddr(server)
+  port = getLocalAddr(server)[1]
   server.listen()
   while true:
     let client = await server.accept()
     discard await client.recvLine()
 
-asyncCheck createServer(10335.Port)
+asyncCheck createServer()
 
 proc f(): Future[void] {.async.} =
-  let s = newAsyncNativeSocket()
-  await s.connect("localhost", 10335.Port)
+  let s = createAsyncNativeSocket()
+  await s.connect("localhost", port)
   await s.send("123")
   echo "Finished"
 

--- a/tests/async/tasyncsend4757.nim
+++ b/tests/async/tasyncsend4757.nim
@@ -1,7 +1,3 @@
-discard """
-output: "Finished"
-"""
-
 import asyncdispatch, asyncnet
 
 var port: Port
@@ -17,10 +13,12 @@ proc createServer() {.async.} =
 
 asyncCheck createServer()
 
+var done = false
 proc f(): Future[void] {.async.} =
   let s = createAsyncNativeSocket()
   await s.connect("localhost", port)
   await s.send("123")
-  echo "Finished"
+  done = true
 
 waitFor f()
+doAssert done

--- a/tests/async/tasyncssl.nim
+++ b/tests/async/tasyncssl.nim
@@ -2,15 +2,13 @@ discard """
   cmd: "nim $target --hints:on --define:ssl $options $file"
   output: "500"
   disabled: "windows"
-  target: c
-  action: compile
 """
 
-# XXX, deactivated
-
-import asyncdispatch, asyncnet, net, strutils, os
+import asyncdispatch, asyncnet, net, strutils
 
 when defined(ssl):
+  var port0: Port
+
   var msgCount = 0
 
   const
@@ -45,22 +43,23 @@ when defined(ssl):
         else:
           doAssert false
 
-  proc createServer(port: Port) {.async.} =
+  proc createServer() {.async.} =
     let serverContext = newContext(verifyMode = CVerifyNone,
                                    certFile = "tests/testdata/mycert.pem",
                                    keyFile = "tests/testdata/mycert.pem")
     var server = newAsyncSocket()
     serverContext.wrapSocket(server)
     server.setSockOpt(OptReuseAddr, true)
-    bindAddr(server, port)
+    bindAddr(server)
+    port0 = getLocalAddr(server)[1]
     server.listen()
     while true:
       let client = await accept(server)
       serverContext.wrapConnectedSocket(client, handshakeAsServer)
       asyncCheck readMessages(client)
 
-  asyncCheck createServer(Port(10335))
-  asyncCheck launchSwarm(Port(10335))
+  asyncCheck createServer()
+  asyncCheck launchSwarm(port0)
   while true:
     poll()
     if clientCount == swarmSize: break

--- a/tests/async/tasyncssl.nim
+++ b/tests/async/tasyncssl.nim
@@ -1,14 +1,13 @@
 discard """
   cmd: "nim $target --hints:on --define:ssl $options $file"
-  output: "500"
-  disabled: "windows"
 """
+# disabled: "windows"
+# seems to fail on linux64, not linux32
 
 import asyncdispatch, asyncnet, net, strutils
 
 when defined(ssl):
   var port0: Port
-
   var msgCount = 0
 
   const
@@ -64,5 +63,4 @@ when defined(ssl):
     poll()
     if clientCount == swarmSize: break
 
-  assert msgCount == swarmSize * messagesToSend
-  echo msgCount
+  assert msgCount == swarmSize * messagesToSend, $msgCount

--- a/tests/async/twinasyncrw.nim
+++ b/tests/async/twinasyncrw.nim
@@ -228,24 +228,16 @@ when defined(windows):
         else:
           doAssert false
 
-  proc createServer(port: Port) {.async.} =
-    var server = createNativeSocket()
-    setBlocking(server, false)
-    block:
-      var name = Sockaddr_in()
-      name.sin_family = toInt(Domain.AF_INET).uint16
-      name.sin_port = htons(uint16(port))
-      name.sin_addr.s_addr = htonl(INADDR_ANY)
-      if bindAddr(server, cast[ptr SockAddr](addr(name)),
-                  sizeof(name).Socklen) < 0'i32:
-        raiseOSError(osLastError())
-
+  proc createServer(server: SocketHandle) {.async.} =
     discard server.listen()
     while true:
       asyncCheck readMessages(await winAccept(AsyncFD(server)))
 
-  asyncCheck createServer(Port(10335))
-  asyncCheck launchSwarm(Port(10335))
+  var server = createNativeSocket()
+  setBlocking(server, false)
+  let port = bindAvailablePort(server)
+  asyncCheck createServer(server)
+  asyncCheck launchSwarm(port)
   while true:
     poll()
     if clientCount == swarmSize: break

--- a/tests/async/twinasyncrw.nim
+++ b/tests/async/twinasyncrw.nim
@@ -1,9 +1,6 @@
-discard """
-  output: "5000"
-"""
 when defined(windows):
   import asyncdispatch, nativesockets, net, strutils, os, winlean
-
+  from stdtest/netutils import bindAvailablePort
   var msgCount = 0
 
   const
@@ -243,6 +240,4 @@ when defined(windows):
     if clientCount == swarmSize: break
 
   assert msgCount == swarmSize * messagesToSend
-  echo msgCount
-else:
-  echo(5000)
+  doAssert msgCount == 5000

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,4 +1,7 @@
-switch("path", "$nim/testament/lib") # so we can `import stdtest/foo` in this dir
+switch("path", "$lib/../testament/lib")
+  # so we can `import stdtest/foo` inside tests
+  # Using $lib/../ instead of $nim/ so you can use a different nim to run tests
+  # during local testing, eg nim --lib:lib.
 
 ## prevent common user config settings to interfere with testament expectations
 ## Indifidual tests can override this if needed to test for these options.


### PR DESCRIPTION
* fix #14320 + avoid hardcoding service ports everywhere, which often gave `Address already in use` errors
* re-enables tests/async/tasyncssl.nim which (IIUC) flaked for similar issues

IIUC the reason tasyncawait starting giving `Address already in use` errors since 5/6/2020, 3:44:15 AM is that some unrelated test was added around that time and it surfaced a pre-existing time-window bug where 2 processes (testament runs tests in parallel) try to bind to same port; a lot of tests were using the same port `10335`, which gave `Address already in use` error.

This PR uses OS to get a port everywhere, and also refactors to remove some code duplication. Unfortunately a lot of tests use the "copy paste" approach, which, while quick and easy for the person who copy pastes, makes maintenance/evolving/bug fixing/increasing generality/etc hard. Eg, any bug fix or code evolution involves N times the amount of work after code is copy pasted N times. This is what happened in this PR.

Copy pasting (even test files) is almost always the wrong thing to do and should be rejected in code review in favor of refactoring as needed.

## flakyAssert
this PR also adds `flakyAssert`, a replacement for `assert` for tests that are known to fail, see doc comments in PR + rationale. This sill show FLAKY_SUCCESS (with notifySuccess = true and on success) or FLAKY_FAILURE, along with context where it came from, and makes it easy to find in source code where a flake happens, so that it can eventually be fixed, and without disabling entire tests altogether. Testament may swallow the FLAKY_SUCCESS/FLAKY_FAILURE if the entire test succeeds, as usual, but in future work we can refine the logic (in just 1 place) to also log those messages to some file that can be shown in summary along with existing summary.
