### PR TITLE
fix #12293 findNimStdLibCompileTime should not break with nimble install compiler

### DIFF
--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -81,6 +81,9 @@ proc findNimStdLib*(): string =
   ## Returns "" on failure.
   try:
     let nimexe = os.findExe("nim")
+      # this can't work with choosenim shims, refs https://github.com/dom96/choosenim/issues/189
+      # it'd need `nim dump --dump.format:json . | jq -r .libpath`
+      # which we should simplify as `nim dump --key:libpath`
     if nimexe.len == 0: return ""
     result = nimexe.splitPath()[0] /../ "lib"
     if not fileExists(result / "system.nim"):
@@ -93,8 +96,8 @@ proc findNimStdLib*(): string =
 proc findNimStdLibCompileTime*(): string =
   ## Same as ``findNimStdLib`` but uses source files used at compile time,
   ## and asserts on error.
-  const sourcePath = currentSourcePath()
-  result = sourcePath.parentDir.parentDir / "lib"
+  const exe = getCurrentCompilerExe()
+  result = exe.parentDir.parentDir / "lib"
   doAssert fileExists(result / "system.nim"), "result:" & result
 
 proc createInterpreter*(scriptName: string;

--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -97,7 +97,7 @@ proc findNimStdLibCompileTime*(): string =
   ## Same as ``findNimStdLib`` but uses source files used at compile time,
   ## and asserts on error.
   const exe = getCurrentCompilerExe()
-  result = exe.parentDir.parentDir / "lib"
+  result = exe.splitFile.dir.parentDir / "lib"
   doAssert fileExists(result / "system.nim"), "result:" & result
 
 proc createInterpreter*(scriptName: string;


### PR DESCRIPTION
* fix #12293
* there are still some subtleties as mentioned in https://github.com/nim-lang/Nim/issues/12293#issuecomment-627958077
but this should work at least:

```
# with nimble develop
cd $nim
NIMBLE_DIR=$HOME/.nimble_fake24 nimble develop
# or, with nimble install for any version recent enough to have this patch:
NIMBLE_DIR=$HOME/.nimble_fake24 nimble install https://github.com/timotheecour/Nim@#pr_fix_findNimStdLibCompileTime

# then:
NIMBLE_DIR=$HOME/.nimble_fake24 nim r $timn_D/tests/nim/all/t10738.nim
```

```nim
# t10738.nim:
import compiler/[nimeval, llstream]
import os
proc evalString(code: string, moduleName = "script.nim") =
  let stream = llStreamOpen(code)
  let lib = findNimStdLibCompileTime()
  var intr = createInterpreter(moduleName, [lib, lib / "pure", lib / "core"])
  intr.evalScript(stream)
  destroyInterpreter(intr)
  llStreamClose(stream)

let runtimeString = "echo \"Hello World\""
evalString(runtimeString)
```