### PR TITLE
make setting `--backend:xxx` also set exception handling strategy

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -394,8 +394,9 @@ proc handleStdinInput*(conf: ConfigRef) =
     conf.outDir = getNimcacheDir(conf)
 
 proc handleBackend*(conf: ConfigRef, backend: TBackend) =
+  if conf.backend != backendInvalid:
+    undefSymbol(conf.symbols, $conf.backend)
   conf.backend = backend
-  conf.cmd = cmdCompileToBackend
   defineSymbol(conf.symbols, $backend)
   case backend
   of backendC:

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -208,6 +208,7 @@ proc mainCommand*(graph: ModuleGraph) =
     handleBackend(conf, backendJs)
     commandCompileToJS(graph)
   of "r": # different from `"run"`!
+    handleBackend(conf, conf.backend)
     conf.globalOptions.incl {optRun, optUseNimcache}
   of "run":
     conf.cmd = cmdRun

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -197,18 +197,21 @@ proc mainCommand*(graph: ModuleGraph) =
   case conf.command.normalize
   of "c", "cc", "compile", "compiletoc":
     handleBackend(conf, backendC) # compile means compileToC currently
+    conf.cmd = cmdCompileToBackend
     commandCompileToC(graph)
   of "cpp", "compiletocpp":
     handleBackend(conf, backendCpp)
+    conf.cmd = cmdCompileToBackend
     commandCompileToC(graph)
   of "objc", "compiletooc":
     handleBackend(conf, backendObjc)
+    conf.cmd = cmdCompileToBackend
     commandCompileToC(graph)
   of "js", "compiletojs":
     handleBackend(conf, backendJs)
+    conf.cmd = cmdCompileToBackend
     commandCompileToJS(graph)
   of "r": # different from `"run"`!
-    handleBackend(conf, conf.backend)
     conf.globalOptions.incl {optRun, optUseNimcache}
   of "run":
     conf.cmd = cmdRun


### PR DESCRIPTION
Currently `nim check a.nim` fails if `a` contains importing and handling of native cpp exceptions. `nim check` isn't aware of cpp exceptions. I thought `nim check --backend:cpp` will fix it, but this PR is required to make it work.