### PR TITLE
fix #14350, cstrings in JS init as null

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1690,9 +1690,7 @@ proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
       result = putToSeq("null", indirect)
   of tySequence, tyString:
     result = putToSeq("[]", indirect)
-  of tyCString:
-    result = putToSeq("\"\"", indirect)
-  of tyOpt, tyProc:
+  of tyCString, tyOpt, tyProc:
     result = putToSeq("null", indirect)
   of tyStatic:
     if t.n != nil:

--- a/tests/js/tcstrinit.nim
+++ b/tests/js/tcstrinit.nim
@@ -2,4 +2,4 @@
 var cstr: cstring
 doAssert cstr == cstring(nil)
 doAssert cstr.isNil
-doAssert cstr != cstring(nil)
+doAssert cstr != cstring("")

--- a/tests/js/tcstrinit.nim
+++ b/tests/js/tcstrinit.nim
@@ -1,5 +1,0 @@
-# #14350
-var cstr: cstring
-doAssert cstr == cstring(nil)
-doAssert cstr.isNil
-doAssert cstr != cstring("")

--- a/tests/js/tcstrinit.nim
+++ b/tests/js/tcstrinit.nim
@@ -1,0 +1,5 @@
+# #14350
+var cstr: cstring
+doAssert cstr == cstring(nil)
+doAssert cstr.isNil
+doAssert cstr != cstring(nil)

--- a/tests/js/tmangle.nim
+++ b/tests/js/tmangle.nim
@@ -62,8 +62,8 @@ block:
     result = result and obj1.`&&`.addr[] == "bar".cstring
     result = result and obj2.`if` == 0
     result = result and obj2.`for` == 0
-    result = result and obj2.`==`.len == 0
-    result = result and obj2.`&&`.len == 0
+    result = result and obj2.`==`.isNil
+    result = result and obj2.`&&`.isNil
   echo test()
 
 # Test codegen for fields with uppercase letters:

--- a/tests/js/trepr.nim
+++ b/tests/js/trepr.nim
@@ -322,7 +322,7 @@ o = [Field0 = [a = "",
 b = @[]],
 Field1 = ""],
 p = nil,
-q = ""]
+q = nil]
 """)
   doAssert(repr(cc) == """
 [a = 12,

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -70,3 +70,10 @@ block: # `$`(SomeInteger)
     testType uint64
     testType int64
     testType BiggestInt
+
+block: # #14350 for JS
+  var cstr: cstring
+  doAssert cstr == cstring(nil)
+  doAssert cstr == nil
+  doAssert cstr.isNil
+  doAssert cstr != cstring("")


### PR DESCRIPTION
This fixes the wrongly introduced behaviour in #14158 which initialized cstrings as `""` instead of `null`. The previous PR got rid of `null` initialized strings/seqs, which I grouped cstrings with without thinking about it

I did locally test the code snippet in #14350 with Karax and it does indeed work as expected. I don't think it's plausible to add a test for that though.