### PR TITLE
Remove the uses of {.procvar.} pragma

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -305,14 +305,14 @@ proc whichMsgClass*(k: MsgKind): MsgClass =
   else: assert false, "msgkind does not fit naming scheme"
 
 proc defaultMsgHandler*(filename: string, line, col: int, msgkind: MsgKind,
-                        arg: string) {.procvar.} =
+                        arg: string) =
   let mc = msgkind.whichMsgClass
   let a = messages[msgkind] % arg
   let message = "$1($2, $3) $4: $5" % [filename, $line, $col, $mc, a]
   if mc == mcError: raise newException(EParseError, message)
   else: writeLine(stdout, message)
 
-proc defaultFindFile*(filename: string): string {.procvar.} =
+proc defaultFindFile*(filename: string): string =
   if existsFile(filename): result = filename
   else: result = ""
 

--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -322,7 +322,7 @@ proc getFile(ftp: AsyncFtpClient, file: File, total: BiggestInt,
   assertReply(await(ftp.expectReply()), "226")
 
 proc defaultOnProgressChanged*(total, progress: BiggestInt,
-    speed: float): Future[void] {.nimcall, gcsafe, procvar.} =
+    speed: float): Future[void] {.nimcall, gcsafe.} =
   ## Default FTP ``onProgressChanged`` handler. Does nothing.
   result = newFuture[void]()
   #echo(total, " ", progress, " ", speed)
@@ -358,7 +358,7 @@ proc doUpload(ftp: AsyncFtpClient, file: File,
   var countdownFut = sleepAsync(1000)
   var sendFut: Future[void] = nil
   while ftp.dsockConnected:
-    if sendFut == nil or sendFut.finished: 
+    if sendFut == nil or sendFut.finished:
       # TODO: Async file reading.
       let len = file.readBuffer(addr(data[0]), 4000)
       setLen(data, len)

--- a/lib/pure/rationals.nim
+++ b/lib/pure/rationals.nim
@@ -225,7 +225,7 @@ proc `/=`*[T](x: var Rational[T], y: T) =
   x.den *= y
   reduce(x)
 
-proc cmp*(x, y: Rational): int {.procvar.} =
+proc cmp*(x, y: Rational): int =
   ## Compares two rationals.
   (x - y).num
 

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -12,8 +12,7 @@
 
 import strutils
 
-proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect,
-  procvar.} =
+proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect.} =
   ## Expand tab characters in `s` replacing them by spaces.
   ##
   ## The amount of inserted spaces for each tab character is the difference
@@ -53,7 +52,7 @@ proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect,
 
 proc partition*(s: string, sep: string,
                 right: bool = false): (string, string, string)
-                {.noSideEffect, procvar.} =
+                {.noSideEffect.} =
   ## Split the string at the first or last occurrence of `sep` into a 3-tuple
   ##
   ## Returns a 3 string tuple of (beforeSep, `sep`, afterSep) or
@@ -72,7 +71,7 @@ proc partition*(s: string, sep: string,
   return if right: ("", "", s) else: (s, "", "")
 
 proc rpartition*(s: string, sep: string): (string, string, string)
-                {.noSideEffect, procvar.} =
+                {.noSideEffect.} =
   ## Split the string at the last occurrence of `sep` into a 3-tuple
   ##
   ## Returns a 3 string tuple of (beforeSep, `sep`, afterSep) or

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -119,7 +119,7 @@ const
     ##   doAssert "01234".find(invalid) == -1
     ##   doAssert "01A34".find(invalid) == 2
 
-proc isAlphaAscii*(c: char): bool {.noSideEffect, procvar,
+proc isAlphaAscii*(c: char): bool {.noSideEffect,
   rtl, extern: "nsuIsAlphaAsciiChar".} =
   ## Checks whether or not character `c` is alphabetical.
   ##
@@ -131,7 +131,7 @@ proc isAlphaAscii*(c: char): bool {.noSideEffect, procvar,
     doAssert isAlphaAscii('8') == false
   return c in Letters
 
-proc isAlphaNumeric*(c: char): bool {.noSideEffect, procvar,
+proc isAlphaNumeric*(c: char): bool {.noSideEffect,
   rtl, extern: "nsuIsAlphaNumericChar".} =
   ## Checks whether or not `c` is alphanumeric.
   ##
@@ -142,7 +142,7 @@ proc isAlphaNumeric*(c: char): bool {.noSideEffect, procvar,
     doAssert isAlphaNumeric(' ') == false
   return c in Letters+Digits
 
-proc isDigit*(c: char): bool {.noSideEffect, procvar,
+proc isDigit*(c: char): bool {.noSideEffect,
   rtl, extern: "nsuIsDigitChar".} =
   ## Checks whether or not `c` is a number.
   ##
@@ -152,7 +152,7 @@ proc isDigit*(c: char): bool {.noSideEffect, procvar,
     doAssert isDigit('8') == true
   return c in Digits
 
-proc isSpaceAscii*(c: char): bool {.noSideEffect, procvar,
+proc isSpaceAscii*(c: char): bool {.noSideEffect,
   rtl, extern: "nsuIsSpaceAsciiChar".} =
   ## Checks whether or not `c` is a whitespace character.
   runnableExamples:
@@ -161,7 +161,7 @@ proc isSpaceAscii*(c: char): bool {.noSideEffect, procvar,
     doAssert isSpaceAscii('\t') == true
   return c in Whitespace
 
-proc isLowerAscii*(c: char): bool {.noSideEffect, procvar,
+proc isLowerAscii*(c: char): bool {.noSideEffect,
   rtl, extern: "nsuIsLowerAsciiChar".} =
   ## Checks whether or not `c` is a lower case character.
   ##
@@ -176,7 +176,7 @@ proc isLowerAscii*(c: char): bool {.noSideEffect, procvar,
     doAssert isLowerAscii('7') == false
   return c in {'a'..'z'}
 
-proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
+proc isUpperAscii*(c: char): bool {.noSideEffect,
   rtl, extern: "nsuIsUpperAsciiChar".} =
   ## Checks whether or not `c` is an upper case character.
   ##
@@ -192,7 +192,7 @@ proc isUpperAscii*(c: char): bool {.noSideEffect, procvar,
   return c in {'A'..'Z'}
 
 
-proc toLowerAscii*(c: char): char {.noSideEffect, procvar,
+proc toLowerAscii*(c: char): char {.noSideEffect,
   rtl, extern: "nsuToLowerAsciiChar".} =
   ## Returns the lower case version of character ``c``.
   ##
@@ -216,7 +216,7 @@ template toImpl(call) =
   for i in 0..len(s) - 1:
     result[i] = call(s[i])
 
-proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
+proc toLowerAscii*(s: string): string {.noSideEffect,
   rtl, extern: "nsuToLowerAsciiStr".} =
   ## Converts string `s` into lower case.
   ##
@@ -230,7 +230,7 @@ proc toLowerAscii*(s: string): string {.noSideEffect, procvar,
     doAssert toLowerAscii("FooBar!") == "foobar!"
   toImpl toLowerAscii
 
-proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
+proc toUpperAscii*(c: char): char {.noSideEffect,
   rtl, extern: "nsuToUpperAsciiChar".} =
   ## Converts character `c` into upper case.
   ##
@@ -250,7 +250,7 @@ proc toUpperAscii*(c: char): char {.noSideEffect, procvar,
   else:
     result = c
 
-proc toUpperAscii*(s: string): string {.noSideEffect, procvar,
+proc toUpperAscii*(s: string): string {.noSideEffect,
   rtl, extern: "nsuToUpperAsciiStr".} =
   ## Converts string `s` into upper case.
   ##
@@ -264,7 +264,7 @@ proc toUpperAscii*(s: string): string {.noSideEffect, procvar,
     doAssert toUpperAscii("FooBar!") == "FOOBAR!"
   toImpl toUpperAscii
 
-proc capitalizeAscii*(s: string): string {.noSideEffect, procvar,
+proc capitalizeAscii*(s: string): string {.noSideEffect,
   rtl, extern: "nsuCapitalizeAscii".} =
   ## Converts the first character of string `s` into upper case.
   ##
@@ -299,7 +299,7 @@ proc nimIdentNormalize*(s: string): string =
       inc j
   if j != s.len: setLen(result, j)
 
-proc normalize*(s: string): string {.noSideEffect, procvar,
+proc normalize*(s: string): string {.noSideEffect,
   rtl, extern: "nsuNormalize".} =
   ## Normalizes the string `s`.
   ##
@@ -323,7 +323,7 @@ proc normalize*(s: string): string {.noSideEffect, procvar,
   if j != s.len: setLen(result, j)
 
 proc cmpIgnoreCase*(a, b: string): int {.noSideEffect,
-  rtl, extern: "nsuCmpIgnoreCase", procvar.} =
+  rtl, extern: "nsuCmpIgnoreCase".} =
   ## Compares two strings in a case insensitive manner. Returns:
   ##
   ## | 0 if a == b
@@ -345,7 +345,7 @@ proc cmpIgnoreCase*(a, b: string): int {.noSideEffect,
                                       # thus we compile without checks here
 
 proc cmpIgnoreStyle*(a, b: string): int {.noSideEffect,
-  rtl, extern: "nsuCmpIgnoreStyle", procvar.} =
+  rtl, extern: "nsuCmpIgnoreStyle".} =
   ## Semantically the same as ``cmp(normalize(a), normalize(b))``. It
   ## is just optimized to not allocate temporary strings. This should
   ## NOT be used to compare Nim identifier names.
@@ -1096,7 +1096,7 @@ proc intToStr*(x: int, minchars: Positive = 1): string {.noSideEffect,
   if x < 0:
     result = '-' & result
 
-proc parseInt*(s: string): int {.noSideEffect, procvar,
+proc parseInt*(s: string): int {.noSideEffect,
   rtl, extern: "nsuParseInt".} =
   ## Parses a decimal integer value contained in `s`.
   ##
@@ -1107,7 +1107,7 @@ proc parseInt*(s: string): int {.noSideEffect, procvar,
   if L != s.len or L == 0:
     raise newException(ValueError, "invalid integer: " & s)
 
-proc parseBiggestInt*(s: string): BiggestInt {.noSideEffect, procvar,
+proc parseBiggestInt*(s: string): BiggestInt {.noSideEffect,
   rtl, extern: "nsuParseBiggestInt".} =
   ## Parses a decimal integer value contained in `s`.
   ##
@@ -1116,7 +1116,7 @@ proc parseBiggestInt*(s: string): BiggestInt {.noSideEffect, procvar,
   if L != s.len or L == 0:
     raise newException(ValueError, "invalid integer: " & s)
 
-proc parseUInt*(s: string): uint {.noSideEffect, procvar,
+proc parseUInt*(s: string): uint {.noSideEffect,
   rtl, extern: "nsuParseUInt".} =
   ## Parses a decimal unsigned integer value contained in `s`.
   ##
@@ -1125,7 +1125,7 @@ proc parseUInt*(s: string): uint {.noSideEffect, procvar,
   if L != s.len or L == 0:
     raise newException(ValueError, "invalid unsigned integer: " & s)
 
-proc parseBiggestUInt*(s: string): BiggestUInt {.noSideEffect, procvar,
+proc parseBiggestUInt*(s: string): BiggestUInt {.noSideEffect,
   rtl, extern: "nsuParseBiggestUInt".} =
   ## Parses a decimal unsigned integer value contained in `s`.
   ##
@@ -1134,7 +1134,7 @@ proc parseBiggestUInt*(s: string): BiggestUInt {.noSideEffect, procvar,
   if L != s.len or L == 0:
     raise newException(ValueError, "invalid unsigned integer: " & s)
 
-proc parseFloat*(s: string): float {.noSideEffect, procvar,
+proc parseFloat*(s: string): float {.noSideEffect,
   rtl, extern: "nsuParseFloat".} =
   ## Parses a decimal floating point value contained in `s`.
   ##
@@ -1147,7 +1147,7 @@ proc parseFloat*(s: string): float {.noSideEffect, procvar,
   if L != s.len or L == 0:
     raise newException(ValueError, "invalid float: " & s)
 
-proc parseBinInt*(s: string): int {.noSideEffect, procvar,
+proc parseBinInt*(s: string): int {.noSideEffect,
   rtl, extern: "nsuParseBinInt".} =
   ## Parses a binary integer value contained in `s`.
   ##
@@ -1176,7 +1176,7 @@ proc parseOctInt*(s: string): int {.noSideEffect,
   if L != s.len or L == 0:
     raise newException(ValueError, "invalid oct integer: " & s)
 
-proc parseHexInt*(s: string): int {.noSideEffect, procvar,
+proc parseHexInt*(s: string): int {.noSideEffect,
   rtl, extern: "nsuParseHexInt".} =
   ## Parses a hexadecimal integer value contained in `s`.
   ##
@@ -1202,7 +1202,7 @@ proc generateHexCharToValueMap(): string =
 
 const hexCharToValueMap = generateHexCharToValueMap()
 
-proc parseHexStr*(s: string): string {.noSideEffect, procvar,
+proc parseHexStr*(s: string): string {.noSideEffect,
   rtl, extern: "nsuParseHexStr".} =
   ## Convert hex-encoded string to byte string, e.g.:
   ##
@@ -2918,12 +2918,12 @@ iterator tokenize*(s: string, seps: set[char] = Whitespace): tuple[
       break
     i = j
 
-proc isEmptyOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
+proc isEmptyOrWhitespace*(s: string): bool {.noSideEffect, rtl,
     extern: "nsuIsEmptyOrWhitespace".} =
   ## Checks if `s` is empty or consists entirely of whitespace characters.
   result = s.allCharsInSet(Whitespace)
 
-proc isNilOrWhitespace*(s: string): bool {.noSideEffect, procvar, rtl,
+proc isNilOrWhitespace*(s: string): bool {.noSideEffect, rtl,
     extern: "nsuIsNilOrWhitespace",
     deprecated: "use isEmptyOrWhitespace instead".} =
   ## Alias for isEmptyOrWhitespace

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -470,7 +470,7 @@ proc binarySearch(c: RuneImpl, tab: openArray[int], len, stride: int): int =
     return t
   return -1
 
-proc toLower*(c: Rune): Rune {.rtl, extern: "nuc$1", procvar.} =
+proc toLower*(c: Rune): Rune {.rtl, extern: "nuc$1".} =
   ## Converts ``c`` into lower case. This works for any rune.
   ##
   ## If possible, prefer ``toLower`` over ``toUpper``.
@@ -488,7 +488,7 @@ proc toLower*(c: Rune): Rune {.rtl, extern: "nuc$1", procvar.} =
     return Rune(c + toLowerSinglets[p+1] - 500)
   return Rune(c)
 
-proc toUpper*(c: Rune): Rune {.rtl, extern: "nuc$1", procvar.} =
+proc toUpper*(c: Rune): Rune {.rtl, extern: "nuc$1".} =
   ## Converts ``c`` into upper case. This works for any rune.
   ##
   ## If possible, prefer ``toLower`` over ``toUpper``.
@@ -506,7 +506,7 @@ proc toUpper*(c: Rune): Rune {.rtl, extern: "nuc$1", procvar.} =
     return Rune(c + toUpperSinglets[p+1] - 500)
   return Rune(c)
 
-proc toTitle*(c: Rune): Rune {.rtl, extern: "nuc$1", procvar.} =
+proc toTitle*(c: Rune): Rune {.rtl, extern: "nuc$1".} =
   ## Converts ``c`` to title case.
   ##
   ## See also:
@@ -519,7 +519,7 @@ proc toTitle*(c: Rune): Rune {.rtl, extern: "nuc$1", procvar.} =
     return Rune(c + toTitleSinglets[p+1] - 500)
   return Rune(c)
 
-proc isLower*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
+proc isLower*(c: Rune): bool {.rtl, extern: "nuc$1".} =
   ## Returns true if ``c`` is a lower case rune.
   ##
   ## If possible, prefer ``isLower`` over ``isUpper``.
@@ -537,7 +537,7 @@ proc isLower*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
   if p >= 0 and c == toUpperSinglets[p]:
     return true
 
-proc isUpper*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
+proc isUpper*(c: Rune): bool {.rtl, extern: "nuc$1".} =
   ## Returns true if ``c`` is a upper case rune.
   ##
   ## If possible, prefer ``isLower`` over ``isUpper``.
@@ -557,7 +557,7 @@ proc isUpper*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
   if p >= 0 and c == toLowerSinglets[p]:
     return true
 
-proc isAlpha*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
+proc isAlpha*(c: Rune): bool {.rtl, extern: "nuc$1".} =
   ## Returns true if ``c`` is an *alpha* rune (i.e., a letter).
   ##
   ## See also:
@@ -576,7 +576,7 @@ proc isAlpha*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
   if p >= 0 and c == alphaSinglets[p]:
     return true
 
-proc isTitle*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
+proc isTitle*(c: Rune): bool {.rtl, extern: "nuc$1".} =
   ## Returns true if ``c`` is a Unicode titlecase code point.
   ##
   ## See also:
@@ -587,7 +587,7 @@ proc isTitle*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
   ## * `isWhiteSpace proc <#isWhiteSpace,Rune>`_
   return isUpper(c) and isLower(c)
 
-proc isWhiteSpace*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
+proc isWhiteSpace*(c: Rune): bool {.rtl, extern: "nuc$1".} =
   ## Returns true if ``c`` is a Unicode whitespace code point.
   ##
   ## See also:
@@ -600,7 +600,7 @@ proc isWhiteSpace*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
   if p >= 0 and c >= spaceRanges[p] and c <= spaceRanges[p+1]:
     return true
 
-proc isCombining*(c: Rune): bool {.rtl, extern: "nuc$1", procvar.} =
+proc isCombining*(c: Rune): bool {.rtl, extern: "nuc$1".} =
   ## Returns true if ``c`` is a Unicode combining code unit.
   ##
   ## See also:
@@ -627,7 +627,7 @@ template runeCheck(s, runeProc) =
     fastRuneAt(s, i, rune, doInc = true)
     result = runeProc(rune) and result
 
-proc isAlpha*(s: string): bool {.noSideEffect, procvar,
+proc isAlpha*(s: string): bool {.noSideEffect,
   rtl, extern: "nuc$1Str".} =
   ## Returns true if ``s`` contains all alphabetic runes.
   runnableExamples:
@@ -635,7 +635,7 @@ proc isAlpha*(s: string): bool {.noSideEffect, procvar,
     doAssert a.isAlpha
   runeCheck(s, isAlpha)
 
-proc isSpace*(s: string): bool {.noSideEffect, procvar,
+proc isSpace*(s: string): bool {.noSideEffect,
   rtl, extern: "nuc$1Str".} =
   ## Returns true if ``s`` contains all whitespace runes.
   runnableExamples:
@@ -656,21 +656,21 @@ template convertRune(s, runeProc) =
     rune = runeProc(rune)
     fastToUTF8Copy(rune, result, resultIndex, doInc = true)
 
-proc toUpper*(s: string): string {.noSideEffect, procvar,
+proc toUpper*(s: string): string {.noSideEffect,
   rtl, extern: "nuc$1Str".} =
   ## Converts ``s`` into upper-case runes.
   runnableExamples:
     doAssert toUpper("abγ") == "ABΓ"
   convertRune(s, toUpper)
 
-proc toLower*(s: string): string {.noSideEffect, procvar,
+proc toLower*(s: string): string {.noSideEffect,
   rtl, extern: "nuc$1Str".} =
   ## Converts ``s`` into lower-case runes.
   runnableExamples:
     doAssert toLower("ABΓ") == "abγ"
   convertRune(s, toLower)
 
-proc swapCase*(s: string): string {.noSideEffect, procvar,
+proc swapCase*(s: string): string {.noSideEffect,
   rtl, extern: "nuc$1".} =
   ## Swaps the case of runes in ``s``.
   ##
@@ -692,7 +692,7 @@ proc swapCase*(s: string): string {.noSideEffect, procvar,
       rune = rune.toUpper()
     fastToUTF8Copy(rune, result, resultIndex, doInc = true)
 
-proc capitalize*(s: string): string {.noSideEffect, procvar,
+proc capitalize*(s: string): string {.noSideEffect,
   rtl, extern: "nuc$1".} =
   ## Converts the first character of ``s`` into an upper-case rune.
   runnableExamples:
@@ -759,7 +759,7 @@ proc translate*(s: string, replacements: proc(key: string): string): string {.
     let word = s[wordStart .. ^1]
     result.add(replacements(word))
 
-proc title*(s: string): string {.noSideEffect, procvar,
+proc title*(s: string): string {.noSideEffect,
   rtl, extern: "nuc$1".} =
   ## Converts ``s`` to a unicode title.
   ##
@@ -821,7 +821,7 @@ proc toRunes*(s: string): seq[Rune] =
   for r in s.runes:
     result.add(r)
 
-proc cmpRunesIgnoreCase*(a, b: string): int {.rtl, extern: "nuc$1", procvar.} =
+proc cmpRunesIgnoreCase*(a, b: string): int {.rtl, extern: "nuc$1".} =
   ## Compares two UTF-8 strings and ignores the case. Returns:
   ##
   ## | 0 if a == b
@@ -1226,7 +1226,7 @@ proc isUpper*(s: string, skipNonAlpha: bool): bool {.
   ## an empty string.
   runeCaseCheck(s, isUpper, skipNonAlpha)
 
-proc isTitle*(s: string): bool {.noSideEffect, procvar, rtl, extern: "nuc$1Str",
+proc isTitle*(s: string): bool {.noSideEffect, rtl, extern: "nuc$1Str",
     deprecated: "Deprecated since version 0.20 since its semantics are unclear".} =
   ## **Deprecated since version 0.20 since its semantics are unclear**
   ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -876,7 +876,7 @@ proc `of`*[T, S](x: T, y: S): bool {.magic: "Of", noSideEffect.}
   ##   assert(FloatingPointDefect of Exception)
   ##   assert(DivByZeroDefect of Exception)
 
-proc cmp*[T](x, y: T): int {.procvar.} =
+proc cmp*[T](x, y: T): int =
   ## Generic compare proc.
   ##
   ## Returns:
@@ -894,7 +894,7 @@ proc cmp*[T](x, y: T): int {.procvar.} =
   if x < y: return -1
   return 1
 
-proc cmp*(x, y: string): int {.noSideEffect, procvar.}
+proc cmp*(x, y: string): int {.noSideEffect.}
   ## Compare proc for strings. More efficient than the generic version.
   ##
   ## **Note**: The precise result values depend on the used C runtime library and

--- a/nimsuggest/sexp.nim
+++ b/nimsuggest/sexp.nim
@@ -290,7 +290,7 @@ proc raiseParseErr*(p: SexpParser, msg: string) {.noinline, noreturn.} =
   ## raises an `ESexpParsingError` exception.
   raise newException(SexpParsingError, errorMsgExpected(p, msg))
 
-proc newSString*(s: string): SexpNode {.procvar.}=
+proc newSString*(s: string): SexpNode =
   ## Creates a new `SString SexpNode`.
   result = SexpNode(kind: SString, str: s)
 
@@ -298,27 +298,27 @@ proc newSStringMove(s: string): SexpNode =
   result = SexpNode(kind: SString)
   shallowCopy(result.str, s)
 
-proc newSInt*(n: BiggestInt): SexpNode {.procvar.} =
+proc newSInt*(n: BiggestInt): SexpNode =
   ## Creates a new `SInt SexpNode`.
   result = SexpNode(kind: SInt, num: n)
 
-proc newSFloat*(n: float): SexpNode {.procvar.} =
+proc newSFloat*(n: float): SexpNode =
   ## Creates a new `SFloat SexpNode`.
   result = SexpNode(kind: SFloat, fnum: n)
 
-proc newSNil*(): SexpNode {.procvar.} =
+proc newSNil*(): SexpNode =
   ## Creates a new `SNil SexpNode`.
   result = SexpNode(kind: SNil)
 
-proc newSCons*(car, cdr: SexpNode): SexpNode {.procvar.} =
+proc newSCons*(car, cdr: SexpNode): SexpNode =
   ## Creates a new `SCons SexpNode`
   result = SexpNode(kind: SCons, car: car, cdr: cdr)
 
-proc newSList*(): SexpNode {.procvar.} =
+proc newSList*(): SexpNode =
   ## Creates a new `SList SexpNode`
   result = SexpNode(kind: SList, elems: @[])
 
-proc newSSymbol*(s: string): SexpNode {.procvar.} =
+proc newSSymbol*(s: string): SexpNode =
   result = SexpNode(kind: SSymbol, symbol: s)
 
 proc newSSymbolMove(s: string): SexpNode =

--- a/tests/generics/t6137.nim
+++ b/tests/generics/t6137.nim
@@ -16,7 +16,7 @@ let
   # define a vector of length 3
   x: vector[3] = [1.0, 3.0, 5.0]
 
-proc vectFunc[T](x: vector[T]): vector[T] {.procvar.} =
+proc vectFunc[T](x: vector[T]): vector[T] =
   # Define a vector function
   result = 2.0*x
 

--- a/tests/manyloc/argument_parser/argument_parser.nim
+++ b/tests/manyloc/argument_parser/argument_parser.nim
@@ -102,7 +102,7 @@ type
 
 # - Tparam_kind procs
 
-proc `$`*(value: Tparam_kind): string {.procvar.} =
+proc `$`*(value: Tparam_kind): string =
   ## Stringifies the type, used to generate help texts.
   case value:
   of PK_EMPTY: result = ""
@@ -137,7 +137,7 @@ proc new_parameter_specification*(consumes = PK_EMPTY,
 
 # - Tparsed_parameter procs
 
-proc `$`*(data: Tparsed_parameter): string {.procvar.} =
+proc `$`*(data: Tparsed_parameter): string =
   ## Stringifies the value, mostly for debug purposes.
   ##
   ## The proc will display the value followed by non string type in brackets.

--- a/tests/manyloc/keineschweine/lib/client_helpers.nim
+++ b/tests/manyloc/keineschweine/lib/client_helpers.nim
@@ -69,7 +69,7 @@ proc updateFileProgress*() =
   downloadProgress.setString($currentFileTransfer.pos & '/' & $currentFileTransfer.fullLen)
 
 ## HFileTransfer
-proc handleFilePartRecv*(serv: PServer; buffer: PBuffer) {.procvar.} =
+proc handleFilePartRecv*(serv: PServer; buffer: PBuffer) =
   var
     f = readScFileTransfer(buffer)
   updateFileProgress()
@@ -110,7 +110,7 @@ proc saveCurrentFile() =
   echo "Write file"
 
 ## HChallengeResult
-proc handleFileChallengeResult*(serv: PServer; buffer: PBuffer) {.procvar.} =
+proc handleFileChallengeResult*(serv: PServer; buffer: PBuffer) =
   var res = readScChallengeResult(buffer).status
   echo "got challnege result: ", res
   if res and currentFileTransfer.readyToSave:
@@ -122,7 +122,7 @@ proc handleFileChallengeResult*(serv: PServer; buffer: PBuffer) {.procvar.} =
     echo "REsetting current file"
 
 ## HFileCHallenge
-proc handleFileChallenge*(serv: PServer; buffer: PBuffer) {.procvar.} =
+proc handleFileChallenge*(serv: PServer; buffer: PBuffer) =
   var
     challenge = readScFileChallenge(buffer)
     path = expandPath(challenge)

--- a/tools/nimgrab.nim
+++ b/tools/nimgrab.nim
@@ -5,7 +5,7 @@ when defined(windows):
 
   proc syncDownload(url, file: string) =
     proc progress(status: DownloadStatus, progress: uint, total: uint,
-                  message: string) {.procvar, gcsafe.} =
+                  message: string) {.gcsafe.} =
       echo "Downloading " & url
       let t = total.BiggestInt
       if t != 0:

--- a/tools/urldownloader.nim
+++ b/tools/urldownloader.nim
@@ -418,7 +418,7 @@ proc downloadToFile*(szUrl: string, szFileName: string,
 
 when isMainModule:
   proc progress(status: DownloadStatus, progress: uint, progressMax: uint,
-                message: string) {.procvar,gcsafe.} =
+                message: string) {.gcsafe.} =
     const downset: set[DownloadStatus] = {statusBeginDownloading,
                                         statusDownloading, statusEndDownloading}
     if status in downset:


### PR DESCRIPTION
This pragma did nothing.

Ref:
- https://github.com/nim-lang/Nim/issues/2172#issuecomment-383276469
- https://github.com/nim-lang/Nim/issues/12975

@Araq Now grepping for `'\bprocvar\b'` in the Nim repo returns these:

```
tests/errmsgs/tcannot_capture_builtin.nim
2:errormsg: "'+' cannot be passed to a procvar"

compiler/sempass2.nim
488:    localError(conf, n.info, "'$1' cannot be passed to a procvar" % n.sym.name.s)

compiler/wordrecg.nim
137:    "compilerproc", "core", "procvar", "base", "used",

doc/manual_experimental.rst
1765:However, one of the overloaded methods calls a procvar which is

doc/manual.rst
3230:  let procVar = (proc(x: string))(p)
3231:  procVar("a")
7319:indirectly; so the ``thread`` pragma implies ``procvar``.
```

I am not sure how to remove or modify procvar references in those. Apart those those, grepping just `'procvar'` returns a lot more hits like `sfProcVar`, `wProcVar` and others, which I don't know how to deal with.