### PR TITLE
fix some issues with --backend

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -160,8 +160,8 @@ proc mydiv(a, b): int {.raises: [].} =
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.
 - The `define` and `undef` pragmas have been de-deprecated.
-- New command: `nim r main.nim [args...]` which compiles and runs main.nim, saving
-  the binary to $nimcache/main$exeExt, using the same logic as `nim c -r` to
+- New command: `nim r main.nim [args...]` which compiles and runs main.nim, and implies `--usenimcache`
+  so that output is saved to $nimcache/main$exeExt, using the same logic as `nim c -r` to
   avoid recompiling when sources don't change. This is now the preferred way to
   run tests, avoiding the usual pain of clobbering your repo with binaries or
   using tricky gitignore rules on posix. Example:
@@ -178,6 +178,12 @@ proc mydiv(a, b): int {.raises: [].} =
 - new hint: `--hint:msgOrigin` will show where a compiler msg (hint|warning|error) was generated; this
   helps in particular when it's non obvious where it came from either because multiple locations generate
   the same message, or because the message involves runtime formatting.
+- new flag `--backend:js|c|cpp|objc (or -b:js etc), to change backend; can be used with any command
+  (eg nim r, doc, check etc); safe to re-assign.
+- new flag `--doccmd:cmd` to pass additional flags for runnableExamples, eg: `--doccmd:-d:foo --threads`
+  use `--doccmd:skip` to skip runnableExamples and rst test snippets.
+- new flag `--usenimcache` to output to nimcache (whatever it resolves to after all commands are processed)
+  and avoids polluting both $pwd and $projectdir. It can be used with any command.
 
 ## Tool changes
 

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -75,14 +75,6 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
   # now process command line arguments again, because some options in the
   # command line can overwrite the config file's settings
   extccomp.initVars(conf)
-  # XXX This is hacky. We need to find a better way.
-  case conf.command
-  of "cpp", "compiletocpp":
-    conf.backend = backendCpp
-    conf.cmd = cmdCompileToBackend
-  else:
-    discard
-
   self.processCmdLine(passCmd2, "", conf)
   if conf.command == "":
     rawMessage(conf, errGenerated, "command missing")

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -502,8 +502,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
         defineSymbol(conf.symbols, "gcmarkandsweep")
       of "destructors", "arc":
         conf.selectedGC = gcArc
-        if conf.backend != backendCpp:
-          conf.exc = excGoto
         defineSymbol(conf.symbols, "gcdestructors")
         defineSymbol(conf.symbols, "gcarc")
         incl conf.globalOptions, optSeqDestructors
@@ -513,8 +511,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
           defineSymbol(conf.symbols, "nimV2")
       of "orc":
         conf.selectedGC = gcOrc
-        if conf.backend != backendCpp:
-          conf.exc = excGoto
         defineSymbol(conf.symbols, "gcdestructors")
         defineSymbol(conf.symbols, "gcorc")
         incl conf.globalOptions, optSeqDestructors

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -218,11 +218,10 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
       writeFile(outp, importStmt & content)
 
       proc interpSnippetCmd(cmd: string): string =
-        result = cmd
         # backward compatibility hacks; interpolation commands should explicitly use `$`
-        result = result.replace("nim ", "$nim")
-        result = result.replace("$1", "$options")
-        result = result % [
+        if cmd.startsWith "nim ": result = "$nim " & cmd[4..^1]
+        else: result = cmd
+        result = result.replace("$1", "$options") % [
           "nim", os.getAppFilename().quoteShell,
           "backend", $d.conf.backend,
           "options", outp.quoteShell,

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -306,13 +306,14 @@ proc isVSCompatible*(conf: ConfigRef): bool =
 proc getConfigVar(conf: ConfigRef; c: TSystemCC, suffix: string): string =
   # use ``cpu.os.cc`` for cross compilation, unless ``--compileOnly`` is given
   # for niminst support
-  let fullSuffix =
-    case conf.backend
-    of backendCpp, backendJs, backendObjc: "." & $conf.backend & suffix
-    of backendC: suffix
-    else:
-      doAssert false
-      ""
+  var fullSuffix = suffix
+  case conf.backend
+  of backendCpp, backendJs, backendObjc: fullSuffix = "." & $conf.backend & suffix
+  of backendC: discard
+  of backendInvalid:
+    # during parsing of cfg files; we don't know the backend yet, no point in
+    # guessing wrong thing
+    return ""
 
   if (conf.target.hostOS != conf.target.targetOS or conf.target.hostCPU != conf.target.targetCPU) and
       optCompileOnly notin conf.globalOptions:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -223,7 +223,7 @@ type
                           ## fields marked with '*' are subject to
                           ## the incremental compilation mechanisms
                           ## (+) means "part of the dependency"
-    backend*: TBackend
+    backend*: TBackend # set via `nim x` or `nim --backend:x`
     target*: Target       # (+)
     linesCompiled*: int   # all lines that have been compiled
     options*: TOptions    # (+)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -419,7 +419,7 @@ proc newConfigRef*(): ConfigRef =
     cIncludes: @[],   # directories to search for included files
     cLibs: @[],       # directories to search for lib files
     cLinkedLibs: @[],  # libraries to link
-    backend: backendC,
+    backend: backendInvalid,
     externalToLink: @[],
     linkOptionsCmd: "",
     compileOptionsCmd: @[],

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -865,7 +865,7 @@ proc parseCodeBlockField(d: PDoc, n: PRstNode, params: var CodeBlockParams) =
   of "test":
     params.testCmd = n.getFieldValue.strip
     if params.testCmd.len == 0:
-      params.testCmd = "nim <backend> -r $1" # The nim backend is auto-set in docgen.nim
+      params.testCmd = "$nim r --backend:$backend $options" # see `interpSnippetCmd`
     else:
       params.testCmd = unescape(params.testCmd)
   of "status", "exitcode":

--- a/tests/misc/mbackend.nim
+++ b/tests/misc/mbackend.nim
@@ -3,11 +3,18 @@ We can't merge this test inside a `when defined(cpp)` because some bug that was
 fixed would not trigger in that case.
 ]#
 
-## bugfix 1: this used to CT error with: Error: unhandled exception: mimportcpp.nim(6, 18) `defined(cpp)`
-static: doAssert defined(cpp)
+import std/compilesettings
+import std/unittest
 
-## checks that `--backend:c` has no side effect (ie, can be overridden by subsequent commands)
-static: doAssert not defined(c)
+static:
+  ## bugfix 1: this used to CT error with: Error: unhandled exception: mimportcpp.nim(6, 18) `defined(cpp)`
+  doAssert defined(cpp)
+  doAssert querySetting(backend) == "cpp"
+
+  ## checks that `--backend:c` has no side effect (ie, can be overridden by subsequent commands)
+  doAssert not defined(c)
+  doAssert not defined(js)
+  doAssert not defined(js)
 
 type
   std_exception {.importcpp: "std::exception", header: "<exception>".} = object

--- a/tests/misc/mimportcpp.nim
+++ b/tests/misc/mimportcpp.nim
@@ -1,0 +1,24 @@
+#[
+We can't merge this test inside a `when defined(cpp)` because some bug that was
+fixed would not trigger in that case.
+]#
+
+## bugfix 1: this used to CT error with: Error: unhandled exception: mimportcpp.nim(6, 18) `defined(cpp)`
+static: doAssert defined(cpp)
+
+## checks that `--backend:c` has no side effect (ie, can be overridden by subsequent commands)
+static: doAssert not defined(c)
+
+type
+  std_exception {.importcpp: "std::exception", header: "<exception>".} = object
+proc what(s: std_exception): cstring {.importcpp: "((char *)#.what())".}
+
+var isThrown = false
+try:
+  ## bugfix 2: this used to CT error with: Error: only a 'ref object' can be raised
+  raise std_exception()
+except std_exception as ex:
+  doAssert ex.what().len > 0
+  isThrown = true
+
+doAssert isThrown

--- a/tests/nimdoc/m13129.nim
+++ b/tests/nimdoc/m13129.nim
@@ -1,3 +1,5 @@
+# issue #13129
+
 when defined(cpp):
   {.push header: "<vector>".}
   type

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -128,3 +128,10 @@ else: # don't run twice the same test
     let file = testsDir / "misc/mimportc.nim"
     let cmd = fmt"{nim} r -b:cpp --hints:off --nimcache:{nimcache} --warningAsError:ProveInit {file}"
     check execCmdEx(cmd) == ("witness\n", 0)
+
+  block: # further issues with `--backend`
+    let file = testsDir / "misc/mimportcpp.nim"
+    var cmd = fmt"{nim} doc -b:cpp --hints:off --nimcache:{nimcache} {file}"
+    check execCmdEx(cmd) == ("", 0)
+    cmd = fmt"{nim} check -b:c -b:cpp --hints:off --nimcache:{nimcache} {file}"
+    check execCmdEx(cmd) == ("", 0)

--- a/tests/trunner.nim
+++ b/tests/trunner.nim
@@ -123,15 +123,18 @@ else: # don't run twice the same test
       let cmd = fmt"{nim} r --backend:{mode} --hints:off --nimcache:{nimcache} {file}"
       check execCmdEx(cmd) == ("ok3\n", 0)
 
+  block: # further issues with `--backend`
+    let file = testsDir / "misc/mbackend.nim"
+    var cmd = fmt"{nim} doc -b:cpp --hints:off --nimcache:{nimcache} {file}"
+    check execCmdEx(cmd) == ("", 0)
+    cmd = fmt"{nim} check -b:c -b:cpp --hints:off --nimcache:{nimcache} {file}"
+    check execCmdEx(cmd) == ("", 0)
+    # issue https://github.com/timotheecour/Nim/issues/175
+    cmd = fmt"{nim} c -b:js -b:cpp --hints:off --nimcache:{nimcache} {file}"
+    check execCmdEx(cmd) == ("", 0)
+
   block: # some importc tests
     # issue #14314
     let file = testsDir / "misc/mimportc.nim"
     let cmd = fmt"{nim} r -b:cpp --hints:off --nimcache:{nimcache} --warningAsError:ProveInit {file}"
     check execCmdEx(cmd) == ("witness\n", 0)
-
-  block: # further issues with `--backend`
-    let file = testsDir / "misc/mimportcpp.nim"
-    var cmd = fmt"{nim} doc -b:cpp --hints:off --nimcache:{nimcache} {file}"
-    check execCmdEx(cmd) == ("", 0)
-    cmd = fmt"{nim} check -b:c -b:cpp --hints:off --nimcache:{nimcache} {file}"
-    check execCmdEx(cmd) == ("", 0)


### PR DESCRIPTION
before this PR, commands like `nim doc -b:cpp` didn't work when the backend (eg cpp) required adjustments (such as `conf.exc = excCpp`), as was noticed in https://github.com/nim-lang/Nim/pull/14349)

this PR fixes that  and other issues with `--backend`:

`nim $cmd --backend:$backend` now works reliably by splitting the backend handling logic into `customizeForBackend` (called for all commands) vs `compileToBackend` (only called for commands that compile to a backend);

* fix https://github.com/timotheecour/Nim/issues/175: `--backend` can safely override previous options so that for eg `nim c -b:cpp main` and `nim c -b:js -b:cpp main` end with with cpp backend selected, and so that defined(c) and defined(js) would be false (no-side-effect rule)

parsing the flag `--backend` has by design zero side effect beyond setting `conf.backend`, so that it can be overridden in subsequent flags and plays well with other commands

* update changelog (should've been done in https://github.com/nim-lang/Nim/pull/14278, made it up to date)

see tests

## ~~CI failure unrelated (https://github.com/nim-lang/Nim/issues/13166)~~ re-ran