### PR TITLE
fix #14364 - turn on the TLS emulation when using Boehm

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -493,6 +493,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       of "boehm":
         conf.selectedGC = gcBoehm
         defineSymbol(conf.symbols, "boehmgc")
+        incl conf.globalOptions, optTlsEmulation # Boehm GC doesn't scan the real TLS
       of "refc":
         conf.selectedGC = gcRefc
       of "v2":


### PR DESCRIPTION
Turn on the TLS emulation when using Boehm, since it doesn't scan the
real TLS.