### PR TITLE
refs #14369 improve docs for importcpp exceptions

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4247,7 +4247,7 @@ It is possible to raise/catch imported C++ exceptions. Types imported using
 caught by reference. Example:
 
 .. code-block:: nim
-    :test: "nim r -b:cpp $1"
+    :test: "nim cpp -r $1"
 
   type
     CStdException {.importcpp: "std::exception", header: "<exception>", inheritable.} = object

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4247,16 +4247,38 @@ It is possible to raise/catch imported C++ exceptions. Types imported using
 caught by reference. Example:
 
 .. code-block:: nim
+    :test: "nim r -b:cpp $1"
 
   type
-    std_exception {.importcpp: "std::exception", header: "<exception>".} = object
+    CStdException {.importcpp: "std::exception", header: "<exception>", inheritable.} = object
+      ## does not inherit from `RootObj`, so we use `inheritable` instead
+    CRuntimeError {.requiresInit, importcpp: "std::runtime_error", header: "<stdexcept>".} = object of CStdException
+      ## `CRuntimeError` has no default constructor => `requiresInit`
+  proc what(s: CStdException): cstring {.importcpp: "((char *)#.what())".}
+  proc initRuntimeError(a: cstring): CRuntimeError {.importcpp: "std::runtime_error(@)", constructor.}
+  proc initStdException(): CStdException {.importcpp: "std::exception()", constructor.}
 
-  proc what(s: std_exception): cstring {.importcpp: "((char *)#.what())".}
+  proc fn() =
+    let a = initRuntimeError("foo")
+    doAssert $a.what == "foo"
+    var b: cstring
+    try: raise initRuntimeError("foo2")
+    except CStdException as e:
+      doAssert e is CStdException
+      b = e.what()
+    doAssert $b == "foo2"
 
-  try:
-    raise std_exception()
-  except std_exception as ex:
-    echo ex.what()
+    try: raise initStdException()
+    except CStdException: discard
+
+    try: raise initRuntimeError("foo3")
+    except CRuntimeError as e:
+      b = e.what()
+    except CStdException:
+      doAssert false
+    doAssert $b == "foo3"
+
+  fn()
 
 
 


### PR DESCRIPTION
* made snippet runnable
* more comprehensive example to help the next person trying to figure out how to properly deal with C++ exceptions (example in existing docs really didn't help much)
* used suggestions from @cooldome in https://github.com/nim-lang/Nim/issues/14369