### PR TITLE
fix #14404 foldr had the classic multiple evaluation bug

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -843,8 +843,7 @@ template foldl*(sequence, operation, first): untyped =
       digits = foldl(numbers, a & (chr(b + ord('0'))), "")
     assert digits == "0815"
 
-  var result: typeof(first)
-  result = first
+  var result: typeof(first) = first
   for x in items(sequence):
     let
       a {.inject.} = result
@@ -883,11 +882,11 @@ template foldr*(sequence, operation: untyped): untyped =
     assert multiplication == 495, "Multiplication is (5*(9*(11)))"
     assert concatenation == "nimiscool"
 
-  let s = sequence
-  assert s.len > 0, "Can't fold empty sequences"
-  var result: typeof(s[0])
-  result = sequence[s.len - 1]
-  for i in countdown(s.len - 2, 0):
+  let s = sequence # xxx inefficient, use {.evalonce.} pending #13750
+  let n = s.len
+  assert n > 0, "Can't fold empty sequences"
+  var result = s[n - 1]
+  for i in countdown(n - 2, 0):
     let
       a {.inject.} = s[i]
       b {.inject.} = result
@@ -1436,6 +1435,7 @@ when isMainModule:
     assert subtraction == 7, "Subtraction is (5-(9-(11)))"
     assert multiplication == 495, "Multiplication is (5*(9*(11)))"
     assert concatenation == "nimiscool"
+    doAssert toSeq(1..3).foldr(a + b) == 6 # issue #14404
 
   block: # mapIt + applyIt test
     counter = 0


### PR DESCRIPTION
fix #14404

# after PR
## move test to tests/stdlib/tsequtils.nim like most modules; rationale:
* this makes modules more lightweight to import for normal usage (eg for parser)
* joinable via megatest
* avoids unintentional bugs that would only be triggered when testing code via an import as opposed to being in same module (eg some symbol being not exported or causing a clash otherwise)

note that `isMainModule` still has its uses, just not for that

## current implementation is not efficient: seq copy un-needed
`let s = sequence` makes an un-necessary copy; `{.evalonce.}` (https://github.com/nim-lang/Nim/pull/13750) would fix that

## 1 redundant copy per iteration
this would save 1 copy per iteration:
```nim
  block:
    var b {.inject.} = s[n - 1]
    for i in countdown(n - 2, 0):
      let a {.inject.} = s[i]
      b = operation
    b
```

## use better tests
foldl/foldr were introduced in 2013, since then nim has improved
* tests should used doAssert, not assert (otherwise testing via -d:release is pointless)
* out of line asserts (let block followed by assert block) are more verbose and less readable than inline asserts
* errmsgs are redundant
so I'll rewrite as:
```nim
  block: # foldr tests
    let
      numbers = @[5, 9, 11]
      addition = foldr(numbers, a + b)
      subtraction = foldr(numbers, a - b)
      multiplication = foldr(numbers, a * b)
      words = @["nim", "is", "cool"]
      concatenation = foldr(words, a & b)
    assert addition == 25, "Addition is (5+(9+(11)))"
    assert subtraction == 7, "Subtraction is (5-(9-(11)))"
    assert multiplication == 495, "Multiplication is (5*(9*(11)))"
    assert concatenation == "nimiscool"
    doAssert toSeq(1..3).foldr(a + b) == 6 # issue #14404
=>
  block: # foldr tests
    let numbers = @[5, 9, 11]
    doAssert foldr(numbers, a + b) == (5+(9+(11)))
    doAssert foldr(numbers, a - b) == (5-(9-(11)))
    doAssert foldr(numbers, a * b) == (5*(9*(11)))
    doAssert foldr(@["nim", "is", "cool"], a & b) == "nimiscool"
    doAssert toSeq(1..3).foldr(a + b) == 6 # issue #14404
```
or even use unittest.check, with obvious benefits

* tests and examples should not be redundant
there's zero difference between `doAssert foldr(numbers, a + b) == (5+(9+(11)))` and `doAssert foldr(numbers, a * b) == (5*(9*(11)))` ; only 1 of these is needed (zero difference = same code path, no corner case); unlike many procs in os.nim which need more testing and more examples because they're full of corner cases that need to be clarified