### PR TITLE
no more code duplication bw liMessage and rawMessage + several bug fixes

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -181,6 +181,12 @@ const
   hintMin* = hintSuccess
   hintMax* = high(TMsgKind)
 
+proc msgToStr*(msg: TMsgKind): string =
+  case msg
+  of warnMin..warnMax: WarningsToStr[ord(msg) - ord(warnMin)]
+  of hintMin..hintMax: HintsToStr[ord(msg) - ord(hintMin)]
+  else: "" # we could at least do $msg - prefix `err`
+
 static:
   doAssert HintsToStr.len == ord(hintMax) - ord(hintMin) + 1
   doAssert WarningsToStr.len == ord(warnMax) - ord(warnMin) + 1

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -345,12 +345,10 @@ proc mainCommand*(graph: ModuleGraph) =
 
       var hints = newJObject() # consider factoring with `listHints`
       for a in hintMin..hintMax:
-        let key = lineinfos.HintsToStr[ord(a) - ord(hintMin)]
-        hints[key] = %(a in conf.notes)
+        hints[a.msgToStr] = %(a in conf.notes)
       var warnings = newJObject()
       for a in warnMin..warnMax:
-        let key = lineinfos.WarningsToStr[ord(a) - ord(warnMin)]
-        warnings[key] = %(a in conf.notes)
+        warnings[a.msgToStr] = %(a in conf.notes)
 
       var dumpdata = %[
         (key: "version", val: %VersionAsString),

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -125,7 +125,7 @@ proc compileSystemModule*(graph: ModuleGraph) =
 
 proc wantMainModule*(conf: ConfigRef) =
   if conf.projectFull.isEmpty:
-    fatal(conf, newLineInfo(conf, AbsoluteFile"command line", 1, 1), errGenerated,
+    fatal(conf, newLineInfo(conf, AbsoluteFile(commandLineDesc), 1, 1), errGenerated,
         "command expects a filename")
   conf.projectMainIdx = fileInfoIdx(conf, addFileExt(conf.projectFull, NimExt))
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -602,11 +602,14 @@ template message*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg = "") =
   const info2 = instantiationInfo(-1, fullPaths = true)
   liMessage(conf, info, msg, arg, doNothing, info2)
 
-proc internalError*(conf: ConfigRef; info: TLineInfo, errMsg: string) =
+proc internalErrorImpl(conf: ConfigRef; info: TLineInfo, errMsg: string, info2: InstantiationInfo) =
   if conf.cmd == cmdIdeTools and conf.structuredErrorHook.isNil: return
-  const info2 = instantiationInfo(-1, fullPaths = true)
   writeContext(conf, info)
   liMessage(conf, info, errInternal, errMsg, doAbort, info2)
+
+template internalError*(conf: ConfigRef; info: TLineInfo, errMsg: string) =
+  const info2 = instantiationInfo(-1, fullPaths = true)
+  internalErrorImpl(conf, info, errMsg, info2)
 
 proc internalError*(conf: ConfigRef; errMsg: string) =
   if conf.cmd == cmdIdeTools and conf.structuredErrorHook.isNil: return

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -612,6 +612,7 @@ template internalError*(conf: ConfigRef; info: TLineInfo, errMsg: string) =
   internalErrorImpl(conf, info, errMsg, info2)
 
 proc internalError*(conf: ConfigRef; errMsg: string) =
+  # xxx refactor with `internalError` overload
   if conf.cmd == cmdIdeTools and conf.structuredErrorHook.isNil: return
   writeContext(conf, unknownLineInfo)
   rawMessage(conf, errInternal, errMsg)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -586,18 +586,9 @@ proc quotedFilename*(conf: ConfigRef; i: TLineInfo): Rope =
   else:
     result = conf.m.fileInfos[i.fileIndex.int32].quotedName
 
-proc listWarnings*(conf: ConfigRef) =
-  msgWriteln(conf, "Warnings:")
-  for warn in warnMin..warnMax:
-    msgWriteln(conf, "  [$1] $2" % [
-      if warn in conf.notes: "x" else: " ",
-      lineinfos.WarningsToStr[ord(warn) - ord(warnMin)]
-    ])
-
-proc listHints*(conf: ConfigRef) =
-  msgWriteln(conf, "Hints:")
-  for hint in hintMin..hintMax:
-    msgWriteln(conf, "  [$1] $2" % [
-      if hint in conf.notes: "x" else: " ",
-      lineinfos.HintsToStr[ord(hint) - ord(hintMin)]
-    ])
+template listMsg(title, r) =
+  msgWriteln(conf, title)
+  for a in r:
+    msgWriteln(conf, "  [$1] $2" % [if a in conf.notes: "x" else: " ", a.msgToStr])
+proc listWarnings*(conf: ConfigRef) = listMsg("Warnings:", warnMin..warnMax)
+proc listHints*(conf: ConfigRef) = listMsg("Hints:", hintMin..hintMax)

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -321,7 +321,8 @@ proc makeTypeDesc*(c: PContext, typ: PType): PType =
 proc makeTypeSymNode*(c: PContext, typ: PType, info: TLineInfo): PNode =
   let typedesc = newTypeS(tyTypeDesc, c)
   incl typedesc.flags, tfCheckedForDestructor
-  typedesc.addSonSkipIntLit(assertNotNil(c.config, typ))
+  internalAssert(c.config, typ != nil)
+  typedesc.addSonSkipIntLit(typ)
   let sym = newSym(skType, c.cache.idAnon, getCurrOwner(c), info,
                    c.config.options).linkTo(typedesc)
   return newSymNode(sym, info)

--- a/compiler/syntaxes.nim
+++ b/compiler/syntaxes.nim
@@ -121,9 +121,9 @@ proc applyFilter(p: var TParsers, n: PNode, filename: AbsoluteFile,
   if f != filtNone:
     assert p.config != nil
     if p.config.hasHint(hintCodeBegin):
-      rawMessage(p.config, hintCodeBegin, [])
+      rawMessage(p.config, hintCodeBegin, "")
       msgWriteln(p.config, result.s)
-      rawMessage(p.config, hintCodeEnd, [])
+      rawMessage(p.config, hintCodeEnd, "")
 
 proc evalPipe(p: var TParsers, n: PNode, filename: AbsoluteFile,
               start: PLLStream): PLLStream =


### PR DESCRIPTION
address leftover TODO from https://github.com/nim-lang/Nim/pull/14317
* no more code duplication bw liMessage and rawMessage (duplication since e254741541b0389dfb0b675116c76a6a144b90b7 in 2009); these functions have accumulated odd unintentional (IMO) differences over the years and make patches harder to write and read; this merge should fix several bugs (or at least fragile bug-prone logic), eg
  * hintProcessing was treated differently for these (so `rawMessage(graph.config, hintProcessing, s.name.s)` was not rendering as dots); this didnt' seem intentional
  * hintMsgOrigin wasn't honored
  * warningAsError was treated suspiciously in rawMessage, and might've simply ignored `warningAsError` (eg with warnCannotOpenFile)
* fix what seems like a bug in msgWrite that would unconditionally reset lastMsgWasDot even if errorOutputs was empty (eg gagging during `compiles()`)
* `--hint:msgorigin` should now work with all compiler generated messages
* internalAssert now formats instantiationInfo correctly
* removed assertNotNil (used once) + other code simplifications, resulting in negative diff stats

## after PR
* I encountered other bugs while fixing this but best to keep this one as mostly refactoring, next one will fix bugs I've encountered (at least they'll only need to be fixed in 1 place)
