### PR TITLE
fix #9227 procs can now have multiple interleaved doc comments + runnableExamples and be docgen'd correctly

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -547,7 +547,9 @@ proc getAllRunnableExamplesRec(d: PDoc; n, orig: PNode; dest: var Rope, previous
     
     etc
   ]##
-  if n.info.fileIndex != orig.info.fileIndex: return
+  # xxx: checkme: owner check instead? this fails with the $nim_prs_D/nimdoc/tester.nim test
+  # now that we're calling `genRecComment` only from here (to maintain correct order wrt runnableExample)
+  # if n.info.fileIndex != orig.info.fileIndex: return
   case n.kind
   of nkCommentStmt:
     if previousIsRunnable:
@@ -761,7 +763,15 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   var literal, plainName = ""
   var kind = tkEof
   var comm: Rope = nil
-  getAllRunnableExamples(d, n, comm)
+  # if n.kind notin routineKinds:
+  # if n.kind notin declarativeDefs:
+  #   comm.add genRecComment(d, n)
+  comm.add genRecComment(d, n)
+  dbg n.kind, n.renderTree, comm
+  # if n.kind notin declarativeDefs:
+  if n.kind in declarativeDefs:
+    getAllRunnableExamples(d, n, comm)
+  dbg comm
   var r: TSrcGen
   # Obtain the plain rendered string for hyperlink titles.
   initTokRender(r, n, {renderNoBody, renderNoComments, renderDocComments,

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -538,16 +538,16 @@ proc getAllRunnableExamplesRec(d: PDoc; n, orig: PNode; dest: var Rope, previous
     ## d2
 
     ## d3 # <- this one should be out; it's part of rest of function body and would likey not make sense in doc comment
-  
+
   It also works with:
   proc fn* =
     ## d0
     runnableExamples: discard
     ## d1
-    
+
     etc
   ]##
-  # xxx: checkme: owner check instead? this fails with the $nim_prs_D/nimdoc/tester.nim test
+  # xxx: checkme: owner check instead? this fails with the $nim/nimdoc/tester.nim test
   # now that we're calling `genRecComment` only from here (to maintain correct order wrt runnableExample)
   # if n.info.fileIndex != orig.info.fileIndex: return
   case n.kind
@@ -763,15 +763,12 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   var literal, plainName = ""
   var kind = tkEof
   var comm: Rope = nil
-  # if n.kind notin routineKinds:
-  # if n.kind notin declarativeDefs:
-  #   comm.add genRecComment(d, n)
+  # skipping this (and doing it inside getAllRunnableExamples) would fix order in
+  # case of a runnableExample appearing before a doccomment, but would cause other
+  # issues
   comm.add genRecComment(d, n)
-  dbg n.kind, n.renderTree, comm
-  # if n.kind notin declarativeDefs:
   if n.kind in declarativeDefs:
     getAllRunnableExamples(d, n, comm)
-  dbg comm
   var r: TSrcGen
   # Obtain the plain rendered string for hyperlink titles.
   initTokRender(r, n, {renderNoBody, renderNoComments, renderDocComments,


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/9227

## TODO
- [ ] I'll add a test once https://github.com/nim-lang/Nim/pull/14439 is merged but it seems to work