### PR TITLE
add test for `define`, `undef`

### DIFF
--- a/tests/pragmas/tpragmas_misc.nim
+++ b/tests/pragmas/tpragmas_misc.nim
@@ -1,0 +1,12 @@
+##[
+tests for misc pragmas that don't need a separate file
+]##
+
+block:
+  static: doAssert not defined(tpragmas_misc_def)
+  {.undef(tpragmas_misc_def).} # works even if not set
+  static: doAssert not defined(tpragmas_misc_def)
+  {.define(tpragmas_misc_def).}
+  static: doAssert defined(tpragmas_misc_def)
+  {.undef(tpragmas_misc_def).}
+  static: doAssert not defined(tpragmas_misc_def)


### PR DESCRIPTION
`undef` is actually not used at all in nim repo, but I rely on it; so I'm adding a test
