### PR TITLE
nim doc --project: `@@` caused issues; use `_._` instead

### DIFF
--- a/compiler/nimpaths.nim
+++ b/compiler/nimpaths.nim
@@ -27,6 +27,9 @@ const
   nimdocOutCss* = "nimdoc.out.css"
     # `out` to make it easier to use with gitignore in user's repos
   htmldocsDirname* = "htmldocs"
+  dotdotMangle* = "_._"  ## refs #13223
+    # if this changes, make sure it's consistent with `esc` and `escapeLink`
+    # lots of other obvious options won't work, see #14454; `_` could work too
 
 proc interp*(path: string, nimr: string): string =
   result = path % ["nimr", nimr]

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -28,6 +28,8 @@
 import strutils, os, hashes, strtabs, rstast, rst, highlite, tables, sequtils,
   algorithm, parseutils
 
+import "$lib/../compiler/nimpaths"
+
 const
   HtmlExt = "html"
   IndexExt* = ".idx"
@@ -77,8 +79,6 @@ type
     filename: string
     testCmd: string
     status: int
-
-const dotdotMangle* = "@@"  ## refs #13223
 
 proc prettyLink*(file: string): string =
   changeFileExt(file, "").replace(dotdotMangle, "..")

--- a/testament/lib/stdtest/specialpaths.nim
+++ b/testament/lib/stdtest/specialpaths.nim
@@ -1,6 +1,15 @@
 #[
 todo: move findNimStdLibCompileTime, findNimStdLib here
 xxx: consider moving this to $nim/compiler/relpaths.nim to get relocatable paths
+
+## note: $lib vs $nim
+note: these can resolve to 3 different paths if running via `nim c --lib:lib foo`,
+eg if compiler was installed via nimble (or is in nim path), and nim is external
+(ie not in `$lib/../bin/` dir)
+
+import "$lib/../compiler/nimpaths" # <- most robust if you want to favor --lib:lib
+import "$nim/compiler/nimpaths"
+import compiler/nimpaths
 ]#
 
 import os

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -12,7 +12,7 @@ from std/sequtils import toSeq,mapIt
 from std/algorithm import sorted
 import stdtest/[specialpaths, unittest_light]
 
-import "$nim/compiler/nimpaths"
+import "$lib/../compiler/nimpaths"
 
 const
   nim = getCurrentCompilerExe()
@@ -101,21 +101,21 @@ else: # don't run twice the same test
       of 0,5:
         let htmlFile = htmldocsDir/"mmain.html"
         check htmlFile in outp # sanity check for `hintSuccessX`
-        assertEquals ret, """
-@@/imp.html
-@@/imp.idx
-dochack.js
+        assertEquals ret, fmt"""
+{dotdotMangle}/imp.html
+{dotdotMangle}/imp.idx
+{docHackJsFname}
 imp.html
 imp.idx
 imp2.html
 imp2.idx
 mmain.html
 mmain.idx
-nimdoc.out.css
-theindex.html""", context
-      of 1: assertEquals ret, """
-dochack.js
-nimdoc.out.css
+{nimdocOutCss}
+{theindexFname}""", context
+      of 1: assertEquals ret, fmt"""
+{docHackJsFname}
+{nimdocOutCss}
 tests/nimdoc/imp.html
 tests/nimdoc/imp.idx
 tests/nimdoc/sub/imp.html
@@ -124,20 +124,20 @@ tests/nimdoc/sub/imp2.html
 tests/nimdoc/sub/imp2.idx
 tests/nimdoc/sub/mmain.html
 tests/nimdoc/sub/mmain.idx
-theindex.html"""
-      of 2, 3: assertEquals ret, """
-dochack.js
+{theindexFname}"""
+      of 2, 3: assertEquals ret, fmt"""
+{docHackJsFname}
 mmain.html
 mmain.idx
-nimdoc.out.css""", context
-      of 4: assertEquals ret, """
-dochack.js
-nimdoc.out.css
+{nimdocOutCss}""", context
+      of 4: assertEquals ret, fmt"""
+{docHackJsFname}
+{nimdocOutCss}
 sub/mmain.html
 sub/mmain.idx""", context
-      of 6: assertEquals ret, """
+      of 6: assertEquals ret, fmt"""
 mmain.html
-nimdoc.out.css""", context
+{nimdocOutCss}""", context
       else: doAssert false
 
   block: # mstatic_assert


### PR DESCRIPTION
we could probably use same mangling for nimcache, it'd look less noisy than current scheme

/cc @kaushalmodi 

should fix your comment:
> https://github.com/nim-lang/Nim/issues/14448#issuecomment-633778346


Other options turned out problematic: `@@`, `..7`, `7..`
* `@@` can cause problems unless it's encoded `%40` (ugly) according to https://stackoverflow.com/questions/19509028/can-i-use-an-at-symbol-inside-urls/19737890
* `..7` would show as hidden since starts with `.`
* `7..` may cause problems on windows see https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ff407623(v%3Doffice.14) and https://answers.microsoft.com/en-us/msoffice/forum/all/kb3203467-causing-attachments-with-consecutive/4c7d7d34-ced2-4386-85a9-4b093523ba4f
* `_.` seems perfect; looks like a `..` without being too similar to it so there's no confusion... well not sure about hyperlinks that could hide underscores but I guess the dot makes it clear still
* [EDIT] sigh... windows also has problems with `_.` see https://stackoverflow.com/questions/4075753/how-to-delete-a-folder-that-name-ended-with-a-dot and in fact CI failed for `tests/misc/trunner.nim` where walkDirRec reported finding `_/imp.html` instead of `_./imp.html` => could indicate bug in stdlib for paths ending with dot which are probably legal on windows but oddly supported


## only alternative: `_`
haven't tried but could work; although it's more likely to clash

## links for reference
* https://secure.n-able.com/webhelp/NC_9-1-0_SO_en/Content/SA_docs/API_Level_Integration/API_Integration_URLEncoding.html
* https://cwe.mitre.org/data/definitions/32.html
* https://answers.microsoft.com/en-us/msoffice/forum/all/kb3203467-causing-attachments-with-consecutive/4c7d7d34-ced2-4386-85a9-4b093523ba4f
* https://docs.microsoft.com/en-us/previous-versions/office/developer/sharepoint-2010/ff407623(v%3Doffice.14)
* https://stackoverflow.com/questions/27142359/is-a-url-with-multiple-consecutive-dots-valid
