### PR TITLE
Revert "niminst: use threaded compression when supported"

### DIFF
--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -700,10 +700,8 @@ RunProgram="tools\downloader.exe"
           if execShellCmd("tar cf $1.tar $1" % proj) != 0:
             echo("External program failed")
 
-        if execShellCmd("xz -T0 -9f $1.tar" % proj) != 0:
-          # Maybe the xz version is too old and doesn't support threading
-          if execShellCmd("xz -9f $1.tar" % proj) != 0:
-            echo("External program failed")
+        if execShellCmd("xz -9f $1.tar" % proj) != 0:
+          echo("External program failed")
     finally:
       setCurrentDir(oldDir)
 


### PR DESCRIPTION
While compression speed is greatly increased with threaded xz, the compression ratio suffers heavily.

The generated tarball went from 4.9MB to 10MB, which is 2x the size and doesn't justify the speed up.

I may look into the potential to employ zstd here instead and see if it provides us with better speed/compression ratio tradeoff.

Reverts nim-lang/Nim#14455