### PR TITLE
Propagate the outDir to rstgen to fix hrefs for modules in subdirs

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -47,7 +47,6 @@ type
     exampleCounter: int
     emitted: IntSet # we need to track which symbols have been emitted
                     # already. See bug #3655
-    destFile*: AbsoluteFile
     thisDir*: AbsoluteDir
     exampleGroups: OrderedTable[string, ExampleGroup]
     wroteSupportFiles*: bool
@@ -179,6 +178,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
   result.module = module
   result.conf = conf
   result.cache = cache
+  result.outDir = conf.outDir
   initRstGenerator(result[], (if conf.cmd != cmdRst2tex: outHtml else: outLatex),
                    conf.configVars, filename.string, {roSupportRawDirective, roSupportMarkdown},
                    docgenFindFile, compilerMsgHandler)
@@ -1366,4 +1366,3 @@ proc commandBuildIndex*(conf: ConfigRef, dir: string, outFile = RelativeFile"") 
 
   if not writeRope(code, filename):
     rawMessage(conf, errCannotOpenFile, filename.string)
-

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.idx
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.idx
@@ -1,0 +1,12 @@
+This is now a header	subdir/subdir_b/utils.html#this-is-now-a-header	 This is now a header	
+Next header	subdir/subdir_b/utils.html#this-is-now-a-header-next-header	  Next header	
+And so on	subdir/subdir_b/utils.html#next-header-and-so-on	   And so on	
+More headers	subdir/subdir_b/utils.html#more-headers	 More headers	
+Up to level 6	subdir/subdir_b/utils.html#more-headers-up-to-level-6	      Up to level 6	
+enumValueA	subdir/subdir_b/utils.html#enumValueA	SomeType.enumValueA	
+enumValueB	subdir/subdir_b/utils.html#enumValueB	SomeType.enumValueB	
+enumValueC	subdir/subdir_b/utils.html#enumValueC	SomeType.enumValueC	
+SomeType	subdir/subdir_b/utils.html#SomeType	utils: SomeType	
+someType	subdir/subdir_b/utils.html#someType_2	utils: someType(): SomeType	
+aEnum	subdir/subdir_b/utils.html#aEnum.t	utils: aEnum(): untyped	
+bEnum	subdir/subdir_b/utils.html#bEnum.t	utils: bEnum(): untyped	

--- a/nimdoc/testproject/expected/testproject.idx
+++ b/nimdoc/testproject/expected/testproject.idx
@@ -1,0 +1,14 @@
+C_A	testproject.html#C_A	testproject: C_A	
+C_B	testproject.html#C_B	testproject: C_B	
+C_C	testproject.html#C_C	testproject: C_C	
+C_D	testproject.html#C_D	testproject: C_D	
+foo	testproject.html#foo.t,SomeType,SomeType	testproject: foo(a, b: SomeType)	
+bar	testproject.html#bar,T,T	testproject: bar[T](a, b: T): T	
+baz	testproject.html#baz,T,T	testproject: baz[T](a, b: T): T	
+buzz	testproject.html#buzz,T,T	testproject: buzz[T](a, b: T): T	
+bar	testproject.html#bar.m	testproject: bar(): untyped	
+aVariable	testproject.html#aVariable	testproject: aVariable	
+A	testproject.html#A	testproject: A	
+B	testproject.html#B	testproject: B	
+someFunc	testproject.html#someFunc	testproject: someFunc()	
+isValid	testproject.html#isValid,T	testproject: isValid[T](x: T): bool	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -72,7 +72,7 @@ function main() {
 <div class="document" id="documentId">
   <div class="container">
     <h1 class="title">Index</h1>
-    Modules: <a href="testproject.html">testproject</a>, <a href="utils.html">utils</a>.<br/><p /><h2>API symbols</h2>
+    Modules: <a href="subdir/subdir_b/utils.html">subdir/subdir_b/utils</a>, <a href="testproject.html">testproject</a>.<br/><p /><h2>API symbols</h2>
 <dl><dt><a name="A" href="#A"><span>A:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="testproject: A" href="testproject.html#A">testproject: A</a></li>


### PR DESCRIPTION
Fixes https://github.com/nim-lang/Nim/issues/14434

- Propagates the conf.outDir from docgen to rstgen so that the output HTML file paths relative to the outDir can be derived correctly.
- Updated the tests
- Added the missing .idx files to the docgen tests.

/cc @timotheecour 