### PR TITLE
fix #14485

### DIFF
--- a/compiler/renderverbatim.nim
+++ b/compiler/renderverbatim.nim
@@ -65,27 +65,10 @@ proc renderNimCode*(result: var string, code: string, isLatex = false) =
     buf.setLen 0
     buf.addEscaped(val)
     let class = tokenClassToStr[kind]
-
-    #[
-    xxx bug in strutils.addf: this crashes:
-    var ret: string
-    ret.addf "foo $1 bar" % ["$"]
-    ]#
-    when false:
-      if isLatex:
-        result.addf "\\span$1{$2}" % [class, buf]
-      else:
-        result.addf  "<span class=\"$1\">$2</span>" % [class, buf]
-
     if isLatex:
-      result.addf "\\span$1{" % [class]
-      result.add buf
-      result.add "}"
+      result.addf "\\span$1{$2}", [class, buf]
     else:
-      result.addf  "<span class=\"$1\">" % [class]
-      result.add buf
-      result.add "</span>"
-
+      result.addf  "<span class=\"$1\">$2</span>", [class, buf]
   while true:
     getNextToken(toknizr, langNim)
     case toknizr.kind

--- a/compiler/renderverbatim.nim
+++ b/compiler/renderverbatim.nim
@@ -65,10 +65,26 @@ proc renderNimCode*(result: var string, code: string, isLatex = false) =
     buf.setLen 0
     buf.addEscaped(val)
     let class = tokenClassToStr[kind]
+
+    #[
+    xxx bug in strutils.addf: this crashes:
+    var ret: string
+    ret.addf "foo $1 bar" % ["$"]
+    ]#
+    when false:
+      if isLatex:
+        result.addf "\\span$1{$2}" % [class, buf]
+      else:
+        result.addf  "<span class=\"$1\">$2</span>" % [class, buf]
+
     if isLatex:
-      result.addf "\\span$1{$2}" % [class, buf]
+      result.addf "\\span$1{" % [class]
+      result.add buf
+      result.add "}"
     else:
-      result.addf  "<span class=\"$1\">$2</span>" % [class, buf]
+      result.addf  "<span class=\"$1\">" % [class]
+      result.add buf
+      result.add "</span>"
 
   while true:
     getNextToken(toknizr, langNim)

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -188,6 +188,8 @@ function main() {
     title="z17()"><wbr />z17<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#p1"
     title="p1()"><wbr />p1<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#addfBug14485"
+    title="addfBug14485()"><wbr />addf<wbr />Bug14485<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -524,6 +526,25 @@ this is a nested doc comment
 ]##</span><span class="Whitespace">
 </span><span class="Keyword">discard</span><span class="Whitespace"> </span><span class="StringLit">&quot;c9&quot;</span><span class="Whitespace">
 </span><span class="Comment"># also work after</span></pre>
+
+</dd>
+<a id="addfBug14485"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#addfBug14485"><span class="Identifier">addfBug14485</span></a><span class="Other">(</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+Some proc
+<p><strong class="examples_text">Example:</strong></p>
+<pre class="listing"><span class="Keyword">discard</span><span class="Whitespace"> </span><span class="StringLit">&quot;foo() = &quot;</span><span class="Whitespace"> </span><span class="Operator">&amp;</span><span class="Whitespace"> </span><span class="Operator">$</span><span class="Punctuation">[</span><span class="DecNumber">1</span><span class="Punctuation">]</span><span class="Whitespace">
+</span><span class="LongComment">#[
+0: let&apos;s also add some broken html to make sure this won&apos;t break in future
+1: &lt;/span&gt;
+2: &lt;/span&gt;
+3: &lt;/span
+4: &lt;/script&gt;
+5: &lt;/script
+6: &lt;/script
+7: end of broken html
+]#</span></pre>
 
 </dd>
 

--- a/nimdoc/testproject/expected/testproject.idx
+++ b/nimdoc/testproject/expected/testproject.idx
@@ -32,6 +32,7 @@ z13	testproject.html#z13	testproject: z13()
 baz	testproject.html#baz	testproject: baz()	
 z17	testproject.html#z17	testproject: z17()	
 p1	testproject.html#p1	testproject: p1()	
+addfBug14485	testproject.html#addfBug14485	testproject: addfBug14485()	
 bar	testproject.html#bar.m	testproject: bar(): untyped	
 z16	testproject.html#z16.m	testproject: z16()	
 z18	testproject.html#z18.m	testproject: z18(): int	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -77,6 +77,10 @@ function main() {
 <li><a class="reference external"
           data-doc-search-tag="testproject: A" href="testproject.html#A">testproject: A</a></li>
           </ul></dd>
+<dt><a name="addfBug14485" href="#addfBug14485"><span>addfBug14485:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: addfBug14485()" href="testproject.html#addfBug14485">testproject: addfBug14485()</a></li>
+          </ul></dd>
 <dt><a name="aEnum" href="#aEnum"><span>aEnum:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="utils: aEnum(): untyped" href="subdir/subdir_b/utils.html#aEnum.t">utils: aEnum(): untyped</a></li>

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -161,6 +161,22 @@ when true: # capture non-doc comments correctly even before 1st token
       # also work after
     # this should be out
 
+when true: # issue #14485
+  proc addfBug14485*() =
+    ## Some proc
+    runnableExamples:
+      discard "foo() = " & $[1]
+      #[
+      0: let's also add some broken html to make sure this won't break in future
+      1: </span>
+      2: </span>
+      3: </span
+      4: </script>
+      5: </script
+      6: </script
+      7: end of broken html
+      ]#
+
 when true: # (most) macros
   macro bar*(): untyped =
     result = newStmtList()


### PR DESCRIPTION
fix #14485

* docs aren't run in CI anymore for performance reasons so this wasn't caught some how
* I was using strutils.addf wrong, `%` should not be used with addf...
```nim
var ret: string
ret.addf "foo $1 bar" % ["$"] # this was the wrong usage
```
* add test

* verified by running `./koch docs` locally

