### PR TITLE
enable compiler docs with their own index+search

### DIFF
--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -5,8 +5,7 @@ import "../compiler/nimpaths"
 
 const
   gaCode* = " --doc.googleAnalytics:UA-48159761-1"
-  # --warning[LockLevel]:off pending #13218
-  nimArgs = "--warning[LockLevel]:off --hint[Conf]:off --hint[Path]:off --hint[Processing]:off -d:boot --putenv:nimversion=$#" % system.NimVersion
+  nimArgs = "--hint:Conf:off --hint:Path:off --hint:Processing:off -d:boot --putenv:nimversion=$#" % system.NimVersion
   gitUrl = "https://github.com/nim-lang/Nim"
   docHtmlOutput = "doc/html"
   webUploadOutput = "web/upload"
@@ -231,6 +230,15 @@ proc buildDocSamples(nimArgs, destPath: string) =
   exec(findNim().quoteShell() & " doc $# -o:$# $#" %
     [nimArgs, destPath / "docgen_sample.html", "doc" / "docgen_sample.nim"])
 
+proc buildDocPackages(nimArgs, destPath: string) =
+  # compiler docs, and later, other packages (perhaps tools, testament etc)
+  let nim = findNim().quoteShell()
+  let extra = "-u:boot"
+    # to avoid broken links to manual from compiler dir, but a multi-package
+    # structure could be supported later
+  exec("$1 doc --project --outdir:$2/compiler $3 --git.url:$4 $5 compiler/nim.nim" %
+    [nim, destPath, nimArgs, gitUrl, extra])
+
 proc buildDoc(nimArgs, destPath: string) =
   # call nim for the documentation:
   var
@@ -262,6 +270,8 @@ proc buildDoc(nimArgs, destPath: string) =
 
   mexec(commands)
   exec(nim & " buildIndex -o:$1/theindex.html $1" % [destPath])
+
+  buildDocPackages(nimArgs, destPath)
 
 proc buildPdfDoc*(nimArgs, destPath: string) =
   createDir(destPath)
@@ -296,20 +306,14 @@ proc buildJS(): string =
   result = getDocHacksJs(nimr = getCurrentDir(), nim)
 
 proc buildDocs*(args: string) =
-  let
-    a = nimArgs & " " & args
-    docHackJsSource = buildJS()
-    docHackJs = docHackJsSource.lastPathPart
+  let docHackJsSource = buildJS()
+  template fn(args, dir) =
+    let dir2 = dir
+    let args2 = args
+    createDir(dir2)
+    buildDocSamples(args2, dir2)
+    buildDoc(args2, dir2)
+    copyFile(docHackJsSource, dir2 / docHackJsSource.lastPathPart)
 
-  let docup = webUploadOutput / NimVersion
-  createDir(docup)
-  buildDocSamples(a, docup)
-  buildDoc(a, docup)
-
-  # 'nimArgs' instead of 'a' is correct here because we don't want
-  # that the offline docs contain the 'gaCode'!
-  createDir(docHtmlOutput)
-  buildDocSamples(nimArgs, docHtmlOutput)
-  buildDoc(nimArgs, docHtmlOutput)
-  copyFile(docHackJsSource, docHtmlOutput / docHackJs)
-  copyFile(docHackJsSource, docup / docHackJs)
+  fn(nimArgs & " " & args, webUploadOutput / NimVersion)
+  fn(nimArgs, docHtmlOutput) # no `args` to avoid offline docs containing the 'gaCode'!


### PR DESCRIPTION
* compiler docs, index and search are now generated (using a single command, which is now possible thanks to recent PR's)
* no interference with existing index + search (ie, using separate indexes based on previous feedback; it'd still be nice to have a master index though)
* remove code duplication in buildDocs


(changed `--hint[Conf]:off`  to `--hint:Conf:off` so that you can copy paste commands without having to edit and quote arguments)

## future work
* address caveat https://github.com/nim-lang/Nim/pull/14493/files#diff-cdc1b5c3c94ae8670cc9a495b8647ba8R272
* master template that links to compiler/theindex.html
in future, would be nice for the html template to allow navigating to both compiler docs + stdlib docs (ie a multi-package index; would be useful for other projects too; ideally it wouldn't need much hardcoding for nim repo)
* multi-backend docs (eg for `nim js` docs)
