### PR TITLE
hotfix doc comments for procs without body

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -642,6 +642,7 @@ proc getAllRunnableExamples(d: PDoc, n: PNode, dest: var Rope) =
   var state = rsStart
   template fn(n2) =
     state = getAllRunnableExamplesImpl(d, n2, dest, state)
+  dest.add genComment(d, n).rope
   case n.kind
   of routineDefs:
     n = n.getRoutineBody

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -501,11 +501,6 @@ proc readAll*(file: File): TaintedString {.tags: [ReadIOEffect], benign.} =
   else:
     result = readAllBuffer(file).TaintedString
 
-proc writeLn[Ty](f: File, x: varargs[Ty, `$`]) =
-  for i in items(x):
-    write(f, i)
-  write(f, "\n")
-
 proc writeLine*[Ty](f: File, x: varargs[Ty, `$`]) {.inline,
                           tags: [WriteIOEffect], benign.} =
   ## writes the values `x` to `f` and then writes "\\n".

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -190,6 +190,14 @@ function main() {
     title="p1()"><wbr />p1<span class="attachedType"></span></a></li>
   <li><a class="reference" href="#addfBug14485"
     title="addfBug14485()"><wbr />addf<wbr />Bug14485<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#c_printf%2Ccstring"
+    title="c_printf(frmt: cstring): cint"><wbr />c_<wbr />printf<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#c_nonexistant%2Ccstring"
+    title="c_nonexistant(frmt: cstring): cint"><wbr />c_<wbr />nonexistant<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#low%2CT"
+    title="low[T: Ordinal | enum | range](x: T): T"><wbr />low<span class="attachedType"></span></a></li>
+  <li><a class="reference" href="#low2%2CT"
+    title="low2[T: Ordinal | enum | range](x: T): T"><wbr />low2<span class="attachedType"></span></a></li>
 
   </ul>
 </li>
@@ -545,6 +553,46 @@ Some proc
 6: &lt;/script
 7: end of broken html
 ]#</span></pre>
+
+</dd>
+<a id="c_printf,cstring"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#c_printf%2Ccstring"><span class="Identifier">c_printf</span></a><span class="Other">(</span><span class="Identifier">frmt</span><span class="Other">:</span> <span class="Identifier">cstring</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">cint</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">importc</span><span class="Other">:</span> <span class="StringLit">&quot;printf&quot;</span><span class="Other">,</span> <span class="Identifier">header</span><span class="Other">:</span> <span class="StringLit">&quot;&lt;stdio.h&gt;&quot;</span><span class="Other">,</span> <span class="Identifier">varargs</span><span class="Other">,</span>
+                                 <span class="Identifier">discardable</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+the c printf. etc.
+
+</dd>
+<a id="c_nonexistant,cstring"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#c_nonexistant%2Ccstring"><span class="Identifier">c_nonexistant</span></a><span class="Other">(</span><span class="Identifier">frmt</span><span class="Other">:</span> <span class="Identifier">cstring</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">cint</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">importc</span><span class="Other">:</span> <span class="StringLit">&quot;nonexistant&quot;</span><span class="Other">,</span> <span class="Identifier">header</span><span class="Other">:</span> <span class="StringLit">&quot;&lt;stdio.h&gt;&quot;</span><span class="Other">,</span>
+                                      <span class="Identifier">varargs</span><span class="Other">,</span> <span class="Identifier">discardable</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+
+
+</dd>
+<a id="low,T"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#low%2CT"><span class="Identifier">low</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">:</span> <span class="Identifier">Ordinal</span> <span class="Operator">|</span> <span class="Keyword">enum</span> <span class="Operator">|</span> <span class="Identifier">range</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">x</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">magic</span><span class="Other">:</span> <span class="StringLit">&quot;Low&quot;</span><span class="Other">,</span> <span class="Identifier">noSideEffect</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+<p>Returns the lowest possible value of an ordinal value <tt class="docutils literal"><span class="pre">x</span></tt>. As a special semantic rule, <tt class="docutils literal"><span class="pre">x</span></tt> may also be a type identifier.</p>
+<p>See also:</p>
+<ul class="simple"><li><a class="reference external" href="#low2,T">low2(T)</a></li>
+</ul>
+<pre class="listing"><span class="Identifier">low</span><span class="Punctuation">(</span><span class="DecNumber">2</span><span class="Punctuation">)</span> <span class="Comment"># =&gt; -9223372036854775808</span></pre>
+
+</dd>
+<a id="low2,T"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#low2%2CT"><span class="Identifier">low2</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">:</span> <span class="Identifier">Ordinal</span> <span class="Operator">|</span> <span class="Keyword">enum</span> <span class="Operator">|</span> <span class="Identifier">range</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">x</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">magic</span><span class="Other">:</span> <span class="StringLit">&quot;Low&quot;</span><span class="Other">,</span> <span class="Identifier">noSideEffect</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+<p>Returns the lowest possible value of an ordinal value <tt class="docutils literal"><span class="pre">x</span></tt>. As a special semantic rule, <tt class="docutils literal"><span class="pre">x</span></tt> may also be a type identifier.</p>
+<p>See also:</p>
+<ul class="simple"><li><a class="reference external" href="#low,T">low(T)</a></li>
+</ul>
+<pre class="listing"><span class="Identifier">low2</span><span class="Punctuation">(</span><span class="DecNumber">2</span><span class="Punctuation">)</span> <span class="Comment"># =&gt; -9223372036854775808</span></pre>
+<p><strong class="examples_text">Example:</strong></p>
+<pre class="listing"><span class="Keyword">discard</span><span class="Whitespace"> </span><span class="StringLit">&quot;in low2&quot;</span></pre>
 
 </dd>
 

--- a/nimdoc/testproject/expected/testproject.idx
+++ b/nimdoc/testproject/expected/testproject.idx
@@ -33,6 +33,10 @@ baz	testproject.html#baz	testproject: baz()
 z17	testproject.html#z17	testproject: z17()	
 p1	testproject.html#p1	testproject: p1()	
 addfBug14485	testproject.html#addfBug14485	testproject: addfBug14485()	
+c_printf	testproject.html#c_printf,cstring	testproject: c_printf(frmt: cstring): cint	
+c_nonexistant	testproject.html#c_nonexistant,cstring	testproject: c_nonexistant(frmt: cstring): cint	
+low	testproject.html#low,T	testproject: low[T: Ordinal | enum | range](x: T): T	
+low2	testproject.html#low2,T	testproject: low2[T: Ordinal | enum | range](x: T): T	
 bar	testproject.html#bar.m	testproject: bar(): untyped	
 z16	testproject.html#z16.m	testproject: z16()	
 z18	testproject.html#z18.m	testproject: z18(): int	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -129,6 +129,14 @@ function main() {
 <li><a class="reference external"
           data-doc-search-tag="testproject: C_D" href="testproject.html#C_D">testproject: C_D</a></li>
           </ul></dd>
+<dt><a name="c_nonexistant" href="#c_nonexistant"><span>c_nonexistant:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: c_nonexistant(frmt: cstring): cint" href="testproject.html#c_nonexistant%2Ccstring">testproject: c_nonexistant(frmt: cstring): cint</a></li>
+          </ul></dd>
+<dt><a name="c_printf" href="#c_printf"><span>c_printf:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: c_printf(frmt: cstring): cint" href="testproject.html#c_printf%2Ccstring">testproject: c_printf(frmt: cstring): cint</a></li>
+          </ul></dd>
 <dt><a name="enumValueA" href="#enumValueA"><span>enumValueA:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="SomeType.enumValueA" href="subdir/subdir_b/utils.html#enumValueA">SomeType.enumValueA</a></li>
@@ -172,6 +180,14 @@ function main() {
 <dt><a name="isValid" href="#isValid"><span>isValid:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="testproject: isValid[T](x: T): bool" href="testproject.html#isValid%2CT">testproject: isValid[T](x: T): bool</a></li>
+          </ul></dd>
+<dt><a name="low" href="#low"><span>low:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: low[T: Ordinal | enum | range](x: T): T" href="testproject.html#low%2CT">testproject: low[T: Ordinal | enum | range](x: T): T</a></li>
+          </ul></dd>
+<dt><a name="low2" href="#low2"><span>low2:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: low2[T: Ordinal | enum | range](x: T): T" href="testproject.html#low2%2CT">testproject: low2[T: Ordinal | enum | range](x: T): T</a></li>
           </ul></dd>
 <dt><a name="myfn" href="#myfn"><span>myfn:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -177,6 +177,36 @@ when true: # issue #14485
       7: end of broken html
       ]#
 
+when true: # procs without `=` (using comment field)
+  proc c_printf*(frmt: cstring): cint {.importc: "printf", header: "<stdio.h>", varargs, discardable.}
+    ## the c printf.
+    ## etc.
+
+  proc c_nonexistant*(frmt: cstring): cint {.importc: "nonexistant", header: "<stdio.h>", varargs, discardable.}
+
+when true: # tests RST inside comments
+  proc low*[T: Ordinal|enum|range](x: T): T {.magic: "Low", noSideEffect.}
+    ## Returns the lowest possible value of an ordinal value `x`. As a special
+    ## semantic rule, `x` may also be a type identifier.
+    ##
+    ## See also:
+    ## * `low2(T) <#low2,T>`_
+    ##
+    ## .. code-block:: Nim
+    ##  low(2) # => -9223372036854775808
+
+  proc low2*[T: Ordinal|enum|range](x: T): T {.magic: "Low", noSideEffect.} =
+    ## Returns the lowest possible value of an ordinal value `x`. As a special
+    ## semantic rule, `x` may also be a type identifier.
+    ##
+    ## See also:
+    ## * `low(T) <#low,T>`_
+    ##
+    ## .. code-block:: Nim
+    ##  low2(2) # => -9223372036854775808
+    runnableExamples:
+      discard "in low2"
+
 when true: # (most) macros
   macro bar*(): untyped =
     result = newStmtList()


### PR DESCRIPTION
this is really a 1 line fix `dest.add genComment(d, n).rope`, the rest is just adding a regression test.
Hopefully with all those regression tests in place, it'll become much harder to accidentally introduce docgen bugs...

fixes a regression where procs without body (ie, no `=` sign) would not have their `comment` field docgen'd

unrelated: remove deadcode writeLn (so that on push, docs will rebuild as otherwise filtering rules would not rebuild docs ...)

