### PR TITLE
walkDirRecFilter, update doc CI filter,  compiler/index.nim for docs + various other fixes

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -1,29 +1,17 @@
 name: Nim Docs CI
 on:
   push:
-    # Run only on changes on these files
-    paths:
-      - 'compiler/docgen.nim'
-      - 'compiler/renderverbatim.nim'
-      - 'doc/**.rst'
-      - 'doc/nimdoc.css' # xxx is it worth duplicating just because of this entry which rarely changes?
-      - 'lib/**.nim'
-      - 'nimdoc/testproject/expected/testproject.html'
-      - 'tools/dochack/dochack.nim'
-      - 'tools/kochdocs.nim'
-      - '.github/workflows/ci_docs.yml'
-
   pull_request:
     # Run only on changes on these files
     paths:
       - 'compiler/docgen.nim'
       - 'compiler/renderverbatim.nim'
       - 'doc/**.rst'
+      - 'doc/nimdoc.css'
       - 'lib/**.nim'
       - 'nimdoc/testproject/expected/testproject.html'
       - 'tools/dochack/dochack.nim'
       - 'tools/kochdocs.nim'
-      - 'tools/dochack/dochack.nim'
       - '.github/workflows/ci_docs.yml'
 
 jobs:

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -114,13 +114,6 @@ jobs:
         shell: bash
         run: ./koch doc --git.commit:devel
 
-      - name: 'Prepare documentation for deployment'
-        if: |
-          github.event_name == 'push' && github.ref == 'refs/heads/devel' &&
-          matrix.target == 'linux'
-        shell: bash
-        run: cp -f doc/html/{overview,index}.html
-
       - name: 'Publish documentation to Github Pages'
         if: |
           github.event_name == 'push' && github.ref == 'refs/heads/devel' &&

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -1,6 +1,16 @@
 name: Nim Docs CI
 on:
   push:
+    paths:
+      - 'compiler/docgen.nim'
+      - 'compiler/renderverbatim.nim'
+      - 'doc/**.rst'
+      - 'doc/nimdoc.css'
+      - 'lib/**.nim'
+      - 'nimdoc/testproject/expected/testproject.html'
+      - 'tools/dochack/dochack.nim'
+      - 'tools/kochdocs.nim'
+      - '.github/workflows/ci_docs.yml'
   pull_request:
     # Run only on changes on these files
     paths:

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -3,16 +3,27 @@ on:
   push:
     # Run only on changes on these files
     paths:
-      - 'lib/**.nim'
+      - 'compiler/docgen.nim'
+      - 'compiler/renderverbatim.nim'
       - 'doc/**.rst'
-      - 'doc/nimdoc.css'
+      - 'doc/nimdoc.css' # xxx is it worth duplicating just because of this entry which rarely changes?
+      - 'lib/**.nim'
+      - 'nimdoc/testproject/expected/testproject.html'
+      - 'tools/dochack/dochack.nim'
+      - 'tools/kochdocs.nim'
       - '.github/workflows/ci_docs.yml'
 
   pull_request:
     # Run only on changes on these files
     paths:
-      - 'lib/**.nim'
+      - 'compiler/docgen.nim'
+      - 'compiler/renderverbatim.nim'
       - 'doc/**.rst'
+      - 'lib/**.nim'
+      - 'nimdoc/testproject/expected/testproject.html'
+      - 'tools/dochack/dochack.nim'
+      - 'tools/kochdocs.nim'
+      - 'tools/dochack/dochack.nim'
       - '.github/workflows/ci_docs.yml'
 
 jobs:

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -19,6 +19,8 @@ import
   typesrenderer, astalgo, lineinfos, intsets,
   pathutils, trees, tables, nimpaths, renderverbatim
 
+from std/private/globs import nativeToUnixPath
+
 const
   exportSection = skField
   docCmdSkip = "skip"
@@ -52,12 +54,6 @@ type
     wroteSupportFiles*: bool
 
   PDoc* = ref TDocumentor ## Alias to type less.
-
-proc nativeToUnix(path: string): string =
-  doAssert not path.isAbsolute # absolute files need more care for the drive
-  when DirSep == '\\':
-    result = replace(path, '\\', '/')
-  else: result = path
 
 proc docOutDir(conf: ConfigRef, subdir: RelativeDir = RelativeDir""): AbsoluteDir =
   if not conf.outDir.isEmpty: conf.outDir else: conf.projectPath / subdir
@@ -97,7 +93,7 @@ proc presentationPath*(conf: ConfigRef, file: AbsoluteFile, isTitle = false): Re
   if isAbsolute(result.string):
     result = file.string.splitPath()[1].RelativeFile
   if isTitle:
-    result = result.string.nativeToUnix.RelativeFile
+    result = result.string.nativeToUnixPath.RelativeFile
   else:
     result = result.string.replace("..", dotdotMangle).RelativeFile
   doAssert not result.isEmpty
@@ -1244,7 +1240,7 @@ proc genOutFile(d: PDoc): Rope =
   # Extract the title. Non API modules generate an entry in the index table.
   if d.meta[metaTitle].len != 0:
     title = d.meta[metaTitle]
-    let external = presentationPath(d.conf, AbsoluteFile d.filename).changeFileExt(HtmlExt).string.nativeToUnix
+    let external = presentationPath(d.conf, AbsoluteFile d.filename).changeFileExt(HtmlExt).string.nativeToUnixPath
     setIndexTerm(d[], external, "", title)
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1251,13 +1251,16 @@ proc genOutFile(d: PDoc): Rope =
     # better than `extractFilename(changeFileExt(d.filename, ""))` as it disambiguates dups
     title = $presentationPath(d.conf, AbsoluteFile d.filename, isTitle = true).changeFileExt("")
 
-  let bodyname = if d.hasToc and not d.isPureRst: "doc.body_toc_group"
+  var groupsection = getConfigVar(d.conf, "doc.body_toc_groupsection")
+  let bodyname = if d.hasToc and not d.isPureRst:
+                   groupsection.setLen 0
+                   "doc.body_toc_group"
                  elif d.hasToc: "doc.body_toc"
                  else: "doc.body_no_toc"
   content = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, bodyname), ["title",
-      "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "theindexhref"],
+      "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "theindexhref", "body_toc_groupsection"],
       [title.rope, toc, d.modDesc, rope(getDateStr()),
-      rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile, theindexFname.RelativeFile)])
+      rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile, theindexFname.RelativeFile), groupsection.rope])
   if optCompileOnly notin d.conf.globalOptions:
     # XXX what is this hack doing here? 'optCompileOnly' means raw output!?
     code = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.file"), [

--- a/compiler/index.nim
+++ b/compiler/index.nim
@@ -8,9 +8,11 @@ This module only exists to generate docs for the compiler.
 ]##
 
 #[
-note: this is named index so that https://nim-lang.github.io/Nim/compiler/ will work
-xxx this should also import other modules, eg `evalffi`, otherwise these aren't
-shown. A glob could be used at CT.
+note: this is named `index` so that navigating to https://nim-lang.github.io/Nim/compiler/
+will work.
+
+xxx this should also import other modules, not transitively imported by `compiler/nim.nim`,
+eg `evalffi`, otherwise these aren't shown. A glob could be used at CT.
 ]#
 
-import nim, evalffi
+import nim

--- a/compiler/index.nim
+++ b/compiler/index.nim
@@ -1,0 +1,16 @@
+##[
+This module only exists to generate docs for the compiler.
+
+## links
+* [main docs](../lib.html)
+* [compiler user guide](../nimc.html)
+* [Internals of the Nim Compiler](../intern.html)
+]##
+
+#[
+note: this is named index so that https://nim-lang.github.io/Nim/compiler/ will work
+xxx this should also import other modules, eg `evalffi`, otherwise these aren't
+shown. A glob could be used at CT.
+]#
+
+import nim, evalffi

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -145,6 +145,9 @@ doc.body_toc_group = """
       <li>
         <a href="$theindexhref">Index</a>
       </li>
+      <li>
+        <a href="compiler/$theindexhref">Compiler Index</a>
+      </li>
     </ul>
   </div>
   <div id="searchInputDiv">

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -81,42 +81,14 @@ $content
 </ul>
 """
 
-doc.body_toc = """
-<div class="row">
-  <div class="three columns">
-  <div class="theme-switch-wrapper">
-    <label class="theme-switch" for="checkbox">
-      <input type="checkbox" id="checkbox" />
-      <div class="slider round"></div>
-    </label>
-   &nbsp;&nbsp;&nbsp; <em>Dark Mode</em>
+doc.body_toc_groupsection = """
+  <div class="search-groupby">
+    Group by:
+    <select onchange="groupBy(this.value)">
+      <option value="section">Section</option>
+      <option value="type">Type</option>
+    </select>
   </div>
-  <div id="global-links">
-    <ul class="simple-boot">
-      <li>
-        <a href="manual.html">Manual</a>
-      </li>
-      <li>
-        <a href="lib.html">Standard library</a>
-      </li>
-      <li>
-        <a href="$theindexhref">Index</a>
-      </li>
-    </ul>
-  </div>
-  <div id="searchInputDiv">
-    Search: <input type="text" id="searchInput"
-      onkeyup="search()" />
-  </div>
-  $tableofcontents
-  </div>
-  <div class="nine columns" id="content">
-  <div id="tocRoot"></div>
-  $deprecationMsg
-  <p class="module-desc">$moduledesc</p>
-  $content
-  </div>
-</div>
 """
 
 @if boot:
@@ -146,7 +118,7 @@ doc.body_toc_group = """
         <a href="$theindexhref">Index</a>
       </li>
       <li>
-        <a href="compiler/$theindexhref">Compiler Index</a>
+        <a href="compiler/$theindexhref">Compiler docs</a>
       </li>
     </ul>
   </div>
@@ -154,13 +126,7 @@ doc.body_toc_group = """
     Search: <input type="text" id="searchInput"
       onkeyup="search()" />
   </div>
-  <div class="search-groupby">
-    Group by:
-    <select onchange="groupBy(this.value)">
-      <option value="section">Section</option>
-      <option value="type">Type</option>
-    </select>
-  </div>
+  $body_toc_groupsection
   $tableofcontents
   </div>
   <div class="nine columns" id="content">
@@ -213,6 +179,8 @@ doc.body_toc_group = """
 </div>
 """
 @end
+
+doc.body_toc %= "${doc.body_toc_group}" # should only be used for boot
 
 doc.body_no_toc = """
 $moduledesc

--- a/doc/idetools.rst
+++ b/doc/idetools.rst
@@ -13,6 +13,8 @@
   "yes, I'm the creator" -- Araq, 2013-07-26 19:28:32.
   </p></blockquote>
 
+Note: this is mostly outdated, see instead `nimsuggest <nimsuggest.html>`_
+
 Nim differs from many other compilers in that it is really fast,
 and being so fast makes it suited to provide external queries for
 text editors about the source code being written. Through the

--- a/koch.nim
+++ b/koch.nim
@@ -651,6 +651,13 @@ when isMainModule:
       of "latest": latest = true
       of "stable": latest = false
       of "nim": nimExe = op.val.absolutePath # absolute so still works with changeDir
+      of "docslocal":
+        # undocumented for now, allows to rebuild local docs in < 40s as follows:
+        # `./koch --nim:$nimb --docslocal:htmldocs2 --doccmd:skip --warnings:off --hints:off`
+        # whereas `./koch docs` takes 190s; useful for development.
+        doAssert op.val.len > 0
+        buildDocsDir(op.cmdLineRest, op.val)
+        break
       else: showHelp()
     of cmdArgument:
       case normalize(op.key)

--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -4,7 +4,7 @@ this can eventually be moved to std/os and `walkDirRec` can be implemented in te
 to avoid duplication
 ]##
 
-import std/os
+import std/[os,strutils]
 
 type
   PathEntry* = object

--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -1,0 +1,54 @@
+##[
+unstable API, internal use only for now.
+this can eventually be moved to std/os and `walkDirRec` can be implemented in terms of this
+to avoid duplication
+]##
+
+import std/os
+
+type
+  PathEntry* = object
+    kind*: PathComponent
+    path*: string
+
+iterator walkDirRecFilter*(dir: string, follow: proc(entry: PathEntry): bool = nil,
+    relative = false, checkDir = true): PathEntry {.tags: [ReadDirEffect].} =
+  ## Improved `os.walkDirRec`.
+  #[
+  note: a yieldFilter isn't needed because caller can filter at call site, without
+  loss of generality, unlike `follow`.
+
+  Future work:
+  * need to document
+  * add a `sort` option, which can be implemented efficiently only here, not at call site.
+  * provide a way to do error reporting, which is tricky because iteration cannot be resumed
+  ]#
+  var stack = @["."]
+  var checkDir = checkDir
+  var entry: PathEntry
+  while stack.len > 0:
+    let d = stack.pop()
+    for k, p in walkDir(dir / d, relative = true, checkDir = checkDir):
+      let rel = d / p
+      entry.kind = k
+      if relative: entry.path = rel
+      else: entry.path = dir / rel
+      if k in {pcDir, pcLinkToDir}:
+        if follow == nil or follow(entry): stack.add rel
+      yield entry
+    checkDir = false
+      # We only check top-level dir, otherwise if a subdir is invalid (eg. wrong
+      # permissions), it'll abort iteration and there would be no way to
+      # continue iteration.
+
+proc nativeToUnixPath*(path: string): string =
+  # pending https://github.com/nim-lang/Nim/pull/13265
+  doAssert not path.isAbsolute # not implemented here; absolute files need more care for the drive
+  when DirSep == '\\':
+    result = replace(path, '\\', '/')
+  else: result = path
+
+when isMainModule:
+  import sugar
+  for a in walkDirRecFilter(".", follow = a=>a.path.lastPathPart notin ["nimcache", ".git", ".csources", "bin"]):
+    echo a

--- a/lib/std/time_t.nim
+++ b/lib/std/time_t.nim
@@ -9,8 +9,8 @@
 
 when defined(nimdoc):
   type
-    impl = distinct int64
-    Time* = impl ## \
+    Impl = distinct int64
+    Time* = Impl ## \
       ## Wrapper for ``time_t``. On posix, this is an alias to ``posix.Time``.
 elif defined(windows):
   when defined(i386) and defined(gcc):

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -11,6 +11,7 @@ import std/[strformat,os,osproc,unittest]
 from std/sequtils import toSeq,mapIt
 from std/algorithm import sorted
 import stdtest/[specialpaths, unittest_light]
+from std/private/globs import nativeToUnixPath
 
 import "$lib/../compiler/nimpaths"
 
@@ -90,11 +91,7 @@ else: # don't run twice the same test
       removeDir(htmldocsDir)
       let (outp, exitCode) = execCmdEx(cmd)
       check exitCode == 0
-      proc nativeToUnixPathWorkaround(a: string): string =
-        # xxx pending https://github.com/nim-lang/Nim/pull/13265 `nativeToUnixPath`
-        a.replace(DirSep, '/')
-
-      let ret = toSeq(walkDirRec(htmldocsDir, relative=true)).mapIt(it.nativeToUnixPathWorkaround).sorted.join("\n")
+      let ret = toSeq(walkDirRec(htmldocsDir, relative=true)).mapIt(it.nativeToUnixPath).sorted.join("\n")
       let context = $(i, ret, cmd)
       var expected = ""
       case i

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -86,6 +86,14 @@ proc nimCompileFold*(desc, input: string, outputDir = "bin", mode = "c", options
   let cmd = findNim().quoteShell() & " " & mode & " -o:" & output & " " & options & " " & input
   execFold(desc, cmd)
 
+proc getRst2html(): seq[string] =
+  for a in walkDirRecFilter("doc"):
+    let path = a.path
+    if a.kind == pcFile and path.splitFile.ext == ".rst" and path.lastPathPart notin
+        ["docs.rst","docstyle.rst", "nimfix.rst"] # xxxx is exclusion intentional?
+      result.add a.path
+  doAssert "doc/manual/var_t_return.rst" in result # sanity check
+
 const
   pdf = """
 doc/manual.rst
@@ -96,39 +104,6 @@ doc/tut3.rst
 doc/nimc.rst
 doc/niminst.rst
 doc/gc.rst
-""".splitWhitespace()
-
-  rst2html = """
-doc/intern.rst
-doc/apis.rst
-doc/lib.rst
-doc/manual.rst
-doc/manual_experimental.rst
-doc/destructors.rst
-doc/tut1.rst
-doc/tut2.rst
-doc/tut3.rst
-doc/nimc.rst
-doc/hcr.rst
-doc/drnim.rst
-doc/overview.rst
-doc/filters.rst
-doc/tools.rst
-doc/niminst.rst
-doc/nimgrep.rst
-doc/gc.rst
-doc/estp.rst
-doc/idetools.rst
-doc/docgen.rst
-doc/koch.rst
-doc/backends.rst
-doc/nimsuggest.rst
-doc/nep1.rst
-doc/nims.rst
-doc/contributing.rst
-doc/codeowners.rst
-doc/packaging.rst
-doc/manual/var_t_return.rst
 """.splitWhitespace()
 
   doc0 = """
@@ -253,6 +228,7 @@ proc buildDocPackages(nimArgs, destPath: string) =
 
 proc buildDoc(nimArgs, destPath: string) =
   # call nim for the documentation:
+  let rst2html = getRst2html()
   var
     commands = newSeq[string](rst2html.len + len(doc0) + len(doc) + withoutIndex.len)
     i = 0

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -231,13 +231,24 @@ proc buildDocSamples(nimArgs, destPath: string) =
     [nimArgs, destPath / "docgen_sample.html", "doc" / "docgen_sample.nim"])
 
 proc buildDocPackages(nimArgs, destPath: string) =
-  # compiler docs, and later, other packages (perhaps tools, testament etc)
+  # compiler docs; later, other packages (perhaps tools, testament etc)
   let nim = findNim().quoteShell()
-  let extra = "-u:boot"
     # to avoid broken links to manual from compiler dir, but a multi-package
     # structure could be supported later
-  exec("$1 doc --project --outdir:$2/compiler $3 --git.url:$4 $5 compiler/nim.nim" %
-    [nim, destPath, nimArgs, gitUrl, extra])
+
+  proc docProject(outdir, options, mainproj: string) =
+    exec("$nim doc --project --outdir:$outdir $nimArgs --git.url:$gitUrl $options $mainproj" % [
+      "nim", nim,
+      "outdir", outdir,
+      "nimArgs", nimArgs,
+      "gitUrl", gitUrl,
+      "options", options,
+      "mainproj", mainproj,
+      ])
+  let extra = "-u:boot"
+  # xxx keep in sync with what's in $nim_prs_D/config/nimdoc.cfg, or, rather,
+  # start using nims instead of nimdoc.cfg
+  docProject(destPath/"compiler", extra, "compiler/index.nim")
 
 proc buildDoc(nimArgs, destPath: string) =
   # call nim for the documentation:
@@ -314,9 +325,9 @@ proc buildDocs*(args: string) =
     let args2 = args
     createDir(dir2)
     buildDocSamples(args2, dir2)
-    buildDoc(args2, dir2)
+    # buildDoc(args2, dir2) # slow part
     buildDocPackages(args2, dir2)
     copyFile(docHackJsSource, dir2 / docHackJsSource.lastPathPart)
 
-  fn(nimArgs & " " & args, webUploadOutput / NimVersion)
+  # fn(nimArgs & " " & args, webUploadOutput / NimVersion)
   fn(nimArgs, docHtmlOutput) # no `args` to avoid offline docs containing the 'gaCode'!

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -90,9 +90,11 @@ proc getRst2html(): seq[string] =
   for a in walkDirRecFilter("doc"):
     let path = a.path
     if a.kind == pcFile and path.splitFile.ext == ".rst" and path.lastPathPart notin
-        ["docs.rst","docstyle.rst", "nimfix.rst"]: # xxxx is exclusion intentional?
+        ["docs.rst", "nimfix.rst"]:
+          # maybe we should still show nimfix, could help reviving it
+          # `docs` is redundant with `overview`, might as well remove that file?
       result.add path
-  doAssert "doc/manual/var_t_return.rst" in result # sanity check
+  doAssert "doc/manual/var_t_return.rst".unixToNativePath in result # sanity check
 
 const
   pdf = """

--- a/tools/nimblepkglist.nim
+++ b/tools/nimblepkglist.nim
@@ -1,3 +1,6 @@
+#[
+deadcode?
+]#
 import base64, strutils, json, htmlgen, dom, algorithm
 
 type


### PR DESCRIPTION
## update doc CI filter to include the files mostly likely to require doc rebuild
unlike previous attempt (https://github.com/nim-lang/Nim/pull/13853/files), this is much more targeted, just the usual suspects that affect docs the most.
* not sure what's the need for special casing `doc/nimdoc.css` ; ok to just merge those 2 lists to avoid duplication (in this or a cleanup pr)?
* I've also asked here https://github.community/t/how-to-factor-paths-in-common-for-push-and-pull-request/115967 for how to refactor 2 paths lists to avoid duplication by having a common subset

EDIT: CI fails on windows, which is a reason why this PR is needed (catch issues on code PRs that introduce problem, not later); I suspect it's because `nim doc --project compiler/nim` fails on windows... investigating

## refactor all workaround implementations of nativeToUnixPath into 1
(I still need to finish https://github.com/nim-lang/Nim/pull/13265)

## added compiler/index.nim
because https://nim-lang.github.io/Nim/compiler/nim.html was very underwhelming
after this PR navigating to https://nim-lang.github.io/Nim/compiler/ will do something useful

## removed template duplication in config/nimdoc.cfg
and made sure it all works; so there's only 1 template to update

## added undocumented `./koch --docslocal:myhtmldocs`
so you can build all the docs n 40s instead of 190s as follows:
`./koch --nim:$nimb --docslocal:htmldocs2 --doccmd:skip --warnings:off --hints:off`
which is useful during local development when you need to run this a few times

## added lib/std/private/globs.nim
for internal use only only (ie for any module inside nim repo) for now, but aim is to eventually merge those into stdlib.os once API stabilizes; same spirit as compiler/pathutils except `lib/std/private/` is the perfect staging place IMO if you need to use it from not just `compiler/` but other places (eg kochdocs, koch, tools, compiler, other modules in stdlib etc), giving it some internal exposure to give a chance to fix API without breaking user code, before converting it.

`private` conveys exactly what it is: for internal use only, if you use it in your code outside of nim repo it may break at any time

* added `walkDirRecFilter`
that's IMO the better API, and the most flexible (and walkDirRec can later be implemented on top of it)
It's a common requested feature (eg see recent thread [Can I "prune" directories with walkDirRect? - Nim forum](https://forum.nim-lang.org/t/5506)) and should be in stdlib; but I also needed it in this PR, see below

* fix a bug in `getDocList`
this was picking up all the nim files in various nimcache folders in my repo (eg those created by runnableExamples); noone noticed since these don't export any symbols and therefore don't end up in the docs, but `nim doc` was being run on all of these, and there were quite a lot, slowing down `koch docs`.

The clean way to filter is via a follow filter (ie "filter early" before recursing down a folder instead of filtering at the end which is less efficient), hence `walkDirRecFilter`


## fix a bug in lib/std/time_t.nim
which was making docs CI fail on windows since the compiler docs were enabled

## used a glob to generate the rst files; added back `docstyle` which wasn't being docgen'd
i added `docstyle`  which seemed like an unintentional omission
I kept docs.rst out since it's just an include
ditto with nimfix which is dead for now ( :-( ), but I wouldn't mind showing it in docs, would increase likelihood it gets revived

=> that's why glob+blacklist is always better than whitelist
