### PR TITLE
Add generic procs to endians module

### DIFF
--- a/lib/pure/endians.nim
+++ b/lib/pure/endians.nim
@@ -111,3 +111,29 @@ else:
   proc bigEndian64*(outp, inp: pointer) {.inline.} = swapEndian64(outp, inp)
   proc bigEndian32*(outp, inp: pointer) {.inline.} = swapEndian32(outp, inp)
   proc bigEndian16*(outp, inp: pointer) {.inline.} = swapEndian16(outp, inp)
+
+proc getLittleEndian*[T](val: T): T {.noSideEffect, inline.} =
+  var src = val
+  when sizeof(T) == 1:
+    result = src
+  elif sizeof(T) == 2:
+    littleEndian16(addr result, addr src)
+  elif sizeof(T) == 4:
+    littleEndian32(addr result, addr src)
+  elif sizeof(T) == 8:
+    littleEndian64(addr result, addr src)
+  else:
+    {.error: "Types that are larger than 64 bits are not supported.".}
+
+proc getBigEndian*[T](val: T): T {.noSideEffect, inline.} =
+  var src = val
+  when sizeof(T) == 1:
+    result = src
+  elif sizeof(T) == 2:
+    bigEndian16(addr result, addr src)
+  elif sizeof(T) == 4:
+    bigEndian32(addr result, addr src)
+  elif sizeof(T) == 8:
+    bigEndian64(addr result, addr src)
+  else:
+    {.error: "Types that are larger than 64 bits are not supported.".}

--- a/tests/stdlib/tendians.nim
+++ b/tests/stdlib/tendians.nim
@@ -1,0 +1,37 @@
+import endians
+
+proc main() =
+  var
+    a8: int8 = 123
+    a16: int16 = 0x1234
+    a32: int32 = 0x12345678
+    a64: int64 = 0x123456789abcde1f
+    l8 = a8.getLittleEndian()
+    l16 = a16.getLittleEndian()
+    l32 = a32.getLittleEndian
+    l64 = a64.getLittleEndian
+    b8 = a8.getBigEndian
+    b16 = a16.getBigEndian
+    b32 = a32.getBigEndian
+    b64 = a64.getBigEndian
+
+  when system.cpuEndian == bigEndian:
+    doAssert l8 == 123
+    doAssert l16 == 0x3412
+    doAssert l32 == 0x78563412
+    doAssert l64 == 0x1fdebc9a78563412
+    doAssert b8 == 123
+    doAssert b16 == 0x1234
+    doAssert b32 == 0x12345678
+    doAssert b64 == 0x123456789abcde1f
+  else:
+    doAssert l8 == 123
+    doAssert l16 == 0x1234
+    doAssert l32 == 0x12345678
+    doAssert l64 == 0x123456789abcde1f
+    doAssert b8 == 123
+    doAssert b16 == 0x3412
+    doAssert b32 == 0x78563412
+    doAssert b64 == 0x1fdebc9a78563412
+
+main()


### PR DESCRIPTION
Existsing `littleEndian*` and `bigEndian` are not easy to use as they take addresses of arguments.
So I added 2 generic procedures.