### PR TITLE
Always semOperand params

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -47,7 +47,7 @@ template rejectEmptyNode(n: PNode) =
   if n.kind == nkEmpty: illFormedAst(n, c.config)
 
 proc semOperand(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
-  rejectEmptyNode(n)
+  if n.kind == nkEmpty: return n #rejectEmptyNode(n)
   # same as 'semExprWithType' but doesn't check for proc vars
   result = semExpr(c, n, flags + {efOperand})
   if result.typ != nil:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2271,7 +2271,7 @@ proc prepareOperand(c: PContext; formal: PType; a: PNode): PNode =
                 #else: {efDetermineType}
     result = c.semOperand(c, a, flags)
   else:
-    result = a
+    result = c.semOperand(c, a, {efDetermineType})
     considerGenSyms(c, result)
 
 proc prepareOperand(c: PContext; a: PNode): PNode =

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2271,7 +2271,10 @@ proc prepareOperand(c: PContext; formal: PType; a: PNode): PNode =
                 #else: {efDetermineType}
     result = c.semOperand(c, a, flags)
   else:
-    result = c.semOperand(c, a, {efDetermineType})
+    if a.kind in nkCallKinds and a.len > 0 and a[0].kind == nkSym and a[0].sym.magic == mNBindSym:
+      result = a
+    else:
+      result = c.semOperand(c, a, {efDetermineType})
     considerGenSyms(c, result)
 
 proc prepareOperand(c: PContext; a: PNode): PNode =


### PR DESCRIPTION
This is most definitely wrong @zah @Araq .

It fixes this snippet infinitely recursing:
```nim
import macros

var a {.compileTime.} = 0

macro test(n: typed): bool =
  n.expectKind nnkDotExpr
  #if a > 3: quit 1 #Uncomment this to limit the recursion
  #inc a
  if n[1].kind == nnkIdent:
    var n = copyNimTree(n)
    n[0] = newCall("default", n[0])
    result = newCall("test", n)
    echo treeRepr result
  else:
    # This is never reached..
    result = newLit(true)

type Foo = object
  x: int

echo test(Foo.x)
```
because the `x` in the macro generated AST `test(default(Foo).x)` is never turned into a sym, while it should as it does in this example:
```nim
import macros

macro test(n: typed): bool =
  n.expectKind nnkDotExpr
  echo treeRepr n
  result = newLit(true)

type Foo = object
  x: int

echo test(default(Foo).x)
```