### PR TITLE
warn about observerable stores but don't prevent them for 1.2.2

### DIFF
--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -43,8 +43,9 @@ proc preventNrvo(p: BProc; le, ri: PNode): bool =
     for i in 1..<ri.len:
       let r = ri[i]
       if isPartOf(le, r) != arNo: return true
-    return canRaiseDisp(p, ri[0]) and
-        (p.nestedTryStmts.len > 0 or locationEscapes(p, le))
+    if canRaiseDisp(p, ri[0]) and
+        (p.nestedTryStmts.len > 0 or locationEscapes(p, le)):
+      message(p.config, le.info, warnObservableStores, $le)
 
 proc hasNoInit(call: PNode): bool {.inline.} =
   result = call[0].kind == nkSym and sfNoInit in call[0].sym.flags

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -52,7 +52,9 @@ type
     warnProveInit, warnProveField, warnProveIndex, warnUnreachableElse,
     warnStaticIndexCheck, warnGcUnsafe, warnGcUnsafe2,
     warnUninit, warnGcMem, warnDestructor, warnLockLevel, warnResultShadowed,
-    warnInconsistentSpacing, warnCaseTransition, warnCycleCreated, warnUser,
+    warnInconsistentSpacing, warnCaseTransition, warnCycleCreated,
+    warnObservableStores,
+    warnUser,
     hintSuccess, hintSuccessX, hintCC,
     hintLineTooLong, hintXDeclaredButNotUsed,
     hintConvToBaseNotNeeded,
@@ -119,6 +121,7 @@ const
     warnInconsistentSpacing: "Number of spaces around '$#' is not consistent",
     warnCaseTransition: "Potential object case transition, instantiate new object instead",
     warnCycleCreated: "$1",
+    warnObservableStores: "observable stores to '$1'",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`
@@ -169,7 +172,8 @@ const
     "ProveInit", "ProveField", "ProveIndex", "UnreachableElse",
     "IndexCheck", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed",
-    "Spacing", "CaseTransition", "CycleCreated", "User"]
+    "Spacing", "CaseTransition", "CycleCreated",
+    "ObservableStores", "User"]
 
   HintsToStr* = [
     "Success", "SuccessX", "CC", "LineTooLong",

--- a/tests/ccgbugs/tcodegenbug1.nim
+++ b/tests/ccgbugs/tcodegenbug1.nim
@@ -4,9 +4,9 @@ obj.inner.id = 7
 id = 7
 obj = (inner: (kind: Just, id: 7))
 2
-(a: "1", b: "2", c: "3")
+(a: "a", b: "b", c: "")
 caught
-(a: "1", b: "", c: "3")'''
+(a: "a", b: "b", c: "")'''
 """
 
 # bug #6960
@@ -164,7 +164,8 @@ proc ohmanNoNRVO =
     discard
 
   echo x
-  doAssert x.c == "3", "shouldn't modify x if f raises"
+  # once NVRO is sorted out, x.c == "3"
+  doAssert x.c == "", "shouldn't modify x if f raises"
 
 ohmanNoNRVO()
 
@@ -179,4 +180,5 @@ try:
 except:
   echo "caught"
 echo xgg
-doAssert xgg.c == "3", "this assert will fail"
+# once NVRO is sorted out, xgg.c == "3"
+doAssert xgg.c == "", "this assert will fail"


### PR DESCRIPTION
 [backport:1.2]; refs https://github.com/nim-lang/RFCs/issues/230