### PR TITLE
fix #14522, litterals > int64.high are now uint64

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -624,11 +624,9 @@ proc getNumber(L: var TLexer, result: var TToken) =
         result.tokType = tkInt64Lit
 
   except ValueError:
-    raise
-    # if false: lexMessageLitNum(L, "invalid number: '$1'", startpos)
+    lexMessageLitNum(L, "invalid number: '$1'", startpos)
   except OverflowDefect, RangeDefect:
-    raise
-    # lexMessageLitNum(L, "number out of range: '$1'", startpos)
+    lexMessageLitNum(L, "number out of range: '$1'", startpos)
   tokenEnd(result, postPos-1)
   L.bufpos = postPos
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -597,7 +597,6 @@ proc getNumber(L: var TLexer, result: var TToken) =
             iNumber = cast[int64](iNumber2)
             ok = true
             result.tokType = tkUInt64Lit
-            dbg iNumber, iNumber2, result.tokType
           except ValueError: discard
         if not ok:
           raise newException(OverflowDefect, "number out of range: " & $result.literal)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -155,8 +155,12 @@ proc checkConvertible(c: PContext, targetTyp: PType, src: PNode): TConvStatus =
     if targetTyp.kind == tyBool:
       discard "convOk"
     elif targetTyp.isOrdinalType:
+      # if src.kind == nkUInt64Lit and
+      #     cast[uint64](src.getInt) notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp):
+      #   result = convNotInRange
       if src.kind in nkCharLit..nkUInt64Lit and
           src.getInt notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp):
+        dbg targetTyp.isOrdinalType, src.kind, targetTyp, src.getInt, firstOrd(c.config, targetTyp), lastOrd(c.config, targetTyp), src.typ
         result = convNotInRange
       elif src.kind in nkFloatLit..nkFloat64Lit and
           (classify(src.floatVal) in {fcNan, fcNegInf, fcInf} or
@@ -316,6 +320,11 @@ proc semConv(c: PContext, n: PNode): PNode =
     of convNotInRange:
       let value =
         if op.kind in {nkCharLit..nkUInt64Lit}: $op.getInt else: $op.getFloat
+        # if op.kind in {nkCharLit..nkUInt64Lit}: $toInt128(op.intVal) else: $op.getFloat
+        # if op.kind in {nkCharLit..nkUInt64Lit}: $op.toInt128 else: $op.getFloat
+      dbg op.kind, n.renderTree, op.intVal, op.intVal.toInt128
+      debug(n)
+      dbg result.typ.typeToString
       localError(c.config, n.info, errGenerated, value & " can't be converted to " &
         result.typ.typeToString)
   else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -316,8 +316,6 @@ proc semConv(c: PContext, n: PNode): PNode =
     of convNotInRange:
       let value =
         if op.kind in {nkCharLit..nkUInt64Lit}: $op.getInt else: $op.getFloat
-        # if op.kind in {nkCharLit..nkUInt64Lit}: $toInt128(op.intVal) else: $op.getFloat
-        # if op.kind in {nkCharLit..nkUInt64Lit}: $op.toInt128 else: $op.getFloat
       localError(c.config, n.info, errGenerated, value & " can't be converted to " &
         result.typ.typeToString)
   else:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -155,12 +155,8 @@ proc checkConvertible(c: PContext, targetTyp: PType, src: PNode): TConvStatus =
     if targetTyp.kind == tyBool:
       discard "convOk"
     elif targetTyp.isOrdinalType:
-      # if src.kind == nkUInt64Lit and
-      #     cast[uint64](src.getInt) notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp):
-      #   result = convNotInRange
       if src.kind in nkCharLit..nkUInt64Lit and
           src.getInt notin firstOrd(c.config, targetTyp)..lastOrd(c.config, targetTyp):
-        dbg targetTyp.isOrdinalType, src.kind, targetTyp, src.getInt, firstOrd(c.config, targetTyp), lastOrd(c.config, targetTyp), src.typ
         result = convNotInRange
       elif src.kind in nkFloatLit..nkFloat64Lit and
           (classify(src.floatVal) in {fcNan, fcNegInf, fcInf} or
@@ -322,9 +318,6 @@ proc semConv(c: PContext, n: PNode): PNode =
         if op.kind in {nkCharLit..nkUInt64Lit}: $op.getInt else: $op.getFloat
         # if op.kind in {nkCharLit..nkUInt64Lit}: $toInt128(op.intVal) else: $op.getFloat
         # if op.kind in {nkCharLit..nkUInt64Lit}: $op.toInt128 else: $op.getFloat
-      dbg op.kind, n.renderTree, op.intVal, op.intVal.toInt128
-      debug(n)
-      dbg result.typ.typeToString
       localError(c.config, n.info, errGenerated, value & " can't be converted to " &
         result.typ.typeToString)
   else:

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -393,7 +393,7 @@ proc captureBetween*(s: string, first: char, second = '\0', start = 0): string =
   result = ""
   discard s.parseUntil(result, if second == '\0': first else: second, i)
 
-proc integerOutOfRangeDefect() {.noinline.} =
+proc integerOutOfRangeError() {.noinline.} =
   raise newException(ValueError, "Parsed integer outside of valid range")
 
 # See #6752
@@ -416,11 +416,11 @@ proc rawParseInt(s: string, b: var BiggestInt, start = 0): int =
       if b >= (low(BiggestInt) + c) div 10:
         b = b * 10 - c
       else:
-        integerOutOfRangeDefect()
+        integerOutOfRangeError()
       inc(i)
       while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
     if sign == -1 and b == low(BiggestInt):
-      integerOutOfRangeDefect()
+      integerOutOfRangeError()
     else:
       b = b * sign
       result = i - start
@@ -459,7 +459,7 @@ proc parseInt*(s: string, number: var int, start = 0): int {.
   result = parseBiggestInt(s, res, start)
   when sizeof(int) <= 4:
     if res < low(int) or res > high(int):
-      integerOutOfRangeDefect()
+      integerOutOfRangeError()
   if result != 0:
     number = int(res)
 
@@ -493,7 +493,7 @@ proc rawParseUInt(s: string, b: var BiggestUInt, start = 0): int =
     prev = 0.BiggestUInt
     i = start
   if i < s.len - 1 and s[i] == '-' and s[i + 1] in {'0'..'9'}:
-    integerOutOfRangeDefect()
+    integerOutOfRangeError()
   if i < s.len and s[i] == '+': inc(i) # Allow
   if i < s.len and s[i] in {'0'..'9'}:
     b = 0
@@ -501,7 +501,7 @@ proc rawParseUInt(s: string, b: var BiggestUInt, start = 0): int =
       prev = res
       res = res * 10 + (ord(s[i]) - ord('0')).BiggestUInt
       if prev > res:
-        integerOutOfRangeDefect()
+        integerOutOfRangeError()
       inc(i)
       while i < s.len and s[i] == '_': inc(i) # underscores are allowed and ignored
     b = res
@@ -540,7 +540,7 @@ proc parseUInt*(s: string, number: var uint, start = 0): int {.
   result = parseBiggestUInt(s, res, start)
   when sizeof(BiggestUInt) > sizeof(uint) and sizeof(uint) <= 4:
     if res > 0xFFFF_FFFF'u64:
-      integerOutOfRangeDefect()
+      integerOutOfRangeError()
   if result != 0:
     number = uint(res)
 

--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -23,3 +23,14 @@ template flakyAssert*(cond: untyped, msg = "", notifySuccess = true) =
       msg2.add " FLAKY_FAILURE "
     msg2.add $expr & " " & msg
     echo msg2
+
+import macros
+
+template doAssertParserRaises*(exception: typedesc, s: static string) =
+  # xxx not sure if there's a simpler way to pass a type (not as NimNode) to a macro
+  # but this works. Note: generic macros would solve this and other issues
+  # cleanly.
+  block:
+    macro doAssertParserRaises2(s2: static string): void =
+      doAssertRaises(exception): discard parseExpr(s2)
+    doAssertParserRaises2(s)

--- a/tests/errmsgs/tinteger_literals.nim
+++ b/tests/errmsgs/tinteger_literals.nim
@@ -4,12 +4,12 @@ errormsg: "number out of range: '300'u8'"
 nimout: '''
 tinteger_literals.nim(12, 9) Error: number out of range: '18446744073709551616'u64'
 tinteger_literals.nim(13, 9) Error: number out of range: '9223372036854775808'i64'
-tinteger_literals.nim(14, 9) Error: number out of range: '9223372036854775808'
 tinteger_literals.nim(15, 9) Error: number out of range: '300'u8'
 '''
 """
 
+
 discard 18446744073709551616'u64 # high(uint64) + 1
 discard 9223372036854775808'i64  # high(int64) + 1
-discard 9223372036854775808      # high(int64) + 1
+discard 9223372036854775808      # high(int64) + 1 # now ok!
 discard 300'u8

--- a/tests/misc/tunsignedconv.nim
+++ b/tests/misc/tunsignedconv.nim
@@ -79,6 +79,9 @@ import stdtest/testutils
 doAssertParserRaises(ValueError): "18374686479671623680'i64"
 doAssertParserRaises(ValueError): "183746864796716236804" # too big to fit uint64
 
+let z = 0xFF000000_00000000'i64
+# doAssertParserRaises(ValueError): "0xFF000000_00000000'i64"
+
 block: # issue #14529
   # BUG: `0xFF000000_0000000000000` should be an error, see https://github.com/nim-lang/Nim/issues/14529
   # doAssertParserRaises(ValueError): "0xFF000000_0000000000" # too big to fit uint64

--- a/tests/misc/tunsignedconv.nim
+++ b/tests/misc/tunsignedconv.nim
@@ -65,6 +65,10 @@ block: # issue #14522
   block:
     let a = 0xFF000000_00000000.uint64
     doAssert a is uint64
+    let a2 = 0xFF000000_00000000'i64
+    doAssert a2 is int64
+    doAssert cast[uint64](a2) == a
+    doAssert cast[int64](a2) == a2
   block:
     let a = 0xFF000000_00000000
     doAssert a is uint64
@@ -78,9 +82,6 @@ import stdtest/testutils
 
 doAssertParserRaises(ValueError): "18374686479671623680'i64"
 doAssertParserRaises(ValueError): "183746864796716236804" # too big to fit uint64
-
-let z = 0xFF000000_00000000'i64
-# doAssertParserRaises(ValueError): "0xFF000000_00000000'i64"
 
 block: # issue #14529
   # BUG: `0xFF000000_0000000000000` should be an error, see https://github.com/nim-lang/Nim/issues/14529

--- a/tests/misc/tunsignedconv.nim
+++ b/tests/misc/tunsignedconv.nim
@@ -84,6 +84,6 @@ doAssertParserRaises(ValueError): "18374686479671623680'i64"
 doAssertParserRaises(ValueError): "183746864796716236804" # too big to fit uint64
 
 block: # issue #14529
-  # BUG: `0xFF000000_0000000000000` should be an error, see https://github.com/nim-lang/Nim/issues/14529
+  # BUG: `0xFF000000_0000000000000` should be an error
   # doAssertParserRaises(ValueError): "0xFF000000_0000000000" # too big to fit uint64
   discard

--- a/tests/misc/tunsignedconv.nim
+++ b/tests/misc/tunsignedconv.nim
@@ -77,6 +77,8 @@ block: # issue #14522
   block:
     let a = 18374686479671623680
     doAssert a is uint64
+    let a2 = 9223372036854775808 # high(int64) + 1
+    doAssert a2 == cast[uint64](high(int64))+1
 
 import stdtest/testutils
 


### PR DESCRIPTION
fix #14522
same rationale as https://github.com/nim-lang/Nim/blob/de27910ab72dca681188953ae963802520271e43/compiler/lexer.nim#L603

## mildly related links
* https://github.com/nim-lang/Nim/issues/14529
* https://github.com/nim-lang/RFCs/issues/228
* https://github.com/timotheecour/Nim/issues/125
