### PR TITLE
manual: removed subjective phrase from 'macros' section about Nims syntax being "flexible enough anyway"

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -5305,8 +5305,7 @@ twice:
   this process iterates.
 
 While macros enable advanced compile-time code transformations, they
-cannot change Nim's syntax. However, this is no real restriction because
-Nim's syntax is flexible enough anyway.
+cannot change Nim's syntax.
 
 Debug Example
 -------------


### PR DESCRIPTION
Removed phrase "However, this is no real restriction because Nim's syntax is flexible enough anyway." from the manual - this is subjective, and I sometimes *do* find myself restricted by Nim's syntax when writing DSLs