### PR TITLE
Add the ability to pass title case headers to an HTTP server

### DIFF
--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -17,7 +17,6 @@ import tables, strutils, parseutils
 type
   HttpHeaders* = ref object
     table*: TableRef[string, seq[string]]
-    isTitleCase: bool
 
   HttpHeaderValues* = distinct seq[string]
 
@@ -101,32 +100,16 @@ const
 const httpNewLine* = "\c\L"
 const headerLimit* = 10_000
 
-proc toTitleCase(s: string): string =
-  result = newString(len(s))
-  var upper = true
-  for i in 0..len(s) - 1:
-    result[i] = if upper: toUpperAscii(s[i]) else: toLowerAscii(s[i])
-    upper = s[i] == '-'
-
-proc toCaseInsensitive(headers: HttpHeaders, s: string): string {.inline.} =
-  return if headers.isTitleCase: toTitleCase(s) else: toLowerAscii(s)
-
-proc newHttpHeaders*(titleCase=false): HttpHeaders =
-  ## Returns a new ``HttpHeaders`` object. if ``titleCase`` is set to true, 
-  ## headers are passed to the server in title case (e.g. "Content-Length")
+proc newHttpHeaders*(): HttpHeaders =
   new result
   result.table = newTable[string, seq[string]]()
-  result.isTitleCase = titleCase
 
 proc newHttpHeaders*(keyValuePairs:
-    openArray[tuple[key: string, val: string]], titleCase=false): HttpHeaders =
-  ## Returns a new ``HttpHeaders`` object from an array. if ``titleCase`` is set to true, 
-  ## headers are passed to the server in title case (e.g. "Content-Length")
+    openArray[tuple[key: string, val: string]]): HttpHeaders =
   new result
   result.table = newTable[string, seq[string]]()
-  result.isTitleCase = titleCase
   for pair in keyValuePairs:
-    let key = result.toCaseInsensitive(pair.key)
+    let key = pair.key.toLowerAscii()
     if key in result.table:
       result.table[key].add(pair.val)
     else:
@@ -147,7 +130,7 @@ proc `[]`*(headers: HttpHeaders, key: string): HttpHeaderValues =
   ##
   ## To access multiple values of a key, use the overloaded ``[]`` below or
   ## to get all of them access the ``table`` field directly.
-  return headers.table[headers.toCaseInsensitive(key)].HttpHeaderValues
+  return headers.table[key.toLowerAscii].HttpHeaderValues
 
 converter toString*(values: HttpHeaderValues): string =
   return seq[string](values)[0]
@@ -156,30 +139,30 @@ proc `[]`*(headers: HttpHeaders, key: string, i: int): string =
   ## Returns the ``i``'th value associated with the given key. If there are
   ## no values associated with the key or the ``i``'th value doesn't exist,
   ## an exception is raised.
-  return headers.table[headers.toCaseInsensitive(key)][i]
+  return headers.table[key.toLowerAscii][i]
 
 proc `[]=`*(headers: HttpHeaders, key, value: string) =
   ## Sets the header entries associated with ``key`` to the specified value.
   ## Replaces any existing values.
-  headers.table[headers.toCaseInsensitive(key)] = @[value]
+  headers.table[key.toLowerAscii] = @[value]
 
 proc `[]=`*(headers: HttpHeaders, key: string, value: seq[string]) =
   ## Sets the header entries associated with ``key`` to the specified list of
   ## values.
   ## Replaces any existing values.
-  headers.table[headers.toCaseInsensitive(key)] = value
+  headers.table[key.toLowerAscii] = value
 
 proc add*(headers: HttpHeaders, key, value: string) =
   ## Adds the specified value to the specified key. Appends to any existing
   ## values associated with the key.
-  if not headers.table.hasKey(headers.toCaseInsensitive(key)):
-    headers.table[headers.toCaseInsensitive(key)] = @[value]
+  if not headers.table.hasKey(key.toLowerAscii):
+    headers.table[key.toLowerAscii] = @[value]
   else:
-    headers.table[headers.toCaseInsensitive(key)].add(value)
+    headers.table[key.toLowerAscii].add(value)
 
 proc del*(headers: HttpHeaders, key: string) =
   ## Delete the header entries associated with ``key``
-  headers.table.del(headers.toCaseInsensitive(key))
+  headers.table.del(key.toLowerAscii)
 
 iterator pairs*(headers: HttpHeaders): tuple[key, value: string] =
   ## Yields each key, value pair.
@@ -194,7 +177,7 @@ proc contains*(values: HttpHeaderValues, value: string): bool =
     if val.toLowerAscii == value.toLowerAscii: return true
 
 proc hasKey*(headers: HttpHeaders, key: string): bool =
-  return headers.table.hasKey(headers.toCaseInsensitive(key))
+  return headers.table.hasKey(key.toLowerAscii())
 
 proc getOrDefault*(headers: HttpHeaders, key: string,
     default = @[""].HttpHeaderValues): HttpHeaderValues =
@@ -353,12 +336,3 @@ when isMainModule:
   doAssert test["foobar"] == ""
 
   doAssert parseHeader("foobar:") == ("foobar", @[""])
-
-  block: # test title case
-    var testTitleCase = newHttpHeaders(titleCase=true)
-    testTitleCase.add("content-length", "1")
-    doAssert testTitleCase.hasKey("Content-Length")
-    for key, val in testTitleCase:
-        doAssert key == "Content-Length"
-
-


### PR DESCRIPTION
My [original PR](https://github.com/nim-lang/Nim/pull/13968) is working when the headers are passed in the constructor to `newHttpClient` 

```
client = newHttpClient(headers=newHttpHeader(...,titleCase=true))
```
but it is not working in case the headers are passed in each request. 

```
client.request(url,HttpGet,headers=newHttpHeader(...,titleCase=true))
```

This is caused by the fact that a new `HttpHeader`object is created in [`override`](https://github.com/nim-lang/Nim/blob/fbc97e712a67f30076f7633880383c8c4ae7866f/lib/pure/httpclient.nim#L963).

Therefore, I would like to revert my [original PR](https://github.com/nim-lang/Nim/pull/13968) and propose a new solution.