### PR TITLE
fix #13469: defined(posix) (etc) now works with nodejs; enable os.getCurrentDir, isAbsolute + other fixes

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -117,7 +117,8 @@ proc commandCompileToJS(graph: ModuleGraph) =
       conf.outFile = RelativeFile(conf.projectName & ".js")
 
     #incl(gGlobalOptions, optSafeCode)
-    setTarget(graph.config.target, osJS, cpuJS)
+    if not isDefined(graph.config, "nodejs"):
+      setTarget(graph.config.target, osJS, cpuJS)
     #initDefines()
     defineSymbol(graph.config.symbols, "ecmascript") # For backward compatibility
     semanticPasses(graph)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1361,26 +1361,26 @@ when not defined(nimscript):
         when useWinUnicode:
           var res = newWideCString("", bufsize)
           while true:
-            var L = getCurrentDirectoryW(bufsize, res)
-            if L == 0'i32:
+            var num = getCurrentDirectoryW(bufsize, res)
+            if num == 0'i32:
               raiseOSError(osLastError())
-            elif L > bufsize:
-              res = newWideCString("", L)
-              bufsize = L
+            elif num > bufsize:
+              res = newWideCString("", num)
+              bufsize = num
             else:
-              result = res$L
+              result = res$num
               break
         else:
           result = newString(bufsize)
           while true:
-            var L = getCurrentDirectoryA(bufsize, result)
-            if L == 0'i32:
+            var num = getCurrentDirectoryA(bufsize, result)
+            if num == 0'i32:
               raiseOSError(osLastError())
-            elif L > bufsize:
-              result = newString(L)
-              bufsize = L
+            elif num > bufsize:
+              result = newString(num)
+              bufsize = num
             else:
-              setLen(result, L)
+              setLen(result, num)
               break
       else:
         var bufsize = 1024 # should be enough
@@ -2016,27 +2016,27 @@ proc expandFilename*(filename: string): string {.rtl, extern: "nos$1",
       var unused: WideCString = nil
       var res = newWideCString("", bufsize)
       while true:
-        var L = getFullPathNameW(newWideCString(filename), bufsize, res, unused)
-        if L == 0'i32:
+        var num = getFullPathNameW(newWideCString(filename), bufsize, res, unused)
+        if num == 0'i32:
           raiseOSError(osLastError(), filename)
-        elif L > bufsize:
-          res = newWideCString("", L)
-          bufsize = L
+        elif num > bufsize:
+          res = newWideCString("", num)
+          bufsize = num
         else:
-          result = res$L
+          result = res$num
           break
     else:
       var unused: cstring = nil
       result = newString(bufsize)
       while true:
-        var L = getFullPathNameA(filename, bufsize, result, unused)
-        if L == 0'i32:
+        var num = getFullPathNameA(filename, bufsize, result, unused)
+        if num == 0'i32:
           raiseOSError(osLastError(), filename)
-        elif L > bufsize:
-          result = newString(L)
-          bufsize = L
+        elif num > bufsize:
+          result = newString(num)
+          bufsize = num
         else:
-          setLen(result, L)
+          setLen(result, num)
           break
     # getFullPathName doesn't do case corrections, so we have to use this convoluted
     # way of retrieving the true filename
@@ -2989,28 +2989,28 @@ proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noN
     when useWinUnicode:
       var buf = newWideCString("", bufsize)
       while true:
-        var L = getModuleFileNameW(0, buf, bufsize)
-        if L == 0'i32:
+        var num = getModuleFileNameW(0, buf, bufsize)
+        if num == 0'i32:
           result = "" # error!
           break
-        elif L > bufsize:
-          buf = newWideCString("", L)
-          bufsize = L
+        elif num > bufsize:
+          buf = newWideCString("", num)
+          bufsize = num
         else:
-          result = buf$L
+          result = buf$num
           break
     else:
       result = newString(bufsize)
       while true:
-        var L = getModuleFileNameA(0, result, bufsize)
-        if L == 0'i32:
+        var num = getModuleFileNameA(0, result, bufsize)
+        if num == 0'i32:
           result = "" # error!
           break
-        elif L > bufsize:
-          result = newString(L)
-          bufsize = L
+        elif num > bufsize:
+          result = newString(num)
+          bufsize = num
         else:
-          setLen(result, L)
+          setLen(result, num)
           break
   elif defined(macosx):
     var size: cuint32

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2572,7 +2572,10 @@ proc epochTime*(): float {.tags: [TimeEffect].} =
   ## on the hardware/OS).
   ##
   ## ``getTime`` should generally be preferred over this proc.
-  when defined(macosx):
+  when false: discard
+  elif defined(js):
+    result = newDate().getTime() / 1000
+  elif defined(macosx):
     var a: Timeval
     gettimeofday(a)
     result = toBiggestFloat(a.tv_sec.int64) + toBiggestFloat(
@@ -2589,8 +2592,6 @@ proc epochTime*(): float {.tags: [TimeEffect].} =
     var secs = i64 div rateDiff
     var subsecs = i64 mod rateDiff
     result = toFloat(int(secs)) + toFloat(int(subsecs)) * 0.0000001
-  elif defined(js):
-    result = newDate().getTime() / 1000
   else:
     {.error: "unknown OS".}
 

--- a/tests/js/tos.nim
+++ b/tests/js/tos.nim
@@ -2,7 +2,7 @@ static: doAssert defined(nodejs)
 
 import os
 
-block:
+template fn() =
   doAssert "./foo//./bar/".normalizedPath == "foo/bar"
   doAssert relativePath(".//foo/bar", "foo") == "bar"
   doAssert "/".isAbsolute
@@ -11,11 +11,12 @@ block:
   doAssert not "foo".isAbsolute
   doAssert relativePath("", "bar") == ""
   doAssert normalizedPath(".///foo//./") == "foo"
-  let cwd = getCurrentDir()
-
-  let isWindows = '\\' in cwd
-  # defined(windows) doesn't work with -d:nodejs but should
-  # these actually break because of that (see https://github.com/nim-lang/Nim/issues/13469)
-  if not isWindows:
+  doAssert getHomeDir() == getHomeDir().static
+  doAssert relativePath("foo/bar", "baz") == "../foo/bar".unixToNativePath
+  when nimvm: discard
+  else:
+    let cwd = getCurrentDir()
     doAssert cwd.isAbsolute
-    doAssert relativePath(getCurrentDir() / "foo", "bar") == "../foo"
+    doAssert relativePath(cwd / "foo", "bar") == ".." / "foo"
+static: fn()
+fn()


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/13469
* isAbsolute now works for all OS on nodejs (and in vm)
* getCurrentDir now works with nodejs
* should unblock this PR https://github.com/nim-lang/Nim/pull/14519 to make even more procs available for nodejs /cc @bung87 
* enhance tests/js/tos.nim ; now also checks VM
* helpful errors with notAvailable
