### PR TITLE
honor --errorMax even for tools (eg `nim doc` etc)

### DIFF
--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -51,7 +51,7 @@ proc commandGenDepend(graph: ModuleGraph) =
       ' ' & changeFileExt(project, "dot").string)
 
 proc commandCheck(graph: ModuleGraph) =
-  graph.config.errorMax = high(int)  # do not stop after first error
+  graph.config.setErrorMaxHighMaybe
   defineSymbol(graph.config.symbols, "nimcheck")
   semanticPasses(graph)  # use an empty backend for semantic checking only
   compileProject(graph)
@@ -59,7 +59,7 @@ proc commandCheck(graph: ModuleGraph) =
 when not defined(leanCompiler):
   proc commandDoc2(graph: ModuleGraph; json: bool) =
     handleDocOutputOptions graph.config
-    graph.config.errorMax = high(int)  # do not stop after first error
+    graph.config.setErrorMaxHighMaybe
     semanticPasses(graph)
     if json: registerPass(graph, docgen2JsonPass)
     else: registerPass(graph, docgen2Pass)
@@ -136,7 +136,7 @@ proc interactivePasses(graph: ModuleGraph) =
   registerPass(graph, evalPass)
 
 proc commandInteractive(graph: ModuleGraph) =
-  graph.config.errorMax = high(int)  # do not stop after first error
+  graph.config.setErrorMaxHighMaybe
   interactivePasses(graph)
   compileSystemModule(graph)
   if graph.config.commandArgs.len > 0:

--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -137,6 +137,7 @@ proc destroyInterpreter*(i: Interpreter) =
 proc runRepl*(r: TLLRepl;
               searchPaths: openArray[string];
               supportNimscript: bool) =
+  ## deadcode but please don't remove... might be revived
   var conf = newConfigRef()
   var cache = newIdentCache()
   var graph = newModuleGraph(cache, conf)
@@ -146,7 +147,7 @@ proc runRepl*(r: TLLRepl;
     if conf.libpath.isEmpty: conf.libpath = AbsoluteDir p
 
   conf.cmd = cmdInteractive
-  conf.errorMax = high(int)
+  conf.setErrorMaxHighMaybe
   initDefines(conf.symbols)
   defineSymbol(conf.symbols, "nimscript")
   if supportNimscript: defineSymbol(conf.symbols, "nimconfig")

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -315,6 +315,14 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
 
+proc assignIfDefault*[T](result: var T, val: T, def = default(T)) =
+  ## if `result` was already assigned to a value (that wasn't `def`), this is a noop.
+  if result == def: result = val
+
+template setErrorMaxHighMaybe*(conf: ConfigRef) =
+  ## do not stop after first error (but honor --errorMax if provided)
+  assignIfDefault(conf.errorMax, high(int))
+
 proc setNoteDefaults*(conf: ConfigRef, note: TNoteKind, enabled = true) =
   template fun(op) =
     conf.notes.op note

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -325,7 +325,7 @@ proc tryConstExpr(c: PContext, n: PNode): PNode =
   let oldErrorOutputs = c.config.m.errorOutputs
 
   c.config.m.errorOutputs = {}
-  c.config.errorMax = high(int)
+  c.config.errorMax = high(int) # `setErrorMaxHighMaybe` not appropriate here
 
   try:
     result = evalConstExpr(c.module, c.graph, e)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2074,8 +2074,7 @@ proc tryExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   if c.compilesContextId == 0:
     inc c.compilesContextIdGenerator
     c.compilesContextId = c.compilesContextIdGenerator
-  # do not halt after first error:
-  c.config.errorMax = high(int)
+  c.config.errorMax = high(int) # `setErrorMaxHighMaybe` not appropriate here
 
   # open a scope for temporary symbol inclusions:
   let oldScope = c.currentScope

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1192,7 +1192,7 @@ proc mainCommand(graph: ModuleGraph) =
   graph.strongSemCheck = strongSemCheck
   graph.compatibleProps = compatibleProps
 
-  graph.config.errorMax = high(int)  # do not stop after first error
+  graph.config.setErrorMaxHighMaybe
   defineSymbol(graph.config.symbols, "nimcheck")
   defineSymbol(graph.config.symbols, "nimDrNim")
 

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -525,8 +525,7 @@ proc mainCommand(graph: ModuleGraph) =
 
   add(conf.searchPaths, conf.libpath)
 
-  # do not stop after the first error:
-  conf.errorMax = high(int)
+  conf.setErrorMaxHighMaybe # honor --errorMax even if it may not make sense here
   # do not print errors, but log them
   conf.writelnHook = myLog
   conf.structuredErrorHook = nil
@@ -674,8 +673,7 @@ else:
 
       add(conf.searchPaths, conf.libpath)
 
-      # do not stop after the first error:
-      conf.errorMax = high(int)
+      conf.setErrorMaxHighMaybe
       # do not print errors, but log them
       conf.writelnHook = myLog
       conf.structuredErrorHook = nil

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -6,7 +6,9 @@ import "../compiler/nimpaths"
 
 const
   gaCode* = " --doc.googleAnalytics:UA-48159761-1"
-  nimArgs = "--hint:Conf:off --hint:Path:off --hint:Processing:off -d:boot --putenv:nimversion=$#" % system.NimVersion
+  # errormax: subsequent errors are probably consequences of 1st one; a simple
+  # bug could cause unlimited number of errors otherwise, hard to debug in CI.
+  nimArgs = "--errormax:3 --hint:Conf:off --hint:Path:off --hint:Processing:off -d:boot --putenv:nimversion=$#" % system.NimVersion
   gitUrl = "https://github.com/nim-lang/Nim"
   docHtmlOutput = "doc/html"
   webUploadOutput = "web/upload"

--- a/tools/nimfind.nim
+++ b/tools/nimfind.nim
@@ -169,8 +169,7 @@ proc mainCommand(graph: ModuleGraph) =
     if not fileExists(conf.projectFull):
       quit "cannot find file: " & conf.projectFull.string
     add(conf.searchPaths, conf.libpath)
-    # do not stop after the first error:
-    conf.errorMax = high(int)
+    conf.setErrorMaxHighMaybe
     try:
       compileProject(graph)
     finally:


### PR DESCRIPTION
when errors happen, they can snowball and subsequent ones are often caused by 1st error, which was one of the motivations for `--errorMax`.
This PR makes `nim doc` and other tools honor `--errorMax` when that flag is provided.
This helps when investigating issues like https://github.com/nim-lang/Nim/issues/14545 where logs (which i saved here https://gist.github.com/timotheecour/651249370f686efe05462f9dbf342d59) were showing 1400 errors.

after this PR it only shows just a few (the relevant ones) which are the ones shown in https://github.com/nim-lang/Nim/issues/14545

CI failure caused by the usual suspects:
* https://github.com/timotheecour/Nim/issues/266 => finally fixing it in https://github.com/nim-lang/Nim/pull/14547
* https://github.com/nim-lang/Nim/issues/14090 => finally removing the flakyness in https://github.com/nim-lang/Nim/pull/14548