### PR TITLE
fix super flaky `tfdleak` test on windows refs #14090

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -529,6 +529,18 @@ proc runCI(cmd: string) =
   # boot without -d:nimHasLibFFI to make sure this still works
   kochExecFold("Boot in release mode", "boot -d:release")
 
+  when false:
+    #[
+    if debugging a tricky issue that's hard to investigate locally, you can
+    edit this as needed and update these to only run on the problematic OS:
+    azure-pipelines.yml
+    .github/workflows/ci_docs.yml
+    .github/workflows/ci_ssl.yml
+    .github/workflows/ci_packages.yml
+    ]#
+    execFold("Run custom test for debugging", "nim c -r tests/stdlib/mfdleakIssue14090.nim")
+    doAssert false, "remember to turn off via `when false`"
+
   ## build nimble early on to enable remainder to depend on it if needed
   kochExecFold("Build Nimble", "nimble")
 

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -543,7 +543,7 @@ const
     # Platform specific flag for creating a File without inheritance.
     when not defined(nimInheritHandles):
       when defined(windows):
-        "N"
+        "N" # probably not completely correct
       elif defined(linux) or defined(bsd):
         "e"
       else:

--- a/tests/stdlib/mfdleakIssue14090.nim
+++ b/tests/stdlib/mfdleakIssue14090.nim
@@ -1,0 +1,30 @@
+#[
+## issue #14090
+this module is to help investigate this issue.
+Running this will show that windows fails this test all the time
+module named `m` to avoid running it automatically.
+]#
+
+import osproc, strutils
+
+proc testFdLeak() =
+  let n = 200
+  var count = [0,0]
+  let options = ["", "-d:nimInheritHandles"]
+  for j in 0..<options.len:
+    let exe = "tests/stdlib/tfdleak"
+    let cmd = "nim c -o:$1 $2 tests/stdlib/tfdleak.nim" % [exe,options[j]]
+    echo (j, cmd)
+    let (outp1, status1) = execCmdEx(cmd)
+    doAssert status1 == 0, outp1
+    for i in 0..<n:
+      let cmd2 = exe
+      echo (j, i, n, cmd2)
+      let (outp, status) = execCmdEx(cmd2)
+      doAssert status == 0
+      if "leaked" in outp:
+        count[j].inc
+        echo count, "\n", outp
+  doAssert count == [0,0], $count
+
+when isMainModule: testFdLeak()

--- a/tests/stdlib/tfdleak.nim
+++ b/tests/stdlib/tfdleak.nim
@@ -13,7 +13,6 @@ else:
 
 proc leakCheck(f: AsyncFD | int | FileHandle | SocketHandle, msg: string,
                expectLeak = defined(nimInheritHandles)) =
-  echo ("leakCheck", getAppFilename(), expectLeak)
   discard startProcess(
     getAppFilename(),
     args = @[$f.int, msg, $expectLeak],


### PR DESCRIPTION
`tfdleak` is probably the most flaky test we have; this PR fixes that by establishing that `isValidHandle` is incorrect and ignoring when is returns true

I did some research (not being a windows user...), it's a a tricky topic but from what I gathered:
* isValidHandle is incorrect on windows and has false positives
* see also the test I added `tests/stdlib/mfdleakIssue14090.nim` which on windows will always fail (and always succeed on linux+osx)
* trying to actually use the file handles (instead of relying on what isValidHandle says) indeed would give errors, indicating it hasn't really leaked but the handle could merely be reused in the child, with a different underlying resource
* added links to relevant docs in the PR that talks about this

my "fix" is to disable the test in the case where a leak is not expected and windows sees a leak, since isValidHandle has false positives

## future work
* fix isValidHandle for windows, possibly using `getHandleInformation` (next step towards closing https://github.com/nim-lang/Nim/issues/14090)
* ensure that when isValidHandle is true, the handle is indeed usable (eg you can read from it)

## incorrect types should be fixed
* I've also encountered a number of types that are incorrect (and could lead to other subtle bugs on windows), eg:


* `proc getOsfhandle(fd: cint): FileHandle` => should be `proc getOsfhandle(fd: cint): Handle`
(FileHandle is cint whereas Handle is int or castable as int); see https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/get-osfhandle?view=vs-2019
```
# in lib/system/io.nim => bug
proc getOsfhandle(fd: cint): FileHandle {.importc: "_get_osfhandle", header: "<io.h>".}
# in lib/windows/winlean.nim => ok
proc get_osfhandle*(fd:FileHandle): Handle {.importc: "_get_osfhandle", header:"<io.h>".}
```
* `proc setHandleInformation(handle: FileHandle, mask, flags: culong): cint {.importc: "SetHandleInformation", header: "<handleapi.h>".}`
is also incorrect according to https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-sethandleinformation
=> 1st param should be Handle not FileHandle

* winlean should really use distinct types eg `BOOL`, `DWORD` etc, which would make it much safer to use those bug prone window APIS


