### PR TITLE
bug fixes with sfMainModule, hints, mainPackageNotes, mainPackageId, hintSuccessX

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -12,7 +12,7 @@ on:
       - 'tools/kochdocs.nim'
       - '.github/workflows/ci_docs.yml'
   pull_request:
-    # Run only on changes on these files
+    # Run only on changes on these files.
     paths:
       - 'compiler/docgen.nim'
       - 'compiler/renderverbatim.nim'

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -913,8 +913,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     if strutils.find(switch, '.') >= 0: options.setConfigVar(conf, switch, arg)
     else: invalidCmdLineOption(conf, pass, switch, info)
 
-template gCmdLineInfo*(): untyped = newLineInfo(commandLineIdx, 1, 1)
-
 proc processCommand*(switch: string, pass: TCmdLinePass; config: ConfigRef) =
   var cmd, arg: string
   splitSwitch(config, switch, cmd, arg, pass, gCmdLineInfo)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -389,10 +389,15 @@ proc mainCommand*(graph: ModuleGraph) =
                 else: "Debug"
     let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
     let project = if optListFullPaths in conf.globalOptions: $conf.projectFull else: $conf.projectName
-    var output = if optCompileOnly in conf.globalOptions and conf.cmd != cmdJsonScript:
-      $conf.jsonBuildFile
+
+    var output: string
+    if optCompileOnly in conf.globalOptions and conf.cmd != cmdJsonScript:
+      output = $conf.jsonBuildFile
+    elif conf.outFile.isEmpty and conf.cmd notin {cmdJsonScript, cmdCompileToBackend, cmdDoc}:
+      # for some cmd we expect a valid absOutFile
+      output = "unknownOutput"
     else:
-      $conf.absOutFile
+      output = $conf.absOutFile
     if optListFullPaths notin conf.globalOptions: output = output.AbsoluteFile.extractFilename
     rawMessage(conf, hintSuccessX, [
       "loc", loc,

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -17,22 +17,29 @@ import
 proc resetSystemArtifacts*(g: ModuleGraph) =
   magicsys.resetSysTypes(g)
 
-proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; filename: AbsoluteFile) =
+template getModuleIdent(graph: ModuleGraph, filename: AbsoluteFile): PIdent =
+  getIdent(graph.cache, splitFile(filename).name)
+
+proc getPackage(graph: ModuleGraph; fileIdx: FileIndex): PSym =
+  ## returns package symbol (skPackage) for yet to be defined module for fileIdx
+  let filename = AbsoluteFile toFullPath(graph.config, fileIdx)
+  let name = getModuleIdent(graph, filename)
+  let info = newLineInfo(fileIdx, 1, 1)
   let
     pck = getPackageName(graph.config, filename.string)
     pck2 = if pck.len > 0: pck else: "unknown"
     pack = getIdent(graph.cache, pck2)
   var packSym = graph.packageSyms.strTableGet(pack)
   if packSym == nil:
-    packSym = newSym(skPackage, getIdent(graph.cache, pck2), nil, result.info)
+    packSym = newSym(skPackage, getIdent(graph.cache, pck2), nil, info)
     initStrTable(packSym.tab)
     graph.packageSyms.strTableAdd(packSym)
   else:
-    let existing = strTableGet(packSym.tab, result.name)
-    if existing != nil and existing.info.fileIndex != result.info.fileIndex:
+    let existing = strTableGet(packSym.tab, name)
+    if existing != nil and existing.info.fileIndex != info.fileIndex:
       when false:
         # we used to produce an error:
-        localError(graph.config, result.info,
+        localError(graph.config, info,
           "module names need to be unique per Nimble package; module clashes with " &
             toFullPath(graph.config, existing.info.fileIndex))
       else:
@@ -40,10 +47,13 @@ proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; fil
         # to resolve the conflicts:
         let pck3 = fakePackageName(graph.config, filename)
         # this makes the new `packSym`'s owner be the original `packSym`
-        packSym = newSym(skPackage, getIdent(graph.cache, pck3), packSym, result.info)
+        packSym = newSym(skPackage, getIdent(graph.cache, pck3), packSym, info)
         initStrTable(packSym.tab)
         graph.packageSyms.strTableAdd(packSym)
+  result = packSym
 
+proc partialInitModule(result: PSym; graph: ModuleGraph; fileIdx: FileIndex; filename: AbsoluteFile) =
+  let packSym = getPackage(graph, fileIdx)
   result.owner = packSym
   result.position = int fileIdx
 
@@ -60,13 +70,15 @@ proc newModule(graph: ModuleGraph; fileIdx: FileIndex): PSym =
   # We cannot call ``newSym`` here, because we have to circumvent the ID
   # mechanism, which we do in order to assign each module a persistent ID.
   result = PSym(kind: skModule, id: -1, # for better error checking
-                name: getIdent(graph.cache, splitFile(filename).name),
+                name: getModuleIdent(graph, filename),
                 info: newLineInfo(fileIdx, 1, 1))
   if not isNimIdentifier(result.name.s):
     rawMessage(graph.config, errGenerated, "invalid module name: " & result.name.s)
   partialInitModule(result, graph, fileIdx, filename)
 
 proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): PSym =
+  var flags = flags
+  if fileIdx == graph.config.projectMainIdx2: flags.incl sfMainModule
   result = graph.getModule(fileIdx)
   if result == nil:
     let filename = AbsoluteFile toFullPath(graph.config, fileIdx)
@@ -95,6 +107,7 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): P
 proc importModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   # this is called by the semantic checking phase
   assert graph.config != nil
+  # dbg result.name.s, result.flags
   result = compileModule(graph, fileIdx, {})
   graph.addDep(s, fileIdx)
   # keep track of import relationships
@@ -104,7 +117,7 @@ proc importModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   #  localError(result.info, errAttemptToRedefine, result.name.s)
   # restore the notes for outer module:
   graph.config.notes =
-    if s.owner.id == graph.config.mainPackageId or isDefined(graph.config, "booting"): graph.config.mainPackageNotes
+    if s.getnimblePkgId == graph.config.mainPackageId or isDefined(graph.config, "booting"): graph.config.mainPackageNotes
     else: graph.config.foreignPackageNotes
 
 proc includeModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PNode =
@@ -135,7 +148,12 @@ proc compileProject*(graph: ModuleGraph; projectFileIdx = InvalidFileIdx) =
   wantMainModule(conf)
   let systemFileIdx = fileInfoIdx(conf, conf.libpath / RelativeFile"system.nim")
   let projectFile = if projectFileIdx == InvalidFileIdx: conf.projectMainIdx else: projectFileIdx
+  conf.projectMainIdx2 = projectFile
+
+  let packSym = getPackage(graph, projectFile)
+  graph.config.mainPackageId = packSym.getnimblePkgId
   graph.importStack.add projectFile
+
   if projectFile == systemFileIdx:
     discard graph.compileModule(projectFile, {sfMainModule, sfSystemModule})
   else:

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -107,7 +107,6 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): P
 proc importModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   # this is called by the semantic checking phase
   assert graph.config != nil
-  # dbg result.name.s, result.flags
   result = compileModule(graph, fileIdx, {})
   graph.addDep(s, fileIdx)
   # keep track of import relationships

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -117,6 +117,8 @@ proc newLineInfo*(fileInfoIdx: FileIndex, line, col: int): TLineInfo =
 proc newLineInfo*(conf: ConfigRef; filename: AbsoluteFile, line, col: int): TLineInfo {.inline.} =
   result = newLineInfo(fileInfoIdx(conf, filename), line, col)
 
+const gCmdLineInfo* = newLineInfo(commandLineIdx, 1, 1)
+
 proc concat(strings: openArray[string]): string =
   var totalLen = 0
   for s in strings: totalLen += s.len

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -273,6 +273,7 @@ type
     lazyPaths*: seq[AbsoluteDir]
     outFile*: RelativeFile
     outDir*: AbsoluteDir
+    jsonBuildFile*: AbsoluteFile
     prefixDir*, libpath*, nimcacheDir*: AbsoluteDir
     dllOverrides, moduleOverrides*, cfileSpecificOptions*: StringTableRef
     projectName*: string # holds a name like 'nim'
@@ -556,11 +557,12 @@ proc getOutFile*(conf: ConfigRef; filename: RelativeFile, ext: string): Absolute
   result = conf.outDir / changeFileExt(filename, ext)
 
 proc absOutFile*(conf: ConfigRef): AbsoluteFile =
-  if false:
-    doAssert not conf.outDir.isEmpty
-    doAssert not conf.outFile.isEmpty
-    # xxx: fix this pre-existing bug causing `SuccessX` error messages to lie
-    # for `jsonscript`
+  doAssert not conf.outDir.isEmpty
+  if conf.outFile.isEmpty:
+    if conf.cmd != cmdDoc:
+      # xxx fails with `nim doc lib/system/io.nim`; this is a preexisting bug;
+      # also, that doesn't show a SuccessX message
+      doAssert not conf.outFile.isEmpty
   result = conf.outDir / conf.outFile
   when defined(posix):
     if dirExists(result.string): result.string.add ".out"

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -113,10 +113,8 @@ const
     nkExportStmt, nkExportExceptStmt, nkFromStmt, nkImportStmt, nkImportExceptStmt}
 
 proc prepareConfigNotes(graph: ModuleGraph; module: PSym) =
-  if sfMainModule in module.flags:
-    graph.config.mainPackageId = module.owner.id
   # don't be verbose unless the module belongs to the main package:
-  if module.owner.id == graph.config.mainPackageId:
+  if module.getnimblePkgId == graph.config.mainPackageId:
     graph.config.notes = graph.config.mainPackageNotes
   else:
     if graph.config.mainPackageNotes == {}: graph.config.mainPackageNotes = graph.config.notes


### PR DESCRIPTION
## before PR
* s.owner.id was used instead of s.getnimblePkgId in some cases (incorrect for modules with duplicate names)
* sfMainModule was incorrectly applied for modules imported by system (eg: io.nim)
* mainPackageNotes were incorrect for modules imported by system (eg: io.nim)
* hintSuccessX was incorrect in several cases, giving wrong results
eg:
```
nim doc lib/system/io.nim
```
didn't honor `--hint:SuccessX` (nor any main package hints) => nor success output msg
and we forced it to honor it, `absOutFile` would give wrong result because `sfMainModule` would not be set for it

* `nim c --compileOnly -o:/tmp/foo/main main` followed by `nim jsonscript --compileOnly -o:/tmp/foo/main main`
would fail if `/tmp/foo/` didn't exist (whereas it works without using jsonscript and --compileOnly)
* `nim c --compileOnly main` followed by `nim jsonscript --compileOnly -o:/tmp/foo/main main`
would silently ignore -o:/tmp/foo/main
(more generally, any mismatch in output file inferred from jsonscript command wrt what json file actually outputs would be silently ignored)
* SuccessX out was lying for `--compileOnly` command, showing a binary that doesn't exist yet (or worse, already exists but wasn't yet over-written), eg: `/pathto/Nim/compiler/nim`
* SuccessX out was lying for jsonscript` command, showing a file that isn't supposed to be produced, eg:

./koch boot -d:release --hint:SuccessX:on --hint:Processing:off
```
Hint: 166960 LOC; 7.474 sec; 550.578MiB peakmem; Release build; proj: /pathto/Nim/compiler/nim.nim; out: /pathto/Nim/compiler/nim [SuccessX]
compiler/nim2 jsonscript -d:release --hint:SuccessX:on --hint:Processing:off --nimcache:nimcache/r_macosx_amd64 compiler/nim.nim
Hint: 16347 LOC; 0.138 sec; 13.461MiB peakmem; Release build; proj: /pathto/Nim/compiler/nim.nim; out: /pathto/Nim.out [SuccessX]
executables are equal: SUCCESS!
```
## after PR
* all those bugs are fixed.
* fixes the leftover from here https://github.com/nim-lang/Nim/pull/13382#discussion_r413597368
* for the jsonscript bugs: it works regardless the command used with `--compileOnly`, eg `--app:lib`, or specifying `-o`, or `--outDir` etc.
the only requirement is that the `jsonscript` command uses the same command line as was used during `--compileOnly` (which is the case in koch.nim for example); the alternative (honoring a different output path specified during jsonscript command) could be implemented in future PR's (note that this was silently not working before this PR), but would need to handle things like `extraCmds`


