### PR TITLE
[superseded] refs #14545 unbreak nim CI docs windows 

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -470,7 +470,11 @@ proc runAllExamples(d: PDoc) =
     # most useful semantics is that `docCmd` comes after `rdoccmd`, so that we can (temporarily) override
     # via command line
     let cmd = "$nim $backend -r --warning:UnusedImport:off --path:$path --nimcache:$nimcache $rdoccmd $docCmd $file" % [
-      "nim", os.getAppFilename(),
+      "nim", getCurrentCompilerExe(),
+        # os.getAppFilename() caused issues and using same compiler is better anyway;
+        # no relocation issues can happen as we're just running tests. Else, `--lib:lib` would
+        # at least be needed otherwise `nim doc system` can cause this on windows:
+        # semtypes.nim(2034, 12) `c.graph.sysTypes[tySequence] == nil`
       "backend", $d.conf.backend,
       "path", quoteShell(d.conf.projectPath),
       "nimcache", quoteShell(outputDir),


### PR DESCRIPTION
this fixes the symptoms of #14545 but underlying issues remain so #14545 should be kept open until we figure out a few things:
* why aren't `d:\a\Nim\Nim\lib\pure\includes\osenv.nim(138, 6)` and `D:\a\Nim\Nim\lib\pure\includes\osenv.nim(138, 6)` resolved to the same path by nim
* why does running via sexec (sequential) instead of mexecec gets rid of some issues
