### PR TITLE
Fix asynchttpserver newline breaking content-length

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -105,8 +105,9 @@ proc respond*(req: Request, code: HttpCode, content: string,
     msg.add("Content-Length: ")
     # this particular way saves allocations:
     msg.addInt content.len
-  
-  msg.add "\c\L\c\L"
+    msg.add "\c\L"
+
+  msg.add "\c\L"
   msg.add(content)
   result = req.client.send(msg)
 


### PR DESCRIPTION
#13846 made it possible to manually specify a content-length, but the newline for the default header value wasn't made conditional. Without this change, the output includes an extra newline which is incorrect and breaks all clients I've tested (curl, chrome, firefox, etc.)

Backport?