### PR TITLE
Fix sugar.dump: It doesn't work correctly with compile time expression

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -150,7 +150,7 @@ macro `->`*(p, b: untyped): untyped =
 
   result = createProcType(p, b)
 
-macro dump*(x: typed): untyped =
+macro dump*(x: untyped): untyped =
   ## Dumps the content of an expression, useful for debugging.
   ## It accepts any expression and prints a textual representation
   ## of the tree representing the expression - as it would appear in


### PR DESCRIPTION
`sugar.dump` print the value of the expression instead of the expression as is when the given expression is evaluated at compile time.

Test code:
```nim
import sugar

dump(123 + 456)
dump(int is Ordinal)
dump(currentSourcePath())
```

Output before this fix:
```
579 = 579
true = true
(filename: "/home/jail/prog.nim", line: 11, column: 24).filename = /home/jail/prog.nim
```

Output after this fix:
```
123 + 456 = 579
int is Ordinal = true
currentSourcePath() = /home/jail/prog.nim
```