### PR TITLE
require kind and ident for gensym in macros

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -496,7 +496,7 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ## If called from macros / compile time procs / static blocks,
   ## `ident` and `rule` can be VM computed value.
 
-proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
+proc genSym*(kind: NimSymKind; ident: string): NimNode {.
   magic: "NGenSym", noSideEffect.}
   ## Generates a fresh symbol that is guaranteed to be unique. The symbol
   ## needs to occur in a declaration context.

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -777,7 +777,7 @@ proc bindParam*(ps: SqlPrepared, paramIdx: int,val: openArray[byte], copy = true
 macro bindParams*(ps: SqlPrepared, params: varargs[untyped]): untyped {.since: (1, 3).} =
   let bindParam = bindSym("bindParam", brOpen)
   let bindNull = bindSym("bindNull")
-  let preparedStatement = genSym()
+  let preparedStatement = genSym(nskLet, "prepared")
   result = newStmtList()
   # Store `ps` in a temporary variable. This prevents `ps` from being evaluated every call.
   result.add newNimNode(nnkLetSection).add(newIdentDefs(preparedStatement, newEmptyNode(), ps))

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -96,7 +96,7 @@ macro evalOnceAs(expAlias, exp: untyped,
   # If `exp` is not a symbol we evaluate it once here and then use the temporary
   # symbol as alias
   if exp.kind != nnkSym and letAssigneable:
-    val = genSym()
+    val = genSym(nskLet, "val")
     result.add(newLetStmt(val, exp))
 
   result.add(

--- a/tests/astspec/tastspec.nim
+++ b/tests/astspec/tastspec.nim
@@ -47,7 +47,7 @@ macro myquote*(args: varargs[untyped]): untyped =
       sym, ident"untyped", newEmptyNode()
     )
 
-  let templateSym = genSym(nskTemplate)
+  let templateSym = genSym(nskTemplate, "template")
   let templateDef = nnkTemplateDef.newTree(
     templateSym,
     newEmptyNode(),
@@ -143,7 +143,7 @@ static:
 
 # this should be just `block` but it doesn't work that way anymore because of VM.
 macro scope(arg: untyped): untyped =
-  let procSym = genSym(nskProc)
+  let procSym = genSym(nskProc, "proc")
   result = quote do:
     proc `procSym`() {.compileTime.} =
       `arg`

--- a/tests/gensym/tgensymgeneric.nim
+++ b/tests/gensym/tgensymgeneric.nim
@@ -40,8 +40,8 @@ doAssert y.x == "abc"
 import macros
 
 static:
-  let sym1 = genSym()
-  let sym2 = genSym()
+  let sym1 = genSym(nskLet, "sym1")
+  let sym2 = genSym(nskLet, "sym2")
   let sym3 = sym1
   let nimsym = sym1.symbol
   doAssert sym1 == sym1


### PR DESCRIPTION
We'll see how much stuff this breaks.