### PR TITLE
openssl: use explicit result for SSL_in_init

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -418,9 +418,9 @@ else:
       sslState {.global.} = cast[proc(ssl: SslPtr): cint {.cdecl, gcsafe.}](sslSymNullable("SSL_state"))
 
     if not theProc.isNil:
-      theProc(ssl)
+      result = theProc(ssl)
     elif not sslState.isNil:
-      sslState(ssl) and SSL_ST_INIT
+      result = sslState(ssl) and SSL_ST_INIT
     else:
       raiseInvalidLibrary MainProc
 


### PR DESCRIPTION
Sometimes the analysis might get funky and decide that the if-expression
below is not an if-expression. Details of how this can happen is largely
unknown, but it's easy to prevent so we will just go forward with that.

Fix #14591