### PR TITLE
[OpenBSD] Add arm support

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -11,7 +11,7 @@ Platforms: """
   solaris: i386;amd64;sparc;sparc64
   freebsd: i386;amd64;powerpc64;arm;arm64
   netbsd: i386;amd64
-  openbsd: i386;amd64
+  openbsd: i386;amd64;arm;arm64
   dragonfly: i386;amd64
   haiku: i386;amd64
   android: i386;arm;arm64

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -90,6 +90,7 @@ case $uos in
     ;;
   *openbsd* )
     myos="openbsd"
+    CC="clang"
     LINK_FLAGS="$LINK_FLAGS -lm"
     ;;
   *netbsd* )


### PR DESCRIPTION
Nim can be built also on arm64 on OpenBSD. Tested with qemu

```
qemu# ../bin/nim -v                                                            
Nim Compiler Version 1.2.0 [OpenBSD: arm64]
Compiled at 2020-06-08
Copyright (c) 2006-2020 by Andreas Rumpf

active boot switches: -d:release
qemu# 
```