### PR TITLE
refs #14605; `hintMsgOrigin` now works in VM code; unittest-like error messages in compiler

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -13,7 +13,7 @@ import
 import std/private/miscdollars
 import std/private/debugutils
 
-type InstantiationInfo = typeof(instantiationInfo())
+type InstantiationInfo* = typeof(instantiationInfo())
 template instLoc(): InstantiationInfo = instantiationInfo(-2, fullPaths = true)
 
 template flushDot(conf, stdorr) =
@@ -374,7 +374,7 @@ proc getMessageStr(msg: TMsgKind, arg: string): string =
   result = msgKindToString(msg) % [arg]
 
 type
-  TErrorHandling = enum doNothing, doAbort, doRaise
+  TErrorHandling* = enum doNothing, doAbort, doRaise
 
 proc log*(s: string) =
   var f: File
@@ -474,7 +474,7 @@ proc formatMsg*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string): s
               else: ErrorTitle
   conf.toFileLineCol(info) & " " & title & getMessageStr(msg, arg)
 
-proc liMessage(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
+proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
                eh: TErrorHandling, info2: InstantiationInfo, isRaw = false) {.noinline.} =
   var
     title: string
@@ -594,7 +594,7 @@ template internalError*(conf: ConfigRef; errMsg: string) =
   internalErrorImpl(conf, unknownLineInfo, errMsg, instLoc())
 
 template internalAssert*(conf: ConfigRef, e: bool) =
-  # xxx merge with globalAssert from PR #14324
+  # xxx merge with `globalAssert`
   if not e:
     const info2 = instLoc()
     let arg = info2.toFileLineCol

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -197,15 +197,11 @@ proc newSymS(kind: TSymKind, n: PNode, c: PContext): PSym =
     suggestDecl(c, n, result)
 
 proc newSymG*(kind: TSymKind, n: PNode, c: PContext): PSym =
-  proc `$`(kind: TSymKind): string = substr(system.`$`(kind), 2).toLowerAscii
-
   # like newSymS, but considers gensym'ed symbols
   if n.kind == nkSym:
     # and sfGenSym in n.sym.flags:
     result = n.sym
-    if result.kind notin {kind, skTemp}:
-      localError(c.config, n.info, "cannot use symbol of kind '" &
-                 $result.kind & "' as a '" & $kind & "'")
+    localAssert c.config, result.kind in {kind, skTemp}, n.info
     when false:
       if sfGenSym in result.flags and result.kind notin {skTemplate, skMacro, skParam}:
         # declarative context, so produce a fresh gensym:

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -201,7 +201,10 @@ proc newSymG*(kind: TSymKind, n: PNode, c: PContext): PSym =
   if n.kind == nkSym:
     # and sfGenSym in n.sym.flags:
     result = n.sym
-    localAssert c.config, result.kind in {kind, skTemp}, n.info
+    if result.kind notin {kind, skTemp}:
+      localError(c.config, n.info, "cannot use symbol of kind '$1' as a '$2'" %
+        [result.kind.toHumanStr, kind.toHumanStr])
+    # xxx or simply: `localAssert c.config, result.kind in {kind, skTemp}, n.info`
     when false:
       if sfGenSym in result.flags and result.kind notin {skTemplate, skMacro, skParam}:
         # declarative context, so produce a fresh gensym:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -514,8 +514,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
         if typ.kind in tyUserTypeClasses and typ.isResolvedUserTypeClass:
           typ = typ.lastSon
         if hasEmpty(typ):
-          localError(c.config, def.info, errCannotInferTypeOfTheLiteral %
-                     ($typ.kind).substr(2).toLowerAscii)
+          localError(c.config, def.info, errCannotInferTypeOfTheLiteral % typ.kind.toHumanStr)
         elif typ.kind == tyProc and tfUnresolved in typ.flags:
           localError(c.config, def.info, errProcHasNoConcreteType % def.renderTree)
         when false:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -904,9 +904,7 @@ proc semAnyRef(c: PContext; n: PNode; kind: TTypeKind; prev: PType): PType =
               semTypeNode(c, body, nil)
     if t.kind == tyTypeDesc and tfUnresolved notin t.flags:
       t = t.base
-    if t.kind == tyVoid:
-      const kindToStr: array[tyPtr..tyRef, string] = ["ptr", "ref"]
-      localError(c.config, n.info, "type '$1 void' is not allowed" % kindToStr[kind])
+    localAssert(c.config, t.kind != tyVoid, n.info)
     result = newOrPrevType(kind, prev, c)
     var isNilable = false
     var wrapperKind = tyNone
@@ -1400,7 +1398,7 @@ proc semObjectTypeForInheritedGenericInst(c: PContext, n: PNode, t: PType) =
 proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
   if s.typ == nil:
     localError(c.config, n.info, "cannot instantiate the '$1' $2" %
-                       [s.name.s, ($s.kind).substr(2).toLowerAscii])
+               [s.name.s, s.kind.toHumanStr])
     return newOrPrevType(tyError, prev, c)
 
   var t = s.typ
@@ -1490,28 +1488,25 @@ proc fixupTypeOf(c: PContext, prev: PType, typExpr: PNode) =
 
 proc semTypeExpr(c: PContext, n: PNode; prev: PType): PType =
   var n = semExprWithType(c, n, {efDetermineType})
-  if n.typ.kind == tyTypeDesc:
-    result = n.typ.base
-    # fix types constructed by macros/template:
-    if prev != nil and prev.sym != nil:
-      if result.sym.isNil:
-        # Behold! you're witnessing enormous power yielded
-        # by macros. Only macros can summon unnamed types
-        # and cast spell upon AST. Here we need to give
-        # it a name taken from left hand side's node
-        result.sym = prev.sym
-        result.sym.typ = result
-      else:
-        # Less powerful routine like template do not have
-        # the ability to produce unnamed types. But still
-        # it has wild power to push a type a bit too far.
-        # So we need to hold it back using alias and prevent
-        # unnecessary new type creation
-        let alias = maybeAliasType(c, result, prev)
-        if alias != nil: result = alias
-  else:
-    localError(c.config, n.info, "expected type, but got: " & n.renderTree)
-    result = errorType(c)
+  localAssert c.config, n.typ.kind == tyTypeDesc, n.info, body = block: return errorType(c)
+  result = n.typ.base
+  # fix types constructed by macros/template:
+  if prev != nil and prev.sym != nil:
+    if result.sym.isNil:
+      # Behold! you're witnessing enormous power yielded
+      # by macros. Only macros can summon unnamed types
+      # and cast spell upon AST. Here we need to give
+      # it a name taken from left hand side's node
+      result.sym = prev.sym
+      result.sym.typ = result
+    else:
+      # Less powerful routine like template do not have
+      # the ability to produce unnamed types. But still
+      # it has wild power to push a type a bit too far.
+      # So we need to hold it back using alias and prevent
+      # unnecessary new type creation
+      let alias = maybeAliasType(c, result, prev)
+      if alias != nil: result = alias
 
 proc freshType(res, prev: PType): PType {.inline.} =
   if prev.isNil:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -72,15 +72,15 @@ proc stackTraceAux(c: PCtx; x: PStackFrame; pc: int; recursionLimit=100) =
       s.add(x.prc.name.s)
     msgWriteln(c.config, s)
 
-proc stackTraceImpl(c: PCtx, tos: PStackFrame, pc: int, msg: string, info: TLineInfo, infoOrigin: InstantiationInfo) {.noinline.} =
+proc stackTraceImpl(c: PCtx, tos: PStackFrame, pc: int,
+  msg: string, lineInfo: TLineInfo, infoOrigin: InstantiationInfo) {.noinline.} =
   # noinline to avoid code bloat
   msgWriteln(c.config, "stack trace: (most recent call last)")
   stackTraceAux(c, tos, pc)
   let action = if c.mode == emRepl: doRaise else: doNothing
     # XXX test if we want 'globalError' for every mode
-  var info = info
-  if info == TLineInfo.default: info = c.debug[pc]
-  liMessage(c.config, info, errGenerated, msg, action, infoOrigin)
+  let lineInfo = if lineInfo == TLineInfo.default: c.debug[pc] else: lineInfo
+  liMessage(c.config, lineInfo, errGenerated, msg, action, infoOrigin)
 
 template stackTrace(c: PCtx, tos: PStackFrame, pc: int,
                     msg: string, lineInfo: TLineInfo = TLineInfo.default) =

--- a/lib/std/private/debugutils.nim
+++ b/lib/std/private/debugutils.nim
@@ -54,15 +54,24 @@ macro conditionToStr*(cond: untyped, msg = ""): string =
     # whether `lhs` is printable
     result.add quote do:
       `ret`.add `cond2`
-  let msg2 = msg.repr
+
+  echo msg.kind
+  if msg.kind in nnkStrLit..nnkTripleStrLit:
+    let msg2 = msg.strVal
+    if msg2.len > 0:
+      result.add quote do:
+        `ret`.add "; " & `msg2`
+  else:
+    let msg2 = msg.repr
+    result.add quote do:
+      `ret`.add "; " & `msg2` & ": " & `msg`
   result.add quote do:
-    if `msg`.len > 0: `ret`.add "; " & `msg2` & ": " & `msg`
     `ret`
 
 when isMainModule:
   template chk(cond: untyped, msg = "") =
     if not cond:
-      let ret = conditionToStr(ret, cond, msg)
+      let ret = conditionToStr(cond, msg)
       # doAssert false, ret
       echo ret
 
@@ -76,4 +85,9 @@ when isMainModule:
       chk c in ["foo1", "foo2", c2]
       chk c != "foo"
       chk c == "bar"
+      chk c == "bar", "gook1"
+      var msg = "gook2"
+      chk c == "bar", msg
+      var x = [12,13]
+      chk c == "bar", $x
   main()

--- a/lib/std/private/debugutils.nim
+++ b/lib/std/private/debugutils.nim
@@ -26,7 +26,6 @@ macro conditionToStr*(cond: untyped, msg = ""): string =
   let cond2 = cond.repr
   let ret = genSym(nskVar, "ret")
   result.add quote do:
-    # `ret`.add "expected: '$1'" % [`cond2`]
     var `ret`: string
     `ret`.add "expected: "
   case cond.kind
@@ -36,26 +35,15 @@ macro conditionToStr*(cond: untyped, msg = ""): string =
     let lhsLit = lhs.repr
     let rhs = cond[2]
     result.add quote do:
+      # we would also branch on `isPureLit`
       `ret`.add "'$#' ($#) $# $#" % [`lhsLit`, $`lhs`, `infix`,  $`rhs`]
-    # let lhsInfo = lhs.info
-    # let lhsInfo = lhs.lineInfo
-    
-    # if not lhs.isPureLit:
-    #   result.add quote do:
-    #     # `ret`.add " lhs: '$1' defined at $2" % [$`lhs`, ]
-    #     `ret`.add " lhs: '$1'" % [$`lhs`, ]
-    # if not rhs.isPureLit:
-    #   result.add quote do:
-    #     `ret`.add " rhs: '$1' " % [$`rhs`]
   else:
-    # eg: nnkDotExpr for foo.bar.isAbsolute
-    let cond2 = cond.repr
-    # we could also provide context info here, eg for `nnkDotExpr`, check
-    # whether `lhs` is printable
+    let cond2 = cond.repr # for example: `nnkDotExpr` for foo.bar.isAbsolute
+    # we could also provide context info here, for example for `nnkDotExpr`, 
+    # we could show `$lhs` if it compiles.
     result.add quote do:
       `ret`.add `cond2`
 
-  echo msg.kind
   if msg.kind in nnkStrLit..nnkTripleStrLit:
     let msg2 = msg.strVal
     if msg2.len > 0:
@@ -72,7 +60,7 @@ when isMainModule:
   template chk(cond: untyped, msg = "") =
     if not cond:
       let ret = conditionToStr(cond, msg)
-      # doAssert false, ret
+      # in a real application, you might use something like `doAssert false, ret`
       echo ret
 
   proc main() =

--- a/lib/std/private/debugutils.nim
+++ b/lib/std/private/debugutils.nim
@@ -1,0 +1,79 @@
+##[
+internal API for now, subject to change
+]##
+
+#[
+see also:
+$nim/testament/lib/stdtest/unittest_light.nim
+]#
+
+import macros
+import std/strutils
+
+proc isPureLit*(a: NimNode): bool =
+  if a.len > 0:
+    for ai in a:
+      if not isPureLit(ai): return false
+    return true
+  else:
+    case a.kind
+    of nnkLiterals:
+      return true
+    else: return false
+
+macro conditionToStr*(cond: untyped, msg = ""): string =
+  result = newStmtList()
+  let cond2 = cond.repr
+  let ret = genSym(nskVar, "ret")
+  result.add quote do:
+    # `ret`.add "expected: '$1'" % [`cond2`]
+    var `ret`: string
+    `ret`.add "expected: "
+  case cond.kind
+  of nnkInfix:
+    let infix = cond[0].repr
+    let lhs = cond[1]
+    let lhsLit = lhs.repr
+    let rhs = cond[2]
+    result.add quote do:
+      `ret`.add "'$#' ($#) $# $#" % [`lhsLit`, $`lhs`, `infix`,  $`rhs`]
+    # let lhsInfo = lhs.info
+    # let lhsInfo = lhs.lineInfo
+    
+    # if not lhs.isPureLit:
+    #   result.add quote do:
+    #     # `ret`.add " lhs: '$1' defined at $2" % [$`lhs`, ]
+    #     `ret`.add " lhs: '$1'" % [$`lhs`, ]
+    # if not rhs.isPureLit:
+    #   result.add quote do:
+    #     `ret`.add " rhs: '$1' " % [$`rhs`]
+  else:
+    # eg: nnkDotExpr for foo.bar.isAbsolute
+    let cond2 = cond.repr
+    # we could also provide context info here, eg for `nnkDotExpr`, check
+    # whether `lhs` is printable
+    result.add quote do:
+      `ret`.add `cond2`
+  let msg2 = msg.repr
+  result.add quote do:
+    if `msg`.len > 0: `ret`.add "; " & `msg2` & ": " & `msg`
+    `ret`
+
+when isMainModule:
+  template chk(cond: untyped, msg = "") =
+    if not cond:
+      let ret = conditionToStr(ret, cond, msg)
+      # doAssert false, ret
+      echo ret
+
+  proc main() =
+    block:
+      var i=1
+      chk 1+i == 3
+    block:
+      var c = "foo"
+      var c2 = "foo3"
+      chk c in ["foo1", "foo2", c2]
+      chk c != "foo"
+      chk c == "bar"
+  main()


### PR DESCRIPTION
* refs #14605
* `hintMsgOrigin` now points to the most useful lineinfo where compiler msg originated, both for `stacktrace` calls as well as for `vmAssert` calls; instead of pointing to the generic `stackTraceImpl` location which is useless, it points to the code that calls `stacktrace` /  `vmAssert`
* enables unittest-like error messages in compiler to show the runtime value
* simplifies code

## example
```nim
if a.kind == nkSym:
  main implementation...
else:
  stackTrace(c, tos, pc, "node is not a symbol")
```
=>
```nim
vmAssert a.kind == nkSym, "node is not a symbol"
main implementation...
```

for example, the code in https://github.com/nim-lang/Nim/issues/14605 now shows:
```
stack trace: (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10918.nim(11, 9) inspect
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10918.nim(23, 8) template/generic instantiation from here
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10918.nim(25, 8) template/generic instantiation of `inspect` from here
/Users/timothee/git_clone/nim/timn/tests/nim/all/t10918.nim(11, 9) Error: expected: 'a.kind' (nkClosedSymChoice) == nkSym; node is not a symbol
    echo p.getImpl().toStrLit
```
note that the `"node is not a symbol"` is not really needed anymore, the runtime context shown should hopefully be clear enough; but I kept it here.

## after PR
after this is accepted, more error messages can use the "short form" and benefit form runtime diagnostic
