### PR TITLE
httpcore: Add http code 308 Permanent Redirect

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -457,7 +457,7 @@ proc sendFile(socket: Socket | AsyncSocket,
   file.close()
 
 proc redirection(status: string): bool =
-  const redirectionNRs = ["301", "302", "303", "307"]
+  const redirectionNRs = ["301", "302", "303", "307", "308"]
   for i in items(redirectionNRs):
     if status.startsWith(i):
       return true

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -66,7 +66,7 @@ const
   Http304* = HttpCode(304)
   Http305* = HttpCode(305)
   Http307* = HttpCode(307)
-  Http308* = HttpCore(308)
+  Http308* = HttpCode(308)
   Http400* = HttpCode(400)
   Http401* = HttpCode(401)
   Http403* = HttpCode(403)

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -66,6 +66,7 @@ const
   Http304* = HttpCode(304)
   Http305* = HttpCode(305)
   Http307* = HttpCode(307)
+  Http308* = HttpCore(308)
   Http400* = HttpCode(400)
   Http401* = HttpCode(401)
   Http403* = HttpCode(403)
@@ -272,6 +273,7 @@ proc `$`*(code: HttpCode): string =
   of 304: "304 Not Modified"
   of 305: "305 Use Proxy"
   of 307: "307 Temporary Redirect"
+  of 308: "308 Permanent Redirect"
   of 400: "400 Bad Request"
   of 401: "401 Unauthorized"
   of 403: "403 Forbidden"


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7538

> This status code is similar to 301 (Moved Permanently) ([RFC7231], Section 6.4.2), except that it does not allow changing the request method from POST to GET.

https://evertpot.com/http/308-permanent-redirect

> The difference between 301 and 308 is that a client that sees a 308 redirect MUST do the exact same request on the target location. If the request was a POST and and had a body, then the client must do a POST request with a body on the new location.