### PR TITLE
Add browsers.findInstalledBrowsers, browsers.openBrowsers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -113,7 +113,7 @@
 - new proc `heapqueue.find[T](heap: HeapQueue[T], x: T): int` to get index of element ``x``.
 
 - Add `browsers.findInstalledBrowsers` to find *all* installed web browsers, not just the default one.
-- Add `browsers.openBrowsers` to open an `url` with one or more web browsers with arbitrary `params`.
+- Add `browsers.openBrowser` to open an `url` with given web browser with arbitrary `params`.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -112,6 +112,10 @@
 
 - new proc `heapqueue.find[T](heap: HeapQueue[T], x: T): int` to get index of element ``x``.
 
+- Add `browsers.findInstalledBrowsers` to find *all* installed web browsers, not just the default one.
+- Add `browsers.openBrowsers` to open an `url` with one or more web browsers with arbitrary `params`.
+
+
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:
 

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -126,21 +126,19 @@ proc findInstalledBrowsers*(limit = 3.Positive, followSymlinks = true): set[WebB
       inc i
       incl result, x
 
-proc openBrowsers*(url: string, browsers: openArray[tuple[browser: WebBrowsers, params: string]]) {.since: (1, 3).} =
-  ## Open an `url` with one or more web browsers with arbitrary `params`.
+proc openBrowser*(url: string, browser: WebBrowsers, params: seq[string]) {.since: (1, 3).} =
+  ## Open an `url` with given web browser with arbitrary `params`.
   ## This does not block. The URL must not be empty string.
-  ## This proc does not raise an exception on error, beware.
   ## To check for installed web browsers see `findInstalledBrowsers()`.
   ##
   ## .. code-block:: nim
-  ##   openBrowsers("https://nim-lang.org", [(wbFirefox, "-new-tab"), (wbChromium, "--new-window")])
-  ##   openBrowsers("http://localhost/karax-spa/index.html", [(wbFirefox, "--devtools")])
+  ##   openBrowser("https://nim-lang.org", wbFirefox, "-new-tab")
+  ##   openBrowser("https://nim-lang.org", wbChromium, "--new-window")
+  ##   openBrowser("http://localhost/karax-spa/index.html", wbFirefox, "--devtools")
   doAssert url.len > 0, "URL must not be empty string"
-  assert browsers.len > 0
-  for x in browsers:
-    when defined(windows):
-      var o = newWideCString($x.browser & " " & x.params)
-      var u = newWideCString(url)
-      discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
-    else:
-      discard execShellCmd($x.browser & " " & quoteShell(x.params) & " " & quoteShell(url))
+  when defined(windows):
+    var o = newWideCString($browser & " " & params.join(" "))
+    var u = newWideCString(url)
+    discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
+  else:
+    discard execShellCmd($browser & " " & quoteShell(params.join(" ")) & " " & quoteShell(url))

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -126,19 +126,22 @@ proc findInstalledBrowsers*(limit = 3.Positive, followSymlinks = true): set[WebB
       inc i
       incl result, x
 
-proc openBrowser*(url: string, browser: WebBrowsers, params: seq[string]) {.since: (1, 3).} =
+proc openBrowser*(url: string, browser: WebBrowsers, params: varargs[string]) {.since: (1, 3).} =
   ## Open an `url` with given web browser with arbitrary `params`.
   ## This does not block. The URL must not be empty string.
   ## To check for installed web browsers see `findInstalledBrowsers()`.
   ##
   ## .. code-block:: nim
+  ##   openBrowser("https://nim-lang.org", wbFirefox)
   ##   openBrowser("https://nim-lang.org", wbFirefox, "-new-tab")
   ##   openBrowser("https://nim-lang.org", wbChromium, "--new-window")
   ##   openBrowser("http://localhost/karax-spa/index.html", wbFirefox, "--devtools")
   doAssert url.len > 0, "URL must not be empty string"
   when defined(windows):
-    var o = newWideCString($browser & " " & params.join(" "))
+    let cmd = if params.len > 0: $browser & " " & params.join(" ") else: $browser
+    var o = newWideCString(cmd)
     var u = newWideCString(url)
     discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
   else:
-    discard execShellCmd($browser & " " & quoteShell(params.join(" ")) & " " & quoteShell(url))
+    let cmd = if params.len > 0: $browser & " " & quoteShell(params.join(" ")) else: $browser & " "
+    discard execShellCmd(cmd & " " & quoteShell(url))

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -130,6 +130,7 @@ proc openBrowser*(url: string, browser: WebBrowsers, params: varargs[string]) {.
   ## Open an `url` with given web browser with arbitrary `params`.
   ## This does not block. The URL must not be empty string.
   ## To check for installed web browsers see `findInstalledBrowsers()`.
+  ## The web browser must be within `PATH`.
   ##
   ## .. code-block:: nim
   ##   openBrowser("https://nim-lang.org", wbFirefox)

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -113,7 +113,7 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   openDefaultBrowserImpl("http:about:blank")  # See IETF RFC-6694 Section 3.
 
 proc findInstalledBrowsers*(limit = 3.Positive, followSymlinks = true): set[WebBrowsers] {.inline, since: (1, 3).} =
-  ## Try to find *all* installed web browsers, not just the default one.
+  ## Try to find *all* installed web browsers within `PATH`, not just the default one.
   ## * if `followSymlinks` is `true` it will follow symbolic links when searching for web browsers.
   ## * `limit` is the maximum limit of *installed* web browsers to return.
   ##

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -13,13 +13,45 @@
 ## Unstable API.
 
 import std/private/since
-
+from os import findExe
 import strutils
 
 when defined(windows):
   import winlean
 else:
   import os, osproc
+
+since (1, 3):
+  type WebBrowsers* = enum          ## Web Browsers
+    wbFirefox = "firefox"           ## Mozilla Firefox
+    wbChrome = "google-chrome"      ## Google Chrome
+    wbChromium = "chromium-browser" ## Chromium
+    wbInternetExplorer = "iexplore" ## Microsoft Internet Explorer
+    wbEdge = "microsoft-edge"       ## Microsoft Edge
+    wbSafari = "safari"             ## Apple Safari
+    wbChromiumSnapshotBin = "chromium-snapshot-bin" ## Chromium Snapshot Binary
+    wbChromiumSnapshot = "chromium-snapshot"        ## Chromium Snapshot from Sources
+    wbUngoogledChromium = "ungoogled-chromium"      ## Chromium Fork
+    wbIceweasel = "iceweasel"       ## Mozilla Firefox Fork
+    wbTorbrowser = "torbrowser"     ## Mozilla Firefox Fork https://www.torproject.org/download
+    wbIcecat = "icecat"             ## Mozilla Firefox Fork
+    wbIceape = "iceape"             ## Mozilla Firefox Fork
+    wbSeamonkey = "seamonkey"       ## Mozilla Firefox Fork
+    wbWaterfox = "waterfox"         ## Mozilla Firefox Fork https://www.waterfox.net
+    wbPalemoon = "palemoon"         ## Mozilla Firefox Fork https://www.palemoon.org
+    wbFalkon = "falkon"             ## KDE Falkon https://www.falkon.org
+    wbKonqueror = "konqueror"       ## KDE Web Browser
+    wbEpiphany = "epiphany"         ## Gnome Web Browser
+    wbMidori = "midori"             ## https://astian.org/midori
+    wbBrave = "brave-browser"       ## https://brave.com
+    wbVivaldi = "vivaldi-browser"   ## https://vivaldi.com
+    wbOpera = "opera"               ## Opera
+    wbSkipstone = "skipstone"       ## GTK/Mozilla based Web Browser
+    wbElinks = "elinks"             ## eLinks http://www.jikos.cz/~mikulas/links
+    wbLynx = "lynx"                 ## Lynx http://lynx.browser.org
+    wbW3m = "w3m"                   ## W3M http://w3m.sourceforge.net
+    wbDillo = "dillo"               ## https://www.dillo.org
+
 
 const osOpenCmd* =
   when defined(macos) or defined(macosx) or defined(windows): "open" else: "xdg-open" ## \
@@ -79,3 +111,36 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   ## .. code-block:: nim
   ##   block: openDefaultBrowser()
   openDefaultBrowserImpl("http:about:blank")  # See IETF RFC-6694 Section 3.
+
+proc findInstalledBrowsers*(limit = 3.Positive, followSymlinks = true): set[WebBrowsers] {.inline, since: (1, 3).} =
+  ## Try to find *all* installed web browsers, not just the default one.
+  ## * if `followSymlinks` is `true` it will follow symbolic links when searching for web browsers.
+  ## * `limit` is the maximum limit of *installed* web browsers to return.
+  ##
+  ## .. code-block:: nim
+  ##   echo findInstalledBrowsers()  ## {firefox, chromium, safari}
+  var i = 0
+  for x in WebBrowsers:
+    if i > limit: break
+    if findExe($x, followSymlinks).len > 0:
+      inc i
+      incl result, x
+
+proc openBrowsers*(url: string, browsers: openArray[tuple[browser: WebBrowsers, params: string]]) {.since: (1, 3).} =
+  ## Open an `url` with one or more web browsers with arbitrary `params`.
+  ## This does not block. The URL must not be empty string.
+  ## This proc does not raise an exception on error, beware.
+  ## To check for installed web browsers see `findInstalledBrowsers()`.
+  ##
+  ## .. code-block:: nim
+  ##   openBrowsers("https://nim-lang.org", [(wbFirefox, "-new-tab"), (wbChromium, "--new-window")])
+  ##   openBrowsers("http://localhost/karax-spa/index.html", [(wbFirefox, "--devtools")])
+  doAssert url.len > 0, "URL must not be empty string"
+  assert browsers.len > 0
+  for x in browsers:
+    when defined(windows):
+      var o = newWideCString($x.browser & " " & x.params)
+      var u = newWideCString(url)
+      discard shellExecuteW(0'i32, o, u, nil, nil, SW_SHOWNORMAL)
+    else:
+      discard execShellCmd($x.browser & " " & quoteShell(x.params) & " " & quoteShell(url))


### PR DESCRIPTION
- Add `browsers.findInstalledBrowsers` to find *all* installed web browsers, not just the default one.
- Add `browsers.openBrowsers` to open an `url` with one or more web browsers with arbitrary `params`.
- `since`, changelog, examples, documentation, etc.

You can open a page you are coding locally with Firefox and Chrome, with DevTools open, all at once.
:)
