### PR TITLE
add compilesettings.nimVersionCT + friends

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,9 @@
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
 
 
+- Add `compilesettings.nimVersionCT` to get the stdlib version nim was compiled at; this is the same as the one reported
+  by `nim dump --dump.format:json . | jq .version` or in `nim -v`, unlike the one in `system.NimVersion`.
+
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:
 

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -190,6 +190,8 @@ proc registerAdditionalOps*(c: PCtx) =
         setResult(a, querySettingImpl(c.config, getInt(a, 0)))
       registerCallback c, "stdlib.compilesettings.querySettingSeq", proc (a: VmArgs) {.nimcall.} =
         setResult(a, querySettingSeqImpl(c.config, getInt(a, 0)))
+      registerCallback c, "stdlib.compilesettings.nimVersionCTImpl", proc (a: VmArgs) {.nimcall.} =
+        a.setResult (NimMajor, NimMinor, NimPatch).toLit
 
     if defined(nimsuggest) or c.config.cmd == cmdCheck:
       discard "don't run staticExec for 'nim suggest'"

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2063,17 +2063,19 @@ template unlikely*(val: bool): bool =
 
 const
   NimMajor* {.intdefine.}: int = 1
-    ## is the major number of Nim's version. Example:
+    ## is the major number of Nim's version.
+    ## See also `compilesettings.nimVersion,nimVersionCT`.
+    ## Example:
     ##
     ## .. code-block:: Nim
     ##   when (NimMajor, NimMinor, NimPatch) >= (1, 3, 1): discard
-    # see also std/private/since
+    # See also `std/private/since`
 
   NimMinor* {.intdefine.}: int = 3
     ## is the minor number of Nim's version.
     ## Odd for devel, even for releases.
 
-  NimPatch* {.intdefine.}: int = 5
+  NimPatch* {.intdefine.}: int = 7
     ## is the patch number of Nim's version.
     ## Odd for devel, even for releases.
 


### PR DESCRIPTION
* refs https://github.com/nim-lang/compilerdev/issues/9
* after this PR `compiler/condsyms` should rarely be needed since you can just do a version test (which self-document when something was added as side benefit)
* `since` is a different thing since it looks at system.NimMajor+friends, which says nothing about the stdlib version nim was compiled at, so is suitable when branching for stdlib features, but not compiler features
* also added `nimVersion` for symmetry, which is useful when `since` falls short, eg: `when nimVersion >= (1,3,5): foo else: bar`, or `when defined(js) and nimVersion >= (1,3,5): bar` etc
* no system bloat

## example
```nim
# in ~/.config/nim/config.nims
import std/compilesettings
when nimVersionCT >= (1,3,5):
  # instead of having to add `defineSymbol("nimHasStacktraceMsgs")` to condsyms.nim
  switch("stacktraceMsgs", "on") # or any thing that is defined in compiler (eg magics) as opposed to stdlib
```


after that I'll resume https://github.com/nim-lang/Nim/pull/14068#issuecomment-618234562

## links
(EDIT)
https://github.com/nim-lang/Nim/pull/16406/files/e1b4468313399c0468c6675bf18a62c7e15b233c..f8d5208f2e377e2bd7c52ed8a96f18255c256850#r549607059