### PR TITLE
[superseded] add optional param `normalizePath*(path: var string, isExe = false)`: koch => ./koch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -112,7 +112,7 @@
 
 - new proc `heapqueue.find[T](heap: HeapQueue[T], x: T): int` to get index of element ``x``.
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
-
+- Add `exe` param to `os.normalizePath*(path: var string, exe = false)`
 
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:

--- a/changelog.md
+++ b/changelog.md
@@ -112,7 +112,7 @@
 
 - new proc `heapqueue.find[T](heap: HeapQueue[T], x: T): int` to get index of element ``x``.
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
-- Add `exe` param to `os.normalizePath*(path: var string, exe = false)`
+- Add `exe` param to `os.normalizePath*(path: var string, isExe = false)`
 
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1407,9 +1407,11 @@ proc absolutePath*(path: string, root = getCurrentDir()): string =
 proc absolutePathInternal(path: string): string =
   absolutePath(path, getCurrentDir())
 
-proc normalizePath*(path: var string, exe = false) {.rtl, extern: "nos$1", tags: [].} =
-  ## Normalize a path. If `exe == true`, on posix, `./` is prepended if `path`
-  ## doesn't contain `/` and is not `"", ".", ".."`.
+proc normalizePath*(path: var string, isExe = false) {.rtl, extern: "nos$1", tags: [].} =
+  ## Normalize a path.
+  ##
+  ## If `isExe == true`, on posix, `./` is prepended if `path` doesn't contain
+  ## `/` and is not `"", ".", ".."`.
   ##
   ## Consecutive directory separators are collapsed, including an initial double slash.
   ##
@@ -1428,13 +1430,13 @@ proc normalizePath*(path: var string, exe = false) {.rtl, extern: "nos$1", tags:
       a.normalizePath()
       assert a == "a/c/d"
       assert normalizedPath("//a//./") == "/a"
-      assert normalizedPath("koch", exe = true) == "./koch" # difference with exe=false
-      assert normalizedPath("bin/nim", exe = true) == "bin/nim"
-    assert normalizedPath("", exe = true) == ""
+      assert normalizedPath("koch", isExe = true) == "./koch"
+      assert normalizedPath("bin/nim", isExe = true) == "bin/nim"
+    assert normalizedPath("", isExe = true) == ""
 
   path = pathnorm.normalizePath(path)
   when defined(posix):
-    if exe and path.len > 0 and DirSep notin path and path != "." and path != "..":
+    if isExe and path.len > 0 and DirSep notin path and path != "." and path != "..":
       path = "./" & path
 
   when false:
@@ -1466,11 +1468,11 @@ proc normalizePath*(path: var string, exe = false) {.rtl, extern: "nos$1", tags:
 
 proc normalizePathAux(path: var string) = normalizePath(path)
 
-proc normalizedPath*(path: string, exe = false): string {.rtl, extern: "nos$1", tags: [].} =
-  ## In-place version of `normalizePath proc <#normalizePath,string>`_
-  if exe:
+proc normalizedPath*(path: string, isExe = false): string {.rtl, extern: "nos$1", tags: [].} =
+  ## outplace version of `normalizePath proc <#normalizePath,string>`_
+  if isExe:
     result = path
-    normalizePath(result, exe = exe)
+    normalizePath(result, isExe = true)
   else: # avoid 1 extra copy
     result = pathnorm.normalizePath(path)
 

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -450,12 +450,7 @@ proc testSpecHelper(r: var TResults, test: TTest, expected: TSpec,
             exeCmd = nodejs
             args = concat(@[exeFile], args)
           else:
-            if defined(posix) and not exeFile.contains('/'):
-              # "security" in Posix is actually just a euphemism
-              # for "unproductive arbitrary shit"
-              exeCmd = "./" & exeFile
-            else:
-              exeCmd = exeFile
+            exeCmd = exeFile.normalizedPath(exe = true)
             if expected.useValgrind:
               args = @["--error-exitcode=1"] & exeCmd & args
               exeCmd = "valgrind"

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -450,7 +450,7 @@ proc testSpecHelper(r: var TResults, test: TTest, expected: TSpec,
             exeCmd = nodejs
             args = concat(@[exeFile], args)
           else:
-            exeCmd = exeFile.normalizedPath(exe = true)
+            exeCmd = exeFile.normalizedPath(isExe = true)
             if expected.useValgrind:
               args = @["--error-exitcode=1"] & exeCmd & args
               exeCmd = "valgrind"

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -209,21 +209,21 @@ block normalizedPath:
     doAssert normalizedPath("/a/b/c/../") == unixToNativePath"/a/b"
     doAssert normalizedPath("//a//.") == unixToNativePath"/a"
 
-  block exe:
-    doAssert normalizedPath("", exe = true) == ""
+  block isExe:
+    doAssert normalizedPath("", isExe = true) == ""
     when defined(posix):
-      doAssert normalizedPath("foo", exe = true) == "./foo"
-      doAssert normalizedPath(".foo.bar", exe = true) == "./.foo.bar"
+      doAssert normalizedPath("foo", isExe = true) == "./foo"
+      doAssert normalizedPath(".foo.bar", isExe = true) == "./.foo.bar"
     when defined(windows):
-      doAssert normalizedPath("foo", exe = true) == "foo"
-    doAssert normalizedPath("foo/bar", exe = true) == unixToNativePath"foo/bar"
-    doAssert normalizedPath("//abc//.", exe = true) == unixToNativePath"/abc"
+      doAssert normalizedPath("foo", isExe = true) == "foo"
+    doAssert normalizedPath("foo/bar", isExe = true) == unixToNativePath"foo/bar"
+    doAssert normalizedPath("//abc//.", isExe = true) == unixToNativePath"/abc"
 
     # edge cases
     when defined(posix):
-      doAssert normalizedPath("foo/", exe = true) == "./foo"
-    doAssert normalizedPath("..", exe = true) == ".."
-    doAssert normalizedPath(".", exe = true) == "."
+      doAssert normalizedPath("foo/", isExe = true) == "./foo"
+    doAssert normalizedPath("..", isExe = true) == ".."
+    doAssert normalizedPath(".", isExe = true) == "."
 
 block isHidden:
   when defined(posix):

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -207,6 +207,23 @@ block normalizedPath:
     doAssert normalizedPath("/a///b") == unixToNativePath"/a/b"
     doAssert normalizedPath("/a/b/c/..") == unixToNativePath"/a/b"
     doAssert normalizedPath("/a/b/c/../") == unixToNativePath"/a/b"
+    doAssert normalizedPath("//a//.") == unixToNativePath"/a"
+
+  block exe:
+    doAssert normalizedPath("", exe = true) == ""
+    when defined(posix):
+      doAssert normalizedPath("foo", exe = true) == "./foo"
+      doAssert normalizedPath(".foo.bar", exe = true) == "./.foo.bar"
+    when defined(windows):
+      doAssert normalizedPath("foo", exe = true) == "foo"
+    doAssert normalizedPath("foo/bar", exe = true) == unixToNativePath"foo/bar"
+    doAssert normalizedPath("//abc//.", exe = true) == unixToNativePath"/abc"
+
+    # edge cases
+    when defined(posix):
+      doAssert normalizedPath("foo/", exe = true) == "./foo"
+    doAssert normalizedPath("..", exe = true) == ".."
+    doAssert normalizedPath(".", exe = true) == "."
 
 block isHidden:
   when defined(posix):


### PR DESCRIPTION
* closes https://github.com/nim-lang/compilerdev/issues/10
