### PR TITLE
compiler/commands: make gitHash settable at compile-time.

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -98,7 +98,7 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
                                  CPU[conf.target.hostCPU].name, CompileDate]),
                {msgStdout})
 
-    const gitHash = gorge("git log -n 1 --format=%H").strip
+    const gitHash {.strdefine.} = gorge("git log -n 1 --format=%H").strip
     when gitHash.len == 40:
       msgWriteln(conf, "git hash: " & gitHash, {msgStdout})
 


### PR DESCRIPTION
This is useful for building nightlies, since we will be building from a
generated source archive and git metadata is lost there.