### PR TITLE
fix #14179, fix #14142, make CI 1.4x faster (2x faster locally)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -62,7 +62,6 @@
 
 - Added high-level `asyncnet.sendTo` and `asyncnet.recvFrom`. UDP functionality.
 
-- `paramCount` & `paramStr` are now defined in os.nim instead of nimscript.nim for nimscript/nimble.
 - `dollars.$` now works for unsigned ints with `nim js`
 
 - Improvements to the `bitops` module, including bitslices, non-mutating versions

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -77,7 +77,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasUserErrors")
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")
-  defineSymbol("nimErrorProcCanHaveBody")
+  defineSymbol("nimErrorProcCanHaveBody") # since #9665 but now unused
   defineSymbol("nimHasInstantiationOfInMacro")
   defineSymbol("nimHasHotCodeReloading")
   defineSymbol("nimHasNilSeqs")

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -77,7 +77,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasUserErrors")
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")
-  defineSymbol("nimErrorProcCanHaveBody") # since #9665 but now unused
+  defineSymbol("nimErrorProcCanHaveBody")
   defineSymbol("nimHasInstantiationOfInMacro")
   defineSymbol("nimHasHotCodeReloading")
   defineSymbol("nimHasNilSeqs")

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -141,12 +141,10 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
     setResult(a, options.existsConfigVar(conf, a.getString 0))
   cbconf nimcacheDir:
     setResult(a, options.getNimcacheDir(conf).string)
-  result.registerCallback "stdlib.os." & astToStr(paramStr),
-    proc (a: VmArgs) =
-      setResult(a, os.paramStr(int a.getInt 0))
-  result.registerCallback "stdlib.os." & astToStr(paramCount),
-    proc (a: VmArgs) =
-      setResult(a, os.paramCount())
+  cbconf paramStr:
+    setResult(a, os.paramStr(int a.getInt 0))
+  cbconf paramCount:
+    setResult(a, os.paramCount())
   cbconf cmpIgnoreStyle:
     setResult(a, strutils.cmpIgnoreStyle(a.getString 0, a.getString 1))
   cbconf cmpIgnoreCase:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3132,7 +3132,7 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
       assert(path != "") # symlinks can't occur for file handles
       formalInfo.kind = getSymlinkFileKind(path)
 
-when defined(js) or defined(nimscript):
+when defined(js):
   when not declared(FileHandle):
     type FileHandle = distinct int32
   when not declared(File):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -75,8 +75,10 @@ elif defined(posix):
 else:
   {.error: "OS module not ported to your operating system!".}
 
-when weirdTarget and defined(nimErrorProcCanHaveBody):
-  {.pragma: noNimScript, error: "this proc is not available on the NimScript target".}
+when weirdTarget:
+  template noNimScript(body): untyped = discard
+  # Adding a `disable` template and `{.pragma: noNimScript, disable.}`
+  # doesn't work pending https://github.com/timotheecour/Nim/issues/142
 else:
   {.pragma: noNimScript.}
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -77,8 +77,6 @@ else:
 
 when weirdTarget:
   template noNimScript(body): untyped = discard
-  # Adding a `disable` template and `{.pragma: noNimScript, disable.}`
-  # doesn't work pending https://github.com/timotheecour/Nim/issues/142
 else:
   {.pragma: noNimScript.}
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2720,23 +2720,7 @@ when defined(nimdoc):
     ##   else:
     ##     # Do something else!
 
-elif defined(nimscript):
-  proc paramStr*(i: int): string =
-    ## Retrieves the ``i``'th command line parameter.
-    discard
-
-  proc paramCount*(): int =
-    ## Retrieves the number of command line parameters.
-    discard
-
-elif defined(js):
-  proc paramStr*(i: int): TaintedString {.tags: [ReadIOEffect].} =
-    raise newException(OSError, "paramStr is not implemented on JavaScript")
-
-  proc paramCount*(): int {.tags: [ReadIOEffect].} =
-    raise newException(OSError, "paramCount is not implemented on JavaScript")
-
-elif defined(nintendoswitch):
+elif defined(nintendoswitch) or weirdTarget:
   proc paramStr*(i: int): TaintedString {.tags: [ReadIOEffect].} =
     raise newException(OSError, "paramStr is not implemented on Nintendo Switch")
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2720,6 +2720,7 @@ when defined(nimdoc):
     ##   else:
     ##     # Do something else!
 
+elif defined(nimscript): discard
 elif defined(nintendoswitch) or weirdTarget:
   proc paramStr*(i: int): TaintedString {.tags: [ReadIOEffect].} =
     raise newException(OSError, "paramStr is not implemented on Nintendo Switch")

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -56,6 +56,14 @@ proc rawExec(cmd: string): int {.tags: [ExecIOEffect], raises: [OSError].} =
 proc warningImpl(arg, orig: string) = discard
 proc hintImpl(arg, orig: string) = discard
 
+proc paramStr*(i: int): string =
+  ## Retrieves the ``i``'th command line parameter.
+  builtin
+
+proc paramCount*(): int =
+  ## Retrieves the number of command line parameters.
+  builtin
+
 proc switch*(key: string, val="") =
   ## Sets a Nim compiler command line switch, for
   ## example ``switch("checks", "on")``.

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -272,9 +272,6 @@ proc selfExec*(command: string) {.
       raise newException(OSError, "FAILED: " & c)
     checkOsError()
 
-from os import paramCount, paramStr
-export paramCount, paramStr
-
 proc put*(key, value: string) =
   ## Sets a configuration 'key' like 'gcc.options.always' to its value.
   builtin

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -69,6 +69,7 @@ import std/[
   decls, compilesettings, with, wrapnils
 ]
 
+
 block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
 

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -69,7 +69,6 @@ import std/[
   decls, compilesettings, with, wrapnils
 ]
 
-
 block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
 
@@ -81,3 +80,10 @@ when false: # #14142
   discard findExe("nim")
 
 echo "Nimscript imports are successful."
+
+block: # #14142
+  discard existsDir("/usr")
+  discard dirExists("/usr")
+  discard existsFile("/usr/foo")
+  discard fileExists("/usr/foo")
+  discard findExe("nim")


### PR DESCRIPTION
* make CI significantly faster (1.4x faster on CI machines, 2x locally) 
by avoiding `import os` (and all the modules that it imports recursively) for every single invocation of `nim`; like wise for short-lived commands (eg `nim dump` or `nim c smallfile` or `inim`)

* fix https://github.com/nim-lang/Nim/issues/14179
* fix https://github.com/nim-lang/Nim/issues/14142
* supersedes https://github.com/nim-lang/Nim/pull/14143
* still keeps https://github.com/nim-lang/Nim/issues/12835 as fixed

see https://github.com/nim-lang/Nim/issues/14179#issuecomment-625200718 for the full context

## CI timings on CI machines
before PR => after PR
Linux_amd64 31m => 21m
Linux_i386 32m => 18m
OSX_amd64 17m => 13m
OSX_amd64_cpp 18m => 13m 
Windows_amd64 38m => 33m

## CI timings locally on OSX
via `XDG_CONFIG_HOME= nim c -r testament/testament all`
494s => 253s
(didn't try `./koch runCI` locally in this experiment)
