### PR TITLE
Documentation only, Change 'Future Directions' to link documentation

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7449,9 +7449,9 @@ be used:
       deepCopy(perThread, someGlobal)
 
 
-Future directions:
+See also:
 
-- A shared GC'ed heap might be provided.
+- `Shared heap memory management. <gc.html>`_.
 
 
 Threadvar pragma


### PR DESCRIPTION
- Documentation only.
- Change "Future Directions" to link documentation about memory management, because Shared Heap is possible nowadays on Nim.
