### PR TITLE
make `fromJson/toJson` work with `array[range, typ]`, + 1 bugfix

### DIFF
--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -20,10 +20,14 @@ xxx
 use toJsonHook,fromJsonHook for Table|OrderedTable
 add Options support also using toJsonHook,fromJsonHook and remove `json=>options` dependency
 
-future direction:
-add a way to customize serialization, for eg allowing missing
-or extra fields in JsonNode, field renaming, and a way to handle cyclic references
-using a cache of already visited addresses.
+Future directions:
+add a way to customize serialization, for eg:
+* allowing missing or extra fields in JsonNode
+* field renaming
+* allow serializing `enum` and `char` as `string` instead of `int`
+  (enum is more compact/efficient, and robust to enum renamings, but string
+  is more human readable)
+* handle cyclic references, using a cache of already visited addresses
 ]#
 
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
@@ -73,8 +77,10 @@ proc fromJson*[T](a: var T, b: JsonNode) =
       fromJson(a[], b)
   elif T is array:
     checkJson a.len == b.len, $(a.len, b.len, $T)
-    for i, val in b.getElems:
-      fromJson(a[i], val)
+    var i = 0
+    for ai in mitems(a):
+      fromJson(ai, b[i])
+      i.inc
   elif T is seq:
     a.setLen b.len
     for i, val in b.getElems:

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -13,12 +13,26 @@ proc testRoundtrip[T](t: T, expected: string) =
 import tables
 import strtabs
 
+type Foo = ref object
+  id: int
+
+proc `==`(a, b: Foo): bool =
+  a.id == b.id
+
 template fn() = 
   block: # toJson, jsonTo
     type Foo = distinct float
     testRoundtrip('x', """120""")
     when not defined(js):
       testRoundtrip(cast[pointer](12345)): """12345"""
+      when nimvm:
+        discard
+        # bugs:
+        # Error: unhandled exception: 'intVal' is not accessible using discriminant 'kind' of type 'TNode' [
+        # Error: VM does not support 'cast' from tyNil to tyPointer
+      else:
+        testRoundtrip(pointer(nil)): """0"""
+        testRoundtrip(cast[pointer](nil)): """0"""
 
     # causes workaround in `fromJson` potentially related to
     # https://github.com/nim-lang/Nim/issues/12282
@@ -39,6 +53,11 @@ template fn() =
     let a = (1.1, "fo", 'x', @[10,11], [true, false], [t,newStringTable()], [0'i8,3'i8], -4'i16, (foo: 0.5'f32, bar: A(a1: "abc"), bar2: A.default))
     testRoundtrip(a):
       """[1.1,"fo",120,[10,11],[true,false],[{"mode":"modeCaseSensitive","table":{"y":"Y","z":"Z"}},{"mode":"modeCaseSensitive","table":{}}],[0,3],-4,{"foo":0.5,"bar":{"a1":"abc"},"bar2":null}]"""
+
+  block:
+    # edge case when user defined `==` doesn't handle `nil` well, eg:
+    # https://github.com/nim-lang/nimble/blob/63695f490728e3935692c29f3d71944d83bb1e83/src/nimblepkg/version.nim#L105
+    testRoundtrip(@[Foo(id: 10), nil]): """[{"id":10},null]"""
 
 static: fn()
 fn()

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -59,5 +59,12 @@ template fn() =
     # https://github.com/nim-lang/nimble/blob/63695f490728e3935692c29f3d71944d83bb1e83/src/nimblepkg/version.nim#L105
     testRoundtrip(@[Foo(id: 10), nil]): """[{"id":10},null]"""
 
+  block:
+    type Foo = enum f1, f2, f3, f4, f5
+    type Bar = enum b1, b2, b3, b4
+    let a = [f2: b2, f3: b3, f4: b4]
+    doAssert b2.ord == 1 # explains the `1`
+    testRoundtrip(a): """[1,2,3]"""
+
 static: fn()
 fn()


### PR DESCRIPTION
* make toJson work with `array[range, typ]`
* 1 bugfix encountered with https://github.com/nim-lang/nimble/blob/63695f490728e3935692c29f3d71944d83bb1e83/src/nimblepkg/version.nim#L105
