### PR TITLE
fix #14475; unittest.require now works with `nim c`; require and check now works with -d:nodejs

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -94,6 +94,7 @@
 ##     echo "suite teardown: run once after the tests"
 
 import std/private/since
+import std/exitprocs
 
 import
   macros, strutils, streams, times, sets, sequtils
@@ -498,7 +499,7 @@ template test*(name, body) {.dirty.} =
   ## .. code-block::
   ##
   ##  [OK] roses are red
-  bind shouldRun, checkpoints, formatters, ensureInitialized, testEnded, exceptionTypeName
+  bind shouldRun, checkpoints, formatters, ensureInitialized, testEnded, exceptionTypeName, setProgramResult
 
   ensureInitialized()
 
@@ -524,7 +525,7 @@ template test*(name, body) {.dirty.} =
 
     finally:
       if testStatusIMPL == TestStatus.FAILED:
-        programResult = 1
+        setProgramResult 1
       let testResult = TestResult(
         suiteName: when declared(testSuiteName): testSuiteName else: "",
         testName: name,
@@ -560,12 +561,11 @@ template fail* =
   ##  fail()
   ##
   ## outputs "Checkpoint A" before quitting.
-  bind ensureInitialized
-
+  bind ensureInitialized, setProgramResult
   when declared(testStatusIMPL):
     testStatusIMPL = TestStatus.FAILED
   else:
-    programResult = 1
+    setProgramResult 1
 
   ensureInitialized()
 
@@ -576,8 +576,7 @@ template fail* =
     else:
       formatter.failureOccurred(checkpoints, "")
 
-  when declared(programResult):
-    if abortOnError: quit(programResult)
+  if abortOnError: quit(1)
 
   checkpoints = @[]
 

--- a/lib/std/exitprocs.nim
+++ b/lib/std/exitprocs.nim
@@ -63,3 +63,25 @@ proc addExitProc*(cl: proc() {.noconv.}) =
   withLock gFunsLock:
     fun()
     gFuns.add Fun(kind: kNoconv, fun2: cl)
+
+when not defined(nimscript):
+  proc getProgramResult*(): int =
+    when defined(js) and defined(nodejs):
+      asm """
+`result` = process.exitCode;
+"""
+    elif not defined(js):
+      result = programResult
+    else:
+      doAssert false
+
+  proc setProgramResult*(a: int) =
+    # pending https://github.com/nim-lang/Nim/issues/14674
+    when defined(js) and defined(nodejs):
+      asm """
+process.exitCode = `a`;
+"""
+    elif not defined(js):
+      programResult = a
+    else:
+      doAssert false

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1127,7 +1127,7 @@ const
     ## is the value that should be passed to `quit <#quit,int>`_ to indicate
     ## failure.
 
-when not defined(nimscript) and not defined(js) and hostOS != "standalone":
+when not defined(js) and hostOS != "standalone":
   var programResult* {.compilerproc, exportc: "nim_program_result".}: int
     ## deprecated, prefer `quit` or `exitprocs.getProgramResult`, `exitprocs.setProgramResult`.
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1127,12 +1127,9 @@ const
     ## is the value that should be passed to `quit <#quit,int>`_ to indicate
     ## failure.
 
-when defined(js) and defined(nodejs) and not defined(nimscript):
-  var programResult* {.importc: "process.exitCode".}: int
-  programResult = 0
-elif hostOS != "standalone":
+when not defined(nimscript) and not defined(js) and hostOS != "standalone":
   var programResult* {.compilerproc, exportc: "nim_program_result".}: int
-    ## deprecated, prefer ``quit``
+    ## deprecated, prefer `quit` or `exitprocs.getProgramResult`, `exitprocs.setProgramResult`.
 
 import std/private/since
 

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -35,7 +35,7 @@ pkg1 "combparser"
 pkg1 "compactdict"
 pkg1 "comprehension", false, "nimble test", "https://github.com/alehander42/comprehension"
 pkg1 "dashing", false, "nim c tests/functional.nim"
-pkg1 "delaunay"
+# pkg1 "delaunay" # pending https://github.com/Nycto/DelaunayNim/issues/3
 pkg1 "docopt"
 pkg1 "easygl", true, "nim c -o:egl -r src/easygl.nim", "https://github.com/jackmott/easygl"
 pkg1 "elvis"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -35,7 +35,7 @@ pkg1 "combparser"
 pkg1 "compactdict"
 pkg1 "comprehension", false, "nimble test", "https://github.com/alehander42/comprehension"
 pkg1 "dashing", false, "nim c tests/functional.nim"
-# pkg1 "delaunay" # pending https://github.com/Nycto/DelaunayNim/issues/3
+pkg1 "delaunay"
 pkg1 "docopt"
 pkg1 "easygl", true, "nim c -o:egl -r src/easygl.nim", "https://github.com/jackmott/easygl"
 pkg1 "elvis"

--- a/tests/js/tunittest_error.nim
+++ b/tests/js/tunittest_error.nim
@@ -3,6 +3,8 @@ discard """
   outputsub: "[FAILED] with exception"
 """
 
+# see also: `tests/stdlib/tunittest_error.nim`
+
 import unittest
 
 proc ddd() =

--- a/tests/stdlib/tquit.nim
+++ b/tests/stdlib/tquit.nim
@@ -5,7 +5,7 @@ just exiting...
 joinable: false
 """
 
-# Test the new beforeQuit variable:
+# Test `addQuitProc`
 
 proc myExit() {.noconv.} =
   write(stdout, "just exiting...\n")

--- a/tests/stdlib/tunittest_error.nim
+++ b/tests/stdlib/tunittest_error.nim
@@ -1,0 +1,22 @@
+discard """
+  exitcode: 1
+  outputsub: "failed: 1 == 3"
+  matrix: "-d:case1; -d:case2"
+  targets: "c js"
+  joinable: false
+"""
+
+when defined case1:
+  import unittest
+  suite "Test":
+    test "test require":
+      check 1==2
+      check 1==3
+
+when defined case2:
+  import unittest
+  suite "Test":
+    test "test require":
+      require 1 == 3
+      if true:
+        quit 0 # if goes here, the test will fail (as it should)

--- a/tests/stdlib/tunittest_error.nim
+++ b/tests/stdlib/tunittest_error.nim
@@ -19,4 +19,4 @@ when defined case2:
     test "test require":
       require 1 == 3
       if true:
-        quit 0 # if goes here, the test will fail (as it should)
+        quit 0 # intentional


### PR DESCRIPTION
* fix #14475: unittest.require now works
* make unittest work with -d:nodejs (which is a related but different issue)

that bug was pretty bad, and in fact fixing it reveals 2 test failures:
* https://github.com/inim-repl/INim/issues/89
* https://github.com/Nycto/DelaunayNim/issues/3

## CI failure unrelated
* https://github.com/nim-lang/Nim/issues/14685