### PR TITLE
Fix #14033 - OpenBSD SFML test

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -205,6 +205,9 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
   llvm_gcc.cpp.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
   clang.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
   clang.cpp.options.linker = "-Wl,-rpath=.:/usr/local/lib:/usr/pkg/lib:/usr/X11R6/lib"
+
+  cincludes: "/usr/local/include"
+  clibdir: "/usr/local/lib"
 @end
 
 # Configuration for the VxWorks

--- a/tests/niminaction/Chapter8/sfml/sfml_test.nim
+++ b/tests/niminaction/Chapter8/sfml/sfml_test.nim
@@ -1,9 +1,6 @@
 discard """
 action: compile
 disabled: "windows"
-disabled: "freebsd"
-disabled: "openbsd"
-disabled: "netbsd"
 """
 
 import sfml, os


### PR DESCRIPTION
Fixes #14033 
Fixes #14089

The SMFL headers are found in `/usr/local/include/SFML` on OpenBSD, FreeBSD and NetBSD. I've tested this locally and running `nim cpp tests/niminaction/Chapter8/sfml/sfml_test.nim` now succeeds on OpenBSD. Let's see what the CI thinks.

Replaces #14679.