### PR TITLE
Close#5586

### DIFF
--- a/tests/coroutines/tgc.nim
+++ b/tests/coroutines/tgc.nim
@@ -1,6 +1,5 @@
 discard """
   target: "c"
-  disabled: "openbsd"
 """
 
 import coro

--- a/tests/coroutines/twait.nim
+++ b/tests/coroutines/twait.nim
@@ -1,7 +1,5 @@
 discard """
   output: "Exit 1\nExit 2"
-  disabled: "macosx"
-  disabled: "openbsd"
   target: "c"
 """
 import coro


### PR DESCRIPTION
#5586 seems to no longer be relevant as recent versions of macos pass `twait`. I can not currently test on `openbsd` but I could get it running somewhere if the ci doesn't run it.