### PR TITLE
Documentation update nims.rst

### DIFF
--- a/doc/nims.rst
+++ b/doc/nims.rst
@@ -87,6 +87,16 @@ At least the following standard library modules are available:
 * `std/editdistance <editdistance.html>`_
 * `std/wordwrap <wordwrap.html>`_
 * `std/sums <sums.html>`_
+* `parsecsv <parsecsv.html>`_
+* `parsecfg <parsecfg.html>`_
+* `parsesql <parsesql.html>`_
+* `xmlparser <xmlparser.html>`_
+* `htmlparser <htmlparser.html>`_
+* `ropes <ropes.html>`_
+* `json <json.html>`_
+* `parsejson <parsejson.html>`_
+* `strtabs <strtabs.html>`_
+* `unidecode <unidecode.html>`_
 
 In addition to the standard Nim syntax (`system <system.html>`_ module),
 NimScripts support the procs and templates defined in the

--- a/doc/nims.rst
+++ b/doc/nims.rst
@@ -102,6 +102,9 @@ In addition to the standard Nim syntax (`system <system.html>`_ module),
 NimScripts support the procs and templates defined in the
 `nimscript <nimscript.html>`_ module too.
 
+See also:
+* `Check the tests for more information about modules compatible with NimScript. <https://github.com/nim-lang/Nim/blob/devel/tests/test_nimscript.nims>`_
+
 
 NimScript as a configuration file
 =================================


### PR DESCRIPTION
- Update `nims.rst` to add modules that work on NimScript as mentioned in the `changelog.md`.
- Documentation only.
