### PR TITLE
make nim-gdb compatible with BSD systems

### DIFF
--- a/bin/nim-gdb
+++ b/bin/nim-gdb
@@ -5,17 +5,15 @@ set -e
 
 which nim > /dev/null || (echo "nim not in PATH"; exit 1)
 which gdb > /dev/null || (echo "gdb not in PATH"; exit 1)
+which readlink > /dev/null || (echo "readlink not in PATH."; exit 1)
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  which greadlink > /dev/null || (echo "readlink not in PATH. Please install coreutils from homebrew."; exit 1)
-  READLINK=greadlink
+if [[ "$(uname -s)" == "Darwin" || "(uname -s)" == *"BSD" ]]; then
+  NIM_SYSROOT=$(dirname $(dirname $($READLINK -f $(which nim))))
 else
-  which readlink > /dev/null || (echo "readlink not in PATH."; exit 1)
-  READLINK=readlink
+  NIM_SYSROOT=$(dirname $(dirname $($READLINK -e $(which nim))))
 fi
 
 # Find out where the pretty printer Python module is
-NIM_SYSROOT=$(dirname $(dirname $($READLINK -e $(which nim))))
 GDB_PYTHON_MODULE_PATH="$NIM_SYSROOT/tools/nim-gdb.py"
 
 # Run GDB with the additional arguments that load the pretty printers


### PR DESCRIPTION
Hello,

I made some small changes to the nim-gdb bash script:

- unified test if readlink executable is available
- also check if os is some *BSD
- MacOS uses the bsd readlink version, where the `-f` flag is equal to the coreutils readlink `-e` flag

I have only been able to test this on FreeBSD, but it should work the same on all the other *BSDs.