### PR TITLE
Hashing with identifiers version of style insensitivity.

### DIFF
--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -340,7 +340,7 @@ proc hash*(sBuf: string, sPos, ePos: int): Hash =
   else:
     murmurHash(toOpenArrayByte(sBuf, sPos, ePos))
 
-proc hashIgnoreStyle*(x: string): Hash =
+proc hashIgnoreStyle*(x: string, idEquality = false): Hash =
   ## Efficient hashing of strings; style is ignored.
   ##
   ## **Note:** This uses different hashing algorithm than `hash(string)`.
@@ -352,7 +352,15 @@ proc hashIgnoreStyle*(x: string): Hash =
     doAssert hashIgnoreStyle("abcdefghi") != hash("abcdefghi")
 
   var h: Hash = 0
-  var i = 0
+
+  var i =
+    if idEquality:
+      if len(x) == 0:
+        return !$h
+      h = h !& ord(x[0])
+      1
+    else: 
+      0
   let xLen = x.len
   while i < xLen:
     var c = x[i]


### PR DESCRIPTION
Work in progress.
I'm open to suggestions as to whether this should be an optional argument on hashIgnoreStyle or an entirely new function.
Also the optional argument name is open to debate and any suggestions to my style are welcome.

The motivation for this is store identifier name strings as table keys because hashing NimNodes directly is problematic.
Also you could use it at runtime where NimNodes can't be used.