### PR TITLE
Documentation Deprecate unroll pragma

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -175,6 +175,8 @@ proc mydiv(a, b): int {.raises: [].} =
   with `--panics:on` `Defects` become unrecoverable errors.
 
 - Added `thiscall` calling convention as specified by Microsoft, mostly for hooking purpose
+- Deprecated `{.unroll.}` pragma, was ignored by the compiler anyways, was a nop.
+
 
 ## Compiler changes
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6210,25 +6210,6 @@ the underlying backend (C compiler) does not support the computed goto
 extension the pragma is simply ignored.
 
 
-unroll pragma
--------------
-The ``unroll`` pragma can be used to tell the compiler that it should unroll
-a `for`:idx: or `while`:idx: loop for execution efficiency:
-
-.. code-block:: nim
-  proc searchChar(s: string, c: char): int =
-    for i in 0 .. s.high:
-      {.unroll: 4.}
-      if s[i] == c: return i
-    result = -1
-
-In the above example, the search loop is unrolled by a factor 4. The unroll
-factor can be left out too; the compiler then chooses an appropriate unroll
-factor.
-
-**Note**: Currently the compiler recognizes but ignores this pragma.
-
-
 immediate pragma
 ----------------
 


### PR DESCRIPTION
- Documentation only.
- Remove `{.unroll.}` pragma from documentation, was always ignored by compiler because never really been implemented, so I remove it from documentation.
- Update changelog.
- https://github.com/nim-lang/Nim/issues/14695#issuecomment-645173728
- https://github.com/nim-lang/Nim/pull/14706#issue-436088492

Other PR for code may follow.

