### PR TITLE
Fix #14715 - detect tool fails on FreeBSD

### DIFF
--- a/tools/detect/detect.nim
+++ b/tools/detect/detect.nim
@@ -14,7 +14,7 @@
 # compilation.
 import os, strutils
 
-when defined(openbsd):
+when defined(openbsd) or defined(freebsd) or defined(netbsd):
   const
     cc = "cc -o $# $#.c"
     cpp = "cc -E -o $#.i $#.c"
@@ -98,8 +98,8 @@ proc main =
     f.write(nimfile % [other])
     close(f)
 
-  let cCompile = when defined(openbsd): ccLinkMath else: cc
-  let cppCompile = when defined(openbsd): cppLinkMath else: cpp
+  let cCompile = defined(openbsd) or defined(freebsd) or defined(netbsd): ccLinkMath else: cc
+  let cppCompile = defined(openbsd) or defined(freebsd) or defined(netbsd): cppLinkMath else: cpp
   if not myExec(cCompile % [gen.addFileExt(ExeExt), gen]): quit(1)
   if not myExec(cppCompile % [pre.addFileExt(ExeExt), pre]): quit(1)
   when defined(windows):


### PR DESCRIPTION
Fixes #14715

FreeBSD also requires linking the math library (see [`fenv`](https://www.freebsd.org/cgi/man.cgi?query=fenv)). It [seems NetBSD does too](https://netbsd.gw.com/cgi-bin/man-cgi?fenv+3+NetBSD-current), though I haven't tested there.

Tested locally on FreeBSD and it appears to work - I now get a `freebsd_amd64_consts.nim` being generated at least.