### PR TITLE
macros.newLit now preserves named vs unnamed tuples

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -112,6 +112,7 @@
 - new proc `heapqueue.find[T](heap: HeapQueue[T], x: T): int` to get index of element ``x``.
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
 - Add `os.normalizeExe`, eg: `koch` => `./koch`.
+- `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
 
 
 ## Language changes

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -801,12 +801,14 @@ proc newLit*[T](s: set[T]): NimNode {.compileTime.} =
     result = newCall(typ,result)
 
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
-  ## See typetraits.isNamedTuple
+  ## See `typetraits.isNamedTuple`
 
 proc newLit*[T: tuple](arg: T): NimNode {.compileTime.} =
+  ## use -d:nimHasWorkaround14720 to restore behavior prior to PR, forcing
+  ## a named tuple even when `arg` is unnamed.
   result = nnkTupleConstr.newTree
-  when isNamedTuple(T):
-    for a,b in arg.fieldPairs:
+  when defined(nimHasWorkaround14720) or isNamedTuple(T):
+    for a, b in arg.fieldPairs:
       result.add nnkExprColonExpr.newTree(newIdentNode(a), newLit(b))
   else:
     for b in arg.fields:

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -43,7 +43,7 @@ pkg1 "elvis"
   # Error: cannot open 'tests/runNative.nim'
 pkg1 "fragments", false, "nim c -r fragments/dsl.nim"
 pkg1 "gara"
-pkg1 "ggplotnim", true, "nim c -d:noCairo -r -d:nimWorkaround14447 tests/tests.nim"
+pkg1 "ggplotnim", true, "nim c -d:noCairo -r -d:nimWorkaround14447 -d:nimHasWorkaround14720 tests/tests.nim"
 # pkg1 "gittyup", true, "nimble test", "https://github.com/disruptek/gittyup"
 pkg1 "glob"
 pkg1 "gnuplot"

--- a/tests/macros/tmacros_various.nim
+++ b/tests/macros/tmacros_various.nim
@@ -194,35 +194,11 @@ static:
     doAssert(v == a)
 
   echo "macrocache ok"
-  
+
 block tupleNewLitTests:
-  macro t0(): untyped =
-    result = newLit(())
-  doAssert t0 == ()
-  macro t1(): untyped =
-    result = newLit((5,))
-  doAssert t1 == (5,)
-  macro t2(): untyped =
-    result = newLit((a: 5))
-  doAssert t2 == (a: 5)
-  macro t3(): untyped =
-    result = newLit((5, "5"))
-  doAssert t3 == (5, "5")
-  macro t4(): untyped =
-    result = newLit((a: 5, b: "5"))
-  doAssert t4 == (a: 5, b: "5")
-  macro t5(): untyped =
-    result = newLit(@[(5,)])
-  doAssert t5 == @[(5,)]
-  macro t6(): untyped =
-    result = newLit(@[(a: 5)])
-  doAssert t6 == @[(a: 5)]
-  macro t7(): untyped =
-    result = newLit(@[(5, "5")])
-  doAssert t7 == @[(5, "5")]
-  macro t8(): untyped =
-    result = newLit(@[(a: 5, b: "5")])
-  doAssert t8 == @[(a: 5, b: "5")]
-  macro t9(): untyped =
-    result = newLit(@[(a: (5, 6), b: ())])
-  doAssert t9 == @[(a: (5, 6), b: ())]
+  macro t(): untyped =
+    result = newLit (1, "foo", (), (1,), (a1: 'x', a2: @["ba"]))
+  doAssert $t() == """(1, "foo", (), (1,), (a1: 'x', a2: @["ba"]))"""
+    # this `$` test is needed because tuple equality doesn't distinguish
+    # between named vs unnamed tuples
+  doAssert t() == (1, "foo", (), (1, ), (a1: 'x', a2: @["ba"]))

--- a/tests/macros/tmacros_various.nim
+++ b/tests/macros/tmacros_various.nim
@@ -194,3 +194,35 @@ static:
     doAssert(v == a)
 
   echo "macrocache ok"
+  
+block tupleNewLitTests:
+  macro t0(): untyped =
+    result = newLit(())
+  doAssert t0 == ()
+  macro t1(): untyped =
+    result = newLit((5,))
+  doAssert t1 == (5,)
+  macro t2(): untyped =
+    result = newLit((a: 5))
+  doAssert t2 == (a: 5)
+  macro t3(): untyped =
+    result = newLit((5, "5"))
+  doAssert t3 == (5, "5")
+  macro t4(): untyped =
+    result = newLit((a: 5, b: "5"))
+  doAssert t4 == (a: 5, b: "5")
+  macro t5(): untyped =
+    result = newLit(@[(5,)])
+  doAssert t5 == @[(5,)]
+  macro t6(): untyped =
+    result = newLit(@[(a: 5)])
+  doAssert t6 == @[(a: 5)]
+  macro t7(): untyped =
+    result = newLit(@[(5, "5")])
+  doAssert t7 == @[(5, "5")]
+  macro t8(): untyped =
+    result = newLit(@[(a: 5, b: "5")])
+  doAssert t8 == @[(a: 5, b: "5")]
+  macro t9(): untyped =
+    result = newLit(@[(a: (5, 6), b: ())])
+  doAssert t9 == @[(a: (5, 6), b: ())]


### PR DESCRIPTION
* supersedes https://github.com/nim-lang/Nim/pull/14688 and closes https://github.com/nim-lang/Nim/pull/14688
* either don't squash (keeping the 2 commits) or ensure @solo989 gets credited as co-author
* the tests in https://github.com/nim-lang/Nim/pull/14688 were not good enough:
  - redundant tests cases
  - didn't actually test the bug fix since those tests would pass even before the PR
* implements the suggested I gave here https://github.com/nim-lang/Nim/pull/14688#issuecomment-645102392

CI failure unrelated: https://github.com/nim-lang/Nim/issues/14685