### PR TITLE
fix #14685 tests/async/t7758.nim flaky

### DIFF
--- a/tests/async/t7758.nim
+++ b/tests/async/t7758.nim
@@ -2,8 +2,8 @@ import asyncdispatch
 import std/unittest
 
 proc task() {.async.} =
-  let t = 40
-  await sleepAsync(t)
+  const tSleep = 40
+  await sleepAsync(tSleep)
 
 proc main() =
   var counter = 0
@@ -14,7 +14,7 @@ proc main() =
 
   let slack = 1
     # because there is overhead in `async` + `sleepAsync`
-    # as can be seen by increasing `t` from 40 to 49, which increases the number
+    # as can be seen by increasing `tSleep` from 40 to 49, which increases the number
     # of failures.
   check counter <= 4 + slack
 

--- a/tests/async/t7758.nim
+++ b/tests/async/t7758.nim
@@ -12,7 +12,7 @@ proc main() =
     inc(counter)
     poll(10)
 
-  let slack = 1
+  const slack = 1
     # because there is overhead in `async` + `sleepAsync`
     # as can be seen by increasing `tSleep` from 40 to 49, which increases the number
     # of failures.

--- a/tests/async/t7758.nim
+++ b/tests/async/t7758.nim
@@ -2,7 +2,8 @@ import asyncdispatch
 import std/unittest
 
 proc task() {.async.} =
-  await sleepAsync(40)
+  let t = 40
+  await sleepAsync(t)
 
 proc main() =
   var counter = 0
@@ -11,6 +12,10 @@ proc main() =
     inc(counter)
     poll(10)
 
-  check counter <= 4
+  let slack = 1
+    # because there is overhead in `async` + `sleepAsync`
+    # as can be seen by increasing `t` from 40 to 49, which increases the number
+    # of failures.
+  check counter <= 4 + slack
 
 for i in 0 .. 10: main()


### PR DESCRIPTION
fix #14685

https://github.com/nim-lang/Nim/pull/14689 helped diagnose the problem that was occuring only on windows; it simply indicates there is overhead; and in fact this can be reproduced locally on OSX as indicated in this PR by gradually increasing `t` and observing a higher probability of errors.

so simply adding a slack fixes this.
