### PR TITLE
Fix allocating 0-sized blocks

### DIFF
--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -749,7 +749,7 @@ proc rawAlloc(a: var MemRegion, requestedSize: int): pointer =
   sysAssert(allocInv(a), "rawAlloc: begin")
   sysAssert(roundup(65, 8) == 72, "rawAlloc: roundup broken")
   sysAssert(requestedSize >= sizeof(FreeCell), "rawAlloc: requested size too small")
-  var size = roundup(requestedSize, MemAlign)
+  var size = roundup(max(1, requestedSize), MemAlign)
   sysAssert(size >= requestedSize, "insufficient allocated size!")
   #c_fprintf(stdout, "alloc; size: %ld; %ld\n", requestedSize, size)
   if size <= SmallChunkSize-smallChunkOverhead():

--- a/tests/system/talloc3.nim
+++ b/tests/system/talloc3.nim
@@ -1,0 +1,10 @@
+discard """
+   cmd: "nim c --gc:arc --stacktrace:off $file"
+"""
+
+var x = allocShared0(0)
+var y = allocShared0(0)
+doAssert x != y
+
+x.deallocShared()
+y.deallocShared()


### PR DESCRIPTION
This fixes a nasty bug with `--gc:arc`. With other `--gc`'s when you request 0-sized block using `allocShared` an allocator adds also a `FreeCell` object for bookkeeping which makes `rawAlloc` function to never receive a `requestedSize == 0`. 

ARC does not add such overhead and calls `rawAlloc` with whatever it gets from `allocShared`. This makes it possible for `requestedSize` to be 0. If so, it allocates a block from OS and adds it to the free list. However. because the `requestedSize` is 0, the next allocation request will return the same address as before using the chunk of size=0 from the free list. In the end when we need to deallocate we end up with what is basically an double free operation.

Also, fixes crash in #14690 when on thread creation we allocate a `sizeof(GcThread)`-sized block which is 0.