### PR TITLE
added normal variate function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -113,7 +113,7 @@
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
 - Add `os.normalizeExe`, eg: `koch` => `./koch`.
 - `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
-
+- Add `random.gauss`, that uses the ratio of uniforms method of sampling from a Gaussian distribution.
 
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -527,8 +527,8 @@ proc gauss*(r: var Rand; mu = 0.0; sigma = 1.0): float =
     a = 0.0
     b = 0.0
   while true:
-    a = rand(1.0)
-    b = (2.0 * rand(1.0) - 1.0) * K
+    a = rand(r, 1.0)
+    b = (2.0 * rand(r, 1.0) - 1.0) * K
     if  b * b <= -4.0 * a * a * ln(a): break
   result = mu + sigma * (b / a)
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -78,7 +78,7 @@
 ##   <lib.html#pure-libraries-hashing>`_
 ##   in the standard library
 
-import algorithm #For upperBound
+import algorithm, math
 
 include "system/inclrtl"
 {.push debugger: off.}
@@ -520,16 +520,17 @@ proc gauss*(r: var Rand; mu = 0.0; sigma = 1.0): float =
   ## Returns a Gaussian random variate,
   ## with mean ``mu`` and standard deviation ``sigma``
   ## using the given state.
-  # Ratio of uniforms method for normal, original version
-  const nvMagic = 4.0 * exp(-0.5) / sqrt(2.0)
+  # Ratio of uniforms method for normal
+  # http://www2.econ.osaka-u.ac.jp/~tanizaki/class/2013/econome3/13.pdf
+  const K = sqrt(2 / E)
   var
-    x = 0.0
+    a = 0.0
+    b = 0.0
   while true:
-    let u = 1.0 - rand(r, 1.0)
-    let v = rand(r, 1.0)
-    x = nvMagic * (v - 0.5) / u
-    if x * x <= -4.0 * ln(u): break
-  result = mu + x * sigma
+    a = rand(1.0)
+    b = (2.0 * rand(1.0) - 1.0) * K
+    if  b * b <= -4.0 * a * a * ln(a): break
+  result = mu + sigma * (b / a)
 
 proc gauss*(mu = 0.0, sigma = 1.0): float =
   ## Returns a Gaussian random variate,

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -79,6 +79,7 @@
 ##   in the standard library
 
 import algorithm, math
+import std/private/since
 
 include "system/inclrtl"
 {.push debugger: off.}
@@ -516,7 +517,7 @@ proc sample*[T, U](a: openArray[T]; cdf: openArray[U]): T =
     doAssert sample(marbles, cdf) == "blue"
   state.sample(a, cdf)
 
-proc gauss*(r: var Rand; mu = 0.0; sigma = 1.0): float =
+proc gauss*(r: var Rand; mu = 0.0; sigma = 1.0): float {.since: (1, 3).} =
   ## Returns a Gaussian random variate,
   ## with mean ``mu`` and standard deviation ``sigma``
   ## using the given state.
@@ -532,7 +533,7 @@ proc gauss*(r: var Rand; mu = 0.0; sigma = 1.0): float =
     if  b * b <= -4.0 * a * a * ln(a): break
   result = mu + sigma * (b / a)
 
-proc gauss*(mu = 0.0, sigma = 1.0): float =
+proc gauss*(mu = 0.0, sigma = 1.0): float {.since: (1, 3).} =
   ## Returns a Gaussian random variate,
   ## with mean ``mu`` and standard deviation ``sigma``.
   ##


### PR DESCRIPTION
Add ``gauss`` proc for sampling random values from a Gaussian distribution.

This uses the [ratio of uniform derivatives method](http://www2.econ.osaka-u.ac.jp/~tanizaki/class/2013/econome3/13.pdf)
also described in Knuth v2 2nd edition p125

Code based on [normalvariate](https://github.com/python/cpython/blob/master/Lib/random.py) python function.

Performance note:
The Gnu gsl lib [claims](https://git.savannah.gnu.org/cgit/gsl.git/tree/randist/gauss.c#n40) this method is faster than [Box–Muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform) but after benchmarks we were [unable](https://gist.github.com/b3liever/23505f9b47124bc9cc40e60d7279b067) to reproduce these numbers.
