### PR TITLE
nep1: use `subjectVerb`, not `verbSubject`

### DIFF
--- a/doc/nep1.rst
+++ b/doc/nep1.rst
@@ -101,11 +101,13 @@ changed in the future.
         fd: int64
       HandleRef = ref Handle # Will be used less often
 
-- Exception and Error types should have the "Error" suffix.
+- Exception and Error types should have the "Error" or "Defect" suffix.
 
   .. code-block:: nim
     type
-      UnluckyError = object of Exception
+      ValueError = object of CatchableError
+      AssertionDefect = object of Defect
+      Foo = object of Exception # bad style, try to inherit CatchableError or Defect
 
 - Unless marked with the `{.pure.}` pragma, members of enums should have an
   identifying prefix, such as an abbreviation of the enum's name.
@@ -146,6 +148,8 @@ changed in the future.
 - When the 'returns transformed copy' version already exists like ``strutils.replace``
   an in-place version should get an ``-In`` suffix (``replaceIn`` for this example).
 
+
+- Use `subjectVerb`, not `verbSubject`, eg: `fileExists`, not `existsFile`.
 
 The stdlib API is designed to be **easy to use** and consistent. Ease of use is
 measured by the number of calls to achieve a concrete high level action. The


### PR DESCRIPTION
* centralized conventions like `Nep1` are great, it avoids guess-work
* the opposite of centralized conventions is: "do as surrounding code does", which is a false good idea often found in some style guides, as it causes underlying problem to get worse (different competing styles survive as different dialects)

@araq after this PR I'd like to deprecate `existsFile` since we have `fileExists` (even if that deprecation shall have long shelf life, there should be "one preferred way"), likewise for similar cases where we have both `subjectVerb` and `verbSubject`.
Deprecations are easy to ignore or enforce on a global basis, so there is no harm there.

