### PR TITLE
Lower the not operators precedence

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -946,11 +946,11 @@ proc isUnary*(tok: TToken): bool =
   tok.strongSpaceB == 0 and
   tok.strongSpaceA > 0
 
-proc getPrecedence*(tok: TToken): int =
+proc getPrecedence*(tok: TToken, isUnary = false): int =
   ## Calculates the precedence of the given token.
   case tok.tokType
   of tkOpr:
-    if isUnary(tok): return 12
+    if isUnary(tok) or isUnary: return 12
     let relevantChar = tok.ident.s[0]
 
     # arrow like?

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1247,7 +1247,7 @@ proc primary(p: var TParser, mode: TPrimaryMode): PNode =
   #|         / 'bind' primary
   if isOperator(p.tok):
     let isSigil = isSigilLike(p.tok)
-    let opPrec = getPrecedence(p.tok)
+    let opPrec = getPrecedence(p.tok, true)
     result = newNodeP(nkPrefix, p)
     var a = newIdentNodeP(p.tok.ident, p)
     result.add(a)
@@ -1259,9 +1259,7 @@ proc primary(p: var TParser, mode: TPrimaryMode): PNode =
       result.add(primary(p, pmSkipSuffix))
       result = primarySuffix(p, result, baseInd, mode)
     else:
-      result.add(primary(p, pmNormal))
-      if getPrecedence(p.tok) >= opPrec:
-        result[^1] = parseOperators(p, result[^1], getPrecedence(p.tok), mode)
+      result.add simpleExprAux(p, opPrec, pmNormal)
     return
 
   case p.tok.tokType

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -286,7 +286,7 @@ proc checkBinary(p: TParser) {.inline.} =
 #| colon = ':' COMMENT?
 #| colcom = ':' COMMENT?
 #|
-#| operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9
+#| operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9 | OP10 | OP11
 #|          | 'or' | 'xor' | 'and'
 #|          | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as' | 'from'
 #|          | 'div' | 'mod' | 'shl' | 'shr' | 'not' | 'static' | '..'
@@ -300,13 +300,14 @@ proc checkBinary(p: TParser) {.inline.} =
 #| arrowExpr = assignExpr (OP1 optInd assignExpr)*
 #| assignExpr = orExpr (OP2 optInd orExpr)*
 #| orExpr = andExpr (OP3 optInd andExpr)*
-#| andExpr = cmpExpr (OP4 optInd cmpExpr)*
-#| cmpExpr = sliceExpr (OP5 optInd sliceExpr)*
-#| sliceExpr = ampExpr (OP6 optInd ampExpr)*
-#| ampExpr = plusExpr (OP7 optInd plusExpr)*
-#| plusExpr = mulExpr (OP8 optInd mulExpr)*
-#| mulExpr = dollarExpr (OP9 optInd dollarExpr)*
-#| dollarExpr = primary (OP10 optInd primary)*
+#| andExpr = notExpr (OP4 optInd notExpr)*
+#| notExpr = (OP5 optInd)* cmpExpr
+#| cmpExpr = sliceExpr (OP6 optInd sliceExpr)*
+#| sliceExpr = ampExpr (OP7 optInd ampExpr)*
+#| ampExpr = plusExpr (OP8 optInd plusExpr)*
+#| plusExpr = mulExpr (OP9 optInd mulExpr)*
+#| mulExpr = dollarExpr (OP10 optInd dollarExpr)*
+#| dollarExpr = primary (OP11 optInd primary)*
 
 proc colcom(p: var TParser, n: PNode) =
   eat(p, tkColon)

--- a/doc/grammar.txt
+++ b/doc/grammar.txt
@@ -4,7 +4,7 @@ comma = ',' COMMENT?
 semicolon = ';' COMMENT?
 colon = ':' COMMENT?
 colcom = ':' COMMENT?
-operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9
+operator =  OP0 | OP1 | OP2 | OP3 | OP4 | OP5 | OP6 | OP7 | OP8 | OP9 | OP10 | OP11
          | 'or' | 'xor' | 'and'
          | 'is' | 'isnot' | 'in' | 'notin' | 'of' | 'as' | 'from' |
          | 'div' | 'mod' | 'shl' | 'shr' | 'not' | 'static' | '..'
@@ -15,13 +15,14 @@ simpleExpr = arrowExpr (OP0 optInd arrowExpr)* pragma?
 arrowExpr = assignExpr (OP1 optInd assignExpr)*
 assignExpr = orExpr (OP2 optInd orExpr)*
 orExpr = andExpr (OP3 optInd andExpr)*
-andExpr = cmpExpr (OP4 optInd cmpExpr)*
-cmpExpr = sliceExpr (OP5 optInd sliceExpr)*
-sliceExpr = ampExpr (OP6 optInd ampExpr)*
-ampExpr = plusExpr (OP7 optInd plusExpr)*
-plusExpr = mulExpr (OP8 optInd mulExpr)*
-mulExpr = dollarExpr (OP9 optInd dollarExpr)*
-dollarExpr = primary (OP10 optInd primary)*
+andExpr = notExpr (OP4 optInd notExpr)*
+notExpr = (OP5 optInd)* cmpExpr
+cmpExpr = sliceExpr (OP6 optInd sliceExpr)*
+sliceExpr = ampExpr (OP7 optInd ampExpr)*
+ampExpr = plusExpr (OP8 optInd plusExpr)*
+plusExpr = mulExpr (OP9 optInd mulExpr)*
+mulExpr = dollarExpr (OP10 optInd dollarExpr)*
+dollarExpr = primary (OP11 optInd primary)*
 symbol = '`' (KEYW|IDENT|literal|(operator|'('|')'|'['|']'|'{'|'}'|'=')+)+ '`'
        | IDENT | KEYW
 exprColonEqExpr = expr (':'|'=' expr)?

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -618,7 +618,7 @@ other binary operators are left-associative.
 Precedence
 ----------
 
-Unary operators always bind stronger than any binary
+Unary operators except for ``not`` always bind stronger than any binary
 operator: ``$a + b`` is ``($a) + b`` and not ``$(a + b)``.
 
 If an unary operator's first character is ``@`` it is a `sigil-like`:idx:
@@ -641,12 +641,13 @@ Otherwise precedence is determined by the first character.
 ================  =======================================================  ==================  ===============
 Precedence level    Operators                                              First character     Terminal symbol
 ================  =======================================================  ==================  ===============
- 10 (highest)                                                              ``$  ^``            OP10
-  9               ``*    /    div   mod   shl  shr  %``                    ``*  %  \  /``      OP9
-  8               ``+    -``                                               ``+  -  ~  |``      OP8
-  7               ``&``                                                    ``&``               OP7
-  6               ``..``                                                   ``.``               OP6
-  5               ``==  <= < >= > !=  in notin is isnot not of as from``   ``=  <  >  !``      OP5
+ 11 (highest)                                                              ``$  ^``            OP11
+ 10               ``*    /    div   mod   shl  shr  %``                    ``*  %  \  /``      OP10
+  9               ``+    -``                                               ``+  -  ~  |``      OP9
+  8               ``&``                                                    ``&``               OP8
+  7               ``..``                                                   ``.``               OP7
+  6               ``==  <= < >= > !=  in notin is isnot not of as from``   ``=  <  >  !``      OP6
+  5               ``not``                                                                      OP5
   4               ``and``                                                                      OP4
   3               ``or xor``                                                                   OP3
   2                                                                        ``@  :  ?``         OP2

--- a/lib/system/alloc.nim
+++ b/lib/system/alloc.nim
@@ -183,13 +183,13 @@ proc mappingInsert(r: int): tuple[fl, sl: int] {.inline.} =
 template mat(): untyped = a.matrix[fl][sl]
 
 proc findSuitableBlock(a: MemRegion; fl, sl: var int): PBigChunk {.inline.} =
-  let tmp = a.slBitmap[fl] and (not 0u32 shl sl)
+  let tmp = a.slBitmap[fl] and ((not 0u32) shl sl)
   result = nil
   if tmp != 0:
     sl = lsbit(tmp)
     result = mat()
   else:
-    fl = lsbit(a.flBitmap and (not 0u32 shl (fl + 1)))
+    fl = lsbit(a.flBitmap and ((not 0u32) shl (fl + 1)))
     if fl > 0:
       sl = lsbit(a.slBitmap[fl])
       result = mat()

--- a/tests/parser/toprprec.nim
+++ b/tests/parser/toprprec.nim
@@ -1,5 +1,11 @@
 discard """
-  output: "done"
+  output: '''
+done
+not -1.0
+not 1.0 and not 1.0
+Q: did we have success? A: yes we did!!
+not -1.0 == not -1.0
+'''
 """
 # Test operator precedence:
 
@@ -35,3 +41,25 @@ var s: TA
 assert init(s) == "4"
 
 echo "done"
+
+
+proc `not`(f: float): string =
+  "not " & $f
+
+echo not -1 / 1
+
+proc `and`(s1, s2: string): string =
+  $s1 & " and " & s2
+
+echo not 1f and not 1f
+
+proc contains(f1, f2: float): string =
+  "Q: did we have success?"
+
+proc `not`(s: string): string =
+  s & " A: yes we did!!"
+
+echo not 1f in 1f
+
+echo not -1 / 1, " == not -1.0"
+


### PR DESCRIPTION
This makes the `not` operator not bind more tightly than binary operators with a higher precedence.