### PR TITLE
{.deprecated: [existsFile: fileExists].}

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -140,7 +140,7 @@ template declareClosures =
     result = options.findFile(conf, s).string
     if result.len == 0:
       result = getCurrentDir() / s
-      if not existsFile(result): result = ""
+      if not fileExists(result): result = ""
 
 proc parseRst(text, filename: string,
               line, column: int, hasToc: var bool,

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -740,7 +740,7 @@ proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile): RelativeF
 
 proc findFile*(conf: ConfigRef; f: string; suppressStdlib = false): AbsoluteFile =
   if f.isAbsolute:
-    result = if f.existsFile: AbsoluteFile(f) else: AbsoluteFile""
+    result = if f.fileExists: AbsoluteFile(f) else: AbsoluteFile""
   else:
     result = rawFindFile(conf, RelativeFile f, suppressStdlib)
     if result.isEmpty:

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7344,9 +7344,9 @@ string expressions in general:
 
   proc getDllName: string =
     result = "mylib.dll"
-    if existsFile(result): return
+    if fileExists(result): return
     result = "mylib2.dll"
-    if existsFile(result): return
+    if fileExists(result): return
     quit("could not load dynamic library")
 
   proc myImport(s: cstring) {.cdecl, importc, dynlib: getDllName().}

--- a/koch.nim
+++ b/koch.nim
@@ -113,7 +113,7 @@ proc tryExec(cmd: string): bool =
   result = execShellCmd(cmd) == 0
 
 proc safeRemove(filename: string) =
-  if existsFile(filename): removeFile(filename)
+  if fileExists(filename): removeFile(filename)
 
 proc overwriteFile(source, dest: string) =
   safeRemove(dest)
@@ -280,11 +280,11 @@ proc findStartNim: string =
   if ok: return nim
   when defined(Posix):
     const buildScript = "build.sh"
-    if existsFile(buildScript):
+    if fileExists(buildScript):
       if tryExec("./" & buildScript): return "bin" / nim
   else:
     const buildScript = "build.bat"
-    if existsFile(buildScript):
+    if fileExists(buildScript):
       if tryExec(buildScript): return "bin" / nim
 
   echo("Found no nim compiler and every attempt to build one failed!")

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -313,7 +313,7 @@ proc defaultMsgHandler*(filename: string, line, col: int, msgkind: MsgKind,
   else: writeLine(stdout, message)
 
 proc defaultFindFile*(filename: string): string =
-  if existsFile(filename): result = filename
+  if fileExists(filename): result = filename
   else: result = ""
 
 proc newSharedState(options: RstParseOptions,
@@ -328,7 +328,7 @@ proc newSharedState(options: RstParseOptions,
 
 proc findRelativeFile(p: RstParser; filename: string): string =
   result = p.filename.splitFile.dir / filename
-  if not existsFile(result):
+  if not fileExists(result):
     result = p.s.findFile(filename)
 
 proc rstMessage(p: RstParser, msgKind: MsgKind, arg: string) =

--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -231,7 +231,7 @@ proc listDirs*(ftp: AsyncFtpClient, dir = ""): Future[seq[string]] {.async.} =
 
   result = splitLines(await ftp.getLines())
 
-proc existsFile*(ftp: AsyncFtpClient, file: string): Future[bool] {.async.} =
+proc fileExists*(ftp: AsyncFtpClient, file: string): Future[bool] {.async.} =
   ## Determines whether ``file`` exists.
   var files = await ftp.listDirs()
   for f in items(files):

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -513,10 +513,10 @@ when defineSsl:
 
   # http://simplestcodings.blogspot.co.uk/2010/08/secure-server-client-using-openssl-in-c.html
   proc loadCertificates(ctx: SslCtx, certFile, keyFile: string) =
-    if certFile != "" and not existsFile(certFile):
+    if certFile != "" and not fileExists(certFile):
       raise newException(system.IOError,
           "Certificate file could not be found: " & certFile)
-    if keyFile != "" and not existsFile(keyFile):
+    if keyFile != "" and not fileExists(keyFile):
       raise newException(system.IOError, "Key file could not be found: " & keyFile)
 
     if certFile != "":

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1118,9 +1118,10 @@ proc fileExists*(filename: string): bool {.rtl, extern: "nos$1",
     return stat(filename, res) >= 0'i32 and S_ISREG(res.st_mode)
 
 when not defined(nimscript):
-  template existsFile*(args: varargs[untyped]): untyped {.deprecated: "use fileExists".} =
-    fileExists(args)
-  # {.deprecated: [existsFile: fileExists].} # pending bug #14819
+  when not defined(js): # `noNimJs` doesn't work with templates, this should improve.
+    template existsFile*(args: varargs[untyped]): untyped {.deprecated: "use fileExists".} =
+      fileExists(args)
+  # {.deprecated: [existsFile: fileExists].} # pending bug #14819; this would avoid above mentioned issue
 
 proc existsDir*(dir: string): bool {.rtl, extern: "nos$1", tags: [ReadDirEffect],
                                      noNimJs.} =

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1118,8 +1118,9 @@ proc fileExists*(filename: string): bool {.rtl, extern: "nos$1",
     return stat(filename, res) >= 0'i32 and S_ISREG(res.st_mode)
 
 when not defined(nimscript):
-  {.deprecated: [existsFile: fileExists].}
-  # refs: https://github.com/nim-lang/Nim/pull/14732
+  template existsFile*(args: varargs[untyped]): untyped {.deprecated: "use fileExists".} =
+    fileExists(args)
+  # {.deprecated: [existsFile: fileExists].} # pending bug #14819
 
 proc existsDir*(dir: string): bool {.rtl, extern: "nos$1", tags: [ReadDirEffect],
                                      noNimJs.} =

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1127,7 +1127,7 @@ proc existsDir*(dir: string): bool {.rtl, extern: "nos$1", tags: [ReadDirEffect]
   ## is returned. Follows symlinks.
   ##
   ## See also:
-  ## * `existsFile proc <#existsFile,string>`_
+  ## * `fileExists proc <#fileExists,string>`_
   ## * `symlinkExists proc <#symlinkExists,string>`_
   when defined(windows):
     when useWinUnicode:
@@ -1147,7 +1147,7 @@ proc symlinkExists*(link: string): bool {.rtl, extern: "nos$1",
   ## regardless of whether the link points to a directory or file.
   ##
   ## See also:
-  ## * `existsFile proc <#existsFile,string>`_
+  ## * `fileExists proc <#fileExists,string>`_
   ## * `existsDir proc <#existsDir,string>`_
   when defined(windows):
     when useWinUnicode:
@@ -1165,7 +1165,7 @@ proc dirExists*(dir: string): bool {.inline, noNimJs.} =
   ## Alias for `existsDir proc <#existsDir,string>`_.
   ##
   ## See also:
-  ## * `existsFile proc <#existsFile,string>`_
+  ## * `fileExists proc <#fileExists,string>`_
   ## * `symlinkExists proc <#symlinkExists,string>`_
   existsDir(dir)
 
@@ -1197,7 +1197,7 @@ proc findExe*(exe: string, followSymlinks: bool = true;
   template checkCurrentDir() =
     for ext in extensions:
       result = addFileExt(exe, ext)
-      if existsFile(result): return
+      if fileExists(result): return
   when defined(posix):
     if '/' in exe: checkCurrentDir()
   else:
@@ -1213,7 +1213,7 @@ proc findExe*(exe: string, followSymlinks: bool = true;
       var x = expandTilde(candidate) / exe
     for ext in extensions:
       var x = addFileExt(x, ext)
-      if existsFile(x):
+      if fileExists(x):
         when not defined(windows):
           while followSymlinks: # doubles as if here
             if x.checkSymlink:
@@ -2024,7 +2024,7 @@ proc expandFilename*(filename: string): string {.rtl, extern: "nos$1",
     # way of retrieving the true filename
     for x in walkFiles(result):
       result = x
-    if not existsFile(result) and not existsDir(result):
+    if not fileExists(result) and not existsDir(result):
       # consider using: `raiseOSError(osLastError(), result)`
       raise newException(OSError, "file '" & result & "' does not exist")
   else:
@@ -2890,7 +2890,7 @@ when not weirdTarget and defined(openbsd):
       # search in path
       for p in split(string(getEnv("PATH")), {PathSep}):
         var x = joinPath(p, exePath)
-        if existsFile(x):
+        if fileExists(x):
           return expandFilename(x)
     else:
       result = ""
@@ -2905,7 +2905,7 @@ when not (defined(windows) or defined(macosx) or weirdTarget):
         # iterate over any path in the $PATH environment variable
         for p in split(string(getEnv("PATH")), {PathSep}):
           var x = joinPath(p, result)
-          if existsFile(x): return x
+          if fileExists(x): return x
     else:
       result = ""
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1097,14 +1097,14 @@ when defined(windows) and not weirdTarget:
     result = f.cFileName[0].int == dot and (f.cFileName[1].int == 0 or
              f.cFileName[1].int == dot and f.cFileName[2].int == 0)
 
-proc existsFile*(filename: string): bool {.rtl, extern: "nos$1",
+proc fileExists*(filename: string): bool {.rtl, extern: "nos$1",
                                           tags: [ReadDirEffect], noNimJs.} =
   ## Returns true if `filename` exists and is a regular file or symlink.
   ##
   ## Directories, device files, named pipes and sockets return false.
   ##
   ## See also:
-  ## * `existsDir proc <#existsDir,string>`_
+  ## * `dirExists proc <#dirExists,string>`_
   ## * `symlinkExists proc <#symlinkExists,string>`_
   when defined(windows):
     when useWinUnicode:
@@ -1116,6 +1116,10 @@ proc existsFile*(filename: string): bool {.rtl, extern: "nos$1",
   else:
     var res: Stat
     return stat(filename, res) >= 0'i32 and S_ISREG(res.st_mode)
+
+when not defined(nimscript):
+  {.deprecated: [existsFile: fileExists].}
+  # refs: https://github.com/nim-lang/Nim/pull/14732
 
 proc existsDir*(dir: string): bool {.rtl, extern: "nos$1", tags: [ReadDirEffect],
                                      noNimJs.} =
@@ -1156,13 +1160,6 @@ proc symlinkExists*(link: string): bool {.rtl, extern: "nos$1",
     var res: Stat
     return lstat(link, res) >= 0'i32 and S_ISLNK(res.st_mode)
 
-proc fileExists*(filename: string): bool {.inline, noNimJs.} =
-  ## Alias for `existsFile proc <#existsFile,string>`_.
-  ##
-  ## See also:
-  ## * `existsDir proc <#existsDir,string>`_
-  ## * `symlinkExists proc <#symlinkExists,string>`_
-  existsFile(filename)
 
 proc dirExists*(dir: string): bool {.inline, noNimJs.} =
   ## Alias for `existsDir proc <#existsDir,string>`_.

--- a/lib/pure/ssl_certs.nim
+++ b/lib/pure/ssl_certs.nim
@@ -79,7 +79,7 @@ iterator scanSSLCertificates*(useEnvVars = false): string =
     when not defined(haiku):
       for p in certificate_paths:
         if p.endsWith(".pem") or p.endsWith(".crt"):
-          if existsFile(p):
+          if fileExists(p):
             yield p
         elif existsDir(p):
           for fn in joinPath(p, "*").walkFiles():

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -131,9 +131,10 @@ proc fileExists*(filename: string): bool {.tags: [ReadIOEffect].} =
   ## Checks if the file exists.
   builtin
 
-{.deprecated: [existsFile: fileExists].}
+template existsFile*(args: varargs[untyped]): untyped {.deprecated: "use fileExists".} =
   # xxx: warning won't be shown for nimsscript because of current logic handling
   # `foreignPackageNotes`
+  fileExists(args)
 
 proc dirExists*(dir: string): bool {.
   tags: [ReadIOEffect].} =

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -131,14 +131,14 @@ proc fileExists*(filename: string): bool {.tags: [ReadIOEffect].} =
   ## Checks if the file exists.
   builtin
 
+{.deprecated: [existsFile: fileExists].}
+  # xxx: warning won't be shown for nimsscript because of current logic handling
+  # `foreignPackageNotes`
+
 proc dirExists*(dir: string): bool {.
   tags: [ReadIOEffect].} =
   ## Checks if the directory `dir` exists.
   builtin
-
-proc existsFile*(filename: string): bool =
-  ## An alias for ``fileExists``.
-  fileExists(filename)
 
 proc existsDir*(dir: string): bool =
   ## An alias for ``dirExists``.

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -86,7 +86,7 @@ proc main =
     quit "[Error] no input file."
   if outfile.len == 0:
     outfile = infile
-  if not existsFile(outfile) or not sameFile(infile, outfile):
+  if not fileExists(outfile) or not sameFile(infile, outfile):
     backup = false # no backup needed since won't be over-written
   if backup:
     let infileBackup = infile & ".backup" # works with .nim or .nims

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -572,7 +572,7 @@ proc `&.?`(a, b: string): string =
 proc processSingleTest(r: var TResults, cat: Category, options, test: string) =
   let test = testsDir &.? cat.string / test
   let target = if cat.string.normalize == "js": targetJS else: targetC
-  if existsFile(test):
+  if fileExists(test):
     testSpec r, makeTest(test, options, cat), {target}
   else:
     doAssert false, test & " test does not exist"

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -438,7 +438,7 @@ proc testSpecHelper(r: var TResults, test: TTest, expected: TSpec,
     else:
       let isJsTarget = target == targetJS
       var exeFile = changeFileExt(test.name, if isJsTarget: "js" else: ExeExt)
-      if not existsFile(exeFile):
+      if not fileExists(exeFile):
         r.addResult(test, target, expected.output,
                     "executable not found: " & exeFile, reExeNotFound)
       else:

--- a/tests/manyloc/keineschweine/dependencies/nake/nake.nim
+++ b/tests/manyloc/keineschweine/dependencies/nake/nake.nim
@@ -51,7 +51,7 @@ template withDir*(dir: string; body: stmt): stmt =
   cd(curDir)
 
 when true:
-  if not existsFile("nakefile.nim"):
+  if not fileExists("nakefile.nim"):
     echo "No nakefile.nim found. Current working dir is ", getCurrentDir()
     quit 1
   var args = ""

--- a/tests/manyloc/keineschweine/enet_server/enet_server.nim
+++ b/tests/manyloc/keineschweine/enet_server/enet_server.nim
@@ -118,7 +118,7 @@ when true:
       of cmdShortOption, cmdLongOption:
         case key
         of "f", "file":
-          if existsFile(val):
+          if fileExists(val):
             zoneCfgFile = val
           else:
             echo("File does not exist: ", val)
@@ -136,7 +136,7 @@ when true:
     address.port = port
 
     var path = getAppDir()/../"data"/zoneFile
-    if not existsFile(path):
+    if not fileExists(path):
       echo("Zone settings file does not exist: ../data/", zoneFile)
       echo(path)
       quit(1)

--- a/tests/manyloc/keineschweine/lib/client_helpers.nim
+++ b/tests/manyloc/keineschweine/lib/client_helpers.nim
@@ -127,7 +127,7 @@ proc handleFileChallenge*(serv: PServer; buffer: PBuffer) =
     challenge = readScFileChallenge(buffer)
     path = expandPath(challenge)
     resp: CsFileChallenge
-  if not existsFile(path):
+  if not fileExists(path):
     resp.needFile = true
     echo "Got file challenge, need file."
   else:

--- a/tests/manyloc/keineschweine/lib/sg_assets.nim
+++ b/tests/manyloc/keineschweine/lib/sg_assets.nim
@@ -221,7 +221,7 @@ template cacheImpl(procName, cacheName, resultType, body: untyped) {.dirty.} =
     cacheName[filename] = result
 
 template checkFile(path: untyped) {.dirty.} =
-  if not existsFile(path):
+  if not fileExists(path):
     errors.add("File missing: " & path)
 
 cacheImpl newSprite, SpriteSheets, PSpriteSheet:
@@ -322,7 +322,7 @@ proc validateSettings*(settings: JsonNode, errors: var seq[string]): bool =
         inc id
 
 proc loadSettingsFromFile*(filename: string, errors: var seq[string]): bool =
-  if not existsFile(filename):
+  if not fileExists(filename):
     errors.add("File does not exist: "&filename)
   else:
     result = loadSettings(readFile(filename), errors)

--- a/tests/manyloc/keineschweine/server/old_dirserver.nim
+++ b/tests/manyloc/keineschweine/server/old_dirserver.nim
@@ -164,7 +164,7 @@ when true:
     of cmdShortOption, cmdLongOption:
       case key
       of "f", "file":
-        if existsFile(val):
+        if fileExists(val):
           cfgFile = val
         else:
           echo("File does not exist: ", val)

--- a/tests/manyloc/keineschweine/server/old_sg_server.nim
+++ b/tests/manyloc/keineschweine/server/old_sg_server.nim
@@ -149,7 +149,7 @@ when true:
     of cmdShortOption, cmdLongOption:
       case key
       of "f", "file":
-        if existsFile(val):
+        if fileExists(val):
           zoneCfgFile = val
         else:
           echo("File does not exist: ", val)
@@ -165,7 +165,7 @@ when true:
     dirServerInfo = jsonSettings["dirserver"]
 
   var path = getAppDir()/../"data"/zoneFile
-  if not existsFile(path):
+  if not fileExists(path):
     echo("Zone settings file does not exist: ../data/", zoneFile)
     echo(path)
     quit(1)

--- a/tests/manyloc/nake/nake.nim
+++ b/tests/manyloc/nake/nake.nim
@@ -51,7 +51,7 @@ template withDir*(dir: string; body: untyped) =
   cd(curDir)
 
 when true:
-  if not existsFile("nakefile.nim"):
+  if not fileExists("nakefile.nim"):
     echo "No nakefile.nim found. Current working dir is ", getCurrentDir()
     quit 1
   var args = ""

--- a/tests/manyloc/nake/nakefile.nim
+++ b/tests/manyloc/nake/nakefile.nim
@@ -86,7 +86,7 @@ task "download", "download game assets":
     client = newHttpClient()
   path.add DirSep
   path.add(extractFilename(GameAssets))
-  if existsFile(path):
+  if fileExists(path):
     echo "The file already exists\n",
       "[R]emove  [M]ove  [Q]uit  [S]kip    Source: ", GameAssets
     case stdin.readLine.toLowerAscii

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -26,7 +26,7 @@ const
 
 proc runCmd(file, options = ""): auto =
   let fileabs = testsDir / file.unixToNativePath
-  doAssert fileabs.existsFile, fileabs
+  doAssert fileabs.fileExists, fileabs
   let cmd = fmt"{nim} {mode} {options} --hints:off {fileabs}"
   result = execCmdEx(cmd)
   when false:  echo result[0] & "\n" & result[1] # for debugging

--- a/tests/newconfig/tfoo.nims
+++ b/tests/newconfig/tfoo.nims
@@ -72,7 +72,7 @@ assert cmpic("HeLLO", "hello") == 0
 assert fileExists("tests/newconfig/tfoo.nims") == true
 assert dirExists("tests") == true
 
-assert existsFile("tests/newconfig/tfoo.nims") == true
+assert fileExists("tests/newconfig/tfoo.nims") == true
 assert existsDir("tests") == true
 
 discard selfExe()

--- a/tests/stdlib/tgetfileinfo.nim
+++ b/tests/stdlib/tgetfileinfo.nim
@@ -20,7 +20,7 @@ proc genBadFileName(limit = 100): string =
     var hitLimit = true
 
     for i in 0..100:
-      if existsFile(result):
+      if fileExists(result):
         result.add("a")
       else:
         hitLimit = false

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -77,6 +77,5 @@ block:
 block: # #14142
   discard existsDir("/usr")
   discard dirExists("/usr")
-  discard existsFile("/usr/foo")
   discard fileExists("/usr/foo")
   discard findExe("nim")

--- a/tools/cmerge.nim
+++ b/tools/cmerge.nim
@@ -9,7 +9,7 @@ proc process(dir, infile: string, outfile: File,
              processed: var HashSet[string]): ProcessResult =
   if processed.containsOrIncl(infile): return prSkipIncludeDir
   let toProcess = dir / infile
-  if not existsFile(toProcess):
+  if not fileExists(toProcess):
     echo "Warning: could not process: ", toProcess
     return prAddIncludeDir
   echo "adding: ", toProcess

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -25,10 +25,10 @@ proc findNimImpl*(): tuple[path: string, ok: bool] =
   let nim = "nim".exe
   result.path = "bin" / nim
   result.ok = true
-  if existsFile(result.path): return
+  if fileExists(result.path): return
   for dir in split(getEnv("PATH"), PathSep):
     result.path = dir / nim
-    if existsFile(result.path): return
+    if fileExists(result.path): return
   # assume there is a symlink to the exe or something:
   return (nim, false)
 
@@ -295,7 +295,7 @@ proc buildPdfDoc*(nimArgs, destPath: string) =
       removeFile(dest)
       moveFile(dest=dest, source=pdf)
       removeFile(changeFileExt(pdf, "aux"))
-      if existsFile(changeFileExt(pdf, "toc")):
+      if fileExists(changeFileExt(pdf, "toc")):
         removeFile(changeFileExt(pdf, "toc"))
       removeFile(changeFileExt(pdf, "log"))
       removeFile(changeFileExt(pdf, "out"))

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -511,7 +511,7 @@ proc walker(pattern; dir: string; counter: var int, errors: var int) =
         if optFollow in options and optRecursive in options and
            path.hasRightDirectory:
           walker(pattern, path, counter, errors)
-  elif existsFile(dir):
+  elif fileExists(dir):
     processFile(pattern, dir, counter, errors)
   else:
     printError "Error: no such file or directory: " & dir

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -639,13 +639,13 @@ proc xzDist(c: var ConfigData; windowsZip=false) =
   proc processFile(destFile, src: string) =
     let dest = tmpDir / destFile
     when false: echo "Copying ", src, " to ", dest
-    if not existsFile(src):
+    if not fileExists(src):
       echo "[Warning] Source file doesn't exist: ", src
     let destDir = dest.splitFile.dir
     if not dirExists(destDir): createDir(destDir)
     copyFileWithPermissions(src, dest)
 
-  if not windowsZip and not existsFile("build" / buildBatFile):
+  if not windowsZip and not fileExists("build" / buildBatFile):
     quit("No C sources found in ./build/, please build by running " &
          "./koch csource -d:release.")
 
@@ -708,8 +708,8 @@ RunProgram="tools\downloader.exe"
 # -- prepare build files for .deb creation
 
 proc debDist(c: var ConfigData) =
-  if not existsFile(getOutputDir(c) / "build.sh"): quit("No build.sh found.")
-  if not existsFile(getOutputDir(c) / "install.sh"): quit("No install.sh found.")
+  if not fileExists(getOutputDir(c) / "build.sh"): quit("No build.sh found.")
+  if not fileExists(getOutputDir(c) / "install.sh"): quit("No install.sh found.")
 
   if c.debOpts.shortDesc == "": quit("shortDesc must be set in the .ini file.")
   if c.debOpts.licenses.len == 0:

--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -199,7 +199,7 @@ proc walkDirRecursively(s: var seq[string], root, ext: string) =
 
 proc addFiles(s: var seq[string], dir, ext: string, patterns: seq[string]) =
   for p in items(patterns):
-    if existsFile(dir / addFileExt(p, ext)):
+    if fileExists(dir / addFileExt(p, ext)):
       s.add(dir / addFileExt(p, ext))
     if existsDir(dir / p):
       walkDirRecursively(s, dir / p, ext)
@@ -273,9 +273,9 @@ proc findNim(c: TConfigData): string =
   if c.nimCompiler.len > 0: return c.nimCompiler
   var nim = "nim".exe
   result = "bin" / nim
-  if existsFile(result): return
+  if fileExists(result): return
   for dir in split(getEnv("PATH"), PathSep):
-    if existsFile(dir / nim): return dir / nim
+    if fileExists(dir / nim): return dir / nim
   # assume there is a symlink to the exe or something:
   return nim
 
@@ -351,7 +351,7 @@ proc buildPdfDoc(c: var TConfigData, destPath: string) =
       removeFile(dest)
       moveFile(dest=dest, source=pdf)
       removeFile(changeFileExt(pdf, "aux"))
-      if existsFile(changeFileExt(pdf, "toc")):
+      if fileExists(changeFileExt(pdf, "toc")):
         removeFile(changeFileExt(pdf, "toc"))
       removeFile(changeFileExt(pdf, "log"))
       removeFile(changeFileExt(pdf, "out"))

--- a/tools/vccexe/vccvswhere.nim
+++ b/tools/vccexe/vccvswhere.nim
@@ -18,7 +18,7 @@ proc vccVswhereExtractVcVarsAllPath(vswherePath: string): string =
   let vsPath = execProcess(&"\"{vswherePath}\" {vswhereArgs}").strip()
   if vsPath.len > 0:
     let vcvarsallPath = joinPath(vsPath, vcvarsRelativePath)
-    if existsFile(vcvarsallPath):
+    if fileExists(vcvarsallPath):
       return vcvarsallPath
 
 proc vccVswhereGeneratePath(envName: string): string =
@@ -41,7 +41,7 @@ proc vccVswhereVcVarsAllPath*(): string =
 
   for tryEnv in ["ProgramFiles(x86)", "ProgramFiles"]:
     let vswherePath = vccVswhereGeneratePath(tryEnv)
-    if vswherePath.len > 0 and existsFile(vswherePath):
+    if vswherePath.len > 0 and fileExists(vswherePath):
       let vcVarsAllPath = vccVswhereExtractVcVarsAllPath(vswherePath)
       if vcVarsAllPath.len > 0:
         return vcVarsAllPath


### PR DESCRIPTION
* 1st commit does the deprecation
* 2nd commit changes all usages in nim repo except under deps which are imported code

refs https://github.com/nim-lang/Nim/pull/14732

reminder: the syntax is in this order: `{.deprecated: [fooOld: fooNew].}`

after this PR: will do `{.deprecated: [existsDir: dirExists].}`

## note
`{.deprecated: [fooOld: fooNew].}` is not mentioned in manual yet and is underused, but is indeed the correct syntax for deprecation in this case (simpler + good for automation, as was case with nimfix which used this), where the deprecation applies to all overloads (or for non-overloadable symbols, this is also the correct thing to use).

IIUC the reason it was removed from manual is because it doesn't work well when you want to deprecate a particular overload, but that shouldn't prevent its use when you don't care about that. If you want to deprecate only a specific overload but not another one, then use:
* `proc fooOld(a: int, b: float) {.deprecated: "use fooNew".} = ...` 
* or `template fooOld(a, b): untyped = fooNew(a, b)` 


## EDIT
this is running into a bug with  `{.deprecated: [fooOld: fooNew].}` which is that this syntax doesn't work with MCS/UFCS inside generics ; i have a minimal example... EDIT: https://github.com/nim-lang/Nim/issues/14819