### PR TITLE
Deprecate rect in favor of the new fromPolar proc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -114,6 +114,8 @@
 - Add `os.normalizeExe`, eg: `koch` => `./koch`.
 - `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
 
+- Deprecate `rect` in favor of `fromPolar` (in the `complex` module)
+
 
 ## Language changes
 - In the newruntime it is now allowed to assign discriminator field without restrictions as long as case object doesn't have custom destructor. Discriminator value doesn't have to be a constant either. If you have custom destructor for case object and you do want to freely assign discriminator fields, it is recommended to refactor object into 2 objects like this:

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -331,13 +331,22 @@ proc phase*[T](z: Complex[T]): T =
 
 proc polar*[T](z: Complex[T]): tuple[r, phi: T] =
   ## Returns ``z`` in polar coordinates.
+  ##
+  ## See also:
+  ## * `fromPolar proc <#fromPolar,tuple[T,T]>`_ for the inverse operation
   (r: abs(z), phi: phase(z))
 
-proc rect*[T](r, phi: T): Complex[T] =
+proc fromPolar*[T](z: tuple[r, phi: T]): Complex[T] =
   ## Returns the complex number with polar coordinates ``r`` and ``phi``.
   ##
   ## | ``result.re = r * cos(phi)``
   ## | ``result.im = r * sin(phi)``
+  ##
+  ## See also:
+  ## * `polar proc <#polar,Complex[T]>`_ for the inverse operation
+  complex(z.r * cos(z.phi), z.r * sin(z.phi))
+
+proc rect*[T](r, phi: T): Complex[T] {.deprecated: "use 'fromPolar' instead".} =
   complex(r * cos(phi), r * sin(phi))
 
 
@@ -425,8 +434,8 @@ when isMainModule:
 
   doAssert(phase(a) == 1.1071487177940904)
   var t = polar(a)
-  doAssert(rect(t.r, t.phi) =~ a)
-  doAssert(rect(1.0, 2.0) =~ complex(-0.4161468365471424, 0.9092974268256817))
+  doAssert(fromPolar(t) =~ a)
+  doAssert(fromPolar((1.0, 2.0)) =~ complex(-0.4161468365471424, 0.9092974268256817))
 
 
   var
@@ -445,8 +454,8 @@ when isMainModule:
 
   doAssert(phase(a64) - 1.107149f < 1e-6)
   var t64 = polar(a64)
-  doAssert(rect(t64.r, t64.phi) =~ a64)
-  doAssert(rect(1.0f, 2.0f) =~ complex(-0.4161468f, 0.90929742f))
+  doAssert(fromPolar(t64) =~ a64)
+  doAssert(fromPolar((1.0f, 2.0f)) =~ complex(-0.4161468f, 0.90929742f))
   doAssert(sizeof(a64) == 8)
   doAssert(sizeof(a) == 16)
 

--- a/lib/pure/complex.nim
+++ b/lib/pure/complex.nim
@@ -10,6 +10,7 @@
 ## This module implements complex numbers.
 ## Complex numbers are currently implemented as generic on a 64-bit or 32-bit float.
 
+import std/private/since
 {.push checks: off, line_dir: off, stack_trace: off, debugger: off.}
 # the user does not want to trace a part of the standard library!
 
@@ -336,8 +337,9 @@ proc polar*[T](z: Complex[T]): tuple[r, phi: T] =
   ## * `fromPolar proc <#fromPolar,tuple[T,T]>`_ for the inverse operation
   (r: abs(z), phi: phase(z))
 
-proc fromPolar*[T](z: tuple[r, phi: T]): Complex[T] =
+proc fromPolar*[T](z: tuple[r, phi: T]): Complex[T] {.since: (1, 3).} =
   ## Returns the complex number with polar coordinates ``r`` and ``phi``.
+  ## **Since**: Version 1.3.
   ##
   ## | ``result.re = r * cos(phi)``
   ## | ``result.im = r * sin(phi)``
@@ -347,6 +349,9 @@ proc fromPolar*[T](z: tuple[r, phi: T]): Complex[T] =
   complex(z.r * cos(z.phi), z.r * sin(z.phi))
 
 proc rect*[T](r, phi: T): Complex[T] {.deprecated: "use 'fromPolar' instead".} =
+  ## Returns the complex number with polar coordinates `r` and `phi`.
+  ## **Deprecated since version 1.3**:
+  ## Use the `fromPolar proc <#fromPolar,tuple[T,T]>`_ instead.
   complex(r * cos(phi), r * sin(phi))
 
 


### PR DESCRIPTION
The name `rect` is misleading and `fromPolar` nicely complements `polar`. Furthermore, `fromPolar` takes a tuple as input, since `polar` returns a tuple. See: https://github.com/nim-lang/Nim/issues/14731#issuecomment-646907483.

Fixes #14731