### PR TITLE
Docs: Fix a broken `code-block`

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -25,13 +25,13 @@
 ## ``AsyncHttpClient``:
 ##
 ## .. code-block:: Nim
-## import asyncdispatch, httpclient
+##   import asyncdispatch, httpclient
 ##
-## proc asyncProc(): Future[string] {.async.} =
-##   var client = newAsyncHttpClient()
-##   return await client.getContent("http://example.com")
+##   proc asyncProc(): Future[string] {.async.} =
+##     var client = newAsyncHttpClient()
+##     return await client.getContent("http://example.com")
 ##
-## echo waitFor asyncProc()
+##   echo waitFor asyncProc()
 ##
 ## The functionality implemented by ``HttpClient`` and ``AsyncHttpClient``
 ## is the same, so you can use whichever one suits you best in the examples

--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -870,26 +870,26 @@ macro mkHandlerTplts(handlers: untyped): untyped =
   # The AST structure of *handlers[0]*:
   #
   # .. code-block::
-  # StmtList
-  #   Call
-  #     Ident "pkNonTerminal"
-  #     StmtList
-  #       Call
-  #         Ident "enter"
-  #         StmtList
-  #           <handler code block>
-  #       Call
-  #         Ident "leave"
-  #         StmtList
-  #           <handler code block>
-  #   Call
-  #     Ident "pkChar"
-  #     StmtList
-  #       Call
-  #         Ident "leave"
-  #         StmtList
-  #           <handler code block>
-  #   ...
+  #   StmtList
+  #     Call
+  #       Ident "pkNonTerminal"
+  #       StmtList
+  #         Call
+  #           Ident "enter"
+  #           StmtList
+  #             <handler code block>
+  #         Call
+  #           Ident "leave"
+  #           StmtList
+  #             <handler code block>
+  #     Call
+  #       Ident "pkChar"
+  #       StmtList
+  #         Call
+  #           Ident "leave"
+  #           StmtList
+  #             <handler code block>
+  #     ...
   proc mkEnter(hdName, body: NimNode): NimNode =
     template helper(hdName, body) {.dirty.} =
       template hdName(s, p, start) =


### PR DESCRIPTION
This PR fixes a broken `code-block` at the top of the [devel httpclient docs](https://nim-lang.github.io/Nim/httpclient.html). The bug was introduced by https://github.com/nim-lang/Nim/pull/14037 (it is not included in the [1.2.2 httpclient docs](https://nim-lang.org/docs/httpclient.html))

I did a quick search for other `code-block`s that are broken in the same way, but the only other one I found (in `pegs.nim`) is not included in the generated documentation.

It would be nice if we could detect such problems during CI.