### PR TITLE
posix_other: add define to force time_t to 64 bit [backport]

### DIFF
--- a/lib/posix/posix_other.nim
+++ b/lib/posix/posix_other.nim
@@ -32,7 +32,12 @@ type
   SocketHandle* = distinct cint # The type used to represent socket descriptors
 
 type
-  Time* {.importc: "time_t", header: "<time.h>".} = distinct clong
+  Time* {.importc: "time_t", header: "<time.h>".} = distinct (
+    when defined(nimUse64BitCTime):
+      int64
+    else:
+      clong
+  )
 
   Timespec* {.importc: "struct timespec",
                header: "<time.h>", final, pure.} = object ## struct timespec


### PR DESCRIPTION
This is a temporary remedy for time_t transition to 64 bit from 32 bit in 
newer Linux libc (musl >= 1.2.0, glibc >= 2.32).

In the future we might want to move away from libc, or figure out a way
to reliably detect the real size of C types at compile time, both of
which are difficult.