### PR TITLE
Add sugar.c

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -113,7 +113,7 @@
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
 - Add `os.normalizeExe`, eg: `koch` => `./koch`.
 - `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
-- Add `sugar.c` convenience template for `cstring("some string")`, *only for Literal* `string`, still allows functions named `c()`.
+- Add `sugar.cs` convenience template for `cstring("some string")`, *only for Literal* `string`, still allows functions named `cs()`.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -113,6 +113,7 @@
 - Add `rstgen.rstToLatex` convenience proc for `renderRstToOut` and `initRstGenerator` with `outLatex` output.
 - Add `os.normalizeExe`, eg: `koch` => `./koch`.
 - `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
+- Add `sugar.c` convenience template for `cstring("some string")`, *only for Literal* `string`, still allows functions named `c()`.
 
 
 ## Language changes

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -346,7 +346,8 @@ since (1, 3):
         doAssert c"Nim" == cstring("Nim")
         doAssert c" " == cstring(" ")
         doAssert c"" == cstring("")
-    system.cstring(s)
+    bind cstring
+    cstring(s)
 
 
 when isMainModule:

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -335,6 +335,19 @@ macro collect*(init, body: untyped): untyped {.since: (1, 1).} =
       call.add init[i]
   result = newTree(nnkStmtListExpr, newVarStmt(res, call), resBody, res)
 
+template c*(s: string{nkRStrLit}): cstring {.since: (1, 3).} =
+  ## Convenience template for `cstring("some string")`, *only for Literal* `string`.
+  ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
+  ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.
+  runnableExamples:
+    static:
+      proc c(s: string) = doAssert false, "Must not match this"
+      doAssert c"Nim" == cstring("Nim")
+      doAssert c" " == cstring(" ")
+      doAssert c"" == cstring("")
+  system.cstring(s)
+
+
 when isMainModule:
   since (1, 1):
     import algorithm

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -336,7 +336,7 @@ macro collect*(init, body: untyped): untyped {.since: (1, 1).} =
   result = newTree(nnkStmtListExpr, newVarStmt(res, call), resBody, res)
 
 since (1, 3):
-  template c*(s: string{nkRStrLit}): cstring  =
+  template c*(s: string{nkRStrLit}): cstring =
     ## Convenience template for `cstring("some string")`, *only for Literal* `string`.
     ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
     ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -336,10 +336,15 @@ macro collect*(init, body: untyped): untyped {.since: (1, 1).} =
   result = newTree(nnkStmtListExpr, newVarStmt(res, call), resBody, res)
 
 since (1, 3):
-  template c*(s: string{nkRStrLit}): cstring =
+  template cs*(s: string{nkRStrLit}): cstring =
     ## Convenience template for `cstring("some string")`, *only for Literal* `string`.
-    ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
+    ## Wont match `"str".cs` nor `cs("str")`, just `cs"str"`, to allow functions named `cs()`.
     ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.
+    runnableExamples:
+      proc cs(s: string) = doAssert false, "Must not match this"
+      doAssert cs"Nim" == cstring("Nim")
+      doAssert cs" " is cstring(" ")
+      doAssert cs"" is cstring("")
     bind cstring
     cstring(s)
 
@@ -403,10 +408,3 @@ when isMainModule:
         of "bird": "word"
         else: d
     assert z == @["word", "word"]
-
-  since (1, 3):
-    block:
-      # proc c(s: string) = doAssert false, "Must not match this"
-      doAssert c"Nim" is cstring
-      doAssert c" " is cstring
-      doAssert c"" is cstring

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -335,17 +335,18 @@ macro collect*(init, body: untyped): untyped {.since: (1, 1).} =
       call.add init[i]
   result = newTree(nnkStmtListExpr, newVarStmt(res, call), resBody, res)
 
-template c*(s: string{nkRStrLit}): cstring {.since: (1, 3).} =
-  ## Convenience template for `cstring("some string")`, *only for Literal* `string`.
-  ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
-  ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.
-  runnableExamples:
-    static:
-      proc c(s: string) = doAssert false, "Must not match this"
-      doAssert c"Nim" == cstring("Nim")
-      doAssert c" " == cstring(" ")
-      doAssert c"" == cstring("")
-  system.cstring(s)
+since (1, 3):
+  template c*(s: string{nkRStrLit}): cstring  =
+    ## Convenience template for `cstring("some string")`, *only for Literal* `string`.
+    ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
+    ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.
+    runnableExamples:
+      static:
+        proc c(s: string) = doAssert false, "Must not match this"
+        doAssert c"Nim" == cstring("Nim")
+        doAssert c" " == cstring(" ")
+        doAssert c"" == cstring("")
+    system.cstring(s)
 
 
 when isMainModule:

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -343,8 +343,8 @@ since (1, 3):
     runnableExamples:
       proc cs(s: string) = doAssert false, "Must not match this"
       doAssert cs"Nim" == cstring("Nim")
-      doAssert cs" " is cstring(" ")
-      doAssert cs"" is cstring("")
+      doAssert cs" " == cstring(" ")
+      doAssert cs"" == cstring("")
     bind cstring
     cstring(s)
 

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -341,11 +341,10 @@ since (1, 3):
     ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
     ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.
     runnableExamples:
-      static:
-        proc c(s: string) = doAssert false, "Must not match this"
-        doAssert c"Nim" == cstring("Nim")
-        doAssert c" " == cstring(" ")
-        doAssert c"" == cstring("")
+      proc c(s: string) = doAssert false, "Must not match this"
+      doAssert c"Nim" is cstring
+      doAssert c" " is cstring
+      doAssert c"" is cstring
     bind cstring
     cstring(s)
 

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -340,11 +340,6 @@ since (1, 3):
     ## Convenience template for `cstring("some string")`, *only for Literal* `string`.
     ## Wont match `"str".c` nor `c("str")`, just `c"str"`, to allow functions named `c()`.
     ## Meant for working with JavaScript or C or C++ interoperability with lots of `cstring`.
-    runnableExamples:
-      proc c(s: string) = doAssert false, "Must not match this"
-      doAssert c"Nim" is cstring
-      doAssert c" " is cstring
-      doAssert c"" is cstring
     bind cstring
     cstring(s)
 
@@ -408,3 +403,10 @@ when isMainModule:
         of "bird": "word"
         else: d
     assert z == @["word", "word"]
+
+  since (1, 3):
+    block:
+      proc c(s: string) = doAssert false, "Must not match this"
+      doAssert c"Nim" is cstring
+      doAssert c" " is cstring
+      doAssert c"" is cstring

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -406,7 +406,7 @@ when isMainModule:
 
   since (1, 3):
     block:
-      proc c(s: string) = doAssert false, "Must not match this"
+      # proc c(s: string) = doAssert false, "Must not match this"
       doAssert c"Nim" is cstring
       doAssert c" " is cstring
       doAssert c"" is cstring


### PR DESCRIPTION
- Add `sugar.c` convenience template for `cstring("some string")`, only for Literal `string`, still allows functions named `c(s: string)`.
- Documentation, `runnableExamples` with `doAssert` and `proc c()` to prove it wont match, `since`, changelog, etc.
- Meant for working with JavaScript or C or C++ interoperability with tons of `cstring("a"), cstring("b"), cstring("c"), ...`