### PR TITLE
Deprecate oldNewlines

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -212,5 +212,6 @@ proc mydiv(a, b): int {.raises: [].} =
 - `nim doc` now outputs under `$projectPath/htmldocs` when `--outdir` is unspecified (with or without `--project`);
   passing `--project` now automatically generates an index and enables search.
   See [docgen](docgen.html#introduction-quick-start) for details.
+- Deprecated `--oldNewlines` and its Deprecated code cleaned out.
 
 ## Tool changes

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -582,16 +582,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     else:
       undefSymbol(conf.symbols, "hotcodereloading")
       undefSymbol(conf.symbols, "useNimRtl")
-  of "oldnewlines":
-    case arg.normalize
-    of "", "on":
-      conf.oldNewlines = true
-      defineSymbol(conf.symbols, "nimOldNewlines")
-    of "off":
-      conf.oldNewlines = false
-      undefSymbol(conf.symbols, "nimOldNewlines")
-    else:
-      localError(conf, info, errOnOrOffExpectedButXFound % arg)
   of "laxstrings": processOnOffSwitch(conf, {optLaxStrings}, arg, pass, info)
   of "nilseqs": processOnOffSwitch(conf, {optNilSeqs}, arg, pass, info)
   of "oldast": processOnOffSwitch(conf, {optOldAst}, arg, pass, info)

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -684,12 +684,7 @@ proc getEscapedChar(L: var TLexer, tok: var TToken) =
   inc(L.bufpos)               # skip '\'
   case L.buf[L.bufpos]
   of 'n', 'N':
-    if L.config.oldNewlines:
-      if tok.tokType == tkCharLit:
-        lexMessage(L, errGenerated, "\\n not allowed in character literal")
-      tok.literal.add(L.config.target.tnl)
-    else:
-      tok.literal.add('\L')
+    tok.literal.add('\L')
     inc(L.bufpos)
   of 'p', 'P':
     if tok.tokType == tkCharLit:

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -101,7 +101,6 @@ Advanced options:
   --excessiveStackTrace:on|off
                             stack traces use full file paths
   --stackTraceMsgs:on|off   enable user defined stack frame msgs via `setFrameMsg`
-  --oldNewlines:on|off      turn on|off the old behaviour of "\n"
   --laxStrings:on|off       when turned on, accessing the zero terminator in
                             strings is allowed; only for backwards compatibility
   --nilseqs:on|off          allow 'nil' for strings/seqs for


### PR DESCRIPTION
- Deprecate `--oldNewlines`.
- Clean out deprecated code from `--oldNewlines`.
- Was deprecated years ago.
- I cant find a project on Nimble that heavily relies on `--oldNewlines` at least from GitHub advanced search.
- CI Fail is 1 Nimble package, unrelated CI fail.
