### PR TITLE
Deprecate laxStrings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -213,4 +213,7 @@ proc mydiv(a, b): int {.raises: [].} =
   passing `--project` now automatically generates an index and enables search.
   See [docgen](docgen.html#introduction-quick-start) for details.
 
+- Deprecated `--laxStrings` for mutating the internal zero terminator on strings and its Deprecated code cleaned out.
+
+
 ## Tool changes

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -931,7 +931,7 @@ proc genSeqElem(p: BProc, n, x, y: PNode, d: var TLoc) =
   if ty.kind in {tyRef, tyPtr}:
     ty = skipTypes(ty.lastSon, abstractVarRange) # emit range check:
   if optBoundsCheck in p.options:
-    if ty.kind == tyString and (not defined(nimNoZeroTerminator) or optLaxStrings in p.options):
+    if ty.kind == tyString and not defined(nimNoZeroTerminator):
       linefmt(p, cpsStmts,
               "if ((NU)($1) > (NU)$2){ #raiseIndexError2($1,$2); $3}$n",
               [rdLoc(b), lenExpr(p, a), raiseInstr(p)])

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -592,7 +592,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       undefSymbol(conf.symbols, "nimOldNewlines")
     else:
       localError(conf, info, errOnOrOffExpectedButXFound % arg)
-  of "laxstrings": processOnOffSwitch(conf, {optLaxStrings}, arg, pass, info)
   of "nilseqs": processOnOffSwitch(conf, {optNilSeqs}, arg, pass, info)
   of "oldast": processOnOffSwitch(conf, {optOldAst}, arg, pass, info)
   of "checks", "x": processOnOffSwitch(conf, ChecksOptions, arg, pass, info)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -39,7 +39,6 @@ type                          # please make sure we have under 32 options
                               # evaluation
     optTrMacros,              # en/disable pattern matching
     optMemTracker,
-    optLaxStrings,
     optNilSeqs,
     optOldAst,
     optSinkInference          # 'sink T' inference

--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -482,8 +482,6 @@ proc foldArrayAccess(m: PSym, n: PNode; g: ModuleGraph): PNode =
     result = newNodeIT(nkCharLit, x.info, n.typ)
     if idx >= 0 and idx < x.strVal.len:
       result.intVal = ord(x.strVal[int(idx)])
-    elif idx == x.strVal.len and optLaxStrings in g.config.options:
-      discard
     else:
       localError(g.config, n.info, formatErrorIndexBound(idx, x.strVal.len-1) & $n)
   else: discard

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -684,8 +684,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       let s = regs[rb].node.strVal
       if idx <% s.len:
         regs[ra].intVal = s[idx].ord
-      elif idx == s.len and optLaxStrings in c.config.options:
-        regs[ra].intVal = 0
       else:
         stackTrace(c, tos, pc, formatErrorIndexBound(idx, s.len-1))
     of opcWrArr:

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -102,8 +102,6 @@ Advanced options:
                             stack traces use full file paths
   --stackTraceMsgs:on|off   enable user defined stack frame msgs via `setFrameMsg`
   --oldNewlines:on|off      turn on|off the old behaviour of "\n"
-  --laxStrings:on|off       when turned on, accessing the zero terminator in
-                            strings is allowed; only for backwards compatibility
   --nilseqs:on|off          allow 'nil' for strings/seqs for
                             backwards compatibility
   --seqsv2:on|off           use the new string/seq implementation based on


### PR DESCRIPTION
- Deprecate `--laxStrings`.
- Clean out deprecated code from `--laxStrings`.
- Was deprecated years ago, was pre-`1.0`.
- I cant find a project on Nimble that heavily relies on `--laxStrings` at least from GitHub advanced search.
- Mutating the internal zero terminator on strings sounds like a can of worms whatsoever.
