### PR TITLE
Deprecate and/or remove ospaths

### DIFF
--- a/lib/pure/reservedmem.nim
+++ b/lib/pure/reservedmem.nim
@@ -18,7 +18,7 @@
 ##
 ## Unstable API.
 
-from ospaths import raiseOSError, osLastError
+from os import raiseOSError, osLastError
 
 template distance*(lhs, rhs: pointer): int =
   cast[int](rhs) - cast[int](lhs)

--- a/lib/pure/ssl_certs.nim
+++ b/lib/pure/ssl_certs.nim
@@ -11,7 +11,7 @@
 ## SSL_CERT_DIR environment variables.
 
 import os, strutils
-from ospaths import existsEnv, getEnv
+from os import existsEnv, getEnv
 import strutils
 
 # SECURITY: this unnecessarily scans through dirs/files regardless of the

--- a/nimpretty/tests/expected/wrong_ind.nim
+++ b/nimpretty/tests/expected/wrong_ind.nim
@@ -2,7 +2,7 @@
 # bug #9505
 
 import std/[
-    strutils, ospaths, os
+    strutils, os
 ]
 import pkg/[
   regex

--- a/nimpretty/tests/wrong_ind.nim
+++ b/nimpretty/tests/wrong_ind.nim
@@ -2,7 +2,7 @@
 # bug #9505
 
 import std/[
-    strutils, ospaths, os
+    strutils, os
 ]
 import pkg/[
   regex

--- a/tests/untestable/thttpclient_ssl_disabled.nim
+++ b/tests/untestable/thttpclient_ssl_disabled.nim
@@ -12,7 +12,7 @@
 import httpclient,
   net,
   unittest,
-  ospaths
+  os
 
 from strutils import contains
 

--- a/tests/untestable/thttpclient_ssl_env_var.nim
+++ b/tests/untestable/thttpclient_ssl_env_var.nim
@@ -13,7 +13,7 @@
 ##  SSL_CERT_FILE=BogusInexistentFileName tests/untestable/thttpclient_ssl_env_var
 ##  SSL_CERT_DIR=BogusInexistentDirName tests/untestable/thttpclient_ssl_env_var
 
-import httpclient, unittest, ospaths
+import httpclient, unittest, os
 from net import newSocket, newContext, wrapSocket, connect, close, Port,
   CVerifyPeerUseEnvVars
 from strutils import contains


### PR DESCRIPTION
- Deprecate and/or remove `ospaths`, to chill out that deprecation warning.
