### PR TITLE
fix bug in semgnrc: runnableExamples should not semcheck, even with > 1 arg

### DIFF
--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -265,7 +265,7 @@ proc semGenericStmt(c: PContext, n: PNode,
         # We're not interested in the example code during this pass so let's
         # skip it
         if s.magic == mRunnableExamples:
-          inc first
+          first = result.safeLen # see trunnableexamples.fun3
       of skGenericParam:
         result[0] = newSymNodeTypeDesc(s, fn.info)
         onUse(fn.info, s)

--- a/tests/nimdoc/trunnableexamples.nim
+++ b/tests/nimdoc/trunnableexamples.nim
@@ -91,6 +91,16 @@ when true: # runnableExamples with rdoccmd
   proc fun2*() =
     runnableExamples "-d:foo": discard # checks that it also works inside procs
 
+  template fun3Impl(): untyped =
+    runnableExamples(rdoccmd="-d:foo"):
+      nonexistant
+        # bugfix: this shouldn't be semchecked when `runnableExamples`
+        # has more than 1 argument
+    discard
+
+  proc fun3*[T]() =
+    fun3Impl()
+
   when false: # future work
     # passing non-string-litterals (for reuse)
     const a = "-b:cpp"


### PR DESCRIPTION
before PR, the added test would fail