### PR TITLE
koch: add --localdocs to allow building only local docs

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -55,8 +55,6 @@ Options:
   --nim:path               use specified path for nim binary
   --localdocs[:path]       only build local documentations. If a path is not
                            specified (or empty), the default is used.
-                           Additionally options passed to docs will be used to
-                           build local documentation.
 Possible Commands:
   boot [options]           bootstraps with given command line options
   distrohelper [bindir]    helper for distro packagers

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -182,7 +182,7 @@ lib/system/iterators.nim
 lib/system/dollars.nim
 lib/system/widestrs.nim
 """.splitWhitespace()
-  
+
   proc follow(a: PathEntry): bool =
     a.path.lastPathPart notin ["nimcache", "htmldocs", "includes", "deprecated", "genode"]
   for entry in walkDirRecFilter("lib", follow = follow):
@@ -318,6 +318,18 @@ proc buildDocsDir*(args: string, dir: string) =
   buildDocPackages(args, dir)
   copyFile(docHackJsSource, dir / docHackJsSource.lastPathPart)
 
-proc buildDocs*(args: string) =
-  buildDocsDir(args, webUploadOutput / NimVersion)
-  buildDocsDir("", docHtmlOutput) # no `args` to avoid offline docs containing the 'gaCode'!
+proc buildDocs*(args: string, localOnly = false, localOutDir = "") =
+  let localOutDir =
+    if localOutDir.len == 0:
+      docHtmlOutput
+    else:
+      localOutDir
+
+  var args = args
+
+  if not localOnly:
+    buildDocsDir(args, webUploadOutput / NimVersion)
+    # no `args` to avoid offline docs containing the 'gaCode'!
+    args.setLen(0)
+
+  buildDocsDir(args, localOutDir)

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -1,6 +1,6 @@
 ## Part of 'koch' responsible for the documentation generation.
 
-import os, strutils, osproc, sets, pathnorm
+import os, strutils, osproc, sets, pathnorm, pegs
 from std/private/globs import nativeToUnixPath, walkDirRecFilter, PathEntry
 import "../compiler/nimpaths"
 
@@ -329,7 +329,8 @@ proc buildDocs*(args: string, localOnly = false, localOutDir = "") =
 
   if not localOnly:
     buildDocsDir(args, webUploadOutput / NimVersion)
-    # no `args` to avoid offline docs containing the 'gaCode'!
-    args.setLen(0)
+
+    let gaFilter = peg"@( y'--doc.googleAnalytics:' @(\s / $) )"
+    args = args.replace(gaFilter)
 
   buildDocsDir(args, localOutDir)


### PR DESCRIPTION
This flag also make koch doc use the passed arguments when building
the offline docs.

This is useful when generating nightlies as we would want to use
--doccmd:skip and also skipping a pass of docgen speed things up
drastically (for non-native targets).

This flag superseded the undocumented --docslocal.