### PR TITLE
typetraits: features and fixes

### DIFF
--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -121,8 +121,13 @@ macro genericParamsImpl(T: typedesc): untyped =
             ret = ai
           of ntyStatic: doAssert false
           else:
-            since (1, 1):
-              ret = newTree(nnkBracketExpr, @[bindSym"StaticParam", ai])
+            # getType from a resolved symbol might return a typedesc symbol.
+            # If so, use it directly instead of wrapping it in StaticParam.
+            if ai.kind == nnkSym and ai.symKind == nskType:
+              ret = ai
+            else:
+              since (1, 1):
+                ret = newTree(nnkBracketExpr, @[bindSym"StaticParam", ai])
           result.add ret
         break
       else:
@@ -163,4 +168,4 @@ when isMainModule:
   fun(int)
 
   var a: seq[int]
-  doAssert typeof(a).genericParams.get(0).value is int
+  doAssert typeof(a).genericParams.get(0) is int

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -165,8 +165,8 @@ since (1, 1):
       var s: seq[Bar[3.0, string]]
       doAssert genericParams(typeof(s)) is (Bar[3.0, string],)
 
-      # NOTE: For the builtin array type, the index range will **always**
-      #       become a range type after typecheck occurred.
+      # NOTE: For the builtin array type, the index generic param will
+      #       **always** become a range type after it's bound to a variable.
       doAssert genericParams(array[10, int]) is (StaticParam[10], int)
       var a: array[10, int]
       doAssert genericParams(typeof(a)) is (range[0..9], int)

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -110,7 +110,7 @@ macro genericParamsImpl(T: typedesc): untyped =
         impl = impl[2]
         continue
       of nnkTypeOfExpr:
-        impl = getType(impl[0])
+        impl = getTypeInst(impl[0])
         continue
       of nnkBracketExpr:
         for i in 1..<impl.len:
@@ -123,7 +123,9 @@ macro genericParamsImpl(T: typedesc): untyped =
           else:
             # getType from a resolved symbol might return a typedesc symbol.
             # If so, use it directly instead of wrapping it in StaticParam.
-            if ai.kind == nnkSym and ai.symKind == nskType:
+            if (ai.kind == nnkSym and ai.symKind == nskType) or
+               (ai.kind == nnkBracketExpr and ai[0].kind == nnkSym and
+                ai[0].symKind == nskType):
               ret = ai
             else:
               since (1, 1):
@@ -137,11 +139,15 @@ since (1, 1):
   template genericParams*(T: typedesc): untyped =
     ## return tuple of generic params for generic `T`
     runnableExamples:
-      type Foo[T1, T2]=object
+      type Foo[T1, T2] = object
       doAssert genericParams(Foo[float, string]) is (float, string)
       type Bar[N: static float, T] = object
       doAssert genericParams(Bar[1.0, string]) is (StaticParam[1.0], string)
       doAssert genericParams(Bar[1.0, string]).get(0).value == 1.0
+      doAssert genericParams(seq[Bar[2.0, string]]).get(0) is Bar[2.0, string]
+      var s: seq[Bar[3.0, string]]
+      doAssert genericParams(typeof(s)) is (Bar[3.0, string],)
+      doAssert genericParams(typedesc[genericParams(typeof s).get(0)]) is (StaticParam[3.0], string)
 
     type T2 = T
     genericParamsImpl(T2)

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -109,6 +109,9 @@ macro genericParamsImpl(T: typedesc): untyped =
       of nnkTypeDef:
         impl = impl[2]
         continue
+      of nnkTypeOfExpr:
+        impl = getType(impl[0])
+        continue
       of nnkBracketExpr:
         for i in 1..<impl.len:
           let ai = impl[i]
@@ -158,3 +161,6 @@ when isMainModule:
     doAssert a2 == "int"
     doAssert a3 == "int"
   fun(int)
+
+  var a: seq[int]
+  doAssert typeof(a).genericParams.get(0).value is int

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -184,6 +184,23 @@ block genericParams:
     doAssert genericParams(Bar4) is (StaticParam[5.0], string)
     doAssert genericParams(Bar[F, string]) is (StaticParam[5.0], string)
 
+  block typeof:
+    var
+      a: seq[int]
+      b: array[42, float]
+      c: array[char, int]
+      d: array[1..2, char]
+
+    doAssert genericParams(typeof(a)).get(0) is int
+    doAssert genericParams(typeof(b)) is (range[0..41], float)
+    doAssert genericParams(typeof(c)) is (char, int)
+    doAssert genericParams(typeof(d)) is (range[1..2], char)
+
+  block nestedContainers:
+    doAssert genericParams(seq[Foo[string, float]]).get(0) is Foo[string, float]
+    doAssert genericParams(array[10, Foo[Bar[1, int], Bar[2, float]]]) is (StaticParam[10], Foo[Bar[1, int], Bar[2, float]])
+    doAssert genericParams(array[1..9, int]) is (range[1..9], int)
+
 ##############################################
 # bug 13095
 


### PR DESCRIPTION
Highlights:
- `genericParams` can now consume `typeof()` expressions.
- `genericParams` can now process nested generics within `seq`, `array`, `set` and all other built-in generic types
- `genericParams` now understand the potential wackiness of `array[I, T]` with it's magical index range.