### PR TITLE
Patch #14716 - add missing `when`

### DIFF
--- a/tools/detect/detect.nim
+++ b/tools/detect/detect.nim
@@ -98,8 +98,8 @@ proc main =
     f.write(nimfile % [other])
     close(f)
 
-  let cCompile = defined(openbsd) or defined(freebsd) or defined(netbsd): ccLinkMath else: cc
-  let cppCompile = defined(openbsd) or defined(freebsd) or defined(netbsd): cppLinkMath else: cpp
+  let cCompile = when defined(openbsd) or defined(freebsd) or defined(netbsd): ccLinkMath else: cc
+  let cppCompile = when defined(openbsd) or defined(freebsd) or defined(netbsd): cppLinkMath else: cpp
   if not myExec(cCompile % [gen.addFileExt(ExeExt), gen]): quit(1)
   if not myExec(cppCompile % [pre.addFileExt(ExeExt), pre]): quit(1)
   when defined(windows):


### PR DESCRIPTION
Patch for #14716 - seems a `when` was lost in the PR and was missed before merging.