### PR TITLE
Clean out Deprecated proc

### DIFF
--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -66,10 +66,6 @@ proc addInt*(result: var string; x: int64) =
   for j in 0..i div 2 - 1:
     swap(result[base+j], result[base+i-j-1])
 
-proc add*(result: var string; x: int64) {.deprecated:
-  "Deprecated since v0.20, use 'addInt'".} =
-  addInt(result, x)
-
 proc nimIntToStr(x: int): string {.compilerRtl.} =
   result = newStringOfCap(sizeof(x)*4)
   result.addInt x
@@ -97,10 +93,6 @@ proc addFloat*(result: var string; x: float) =
     var buffer {.noinit.}: array[65, char]
     let n = writeFloatToBuffer(buffer, x)
     result.addCstringN(cstring(buffer[0].addr), n)
-
-proc add*(result: var string; x: float) {.deprecated:
-  "Deprecated since v0.20, use 'addFloat'".} =
-  addFloat(result, x)
 
 proc nimFloatToStr(f: float): string {.compilerproc.} =
   result = newStringOfCap(8)

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -8,14 +8,6 @@ proc test(foo: Foo[int])
   required type for foo: Foo[int]
   but expression 'bar' is of type: Bar[system.int]
 t3330.nim(63, 8) Hint: Non-matching candidates for add(k, string, T)
-proc add(result: var string; x: float)
-  first type mismatch at position: 1
-  required type for result: var string
-  but expression 'k' is of type: Alias
-proc add(result: var string; x: int64)
-  first type mismatch at position: 1
-  required type for result: var string
-  but expression 'k' is of type: Alias
 proc add(x: var string; y: char)
   first type mismatch at position: 1
   required type for x: var string
@@ -76,4 +68,3 @@ proc test(foo: Foo[int]) =
 
 var bar = Bar[int]()
 bar.test()
-

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -1,13 +1,13 @@
 discard """
 errormsg: "type mismatch: got <Bar[system.int]>"
 nimout: '''
-t3330.nim(78, 4) Error: type mismatch: got <Bar[system.int]>
+t3330.nim(70, 4) Error: type mismatch: got <Bar[system.int]>
 but expected one of:
 proc test(foo: Foo[int])
   first type mismatch at position: 1
   required type for foo: Foo[int]
   but expression 'bar' is of type: Bar[system.int]
-t3330.nim(63, 8) Hint: Non-matching candidates for add(k, string, T)
+t3330.nim(55, 8) Hint: Non-matching candidates for add(k, string, T)
 proc add(x: var string; y: char)
   first type mismatch at position: 1
   required type for x: var string
@@ -29,10 +29,10 @@ proc add[T](x: var seq[T]; y: sink T)
   required type for x: var seq[T]
   but expression 'k' is of type: Alias
 
-t3330.nim(63, 8) template/generic instantiation of `add` from here
-t3330.nim(70, 6) Foo: 'bar.value' cannot be assigned to
-t3330.nim(63, 8) template/generic instantiation of `add` from here
-t3330.nim(71, 6) Foo: 'bar.x' cannot be assigned to
+t3330.nim(55, 8) template/generic instantiation of `add` from here
+t3330.nim(62, 6) Foo: 'bar.value' cannot be assigned to
+t3330.nim(55, 8) template/generic instantiation of `add` from here
+t3330.nim(63, 6) Foo: 'bar.x' cannot be assigned to
 
 expression: test(bar)'''
 """

--- a/tests/system/tostring.nim
+++ b/tests/system/tostring.nim
@@ -83,6 +83,10 @@ proc stringCompare() =
   doAssert b == "bee"
   b.add g
   doAssert b == "bee"
+  c.addFloat 123.456
+  doAssert c == "123.456"
+  d.addInt 123456
+  doAssert d == "123456"
 
   doAssert e == ""
   doAssert "" == e

--- a/tests/system/tostring.nim
+++ b/tests/system/tostring.nim
@@ -83,10 +83,6 @@ proc stringCompare() =
   doAssert b == "bee"
   b.add g
   doAssert b == "bee"
-  c.add 123.456
-  doAssert c == "123.456"
-  d.add 123456
-  doAssert d == "123456"
 
   doAssert e == ""
   doAssert "" == e


### PR DESCRIPTION
- Remove and/or clean out Deprecated `add` proc for floats. Deprecated since `0.20`.
