### PR TITLE
fix #13432 typetraits.$: $(int,) is now (int,); $tuple[] is now tuple[]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -115,6 +115,7 @@
 - `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
 - Add `random.gauss`, that uses the ratio of uniforms method of sampling from a Gaussian distribution.
 - Add `typetraits.elementType` to get element type of an iterable.
+- `typetraits.$`: `$(int,)` is now `"(int,)"`; `$tuple[]` is now `"tuple[]"`
 
 ## Language changes
 - In the newruntime it is now allowed to assign to the discriminator field

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -634,13 +634,14 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
           if i < t.n.len - 1: result.add(", ")
         result.add(']')
       elif t.len == 0:
-        result = "tuple"
+        result = "tuple[]"
       else:
         if prefer == preferTypeName: result = "("
         else: result = "tuple of ("
         for i in 0..<t.len:
           result.add(typeToString(t[i]))
           if i < t.len - 1: result.add(", ")
+          elif t.len == 1: result.add(",")
         result.add(')')
     of tyPtr, tyRef, tyVar, tyLent:
       result = typeToStr[t.kind]

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -149,24 +149,3 @@ since (1, 1):
 
     type T2 = T
     genericParamsImpl(T2)
-
-when isMainModule:
-  static:
-    doAssert $type(42) == "int"
-    doAssert int.name == "int"
-
-  const a1 = name(int)
-  const a2 = $(int)
-  const a3 = $int
-  doAssert a1 == "int"
-  doAssert a2 == "int"
-  doAssert a3 == "int"
-
-  proc fun[T: typedesc](t: T) =
-    const a1 = name(t)
-    const a2 = $(t)
-    const a3 = $t
-    doAssert a1 == "int"
-    doAssert a2 == "int"
-    doAssert a3 == "int"
-  fun(int)

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -26,6 +26,37 @@ proc typeToString*(t: typedesc, prefer = "preferTypeName"): string {.magic: "Typ
   ## prefer = "preferResolved" will resolve type aliases recursively.
   # Move to typetraits.nim once api stabilized.
 
+block: # name, `$`
+  static:
+    doAssert $type(42) == "int"
+    doAssert int.name == "int"
+
+  const a1 = name(int)
+  const a2 = $(int)
+  const a3 = $int
+  doAssert a1 == "int"
+  doAssert a2 == "int"
+  doAssert a3 == "int"
+
+  proc fun[T: typedesc](t: T) =
+    const a1 = name(t)
+    const a2 = $(t)
+    const a3 = $t
+    doAssert a1 == "int"
+    doAssert a2 == "int"
+    doAssert a3 == "int"
+  fun(int)
+
+  doAssert $(int,) == "(int,)"
+  doAssert $(1,) == "(1,)" # just for comparison to make sure it has same structure
+  doAssert $tuple[] == "tuple[]"
+  doAssert $(int,) == "(int,)"
+  doAssert $(int, float) == "(int, float)"
+  doAssert $((int), tuple[], tuple[a: uint], tuple[a: uint, b: float], (int,), (int, float)) == "(int, tuple[], tuple[a: uint], tuple[a: uint, b: float], tuple of (int,), tuple of (int, float))"
+  # xxx this is inconsistent, it should be:
+  # "(int, tuple[], tuple[a: uint], tuple[a: uint, b: float], (int,), (int, float))"
+  # which matches how you write it, is consistent with `$(int,)`, and is un-ambiguous.
+
 block: # typeToString
   type MyInt = int
   type


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/13432

$(int,) is now (int,) instead of (int); $tuple[] is now tuple[] instead of tuple

## future work:
will make:
```nim
doAssert $((int), tuple[], tuple[a: uint], tuple[a: uint, b: float], (int,), (int, float)) == "(int, tuple[], tuple[a: uint], tuple[a: uint, b: float], tuple of (int,), tuple of (int, float))"
=>
doAssert $((int), tuple[], tuple[a: uint], tuple[a: uint, b: float], (int,), (int, float)) == "(int, tuple[], tuple[a: uint], tuple[a: uint, b: float], (int,), (int, float))"
```

which matches how you write it, is consistent with `$(int,)`, and is un-ambiguous.

(EDIT: => https://github.com/nim-lang/Nim/pull/14812)