### PR TITLE
expr => untyped; stmt => typed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -221,6 +221,7 @@ proc mydiv(a, b): int {.raises: [].} =
   See [docgen](docgen.html#introduction-quick-start) for details.
 - Removed the `--oldNewlines` switch.
 - Removed the `--laxStrings` switch for mutating the internal zero terminator on strings.
+- `$getType(untyped)` is now "untyped" instead of "expr", `$getType(typed)` is now "typed" instead of "stmt"
 
 
 ## Tool changes

--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -93,8 +93,8 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyBool: result = atomicType("bool", mBool)
   of tyChar: result = atomicType("char", mChar)
   of tyNil: result = atomicType("nil", mNil)
-  of tyUntyped: result = atomicType("expr", mExpr)
-  of tyTyped: result = atomicType("stmt", mStmt)
+  of tyUntyped: result = atomicType("untyped", mExpr)
+  of tyTyped: result = atomicType("typed", mStmt)
   of tyVoid: result = atomicType("void", mVoid)
   of tyEmpty: result = atomicType("empty", mNone)
   of tyUncheckedArray:

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -49,6 +49,10 @@ block: # typeToString
   doAssert (tuple[a: C2b[MyInt, C4[cstring]], b: cint, c: float]).name3 ==
     "tuple[a: C[MyInt{int}, C4[cstring]], b: cint{int32}, c: float]"
 
+  macro fn(): string =
+    newLit $($getType(untyped), $getType(typed))
+  doAssert fn() == """("untyped", "typed")"""
+
 block distinctBase:
   block:
     type

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -50,6 +50,8 @@ block: # typeToString
     "tuple[a: C[MyInt{int}, C4[cstring]], b: cint{int32}, c: float]"
 
   macro fn(): string =
+    # not 100% sure whether this should even compile; if some PR breaks this test,
+    # this could be revisited, maybe.
     newLit $($getType(untyped), $getType(typed))
   doAssert fn() == """("untyped", "typed")"""
 


### PR DESCRIPTION
not even sure whether the test should be legal, but the fix should be.
(if you have a better idea for a test let me know)
