### PR TITLE
SSL_CTX_load_verify_locations parameters are reversed

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -614,7 +614,7 @@ when defineSsl:
       if verifyMode != CVerifyNone:
         # Use the caDir and caFile parameters if set
         if caDir != "" or caFile != "":
-          if newCTX.SSL_CTX_load_verify_locations(caDir, caFile) != 0:
+          if newCTX.SSL_CTX_load_verify_locations(caFile, caDir) != 0:
             raise newException(IOError, "Failed to load SSL/TLS CA certificate(s).")
 
         else:


### PR DESCRIPTION
Parameters are reversed:
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_load_verify_locations.html

 int SSL_CTX_load_verify_locations(SSL_CTX *ctx, const char *CAfile,
                                   const char *CApath);