### PR TITLE
asyncnet, net: the SIGPIPE avoidance package for SSL_shutdown()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -115,6 +115,7 @@
 - `macros.newLit` now preserves named vs unnamed tuples; use `-d:nimHasWorkaround14720` to keep old behavior
 - Add `random.gauss`, that uses the ratio of uniforms method of sampling from a Gaussian distribution.
 - Add `typetraits.elementType` to get element type of an iterable.
+- Add `posix_utils.ignoreSignals`, a macro that allows external signals to be temporary ignored.
 
 ## Language changes
 - In the newruntime it is now allowed to assign to the discriminator field

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -80,7 +80,7 @@ when defineSsl:
 
 when defined(posix):
   from posix import SIGPIPE
-  from posix_utils import ignoreSignals
+  from posix_utils import nil
 
 # Note: The enumerations are mapped to Window's constants.
 
@@ -1060,8 +1060,8 @@ proc close*(socket: Socket) =
         # established, see:
         # https://github.com/openssl/openssl/issues/710#issuecomment-253897666
         if SSL_in_init(socket.sslHandle) == 0 and not socket.sslInhibitShutdown:
-          when defined(posix):
-            ignoreSignals(SIGPIPE): doSSLShutdown()
+          when defined(posix) and declared(posix_utils.ignoreSignals):
+            posix_utils.ignoreSignals(SIGPIPE): doSSLShutdown()
           else:
             doSSLShutdown()
   finally:


### PR DESCRIPTION
This PR addresses the following:
- `SSL_shutdown` is still attempted after a fatal error.
- `SIGPIPE` is not handled during graceful shutdown of a SSL connection (not addressed for all POSIX).

Some additions along the way:
- `posix_utils.ignoreSignals`: A nice macro that allows specified signals to be avoided in the given code block.

Ref #9867