### PR TITLE
Warn about calling wrappers at compile time until #14049 is fixed.

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -843,7 +843,10 @@ language features:
 * closure iterators
 * the ``cast`` operator
 * reference (pointer) types
-* the FFI
+* FFI
+
+The use of wrappers that use FFI and/or ``cast`` is also disallowed. Note that
+these wrappers include the ones in the standard libraries.
 
 Some or all of these restrictions are likely to be lifted over time.
 


### PR DESCRIPTION
See #14049.