### PR TITLE
VM profiler

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -884,6 +884,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       localError(conf, info, "unknown Nim version; currently supported values are: {1.0}")
   of "benchmarkvm":
     processOnOffSwitchG(conf, {optBenchmarkVM}, arg, pass, info)
+  of "profilevm":
+    processOnOffSwitchG(conf, {optProfileVM}, arg, pass, info)
   of "sinkinference":
     processOnOffSwitch(conf, {optSinkInference}, arg, pass, info)
   of "panics":

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -10,7 +10,7 @@
 ## This module contains the ``TMsgKind`` enum as well as the
 ## ``TLineInfo`` object.
 
-import ropes, tables, pathutils
+import ropes, tables, pathutils, hashes
 
 const
   explanationsBaseUrl* = "https://nim-lang.github.io/Nim"
@@ -270,6 +270,9 @@ type
   ESuggestDone* = object of ValueError
 
 proc `==`*(a, b: FileIndex): bool {.borrow.}
+
+proc hash*(i: TLineInfo): Hash =
+  hash (i.line.int, i.col.int, i.fileIndex.int)
 
 proc raiseRecoverableError*(msg: string) {.noinline.} =
   raise newException(ERecoverableError, msg)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -19,7 +19,7 @@ import
   cgen, json, nversion,
   platform, nimconf, passaux, depends, vm, idgen,
   modules,
-  modulegraphs, tables, rod, lineinfos, pathutils
+  modulegraphs, tables, rod, lineinfos, pathutils, vmprofiler
 
 when not defined(leanCompiler):
   import jsgen, docgen, docgen2
@@ -404,6 +404,8 @@ proc mainCommand*(graph: ModuleGraph) =
     else:
       output = $conf.absOutFile
     if optListFullPaths notin conf.globalOptions: output = output.AbsoluteFile.extractFilename
+    if optProfileVM in conf.globalOptions:
+      echo conf.dump(conf.vmProfileData)
     rawMessage(conf, hintSuccessX, [
       "loc", loc,
       "sec", sec,

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -9,7 +9,7 @@
 
 import
   os, strutils, strtabs, sets, lineinfos, platform,
-  prefixmatches, pathutils, nimpaths
+  prefixmatches, pathutils, nimpaths, tables
 
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
@@ -218,6 +218,13 @@ type
     version*: int
   Suggestions* = seq[Suggest]
 
+  ProfileInfo* = object
+    time*: float
+    count*: int
+
+  ProfileData* = ref object
+    data*: TableRef[TLineInfo, ProfileInfo]
+
   ConfigRef* = ref object ## every global configuration
                           ## fields marked with '*' are subject to
                           ## the incremental compilation mechanisms
@@ -315,6 +322,7 @@ type
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
+    vmProfileData*: ProfileData
 
 proc assignIfDefault*[T](result: var T, val: T, def = default(T)) =
   ## if `result` was already assigned to a value (that wasn't `def`), this is a noop.
@@ -391,6 +399,9 @@ template newPackageCache*(): untyped =
                  else:
                    modeCaseSensitive)
 
+proc newProfileData(): ProfileData =
+  ProfileData(data: newTable[TLineInfo, ProfileInfo]())
+
 proc newConfigRef*(): ConfigRef =
   result = ConfigRef(
     selectedGC: gcRefc,
@@ -443,6 +454,7 @@ proc newConfigRef*(): ConfigRef =
     arguments: "",
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
+    vmProfileData: newProfileData(),
   )
   setTargetFromSystem(result.target)
   # enable colors by default on terminals

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -95,6 +95,7 @@ type                          # please make sure we have under 32 options
     optPanics                 # turn panics (sysFatal) into a process termination
     optNimV1Emulation         # emulate Nim v1.0
     optSourcemap
+    optProfileVM              # enable VM profiler
 
   TGlobalOptions* = set[TGlobalOption]
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -16,7 +16,7 @@ import
   strutils, msgs, vmdef, vmgen, nimsets, types, passes,
   parser, vmdeps, idents, trees, renderer, options, transf, parseutils,
   vmmarshal, gorgeimpl, lineinfos, tables, btrees, macrocacheimpl,
-  modulegraphs, sighashes, int128, times, std/private/miscdollars
+  modulegraphs, sighashes, int128, vmprofiler
 
 from semfold import leValueConv, ordinalValToString
 from evaltempl import evalTemplate
@@ -516,44 +516,6 @@ template maybeHandlePtr(node2: PNode, reg: TFullReg, isAssign2: bool): bool =
 
 when not defined(nimHasSinkInference):
   {.pragma: nosinks.}
-
-proc dump(p: var Profiler, c: PCtx) =
-  if optProfileVM in c.config.globalOptions:
-    echo "\nprof:     µs     count  location"
-    var data = c.profiler.data
-    for i in 0..<32:
-      var tMax: float
-      var infoMax: ProfileInfo
-      var flMax: TLineInfo
-      for fl, info in data:
-        if info.time > infoMax.time:
-          infoMax = info
-          flMax = fl
-      if infoMax.count == 0:
-        break
-      var msg = "  " & align($int(infoMax.time * 1e6), 10) &
-                       align($int(infoMax.count), 10) & "  "
-      toLocation(msg, c.config.toMsgFilename(flMax.fileIndex), flMax.line.int, 0)
-      echo msg
-      data.del flMax
-
-proc enter(prof: var Profiler, c: PCtx, tos: PStackFrame) {.inline.} =
-  if optProfileVM in c.config.globalOptions:
-    prof.tEnter = cpuTime()
-    prof.tos = tos
-
-proc leave(prof: var Profiler, c: PCtx) {.inline.} =
-  if optProfileVM in c.config.globalOptions:
-    let tLeave = cpuTime()
-    var tos = prof.tos
-    while tos != nil:
-      if tos.prc != nil:
-        let li = TLineInfo(fileIndex: tos.prc.info.fileIndex, line: tos.prc.info.line)
-        if li notin c.profiler.data:
-          c.profiler.data[li] = ProfileInfo()
-        c.profiler.data[li].time += tLeave - prof.tEnter
-        inc c.profiler.data[li].count
-      tos = tos.next
 
 proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
   var pc = start

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2076,7 +2076,6 @@ proc execute(c: PCtx, start: int): PNode =
   var tos = PStackFrame(prc: nil, comesFrom: 0, next: nil)
   newSeq(tos.slots, c.prc.maxSlots)
   result = rawExecute(c, start, tos).regToNode
-  c.profiler.dump(c)
 
 proc execProc*(c: PCtx; sym: PSym; args: openArray[PNode]): PNode =
   if sym.kind in routineKinds:
@@ -2099,7 +2098,6 @@ proc execProc*(c: PCtx; sym: PSym; args: openArray[PNode]): PNode =
         putIntoReg(tos.slots[i], args[i-1])
 
       result = rawExecute(c, start, tos).regToNode
-      c.profiler.dump(c)
   else:
     localError(c.config, sym.info,
       "NimScript: attempt to call non-routine: " & sym.name.s)
@@ -2174,7 +2172,6 @@ proc evalConstExprAux(module: PSym;
   result = rawExecute(c, start, tos).regToNode
   if result.info.col < 0: result.info = n.info
   c.mode = oldMode
-  c.profiler.dump(c)
 
 proc evalConstExpr*(module: PSym; g: ModuleGraph; e: PNode): PNode =
   result = evalConstExprAux(module, g, nil, e, emConst)
@@ -2293,4 +2290,3 @@ proc evalMacroCall*(module: PSym; g: ModuleGraph;
   dec(g.config.evalMacroCounter)
   c.callsite = nil
   c.mode = oldMode
-  c.profiler.dump(c)

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -10,7 +10,7 @@
 ## This module contains the type definitions for the new evaluation engine.
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
-import ast, idents, options, modulegraphs, lineinfos
+import ast, idents, options, modulegraphs, lineinfos, tables, hashes
 
 type TInstrType* = uint64
 
@@ -261,10 +261,20 @@ type
     config*: ConfigRef
     graph*: ModuleGraph
     oldErrorCount*: int
+    profile*: Profile
+
+  FileLine* = object
+    fileIndex*: FileIndex
+    line*: uint16
+
+  Profile* = Table[FileLine, float]
 
   TPosition* = distinct int
 
   PEvalContext* = PCtx
+
+proc hash*(f: FileLine): Hash =
+  f.line.int * 32768 + f.fileIndex.int
 
 proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph): PCtx =
   PCtx(code: @[], debug: @[],

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -261,13 +261,26 @@ type
     config*: ConfigRef
     graph*: ModuleGraph
     oldErrorCount*: int
-    profile*: Profile
+    profiler*: Profiler
 
+  PStackFrame* = ref TStackFrame
+  TStackFrame* = object
+    prc*: PSym                 # current prc; proc that is evaluated
+    slots*: seq[TFullReg]      # parameters passed to the proc + locals;
+                              # parameters come first
+    next*: PStackFrame         # for stacking
+    comesFrom*: int
+    safePoints*: seq[int]      # used for exception handling
+                              # XXX 'break' should perform cleanup actions
+                              # What does the C backend do for it?
   ProfileInfo* = object
     time*: float
     count*: int
 
-  Profile* = Table[TLineInfo, ProfileInfo]
+  Profiler* = object
+    tEnter*: float
+    tos*: PStackFrame
+    data*: Table[TLineInfo, ProfileInfo]
 
   TPosition* = distinct int
 

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -274,7 +274,9 @@ type
   PEvalContext* = PCtx
 
 proc hash*(f: FileLine): Hash =
-  f.line.int * 32768 + f.fileIndex.int
+  result = result !& f.line.int
+  result = result !& f.fileIndex.int
+  result = !$ result
 
 proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph): PCtx =
   PCtx(code: @[], debug: @[],

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -287,7 +287,7 @@ type
   PEvalContext* = PCtx
 
 proc hash*(i: TLineInfo): Hash =
-  hash([i.line.int, i.col.int, i.fileIndex.int])
+  hash (i.line.int, i.col.int, i.fileIndex.int)
 
 proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph): PCtx =
   PCtx(code: @[], debug: @[],

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -287,7 +287,7 @@ type
   PEvalContext* = PCtx
 
 proc hash*(i: TLineInfo): Hash =
-  result = !$(i.line.int !& i.col.int !& i.fileIndex.int)
+  hash([i.line.int, i.col.int, i.fileIndex.int])
 
 proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph): PCtx =
   PCtx(code: @[], debug: @[],

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -263,20 +263,18 @@ type
     oldErrorCount*: int
     profile*: Profile
 
-  FileLine* = object
-    fileIndex*: FileIndex
-    line*: uint16
+  ProfileInfo* = object
+    time*: float
+    count*: int
 
-  Profile* = Table[FileLine, float]
+  Profile* = Table[TLineInfo, ProfileInfo]
 
   TPosition* = distinct int
 
   PEvalContext* = PCtx
 
-proc hash*(f: FileLine): Hash =
-  result = result !& f.line.int
-  result = result !& f.fileIndex.int
-  result = !$ result
+proc hash*(i: TLineInfo): Hash =
+  result = !$(i.line.int !& i.col.int !& i.fileIndex.int)
 
 proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph): PCtx =
   PCtx(code: @[], debug: @[],

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -10,7 +10,7 @@
 ## This module contains the type definitions for the new evaluation engine.
 ## An instruction is 1-3 int32s in memory, it is a register based VM.
 
-import ast, idents, options, modulegraphs, lineinfos, tables, hashes
+import ast, idents, options, modulegraphs, lineinfos
 
 type TInstrType* = uint64
 
@@ -273,21 +273,13 @@ type
     safePoints*: seq[int]      # used for exception handling
                               # XXX 'break' should perform cleanup actions
                               # What does the C backend do for it?
-  ProfileInfo* = object
-    time*: float
-    count*: int
-
   Profiler* = object
     tEnter*: float
     tos*: PStackFrame
-    data*: Table[TLineInfo, ProfileInfo]
 
   TPosition* = distinct int
 
   PEvalContext* = PCtx
-
-proc hash*(i: TLineInfo): Hash =
-  hash (i.line.int, i.col.int, i.fileIndex.int)
 
 proc newCtx*(module: PSym; cache: IdentCache; g: ModuleGraph): PCtx =
   PCtx(code: @[], debug: @[],

--- a/compiler/vmprofiler.nim
+++ b/compiler/vmprofiler.nim
@@ -24,7 +24,7 @@ proc leave*(prof: var Profiler, c: PCtx) {.inline.} =
 
 proc dump*(conf: ConfigRef, pd: ProfileData): string =
   var data = pd.data
-  echo "\nprof:     µs     count  location"
+  echo "\nprof:     µs    #instr  location"
   for i in 0..<32:
     var tMax: float
     var infoMax: ProfileInfo

--- a/compiler/vmprofiler.nim
+++ b/compiler/vmprofiler.nim
@@ -1,0 +1,42 @@
+
+import
+  options, vmdef, times, std/private/miscdollars, lineinfos, strutils, tables,
+  msgs
+  
+proc enter*(prof: var Profiler, c: PCtx, tos: PStackFrame) {.inline.} =
+  if optProfileVM in c.config.globalOptions:
+    prof.tEnter = cpuTime()
+    prof.tos = tos
+
+proc leave*(prof: var Profiler, c: PCtx) {.inline.} =
+  if optProfileVM in c.config.globalOptions:
+    let tLeave = cpuTime()
+    var tos = prof.tos
+    while tos != nil:
+      if tos.prc != nil:
+        let li = TLineInfo(fileIndex: tos.prc.info.fileIndex, line: tos.prc.info.line)
+        if li notin c.profiler.data:
+          c.profiler.data[li] = ProfileInfo()
+        c.profiler.data[li].time += tLeave - prof.tEnter
+        inc c.profiler.data[li].count
+      tos = tos.next
+
+proc dump*(p: var Profiler, c: PCtx) =
+  if optProfileVM in c.config.globalOptions:
+    echo "\nprof:     µs     count  location"
+    var data = c.profiler.data
+    for i in 0..<32:
+      var tMax: float
+      var infoMax: ProfileInfo
+      var flMax: TLineInfo
+      for fl, info in data:
+        if info.time > infoMax.time:
+          infoMax = info
+          flMax = fl
+      if infoMax.count == 0:
+        break
+      var msg = "  " & align($int(infoMax.time * 1e6), 10) &
+                       align($int(infoMax.count), 10) & "  "
+      toLocation(msg, c.config.toMsgFilename(flMax.fileIndex), flMax.line.int, 0)
+      echo msg
+      data.del flMax

--- a/compiler/vmprofiler.nim
+++ b/compiler/vmprofiler.nim
@@ -14,7 +14,7 @@ proc leave*(prof: var Profiler, c: PCtx) {.inline.} =
     var tos = prof.tos
     while tos != nil:
       if tos.prc != nil:
-        let li = TLineInfo(fileIndex: tos.prc.info.fileIndex, line: tos.prc.info.line)
+        let li = tos.prc.info
         if li notin c.profiler.data:
           c.profiler.data[li] = ProfileInfo()
         c.profiler.data[li].time += tLeave - prof.tEnter
@@ -35,8 +35,7 @@ proc dump*(p: var Profiler, c: PCtx) =
           flMax = fl
       if infoMax.count == 0:
         break
-      var msg = "  " & align($int(infoMax.time * 1e6), 10) &
-                       align($int(infoMax.count), 10) & "  "
-      toLocation(msg, c.config.toMsgFilename(flMax.fileIndex), flMax.line.int, 0)
-      echo msg
+      echo  "  " & align($int(infoMax.time * 1e6), 10) &
+                   align($int(infoMax.count), 10) & "  " &
+                   c.config.toFileLineCol(flMax)
       data.del flMax

--- a/compiler/vmprofiler.nim
+++ b/compiler/vmprofiler.nim
@@ -19,7 +19,8 @@ proc leave*(prof: var Profiler, c: PCtx) {.inline.} =
         if li notin data:
           data[li] = ProfileInfo()
         data[li].time += tLeave - prof.tEnter
-        inc data[li].count
+        if tos == prof.tos:
+          inc data[li].count
       tos = tos.next
 
 proc dump*(conf: ConfigRef, pd: ProfileData): string =

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -150,5 +150,6 @@ Advanced options:
                             works better with `--stackTrace:on`
                             see also https://nim-lang.github.io/Nim/estp.html
   --benchmarkVM:on|off      enable benchmarking of VM code with cpuTime()
+  --profileVM:on|off        enable compile time VM profiler
   --sinkInference:on|off    en-/disable sink parameter inference (default: on)
   --panics:on|off           turn panics into process terminations (default: off)


### PR DESCRIPTION
The profiler hooks into the inner loop of `rawExecute` and counts the inclusive/accumulative total time spent on each stack frame. 

Can be enabled with `--profileVM:on`

Output is written to stdout at compile time and looks something like this:

```
prof:     µs    #instr  location
      393274    324939  /home/ico/external/Nim/compiler/cgen.nim(121, 7)
      190945    257528  /home/ico/external/Nim/lib/system.nim(2952, 6)
      147458       616  /home/ico/external/Nim/lib/pure/strutils.nim(2131, 6)
       91713        17  /home/ico/external/Nim/lib/pure/strutils.nim(2770, 6)
       90879    136833  /home/ico/external/Nim/lib/pure/strutils.nim(2707, 6)
       69290        35  /home/ico/external/Nim/lib/system.nim(2973, 6)
       67004    100068  /home/ico/external/Nim/lib/pure/strutils.nim(1888, 6)
       44715       288  /home/ico/external/Nim/lib/pure/strutils.nim(2117, 6)
       44288       672  /home/ico/external/Nim/lib/pure/strutils.nim(1969, 6)
       41896     58468  /home/ico/external/Nim/lib/pure/strutils.nim(1869, 6)
       31696     39215  /home/ico/external/Nim/lib/system/assertions.nim(11, 6)
       17989      2099  /home/ico/external/Nim/lib/pure/strutils.nim(1267, 7)
       17357     22582  /home/ico/external/Nim/lib/core/macros.nim(637, 6)
       11308     15410  /home/ico/external/Nim/lib/pure/strutils.nim(282, 6)
       10792      8628  /home/ico/external/Nim/lib/pure/strformat.nim(526, 6)
        8777     13312  /home/ico/external/Nim/compiler/bitsets.nim(82, 10)
```
