### PR TITLE
Fix nimdoc invalid css on theme switch class

### DIFF
--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -63,12 +63,13 @@ Modified by Boyd Greenfield and narimiran
 .theme-switch-wrapper {
   display: flex;
   align-items: center;
-
-  em {
-    margin-left: 10px;
-    font-size: 1rem;
-  }
 }
+
+.theme-switch-wrapper em {
+  margin-left: 10px;
+  font-size: 1rem;
+}
+
 .theme-switch {
   display: inline-block;
   height: 22px;


### PR DESCRIPTION
For some reason, there was an invalid css syntax on the `nimdoc.css` file. This PR fixes that 😆 