### PR TITLE
docs: Make `..<`, `.. ^` more discoverable

### DIFF
--- a/lib/system_overview.rst
+++ b/lib/system_overview.rst
@@ -45,24 +45,27 @@ Proc                              Usage
 Seqs
 ----
 
-========================================   ==========================================
-Proc                                       Usage
-========================================   ==========================================
-`newSeq<#newSeq>`_                         Create a new sequence of a given length
-`newSeqOfCap<#newSeqOfCap,Natural>`_       Create a new sequence with zero length
-                                           and a given capacity
-`setLen<#setLen,seq[T][T],Natural>`_       Set the length of a sequence
-`len<#len,seq[T][T]>`_                     Return the length of a sequence
-`@<#@,array[IDX,T]>`_                      Turn an array into a sequence
-`add<#add,seq[T][T],T>`_                   Add an item to the sequence
-`insert<#insert,seq[T][T],T>`_             Insert an item at a specific position
-`delete<#delete,seq[T][T],Natural>`_       Delete an item while preserving the
-                                           order of elements (`O(n)` operation)
-`del<#del,seq[T][T],Natural>`_             `O(1)` removal, doesn't preserve the order
-`pop<#pop,seq[T][T]>`_                     Remove and return last item of a sequence
-`x & y<#&,seq[T][T],seq[T][T]>`_           Concatenate two sequences
-`x[a..b]<#[],openArray[T],HSlice[U,V]>`_   Slice of a sequence (both ends included)
-========================================   ==========================================
+===========================================   ==========================================
+Proc                                          Usage
+===========================================   ==========================================
+`newSeq<#newSeq>`_                            Create a new sequence of a given length
+`newSeqOfCap<#newSeqOfCap,Natural>`_          Create a new sequence with zero length
+                                              and a given capacity
+`setLen<#setLen,seq[T][T],Natural>`_          Set the length of a sequence
+`len<#len,seq[T][T]>`_                        Return the length of a sequence
+`@<#@,array[IDX,T]>`_                         Turn an array into a sequence
+`add<#add,seq[T][T],T>`_                      Add an item to the sequence
+`insert<#insert,seq[T][T],T>`_                Insert an item at a specific position
+`delete<#delete,seq[T][T],Natural>`_          Delete an item while preserving the
+                                              order of elements (`O(n)` operation)
+`del<#del,seq[T][T],Natural>`_                `O(1)` removal, doesn't preserve the order
+`pop<#pop,seq[T][T]>`_                        Remove and return last item of a sequence
+`x & y<#&,seq[T][T],seq[T][T]>`_              Concatenate two sequences
+`x[a..b]<#[],openArray[T],HSlice[U,V]>`_      Slice of a sequence (both ends included)
+`x[a..^b]<#[],openArray[T],HSlice[U,V]>`_     Slice of a sequence but `b` is a 
+                                              reversed index (both ends included)
+`x[a..\<b]<#[],openArray[T],HSlice[U,V]>`_    Slice of a sequence (excluded upper bound)
+===========================================   ==========================================
 
 **See also:**
 * `sequtils module <sequtils.html>`_ for operations on container
@@ -160,8 +163,10 @@ Proc                                           Usage
 `T or F<#or,bool,bool>`_                       Boolean `or`
 `T xor F<#xor,bool,bool>`_                     Boolean `xor` (exclusive or)
 `not T<#not,bool>`_                            Boolean `not`
+`a[^x]<#^.t,int>`_                             Take the element at the reversed index `x`
 `a .. b<#..,T,U>`_                             Binary slice that constructs an interval
                                                `[a, b]`
+`a ..^ b<#..^.t,untyped,untyped>`_             Interval `[a, b]` but `b` as reversed index
 [a ..< b](#..<.t,untyped,untyped)              Interval `[a, b)` (excluded upper bound)
 [runnableExamples](#runnableExamples,untyped)  Create testable documentation
 =============================================  ============================================


### PR DESCRIPTION
Fixes #14717 by providing the requested slice operators at misc and seqs tables.