### PR TITLE
Faster --stacktrace:on by avoiding linked list

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -145,7 +145,7 @@ proc assignLabel(b: var TBlock): Rope {.inline.} =
 proc blockBody(b: var TBlock): Rope =
   result = b.sections[cpsLocals]
   if b.frameLen > 0:
-    result.addf("FR_.len+=$1;$n", [b.frameLen.rope])
+    result.addf("FR_.len+=$1;$n", [b.frameLen.rope]) # PRTEMP
   result.add(b.sections[cpsInit])
   result.add(b.sections[cpsStmts])
 
@@ -163,7 +163,7 @@ proc endBlock(p: BProc) =
   let frameLen = p.blocks[topBlock].frameLen
   var blockEnd: Rope
   if frameLen > 0:
-    blockEnd.addf("FR_.len-=$1;$n", [frameLen.rope])
+    blockEnd.addf("FR_.len-=$1;$n", [frameLen.rope]) # PRTEMP
   if p.blocks[topBlock].label != nil:
     blockEnd.addf("} $1: ;$n", [p.blocks[topBlock].label])
   else:

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -145,7 +145,7 @@ proc assignLabel(b: var TBlock): Rope {.inline.} =
 proc blockBody(b: var TBlock): Rope =
   result = b.sections[cpsLocals]
   if b.frameLen > 0:
-    result.addf("FR_.len+=$1;$n", [b.frameLen.rope]) # PRTEMP
+    result.addf("FR_.len+=$1;$n", [b.frameLen.rope]) # deadcode
   result.add(b.sections[cpsInit])
   result.add(b.sections[cpsStmts])
 
@@ -163,7 +163,7 @@ proc endBlock(p: BProc) =
   let frameLen = p.blocks[topBlock].frameLen
   var blockEnd: Rope
   if frameLen > 0:
-    blockEnd.addf("FR_.len-=$1;$n", [frameLen.rope]) # PRTEMP
+    blockEnd.addf("FR_.len-=$1;$n", [frameLen.rope]) # deadcode
   if p.blocks[topBlock].label != nil:
     blockEnd.addf("} $1: ;$n", [p.blocks[topBlock].label])
   else:

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -948,7 +948,7 @@ proc genRestoreFrameAfterException(p: BProc) =
   if optStackTrace in p.module.config.options:
     if hasCurFramePointer notin p.flags:
       p.flags.incl hasCurFramePointer
-      p.procSec(cpsLocals).add(ropecg(p.module, "\tTFrame* _nimCurFrame;$n", []))
+      p.procSec(cpsLocals).add(ropecg(p.module, "\tNU _nimCurFrame;$n", []))
       p.procSec(cpsInit).add(ropecg(p.module, "\t_nimCurFrame = #getFrame();$n", []))
     linefmt(p, cpsStmts, "#setFrame(_nimCurFrame);$n", [])
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1706,7 +1706,7 @@ proc genInitCode(m: BModule) =
         var procname = makeCString(m.module.name.s)
         prc.add(initFrame(m.initProc, m.module.info, procname, quotedFilename(m.config, m.module.info)))
       else:
-        prc.add(~"\tTFrame FR_; FR_.len = 0;$N")
+        prc.add(~"\tTFrame FR_; FR_.len = 0;$N") # PRTEMP
 
     writeSection(initProc, cpsInit, m.hcrOn)
     writeSection(initProc, cpsStmts)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -645,7 +645,7 @@ $1 define nimRefreshFile(file, line) #nimRefreshFile2(file, line)
 $1 define nimRefreshLine(line) #nimRefreshLine2(line)
 """
   #[
-  dead code that could be revived one day
+  deadcode that could be revived (see `endb`)
   $1  define nimfrs_(proc, file, slots, length) \
       struct {TFrame* prev;NCSTRING procname;NI line;NCSTRING filename; NI len; VarSlot s[slots];} FR_; \
       FR_.procname = proc; FR_.filename = file; FR_.line = 0; FR_.len = length; #nimFrame((TFrame*)&FR_);
@@ -1692,7 +1692,7 @@ proc genInitCode(m: BModule) =
     # Give this small function its own scope
     prc.addf("{$N", [])
     # Keep a bogus frame in case the code needs one
-    # prc.add(~"\tTFrame FR_; FR_.len = 0;$N")
+    # prc.add(~"\tTFrame FR_; FR_.len = 0;$N") # deadcode: FR_.len = 0
 
     writeSection(preInitProc, cpsLocals)
     writeSection(preInitProc, cpsInit, m.hcrOn)
@@ -1718,7 +1718,8 @@ proc genInitCode(m: BModule) =
         var procname = makeCString(m.module.name.s)
         prc.add(initFrame(m.initProc, m.module.info, procname, quotedFilename(m.config, m.module.info)))
       else:
-        prc.add(~"\tTFrame FR_; FR_.len = 0;$N") # PRTEMP
+        # prc.add(~"\tTFrame FR_; FR_.len = 0;$N") # deadcode
+        prc.add(~"\tTFrame FR_; $N")
 
     writeSection(initProc, cpsInit, m.hcrOn)
     writeSection(initProc, cpsStmts)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -623,7 +623,8 @@ $1 define nimfr_(procname, filename, line2) \
   #nimFrame(procname, filename, line2); \
 
 $1 define nimln_(line2, file) \
-  #nimLine(file, line2)
+  #nimLine2(line2) \
+  // #nimLine(file, line2)
 """
   #[
   dead code that could be revived one day
@@ -635,12 +636,13 @@ $1 define nimln_(line2, file) \
     appcg(p.module, p.module.s[cfsFrameDefines], frameDefines, ["#"])
 
   discard cgsym(p.module, "nimFrame")
-  var line = 1
-  if p.prc != nil and p.prc.ast != nil:
-    line = p.prc.ast.info.line.int
-  result = ropecg(p.module, "\tnimfr_($1, $2, $3);$n", [procname, filename, line])
-  if p.prc != nil and p.prc.ast != nil:
-    genLineDir(p, p.prc.ast.info)
+  # var line = 1
+  # if p.prc != nil and p.prc.ast != nil:
+  #   line = p.prc.ast.info.line.int
+  # result = ropecg(p.module, "\tnimfr_($1, $2, $3);$n", [procname, filename, line])
+  # if p.prc != nil and p.prc.ast != nil:
+  #   genLineDir(p, p.prc.ast.info)
+  result = ropecg(p.module, "\tnimfr_($1, $2, $3);$n", [procname, filename, 0])
 
 proc initFrameNoDebug(p: BProc; frame, procname, filename: Rope; line: int): Rope =
   # TODO: see where this comes from, needs to be updated

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -643,13 +643,14 @@ $1 define nimRefreshLine(line) #nimRefreshLine2(line)
 
   discard cgsym(p.module, nimFrame)
   p.lastLineInfo.fileIndex = info.fileIndex # CHECKME
-  # var line = 1
+  var line = 0
+
+  # this incurs a small cost and may not be needed since 1st statement will update line:
   # if p.prc != nil and p.prc.ast != nil:
   #   line = p.prc.ast.info.line.int
-  # result = ropecg(p.module, "\tnimfr_($1, $2, $3);$n", [procname, filename, line])
-  # if p.prc != nil and p.prc.ast != nil:
-  #   genLineDir(p, p.prc.ast.info)
-  result = ropecg(p.module, "\tnimfr_($1, $2, $3);$n", [procname, filename, 0])
+
+  result = ropecg(p.module, "\tnimfr_($1, $2, $3);$n", [procname, filename, line])
+  if line != 0: genLineDir(p, p.prc.ast.info)
 
 proc initFrameNoDebug(p: BProc; frame, procname, filename: Rope; line: int): Rope =
   # TODO: see where this comes from, needs to be updated

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -196,6 +196,10 @@ proc newProc*(prc: PSym, module: BModule): BProc =
   result.nestedTryStmts = @[]
   result.finallySafePoints = @[]
   result.sigConflicts = initCountTable[string]()
+  if prc != nil:
+    result.lastLineInfo = prc.info
+  else:
+    result.lastLineInfo = module.module.info
 
 proc newModuleList*(g: ModuleGraph): BModuleList =
   BModuleList(typeInfoMarker: initTable[SigHash, tuple[str: Rope, owner: PSym]](),

--- a/compiler/cgendata.nim
+++ b/compiler/cgendata.nim
@@ -62,7 +62,7 @@ type
     isLoop*: bool             # whether block is a loop
     nestedTryStmts*: int16    # how many try statements is it nested into
     nestedExceptStmts*: int16 # how many except statements is it nested into
-    frameLen*: int16
+    frameLen*: int16          # deadcode, currently always 0 (remnant from `endb`)
 
   TCProcFlag* = enum
     beforeRetNeeded,

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -119,3 +119,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasStacktraceMsgs")
   defineSymbol("nimDoesntTrackDefects")
   defineSymbol("nimHasLentIterators")
+  defineSymbol("nimHasCgenVersion1")

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -427,6 +427,8 @@ proc noAbsolutePaths(conf: ConfigRef): bool {.inline.} =
   # `optGenMapping` is included here for niminst.
   result = conf.globalOptions * {optGenScript, optGenMapping} != {}
 
+const NIM_CGEN_VERSION = 1
+
 proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string =
   result = conf.compileOptions
   addOpt(result, conf.cfileSpecificOptions.getOrDefault(fullNimFile))
@@ -449,6 +451,8 @@ proc cFileSpecificOptions(conf: ConfigRef; nimname, fullNimFile: string): string
     else: addOpt(result, getOptSize(conf, conf.cCompiler))
   let key = nimname & ".always"
   if existsConfigVar(conf, key): addOpt(result, getConfigVar(conf, key))
+
+  result.add " -DNIM_CGEN_VERSION=$1 " % $NIM_CGEN_VERSION
 
 proc getCompileOptions(conf: ConfigRef): string =
   result = cFileSpecificOptions(conf, "__dummy__", "__dummy__")

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -34,7 +34,8 @@ proc toCChar*(c: char; result: var string) =
     result.add c
 
 proc makeCString*(s: string): Rope =
-  const MaxLineLength = 64
+  const MaxLineLength = 128
+    # WAS: 64 ; what's the point of this limit? it results in broken strings (include filenames in cgen files)
   result = nil
   var res = newStringOfCap(int(s.len.toFloat * 1.1) + 1)
   res.add("\"")

--- a/koch.nim.cfg
+++ b/koch.nim.cfg
@@ -5,3 +5,11 @@
   # workaround see https://github.com/nim-lang/Nim/pull/14291
   --lib:lib
 @end
+
+@if nimHasCgenVersion1:
+@else:
+  # for bootstrap.
+  # `FR_` etc are no longer there; we could also add more logic to support this
+  # during bootstrap but it may not be worth it
+  --stacktrace:off
+@end

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -521,15 +521,6 @@ typedef char* NCSTRING;
   } TFrame;
 #endif
 
-#if NIM_CGEN_VERSION == 1
-  // PRTEMP
-  typedef struct {
-    NCSTRING procname;
-    NI line;
-    NCSTRING filename;
-  } TFrame;
-#endif
-
 #define NIM_POSIX_INIT  __attribute__((constructor))
 
 #ifdef __GNUC__

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -100,9 +100,8 @@ __AVR__
   /* these should support C99's inline */
   /* the test for __POCC__ has to come before the test for _MSC_VER,
      because PellesC defines _MSC_VER too. This is brain-dead. */
-//#  define N_INLINE(rettype, name) inline rettype name
-// #  define N_INLINE(rettype, name) inline rettype name
-#  define N_INLINE(rettype, name) __attribute__((always_inline)) rettype name
+#  define N_INLINE(rettype, name) inline rettype name
+// #  define N_INLINE(rettype, name) __attribute__((always_inline)) rettype name
 #elif defined(__BORLANDC__) || defined(_MSC_VER)
 /* Borland's compiler is really STRANGE here; note that the __fastcall
    keyword cannot be before the return type, but __inline cannot be after

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -24,6 +24,12 @@ __AVR__
 #ifndef NIMBASE_H
 #define NIMBASE_H
 
+#ifndef NIM_CGEN_VERSION
+  // We increment `NIM_CGEN_VERSION` each time a change is needed, this is
+  // used to make bootstrapping work when changes are needed in this file.
+  #define NIM_CGEN_VERSION 0
+#endif
+
 /*------------ declaring a custom attribute to support using LLVM's Address Sanitizer ------------ */
 
 /*
@@ -87,13 +93,16 @@ __AVR__
 #  define __DECLSPEC_SUPPORTED 1
 #endif
 
+
 /* calling convention mess ----------------------------------------------- */
 #if defined(__GNUC__) || defined(__LCC__) || defined(__POCC__) \
                       || defined(__TINYC__)
   /* these should support C99's inline */
   /* the test for __POCC__ has to come before the test for _MSC_VER,
      because PellesC defines _MSC_VER too. This is brain-dead. */
-#  define N_INLINE(rettype, name) inline rettype name
+//#  define N_INLINE(rettype, name) inline rettype name
+// #  define N_INLINE(rettype, name) inline rettype name
+#  define N_INLINE(rettype, name) __attribute__((always_inline)) rettype name
 #elif defined(__BORLANDC__) || defined(_MSC_VER)
 /* Borland's compiler is really STRANGE here; note that the __fastcall
    keyword cannot be before the return type, but __inline cannot be after
@@ -503,16 +512,24 @@ typedef char* NCSTRING;
 #  endif
 #endif
 
-typedef struct TFrame_ TFrame;
-struct TFrame_ {
-  TFrame* prev;
-  NCSTRING procname;
-  NI line;
-  NCSTRING filename;
-  NI16 len;
-  NI16 calldepth;
-  NI frameMsgLen;
-};
+#if NIM_CGEN_VERSION < 1
+  typedef struct {
+    NCSTRING procname;
+    NI line;
+    NCSTRING filename;
+    NI16 len;
+    NI frameMsgLen;
+  } TFrame;
+#endif
+
+#if NIM_CGEN_VERSION == 1
+  // PRTEMP
+  typedef struct {
+    NCSTRING procname;
+    NI line;
+    NCSTRING filename;
+  } TFrame;
+#endif
 
 #define NIM_POSIX_INIT  __attribute__((constructor))
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -25,8 +25,8 @@ __AVR__
 #define NIMBASE_H
 
 #ifndef NIM_CGEN_VERSION
-  // We increment `NIM_CGEN_VERSION` each time a change is needed, this is
-  // used to make bootstrapping work when changes are needed in this file.
+  // We increment `NIM_CGEN_VERSION` each time an incompatible change is needed,
+  // this is used to make bootstrapping work.
   #define NIM_CGEN_VERSION 0
 #endif
 
@@ -93,7 +93,6 @@ __AVR__
 #  define __DECLSPEC_SUPPORTED 1
 #endif
 
-
 /* calling convention mess ----------------------------------------------- */
 #if defined(__GNUC__) || defined(__LCC__) || defined(__POCC__) \
                       || defined(__TINYC__)
@@ -101,7 +100,6 @@ __AVR__
   /* the test for __POCC__ has to come before the test for _MSC_VER,
      because PellesC defines _MSC_VER too. This is brain-dead. */
 #  define N_INLINE(rettype, name) inline rettype name
-// #  define N_INLINE(rettype, name) __attribute__((always_inline)) rettype name
 #elif defined(__BORLANDC__) || defined(_MSC_VER)
 /* Borland's compiler is really STRANGE here; note that the __fastcall
    keyword cannot be before the return type, but __inline cannot be after

--- a/lib/std/stackframes.nim
+++ b/lib/std/stackframes.nim
@@ -18,10 +18,10 @@ template setFrameMsg*(msg: string, prefix = " ") =
   ## in a given PFrame. Noop unless passing --stacktraceMsgs and --stacktrace
   when NimStackTrace and NimStackTraceMsgs:
     block:
-      let msg2 = msg # BUGFIX!! TODO: shallow?
+      let msg2 = msg # in case it changes the frame, or invalidates due to realloc; TODO: shallow?
       var fr = getCurrentFrame()
       # consider setting a custom upper limit on size (analog to stack overflow)
       frameMsgBuf.setLen fr.frameMsgLen
       frameMsgBuf.add prefix
       frameMsgBuf.add msg2
-      fr.frameMsgLen += prefix.len + msg2.len
+      fr.frameMsgLen = frameMsgBuf.len

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1912,16 +1912,13 @@ var
 type
   PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;
                         ## part of the debugger API.
-  # keep in sync with nimbase.h `struct TFrame_`
   TFrame* {.final.} = object ## The frame itself.
-  # TFrame* {.final, importc, nodecl.} = object ## The frame itself.
     procname*: cstring  ## Name of the proc that is currently executing.
     line*: int          ## Line number of the proc that is currently executing.
     filename*: cstring  ## Filename of the proc that is currently executing.
-    # len*: int16         ## Length of the inspectable slots. PRTEMP
+    # xxx in future work, these should be accessible through a lookup table.
     when NimStackTraceMsgs:
       frameMsgLen*: int   ## end position in frameMsgBuf for this frame.
-    # TODO: cache filename, procname
 
 when defined(js):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1913,15 +1913,15 @@ type
   PFrame* = ptr TFrame  ## Represents a runtime frame of the call stack;
                         ## part of the debugger API.
   # keep in sync with nimbase.h `struct TFrame_`
-  TFrame* {.importc, nodecl, final.} = object ## The frame itself.
-    prev*: PFrame       ## Previous frame; used for chaining the call stack.
+  TFrame* {.final.} = object ## The frame itself.
+  # TFrame* {.final, importc, nodecl.} = object ## The frame itself.
     procname*: cstring  ## Name of the proc that is currently executing.
     line*: int          ## Line number of the proc that is currently executing.
     filename*: cstring  ## Filename of the proc that is currently executing.
-    len*: int16         ## Length of the inspectable slots.
-    calldepth*: int16   ## Used for max call depth checking.
+    # len*: int16         ## Length of the inspectable slots. PRTEMP
     when NimStackTraceMsgs:
       frameMsgLen*: int   ## end position in frameMsgBuf for this frame.
+    # TODO: cache filename, procname
 
 when defined(js):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =

--- a/lib/system/embedded.nim
+++ b/lib/system/embedded.nim
@@ -15,8 +15,10 @@ proc chckRange(i, a, b: int): int {.inline, compilerproc.}
 proc chckRangeF(x, a, b: float): float {.inline, compilerproc.}
 proc chckNil(p: pointer) {.inline, compilerproc.}
 
-proc nimFrame(s: PFrame) {.compilerRtl, inl, exportc: "nimFrame".} = discard
+proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises: [].} = discard
 proc popFrame {.compilerRtl, inl.} = discard
+proc nimRefreshLine2(line: int) {.compilerRtl, inl, raises: [].} = discard
+proc nimRefreshFile2(filename: cstring, line: int) {.compilerRtl, inl, raises: [].} = discard
 
 proc setFrame(s: PFrame) {.compilerRtl, inl.} = discard
 proc pushSafePoint(s: PSafePoint) {.compilerRtl, inl.} = discard

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -612,6 +612,15 @@ proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises
     proc c_realloc(p: pointer, newsize: csize_t): pointer {.importc: "realloc", header: "<stdlib.h>".}
     # tframes = cast[type(tframes)](realloc0(tframes, sz*old, sz*tframesCap))
     frameData.tframes = cast[type(frameData.tframes)](c_realloc(frameData.tframes, cast[csize_t](sz*frameData.tframesCap)))
+    when NimStackTraceMsgs:
+      if frameData.frameIndex == 1:
+        # throw-away frame to avoid edge cases
+        let fr0 = getCurrentFrameInternal(0)
+        fr0.frameMsgLen = 0
+        fr0.procname = nil
+        fr0.filename = nil
+        fr0.line = 0
+
   let fr = getCurrentFrameInternal(frameData.frameIndex)
   when NimStackTraceMsgs:
     fr.frameMsgLen = getCurrentFrameInternal(frameData.frameIndex-1).frameMsgLen

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -564,6 +564,8 @@ proc callDepthLimitReached() {.noinline.} =
       "recursions instead.\n")
   quit(1)
 
+proc nimLine2(line: int) {.compilerRtl, inl, raises: [].} =
+    frameData.tframes[frameData.frameIndex].line = line
 proc nimLine(filename: cstring, line: int) {.compilerRtl, inl, raises: [].} =
   #[
   # TODO: compare apples to apples, eg wo nimLine only nimFrame
@@ -596,7 +598,8 @@ proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises
     frameData.tframes[frameData.frameIndex].frameMsgLen = frameData.tframes[frameData.frameIndex-1].frameMsgLen
   frameData.tframes[frameData.frameIndex].procname = procname
   frameData.tframes[frameData.frameIndex].filename = filename
-  frameData.tframes[frameData.frameIndex].line = line
+  # frameData.tframes[frameData.frameIndex].line = line
+  frameData.tframes[frameData.frameIndex].line = 0
   # tframes[frameIndex].len = 0 # CHECKME
   # frameData.nimFrameGuard = false
 

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -592,8 +592,9 @@ proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises
   frameData.tframes[frameData.frameIndex].procname = procname
   frameData.tframes[frameData.frameIndex].filename = filename
   frameData.tframes[frameData.frameIndex].line = line
-  # frameData.tframes[frameData.frameIndex].line = 0
-  # tframes[frameIndex].len = 0 # CHECKME
+  #[
+  could also inspect argument slots here.
+  ]#
 
 when defined(cpp) and appType != "lib" and not gotoBasedExceptions and
     not defined(js) and not defined(nimscript) and

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -94,7 +94,10 @@ proc setFrameState*(state: FrameState) {.compilerRtl, inl.} =
   excHandler = state.excHandler
   currException = state.currException
 
-proc getFrame*(): FrameIndex {.compilerRtl, inl.} = frameData.frameIndex
+proc getFrame*(): FrameIndex {.compilerRtl, inl.} = frameData.frameIndex # RENAME
+template getCurrentFrameIndexInternal*(): PFrame = frameData.frameIndex
+template getCurrentFrameInternal*(): PFrame = frameData.tframes[frameData.frameIndex].addr
+  ## re-exported in std/stackframes
 
 proc popFrame {.compilerRtl, inl.} =
   frameData.frameIndex.dec

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -581,10 +581,6 @@ proc nimRefreshFile2(filename: cstring, line: int) {.compilerRtl, inl, raises: [
 proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises: [].} =
   # TODO: how to ensure no GC used here? `noSideEffect and nogc` don't work for that
   frameData.frameIndex.inc
-  # if frameData.nimFrameGuard:
-  #   c_printf("nimFrame:%*s %s:%s %lld\n", frameIndex, "", filename, procname, frameIndex)
-  #   return
-  # frameData.nimFrameGuard = true
   if frameData.frameIndex == nimCallDepthLimit: callDepthLimitReached()
   if frameData.frameIndex >= cast[FrameIndex](frameData.tframesCap):
     const sz = sizeof(TFrame)

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -598,8 +598,8 @@ proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises
     frameData.tframes[frameData.frameIndex].frameMsgLen = frameData.tframes[frameData.frameIndex-1].frameMsgLen
   frameData.tframes[frameData.frameIndex].procname = procname
   frameData.tframes[frameData.frameIndex].filename = filename
-  # frameData.tframes[frameData.frameIndex].line = line
-  frameData.tframes[frameData.frameIndex].line = 0
+  frameData.tframes[frameData.frameIndex].line = line
+  # frameData.tframes[frameData.frameIndex].line = 0
   # tframes[frameIndex].len = 0 # CHECKME
   # frameData.nimFrameGuard = false
 

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -564,17 +564,17 @@ proc callDepthLimitReached() {.noinline.} =
       "recursions instead.\n")
   quit(1)
 
-proc nimLine2(line: int) {.compilerRtl, inl, raises: [].} =
+proc nimRefreshLine2(line: int) {.compilerRtl, inl, raises: [].} =
     frameData.tframes[frameData.frameIndex].line = line
-proc nimLine(filename: cstring, line: int) {.compilerRtl, inl, raises: [].} =
+
+proc nimRefreshFile2(filename: cstring, line: int) {.compilerRtl, inl, raises: [].} =
   #[
   # TODO: compare apples to apples, eg wo nimLine only nimFrame
-  TODO: no need for filename when we have nimFrame, since filename won't change
+  note that filename can change within a function because of templates
   SEE also:
   codegenDecl: "static __attribute__((__always_inline__)) $# $# $#"
   __attribute__ ((optimize(1)))
   ]#
-    # c_printf "D20200308T182538\n"
     frameData.tframes[frameData.frameIndex].filename = filename
     frameData.tframes[frameData.frameIndex].line = line
 

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -597,7 +597,6 @@ proc nimFrame(procname, filename: cstring, line: int) {.compilerRtl, inl, raises
   frameData.tframes[frameData.frameIndex].line = line
   # frameData.tframes[frameData.frameIndex].line = 0
   # tframes[frameIndex].len = 0 # CHECKME
-  # frameData.nimFrameGuard = false
 
 when defined(cpp) and appType != "lib" and not gotoBasedExceptions and
     not defined(js) and not defined(nimscript) and

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -66,17 +66,14 @@ type FrameIndex = uint
   # maybe use distinct?
 
 type FrameData = object
-  nimFrameGuard: bool
   tframesCap: int
   frameIndex: FrameIndex
     # more efficient than just relying on tframes.len, eg for tframes.setLen(len-1) we don't want to do any checks not call dtor etc
   tframes: ptr UncheckedArray[TFrame]
-  # tframes* array[1000, TFrame]
-  # tframes: seq[TFrame]
 
 var
-  # frameData {.threadvar.}: FrameData
-  frameData {.threadvar, exportc: "c_frameData".}: FrameData
+  frameData {.threadvar.}: FrameData
+  # frameData {.threadvar, exportc: "c_frameData".}: FrameData
 
   excHandler {.threadvar.}: PSafePoint
     # list of exception handlers

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -441,6 +441,7 @@ proc newObj(typ: PNimType, size: int): pointer {.compilerRtl.} =
   when defined(memProfiler): nimProfile(size)
 
 {.push overflowChecks: on.}
+{.push stackTrace: off.}
 proc newSeq(typ: PNimType, len: int): pointer {.compilerRtl.} =
   # `newObj` already uses locks, so no need for them here.
   let size = align(GenericSeqSize, typ.base.align) + len * typ.base.size
@@ -448,6 +449,7 @@ proc newSeq(typ: PNimType, len: int): pointer {.compilerRtl.} =
   cast[PGenericSeq](result).len = len
   cast[PGenericSeq](result).reserved = len
   when defined(memProfiler): nimProfile(size)
+{.pop.}
 {.pop.}
 
 proc newObjRC1(typ: PNimType, size: int): pointer {.compilerRtl.} =

--- a/tests/async/tasync_traceback.nim
+++ b/tests/async/tasync_traceback.nim
@@ -1,7 +1,5 @@
 discard """
-  exitcode: 0
   disabled: "windows"
-  output: "Matched"
 """
 import asyncdispatch, strutils
 
@@ -143,7 +141,4 @@ for i in 0 ..< resLines.len:
     echo resLines[i]
     ok = false
 
-if ok:
-  echo("Matched")
-else:
-  quit(QuitFailure)
+doAssert ok


### PR DESCRIPTION
* this is essentially the 1st part of https://github.com/nim-lang/Nim/pull/13630 which I'm splitting off for simplicity. It turns the linked list into a thread local growable array of TFrame as well as other optimizations
* also works with --stacktracemsgs:on|off; 
* fixes a "multiple evaluation" issue in `stackframes.setFrameMsg`

## example 1
nim r -d:danger --stacktrace:on --stacktracemsgs:off main.nim
before PR: 3.1s
after PR: 2.2s

```nim
when true:
  import times
  var x = 0.uint
  proc fun(i: uint) {.inline.} = x+=i
  proc main() =
    let t = cpuTime()
    let n = 1000_000_000
    for i in 0..<n:
      fun(cast[uint](i))
    echo cpuTime() - t
    doAssert x > 0
    echo x
    proc bar()=echo getStacktrace()
    bar()
  main()
```

## example 2
after compiling nim with `-d:release --stacktrace:on --stacktracemsgs:off`, compiling nim twice; the 2nd time takes 14.9s before PR and 11.7s after PR. I'm measuring the 2nd compilation because the 1st one involves unrelated costs (C compiler) whereas the 2nd one would skip these thanks to `betterRun`

## after this PR
* remove (filename, procname) and push a single location index (as int) which is an index into a lookup table; this will give a further performance boost as well as added flexibility such as getting column info (and even source line info, can be user defined), for free.

