### PR TITLE
Limit number of error messages from gcc/clang backend

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -167,17 +167,19 @@ path="$lib/pure"
   @end
 @end
 
+gcc.maxerrorsimpl = "-fmax-errors=3"
+
 @if macosx or freebsd or openbsd:
   cc = clang
   tlsEmulation:on
-  gcc.options.always = "-w -fmax-errors=3"
-  gcc.cpp.options.always = "-w -fmax-errors=3 -fpermissive"
+  gcc.options.always %= "-w ${gcc.maxerrorsimpl}"
+  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive"
 @elif windows:
-  gcc.options.always = "-w -fmax-errors=3 -mno-ms-bitfields"
-  gcc.cpp.options.always = "-w -fmax-errors=3 -fpermissive -mno-ms-bitfields"
+  gcc.options.always %= "-w ${gcc.maxerrorsimpl} -mno-ms-bitfields"
+  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive -mno-ms-bitfields"
 @else:
-  gcc.options.always = "-w -fmax-errors=3"
-  gcc.cpp.options.always = "-w -fmax-errors=3 -fpermissive"
+  gcc.options.always %= "-w ${gcc.maxerrorsimpl}"
+  gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive"
 @end
 
 # Configuration for Objective-C compiler:

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -170,14 +170,14 @@ path="$lib/pure"
 @if macosx or freebsd or openbsd:
   cc = clang
   tlsEmulation:on
-  gcc.options.always = "-w"
-  gcc.cpp.options.always = "-w -fpermissive"
+  gcc.options.always = "-w -fmax-errors=3"
+  gcc.cpp.options.always = "-w -fmax-errors=3 -fpermissive"
 @elif windows:
-  gcc.options.always = "-w -mno-ms-bitfields"
-  gcc.cpp.options.always = "-w -fpermissive -mno-ms-bitfields"
+  gcc.options.always = "-w -fmax-errors=3 -mno-ms-bitfields"
+  gcc.cpp.options.always = "-w -fmax-errors=3 -fpermissive -mno-ms-bitfields"
 @else:
-  gcc.options.always = "-w"
-  gcc.cpp.options.always = "-w -fpermissive"
+  gcc.options.always = "-w -fmax-errors=3"
+  gcc.cpp.options.always = "-w -fmax-errors=3 -fpermissive"
 @end
 
 # Configuration for Objective-C compiler:
@@ -245,7 +245,7 @@ llvm_gcc.options.size = "-Os"
 # Configuration for the LLVM CLang compiler:
 clang.options.debug = "-g"
 clang.cpp.options.debug = "-g"
-clang.options.always = "-w"
+clang.options.always = "-w -ferror-limit=3"
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 

--- a/tests/misc/msizeof5.nim.cfg
+++ b/tests/misc/msizeof5.nim.cfg
@@ -1,0 +1,5 @@
+# Do not limit number of error messages from backend compiler.
+gcc.options.always %= "${gcc.options.always} -fmax-errors=100"
+clang.options.always %= "${clang.options.always} -ferror-limit=100"
+gcc.cpp.options.always %= "${gcc.cpp.options.always} -fmax-errors=100"
+clang.cpp.options.always %= "${clang.cpp.options.always} -ferror-limit=100"


### PR DESCRIPTION
C/C++ backend compiler sometimes output large amount of error messages.
But I always read only 1st error message, fix it and compile again.
2nd or later error messages are rarely useful.
Fixing 1st error often fix other errors.
When there are really large amout of error message, it take long time to displaying them.
This PR adds compiler options to gcc and clang so that they stop after emitting 3 error messages.
It keep your console clean and backend compiler ends quickly even if there are large amount of error messages.
Is there case you need to read all error messages from backend compiler?

I could not find vcc compiler option that limit number of error messages.