### PR TITLE
Clean out sets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -185,6 +185,9 @@ proc mydiv(a, b): int {.raises: [].} =
 - Deprecated `{.unroll.}` pragma, was ignored by the compiler anyways, was a nop.
 
 
+- Remove `sets.isValid`, `sets.toSet`, `sets.initSet`, was deprecated since `0.20`, Sets are initialized by default.
+
+
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -587,28 +587,6 @@ proc `$`*[A](s: HashSet[A]): string =
   ##   # --> {no, esc'aping, is " provided}
   dollarImpl()
 
-
-proc initSet*[A](initialSize = defaultInitialSize): HashSet[A] {.deprecated:
-     "Deprecated since v0.20, use 'initHashSet'".} = initHashSet[A](initialSize)
-
-proc toSet*[A](keys: openArray[A]): HashSet[A] {.deprecated:
-     "Deprecated since v0.20, use 'toHashSet'".} = toHashSet[A](keys)
-
-proc isValid*[A](s: HashSet[A]): bool {.deprecated:
-     "Deprecated since v0.20; sets are initialized by default".} =
-  ## Returns `true` if the set has been initialized (with `initHashSet proc
-  ## <#initHashSet,int>`_ or `init proc <#init,HashSet[A],int>`_).
-  ##
-  ## **Examples:**
-  ##
-  ## .. code-block ::
-  ##   proc savePreferences(options: HashSet[string]) =
-  ##     assert options.isValid, "Pass an initialized set!"
-  ##     # Do stuff here, may crash in release builds!
-  result = s.data.len > 0
-
-
-
 # ---------------------------------------------------------------------
 # --------------------------- OrderedSet ------------------------------
 # ---------------------------------------------------------------------


### PR DESCRIPTION
- Remove `sets.isValid`, `sets.toSet`, `sets.initSet`, was deprecated since `0.20`, Sets are initialized by default.
- Unrelated CI fail, failed to read `arraymancer` package for some reason.
