### PR TITLE
Clean out sharedlists

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -185,6 +185,9 @@ proc mydiv(a, b): int {.raises: [].} =
 - Deprecated `{.unroll.}` pragma, was ignored by the compiler anyways, was a nop.
 
 
+- Remove `sharedlists.initSharedList`, was deprecated and produces undefined behaviour.
+
+
 ## Compiler changes
 
 - Specific warnings can now be turned into errors via `--warningAsError[X]:on|off`.

--- a/lib/pure/collections/sharedlist.nim
+++ b/lib/pure/collections/sharedlist.nim
@@ -94,10 +94,4 @@ proc deinitSharedList*[A](t: var SharedList[A]) =
   clear(t)
   deinitLock t.lock
 
-proc initSharedList*[A](): SharedList[A] {.deprecated: "use 'init' instead".} =
-  ## This is not posix compliant, may introduce undefined behavior.
-  initLock result.lock
-  result.head = nil
-  result.tail = nil
-
 {.pop.}


### PR DESCRIPTION
- Remove `sharedlists.initSharedList`, was deprecated and produces undefined behavior.
