### PR TITLE
Fix #14844

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -225,6 +225,7 @@ type
     nkModuleRef           # for .rod file support: A (moduleId, itemId) pair
     nkReplayAction        # for .rod file support: A replay action
     nkNilRodNode          # for .rod file support: a 'nil' PNode
+    nkEarlySemArg         # When an argument was semmed early, but we might need the untyped AST later, the semmed AST is the first, the unsemmed the second son
 
   TNodeKinds* = set[TNodeKind]
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -629,11 +629,12 @@ proc semOverloadedCallHandleEarlySym(c: PContext, n, nOrig: PNode,
       argsWrappedInPotentialEarlySem[i] = n[i]
       n[i] = n[i][0]
   result = semOverloadedCall(c, n, nOrig, filter, flags)
-  for i in 1..<argsWrappedInPotentialEarlySem.len:
-    if argsWrappedInPotentialEarlySem[i] != nil:
-      argsWrappedInPotentialEarlySem[i][0] = result[i]
-      n[i] = argsWrappedInPotentialEarlySem[i]
-      result[i] = n[i]
+  if result != nil:
+    for i in 1..<argsWrappedInPotentialEarlySem.len:
+      if argsWrappedInPotentialEarlySem[i] != nil:
+        argsWrappedInPotentialEarlySem[i][0] = result[i]
+        n[i] = argsWrappedInPotentialEarlySem[i]
+        result[i] = n[i]
 
 proc explicitGenericInstError(c: PContext; n: PNode): PNode =
   localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n))

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -582,14 +582,6 @@ proc tryDeref(n: PNode): PNode =
 
 proc semOverloadedCall(c: PContext, n, nOrig: PNode,
                        filter: TSymKinds, flags: TExprFlags): PNode {.nosinks.} =
-  var earlySym: PNode
-  var argsWrappedInPotentialEarlySem = newSeq[PNode](n.len)
-  for i in 1..<n.len:
-    if  n[i] != nil and n[i].kind == nkEarlySemArg:
-      # Store wrapping
-      argsWrappedInPotentialEarlySem[i] = n[i]
-      # Unwrap
-      n[i] = n[i][0]
   var errors: CandidateErrors = @[] # if efExplain in flags: @[] else: nil
   var r = resolveOverloads(c, n, nOrig, filter, flags, errors, efExplain in flags)
   if r.state == csMatch:
@@ -599,10 +591,6 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
       message(c.config, n.info, hintUserRaw,
               "Non-matching candidates for " & renderTree(n) & "\n" &
               candidates)
-    #X: Shouldn't this be moved up so that we always do this? XX: Or down?
-    for i in 1..<argsWrappedInPotentialEarlySem.len:
-      if argsWrappedInPotentialEarlySem[i] != nil:
-        n[i] = argsWrappedInPotentialEarlySem[i]
     result = semResolvedCall(c, r, n, flags)
   elif implicitDeref in c.features and canDeref(n):
     # try to deref the first argument and then try overloading resolution again:
@@ -632,6 +620,19 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
       discard semOverloadedCall(c, n, nOrig, filter, flags + {efExplain})
     elif efNoUndeclared notin flags:
       notFoundError(c, n, errors)
+
+proc semOverloadedCallHandleEarlySym(c: PContext, n, nOrig: PNode,
+                       filter: TSymKinds, flags: TExprFlags): PNode {.nosinks.} =
+  var argsWrappedInPotentialEarlySem = newSeq[PNode](n.len)
+  for i in 1..<n.len:
+    if  n[i] != nil and n[i].kind == nkEarlySemArg:
+      argsWrappedInPotentialEarlySem[i] = n[i]
+      n[i] = n[i][0]
+  result = semOverloadedCall(c, n, nOrig, filter, flags)
+  for i in 1..<argsWrappedInPotentialEarlySem.len:
+    if argsWrappedInPotentialEarlySem[i] != nil:
+      n[i] = argsWrappedInPotentialEarlySem[i]
+      result[i] = n[i]
 
 proc explicitGenericInstError(c: PContext; n: PNode): PNode =
   localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n))

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -631,6 +631,7 @@ proc semOverloadedCallHandleEarlySym(c: PContext, n, nOrig: PNode,
   result = semOverloadedCall(c, n, nOrig, filter, flags)
   for i in 1..<argsWrappedInPotentialEarlySem.len:
     if argsWrappedInPotentialEarlySem[i] != nil:
+      argsWrappedInPotentialEarlySem[i][0] = result[i]
       n[i] = argsWrappedInPotentialEarlySem[i]
       result[i] = n[i]
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -877,16 +877,15 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode, nOrig: PNode,
     let callee = result[0].sym
     case callee.kind
     of skMacro, skTemplate:
-      let typ = callee.typ.n
-      if result.len > 1 and result[1].kind == nkEarlySemArg and typ.len > 1 and typ[1].typ != nil and typ[1].typ.kind == tyUntyped:
+      if result.len > 1 and result[1].kind == nkEarlySemArg:
         #First argument is early gensymmed because of the method call syntax
         assert n[1] == result[1]
-        result[1] = result[1][1]
-        n[1] = result[1]
-        echo "Warning, semmed twice" #TODO: Warn properly
-      elif result.len > 1 and result[1].kind == nkEarlySemArg:
-        assert n[1] == result[1]
-        result[1] = result[1][0]
+        let typ = callee.typ.n
+        if typ.len > 1 and typ[1].typ != nil and typ[1].typ.kind == tyUntyped:
+          result[1] = result[1][1]
+          # TODO: Hint that this will sem twice
+        else:
+          result[1] = result[1][0]
         n[1] = result[1]
     else:
       if result.len > 1 and result[1].kind == nkEarlySemArg:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2250,6 +2250,7 @@ proc semSizeof(c: PContext, n: PNode): PNode =
 proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
   # this is a hotspot in the compiler!
   result = n
+  if result.len > 1 and result[1].kind == nkEarlySemArg: result[1] = result[1][0]
   case s.magic # magics that need special treatment
   of mAddr:
     markUsed(c, n.info, s)
@@ -2285,7 +2286,6 @@ proc semMagic(c: PContext, n: PNode, s: PSym, flags: TExprFlags): PNode =
     markUsed(c, n.info, s)
     result = semQuoteAst(c, n)
   of mAstToStr:
-    if n[1].kind == nkEarlySemArg: n[1] = n[1][0]
     markUsed(c, n.info, s)
     checkSonsLen(n, 2, c.config)
     result = newStrNodeT(renderTree(n[1], {renderNoComments}), n, c.graph)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -880,9 +880,19 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode, nOrig: PNode,
       let typ = callee.typ.n
       if result.len > 1 and result[1].kind == nkEarlySemArg and typ.len > 1 and typ[1].typ != nil and typ[1].typ.kind == tyUntyped:
         #First argument is early gensymmed because of the method call syntax
+        assert n[1] == result[1]
         result[1] = result[1][1]
+        n[1] = result[1]
         echo "Warning, semmed twice" #TODO: Warn properly
+      elif result.len > 1 and result[1].kind == nkEarlySemArg:
+        assert n[1] == result[1]
+        result[1] = result[1][0]
+        n[1] = result[1]
     else:
+      if result.len > 1 and result[1].kind == nkEarlySemArg:
+        assert n[1] == result[1]
+        result[1] = result[1][0]
+        n[1] = result[1]
       if callee.kind == skIterator and callee.id == c.p.owner.id:
         localError(c.config, n.info, errRecursiveDependencyIteratorX % callee.name.s)
         # error correction, prevents endless for loop elimination in transf.

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -49,7 +49,6 @@ template rejectEmptyNode(n: PNode) =
   if n.kind == nkEmpty: illFormedAst(n, c.config)
 
 proc semOperand(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
-  let n = if n.kind == nkEarlySemArg: n[0] else: n
   rejectEmptyNode(n)
   # same as 'semExprWithType' but doesn't check for proc vars
   result = semExpr(c, n, flags + {efOperand})
@@ -84,7 +83,6 @@ proc semExprCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
     result = errorNode(c, n)
 
 proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
-  let n = if n.kind == nkEarlySemArg: n[0] else: n
   result = semExprCheck(c, n, flags)
   if result.typ == nil and efInTypeof in flags:
     result.typ = c.voidType
@@ -2754,6 +2752,7 @@ proc enumFieldSymChoice(c: PContext, n: PNode, s: PSym): PNode =
       a = nextOverloadIter(o, c, n)
 
 proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
+  let n = if n.kind == nkEarlySemArg: n[0] else: n
   when defined(nimCompilerStacktraceHints):
     setFrameMsg c.config$n.info & " " & $n.kind
   when false: # see `tdebugutils`

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -878,10 +878,8 @@ proc semOverloadedCallAnalyseEffects(c: PContext, n: PNode, nOrig: PNode,
     case callee.kind
     of skMacro, skTemplate:
       let typ = callee.typ.n
-      #The first argument might be early gensymmed because of the method call syntax
-      if n.len > 1 and n[1].kind == nkEarlySemArg and typ.len > 1 and typ[1].typ != nil and typ[1].typ.kind == tyUntyped:
-        assert n[1] == result[1]
-        n[1] = n[1][1]
+      if result.len > 1 and result[1].kind == nkEarlySemArg and typ.len > 1 and typ[1].typ != nil and typ[1].typ.kind == tyUntyped:
+        #First argument is early gensymmed because of the method call syntax
         result[1] = result[1][1]
         echo "Warning, semmed twice" #TODO: Warn properly
     else:

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1047,10 +1047,8 @@ template applyIt*(varSeq, op: untyped) =
     nums.applyIt(it * 3)
     assert nums[0] + nums[3] == 15
 
-  for i in low(varSeq) .. high(varSeq):
-    let it {.inject.} = varSeq[i]
-    varSeq[i] = op
-
+  for it {.inject.} in mitems(varSeq):
+    it = op
 
 template newSeqWith*(len: int, init: untyped): untyped =
   ## Creates a new `seq` of length `len`, calling `init` to initialize

--- a/tests/macros/tmacros_issues.nim
+++ b/tests/macros/tmacros_issues.nim
@@ -21,6 +21,11 @@ false
 true
 @[i0, i1, i2, i3, i4]
 @[tmp, tmp, tmp, tmp, tmp]
+hey
+hey
+now method:
+hey
+hey
 '''
 
   output: '''
@@ -519,3 +524,19 @@ block double_sem_for_procs:
     result = 10.0
 
   discard exp(5.0)
+
+# bug #14844
+var c {.compileTime.} = 0
+macro echoes: untyped =
+  echo "compTime"
+  result = newLit c
+  inc c
+
+template doubleEval(n): untyped =
+  echo n; echo n;
+
+doubleEval(echoes)
+static: echo "now method:"
+(echoes).doubleEval()
+static: echo "now method command:"
+(echoes).doubleEval #TODO: This is still broken

--- a/tests/macros/tmacros_issues.nim
+++ b/tests/macros/tmacros_issues.nim
@@ -21,11 +21,16 @@ false
 true
 @[i0, i1, i2, i3, i4]
 @[tmp, tmp, tmp, tmp, tmp]
-hey
-hey
+compTime
+compTime
 now method:
-hey
-hey
+compTime
+compTime
+compTime
+now method command:
+compTime
+compTime
+compTime
 '''
 
   output: '''
@@ -46,6 +51,12 @@ false
 true
 false
 1.0
+0
+1
+3
+4
+6
+7
 '''
 """
 
@@ -539,4 +550,4 @@ doubleEval(echoes)
 static: echo "now method:"
 (echoes).doubleEval()
 static: echo "now method command:"
-(echoes).doubleEval #TODO: This is still broken
+(echoes).doubleEval

--- a/tests/template/tmethodcall.nim
+++ b/tests/template/tmethodcall.nim
@@ -22,3 +22,25 @@ block:
   let a = vec2f(1.0,0.0)
   let b = vec2f(3.0,1.0)
   let c = (a - b).foo() # breaks
+
+# bug #14844
+template bug: untyped =
+  template makeSeq: untyped =
+    var i = 0
+    for _ in 0..<10: # Already fails with 0..<6 which is exactly 10 / 2 + 1
+      assert i in 0..<10 # This assertion fails
+      inc i
+    @[1] # Works with [1]
+
+  template last(s): untyped = s[s.len - 1] # Works with s[^1]
+
+  echo last(makeSeq()) # This works
+  echo makeSeq().last() # This doesn't work
+  echo makeSeq().last # This doesn't work
+
+bug
+
+proc main =
+  bug
+
+main()

--- a/tests/template/tmethodcall.nim
+++ b/tests/template/tmethodcall.nim
@@ -1,3 +1,14 @@
+discard """
+output: '''
+1
+1
+1
+1
+1
+1
+'''
+"""
+
 # bug #5909
 type
   Vec2[T] = tuple

--- a/tests/template/twrongmapit.nim
+++ b/tests/template/twrongmapit.nim
@@ -27,6 +27,7 @@ when ATTEMPT == 0:
 # bug #1543
 import sequtils
 
+applyIt (var i = @[""];i), it
 (var i = @[""];i).applyIt(it)
 # now works:
 echo "##", i[0], "##"

--- a/tests/template/twrongmapit.nim
+++ b/tests/template/twrongmapit.nim
@@ -29,5 +29,3 @@ import sequtils
 
 applyIt (var i = @[""];i), it
 (var i = @[""];i).applyIt(it)
-# now works:
-echo "##", i[0], "##"

--- a/tests/template/twrongmapit.nim
+++ b/tests/template/twrongmapit.nim
@@ -1,5 +1,5 @@
 discard """
-  output: "####"
+  output: ""
 """
 # unfortunately our tester doesn't support multiple lines of compiler
 # error messages yet...
@@ -29,3 +29,9 @@ import sequtils
 
 applyIt (var i = @[""];i), it
 (var i = @[""];i).applyIt(it)
+
+#i is not in scope anymore here. This is in accordance with the
+#normal scoping rules:
+# for it in mitems( (var i = @[""]; i) ):
+#   it = it
+# echo i # undeclared identifier: 'i'


### PR DESCRIPTION
One test will fail because the current broken behaviour allowed it to (https://play.nim-lang.org/#ix=2qAU).
Should both fail or work? A manual `(var i = 0); (var i = 0)` currently fails.. (for more context see https://github.com/nim-lang/Nim/commit/bb532a697edad1bac60a87a7ff43956c9635973d#diff-705c21e2cbb7aca092a9882547994008)