### PR TITLE
Add os.toFilePerm

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -122,7 +122,7 @@
 
 - `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
 
-- Add `os.fromUnixPerm` convenience func to convert Unix-like file permission to `set[FilePermission]`,
+- Add `os.toFilePerm` convenience func to convert Unix-like file permission to `set[FilePermission]`,
   eg. you type `0o777` instead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -122,8 +122,8 @@
 
 - `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
 
-- Add `os.fromUnixFilePermission` convenience func to convert Unix-like file permission to `set[FilePermission]`,
-  eg. you type `7,7,7` instead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
+- Add `os.fromUnixPerm` convenience func to convert Unix-like file permission to `set[FilePermission]`,
+  eg. you type `0o777` instead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -122,7 +122,7 @@
 
 - `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
 
-- Add `os.toFilePerm` convenience func to convert Unix-like file permission to `set[FilePermission]`,
+- Add `os.toFilePermissions` convenience func to convert Unix-like file permission to `set[FilePermission]`,
   eg. you type `0o777` instead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -120,7 +120,7 @@
 - `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
 
 - Add `os.fromUnixFilePermission` convenience func to convert Unix-like file permission to `set[FilePermission]`,
-  eg. you type `7,7,7` istead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
+  eg. you type `7,7,7` instead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -119,6 +119,10 @@
 
 - `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
 
+- Add `os.fromUnixFilePermission` convenience func to convert Unix-like file permission to `set[FilePermission]`,
+  eg. you type `7,7,7` istead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`, etc.
+
+
 ## Language changes
 - In the newruntime it is now allowed to assign to the discriminator field
   without restrictions as long as case object doesn't have custom destructor.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1680,7 +1680,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-func toFilePermissions*(perm: uint): set[FilePermission] {.since: (1, 3).} =
+func toFilePermissions*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
   ## Convenience func to convert Unix like file permission to ``set[FilePermission]``.
   ##
   ## See also:
@@ -1693,7 +1693,7 @@ func toFilePermissions*(perm: uint): set[FilePermission] {.since: (1, 3).} =
     doAssert toFilePermissions(0o644) == {fpUserWrite, fpUserRead, fpGroupRead, fpOthersRead}
     doAssert toFilePermissions(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
     doAssert toFilePermissions(0o000) == {}
-  var perm = perm
+  var perm = uint(perm)
   for permBase in [fpOthersExec, fpGroupExec, fpUserExec]:
     if (perm and 1) != 0: result.incl permBase         # Exec
     if (perm and 2) != 0: result.incl permBase.succ()  # Read

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1686,7 +1686,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-func toFilePermissions*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
+func toFilePermissions*(perm: uint): set[FilePermission] {.since: (1, 3).} =
   ## Convenience func to convert Unix like file permission to ``set[FilePermission]``.
   ##
   ## See also:
@@ -1699,7 +1699,7 @@ func toFilePermissions*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
     doAssert toFilePermissions(0o644) == {fpUserWrite, fpUserRead, fpGroupRead, fpOthersRead}
     doAssert toFilePermissions(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
     doAssert toFilePermissions(0o000) == {}
-  var perm = uint perm
+  var perm = perm
   for permBase in [fpOthersExec, fpGroupExec, fpUserExec]:
     if (perm and 1) != 0: result.incl permBase         # Exec
     if (perm and 2) != 0: result.incl permBase.succ()  # Read

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1686,19 +1686,19 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-func toFilePerm*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
+func toFilePermissions*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
   ## Convenience func to convert Unix like file permission to ``set[FilePermission]``.
   ##
   ## See also:
   ## * `getFilePermissions <#getFilePermissions,string>`_
   ## * `setFilePermissions <#setFilePermissions,string,set[FilePermission]>`_
   runnableExamples:
-    doAssert toFilePerm(0o700) == {fpUserExec, fpUserRead, fpUserWrite}
-    doAssert toFilePerm(0o070) == {fpGroupExec, fpGroupRead, fpGroupWrite}
-    doAssert toFilePerm(0o007) == {fpOthersExec, fpOthersRead, fpOthersWrite}
-    doAssert toFilePerm(0o644) == {fpUserWrite, fpUserRead, fpGroupRead, fpOthersRead}
-    doAssert toFilePerm(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
-    doAssert toFilePerm(0o000) == {}
+    doAssert toFilePermissions(0o700) == {fpUserExec, fpUserRead, fpUserWrite}
+    doAssert toFilePermissions(0o070) == {fpGroupExec, fpGroupRead, fpGroupWrite}
+    doAssert toFilePermissions(0o007) == {fpOthersExec, fpOthersRead, fpOthersWrite}
+    doAssert toFilePermissions(0o644) == {fpUserWrite, fpUserRead, fpGroupRead, fpOthersRead}
+    doAssert toFilePermissions(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
+    doAssert toFilePermissions(0o000) == {}
   var perm = uint perm
   for permBase in [fpOthersExec, fpGroupExec, fpUserExec]:
     if (perm and 1) != 0: result.incl permBase         # Exec

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1686,7 +1686,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-func toFilePerm*(perm: Natural): set[FilePermission] {.inline, since: (1, 3).} =
+func toFilePerm*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
   ## Convenience func to convert Unix like file permission to ``set[FilePermission]``.
   ##
   ## See also:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1686,19 +1686,19 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-func fromUnixPerm*(perm: Natural): set[FilePermission] {.inline, since: (1, 3).} =
+func toFilePerm*(perm: Natural): set[FilePermission] {.inline, since: (1, 3).} =
   ## Convenience func to convert Unix like file permission to ``set[FilePermission]``.
   ##
   ## See also:
   ## * `getFilePermissions <#getFilePermissions,string>`_
   ## * `setFilePermissions <#setFilePermissions,string,set[FilePermission]>`_
   runnableExamples:
-    doAssert fromUnixPerm(0o700) == {fpUserExec, fpUserRead, fpUserWrite}
-    doAssert fromUnixPerm(0o070) == {fpGroupExec, fpGroupRead, fpGroupWrite}
-    doAssert fromUnixPerm(0o007) == {fpOthersExec, fpOthersRead, fpOthersWrite}
-    doAssert fromUnixPerm(0o644) == {fpUserWrite, fpUserRead, fpGroupRead, fpOthersRead}
-    doAssert fromUnixPerm(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
-    doAssert fromUnixPerm(0o000) == {}
+    doAssert toFilePerm(0o700) == {fpUserExec, fpUserRead, fpUserWrite}
+    doAssert toFilePerm(0o070) == {fpGroupExec, fpGroupRead, fpGroupWrite}
+    doAssert toFilePerm(0o007) == {fpOthersExec, fpOthersRead, fpOthersWrite}
+    doAssert toFilePerm(0o644) == {fpUserWrite, fpUserRead, fpGroupRead, fpOthersRead}
+    doAssert toFilePerm(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
+    doAssert toFilePerm(0o000) == {}
   var perm = uint perm
   for permBase in [fpOthersExec, fpGroupExec, fpUserExec]:
     if (perm and 1) != 0: result.incl permBase         # Exec

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1691,9 +1691,10 @@ template fromUnixImpl(unixPerm: range[0..7]; i: static[int]): set[FilePermission
   var r = fpUserRead
   var w = fpUserWrite
   var x = fpUserExec
-  inc r, i
-  inc w, i
-  inc x, i
+  when i > 0:
+    inc r, i
+    inc w, i
+    inc x, i
   case unixPerm
   of 0: {}
   of 1: {x}

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1700,16 +1700,11 @@ func fromUnixPerm*(perm: Natural): set[FilePermission] {.inline, since: (1, 3).}
     doAssert fromUnixPerm(0o777) == {fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}
     doAssert fromUnixPerm(0o000) == {}
   var perm = uint perm
-  # We might want some form of loop unrolling
   for permBase in [fpOthersExec, fpGroupExec, fpUserExec]:
-    # Exec
-    if (perm and 1) != 0: result.incl permBase
-    # Read
-    if (perm and 2) != 0: result.incl permBase.succ()
-    # Write
-    if (perm and 4) != 0: result.incl permBase.succ(2)
-    # Shift to next permission group
-    perm = perm shr 3
+    if (perm and 1) != 0: result.incl permBase         # Exec
+    if (perm and 2) != 0: result.incl permBase.succ()  # Read
+    if (perm and 4) != 0: result.incl permBase.succ(2) # Write
+    perm = perm shr 3  # Shift to next permission group
 
 proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",
   tags: [ReadIOEffect, WriteIOEffect], noWeirdTarget.} =

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1686,7 +1686,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-func toFilePerm*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
+func toFilePermissions*(perm: Natural): set[FilePermission] {.since: (1, 3).} =
   ## Convenience func to convert Unix like file permission to ``set[FilePermission]``.
   ##
   ## See also:


### PR DESCRIPTION
- Add `os.fromUnixFilePermission` convenience `func` to convert Unix-like file permission to `set[FilePermission]`.
- Documentation, `since`, `runnableExamples` with `doAssert`, works at compile-time, etc etc.
- You can feed it to other pre-existent `proc` of `os` for comfy coding without breaking any API.

## Example 
You type `7,7,7` instead of `{fpUserExec, fpUserWrite, fpUserRead, fpGroupExec, fpGroupWrite, fpGroupRead, fpOthersExec, fpOthersWrite, fpOthersRead}`.
:)
