### PR TITLE
Recognize different section levels

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -322,6 +322,12 @@ proc newSharedState(options: RstParseOptions,
   new(result)
   result.subs = @[]
   result.refs = @[]
+
+  result.underlineToLevel['-'] = 1
+  result.underlineToLevel['^'] = 2
+  result.underlineToLevel['\''] = 3
+  result.underlineToLevel['.'] = 4
+
   result.options = options
   result.msgHandler = if not isNil(msgHandler): msgHandler else: defaultMsgHandler
   result.findFile = if not isNil(findFile): findFile else: defaultFindFile

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -33,6 +33,27 @@ suite "YAML syntax highlighting":
 <span class="Punctuation">:</span> <span class="StringLit">value</span>
 <span class="Keyword">...</span></pre>"""
 
+
+  test "Section header levels":
+    assert rstToHtml("""
+section
+-------
+
+subsection
+^^^^^^^^^^
+
+subsubsection
+'''''''''''''
+
+paragraph
+.........
+""") == """
+<h1 id="section">section</h1>
+<h2 id="subsection">subsection</h2>
+<h3 id="subsubsection">subsubsection</h3>
+<h4 id="paragraph">paragraph</h4>
+"""
+
   test "Block scalars":
     let input = """.. code-block:: yaml
     a literal block scalar: |

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -8,6 +8,30 @@ import ../../lib/packages/docutils/rstgen
 import ../../lib/packages/docutils/rst
 import unittest
 
+suite "Section headers":
+  test "Section header levels":
+    let output = rstToHtml("""
+section
+-------
+
+subsection
+^^^^^^^^^^
+
+subsubsection
+'''''''''''''
+
+paragraph
+.........
+""", {}, defaultConfig())
+
+    assert output == """
+
+<h1 id="section">section</h1>
+<h2 id="subsection">subsection</h2>
+<h3 id="subsubsection">subsubsection</h3>
+<h4 id="paragraph">paragraph</h4>"""
+
+
 suite "YAML syntax highlighting":
   test "Basics":
     let input = """.. code-block:: yaml
@@ -32,27 +56,6 @@ suite "YAML syntax highlighting":
 <span class="Punctuation">?</span> <span class="StringLit">key</span>
 <span class="Punctuation">:</span> <span class="StringLit">value</span>
 <span class="Keyword">...</span></pre>"""
-
-
-  test "Section header levels":
-    assert rstToHtml("""
-section
--------
-
-subsection
-^^^^^^^^^^
-
-subsubsection
-'''''''''''''
-
-paragraph
-.........
-""") == """
-<h1 id="section">section</h1>
-<h2 id="subsection">subsection</h2>
-<h3 id="subsubsection">subsubsection</h3>
-<h4 id="paragraph">paragraph</h4>
-"""
 
   test "Block scalars":
     let input = """.. code-block:: yaml


### PR DESCRIPTION
Add support for different section levels in RST parser.

```rst
section (level 1)
-----------------

subsection (level 2)
^^^^^^^^^^^^^^^^^^^^

subsubsection (level 3)
'''''''''''''''''''''''

paragraph (level 4)
...................
```

Most (If not all) existing documentation uses `------` for sections so this will not affect already written text in any way. 

Added unit test for new functionality