### PR TITLE
add decls.byLent, turns an expression into a `let`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -140,8 +140,6 @@
   initial size must be a power of two - this is done internally.
   Proc `rightSize` for Tables and HashSets is deprecated, as it is not needed anymore.
 
-
-- `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
 - Add `decls.byLent` to turn an argument into a let param, useful for overload resolution.
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -141,6 +141,8 @@
   Proc `rightSize` for Tables and HashSets is deprecated, as it is not needed anymore.
 
 
+- `strformat.fmt` and `strformat.&` support `= specifier`. `fmt"{expr=}"` now expands to `fmt"expr={expr}"`.
+- Add `decls.byLent` to turn an argument into a let param, useful for overload resolution.
 
 ## Language changes
 - In the newruntime it is now allowed to assign to the discriminator field

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -13,6 +13,7 @@ import
 
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
+from std/decls import byLent
 
 const
   hasTinyCBackend* = defined(tinyc)
@@ -619,12 +620,6 @@ proc shortenDir*(conf: ConfigRef; dir: string): string {.
     return substr(dir, prefix.len)
   result = dir
 
-proc removeTrailingDirSep*(path: string): string =
-  if (path.len > 0) and (path[^1] == DirSep):
-    result = substr(path, 0, path.len - 2)
-  else:
-    result = path
-
 proc disableNimblePath*(conf: ConfigRef) =
   incl conf.globalOptions, optNoNimblePath
   conf.lazyPaths.setLen(0)
@@ -653,7 +648,7 @@ proc getNimcacheDir*(conf: ConfigRef): AbsoluteDir =
                (if isDefined(conf, "release") or isDefined(conf, "danger"): "_r" else: "_d"))
 
 proc pathSubs*(conf: ConfigRef; p, config: string): string =
-  let home = removeTrailingDirSep(os.getHomeDir())
+  let home = os.getHomeDir().normalizePathEnd
   result = unixToNativePath(p % [
     "nim", getPrefixDir(conf).string,
     "lib", conf.libpath.string,
@@ -668,7 +663,7 @@ iterator nimbleSubs*(conf: ConfigRef; p: string): string =
   let pl = p.toLowerAscii
   if "$nimblepath" in pl or "$nimbledir" in pl:
     for i in countdown(conf.nimblePaths.len-1, 0):
-      let nimblePath = removeTrailingDirSep(conf.nimblePaths[i].string)
+      let nimblePath = conf.nimblePaths[i].string.byLent.normalizePathEnd
       yield p % ["nimblepath", nimblePath, "nimbledir", nimblePath]
   else:
     yield p

--- a/lib/std/decls.nim
+++ b/lib/std/decls.nim
@@ -1,5 +1,9 @@
-# see `semLowerLetVarCustomPragma` for compiler support that enables these
-# lowerings
+#[
+keep this module dependency-light to be usable in low level modules.
+
+see `semLowerLetVarCustomPragma` for compiler support that enables these
+lowerings
+]#
 
 template byaddr*(lhs, typ, ex) =
   ## Allows a syntax for lvalue reference, exact analog to
@@ -17,3 +21,15 @@ template byaddr*(lhs, typ, ex) =
   else:
     let tmp: ptr typ = addr(ex)
   template lhs: untyped = tmp[]
+
+proc byLent*[T](a: T): lent T {.inline.} =
+  ## Transforms `a` into a let param without copying; this is useful for overload
+  ## resolution
+  runnableExamples:
+    proc fn(a: int): int = result = a*2
+    proc fn(a: var int) = a = a*2
+    var x = 3
+    # x = fn(x)  # would give: Error: expression 'fn(x)' has no type (or is ambiguous)
+    x = fn(x.byLent) # works
+    doAssert x == 3*2
+  a

--- a/lib/std/decls.nim
+++ b/lib/std/decls.nim
@@ -32,4 +32,4 @@ proc byLent*[T](a: T): lent T {.inline.} =
     # x = fn(x)  # would give: Error: expression 'fn(x)' has no type (or is ambiguous)
     x = fn(x.byLent) # works
     doAssert x == 3*2
-  a
+  result = a # just `a` hits: bug #14420

--- a/lib/std/decls.nim
+++ b/lib/std/decls.nim
@@ -22,7 +22,7 @@ template byaddr*(lhs, typ, ex) =
     let tmp: ptr typ = addr(ex)
   template lhs: untyped = tmp[]
 
-proc byLent*[T](a: T): lent T {.inline.} =
+proc byLent*[T](a: var T): lent T {.inline.} =
   ## Transforms `a` into a let param without copying; this is useful for overload
   ## resolution
   runnableExamples:

--- a/tests/js/taddr.nim
+++ b/tests/js/taddr.nim
@@ -78,29 +78,39 @@ doAssert(someGlobalPtr[] == 5)
 someGlobalPtr[] = 10
 doAssert(someGlobal == 10)
 
-from std/decls import byLent
-
 block:
   # issue #14576
   # lots of these used to give: Error: internal error: genAddr: 2
+  proc byLentAny[T](a: T): lent T = a
+  proc byLentVar[T](a: var T): lent T = a # see also decls.byLent
   proc byPtr[T](a: T): ptr T = a.unsafeAddr
 
   block:
     let a = (10,11)
-    let (x,y) = byLent(a)
+    let (x,y) = byLentAny(a)
+    doAssert (x,y) == a
+  block:
+    var a = (10,11)
+    let (x,y) = byLentAny(a)
     doAssert (x,y) == a
 
   block:
     let a = 10
-    doAssert byLent(a) == 10
-    let a2 = byLent(a)
+    doAssert byLentAny(a) == 10
+    let a2 = byLentAny(a)
     doAssert a2 == 10
 
   block:
     let a = [11,12]
-    doAssert byLent(a) == [11,12]
+    doAssert byLentAny(a) == [11,12]
     let a2 = (11,)
-    doAssert byLent(a2) == (11,)
+    doAssert byLentAny(a2) == (11,)
+
+  block:
+    var a = [11,12]
+    doAssert byLentVar(a) == [11,12]
+    var a2 = (11,)
+    doAssert byLentVar(a2) == (11,)
 
   block:
     when defined(c) and defined(release):
@@ -114,9 +124,9 @@ block:
       doAssert byPtr(a3)[] == 14
 
   block:
-    proc byLent2[T](a: seq[T]): lent T = a[1]
+    proc byLentElem[T](a: seq[T]): lent T = a[1]
     var a = @[20,21,22]
-    doAssert byLent2(a) == 21
+    doAssert byLentElem(a) == 21
 
   block: # sanity checks
     proc bar[T](a: var T): var T = a

--- a/tests/js/taddr.nim
+++ b/tests/js/taddr.nim
@@ -131,6 +131,6 @@ block:
     bar(a2).inc
     doAssert a2 == 13
 
-  block: # xxx: bug this doesn't work
+  block: # pending bug #14877
     when false:
       proc byLent2[T](a: T): lent type(a[0]) = a[0]

--- a/tests/js/taddr.nim
+++ b/tests/js/taddr.nim
@@ -78,10 +78,11 @@ doAssert(someGlobalPtr[] == 5)
 someGlobalPtr[] = 10
 doAssert(someGlobal == 10)
 
+from std/decls import byLent
+
 block:
   # issue #14576
   # lots of these used to give: Error: internal error: genAddr: 2
-  proc byLent[T](a: T): lent T = a
   proc byPtr[T](a: T): ptr T = a.unsafeAddr
 
   block:
@@ -90,14 +91,10 @@ block:
     doAssert (x,y) == a
 
   block:
-    when defined(c) and defined(release):
-      # bug; pending https://github.com/nim-lang/Nim/issues/14578
-      discard
-    else:
-      let a = 10
-      doAssert byLent(a) == 10
-      let a2 = byLent(a)
-      doAssert a2 == 10
+    let a = 10
+    doAssert byLent(a) == 10
+    let a2 = byLent(a)
+    doAssert a2 == 10
 
   block:
     let a = [11,12]


### PR DESCRIPTION
add decls.byLent which turns an argument into a let-param; one use case is forcing a `let param` overload.
this was kind of blocked by 
now that these `lent` bugs have been fixed (https://github.com/nim-lang/Nim/issues/14578 and https://github.com/nim-lang/Nim/issues/14557 and https://github.com/nim-lang/Nim/issues/14576), this is worthwhile.

* see examples in this PR
* see also this example:
```nim
when true:
  import std/decls
  proc fun(y: int): int = result = 10
  proc fun(y: var int) = y = 10
  proc main()=
    var it = 0
    it = fun(it.byLent) # without byLent, would give: Error: expression 'fun(it)' has no type
  main()
```

which is a reduction of the only test failure I'm getting in https://github.com/nim-lang/Nim/pull/14869, for package https://github.com/Vindaar/ggplotnim

2020-07-01T10:34:35.1020690Z /Users/runner/.nimble/pkgs/ginger-0.2.5/ginger.nim(1358, 40) Error: expression 'updateScale(view, it)' has no type (or is ambiguous)

using `byLent` is the correct way to handle this IMO
