### PR TITLE
allocate closure env on stack if viable (wip)

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2408,8 +2408,12 @@ proc genClosure(p: BProc, n: PNode, d: var TLoc) =
                 [d.rdLoc, a.rdLoc, b.rdLoc])
     else:
       getTemp(p, n.typ, tmp)
-      linefmt(p, cpsStmts, "$1.ClP_0 = $2; $1.ClE_0 = $3;$n",
-              [tmp.rdLoc, a.rdLoc, b.rdLoc])
+      if n[1].typ.kind == tyObject: # closure env is allocated on stack
+        linefmt(p, cpsStmts, "$1.ClP_0 = $2; $1.ClE_0 = &$3;$n",
+                [tmp.rdLoc, a.rdLoc, b.rdLoc])
+      else:
+        linefmt(p, cpsStmts, "$1.ClP_0 = $2; $1.ClE_0 = $3;$n",
+                [tmp.rdLoc, a.rdLoc, b.rdLoc])
       putLocIntoDest(p, d, tmp)
 
 proc genArrayConstr(p: BProc, n: PNode, d: var TLoc) =

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -260,7 +260,10 @@ proc genBreakState(p: BProc, n: PNode, d: var TLoc) =
 
   if n[0].kind == nkClosure:
     initLocExpr(p, n[0][1], a)
-    d.r = "(((NI*) $1)[1] < 0)" % [rdLoc(a)]
+    if n[0][1].typ.kind == tyObject:
+      d.r = "(((NI*) &($1))[1] < 0)" % [rdLoc(a)]
+    else:
+      d.r = "(((NI*) $1)[1] < 0)" % [rdLoc(a)]
   else:
     initLocExpr(p, n[0], a)
     # the environment is guaranteed to contain the 'state' field at offset 1:

--- a/tests/closure/tstackenv.nim
+++ b/tests/closure/tstackenv.nim
@@ -1,0 +1,47 @@
+discard """
+  target: "c"
+"""
+
+type Thing {.byref.} = object
+  x: int
+
+proc paramWasntCopied(t: Thing; tAddr: ptr Thing) =
+  # stack closures don't copy captured params but rather
+  # store ptrs to them
+  var y = 0
+  proc inner =
+    y += t.x
+  
+  inner()
+  doAssert y == t.x
+  let myAddr = unsafeAddr(t)
+  # since no copy occured we should have the same address
+  doAssert myAddr == tAddr
+
+proc paramWasCopied(t: Thing; tAddr: ptr Thing): proc =
+  var y = 0
+  proc inner =
+    y += t.x
+  
+  inner()
+  doAssert y == t.x
+  let myAddr = unsafeAddr(t)
+  doAssert myAddr != tAddr
+  return inner
+
+proc captureVarParam(t: var Thing) = 
+  # stack closures can capture var params
+  proc inner =
+    t.x += 10
+  
+  inner()
+
+proc foo =
+  var t = Thing(x: 10)
+  let tAddr = addr(t)
+  paramWasntCopied(t, tAddr)
+  discard paramWasCopied(t, tAddr)
+  captureVarParam(t)
+  doAssert t.x == 20
+
+foo()


### PR DESCRIPTION
Opening a PR to check how it does on the tests.

If no inner proc is actually passed somewhere we can make the closure env a non ref object and pass it to the inner procs as a ptr instead. This should make some common uses of inner procs much more performant. It would also make it valid to capture an outer `var` argument inside non escaping inner procs (not implemented yet).
Not sure if the check for this (`anyInnerProcMightEscape`) covers all the cases thoroughly though, so it needs to be reviewed.