### PR TITLE
Add Deprecated pragma to Deprecated module

### DIFF
--- a/lib/core/macrocache.nim
+++ b/lib/core/macrocache.nim
@@ -13,6 +13,8 @@
 ## as it breaks incremental compilations.
 ## Instead the API here needs to be used.
 
+{.deprecated: "Deprecated since 0.19; Not supported anymore as it breaks incremental compilation.".}
+
 type
   CacheSeq* = distinct string
   CacheTable* = distinct string


### PR DESCRIPTION
- Add `{.deprecated.}` pragma to Deprecated module.
- Documentation explicitly says its Deprecated since `0.19` but it has no pragma.
