### PR TITLE
nimpretty support for multiple files

### DIFF
--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -14,7 +14,7 @@ when not defined(nimpretty):
 
 import ../compiler / [idents, msgs, syntaxes, options, pathutils, layouter]
 
-import parseopt, strutils, os
+import parseopt, strutils, os, sequtils
 
 const
   Version = "0.2"
@@ -22,9 +22,10 @@ const
 
   (c) 2017 Andreas Rumpf
 Usage:
-  nimpretty [options] file.nim
+  nimpretty [options] [nimfiles...]
 Options:
   --out:file            set the output file (default: overwrite the input file)
+  --outDir:dir          set the output dir (default: overwrite the input files)
   --indent:N[=0]        set the number of spaces that is used for indentation
                         --indent:0 means autodetection (default behaviour)
   --maxLineLen:N        set the desired maximum line length (default: 80)
@@ -61,37 +62,61 @@ proc prettyPrint(infile, outfile: string, opt: PrettyOptions) =
     closeParsers(p)
 
 proc main =
-  var infile, outfile: string
+  var outfile, outdir: string
+
+  var infiles = newSeq[string]()
+  var outfiles = newSeq[string]()
+
   var backup = false
     # when `on`, create a backup file of input in case
     # `prettyPrint` could over-write it (note that the backup may happen even
     # if input is not actually over-written, when nimpretty is a noop).
     # --backup was un-documented (rely on git instead).
   var opt = PrettyOptions(indWidth: 0, maxLineLen: 80)
+
+
   for kind, key, val in getopt():
     case kind
     of cmdArgument:
-      infile = key.addFileExt(".nim")
+      infiles.add(key.addFileExt(".nim"))
     of cmdLongOption, cmdShortOption:
       case normalize(key)
       of "help", "h": writeHelp()
       of "version", "v": writeVersion()
       of "backup": backup = parseBool(val)
       of "output", "o", "out": outfile = val
+      of "outDir", "outdir", "d": outdir = val
       of "indent": opt.indWidth = parseInt(val)
       of "maxlinelen": opt.maxLineLen = parseInt(val)
       else: writeHelp()
     of cmdEnd: assert(false) # cannot happen
-  if infile.len == 0:
+  if infiles.len == 0:
     quit "[Error] no input file."
-  if outfile.len == 0:
-    outfile = infile
-  if not fileExists(outfile) or not sameFile(infile, outfile):
-    backup = false # no backup needed since won't be over-written
-  if backup:
-    let infileBackup = infile & ".backup" # works with .nim or .nims
-    echo "writing backup " & infile & " > " & infileBackup
-    os.copyFile(source = infile, dest = infileBackup)
-  prettyPrint(infile, outfile, opt)
+
+  if outfile.len != 0 and outdir.len != 0:
+    quit "[Error] out and outDir cannot both be specified"
+
+  if outfile.len == 0 and outdir.len == 0:
+    outfiles = infiles
+  elif outfile.len != 0 and infiles.len > 1:
+    # Take the last file to maintain backwards compatibility
+    let infile = infiles[^1]
+    infiles = @[infile]
+    outfiles = @[outfile]
+  elif outfile.len != 0:
+    outfiles = @[outfile]
+  elif outdir.len != 0:
+    outfiles = infiles.mapIt($(joinPath(outdir, it)))
+
+  for (infile, outfile) in zip(infiles, outfiles):
+    let (dir, _, _) = splitFile(outfile)
+    createDir(dir)
+    if not fileExists(outfile) or not sameFile(infile, outfile):
+      backup = false # no backup needed since won't be over-written
+    if backup:
+      let infileBackup = infile & ".backup" # works with .nim or .nims
+      echo "writing backup " & infile & " > " & infileBackup
+      os.copyFile(source = infile, dest = infileBackup)
+    prettyPrint(infile, outfile, opt)
 
 main()

--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -22,7 +22,7 @@ const
 
   (c) 2017 Andreas Rumpf
 Usage:
-  nimpretty [options] [nimfiles...]
+  nimpretty [options] nimfiles...
 Options:
   --out:file            set the output file (default: overwrite the input file)
   --outDir:dir          set the output dir (default: overwrite the input files)
@@ -85,7 +85,7 @@ proc main =
       of "version", "v": writeVersion()
       of "backup": backup = parseBool(val)
       of "output", "o", "out": outfile = val
-      of "outDir", "outdir", "d": outdir = val
+      of "outDir", "outdir": outdir = val
       of "indent": opt.indWidth = parseInt(val)
       of "maxlinelen": opt.maxLineLen = parseInt(val)
       else: writeHelp()

--- a/nimpretty/tester.nim
+++ b/nimpretty/tester.nim
@@ -1,9 +1,10 @@
 # Small program that runs the test cases
 
-import strutils, os
+import strutils, os, sequtils
 
 const
   dir = "nimpretty/tests/"
+  outputdir = dir / "outputdir"
 
 var
   failures = 0
@@ -30,13 +31,36 @@ proc test(infile, ext: string) =
   else:
     echo "SUCCESS: files identical: ", nimFile
 
-for t in walkFiles(dir / "*.nim"):
+proc testTogether(infiles: seq[string]) =
+  if execShellCmd("$# --outDir:$# --backup:off $#" % [nimp, outputdir, infiles.join(" ")]) != 0:
+    echo "FAILURE: nimpretty cannot prettify files: ", $infiles
+    failures += 1
+    return
+
+  for infile in infiles:
+    let nimFile = splitFile(infile).name
+    let expected = dir / "expected" / nimFile & ".nim"
+    let produced = dir / "outputdir" / infile
+    if readFile(expected) != readFile(produced):
+      echo "FAILURE: files differ: ", nimFile
+      discard execShellCmd("diff -uNdr " & expected & " " & produced)
+      failures += 1
+    else:
+      echo "SUCCESS: files identical: ", nimFile
+
+let allFiles = toSeq(walkFiles(dir / "*.nim"))
+for t in allFiles:
   test(t, "pretty")
   # also test that pretty(pretty(x)) == pretty(x)
   test(t.changeFileExt("pretty"), "pretty2")
 
   removeFile(t.changeFileExt("pretty"))
   removeFile(t.changeFileExt("pretty2"))
+
+testTogether(allFiles)
+removeDir(outputdir)
+
+
 
 
 if failures > 0: quit($failures & " failures occurred.")


### PR DESCRIPTION
adding support for multiple files makes it easier to operate on a project without having to invoke nimpretty multiple times