### PR TITLE
Fix #2408 - add -d:globalSymbols

### DIFF
--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -454,6 +454,9 @@ Define                   Effect
                          path for the ``sh`` binary, in cases where it is not
                          located in the default location ``/bin/sh``.
 ``noSignalHandler``      Disable the crash handler from ``system.nim``.
+``globalSymbols``        Load all ``{.dynlib.}`` libraries with the ``RTLD_GLOBAL``
+                         flag on Posix systems to resolve symbols in subsequently
+                         loaded libraries.
 ======================   =========================================================
 
 

--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -91,7 +91,10 @@ when defined(posix):
     dlclose(lib)
 
   proc nimLoadLibrary(path: string): LibHandle =
-    result = dlopen(path, RTLD_NOW)
+    let flags =
+      when defined(globalSymbols): RTLD_NOW or RTLD_GLOBAL
+      else: RTLD_NOW
+    result = dlopen(path, flags)
     when defined(nimDebugDlOpen):
       let error = dlerror()
       if error != nil:


### PR DESCRIPTION
Per suggestion in #2408, adding a new `define` but calling it `globalSymbols` to match `dynlib.nim:loadLib()`:
```nim
proc loadLib(path: string, globalSymbols = false): LibHandle
```