### PR TITLE
fix #14905: new recommended flag for performance/benchmarking: -d:nimDisableAssertMsgs

### DIFF
--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -419,45 +419,51 @@ The standard library supports a growing number of ``useX`` conditional defines
 affecting how some features are implemented. This section tries to give a
 complete list.
 
-======================   =========================================================
-Define                   Effect
-======================   =========================================================
-``release``              Turns on the optimizer.
-                         More aggressive optimizations are possible, e.g.:
-                         ``--passC:-ffast-math`` (but see issue #10305)
-``danger``               Turns off all runtime checks and turns on the optimizer.
-``useFork``              Makes ``osproc`` use ``fork`` instead of ``posix_spawn``.
-``useNimRtl``            Compile and link against ``nimrtl.dll``.
-``useMalloc``            Makes Nim use C's `malloc`:idx: instead of Nim's
-                         own memory manager, albeit prefixing each allocation with
-                         its size to support clearing memory on reallocation.
-                         This only works with ``gc:none`` and
-                         with ``--newruntime``.
-``useRealtimeGC``        Enables support of Nim's GC for *soft* realtime
-                         systems. See the documentation of the `gc <gc.html>`_
-                         for further information.
-``logGC``                Enable GC logging to stdout.
-``nodejs``               The JS target is actually ``node.js``.
-``ssl``                  Enables OpenSSL support for the sockets module.
-``memProfiler``          Enables memory profiling for the native GC.
-``uClibc``               Use uClibc instead of libc. (Relevant for Unix-like OSes)
-``checkAbi``             When using types from C headers, add checks that compare
-                         what's in the Nim file with what's in the C header.
-                         This may become enabled by default in the future.
-``tempDir``              This symbol takes a string as its value, like
-                         ``--define:tempDir:/some/temp/path`` to override the
-                         temporary directory returned by ``os.getTempDir()``.
-                         The value **should** end with a directory separator
-                         character. (Relevant for the Android platform)
-``useShPath``            This symbol takes a string as its value, like
-                         ``--define:useShPath:/opt/sh/bin/sh`` to override the
-                         path for the ``sh`` binary, in cases where it is not
-                         located in the default location ``/bin/sh``.
-``noSignalHandler``      Disable the crash handler from ``system.nim``.
-``globalSymbols``        Load all ``{.dynlib.}`` libraries with the ``RTLD_GLOBAL``
-                         flag on Posix systems to resolve symbols in subsequently
-                         loaded libraries.
-======================   =========================================================
+================================   =========================================================
+Define                             Effect
+================================   =========================================================
+``release``                        Turns on the optimizer.
+                                   More aggressive optimizations are possible, e.g.:
+                                   ``--passC:-ffast-math`` (but see issue #10305)
+``danger``                         Turns off all runtime checks and turns on the optimizer.
+``nimDisableAssertMsgs``           Turns off assert/doAssert messages (see bug #14905) which
+                                   can improve performance.
+``nimDisableAssertComputedMsgs``   Compromises code size in favor of better debugging,
+                                   preserving the parts of the assert/doAssert messages that
+                                   are known at CT. This still allows good inlning as it avoids
+                                   code bloat where the assert is called.
+``useFork``                        Makes ``osproc`` use ``fork`` instead of ``posix_spawn``.
+``useNimRtl``                      Compile and link against ``nimrtl.dll``.
+``useMalloc``                      Makes Nim use C's `malloc`:idx: instead of Nim's
+                                   own memory manager, albeit prefixing each allocation with
+                                   its size to support clearing memory on reallocation.
+                                   This only works with ``gc:none`` and
+                                   with ``--newruntime``.
+``useRealtimeGC``                  Enables support of Nim's GC for *soft* realtime
+                                   systems. See the documentation of the `gc <gc.html>`_
+                                   for further information.
+``logGC``                          Enable GC logging to stdout.
+``nodejs``                         The JS target is actually ``node.js``.
+``ssl``                            Enables OpenSSL support for the sockets module.
+``memProfiler``                    Enables memory profiling for the native GC.
+``uClibc``                         Use uClibc instead of libc. (Relevant for Unix-like OSes)
+``checkAbi``                       When using types from C headers, add checks that compare
+                                   what's in the Nim file with what's in the C header.
+                                   This may become enabled by default in the future.
+``tempDir``                        This symbol takes a string as its value, like
+                                   ``--define:tempDir:/some/temp/path`` to override the
+                                   temporary directory returned by ``os.getTempDir()``.
+                                   The value **should** end with a directory separator
+                                   character. (Relevant for the Android platform)
+``useShPath``                      This symbol takes a string as its value, like
+                                   ``--define:useShPath:/opt/sh/bin/sh`` to override the
+                                   path for the ``sh`` binary, in cases where it is not
+                                   located in the default location ``/bin/sh``.
+``noSignalHandler``                Disable the crash handler from ``system.nim``.
+``globalSymbols``                  Load all ``{.dynlib.}`` libraries with the ``RTLD_GLOBAL``
+                                   flag on Posix systems to resolve symbols in subsequently
+                                   loaded libraries.
+================================   =========================================================
 
 
 

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -623,6 +623,18 @@ However, sometimes one has to optimize. Do it in the following order:
 This section can only help you with the last item.
 
 
+Recommended flags for highest performance and for benchmarking
+--------------------------------------------------------------
+To get the highest runtime performance:
+
+.. code-block::
+  nim c -d:danger -d:nimDisableAssertMsgs main.nim
+  --passc:-flto --passl:-flto # usually helps but can sometimes hurt
+  --gc:arc # usually helps but can sometimes hurt
+  -d:nimDisableAssertMsgs
+    # this can improve performance, and more importantly prevents drawing wrong
+    # conclusions from unrelated changes (see bug #14905)
+
 Optimizing string handling
 --------------------------
 

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -633,7 +633,8 @@ To get the highest runtime performance:
   --gc:arc # usually helps but can sometimes hurt
   -d:nimDisableAssertMsgs
     # this can improve performance, and more importantly prevents drawing wrong
-    # conclusions from unrelated changes (see bug #14905)
+    # conclusions from unrelated changes (see bug #14905); for a compromise,
+    # use `-d:nimDisableAssertComputedMsgs`.
 
 Optimizing string handling
 --------------------------


### PR DESCRIPTION
* fix #14905 (make sure you read that carefully and understand it before reading this PR)
* `-d:nimDisableAssertMsgs` completely optimizes away the code that generates the assert/doAssert message: ```ploc & " `" & expr & "` " & msg```

## example1
```nim
# D20200704T184212
proc main[T](x, y: T) =
  proc bar(): string =
    echo "in bar" # wont be executed with -d:nimDisableAssertMsgs
    return "foo"
  doAssert x == y, $(x, y, bar())
main(12, 13)
```
* note that the assert/doAssert message generation generates code bloat (pressure on instruction cache) even if it's not executed at runtime, which can cause performance drop as well as the issues mentioned in #14905 where unrelated code changes would cause 1.4X performance differences, because it can affect C compiler's inlining decisions
* it would not be enough to drop `ploc` or `expr` or `msg`, as either of these would still affect code bloat (eg preventing some inlining to happen depending on context, where the context is hard/impossible to model)
* note that the argument "use assert instead of doAssert if you care about performance or in benchmarks" is invalid, because doAssert is still useful both in danger builds (eg to do a cheap but important check) or in benchmarks (eg to avoid optimizing away some code)

## example2: 11x speedup via `-d:nimDisableAssertMsgs`
speedup from `-d:nimDisableAssertMsgs` can be arbitrarily large, eg:

nim r -d:danger -d:case2 $timn_D/tests/nim/all/t11044.nim
with -d:nimDisableAssertMsgs: 0.539
without -d:nimDisableAssertMsgs: 6.60

note that in this particular simple example, `--passc:-flto --passl:-flto` would've given same result for both, but `--passc:-flto --passl:-flto` doesn't always help (eg, nim itself compiled with `--passc:-flto --passl:-flto -d:danger`  is slower than with `-d:danger`).

```nim
when true:
  # import timn/exp/benchutils2
  from times import cpuTime
  template benchmarkDisp*(name, n, body): untyped =
    let t = cpuTime()
    for i in 0..<n:
      body
    let t2 = cpuTime() - t
    echo (name, t2)

  proc bar(n: int): int =
    result = 0
    for i in 0..<n:
      result += (i*i) div n
      doAssert result != -3, $(result, i, n)
  proc main() =
    var tot = 0
    benchmarkDisp("bar", 10):
      tot += bar(1_00000000)
    echo tot
  main()
```
