### PR TITLE
Fix logging tiny bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -125,7 +125,7 @@
 
 - Add `jsre` module, [Regular Expressions for the JavaScript target.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
 - Made `maxLines` argument `Positive` in `logging.newRollingFileLogger`,
-  because negative values cause 1 new file per line of log, and make no sense whatsoever.
+  because negative values will result in a new file being created for each logged line which doesn't make sense.
 - Changed `log` on `logging` to use proper log level on JavaScript target,
   eg. `debug` uses `console.debug`, `info` uses `console.info`, `warn` uses `console.warn`, etc.
 

--- a/changelog.md
+++ b/changelog.md
@@ -126,7 +126,7 @@
 - Add `jsre` module, [Regular Expressions for the JavaScript target.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
 - Made `maxLines` argument `Positive` in `logging.newRollingFileLogger`,
   because negative values will result in a new file being created for each logged line which doesn't make sense.
-- Changed `log` on `logging` to use proper log level on JavaScript target,
+- Changed `log` in `logging` to use proper log level on JavaScript target,
   eg. `debug` uses `console.debug`, `info` uses `console.info`, `warn` uses `console.warn`, etc.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -124,6 +124,10 @@
 - deprecations: `os.existsDir` => `dirExists`, `os.existsFile` => `fileExists`
 
 - Add `jsre` module, [Regular Expressions for the JavaScript target.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
+- Changed `maxLines` to `Positive` on `logging.newRollingFileLogger`,
+  because negative values cause 1 new file per line of log, and make no sense whatsoever.
+- Changed `log` on `logging` to use proper log level on JavaScript target,
+  eg. `debug` uses `console.debug`, `info` uses `console.info`, `warn` uses `console.warn`, etc.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -124,7 +124,7 @@
 - deprecations: `os.existsDir` => `dirExists`, `os.existsFile` => `fileExists`
 
 - Add `jsre` module, [Regular Expressions for the JavaScript target.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
-- Changed `maxLines` to `Positive` on `logging.newRollingFileLogger`,
+- Made `maxLines` argument `Positive` in `logging.newRollingFileLogger`,
   because negative values cause 1 new file per line of log, and make no sense whatsoever.
 - Changed `log` on `logging` to use proper log level on JavaScript target,
   eg. `debug` uses `console.debug`, `info` uses `console.info`, `warn` uses `console.warn`, etc.

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -508,8 +508,11 @@ when not defined(js):
 
   # ------
 
-  template countLogLines(logger: RollingFileLogger): int =
-    readFile(logger.baseName).countLines()
+  proc countLogLines(logger: RollingFileLogger): int =
+    let fp = open(logger.baseName, fmRead)
+    for line in fp.lines():
+      result.inc()
+    fp.close()
 
   proc countFiles(filename: string): int =
     # Example: file.log.1


### PR DESCRIPTION
- Changed `maxLines` to `Positive` on `logging.newRollingFileLogger`,
  because negative values cause 1 new file per line of log, and make no sense whatsoever.
- Changed `log` on `logging` to use proper log level on JavaScript target,
  eg. `debug` uses `console.debug`, `info` uses `console.info`, `warn` uses `console.warn`, etc.
- Internal proc `countLogLines` simplified.

You can check the Bug with this code:
```nim
import logging
var rollingLog = newRollingFileLogger("rolling.log", maxLines = -9)
addHandler(rollingLog)
for _ in 0..99: info "42"
```

:)