### PR TITLE
enable,document,test getImplTransformed, very useful for understanding how nim transforms code

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -281,12 +281,12 @@ else: # bootstrapping substitute
 
 {.pop.}
 
-since (1,3,5):
+when (NimMajor, NimMinor, NimPatch) >= (1, 3, 5) or defined(nimSymImplTransform):
   proc getImplTransformed*(symbol: NimNode): NimNode {.magic: "GetImplTransf", noSideEffect.}
     ## For a typed proc returns the AST after transformation pass; this is useful
-    ## for debugging how the compiler transforms code but note that code transformations
-    ## are implementation dependent and subject to change.
-    ## see example in `tests/macros/tmacros_various.nim`.
+    ## for debugging how the compiler transforms code (eg: `defer`, `for`) but
+    ## note that code transformations are implementation dependent and subject to change.
+    ## See an example in `tests/macros/tmacros_various.nim`.
 
 when defined(nimHasSymOwnerInMacro):
   proc owner*(sym: NimNode): NimNode {.magic: "SymOwner", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -281,9 +281,12 @@ else: # bootstrapping substitute
 
 {.pop.}
 
-when defined(nimSymImplTransform):
+since (1,3,5):
   proc getImplTransformed*(symbol: NimNode): NimNode {.magic: "GetImplTransf", noSideEffect.}
-    ## For a typed proc returns the AST after transformation pass.
+    ## For a typed proc returns the AST after transformation pass; this is useful
+    ## for debugging how the compiler transforms code but note that code transformations
+    ## are implementation dependent and subject to change.
+    ## see example in `tests/macros/tmacros_various.nim`.
 
 when defined(nimHasSymOwnerInMacro):
   proc owner*(sym: NimNode): NimNode {.magic: "SymOwner", noSideEffect.}

--- a/tests/macros/tmacros_various.nim
+++ b/tests/macros/tmacros_various.nim
@@ -202,3 +202,24 @@ block tupleNewLitTests:
     # this `$` test is needed because tuple equality doesn't distinguish
     # between named vs unnamed tuples
   doAssert t() == (1, "foo", (), (1, ), (a1: 'x', a2: @["ba"]))
+
+from strutils import contains
+block getImplTransformed:
+  macro bar(a: typed): string =
+    # newLit a.getImpl.repr # this would be before code transformation
+    let b = a.getImplTransformed
+    newLit b.repr
+  template toExpand() =
+    for ai in 0..2: echo ai
+  proc baz(a=1): int =
+    defer: discard
+    toExpand()
+    12
+  const code = bar(baz)
+  echo code
+  # sanity check:
+  doAssert "finally" in code # `defer` is lowered to try/finally
+  doAssert "while" in code # `for` is lowered to `while`
+  doAssert "toExpand" notin code
+    # template is expanded (but that would already be the case with
+    # `a.getImpl.repr`, unlike the other transformations mentioned above

--- a/tests/macros/tmacros_various.nim
+++ b/tests/macros/tmacros_various.nim
@@ -216,7 +216,6 @@ block getImplTransformed:
     toExpand()
     12
   const code = bar(baz)
-  echo code
   # sanity check:
   doAssert "finally" in code # `defer` is lowered to try/finally
   doAssert "while" in code # `for` is lowered to `while`


### PR DESCRIPTION
`getImplTransformed` is very useful to understand how code is transformed, whether for curiosity, to spot inefficiencies / bugs, or to help with debugging during compiler bugfixing

## example
```nim
when true:
  macro bar(a: typed): string =
    # newLit a.getImpl.repr # this would be before code transformation
    let b = a.getImplTransformed
    newLit b.repr
  template toExpand() =
    for ai in 0..2: echo ai
  proc baz(a=1): int =
    defer: discard
    toExpand()
    12
  echo bar(baz)
```

returns:
```nim
proc baz(a = 1): int =
  result =
    try:
      block :tmp15945026:
        var ai`gensym15941048
        ## An alias for `countup(a, b, 1)`.
        ##
        ## See also:
        ## * [..<](#..<.i,T,T)
        ##
        ## .. code-block:: Nim
        ##   for i in 3 .. 7:
        ##     echo i # => 3; 4; 5; 6; 7
        var res = 0
        block :tmp15945029:
          while res <= 2:
            ai`gensym15941048 = T(res)
            echo [ai`gensym15941048]
            inc(res, 1)
      12
    finally:
      discard
```

