### PR TITLE
[superseded] fix #14895 by calling `nextPowerOfTwo` instead of `rightSize`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -128,6 +128,8 @@
   because negative values will result in a new file being created for each logged line which doesn't make sense.
 - Changed `log` in `logging` to use proper log level on JavaScript target,
   eg. `debug` uses `console.debug`, `info` uses `console.info`, `warn` uses `console.warn`, etc.
+- table-like initialization routines (e.g. `initTable`) can now accept non-power-of-2 `initialSize`
+  parameter, and it will be automatically resized via `nextPowerOfTwo`.
 
 
 ## Language changes

--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -76,17 +76,9 @@ template checkIfInitialized(deq: typed) =
     if deq.mask == 0:
       initImpl(deq, defaultInitialSize)
 
-proc initDeque*[T](initialSize: int = 4): Deque[T] =
-  ## Create a new empty deque.
-  ##
-  ## Optionally, the initial capacity can be reserved via `initialSize`
-  ## as a performance optimization.
-  ## The length of a newly created deque will still be 0.
-  ##
-  ## ``initialSize`` must be a power of two (default: 4).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_.
+proc initDeque*[T](initialSize: int = defaultInitialSize): Deque[T] =
+  ## Creates a new empty `Deque`, see `initTable proc<table.html#initTable,int>`_
+  ## for explanation on parameters.
   result.initImpl(initialSize)
 
 proc len*[T](deq: Deque[T]): int {.inline.} =

--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -77,7 +77,7 @@ template checkIfInitialized(deq: typed) =
       initImpl(deq, defaultInitialSize)
 
 proc initDeque*[T](initialSize: int = defaultInitialSize): Deque[T] =
-  ## Creates a new empty `Deque`, see `initTable proc<table.html#initTable,int>`_
+  ## Creates a new empty `Deque`, see `initTable proc<tables.html#initTable>`_
   ## for explanation on parameters.
   result.initImpl(initialSize)
 

--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -67,9 +67,9 @@ const
   defaultInitialSize* = 4
 
 template initImpl(result: typed, initialSize: int) =
-  assert isPowerOfTwo(initialSize)
-  result.mask = initialSize-1
-  newSeq(result.data, initialSize)
+  let size2 = nextPowerOfTwo(initialSize)
+  result.mask = size2-1
+  newSeq(result.data, size2)
 
 template checkIfInitialized(deq: typed) =
   when compiles(defaultInitialSize):

--- a/lib/pure/collections/setimpl.nim
+++ b/lib/pure/collections/setimpl.nim
@@ -16,12 +16,12 @@ template dataLen(t): untyped = len(t.data)
 include hashcommon
 
 template initImpl(s: typed, size: int) =
-  assert isPowerOfTwo(size)
+  let size2 = nextPowerOfTwo(size)
   when s is OrderedSet:
     s.first = -1
     s.last = -1
   s.counter = 0
-  newSeq(s.data, size)
+  newSeq(s.data, size2)
 
 template rawInsertImpl() {.dirty.} =
   if data.len == 0:

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -208,11 +208,10 @@ proc len*[A, B](t: var SharedTable[A, B]): int =
     result = t.counter
 
 proc init*[A, B](t: var SharedTable[A, B], initialSize = 64) =
-  ## creates a new empty SharedTable.
+  ## Creates a new empty `SharedTable`, see `initTable proc<tables.html#initTable>`_
+  ## for explanation on parameters.
   ##
   ## This proc must be called before any other usage of `t`.
-  ##
-  ## To store `n` elements without resizing, usse `initialSize=rightSize(n)`.
   let size2 = nextPowerOfTwo(initialSize)
   t.counter = 0
   t.dataLen = size2

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -208,11 +208,11 @@ proc len*[A, B](t: var SharedTable[A, B]): int =
     result = t.counter
 
 proc init*[A, B](t: var SharedTable[A, B], initialSize = 64) =
-  ## creates a new hash table that is empty.
+  ## creates a new empty SharedTable.
   ##
   ## This proc must be called before any other usage of `t`.
   ##
-  ## To store `n` elements without resizing you can use `rightSize`.
+  ## To store `n` elements without resizing, usse `initialSize=rightSize(n)`.
   let size2 = nextPowerOfTwo(initialSize)
   t.counter = 0
   t.dataLen = size2

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -212,14 +212,12 @@ proc init*[A, B](t: var SharedTable[A, B], initialSize = 64) =
   ##
   ## This proc must be called before any other usage of `t`.
   ##
-  ## `initialSize` needs to be a power of two. If you need to accept runtime
-  ## values for this you could use the ``nextPowerOfTwo`` proc from the
-  ## `math <math.html>`_ module or the ``rightSize`` proc from this module.
-  assert isPowerOfTwo(initialSize)
+  ## To store `n` elements without resizing you can use `rightSize`.
+  let size2 = nextPowerOfTwo(initialSize)
   t.counter = 0
-  t.dataLen = initialSize
+  t.dataLen = size2
   t.data = cast[KeyValuePairSeq[A, B]](allocShared0(
-                                      sizeof(KeyValuePair[A, B]) * initialSize))
+                                      sizeof(KeyValuePair[A, B]) * size2))
   initLock t.lock
 
 proc deinitSharedTable*[A, B](t: var SharedTable[A, B]) =

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -121,12 +121,12 @@ template ctAnd(a, b): bool =
   else: false
 
 template initImpl(result: typed, size: int) =
+  let size2 = nextPowerOfTwo(size)
   when ctAnd(declared(SharedTable), type(result) is SharedTable):
-    init(result, size)
+    init(result, size2)
   else:
-    assert isPowerOfTwo(size)
     result.counter = 0
-    newSeq(result.data, size)
+    newSeq(result.data, size2)
     when compiles(result.first):
       result.first = -1
       result.last = -1

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -286,23 +286,28 @@ proc enlarge[A, B](t: var Table[A, B]) =
 # -------------------------------------------------------------------
 
 proc initTable*[A, B](initialSize = defaultInitialSize): Table[A, B] =
-  ## Creates a new empty `Table`.
+  ## Creates a new empty `Table` with at least `initialSize` slots.
   ##
-  ## To store `n` elements without resizing, use `initialSize=rightSize(n)`,
-  ## see `rightSize proc<#rightSize,Natural>`_.
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ will be called to
-  ## ensure a power of 2 will be used.
+  ## `initTable` will allocate a seq of size `nextPowerOfTwo(initialSize)`.
+  ## To store `n` elements without resizing, use `initialSize = rightSize(n)`.
   ##
-  ## Starting from Nim v0.20, tables are initialized by default and it is
-  ## not necessary to call this function explicitly.
+  ## Starting from Nim v0.20, `Table` and table-like data structures
+  ## (except `SharedTable`) are initialized by default and it is
+  ## not necessary to call this function explicitly, unless you want to
+  ## pre-allocate space to reduce likelihood of resizing.
   ##
   ## See also:
   ## * `toTable proc<#toTable,openArray[]>`_
   ## * `newTable proc<#newTable,int>`_ for creating a `TableRef`
+  ## * `rightSize proc<#rightSize,Natural>`_
+  ## * `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_
   runnableExamples:
     let
       a = initTable[int, string]()
-      b = initTable[char, seq[int]]()
+      b = initTable[char, seq[int]](123)
+        # will allocate 128 slots, but to store 123 elements without resizing,
+        # use `rightSize(123)`
+    doAssert b.len == 0
   initImpl(result, initialSize)
 
 proc `[]=`*[A, B](t: var Table[A, B], key: A, val: B) =

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -288,11 +288,9 @@ proc enlarge[A, B](t: var Table[A, B]) =
 proc initTable*[A, B](initialSize = defaultInitialSize): Table[A, B] =
   ## Creates a new hash table that is empty.
   ##
-  ## ``initialSize`` must be a power of two (default: 64).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
-  ## from this module.
+  ## `initialSize` will be resized via
+  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ `; if you expect `n`
+  ## elements you can use `rightSize proc<#rightSize,Natural>`_.
   ##
   ## Starting from Nim v0.20, tables are initialized by default and it is
   ## not necessary to call this function explicitly.

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -286,11 +286,12 @@ proc enlarge[A, B](t: var Table[A, B]) =
 # -------------------------------------------------------------------
 
 proc initTable*[A, B](initialSize = defaultInitialSize): Table[A, B] =
-  ## Creates a new hash table that is empty.
+  ## Creates a new empty `Table`.
   ##
-  ## `initialSize` will be resized via
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ `; if you expect `n`
-  ## elements you can use `rightSize proc<#rightSize,Natural>`_.
+  ## To store `n` elements without resizing, usse `initialSize=rightSize(n)`,
+  ## see `rightSize proc<#rightSize,Natural>`_.
+  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ will be called to
+  ## ensure a power of 2 will be used.
   ##
   ## Starting from Nim v0.20, tables are initialized by default and it is
   ## not necessary to call this function explicitly.

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -230,7 +230,7 @@ type
     ## `data` and `counter` are internal implementation details which
     ## can't be accessed.
     ##
-    ## For creating an empty Table, use `initTable proc<#initTable,int>`_.
+    ## For creating an empty Table, use `initTable proc<#initTable>`_.
     data: KeyValuePairSeq[A, B]
     counter: int
   TableRef*[A, B] = ref Table[A, B] ## Ref version of `Table<#Table>`_.
@@ -327,7 +327,7 @@ proc toTable*[A, B](pairs: openArray[(A, B)]): Table[A, B] =
   ## ``pairs`` is a container consisting of ``(key, value)`` tuples.
   ##
   ## See also:
-  ## * `initTable proc<#initTable,int>`_
+  ## * `initTable proc<#initTable>`_
   ## * `newTable proc<#newTable,openArray[]>`_ for a `TableRef` version
   runnableExamples:
     let a = [('a', 5), ('b', 9)]
@@ -777,13 +777,13 @@ iterator allValues*[A, B](t: Table[A, B]; key: A): B =
 
 
 proc newTable*[A, B](initialSize = defaultInitialSize): <//>TableRef[A, B] =
-  ## Creates a new empty `TableRef`, see `initTable proc<#initTable,int>`_
+  ## Creates a new empty `TableRef`, see `initTable proc<#initTable>`_
   ## for explanation on parameters.
   ##
   ## See also:
   ## * `newTable proc<#newTable,openArray[]>`_ for creating a `TableRef`
   ##   from a collection of `(key, value)` pairs
-  ## * `initTable proc<#initTable,int>`_ for creating a `Table`
+  ## * `initTable proc<#initTable>`_ for creating a `Table`
   runnableExamples:
     let
       a = newTable[int, string]()
@@ -1252,7 +1252,7 @@ template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
 # ----------------------------------------------------------------------
 
 proc initOrderedTable*[A, B](initialSize = defaultInitialSize): OrderedTable[A, B] =
-  ## Creates a new empty `OrderedTable`, see `initTable proc<#initTable,int>`_
+  ## Creates a new empty `OrderedTable`, see `initTable proc<#initTable>`_
   ## for explanation on parameters.
   ##
   ## See also:
@@ -1755,7 +1755,7 @@ iterator mvalues*[A, B](t: var OrderedTable[A, B]): var B =
 # ---------------------------------------------------------------------------
 
 proc newOrderedTable*[A, B](initialSize = defaultInitialSize): <//>OrderedTableRef[A, B] =
-  ## Creates a new empty `OrderedTableRef`, see `initTable proc<#initTable,int>`_
+  ## Creates a new empty `OrderedTableRef`, see `initTable proc<#initTable>`_
   ## for explanation on parameters.
   ##
   ## See also:
@@ -2230,7 +2230,7 @@ proc inc*[A](t: var CountTable[A], key: A, val: Positive = 1)
 # ----------------------------------------------------------------------
 
 proc initCountTable*[A](initialSize = defaultInitialSize): CountTable[A] =
-  ## Creates a new empty `CountTable`, see `initTable proc<#initTable,int>`_
+  ## Creates a new empty `CountTable`, see `initTable proc<#initTable>`_
   ## for explanation on parameters.
   ##
   ## See also:
@@ -2588,7 +2588,7 @@ iterator mvalues*[A](t: var CountTable[A]): var int =
 proc inc*[A](t: CountTableRef[A], key: A, val = 1)
 
 proc newCountTable*[A](initialSize = defaultInitialSize): <//>CountTableRef[A] =
-  ## Creates a new empty `CountTableRef`, see `initTable proc<#initTable,int>`_
+  ## Creates a new empty `CountTableRef`, see `initTable proc<#initTable>`_
   ## for explanation on parameters.
   ##
   ## See also:

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -777,13 +777,8 @@ iterator allValues*[A, B](t: Table[A, B]; key: A): B =
 
 
 proc newTable*[A, B](initialSize = defaultInitialSize): <//>TableRef[A, B] =
-  ## Creates a new ref hash table that is empty.
-  ##
-  ## ``initialSize`` must be a power of two (default: 64).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
-  ## from this module.
+  ## Creates a new empty `TableRef`, see `initTable proc<#initTable,int>`_
+  ## for explanation on parameters.
   ##
   ## See also:
   ## * `newTable proc<#newTable,openArray[]>`_ for creating a `TableRef`
@@ -1257,16 +1252,8 @@ template forAllOrderedPairs(yieldStmt: untyped) {.dirty.} =
 # ----------------------------------------------------------------------
 
 proc initOrderedTable*[A, B](initialSize = defaultInitialSize): OrderedTable[A, B] =
-  ## Creates a new ordered hash table that is empty.
-  ##
-  ## ``initialSize`` must be a power of two (default: 64).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
-  ## from this module.
-  ##
-  ## Starting from Nim v0.20, tables are initialized by default and it is
-  ## not necessary to call this function explicitly.
+  ## Creates a new empty `OrderedTable`, see `initTable proc<#initTable,int>`_
+  ## for explanation on parameters.
   ##
   ## See also:
   ## * `toOrderedTable proc<#toOrderedTable,openArray[]>`_
@@ -1768,13 +1755,8 @@ iterator mvalues*[A, B](t: var OrderedTable[A, B]): var B =
 # ---------------------------------------------------------------------------
 
 proc newOrderedTable*[A, B](initialSize = defaultInitialSize): <//>OrderedTableRef[A, B] =
-  ## Creates a new ordered ref hash table that is empty.
-  ##
-  ## ``initialSize`` must be a power of two (default: 64).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
-  ## from this module.
+  ## Creates a new empty `OrderedTableRef`, see `initTable proc<#initTable,int>`_
+  ## for explanation on parameters.
   ##
   ## See also:
   ## * `newOrderedTable proc<#newOrderedTable,openArray[]>`_ for creating
@@ -2248,16 +2230,8 @@ proc inc*[A](t: var CountTable[A], key: A, val: Positive = 1)
 # ----------------------------------------------------------------------
 
 proc initCountTable*[A](initialSize = defaultInitialSize): CountTable[A] =
-  ## Creates a new count table that is empty.
-  ##
-  ## ``initialSize`` must be a power of two (default: 64).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
-  ## from this module.
-  ##
-  ## Starting from Nim v0.20, tables are initialized by default and it is
-  ## not necessary to call this function explicitly.
+  ## Creates a new empty `CountTable`, see `initTable proc<#initTable,int>`_
+  ## for explanation on parameters.
   ##
   ## See also:
   ## * `toCountTable proc<#toCountTable,openArray[A]>`_
@@ -2614,13 +2588,8 @@ iterator mvalues*[A](t: var CountTable[A]): var int =
 proc inc*[A](t: CountTableRef[A], key: A, val = 1)
 
 proc newCountTable*[A](initialSize = defaultInitialSize): <//>CountTableRef[A] =
-  ## Creates a new ref count table that is empty.
-  ##
-  ## ``initialSize`` must be a power of two (default: 64).
-  ## If you need to accept runtime values for this you could use the
-  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
-  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
-  ## from this module.
+  ## Creates a new empty `CountTableRef`, see `initTable proc<#initTable,int>`_
+  ## for explanation on parameters.
   ##
   ## See also:
   ## * `newCountTable proc<#newCountTable,openArray[A]>`_ for creating

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -288,7 +288,7 @@ proc enlarge[A, B](t: var Table[A, B]) =
 proc initTable*[A, B](initialSize = defaultInitialSize): Table[A, B] =
   ## Creates a new empty `Table`.
   ##
-  ## To store `n` elements without resizing, usse `initialSize=rightSize(n)`,
+  ## To store `n` elements without resizing, use `initialSize=rightSize(n)`,
   ## see `rightSize proc<#rightSize,Natural>`_.
   ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ will be called to
   ## ensure a power of 2 will be used.

--- a/tests/misc/tsimplesort.nim
+++ b/tests/misc/tsimplesort.nim
@@ -106,7 +106,7 @@ proc del*[A, B](t: var TTable[A, B], key: A) =
     dec(t.counter)
 
 proc initTable*[A, B](initialSize=64): TTable[A, B] =
-  ## creates a new empty hash table.
+  ## creates a new empty `TTable`.
   let size2 = nextPowerOfTwo(initialSize)
   result.counter = 0
   newSeq(result.data, size2)

--- a/tests/misc/tsimplesort.nim
+++ b/tests/misc/tsimplesort.nim
@@ -106,11 +106,10 @@ proc del*[A, B](t: var TTable[A, B], key: A) =
     dec(t.counter)
 
 proc initTable*[A, B](initialSize=64): TTable[A, B] =
-  ## creates a new hash table that is empty. `initialSize` needs to be
-  ## a power of two.
-  assert isPowerOfTwo(initialSize)
+  ## creates a new empty hash table.
+  let size2 = nextPowerOfTwo(initialSize)
   result.counter = 0
-  newSeq(result.data, initialSize)
+  newSeq(result.data, size2)
 
 proc toTable*[A, B](pairs: openarray[tuple[key: A,
                     val: B]]): TTable[A, B] =
@@ -199,11 +198,10 @@ proc `[]=`*[A](t: var TCountTable[A], key: A, val: int) =
   putImpl()
 
 proc initCountTable*[A](initialSize=64): TCountTable[A] =
-  ## creates a new count table that is empty. `initialSize` needs to be
-  ## a power of two.
-  assert isPowerOfTwo(initialSize)
+  ## creates a new empty `CountTable`.
+  let size2 = nextPowerOfTwo(initialSize)
   result.counter = 0
-  newSeq(result.data, initialSize)
+  newSeq(result.data, size2)
 
 proc toCountTable*[A](keys: openArray[A]): TCountTable[A] =
   ## creates a new count table with every key in `keys` having a count of 1.


### PR DESCRIPTION
* fix #14895 and relax condition that input size must be a power of 2
* avoid performance regressions and problems with approach in https://github.com/nim-lang/Nim/pull/14926; unlike in that PR there is no risk of rightSize being called twice, since `nextPowerOfTwo(n) = n` when n is a power of 2 (unlike rightSize(n))
* unlike some other proposal that was treating power of 2 inputs differently, this PR doesn't special case power of 2 inputs and guarantees monotonic behavior
> Was the approach of "only call rightSize if the argument is not a power of two" considered? (I don't have a strong opinion).
=> see https://github.com/nim-lang/Nim/pull/14926#issuecomment-654753704 for details

* forward compatible in case underlying implementation changes

~~TODO before merging: update doc comments~~ done
