### PR TITLE
Clean out macros

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -139,7 +139,7 @@
 - Tables, HashSets, SharedTables and deques don't require anymore that the passed
   initial size must be a power of two - this is done internally.
   Proc `rightSize` for Tables and HashSets is deprecated, as it is not needed anymore.
-
+- Removed deprecated symbols from `macros` module, deprecated as far back as `0.15`.
 
 
 ## Language changes

--- a/examples/talk/formatoptimizer.nim
+++ b/examples/talk/formatoptimizer.nim
@@ -33,7 +33,7 @@ macro optFormat{`%`(f, a)}(f: string{lit}, a: openArray[string]): untyped =
   #newCall("&")
   let f = f.strVal
   formatImpl(newLit)
-  result = nestList(!"&", result)
+  result = nestList(newIdentNode("&"), result)
 
 template optAdd1{x = y; add(x, z)}(x, y, z: string) =
   x = y & z

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -140,7 +140,7 @@ const
 
 {.push warnings: off.}
 
-proc `!`*(s: string): NimIdent {.magic: "StrToIdent", noSideEffect, deprecated:
+proc toNimIdent*(s: string): NimIdent {.magic: "StrToIdent", noSideEffect, deprecated:
   "Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.".}
   ## Constructs an identifier from the string `s`.
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -140,6 +140,10 @@ const
 
 {.push warnings: off.}
 
+proc `!`*(s: string): NimIdent {.magic: "StrToIdent", noSideEffect, deprecated:
+  "Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.".}
+  ## Constructs an identifier from the string `s`.
+
 proc `==`*(a, b: NimIdent): bool {.magic: "EqIdent", noSideEffect, deprecated:
   "Deprecated since version 0.18.1; Use '==' on 'NimNode' instead.".}
   ## Compares two Nim identifiers.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -237,6 +237,8 @@ proc ident*(n: NimNode): NimIdent {.magic: "NIdent", noSideEffect, deprecated:
 proc symbol*(n: NimNode): NimSym {.magic: "NSymbol", noSideEffect, deprecated:
   "Deprecated since version 0.18.1; All functionality is defined on 'NimNode'.".}
 
+proc getImpl*(s: NimSym): NimNode {.magic: "GetImpl", noSideEffect, deprecated: "use `getImpl: NimNode -> NimNode` instead".}
+
 when defined(nimSymKind):
   proc symKind*(symbol: NimNode): NimSymKind {.magic: "NSymKind", noSideEffect.}
   proc getImpl*(symbol: NimNode): NimNode {.magic: "GetImpl", noSideEffect.}
@@ -376,23 +378,6 @@ proc getTypeImpl*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
 
 proc `intVal=`*(n: NimNode, val: BiggestInt) {.magic: "NSetIntVal", noSideEffect.}
 proc `floatVal=`*(n: NimNode, val: BiggestFloat) {.magic: "NSetFloatVal", noSideEffect.}
-
-{.push warnings: off.}
-
-proc `symbol=`*(n: NimNode, val: NimSym) {.magic: "NSetSymbol", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Generate a new 'NimNode' with 'genSym' instead.".}
-
-proc `ident=`*(n: NimNode, val: NimIdent) {.magic: "NSetIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.1; Generate a new 'NimNode' with 'ident(string)' instead.".}
-
-{.pop.}
-
-#proc `typ=`*(n: NimNode, typ: typedesc) {.magic: "NSetType".}
-# this is not sound! Unfortunately forbidding 'typ=' is not enough, as you
-# can easily do:
-#   let bracket = semCheck([1, 2])
-#   let fake = semCheck(2.0)
-#   bracket[0] = fake  # constructs a mixed array with ints and floats!
 
 proc `strVal=`*(n: NimNode, val: string) {.magic: "NSetStrVal", noSideEffect.}
   ## Sets the string value of a string literal or comment.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -140,14 +140,6 @@ const
 
 {.push warnings: off.}
 
-proc `!`*(s: string): NimIdent {.magic: "StrToIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.".}
-  ## Constructs an identifier from the string `s`.
-
-proc toNimIdent*(s: string): NimIdent {.magic: "StrToIdent", noSideEffect, deprecated:
-  "Deprecated since version 0.18.0: Use 'ident' or 'newIdentNode' instead.".}
-  ## Constructs an identifier from the string `s`.
-
 proc `==`*(a, b: NimIdent): bool {.magic: "EqIdent", noSideEffect, deprecated:
   "Deprecated since version 0.18.1; Use '==' on 'NimNode' instead.".}
   ## Compares two Nim identifiers.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -826,14 +826,6 @@ proc nestList*(op: NimNode; pack: NimNode; init: NimNode): NimNode {.compileTime
   for i in countdown(pack.len - 1, 0):
     result = newCall(op, pack[i], result)
 
-{.push warnings: off.}
-
-proc nestList*(theProc: NimIdent, x: NimNode): NimNode {.compileTime, deprecated:
-  "Deprecated since v0.18.1; use one of 'nestList(NimNode, ...)' instead.".} =
-  nestList(newIdentNode(theProc), x)
-
-{.pop.}
-
 proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indented = false) {.benign.} =
   if level > 0:
     if indented:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1628,21 +1628,6 @@ macro getCustomPragmaVal*(n: typed, cp: typed{nkSym}): untyped =
   if result.kind == nnkEmpty:
     error(n.repr & " doesn't have a pragma named " & cp.repr()) # returning an empty node results in most cases in a cryptic error,
 
-
-when not defined(booting):
-  template emit*(e: static[string]): untyped {.deprecated.} =
-    ## Accepts a single string argument and treats it as nim code
-    ## that should be inserted verbatim in the program
-    ## Example:
-    ##
-    ## .. code-block:: nim
-    ##   emit("echo " & '"' & "hello world".toUpper & '"')
-    ##
-    ## Deprecated since version 0.15 since it's so rarely useful.
-    macro payload: untyped {.gensym.} =
-      result = parseStmt(e)
-    payload()
-
 macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped =
   result = newCall(callee)
   for i in 0 ..< args.len:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -379,6 +379,16 @@ proc getTypeImpl*(n: typedesc): NimNode {.magic: "NGetType", noSideEffect.}
 proc `intVal=`*(n: NimNode, val: BiggestInt) {.magic: "NSetIntVal", noSideEffect.}
 proc `floatVal=`*(n: NimNode, val: BiggestFloat) {.magic: "NSetFloatVal", noSideEffect.}
 
+{.push warnings: off.}
+
+proc `symbol=`*(n: NimNode, val: NimSym) {.magic: "NSetSymbol", noSideEffect, deprecated:
+  "Deprecated since version 0.18.1; Generate a new 'NimNode' with 'genSym' instead.".}
+
+proc `ident=`*(n: NimNode, val: NimIdent) {.magic: "NSetIdent", noSideEffect, deprecated:
+  "Deprecated since version 0.18.1; Generate a new 'NimNode' with 'ident(string)' instead.".}
+
+{.pop.}
+
 proc `strVal=`*(n: NimNode, val: string) {.magic: "NSetStrVal", noSideEffect.}
   ## Sets the string value of a string literal or comment.
   ## Setting `strVal` is disallowed for `nnkIdent` and `nnkSym` nodes; a new node

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -237,8 +237,6 @@ proc ident*(n: NimNode): NimIdent {.magic: "NIdent", noSideEffect, deprecated:
 proc symbol*(n: NimNode): NimSym {.magic: "NSymbol", noSideEffect, deprecated:
   "Deprecated since version 0.18.1; All functionality is defined on 'NimNode'.".}
 
-proc getImpl*(s: NimSym): NimNode {.magic: "GetImpl", noSideEffect, deprecated: "use `getImpl: NimNode -> NimNode` instead".}
-
 when defined(nimSymKind):
   proc symKind*(symbol: NimNode): NimSymKind {.magic: "NSymKind", noSideEffect.}
   proc getImpl*(symbol: NimNode): NimNode {.magic: "GetImpl", noSideEffect.}

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -679,7 +679,7 @@ macro check*(conditions: untyped): untyped =
     result = newNimNode(nnkStmtList)
     for node in checked:
       if node.kind != nnkCommentStmt:
-        result.add(newCall(!"check", node))
+        result.add(newCall(newIdentNode("check"), node))
 
   else:
     let lineinfo = newStrLitNode(checked.lineInfo)

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -9,7 +9,7 @@ var packages2*: seq[tuple[name, cmd: string; hasDeps: bool; url: string, useHead
 
 
 # packages A-M
-pkg1 "alea", true
+# pkg1 "alea", true
 pkg1 "argparse"
 pkg1 "arraymancer", true, "nim c tests/tests_cpu.nim"
 pkg1 "ast_pattern_matching", false, "nim c -r --oldgensym:on tests/test1.nim"

--- a/tests/macros/tmemit.nim
+++ b/tests/macros/tmemit.nim
@@ -1,14 +1,11 @@
 discard """
   output: '''
-HELLO WORLD
 c_func
 12
 '''
 """
 
 import macros, strutils
-
-emit("echo " & '"' & "hello world".toUpperAscii & '"')
 
 # bug #1025
 

--- a/tests/showoff/tformatopt.nim
+++ b/tests/showoff/tformatopt.nim
@@ -37,7 +37,7 @@ macro optFormat{`%`(f, a)}(f: string{lit}, a: openArray[string]): untyped =
   result = newNimNode(nnkBracket)
   let f = f.strVal
   formatImpl(newLit)
-  result = nestList(!"&", result)
+  result = nestList(newIdentNode("&"), result)
 
 template optAdd1{x = y; add(x, z)}(x, y, z: string) =
   x = y & z

--- a/tests/usingstmt/tusingstatement.nim
+++ b/tests/usingstmt/tusingstatement.nim
@@ -38,7 +38,7 @@ macro autoClose(args: varargs[untyped]): untyped =
       varAssignment.add(varValue)
       variables.add(varAssignment)
 
-      closingCalls.add(newCall(!"close", varName))
+      closingCalls.add(newCall(newIdentNode("close"), varName))
     else:
       error "Using statement: Unexpected expression. Got " &
         $args[i].kind & " instead of assignment."


### PR DESCRIPTION
- Clean out Deprecated stuff from macros, deprecated a long time ago, since `0.15` ~ `0.18`, pre-`1.0`.
