### PR TITLE
fix #6608

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -957,6 +957,13 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode =
         if not hasErrorType:
           msg.add(">\nbut expected one of: \n" &
               typeToString(n[0].typ))
+          # prefer notin preferToResolveSymbols
+          # t.sym != nil
+          # sfAnon notin t.sym.flags
+          # t.kind != tySequence[It is tyProc]
+          if n[0].typ.sym != nil and sfAnon notin n[0].sym.flags:
+            msg.add(" = " & 
+                typeToString(n[0].typ, preferDesc))
           localError(c.config, n.info, msg)
         return errorNode(c, n)
       result = nil

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -955,15 +955,17 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode =
             hasErrorType = true
             break
         if not hasErrorType:
+          let typ = n[0].typ
           msg.add(">\nbut expected one of: \n" &
-              typeToString(n[0].typ))
+              typeToString(typ))
           # prefer notin preferToResolveSymbols
           # t.sym != nil
           # sfAnon notin t.sym.flags
-          # t.kind != tySequence[It is tyProc]
-          if n[0].typ.sym != nil and sfAnon notin n[0].sym.flags:
+          # t.kind != tySequence(It is tyProc)
+          if typ.sym != nil and sfAnon notin typ.sym.flags and 
+                                typ.kind == tyProc:
             msg.add(" = " & 
-                typeToString(n[0].typ, preferDesc))
+                typeToString(typ, preferDesc))
           localError(c.config, n.info, msg)
         return errorNode(c, n)
       result = nil

--- a/tests/errmsgs/t6608.nim
+++ b/tests/errmsgs/t6608.nim
@@ -1,8 +1,7 @@
 discard """
-  errormsg: " Error: type mismatch: got <>
-but expected one of:
-AcceptCB = proc (s: string){.closure.}"
-  line: 12
+  errormsg: "errmsgs/t6608.nim(12, 4) Error: type mismatch: got <>
+but expected one of: 
+AcceptCB = proc (s: string){.closure.}
 """
 
 type

--- a/tests/errmsgs/t6608.nim
+++ b/tests/errmsgs/t6608.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: '''errmsgs/t6608.nim(12, 4) Error: type mismatch: got <>
+  nimout: '''errmsgs/t6608.nim(12, 4) Error: type mismatch: got <>
 but expected one of: 
 AcceptCB = proc (s: string){.closure.}'''
   line: 12

--- a/tests/errmsgs/t6608.nim
+++ b/tests/errmsgs/t6608.nim
@@ -1,5 +1,5 @@
 discard """
-  nimout: '''errmsgs/t6608.nim(12, 4) Error: type mismatch: got <>
+  nimout: '''t6608.nim(12, 4) Error: type mismatch: got <>
 but expected one of: 
 AcceptCB = proc (s: string){.closure.}'''
   line: 12

--- a/tests/errmsgs/t6608.nim
+++ b/tests/errmsgs/t6608.nim
@@ -1,8 +1,10 @@
 discard """
-  nimout: '''t6608.nim(12, 4) Error: type mismatch: got <>
-but expected one of: 
+  cmd: "nim c --hints:off $file"
+  errormsg: "type mismatch: got <>"
+  nimout: '''t6608.nim(14, 4) Error: type mismatch: got <>
+but expected one of:
 AcceptCB = proc (s: string){.closure.}'''
-  line: 12
+  line: 14
 """
 
 type

--- a/tests/errmsgs/t6608.nim
+++ b/tests/errmsgs/t6608.nim
@@ -1,0 +1,14 @@
+discard """
+  errormsg: " Error: type mismatch: got <>
+but expected one of:
+AcceptCB = proc (s: string){.closure.}"
+  line: 12
+"""
+
+type
+  AcceptCB = proc (s: string)
+
+proc x(x: AcceptCB) =
+  x()
+
+x()

--- a/tests/errmsgs/t6608.nim
+++ b/tests/errmsgs/t6608.nim
@@ -1,7 +1,8 @@
 discard """
-  errormsg: "errmsgs/t6608.nim(12, 4) Error: type mismatch: got <>
+  errormsg: '''errmsgs/t6608.nim(12, 4) Error: type mismatch: got <>
 but expected one of: 
-AcceptCB = proc (s: string){.closure.}
+AcceptCB = proc (s: string){.closure.}'''
+  line: 12
 """
 
 type


### PR DESCRIPTION
```nim
type
  AcceptCB = proc (s: string)

proc x(x: AcceptCB) =
  x()
```
Before:
```
t6608.nim(5, 4) Error: type mismatch: got <>
but expected one of:
AcceptCB
```
After:
```
t6608.nim(5, 4) Error: type mismatch: got <>
but expected one of:
AcceptCB = proc (s: string){.closure.}
```