### PR TITLE
fix index error in logging (substituteLog)

### DIFF
--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -287,6 +287,7 @@ proc substituteLog*(frmt: string, level: Level,
   runnableExamples:
     doAssert substituteLog(defaultFmtStr, lvlInfo, "a message") == "INFO a message"
     doAssert substituteLog("$levelid - ", lvlError, "an error") == "E - an error"
+    doAssert substituteLog("$levelid", lvlDebug, "error") == "Derror"
   var msgLen = 0
   for arg in args:
     msgLen += arg.len
@@ -300,7 +301,7 @@ proc substituteLog*(frmt: string, level: Level,
       inc(i)
       var v = ""
       let app = when defined(js): "" else: getAppFilename()
-      while frmt[i] in IdentChars:
+      while i < frmt.len and frmt[i] in IdentChars:
         v.add(toLowerAscii(frmt[i]))
         inc(i)
       case v


### PR DESCRIPTION
Calling substituteLog with a frmt string that only has a $variable (or only $) and no space or other character after that leads to an IndexError at runtime.

Output of
```nim
import logging
echo substituteLog("$levelid", lvlDebug, "error")
```
is
```
...
.../lib/pure/logging.nim(305) substituteLog
.../lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: index 8 not in 0 .. 7 [IndexError]
```

After seeing the output everyone will probably want to add a space anyway but I think it still should not lead to an IndexError to not do so. There is a runnableExamples test and a fix for the IndexError in this PR. The length check solves this error but I don't know if it is the most fitting solution.