### PR TITLE
misc changes pulled out from #14976

### DIFF
--- a/compiler/idents.nim
+++ b/compiler/idents.nim
@@ -116,3 +116,7 @@ proc newIdentCache*(): IdentCache =
 proc whichKeyword*(id: PIdent): TSpecialWord =
   if id.id < 0: result = wInvalid
   else: result = TSpecialWord(id.id)
+
+proc sameIdent*(cache: IdentCache, ident: PIdent, name: string): bool =
+  ## checks whether `ident` is the same as `name` modulo style
+  result = ident.id == getIdent(cache, name).id

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -183,7 +183,7 @@ proc isCastable(c: PContext; dst, src: PType): bool =
   ## Casting is very unrestrictive; casts are allowed as long as
   ## castDest.size >= src.size, and typeAllowed(dst, skParam)
   #const
-  #  castableTypeKinds = {tyInt, tyPtr, tyRef, tyCstring, tyString,
+  #  castableTypeKinds = {tyInt, tyPtr, tyRef, tyCString, tyString,
   #                       tySequence, tyPointer, tyNil, tyOpenArray,
   #                       tyProc, tySet, tyEnum, tyBool, tyChar}
   let src = src.skipTypes(tyUserTypeClasses)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -27,6 +27,9 @@ Runtime checks (see -x):
   --infChecks:on|off        turn Inf checks on|off
   --refChecks:on|off        turn ref checks on|off (only for --newruntime)
 
+Static checks:
+  --staticBoundsChecks:on|off experimental
+
 Advanced options:
   -o:FILE, --out:FILE       set the output filename
   --outdir:DIR              set the path where the output file will be written

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -255,7 +255,7 @@ when hasSomeStackTrace:
       var
         tempFrames: array[maxStackTraceLines, PFrame] # but better than a threadvar
     const
-      firstCalls = 32
+      firstCalls = 64
     var
       it = f
       i = 0


### PR DESCRIPTION
this moves certain things out of https://github.com/nim-lang/Nim/pull/14976 to make #14976 a bit smaller

* excpt.nim: firstCalls = 32 => firstCalls = 64
before PR, long stacktraces were split unequally, with only 32 frames at bottom of stack; I argue that the bottom of the stack is actually more important, since a common case is that we get into a stack overflow by going in some endless recursion, after an intial prelude; the endless recursion (top of stack) won't be very informative as it'll just cycle through the same cycle P1=>P2=>P3=>P1 etc, whereas the bottom shows how you got there, and truncating it to 32 would often be too short to show how we start the recursion.

## future work
a smarter thing to do would be to detect cycles in the stacktraces we're outputting and only showing the 1st cycle:

with this file:
```nim
proc fun1()
proc fun2()=fun1()
proc fun1()=fun2()

proc main1()=fun1()
proc main()=main1()
main()
```

```
stack trace: (most recent call last)
mviewfroms.nim(18, 26)   deep
mviewfroms.nim(6, 11)    checkEscapeImpl
assertions.nim(30, 26)   failedAssertImpl
```


```
Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11080.nim(11) t11080
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11080.nim(10) main
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11080.nim(9) main1
<cycle start> (cycle repeated 2000 times)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11080.nim(7) fun1
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11080.nim(6) fun2
<cycle end>
# here there could be additional frames at the top of the stack that aren't part of the cycle, eg because it causes some gc memory issue
Error: call depth limit reached in a debug build (2000 function calls). You can change it with -d:nimCallDepthLimit=<int> but really try to avoid deep recursions instead.
```

