### PR TITLE
Fix #14971 OrderedTable del and pop are slow

### DIFF
--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -37,6 +37,10 @@ template st_maybeRehashPutImpl(enlarge) {.dirty.} =
   rawInsert(t, t.data, key, val, hc, index)
   inc(t.counter)
 
+proc itemMoved[T](t: T, h: int) =
+  ## no-op for tables that don't care about backshift
+  discard
+
 proc enlarge[A, B](t: var SharedTable[A, B]) =
   let oldSize = t.dataLen
   let size = oldSize * growthFactor

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -100,6 +100,7 @@ template delImplIdx(t, i) =
           t.data[j] = t.data[i]
         else:
           t.data[j] = move(t.data[i]) # data[j] will be marked EMPTY next loop
+        itemMoved(t, j)
 
 template delImpl() {.dirty.} =
   var hc: Hash

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -82,24 +82,23 @@ template delImplIdx(t, i) =
   let msk = maxHash(t)
   if i >= 0:
     dec(t.counter)
-    block outer:
-      while true:         # KnuthV3 Algo6.4R adapted for i=i+1 instead of i=i-1
-        var j = i         # The correctness of this depends on (h+1) in nextTry,
-        var r = j         # though may be adaptable to other simple sequences.
-        t.data[i].hcode = 0              # mark current EMPTY
-        t.data[i].key = default(type(t.data[i].key))
-        t.data[i].val = default(type(t.data[i].val))
+    block outer:         # KnuthV3 Algo6.4R adapted for i=i+1 instead of i=i-1
+      while true:        # The correctness of this depends on (h+1) in nextTry,
+        let j = i        # though may be adaptable to other simple sequences.
+        t.data[j].hcode = 0              # mark current EMPTY
+        t.data[j].key = default(typeof(t.data[j].key))
+        t.data[j].val = default(typeof(t.data[j].val))
         while true:
-          i = (i + 1) and msk            # increment mod table size
-          if isEmpty(t.data[i].hcode):   # end of collision cluster; So all done
+          i = (i + 1) and msk               # increment mod table size
+          if isEmpty(t.data[i].hcode):      # end of collision cluster; So all done
             break outer
-          r = t.data[i].hcode and msk    # "home" location of key@i
+          let r = t.data[i].hcode and msk   # "home" location of key@i
           if not ((i >= r and r > j) or (r > j and j > i) or (j > i and i >= r)):
             break
         when defined(js):
           t.data[j] = t.data[i]
         else:
-          t.data[j] = move(t.data[i]) # data[j] will be marked EMPTY next loop
+          t.data[j] = move(t.data[i]) # data[i] will be marked EMPTY next loop
         itemMoved(t, j)
 
 template delImpl() {.dirty.} =


### PR DESCRIPTION
* OrderedTable deletes were O(n),now are O(1)
* singly-linked list changed to doubly-linked
* new table is no longer created on del
* uses about 40% less memory if del is used
* uses 8 bytes more per entry for back link
* added itemMoved callback when backshifting after delete
* itemMoved is a no-op on all but OrderedTable
* for OrderedTable, itemMoved adjusts the linked list
* added new tests
* modified delImplIdx to maybe be clearer