### PR TITLE
fix #14822 copy test into var in matrix process, so can reset startTime before actully run

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -474,7 +474,6 @@ iterator listPackages(part: PkgPart): tuple[name, url, cmd: string, hasDeps: boo
         raise newException(ValueError, "Cannot find package '$#'." % n)
 
 proc makeSupTest(test, options: string, cat: Category): TTest =
-  new result
   result.cat = cat
   result.name = test
   result.options = options

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -473,7 +473,8 @@ iterator listPackages(part: PkgPart): tuple[name, url, cmd: string, hasDeps: boo
       if not found:
         raise newException(ValueError, "Cannot find package '$#'." % n)
 
-proc makeSupTest(test, options: string, cat: Category): TTest =
+proc makeSupTest(test, options: string, cat: Category): ref TTest =
+  result = new TTest
   result.cat = cat
   result.name = test
   result.options = options

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -473,8 +473,8 @@ iterator listPackages(part: PkgPart): tuple[name, url, cmd: string, hasDeps: boo
       if not found:
         raise newException(ValueError, "Cannot find package '$#'." % n)
 
-proc makeSupTest(test, options: string, cat: Category): ref TTest =
-  result = new TTest
+proc makeSupTest(test, options: string, cat: Category): TTest =
+  new result
   result.cat = cat
   result.name = test
   result.options = options

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -58,8 +58,8 @@ type
   TResults = object
     total, passed, skipped: int
     data: string
-
-  TTest = object
+  TTest = ref TTestObj
+  TTestObj = object
     name: string
     cat: Category
     options: string
@@ -251,7 +251,7 @@ proc `$`(x: TResults): string =
             "Tests skipped: $2 / $3 <br />\n") %
             [$x.passed, $x.skipped, $x.total]
 
-proc addResult(r: var TResults, test: ref TTest, target: TTarget,
+proc addResult(r: var TResults, test: TTest, target: TTarget,
                expected, given: string, successOrig: TResultEnum) =
   # test.name is easier to find than test.name.extractFilename
   # A bit hacky but simple and works with tests/testament/tshould_not_work.nim
@@ -318,7 +318,7 @@ proc addResult(r: var TResults, test: ref TTest, target: TTarget,
       discard waitForExit(p)
       close(p)
 
-proc cmpMsgs(r: var TResults, expected, given: TSpec, test: ref TTest, target: TTarget) =
+proc cmpMsgs(r: var TResults, expected, given: TSpec, test: TTest, target: TTarget) =
   if strip(expected.msg) notin strip(given.msg):
     r.addResult(test, target, expected.msg, given.msg, reMsgsDiffer)
   elif expected.nimout.len > 0 and expected.nimout.normalizeMsg notin given.nimout.normalizeMsg:
@@ -343,7 +343,7 @@ proc cmpMsgs(r: var TResults, expected, given: TSpec, test: ref TTest, target: T
     r.addResult(test, target, expected.msg, given.msg, reSuccess)
     inc(r.passed)
 
-proc generatedFile(test: ref TTest, target: TTarget): string =
+proc generatedFile(test: TTest, target: TTarget): string =
   if target == targetJS:
     result = test.name.changeFileExt("js")
   else:
@@ -354,7 +354,7 @@ proc generatedFile(test: ref TTest, target: TTarget): string =
 proc needsCodegenCheck(spec: TSpec): bool =
   result = spec.maxCodeSize > 0 or spec.ccodeCheck.len > 0
 
-proc codegenCheck(test: ref TTest, target: TTarget, spec: TSpec, expectedMsg: var string,
+proc codegenCheck(test: TTest, target: TTarget, spec: TSpec, expectedMsg: var string,
                   given: var TSpec) =
   try:
     let genFile = generatedFile(test, target)
@@ -379,7 +379,7 @@ proc codegenCheck(test: ref TTest, target: TTarget, spec: TSpec, expectedMsg: va
     given.err = reCodeNotFound
     echo getCurrentExceptionMsg()
 
-proc nimoutCheck(test: ref TTest; expectedNimout: string; given: var TSpec) =
+proc nimoutCheck(test: TTest; expectedNimout: string; given: var TSpec) =
   let giv = given.nimout.strip
   var currentPos = 0
   # Only check that nimout contains all expected lines in that order.
@@ -390,7 +390,7 @@ proc nimoutCheck(test: ref TTest; expectedNimout: string; given: var TSpec) =
       given.err = reMsgsDiffer
       break
 
-proc compilerOutputTests(test: ref TTest, target: TTarget, given: var TSpec,
+proc compilerOutputTests(test: TTest, target: TTarget, given: var TSpec,
                          expected: TSpec; r: var TResults) =
   var expectedmsg: string = ""
   var givenmsg: string = ""
@@ -413,7 +413,7 @@ proc getTestSpecTarget(): TTarget =
   else:
     result = targetC
 
-proc checkDisabled(r: var TResults, test: ref TTest): bool =
+proc checkDisabled(r: var TResults, test: TTest): bool =
   if test.spec.err in {reDisabled, reJoined}:
     # targetC is a lie, but parameter is required
     r.addResult(test, targetC, "", "", test.spec.err)
@@ -425,7 +425,7 @@ proc checkDisabled(r: var TResults, test: ref TTest): bool =
 
 var count = 0
 
-proc testSpecHelper(r: var TResults, test: ref TTest, expected: TSpec,
+proc testSpecHelper(r: var TResults, test: TTest, expected: TSpec,
                     target: TTarget, nimcache: string, extraOptions = "") =
   test.startTime = epochTime()
   case expected.action
@@ -486,7 +486,7 @@ proc testSpecHelper(r: var TResults, test: ref TTest, expected: TSpec,
                               nimcache, target)
     cmpMsgs(r, expected, given, test, target)
 
-proc targetHelper(r: var TResults, test: ref TTest, expected: TSpec, extraOptions = "") =
+proc targetHelper(r: var TResults, test: TTest, expected: TSpec, extraOptions = "") =
   for target in expected.targets:
     inc(r.total)
     if target notin gTargets:
@@ -499,7 +499,7 @@ proc targetHelper(r: var TResults, test: ref TTest, expected: TSpec, extraOption
       let nimcache = nimcacheDir(test.name, test.options, target)
       testSpecHelper(r, test, expected, target, nimcache, extraOptions)
 
-proc testSpec(r: var TResults, test: ref TTest, targets: set[TTarget] = {}) =
+proc testSpec(r: var TResults, test: TTest, targets: set[TTarget] = {}) =
   var expected = test.spec
   if expected.parseErrors.len > 0:
     # targetC is a lie, but a parameter is required
@@ -518,13 +518,13 @@ proc testSpec(r: var TResults, test: ref TTest, targets: set[TTarget] = {}) =
   else:
     targetHelper(r, test, expected)
 
-proc testSpecWithNimcache(r: var TResults, test: ref TTest; nimcache: string) =
+proc testSpecWithNimcache(r: var TResults, test: TTest; nimcache: string) =
   if not checkDisabled(r, test): return
   for target in test.spec.targets:
     inc(r.total)
     testSpecHelper(r, test, test.spec, target, nimcache)
 
-proc testC(r: var TResults, test: ref TTest, action: TTestAction) =
+proc testC(r: var TResults, test: TTest, action: TTestAction) =
   # runs C code. Doesn't support any specs, just goes by exit code.
   if not checkDisabled(r, test): return
 
@@ -540,7 +540,7 @@ proc testC(r: var TResults, test: ref TTest, action: TTestAction) =
     if exitCode != 0: given.err = reExitcodesDiffer
   if given.err == reSuccess: inc(r.passed)
 
-proc testExec(r: var TResults, test: ref TTest) =
+proc testExec(r: var TResults, test: TTest) =
   # runs executable or script, just goes by exit code
   if not checkDisabled(r, test): return
 
@@ -556,16 +556,16 @@ proc testExec(r: var TResults, test: ref TTest) =
   if given.err == reSuccess: inc(r.passed)
   r.addResult(test, targetC, "", given.msg, given.err)
 
-proc makeTest(test, options: string, cat: Category):ref TTest =
-  result = new TTest
+proc makeTest(test, options: string, cat: Category): TTest =
+  new result
   result.cat = cat
   result.name = test
   result.options = options
   result.spec = parseSpec(addFileExt(test, ".nim"))
   result.startTime = epochTime()
 
-proc makeRawTest(test, options: string, cat: Category): ref TTest =
-  result = new TTest
+proc makeRawTest(test, options: string, cat: Category): TTest =
+  new result
   result.cat = cat
   result.name = test
   result.options = options


### PR DESCRIPTION
related issue https://github.com/nim-lang/Nim/issues/14822
current output
```
PASS: tests/stdlib/tosprocterminate.nim C                          ( 7.75 sec)
PASS: tests/stdlib/tosprocterminate.nim C++                        ( 7.59 sec)
PASS: tests/stdlib/tosprocterminate.nim C                          ( 7.51 sec)
PASS: tests/stdlib/tosprocterminate.nim C++                        ( 7.36 sec)
```
I assuming get about 4s for each, not know where extro 3s coming from.