### PR TITLE
fix odbc regressions

### DIFF
--- a/lib/wrappers/odbcsql.nim
+++ b/lib/wrappers/odbcsql.nim
@@ -39,16 +39,16 @@ when defined(nimHasStyleChecks):
 type
   TSqlChar* = char
   TSqlSmallInt* = int16
-  SqlUSmallInt* = int16
+  SqlUSmallInt* = uint16
   SqlHandle* = pointer
   SqlHEnv* = SqlHandle
   SqlHDBC* = SqlHandle
   SqlHStmt* = SqlHandle
   SqlHDesc* = SqlHandle
   TSqlInteger* = int32
-  SqlUInteger* = int32
-  TSqlLen* = int64
-  TSqlULen* = uint64
+  SqlUInteger* = uint32
+  TSqlLen* = int
+  TSqlULen* = uint
   SqlPointer* = pointer
   TSqlReal* = cfloat
   TSqlDouble* = cdouble

--- a/lib/wrappers/odbcsql.nim
+++ b/lib/wrappers/odbcsql.nim
@@ -39,14 +39,14 @@ when defined(nimHasStyleChecks):
 type
   TSqlChar* = char
   TSqlSmallInt* = int16
-  SqlUSmallInt* = uint16
+  SqlUSmallInt* = int16
   SqlHandle* = pointer
   SqlHEnv* = SqlHandle
   SqlHDBC* = SqlHandle
   SqlHStmt* = SqlHandle
   SqlHDesc* = SqlHandle
   TSqlInteger* = int32
-  SqlUInteger* = uint32
+  SqlUInteger* = int32
   TSqlLen* = int
   TSqlULen* = uint
   SqlPointer* = pointer


### PR DESCRIPTION
Fix regressions introduced with fix for issue #9771.
TSqlLen,  TSqlULen should have platform dependent length. 32bit on 32bit platform and 64bit on 64bit platform.