### PR TITLE
new `getCapturedMsgs` API to capture the messages output by compiler, for testing

### DIFF
--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -119,3 +119,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasStacktraceMsgs")
   defineSymbol("nimDoesntTrackDefects")
   defineSymbol("nimHasLentIterators")
+  defineSymbol("nimHasCapturedMsgs")

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -163,6 +163,7 @@ type
       ## which itself requires `nimble install libffi`, see #10150
       ## Note: this feature can't be localized with {.push.}
     vmopsDanger,
+    staticEscapeChecks,
 
   LegacyFeature* = enum
     allowSemcheckedAstModification,
@@ -320,6 +321,8 @@ type
     suggestMaxResults*: int
     lastLineInfo*: TLineInfo
     writelnHook*: proc (output: string) {.closure.} # cannot make this gcsafe yet because of Nimble
+    capturedMsgs*: string
+    capturedMsgsState*: bool
     structuredErrorHook*: proc (config: ConfigRef; info: TLineInfo; msg: string;
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -163,7 +163,6 @@ type
       ## which itself requires `nimble install libffi`, see #10150
       ## Note: this feature can't be localized with {.push.}
     vmopsDanger,
-    staticEscapeChecks,
 
   LegacyFeature* = enum
     allowSemcheckedAstModification,

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -22,7 +22,6 @@ from hashes import hash
 from osproc import nil
 
 import vmconv
-from astalgo import debug
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)

--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -54,3 +54,14 @@ proc querySettingSeq*(setting: MultipleValueSetting): seq[string] {.
   ##
   ## .. code-block:: Nim
   ##   const nimblePaths = compileSettingSeq(MultipleValueSetting.nimblePaths)
+
+type CaptureMode* = enum
+  captureInvalid
+  captureStart
+  captureStop
+
+when defined(nimHasCapturedMsgs):
+  proc setCapturedMsgsImpl(mode: CaptureMode) {.compileTime.} = discard
+  template setCapturedMsgs*(mode: CaptureMode) =
+    static: setCapturedMsgsImpl(mode)
+  proc getCapturedMsgs*(): string {.compileTime.} = doAssert false

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -18,3 +18,18 @@ static:
 doAssert "myNimCache" in nc
 doAssert "myNimblePath" in np[0]
 doAssert querySetting(backend) == "c"
+
+block:
+  setCapturedMsgs(captureStart)
+  proc fun(){.deprecated.} = discard
+  {.push warning[Deprecated]: on.}
+  fun()
+  {.pop.}
+  doAssert "Warning: fun is deprecated [Deprecated]" in getCapturedMsgs()
+  {.push warning[Deprecated]: off.}
+  fun()
+  {.pop.}
+  doAssert "Warning: fun is deprecated [Deprecated]" notin getCapturedMsgs()
+  # fun() # uncommenting this would cause error: `conf.capturedMsgs.len == 0` capturedMsgs not empty:
+  # which is by design: you must call `getCapturedMsgs()` before it.
+  setCapturedMsgs(captureStop)


### PR DESCRIPTION
rationale:
* easier to read test when the warning/hint message being issued is tested right below the code that triggers it as opposed to on top in a testament spec section, especially if a lot of messages are generated and it's hard to identify where they come from in code
* makes it suitable for writing tests without testament (for user code that doesn't want to use testament)
* avoids having to write a separate "runner" (whether it's testament or some code that compiles a nim program and collects the stderr of compilation process) just to check the messages

it also allows arbitrary user defined logic on the generated messages, without having to bake it in the compiler (or testament)

I'm heavily relying on this feature in https://github.com/nim-lang/Nim/pull/14976 , see tests/misc/tviewfroms.nim which reads much better with the assert conditions on the generated compiler messages (warnings, in this case) appearing right below the expression that triggers them, rather than lumped at the top. This makes the tests self documenting and makes it easier to move things around for example without having to change the section at the top.
