### PR TITLE
io: fix SetHandleInformation signature to match Windows'

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -283,10 +283,10 @@ elif defined(windows):
     importc: "_get_osfhandle", header: "<io.h>".}
 
   type
-    Handle = distinct pointer
+    IoHandle = distinct pointer
       ## Windows' HANDLE type. Defined as an untyped pointer but is **not**
-      ## one.
-  proc setHandleInformation(handle: Handle, mask, flags: culong): cint {.
+      ## one. Named like this to avoid collision with other `system` modules.
+  proc setHandleInformation(handle: IoHandle, mask, flags: culong): cint {.
     importc: "SetHandleInformation", header: "<handleapi.h>".}
 
 const
@@ -343,7 +343,7 @@ when defined(nimdoc) or (defined(posix) and not defined(nimscript)) or defined(w
       flags = if inheritable: flags and not FD_CLOEXEC else: flags or FD_CLOEXEC
       result = c_fcntl(f, F_SETFD, flags) != -1
     else:
-      result = setHandleInformation(cast[Handle](f), HANDLE_FLAG_INHERIT,
+      result = setHandleInformation(cast[IoHandle](f), HANDLE_FLAG_INHERIT,
                                     culong inheritable) != 0
 
 proc readLine*(f: File, line: var TaintedString): bool {.tags: [ReadIOEffect],

--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -282,7 +282,11 @@ elif defined(windows):
   proc getOsfhandle(fd: cint): int {.
     importc: "_get_osfhandle", header: "<io.h>".}
 
-  proc setHandleInformation(handle: int, mask, flags: culong): cint {.
+  type
+    Handle = distinct pointer
+      ## Windows' HANDLE type. Defined as an untyped pointer but is **not**
+      ## one.
+  proc setHandleInformation(handle: Handle, mask, flags: culong): cint {.
     importc: "SetHandleInformation", header: "<handleapi.h>".}
 
 const
@@ -339,7 +343,8 @@ when defined(nimdoc) or (defined(posix) and not defined(nimscript)) or defined(w
       flags = if inheritable: flags and not FD_CLOEXEC else: flags or FD_CLOEXEC
       result = c_fcntl(f, F_SETFD, flags) != -1
     else:
-      result = setHandleInformation(f.int, HANDLE_FLAG_INHERIT, culong inheritable) != 0
+      result = setHandleInformation(cast[Handle](f), HANDLE_FLAG_INHERIT,
+                                    culong inheritable) != 0
 
 proc readLine*(f: File, line: var TaintedString): bool {.tags: [ReadIOEffect],
               benign.} =


### PR DESCRIPTION
Fixes #14980

We might want to add VCC to our test matrix in the future.