### PR TITLE
fix #15033, add T: SomeNumber to `^` in stdlib/math

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -958,7 +958,7 @@ proc sgn*[T: SomeNumber](x: T): int {.inline.} =
 {.pop.}
 {.pop.}
 
-proc `^`*[T](x: T, y: Natural): T =
+proc `^`*[T: SomeNumber](x: T, y: Natural): T =
   ## Computes ``x`` to the power ``y``.
   ##
   ## Exponent ``y`` must be non-negative, use


### PR DESCRIPTION
* fixes #15033 
* If this would break anyone's code, I'm really interested how you use `^` with a type other then ints and floats 😉  