### PR TITLE
[superseded] Increase buffer size for readlink to 1024

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1213,11 +1213,11 @@ proc findExe*(exe: string, followSymlinks: bool = true;
         when not defined(windows):
           while followSymlinks: # doubles as if here
             if x.checkSymlink:
-              var r = newString(256)
-              var len = readlink(x, r, 256)
+              var r = newString(1024)
+              var len = readlink(x, r, 1024)
               if len < 0:
                 raiseOSError(osLastError(), exe)
-              if len > 256:
+              if len > 1024:
                 r = newString(len+1)
                 len = readlink(x, r, len)
               setLen(r, len)
@@ -2555,11 +2555,11 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   when defined(windows):
     result = symlinkPath
   else:
-    result = newString(256)
-    var len = readlink(symlinkPath, result, 256)
+    result = newString(1024)
+    var len = readlink(symlinkPath, result, 1024)
     if len < 0:
       raiseOSError(osLastError(), symlinkPath)
-    if len > 256:
+    if len > 1024:
       result = newString(len+1)
       len = readlink(symlinkPath, result, len)
     setLen(result, len)
@@ -2850,9 +2850,9 @@ when not weirdTarget and (defined(freebsd) or defined(dragonfly)):
 
 when not weirdTarget and (defined(linux) or defined(solaris) or defined(bsd) or defined(aix)):
   proc getApplAux(procPath: string): string =
-    result = newString(256)
-    var len = readlink(procPath, result, 256)
-    if len > 256:
+    result = newString(1024)
+    var len = readlink(procPath, result, 1024)
+    if len > 1024:
       result = newString(len+1)
       len = readlink(procPath, result, len)
     setLen(result, len)


### PR DESCRIPTION
If Nim is installed in a long prefix on Linux, "nim c" was not able to
read its nim.cfg since it tried to read the link target of
/proc/self/exe which may be longer than the previous 256 long buffer.

Reproducer (notice the missing `Hint: used config file ...` in the second run):
<details open><summary>

```sh
podman run --rm -t gcc sh -c '
ver=1.2.4
curl -sL "https://nim-lang.org/download/nim-${ver}-linux_x64.tar.xz" | tar -xJ
echo import os > test.nim

for len in 246 247 ; do
    prefix="/$( yes a|tr -d \\n|head "-c${len}" )"
    (cd "nim-${ver}" && ./install.sh "${prefix}")
    nim_exe="${prefix}/nim/bin/nim"
    echo "${#nim_exe} ${nim_exe}"
    PATH="${prefix}/nim/bin:${PATH}" "${nim_exe}" c test.nim
done
'
```
</summary>

```
Nim build detected
copying files...
installation successful
259 /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/nim/bin/nim
Hint: used config file '/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/nim/config/nim.cfg' [Conf]
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: test [Processing]
Hint: os [Processing]
Hint: strutils [Processing]
Hint: parseutils [Processing]
Hint: math [Processing]
Hint: bitops [Processing]
Hint: macros [Processing]
Hint: algorithm [Processing]
Hint: unicode [Processing]
Hint: pathnorm [Processing]
Hint: osseps [Processing]
Hint: posix [Processing]
Hint: times [Processing]
Hint: options [Processing]
Hint: typetraits [Processing]
/test.nim(1, 8) Warning: imported and not used: 'os' [UnusedImport]
CC: stdlib_system.nim
CC: stdlib_times.nim
CC: stdlib_os.nim
CC: test.nim
Hint:  [Link]
Hint: 36222 LOC; 1.328 sec; 47.211MiB peakmem; Debug build; proj: /test.nim; out: /test [SuccessX]
Nim build detected
copying files...
installation successful
260 /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/nim/bin/nim
Hint: system [Processing]
Hint: widestrs [Processing]
Hint: io [Processing]
Hint: test [Processing]
/test.nim(1, 8) Error: cannot open file: os
```
</details>