### PR TITLE
jsre: try to fix nightlies

### DIFF
--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -1,6 +1,9 @@
 ## Regular Expressions for the JavaScript target.
 ## * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 
+when not defined(js) and not defined(Nimdoc):
+  {.error: "This module only works on the JavaScript platform".}
+
 type RegExp* {.importjs.} = object    ## Regular Expressions for JavaScript target.
   flags* {.importjs.}: cstring        ## cstring that contains the flags of the RegExp object.
   dotAll* {.importjs.}: bool          ## Whether `.` matches newlines or not.

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -160,6 +160,7 @@ lib/posix/posix_linux_amd64_consts.nim
 lib/posix/posix_other_consts.nim
 lib/posix/posix_openbsd_amd64.nim
 lib/posix/posix_haiku.nim
+lib/js/jsre.nim
 """.splitWhitespace()
 
 when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
@@ -258,7 +259,7 @@ proc buildDoc(nimArgs, destPath: string) =
       destPath / changeFileExt(splitFile(d).name, "html"), d]
     i.inc
   for d in items(doc):
-    let extra = if isJsOnly(d): " --backend:js " else: ""
+    let extra = if isJsOnly(d): "--backend:js" else: ""
     var nimArgs2 = nimArgs
     if d.isRelativeTo("compiler"): doAssert false
     commands[i] = nim & " doc $# $# --git.url:$# --outdir:$# --index:on $#" %


### PR DESCRIPTION
Documentation for `jsre` is already missing from https://nim-lang.github.io/Nim/lib.html#pure-libraries-modules-for-js-backend, so not much harm done, and we might finally unblock our nightlies.