### PR TITLE
fix #14684

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -486,6 +486,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "project":
     processOnOffSwitchG(conf, {optWholeProject, optGenIndex}, arg, pass, info)
   of "gc":
+    if conf.backend == backendJs:
+      return
     expectArg(conf, switch, arg, pass, info)
     if pass in {passCmd2, passPP}:
       case arg.normalize


### PR DESCRIPTION
ignore gc switch when `backendJs`