### PR TITLE
asyncnet, net: don't attempt SSL_shutdown if a fatal error occurred

### DIFF
--- a/tests/stdlib/tssl.nim
+++ b/tests/stdlib/tssl.nim
@@ -59,3 +59,5 @@ proc main() =
       discard
     finally:
       peer.close()
+
+when isMainModule: main()

--- a/tests/stdlib/tssl.nim
+++ b/tests/stdlib/tssl.nim
@@ -1,0 +1,52 @@
+discard """
+  joinable: false
+"""
+
+import net, nativesockets
+
+when defined(posix): import posix
+
+const DummyData = "dummy data\n"
+
+when defined(ssl):
+  let serverContext = newContext(verifyMode = CVerifyNone,
+                                 certFile = "tests/testdata/mycert.pem",
+                                 keyFile = "tests/testdata/mycert.pem")
+
+  when defined(posix):
+    signal(SIGPIPE, SIG_IGN)
+
+  proc connector(port: Port) {.thread.} =
+    let clientContext = newContext(verifyMode = CVerifyNone)
+    var client = newSocket(buffered = false)
+    clientContext.wrapSocket(client)
+    client.connect("localhost", port)
+
+    discard client.recvLine()
+    client.getFd.close()
+
+  block:
+    var server = newSocket(buffered = false)
+    serverContext.wrapSocket(server)
+    server.bindAddr(address = "localhost")
+    let (_, port) = server.getLocalAddr()
+    server.listen()
+
+    var clientThread: Thread[Port]
+    createThread(clientThread, connector, port)
+
+    var peer: Socket
+    try:
+      server.accept(peer)
+      peer.send(DummyData)
+
+      joinThread clientThread
+
+      peer.send(DummyData, {})
+      peer.send(DummyData, {})
+    except:
+      discard
+    finally:
+      peer.close()
+
+    server.close()

--- a/tests/stdlib/tssl.nim
+++ b/tests/stdlib/tssl.nim
@@ -42,8 +42,9 @@ when defined(ssl):
 
       joinThread clientThread
 
-      peer.send(DummyData, {})
-      peer.send(DummyData, {})
+      while true:
+        # Send data until we get EPIPE.
+        peer.send(DummyData, {})
     except:
       discard
     finally:

--- a/tests/stdlib/tssl.nims
+++ b/tests/stdlib/tssl.nims
@@ -1,0 +1,2 @@
+--threads:on
+--d:ssl

--- a/tests/stdlib/tssl.nims
+++ b/tests/stdlib/tssl.nims
@@ -1,4 +1,5 @@
 --threads:on
 --d:ssl
 when defined(freebsd):
+  # See https://github.com/nim-lang/Nim/pull/15066#issuecomment-665541265
   --tlsEmulation:off

--- a/tests/stdlib/tssl.nims
+++ b/tests/stdlib/tssl.nims
@@ -1,2 +1,3 @@
 --threads:on
 --d:ssl
+--gc:arc

--- a/tests/stdlib/tssl.nims
+++ b/tests/stdlib/tssl.nims
@@ -1,3 +1,4 @@
 --threads:on
 --d:ssl
---gc:arc
+when defined(freebsd):
+  --tlsEmulation:off


### PR DESCRIPTION
Per TLS standard and SSL_shutdown(3ssl). This should prevent errors
coming from a close() after a bad event (ie. the other end of the pipe
is closed before shutdown can be negotiated).

Ref #9867