### PR TITLE
fix #15082 unittest handle check out of test scope

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -567,7 +567,8 @@ template fail* =
   ##
   ## outputs "Checkpoint A" before quitting.
   bind ensureInitialized, setProgramResult
-  checkResults[^1] = false
+  if checkResults.len > 0:
+    checkResults[^1] = false
   when declared(testStatusIMPL):
     testStatusIMPL = TestStatus.FAILED
   else:


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/15082

dont know how to test unittest 

here is code during debuging
``` nim
import unittest

proc sharedTestCode() =
  check 3 == 4

suite "Suite name isn't relevant":

  test "This prints [FAILED]":
    check 1 == 2

  test "This prints [OK]":
    sharedTestCode()

  test "skip":
    skip()
  
  test "skip then continue":
    check 7 == 8
  
  test "see a success":
    check 9 == 9

test "single":
  check 5 == 6

```  

have to bind `contains` in devel branch, dont know why, old build nimlsp in vscode show it can find `strutils.contains` symbol.  

so we dont reset `checkpoints = @[]` in `fails` or `skip` , it's in the end of `template test`

outputs:  
```

[Suite] Suite name isn't relevant
    /Users/bung/t15082.nim(9, 12): Check failed: 1 == 2
  [FAILED] This prints [FAILED]
    /Users/bung/t15082.nim(4, 10): Check failed: 3 == 4
  [FAILED] This prints [OK]
  [SKIPPED] skip
    /Users/bung/t15082.nim(18, 12): Check failed: 7 == 8
  [FAILED] skip then continue
  [OK] see a success
/Users/bung/t15082.nim(24, 10): Check failed: 5 == 6
[FAILED] single
Error: execution of an external program failed: '/Users/bung/t15082 '
```
