### PR TITLE
Change clibdir and cincludes for NetBSD

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -212,6 +212,14 @@ clang.objc.options.linker = "-lobjc -lgnustep-base"
   clibdir: "/usr/local/lib"
 @end
 
+@if freebsd or openbsd:
+  cincludes: "/usr/local/include"
+  clibdir: "/usr/local/lib"
+@elif netbsd:
+  cincludes: "/usr/pkg/include"
+  clibdir: "/usr/pkg/lib"
+@end
+
 # Configuration for the VxWorks
 # This has been tested with VxWorks 6.9 only
 @if vxworks:


### PR DESCRIPTION
This alters the `clibdir` and `cincludes` configuration for NetBSD. NetBSD uses `pkgsrc` for package management, and installs libraries and headers inside `/usr/pkg` by default, as [explained here](https://www.netbsd.org/docs/pkgsrc/files.html).

This fixes the `tests/niminaction/Chapter8/sfml/sfml_test.nim` test on NetBSD.