### PR TITLE
disable sink inference, only enable it for the stdlib. 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -265,6 +265,10 @@ proc mydiv(a, b): int {.raises: [].} =
 - Removed the `--oldast` switch.
 - `$getType(untyped)` is now "untyped" instead of "expr", `$getType(typed)` is
   now "typed" instead of "stmt".
+- Sink inference is now disabled per default and has to enabled explicitly via
+  `--sinkInference:on`. *Note*: For the standard library sink inference remains
+  enabled. This change is most relevant for the `--gc:arc`, `--gc:orc` memory
+  management modes.
 
 
 ## Tool changes

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -373,7 +373,7 @@ const
   DefaultOptions* = {optObjCheck, optFieldCheck, optRangeCheck,
     optBoundsCheck, optOverflowCheck, optAssert, optWarns, optRefCheck,
     optHints, optStackTrace, optLineTrace, # consider adding `optStackTraceMsgs`
-    optTrMacros, optStyleCheck, optSinkInference}
+    optTrMacros, optStyleCheck}
   DefaultGlobalOptions* = {optThreadAnalysis,
     optExcessiveStackTrace, optListFullPaths}
 

--- a/doc/destructors.rst
+++ b/doc/destructors.rst
@@ -261,8 +261,14 @@ optimizations (and the current implementation does not).
 Sink parameter inference
 ========================
 
-The current implementation does a limited form of sink parameter
-inference. The `.nosinks`:idx: pragma can be used to disable this inference
+The current implementation can do a limited form of sink parameter
+inference. But it has to be enabled via `--sinkInference:on`, either
+on the command line or via a `push` pragma.
+
+To enable it for a section of code, one can
+use `{.push sinkInference: on.}`...`{.pop.}`.
+
+The `.nosinks`:idx: pragma can be used to disable this inference
 for a single routine:
 
 .. code-block:: nim
@@ -270,8 +276,6 @@ for a single routine:
   proc addX(x: T; child: T) {.nosinks.} =
     x.s.add child
 
-To disable it for a section of code, one can
-use `{.push sinkInference: off.}`...`{.pop.}`.
 
 The details of the inference algorithm are currently undocumented.
 

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -48,3 +48,6 @@ when defined(nimlocks):
   {.pragma: benign, gcsafe, locks: 0.}
 else:
   {.pragma: benign, gcsafe.}
+
+when defined(nimHasSinkInference):
+  {.push sinkInference: on.}

--- a/tests/arc/nim.cfg
+++ b/tests/arc/nim.cfg
@@ -1,0 +1,1 @@
+--sinkInference:on

--- a/tests/destructor/nim.cfg
+++ b/tests/destructor/nim.cfg
@@ -1,0 +1,1 @@
+--sinkInference:on


### PR DESCRIPTION
Reason: better source code compatibility with Nim v1.