### PR TITLE
fix #14139

### DIFF
--- a/lib/pure/collections/heapqueue.nim
+++ b/lib/pure/collections/heapqueue.nim
@@ -159,9 +159,9 @@ proc pushpop*[T](heap: var HeapQueue[T], item: T): T =
   if heap.len > 0 and heapCmp(heap.data[0], item):
     result = item
     swap(result, heap.data[0])
+    siftup(heap, 0)
   else:
     result = item
-    siftup(heap, 0)
 
 proc clear*[T](heap: var HeapQueue[T]) =
   ## Remove all elements from `heap`, making it empty.

--- a/lib/pure/collections/heapqueue.nim
+++ b/lib/pure/collections/heapqueue.nim
@@ -162,7 +162,6 @@ proc pushpop*[T](heap: var HeapQueue[T], item: T): T =
   else:
     result = item
     siftup(heap, 0)
-  return item
 
 proc clear*[T](heap: var HeapQueue[T]) =
   ## Remove all elements from `heap`, making it empty.

--- a/lib/pure/collections/heapqueue.nim
+++ b/lib/pure/collections/heapqueue.nim
@@ -156,9 +156,11 @@ proc replace*[T](heap: var HeapQueue[T], item: T): T =
 
 proc pushpop*[T](heap: var HeapQueue[T], item: T): T =
   ## Fast version of a push followed by a pop.
-  var item = item
   if heap.len > 0 and heapCmp(heap.data[0], item):
-    swap(item, heap.data[0])
+    result = item
+    swap(result, heap.data[0])
+  else:
+    result = item
     siftup(heap, 0)
   return item
 

--- a/lib/pure/collections/heapqueue.nim
+++ b/lib/pure/collections/heapqueue.nim
@@ -156,8 +156,9 @@ proc replace*[T](heap: var HeapQueue[T], item: T): T =
 
 proc pushpop*[T](heap: var HeapQueue[T], item: T): T =
   ## Fast version of a push followed by a pop.
-  if heap.len > 0 and heapCmp(heap[0], item):
-    swap(item, heap[0])
+  var item = item
+  if heap.len > 0 and heapCmp(heap.data[0], item):
+    swap(item, heap.data[0])
     siftup(heap, 0)
   return item
 

--- a/lib/pure/collections/heapqueue.nim
+++ b/lib/pure/collections/heapqueue.nim
@@ -156,12 +156,10 @@ proc replace*[T](heap: var HeapQueue[T], item: T): T =
 
 proc pushpop*[T](heap: var HeapQueue[T], item: T): T =
   ## Fast version of a push followed by a pop.
+  result = item
   if heap.len > 0 and heapCmp(heap.data[0], item):
-    result = item
     swap(result, heap.data[0])
     siftup(heap, 0)
-  else:
-    result = item
 
 proc clear*[T](heap: var HeapQueue[T]) =
   ## Remove all elements from `heap`, making it empty.

--- a/tests/stdlib/t14139.nim
+++ b/tests/stdlib/t14139.nim
@@ -5,5 +5,5 @@ var test_queue : HeapQueue[int]
 test_queue.push(7)
 test_queue.push(3)
 test_queue.push(9)
-let i = test_queue.pushpop(10) # This will not compile
+let i = test_queue.pushpop(10)
 assert i == 3

--- a/tests/stdlib/t14139.nim
+++ b/tests/stdlib/t14139.nim
@@ -1,0 +1,9 @@
+import heapqueue
+
+var test_queue : HeapQueue[int]
+
+test_queue.push(7)
+test_queue.push(3)
+test_queue.push(9)
+let i = test_queue.pushpop(10) # This will not compile
+assert i == 3


### PR DESCRIPTION
Maybe also add `var T` version to reduce one copy?(But maybe move semantics are good enough to reduce copies?) 

```nim
proc pushpop*[T](heap: var HeapQueue[T], item: var T): T =
  ## Fast version of a push followed by a pop.
  if heap.len > 0 and heapCmp(heap.data[0], item):
    swap(item, heap.data[0])
    siftup(heap, 0)
  return item
```