### PR TITLE
Add some enhancements to `jsonutils.nim`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,20 @@
 
 ## Standard library additions and changes
 
+- Added some enhancements to `std/jsonutils` module.
+  * Added a possibility to deserialize JSON arrays directly to `HashSet` and
+    `OrderedSet` types and respectively to serialize those types to JSON arrays
+    via `jsonutils.fromJson` and `jsonutils.toJson` procedures.
+  * Added a possibility to deserialize JSON `null` objects to Nim option objects
+    and respectively to serialize Nim option object to JSON object if `isSome`
+    or to JSON null object if `isNone` via `jsonutils.fromJson` and
+    `jsonutils.toJson` procedures.
+  * Added `Joptions` parameter to `jsonutils.fromJson` procedure currently
+    containing two boolean options `allowExtraKeys` and `allowMissingKeys`.
+    - If `allowExtraKeys` is `true` Nim's object to which the JSON is parsed is
+      not required to have a field for every JSON key.
+    - If `allowMissingKeys` is `true` Nim's object to which JSON is parsed is
+      allowed to have fields without corresponding JSON keys.
 - Added `bindParams`, `bindParam` to `db_sqlite` for binding parameters into a `SqlPrepared` statement.
 - Add `tryInsert`,`insert` procs to `db_*` libs accept primary key column name.
 - Added `xmltree.newVerbatimText` support create `style`'s,`script`'s text.

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -909,42 +909,6 @@ iterator pairs*[A](s: OrderedSet[A]): tuple[a: int, b: A] =
   forAllOrderedPairs:
     yield (idx, s.data[h].key)
 
-proc fromJsonHook*[A, B](s: var SomeSet[A], jsonNode: B) =
-  ## Enables `fromJson` for `HashSet` and `OrderedSet` types.
-  ## 
-  ## See also:
-  ## * `toJsonHook proc<#toJsonHook,SomeSet[A]>`_
-  runnableExamples:
-    import std/[json, jsonutils]
-    var foo: tuple[hs: HashSet[string], os: OrderedSet[string]]
-    fromJson(foo, parseJson("""
-      {"hs": ["hash", "set"], "os": ["ordered", "set"]}"""))
-    assert foo.hs == ["hash", "set"].toHashSet
-    assert foo.os == ["ordered", "set"].toOrderedSet
-
-  mixin jsonTo
-  assert jsonNode.kind == JArray,
-          "The kind of the `jsonNode` must be `JArray`, but its actual " &
-          "type is `" & $jsonNode.kind & "`."
-  clear(s)
-  for v in jsonNode:
-    incl(s, jsonTo(v, A))
-
-proc toJsonHook*[A](s: SomeSet[A]): auto =
-  ## Enables `toJson` for `HashSet` and `OrderedSet` types.
-  ##
-  ## See also:
-  ## * `fromJsonHook proc<#fromJsonHook,SomeSet[A],B>`_
-  runnableExamples:
-    import std/[json, jsonutils]
-    let foo = (hs: ["hash"].toHashSet, os: ["ordered", "set"].toOrderedSet)
-    assert $toJson(foo) == """{"hs":["hash"],"os":["ordered","set"]}"""
-
-  mixin newJArray, toJson
-  result = newJArray()
-  for k in s:
-    add(result, toJson(k))
-
 # -----------------------------------------------------------------------
 
 

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -1750,45 +1750,6 @@ iterator mvalues*[A, B](t: var OrderedTable[A, B]): var B =
     yield t.data[h].val
     assert(len(t) == L, "the length of the table changed while iterating over it")
 
-proc fromJsonHook*[K, V, JN](t: var (Table[K, V] | OrderedTable[K, V]),
-                             jsonNode: JN) =
-  ## Enables `fromJson` for `Table` and `OrderedTable` types.
-  ## 
-  ## See also:
-  ## * `toJsonHook proc<#toJsonHook,(Table[K,V]|OrderedTable[K,V])>`_
-  runnableExamples:
-    import std/[json, jsonutils]
-    var foo: tuple[t: Table[string, int], ot: OrderedTable[string, int]]
-    fromJson(foo, parseJson("""
-      {"t":{"two":2,"one":1},"ot":{"one":1,"three":3}}"""))
-    assert foo.t == [("one", 1), ("two", 2)].toTable
-    assert foo.ot == [("one", 1), ("three", 3)].toOrderedTable
-
-  mixin jsonTo
-  assert jsonNode.kind == JObject,
-          "The kind of the `jsonNode` must be `JObject`, but its actual " &
-          "type is `" & $jsonNode.kind & "`."
-  clear(t)
-  for k, v in jsonNode:
-    t[k] = jsonTo(v, V)
-
-proc toJsonHook*[K, V](t: (Table[K, V] | OrderedTable[K, V])): auto =
-  ## Enables `toJson` for `Table` and `OrderedTable` types.
-  ##
-  ## See also:
-  ## * `fromJsonHook proc<#fromJsonHook,(Table[K,V]|OrderedTable[K,V]),JN>`_
-  runnableExamples:
-    import std/[json, jsonutils]
-    let foo = (
-      t: [("two", 2)].toTable,
-      ot: [("one", 1), ("three", 3)].toOrderedTable)
-    assert $toJson(foo) == """{"t":{"two":2},"ot":{"one":1,"three":3}}"""
-
-  mixin newJObject, toJson
-  result = newJObject()
-  for k, v in pairs(t):
-    result[k] = toJson(v)
-
 # ---------------------------------------------------------------------------
 # --------------------------- OrderedTableRef -------------------------------
 # ---------------------------------------------------------------------------

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -372,43 +372,6 @@ proc unsafeGet*[T](self: Option[T]): T {.inline.}=
   assert self.isSome
   self.val
 
-proc fromJsonHook*[T, JN](self: var Option[T], jsonNode: JN) =
-  ## Enables `fromJson` for `Option` types.
-  ## 
-  ## See also:
-  ## * `toJsonHook proc<#toJsonHook,Option[T]>`_
-  runnableExamples:
-    import std/[json, jsonutils]
-    var opt: Option[string]
-    fromJsonHook(opt, parseJson("\"test\""))
-    assert get(opt) == "test"
-    fromJson(opt, parseJson("null"))
-    assert isNone(opt)
-
-  mixin jsonTo, JNull
-  if jsonNode.kind != JNull:
-    self = some(jsonTo(jsonNode, T))
-  else:
-    self = none[T]()
-
-proc toJsonHook*[T](self: Option[T]): auto =
-  ## Enables `toJson` for `Option` types.
-  ##
-  ## See also:
-  ## * `fromJsonHook proc<#fromJsonHook,Option[T],JN>`_
-  runnableExamples:
-    import std/[json, jsonutils]
-    let optSome = some("test")
-    assert $toJson(optSome) == "\"test\""
-    let optNone = none[string]()
-    assert $toJson(optNone) == "null"
-
-  mixin toJson, newJNull
-  if isSome(self):
-    toJson(get(self))
-  else:
-    newJNull()
-
 when isMainModule:
   import unittest, sequtils
 

--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -89,6 +89,7 @@ const
   growthFactor = 2
   startSize = 64
 
+proc mode*(t: StringTableRef): StringTableMode {.inline.} = t.mode
 
 iterator pairs*(t: StringTableRef): tuple[key, value: string] =
   ## Iterates over every `(key, value)` pair in the table `t`.
@@ -418,25 +419,6 @@ proc `%`*(f: string, t: StringTableRef, flags: set[FormatFlag] = {}): string {.
     else:
       add(result, f[i])
       inc(i)
-
-since (1,3,5):
-  proc fromJsonHook*[T](a: var StringTableRef, b: T) =
-    ## for json.fromJson
-    mixin jsonTo
-    var mode = jsonTo(b["mode"], StringTableMode)
-    a = newStringTable(mode)
-    let b2 = b["table"]
-    for k,v in b2: a[k] = jsonTo(v, string)
-
-  proc toJsonHook*[](a: StringTableRef): auto =
-    ## for json.toJson
-    mixin newJObject
-    mixin toJson
-    result = newJObject()
-    result["mode"] = toJson($a.mode)
-    let t = newJObject()
-    for k,v in a: t[k] = toJson(v)
-    result["table"] = t
 
 when isMainModule:
   var x = {"k": "v", "11": "22", "565": "67"}.newStringTable

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -122,8 +122,9 @@ template fromJsonFields(newObj, oldObj, json, discKeys, opt) =
         # if there are no discriminant keys the `oldObj` must always have the
         # same keys as the new one. Otherwise we must check, because they could
         # be set to different branches.
-        if discKeys.len == 0 or hasField(oldObj, key):
-          val = accessField(oldObj, key)
+        when typeof(oldObj) isnot typeof(nil):
+          if discKeys.len == 0 or hasField(oldObj, key):
+            val = accessField(oldObj, key)
       else:
         checkJson false, $($T, key, json)
     else:
@@ -219,17 +220,17 @@ proc fromJson*[T](a: var T, b: JsonNode, opt = Joptions()) =
         default(typ)
     const keys = getDiscriminants(T)
     when keys.len == 0:
-      fromJsonFields(a, a, b, keys, opt)
+      fromJsonFields(a, nil, b, keys, opt)
     else:
       if discKeysMatch(a, b, keys):
-        fromJsonFields(a, a, b, keys, opt)
+        fromJsonFields(a, nil, b, keys, opt)
       else:
         var newObj = initCaseObject(T, fun)
         fromJsonFields(newObj, a, b, keys, opt)
         a = newObj
   elif T is tuple:
     when isNamedTuple(T):
-      fromJsonFields(a, a, b, seq[string].default, opt)
+      fromJsonFields(a, nil, b, seq[string].default, opt)
     else:
       checkJson b.kind == JArray, $(b.kind) # we could customize whether to allow JNull
       var i = 0

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -213,7 +213,7 @@ proc fromJson*[T](a: var T, b: JsonNode, opt = Joptions()) =
     for i, val in b.getElems:
       fromJson(a[i], val)
   elif T is object:
-    template fun(key, typ): untyped =
+    template fun(key, typ): untyped {.used.} =
       if b.hasKey key:
         jsonTo(b[key], typ)
       elif hasField(a, key):

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -23,6 +23,8 @@ add a way to customize serialization, for eg:
   (enum is more compact/efficient, and robust to enum renamings, but string
   is more human readable)
 * handle cyclic references, using a cache of already visited addresses
+* implement support for serialization and de-serialization of nested variant
+  objects.
 ]#
 
 import std/macros

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -13,8 +13,7 @@ proc testRoundtrip[T](t: T, expected: string) =
   t2.fromJson(j)
   doAssert t2.toJson == j
 
-import tables, sets, algorithm, sequtils, options
-import strtabs
+import tables, sets, algorithm, sequtils, options, strtabs
 
 type Foo = ref object
   id: int
@@ -140,6 +139,14 @@ template fn() =
     testRoundtrip(none[string]()): "null"
     testRoundtrip(some(42)): "42"
     testRoundtrip(none[int]()): "null"
+
+  block testStrtabs:
+    testRoundtrip(newStringTable(modeStyleInsensitive)):
+      """{"mode":"modeStyleInsensitive","table":{}}"""
+
+    testRoundtrip(
+      newStringTable("name", "John", "surname", "Doe", modeCaseSensitive)):
+        """{"mode":"modeCaseSensitive","table":{"name":"John","surname":"Doe"}}"""
 
   block testJoptions:
     type

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -264,5 +264,34 @@ template fn() =
       doAssert foo.c == 0
       doAssert foo.c0 == 42
 
+    when false:
+      ## TODO: Implement support for nested variant objects allowing the tests
+      ## bellow to pass.
+      block testNestedVariantObjects:
+        type
+          Variant = object
+            case b: bool
+            of false:
+              case bf: bool
+              of false: bff: int
+              of true: bft: float
+            of true:
+              case bt: bool
+              of false: btf: string
+              of true: btt: char
+
+        testRoundtrip(Variant(b: false, bf: false, bff: 42)):
+          """{"b": false, "bf": false, "bff": 42}"""
+        testRoundtrip(Variant(b: false, bf: true, bft: 3.14159)):
+          """{"b": false, "bf": true, "bft": 3.14159}"""
+        testRoundtrip(Variant(b: true, bt: false, btf: "test")):
+          """{"b": true, "bt": false, "btf": "test"}"""
+        testRoundtrip(Variant(b: true, bt: true, btt: 'c')):
+          """{"b": true, "bt": true, "btt": "c"}"""
+        
+        # TODO: Add additional tests with missing and extra JSON keys, both when
+        # allowed and forbidden analogous to the tests for the not nested
+        # variant objects.
+
 static: fn()
 fn()

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -13,7 +13,7 @@ proc testRoundtrip[T](t: T, expected: string) =
   t2.fromJson(j)
   doAssert t2.toJson == j
 
-import tables
+import tables, sets, algorithm, sequtils, options
 import strtabs
 
 type Foo = ref object
@@ -118,6 +118,151 @@ template fn() =
     testRoundtrip(Foo[float](t1: true, z1: 5, t2: 3, z4: 12)): """{"t1":true,"z1":5,"t2":3,"z4":12}"""
     testRoundtrip(Foo[int](t1: false, z2: 7)): """{"t1":false,"z2":7}"""
     # pending https://github.com/nim-lang/Nim/issues/14698, test with `type Foo[T] = ref object`
+
+  block testHashSet:
+    testRoundtrip(HashSet[string]()): "[]"
+    testRoundtrip([""].toHashSet): """[""]"""
+    testRoundtrip(["one"].toHashSet): """["one"]"""
+
+    var s: HashSet[string]
+    fromJson(s, parseJson("""["one","two"]"""))
+    doAssert s == ["one", "two"].toHashSet
+
+    let jsonNode = toJson(s)
+    doAssert jsonNode.elems.mapIt(it.str).sorted == @["one", "two"]
+
+  block testOrderedSet:
+    testRoundtrip(["one", "two", "three"].toOrderedSet):
+      """["one","two","three"]"""
+
+  block testOption:
+    testRoundtrip(some("test")): "\"test\""
+    testRoundtrip(none[string]()): "null"
+    testRoundtrip(some(42)): "42"
+    testRoundtrip(none[int]()): "null"
+
+  block testJoptions:
+    type
+      AboutLifeUniverseAndEverythingElse = object
+        question: string
+        answer: int
+
+    block testExceptionOnExtraKeys:
+      var guide: AboutLifeUniverseAndEverythingElse
+      let json = parseJson(
+        """{"question":"6*9=?","answer":42,"author":"Douglas Adams"}""")
+      doAssertRaises ValueError, fromJson(guide, json)
+      doAssertRaises ValueError,
+                     fromJson(guide, json, Joptions(allowMissingKeys: true))
+
+      type
+        A = object
+          a1,a2,a3: int
+      var a: A
+      let j = parseJson("""{"a3": 1, "a4": 2}""")
+      doAssertRaises ValueError,
+                     fromJson(a, j, Joptions(allowMissingKeys: true))
+
+    block testExceptionOnMissingKeys:
+      var guide: AboutLifeUniverseAndEverythingElse
+      let json = parseJson("""{"answer":42}""")
+      doAssertRaises ValueError, fromJson(guide, json)
+      doAssertRaises ValueError,
+                     fromJson(guide, json, Joptions(allowExtraKeys: true))
+
+    block testAllowExtraKeys:
+      var guide: AboutLifeUniverseAndEverythingElse
+      let json = parseJson(
+        """{"question":"6*9=?","answer":42,"author":"Douglas Adams"}""")
+      fromJson(guide, json, Joptions(allowExtraKeys: true))
+      doAssert guide == AboutLifeUniverseAndEverythingElse(
+        question: "6*9=?", answer: 42)
+
+    block testAllowMissingKeys:
+      var guide = AboutLifeUniverseAndEverythingElse(
+        question: "6*9=?", answer: 54)
+      let json = parseJson("""{"answer":42}""")
+      fromJson(guide, json, Joptions(allowMissingKeys: true))
+      doAssert guide == AboutLifeUniverseAndEverythingElse(
+        question: "6*9=?", answer: 42)
+
+    block testAllowExtraAndMissingKeys:
+      var guide = AboutLifeUniverseAndEverythingElse(
+        question: "6*9=?", answer: 54)
+      let json = parseJson(
+        """{"answer":42,"author":"Douglas Adams"}""")
+      fromJson(guide, json, Joptions(
+        allowExtraKeys: true, allowMissingKeys: true))
+      doAssert guide == AboutLifeUniverseAndEverythingElse(
+        question: "6*9=?", answer: 42)
+
+    type
+      Foo = object
+        a: array[2, string]
+        case b: bool
+        of false: f: float
+        of true: t: tuple[i: int, s: string]
+        case c: range[0 .. 2]
+        of 0: c0: int
+        of 1: c1: float
+        of 2: c2: string
+
+    block testExceptionOnMissingDiscriminantKey:
+      var foo: Foo
+      let json = parseJson("""{"a":["one","two"]}""")
+      doAssertRaises ValueError, fromJson(foo, json)
+
+    block testDoNotResetMissingFieldsWhenHaveDiscriminantKey:
+      var foo = Foo(a: ["one", "two"], b: true, t: (i: 42, s: "s"),
+                    c: 0, c0: 1)
+      let json = parseJson("""{"b":true,"c":2}""")
+      fromJson(foo, json, Joptions(allowMissingKeys: true))
+      doAssert foo.a == ["one", "two"]
+      doAssert foo.b
+      doAssert foo.t == (i: 42, s: "s")
+      doAssert foo.c == 2
+      doAssert foo.c2 == ""
+
+    block testAllowMissingDiscriminantKeys:
+      var foo: Foo
+      let json = parseJson("""{"a":["one","two"],"c":1,"c1":3.14159}""")
+      fromJson(foo, json, Joptions(allowMissingKeys: true))
+      doAssert foo.a == ["one", "two"]
+      doAssert not foo.b
+      doAssert foo.f == 0.0
+      doAssert foo.c == 1
+      doAssert foo.c1 == 3.14159
+
+    block testExceptionOnWrongDiscirminatBranchInJson:
+      var foo = Foo(b: false, f: 3.14159, c: 0, c0: 42)
+      let json = parseJson("""{"c2": "hello"}""")
+      doAssertRaises ValueError,
+                     fromJson(foo, json, Joptions(allowMissingKeys: true))
+      # Test that the original fields are not reset.
+      doAssert not foo.b
+      doAssert foo.f == 3.14159
+      doAssert foo.c == 0
+      doAssert foo.c0 == 42
+
+    block testNoExceptionOnRightDiscriminantBranchInJson:
+      var foo = Foo(b: false, f: 0, c:1, c1: 0)
+      let json = parseJson("""{"f":2.71828,"c1": 3.14159}""")
+      fromJson(foo, json, Joptions(allowMissingKeys: true))
+      doAssert not foo.b
+      doAssert foo.f == 2.71828
+      doAssert foo.c == 1
+      doAssert foo.c1 == 3.14159
+
+    block testAllowExtraKeysInJsonOnWrongDisciriminatBranch:
+      var foo = Foo(b: false, f: 3.14159, c: 0, c0: 42)
+      let json = parseJson("""{"c2": "hello"}""")
+      fromJson(foo, json, Joptions(allowMissingKeys: true,
+                                   allowExtraKeys: true))
+      # Test that the original fields are not reset.
+      doAssert not foo.b
+      doAssert foo.f == 3.14159
+      doAssert foo.c == 0
+      doAssert foo.c0 == 42
 
 static: fn()
 fn()


### PR DESCRIPTION
* Use `jsonutils.nim` hookable API to add a possibility to deserialize JSON arrays directly to `HashSet` and `OrderedSet` types and respectively to serialize those types to JSON arrays.

* Also add a possibility to deserialize JSON `null` objects to Nim option objects and respectively to serialize Nim option object to JSON object if `isSome` or to JSON `null` object if `isNone`.
    
* Move serialization/deserialization functionality for `Table` and `OrderedTable` types from `jsonutils.nim` to `tables.nim` via the hookable API.
    
* Add object `jsonutils.Joptions` and parameter from its type to `jsonutils.fromJson` procedure to control whether to allow deserializing JSON objects to Nim objects when the JSON has some extra or missing keys.
    
* Add unit tests for the added functionalities to `tjsonutils.nim`.
