### PR TITLE
Remove `noSideEffect` pragmas

### DIFF
--- a/lib/pure/strtabs.nim
+++ b/lib/pure/strtabs.nim
@@ -232,7 +232,7 @@ proc enlarge(t: StringTableRef) =
   swap(t.data, n)
 
 proc `[]=`*(t: StringTableRef, key, val: string) {.
-  rtlFunc, extern: "nstPut", noSideEffect.} =
+  rtlFunc, extern: "nstPut".} =
   ## Inserts a `(key, value)` pair into `t`.
   ##
   ## See also:

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -334,7 +334,7 @@ proc insert*(father, son: XmlNode, index: int) {.inline.} =
   else:
     insert(father.s, son, len(father.s))
 
-proc delete*(n: XmlNode, i: Natural) {.noSideEffect.} =
+proc delete*(n: XmlNode, i: Natural) =
   ## Delete the `i`'th child of `n`.
   ##
   ## See also:


### PR DESCRIPTION
These don't seem to make sense for the purpose of the procs and lead
to errors when the `--experimental:strictFuncs` feature is enabled.

See also https://github.com/nim-lang/Nim/issues/15142