### PR TITLE
Add `iterator inotify_events` which is *almost always* needed logic

### DIFF
--- a/lib/posix/inotify.nim
+++ b/lib/posix/inotify.nim
@@ -73,6 +73,20 @@ proc inotify_rm_watch*(fd: cint; wd: cint): cint {.cdecl,
     importc: "inotify_rm_watch", header: "<sys/inotify.h>".}
   ## Remove the watch specified by WD from the inotify instance FD.
 
+iterator inotify_events*(evs: pointer, n: int): ptr InotifyEvent =
+  ## Abstract the packed buffer interface to yield event object pointers.
+  ##
+  ## .. code-block:: Nim
+  ##   var evs = newSeq[byte](8192)        # Already did inotify_init+add_watch
+  ##   while (let n = read(fd, evs[0].addr, 8192); n) > 0:     # read forever
+  ##     for e in inotify_events(evs[0].addr, n): echo e[].len # echo name lens
+  var ev: ptr InotifyEvent = cast[ptr InotifyEvent](evs)
+  var n = n
+  while n > 0:
+    yield ev
+    let sz = InotifyEvent.sizeof + int(ev[].len)
+    n -= sz
+    ev = cast[ptr InotifyEvent](cast[uint](ev) + uint(sz))
 
 runnableExamples:
   when defined(linux):


### PR DESCRIPTION
The commit message expands on "almost always".  It seems to me the least we should do to reduce likelihood of the bug of treating the whole read buffer as a single answer is to provide this iterator in the module.  It's existence alone may "jog memory" that multiple events per read can be delivered.  In addition, it makes doing the (almost always) right thing "easy".

On "easy"...yeah, client code still needs to deal with a `ptr InotifyEvent`, but that is kind of intrinsic to the low level interface.  A higher level iterator that creates a Nim `string` is certainly possible, but the `name` may be zero length, the `Inotify.wd|mask|cookie` may be needed, etc. depending on the use case.  So, to be fully general we would want a new type that had all that and `name` as a Nim `string`.  Also, the iterator loop lifetime of the memory may be sufficient and just doing a `cast[cstring](yieldVal[].name.addr)` is not so awful since the kernel guarantees NUL-termination and work on filenames is likely to want a `cstring` anyway.  So, this PR just does the "minimal thing we should" for client code.

Writing a test case for this is hard.  Doing it "for real" needs Linux-only.  Doing it synthetically requires a synthetic buffer (or at least two, one big-endian, one little-endian because the `Inotify.len` field comes in "native endian" and matters to the logic).  But A) the logic is really pretty simple and B) I have tested this out-of-band on my systems and it works fine { EDIT: and C) inotify isn't really tested now anyway... }