### PR TITLE
fix sqlgetdata regression in odbc

### DIFF
--- a/lib/impure/db_odbc.nim
+++ b/lib/impure/db_odbc.nim
@@ -321,7 +321,7 @@ iterator instantRows*(db: var DbConn, query: SqlQuery,
       for colId in 1..cCnt:
         buf[0] = '\0'
         db.sqlCheck(SQLGetData(db.stmt, colId.SqlUSmallInt, SQL_C_CHAR,
-                                 cast[cstring](buf.addr), 4095,sz.addr))
+                                 cast[cstring](buf.addr), 4095, sz.addr))
         rowRes[colId-1] = $(addr buf)
       yield (row: rowRes, len: cCnt.int)
       res = SQLFetch(db.stmt)
@@ -388,7 +388,7 @@ proc getAllRows*(db: var DbConn, query: SqlQuery,
       for colId in 1..cCnt:
         buf[0] = '\0'
         db.sqlCheck(SQLGetData(db.stmt, colId.SqlUSmallInt, SQL_C_CHAR,
-                                 cast[cstring](buf.addr), 4095,sz.addr))
+                                 cast[cstring](buf.addr), 4095, sz.addr))
         rowRes[colId-1] = $(addr buf)
       rows.add(rowRes)
       res = SQLFetch(db.stmt)

--- a/lib/impure/db_odbc.nim
+++ b/lib/impure/db_odbc.nim
@@ -279,7 +279,7 @@ iterator fastRows*(db: var DbConn, query: SqlQuery,
   ## Rows are retrieved from the server at each iteration.
   var
     rowRes: Row
-    sz: TSqlInteger = 0
+    sz: TSqlLen = 0
     cCnt: TSqlSmallInt = 0
     res: TSqlSmallInt = 0
   res = db.prepareFetch(query, args)
@@ -293,8 +293,7 @@ iterator fastRows*(db: var DbConn, query: SqlQuery,
       for colId in 1..cCnt:
         buf[0] = '\0'
         db.sqlCheck(SQLGetData(db.stmt, colId.SqlUSmallInt, SQL_C_CHAR,
-                                 cast[cstring](buf.addr), 4095.TSqlSmallInt,
-                                 sz.addr))
+                                 cast[cstring](buf.addr), 4095, sz.addr))
         rowRes[colId-1] = $(addr buf)
       yield rowRes
       res = SQLFetch(db.stmt)
@@ -308,7 +307,7 @@ iterator instantRows*(db: var DbConn, query: SqlQuery,
   ## on demand using []. Returned handle is valid only within the iterator body.
   var
     rowRes: Row = @[]
-    sz: TSqlInteger = 0
+    sz: TSqlLen = 0
     cCnt: TSqlSmallInt = 0
     res: TSqlSmallInt = 0
   res = db.prepareFetch(query, args)
@@ -322,8 +321,7 @@ iterator instantRows*(db: var DbConn, query: SqlQuery,
       for colId in 1..cCnt:
         buf[0] = '\0'
         db.sqlCheck(SQLGetData(db.stmt, colId.SqlUSmallInt, SQL_C_CHAR,
-                                 cast[cstring](buf.addr), 4095.TSqlSmallInt,
-                                 sz.addr))
+                                 cast[cstring](buf.addr), 4095,sz.addr))
         rowRes[colId-1] = $(addr buf)
       yield (row: rowRes, len: cCnt.int)
       res = SQLFetch(db.stmt)
@@ -349,7 +347,7 @@ proc getRow*(db: var DbConn, query: SqlQuery,
   ## will return a Row with empty strings for each column.
   var
     rowRes: Row
-    sz: TSqlInteger = 0
+    sz: TSqlLen = 0
     cCnt: TSqlSmallInt = 0
     res: TSqlSmallInt = 0
   res = db.prepareFetch(query, args)
@@ -362,8 +360,7 @@ proc getRow*(db: var DbConn, query: SqlQuery,
     for colId in 1..cCnt:
       buf[0] = '\0'
       db.sqlCheck(SQLGetData(db.stmt, colId.SqlUSmallInt, SQL_C_CHAR,
-                               cast[cstring](buf.addr), 4095.TSqlSmallInt,
-                               sz.addr))
+                               cast[cstring](buf.addr), 4095, sz.addr))
       rowRes[colId-1] = $(addr buf)
     res = SQLFetch(db.stmt)
     result = rowRes
@@ -377,7 +374,7 @@ proc getAllRows*(db: var DbConn, query: SqlQuery,
   var
     rows: seq[Row] = @[]
     rowRes: Row
-    sz: TSqlInteger = 0
+    sz: TSqlLen = 0
     cCnt: TSqlSmallInt = 0
     res: TSqlSmallInt = 0
   res = db.prepareFetch(query, args)
@@ -391,8 +388,7 @@ proc getAllRows*(db: var DbConn, query: SqlQuery,
       for colId in 1..cCnt:
         buf[0] = '\0'
         db.sqlCheck(SQLGetData(db.stmt, colId.SqlUSmallInt, SQL_C_CHAR,
-                                 cast[cstring](buf.addr), 4095.TSqlSmallInt,
-                                 sz.addr))
+                                 cast[cstring](buf.addr), 4095,sz.addr))
         rowRes[colId-1] = $(addr buf)
       rows.add(rowRes)
       res = SQLFetch(db.stmt)

--- a/lib/wrappers/odbcsql.nim
+++ b/lib/wrappers/odbcsql.nim
@@ -718,14 +718,14 @@ proc SQLNumResultCols*(StatementHandle: SqlHStmt, ColumnCount: var TSqlSmallInt)
 proc SQLDescribeCol*(StatementHandle: SqlHStmt, ColumnNumber: SqlUSmallInt,
                      ColumnName: PSQLCHAR, BufferLength: TSqlSmallInt,
                      NameLength: var TSqlSmallInt, DataType: var TSqlSmallInt,
-                     ColumnSize: var TSQLULEN,
+                     ColumnSize: var TSqlULen,
                      DecimalDigits: var TSqlSmallInt, Nullable: var TSqlSmallInt): TSqlSmallInt{.
     dynlib: odbclib, importc.}
 proc SQLFetchScroll*(StatementHandle: SqlHStmt, FetchOrientation: TSqlSmallInt,
-                     FetchOffset: TSqlInteger): TSqlSmallInt{.dynlib: odbclib,
+                     FetchOffset: TSqlLen): TSqlSmallInt{.dynlib: odbclib,
     importc.}
 proc SQLExtendedFetch*(hstmt: SqlHStmt, fFetchType: SqlUSmallInt,
-                       irow: TSqlInteger, pcrow: var TSQLULEN,
+                       irow: TSqlLen, pcrow: var TSqlULen,
                        rgfRowStatus: PSQLUSMALLINT): TSqlSmallInt{.dynlib: odbclib,
     importc.}
 proc SQLGetData*(StatementHandle: SqlHStmt, ColumnNumber: SqlUSmallInt,

--- a/lib/wrappers/odbcsql.nim
+++ b/lib/wrappers/odbcsql.nim
@@ -730,7 +730,7 @@ proc SQLExtendedFetch*(hstmt: SqlHStmt, fFetchType: SqlUSmallInt,
     importc.}
 proc SQLGetData*(StatementHandle: SqlHStmt, ColumnNumber: SqlUSmallInt,
                  TargetType: TSqlSmallInt, TargetValue: SqlPointer,
-                 BufferLength: TSqlInteger, StrLen_or_Ind: PSQLINTEGER): TSqlSmallInt{.
+                 BufferLength: TSqlLen, StrLen_or_Ind: ptr TSqlLen): TSqlSmallInt{.
     dynlib: odbclib, importc.}
 proc SQLSetStmtAttr*(StatementHandle: SqlHStmt, Attribute: TSqlInteger,
                      Value: SqlPointer, StringLength: TSqlInteger): TSqlSmallInt{.


### PR DESCRIPTION
Chasing regression caused by https://github.com/nim-lang/Nim/pull/14357.
Last 2 arguments of SQLGetData need have TSqlLen in its types.

Official docs:
https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgetdata-function?view=sql-server-ver15

