### PR TITLE
Added more SSL documentation to `net` module.

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1954,7 +1954,8 @@ proc connect*(socket: Socket, address: string, port = Port(0),
   ## the connection to the server to be made.
   ##
   ## **Warning:** This procedure appears to be broken for SSL connections as of
-  ## Nim v1.0.2. Consider using the other `connect` procedure.
+  ## Nim v1.0.2. Consider using the other `connect` procedure. See
+  ## https://github.com/nim-lang/Nim/issues/15215 for more info.
   socket.fd.setBlocking(false)
 
   socket.connectAsync(address, port, socket.domain)

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -38,7 +38,7 @@
 ##   var socket = newSocket()
 ##   socket.connect("google.com", Port(80))
 ##
-## For SSL, use the next example.
+## For SSL, use the following example (and make sure to compile with ``-d:ssl``):
 ##
 ## .. code-block:: Nim
 ##   var socket = newSocket()

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -20,7 +20,8 @@
 ## ====
 ##
 ## In order to use the SSL procedures defined in this module, you will need to
-## compile your application with the ``-d:ssl`` flag.
+## compile your application with the ``-d:ssl`` flag. See the `newContext`
+## procedure for additional details.
 ##
 ## Examples
 ## ========
@@ -36,8 +37,16 @@
 ##   var socket = newSocket()
 ##   socket.connect("google.com", Port(80))
 ##
+## For SSL, use the next example.
+##
+## .. code-block:: Nim
+##   var socket = newSocket()
+##   var ctx = newContext()
+##   wrapSocket(ctx, socket)
+##   socket.connect("google.com", Port(443))
+##
 ## UDP is a connectionless protocol, so UDP sockets don't have to explicitly
-## call the ``connect`` procedure. They can simply start sending data
+## call the `connect` procedure. They can simply start sending data
 ## immediately.
 ##
 ## .. code-block:: Nim
@@ -1942,6 +1951,9 @@ proc connect*(socket: Socket, address: string, port = Port(0),
   ##
   ## The ``timeout`` parameter specifies the time in milliseconds to allow for
   ## the connection to the server to be made.
+  ##
+  ## Do not use this version of `connect` for an SSL socket. Instead use the
+  ## version with no `timeout` parameter.
   socket.fd.setBlocking(false)
 
   socket.connectAsync(address, port, socket.domain)

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -47,7 +47,7 @@
 ##   socket.connect("google.com", Port(443))
 ##
 ## UDP is a connectionless protocol, so UDP sockets don't have to explicitly
-## call the `connect<net.html#connect%2CSocket%2Cstring>`_ procedure. They can
+## call the `connect <net.html#connect%2CSocket%2Cstring>`_ procedure. They can
 ## simply start sending data immediately.
 ##
 ## .. code-block:: Nim

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -21,7 +21,7 @@
 ##
 ## In order to use the SSL procedures defined in this module, you will need to
 ## compile your application with the ``-d:ssl`` flag. See the
-## `newContext<net.html#newContext%2Cstring%2Cstring%2Cstring%2Cstring>`_
+## `newContext<net.html#newContext%2Cstring%2Cstring%2Cstring%2Cstring%2Cstring>`_
 ## procedure for additional details.
 ##
 ## Examples
@@ -47,7 +47,7 @@
 ##   socket.connect("google.com", Port(443))
 ##
 ## UDP is a connectionless protocol, so UDP sockets don't have to explicitly
-## call the `connect<net.html#connect%2CSocket%2Cstring>`_ procedure. They can
+## call the `connect <net.html#connect%2CSocket%2Cstring>`_ procedure. They can
 ## simply start sending data immediately.
 ##
 ## .. code-block:: Nim

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -20,7 +20,8 @@
 ## ====
 ##
 ## In order to use the SSL procedures defined in this module, you will need to
-## compile your application with the ``-d:ssl`` flag. See the `newContext`
+## compile your application with the ``-d:ssl`` flag. See the
+## `newContext<net.html#newContext%2Cstring%2Cstring%2Cstring%2Cstring>`_
 ## procedure for additional details.
 ##
 ## Examples
@@ -46,8 +47,8 @@
 ##   socket.connect("google.com", Port(443))
 ##
 ## UDP is a connectionless protocol, so UDP sockets don't have to explicitly
-## call the `connect` procedure. They can simply start sending data
-## immediately.
+## call the `connect<net.html#connect%2CSocket%2Cstring>`_ procedure. They can
+## simply start sending data immediately.
 ##
 ## .. code-block:: Nim
 ##   var socket = newSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1953,8 +1953,8 @@ proc connect*(socket: Socket, address: string, port = Port(0),
   ## The ``timeout`` parameter specifies the time in milliseconds to allow for
   ## the connection to the server to be made.
   ##
-  ## Do not use this version of `connect` for an SSL socket. Instead use the
-  ## version with no `timeout` parameter.
+  ## **Warning:** This procedure appears to be broken for SSL connections as of
+  ## Nim v1.0.2. Consider using the other `connect` procedure.
   socket.fd.setBlocking(false)
 
   socket.connectAsync(address, port, socket.domain)


### PR DESCRIPTION
As promised on the Nim forum, here is a little bit more documentation to guide to the new user on how to make an non-async SSL connection via the `net` module. This includes a simple example and a notice on the version of `connect` that does not support SSL to use the other `connect` procedure.