### PR TITLE
Use more `lent` in options

### DIFF
--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -185,7 +185,7 @@ proc get*[T](self: Option[T]): lent T {.inline.} =
     raise newException(UnpackDefect, "Can't obtain a value from a `none`")
   result = self.val
 
-proc get*[T](self: Option[T], otherwise: T): lent T {.inline.} =
+proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
   ## Returns the contents of the `Option` or an `otherwise` value if
   ## the `Option` is `None`.
   runnableExamples:
@@ -196,9 +196,9 @@ proc get*[T](self: Option[T], otherwise: T): lent T {.inline.} =
     assert b.get(9999) == 9999
 
   if self.isSome:
-    result = self.val
+    self.val
   else:
-    result = otherwise
+    otherwise
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns contents of the `var Option`. If it is `None`, then an exception

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -185,7 +185,7 @@ proc get*[T](self: Option[T]): lent T {.inline.} =
     raise newException(UnpackDefect, "Can't obtain a value from a `none`")
   result = self.val
 
-proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
+proc get*[T](self: Option[T], otherwise: T): lent T {.inline.} =
   ## Returns the contents of the `Option` or an `otherwise` value if
   ## the `Option` is `None`.
   runnableExamples:
@@ -196,9 +196,9 @@ proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
     assert b.get(9999) == 9999
 
   if self.isSome:
-    self.val
+    result = self.val
   else:
-    otherwise
+    result = otherwise
 
 proc get*[T](self: var Option[T]): var T {.inline.} =
   ## Returns contents of the `var Option`. If it is `None`, then an exception
@@ -363,14 +363,14 @@ proc `$`*[T](self: Option[T]): string =
   else:
     result = "None[" & name(T) & "]"
 
-proc unsafeGet*[T](self: Option[T]): T {.inline.}=
+proc unsafeGet*[T](self: Option[T]): lent T {.inline.}=
   ## Returns the value of a `some`. Behavior is undefined for `none`.
   ##
   ## **Note:** Use it only when you are **absolutely sure** the value is present
   ## (e.g. after checking `isSome <#isSome,Option[T]>`_).
   ## Generally, using `get proc <#get,Option[T]>`_ is preferred.
   assert self.isSome
-  self.val
+  result = self.val
 
 
 when isMainModule:


### PR DESCRIPTION
Extend https://github.com/nim-lang/Nim/pull/14442 to ~~`get` with otherwise~~ and `unsafeGet`.

This is very useful to not run out of stack when manipulating optional large datatypes like cryptographic hashes.

Edit
```Nim
proc get*[T](self: Option[T], otherwise: T): lent T {.inline.} =
  ## Returns the contents of the `Option` or an `otherwise` value if
  ## Returns the contents of the `Option` or an `otherwise` value if
  ## the `Option` is `None`.
  ## the `Option` is `None`.
  runnableExamples:
  runnableExamples:
@@ -196,9 +196,9 @@ proc get*[T](self: Option[T], otherwise: T): T {.inline.} =
    assert b.get(9999) == 9999
    assert b.get(9999) == 9999


  if self.isSome:
  if self.isSome:
    self.val
    result = self.val
  else:
  else:
    otherwise
    result = otherwise
```
doesn't compile due to var t returns rule: https://nim-lang.org/docs/var_t_return.html