### PR TITLE
typetraits: implements `value in type`

### DIFF
--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -295,10 +295,7 @@ proc hasClosure*(fn: NimNode): bool {.since: (1, 5, 1).} =
 macro inEnumWithHoles[U: Ordinal](T: typedesc[enum], v: U): bool =
   let
     eq = bindSym("==", brOpen)
-    le = bindSym("<=", brOpen)
-    ge = bindSym(">=", brOpen)
     `or` = bindSym"or"
-    `and` = bindSym"and"
     ord = bindSym"ord"
 
   let value = genSym()

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -306,27 +306,16 @@ macro inEnumWithHoles[U: Ordinal](T: typedesc[enum], v: U): bool =
     newLetStmt(value, newCall(ord, v))
   )
 
-  template newOrdLit(lit: untyped): NimNode =
-    if lit.kind != nnkSym:
-      newCall(ord, newLit lit)
-    else:
-      newCall(ord, lit)
-
-  when T is Ordinal:
-    result.add newCall(`and`,
-                       newCall(ge, value, newOrdLit T.low),
-                       newCall(le, value, newOrdLit T.high))
-  else:
-    var matcher: NimNode
-    let enumDef = getType(T)
-    for i in enumDef.findChild(it.kind == nnkEnumTy):
-      if i.kind != nnkEmpty:
-        let match = newCall(eq, newOrdLit i, value)
-        if matcher.isNil:
-          matcher = match
-        else:
-          matcher = newCall(`or`, matcher, match)
-    result.add matcher
+  var matcher: NimNode
+  let enumDef = getType(T)
+  for i in enumDef.findChild(it.kind == nnkEnumTy):
+    if i.kind != nnkEmpty:
+      let match = newCall(eq, newCall(ord, i), value)
+      if matcher.isNil:
+        matcher = match
+      else:
+        matcher = newCall(`or`, matcher, match)
+  result.add matcher
 
 func contains*[U, V: SomeOrdinal](T: typedesc[U], v: V): bool
                                  {.inline, since: (1, 3, 5).} =

--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -1,5 +1,6 @@
 import typetraits
 import macros
+import fenv
 
 block: # isNamedTuple
   type Foo1 = (a:1,).type
@@ -350,3 +351,55 @@ block: # enum.len
     doAssert MyEnum.enumLen == 4
     doAssert OtherEnum.enumLen == 3
     doAssert MyFlag.enumLen == 4
+
+block contains:
+  block ordinal:
+    doAssert -10 notin uint8
+    doAssert 10 in uint8
+    doAssert high(uint64) notin int32
+    doAssert -10 in int32
+
+  block float:
+    doAssert -float64.maximumPositiveValue in float64
+    doAssert float64.maximumPositiveValue notin float32
+
+  block range:
+    doAssert 0u32 in Natural
+    doAssert 0 notin Positive
+    doAssert 0 in Natural
+
+    type
+      Letters = range['a'..'z']
+
+    doAssert '0' notin Letters
+    doAssert 'a' in Letters
+    doAssert ord(' ') notin Letters
+    doAssert ord('a') in Letters
+
+    type
+      ZeroOrPositiveFloat = range[0.0..high(float)]
+      ZeroOrPositiveFloat32 = range[0.0f32..high(float32)]
+    doAssert -10.0f32 notin ZeroOrPositiveFloat
+    doAssert 10.0 in ZeroOrPositiveFloat
+
+  block `enum`:
+    type
+      E {.pure.} = enum
+        A
+        B
+        C
+        D
+    doAssert 3 in E
+    doAssert 10 notin E
+
+    type
+      Holes {.pure.} = enum
+        A = 1
+        B
+        C
+        D = 9
+        E
+        F = 20
+
+    doAssert 1 in Holes
+    doAssert -10 notin Holes


### PR DESCRIPTION
This is useful for safe runtime type conversion, especially in
range-heavy code.

Example:

```nim
type
  AllowedPort = range[1024..65535]

stdout.write("Please enter a port [1024-65535]: ")
stdout.flushFile()
let port = stdin.readLine().parseInt()

if port in AllowedPort:
  setupServer(AllowedPort(port))
else:
  stderr.write("Invalid port number")
```