### PR TITLE
doc/nimdoc.css: align field names to the right

### DIFF
--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -582,6 +582,7 @@ table th {
 
 table th.docinfo-name {
     background-color: transparent;
+    text-align: right;
 }
 
 table tr:hover {


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/4961280/90965897-f3e35280-e4bb-11ea-9302-7359beb5e1e4.png)

After:
![after](https://user-images.githubusercontent.com/4961280/90965910-05c4f580-e4bc-11ea-96ba-274ef054ab58.png)