### PR TITLE
Add eopkg to package manager list

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -231,6 +231,8 @@ proc foreignDepInstallCmd*(foreignPackageName: string): (string, bool) =
       result = ("netpkg install " & p, true)
     elif detectOs(NixOS):
       result = ("nix-env -i " & p, false)
+    elif detectOS(Solus):
+      result = ("eopkg it " & p, true)
     elif detectOs(Solaris):
       result = ("pkg install " & p, true)
     elif detectOs(PCLinuxOS):


### PR DESCRIPTION
Added 2 lines in order to avoid mistake in package manager detecting (otherwise it detects Solus package manager as "pkg" [Solaris])