### PR TITLE
Raise KeyError if passed an invalid entry in `parsecsv.rowEntry`

### DIFF
--- a/lib/pure/parsecsv.nim
+++ b/lib/pure/parsecsv.nim
@@ -322,24 +322,29 @@ proc rowEntry*(my: var CsvParser, entry: string): var string =
   ##
   ## Assumes that `readHeaderRow <#readHeaderRow,CsvParser>`_ has already been
   ## called.
+  ## 
+  ## If specified `entry` does not exist, raises KeyError.
   runnableExamples:
     import streams
     var strm = newStringStream("One,Two,Three\n1,2,3\n\n10,20,30")
     var parser: CsvParser
     parser.open(strm, "tmp.csv")
-    ## Need calling `readHeaderRow`.
+    ## Requires calling `readHeaderRow`.
     parser.readHeaderRow()
     doAssert parser.readRow()
     doAssert parser.rowEntry("One") == "1"
     doAssert parser.rowEntry("Two") == "2"
     doAssert parser.rowEntry("Three") == "3"
-    ## `parser.rowEntry("NotExistEntry")` causes SIGSEGV fault.
+    doAssertRaises(KeyError):
+      discard parser.rowEntry("NonexistentEntry")
     parser.close()
     strm.close()
 
   let index = my.headers.find(entry)
   if index >= 0:
     result = my.row[index]
+  else:
+    raise newException(KeyError, "Entry `" & entry & "` doesn't exist")
 
 when not defined(testing) and isMainModule:
   import os


### PR DESCRIPTION
Motivated by https://stackoverflow.com/q/63577715/14164200

`parsecsv.rowEntry` doesn't return anything if passed an invalid row header name, which leads to a SIGSEGV since (I believe) the proc is basically returning nil and strings can't be nil.

That said, should it also return `string` instead of `var string`? I can't think of any reason why the result should be mutable, and using `string` would have prevented the SIGSEGV.

Lastly (sorry!) shouldn't `var T` procs either require a result for non-nillable types , or return the default value for `T` if one is missing? Should I create an issue for this?