### PR TITLE
Add converter from Option[T] to bool

### DIFF
--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -372,6 +372,19 @@ proc unsafeGet*[T](self: Option[T]): lent T {.inline.}=
   assert self.isSome
   result = self.val
 
+converter toBool*[T](self: Option[T]): bool =
+  ## Converts an option to be true if it is `Some`.
+  runnableExamples:
+    var isSome = false
+    var val = some "I have some"
+    if val: # Allows easy checking if an option has a value
+      isSome = true
+    assert isSome == true
+    val = none(string)
+    if not val:
+      isSome = false
+    assert isSome == false
+  return self.isSome
 
 when isMainModule:
   import unittest, sequtils


### PR DESCRIPTION
Adds a small converter for syntactic sugar in checking if `Option[T]` contains a value
```nim
var value = some("some value")
# This
if value:
    # Do work on value
# Instead of this
if value.isSome:
    # Do work on value
```