### PR TITLE
typetraits: add rangeof(T), a shortcut for low(T)..high(T)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -148,7 +148,7 @@
 - Added `deques.toDeque`, which creates a deque from an openArray. The usage is
   similar to procs such as `sets.toHashSet` and `tables.toTable`. Previously,
   it was necessary to create an empty deque and add items manually.
-  
+
 - `std/with`, `sugar.dup` now support object field assignment expression:
   ```nim
   import std/with
@@ -168,6 +168,29 @@
   cannot be applied to every use case. The limitations and the (lack of) reliability
   of `round` are well documented.
 
+- Added `typetraits.rangeof` which returns a slice with the full range of
+  a given type. This is a shortcut for `low(T)..high(T)` aiming to improve
+  the ergonomics of performing safe type conversions, especially between
+  range types. Below is an example usage of the new function:
+  ```nim
+  import typetraits, strutils
+
+  type
+    AllowedPort = range[1024..65535]
+
+  proc setupServer(port: AllowedPort) =
+    # Setup a webserver...
+    discard
+
+  stdout.write("Please enter a port [1024-65535]: ")
+  stdout.flushFile()
+  let port = stdin.readLine().parseInt()
+
+  if port in rangeof(AllowedPort):
+    setupServer(AllowedPort(port))
+  else:
+    stderr.write("Invalid port number")
+  ```
 
 
 ## Language changes

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -183,3 +183,32 @@ since (1, 1):
 
     type T2 = T
     genericParamsImpl(T2)
+
+func rangeof*(T: typedesc): Slice[T] {.inline, since: (1, 3, 5).} =
+  ## Returns a slice containing the full range of type `T`. This is a shortcut
+  ## for `low(T)..high(T)`.
+  ##
+  ## This proc is useful for verifying whether value of one type
+  ## can be safely converted to an another:
+  ##
+  ## .. code-block:: nim
+  ##    :test: "$nim $backend $options"
+  ##
+  ##   import strutils
+  ##
+  ##   type
+  ##     AllowedPort = range[1024..65535]
+  ##
+  ##   proc setupServer(port: AllowedPort) =
+  ##     # Setup a webserver...
+  ##     discard
+  ##
+  ##   stdout.write("Please enter a port [1024-65535]: ")
+  ##   stdout.flushFile()
+  ##   let port = stdin.readLine().parseInt()
+  ##
+  ##   if port in rangeof(AllowedPort):
+  ##     setupServer(AllowedPort(port))
+  ##   else:
+  ##     stderr.write("Invalid port number")
+  low(T)..high(T)


### PR DESCRIPTION
This func returns a slice with the full range of type `T`, basically a
shortcut for `low(T)..high(T)`. This is useful for verifying whether a
value of one type can be converted to an another.

The main use case for this would be as a sugar for the initial
conversion between an ordinal and a `range` type, though it's flexible
enough that it can be used for many other situations, like conversions
between int/uint of different sizes.

This is an alternative to #15212 in which runtime values and types are
now properly separated with an explicit function call.

Closes #15212.