### PR TITLE
Add SSL_CTX_set_session_id_context

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -825,6 +825,9 @@ when defineSsl:
     else:
       result = getPeerCertificates(socket.sslHandle)
 
+  proc `sessionIdContext=`*(ctx: SslContext, sidCtx: string) =
+      SSL_CTX_set_session_id_context(ctx.context, sidCtx, sidCtx.len)
+  
 proc getSocketError*(socket: Socket): OSErrorCode =
   ## Checks ``osLastError`` for a valid error. If it has been reset it uses
   ## the last error stored in the socket object.

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -828,6 +828,9 @@ when defineSsl:
   proc `sessionIdContext=`*(ctx: SslContext, sidCtx: string) =
       ## Set the session id context, used for resuming handshakes
       ## Must be unique to application.
+      ## sidCtx must be at most 32 characters in length.
+      if sidCtx.len > 32:
+        raiseSSLError("sessionIdContext must be shorter than 32 characters")
       SSL_CTX_set_session_id_context(ctx.context, sidCtx, sidCtx.len)
   
 proc getSocketError*(socket: Socket): OSErrorCode =

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -826,6 +826,8 @@ when defineSsl:
       result = getPeerCertificates(socket.sslHandle)
 
   proc `sessionIdContext=`*(ctx: SslContext, sidCtx: string) =
+      ## Set the session id context, used for resuming handshakes
+      ## Must be unique to application.
       SSL_CTX_set_session_id_context(ctx.context, sidCtx, sidCtx.len)
   
 proc getSocketError*(socket: Socket): OSErrorCode =

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -826,12 +826,20 @@ when defineSsl:
       result = getPeerCertificates(socket.sslHandle)
 
   proc `sessionIdContext=`*(ctx: SslContext, sidCtx: string) =
-      ## Set the session id context, used for resuming handshakes
-      ## Must be unique to application.
-      ## sidCtx must be at most 32 characters in length.
-      if sidCtx.len > 32:
-        raiseSSLError("sessionIdContext must be shorter than 32 characters")
-      SSL_CTX_set_session_id_context(ctx.context, sidCtx, sidCtx.len)
+    ## Sets the session id context in which a session can be reused.
+    ## Used for permitting clients to reuse a session id instead of
+    ## doing a new handshake.
+    ##
+    ## TLS clients might attempt to resume a session using the session id context,
+    ## thus it must be set if verifyMode is set to CVerifyPeer or CVerifyPeerUseEnvVars,
+    ## otherwise the connection will fail and SslError will be raised if resumption occurs.
+    ##
+    ## - Only useful if set server-side.
+    ## - Should be unique per-application to prevent clients from malfunctioning.
+    ## - sidCtx must be at most 32 characters in length.
+    if sidCtx.len > 32:
+      raiseSSLError("sessionIdContext must be shorter than 32 characters")
+    SSL_CTX_set_session_id_context(ctx.context, sidCtx, sidCtx.len)
   
 proc getSocketError*(socket: Socket): OSErrorCode =
   ## Checks ``osLastError`` for a valid error. If it has been reset it uses

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -436,6 +436,7 @@ proc SSL_new*(context: SslCtx): SslPtr{.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_get_SSL_CTX*(ssl: SslPtr): SslCtx {.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_set_SSL_CTX*(ssl: SslPtr, ctx: SslCtx): SslCtx {.cdecl, dynlib: DLLSSLName, importc.}
+proc SSL_CTX_set_session_id_context*(context: SslCtx, sid_ctx: string, sid_ctx_len: int){.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_get0_verified_chain*(ssl: SslPtr): PSTACK {.cdecl, dynlib: DLLSSLName,
     importc.}
 proc SSL_CTX_new*(meth: PSSL_METHOD): SslCtx{.cdecl,


### PR DESCRIPTION
Some clients might attempt to resume a session which require initialisation of the id context using `SSL_CTX_set_session_id_context` by the server. From what I noticed, openssl.nim lacks this function, resulting in possible runtime errors since the id context cannot be initialised.

https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_session_id_context.html

> If the session id context is not set on an SSL/TLS server and client certificates are used, stored sessions will not be reused but a fatal error will be flagged and the handshake will fail.

https://www.openssl.org/docs/manmaster/man3/SSL_CTX_set_session_cache_mode.html

> Since a client may try to reuse a session intended for use in a different context, the session id context must be set by the server (see SSL_CTX_set_session_id_context(3)).

https://github.com/openssl/openssl/issues/10168#issuecomment-542654427
