### PR TITLE
Basic VM resume support

### DIFF
--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -134,6 +134,10 @@ proc destroyInterpreter*(i: Interpreter) =
   ## destructor.
   discard "currently nothing to do."
 
+proc resume*(i: Interpreter): PNode =
+  let c = PCtx i.graph.vm
+  result = execFromCtx(c, c.pc + 1, c.tos)
+
 proc runRepl*(r: TLLRepl;
               searchPaths: openArray[string];
               supportNimscript: bool) =

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -261,8 +261,10 @@ type
     config*: ConfigRef
     graph*: ModuleGraph
     oldErrorCount*: int
+    pc*: int
     profiler*: Profiler
     templInstCounter*: ref int # gives every template instantiation a unique ID, needed here for getAst
+    tos*: PStackFrame
 
   PStackFrame* = ref TStackFrame
   TStackFrame* = object

--- a/tests/compilerapi/exposed.nim
+++ b/tests/compilerapi/exposed.nim
@@ -1,3 +1,7 @@
+const overrideMsg = "implementation overridden by tcompilerapi.nim"
 
 proc addFloats*(x, y, z: float): float =
-  discard "implementation overridden by tcompilerapi.nim"
+  discard overrideMsg
+
+proc suspend*() =
+  discard overrideMsg

--- a/tests/compilerapi/resumectx.nim
+++ b/tests/compilerapi/resumectx.nim
@@ -1,0 +1,5 @@
+import exposed
+
+proc testSuspendAndResume*() =
+  suspend() # will raise
+  echo "resumed"


### PR DESCRIPTION
Discussed briefly at https://forum.nim-lang.org/t/6724.

This stores the program counter and stack in the VM context, so the vm can be resumed after an exception. This allows a VM to be treated like a fiber, and could potentially be used for basic breakpoint support.