### PR TITLE
testament/htmlgen: Fix collapse/expand panel on click

### DIFF
--- a/testament/htmlgen.nim
+++ b/testament/htmlgen.nim
@@ -16,7 +16,7 @@ import "testamenthtml.nimf"
 proc generateTestResultPanelPartial(outfile: File, testResultRow: JsonNode) =
   let
     trId = htmlQuote(testResultRow["category"].str & "_" & testResultRow["name"].str).
-        multiReplace({".": "_", " ": "_", ":": "_"})
+        multiReplace({".": "_", " ": "_", ":": "_", "/": "_"})
     name = testResultRow["name"].str.htmlQuote()
     category = testResultRow["category"].str.htmlQuote()
     target = testResultRow["target"].str.htmlQuote()


### PR DESCRIPTION
Fixes jquery error when clicking to collapse/expand a panel in the `testresults.html` generated by `testament html`

The error:
```
Uncaught Error: Syntax error, unrecognized expression: #panel-body-testResult-wasm_tests/wasm/taddr_nim_WAsm
    jQuery 7
    b https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js:6
    <anonymous> https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js:6
    jQuery 2
jquery.min.js:2:12468
```