### PR TITLE
add getprotobyname

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -168,6 +168,9 @@
   cannot be applied to every use case. The limitations and the (lack of) reliability
   of `round` are well documented.
 
+- Add `getprotobyname` to `winlean`. Add `getProtoByname` to `nativesockets` which returns a protocol code
+  from the database that matches the protocol `name`.
+
 
 
 ## Language changes

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -186,6 +186,7 @@ proc toSockType*(protocol: Protocol): SockType =
     SOCK_RAW
 
 proc getProtoByName*(name: string): int =
+  ## Returns a protocol code from the database that matches the protocol ``name``.
   when useWinVersion:
     let protoent = winlean.getprotobyname(name.cstring)
   else:

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -13,6 +13,8 @@
 # TODO: Clean up the exports a bit and everything else in general.
 
 import os, options
+import std/private/since
+
 
 when hostOS == "solaris":
   {.passl: "-lsocket -lnsl".}
@@ -185,7 +187,7 @@ proc toSockType*(protocol: Protocol): SockType =
   of IPPROTO_IP, IPPROTO_IPV6, IPPROTO_RAW, IPPROTO_ICMP, IPPROTO_ICMPV6:
     SOCK_RAW
 
-proc getProtoByName*(name: string): int =
+proc getProtoByName*(name: string): int {.since: (1, 3, 5).} =
   ## Returns a protocol code from the database that matches the protocol ``name``.
   when useWinVersion:
     let protoent = winlean.getprotobyname(name.cstring)

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -185,6 +185,17 @@ proc toSockType*(protocol: Protocol): SockType =
   of IPPROTO_IP, IPPROTO_IPV6, IPPROTO_RAW, IPPROTO_ICMP, IPPROTO_ICMPV6:
     SOCK_RAW
 
+proc getProtoByName*(name: string): int =
+  when useWinVersion:
+    let protoent = winlean.getprotobyname(name.cstring)
+  else:
+    let protoent = posix.getprotobyname(name.cstring)
+  
+  if protoent == nil:
+    raise newException(OsError, "protocol not found")
+
+  result = protoent.p_proto.int
+
 proc close*(socket: SocketHandle) =
   ## closes a socket.
   when useWinVersion:

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -96,6 +96,12 @@ type
     dwPlatformId*: DWORD
     szCSDVersion*: array[0..127, WinChar]
 
+  Protoent* = object
+    p_name*: cstring
+    p_aliases*: cstringArray
+    p_proto*: cshort
+
+
 const
   STARTF_USESHOWWINDOW* = 1'i32
   STARTF_USESTDHANDLES* = 256'i32
@@ -572,6 +578,14 @@ proc gethostbyname*(name: cstring): ptr Hostent {.
 
 proc gethostname*(hostname: cstring, len: cint): cint {.
   stdcall, importc: "gethostname", dynlib: ws2dll, sideEffect.}
+
+proc getprotobyname*(
+  name: cstring
+): ptr Protoent {.stdcall, importc: "getprotobyname", dynlib: ws2dll, sideEffect.}
+
+proc getprotobynumber*(
+  proto: cint
+): ptr Protoent {.stdcall, importc: "getprotobynumber", dynlib: ws2dll, sideEffect.}
 
 proc socket*(af, typ, protocol: cint): SocketHandle {.
   stdcall, importc: "socket", dynlib: ws2dll.}

--- a/tests/stdlib/tgetprotobyname.nim
+++ b/tests/stdlib/tgetprotobyname.nim
@@ -9,6 +9,17 @@ discard """
 
 import nativesockets
 
+
+doAssert getProtoByName("ip") == 0
+doAssert getProtoByName("ipv6") == 41
 doAssert getProtoByName("tcp") == 6
 doAssert getProtoByName("udp") == 17
 doAssert getProtoByName("icmp") == 1
+doAssert getProtoByName("ipv6-icmp") == 58
+
+when defined(windows):
+  doAssertRaises(OSError):
+    discard getProtoByName("raw")
+
+doAssertRaises(OSError):
+  discard getProtoByName("Error")

--- a/tests/stdlib/tgetprotobyname.nim
+++ b/tests/stdlib/tgetprotobyname.nim
@@ -1,0 +1,14 @@
+discard """
+  cmd:      "nim c -r --styleCheck:hint --panics:on $options $file"
+  targets:  "c"
+  nimout:   ""
+  action:   "run"
+  exitcode: 0
+  timeout:  60.0
+"""
+
+import nativesockets
+
+doAssert getProtoByName("tcp") == 6
+doAssert getProtoByName("udp") == 17
+doAssert getProtoByName("icmp") == 1


### PR DESCRIPTION
work like something in Python: https://docs.python.org/3/library/socket.html#socket.getprotobyname

Cpython implemention: https://github.com/python/cpython/blob/e822e37946f27c09953bb5733acf3b07c2db690f/Modules/socketmodule.c#L5900

From MSDN:

The protoent structure contains the name and protocol numbers that correspond to a given protocol name. Applications must never attempt to modify this structure or to **free any of its components**. Furthermore, only one copy of this structure is allocated per thread, and therefore, the application should copy any information it needs before issuing any other Windows Sockets function calls.