### PR TITLE
more Protocol supports in windows

### DIFF
--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -65,14 +65,14 @@ type
     SOCK_RAW = 3,      ## raw protocols atop the network layer.
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
-  Protocol* = enum    ## third argument to `socket` proc
-    IPPROTO_TCP = 6,  ## Transmission control protocol.
-    IPPROTO_UDP = 17, ## User datagram protocol.
-    IPPROTO_IP,       ## Internet protocol. Unsupported on Windows.
-    IPPROTO_IPV6,     ## Internet Protocol Version 6. Unsupported on Windows.
-    IPPROTO_RAW,      ## Raw IP Packets Protocol. Unsupported on Windows.
-    IPPROTO_ICMP      ## Control message protocol. Unsupported on Windows.
-    IPPROTO_ICMPV6    ## Control message protocol for IPv6. Unsupported on Windows.
+  Protocol* = enum     ## third argument to `socket` proc
+    IPPROTO_IP = 0,    ## Internet protocol.
+    IPPROTO_ICMP = 1   ## Control message protocol.
+    IPPROTO_TCP = 6,   ## Transmission control protocol.
+    IPPROTO_UDP = 17,  ## User datagram protocol.
+    IPPROTO_IPV6 = 41, ## Internet Protocol Version 6.
+    IPPROTO_ICMPV6     ## Control message protocol for IPv6. Unsupported on Windows.
+    IPPROTO_RAW,       ## Raw IP Packets Protocol. Unsupported on Windows.
 
   Servent* = object ## information about a service
     name*: string

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -65,14 +65,14 @@ type
     SOCK_RAW = 3,      ## raw protocols atop the network layer.
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
-  Protocol* = enum      ## third argument to `socket` proc
-    IPPROTO_IP = 0,     ## Internet protocol.
-    IPPROTO_ICMP = 1    ## Control message protocol.
-    IPPROTO_TCP = 6,    ## Transmission control protocol.
-    IPPROTO_UDP = 17,   ## User datagram protocol.
-    IPPROTO_IPV6 = 41,  ## Internet Protocol Version 6.
-    IPPROTO_ICMPV6 = 58 ## Control message protocol for IPv6.
-    IPPROTO_RAW,        ## Raw IP Packets Protocol. Unsupported on Windows.
+  Protocol* = enum    ## third argument to `socket` proc
+    IPPROTO_TCP = 6,  ## Transmission control protocol.
+    IPPROTO_UDP = 17, ## User datagram protocol.
+    IPPROTO_IP,       ## Internet protocol.
+    IPPROTO_IPV6,     ## Internet Protocol Version 6.
+    IPPROTO_RAW,      ## Raw IP Packets Protocol. Unsupported on Windows.
+    IPPROTO_ICMP      ## Control message protocol.
+    IPPROTO_ICMPV6    ## Control message protocol for IPv6.
 
   Servent* = object ## information about a service
     name*: string
@@ -174,7 +174,21 @@ else:
     result = cint(ord(typ))
 
   proc toInt(p: Protocol): cint =
-    result = cint(ord(p))
+    case p
+    of IPPROTO_IP:
+      result = 0.cint
+    of IPPROTO_ICMP:
+      result = 1.cint
+    of IPPROTO_TCP:
+      result = 6.cint
+    of IPPROTO_UDP:
+      result = 17.cint
+    of IPPROTO_IPV6:
+      result = 41.cint
+    of IPPROTO_ICMPV6:
+      result = 58.cint
+    else:
+      result = cint(ord(p))
 
 proc toSockType*(protocol: Protocol): SockType =
   result = case protocol

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -65,14 +65,14 @@ type
     SOCK_RAW = 3,      ## raw protocols atop the network layer.
     SOCK_SEQPACKET = 5 ## reliable sequenced packet service
 
-  Protocol* = enum     ## third argument to `socket` proc
-    IPPROTO_IP = 0,    ## Internet protocol.
-    IPPROTO_ICMP = 1   ## Control message protocol.
-    IPPROTO_TCP = 6,   ## Transmission control protocol.
-    IPPROTO_UDP = 17,  ## User datagram protocol.
-    IPPROTO_IPV6 = 41, ## Internet Protocol Version 6.
-    IPPROTO_ICMPV6     ## Control message protocol for IPv6. Unsupported on Windows.
-    IPPROTO_RAW,       ## Raw IP Packets Protocol. Unsupported on Windows.
+  Protocol* = enum      ## third argument to `socket` proc
+    IPPROTO_IP = 0,     ## Internet protocol.
+    IPPROTO_ICMP = 1    ## Control message protocol.
+    IPPROTO_TCP = 6,    ## Transmission control protocol.
+    IPPROTO_UDP = 17,   ## User datagram protocol.
+    IPPROTO_IPV6 = 41,  ## Internet Protocol Version 6.
+    IPPROTO_ICMPV6 = 58 ## Control message protocol for IPv6.
+    IPPROTO_RAW,        ## Raw IP Packets Protocol. Unsupported on Windows.
 
   Servent* = object ## information about a service
     name*: string

--- a/test.nim
+++ b/test.nim
@@ -1,0 +1,7 @@
+import nativesockets
+
+
+echo "icmpv6: ", getProtoByName("ipv6-icmp")
+echo "icmp: ", getProtoByName("icmp")
+echo "ipv6: ", getProtoByName("ipv6")
+echo "ip: ", getProtoByName("ip")

--- a/test.nim
+++ b/test.nim
@@ -1,7 +1,0 @@
-import nativesockets
-
-
-echo "icmpv6: ", getProtoByName("ipv6-icmp")
-echo "icmp: ", getProtoByName("icmp")
-echo "ipv6: ", getProtoByName("ipv6")
-echo "ip: ", getProtoByName("ip")

--- a/tests/stdlib/tnativesockets.nim
+++ b/tests/stdlib/tnativesockets.nim
@@ -1,0 +1,29 @@
+discard """
+  cmd:      "nim c -r --styleCheck:hint --panics:on $options $file"
+  targets:  "c"
+  nimout:   ""
+  action:   "run"
+  exitcode: 0
+  timeout:  60.0
+"""
+
+import nativesockets
+
+
+when defined(windows):
+  doAssert toInt(IPPROTO_IP) == 0.cint
+  doAssert toInt(IPPROTO_ICMP) == 1.cint
+  doAssert toInt(IPPROTO_TCP) == 6.cint
+  doAssert toInt(IPPROTO_UDP) == 17.cint
+  doAssert toInt(IPPROTO_IPV6) == 41.cint
+  doAssert toInt(IPPROTO_ICMPV6) == 58.cint
+  doAssert toInt(IPPROTO_RAW) == 20.cint
+
+  # no changes to enum value
+  doAssert ord(IPPROTO_TCP) == 6
+  doAssert ord(IPPROTO_UDP) == 17
+  doAssert ord(IPPROTO_IP) == 18
+  doAssert ord(IPPROTO_IPV6) == 19
+  doAssert ord(IPPROTO_RAW) == 20
+  doAssert ord(IPPROTO_ICMP) == 21
+  doAssert ord(IPPROTO_ICMPV6) == 22


### PR DESCRIPTION
I have to modify the order of enum because of error: invalid order in enum.

I use `getprotobyname` to get the number of proto, it seems that only IPPROTO_RAW doesn't get supports in my win 10.

