### PR TITLE
getPeerCertificates() for libressl and openssl10

### DIFF
--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -437,8 +437,6 @@ proc SSL_free*(ssl: SslPtr){.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_get_SSL_CTX*(ssl: SslPtr): SslCtx {.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_set_SSL_CTX*(ssl: SslPtr, ctx: SslCtx): SslCtx {.cdecl, dynlib: DLLSSLName, importc.}
 proc SSL_CTX_set_session_id_context*(context: SslCtx, sid_ctx: string, sid_ctx_len: int){.cdecl, dynlib: DLLSSLName, importc.}
-proc SSL_get0_verified_chain*(ssl: SslPtr): PSTACK {.cdecl, dynlib: DLLSSLName,
-    importc.}
 proc SSL_CTX_new*(meth: PSSL_METHOD): SslCtx{.cdecl,
     dynlib: DLLSSLName, importc.}
 proc SSL_CTX_load_verify_locations*(ctx: SslCtx, CAfile: cstring,
@@ -506,10 +504,15 @@ proc ERR_peek_last_error*(): culong{.cdecl, dynlib: DLLUtilName, importc.}
 
 proc OPENSSL_config*(configName: cstring){.cdecl, dynlib: DLLSSLName, importc.}
 
-proc OPENSSL_sk_num*(stack: PSTACK): int {.cdecl, dynlib: DLLSSLName, importc.}
-
-proc OPENSSL_sk_value*(stack: PSTACK, index: int): pointer {.cdecl,
-    dynlib: DLLSSLName, importc.}
+when defined(libressl) or defined(openssl10):
+  proc sk_num*(stack: PSTACK): int {.cdecl, dynlib: DLLSSLName, importc.}
+  proc sk_value*(stack: PSTACK, index: int): pointer {.cdecl, dynlib: DLLSSLName, importc.}
+  proc sk_insert*(stack: PSTACK, data: pointer, idx: int) {.cdecl, dynlib: DLLSSLName, importc.}
+  proc SSL_get_peer_cert_chain*(ssl: SslPtr): PSTACK {.cdecl, dynlib: DLLSSLName, importc.}
+else:
+  proc OPENSSL_sk_num*(stack: PSTACK): int {.cdecl, dynlib: DLLSSLName, importc.}
+  proc OPENSSL_sk_value*(stack: PSTACK, index: int): pointer {.cdecl, dynlib: DLLSSLName, importc.}
+  proc SSL_get0_verified_chain*(ssl: SslPtr): PSTACK {.cdecl, dynlib: DLLSSLName, importc.}
 
 proc d2i_X509*(px: ptr PX509, i: ptr ptr cuchar, len: cint): PX509 {.cdecl,
     dynlib: DLLSSLName, importc.}


### PR DESCRIPTION
The proc `getPeerCertificates` uses functions which are only defined in the latest OpenSSL(1.1.x). For the sake of compatibility, I made some changes that use the `-d:libressl` and `-d:openssl10` compile flags, in order to import the correct functions for these SSL libraries.
The output should, in most cases, be the same among the different versions. I have also tried to keep the code similar with the original one.

https://www.openssl.org/docs/man1.0.2/man3/SSL_get_peer_cert_chain.html
https://github.com/sergot/openssl/issues/62