### PR TITLE
nimStackTraceOverride: enable stack traces in exceptions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -148,7 +148,7 @@
 - Added `deques.toDeque`, which creates a deque from an openArray. The usage is
   similar to procs such as `sets.toHashSet` and `tables.toTable`. Previously,
   it was necessary to create an empty deque and add items manually.
-  
+
 - `std/with`, `sugar.dup` now support object field assignment expression:
   ```nim
   import std/with
@@ -168,7 +168,12 @@
   cannot be applied to every use case. The limitations and the (lack of) reliability
   of `round` are well documented.
 
+- New type: `cuintptr_t` - the same as `uintptr_t` in C.
 
+- `system/excpt`, `asyncfutures`: `-d:nimStackTraceOverride` now has exception
+  stack traces, with support for an efficient implementation that separates the
+  cheap stack unwinding step from the relatively expensive debugging info
+  collection that's done on demand.
 
 ## Language changes
 

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -311,7 +311,12 @@ proc getHint(entry: StackTraceEntry): string =
     if cmpIgnoreStyle(entry.filename, "asyncmacro.nim") == 0:
       return "Resumes an async procedure"
 
-proc `$`*(entries: seq[StackTraceEntry]): string =
+proc `$`*(stackTraceEntries: seq[StackTraceEntry]): string =
+  when defined(nimStackTraceOverride):
+    let entries = addDebuggingInfo(stackTraceEntries)
+  else:
+    let entries = stackTraceEntries
+
   result = ""
   # Find longest filename & line number combo for alignment purposes.
   var longestLeft = 0
@@ -326,10 +331,10 @@ proc `$`*(entries: seq[StackTraceEntry]): string =
   # Format the entries.
   for entry in entries:
     if entry.procname.isNil:
-      if entry.line == -10:
+      if entry.line == reraisedFromBegin:
         result.add(spaces(indent) & "#[\n")
         indent.inc(2)
-      else:
+      elif entry.line == reraisedFromEnd:
         indent.dec(2)
         result.add(spaces(indent) & "]#\n")
       continue

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1381,6 +1381,12 @@ type # these work for most platforms:
   culonglong* {.importc: "unsigned long long", nodecl.} = uint64
     ## This is the same as the type ``unsigned long long`` in *C*.
 
+  # There is a disparity on macOS where Nim's `uint` is `unsigned long long` and
+  # `uintptr_t` is `unsigned long`. Even though both data types are the same
+  # size (64 bits), clang++ refuses to do automatic conversion between them.
+  cuintptr_t* {.importc: "uintptr_t", nodecl.} = uint
+    ## This is the same as the type ``uintptr_t`` in *C*.
+
   cstringArray* {.importc: "char**", nodecl.} = ptr UncheckedArray[cstring]
     ## This is binary compatible to the type ``char**`` in *C*. The array's
     ## high value is large enough to disable bounds checking in practice.

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -25,6 +25,11 @@ type
                             ## rendered at a later time, we should ensure the stacktrace
                             ## data isn't invalidated; any pointer into PFrame is
                             ## subject to being invalidated so shouldn't be stored.
+    when defined(nimStackTraceOverride):
+      programCounter*: uint ## Program counter - will be used to get the rest of the info,
+                            ## when `$` is called on this type. We can't use
+                            ## "cuintptr_t" in here.
+      procnameStr*, filenameStr*: string ## GC-ed objects holding the cstrings in "procname" and "filename"
 
   Exception* {.compilerproc, magic: "Exception".} = object of RootObj ## \
     ## Base exception class.


### PR DESCRIPTION
This is a two-step stack trace collection scheme, because re-raised
exceptions will collect multiple stack traces but use them rarely, when
printing info about an uncaught exception, so it makes sense to only do
the cheap stack unwinding all the time and the relatively expensive
debugging information collection on-demand.

`asyncfutures` implements its own `$` proc for printing
`seq[StackTraceEntry]`, so we have to add the debugging info there, just
like we do for the private `$` proc in `system/excpt`.

New type: `cuintptr_t` - needed because of clang++ on macOS.

Fixes https://github.com/status-im/nim-libbacktrace/issues/5

Please backport this to Nim-1.2.x .