### PR TITLE
make 'for' a keyword operator

### DIFF
--- a/compiler/layouter.nim
+++ b/compiler/layouter.nim
@@ -327,7 +327,8 @@ const
 
   splitters = openPars + {tkComma, tkSemiColon} # do not add 'tkColon' here!
   oprSet = {tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs,
-            tkIsnot, tkNot, tkOf, tkAs, tkFrom, tkDotDot, tkAnd, tkOr, tkXor}
+            tkIsnot, tkNot, tkOf, tkAs, tkFrom, tkDotDot, tkAnd, tkOr, tkXor,
+            tkFor}
 
 template goodCol(col): bool = col >= em.maxLineLen div 2
 

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -950,6 +950,7 @@ proc getPrecedence*(tok: Token): int =
   of tkIn, tkNotin, tkIs, tkIsnot, tkOf, tkAs, tkFrom: result = 5
   of tkAnd: result = 4
   of tkOr, tkXor, tkPtr, tkRef: result = 3
+  of tkFor: result = 1
   else: return -10
 
 proc newlineFollows*(L: Lexer): bool =

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -269,7 +269,7 @@ proc isOperator(tok: Token): bool =
   ## Determines if the given token is an operator type token.
   tok.tokType in {tkOpr, tkDiv, tkMod, tkShl, tkShr, tkIn, tkNotin, tkIs,
                   tkIsnot, tkNot, tkOf, tkAs, tkFrom, tkDotDot, tkAnd,
-                  tkOr, tkXor}
+                  tkOr, tkXor, tkFor}
 
 proc isUnary(tok: Token): bool =
   ## Check if the given token is a unary operator

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -565,7 +565,7 @@ following characters::
 defined here.)
 
 These keywords are also operators:
-``and or not xor shl shr div mod in notin is isnot of as from``.
+``and or not xor shl shr div mod in notin is isnot of as from for``.
 
 `.`:tok: `=`:tok:, `:`:tok:, `::`:tok: are not available as general operators; they
 are used for other notational purposes.
@@ -650,7 +650,7 @@ Precedence level    Operators                                              First
   4               ``and``                                                                      OP4
   3               ``or xor``                                                                   OP3
   2                                                                        ``@  :  ?``         OP2
-  1               *assignment operator* (like ``+=``, ``*=``)                                  OP1
+  1               *assignment operator* (like ``+=``, ``*=``), ``for``                         OP1
   0 (lowest)      *arrow like operator* (like ``->``, ``=>``)                                  OP0
 ================  =======================================================  ==================  ===============
 

--- a/tests/parser/tstatementoperators.nim
+++ b/tests/parser/tstatementoperators.nim
@@ -4,9 +4,61 @@ Infix
   Ident "from"
   Ident "a"
   Ident "b"
+Infix
+  Ident "for"
+  Infix
+    Ident "for"
+    Ident "a"
+    Infix
+      Ident "in"
+      Ident "b"
+      Ident "c"
+  Infix
+    Ident "in"
+    Ident "d"
+    Ident "e"
+Infix
+  Ident "for"
+  Infix
+    Ident "for"
+    StmtListExpr
+      ForStmt
+        Ident "a"
+        Ident "b"
+        Ident "c"
+    Infix
+      Ident "in"
+      Ident "d"
+      Ident "e"
+  Infix
+    Ident "in"
+    Ident "f"
+    Ident "g"
 '''
 """
 
-from macros import dumpTree
+import macros
 
 dumpTree(a from b)
+dumpTree(a for b in c for d in e)
+dumpTree((for a in b: c) for d in e for f in g)
+
+proc `from`(a, b: int): int = b - a
+doAssert(3 from 4 == 1)
+
+macro `for`(ex: untyped, rang: untyped{nkInfix}): untyped =
+  let
+    itName = rang[1]
+    itExpr = rang[2]
+  result = quote do:
+    type TItem = typeof(when compiles(for _ in `itExpr`.items: discard): `itExpr`.items else: `itExpr`, typeOfIter)
+    type TResult = typeof(block:
+      var `itName`: TItem
+      `ex`)
+    var s: seq[TResult]
+    for it in `itExpr`:
+      let `itName` = it
+      s.add(`ex`)
+    s
+
+doAssert((a + 1 for a in [1, 2, 3, 4, 5]) == @[2, 3, 4, 5, 6])


### PR DESCRIPTION
Precedence is 1 like `=` and `+=`, could change if anyone has a better suggestion.

Uses are pretty obvious, it's for custom comprehension/zero overhead iterator macros. I don't think it should be defined directly as an operator macro in libraries (`comp: a for b in c` instead of directly `a for b in c`) but some people may choose to put them in their scripts or small programs as a familiar construct from other languages.

It's kind of like `=>`, except the implementation and behavior of infix `for` are pretty ambiguous compared to `=>` so defining it in sugar would be controversial. Maybe a fusion module.