### PR TITLE
Fix Nimpretty bug

### DIFF
--- a/nimpretty/nimpretty.nim
+++ b/nimpretty/nimpretty.nim
@@ -117,6 +117,7 @@ proc main =
       let infileBackup = infile & ".backup" # works with .nim or .nims
       echo "writing backup " & infile & " > " & infileBackup
       os.copyFile(source = infile, dest = infileBackup)
+    assert outfile.splitFile.ext in [".nim", ".nims"], "Output file must be .nim or .nims"
     prettyPrint(infile, outfile, opt)
 
 main()

--- a/nimpretty/tester.nim
+++ b/nimpretty/tester.nim
@@ -50,12 +50,12 @@ proc testTogether(infiles: seq[string]) =
 
 let allFiles = toSeq(walkFiles(dir / "*.nim"))
 for t in allFiles:
-  test(t, "pretty")
+  test(t, ".pretty.nim")
   # also test that pretty(pretty(x)) == pretty(x)
-  test(t.changeFileExt("pretty"), "pretty2")
+  test(t.changeFileExt(".pretty.nim"), ".pretty2.nim")
 
-  removeFile(t.changeFileExt("pretty"))
-  removeFile(t.changeFileExt("pretty2"))
+  removeFile(t.changeFileExt(".pretty.nim"))
+  removeFile(t.changeFileExt(".pretty2.nim"))
 
 testTogether(allFiles)
 removeDir(outputdir)


### PR DESCRIPTION
- Fix Nimpretty output file should be a Nim file.
- Nimpretty was taking anything as file extension as output I noticed when I made a typo.

```console
$ nimpretty --out:nimpretty.rs nimpretty.nim
Error: unhandled exception: nimpretty.nim(120, 12) `outfile.splitFile.ext in [".nim", ".nims"]` 
Output file must be .nim or .nims [AssertionDefect]

$
```

:) 
