### PR TITLE
Fix Nimgrep bug

### DIFF
--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -83,9 +83,9 @@ var
   excludeDir: seq[Regex]
   useWriteStyled = true
   oneline = true
-  linesBefore = 0
-  linesAfter = 0
-  linesContext = 0
+  linesBefore: Natural = 0
+  linesAfter: Natural = 0
+  linesContext: Natural = 0
   colorTheme = "simple"
   newLine = false
 


### PR DESCRIPTION
- Fix Nimgrep invalid input bug.
- Nimgrep parameter takes negative values that make no sense and produce buggy output in loop.
- 3 line diff.

```console
$ nimgrep --afterContext:-9 --beforeContext:-9 --context:-9 linesBefore nimgrep.nim
```

Prints the whole file several times in loop.

:) 
