### PR TITLE
Introduce explicit copy

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -408,7 +408,7 @@ proc passCopyToSink(n: PNode; c: var Con; s: var Scope): PNode =
     if isLValue(n) and not isCapturedVar(n) and n.typ.skipTypes(abstractInst).kind != tyRef and c.inSpawn == 0:
       message(c.graph.config, n.info, hintPerformance,
         ("passing '$1' to a sink parameter introduces an implicit copy; " &
-        "if possible, rearrange your program's control flow to prevent it") % $n)
+         "if possible, rearrange your program's control flow to prevent it or use 'copy($1)' to hint the compiler it is intentional") % $n)
   else:
     if c.graph.config.selectedGC in {gcArc, gcOrc}:
       assert(not containsGarbageCollectedRef(n.typ))

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -447,10 +447,6 @@ proc shallowCopy*[T](x: var T, y: T) {.noSideEffect, magic: "ShallowCopy".}
   ## There is a reason why the default assignment does a deep copy of sequences
   ## and strings.
 
-
-proc copy[T](x: T): T {.noSideEffect, magic: "ShallowCopy".}
-
-
 when defined(nimArrIdx):
   # :array|openArray|string|seq|cstring|tuple
   proc `[]`*[I: Ordinal;T](a: T; i: I): T {.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -264,7 +264,7 @@ proc move*[T](x: var T): T {.magic: "Move", noSideEffect.} =
   result = x
   wasMoved(x)
 
-func copy*[T](x: T): T =
+func copy*[T](x: T): T {.inline.} =
   ## make explicit copy of the argument `x`, used to signal to the compiler
   ## the copy is intentional
   result = x

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -264,6 +264,11 @@ proc move*[T](x: var T): T {.magic: "Move", noSideEffect.} =
   result = x
   wasMoved(x)
 
+func copy*[T](x: T): T =
+  ## make explicit copy of the argument `x`, used to signal to the compiler
+  ## the copy is intentional
+  result = x
+
 type
   range*[T]{.magic: "Range".}         ## Generic type to construct range types.
   array*[I, T]{.magic: "Array".}      ## Generic type to construct
@@ -441,6 +446,10 @@ proc shallowCopy*[T](x: var T, y: T) {.noSideEffect, magic: "ShallowCopy".}
   ## Be careful with the changed semantics though!
   ## There is a reason why the default assignment does a deep copy of sequences
   ## and strings.
+
+
+proc copy[T](x: T): T {.noSideEffect, magic: "ShallowCopy".}
+
 
 when defined(nimArrIdx):
   # :array|openArray|string|seq|cstring|tuple

--- a/tests/arc/tcopytosink_warning.nim
+++ b/tests/arc/tcopytosink_warning.nim
@@ -1,0 +1,16 @@
+discard """
+  cmd: "nim c --gc:arc $file"
+  nimout: "tcopytosink_warning.nim(13, 9) Hint: passing 'x' to a sink parameter introduces an implicit copy; if possible, rearrange your program's control flow to prevent it [Performance]"
+  output: "x"
+"""
+
+proc test(v: var seq[string], x: sink string) =
+  v.add x
+
+var v = @["a", "b", "c"]
+var x = "x"
+
+test(v, x)  # produces warning
+test(v, copy(x)) # no warning
+
+echo x  # use after sink

--- a/tests/arc/tcopytosink_warning.nim
+++ b/tests/arc/tcopytosink_warning.nim
@@ -1,8 +1,11 @@
 discard """
   cmd: "nim c --gc:arc $file"
-  nimout: "tcopytosink_warning.nim(13, 9) Hint: passing 'x' to a sink parameter introduces an implicit copy; if possible, rearrange your program's control flow to prevent it [Performance]"
+  nimout: '''tcopytosink_warning.nim(17, 7) Hint: myhint [User]
+tcopytosink_warning.nim(19, 9) Hint: passing 'x' to a sink parameter introduces an implicit copy; if possible, rearrange your program's control flow to prevent it or use 'copy(x)' to hint the compiler it is intentional [Performance]
+'''
   output: "x"
 """
+import macros
 
 proc test(v: var seq[string], x: sink string) =
   v.add x
@@ -10,7 +13,10 @@ proc test(v: var seq[string], x: sink string) =
 var v = @["a", "b", "c"]
 var x = "x"
 
-test(v, x)  # produces warning
+static:
+  hint("myhint")
 test(v, copy(x)) # no warning
+test(v, x)  # produces warning
 
 echo x  # use after sink
+


### PR DESCRIPTION
The way to manage the performance warning. Also makes performance predictable.