### PR TITLE
Fixed undeclared nimIdentNormalize compilation error in parseEnum

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1294,8 +1294,7 @@ macro genEnumStmt(typ: typedesc, argSym: typed, default: typed): untyped =
   let typ = typ.getTypeInst[1]
   let impl = typ.getImpl[2]
   expectKind impl, nnkEnumTy
-  result = nnkCaseStmt.newTree(nnkDotExpr.newTree(argSym,
-                                                  bindSym"nimIdentNormalize"))
+  result = nnkCaseStmt.newTree(newCall(bindSym"nimIdentNormalize", argSym))
   # stores all processed field strings to give error msg for ambiguous enums
   var foundFields: seq[string] = @[]
   var fStr = "" # string of current field


### PR DESCRIPTION
This fixes an issue in `parseEnum`, which unfortunately I was not able to reduce to a small sample. The code is pretty convoluted in multiple layers of macros, templates and generics. Here's the build log with the error: https://travis-ci.org/github/yglukhov/rod/builds/727725734

Gist:
```
~/rod/rod/component/camera.nim(86, 33) template/generic instantiation of `genSerializationCodeForComponent` from here
~/rod/rod/utils/serialization_codegen.nim(106, 30) template/generic instantiation of `genSerializerProc` from here
~/rod/rod/component/camera.nim(86, 34) template/generic instantiation of `visit` from here
~/rod/rod/utils/json_deserializer.nim(100, 29) template/generic instantiation of `parseEnum` from here
~/nim-devel/lib/pure/strutils.nim(1354, 14) template/generic instantiation of `genEnumStmt` from here
~/rod/rod/rod_types.nim(77, 25) Error: undeclared field: 'nimIdentNormalize' for type system.string [declared in ~/nim-devel/lib/system.nim(34, 3)] 
```
I figured in this case, `nnkCall` is better than `nnkDotExpr` anyway.

EDIT: The issue is a regression btw. Doesn't reproduce with 1.2.4.