### PR TITLE
added decodeQuery() to uri.nim

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -142,7 +142,7 @@ proc encodeQuery*(query: openArray[(string, string)], usePlus = true,
       result.add('=')
       result.add(encodeUrl(val, usePlus))
 
-proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] =
+proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] {.since: (1, 3).} =
   ## Decode a URL query string into a set of (key, value) parameters.
   ##
   ## **See also:**

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -160,8 +160,8 @@ proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] {.since: (1, 3).
   for c in urlQuery:
 
     if c == '&':
-      if name.len == 0 and buffer.len > 0: result.add (buffer, "")
-      elif name.len > 0: result.add (name, buffer)
+      if name.len > 0: result.add (name, buffer)
+      elif buffer.len > 0: result.add (buffer, "")
       name = ""
       buffer = ""
     elif c == '=':
@@ -181,8 +181,8 @@ proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] {.since: (1, 3).
     else:
       buffer.add(c)
 
-  if name.len == 0 and buffer.len > 0: result.add (buffer, "")
-  elif name.len > 0: result.add (name, buffer)
+  if name.len > 0: result.add (name, buffer)
+  elif buffer.len > 0: result.add (buffer, "")
 
 proc parseAuthority(authority: string, result: var Uri) =
   var i = 0

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -39,6 +39,7 @@
 
 import strutils, parseutils, base64
 include includes/decode_helpers
+import std/private/since
 
 type
   Url* = distinct string

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -157,53 +157,39 @@ proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] =
     buffer = ""
     encodedchar = ""
 
-  var pairs = newSeq[(string, string)]()
-
   proc getPair(name, buffer: string): (string, string) =
-    return if name.len == 0 and buffer.len > 0: (buffer, "")
-      elif name.len > 0: (name, buffer)
-      else: ("", "")
+    if name.len == 0 and buffer.len > 0: (buffer, "")
+    elif name.len > 0: (name, buffer)
+    else: ("", "")
 
   for c in urlQuery:
 
     if c == '&':
       let (key, value) = getPair(name, buffer)
       if key.len > 0:
-        pairs.add((key, value))
+        result.add((key, value))
       name = ""
       buffer = ""
-      continue
-
-    if c == '=':
+    elif c == '=':
       name = buffer
       buffer = ""
-      continue
-
-    if encodedchar.len > 1:
+    elif encodedchar.len > 1:
       encodedchar.add(c)
       if (encodedchar.len - 1) mod 3 == 0:
         let decodedchar = chr(fromHex[int](encodedchar))
         if decodedchar != '\x00':
           buffer.add(decodedchar)
           encodedchar = ""
-          continue
-      continue
-
-    if c == '%':
+    elif c == '%':
       encodedchar.add("0x")
-      continue
-
-    if c == '+':
+    elif c == '+':
       buffer.add(' ')
-      continue
-
-    buffer.add(c)
+    else:
+      buffer.add(c)
 
   let (key, value) = getPair(name, buffer)
   if key.len > 0:
-    pairs.add((key, value))
-
-  return pairs
+    result.add((key, value))
 
 proc parseAuthority(authority: string, result: var Uri) =
   var i = 0

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -157,17 +157,11 @@ proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] {.since: (1, 3).
     buffer = ""
     encodedchar = ""
 
-  proc getPair(name, buffer: string): (string, string) =
-    if name.len == 0 and buffer.len > 0: (buffer, "")
-    elif name.len > 0: (name, buffer)
-    else: ("", "")
-
   for c in urlQuery:
 
     if c == '&':
-      let (key, value) = getPair(name, buffer)
-      if key.len > 0:
-        result.add((key, value))
+      if name.len == 0 and buffer.len > 0: result.add (buffer, "")
+      elif name.len > 0: result.add (name, buffer)
       name = ""
       buffer = ""
     elif c == '=':
@@ -187,9 +181,8 @@ proc decodeQuery*(urlQuery: string = ""): seq[(string, string)] {.since: (1, 3).
     else:
       buffer.add(c)
 
-  let (key, value) = getPair(name, buffer)
-  if key.len > 0:
-    result.add((key, value))
+  if name.len == 0 and buffer.len > 0: result.add (buffer, "")
+  elif name.len > 0: result.add (name, buffer)
 
 proc parseAuthority(authority: string, result: var Uri) =
   var i = 0


### PR DESCRIPTION
Implements decodeQuery in uri module.
```
doAssert decodeQuery("") == {:}
doAssert decodeQuery("foo=bar") == {"foo": "bar"}
doAssert decodeQuery("foo=bar+%26+baz") == {"foo": "bar & baz"}
doAssert decodeQuery("foo") == {"foo": ""}
```