### PR TITLE
koch, compiler: bundle fusion as part of the source archive [backport:1.4]

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -76,6 +76,7 @@ Files: "lib"
 [Other]
 Files: "examples"
 Files: "dist/nimble"
+Files: "dist/fusion"
 
 Files: "tests"
 

--- a/koch.nim
+++ b/koch.nim
@@ -201,7 +201,8 @@ proc bundleWinTools(args: string) =
 
 proc bundleFusion(latest: bool) =
   let commit = if latest: "HEAD" else: FusionStableCommit
-  cloneDependency(distDir, "https://github.com/nim-lang/fusion.git", commit)
+  cloneDependency(distDir, "https://github.com/nim-lang/fusion.git", commit,
+                  allowBundled = true)
   copyDir(distDir / "fusion" / "src" / "fusion", "lib" / "fusion")
 
 proc zip(latest: bool; args: string) =

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -1,13 +1,25 @@
-import os, uri, strformat
+import os, uri, strformat, osproc
 
 proc exec(cmd: string) =
   echo "deps.cmd: " & cmd
   let status = execShellCmd(cmd)
   doAssert status == 0, cmd
 
+proc execEx(cmd: string): tuple[output: TaintedString, exitCode: int] =
+  echo "deps.cmd: " & cmd
+  execCmdEx(cmd, {poStdErrToStdOut, poUsePath, poEvalCommand})
+
+proc isGitRepo(dir: string): bool =
+  # This command is used to get the relative path to the root of the repository.
+  # Using this, we can verify whether a folder is a git repository by checking
+  # whether the command success and if the output is empty.
+  let (output, status) = execEx fmt"git -C {quoteShell(dir)} rev-parse --show-cdup"
+  result = status == 0 and output == ""
+
 const commitHead* = "HEAD"
 
-proc cloneDependency*(destDirBase: string, url: string, commit = commitHead, appendRepoName = true) =
+proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
+                      appendRepoName = true, allowBundled = false) =
   let destDirBase = destDirBase.absolutePath
   let p = url.parseUri.path
   let name = p.splitFile.name
@@ -18,5 +30,10 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead, app
     # note: old code used `destDir / .git` but that wouldn't prevent git clone
     # from failing
     exec fmt"git clone -q {url} {destDir2}"
-  exec fmt"git -C {destDir2} fetch -q"
-  exec fmt"git -C {destDir2} checkout -q {commit}"
+  if isGitRepo(destDir):
+    exec fmt"git -C {destDir2} fetch -q"
+    exec fmt"git -C {destDir2} checkout -q {commit}"
+  elif allowBundled:
+    discard "this dependency was bundled with Nim, don't do anything"
+  else:
+    quit "FAILURE: " & destdir & " already exists but is not a git repo"


### PR DESCRIPTION
This allows distributions to build Nim from the downloaded source
archive without an Internet connection.