### PR TITLE
system/stacktraces: remove redundant cuintptr_t

### DIFF
--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -18,9 +18,6 @@ const
 when defined(nimStackTraceOverride):
   ## Procedure types for overriding the default stack trace.
   type
-    cuintptr_t {.importc: "uintptr_t", nodecl.} = uint
-      ## This is the same as the type ``uintptr_t`` in C.
-
     StackTraceOverrideGetTracebackProc* = proc (): string {.
       nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
     StackTraceOverrideGetProgramCountersProc* = proc (maxLength: cint): seq[cuintptr_t] {.


### PR DESCRIPTION
That type is already declared in "system.nim". This results in two different structs being generated for "seq[cuintptr_t]" in those
different modules and clang++ 10.0.1 refuses to convert between pointers to functions that take or return those different structs.

```text
[amd] 17 Sun Sep 27 23:24:13 |/mnt/sda3/storage/CODE/status/nim-beacon-chain-clean/vendor/nim-libbacktrace|
stefan$ PATH="/src/77_DLD/CODE/00_github/Nim/bin:$PATH" nim cpp -f --outdir:build --skipParentCfg:on --skipUserCfg:on --cc:clang --verbosity:0 --hints:off --debugger:native -d:release -d:nimStackTraceOverride tests/test1.nim
/mnt/sde1/storage/nim-beacon-chain-clean/vendor/nim-libbacktrace/libbacktrace.nim:72:2: error: no matching function for call to 'registerStackTraceOverrideGetProgramCounters__9aRl3M6pubRkc9atWQ9cVjsLg'
        registerStackTraceOverrideGetProgramCounters__9aRl3M6pubRkc9atWQ9cVjsLg(getProgramCounters__Jaci89bc2C7sCKeQ6g9cs9bZQ);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/stefan/.cache/nim/test1_r/@m..@slibbacktrace.nim.cpp:93:31: note: candidate function not viable: no known conversion from 'tySequence__FOZZXTcrWwPxI5EI1NXS9cg *(int)' to 'tyProc__9aQB3qdIsRDJPwpK2vx9cqzw' (aka 'tySequence__nnM7FynWivkbiem9b8zu0bw *(*)(int)') for 1st argument
N_LIB_PRIVATE N_NIMCALL(void, registerStackTraceOverrideGetProgramCounters__9aRl3M6pubRkc9atWQ9cVjsLg)(tyProc__9aQB3qdIsRDJPwpK2vx9cqzw overrideProc);
                              ^
/mnt/sda3/storage/CODE/00_github/Nim/lib/nimbase.h:252:44: note: expanded from macro 'N_NIMCALL'
#  define N_NIMCALL(rettype, name) rettype name /* no modifier */
                                           ^
/mnt/sde1/storage/nim-beacon-chain-clean/vendor/nim-libbacktrace/libbacktrace.nim:114:2: error: no matching function for call to 'registerStackTraceOverrideGetDebuggingInfo__tUgAUij0WHXZiIKUTyVZNg'
        registerStackTraceOverrideGetDebuggingInfo__tUgAUij0WHXZiIKUTyVZNg(getDebuggingInfo__rQzWLGtpaYp07wl8K7UUag);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/stefan/.cache/nim/test1_r/@m..@slibbacktrace.nim.cpp:97:31: note: candidate function not viable: no known conversion from 'tySequence__uB9b75OUPRENsBAu4AnoePA *(tySequence__FOZZXTcrWwPxI5EI1NXS9cg *, int)' to 'tyProc__NRaNij7dlzIlwVvN4aud1g' (aka 'tySequence__uB9b75OUPRENsBAu4AnoePA *(*)(tySequence__nnM7FynWivkbiem9b8zu0bw *, int)') for 1st argument
N_LIB_PRIVATE N_NIMCALL(void, registerStackTraceOverrideGetDebuggingInfo__tUgAUij0WHXZiIKUTyVZNg)(tyProc__NRaNij7dlzIlwVvN4aud1g overrideProc);
                              ^
/mnt/sda3/storage/CODE/00_github/Nim/lib/nimbase.h:252:44: note: expanded from macro 'N_NIMCALL'
#  define N_NIMCALL(rettype, name) rettype name /* no modifier */
                                           ^
2 errors generated.
Error: execution of an external compiler program 'clang++ -c -std=gnu++14 -funsigned-char  -I/mnt/sde1/storage/nim-beacon-chain-clean/vendor/nim-libbacktrace -I/mnt/sde1/storage/nim-beacon-chain-clean/vendor/nim-libbacktrace/install/usr/include -g  -O3 -fno-ident   -I/mnt/sda3/storage/CODE/00_github/Nim/lib -I/mnt/sde1/storage/nim-beacon-chain-clean/vendor/nim-libbacktrace/tests -o /home/stefan/.cache/nim/test1_r/@m..@slibbacktrace.nim.cpp.o /home/stefan/.cache/nim/test1_r/@m..@slibbacktrace.nim.cpp' failed with exit code: 1
```
