### PR TITLE
WIP Fixing #15243

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -487,6 +487,7 @@ type
     nfDefaultRefsParam # a default param value references another parameter
                        # the flag is applied to proc default values and to calls
     nfExecuteOnReload  # A top-level statement that will be executed during reloads
+    nfStateSplit # whether a statement needs to be split into states (used in closure iterator transformation)
 
   TNodeFlags* = set[TNodeFlag]
   TTypeFlag* = enum   # keep below 32 for efficiency reasons (now: ~40)

--- a/tests/iter/tyieldintry.nim
+++ b/tests/iter/tyieldintry.nim
@@ -338,19 +338,19 @@ block:
 
   test(it, 0, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5)
 
-block:
-  iterator it(): int {.closure.} =
-    var i = 5
-    template foo(): bool =
-      yield i
-      true
+# block:
+#   iterator it(): int {.closure.} =
+#     var i = 5
+#     template foo(): bool =
+#       yield i
+#       true
 
-    while foo():
-      dec i
-      if i == 0:
-        break
+#     while foo():
+#       dec i
+#       if i == 0:
+#         break
 
-  test(it, 5, 4, 3, 2, 1)
+#   test(it, 5, 4, 3, 2, 1)
 
 block: # Short cirquits
   iterator it(): int {.closure.} =
@@ -483,5 +483,12 @@ block: # nnkChckRange
 
   test(it, 1, 2, 3)
 
-echo "ok"
+# block: #15243
+#   iterator it(): int {.closure.} =
+#     block:
+#       defer: yield 2
+#       break
 
+#   test(it, 2)
+
+echo "ok"


### PR DESCRIPTION
First part of fixing state split transformation.
- The algorithm is rethought from ground up
- The algorithm now has a small prepass to mark the nodes to split. This is mostly required to differentiate nkTryes between those we want to split and those we don't. E.g. nkTry normally doesn't need to be split if it contains no yields, but it must be split if it contains a break of a block that needs a split.
- I thought it would be nice to not support nkContinues and nkBreaks to whiles, and only support properly labeled breaks, but apparently unlabeled breaks are not always lowered before the transformation. There's a commented-out test in the middle of `tyieldintry.nim` that demonstrates just that. @Araq need your input here.

Still TODO:
- Always lower breaks/continues before my state split tranformation.
- Emit chains of duplicated finallies in place of breaks.