### PR TITLE
document breaking change that items no longer works with enum with holes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -286,6 +286,7 @@ proc mydiv(a, b): int {.raises: [].} =
 - Added a ``.noalias`` pragma. It is mapped to C's ``restrict`` keyword for the increased
   performance this keyword can enable.
 
+- `items` no longer compiles with enum with holes as its behavior was error prone, see #14004
 
 ## Compiler changes
 


### PR DESCRIPTION
/cc @Araq https://github.com/nim-lang/Nim/pull/14004 was probably a good change but it does break some packages and there is no deprecation period or compatibility flag
(eg see https://github.com/ba0f3/dnsclient.nim/pull/4 for a modification to code to work around this breaking change)

this no longer compiles
```nim
type Foo = enum
  k1 = 10
  k2 = 12
for k in Foo: discard
```
