### PR TITLE
Dont assert on setstacksize result in iOS

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -319,7 +319,10 @@ else:
     when hasSharedHeap: t.core.stackSize = ThreadStackSize
     var a {.noinit.}: Pthread_attr
     doAssert pthread_attr_init(a) == 0
-    doAssert pthread_attr_setstacksize(a, ThreadStackSize) == 0
+    let setstacksizeResult = pthread_attr_setstacksize(a, ThreadStackSize)
+    when not defined(ios):
+      # This fails on iOS
+      doAssert(setstacksizeResult == 0)
     if pthread_create(t.sys, a, threadProcWrapper[TArg], addr(t)) != 0:
       raise newException(ResourceExhaustedError, "cannot create thread")
     doAssert pthread_attr_destroy(a) == 0


### PR DESCRIPTION
Dunno why, but `pthread_attr_setstacksize` returns EINVAL on iOS, with seemingly correct `ThreadStackSize` (2093056)