### PR TITLE
Add first draft of new osproc.readLines

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -199,6 +199,8 @@
 
 - Add `initUri(isIpv6: bool)` to `uri` module, now `uri` supports parsing ipv6 hostname.
 
+- Add `readLines(p: Process)` to `osproc` module for `startProcess` convenience.
+
 ## Language changes
 
 - The `=destroy` hook no longer has to reset its target, as the compiler now automatically inserts

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -444,7 +444,7 @@ proc execProcesses*(cmds: openArray[string],
       if afterRunEvent != nil: afterRunEvent(i, p)
       close(p)
 
-iterator lines*(p: Process): string =
+iterator lines*(p: Process): string {.since: (1, 3), tags: [ReadIOEffect].} =
   ## Convenience iterator for working with `startProcess` to read data from a
   ## background process.
   ##
@@ -473,7 +473,7 @@ iterator lines*(p: Process): string =
     else:
       if p.peekExitCode != -1: break
 
-proc readLines*(p: Process): (seq[string], int) =
+proc readLines*(p: Process): (seq[string], int) {.since: (1, 3).} =
   ## Convenience function for working with `startProcess` to read data from a
   ## background process.
   ##

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -444,30 +444,56 @@ proc execProcesses*(cmds: openArray[string],
       if afterRunEvent != nil: afterRunEvent(i, p)
       close(p)
 
-proc readLines*(p: Process): (seq[string], int) =
-  ## Convenience function for working with `startProcess` to read data from a
+iterator lines*(p: Process): string =
+  ## Convenience iterator for working with `startProcess` to read data from a
   ## background process.
+  ##
+  ## See also:
+  ## * `readLines proc <#readLines,Process>`_
   ##
   ## Example:
   ##
   ## .. code-block:: Nim
-  ##  const opts = {poUsePath, poDaemon, poStdErrToStdOut}
-  ##  var ps: seq[Process]
-  ##  for prog in ["a", "b"]: # run 2 progs in parallel
-  ##    ps.add startProcess("nim", "", ["r", prog], nil, opts)
-  ##  for p in ps:
-  ##    let (lines, exCode) = p.readLines
-  ##    if exCode != 0:
-  ##      for line in lines: echo line
-  ##    p.close
+  ##   const opts = {poUsePath, poDaemon, poStdErrToStdOut}
+  ##   var ps: seq[Process]
+  ##   for prog in ["a", "b"]: # run 2 progs in parallel
+  ##     ps.add startProcess("nim", "", ["r", prog], nil, opts)
+  ##   for p in ps:
+  ##     var i = 0
+  ##     for line in p.lines:
+  ##       echo line
+  ##       i.inc
+  ##       if i > 100: break
+  ##     p.close
   var outp = p.outputStream
   var line = newStringOfCap(120)
   while true:
     if outp.readLine(line):
-      result[0].add(line)
+      yield line
     else:
-      result[1] = p.peekExitCode
-      if result[1] != -1: break
+      if p.peekExitCode != -1: break
+
+proc readLines*(p: Process): (seq[string], int) =
+  ## Convenience function for working with `startProcess` to read data from a
+  ## background process.
+  ##
+  ## See also:
+  ## * `lines iterator <#lines.i,Process>`_
+  ##
+  ## Example:
+  ##
+  ## .. code-block:: Nim
+  ##   const opts = {poUsePath, poDaemon, poStdErrToStdOut}
+  ##   var ps: seq[Process]
+  ##   for prog in ["a", "b"]: # run 2 progs in parallel
+  ##     ps.add startProcess("nim", "", ["r", prog], nil, opts)
+  ##   for p in ps:
+  ##     let (lines, exCode) = p.readLines
+  ##     if exCode != 0:
+  ##       for line in lines: echo line
+  ##     p.close
+  for line in p.lines: result[0].add(line)
+  result[1] = p.peekExitCode
 
 when not defined(useNimRtl):
   proc execProcess(command: string, workingDir: string = "",

--- a/tests/osproc/readlines.nim
+++ b/tests/osproc/readlines.nim
@@ -1,0 +1,19 @@
+discard """
+  output: '''Error: cannot open 'a.nim'
+Error: cannot open 'b.nim''''
+  targets: "c"
+"""
+
+import osproc
+
+const opts = {poUsePath, poDaemon, poStdErrToStdOut}
+
+var ps: seq[Process] # compile & run 2 progs in parallel
+for prog in ["a", "b"]:
+  ps.add startProcess("nim", "", ["r", prog], nil, opts)
+
+for p in ps:
+  let (lines, exCode) = p.readLines
+  if exCode != 0:
+    for line in lines: echo line
+  p.close

--- a/tests/osproc/treadlines.nim
+++ b/tests/osproc/treadlines.nim
@@ -7,11 +7,11 @@ Error: cannot open 'b.nim'
 
 import osproc
 
-const opts = {poUsePath, poDaemon, poStdErrToStdOut}
-
 var ps: seq[Process] # compile & run 2 progs in parallel
 for prog in ["a", "b"]:
-  ps.add startProcess("nim", "", ["r", "--hint[Conf]=off", prog], nil, opts)
+  ps.add startProcess("nim", "",
+                      ["r", "--hint[Conf]=off", "hint[Processing]=off", prog],
+                      options = {poUsePath, poDaemon, poStdErrToStdOut})
 
 for p in ps:
   let (lines, exCode) = p.readLines

--- a/tests/osproc/treadlines.nim
+++ b/tests/osproc/treadlines.nim
@@ -11,7 +11,7 @@ const opts = {poUsePath, poDaemon, poStdErrToStdOut}
 
 var ps: seq[Process] # compile & run 2 progs in parallel
 for prog in ["a", "b"]:
-  ps.add startProcess("nim", "", ["r", prog], nil, opts)
+  ps.add startProcess("nim", "", ["r", "--hint[Conf]=off", prog], nil, opts)
 
 for p in ps:
   let (lines, exCode) = p.readLines

--- a/tests/osproc/treadlines.nim
+++ b/tests/osproc/treadlines.nim
@@ -1,6 +1,7 @@
 discard """
   output: '''Error: cannot open 'a.nim'
-Error: cannot open 'b.nim''''
+Error: cannot open 'b.nim'
+'''
   targets: "c"
 """
 

--- a/tests/osproc/treadlines.nim
+++ b/tests/osproc/treadlines.nim
@@ -10,7 +10,7 @@ import osproc
 var ps: seq[Process] # compile & run 2 progs in parallel
 for prog in ["a", "b"]:
   ps.add startProcess("nim", "",
-                      ["r", "--hint[Conf]=off", "hint[Processing]=off", prog],
+                      ["r", "--hint[Conf]=off", "--hint[Processing]=off", prog],
                       options = {poUsePath, poDaemon, poStdErrToStdOut})
 
 for p in ps:


### PR DESCRIPTION
The example in the doc comment also serves as motivation (and could be converted into a test with just an `import osproc` and a `discard` of output up top).  { My actual use-case is different, but less self-contained.  With so many idle cores these days there are many circumstances where launching programs in parallel makes sense. }

The `seq[string]` return makes this new `readLines(Process)` call side-step CRLF vs LF conversion questions since `lines`-like calls in Nim all remove the ending.  So there should be no caller expectation of non-conversion (unlike immediately subsequent `execProcess`).  An `echo` loop can put back the OS-local line-endings as desired.