### PR TITLE
osproc.hasData: add optional timeoutMicroseconds parameter

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1484,14 +1484,20 @@ elif not defined(useNimRtl):
 
     pruneProcessSet(readfds, (rd))
 
-  proc hasData*(p: Process): bool =
+  proc hasData*(p: Process, timeoutMicroseconds = -1): bool =
     var rd: TFdSet
-
     FD_ZERO(rd)
     let m = max(0, int(p.outHandle))
     FD_SET(cint(p.outHandle), rd)
 
-    result = int(select(cint(m+1), addr(rd), nil, nil, nil)) == 1
+    if timeoutMicroseconds != -1:
+      var tv = Timeval(
+        tv_sec: posix.Time(0),
+        tv_usec: Suseconds(timeoutMicroseconds)
+      )
+      return int(select(cint(m+1), addr(rd), nil, nil, addr(tv))) == 1
+    else:
+      return int(select(cint(m+1), addr(rd), nil, nil, nil)) == 1
 
 
 proc execCmdEx*(command: string, options: set[ProcessOption] = {


### PR DESCRIPTION
The current implementation of `hasData` in the `osproc` module has a problem: it doesn't pass a timeout to the call to `select(2)`. This means that it will block indefinitely when calling `hasData` on a process with an empty stdout. Here's a reproduction of the issue: https://play.nim-lang.org/#ix=2z5f

I updated `osproc.hasData` to receive a `timeoutMicroseconds` parameter and create a `struct timeval` with `tv_usec` set to that.

I think not having a timeout is the wrong default - I chose that to keep `hasData` backwards compatible - but I'm not sure on what is the right default either.

I did some tests locally with the `cat` example, and it seems that setting the timeout too low (< 5000 microseconds) doesn't allow enough time for `cat` to write its `stdin` input to `stdout`. 