### PR TITLE
Clean out niminst

### DIFF
--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -7,12 +7,6 @@
 #    distribution, for details about the copyright.
 #
 
-const
-  haveZipLib = false # zip not in stdlib anymore
-
-when haveZipLib:
-  import zipfiles
-
 import
   os, strutils, parseopt, parsecfg, strtabs, streams, debcreation,
   std / sha1
@@ -36,7 +30,6 @@ type
     actionInno,   # action: create Inno Setup installer
     actionNsis,   # action: create NSIS installer
     actionScripts # action: create install and deinstall scripts
-    actionZip,    # action: create zip file
     actionXz,     # action: create xz file
     actionDeb     # action: prepare deb package
 
@@ -75,7 +68,7 @@ const
     "$configdir", "$datadir", "$docdir", "$libdir"
   ]
 
-proc iniConfigData(c: var ConfigData) =
+func iniConfigData(c: var ConfigData) =
   c.actions = {}
   for i in low(FileCategory)..high(FileCategory): c.cat[i] = @[]
   c.binPaths = @[]
@@ -107,17 +100,17 @@ proc iniConfigData(c: var ConfigData) =
   c.debOpts.shortDesc = ""
   c.debOpts.licenses = @[]
 
-proc firstBinPath(c: ConfigData): string =
+func firstBinPath(c: ConfigData): string =
   if c.binPaths.len > 0: result = c.binPaths[0]
   else: result = ""
 
-proc `\`(a, b: string): string =
+func `\`(a, b: string): string =
   result = if a.len == 0: b else: a & '\\' & b
 
 template toUnix(s: string): string = s.replace('\\', '/')
 template toWin(s: string): string = s.replace('/', '\\')
 
-proc skipRoot(f: string): string =
+func skipRoot(f: string): string =
   # "abc/def/xyz" --> "def/xyz"
   var i = 0
   result = ""
@@ -146,7 +139,6 @@ Usage:
 Command:
   csource             build C source code for source based installations
   scripts             build install and deinstall scripts
-  zip                 build the ZIP file
   inno                build the Inno Setup installer
   nsis                build the NSIS Setup installer
   deb                 create files for debhelper
@@ -175,7 +167,6 @@ proc parseCmdLine(c: var ConfigData) =
           case a
           of "csource": incl(c.actions, actionCSource)
           of "scripts": incl(c.actions, actionScripts)
-          of "zip": incl(c.actions, actionZip)
           of "xz": incl(c.actions, actionXz)
           of "inno": incl(c.actions, actionInno)
           of "nsis": incl(c.actions, actionNsis)
@@ -221,11 +212,11 @@ proc eqT(a, b: string; t: proc (a: char): char{.nimcall.}): bool =
       inc j
   result = i >= a.len and j >= b.len
 
-proc tPath(c: char): char =
+func tPath(c: char): char =
   if c == '\\': '/'
   else: c
 
-proc ignoreFile(f, explicit: string, allowHtml: bool): bool =
+func ignoreFile(f, explicit: string, allowHtml: bool): bool =
   let (_, name, ext) = splitFile(f)
   let html = if not allowHtml: ".html" else: ""
   result = (ext in ["", ".exe", ".idx", ".o", ".obj", ".dylib"] or
@@ -283,13 +274,13 @@ proc yesno(p: var CfgParser, v: string): bool =
     result = false
   else: quit(errorStr(p, "unknown value; use: yes|no"))
 
-proc incl(s: var seq[string], x: string): int =
+func incl(s: var seq[string], x: string): int =
   for i in 0 ..< s.len:
     if cmpIgnoreStyle(s[i], x) == 0: return i
   s.add(x)
   result = s.len-1
 
-proc platforms(c: var ConfigData, v: string) =
+func platforms(c: var ConfigData, v: string) =
   for line in splitLines(v):
     let p = line.find(": ")
     if p <= 1: continue
@@ -462,10 +453,10 @@ proc readCFiles(c: var ConfigData, osA, cpuA: int) =
   else:
     quit("Cannot open: " & f)
 
-proc buildDir(os, cpu: int): string =
-  return "c_code" / ($os & "_" & $cpu)
+func buildDir(os, cpu: int): string =
+  "c_code" / ($os & "_" & $cpu)
 
-proc getOutputDir(c: var ConfigData): string =
+func getOutputDir(c: var ConfigData): string =
   if c.outdir.len > 0: c.outdir else: "build"
 
 proc writeFile(filename, content, newline: string) =
@@ -596,42 +587,6 @@ proc setupDist2(c: var ConfigData) =
     else:
       quit("External program failed")
 
-# ------------------ generate ZIP file ---------------------------------------
-when haveZipLib:
-  proc zipDist(c: var ConfigData) =
-    var proj = toLowerAscii(c.name) & "-" & c.version
-    var n = "$#.zip" % proj
-    if c.outdir.len == 0: n = "build" / n
-    else: n = c.outdir / n
-    var z: ZipArchive
-    if open(z, n, fmWrite):
-      addFile(z, proj / buildBatFile, "build" / buildBatFile)
-      addFile(z, proj / buildBatFile32, "build" / buildBatFile32)
-      addFile(z, proj / buildBatFile64, "build" / buildBatFile64)
-      addFile(z, proj / buildShFile, "build" / buildShFile)
-      addFile(z, proj / makeFile, "build" / makeFile)
-      addFile(z, proj / installShFile, installShFile)
-      addFile(z, proj / deinstallShFile, deinstallShFile)
-
-      template addFileAux(src, dst) = addFile(z, dst, src)
-      gatherFiles(addFileAux, c.libpath, proj / "c_code")
-      for osA in 1..c.oses.len:
-        for cpuA in 1..c.cpus.len:
-          var dir = buildDir(osA, cpuA)
-          for k, f in walkDir("build" / dir):
-            if k == pcFile: addFile(z, proj / dir / extractFilename(f), f)
-
-      for cat in items({fcConfig..fcOther, fcUnix, fcNimble}):
-        for f in items(c.cat[cat]): addFile(z, proj / f, f)
-
-      # Copy the .nimble file over
-      let nimbleFile = c.nimblePkgName & ".nimble"
-      processFile(z, proj / nimbleFile, nimbleFile)
-
-      close(z)
-    else:
-      quit("Cannot open for writing: " & n)
-
 proc xzDist(c: var ConfigData; windowsZip=false) =
   let proj = toLowerAscii(c.name) & "-" & c.version
   let tmpDir = if c.outdir.len == 0: "build" else: c.outdir
@@ -753,21 +708,23 @@ proc debDist(c: var ConfigData) =
 
 # ------------------- main ----------------------------------------------------
 
-var c: ConfigData
-iniConfigData(c)
-parseCmdLine(c)
-parseIniFile(c)
-if actionInno in c.actions:
-  setupDist(c)
-if actionNsis in c.actions:
-  setupDist2(c)
-if actionCSource in c.actions:
-  srcdist(c)
-if actionScripts in c.actions:
-  writeInstallScripts(c)
-if actionZip in c.actions:
-  xzDist(c, true)
-if actionXz in c.actions:
-  xzDist(c)
-if actionDeb in c.actions:
-  debDist(c)
+proc main() =
+  var c: ConfigData
+  iniConfigData(c)
+  parseCmdLine(c)
+  parseIniFile(c)
+  if actionInno in c.actions:
+    setupDist(c)
+  if actionNsis in c.actions:
+    setupDist2(c)
+  if actionCSource in c.actions:
+    srcdist(c)
+  if actionScripts in c.actions:
+    writeInstallScripts(c)
+  if actionXz in c.actions:
+    xzDist(c)
+  if actionDeb in c.actions:
+    debDist(c)
+
+when isMainModule:
+  main()


### PR DESCRIPTION
- Remove old deprecated unused code from Niminst.
- Has unused code `when false:` style, since the days Nim had ZIP on stdlib.
