### PR TITLE
Fix #15452 - ip protocol not defined on NetBSD

### DIFF
--- a/tests/stdlib/tgetprotobyname.nim
+++ b/tests/stdlib/tgetprotobyname.nim
@@ -10,7 +10,10 @@ discard """
 import nativesockets
 
 
-doAssert getProtoByName("ip") == 0
+when not defined(netbsd):
+  # Ref: https://github.com/nim-lang/Nim/issues/15452 - NetBSD doesn't define an `ip` protocol
+  doAssert getProtoByName("ip") == 0
+
 doAssert getProtoByName("ipv6") == 41
 doAssert getProtoByName("tcp") == 6
 doAssert getProtoByName("udp") == 17


### PR DESCRIPTION
Fixes #15452 - the `ip` protocol is not defined in NetBSD.