### PR TITLE
doc(sugar): added description and examples to dup

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -217,7 +217,10 @@ since (1, 1):
 
   macro dup*[T](arg: T, calls: varargs[untyped]): T =
     ## Turns an `in-place`:idx: algorithm into one that works on
-    ## a copy and returns this copy.
+    ## a copy and returns this copy, without modifying its input.
+    ##
+    ## This macro also allows for (otherwise in-place) function chaining.
+    ##
     ## **Since**: Version 1.2.
     runnableExamples:
       import algorithm
@@ -233,6 +236,21 @@ since (1, 1):
       var s1 = "abc"
       var s2 = "xyz"
       doAssert s1 & s2 == s1.dup(&= s2)
+
+      proc makePalindrome(s: var string) =
+        for i in countdown(s.len-2, 0):
+          s.add(s[i])
+
+      var c = "xyz"
+
+      # An underscore (_) can be used to denote the place of the argument you're passing:
+      # b = "xyz"
+      var d = dup c:
+        makePalindrome # xyzyx
+        sort(_, SortOrder.Descending) # zyyxx
+        makePalindrome # zyyxxxyyz
+
+      doAssert d == "zyyxxxyyz"
 
     result = newNimNode(nnkStmtListExpr, arg)
     let tmp = genSym(nskVar, "dupResult")


### PR DESCRIPTION
## Solving issue #14405

Added more description and examples to sugar/dup documentation.

### Description
#### Before:
![image](https://user-images.githubusercontent.com/33612042/94884841-f767e300-0444-11eb-8600-e2ef3ac564a3.png)

#### After:
![image](https://user-images.githubusercontent.com/33612042/95030392-d2ae7e00-0685-11eb-9b8b-6c5a545c4514.png)

### Examples
#### Before:
![image](https://user-images.githubusercontent.com/33612042/94884941-43b32300-0445-11eb-987c-bc6a843a49e0.png)

#### After
![image](https://user-images.githubusercontent.com/33612042/95030413-f1147980-0685-11eb-9d4c-c507fef07d61.png)


