### PR TITLE
Add compile-time unrolled for loops

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -294,6 +294,7 @@ proc mydiv(a, b): int {.raises: [].} =
 
 
 - Added `critbits.toCritBitTree`, similar to `tables.toTable`, creates a new `CritBitTree` with given arguments.
+- Added `system.staticFor` compile-time unrolled for loop iterator.
 
 
 ## Compiler changes

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -648,7 +648,7 @@ proc genParForStmt(p: BProc, t: PNode) =
 
     # $n at the beginning because of #9710
     if call.len == 4: # `||`(a, b, annotation)
-      lineF(p, cpsStmts, "$n#pragma omp $4$n" &
+      lineF(p, cpsStmts, "$n#pragma $4$n" &
                           "for ($1 = $2; $1 <= $3; ++$1)",
                           [forLoopVar.loc.rdLoc,
                           rangeA.rdLoc, rangeB.rdLoc,
@@ -656,7 +656,7 @@ proc genParForStmt(p: BProc, t: PNode) =
     else: # `||`(a, b, step, annotation)
       var step: TLoc
       initLocExpr(p, call[3], step)
-      lineF(p, cpsStmts, "$n#pragma omp $5$n" &
+      lineF(p, cpsStmts, "$n#pragma $5$n" &
                     "for ($1 = $2; $1 <= $3; $1 += $4)",
                     [forLoopVar.loc.rdLoc,
                     rangeA.rdLoc, rangeB.rdLoc, step.rdLoc,

--- a/lib/system/iterators_1.nim
+++ b/lib/system/iterators_1.nim
@@ -1,3 +1,5 @@
+import std/private/since
+
 when sizeof(int) <= 2:
   type IntLikeForCount = int|int8|int16|char|bool|uint8|enum
 else:
@@ -178,7 +180,7 @@ else: # not defined(nimNewRoof)
       inc i
 
 
-iterator `||`*[S, T](a: S, b: T, annotation: static string = "parallel for"): T {.
+iterator `||`*[S, T](a: S, b: T, annotation: static string = "omp parallel for"): T {.
   inline, magic: "OmpParFor", sideEffect.} =
   ## OpenMP parallel loop iterator. Same as `..` but the loop may run in parallel.
   ##
@@ -195,7 +197,7 @@ iterator `||`*[S, T](a: S, b: T, annotation: static string = "parallel for"): T 
   ## and GC.
   discard
 
-iterator `||`*[S, T](a: S, b: T, step: Positive, annotation: static string = "parallel for"): T {.
+iterator `||`*[S, T](a: S, b: T, step: Positive, annotation: static string = "omp parallel for"): T {.
   inline, magic: "OmpParFor", sideEffect.} =
   ## OpenMP parallel loop iterator with stepping.
   ## Same as `countup` but the loop may run in parallel.
@@ -212,3 +214,35 @@ iterator `||`*[S, T](a: S, b: T, step: Positive, annotation: static string = "pa
   ## versions of ``||`` will get proper support by Nim's code generator
   ## and GC.
   discard
+
+
+since (1, 3):
+  template staticFor*(a, b: SomeInteger; unroll: static Positive): untyped =
+    ## Compile-time unrolled for loop iterator.
+    ##
+    ## * If `unroll = 1`, unrolling is disabled (ignored).
+    ## * If `unroll` is > `1`, unrolling is enabled.
+    ## * If `unroll` is bigger than the total loop iterations,
+    ##   no error is produced and the loop is completely unrolled.
+    ##
+    ## Example:
+    ##
+    ## .. code-block:: Nim
+    ##   for i in staticFor(0, 99, 99): discard
+    ##
+    ## Compiles to approximately:
+    ##
+    ## .. code-block:: c
+    ##   #pragma unroll 99
+    ##   for (i = 0; i <= 99; ++i) {  };
+    ##
+    ## Nim emits `#pragma unroll` delegating the for loop unrolling to C, see also:
+    ## * https://en.wikipedia.org/wiki/Loop_unrolling
+    ## * http://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#index-pragma-GCC-unroll-n
+    ## * http://clang.llvm.org/docs/AttributeReference.html#pragma-unroll-pragma-nounroll
+    ## * Only GCC and Clang are supported, otherwise a normal `..` iterator is used.
+    runnableExamples:
+      for i in staticFor(-9, 9, 5): echo i ## Check the generated C or Assembly.
+    when defined(gcc) and not defined(js):   system.`||`(a, b, "GCC unroll " & $unroll)
+    elif defined(clang) and not defined(js): system.`||`(a, b, "unroll " & $unroll)
+    else:                                    system.`..`(a, b) # MSVC wont have pragma.

--- a/lib/system/iterators_1.nim
+++ b/lib/system/iterators_1.nim
@@ -1,5 +1,3 @@
-import std/private/since
-
 when sizeof(int) <= 2:
   type IntLikeForCount = int|int8|int16|char|bool|uint8|enum
 else:

--- a/lib/system/iterators_1.nim
+++ b/lib/system/iterators_1.nim
@@ -216,33 +216,32 @@ iterator `||`*[S, T](a: S, b: T, step: Positive, annotation: static string = "om
   discard
 
 
-since (1, 3):
-  template staticFor*(a, b: SomeInteger; unroll: static Positive): untyped =
-    ## Compile-time unrolled for loop iterator.
-    ##
-    ## * If `unroll = 1`, unrolling is disabled (ignored).
-    ## * If `unroll` is > `1`, unrolling is enabled.
-    ## * If `unroll` is bigger than the total loop iterations,
-    ##   no error is produced and the loop is completely unrolled.
-    ##
-    ## Example:
-    ##
-    ## .. code-block:: Nim
-    ##   for i in staticFor(0, 99, 99): discard
-    ##
-    ## Compiles to approximately:
-    ##
-    ## .. code-block:: c
-    ##   #pragma unroll 99
-    ##   for (i = 0; i <= 99; ++i) {  };
-    ##
-    ## Nim emits `#pragma unroll` delegating the for loop unrolling to C, see also:
-    ## * https://en.wikipedia.org/wiki/Loop_unrolling
-    ## * http://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#index-pragma-GCC-unroll-n
-    ## * http://clang.llvm.org/docs/AttributeReference.html#pragma-unroll-pragma-nounroll
-    ## * Only GCC and Clang are supported, otherwise a normal `..` iterator is used.
-    runnableExamples:
-      for i in staticFor(-9, 9, 5): echo i ## Check the generated C or Assembly.
-    when defined(gcc) and not defined(js):   system.`||`(a, b, "GCC unroll " & $unroll)
-    elif defined(clang) and not defined(js): system.`||`(a, b, "unroll " & $unroll)
-    else:                                    system.`..`(a, b) # MSVC wont have pragma.
+template staticFor*(a, b: SomeInteger; unroll: static Positive): untyped =
+  ## Compile-time unrolled for loop iterator.
+  ##
+  ## * If `unroll = 1`, unrolling is disabled (ignored).
+  ## * If `unroll` is > `1`, unrolling is enabled.
+  ## * If `unroll` is bigger than the total loop iterations,
+  ##   no error is produced and the loop is completely unrolled.
+  ##
+  ## Example:
+  ##
+  ## .. code-block:: Nim
+  ##   for i in staticFor(0, 99, 99): discard
+  ##
+  ## Compiles to approximately:
+  ##
+  ## .. code-block:: c
+  ##   #pragma unroll 99
+  ##   for (i = 0; i <= 99; ++i) {  };
+  ##
+  ## Nim emits `#pragma unroll` delegating the for loop unrolling to C, see also:
+  ## * https://en.wikipedia.org/wiki/Loop_unrolling
+  ## * http://gcc.gnu.org/onlinedocs/gcc/Loop-Specific-Pragmas.html#index-pragma-GCC-unroll-n
+  ## * http://clang.llvm.org/docs/AttributeReference.html#pragma-unroll-pragma-nounroll
+  ## * Only GCC and Clang are supported, otherwise a normal `..` iterator is used.
+  runnableExamples:
+    for i in staticFor(-9, 9, 5): echo i ## Check the generated C or Assembly.
+  when defined(gcc) and not defined(js):   system.`||`(a, b, "GCC unroll " & $unroll)
+  elif defined(clang) and not defined(js): system.`||`(a, b, "unroll " & $unroll)
+  else:                                    system.`..`(a, b) # MSVC wont have pragma.


### PR DESCRIPTION
- Add compile-time unrolled for loops.
- Documentation, examples, links, runnableExamples, changelog, etc.
- Tiny diff.
