### PR TITLE
Ref #14094 - disable hot code reloading tests on NetBSD

### DIFF
--- a/tests/dll/nimhcr_integration.nim
+++ b/tests/dll/nimhcr_integration.nim
@@ -1,5 +1,6 @@
 discard """
   disabled: "openbsd"
+  disabled: "netbsd"
   disabled: "macosx"
   output: '''
 main: HELLO!

--- a/tests/dll/nimhcr_unit.nim
+++ b/tests/dll/nimhcr_unit.nim
@@ -1,5 +1,6 @@
 discard """
 disabled: "openbsd"
+disabled: "netbsd"
 output: '''
 fastcall_proc implementation #1 10
 11


### PR DESCRIPTION
Fixes #14094 

The hot code reloading tests are already disabled on OpenBSD due to a similar issue, this just adds NetBSD to the list. Eventually, at some point in the future, somebody smarter than me might be able to fix the underlying problem. For now though we'll just take the easy way out.