### PR TITLE
koch: remove c2nim from windows release builds

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -168,7 +168,6 @@ proc bundleWinTools(args: string) =
   buildVccTool(args)
   nimCompile("tools/nimgrab.nim", options = "-d:ssl " & args)
   nimCompile("tools/nimgrep.nim", options = args)
-  bundleC2nim(args)
   nimCompile("testament/testament.nim", options = args)
   when false:
     # not yet a tool worth including


### PR DESCRIPTION
We don't ship this tool with any other OS, and the c2nim bundle is
non-deterministic due to the lack of a pinned commit.

/cc @Araq I'll let you decide if this should be in for 1.4.