### PR TITLE
Return type of asyncftpclient to fix #13641

### DIFF
--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -63,7 +63,7 @@
 ##    import asyncdispatch, asyncftpclient
 ##
 ##    proc onProgressChanged(total, progress: BiggestInt,
-##                            speed: float): Future[void] =
+##                            speed: float) {.async.} =
 ##      echo("Uploaded ", progress, " of ", total, " bytes")
 ##      echo("Current speed: ", speed, " kb/s")
 ##


### PR DESCRIPTION
Related to: #13641

The return type in the documentation was incorrect, note that this is a bit annoying to trigger normally since it's a runtime error and your upload/download should take longer than 1000 ms (the default). I have another PR to make that configurable.