### PR TITLE
Provide a configurable progressInterval for asyncftpclient.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -209,6 +209,9 @@
   is similar to procs such as `sets.toHashSet` and `tables.toTable`. Previously,
   it was necessary to create an empty IntSet and add items manually.
 
+- Added `progressInterval` argument to `asyncftpclient.newAsyncFtpClient` to control the interval
+  at which progress callbacks are called.
+
 
 ## Language changes
 

--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -59,6 +59,9 @@
 ## by specifying a ``onProgressChanged`` procedure to the ``store`` or
 ## ``retrFile`` procedures.
 ##
+## Procs that take an ``onProgressChanged`` callback will call this every
+## ``progressInterval`` milliseconds.
+##
 ## .. code-block::nim
 ##    import asyncdispatch, asyncftpclient
 ##
@@ -68,7 +71,7 @@
 ##      echo("Current speed: ", speed, " kb/s")
 ##
 ##    proc main() {.async.} =
-##      var ftp = newAsyncFtpClient("example.com", user = "test", pass = "test")
+##      var ftp = newAsyncFtpClient("example.com", user = "test", pass = "test", progressInterval = 500)
 ##      await ftp.connect()
 ##      await ftp.store("file.txt", "/home/user/file.txt", onProgressChanged)
 ##      echo("File finished uploading")
@@ -85,6 +88,7 @@ type
     user*, pass*: string
     address*: string
     port*: Port
+    progressInterval: int
     jobInProgress*: bool
     job*: FtpJob
     dsockConnected*: bool
@@ -303,7 +307,7 @@ proc getFile(ftp: AsyncFtpClient, file: File, total: BiggestInt,
   assert ftp.dsockConnected
   var progress = 0
   var progressInSecond = 0
-  var countdownFut = sleepAsync(1000)
+  var countdownFut = sleepAsync(ftp.progressInterval)
   var dataFut = ftp.dsock.recv(BufferSize)
   while ftp.dsockConnected:
     await dataFut or countdownFut
@@ -311,7 +315,7 @@ proc getFile(ftp: AsyncFtpClient, file: File, total: BiggestInt,
       asyncCheck onProgressChanged(total, progress,
           progressInSecond.float)
       progressInSecond = 0
-      countdownFut = sleepAsync(1000)
+      countdownFut = sleepAsync(ftp.progressInterval)
 
     if dataFut.finished:
       let data = dataFut.read
@@ -359,7 +363,7 @@ proc doUpload(ftp: AsyncFtpClient, file: File,
   var data = newString(4000)
   var progress = 0
   var progressInSecond = 0
-  var countdownFut = sleepAsync(1000)
+  var countdownFut = sleepAsync(ftp.progressInterval)
   var sendFut: Future[void] = nil
   while ftp.dsockConnected:
     if sendFut == nil or sendFut.finished:
@@ -380,7 +384,7 @@ proc doUpload(ftp: AsyncFtpClient, file: File,
     if countdownFut.finished:
       asyncCheck onProgressChanged(total, progress, progressInSecond.float)
       progressInSecond = 0
-      countdownFut = sleepAsync(1000)
+      countdownFut = sleepAsync(ftp.progressInterval)
 
     await countdownFut or sendFut
 
@@ -415,13 +419,14 @@ proc removeDir*(ftp: AsyncFtpClient, dir: string) {.async.} =
   assertReply(await ftp.send("RMD " & dir), "250")
 
 proc newAsyncFtpClient*(address: string, port = Port(21),
-    user, pass = ""): AsyncFtpClient =
+    user, pass = "", progressInterval: int = 1000): AsyncFtpClient =
   ## Creates a new ``AsyncFtpClient`` object.
   new result
   result.user = user
   result.pass = pass
   result.address = address
   result.port = port
+  result.progressInterval = progressInterval
   result.dsockConnected = false
   result.csock = newAsyncSocket()
 


### PR DESCRIPTION
Make the progressInterval used to fire callbacks in the asyncftpclient configurable.