### PR TITLE
Provide non-splitting parseHeaderField in httpcore

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -221,7 +221,7 @@ proc processRequest(
       await request.respondError(Http413)
       client.close(); return false
     if lineFut.mget == "\c\L": break
-    let (key, value) = parseHeader(lineFut.mget)
+    let (key, value) = parseHeaderField(lineFut.mget)
     request.headers[key] = value
     # Ensure the client isn't trying to DoS us.
     if request.headers.len > headerLimit:

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -219,7 +219,8 @@ func parseList(line: string, list: var seq[string], start: int): int =
       i.inc # Skip ,
     current.setLen(0)
 
-func parseHeader*(line: string): tuple[key: string, value: seq[string]] =
+func parseHeader*(line: string): tuple[key: string, value: seq[string]]
+    {.deprecated: "Deprecated use `parseHeaderField` instead".} =
   ## Parses a single raw header HTTP line into key value pairs.
   ##
   ## Used by ``asynchttpserver`` and ``httpclient`` internally and should not

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -219,10 +219,8 @@ func parseList(line: string, list: var seq[string], start: int): int =
       i.inc # Skip ,
     current.setLen(0)
 
-func parseHeader*(line: string, noSplit: bool = false): tuple[key: string, value: seq[string]] =
-  ## Parses a single raw header HTTP line into key value pairs. ``noSplit``
-  ## affects if header values (except for ``Cookie``) are split on ``,`` or
-  ## not.
+func parseHeader*(line: string): tuple[key: string, value: seq[string]] =
+  ## Parses a single raw header HTTP line into key value pairs.
   ##
   ## Used by ``asynchttpserver`` and ``httpclient`` internally and should not
   ## be used by you.
@@ -235,11 +233,21 @@ func parseHeader*(line: string, noSplit: bool = false): tuple[key: string, value
       i += line.skipWhitespace(i)
       result.value.add line.substr(i)
     else:
-      if noSplit:
-        i += line.skipWhitespace(i)
-        result.value.add line.substr(i)
-      else:
-        i += parseList(line, result.value, i)
+      i += parseList(line, result.value, i)
+  elif result.key.len > 0:
+    result.value = @[""]
+  else:
+    result.value = @[]
+
+func parseHeaderField*(line: string): tuple[key: string, value: seq[string]] =
+  ## Parses a single raw header HTTP line into key value pairs.
+  result.value = @[]
+  var i = 0
+  i = line.parseUntil(result.key, ':')
+  inc(i) # skip :
+  if i < len(line):
+    i += line.skipWhitespace(i)
+    result.value.add line.substr(i)
   elif result.key.len > 0:
     result.value = @[""]
   else:

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -219,8 +219,10 @@ func parseList(line: string, list: var seq[string], start: int): int =
       i.inc # Skip ,
     current.setLen(0)
 
-func parseHeader*(line: string): tuple[key: string, value: seq[string]] =
-  ## Parses a single raw header HTTP line into key value pairs.
+func parseHeader*(line: string, noSplit: bool = false): tuple[key: string, value: seq[string]] =
+  ## Parses a single raw header HTTP line into key value pairs. ``noSplit``
+  ## affects if header values (except for ``Cookie``) are split on ``,`` or
+  ## not.
   ##
   ## Used by ``asynchttpserver`` and ``httpclient`` internally and should not
   ## be used by you.
@@ -233,7 +235,11 @@ func parseHeader*(line: string): tuple[key: string, value: seq[string]] =
       i += line.skipWhitespace(i)
       result.value.add line.substr(i)
     else:
-      i += parseList(line, result.value, i)
+      if noSplit:
+        i += line.skipWhitespace(i)
+        result.value.add line.substr(i)
+      else:
+        i += parseList(line, result.value, i)
   elif result.key.len > 0:
     result.value = @[""]
   else:

--- a/tests/stdlib/thttpcore.nim
+++ b/tests/stdlib/thttpcore.nim
@@ -51,3 +51,8 @@ suite "httpcore":
     doAssert parseHeader("Accept: foo, bar") == (key: "Accept", value: @["foo", "bar"])
     doAssert parseHeader("Accept: foo, bar, prologue") == (key: "Accept", value: @["foo", "bar", "prologue"])
     doAssert parseHeader("Accept: foo, bar, prologue, starlight") == (key: "Accept", value: @["foo", "bar", "prologue", "starlight"])
+
+
+  test "test parseHeader with noSplit":
+    doAssert parseHeader("Accept: foo, bar", noSplit = true) ==  ("Accept", @["foo, bar"])
+    doAssert parseHeader("Accept: foo, bar", noSplit = false) ==  ("Accept", @["foo", "bar"])

--- a/tests/stdlib/thttpcore.nim
+++ b/tests/stdlib/thttpcore.nim
@@ -53,6 +53,5 @@ suite "httpcore":
     doAssert parseHeader("Accept: foo, bar, prologue, starlight") == (key: "Accept", value: @["foo", "bar", "prologue", "starlight"])
 
 
-  test "test parseHeader with noSplit":
-    doAssert parseHeader("Accept: foo, bar", noSplit = true) ==  ("Accept", @["foo, bar"])
-    doAssert parseHeader("Accept: foo, bar", noSplit = false) ==  ("Accept", @["foo", "bar"])
+  test "test parseHeaderField":
+    doAssert parseHeaderField("Accept: foo, bar") ==  ("Accept", @["foo, bar"])


### PR DESCRIPTION
Several issues are related to header splitting, one of them being #11757. This PR provides a ``noSplit`` option to httpcore's ``parseHeader`` to allow for several other issues to be worked on.