### PR TITLE
renderer: use the biggest integer type for masking literals [backport]

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -336,7 +336,7 @@ proc litAux(g: TSrcGen; n: PNode, x: BiggestInt, size: int): string =
 
   if nfBase2 in n.flags: result = "0b" & toBin(x, size * 8)
   elif nfBase8 in n.flags:
-    var y = if size < sizeof(BiggestInt): x and ((1 shl (size*8)) - 1)
+    var y = if size < sizeof(BiggestInt): x and ((1.BiggestInt shl (size*8)) - 1)
             else: x
     result = "0o" & toOct(y, size * 3)
   elif nfBase16 in n.flags: result = "0x" & toHex(x, size * 2)

--- a/tests/macros/tmacros_issues.nim
+++ b/tests/macros/tmacros_issues.nim
@@ -29,6 +29,7 @@ array[0 .. 100, int]
 10
 test
 0o377'i8
+0o000000000755'i32
 1
 2
 3
@@ -257,6 +258,7 @@ macro toRendererBug(n): untyped =
   result = newLit repr(n)
 
 echo toRendererBug(0o377'i8)
+echo toRendererBug(0o755'i32)
 
 # bug #12129
 macro foobar() =


### PR DESCRIPTION
On 32-bit system the mask would have a size of 32-bit, which is smaller
than the BiggestInt (usually 64-bit) it was masked against.

For some reason this only affect 32-bit Windows but not 32-bit Linux.
Might just be a difference in how gcc handle out of bound shifts for
Windows and Linux.

~~Will be taken out of draft once I verify that the fix work on Windows.~~ **EDIT**: it's working and also added a test.