### PR TITLE
Fix #15493 - tests/stdlib/tssl failing on NetBSD

### DIFF
--- a/tests/stdlib/tssl.nims
+++ b/tests/stdlib/tssl.nims
@@ -1,5 +1,5 @@
 --threads:on
 --d:ssl
-when defined(freebsd):
-  # See https://github.com/nim-lang/Nim/pull/15066#issuecomment-665541265
+when defined(freebsd) or defined(netbsd):
+  # See https://github.com/nim-lang/Nim/pull/15066#issuecomment-665541265 and https://github.com/nim-lang/Nim/issues/15493
   --tlsEmulation:off


### PR DESCRIPTION
Fixes #15493 - TLS emulation was already disabled for FreeBSD due to the same issue.