### PR TITLE
[superseded] new pointers.toUncheckedArray

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -212,6 +212,7 @@
 - Added `progressInterval` argument to `asyncftpclient.newAsyncFtpClient` to control the interval
   at which progress callbacks are called.
 
+- Added module `pointers` containing `toUncheckedArray`
 
 ## Language changes
 

--- a/lib/std/pointers.nim
+++ b/lib/std/pointers.nim
@@ -2,8 +2,10 @@
 Convenience procs to deal with pointer-like variables.
 ]##
 
-proc toUncheckedArray*[T](a: ptr[T]): ptr UncheckedArray[T] {.inline.} =
-  ## calls `cast[ptr UncheckedArray[T]]` (less error prone).
+proc toUncheckedArray*[T](a: ptr T): ptr UncheckedArray[T] {.inline.} =
+  ## Shortcut for `cast[ptr UncheckedArray[T]](a)`, where T is inferred.
+  ## This allows array indexing operations on `a`.
+  ## This is unsafe as it returns `UncheckedArray`.
   runnableExamples:
     var a = @[10, 11, 12]
     let pa = a[1].addr.toUncheckedArray

--- a/lib/std/pointers.nim
+++ b/lib/std/pointers.nim
@@ -1,0 +1,15 @@
+##[
+Convenience procs to deal with pointer-like variables.
+]##
+
+proc toUncheckedArray*[T](a: ptr[T]): ptr UncheckedArray[T] {.inline.} =
+  ## calls `cast[ptr UncheckedArray[T]]` (less error prone).
+  runnableExamples:
+    var a = @[10, 11, 12]
+    let pa = a[1].addr.toUncheckedArray
+    doAssert pa[-1] == 10
+    pa[0] = 100
+    doAssert a == @[10, 100, 12]
+    pa[0] += 5
+    doAssert a[1] == 105
+  cast[ptr UncheckedArray[T]](a)


### PR DESCRIPTION
alternative to https://github.com/nim-lang/Nim/pull/15490

adds `toUncheckedArray`
```nim
# before
let px = cast[ptr UncheckedArray[type(x)]](x)
# after
let px = x.toUncheckedArray
```

it provides a safer and more readable construct than the explicit cast (which is error prone since the cast will happily accept any type without giving any compiler error, eg in case of `let px = cast[ptr UncheckedArray[int]](pointerToInt8)`



