### PR TITLE
effects: exclude swap() from "indirect calls" assumption

### DIFF
--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -552,7 +552,7 @@ proc isNoEffectList(n: PNode): bool {.inline.} =
   n.len == 0 or (n[tagEffects] == nil and n[exceptionEffects] == nil)
 
 proc isTrival(caller: PNode): bool {.inline.} =
-  result = caller.kind == nkSym and caller.sym.magic in {mEqProc, mIsNil, mMove, mWasMoved}
+  result = caller.kind == nkSym and caller.sym.magic in {mEqProc, mIsNil, mMove, mWasMoved, mSwap}
 
 proc trackOperandForIndirectCall(tracked: PEffects, n: PNode, paramType: PType; caller: PNode) =
   let a = skipConvAndClosure(n)

--- a/tests/effects/teffects10.nim
+++ b/tests/effects/teffects10.nim
@@ -1,0 +1,12 @@
+discard """
+action: compile
+"""
+
+# https://github.com/nim-lang/Nim/issues/15495
+
+proc f() {.raises: [].} =
+  var a: proc ()
+  var b: proc ()
+  swap(a, b)
+
+f()


### PR DESCRIPTION
fixes #15495 

swap() will never call any procs passed to it, and so it can be safely
excluded from the "assume indirect calls are taken" effects tracking
rule.