### PR TITLE
add os.rebasePath; implements RFCs/256

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -57,6 +57,7 @@
 
 - `strscans.scanf` now supports parsing single characters.
 
+- Added `os.rebasePath`
 
 ## Language changes
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -476,6 +476,20 @@ proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
   let ret = relativePath(path, base)
   result = path.len > 0 and not ret.startsWith ".."
 
+proc rebasePath*(path, oldBase, newBase: string, check: static bool = true): string =
+  ## returns `newBase / path.relativePath(oldBase)`
+  runnableExamples:
+    doAssert "/home/foo/baz".rebasePath("/home/foo", "/tmp") == "/tmp/baz"
+    ## `path` must be relative to `oldBase`:
+    doAssertRaises(OSError): discard "/home/foo/baz".rebasePath("/home/other", "/tmp")
+    ## unless `check = false`, in which case it returns `path` unchanged:
+    doAssert "/home/foo/baz".rebasePath("/home/other", "/tmp", check = false) == "/home/foo/baz"
+  if path.isRelativeTo(oldBase):
+    result = newBase / path.relativePath(oldBase)
+  else:
+    when check: raise newException(OSError, $(path, oldBase, newBase))
+    result = path
+
 proc parentDirPos(path: string): int =
   var q = 1
   if len(path) >= 1 and path[len(path)-1] in {DirSep, AltSep}: q = 2

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -479,11 +479,12 @@ proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
 proc rebasePath*(path, oldBase, newBase: string, check: static bool = true): string {.since: (1,5,1).} =
   ## returns `newBase / path.relativePath(oldBase)`, see examples for details.
   runnableExamples:
-    doAssert "/home/foo/baz".rebasePath("/home/foo", "/tmp") == "/tmp/baz"
+    doAssert "/home/foo/baz".rebasePath("/home/foo", "/tmp").unixToNativePath == "/tmp/baz".unixToNativePath
     ## `path` must be relative to `oldBase`:
     doAssertRaises(OSError): discard "/home/foo/baz".rebasePath("/home/other", "/tmp")
     ## unless `check = false`, in which case it returns `path` unchanged:
-    doAssert "/home/foo/baz".rebasePath("/home/other", "/tmp", check = false) == "/home/foo/baz"
+    doAssert "/home/foo/baz".rebasePath("/home/other", "/tmp", check = false).unixToNativePath == "/home/foo/baz".unixToNativePath
+
   if path.isRelativeTo(oldBase):
     result = newBase / path.relativePath(oldBase)
   else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -476,8 +476,8 @@ proc isRelativeTo*(path: string, base: string): bool {.since: (1, 1).} =
   let ret = relativePath(path, base)
   result = path.len > 0 and not ret.startsWith ".."
 
-proc rebasePath*(path, oldBase, newBase: string, check: static bool = true): string =
-  ## returns `newBase / path.relativePath(oldBase)`
+proc rebasePath*(path, oldBase, newBase: string, check: static bool = true): string {.since: (1,5,1).} =
+  ## returns `newBase / path.relativePath(oldBase)`, see examples for details.
   runnableExamples:
     doAssert "/home/foo/baz".rebasePath("/home/foo", "/tmp") == "/tmp/baz"
     ## `path` must be relative to `oldBase`:


### PR DESCRIPTION
## example use cases:
* nim doc itself relies on similar functionality to map `sombase/foo/bar/baz.nim` to `newbase/foo/bar/baz.nim`
* mapping (translating) files from a mounted directory to a native directory eg:
```nim
let native = "/media/psf/Home/git_clone/nim/timn".rebasePath("/media/psf/Home/", getHome())
```
* mapping files to rebase some prefix to a backup directory

## note
the `check: static bool` param being static avoids complications from https://github.com/nim-lang/RFCs/issues/256#issuecomment-698192985; it's unlikely one would want to choose at runtime whether to use check=true/false so a static param is justified here.

