### PR TITLE
Fix --gc:arc in nimscript

### DIFF
--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -228,11 +228,14 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
 
   # watch out, "newruntime" can be set within NimScript itself and then we need
   # to remember this:
+  if conf.selectedGC == gcUnselected:
+    conf.selectedGC = oldSelectedGC
   if optOwnedRefs in oldGlobalOptions:
     conf.globalOptions.incl {optTinyRtti, optOwnedRefs, optSeqDestructors}
     defineSymbol(conf.symbols, "nimv2")
-  if conf.selectedGC == gcUnselected:
-    conf.selectedGC = oldSelectedGC
+  if conf.selectedGC in {gcArc, gcOrc}:
+    conf.globalOptions.incl {optTinyRtti, optSeqDestructors}
+    defineSymbol(conf.symbols, "nimv2")
 
   # ensure we load 'system.nim' again for the real non-config stuff!
   resetSystemArtifacts(graph)


### PR DESCRIPTION
I have a weird issue that adding `switch("gc", "arc")` to nim script doesn't work, in command line it does work.
However I can't replicate this problem in the small test case for unknown reason.

This PR fixes the issue. Nimscipt undefs the "nimV2" and that causes the problem.

P.S.
I am now moved to `--gc:arc` with `--sinkInference:off --cursorInference:off --deepcopy:on` but it works.