### PR TITLE
const now works with ref types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -366,10 +366,8 @@
 - `nimscript` now handles `except Exception as e`.
 
 - The `cstring` doesn't support `[]=` operator in JS backend.
-- `nimscript` now handles `except Exception as e`
 
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
-- The `cstring` doesn't support `[]=` operator in JS backend.
 
 - `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`;
   use `-d:nimLegacyCopyFile` for OSX < 10.5.

--- a/changelog.md
+++ b/changelog.md
@@ -402,6 +402,7 @@
   for an object type in the current scope.
 
 - `typeof(voidStmt)` now works and returns `void`.
+- `const` now works with types containing `ref`, see `tests/vm/tconstrefs.nim`
 
 - The `gc:orc` algorithm was refined so that custom container types can participate in the
   cycle collection process.

--- a/changelog.md
+++ b/changelog.md
@@ -366,8 +366,10 @@
 - `nimscript` now handles `except Exception as e`.
 
 - The `cstring` doesn't support `[]=` operator in JS backend.
+- `nimscript` now handles `except Exception as e`
 
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
+- The `cstring` doesn't support `[]=` operator in JS backend.
 
 - `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`;
   use `-d:nimLegacyCopyFile` for OSX < 10.5.

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2692,6 +2692,13 @@ proc genConstStmt(p: BProc, n: PNode) =
       if not isSimpleConst(sym.typ) and sym.itemId.item in m.alive and genConstSetup(p, sym):
         genConstDefinition(m, p, sym)
 
+# proc containsRef(t: PType): bool =
+#   # consider moving to 
+#   let t = skipTypes(t, abstractVar)
+#   case t.kind
+#   of tyRef: return true
+#   of tySequence: return t[]
+
 proc expr(p: BProc, n: PNode, d: var TLoc) =
   when defined(nimCompilerStacktraceHints):
     setFrameMsg p.config$n.info & " " & $n.kind
@@ -2724,8 +2731,7 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         internalError(p.config, n.info, "expr: proc not init " & sym.name.s)
       putLocIntoDest(p, d, sym.loc)
     of skConst:
-      let t = skipTypes(sym.typ, abstractVar)
-      if t.kind == tyRef:
+      if containsTyRef(sym.typ.skipTypes(abstractVar)):
         expr(p, sym.ast, d)
       elif isSimpleConst(sym.typ):
         putIntoDest(p, d, n, genLiteral(p, sym.ast, sym.typ), OnStatic)

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2692,13 +2692,6 @@ proc genConstStmt(p: BProc, n: PNode) =
       if not isSimpleConst(sym.typ) and sym.itemId.item in m.alive and genConstSetup(p, sym):
         genConstDefinition(m, p, sym)
 
-# proc containsRef(t: PType): bool =
-#   # consider moving to 
-#   let t = skipTypes(t, abstractVar)
-#   case t.kind
-#   of tyRef: return true
-#   of tySequence: return t[]
-
 proc expr(p: BProc, n: PNode, d: var TLoc) =
   when defined(nimCompilerStacktraceHints):
     setFrameMsg p.config$n.info & " " & $n.kind

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2724,7 +2724,10 @@ proc expr(p: BProc, n: PNode, d: var TLoc) =
         internalError(p.config, n.info, "expr: proc not init " & sym.name.s)
       putLocIntoDest(p, d, sym.loc)
     of skConst:
-      if isSimpleConst(sym.typ):
+      let t = skipTypes(sym.typ, abstractVar)
+      if t.kind == tyRef:
+        expr(p, sym.ast, d)
+      elif isSimpleConst(sym.typ):
         putIntoDest(p, d, n, genLiteral(p, sym.ast, sym.typ), OnStatic)
       elif useAliveDataFromDce in p.module.flags:
         genConstHeader(p.module, p.module, p, sym)

--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -78,7 +78,7 @@ proc canAlias*(arg, ret: PType): bool =
     result = canAlias(arg, ret, marker)
 
 proc checkIsolate*(n: PNode): bool =
-  if types.containsTyRef(n.typ):
+  if types.containsTyRefOrClosure(n.typ):
     # XXX Maybe require that 'n.typ' is acyclic. This is not much
     # worse than the already exisiting inheritance and closure restrictions.
     case n.kind
@@ -95,7 +95,7 @@ proc checkIsolate*(n: PNode): bool =
           discard "fine, it is isolated already"
         else:
           let argType = n[i].typ
-          if argType != nil and not isCompileTimeOnly(argType) and containsTyRef(argType):
+          if argType != nil and not isCompileTimeOnly(argType) and containsTyRefOrClosure(argType):
             if argType.canAlias(n.typ):
               return false
       result = true

--- a/compiler/spawn.nim
+++ b/compiler/spawn.nim
@@ -215,7 +215,7 @@ proc setupArgsForConcurrency(g: ModuleGraph; n: PNode; objType: PType;
 
       if formals[i].typ.kind in {tyTypeDesc, tyStatic}:
         continue
-    #elif containsTyRef(argType):
+    #elif containsTyRefOrClosure(argType):
     #  localError(n[i].info, "'spawn'ed function cannot refer to 'ref'/closure")
 
     let fieldname = if i < formals.len: formals[i].sym.name else: tmpName
@@ -246,7 +246,7 @@ proc setupArgsForParallelism(g: ModuleGraph; n: PNode; objType: PType;
 
     let argType = skipTypes(if i < formals.len: formals[i].typ else: n.typ,
                             abstractInst)
-    #if containsTyRef(argType):
+    #if containsTyRefOrClosure(argType):
     #  localError(n.info, "'spawn'ed function cannot refer to 'ref'/closure")
 
     let fieldname = if i < formals.len: formals[i].sym.name else: tmpName

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -161,8 +161,8 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
     elif kind in {skVar, skLet}:
       result = t[1]
   of tyRef:
-    if kind == skConst: result = t
-    else: result = typeAllowedAux(marker, t.lastSon, kind, c, flags+{taHeap})
+    # skConst is now allowed
+    result = typeAllowedAux(marker, t.lastSon, kind, c, flags+{taHeap})
   of tyPtr:
     result = typeAllowedAux(marker, t.lastSon, kind, c, flags+{taHeap})
   of tySet:

--- a/compiler/typeallowed.nim
+++ b/compiler/typeallowed.nim
@@ -170,8 +170,8 @@ proc typeAllowedAux(marker: var IntSet, typ: PType, kind: TSymKind,
       result = typeAllowedAux(marker, t[i], kind, c, flags)
       if result != nil: break
   of tyObject, tyTuple:
-    if kind in {skProc, skFunc, skConst} and
-        t.kind == tyObject and t[0] != nil:
+    # skConst is now allowed
+    if kind in {skProc, skFunc} and t.kind == tyObject and t[0] != nil:
       result = t
     else:
       let flags = flags+{taField}

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -271,7 +271,7 @@ proc searchTypeForAux(t: PType, predicate: TTypePredicate,
     if not result: result = searchTypeNodeForAux(t.n, predicate, marker)
   of tyGenericInst, tyDistinct, tyAlias, tySink:
     result = searchTypeForAux(lastSon(t), predicate, marker)
-  of tyArray, tySet, tyTuple:
+  of tyArray, tySet, tyTuple, tySequence:
     for i in 0..<t.len:
       result = searchTypeForAux(t[i], predicate, marker)
       if result: return

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -353,12 +353,16 @@ proc isManagedMemory(t: PType): bool =
 proc containsManagedMemory*(typ: PType): bool =
   result = searchTypeFor(typ, isManagedMemory)
 
-proc isTyRef(t: PType): bool =
-  result = t.kind == tyRef or (t.kind == tyProc and t.callConv == ccClosure)
+proc containsTyRefOrClosure*(typ: PType): bool =
+  ## returns true if typ contains a ref or closure
+  proc fn(t: PType): bool =
+    result = t.kind == tyRef or (t.kind == tyProc and t.callConv == ccClosure)
+  result = searchTypeFor(typ, fn)
 
 proc containsTyRef*(typ: PType): bool =
-  # returns true if typ contains a 'ref'
-  result = searchTypeFor(typ, isTyRef)
+  proc fn(t: PType): bool =
+    result = t.kind == tyRef
+  result = searchTypeFor(typ, fn)
 
 proc isHiddenPointer(t: PType): bool =
   result = t.kind in {tyString, tySequence, tyOpenArray, tyVarargs}

--- a/tests/errmsgs/t5870.nim
+++ b/tests/errmsgs/t5870.nim
@@ -1,8 +1,3 @@
-discard """
-errormsg: "invalid type: 'SomeRefObj' in this context: 'seq[SomeRefObj]' for const"
-line: 14
-"""
-
 # bug #5870
 type SomeRefObj = ref object of RootObj
     someIntMember: int
@@ -13,5 +8,5 @@ proc createSomeRefObj(v: int): SomeRefObj=
 
 const compileTimeSeqOfRefObjs = @[createSomeRefObj(100500), createSomeRefObj(2)]
 
-for i in 0..1:
-  echo compileTimeSeqOfRefObjs[i].someIntMember
+doAssert compileTimeSeqOfRefObjs[0].someIntMember == 100500
+doAssert compileTimeSeqOfRefObjs[1].someIntMember == 2

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -22,6 +22,22 @@ block: # nested ref objects
   const f = Foo2(f0: Bar(b0: 1))
   doAssert f.f0.b0 == 1
 
+block: # ref object of
+  type Foo = ref object of RootObj
+    f0: int
+  const f = @[Foo(f0: 1), Foo(f0: 2)]
+  doAssert f[1].f0 == 2
+  let f2 = f
+  doAssert f2[1].f0 == 2
+
+  type Goo = ref object of Foo
+    g0: int
+  const g = @[Goo(g0: 3), Goo(g0: 4, f0: 5)]
+  doAssert g[0].g0 == 3
+  doAssert g[0].f0 == 0
+  doAssert g[1].g0 == 4
+  doAssert g[1].f0 == 5
+
 block: # complex example
   type Bar = ref object
     b0: int

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -1,5 +1,72 @@
 import std/json
 
+block: # ref objects
+  type Foo = ref object
+    x1: int
+    x2: string
+    x3: seq[string]
+  const j1 = Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])
+  doAssert j1[] == Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])[]
+  doAssert $j1[] == """(x1: 12, x2: "asdf", x3: @["foo", "bar"])"""
+  doAssert j1.x2 == "asdf"
+
+block: # nested ref objects
+  type Bar = ref object
+    b0: int
+  type Foo2 = ref object
+    f0: Bar
+  const f = Foo2(f0: Bar(b0: 1))
+  doAssert f.f0.b0 == 1
+
+block: # complex example
+  type Bar = ref object
+    b0: int
+  type Foo3 = ref object
+    f0: Bar
+    f1: array[2, Bar]
+    f2: seq[Bar]
+    f3: seq[Foo3]
+    f4: string
+
+  proc initFoo3(s: string): Foo3 =
+    result = Foo3(f0: Bar(b0: 2))
+    result.f1 = [nil, Bar(b0: 3)]
+    result.f2 = @[Bar(b0: 4)]
+    result.f3 = @[Foo3(f4: s)]
+    result.f4 = s
+
+  const f = initFoo3("abc")
+  let f2 = f
+  var f3 = f
+  var f4 = f.unsafeAddr[]
+  var f5 = [f,f]
+
+  proc fn(a: Foo3) =
+    # shows we can pass a const ref to a proc
+    doAssert a.f4 == "abc"
+
+  fn(f)
+
+  template check(x: Foo3) =
+    fn(x)
+    doAssert x.f0.b0 == 2
+    doAssert x.f1[0] == nil
+    doAssert x.f1[1].b0 == 3
+    doAssert x.f2[0].b0 == 4
+    doAssert x.f3[0].f4 == "abc"
+    doAssert x.f4 == "abc"
+
+  check(f)
+  check(f2)
+  check(f3)
+  check(f4)
+  check(f5[0])
+
+  const f6 = f.f3
+  doAssert f6[0].f4 == "abc"
+  # let f7 = f6
+  # doAssert f7[0].f4 == "abc"
+
 block: # case ref objects
   const j = parseJson(""" {"x1":12,"x2":"asdf","x3":[1,2]} """)
   const x1 = j["x1"].getInt
@@ -10,12 +77,3 @@ block: # case ref objects
 
   doAssert x1 == 12
   doAssert x2 == @[1, 2]
-
-block: # case objects
-  type Foo = ref object
-    x1: int
-    x2: string
-    x3: seq[string]
-  const j1 = Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])
-  doAssert j1[] == Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])[]
-  doAssert $j1[] == """(x1: 12, x2: "asdf", x3: @["foo", "bar"])"""

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -1,0 +1,21 @@
+import std/json
+
+block: # case ref objects
+  const j = parseJson(""" {"x1":12,"x2":"asdf","x3":[1,2]} """)
+  const x1 = j["x1"].getInt
+  const x2 = j["x3"].to(seq[int])
+  when false:
+    # pending https://github.com/nim-lang/Nim/issues/13081
+    echo j["x1"].getInt
+
+  doAssert x1 == 12
+  doAssert x2 == @[1, 2]
+
+block: # case objects
+  type Foo = ref object
+    x1: int
+    x2: string
+    x3: seq[string]
+  const j1 = Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])
+  doAssert j1[] == Foo(x1: 12, x2: "asdf", x3: @["foo", "bar"])[]
+  doAssert $j1[] == """(x1: 12, x2: "asdf", x3: @["foo", "bar"])"""

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -97,13 +97,12 @@ block: # case ref objects
   const j = parseJson(""" {"x1":12,"x2":"asdf","x3":[1,2]} """)
   const x1 = j["x1"].getInt
   const x2 = j["x3"].to(seq[int])
-  when false:
-    # pending https://github.com/nim-lang/Nim/issues/13081
-    echo j["x1"].getInt
-  doAssert j["x1"].getInt.static == 12
-
   doAssert x1 == 12
   doAssert x2 == @[1, 2]
+  doAssert j["x1"].getInt.static == 12
+  when false:
+    # xxx still an issue, related to closed bugs: bug #13081, bug #8015
+    echo j["x1"].getInt
 
 block: # regression test with closures
   type MyProc = proc (x: int): int
@@ -112,6 +111,6 @@ block: # regression test with closures
     result.add even
     result.setLen 2 # intentionally leaving 1 unassigned
   const a = bar()
-  when not defined(js):
+  when not defined(js): # xxx
     doAssert a == bar()
   doAssert a[0](2) == 2*3

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -104,3 +104,13 @@ block: # case ref objects
 
   doAssert x1 == 12
   doAssert x2 == @[1, 2]
+
+block: # regression test with closures
+  type MyProc = proc (x: int): int
+  proc even(x: int): int = x*3
+  proc bar(): seq[MyProc] =
+    result.add even
+    result.setLen 2 # intentionally leaving 1 unassigned
+  const a = bar()
+  doAssert a == bar()
+  doAssert a[0](2) == 2*3

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -112,5 +112,6 @@ block: # regression test with closures
     result.add even
     result.setLen 2 # intentionally leaving 1 unassigned
   const a = bar()
-  doAssert a == bar()
+  when not defined(js):
+    doAssert a == bar()
   doAssert a[0](2) == 2*3

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -64,8 +64,14 @@ block: # complex example
 
   const f6 = f.f3
   doAssert f6[0].f4 == "abc"
-  # let f7 = f6
-  # doAssert f7[0].f4 == "abc"
+  let f7 = f6
+  doAssert f7[0].f4 == "abc"
+  var f8: array[2,Bar]
+  f8 = f.f1
+  doAssert f8[1].b0 == 3
+  var f9: (Foo3,)
+  f9[0] = f
+  doAssert f9.f0.b0 == 2
 
 block: # case ref objects
   const j = parseJson(""" {"x1":12,"x2":"asdf","x3":[1,2]} """)

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -1,3 +1,7 @@
+discard """
+  targets:  "c cpp js"
+"""
+
 import std/json
 
 block: # ref objects
@@ -71,7 +75,7 @@ block: # complex example
   doAssert f8[1].b0 == 3
   var f9: (Foo3,)
   f9[0] = f
-  doAssert f9.f0.b0 == 2
+  doAssert f9[0].f0.b0 == 2
 
 block: # case ref objects
   const j = parseJson(""" {"x1":12,"x2":"asdf","x3":[1,2]} """)

--- a/tests/vm/tconstrefs.nim
+++ b/tests/vm/tconstrefs.nim
@@ -84,6 +84,7 @@ block: # case ref objects
   when false:
     # pending https://github.com/nim-lang/Nim/issues/13081
     echo j["x1"].getInt
+  doAssert j["x1"].getInt.static == 12
 
   doAssert x1 == 12
   doAssert x2 == @[1, 2]

--- a/tests/vm/tseq_badinit.nim
+++ b/tests/vm/tseq_badinit.nim
@@ -47,7 +47,7 @@ test(char, '0')
 test(bool, false)
 test(uint8, 2)
 test(string, "data")
-test(MyProc, even)
+# test(MyProc, even) # PRTEMP
 test(MyEnum, E02)
 test(AObj, AObj())
 test(ATup, (i:11, d:9.99))

--- a/tests/vm/tseq_badinit.nim
+++ b/tests/vm/tseq_badinit.nim
@@ -47,7 +47,7 @@ test(char, '0')
 test(bool, false)
 test(uint8, 2)
 test(string, "data")
-# test(MyProc, even) # PRTEMP
+test(MyProc, even)
 test(MyEnum, E02)
 test(AObj, AObj())
 test(ATup, (i:11, d:9.99))


### PR DESCRIPTION
* const now works with ref types, even if the ref occurs somewhere nested
* works with c,cpp,js, with or without --gc:arc
* see tests tests/vm/tconstrefs.nim
* when codegen encounters a const sym, it gets expanded out via its ast as if the whole const expression was inlined; you can inspect the generated C code to see how it works. This addresses the concerns raised in https://github.com/nim-lang/Nim/pull/13082.
* fixes https://github.com/nim-lang/Nim/issues/5870 properly
* bugfix in `searchTypeForAux` which didn't consider `tySequence`
* renamed containsTyRef to containsTyRefOrClosure (since i needed an actual `containsTyRef`), which explains the small diff for compiler/spawn.nim, compiler/isolation_check.nim
* the only caveat is ref case objects, but that's a pre-existing separate issue, see https://github.com/nim-lang/Nim/issues/13081

## example 1: nested ref
```nim
when true:
  block:
    type Foo = ref object
      x1: string
      x2: seq[Foo]
    const j1 = Foo(x1: "asdf", x2: @[Foo(x1: "bar")])
    echo j1[]
    let j2 = j1
    doAssert j2.x2[0].x1 == "bar"
```
## example 2: Table
```nim
when true:
  import std/tables
  const a = {1: "1", 2: "2"}.newTable
```

More generally, this enables very useful patterns, eg reading a config file at CT (json, etc) into some ref const, and **caching** it for reuse, making it available at RT and CT. This would not be possible before this PR.

More on this config file idea later (a DRY + typesafe config available at RT + CT)

## links
* https://github.com/nim-lang/RFCs/issues/271
* also fixes [How to create const object of non-root object type - Nim forum](https://forum.nim-lang.org/t/7860)

## scratch below
* `dontInlineConstant`
* https://github.com/nim-lang/RFCs/issues/257
* https://github.com/nim-lang/Nim/pull/16115
