### PR TITLE
os: add overload copyFile*(source, dest: string, isDir = false) (EDIT: copyFileToDir)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -209,6 +209,7 @@
 - Added `progressInterval` argument to `asyncftpclient.newAsyncFtpClient` to control the interval
   at which progress callbacks are called.
 
+- Added `os.copyFileToDir`
 
 ## Language changes
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1738,7 +1738,7 @@ proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",
     flushFile(d)
     close(d)
 
-proc copyFileToDir*(source, dir: string) {.since: (1,3,7).} =
+proc copyFileToDir*(source, dir: string) {.noWeirdTarget, since: (1,3,7).} =
   ## Copies a file `source` into directory `dir`, which must exist.
   if dir.len == 0: # treating "" as "." is error prone
     raise newException(ValueError, "dest is empty")

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -36,19 +36,19 @@ block fileOperations:
   createDir(dname)
   doAssert dirExists(dname)
 
-  block copyFile:
+  block: # copyFile, copyFileToDir
     doAssertRaises(OSError): copyFile(dname/"nonexistant.txt", dname/"nonexistant.txt")
     let fname = "D20201009T112235"
     let fname2 = "D20201009T112235.2"
     writeFile(dname/fname, "foo")
     let sub = "sub"
     doAssertRaises(OSError): copyFile(dname/fname, dname/sub/fname2)
-    doAssertRaises(OSError): copyFile(dname/fname, dname/sub,isDir=true)
-    doAssertRaises(ValueError): copyFile(dname/fname, "",isDir=true)
+    doAssertRaises(OSError): copyFileToDir(dname/fname, dname/sub)
+    doAssertRaises(ValueError): copyFileToDir(dname/fname, "")
     copyFile(dname/fname, dname/fname2)
     doAssert fileExists(dname/fname2)
     createDir(dname/sub)
-    copyFile(dname/fname, dname/sub,isDir=true)
+    copyFileToDir(dname/fname, dname/sub)
     doAssert fileExists(dname/sub/fname)
     removeDir(dname/sub)
     doAssert not dirExists(dname/sub)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -36,6 +36,25 @@ block fileOperations:
   createDir(dname)
   doAssert dirExists(dname)
 
+  block copyFile:
+    doAssertRaises(OSError): copyFile(dname/"nonexistant.txt", dname/"nonexistant.txt")
+    let fname = "D20201009T112235"
+    let fname2 = "D20201009T112235.2"
+    writeFile(dname/fname, "foo")
+    let sub = "sub"
+    doAssertRaises(OSError): copyFile(dname/fname, dname/sub/fname2)
+    doAssertRaises(OSError): copyFile(dname/fname, dname/sub,isDir=true)
+    doAssertRaises(ValueError): copyFile(dname/fname, "",isDir=true)
+    copyFile(dname/fname, dname/fname2)
+    doAssert fileExists(dname/fname2)
+    createDir(dname/sub)
+    copyFile(dname/fname, dname/sub,isDir=true)
+    doAssert fileExists(dname/sub/fname)
+    removeDir(dname/sub)
+    doAssert not dirExists(dname/sub)
+    removeFile(dname/fname)
+    removeFile(dname/fname2)
+
   # Test creating files and dirs
   for dir in dirs:
     createDir(dname/dir)


### PR DESCRIPTION
* add overload `copyFile*(source, dest: string, isDir = false)`
more DRY than what's used 90% of the time:
```nim
copyFile("a/foo.txt", "b/foo.txt")
=>
copyFile("a/foo.txt", "b", isDir = true)
```

* improve docs
* add missing tests for copyFile

## TODO after this PR
* add similar overload to `copyFileWithPermissions`
