### PR TITLE
close socket in getPrimaryIPAddr

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -2006,4 +2006,5 @@ proc getPrimaryIPAddr*(dest = parseIpAddress("8.8.8.8")): IpAddress =
     else:
       newSocket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
   socket.connect($dest, 80.Port)
-  socket.getLocalAddr()[0].parseIpAddress()
+  result = socket.getLocalAddr()[0].parseIpAddress()
+  socket.close()


### PR DESCRIPTION
``getPrimaryIPAddr`` currently leaks a file descriptor. Closing the socket fixes that.