### PR TITLE
fix #15413: support JSON in int64.high+1..uint64.high as JUint, and beyond as JNumber

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # v1.6.x - yyyy-mm-dd
 
 
-
 ## Standard library additions and changes
+-  `json` now supports parsing uint64 values > int64.high (via a new JUInt kind),
+   and values beyond the range of int64/uint64 are now parsed as a new JNumber kind.
 
 
 

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1063,7 +1063,7 @@ when defined(nimFixedForwardGeneric):
     dst = jsonNode.copy
 
   proc initFromJson[T: SomeInteger](dst: var T; jsonNode: JsonNode, jsonPath: var string) =
-    if jsonNode.kind == JUInt:
+    if jsonNode != nil and jsonNode.kind == JUInt:
       dst = T(jsonNode.unum)
     else:
       verifyJsonKind(jsonNode, {JInt}, jsonPath)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -26,8 +26,8 @@
 ##
 ## The ``parseJson`` procedure takes a string containing JSON and returns a
 ## ``JsonNode`` object. This is an object variant and it is either a
-## ``JObject``, ``JArray``, ``JString``, ``JInt``, ``JUInt``, ``JFloat``, ``JBool`` or
-## ``JNull``. You check the kind of this object variant by using the ``kind``
+## ``JObject``, ``JArray``, ``JString``, ``JInt``, ``JUInt``, ``JFloat``, `JNumber`,
+## ``JBool`` or ``JNull``. You check the kind of this object variant by using the ``kind``
 ## accessor.
 ##
 ## For a ``JsonNode`` who's kind is ``JObject``, you can access its fields using
@@ -174,7 +174,8 @@ type
     JString,
     JObject,
     JArray,
-    JUInt
+    JUInt,
+    JNumber,
 
   JsonNode* = ref JsonNodeObj ## JSON node
   JsonNodeObj* {.acyclic.} = object
@@ -185,6 +186,8 @@ type
       num*: BiggestInt
     of JUInt:
       unum*: BiggestUInt
+    of JNumber:
+      rawNum*: string
     of JFloat:
       fnum*: float
     of JBool:
@@ -211,6 +214,10 @@ proc newJInt*(n: BiggestInt): JsonNode =
 proc newJUInt*(n: BiggestUInt): JsonNode =
   ## Creates a new `JUInt JsonNode`.
   result = JsonNode(kind: JUInt, unum: n)
+
+proc newJNumber*(a: string): JsonNode =
+  ## Creates a new `JNumber JsonNode`.
+  result = JsonNode(kind: JNumber, rawNum: a)
 
 proc newJFloat*(n: float): JsonNode =
   ## Creates a new `JFloat JsonNode`.
@@ -257,6 +264,18 @@ proc getBiggestUInt*(n: JsonNode, default: BiggestUInt = 0): BiggestUInt =
   ## Retrieves the BiggestUInt value of a `JUInt JsonNode`.
   ##
   ## Returns ``default`` if ``n`` is not a ``JInt``, or if ``n`` is nil.
+  if n.isNil: return default
+  elif n.kind == JInt:
+    if n.num >= 0: return cast[BiggestUInt](n.num)
+    else: return default
+  elif n.kind == JUInt: return n.unum
+  else: return default
+
+proc getNumber*(n: JsonNode, default: string = "0"): string =
+  ## Retrieves the BiggestUInt value of a `JUInt JsonNode`.
+  ##
+  ## Returns ``default`` if ``n`` is not a ``JInt``, or if ``n`` is nil.
+  return n.
   if n.isNil: return default
   elif n.kind == JInt:
     if n.num >= 0: return cast[BiggestUInt](n.num)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -969,7 +969,7 @@ when defined(js):
     of JInt:
       result = newJInt(cast[int](x))
     of JUInt:
-      result = newJUInt(cast[uint](x))
+      result = newJUInt(cast[BiggestUInt](x))
     of JFloat:
       result = newJFloat(cast[float](x))
     of JString:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2402,6 +2402,9 @@ when defined(js) or defined(nimscript):
   proc addInt*(result: var string; x: int64) =
     result.add $x
 
+  proc addInt*(result: var string; x: uint64) =
+    addInt(result, cast[int64](x)) # checkme
+
   proc addFloat*(result: var string; x: float) =
     result.add $x
 

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -40,7 +40,7 @@ proc hashString(s: string): int {.compilerproc.} =
   h = h + h shl 15
   result = cast[int](h)
 
-proc addInt*(result: var string; x: int64) =
+proc addIntImpl(result: var string; x: int64) =
   ## Converts integer to its string representation and appends it to `result`.
   ##
   ## .. code-block:: Nim
@@ -66,7 +66,7 @@ proc addInt*(result: var string; x: int64) =
   for j in 0..i div 2 - 1:
     swap(result[base+j], result[base+i-j-1])
 
-proc addInt*(result: var string; x: uint64) =
+proc addIntImpl(result: var string; x: uint64) =
   # PRTEMP: TODO: add tests
   let base = result.len
   setLen(result, base + sizeof(x)*4)
@@ -82,6 +82,9 @@ proc addInt*(result: var string; x: uint64) =
   # mirror the string:
   for j in 0..i div 2 - 1:
     swap(result[base+j], result[base+i-j-1])
+
+proc addInt*(result: var string; x: SomeInteger) = addIntImpl(result, x)
+  # indirection needed, see tests/vm/tmisc_vm.nim
 
 proc nimIntToStr(x: int): string {.compilerRtl.} =
   result = newStringOfCap(sizeof(x)*4)

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -66,6 +66,23 @@ proc addInt*(result: var string; x: int64) =
   for j in 0..i div 2 - 1:
     swap(result[base+j], result[base+i-j-1])
 
+proc addInt*(result: var string; x: uint64) =
+  # PRTEMP: TODO: add tests
+  let base = result.len
+  setLen(result, base + sizeof(x)*4)
+  var i = 0
+  var y = x
+  while true:
+    var d = y div 10
+    result[base+i] = chr(abs(int(y - d*10)) + ord('0'))
+    inc(i)
+    y = d
+    if y == 0: break
+  setLen(result, base+i)
+  # mirror the string:
+  for j in 0..i div 2 - 1:
+    swap(result[base+j], result[base+i-j-1])
+
 proc nimIntToStr(x: int): string {.compilerRtl.} =
   result = newStringOfCap(sizeof(x)*4)
   result.addInt x

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -245,7 +245,7 @@ block: # uint64; bug #15413
     doAssert x2 > cast[uint64](int64.high)
 
 block: # JNumber
-  doAssert uint.high == 18446744073709551615'u64
+  doAssert uint64.high == 18446744073709551615'u64
   let x = "184467440737095516151"
   let j = parseJson(x)
   doAssert $j == x

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -243,3 +243,13 @@ block: # uint64; bug #15413
     let x2 = j.getBiggestUInt
     doAssert x2 == 18446744073709551605'u64
     doAssert x2 > cast[uint64](int64.high)
+
+block: # JNumber
+  doAssert uint.high == 18446744073709551615'u64
+  let x = "184467440737095516151"
+  let j = parseJson(x)
+  doAssert $j == x
+  doAssert j.pretty == x
+  doAssert j.kind == JNumber
+  let x2 = j.getNumber
+  doAssert x2 == x

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -239,7 +239,7 @@ block: # uint64; bug #15413
     let j = parseJson(x)
     doAssert $j == "18446744073709551605"
     doAssert j.pretty == "18446744073709551605"
-    doAssert j.kind == JUint
+    doAssert j.kind == JUInt
     let x2 = j.getBiggestUInt
     doAssert x2 == 18446744073709551605'u64
     doAssert x2 > cast[uint64](int64.high)

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -233,7 +233,7 @@ doAssert not isRefSkipDistinct(MyObject)
 doAssert isRefSkipDistinct(MyDistinct)
 doAssert isRefSkipDistinct(MyOtherDistinct)
 
-block: # uint64
+block: # uint64; bug #15413
   when not defined(js):
     let x = "18446744073709551605"
     let j = parseJson(x)

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -232,3 +232,14 @@ doAssert isRefSkipDistinct(MyRef)
 doAssert not isRefSkipDistinct(MyObject)
 doAssert isRefSkipDistinct(MyDistinct)
 doAssert isRefSkipDistinct(MyOtherDistinct)
+
+block: # uint64
+  when not defined(js):
+    let x = "18446744073709551605"
+    let j = parseJson(x)
+    doAssert $j == "18446744073709551605"
+    doAssert j.pretty == "18446744073709551605"
+    doAssert j.kind == JUint
+    let x2 = j.getBiggestUInt
+    doAssert x2 == 18446744073709551605'u64
+    doAssert x2 > cast[uint64](int64.high)


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/15413

see rationale here: https://github.com/nim-lang/Nim/issues/15413#issuecomment-706602931, in particular wrt BigInt vs uint64

the only breakage caused by this change was in a single package, `nimpy.nim(821, 3) Error: not all cases are covered; missing: {JUInt, JNumber}` and I've already fixed that in https://github.com/yglukhov/nimpy/pull/177 using `trailing else`.

(this could've also been fixed by #15646, after which I'd add `{.allowMissingCases.}` pragma as described in https://github.com/nim-lang/Nim/pull/15646)
