### PR TITLE
dup docs: add an example with `addQuoted`

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -245,6 +245,8 @@ since (1, 1):
 
       # An underscore (_) can be used to denote the place of the argument you're passing:
       doAssert "".dup(addQuoted(_, "foo")) == "\"foo\""
+      # but `_` is optional here since the substitution is in 1st position:
+      doAssert "".dup(addQuoted("foo")) == "\"foo\""
 
       # chaining:
       # b = "xyz"

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -244,6 +244,9 @@ since (1, 1):
       var c = "xyz"
 
       # An underscore (_) can be used to denote the place of the argument you're passing:
+      doAssert "".dup(addQuoted(_, "foo")) == "\"foo\""
+
+      # chaining:
       # b = "xyz"
       var d = dup c:
         makePalindrome # xyzyx


### PR DESCRIPTION
`_` was lacking a simpler example