### PR TITLE
Update the list of GC options when raising an error (closes #15547)

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -229,7 +229,7 @@ proc processCompile(conf: ConfigRef; filename: string) =
   extccomp.addExternalFileToCompile(conf, found)
 
 const
-  errNoneBoehmRefcExpectedButXFound = "'none', 'boehm' or 'refc' expected, but '$1' found"
+  errNoneBoehmRefcExpectedButXFound = "'arc', 'orc', 'markAndSweep', 'boehm', 'go', 'none', 'regions', or 'refc' expected, but '$1' found"
   errNoneSpeedOrSizeExpectedButXFound = "'none', 'speed' or 'size' expected, but '$1' found"
   errGuiConsoleOrLibExpectedButXFound = "'gui', 'console' or 'lib' expected, but '$1' found"
   errInvalidExceptionSystem = "'goto', 'setjump', 'cpp' or 'quirky' expected, but '$1' found"


### PR DESCRIPTION
Also, it appears that the list of GC options is different between the GC docs and the compiler manual. Specifically, the compiler manual mentions "regions" but the GC docs don't. I'm happy to fix one of them but I'm not sure which is wrong.

As a side note: should I be making a changelog addition as well?