### PR TITLE
terminal: fix fgColor/bgColor commands [backport]

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -689,10 +689,9 @@ template styledEchoProcessArg(f: File, color: Color) =
 template styledEchoProcessArg(f: File, cmd: TerminalCmd) =
   when cmd == resetStyle:
     resetAttributes(f)
-  when cmd == fgColor:
-    fgSetColor = true
-  when cmd == bgColor:
-    fgSetColor = false
+  elif cmd in {fgColor, bgColor}:
+    let term = getTerminal()
+    term.fgSetColor = cmd == fgColor
 
 macro styledWrite*(f: File, m: varargs[typed]): untyped =
   ## Similar to ``write``, but treating terminal style arguments specially.

--- a/tests/stdlib/tterminal.nim
+++ b/tests/stdlib/tterminal.nim
@@ -1,0 +1,8 @@
+discard """
+  action: compile
+"""
+
+import terminal, colors
+
+styledEcho fgColor, colRed, "Test"
+styledEcho bgColor, colBlue, "Test"


### PR DESCRIPTION
Since #8296, fgSetColor is no longer a global. These commands were
probably left out from the change as an oversight, so some tests have
been added to make sure this won't happen again.