### PR TITLE
close socket in getPrimaryIPAddr even if exception occurs

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -2005,6 +2005,8 @@ proc getPrimaryIPAddr*(dest = parseIpAddress("8.8.8.8")): IpAddress =
       newSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
     else:
       newSocket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP)
-  socket.connect($dest, 80.Port)
-  result = socket.getLocalAddr()[0].parseIpAddress()
-  socket.close()
+  try:
+    socket.connect($dest, 80.Port)
+    result = socket.getLocalAddr()[0].parseIpAddress()
+  finally:
+    socket.close()


### PR DESCRIPTION
Recently #15538 was merged. But the socket [would still not be closed if an exception occurs](https://github.com/nim-lang/Nim/commit/c7ccbfac39008903826d8c56d9eaa6572c9acea7#commitcomment-43135726). This fixes that as proposed by @alaviss.