### PR TITLE
ci docs: add config/nimdoc.cfg to paths

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'compiler/docgen.nim'
       - 'compiler/renderverbatim.nim'
+      - 'config/nimdoc.cfg'
       - 'doc/**.rst'
       - 'doc/nimdoc.css'
       - 'lib/**.nim'
@@ -17,6 +18,7 @@ on:
     paths:
       - 'compiler/docgen.nim'
       - 'compiler/renderverbatim.nim'
+      - 'config/nimdoc.cfg'
       - 'doc/**.rst'
       - 'doc/nimdoc.css'
       - 'lib/**.nim'


### PR DESCRIPTION
https://github.com/nim-lang/Nim/pull/15562 should've triggered a doc run, but didn't; this fixes that