### PR TITLE
add a section on naming new stdlib module names

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -558,12 +558,14 @@ to existing modules is acceptable. For two reasons:
 
 Conventions
 -----------
-New stdlib modules should go under `Nim/lib/std/`. The rationale is to require
+1. New stdlib modules should go under `Nim/lib/std/`. The rationale is to require
 users to import via `import std/foo` instead of `import foo`, which would cause
 potential conflicts with nimble packages. Note that this still applies for new modules
 in existing logical directories, eg:
 use `lib/std/collections/foo.nim`, not `lib/pure/collections/foo.nim`.
 
-New module names should prefer plural form whenever possible, eg:
+2. New module names should prefer plural form whenever possible, eg:
 `std/sums.nim` instead of `std/sum.nim`. In particular, this reduces chances of conflicts
-between module name and the symbols it defines.
+between module name and the symbols it defines. Furthermore, is should use `snake_case`
+and not use capital letters, which cause issues when going from an OS without case
+sensitivity to an OS without it.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -555,3 +555,15 @@ to existing modules is acceptable. For two reasons:
    Newly introduced issues have to be balanced against motivating new people. We know where
    to find perfectly designed pieces of software that have no bugs -- these are the systems
    that nobody uses.
+
+Conventions
+-----------
+New stdlib modules should go under `Nim/lib/std/`. The rationale is to require
+users to import via `import std/foo` instead of `import foo`, which would cause
+potential conflicts with nimble packages. Note that this still applies for new modules
+in existing logical directories, eg:
+use `lib/std/collections/foo.nim`, not `lib/pure/collections/foo.nim`.
+
+New module names should prefer plural form whenever possible, eg:
+`std/sums.nim` instead of `std/sum.nim`. In particular, this reduces chances of conflicts
+between module name and the symbols it defines.


### PR DESCRIPTION
* New stdlib modules should go under `Nim/lib/std/` [...]
refs: https://github.com/nim-lang/Nim/pull/8024#issuecomment-396943421
> There is no reason whatsoever we can't have a long deprecation period for import strutils and the like, we can even decide the old stdlib modules should be seen as "keyword-like" and do not have to deprecate it at all (!) but all the new stuff ends up in std.

* New module names should prefer plural form whenever possible [...]
it's a commonly accepted convention that would benefit from being even more accepted, see https://github.com/nim-lang/Nim/issues/12001#issuecomment-525036133
it also reduces chances of issues like https://github.com/nim-lang/Nim/issues/12213

* refs https://github.com/nim-lang/Nim/issues/12001