### PR TITLE
glob: more flexible than `walkDirRec`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 
 
 ## Standard library additions and changes
-
+- Added `globs.glob`, more flexible than `walkDirRec`.
 
 
 ## Language changes

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -19,7 +19,7 @@ import
   typesrenderer, astalgo, lineinfos, intsets,
   pathutils, trees, tables, nimpaths, renderverbatim, osproc
 
-from std/private/globs import nativeToUnixPath
+from std/private/osutils import nativeToUnixPath
 
 const
   exportSection = skField

--- a/lib/std/globs.nim
+++ b/lib/std/globs.nim
@@ -1,0 +1,38 @@
+import std/os
+
+type
+  PathEntry* = object
+    kind*: PathComponent
+    path*: string
+
+iterator glob*(dir: string, follow: proc(entry: PathEntry): bool = nil,
+    relative = false, checkDir = true): PathEntry {.tags: [ReadDirEffect].} =
+  ## Improved `os.walkDirRec`.
+  #[
+  note: a yieldFilter isn't needed because caller can filter at call site, without
+  loss of generality, unlike `follow`.
+
+  Future work:
+  * need to document
+  * add a `sort` option, which can be implemented efficiently only here, not at call site.
+  * provide a way to do error reporting, which is tricky because iteration cannot be resumed
+  * `walkDirRec` can be implemented in terms of this to avoid duplication,
+  modulo some refactoring.
+  ]#
+  var stack = @["."]
+  var checkDir = checkDir
+  var entry: PathEntry
+  while stack.len > 0:
+    let d = stack.pop()
+    for k, p in walkDir(dir / d, relative = true, checkDir = checkDir):
+      let rel = d / p
+      entry.kind = k
+      if relative: entry.path = rel
+      else: entry.path = dir / rel
+      if k in {pcDir, pcLinkToDir}:
+        if follow == nil or follow(entry): stack.add rel
+      yield entry
+    checkDir = false
+      # We only check top-level dir, otherwise if a subdir is invalid (eg. wrong
+      # permissions), it'll abort iteration and there would be no way to
+      # continue iteration.

--- a/lib/std/globs.nim
+++ b/lib/std/globs.nim
@@ -1,3 +1,13 @@
+#[
+## Design rationale
+* an intermediate `GlobOpt` is used to allow easier proc forwarding
+* a yieldFilter, regex match etc isn't needed because caller can filter at
+  call site, without loss of generality, unlike `follow`; this simplifies the API.
+
+## Future work:
+* provide a way to do error reporting, which is tricky because iteration cannot be resumed
+]#
+
 import std/os
 import std/algorithm
 import std/deques
@@ -52,23 +62,15 @@ iterator globOpt*(opt: GlobOpt): PathEntry =
       # list hidden files of depth <= 2 + 1 in your home.
       for e in glob(getHomeDir(), follow = a=>a.path.isHidden and a.depth <= 2):
         if e.kind in {pcFile, pcLinkToFile}: echo e.path
-  #[
-  note:
-  * a yieldFilter, regex match etc isn't needed because caller can filter at
-  call site, without loss of generality, unlike `follow`; this simplifies the API.
 
-  Future work:
-  * provide a way to do error reporting, which is tricky because iteration cannot be resumed
-  * `walkDirRec` can be implemented in terms of this to avoid duplication,
-    modulo some refactoring.
-  ]#
   var entry = PathEntry(depth: 0, path: ".")
-  entry.kind = if symlinkExists(opt.dir): pcLinkToDir else: pcDir
-  # var stack: seq[PathEntry]
+  # entry.kind = if symlinkExists(opt.dir): pcLinkToDir else: pcDir
+  entry.kind = if false: pcLinkToDir else: pcDir
   var stack = initDeque[PathEntry]()
 
   var checkDir = opt.checkDir
-  if dirExists(opt.dir):
+  # if dirExists(opt.dir):
+  if true:
     stack.addLast entry
   elif checkDir:
     raise newException(OSError, "invalid root dir: " & opt.dir)
@@ -109,4 +111,5 @@ iterator globOpt*(opt: GlobOpt): PathEntry =
             stack.addLast PathEntry(depth: current.depth + 1, path: current.path / ai.path, kind: ai.kind)
 
 template glob*(args: varargs[untyped]): untyped =
+  ## convenience wrapper
   globOpt(initGlobOpt(args))

--- a/lib/std/globs.nim
+++ b/lib/std/globs.nim
@@ -11,12 +11,13 @@ type
       ## absolute or relative path wrt globbed dir
     depth*: int
       ## depth wrt globbed dir
+    epilogue*: bool
 
-iterator glob*(dir: string, relative = false, checkDir = true, includeRoot = false,
+iterator glob*(dir: string, relative = false, checkDir = true, includeRoot = false, includeEpilogue = false,
     follow: proc(entry: PathEntry): bool = nil,
     sortCmp: proc (x, y: PathEntrySub): int = nil,
     topFirst = true):
-    PathEntry {.closure, tags: [ReadDirEffect].} =
+    PathEntry {.tags: [ReadDirEffect].} =
   ## Recursively walks `dir` which must exist when checkDir=true (else raises `OSError`).
   ## Paths in `result.path` are relative to `dir` unless `relative=false`,
   ## `result.depth >= 1` is the tree depth relative to the root `dir` (at depth 0).
@@ -32,69 +33,53 @@ iterator glob*(dir: string, relative = false, checkDir = true, includeRoot = fal
   note:
   * a yieldFilter, regex match etc isn't needed because caller can filter at
   call site, without loss of generality, unlike `follow`; this simplifies the API.
-  * a closure iterator is used since we need multiple yield statements and it simplifies code.
-    In practice optimized performance drops by less than 2%, likely 0 when filesystem is not "hot".
 
   Future work:
-  * need to document
-  * add a `sort` option, which can be implemented efficiently only here, not at call site.
   * provide a way to do error reporting, which is tricky because iteration cannot be resumed
   * `walkDirRec` can be implemented in terms of this to avoid duplication,
     modulo some refactoring.
   ]#
-  echo()
-  var stack = @[(0, ".")]
+  var entry = PathEntry(depth: 0, path: ".")
+  entry.kind = if symlinkExists(dir): pcLinkToDir else: pcDir
+  var stack: seq[PathEntry]
+
   var checkDir = checkDir
-  var entry: PathEntry
+  if dirExists(dir):
+    stack.add entry
+  elif checkDir:
+    raise newException(OSError, "invalid root dir: " & dir)
+
   var dirsLevel: seq[PathEntrySub]
-  if not dirExists(dir):
-    if checkDir:
-      raise newException(OSError, "invalid root dir: " & dir)
-    else:
-      return
-
-  if includeRoot:
-    if symlinkExists(dir):
-      entry.kind = pcLinkToDir
-    else:
-      entry.kind = pcDir
-    entry.path = if relative: "." else: dir
-    normalizePath(entry.path)
-    entry.depth = 0
-    yield entry
-
-  template processEntry(): untyped =
-    let rel = d / p
-    entry.depth = depth + 1
-    entry.kind = k
-    if relative: entry.path = rel
-    else: entry.path = dir / rel
-    normalizePath(entry.path) # pending https://github.com/timotheecour/Nim/issues/343
-    if k in {pcDir, pcLinkToDir}:
-      if follow == nil or follow(entry): stack.add (depth + 1, rel)
-    entry
-
   while stack.len > 0:
-    let (depth, d) = stack.pop()
-    # checkDir is still needed here in first iteration because things could
-    # fail for reasons other than `not dirExists`.
+    let current = stack.pop()
+    # let current = stack.popFront()
+    entry.epilogue = current.epilogue
+    entry.depth = current.depth
+    entry.kind = current.kind
+    entry.path = if relative: current.path else: dir / current.path
+    normalizePath(entry.path) # pending https://github.com/timotheecour/Nim/issues/343
 
-    if sortCmp != nil:
-      dirsLevel.setLen 0
-    # echo "...: ", d
-    for k, p in walkDir(dir / d, relative = true, checkDir = checkDir):
-      if sortCmp != nil:
-        dirsLevel.add PathEntrySub(kind: k, path: p)
-      else:
-        yield processEntry()
-    if sortCmp != nil:
-      sort(dirsLevel, sortCmp)
-      for ai in dirsLevel:
-        let k = ai.kind
-        let p = ai.path
-        yield processEntry()
+    if includeRoot or current.depth > 0:
+      yield entry
 
-    checkDir = false
-      # We only check top-level dir, otherwise if a subdir is invalid (eg. wrong
-      # permissions), it'll abort iteration and there would be no way to
-      # continue iteration.
+    if current.kind in {pcDir, pcLinkToDir} and not current.epilogue:
+      if follow == nil or follow(current):
+        if sortCmp != nil:
+          dirsLevel.setLen 0
+        if includeEpilogue:
+          stack.add PathEntry(depth: current.depth, path: current.path, kind: current.kind, epilogue: true)
+        # checkDir is still needed here in first iteration because things could
+        # fail for reasons other than `not dirExists`.
+        for k, p in walkDir(dir / current.path, relative = true, checkDir = checkDir):
+          if sortCmp != nil:
+            dirsLevel.add PathEntrySub(kind: k, path: p)
+          else:
+            stack.add PathEntry(depth: current.depth + 1, path: current.path / p, kind: k)
+        checkDir = false
+          # We only check top-level dir, otherwise if a subdir is invalid (eg. wrong
+          # permissions), it'll abort iteration and there would be no way to resume iteration.
+        if sortCmp != nil:
+          sort(dirsLevel, sortCmp)
+          for i in countdown(dirsLevel.len-1, 0):
+            let ai = dirsLevel[i]
+            stack.add PathEntry(depth: current.depth + 1, path: current.path / ai.path, kind: ai.kind)

--- a/lib/std/globs.nim
+++ b/lib/std/globs.nim
@@ -4,33 +4,51 @@ type
   PathEntry* = object
     kind*: PathComponent
     path*: string
+      ## absolute or relative path wrt globbed dir
+    depth*: int
+      ## depth wrt globbed dir
 
 iterator glob*(dir: string, follow: proc(entry: PathEntry): bool = nil,
     relative = false, checkDir = true): PathEntry {.tags: [ReadDirEffect].} =
-  ## Improved `os.walkDirRec`.
+  ## Recursively walks `dir` which must exist when checkDir=true (else raises `OSError`).
+  ## Paths in `result.path` are relative to `dir` unless `relative=false`,
+  ## `result.depth >= 1` is the tree depth relative to the root `dir` (at depth 0).
+  ## if `follow != nil`, `glob` visits `entry` if `filter(entry) == true`.
+  ## This is more flexible than `os.walkDirRec`.
+  runnableExamples:
+    import os,sugar
+    if defined(nimGlobsEnableExample): # `if` intentional
+      # list hidden files of depth <= 2 + 1 in your home.
+      for e in glob(getHomeDir(), follow = a=>a.path.isHidden and a.depth <= 2):
+        if e.kind in {pcFile, pcLinkToFile}: echo e.path
   #[
-  note: a yieldFilter isn't needed because caller can filter at call site, without
-  loss of generality, unlike `follow`.
+  note: a yieldFilter, regex match etc isn't needed because caller can filter at
+  call site, without loss of generality, unlike `follow`; this simplifies the API.
 
   Future work:
   * need to document
+  * add `includeRoot = false` (ie, depth = 0) to optionally add the root dir;
+    this must be done while preserving a single `yield` to avoid code bloat.
   * add a `sort` option, which can be implemented efficiently only here, not at call site.
   * provide a way to do error reporting, which is tricky because iteration cannot be resumed
   * `walkDirRec` can be implemented in terms of this to avoid duplication,
-  modulo some refactoring.
+    modulo some refactoring.
   ]#
-  var stack = @["."]
+  var stack = @[(0, ".")]
   var checkDir = checkDir
   var entry: PathEntry
+  # if includeRoot:
   while stack.len > 0:
-    let d = stack.pop()
+    let (depth, d) = stack.pop()
     for k, p in walkDir(dir / d, relative = true, checkDir = checkDir):
       let rel = d / p
+      entry.depth = depth + 1
       entry.kind = k
       if relative: entry.path = rel
       else: entry.path = dir / rel
+      normalizePath(entry.path) # pending https://github.com/timotheecour/Nim/issues/343
       if k in {pcDir, pcLinkToDir}:
-        if follow == nil or follow(entry): stack.add rel
+        if follow == nil or follow(entry): stack.add (depth + 1, rel)
       yield entry
     checkDir = false
       # We only check top-level dir, otherwise if a subdir is invalid (eg. wrong

--- a/lib/std/globs.nim
+++ b/lib/std/globs.nim
@@ -9,7 +9,7 @@ type
       ## depth wrt globbed dir
 
 iterator glob*(dir: string, follow: proc(entry: PathEntry): bool = nil,
-    relative = false, checkDir = true): PathEntry {.tags: [ReadDirEffect].} =
+    relative = false, checkDir = true): PathEntry {.closure, tags: [ReadDirEffect].} =
   ## Recursively walks `dir` which must exist when checkDir=true (else raises `OSError`).
   ## Paths in `result.path` are relative to `dir` unless `relative=false`,
   ## `result.depth >= 1` is the tree depth relative to the root `dir` (at depth 0).

--- a/lib/std/globs.nim
+++ b/lib/std/globs.nim
@@ -17,7 +17,7 @@ iterator glob*(dir: string, follow: proc(entry: PathEntry): bool = nil,
   ## This is more flexible than `os.walkDirRec`.
   runnableExamples:
     import os,sugar
-    if defined(nimGlobsEnableExample): # `if` intentional
+    if false:
       # list hidden files of depth <= 2 + 1 in your home.
       for e in glob(getHomeDir(), follow = a=>a.path.isHidden and a.depth <= 2):
         if e.kind in {pcFile, pcLinkToFile}: echo e.path

--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -8,7 +8,8 @@ this module should be renamed to reflect its scope, eg to osutils.
 
 import std/[os,strutils,globs]
 
-{.deprecated: [walkDirRecFilter: glob].}
+# {.deprecated: [walkDirRecFilter: glob].}
+# export glob
 
 proc nativeToUnixPath*(path: string): string =
   # pending https://github.com/nim-lang/Nim/pull/13265

--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -1,45 +1,14 @@
 ##[
 unstable API, internal use only for now.
-this can eventually be moved to std/os and `walkDirRec` can be implemented in terms of this
-to avoid duplication
 ]##
 
-import std/[os,strutils]
+#[
+this module should be renamed to reflect its scope, eg to osutils.
+]#
 
-type
-  PathEntry* = object
-    kind*: PathComponent
-    path*: string
+import std/[os,strutils,globs]
 
-iterator walkDirRecFilter*(dir: string, follow: proc(entry: PathEntry): bool = nil,
-    relative = false, checkDir = true): PathEntry {.tags: [ReadDirEffect].} =
-  ## Improved `os.walkDirRec`.
-  #[
-  note: a yieldFilter isn't needed because caller can filter at call site, without
-  loss of generality, unlike `follow`.
-
-  Future work:
-  * need to document
-  * add a `sort` option, which can be implemented efficiently only here, not at call site.
-  * provide a way to do error reporting, which is tricky because iteration cannot be resumed
-  ]#
-  var stack = @["."]
-  var checkDir = checkDir
-  var entry: PathEntry
-  while stack.len > 0:
-    let d = stack.pop()
-    for k, p in walkDir(dir / d, relative = true, checkDir = checkDir):
-      let rel = d / p
-      entry.kind = k
-      if relative: entry.path = rel
-      else: entry.path = dir / rel
-      if k in {pcDir, pcLinkToDir}:
-        if follow == nil or follow(entry): stack.add rel
-      yield entry
-    checkDir = false
-      # We only check top-level dir, otherwise if a subdir is invalid (eg. wrong
-      # permissions), it'll abort iteration and there would be no way to
-      # continue iteration.
+{.deprecated: [walkDirRecFilter: glob].}
 
 proc nativeToUnixPath*(path: string): string =
   # pending https://github.com/nim-lang/Nim/pull/13265
@@ -47,8 +16,3 @@ proc nativeToUnixPath*(path: string): string =
   when DirSep == '\\':
     result = replace(path, '\\', '/')
   else: result = path
-
-when isMainModule:
-  import sugar
-  for a in walkDirRecFilter(".", follow = a=>a.path.lastPathPart notin ["nimcache", ".git", ".csources", "bin"]):
-    echo a

--- a/lib/std/private/osutils.nim
+++ b/lib/std/private/osutils.nim
@@ -2,10 +2,7 @@
 unstable API, internal use only for now.
 ]##
 
-import std/[os,strutils,globs]
-
-{.deprecated: [walkDirRecFilter: glob].}
-export glob
+import std/[os,strutils]
 
 proc nativeToUnixPath*(path: string): string =
   # pending https://github.com/nim-lang/Nim/pull/13265

--- a/lib/std/private/osutils.nim
+++ b/lib/std/private/osutils.nim
@@ -2,14 +2,10 @@
 unstable API, internal use only for now.
 ]##
 
-#[
-this module should be renamed to reflect its scope, eg to osutils.
-]#
-
 import std/[os,strutils,globs]
 
-# {.deprecated: [walkDirRecFilter: glob].}
-# export glob
+{.deprecated: [walkDirRecFilter: glob].}
+export glob
 
 proc nativeToUnixPath*(path: string): string =
   # pending https://github.com/nim-lang/Nim/pull/13265

--- a/testament/lib/stdtest/osutils.nim
+++ b/testament/lib/stdtest/osutils.nim
@@ -7,9 +7,9 @@ proc genTestPaths*(dir: string, paths: seq[string]) =
   for a in paths:
     doAssert not a.isAbsolute
     doAssert a.len > 0
-    let a = dir / a
+    let a2 = dir / a
     if a.endsWith("/"):
-      createDir(a)
+      createDir(a2)
     else:
-      createDir(a.parentDir)
-      writeFile(a, "")
+      createDir(a2.parentDir)
+      writeFile(a2, "")

--- a/testament/lib/stdtest/osutils.nim
+++ b/testament/lib/stdtest/osutils.nim
@@ -1,13 +1,15 @@
-import std/[os]
+import std/[os,strutils]
 
 proc genTestPaths*(dir: string, paths: seq[string]) =
   ## generates a filesystem rooted under `dir` from given relative `paths`.
   ## `paths` ending in `/` are treated as directories.
   # xxx use this in tos.nim
   for a in paths:
-    doAssert a.isRelativePath
+    doAssert not a.isAbsolute
+    doAssert a.len > 0
+    let a = dir / a
     if a.endsWith("/"):
       createDir(a)
     else:
       createDir(a.parentDir)
-      
+      writeFile(a, "")

--- a/testament/lib/stdtest/osutils.nim
+++ b/testament/lib/stdtest/osutils.nim
@@ -1,0 +1,13 @@
+import std/[os]
+
+proc genTestPaths*(dir: string, paths: seq[string]) =
+  ## generates a filesystem rooted under `dir` from given relative `paths`.
+  ## `paths` ending in `/` are treated as directories.
+  # xxx use this in tos.nim
+  for a in paths:
+    doAssert a.isRelativePath
+    if a.endsWith("/"):
+      createDir(a)
+    else:
+      createDir(a.parentDir)
+      

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -11,7 +11,7 @@ import std/[strformat,os,osproc,unittest]
 from std/sequtils import toSeq,mapIt
 from std/algorithm import sorted
 import stdtest/[specialpaths, unittest_light]
-from std/private/globs import nativeToUnixPath
+from std/private/osutils import nativeToUnixPath
 
 import "$lib/../compiler/nimpaths"
 

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -8,8 +8,9 @@ proc processAux[T](a: T): seq[string] =
 proc process[T](a: T): seq[string] =
   a.processAux.sorted
 
+const dir = buildDir/"D20201013T100140"
+
 block: # glob
-  const dir = buildDir/"D20201013T100140"
   defer: removeDir(dir)
   let paths = """
 d1/f1.txt
@@ -29,9 +30,6 @@ f5
     # filter by pcDir
     doAssert toSeq(glob(dir, relative = true))
       .filterIt(it.kind == pcDir).process == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
-  
-  const s = toSeq(glob(dir, relative = true)).filterIt(it.kind == pcDir).process
-  echo s
 
   block: # includeRoot
     doAssert toSeq(glob(dir, relative = true, includeRoot = true))
@@ -52,3 +50,12 @@ f5
   # includeEpilogue
   doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, includeEpilogue = true, includeRoot = true)).processAux == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1a", "d1/d1b", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/d1b/d1b1", "d1/d1b", "d1/f1.txt", "d1", "d2", "d2", "f5", "."]
 
+
+proc main()=
+  let s = toSeq(glob(dir, relative = true))
+
+when false:
+  #[
+  pending https://github.com/nim-lang/Nim/issues/15597 and https://github.com/nim-lang/Nim/issues/15595
+  ]#
+  static: main()

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -1,5 +1,18 @@
 import std/[sugar,globs,os,strutils,sequtils,algorithm]
+from std/private/globs as globsOld import nativeToUnixPath
 import stdtest/[specialpaths,osutils]
+
+# proc nativeToUnixPath*(path: string): string =
+#   # pending https://github.com/nim-lang/Nim/pull/13265
+#   doAssert not path.isAbsolute # not implemented here; absolute files need more care for the drive
+#   when DirSep == '\\':
+#     result = replace(path, '\\', '/')
+#   else: result = path
+
+# import timn/exp/taps
+
+proc process[T](a: T): seq[string] =
+  a.mapIt(it.path.nativeToUnixPath).sorted
 
 block: # glob
   let dir = buildDir/"D20201013T100140"
@@ -11,11 +24,15 @@ d1/d1a/f3
 d1/d1a/d1a1/
 d1/d1b/d1b1/f4
 d2/
+f5
 """.splitLines.filter(a=>a.len>0)
   genTestPaths(dir, paths)
   doAssert toSeq(glob(dir, follow = a=>a.path.lastPathPart != "d1b", relative = true))
-    .filterIt(it.kind == pcFile).mapIt(it.path).sorted == @["d1/d1a/f2.txt", "d1/d1a/f3", "d1/f1.txt"]
+    .filterIt(it.kind == pcFile).process == @["d1/d1a/f2.txt", "d1/d1a/f3", "d1/f1.txt", "f5"]
   doAssert toSeq(glob(dir, relative = true))
-    .filterIt(it.kind == pcDir).mapIt(it.path).sorted == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
+    .filterIt(it.kind == pcDir).process == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
+  doAssert toSeq(glob(dir, relative = true, includeRoot = true))
+    .filterIt(it.kind == pcDir).process == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
   doAssertRaises(OSError): discard toSeq(glob("nonexistant"))
+  doAssertRaises(OSError): discard toSeq(glob("f5"))
   doAssert toSeq(glob("nonexistant", checkDir = false)) == @[]

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -6,6 +6,7 @@ import timn/exp/taps
 
 proc processAux[T](a: T): seq[string] =
   a.mapIt(it.path.nativeToUnixPath)
+
 proc process[T](a: T): seq[string] =
   a.processAux.sorted
 
@@ -22,18 +23,30 @@ d2/
 f5
 """.splitLines.filter(a=>a.len>0)
   genTestPaths(dir, paths)
-  doAssert toSeq(glob(dir, follow = a=>a.path.lastPathPart != "d1b", relative = true))
-    .filterIt(it.kind == pcFile).process == @["d1/d1a/f2.txt", "d1/d1a/f3", "d1/f1.txt", "f5"]
-  doAssert toSeq(glob(dir, relative = true))
-    .filterIt(it.kind == pcDir).process == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
-  doAssert toSeq(glob(dir, relative = true, includeRoot = true))
-    .filterIt(it.kind == pcDir).process == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
-  doAssertRaises(OSError): discard toSeq(glob("nonexistant"))
-  doAssertRaises(OSError): discard toSeq(glob("f5"))
-  doAssert toSeq(glob("nonexistant", checkDir = false)) == @[]
 
+  block: # follow
+    # filter by pcFile
+    doAssert toSeq(glob(dir, follow = a=>a.path.lastPathPart != "d1b", relative = true))
+      .filterIt(it.kind == pcFile).process == @["d1/d1a/f2.txt", "d1/d1a/f3", "d1/f1.txt", "f5"]
+    # filter by pcDir
+    doAssert toSeq(glob(dir, relative = true))
+      .filterIt(it.kind == pcDir).process == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
+
+  block: # includeRoot
+    doAssert toSeq(glob(dir, relative = true, includeRoot = true))
+    .filterIt(it.kind == pcDir).process == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
+
+  block: # checkDir
+    doAssertRaises(OSError): discard toSeq(glob("nonexistant"))
+    doAssertRaises(OSError): discard toSeq(glob("f5"))
+    doAssert toSeq(glob("nonexistant", checkDir = false)) == @[]
+
+  # sortCmp
   proc mySort(a, b: PathEntrySub): int = cmp(a.path, b.path)
-  proc mySort2(a, b: PathEntrySub): int = -cmp(a.path, b.path)
-  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort2)).processAux == @["f5", "d2", "d1", "d1/f1.txt", "d1/d1b", "d1/d1a", "d1/d1a/f3", "d1/d1a/f2.txt", "d1/d1a/d1a1", "d1/d1b/d1b1", "d1/d1b/d1b1/f4"]
-  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort))
-    .processAux.tap == @["d1", "d2", "f5", "d1/d1a", "d1/d1b", "d1/f1.txt", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3"]
+  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort)).processAux == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1b", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/f1.txt", "d2", "f5"]
+
+  # gBfs
+  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, globMode = gBfs)).processAux == @["d1", "d2", "f5", "d1/d1a", "d1/d1b", "d1/f1.txt", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1b/d1b1", "d1/d1b/d1b1/f4"]
+
+  # includeEpilogue
+  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, includeEpilogue = true, includeRoot = true)).processAux.tap == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1a", "d1/d1b", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/d1b/d1b1", "d1/d1b", "d1/f1.txt", "d1", "d2", "d2", "f5", "."]

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -9,7 +9,7 @@ proc process[T](a: T): seq[string] =
   a.processAux.sorted
 
 block: # glob
-  let dir = buildDir/"D20201013T100140"
+  const dir = buildDir/"D20201013T100140"
   defer: removeDir(dir)
   let paths = """
 d1/f1.txt
@@ -29,6 +29,9 @@ f5
     # filter by pcDir
     doAssert toSeq(glob(dir, relative = true))
       .filterIt(it.kind == pcDir).process == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
+  
+  const s = toSeq(glob(dir, relative = true)).filterIt(it.kind == pcDir).process
+  echo s
 
   block: # includeRoot
     doAssert toSeq(glob(dir, relative = true, includeRoot = true))
@@ -48,3 +51,4 @@ f5
 
   # includeEpilogue
   doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, includeEpilogue = true, includeRoot = true)).processAux == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1a", "d1/d1b", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/d1b/d1b1", "d1/d1b", "d1/f1.txt", "d1", "d2", "d2", "f5", "."]
+

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -1,17 +1,21 @@
-import std/[sugar,globs,os,strutils]
-import stdtest/specialpaths
+import std/[sugar,globs,os,strutils,sequtils,algorithm]
+import stdtest/[specialpaths,osutils]
 
 block: # glob
   let dir = buildDir/"D20201013T100140"
   defer: removeDir(dir)
-  let files = """
+  let paths = """
 d1/f1.txt
-d1/d2/f2.txt
-d1/d2/f3.txt
-d1/d3/
-d4/
-""".splitLines
-  for 
-
-  for a in walkDirRecFilter(".", follow = a=>a.path.lastPathPart notin ["nimcache", ".git", ".csources", "bin"]):
-    echo a
+d1/d1a/f2.txt
+d1/d1a/f3
+d1/d1a/d1a1/
+d1/d1b/d1b1/f4
+d2/
+""".splitLines.filter(a=>a.len>0)
+  genTestPaths(dir, paths)
+  doAssert toSeq(glob(dir, follow = a=>a.path.lastPathPart != "d1b", relative = true))
+    .filterIt(it.kind == pcFile).mapIt(it.path).sorted == @["d1/d1a/f2.txt", "d1/d1a/f3", "d1/f1.txt"]
+  doAssert toSeq(glob(dir, relative = true))
+    .filterIt(it.kind == pcDir).mapIt(it.path).sorted == @["d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1b", "d1/d1b/d1b1", "d2"]
+  doAssertRaises(OSError): discard toSeq(glob("nonexistant"))
+  doAssert toSeq(glob("nonexistant", checkDir = false)) == @[]

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -2,8 +2,6 @@ import std/[sugar,globs,os,strutils,sequtils,algorithm]
 from std/private/osutils as osutils2 import nativeToUnixPath
 import stdtest/[specialpaths,osutils]
 
-import timn/exp/taps
-
 proc processAux[T](a: T): seq[string] =
   a.mapIt(it.path.nativeToUnixPath)
 
@@ -49,4 +47,4 @@ f5
   doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, globMode = gBfs)).processAux == @["d1", "d2", "f5", "d1/d1a", "d1/d1b", "d1/f1.txt", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1b/d1b1", "d1/d1b/d1b1/f4"]
 
   # includeEpilogue
-  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, includeEpilogue = true, includeRoot = true)).processAux.tap == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1a", "d1/d1b", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/d1b/d1b1", "d1/d1b", "d1/f1.txt", "d1", "d2", "d2", "f5", "."]
+  doAssert toSeq(glob(dir, relative = true, sortCmp = mySort, includeEpilogue = true, includeRoot = true)).processAux == @[".", "d1", "d1/d1a", "d1/d1a/d1a1", "d1/d1a/d1a1", "d1/d1a/f2.txt", "d1/d1a/f3", "d1/d1a", "d1/d1b", "d1/d1b/d1b1", "d1/d1b/d1b1/f4", "d1/d1b/d1b1", "d1/d1b", "d1/f1.txt", "d1", "d2", "d2", "f5", "."]

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -1,0 +1,17 @@
+import std/[sugar,globs,os,strutils]
+import stdtest/specialpaths
+
+block: # glob
+  let dir = buildDir/"D20201013T100140"
+  defer: removeDir(dir)
+  let files = """
+d1/f1.txt
+d1/d2/f2.txt
+d1/d2/f3.txt
+d1/d3/
+d4/
+""".splitLines
+  for 
+
+  for a in walkDirRecFilter(".", follow = a=>a.path.lastPathPart notin ["nimcache", ".git", ".csources", "bin"]):
+    echo a

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -1,7 +1,8 @@
 ## Part of 'koch' responsible for the documentation generation.
 
 import os, strutils, osproc, sets, pathnorm, pegs
-from std/private/globs import nativeToUnixPath, walkDirRecFilter, PathEntry
+from std/private/osutils import nativeToUnixPath
+from std/globs import globs, PathEntry
 import "../compiler/nimpaths"
 
 const
@@ -99,7 +100,7 @@ proc nimCompileFold*(desc, input: string, outputDir = "bin", mode = "c", options
   execFold(desc, cmd)
 
 proc getRst2html(): seq[string] =
-  for a in walkDirRecFilter("doc"):
+  for a in glob("doc"):
     let path = a.path
     if a.kind == pcFile and path.splitFile.ext == ".rst" and path.lastPathPart notin
         ["docs.rst", "nimfix.rst"]:
@@ -188,7 +189,7 @@ lib/system/widestrs.nim
 
   proc follow(a: PathEntry): bool =
     a.path.lastPathPart notin ["nimcache", "htmldocs", "includes", "deprecated", "genode"]
-  for entry in walkDirRecFilter("lib", follow = follow):
+  for entry in glob("lib", follow = follow):
     let a = entry.path
     if entry.kind != pcFile or a.splitFile.ext != ".nim" or
        (a.isRelativeTo("lib/system") and a.nativeToUnixPath notin goodSystem) or

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -2,7 +2,7 @@
 
 import os, strutils, osproc, sets, pathnorm, pegs
 from std/private/osutils import nativeToUnixPath
-from std/globs import globs, PathEntry
+from std/globs import glob, PathEntry
 import "../compiler/nimpaths"
 
 const


### PR DESCRIPTION
* BFS and DFS traversal
* optional callback to choose whether to recurse down a directory; this can make a large difference by skipping early rather than filter the yielded elements
* optional callback to sort immediate children of a directory; this allows the intersting property of iteration in global sorted order (both BFS and DFS) while only requiring O(n) memory where n = largest nb immediate children of any directory; we don't need to sort all (recursive) entries
* ~3X faster than unix `find` (not sure why); I tested on a dir with 500k recursive entries (filesystem was hot, ie after a coldstart)
* optional epilogue option: each dir is yielded both before all its children and right after, which simplifies aggregate processing, eg to generate aggregate statistics per directory (eg: recursive number of files rooted in each dir)
* see tests tests/stdlib/tglobs.nim

## links
* fixes https://github.com/nim-lang/RFCs/issues/261

## limitation
* it almost works in VM but is hitting https://github.com/nim-lang/Nim/issues/15595 (easy workaround) and https://github.com/nim-lang/Nim/issues/15597 (no easy workaround I'm aware of)