### PR TITLE
document that Nim executable must be included

### DIFF
--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -94,7 +94,7 @@ Example "template" **to edit** and write a Testament unittest:
 
     valgrind: false   # Can use Valgrind to check for memory leaks, or not (Linux 64Bit only).
 
-    cmd: "c -r $file" # Command the test should use to run.
+    cmd: "nim c -r $file" # Command the test should use to run.
 
     maxcodesize: 666  # Maximum generated temporary intermediate code file size for the test.
 


### PR DESCRIPTION
Nim tests already do this (e.g., [tprogmem.nim](https://github.com/nim-lang/Nim/blob/devel/tests/ccgbugs/tprogmem.nim)) so modifying [the relevant line](https://github.com/nim-lang/Nim/blob/9a110047cbe2826b1d4afe63e3a1f5a08422b73f/testament/specs.nim#L104) to
```nim
result = compilerPrefix & " " & s.cmd
```
line would not have been easy.