### PR TITLE
Nimgrep improvements 2

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -262,7 +262,8 @@ proc debuggerTests(r: var TResults, cat: Category, options: string) =
   if fileExists("tools/nimgrep.nim"):
     var t = makeTest("tools/nimgrep", options & " --debugger:on", cat)
     t.spec.action = actionCompile
-    # force target to C because of MacOS 10.15 clang++ bug (see #15612)
+    # force target to C because of MacOS 10.15 SDK headers bug
+    # https://github.com/nim-lang/Nim/pull/15612#issuecomment-712471879
     t.spec.targets = { targetC }
     testSpec r, t
 

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -262,6 +262,8 @@ proc debuggerTests(r: var TResults, cat: Category, options: string) =
   if fileExists("tools/nimgrep.nim"):
     var t = makeTest("tools/nimgrep", options & " --debugger:on", cat)
     t.spec.action = actionCompile
+    # force target to C because of MacOS 10.15 clang++ bug (see #15612)
+    t.spec.targets = { targetC }
     testSpec r, t
 
 # ------------------------- JS tests ------------------------------------------

--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -1196,7 +1196,7 @@ if searchOpt.pattern.len == 0:
   reportError("empty pattern was given")
 else:
   if paths.len == 0:
-    paths.add(os.getCurrentDir())
+    paths.add(".")
   if nWorkers == 0:
     run1Thread()
   else:

--- a/tools/nimgrep.nim.cfg
+++ b/tools/nimgrep.nim.cfg
@@ -1,2 +1,2 @@
 # using markandsweep because of bug https://github.com/nim-lang/Nim/issues/14138
---threads:on --gc:markandsweep
+--threads:on --gc:orc

--- a/tools/nimgrep.nim.cfg
+++ b/tools/nimgrep.nim.cfg
@@ -1,2 +1,4 @@
-# using markandsweep because of bug https://github.com/nim-lang/Nim/issues/14138
+# don't use --gc:refc because of bug
+# https://github.com/nim-lang/Nim/issues/14138 .
+# --gc:orc and --gc:markandsweep work well.
 --threads:on --gc:orc

--- a/tools/nimgrep.nim.cfg
+++ b/tools/nimgrep.nim.cfg
@@ -1,5 +1,2 @@
-# The GC is stable enough now:
-
-#--gc:none
-
-
+# using markandsweep because of bug https://github.com/nim-lang/Nim/issues/14138
+--threads:on --gc:markandsweep


### PR DESCRIPTION
I'm using nimgrep a lot in my daily job, and I added a few useful things.

* Speed up search by using multiple threads (options --nWorkers:N, -n:N)
* UPDATED: implement pipe mode `-`, which allows for using nimgrep in Unix filters.
* Ability to limit output by cropping lines at a fixed number of 8-bit characters (--limit:N, -m:N) or by terminal width (--fit). See example on picture below. It's useful when dealing with binary files with long lines or when printing on small screens, since line breaks mess up visual perception.
* Better displaying of non-printable characters by substituted ASCII characters with colors (--onlyAscii, -o). It's useful for displaying binary files, especially with the limit options above.
* Ability to detect binary files and exclude them from the search (--bin:no = --text, -t) or include only them (--bin:only)
* Add --sortTime option to be able e.g. search starting from recently changed files — when you remember that what you are looking for is recent
* The order in which files appear is fixed now: it's alphabetic sorting by default (unless --sortTime is specified). I want the ability to expect that files will appear in stable order any time to memorize where should I look to; while Linux directory walking yields you files and directories non-deterministically. It's especially important with threads that would mess up the order if they were given the chance. (However this increases memory consumption in multi-thread mode since search results need to be stored in memory until contiguous sequence of files is received from thread workers)
* Add --match and --noMatch option. Useful when you want to search only specific files based on presence of string/match in them, e.g. an appropriate import statement, or copyright year, or language extensions/features/versions for such languages...
* Proper printing of TABs — useful e.g. when searching through some C code bases like linux kernel
* Add --count option for displaying only number of matches in files
* add --includeDir option for limiting search only to specific directories (e.g. '.*tests' if your project have such a convention for unit tests)
* UPDATED: (probably breaking) replacement mode now requires specifying all 3 positional arguments, since it seems too dangerous that something will be omitted and works not as expecting, especially considering that --confirm is not default. Once playing with --replace I made a mistake of forgetting specify any replacement, and nimgrep accepted it as an empty string "", basically deleting all patterns. Targets also should be specified explicitly: current dir "." is too dangerous for a default setting.
* (possibly a breaking change?) if no directory is specified then "." is used instead of the fullpath, which was redundant IMHO
* Peg can be used for all patterns now (including --includeFile, --match, etc)
* fix performance regression introduced in nimgrep improvements #12779, which slowed down search by 10—15 %.
* switch to --gc:orc
* miscellaneous: better error reporting. #13950 is fixed in another way (CC @genotrance). Fix #15318 (CC @juancarlospaco).
* UPDATED: --help is reworked and better structured.

![image](https://user-images.githubusercontent.com/1299583/96348417-2ae77600-10b1-11eb-8d88-f3582d6a444d.png)

A note on thread performance: the speed up with regex is not very great, it's limited to factor 2.5—3. Basically after reaching -n:3 or -n:4 threads performance stops to increase. I debugged that with gdb, it seems that the program with large number of threads (e.g. -n:20) spends almost all its time in syscalls read, that is reading the files into the process memory. I don't know whether it's gotten memory-bound or Linux is unable to deliver file contents because of some internal locks. When using (slow) Peg pattern, performance increases nearly linearly: I got speed-up 5.5—5.8 on my 6-core Ryzen 3600 with -n:6 and -n:12.

With --gc:orc speed is about the same as with --gc:markandsweep. But with orc nimgrep consumes ~2 times less memory in multi-threaded mode: 170 MB with -n:6 on Nim repository, while it is 370 MB with --gc:markandsweep. (Measure by Linux utility /usr/bin/time --verbose).