### PR TITLE
Fix FreeBSD build failures

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,25 +1,19 @@
 # see https://man.sr.ht/builds.sr.ht/compatibility.md#freebsd
 image: freebsd/latest
-
-# packages:
-# - databases/sqlite3
-# - devel/boehm-gc-threaded
-# - devel/pcre
-# - devel/sdl20
-# - devel/sfml
-# - www/node
-# - devel/gmake
-# - devel/git
+packages:
+- databases/sqlite3
+- devel/boehm-gc-threaded
+- devel/pcre
+- devel/sdl20
+- devel/sfml
+- www/node
+- devel/gmake
 sources:
 - https://github.com/nim-lang/Nim
 environment:
   CC: /usr/bin/clang
 tasks:
 - setup: |
-    # workaround https://github.com/timotheecour/Nim/issues/76
-    sudo pkg update -q -f
-    sudo pkg install -y -q databases/sqlite3 devel/boehm-gc-threaded devel/pcre \
-      devel/sdl20 devel/sfml www/node devel/gmake devel/git
     cd Nim
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)


### PR DESCRIPTION
The FreeBSD CI is/was failing, due to a conflict with installing Git.

Git is guaranteed to be in the base image, so this removes that package from the package list. It also reverts back to the built-in `packages` tag since it's officially supported.

Should the build fail in the future, the best place to go is the #sr.ht channel on freenode.