### PR TITLE
Fix LTO issues on OSX by only passing -fuse-ld=lld on windows

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -328,32 +328,33 @@ tcc.options.always = "-w"
   --define:nimOldShiftRight
 @end
 
-@if lto or lto_incremental:
+@if nim_lto or nim_lto_incremental:
   @if lto_incremental:
    vcc.options.always%= "${vcc.options.always} /GL /Gw /Gy"
    vcc.cpp.options.always%= "${vcc.cpp.options.always} /GL /Gw /Gy"
-   vcc.options.linker %= "${vcc.options.linker} /link /LTCG:incremental"
-   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /link /LTCG:incremental"
+   vcc.options.linker %= "${vcc.options.linker} /LTCG:incremental"
+   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /LTCG:incremental"
   @else:
    vcc.options.always%= "${vcc.options.always} /GL"
    vcc.cpp.options.always%= "${vcc.cpp.options.always} /GL"
-   vcc.options.linker %= "${vcc.options.linker} /link /LTCG"
-   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /link /LTCG"
+   vcc.options.linker %= "${vcc.options.linker} /LTCG"
+   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /LTCG"
   @end
   clang_cl.options.always%= "${clang_cl.options.always} -flto"
-  clang_cl.cpp.options.always%= "${clang.cpp.options.always} -flto"
+  clang_cl.cpp.options.always%= "${clang_cl.cpp.options.always} -flto"
   clang.options.always%= "${clang.options.always} -flto"
   clang.cpp.options.always%= "${clang.cpp.options.always} -flto"
   icl.options.always %= "${icl.options.always} /Qipo"
   icl.cpp.options.always %= "${icl.cpp.options.always} /Qipo"
   gcc.options.always %= "${gcc.options.always} -flto"
   gcc.cpp.options.always %= "${gcc.cpp.options.always} -flto"
-  clang.options.linker %= "${clang.options.linker} -fuse-ld=lld -flto"
-  clang.cpp.options.linker %= "${clang.cpp.options.linker} -fuse-ld=lld -flto"
-  gcc.options.linker %= "${gcc.options.linker} -flto"
-  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -flto"
+  @if windows:
+      clang.options.linker %= "${clang.options.linker} -fuse-ld=lld"
+      clang.cpp.options.linker %= "${clang.cpp.options.linker} -fuse-ld=lld"
+  @end
 @end
-@if strip:
+
+@if strip_debug_info:
   gcc.options.linker %= "${gcc.options.linker} -s"
   gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -s"
   clang.options.linker %= "${clang.options.linker} -s"


### PR DESCRIPTION
Fixes #15578 
I can't be completely sure that it will work because I don't have aMack for testing.
This PR also renames -d:lto to -d:nim_lto and -d:strip to -d:strip_debug_info