### PR TITLE
add Source+Edit links on top of every docgend file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 
 ## Compiler changes
 add `--declaredlocs` to show symbol declaration location in messages
+* Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given
 
 
 ## Tool changes

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -396,6 +396,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   var
     key, val: string
   case switch.normalize
+  of "input", "i": # PRTEMP
+    expectArg(conf, switch, arg, pass, info)
   of "path", "p":
     expectArg(conf, switch, arg, pass, info)
     for path in nimbleSubs(conf, arg):

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1241,7 +1241,7 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
   content = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, bodyname), ["title",
       "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "theindexhref", "body_toc_groupsection", "seeSrc"],
       [title.rope, toc, d.modDesc, rope(getDateStr()),
-      rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile..AbsoluteFile, theindexFname.RelativeFile), groupsection.rope, seeSrcRope])
+      rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile.AbsoluteFile, theindexFname.RelativeFile), groupsection.rope, seeSrcRope])
   if optCompileOnly notin d.conf.globalOptions:
     # XXX what is this hack doing here? 'optCompileOnly' means raw output!?
     code = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.file"), [

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -777,6 +777,28 @@ type DocFlags = enum
   kDefault
   kForceExport
 
+proc genSeeSrcRope(d: PDoc, path: string, line: int): Rope=
+  var seeSrcRope: Rope = nil
+  let docItemSeeSrc = getConfigVar(d.conf, "doc.item.seesrc")
+  if docItemSeeSrc.len > 0:
+    let path = relativeTo(AbsoluteFile path, AbsoluteDir getCurrentDir(), '/')
+    when false:
+      let cwd = canonicalizePath(d.conf, getCurrentDir())
+      var path = path
+      if path.startsWith(cwd):
+        path = path[cwd.len+1..^1].replace('\\', '/')
+    let gitUrl = getConfigVar(d.conf, "git.url")
+    if gitUrl.len > 0:
+      let defaultBranch =
+        if NimPatch mod 2 == 1: "devel"
+        else: "version-$1-$2" % [$NimMajor, $NimMinor]
+      let commit = getConfigVar(d.conf, "git.commit", defaultBranch)
+      let develBranch = getConfigVar(d.conf, "git.devel", "devel")
+      dispA(d.conf, seeSrcRope, "$1", "", [ropeFormatNamedVars(d.conf, docItemSeeSrc,
+          ["path", "line", "url", "commit", "devel"], [rope path.string,
+          rope($line), rope gitUrl, rope commit, rope develBranch])])
+  return seeSrcRope
+
 proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   if (docFlags != kForceExport) and not isVisible(d, nameNode): return
   let
@@ -822,26 +844,7 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   nodeToHighlightedHtml(d, n, result, {renderNoBody, renderNoComments,
     renderDocComments, renderSyms}, symbolOrIdEncRope)
 
-  var seeSrcRope: Rope = nil
-  let docItemSeeSrc = getConfigVar(d.conf, "doc.item.seesrc")
-  if docItemSeeSrc.len > 0:
-    let path = relativeTo(AbsoluteFile toFullPath(d.conf, n.info), AbsoluteDir getCurrentDir(), '/')
-    when false:
-      let cwd = canonicalizePath(d.conf, getCurrentDir())
-      var path = toFullPath(d.conf, n.info)
-      if path.startsWith(cwd):
-        path = path[cwd.len+1..^1].replace('\\', '/')
-    let gitUrl = getConfigVar(d.conf, "git.url")
-    if gitUrl.len > 0:
-      let defaultBranch =
-        if NimPatch mod 2 == 1: "devel"
-        else: "version-$1-$2" % [$NimMajor, $NimMinor]
-      let commit = getConfigVar(d.conf, "git.commit", defaultBranch)
-      let develBranch = getConfigVar(d.conf, "git.devel", "devel")
-      dispA(d.conf, seeSrcRope, "$1", "", [ropeFormatNamedVars(d.conf, docItemSeeSrc,
-          ["path", "line", "url", "commit", "devel"], [rope path.string,
-          rope($n.info.line), rope gitUrl, rope commit, rope develBranch])])
-
+  let seeSrcRope = genSeeSrcRope(d, toFullPath(d.conf, n.info), n.info.line.int)
   d.section[k].add(ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.item"),
     ["name", "header", "desc", "itemID", "header_plain", "itemSym",
       "itemSymOrID", "itemSymEnc", "itemSymOrIDEnc", "seeSrc", "deprecationMsg"],
@@ -1234,10 +1237,11 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
                    "doc.body_toc_group"
                  elif d.hasToc: "doc.body_toc"
                  else: "doc.body_no_toc"
+  let seeSrcRope = genSeeSrcRope(d, d.filename, 1)
   content = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, bodyname), ["title",
-      "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "theindexhref", "body_toc_groupsection"],
+      "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "theindexhref", "body_toc_groupsection", "seeSrc"],
       [title.rope, toc, d.modDesc, rope(getDateStr()),
-      rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile.AbsoluteFile, theindexFname.RelativeFile), groupsection.rope])
+      rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile..AbsoluteFile, theindexFname.RelativeFile), groupsection.rope, seeSrcRope])
   if optCompileOnly notin d.conf.globalOptions:
     # XXX what is this hack doing here? 'optCompileOnly' means raw output!?
     code = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.file"), [

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -777,8 +777,7 @@ type DocFlags = enum
   kDefault
   kForceExport
 
-proc genSeeSrcRope(d: PDoc, path: string, line: int): Rope=
-  var seeSrcRope: Rope = nil
+proc genSeeSrcRope(d: PDoc, path: string, line: int): Rope =
   let docItemSeeSrc = getConfigVar(d.conf, "doc.item.seesrc")
   if docItemSeeSrc.len > 0:
     let path = relativeTo(AbsoluteFile path, AbsoluteDir getCurrentDir(), '/')
@@ -794,10 +793,9 @@ proc genSeeSrcRope(d: PDoc, path: string, line: int): Rope=
         else: "version-$1-$2" % [$NimMajor, $NimMinor]
       let commit = getConfigVar(d.conf, "git.commit", defaultBranch)
       let develBranch = getConfigVar(d.conf, "git.devel", "devel")
-      dispA(d.conf, seeSrcRope, "$1", "", [ropeFormatNamedVars(d.conf, docItemSeeSrc,
+      dispA(d.conf, result, "$1", "", [ropeFormatNamedVars(d.conf, docItemSeeSrc,
           ["path", "line", "url", "commit", "devel"], [rope path.string,
           rope($line), rope gitUrl, rope commit, rope develBranch])])
-  return seeSrcRope
 
 proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   if (docFlags != kForceExport) and not isVisible(d, nameNode): return

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -187,6 +187,7 @@ doc.body_toc_group = """
   </div>
   $tableofcontents
   </div>
+  $seeSrc
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   $deprecationMsg

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -80,7 +80,7 @@ doc.item.tocTable = """
 doc.item.seesrc = """&nbsp;&nbsp;<a
 href="${url}/tree/${commit}/${path}#L${line}"
 class="link-seesrc" target="_blank">Source</a>
-<a href="${url}/edit/${devel}/${path}#L${line}" class="link-seesrc" target="_blank" >Edit</a>
+&nbsp;&nbsp;<a href="${url}/edit/${devel}/${path}#L${line}" class="link-seesrc" target="_blank" >Edit</a>
 """
 
 doc.deprecationmsg = """

--- a/nimdoc/test_out_index_dot_html/expected/index.html
+++ b/nimdoc/test_out_index_dot_html/expected/index.html
@@ -106,6 +106,7 @@ function main() {
 </ul>
 
   </div>
+  
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.html
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.html
@@ -132,6 +132,7 @@ function main() {
 </ul>
 
   </div>
+  
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -358,6 +358,7 @@ function main() {
 </ul>
 
   </div>
+  
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/9296
refs https://github.com/nim-lang/Nim/issues/15616#issuecomment-711424441

this PR lowers barrier to write simple PR's as well as make it easier to go to source code.

after PR, we get this:

for tut2.rst:
![image](https://user-images.githubusercontent.com/2194784/96517652-2db3a980-121e-11eb-87ac-25dd0981ce25.png)

for macros.nim:

![image](https://user-images.githubusercontent.com/2194784/96517757-60f63880-121e-11eb-8fca-734dae9215ee.png)


## CI failure unrelated: https://github.com/citycide/glob/issues/49

## future work:
handle include files (both rst includes and nim includes) so that they also show Source/Edit links => https://github.com/nim-lang/RFCs/issues/328