### PR TITLE
$(uint|uint64) now works with nimscript

### DIFF
--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -19,6 +19,26 @@ when defined(js):
       ## 64bit ints.
       # pending https://github.com/nim-lang/RFCs/issues/187
       $(cast[int](x))
+else:
+  proc `$`*(x: uint64): string {.noSideEffect, raises: [].} =
+    ## The stringify operator for an unsigned integer argument. Returns `x`
+    ## converted to a decimal string.
+    if x == 0:
+      result = "0"
+    else:
+      result = newString(60)
+      var i = 0
+      var n = x
+      while n != 0:
+        let nn = n div 10'u64
+        result[i] = char(n - 10'u64 * nn + ord('0'))
+        inc i
+        n = nn
+      result.setLen i
+
+      let half = i div 2
+      # Reverse
+      for t in 0 .. half-1: swap(result[t], result[i-t-1])
 
 proc `$`*(x: int64): string {.magic: "Int64ToStr", noSideEffect.}
   ## The stringify operator for an integer argument. Returns `x`

--- a/lib/system/mm/go.nim
+++ b/lib/system/mm/go.nim
@@ -35,8 +35,6 @@ proc goMalloc(size: uint): pointer {.importc: "go_malloc", dynlib: goLib.}
 proc goSetFinalizer(obj: pointer, f: pointer) {.importc: "set_finalizer", codegenDecl:"$1 $2$3 __asm__ (\"main.Set_finalizer\");\n$1 $2$3", dynlib: goLib.}
 proc writebarrierptr(dest: PPointer, src: pointer) {.importc: "writebarrierptr", codegenDecl:"$1 $2$3 __asm__ (\"main.Atomic_store_pointer\");\n$1 $2$3", dynlib: goLib.}
 
-proc `$`*(x: uint64): string {.noSideEffect, raises: [].}
-
 proc GC_getStatistics(): string =
   var mstats = goMemStats()
   result = "[GC] total allocated memory: " & $(mstats.total_alloc) & "\n" &

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -283,26 +283,6 @@ proc nimCharToStr(x: char): string {.compilerRtl.} =
   result = newString(1)
   result[0] = x
 
-proc `$`*(x: uint64): string {.noSideEffect, raises: [].} =
-  ## The stringify operator for an unsigned integer argument. Returns `x`
-  ## converted to a decimal string.
-  if x == 0:
-    result = "0"
-  else:
-    result = newString(60)
-    var i = 0
-    var n = x
-    while n != 0:
-      let nn = n div 10'u64
-      result[i] = char(n - 10'u64 * nn + ord('0'))
-      inc i
-      n = nn
-    result.setLen i
-
-    let half = i div 2
-    # Reverse
-    for t in 0 .. half-1: swap(result[t], result[i-t-1])
-
 when defined(gcDestructors):
   proc GC_getStatistics*(): string =
     result = "[GC] total memory: "

--- a/tests/test_nimscript.nims
+++ b/tests/test_nimscript.nims
@@ -73,6 +73,9 @@ echo "Nimscript imports are successful."
 
 block:
   doAssert "./foo//./bar/".normalizedPath == "foo/bar".unixToNativePath
+block:
+  doAssert $3'u == "3"
+  doAssert $3'u64 == "3"
 
 block: # #14142
   discard dirExists("/usr")


### PR DESCRIPTION
* `$(uint|uint64)` now works with nimscript
* more logical organization, moving $ where it belongs