### PR TITLE
new {.allowMissingCases.} pragma to allow growing enums

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -295,6 +295,7 @@ type
     sfUsedInFinallyOrExcept  # symbol is used inside an 'except' or 'finally'
     sfSingleUsedTemp  # For temporaries that we know will only be used once
     sfNoalias         # 'noalias' annotation, means C's 'restrict'
+    sfAllowMissingCases  # issue warnMissingCases instead of error
 
   TSymFlags* = set[TSymFlag]
 

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -56,6 +56,7 @@ type
     warnInconsistentSpacing, warnCaseTransition, warnCycleCreated,
     warnObservableStores,
     warnUser,
+    warnMissingCases,
     hintSuccess, hintSuccessX, hintCC,
     hintLineTooLong, hintXDeclaredButNotUsed,
     hintXCannotRaiseY,
@@ -126,6 +127,7 @@ const
     warnCycleCreated: "$1",
     warnObservableStores: "observable stores to '$1'",
     warnUser: "$1",
+    warnMissingCases: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`
     hintSuccessX: "${loc} lines; ${sec}s; $mem; $build build; proj: $project; out: $output",
@@ -177,7 +179,7 @@ const
     "IndexCheck", "GcUnsafe", "GcUnsafe2", "Uninit",
     "GcMem", "Destructor", "LockLevel", "ResultShadowed",
     "Spacing", "CaseTransition", "CycleCreated",
-    "ObservableStores", "User"]
+    "ObservableStores", "User", "MissingCases"]
 
   HintsToStr* = [
     "Success", "SuccessX", "CC", "LineTooLong",

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -63,7 +63,7 @@ const
     wPure, wHeader, wCompilerProc, wCore, wFinal, wSize, wShallow,
     wIncompleteStruct, wCompleteStruct, wByCopy, wByRef,
     wInheritable, wGensym, wInject, wRequiresInit, wUnchecked, wUnion, wPacked,
-    wBorrow, wGcSafe, wPartial, wExplain, wPackage}
+    wBorrow, wGcSafe, wPartial, wExplain, wPackage, wAllowMissingCases}
   fieldPragmas* = declPragmas + {
     wGuard, wBitsize, wCursor, wRequiresInit, wNoalias} - {wExportNims, wNodecl} # why exclude these?
   varPragmas* = declPragmas + {wVolatile, wRegister, wThreadVar,
@@ -875,6 +875,12 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         if sym != nil:
           if k == wPure and sym.kind in routineKinds: invalidPragma(c, it)
           else: incl(sym.flags, sfPure)
+      of wAllowMissingCases:
+        # let s = expectStrLit(c, it)
+        noVal(c, it) # TODO: allow allowMissingCases:false
+        if sym != nil:
+          incl(sym.flags, sfAllowMissingCases)
+        else: localError(c.config, it.info, "expected a `sym`")
       of wVolatile:
         noVal(c, it)
         incl(sym.flags, sfVolatile)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -701,9 +701,13 @@ proc semRecordCase(c: PContext, n: PNode, check: var IntSet, pos: var int,
     delSon(b, b.len - 1)
     semRecordNodeAux(c, lastSon(n[i]), check, pos, b, rectype, hasCaseFields = true)
   if chckCovered and covered != toCover(c, a[0].typ):
-    if a[0].typ.skipTypes(abstractRange).kind == tyEnum:
-      localError(c.config, a.info, "not all cases are covered; missing: $1" %
-                 formatMissingEnums(c, a))
+    let typ = a[0].typ.skipTypes(abstractRange)
+    if typ.kind == tyEnum:
+      template msg: untyped = "not all cases are covered; missing: $1" % formatMissingEnums(c, a)
+      if sfAllowMissingCases in typ.sym.flags:
+         message(c.config, a.info, warnMissingCases, msg())
+      else:
+        localError(c.config, a.info, msg())
     else:
       localError(c.config, a.info, "not all cases are covered")
   father.add a

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -86,7 +86,7 @@ type
     wStdIn, wStdOut, wStdErr,
 
     wInOut, wByCopy, wByRef, wOneWay,
-    wBitsize
+    wBitsize, wAllowMissingCases
 
   TSpecialWords* = set[TSpecialWord]
 
@@ -175,7 +175,7 @@ const
     "stdin", "stdout", "stderr",
 
     "inout", "bycopy", "byref", "oneway",
-    "bitsize"
+    "bitsize", "allowMissingCases"
     ]
 
 proc findStr*(a: openArray[string], s: string): int =

--- a/tests/casestmt/tincompletecaseobject.nim
+++ b/tests/casestmt/tincompletecaseobject.nim
@@ -1,10 +1,33 @@
 discard """
+nimout: '''
+tincompletecaseobject.nim(19, 3) Warning: not all cases are covered; missing: {f2} [MissingCases]
+tincompletecaseobject.nim(24, 5) Warning: not all cases are covered; missing: {f2} [MissingCases]
+'''
 errormsg: '''
 not all cases are covered; missing: {nnkComesFrom, nnkDotCall, nnkHiddenCallConv, nnkVarTuple, nnkCurlyExpr, nnkRange, nnkCheckedFieldExpr, nnkDerefExpr, nnkElifExpr, nnkElseExpr, nnkLambda, nnkDo, nnkBind, nnkClosedSymChoice, nnkHiddenSubConv, nnkConv, nnkStaticExpr, nnkAddr, nnkHiddenAddr, nnkHiddenDeref, nnkObjDownConv, nnkObjUpConv, nnkChckRangeF, nnkChckRange64, nnkChckRange, nnkStringToCString, nnkCStringToString, nnkFastAsgn, nnkGenericParams, nnkFormalParams, nnkOfInherit, nnkImportAs, nnkConverterDef, nnkMacroDef, nnkTemplateDef, nnkIteratorDef, nnkOfBranch, nnkElifBranch, nnkExceptBranch, nnkElse, nnkAsmStmt, nnkTypeDef, nnkFinally, nnkContinueStmt, nnkImportStmt, nnkImportExceptStmt, nnkExportStmt, nnkExportExceptStmt, nnkFromStmt, nnkIncludeStmt, nnkUsingStmt, nnkBlockExpr, nnkStmtListType, nnkBlockType, nnkWith, nnkWithout, nnkTypeOfExpr, nnkObjectTy, nnkTupleTy, nnkTupleClassTy, nnkTypeClassTy, nnkStaticTy, nnkRecList, nnkRecCase, nnkRecWhen, nnkVarTy, nnkConstTy, nnkMutableTy, nnkDistinctTy, nnkProcTy, nnkIteratorTy, nnkSharedTy, nnkEnumTy, nnkEnumFieldDef, nnkArglist, nnkPattern, nnkReturnToken, nnkClosure, nnkGotoState, nnkState, nnkBreakState, nnkFuncDef, nnkTupleConstr}
 '''
 """
 
 # this isn't imported from macros.nim to make it robust against possible changes in the ast.
+
+block:
+  type Foo {.allowMissingCases.} = enum
+    f0
+    f1
+    f2
+  var f: Foo
+  case f
+  of f0: discard
+  of f1: discard
+
+  type Bar = object
+    case k: Foo
+    of f0:
+      v0: string
+    of f1:
+      v1: string
+
+  var b: Bar
 
 type
   NimNodeKind* = enum


### PR DESCRIPTION
use case: minimize impact of PR's like https://github.com/nim-lang/Nim/pull/15545 that extend existing enum's (refs https://github.com/nim-lang/Nim/pull/15545#issuecomment-712513813)

No solution is 100% foolproof (it's a hard problem) but this one is particularly simple by avoiding to litter the code with `when: ... else` everywhere which would make the code hard to maintain.
Client code will get a warning with `-d:workaround15545` (which could be localized in `{.push warningAsError[AllowMissingCases].} {.pop.}` sections) to help them migrate.

So long code doesn't generate enums with added enum members (eg `JNumber`, `JUint` in that PR example), most existing code would continue to work.

```nim
when defined(workaround15545):
  {.pragma: workaround15545, allowMissingCases .}
else:
  {.pragma: workaround15545 .}

type
  JsonNodeKind* {.workaround15545.} = enum ## possible JSON node types
    JNull,
    JBool,
    JInt,
    JFloat,
    JString,
    JObject,
    JArray
```
