### PR TITLE
fix #12150 C++ free functions are now supported using new `importcpp:"!$1"` syntax

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -206,6 +206,9 @@ provided by the operating system.
 - The `cstring` doesn't support `[]=` operator in JS backend.
 
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
+- `importcpp` procs now support free functions via `!` prefix:
+`proc freeFn(a: cint) {.importcpp: "!$1".}` maps to `void freeFn(int)`.
+likewise with `importcpp: "!freeFn"`.
 
 - `typetraits.distinctBase` now is identity instead of error for non distinct types.
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -298,6 +298,9 @@ type
     sfUsedInFinallyOrExcept  # symbol is used inside an 'except' or 'finally'
     sfSingleUsedTemp  # For temporaries that we know will only be used once
     sfNoalias         # 'noalias' annotation, means C's 'restrict'
+    sfCompileToCpp
+      # skModule: compile the module as C++ code
+      # skType, skProc: C++ symbol
 
   TSymFlags* = set[TSymFlag]
 
@@ -321,7 +324,6 @@ const
   sfReorder* = sfForward
     # reordering pass is enabled
 
-  sfCompileToCpp* = sfInfixCall       # compile the module as C++ code
   sfCompileToObjc* = sfNamedParamCall # compile the module as Objective-C code
   sfExperimental* = sfOverriden       # module uses the .experimental switch
   sfGoto* = sfOverriden               # var is used for 'goto' code generation
@@ -1945,7 +1947,7 @@ proc canRaiseConservative*(fn: PNode): bool =
 
 proc canRaise*(fn: PNode): bool =
   if fn.kind == nkSym and (fn.sym.magic notin magicsThatCanRaise or
-      {sfImportc, sfInfixCall} * fn.sym.flags == {sfImportc} or
+      {sfImportc, sfCompileToCpp} * fn.sym.flags == {sfImportc} or
       sfGeneratedOp in fn.sym.flags):
     result = false
   elif fn.kind == nkSym and fn.sym.magic == mEcho:

--- a/compiler/ccgcalls.nim
+++ b/compiler/ccgcalls.nim
@@ -281,7 +281,7 @@ proc genArg(p: BProc, n: PNode, param: PSym; call: PNode, needsTmp = false): Rop
     # means '*T'. See posix.nim for lots of examples that do that in the wild.
     let callee = call[0]
     if callee.kind == nkSym and
-        {sfImportc, sfInfixCall, sfCompilerProc} * callee.sym.flags == {sfImportc} and
+        {sfImportc, sfCompileToCpp, sfCompilerProc} * callee.sym.flags == {sfImportc} and
         {lfHeader, lfNoDecl} * callee.sym.loc.flags != {}:
       result = addrLoc(p.config, a)
     else:

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -201,8 +201,8 @@ proc isImportedType(t: PType): bool =
 
 proc isImportedCppType(t: PType): bool =
   let x = t.skipTypes(irrelevantForBackend)
-  result = (t.sym != nil and sfInfixCall in t.sym.flags) or
-           (x.sym != nil and sfInfixCall in x.sym.flags)
+  result = (t.sym != nil and sfCompileToCpp in t.sym.flags) or
+           (x.sym != nil and sfCompileToCpp in x.sym.flags)
 
 proc getTypeDescAux(m: BModule, origTyp: PType, check: var IntSet; kind: TSymKind): Rope
 

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1099,7 +1099,7 @@ proc requiresExternC(m: BModule; sym: PSym): bool {.inline.} =
   result = (sfCompileToCpp in m.module.flags and
            sfCompileToCpp notin sym.getModule().flags and
            m.config.backend != backendCpp) or (
-           sym.flags * {sfInfixCall, sfCompilerProc, sfMangleCpp} == {} and
+           sym.flags * {sfCompileToCpp, sfCompilerProc, sfMangleCpp} == {} and
            sym.flags * {sfImportc, sfExportc} != {} and
            sym.magic == mNone and
            m.config.backend == backendCpp)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -180,6 +180,10 @@ proc processImportCompilerProc(c: PContext; s: PSym, extname: string, info: TLin
 proc processImportCpp(c: PContext; s: PSym, extname: string, info: TLineInfo) =
   var extname = extname
   let isFreeFunction = extname.startsWith "!"
+  #[
+  example: `proc fun2(a: cstring): cint {.importcpp:"!fun2".}`
+  see more tests in tests/cpp/t12150.nim
+  ]#
   if isFreeFunction:
     extname = extname[1..^1]
   else:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -178,9 +178,15 @@ proc processImportCompilerProc(c: PContext; s: PSym, extname: string, info: TLin
   incl(s.loc.flags, lfImportCompilerProc)
 
 proc processImportCpp(c: PContext; s: PSym, extname: string, info: TLineInfo) =
+  var extname = extname
+  let isFreeFunction = extname.startsWith "!"
+  if isFreeFunction:
+    extname = extname[1..^1]
+  else:
+    incl(s.flags, sfInfixCall)
   setExternName(c, s, extname, info)
   incl(s.flags, sfImportc)
-  incl(s.flags, sfInfixCall)
+  incl(s.flags, sfCompileToCpp)
   excl(s.flags, sfForward)
   if c.config.backend == backendC:
     let m = s.getModule()

--- a/compiler/sighashes.nim
+++ b/compiler/sighashes.nim
@@ -108,7 +108,7 @@ proc hashType(c: var MD5Context, t: PType; flags: set[ConsiderFlag]) =
     else:
       c.hashSym(t.sym)
   of tyGenericInst:
-    if sfInfixCall in t.base.sym.flags:
+    if sfCompileToCpp in t.base.sym.flags:
       # This is an imported C++ generic type.
       # We cannot trust the `lastSon` to hold a properly populated and unique
       # value for each instantiation, so we hash the generic parameters here:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -279,7 +279,7 @@ proc containsObject*(t: PType): bool =
 
 proc isObjectWithTypeFieldPredicate(t: PType): bool =
   result = t.kind == tyObject and t[0] == nil and
-      not (t.sym != nil and {sfPure, sfInfixCall} * t.sym.flags != {}) and
+      not (t.sym != nil and {sfPure, sfCompileToCpp} * t.sym.flags != {}) and
       tfFinal notin t.flags
 
 type

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7014,14 +7014,16 @@ language for maximum flexibility:
 - A dot following the hash ``#.`` indicates that the call should use C++'s dot
   or arrow notation.
 - An at symbol ``@`` is replaced by the remaining arguments, separated by commas.
-- An exclamation symbol ``!`` indicates a free function.
+- An exclamation symbol ``!`` indicates a free (non-member) function.
 
 For example:
 
 .. code-block:: nim
+  // member function
   proc cppMethod(this: CppObj, a, b, c: cint) {.importcpp: "#.CppMethod(@)".}
   var x: ptr CppObj
   cppMethod(x[], 1, 2, 3)
+  // free function
   proc freeFn(a: cint) {.importcpp: "!$1".} # or importcpp: "!freeFn"
   freeFn(4)
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7014,6 +7014,7 @@ language for maximum flexibility:
 - A dot following the hash ``#.`` indicates that the call should use C++'s dot
   or arrow notation.
 - An at symbol ``@`` is replaced by the remaining arguments, separated by commas.
+- An exclamation symbol ``!`` indicates a free function.
 
 For example:
 
@@ -7021,11 +7022,14 @@ For example:
   proc cppMethod(this: CppObj, a, b, c: cint) {.importcpp: "#.CppMethod(@)".}
   var x: ptr CppObj
   cppMethod(x[], 1, 2, 3)
+  proc freeFn(a: cint) {.importcpp: "!$1".} # or importcpp: "!freeFn"
+  freeFn(4)
 
 Produces:
 
 .. code-block:: C
-  x->CppMethod(1, 2, 3)
+  x->CppMethod(1, 2, 3);
+  freeFn(4);
 
 As a special rule to keep backward compatibility with older versions of the
 ``importcpp`` pragma, if there is no special pattern

--- a/tests/cpp/m12150.nim
+++ b/tests/cpp/m12150.nim
@@ -1,0 +1,4 @@
+proc fun1(): cint {.exportcpp.} = 10
+proc fun2(a: cstring): cint {.exportcpp.} = 11
+proc fun2(): cint {.exportcpp.} = 12
+proc fun3(): cint {.exportc.} = 13

--- a/tests/cpp/t12150.nim
+++ b/tests/cpp/t12150.nim
@@ -1,3 +1,7 @@
+discard """
+  targets: "cpp"
+"""
+
 proc fun1(): cint {.importcpp:"!$1".}
 proc fun2(a: cstring): cint {.importcpp:"!fun2".}
 proc fun2(): cint {.importcpp:"!$1".}

--- a/tests/cpp/t12150.nim
+++ b/tests/cpp/t12150.nim
@@ -1,0 +1,14 @@
+proc fun1(): cint {.importcpp:"!$1".}
+proc fun2(a: cstring): cint {.importcpp:"!fun2".}
+proc fun2(): cint {.importcpp:"!$1".}
+proc fun2Aux(): cint {.importcpp:"!fun2".}
+proc fun3(): cint {.importc.}
+
+doAssert fun1() == 10
+doAssert fun2(nil) == 11
+doAssert fun2() == 12
+doAssert fun2Aux() == 12
+doAssert fun3() == 13
+
+import ./m12150
+


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/12150

## example
```nim
proc freeFn(a: cint) {.importcpp: "!$1".}
# maps to `void freeFn(int)`
```

