### PR TITLE
Remove bit about opening files not raising

### DIFF
--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -345,10 +345,8 @@ The compiler will prevent you from raising an exception created on the stack.
 All raised exceptions should at least specify the reason for being raised in
 the ``msg`` field.
 
-A convention is that exceptions should be raised in *exceptional* cases:
-For example, if a file cannot be opened, this should not raise an
-exception since this is quite common (the file may not exist).
-
+A convention is that exceptions should be raised in *exceptional* cases,
+they should not be used as an alternative method of control flow.
 
 Raise statement
 ---------------


### PR DESCRIPTION
Resolves #15616

I am removing this bit because this advice to not throw on recoverable-from cases like a file failing to open is actually not respected by Nim standard library. `readFile` and `readLines` both throw and exceptions must be used as a method of control flow for the recovery from that. There are alternatives, like opening a file handle instead of using these helpers, but that's less convenient than these helper methods for cases where you really want to just slurp up a file to memory and use a fallback value if it doesn't exist or is for whatever reason not readable.