### PR TITLE
experiment showing how iterators can (almost) be implemented with a library solution

### DIFF
--- a/lib/std/iterates.nim
+++ b/lib/std/iterates.nim
@@ -1,0 +1,33 @@
+import std/macros
+
+macro iterate*(x: ForLoopStmt): untyped =
+  let lhs = x[0]
+  let body = x[^1]
+  let iterateArgs = x[^2]
+  doAssert iterateArgs.len >= 2
+  let call = iterateArgs[1]
+
+  let formal = nnkFormalParams.newTree(newEmptyNode())
+  doAssert iterateArgs.len == 2
+  for i in 0..<x.len - 2:
+    formal.add nnkIdentDefs.newTree(x[i], ident"auto", newEmptyNode())
+
+  let anon = nnkLambda.newTree(
+    newEmptyNode(),
+    newEmptyNode(),
+    newEmptyNode(),
+    formal,
+    newEmptyNode(),
+    newEmptyNode(),
+    body
+  )
+
+  let par = nnkPar.newTree(anon)
+  if false:
+    call.insert(1, par)
+  else:
+    let par2 = quote do:
+      # cont = `par` # bug: doesn't work: Error: undeclared identifier: 'cont' (and would be ugly)
+      `par` # bug: downside, is it requires all optional args passed
+    call.add(par2)
+  result = call

--- a/tests/stdlib/titerates.nim
+++ b/tests/stdlib/titerates.nim
@@ -1,0 +1,38 @@
+discard """
+  targets: "c cpp js"
+"""
+
+import std/iterates
+
+proc myIter[T](s: seq[T], cont: proc(_: T)) =
+  for ai in s: cont ai*10
+
+proc myIter2(a, b: int, cont: proc(a1: int, a2: string)) =
+  for ai in a..b:
+    cont ai, $ai
+
+template toSeq(T, a: untyped): untyped =
+  # type T = typeof(block: (for ai in iterate(a): ai))
+  var ret = newSeq[T]()
+  for x in iterate a:
+    ret.add x
+  ret
+
+template main() =
+  block:
+    var ret: seq[int]
+    for x in iterate myIter(@[2,3]):
+      ret.add x
+    doAssert ret == @[20, 30]
+
+    doAssert toSeq(float, myIter(@[1.5, 2.0])) == @[15.0, 20.0]
+    doAssert toSeq(int, myIter(@[3])) == @[30]
+
+  block:
+    var ret: seq[(int, string)]
+    for k,v in iterate myIter2(2,5):
+      ret.add (k,v)
+    doAssert ret == @[(2, "2"), (3, "3"), (4, "4"), (5, "5")]
+
+static: main()
+main()

--- a/tests/stdlib/titerates.nim
+++ b/tests/stdlib/titerates.nim
@@ -34,5 +34,21 @@ template main() =
       ret.add (k,v)
     doAssert ret == @[(2, "2"), (3, "3"), (4, "4"), (5, "5")]
 
+  block: # continue, break
+    proc fn1(n: int, cont: proc(_: int)) =
+      for ai in 0..<n: cont ai
+
+    var ret: seq[string]
+    for x in iterate fn1(5):
+      ret.add $x
+      if x==2:
+        ret.add "continue"
+        continue
+      if x==3:
+        ret.add "break"
+        break
+      ret.add "after"
+    doAssert ret == @["0", "after", "1", "after", "2", "continue", "3", "break"]
+
 static: main()
 main()


### PR DESCRIPTION
support material for https://github.com/nim-lang/RFCs/issues/272

would fix these long standing issues with closure iterators:
* closure iterators can't be used in VM
https://github.com/nim-lang/Nim/pull/15818
* closure iterators can't be used in js
https://github.com/nim-lang/Nim/issues/4695
* closure iterators can't be recursive
https://forum.nim-lang.org/t/7020#44149
* defer/exceptions don't work in closure iterators:
https://github.com/nim-lang/Nim/issues/15501
https://github.com/nim-lang/Nim/issues/11815
* [Closure iterators can leak resources and there is no easy way to prevent it · Issue #13289 · nim-lang/Nim](https://github.com/nim-lang/Nim/issues/13289) https://github.com/nim-lang/Nim/issues/13289


## links
* https://github.com/nim-lang/Nim/issues/15501#issuecomment-730231149
* https://github.com/nim-lang/RFCs/issues/272
