### PR TITLE
add `--declaredlocs` to show symbol declaration location in message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@
 
 
 ## Compiler changes
-
+add `--declaredlocs` to show symbol declaration location in messages
 
 
 ## Tool changes

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -794,6 +794,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info)
   of "listfullpaths":
     processOnOffSwitchG(conf, {optListFullPaths}, arg, pass, info)
+  of "declaredlocs":
+    processOnOffSwitchG(conf, {optDeclaredLocs}, arg, pass, info)
   of "dynliboverride":
     dynlibOverride(conf, switch, arg, pass, info)
   of "dynliboverrideall":

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -69,6 +69,7 @@ type
     hintUser, hintUserRaw,
     hintExtendedContext,
     hintMsgOrigin, # since 1.3.5
+    hintDeclaredLoc, # since 1.5.1
 
 const
   MsgKindToStr*: array[TMsgKind, string] = [
@@ -159,6 +160,7 @@ const
     hintUserRaw: "$1",
     hintExtendedContext: "$1",
     hintMsgOrigin: "$1",
+    hintDeclaredLoc: "$1",
   ]
 
 const
@@ -186,7 +188,7 @@ const
     "ExprAlwaysX", "QuitCalled", "Processing", "CodeBegin", "CodeEnd", "Conf",
     "Path", "CondTrue", "CondFalse", "Name", "Pattern", "Exec", "Link", "Dependency",
     "Source", "Performance", "StackTrace", "GCStats", "GlobalVar", "ExpandMacro",
-    "User", "UserRaw", "ExtendedContext", "MsgOrigin",
+    "User", "UserRaw", "ExtendedContext", "MsgOrigin", "DeclaredLoc"
   ]
 
 const
@@ -215,7 +217,7 @@ type
 
 proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result[3] = {low(TNoteKind)..high(TNoteKind)} - {warnObservableStores}
-  result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext}
+  result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext, hintDeclaredLoc}
   result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin}

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -81,6 +81,7 @@ type                          # please make sure we have under 32 options
     optDocInternal            # generate documentation for non-exported symbols
     optMixedMode              # true if some module triggered C++ codegen
     optListFullPaths          # use full paths in toMsgFilename
+    optDeclaredLocs           # show declaration locations in messages
     optNoNimblePath
     optHotCodeReloading
     optDynlibOverrideAll

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -208,6 +208,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
             {renderNoBody, renderNoComments, renderNoPragmas}))
     else:
       candidates.add(getProcHeader(c.config, err.sym, prefer))
+    candidates.addDeclaredLocMaybe(c.config, err.sym)
     candidates.add("\n")
     let nArg = if err.firstMismatch.arg < n.len: n[err.firstMismatch.arg] else: nil
     let nameParam = if err.firstMismatch.formal != nil: err.firstMismatch.formal.name.s else: ""
@@ -230,9 +231,8 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
         candidates.add typeToString(wanted)
-        when false:
-          if wanted.sym != nil:
-            candidates.add "(" & (c.config $ wanted.sym.info) & ")"
+        if wanted.sym != nil:
+          candidates.addDeclaredLocMaybe(c.config, wanted.sym)
         candidates.add "\n  but expression '"
         if err.firstMismatch.kind == kVarNeeded:
           candidates.add renderNotLValue(nArg)
@@ -242,9 +242,8 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           candidates.add "' is of type: "
           var got = nArg.typ
           candidates.add typeToString(got)
-          when false:
-            if got.sym != nil:
-              candidates.add "(" & (c.config $ got.sym.info) & ")"
+          if got.sym != nil:
+            candidates.addDeclaredLocMaybe(c.config, got.sym)
 
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -123,8 +123,13 @@ proc isIntLit*(t: PType): bool {.inline.} =
 proc isFloatLit*(t: PType): bool {.inline.} =
   result = t.kind == tyFloat and t.n != nil and t.n.kind == nkFloatLit
 
-proc addDeclaredLoc(result: var string, conf: ConfigRef; sym: PSym) =
-  result.add " [declared in " & conf$sym.info & "]"
+proc addDeclaredLoc*(result: var string, conf: ConfigRef; sym: PSym) =
+  # result.add " [declared in " & conf$sym.info & "]"
+  result.add " [declared in " & toFileLineCol(conf, sym.info) & "]"
+
+proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
+  if optDeclaredLocs in conf.globalOptions:
+    addDeclaredLoc(result, conf, sym)
 
 proc addTypeHeader*(result: var string, conf: ConfigRef; typ: PType; prefer: TPreferedDesc = preferMixed; getDeclarationPath = true) =
   result.add typeToString(typ, prefer)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,6 +35,7 @@ Advanced options:
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths:on|off    list full paths in messages
+  --declaredlocs:on|off     show declaration locations in messages
   -w:on|off|list, --warnings:on|off|list
                             turn all warnings on|off or list all available
   --warning[X]:on|off       turn specific warning X on|off


### PR DESCRIPTION
too verbose by default but very useful when you need to figure out where symbols are declared without guesswork.
(also avoids having to instrument compiler when chasing those things, eg see https://github.com/nim-lang/Nim/pull/15660/files#diff-083ab8ee8fb7c645dd951c50f3b05f3fbb27605001375f4870a1a0ddc21b7e04R233)

## example
```nim
type Foo = ref object
discard $Foo()
```


nim r --listfullpaths --declaredlocs main
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11164.nim(5, 1) template/generic instantiation from here
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11164.nim(16, 11) Error: type mismatch: got <Foo>
but expected one of:
proc `$`(s: WideCString): string [declared in /Users/timothee/git_clone/nim/Nim_prs/lib/system/widestrs.nim(215, 6)]
  first type mismatch at position: 1
  required type for s: WideCString [declared in /Users/timothee/git_clone/nim/Nim_prs/lib/system/widestrs.nim(60, 5)]
  but expression 'Foo()' is of type: Foo [declared in /Users/timothee/git_clone/nim/timn/tests/nim/all/t11164.nim(15, 8)]
proc `$`(t: typedesc): string [declared in /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim(78, 6)]
  first type mismatch at position: 1
  required type for t: typedesc [declared in /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim(78, 11)]
  but expression 'Foo()' is of type: Foo [declared in /Users/timothee/git_clone/nim/timn/tests/nim/all/t11164.nim(15, 8)]
...
```

## note:
honors `--listfullpaths` (ie same logic as what's used in listfullpaths is used to display paths; note that the logic used for listfullpaths could be improved but that's out of scope for this PR)


## future work
- [x] apply same treatment to `type mismatch: got <...` errors, eg:
```nim
type Foo = ref object
var b: string = Foo()
```
=> https://github.com/nim-lang/Nim/pull/15673