### PR TITLE
honor --declaredLocs in more places, including type mismatch errors; also show `kind` with --declaredLocs

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -154,12 +154,14 @@ type
     scope*: PScope
     inSymChoice: IntSet
 
-proc getSymRepr*(conf: ConfigRef; s: PSym): string =
+proc getSymRepr*(conf: ConfigRef; s: PSym, getDeclarationPath = true): string =
   case s.kind
   of routineKinds, skType:
-    result = getProcHeader(conf, s)
+    result = getProcHeader(conf, s, getDeclarationPath = getDeclarationPath)
   else:
-    result = s.name.s
+    result = "'$1'" % s.name.s
+    if getDeclarationPath:
+      result.addDeclaredLoc(conf, s)
 
 proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope) =
   # check if all symbols have been used and defined:
@@ -172,7 +174,7 @@ proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope) =
       # and slow 'suggest' down:
       if missingImpls == 0:
         localError(c.config, s.info, "implementation of '$1' expected" %
-            getSymRepr(c.config, s))
+            getSymRepr(c.config, s, getDeclarationPath=false))
       inc missingImpls
     elif {sfUsed, sfExported} * s.flags == {}:
       if s.kind notin {skForVar, skParam, skMethod, skUnknown, skGenericParam, skEnumField}:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -231,8 +231,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
         candidates.add typeToString(wanted)
-        if wanted.sym != nil:
-          candidates.addDeclaredLocMaybe(c.config, wanted.sym)
+        candidates.addDeclaredLocMaybe(c.config, wanted)
         candidates.add "\n  but expression '"
         if err.firstMismatch.kind == kVarNeeded:
           candidates.add renderNotLValue(nArg)
@@ -242,9 +241,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           candidates.add "' is of type: "
           var got = nArg.typ
           candidates.add typeToString(got)
-          if got.sym != nil:
-            candidates.addDeclaredLocMaybe(c.config, got.sym)
-
+          candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)
       of kUnknown: discard "do not break 'nim check'"

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -317,7 +317,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      result &= "\n  found '$1' of kind '$2'" % [getSymRepr(c.config, sym), sym.kind.toHumanStr]
+      result &= "\n  found '$1'" % [getSymRepr(c.config, sym)]
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -317,7 +317,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      result &= "\n  found '$1'" % [getSymRepr(c.config, sym)]
+      result &= "\n  found $1" % [getSymRepr(c.config, sym)]
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -965,8 +965,9 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode =
           # t.kind != tySequence(It is tyProc)
           if typ.sym != nil and sfAnon notin typ.sym.flags and
                                 typ.kind == tyProc:
-            msg.add(" = " &
-                typeToString(typ, preferDesc))
+            # when can `typ.sym != nil` ever happen?
+            msg.add(" = " & typeToString(typ, preferDesc))
+          msg.addDeclaredLocMaybe(c.config, typ)
           localError(c.config, n.info, msg)
         return errorNode(c, n)
       result = nil

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -130,13 +130,15 @@ proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
   if optDeclaredLocs in conf.globalOptions and sym != nil:
     addDeclaredLoc(result, conf, sym)
 
+proc addDeclaredLoc(result: var string, conf: ConfigRef; typ: PType) =
+  let typ = typ.skipTypes(abstractInst - {tyRange})
+  result.add " [$1" % typ.kind.toHumanStr
+  if typ.sym != nil:
+    result.add " declared in " & toFileLineCol(conf, typ.sym.info)
+  result.add "]"
+
 proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; typ: PType) =
-  if optDeclaredLocs in conf.globalOptions:
-    let typ = typ.skipTypes(abstractInst - {tyRange})
-    result.add " [$1" % typ.kind.toHumanStr
-    if typ.sym != nil:
-      result.add " declared in " & toFileLineCol(conf, typ.sym.info)
-    result.add "]"
+  if optDeclaredLocs in conf.globalOptions: addDeclaredLoc(result, conf, typ)
 
 proc addTypeHeader*(result: var string, conf: ConfigRef; typ: PType; prefer: TPreferedDesc = preferMixed; getDeclarationPath = true) =
   result.add typeToString(typ, prefer)
@@ -1480,13 +1482,19 @@ proc skipHiddenSubConv*(n: PNode): PNode =
 
 proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType) =
   if formal.kind != tyError and actual.kind != tyError:
-    let named = typeToString(formal)
+    let actualStr = typeToString(actual)
+    let formalStr = typeToString(formal)
     let desc = typeToString(formal, preferDesc)
-    let x = if named == desc: named else: named & " = " & desc
-    var msg = "type mismatch: got <" & typeToString(actual) & ">"
-    msg.addDeclaredLocMaybe(conf, actual)
-    msg.add " but expected '" & x & "'"
-    msg.addDeclaredLocMaybe(conf, formal)
+    let x = if formalStr == desc: formalStr else: formalStr & " = " & desc
+    let verbose = actualStr == formalStr or optDeclaredLocs in conf.globalOptions
+    var msg = "type mismatch:"
+    if verbose: msg.add "\n"
+    msg.add  " got <$1>" % actualStr
+    if verbose:
+      msg.addDeclaredLoc(conf, actual)
+      msg.add "\n"
+    msg.add " but expected '$1'" % x
+    if verbose: msg.addDeclaredLoc(conf, formal)
 
     if formal.kind == tyProc and actual.kind == tyProc:
       case compatibleEffects(formal, actual)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -132,6 +132,7 @@ proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
 
 proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; typ: PType) =
   if optDeclaredLocs in conf.globalOptions:
+    let typ = typ.skipTypes(abstractInst - {tyRange})
     result.add " [$1" % typ.kind.toHumanStr
     if typ.sym != nil:
       result.add " declared in " & toFileLineCol(conf, typ.sym.info)

--- a/tests/errmsgs/t8794.nim
+++ b/tests/errmsgs/t8794.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim check $options $file"
   errormsg: ""
   nimout: '''
-t8794.nim(39, 27) Error: undeclared field: 'a3' for type m8794.Foo3 [declared in m8794.nim(1, 6)]
+t8794.nim(39, 27) Error: undeclared field: 'a3' for type m8794.Foo3 [type declared in m8794.nim(1, 6)]
 '''
 """
 

--- a/tests/errmsgs/undeclared_routime.nim
+++ b/tests/errmsgs/undeclared_routime.nim
@@ -2,8 +2,8 @@ discard """
 cmd: '''nim c --hints:off $file'''
 errormsg: "attempting to call routine: 'myiter'"
 nimout: '''undeclared_routime.nim(13, 15) Error: attempting to call routine: 'myiter'
-  found 'undeclared_routime.myiter(a: string)[declared in undeclared_routime.nim(10, 9)]' of kind 'iterator'
-  found 'undeclared_routime.myiter()[declared in undeclared_routime.nim(11, 9)]' of kind 'iterator'
+  found 'undeclared_routime.myiter(a: string)[iterator declared in undeclared_routime.nim(10, 9)]'
+  found 'undeclared_routime.myiter()[iterator declared in undeclared_routime.nim(11, 9)]'
 '''
 """
 

--- a/tests/misc/tnoop.nim
+++ b/tests/misc/tnoop.nim
@@ -1,6 +1,6 @@
 discard """
   nimout: '''
-  found 'a' of kind 'var'
+  found 'a' [var declared in tnoop.nim(11, 3)]
   '''
   file: "tnoop.nim"
   line: 13


### PR DESCRIPTION
followup after https://github.com/nim-lang/Nim/pull/15666
* honor `--declaredLocs` in more places, including type mismatch errors, see example 1
* show (humanized) symbol kind in declared in message, which helps with cryptic errors, see example 2

## example 1
```nim
block:
  type Foo = ref object
  type Foo2 = object
  type Bar[T]=object
  var b: Bar[float]
  b = Foo()
```
before PR:
```
t11164.nim(77, 10) Error: type mismatch: got <Foo> but expected 'Bar[system.float]'
    b = Foo()
```
after PR, when passing `--declaredLocs --listfullpaths:off`:
```
t11164.nim(77, 10) Error: type mismatch: got <Foo> [ref declared in t11164.nim(73, 8)] but expected 'Bar[system.float]' [object declared in t11164.nim(75, 8)]
    b = Foo()
```

## example 2
```nim
block:
  type Foo = object
  proc fun(a: ref) = discard
  fun(Foo())
```
before PR: 
```
t11164.nim(43, 6) Error: type mismatch: got <Foo>
but expected one of:
proc fun(a: ref)
  first type mismatch at position: 1
  required type for a: ref
  but expression 'Foo()' is of type: Foo
```
=> cryptic, the error doesn't tell you why Foo doesn't match unless you know that Foo is of kind `object` instead of `ref`
**This is a common problem** in my experience.

after PR, when passing `--declaredLocs --listfullpaths:off`:
```
t11164.nim(43, 6) Error: type mismatch: got <Foo>
but expected one of:
proc fun(a: ref) [proc declared in t11164.nim(42, 8)]
  first type mismatch at position: 1
  required type for a: ref [builtInTypeClass declared in t11164.nim(42, 12)]
  but expression 'Foo()' is of type: Foo [object declared in t11164.nim(39, 8)]
```
=> now you have all the context to understand the mismatch: fun expects a ref, but Foo is of kind object

## future work
- [x] we should also honor --declaredLocs for `cannot instantiate` errors:
```nim
block:
  type Foo[T:ref] = ref object
  type Bar = object
  type Foo1 = Foo[Bar]
```

currently still gives
```
t11164.nim(29, 18) Error: cannot instantiate Foo
got: <type Bar>
but expected: <T: ref>
    type Foo1 = Foo[Bar]
```
which has same drawback of lacking sufficient context to understand the error (especially in complicated cases)


=> https://github.com/nim-lang/Nim/pull/17745