### PR TITLE
fix #15662

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1229,15 +1229,15 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNSymbol: genUnaryABC(c, n, dest, opcNSymbol)
   of mNIdent: genUnaryABC(c, n, dest, opcNIdent)
   of mNGetType:
-      let tmp = c.genx(n[1])
-      if dest < 0: dest = c.getTemp(n.typ)
-      let rc = case n[0].sym.name.s:
-        of "getType": 0
-        of "typeKind": 1
-        of "getTypeInst": 2
-        else: 3  # "getTypeImpl"
-      c.gABC(n, opcNGetType, dest, tmp, rc)
-      c.freeTemp(tmp)
+    let tmp = c.genx(n[1])
+    if dest < 0: dest = c.getTemp(n.typ)
+    let rc = case n[0].sym.name.s:
+      of "getType": 0
+      of "typeKind": 1
+      of "getTypeInst": 2
+      else: 3  # "getTypeImpl"
+    c.gABC(n, opcNGetType, dest, tmp, rc)
+    c.freeTemp(tmp)
     #genUnaryABC(c, n, dest, opcNGetType)
   of mNSizeOf:
     let imm = case n[0].sym.name.s:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -586,9 +586,8 @@ proc genCall(c: PCtx; n: PNode; dest: var TDest) =
   # varargs need 'opcSetType' for the FFI support:
   let fntyp = skipTypes(n[0].typ, abstractInst)
   for i in 0..<n.len:
-    #if i > 0 and i < fntyp.len:
-    #  let paramType = fntyp.n[i]
-    #  if paramType.typ.isCompileTimeOnly: continue
+    let paramType = fntyp.n[i].typ
+    if paramType != nil and paramType.kind == tyTypeDesc: continue
     var r: TRegister = x+i
     c.gen(n[i], r, {gfIsParam})
     if i >= fntyp.len:

--- a/tests/vm/tconstobj.nim
+++ b/tests/vm/tconstobj.nim
@@ -70,3 +70,8 @@ static: # issue #11861
   var ifb2: InheritedFromBase
   initBase(ifb2)
   doAssert(ifb2.txt == "Initialized string from base")
+
+
+static: # issue #15662
+  proc a(T: typedesc) = echo T.type
+  a((int, int))


### PR DESCRIPTION
fix #15662. 
Skip typedesc arguments, as far I cal tell they are used only to instantiate the proc