### PR TITLE
Handle BLOB column type in SQLite as binary data

### DIFF
--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -247,8 +247,7 @@ proc setRow(stmt: PStmt, r: var Row, cols: cint) =
     if column_type(stmt, col) == SQLITE_BLOB:
       copyMem(addr(r[col][0]), column_blob(stmt, col), cb)
     else:
-      # setLen(r[col], 0)
-      # it seems weird to use setLen(0) after setLen(cb)
+      setLen(r[col], 0)
       let x = column_text(stmt, col)
       if not isNil(x): add(r[col], x)
 

--- a/tests/stdlib/tsqlitebindatas.nim
+++ b/tests/stdlib/tsqlitebindatas.nim
@@ -1,0 +1,50 @@
+discard """
+  action: "run"
+  exitcode: 0
+"""
+import db_sqlite
+import random
+import os
+from stdtest/specialpaths import buildDir
+
+block tsqlitebindatas: ## db_sqlite binary data
+  const dbName = buildDir / "tsqlitebindatas.db"
+
+  let origName = "Bobby"
+  var orig = newSeq[float64](150)
+  randomize()
+  for x in orig.mitems:
+    x = rand(1.0)/10.0
+
+  discard tryRemoveFile(dbName)
+  let db = open(dbName, "", "", "")
+  let createTableStr = sql"""CREATE TABLE test(
+    id INTEGER NOT NULL PRIMARY KEY,
+    name TEXT,
+    data BLOB
+  )
+  """
+  db.exec(createTableStr)
+
+  var dbuf = newSeq[byte](orig.len*sizeof(float64))
+  copyMem(unsafeAddr(dbuf[0]), unsafeAddr(orig[0]), dbuf.len)
+
+  var insertStmt = db.prepare("INSERT INTO test (id, name, data) VALUES (?, ?, ?)")
+  insertStmt.bindParams(1, origName, dbuf)
+  let bres = db.tryExec(insertStmt)
+  doAssert(bres)
+
+  finalize(insertStmt)
+
+  var nameTest = db.getValue(sql"SELECT name FROM test WHERE id = ?", 1)
+  doAssert nameTest == origName
+
+  var dataTest = db.getValue(sql"SELECT data FROM test WHERE id = ?", 1)
+  let seqSize = int(dataTest.len*sizeof(byte)/sizeof(float64))
+  var res: seq[float64] = newSeq[float64](seqSize)
+  copyMem(unsafeAddr(res[0]), addr(dataTest[0]), dataTest.len)
+  doAssert res.len == orig.len
+  doAssert res == orig
+
+  db.close()
+  doAssert tryRemoveFile(dbName)


### PR DESCRIPTION
Insertion of binary data can be done using prepared statement but retrieval cannot even on BLOB type.

This avoids issues of trying to retrieve binary data that contains characters \0, \n from truncating data without having to devle into the low level wrapper of sqlite3. 

Casting TEXT or VARCHAR to cstring is fine, but BLOB is explicit binary data and shouldn't but submitted to cstring limitation.
