### PR TITLE
remove all mentions of doc2, jsondoc2 (except 1 mentioning the alias)

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -77,7 +77,7 @@ type                          # please make sure we have under 32 options
     optIdeTerse               # idetools: use terse descriptions
     optExcessiveStackTrace    # fully qualified module filenames
     optShowAllMismatches      # show all overloading resolution candidates
-    optWholeProject           # for 'doc2': output any dependency
+    optWholeProject           # for 'doc': output any dependency
     optDocInternal            # generate documentation for non-exported symbols
     optMixedMode              # true if some module triggered C++ codegen
     optListFullPaths          # use full paths in toMsgFilename

--- a/compiler/typesrenderer.nim
+++ b/compiler/typesrenderer.nim
@@ -90,7 +90,7 @@ proc renderParamTypes(found: var seq[string], n: PNode) =
   ## Recursive helper, adds to `found` any types, or keeps diving the AST.
   ##
   ## The normal `doc` generator doesn't include .typ information, so the
-  ## function won't render types for parameters with default values. The `doc2`
+  ## function won't render types for parameters with default values. The `doc`
   ## generator does include the information.
   case n.kind
   of nkFormalParams:

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -73,7 +73,7 @@ Advanced options:
   --clibdir:DIR             modify the linker library search path
   --clib:LIBNAME            link an additional C library
                             (you should omit platform-specific extensions)
-  --project                 document the whole project (doc2)
+  --project                 document the whole project (doc)
   --docRoot:path            `nim doc --docRoot:/foo --project --outdir:docs /foo/sub/main.nim`
                             generates: docs/sub/main.html
                             if path == @pkg, will use nimble file enclosing dir
@@ -85,7 +85,7 @@ Advanced options:
   --docCmd:cmd              if `cmd == skip`, skips runnableExamples
                             else, runs runnableExamples with given options, e.g.:
                             `--docCmd:"-d:foo --threads:on"`
-  --docSeeSrcUrl:url        activate 'see source' for doc and doc2 commands
+  --docSeeSrcUrl:url        activate 'see source' for doc command
                             (see doc.item.seesrc in config/nimdoc.cfg)
   --docInternal             also generate documentation for non-exported symbols
   --lineDir:on|off          generation of #line directive on|off

--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -193,7 +193,7 @@ Index switch
 ------------
 
 ::
-  nim doc2 --index:on filename.nim
+  nim doc --index:on filename.nim
 
 This will generate an index of all the exported symbols in the input Nim
 module, and put it into a neighboring file with the extension of ``.idx``. The
@@ -210,7 +210,7 @@ See source switch
 -----------------
 
 ::
-  nim doc2 --git.url:<url> filename.nim
+  nim doc --git.url:<url> filename.nim
 
 With the ``git.url`` switch the *See source* hyperlink will appear below each
 documented item in your source code pointing to the implementation of that
@@ -262,8 +262,8 @@ HTML anchor generation
 When you run the ``rst2html`` command, all sections in the RST document will
 get an anchor you can hyperlink to. Usually, you can guess the anchor lower
 casing the section title and replacing spaces with dashes, and in any case, you
-can get it from the table of contents. But when you run the ``doc`` or ``doc2``
-commands to generate API documentation, some symbol get one or two anchors at
+can get it from the table of contents. But when you run the ``doc``
+command to generate API documentation, some symbol get one or two anchors at
 the same time: a numerical identifier, or a plain name plus a complex name.
 
 The numerical identifier is just a random number. The number gets assigned

--- a/doc/docstyle.rst
+++ b/doc/docstyle.rst
@@ -78,7 +78,7 @@ Whenever an example of usage would be helpful to the user, you should include on
       doAssert addThree(3, 125, 6) == -122
     result = x +% y +% z
 
-The commands ``nim doc`` and ``nim doc2`` will then correctly syntax highlight the Nim code within the documentation.
+The command ``nim doc`` will then correctly syntax highlight the Nim code within the documentation.
 
 Types
 -----

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -516,7 +516,7 @@ can be read in the `Nim Backend Integration document <backends.html>`_.
 Nim documentation tools
 =======================
 
-Nim provides the `doc`:idx: and `doc2`:idx: commands to generate HTML
+Nim provides the `doc`:idx: command to generate HTML
 documentation from ``.nim`` source files. Only exported symbols will appear in
 the output. For more details `see the docgen documentation <docgen.html>`_.
 

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -457,7 +457,7 @@ If you want to add the ``{.raises.}`` pragma to existing code, the compiler can
 also help you. You can add the ``{.effects.}`` pragma statement to your proc and
 the compiler will output all inferred effects up to that point (exception
 tracking is part of Nim's effect system). Another more roundabout way to
-find out the list of exceptions raised by a proc is to use the Nim ``doc2``
+find out the list of exceptions raised by a proc is to use the Nim ``doc``
 command which generates documentation for a whole module and decorates all
 procs with the list of raised exceptions. You can read more about Nim's
 `effect system and related pragmas in the manual <manual.html#effect-system>`_.

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -265,7 +265,7 @@ proc buildDoc(nimArgs, destPath: string) =
       [extra, nimArgs2, gitUrl, destPath, d]
     i.inc
   for d in items(withoutIndex):
-    commands[i] = nim & " doc2 $# --git.url:$# -o:$# $#" %
+    commands[i] = nim & " doc $# --git.url:$# -o:$# $#" %
       [nimArgs, gitUrl,
       destPath / changeFileExt(splitFile(d).name, "html"), d]
     i.inc

--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -326,7 +326,7 @@ proc buildDoc(c: var TConfigData, destPath: string) =
       destPath / changeFileExt(splitFile(d).name, "html"), d]
     i.inc
   for d in items(c.srcdoc2):
-    commands[i] = findNim(c) & " doc2 $# --git.url:$# -o:$# --index:on $#" %
+    commands[i] = findNim(c) & " doc $# --git.url:$# -o:$# --index:on $#" %
       [c.nimArgs, c.gitURL,
       destPath / changeFileExt(splitFile(d).name, "html"), d]
     i.inc
@@ -361,7 +361,7 @@ proc buildAddDoc(c: var TConfigData, destPath: string) =
   # build additional documentation (without the index):
   var commands = newSeq[string](c.webdoc.len)
   for i, doc in pairs(c.webdoc):
-    commands[i] = findNim(c) & " doc2 $# --git.url:$# -o:$# $#" %
+    commands[i] = findNim(c) & " doc $# --git.url:$# -o:$# $#" %
       [c.nimArgs, c.gitURL,
       destPath / changeFileExt(splitFile(doc).name, "html"), doc]
   mexec(commands, c.numProcessors)
@@ -537,7 +537,7 @@ proc json2(c: var TConfigData) =
   var i = 0
   for d in items(c.srcdoc2):
     createDir(destPath / splitFile(d).dir)
-    commands[i] = findNim(c) & " jsondoc2 $# --git.url:$# -o:$# --index:on $#" %
+    commands[i] = findNim(c) & " jsondoc $# --git.url:$# -o:$# --index:on $#" %
       [c.nimArgs, c.gitURL,
       destPath / changeFileExt(d, "json"), d]
     i.inc


### PR DESCRIPTION
- [ ] the PR should be correct as is but shall I also change:
srcdoc, srcdoc2
to
srcdoc0, srcdoc
?
it's used in tools/nimweb.nim and not sure whether there's any outside clients for those.

## note:
this one seems unrelated:
`lib/pure/htmlgen.nim:336:44:  result = xmlCheckedTag(e, "iframe", "src srcdoc name sandbox width height" &`

