### PR TITLE
followup #15642: make source + edit also work with stdlib (which uses -d:boot)

### DIFF
--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -146,6 +146,7 @@ doc.body_toc_group = """
   $body_toc_groupsection
   $tableofcontents
   </div>
+  $seeSrc
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   $deprecationMsg
@@ -156,7 +157,7 @@ doc.body_toc_group = """
 """
 
 @else
-
+# keep in sink with other `doc.body_toc_group` or better, refactor
 doc.body_toc_group = """
 <div class="row">
   <div class="three columns">


### PR DESCRIPTION
fixes this https://github.com/nim-lang/Nim/pull/15642#issuecomment-714672734

> it works locally, and it works for compiler docs https://nim-lang.github.io/Nim/compiler/ast.html but somehow not for stdlib docs https://nim-lang.github.io/Nim/os.html which are generated a bit differently; this should be fixed