### PR TITLE
add --nimExecReplace:exe for use in nimscript

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 - Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given.
+- Added `--nimExecReplacec:exe` for use in nimscript
 
 
 ## Tool changes

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 - Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given.
-- Added `--nimExecReplacec:exe` for use in nimscript
+- Added `--nimExecReplace:exe` for use in nimscript
 
 
 ## Tool changes

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -769,6 +769,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "cc":
     expectArg(conf, switch, arg, pass, info)
     setCC(conf, arg, info)
+  of "nimexecreplace":
+    conf.nimExecReplace = if arg.len == 0: getAppFilename() else: arg
   of "track":
     expectArg(conf, switch, arg, pass, info)
     track(conf, arg, info)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -246,6 +246,7 @@ type
     evalMacroCounter*: int
     exitcode*: int8
     cmd*: TCommands  # the command
+    nimExecReplace*: string
     selectedGC*: TGCMode       # the selected GC (+)
     exc*: ExceptionSystem
     verbosity*: int            # how verbose the compiler is

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -17,7 +17,7 @@ import
   pathutils
 
 # we support 'cmpIgnoreStyle' natively for efficiency:
-from strutils import cmpIgnoreStyle, contains
+from strutils import cmpIgnoreStyle, contains, startsWith
 
 proc listDirs(a: VmArgs, filter: set[PathComponent]) =
   let dir = getString(a, 0)
@@ -110,7 +110,12 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
     if defined(nimsuggest) or graph.config.cmd == cmdCheck:
       discard
     else:
-      setResult(a, osproc.execCmd getString(a, 0))
+      var cmd = getString(a, 0)
+      if graph.config.nimExecReplace.len > 0:
+        let prefix = "nim "
+        if cmd.startsWith prefix:
+          cmd = graph.config.nimExecReplace.quoteShell & " " & cmd[prefix.len..^1]
+      setResult(a, osproc.execCmd cmd)
 
   cbconf getEnv:
     setResult(a, os.getEnv(a.getString 0, a.getString 1))

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -69,6 +69,9 @@ Advanced options:
   -t, --passC:OPTION        pass an option to the C compiler
   -l, --passL:OPTION        pass an option to the linker
   --cc:SYMBOL               specify the C compiler
+  --nimExecReplacec:exe    `exec("nim args...")` calls in nimscript are replaced
+                            by changing nim to `exe`, or `getAppFilename()` when `exe`
+                            is not specified
   --cincludes:DIR           modify the C compiler header search path
   --clibdir:DIR             modify the linker library search path
   --clib:LIBNAME            link an additional C library

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -69,7 +69,7 @@ Advanced options:
   -t, --passC:OPTION        pass an option to the C compiler
   -l, --passL:OPTION        pass an option to the linker
   --cc:SYMBOL               specify the C compiler
-  --nimExecReplacec:exe    `exec("nim args...")` calls in nimscript are replaced
+  --nimExecReplace:exe    `exec("nim args...")` calls in nimscript are replaced
                             by changing nim to `exe`, or `getAppFilename()` when `exe`
                             is not specified
   --cincludes:DIR           modify the C compiler header search path


### PR DESCRIPTION
* fixes https://github.com/nim-lang/RFCs/issues/273

## example
```nim
bin/nim_foo e main.nims # exec unmodified
bin/nim_foo e --nimExecReplace main.nims # exec("nim args...") changed by s/nim/getAppFilename().quoteShell/
bin/nim_foo e --nimExecReplace:exe main.nims # exec("nim args...") changed by s/nim/exe.quoteShell/
```
the last form (with explicit exe) is also useful in some cases, but the 1st form `--nimExecReplace` is the most common.

nimble can then forward it's `--nim:exe` cmdline argument to: `exe --nimExecReplace args...` which would fix this: https://github.com/nim-lang/nimble/issues/865

## potential future work
very similar to this PR (a tiny modification), a slight variation on an idea suggested by @dom96 in https://github.com/nim-lang/RFCs/issues/273#issuecomment-714793293 is to add: `--nimExecReplaceArgs:str` which would work as follows:

`nim e --nimExecReplaceArgs:"--gc:arc -d:danger" myscript.nims`

and this would replace `exec "nim args..."` by `exec "nim --gc:arc -d:danger args..."`
so that existing `args` can still override what we're passing on cmdline

(to be discussed separately)
