### PR TITLE
new: `nim --eval:cmd` to run a command directly; also fixes #15731

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 - Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given.
-- Added `nim -e cmd` to evaluate a command directly, see manual for details
+- Added `nim --eval:cmd` to evaluate a command directly, see `nim --help`
 
 
 ## Tool changes

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,8 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 - Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given.
+add `--declaredlocs` to show symbol declaration location in messages
+- Added `nim -i cmd` to run a command directly, see manual for details
 
 
 ## Tool changes

--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,6 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 - Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given.
-add `--declaredlocs` to show symbol declaration location in messages
 - Added `nim -e cmd` to evaluate a command directly, see manual for details
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,7 @@
 - Added `--declaredlocs` to show symbol declaration location in messages.
 - Source+Edit links now appear on top of every docgen'd page when `nim doc --git.url:url ...` is given.
 add `--declaredlocs` to show symbol declaration location in messages
-- Added `nim -i cmd` to run a command directly, see manual for details
+- Added `nim -e cmd` to evaluate a command directly, see manual for details
 
 
 ## Tool changes

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -41,7 +41,9 @@ proc initDefinesProg*(self: NimProg, conf: ConfigRef, name: string) =
 
 proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
   self.processCmdLine(passCmd1, "", conf)
-  if self.supportsStdinFile and conf.projectName == "-":
+  if conf.projectIsCmd and conf.projectName in ["-", ""]:
+    handleCmdInput(conf)
+  elif self.supportsStdinFile and conf.projectName == "-":
     handleStdinInput(conf)
   elif conf.projectName != "":
     try:

--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -61,6 +61,8 @@ proc loadConfigsAndRunMainCommand*(self: NimProg, cache: IdentCache; conf: Confi
                                    graph: ModuleGraph): bool =
   if self.suggestMode:
     conf.command = "nimsuggest"
+  if conf.command == "e":
+    incl(conf.globalOptions, optWasNimscript)
   loadConfigs(DefaultConfig, cache, conf, graph.idgen) # load all config files
 
   if not self.suggestMode:

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -403,7 +403,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   var
     key, val: string
   case switch.normalize
-  of "eval", "e": # (switch `e` not to be confused with command `e` for nimscript)
+  of "eval":
     expectArg(conf, switch, arg, pass, info)
     conf.projectIsCmd = true
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -409,7 +409,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)
     if conf.command == "":
       conf.command = "e" # better than "r" as a default
-      incl(conf.globalOptions, optWasNimscript)
       conf.implicitCmd = true
   of "path", "p":
     expectArg(conf, switch, arg, pass, info)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -403,7 +403,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   var
     key, val: string
   case switch.normalize
-  of "input", "i":
+  of "e": # switch `-e` (not to be confused with command `e` for nimscript)
     conf.projectIsCmd = true
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)
     if conf.command == "":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -408,7 +408,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.projectIsCmd = true
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)
     if conf.command == "":
-      conf.command = "r"
+      conf.command = "e" # better than "r" as a default
       conf.implicitCmd = true
   of "path", "p":
     expectArg(conf, switch, arg, pass, info)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -409,6 +409,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)
     if conf.command == "":
       conf.command = "e" # better than "r" as a default
+      incl(conf.globalOptions, optWasNimscript)
       conf.implicitCmd = true
   of "path", "p":
     expectArg(conf, switch, arg, pass, info)

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -403,7 +403,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   var
     key, val: string
   case switch.normalize
-  of "e": # switch `-e` (not to be confused with command `e` for nimscript)
+  of "eval", "e": # (switch `e` not to be confused with command `e` for nimscript)
+    expectArg(conf, switch, arg, pass, info)
     conf.projectIsCmd = true
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)
     if conf.command == "":
@@ -794,9 +795,6 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "def":
     expectNoArg(conf, switch, arg, pass, info)
     conf.ideCmd = ideDef
-  of "eval":
-    expectArg(conf, switch, arg, pass, info)
-    conf.evalExpr = arg
   of "context":
     expectNoArg(conf, switch, arg, pass, info)
     conf.ideCmd = ideCon

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1024,6 +1024,8 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
     lit $(%* conf.projectIsStdin)
     lit ",\L\"projectIsCmd\": "
     lit $(%* conf.projectIsCmd)
+    lit ",\L\"cmdInput\": "
+    lit $(%* conf.cmdInput)
 
     if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
       lit ",\L\"cmdline\": "
@@ -1060,8 +1062,10 @@ proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; projectfile: Absol
       return true
 
     if conf.projectIsCmd or projectIsCmd:
-      # PRTEMP compare cmdInput
-      return true
+      if not (conf.projectIsCmd and projectIsCmd): return true
+      if not data.hasKey("cmdInput"): return true
+      let cmdInput = data["cmdInput"].getStr
+      if cmdInput != conf.cmdInput: return true
 
     let depfilesPairs = data["depfiles"]
     doAssert depfilesPairs.kind == JArray

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1022,6 +1022,8 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
 
     lit ",\L\"stdinInput\": "
     lit $(%* conf.projectIsStdin)
+    lit ",\L\"projectIsCmd\": "
+    lit $(%* conf.projectIsCmd)
 
     if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
       lit ",\L\"cmdline\": "
@@ -1051,9 +1053,14 @@ proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; projectfile: Absol
       return true
     if not data.hasKey("stdinInput"): return true
     let stdinInput = data["stdinInput"].getBool
+    let projectIsCmd = data["projectIsCmd"].getBool
     if conf.projectIsStdin or stdinInput:
       # could optimize by returning false if stdin input was the same,
       # but I'm not sure how to get full stding input
+      return true
+
+    if conf.projectIsCmd or projectIsCmd:
+      # PRTEMP compare cmdInput
       return true
 
     let depfilesPairs = data["depfiles"]

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -348,11 +348,12 @@ proc mainCommand*(graph: ModuleGraph) =
     conf.cmd = cmdInteractive
     commandInteractive(graph)
   of "e":
-    if not fileExists(conf.projectFull):
+    if conf.projectIsCmd or conf.projectIsStdin: discard
+    elif not fileExists(conf.projectFull):
       rawMessage(conf, errGenerated, "NimScript file does not exist: " & conf.projectFull.string)
     elif not conf.projectFull.string.endsWith(".nims"):
       rawMessage(conf, errGenerated, "not a NimScript file: " & conf.projectFull.string)
-    # main NimScript logic handled in cmdlinehelper.nim.
+    # main NimScript logic handled in `loadConfigs`.
   of "nop", "help":
     # prevent the "success" message:
     conf.cmd = cmdDump

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -86,7 +86,7 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): P
   template processModuleAux =
     var s: PLLStream
     if sfMainModule in flags:
-      if graph.config.projectIsStdin: s = stdin.llStreamOpen 
+      if graph.config.projectIsStdin: s = stdin.llStreamOpen
       elif graph.config.projectIsCmd: s = llStreamOpen(graph.config.cmdInput)
     discard processModule(graph, result, idGeneratorFromModule(result), s)
   if result == nil:
@@ -139,12 +139,9 @@ proc compileSystemModule*(graph: ModuleGraph) =
     discard graph.compileModule(graph.config.m.systemFileIdx, {sfSystemModule})
 
 proc wantMainModule*(conf: ConfigRef) =
-  template bail(msg) =
-    fatal(conf, newLineInfo(conf, AbsoluteFile(commandLineDesc), 1, 1), errGenerated, msg)
-  if conf.projectIsCmd:
-    if conf.cmdInput.len == 0: # PRTEMP
-      bail "--input expects a command"
-  elif conf.projectFull.isEmpty: bail "command expects a filename"
+  if conf.projectFull.isEmpty:
+    fatal(conf, newLineInfo(conf, AbsoluteFile(commandLineDesc), 1, 1), errGenerated,
+        "command expects a filename")
   conf.projectMainIdx = fileInfoIdx(conf, addFileExt(conf.projectFull, NimExt))
 
 proc compileProject*(graph: ModuleGraph; projectFileIdx = InvalidFileIdx) =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -523,6 +523,7 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
   let s = if isRaw: arg else: getMessageStr(msg, arg)
   if not ignoreMsg:
     let loc = if info != unknownLineInfo: conf.toFileLineCol(info) & " " else: ""
+    # we could also show `conf.cmdInput` here for `projectIsCmd`
     var kindmsg = if kind.len > 0: KindFormat % kind else: ""
     if conf.structuredErrorHook != nil:
       conf.structuredErrorHook(conf, info, s & kindmsg, sev)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -52,6 +52,7 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
       if p.val.len > 0:
         config.commandLine.add ':'
         config.commandLine.add p.val.quoteShell
+
       if p.key == "": # `-` was passed to indicate main project is stdin
         p.key = "-"
         if processArgument(pass, p, argsCount, config): break

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -79,7 +79,8 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
 
   self.processCmdLineAndProjectPath(conf)
   var graph = newModuleGraph(cache, conf)
-  if not self.loadConfigsAndRunMainCommand(cache, conf, graph): return
+  if not self.loadConfigsAndRunMainCommand(cache, conf, graph):
+    return
   mainCommand(graph)
   if conf.hasHint(hintGCStats): echo(GC_getStatistics())
   #echo(GC_getStatistics())

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -52,7 +52,6 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
       if p.val.len > 0:
         config.commandLine.add ':'
         config.commandLine.add p.val.quoteShell
-
       if p.key == "": # `-` was passed to indicate main project is stdin
         p.key = "-"
         if processArgument(pass, p, argsCount, config): break

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -255,7 +255,7 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef; idgen: 
       if conf.projectIsStdin: s = stdin.llStreamOpen
       elif conf.projectIsCmd: s = llStreamOpen(conf.cmdInput)
     if s == nil and fileExists(p): s = llStreamOpen(p, fmRead)
-    if s!=nil:
+    if s != nil:
       configFiles.add(p)
       runNimScript(cache, p, idgen, freshDefines = false, conf, s)
 

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -251,7 +251,7 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef; idgen: 
   template runNimScriptIfExists(path: AbsoluteFile, isMain = false) =
     let p = path # eval once
     var s: PLLStream
-    if isMain and conf.command == "e":
+    if isMain and optWasNimscript in conf.globalOptions:
       if conf.projectIsStdin: s = stdin.llStreamOpen
       elif conf.projectIsCmd: s = llStreamOpen(conf.cmdInput)
     if s == nil and fileExists(p): s = llStreamOpen(p, fmRead)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -246,6 +246,7 @@ type
     evalMacroCounter*: int
     exitcode*: int8
     cmd*: TCommands  # the command
+    cmdInput*: string  # input command
     selectedGC*: TGCMode       # the selected GC (+)
     exc*: ExceptionSystem
     verbosity*: int            # how verbose the compiler is
@@ -292,6 +293,8 @@ type
     projectPath*: AbsoluteDir # holds a path like /home/alice/projects/nim/compiler/
     projectFull*: AbsoluteFile # projectPath/projectName
     projectIsStdin*: bool # whether we're compiling from stdin
+    projectIsCmd*: bool # whether we're compiling from a command input
+    implicitCmd*: bool # whether some flag triggered an implicit `command`
     lastMsgWasDot*: bool # the last compiler message was a single '.'
     projectMainIdx*: FileIndex # the canonical path id of the main module
     projectMainIdx2*: FileIndex # consider merging with projectMainIdx
@@ -439,6 +442,7 @@ proc newConfigRef*(): ConfigRef =
     projectPath: AbsoluteDir"", # holds a path like /home/alice/projects/nim/compiler/
     projectFull: AbsoluteFile"", # projectPath/projectName
     projectIsStdin: false, # whether we're compiling from stdin
+    projectIsCmd: false,
     projectMainIdx: FileIndex(0'i32), # the canonical path id of the main module
     command: "", # the main command (e.g. cc, check, scan, etc)
     commandArgs: @[], # any arguments after the main command

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -253,7 +253,6 @@ type
     exc*: ExceptionSystem
     verbosity*: int            # how verbose the compiler is
     numberOfProcessors*: int   # number of processors
-    evalExpr*: string          # expression for idetools --eval
     lastCmdTime*: float        # when caas is enabled, we measure each command
     symbolFiles*: SymbolFilesOption
 
@@ -421,7 +420,6 @@ proc newConfigRef*(): ConfigRef =
     macrosToExpand: newStringTable(modeStyleInsensitive),
     arcToExpand: newStringTable(modeStyleInsensitive),
     m: initMsgConfig(),
-    evalExpr: "",
     cppDefines: initHashSet[string](),
     headerFile: "", features: {}, legacyFeatures: {}, foreignPackageNotes: {hintProcessing, warnUnknownMagic,
     hintQuitCalled, hintExecuting},

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -247,6 +247,8 @@ type
     exitcode*: int8
     cmd*: TCommands  # the command
     cmdInput*: string  # input command
+    projectIsCmd*: bool # whether we're compiling from a command input
+    implicitCmd*: bool # whether some flag triggered an implicit `command`
     selectedGC*: TGCMode       # the selected GC (+)
     exc*: ExceptionSystem
     verbosity*: int            # how verbose the compiler is
@@ -293,8 +295,6 @@ type
     projectPath*: AbsoluteDir # holds a path like /home/alice/projects/nim/compiler/
     projectFull*: AbsoluteFile # projectPath/projectName
     projectIsStdin*: bool # whether we're compiling from stdin
-    projectIsCmd*: bool # whether we're compiling from a command input
-    implicitCmd*: bool # whether some flag triggered an implicit `command`
     lastMsgWasDot*: bool # the last compiler message was a single '.'
     projectMainIdx*: FileIndex # the canonical path id of the main module
     projectMainIdx2*: FileIndex # consider merging with projectMainIdx
@@ -442,7 +442,6 @@ proc newConfigRef*(): ConfigRef =
     projectPath: AbsoluteDir"", # holds a path like /home/alice/projects/nim/compiler/
     projectFull: AbsoluteFile"", # projectPath/projectName
     projectIsStdin: false, # whether we're compiling from stdin
-    projectIsCmd: false,
     projectMainIdx: FileIndex(0'i32), # the canonical path id of the main module
     command: "", # the main command (e.g. cc, check, scan, etc)
     commandArgs: @[], # any arguments after the main command

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -199,7 +199,7 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
 
 proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
                    idgen: IdGenerator;
-                   freshDefines=true; conf: ConfigRef) =
+                   freshDefines=true; conf: ConfigRef, stream: PLLStream) =
   let oldSymbolFiles = conf.symbolFiles
   conf.symbolFiles = disabledSf
 
@@ -226,7 +226,7 @@ proc runNimScript*(cache: IdentCache; scriptName: AbsoluteFile;
   graph.vm = vm
 
   graph.compileSystemModule()
-  discard graph.processModule(m, vm.idgen, llStreamOpen(scriptName, fmRead))
+  discard graph.processModule(m, vm.idgen, stream)
 
   # watch out, "newruntime" can be set within NimScript itself and then we need
   # to remember this:

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2113,14 +2113,14 @@ proc evalStmt*(c: PCtx, n: PNode) =
   if c.code[start].opcode != opcEof:
     discard execute(c, start)
 
-when false:
-  proc evalExpr*(c: PCtx, n: PNode): PNode =
-    # `nim --eval:"expr"` might've used it at some point for idetools; could
-    # be revived for nimsuggest
-    let n = transformExpr(c.graph, c.idgen, c.module, n)
-    let start = genExpr(c, n)
-    assert c.code[start].opcode != opcEof
-    result = execute(c, start)
+proc evalExpr*(c: PCtx, n: PNode): PNode =
+  # deadcode
+  # `nim --eval:"expr"` might've used it at some point for idetools; could
+  # be revived for nimsuggest
+  let n = transformExpr(c.graph, c.idgen, c.module, n)
+  let start = genExpr(c, n)
+  assert c.code[start].opcode != opcEof
+  result = execute(c, start)
 
 proc getGlobalValue*(c: PCtx; s: PSym): PNode =
   internalAssert c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2113,11 +2113,14 @@ proc evalStmt*(c: PCtx, n: PNode) =
   if c.code[start].opcode != opcEof:
     discard execute(c, start)
 
-proc evalExpr*(c: PCtx, n: PNode): PNode =
-  let n = transformExpr(c.graph, c.idgen, c.module, n)
-  let start = genExpr(c, n)
-  assert c.code[start].opcode != opcEof
-  result = execute(c, start)
+when false:
+  proc evalExpr*(c: PCtx, n: PNode): PNode =
+    # `nim --eval:"expr"` might've used it at some point for idetools; could
+    # be revived for nimsuggest
+    let n = transformExpr(c.graph, c.idgen, c.module, n)
+    let start = genExpr(c, n)
+    assert c.code[start].opcode != opcEof
+    result = execute(c, start)
 
 proc getGlobalValue*(c: PCtx; s: PSym): PNode =
   internalAssert c.config, s.kind in {skLet, skVar} and sfGlobal in s.flags

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -31,9 +31,9 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
-  -e, --eval:cmd            evaluates (compiles and runs) nim code directly
-                            implies `e` (nimscript) if no command is provided, but
-                            customizable and works with all other flags.
+  -e, --eval:cmd            evaluates nim code directly; e.g.: `nim -e:"echo 1"`
+                            defaults to `e` (nimscript) but customizable:
+                            `nim r -e:'for a in stdin.lines: echo a'`
   --fullhelp                show all command line switches
   -h, --help                show this help
   -v, --version             show detailed version information

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -31,7 +31,7 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
-  -e:cmd                    evaluates (compiles and runs) nim code directly
+  -e, --eval:cmd            evaluates (compiles and runs) nim code directly
                             implies `r` command if no command is provided.
   --fullhelp                show all command line switches
   -h, --help                show this help

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -32,7 +32,8 @@ Options:
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
   -e, --eval:cmd            evaluates (compiles and runs) nim code directly
-                            implies `r` command if no command is provided.
+                            implies `e` (nimscript) if no command is provided, but
+                            customizable and works with all other flags.
   --fullhelp                show all command line switches
   -h, --help                show this help
   -v, --version             show detailed version information

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -31,9 +31,9 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
-  -e, --eval:cmd            evaluates nim code directly; e.g.: `nim -e:"echo 1"`
+  --eval:cmd                evaluates nim code directly; e.g.: `nim --eval:"echo 1"`
                             defaults to `e` (nimscript) but customizable:
-                            `nim r -e:'for a in stdin.lines: echo a'`
+                            `nim r --eval:'for a in stdin.lines: echo a'`
   --fullhelp                show all command line switches
   -h, --help                show this help
   -v, --version             show detailed version information

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -31,7 +31,7 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
-  -i:cmd, --input:cmd       compiles and runs nim code contained in `cmd` string.
+  -e:cmd                    evaluates (compiles and runs) nim code directly
                             implies `r` command if no command is provided.
   --fullhelp                show all command line switches
   -h, --help                show this help

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -31,6 +31,8 @@ Options:
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
   -r, --run                 run the compiled program with given arguments
+  -i:cmd, --input:cmd       compiles and runs nim code contained in `cmd` string.
+                            implies `r` command if no command is provided.
   --fullhelp                show all command line switches
   -h, --help                show this help
   -v, --version             show detailed version information


### PR DESCRIPTION
## why?
* so I don't have to reach for python/D/node/bash next time I want to run a quick one-off one-liner, or open a nim file just for something I'll use once, and because I can write this faster in nim than looking up bash specific commands:
```
# using c backend:
find . | nim -e:'import os,times; for a in stdin.lines: (if a.getLastAccessTime > getTime()-1.hours: echo a)'

# or as a fast calculator thanks to nimscript:
nim e -e:'echo 1/3'
```


## common in other languages
* python: `python3 -c 'print(1+1)'`
* D: `rdmd --eval 'writeln(1+1)'`
* node: `node -e 'console.log(1+1)'`
* mongo: `mongo --eval '1+1'`
* ruby: `ruby -e 'print(1+1)'`
* perl: `perl -e 'print 1+1'`
* bash: `bash -c 'echo 1'`
* matlab, octave: `matlab -r 'disp(1+1)'`
etc... (even if those also have a `pipe code from stdin` variant )

## often better than the existing `echo cmd | nim r -`
* can be used with a shell command
* `echo cmd | nim r -` **prevents using stdin**, which prevents many useful cases (streaming based) in one-off commands. This new feature allows using stdin, eg:
```
`yes | nim -e:'for a in stdin.lines: echo (a,)'`
find . | nim -e:'import os; for a in stdin.lines: echo a.splitFile.ext'
```

* `echo cmd | nim r -` already exists but this new feature is simpler to use: less typing is essential for quick evaluation, eg:
```
echo "echo 1+1" | nim r -
vs
nim -e:"echo 1+1"
```
* furthermore, that's easy to edit on cmdline (press arrow up to recall previous cmd, then edit the cmd which is conveniently in last position)
* I'm now more inclined to use `nim` rather than python or D everytime I need a quick expression evaluator/calculator etc

## not redundant with `inim`
inim is very useful in general but doesn't replace the simplicity of this standalone, dependency free feature. Furthermore, inim can't be used like that, only as a pipe which has same drawbacks as `echo 'echo 1+1' | nim r -' (prevents using stdin etc)

## usage: works with all existing features (ie orthogonal design)
(or at least should, all combinations I tried work)

```bash
nim -e:cmd # implies `r` command, writes to $HOME/.cache/nim/cmdfile_d/cmdfile
nim -e:cmd - # - takes placeholder of the file position; same behavior as above
nim r -e:cmd - # `r` is now explicit; same behavior as above
nim js -r -e:cmd # this also works
nim r -b:js -e:cmd # ditto
nim doc -r -b:js -e:cmd -d:foo # ditto

# when a filename is given (instead of - or no positional argument), it's used to read in config nims/cfg files as usual
# this is consistent with other commands, eg `nim dump pathto/main.nim`
nim -e:cmd pathto/main.nim # will pretend pathto/main.nim contains `cmd` and read any config nims/cfg found as usual

# runtime arguments work too, but obviously consumes a file placeholder
nim -e:cmd - arg1 arg2 # commandLineParams().len would be 2
nim -e:cmd pathto/main.nim arg1 arg2 # explicit filename given
nim r -e:cmd pathto/main.nim arg1 arg2 # same as above

# also works in combination with nimscript, and is quite useful for the speed it offers
nim e -e:cmd
nim e -e:cmd -
nim e -e:cmd patho/main.nims # analog to `nim r -e:cmd patho/main.nim`, will pretend pathto/main.nims contains `cmd` and read any config nims/cfg found as usual
```

## newlines are also possible if it doesn't fit in a 1-liner
```bash
# this:
nim -e:'
echo 1
echo 2'

# or this (among other possibilities):
nim -e:"$(printf 'echo 1\necho 2')"
```

## honors `betterRun` to avoid recompiling when -e:cmd doesn't change
```
nim -e:cmd - foo
nim -e:cmd - bar # re-runs with a different runtime argument but doesn't recompile
```

## bikeshedding
I initially used `-i` (for `input`) but changed it to `-e` (for eval), which is consistent with majority of languages

## preexisting bugfix
`echo 'echo 1/3' | nim e -` now works; fixes https://github.com/nim-lang/Nim/issues/15731

