### PR TITLE
add args optional param to osproc.execCmdEx

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,11 +3,12 @@
 
 
 ## Standard library additions and changes
-- Added `args` optional param to `osproc.execCmdEx`
 
 - `prelude` now works with the JavaScript target.
 
 - Added `ioutils` module containing `duplicate` and `duplicateTo` to duplicate `FileHandle` using C function `dup` and `dup2`.
+
+- Added `osproc.execArgs`
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 
 
 ## Standard library additions and changes
+- Added `args` optional param to `osproc.execCmdEx`
 
 - `prelude` now works with the JavaScript target.
 

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -267,16 +267,16 @@ else: # main driver
     doAssert waitForExit(p) == QuitFailure # avoid zombies
 
   import std/strtabs
-  block execProcess:
+  block: # execArgs, execCmdEx
     var result = execCmdEx(fmt"{nim} r --hints:off -", options = {}, input = "echo 3*4")
     stripLineEnd(result[0])
     doAssert result == ("12", 0)
 
-    block: # args
-      var result2 = execCmdEx(fmt"{nim}", options = {}, input = "echo 3*4", args = ["r", "--hints:off", "-"])
+    block:
+      var result2 = execArgs(fmt"{nim}", ["r", "--hints:off", "-"], options = {}, input = "echo 3*4")
       stripLineEnd(result2[0])
       doAssert result2 == result
-      doAssertRaises(OSError): discard execCmdEx(fmt"{nim} r --hints:off -", options = {}, input = "echo 3*4", args = [])
+      doAssertRaises(OSError): discard execArgs(fmt"{nim} r --hints:off -", @[], options = {}, input = "echo 3*4")
 
     when not defined(windows):
       doAssert execCmdEx("ls --nonexistant").exitCode != 0

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -276,7 +276,7 @@ else: # main driver
       var result2 = execCmdEx(fmt"{nim}", options = {}, input = "echo 3*4", args = ["r", "--hints:off", "-"])
       stripLineEnd(result2[0])
       doAssert result2 == result
-      doAssertRaises(OSError): discard execCmdEx(fmt"{nim} r --hints:off -", options = {}, input = "echo 3*4", useArgs = true)
+      doAssertRaises(OSError): discard execCmdEx(fmt"{nim} r --hints:off -", options = {}, input = "echo 3*4", args = [])
 
     when not defined(windows):
       doAssert execCmdEx("ls --nonexistant").exitCode != 0

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -81,7 +81,7 @@ elif defined(case_testfile4):
 
 else: # main driver
   import stdtest/[specialpaths, unittest_light]
-  import os, osproc, strutils
+  import os, osproc, strutils, strformat
   const nim = getCurrentCompilerExe()
   const sourcePath = currentSourcePath()
   let dir = getCurrentDir() / "tests" / "osproc"
@@ -267,10 +267,17 @@ else: # main driver
     doAssert waitForExit(p) == QuitFailure # avoid zombies
 
   import std/strtabs
-  block execProcessTest:
-    var result = execCmdEx("nim r --hints:off -", options = {}, input = "echo 3*4")
+  block execProcess:
+    var result = execCmdEx(fmt"{nim} r --hints:off -", options = {}, input = "echo 3*4")
     stripLineEnd(result[0])
     doAssert result == ("12", 0)
+
+    block: # args
+      var result2 = execCmdEx(fmt"{nim}", options = {}, input = "echo 3*4", args = ["r", "--hints:off", "-"])
+      stripLineEnd(result2[0])
+      doAssert result2 == result
+      doAssertRaises(OSError): discard execCmdEx(fmt"{nim} r --hints:off -", options = {}, input = "echo 3*4", useArgs = true)
+
     when not defined(windows):
       doAssert execCmdEx("ls --nonexistant").exitCode != 0
     when false:


### PR DESCRIPTION
followup after #14211
args is occasionally more convenient that passing a cmdline to be passed to the shell, or when using the shell is undesirable. This also makes things more consistent given that the other procs accept optional `args`.
`useArgs` is needed when user isn't sure whether args.len>0 but he's not passing a shell command

## future work
* remove `execCmdEx2` in testament/testament.nim to use that instead

* pending https://github.com/nim-lang/Nim/issues/15722, we'll be able to simplify the implementation (same user interface) by using compile time option type, eg:

```nim
proc execCmdEx(..., args: openArray[string] or tuple[] = ()): ...
```
which would avoid have 2 overloads of `execCmdEx` and 1 extra `execCmdExImpl`, and instead would allow having a single `execCmdEx`, which would be able to do `when args is tuple[]`; the problem is currently that this pattern, while it works with other types, doesn't work with openArray.
