### PR TITLE
Fixed iteration limit hit from execproc

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2078,6 +2078,7 @@ proc execute(c: PCtx, start: int): PNode =
   result = rawExecute(c, start, tos).regToNode
 
 proc execProc*(c: PCtx; sym: PSym; args: openArray[PNode]): PNode =
+  c.loopIterations = c.config.maxLoopIterationsVM
   if sym.kind in routineKinds:
     if sym.typ.len-1 != args.len:
       localError(c.config, sym.info,


### PR DESCRIPTION
When calling procs from Nimscript in Nim you could hit the VM iteration limit even though the code is functioning properly. This resolves that by making the iteration limit reset eachtime you call a proc.