### PR TITLE
[backport] fix #15595 procvar `==` works in VM

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -993,9 +993,9 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       else:
         let nb = regs[rb].node
         let nc = regs[rc].node
-        if nb.kind != nc.kind: discard
-        elif (nb == nc) or (nb.kind == nkNilLit): ret = true
-        elif nb.kind == nkIntLit and nb.intVal == nc.intVal: # TODO: nkPtrLit
+        if sameConstant(nb, nc): ret = true
+          # this also takes care of procvar's, represented as nkTupleConstr, eg (nil, nil)
+        elif nb.kind == nkIntLit and nc.kind == nkIntLit and nb.intVal == nc.intVal: # TODO: nkPtrLit
           let tb = nb.getTyp
           let tc = nc.getTyp
           ret = tb.kind in PtrLikeKinds and tc.kind == tb.kind

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -993,7 +993,9 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       else:
         let nb = regs[rb].node
         let nc = regs[rc].node
-        if sameConstant(nb, nc): ret = true
+        if nb.kind != nc.kind: discard
+        elif (nb == nc) or (nb.kind == nkNilLit): ret = true # intentional
+        elif sameConstant(nb, nc): ret = true
           # this also takes care of procvar's, represented as nkTupleConstr, eg (nil, nil)
         elif nb.kind == nkIntLit and nc.kind == nkIntLit and nb.intVal == nc.intVal: # TODO: nkPtrLit
           let tb = nb.getTyp

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -205,6 +205,30 @@ block: # bug #13081
   static:
     doAssert j1.x1 == 12
 
+block: # bug #15595
+  proc fn0()=echo 0
+  proc fn1()=discard
+  proc main=
+    var local = 0
+    proc fn2()=echo local
+    var a0 = fn0
+    var a1 = fn1
+    var a2 = fn2
+    var a3: proc()
+    var a4: proc()
+    doAssert a0 == fn0 # bugfix
+    doAssert a1 == fn1 # ditto
+    doAssert a2 == fn2 # ditto
+
+    doAssert fn0 != fn1
+
+    doAssert a2 != nil
+    doAssert a3 == nil # bugfix
+
+    doAssert a3 == a4 # bugfix
+  static: main()
+  main()
+
 # bug #15363
 import sequtils
 


### PR DESCRIPTION
fix #15595

`==` was badly broken for procvar's in VM before PR; code didn't consider fact that procvar can be a `nkTupleConstr` (eg: `(nil,nil)`)