### PR TITLE
Document implicit return values from procedures

### DIFF
--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -641,6 +641,16 @@ initialised with the type's default value. Note that referential data types will
 be ``nil`` at the start of the procedure, and thus may require manual
 initialisation.
 
+A procedure that does not have any ``return`` statement and does not use the
+special ``result`` variable returns the value of its last expression. For example,
+this procedure
+
+.. code-block:: nim
+    :test: "nim c $1"
+  proc helloWorld(): string =
+      "Hello, World!"
+
+returns the string "Hello, World!".
 
 Parameters
 ----------


### PR DESCRIPTION
I am new to Nim.

After reading the tutorials I've started doing exercism.io exercises, and the first hello world comes with a suggested implementation generated that is similar to the procedure in the example. This surprised to me, since the tutorial did not mention this was possible. I do not find it in the manual either.

I've done a few tests and Nim seems to act like Perl, Ruby, and other languages in which the last expression is returned. I've noticed as well that as soon as there is a `return` statement or the variable `result` is used anywhere in the body, this rule does not hold.

So I wrote this patch optimistically, but I do not know what I am doing really :).