### PR TITLE
fix #15740 --hint:conf now works more reliably

### DIFF
--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -287,16 +287,21 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef; idgen: 
     if cfg == DefaultConfig:
       runNimScriptIfExists(pd / DefaultConfigNims)
 
-  for filename in configFiles:
-    # delayed to here so that `hintConf` is honored
-    rawMessage(conf, hintConf, filename.string)
-
   let scriptFile = conf.projectFull.changeFileExt("nims")
+  let isMain = scriptFile == conf.projectFull
+  template showHintConf =
+    for filename in configFiles:
+      # delayed to here so that `hintConf` is honored
+      rawMessage(conf, hintConf, filename.string)
+  if isMain:
+    showHintConf()
+    configFiles.setLen 0
   if conf.command != "nimsuggest":
     runNimScriptIfExists(scriptFile)
   else:
-    if scriptFile != conf.projectFull:
+    if not isMain:
       runNimScriptIfExists(scriptFile)
     else:
       # 'nimsuggest foo.nims' means to just auto-complete the NimScript file
       discard
+  showHintConf()


### PR DESCRIPTION
# fixes https://github.com/nim-lang/Nim/issues/15740

input:

earlier_configs.nims (ie all other cfg and nims files that are processed before main.nims)
main.nims
main.nim

### before PR
nim r --hint:conf main.nim
earlier_configs.nims [Conf]

ditto with nim e --hint:conf main.nims

### after PR
nim r --hint:conf main.nim
earlier_configs.nims [Conf]
main.nims [Conf]

ditto with nim e --hint:conf main.nims

# fixes another bug, that --hint:conf is not honored if it's in main.nims
after this PR, `nim r main.nim` honors a --hint:conf even if it appears in main.nims

### note for `nim e main.nims`
it will print conf hints before main.nims starts processing (since that's now the main file we're interested in), and a --hint:conf that appears in main.nims will apply to that last main.nims file in this case

