### PR TITLE
fix #14272 #12349 -d:release -d:danger -d:nimLto -d:nimStrip honor user config

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -393,9 +393,17 @@ proc handleStdinInput*(conf: ConfigRef) =
 
 proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
                     conf: ConfigRef) =
+  let switch2 = switch.normalize
+  if conf.switchesProcessed.contains switch2:
+    if conf.switchesProcessedLazy:
+      # eg: if -d:danger sets stacktrace:off but some config already set `stacktrace`, skip
+      return
+  else:
+    conf.switchesProcessed.add switch2
+
   var
     key, val: string
-  case switch.normalize
+  case switch2
   of "path", "p":
     expectArg(conf, switch, arg, pass, info)
     for path in nimbleSubs(conf, arg):

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -267,6 +267,8 @@ type
     cmdlineNotes*: TNoteKinds # notes that have been set/unset from cmdline
     foreignPackageNotes*: TNoteKinds
     notes*: TNoteKinds # notes after resolving all logic(defaults, verbosity)/cmdline/configs
+    switchesProcessed*: seq[string]
+    switchesProcessedLazy*: bool
     warningAsErrors*: TNoteKinds
     mainPackageNotes*: TNoteKinds
     mainPackageId*: int
@@ -550,6 +552,7 @@ const
   TexExt* = "tex"
   IniExt* = "ini"
   DefaultConfig* = RelativeFile"nim.cfg"
+  DefaultConfigEpilogue* = RelativeFile"nim_epilogue.cfg"
   DefaultConfigNims* = RelativeFile"config.nims"
   DocConfig* = RelativeFile"nimdoc.cfg"
   DocTexConfig* = RelativeFile"nimdoc.tex.cfg"

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -52,38 +52,6 @@ path="$lib/pure"
   nimblepath="$home/.nimble/pkgs/"
 @end
 
-@if danger or quick:
-  obj_checks:off
-  field_checks:off
-  range_checks:off
-  bound_checks:off
-  overflow_checks:off
-  assertions:off
-  stacktrace:off
-  linetrace:off
-  debugger:off
-  line_dir:off
-  dead_code_elim:on
-  @if nimHasNilChecks:
-    nilchecks:off
-  @end
-@end
-
-@if release or danger:
-  stacktrace:off
-  excessiveStackTrace:off
-  linetrace:off
-  debugger:off
-  line_dir:off
-  opt:speed
-  define:release
-@end
-
-@if false: # not danger: # this does not work yet.
-  clang.options.always %= "${clang.options.always} -fsanitize=null -fsanitize-undefined-trap-on-error"
-  gcc.options.always %= "${gcc.options.always} -fsanitize=null -fsanitize-undefined-trap-on-error"
-@end
-
 @if unix and mingw:
   # Cross compile for Windows from Linux/OSX using MinGW
   i386.windows.gcc.exe = "i686-w64-mingw32-gcc"
@@ -259,20 +227,6 @@ clang.options.always = "-w -ferror-limit=3"
 clang.options.speed = "-O3"
 clang.options.size = "-Os"
 
-@if windows:
-  clang_cl.cpp.options.always %= "${clang_cl.options.always} /EHsc"
-  @if not release and not safety and not danger:
-    clang_cl.options.linker = "/Z7"
-    clang_cl.cpp.options.linker = "/Z7"
-  @end
-  clang.options.debug = "-g -gcodeview"
-  clang.cpp.options.debug = "-g -gcodeview"
-  @if not release and not safety and not danger:
-    clang.options.linker = "-g"
-    clang.cpp.options.linker = "-g"
-  @end
-@end
-
 # Configuration for the Visual C/C++ compiler:
 # VCCEXE is a tool that invokes the Visual Studio Developer Command Prompt
 # before calling the compiler.
@@ -326,36 +280,4 @@ tcc.options.always = "-w"
   --multimethods:on
   --define:nimOldCaseObjects
   --define:nimOldShiftRight
-@end
-
-@if lto or lto_incremental:
-  @if lto_incremental:
-   vcc.options.always%= "${vcc.options.always} /GL /Gw /Gy"
-   vcc.cpp.options.always%= "${vcc.cpp.options.always} /GL /Gw /Gy"
-   vcc.options.linker %= "${vcc.options.linker} /link /LTCG:incremental"
-   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /link /LTCG:incremental"
-  @else:
-   vcc.options.always%= "${vcc.options.always} /GL"
-   vcc.cpp.options.always%= "${vcc.cpp.options.always} /GL"
-   vcc.options.linker %= "${vcc.options.linker} /link /LTCG"
-   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /link /LTCG"
-  @end
-  clang_cl.options.always%= "${clang_cl.options.always} -flto"
-  clang_cl.cpp.options.always%= "${clang.cpp.options.always} -flto"
-  clang.options.always%= "${clang.options.always} -flto"
-  clang.cpp.options.always%= "${clang.cpp.options.always} -flto"
-  icl.options.always %= "${icl.options.always} /Qipo"
-  icl.cpp.options.always %= "${icl.cpp.options.always} /Qipo"
-  gcc.options.always %= "${gcc.options.always} -flto"
-  gcc.cpp.options.always %= "${gcc.cpp.options.always} -flto"
-  clang.options.linker %= "${clang.options.linker} -fuse-ld=lld -flto"
-  clang.cpp.options.linker %= "${clang.cpp.options.linker} -fuse-ld=lld -flto"
-  gcc.options.linker %= "${gcc.options.linker} -flto"
-  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -flto"
-@end
-@if strip:
-  gcc.options.linker %= "${gcc.options.linker} -s"
-  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -s"
-  clang.options.linker %= "${clang.options.linker} -s"
-  clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
 @end

--- a/config/nim_epilogue.cfg
+++ b/config/nim_epilogue.cfg
@@ -1,0 +1,79 @@
+@if danger or quick:
+  obj_checks:off
+  field_checks:off
+  range_checks:off
+  bound_checks:off
+  overflow_checks:off
+  assertions:off
+  stacktrace:off
+  linetrace:off
+  debugger:off
+  line_dir:off
+  dead_code_elim:on
+  @if nimHasNilChecks:
+    nilchecks:off
+  @end
+@end
+
+@if release or danger:
+  stacktrace:off
+  excessiveStackTrace:off
+  linetrace:off
+  debugger:off
+  line_dir:off
+  opt:speed
+  define:release
+@end
+
+@if windows:
+  clang_cl.cpp.options.always %= "${clang_cl.options.always} /EHsc"
+  @if not release and not safety and not danger:
+    clang_cl.options.linker = "/Z7"
+    clang_cl.cpp.options.linker = "/Z7"
+  @end
+  clang.options.debug = "-g -gcodeview"
+  clang.cpp.options.debug = "-g -gcodeview"
+  @if not release and not safety and not danger:
+    clang.options.linker = "-g"
+    clang.cpp.options.linker = "-g"
+  @end
+@end
+
+@if false: # not danger: # this does not work yet.
+  clang.options.always %= "${clang.options.always} -fsanitize=null -fsanitize-undefined-trap-on-error"
+  gcc.options.always %= "${gcc.options.always} -fsanitize=null -fsanitize-undefined-trap-on-error"
+@end
+
+@if nimLto or nimLto_incremental or lto or lto_incremental:
+  @if nimLto_incremental or lto_incremental:
+   vcc.options.always%= "${vcc.options.always} /GL /Gw /Gy"
+   vcc.cpp.options.always%= "${vcc.cpp.options.always} /GL /Gw /Gy"
+   vcc.options.linker %= "${vcc.options.linker} /link /LTCG:incremental"
+   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /link /LTCG:incremental"
+  @else:
+   vcc.options.always%= "${vcc.options.always} /GL"
+   vcc.cpp.options.always%= "${vcc.cpp.options.always} /GL"
+   vcc.options.linker %= "${vcc.options.linker} /link /LTCG"
+   vcc.cpp.options.linker %= "${vcc.cpp.options.linker} /link /LTCG"
+  @end
+  clang_cl.options.always%= "${clang_cl.options.always} -flto"
+  clang_cl.cpp.options.always%= "${clang.cpp.options.always} -flto"
+  clang.options.always%= "${clang.options.always} -flto"
+  clang.cpp.options.always%= "${clang.cpp.options.always} -flto"
+  icl.options.always %= "${icl.options.always} /Qipo"
+  icl.cpp.options.always %= "${icl.cpp.options.always} /Qipo"
+  gcc.options.always %= "${gcc.options.always} -flto"
+  gcc.cpp.options.always %= "${gcc.cpp.options.always} -flto"
+  clang.options.linker %= "${clang.options.linker} -fuse-ld=lld -flto"
+  clang.cpp.options.linker %= "${clang.cpp.options.linker} -fuse-ld=lld -flto"
+  gcc.options.linker %= "${gcc.options.linker} -flto"
+  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -flto"
+@end
+
+@if nimStrip or strip:
+  gcc.options.linker %= "${gcc.options.linker} -s"
+  gcc.cpp.options.linker %= "${gcc.cpp.options.linker} -s"
+  clang.options.linker %= "${clang.options.linker} -s"
+  clang.cpp.options.linker %= "${clang.cpp.options.linker} -s"
+@end
+


### PR DESCRIPTION
@araq early feedback welcome before I go down this road further, simple things at least seem to work as intended

* fix #14272 #12349 -d:release -d:danger -d:nimLto -d:nimStrip honor user config
* -d:nimLto aliases -d:lto and -d:lto should get deprecated, ditto with strip
* this is mostly orthogonal to https://github.com/nim-lang/RFCs/issues/278, `--opt:release` + friends is not discussed in this PR

this should work:

* meta flags (-d:release -d:danger -d:nimLto -d:nimStrip for now, more generally flags that set other flags) should now honor user config.
* if a flag `foo` (eg: `stacktrace:on`) is set in user config, then a meta flag (eg: -d:danger) will not override it

eg:
```
# in ~/.config/config.nims
--stacktrace:on

# in myproj/config.nims
-d:danger
```

```
nim r myproj/main.nim
# behaves like `nim r -d:danger --stacktrace:on myproj/main.nim`
```
ie, --stacktrace:on will be honored, and other flags set by meta-flag -d:danger will be honored

## caveats
normal flags should work but I haven't tried the situation where a user sets a configvar flag (dotted flags like `clang_cl.options.linker`) and then it gets reset in nim_epilogue.cfg.

## TODO before merging
add tests

this needs more testing, please try and break it and report back.

