### PR TITLE
refactor(nimdoc): rewrite docs JS in Nim

### DIFF
--- a/config/doc.nim
+++ b/config/doc.nim
@@ -1,0 +1,41 @@
+import dom
+import jsffi
+
+let localStorage {.importc, nodecl.}: LocalStorage
+let documentDocumentElement {.importc: "document.documentElement",
+    nodecl.}: Element
+let documentDocumentElementDataset {.importc: "document.documentElement.dataset",
+    nodecl.}: JSObject
+
+proc main* {.exportc.} =
+  let toggleSwitch = document.querySelector(""".theme-switch input[type="checkbox"]""")
+  let currentTheme = localStorage.getItem("theme")
+
+
+  if (not currentTheme.isNull()):
+    documentDocumentElementDataset.theme = currentTheme
+
+    if currentTheme == "dark" and not toggleSwitch.isNull():
+      toggleSwitch.checked = true
+
+  if not toggleSwitch.isNull():
+    toggleSwitch.addEventListener("change", proc (event: Event) =
+      let eventTarget = cast[JSObject](event).target
+      let checked: bool = cast[bool](eventTarget.checked)
+      let theme = if checked: "dark" else: "light"
+
+      documentDocumentElementDataset.theme = theme
+      localStorage.setItem("theme", theme),
+      false)
+
+  let pragmaDots = document.getElementsByClassName("pragmadots")
+
+  for item in pragmaDots:
+    item.addEventListener("click", proc (event: Event) =
+      # Hide tease
+      # event.target.parentNode.style.display = "none";
+      cast[JSObject](event.target).parentNode.style.display = "none";
+      # Show actual
+      cast[JSObject](event.target).parentNode.nextElementSibling.style.display = "inline";
+    ,
+    false)

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -234,41 +234,7 @@ doc.file = """<?xml version="1.0" encoding="utf-8" ?>
 
 <script type="text/javascript" src="$dochackjs"></script>
 
-<script type="text/javascript">
-function main() {
-  var pragmaDots = document.getElementsByClassName("pragmadots");
-  for (var i = 0; i < pragmaDots.length; i++) {
-    pragmaDots[i].onclick = function(event) {
-      // Hide tease
-      event.target.parentNode.style.display = "none";
-      // Show actual
-      event.target.parentNode.nextElementSibling.style.display = "inline";
-    }
-  }
-
-  const toggleSwitch = document.querySelector('.theme-switch input[type="checkbox"]');
-  function switchTheme(e) {
-      if (e.target.checked) {
-          document.documentElement.setAttribute('data-theme', 'dark');
-          localStorage.setItem('theme', 'dark');
-      } else {
-          document.documentElement.setAttribute('data-theme', 'light');
-          localStorage.setItem('theme', 'light');
-      }
-  }
-
-  toggleSwitch.addEventListener('change', switchTheme, false);
-
-  const currentTheme = localStorage.getItem('theme') ? localStorage.getItem('theme') : null;
-  if (currentTheme) {
-    document.documentElement.setAttribute('data-theme', currentTheme);
-
-    if (currentTheme === 'dark') {
-      toggleSwitch.checked = true;
-    }
-  }
-}
-</script>
+<script type="text/javascript" src="$docjs"></script>
 
 </head>
 <body onload="main()">


### PR DESCRIPTION
As discussed on the Nim Discord yesterday this rewrites the JS on the generated docs to use a script rewritten in Nim.
It also fixes a bug where the preferred theme would not be applied on `theindex.html`.
Unfortunately I couldn't figure out how to fully integrate the new script into the build system.

I dropped the Nim file I wrote in `config/doc.nim` and am requesting that someone with more knowledge of the build system move it somewhere appropriate.
Looking at how `dochack.js` is used this seems like a relatively complex task to do, but I'd be happy to help if given proper guidance.

- [ ] Move the new Nim file somewhere appropriate
- [ ] Compile it just like dochack during doc generation
- [ ] Update tests for the new output
- [ ] Maybe add tests for the new Nim file?