### PR TITLE
Spawn in arc doesn't need gcsafe proc

### DIFF
--- a/compiler/spawn.nim
+++ b/compiler/spawn.nim
@@ -325,7 +325,7 @@ proc wrapProcForSpawn*(g: ModuleGraph; idgen: IdGenerator; owner: PSym; spawnExp
   if n.kind notin nkCallKinds:
     localError(g.config, n.info, "'spawn' takes a call expression; got " & $n)
     return
-  if optThreadAnalysis in g.config.globalOptions:
+  if optThreadAnalysis in g.config.globalOptions and g.config.selectedGC notin {gcArc, gcOrc}:
     if {tfThread, tfNoSideEffect} * n[0].typ.flags == {}:
       localError(g.config, n.info, "'spawn' takes a GC safe call expression")
 


### PR DESCRIPTION
While I was removing {.gcsafe.} sprinkle from the code I have found spawn still does gcsafe analysis which no longer mandatory.
Which this change I can remove all {.gcsafe.} annotations in my project.