### PR TITLE
IPv6 text representation according to RFC 5952

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1807,7 +1807,7 @@ proc `$`*(address: IpAddress): string =
         var word: uint16 = (cast[uint16](address.address_v6[i*2])) shl 8
         word = word or cast[uint16](address.address_v6[i*2+1])
 
-        if biggestZeroCount != 0 and # Check if group is in skip group
+        if biggestZeroCount > 1 and # Check if group is in skip group
           (i >= biggestZeroStart and i < (biggestZeroStart + biggestZeroCount)):
           if i == biggestZeroStart: # skip start
             result.add("::")


### PR DESCRIPTION
Currently, the textual representation of IPv6 in Nim shortens a single group of zeros within the IPv6 address with "::". Let's see:
```
::2:3:4:5:6:7:8
1::3:4:5:6:7:8
1:2::4:5:6:7:8
1:2:3::5:6:7:8
1:2:3:4::6:7:8
1:2:3:4:5::7:8
1:2:3:4:5:6::8
1:2:3:4:5:6:7::
```

Yes, this is in accordance with [RFC 4291](https://tools.ietf.org/html/rfc4291#section-2.2). However, there is [RFC 5952](https://tools.ietf.org/html/rfc5952#section-4) which recommends not to shorten a single group of zeros with "::". The above examples would look like this:
```
0:2:3:4:5:6:7:8
1:0:3:4:5:6:7:8
1:2:0:4:5:6:7:8
1:2:3:0:5:6:7:8
1:2:3:4:0:6:7:8
1:2:3:4:5:0:7:8
1:2:3:4:5:6:0:8
1:2:3:4:5:6:7:0
```

Therefore, I made this pull request to discuss which representation to adopt.