### PR TITLE
Make default state public

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - `prelude` now works with the JavaScript target.
 
 - Added `ioutils` module containing `duplicate` and `duplicateTo` to duplicate `FileHandle` using C function `dup` and `dup2`.
-
+- Added `randState` template that exposes the default random number generator. Useful for library authors.
 
 ## Language changes
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -119,10 +119,11 @@ else:
     a0: 0x69B4C98CB8530805u64,
     a1: 0xFED1DD3004688D67CAu64) # global for backwards compatibility
 
-template randState*(): untyped =
-  ## Makes the default Rand state accessible from other modules.
-  ## Useful for module authors.
-  state
+since (1, 5):
+  template randState*(): untyped =
+    ## Makes the default Rand state accessible from other modules.
+    ## Useful for module authors.
+    state
 
 proc rotl(x, k: Ui): Ui =
   result = (x shl k) or (x shr (Ui(64) - k))

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -119,6 +119,11 @@ else:
     a0: 0x69B4C98CB8530805u64,
     a1: 0xFED1DD3004688D67CAu64) # global for backwards compatibility
 
+template randState*(): untyped =
+  ## Makes the default Rand state accessible from other modules.
+  ## Useful for module authors.
+  state
+
 proc rotl(x, k: Ui): Ui =
   result = (x shl k) or (x shr (Ui(64) - k))
 


### PR DESCRIPTION
It was previously [discussed](https://github.com/nim-lang/Nim/pull/14725#issuecomment-646959447). that exporting state is needed for writing 3rd party modules (like in `fusion`) that add new random functions.