### PR TITLE
canAlias improvement

### DIFF
--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -64,9 +64,18 @@ proc canAlias(arg, ret: PType; marker: var IntSet): bool =
   else:
     result = false
 
+proc isValueOnlyType(t: PType): bool = 
+  # t doesn't contain pointers and references
+  proc wrap(t: PType): bool {.nimcall.} = t.kind in {tyRef, tyPtr, tyVar}
+  result = not types.searchTypeFor(t, wrap)
+
 proc canAlias*(arg, ret: PType): bool =
-  var marker = initIntSet()
-  result = canAlias(arg, ret, marker)
+  if isValueOnlyType(arg):
+    # can alias only with unsafeAddr(arg.x) and we don't care if it is not safe
+    result = false
+  else:
+    var marker = initIntSet()
+    result = canAlias(arg, ret, marker)
 
 proc checkIsolate*(n: PNode): bool =
   if types.containsTyRef(n.typ):

--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -66,7 +66,7 @@ proc canAlias(arg, ret: PType; marker: var IntSet): bool =
 
 proc isValueOnlyType(t: PType): bool = 
   # t doesn't contain pointers and references
-  proc wrap(t: PType): bool {.nimcall.} = t.kind in {tyRef, tyPtr, tyVar}
+  proc wrap(t: PType): bool {.nimcall.} = t.kind in {tyRef, tyPtr, tyVar, tyLent}
   result = not types.searchTypeFor(t, wrap)
 
 proc canAlias*(arg, ret: PType): bool =


### PR DESCRIPTION
improvement discussed offline. Arguments without var, ptr, ref don't come with alias risk.
