### PR TITLE
fix #15638

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2534,6 +2534,7 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
     if n[0].kind != nkEmpty:
       genLineDir(p, n)
       gen(p, n[0], r)
+      r.res = "var _ = " & r.res
   of nkAsmStmt: genAsmOrEmitStmt(p, n)
   of nkTryStmt, nkHiddenTryStmt: genTry(p, n, r)
   of nkRaiseStmt: genRaiseStmt(p, n)

--- a/tests/js/tdiscard.nim
+++ b/tests/js/tdiscard.nim
@@ -1,0 +1,3 @@
+import dom
+
+discard Node()


### PR DESCRIPTION
Generates `_` for all discardable variable:
```js
var _ = {m_type: NTI486539301, attributes: [], childNodes: [], children: [], data: null, firstChild: null}
```