### PR TITLE
feat(json): delete index and item from JArray #15001

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -559,6 +559,26 @@ proc `{}=`*(node: JsonNode, keys: varargs[string], value: JsonNode) =
     node = node[keys[i]]
   node[keys[keys.len-1]] = value
 
+proc delete*(arr: JsonNode, value: JsonNode) =
+  ## Find and deletes value on the json array.
+  assert(arr.kind == JArray)
+  var foundIndex = -1
+  for index, element in arr.elems:
+    if element == value:
+      foundIndex = index
+  if foundIndex >= 0:
+    arr.elems.delete(foundIndex)
+  else:
+    raise newException(Exception, "value not in array")
+
+proc delete*(arr: JsonNode, index: int) =
+  ## Deletes an item in array by index
+  assert(arr.kind == JArray)
+  if arr.elems.len >= (index + 1) and index >= 0:
+    arr.elems.delete(index)
+  else:
+    raise newException(IndexDefect, "index out of bounds")
+
 proc delete*(obj: JsonNode, key: string) =
   ## Deletes ``obj[key]``.
   assert(obj.kind == JObject)


### PR DESCRIPTION
Solving issue #15001 
Added JsonNode delete by index and JsonNode value, thought of doing explicit values like string and int, but would be ambiguous with index and object "key" delete function.

Test with nim v1.4.0:
![image](https://user-images.githubusercontent.com/33612042/97670749-a8be6080-1a65-11eb-915e-72ff8ff74d4c.png)
