### PR TITLE
fix #15651

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1927,6 +1927,8 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     genReprAux(p, n, r, "reprJSONStringify")
   else:
     genReprAux(p, n, r, "reprAny", genTypeInfo(p, t))
+  echo r.kind
+  r.kind = resExpr
 
 proc genOf(p: PProc, n: PNode, r: var TCompRes) =
   var x: TCompRes

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1927,7 +1927,6 @@ proc genRepr(p: PProc, n: PNode, r: var TCompRes) =
     genReprAux(p, n, r, "reprJSONStringify")
   else:
     genReprAux(p, n, r, "reprAny", genTypeInfo(p, t))
-  echo r.kind
   r.kind = resExpr
 
 proc genOf(p: PProc, n: PNode, r: var TCompRes) =

--- a/tests/js/treprinifexpr.nim
+++ b/tests/js/treprinifexpr.nim
@@ -1,0 +1,18 @@
+type
+  Enum = enum A
+
+let
+  enumVal = A
+  tmp = if true: $enumVal else: $enumVal
+
+let
+  intVal = 12
+  tmp2 = if true: repr(intVal) else: $enumVal
+
+let
+  strVal = "123"
+  tmp3 = if true: repr(strVal) else: $strVal
+
+let
+  floatVal = 12.4
+  tmp4 = if true: repr(floatVal) else: $floatVal


### PR DESCRIPTION
Some `expr`(for example magics) returns `resNone`, can't be used in if expr:

```nim
let
  tmp = if true: expr else: expr
```