### PR TITLE
fix #8821

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -865,6 +865,7 @@ proc genRaiseStmt(p: PProc, n: PNode) =
 proc genCaseJS(p: PProc, n: PNode, r: var TCompRes) =
   var
     cond, stmt: TCompRes
+    totalRange = 0
   genLineDir(p, n)
   gen(p, n[0], cond)
   let stringSwitch = skipTypes(n[0].typ, abstractVar).kind == tyString
@@ -884,6 +885,10 @@ proc genCaseJS(p: PProc, n: PNode, r: var TCompRes) =
         let e = it[j]
         if e.kind == nkRange:
           var v = copyNode(e[0])
+          inc(totalRange, int(e[1].intVal - v.intVal))
+          if totalRange > 65535:
+            localError(p.config, n.info, 
+                       "Your case statement contains too many branches, consider using if/else instead!")
           while v.intVal <= e[1].intVal:
             gen(p, v, cond)
             lineF(p, "case $1:$n", [cond.rdLoc])

--- a/tests/js/t8821.nim
+++ b/tests/js/t8821.nim
@@ -1,5 +1,5 @@
 discard """
-  nimout: "t8821.nim(6, 3) Error: Your case statement contains too many branches, consider using if/else instead!"
+  errormsg: "Your case statement contains too many branches, consider using if/else instead!"
 """
 
 proc isInt32(i: int): bool =

--- a/tests/js/t8821.nim
+++ b/tests/js/t8821.nim
@@ -1,0 +1,12 @@
+discard """
+  nimout: "t8821.nim(6, 3) Error: Your case statement contains too many branches, consider using if/else instead!"
+"""
+
+proc isInt32(i: int): bool =
+  case i 
+  of 1 .. 70000:
+    return true
+  else:
+    return false
+
+discard isInt32(1)


### PR DESCRIPTION
Added a limitation for total length of range.

Choose 65535 because it generates 1 MB JS file for simple program
```nim
proc isInt32(i: int): bool =
  case i 
  of 1 .. 65536:
    return true
  else:
    return false

echo isInt32(1)
```
