### PR TITLE
Closure iterators are not supported by VM

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1980,6 +1980,8 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       genRdVar(c, n, dest, flags)
     of skProc, skFunc, skConverter, skMacro, skTemplate, skMethod, skIterator:
       # 'skTemplate' is only allowed for 'getAst' support:
+      if s.kind == skIterator and s.typ.callConv == TCallingConvention.ccClosure:
+        globalError(c.config, n.info, "Closure iterators are not supported by VM!")
       if procIsCallback(c, s): discard
       elif importcCond(s): c.importcSym(n.info, s)
       genLit(c, n, dest)

--- a/tests/vm/tclosureiterator.nim
+++ b/tests/vm/tclosureiterator.nim
@@ -1,0 +1,9 @@
+discard """
+  errormsg: "Closure iterators are not supported by VM!"
+"""
+
+iterator iter*(): int {.closure.} =
+  yield 3
+
+static:
+  var x = iter


### PR DESCRIPTION
I can raise error messages in JS backend too.
Are there some plans or ideas to implement closure iterators in VM or JS backend.