### PR TITLE
fix static[Slice[T]] as argument issue

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1079,7 +1079,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     return typeRel(c, f, lastSon(aOrig), flags)
 
   if a.kind == tyGenericInst and
-      skipTypes(f, {tyVar, tyLent, tySink}).kind notin {
+      skipTypes(f, {tyStatic, tyVar, tyLent, tySink}).kind notin {
         tyGenericBody, tyGenericInvocation,
         tyGenericInst, tyGenericParam} + tyTypeClasses:
     return typeRel(c, f, lastSon(a), flags)

--- a/tests/types/tisopr.nim
+++ b/tests/types/tisopr.nim
@@ -109,3 +109,15 @@ block:
   doAssert Foo2[int,float|int] is Foo
   doAssert Foo2[int,float|int] isnot Bar
   doAssert int is (int|float)
+
+
+block:
+  # Slice[T] as static type issue
+  type
+    MyEnum = enum
+      x1, x2, x3, x4, x5, x6
+
+  proc enumGen[T: enum](s: static[Slice[T]]) = 
+    doAssert($s.a & "  " & $s.b == "x1  x3")
+
+  enumGen(x1..x3)


### PR DESCRIPTION
When I worked on genEnumCaseStmt macro, I found that ` static[Slice[T]]` as proc/macro arguments don't work. Value can't be matched against the argument.

This is a fix with a test.