### PR TITLE
fix #13115

### DIFF
--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -159,4 +159,9 @@ proc rawWrite*(f: CFilePtr, s: cstring) {.compilerproc, nonReloadable, inline.} 
   discard c_fwrite(s, 1, cast[csize_t](s.len), f)
   discard c_fflush(f)
 
+proc rawWriteString*(f: CFilePtr, s: string) {.compilerproc, nonReloadable, inline.} =
+  # we cannot throw an exception here!
+  discard c_fwrite(s.cstring, 1, cast[csize_t](s.len), f)
+  discard c_fflush(f)
+
 {.pop.}

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -32,11 +32,26 @@ else:
   proc writeToStdErr(msg: cstring) =
     discard MessageBoxA(nil, msg, nil, 0)
 
-proc showErrorMessage(data: string) {.gcsafe, raises: [].} =
+proc showErrorMessage(data: cstring) {.gcsafe, raises: [].} =
   var toWrite = true
   if errorMessageWriter != nil:
     try:
       errorMessageWriter($data)
+      toWrite = false
+    except:
+      discard
+  if toWrite:
+    when defined(genode):
+      # stderr not available by default, use the LOG session
+      echo data
+    else:
+      writeToStdErr(data)
+
+proc showErrorMessage(data: string) {.gcsafe, raises: [].} =
+  var toWrite = true
+  if errorMessageWriter != nil:
+    try:
+      errorMessageWriter(data)
       toWrite = false
     except:
       discard

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -25,14 +25,14 @@ when defined(windows):
   const ERROR_BAD_EXE_FORMAT = 193
 
 when not defined(windows) or not defined(guiapp):
-  proc writeToStdErr(msg: cstring) = rawWrite(cstderr, msg)
+  proc writeToStdErr(msg: string) = rawWriteString(cstderr, msg)
 else:
   proc MessageBoxA(hWnd: pointer, lpText, lpCaption: cstring, uType: int): int32 {.
     header: "<windows.h>", nodecl.}
   proc writeToStdErr(msg: cstring) =
     discard MessageBoxA(nil, msg, nil, 0)
 
-proc showErrorMessage(data: cstring) {.gcsafe, raises: [].} =
+proc showErrorMessage(data: string) {.gcsafe, raises: [].} =
   var toWrite = true
   if errorMessageWriter != nil:
     try:

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -32,21 +32,6 @@ else:
   proc writeToStdErr(msg: cstring) =
     discard MessageBoxA(nil, msg, nil, 0)
 
-proc showErrorMessage(data: cstring) {.gcsafe, raises: [].} =
-  var toWrite = true
-  if errorMessageWriter != nil:
-    try:
-      errorMessageWriter($data)
-      toWrite = false
-    except:
-      discard
-  if toWrite:
-    when defined(genode):
-      # stderr not available by default, use the LOG session
-      echo data
-    else:
-      writeToStdErr(data)
-
 proc showErrorMessage(data: string) {.gcsafe, raises: [].} =
   var toWrite = true
   if errorMessageWriter != nil:

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -1,0 +1,11 @@
+discard """
+  exitcode: 1
+  output: '''t13115.nim(11)           t13115
+Error: unhandled exception: This char is `
+` and works fine! [Exception]'''
+"""
+
+const b_null: char = 0.char
+var msg = "This char is `" & $b_null & "` and works fine!"
+
+raise newException(Exception, msg)


### PR DESCRIPTION
It seems passing string to cstring sometimes truncates the data. So we need a proc accepting string parameters.
There are many `rawWrite` in source codes, I don't whether I should change them. So now I add `rawWriteString` temporarily .

![image](https://user-images.githubusercontent.com/43030857/98317707-f9126100-2017-11eb-9210-6281e079a603.png)

This only works with `koch temp` now.

Any hints?