### PR TITLE
Console apps in Windows can rise OSError

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -37,7 +37,10 @@ type
 
 var gTerm {.threadvar.}: owned(PTerminal)
 
-proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [].}
+when defined(windows) and defined(consoleapp):
+  proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [OSError].}
+else:
+  proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [].}
 
 proc getTerminal(): PTerminal {.inline.} =
   if isNil(gTerm):


### PR DESCRIPTION
Console apps in Windows implementation can rise OSError so I've fixed it, see below some examples for reference:
https://github.com/nim-lang/Nim/blob/c07807bedf1749fa9d3e826d3d736907fefbe568/lib/pure/terminal.nim#L170
https://github.com/nim-lang/Nim/blob/c07807bedf1749fa9d3e826d3d736907fefbe568/lib/pure/terminal.nim#L178
https://github.com/nim-lang/Nim/blob/c07807bedf1749fa9d3e826d3d736907fefbe568/lib/pure/terminal.nim#L191-L192
https://github.com/nim-lang/Nim/blob/c07807bedf1749fa9d3e826d3d736907fefbe568/lib/pure/terminal.nim#L196-L197
...