### PR TITLE
Console apps in Windows can raise OSError, effects system must be OS agnostic

### DIFF
--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -37,7 +37,7 @@ type
 
 var gTerm {.threadvar.}: owned(PTerminal)
 
-proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [].}
+proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [OSError].}
 
 proc getTerminal(): PTerminal {.inline.} =
   if isNil(gTerm):

--- a/lib/pure/terminal.nim
+++ b/lib/pure/terminal.nim
@@ -37,10 +37,7 @@ type
 
 var gTerm {.threadvar.}: owned(PTerminal)
 
-when defined(windows) and defined(consoleapp):
-  proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [OSError].}
-else:
-  proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [].}
+proc newTerminal(): owned(PTerminal) {.gcsafe, raises: [].}
 
 proc getTerminal(): PTerminal {.inline.} =
   if isNil(gTerm):


### PR DESCRIPTION
Reverts nim-lang/Nim#15874