### PR TITLE
fix #12726 Cannot take the compile-time sizeof Atomic types

### DIFF
--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -51,10 +51,11 @@ when defined(cpp) or defined(nimdoc):
         ## with other moSequentiallyConsistent operations.
 
   type
-    Atomic* {.importcpp: "std::atomic".} [T] = object
+    Atomic*[T] {.importcpp: "std::atomic", completeStruct.} = object
       ## An atomic object with underlying type `T`.
+      raw: T
 
-    AtomicFlag* {.importcpp: "std::atomic_flag".} = object
+    AtomicFlag* {.importcpp: "std::atomic_flag", size: 1.} = object
       ## An atomic boolean state.
 
   # Access operations
@@ -249,10 +250,10 @@ else:
     type
       # Atomic* {.importcpp: "_Atomic('0)".} [T] = object
 
-      AtomicInt8 {.importc: "_Atomic NI8".} = object
-      AtomicInt16 {.importc: "_Atomic NI16".} = object
-      AtomicInt32 {.importc: "_Atomic NI32".} = object
-      AtomicInt64 {.importc: "_Atomic NI64".} = object
+      AtomicInt8 {.importc: "_Atomic NI8", size: 1.} = object
+      AtomicInt16 {.importc: "_Atomic NI16", size: 2.} = object
+      AtomicInt32 {.importc: "_Atomic NI32", size: 4.} = object
+      AtomicInt64 {.importc: "_Atomic NI64", size: 8.} = object
 
     template atomicType*(T: typedesc[Trivial]): untyped =
       # Maps the size of a trivial type to it's internal atomic type
@@ -262,7 +263,7 @@ else:
       elif sizeof(T) == 8: AtomicInt64
 
     type
-      AtomicFlag* {.importc: "atomic_flag".} = object
+      AtomicFlag* {.importc: "atomic_flag", size: 1.} = object
 
       Atomic*[T] = object
         when T is Trivial:

--- a/tests/stdlib/concurrency/tatomics_size.nim
+++ b/tests/stdlib/concurrency/tatomics_size.nim
@@ -14,5 +14,5 @@ block testSize: # issue 12726
       back: Atomic[ptr int]
       f: AtomicFlag
   static:
-    doAssert sizeof(Node) == 8
-    doAssert sizeof(MyChannel) == 16
+    doAssert sizeof(Node) == sizeof(pointer)
+    doAssert sizeof(MyChannel) == sizeof(pointer) * 2

--- a/tests/stdlib/concurrency/tatomics_size.nim
+++ b/tests/stdlib/concurrency/tatomics_size.nim
@@ -1,0 +1,18 @@
+discard """
+  targets: "c cpp"
+"""
+import std/atomics
+
+block testSize: # issue 12726
+  type
+    Node = ptr object
+      # works
+      next: Atomic[pointer]
+      f:AtomicFlag
+    MyChannel = object
+      # type not defined completely
+      back: Atomic[ptr int]
+      f: AtomicFlag
+  static:
+    doAssert sizeof(Node) == 8
+    doAssert sizeof(MyChannel) == 16


### PR DESCRIPTION
fix #12726 follow the issue comments 

there's one thing am not sure:  

https://stackoverflow.com/questions/15452447/is-it-guaranteed-that-sizeofstdatomicinteger-type-sizeofinteger-type

> Per Paragraph 29.5/9 of the C++11 Standard:

> [ Note: The representation of an atomic specialization need not have the same size as its corresponding argument type.  Specializations should have the same size whenever possible, as this reduces the effort required to port existing code. > —end note ]