### PR TITLE
Add Trash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,8 @@
 - Removed deprecated `iup` module from stdlib, it has already moved to
   [nimble](https://github.com/nim-lang/iup).
 
+- Added `os.moveFileToTrash` to move files to `os.osTrash`.
+- Added `os.moveFileFromTrash` to move files back from `os.osTrash`.
 
 
 ## Language changes

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3342,9 +3342,10 @@ since (1, 5):
     ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
     ## * `removeFile proc <#removeFile,string>`_
     runnableExamples:
-      writeFile("example.txt", "")
-      moveFileToTrash("example.txt")
-      moveFileFromTrash(getCurrentDir() / "example.txt")
+      when not defined(js) and not defined(nimscript):
+        writeFile("example.txt", "")
+        moveFileToTrash("example.txt")
+        moveFileFromTrash(getCurrentDir() / "example.txt")
 
     assert filename.len > 0, "filename must not be empty string"
     if dirExists(trashPath):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3303,7 +3303,7 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
 
 
 since (1, 5):
-  let osTrash*: string =
+  let osTrash* {.noWeirdTarget.}: string =
     when defined(linux) or defined(bsd):
       getEnv("XDG_DATA_HOME", getHomeDir()) / ".local/share/Trash"
     elif defined(osx):
@@ -3311,7 +3311,7 @@ since (1, 5):
     else:
       getTempDir() # Android has no Trash, some apps just use a temporary folder.
 
-  proc moveFileToTrash*(filename: string; trashPath = osTrash; postfixStart = 1.Positive): string =
+  proc moveFileToTrash*(filename: string; trashPath = osTrash; postfixStart = 1.Positive): string {.noWeirdTarget.} =
     ## Move file from `filename` to `trashPath`, `trashPath` defaults to `osTrash`.
     ##
     ## If a file with the same name already exists in the Trash folder,
@@ -3360,7 +3360,7 @@ since (1, 5):
       moveFile(expandFilename(filename), trashed)
     result = trashed
 
-  proc moveFileFromTrash*(filename: string; trashPath = osTrash) =
+  proc moveFileFromTrash*(filename: string; trashPath = osTrash) {.noWeirdTarget.} =
     ## Move file from `trashPath` to `filename`, `trashPath` defaults to `osTrash`.
     ##
     ## If a file with the same name already exists in the Trash folder,

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3324,12 +3324,15 @@ since (1, 5):
     when defined(linux) or defined(bsd):
       let fullPath = expandFilename(filename)
       let fname = extractFilename(fullPath)
+      var trashinfo = "[Trash Info]\nPath="
+      trashinfo.add fullPath
+      trashinfo.add "\nDeletionDate="
+      trashinfo.add now().format("yyyy-MM-dd'T'HH:MM:ss")
+      trashinfo.add "\n"
       discard existsOrCreateDir(trashPath / "files")
       discard existsOrCreateDir(trashPath / "info")
       moveFile(fullPath, trashPath / "files" / fname)
-      writeFile(trashPath / "info" / fname & ".trashinfo",
-        "[Trash Info]\nPath=" & fullPath & "\nDeletionDate=" &
-        now().format("yyyy-MM-dd'T'HH:MM:ss") & "\n")
+      writeFile(trashPath / "info" / fname & ".trashinfo", trashinfo)
     else:
       moveFile(expandFilename(filename), trashPath / extractFilename(filename))
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3303,16 +3303,18 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
 
 
 since (1, 5):
-  let osTrash* {.noWeirdTarget.}: string =
-    when defined(linux) or defined(bsd):
-      getEnv("XDG_DATA_HOME", getHomeDir()) / ".local/share/Trash"
-    elif defined(osx):
-      getEnv("HOME", getHomeDir()) / ".Trash"
-    else:
-      getTempDir() # Android has no Trash, some apps just use a temporary folder.
+  proc getTrash*(): string {.noWeirdTarget.} =
+    ## Return the operating system Trash directory.
+    result =
+      when defined(linux) or defined(bsd):
+        getEnv("XDG_DATA_HOME", getHomeDir()) / ".local/share/Trash"
+      elif defined(osx):
+        getEnv("HOME", getHomeDir()) / ".Trash"
+      else:
+        getTempDir() # Android has no Trash, some apps just use a temporary folder.
 
-  proc moveFileToTrash*(filename: string; trashPath = osTrash; postfixStart = 1.Positive): string {.noWeirdTarget.} =
-    ## Move file from `filename` to `trashPath`, `trashPath` defaults to `osTrash`.
+  proc moveFileToTrash*(filename: string; trashPath = getTrash(); postfixStart = 1.Positive): string {.noWeirdTarget.} =
+    ## Move file from `filename` to `trashPath`, `trashPath` defaults to `getTrash()`.
     ##
     ## If a file with the same name already exists in the Trash folder,
     ## then appends a postfix like `" (1)"`, `" (2)"`, `" (3)"`, etc,
@@ -3360,8 +3362,8 @@ since (1, 5):
       moveFile(expandFilename(filename), trashed)
     result = trashed
 
-  proc moveFileFromTrash*(filename: string; trashPath = osTrash) {.noWeirdTarget.} =
-    ## Move file from `trashPath` to `filename`, `trashPath` defaults to `osTrash`.
+  proc moveFileFromTrash*(filename: string; trashPath = getTrash()) {.noWeirdTarget.} =
+    ## Move file from `trashPath` to `filename`, `trashPath` defaults to `getTrash()`.
     ##
     ## If a file with the same name already exists in the Trash folder,
     ## then the generated postfix like `" (1)"`, `" (2)"`, `" (3)"`, etc,

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3311,12 +3311,15 @@ since (1, 5):
     else:
       getTempDir() # Android has no Trash, some apps just use a temporary folder.
 
-  proc moveFileToTrash*(filename: string; trashPath = osTrash): string =
+  proc moveFileToTrash*(filename: string; trashPath = osTrash; postfixStart = 1.Positive): string =
     ## Move file from `filename` to `trashPath`, `trashPath` defaults to `osTrash`.
     ##
     ## If a file with the same name already exists in the Trash folder,
     ## then appends a postfix like `" (1)"`, `" (2)"`, `" (3)"`, etc,
     ## returns the path of the file in the Trash, with the generated postfix if any.
+    ##
+    ## If you know the latest highest postfix used on the Trash folder,
+    ## then you can use `postfixStart` for better performance.
     ##
     ## * http://www.freedesktop.org/wiki/Specifications/trash-spec
     ## * http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
@@ -3333,7 +3336,7 @@ since (1, 5):
       else: trashPath / fname
     # If file exists on Trash, append " (1)", " (2)", " (3)", etc.
     if fileExists(trashed):
-      for i in 1 .. int.high:
+      for i in postfixStart .. int.high:
         var prefix = " ("
         prefix.add $i
         prefix.add ")"
@@ -3370,11 +3373,11 @@ since (1, 5):
     ## See also:
     ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
     ## * `removeFile proc <#removeFile,string>`_
-    runnableExamples "-r:off -b:c":
-      writeFile("example.txt", "")
-      let trashedFile = moveFileToTrash("example.txt")
-      moveFileFromTrash(getCurrentDir() / extractFilename(trashedFile))
-
+    ##
+    ## .. code-block:: nim
+    ##   writeFile("example.txt", "")
+    ##   let trashedFile = moveFileToTrash("example.txt")
+    ##   moveFileFromTrash(getCurrentDir() / extractFilename(trashedFile))
     assert filename.len > 0, "filename must not be empty string"
     if dirExists(trashPath):
       when defined(linux) or defined(bsd):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3303,7 +3303,7 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
 
 
 since (1, 5):
-  const osTrash*: string =
+  let osTrash*: string =
     when defined(linux) or defined(bsd):
       getEnv("XDG_DATA_HOME", getHomeDir()) / ".local/share/Trash"
     elif defined(osx):


### PR DESCRIPTION
- Add OS Trash support, as alternative to `removeFile`, interesting for library authors.
- Allows to trash several files with the same name.
- Documentation with links, `runnableExamples`, `since`, changelog, etc.

```nim
import os
writeFile("example.txt", "")
echo moveFileToTrash("example.txt")
moveFileFromTrash(getCurrentDir() / "example.txt")
```

```nim
import os
echo moveFileToTrash("example.txt", trashPath = "/my/custom/trash/")
moveFileFromTrash(getCurrentDir() / "example.txt", trashPath = "/my/custom/trash/")
```
