### PR TITLE
 `cast` now works in VM in more contexts, behaving like in RT; eg: `int|pointer <=> ptr T | ref T` (eg: enables nimyaml at CT)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -80,6 +80,8 @@
 
 - `cast` now works in VM in more contexts, behaving like in RT; eg: `int <=> ptr T | ref T`,
   see `tcastint.testCastRefOrPtr`
+- `cast` now works in VM in more contexts, behaving the same as in runtime, in particular
+  `cast[int](x)` now works for `x: ptr T | ref T`, and likewise for reverse direction.
 
 ## Tool changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -78,6 +78,8 @@
 
 - VM now supports `addr(mystring[ind])` (index + index assignment)
 
+- `cast` now works in VM in more contexts, behaving like in RT; eg: `int <=> ptr T | ref T`,
+  see `tcastint.testCastRefOrPtr`
 
 ## Tool changes
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -630,7 +630,11 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       let rb = instr.regB
       let typ = regs[ra].node.typ
       if typ.kind == tyRef:
-        regs[ra].node = cast[PNode](regs[rb].intVal)
+        template fn(val) = regs[ra].node = cast[PNode](val.intVal)
+        case regs[rb].kind
+        of rkInt: fn(regs[rb])
+        of rkNode: fn(regs[rb].node)
+        else: stackTrace(c, tos, pc, "regs[rb].kind: " & $regs[rb].kind)
       else:
         let node2 = newNodeIT(nkIntLit, c.debug[pc], typ)
         case regs[rb].kind

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -618,6 +618,9 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
             stackTrace(c, tos, pc, "opcCastPtrToInt: " & $regs[rb].node.kind)
         of rkNodeAddr:
           regs[ra].intVal = cast[int](regs[rb].nodeAddr)
+        of rkInt:
+          # could be tightened by checking type, eg `tyPointer`
+          regs[ra].intVal = regs[rb].intVal
         else:
           stackTrace(c, tos, pc, "opcCastPtrToInt: got " & $regs[rb].kind)
       of 2: # tyRef
@@ -1033,6 +1036,8 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           ret = ptrEquality(regs[rb].nodeAddr, regs[rc].node)
       elif regs[rc].kind == rkNodeAddr:
         ret = ptrEquality(regs[rc].nodeAddr, regs[rb].node)
+      elif regs[rc].kind == rkInt and regs[rb].kind == rkInt:
+        ret = regs[rb].intVal == regs[rc].intVal
       else:
         let nb = regs[rb].node
         let nc = regs[rc].node

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -889,14 +889,14 @@ proc genCastIntFloat(c: PCtx; n: PNode; dest: var TDest) =
       c.gABC(n, opcCastFloatToInt64, dest, tmp)
       # narrowing for 64 bits not needed (no extended sign bits available).
     c.freeTemp(tmp)
-  elif src.kind in PtrLikeKinds + {tyRef} and dst.kind == tyInt:
+  elif src.kind in PtrLikeKinds + {tyRef} and dst.kind in {tyInt, tyPointer}:
     let tmp = c.genx(n[1])
     if dest < 0: dest = c.getTemp(n[0].typ)
     var imm: BiggestInt = if src.kind in PtrLikeKinds: 1 else: 2
     c.gABI(n, opcCastPtrToInt, dest, tmp, imm)
     c.freeTemp(tmp)
   elif (src.kind in PtrLikeKinds and dst.kind in PtrLikeKinds) or
-    (src.kind == tyInt and dst.kind in PtrLikeKinds + {tyRef}):
+    (src.kind in {tyInt, tyPointer} and dst.kind in PtrLikeKinds + {tyRef}):
     let tmp = c.genx(n[1])
     if dest < 0: dest = c.getTemp(n[0].typ)
     c.gABx(n, opcSetType, dest, c.genType(dst))

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -895,7 +895,8 @@ proc genCastIntFloat(c: PCtx; n: PNode; dest: var TDest) =
     var imm: BiggestInt = if src.kind in PtrLikeKinds: 1 else: 2
     c.gABI(n, opcCastPtrToInt, dest, tmp, imm)
     c.freeTemp(tmp)
-  elif src.kind in PtrLikeKinds + {tyInt} and dst.kind in PtrLikeKinds:
+  elif (src.kind in PtrLikeKinds and dst.kind in PtrLikeKinds) or
+    (src.kind == tyInt and dst.kind in PtrLikeKinds + {tyRef}):
     let tmp = c.genx(n[1])
     if dest < 0: dest = c.getTemp(n[0].typ)
     c.gABx(n, opcSetType, dest, c.genType(dst))

--- a/tests/vm/tcastint.nim
+++ b/tests/vm/tcastint.nim
@@ -288,12 +288,43 @@ proc test_float32_castB() =
   # any surprising content.
   doAssert cast[uint64](c) == 3270918144'u64
 
+proc testCastRefOrPtr() =
+  type TFoo = object
+    f0: string
+
+  template fn(Foo, a) =
+    let pa = cast[int](a)
+    var a2 = cast[Foo](pa)
+    let pa2 = cast[int](pa)
+    doAssert a2[] == a[]
+    doAssert a2.f0 == a.f0
+    doAssert pa2 == pa
+
+    a2.f0 = "abc2"
+    doAssert a.f0 == "abc2"
+    let b = TFoo(f0: "abc3")
+    a2[] = b
+    doAssert a2.f0 == "abc3"
+    doAssert a2[] == b
+
+  block: # ref <=> int
+    type Foo = ref TFoo
+    var a = Foo(f0: "abc")
+    fn(Foo, a)
+
+  block: # ptr <=> int
+    type Foo = ptr TFoo
+    var a0 = TFoo(f0: "abc")
+    let a = a0.addr
+    fn(Foo, a)
+
 template main =
   test()
   test_float_cast()
   test_float32_cast()
   free_integer_casting()
   test_float32_castB()
+  testCastRefOrPtr()
 
 static: main()
 main()

--- a/tests/vm/tcastint.nim
+++ b/tests/vm/tcastint.nim
@@ -1,7 +1,3 @@
-discard """
-  output: "OK"
-"""
-
 import macros
 
 type
@@ -292,16 +288,12 @@ proc test_float32_castB() =
   # any surprising content.
   doAssert cast[uint64](c) == 3270918144'u64
 
-test()
-test_float_cast()
-test_float32_cast()
-free_integer_casting()
-test_float32_castB()
-static:
+template main =
   test()
   test_float_cast()
   test_float32_cast()
   free_integer_casting()
   test_float32_castB()
 
-echo "OK"
+static: main()
+main()


### PR DESCRIPTION
* continues what was started in https://github.com/nim-lang/Nim/pull/12877
* see tests: `tcastint.testCastRefOrPtr`

## future work
* also handle casts involving `tyCstring`, eg `cast[int](someCstring)`

## example use case
* after this PR `nimyaml` works in VM even with ref types, see https://github.com/flyx/NimYAML/issues/70#issuecomment-726498869

EDIT: and even with cyclic structures involving YAML anchors, see https://github.com/flyx/NimYAML/issues/92#issuecomment-727264180

(and after https://github.com/nim-lang/Nim/pull/15528 it works with const too)

* but obviously this is generally useful and makes more code work at CT (without needing to annotate with lots of `when nimvm` and custom workarounds)

