### PR TITLE
add overload `add(a: var string, b: openArray[char])`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -173,8 +173,8 @@ provided by the operating system.
   dumping (on select signals) and notifying the parent process about the cause
   of termination.
 
-- Added `strip` and `setSlice` to `std/strbasics`.
-
+- Added `std/strbasics` for high performance string operations.
+  Added `strip`, `setSlice`, `add(a: var string, b: openArray[char])`.
 
 - Added to `wrapnils` an option-like API via `??.`, `isSome`, `get`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -183,6 +183,7 @@ provided by the operating system.
 
 - Added overload `ssytem.add(a: var string, b: openArray[char])`
 - Added overload `sytem.add(a: var string, b: openArray[char])`
+- Added overload `system.add(a: var string, b: openArray[char])`.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -181,6 +181,8 @@ provided by the operating system.
 - `std/options` changed `$some(3)` to `"some(3)"` instead of `"Some(3)"`
   and `$none(int)` to `"none(int)"` instead of `"None[int]"`.
 
+- Added overload `ssytem.add(a: var string, b: openArray[char])`
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/changelog.md
+++ b/changelog.md
@@ -181,9 +181,6 @@ provided by the operating system.
 - `std/options` changed `$some(3)` to `"some(3)"` instead of `"Some(3)"`
   and `$none(int)` to `"none(int)"` instead of `"None[int]"`.
 
-- Added overload `ssytem.add(a: var string, b: openArray[char])`
-- Added overload `sytem.add(a: var string, b: openArray[char])`
-- Added overload `system.add(a: var string, b: openArray[char])`.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -182,6 +182,7 @@ provided by the operating system.
   and `$none(int)` to `"none(int)"` instead of `"None[int]"`.
 
 - Added overload `ssytem.add(a: var string, b: openArray[char])`
+- Added overload `sytem.add(a: var string, b: openArray[char])`
 
 ## Language changes
 

--- a/lib/std/strbasics.nim
+++ b/lib/std/strbasics.nim
@@ -8,8 +8,24 @@
 #
 
 ## This module provides some high performance string operations.
+##
+## Experimental API, subject to change.
 
 const whitespaces = {' ', '\t', '\v', '\r', '\l', '\f'}
+
+proc add*(x: var string, y: openArray[char]) =
+  ## Concatenates `x` and `y` in place. `y` must not overlap with `x` to
+  ## allow future `memcpy` optimizations.
+  # Use `{.noalias.}` ?
+  let n = x.len
+  x.setLen n + y.len
+    # pending https://github.com/nim-lang/Nim/issues/14655#issuecomment-643671397
+    # use x.setLen(n + y.len, isInit = false)
+  var i = 0
+  while i < y.len:
+    x[n + i] = y[i]
+    i.inc
+  # xxx use `nimCopyMem(x[n].addr, y[0].addr, y.len)` after some refactoring
 
 func stripSlice(s: openArray[char], leading = true, trailing = true, chars: set[char] = whitespaces): Slice[int] =
   ## Returns the slice range of `s` which is stripped `chars`.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1069,27 +1069,16 @@ proc add*(x: var string, y: char) {.magic: "AppendStrCh", noSideEffect.}
   ##   tmp.add('a')
   ##   tmp.add('b')
   ##   assert(tmp == "ab")
-proc add*(x: var string, y: string) {.magic: "AppendStrStr", noSideEffect.}
+
+proc add*(x: var string, y: string) {.magic: "AppendStrStr", noSideEffect.} =
   ## Concatenates `x` and `y` in place.
   ##
-  ## .. code-block:: Nim
-  ##   var tmp = ""
-  ##   tmp.add("ab")
-  ##   tmp.add("cd")
-  ##   assert(tmp == "abcd")
-
-proc add*(x: var string, y: openArray[char]) =
-  ## Concatenates `x` and `y` in place. `y` must not overlap with `x` to
-  ## allow future memcpy optimizations.
-  let n = x.len
-  x.setLen n + y.len
-    # pending https://github.com/nim-lang/Nim/issues/14655#issuecomment-643671397
-    # use x.setLen(n + y.len, isInit = false)
-  var i = 0
-  while i < y.len:
-    x[n + i] = y[i]
-    i.inc
-  # xxx use `nimCopyMem(x[n].addr, y[0].addr, y.len)` after some refactoring
+  ## See also `strbasics.add`.
+  runnableExamples:
+    var tmp = ""
+    tmp.add("ab")
+    tmp.add("cd")
+    assert tmp == "abcd"
 
 type
   Endianness* = enum ## Type describing the endianness of a processor.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1078,6 +1078,18 @@ proc add*(x: var string, y: string) {.magic: "AppendStrStr", noSideEffect.}
   ##   tmp.add("cd")
   ##   assert(tmp == "abcd")
 
+proc add*(x: var string, y: openArray[char]) =
+  ## Concatenates `x` and `y` in place. `y` must not overlap with `x` to
+  ## allow future memcpy optimizations.
+  let n = x.len
+  x.setLen n + y.len
+    # pending https://github.com/nim-lang/Nim/issues/14655#issuecomment-643671397
+    # use x.setLen(n + y.len, isInit = false)
+  var i=0
+  while i<y.len:
+    x[n + i] = y[i]
+    i.inc
+  # xxx use `nimCopyMem(x[n].addr, y[0].addr, y.len)` after some refactoring
 
 type
   Endianness* = enum ## Type describing the endianness of a processor.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1085,8 +1085,8 @@ proc add*(x: var string, y: openArray[char]) =
   x.setLen n + y.len
     # pending https://github.com/nim-lang/Nim/issues/14655#issuecomment-643671397
     # use x.setLen(n + y.len, isInit = false)
-  var i=0
-  while i<y.len:
+  var i = 0
+  while i < y.len:
     x[n + i] = y[i]
     i.inc
   # xxx use `nimCopyMem(x[n].addr, y[0].addr, y.len)` after some refactoring

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -16,10 +16,6 @@ proc add(x: var string; y: cstring)
   first type mismatch at position: 1
   required type for x: var string
   but expression 'k' is of type: Alias
-proc add(x: var string; y: openArray[char])
-  first type mismatch at position: 1
-  required type for x: var string
-  but expression 'k' is of type: Alias
 proc add(x: var string; y: string)
   first type mismatch at position: 1
   required type for x: var string
@@ -47,9 +43,13 @@ expression: test(bar)'''
 
 
 
-## line 50
 
 
+
+
+
+
+## line 60
 type
   Foo[T] = concept k
     add(k, string, T)

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -16,6 +16,10 @@ proc add(x: var string; y: cstring)
   first type mismatch at position: 1
   required type for x: var string
   but expression 'k' is of type: Alias
+proc add(x: var string; y: openArray[char])
+  first type mismatch at position: 1
+  required type for x: var string
+  but expression 'k' is of type: Alias
 proc add(x: var string; y: string)
   first type mismatch at position: 1
   required type for x: var string
@@ -43,13 +47,9 @@ expression: test(bar)'''
 
 
 
+## line 50
 
 
-
-
-
-
-## line 60
 type
   Foo[T] = concept k
     add(k, string, T)

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -6,8 +6,8 @@ discard """
 import std/[strbasics, sugar]
 
 proc main() =
-  block: # strip
-    when not defined(gcArc): # pending bug #17173
+  when not defined(gcArc): # pending bug #17173
+    block: # strip
       var a = "  vhellov   "
       strip(a)
       doAssert a == "vhellov"
@@ -107,20 +107,20 @@ proc main() =
         doAssert a.dup(strip(chars = {'x', 'i'})) == " "
         doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
 
-      block: # setSlice
-        var a = "Hello, Nim!"
-        doassert a.dup(setSlice(7 .. 9)) == "Nim"
-        doAssert a.dup(setSlice(0 .. 0)) == "H"
-        doAssert a.dup(setSlice(0 .. 1)) == "He"
-        doAssert a.dup(setSlice(0 .. 10)) == a
-        doAssert a.dup(setSlice(1 .. 0)).len == 0
-        doAssert a.dup(setSlice(20 .. -1)).len == 0
+    block: # setSlice
+      var a = "Hello, Nim!"
+      doassert a.dup(setSlice(7 .. 9)) == "Nim"
+      doAssert a.dup(setSlice(0 .. 0)) == "H"
+      doAssert a.dup(setSlice(0 .. 1)) == "He"
+      doAssert a.dup(setSlice(0 .. 10)) == a
+      doAssert a.dup(setSlice(1 .. 0)).len == 0
+      doAssert a.dup(setSlice(20 .. -1)).len == 0
 
-        doAssertRaises(AssertionDefect):
-          discard a.dup(setSlice(-1 .. 1))
+      doAssertRaises(AssertionDefect):
+        discard a.dup(setSlice(-1 .. 1))
 
-        doAssertRaises(AssertionDefect):
-          discard a.dup(setSlice(1 .. 11))
+      doAssertRaises(AssertionDefect):
+        discard a.dup(setSlice(1 .. 11))
 
   block: # add
     var a0 = "hi"

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -1,126 +1,139 @@
 discard """
   targets: "c cpp js"
+  matrix: "--gc:refc; --gc:arc"
 """
 
 import std/[strbasics, sugar]
 
+proc main() =
+  block: # strip
+    when not defined(gcArc): # pending bug #17173
+      var a = "  vhellov   "
+      strip(a)
+      doAssert a == "vhellov"
 
-proc teststrip() =
-  var a = "  vhellov   "
-  strip(a)
-  doAssert a == "vhellov"
+      a = "  vhellov   "
+      a.strip(leading = false)
+      doAssert a == "  vhellov"
 
-  a = "  vhellov   "
-  a.strip(leading = false)
-  doAssert a == "  vhellov"
+      a = "  vhellov   "
+      a.strip(trailing = false)
+      doAssert a == "vhellov   "
 
-  a = "  vhellov   "
-  a.strip(trailing = false)
-  doAssert a == "vhellov   "
+      a.strip()
+      a.strip(chars = {'v'})
+      doAssert a == "hello"
 
-  a.strip()
-  a.strip(chars = {'v'})
-  doAssert a == "hello"
+      a = "  vhellov   "
+      a.strip()
+      a.strip(leading = false, chars = {'v'})
+      doAssert a == "vhello"
 
-  a = "  vhellov   "
-  a.strip()
-  a.strip(leading = false, chars = {'v'})
-  doAssert a == "vhello"
+      var c = "blaXbla"
+      c.strip(chars = {'b', 'a'})
+      doAssert c == "laXbl"
+      c = "blaXbla"
+      c.strip(chars = {'b', 'a', 'l'})
+      doAssert c == "X"
 
-  var c = "blaXbla"
-  c.strip(chars = {'b', 'a'})
-  doAssert c == "laXbl"
-  c = "blaXbla"
-  c.strip(chars = {'b', 'a', 'l'})
-  doAssert c == "X"
+      block:
+        var a = "xxxxxx"
+        a.strip(chars={'x'})
+        doAssert a.len == 0
 
-  block:
-    var a = "xxxxxx"
-    a.strip(chars={'x'})
-    doAssert a.len == 0
+      block:
+        var a = "x"
+        a.strip(chars={'x'})
+        doAssert a.len == 0
+      
+      block:
+        var a = "x"
+        a.strip(chars={'1'})
+        doAssert a.len == 1
 
-  block:
-    var a = "x"
-    a.strip(chars={'x'})
-    doAssert a.len == 0
-  
-  block:
-    var a = "x"
-    a.strip(chars={'1'})
-    doAssert a.len == 1
+      block:
+        var a = ""
+        a.strip(chars={'x'})
+        doAssert a.len == 0
 
-  block:
-    var a = ""
-    a.strip(chars={'x'})
-    doAssert a.len == 0
+      block:
+        var a = "xxx xxx"
+        a.strip(chars={'x'})
+        doAssert a == " "
 
-  block:
-    var a = "xxx xxx"
-    a.strip(chars={'x'})
-    doAssert a == " "
+      block:
+        var a = "xxx  wind"
+        a.strip(chars={'x'})
+        doAssert a == "  wind"
 
-  block:
-    var a = "xxx  wind"
-    a.strip(chars={'x'})
-    doAssert a == "  wind"
+      block:
+        var a = "xxx  iii"
+        a.strip(chars={'i'})
+        doAssert a == "xxx  "
 
-  block:
-    var a = "xxx  iii"
-    a.strip(chars={'i'})
-    doAssert a == "xxx  "
+      block:
+        var a = "xxx  iii"
+        doAssert a.dup(strip(chars = {'i'})) == "xxx  "
+        doAssert a.dup(strip(chars = {' '})) == "xxx  iii"
+        doAssert a.dup(strip(chars = {'x'})) == "  iii"
+        doAssert a.dup(strip(chars = {'x', ' '})) == "iii"
+        doAssert a.dup(strip(chars = {'x', 'i'})) == "  "
+        doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
 
-  block:
-    var a = "xxx  iii"
-    doAssert a.dup(strip(chars = {'i'})) == "xxx  "
-    doAssert a.dup(strip(chars = {' '})) == "xxx  iii"
-    doAssert a.dup(strip(chars = {'x'})) == "  iii"
-    doAssert a.dup(strip(chars = {'x', ' '})) == "iii"
-    doAssert a.dup(strip(chars = {'x', 'i'})) == "  "
-    doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
+      block:
+        var a = "x  i"
+        doAssert a.dup(strip(chars = {'i'})) == "x  "
+        doAssert a.dup(strip(chars = {' '})) == "x  i"
+        doAssert a.dup(strip(chars = {'x'})) == "  i"
+        doAssert a.dup(strip(chars = {'x', ' '})) == "i"
+        doAssert a.dup(strip(chars = {'x', 'i'})) == "  "
+        doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
 
-  block:
-    var a = "x  i"
-    doAssert a.dup(strip(chars = {'i'})) == "x  "
-    doAssert a.dup(strip(chars = {' '})) == "x  i"
-    doAssert a.dup(strip(chars = {'x'})) == "  i"
-    doAssert a.dup(strip(chars = {'x', ' '})) == "i"
-    doAssert a.dup(strip(chars = {'x', 'i'})) == "  "
-    doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
+      block:
+        var a = ""
+        doAssert a.dup(strip(chars = {'i'})).len == 0
+        doAssert a.dup(strip(chars = {' '})).len == 0
+        doAssert a.dup(strip(chars = {'x'})).len == 0
+        doAssert a.dup(strip(chars = {'x', ' '})).len == 0
+        doAssert a.dup(strip(chars = {'x', 'i'})).len == 0
+        doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
 
-  block:
-    var a = ""
-    doAssert a.dup(strip(chars = {'i'})).len == 0
-    doAssert a.dup(strip(chars = {' '})).len == 0
-    doAssert a.dup(strip(chars = {'x'})).len == 0
-    doAssert a.dup(strip(chars = {'x', ' '})).len == 0
-    doAssert a.dup(strip(chars = {'x', 'i'})).len == 0
-    doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
+      block:
+        var a = " "
+        doAssert a.dup(strip(chars = {'i'})) == " "
+        doAssert a.dup(strip(chars = {' '})).len == 0
+        doAssert a.dup(strip(chars = {'x'})) == " "
+        doAssert a.dup(strip(chars = {'x', ' '})).len == 0
+        doAssert a.dup(strip(chars = {'x', 'i'})) == " "
+        doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
 
-  block:
-    var a = " "
-    doAssert a.dup(strip(chars = {'i'})) == " "
-    doAssert a.dup(strip(chars = {' '})).len == 0
-    doAssert a.dup(strip(chars = {'x'})) == " "
-    doAssert a.dup(strip(chars = {'x', ' '})).len == 0
-    doAssert a.dup(strip(chars = {'x', 'i'})) == " "
-    doAssert a.dup(strip(chars = {'x', 'i', ' '})).len == 0
+      block: # setSlice
+        var a = "Hello, Nim!"
+        doassert a.dup(setSlice(7 .. 9)) == "Nim"
+        doAssert a.dup(setSlice(0 .. 0)) == "H"
+        doAssert a.dup(setSlice(0 .. 1)) == "He"
+        doAssert a.dup(setSlice(0 .. 10)) == a
+        doAssert a.dup(setSlice(1 .. 0)).len == 0
+        doAssert a.dup(setSlice(20 .. -1)).len == 0
 
+        doAssertRaises(AssertionDefect):
+          discard a.dup(setSlice(-1 .. 1))
 
-  block:
-    var a = "Hello, Nim!"
-    doassert a.dup(setSlice(7 .. 9)) == "Nim"
-    doAssert a.dup(setSlice(0 .. 0)) == "H"
-    doAssert a.dup(setSlice(0 .. 1)) == "He"
-    doAssert a.dup(setSlice(0 .. 10)) == a
-    doAssert a.dup(setSlice(1 .. 0)).len == 0
-    doAssert a.dup(setSlice(20 .. -1)).len == 0
+        doAssertRaises(AssertionDefect):
+          discard a.dup(setSlice(1 .. 11))
 
+  block: # add
+    var a0 = "hi"
+    var b0 = "foobar"
+    when nimvm:
+      discard # pending bug #15952
+    else:
+      a0.add b0.toOpenArray(1,3)
+      doAssert a0 == "hioob"
+    proc fn(c: openArray[char]): string =
+      result.add c
+    doAssert fn("def") == "def"
+    doAssert fn(['d','\0', 'f'])[2] == 'f'
 
-    doAssertRaises(AssertionDefect):
-      discard a.dup(setSlice(-1 .. 1))
-
-    doAssertRaises(AssertionDefect):
-      discard a.dup(setSlice(1 .. 11))
-
-static: teststrip()
-teststrip()
+static: main()
+main()

--- a/tests/vm/tstring_openarray.nim
+++ b/tests/vm/tstring_openarray.nim
@@ -13,6 +13,7 @@ proc set_all[T](s: var openArray[T]; val: T) =
     s[i] = val
 
 proc test() =
+  block:
     var a0 = "hello_world"
     var a1 = [1,2,3,4,5,6,7,8,9]
     var a2 = @[1,2,3,4,5,6,7,8,9]
@@ -22,6 +23,18 @@ proc test() =
     doAssert a0 == "iiiiiiiiiii"
     doAssert a1 == [4,4,4,4,4,4,4,4,4]
     doAssert a2 == @[4,4,4,4,4,4,4,4,4]
+  block:
+    var a0 = "hi"
+    var b0 = "foobar"
+    when nimvm:
+      discard # otherwise hits: bug #15952
+    else:
+      a0.add b0.toOpenArray(1,3)
+      doAssert a0 == "hioob"
+  proc fn(c: openArray[char]): string =
+    result.add c
+  doAssert fn("def") == "def"
+  doAssert fn(['d','\0', 'f'])[2] == 'f'
 
 const constval0 = "hello".map(proc(x: char): char = x)
 const constval1 = [1,2,3,4].map(proc(x: int): int = x)
@@ -31,4 +44,4 @@ doAssert([1,2,3,4].map(proc(x: int): int = x) == constval1)
 
 test()
 static:
-    test()
+  test()

--- a/tests/vm/tstring_openarray.nim
+++ b/tests/vm/tstring_openarray.nim
@@ -12,29 +12,16 @@ proc set_all[T](s: var openArray[T]; val: T) =
   for i in 0..<s.len:
     s[i] = val
 
-proc test() =
-  block:
-    var a0 = "hello_world"
-    var a1 = [1,2,3,4,5,6,7,8,9]
-    var a2 = @[1,2,3,4,5,6,7,8,9]
-    a0.set_all('i')
-    a1.set_all(4)
-    a2.set_all(4)
-    doAssert a0 == "iiiiiiiiiii"
-    doAssert a1 == [4,4,4,4,4,4,4,4,4]
-    doAssert a2 == @[4,4,4,4,4,4,4,4,4]
-  block:
-    var a0 = "hi"
-    var b0 = "foobar"
-    when nimvm:
-      discard # otherwise hits: bug #15952
-    else:
-      a0.add b0.toOpenArray(1,3)
-      doAssert a0 == "hioob"
-  proc fn(c: openArray[char]): string =
-    result.add c
-  doAssert fn("def") == "def"
-  doAssert fn(['d','\0', 'f'])[2] == 'f'
+proc main() =
+  var a0 = "hello_world"
+  var a1 = [1,2,3,4,5,6,7,8,9]
+  var a2 = @[1,2,3,4,5,6,7,8,9]
+  a0.set_all('i')
+  a1.set_all(4)
+  a2.set_all(4)
+  doAssert a0 == "iiiiiiiiiii"
+  doAssert a1 == [4,4,4,4,4,4,4,4,4]
+  doAssert a2 == @[4,4,4,4,4,4,4,4,4]
 
 const constval0 = "hello".map(proc(x: char): char = x)
 const constval1 = [1,2,3,4].map(proc(x: int): int = x)
@@ -42,6 +29,5 @@ const constval1 = [1,2,3,4].map(proc(x: int): int = x)
 doAssert("hello".map(proc(x: char): char = x) == constval0)
 doAssert([1,2,3,4].map(proc(x: int): int = x) == constval1)
 
-test()
-static:
-  test()
+static: main()
+main()


### PR DESCRIPTION
2 goals:
* it's currently hard to convert openArray[char] to a string (unless you do it manually, essentially inlining the code in this PR)
* avoid allocations when possible if user already has a `y` openArray to begin with

## future work
- [ ] after merged, fix this comment:
https://github.com/nim-lang/Nim/pull/15421/files#r522703485
- [ ] see also `addCstringN`
- [x] see https://github.com/nim-lang/Nim/pull/15951#issuecomment-785329824 (see also https://github.com/nim-lang/Nim/pull/17478)