### PR TITLE
[cleanup, testament] targets: use cpp instead of c++ everywhere (was by far the most common)

### DIFF
--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -26,7 +26,7 @@ Options
 * ``--print``                   Also print results to the console
 * ``--simulate``                See what tests would be run but don't run them (for debugging)
 * ``--failing``                 Only show failing/ignored tests
-* ``--targets:"c c++ js objc"`` Run tests for specified targets (default: all)
+* ``--targets:"c cpp js objc"`` Run tests for specified targets (default: all)
 * ``--nim:path``                Use a particular nim executable (default: ``$PATH/nim``)
 * ``--directory:dir``           Change to directory dir before reading the tests or doing anything else.
 * ``--colors:on|off``           Turn messages coloring on|off.

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -41,7 +41,7 @@ Options:
   --print                   also print results to the console
   --simulate                see what tests would be run but don't run them (for debugging)
   --failing                 only show failing/ignored tests
-  --targets:"c c++ js objc" run tests for specified targets (default: all)
+  --targets:"c cpp js objc" run tests for specified targets (default: all)
   --nim:path                use a particular nim executable (default: $$PATH/nim)
   --directory:dir           Change to directory dir before reading the tests or doing anything else.
   --colors:on|off           Turn messages coloring on|off.

--- a/tests/float/tfloatmod.nim
+++ b/tests/float/tfloatmod.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "c c++ js"
+  targets: "c cpp js"
   output: "ok"
   exitcode: "0"
 """

--- a/tests/osproc/passenv.nim
+++ b/tests/osproc/passenv.nim
@@ -1,7 +1,7 @@
 discard """
   file: "passenv.nim"
   output: "123"
-  targets: "c c++ objc"
+  targets: "c cpp objc"
 """
 
 import osproc, os, strtabs

--- a/tests/stdlib/tfrexp1.nim
+++ b/tests/stdlib/tfrexp1.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: "js c c++"
+  targets: "js c cpp"
   output: '''ok'''
 """
 


### PR DESCRIPTION
targets:cpp is much more common than targets:c++ so I'm moving everything to targets:cpp