### PR TITLE
Documentation only

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -317,8 +317,9 @@ Stropping
 ---------
 
 `Stropping <https://en.wikipedia.org/wiki/Stropping_(syntax)>`_
-allows the same letter sequence to be used both as a keyword and as an identifier,
-this simplifies parsing and FFI with languages where that identifier is not a reserved keyword.
+allows the same letter sequence to be used both as a keyword and as an identifier, this simplifies parsing and
+`FFI <https://en.wikipedia.org/wiki/Foreign_function_interface>`_
+with languages where that identifier is not a reserved keyword.
 For example, allowing a variable named `if` without clashing with the keyword `if`.
 In Nim, this is achieved via backticks, allowing any reserved word to be used as an identifier.
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -8,7 +8,7 @@ Nim Manual
 .. contents::
 
 
-  "Complexity" seems to be a lot like "energy": you can transfer it from the 
+  "Complexity" seems to be a lot like "energy": you can transfer it from the
   end-user to one/some of the other players, but the total amount seems to remain
   pretty much constant for a given task. -- Ran
 
@@ -311,6 +311,35 @@ is the preferred way of writing keywords).
 Historically, Nim was a fully `style-insensitive`:idx: language. This meant that
 it was not case-sensitive and underscores were ignored and there was not even a
 distinction between ``foo`` and ``Foo``.
+
+
+Stropping
+---------
+
+`Stropping <https://en.wikipedia.org/wiki/Stropping_(syntax)>`_
+allows the same letter sequence to be used both as a keyword and as an identifier, and simplifies parsing.
+For example, allowing a variable named `if` without clashing with the keyword `if`.
+In Nim, this is achieved via backticks, allowing any reserved word to be used as an identifier.
+
+Examples
+
+.. code-block:: nim
+  var `var` = "Hello Stropping"
+
+.. code-block:: nim
+  type Type = object
+  `int`: int
+
+  let `object` = Type(`int`: 9)
+  assert `object` is Type
+  assert `object`.`int` == 9
+
+  var `var` = 42
+  let `let` = 8
+  assert `var` + `let` == 50
+
+  const `assert` = true
+  assert `assert`
 
 
 String literals

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -316,13 +316,7 @@ distinction between ``foo`` and ``Foo``.
 Stropping
 ---------
 
-`Stropping <https://en.wikipedia.org/wiki/Stropping_(syntax)>`_
-allows the same letter sequence to be used both as a keyword and as an identifier, this simplifies parsing and
-`FFI <https://en.wikipedia.org/wiki/Foreign_function_interface>`_
-with languages where that identifier is not a reserved keyword.
-
-For example, allowing a variable named `if` without clashing with the keyword `if`.
-In Nim, this is achieved via backticks, allowing any reserved word to be used as an identifier.
+If a keyword is enclosed in backticks it loses its keyword property and becomes an ordinary identifier.
 
 Examples
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -317,7 +317,8 @@ Stropping
 ---------
 
 `Stropping <https://en.wikipedia.org/wiki/Stropping_(syntax)>`_
-allows the same letter sequence to be used both as a keyword and as an identifier, and simplifies parsing.
+allows the same letter sequence to be used both as a keyword and as an identifier,
+this simplifies parsing and FFI with languages where that identifier is not a reserved keyword.
 For example, allowing a variable named `if` without clashing with the keyword `if`.
 In Nim, this is achieved via backticks, allowing any reserved word to be used as an identifier.
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -320,6 +320,7 @@ Stropping
 allows the same letter sequence to be used both as a keyword and as an identifier, this simplifies parsing and
 `FFI <https://en.wikipedia.org/wiki/Foreign_function_interface>`_
 with languages where that identifier is not a reserved keyword.
+
 For example, allowing a variable named `if` without clashing with the keyword `if`.
 In Nim, this is achieved via backticks, allowing any reserved word to be used as an identifier.
 
@@ -330,7 +331,7 @@ Examples
 
 .. code-block:: nim
   type Type = object
-  `int`: int
+    `int`: int
 
   let `object` = Type(`int`: 9)
   assert `object` is Type


### PR DESCRIPTION
- Documentation only, based (but not copied) from Wikipedia, links and examples.
- Fix #15806 
