### PR TITLE
fix #15973 getStacktrace works in VM

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,7 @@
 
 - `os.FileInfo` (returned by `getFileInfo`) now contains `blockSize`,
   determining preferred I/O block size for this file object.
+- `getStacktrace` now works in VM.
 
 - `repr` now doesn't insert trailing newline; previous behavior was very inconsistent,
   see #16034. Use `-d:nimLegacyReprWithNewline` for previous behavior.

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -238,6 +238,17 @@ type
     currentLineInfo*: TLineInfo
   VmCallback* = proc (args: VmArgs) {.closure.}
 
+  PStackFrame* = ref TStackFrame
+  TStackFrame* = object
+    prc*: PSym                 # current prc; proc that is evaluated
+    slots*: seq[TFullReg]      # parameters passed to the proc + locals;
+                              # parameters come first
+    next*: PStackFrame         # for stacking
+    comesFrom*: int
+    safePoints*: seq[int]      # used for exception handling
+                              # XXX 'break' should perform cleanup actions
+                              # What does the C backend do for it?
+
   PCtx* = ref TCtx
   TCtx* = object of TPassContext # code gen context
     code*: seq[TInstr]
@@ -264,17 +275,8 @@ type
     oldErrorCount*: int
     profiler*: Profiler
     templInstCounter*: ref int # gives every template instantiation a unique ID, needed here for getAst
+    tosSaved*: PStackFrame
 
-  PStackFrame* = ref TStackFrame
-  TStackFrame* = object
-    prc*: PSym                 # current prc; proc that is evaluated
-    slots*: seq[TFullReg]      # parameters passed to the proc + locals;
-                              # parameters come first
-    next*: PStackFrame         # for stacking
-    comesFrom*: int
-    safePoints*: seq[int]      # used for exception handling
-                              # XXX 'break' should perform cleanup actions
-                              # What does the C backend do for it?
   Profiler* = object
     tEnter*: float
     tos*: PStackFrame

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -216,6 +216,11 @@ proc registerAdditionalOps*(c: PCtx) =
                   "isExported() requires a symbol. '" & $n & "' is of kind '" & $n.kind & "'", n.info)
     setResult(a, sfExported in n.sym.flags)
 
+  registerCallback c, "stdlib.system.getStackTrace", proc(a: VmArgs) =
+    var ret: string
+    getStackTraceVM(ret, c, c.tosSaved, info = a.currentLineInfo)
+    setResult(a, ret)
+
   proc hashVmImpl(a: VmArgs) =
     var res = hashes.hash(a.getString(0), a.getInt(1).int, a.getInt(2).int)
     if c.config.backend == backendJs:

--- a/tests/errmsgs/tproper_stacktrace4.nim
+++ b/tests/errmsgs/tproper_stacktrace4.nim
@@ -1,0 +1,44 @@
+discard """
+  targets: "c js cpp"
+"""
+
+# tests `getStacktrace`
+
+const vm = """
+stack trace: (most recent call last)
+tproper_stacktrace4.nim(43, 14) tproper_stacktrace4
+tproper_stacktrace4.nim(42, 19) fn3
+tproper_stacktrace4.nim(41, 18) fn2
+tproper_stacktrace4.nim(33, 26) fn"""
+
+const js = """
+Traceback (most recent call last)
+tproper_stacktrace4.nim(44) at module tproper_stacktrace4
+tproper_stacktrace4.nim(42) at tproper_stacktrace4.fn3
+tproper_stacktrace4.nim(41) at tproper_stacktrace4.fn2
+tproper_stacktrace4.nim(33) at tproper_stacktrace4.fn
+"""
+
+const c = """
+Traceback (most recent call last)
+tproper_stacktrace4.nim(44) tproper_stacktrace4
+tproper_stacktrace4.nim(42) fn3
+tproper_stacktrace4.nim(41) fn2
+tproper_stacktrace4.nim(33) fn
+"""
+
+# line 30
+when true:
+  proc fn()=
+    let s = getStacktrace()
+    when nimvm:
+      doAssert s == vm, "\n" & s
+    else:
+      when defined(js):
+        doAssert s == js, "\n" & s
+      else:
+        doAssert s == c, "\n" & s
+  proc fn2() = fn()
+  proc fn3() = fn2()
+  static: fn3()
+  fn3()


### PR DESCRIPTION
* fix #15973 getStacktrace works in VM
* stackTraceAux now computed with iteration instead of recursion
* stackTraceAux now reuses code instead of duplicating it
* see tests/errmsgs/tproper_stacktrace4.nim