### PR TITLE
Utility macro to fill holes in enums with synthetic values

### DIFF
--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -9,11 +9,11 @@
 
 import macros
 
-macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed, 
+macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
             userMin, userMax: static[int], normalizer: static[proc(s :string): string]): untyped =
   # generates a case stmt, which assigns the correct enum field given
   # a normalized string comparison to the `argSym` input.
-  # string normalization is done using passed normalizer. 
+  # string normalization is done using passed normalizer.
   # NOTE: for an enum with fields Foo, Bar, ... we cannot generate
   # `of "Foo".nimIdentNormalize: Foo`.
   # This will fail, if the enum is not defined at top level (e.g. in a block).
@@ -62,3 +62,74 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
   else:
     expectKind(default, nnkSym)
     result.add nnkElse.newTree(default)
+
+const syntheticElemPrefix = "_sythetic_undefined_elem_"
+
+proc intEnumWithHoles(enumBody: NimNode): NimNode =
+  ## Fills the holes in an enum that has int or char values, with synthetic elems
+  ## to benefit from making the enum an ordinal
+  ## Only int values and with low sparsity, i.e. there cannot be an excesive number of
+  ## holes as the ordinal would be grow with too many synthetic elements.
+  if not (
+    enumBody.kind == nnkStmtList and enumBody.len == 1 and
+    enumBody[0].kind == nnkTypeSection and enumBody[0].len == 1 and
+    enumBody[0][0][2].kind == nnkEnumTy):
+     error("intEnumWithHoles: Expected an enum definition", enumBody)
+
+  let typeDef = enumBody[0][0]
+  let origEnum = typeDef[2]
+
+  # To limit the growth of synthetic elements we limit it to sparsity ratio  to 5 times
+  # the number of original elems.
+  # Enums with to many holes and big int assignment are not a good fit for the Ordinal set.
+  var maxAllowedSize = max(256, origEnum.len * 5)
+
+  var elems: seq[NimNode]
+  var nextOrd: int64 
+
+  for i, e in origEnum:
+    if i > 0: # Ignore first empty node
+      if e.kind == nnkIdent:
+        elems.add(e)
+        inc(nextOrd) 
+
+      elif e.kind == nnkEnumFieldDef:
+        var ordValue: int64
+        var lit: NimNode
+
+        if e[1].kind == nnkPrefix and e[1][0] == ident("-"): # Negative numger
+          lit = e[1][1]
+          ordValue = -1 * lit.intVal
+        else:
+          lit = e[1]
+          ordValue = lit.intVal
+
+        if lit.kind notin nnkCharLit..nnkUInt64Lit:
+          error("intEnumWithHoles: Only char are int values are allowed for the enum field values", e)
+
+        if elems.len + (ordValue - nextOrd) > maxAllowedSize:
+          error("intEnumWithHoles: Enum has too many holes. It is too sparse to efficiently convert to an Ordinal.")
+
+        for holeIx in nextOrd..(ordValue - 1):
+          elems.add newIdentNode(syntheticElemPrefix & $holeIx)
+
+        elems.add e
+        nextOrd = ordValue + 1
+
+  typeDef[2] = newNimNode(nnkEnumTy).add(newEmptyNode()).add(elems)
+  result = enumBody
+
+macro intEnumWithHoles*(body: untyped): untyped =
+  result = intEnumWithHoles(body)
+
+proc isDefined*[A: Ordinal](a: A): bool =
+  ## Check whether a is defined in an enum with Holes
+  $a != syntheticElemPrefix & $ord(a)
+
+iterator definedItems*(E: typedesc[enum]): E {.inline.} =
+  ## Filters out synthetic elements covering holes in enums with int values
+  ## crated by macro intEnumWithHoles
+  for e in items(E):
+    if isDefined(e):
+      yield e
+

--- a/tests/stdlib/tenumutils.nim
+++ b/tests/stdlib/tenumutils.nim
@@ -1,0 +1,85 @@
+import std/enumutils
+import std/packedsets
+
+template assertNotCompiling(code: untyped) =
+  doAssert not compiles(code)
+
+block:
+  intEnumWithHoles:
+    type EnumWithHoles = enum A, B, C = 10, D, E = 12, F
+
+  assert EnumWithHoles.low == A
+  assert EnumWithHoles.high == F
+
+  assert ord(B) == 1
+  assert ord(C) == 10
+  assert ord(D) == 11
+  assert ord(E) == 12
+  assert ord(F) == 13
+  assert EnumWithHoles(1)  == B
+  assert EnumWithHoles(10) == C
+  assert EnumWithHoles(11) == D
+  assert EnumWithHoles(12) == E
+  assert EnumWithHoles(13) == F
+
+  assert not compiles(EnumWithHoles(100))
+
+  var x: array[EnumWithHoles, string]
+  var enumSet: PackedSet[EnumWithHoles]
+
+import macros
+
+block negativeRange:
+  intEnumWithHoles:
+    type NegativeIndexes = enum X = -3, Y = -1
+
+  var enumSet: PackedSet[NegativeIndexes]
+
+block charEnums:
+  intEnumWithHoles:
+    type CharEnum = enum A = 'a', B, E = 'e'
+
+  assert char(E) == 'e'
+  assert CharEnum('e') == E
+  var x: array[CharEnum, string]
+
+assertNotCompiling:
+  type CharEnum = enum A = 'a', B, E = 'e'
+  var x: array[CharEnum, string]
+
+assertNotCompiling:
+  intEnumWithHoles:
+    type UnorderedCharEnum = enum A = 'c', B, C = 'a'
+
+assertNotCompiling:
+  intEnumWithHoles:
+    type Unordered = enum A, B, C = 12, E, D = 11, F
+
+assertNotCompiling:
+  intEnumWithHoles:
+    type Unordered = enum A = -1, B = -2
+
+assertNotCompiling:
+  intEnumWithHoles:
+    type TooSparse = enum A, B, C = 300, D
+
+block isDefined:
+  intEnumWithHoles:
+    type Letters = enum J = 'j', K, Z = 'z'
+
+  assert not isDefined(Letters('a'))
+  assert isDefined(Letters('j'))
+  assert isDefined(Letters('k'))
+  assert not isDefined(Letters('h'))
+  assert isDefined(Letters('z'))
+
+block safeIteration:
+  intEnumWithHoles:
+    type Holed = enum A, B = 10, F = 15
+
+  var inHoled: PackedSet[Holed]
+
+  for e in definedItems(Holed):
+    inHoled.incl(e)
+
+  assert inHoled == [A, B, F].toPackedSet


### PR DESCRIPTION
It seems like Nim is missing some ergonomics in the common use case of mapping C 'enums' with holes.
These enums are usually quite dense but likely to contain holes, e.g. scancodes, etc.

It's a pity we lose the powerful Nim ordinal feature like using typesafe packed sets or array encodings for mapping without having to to do int conversion and manual mapping. For instance: https://forum.nim-lang.org/t/7086 

I propose here a tactical solution with a macro filling the holes with synthetic values. I don't see downsides compared to the current enum with holes, as the conversion to the enum is already not compile time safe, other than the iteration would return invalid values, there is a safe utility function for iterating ```definedItems``` and ```isDefined``` that would return an exception if a hole is being read. 