### PR TITLE
fix #15939 #15464 #16169 #16226 VM now supports `addr(mystring[ind])` (index + index assignment)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -66,6 +66,7 @@
 
 - Added `nim --eval:cmd` to evaluate a command directly, see `nim --help`.
 
+- VM now supports `addr(mystring[ind])` (index + index assignment)
 
 
 ## Tool changes

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -994,6 +994,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       elif regs[rc].kind == rkNodeAddr:
         ret = ptrEquality(regs[rc].nodeAddr, regs[rb].node)
       else:
+        dbg regs[rb].kind
         let nb = regs[rb].node
         let nc = regs[rc].node
         if nb.kind != nc.kind: discard

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -122,21 +122,16 @@ proc derefPtrToReg(address: BiggestInt, typ: PType, r: var TFullReg, isAssign: b
       cast[ptr T](address)[] = T(r.field)
     else:
       r.ensureKind(rkind)
-      dbg address
       let val = cast[ptr T](address)[]
-      dbg val, $T, T is SomeInteger
-      when T is SomeInteger:
-        r.field = BiggestInt(val)
-      elif T is char:
+      when T is SomeInteger | char:
         r.field = BiggestInt(val)
       else:
         r.field = val
     return true
 
   ## see also typeinfo.getBiggestInt
-  dbg typ.kind
   case typ.kind
-  of tyChar: fun(intVal, char, rkInt) # xxx char?
+  of tyChar: fun(intVal, char, rkInt)
   of tyInt: fun(intVal, int, rkInt)
   of tyInt8: fun(intVal, int8, rkInt)
   of tyInt16: fun(intVal, int16, rkInt)
@@ -1027,19 +1022,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
           ret = ptrEquality(regs[rb].nodeAddr, regs[rc].node)
       elif regs[rc].kind == rkNodeAddr:
         ret = ptrEquality(regs[rc].nodeAddr, regs[rb].node)
-      elif regs[rc].kind == rkNode and regs[rb].kind == rkInt: # PRTEMP
-        let nc = regs[rc].node
-        let nb = regs[rb].intVal
-        dbg nb
-        dbg nc
-        dbg nc.kind
-        # factor out
-        let intVal2 = if nc.kind == nkNilLit: 0 else: nc.intVal.int
-        ret = intVal2 == nb
-        # dbg regs[rb].kind
-        # if regs[rb].kind == rkInt:
-        #   dbg regs[rc].kind
-        #   dbg regs[rb].intVal
       else:
         let nb = regs[rb].node
         let nc = regs[rc].node

--- a/compiler/vmdef.nim
+++ b/compiler/vmdef.nim
@@ -78,6 +78,7 @@ type
     opcWrDeref,
     opcWrStrIdx,
     opcLdStrIdx, # a = b[c]
+    opcLdStrIdxAddr,  # a = addr(b[c])
 
     opcAddInt,
     opcAddImmInt,

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1656,6 +1656,11 @@ proc genArrAccessOpcode(c: PCtx; n: PNode; dest: var TDest; opc: TOpcode;
   if dest < 0: dest = c.getTemp(n.typ)
   if opc == opcLdArr and {gfNodeAddr} * flags != {}:
     c.gABC(n, opcLdArrAddr, dest, a, b)
+  elif opc == opcLdStrIdxAddr and {gfNodeAddr} * flags != {}:
+    # dbg n.renderTree
+    # dbg n.typ
+    # genTypeLit(c, n.typ, dest)
+    c.gABC(n, opcLdStrIdxAddr, dest, a, b)
   elif needsRegLoad():
     var cc = c.getTemp(n.typ)
     c.gABC(n, opc, cc, a, b)
@@ -1749,7 +1754,11 @@ proc genCheckedObjAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
 proc genArrAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
   let arrayType = n[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind
   if arrayType in {tyString, tyCString}:
-    genArrAccessOpcode(c, n, dest, opcLdStrIdx, {})
+    if gfNodeAddr in flags:
+      # improve
+      genArrAccessOpcode(c, n, dest, opcLdStrIdxAddr, flags)
+    else:
+      genArrAccessOpcode(c, n, dest, opcLdStrIdx, {})
   elif arrayType == tyTypeDesc:
     c.genTypeLit(n.typ, dest)
   else:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1654,12 +1654,9 @@ proc genArrAccessOpcode(c: PCtx; n: PNode; dest: var TDest; opc: TOpcode;
   let a = c.genx(n[0], flags)
   let b = c.genIndex(n[1], n[0].typ)
   if dest < 0: dest = c.getTemp(n.typ)
-  if opc == opcLdArr and {gfNodeAddr} * flags != {}:
+  if opc == opcLdArr and gfNodeAddr in flags:
     c.gABC(n, opcLdArrAddr, dest, a, b)
-  elif opc == opcLdStrIdxAddr and {gfNodeAddr} * flags != {}:
-    # dbg n.renderTree
-    # dbg n.typ
-    # genTypeLit(c, n.typ, dest)
+  elif opc == opcLdStrIdxAddr and gfNodeAddr in flags:
     c.gABC(n, opcLdStrIdxAddr, dest, a, b)
   elif needsRegLoad():
     var cc = c.getTemp(n.typ)
@@ -1755,7 +1752,6 @@ proc genArrAccess(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags) =
   let arrayType = n[0].typ.skipTypes(abstractVarRange-{tyTypeDesc}).kind
   if arrayType in {tyString, tyCString}:
     if gfNodeAddr in flags:
-      # improve
       genArrAccessOpcode(c, n, dest, opcLdStrIdxAddr, flags)
     else:
       genArrAccessOpcode(c, n, dest, opcLdStrIdx, {})

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -196,10 +196,27 @@ template test14339() = # bug #14339
       when not defined(js): # pending bug #16003
         doAssert a.val == 5
 
+proc test15939() = # bug #15939
+  template fn(a) =
+    let pa = a[0].addr
+    doAssert pa != nil
+    doAssert pa[] == 'a'
+    pa[] = 'x'
+    doAssert pa[] == 'x'
+    doAssert a == "xbc"
+  # mystring[ind].addr
+  var a = "abc"
+  fn(a)
+  # mycstring[ind].addr
+  var a2 = "abc"
+  var b2 = a2.cstring
+  fn(b2)
+
 template main =
   # xxx wrap all other tests here like that so they're also tested in VM
   test14420()
   test14339()
+  test15939()
 
 static: main()
 main()

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -204,13 +204,24 @@ proc test15939() = # bug #15939
     pa[] = 'x'
     doAssert pa[] == 'x'
     doAssert a == "xbc"
+    when not defined js: # otherwise overflows
+      let pa2 = cast[ptr char](cast[int](pa) + 1)
+      doAssert pa2[] == 'b'
+      pa2[] = 'B'
+      doAssert a == "xBc"
+
   # mystring[ind].addr
   var a = "abc"
   fn(a)
+
   # mycstring[ind].addr
-  var a2 = "abc"
-  var b2 = a2.cstring
-  fn(b2)
+  template cstringTest =
+    var a2 = "abc"
+    var b2 = a2.cstring
+    fn(b2)
+  when nimvm: cstringTest()
+  else: # can't take address of cstring element in js
+    when not defined(js): cstringTest()
 
 template main =
   # xxx wrap all other tests here like that so they're also tested in VM

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -196,6 +196,30 @@ template test14339() = # bug #14339
       when not defined(js): # pending bug #16003
         doAssert a.val == 5
 
+template testStatic15464() = # bug #15464
+  proc access(s: var seq[char], i: int): var char = s[i]
+  proc access(s: var string, i: int): var char = s[i]
+  static:
+    var s = @['a', 'b', 'c']
+    access(s, 2) = 'C'
+    doAssert access(s, 2) == 'C'
+  static:
+    var s = "abc"
+    access(s, 2) = 'C'
+    doAssert access(s, 2) == 'C'
+
+proc test15464() = # alternative bug #15464
+  proc access(s: var seq[char], i: int): var char = s[i]
+  proc access(s: var string, i: int): var char = s[i]
+  block:
+    var s = @['a', 'b', 'c']
+    access(s, 2) = 'C'
+    doAssert access(s, 2) == 'C'
+  block:
+    var s = "abc"
+    access(s, 2) = 'C'
+    doAssert access(s, 2) == 'C'
+
 proc test15939() = # bug #15939
   template fn(a) =
     let pa = a[0].addr
@@ -227,7 +251,9 @@ template main =
   # xxx wrap all other tests here like that so they're also tested in VM
   test14420()
   test14339()
+  test15464()
   test15939()
 
+testStatic15464()
 static: main()
 main()

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -208,7 +208,7 @@ template testStatic15464() = # bug #15464
     access(s, 2) = 'C'
     doAssert access(s, 2) == 'C'
 
-proc test15464() = # alternative bug #15464
+proc test15464() = # bug #15464 (v2)
   proc access(s: var seq[char], i: int): var char = s[i]
   proc access(s: var string, i: int): var char = s[i]
   block:
@@ -220,7 +220,19 @@ proc test15464() = # alternative bug #15464
     access(s, 2) = 'C'
     doAssert access(s, 2) == 'C'
 
-proc test15939() = # bug #15939
+block: # bug #15939
+  block:
+    const foo = "foo"
+    proc proc1(s: var string) =
+      if s[^1] notin {'a'..'z'}:
+        s = ""
+    proc proc2(f: string): string =
+      result = f
+      proc1(result)
+    const bar = proc2(foo)
+    doAssert bar == "foo"
+
+proc test15939() = # bug #15939 (v2)
   template fn(a) =
     let pa = a[0].addr
     doAssert pa != nil


### PR DESCRIPTION
fix #15464
fix #15939
fix #16169
fix #16226
see test: tests/misc/taddr.nim

## future work after this is merged:
- [x] re-enable argparse (refs dd5405c)
