### PR TITLE
Fix #15977 parsesql lib can't parse data type unsigned constrain, AUTO_INCREMENT column definition

### DIFF
--- a/lib/pure/parsesql.nim
+++ b/lib/pure/parsesql.nim
@@ -501,6 +501,7 @@ type
     nkColumnReference,
     nkReferences,
     nkDefault,
+    nkAutoIncrement,
     nkCheck,
     nkConstraint,
     nkUnique,
@@ -828,6 +829,9 @@ proc parseColumnConstraints(p: var SqlParser, result: SqlNode) =
       var n = newNode(nkDefault)
       n.add(parseExpr(p))
       result.add(n)
+    elif isKeyw(p, "auto_increment"):
+      getTok(p)
+      result.add(newNode(nkAutoIncrement))
     elif isKeyw(p, "references"):
       getTok(p)
       var n = newNode(nkReferences)
@@ -1299,6 +1303,8 @@ proc ra(n: SqlNode, s: var SqlWriter) =
   of nkDefault:
     s.addKeyw("default")
     ra(n.sons[0], s)
+  of nkAutoIncrement:
+    s.addKeyw("auto_increment")
   of nkCheck:
     s.addKeyw("check")
     ra(n.sons[0], s)

--- a/lib/pure/parsesql.nim
+++ b/lib/pure/parsesql.nim
@@ -648,7 +648,7 @@ proc parseDataType(p: var SqlParser): SqlNode =
   else:
     expectIdent(p)
     let isNumericDataType = isKeyw(p, "fixed") or 
-      isKeyw(p,"bigint") or 
+      isKeyw(p, "bigint") or 
       isKeyw(p, "dec") or 
       isKeyw(p, "integer") or 
       isKeyw(p, "smallint") or 
@@ -658,7 +658,7 @@ proc parseDataType(p: var SqlParser): SqlNode =
       isKeyw(p, "numeric") or 
       isKeyw(p, "float") or 
       isKeyw(p, "real") or 
-      isKeyw(p,"int") or isKeyw(p, "double")
+      isKeyw(p, "int") or isKeyw(p, "double")
     if isNumericDataType:
       result = newNode(nkNumericDef)
       result.add newNode(nkIdent, p.tok.literal)

--- a/tests/stdlib/tparsesql.nim
+++ b/tests/stdlib/tparsesql.nim
@@ -207,3 +207,5 @@ SELECT `SELECT`, `FROM` as `GROUP` FROM `WHERE`;
 doAssert $parseSQL("""
 SELECT "SELECT", "FROM" as "GROUP" FROM "WHERE";
 """) == """select "SELECT", "FROM" as "GROUP" from "WHERE";"""
+
+doAssert $parseSQL("""CREATE TABLE Persons (Personid int NOT NULL AUTO_INCREMENT);""") == """create table Persons(Personid  int  not null  auto_increment );;"""

--- a/tests/stdlib/tparsesql.nim
+++ b/tests/stdlib/tparsesql.nim
@@ -2,6 +2,7 @@ discard """
   targets: "c js"
 """
 import parsesql
+import unittest
 
 doAssert $parseSQL("SELECT foo FROM table;") == "select foo from table;"
 doAssert $parseSQL("""
@@ -209,3 +210,9 @@ SELECT "SELECT", "FROM" as "GROUP" FROM "WHERE";
 """) == """select "SELECT", "FROM" as "GROUP" from "WHERE";"""
 
 doAssert $parseSQL("""CREATE TABLE Persons (Personid int NOT NULL AUTO_INCREMENT);""") == """create table Persons(Personid  int  not null  auto_increment );;"""
+
+doAssert $parseSQL("""create table num_tests (s text, u8 tinyint unsigned, s8 tinyint, u int unsigned zerofill, i int, b bigint zerofill);""") == """create table num_tests(s  text , u8  tinyint unsigned , s8  tinyint , u  int unsigned zerofill , i  int , b  bigint zerofill );;"""
+expect SqlParseError:
+  discard parseSQL("""create table num_tests (b bigint zerofill unsigned);""")
+
+doAssert $parseSQL("""create table num_tests (d DOUBLE PRECISION unsigned zerofill, i double, b real zerofill);""") == """create table num_tests(d  DOUBLE PRECISION unsigned zerofill , i  double , b  real zerofill );;"""


### PR DESCRIPTION
Fix #15977

remain old problem: 
1.  "extra space and semicolon." 
2.  "`M` digits"