### PR TITLE
fix #4132  set lfNoDeepCopy for getTemp

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -469,7 +469,7 @@ proc getTemp(p: BProc, t: PType, result: var TLoc; needsInit=false) =
   result.k = locTemp
   result.lode = lodeTyp t
   result.storage = OnStack
-  result.flags = {}
+  result.flags = {lfNoDeepCopy}
   constructLoc(p, result, not needsInit)
 
 proc getTempCpp(p: BProc, t: PType, result: var TLoc; value: Rope) =

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -479,7 +479,7 @@ proc getTempCpp(p: BProc, t: PType, result: var TLoc; value: Rope) =
   result.k = locTemp
   result.lode = lodeTyp t
   result.storage = OnStack
-  result.flags = {}
+  result.flags = {lfNoDeepCopy}
 
 proc getIntTemp(p: BProc, result: var TLoc) =
   inc(p.labels)


### PR DESCRIPTION
Does `getTemp`  need copy?