### PR TITLE
add projectPath api to NimSuggest

### DIFF
--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -658,6 +658,9 @@ else:
     idle: int
     cachedMsgs: CachedMsgs
 
+  proc projectPath*(nimsuggest: NimSuggest): string =
+    nimsuggest.graph.conf.projectPath
+
   proc initNimSuggest*(project: string, nimPath: string = ""): NimSuggest =
     var retval: ModuleGraph
     proc mockCommand(graph: ModuleGraph) =

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -659,7 +659,7 @@ else:
     cachedMsgs: CachedMsgs
 
   proc projectPath*(nimsuggest: NimSuggest): string =
-    nimsuggest.graph.config.projectPath
+    nimsuggest.graph.config.projectPath.string
 
   proc initNimSuggest*(project: string, nimPath: string = ""): NimSuggest =
     var retval: ModuleGraph

--- a/nimsuggest/nimsuggest.nim
+++ b/nimsuggest/nimsuggest.nim
@@ -659,7 +659,7 @@ else:
     cachedMsgs: CachedMsgs
 
   proc projectPath*(nimsuggest: NimSuggest): string =
-    nimsuggest.graph.conf.projectPath
+    nimsuggest.graph.config.projectPath
 
   proc initNimSuggest*(project: string, nimPath: string = ""): NimSuggest =
     var retval: ModuleGraph


### PR DESCRIPTION
when developer pass nim file path to initNimsuggest, they may not know the NimSuggest instance `projectPath` is, they may assuming editor project root, but they may wrong.