### PR TITLE
fix #14339, #13511, #14420: fixes limited VM support for addr

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -746,10 +746,13 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       regs[ra].regAddr = addr(regs[rb])
     of opcAddrNode:
       decodeB(rkNodeAddr)
-      if regs[rb].kind == rkNode:
+      case regs[rb].kind
+      of rkNode:
         regs[ra].nodeAddr = addr(regs[rb].node)
+      of rkNodeAddr: # bug #14339
+        regs[ra].nodeAddr = regs[rb].nodeAddr
       else:
-        stackTrace(c, tos, pc, "limited VM support for 'addr'")
+        stackTrace(c, tos, pc, "limited VM support for 'addr', got kind: " & $regs[rb].kind)
     of opcLdDeref:
       # a = b[]
       let ra = instr.regA

--- a/tests/macros/tmacros_various.nim
+++ b/tests/macros/tmacros_various.nim
@@ -245,3 +245,28 @@ xbenchmark:
     discard inputtest
   fastSHA("hey")
 
+
+block: # bug #13511
+  type
+    Builder = ref object
+      components: seq[Component]
+    Component = object
+
+  proc add(builder: var Builder, component: Component) {.compileTime.} =
+    builder.components.add(component)
+
+  macro debugAst(arg: typed): untyped =
+    ## just for debugging purpose.
+    discard arg.treeRepr
+    return arg
+
+  static:
+    var component = Component()
+    var builder = Builder()
+
+    template foo(): untyped =
+      ## WAS: this doc comment causes compilation failure.
+      builder
+
+    debugAst:
+      add(foo(), component)

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -144,7 +144,11 @@ template test14339() = # bug #14339
       n.val
     var a = Node(val: 3)
     a.bar() = 5
-    doAssert a.val == 5
+    when nimvm:
+      doAssert a.val == 5
+    else:
+      when not defined(js): # pending bug #16003
+        doAssert a.val == 5
 
 test14339()
 static: test14339()

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -123,3 +123,16 @@ block:
   block: # pending bug #15959
     when false:
       proc byLent2[T](a: T): lent type(a[0]) = a[0]
+
+block: # bug #14339
+  type
+    Node = ref object
+      val: int
+  proc bar(c: Node): var int =
+    var n = c # was: Error: limited VM support for 'addr'
+    c.val
+  proc main =
+    var a = Node()
+    discard a.bar()
+  static: main()
+  main()

--- a/tests/misc/taddr.nim
+++ b/tests/misc/taddr.nim
@@ -124,15 +124,27 @@ block:
     when false:
       proc byLent2[T](a: T): lent type(a[0]) = a[0]
 
-block: # bug #14339
-  type
-    Node = ref object
-      val: int
-  proc bar(c: Node): var int =
-    var n = c # was: Error: limited VM support for 'addr'
-    c.val
-  proc main =
+template test14339() = # bug #14339
+  block:
+    type
+      Node = ref object
+        val: int
+    proc bar(c: Node): var int =
+      var n = c # was: Error: limited VM support for 'addr'
+      c.val
     var a = Node()
     discard a.bar()
-  static: main()
-  main()
+  block:
+    type
+      Node = ref object
+        val: int
+    proc bar(c: Node): var int =
+      var n = c
+      doAssert n.val == n[].val
+      n.val
+    var a = Node(val: 3)
+    a.bar() = 5
+    doAssert a.val == 5
+
+test14339()
+static: test14339()

--- a/tests/stdlib/tcritbits.nim
+++ b/tests/stdlib/tcritbits.nim
@@ -1,61 +1,69 @@
-import sequtils, critbits
+import std/[sequtils,critbits]
 
+template main =
+  var r: CritBitTree[void]
+  r.incl "abc"
+  r.incl "xyz"
+  r.incl "def"
+  r.incl "definition"
+  r.incl "prefix"
+  r.incl "foo"
 
-var r: CritBitTree[void]
-r.incl "abc"
-r.incl "xyz"
-r.incl "def"
-r.incl "definition"
-r.incl "prefix"
-r.incl "foo"
+  doAssert r.contains"def"
 
-doAssert r.contains"def"
+  r.excl "def"
+  assert r.missingOrExcl("foo") == false
+  assert "foo" notin toSeq(r.items)
 
-r.excl "def"
-assert r.missingOrExcl("foo") == false
-assert "foo" notin toSeq(r.items)
+  assert r.missingOrExcl("foo") == true
 
-assert r.missingOrExcl("foo") == true
+  assert toSeq(r.items) == @["abc", "definition", "prefix", "xyz"]
 
-assert toSeq(r.items) == @["abc", "definition", "prefix", "xyz"]
+  assert toSeq(r.itemsWithPrefix("de")) == @["definition"]
+  var c = CritBitTree[int]()
 
-assert toSeq(r.itemsWithPrefix("de")) == @["definition"]
-var c = CritBitTree[int]()
+  c.inc("a")
+  assert c["a"] == 1
 
-c.inc("a")
-assert c["a"] == 1
+  c.inc("a", 4)
+  assert c["a"] == 5
 
-c.inc("a", 4)
-assert c["a"] == 5
+  c.inc("a", -5)
+  assert c["a"] == 0
 
-c.inc("a", -5)
-assert c["a"] == 0
+  c.inc("b", 2)
+  assert c["b"] == 2
 
-c.inc("b", 2)
-assert c["b"] == 2
+  c.inc("c", 3)
+  assert c["c"] == 3
 
-c.inc("c", 3)
-assert c["c"] == 3
+  c.inc("a", 1)
+  assert c["a"] == 1
 
-c.inc("a", 1)
-assert c["a"] == 1
+  var cf = CritBitTree[float]()
 
-var cf = CritBitTree[float]()
+  cf.incl("a", 1.0)
+  assert cf["a"] == 1.0
 
-cf.incl("a", 1.0)
-assert cf["a"] == 1.0
+  cf.incl("b", 2.0)
+  assert cf["b"] == 2.0
 
-cf.incl("b", 2.0)
-assert cf["b"] == 2.0
+  cf.incl("c", 3.0)
+  assert cf["c"] == 3.0
 
-cf.incl("c", 3.0)
-assert cf["c"] == 3.0
+  assert cf.len == 3
+  cf.excl("c")
+  assert cf.len == 2
 
-assert cf.len == 3
-cf.excl("c")
-assert cf.len == 2
+  var cb: CritBitTree[string]
+  cb.incl("help", "help")
+  for k in cb.keysWithPrefix("helpp"):
+    doAssert false, "there is no prefix helpp"
 
-var cb: CritBitTree[string]
-cb.incl("help", "help")
-for k in cb.keysWithPrefix("helpp"):
-  doAssert false, "there is no prefix helpp"
+  block: # bug #14339
+    var strings: CritBitTree[int]
+    discard strings.containsOrIncl("foo", 3)
+    doAssert strings["foo"] == 3
+
+main()
+static: main()


### PR DESCRIPTION
* fix #14420 (all snippets are tested in this PR, with c,cpp,js,vm)
* fix #14339 ditto
* fix #13511 ditto
* moved isMainModule in critbits to tests/stdlib/tcritbits.nim
* add regression tests for #14339 in tests/stdlib/tcritbits.nim (critbit snippet) and taddr.nim (generic snippet)
* identified a new related bug that affects js => https://github.com/nim-lang/Nim/issues/16003

## future work
now that #14420 will be closed (all snippets work in all backends), decide whether we still need to do anything about https://github.com/nim-lang/Nim/issues/14420#issuecomment-633711557, which is a separate issue /cc @cooldome 
