### PR TITLE
Add more summation functions

### DIFF
--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -70,7 +70,7 @@ func twoSum*[T](a, b: T): (T, T) =
   let z = result[0] - a
   result[1] = (a - (result[0] - z)) + (b - z)
 
-func sum2*[T : SomeFloat](v: openArray[T]): T =
+func sum2*[T: SomeFloat](v: openArray[T]): T =
   ## sum an array v using twoSum function
   if len(v) == 0:
     return 0.0

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -145,45 +145,6 @@ func fsum*[T: SomeFloat](x: openArray[T]): T =
   ## Alias of shewchuckSum function as python fsum
   sumShewchuck(x)
 
-func neumaierSum*[T: SomeFloat](x: openArray[T]): T =
-  ## improved Kahan–Babuška algorithm
-  ## https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
-  var sum = 0.0
-  var c = 0.0 # A running compensation for lost low-order bits.
-  for v in x:
-    var t = sum + v
-    # If sum is bigger, low-order digits of input[i] are lost.
-    if abs(sum) >= abs(v):
-      c += (sum - t) + v
-    else:
-      c += (v - t) + sum # Else low-order digits of sum are lost.
-      sum = t
-  return sum + c # Correction only applied once in the very end.
-
-func kleinSum*[T: SomeFloat](x: openArray[T]): T =
-  ## Klein variant
-  ## https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
-  var sum = 0.0
-  var cs = 0.0
-  var ccs = 0.0
-  for v in x:
-    var t = sum + v
-    var c = 0.0
-    var cc = 0.0
-    if abs(sum) >= abs(v):
-      c = (sum - t) + v
-    else:
-      c = (v - t) + sum
-    sum = t
-    t = cs + c
-    if abs(cs) >= abs(c):
-      cc = (cs - t) + c
-    else:
-      cc = (c - t) + cs
-    cs = t
-    ccs = ccs + cc
-  return sum + cs + ccs
-
 runnableExamples:
   static:
     block:

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -154,6 +154,10 @@ runnableExamples:
       const data = [1, 2, 3, 4, 5, 6, 7, 8, 9]
       doAssert sumKbn(data) == 45
       doAssert sumPairs(data) == 45
+      const dataFloat = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      doAssert sumPairs(dataFloat) != 1.0 # 0.9999...
+      doAssert sumKbn(dataFloat) == 1.0
+      doAssert sumShewchuck(dataFloat) == 1.0
 
 
 when isMainModule:
@@ -164,6 +168,7 @@ when isMainModule:
     epsilon /= 2.0
   let data = @[1.0, epsilon, -epsilon]
   assert sumKbn(data) == 1.0
+  assert sumShewchuck(data) == 1.0
   assert sumPairs(data) != 1.0 # known to fail
   assert (1.0 + epsilon) - epsilon != 1.0
 
@@ -171,10 +176,12 @@ when isMainModule:
   for n in 1 .. 1000:
     tc1.add 1.0 / n.float
   assert sumKbn(tc1) == 7.485470860550345
+  assert sumShewchuck(tc1) == 7.485470860550345
   assert sumPairs(tc1) == 7.485470860550345
 
   var tc2: seq[float]
   for n in 1 .. 1000:
     tc2.add pow(-1.0, n.float) / n.float
   assert sumKbn(tc2) == -0.6926474305598203
+  assert sumShewchuck(tc2) == -0.6926474305598203
   assert sumPairs(tc2) == -0.6926474305598204

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -77,8 +77,8 @@ func sum2*[T: SomeFloat](v: openArray[T]): T =
 
   var s = v[0]
   var e: float
-  for x in v[1..^1]:
-    let sum = twoSum(s, x)
+  for i in 1..<v.len-1:
+    let sum = twoSum(s, v[i])
     s = sum[0]
     e += sum[1]
   return s + e

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -91,43 +91,43 @@ func sumShewchuck_add[T: SomeFloat](v: openArray[T]): seq[T] =
     var x = x
     var i = 0
     for y in result:
-       let sum = twoSum(x, y)
-       let hi = sum[0]
-       let lo = sum[1]
-       if lo != 0.0:
-          result[i] = lo
-          i.inc
-       x = hi
+      let sum = twoSum(x, y)
+      let hi = sum[0]
+      let lo = sum[1]
+      if lo != 0.0:
+        result[i] = lo
+        i.inc
+      x = hi
     setLen(result, i + 1)
     result[i] = x
 
 func sumShewchuck_total[T: SomeFloat](partials: openArray[T]): T =
   var hi = 0.0
   if len(partials) > 0:
-     var n = len(partials)
-     dec(n)
-     hi = partials[n]
-     var lo = 0.0
-     while n > 0:
-       var x = hi
-       dec(n)
-       var y = partials[n]
-       let sum = twoSum(x, y)
-       hi = sum[0]
-       lo = sum[1]
-       if lo != 0.0:
-         break
-       if (n > 0 and
-           (
-             (lo < 0.0 and partials[n - 1] < 0.0) or
-             (lo > 0.0 and partials[n - 1] > 0.0)
-           )
-         ):
-           y = lo * 2.0
-           x = hi + y
-           var yr = x - hi
-           if y == yr:
-             hi = x
+    var n = len(partials)
+    dec(n)
+    hi = partials[n]
+    var lo = 0.0
+    while n > 0:
+      var x = hi
+      dec(n)
+      var y = partials[n]
+      let sum = twoSum(x, y)
+      hi = sum[0]
+      lo = sum[1]
+      if lo != 0.0:
+        break
+      if (n > 0 and
+          (
+            (lo < 0.0 and partials[n - 1] < 0.0) or
+            (lo > 0.0 and partials[n - 1] > 0.0)
+          )
+        ):
+        y = lo * 2.0
+        x = hi + y
+        var yr = x - hi
+        if y == yr:
+          hi = x
   result = hi
 
 func sumShewchuck*[T: SomeFloat](x: openArray[T]): T =

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -53,7 +53,7 @@ func sumPairs*[T](x: openArray[T]): T =
   let n = len(x)
   if n == 0: T(0) else: sumPairwise(x, 0, n)
 
-func fastTwoSum*[T : SomeFloat](a, b: T): (T, T) =
+func fastTwoSum*[T: SomeFloat](a, b: T): (T, T) =
   ## Deker's algorithm
   ## pre-condition: |a| >= |b|
   ## you must swap a and b if pre-condition is not satisfied

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -85,9 +85,6 @@ func sum2*[T: SomeFloat](v: openArray[T]): T =
   return s + e
 
 func sumShewchuck_add[T: SomeFloat](v: openArray[T]): seq[T] =
-  ## Original PR: https://github.com/nim-lang/Nim/pull/9284
-  ## Return partials result.
-  ## Result must be summed
   for x in v:
     var x = x
     var i = 0
@@ -132,13 +129,19 @@ func sumShewchuck_total[T: SomeFloat](partials: openArray[T]): T =
   result = hi
 
 func sumShewchuck*[T: SomeFloat](x: openArray[T]): T =
+  ## Shewchuk's summation
   ## Full precision sum of values in iterable. Returns the value of the
   ## sum, rounded to the nearest representable floating-point number
   ## using the round-half-to-even rule
   ##
-  ## https://docs.python.org/3/library/math.html#math.fsum
-  ## https://code.activestate.com/recipes/393090/
-  ## www-2.cs.cmu.edu/afs/cs/project/quake/public/papers/robust-arithmetic.ps
+  ## See also:
+  ## - https://docs.python.org/3/library/math.html#math.fsum
+  ## - https://code.activestate.com/recipes/393090/
+  ##
+  ## Reference:
+  ## Shewchuk, JR. (1996) Adaptive Precision Floating-Point Arithmetic and \
+  ## Fast Robust GeometricPredicates.
+  ## http://www-2.cs.cmu.edu/afs/cs/project/quake/public/papers/robust-arithmetic.ps
   sumShewchuck_total(sumShewchuck_add(x))
 
 func fsum*[T: SomeFloat](x: openArray[T]): T =

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -133,7 +133,6 @@ func shewchuckSum_total*[T: SomeFloat](partials: openArray[T]): T =
            if y == yr:
              hi = x
   result = hi
-  return result
 
 func shewchuckSum*[T: SomeFloat](x: openArray[T]): T =
   ## https://docs.python.org/3/library/math.html#math.fsum

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -59,6 +59,7 @@ func fastTwoSum*[T: SomeFloat](a, b: T): (T, T) =
   ## you must swap a and b if pre-condition is not satisfied
   ## s + r = a + b exactly (s is result[0] and r is result[1])
   ## s is the nearest FP number of a + B
+  assert(abs(a) >= abs(b))
   result[0] = a + b
   result[1] = b - (result[0] - a)
 

--- a/lib/std/sums.nim
+++ b/lib/std/sums.nim
@@ -83,11 +83,7 @@ func sum2*[T: SomeFloat](v: openArray[T]): T =
     e += sum[1]
   return s + e
 
-func shewchuckSum_add*[T: SomeFloat](v: openArray[T]): seq[T] =
-  ## Full precision sum of values in iterable. Returns the value of the
-  ## sum, rounded to the nearest representable floating-point number
-  ## using the round-half-to-even rule
-  ##
+func sumShewchuck_add[T: SomeFloat](v: openArray[T]): seq[T] =
   ## Original PR: https://github.com/nim-lang/Nim/pull/9284
   ## Return partials result.
   ## Result must be summed
@@ -105,7 +101,7 @@ func shewchuckSum_add*[T: SomeFloat](v: openArray[T]): seq[T] =
     setLen(result, i + 1)
     result[i] = x
 
-func shewchuckSum_total*[T: SomeFloat](partials: openArray[T]): T =
+func sumShewchuck_total[T: SomeFloat](partials: openArray[T]): T =
   var hi = 0.0
   if len(partials) > 0:
      var n = len(partials)
@@ -134,15 +130,19 @@ func shewchuckSum_total*[T: SomeFloat](partials: openArray[T]): T =
              hi = x
   result = hi
 
-func shewchuckSum*[T: SomeFloat](x: openArray[T]): T =
+func sumShewchuck*[T: SomeFloat](x: openArray[T]): T =
+  ## Full precision sum of values in iterable. Returns the value of the
+  ## sum, rounded to the nearest representable floating-point number
+  ## using the round-half-to-even rule
+  ##
   ## https://docs.python.org/3/library/math.html#math.fsum
   ## https://code.activestate.com/recipes/393090/
   ## www-2.cs.cmu.edu/afs/cs/project/quake/public/papers/robust-arithmetic.ps
-  shewchuckSum_total(shewchuckSum_add(x))
+  sumShewchuck_total(sumShewchuck_add(x))
 
 func fsum*[T: SomeFloat](x: openArray[T]): T =
   ## Alias of shewchuckSum function as python fsum
-  shewchuckSum(x)
+  sumShewchuck(x)
 
 func neumaierSum*[T: SomeFloat](x: openArray[T]): T =
   ## improved Kahan–Babuška algorithm


### PR DESCRIPTION
I don't know if all the code has to be integrated in nim or if I have to make a dedicated library, nevertheless as there is already a library in std I allow myself to propose some new functions.

AFAIK, Julia uses pairwise summation and Python, Shewchuk robust summation [1]. I propose to add a `fsum` func as python does.
BTW, there are the classical twoSum functions and kahan variant/improvement.

Tiny example
```
import sequtils
import std/sums

let tab = @[0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]

echo "foldl (naive): ", foldl(tab, a + b)
# foldl: 0.9999999999999999
echo "pairs: ", sumPairs(tab)
# pairs: 0.9999999999999999
echo "kbn: ", sumKbn(tab)
# kbn: 1.0
echo "fsum: ", fsum(tab)
# fsum: 1.0
var part = shewchuckSum_add(tab)
echo "part: ", part
# part @[5.551115123125783e-17, 1.0]
echo sumPairs(part)
# 1.0
echo sumKbn(part)
# 1.0
```
If you consider that these functions deserve to be integrated, I will improve the PR with tests, comments and cleanup as usual.

[1] https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Support_by_libraries