### PR TITLE
`defer` now works at top-level

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 
 - Added `nim --eval:cmd` to evaluate a command directly, see `nim --help`.
 
+- `defer` now works at top-level
 
 
 ## Tool changes

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2889,8 +2889,6 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkStaticStmt:
     result = semStaticStmt(c, n)
   of nkDefer:
-    if c.currentScope == c.topLevelScope:
-      localError(c.config, n.info, "defer statement not supported at top level")
     n[0] = semExpr(c, n[0])
     if not n[0].typ.isEmptyType and not implicitlyDiscardable(n[0]):
       localError(c.config, n.info, "'defer' takes a 'void' expression")

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -4441,9 +4441,6 @@ Is rewritten to:
     finally:
       close(f)
 
-Top-level ``defer`` statements are not supported
-since it's unclear what such a statement should refer to.
-
 
 Raise statement
 ---------------

--- a/tests/exception/tdefer1.nim
+++ b/tests/exception/tdefer1.nim
@@ -1,18 +1,28 @@
 discard """
-  output: '''hi
+  targets: "c cpp js"
+  output: '''
+hi1
 1
-hi
+hi2
 2
 B
-A'''
+A
+ok4
+ok6
+ok8
+ok7
+ok5
+'''
 """
+
+# see also: tests/exception/tdefer2.nim
 
 # bug #1742
 
 import strutils
 let x = try: parseInt("133a")
         except: -1
-        finally: echo "hi"
+        finally: echo "hi1"
 
 
 template atFuncEnd =
@@ -22,9 +32,9 @@ template atFuncEnd =
     echo "B"
 
 template testB(): untyped =
-    let a = 0
-    defer: echo "hi"
-    a
+  let a = 0
+  defer: echo "hi2"
+  a
 
 proc main =
   atFuncEnd()
@@ -33,3 +43,14 @@ proc main =
   echo 2
 
 main()
+
+template main2 =
+  # defer at top-level scope
+  echo "ok4"
+  defer: echo "ok5"
+  echo "ok6"
+  defer: echo "ok7"
+  echo "ok8"
+
+static: main2()
+main2()

--- a/tests/exception/tdefer2.nim
+++ b/tests/exception/tdefer2.nim
@@ -1,0 +1,22 @@
+discard """
+  exitcode: 1
+  output: '''
+ok1
+ok3
+ok2
+tdefer2.nim(21)          tdefer2
+Error: unhandled exception: ok4 [ValueError]
+'''
+"""
+
+
+
+
+# line 15
+
+echo "ok1"
+defer: echo "ok2"
+echo "ok3"
+if true:
+  raise newException(ValueError, "ok4")
+echo "ok5"


### PR DESCRIPTION
## example with `import`
```nim
# in sub.nim
echo "b1"
defer: echo "b3"
echo "b2"

# in main.nim
echo "a1"
defer: echo "a3"
import ./sub
echo "a2"
```
nim r main
b1
b2
b3
a1
a2
a3

## TODO before re-opening
see if https://github.com/nim-lang/Nim/issues/9705 is still a problem