### PR TITLE
fix #15623

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -674,7 +674,7 @@ proc getConstExpr(m: PSym, n: PNode; idgen: IdGenerator; g: ModuleGraph): PNode 
   of nkCast:
     var a = getConstExpr(m, n[1], idgen, g)
     if a == nil: return
-    if n.typ != nil and n.typ.kind in NilableTypes:
+    if n.typ != nil and n.typ.kind in NilableTypes and a.kind != nkNilLit:
       # we allow compile-time 'cast' for pointer types:
       result = a
       result.typ = n.typ

--- a/lib/posix/posix_linux_amd64_consts.nim
+++ b/lib/posix/posix_linux_amd64_consts.nim
@@ -365,7 +365,7 @@ const SCHED_RR* = cint(2)
 const SCHED_OTHER* = cint(0)
 
 # <semaphore.h>
-const SEM_FAILED* = cast[pointer]((nil))
+const SEM_FAILED* = nil
 
 # <signal.h>
 const SIGEV_NONE* = cint(1)

--- a/tests/ccgbugs/t15623.nim
+++ b/tests/ccgbugs/t15623.nim
@@ -1,0 +1,10 @@
+discard """
+  action: "compile"
+"""
+
+block:
+  echo cast[ptr int](nil)[]
+
+block:
+  var x: ref int = nil
+  echo cast[ptr int](x)[]

--- a/tests/ccgbugs/t15623.nim
+++ b/tests/ccgbugs/t15623.nim
@@ -2,6 +2,7 @@ discard """
   action: "compile"
 """
 
+# bug #15623
 block:
   echo cast[ptr int](nil)[]
 

--- a/tests/ccgbugs/t15623_2.nim
+++ b/tests/ccgbugs/t15623_2.nim
@@ -1,0 +1,13 @@
+discard """
+  output: '''0
+0
+'''
+"""
+
+# bug #15623
+block:
+  echo cast[int](cast[ptr int](nil))
+
+block:
+  var x: ref int = nil
+  echo cast[int](cast[ptr int](x))


### PR DESCRIPTION
After this PR. `const expr` doesn't fold `cast[pointer](nil)` into `nil` anymore which will cause problem in c codegen.
```nim
const a = cast[pointer](nil)
```
For example `cast[ptr int](nil)[]` generates `(*NIM_NIL)`

Because VM doesn't support cast nil to pointer, it will cause the same errors as static expr: `VM does not support 'cast' from tyNil to tyPointer`.

```nim
static:
  let a = cast[pointer](nil)
```
If this PR is merged, maybe we could support cast nil to pointer in VM like this
```nim
  elif src.kind == tyNil:
    if dest < 0: dest = c.getTemp(n[0].typ)
    genLit(c, n[1], dest)
```
See PR #16009