### PR TITLE
follow #16009 VM supports cast nil to ptr

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -901,6 +901,9 @@ proc genCastIntFloat(c: PCtx; n: PNode; dest: var TDest) =
     c.gABx(n, opcSetType, dest, c.genType(dst))
     c.gABC(n, opcCastIntToPtr, dest, tmp)
     c.freeTemp(tmp)
+  elif src.kind == tyNil and dst.kind in PtrLikeKinds:
+    if dest < 0: dest = c.getTemp(n[0].typ)
+    genLit(c, n[1], dest)
   else:
     # todo: support cast from tyInt to tyRef
     globalError(c.config, n.info, "VM does not support 'cast' from " & $src.kind & " to " & $dst.kind)

--- a/tests/vm/tcastnil.nim
+++ b/tests/vm/tcastnil.nim
@@ -1,0 +1,25 @@
+discard """
+  nimout: '''nil
+nil
+nil
+nil
+'''
+"""
+
+block:
+  static:
+    let a = cast[pointer](nil)
+    echo a.repr
+
+block:
+  static:
+    echo cast[ptr int](nil).repr
+
+block:
+  const str = cast[ptr int](nil)
+  static:
+    echo str.repr
+
+block:
+  static:
+    echo cast[ptr int](nil).repr

--- a/tests/vm/tcastnil.nim
+++ b/tests/vm/tcastnil.nim
@@ -3,6 +3,7 @@ discard """
 nil
 nil
 nil
+nil
 '''
 """
 
@@ -23,3 +24,7 @@ block:
 block:
   static:
     echo cast[ptr int](nil).repr
+
+block:
+  static:
+    echo cast[RootRef](nil).repr


### PR DESCRIPTION
Before only `const x = cast[pointer](nil)` works.
Now `static: let a = cast[pointer](nil)` also works.