### PR TITLE
fix #16011 endOfFile

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -531,10 +531,7 @@ proc rawFileSize(file: File): int64 =
 
 proc endOfFile*(f: File): bool {.tags: [], benign.} =
   ## Returns true if `f` is at the end.
-  var c = c_fgetc(f)
-  discard c_ungetc(c, f)
-  return c < 0'i32
-  #result = c_feof(f) != 0
+  result = c_feof(f) != 0 # fixes bug #16011
 
 proc readAllFile(file: File, len: int64): string =
   # We acquire the filesize beforehand and hope it doesn't change.


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/16011

WIP because I need to figure out what to do with `tests/misc/treadln.nim`, which fails with this PR as written:
```nim
var
  inp: File
  line: string
if open(inp, "tests/misc/treadln.nim"):
  while not endOfFile(inp):
    line = readLine(inp)
    if line.len >= 2 and line[0] == '#' and line[1] == ' ':
      echo line[2..^1]
  close(inp)
```

note that this pattern (calling `endOfFile` before reading data) is wrong, as described in several places, eg: https://stackoverflow.com/a/5432517/1426932

> In this case, feof() is called before any data has been read, so it returns false. The loop is entered, fgetc() is called (and returns EOF), and count is incremented. Then feof() is called and returns true, causing the loop to abort.
> This happens in all such cases. feof() does not return true until after a read on the stream encounters the end of file. The purpose of feof() is NOT to check if the next read will reach the end of file. The purpose of feof() is to determine the status of a previous read function and distinguish between an error condition and the end of the data stream

-----

if changing `endOfFile` is an unacceptable breaking change, than maybe we need to document this caveat and add another proc `isEOF` or `endOfFilePost` implemented as:
```nim
proc isEOF*(f: File): bool {.tags: [], benign.} =
  ## Returns true if `f` is at the end after reading data.
  result = c_feof(f) != 0
```

and encourage people to use this instead of `endOfFile` which is buggy.