### PR TITLE
fix #15097 Compiler crashes when referring to an undeclared gensymmed…

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1768,6 +1768,8 @@ proc skipGenericOwner*(s: PSym): PSym =
 
 proc originatingModule*(s: PSym): PSym =
   result = s.owner
+  if result.owner == nil:
+    raiseRecoverableError("cannot find owner of call routine `" & $s.name.s & "` from invalid AST node")
   while result.kind != skModule: result = result.owner
 
 proc isRoutine*(s: PSym): bool {.inline.} =

--- a/tests/errmsgs/t15097.nim
+++ b/tests/errmsgs/t15097.nim
@@ -1,0 +1,13 @@
+discard """
+  errmsg: "unhandled exception: cannot find owner of call routine `tmp` from invalid AST node [ERecoverableError]"
+  file: ""
+"""
+import macros
+
+macro foo: untyped = 
+  result = newStmtList()
+  let tmp = genSym(nskProc, "tmp") # or nskMacro, nskTemplate...
+  result.add quote do:
+    let bar = `tmp`()
+    
+foo()


### PR DESCRIPTION
… proc/macro/template
fix #15097 