### PR TITLE
almostEqual: fix for Inf values and add an option for NaN

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -158,7 +158,7 @@ proc classify*(x: float): FloatClass =
     return fcSubnormal
   return fcNormal
 
-proc almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4, equalNan:  bool = false): bool {.
+proc almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4, equalNan = false): bool {.
       since: (1, 5), inline, noSideEffect.} =
   ## Checks if two float values are almost equal, using
   ## `machine epsilon <https://en.wikipedia.org/wiki/Machine_epsilon>`_.

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -189,7 +189,7 @@ proc almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4, equalNan
     doAssert almostEqual(NaN, NaN, equalNan = true)
 
   if (equalNan == true) and (classify(x) == fcNan) and (classify(y) == fcNan):
-      return true
+    return true
 
   if x == y: # short circuit exact equality and allow Inf comparison
     return true


### PR DESCRIPTION
almostEqual contains a bug with Inf values, where `Inf == Inf` returns true, `almostEqual(Inf, Inf)` returns false.

BTW, I propose to add an option to handle NaN case when we hope that NaN == NaN returns true; which is not normally the case, but can sometimes be useful. This option exists in numpy for example.
