### PR TITLE
contributing docs: always mentioned referenced issues in PR body, not just title

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -378,7 +378,7 @@ General commit rules
 
 1. Important, critical bugfixes that have a tiny chance of breaking
    somebody's code should be backported to the latest stable release
-   branch (currently 1.2.x) and maybe also to the 1.0 branch.
+   branch (currently 1.4.x) and maybe also all the way back to the 1.0.x branch.
    The commit message should contain the tag ``[backport]`` for "backport to all
    stable releases" and the tag ``[backport:$VERSION]`` for backporting to the
    given $VERSION.
@@ -417,7 +417,14 @@ General commit rules
    close it when the PR is committed), wheres issue ``#124`` is referenced
    (e.g.: partially fixed) and won't close the issue when committed.
 
-6. Commits should be always be rebased against devel (so a fast forward
+6. PR body (not just PR title) should contain references to fixed/referenced github
+  issues, e.g.: `fix #123` or `refs #123`. This is so that you get proper cross
+  referencing from linked issue to the PR (github won't make those links with just
+  PR title, and commit messages aren't always sufficient to ensure that, e.g.
+  can't be changed after a PR is merged).
+
+
+7. Commits should be always be rebased against devel (so a fast forward
    merge can happen)
 
    e.g.: use ``git pull --rebase origin devel``. This is to avoid messing up
@@ -426,7 +433,7 @@ General commit rules
    squash all commits using the script shown in
    https://github.com/nim-lang/Nim/pull/9356
 
-7. Do not mix pure formatting changes (e.g. whitespace changes, nimpretty) or
+8. Do not mix pure formatting changes (e.g. whitespace changes, nimpretty) or
    automated changes (e.g. nimfix) with other code changes: these should be in
    separate commits (and the merge on GitHub should not squash these into 1).
 


### PR DESCRIPTION
I always do this in my PR's and it helps with cross-referencing from linked issue <=> PR.
Until github fixes this (by honoring links in titles, see https://github.com/isaacs/github/issues/568), this is needed.
