### PR TITLE
fix numbering in contributing.rst

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -407,7 +407,6 @@ General commit rules
 
       #!/bin/sh
       git diff --check --cached || exit $?
-
 5. Describe your commit and use your common sense.
    Example commit message:
 
@@ -418,11 +417,10 @@ General commit rules
    (e.g.: partially fixed) and won't close the issue when committed.
 
 6. PR body (not just PR title) should contain references to fixed/referenced github
-  issues, e.g.: `fix #123` or `refs #123`. This is so that you get proper cross
-  referencing from linked issue to the PR (github won't make those links with just
-  PR title, and commit messages aren't always sufficient to ensure that, e.g.
-  can't be changed after a PR is merged).
-
+   issues, e.g.: `fix #123` or `refs #123`. This is so that you get proper cross
+   referencing from linked issue to the PR (github won't make those links with just
+   PR title, and commit messages aren't always sufficient to ensure that, e.g.
+   can't be changed after a PR is merged).
 
 7. Commits should be always be rebased against devel (so a fast forward
    merge can happen)


### PR DESCRIPTION
* adds workaround for https://github.com/nim-lang/Nim/issues/16041 (see bullet point 4) otherwise numbering/formatting is wrong:

![image](https://user-images.githubusercontent.com/2194784/99614376-37bbfa00-29ce-11eb-8033-8549caa68e7f.png)

* fix indentation from my previous contributing.rst PR that caused bad formatting
