### PR TITLE
add `deferScoped`, library defined scoped `defer`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,8 @@
 - `os.FileInfo` (returned by `getFileInfo`) now contains `blockSize`,
   determining preferred I/O block size for this file object.
 
+- Added `defers.deferSCoped` as a library-defined, scoped alternative to `defer`.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -13,6 +13,10 @@
 import std/private/since
 import macros, typetraits
 
+since (1,5,1):
+  import std/defers
+  export defers
+
 proc checkPragma(ex, prag: var NimNode) =
   since (1, 3):
     if ex.kind == nnkPragmaExpr:

--- a/lib/std/defers.nim
+++ b/lib/std/defers.nim
@@ -1,0 +1,12 @@
+template deferScoped*(cleanup, body) =
+  ## Similar to builtin `defer` statement, but operates on a scope `body`,
+  ## whereas `defer` operates until end of block it's defined in.
+  ## Implemented as: `try: body ... finally: cleanup`
+  runnableExamples:
+    from std/strutils import contains
+    let a = open(currentSourcePath)
+    deferScoped: close(a) # immediately follows code that needs cleanup
+    do:
+      doAssert "deferScoped" in readAll(a)
+  try: body
+  finally: cleanup


### PR DESCRIPTION
A lot of code (in compiler, stdlib, nimble) is incorrect wrt exception handling as mentioned here https://forum.nim-lang.org/t/4022#44758 

> Typical example is code that looks correct but isn't because author is unaware that something might raise (eg os.sameFileContent is actually buggy since readBuffer can raise, as I mentioned in https://github.com/nim-lang/Nim/pull/16008/files#r524822306), or worse, might be correct today but become incorrect after some unrelated change in the future. defer prevents this entire class of bug, and does so without adding (sometimes large) lexical scopes.

however there's some pushback for using `defer` more widely in compiler sources  https://forum.nim-lang.org/t/4022#44770

> Great update! However, I still don't like to see defer in the Nim compiler code and I dislike it so much that I thought of adding a switch --araqstyle (which forbids defer and continue) that is enabled for the compiler's code.

and there are legitimate cases where defer in a scope is preferable.

This PR adds a library defined scoped `defer`. The semantic differences wrt `defer` have been explained in https://github.com/nim-lang/Nim/pull/16010 and this in no way makes builtin `defer` (aka D's `scope(exit)`) obsolete; just different use cases, with, yes, some overlap.

## example
```nim
when true:
    from std/strutils import contains
    let a = open(currentSourcePath)
    deferScoped: close(a) # immediately follows code that needs cleanup
    do:
      doAssert "deferScoped" in readAll(a)
```

## links
* originally proposed in https://github.com/nim-lang/RFCs/issues/236#issuecomment-646855314
* performance benchmarks (see https://forum.nim-lang.org/t/4022#44762 and https://forum.nim-lang.org/t/4022#44816) will still need to be done eventually, especially for the "manual" error code-sylye handling vs "try/finally" style (defer vs scopedDefer are identical in that respect)

## why not just use try/finally?
as explained in https://github.com/nim-lang/RFCs/issues/236#issuecomment-646855314 
> which syntactically improves a bit over try/finally because the cleanup code immediately follows the code that needs cleaning up

## notes
* only controversial point in PR: in `std/defers` because modules are cheap (https://github.com/nim-lang/Nim/pull/14614) but re-exported in std/sugar (which is a heavier kitchen sink-like dependency that is likely to keep growing), so that client code can use this without sugar dependency if needed.