### PR TITLE
Speed up parsejson 3.25x (with a gcc-10.2 PGO build) on number heavy input

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,11 @@
   literals remain in the "raw" string form so that client code can easily treat
   small and large numbers uniformly.
 
+- The parsejson module now combines number validation & parsing to net a speed
+  up of over 2x on number heavy inputs.  It also allows *not* retaining origin
+  strings for integers & floats for another 1.5x speed up (over 3X overall).
+  A couple convenience iterators were also added.
+
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -809,22 +809,12 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool): JsonNode =
     p.a = ""
     discard getTok(p)
   of tkInt:
-    if rawIntegers:
-      result = newJRawNumber(p.a)
-    else:
-      try:
-        result = newJInt(p.getInt)
-      except ValueError:
-        result = newJRawNumber(p.a)
+    result = if rawIntegers or p.giant: newJRawNumber(p.a)
+             else: newJInt(p.getInt)
     discard getTok(p)
   of tkFloat:
-    if rawFloats:
-      result = newJRawNumber(p.a)
-    else:
-      try:
-        result = newJFloat(p.getFloat)
-      except ValueError:
-        result = newJRawNumber(p.a)
+    result = if rawFloats or p.giant: newJRawNumber(p.a)
+             else: newJFloat(p.getFloat)
     discard getTok(p)
   of tkTrue:
     result = newJBool(true)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -809,11 +809,11 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool): JsonNode =
     p.a = ""
     discard getTok(p)
   of tkInt:
-    result = if rawIntegers or p.giant: newJRawNumber(p.a)
+    result = if rawIntegers or p.isGiant: newJRawNumber(p.a)
              else: newJInt(p.getInt)
     discard getTok(p)
   of tkFloat:
-    result = if rawFloats or p.giant: newJRawNumber(p.a)
+    result = if rawFloats or p.isGiant: newJRawNumber(p.a)
              else: newJFloat(p.getFloat)
     discard getTok(p)
   of tkTrue:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -813,7 +813,7 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool): JsonNode =
       result = newJRawNumber(p.a)
     else:
       try:
-        result = newJInt(parseBiggestInt(p.a))
+        result = newJInt(p.getInt)
       except ValueError:
         result = newJRawNumber(p.a)
     discard getTok(p)
@@ -822,7 +822,7 @@ proc parseJson(p: var JsonParser; rawIntegers, rawFloats: bool): JsonNode =
       result = newJRawNumber(p.a)
     else:
       try:
-        result = newJFloat(parseFloat(p.a))
+        result = newJFloat(p.getFloat)
       except ValueError:
         result = newJRawNumber(p.a)
     discard getTok(p)

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -388,7 +388,7 @@ proc parseNumber(my: var JsonParser): TokKind {.inline.} =
         break                                   # a second '.' is forbidden
       pnt = nD                                  # save location of '.' (point)
       nD.dec                                    # undo loop's nD.inc
-    elif nD < 20:                               # 2**63==9.2e18 => 19 digits ok
+    elif nD < 18:                               # 2**63==9.2e18 => 19 digits ok
       my.i = 10 * my.i + my.buf[i].i64          # core ASCII->binary transform
     else:                                       # 20+ digits before decimal
       p10.inc                                   # any digit moves implicit '.'

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -64,9 +64,9 @@ type
 
   JsonParser* = object of BaseLexer ## the parser object.
     a*: string      ## last valid string
-    i*: int64       ## last valid integer
-    f*: float       ## last valid float
-    giant*: bool    ## true if tkInt or tkFloat overflow native bounds
+    i: int64        # last valid integer
+    f: float        # last valid float
+    giant: bool     # true if tkInt or tkFloat overflow native bounds
     tok*: TokKind   ## current token kind
     kind: JsonEventKind
     err: JsonError
@@ -135,13 +135,18 @@ proc str*(my: JsonParser): string {.inline.} =
   assert(my.kind in {jsonInt, jsonFloat, jsonString})
   return my.a
 
+proc isGiant*(my: JsonParser): bool {.inline.} =
+  ## returns whether the last ``tkInt|tkFloat`` token was not CPU native
+  assert(my.tok == tkInt)
+  return cast[BiggestInt](my.i) # A no-op unless BiggestInt changes
+
 proc getInt*(my: JsonParser): BiggestInt {.inline.} =
-  ## returns the number for the event: ``jsonInt``
+  ## returns the number for the last ``tkInt`` token as a ``BiggestInt``
   assert(my.tok == tkInt)
   return cast[BiggestInt](my.i) # A no-op unless BiggestInt changes
 
 proc getFloat*(my: JsonParser): float {.inline.} =
-  ## returns the number for the event: ``jsonFloat``
+  ## returns the number for the last ``tkFloat`` token as a ``float``.
   assert(my.tok == tkFloat)
   return my.f
 

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -392,14 +392,20 @@ proc parseNumber(my: var JsonParser): TokKind {.inline.} =
   elif noDot: # and my.i < (1'i64 shl 53'i64) ? # No '.' & No [Ee]xponent
     my.bufpos = i
     if my.strIntegers:
-      my.a.setLen i - my.bufpos
-      copyMem my.a[0].addr, my.buf[my.bufpos].addr, i - my.bufpos
+      when nimvm:
+        my.a = my.buf[my.bufpos..<i]
+      else:
+        my.a.setLen i - my.bufpos
+        copyMem my.a[0].addr, my.buf[my.bufpos].addr, i - my.bufpos
     return tkInt                                # mark as integer
   exp += pnt - nD + p10                         # combine explicit&implicit exp
   my.f = my.i.float * pow10(exp)                # has round-off vs. 80-bit
   if my.strFloats:
-    my.a.setLen i - my.bufpos
-    copyMem my.a[0].addr, my.buf[my.bufpos].addr, i - my.bufpos
+    when nimvm:
+      my.a = my.buf[my.bufpos..<i]
+    else:
+      my.a.setLen i - my.bufpos
+      copyMem my.a[0].addr, my.buf[my.bufpos].addr, i - my.bufpos
   my.bufpos = i
   return tkFloat                                # mark as float
 

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -343,8 +343,10 @@ template doCopy(a, b, start, endp1: untyped): untyped =
   jsOrVmBlock:
     a = b[start ..< endp1]
   do:
-    a.setLen endp1 - start
-    copyMem a[0].addr, b[start].addr, endp1 - start
+    let n = endp1 - start
+    if n > 0:
+      a.setLen n
+      copyMem a[0].addr, b[start].addr, n
 
 proc i64(c: char): int64 {.inline.} = int64(ord(c) - ord('0'))
 

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -392,7 +392,7 @@ proc parseNumber(my: var JsonParser): TokKind {.inline.} =
   elif noDot: # and my.i < (1'i64 shl 53'i64) ? # No '.' & No [Ee]xponent
     my.bufpos = i
     if my.strIntegers:
-      when nimvm:
+      when defined(nimscript):
         my.a = my.buf[my.bufpos..<i]
       else:
         my.a.setLen i - my.bufpos
@@ -401,7 +401,7 @@ proc parseNumber(my: var JsonParser): TokKind {.inline.} =
   exp += pnt - nD + p10                         # combine explicit&implicit exp
   my.f = my.i.float * pow10(exp)                # has round-off vs. 80-bit
   if my.strFloats:
-    when nimvm:
+    when defined(nimscript):
       my.a = my.buf[my.bufpos..<i]
     else:
       my.a.setLen i - my.bufpos

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -136,12 +136,12 @@ proc str*(my: JsonParser): string {.inline.} =
 
 proc getInt*(my: JsonParser): BiggestInt {.inline.} =
   ## returns the number for the event: ``jsonInt``
-  assert(my.kind == jsonInt)
+  assert(my.tok == tkInt)
   return cast[BiggestInt](my.i) # A no-op unless BiggestInt changes
 
 proc getFloat*(my: JsonParser): float {.inline.} =
   ## returns the number for the event: ``jsonFloat``
-  assert(my.kind == jsonFloat)
+  assert(my.tok == tkFloat)
   return my.f
 
 proc kind*(my: JsonParser): JsonEventKind {.inline.} =

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -137,8 +137,8 @@ proc str*(my: JsonParser): string {.inline.} =
 
 proc isGiant*(my: JsonParser): bool {.inline.} =
   ## returns whether the last ``tkInt|tkFloat`` token was not CPU native
-  assert(my.tok == tkInt)
-  return cast[BiggestInt](my.i) # A no-op unless BiggestInt changes
+  assert(my.tok in {tkInt, tkFloat})
+  return my.giant
 
 proc getInt*(my: JsonParser): BiggestInt {.inline.} =
   ## returns the number for the last ``tkInt`` token as a ``BiggestInt``

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -392,12 +392,14 @@ proc parseNumber(my: var JsonParser): TokKind {.inline.} =
   elif noDot: # and my.i < (1'i64 shl 53'i64) ? # No '.' & No [Ee]xponent
     my.bufpos = i
     if my.strIntegers:
-      my.a = my.buf[my.bufpos..<i]
+      my.a.setLen i - my.bufpos
+      copyMem my.a[0].addr, my.buf[my.bufpos].addr, i - my.bufpos
     return tkInt                                # mark as integer
   exp += pnt - nD + p10                         # combine explicit&implicit exp
   my.f = my.i.float * pow10(exp)                # has round-off vs. 80-bit
   if my.strFloats:
-    my.a = my.buf[my.bufpos..<i]
+    my.a.setLen i - my.bufpos
+    copyMem my.a[0].addr, my.buf[my.bufpos].addr, i - my.bufpos
   my.bufpos = i
   return tkFloat                                # mark as float
 

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -388,7 +388,7 @@ proc parseNumber(my: var JsonParser): TokKind {.inline.} =
         break                                   # a second '.' is forbidden
       pnt = nD                                  # save location of '.' (point)
       nD.dec                                    # undo loop's nD.inc
-    elif nD < 18:                               # 2**63==9.2e18 => 19 digits ok
+    elif nD < 18:                               # 2**63==9.2e18 => 18 digits ok
       my.i = 10 * my.i + my.buf[i].i64          # core ASCII->binary transform
     else:                                       # 20+ digits before decimal
       p10.inc                                   # any digit moves implicit '.'

--- a/lib/pure/parsejson.nim
+++ b/lib/pure/parsejson.nim
@@ -137,12 +137,12 @@ proc str*(my: JsonParser): string {.inline.} =
 proc getInt*(my: JsonParser): BiggestInt {.inline.} =
   ## returns the number for the event: ``jsonInt``
   assert(my.kind == jsonInt)
-  return parseBiggestInt(my.a)
+  return cast[BiggestInt](my.i) # A no-op unless BiggestInt changes
 
 proc getFloat*(my: JsonParser): float {.inline.} =
   ## returns the number for the event: ``jsonFloat``
   assert(my.kind == jsonFloat)
-  return parseFloat(my.a)
+  return my.f
 
 proc kind*(my: JsonParser): JsonEventKind {.inline.} =
   ## returns the current event type for the JSON parser

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -4,6 +4,7 @@ discard """
 
 import std/jsonutils
 import std/json
+import std/math
 
 proc testRoundtrip[T](t: T, expected: string) =
   let j = t.toJson
@@ -238,7 +239,7 @@ template fn() =
       doAssert not foo.b
       doAssert foo.f == 0.0
       doAssert foo.c == 1
-      doAssert foo.c1 == 3.14159
+      doAssert almostEqual(foo.c1, 3.14159, 1)
 
     block testExceptionOnWrongDiscirminatBranchInJson:
       var foo = Foo(b: false, f: 3.14159, c: 0, c0: 42)
@@ -247,7 +248,7 @@ template fn() =
                      fromJson(foo, json, Joptions(allowMissingKeys: true))
       # Test that the original fields are not reset.
       doAssert not foo.b
-      doAssert foo.f == 3.14159
+      doAssert almostEqual(foo.f, 3.14159, 1)
       doAssert foo.c == 0
       doAssert foo.c0 == 42
 
@@ -258,7 +259,7 @@ template fn() =
       doAssert not foo.b
       doAssert foo.f == 2.71828
       doAssert foo.c == 1
-      doAssert foo.c1 == 3.14159
+      doAssert almostEqual(foo.c1, 3.14159, 1)
 
     block testAllowExtraKeysInJsonOnWrongDisciriminatBranch:
       var foo = Foo(b: false, f: 3.14159, c: 0, c0: 42)
@@ -267,7 +268,7 @@ template fn() =
                                    allowExtraKeys: true))
       # Test that the original fields are not reset.
       doAssert not foo.b
-      doAssert foo.f == 3.14159
+      doAssert almostEqual(foo.f, 3.14159, 1)
       doAssert foo.c == 0
       doAssert foo.c0 == 42
 


### PR DESCRIPTION
Also add a couple convenience iterators and update `changelog.md`.

The basic idea here is to process the ASCII just once in a combination
validation/classification/parse rather than validating/classifying a
number in `parsejson.parseNumber`, then doing the same work again in
`parseFloat`/`parseInt` and finally doing it a 3rd time in the C library
`strtod`/etc.  The last is especially slow on some libc's/common CPUs
due to `long double`/80-bit extended precision arithmetic on each digit.
In any event, the new fully functional `parseNumber` is not actually much
more code than the old classifying-only `parseNumber`.

Because we aim to do this work just once and the output of the work is
an int64|float, this PR adds those exported fields to `JsonParser`.  (It
also documents two existing but undocumented fields.)

One simple optimization done here is pow10.  It uses a small lookup
table for the power of 10 multiplier.  The full 2048*8B = 16 KiB one is
bigger than is useful.  In truth most numbers in any given run will
likely be of similar orders of magnitude, meaning the cache cost would
not be heavy, but probably best to not rely only likelihood.  So fall
back to a fast integer-exponentiation algorithm when out of range.

The new `parseNumber` itself is more or less a straight-line parse of
scientific notation where the '.' can be anywhere in the number.  To do
the right power-of-10 scaling later, we need to bookkeep a little more
than the old `parseNumber` as noted in side comments in the code.

Note that calling code that always wants a `float` even if the textual
representation looks like an integer can do something like `if p.tok ==
tkInt: float(p.i) else: p.f` or similar, depending on context.

Note that since we form the final float by integer * powerOf10 and since
powers of 10 have some intrinsic binary representational error and since
some alternative approaches (on just some CPUs) use 80-bit floats, it is
possible for the number to mismatch those other approaches in the least
significant mantissa bit (or for the ASCII->binary->ASCII round-trip to
not be the identity).  On those CPUs only, better matching results can
maybe be gotten from an `emit` using `long double` if desired (also with
a long double table for powers of 10 and the powers of 10 calculation).
This strikes me as unlikely to be truly needed long-term, though.