### PR TITLE
jsonutils: support cstring (including as Table key); improve docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,8 @@
 - Added an overload for the `collect` macro that inferes the container type based
   on the syntax of the last expression. Works with std seqs, tables and sets.
 
+- `jsonutils` now handles `cstring` (including as Table key)
+
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 

--- a/changelog.md
+++ b/changelog.md
@@ -47,7 +47,7 @@
 - Added an overload for the `collect` macro that inferes the container type based
   on the syntax of the last expression. Works with std seqs, tables and sets.
 
-- `jsonutils` now handles `cstring` (including as Table key)
+- `jsonutils` now handles `cstring` (including as Table key).
 
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -11,7 +11,7 @@ runnableExamples:
     z1: int8
   let a = (1.5'f32, (b: "b2", a: "a2"), 'x', @[Foo(t: true, z1: -3), nil], [{"name": "John"}.newStringTable])
   let j = a.toJson
-  doAssert j.jsonTo(typeof(a)).toJson == j
+  assert j.jsonTo(typeof(a)).toJson == j
 
 import std/[json,strutils,tables,sets,strtabs,options]
 
@@ -316,8 +316,8 @@ proc toJsonHook*[K: string|cstring, V](t: (Table[K, V] | OrderedTable[K, V])): J
     assert $toJson(foo) == """{"t":{"two":2},"ot":{"one":1,"three":3}}"""
     # if keys are not string|cstring, you can use this:
     let a = {10: "foo", 11: "bar"}.newOrderedTable
-    let a2 = collect(newSeq): (for k,v in a: (k,v))
-    doAssert $toJson(a2) == """[[10,"foo"],[11,"bar"]]"""
+    let a2 = collect: (for k,v in a: (k,v))
+    assert $toJson(a2) == """[[10,"foo"],[11,"bar"]]"""
 
   result = newJObject()
   for k, v in pairs(t):

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -197,6 +197,11 @@ proc fromJson*[T](a: var T, b: JsonNode, opt = Joptions()) =
     else:
       a.distinctBase.fromJson(b)
   elif T is string|SomeNumber: a = to(b,T)
+  elif T is cstring:
+    case b.kind
+    of JNull: a = nil
+    of JString: a = b.str
+    else: checkJson false, $($T, " ", b)
   elif T is JsonNode: a = b
   elif T is ref | ptr:
     if b.kind == JNull: a = nil
@@ -273,9 +278,10 @@ proc toJson*[T](a: T): JsonNode =
   elif T is bool: result = %(a)
   elif T is SomeInteger: result = %a
   elif T is Ordinal: result = %(a.ord)
+  elif T is cstring: (if a == nil: result = newJNull() else: result = % $a)
   else: result = %a
 
-proc fromJsonHook*[K, V](t: var (Table[K, V] | OrderedTable[K, V]),
+proc fromJsonHook*[K: string|cstring, V](t: var (Table[K, V] | OrderedTable[K, V]),
                          jsonNode: JsonNode) =
   ## Enables `fromJson` for `Table` and `OrderedTable` types.
   ## 
@@ -296,21 +302,27 @@ proc fromJsonHook*[K, V](t: var (Table[K, V] | OrderedTable[K, V]),
   for k, v in jsonNode:
     t[k] = jsonTo(v, V)
 
-proc toJsonHook*[K, V](t: (Table[K, V] | OrderedTable[K, V])): JsonNode =
+proc toJsonHook*[K: string|cstring, V](t: (Table[K, V] | OrderedTable[K, V])): JsonNode =
   ## Enables `toJson` for `Table` and `OrderedTable` types.
   ##
   ## See also:
   ## * `fromJsonHook proc<#fromJsonHook,,JsonNode>`_
+  # pending PR #9217 use: toSeq(a) instead of `collect` in `runnableExamples`.
   runnableExamples:
-    import std/[tables, json]
+    import std/[tables, json, sugar]
     let foo = (
       t: [("two", 2)].toTable,
       ot: [("one", 1), ("three", 3)].toOrderedTable)
     assert $toJson(foo) == """{"t":{"two":2},"ot":{"one":1,"three":3}}"""
+    # if keys are not string|cstring, you can use this:
+    let a = {10: "foo", 11: "bar"}.newOrderedTable
+    let a2 = collect(newSeq): (for k,v in a: (k,v))
+    doAssert $toJson(a2) == """[[10,"foo"],[11,"bar"]]"""
 
   result = newJObject()
   for k, v in pairs(t):
-    result[k] = toJson(v)
+    # not sure if $k has overhead for string
+    result[(when K is string: k else: $k)] = toJson(v)
 
 proc fromJsonHook*[A](s: var SomeSet[A], jsonNode: JsonNode) =
   ## Enables `fromJson` for `HashSet` and `OrderedSet` types.

--- a/tests/stdlib/thashes.nim
+++ b/tests/stdlib/thashes.nim
@@ -87,6 +87,7 @@ block largeSize: # longer than 4 characters
 
 proc main() =
   doAssert hash(0.0) == hash(0)
+  # bug #16061
   doAssert hash(cstring"abracadabra") == 97309975
   doAssert hash(cstring"abracadabra") == hash("abracadabra")
 

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -14,6 +14,7 @@ proc testRoundtrip[T](t: T, expected: string) =
   doAssert t2.toJson == j
 
 import tables, sets, algorithm, sequtils, options, strtabs
+from strutils import contains
 
 type Foo = ref object
   id: int
@@ -40,27 +41,31 @@ template fn() =
     # https://github.com/nim-lang/Nim/issues/12282
     testRoundtrip(Foo(1.5)): """1.5"""
 
-  block:
+  block: # OrderedTable
     testRoundtrip({"z": "Z", "y": "Y"}.toOrderedTable): """{"z":"Z","y":"Y"}"""
+    doAssert toJson({"z": 10, "": 11}.newTable).`$`.contains """"":11""" # allows hash to change
+    when nimvm: discard # pending bug #16061
+    else:
+      testRoundtrip({"z".cstring: 1, "".cstring: 2}.toOrderedTable): """{"z":1,"":2}"""
     testRoundtrip({"z": (f1: 'f'), }.toTable): """{"z":{"f1":102}}"""
 
-  block:
+  block: # StringTable
     testRoundtrip({"name": "John", "city": "Monaco"}.newStringTable): """{"mode":"modeCaseSensitive","table":{"city":"Monaco","name":"John"}}"""
 
   block: # complex example
     let t = {"z": "Z", "y": "Y"}.newStringTable
     type A = ref object
       a1: string
-    let a = (1.1, "fo", 'x', @[10,11], [true, false], [t,newStringTable()], [0'i8,3'i8], -4'i16, (foo: 0.5'f32, bar: A(a1: "abc"), bar2: A.default))
+    let a = (1.1, "fo", 'x', @[10,11], [true, false], [t,newStringTable()], [0'i8,3'i8], -4'i16, (foo: 0.5'f32, bar: A(a1: "abc"), bar2: A.default, cstring1: "foo", cstring2: "", cstring3: cstring(nil)))
     testRoundtrip(a):
-      """[1.1,"fo",120,[10,11],[true,false],[{"mode":"modeCaseSensitive","table":{"y":"Y","z":"Z"}},{"mode":"modeCaseSensitive","table":{}}],[0,3],-4,{"foo":0.5,"bar":{"a1":"abc"},"bar2":null}]"""
+      """[1.1,"fo",120,[10,11],[true,false],[{"mode":"modeCaseSensitive","table":{"y":"Y","z":"Z"}},{"mode":"modeCaseSensitive","table":{}}],[0,3],-4,{"foo":0.5,"bar":{"a1":"abc"},"bar2":null,"cstring1":"foo","cstring2":"","cstring3":null}]"""
 
   block:
     # edge case when user defined `==` doesn't handle `nil` well, e.g.:
     # https://github.com/nim-lang/nimble/blob/63695f490728e3935692c29f3d71944d83bb1e83/src/nimblepkg/version.nim#L105
     testRoundtrip(@[Foo(id: 10), nil]): """[{"id":10},null]"""
 
-  block:
+  block: # enum
     type Foo = enum f1, f2, f3, f4, f5
     type Bar = enum b1, b2, b3, b4
     let a = [f2: b2, f3: b3, f4: b4]

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -44,9 +44,7 @@ template fn() =
   block: # OrderedTable
     testRoundtrip({"z": "Z", "y": "Y"}.toOrderedTable): """{"z":"Z","y":"Y"}"""
     doAssert toJson({"z": 10, "": 11}.newTable).`$`.contains """"":11""" # allows hash to change
-    when nimvm: discard # pending bug #16061
-    else:
-      testRoundtrip({"z".cstring: 1, "".cstring: 2}.toOrderedTable): """{"z":1,"":2}"""
+    testRoundtrip({"z".cstring: 1, "".cstring: 2}.toOrderedTable): """{"z":1,"":2}"""
     testRoundtrip({"z": (f1: 'f'), }.toTable): """{"z":{"f1":102}}"""
 
   block: # StringTable


### PR DESCRIPTION
* support cstring
* support cstring as Table key
* improve docs wrt Table keys, refs https://forum.nim-lang.org/t/7121#44878
> That's exactly why I was wondering. Seems like it should work out of the box which is why I was surprised.

* un-disable a test that now works

## future work
- [ ] support arbitrary keys in Table using the same trick as in the runnableExamples, there's no possible ambiguity there (maybe needs https://github.com/nim-lang/Nim/pull/9217 or providing a similar iterator byPairs)