### PR TITLE
alternative way to fix #16022

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -327,10 +327,10 @@ proc setPointer*(x: Any, y: pointer) =
   ## ``akString``, ``akCString``, ``akProc``, ``akRef``, ``akPtr``,
   ## ``akPointer``, ``akSequence``.
   assert x.rawType.kind in pointerLike
-  if y != nil:
+  if y != nil and x.rawType.kind != tyPointer:
     genericAssign(x.value, y, x.rawType)
   else:
-    cast[ppointer](x.value)[] = nil
+    cast[ppointer](x.value)[] = y
 
 proc fieldsAux(p: pointer, n: ptr TNimNode,
                ret: var seq[tuple[name: cstring, any: Any]]) =

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -7,6 +7,7 @@ omega 200
 Some(null)
 None[JsonNode]
 (numeric: "")
+hello world
 '''
 joinable: false
 """
@@ -138,7 +139,7 @@ block:
   echo ($$a2).to[:Option[JsonNode]]
 
 
-#  bug #15620
+# bug #15620
 block:
   let str = """{"numeric": null}"""
 
@@ -148,3 +149,9 @@ block:
 
   let test = to[LegacyEntry](str)
   echo test
+
+# bug #16022
+block:
+  let p: proc () = proc () = echo "hello world"
+  let poc = (to[typeof(p)]($$p))
+  poc()


### PR DESCRIPTION
Let's see whether this could cause memory pollution
https://github.com/nim-lang/Nim/issues/9754

The test for #9754
https://github.com/nim-lang/Nim/blob/devel/tests/stdlib/t9754.nim

`genicAssign` will copy the memory of pointer. 