### PR TITLE
fix #2844 #3911; add --spellsuggest to suggest symbols in scope with similar spellings on undefined symbol error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -261,6 +261,8 @@
 
 - Deprecated `--nilseqs` which is now a noop.
 
+- Added `--spellSuggest` to show spelling suggestions on typos.
+
 - Source+Edit links now appear on top of every docgen'd page when
   `nim doc --git.url:url ...` is given.
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -864,8 +864,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "listfullpaths":
     processOnOffSwitchG(conf, {optListFullPaths}, arg, pass, info)
   of "spellsuggest":
-    expectArg(conf, switch, arg, pass, info)
-    conf.spellSuggestMax = parseInt(arg)
+    if arg.len == 0: conf.spellSuggestMax = spellSuggestSecretSauce
+    elif arg == "auto": conf.spellSuggestMax = spellSuggestSecretSauce
+    else: conf.spellSuggestMax = parseInt(arg)
   of "declaredlocs":
     processOnOffSwitchG(conf, {optDeclaredLocs}, arg, pass, info)
   of "dynliboverride":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -864,7 +864,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "listfullpaths":
     processOnOffSwitchG(conf, {optListFullPaths}, arg, pass, info)
   of "spellsuggest":
-    processOnOffSwitchG(conf, {optSpellSuggest}, arg, pass, info)
+    expectArg(conf, switch, arg, pass, info)
+    conf.spellSuggestMax = parseInt(arg)
   of "declaredlocs":
     processOnOffSwitchG(conf, {optDeclaredLocs}, arg, pass, info)
   of "dynliboverride":

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -863,6 +863,8 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info)
   of "listfullpaths":
     processOnOffSwitchG(conf, {optListFullPaths}, arg, pass, info)
+  of "spellsuggest":
+    processOnOffSwitchG(conf, {optSpellSuggest}, arg, pass, info)
   of "declaredlocs":
     processOnOffSwitchG(conf, {optDeclaredLocs}, arg, pass, info)
   of "dynliboverride":

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -374,11 +374,8 @@ type E = object
 
 template toOrderTup(a: E): auto =
   # `dist` is first, to favor nearby matches
-  # `depth` is next, to favor nearby enclosing scopes amongst ties
-  # `sym.name.s` is last, to make the list ordered and more deterministic
-  # to make it more deterministic, we'd need to also take into account
-  # `addDeclaredLoc` among ties, e.g. a symbol `foo` in 2 files f1.nim, f2.nim.
-  # (a.dist, a.depth, a.sym.name.s)
+  # `depth` is next, to favor nearby enclosing scopes among ties
+  # `sym.name.s` is last, to make the list ordered and deterministic among ties
   (a.dist, a.depth, a.msg)
 
 proc `<`(a, b: E): bool =

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -354,22 +354,20 @@ proc mergeShadowScope*(c: PContext) =
     else:
       c.addInterfaceDecl(sym)
 
-when defined(nimfix):
-  # when we cannot find the identifier, retry with a changed identifier:
-  proc altSpelling(x: PIdent): PIdent =
-    case x.s[0]
-    of 'A'..'Z': result = getIdent(toLowerAscii(x.s[0]) & x.s.substr(1))
-    of 'a'..'z': result = getIdent(toLowerAscii(x.s[0]) & x.s.substr(1))
-    else: result = x
+proc altSpelling(x: PIdent): PIdent =
+  case x.s[0]
+  of 'A'..'Z': result = getIdent(toLowerAscii(x.s[0]) & x.s.substr(1))
+  of 'a'..'z': result = getIdent(toLowerAscii(x.s[0]) & x.s.substr(1))
+  else: result = x
 
-  template fixSpelling(n: PNode; ident: PIdent; op: untyped) =
+proc fixSpelling(c: PContext, n: PNode, ident: PIdent) =
+  ## when we cannot find the identifier, retry with a changed identifier
+  if isDefined(c, "nimFixSpelling") or defined(nimfix):
     let alt = ident.altSpelling
-    result = op(c, alt).skipAlias(n)
+    result = searchInScopes(c, alt).skipAlias(n)
     if result != nil:
       prettybase.replaceDeprecated(n.info, ident, alt)
       return result
-else:
-  template fixSpelling(n: PNode; ident: PIdent; op: untyped) = discard
 
 proc errorUseQualifier(c: PContext; info: TLineInfo; s: PSym; amb: var bool): PSym =
   var err = "ambiguous identifier: '" & s.name.s & "'"

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -14,8 +14,6 @@ import
   renderer, nimfix/prettybase, lineinfos, strutils,
   modulegraphs
 
-import std/wrapnils
-
 proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope)
 
 proc noidentError(conf: ConfigRef; n, origin: PNode) =

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -375,7 +375,7 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
   var list = initHeapQueue[E]()
   let name0 = ident.s.nimIdentNormalize
   var depth = 0
-  for scope in walkScopes(c.currentScope):
+  for scope in allScopes(c.currentScope):
     for h in 0..high(scope.symbols.data):
       if scope.symbols.data[h] != nil:
         let identi = scope.symbols.data[h]

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -410,8 +410,7 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
     elif count >= c.config.spellSuggestMax: break
     if count == 0:
       result.add "\ncandidate misspellings (edit distance, lexical scope distance): "
-    result.add "\n ($1, $2): '$3'" % [$e.dist, $e.depth, e.sym.name.s]
-    addDeclaredLoc(result, c.config, e.sym) # skipAlias not needed
+    result.add e.msg
     count.inc
 
 proc errorUseQualifier(c: PContext; info: TLineInfo; s: PSym; amb: var bool): PSym =

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -403,8 +403,11 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
   var count = 0
   while true:
     # pending https://github.com/timotheecour/Nim/issues/373 use more efficient `itemsSorted`.
-    if count >= c.config.spellSuggestMax or list.len == 0: break
+    if list.len == 0: break
     let e = list.pop()
+    if c.config.spellSuggestMax == spellSuggestSecretSauce:
+      if e.dist > e0.dist: break
+    elif count >= c.config.spellSuggestMax: break
     if count == 0:
       result.add "\ncandidate misspellings (edit distance, lexical scope distance): "
     result.add "\n ($1, $2): '$3'" % [$e.dist, $e.depth, e.sym.name.s]

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -392,7 +392,8 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
     if count == 0:
       result.add "\ncandidate misspellings (edit distance, lexical scope distance): "
     result.add "\n ($1, $2): '$3'" % [$dist, $depth, sym.name.s]
-    addDeclaredLocMaybe(result, c.config, sym) # skipAlias not needed
+    # addDeclaredLocMaybe(result, c.config, sym) # skipAlias not needed
+    addDeclaredLoc(result, c.config, sym) # skipAlias not needed
     count.inc
 
 proc errorUseQualifier(c: PContext; info: TLineInfo; s: PSym; amb: var bool): PSym =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -80,7 +80,6 @@ type                          # please make sure we have under 32 options
     optMixedMode              # true if some module triggered C++ codegen
     optListFullPaths          # use full paths in toMsgFilename
     optDeclaredLocs           # show declaration locations in messages
-    optSpellSuggest           # spelling suggestions for typos
     optNoNimblePath
     optHotCodeReloading
     optDynlibOverrideAll
@@ -269,6 +268,7 @@ type
     numberOfProcessors*: int   # number of processors
     lastCmdTime*: float        # when caas is enabled, we measure each command
     symbolFiles*: SymbolFilesOption
+    spellSuggestMax*: int # max number of spelling suggestions for typos
 
     cppDefines*: HashSet[string] # (*)
     headerFile*: string

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -80,6 +80,7 @@ type                          # please make sure we have under 32 options
     optMixedMode              # true if some module triggered C++ codegen
     optListFullPaths          # use full paths in toMsgFilename
     optDeclaredLocs           # show declaration locations in messages
+    optSpellSuggest           # spelling suggestions for typos
     optNoNimblePath
     optHotCodeReloading
     optDynlibOverrideAll

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -576,6 +576,7 @@ const
   htmldocsDir* = htmldocsDirname.RelativeDir
   docRootDefault* = "@default" # using `@` instead of `$` to avoid shell quoting complications
   oKeepVariableNames* = true
+  spellSuggestSecretSauce* = -1
 
 proc mainCommandArg*(conf: ConfigRef): string =
   ## This is intended for commands like check or parse

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -407,6 +407,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
 
     if overloadsState == csEmpty and result.state == csEmpty:
       if efNoUndeclared notin flags: # for tests/pragmas/tcustom_pragma.nim
+        # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
         localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
       return
     elif result.state != csMatch:

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,7 +35,7 @@ Advanced options:
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths:on|off    list full paths in messages
   --declaredLocs:on|off     show declaration locations in messages
-  --spellSuggest|:num       show at most `num >=0` spelling suggestions on typos.
+  --spellSuggest|:num       show at most `num >= 0` spelling suggestions on typos.
                             if `num` is not specified (or `auto`), return
                             an implementation defined set of suggestions.
   -w:on|off|list, --warnings:on|off|list

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,7 +35,7 @@ Advanced options:
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths:on|off    list full paths in messages
   --declaredLocs:on|off     show declaration locations in messages
-  --spellSuggest:on|off     show spelling suggestions on typos
+  --spellSuggest:num        show at most `num` spelling suggestions on typos
   -w:on|off|list, --warnings:on|off|list
                             turn all warnings on|off or list all available
   --warning[X]:on|off       turn specific warning X on|off

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,6 +35,7 @@ Advanced options:
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths:on|off    list full paths in messages
   --declaredLocs:on|off     show declaration locations in messages
+  --spellSuggest:on|off     show spelling suggestions on typos
   -w:on|off|list, --warnings:on|off|list
                             turn all warnings on|off or list all available
   --warning[X]:on|off       turn specific warning X on|off

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -35,7 +35,9 @@ Advanced options:
   --colors:on|off           turn compiler messages coloring on|off
   --listFullPaths:on|off    list full paths in messages
   --declaredLocs:on|off     show declaration locations in messages
-  --spellSuggest:num        show at most `num` spelling suggestions on typos
+  --spellSuggest|:num       show at most `num >=0` spelling suggestions on typos.
+                            if `num` is not specified (or `auto`), return
+                            an implementation defined set of suggestions.
   -w:on|off|list, --warnings:on|off|list
                             turn all warnings on|off or list all available
   --warning[X]:on|off       turn specific warning X on|off

--- a/tests/misc/mspellsuggest.nim
+++ b/tests/misc/mspellsuggest.nim
@@ -1,0 +1,7 @@
+proc fooBar4*(a: int) = discard
+var fooBar9* = 0
+
+var fooCar* = 0
+type FooBar* = int
+type FooCar* = int
+type GooBa* = int

--- a/tests/misc/tspellsuggest.nim
+++ b/tests/misc/tspellsuggest.nim
@@ -23,7 +23,7 @@ candidate misspellings (edit distance, lexical scope distance):
 '''
 """
 
-# tests `--spellsuggest`
+# tests `--spellsuggest:num`
 
 
 

--- a/tests/misc/tspellsuggest.nim
+++ b/tests/misc/tspellsuggest.nim
@@ -1,0 +1,45 @@
+discard """
+  # pending bug #16521 (bug 12) use `matrix`
+  cmd: "nim c --spellsuggest:15 --declaredlocs --hints:off $file"
+  action: "reject"
+  nimout: '''
+tspellsuggest.nim(45, 13) Error: undeclared identifier: 'fooBar'
+candidate misspellings (edit distance, lexical scope distance):
+ (1, 0): 'fooBar8' [var declared in tspellsuggest.nim(43, 9)]
+ (1, 1): 'fooBar7' [var declared in tspellsuggest.nim(41, 7)]
+ (1, 3): 'fooBar2' [let declared in tspellsuggest.nim(34, 5)]
+ (1, 3): 'fooBar3' [const declared in tspellsuggest.nim(35, 7)]
+ (1, 3): 'fooBar4' [proc declared in tspellsuggest.nim(36, 6)]
+ (1, 3): 'fooBar5' [template declared in tspellsuggest.nim(37, 10)]
+ (1, 3): 'fooBar6' [macro declared in tspellsuggest.nim(38, 7)]
+ (1, 3): 'fooBar1' [var declared in tspellsuggest.nim(33, 5)]
+ (1, 5): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
+ (1, 5): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
+ (1, 5): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
+ (1, 5): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
+ (2, 5): 'GooBa' [type declared in mspellsuggest.nim(7, 6)]
+ (2, 5): 'FooCar' [type declared in mspellsuggest.nim(6, 6)]
+ (3, 0): 'fooBarBaz' [const declared in tspellsuggest.nim(44, 11)]
+'''
+"""
+
+
+
+
+
+# line 30
+import ./mspellsuggest
+
+var fooBar1 = 0
+let fooBar2 = 0
+const fooBar3 = 0
+proc fooBar4() = discard
+template fooBar5() = discard
+macro fooBar6() = discard
+
+proc main =
+  var fooBar7 = 0
+  block:
+    var fooBar8 = 0
+    const fooBarBaz = 0
+    let x = fooBar

--- a/tests/misc/tspellsuggest.nim
+++ b/tests/misc/tspellsuggest.nim
@@ -1,6 +1,6 @@
 discard """
   # pending bug #16521 (bug 12) use `matrix`
-  cmd: "nim c --spellsuggest:15 --declaredlocs --hints:off $file"
+  cmd: "nim c --spellsuggest:15 --hints:off $file"
   action: "reject"
   nimout: '''
 tspellsuggest.nim(45, 13) Error: undeclared identifier: 'fooBar'
@@ -23,7 +23,7 @@ candidate misspellings (edit distance, lexical scope distance):
 '''
 """
 
-
+# tests `--spellsuggest`
 
 
 

--- a/tests/misc/tspellsuggest.nim
+++ b/tests/misc/tspellsuggest.nim
@@ -7,18 +7,18 @@ tspellsuggest.nim(45, 13) Error: undeclared identifier: 'fooBar'
 candidate misspellings (edit distance, lexical scope distance):
  (1, 0): 'fooBar8' [var declared in tspellsuggest.nim(43, 9)]
  (1, 1): 'fooBar7' [var declared in tspellsuggest.nim(41, 7)]
+ (1, 3): 'fooBar1' [var declared in tspellsuggest.nim(33, 5)]
  (1, 3): 'fooBar2' [let declared in tspellsuggest.nim(34, 5)]
  (1, 3): 'fooBar3' [const declared in tspellsuggest.nim(35, 7)]
  (1, 3): 'fooBar4' [proc declared in tspellsuggest.nim(36, 6)]
  (1, 3): 'fooBar5' [template declared in tspellsuggest.nim(37, 10)]
  (1, 3): 'fooBar6' [macro declared in tspellsuggest.nim(38, 7)]
- (1, 3): 'fooBar1' [var declared in tspellsuggest.nim(33, 5)]
  (1, 5): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
+ (1, 5): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
  (1, 5): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
  (1, 5): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
- (1, 5): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
- (2, 5): 'GooBa' [type declared in mspellsuggest.nim(7, 6)]
  (2, 5): 'FooCar' [type declared in mspellsuggest.nim(6, 6)]
+ (2, 5): 'GooBa' [type declared in mspellsuggest.nim(7, 6)]
  (3, 0): 'fooBarBaz' [const declared in tspellsuggest.nim(44, 11)]
 '''
 """

--- a/tests/misc/tspellsuggest2.nim
+++ b/tests/misc/tspellsuggest2.nim
@@ -1,0 +1,45 @@
+discard """
+  # pending bug #16521 (bug 12) use `matrix`
+  cmd: "nim c --spellsuggest --hints:off $file"
+  action: "reject"
+  nimout: '''
+tspellsuggest2.nim(45, 13) Error: undeclared identifier: 'fooBar'
+candidate misspellings (edit distance, lexical scope distance):
+ (1, 0): 'fooBar8' [var declared in tspellsuggest2.nim(43, 9)]
+ (1, 1): 'fooBar7' [var declared in tspellsuggest2.nim(41, 7)]
+ (1, 3): 'fooBar1' [var declared in tspellsuggest2.nim(33, 5)]
+ (1, 3): 'fooBar2' [let declared in tspellsuggest2.nim(34, 5)]
+ (1, 3): 'fooBar3' [const declared in tspellsuggest2.nim(35, 7)]
+ (1, 3): 'fooBar4' [proc declared in tspellsuggest2.nim(36, 6)]
+ (1, 3): 'fooBar5' [template declared in tspellsuggest2.nim(37, 10)]
+ (1, 3): 'fooBar6' [macro declared in tspellsuggest2.nim(38, 7)]
+ (1, 5): 'FooBar' [type declared in mspellsuggest.nim(5, 6)]
+ (1, 5): 'fooBar4' [proc declared in mspellsuggest.nim(1, 6)]
+ (1, 5): 'fooBar9' [var declared in mspellsuggest.nim(2, 5)]
+ (1, 5): 'fooCar' [var declared in mspellsuggest.nim(4, 5)]
+'''
+"""
+
+# tests `--spellsuggest`
+
+
+
+
+
+
+# line 30
+import ./mspellsuggest
+
+var fooBar1 = 0
+let fooBar2 = 0
+const fooBar3 = 0
+proc fooBar4() = discard
+template fooBar5() = discard
+macro fooBar6() = discard
+
+proc main =
+  var fooBar7 = 0
+  block:
+    var fooBar8 = 0
+    const fooBarBaz = 0
+    let x = fooBar


### PR DESCRIPTION
fix #2844
fix #3911
fix #9197

saves time when perplexed about a symbol that you think should exist but was misspelt.

Some other languages have a similar feature too, and it helps.

## note
* only suggests the symbols with smallest edit distance wrt typo
* among those, only suggests the symbols in the nearest scope

## example 1
```nim
when true:
  let foobar0 = 1
  proc main()=
    type foobar1 = int
    var foobar2 = 1
    echo foobar
  main()
```
```
nim r --spellsuggest --listfullpaths:off t11334.nim
t11334.nim(26, 10) Error: undeclared identifier: 'foobar'
  candidate misspelling: 'foobar1' [type declared in t11334.nim(24, 10)]
  candidate misspelling: 'foobar2' [var declared in t11334.nim(25, 9)]
```

## example 2
```nim
when true:
  import strutils
  proc main()=
    strutils2.normalizeStr 1 #  candidate misspelling: 'strutils' [module declared in strutils.nim(1, 2)]
    # strutils.normalizeStr 1 # candidate misspelling: 'normalize' [proc declared in strutils.nim(304, 6)]
    # echo2 1 # candidate misspelling: 'echo' [proc declared in system.nim(1985, 8)]
  main()
```

## future work
- [ ] make this flag also suggest when a module import is misspellt, including things like `import exitprocs` instead of `import std/exitprocs`
- [ ] also use spellsuggestions in more contexts, eg unrecognized pragmas, compiler flags/commands etc

- [ ] add Damerau–Levenshtein distance algorithm to std/editdistance, which allows adjacent transpositions with cost 1 instead of cost 2, and use that instead (see https://github.com/timotheecour/Nim/issues/397)

- [ ] assign low cost (or cost 1) to moves: abcDef => defAbc; eg for pathJoin vs joinPath

- [x] I've left open for future work the currently un-allowed `--spellsuggest` (without argument), which will use some secret sauce based on length of query + max edit distance, but even with that secret sauce, `--spellsuggest:N` will still be useful (EDIT: now implemented)

- [x] I don't believe this adds any meaningful overhead so `--spellsuggest` can become a default once the 0 arg version is implemented
  => https://github.com/nim-lang/Nim/pull/17401

- [ ] make this work with dotExpr:
```nim
import strutils
echo "FOO".toLowerAscii2 # currently doesn't honor --spellsuggest
```

## links
* #3911
* #2844
* maybe same/similar algorithm could be used for doc search (see dochacks, fuzzysearch) which is still buggy, see https://github.com/nim-lang/Nim/issues/9198 and https://github.com/nim-lang/Nim/issues/9406 and https://github.com/nim-lang/Nim/issues/13955
