### PR TITLE
collectIt: better collect; also closes #16078, #16098 #16372

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -273,8 +273,6 @@ since (1, 1):
     underscoredCalls(result, calls, tmp)
     result.add tmp
 
-import timn/dbgs
-
 proc transLastStmt(n, res, bracketExpr: NimNode): (NimNode, NimNode, NimNode) {.since: (1, 1).} =
   # Looks for the last statement of the last statement, etc...
   case n.kind

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -95,4 +95,4 @@ block: # collect
 
 block: # collectTo
   # bug: this doesn't work inside a `runnableExamples`, see bug #13491
-  doAssert (collectTo(newStringOfCap(10)) do: (for c in 'a'..'c': yield c)) == "abc"
+  doAssert ("".collectIt do: (for c in "abc": yield c)) == "abc"

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -1,0 +1,98 @@
+import std/sugar
+
+block dup_with_field:
+  type
+    Foo = object
+      col, pos: int
+      name: string
+
+  proc inc_col(foo: var Foo) = inc(foo.col)
+  proc inc_pos(foo: var Foo) = inc(foo.pos)
+  proc name_append(foo: var Foo, s: string) = foo.name &= s
+
+  let a = Foo(col: 1, pos: 2, name: "foo")
+  block:
+    let b = a.dup(inc_col, inc_pos):
+      _.pos = 3
+      name_append("bar")
+      inc_pos
+
+    doAssert(b == Foo(col: 2, pos: 4, name: "foobar"))
+
+  block:
+    let b = a.dup(inc_col, pos = 3, name = "bar"):
+      name_append("bar")
+      inc_pos
+
+    doAssert(b == Foo(col: 2, pos: 4, name: "barbar"))
+
+import algorithm
+
+var a = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
+doAssert dup(a, sort(_)) == sorted(a)
+doAssert a.dup(sort) == sorted(a)
+#Chaining:
+var aCopy = a
+aCopy.insert(10)
+doAssert a.dup(insert(10)).dup(sort()) == sorted(aCopy)
+
+import random
+
+const b = @[0, 1, 2]
+let c = b.dup shuffle()
+doAssert c[0] == 1
+doAssert c[1] == 0
+
+import sets, tables, strutils
+
+block: # collect
+  let data = @["bird", "word"] # if this gets stuck in your head, its not my fault
+  assert collect(newSeq, for (i, d) in data.pairs: (if i mod 2 == 0: d)) == @["bird"]
+  assert collect(initTable(2), for (i, d) in data.pairs: {i: d}) == {0: "bird",
+        1: "word"}.toTable
+  assert initHashSet.collect(for d in data.items: {d}) == data.toHashSet
+
+  let x = collect(newSeqOfCap(4)):
+      for (i, d) in data.pairs:
+        if i mod 2 == 0: d
+  assert x == @["bird"]
+
+  # bug #12874
+
+  let bug1 = collect(
+      newSeq,
+      for (i, d) in data.pairs:(
+        block:
+          if i mod 2 == 0:
+            d
+          else:
+            d & d
+        )
+  )
+  assert bug1 == @["bird", "wordword"]
+
+  let y = collect(newSeq):
+    for (i, d) in data.pairs:
+      try: parseInt(d) except: 0
+  assert y == @[0, 0]
+
+  let z = collect(newSeq):
+    for (i, d) in data.pairs:
+      case d
+      of "bird": "word"
+      else: d
+  assert z == @["word", "word"]
+
+
+  proc tforum =
+    let ans = collect(newSeq):
+      for y in 0..10:
+        if y mod 5 == 2:
+          for x in 0..y:
+            x
+
+  tforum()
+
+block: # collectTo
+  # bug: this doesn't work inside a `runnableExamples`, see bug #13491
+  doAssert (collectTo(newStringOfCap(10)) do: (for c in 'a'..'c': yield c)) == "abc"

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -40,8 +40,9 @@ import random
 
 const b = @[0, 1, 2]
 let c = b.dup shuffle()
-doAssert c[0] == 1
-doAssert c[1] == 0
+doAssert c[0] in [0,1,2]
+doAssert c[1] in [0,1,2]
+doAssert c[1] != c[0]
 
 import sets, tables, strutils
 

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -97,3 +97,9 @@ block: # collect
 block: # collectTo
   # bug: this doesn't work inside a `runnableExamples`, see bug #13491
   doAssert ("".collectIt do: (for c in "abc": yield c)) == "abc"
+
+  block: # bug #16098
+    let a =  set[int8].default.collectIt:
+      for i in 0 .. 8:
+        if i mod 2 == 0 : yield {i.int8}
+    doAssert a == {0'i8, 2, 4, 6, 8}


### PR DESCRIPTION
TLDR: explicit `yield e` instead of implicit `e` offers more flexibility, without causing ambiguities

## `collect` vs `collectIt`:
* collectIt is more flexible, eg works with `string`
```nim
# generate a random string starting with "pre"
echo "pre".collectIt(for i in 1..4: yield sample({'a'..'z'})) # prexghh
```

* allows multiple "yield", unlike collect, eg for zipping
```nim
    let x1 = "".collectIt:
      yield '{'
      for c in "foo": yield c
      for c in 'a'..'c': yield c
      yield '}'
    doAssert x1 == "{fooabc}"
```

* doesn't have the bugs of collect mentioned in https://github.com/nim-lang/Nim/issues/16078 (eg top-level `when` breaks collect)

* allows accessing the container when needed:
```nim
   import std/sets
    let y = initHashSet[int]().collectIt:
      for a in 0..3:
        debugEcho it # this wouldn't be possible with collect, you'd have to transform to explicit block
        yield {a*2} # syntax for set
      it.excl 0 # possible too
      it.incl it.len*10 # possible too
    doAssert y == [4, 2, 6, 30].toHashSet
```

* thanks to that, it also works with array, and allows inserting out of order or other custom logic

* closes #16078 by providing a suitable alternative
* closes #16098 ditto
* closes #16372 ditto

* etc, see tests

## note
the only advantage of collect currently is type inference, in the case where it's needed. However, again in this case, explicit (via placeholders) is better than implicit and future versions will allow type inference as follows:
```nim
# newSeq[_] or newSeq[auto], not sure yet
let s2 = collectIt(newSeq[_]): for i in 0..2: yield i.float # will infer seq[float]
let s3 = collectIt(initTable[_, _]): for i in 0..2: yield {i: $i} # will infer initTable[int, string]
```
it's better because it's more flexible.

## note2:
omitting `init` will in future also be possible, infering seq[T]:
```nim
let s1 = collectIt: for i in 0..2: yield i.float # will infer seq[float] here
```
