### PR TITLE
fix #9695 asyncmacro: tfuturevar fails when activated [backport: 1.0]

### DIFF
--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -118,7 +118,8 @@ proc getFutureVarIdents(params: NimNode): seq[NimNode] {.compileTime.} =
   for i in 1 ..< len(params):
     expectKind(params[i], nnkIdentDefs)
     if params[i][1].kind == nnkBracketExpr and
-       params[i][1][0].eqIdent("futurevar"):
+       params[i][1][0].eqIdent("FutureVar"):
+      ## eqIdent: first char is case sensitive!!!
       result.add(params[i][0])
 
 proc isInvalidReturnType(typeName: string): bool =

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -118,7 +118,7 @@ proc getFutureVarIdents(params: NimNode): seq[NimNode] {.compileTime.} =
   for i in 1 ..< len(params):
     expectKind(params[i], nnkIdentDefs)
     if params[i][1].kind == nnkBracketExpr and
-       params[i][1][0].eqIdent("FutureVar"):
+       params[i][1][0].eqIdent(FutureVar.astToStr):
       ## eqIdent: first char is case sensitive!!!
       result.add(params[i][0])
 

--- a/tests/async/tfuturevar.nim
+++ b/tests/async/tfuturevar.nim
@@ -1,7 +1,3 @@
-discard """
-action: run
-"""
-
 import asyncdispatch
 
 proc completeOnReturn(fut: FutureVar[string], x: bool) {.async.} =

--- a/tests/async/tfuturevar.nim
+++ b/tests/async/tfuturevar.nim
@@ -1,7 +1,6 @@
 discard """
-action: compile
+action: run
 """
-# XXX: action should be run!
 
 import asyncdispatch
 


### PR DESCRIPTION
fix #9695
This bug is introduced in https://github.com/nim-lang/Nim/pull/7573