### PR TITLE
fix #16052 - repr for seq in repr_v2 (add pointer)

### DIFF
--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -158,7 +158,7 @@ proc repr*[T](x: seq[T]): string =
   ##
   ## .. code-block:: Nim
   ##   $(@[23, 45]) == "@[23, 45]"
-  collectionToRepr(x, "@[", ", ", "]")
+  repr(pointer(unsafeAddr(s[0]))) & collectionToRepr(x, "@[", ", ", "]")
 
 proc repr*[T, U](x: HSlice[T, U]): string =
   ## Generic `repr` operator for slices that is lifted from the components

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -158,7 +158,8 @@ proc repr*[T](x: seq[T]): string =
   ##
   ## .. code-block:: Nim
   ##   $(@[23, 45]) == "@[23, 45]"
-  repr(pointer(unsafeAddr(s[0]))) & collectionToRepr(x, "@[", ", ", "]")
+  result = repr(pointer(unsafeAddr(x)))
+  result.add collectionToRepr(x, "@[", ", ", "]")
 
 proc repr*[T, U](x: HSlice[T, U]): string =
   ## Generic `repr` operator for slices that is lifted from the components


### PR DESCRIPTION
fix #16052. see also previous discussion there (cc @timotheecour).

### status (edited)

- [ ] working fix for main issue
- [ ] fix also repr for ptr as mentioned by @Clyybber in the [issue](https://github.com/nim-lang/Nim/issues/16052#issuecomment-731138599). **is it ok to do it here?**
- [ ] add 0x as prefix for pointers
- [ ] add tests
- [ ] update documentation

### example

recall the issue with a new example `issue.nim`:

```nim
let s = @[0]
echo s.repr
echo s.unsafeAddr.pointer.repr
echo s[0].unsafeAddr.pointer.repr
```

(on windows)

`nim r issue`:
```
000000000018F050@[0]
000000000042FFC8
000000000018F060
```

`nim --gc:arc issue`:

before the fix:

```
@[0]
0000000000418A90
0000000000900048
```

after the fix:

```
0000000000900048@[0]
0000000000418A90
0000000000900048
```

 ### discussion

note that the current fix does not exactly replicate the behaviour of standard gc. in fact in standard gc the pointer value is different from the pointer value of first element of sequence (by 4 bits, which I find a bit odd). I am not sure why this happens, I was not able to follow up how the pointer is created with standard gc (it happens with magic). for gc:arc I am using the pointer of the first value. **let me know if it is ok like that**.

### remarks

regarding documentation as far as I understand the documentation will not be actually the one that user sees, since I guess it is compiled with standard gc. It will be the one that is seen by users when gc:orc will be default. anyway it is good to have it consistent now. with that in mind the current example (`$(@[23, 45]) == "@[23, 45]"`) refers to `$` instead of `repr` and this is the same for all repr. I think it should be updated to `repr(@[23, 45]) == "0000000000900048@[23, 45]"` and I would consistently update the documentation for all repr procs.

*remark 1*: I guess that most of the proc repr could be changed to func, **do we want to do it? I could do it here**. Incidentally, if I try with repr for seq it says it has side effects and I am not sure why (unsafeAddr is marked noSideEffects).

*remark 2*: I think it could be useful for new users to add two lines of comments (not doc comments, standard comments) at top of repr_v2, I was thinking of the following two lines but **I am not sure if they are factually correct (or whether it is worth to add such comments)**:

```nim
# repr_v2 is a new version of repr that does not use PNimType (which was possibly hurting performance)
# it is repr that system uses when nimV2 is defined (in particular it is used for gc:arc/orc)
```

*remark 3*: another thing I notice is that with respect to v1.4, in devel version the pointer in standard gc is formatted in a different way (no 0x and keeping all 0). I have no idea why this is happening with default gc (reprPointer in repr.nim seems unchanged to me), but I could easily add a 0x prefix, I think it would be more correct (I would still keep the 0s since they make evident the size of pointer, I guess there will be less of them on 32 bit system). **should I add a 0x prefix?**