### PR TITLE
deprecate io.getFileSize, fix os.getFileSize

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -745,8 +745,10 @@ proc getFilePos*(f: File): int64 {.benign.} =
   result = c_ftell(f)
   if result < 0: raiseEIO("cannot retrieve file position")
 
-proc getFileSize*(f: File): int64 {.tags: [ReadIOEffect], benign.} =
+proc getFileSize*(f: File): int64 {.tags: [ReadIOEffect], benign, deprecated: "use `os.getFileSize`".} =
   ## retrieves the file size (in bytes) of `f`.
+  ## Caution: this uses `c_fseek(f, 0, SEEK_END)`, which is undefined behavior
+  ## on some systems, and can overflow for large files on others.
   let oldPos = getFilePos(f)
   discard c_fseek(f, 0, 2) # seek the end of the file
   result = getFilePos(f)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -26,6 +26,7 @@ Raises
 # test os path creation, iteration, and deletion
 
 import os, strutils, pathnorm
+from stdtest/specialpaths import buildDir
 
 block fileOperations:
   let files = @["these.txt", "are.x", "testing.r", "files.q"]
@@ -502,6 +503,16 @@ block: # normalizePathEnd
     doAssert r"D:\".normalizePathEnd == r"D:"
     doAssert r"E:/".normalizePathEnd(trailingSep = true) == r"E:\"
     doAssert "/".normalizePathEnd == r"\"
+
+block: # getFileSize
+  var s = "abc\0def\0"
+  let file = buildDir / "D20201121T182307"
+  writeFile(file, s)
+  defer: removeFile(file)
+  let f = open(file)
+  defer: close(f)
+  doAssert f.getFileSize == s.len
+  doAssert file.getFileSize == s.len
 
 block: # isValidFilename
   # Negative Tests.


### PR DESCRIPTION
this is discussed here:
* https://stackoverflow.com/questions/8236/how-do-you-determine-the-size-of-a-file-in-c
* https://stackoverflow.com/questions/21050603/understanding-undefined-behavior-for-a-binary-stream-using-fseekfile-0-seek-e
* https://stackoverflow.com/questions/5957845/using-fseek-and-ftell-to-determine-the-size-of-a-file-has-a-vulnerability

my understanding:
* on non posix systems, SEEK_END could UB according to C standard, but then stat is also not available there
* SEEK_END should work on posix systems
* on windows, from my limited windows understanding, since binary vs text makes a difference there, the above mentioned UB seems plausible
* on windows an API call is available anyways: `GetFileSizeEx` (or `FindFirstFileA`)

## size overflow: ftell vs ftello
this is likely wrong for large files, even on posix, depending no which C standard is used

https://stackoverflow.com/questions/8236/how-do-you-determine-the-size-of-a-file-in-c#comment31706557_8247, regarding range of ftell, used by getFileSize, used by `getFileSize`:

> Both C99 and C11 return long int from ftell(). (unsigned long) casting does not improve the range as already limited by the function. ftell() return -1 on error and that get obfuscated with the cast. Suggest fsize() return the same type as ftell(). – chux - Reinstate Monica Jan 12 '14 at 22:03


https://man7.org/linux/man-pages/man3/ftello.3.html

## fseek error is silently ignored
`discard c_fseek(f, 0, 2)`