### PR TITLE
add sugar.exported for exporting macro outputs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,9 @@
 - `repr` now doesn't insert trailing newline; previous behavior was very inconsistent,
   see #16034. Use `-d:nimLegacyReprWithNewline` for previous behavior.
 
+- Added `sugar.exported` for converting unexported statements to exported ones.
+  Can be used for macro outputs.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`

--- a/tests/stdlib/msugarexported.nim
+++ b/tests/stdlib/msugarexported.nim
@@ -1,0 +1,22 @@
+import sugar
+
+template defineX(y) =
+  let x {.inject.} = y
+
+exported defineX(3)
+
+template bar(T, body) {.dirty.} =
+  proc foo(x: T): T =
+    body
+
+exported:
+  bar int:
+    x + 1
+  bar string:
+    x & '.'
+
+exported:
+  type Foo = object
+    field: int
+
+proc macroPragmaProc(): bool {.exported.} = true

--- a/tests/stdlib/tsugarexported.nim
+++ b/tests/stdlib/tsugarexported.nim
@@ -1,0 +1,10 @@
+import ./msugarexported
+
+doAssert x == 3
+doAssert foo(1) == 2
+doAssert foo("Hello") == "Hello."
+
+var obj: Foo
+doAssert not compiles(obj.field)
+
+doAssert macroPragmaProc()


### PR DESCRIPTION
Limitations:

* While it's probably possible, I don't think it would be wise to indiscriminately export all object fields. This is meant to be a unified way of exporting, but you should be able to choose which fields you export.
* Type and variable macro pragmas cannot be used as `typed` arguments. For typedefs I tried doing `typed{~nkTypeDef}` and overloading for `untyped{nkTypeDef}`, and it still chose the typed overload. I also could not get it to work for variable macro pragmas, but even if I did the signature for the overload would make it hard to distinguish as being specifically for variable macro pragmas. (also you can't know if it's let or var)
* This still outputs `x is declared but not used` because the `typed` argument has to be checked. I don't know how to work around this.

The utopic best case scenario would be modifying the `export` statement syntax and behavior to make it possible to do something like:

```nim
export proc foo(x: int) = echo x
```

which you could then use macro calls on instead of `proc foo = ...`. Many people have complained about postfix `*` and nothing's changed yet so I'm sure there's a reason this wouldn't be optimal.

A question you might have is, why can't we just do `export foo` afterward? You can do this for types and variables but not for routines because it would export every single overload of the symbol that you are exporting.