### PR TITLE
[FEATURE] `items` for `iterator(): T`

### DIFF
--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -3,6 +3,16 @@ when defined(nimHasLentIterators) and not defined(nimWorkaround14447):
 else:
   template lent2(T): untyped = T
 
+iterator items*[T](it: iterator(): T): T =
+  ## Iterates over each result of `it` iterator
+  while true:
+    let next = it()
+    if it.finished:
+      break
+    else:
+      yield next
+
+
 iterator items*[T: not char](a: openArray[T]): lent2 T {.inline.} =
   ## Iterates over each item of `a`.
   var i = 0

--- a/tests/iter/titer14.nim
+++ b/tests/iter/titer14.nim
@@ -5,3 +5,26 @@ proc f() =
 
   iterator b(): int =
     for x in a(): yield x
+
+proc g(): iterator(): char =
+  return iterator(): char =
+    for i in "123123":
+      yield i
+
+var buf: string
+for ch in g():
+  buf &= ch
+
+assert buf == "123123"
+
+iterator h(): iterator(): char =
+  for i in "hello":
+    yield iterator(): char =
+      yield i
+
+var buf2: string
+for it in h():
+  for ch in it:
+    buf2 &= ch
+
+assert buf2 == "hello"


### PR DESCRIPTION
Add `items` overload for closure iterators - it is really counter-intuitive there is no default way to iterate over closure *iterator* values. E.g. code 

```nim
var it: iterator(): int

for val in it:
  discard
```

Fails with type mismatch error - `Error: type mismatch: got <iterator (): int{.closure.}> but expected one of: ... `
