### PR TITLE
fix rope index

### DIFF
--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -204,8 +204,8 @@ proc `[]`*(r: Rope, i: int): char {.rtl, extern: "nroCharAt".} =
       if x.left.length > j:
         x = x.left
       else:
+        dec(j, x.left.len)
         x = x.right
-        dec(j, x.len)
 
 iterator leaves*(r: Rope): string =
   ## iterates over any leaf string in the rope `r`.

--- a/lib/pure/ropes.nim
+++ b/lib/pure/ropes.nim
@@ -204,7 +204,7 @@ proc `[]`*(r: Rope, i: int): char {.rtl, extern: "nroCharAt".} =
       if x.left.length > j:
         x = x.left
       else:
-        dec(j, x.left.len)
+        dec(j, x.left.length)
         x = x.right
 
 iterator leaves*(r: Rope): string =

--- a/tests/stdlib/tropes.nim
+++ b/tests/stdlib/tropes.nim
@@ -1,0 +1,66 @@
+import ropes
+
+
+block:
+  let r: Rope = nil
+  doAssert r[0] == '\0'
+
+block:
+  var
+    r1 = rope("Hello")
+    r2 = rope("Nim-Lang")
+
+  let r = r1 & r2
+  let s = $r
+  for i in 0 ..< r.len:
+    doAssert r[i] == s[i]
+
+  doAssert r[66] == '\0'
+
+block:
+  let r = rope("Hello, Nim-Lang")
+
+  let s = $r
+  for i in 0 ..< r.len:
+    doAssert r[i] == s[i]
+
+  doAssert r[66] == '\0'
+
+block:
+  var r: Rope
+  r.add rope("Nim ")
+  r.add rope("is ")
+  r.add rope("a ")
+  r.add rope("great ")
+  r.add rope("language")
+
+  let s = $r
+  for i in 0 ..< r.len:
+    doAssert r[i] == s[i]
+
+  doAssert r[66] == '\0'
+
+block:
+  var r: Rope
+  r.add rope("My Conquest")
+  r.add rope(" is ")
+  r.add rope("the Sea of Stars")
+
+  let s = $r
+  for i in 0 ..< r.len:
+    doAssert r[i] == s[i]
+
+  doAssert r[66] == '\0'
+
+block:
+  var r: Rope
+  r.add rope("My Conquest")
+  r.add rope(" is ")
+  r.add rope("the Sea of Stars")
+
+  var i: int
+  for item in r:
+    doAssert r[i] == item
+    inc i
+
+  doAssert r[66] == '\0'


### PR DESCRIPTION
This doesn't work since Nim v 0.13.0
```nim
import ropes


block:
  var
    r1 = rope("Hello")
    r2 = rope("Nim-Lang")

  let r = r1 & r2
  let s = $r
  for i in 0 ..< r.len:
    doAssert r[i] == s[i]

block:
  let r = rope("Hello, Nim-Lang")

  let s = $r
  for i in 0 ..< r.len:
    doAssert r[i] == s[i]
```