### PR TITLE
ansi_c: support rawWrite(cstderr|cstdout, s) in js, nodejs, vm

### DIFF
--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -13,6 +13,7 @@ template setX(k, field) {.dirty.} =
   a.slots[a.ra].ensureKind(k)
   a.slots[a.ra].field = v
 
+template setResult*[T: void](a: VmArgs, b: T) = discard
 proc setResult*(a: VmArgs; v: BiggestInt) = setX(rkInt, intVal)
 proc setResult*(a: VmArgs; v: BiggestFloat) = setX(rkFloat, floatVal)
 proc setResult*(a: VmArgs; v: bool) =

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -20,6 +20,7 @@ from times import cpuTime
 
 from hashes import hash
 from osproc import nil
+from system/ansi_c import cstderr, rawWrite
 
 import vmconv
 
@@ -198,6 +199,12 @@ proc registerAdditionalOps*(c: PCtx) =
     else:
       systemop gorgeEx
   macrosop getProjectPath
+
+  registerCallback c, "stdlib.rawWrite", proc (a: VmArgs) {.nimcall.} =
+    # let file = a[0]
+    let file = cstderr
+    let s = a.getString(1)
+    setResult(a, rawWrite(file, s))
 
   registerCallback c, "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -105,10 +105,13 @@ proc rawWriteStackTrace(): string =
   else:
     result = "No stack traceback available\n"
 
+from system/ansi_c import cstderr, rawWrite
+  # ansi_c already imported via system > ansi_c
+
 proc writeStackTrace() =
   var trace = rawWriteStackTrace()
   trace.setLen(trace.len - 1)
-  echo trace
+  rawWrite(cstderr, trace)
 
 proc getStackTrace*(): string = rawWriteStackTrace()
 proc getStackTrace*(e: ref Exception): string = e.trace

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -110,7 +110,6 @@ from system/ansi_c import cstderr, rawWrite
 
 proc writeStackTrace() =
   var trace = rawWriteStackTrace()
-  trace.setLen(trace.len - 1)
   rawWrite(cstderr, trace)
 
 proc getStackTrace*(): string = rawWriteStackTrace()

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -110,6 +110,9 @@ from system/ansi_c import cstderr, rawWrite
 
 proc writeStackTrace() =
   var trace = rawWriteStackTrace()
+  when not defined(nodejs):
+    # maybe we need `rawWriteln`, instead of special case here
+    trace.setLen(trace.len - 1)
   rawWrite(cstderr, trace)
 
 proc getStackTrace*(): string = rawWriteStackTrace()

--- a/tests/stdlib/tansi_c.nim
+++ b/tests/stdlib/tansi_c.nim
@@ -1,0 +1,12 @@
+discard """
+  targets: "c js"
+"""
+
+import system/ansi_c
+
+proc main =
+  rawWrite(cstdout, "ok1")
+  rawWrite(cstderr, "ok2")
+
+static: main()
+main()

--- a/tests/stdlib/tansi_c.nim
+++ b/tests/stdlib/tansi_c.nim
@@ -2,11 +2,14 @@ discard """
   targets: "c js"
 """
 
+# pending bug #7999, test stderr, stdout separately
 import system/ansi_c
 
 proc main =
   rawWrite(cstdout, "ok1")
   rawWrite(cstderr, "ok2")
+  rawWrite(cstdout, "ok3\n")
+  rawWrite(cstderr, "ok4\n")
 
 static: main()
 main()


### PR DESCRIPTION
followup on https://github.com/nim-lang/Nim/pull/16016.

with this PR:
* `rawWrite(cstderr|cstdout, s)` now works in js, nodejs, vm (and vm+js, vm+nodejs)
this is useful in itself (in particular writing without newline for vm, unlike echo, or writing to stderr in vm/nodejs/js), and also avoids having to special case a lot of existing code using `rawWrite` for those backends.

* writeStackTrace writes to stderr for js,nodejs, consistently with docs for writeStackTrace and with c backend
* `--panics:on` now works better with `js/nodejs` (previously, would give `stderr` not defined)

## example
```nim
proc fn() =
  writeStackTrace()
fn()

from system/ansi_c import rawWrite, cstderr, cstdout
rawWrite(cstderr, "ok1")
rawWrite(cstderr, "ok2\n")
rawWrite(cstdout, "ok3")
rawWrite(cstdout, "ok4\n")

doAssertRaises(AssertionDefect):
  doAssert false, "foo"
```

nim r --panics main:
```
Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(7) t11366
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(6) fn
ok1ok2
ok3ok4
Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(15) t11366
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(30) failedAssertImpl
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(23) raiseAssert
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(45) sysFatal
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(33) sysFatal
Error: unhandled exception: /Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(15, 43) `false` foo [AssertionDefect]
```

nim r -b:js --panics -d:nodejs main
almost same:
```
Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(7) at module t11366
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(6) at t11366.fn
ok1ok2
ok3ok4
Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(15) at module t11366
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(30) at assertions.failedAssertImpl
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(23) at assertions.raiseAssert
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(45) at sysFatal.sysFatal
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(33) at sysFatal.sysFatal
```

nim r -b:js --panics main

in this case it now correctly shows the AssertionDefect error + msg, but later fails for a different reason, because exit isn't defined; this can be fixed and is the same issue as https://github.com/nim-lang/Nim/issues/16074
Another caveat is rawWrite behaves more like some hypothetical `rawWriteln`

```
Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(7) at module t11366
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(6) at t11366.fn

ok1
ok2

ok3
ok4

Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(15) at module t11366
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(30) at assertions.failedAssertImpl
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(23) at assertions.raiseAssert
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(45) at sysFatal.sysFatal
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(33) at sysFatal.sysFatal

Error: unhandled exception: /Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(15, 43) `false` foo [AssertionDefect]

Traceback (most recent call last)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11366.nim(109) at module t11366
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(23) at assertions.raiseAssert
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(45) at sysFatal.sysFatal
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(33) at sysFatal.sysFatal

Error: unhandled exception: expected raising 'AssertionDefect', instead raised foreign exception by:
doAssert false, "foo" [AssertionDefect]

/Users/timothee/git_clone/nim/timn/build/nimcache/t11366.js:506
    exit(1);
    ^

ReferenceError: exit is not defined
    at sysFatal_218103880 (/Users/timothee/git_clone/nim/timn/build/nimcache/t11366.js:506:5)
```

