### PR TITLE
Update documentation.

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -16,7 +16,7 @@
 ## Note: Nim does not currently include the ``libmysql.dll`` (Windows)
 ## dynamically linked dependency for the proper operation of MySql wrapper.
 ## You may also find that users that do not have a mysql shell installation
-## will require the ``libssl-1_1-X64.dll`` (Windows) and ``libcrypto-1_1-X64.dll``
+## will require the ``libssl`` (Windows) and ``libcrypto`` DLL's
 ## dependencies to be included.
 ## Tools which explore dependency requirements can be helpful in resolving
 ## issues.

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -13,6 +13,14 @@
 ## See also: `db_odbc <db_odbc.html>`_, `db_sqlite <db_sqlite.html>`_,
 ## `db_postgres <db_postgres.html>`_.
 ##
+## Note: Nim does not currently include the ``libmysql.dll`` (Windows)
+## dynamically linked dependency for the proper operation of MySql wrapper.
+## You may also find that users that do not have a mysql shell installation
+## will require the ``libssl-1_1-X64.dll`` (Windows) and ``libcrypto-1_1-X64.dll``
+## dependencies to be included.
+## Tools which explore dependency requirements can be helpful in resolving
+## issues.
+##
 ## Parameter substitution
 ## ======================
 ##


### PR DESCRIPTION
I have included a little note which would help clarify the requirements for the use of the db_mysql and mysql modules. Namely, the requirement for libmysql, and the issues which may arise on systems which do not include a mysql shell installation (note: these experiences were made on Windows 10).