### PR TITLE
fix #16120

### DIFF
--- a/tests/arc/t14383.nim
+++ b/tests/arc/t14383.nim
@@ -19,6 +19,8 @@ seq[T]:
 destroying: ('first', 42)
 destroying: ('second', 20)
 destroying: ('third', 12)
+
+1 1
 '''
 """
 
@@ -112,3 +114,15 @@ echo()
 echo "seq[T]:"
 seqT()
 echo()
+
+
+#------------------------------------------------------------------------------
+# Issue #16120, const seq into sink
+#------------------------------------------------------------------------------
+
+proc main =
+  let avals = @[@[1.0'f32, 4.0, 7.0, 10.0]]
+  let rankdef = avals
+  echo avals.len, " ", rankdef.len
+
+main()


### PR DESCRIPTION
The problem was that constant args never went through createTypeBoundOps, due to this line:
```nim
if getConstExpr(tracked.ownerModule, n, tracked.c.idgen, tracked.graph) != nil:
    return
```

Tha change is minimal, replaced:
```nim
if getConstExpr(tracked.ownerModule, n, tracked.c.idgen, tracked.graph) != nil:
  return
```
with
```nim
if getConstExpr(tracked.ownerModule, n, tracked.c.idgen, tracked.graph) == nil:
  ...
```    
and moved ops in or out from this if statement, no changes to ops themselves.

