### PR TITLE
add a testcase

### DIFF
--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -357,3 +357,12 @@ proc fn(N1: static int, N2: static int, T: typedesc): array[N1 * N2, T] =
   doAssert(len(result) == N1 * N2)
 
 let yy = fn(5, 10, float)
+
+
+block:
+  block:
+    type Foo[N: static int] = array[cint(0) .. cint(N), float]
+    type T = Foo[3]
+  block:
+    type Foo[N: static int] = array[int32(0) .. int32(N), float]
+    type T = Foo[3]


### PR DESCRIPTION
The code doesn't work in Nim 0.20.2(fixed in Nim 1.0.0), add a testcase in case of regression.

fix https://github.com/timotheecour/Nim/issues/15
```nim
block:
  block:
    type Foo[N: static int] = array[cint(0) .. cint(N), float]
    type T = Foo[3]
  block:
    type Foo[N: static int] = array[int32(0) .. int32(N), float]
    type T = Foo[3]
```