### PR TITLE
fix realtimeGC tests; testament: error instead of echo when testament category is empty; 

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -746,7 +746,9 @@ proc processCategory(r: var TResults, cat: Category,
       testSpec r, test
       inc testsRun
     if testsRun == 0:
-      echo "[Warning] - Invalid category specified \"", cat.string, "\", no tests were run"
+      const whiteListedDirs = ["deps"]
+      doAssert cat.string in whiteListedDirs,
+        "Invalid category specified: '$#' not in whilelist: $#" % [cat.string, $whiteListedDirs]
 
 proc processPattern(r: var TResults, pattern, options: string; simulate: bool) =
   var testsRun = 0

--- a/tests/realtimeGC/cmain.c
+++ b/tests/realtimeGC/cmain.c
@@ -1,3 +1,5 @@
+/* xxx consider removing, this seems redundant with tmain.nim */
+
 #ifdef WIN
 #include <windows.h>
 #else
@@ -28,7 +30,7 @@ int main(int argc, char* argv[])
     status = (pFunc)GetProcAddress((HMODULE) hndl, (char const*)"status");
     count = (pFunc)GetProcAddress((HMODULE) hndl, (char const*)"count");
     checkOccupiedMem = (pFunc)GetProcAddress((HMODULE) hndl, (char const*)"checkOccupiedMem");
-#else /* OSX || NIX */
+#else /* OSX || NIX xxx: OSX assumes dylib*/
     hndl = (void*) dlopen((char const*)"./tests/realtimeGC/libshared.so", RTLD_LAZY);
     status = (pFunc) dlsym(hndl, (char const*)"status");
     count = (pFunc) dlsym(hndl, (char const*)"count");

--- a/tests/realtimeGC/main.nim.cfg
+++ b/tests/realtimeGC/main.nim.cfg
@@ -1,6 +1,0 @@
-
---app:console
---threads:on
-
--d:release
--d:useRealtimeGC

--- a/tests/realtimeGC/readme.txt
+++ b/tests/realtimeGC/readme.txt
@@ -1,21 +1,10 @@
 Test the realtime GC without linking nimrtl.dll/so.
 
-Note, this is a long running test, default is 35 minutes. To change the
-the run time see RUNTIME in nmain.nim and cmain.c.
+To build by hand and run the test for 35 minutes:
+    $ nim r --threads:on -d:runtimeSecs:2100 tests/realtimeGC/nmain.nim
 
-You can build shared.nim, nmain.nim, and cmain.c by running make (nix systems)
-or make.bat (Windows systems). They both assume GCC and that it's in your
-path. Output: shared.(dll/so), cmain(.exe), nmain(.exe).
-
-To run the test: execute either nmain or cmain in a shell window.
-
-To build by hand:
-
-  - build the shared object (shared.nim):
-
-    $ nim c tests/realtimeGC/shared.nim
-
-  - build the client executables:
-
-    $ nim c --threads:on tests/realtimeGC/nmain.nim
+```
+xxx do we still need tests/realtimeGC/cmain.c?
+if so, tests/realtimeGC/cmain.c needs to updated and factorized with nmain.nim to avoid duplication (even if it's a C file)
+```
     $ gcc -o tests/realtimeGC/cmain tests/realtimeGC/cmain.c -ldl

--- a/tests/realtimeGC/shared.nim
+++ b/tests/realtimeGC/shared.nim
@@ -1,8 +1,3 @@
-discard """
-cmd: "nim $target --debuginfo --hints:on --app:lib $options $file"
-action: compile
-"""
-
 import strutils
 
 # Global state, accessing with threads, no locks. Don't do this at

--- a/tests/realtimeGC/shared.nim.cfg
+++ b/tests/realtimeGC/shared.nim.cfg
@@ -1,5 +1,0 @@
---app:lib
---threads:on
-
--d:release
--d:useRealtimeGC


### PR DESCRIPTION
after PR:
* error if a category is empty (instead of echo some meaningless warning that won't be caught)
* `realtimeGC` category is now tested by testament instead of being silently untested
