### PR TITLE
fix #14242 `testament r tests/js/foo` now works; testament now honors --targets

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -563,13 +563,13 @@ proc `&.?`(a, b: string): string =
   # candidate for the stdlib?
   result = if b.startsWith(a): b else: a & b
 
-proc processSingleTest(r: var TResults, cat: Category, options, test: string) =
-  let test = testsDir &.? cat.string / test
-  let target = if cat.string.normalize == "js": targetJS else: targetC
-  if fileExists(test):
-    testSpec r, makeTest(test, options, cat), {target}
-  else:
-    doAssert false, test & " test does not exist"
+proc processSingleTest(r: var TResults, cat: Category, options, test: string, targets: set[TTarget], targetsSet: bool) =
+  var targets = targets
+  if not targetsSet:
+    let target = if cat.string.normalize == "js": targetJS else: targetC
+    targets = {target}
+  doAssert fileExists(test), test & " test does not exist"
+  testSpec r, makeTest(test, options, cat), targets
 
 proc isJoinableSpec(spec: TSpec): bool =
   result = not spec.sortoutput and

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -57,10 +57,10 @@ type
     reInvalidSpec       # test had problems to parse the spec
 
   TTarget* = enum
-    targetC = "C"
-    targetCpp = "C++"
-    targetObjC = "ObjC"
-    targetJS = "JS"
+    targetC = "c"
+    targetCpp = "cpp"
+    targetObjC = "objc"
+    targetJS = "js"
 
   InlineError* = object
     kind*: string

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -2,36 +2,36 @@ discard """
 cmd: "testament/testament --directory:testament --colors:off --backendLogging:off --nim:../compiler/nim category shouldfail"
 action: compile
 nimout: '''
-FAIL: tests/shouldfail/tccodecheck.nim C
+FAIL: tests/shouldfail/tccodecheck.nim c
 Failure: reCodegenFailure
 Expected:
 baz
-FAIL: tests/shouldfail/tcolumn.nim C
+FAIL: tests/shouldfail/tcolumn.nim c
 Failure: reLinesDiffer
-FAIL: tests/shouldfail/terrormsg.nim C
+FAIL: tests/shouldfail/terrormsg.nim c
 Failure: reMsgsDiffer
-FAIL: tests/shouldfail/texitcode1.nim C
+FAIL: tests/shouldfail/texitcode1.nim c
 Failure: reExitcodesDiffer
-FAIL: tests/shouldfail/tfile.nim C
+FAIL: tests/shouldfail/tfile.nim c
 Failure: reFilesDiffer
-FAIL: tests/shouldfail/tline.nim C
+FAIL: tests/shouldfail/tline.nim c
 Failure: reLinesDiffer
-FAIL: tests/shouldfail/tmaxcodesize.nim C
+FAIL: tests/shouldfail/tmaxcodesize.nim c
 Failure: reCodegenFailure
 max allowed size: 1
-FAIL: tests/shouldfail/tnimout.nim C
+FAIL: tests/shouldfail/tnimout.nim c
 Failure: reMsgsDiffer
-FAIL: tests/shouldfail/toutput.nim C
+FAIL: tests/shouldfail/toutput.nim c
 Failure: reOutputsDiffer
-FAIL: tests/shouldfail/toutputsub.nim C
+FAIL: tests/shouldfail/toutputsub.nim c
 Failure: reOutputsDiffer
-FAIL: tests/shouldfail/treject.nim C
+FAIL: tests/shouldfail/treject.nim c
 Failure: reFilesDiffer
-FAIL: tests/shouldfail/tsortoutput.nim C
+FAIL: tests/shouldfail/tsortoutput.nim c
 Failure: reOutputsDiffer
-FAIL: tests/shouldfail/ttimeout.nim C
+FAIL: tests/shouldfail/ttimeout.nim c
 Failure: reTimeout
-FAIL: tests/shouldfail/tvalgrind.nim C
+FAIL: tests/shouldfail/tvalgrind.nim c
 Failure: reExitcodesDiffer
 '''
 """


### PR DESCRIPTION
fix #14242