### PR TITLE
testament: error instead of silently overwrite a spec

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -8,7 +8,7 @@
 #
 
 import sequtils, parseutils, strutils, os, streams, parsecfg,
-  tables, hashes
+  tables, hashes, sets
 
 type TestamentData* = ref object
   # better to group globals under 1 object; could group the other ones here too
@@ -244,11 +244,15 @@ proc parseSpec*(filename: string): TSpec =
   var ss = newStringStream(specStr)
   var p: CfgParser
   open(p, ss, filename, 1)
+  var flags: HashSet[string]
   while true:
     var e = next(p)
     case e.kind
     of cfgKeyValuePair:
-      case normalize(e.key)
+      let key = e.key.normalize
+      doAssert key notin flags, key
+      flags.incl key
+      case key
       of "action":
         case e.value.normalize
         of "compile":

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -82,7 +82,7 @@ type
     tline*, tcolumn*: int
     exitCode*: int
     msg*: string
-    ccodeCheck*: string
+    ccodeCheck*: seq[string]
     maxCodeSize*: int
     err*: TResultEnum
     inCurrentBatch*: bool
@@ -250,7 +250,8 @@ proc parseSpec*(filename: string): TSpec =
     case e.kind
     of cfgKeyValuePair:
       let key = e.key.normalize
-      const whiteListMulti = ["disabled"]
+      # const whiteListMulti = ["disabled"]
+      const whiteListMulti = ["disabled", "ccodecheck"] # PRTEMP
       if key notin whiteListMulti:
         doAssert key notin flags, $(key, filename)
       flags.incl key
@@ -367,7 +368,7 @@ proc parseSpec*(filename: string): TSpec =
         else:
           result.cmd = e.value
       of "ccodecheck":
-        result.ccodeCheck = e.value
+        result.ccodeCheck.add e.value
       of "maxcodesize":
         discard parseInt(e.value, result.maxCodeSize)
       of "timeout":

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -250,7 +250,9 @@ proc parseSpec*(filename: string): TSpec =
     case e.kind
     of cfgKeyValuePair:
       let key = e.key.normalize
-      doAssert key notin flags, key
+      const whiteListMulti = ["disabled"]
+      if key notin whiteListMulti:
+        doAssert key notin flags, $(key, filename)
       flags.incl key
       case key
       of "action":

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -251,6 +251,8 @@ proc parseSpec*(filename: string): TSpec =
     of cfgKeyValuePair:
       let key = e.key.normalize
       const whiteListMulti = ["disabled", "ccodecheck"]
+        ## list of flags that are correctly handled when passed multiple times
+        ## (instead of being overwritten)
       if key notin whiteListMulti:
         doAssert key notin flags, $(key, filename)
       flags.incl key

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -250,8 +250,7 @@ proc parseSpec*(filename: string): TSpec =
     case e.kind
     of cfgKeyValuePair:
       let key = e.key.normalize
-      # const whiteListMulti = ["disabled"]
-      const whiteListMulti = ["disabled", "ccodecheck"] # PRTEMP
+      const whiteListMulti = ["disabled", "ccodecheck"]
       if key notin whiteListMulti:
         doAssert key notin flags, $(key, filename)
       flags.incl key
@@ -305,7 +304,7 @@ proc parseSpec*(filename: string): TSpec =
         result.msg = e.value
         if result.action != actionRun:
           result.action = actionCompile
-      of "errormsg", "errmsg":
+      of "errormsg", "errmsg": # xxx just use errormsg, no need for such aliases
         result.msg = e.value
         result.action = actionReject
       of "nimout":

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -402,7 +402,7 @@ proc codegenCheck(test: TTest, target: TTarget, spec: TSpec, expectedMsg: var st
     let genFile = generatedFile(test, target)
     let contents = readFile(genFile).string
     for check in spec.ccodeCheck:
-      if check[0] == '\\':
+      if check.len > 0 and check[0] == '\\':
         # little hack to get 'match' support:
         if not contents.match(check.peg):
           given.err = reCodegenFailure

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -401,8 +401,7 @@ proc codegenCheck(test: TTest, target: TTarget, spec: TSpec, expectedMsg: var st
   try:
     let genFile = generatedFile(test, target)
     let contents = readFile(genFile).string
-    let check = spec.ccodeCheck
-    if check.len > 0:
+    for check in spec.ccodeCheck:
       if check[0] == '\\':
         # little hack to get 'match' support:
         if not contents.match(check.peg):

--- a/tests/casestmt/tcaseexpr1.nim
+++ b/tests/casestmt/tcaseexpr1.nim
@@ -1,17 +1,23 @@
 discard """
-  errormsg: "type mismatch: got <string> but expected 'int'"
-  line: 33
-  file: "tcaseexpr1.nim"
-
-  errormsg: "not all cases are covered; missing: {C}"
-  line: 27
-  file: "tcaseexpr1.nim"
+  cmd: "nim check $options $file"
+  action: "reject"
+  nimout: '''
+tcaseexpr1.nim(33, 10) Error: not all cases are covered; missing: {C}
+'''
 """
 
-# NOTE: This spec is wrong. Spec doesn't support multiple error
-# messages. The first one is simply overridden by the second one.
-# This just has never been noticed.
+#[
+# xxx make nimout comparison use nimoutCheck instead of:
+elif expected.nimout.len > 0 and expected.nimout.normalizeMsg notin given.nimout.normalizeMsg:
 
+and then use nimout: '''
+tcaseexpr1.nim(33, 10) Error: not all cases are covered2; missing: {C}
+tcaseexpr1.nim(39, 12) Error: type mismatch: got <string> but expected 'int literal(10)'
+'''
+]#
+
+
+# line 20
 type
   E = enum A, B, C
 

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -5,5 +5,7 @@ discard """
   outputsub: ''' and works fine! [Exception]'''
 """
 
+# xxx bug: doesn't yet work for cpp
+
 var msg = "This char is `" & '\0' & "` and works fine!"
 raise newException(Exception, msg)

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -2,12 +2,8 @@ discard """
   exitcode: 1
   targets: "c"
   matrix: "-d:debug; -d:release"
-  outputsub: '''t13115.nim(13)           t13115
-Error: unhandled exception: This char is'''
   outputsub: ''' and works fine! [Exception]'''
 """
 
-const b_null: char = 0.char
-var msg = "This char is `" & $b_null & "` and works fine!"
-
+var msg = "This char is `" & '\0' & "` and works fine!"
 raise newException(Exception, msg)

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -5,6 +5,7 @@ discard """
   outputsub: ''' and works fine! [Exception]'''
 """
 
+# bug #13115
 # xxx bug: doesn't yet work for cpp
 
 var msg = "This char is `" & '\0' & "` and works fine!"

--- a/tests/generics/tmetafield.nim
+++ b/tests/generics/tmetafield.nim
@@ -1,10 +1,23 @@
 discard """
   cmd: "nim check $options $file"
-  errormsg: "'proc' is not a concrete type"
-  errormsg: "'Foo' is not a concrete type."
-  errormsg: "invalid type: 'proc' in this context: 'TBaseMed'"
+  action: "reject"
+  nimout: '''
+tmetafield.nim(26, 5) Error: 'proc' is not a concrete type; for a callback without parameters use 'proc()'
+tmetafield.nim(27, 5) Error: 'Foo' is not a concrete type
+tmetafield.nim(29, 5) Error: invalid type: 'proc' in this context: 'TBaseMed' for var
+'''
 """
 
+# bug #188
+
+
+
+
+
+
+
+
+# line 20
 type
   Foo[T] = object
     x: T
@@ -15,4 +28,3 @@ type
 
 var a: TBaseMed
 
-# issue 188


### PR DESCRIPTION
followup https://github.com/nim-lang/Nim/pull/15930
refs https://github.com/nim-lang/Nim/pull/15930/files#r531796278 /cc @xflywind 

before PR, lots of tests were wrong (in the sense they assumed some things were being tested but they were in fact not being tested because testament spec was overwriting the fields written more than once)

after PR: this is fixed and overwriting would result in errors


## future work
make nimout comparison use nimoutCheck instead of:
```nim
elif expected.nimout.len > 0 and expected.nimout.normalizeMsg notin given.nimout.normalizeMsg:
```

and then use
```nim
nimout: '''
tcaseexpr1.nim(33, 10) Error: not all cases are covered2; missing: {C}
tcaseexpr1.nim(39, 12) Error: type mismatch: got <string> but expected 'int literal(10)'
'''
```
in tests/casestmt/tcaseexpr1.nim

## CI failure unrelated: https://github.com/nim-lang/Nim/issues/16169