### PR TITLE
fix partially #13115 (now works for cpp; but still fails for js on openbsd)

### DIFF
--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -3,7 +3,11 @@ discard """
   targets: "c js cpp"
   matrix: "-d:debug; -d:release"
   outputsub: ''' and works fine! [Exception]'''
+  disabled: openbsd
 """
+#[
+disabled: openbsd: just for js
+]#
 
 # bug #13115
 

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -14,7 +14,11 @@ else:
     const file = currentSourcePath
     for b in "c js cpp".split:
       when defined(openbsd):
-        if b == "js": continue # xxx bug: pending #13115
+        if b == "js":
+          # xxx bug: pending #13115
+          # remove special case once nodejs updated >= 12.16.2
+          # refs https://github.com/nim-lang/Nim/pull/16167#issuecomment-738270751
+          continue
       for opt in ["-d:nim_t13115_static", ""]:
         let cmd = fmt"{nim} r -b:{b} -d:nim_t13115 {opt} --hints:off {file}"
         let (outp, exitCode) = execCmdEx(cmd)

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -18,6 +18,10 @@ else:
       for opt in ["-d:nim_t13115_static", ""]:
         let cmd = fmt"{nim} r -b:{b} -d:nim_t13115 {opt} --hints:off {file}"
         let (outp, exitCode) = execCmdEx(cmd)
-        doAssert msg in outp, cmd & "\n" & msg
+        when defined windows:
+          # `\0` not preserved on windows
+          doAssert "` and works fine!" in outp, cmd & "\n" & msg
+        else:
+          doAssert msg in outp, cmd & "\n" & msg
         doAssert exitCode == 1
   main()

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -19,7 +19,14 @@ else:
           # remove special case once nodejs updated >= 12.16.2
           # refs https://github.com/nim-lang/Nim/pull/16167#issuecomment-738270751
           continue
-      for opt in ["-d:nim_t13115_static", ""]:
+
+      # save CI time by avoiding mostly redundant combinations as far as this bug is concerned
+      var opts = case b
+        of "c": @["", "-d:nim_t13115_static", "-d:danger", "-d:debug"]
+        of "js": @["", "-d:nim_t13115_static"]
+        else: @[""]
+
+      for opt in opts:
         let cmd = fmt"{nim} r -b:{b} -d:nim_t13115 {opt} --hints:off {file}"
         let (outp, exitCode) = execCmdEx(cmd)
         when defined windows:

--- a/tests/exception/t13115.nim
+++ b/tests/exception/t13115.nim
@@ -1,12 +1,14 @@
 discard """
   exitcode: 1
-  targets: "c"
+  targets: "c js cpp"
   matrix: "-d:debug; -d:release"
   outputsub: ''' and works fine! [Exception]'''
 """
 
 # bug #13115
-# xxx bug: doesn't yet work for cpp
 
-var msg = "This char is `" & '\0' & "` and works fine!"
-raise newException(Exception, msg)
+template fn =
+  var msg = "This char is `" & '\0' & "` and works fine!"
+  raise newException(Exception, msg)
+# static: fn() # would also work
+fn()


### PR DESCRIPTION
fix partially #13115 (js on openbsd still broken for some reason)

/cc @xflywind 
before PR: works for js,cpp,vm
after PR: also cpp

## future work
- [ ] doesn't yet work for `openbsd + js` ; EDIT: ... due to an upstream nodejs bug that has been patched in more recent nodejs version
