### PR TITLE
Update Documentation db_mysql (devel)

### DIFF
--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -13,6 +13,15 @@
 ## See also: `db_odbc <db_odbc.html>`_, `db_sqlite <db_sqlite.html>`_,
 ## `db_postgres <db_postgres.html>`_.
 ##
+## Note: Nim does not currently include the ``libmysql.dll`` (Windows)
+## dynamically linked dependency for the proper operation of MySql wrapper.
+## You may also find that users that do not have a mysql shell installation
+## will require the ``libssl`` and ``libcrypto`` DLL's (Windows)
+## dependencies to be included (see foreignDep function in nimble).
+## Tools which explore dependency requirements can be helpful in resolving
+## issues.
+## 
+##
 ## Parameter substitution
 ## ======================
 ##


### PR DESCRIPTION
Adding notation to help new users use impure libraries that does not have the dependency included with nim.

Was running into some errors trying to update my previous fork to devel so just reforked and pulling again.