### PR TITLE
styleCheck: Fix error for `sugar` and `std/with`

### DIFF
--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -1250,7 +1250,7 @@ all the arguments, but also the matched operators in reverse polish notation:
   echo x + y * z - x
 
 This passes the expression ``x + y * z - x`` to the ``optM`` macro as
-an ``nnkArgList`` node containing::
+an ``nnkArglist`` node containing::
 
   Arglist
     Sym "x"

--- a/lib/std/private/underscored_calls.nim
+++ b/lib/std/private/underscored_calls.nim
@@ -39,7 +39,7 @@ proc underscoredCall(n, arg0: NimNode): NimNode =
     result.add arg0
 
 proc underscoredCalls*(result, calls, arg0: NimNode) =
-  expectKind calls, {nnkArgList, nnkStmtList, nnkStmtListExpr}
+  expectKind calls, {nnkArglist, nnkStmtList, nnkStmtListExpr}
 
   for call in calls:
     if call.kind in {nnkStmtList, nnkStmtListExpr}:

--- a/tests/astspec/tastspec.nim
+++ b/tests/astspec/tastspec.nim
@@ -929,7 +929,7 @@ static:
         (x & y & z) is string
 
     ast.peelOff({nnkStmtList, nnkTypeSection}).matchAst:
-    of nnkTypeDef(_, _, nnkTypeClassTy(nnkArgList, _, _, nnkStmtList)):
+    of nnkTypeDef(_, _, nnkTypeClassTy(nnkArglist, _, _, nnkStmtList)):
       # note this isn't nnkConceptTy!
       echo "ok"
 


### PR DESCRIPTION
With this commit, we no longer see an error if we pass
`--styleCheck:error` when compiling a file that contains `import sugar`
or `import std/with`.

The problem was that those modules (and only those modules) import
`std/private/underscored_calls`, which contained a styleCheck issue:
its spelling of `nnkArgList` didn't match the `nnkArglist` spelling in
`macros.nim`.

This commit fixes the issue by renaming `nnkArglist` to `nnkArgList`
repo-wide.

Fixes: #16174

CI failure is unrelated (see https://github.com/nim-lang/Nim/issues/16169).