### PR TITLE
styleCheck: Fix some inconsistent identifiers

### DIFF
--- a/lib/experimental/diff.nim
+++ b/lib/experimental/diff.nim
@@ -138,7 +138,7 @@ proc sms(dataA: var DiffData; lowerA, upperA: int; dataB: DiffData; lowerB, uppe
 
   for D in 0 .. maxD:
     # Extend the forward path.
-    for k in countUp(downK - D, downK + D, 2):
+    for k in countup(downK - D, downK + D, 2):
       # find the only or better starting point
       var x: int
       if k == downK - D:
@@ -164,7 +164,7 @@ proc sms(dataA: var DiffData; lowerA, upperA: int; dataB: DiffData; lowerB, uppe
                        y: downVector[downOffset + k] - k)
 
     # Extend the reverse path.
-    for k in countUp(upK - D, upK + D, 2):
+    for k in countup(upK - D, upK + D, 2):
       # find the only or better starting point
       var x: int
       if k == upK + D:

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1460,8 +1460,8 @@ else:
   proc createTextNode*(d: Document, identifier: cstring): Node {.importcpp.}
   proc createComment*(d: Document, data: cstring): Node {.importcpp.}
 
-proc setTimeout*(action: proc(); ms: int): Timeout {.importc, nodecl.}
-proc clearTimeout*(t: Timeout) {.importc, nodecl.}
+proc setTimeout*(action: proc(); ms: int): TimeOut {.importc, nodecl.}
+proc clearTimeout*(t: TimeOut) {.importc, nodecl.}
 
 {.push importcpp.}
 
@@ -1719,9 +1719,9 @@ proc offsetTop*(e: Node): int {.importcpp: "#.offsetTop", nodecl.}
 proc offsetLeft*(e: Node): int {.importcpp: "#.offsetLeft", nodecl.}
 
 since (1, 3):
-  func newDomParser*(): DOMParser {.importcpp: "new DOMParser()".}
+  func newDomParser*(): DomParser {.importcpp: "new DOMParser()".}
     ## DOM Parser constructor.
-  func parseFromString*(this: DOMParser; str: cstring; mimeType: cstring): Document {.importcpp.}
+  func parseFromString*(this: DomParser; str: cstring; mimeType: cstring): Document {.importcpp.}
     ## Parse from string to `Document`.
 
   proc newDomException*(): DomException {.importcpp: "new DomException()", constructor.}
@@ -1733,7 +1733,7 @@ since (1, 3):
 
   proc newFileReader*(): FileReader {.importcpp: "new FileReader()", constructor.}
     ## File Reader constructor
-  proc error*(f: FileReader): DOMException {.importcpp: "#.error", nodecl.}
+  proc error*(f: FileReader): DomException {.importcpp: "#.error", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/error
   proc readyState*(f: FileReader): FileReaderState {.importcpp: "#.readyState", nodecl.}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readyState

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -380,7 +380,7 @@ iterator pairs*[K: JsKey, V](assoc: JsAssoc[K, V]): (K,V) =
   yield (k.toJsKey(K), v)
   {.emit: "}".}
 
-iterator items*[K, V](assoc: JSAssoc[K, V]): V =
+iterator items*[K, V](assoc: JsAssoc[K, V]): V =
   ## Yields the `values` in a JsAssoc.
   var v: V
   {.emit: "for (var k in `assoc`) {".}
@@ -389,7 +389,7 @@ iterator items*[K, V](assoc: JSAssoc[K, V]): V =
   yield v
   {.emit: "}".}
 
-iterator keys*[K: JsKey, V](assoc: JSAssoc[K, V]): K =
+iterator keys*[K: JsKey, V](assoc: JsAssoc[K, V]): K =
   ## Yields the `keys` in a JsAssoc.
   var k: cstring
   {.emit: "for (var `k` in `assoc`) {".}

--- a/lib/nimhcr.nim
+++ b/lib/nimhcr.nim
@@ -230,7 +230,7 @@ when defined(createNimHcr):
     when defined(testNimHcr): return ($arg).splitFile.name.splitFile.name
     else: return $arg
 
-  {.pragma: nimhcr, compilerProc, exportc, dynlib.}
+  {.pragma: nimhcr, compilerproc, exportc, dynlib.}
 
   # XXX these types are CPU specific and need ARM etc support
   type
@@ -622,7 +622,7 @@ elif defined(hotcodereloading) or defined(testNimHcr):
                       elif defined(macosx): "libnimhcr." & dllExt
                       else: "libnimhcr." & dllExt
 
-    {.pragma: nimhcr, compilerProc, importc, dynlib: nimhcrLibname.}
+    {.pragma: nimhcr, compilerproc, importc, dynlib: nimhcrLibname.}
 
     proc hcrRegisterProc*(module: cstring, name: cstring, fn: pointer): pointer {.nimhcr.}
 

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -182,7 +182,7 @@ proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
   elif returnType.kind == nnkEmpty:
     baseType = returnType
   else:
-    verifyReturnType(repr(returnType), returntype)
+    verifyReturnType(repr(returnType), returnType)
 
   let subtypeIsVoid = returnType.kind == nnkEmpty or
         (baseType.kind == nnkIdent and returnType[1].eqIdent("void"))

--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -54,7 +54,7 @@ proc signal(cv: var Semaphore) =
 const CacheLineSize = 32 # true for most archs
 
 type
-  Barrier {.compilerProc.} = object
+  Barrier {.compilerproc.} = object
     entered: int
     cv: Semaphore # Semaphore takes 3 words at least
     when sizeof(int) < 8:
@@ -63,26 +63,26 @@ type
     cacheAlign2: array[CacheLineSize-sizeof(int), byte]
     interest: bool # whether the master is interested in the "all done" event
 
-proc barrierEnter(b: ptr Barrier) {.compilerProc, inline.} =
+proc barrierEnter(b: ptr Barrier) {.compilerproc, inline.} =
   # due to the signaling between threads, it is ensured we are the only
   # one with access to 'entered' so we don't need 'atomicInc' here:
   inc b.entered
   # also we need no 'fence' instructions here as soon 'nimArgsPassingDone'
   # will be called which already will perform a fence for us.
 
-proc barrierLeave(b: ptr Barrier) {.compilerProc, inline.} =
+proc barrierLeave(b: ptr Barrier) {.compilerproc, inline.} =
   atomicInc b.left
   when not defined(x86): fence()
   # We may not have seen the final value of b.entered yet,
   # so we need to check for >= instead of ==.
   if b.interest and b.left >= b.entered: signal(b.cv)
 
-proc openBarrier(b: ptr Barrier) {.compilerProc, inline.} =
+proc openBarrier(b: ptr Barrier) {.compilerproc, inline.} =
   b.entered = 0
   b.left = 0
   b.interest = false
 
-proc closeBarrier(b: ptr Barrier) {.compilerProc.} =
+proc closeBarrier(b: ptr Barrier) {.compilerproc.} =
   fence()
   if b.left != b.entered:
     b.cv.initSemaphore()
@@ -114,7 +114,7 @@ type
   FlowVarObj[T] = object of FlowVarBaseObj
     blob: T
 
-  FlowVar*{.compilerProc.}[T] = ref FlowVarObj[T] ## A data flow variable.
+  FlowVar*{.compilerproc.}[T] = ref FlowVarObj[T] ## A data flow variable.
 
   ToFreeQueue = object
     len: int
@@ -212,14 +212,14 @@ proc `=destroy`[T](fv: var FlowVarObj[T]) =
   finished(fv)
   `=destroy`(fv.blob)
 
-proc nimCreateFlowVar[T](): FlowVar[T] {.compilerProc.} =
+proc nimCreateFlowVar[T](): FlowVar[T] {.compilerproc.} =
   new(result)
 
-proc nimFlowVarCreateSemaphore(fv: FlowVarBase) {.compilerProc.} =
+proc nimFlowVarCreateSemaphore(fv: FlowVarBase) {.compilerproc.} =
   fv.cv.initSemaphore()
   fv.usesSemaphore = true
 
-proc nimFlowVarSignal(fv: FlowVarBase) {.compilerProc.} =
+proc nimFlowVarSignal(fv: FlowVarBase) {.compilerproc.} =
   if fv.ai != nil:
     acquire(fv.ai.cv.L)
     fv.ai.idx = fv.idx
@@ -305,7 +305,7 @@ proc isReady*(fv: FlowVarBase): bool =
   else:
     result = true
 
-proc nimArgsPassingDone(p: pointer) {.compilerProc.} =
+proc nimArgsPassingDone(p: pointer) {.compilerproc.} =
   let w = cast[ptr Worker](p)
   signal(w.taskStarted)
 
@@ -489,7 +489,7 @@ var
 
 initLock stateLock
 
-proc nimSpawn3(fn: WorkerProc; data: pointer) {.compilerProc.} =
+proc nimSpawn3(fn: WorkerProc; data: pointer) {.compilerproc.} =
   # implementation of 'spawn' that is used by the code generator.
   while true:
     if selectWorker(readyWorker, fn, data): return
@@ -574,7 +574,7 @@ var
 
 initLock distinguishedLock
 
-proc nimSpawn4(fn: WorkerProc; data: pointer; id: ThreadId) {.compilerProc.} =
+proc nimSpawn4(fn: WorkerProc; data: pointer; id: ThreadId) {.compilerproc.} =
   acquire(distinguishedLock)
   if not distinguishedData[id].initialized:
     activateDistinguishedThread(id)

--- a/lib/pure/ioselects/ioselectors_poll.nim
+++ b/lib/pure/ioselects/ioselectors_poll.nim
@@ -209,7 +209,7 @@ proc close*(ev: SelectEvent) =
     raiseIOSelectorsError(osLastError())
 
 proc selectInto*[T](s: Selector[T], timeout: int,
-                    results: var openarray[ReadyKey]): int =
+                    results: var openArray[ReadyKey]): int =
   var maxres = MAX_POLL_EVENTS
   if maxres > len(results):
     maxres = len(results)

--- a/lib/pure/ioselects/ioselectors_select.nim
+++ b/lib/pure/ioselects/ioselectors_select.nim
@@ -305,7 +305,7 @@ proc unregister*[T](s: Selector[T], ev: SelectEvent) =
     s.delKey(fd)
 
 proc selectInto*[T](s: Selector[T], timeout: int,
-                    results: var openarray[ReadyKey]): int =
+                    results: var openArray[ReadyKey]): int =
   var tv = Timeval()
   var ptv = addr tv
   var rset, wset, eset: FdSet

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -232,8 +232,8 @@ proc open*(filename: string, mode: FileMode = fmRead,
 
     if newFileSize != -1:
       flags = flags or O_CREAT or O_TRUNC
-      var permissions_mode = S_IRUSR or S_IWUSR
-      result.handle = open(filename, flags, permissions_mode)
+      var permissionsMode = S_IRUSR or S_IWUSR
+      result.handle = open(filename, flags, permissionsMode)
     else:
       result.handle = open(filename, flags)
 

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -209,7 +209,7 @@ proc getProtoByName*(name: string): int {.since: (1, 3, 5).} =
     let protoent = posix.getprotobyname(name.cstring)
   
   if protoent == nil:
-    raise newException(OsError, "protocol not found")
+    raise newException(OSError, "protocol not found")
 
   result = protoent.p_proto.int
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -551,7 +551,7 @@ when defineSsl:
 
   proc newContext*(protVersion = protSSLv23, verifyMode = CVerifyPeer,
                    certFile = "", keyFile = "", cipherList = CiphersIntermediate,
-                   caDir = "", caFile = ""): SSLContext =
+                   caDir = "", caFile = ""): SslContext =
     ## Creates an SSL context.
     ##
     ## Protocol version specifies the protocol to use. SSLv2, SSLv3, TLSv1
@@ -644,7 +644,7 @@ when defineSsl:
           if not found:
             raise newException(IOError, "No SSL/TLS CA certificates found.")
 
-    result = SSLContext(context: newCTX, referencedData: initHashSet[int](),
+    result = SslContext(context: newCTX, referencedData: initHashSet[int](),
       extraInternal: new(SslContextExtraInternal))
 
   proc getExtraInternal(ctx: SslContext): SslContextExtraInternal =
@@ -750,7 +750,7 @@ when defineSsl:
     ## Wildcards match only in the left-most label.
     ## When name starts with a dot it will be matched by a certificate valid for any subdomain
     when not defined(nimDisableCertificateValidation) and not defined(windows):
-      assert socket.isSSL
+      assert socket.isSsl
       let certificate = socket.sslHandle.SSL_get_peer_certificate()
       if certificate.isNil:
         raiseSSLError("No SSL certificate found.")
@@ -763,7 +763,7 @@ when defineSsl:
       if match != 1:
         raiseSSLError("SSL Certificate check failed.")
 
-  proc wrapConnectedSocket*(ctx: SSLContext, socket: Socket,
+  proc wrapConnectedSocket*(ctx: SslContext, socket: Socket,
                             handshake: SslHandshakeType,
                             hostname: string = "") =
     ## Wraps a connected socket in an SSL context. This function effectively

--- a/lib/pure/punycode.nim
+++ b/lib/pure/punycode.nim
@@ -161,13 +161,13 @@ proc decode*(encoded: string): string {.raises: [PunyError].} =
         break
       w *= Base - t
       k += Base
-    bias = adapt(i - oldi, runelen(result) + 1, oldi == 0)
+    bias = adapt(i - oldi, runeLen(result) + 1, oldi == 0)
 
-    if i div (runelen(result) + 1) > high(int32) - n:
+    if i div (runeLen(result) + 1) > high(int32) - n:
       raise newException(PunyError, "Value too large")
 
-    n += i div (runelen(result) + 1)
-    i = i mod (runelen(result) + 1)
+    n += i div (runeLen(result) + 1)
+    i = i mod (runeLen(result) + 1)
     insert(result, $Rune(n), i)
     inc i
 

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -162,7 +162,7 @@ when defined(nimdoc):
     ## Unregisters file/socket descriptor ``fd`` from selector ``s``.
 
   proc selectInto*[T](s: Selector[T], timeout: int,
-                      results: var openarray[ReadyKey]): int =
+                      results: var openArray[ReadyKey]): int =
     ## Waits for events registered in selector ``s``.
     ##
     ## The ``timeout`` argument specifies the maximum number of milliseconds

--- a/lib/pure/smtp.nim
+++ b/lib/pure/smtp.nim
@@ -112,17 +112,17 @@ proc quitExcpt(smtp: Smtp, msg: string) =
 const compiledWithSsl = defined(ssl)
 
 when not defined(ssl):
-  let defaultSSLContext: SSLContext = nil
+  let defaultSSLContext: SslContext = nil
 else:
-  var defaultSSLContext {.threadvar.}: SSLContext
+  var defaultSSLContext {.threadvar.}: SslContext
 
-  proc getSSLContext(): SSLContext =
+  proc getSSLContext(): SslContext =
     if defaultSSLContext == nil:
       defaultSSLContext = newContext(verifyMode = CVerifyNone)
     result = defaultSSLContext
 
 proc createMessage*(mSubject, mBody: string, mTo, mCc: seq[string],
-                otherHeaders: openarray[tuple[name, value: string]]): Message =
+                otherHeaders: openArray[tuple[name, value: string]]): Message =
   ## Creates a new MIME compliant message.
   ##
   ## You need to make sure that ``mSubject``, ``mTo`` and ``mCc`` don't contain
@@ -172,7 +172,7 @@ proc `$`*(msg: Message): string =
   result.add(msg.msgBody)
 
 proc newSmtp*(useSsl = false, debug = false,
-              sslContext: SSLContext = nil): Smtp =
+              sslContext: SslContext = nil): Smtp =
   ## Creates a new ``Smtp`` instance.
   new result
   result.debug = debug
@@ -187,7 +187,7 @@ proc newSmtp*(useSsl = false, debug = false,
       {.error: "SMTP module compiled without SSL support".}
 
 proc newAsyncSmtp*(useSsl = false, debug = false,
-                   sslContext: SSLContext = nil): AsyncSmtp =
+                   sslContext: SslContext = nil): AsyncSmtp =
   ## Creates a new ``AsyncSmtp`` instance.
   new result
   result.debug = debug
@@ -222,7 +222,7 @@ proc checkReply*(smtp: Smtp | AsyncSmtp, reply: string) {.multisync.} =
   ## `SMTP extensions<https://en.wikipedia.org/wiki/Extended_SMTP>`_.
 
   var line = await smtp.debugRecv()
-  if not line.startswith(reply):
+  if not line.startsWith(reply):
     await quitExcpt(smtp, "Expected " & reply & " reply, got: " & line)
 
 proc helo*(smtp: Smtp | AsyncSmtp) {.multisync.} =
@@ -239,7 +239,7 @@ proc connect*(smtp: Smtp | AsyncSmtp,
   await smtp.checkReply("220")
   await smtp.helo()
 
-proc startTls*(smtp: Smtp | AsyncSmtp, sslContext: SSLContext = nil) {.multisync.} =
+proc startTls*(smtp: Smtp | AsyncSmtp, sslContext: SslContext = nil) {.multisync.} =
   ## Put the SMTP connection in TLS (Transport Layer Security) mode.
   ## May fail with ReplyError
   await smtp.debugSend("STARTTLS\c\L")

--- a/lib/pure/ssl_certs.nim
+++ b/lib/pure/ssl_certs.nim
@@ -20,7 +20,7 @@ import strutils
 
 # FWIW look for files before scanning entire dirs.
 
-const certificate_paths = [
+const certificatePaths = [
     # Debian, Ubuntu, Arch: maintained by update-ca-certificates, SUSE, Gentoo
     # NetBSD (security/mozilla-rootcerts)
     # SLES10/SLES11, https://golang.org/issue/12139
@@ -77,7 +77,7 @@ iterator scanSSLCertificates*(useEnvVars = false): string =
 
   else:
     when not defined(haiku):
-      for p in certificate_paths:
+      for p in certificatePaths:
         if p.endsWith(".pem") or p.endsWith(".crt"):
           if fileExists(p):
             yield p

--- a/lib/pure/stats.nim
+++ b/lib/pure/stats.nim
@@ -103,7 +103,7 @@ proc push*(s: var RunningStat, x: int) =
   ## and the other push operation is called.
   s.push(toFloat(x))
 
-proc push*(s: var RunningStat, x: openarray[float|int]) =
+proc push*(s: var RunningStat, x: openArray[float|int]) =
   ## pushes all values of `x` for processing.
   ##
   ## Int values of `x` are simply converted to ``float`` and
@@ -277,7 +277,7 @@ proc push*(r: var RunningRegress, x, y: int) {.inline.} =
   ## and the other push operation is called.
   r.push(toFloat(x), toFloat(y))
 
-proc push*(r: var RunningRegress, x, y: openarray[float|int]) =
+proc push*(r: var RunningRegress, x, y: openArray[float|int]) =
   ## pushes two sets of values `x` and `y` for processing.
   assert(x.len == y.len)
   for i in 0..<x.len:

--- a/lib/system/gc_regions.nim
+++ b/lib/system/gc_regions.nim
@@ -87,8 +87,8 @@ type
     region: ptr MemRegion
 
 var
-  tlRegion {.threadVar.}: MemRegion
-#  tempStrRegion {.threadVar.}: MemRegion  # not yet used
+  tlRegion {.threadvar.}: MemRegion
+#  tempStrRegion {.threadvar.}: MemRegion  # not yet used
 
 template withRegion*(r: var MemRegion; body: untyped) =
   let oldRegion = tlRegion
@@ -437,5 +437,5 @@ proc getTotalMem*(r: MemRegion): int =
 
 proc nimGC_setStackBottom(theStackBottom: pointer) = discard
 
-proc nimGCref(x: pointer) {.compilerProc.} = discard
-proc nimGCunref(x: pointer) {.compilerProc.} = discard
+proc nimGCref(x: pointer) {.compilerproc.} = discard
+proc nimGCunref(x: pointer) {.compilerproc.} = discard

--- a/lib/system/mm/go.nim
+++ b/lib/system/mm/go.nim
@@ -130,8 +130,8 @@ proc growObj(old: pointer, newsize: int): pointer =
 
 proc nimGCref(p: pointer) {.compilerproc, inline.} = discard
 proc nimGCunref(p: pointer) {.compilerproc, inline.} = discard
-proc nimGCunrefNoCycle(p: pointer) {.compilerProc, inline.} = discard
-proc nimGCunrefRC1(p: pointer) {.compilerProc, inline.} = discard
+proc nimGCunrefNoCycle(p: pointer) {.compilerproc, inline.} = discard
+proc nimGCunrefRC1(p: pointer) {.compilerproc, inline.} = discard
 proc nimGCvisit(d: pointer, op: int) {.compilerRtl.} = discard
 
 proc unsureAsgnRef(dest: PPointer, src: pointer) {.compilerproc, inline.} =

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -191,7 +191,7 @@ template checkOsError =
 template log(msg: string, body: untyped) =
   if mode in {ScriptMode.Verbose, ScriptMode.Whatif}:
     echo "[NimScript] ", msg
-  if mode != ScriptMode.WhatIf:
+  if mode != ScriptMode.Whatif:
     body
 
 proc listDirs*(dir: string): seq[string] =

--- a/lib/system/sysspawn.nim
+++ b/lib/system/sysspawn.nim
@@ -80,22 +80,22 @@ proc signal(cv: var FastCondVar) =
   signal(cv.slow)
 
 type
-  Barrier* {.compilerProc.} = object
+  Barrier* {.compilerproc.} = object
     counter: int
     cv: CondVar
 
-proc barrierEnter*(b: ptr Barrier) {.compilerProc.} =
+proc barrierEnter*(b: ptr Barrier) {.compilerproc.} =
   atomicInc b.counter
 
-proc barrierLeave*(b: ptr Barrier) {.compilerProc.} =
+proc barrierLeave*(b: ptr Barrier) {.compilerproc.} =
   atomicDec b.counter
   if b.counter <= 0: signal(b.cv)
 
-proc openBarrier*(b: ptr Barrier) {.compilerProc.} =
+proc openBarrier*(b: ptr Barrier) {.compilerproc.} =
   b.counter = 0
   b.cv = createCondVar()
 
-proc closeBarrier*(b: ptr Barrier) {.compilerProc.} =
+proc closeBarrier*(b: ptr Barrier) {.compilerproc.} =
   await(b.cv)
   destroyCondVar(b.cv)
 
@@ -113,7 +113,7 @@ type
     data: pointer
     ready: bool # put it here for correct alignment!
 
-proc nimArgsPassingDone(p: pointer) {.compilerProc.} =
+proc nimArgsPassingDone(p: pointer) {.compilerproc.} =
   let w = cast[ptr Worker](p)
   signal(w.taskStarted)
 
@@ -167,7 +167,7 @@ template spawnX*(call: typed) =
   if preferSpawn(): spawn call
   else: call
 
-proc nimSpawn(fn: WorkerProc; data: pointer) {.compilerProc.} =
+proc nimSpawn(fn: WorkerProc; data: pointer) {.compilerproc.} =
   # implementation of 'spawn' that is used by the code generator.
   while true:
     for i in 0.. high(workers):


### PR DESCRIPTION
This PR fixes some problems that are reported when compiling with `--styleCheck:error`.

The commits are atomic: the first commit acts on mismatched identifiers; the second deals with `snake_case` -> `camelCase`.