### PR TITLE
add math.isNaN

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,8 @@
 - `strscans.scanf` now supports parsing single characters.
 
 
+- Added `math.isNaN`.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1683,6 +1683,7 @@ proc decodeURIComponent*(uri: cstring): cstring {.importc, nodecl.}
 proc encodeURIComponent*(uri: cstring): cstring {.importc, nodecl.}
 proc isFinite*(x: BiggestFloat): bool {.importc, nodecl.}
 proc isNaN*(x: BiggestFloat): bool {.importc, nodecl.}
+  ## see also `math.isNaN`.
 
 proc newEvent*(name: cstring): Event {.importcpp: "new Event(@)", constructor.}
 

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -59,11 +59,6 @@ import std/private/since
 import bitops, fenv
 
 when defined(c) or defined(cpp):
-  #[
-  Low level wrappers around C math functions.
-  Consider moving this and other direct c wrappers to a dedicated `std/cmath`,
-  refs https://github.com/nim-lang/RFCs/issues/92#issuecomment-735328291
-  ]#
   proc c_isnan(x: float): bool {.importc: "isnan", header: "<math.h>".}
     # a generic like `x: SomeFloat` might work too if this is implemented via a C macro.
 

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -57,7 +57,14 @@ import std/private/since
                        # of the standard library!
 
 import bitops, fenv
-from std/cmath import nil
+
+when defined(c) or defined(cpp):
+  #[
+  Low level wrappers around C math functions.
+  Consider moving this to a dedicated `std/cmath`.
+  ]#
+  proc c_isnan*(x: float): bool {.importc: "isnan", header: "<math.h>".}
+    # a generic like `x: SomeFloat` might work too if this is implemented via a C macro.
 
 func binom*(n, k: int): int =
   ## Computes the `binomial coefficient <https://en.wikipedia.org/wiki/Binomial_coefficient>`_.
@@ -145,7 +152,7 @@ func isNaN*(x: SomeFloat): bool {.inline, since: (1,5,1).} =
   when nimvm: fn()
   else:
     when defined(js): fn()
-    else: result = cmath.isnan(x)
+    else: result = c_isnan(x)
 
 func classify*(x: float): FloatClass =
   ## Classifies a floating point value.

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -165,9 +165,6 @@ func classify*(x: float): FloatClass =
     doAssert classify(-0.3/0.0) == fcNegInf
     doAssert classify(5.0e-324) == fcSubnormal
 
-  # xxx support `--passc:-ffast-math`; we could use `isNaN` and make sure
-  # it works for all floats.
-
   # JavaScript and most C compilers have no classify:
   if x == 0.0:
     if 1.0/x == Inf:

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -158,6 +158,15 @@ func classify*(x: float): FloatClass =
     return fcSubnormal
   return fcNormal
 
+proc isNaN*(x: SomeFloat): bool {.inline, since: (1,5,1).} =
+  ## Returns whether `x` is a `NaN`, more efficiently than via `classify(x) == fcNan`.
+  ## Does not work with: `--passc:-ffast-math`.
+  runnableExamples:
+    doAssert NaN.isNaN
+    doAssert not Inf.isNaN
+    doAssert isNaN(Inf - Inf)
+  result = x != x
+
 func almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4): bool {.
     since: (1, 5), inline.} =
   ## Checks if two float values are almost equal, using

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -61,9 +61,10 @@ import bitops, fenv
 when defined(c) or defined(cpp):
   #[
   Low level wrappers around C math functions.
-  Consider moving this to a dedicated `std/cmath`.
+  Consider moving this and other direct c wrappers to a dedicated `std/cmath`,
+  refs https://github.com/nim-lang/RFCs/issues/92#issuecomment-735328291
   ]#
-  proc c_isnan*(x: float): bool {.importc: "isnan", header: "<math.h>".}
+  proc c_isnan(x: float): bool {.importc: "isnan", header: "<math.h>".}
     # a generic like `x: SomeFloat` might work too if this is implemented via a C macro.
 
 func binom*(n, k: int): int =
@@ -148,6 +149,9 @@ func isNaN*(x: SomeFloat): bool {.inline, since: (1,5,1).} =
     doAssert NaN.isNaN
     doAssert not Inf.isNaN
     doAssert isNaN(Inf - Inf)
+    doAssert not isNan(3.1415926)
+    doAssert not isNan(0'f32)
+
   template fn: untyped = result = x != x
   when nimvm: fn()
   else:

--- a/lib/std/cmath.nim
+++ b/lib/std/cmath.nim
@@ -1,0 +1,6 @@
+##[
+Low level wrappers around C math functions.
+]##
+
+proc isnan*(x: float): bool {.importc: "isnan", header: "<math.h>".}
+  # a generic like `x: SomeFloat` might work too if this is implemented via a C macro.

--- a/lib/std/cmath.nim
+++ b/lib/std/cmath.nim
@@ -1,6 +1,0 @@
-##[
-Low level wrappers around C math functions.
-]##
-
-proc isnan*(x: float): bool {.importc: "isnan", header: "<math.h>".}
-  # a generic like `x: SomeFloat` might work too if this is implemented via a C macro.


### PR DESCRIPTION
as:
https://en.cppreference.com/w/c/numeric/math/isnan
https://numpy.org/doc/stable/reference/generated/numpy.isnan.html
etc

## note
making isNaN work with `--passc:-ffast-math` is tricky (see also https://bugs.launchpad.net/mixxx/+bug/1524561); I made it work by wrapping cmath.isnan which I've added to a new module cmath, intended to grow (refs: https://github.com/nim-lang/RFCs/issues/92)

in particular:
* this worked on windows but for some obscure reason not on OSX:
```nim
proc isNaN*(x: SomeFloat): bool {.inline, codegenDecl: """ __attribute__ ((optimize("fno-fast-math"))) $1 $2 $3""".} =
  result = x != x
```

* `{.localpassc:"-fno-fast-math”.}` would apply to whole module, and moving it to a different module with different compilation options would prevent inlining.

So wrapping cmath.isnan was the simplest, and is also the most efficient in benchmark below.

## future work
- [ ] make `classify` work with `--passc:-ffast-math`
- [ ] add `targets:"c js"` to tmath after fixing js bugs
- [ ] address this: https://github.com/nim-lang/Nim/pull/16179#issuecomment-736787349 (add `isFinite` etc)

## CI failure unrelated:
https://github.com/timotheecour/Nim/issues/442