### PR TITLE
testament: nimout now consistently uses nimoutCheck

### DIFF
--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -1,4 +1,5 @@
 import std/private/miscdollars
+import std/strutils
 
 template flakyAssert*(cond: untyped, msg = "", notifySuccess = true) =
   ## API to deal with flaky or failing tests. This avoids disabling entire tests
@@ -23,3 +24,13 @@ template flakyAssert*(cond: untyped, msg = "", notifySuccess = true) =
       msg2.add " FLAKY_FAILURE "
     msg2.add $expr & " " & msg
     echo msg2
+
+proc greedyOrderedSubsetLines*(lhs, rhs: string): bool =
+  ## returns true if each stripped line in `lhs` appears in rhs, using a greedy matching.
+  let rhs = rhs.strip
+  var currentPos = 0
+  for line in lhs.strip.splitLines:
+    currentPos = rhs.find(line.strip, currentPos)
+    if currentPos < 0:
+      return false
+  return true

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -15,6 +15,7 @@ import
   algorithm, times, md5, sequtils, azure, intsets
 from std/sugar import dup
 import compiler/nodejs
+import lib/stdtest/testutils
 
 var useColors = true
 var backendLogging = true
@@ -364,7 +365,7 @@ proc cmpMsgs(r: var TResults, expected, given: TSpec, test: TTest, target: TTarg
     checkForInlineErrors(r, expected, given, test, target)
   elif strip(expected.msg) notin strip(given.msg):
     r.addResult(test, target, expected.msg, given.msg, reMsgsDiffer)
-  elif expected.nimout.len > 0 and expected.nimout.normalizeMsg notin given.nimout.normalizeMsg:
+  elif expected.nimout.len > 0 and not greedyOrderedSubsetLines(expected.nimout, given.nimout):
     r.addResult(test, target, expected.nimout, given.nimout, reMsgsDiffer)
   elif expected.tfile == "" and extractFilename(expected.file) != extractFilename(given.file) and
       "internal error:" notin expected.msg:
@@ -422,17 +423,8 @@ proc codegenCheck(test: TTest, target: TTarget, spec: TSpec, expectedMsg: var st
     echo getCurrentExceptionMsg()
 
 proc nimoutCheck(test: TTest; expectedNimout: string; given: var TSpec) =
-  let giv = given.nimout.strip
-  var currentPos = 0
-  # Only check that nimout contains all expected lines in that order.
-  # There may be more output in nimout. It is ignored here.
-  for line in expectedNimout.strip.splitLines:
-    currentPos = giv.find(line.strip, currentPos)
-    if currentPos < 0:
-      given.err = reMsgsDiffer
-      break
-
-
+  if not greedyOrderedSubsetLines(expectedNimout, given.nimout):
+    given.err = reMsgsDiffer
 
 proc compilerOutputTests(test: TTest, target: TTarget, given: var TSpec,
                          expected: TSpec; r: var TResults) =

--- a/tests/casestmt/tcaseexpr1.nim
+++ b/tests/casestmt/tcaseexpr1.nim
@@ -3,18 +3,18 @@ discard """
   action: "reject"
   nimout: '''
 tcaseexpr1.nim(33, 10) Error: not all cases are covered; missing: {C}
+tcaseexpr1.nim(39, 12) Error: type mismatch: got <string> but expected 'int literal(10)'
 '''
 """
 
-#[
-# xxx make nimout comparison use nimoutCheck instead of:
-elif expected.nimout.len > 0 and expected.nimout.normalizeMsg notin given.nimout.normalizeMsg:
 
-and then use nimout: '''
-tcaseexpr1.nim(33, 10) Error: not all cases are covered2; missing: {C}
-tcaseexpr1.nim(39, 12) Error: type mismatch: got <string> but expected 'int literal(10)'
-'''
-]#
+
+
+
+
+
+
+
 
 
 # line 20

--- a/tests/stdlib/ttestutils.nim
+++ b/tests/stdlib/ttestutils.nim
@@ -1,0 +1,6 @@
+import stdtest/testutils
+
+block: # greedyOrderedSubsetLines
+  doAssert greedyOrderedSubsetLines("a1\na3", "a0\na1\na2\na3\na4")
+  doAssert not greedyOrderedSubsetLines("a3\na1", "a0\na1\na2\na3\na4") # out of order
+  doAssert not greedyOrderedSubsetLines("a1\na5", "a0\na1\na2\na3\na4") # a5 not in lhs


### PR DESCRIPTION
before PR, some uses of nimout were checking that nimout.expected was a subset of nimout.given, others were using `nimoutCheck` which checks that each line of nimout.expected appears (in order) in nimout.given, which is different, see tests/casestmt/tcaseexpr1.nim and tests/stdlib/ttestutils.nim; nimoutCheck is more useful since it allows interleaving extra messages that are of no interest to a given test.

after PR
* nimout consistently uses nimoutCheck, factored via a `greedyOrderedSubsetLines` proc
* `greedyOrderedSubsetLines` has a test

this finishes the work started in https://github.com/nim-lang/Nim/pull/16166 where testament silently was ignoring some checks, see https://github.com/nim-lang/Nim/pull/16166/files#diff-0fae04b7221d71e1d79fce15a7d062c187589069371764a010a99db05693c5ae ; now we have a proper means to check for nimout in that case

