### PR TITLE
prefer x == nil to x.isNil

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1572,6 +1572,7 @@ proc isNil*[T](x: seq[T]): bool {.noSideEffect, magic: "IsNil", nilError.}
 
 proc isNil*[T](x: ref T): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
+  # see #16191
 
 proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
   ## Requires `--nilseqs:on`.
@@ -1581,19 +1582,22 @@ proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
 
 proc isNil*[T](x: ptr T): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
+  # see #16191
 
 proc isNil*(x: pointer): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
+  # see #16191
 
 proc isNil*(x: cstring): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
+  # see #16191
 
 proc isNil*[T: proc](x: T): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
   ## 
   ## Fast check whether `x` is nil. This is sometimes more efficient than
   ## ``== nil``.
-
+  # see #16191
 
 proc `@`*[T](a: openArray[T]): seq[T] =
   ## Turns an *openArray* into a sequence.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1571,6 +1571,8 @@ proc isNil*[T](x: seq[T]): bool {.noSideEffect, magic: "IsNil", nilError.}
   ## * `isNil(string) <#isNil,string>`_
 
 proc isNil*[T](x: ref T): bool {.noSideEffect, magic: "IsNil".}
+  ## `x == nil` or `x != nil` is preferred, please use that instead.
+
 proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
   ## Requires `--nilseqs:on`.
   ##
@@ -1578,9 +1580,17 @@ proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
   ## * `isNil(seq[T]) <#isNil,seq[T][T]>`_
 
 proc isNil*[T](x: ptr T): bool {.noSideEffect, magic: "IsNil".}
+  ## `x == nil` or `x != nil` is preferred, please use that instead.
+
 proc isNil*(x: pointer): bool {.noSideEffect, magic: "IsNil".}
+  ## `x == nil` or `x != nil` is preferred, please use that instead.
+
 proc isNil*(x: cstring): bool {.noSideEffect, magic: "IsNil".}
+  ## `x == nil` or `x != nil` is preferred, please use that instead.
+
 proc isNil*[T: proc](x: T): bool {.noSideEffect, magic: "IsNil".}
+  ## `x == nil` or `x != nil` is preferred, please use that instead.
+  ## 
   ## Fast check whether `x` is nil. This is sometimes more efficient than
   ## ``== nil``.
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1572,7 +1572,6 @@ proc isNil*[T](x: seq[T]): bool {.noSideEffect, magic: "IsNil", nilError.}
 
 proc isNil*[T](x: ref T): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
-  # see #16191
 
 proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
   ## Requires `--nilseqs:on`.
@@ -1582,22 +1581,18 @@ proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", nilError.}
 
 proc isNil*[T](x: ptr T): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
-  # see #16191
 
 proc isNil*(x: pointer): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
-  # see #16191
 
 proc isNil*(x: cstring): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
-  # see #16191
 
 proc isNil*[T: proc](x: T): bool {.noSideEffect, magic: "IsNil".}
   ## `x == nil` or `x != nil` is preferred, please use that instead.
   ## 
   ## Fast check whether `x` is nil. This is sometimes more efficient than
   ## ``== nil``.
-  # see #16191
 
 proc `@`*[T](a: openArray[T]): seq[T] =
   ## Turns an *openArray* into a sequence.


### PR DESCRIPTION
Let me assume that `x == nil` or `x != nil` is preferred.

> Araq:  use  != nil please
> Araq: isNil could be deprecated, it's pointless

https://discord.com/channels/371759389889003530/371759389889003532/696718991019999252

EDITED:
So which one is preferred? We need some docs for either of situations I think.