### PR TITLE
Don't add content-length header on GET request when there is no body.

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -980,7 +980,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url, httpMethod: string,
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
-  elif not(httpMethod == "GET" and body.len == 0):
+  elif not (httpMethod == "GET" and body.len == 0):
     client.headers["Content-Length"] = $body.len
 
   when client is AsyncHttpClient:

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -980,7 +980,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url, httpMethod: string,
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
-  elif not (httpMethod == "GET" and body.len == 0):
+  elif httpMethod in ["POST", "PATCH", "PUT"] or body.len != 0:
     client.headers["Content-Length"] = $body.len
 
   when client is AsyncHttpClient:

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -980,7 +980,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url, httpMethod: string,
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
-  else:
+  elif not(httpMethod == "GET" and body.len == 0):
     client.headers["Content-Length"] = $body.len
 
   when client is AsyncHttpClient:


### PR DESCRIPTION
Nim's HTTP client always sends `content-length:0` even when there is no need for it, which causes problems for some servers.

The problem is ~100% of GET requests have no body. It is possible but very rare for GET requests to have body.
Its the POST requests usually have a body and must send `content-length`. 

Some HTTP servers (probably badly coded) reject the request when you send them `content-length:0` on GET requests. Its a big problem for me. No one else sends `content-length:0` on GETs ... curl does not, python does not, node does not... 

Nim looks bad because the other languages all work fine. Nim should not send useless `content-length:0` on GET requests so that it acts like every one else.

I don't think sending `content-length:0` on GET request was a conscious effort and looks like a bug caused by complex code.

Its also wasted bandwidth to send `content-length:0` all the time.

Notes:

`A payload within a GET request message has no defined semantics;
   sending a payload body on a GET request might cause some existing
   implementations to reject the request.`
https://tools.ietf.org/html/rfc7231#section-4.3.1

"Since you normally doesn't send any additional data when you do a GET request, the header Content-Length should not be sent at all." from https://stackoverflow.com/questions/8540931/what-is-the-correct-content-length-to-set-for-a-get-request#:~:text=The%20Content%2DLength%20entity%2Dheader,the%20request%20been%20a%20GET.

https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13

https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4
