### PR TITLE
close #8895; add threadutils.onceGlobal, onceThread

### DIFF
--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -3,6 +3,8 @@ import std/locks
 var lock: Lock
 initLock(lock)
 
+# var lockSubs: seq[Lock]
+
 template onceGlobal*(body: untyped) =
   ## evaluate `body` once, even in presence of multiple threads.
   runnableExamples "--threads":
@@ -15,10 +17,19 @@ template onceGlobal*(body: untyped) =
     joinThreads(thr)
 
   var witness {.global.}: bool
-  withLock lock:
-    if not witness:
-      witness = true
-      body
+  # var lockIndex {.global.}: int
+  # TODO is atomic needed?
+  if not witness:
+    # var lockSub {.global.}: Lock
+    # initLock(lock)
+    withLock lock:
+      # lockSubs
+      if not witness:
+        witness = true
+        # this could take a while
+        # lockSubs
+        # lockIndex
+        body
 
 template onceThread*(body: untyped) =
   # var witness {.threadvar.}: bool

--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -56,6 +56,20 @@ template onceGlobal*(body: untyped) =
   onceGlobal(false, body)
 
 template onceThread*(body: untyped) =
+  ## Evaluate `body` once per thread
+  runnableExamples:
+    var count = 0
+    proc fn(n: int) =
+      for i in 0..<3:
+        onceThread:
+          count.inc
+      if n > 1: fn(n-1) # re-entrant code
+    fn(3)
+    doAssert count == 1
+    onceThread: # each instance is unique
+      count.inc
+    doAssert count == 2
+
   var witness {.threadvar, global.}: bool
   if not witness:
     body

--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -28,6 +28,17 @@ template onceGlobal*(retryOnFailure: bool, body: untyped) =
         count2.inc
     doAssert count2 == 1
     joinThreads(thr)
+  runnableExamples:
+    # each instantiation is independant:
+    var count = 0
+    proc bar[T](a: T): int =
+      onceGlobal: count.inc
+      result = count
+    doAssert bar(1) == 1
+    doAssert bar(2) == 1
+    doAssert bar(3.1) == 2
+    doAssert bar(4.2) == 2
+    doAssert bar(5.1'f32) == 3
 
   var witness {.global.}: int
   var lock2 {.global.}: Lock
@@ -56,7 +67,8 @@ template onceGlobal*(body: untyped) =
   onceGlobal(false, body)
 
 template onceThread*(body: untyped) =
-  ## Evaluate `body` once per thread
+  ## Evaluate `body` once per thread. Like `onceGlobal`, each instantiation
+  ## is independant.
   runnableExamples:
     var count = 0
     proc fn(n: int) =

--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -1,0 +1,27 @@
+import std/locks
+
+var lock: Lock
+initLock(lock)
+
+template onceGlobal*(body: untyped) =
+  ## evaluate `body` once, even in presence of multiple threads.
+  runnableExamples "--threads":
+    var thr: array[2, Thread[void]]
+    var count = 0
+    proc threadFunc() {.thread.} =
+      onceGlobal: count.inc
+      doAssert count == 1
+    for t in mitems(thr): t.createThread threadFunc
+    joinThreads(thr)
+
+  var witness {.global.}: bool
+  withLock lock:
+    if not witness:
+      witness = true
+      body
+
+template onceThread*(body: untyped) =
+  var witness {.threadvar.}: bool
+  if not witness:
+    witness = true
+    body

--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -21,7 +21,10 @@ template onceGlobal*(body: untyped) =
       body
 
 template onceThread*(body: untyped) =
-  var witness {.threadvar.}: bool
+  # var witness {.threadvar.}: bool
+  # var witness {.threadvar, inject.}: bool
+  var witness {.threadvar, global.}: bool
   if not witness:
+    echo "here"
     witness = true
     body

--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -1,27 +1,41 @@
 import std/locks
-import timn/dbgs
 
 var lock: Lock
-initLock(lock) # xxx instead, do this on 1st call to `onceGlobal`, using `atomic`.
+initLock(lock)
 
-template onceGlobal*(body: untyped) =
-  ## evaluate `body` once, even in presence of multiple threads.
+template onceGlobal*(retryOnFailure: bool, body: untyped) =
+  ## Evaluate `body` once, even in presence of multiple threads. If `body` is
+  ## executing in thread A, thread B will block until A returns from this block.
+  ## Each template instantiation of `onceGlobal` has its own lock to avoid blocking
+  ## each other.
+  ## If thread A raises, whether thread B re-executes `body` depends on whether
+  ## `retryOnFailure`.
   runnableExamples "--threads":
+    from std/os import sleep
     var thr: array[2, Thread[void]]
     var count = 0
+    var count2 = 0
     proc threadFunc() {.thread.} =
-      onceGlobal: count.inc
+      for j in 0..<3:
+        onceGlobal:
+          while count2 == 0: sleep(10)
+          count.inc
       doAssert count == 1
     for t in mitems(thr): t.createThread threadFunc
+    for j in 0..<3:
+      onceGlobal: # no deadlock, this has its own lock
+        sleep(10)
+        count2.inc
+    doAssert count2 == 1
     joinThreads(thr)
 
   var witness {.global.}: int
   var lock2 {.global.}: Lock
+
   # TODO is atomic needed?
   if witness < 2:
     withLock lock:
       if witness == 0:
-        # dbg "initLock", astToStr(lock2), astToStr(body)
         initLock(lock2)
         witness = 1
     # we release the single `lock` to avoid blocking unrelated `onceGlobal` calls.
@@ -30,15 +44,19 @@ template onceGlobal*(body: untyped) =
         if witness == 1:
           # TODO: add option `retryOnFailure`, see https://github.com/nim-lang/Nim/pull/16192/files#r540648534
           # and make sure we don't nest 2 levels of try/finally (withLock uses 1 already)
-          body
-          witness = 2
-            # this must occur after `body` otherwise next callers will return immediately
+          try:
+            # `witness = 2` must not occur before `body` otherwise next callers will return immediately
+            body
+            if retryOnFailure: witness = 2
+          finally:
+            if not retryOnFailure: witness = 2
+
+template onceGlobal*(body: untyped) =
+  ## overload with `retryOnFailure = false`.
+  onceGlobal(false, body)
 
 template onceThread*(body: untyped) =
-  # var witness {.threadvar.}: bool
-  # var witness {.threadvar, inject.}: bool
   var witness {.threadvar, global.}: bool
   if not witness:
-    echo "here"
-    witness = true
     body
+    witness = true

--- a/lib/std/threadutils.nim
+++ b/lib/std/threadutils.nim
@@ -1,9 +1,8 @@
 import std/locks
+import timn/dbgs
 
 var lock: Lock
-initLock(lock)
-
-# var lockSubs: seq[Lock]
+initLock(lock) # xxx instead, do this on 1st call to `onceGlobal`, using `atomic`.
 
 template onceGlobal*(body: untyped) =
   ## evaluate `body` once, even in presence of multiple threads.
@@ -16,20 +15,24 @@ template onceGlobal*(body: untyped) =
     for t in mitems(thr): t.createThread threadFunc
     joinThreads(thr)
 
-  var witness {.global.}: bool
-  # var lockIndex {.global.}: int
+  var witness {.global.}: int
+  var lock2 {.global.}: Lock
   # TODO is atomic needed?
-  if not witness:
-    # var lockSub {.global.}: Lock
-    # initLock(lock)
+  if witness < 2:
     withLock lock:
-      # lockSubs
-      if not witness:
-        witness = true
-        # this could take a while
-        # lockSubs
-        # lockIndex
-        body
+      if witness == 0:
+        # dbg "initLock", astToStr(lock2), astToStr(body)
+        initLock(lock2)
+        witness = 1
+    # we release the single `lock` to avoid blocking unrelated `onceGlobal` calls.
+    if witness == 1:
+      withLock lock2:
+        if witness == 1:
+          # TODO: add option `retryOnFailure`, see https://github.com/nim-lang/Nim/pull/16192/files#r540648534
+          # and make sure we don't nest 2 levels of try/finally (withLock uses 1 already)
+          body
+          witness = 2
+            # this must occur after `body` otherwise next callers will return immediately
 
 template onceThread*(body: untyped) =
   # var witness {.threadvar.}: bool

--- a/tests/stdlib/tthreadutils.nim
+++ b/tests/stdlib/tthreadutils.nim
@@ -2,17 +2,20 @@ discard """
 joinable: false
 """
 
+#[
+run with: `-d:nimTthreadutilsNum:10000` for stress testing
+]#
+
 when defined nimTthreadutilsSub:
   import std/threadutils
-  const N = 10
-  var thr: array[N, Thread[int]]
+  var thr: array[10, Thread[int]]
   var count = 0
   proc threadFunc(a: int) {.thread.} =
     onceGlobal: count.inc
     doAssert count == 1
   proc main =
-    for i in 0..<N:
-      createThread(thr[i], threadFunc, i)
+    for i, t in mpairs(thr):
+      t.createThread(threadFunc, i)
     joinThreads(thr)
   main()
 
@@ -20,14 +23,25 @@ else:
   from stdtest/specialpaths import buildDir
   import os, strformat
   proc main =
-    # const N = 10000 # for manual testing
-    const N = 100 # in CI, save some time
-    const nim = getCurrentCompilerExe()
-    const exe = buildDir / currentSourcePath.lastPathPart
-    const file = currentSourcePath
-    let cmd = fmt"{nim} c -d:nimTthreadutilsSub --threads -o:{exe} {file}"
-    doAssert execShellCmd(cmd) == 0
-    for i in 0..<N:
-      let ret = execShellCmd(exe)
-      doAssert ret == 0, $i
+    block: # onceGlobal
+      const nim = getCurrentCompilerExe()
+      const exe = buildDir / currentSourcePath.lastPathPart
+      const file = currentSourcePath
+      let cmd = fmt"{nim} c -d:nimTthreadutilsSub --threads -o:{exe} {file}"
+      doAssert execShellCmd(cmd) == 0
+      const nimTthreadutilsNum {.intdefine.} = 100 # in CI, save some time
+      for i in 0..<nimTthreadutilsNum:
+        let ret = execShellCmd(exe)
+        doAssert ret == 0, $i
+
   main()
+
+  import std/threadutils
+
+  block: #onceThread
+    var count = 0
+    for i in 0..<10:
+      onceThread:
+        count.inc
+        echo i
+    doAssert count == 1

--- a/tests/stdlib/tthreadutils.nim
+++ b/tests/stdlib/tthreadutils.nim
@@ -27,11 +27,14 @@ when defined nimTthreadutilsSub:
     var count = 0
     var count2 = 0
     proc threadFunc() {.thread.} =
-      for j in 0..<3:
-        onceGlobal:
-          while count2 == 0: sleep(10)
-          count.inc
-      doAssert count == 1
+      proc fnAux(m: int) =
+        for j in 0..<3:
+          onceGlobal:
+            while count2 == 0: sleep(10)
+            count.inc
+        doAssert count == 1
+        if m > 0: fnAux(m-1) # test for re-entrant code
+      fnAux(3)
     for t in mitems(thr): t.createThread threadFunc
     for j in 0..<3:
       onceGlobal: # no deadlock, this has its own lock
@@ -74,7 +77,7 @@ else:
       const nim = getCurrentCompilerExe()
       const exe = buildDir / currentSourcePath.lastPathPart
       const file = currentSourcePath
-      let cmd = fmt"{nim} c -d:nimTthreadutilsSub --threads -o:{exe} {file}"
+      let cmd = fmt"{nim} c -d:nimTthreadutilsSub --hints:off --threads -o:{exe} {file}"
       doAssert execShellCmd(cmd) == 0
       const nimTthreadutilsNum {.intdefine.} = 100 # in CI, save some time
       for i in 0..<nimTthreadutilsNum:
@@ -85,7 +88,7 @@ else:
 
   import std/threadutils
 
-  block: #onceThread
+  block: # `onceThread` basic example
     var count = 0
     for i in 0..<10:
       onceThread:
@@ -95,3 +98,26 @@ else:
     onceThread:
       count.inc
     doAssert count == 2
+
+  block: # `onceThread`, test for re-entrant code
+    var count = 0
+    var countCT {.compileTime.} = 0
+    proc fn(n: int) =
+      for i in 0..<3:
+        onceThread:
+          when nimvm:
+            countCT.inc
+          else:
+            count.inc
+      if n > 1:
+        fn(n-1)
+    proc main() =
+      fn(5)
+      fn(4)
+      when nimvm:
+        echo countCT
+        # doAssert countCT == 1 # fails
+      else:
+        doAssert count == 1
+    # static: main() # xxx support vm + js
+    main()

--- a/tests/stdlib/tthreadutils.nim
+++ b/tests/stdlib/tthreadutils.nim
@@ -1,0 +1,33 @@
+discard """
+joinable: false
+"""
+
+when defined nimTthreadutilsSub:
+  import std/threadutils
+  const N = 10
+  var thr: array[N, Thread[int]]
+  var count = 0
+  proc threadFunc(a: int) {.thread.} =
+    onceGlobal: count.inc
+    doAssert count == 1
+  proc main =
+    for i in 0..<N:
+      createThread(thr[i], threadFunc, i)
+    joinThreads(thr)
+  main()
+
+else:
+  from stdtest/specialpaths import buildDir
+  import os, strformat
+  proc main =
+    # const N = 10000 # for manual testing
+    const N = 100 # in CI, save some time
+    const nim = getCurrentCompilerExe()
+    const exe = buildDir / currentSourcePath.lastPathPart
+    const file = currentSourcePath
+    let cmd = fmt"{nim} c -d:nimTthreadutilsSub --threads -o:{exe} {file}"
+    doAssert execShellCmd(cmd) == 0
+    for i in 0..<N:
+      let ret = execShellCmd(exe)
+      doAssert ret == 0, $i
+  main()


### PR DESCRIPTION
* alternative to https://github.com/nim-lang/Nim/pull/16192 /cc @xflywind , simpler for client code to use since they don't to define an auxiliary `Once` variable, instead this works:
```nim
onceGlobal:
  someCode
onceGlobal:
  someOtherCode
onceGlobal(retryOnFailure = true):
  someOtherCodeThatMightRaise
```

* closes #8895
```nim
  ## Evaluate `body` once, even in presence of multiple threads. If `body` is
  ## executing in thread A, thread B will block until A returns from this block.
  ## Each template instantiation of `onceGlobal` has its own lock to avoid blocking
  ## each other.
  ## If thread A raises, whether thread B re-executes `body` depends on whether
  ## `retryOnFailure`.
```

## benchmark
comparing:
onceGlobal
onceThread
system.once
std/once from https://github.com/nim-lang/Nim/pull/16192
https://github.com/timotheecour/vitanim/blob/master/testcases/t10976_results.md


## TODO
- [ ] deprecate system.once which is buggy
- [ ] support js
- [ ] support vm
- [ ] also allow taking an optional `Once` object to allow more flexibility as to what executes once (eg: in case once per instantiation is not desired)