### PR TITLE
oids: switch from PRNG to random module

### DIFF
--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -52,7 +52,7 @@ proc parseOid*(str: cstring): Oid =
     inc(i)
 
 proc oidToString*(oid: Oid, str: cstring) =
-  ## Converts an oid to `str`.
+  ## Converts an oid to `str` which must have space allocated for 25 elements.
   const hex = "0123456789abcdef"
   # work around a compiler bug:
   var str = str
@@ -94,7 +94,3 @@ proc generatedTime*(oid: Oid): Time =
   var dummy = oid.time
   bigEndian32(addr(tmp), addr(dummy))
   result = fromUnix(tmp)
-
-when not defined(testing) and isMainModule:
-  let xo = genOid()
-  echo xo.generatedTime

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -76,7 +76,8 @@ var
   t = getTime().toUnix.int32
   seed = initRand(t)
   incr: int = seed.rand(0x7fff)
-  fuzz = int32(seed.rand(high(int32)))
+
+let fuzz = int32(seed.rand(high(int32)))
 
 proc genOid*(): Oid =
   ## Generates a new OID.

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -12,24 +12,24 @@
 ## produce a globally distributed unique ID. This implementation was extracted
 ## from the Mongodb interface and it thus binary compatible with a Mongo OID.
 ##
-## This implementation calls ``math.randomize()`` for the first call of
+## This implementation calls `random.randomize()` for the first call of
 ## ``genOid``.
 
-import hashes, times, endians
+import hashes, times, endians, random
 
 type
-  Oid* = object  ## an OID
+  Oid* = object  ## An OID.
     time: int32  ##
     fuzz: int32  ##
     count: int32 ##
 
 proc `==`*(oid1: Oid, oid2: Oid): bool =
-  ## Compare two Mongo Object IDs for equality
+  ## Compares two Mongo Object IDs for equality.
   return (oid1.time == oid2.time) and (oid1.fuzz == oid2.fuzz) and
           (oid1.count == oid2.count)
 
 proc hash*(oid: Oid): Hash =
-  ## Generate hash of Oid for use in hashtables
+  ## Generates hash of Oid for use in hashtables.
   var h: Hash = 0
   h = h !& hash(oid.time)
   h = h !& hash(oid.fuzz)
@@ -44,7 +44,7 @@ proc hexbyte*(hex: char): int =
   else: discard
 
 proc parseOid*(str: cstring): Oid =
-  ## parses an OID.
+  ## Parses an OID.
   var bytes = cast[cstring](addr(result.time))
   var i = 0
   while i < 12:
@@ -52,6 +52,7 @@ proc parseOid*(str: cstring): Oid =
     inc(i)
 
 proc oidToString*(oid: Oid, str: cstring) =
+  ## Converts a oid to `str`.
   const hex = "0123456789abcdef"
   # work around a compiler bug:
   var str = str
@@ -66,21 +67,20 @@ proc oidToString*(oid: Oid, str: cstring) =
   str[24] = '\0'
 
 proc `$`*(oid: Oid): string =
+  ## Converts a oid to string.
   result = newString(24)
   oidToString(oid, result)
 
-proc rand(): cint {.importc: "rand", header: "<stdlib.h>", nodecl.}
-proc srand(seed: cint) {.importc: "srand", header: "<stdlib.h>", nodecl.}
 
 var t = getTime().toUnix.int32
-srand(t)
+randomize(t)
 
 var
-  incr: int = rand()
-  fuzz: int32 = rand()
+  incr: int = rand(0x7fff)
+  fuzz = int32(rand(high(int32)))
 
 proc genOid*(): Oid =
-  ## generates a new OID.
+  ## Generates a new OID.
   t = getTime().toUnix.int32
   var i = int32(atomicInc(incr))
 
@@ -89,7 +89,7 @@ proc genOid*(): Oid =
   bigEndian32(addr result.count, addr(i))
 
 proc generatedTime*(oid: Oid): Time =
-  ## returns the generated timestamp of the OID.
+  ## Returns the generated timestamp of the OID.
   var tmp: int32
   var dummy = oid.time
   bigEndian32(addr(tmp), addr(dummy))

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -12,7 +12,7 @@
 ## produce a globally distributed unique ID. This implementation was extracted
 ## from the Mongodb interface and it thus binary compatible with a Mongo OID.
 ##
-## This implementation calls `random.randomize()` for the first call of
+## This implementation calls `initRand()` for the first call of
 ## ``genOid``.
 
 import hashes, times, endians, random

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -73,11 +73,11 @@ proc `$`*(oid: Oid): string =
 
 
 var t = getTime().toUnix.int32
-randomize(t)
+var seed = initRand(t)
 
 var
-  incr: int = rand(0x7fff)
-  fuzz = int32(rand(high(int32)))
+  incr: int = seed.rand(0x7fff)
+  fuzz = int32(seed.rand(high(int32)))
 
 proc genOid*(): Oid =
   ## Generates a new OID.

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -75,9 +75,9 @@ proc `$`*(oid: Oid): string =
 var
   t = getTime().toUnix.int32
   seed = initRand(t)
-  incr: int = seed.rand(0x7fff)
+  incr: int = seed.rand(int.high)
 
-let fuzz = int32(seed.rand(high(int32)))
+let fuzz = cast[int32](seed.rand(high(int)))
 
 proc genOid*(): Oid =
   ## Generates a new OID.
@@ -85,7 +85,7 @@ proc genOid*(): Oid =
     doAssert ($genOid()).len == 24
     if false: doAssert $genOid() == "5fc7f546ddbbc84800006aaf"
   t = getTime().toUnix.int32
-  var i = int32(atomicInc(incr))
+  var i = cast[int32](atomicInc(incr))
 
   bigEndian32(addr result.time, addr(t))
   result.fuzz = fuzz

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -52,7 +52,7 @@ proc parseOid*(str: cstring): Oid =
     inc(i)
 
 proc oidToString*(oid: Oid, str: cstring) =
-  ## Converts a oid to `str`.
+  ## Converts an oid to `str`.
   const hex = "0123456789abcdef"
   # work around a compiler bug:
   var str = str

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -67,7 +67,7 @@ proc oidToString*(oid: Oid, str: cstring) =
   str[24] = '\0'
 
 proc `$`*(oid: Oid): string =
-  ## Converts a oid to string.
+  ## Converts an oid to string.
   result = newString(24)
   oidToString(oid, result)
 

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -81,6 +81,9 @@ var
 
 proc genOid*(): Oid =
   ## Generates a new OID.
+  runnableExamples:
+    doAssert ($genOid()).len == 24
+    if false: doAssert $genOid() == "5fc7f546ddbbc84800006aaf"
   t = getTime().toUnix.int32
   var i = int32(atomicInc(incr))
 

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -72,10 +72,9 @@ proc `$`*(oid: Oid): string =
   oidToString(oid, result)
 
 
-var t = getTime().toUnix.int32
-var seed = initRand(t)
-
 var
+  t = getTime().toUnix.int32
+  seed = initRand(t)
   incr: int = seed.rand(0x7fff)
   fuzz = int32(seed.rand(high(int32)))
 

--- a/tests/stdlib/toids.nim
+++ b/tests/stdlib/toids.nim
@@ -1,0 +1,6 @@
+import std/oids
+
+
+block: # genOid
+  let x = genOid()
+  doAssert ($x).len == 24


### PR DESCRIPTION
`0x7fff` is enough to use and is often used as `RAND_MAX` in PRNG.
http://www.cplusplus.com/reference/cstdlib/RAND_MAX

- [ ] If this PR is acceptable, next PR will add a overload for `genOid` which accepts `Rand` as a parameter.

Benefits:
- More pure(more possible to work in JS backend)
- Benefits from the improvement from `random` module
- Random module also provides better interface(`initRand`, `next`) and could be used to improve `genOid`