### PR TITLE
move decode_helpers to std/private

### DIFF
--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -32,7 +32,7 @@
 import strutils, os, strtabs, cookies, uri
 export uri.encodeUrl, uri.decodeUrl
 
-include includes/decode_helpers
+import std/decode_helpers
 
 proc addXmlChar(dest: var string, c: char) {.inline.} =
   case c

--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -32,7 +32,7 @@
 import strutils, os, strtabs, cookies, uri
 export uri.encodeUrl, uri.decodeUrl
 
-import std/decode_helpers
+import std/private/decode_helpers
 
 proc addXmlChar(dest: var string, c: char) {.inline.} =
   case c

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -47,7 +47,7 @@
 import std/private/since
 
 import strutils, parseutils, base64
-include includes/decode_helpers
+import std/decode_helpers
 
 
 type

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -47,7 +47,7 @@
 import std/private/since
 
 import strutils, parseutils, base64
-import std/decode_helpers
+import std/private/decode_helpers
 
 
 type

--- a/lib/std/decode_helpers.nim
+++ b/lib/std/decode_helpers.nim
@@ -1,13 +1,11 @@
-# Include file that implements 'decodePercent' and friends. Do not import it!
-
-proc handleHexChar(c: char, x: var int, f: var bool) {.inline.} =
+proc handleHexChar*(c: char, x: var int, f: var bool) {.inline.} =
   case c
   of '0'..'9': x = (x shl 4) or (ord(c) - ord('0'))
   of 'a'..'f': x = (x shl 4) or (ord(c) - ord('a') + 10)
   of 'A'..'F': x = (x shl 4) or (ord(c) - ord('A') + 10)
   else: f = true
 
-proc decodePercent(s: string, i: var int): char =
+proc decodePercent*(s: string, i: var int): char =
   ## Converts `%xx` hexadecimal to the charracter with ordinal number `xx`.
   ##
   ## If `xx` is not a valid hexadecimal value, it is left intact: only the

--- a/lib/std/private/decode_helpers.nim
+++ b/lib/std/private/decode_helpers.nim
@@ -5,8 +5,8 @@ proc handleHexChar*(c: char, x: var int, f: var bool) {.inline.} =
   of 'A'..'F': x = (x shl 4) or (ord(c) - ord('A') + 10)
   else: f = true
 
-proc decodePercent*(s: string, i: var int): char =
-  ## Converts `%xx` hexadecimal to the charracter with ordinal number `xx`.
+proc decodePercent*(s: openArray[char], i: var int): char =
+  ## Converts `%xx` hexadecimal to the character with ordinal number `xx`.
   ##
   ## If `xx` is not a valid hexadecimal value, it is left intact: only the
   ## leading `%` is returned as-is, and `xx` characters will be processed in the


### PR DESCRIPTION
`handleHexChar` is very common to use in stdlib, let's export it!

compiler/lexer
```nim
proc handleHexChar(L: var Lexer, xi: var int; position: range[0..4])
```

lib/pure/parsecfg
```nim
proc handleHexChar(c: var CfgParser, xi: var int)
```

lib/pure/parsejson
```nim
proc handleHexChar(c: char, x: var int): bool
```

lib/pure/parsesql
```nim
proc handleHexChar(c: var SqlLexer, xi: var int)
```

lib/pure/pegs
```nim
proc handleHexChar(c: var PegLexer, xi: var int)
```

nimsuggest/sexps
```nim
proc handleHexChar(c: char, x: var int): bool
```

And uri and cgi module. They all share similar parts and could use `decode_helpers` instead!!!

- [ ] If this PR is acceptable, next PR I will clean them all.