### PR TITLE
[superseded] test ci_ssl.yml on each PR/push

### DIFF
--- a/.github/workflows/ci_ssl.yml
+++ b/.github/workflows/ci_ssl.yml
@@ -1,14 +1,18 @@
 name: Nim SSL CI
-on:
-  pull_request:
-    # Run only on changes on related files
-    paths:
-      - 'lib/pure/httpclient.nim'
-      - 'lib/pure/net.nim'
-      - 'lib/pure/ssl_certs.nim'
-      - 'lib/wrappers/openssl.nim'
-      - 'tests/stdlib/thttpclient_ssl*'
-      - 'tests/untestable/thttpclient_ssl*'
+on: [push, pull_request]
+# this used to be lazy but allowed in hard to find regressions, see
+# https://github.com/nim-lang/Nim/pull/16196#issuecomment-736773751
+
+# on:
+#   pull_request:
+#     # Run only on changes on related files
+#     paths:
+#       - 'lib/pure/httpclient.nim'
+#       - 'lib/pure/net.nim'
+#       - 'lib/pure/ssl_certs.nim'
+#       - 'lib/wrappers/openssl.nim'
+#       - 'tests/stdlib/thttpclient_ssl*'
+#       - 'tests/untestable/thttpclient_ssl*'
 
 jobs:
   build:


### PR DESCRIPTION
rationale: as noted in https://github.com/nim-lang/Nim/pull/16196#issuecomment-736773751, a regression was introduced at some unknown point in time but wasn't detected until https://github.com/nim-lang/Nim/pull/16196 because of the "lazy testing" logic in place.

This fixes that (at a small CI cost) by testing on each PR/push.

The logic behind `Run only on changes on related files` is too brittle and introduces hard to find regressions when they happen since we don't know when the bug was introduced and it could span a large number of commits.

note: this will probably fail (refs https://github.com/timotheecour/Nim/issues/410), because of a regression introduced at some point in the past.

## question for reviewers
why can't we simply remove `.github/workflows/ci_ssl.yml` and treat it as a normal test?
this simplifies testing logic (removing duplication in yml files) and reduces CI testing time (most of which is spent here on simply bootstrapping nim)

EDIT: potentially superseded by https://github.com/nim-lang/Nim/pull/16221 depending on how it goes
