### PR TITLE
add test for --eval; fix a minor bug

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -450,6 +450,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     conf.projectIsCmd = true
     conf.cmdInput = arg # can be empty (a nim file with empty content is valid too)
     if conf.cmd == cmdNone:
+      conf.command = "e"
       conf.setCmd cmdNimscript # better than `cmdCrun` as a default
       conf.implicitCmd = true
   of "path", "p":

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -216,3 +216,9 @@ mmain.html
     let file = testsDir / "misc/mimportc.nim"
     let cmd = fmt"{nim} r -b:cpp --hints:off --nimcache:{nimcache} --warningAsError:ProveInit {file}"
     check execCmdEx(cmd) == ("witness\n", 0)
+
+  block: # nim --eval
+    let opt = "--hints:off"
+    check fmt"""{nim} {opt} --eval:"echo defined(nimscript)"""".execCmdEx == ("true\n", 0)
+    check fmt"""{nim} r {opt} --eval:"echo defined(c)"""".execCmdEx == ("true\n", 0)
+    check fmt"""{nim} r -b:js {opt} --eval:"echo defined(js)"""".execCmdEx == ("true\n", 0)


### PR DESCRIPTION
fix this bug:
if user had
```nim 
task someTask, "some help":
  define "foobar"
```
in his user config, `nim --eval:'echo 1'` would show 
```
someTask some help
```

because of nimscript.nim:

```nim
    if cmd.len == 0 or cmd ==? "help":
      setCommand "help"
      writeTask(astToStr(name), description)
```

this PR fixes that, and adds a test for `--eval` which previously didn't have one