### PR TITLE
js module also uses runnableExamples

### DIFF
--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -12,26 +12,25 @@
 ## and ``JsAssoc`` together with the provided macros allows for smoother
 ## interfacing with JavaScript, allowing for example quick and easy imports of
 ## JavaScript variables:
-##
-## .. code-block:: nim
-##
-##  # Here, we are using jQuery for just a few calls and do not want to wrap the
-##  # whole library:
-##
-##  # import the document object and the console
-##  var document {.importc, nodecl.}: JsObject
-##  var console {.importc, nodecl.}: JsObject
-##  # import the "$" function
-##  proc jq(selector: JsObject): JsObject {.importcpp: "$$(#)".}
-##
-##  # Use jQuery to make the following code run, after the document is ready.
-##  # This uses an experimental ``.()`` operator for ``JsObject``, to emit
-##  # JavaScript calls, when no corresponding proc exists for ``JsObject``.
-##  proc main =
-##    jq(document).ready(proc() =
-##      console.log("Hello JavaScript!")
-##    )
-##
+
+runnableExamples:
+  # Here, we are using jQuery for just a few calls and do not want to wrap the
+  # whole library:
+
+  # import the document object and the console
+  var document {.importc, nodecl.}: JsObject
+  var console {.importc, nodecl.}: JsObject
+  # import the "$" function
+  proc jq(selector: JsObject): JsObject {.importcpp: "$$(#)".}
+
+  # Use jQuery to make the following code run, after the document is ready.
+  # This uses an experimental ``.()`` operator for ``JsObject``, to emit
+  # JavaScript calls, when no corresponding proc exists for ``JsObject``.
+  proc main =
+    jq(document).ready(proc() =
+      console.log("Hello JavaScript!")
+    )
+
 
 when not defined(js) and not defined(nimdoc) and not defined(nimsuggest):
   {.fatal: "Module jsFFI is designed to be used with the JavaScript backend.".}
@@ -221,14 +220,10 @@ proc `==`*(x, y: JsRoot): bool {.importcpp: "(# === #)".}
 macro `.`*(obj: JsObject, field: untyped): JsObject =
   ## Experimental dot accessor (get) for type JsObject.
   ## Returns the value of a property of name `field` from a JsObject `x`.
-  ##
-  ## Example:
-  ##
-  ## .. code-block:: nim
-  ##
-  ##  let obj = newJsObject()
-  ##  obj.a = 20
-  ##  console.log(obj.a) # puts 20 onto the console.
+  runnableExamples:
+    let obj = newJsObject()
+    obj.a = 20
+    assert obj.a.to(int) == 20
   if validJsName($field):
     let importString = "#." & $field
     result = quote do:

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -1,17 +1,14 @@
 ## Regular Expressions for the JavaScript target.
 ## * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-##
-## Examples
-## ========
-##
-## .. code-block::nim
-##   let jsregex: RegExp = newRegExp(r"\s+", r"i")
-##   jsregex.compile(r"\w+", r"i")
-##   doAssert jsregex.test(r"nim javascript")
-##   doAssert jsregex.exec(r"nim javascript") == @["nim".cstring]
-##   doAssert jsregex.toString() == r"/\w+/i"
-##   jsregex.compile(r"[0-9]", r"i")
-##   doAssert jsregex.test(r"0123456789abcd")
+
+runnableExamples:
+  let jsregex: RegExp = newRegExp(r"\s+", r"i")
+  jsregex.compile(r"\w+", r"i")
+  doAssert jsregex.test(r"nim javascript")
+  doAssert jsregex.exec(r"nim javascript") == @["nim".cstring]
+  doAssert jsregex.toString() == r"/\w+/i"
+  jsregex.compile(r"[0-9]", r"i")
+  doAssert jsregex.test(r"0123456789abcd")
 
 
 when not defined(js) and not defined(Nimdoc):


### PR DESCRIPTION
`koch temp doc -b:js lib/js/jsffi` to generate docs.