### PR TITLE
minor fix to Posix part of walkDir

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2129,13 +2129,15 @@ iterator walkDir*(dir: string; relative = false, checkDir = false):
 
             when defined(linux) or defined(macosx) or
                  defined(bsd) or defined(genode) or defined(nintendoswitch):
-              if x.d_type != DT_UNKNOWN:
-                if x.d_type == DT_DIR: k = pcDir
-                if x.d_type == DT_LNK:
-                  if dirExists(path): k = pcLinkToDir
-                  else: k = pcLinkToFile
-              else:
+              case x.d_type
+              of DT_DIR: k = pcDir
+              of DT_LNK:
+                if dirExists(path): k = pcLinkToDir
+                else: k = pcLinkToFile
+              of DT_UNKNOWN:
                 kSetGeneric()
+              else: # e.g. DT_REG etc
+                discard # leave it as pcFile
             else:  # assuming that field `d_type` is not present
               kSetGeneric()
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2122,7 +2122,7 @@ iterator walkDir*(dir: string; relative = false, checkDir = false):
 
             template kSetGeneric() =  # pure Posix component `k` resolution
               if lstat(path, s) < 0'i32: continue  # don't yield
-              if S_ISDIR(s.st_mode):
+              elif S_ISDIR(s.st_mode):
                 k = pcDir
               elif S_ISLNK(s.st_mode):
                 k = getSymlinkFileKind(path)


### PR DESCRIPTION
It's modified to be one-yield-style.
The logic is the same as before: there is a default part to check `dirent` (that is enabled for Linux, MacOS, BSD) and fall-back to generic Posix check if `d_type` from `dirent` is unknown.
Also notice change break->continue in the generic-Posix branch. I think using break is an obvious mistake since `lstat` can fail by multiple reasons, for example if symlink is leading to permission denied area or the loop is detected, and `walkDir` should not be interrupted because of those errors. I think this mistake was not noticed because generic-Posix branch is rarely used on the popular systems mentioned (though allegedly it can be seen even on Linux with XFS filesystem in a huge directory). cc @timotheecour 