### PR TITLE
Mention std/enumerate by name

### DIFF
--- a/lib/std/enumerate.nim
+++ b/lib/std/enumerate.nim
@@ -7,8 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-## This module implements `enumerate` syntactic sugar based on Nim's
-## macro system.
+## The ``std/enumerate`` module implements `enumerate` syntactic sugar
+## based on Nim's macro system.
 
 import std/private/since
 import macros


### PR DESCRIPTION
Certainly on me, but I couldn't figure out how to import this module. Also conforms to what [other std modules](https://nim-lang.org/docs/monotimes.html) do.