### PR TITLE
bring back argparse

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -9,7 +9,7 @@ var packages2*: seq[tuple[name, cmd: string; url: string, useHead: bool]] = @[]
 
 # packages A-M
 # pkg1 "alea"
-# pkg1 "argparse"
+pkg1 "argparse"
 pkg1 "arraymancer", "nim c tests/tests_cpu.nim"
 # pkg1 "ast_pattern_matching", "nim c -r --oldgensym:on tests/test1.nim"
 pkg1 "awk"


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/15987

with commit
```
commit c731f7ab149a539782b0b000853ecef058bc3dde (upstream/devel)
Author: Timothee Cour <timothee.cour2@gmail.com>
Date:   Thu Dec 3 07:55:43 2020 -0800

    fixes #15939, fixes #15464, fixes #16169, fixes #16226 VM now supports `addr(mystring[ind])` (index + index assignment) (#15987)
```