### PR TITLE
Fixes N_LIB_IMPORT breaking C++ linker

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -219,7 +219,7 @@ __AVR__
 #  endif
 #  define N_LIB_EXPORT NIM_EXTERNC __attribute__((visibility("default")))
 #  define N_LIB_EXPORT_VAR  __attribute__((visibility("default")))
-#  define N_LIB_IMPORT  extern
+#  define N_LIB_IMPORT NIM_EXTERNC
 #endif
 
 #define N_NOCONV(rettype, name) rettype name


### PR DESCRIPTION
So I'm not an expert with these decorations, but with the code as-is currently I get the following error when trying to compile my ESP32 program that I compiled with `--app:lib` (for a workaround to #16249):

```
Linking /tmp/mkESP/sketch_esp32/sketch.bin
  Versions: 617169f-dirty, 1.0.4
/tmp/mkESP/sketch_esp32/user_obj.ar(sketch.cpp.o):(.literal._Z5setupv+0xa0): undefined reference to `NimMain()'
/tmp/mkESP/sketch_esp32/user_obj.ar(sketch.cpp.o): In function `setup()':
../hardware/sketch.cpp:231: undefined reference to `NimMain()'
```

I believe the bug is in this line, mainly because it hasn't been modified for 13 years(!).

![image](https://user-images.githubusercontent.com/246651/101241889-07749b00-36f2-11eb-8bb4-916330b6e4dd.png)
