### PR TITLE
use nimlint to enforce best practices

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -18,13 +18,10 @@
 ##
 ## The above output could be the result of a code snippet like:
 ##
-## .. code-block:: nim
-##
-##   if detectOs(Ubuntu):
-##     foreignDep "lbiblas-dev"
-##     foreignDep "libvoodoo"
-##
-##
+runnableExamples:
+  if detectOs(Ubuntu):
+    foreignDep "lbiblas-dev"
+    foreignDep "libvoodoo"
 ## See `packaging <packaging.html>`_ for hints on distributing Nim using OS packages.
 
 from strutils import contains, toLowerAscii
@@ -201,7 +198,7 @@ proc detectOsImpl(d: Distribution): bool =
 
 template detectOs*(d: untyped): bool =
   ## Distro/OS detection. For convenience the
-  ## required ``Distribution.`` qualifier is added to the
+  ## required `Distribution.` qualifier is added to the
   ## enum value.
   detectOsImpl(Distribution.d)
 


### PR DESCRIPTION
Ref RFC https://github.com/timotheecour/Nim/issues/415 and https://github.com/nim-compiler-dev/nimlint

Before this PR

```
D:\QQPCmgr\Desktop\Nim>nimlint -i=lib/pure/distros.nim -o:out.nim --verbose=true
[lint] hintCodeBlocks: D:\QQPCmgr\Desktop\Nim\lib\pure\distros.nim(21)
code blocks => runnableExamples

[lint] hintBackticks: D:\QQPCmgr\Desktop\Nim\lib\pure\distros.nim(204)
double backticks => single backtick
```

After this PR

```
D:\QQPCmgr\Desktop\Nim>nimlint -i=lib/pure/distros.nim -o:out.nim --verbose=true

```