### PR TITLE
[JS] Resolved variable's being considered indirect, making interop easier.

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1288,7 +1288,7 @@ template isIndirect(x: PSym): bool =
     #(mapType(v.typ) != etyObject) and
     {sfImportc, sfExportc} * v.flags == {} and
     v.kind notin {skProc, skFunc, skConverter, skMethod, skIterator,
-                  skConst, skTemp, skLet})
+                  skConst, skTemp, skLet, skVar})
 
 proc genAddr(p: PProc, n: PNode, r: var TCompRes) =
   case n[0].kind


### PR DESCRIPTION
Prior to this change the JS emitted code for variables would always be considered indirect resulting in the following Nim code emitting the following JS. Which I believe to be wrong as it made the interoping require accessing `[0]` of an array if passed to native js.
```nim
import jsffi
var t = jsNull
t = newJsObject()
```
```js
var t_2616014 = [null];
t_2616014[0] = {};
```