### PR TITLE
math.nim: Use `func` everywhere

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -71,12 +71,12 @@ func binom*(n, k: int): int =
   for i in countup(2, k):
     result = (result * (n + 1 - i)) div i
 
-proc createFactTable[N: static[int]]: array[N, int] =
+func createFactTable[N: static[int]]: array[N, int] =
   result[0] = 1
   for i in 1 ..< N:
     result[i] = result[i - 1] * i
 
-proc fac*(n: int): int =
+func fac*(n: int): int =
   ## Computes the `factorial <https://en.wikipedia.org/wiki/Factorial>`_ of
   ## a non-negative integer ``n``.
   ##
@@ -133,7 +133,7 @@ type
     fcInf,           ## value is positive infinity
     fcNegInf         ## value is negative infinity
 
-proc classify*(x: float): FloatClass =
+func classify*(x: float): FloatClass =
   ## Classifies a floating point value.
   ##
   ## Returns ``x``'s class as specified by `FloatClass enum<#FloatClass>`_.
@@ -258,7 +258,7 @@ func prod*[T](x: openArray[T]): T =
   result = 1.T
   for i in items(x): result = result * i
 
-proc cumsummed*[T](x: openArray[T]): seq[T] =
+func cumsummed*[T](x: openArray[T]): seq[T] =
   ## Return cumulative (aka prefix) summation of ``x``.
   ##
   ## See also:
@@ -271,7 +271,7 @@ proc cumsummed*[T](x: openArray[T]): seq[T] =
   result[0] = x[0]
   for i in 1 ..< x.len: result[i] = result[i-1] + x[i]
 
-proc cumsum*[T](x: var openArray[T]) =
+func cumsum*[T](x: var openArray[T]) =
   ## Transforms ``x`` in-place (must be declared as `var`) into its
   ## cumulative (aka prefix) summation.
   ##
@@ -952,7 +952,7 @@ func splitDecimal*[T: float32|float64](x: T): tuple[intpart: T, floatpart: T] =
     result.floatpart = -result.floatpart
 
 
-proc degToRad*[T: float32|float64](d: T): T {.inline.} =
+func degToRad*[T: float32|float64](d: T): T {.inline.} =
   ## Convert from degrees to radians.
   ##
   ## See also:
@@ -962,7 +962,7 @@ proc degToRad*[T: float32|float64](d: T): T {.inline.} =
     doAssert degToRad(180.0) == 3.141592653589793
   result = T(d) * RadPerDeg
 
-proc radToDeg*[T: float32|float64](d: T): T {.inline.} =
+func radToDeg*[T: float32|float64](d: T): T {.inline.} =
   ## Convert from radians to degrees.
   ##
   ## See also:
@@ -972,7 +972,7 @@ proc radToDeg*[T: float32|float64](d: T): T {.inline.} =
     doAssert radToDeg(2 * PI) == 360.0
   result = T(d) / RadPerDeg
 
-proc sgn*[T: SomeNumber](x: T): int {.inline.} =
+func sgn*[T: SomeNumber](x: T): int {.inline.} =
   ## Sign function.
   ##
   ## Returns:
@@ -989,7 +989,7 @@ proc sgn*[T: SomeNumber](x: T): int {.inline.} =
 {.pop.}
 {.pop.}
 
-proc `^`*[T: SomeNumber](x: T, y: Natural): T =
+func `^`*[T: SomeNumber](x: T, y: Natural): T =
   ## Computes ``x`` to the power ``y``.
   ##
   ## Exponent ``y`` must be non-negative, use
@@ -1024,7 +1024,7 @@ proc `^`*[T: SomeNumber](x: T, y: Natural): T =
         break
       x *= x
 
-proc gcd*[T](x, y: T): T =
+func gcd*[T](x, y: T): T =
   ## Computes the greatest common (positive) divisor of ``x`` and ``y``.
   ##
   ## Note that for floats, the result cannot always be interpreted as
@@ -1042,7 +1042,7 @@ proc gcd*[T](x, y: T): T =
     swap x, y
   abs x
 
-proc gcd*(x, y: SomeInteger): SomeInteger =
+func gcd*(x, y: SomeInteger): SomeInteger =
   ## Computes the greatest common (positive) divisor of ``x`` and ``y``,
   ## using binary GCD (aka Stein's) algorithm.
   ##
@@ -1075,7 +1075,7 @@ proc gcd*(x, y: SomeInteger): SomeInteger =
     x -= y
   y shl shift
 
-proc gcd*[T](x: openArray[T]): T {.since: (1, 1).} =
+func gcd*[T](x: openArray[T]): T {.since: (1, 1).} =
   ## Computes the greatest common (positive) divisor of the elements of ``x``.
   ##
   ## See also:
@@ -1088,7 +1088,7 @@ proc gcd*[T](x: openArray[T]): T {.since: (1, 1).} =
     result = gcd(result, x[i])
     inc(i)
 
-proc lcm*[T](x, y: T): T =
+func lcm*[T](x, y: T): T =
   ## Computes the least common multiple of ``x`` and ``y``.
   ##
   ## See also:
@@ -1098,7 +1098,7 @@ proc lcm*[T](x, y: T): T =
     doAssert lcm(13, 39) == 39
   x div gcd(x, y) * y
 
-proc lcm*[T](x: openArray[T]): T {.since: (1, 1).} =
+func lcm*[T](x: openArray[T]): T {.since: (1, 1).} =
   ## Computes the least common multiple of the elements of ``x``.
   ##
   ## See also:

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -845,7 +845,7 @@ func floorDiv*[T: SomeInteger](x, y: T): T =
 func floorMod*[T: SomeNumber](x, y: T): T =
   ## Floor modulus is conceptually defined as ``x - (floorDiv(x, y) * y)``.
   ##
-  ## This proc behaves the same as the ``%`` operator in Python.
+  ## This func behaves the same as the ``%`` operator in Python.
   ##
   ## See also:
   ## * `mod func <#mod,float64,float64>`_

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -81,7 +81,7 @@ func fac*(n: int): int =
   ## a non-negative integer ``n``.
   ##
   ## See also:
-  ## * `prod proc <#prod,openArray[T]>`_
+  ## * `prod func <#prod,openArray[T]>`_
   runnableExamples:
     doAssert fac(3) == 6
     doAssert fac(4) == 24
@@ -124,7 +124,7 @@ const
 type
   FloatClass* = enum ## Describes the class a floating point value belongs to.
                      ## This is the type that is returned by
-                     ## `classify proc <#classify,float>`_.
+                     ## `classify func <#classify,float>`_.
     fcNormal,        ## value is an ordinary nonzero floating point value
     fcSubnormal,     ## value is a subnormal (a very small) floating point value
     fcZero,          ## value is zero
@@ -198,7 +198,7 @@ func isPowerOfTwo*(x: int): bool =
   ## Zero and negative numbers are not a power of two.
   ##
   ## See also:
-  ## * `nextPowerOfTwo proc<#nextPowerOfTwo,int>`_
+  ## * `nextPowerOfTwo func<#nextPowerOfTwo,int>`_
   runnableExamples:
     doAssert isPowerOfTwo(16) == true
     doAssert isPowerOfTwo(5) == false
@@ -212,7 +212,7 @@ func nextPowerOfTwo*(x: int): int =
   ## Zero and negative numbers get rounded up to 1.
   ##
   ## See also:
-  ## * `isPowerOfTwo proc<#isPowerOfTwo,int>`_
+  ## * `isPowerOfTwo func<#isPowerOfTwo,int>`_
   runnableExamples:
     doAssert nextPowerOfTwo(16) == 16
     doAssert nextPowerOfTwo(5) == 8
@@ -236,9 +236,9 @@ func sum*[T](x: openArray[T]): T =
   ## If ``x`` is empty, 0 is returned.
   ##
   ## See also:
-  ## * `prod proc <#prod,openArray[T]>`_
-  ## * `cumsum proc <#cumsum,openArray[T]>`_
-  ## * `cumsummed proc <#cumsummed,openArray[T]>`_
+  ## * `prod func <#prod,openArray[T]>`_
+  ## * `cumsum func <#cumsum,openArray[T]>`_
+  ## * `cumsummed func <#cumsummed,openArray[T]>`_
   runnableExamples:
     doAssert sum([1, 2, 3, 4]) == 10
     doAssert sum([-1.5, 2.7, -0.1]) == 1.1
@@ -250,8 +250,8 @@ func prod*[T](x: openArray[T]): T =
   ## If ``x`` is empty, 1 is returned.
   ##
   ## See also:
-  ## * `sum proc <#sum,openArray[T]>`_
-  ## * `fac proc <#fac,int>`_
+  ## * `sum func <#sum,openArray[T]>`_
+  ## * `fac func <#fac,int>`_
   runnableExamples:
     doAssert prod([1, 2, 3, 4]) == 24
     doAssert prod([-4, 3, 5]) == -60
@@ -262,8 +262,8 @@ func cumsummed*[T](x: openArray[T]): seq[T] =
   ## Return cumulative (aka prefix) summation of ``x``.
   ##
   ## See also:
-  ## * `sum proc <#sum,openArray[T]>`_
-  ## * `cumsum proc <#cumsum,openArray[T]>`_ for the in-place version
+  ## * `sum func <#sum,openArray[T]>`_
+  ## * `cumsum func <#cumsum,openArray[T]>`_ for the in-place version
   runnableExamples:
     let a = [1, 2, 3, 4]
     doAssert cumsummed(a) == @[1, 3, 6, 10]
@@ -276,8 +276,8 @@ func cumsum*[T](x: var openArray[T]) =
   ## cumulative (aka prefix) summation.
   ##
   ## See also:
-  ## * `sum proc <#sum,openArray[T]>`_
-  ## * `cumsummed proc <#cumsummed,openArray[T]>`_ for a version which
+  ## * `sum func <#sum,openArray[T]>`_
+  ## * `cumsummed func <#cumsummed,openArray[T]>`_ for a version which
   ##   returns cumsummed sequence
   runnableExamples:
     var a = [1, 2, 3, 4]
@@ -291,7 +291,7 @@ when not defined(js): # C
     ## Computes the square root of ``x``.
     ##
     ## See also:
-    ## * `cbrt proc <#cbrt,float64>`_ for cubic root
+    ## * `cbrt func <#cbrt,float64>`_ for cubic root
     ##
     ## .. code-block:: nim
     ##  echo sqrt(4.0)  ## 2.0
@@ -302,7 +302,7 @@ when not defined(js): # C
     ## Computes the cubic root of ``x``.
     ##
     ## See also:
-    ## * `sqrt proc <#sqrt,float64>`_ for square root
+    ## * `sqrt func <#sqrt,float64>`_ for square root
     ##
     ## .. code-block:: nim
     ##  echo cbrt(8.0)   ## 2.0
@@ -314,10 +314,10 @@ when not defined(js): # C
     ## of ``x``.
     ##
     ## See also:
-    ## * `log proc <#log,T,T>`_
-    ## * `log10 proc <#log10,float64>`_
-    ## * `log2 proc <#log2,float64>`_
-    ## * `exp proc <#exp,float64>`_
+    ## * `log func <#log,T,T>`_
+    ## * `log10 func <#log10,float64>`_
+    ## * `log2 func <#log2,float64>`_
+    ## * `exp func <#exp,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo ln(exp(4.0)) ## 4.0
@@ -338,10 +338,10 @@ func log*[T: SomeFloat](x, base: T): T =
   ## Computes the logarithm of ``x`` to base ``base``.
   ##
   ## See also:
-  ## * `ln proc <#ln,float64>`_
-  ## * `log10 proc <#log10,float64>`_
-  ## * `log2 proc <#log2,float64>`_
-  ## * `exp proc <#exp,float64>`_
+  ## * `ln func <#ln,float64>`_
+  ## * `log10 func <#log10,float64>`_
+  ## * `log2 func <#log2,float64>`_
+  ## * `exp func <#exp,float64>`_
   ##
   ## .. code-block:: nim
   ##  echo log(9.0, 3.0)  ## 2.0
@@ -357,10 +357,10 @@ when not defined(js): # C
     ## Computes the common logarithm (base 10) of ``x``.
     ##
     ## See also:
-    ## * `ln proc <#ln,float64>`_
-    ## * `log proc <#log,T,T>`_
-    ## * `log2 proc <#log2,float64>`_
-    ## * `exp proc <#exp,float64>`_
+    ## * `ln func <#ln,float64>`_
+    ## * `log func <#log,T,T>`_
+    ## * `log2 func <#log2,float64>`_
+    ## * `exp func <#exp,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo log10(100.0)  ## 2.0
@@ -371,10 +371,10 @@ when not defined(js): # C
     ## Computes the exponential function of ``x`` (e^x).
     ##
     ## See also:
-    ## * `ln proc <#ln,float64>`_
-    ## * `log proc <#log,T,T>`_
-    ## * `log10 proc <#log10,float64>`_
-    ## * `log2 proc <#log2,float64>`_
+    ## * `ln func <#ln,float64>`_
+    ## * `log func <#log,T,T>`_
+    ## * `log10 func <#log10,float64>`_
+    ## * `log2 func <#log2,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo exp(1.0)     ## 2.718281828459045
@@ -386,10 +386,10 @@ when not defined(js): # C
     ## Computes the sine of ``x``.
     ##
     ## See also:
-    ## * `cos proc <#cos,float64>`_
-    ## * `tan proc <#tan,float64>`_
-    ## * `arcsin proc <#arcsin,float64>`_
-    ## * `sinh proc <#sinh,float64>`_
+    ## * `cos func <#cos,float64>`_
+    ## * `tan func <#tan,float64>`_
+    ## * `arcsin func <#arcsin,float64>`_
+    ## * `sinh func <#sinh,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo sin(PI / 6)         ## 0.4999999999999999
@@ -399,10 +399,10 @@ when not defined(js): # C
     ## Computes the cosine of ``x``.
     ##
     ## See also:
-    ## * `sin proc <#sin,float64>`_
-    ## * `tan proc <#tan,float64>`_
-    ## * `arccos proc <#arccos,float64>`_
-    ## * `cosh proc <#cosh,float64>`_
+    ## * `sin func <#sin,float64>`_
+    ## * `tan func <#tan,float64>`_
+    ## * `arccos func <#arccos,float64>`_
+    ## * `cosh func <#cosh,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo cos(2 * PI)         ## 1.0
@@ -412,10 +412,10 @@ when not defined(js): # C
     ## Computes the tangent of ``x``.
     ##
     ## See also:
-    ## * `sin proc <#sin,float64>`_
-    ## * `cos proc <#cos,float64>`_
-    ## * `arctan proc <#arctan,float64>`_
-    ## * `tanh proc <#tanh,float64>`_
+    ## * `sin func <#sin,float64>`_
+    ## * `cos func <#cos,float64>`_
+    ## * `arctan func <#arctan,float64>`_
+    ## * `tanh func <#tanh,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo tan(degToRad(45.0)) ## 0.9999999999999999
@@ -425,10 +425,10 @@ when not defined(js): # C
     ## Computes the `hyperbolic sine <https://en.wikipedia.org/wiki/Hyperbolic_function#Definitions>`_ of ``x``.
     ##
     ## See also:
-    ## * `cosh proc <#cosh,float64>`_
-    ## * `tanh proc <#tanh,float64>`_
-    ## * `arcsinh proc <#arcsinh,float64>`_
-    ## * `sin proc <#sin,float64>`_
+    ## * `cosh func <#cosh,float64>`_
+    ## * `tanh func <#tanh,float64>`_
+    ## * `arcsinh func <#arcsinh,float64>`_
+    ## * `sin func <#sin,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo sinh(0.0)            ## 0.0
@@ -439,10 +439,10 @@ when not defined(js): # C
     ## Computes the `hyperbolic cosine <https://en.wikipedia.org/wiki/Hyperbolic_function#Definitions>`_ of ``x``.
     ##
     ## See also:
-    ## * `sinh proc <#sinh,float64>`_
-    ## * `tanh proc <#tanh,float64>`_
-    ## * `arccosh proc <#arccosh,float64>`_
-    ## * `cos proc <#cos,float64>`_
+    ## * `sinh func <#sinh,float64>`_
+    ## * `tanh func <#tanh,float64>`_
+    ## * `arccosh func <#arccosh,float64>`_
+    ## * `cos func <#cos,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo cosh(0.0)            ## 1.0
@@ -453,10 +453,10 @@ when not defined(js): # C
     ## Computes the `hyperbolic tangent <https://en.wikipedia.org/wiki/Hyperbolic_function#Definitions>`_ of ``x``.
     ##
     ## See also:
-    ## * `sinh proc <#sinh,float64>`_
-    ## * `cosh proc <#cosh,float64>`_
-    ## * `arctanh proc <#arctanh,float64>`_
-    ## * `tan proc <#tan,float64>`_
+    ## * `sinh func <#sinh,float64>`_
+    ## * `cosh func <#cosh,float64>`_
+    ## * `arctanh func <#arctanh,float64>`_
+    ## * `tan func <#tan,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo tanh(0.0)            ## 0.0
@@ -468,10 +468,10 @@ when not defined(js): # C
     ## Computes the arc cosine of ``x``.
     ##
     ## See also:
-    ## * `arcsin proc <#arcsin,float64>`_
-    ## * `arctan proc <#arctan,float64>`_
-    ## * `arctan2 proc <#arctan2,float64,float64>`_
-    ## * `cos proc <#cos,float64>`_
+    ## * `arcsin func <#arcsin,float64>`_
+    ## * `arctan func <#arctan,float64>`_
+    ## * `arctan2 func <#arctan2,float64,float64>`_
+    ## * `cos func <#cos,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo radToDeg(arccos(0.0)) ## 90.0
@@ -481,10 +481,10 @@ when not defined(js): # C
     ## Computes the arc sine of ``x``.
     ##
     ## See also:
-    ## * `arccos proc <#arccos,float64>`_
-    ## * `arctan proc <#arctan,float64>`_
-    ## * `arctan2 proc <#arctan2,float64,float64>`_
-    ## * `sin proc <#sin,float64>`_
+    ## * `arccos func <#arccos,float64>`_
+    ## * `arctan func <#arctan,float64>`_
+    ## * `arctan2 func <#arctan2,float64,float64>`_
+    ## * `sin func <#sin,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo radToDeg(arcsin(0.0)) ## 0.0
@@ -494,10 +494,10 @@ when not defined(js): # C
     ## Calculate the arc tangent of ``x``.
     ##
     ## See also:
-    ## * `arcsin proc <#arcsin,float64>`_
-    ## * `arccos proc <#arccos,float64>`_
-    ## * `arctan2 proc <#arctan2,float64,float64>`_
-    ## * `tan proc <#tan,float64>`_
+    ## * `arcsin func <#arcsin,float64>`_
+    ## * `arccos func <#arccos,float64>`_
+    ## * `arctan2 func <#arctan2,float64,float64>`_
+    ## * `tan func <#tan,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo arctan(1.0) ## 0.7853981633974483
@@ -511,10 +511,10 @@ when not defined(js): # C
     ## pi/2 or -pi/2 (``x`` near 0).
     ##
     ## See also:
-    ## * `arcsin proc <#arcsin,float64>`_
-    ## * `arccos proc <#arccos,float64>`_
-    ## * `arctan proc <#arctan,float64>`_
-    ## * `tan proc <#tan,float64>`_
+    ## * `arcsin func <#arcsin,float64>`_
+    ## * `arccos func <#arccos,float64>`_
+    ## * `arctan func <#arctan,float64>`_
+    ## * `tan func <#tan,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo arctan2(1.0, 0.0) ## 1.570796326794897
@@ -596,12 +596,12 @@ when not defined(js): # C
   func pow*(x, y: float64): float64 {.importc: "pow", header: "<math.h>".}
     ## Computes x to power raised of y.
     ##
-    ## To compute power between integers (e.g. 2^6), use `^ proc<#^,T,Natural>`_.
+    ## To compute power between integers (e.g. 2^6), use `^ func<#^,T,Natural>`_.
     ##
     ## See also:
-    ## * `^ proc<#^,T,Natural>`_
-    ## * `sqrt proc <#sqrt,float64>`_
-    ## * `cbrt proc <#cbrt,float64>`_
+    ## * `^ func<#^,T,Natural>`_
+    ## * `sqrt func <#sqrt,float64>`_
+    ## * `cbrt func <#cbrt,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo pow(100, 1.5)  ## 1000.0
@@ -626,7 +626,7 @@ when not defined(js): # C
       ## Note: Not available for JS backend.
       ##
       ## See also:
-      ## * `lgamma proc <#lgamma,float64>`_ for a natural log of gamma function
+      ## * `lgamma func <#lgamma,float64>`_ for a natural log of gamma function
       ##
       ## .. code-block:: Nim
       ##  echo gamma(1.0)  # 1.0
@@ -640,7 +640,7 @@ when not defined(js): # C
       ## Note: Not available for JS backend.
       ##
       ## See also:
-      ## * `gamma proc <#gamma,float64>`_ for gamma function
+      ## * `gamma func <#gamma,float64>`_ for gamma function
       ##
       ## .. code-block:: Nim
       ##  echo lgamma(1.0)  # 1.0
@@ -653,9 +653,9 @@ when not defined(js): # C
     ## Computes the floor function (i.e., the largest integer not greater than ``x``).
     ##
     ## See also:
-    ## * `ceil proc <#ceil,float64>`_
-    ## * `round proc <#round,float64>`_
-    ## * `trunc proc <#trunc,float64>`_
+    ## * `ceil func <#ceil,float64>`_
+    ## * `round func <#round,float64>`_
+    ## * `trunc func <#trunc,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo floor(2.1)  ## 2.0
@@ -668,9 +668,9 @@ when not defined(js): # C
     ## than ``x``).
     ##
     ## See also:
-    ## * `floor proc <#floor,float64>`_
-    ## * `round proc <#round,float64>`_
-    ## * `trunc proc <#trunc,float64>`_
+    ## * `floor func <#floor,float64>`_
+    ## * `round func <#round,float64>`_
+    ## * `trunc func <#trunc,float64>`_
     ##
     ## .. code-block:: nim
     ##  echo ceil(2.1)  ## 3.0
@@ -737,15 +737,15 @@ when not defined(js): # C
     func round*(x: float64): float64 {.importc: "round", header: "<math.h>".}
       ## Rounds a float to zero decimal places.
       ##
-      ## Used internally by the `round proc <#round,T,int>`_
+      ## Used internally by the `round func <#round,T,int>`_
       ## when the specified number of places is 0.
       ##
       ## See also:
-      ## * `round proc <#round,T,int>`_ for rounding to the specific
+      ## * `round func <#round,T,int>`_ for rounding to the specific
       ##   number of decimal places
-      ## * `floor proc <#floor,float64>`_
-      ## * `ceil proc <#ceil,float64>`_
-      ## * `trunc proc <#trunc,float64>`_
+      ## * `floor func <#floor,float64>`_
+      ## * `ceil func <#ceil,float64>`_
+      ## * `trunc func <#trunc,float64>`_
       ##
       ## .. code-block:: nim
       ##   echo round(3.4) ## 3.0
@@ -757,9 +757,9 @@ when not defined(js): # C
       ## Truncates ``x`` to the decimal point.
       ##
       ## See also:
-      ## * `floor proc <#floor,float64>`_
-      ## * `ceil proc <#ceil,float64>`_
-      ## * `round proc <#round,float64>`_
+      ## * `floor func <#floor,float64>`_
+      ## * `ceil func <#ceil,float64>`_
+      ## * `round func <#round,float64>`_
       ##
       ## .. code-block:: nim
       ##  echo trunc(PI) # 3.0
@@ -770,7 +770,7 @@ when not defined(js): # C
     ## Computes the modulo operation for float values (the remainder of ``x`` divided by ``y``).
     ##
     ## See also:
-    ## * `floorMod proc <#floorMod,T,T>`_ for Python-like (% operator) behavior
+    ## * `floorMod func <#floorMod,T,T>`_ for Python-like (% operator) behavior
     ##
     ## .. code-block:: nim
     ##  ( 6.5 mod  2.5) ==  1.5
@@ -831,7 +831,7 @@ func floorDiv*[T: SomeInteger](x, y: T): T =
   ##
   ## See also:
   ## * `system.div proc <system.html#div,int,int>`_ for integer division
-  ## * `floorMod proc <#floorMod,T,T>`_ for Python-like (% operator) behavior
+  ## * `floorMod func <#floorMod,T,T>`_ for Python-like (% operator) behavior
   ##
   ## .. code-block:: nim
   ##  echo floorDiv( 13,  3) #  4
@@ -848,8 +848,8 @@ func floorMod*[T: SomeNumber](x, y: T): T =
   ## This proc behaves the same as the ``%`` operator in Python.
   ##
   ## See also:
-  ## * `mod proc <#mod,float64,float64>`_
-  ## * `floorDiv proc <#floorDiv,T,T>`_
+  ## * `mod func <#mod,float64,float64>`_
+  ## * `floorDiv func <#floorDiv,T,T>`_
   ##
   ## .. code-block:: nim
   ##  echo floorMod( 13,  3) #  1
@@ -902,10 +902,10 @@ when not defined(js):
       ## Computes the binary logarithm (base 2) of ``x``.
       ##
       ## See also:
-      ## * `log proc <#log,T,T>`_
-      ## * `log10 proc <#log10,float64>`_
-      ## * `ln proc <#ln,float64>`_
-      ## * `exp proc <#exp,float64>`_
+      ## * `log func <#log,T,T>`_
+      ## * `log10 func <#log10,float64>`_
+      ## * `ln func <#ln,float64>`_
+      ## * `exp func <#exp,float64>`_
       ##
       ## .. code-block:: Nim
       ##  echo log2(8.0)  # 3.0
@@ -956,7 +956,7 @@ func degToRad*[T: float32|float64](d: T): T {.inline.} =
   ## Convert from degrees to radians.
   ##
   ## See also:
-  ## * `radToDeg proc <#radToDeg,T>`_
+  ## * `radToDeg func <#radToDeg,T>`_
   ##
   runnableExamples:
     doAssert degToRad(180.0) == 3.141592653589793
@@ -966,7 +966,7 @@ func radToDeg*[T: float32|float64](d: T): T {.inline.} =
   ## Convert from radians to degrees.
   ##
   ## See also:
-  ## * `degToRad proc <#degToRad,T>`_
+  ## * `degToRad func <#degToRad,T>`_
   ##
   runnableExamples:
     doAssert radToDeg(2 * PI) == 360.0
@@ -993,13 +993,13 @@ func `^`*[T: SomeNumber](x: T, y: Natural): T =
   ## Computes ``x`` to the power ``y``.
   ##
   ## Exponent ``y`` must be non-negative, use
-  ## `pow proc <#pow,float64,float64>`_ for negative exponents.
+  ## `pow func <#pow,float64,float64>`_ for negative exponents.
   ##
   ## See also:
-  ## * `pow proc <#pow,float64,float64>`_ for negative exponent or
+  ## * `pow func <#pow,float64,float64>`_ for negative exponent or
   ##   floats
-  ## * `sqrt proc <#sqrt,float64>`_
-  ## * `cbrt proc <#cbrt,float64>`_
+  ## * `sqrt func <#sqrt,float64>`_
+  ## * `cbrt func <#cbrt,float64>`_
   ##
   runnableExamples:
     assert -3.0^0 == 1.0
@@ -1032,8 +1032,8 @@ func gcd*[T](x, y: T): T =
   ## where N and M are positive integers."
   ##
   ## See also:
-  ## * `gcd proc <#gcd,SomeInteger,SomeInteger>`_ for integer version
-  ## * `lcm proc <#lcm,T,T>`_
+  ## * `gcd func <#gcd,SomeInteger,SomeInteger>`_ for integer version
+  ## * `lcm func <#lcm,T,T>`_
   runnableExamples:
     doAssert gcd(13.5, 9.0) == 4.5
   var (x, y) = (x, y)
@@ -1047,8 +1047,8 @@ func gcd*(x, y: SomeInteger): SomeInteger =
   ## using binary GCD (aka Stein's) algorithm.
   ##
   ## See also:
-  ## * `gcd proc <#gcd,T,T>`_ for floats version
-  ## * `lcm proc <#lcm,T,T>`_
+  ## * `gcd func <#gcd,T,T>`_ for floats version
+  ## * `lcm func <#lcm,T,T>`_
   runnableExamples:
     doAssert gcd(12, 8) == 4
     doAssert gcd(17, 63) == 1
@@ -1079,7 +1079,7 @@ func gcd*[T](x: openArray[T]): T {.since: (1, 1).} =
   ## Computes the greatest common (positive) divisor of the elements of ``x``.
   ##
   ## See also:
-  ## * `gcd proc <#gcd,T,T>`_ for integer version
+  ## * `gcd func <#gcd,T,T>`_ for integer version
   runnableExamples:
     doAssert gcd(@[13.5, 9.0]) == 4.5
   result = x[0]
@@ -1092,7 +1092,7 @@ func lcm*[T](x, y: T): T =
   ## Computes the least common multiple of ``x`` and ``y``.
   ##
   ## See also:
-  ## * `gcd proc <#gcd,T,T>`_
+  ## * `gcd func <#gcd,T,T>`_
   runnableExamples:
     doAssert lcm(24, 30) == 120
     doAssert lcm(13, 39) == 39
@@ -1102,7 +1102,7 @@ func lcm*[T](x: openArray[T]): T {.since: (1, 1).} =
   ## Computes the least common multiple of the elements of ``x``.
   ##
   ## See also:
-  ## * `gcd proc <#gcd,T,T>`_ for integer version
+  ## * `gcd func <#gcd,T,T>`_ for integer version
   runnableExamples:
     doAssert lcm(@[24, 30]) == 120
   result = x[0]

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -58,7 +58,7 @@ import std/private/since
 
 import bitops, fenv
 
-proc binom*(n, k: int): int {.noSideEffect.} =
+func binom*(n, k: int): int =
   ## Computes the `binomial coefficient <https://en.wikipedia.org/wiki/Binomial_coefficient>`_.
   runnableExamples:
     doAssert binom(6, 2) == binom(6, 4)
@@ -158,8 +158,8 @@ proc classify*(x: float): FloatClass =
     return fcSubnormal
   return fcNormal
 
-proc almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4): bool {.
-      since: (1, 5), inline, noSideEffect.} =
+func almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4): bool {.
+    since: (1, 5), inline.} =
   ## Checks if two float values are almost equal, using
   ## `machine epsilon <https://en.wikipedia.org/wiki/Machine_epsilon>`_.
   ##
@@ -192,7 +192,7 @@ proc almostEqual*[T: SomeFloat](x, y: T; unitsInLastPlace: Natural = 4): bool {.
   result = diff <= epsilon(T) * abs(x + y) * T(unitsInLastPlace) or
       diff < minimumPositiveValue(T)
 
-proc isPowerOfTwo*(x: int): bool {.noSideEffect.} =
+func isPowerOfTwo*(x: int): bool =
   ## Returns ``true``, if ``x`` is a power of two, ``false`` otherwise.
   ##
   ## Zero and negative numbers are not a power of two.
@@ -206,7 +206,7 @@ proc isPowerOfTwo*(x: int): bool {.noSideEffect.} =
     doAssert isPowerOfTwo(-16) == false
   return (x > 0) and ((x and (x - 1)) == 0)
 
-proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
+func nextPowerOfTwo*(x: int): int =
   ## Returns ``x`` rounded up to the nearest power of two.
   ##
   ## Zero and negative numbers get rounded up to 1.
@@ -230,7 +230,7 @@ proc nextPowerOfTwo*(x: int): int {.noSideEffect.} =
   result = result or (result shr 1)
   result += 1 + ord(x <= 0)
 
-proc sum*[T](x: openArray[T]): T {.noSideEffect.} =
+func sum*[T](x: openArray[T]): T =
   ## Computes the sum of the elements in ``x``.
   ##
   ## If ``x`` is empty, 0 is returned.
@@ -244,7 +244,7 @@ proc sum*[T](x: openArray[T]): T {.noSideEffect.} =
     doAssert sum([-1.5, 2.7, -0.1]) == 1.1
   for i in items(x): result = result + i
 
-proc prod*[T](x: openArray[T]): T {.noSideEffect.} =
+func prod*[T](x: openArray[T]): T =
   ## Computes the product of the elements in ``x``.
   ##
   ## If ``x`` is empty, 1 is returned.
@@ -285,10 +285,9 @@ proc cumsum*[T](x: var openArray[T]) =
     doAssert a == @[1, 3, 6, 10]
   for i in 1 ..< x.len: x[i] = x[i-1] + x[i]
 
-{.push noSideEffect.}
 when not defined(js): # C
-  proc sqrt*(x: float32): float32 {.importc: "sqrtf", header: "<math.h>".}
-  proc sqrt*(x: float64): float64 {.importc: "sqrt", header: "<math.h>".}
+  func sqrt*(x: float32): float32 {.importc: "sqrtf", header: "<math.h>".}
+  func sqrt*(x: float64): float64 {.importc: "sqrt", header: "<math.h>".}
     ## Computes the square root of ``x``.
     ##
     ## See also:
@@ -298,8 +297,8 @@ when not defined(js): # C
     ##  echo sqrt(4.0)  ## 2.0
     ##  echo sqrt(1.44) ## 1.2
     ##  echo sqrt(-4.0) ## nan
-  proc cbrt*(x: float32): float32 {.importc: "cbrtf", header: "<math.h>".}
-  proc cbrt*(x: float64): float64 {.importc: "cbrt", header: "<math.h>".}
+  func cbrt*(x: float32): float32 {.importc: "cbrtf", header: "<math.h>".}
+  func cbrt*(x: float64): float64 {.importc: "cbrt", header: "<math.h>".}
     ## Computes the cubic root of ``x``.
     ##
     ## See also:
@@ -309,8 +308,8 @@ when not defined(js): # C
     ##  echo cbrt(8.0)   ## 2.0
     ##  echo cbrt(2.197) ## 1.3
     ##  echo cbrt(-27.0) ## -3.0
-  proc ln*(x: float32): float32 {.importc: "logf", header: "<math.h>".}
-  proc ln*(x: float64): float64 {.importc: "log", header: "<math.h>".}
+  func ln*(x: float32): float32 {.importc: "logf", header: "<math.h>".}
+  func ln*(x: float64): float64 {.importc: "log", header: "<math.h>".}
     ## Computes the `natural logarithm <https://en.wikipedia.org/wiki/Natural_logarithm>`_
     ## of ``x``.
     ##
@@ -326,16 +325,16 @@ when not defined(js): # C
     ##  echo ln(0.0)      ## -inf
     ##  echo ln(-7.0)     ## nan
 else: # JS
-  proc sqrt*(x: float32): float32 {.importc: "Math.sqrt", nodecl.}
-  proc sqrt*(x: float64): float64 {.importc: "Math.sqrt", nodecl.}
+  func sqrt*(x: float32): float32 {.importc: "Math.sqrt", nodecl.}
+  func sqrt*(x: float64): float64 {.importc: "Math.sqrt", nodecl.}
 
-  proc cbrt*(x: float32): float32 {.importc: "Math.cbrt", nodecl.}
-  proc cbrt*(x: float64): float64 {.importc: "Math.cbrt", nodecl.}
+  func cbrt*(x: float32): float32 {.importc: "Math.cbrt", nodecl.}
+  func cbrt*(x: float64): float64 {.importc: "Math.cbrt", nodecl.}
 
-  proc ln*(x: float32): float32 {.importc: "Math.log", nodecl.}
-  proc ln*(x: float64): float64 {.importc: "Math.log", nodecl.}
+  func ln*(x: float32): float32 {.importc: "Math.log", nodecl.}
+  func ln*(x: float64): float64 {.importc: "Math.log", nodecl.}
 
-proc log*[T: SomeFloat](x, base: T): T =
+func log*[T: SomeFloat](x, base: T): T =
   ## Computes the logarithm of ``x`` to base ``base``.
   ##
   ## See also:
@@ -353,8 +352,8 @@ proc log*[T: SomeFloat](x, base: T): T =
   ln(x) / ln(base)
 
 when not defined(js): # C
-  proc log10*(x: float32): float32 {.importc: "log10f", header: "<math.h>".}
-  proc log10*(x: float64): float64 {.importc: "log10", header: "<math.h>".}
+  func log10*(x: float32): float32 {.importc: "log10f", header: "<math.h>".}
+  func log10*(x: float64): float64 {.importc: "log10", header: "<math.h>".}
     ## Computes the common logarithm (base 10) of ``x``.
     ##
     ## See also:
@@ -367,8 +366,8 @@ when not defined(js): # C
     ##  echo log10(100.0)  ## 2.0
     ##  echo log10(0.0)    ## nan
     ##  echo log10(-100.0) ## -inf
-  proc exp*(x: float32): float32 {.importc: "expf", header: "<math.h>".}
-  proc exp*(x: float64): float64 {.importc: "exp", header: "<math.h>".}
+  func exp*(x: float32): float32 {.importc: "expf", header: "<math.h>".}
+  func exp*(x: float64): float64 {.importc: "exp", header: "<math.h>".}
     ## Computes the exponential function of ``x`` (e^x).
     ##
     ## See also:
@@ -382,8 +381,8 @@ when not defined(js): # C
     ##  echo ln(exp(4.0)) ## 4.0
     ##  echo exp(0.0)     ## 1.0
     ##  echo exp(-1.0)    ## 0.3678794411714423
-  proc sin*(x: float32): float32 {.importc: "sinf", header: "<math.h>".}
-  proc sin*(x: float64): float64 {.importc: "sin", header: "<math.h>".}
+  func sin*(x: float32): float32 {.importc: "sinf", header: "<math.h>".}
+  func sin*(x: float64): float64 {.importc: "sin", header: "<math.h>".}
     ## Computes the sine of ``x``.
     ##
     ## See also:
@@ -395,8 +394,8 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo sin(PI / 6)         ## 0.4999999999999999
     ##  echo sin(degToRad(90.0)) ## 1.0
-  proc cos*(x: float32): float32 {.importc: "cosf", header: "<math.h>".}
-  proc cos*(x: float64): float64 {.importc: "cos", header: "<math.h>".}
+  func cos*(x: float32): float32 {.importc: "cosf", header: "<math.h>".}
+  func cos*(x: float64): float64 {.importc: "cos", header: "<math.h>".}
     ## Computes the cosine of ``x``.
     ##
     ## See also:
@@ -408,8 +407,8 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo cos(2 * PI)         ## 1.0
     ##  echo cos(degToRad(60.0)) ## 0.5000000000000001
-  proc tan*(x: float32): float32 {.importc: "tanf", header: "<math.h>".}
-  proc tan*(x: float64): float64 {.importc: "tan", header: "<math.h>".}
+  func tan*(x: float32): float32 {.importc: "tanf", header: "<math.h>".}
+  func tan*(x: float64): float64 {.importc: "tan", header: "<math.h>".}
     ## Computes the tangent of ``x``.
     ##
     ## See also:
@@ -421,8 +420,8 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo tan(degToRad(45.0)) ## 0.9999999999999999
     ##  echo tan(PI / 4)         ## 0.9999999999999999
-  proc sinh*(x: float32): float32 {.importc: "sinhf", header: "<math.h>".}
-  proc sinh*(x: float64): float64 {.importc: "sinh", header: "<math.h>".}
+  func sinh*(x: float32): float32 {.importc: "sinhf", header: "<math.h>".}
+  func sinh*(x: float64): float64 {.importc: "sinh", header: "<math.h>".}
     ## Computes the `hyperbolic sine <https://en.wikipedia.org/wiki/Hyperbolic_function#Definitions>`_ of ``x``.
     ##
     ## See also:
@@ -435,8 +434,8 @@ when not defined(js): # C
     ##  echo sinh(0.0)            ## 0.0
     ##  echo sinh(1.0)            ## 1.175201193643801
     ##  echo sinh(degToRad(90.0)) ## 2.301298902307295
-  proc cosh*(x: float32): float32 {.importc: "coshf", header: "<math.h>".}
-  proc cosh*(x: float64): float64 {.importc: "cosh", header: "<math.h>".}
+  func cosh*(x: float32): float32 {.importc: "coshf", header: "<math.h>".}
+  func cosh*(x: float64): float64 {.importc: "cosh", header: "<math.h>".}
     ## Computes the `hyperbolic cosine <https://en.wikipedia.org/wiki/Hyperbolic_function#Definitions>`_ of ``x``.
     ##
     ## See also:
@@ -449,8 +448,8 @@ when not defined(js): # C
     ##  echo cosh(0.0)            ## 1.0
     ##  echo cosh(1.0)            ## 1.543080634815244
     ##  echo cosh(degToRad(90.0)) ## 2.509178478658057
-  proc tanh*(x: float32): float32 {.importc: "tanhf", header: "<math.h>".}
-  proc tanh*(x: float64): float64 {.importc: "tanh", header: "<math.h>".}
+  func tanh*(x: float32): float32 {.importc: "tanhf", header: "<math.h>".}
+  func tanh*(x: float64): float64 {.importc: "tanh", header: "<math.h>".}
     ## Computes the `hyperbolic tangent <https://en.wikipedia.org/wiki/Hyperbolic_function#Definitions>`_ of ``x``.
     ##
     ## See also:
@@ -464,8 +463,8 @@ when not defined(js): # C
     ##  echo tanh(1.0)            ## 0.7615941559557649
     ##  echo tanh(degToRad(90.0)) ## 0.9171523356672744
 
-  proc arccos*(x: float32): float32 {.importc: "acosf", header: "<math.h>".}
-  proc arccos*(x: float64): float64 {.importc: "acos", header: "<math.h>".}
+  func arccos*(x: float32): float32 {.importc: "acosf", header: "<math.h>".}
+  func arccos*(x: float64): float64 {.importc: "acos", header: "<math.h>".}
     ## Computes the arc cosine of ``x``.
     ##
     ## See also:
@@ -477,8 +476,8 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo radToDeg(arccos(0.0)) ## 90.0
     ##  echo radToDeg(arccos(1.0)) ## 0.0
-  proc arcsin*(x: float32): float32 {.importc: "asinf", header: "<math.h>".}
-  proc arcsin*(x: float64): float64 {.importc: "asin", header: "<math.h>".}
+  func arcsin*(x: float32): float32 {.importc: "asinf", header: "<math.h>".}
+  func arcsin*(x: float64): float64 {.importc: "asin", header: "<math.h>".}
     ## Computes the arc sine of ``x``.
     ##
     ## See also:
@@ -490,8 +489,8 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo radToDeg(arcsin(0.0)) ## 0.0
     ##  echo radToDeg(arcsin(1.0)) ## 90.0
-  proc arctan*(x: float32): float32 {.importc: "atanf", header: "<math.h>".}
-  proc arctan*(x: float64): float64 {.importc: "atan", header: "<math.h>".}
+  func arctan*(x: float32): float32 {.importc: "atanf", header: "<math.h>".}
+  func arctan*(x: float64): float64 {.importc: "atan", header: "<math.h>".}
     ## Calculate the arc tangent of ``x``.
     ##
     ## See also:
@@ -503,9 +502,9 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo arctan(1.0) ## 0.7853981633974483
     ##  echo radToDeg(arctan(1.0)) ## 45.0
-  proc arctan2*(y, x: float32): float32 {.importc: "atan2f",
+  func arctan2*(y, x: float32): float32 {.importc: "atan2f",
       header: "<math.h>".}
-  proc arctan2*(y, x: float64): float64 {.importc: "atan2", header: "<math.h>".}
+  func arctan2*(y, x: float64): float64 {.importc: "atan2", header: "<math.h>".}
     ## Calculate the arc tangent of ``y`` / ``x``.
     ##
     ## It produces correct results even when the resulting angle is near
@@ -520,81 +519,81 @@ when not defined(js): # C
     ## .. code-block:: nim
     ##  echo arctan2(1.0, 0.0) ## 1.570796326794897
     ##  echo radToDeg(arctan2(1.0, 0.0)) ## 90.0
-  proc arcsinh*(x: float32): float32 {.importc: "asinhf", header: "<math.h>".}
-  proc arcsinh*(x: float64): float64 {.importc: "asinh", header: "<math.h>".}
+  func arcsinh*(x: float32): float32 {.importc: "asinhf", header: "<math.h>".}
+  func arcsinh*(x: float64): float64 {.importc: "asinh", header: "<math.h>".}
     ## Computes the inverse hyperbolic sine of ``x``.
-  proc arccosh*(x: float32): float32 {.importc: "acoshf", header: "<math.h>".}
-  proc arccosh*(x: float64): float64 {.importc: "acosh", header: "<math.h>".}
+  func arccosh*(x: float32): float32 {.importc: "acoshf", header: "<math.h>".}
+  func arccosh*(x: float64): float64 {.importc: "acosh", header: "<math.h>".}
     ## Computes the inverse hyperbolic cosine of ``x``.
-  proc arctanh*(x: float32): float32 {.importc: "atanhf", header: "<math.h>".}
-  proc arctanh*(x: float64): float64 {.importc: "atanh", header: "<math.h>".}
+  func arctanh*(x: float32): float32 {.importc: "atanhf", header: "<math.h>".}
+  func arctanh*(x: float64): float64 {.importc: "atanh", header: "<math.h>".}
     ## Computes the inverse hyperbolic tangent of ``x``.
 
 else: # JS
-  proc log10*(x: float32): float32 {.importc: "Math.log10", nodecl.}
-  proc log10*(x: float64): float64 {.importc: "Math.log10", nodecl.}
-  proc log2*(x: float32): float32 {.importc: "Math.log2", nodecl.}
-  proc log2*(x: float64): float64 {.importc: "Math.log2", nodecl.}
-  proc exp*(x: float32): float32 {.importc: "Math.exp", nodecl.}
-  proc exp*(x: float64): float64 {.importc: "Math.exp", nodecl.}
+  func log10*(x: float32): float32 {.importc: "Math.log10", nodecl.}
+  func log10*(x: float64): float64 {.importc: "Math.log10", nodecl.}
+  func log2*(x: float32): float32 {.importc: "Math.log2", nodecl.}
+  func log2*(x: float64): float64 {.importc: "Math.log2", nodecl.}
+  func exp*(x: float32): float32 {.importc: "Math.exp", nodecl.}
+  func exp*(x: float64): float64 {.importc: "Math.exp", nodecl.}
 
-  proc sin*[T: float32|float64](x: T): T {.importc: "Math.sin", nodecl.}
-  proc cos*[T: float32|float64](x: T): T {.importc: "Math.cos", nodecl.}
-  proc tan*[T: float32|float64](x: T): T {.importc: "Math.tan", nodecl.}
+  func sin*[T: float32|float64](x: T): T {.importc: "Math.sin", nodecl.}
+  func cos*[T: float32|float64](x: T): T {.importc: "Math.cos", nodecl.}
+  func tan*[T: float32|float64](x: T): T {.importc: "Math.tan", nodecl.}
 
-  proc sinh*[T: float32|float64](x: T): T {.importc: "Math.sinh", nodecl.}
-  proc cosh*[T: float32|float64](x: T): T {.importc: "Math.cosh", nodecl.}
-  proc tanh*[T: float32|float64](x: T): T {.importc: "Math.tanh", nodecl.}
+  func sinh*[T: float32|float64](x: T): T {.importc: "Math.sinh", nodecl.}
+  func cosh*[T: float32|float64](x: T): T {.importc: "Math.cosh", nodecl.}
+  func tanh*[T: float32|float64](x: T): T {.importc: "Math.tanh", nodecl.}
 
-  proc arcsin*[T: float32|float64](x: T): T {.importc: "Math.asin", nodecl.}
-  proc arccos*[T: float32|float64](x: T): T {.importc: "Math.acos", nodecl.}
-  proc arctan*[T: float32|float64](x: T): T {.importc: "Math.atan", nodecl.}
-  proc arctan2*[T: float32|float64](y, x: T): T {.importc: "Math.atan2", nodecl.}
+  func arcsin*[T: float32|float64](x: T): T {.importc: "Math.asin", nodecl.}
+  func arccos*[T: float32|float64](x: T): T {.importc: "Math.acos", nodecl.}
+  func arctan*[T: float32|float64](x: T): T {.importc: "Math.atan", nodecl.}
+  func arctan2*[T: float32|float64](y, x: T): T {.importc: "Math.atan2", nodecl.}
 
-  proc arcsinh*[T: float32|float64](x: T): T {.importc: "Math.asinh", nodecl.}
-  proc arccosh*[T: float32|float64](x: T): T {.importc: "Math.acosh", nodecl.}
-  proc arctanh*[T: float32|float64](x: T): T {.importc: "Math.atanh", nodecl.}
+  func arcsinh*[T: float32|float64](x: T): T {.importc: "Math.asinh", nodecl.}
+  func arccosh*[T: float32|float64](x: T): T {.importc: "Math.acosh", nodecl.}
+  func arctanh*[T: float32|float64](x: T): T {.importc: "Math.atanh", nodecl.}
 
-proc cot*[T: float32|float64](x: T): T = 1.0 / tan(x)
+func cot*[T: float32|float64](x: T): T = 1.0 / tan(x)
   ## Computes the cotangent of ``x`` (1 / tan(x)).
-proc sec*[T: float32|float64](x: T): T = 1.0 / cos(x)
+func sec*[T: float32|float64](x: T): T = 1.0 / cos(x)
   ## Computes the secant of ``x`` (1 / cos(x)).
-proc csc*[T: float32|float64](x: T): T = 1.0 / sin(x)
+func csc*[T: float32|float64](x: T): T = 1.0 / sin(x)
   ## Computes the cosecant of ``x`` (1 / sin(x)).
 
-proc coth*[T: float32|float64](x: T): T = 1.0 / tanh(x)
+func coth*[T: float32|float64](x: T): T = 1.0 / tanh(x)
   ## Computes the hyperbolic cotangent of ``x`` (1 / tanh(x)).
-proc sech*[T: float32|float64](x: T): T = 1.0 / cosh(x)
+func sech*[T: float32|float64](x: T): T = 1.0 / cosh(x)
   ## Computes the hyperbolic secant of ``x`` (1 / cosh(x)).
-proc csch*[T: float32|float64](x: T): T = 1.0 / sinh(x)
+func csch*[T: float32|float64](x: T): T = 1.0 / sinh(x)
   ## Computes the hyperbolic cosecant of ``x`` (1 / sinh(x)).
 
-proc arccot*[T: float32|float64](x: T): T = arctan(1.0 / x)
+func arccot*[T: float32|float64](x: T): T = arctan(1.0 / x)
   ## Computes the inverse cotangent of ``x``.
-proc arcsec*[T: float32|float64](x: T): T = arccos(1.0 / x)
+func arcsec*[T: float32|float64](x: T): T = arccos(1.0 / x)
   ## Computes the inverse secant of ``x``.
-proc arccsc*[T: float32|float64](x: T): T = arcsin(1.0 / x)
+func arccsc*[T: float32|float64](x: T): T = arcsin(1.0 / x)
   ## Computes the inverse cosecant of ``x``.
 
-proc arccoth*[T: float32|float64](x: T): T = arctanh(1.0 / x)
+func arccoth*[T: float32|float64](x: T): T = arctanh(1.0 / x)
   ## Computes the inverse hyperbolic cotangent of ``x``.
-proc arcsech*[T: float32|float64](x: T): T = arccosh(1.0 / x)
+func arcsech*[T: float32|float64](x: T): T = arccosh(1.0 / x)
   ## Computes the inverse hyperbolic secant of ``x``.
-proc arccsch*[T: float32|float64](x: T): T = arcsinh(1.0 / x)
+func arccsch*[T: float32|float64](x: T): T = arcsinh(1.0 / x)
   ## Computes the inverse hyperbolic cosecant of ``x``.
 
 const windowsCC89 = defined(windows) and defined(bcc)
 
 when not defined(js): # C
-  proc hypot*(x, y: float32): float32 {.importc: "hypotf", header: "<math.h>".}
-  proc hypot*(x, y: float64): float64 {.importc: "hypot", header: "<math.h>".}
+  func hypot*(x, y: float32): float32 {.importc: "hypotf", header: "<math.h>".}
+  func hypot*(x, y: float64): float64 {.importc: "hypot", header: "<math.h>".}
     ## Computes the hypotenuse of a right-angle triangle with ``x`` and
     ## ``y`` as its base and height. Equivalent to ``sqrt(x*x + y*y)``.
     ##
     ## .. code-block:: nim
     ##  echo hypot(4.0, 3.0) ## 5.0
-  proc pow*(x, y: float32): float32 {.importc: "powf", header: "<math.h>".}
-  proc pow*(x, y: float64): float64 {.importc: "pow", header: "<math.h>".}
+  func pow*(x, y: float32): float32 {.importc: "powf", header: "<math.h>".}
+  func pow*(x, y: float64): float64 {.importc: "pow", header: "<math.h>".}
     ## Computes x to power raised of y.
     ##
     ## To compute power between integers (e.g. 2^6), use `^ proc<#^,T,Natural>`_.
@@ -610,18 +609,18 @@ when not defined(js): # C
 
   # TODO: add C89 version on windows
   when not windowsCC89:
-    proc erf*(x: float32): float32 {.importc: "erff", header: "<math.h>".}
-    proc erf*(x: float64): float64 {.importc: "erf", header: "<math.h>".}
+    func erf*(x: float32): float32 {.importc: "erff", header: "<math.h>".}
+    func erf*(x: float64): float64 {.importc: "erf", header: "<math.h>".}
       ## Computes the `error function <https://en.wikipedia.org/wiki/Error_function>`_ for ``x``.
       ##
       ## Note: Not available for JS backend.
-    proc erfc*(x: float32): float32 {.importc: "erfcf", header: "<math.h>".}
-    proc erfc*(x: float64): float64 {.importc: "erfc", header: "<math.h>".}
+    func erfc*(x: float32): float32 {.importc: "erfcf", header: "<math.h>".}
+    func erfc*(x: float64): float64 {.importc: "erfc", header: "<math.h>".}
       ## Computes the `complementary error function <https://en.wikipedia.org/wiki/Error_function#Complementary_error_function>`_ for ``x``.
       ##
       ## Note: Not available for JS backend.
-    proc gamma*(x: float32): float32 {.importc: "tgammaf", header: "<math.h>".}
-    proc gamma*(x: float64): float64 {.importc: "tgamma", header: "<math.h>".}
+    func gamma*(x: float32): float32 {.importc: "tgammaf", header: "<math.h>".}
+    func gamma*(x: float64): float64 {.importc: "tgamma", header: "<math.h>".}
       ## Computes the `gamma function <https://en.wikipedia.org/wiki/Gamma_function>`_ for ``x``.
       ##
       ## Note: Not available for JS backend.
@@ -634,8 +633,8 @@ when not defined(js): # C
       ##  echo gamma(4.0)  # 6.0
       ##  echo gamma(11.0) # 3628800.0
       ##  echo gamma(-1.0) # nan
-    proc lgamma*(x: float32): float32 {.importc: "lgammaf", header: "<math.h>".}
-    proc lgamma*(x: float64): float64 {.importc: "lgamma", header: "<math.h>".}
+    func lgamma*(x: float32): float32 {.importc: "lgammaf", header: "<math.h>".}
+    func lgamma*(x: float64): float64 {.importc: "lgamma", header: "<math.h>".}
       ## Computes the natural log of the gamma function for ``x``.
       ##
       ## Note: Not available for JS backend.
@@ -649,8 +648,8 @@ when not defined(js): # C
       ##  echo lgamma(11.0) # 15.10441257307552
       ##  echo lgamma(-1.0) # inf
 
-  proc floor*(x: float32): float32 {.importc: "floorf", header: "<math.h>".}
-  proc floor*(x: float64): float64 {.importc: "floor", header: "<math.h>".}
+  func floor*(x: float32): float32 {.importc: "floorf", header: "<math.h>".}
+  func floor*(x: float64): float64 {.importc: "floor", header: "<math.h>".}
     ## Computes the floor function (i.e., the largest integer not greater than ``x``).
     ##
     ## See also:
@@ -663,8 +662,8 @@ when not defined(js): # C
     ##  echo floor(2.9)  ## 2.0
     ##  echo floor(-3.5) ## -4.0
 
-  proc ceil*(x: float32): float32 {.importc: "ceilf", header: "<math.h>".}
-  proc ceil*(x: float64): float64 {.importc: "ceil", header: "<math.h>".}
+  func ceil*(x: float32): float32 {.importc: "ceilf", header: "<math.h>".}
+  func ceil*(x: float64): float64 {.importc: "ceil", header: "<math.h>".}
     ## Computes the ceiling function (i.e., the smallest integer not smaller
     ## than ``x``).
     ##
@@ -681,7 +680,7 @@ when not defined(js): # C
   when windowsCC89:
     # MSVC 2010 don't have trunc/truncf
     # this implementation was inspired by Go-lang Math.Trunc
-    proc truncImpl(f: float64): float64 =
+    func truncImpl(f: float64): float64 =
       const
         mask: uint64 = 0x7FF
         shift: uint64 = 64 - 12
@@ -701,7 +700,7 @@ when not defined(js): # C
 
       result = cast[float64](x)
 
-    proc truncImpl(f: float32): float32 =
+    func truncImpl(f: float32): float32 =
       const
         mask: uint32 = 0xFF
         shift: uint32 = 32 - 9
@@ -721,21 +720,21 @@ when not defined(js): # C
 
       result = cast[float32](x)
 
-    proc trunc*(x: float64): float64 =
+    func trunc*(x: float64): float64 =
       if classify(x) in {fcZero, fcNegZero, fcNan, fcInf, fcNegInf}: return x
       result = truncImpl(x)
 
-    proc trunc*(x: float32): float32 =
+    func trunc*(x: float32): float32 =
       if classify(x) in {fcZero, fcNegZero, fcNan, fcInf, fcNegInf}: return x
       result = truncImpl(x)
 
-    proc round*[T: float32|float64](x: T): T =
+    func round*[T: float32|float64](x: T): T =
       ## Windows compilers prior to MSVC 2012 do not implement 'round',
       ## 'roundl' or 'roundf'.
       result = if x < 0.0: ceil(x - T(0.5)) else: floor(x + T(0.5))
   else:
-    proc round*(x: float32): float32 {.importc: "roundf", header: "<math.h>".}
-    proc round*(x: float64): float64 {.importc: "round", header: "<math.h>".}
+    func round*(x: float32): float32 {.importc: "roundf", header: "<math.h>".}
+    func round*(x: float64): float64 {.importc: "round", header: "<math.h>".}
       ## Rounds a float to zero decimal places.
       ##
       ## Used internally by the `round proc <#round,T,int>`_
@@ -753,8 +752,8 @@ when not defined(js): # C
       ##   echo round(3.5) ## 4.0
       ##   echo round(4.5) ## 5.0
 
-    proc trunc*(x: float32): float32 {.importc: "truncf", header: "<math.h>".}
-    proc trunc*(x: float64): float64 {.importc: "trunc", header: "<math.h>".}
+    func trunc*(x: float32): float32 {.importc: "truncf", header: "<math.h>".}
+    func trunc*(x: float64): float64 {.importc: "trunc", header: "<math.h>".}
       ## Truncates ``x`` to the decimal point.
       ##
       ## See also:
@@ -766,8 +765,8 @@ when not defined(js): # C
       ##  echo trunc(PI) # 3.0
       ##  echo trunc(-1.85) # -1.0
 
-  proc `mod`*(x, y: float32): float32 {.importc: "fmodf", header: "<math.h>".}
-  proc `mod`*(x, y: float64): float64 {.importc: "fmod", header: "<math.h>".}
+  func `mod`*(x, y: float32): float32 {.importc: "fmodf", header: "<math.h>".}
+  func `mod`*(x, y: float64): float64 {.importc: "fmod", header: "<math.h>".}
     ## Computes the modulo operation for float values (the remainder of ``x`` divided by ``y``).
     ##
     ## See also:
@@ -780,20 +779,20 @@ when not defined(js): # C
     ##  (-6.5 mod -2.5) == -1.5
 
 else: # JS
-  proc hypot*(x, y: float32): float32 {.importc: "Math.hypot", varargs, nodecl.}
-  proc hypot*(x, y: float64): float64 {.importc: "Math.hypot", varargs, nodecl.}
-  proc pow*(x, y: float32): float32 {.importc: "Math.pow", nodecl.}
-  proc pow*(x, y: float64): float64 {.importc: "Math.pow", nodecl.}
-  proc floor*(x: float32): float32 {.importc: "Math.floor", nodecl.}
-  proc floor*(x: float64): float64 {.importc: "Math.floor", nodecl.}
-  proc ceil*(x: float32): float32 {.importc: "Math.ceil", nodecl.}
-  proc ceil*(x: float64): float64 {.importc: "Math.ceil", nodecl.}
-  proc round*(x: float): float {.importc: "Math.round", nodecl.}
-  proc trunc*(x: float32): float32 {.importc: "Math.trunc", nodecl.}
-  proc trunc*(x: float64): float64 {.importc: "Math.trunc", nodecl.}
+  func hypot*(x, y: float32): float32 {.importc: "Math.hypot", varargs, nodecl.}
+  func hypot*(x, y: float64): float64 {.importc: "Math.hypot", varargs, nodecl.}
+  func pow*(x, y: float32): float32 {.importc: "Math.pow", nodecl.}
+  func pow*(x, y: float64): float64 {.importc: "Math.pow", nodecl.}
+  func floor*(x: float32): float32 {.importc: "Math.floor", nodecl.}
+  func floor*(x: float64): float64 {.importc: "Math.floor", nodecl.}
+  func ceil*(x: float32): float32 {.importc: "Math.ceil", nodecl.}
+  func ceil*(x: float64): float64 {.importc: "Math.ceil", nodecl.}
+  func round*(x: float): float {.importc: "Math.round", nodecl.}
+  func trunc*(x: float32): float32 {.importc: "Math.trunc", nodecl.}
+  func trunc*(x: float64): float64 {.importc: "Math.trunc", nodecl.}
 
-  proc `mod`*(x, y: float32): float32 {.importcpp: "# % #".}
-  proc `mod`*(x, y: float64): float64 {.importcpp: "# % #".}
+  func `mod`*(x, y: float32): float32 {.importcpp: "# % #".}
+  func `mod`*(x, y: float64): float64 {.importcpp: "# % #".}
     ## Computes the modulo operation for float values (the remainder of ``x`` divided by ``y``).
     ##
     ## .. code-block:: nim
@@ -802,7 +801,7 @@ else: # JS
     ##  ( 6.5 mod -2.5) ==  1.5
     ##  (-6.5 mod -2.5) == -1.5
 
-proc round*[T: float32|float64](x: T, places: int): T =
+func round*[T: float32|float64](x: T, places: int): T =
   ## Decimal rounding on a binary floating point number.
   ##
   ## This function is NOT reliable. Floating point numbers cannot hold
@@ -823,7 +822,7 @@ proc round*[T: float32|float64](x: T, places: int): T =
     var mult = pow(10.0, places.T)
     result = round(x*mult)/mult
 
-proc floorDiv*[T: SomeInteger](x, y: T): T =
+func floorDiv*[T: SomeInteger](x, y: T): T =
   ## Floor division is conceptually defined as ``floor(x / y)``.
   ##
   ## This is different from the `system.div <system.html#div,int,int>`_
@@ -843,7 +842,7 @@ proc floorDiv*[T: SomeInteger](x, y: T): T =
   let r = x mod y
   if (r > 0 and y < 0) or (r < 0 and y > 0): result.dec 1
 
-proc floorMod*[T: SomeNumber](x, y: T): T =
+func floorMod*[T: SomeNumber](x, y: T): T =
   ## Floor modulus is conceptually defined as ``x - (floorDiv(x, y) * y)``.
   ##
   ## This proc behaves the same as the ``%`` operator in Python.
@@ -861,11 +860,11 @@ proc floorMod*[T: SomeNumber](x, y: T): T =
   if (result > 0 and y < 0) or (result < 0 and y > 0): result += y
 
 when not defined(js):
-  proc c_frexp*(x: float32, exponent: var int32): float32 {.
-    importc: "frexp", header: "<math.h>".}
-  proc c_frexp*(x: float64, exponent: var int32): float64 {.
-    importc: "frexp", header: "<math.h>".}
-  proc frexp*[T, U](x: T, exponent: var U): T =
+  func c_frexp*(x: float32, exponent: var int32): float32 {.
+      importc: "frexp", header: "<math.h>".}
+  func c_frexp*(x: float64, exponent: var int32): float64 {.
+      importc: "frexp", header: "<math.h>".}
+  func frexp*[T, U](x: T, exponent: var U): T =
     ## Split a number into mantissa and exponent.
     ##
     ## ``frexp`` calculates the mantissa m (a float greater than or equal to 0.5
@@ -892,14 +891,14 @@ when not defined(js):
       if frac == 0.5: return T(exp - 1)
       log10(frac)*(1/ln2) + T(exp)
 
-    proc log2*(x: float32): float32 = log2Impl(x)
-    proc log2*(x: float64): float64 = log2Impl(x)
+    func log2*(x: float32): float32 = log2Impl(x)
+    func log2*(x: float64): float64 = log2Impl(x)
       ## Log2 returns the binary logarithm of x.
       ## The special cases are the same as for Log.
 
   else:
-    proc log2*(x: float32): float32 {.importc: "log2f", header: "<math.h>".}
-    proc log2*(x: float64): float64 {.importc: "log2", header: "<math.h>".}
+    func log2*(x: float32): float32 {.importc: "log2f", header: "<math.h>".}
+    func log2*(x: float64): float64 {.importc: "log2", header: "<math.h>".}
       ## Computes the binary logarithm (base 2) of ``x``.
       ##
       ## See also:
@@ -915,7 +914,7 @@ when not defined(js):
       ##  echo log2(-2.0) # nan
 
 else:
-  proc frexp*[T: float32|float64](x: T, exponent: var int): T =
+  func frexp*[T: float32|float64](x: T, exponent: var int): T =
     if x == 0.0:
       exponent = 0
       result = 0.0
@@ -931,7 +930,7 @@ else:
       if exponent == 1024 and result == 0.0:
         result = 0.99999999999999988898
 
-proc splitDecimal*[T: float32|float64](x: T): tuple[intpart: T, floatpart: T] =
+func splitDecimal*[T: float32|float64](x: T): tuple[intpart: T, floatpart: T] =
   ## Breaks ``x`` into an integer and a fractional part.
   ##
   ## Returns a tuple containing ``intpart`` and ``floatpart`` representing
@@ -952,7 +951,6 @@ proc splitDecimal*[T: float32|float64](x: T): tuple[intpart: T, floatpart: T] =
     result.intpart = -result.intpart
     result.floatpart = -result.floatpart
 
-{.pop.}
 
 proc degToRad*[T: float32|float64](d: T): T {.inline.} =
   ## Convert from degrees to radians.

--- a/tests/effects/tstrict_funcs.nim
+++ b/tests/effects/tstrict_funcs.nim
@@ -2,7 +2,15 @@ discard """
   cmd: "nim c --experimental:strictFuncs --experimental:views $file"
 """
 
-import tables, streams, nre, parsecsv, uri, httpcore, strutils
+import tables, streams, parsecsv
+# We import the below modules to check that they compile with `strictFuncs`.
+# They are otherwise unused in this file.
+import
+  httpcore,
+  math,
+  nre,
+  strutils,
+  uri
 
 type
   Contig2Reads = TableRef[string, seq[string]]


### PR DESCRIPTION
Continuing the work from https://github.com/nim-lang/Nim/pull/16281. It's quite nice to Ctrl+f for `proc` in [the strutils docs](https://nim-lang.github.io/Nim/strutils.html) now. Can we do `math` too? 

Again, each commit does just one thing. A reviewer may find it more pleasant to review the commits individually.

In the https://github.com/nim-lang/Nim/commit/f36a43b0c2e2caf81120bdb99c8cb4fb4be0febe commit I've tried to reduce the chance of merge conflicts later if we keep adding modules. The wording might be bad, though - is `nre` in the right place?