### PR TITLE
make rand consistent with other overloads

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -217,8 +217,7 @@ proc rand*(r: var Rand; max: Natural): int {.benign.} =
   ## Returns a random integer in the range `0..max` using the given state.
   ##
   ## See also:
-  ## * `rand proc<#rand,int>`_ that returns an integer using the default
-  ##   random number generator
+  ## * `rand proc<#rand,T>`_ `T` are integers, floats, and enums without holes.
   ## * `rand proc<#rand,Rand,range[]>`_ that returns a float
   ## * `rand proc<#rand,Rand,HSlice[T,T]>`_ that accepts a slice
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
@@ -232,28 +231,6 @@ proc rand*(r: var Rand; max: Natural): int {.benign.} =
     let x = next(r)
     if x <= randMax - (randMax mod Ui(max)):
       return int(x mod (uint64(max)+1u64))
-
-proc rand*(max: int): int {.benign.} =
-  ## Returns a random integer in the range `0..max`.
-  ##
-  ## If `randomize<#randomize>`_ has not been called, the sequence of random
-  ## numbers returned from this proc will always be the same.
-  ##
-  ## This proc uses the default random number generator. Thus, it is **not**
-  ## thread-safe.
-  ##
-  ## See also:
-  ## * `rand proc<#rand,Rand,Natural>`_ that returns an integer using a
-  ##   provided state
-  ## * `rand proc<#rand,float>`_ that returns a float
-  ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice
-  ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
-  runnableExamples:
-    randomize(123)
-    doAssert rand(100) == 0
-    doAssert rand(100) == 96
-    doAssert rand(100) == 66
-  rand(state, max)
 
 proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
   ## Returns a random floating point number in the range `0.0..max`
@@ -276,8 +253,10 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
     let u = (0x3FFu64 shl 52u64) or (x shr 12u64)
     result = (cast[float](u) - 1.0) * max
 
-proc rand*(max: float): float {.benign.} =
-  ## Returns a random floating point number in the range `0.0..max`.
+proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
+  ## Returns a random floating point number in the range `T(0) .. max`.
+  ## 
+  ## Allowed types for `T` are integers, floats, and enums without holes.
   ##
   ## If `randomize<#randomize>`_ has not been called, the sequence of random
   ## numbers returned from this proc will always be the same.
@@ -286,13 +265,18 @@ proc rand*(max: float): float {.benign.} =
   ## thread-safe.
   ##
   ## See also:
+  ## * `rand proc<#rand,Rand,Natural>`_ that returns an integer using a
+  ##   provided state
   ## * `rand proc<#rand,Rand,range[]>`_ that returns a float using a
   ##   provided state
-  ## * `rand proc<#rand,int>`_ that returns an integer
   ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
   runnableExamples:
-    randomize(234)
+    randomize(123)
+    doAssert rand(100) == 0
+    doAssert rand(100) == 96
+    doAssert rand(100) == 66
+
     let f = rand(1.0)
     ## f = 8.717181376738381e-07
   rand(state, max)
@@ -335,8 +319,7 @@ proc rand*[T: Ordinal or SomeFloat](x: HSlice[T, T]): T =
   ## See also:
   ## * `rand proc<#rand,Rand,HSlice[T,T]>`_ that accepts a slice and uses
   ##   a provided state
-  ## * `rand proc<#rand,int>`_ that returns an integer
-  ## * `rand proc<#rand,float>`_ that returns a floating point number
+  ## * `rand proc<#rand,T>`_ `T` are integers, floats, and enums without holes.
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
   runnableExamples:
     randomize(345)
@@ -355,8 +338,7 @@ proc rand*[T: SomeInteger](t: typedesc[T]): T =
   ## thread-safe.
   ##
   ## See also:
-  ## * `rand proc<#rand,int>`_ that returns an integer
-  ## * `rand proc<#rand,float>`_ that returns a floating point number
+  ## * `rand proc<#rand,T>`_ `T` are integers, floats, and enums without holes.
   ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice
   runnableExamples:
     randomize(567)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -255,7 +255,7 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
     result = (cast[float](u) - 1.0) * max
 
 proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
-  ## Returns a random number in the range `T(0) .. max`. Notes that `max` must be >= T(0).
+  ## Returns a random number in the range `T(0) .. max`. Note that `max` must be >= T(0).
   ##
   ## If `randomize<#randomize>`_ has not been called, the sequence of random
   ## numbers returned from this proc will always be the same.

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -279,7 +279,11 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
 
     let f = rand(1.0)
     ## f = 8.717181376738381e-07
-  result = T(rand(state, max))
+
+  when T is SomeFloat:
+    result = rand(state, max)
+  else:
+    result = T(rand(state, int(max)))
 
 proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
   ## For a slice `a..b`, returns a value in the range `a..b` using the given

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -217,7 +217,8 @@ proc rand*(r: var Rand; max: Natural): int {.benign.} =
   ## Returns a random integer in the range `0..max` using the given state.
   ##
   ## See also:
-  ## * `rand proc<#rand,T>`_ `T` are integers, floats, and enums without holes.
+  ## * `rand proc<#rand,T>`_ that accepts an ordinal type
+  ## * `rand proc<#rand,T_2>_ that accepts a float type
   ## * `rand proc<#rand,Rand,range[]>`_ that returns a float
   ## * `rand proc<#rand,Rand,HSlice[T,T]>`_ that accepts a slice
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
@@ -254,8 +255,8 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
     let u = (0x3FFu64 shl 52u64) or (x shr 12u64)
     result = (cast[float](u) - 1.0) * max
 
-proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
-  ## Returns a random number in the range `T(0) .. max`. Note that `max` must be >= T(0).
+proc rand*[T: Ordinal](max: T): int {.benign.} =
+  ## Returns an integer random number in the range `T(0) .. max`. Note that `max` must be >= T(0).
   ##
   ## If `randomize<#randomize>`_ has not been called, the sequence of random
   ## numbers returned from this proc will always be the same.
@@ -264,6 +265,7 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
   ## thread-safe.
   ##
   ## See also:
+  ## * `rand proc<#rand,T_2>_ that accepts a float type
   ## * `rand proc<#rand,Rand,Natural>`_ that returns an integer using a
   ##   provided state
   ## * `rand proc<#rand,Rand,range[]>`_ that returns a float using a
@@ -276,20 +278,32 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
     doAssert rand(100) == 96
     doAssert rand(100) == 66
 
+  result = rand(state, int(max))
+
+proc rand*[T: SomeFloat](max: T): float {.benign.} =
+  ## Returns a float random number in the range `T(0) .. max`. Note that `max` must be >= T(0).
+  ##
+  ## If `randomize<#randomize>`_ has not been called, the sequence of random
+  ## numbers returned from this proc will always be the same.
+  ##
+  ## This proc uses the default random number generator. Thus, it is **not**
+  ## thread-safe.
+  ##
+  ## See also:
+  ## * `rand proc<#rand,T>`_ that accepts an ordinal type
+  ## * `rand proc<#rand,Rand,Natural>`_ that returns an integer using a
+  ##   provided state
+  ## * `rand proc<#rand,Rand,range[]>`_ that returns a float using a
+  ##   provided state
+  ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice
+  ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
+  runnableExamples:
+    randomize(123)
+
     let f = rand(1.0)
     doAssert f >= 0.0 and f <= 1.0
 
-  when T is range:
-    static:
-      doAssert T.low.ord == 0, "range should start from 0"
-  elif T is enum:
-    static:
-      doAssert T.low.ord == 0, "enum should start from 0"
-
-  when T is SomeFloat:
-    result = rand(state, max)
-  else:
-    result = T(rand(state, int(max)))
+  result = rand(state, max)
 
 proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
   ## For a slice `a..b`, returns a value in the range `a..b` using the given
@@ -329,7 +343,8 @@ proc rand*[T: Ordinal or SomeFloat](x: HSlice[T, T]): T =
   ## See also:
   ## * `rand proc<#rand,Rand,HSlice[T,T]>`_ that accepts a slice and uses
   ##   a provided state
-  ## * `rand proc<#rand,T>`_ `T` are integers, floats, and enums without holes.
+  ## * `rand proc<#rand,T>`_ that accepts an ordinal type
+  ## * `rand proc<#rand,T_2>_ that accepts a float type
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
   runnableExamples:
     randomize(345)
@@ -348,7 +363,8 @@ proc rand*[T: SomeInteger](t: typedesc[T]): T =
   ## thread-safe.
   ##
   ## See also:
-  ## * `rand proc<#rand,T>`_ `T` are integers, floats, and enums without holes.
+  ## * `rand proc<#rand,T>`_ that accepts an ordinal type
+  ## * `rand proc<#rand,T_2>_ that accepts a float type
   ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice
   runnableExamples:
     randomize(567)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -218,7 +218,7 @@ proc rand*(r: var Rand; max: Natural): int {.benign.} =
   ##
   ## See also:
   ## * `rand proc<#rand,T>`_ that accepts an ordinal type
-  ## * `rand proc<#rand,T_2>_ that accepts a float type
+  ## * `rand proc<#rand,T_2>`_ that accepts a float type
   ## * `rand proc<#rand,Rand,range[]>`_ that returns a float
   ## * `rand proc<#rand,Rand,HSlice[T,T]>`_ that accepts a slice
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
@@ -265,7 +265,7 @@ proc rand*[T: Ordinal](max: T): int {.benign.} =
   ## thread-safe.
   ##
   ## See also:
-  ## * `rand proc<#rand,T_2>_ that accepts a float type
+  ## * `rand proc<#rand,T_2>`_ that accepts a float type
   ## * `rand proc<#rand,Rand,Natural>`_ that returns an integer using a
   ##   provided state
   ## * `rand proc<#rand,Rand,range[]>`_ that returns a float using a
@@ -344,7 +344,7 @@ proc rand*[T: Ordinal or SomeFloat](x: HSlice[T, T]): T =
   ## * `rand proc<#rand,Rand,HSlice[T,T]>`_ that accepts a slice and uses
   ##   a provided state
   ## * `rand proc<#rand,T>`_ that accepts an ordinal type
-  ## * `rand proc<#rand,T_2>_ that accepts a float type
+  ## * `rand proc<#rand,T_2>`_ that accepts a float type
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
   runnableExamples:
     randomize(345)
@@ -364,7 +364,7 @@ proc rand*[T: SomeInteger](t: typedesc[T]): T =
   ##
   ## See also:
   ## * `rand proc<#rand,T>`_ that accepts an ordinal type
-  ## * `rand proc<#rand,T_2>_ that accepts a float type
+  ## * `rand proc<#rand,T_2>`_ that accepts a float type
   ## * `rand proc<#rand,HSlice[T,T]>`_ that accepts a slice
   runnableExamples:
     randomize(567)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -255,7 +255,7 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
     result = (cast[float](u) - 1.0) * max
 
 proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
-  ## Returns a random number in the range `T(0) .. max`.
+  ## Returns a random number in the range `T(0) .. max`. Notes that `max` must be >= T(0).
   ##
   ## If `randomize<#randomize>`_ has not been called, the sequence of random
   ## numbers returned from this proc will always be the same.

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -277,7 +277,7 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
     doAssert rand(100) == 66
 
     let f = rand(1.0)
-    x >= 0.0 and x <= 1.0
+    doAssert x >= 0.0 and x <= 1.0
 
   when T is SomeFloat:
     result = rand(state, max)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -279,6 +279,13 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
     let f = rand(1.0)
     doAssert f >= 0.0 and f <= 1.0
 
+  when T is range:
+    static:
+      doAssert T.low.ord == 0, "range should start from 0"
+  elif T is enum:
+    static:
+      doAssert T.low.ord == 0, "enum should start from 0"
+
   when T is SomeFloat:
     result = rand(state, max)
   else:

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -279,7 +279,7 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
 
     let f = rand(1.0)
     ## f = 8.717181376738381e-07
-  rand(state, max)
+  result = T(rand(state, max))
 
 proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
   ## For a slice `a..b`, returns a value in the range `a..b` using the given

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -245,7 +245,7 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
   runnableExamples:
     var r = initRand(234)
     let f = r.rand(1.0)
-    assert x >= 0.0 and x <= 1.0
+    assert f >= 0.0 and f <= 1.0
 
   let x = next(r)
   when defined(js):
@@ -277,7 +277,7 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
     doAssert rand(100) == 66
 
     let f = rand(1.0)
-    doAssert x >= 0.0 and x <= 1.0
+    doAssert f >= 0.0 and f <= 1.0
 
   when T is SomeFloat:
     result = rand(state, max)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -245,7 +245,8 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
   runnableExamples:
     var r = initRand(234)
     let f = r.rand(1.0)
-    ## f = 8.717181376738381e-07
+    assert x >= 0.0 and x <= 1.0
+
   let x = next(r)
   when defined(js):
     result = (float(x) / float(high(uint32))) * max
@@ -276,7 +277,7 @@ proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
     doAssert rand(100) == 66
 
     let f = rand(1.0)
-    ## f = 8.717181376738381e-07
+    x >= 0.0 and x <= 1.0
 
   when T is SomeFloat:
     result = rand(state, max)

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -254,9 +254,7 @@ proc rand*(r: var Rand; max: range[0.0 .. high(float)]): float {.benign.} =
     result = (cast[float](u) - 1.0) * max
 
 proc rand*[T: Ordinal or SomeFloat](max: T): T {.benign.} =
-  ## Returns a random floating point number in the range `T(0) .. max`.
-  ## 
-  ## Allowed types for `T` are integers, floats, and enums without holes.
+  ## Returns a random number in the range `T(0) .. max`.
   ##
   ## If `randomize<#randomize>`_ has not been called, the sequence of random
   ## numbers returned from this proc will always be the same.

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -33,19 +33,11 @@ proc main =
   doAssert rand(0) == 0
   doAssert sample("a") == 'a'
 
-  when compileOption("rangeChecks"):
-    try:
-      discard rand(-1)
-      doAssert false
-    except RangeDefect:
-      discard
+  doAssertRaises(RangeDefect):
+    discard rand(-1)
 
-    try:
-      discard rand(-1.0)
-      doAssert false
-    except RangeDefect:
-      discard
-
+  doAssertRaises(RangeDefect):
+    discard rand(-1.0)
 
   # don't use causes integer overflow
   doAssert compiles(rand[int](low(int) .. high(int)))
@@ -53,6 +45,7 @@ proc main =
 
 main()
 
+import math
 
 block:
   type Fooa = enum k0,k1,k2
@@ -64,3 +57,6 @@ block:
   doAssert rand(int64.high) == 1967081787890826204
   doAssert compiles(echo rand(uint64.high))
   doAssert (rand(char.high),) == ('\a',)
+
+  doAssert almostEqual(rand(12.5), 6.371734653537684)
+  doAssert almostEqual(rand(2233.3322), 1039.453087565187)

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -2,30 +2,18 @@ discard """
   joinable: false
 """
 
-import random
+import std/[random, stats]
 
 randomize(233)
 
 proc main =
   var occur: array[1000, int]
 
-  var x = 8234
   for i in 0..100_000:
-    x = rand(high(occur))
+    let x = rand(high(occur))
     inc occur[x]
 
   doAssert max(occur) <= 140 and min(occur) >= 60 # gives some slack
-
-  when false:
-    var rs: RunningStat
-    for j in 1..5:
-      for i in 1 .. 1_000:
-        rs.push(gauss())
-      echo("mean: ", rs.mean,
-        " stdDev: ", rs.standardDeviation(),
-        " min: ", rs.min,
-        " max: ", rs.max)
-      rs.clear()
 
   var a = [0, 1]
   shuffle(a)
@@ -66,3 +54,14 @@ block:
 
   type DiceRoll = range[0..6]
   doAssert rand(DiceRoll).int == 4
+
+var rs: RunningStat
+for j in 1..5:
+  for i in 1 .. 1_000:
+    rs.push(gauss())
+  doAssert abs(rs.mean-0) < 0.08, $rs.mean
+  doAssert abs(rs.standardDeviation()-1.0) < 0.1
+  let maxVal = 3.0
+  doAssert abs(rs.min + maxVal) < 1.0
+  doAssert abs(rs.max-maxVal) < 1.0
+  rs.clear()

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -61,5 +61,5 @@ block:
   doAssert almostEqual(rand(12.5), 6.371734653537684)
   doAssert almostEqual(rand(2233.3322), 1039.453087565187)
 
-  type DiceRoll = distinct range[0..6]
-  doAssert rand(6).int == 4
+  type DiceRoll = range[0..6]
+  doAssert rand(DiceRoll).int == 4

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -1,8 +1,10 @@
 discard """
-  action: compile
+  joinable: false
 """
 
 import random
+
+randomize(233)
 
 proc main =
   var occur: array[1000, int]
@@ -11,11 +13,6 @@ proc main =
   for i in 0..100_000:
     x = rand(high(occur))
     inc occur[x]
-  for i, oc in occur:
-    if oc < 69:
-      doAssert false, "too few occurrences of " & $i
-    elif oc > 150:
-      doAssert false, "too many occurrences of " & $i
 
   when false:
     var rs: RunningStat
@@ -53,19 +50,17 @@ proc main =
   # don't use causes integer overflow
   doAssert compiles(rand[int](low(int) .. high(int)))
 
-randomize(223)
 
-for i in 0 .. 10:
-  main()
+main()
 
 
 block:
   type Fooa = enum k0,k1,k2
-  echo rand(Fooa.high)
+  doAssert rand(Fooa.high) == k1
 
   type Dollar = distinct int
-  echo rand(int.high.Dollar).int
+  doAssert rand(int.high.Dollar).int == 7266116338782525390
 
-  echo rand(int64.high)
-  echo rand(uint64.high)
-  echo (rand(char.high),)
+  doAssert rand(int64.high) == 1967081787890826204
+  doAssert compiles(echo rand(uint64.high))
+  doAssert (rand(char.high),) == ('\a',)

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -60,3 +60,6 @@ block:
 
   doAssert almostEqual(rand(12.5), 6.371734653537684)
   doAssert almostEqual(rand(2233.3322), 1039.453087565187)
+
+  type DiceRoll = distinct range[0..6]
+  doAssert rand(6).int == 4

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -72,3 +72,7 @@ for i in 0..<100000:
   if rand(5.DiceRoll) < 3:
     flag = true
 doAssert flag
+
+type Foob = enum g0 = 1, g1 , g2
+for i in 0 ..< 100:
+  discard rand(Foob.high)

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -14,6 +14,8 @@ proc main =
     x = rand(high(occur))
     inc occur[x]
 
+  doAssert max(occur) <= 140 and min(occur) >= 60 # gives some slack
+
   when false:
     var rs: RunningStat
     for j in 1..5:

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -57,3 +57,15 @@ randomize(223)
 
 for i in 0 .. 10:
   main()
+
+
+block:
+  type Fooa = enum k0,k1,k2
+  echo rand(Fooa.high)
+
+  type Dollar = distinct int
+  echo rand(int.high.Dollar).int
+
+  echo rand(int64.high)
+  echo rand(uint64.high)
+  echo (rand(char.high),)

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -52,9 +52,9 @@ block:
   doAssert rand(Fooa.high) == k1
 
   type Dollar = distinct int
-  doAssert rand(int.high.Dollar).int == 7266116338782525390
+  doAssert $rand(int.high.Dollar).int == "7266116338782525390"
 
-  doAssert rand(int64.high) == 1967081787890826204
+  doAssert $rand(int64.high) == "1967081787890826204"
   doAssert compiles(echo rand(uint64.high))
   doAssert (rand(char.high),) == ('\a',)
 

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -52,9 +52,9 @@ block:
   doAssert rand(Fooa.high) == k1
 
   type Dollar = distinct int
-  doAssert $rand(int.high.Dollar).int == "7266116338782525390"
+  doAssert rand(int(100).Dollar).int == 35
 
-  doAssert $rand(int64.high) == "1967081787890826204"
+  doAssert rand(12'u64) == 8
   doAssert compiles(echo rand(uint64.high))
   doAssert (rand(char.high),) == ('\a',)
 

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -40,14 +40,14 @@ import math
 
 block:
   type Fooa = enum k0,k1,k2
-  doAssert rand(Fooa.high) == k1
+  doAssert rand(Fooa.high) == k1.int
 
   type Dollar = distinct int
   doAssert rand(int(100).Dollar).int == 35
 
   doAssert rand(12'u64) == 8
   doAssert compiles(echo rand(uint64.high))
-  doAssert (rand(char.high),) == ('\a',)
+  doAssert (rand(char.high),) == (ord('\a'),)
 
   doAssert almostEqual(rand(12.5), 6.371734653537684)
   doAssert almostEqual(rand(2233.3322), 1039.453087565187)
@@ -65,3 +65,10 @@ for j in 1..5:
   doAssert abs(rs.min + maxVal) < 1.0
   doAssert abs(rs.max-maxVal) < 1.0
   rs.clear()
+
+type DiceRoll = range[3..6]
+var flag = false
+for i in 0..<100000:
+  if rand(5.DiceRoll) < 3:
+    flag = true
+doAssert flag

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -33,11 +33,12 @@ proc main =
   doAssert rand(0) == 0
   doAssert sample("a") == 'a'
 
-  doAssertRaises(RangeDefect):
-    discard rand(-1)
+  when compileOption("rangeChecks"):
+    doAssertRaises(RangeDefect):
+      discard rand(-1)
 
-  doAssertRaises(RangeDefect):
-    discard rand(-1.0)
+    doAssertRaises(RangeDefect):
+      discard rand(-1.0)
 
   # don't use causes integer overflow
   doAssert compiles(rand[int](low(int) .. high(int)))


### PR DESCRIPTION
Make it consistent with other overloads
```nim
proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
  when T is SomeFloat:
    result = rand(r, x.b - x.a) + x.a
  else: # Integers and Enum types
    result = T(rand(r, int(x.b) - int(x.a)) + int(x.a))
```