### PR TITLE
sequtils.nim: Change some `func` back to `proc`

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -359,7 +359,7 @@ func distribute*[T](s: seq[T], num: Positive, spread = true): seq[seq[T]] =
         result[i].add(s[g])
       first = last
 
-func map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
+proc map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
                                                             seq[S]{.inline.} =
   ## Returns a new sequence with the results of `op` proc applied to every
   ## item in the container `s`.
@@ -373,7 +373,7 @@ func map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
   ## See also:
   ## * `sugar.collect macro<sugar.html#collect.m%2Cuntyped%2Cuntyped>`_
   ## * `mapIt template<#mapIt.t,typed,untyped>`_
-  ## * `apply func<#apply,openArray[T],proc(T)_2>`_ for the in-place version
+  ## * `apply proc<#apply,openArray[T],proc(T)_2>`_ for the in-place version
   ##
   runnableExamples:
     let
@@ -385,7 +385,7 @@ func map*[T, S](s: openArray[T], op: proc (x: T): S {.closure.}):
   for i in 0 ..< s.len:
     result[i] = op(s[i])
 
-func apply*[T](s: var openArray[T], op: proc (x: var T) {.closure.})
+proc apply*[T](s: var openArray[T], op: proc (x: var T) {.closure.})
                                                               {.inline.} =
   ## Applies `op` to every item in `s` modifying it directly.
   ##
@@ -396,7 +396,7 @@ func apply*[T](s: var openArray[T], op: proc (x: var T) {.closure.})
   ##
   ## See also:
   ## * `applyIt template<#applyIt.t,untyped,untyped>`_
-  ## * `map func<#map,openArray[T],proc(T)>`_
+  ## * `map proc<#map,openArray[T],proc(T)>`_
   ##
   runnableExamples:
     var a = @["1", "2", "3", "4"]
@@ -405,7 +405,7 @@ func apply*[T](s: var openArray[T], op: proc (x: var T) {.closure.})
 
   for i in 0 ..< s.len: op(s[i])
 
-func apply*[T](s: var openArray[T], op: proc (x: T): T {.closure.})
+proc apply*[T](s: var openArray[T], op: proc (x: T): T {.closure.})
                                                               {.inline.} =
   ## Applies `op` to every item in `s` modifying it directly.
   ##
@@ -416,7 +416,7 @@ func apply*[T](s: var openArray[T], op: proc (x: T): T {.closure.})
   ##
   ## See also:
   ## * `applyIt template<#applyIt.t,untyped,untyped>`_
-  ## * `map func<#map,openArray[T],proc(T)>`_
+  ## * `map proc<#map,openArray[T],proc(T)>`_
   ##
   runnableExamples:
     var a = @["1", "2", "3", "4"]
@@ -425,7 +425,7 @@ func apply*[T](s: var openArray[T], op: proc (x: T): T {.closure.})
 
   for i in 0 ..< s.len: s[i] = op(s[i])
 
-func apply*[T](s: openArray[T], op: proc (x: T) {.closure.}) {.inline, since: (1, 3).} =
+proc apply*[T](s: openArray[T], op: proc (x: T) {.closure.}) {.inline, since: (1, 3).} =
   ## Same as `apply` but for proc that do not return and do not mutate `s` directly.
   runnableExamples:
     var message: string
@@ -442,7 +442,7 @@ iterator filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): T =
   ##
   ## See also:
   ## * `sugar.collect macro<sugar.html#collect.m%2Cuntyped%2Cuntyped>`_
-  ## * `fliter func<#filter,openArray[T],proc(T)>`_
+  ## * `fliter proc<#filter,openArray[T],proc(T)>`_
   ## * `filterIt template<#filterIt.t,untyped,untyped>`_
   ##
   runnableExamples:
@@ -456,7 +456,7 @@ iterator filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): T =
     if pred(s[i]):
       yield s[i]
 
-func filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
+proc filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
                                                                   {.inline.} =
   ## Returns a new sequence with all the items of `s` that fulfilled the
   ## predicate `pred` (function that returns a `bool`).
@@ -468,7 +468,7 @@ func filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
   ## * `sugar.collect macro<sugar.html#collect.m%2Cuntyped%2Cuntyped>`_
   ## * `filterIt template<#filterIt.t,untyped,untyped>`_
   ## * `filter iterator<#filter.i,openArray[T],proc(T)>`_
-  ## * `keepIf func<#keepIf,seq[T],proc(T)>`_ for the in-place version
+  ## * `keepIf proc<#keepIf,seq[T],proc(T)>`_ for the in-place version
   ##
   runnableExamples:
     let
@@ -483,19 +483,19 @@ func filter*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): seq[T]
     if pred(s[i]):
       result.add(s[i])
 
-func keepIf*[T](s: var seq[T], pred: proc(x: T): bool {.closure.})
+proc keepIf*[T](s: var seq[T], pred: proc(x: T): bool {.closure.})
                                                                 {.inline.} =
   ## Keeps the items in the passed sequence `s` if they fulfilled the
   ## predicate `pred` (function that returns a `bool`).
   ##
   ## Note that `s` must be declared as a ``var``.
   ##
-  ## Similar to the `filter func<#filter,openArray[T],proc(T)>`_,
+  ## Similar to the `filter proc<#filter,openArray[T],proc(T)>`_,
   ## but modifies the sequence directly.
   ##
   ## See also:
   ## * `keepItIf template<#keepItIf.t,seq,untyped>`_
-  ## * `filter func<#filter,openArray[T],proc(T)>`_
+  ## * `filter proc<#filter,openArray[T],proc(T)>`_
   ##
   runnableExamples:
     var floats = @[13.0, 12.5, 5.8, 2.0, 6.1, 9.9, 10.1]
@@ -576,7 +576,7 @@ template filterIt*(s, pred: untyped): untyped =
   ## Returns a new sequence with all the items of `s` that fulfilled the
   ## predicate `pred`.
   ##
-  ## Unlike the `filter func<#filter,openArray[T],proc(T)>`_ and
+  ## Unlike the `filter proc<#filter,openArray[T],proc(T)>`_ and
   ## `filter iterator<#filter.i,openArray[T],proc(T)>`_,
   ## the predicate needs to be an expression using the `it` variable
   ## for testing, like: `filterIt("abcxyz", it == 'x')`.
@@ -586,7 +586,7 @@ template filterIt*(s, pred: untyped): untyped =
   ##
   ## See also:
   ## * `sugar.collect macro<sugar.html#collect.m%2Cuntyped%2Cuntyped>`_
-  ## * `fliter func<#filter,openArray[T],proc(T)>`_
+  ## * `fliter proc<#filter,openArray[T],proc(T)>`_
   ## * `filter iterator<#filter.i,openArray[T],proc(T)>`_
   ##
   runnableExamples:
@@ -606,12 +606,12 @@ template keepItIf*(varSeq: seq, pred: untyped) =
   ## Keeps the items in the passed sequence (must be declared as a `var`)
   ## if they fulfilled the predicate.
   ##
-  ## Unlike the `keepIf func<#keepIf,seq[T],proc(T)>`_,
+  ## Unlike the `keepIf proc<#keepIf,seq[T],proc(T)>`_,
   ## the predicate needs to be an expression using
   ## the `it` variable for testing, like: `keepItIf("abcxyz", it == 'x')`.
   ##
   ## See also:
-  ## * `keepIf func<#keepIf,seq[T],proc(T)>`_
+  ## * `keepIf proc<#keepIf,seq[T],proc(T)>`_
   ## * `filterIt template<#filterIt.t,untyped,untyped>`_
   ##
   runnableExamples:
@@ -650,13 +650,13 @@ since (1, 1):
       if pred: result += 1
     result
 
-func all*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): bool =
+proc all*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): bool =
   ## Iterates through a container and checks if every item fulfills the
   ## predicate.
   ##
   ## See also:
   ## * `allIt template<#allIt.t,untyped,untyped>`_
-  ## * `any func<#any,openArray[T],proc(T)>`_
+  ## * `any proc<#any,openArray[T],proc(T)>`_
   ##
   runnableExamples:
     let numbers = @[1, 4, 5, 8, 9, 7, 4]
@@ -672,12 +672,12 @@ template allIt*(s, pred: untyped): bool =
   ## Iterates through a container and checks if every item fulfills the
   ## predicate.
   ##
-  ## Unlike the `all func<#all,openArray[T],proc(T)>`_,
+  ## Unlike the `all proc<#all,openArray[T],proc(T)>`_,
   ## the predicate needs to be an expression using
   ## the `it` variable for testing, like: `allIt("abba", it == 'a')`.
   ##
   ## See also:
-  ## * `all func<#all,openArray[T],proc(T)>`_
+  ## * `all proc<#all,openArray[T],proc(T)>`_
   ## * `anyIt template<#anyIt.t,untyped,untyped>`_
   ##
   runnableExamples:
@@ -692,13 +692,13 @@ template allIt*(s, pred: untyped): bool =
       break
   result
 
-func any*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): bool =
+proc any*[T](s: openArray[T], pred: proc(x: T): bool {.closure.}): bool =
   ## Iterates through a container and checks if some item fulfills the
   ## predicate.
   ##
   ## See also:
   ## * `anyIt template<#anyIt.t,untyped,untyped>`_
-  ## * `all func<#all,openArray[T],proc(T)>`_
+  ## * `all proc<#all,openArray[T],proc(T)>`_
   ##
   runnableExamples:
     let numbers = @[1, 4, 5, 8, 9, 7, 4]
@@ -714,12 +714,12 @@ template anyIt*(s, pred: untyped): bool =
   ## Iterates through a container and checks if some item fulfills the
   ## predicate.
   ##
-  ## Unlike the `any func<#any,openArray[T],proc(T)>`_,
+  ## Unlike the `any proc<#any,openArray[T],proc(T)>`_,
   ## the predicate needs to be an expression using
   ## the `it` variable for testing, like: `anyIt("abba", it == 'a')`.
   ##
   ## See also:
-  ## * `any func<#any,openArray[T],proc(T)>`_
+  ## * `any proc<#any,openArray[T],proc(T)>`_
   ## * `allIt template<#allIt.t,untyped,untyped>`_
   ##
   runnableExamples:
@@ -946,7 +946,7 @@ template mapIt*(s: typed, op: untyped): untyped =
   ##
   ## See also:
   ## * `sugar.collect macro<sugar.html#collect.m%2Cuntyped%2Cuntyped>`_
-  ## * `map func<#map,openArray[T],proc(T)>`_
+  ## * `map proc<#map,openArray[T],proc(T)>`_
   ## * `applyIt template<#applyIt.t,untyped,untyped>`_ for the in-place version
   ##
   runnableExamples:
@@ -1007,14 +1007,14 @@ template mapIt*(s: typed, op: untyped): untyped =
     map(s, f)
 
 template applyIt*(varSeq, op: untyped) =
-  ## Convenience template around the mutable `apply` func to reduce typing.
+  ## Convenience template around the mutable `apply` proc to reduce typing.
   ##
   ## The template injects the `it` variable which you can use directly in an
   ## expression. The expression has to return the same type as the sequence you
   ## are mutating.
   ##
   ## See also:
-  ## * `apply func<#apply,openArray[T],proc(T)_2>`_
+  ## * `apply proc<#apply,openArray[T],proc(T)_2>`_
   ## * `mapIt template<#mapIt.t,typed,untyped>`_
   ##
   runnableExamples:


### PR DESCRIPTION
This PR is a partial revert of commit 6f57ebae349f (#16293), in case that's preferred to a full revert.

It changes the funcs that take a `proc` parameter back to procs.

See: https://github.com/nim-lang/Nim/issues/16303 and https://github.com/nim-lang/Nim/pull/16304#issuecomment-742140012:
> > To confirm: do we want to change a proc that has a proc parameter into a func?
> 
> No, it was an oversight by me. We don't want that. Callbacks can have effects.

Note that this PR doesn't fix regressions that @timotheecour mentions in https://github.com/nim-lang/Nim/issues/16305. For example:
```Nim
import std/sequtils
type Foo = ref object
  x: int
let a1 = zip(@[1,2], @[1,2]) # ok
let a2 = zip(@[Foo(x: 1)], @[Foo(x: 2)]) # error
```

still produces this error when compiling with `--experimental:strictFuncs`:
```
/Nim/lib/pure/collections/sequtils.nim(248, 8) Error: 'zip' can have side effects
an object reachable from 's1' is potentially mutated
/Nim/lib/pure/collections/sequtils.nim(284, 17) the mutation is here
/Nim/lib/pure/collections/sequtils.nim(284, 17) is the statement that connected the mutation to the parameter
``` 