### PR TITLE
Added `refSlice` and `mRefSlice` which sensibly iterates openArray slices.

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1110,7 +1110,7 @@ iterator refSlice*[T](arr: openArray[T], slice: Slice[int]): lent T {.since: (1,
   ## Iterators over a non duplicating slice of the array.
   runnableExamples:
     var a = [10, 20, 30]
-    for i in a.refSlice[1..2]:
+    for i in a.refSlice(1..2):
       assert a[i] == 20 or a[i] == 30
   for x in arr.toOpenArray(slice.a, slice.b):
     yield x
@@ -1119,7 +1119,7 @@ iterator mRefSlice*[T](arr: var openArray[T], slice: Slice[int]): var T {.since:
   ## Iterators over a mutable non duplicating slice of the array.
   runnableExamples:
     var a = [10, 20, 30]
-    for i in a.mrefSlice[1..2]:
+    for i in a.mrefSlice(1..2):
       i *= 2
     assert a == [10, 40, 60]
   for x in slice:

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1119,7 +1119,7 @@ iterator mRefSlice*[T](arr: var openArray[T], slice: Slice[int]): var T {.since:
   ## Iterators over a mutable non duplicating slice of the array.
   runnableExamples:
     var a = [10, 20, 30]
-    for i in a.refSlice[1..2]:
+    for i in a.mrefSlice[1..2]:
       i *= 2
     assert a == [10, 40, 60]
   for x in slice:

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1105,3 +1105,22 @@ iterator items*[T](xs: iterator: T): T =
   ## templates.
   for x in xs():
     yield x
+
+iterator refSlice*[T](arr: openArray[T], slice: Slice[int]): lent T {.since: (1, 5).} =
+  ## Iterators over a non duplicating slice of the array.
+  runnableExamples:
+    var a = [10, 20, 30]
+    for i in a.refSlice[1..2]:
+      assert a[i] == 20 or a[i] == 30
+  for x in arr.toOpenArray(slice.a, slice.b):
+    yield x
+
+iterator mRefSlice*[T](arr: var openArray[T], slice: Slice[int]): var T {.since: (1, 5).} =
+  ## Iterators over a mutable non duplicating slice of the array.
+  runnableExamples:
+    var a = [10, 20, 30]
+    for i in a.refSlice[1..2]:
+      i *= 2
+    assert a == [10, 40, 60]
+  for x in slice:
+    yield arr[x]

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1111,7 +1111,7 @@ iterator refSlice*[T](arr: openArray[T], slice: Slice[int]): lent T {.since: (1,
   runnableExamples:
     var a = [10, 20, 30]
     for i in a.refSlice(1..2):
-      assert a[i] == 20 or a[i] == 30
+      assert i == 20 or i == 30
   for x in arr.toOpenArray(slice.a, slice.b):
     yield x
 

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -455,3 +455,14 @@ block:
         yield i
 
   doAssert: iter(3).mapIt(2*it).foldl(a + b) == 6
+
+block:
+  # Tests for slice iterators
+  var a = [10, 20, 11, 21, 12, 22, 13, 23, 14, 24]
+  for v in a.mRefSlice(3..5):
+    v *= 2
+  doAssert(a == [10, 20, 11, 42, 24, 44, 13, 23, 14, 24])
+  let b = [5, 3, 2, 10, 20, 20]
+  for v in b.refSlice(3..5):
+    doAssert v == 10 or v == 20
+    


### PR DESCRIPTION
Adds an iterator which allows using slices to iterate openarrays without duplicating. Akin to doing `for _ in a.toOpenArray` but with more reasonable syntax. Probably needs renamed to something more descriptive.