### PR TITLE
Add jsxmlserializer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,10 +56,13 @@
 - `writeStackTrace` is available in JS backend now.
 
 - `strscans.scanf` now supports parsing single characters.
-- `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`. 
+- `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`.
 
 
 - Added `math.isNaN`.
+
+- Added `jsxmlserializer` module for [`XMLSerializer`](https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer) for the JavaScript target.
+
 
 ## Language changes
 

--- a/lib/js/jsxmlserializer.nim
+++ b/lib/js/jsxmlserializer.nim
@@ -1,0 +1,21 @@
+## - `XMLSerializer` for the JavaScript target: https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer
+when not defined(js) and not defined(nimdoc):
+  {.fatal: "Module jsxmlserializer is designed to be used with the JavaScript backend.".}
+
+from dom import Node
+export Node
+
+type XMLSerializer* = ref object  ## XMLSerializer API.
+
+func newXMLSerializer*(): XMLSerializer {.importjs: "new XMLSerializer()".}
+  ## https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer
+
+func serializeToString*(this: XMLSerializer; node: Node): cstring {.importjs: "#.serializeToString(#)".}
+  ## https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer/serializeToString
+
+
+runnableExamples:
+  when defined(nimJsXMLSerializerTests):
+    from dom import document
+    let cerealizer: XMLSerializer = newXMLSerializer()
+    echo cerealizer.serializeToString(node = document)


### PR DESCRIPTION
- Added `jsxmlserializer` module for `XMLSerializer` for the JavaScript target.
- https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer
- Serialize DOM to XML very fast. Tiny diff.

```nim
let cerealizer: XMLSerializer = newXMLSerializer()
echo cerealizer.serializeToString(node = document)
```

![temp](https://user-images.githubusercontent.com/1189414/102003135-37b7cd00-3ce2-11eb-83f2-a7ee05c5d45a.png)
