### PR TITLE
Syntax (RST) fix Internals of the Compiler

### DIFF
--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -118,20 +118,22 @@ Rebuilding the compiler
 
 After an initial build via `sh build_all.sh` on posix or `build_all.bat` on windows,
 you can rebuild the compiler as follows:
+
 * `nim c koch` if you need to rebuild koch
 * `./koch boot -d:release` this ensures the compiler can rebuild itself
   (use `koch` instead of `./koch` on windows), which builds the compiler 3 times.
 
 A faster approach if you don't need to run the full bootstrapping implied by `koch boot`,
 is the following:
+
 * `pathto/nim c --lib:lib -d:release -o:bin/nim_temp compiler/nim.nim`
+
 Where `pathto/nim` is any nim binary sufficiently recent (e.g. `bin/nim_cources`
 built during bootstrap or `$HOME/.nimble/bin/nim` installed by `choosenim 1.2.0`)
 
 You can pass any additional options such as `-d:leanCompiler` if you don't need
 certain features or `-d:debug --stacktrace:on --excessiveStackTrace --stackTraceMsgs`
-for debugging the compiler. See also
-[Debugging the compiler](intern.html#debugging-the-compiler).
+for debugging the compiler. See also `Debugging the compiler`_.
 
 Debugging the compiler
 ======================
@@ -174,8 +176,7 @@ To create a new compiler for each run, use ``koch temp``::
 
 ``koch temp`` creates a debug build of the compiler, which is useful
 to create stacktraces for compiler debugging. See also
-[Rebuilding the compiler](intern.html#rebuilding-the-compiler) if you need
-more control.
+`Rebuilding the compiler`_ if you need more control.
 
 Bisecting for regressions
 =========================
@@ -189,8 +190,7 @@ current commit.::
 
 You can also bisect using custom options to build the compiler, for example if
 you don't need a debug version of the compiler (which runs slower), you can replace
-`./koch temp` by explicit compilation command, see
-[Rebuilding the compiler](intern.html#rebuilding-the-compiler).
+`./koch temp` by explicit compilation command, see `Rebuilding the compiler`_.
 
 The compiler's architecture
 ===========================


### PR DESCRIPTION
'Rebuilding the Compiler' and a few other sections required syntax fixes:
* new lines before and after lists to fix rendering
* use internal reference instead of Markdown style link