### PR TITLE
fix #16330 tshould_not_work

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -144,7 +144,7 @@ proc prepareTestArgs(cmdTemplate, filename, options, nimcache: string,
   options.add " " & extraOptions
   result = parseCmdLine(cmdTemplate % ["target", targetToCmd[target],
                       "options", options, "file", filename.quoteShell,
-                      "filedir", filename.getFileDir()])
+                      "filedir", filename.getFileDir(), "nim", compilerPrefix])
 
 proc callCompiler(cmdTemplate, filename, options, nimcache: string,
                   target: TTarget, extraOptions = ""): TSpec =
@@ -682,7 +682,7 @@ proc main() =
       gTargets = parseTargets(targetsStr)
       targetsSet = true
     of "nim":
-      compilerPrefix = addFileExt(p.val.string, ExeExt)
+      compilerPrefix = addFileExt(p.val.string.absolutePath, ExeExt)
     of "directory":
       setCurrentDir(p.val.string)
     of "colors":

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -1,5 +1,5 @@
 discard """
-cmd: "testament/testament --directory:testament --colors:off --backendLogging:off --nim:../compiler/nim category shouldfail"
+cmd: "testament/testament --directory:testament --colors:off --backendLogging:off --nim:$nim category shouldfail"
 action: compile
 nimout: '''
 FAIL: tests/shouldfail/tccodecheck.nim c
@@ -35,5 +35,3 @@ FAIL: tests/shouldfail/tvalgrind.nim c
 Failure: reExitcodesDiffer
 '''
 """
-
-# xxx `--nim:../compiler/nim`, doesn't seem correct (and should also honor `testament --nim`)


### PR DESCRIPTION
fix #16330

this now works:
```
XDG_CONFIG_HOME= nim r testament/testament --nim:pathto/nim r tests/testament/tshould_not_work.nim
```
including if `pathto/nim` is a relative path, eg `bin/nim_temp`