### PR TITLE
testament: error instead of silently ignore invalid targets; remove pointless alias target vs targets; document matrix; DRY

### DIFF
--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -152,8 +152,11 @@ Example "template" **to edit** and write a Testament unittest:
     # Timeout seconds to run the test. Fractional values are supported.
     timeout: 1.5
 
-    # Targets to run the test into (C, C++, JavaScript, etc).
-    target: "c js"
+    # Targets to run the test into (c, cpp, objc, js).
+    targets: "c js"
+
+    # flags with which to run the test, delimited by `;`
+    matrix: "; -d:release; -d:caseFoo -d:release"
 
     # Conditions that will skip this test. Use of multiple "disabled" clauses
     # is permitted.
@@ -221,7 +224,7 @@ JavaScript tests:
 .. code-block:: nim
 
   discard """
-    target: "js"
+    targets: "js"
   """
   when defined(js):
     import jsconsole

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -382,14 +382,14 @@ proc parseSpec*(filename: string): TSpec =
           case v
           of "c":
             result.targets.incl(targetC)
-          of "cpp", "c++":
+          of "cpp":
             result.targets.incl(targetCpp)
           of "objc":
             result.targets.incl(targetObjC)
           of "js":
             result.targets.incl(targetJS)
           else:
-            result.parseErrors.addLine "cannot interpret as a target: ", e.value
+            result.parseErrors.addLine "cannot interpret as a target: '$1'" % v
       of "matrix":
         for v in e.value.split(';'):
           result.matrix.add(v.strip)

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -377,7 +377,7 @@ proc parseSpec*(filename: string): TSpec =
           result.timeout = parseFloat(e.value)
         except ValueError:
           result.parseErrors.addLine "cannot interpret as a float: ", e.value
-      of "targets":
+      of "targets", "target":
         try:
           result.targets.incl parseTargets(e.value)
         except ValueError as e:

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -218,7 +218,7 @@ proc parseTargets*(value: string): set[TTarget] =
     of "cpp": result.incl(targetCpp)
     of "objc": result.incl(targetObjC)
     of "js": result.incl(targetJS)
-    else: doAssert false, "invalid target: '$#'" % v
+    else: raise newException(ValueError, "invalid target: '$#'" % v)
 
 proc addLine*(self: var string; a: string) =
   self.add a
@@ -377,19 +377,11 @@ proc parseSpec*(filename: string): TSpec =
           result.timeout = parseFloat(e.value)
         except ValueError:
           result.parseErrors.addLine "cannot interpret as a float: ", e.value
-      of "target", "targets":
-        for v in e.value.normalize.splitWhitespace:
-          case v
-          of "c":
-            result.targets.incl(targetC)
-          of "cpp":
-            result.targets.incl(targetCpp)
-          of "objc":
-            result.targets.incl(targetObjC)
-          of "js":
-            result.targets.incl(targetJS)
-          else:
-            result.parseErrors.addLine "cannot interpret as a target: '$1'" % v
+      of "targets":
+        try:
+          result.targets.incl parseTargets(e.value)
+        except ValueError as e:
+          result.parseErrors.addLine e.msg
       of "matrix":
         for v in e.value.split(';'):
           result.matrix.add(v.strip)

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -215,10 +215,10 @@ proc parseTargets*(value: string): set[TTarget] =
   for v in value.normalize.splitWhitespace:
     case v
     of "c": result.incl(targetC)
-    of "cpp", "c++": result.incl(targetCpp)
+    of "cpp": result.incl(targetCpp)
     of "objc": result.incl(targetObjC)
     of "js": result.incl(targetJS)
-    else: echo "target ignored: " & v
+    else: doAssert false, "invalid target: '$#'" % v
 
 proc addLine*(self: var string; a: string) =
   self.add a

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -215,7 +215,7 @@ proc parseTargets*(value: string): set[TTarget] =
   for v in value.normalize.splitWhitespace:
     case v
     of "c": result.incl(targetC)
-    of "cpp": result.incl(targetCpp)
+    of "cpp", "c++": result.incl(targetCpp)
     of "objc": result.incl(targetObjC)
     of "js": result.incl(targetJS)
     else: raise newException(ValueError, "invalid target: '$#'" % v)

--- a/tests/align/talign.nim
+++ b/tests/align/talign.nim
@@ -1,6 +1,6 @@
 discard """
 ccodeCheck: "\\i @'NIM_ALIGN(128) NI mylocal1' .*"
-target: "c cpp"
+targets: "c cpp"
 output: "align ok"
 """
 

--- a/tests/arc/trtree.nim
+++ b/tests/arc/trtree.nim
@@ -1,7 +1,7 @@
 discard """
   output: '''1 [2, 3, 4, 7]
 [0, 0]'''
-  target: "c"
+  targets: "c"
   joinable: false
 disabled: 32bit
   cmd: "nim c --gc:arc $file"

--- a/tests/ccgbugs/tmissingvolatile.nim
+++ b/tests/ccgbugs/tmissingvolatile.nim
@@ -2,7 +2,7 @@ discard """
   output: "1"
   cmd: r"nim c --hints:on $options -d:release $file"
   ccodecheck: "'NI volatile state;'"
-  target: "C"
+  targets: "C"
 """
 
 # bug #1539

--- a/tests/ccgbugs/tmissingvolatile.nim
+++ b/tests/ccgbugs/tmissingvolatile.nim
@@ -2,7 +2,7 @@ discard """
   output: "1"
   cmd: r"nim c --hints:on $options -d:release $file"
   ccodecheck: "'NI volatile state;'"
-  targets: "C"
+  targets: "c"
 """
 
 # bug #1539

--- a/tests/ccgbugs/tprogmem.nim
+++ b/tests/ccgbugs/tprogmem.nim
@@ -2,7 +2,7 @@ discard """
   output: "5"
   cmd: r"nim c --hints:on $options -d:release $file"
   ccodecheck: "'/*PROGMEM*/ myLetVariable = {'"
-  targets: "C"
+  targets: "c"
 """
 
 var myLetVariable {.exportc, codegenDecl: "$# /*PROGMEM*/ $#".} = [1, 2, 3]

--- a/tests/ccgbugs/tprogmem.nim
+++ b/tests/ccgbugs/tprogmem.nim
@@ -2,7 +2,7 @@ discard """
   output: "5"
   cmd: r"nim c --hints:on $options -d:release $file"
   ccodecheck: "'/*PROGMEM*/ myLetVariable = {'"
-  target: "C"
+  targets: "C"
 """
 
 var myLetVariable {.exportc, codegenDecl: "$# /*PROGMEM*/ $#".} = [1, 2, 3]

--- a/tests/ccgbugs2/tinefficient_const_table.nim
+++ b/tests/ccgbugs2/tinefficient_const_table.nim
@@ -6,7 +6,7 @@ of
 words'''
   cmd: r"nim c --hints:on $options -d:release $file"
   ccodecheck: "! @'genericSeqAssign'"
-  target: "c"
+  targets: "c"
 """
 
 # bug #4354

--- a/tests/closure/tclosure.nim
+++ b/tests/closure/tclosure.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c"
+  targets: "c"
   output: '''
 1 3 6 11 20 foo
 foo88

--- a/tests/compiler/tcppCompileToNamespace.nim
+++ b/tests/compiler/tcppCompileToNamespace.nim
@@ -1,6 +1,5 @@
 discard """
 cmd: "nim cpp --cppCompileToNamespace:foo $options -r $file"
-target: cpp
 """
 
 # Theoretically nim could just ignore the flag cppCompileToNamespace

--- a/tests/coroutines/texceptions.nim
+++ b/tests/coroutines/texceptions.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c"
+  targets: "c"
   disabled: true
 """
 

--- a/tests/coroutines/tgc.nim
+++ b/tests/coroutines/tgc.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c"
+  targets: "c"
 """
 
 import coro

--- a/tests/coroutines/titerators.nim
+++ b/tests/coroutines/titerators.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c"
+  targets: "c"
 disabled: true
 """
 

--- a/tests/coroutines/twait.nim
+++ b/tests/coroutines/twait.nim
@@ -1,6 +1,6 @@
 discard """
   output: "Exit 1\nExit 2"
-  target: "c"
+  targets: "c"
 """
 import coro
 

--- a/tests/cpp/tevalorder.nim
+++ b/tests/cpp/tevalorder.nim
@@ -2,7 +2,7 @@ discard """
   output: '''0
 1
 2'''
-target: "cpp"
+targets: "cpp"
 """
 
 # bug #8202

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -8,7 +8,7 @@ test destroyed 0
 4
 Pony is dying!'''
 joinable: false
-target: "C"
+targets: "c"
 """
 
 # bug #4214

--- a/tests/destructor/tuse_result_prevents_sinks.nim
+++ b/tests/destructor/tuse_result_prevents_sinks.nim
@@ -1,6 +1,6 @@
 discard """
   output: ""
-  target: "C"
+  targets: "c"
 """
 
 # bug #9594

--- a/tests/exception/t9657.nim
+++ b/tests/exception/t9657.nim
@@ -1,7 +1,7 @@
 discard """
   action: run
   exitcode: 1
-  target: "c cpp"
+  targets: "c cpp"
   disabled: "openbsd"
   disabled: "netbsd"
 """

--- a/tests/flags/tgenscript.nim
+++ b/tests/flags/tgenscript.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c"
+  targets: "c"
   action: compile
 """
 

--- a/tests/iter/titervaropenarray.nim
+++ b/tests/iter/titervaropenarray.nim
@@ -1,6 +1,6 @@
 discard """
   output: "123"
-  targets: "C"
+  targets: "c"
 """
 # Try to break the transformation pass:
 iterator iterAndZero(a: var openArray[int]): int =

--- a/tests/objects/tobjcov.nim
+++ b/tests/objects/tobjcov.nim
@@ -1,6 +1,6 @@
 discard """
 action: compile
-target: "c"
+targets: "c"
 """
 
 # Covariance is not type safe:

--- a/tests/stdlib/t10231.nim
+++ b/tests/stdlib/t10231.nim
@@ -1,5 +1,5 @@
 discard """
-  target: cpp
+  targets: "cpp"
   action: run
   exitcode: 0
 """

--- a/tests/stdlib/thashes.nim
+++ b/tests/stdlib/thashes.nim
@@ -1,5 +1,5 @@
 discard """
-  targets: '''c c++ js'''
+  targets: "c cpp js"
 """
 
 import hashes

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c js"
+  targets: "c js"
 """
 
 import times, strutils, unittest

--- a/tests/system/tatomics1.nim
+++ b/tests/system/tatomics1.nim
@@ -1,5 +1,5 @@
 discard """
-  target: "c cpp js"
+  targets: "c cpp js"
 """
 
 var x = 10


### PR DESCRIPTION
* document `matrix` in testament.rst 
* remove code duplication (parseTargets content was duplicated)
* silently ignoring invalid spec doesn't make sense, this PR errors instead
* remove pointless aliasing `targets vs target` and instead only allow `targets` which is much more common (and fix tests); helps with searching especially for users not aware that the less common `target` even existed
* lowercase targets
* followup https://github.com/nim-lang/Nim/pull/15961 by enforcing it to avoid things like https://github.com/nim-lang/Nim/pull/15933#discussion_r542016310


this will do the right thing:
```
XDG_CONFIG_HOME= nim r -f testament/testament.nim --targets:'js c' r tests/stdlib/thashes.nim
```

these will fail:
```
XDG_CONFIG_HOME= nim r -f testament/testament.nim --targets:'js c nonexistant' r tests/stdlib/thashes.nim
```

or after adding an invalid target in tests/stdlib/thashes.nim:
```
XDG_CONFIG_HOME= nim r -f testament/testament.nim r tests/stdlib/thashes.nim
```
