### PR TITLE
fix #16206, `nim r / nim -r` recompiles if cwd changes

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -1023,6 +1023,8 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
     lit $(%* conf.projectIsCmd)
     lit ",\L\"cmdInput\": "
     lit $(%* conf.cmdInput)
+    lit ",\L\"currentDir\": "
+    lit $(%* getCurrentDir())
 
     if optRun in conf.globalOptions or isDefined(conf, "nimBetterRun"):
       lit ",\L\"cmdline\": "
@@ -1043,14 +1045,23 @@ proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; projectfile: Absol
   result = false
   try:
     let data = json.parseFile(jsonFile.string)
-    if not data.hasKey("depfiles") or not data.hasKey("cmdline"):
+    for key in "depfiles cmdline stdinInput currentDir".split:
+      if not data.hasKey(key): return true
+    if getCurrentDir() != data["currentDir"].getStr:
+      # fixes bug #16271
+      # Note that simply comparing `expandFilename(projectFile)` would
+      # not be sufficient in case other flags depend implicitly on `getCurrentDir`,
+      # and would require much more care. Simply re-compiling is safer for now.
+      # A better strategy for future work would be to cache (with an LRU cache)
+      # the N most recent unique build instructions, as done with `rdmd`,
+      # which is both robust and avoids recompilation when switching back and forth
+      # between projects, see https://github.com/timotheecour/Nim/issues/199
       return true
     let oldCmdLine = data["cmdline"].getStr
     if conf.commandLine != oldCmdLine:
       return true
     if hashNimExe() != data["nimexe"].getStr:
       return true
-    if not data.hasKey("stdinInput"): return true
     let stdinInput = data["stdinInput"].getBool
     let projectIsCmd = data["projectIsCmd"].getBool
     if conf.projectIsStdin or stdinInput:


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/16271

`nim r` / `nim -r` recompiles if cwd changes

I'm hitting same bug as original reporter of https://github.com/nim-lang/Nim/issues/16271, eg with `nim r testament/testament args...`; this PR fixes that in the simplest possible way, that is robust even if pessimistic (recompile on cwd change). Future PR's can add more logic to be robust and less pessimistic, see comment in PR.

## future work
* `-d:nimBetterRunIgnoreCwd` (see `pr_fix_nimcache_nimrun_16271_followup_nimBetterRunIgnoreCwd` wip PR)
* robust approach described inside PR comment (it has other advantages which is caching more than 1 compilation, using a LRU cache to avoid blowing up disk usage)
