### PR TITLE
More colorful error messages

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -11,7 +11,7 @@
 # included from sem.nim
 
 from algorithm import sort
-
+from renderer import quoteExpr
 proc sameMethodDispatcher(a, b: PSym): bool =
   result = false
   if a.kind == skMethod and b.kind == skMethod:
@@ -234,16 +234,16 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         let wanted = err.firstMismatch.formal.typ
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
-        candidates.addTypeDeclVerboseMaybe(c.config, wanted)
-        candidates.add "\n  but expression '"
+        candidates.add typeToString(wanted)
+        candidates.addDeclaredLocMaybe(c.config, wanted)
+        candidates.add "\n  but expression "
         if err.firstMismatch.kind == kVarNeeded:
-          candidates.add renderNotLValue(nArg)
-          candidates.add "' is immutable, not 'var'"
+          candidates.add "$1 is immutable, not 'var'" % renderNotLValue(nArg).quoteExpr
         else:
-          candidates.add renderTree(nArg)
-          candidates.add "' is of type: "
-          let got = nArg.typ
-          candidates.addTypeDeclVerboseMaybe(c.config, got)
+          candidates.add "$1 is of type: " % renderTree(nArg).quoteExpr
+          var got = nArg.typ
+          candidates.add typeToString(got).quoteExpr
+          candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil:
             if got.kind == tyProc and wanted.kind == tyProc:
@@ -274,8 +274,8 @@ const
   errTypeMismatch = "type mismatch: got <"
   errButExpected = "but expected one of:"
   errUndeclaredField = "undeclared field: '$1'"
-  errUndeclaredRoutine = "attempting to call undeclared routine: '$1'"
-  errBadRoutine = "attempting to call routine: '$1'$2"
+  errUndeclaredRoutine = "attempting to call undeclared routine: $1"
+  errBadRoutine = "attempting to call routine: $1$2"
   errAmbiguousCallXYZ = "ambiguous call; both $1 and $2 match for: $3"
 
 proc notFoundError*(c: PContext, n: PNode, errors: CandidateErrors) =
@@ -287,7 +287,7 @@ proc notFoundError*(c: PContext, n: PNode, errors: CandidateErrors) =
     globalError(c.config, n.info, "type mismatch")
     return
   if errors.len == 0:
-    localError(c.config, n.info, "expression '$1' cannot be called" % n[0].renderTree)
+    localError(c.config, n.info, "expression $1 cannot be called" % n[0].renderTree.quoteExpr)
     return
 
   let (prefer, candidates) = presentFailedCandidates(c, n, errors)
@@ -325,7 +325,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      result &= "\n  found $1" % [getSymRepr(c.config, sym)]
+      result &= "\n  found $1" % [getSymRepr(c.config, sym).quoteExpr]
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s
@@ -344,8 +344,8 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     let suffix = if result.len > 0: " " & result else: ""
     result = errUndeclaredField % ident & typeHint & suffix
   else:
-    if result.len == 0: result = errUndeclaredRoutine % ident
-    else: result = errBadRoutine % [ident, result]
+    if result.len == 0: result = errUndeclaredRoutine % ident.quoteExpr
+    else: result = errBadRoutine % [ident.quoteExpr, result.quoteExpr]
 
 proc resolveOverloads(c: PContext, n, orig: PNode,
                       filter: TSymKinds, flags: TExprFlags,
@@ -432,8 +432,8 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       return
     elif result.state != csMatch:
       if nfExprCall in n.flags:
-        localError(c.config, n.info, "expression '$1' cannot be called" %
-                   renderTree(n, {renderNoComments}))
+        localError(c.config, n.info, "expression $1 cannot be called" %
+                   renderTree(n, {renderNoComments}).quoteExpr)
       else:
         if {nfDotField, nfDotSetter} * n.flags != {}:
           # clean up the inserted ops
@@ -457,8 +457,8 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
       args.add(")")
 
       localError(c.config, n.info, errAmbiguousCallXYZ % [
-        getProcHeader(c.config, result.calleeSym),
-        getProcHeader(c.config, alt.calleeSym),
+        getProcHeader(c.config, result.calleeSym).quoteExpr,
+        getProcHeader(c.config, alt.calleeSym).quoteExpr,
         args])
 
 proc instGenericConvertersArg*(c: PContext, a: PNode, x: TCandidate) =
@@ -622,7 +622,7 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
       notFoundError(c, n, errors)
 
 proc explicitGenericInstError(c: PContext; n: PNode): PNode =
-  localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n))
+  localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n).quoteExpr)
   result = n
 
 proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =
@@ -664,8 +664,8 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
     # number of generic type parameters:
     if s.ast[genericParamsPos].safeLen != n.len-1:
       let expected = s.ast[genericParamsPos].safeLen
-      localError(c.config, getCallLineInfo(n), errGenerated, "cannot instantiate: '" & renderTree(n) &
-         "'; got " & $(n.len-1) & " typeof(s) but expected " & $expected)
+      localError(c.config, getCallLineInfo(n), errGenerated, "cannot instantiate: " & renderTree(n) &
+         "; got " & $(n.len-1) & " typeof(s) but expected " & $expected)
       return n
     result = explicitGenericSym(c, n, s)
     if result == nil: result = explicitGenericInstError(c, n)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -325,7 +325,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      result &= "\n  found $1" % [getSymRepr(c.config, sym).quoteExpr]
+      result &= "\n  found $1" % [getSymRepr(c.config, sym)]
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s
@@ -345,7 +345,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     result = errUndeclaredField % ident & typeHint & suffix
   else:
     if result.len == 0: result = errUndeclaredRoutine % ident.quoteExpr
-    else: result = errBadRoutine % [ident.quoteExpr, result.quoteExpr]
+    else: result = errBadRoutine % [ident.quoteExpr, result]
 
 proc resolveOverloads(c: PContext, n, orig: PNode,
                       filter: TSymKinds, flags: TExprFlags,
@@ -622,7 +622,7 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
       notFoundError(c, n, errors)
 
 proc explicitGenericInstError(c: PContext; n: PNode): PNode =
-  localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n).quoteExpr)
+  localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n))
   result = n
 
 proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -234,16 +234,16 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         let wanted = err.firstMismatch.formal.typ
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
-        candidates.add typeToString(wanted)
-        candidates.addDeclaredLocMaybe(c.config, wanted)
-        candidates.add "\n  but expression "
+        candidates.addTypeDeclVerboseMaybe(c.config, wanted)
+        candidates.add "\n  but expression '"
         if err.firstMismatch.kind == kVarNeeded:
-          candidates.add "$1 is immutable, not 'var'" % renderNotLValue(nArg).quoteExpr
+          candidates.add renderNotLValue(nArg)
+          candidates.add "' is immutable, not 'var'"
         else:
-          candidates.add "$1 is of type: " % renderTree(nArg).quoteExpr
-          var got = nArg.typ
-          candidates.add typeToString(got).quoteExpr
-          candidates.addDeclaredLocMaybe(c.config, got)
+          candidates.add renderTree(nArg)
+          candidates.add "' is of type: "
+          let got = nArg.typ
+          candidates.addTypeDeclVerboseMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil:
             if got.kind == tyProc and wanted.kind == tyProc:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -53,10 +53,10 @@ proc typeToString*(typ: PType; prefer: TPreferedDesc = preferName): string
 
 proc addTypeDeclVerboseMaybe*(result: var string, conf: ConfigRef; typ: PType) =
   if optDeclaredLocs in conf.globalOptions:
-    result.add typeToString(typ, preferMixed)
+    result.add typeToString(typ, preferMixed).quoteExpr
     result.addDeclaredLoc(conf, typ)
   else:
-    result.add typeToString(typ)
+    result.add typeToString(typ).quoteExpr
 
 template `$`*(typ: PType): string = typeToString(typ)
 

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -6,28 +6,28 @@ but expected one of:
 proc test(foo: Foo[int])
   first type mismatch at position: 1
   required type for foo: Foo[int]
-  but expression 'bar' is of type: Bar[system.int]
+  but expression 'bar' is of type: 'Bar[system.int]'
 t3330.nim(55, 8) Hint: Non-matching candidates for add(k, string, T)
 proc add(x: var string; y: char)
   first type mismatch at position: 1
   required type for x: var string
-  but expression 'k' is of type: Alias
+  but expression 'k' is of type: 'Alias'
 proc add(x: var string; y: cstring)
   first type mismatch at position: 1
   required type for x: var string
-  but expression 'k' is of type: Alias
+  but expression 'k' is of type: 'Alias'
 proc add(x: var string; y: string)
   first type mismatch at position: 1
   required type for x: var string
-  but expression 'k' is of type: Alias
+  but expression 'k' is of type: 'Alias'
 proc add[T](x: var seq[T]; y: openArray[T])
   first type mismatch at position: 1
   required type for x: var seq[T]
-  but expression 'k' is of type: Alias
+  but expression 'k' is of type: 'Alias'
 proc add[T](x: var seq[T]; y: sink T)
   first type mismatch at position: 1
   required type for x: var seq[T]
-  but expression 'k' is of type: Alias
+  but expression 'k' is of type: 'Alias'
 
 t3330.nim(55, 8) template/generic instantiation of `add` from here
 t3330.nim(62, 6) Foo: 'bar.value' cannot be assigned to

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -5,28 +5,28 @@ t3330.nim(70, 4) Error: type mismatch: got <Bar[system.int]>
 but expected one of:
 proc test(foo: Foo[int])
   first type mismatch at position: 1
-  required type for foo: Foo[int]
+  required type for foo: 'Foo[int]'
   but expression 'bar' is of type: 'Bar[system.int]'
 t3330.nim(55, 8) Hint: Non-matching candidates for add(k, string, T)
 proc add(x: var string; y: char)
   first type mismatch at position: 1
-  required type for x: var string
+  required type for x: 'var string'
   but expression 'k' is of type: 'Alias'
 proc add(x: var string; y: cstring)
   first type mismatch at position: 1
-  required type for x: var string
+  required type for x: 'var string'
   but expression 'k' is of type: 'Alias'
 proc add(x: var string; y: string)
   first type mismatch at position: 1
-  required type for x: var string
+  required type for x: 'var string'
   but expression 'k' is of type: 'Alias'
 proc add[T](x: var seq[T]; y: openArray[T])
   first type mismatch at position: 1
-  required type for x: var seq[T]
+  required type for x: 'var seq[T]'
   but expression 'k' is of type: 'Alias'
 proc add[T](x: var seq[T]; y: sink T)
   first type mismatch at position: 1
-  required type for x: var seq[T]
+  required type for x: 'var seq[T]'
   but expression 'k' is of type: 'Alias'
 
 t3330.nim(55, 8) template/generic instantiation of `add` from here

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -5,13 +5,13 @@ texplain.nim(162, 10) Hint: Non-matching candidates for e(y)
 proc e(i: int): int
   first type mismatch at position: 1
   required type for i: int
-  but expression 'y' is of type: MatchingType
+  but expression 'y' is of type: 'MatchingType'
 
 texplain.nim(165, 7) Hint: Non-matching candidates for e(10)
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
-  but expression '10' is of type: int literal(10)
+  but expression '10' is of type: 'int literal(10)'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: 'foo'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: '.'
 texplain.nim(128, 6) ExplainedConcept: expression '.' cannot be called
@@ -27,7 +27,7 @@ texplain.nim(168, 10) Hint: Non-matching candidates for e(10)
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
-  but expression '10' is of type: int literal(10)
+  but expression '10' is of type: 'int literal(10)'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: 'foo'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: '.'
 texplain.nim(128, 6) ExplainedConcept: expression '.' cannot be called
@@ -44,11 +44,11 @@ but expected one of:
 proc e(i: int): int
   first type mismatch at position: 1
   required type for i: int
-  but expression 'n' is of type: NonMatchingType
+  but expression 'n' is of type: 'NonMatchingType'
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
-  but expression 'n' is of type: NonMatchingType
+  but expression 'n' is of type: 'NonMatchingType'
 texplain.nim(172, 9) template/generic instantiation of `assert` from here
 texplain.nim(128, 5) ExplainedConcept: concept predicate failed
 
@@ -58,35 +58,35 @@ but expected one of:
 proc r(i: string): int
   first type mismatch at position: 1
   required type for i: string
-  but expression 'n' is of type: NonMatchingType
+  but expression 'n' is of type: 'NonMatchingType'
 proc r(o: RegularConcept): int
   first type mismatch at position: 1
   required type for o: RegularConcept
-  but expression 'n' is of type: NonMatchingType
+  but expression 'n' is of type: 'NonMatchingType'
 texplain.nim(173, 9) template/generic instantiation of `assert` from here
 texplain.nim(132, 5) RegularConcept: concept predicate failed
 proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
   required type for a: SomeNumber
-  but expression 'n' is of type: NonMatchingType
+  but expression 'n' is of type: 'NonMatchingType'
 
 expression: r(n)
 texplain.nim(174, 20) Hint: Non-matching candidates for r(y)
 proc r(i: string): int
   first type mismatch at position: 1
   required type for i: string
-  but expression 'y' is of type: MatchingType
+  but expression 'y' is of type: 'MatchingType'
 proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
   required type for a: SomeNumber
-  but expression 'y' is of type: MatchingType
+  but expression 'y' is of type: 'MatchingType'
 
 texplain.nim(182, 2) Error: type mismatch: got <MatchingType>
 but expected one of:
 proc f(o: NestedConcept)
   first type mismatch at position: 1
   required type for o: NestedConcept
-  but expression 'y' is of type: MatchingType
+  but expression 'y' is of type: 'MatchingType'
 texplain.nim(132, 6) RegularConcept: undeclared field: 'foo'
 texplain.nim(132, 6) RegularConcept: undeclared field: '.'
 texplain.nim(132, 6) RegularConcept: expression '.' cannot be called

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -4,13 +4,13 @@ discard """
 texplain.nim(162, 10) Hint: Non-matching candidates for e(y)
 proc e(i: int): int
   first type mismatch at position: 1
-  required type for i: int
+  required type for i: 'int'
   but expression 'y' is of type: 'MatchingType'
 
 texplain.nim(165, 7) Hint: Non-matching candidates for e(10)
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
-  required type for o: ExplainedConcept
+  required type for o: 'ExplainedConcept'
   but expression '10' is of type: 'int literal(10)'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: 'foo'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: '.'
@@ -26,7 +26,7 @@ texplain.nim(128, 5) ExplainedConcept: concept predicate failed
 texplain.nim(168, 10) Hint: Non-matching candidates for e(10)
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
-  required type for o: ExplainedConcept
+  required type for o: 'ExplainedConcept'
   but expression '10' is of type: 'int literal(10)'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: 'foo'
 texplain.nim(128, 6) ExplainedConcept: undeclared field: '.'
@@ -43,11 +43,11 @@ texplain.nim(172, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
 proc e(i: int): int
   first type mismatch at position: 1
-  required type for i: int
+  required type for i: 'int'
   but expression 'n' is of type: 'NonMatchingType'
 proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
-  required type for o: ExplainedConcept
+  required type for o: 'ExplainedConcept'
   but expression 'n' is of type: 'NonMatchingType'
 texplain.nim(172, 9) template/generic instantiation of `assert` from here
 texplain.nim(128, 5) ExplainedConcept: concept predicate failed
@@ -57,35 +57,35 @@ texplain.nim(173, 20) Error: type mismatch: got <NonMatchingType>
 but expected one of:
 proc r(i: string): int
   first type mismatch at position: 1
-  required type for i: string
+  required type for i: 'string'
   but expression 'n' is of type: 'NonMatchingType'
 proc r(o: RegularConcept): int
   first type mismatch at position: 1
-  required type for o: RegularConcept
+  required type for o: 'RegularConcept'
   but expression 'n' is of type: 'NonMatchingType'
 texplain.nim(173, 9) template/generic instantiation of `assert` from here
 texplain.nim(132, 5) RegularConcept: concept predicate failed
 proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
-  required type for a: SomeNumber
+  required type for a: 'SomeNumber'
   but expression 'n' is of type: 'NonMatchingType'
 
 expression: r(n)
 texplain.nim(174, 20) Hint: Non-matching candidates for r(y)
 proc r(i: string): int
   first type mismatch at position: 1
-  required type for i: string
+  required type for i: 'string'
   but expression 'y' is of type: 'MatchingType'
 proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1
-  required type for a: SomeNumber
+  required type for a: 'SomeNumber'
   but expression 'y' is of type: 'MatchingType'
 
 texplain.nim(182, 2) Error: type mismatch: got <MatchingType>
 but expected one of:
 proc f(o: NestedConcept)
   first type mismatch at position: 1
-  required type for o: NestedConcept
+  required type for o: 'NestedConcept'
   but expression 'y' is of type: 'MatchingType'
 texplain.nim(132, 6) RegularConcept: undeclared field: 'foo'
 texplain.nim(132, 6) RegularConcept: undeclared field: '.'

--- a/tests/errmsgs/t8434.nim
+++ b/tests/errmsgs/t8434.nim
@@ -4,7 +4,7 @@ discard """
 proc fun0[T1: int | float | object | array | seq](a1: T1; a2: int)
   first type mismatch at position: 1
   required type for a1: T1: int or float or object or array or seq
-  but expression 'byte(1)' is of type: byte
+  but expression 'byte(1)' is of type: 'byte'
 
 expression: fun0(byte(1), 0)
 '''

--- a/tests/errmsgs/t8434.nim
+++ b/tests/errmsgs/t8434.nim
@@ -3,7 +3,7 @@ discard """
   nimout: '''but expected one of:
 proc fun0[T1: int | float | object | array | seq](a1: T1; a2: int)
   first type mismatch at position: 1
-  required type for a1: T1: int or float or object or array or seq
+  required type for a1: 'T1: int or float or object or array or seq'
   but expression 'byte(1)' is of type: 'byte'
 
 expression: fun0(byte(1), 0)

--- a/tests/errmsgs/tdeclaredlocs.nim
+++ b/tests/errmsgs/tdeclaredlocs.nim
@@ -7,44 +7,44 @@ tdeclaredlocs.nim(92, 3) Error: type mismatch: got <seq[MyInt2]>
 but expected one of:
 proc fn(a: Bam) [proc declared in tdeclaredlocs.nim(86, 6)]
   first type mismatch at position: 1
-  required type for a: Bam [object declared in tdeclaredlocs.nim(78, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'Bam' [object declared in tdeclaredlocs.nim(78, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: Goo[MyInt2]) [proc declared in tdeclaredlocs.nim(89, 6)]
   first type mismatch at position: 1
-  required type for a: Goo[MyInt2{char}] [object declared in tdeclaredlocs.nim(79, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'Goo[MyInt2{char}]' [object declared in tdeclaredlocs.nim(79, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: Goo[cint]) [proc declared in tdeclaredlocs.nim(88, 6)]
   first type mismatch at position: 1
-  required type for a: Goo[cint{int32}] [object declared in tdeclaredlocs.nim(79, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'Goo[cint{int32}]' [object declared in tdeclaredlocs.nim(79, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: array[3, Bar]) [proc declared in tdeclaredlocs.nim(82, 6)]
   first type mismatch at position: 1
-  required type for a: array[0..2, Bar] [object declared in tdeclaredlocs.nim(74, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'array[0..2, Bar]' [object declared in tdeclaredlocs.nim(74, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: seq[Bar]) [proc declared in tdeclaredlocs.nim(81, 6)]
   first type mismatch at position: 1
-  required type for a: seq[Bar] [object declared in tdeclaredlocs.nim(74, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'seq[Bar]' [object declared in tdeclaredlocs.nim(74, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: seq[MyInt1]) [proc declared in tdeclaredlocs.nim(80, 6)]
   first type mismatch at position: 1
-  required type for a: seq[MyInt1{int}] [int declared in tdeclaredlocs.nim(72, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'seq[MyInt1{int}]' [int declared in tdeclaredlocs.nim(72, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: set[Baz]) [proc declared in tdeclaredlocs.nim(84, 6)]
   first type mismatch at position: 1
-  required type for a: set[Baz{enum}] [enum declared in tdeclaredlocs.nim(75, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'set[Baz{enum}]' [enum declared in tdeclaredlocs.nim(75, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: set[MyInt2]) [proc declared in tdeclaredlocs.nim(83, 6)]
   first type mismatch at position: 1
-  required type for a: set[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'set[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: var SetBaz) [proc declared in tdeclaredlocs.nim(85, 6)]
   first type mismatch at position: 1
-  required type for a: var SetBaz [enum declared in tdeclaredlocs.nim(75, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'var SetBaz' [enum declared in tdeclaredlocs.nim(75, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 proc fn(a: var ref ptr Bam) [proc declared in tdeclaredlocs.nim(87, 6)]
   first type mismatch at position: 1
-  required type for a: var ref ptr Bam [object declared in tdeclaredlocs.nim(78, 3)]
-  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  required type for a: 'var ref ptr Bam' [object declared in tdeclaredlocs.nim(78, 3)]
+  but expression 'a' is of type: 'seq[MyInt2{char}]' [char declared in tdeclaredlocs.nim(73, 3)]
 
 expression: fn(a)
 '''

--- a/tests/errmsgs/tdetailed_position.nim
+++ b/tests/errmsgs/tdetailed_position.nim
@@ -1,12 +1,13 @@
 
 discard """
-cmd: "nim check $file"
+cmd: "nim check --hints: off $file"
 errormsg: "type mismatch: got <int literal(1), int literal(2), int literal(3)>"
 nimout: '''
+tdetailed_position.nim(23, 5) Error: type mismatch: got <int literal(1), int literal(2), int literal(3)>
 but expected one of:
 proc main(a, b, c: string)
   first type mismatch at position: 1
-  required type for a: string
+  required type for a: 'string'
   but expression '1' is of type: 'int literal(1)'
 
 expression: main(1, 2, 3)

--- a/tests/errmsgs/tdetailed_position.nim
+++ b/tests/errmsgs/tdetailed_position.nim
@@ -7,7 +7,7 @@ but expected one of:
 proc main(a, b, c: string)
   first type mismatch at position: 1
   required type for a: string
-  but expression '1' is of type: int literal(1)
+  but expression '1' is of type: 'int literal(1)'
 
 expression: main(1, 2, 3)
 '''

--- a/tests/errmsgs/tgcsafety.nim
+++ b/tests/errmsgs/tgcsafety.nim
@@ -10,7 +10,7 @@ proc serve(server: AsyncHttpServer; port: Port;
     Future[void])
   first type mismatch at position: 3
   required type for callback: proc (request: Request): Future[system.void]{.closure, gcsafe.}
-  but expression 'cb' is of type: proc (req: Request): Future[system.void]{.locks: <unknown>.}
+  but expression 'cb' is of type: 'proc (req: Request): Future[system.void]{.locks: <unknown>.}'
   This expression is not GC-safe. Annotate the proc with {.gcsafe.} to get extended error information.
 
 expression: serve(server, Port(7898), cb)

--- a/tests/errmsgs/tgcsafety.nim
+++ b/tests/errmsgs/tgcsafety.nim
@@ -1,16 +1,17 @@
 discard """
-cmd: "nim check $file"
+cmd: "nim check --hints:off $file"
 errormsg: "type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.void]{.locks: <unknown>.}>"
 nimout: '''
-tgcsafety.nim(31, 18) Error: type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.void]{.locks: <unknown>.}>
+tgcsafety.nim(32, 18) Error: type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.void]{.locks: <unknown>.}>
 but expected one of:
 proc serve(server: AsyncHttpServer; port: Port;
            callback: proc (request: Request): Future[void] {.closure, gcsafe.};
            address = ""; assumedDescriptorsPerRequest = -1): owned(
     Future[void])
   first type mismatch at position: 3
-  required type for callback: proc (request: Request): Future[system.void]{.closure, gcsafe.}
+  required type for callback: 'proc (request: Request): Future[system.void]{.closure, gcsafe.}'
   but expression 'cb' is of type: 'proc (req: Request): Future[system.void]{.locks: <unknown>.}'
+  Pragma mismatch: got '{..}', but expected '{.gcsafe.}'.
   This expression is not GC-safe. Annotate the proc with {.gcsafe.} to get extended error information.
 
 expression: serve(server, Port(7898), cb)

--- a/tests/errmsgs/tproc_mismatch.nim
+++ b/tests/errmsgs/tproc_mismatch.nim
@@ -9,7 +9,7 @@ tproc_mismatch.nim(39, 6) Error: type mismatch: got <proc (){.inline, noSideEffe
 but expected one of:
 proc bar(a: proc ())
   first type mismatch at position: 1
-  required type for a: proc (){.closure.}
+  required type for a: 'proc (){.closure.}'
   but expression 'fn1' is of type: 'proc (){.inline, noSideEffect, gcsafe, locks: 0.}'
   Calling convention mismatch: got '{.inline.}', but expected '{.closure.}'.
 

--- a/tests/errmsgs/tproc_mismatch.nim
+++ b/tests/errmsgs/tproc_mismatch.nim
@@ -10,7 +10,7 @@ but expected one of:
 proc bar(a: proc ())
   first type mismatch at position: 1
   required type for a: proc (){.closure.}
-  but expression 'fn1' is of type: proc (){.inline, noSideEffect, gcsafe, locks: 0.}
+  but expression 'fn1' is of type: 'proc (){.inline, noSideEffect, gcsafe, locks: 0.}'
   Calling convention mismatch: got '{.inline.}', but expected '{.closure.}'.
 
 expression: bar(fn1)

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -2,86 +2,86 @@ discard """
   cmd: "nim check --showAllMismatches:on --hints:off $file"
   nimout: '''
 tsigmatch.nim(113, 4) Error: type mismatch: got <A, string>
-but expected one of: 
+but expected one of:
 proc f(a: A)
   first type mismatch at position: 2
   extra argument given
 proc f(b: B)
   first type mismatch at position: 1
-  required type for b: B
+  required type for b: 'B'
   but expression 'A()' is of type: 'A'
 
 expression: f(A(), "extra")
 tsigmatch.nim(127, 6) Error: type mismatch: got <(string, proc (){.gcsafe, locks: 0.})>
-but expected one of: 
+but expected one of:
 proc foo(x: (string, proc ()))
   first type mismatch at position: 1
-  required type for x: (string, proc (){.closure.})
+  required type for x: '(string, proc (){.closure.})'
   but expression '("foobar", proc () = echo(["Hello!"]))' is of type: '(string, proc (){.gcsafe, locks: 0.})'
 
 expression: foo(("foobar", proc () = echo(["Hello!"])))
 tsigmatch.nim(134, 11) Error: type mismatch: got <proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}>
-but expected one of: 
+but expected one of:
 proc foo[T, S](op: proc (x: T): S {.cdecl.}): auto
   first type mismatch at position: 1
-  required type for op: proc (x: T): S{.cdecl.}
+  required type for op: 'proc (x: T): S{.cdecl.}'
   but expression 'fun' is of type: 'proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}'
   Calling convention mismatch: got '{.nimcall.}', but expected '{.cdecl.}'.
 proc foo[T, S](op: proc (x: T): S {.safecall.}): auto
   first type mismatch at position: 1
-  required type for op: proc (x: T): S{.safecall.}
+  required type for op: 'proc (x: T): S{.safecall.}'
   but expression 'fun' is of type: 'proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}'
   Calling convention mismatch: got '{.nimcall.}', but expected '{.safecall.}'.
 
 expression: foo(fun)
 tsigmatch.nim(145, 13) Error: type mismatch: got <array[0..0, proc (x: int){.gcsafe, locks: 0.}]>
-but expected one of: 
+but expected one of:
 proc takesFuncs(fs: openArray[proc (x: int) {.gcsafe, locks: 0.}])
   first type mismatch at position: 1
-  required type for fs: openArray[proc (x: int){.closure, gcsafe, locks: 0.}]
+  required type for fs: 'openArray[proc (x: int){.closure, gcsafe, locks: 0.}]'
   but expression '[proc (x: int) {.gcsafe, locks: 0.} = echo [x]]' is of type: 'array[0..0, proc (x: int){.gcsafe, locks: 0.}]'
 
 expression: takesFuncs([proc (x: int) {.gcsafe, locks: 0.} = echo [x]])
 tsigmatch.nim(151, 4) Error: type mismatch: got <int literal(10), a0: int literal(5), string>
-but expected one of: 
+but expected one of:
 proc f(a0: uint8; b: string)
   first type mismatch at position: 2
   named param already provided: a0
 
 expression: f(10, a0 = 5, "")
 tsigmatch.nim(158, 4) Error: type mismatch: got <string, string, string, string, string, float64, string>
-but expected one of: 
+but expected one of:
 proc f(a1: int)
   first type mismatch at position: 1
-  required type for a1: int
+  required type for a1: 'int'
   but expression '"asdf"' is of type: 'string'
 proc f(a1: string; a2: varargs[string]; a3: float; a4: var string)
   first type mismatch at position: 7
-  required type for a4: var string
+  required type for a4: 'var string'
   but expression '"bad"' is immutable, not 'var'
 
 expression: f("asdf", "1", "2", "3", "4", 2.3, "bad")
 tsigmatch.nim(166, 4) Error: type mismatch: got <string, a0: int literal(12)>
-but expected one of: 
+but expected one of:
 proc f(x: string; a0: string)
   first type mismatch at position: 2
-  required type for a0: string
+  required type for a0: 'string'
   but expression 'a0 = 12' is of type: 'int literal(12)'
 proc f(x: string; a0: var int)
   first type mismatch at position: 2
-  required type for a0: var int
+  required type for a0: 'var int'
   but expression 'a0 = 12' is immutable, not 'var'
 
 expression: f(foo, a0 = 12)
 tsigmatch.nim(173, 7) Error: type mismatch: got <Mystring, string>
-but expected one of: 
+but expected one of:
 proc fun1(a1: MyInt; a2: Mystring)
   first type mismatch at position: 1
-  required type for a1: MyInt
+  required type for a1: 'MyInt'
   but expression 'default(Mystring)' is of type: 'Mystring'
 proc fun1(a1: float; a2: Mystring)
   first type mismatch at position: 1
-  required type for a1: float
+  required type for a1: 'float'
   but expression 'default(Mystring)' is of type: 'Mystring'
 
 expression: fun1(default(Mystring), "asdf")

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -1,86 +1,88 @@
 discard """
   cmd: "nim check --showAllMismatches:on --hints:off $file"
   nimout: '''
-tsigmatch.nim(111, 4) Error: type mismatch: got <A, string>
-but expected one of:
+tsigmatch.nim(113, 4) Error: type mismatch: got <A, string>
+but expected one of: 
 proc f(a: A)
   first type mismatch at position: 2
   extra argument given
 proc f(b: B)
   first type mismatch at position: 1
   required type for b: B
-  but expression 'A()' is of type: A
+  but expression 'A()' is of type: 'A'
 
 expression: f(A(), "extra")
-tsigmatch.nim(125, 6) Error: type mismatch: got <(string, proc (){.gcsafe, locks: 0.})>
-but expected one of:
+tsigmatch.nim(127, 6) Error: type mismatch: got <(string, proc (){.gcsafe, locks: 0.})>
+but expected one of: 
 proc foo(x: (string, proc ()))
   first type mismatch at position: 1
   required type for x: (string, proc (){.closure.})
-  but expression '("foobar", proc () = echo(["Hello!"]))' is of type: (string, proc (){.gcsafe, locks: 0.})
+  but expression '("foobar", proc () = echo(["Hello!"]))' is of type: '(string, proc (){.gcsafe, locks: 0.})'
 
 expression: foo(("foobar", proc () = echo(["Hello!"])))
-tsigmatch.nim(132, 11) Error: type mismatch: got <proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}>
-but expected one of:
+tsigmatch.nim(134, 11) Error: type mismatch: got <proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}>
+but expected one of: 
 proc foo[T, S](op: proc (x: T): S {.cdecl.}): auto
   first type mismatch at position: 1
   required type for op: proc (x: T): S{.cdecl.}
-  but expression 'fun' is of type: proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}
+  but expression 'fun' is of type: 'proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}'
+  Calling convention mismatch: got '{.nimcall.}', but expected '{.cdecl.}'.
 proc foo[T, S](op: proc (x: T): S {.safecall.}): auto
   first type mismatch at position: 1
   required type for op: proc (x: T): S{.safecall.}
-  but expression 'fun' is of type: proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}
+  but expression 'fun' is of type: 'proc (s: string): string{.noSideEffect, gcsafe, locks: 0.}'
+  Calling convention mismatch: got '{.nimcall.}', but expected '{.safecall.}'.
 
 expression: foo(fun)
-tsigmatch.nim(143, 13) Error: type mismatch: got <array[0..0, proc (x: int){.gcsafe, locks: 0.}]>
-but expected one of:
+tsigmatch.nim(145, 13) Error: type mismatch: got <array[0..0, proc (x: int){.gcsafe, locks: 0.}]>
+but expected one of: 
 proc takesFuncs(fs: openArray[proc (x: int) {.gcsafe, locks: 0.}])
   first type mismatch at position: 1
   required type for fs: openArray[proc (x: int){.closure, gcsafe, locks: 0.}]
-  but expression '[proc (x: int) {.gcsafe, locks: 0.} = echo [x]]' is of type: array[0..0, proc (x: int){.gcsafe, locks: 0.}]
+  but expression '[proc (x: int) {.gcsafe, locks: 0.} = echo [x]]' is of type: 'array[0..0, proc (x: int){.gcsafe, locks: 0.}]'
 
 expression: takesFuncs([proc (x: int) {.gcsafe, locks: 0.} = echo [x]])
-tsigmatch.nim(149, 4) Error: type mismatch: got <int literal(10), a0: int literal(5), string>
-but expected one of:
+tsigmatch.nim(151, 4) Error: type mismatch: got <int literal(10), a0: int literal(5), string>
+but expected one of: 
 proc f(a0: uint8; b: string)
   first type mismatch at position: 2
   named param already provided: a0
 
 expression: f(10, a0 = 5, "")
-tsigmatch.nim(156, 4) Error: type mismatch: got <string, string, string, string, string, float64, string>
-but expected one of:
+tsigmatch.nim(158, 4) Error: type mismatch: got <string, string, string, string, string, float64, string>
+but expected one of: 
 proc f(a1: int)
   first type mismatch at position: 1
   required type for a1: int
-  but expression '"asdf"' is of type: string
+  but expression '"asdf"' is of type: 'string'
 proc f(a1: string; a2: varargs[string]; a3: float; a4: var string)
   first type mismatch at position: 7
   required type for a4: var string
   but expression '"bad"' is immutable, not 'var'
 
 expression: f("asdf", "1", "2", "3", "4", 2.3, "bad")
-tsigmatch.nim(164, 4) Error: type mismatch: got <string, a0: int literal(12)>
-but expected one of:
+tsigmatch.nim(166, 4) Error: type mismatch: got <string, a0: int literal(12)>
+but expected one of: 
 proc f(x: string; a0: string)
   first type mismatch at position: 2
   required type for a0: string
-  but expression 'a0 = 12' is of type: int literal(12)
+  but expression 'a0 = 12' is of type: 'int literal(12)'
 proc f(x: string; a0: var int)
   first type mismatch at position: 2
   required type for a0: var int
   but expression 'a0 = 12' is immutable, not 'var'
 
 expression: f(foo, a0 = 12)
-tsigmatch.nim(171, 7) Error: type mismatch: got <Mystring, string>
-but expected one of:
+tsigmatch.nim(173, 7) Error: type mismatch: got <Mystring, string>
+but expected one of: 
 proc fun1(a1: MyInt; a2: Mystring)
   first type mismatch at position: 1
   required type for a1: MyInt
-  but expression 'default(Mystring)' is of type: Mystring
+  but expression 'default(Mystring)' is of type: 'Mystring'
 proc fun1(a1: float; a2: Mystring)
   first type mismatch at position: 1
   required type for a1: float
-  but expression 'default(Mystring)' is of type: Mystring
+  but expression 'default(Mystring)' is of type: 'Mystring'
 
 expression: fun1(default(Mystring), "asdf")
 '''

--- a/tests/errmsgs/tsigmatch2.nim
+++ b/tests/errmsgs/tsigmatch2.nim
@@ -2,24 +2,24 @@ discard """
   cmd: "nim check --showAllMismatches:on --hints:off $file"
   nimout: '''
 tsigmatch2.nim(40, 14) Error: type mismatch: got <float64>
-but expected one of:
+but expected one of: 
 proc foo(args: varargs[string, myproc]): string
   first type mismatch at position: 1
   required type for args: varargs[string]
-  but expression '1.2' is of type: float64
+  but expression '1.2' is of type: 'float64'
 proc foo(i: Foo): string
   first type mismatch at position: 1
   required type for i: Foo
-  but expression '1.2' is of type: float64
+  but expression '1.2' is of type: 'float64'
 
 expression: foo(1.2)
 tsigmatch2.nim(40, 14) Error: expression '' has no type (or is ambiguous)
 tsigmatch2.nim(46, 7) Error: type mismatch: got <int literal(1)>
-but expected one of:
+but expected one of: 
 proc foo(args: varargs[string, myproc])
   first type mismatch at position: 1
   required type for args: varargs[string]
-  but expression '1' is of type: int literal(1)
+  but expression '1' is of type: 'int literal(1)'
 
 expression: foo 1
 '''

--- a/tests/errmsgs/tsigmatch2.nim
+++ b/tests/errmsgs/tsigmatch2.nim
@@ -2,23 +2,23 @@ discard """
   cmd: "nim check --showAllMismatches:on --hints:off $file"
   nimout: '''
 tsigmatch2.nim(40, 14) Error: type mismatch: got <float64>
-but expected one of: 
+but expected one of:
 proc foo(args: varargs[string, myproc]): string
   first type mismatch at position: 1
-  required type for args: varargs[string]
+  required type for args: 'varargs[string]'
   but expression '1.2' is of type: 'float64'
 proc foo(i: Foo): string
   first type mismatch at position: 1
-  required type for i: Foo
+  required type for i: 'Foo'
   but expression '1.2' is of type: 'float64'
 
 expression: foo(1.2)
 tsigmatch2.nim(40, 14) Error: expression '' has no type (or is ambiguous)
 tsigmatch2.nim(46, 7) Error: type mismatch: got <int literal(1)>
-but expected one of: 
+but expected one of:
 proc foo(args: varargs[string, myproc])
   first type mismatch at position: 1
-  required type for args: varargs[string]
+  required type for args: 'varargs[string]'
   but expression '1' is of type: 'int literal(1)'
 
 expression: foo 1

--- a/tests/errmsgs/tundeclared_routine.nim
+++ b/tests/errmsgs/tundeclared_routine.nim
@@ -2,18 +2,18 @@ discard """
 cmd: '''nim check --hints:off $file'''
 action: reject
 nimout: '''
-tundeclared_routine.nim(45, 17) Error: attempting to call routine: 'myiter''
-  found 'tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(43, 12)]'
-  found 'tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(44, 12)]''
-tundeclared_routine.nim(45, 17) Error: attempting to call routine: 'myiter''
-  found 'tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(43, 12)]'
-  found 'tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(44, 12)]''
+tundeclared_routine.nim(45, 17) Error: attempting to call routine: 'myiter'
+  found tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(43, 12)]
+  found tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(44, 12)]
+tundeclared_routine.nim(45, 17) Error: attempting to call routine: 'myiter'
+  found tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(43, 12)]
+  found tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(44, 12)]
 tundeclared_routine.nim(45, 17) Error: expression 'myiter' cannot be called
 tundeclared_routine.nim(45, 17) Error: expression '' has no type (or is ambiguous)
 tundeclared_routine.nim(45, 7) Error: 'let' symbol requires an initialization
 tundeclared_routine.nim(50, 28) Error: invalid pragma: myPragma
 tundeclared_routine.nim(57, 13) Error: undeclared field: 'bar3' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(54, 8)] 
-  found 'tundeclared_routine.bar3() [iterator declared in tundeclared_routine.nim(56, 12)]'
+  found tundeclared_routine.bar3() [iterator declared in tundeclared_routine.nim(56, 12)]
 tundeclared_routine.nim(57, 13) Error: undeclared field: '.' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(54, 8)]
 tundeclared_routine.nim(57, 13) Error: expression '.' cannot be called
 tundeclared_routine.nim(57, 13) Error: expression '' has no type (or is ambiguous)
@@ -24,10 +24,10 @@ tundeclared_routine.nim(62, 13) Error: expression '.' cannot be called
 tundeclared_routine.nim(62, 13) Error: expression '' has no type (or is ambiguous)
 tundeclared_routine.nim(62, 7) Error: 'let' symbol requires an initialization
 tundeclared_routine.nim(65, 11) Error: undeclared identifier: 'bad5'
-tundeclared_routine.nim(65, 15) Error: attempting to call routine: 'bad5''
-  found ''bad5' [unknown declared in tundeclared_routine.nim(65, 11)]''
-tundeclared_routine.nim(65, 15) Error: attempting to call routine: 'bad5''
-  found ''bad5' [unknown declared in tundeclared_routine.nim(65, 11)]''
+tundeclared_routine.nim(65, 15) Error: attempting to call routine: 'bad5'
+  found 'bad5' [unknown declared in tundeclared_routine.nim(65, 11)]
+tundeclared_routine.nim(65, 15) Error: attempting to call routine: 'bad5'
+  found 'bad5' [unknown declared in tundeclared_routine.nim(65, 11)]
 tundeclared_routine.nim(65, 15) Error: expression 'bad5' cannot be called
 tundeclared_routine.nim(65, 15) Error: expression '' has no type (or is ambiguous)
 tundeclared_routine.nim(65, 7) Error: 'let' symbol requires an initialization

--- a/tests/errmsgs/tundeclared_routine.nim
+++ b/tests/errmsgs/tundeclared_routine.nim
@@ -2,14 +2,35 @@ discard """
 cmd: '''nim check --hints:off $file'''
 action: reject
 nimout: '''
-tundeclared_routine.nim(24, 17) Error: attempting to call routine: 'myiter'
-  found tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(22, 12)]
-  found tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(23, 12)]
-tundeclared_routine.nim(29, 28) Error: invalid pragma: myPragma
-tundeclared_routine.nim(36, 13) Error: undeclared field: 'bar3' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(33, 8)]
-  found tundeclared_routine.bar3() [iterator declared in tundeclared_routine.nim(35, 12)]
-tundeclared_routine.nim(41, 13) Error: undeclared field: 'bar4' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(39, 8)]
-tundeclared_routine.nim(44, 15) Error: attempting to call routine: 'bad5'
+tundeclared_routine.nim(45, 17) Error: attempting to call routine: 'myiter''
+  found 'tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(43, 12)]'
+  found 'tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(44, 12)]''
+tundeclared_routine.nim(45, 17) Error: attempting to call routine: 'myiter''
+  found 'tundeclared_routine.myiter(a: string) [iterator declared in tundeclared_routine.nim(43, 12)]'
+  found 'tundeclared_routine.myiter() [iterator declared in tundeclared_routine.nim(44, 12)]''
+tundeclared_routine.nim(45, 17) Error: expression 'myiter' cannot be called
+tundeclared_routine.nim(45, 17) Error: expression '' has no type (or is ambiguous)
+tundeclared_routine.nim(45, 7) Error: 'let' symbol requires an initialization
+tundeclared_routine.nim(50, 28) Error: invalid pragma: myPragma
+tundeclared_routine.nim(57, 13) Error: undeclared field: 'bar3' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(54, 8)] 
+  found 'tundeclared_routine.bar3() [iterator declared in tundeclared_routine.nim(56, 12)]'
+tundeclared_routine.nim(57, 13) Error: undeclared field: '.' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(54, 8)]
+tundeclared_routine.nim(57, 13) Error: expression '.' cannot be called
+tundeclared_routine.nim(57, 13) Error: expression '' has no type (or is ambiguous)
+tundeclared_routine.nim(57, 7) Error: 'let' symbol requires an initialization
+tundeclared_routine.nim(62, 13) Error: undeclared field: 'bar4' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(60, 8)]
+tundeclared_routine.nim(62, 13) Error: undeclared field: '.' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(60, 8)]
+tundeclared_routine.nim(62, 13) Error: expression '.' cannot be called
+tundeclared_routine.nim(62, 13) Error: expression '' has no type (or is ambiguous)
+tundeclared_routine.nim(62, 7) Error: 'let' symbol requires an initialization
+tundeclared_routine.nim(65, 11) Error: undeclared identifier: 'bad5'
+tundeclared_routine.nim(65, 15) Error: attempting to call routine: 'bad5''
+  found ''bad5' [unknown declared in tundeclared_routine.nim(65, 11)]''
+tundeclared_routine.nim(65, 15) Error: attempting to call routine: 'bad5''
+  found ''bad5' [unknown declared in tundeclared_routine.nim(65, 11)]''
+tundeclared_routine.nim(65, 15) Error: expression 'bad5' cannot be called
+tundeclared_routine.nim(65, 15) Error: expression '' has no type (or is ambiguous)
+tundeclared_routine.nim(65, 7) Error: 'let' symbol requires an initialization
 '''
 """
 

--- a/tests/errmsgs/tunknown_named_parameter.nim
+++ b/tests/errmsgs/tunknown_named_parameter.nim
@@ -1,21 +1,24 @@
 discard """
-cmd: "nim check $file"
-errormsg: "type mismatch: got <string, set[char], maxsplits: int literal(1)>"
+cmd: "nim check --hints:off $file"
+action: reject
 nimout: '''
+tunknown_named_parameter.nim(30, 10) Error: type mismatch: got <string, set[char], maxsplits: int literal(1)>
+but expected one of: 
 func rsplit(s: string; sep: char; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
   required type for sep: char
-  but expression '{':'}' is of type: set[char]
+  but expression '{':'}' is of type: 'set[char]'
 func rsplit(s: string; sep: string; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
   required type for sep: string
-  but expression '{':'}' is of type: set[char]
+  but expression '{':'}' is of type: 'set[char]'
 func rsplit(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[
     string]
   first type mismatch at position: 3
   unknown named parameter: maxsplits
 
 expression: rsplit("abc:def", {':'}, maxsplits = 1)
+tunknown_named_parameter.nim(29, 8) Warning: imported and not used: 'strutils' [UnusedImport]
 '''
 """
 

--- a/tests/errmsgs/tunknown_named_parameter.nim
+++ b/tests/errmsgs/tunknown_named_parameter.nim
@@ -3,14 +3,14 @@ cmd: "nim check --hints:off $file"
 action: reject
 nimout: '''
 tunknown_named_parameter.nim(30, 10) Error: type mismatch: got <string, set[char], maxsplits: int literal(1)>
-but expected one of: 
+but expected one of:
 func rsplit(s: string; sep: char; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
-  required type for sep: char
+  required type for sep: 'char'
   but expression '{':'}' is of type: 'set[char]'
 func rsplit(s: string; sep: string; maxsplit: int = -1): seq[string]
   first type mismatch at position: 2
-  required type for sep: string
+  required type for sep: 'string'
   but expression '{':'}' is of type: 'set[char]'
 func rsplit(s: string; seps: set[char] = Whitespace; maxsplit: int = -1): seq[
     string]

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -1,18 +1,20 @@
 discard """
-errormsg: "type mismatch: got <array[0..0, typedesc[int]]>"
+cmd: '''nim check --hints:off $file'''
+action: reject
 nimout: '''
-twrong_at_operator.nim(21, 30) Error: type mismatch: got <array[0..0, typedesc[int]]>
-but expected one of:
+twrong_at_operator.nim(23, 30) Error: type mismatch: got <array[0..0, typedesc[int]]>
+but expected one of: 
 proc `@`[IDX, T](a: sink array[IDX, T]): seq[T]
   first type mismatch at position: 1
   required type for a: sink array[IDX, T]
-  but expression '[int]' is of type: array[0..0, typedesc[int]]
+  but expression '[int]' is of type: 'array[0..0, typedesc[int]]'
 proc `@`[T](a: openArray[T]): seq[T]
   first type mismatch at position: 1
   required type for a: openArray[T]
-  but expression '[int]' is of type: array[0..0, typedesc[int]]
+  but expression '[int]' is of type: 'array[0..0, typedesc[int]]'
 
 expression: @[int]
+twrong_at_operator.nim(23, 30) Error: expression '' has no type (or is ambiguous)
 '''
 disabled: "32bit"
 """

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -3,14 +3,14 @@ cmd: '''nim check --hints:off $file'''
 action: reject
 nimout: '''
 twrong_at_operator.nim(23, 30) Error: type mismatch: got <array[0..0, typedesc[int]]>
-but expected one of: 
+but expected one of:
 proc `@`[IDX, T](a: sink array[IDX, T]): seq[T]
   first type mismatch at position: 1
-  required type for a: sink array[IDX, T]
+  required type for a: 'sink array[IDX, T]'
   but expression '[int]' is of type: 'array[0..0, typedesc[int]]'
 proc `@`[T](a: openArray[T]): seq[T]
   first type mismatch at position: 1
-  required type for a: openArray[T]
+  required type for a: 'openArray[T]'
   but expression '[int]' is of type: 'array[0..0, typedesc[int]]'
 
 expression: @[int]

--- a/tests/misc/t9039.nim
+++ b/tests/misc/t9039.nim
@@ -1,8 +1,16 @@
 discard """
   action: reject
   nimout: '''
-t9039.nim(22, 22) Error: type mismatch: got <array[0..2, int], int, array[0..1, int]>
-but expression 'nesting + 1' is of type: int
+t9039.nim(30, 22) Error: type mismatch: got <array[0..2, int], int, array[0..1, int]>
+but expected one of:
+func shapeBad[T: not char](s: openArray[T]; rank: static[int]; nesting = 0;
+                           parent_shape = default(array[rank, int])): array[
+    rank, int]
+  first type mismatch at position: 2
+  required type for rank: 'static[int]'
+  but expression 'nesting + 1' is of type: 'int'
+
+expression: shapeBad(s[0], nesting + 1, result)
 '''
 """
 

--- a/tests/range/tenums.nim
+++ b/tests/range/tenums.nim
@@ -6,16 +6,16 @@ tenums.nim(32, 20) Error: type mismatch: got <Letters>
 but expected one of:
 proc takesChristmasColor(color: ChristmasColors)
   first type mismatch at position: 1
-  required type for color: ChristmasColors
-  but expression 'A' is of type: Letters
+  required type for color: 'ChristmasColors'
+  but expression 'A' is of type: 'Letters'
 
 expression: takesChristmasColor(A)
 tenums.nim(33, 20) Error: type mismatch: got <BC>
 but expected one of:
 proc takesChristmasColor(color: ChristmasColors)
   first type mismatch at position: 1
-  required type for color: ChristmasColors
-  but expression 'BC(C)' is of type: BC
+  required type for color: 'ChristmasColors'
+  but expression 'BC(C)' is of type: 'BC'
 
 expression: takesChristmasColor(BC(C))
 '''

--- a/tests/typerel/t7600_1.nim
+++ b/tests/typerel/t7600_1.nim
@@ -4,8 +4,8 @@ nimout: '''t7600_1.nim(21, 6) Error: type mismatch: got <Thin[system.int]>
 but expected one of:
 proc test[T](x: Paper[T])
   first type mismatch at position: 1
-  required type for x: Paper[test.T]
-  but expression 'tn' is of type: Thin[system.int]
+  required type for x: 'Paper[test.T]'
+  but expression 'tn' is of type: 'Thin[system.int]'
 
 expression: test tn'''
 """

--- a/tests/typerel/t7600_2.nim
+++ b/tests/typerel/t7600_2.nim
@@ -4,8 +4,8 @@ nimout: '''t7600_2.nim(20, 6) Error: type mismatch: got <Thin>
 but expected one of:
 proc test(x: Paper)
   first type mismatch at position: 1
-  required type for x: Paper
-  but expression 'tn' is of type: Thin
+  required type for x: 'Paper'
+  but expression 'tn' is of type: 'Thin'
 
 expression: test tn'''
 """

--- a/tests/varres/tprevent_forloopvar_mutations.nim
+++ b/tests/varres/tprevent_forloopvar_mutations.nim
@@ -4,7 +4,7 @@ discard """
 but expected one of:
 proc inc[T: Ordinal](x: var T; y = 1)
   first type mismatch at position: 1
-  required type for x: var T: Ordinal
+  required type for x: 'var T: Ordinal'
   but expression 'i' is immutable, not 'var'
 
 expression: inc i


### PR DESCRIPTION
This PR uses ANSI colours to make the terminal output of errors quicker to read and spacing out the errors for overload errors. Highlighting the actual issues. Also adds a explict message about immutable variables being the cause of errors.
```nim
#Sample code used for this test.
let stringValue = "Hmm"
stringValue.add(10)
```

![image](https://user-images.githubusercontent.com/11792483/102170687-2db4dc00-3e52-11eb-8980-0b5bd474743a.png)

![image](https://user-images.githubusercontent.com/11792483/102170556-e0d10580-3e51-11eb-8982-f9763cc89ad7.png)

## (EDIT) links
* refs https://github.com/nim-lang/RFCs/issues/87
* refs https://github.com/nim-lang/Nim/issues/2844#issuecomment-107060552
