### PR TITLE
fix #16354 `projectFull` is now an AbsoluteFile for `nim r main`

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -14,13 +14,6 @@ import
   lineinfos, modulegraphs, condsyms, os, pathutils, parseopt
 from strutils import `%`
 
-proc prependCurDir*(f: AbsoluteFile): AbsoluteFile =
-  when defined(unix):
-    if os.isAbsolute(f.string): result = f
-    else: result = AbsoluteFile("./" & f.string)
-  else:
-    result = f
-
 proc addCmdPrefix*(result: var string, kind: CmdLineKind) =
   # consider moving this to std/parseopt
   case kind

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -307,6 +307,7 @@ type
     projectName*: string # holds a name like 'nim'
     projectPath*: AbsoluteDir # holds a path like /home/alice/projects/nim/compiler/
     projectFull*: AbsoluteFile # projectPath/projectName
+    projectIsRealFile*: bool # false for stdin, cmdline, invalid path
     projectIsStdin*: bool # whether we're compiling from stdin
     lastMsgWasDot*: set[StdOrrKind] # the last compiler message was a single '.'
     projectMainIdx*: FileIndex # the canonical path id of the main module


### PR DESCRIPTION
fix #16354

@Clyybber this fixes a bug and also will help with your comment https://github.com/nim-lang/Nim/pull/16349#issuecomment-744707351

