### PR TITLE
std/lists: O(1) concatenation of singly- and doubly linked lists.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -77,7 +77,8 @@
 
 - Added `lists.copy` for shallow copying singly- and doubly linked lists.
 
-- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
+- `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
+  an O(1) variation that consumes its argument, `addMove`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -75,7 +75,7 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
+- `add` is now overloaded also for the O(1) concatenation of `SinglyLinkedList`s.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -78,7 +78,7 @@
 - Added `lists.copy` for shallow copying singly- and doubly linked lists.
 
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
-  an O(1) variation that consumes its argument, `addMove`, is also supplied.
+  an O(1) variation that consumes its argument, `addMoved`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -82,8 +82,7 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `lists.append` is now overloaded also for the O(1) concatenation of singly- and doubly
-  linked lists.
+- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -65,6 +65,9 @@
 
 - `echo` and `debugEcho` will now raise `IOError` if writing to stdout fails.  Previous behavior
   silently ignored errors.  See #16366.  Use `-d:nimLegacyEchoNoRaise` for previous behavior.
+- Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
+  `openArray`s, and `lists.concat` for the O(1) concatenation of singly- and doubly
+  linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -75,8 +75,7 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `lists.append` is now overloaded also for the O(1) concatenation of singly- and doubly
-  linked lists.
+- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -84,7 +84,8 @@
 
 - Added `lists.copy` for shallow copying singly- and doubly linked lists.
 
-- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
+- `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
+  an O(1) variation that consumes its argument, `addMove`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -71,7 +71,7 @@
 - Added `lists.copy` for shallow copying singly- and doubly linked lists.
 
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
-  an O(1) variation that consumes its argument, `addMove`, is also supplied.
+  an O(1) variation that consumes its argument, `addMoved`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -85,7 +85,7 @@
 - Added `lists.copy` for shallow copying singly- and doubly linked lists.
 
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
-  an O(1) variation that consumes its argument, `addMove`, is also supplied.
+  an O(1) variation that consumes its argument, `addMoved`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -80,7 +80,9 @@
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
   an O(1) variation that consumes its argument, `addMoved`, is also supplied.
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
-  `openArray`s, and `lists.concat` for the O(1) concatenation of singly- and doubly
+  `openArray`s.
+
+- `lists.append` is now overloaded also for the O(1) concatenation of singly- and doubly
   linked lists.
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -66,7 +66,9 @@
 - `echo` and `debugEcho` will now raise `IOError` if writing to stdout fails.  Previous behavior
   silently ignored errors.  See #16366.  Use `-d:nimLegacyEchoNoRaise` for previous behavior.
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
-  `openArray`s, and `lists.concat` for the O(1) concatenation of singly- and doubly
+  `openArray`s.
+
+- `lists.append` is now overloaded also for the O(1) concatenation of singly- and doubly
   linked lists.
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -73,7 +73,9 @@
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
   an O(1) variation that consumes its argument, `addMoved`, is also supplied.
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
-  `openArray`s, and `lists.concat` for the O(1) concatenation of singly- and doubly
+  `openArray`s.
+
+- `lists.append` is now overloaded also for the O(1) concatenation of singly- and doubly
   linked lists.
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -65,27 +65,11 @@
 
 - `echo` and `debugEcho` will now raise `IOError` if writing to stdout fails.  Previous behavior
   silently ignored errors.  See #16366.  Use `-d:nimLegacyEchoNoRaise` for previous behavior.
-- Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
-  `openArray`s.
 
-- Added `lists.copy` for shallow copying singly- and doubly linked lists.
-
-- `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
-  an O(1) variation that consumes its argument, `addMoved`, is also supplied.
-- Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
-  `openArray`s.
-
-- Added `lists.copy` for shallow copying singly- and doubly linked lists.
-
-- `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
-  an O(1) variation that consumes its argument, `addMoved`, is also supplied.
-- Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
-  `openArray`s.
-
-- Added `lists.copy` for shallow copying singly- and doubly linked lists.
-
-- `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
-  an O(1) variation that consumes its argument, `addMoved`, is also supplied.
+- Added new operations for singly- and doubly linked lists: `lists.toSinglyLinkedList`
+  and `lists.toDoublyLinkedList` convert from `openArray`s; `lists.copy` implements
+  shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
+  its argument, `addMoved`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -68,7 +68,9 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `add` is now overloaded also for the O(1) concatenation of `SinglyLinkedList`s.
+- Added `lists.copy` for shallow copying singly- and doubly linked lists.
+
+- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -68,7 +68,7 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
+- `add` is now overloaded also for the O(1) concatenation of `SinglyLinkedList`s.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -72,6 +72,9 @@
 
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
   an O(1) variation that consumes its argument, `addMoved`, is also supplied.
+- Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
+  `openArray`s, and `lists.concat` for the O(1) concatenation of singly- and doubly
+  linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -79,6 +79,9 @@
 
 - `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
   an O(1) variation that consumes its argument, `addMoved`, is also supplied.
+- Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
+  `openArray`s, and `lists.concat` for the O(1) concatenation of singly- and doubly
+  linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -82,7 +82,9 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `add` is now overloaded also for the O(1) concatenation of `SinglyLinkedList`s.
+- Added `lists.copy` for shallow copying singly- and doubly linked lists.
+
+- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -75,7 +75,9 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `add` is now overloaded also for the O(1) concatenation of `SinglyLinkedList`s.
+- Added `lists.copy` for shallow copying singly- and doubly linked lists.
+
+- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -70,7 +70,8 @@
 
 - Added `lists.copy` for shallow copying singly- and doubly linked lists.
 
-- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
+- `add` is now overloaded also for the concatenation of singly- and doubly linked lists;
+  an O(1) variation that consumes its argument, `addMove`, is also supplied.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -68,8 +68,7 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `lists.append` is now overloaded also for the O(1) concatenation of singly- and doubly
-  linked lists.
+- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -82,7 +82,7 @@
 - Added `lists.toSinglyLinkedList` and `lists.toDoublyLinkedList` for conversion from
   `openArray`s.
 
-- `add` is now overloaded also for the O(1) concatenation of singly- and doubly linked lists.
+- `add` is now overloaded also for the O(1) concatenation of `SinglyLinkedList`s.
 
 ## Language changes
 

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -179,7 +179,7 @@ proc newSinglyLinkedNode*[T](value: T): <//>(SinglyLinkedNode[T]) =
   new(result)
   result.value = value
 
-func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (1, 6).} =
+func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (1, 5, 1).} =
   ## Creates a new `SinglyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
@@ -190,7 +190,7 @@ func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (
   for elem in elems.items:
     result.append(elem)
 
-func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (1, 6).} =
+func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (1, 5, 1).} =
   ## Creates a new `DoublyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
@@ -458,7 +458,7 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 6).} =
+func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5, 1).} =
   ## Creates a shallow copy of `a`.
   runnableExamples:
     import sequtils
@@ -481,7 +481,7 @@ func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 6).} =
   for x in a:
     result.append(x)
 
-proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 6).} =
+proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
   ## Moves `b` to the end of `a`. Efficiency: O(1).
   ## Note that `b` becomes empty after the operation.
   ## Self-adding results in an empty list.
@@ -607,7 +607,7 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 6).} =
+func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5, 1).} =
   ## Creates a shallow copy of `a`.
   runnableExamples:
     type Foo = ref object
@@ -626,7 +626,7 @@ func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 6).} =
   for x in a:
     result.append(x)
 
-proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 6).} =
+proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5, 1).} =
   ## Moves `b` to the end of `a`. Efficiency: O(1).
   ## Note that `b` becomes empty after the operation.
   ## Self-adding results in an empty list.
@@ -654,7 +654,7 @@ proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 6).} =
   b.head = nil
   b.tail = nil
 
-proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 6).} =
+proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5, 1).} =
   ## Appends a shallow copy of `b` to the end of `a`.
   ##
   ## See also:

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -520,6 +520,20 @@ proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 
   var tmp = L2.copy
   L1.addMove tmp
 
+proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends a shallow copy of `L2` to the end of `L1`.
+  runnableExamples:
+    import sequtils
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
+    a.add b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == [4, 5]
+    a.add a
+    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  var tmp = L2.copy
+  L1.addMove tmp
+
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
   ##
@@ -685,6 +699,20 @@ proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 
     assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
   var tmp = b.copy
   a.addMoved tmp
+
+proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends a shallow copy of `L2` to the end of `L1`.
+  runnableExamples:
+    import sequtils
+    var a = [1, 2, 3].toDoublyLinkedList
+    let b = [4, 5].toDoublyLinkedList
+    a.add b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == [4, 5]
+    a.add a
+    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  var tmp = L2.copy
+  L1.addMove tmp
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -182,8 +182,9 @@ func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] =
   ## Creates a new `SinglyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
+    import sequtils
     let a = [1, 2, 3, 4, 5].toSinglyLinkedList
-    assert a.ToSeq == [1, 2, 3, 4, 5]
+    assert a.toSeq == [1, 2, 3, 4, 5]
   result = initSinglyLinkedList[T]()
   for elem in elems.items:
     result.append(elem)
@@ -192,8 +193,9 @@ func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] =
   ## Creates a new `DoublyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
+    import sequtils
     let a = [1, 2, 3, 4, 5].toDoublyLinkedList
-    assert a.ToSeq == [1, 2, 3, 4, 5]
+    assert a.toSeq == [1, 2, 3, 4, 5]
   result = initDoublyLinkedList[T]()
   for elem in elems.items:
     result.append(elem)
@@ -459,6 +461,7 @@ proc concat*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) =
   ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
+    import sequtils
     var a = [1, 2, 3].toSinglyLinkedList
     let b = [4, 5].toSinglyLinkedList
     assert a.toSeq == [1, 2, 3, 4, 5]
@@ -559,6 +562,7 @@ proc concat*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) =
   ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
+    import sequtils
     var a = [1, 2, 3].toDoublyLinkedList
     let b = [4, 5].toDoublyLinkedList
     assert a.toSeq == [1, 2, 3, 4, 5]

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -477,19 +477,20 @@ func copy*[T](L: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
   for x in L:
     result.append(x)
 
-proc add*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
+proc addMove*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
   ## Moves `L2` to the end of `L1`. Efficiency: O(1).
   ## Note that `L2` becomes empty after the operation.
   ## Self-adding results in an empty list.
   runnableExamples:
+    import sequtils
     var
       a = [1, 2, 3].toSinglyLinkedList
       b = [4, 5].toSinglyLinkedList
-    a.add(b)
-    assert $a == "[1, 2, 3, 4, 5]"
-    assert $b == "[]"
-    a.add(a)
-    assert $a == "[]"
+    a.addMove b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == []
+    a.addMove a
+    assert a.toSeq == []
   if L1.tail != nil:
     L1.tail.next = L2.head
   L1.tail = L2.tail
@@ -497,6 +498,20 @@ proc add*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
     L1.head = L2.head
   L2.head = nil
   L2.tail = nil
+
+proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends a shallow copy of `L2` to the end of `L1`.
+  runnableExamples:
+    import sequtils
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
+    a.add b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == [4, 5]
+    a.add a
+    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  var tmp = L2.copy
+  L1.addMove tmp
 
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
@@ -603,19 +618,20 @@ func copy*[T](L: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
   for x in L:
     result.append(x)
 
-proc add*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
+proc addMove*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
   ## Moves `L2` to the end of `L1`. Efficiency: O(1).
   ## Note that `L2` becomes empty after the operation.
   ## Self-adding results in an empty list.
   runnableExamples:
+    import sequtils
     var
       a = [1, 2, 3].toDoublyLinkedList
       b = [4, 5].toDoublyLinkedList
-    a.add(b)
-    assert $a == "[1, 2, 3, 4, 5]"
-    assert $b == "[]"
-    a.add(a)
-    assert $a == "[]"
+    a.addMove b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == []
+    a.addMove a
+    assert a.toSeq == []
   if L2.head != nil:
     L2.head.prev = L1.tail
   if L1.tail != nil:
@@ -625,6 +641,20 @@ proc add*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
     L1.head = L2.head
   L2.head = nil
   L2.tail = nil
+
+proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends a shallow copy of `L2` to the end of `L1`.
+  runnableExamples:
+    import sequtils
+    var a = [1, 2, 3].toDoublyLinkedList
+    let b = [4, 5].toDoublyLinkedList
+    a.add b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == [4, 5]
+    a.add a
+    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  var tmp = L2.copy
+  L1.addMove tmp
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -461,15 +461,19 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
 func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
   ## Creates a shallow copy of `a`.
   runnableExamples:
+    import sequtils
     type Foo = ref object
       x: int
-    var f = Foo(x: 1)
-    let
+    var
+      f = Foo(x: 1)
       a = [f].toSinglyLinkedList
-      b = a.copy
+    let b = a.copy
+    a.add [f].toSinglyLinkedList
+    assert a.toSeq == [f, f]
+    assert b.toSeq == [f] # b isn't modified...
     f.x = 42
     assert a.head.value.x == 42
-    assert b.head.value.x == 42
+    assert b.head.value.x == 42 # ... but the elements are not deep copied
 
     let c = [1, 2, 3].toSinglyLinkedList
     assert $c == $c.copy

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -510,7 +510,6 @@ proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
 proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
   ## Appends a shallow copy of `L2` to the end of `L1`.
   runnableExamples:
-    import sequtils
     var a = [1, 2, 3].toSinglyLinkedList
     let b = [4, 5].toSinglyLinkedList
     a.add b

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -464,6 +464,7 @@ proc concat*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) =
     import sequtils
     var a = [1, 2, 3].toSinglyLinkedList
     let b = [4, 5].toSinglyLinkedList
+    a.concat(b)
     assert a.toSeq == [1, 2, 3, 4, 5]
   if L1.tail != nil:
     L1.tail.next = L2.head
@@ -565,6 +566,7 @@ proc concat*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) =
     import sequtils
     var a = [1, 2, 3].toDoublyLinkedList
     let b = [4, 5].toDoublyLinkedList
+    a.concat(b)
     assert a.toSeq == [1, 2, 3, 4, 5]
   if L1.tail != nil:
     L1.tail.next = L2.head

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -178,6 +178,26 @@ proc newSinglyLinkedNode*[T](value: T): <//>(SinglyLinkedNode[T]) =
   new(result)
   result.value = value
 
+func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] =
+  ## Creates a new `SinglyLinkedList` with the members of the
+  ## given collection (seq, array, or string) `elems`.
+  runnableExamples:
+    let a = [1, 2, 3, 4, 5].toSinglyLinkedList
+    assert a.ToSeq == [1, 2, 3, 4, 5]
+  result = initSinglyLinkedList[T]()
+  for elem in elems.items:
+    result.append(elem)
+
+func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] =
+  ## Creates a new `DoublyLinkedList` with the members of the
+  ## given collection (seq, array, or string) `elems`.
+  runnableExamples:
+    let a = [1, 2, 3, 4, 5].toDoublyLinkedList
+    assert a.ToSeq == [1, 2, 3, 4, 5]
+  result = initDoublyLinkedList[T]()
+  for elem in elems.items:
+    result.append(elem)
+
 template itemsListImpl() {.dirty.} =
   var it = L.head
   while it != nil:
@@ -435,6 +455,18 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
+proc concat*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) =
+  ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
+  ## Note that the two lists share structure after the operation.
+  runnableExamples:
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
+    assert a.toSeq == [1, 2, 3, 4, 5]
+  if L1.tail != nil:
+    L1.tail.next = L2.head
+  L1.tail = L2.tail
+  if L1.head == nil:
+    L1.head = L2.head
 
 
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
@@ -522,6 +554,19 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     a.prepend(8)
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
+
+proc concat*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) =
+  ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
+  ## Note that the two lists share structure after the operation.
+  runnableExamples:
+    var a = [1, 2, 3].toDoublyLinkedList
+    let b = [4, 5].toDoublyLinkedList
+    assert a.toSeq == [1, 2, 3, 4, 5]
+  if L1.tail != nil:
+    L1.tail.next = L2.head
+  L1.tail = L2.tail
+  if L1.head == nil:
+    L1.head = L2.head
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -507,6 +507,20 @@ proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 6).} =
   b.head = nil
   b.tail = nil
 
+proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends a shallow copy of `L2` to the end of `L1`.
+  runnableExamples:
+    import sequtils
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
+    a.add b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == [4, 5]
+    a.add a
+    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  var tmp = L2.copy
+  L1.addMove tmp
+
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
   ##
@@ -658,6 +672,20 @@ proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 6).} =
     assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
   var tmp = b.copy
   a.addMoved tmp
+
+proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends a shallow copy of `L2` to the end of `L1`.
+  runnableExamples:
+    import sequtils
+    var a = [1, 2, 3].toDoublyLinkedList
+    let b = [4, 5].toDoublyLinkedList
+    a.add b
+    assert a.toSeq == [1, 2, 3, 4, 5]
+    assert b.toSeq == [4, 5]
+    a.add a
+    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+  var tmp = L2.copy
+  L1.addMove tmp
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -677,15 +677,15 @@ proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 
   ## Appends a shallow copy of `L2` to the end of `L1`.
   runnableExamples:
     import sequtils
-    var a = [1, 2, 3].toDoublyLinkedList
-    let b = [4, 5].toDoublyLinkedList
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
     a.add b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == [4, 5]
     a.add a
     assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = L2.copy
-  L1.addMove tmp
+  var tmp = b.copy
+  a.addMoved tmp
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -72,6 +72,7 @@
 ## * `deques module <deques.html>`_ for double-ended queues
 ## * `sharedlist module <sharedlist.html>`_ for shared singly-linked lists
 
+import std/private/since
 
 when not defined(nimhygiene):
   {.pragma: dirty.}
@@ -178,7 +179,7 @@ proc newSinglyLinkedNode*[T](value: T): <//>(SinglyLinkedNode[T]) =
   new(result)
   result.value = value
 
-func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] =
+func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (1, 5).} =
   ## Creates a new `SinglyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
@@ -189,7 +190,7 @@ func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] =
   for elem in elems.items:
     result.append(elem)
 
-func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] =
+func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (1, 5).} =
   ## Creates a new `DoublyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
@@ -457,7 +458,7 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-proc concat*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) =
+proc concat*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
   ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
@@ -559,7 +560,7 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-proc concat*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) =
+proc concat*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
   ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -458,13 +458,13 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-proc append*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends (adds to the end) `L2` to `L1`. Efficiency: O(1).
+proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Adds `L2` to the end of `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
     var a = [1, 2, 3].toSinglyLinkedList
     let b = [4, 5].toSinglyLinkedList
-    a.append(b)
+    a.add(b)
     assert $a == "[1, 2, 3, 4, 5]"
   if L1.tail != nil:
     L1.tail.next = L2.head
@@ -559,13 +559,13 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-proc append*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends (adds to the end) `L2` to `L1`. Efficiency: O(1).
+proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Adds `L2` to the end of `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
     var a = [1, 2, 3].toDoublyLinkedList
     let b = [4, 5].toDoublyLinkedList
-    a.append(b)
+    a.add(b)
     assert $a == "[1, 2, 3, 4, 5]"
   if L1.tail != nil:
     L1.tail.next = L2.head

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -458,20 +458,32 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Adds `L2` to the end of `L1`. Efficiency: O(1).
-  ## Note that the two lists share structure after the operation.
+func copy*[T](L: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
+  ## Creates a shallow copy of `L`.
   runnableExamples:
-    var a = [1, 2, 3].toSinglyLinkedList
-    let b = [4, 5].toSinglyLinkedList
+    let a = [1, 2, 3].toSinglyLinkedList
+    assert $a == $a.copy
+  result = initSinglyLinkedList[T]()
+  for x in L:
+    result.append(x)
+
+proc add*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Moves `L2` to the end of `L1`. Efficiency: O(1).
+  ## Note that `L2` becomes empty after the operation.
+  runnableExamples:
+    var
+      a = [1, 2, 3].toSinglyLinkedList
+      b = [4, 5].toSinglyLinkedList
     a.add(b)
     assert $a == "[1, 2, 3, 4, 5]"
+    assert $b == "[]"
   if L1.tail != nil:
     L1.tail.next = L2.head
   L1.tail = L2.tail
   if L1.head == nil:
     L1.head = L2.head
-
+  L2.head = nil
+  L2.tail = nil
 
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
@@ -558,6 +570,35 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     a.prepend(8)
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
+
+func copy*[T](L: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
+  ## Creates a shallow copy of `L`.
+  runnableExamples:
+    let a = [1, 2, 3].toDoublyLinkedList
+    assert $a == $a.copy
+  result = initDoublyLinkedList[T]()
+  for x in L:
+    result.append(x)
+
+proc add*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Moves `L2` to the end of `L1`. Efficiency: O(1).
+  ## Note that `L2` becomes empty after the operation.
+  runnableExamples:
+    var
+      a = [1, 2, 3].toDoublyLinkedList
+      b = [4, 5].toDoublyLinkedList
+    a.add(b)
+    assert $a == "[1, 2, 3, 4, 5]"
+    assert $b == "[]"
+  if L2.head != nil:
+    L2.head.prev = L1.tail
+  if L1.tail != nil:
+    L1.tail.next = L2.head
+  L1.tail = L2.tail
+  if L1.head == nil:
+    L1.head = L2.head
+  L2.head = nil
+  L2.tail = nil
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -458,15 +458,14 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-proc concat*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
+proc append*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends (adds to the end) `L2` to `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
-    import sequtils
     var a = [1, 2, 3].toSinglyLinkedList
     let b = [4, 5].toSinglyLinkedList
-    a.concat(b)
-    assert a.toSeq == [1, 2, 3, 4, 5]
+    a.append(b)
+    assert $a == "[1, 2, 3, 4, 5]"
   if L1.tail != nil:
     L1.tail.next = L2.head
   L1.tail = L2.tail
@@ -560,15 +559,14 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-proc concat*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Concatenates (adds to the end) `L2` to `L1`. Efficiency: O(1).
+proc append*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Appends (adds to the end) `L2` to `L1`. Efficiency: O(1).
   ## Note that the two lists share structure after the operation.
   runnableExamples:
-    import sequtils
     var a = [1, 2, 3].toDoublyLinkedList
     let b = [4, 5].toDoublyLinkedList
-    a.concat(b)
-    assert a.toSeq == [1, 2, 3, 4, 5]
+    a.append(b)
+    assert $a == "[1, 2, 3, 4, 5]"
   if L1.tail != nil:
     L1.tail.next = L2.head
   L1.tail = L2.tail

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -458,8 +458,8 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-func copy*[T](L: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
-  ## Creates a shallow copy of `L`.
+func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
+  ## Creates a shallow copy of `a`.
   runnableExamples:
     type Foo = ref object
       x: int
@@ -474,44 +474,34 @@ func copy*[T](L: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
     let c = [1, 2, 3].toSinglyLinkedList
     assert $c == $c.copy
   result = initSinglyLinkedList[T]()
-  for x in L:
+  for x in a:
     result.append(x)
 
-proc addMove*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Moves `L2` to the end of `L1`. Efficiency: O(1).
-  ## Note that `L2` becomes empty after the operation.
+proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5).} =
+  ## Moves `b` to the end of `a`. Efficiency: O(1).
+  ## Note that `b` becomes empty after the operation.
   ## Self-adding results in an empty list.
+  ##
+  ## See also:
+  ## * `add proc <#add,T,T>`_
+  ##   for adding a copy of a list
   runnableExamples:
     import sequtils
     var
       a = [1, 2, 3].toSinglyLinkedList
       b = [4, 5].toSinglyLinkedList
-    a.addMove b
+    a.addMoved b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == []
-    a.addMove a
+    a.addMoved a
     assert a.toSeq == []
-  if L1.tail != nil:
-    L1.tail.next = L2.head
-  L1.tail = L2.tail
-  if L1.head == nil:
-    L1.head = L2.head
-  L2.head = nil
-  L2.tail = nil
-
-proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends a shallow copy of `L2` to the end of `L1`.
-  runnableExamples:
-    import sequtils
-    var a = [1, 2, 3].toSinglyLinkedList
-    let b = [4, 5].toSinglyLinkedList
-    a.add b
-    assert a.toSeq == [1, 2, 3, 4, 5]
-    assert b.toSeq == [4, 5]
-    a.add a
-    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = L2.copy
-  L1.addMove tmp
+  if a.tail != nil:
+    a.tail.next = b.head
+  a.tail = b.tail
+  if a.head == nil:
+    a.head = b.head
+  b.head = nil
+  b.tail = nil
 
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
@@ -599,8 +589,8 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-func copy*[T](L: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
-  ## Creates a shallow copy of `L`.
+func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
+  ## Creates a shallow copy of `a`.
   runnableExamples:
     type Foo = ref object
       x: int
@@ -615,46 +605,55 @@ func copy*[T](L: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
     let c = [1, 2, 3].toDoublyLinkedList
     assert $c == $c.copy
   result = initDoublyLinkedList[T]()
-  for x in L:
+  for x in a:
     result.append(x)
 
-proc addMove*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Moves `L2` to the end of `L1`. Efficiency: O(1).
-  ## Note that `L2` becomes empty after the operation.
+proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5).} =
+  ## Moves `b` to the end of `a`. Efficiency: O(1).
+  ## Note that `b` becomes empty after the operation.
   ## Self-adding results in an empty list.
+  ##
+  ## See also:
+  ## * `add proc <#add,T,T>`_
+  ##   for adding a copy of a list
   runnableExamples:
     import sequtils
     var
       a = [1, 2, 3].toDoublyLinkedList
       b = [4, 5].toDoublyLinkedList
-    a.addMove b
+    a.addMoved b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == []
-    a.addMove a
+    a.addMoved a
     assert a.toSeq == []
-  if L2.head != nil:
-    L2.head.prev = L1.tail
-  if L1.tail != nil:
-    L1.tail.next = L2.head
-  L1.tail = L2.tail
-  if L1.head == nil:
-    L1.head = L2.head
-  L2.head = nil
-  L2.tail = nil
+  if b.head != nil:
+    b.head.prev = a.tail
+  if a.tail != nil:
+    a.tail.next = b.head
+  a.tail = b.tail
+  if a.head == nil:
+    a.head = b.head
+  b.head = nil
+  b.tail = nil
 
-proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends a shallow copy of `L2` to the end of `L1`.
+proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5).} =
+  ## Appends a shallow copy of `b` to the end of `a`.
+  ##
+  ## See also:
+  ## * `addMoved proc <#addMoved,SinglyLinkedList[T],SinglyLinkedList[T]>`_
+  ## * `addMoved proc <#addMoved,DoublyLinkedList[T],DoublyLinkedList[T]>`_
+  ##   for moving the second list instead of copying
   runnableExamples:
     import sequtils
-    var a = [1, 2, 3].toDoublyLinkedList
-    let b = [4, 5].toDoublyLinkedList
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
     a.add b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == [4, 5]
     a.add a
     assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = L2.copy
-  L1.addMove tmp
+  var tmp = b.copy
+  a.addMoved tmp
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -704,15 +704,15 @@ proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 
   ## Appends a shallow copy of `L2` to the end of `L1`.
   runnableExamples:
     import sequtils
-    var a = [1, 2, 3].toDoublyLinkedList
-    let b = [4, 5].toDoublyLinkedList
+    var a = [1, 2, 3].toSinglyLinkedList
+    let b = [4, 5].toSinglyLinkedList
     a.add b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == [4, 5]
     a.add a
     assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = L2.copy
-  L1.addMove tmp
+  var tmp = b.copy
+  a.addMoved tmp
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -559,20 +559,6 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Adds `L2` to the end of `L1`. Efficiency: O(1).
-  ## Note that the two lists share structure after the operation.
-  runnableExamples:
-    var a = [1, 2, 3].toDoublyLinkedList
-    let b = [4, 5].toDoublyLinkedList
-    a.add(b)
-    assert $a == "[1, 2, 3, 4, 5]"
-  if L1.tail != nil:
-    L1.tail.next = L2.head
-  L1.tail = L2.tail
-  if L1.head == nil:
-    L1.head = L2.head
-
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Removes a node `n` from `L`. Efficiency: O(1).
   runnableExamples:

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -179,7 +179,7 @@ proc newSinglyLinkedNode*[T](value: T): <//>(SinglyLinkedNode[T]) =
   new(result)
   result.value = value
 
-func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (1, 5).} =
+func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (1, 6).} =
   ## Creates a new `SinglyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
@@ -190,7 +190,7 @@ func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (
   for elem in elems.items:
     result.append(elem)
 
-func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (1, 5).} =
+func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (1, 6).} =
   ## Creates a new `DoublyLinkedList` with the members of the
   ## given collection (seq, array, or string) `elems`.
   runnableExamples:
@@ -458,7 +458,7 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     assert a.contains(9)
   prepend(L, newSinglyLinkedNode(value))
 
-func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
+func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 6).} =
   ## Creates a shallow copy of `a`.
   runnableExamples:
     import sequtils
@@ -481,7 +481,7 @@ func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
   for x in a:
     result.append(x)
 
-proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5).} =
+proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 6).} =
   ## Moves `b` to the end of `a`. Efficiency: O(1).
   ## Note that `b` becomes empty after the operation.
   ## Self-adding results in an empty list.
@@ -593,7 +593,7 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     assert a.contains(9)
   prepend(L, newDoublyLinkedNode(value))
 
-func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
+func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 6).} =
   ## Creates a shallow copy of `a`.
   runnableExamples:
     type Foo = ref object
@@ -612,7 +612,7 @@ func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
   for x in a:
     result.append(x)
 
-proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5).} =
+proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 6).} =
   ## Moves `b` to the end of `a`. Efficiency: O(1).
   ## Note that `b` becomes empty after the operation.
   ## Self-adding results in an empty list.
@@ -640,7 +640,7 @@ proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5).} =
   b.head = nil
   b.tail = nil
 
-proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5).} =
+proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 6).} =
   ## Appends a shallow copy of `b` to the end of `a`.
   ##
   ## See also:

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -476,34 +476,40 @@ func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5, 1).} 
     let c = [1, 2, 3].toSinglyLinkedList
     assert $c == $c.copy
   result = initSinglyLinkedList[T]()
-  for x in a:
+  for x in a.items:
     result.append(x)
 
 proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
   ## Moves `b` to the end of `a`. Efficiency: O(1).
-  ## Note that `b` becomes empty after the operation.
-  ## Self-adding results in an empty list.
+  ## Note that `b` becomes empty after the operation unless it has the same address as `a`.
+  ## Self-adding results in a cycle.
   ##
   ## See also:
   ## * `add proc <#add,T,T>`_
   ##   for adding a copy of a list
   runnableExamples:
-    import sequtils
+    import sequtils, std/enumerate, std/sugar
     var
       a = [1, 2, 3].toSinglyLinkedList
       b = [4, 5].toSinglyLinkedList
+      c = [0, 1].toSinglyLinkedList
     a.addMoved b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == []
-    a.addMoved a
-    assert a.toSeq == []
+    c.addMoved c
+    let s = collect:
+      for i, ci in enumerate(c):
+        if i == 6: break
+        ci
+    assert s == [0, 1, 0, 1, 0, 1]
   if a.tail != nil:
     a.tail.next = b.head
   a.tail = b.tail
   if a.head == nil:
     a.head = b.head
-  b.head = nil
-  b.tail = nil
+  if a.addr != b.addr:
+    b.head = nil
+    b.tail = nil
 
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
@@ -607,27 +613,32 @@ func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5, 1).} 
     let c = [1, 2, 3].toDoublyLinkedList
     assert $c == $c.copy
   result = initDoublyLinkedList[T]()
-  for x in a:
+  for x in a.items:
     result.append(x)
 
 proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5, 1).} =
   ## Moves `b` to the end of `a`. Efficiency: O(1).
-  ## Note that `b` becomes empty after the operation.
-  ## Self-adding results in an empty list.
+  ## Note that `b` becomes empty after the operation unless it has the same address as `a`.
+  ## Self-adding results in a cycle.
   ##
   ## See also:
   ## * `add proc <#add,T,T>`_
   ##   for adding a copy of a list
   runnableExamples:
-    import sequtils
+    import sequtils, std/enumerate, std/sugar
     var
       a = [1, 2, 3].toDoublyLinkedList
       b = [4, 5].toDoublyLinkedList
+      c = [0, 1].toDoublyLinkedList
     a.addMoved b
     assert a.toSeq == [1, 2, 3, 4, 5]
     assert b.toSeq == []
-    a.addMoved a
-    assert a.toSeq == []
+    c.addMoved c
+    let s = collect:
+      for i, ci in enumerate(c):
+        if i == 6: break
+        ci
+    assert s == [0, 1, 0, 1, 0, 1]
   if b.head != nil:
     b.head.prev = a.tail
   if a.tail != nil:
@@ -635,8 +646,9 @@ proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5, 1).} =
   a.tail = b.tail
   if a.head == nil:
     a.head = b.head
-  b.head = nil
-  b.tail = nil
+  if a.addr != b.addr:
+    b.head = nil
+    b.tail = nil
 
 proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5, 1).} =
   ## Appends a shallow copy of `b` to the end of `a`.

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -180,8 +180,7 @@ proc newSinglyLinkedNode*[T](value: T): <//>(SinglyLinkedNode[T]) =
   result.value = value
 
 func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (1, 5, 1).} =
-  ## Creates a new `SinglyLinkedList` with the members of the
-  ## given collection (seq, array, or string) `elems`.
+  ## Creates a new `SinglyLinkedList` from members of `elems`.
   runnableExamples:
     import sequtils
     let a = [1, 2, 3, 4, 5].toSinglyLinkedList
@@ -191,8 +190,7 @@ func toSinglyLinkedList*[T](elems: openArray[T]): SinglyLinkedList[T] {.since: (
     result.append(elem)
 
 func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (1, 5, 1).} =
-  ## Creates a new `DoublyLinkedList` with the members of the
-  ## given collection (seq, array, or string) `elems`.
+  ## Creates a new `DoublyLinkedList` from members of `elems`.
   runnableExamples:
     import sequtils
     let a = [1, 2, 3, 4, 5].toDoublyLinkedList
@@ -507,33 +505,6 @@ proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
   b.head = nil
   b.tail = nil
 
-proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends a shallow copy of `L2` to the end of `L1`.
-  runnableExamples:
-    var a = [1, 2, 3].toSinglyLinkedList
-    let b = [4, 5].toSinglyLinkedList
-    a.add b
-    assert a.toSeq == [1, 2, 3, 4, 5]
-    assert b.toSeq == [4, 5]
-    a.add a
-    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = L2.copy
-  L1.addMove tmp
-
-proc add*[T](L1: var SinglyLinkedList[T], L2: SinglyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends a shallow copy of `L2` to the end of `L1`.
-  runnableExamples:
-    import sequtils
-    var a = [1, 2, 3].toSinglyLinkedList
-    let b = [4, 5].toSinglyLinkedList
-    a.add b
-    assert a.toSeq == [1, 2, 3, 4, 5]
-    assert b.toSeq == [4, 5]
-    a.add a
-    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = L2.copy
-  L1.addMove tmp
-
 proc append*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
   ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
   ##
@@ -674,34 +645,6 @@ proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5, 1).} =
   ## * `addMoved proc <#addMoved,SinglyLinkedList[T],SinglyLinkedList[T]>`_
   ## * `addMoved proc <#addMoved,DoublyLinkedList[T],DoublyLinkedList[T]>`_
   ##   for moving the second list instead of copying
-  runnableExamples:
-    import sequtils
-    var a = [1, 2, 3].toSinglyLinkedList
-    let b = [4, 5].toSinglyLinkedList
-    a.add b
-    assert a.toSeq == [1, 2, 3, 4, 5]
-    assert b.toSeq == [4, 5]
-    a.add a
-    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = b.copy
-  a.addMoved tmp
-
-proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends a shallow copy of `L2` to the end of `L1`.
-  runnableExamples:
-    import sequtils
-    var a = [1, 2, 3].toSinglyLinkedList
-    let b = [4, 5].toSinglyLinkedList
-    a.add b
-    assert a.toSeq == [1, 2, 3, 4, 5]
-    assert b.toSeq == [4, 5]
-    a.add a
-    assert a.toSeq == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
-  var tmp = b.copy
-  a.addMoved tmp
-
-proc add*[T](L1: var DoublyLinkedList[T], L2: DoublyLinkedList[T]) {.since: (1, 5).} =
-  ## Appends a shallow copy of `L2` to the end of `L1`.
   runnableExamples:
     import sequtils
     var a = [1, 2, 3].toSinglyLinkedList

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -461,8 +461,18 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
 func copy*[T](L: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
   ## Creates a shallow copy of `L`.
   runnableExamples:
-    let a = [1, 2, 3].toSinglyLinkedList
-    assert $a == $a.copy
+    type Foo = ref object
+      x: int
+    var f = Foo(x: 1)
+    let
+      a = [f].toSinglyLinkedList
+      b = a.copy
+    f.x = 42
+    assert a.head.value.x == 42
+    assert b.head.value.x == 42
+
+    let c = [1, 2, 3].toSinglyLinkedList
+    assert $c == $c.copy
   result = initSinglyLinkedList[T]()
   for x in L:
     result.append(x)
@@ -470,6 +480,7 @@ func copy*[T](L: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5).} =
 proc add*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
   ## Moves `L2` to the end of `L1`. Efficiency: O(1).
   ## Note that `L2` becomes empty after the operation.
+  ## Self-adding results in an empty list.
   runnableExamples:
     var
       a = [1, 2, 3].toSinglyLinkedList
@@ -477,6 +488,8 @@ proc add*[T](L1, L2: var SinglyLinkedList[T]) {.since: (1, 5).} =
     a.add(b)
     assert $a == "[1, 2, 3, 4, 5]"
     assert $b == "[]"
+    a.add(a)
+    assert $a == "[]"
   if L1.tail != nil:
     L1.tail.next = L2.head
   L1.tail = L2.tail
@@ -574,8 +587,18 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
 func copy*[T](L: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
   ## Creates a shallow copy of `L`.
   runnableExamples:
-    let a = [1, 2, 3].toDoublyLinkedList
-    assert $a == $a.copy
+    type Foo = ref object
+      x: int
+    var f = Foo(x: 1)
+    let
+      a = [f].toDoublyLinkedList
+      b = a.copy
+    f.x = 42
+    assert a.head.value.x == 42
+    assert b.head.value.x == 42
+
+    let c = [1, 2, 3].toDoublyLinkedList
+    assert $c == $c.copy
   result = initDoublyLinkedList[T]()
   for x in L:
     result.append(x)
@@ -583,6 +606,7 @@ func copy*[T](L: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5).} =
 proc add*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
   ## Moves `L2` to the end of `L1`. Efficiency: O(1).
   ## Note that `L2` becomes empty after the operation.
+  ## Self-adding results in an empty list.
   runnableExamples:
     var
       a = [1, 2, 3].toDoublyLinkedList
@@ -590,6 +614,8 @@ proc add*[T](L1, L2: var DoublyLinkedList[T]) {.since: (1, 5).} =
     a.add(b)
     assert $a == "[1, 2, 3, 4, 5]"
     assert $b == "[]"
+    a.add(a)
+    assert $a == "[]"
   if L2.head != nil:
     L2.head.prev = L1.tail
   if L1.tail != nil:

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -120,6 +120,9 @@ template testCommon(initList, toList) =
       l2.add l3 # re-adding l3 that was destroyed is now a no-op
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
+      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
+      doAssert l2.toSeq == [2, 3, 4, 5, 6]
+      doAssert l3.toSeq == []
     block:
       var
         l0 = initList[int]()

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -95,25 +95,51 @@ block toDoublyLinkedList:
   doAssert [1, 2, 3].toDoublyLinkedList.toSeq == [1, 2, 3]
 
 block add:
-  block:
-    var
-      l0 = initSinglyLinkedList[int]()
-      l1 = [1].toSinglyLinkedList
-      l2 = [2, 3].toSinglyLinkedList
-      l3 = [4, 5, 6].toSinglyLinkedList
-    l0.add(l3)
-    l1.add(l3)
-    l2.add(l3)
-    doAssert l0.toSeq == [4, 5, 6]
-    doAssert l1.toSeq == [1, 4, 5, 6]
-    doAssert l2.toSeq == [2, 3, 4, 5, 6]
-  block:
-    var
-      l0 = initSinglyLinkedList[int]()
-      l1 = [1].toSinglyLinkedList
-      l2 = [2, 3].toSinglyLinkedList
-      l3 = [4, 5, 6].toSinglyLinkedList
-    l3.add(l0)
-    l2.add(l1)
-    doAssert l3.toSeq == [4, 5, 6]
-    doAssert l2.toSeq == [2, 3, 1]
+  block: # SinglyLinkedList
+    block:
+      var
+        l0 = initSinglyLinkedList[int]()
+        l1 = [1].toSinglyLinkedList
+        l2 = [2, 3].toSinglyLinkedList
+        l3 = [4, 5, 6].toSinglyLinkedList
+      l0.add(l3.copy)
+      l1.add(l3.copy)
+      l2.add(l3)
+      doAssert l0.toSeq == [4, 5, 6]
+      doAssert l1.toSeq == [1, 4, 5, 6]
+      doAssert l2.toSeq == [2, 3, 4, 5, 6]
+      doAssert l3.toSeq == []
+    block:
+      var
+        l0 = initSinglyLinkedList[int]()
+        l1 = [1].toSinglyLinkedList
+        l2 = [2, 3].toSinglyLinkedList
+        l3 = [4, 5, 6].toSinglyLinkedList
+      l3.add(l0)
+      l2.add(l1)
+      doAssert l3.toSeq == [4, 5, 6]
+      doAssert l2.toSeq == [2, 3, 1]
+  block: # DoublyLinkedList
+    block:
+      var
+        l0 = initDoublyLinkedList[int]()
+        l1 = [1].toDoublyLinkedList
+        l2 = [2, 3].toDoublyLinkedList
+        l3 = [4, 5, 6].toDoublyLinkedList
+      l0.add(l3.copy)
+      l1.add(l3.copy)
+      l2.add(l3)
+      doAssert l0.toSeq == [4, 5, 6]
+      doAssert l1.toSeq == [1, 4, 5, 6]
+      doAssert l2.toSeq == [2, 3, 4, 5, 6]
+      doAssert l3.toSeq == []
+    block:
+      var
+        l0 = initDoublyLinkedList[int]()
+        l1 = [1].toDoublyLinkedList
+        l2 = [2, 3].toDoublyLinkedList
+        l3 = [4, 5, 6].toDoublyLinkedList
+      l3.add(l0)
+      l2.add(l1)
+      doAssert l3.toSeq == [4, 5, 6]
+      doAssert l2.toSeq == [2, 3, 1]

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -94,6 +94,19 @@ block toDoublyLinkedList:
   doAssert [1].toDoublyLinkedList.toSeq == [1]
   doAssert [1, 2, 3].toDoublyLinkedList.toSeq == [1, 2, 3]
 
+block copy:
+  doAssert array[0, int].default.toSinglyLinkedList.copy.toSeq == []
+  doAssert [1].toSinglyLinkedList.copy.toSeq == [1]
+  doAssert [1, 2].toSinglyLinkedList.copy.toSeq == [1, 2]
+  doAssert [1, 2, 3].toSinglyLinkedList.copy.toSeq == [1, 2, 3]
+  type Foo = ref object
+    x: int
+  var f = Foo(x: 1)
+  let a = [f, f].toSinglyLinkedList
+  f.x = 42
+  assert a.head.value == f
+  assert a.head.next.value == f
+
 block add:
   block: # SinglyLinkedList
     block:
@@ -102,11 +115,16 @@ block add:
         l1 = [1].toSinglyLinkedList
         l2 = [2, 3].toSinglyLinkedList
         l3 = [4, 5, 6].toSinglyLinkedList
-      l0.add(l3.copy)
-      l1.add(l3.copy)
-      l2.add(l3)
+        l4 = l3.copy
+        l5 = l3.copy
+      l0.add(l3)
+      l1.add(l4)
+      l2.add(l5)
       doAssert l0.toSeq == [4, 5, 6]
       doAssert l1.toSeq == [1, 4, 5, 6]
+      doAssert l2.toSeq == [2, 3, 4, 5, 6]
+      doAssert l3.toSeq == []
+      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
     block:
@@ -126,11 +144,16 @@ block add:
         l1 = [1].toDoublyLinkedList
         l2 = [2, 3].toDoublyLinkedList
         l3 = [4, 5, 6].toDoublyLinkedList
-      l0.add(l3.copy)
-      l1.add(l3.copy)
-      l2.add(l3)
+        l4 = l3.copy
+        l5 = l3.copy
+      l0.add(l3)
+      l1.add(l4)
+      l2.add(l5)
       doAssert l0.toSeq == [4, 5, 6]
       doAssert l1.toSeq == [1, 4, 5, 6]
+      doAssert l2.toSeq == [2, 3, 4, 5, 6]
+      doAssert l3.toSeq == []
+      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
     block:

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -82,87 +82,60 @@ block tlistsToString:
     l.append('3')
     doAssert $l == """['1', '2', '3']"""
 
-block toSinglyLinkedList:
-  let l = seq[int].default
-  doAssert l.toSinglyLinkedList.toSeq == []
-  doAssert [1].toSinglyLinkedList.toSeq == [1]
-  doAssert [1, 2, 3].toSinglyLinkedList.toSeq == [1, 2, 3]
-
-block toDoublyLinkedList:
-  let l = seq[int].default
-  doAssert l.toDoublyLinkedList.toSeq == []
-  doAssert [1].toDoublyLinkedList.toSeq == [1]
-  doAssert [1, 2, 3].toDoublyLinkedList.toSeq == [1, 2, 3]
+block: # toSinglyLinkedList, toDoublyLinkedList
+  template testCommon(toList) =
+    let l = seq[int].default
+    doAssert l.toList.toSeq == []
+    doAssert [1].toList.toSeq == [1]
+    doAssert [1, 2, 3].toList.toSeq == [1, 2, 3]
+  testCommon(toSinglyLinkedList)
+  testCommon(toDoublyLinkedList)
 
 block copy:
-  doAssert array[0, int].default.toSinglyLinkedList.copy.toSeq == []
-  doAssert [1].toSinglyLinkedList.copy.toSeq == [1]
-  doAssert [1, 2].toSinglyLinkedList.copy.toSeq == [1, 2]
-  doAssert [1, 2, 3].toSinglyLinkedList.copy.toSeq == [1, 2, 3]
-  type Foo = ref object
-    x: int
-  var f = Foo(x: 1)
-  let a = [f, f].toSinglyLinkedList
-  f.x = 42
-  assert a.head.value == f
-  assert a.head.next.value == f
+  template testCommon(toList) =
+    doAssert array[0, int].default.toList.copy.toSeq == []
+    doAssert [1].toList.copy.toSeq == [1]
+    doAssert [1, 2].toList.copy.toSeq == [1, 2]
+    doAssert [1, 2, 3].toList.copy.toSeq == [1, 2, 3]
+    type Foo = ref object
+      x: int
+    var f = Foo(x: 1)
+    let a = [f, f].toList
+    f.x = 42
+    assert a.head.value == f
+    assert a.head.next.value == f
+  testCommon(toSinglyLinkedList)
+  testCommon(toDoublyLinkedList)
 
 block add:
-  block: # SinglyLinkedList
+  template testCommon(initList, toList) =
     block:
       var
-        l0 = initSinglyLinkedList[int]()
-        l1 = [1].toSinglyLinkedList
-        l2 = [2, 3].toSinglyLinkedList
-        l3 = [4, 5, 6].toSinglyLinkedList
+        l0 = initList[int]()
+        l1 = [1].toList
+        l2 = [2, 3].toList
+        l3 = [4, 5, 6].toList
         l4 = l3.copy
         l5 = l3.copy
-      l0.add(l3)
-      l1.add(l4)
-      l2.add(l5)
+      l0.add l3
+      l1.add l4
+      l2.add l5
       doAssert l0.toSeq == [4, 5, 6]
       doAssert l1.toSeq == [1, 4, 5, 6]
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
-      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
+      l2.add l3 # re-adding l3 that was destroyed is now a no-op
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
     block:
       var
-        l0 = initSinglyLinkedList[int]()
-        l1 = [1].toSinglyLinkedList
-        l2 = [2, 3].toSinglyLinkedList
-        l3 = [4, 5, 6].toSinglyLinkedList
-      l3.add(l0)
-      l2.add(l1)
+        l0 = initList[int]()
+        l1 = [1].toList
+        l2 = [2, 3].toList
+        l3 = [4, 5, 6].toList
+      l3.add l0
+      l2.add l1
       doAssert l3.toSeq == [4, 5, 6]
       doAssert l2.toSeq == [2, 3, 1]
-  block: # DoublyLinkedList
-    block:
-      var
-        l0 = initDoublyLinkedList[int]()
-        l1 = [1].toDoublyLinkedList
-        l2 = [2, 3].toDoublyLinkedList
-        l3 = [4, 5, 6].toDoublyLinkedList
-        l4 = l3.copy
-        l5 = l3.copy
-      l0.add(l3)
-      l1.add(l4)
-      l2.add(l5)
-      doAssert l0.toSeq == [4, 5, 6]
-      doAssert l1.toSeq == [1, 4, 5, 6]
-      doAssert l2.toSeq == [2, 3, 4, 5, 6]
-      doAssert l3.toSeq == []
-      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
-      doAssert l2.toSeq == [2, 3, 4, 5, 6]
-      doAssert l3.toSeq == []
-    block:
-      var
-        l0 = initDoublyLinkedList[int]()
-        l1 = [1].toDoublyLinkedList
-        l2 = [2, 3].toDoublyLinkedList
-        l3 = [4, 5, 6].toDoublyLinkedList
-      l3.add(l0)
-      l2.add(l1)
-      doAssert l3.toSeq == [4, 5, 6]
-      doAssert l2.toSeq == [2, 3, 1]
+  testCommon(initSinglyLinkedList, toSinglyLinkedList)
+  testCommon(initDoublyLinkedList, toDoublyLinkedList)

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -123,6 +123,9 @@ template testCommon(initList, toList) =
       l2.add(l3) # re-adding l3 that was destroyed is now a no-op
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
+      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
+      doAssert l2.toSeq == [2, 3, 4, 5, 6]
+      doAssert l3.toSeq == []
     block:
       var
         l0 = initList[int]()

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -82,17 +82,15 @@ block tlistsToString:
     l.append('3')
     doAssert $l == """['1', '2', '3']"""
 
-block: # toSinglyLinkedList, toDoublyLinkedList
-  template testCommon(toList) =
+template testCommon(initList, toList) =
+
+  block: # toSinglyLinkedList, toDoublyLinkedList
     let l = seq[int].default
     doAssert l.toList.toSeq == []
     doAssert [1].toList.toSeq == [1]
     doAssert [1, 2, 3].toList.toSeq == [1, 2, 3]
-  testCommon(toSinglyLinkedList)
-  testCommon(toDoublyLinkedList)
 
-block copy:
-  template testCommon(toList) =
+  block copy:
     doAssert array[0, int].default.toList.copy.toSeq == []
     doAssert [1].toList.copy.toSeq == [1]
     doAssert [1, 2].toList.copy.toSeq == [1, 2]
@@ -104,22 +102,17 @@ block copy:
     f.x = 42
     assert a.head.value == f
     assert a.head.next.value == f
-  testCommon(toSinglyLinkedList)
-  testCommon(toDoublyLinkedList)
 
-block add:
-  template testCommon(initList, toList) =
+  block: # add, addMove
     block:
       var
         l0 = initList[int]()
         l1 = [1].toList
         l2 = [2, 3].toList
         l3 = [4, 5, 6].toList
-        l4 = l3.copy
-        l5 = l3.copy
       l0.add l3
-      l1.add l4
-      l2.add l5
+      l1.add l3
+      l2.addMove l3
       doAssert l0.toSeq == [4, 5, 6]
       doAssert l1.toSeq == [1, 4, 5, 6]
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
@@ -133,9 +126,12 @@ block add:
         l1 = [1].toList
         l2 = [2, 3].toList
         l3 = [4, 5, 6].toList
-      l3.add l0
-      l2.add l1
+      l3.addMove l0
+      l2.addMove l1
       doAssert l3.toSeq == [4, 5, 6]
       doAssert l2.toSeq == [2, 3, 1]
-  testCommon(initSinglyLinkedList, toSinglyLinkedList)
-  testCommon(initDoublyLinkedList, toDoublyLinkedList)
+      l3.add l0
+      doAssert l3.toSeq == [4, 5, 6]
+
+testCommon initSinglyLinkedList, toSinglyLinkedList
+testCommon initDoublyLinkedList, toDoublyLinkedList

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -81,3 +81,63 @@ block tlistsToString:
     l.append('2')
     l.append('3')
     doAssert $l == """['1', '2', '3']"""
+
+block SinglyLinkedListConversion:
+  let l: seq[int] = @[]
+  doAssert $l.toSinglyLinkedList == "[]"
+  doAssert $[1].toSinglyLinkedList == "[1]"
+  doAssert $[1, 2, 3].toSinglyLinkedList == "[1, 2, 3]"
+
+block DoublyLinkedListConversion:
+  let l: seq[int] = @[]
+  doAssert $l.toDoublyLinkedList == "[]"
+  doAssert $[1].toDoublyLinkedList == "[1]"
+  doAssert $[1, 2, 3].toDoublyLinkedList == "[1, 2, 3]"
+
+block SinglyLinkedListConcat:
+  block:
+    var
+      l0 = initSinglyLinkedList[int]()
+      l1 = [1].toSinglyLinkedList
+      l2 = [2, 3].toSinglyLinkedList
+      l3 = [4, 5, 6].toSinglyLinkedList
+    l0.concat(l3)
+    l1.concat(l3)
+    l2.concat(l3)
+    doAssert $l0 == "[4, 5, 6]"
+    doAssert $l1 == "[1, 4, 5, 6]"
+    doAssert $l2 == "[2, 3, 4, 5, 6]"
+  block:
+    var
+      l0 = initSinglyLinkedList[int]()
+      l1 = [1].toSinglyLinkedList
+      l2 = [2, 3].toSinglyLinkedList
+      l3 = [4, 5, 6].toSinglyLinkedList
+    l3.concat(l0)
+    l2.concat(l1)
+    doAssert $l3 == "[4, 5, 6]"
+    doAssert $l2 == "[2, 3, 1]"
+
+block DoublyLinkedListConcat:
+  block:
+    var
+      l0 = initDoublyLinkedList[int]()
+      l1 = [1].toDoublyLinkedList
+      l2 = [2, 3].toDoublyLinkedList
+      l3 = [4, 5, 6].toDoublyLinkedList
+    l0.concat(l3)
+    l1.concat(l3)
+    l2.concat(l3)
+    doAssert $l0 == "[4, 5, 6]"
+    doAssert $l1 == "[1, 4, 5, 6]"
+    doAssert $l2 == "[2, 3, 4, 5, 6]"
+  block:
+    var
+      l0 = initDoublyLinkedList[int]()
+      l1 = [1].toDoublyLinkedList
+      l2 = [2, 3].toDoublyLinkedList
+      l3 = [4, 5, 6].toDoublyLinkedList
+    l3.concat(l0)
+    l2.concat(l1)
+    doAssert $l3 == "[4, 5, 6]"
+    doAssert $l2 == "[2, 3, 1]"

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -94,16 +94,16 @@ block DoublyLinkedListConversion:
   doAssert $[1].toDoublyLinkedList == "[1]"
   doAssert $[1, 2, 3].toDoublyLinkedList == "[1, 2, 3]"
 
-block AppendingSinglyLinkedLists:
+block AddingSinglyLinkedLists:
   block:
     var
       l0 = initSinglyLinkedList[int]()
       l1 = [1].toSinglyLinkedList
       l2 = [2, 3].toSinglyLinkedList
       l3 = [4, 5, 6].toSinglyLinkedList
-    l0.append(l3)
-    l1.append(l3)
-    l2.append(l3)
+    l0.add(l3)
+    l1.add(l3)
+    l2.add(l3)
     doAssert $l0 == "[4, 5, 6]"
     doAssert $l1 == "[1, 4, 5, 6]"
     doAssert $l2 == "[2, 3, 4, 5, 6]"
@@ -113,21 +113,21 @@ block AppendingSinglyLinkedLists:
       l1 = [1].toSinglyLinkedList
       l2 = [2, 3].toSinglyLinkedList
       l3 = [4, 5, 6].toSinglyLinkedList
-    l3.append(l0)
-    l2.append(l1)
+    l3.add(l0)
+    l2.add(l1)
     doAssert $l3 == "[4, 5, 6]"
     doAssert $l2 == "[2, 3, 1]"
 
-block AppendingDoublyLinkedLists:
+block AddingDoublyLinkedLists:
   block:
     var
       l0 = initDoublyLinkedList[int]()
       l1 = [1].toDoublyLinkedList
       l2 = [2, 3].toDoublyLinkedList
       l3 = [4, 5, 6].toDoublyLinkedList
-    l0.append(l3)
-    l1.append(l3)
-    l2.append(l3)
+    l0.add(l3)
+    l1.add(l3)
+    l2.add(l3)
     doAssert $l0 == "[4, 5, 6]"
     doAssert $l1 == "[1, 4, 5, 6]"
     doAssert $l2 == "[2, 3, 4, 5, 6]"
@@ -137,7 +137,7 @@ block AppendingDoublyLinkedLists:
       l1 = [1].toDoublyLinkedList
       l2 = [2, 3].toDoublyLinkedList
       l3 = [4, 5, 6].toDoublyLinkedList
-    l3.append(l0)
-    l2.append(l1)
+    l3.add(l0)
+    l2.add(l1)
     doAssert $l3 == "[4, 5, 6]"
     doAssert $l2 == "[2, 3, 1]"

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -2,7 +2,7 @@ discard """
   targets: "c js"
 """
 
-import lists, sequtils
+import lists, sequtils, std/enumerate, std/sugar
 
 const
   data = [1, 2, 3, 4, 5, 6]
@@ -97,11 +97,16 @@ template testCommon(initList, toList) =
     doAssert [1, 2, 3].toList.copy.toSeq == [1, 2, 3]
     type Foo = ref object
       x: int
-    var f = Foo(x: 1)
-    let a = [f, f].toList
-    f.x = 42
-    assert a.head.value == f
-    assert a.head.next.value == f
+    var f0 = Foo(x: 0)
+    let f1 = Foo(x: 1)
+    var a = [f0].toList
+    var b = a.copy
+    b.append f1
+    doAssert a.toSeq == [f0]
+    doAssert b.toSeq == [f0, f1]
+    f0.x = 42
+    assert a.head.value.x == 42
+    assert b.head.value.x == 42
 
   block: # add, addMoved
     block:
@@ -132,6 +137,14 @@ template testCommon(initList, toList) =
       doAssert l2.toSeq == [2, 3, 1]
       l3.add l0
       doAssert l3.toSeq == [4, 5, 6]
+    block:
+      var c = [0, 1].toList
+      c.addMoved c
+      let s = collect:
+        for i, ci in enumerate(c):
+          if i == 6: break
+          ci
+      doAssert s == [0, 1, 0, 1, 0, 1]
 
 testCommon initSinglyLinkedList, toSinglyLinkedList
 testCommon initDoublyLinkedList, toDoublyLinkedList

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -2,7 +2,7 @@ discard """
   targets: "c js"
 """
 
-import lists
+import lists, sequtils
 
 const
   data = [1, 2, 3, 4, 5, 6]
@@ -82,19 +82,19 @@ block tlistsToString:
     l.append('3')
     doAssert $l == """['1', '2', '3']"""
 
-block SinglyLinkedListConversion:
-  let l: seq[int] = @[]
-  doAssert $l.toSinglyLinkedList == "[]"
-  doAssert $[1].toSinglyLinkedList == "[1]"
-  doAssert $[1, 2, 3].toSinglyLinkedList == "[1, 2, 3]"
+block toSinglyLinkedList:
+  let l = seq[int].default
+  doAssert l.toSinglyLinkedList.toSeq == []
+  doAssert [1].toSinglyLinkedList.toSeq == [1]
+  doAssert [1, 2, 3].toSinglyLinkedList.toSeq == [1, 2, 3]
 
-block DoublyLinkedListConversion:
-  let l: seq[int] = @[]
-  doAssert $l.toDoublyLinkedList == "[]"
-  doAssert $[1].toDoublyLinkedList == "[1]"
-  doAssert $[1, 2, 3].toDoublyLinkedList == "[1, 2, 3]"
+block toDoublyLinkedList:
+  let l = seq[int].default
+  doAssert l.toDoublyLinkedList.toSeq == []
+  doAssert [1].toDoublyLinkedList.toSeq == [1]
+  doAssert [1, 2, 3].toDoublyLinkedList.toSeq == [1, 2, 3]
 
-block AddingSinglyLinkedLists:
+block add:
   block:
     var
       l0 = initSinglyLinkedList[int]()
@@ -104,9 +104,9 @@ block AddingSinglyLinkedLists:
     l0.add(l3)
     l1.add(l3)
     l2.add(l3)
-    doAssert $l0 == "[4, 5, 6]"
-    doAssert $l1 == "[1, 4, 5, 6]"
-    doAssert $l2 == "[2, 3, 4, 5, 6]"
+    doAssert l0.toSeq == [4, 5, 6]
+    doAssert l1.toSeq == [1, 4, 5, 6]
+    doAssert l2.toSeq == [2, 3, 4, 5, 6]
   block:
     var
       l0 = initSinglyLinkedList[int]()
@@ -115,5 +115,5 @@ block AddingSinglyLinkedLists:
       l3 = [4, 5, 6].toSinglyLinkedList
     l3.add(l0)
     l2.add(l1)
-    doAssert $l3 == "[4, 5, 6]"
-    doAssert $l2 == "[2, 3, 1]"
+    doAssert l3.toSeq == [4, 5, 6]
+    doAssert l2.toSeq == [2, 3, 1]

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -103,7 +103,7 @@ template testCommon(initList, toList) =
     assert a.head.value == f
     assert a.head.next.value == f
 
-  block: # add, addMove
+  block: # add, addMoved
     block:
       var
         l0 = initList[int]()
@@ -112,7 +112,7 @@ template testCommon(initList, toList) =
         l3 = [4, 5, 6].toList
       l0.add l3
       l1.add l3
-      l2.addMove l3
+      l2.addMoved l3
       doAssert l0.toSeq == [4, 5, 6]
       doAssert l1.toSeq == [1, 4, 5, 6]
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
@@ -126,8 +126,8 @@ template testCommon(initList, toList) =
         l1 = [1].toList
         l2 = [2, 3].toList
         l3 = [4, 5, 6].toList
-      l3.addMove l0
-      l2.addMove l1
+      l3.addMoved l0
+      l2.addMoved l1
       doAssert l3.toSeq == [4, 5, 6]
       doAssert l2.toSeq == [2, 3, 1]
       l3.add l0

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -117,27 +117,3 @@ block AddingSinglyLinkedLists:
     l2.add(l1)
     doAssert $l3 == "[4, 5, 6]"
     doAssert $l2 == "[2, 3, 1]"
-
-block AddingDoublyLinkedLists:
-  block:
-    var
-      l0 = initDoublyLinkedList[int]()
-      l1 = [1].toDoublyLinkedList
-      l2 = [2, 3].toDoublyLinkedList
-      l3 = [4, 5, 6].toDoublyLinkedList
-    l0.add(l3)
-    l1.add(l3)
-    l2.add(l3)
-    doAssert $l0 == "[4, 5, 6]"
-    doAssert $l1 == "[1, 4, 5, 6]"
-    doAssert $l2 == "[2, 3, 4, 5, 6]"
-  block:
-    var
-      l0 = initDoublyLinkedList[int]()
-      l1 = [1].toDoublyLinkedList
-      l2 = [2, 3].toDoublyLinkedList
-      l3 = [4, 5, 6].toDoublyLinkedList
-    l3.add(l0)
-    l2.add(l1)
-    doAssert $l3 == "[4, 5, 6]"
-    doAssert $l2 == "[2, 3, 1]"

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -94,16 +94,16 @@ block DoublyLinkedListConversion:
   doAssert $[1].toDoublyLinkedList == "[1]"
   doAssert $[1, 2, 3].toDoublyLinkedList == "[1, 2, 3]"
 
-block SinglyLinkedListConcat:
+block AppendingSinglyLinkedLists:
   block:
     var
       l0 = initSinglyLinkedList[int]()
       l1 = [1].toSinglyLinkedList
       l2 = [2, 3].toSinglyLinkedList
       l3 = [4, 5, 6].toSinglyLinkedList
-    l0.concat(l3)
-    l1.concat(l3)
-    l2.concat(l3)
+    l0.append(l3)
+    l1.append(l3)
+    l2.append(l3)
     doAssert $l0 == "[4, 5, 6]"
     doAssert $l1 == "[1, 4, 5, 6]"
     doAssert $l2 == "[2, 3, 4, 5, 6]"
@@ -113,21 +113,21 @@ block SinglyLinkedListConcat:
       l1 = [1].toSinglyLinkedList
       l2 = [2, 3].toSinglyLinkedList
       l3 = [4, 5, 6].toSinglyLinkedList
-    l3.concat(l0)
-    l2.concat(l1)
+    l3.append(l0)
+    l2.append(l1)
     doAssert $l3 == "[4, 5, 6]"
     doAssert $l2 == "[2, 3, 1]"
 
-block DoublyLinkedListConcat:
+block AppendingDoublyLinkedLists:
   block:
     var
       l0 = initDoublyLinkedList[int]()
       l1 = [1].toDoublyLinkedList
       l2 = [2, 3].toDoublyLinkedList
       l3 = [4, 5, 6].toDoublyLinkedList
-    l0.concat(l3)
-    l1.concat(l3)
-    l2.concat(l3)
+    l0.append(l3)
+    l1.append(l3)
+    l2.append(l3)
     doAssert $l0 == "[4, 5, 6]"
     doAssert $l1 == "[1, 4, 5, 6]"
     doAssert $l2 == "[2, 3, 4, 5, 6]"
@@ -137,7 +137,7 @@ block DoublyLinkedListConcat:
       l1 = [1].toDoublyLinkedList
       l2 = [2, 3].toDoublyLinkedList
       l3 = [4, 5, 6].toDoublyLinkedList
-    l3.concat(l0)
-    l2.concat(l1)
+    l3.append(l0)
+    l2.append(l1)
     doAssert $l3 == "[4, 5, 6]"
     doAssert $l2 == "[2, 3, 1]"

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -120,12 +120,6 @@ template testCommon(initList, toList) =
       l2.add l3 # re-adding l3 that was destroyed is now a no-op
       doAssert l2.toSeq == [2, 3, 4, 5, 6]
       doAssert l3.toSeq == []
-      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
-      doAssert l2.toSeq == [2, 3, 4, 5, 6]
-      doAssert l3.toSeq == []
-      l2.add(l3) # re-adding l3 that was destroyed is now a no-op
-      doAssert l2.toSeq == [2, 3, 4, 5, 6]
-      doAssert l3.toSeq == []
     block:
       var
         l0 = initList[int]()


### PR DESCRIPTION
There is also new `toSinglyLinkedList` and `toDoublyLinkedList`
functions for conversion from `openArray`s, similarly
to `toHashSet` or `toTable`.