### PR TITLE
add .github/workflows/needs-rebase.yml to auto-tag PRs needing rebase

### DIFF
--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -1,0 +1,26 @@
+# adapted from https://github.com/eps1lon/actions-label-merge-conflict
+
+name: "Pull Request Needs Rebase?"
+
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolved
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    # types: [synchronize]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  needs-rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR needs rebase
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          dirtyLabel: "needs-rebase"
+          removeOnDirtyLabel: "no conflicts"
+          commentOnDirty: "conflicts detected, rebase needed"
+          commentOnClean: "conflicts have been resolved"

--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -23,4 +23,3 @@ jobs:
           dirtyLabel: "needs-rebase"
           removeOnDirtyLabel: "no conflicts"
           commentOnDirty: "conflicts detected, rebase needed"
-          commentOnClean: "conflicts have been resolved"

--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -22,4 +22,5 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           dirtyLabel: "needs-rebase"
           removeOnDirtyLabel: "no conflicts"
-          commentOnDirty: "conflicts detected, rebase needed"
+          # xxx enable this if label change isn't triggering a notification to PR author
+          # commentOnDirty: "conflicts detected, rebase needed"


### PR DESCRIPTION
## links
https://github.community/t/run-actions-on-pull-requests-with-merge-conflicts/17104
https://github.com/eps1lon/actions-label-merge-conflict
https://github.com/isaacs/github/issues/224
(another similar action was https://github.com/mschilde/auto-label-merge-conflicts)


## example
see conclicts label in this other project: https://github.com/OpenShot/libopenshot/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc+label%3Aconflicts

![image](https://user-images.githubusercontent.com/2194784/102539168-2c59fe00-4062-11eb-9855-40f7f0356379.png)
