### PR TITLE
RST enumlist followup

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -48,6 +48,10 @@
 ## * markdown code blocks
 ## * markdown links
 ## * markdown headlines
+## * using ``1`` as auto-enumerator in enumerated lists like RST ``#``
+##   (auto-enumerator ``1`` can not be used with ``#`` in the same list)
+##
+## **Note:** By default nim has ``roSupportMarkdown`` turned **on**.
 ##
 ## Limitations:
 ##
@@ -1538,8 +1542,12 @@ proc parseEnumList(p: var RstParser): PRstNode =
     if match(p, p.idx, wildcards[w]): break
     inc w
   assert w < wildcards.len
+  let autoEnums = if roSupportMarkdown in p.s.options: @["#", "1"] else: @["#"]
+  var prevAE = ""  # so as not allow mixing auto-enumerators `1` and `#`
+  var curEnum = 1
   for i in 0 ..< wildToken[w]-1:  # add first enumerator with (, ), and .
     if p.tok[p.idx + i].symbol == "#":
+      prevAE = "#"
       result.text.add "1"
     else:
       result.text.add p.tok[p.idx + i].symbol
@@ -1557,17 +1565,19 @@ proc parseEnumList(p: var RstParser): PRstNode =
       # check that it's in sequence: enumerator == next(prevEnum)
       if "n" in wildcards[w]:  # arabic numeral
         let prevEnumI = try: parseInt(prevEnum) except: 1
-        let curEnum =
-          if enumerator == "#": prevEnumI + 1
-          else: (try: parseInt(enumerator) except: 1)
+        if enumerator in autoEnums:
+          if prevAE != "" and enumerator != prevAE:
+            break
+          prevAE = enumerator
+          curEnum = prevEnumI + 1
+        else: curEnum = (try: parseInt(enumerator) except: 1)
         if curEnum - prevEnumI != 1:
           break
         prevEnum = enumerator
       else:  # a..z
         let prevEnumI = ord(prevEnum[0])
-        let curEnum =
-          if enumerator == "#": prevEnumI + 1
-          else: ord(enumerator[0])
+        if enumerator == "#": curEnum = prevEnumI + 1
+        else: curEnum = ord(enumerator[0])
         if curEnum - prevEnumI != 1:
           break
         prevEnum = $chr(curEnum)

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1195,7 +1195,8 @@ proc whichSection(p: RstParser): RstNodeKind =
     elif match(p, p.idx, ":w:") and predNL(p):
       # (currentTok(p).symbol == ":")
       result = rnFieldList
-    elif match(p, p.idx, "(e) ") or match(p, p.idx, "e. "):
+    elif match(p, p.idx, "(e) ") or match(p, p.idx, "e) ") or
+         match(p, p.idx, "e. "):
       result = rnEnumList
     elif isDefList(p):
       result = rnDefList

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -440,13 +440,18 @@ Test1
       Check that auto-numbered enumeration lists work.
 
       #. string1
+
       #. string2
+
       #. string3
+
+      #) string5
+      #) string6
       """
     let output5 = rstToHtml(input5, {roSupportMarkdown}, defaultConfig())
-    assert count(output5, "<ol ") == 1
-    assert count(output5, "</ol>") == 1
-    assert count(output5, "<li>") == 3
+    assert count(output5, "<ol ") == 2
+    assert count(output5, "</ol>") == 2
+    assert count(output5, "<li>") == 5
 
     let input6 = dedent """
       ... And for alphabetic enumerators too!

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -453,6 +453,18 @@ Test1
     assert count(output5, "</ol>") == 2
     assert count(output5, "<li>") == 5
 
+    let input5a = dedent """
+      Auto-numbered RST list can start with 1 even when Markdown support is on.
+
+      1. string1
+      #. string2
+      #. string3
+      """
+    let output5a = rstToHtml(input5a, {roSupportMarkdown}, defaultConfig())
+    assert count(output5a, "<ol ") == 1
+    assert count(output5a, "</ol>") == 1
+    assert count(output5a, "<li>") == 3
+
     let input6 = dedent """
       ... And for alphabetic enumerators too!
 
@@ -478,6 +490,25 @@ Test1
     assert count(output7, "</ol>") == 1
     assert count(output7, "<li>") == 3
     assert "start=\"3\"" in output7 and "class=\"upperalpha simple\"" in output7
+
+  test "Markdown enumerated lists":
+    let input1 = dedent """
+      Below are 2 enumerated lists: Markdown-style (5 items) and RST (1 item)
+      1. line1
+      1. line2
+      1. line3
+      1. line4
+
+      1. line5
+
+      #. lineA
+      """
+    let output1 = rstToHtml(input1, {roSupportMarkdown}, defaultConfig())
+    for i in 1..5:
+      assert ($i & ". line" & $i) notin output1
+      assert ("<li>line" & $i & "</li>") in output1
+    assert count(output1, "<ol ") == 2
+    assert count(output1, "</ol>") == 2
 
   test "RST bullet lists":
     let input1 = dedent """


### PR DESCRIPTION
This adds possibility to use `1` as auto-enumerator in enumerated lists (follow-up to #16295)

```
1. x
1. y
```
generates `1-2` list.

`#` and `1` can not be used in one list as auto-numerator simultaneously — it will split the list to two.

However the exception:
```
1. x
#. y
```
works fine as a pure RST list, 1 does not go as auto-enumerator.

Also i noticed a bug that special case of auto-enumerator in format `#)` did not work, fix's in commit 1.