### PR TITLE
fix #14340

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -8,6 +8,8 @@
 #
 
 # included from cgen.nim
+when defined(nimCompilerStackraceHints):
+  import std/stackframes
 
 proc getNullValueAuxT(p: BProc; orig, t: PType; obj, constOrNil: PNode,
                       result: var Rope; count: var int;
@@ -2643,6 +2645,8 @@ proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
       d.storage = OnStatic
 
 proc expr(p: BProc, n: PNode, d: var TLoc) =
+  when defined(nimCompilerStackraceHints):
+    setFrameMsg p.config$n.info & " " & $n.kind
   p.currLineInfo = n.info
 
   case n.kind

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3093,8 +3093,9 @@ proc genBracedInit(p: BProc, n: PNode; isConst: bool; optionalType: PType): Rope
       else:
         result = genConstSeq(p, n, typ, isConst)
     of tyProc:
-      if typ.callConv == ccClosure and n.kind == nkClosure and n.len > 1 and n[1].kind == nkNilLit:
-        # refs bug #14340
+      if typ.callConv == ccClosure and n.safeLen > 1 and n[1].kind == nkNilLit:
+        # n.kind could be: nkClosure, nkTupleConstr and maybe others; `n.safeLen`
+        # guards against the case of `nkSym`, refs bug #14340.
         # Conversion: nimcall -> closure.
         # this hack fixes issue that nkNilLit is expanded to {NIM_NIL,NIM_NIL}
         # this behaviour is needed since closure_var = nil must be

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -3089,7 +3089,8 @@ proc genBracedInit(p: BProc, n: PNode; isConst: bool; optionalType: PType): Rope
       else:
         result = genConstSeq(p, n, typ, isConst)
     of tyProc:
-      if typ.callConv == ccClosure and n.len > 1 and n[1].kind == nkNilLit:
+      if typ.callConv == ccClosure and n.kind == nkClosure and n.len > 1 and n[1].kind == nkNilLit:
+        # refs bug #14340
         # Conversion: nimcall -> closure.
         # this hack fixes issue that nkNilLit is expanded to {NIM_NIL,NIM_NIL}
         # this behaviour is needed since closure_var = nil must be

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -8,8 +8,6 @@
 #
 
 # included from cgen.nim
-when defined(nimCompilerStackraceHints):
-  import std/stackframes
 
 proc getNullValueAuxT(p: BProc; orig, t: PType; obj, constOrNil: PNode,
                       result: var Rope; count: var int;
@@ -2645,8 +2643,6 @@ proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
       d.storage = OnStatic
 
 proc expr(p: BProc, n: PNode, d: var TLoc) =
-  when defined(nimCompilerStackraceHints):
-    setFrameMsg p.config$n.info & " " & $n.kind
   p.currLineInfo = n.info
 
   case n.kind

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -306,6 +306,15 @@ block: # bug #8007
   const d = @[Cost(kind: Fixed, cost: 999), Cost(kind: Dynamic, handler: foo)]
   doAssert $d == "@[(kind: Fixed, cost: 999), (kind: Dynamic, handler: ...)]"
 
+block: # bug #14340
+  proc opl3EnvelopeCalcSin0() = discard
+  type EnvelopeSinfunc = proc()
+  # const EnvelopeCalcSin0 = opl3EnvelopeCalcSin0 # ok
+  const EnvelopeCalcSin0: EnvelopeSinfunc = opl3EnvelopeCalcSin0 # was bug
+  const envelopeSin = [EnvelopeCalcSin0]
+  var a = 0
+  envelopeSin[a]()
+
 block: # VM wrong register free causes errors in unrelated code
   block: # bug #15597
     #[

--- a/tests/vm/tvmmisc.nim
+++ b/tests/vm/tvmmisc.nim
@@ -307,13 +307,21 @@ block: # bug #8007
   doAssert $d == "@[(kind: Fixed, cost: 999), (kind: Dynamic, handler: ...)]"
 
 block: # bug #14340
-  proc opl3EnvelopeCalcSin0() = discard
-  type EnvelopeSinfunc = proc()
-  # const EnvelopeCalcSin0 = opl3EnvelopeCalcSin0 # ok
-  const EnvelopeCalcSin0: EnvelopeSinfunc = opl3EnvelopeCalcSin0 # was bug
-  const envelopeSin = [EnvelopeCalcSin0]
-  var a = 0
-  envelopeSin[a]()
+  block:
+    proc opl3EnvelopeCalcSin0() = discard
+    type EnvelopeSinfunc = proc()
+    # const EnvelopeCalcSin0 = opl3EnvelopeCalcSin0 # ok
+    const EnvelopeCalcSin0: EnvelopeSinfunc = opl3EnvelopeCalcSin0 # was bug
+    const envelopeSin = [EnvelopeCalcSin0]
+    var a = 0
+    envelopeSin[a]()
+
+  block:
+    type Mutator = proc() {.noSideEffect, gcsafe, locks: 0.}
+    proc mutator0() = discard
+    const mTable = [Mutator(mutator0)]
+    var i=0
+    mTable[i]()
 
 block: # VM wrong register free causes errors in unrelated code
   block: # bug #15597


### PR DESCRIPTION
fix #14340

note:
from https://github.com/nim-lang/Nim/pull/16168#issuecomment-735052088

> Instead check for n.kind == nkClosure or whatever it's named.

it turns out this wasn't enough, as it'd fail one of the tests I've added in this PR, so the fix is the same as the one that was done in https://github.com/nim-lang/Nim/pull/16168, but with the addition of the reduced test case https://github.com/nim-lang/Nim/issues/14340#issuecomment-747809362 and the reduced case that would fail if we had instead `n.kind == nkClosure`