### PR TITLE
fix cmpIgnoreStyle bug in typeinfo module

### DIFF
--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -372,6 +372,7 @@ proc cmpIgnoreStyle(a, b: cstring): int {.noSideEffect.} =
     else: result = c
   var i = 0
   var j = 0
+  if a[0] != b[0]: return 1
   while true:
     while a[i] == '_': inc(i)
     while b[j] == '_': inc(j) # BUGFIX: typo

--- a/tests/stdlib/ttypeinfo.nim
+++ b/tests/stdlib/ttypeinfo.nim
@@ -58,3 +58,14 @@ block:
   for i in 0 .. m.len-1:
     for j in 0 .. m[i].len-1:
       doAssert getString(m[i][j]) == myArr[i][j]
+
+block:
+  type
+    Test = enum
+      Hello, he_llo
+
+  var x = hello
+  var y = x.toAny
+
+  doAssert getEnumOrdinal(y, "Hello") == 0
+  doAssert getEnumOrdinal(y, "hello") == 1


### PR DESCRIPTION
Before this PR:
```nim
import typeinfo
  

block:
  type
    Test = enum
      Hello, he_llo

  var x = hello
  var y = x.toAny

  doAssert getEnumOrdinal(y, "Hello") == 0
  doAssert getEnumOrdinal(y, "hello") == 1
```

```
/usercode/in.nim(13)     in
/playground/nim/lib/system/assertions.nim(30) failedAssertImpl
/playground/nim/lib/system/assertions.nim(23) raiseAssert
/playground/nim/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: /usercode/in.nim(13, 12) `getEnumOrdinal(y, "hello") == 1`  [AssertionDefect]
```