### PR TITLE
refs #15667 improve invalid indentation errors, report when & where `=` could be missing

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -163,6 +163,7 @@ proc prettyTok*(tok: Token): string =
   else: $tok
 
 proc printTok*(conf: ConfigRef; tok: Token) =
+  # xxx factor with toLocation
   msgWriteln(conf, $tok.line & ":" & $tok.col & "\t" & $tok.tokType & " " & $tok)
 
 proc initToken*(L: var Token) =

--- a/tests/parser/t15667.nim
+++ b/tests/parser/t15667.nim
@@ -1,0 +1,18 @@
+discard """
+  action: "reject"
+  nimout: '''
+t15667.nim(18, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(14, 12) ?
+'''
+"""
+
+
+
+# line 10
+block:
+  proc asdfasdfsd() {. exportc, 
+      inline
+         .}     # foo
+    #[
+    bar
+    ]#
+    discard

--- a/tests/parser/t15667.nim
+++ b/tests/parser/t15667.nim
@@ -1,18 +1,58 @@
 discard """
+  cmd: "nim check $options $file"
   action: "reject"
   nimout: '''
-t15667.nim(18, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(14, 12) ?
+t15667.nim(23, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(22, 13) ?
+t15667.nim(28, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(26, 13) ?
+t15667.nim(33, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(31, 25) ?
+t15667.nim(42, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(38, 12) ?
+t15667.nim(56, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(55, 13) ?
 '''
 """
 
 
 
-# line 10
+
+
+
+
+
+# line 20
 block:
+  proc fn1()
+    discard
+
+block:
+  proc fn2()
+    #
+    discard
+
+block:
+  proc fn3() {.exportc.}
+    #
+    discard
+
+block: # complex example
   proc asdfasdfsd() {. exportc, 
       inline
          .}     # foo
     #[
     bar
     ]#
+    discard
+
+block: # xxx this doesn't work yet (only a bare `invalid indentation` error)
+  proc fn5()
+    ##
+    discard
+
+block: # ditto
+  proc fn6*()
+    ## foo bar
+    runnableExamples: discard
+
+block:
+  proc fn8()
+    runnableExamples:
+      discard
     discard


### PR DESCRIPTION
improves the most common case where `invalid indentation errors` is confusing, refs https://github.com/nim-lang/Nim/issues/15667

* report when & where `=` could be missing; the location reported points exactly to the line/col where the `=` is missing even in presence of comments/doc comments/pragmas etc
* honors --listfullpaths (as always) to help with jump-to-code editors

## example
```nim
# line 10
block:
  proc asdfasdfsd() {. exportc, 
      inline
         .}     # foo
    #[
    bar
    ]#
    discard
```

```
t15667.nim(18, 5) Error: invalid indentation, maybe you forgot a '=' at t15667.nim(14, 12) ?
```

## future work
some of the `errInvalidIndentation` errors can be improved easily by showing more context on what the expected indentation (range) be, eg:
```nim
proc optPar(p: var Parser) =
  if p.tok.indent >= 0:
    if p.tok.indent < p.currInd: parMessage(p, errInvalidIndentation)
    if p.tok.indent < p.currInd: parMessage(p, "invalid indentation: expected >= $1, got $2" % [p.currInd, p.tok.indent]))
```

handle this to also provide better errmsg here (refs: https://github.com/nim-lang/Nim/pull/16484/files#r549871983)
```nim
  proc fn*()
    ## foo bar
    runnableExamples: discard
  proc fn() = discard
```
