### PR TITLE
use -d:nimCompilerStackraceHints in more places

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -9,6 +9,9 @@
 
 # included from cgen.nim
 
+when defined(nimCompilerStackraceHints):
+  import std/stackframes
+
 proc getNullValueAuxT(p: BProc; orig, t: PType; obj, constOrNil: PNode,
                       result: var Rope; count: var int;
                       isConst: bool, info: TLineInfo)
@@ -2643,6 +2646,8 @@ proc exprComplexConst(p: BProc, n: PNode, d: var TLoc) =
       d.storage = OnStatic
 
 proc expr(p: BProc, n: PNode, d: var TLoc) =
+  when defined(nimCompilerStackraceHints):
+    setFrameMsg p.config$n.info & " " & $n.kind
   p.currLineInfo = n.info
 
   case n.kind


### PR DESCRIPTION
followup for https://github.com/nim-lang/Nim/pull/13351

this helped a lot when doing the code reduction in https://github.com/nim-lang/Nim/issues/14340#issuecomment-747809362

## before PR:
at devel 0b7847ba3cbbc2baaeeedf6bbe66823079686662:
```
git clone https://gitea.com/BarrOff/nimPoP.git
cd nimPoP
nim c src/nimPoP.nim
/Users/timothee/git_clone/nim/Nim_devel/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: 'sons' is not accessible using discriminant 'kind' of type 'TNode' [FieldDefect]
```

## before PR, with debug nim
after recompiling nim with `--stacktrace:on --stacktracemsgs -d:nimCompilerStackraceHints`

```
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(1020) genBracketExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(911) genArrayElem
/Users/timothee/git_clone/nim/Nim_prs/compiler/cgen.nim(619) initLocExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(2674) expr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(2524) genComplexConst
/Users/timothee/git_clone/nim/Nim_prs/compiler/cgen.nim(1207) requestConstImpl
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(3111) genBracedInit
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(3013) genConstSimpleList
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(3092) genBracedInit
/Users/timothee/git_clone/nim/Nim_prs/compiler/ast.nim(1115) len
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: 'sons' is not accessible using discriminant 'kind' of type 'TNode' [FieldDefect]
```

=> gives 0 indication of what part of the code being cgen'd causes the error


### after PR
after recompiling nim with `--stacktrace:on --stacktracemsgs -d:nimCompilerStackraceHints`

=> now we know its' inside this: `/Users/timothee/git_clone/nim/temp/nimPoP/src/nimPoP/opl3.nim(657, 16) nkSym`, and also mroe this is called from, etc

```
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgcalls.nim(401) genClosureCall
/Users/timothee/git_clone/nim/Nim_prs/compiler/cgen.nim(619) initLocExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(2771) expr /Users/timothee/git_clone/nim/temp/nimPoP/src/nimPoP/opl3.nim(657, 27) nkBracketExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(1023) genBracketExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(914) genArrayElem
/Users/timothee/git_clone/nim/Nim_prs/compiler/cgen.nim(619) initLocExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(2679) expr /Users/timothee/git_clone/nim/temp/nimPoP/src/nimPoP/opl3.nim(657, 16) nkSym
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(2527) genComplexConst
/Users/timothee/git_clone/nim/Nim_prs/compiler/cgen.nim(1207) requestConstImpl
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(3116) genBracedInit
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(3018) genConstSimpleList
/Users/timothee/git_clone/nim/Nim_prs/compiler/ccgexprs.nim(3097) genBracedInit
/Users/timothee/git_clone/nim/Nim_prs/compiler/ast.nim(1115) len
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: 'sons' is not accessible using discriminant 'kind' of type 'TNode' [FieldDefect]
```

## future work
* extend `-d:nimCompilerStackraceHints` to a few more key strategic places
* make compiler use `conf.isDefined` instead of `defined` so that we don't need to recompile nim just to get `nimCompilerStackraceHints` enabled (as long as nim was already compiled with `--stacktrace:on --stacktracemsgs`)
