### PR TITLE
add `toBits` and `fromBits` to math

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -66,6 +66,8 @@
 - `echo` and `debugEcho` will now raise `IOError` if writing to stdout fails.  Previous behavior
   silently ignored errors.  See #16366.  Use `-d:nimLegacyEchoNoRaise` for previous behavior.
 
+- Added `toBits` and `fromBits` to math.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -1131,3 +1131,23 @@ func lcm*[T](x: openArray[T]): T {.since: (1, 1).} =
   while i < x.len:
     result = lcm(result, x[i])
     inc(i)
+
+
+when not defined(js) and not defined(nimscript):
+  func toBits*(x: float64): uint64 {.since: (1, 5, 1).} =
+    ## Returns the IEEE 754 binary representation of float64.
+    cast[uint64](x)
+
+  func toBits*(x: float32): uint32 {.since: (1, 5, 1).} =
+    ## Returns the IEEE 754 binary representation of float32.
+    cast[uint32](x)
+
+  func fromBits*(x: uint64): float64 {.since: (1, 5, 1).} =
+    ## Returns the floating-point number corresponding
+    ## to the IEEE 754 binary representation.
+    cast[float64](x)
+
+  func fromBits*(x: uint32): float32 {.since: (1, 5, 1).} =
+    ## Returns the floating-point number corresponding
+    ## to the IEEE 754 binary representation.
+    cast[float32](x)

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -298,8 +298,6 @@ when not defined(js):
   proc testGen() =
     template impl(num) =
       doAssert fromBits(toBits(float64(num))) == float64(num)
-      echo fromBits(toBits(float32(num)))
-      echo float32(num)
       doAssert fromBits(toBits(float32(num))) == float32(num)
 
     impl(0)

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -293,3 +293,24 @@ template main =
 
 main()
 static: main()
+
+when not defined(js):
+  proc testGen() =
+    template impl(num) =
+      doAssert fromBits(toBits(float64(num))) == float64(num)
+      echo fromBits(toBits(float32(num)))
+      echo float32(num)
+      doAssert fromBits(toBits(float32(num))) == float32(num)
+
+    impl(0)
+    impl(1)
+    impl(1000)
+    impl(-100)
+    impl(0.0)
+    impl(-0.0)
+    impl(3.1415926'f32)
+    impl(-3.1415926'f32)
+    impl(Inf)
+    impl(-Inf)
+
+  testGen()


### PR DESCRIPTION
It's not easy to support JS backend.

Todo in the following PR:
- [x] signbits
- [x] copysign