### PR TITLE
remove compiler warning when calling osproc.execProcess

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -979,7 +979,7 @@ elif not defined(useNimRtl):
         when not defined(android): "/bin/sh"
         else: "/system/bin/sh"
       data.sysCommand = useShPath
-      sysArgsRaw = @[data.sysCommand, "-c", command]
+      sysArgsRaw = @[useShPath, "-c", command]
       assert args.len == 0, "`args` has to be empty when using poEvalCommand."
     else:
       data.sysCommand = command


### PR DESCRIPTION
Fixes #16421.

Compiling the file from the issue no longer produces the warning.
```console
user@user:~$ nim c --gc:arc sink.nim 
Hint: used config file '/home/user/nim/config/nim.cfg' [Conf]
Hint: used config file '/home/user/nim/config/config.nims' [Conf]
...........................
Hint:  [Link]
Hint: 47307 lines; 0.815s; 61.188MiB peakmem; Debug build; proj: /home/user/sink.nim; out: /home/user/sink [SuccessX]
```