### PR TITLE
remove compiler warning when calling os.parseCmdLine

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2585,9 +2585,8 @@ proc parseCmdLine*(c: string): seq[string] {.
 
   result = @[]
   var i = 0
-  var a = ""
   while true:
-    setLen(a, 0)
+    var a = ""
     # eat all delimiting whitespace
     while i < c.len and c[i] in {' ', '\t', '\l', '\r'}: inc(i)
     if i >= c.len: break


### PR DESCRIPTION
Fixes #16314.

The first warning seems to have already been resolved. This PR resolves the second warning from the issue.

```console
user@user:~$ nim c --gc:arc ding.nim
Hint: used config file '/home/user/nim/config/nim.cfg' [Conf]
Hint: used config file '/home/user/nim/config/config.nims' [Conf]
....................
Hint:  [Link]
Hint: 42348 lines; 0.708s; 61.184MiB peakmem; Debug build; proj: /home/user/ding.nim; out: /home/user/ding [SuccessX]
```