### PR TITLE
[backport => 1.0] fix #16428 vmops now works for generic procs

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1961,14 +1961,6 @@ proc matches(s: PSym; x: string): bool =
     s = if sfFromGeneric in s.flags: s.owner.owner else: s.owner
   result = true
 
-proc matches2(s: PSym; y: varargs[string]): bool =
-  var s = s
-  for i in 1..y.len:
-    if s == nil or (y[^i].cmpIgnoreStyle(s.name.s) != 0 and y[^i] != "*"):
-      return false
-    s = if sfFromGeneric in s.flags: s.owner.owner else: s.owner
-  result = true
-
 proc procIsCallback(c: PCtx; s: PSym): bool =
   if s.offset < -1: return true
   var i = -2
@@ -2024,11 +2016,11 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       elif s.kind == skMethod:
         localError(c.config, n.info, "cannot call method " & s.name.s &
           " at compile time")
-      elif matches2(s, "stdlib", "marshal", "to"):
+      elif matches(s, "stdlib.marshal.to"):
         # XXX marshal load&store should not be opcodes, but use the
         # general callback mechanisms.
         genMarshalLoad(c, n, dest)
-      elif matches2(s, "stdlib", "marshal", "$$"):
+      elif matches(s, "stdlib.marshal.$$"):
         genMarshalStore(c, n, dest)
       else:
         genCall(c, n, dest)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1958,10 +1958,10 @@ proc matches(s: PSym; x: string): bool =
   for i in 1..y.len:
     if s == nil or (y[^i].cmpIgnoreStyle(s.name.s) != 0 and y[^i] != "*"):
       return false
-    s = s.owner
+    s = if sfFromGeneric in s.flags: s.owner.owner else: s.owner
   result = true
 
-proc matches(s: PSym; y: varargs[string]): bool =
+proc matches2(s: PSym; y: varargs[string]): bool =
   var s = s
   for i in 1..y.len:
     if s == nil or (y[^i].cmpIgnoreStyle(s.name.s) != 0 and y[^i] != "*"):
@@ -2024,11 +2024,11 @@ proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
       elif s.kind == skMethod:
         localError(c.config, n.info, "cannot call method " & s.name.s &
           " at compile time")
-      elif matches(s, "stdlib", "marshal", "to"):
+      elif matches2(s, "stdlib", "marshal", "to"):
         # XXX marshal load&store should not be opcodes, but use the
         # general callback mechanisms.
         genMarshalLoad(c, n, dest)
-      elif matches(s, "stdlib", "marshal", "$$"):
+      elif matches2(s, "stdlib", "marshal", "$$"):
         genMarshalStore(c, n, dest)
       else:
         genCall(c, n, dest)

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -567,6 +567,8 @@ else: # JS
   func tanh*[T: float32|float64](x: T): T {.importc: "Math.tanh", nodecl.}
 
   func arcsin*[T: float32|float64](x: T): T {.importc: "Math.asin", nodecl.}
+    # keep this as generic or update test in `tvmops.nim` to make sure we
+    # keep testing that generic importc procs work
   func arccos*[T: float32|float64](x: T): T {.importc: "Math.acos", nodecl.}
   func arctan*[T: float32|float64](x: T): T {.importc: "Math.atan", nodecl.}
   func arctan2*[T: float32|float64](y, x: T): T {.importc: "Math.atan2", nodecl.}

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -1,3 +1,7 @@
+discard """
+  targets: "c cpp js"
+"""
+
 #[
 test for vmops.nim
 ]#


### PR DESCRIPTION
* fix #16428 
* remove code duplication (matches overload)

note: the fix comes from fact that `s = if sfFromGeneric in s.flags: s.owner.owner else: s.owner` is now used for vmops instead of `s = s.owner` 
