### PR TITLE
add sequtils to prelude

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,8 @@
   and `lists.toDoublyLinkedList` convert from `openArray`s; `lists.copy` implements
   shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
   its argument, `addMoved`, is also supplied.
+  
+- Added `sequtils` import to `prelude`.
 
 ## Language changes
 

--- a/lib/prelude.nim
+++ b/lib/prelude.nim
@@ -19,5 +19,5 @@
 ##   import os, strutils, times, parseutils, hashes, tables, sets
 ##   when not defined(js): import parseopt
 
-import os, strutils, times, parseutils, hashes, tables, sets
+import os, strutils, times, parseutils, hashes, tables, sets, sequtils
 when not defined(js): import parseopt

--- a/lib/prelude.nim
+++ b/lib/prelude.nim
@@ -16,7 +16,7 @@
 ## Same as:
 ##
 ## .. code-block:: nim
-##   import os, strutils, times, parseutils, hashes, tables, sets
+##   import os, strutils, times, parseutils, hashes, tables, sets, sequtils
 ##   when not defined(js): import parseopt
 
 import os, strutils, times, parseutils, hashes, tables, sets, sequtils


### PR DESCRIPTION
i would argue that sequtils is used just as often as the other imports in prelude, and it'd be nice for it to be included.