### PR TITLE
RST: implement admonitions

### DIFF
--- a/config/nimdoc.tex.cfg
+++ b/config/nimdoc.tex.cfg
@@ -52,6 +52,15 @@ doc.file = """
 \usepackage{hyperref}
 \usepackage{enumitem}
 
+\usepackage{xcolor}
+\usepackage[tikz]{mdframed}
+\usetikzlibrary{shadows}
+\mdfsetup{%
+linewidth=3,
+topline=false,
+rightline=false,
+bottomline=false}
+
 \begin{document}
 \title{$title $version}
 \author{$author}

--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -14,9 +14,9 @@ Modified by Boyd Greenfield and narimiran
   --primary-background: #fff;
   --secondary-background: ghostwhite;
   --third-background: #e8e8e8;
-  --info-background: #88ff88;
-  --warning-background: #eeee00;
-  --error-background: #ffbbaa;
+  --info-background: #50c050;
+  --warning-background: #c0a000;
+  --error-background: #e04040;
   --border: #dde;
   --text: #222;
   --anchor: #07b;
@@ -42,9 +42,9 @@ Modified by Boyd Greenfield and narimiran
   --primary-background: #171921;
   --secondary-background: #1e202a;
   --third-background: #2b2e3b;
-  --info-background: #006000;
-  --warning-background: #606000;
-  --error-background: #702000;
+  --info-background: #008000;
+  --warning-background: #807000;
+  --error-background: #c03000;
   --border: #0e1014;
   --text: #fff;
   --anchor: #8be9fd;
@@ -615,38 +615,32 @@ table.borderless td, table.borderless th {
      The right padding separates the table cells. */
   padding: 0 0.5em 0 0 !important; }
 
-.admonition_info {
-  border: 0.15em solid var(--info-background);
+.admonition {
+    padding: 0.3em;
+    background-color: var(--secondary-background);
+    border-left: 0.4em solid #7f7f84;
+    margin-bottom: 0.5em;
+    -webkit-box-shadow: 0 5px 8px -6px rgba(0,0,0,.2);
+       -moz-box-shadow: 0 5px 8px -6px rgba(0,0,0,.2);
+            box-shadow: 0 5px 8px -6px rgba(0,0,0,.2);
 }
-.admonition_info th {
-  background-color: var(--info-background);
-  text-align: left;
+.admonition-info {
+    border-color: var(--info-background);
 }
-.admonition_info td {
-  padding: 0.3em;
-  padding-left: 2em;
+.admonition-info-text {
+    color: var(--info-background);
 }
-.admonition_warning {
-  border: 0.15em solid var(--warning-background);
+.admonition-warning {
+    border-color: var(--warning-background);
 }
-.admonition_warning th {
-  background-color: var(--warning-background);
-  text-align: left;
+.admonition-warning-text {
+    color: var(--warning-background);
 }
-.admonition_warning td {
-  padding: 0.3em;
-  padding-left: 2em;
+.admonition-error {
+    border-color: var(--error-background);
 }
-.admonition_error {
-  border: 0.15em solid var(--error-background);
-}
-.admonition_error th {
-  background-color: var(--error-background);
-  text-align: left;
-}
-.admonition_error td {
-  padding: 0.3em;
-  padding-left: 2em;
+.admonition-error-text {
+    color: var(--error-background);
 }
 
 .first {

--- a/doc/nimdoc.css
+++ b/doc/nimdoc.css
@@ -14,6 +14,9 @@ Modified by Boyd Greenfield and narimiran
   --primary-background: #fff;
   --secondary-background: ghostwhite;
   --third-background: #e8e8e8;
+  --info-background: #88ff88;
+  --warning-background: #eeee00;
+  --error-background: #ffbbaa;
   --border: #dde;
   --text: #222;
   --anchor: #07b;
@@ -39,6 +42,9 @@ Modified by Boyd Greenfield and narimiran
   --primary-background: #171921;
   --secondary-background: #1e202a;
   --third-background: #2b2e3b;
+  --info-background: #006000;
+  --warning-background: #606000;
+  --error-background: #702000;
   --border: #0e1014;
   --text: #fff;
   --anchor: #8be9fd;
@@ -608,6 +614,40 @@ table.borderless td, table.borderless th {
   /* Override padding for "table.docutils td" with "! important".
      The right padding separates the table cells. */
   padding: 0 0.5em 0 0 !important; }
+
+.admonition_info {
+  border: 0.15em solid var(--info-background);
+}
+.admonition_info th {
+  background-color: var(--info-background);
+  text-align: left;
+}
+.admonition_info td {
+  padding: 0.3em;
+  padding-left: 2em;
+}
+.admonition_warning {
+  border: 0.15em solid var(--warning-background);
+}
+.admonition_warning th {
+  background-color: var(--warning-background);
+  text-align: left;
+}
+.admonition_warning td {
+  padding: 0.3em;
+  padding-left: 2em;
+}
+.admonition_error {
+  border: 0.15em solid var(--error-background);
+}
+.admonition_error th {
+  background-color: var(--error-background);
+  text-align: left;
+}
+.admonition_error td {
+  padding: 0.3em;
+  padding-left: 2em;
+}
 
 .first {
   /* Override more specific margin styles with "! important". */

--- a/lib/packages/docutils/rstast.nim
+++ b/lib/packages/docutils/rstast.nim
@@ -41,8 +41,11 @@ type
     rnLabel,                  # used for footnotes and other things
     rnFootnote,               # a footnote
     rnCitation,               # similar to footnote
-    rnStandaloneHyperlink, rnHyperlink, rnRef, rnDirective, # a directive
-    rnDirArg, rnRaw, rnTitle, rnContents, rnImage, rnFigure, rnCodeBlock,
+    rnStandaloneHyperlink, rnHyperlink, rnRef,
+    rnDirective,              # a general directive
+    rnDirArg,                 # a directive argument (for some directives).
+                              # here are directives that are not rnDirective:
+    rnRaw, rnTitle, rnContents, rnImage, rnFigure, rnCodeBlock, rnAdmonition,
     rnRawHtml, rnRawLatex,
     rnContainer,              # ``container`` directive
     rnIndex,                  # index directve:
@@ -70,6 +73,7 @@ type
     kind*: RstNodeKind       ## the node's kind
     text*: string             ## valid for leafs in the AST; and the title of
                               ## the document or the section; and rnEnumList
+                              ## and rnAdmonition
     level*: int               ## valid for some node kinds
     sons*: RstNodeSeq        ## the node's sons
 
@@ -316,3 +320,13 @@ proc renderRstToJson*(node: PRstNode): string =
   ##     "sons":optional node array
   ##   }
   renderRstToJsonNode(node).pretty
+
+proc dumpRstTree*(node: PRstNode, indent=0) =
+  ## print parsed RST tree (for debugging)
+  if node == nil:
+    echo " ".repeat(indent), "[nil]"
+    return
+  echo " ".repeat(indent), node.kind, "\t", (
+      if node.text=="": "" else: "'" & node.text & "'")
+  for son in node.sons:
+    dumpRstTree(son, indent=indent+2)

--- a/lib/packages/docutils/rstast.nim
+++ b/lib/packages/docutils/rstast.nim
@@ -321,12 +321,16 @@ proc renderRstToJson*(node: PRstNode): string =
   ##   }
   renderRstToJsonNode(node).pretty
 
-proc dumpRstTree*(node: PRstNode, indent=0) =
-  ## print parsed RST tree (for debugging)
+proc renderRstToStr*(node: PRstNode, indent=0): string =
+  ## Writes the parsed RST `node` into a compact string
+  ## representation in the format (one line per every sub-node):
+  ## ``indent - kind - text - level (if non-zero)``
+  ## (suitable for debugging of RST parsing).
   if node == nil:
-    echo " ".repeat(indent), "[nil]"
+    result.add " ".repeat(indent) & "[nil]\n"
     return
-  echo " ".repeat(indent), node.kind, "\t", (
-      if node.text=="": "" else: "'" & node.text & "'")
+  result.add " ".repeat(indent) & $node.kind & "\t" &
+      (if node.text == "": "" else: "'" & node.text & "'") &
+      (if node.level == 0: "" else: "\tlevel=" & $node.level) & "\n"
   for son in node.sons:
-    dumpRstTree(son, indent=indent+2)
+    result.add renderRstToStr(son, indent=indent+2)

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1080,24 +1080,26 @@ proc renderEnumList(d: PDoc, n: PRstNode, result: var string) =
             result)
 
 proc renderAdmonition(d: PDoc, n: PRstNode, result: var string) =
-  var htmlCls = "admonition_warning"
-  var texSz = "\\large"
+  var
+    htmlCls = "admonition_warning"
+    texSz = "\\large"
+    texColor = "orange"
   case n.text
   of "hint", "note", "tip":
-    htmlCls = "admonition-info"; texSz = "\\normalsize"
+    htmlCls = "admonition-info"; texSz = "\\normalsize"; texColor = "green"
   of "attention", "admonition", "important", "warning":
-    htmlCls = "admonition-warning"; texSz = "\\large"
+    htmlCls = "admonition-warning"; texSz = "\\large"; texColor = "orange"
   of "danger", "error":
-    htmlCls = "admonition-error"; texSz = "\\Large"
+    htmlCls = "admonition-error"; texSz = "\\Large"; texColor = "red"
   else: discard
   let txt = n.text.capitalizeAscii()
   let htmlHead = "<div class=\"admonition " & htmlCls & "\">"
   renderAux(d, n,
       htmlHead & "<span class=\"" & htmlCls & "-text\"><b>" & txt &
         ":</b></span>\n" & "$1</div>\n",
-      "\n\n\\vspace{0.4em}\\fbox{\\parbox{0.95\\linewidth}{" &
-        "\\vspace{0.3em}{" & texSz & "\\textbf{" & txt & ":}} " &
-        "$1\\vspace{0.3em}}}\n\n\\vspace{0.4em}\n",
+      "\n\n\\begin{mdframed}[linecolor=" & texColor & "]\n" &
+        "{" & texSz & "\\color{" & texColor & "}{\\textbf{" & txt & ":}}} " &
+        "$1\n\\end{mdframed}\n",
       result)
 
 proc renderRstToOut(d: PDoc, n: PRstNode, result: var string) =

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1084,19 +1084,20 @@ proc renderAdmonition(d: PDoc, n: PRstNode, result: var string) =
   var texSz = "\\large"
   case n.text
   of "hint", "note", "tip":
-    htmlCls = "admonition_info"; texSz = "\\normalsize"
+    htmlCls = "admonition-info"; texSz = "\\normalsize"
   of "attention", "admonition", "important", "warning":
-    htmlCls = "admonition_warning"; texSz = "\\large"
+    htmlCls = "admonition-warning"; texSz = "\\large"
   of "danger", "error":
-    htmlCls = "admonition_error"; texSz = "\\Large"
+    htmlCls = "admonition-error"; texSz = "\\Large"
   else: discard
   let txt = n.text.capitalizeAscii()
-  let htmlTab = "<table width=\"95%\" class=\"" & htmlCls & "\">\n"
+  let htmlHead = "<div class=\"admonition " & htmlCls & "\">"
   renderAux(d, n,
-      htmlTab & "<tr><th>" & txt & ":</th></tr>\n" &
-        "<tr><td>$1</td></tr></table>\n",
-      "\\\\\\fbox{\\parbox{0.9\\linewidth}{" & texSz & "\\textbf{" &
-        txt & ":}\\\\$1}}\n\n",
+      htmlHead & "<span class=\"" & htmlCls & "-text\"><b>" & txt &
+        ":</b></span>\n" & "$1</div>\n",
+      "\n\n\\vspace{0.4em}\\fbox{\\parbox{0.95\\linewidth}{" &
+        "\\vspace{0.3em}{" & texSz & "\\textbf{" & txt & ":}} " &
+        "$1\\vspace{0.3em}}}\n\n\\vspace{0.4em}\n",
       result)
 
 proc renderRstToOut(d: PDoc, n: PRstNode, result: var string) =

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1079,6 +1079,26 @@ proc renderEnumList(d: PDoc, n: PRstNode, result: var string) =
             "\\begin{enumerate}" & specifier & "$1\\end{enumerate}\n",
             result)
 
+proc renderAdmonition(d: PDoc, n: PRstNode, result: var string) =
+  var htmlCls = "admonition_warning"
+  var texSz = "\\large"
+  case n.text
+  of "hint", "note", "tip":
+    htmlCls = "admonition_info"; texSz = "\\normalsize"
+  of "attention", "admonition", "important", "warning":
+    htmlCls = "admonition_warning"; texSz = "\\large"
+  of "danger", "error":
+    htmlCls = "admonition_error"; texSz = "\\Large"
+  else: discard
+  let txt = n.text.capitalizeAscii()
+  let htmlTab = "<table width=\"95%\" class=\"" & htmlCls & "\">\n"
+  renderAux(d, n,
+      htmlTab & "<tr><th>" & txt & ":</th></tr>\n" &
+        "<tr><td>$1</td></tr></table>\n",
+      "\\\\\\fbox{\\parbox{0.9\\linewidth}{" & texSz & "\\textbf{" &
+        txt & ":}\\\\$1}}\n\n",
+      result)
+
 proc renderRstToOut(d: PDoc, n: PRstNode, result: var string) =
   if n == nil: return
   case n.kind
@@ -1143,6 +1163,7 @@ proc renderRstToOut(d: PDoc, n: PRstNode, result: var string) =
   of rnBlockQuote:
     renderAux(d, n, "<blockquote><p>$1</p></blockquote>\n",
                     "\\begin{quote}$1\\end{quote}\n", result)
+  of rnAdmonition: renderAdmonition(d, n, result)
   of rnTable, rnGridTable, rnMarkdownTable:
     renderAux(d, n,
       "<table border=\"1\" class=\"docutils\">$1</table>",

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -552,7 +552,7 @@ Test1
     let output0 = rstToHtml(input0, {roSupportMarkdown}, defaultConfig())
     for a in ["admonition", "attention", "caution", "danger", "error", "hint",
         "important", "note", "tip", "warning" ]:
-      assert "endOf " & a & "</td></tr></table>" in output0
+      assert "endOf " & a & "</div>" in output0
 
     # Test that admonition does not swallow up the next paragraph.
     let input1 = dedent """
@@ -561,9 +561,9 @@ Test1
       Test paragraph.
     """
     let output1 = rstToHtml(input1, {roSupportMarkdown}, defaultConfig())
-    assert "endOfError</td></tr></table>" in output1
+    assert "endOfError</div>" in output1
     assert "<p>Test paragraph. </p>" in output1
-    assert "class=\"admonition_error\"" in output1
+    assert "class=\"admonition admonition-error\"" in output1
 
     # Test that second line is parsed as continuation of the first line.
     let input2 = dedent """
@@ -573,16 +573,16 @@ Test1
       Test paragraph.
     """
     let output2 = rstToHtml(input2, {roSupportMarkdown}, defaultConfig())
-    assert "endOfError Test2p.</td></tr></table>" in output2
+    assert "endOfError Test2p.</div>" in output2
     assert "<p>Test paragraph. </p>" in output2
-    assert "class=\"admonition_error\"" in output2
+    assert "class=\"admonition admonition-error\"" in output2
 
     let input3 = dedent """
       .. note:: endOfNote
     """
     let output3 = rstToHtml(input3, {roSupportMarkdown}, defaultConfig())
-    assert "endOfNote</td></tr></table>" in output3
-    assert "class=\"admonition_info\"" in output3
+    assert "endOfNote</div>" in output3
+    assert "class=\"admonition admonition-info\"" in output3
 
 suite "RST/Code highlight":
   test "Basic Python code highlight":

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -535,6 +535,55 @@ Test1
     assert count(output1, "<ul ") == 1
     assert count(output1, "</ul>") == 1
 
+  test "RST admonitions":
+    # check that all admonitions are implemented
+    let input0 = dedent """
+      .. admonition:: endOf admonition
+      .. attention:: endOf attention
+      .. caution:: endOf caution
+      .. danger:: endOf danger
+      .. error:: endOf error
+      .. hint:: endOf hint
+      .. important:: endOf important
+      .. note:: endOf note
+      .. tip:: endOf tip
+      .. warning:: endOf warning
+    """
+    let output0 = rstToHtml(input0, {roSupportMarkdown}, defaultConfig())
+    for a in ["admonition", "attention", "caution", "danger", "error", "hint",
+        "important", "note", "tip", "warning" ]:
+      assert "endOf " & a & "</td></tr></table>" in output0
+
+    # Test that admonition does not swallow up the next paragraph.
+    let input1 = dedent """
+      .. error:: endOfError
+
+      Test paragraph.
+    """
+    let output1 = rstToHtml(input1, {roSupportMarkdown}, defaultConfig())
+    assert "endOfError</td></tr></table>" in output1
+    assert "<p>Test paragraph. </p>" in output1
+    assert "class=\"admonition_error\"" in output1
+
+    # Test that second line is parsed as continuation of the first line.
+    let input2 = dedent """
+      .. error:: endOfError
+        Test2p.
+
+      Test paragraph.
+    """
+    let output2 = rstToHtml(input2, {roSupportMarkdown}, defaultConfig())
+    assert "endOfError Test2p.</td></tr></table>" in output2
+    assert "<p>Test paragraph. </p>" in output2
+    assert "class=\"admonition_error\"" in output2
+
+    let input3 = dedent """
+      .. note:: endOfNote
+    """
+    let output3 = rstToHtml(input3, {roSupportMarkdown}, defaultConfig())
+    assert "endOfNote</td></tr></table>" in output3
+    assert "class=\"admonition_info\"" in output3
+
 suite "RST/Code highlight":
   test "Basic Python code highlight":
     let pythonCode = """


### PR DESCRIPTION
Here is how they look (in dark theme): 
![admonitions](https://user-images.githubusercontent.com/1299583/102928543-ebbb1400-44a9-11eb-9177-588f783605ff.png)

Latex rendering is more simplistic:
![image](https://user-images.githubusercontent.com/1299583/102929507-cb8c5480-44ab-11eb-9382-dc5fbdd90542.png)

Admonitions are grouped to 3 different types: info (note in the picture), warnings, errors.

Also documentation in rst.nim is expanded.

CC @narimiran 