### PR TITLE
disable pkg/criterion refs https://github.com/disruptek/criterion/issues/3

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -31,7 +31,7 @@ pkg1 "cligen", "nim c --path:. -r cligen.nim"
 pkg1 "combparser", "nimble test --gc:orc"
 pkg1 "compactdict"
 pkg1 "comprehension", "nimble test", "https://github.com/alehander42/comprehension"
-pkg1 "criterion"
+# pkg1 "criterion" # pending https://github.com/disruptek/criterion/issues/3 (wrongly closed)
 pkg1 "dashing", "nim c tests/functional.nim"
 pkg1 "delaunay"
 pkg1 "docopt"


### PR DESCRIPTION
https://github.com/disruptek/criterion/issues/3 was closed but this issue affects all recently rebased PR's, so this PR disables criterion (/cc @disruptek) until we fix the underlying cause.

## future work
check whether https://github.com/disruptek/criterion/blob/0170d38964eb19d3276acafe516c70ce1f26afd7/criterion.nimble#L12 is valid (it very well might be):
```nim
task test, "run unit tests":
  when defined(windows):
    exec "testes.cmd"
  else:
    exec "testes"
```
and then, if indeed valid, fix testament so that `nimble build` runs before `nimble test` so that `$HOME/.nimble//bin/testes` is in $PATH before `testes` can be called (/cc @Clyybber) then re-enable criterion

