### PR TITLE
Colorful output Hotshot part deux(Different method of #16356)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -84,7 +84,7 @@
 - VM now supports `addr(mystring[ind])` (index + index assignment)
 - Type mismatch errors now show more context, use `-d:nimLegacyTypeMismatch` for previous
   behavior.
-
+- Added colored compiler output. Errors, hints, and warnings have highlighted messages.
 
 ## Tool changes
 

--- a/compiler/colormsg.nim
+++ b/compiler/colormsg.nim
@@ -1,0 +1,12 @@
+import terminal, strutils, strformat, options
+type MsgColor* = enum
+  mcError, mcWarn, mcHint, mcExpected, mcDefault, mcHighlight
+
+# May want to also add styling for each of these
+const defaultColors: array[MsgColor, ForegroundColor] = [fgRed, fgYellow, fgGreen, fgBlue, fgDefault, fgMagenta] 
+
+proc colorError*(msg: string, col: MsgColor, c: ConfigRef): string =
+  if optUseColors in c.globalOptions:
+    fmt"{defaultColors[col].ansiForegroundColorCode}{msg}{ansiResetCode}"
+  else:
+    msg

--- a/compiler/colormsg.nim
+++ b/compiler/colormsg.nim
@@ -6,8 +6,8 @@
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
 #
-# This module is for adding colour to error messages from the compiler,
-# using strformat and terminal.
+## This module is for adding colour to error messages from the compiler,
+## using strformat and terminal.
 
 import terminal, strutils, strformat, options
 type MsgColor* = enum

--- a/compiler/colormsg.nim
+++ b/compiler/colormsg.nim
@@ -1,3 +1,14 @@
+#
+#
+#           The Nim Compiler
+#        (c) Copyright 2020 Nim Contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+# This module is for adding colour to error messages from the compiler,
+# using strformat and terminal.
+
 import terminal, strutils, strformat, options
 type MsgColor* = enum
   mcError, mcWarn, mcHint, mcExpected, mcDefault, mcHighlight

--- a/compiler/colormsg.nim
+++ b/compiler/colormsg.nim
@@ -6,7 +6,7 @@
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
 #
-## This module is for adding colour to error messages from the compiler,
+## This module is for adding color to error messages from the compiler,
 ## using strformat and terminal.
 
 import terminal, strutils, strformat, options
@@ -14,7 +14,14 @@ type MsgColor* = enum
   mcError, mcWarn, mcHint, mcExpected, mcDefault, mcHighlight
 
 # May want to also add styling for each of these
-const defaultColors: array[MsgColor, ForegroundColor] = [fgRed, fgYellow, fgGreen, fgBlue, fgDefault, fgMagenta] 
+const defaultColors: array[MsgColor, ForegroundColor] = [
+  mcError: fgRed,
+  mcWarn: fgYellow,
+  mcHint: fgGreen,
+  mcExpected: fgBlue,
+  mcDefault: fgDefault,
+  mcHighlight: fgMagenta
+  ]
 
 proc colorMsg*(msg: string, col: MsgColor, c: ConfigRef): string =
   if optUseColors in c.globalOptions:

--- a/compiler/colormsg.nim
+++ b/compiler/colormsg.nim
@@ -5,8 +5,23 @@ type MsgColor* = enum
 # May want to also add styling for each of these
 const defaultColors: array[MsgColor, ForegroundColor] = [fgRed, fgYellow, fgGreen, fgBlue, fgDefault, fgMagenta] 
 
-proc colorError*(msg: string, col: MsgColor, c: ConfigRef): string =
+proc colorMsg*(msg: string, col: MsgColor, c: ConfigRef): string =
   if optUseColors in c.globalOptions:
     fmt"{defaultColors[col].ansiForegroundColorCode}{msg}{ansiResetCode}"
   else:
     msg
+
+template colorError*(msg: string, c: ConfigRef): string =
+  msg.colorMsg(mcError, c)
+
+template colorWarn*(msg: string, c: ConfigRef): string =
+  msg.colorMsg(mcWarn, c)
+
+template colorHint*(msg: string, c: ConfigRef): string =
+  msg.colorMsg(mcHint, c)
+
+template colorExpect*(msg: string, c: ConfigRef): string =
+  msg.colorMsg(mcExpected, c)
+
+template colorHighlight*(msg: string, c: ConfigRef): string =
+  msg.colorMsg(mcHighlight, c)

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -182,7 +182,7 @@ proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope) =
         # maybe they can be made skGenericParam as well.
         if s.typ != nil and tfImplicitTypeParam notin s.typ.flags and
            s.typ.kind != tyGenericParam:
-          message(c.config, s.info, hintXDeclaredButNotUsed, s.name.s)
+          message(c.config, s.info, hintXDeclaredButNotUsed, s.name.s.colorHint(c.config))
     s = nextIter(it, scope.symbols)
 
 proc wrongRedefinition*(c: PContext; info: TLineInfo, s: string;

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -11,7 +11,7 @@
 
 import
   intsets, ast, astalgo, idents, semdata, types, msgs, options,
-  renderer, nimfix/prettybase, lineinfos, strutils
+  renderer, nimfix/prettybase, lineinfos, strutils, colormsg
 
 proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope)
 
@@ -189,8 +189,8 @@ proc wrongRedefinition*(c: PContext; info: TLineInfo, s: string;
                         conflictsWith: TLineInfo) =
   if c.config.cmd != cmdInteractive:
     localError(c.config, info,
-      "redefinition of '$1'; previous declaration here: $2" %
-      [s, c.config $ conflictsWith])
+      ("redefinition of '$1'; previous declaration here: $2" %
+      [s, c.config $ conflictsWith]).colorError(mcError, c.config))
 
 proc addDecl*(c: PContext, sym: PSym, info: TLineInfo) =
   let conflict = c.currentScope.addUniqueSym(sym)

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -190,7 +190,7 @@ proc wrongRedefinition*(c: PContext; info: TLineInfo, s: string;
   if c.config.cmd != cmdInteractive:
     localError(c.config, info,
       ("redefinition of '$1'; previous declaration here: $2" %
-      [s, c.config $ conflictsWith]).colorError(mcError, c.config))
+      [s, c.config $ conflictsWith]).colorError(c.config))
 
 proc addDecl*(c: PContext, sym: PSym, info: TLineInfo) =
   let conflict = c.currentScope.addUniqueSym(sym)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -487,26 +487,29 @@ proc formatMsg*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string): s
   conf.toFileLineCol(info) & " " & title & getMessageStr(msg, arg)
 
 proc colorError(s: string, color: ForegroundColor): string =
-  when not defined(colorfulError):
-    template isQuote(val: untyped): untyped = val == '\''
-    template isNotQuote(val: untyped): untyped = val != '\''
-    var pos = 0
-    while pos < s.len:
-      if s[pos].isQuote:
-        inc pos
-        let start = pos
-        let nested = pos < s.high and s[pos].isQuote
-        inc pos
-        while (pos < s.len and s[pos].isNotQuote and not nested) or (nested and pos < s.high and (s[pos].isNotQuote or s[pos + 1].isNotQuote)):
-          inc pos
-        if nested:
-          inc pos
-        #Highlight error
-        result.add fmt"""{color.ansiForegroundColorCode}{s[start..(pos - 1)]}{ansiResetCode}"""
-      else:
-        result.add s[pos]
+  template isQuote(val: untyped): untyped = val == '\''
+  template isNotQuote(val: untyped): untyped = val != '\''
+  var pos = 0
+  while pos < s.len:
+    if s[pos].isQuote:
       inc pos
-  else: a
+      let start = pos
+      let nested = pos < s.high and s[pos].isQuote
+      inc pos
+      while (pos < s.len and s[pos].isNotQuote and not nested) or (nested and pos < s.high and (s[pos].isNotQuote or s[pos + 1].isNotQuote)):
+        inc pos
+      if nested:
+        inc pos
+
+      #Highlight error
+      when not defined(colorfulError):
+        if s[pos].isQuote or s[pos + 1].isQuote:
+          result.add fmt"""{color.ansiForegroundColorCode}{s[start..(pos - 1)]}{ansiResetCode}"""
+      else:
+        result.add s[start..(pos - 1)]
+    else:
+      result.add s[pos]
+    inc pos
 
 proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
                eh: TErrorHandling, info2: InstantiationInfo, isRaw = false) {.noinline.} =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -564,7 +564,7 @@ template fatal*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg = "") =
 template globalAssert*(conf: ConfigRef; cond: untyped, info: TLineInfo = unknownLineInfo, arg = "") =
   ## avoids boilerplate
   if not cond:
-    var arg2 = "'$1' failed" % [astToStr(cond)]
+    var arg2 = "'$1' failed" % [astToStr(cond).colorError(mcError, conf)]
     if arg.len > 0: arg2.add "; " & astToStr(arg) & ": " & arg
     liMessage(conf, info, errGenerated, arg2, doRaise, instLoc())
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -441,7 +441,7 @@ proc writeContext(conf: ConfigRef; lastinfo: TLineInfo) =
         let message = if context.detail == "":
           instantiationFrom
         else:
-          instantiationOfFrom.format(context.detail.colorError(mcError, conf))
+          instantiationOfFrom.format(context.detail.colorError(conf))
         styledMsgWriteln(styleBright, conf.toFileLineCol(context.info), " ", resetStyle, message)
     info = context.info
 
@@ -478,10 +478,10 @@ proc writeSurroundingSrc(conf: ConfigRef; info: TLineInfo) =
   let
     msg = $sourceLine(conf, info)
     uncolored = msg[0..<info.col]
-    colored = msg[info.col..^1].colorError(mcError, conf)
+    colored = msg[info.col..^1].colorError(conf)
   msgWriteln(conf, indent & uncolored & colored)
   if info.col >= 0:
-    msgWriteln(conf, (indent & spaces(info.col) & '^').colorError(mcError, conf))
+    msgWriteln(conf, (indent & spaces(info.col) & '^').colorError(conf))
 
 proc formatMsg*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string): string =
   let title = case msg
@@ -564,7 +564,7 @@ template fatal*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg = "") =
 template globalAssert*(conf: ConfigRef; cond: untyped, info: TLineInfo = unknownLineInfo, arg = "") =
   ## avoids boilerplate
   if not cond:
-    var arg2 = "'$1' failed" % [astToStr(cond).colorError(mcError, conf)]
+    var arg2 = "'$1' failed" % [astToStr(cond).colorError(conf)]
     if arg.len > 0: arg2.add "; " & astToStr(arg) & ": " & arg
     liMessage(conf, info, errGenerated, arg2, doRaise, instLoc())
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -568,7 +568,7 @@ template fatal*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg = "") =
 template globalAssert*(conf: ConfigRef; cond: untyped, info: TLineInfo = unknownLineInfo, arg = "") =
   ## avoids boilerplate
   if not cond:
-    var arg2 = "'$1' failed" % [astToStr(cond).colorError(conf)]
+    var arg2 = "'$1' failed" % [astToStr(cond)]
     if arg.len > 0: arg2.add "; " & astToStr(arg) & ": " & arg
     liMessage(conf, info, errGenerated, arg2, doRaise, instLoc())
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -9,7 +9,7 @@
 
 import
   options, strutils, os, tables, ropes, terminal, macros,
-  lineinfos, pathutils
+  lineinfos, pathutils, strformat
 import std/private/miscdollars
 import strutils2
 
@@ -486,6 +486,28 @@ proc formatMsg*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string): s
               else: ErrorTitle
   conf.toFileLineCol(info) & " " & title & getMessageStr(msg, arg)
 
+proc colorError(s: string, color: ForegroundColor): string =
+  when not defined(colorfulError):
+    template isQuote(val: untyped): untyped = val == '\''
+    template isNotQuote(val: untyped): untyped = val != '\''
+    var pos = 0
+    while pos < s.len:
+      if s[pos].isQuote:
+        inc pos
+        let start = pos
+        let nested = pos < s.high and s[pos].isQuote
+        inc pos
+        while (pos < s.len and s[pos].isNotQuote and not nested) or (nested and pos < s.high and (s[pos].isNotQuote or s[pos + 1].isNotQuote)):
+          inc pos
+        if nested:
+          inc pos
+        #Highlight error
+        result.add fmt"""{color.ansiForegroundColorCode}{s[start..(pos - 1)]}{ansiResetCode}"""
+      else:
+        result.add s[pos]
+      inc pos
+  else: a
+
 proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
                eh: TErrorHandling, info2: InstantiationInfo, isRaw = false) {.noinline.} =
   var
@@ -524,7 +546,7 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
     color = HintColor
     inc(conf.hintCounter)
 
-  let s = if isRaw: arg else: getMessageStr(msg, arg)
+  let s = if isRaw: arg.colorError(color) else: getMessageStr(msg, arg).colorError(color)
   if not ignoreMsg:
     let loc = if info != unknownLineInfo: conf.toFileLineCol(info) & " " else: ""
     # we could also show `conf.cmdInput` here for `projectIsCmd`

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -11,7 +11,8 @@
 
 import
   llstream, commands, os, strutils, msgs, lexer, ast,
-  options, idents, wordrecg, strtabs, lineinfos, pathutils, scriptconfig
+  options, idents, wordrecg, strtabs, lineinfos, pathutils, scriptconfig,
+  colormsg
 
 # ---------------- configuration file parser -----------------------------
 # we use Nim's scanner here to save space and work
@@ -297,7 +298,7 @@ proc loadConfigs*(cfg: RelativeFile; cache: IdentCache; conf: ConfigRef; idgen: 
   template showHintConf =
     for filename in configFiles:
       # delayed to here so that `hintConf` is honored
-      rawMessage(conf, hintConf, filename.string)
+      rawMessage(conf, hintConf, filename.string.colorHint(conf))
   if scriptIsProj:
     showHintConf()
     configFiles.setLen 0

--- a/compiler/procfind.nim
+++ b/compiler/procfind.nim
@@ -11,7 +11,7 @@
 # This is needed for proper handling of forward declarations.
 
 import
-  ast, astalgo, msgs, semdata, types, trees, strutils, lookups
+  ast, astalgo, msgs, semdata, types, trees, strutils, lookups, colormsg
 
 proc equalGenericParams(procA, procB: PNode): bool =
   if procA.len != procB.len: return false
@@ -44,7 +44,7 @@ proc searchForProcAux(c: PContext, scope: PScope, fn: PSym): PSym =
           localError(c.config, fn.info, message)
         return
       of paramsIncompatible:
-        localError(c.config, fn.info, "overloaded '$1' leads to ambiguous calls" % fn.name.s)
+        localError(c.config, fn.info, colorError("overloaded '$1' leads to ambiguous calls" % fn.name.s, c.config))
         return
       of paramsNotEqual:
         discard

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1680,6 +1680,10 @@ proc quoteExpr*(a: string): string {.inline.} =
   ## can be used for quoting expressions in error msgs.
   "'" & a & "'"
 
+proc doubleQuoteExpr*(a: string): string {.inline.} =
+  ## can be used for double quotes in error msgs.
+  "''" & a & "''"
+
 proc genFieldDefect*(field: PSym, disc: PSym): string =
   ## this needs to be in a module accessible by jsgen, ccgexprs, and vm to
   ## provide this error msg FieldDefect; msgs would be better but it does not

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1680,10 +1680,6 @@ proc quoteExpr*(a: string): string {.inline.} =
   ## can be used for quoting expressions in error msgs.
   "'" & a & "'"
 
-proc doubleQuoteExpr*(a: string): string {.inline.} =
-  ## can be used for double quotes in error msgs.
-  "''" & a & "''"
-
 proc genFieldDefect*(field: PSym, disc: PSym): string =
   ## this needs to be in a module accessible by jsgen, ccgexprs, and vm to
   ## provide this error msg FieldDefect; msgs would be better but it does not

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -240,7 +240,7 @@ proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
     else:
       err = "invalid type: '$1' in this context: '$2' for $3" % [typeToString(t),
               typeToString(typ), toHumanStr(kind)]
-    localError(c.config, info, err.colorError(mcError, c.config))
+    localError(c.config, info, err.colorError(c.config))
 
 proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
   typeAllowedCheck(c, typ.n.info, typ, skProc)
@@ -458,7 +458,7 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
   markUsed(c, info, sym)
   onUse(info, sym)
   if sym == c.p.owner:
-    globalError(c.config, info, ("recursive dependency: '$1'" % sym.name.s).colorError(mcError, c.config))
+    globalError(c.config, info, ("recursive dependency: '$1'" % sym.name.s).colorError(c.config))
 
   let genericParams = sym.ast[genericParamsPos].len
   let suppliedParams = max(n.safeLen - 1, 0)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -619,7 +619,7 @@ proc myProcess(context: PPassContext, n: PNode): PNode {.nosinks.} =
 proc reportUnusedModules(c: PContext) =
   for i in 0..high(c.unusedImports):
     if sfUsed notin c.unusedImports[i][0].flags:
-      message(c.config, c.unusedImports[i][1], warnUnusedImportX, c.unusedImports[i][0].name.s)
+      message(c.config, c.unusedImports[i][1], warnUnusedImportX, c.unusedImports[i][0].name.s.colorWarn(c.config))
 
 proc myClose(graph: ModuleGraph; context: PPassContext, n: PNode): PNode =
   var c = PContext(context)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -17,7 +17,7 @@ import
   intsets, transf, vmdef, vm, aliases, cgmeth, lambdalifting,
   evaltempl, patterns, parampatterns, sempass2, linter, semmacrosanity,
   lowerings, plugins/active, rod, lineinfos, strtabs, int128,
-  isolation_check, typeallowed
+  isolation_check, typeallowed, colormsg
 
 from modulegraphs import ModuleGraph, PPassContext, onUse, onDef, onDefResolveForward
 
@@ -240,7 +240,7 @@ proc typeAllowedCheck(c: PContext; info: TLineInfo; typ: PType; kind: TSymKind;
     else:
       err = "invalid type: '$1' in this context: '$2' for $3" % [typeToString(t),
               typeToString(typ), toHumanStr(kind)]
-    localError(c.config, info, err)
+    localError(c.config, info, err.colorError(mcError, c.config))
 
 proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
   typeAllowedCheck(c, typ.n.info, typ, skProc)
@@ -458,7 +458,7 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
   markUsed(c, info, sym)
   onUse(info, sym)
   if sym == c.p.owner:
-    globalError(c.config, info, "recursive dependency: '$1'" % sym.name.s)
+    globalError(c.config, info, ("recursive dependency: '$1'" % sym.name.s).colorError(mcError, c.config))
 
   let genericParams = sym.ast[genericParamsPos].len
   let suppliedParams = max(n.safeLen - 1, 0)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -277,7 +277,7 @@ proc notFoundError*(c: PContext, n: PNode, errors: CandidateErrors) =
     globalError(c.config, n.info, "type mismatch")
     return
   if errors.len == 0:
-    localError(c.config, n.info, "expression '$1' cannot be called" % n[0].renderTree)
+    localError(c.config, n.info, ("expression '$1' cannot be called" % n[0].renderTree).colorError(mcError, c.config))
     return
 
   let (prefer, candidates) = presentFailedCandidates(c, n, errors)
@@ -409,7 +409,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
     elif result.state != csMatch:
       if nfExprCall in n.flags:
         localError(c.config, n.info, "expression '$1' cannot be called" %
-                   renderTree(n, {renderNoComments}))
+                   renderTree(n, {renderNoComments}).colorError(mcError, c.config))
       else:
         if {nfDotField, nfDotSetter} * n.flags != {}:
           # clean up the inserted ops

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -256,7 +256,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
     candidatesAll.add candidates
   candidatesAll.sort # fix #13538
   if immutParam.len > 0:
-    candidatesAll.insert(("\nAtleast one mismatch is due to " & immutParam & " being immutable\n\n").quoteExpr)
+    candidatesAll.insert(("\nAtleast one mismatch is due to " & immutParam.quoteExpr & " being immutable\n\n"))
   candidates = join(candidatesAll)
   if skipped > 0:
     candidates.add($skipped & " other mismatching symbols have been " &

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -213,7 +213,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
     let nArg = if err.firstMismatch.arg < n.len: n[err.firstMismatch.arg] else: nil
     let nameParam = if err.firstMismatch.formal != nil: err.firstMismatch.formal.name.s else: ""
     if n.len > 1:
-      candidates.add("  first type mismatch at position: " & $err.firstMismatch.arg)
+      candidates.add("  'first type mismatch at position: " & $err.firstMismatch.arg & "'")
       # candidates.add "\n  reason: " & $err.firstMismatch.kind # for debugging
       case err.firstMismatch.kind
       of kUnknownNamedParam:
@@ -238,14 +238,14 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           candidates.add "'' 'is immutable, not' ''var''"
         else:
           candidates.add renderTree(nArg)
-          candidates.add "' is of type: "
+          candidates.add "'' 'is of type:' ''"
           var got = nArg.typ
-          candidates.add typeToString(got)
+          candidates.add typeToString(got) & "''"
           candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)
       of kUnknown: discard "do not break 'nim check'"
-      candidates.add "\n"
+      candidates.add "\n\n"
       if err.firstMismatch.arg == 1 and nArg.kind == nkTupleConstr and
           n.kind == nkCommand:
         maybeWrongSpace = true

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -246,7 +246,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           #addColorError("'$1' is immutable, not 'var'" % renderNotLValue(nArg))
         else:
           var got = nArg.typ
-          addColorError("'$1' is of type: $2" % [renderTree(nArg), typeToString(got)])
+          candidates.add("'$1' is of type: $2" % [renderTree(nArg).colorError(c.config), typeToString(got).colorError(c.config)])
           candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -11,7 +11,7 @@
 # included from sem.nim
 
 from algorithm import sort
-
+from renderer import quoteExpr, doubleQuoteExpr
 proc sameMethodDispatcher(a, b: PSym): bool =
   result = false
   if a.kind == skMethod and b.kind == skMethod:
@@ -232,15 +232,15 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         candidates.add("\n  required type for " & nameParam &  ": ")
         candidates.add typeToString(wanted)
         candidates.addDeclaredLocMaybe(c.config, wanted)
-        candidates.add "\n  but expression ''"
+        candidates.add "\n  but expression "
         if err.firstMismatch.kind == kVarNeeded:
-          candidates.add renderNotLValue(nArg)
-          candidates.add "'' 'is immutable, not' ''var''"
+          candidates.add renderNotLValue(nArg).doubleQuoteExpr
+          candidates.add " is immutable, not ".quoteExpr & "var".doubleQuoteExpr
         else:
-          candidates.add renderTree(nArg)
-          candidates.add "'' 'is of type:' ''"
+          candidates.add renderTree(nArg).doubleQuoteExpr
+          candidates.add " is of type: ".quoteExpr
           var got = nArg.typ
-          candidates.add typeToString(got) & "''"
+          candidates.add typeToString(got).doubleQuoteExpr
           candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)
@@ -643,8 +643,8 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
     # number of generic type parameters:
     if s.ast[genericParamsPos].safeLen != n.len-1:
       let expected = s.ast[genericParamsPos].safeLen
-      localError(c.config, getCallLineInfo(n), errGenerated, "cannot instantiate: '" & renderTree(n) &
-         "'; got " & $(n.len-1) & " typeof(s) but expected " & $expected)
+      localError(c.config, getCallLineInfo(n), errGenerated, "cannot instantiate: " & renderTree(n).doubleQuoteExpr &
+         "; got " & $(n.len-1) & " typeof(s) but expected " & $expected)
       return n
     result = explicitGenericSym(c, n, s)
     if result == nil: result = explicitGenericInstError(c, n)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -232,10 +232,10 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         candidates.add("\n  required type for " & nameParam &  ": ")
         candidates.add typeToString(wanted)
         candidates.addDeclaredLocMaybe(c.config, wanted)
-        candidates.add "\n  but expression '"
+        candidates.add "\n  but expression ''"
         if err.firstMismatch.kind == kVarNeeded:
           candidates.add renderNotLValue(nArg)
-          candidates.add "' is immutable, not 'var'"
+          candidates.add "'' 'is immutable, not' ''var''"
         else:
           candidates.add renderTree(nArg)
           candidates.add "' is of type: "

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -204,6 +204,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
   var skipped = 0
 
   template addColorError(a: string) = candidates.add(a.colorError(c.config))
+  template addColorExpect(a: string) = candidates.add(a.colorExpect(c.config))
   template addColorHl(a: string) = candidates.add(a.colorHighlight(c.config))
 
   for err in errors:
@@ -238,7 +239,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         var wanted = err.firstMismatch.formal.typ
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
-        addColorHl(typeToString(wanted))
+        addColorExpect(typeToString(wanted))
         candidates.addDeclaredLocMaybe(c.config, wanted)
         candidates.add "\n  but expression "
         if err.firstMismatch.kind == kVarNeeded:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -242,7 +242,9 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         candidates.addDeclaredLocMaybe(c.config, wanted)
         candidates.add "\n  but expression "
         if err.firstMismatch.kind == kVarNeeded:
-          addColorError("'$1' is immutable, not 'var'" % renderNotLValue(nArg))
+          let symbol = renderNotLValue(nArg).quoteExpr.colorError(c.config)
+          candidates.add("$1 is $2" % [symbol, "immutable, not 'var'".colorError(c.config)])
+          #addColorError("'$1' is immutable, not 'var'" % renderNotLValue(nArg))
         else:
           var got = nArg.typ
           addColorError("'$1' is of type: $2" % [renderTree(nArg), typeToString(got)])

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -11,8 +11,7 @@
 # included from sem.nim
 
 from algorithm import sort
-import colormsg
-import strformat
+import colormsg, strformat
 
 proc sameMethodDispatcher(a, b: PSym): bool =
   result = false

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -198,6 +198,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
   var candidatesAll: seq[string]
   var candidates = ""
   var skipped = 0
+  var immutParam = "" #Stores the name of an immutable param that needs to be 'var'
   for err in errors:
     candidates.setLen 0
     if filterOnlyFirst and err.firstMismatch.arg == 1:
@@ -235,6 +236,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         candidates.add "\n  but expression '"
         if err.firstMismatch.kind == kVarNeeded:
           candidates.add renderNotLValue(nArg)
+          immutParam = renderNotLValue(nArg)
           candidates.add "' is immutable, not 'var'"
         else:
           candidates.add renderTree(nArg)
@@ -253,6 +255,8 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
       candidates.add(diag & "\n")
     candidatesAll.add candidates
   candidatesAll.sort # fix #13538
+  if immutParam.len > 0:
+    candidatesAll.insert(("\nAtleast one mismatch is due to " & immutParam & " being immutable\n\n").quoteExpr)
   candidates = join(candidatesAll)
   if skipped > 0:
     candidates.add($skipped & " other mismatching symbols have been " &

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -127,10 +127,9 @@ proc pickBestCandidate(c: PContext, headSymbol: PNode,
 
 proc effectProblem(f, a: PType; result: var string; c: PContext) =
   template addColorError(a: string) = result.add a.colorError(c.config)
-  template addColorHint(a: string) = result.add a.colorHint(c.config)
   if f.kind == tyProc and a.kind == tyProc:
     if tfThread in f.flags and tfThread notin a.flags:
-      addColorHint "\n  This expression is not GC-safe. Annotate the " &
+      addColorError "\n  This expression is not GC-safe. Annotate the " &
           "proc with {.gcsafe.} to get extended error information."
     elif tfNoSideEffect in f.flags and tfNoSideEffect notin a.flags:
       addColorError "\n  This expression can have side effects. Annotate the " &

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -322,7 +322,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      result &= "\n  found $1" % [getSymRepr(c.config, sym).quoteExpr]
+      result &= "\n  found $1" % [getSymRepr(c.config, sym)]
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -11,7 +11,7 @@
 # included from sem.nim
 
 from algorithm import sort
-from renderer import quoteExpr, doubleQuoteExpr
+from renderer import quoteExpr
 proc sameMethodDispatcher(a, b: PSym): bool =
   result = false
   if a.kind == skMethod and b.kind == skMethod:
@@ -213,7 +213,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
     let nArg = if err.firstMismatch.arg < n.len: n[err.firstMismatch.arg] else: nil
     let nameParam = if err.firstMismatch.formal != nil: err.firstMismatch.formal.name.s else: ""
     if n.len > 1:
-      candidates.add("  'first type mismatch at position: " & $err.firstMismatch.arg & "'")
+      candidates.add("  first type mismatch at position: " & $err.firstMismatch.arg)
       # candidates.add "\n  reason: " & $err.firstMismatch.kind # for debugging
       case err.firstMismatch.kind
       of kUnknownNamedParam:
@@ -232,15 +232,15 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         candidates.add("\n  required type for " & nameParam &  ": ")
         candidates.add typeToString(wanted)
         candidates.addDeclaredLocMaybe(c.config, wanted)
-        candidates.add "\n  but expression "
+        candidates.add "\n  but expression '"
         if err.firstMismatch.kind == kVarNeeded:
-          candidates.add renderNotLValue(nArg).doubleQuoteExpr
-          candidates.add " is immutable, not ".quoteExpr & "var".doubleQuoteExpr
+          candidates.add renderNotLValue(nArg)
+          candidates.add "' is immutable, not 'var'"
         else:
-          candidates.add renderTree(nArg).doubleQuoteExpr
-          candidates.add " is of type: ".quoteExpr
+          candidates.add renderTree(nArg)
+          candidates.add "' is of type: "
           var got = nArg.typ
-          candidates.add typeToString(got).doubleQuoteExpr
+          candidates.add typeToString(got).quoteExpr
           candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)
@@ -643,8 +643,8 @@ proc explicitGenericInstantiation(c: PContext, n: PNode, s: PSym): PNode =
     # number of generic type parameters:
     if s.ast[genericParamsPos].safeLen != n.len-1:
       let expected = s.ast[genericParamsPos].safeLen
-      localError(c.config, getCallLineInfo(n), errGenerated, "cannot instantiate: " & renderTree(n).doubleQuoteExpr &
-         "; got " & $(n.len-1) & " typeof(s) but expected " & $expected)
+      localError(c.config, getCallLineInfo(n), errGenerated, "cannot instantiate: '" & renderTree(n) &
+         "'; got " & $(n.len-1) & " typeof(s) but expected " & $expected)
       return n
     result = explicitGenericSym(c, n, s)
     if result == nil: result = explicitGenericInstError(c, n)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -214,7 +214,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
     let nArg = if err.firstMismatch.arg < n.len: n[err.firstMismatch.arg] else: nil
     let nameParam = if err.firstMismatch.formal != nil: err.firstMismatch.formal.name.s else: ""
     if n.len > 1:
-      candidates.add(("  first type mismatch at position: " & $err.firstMismatch.arg).colorError(mcError, c.config))
+      candidates.add(("  first type mismatch at position: " & $err.firstMismatch.arg).colorError(c.config))
       # candidates.add "\n  reason: " & $err.firstMismatch.kind # for debugging
       case err.firstMismatch.kind
       of kUnknownNamedParam:
@@ -231,14 +231,14 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         var wanted = err.firstMismatch.formal.typ
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
-        candidates.add typeToString(wanted).colorError(mcHighlight, c.config)
+        candidates.add typeToString(wanted).colorHighlight(c.config)
         candidates.addDeclaredLocMaybe(c.config, wanted)
         candidates.add "\n  but expression "
         if err.firstMismatch.kind == kVarNeeded:
-          candidates.add ("$1 is immutable, not 'var'" % renderNotLValue(nArg)).colorError(mcError, c.config)
+          candidates.add ("$1 is immutable, not 'var'" % renderNotLValue(nArg)).colorError(c.config)
         else:
           var got = nArg.typ
-          candidates.add ("$1 is of type: $2" % [renderTree(nArg), typeToString(got)]).colorError(mcError, c.config)
+          candidates.add ("$1 is of type: $2" % [renderTree(nArg), typeToString(got)]).colorError(c.config)
           candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)
@@ -277,12 +277,12 @@ proc notFoundError*(c: PContext, n: PNode, errors: CandidateErrors) =
     globalError(c.config, n.info, "type mismatch")
     return
   if errors.len == 0:
-    localError(c.config, n.info, ("expression '$1' cannot be called" % n[0].renderTree).colorError(mcError, c.config))
+    localError(c.config, n.info, ("expression '$1' cannot be called" % n[0].renderTree).colorError(c.config))
     return
 
   let (prefer, candidates) = presentFailedCandidates(c, n, errors)
   var result = errTypeMismatch
-  result.add(fmt"<{describeArgs(c, n, 1, prefer)}>".colorError(mcError, c.config))
+  result.add(fmt"<{describeArgs(c, n, 1, prefer)}>".colorError(c.config))
   if candidates != "":
     result.add("\n" & errButExpected & "\n" & candidates)
   localError(c.config, n.info, result & "\nexpression: " & $n)
@@ -409,7 +409,7 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
     elif result.state != csMatch:
       if nfExprCall in n.flags:
         localError(c.config, n.info, "expression '$1' cannot be called" %
-                   renderTree(n, {renderNoComments}).colorError(mcError, c.config))
+                   renderTree(n, {renderNoComments}).colorError(c.config))
       else:
         if {nfDotField, nfDotSetter} * n.flags != {}:
           # clean up the inserted ops

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -245,7 +245,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
           addColorError("'$1' is immutable, not 'var'" % renderNotLValue(nArg))
         else:
           var got = nArg.typ
-          addColorError("'$1' is of type: '$2'" % [renderTree(nArg), typeToString(got)])
+          addColorError("'$1' is of type: $2" % [renderTree(nArg), typeToString(got)])
           candidates.addDeclaredLocMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil: effectProblem(wanted, got, candidates, c)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -341,7 +341,7 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     result = errUndeclaredField % ident.colorError(c.config) & typeHint & " " & result
   else:
     if result.len == 0: result = errUndeclaredRoutine % ident.colorError(c.config)
-    else: result = errBadRoutine % [ident.quoteExpr.colorError(c.config), result.quoteExpr.colorError(c.config)]
+    else: result = errBadRoutine % [ident.colorError(c.config), result.colorError(c.config)]
 
 proc resolveOverloads(c: PContext, n, orig: PNode,
                       filter: TSymKinds, flags: TExprFlags,

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -607,7 +607,7 @@ proc semOverloadedCall(c: PContext, n, nOrig: PNode,
       notFoundError(c, n, errors)
 
 proc explicitGenericInstError(c: PContext; n: PNode): PNode =
-  localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n).quoteExpr)
+  localError(c.config, getCallLineInfo(n), errCannotInstantiateX % renderTree(n))
   result = n
 
 proc explicitGenericSym(c: PContext, n: PNode, s: PSym): PNode =

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -576,8 +576,8 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
     if x.kind == nkExprColonExpr and x.len == 2:
       var idx = semConstExpr(c, x[0])
       if not isOrdinalType(idx.typ):
-        localError(c.config, idx.info, "expected ordinal value for array " &
-                   "index, got '$1'" % renderTree(idx))
+        localError(c.config, idx.info, ("expected ordinal value for array " &
+                   "index, got '$1'" % renderTree(idx)).colorError(mcError, c.config))
       else:
         firstIndex = getOrdValue(idx)
         lastIndex = firstIndex
@@ -593,8 +593,8 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       if lastIndex == lastValidIndex:
         let validIndex = makeRangeType(c, toInt64(firstIndex), toInt64(lastValidIndex), n.info,
                                        indexType)
-        localError(c.config, n.info, "size of array exceeds range of index " &
-          "type '$1' by $2 elements" % [typeToString(validIndex), $(n.len-i)])
+        localError(c.config, n.info, ("size of array exceeds range of index " &
+          "type '$1' by $2 elements" % [typeToString(validIndex), $(n.len-i)]).colorError(mcError, c.config))
 
       x = n[i]
       if x.kind == nkExprColonExpr and x.len == 2:
@@ -1921,12 +1921,12 @@ proc expectMacroOrTemplateCall(c: PContext, n: PNode): PSym =
       return errorSym(c, n[0])
 
     if expandedSym.kind notin {skMacro, skTemplate}:
-      localError(c.config, n.info, "'$1' is not a macro or template" % expandedSym.name.s)
+      localError(c.config, n.info, ("'$1' is not a macro or template" % expandedSym.name.s).colorError(mcError, c.config))
       return errorSym(c, n[0])
 
     result = expandedSym
   else:
-    localError(c.config, n.info, "'$1' is not a macro or template" % n.renderTree)
+    localError(c.config, n.info, ("'$1' is not a macro or template" % n.renderTree).colorError(mcError, c.config))
     result = errorSym(c, n)
 
 proc expectString(c: PContext, n: PNode): string =
@@ -1934,7 +1934,7 @@ proc expectString(c: PContext, n: PNode): string =
   if n.kind in nkStrKinds:
     return n.strVal
   else:
-    localError(c.config, n.info, errStringLiteralExpected)
+    localError(c.config, n.info, errStringLiteralExpected.colorError(mcError, c.config))
 
 proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =
   result = newSym(kind, c.cache.idAnon, nextId c.idgen, getCurrOwner(c), info)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -284,7 +284,7 @@ proc semConv(c: PContext, n: PNode): PNode =
   # special case to make MyObject(x = 3) produce a nicer error message:
   if n[1].kind == nkExprEqExpr and
       targetType.skipTypes(abstractPtrs).kind == tyObject:
-    localError(c.config, n.info, "object construction uses ':', not '='")
+    localError(c.config, n.info, "object construction uses ':', not '='".colorError(c.config))
   var op = semExprWithType(c, n[1])
   if targetType.kind != tyGenericParam and targetType.isMetaType:
     let final = inferWithMetatype(c, targetType, op, true)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -577,7 +577,7 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       var idx = semConstExpr(c, x[0])
       if not isOrdinalType(idx.typ):
         localError(c.config, idx.info, ("expected ordinal value for array " &
-                   "index, got '$1'" % renderTree(idx)).colorError(mcError, c.config))
+                   "index, got '$1'" % renderTree(idx)).colorError(c.config))
       else:
         firstIndex = getOrdValue(idx)
         lastIndex = firstIndex
@@ -594,7 +594,7 @@ proc semArrayConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
         let validIndex = makeRangeType(c, toInt64(firstIndex), toInt64(lastValidIndex), n.info,
                                        indexType)
         localError(c.config, n.info, ("size of array exceeds range of index " &
-          "type '$1' by $2 elements" % [typeToString(validIndex), $(n.len-i)]).colorError(mcError, c.config))
+          "type '$1' by $2 elements" % [typeToString(validIndex), $(n.len-i)]).colorError(c.config))
 
       x = n[i]
       if x.kind == nkExprColonExpr and x.len == 2:
@@ -1921,12 +1921,12 @@ proc expectMacroOrTemplateCall(c: PContext, n: PNode): PSym =
       return errorSym(c, n[0])
 
     if expandedSym.kind notin {skMacro, skTemplate}:
-      localError(c.config, n.info, ("'$1' is not a macro or template" % expandedSym.name.s).colorError(mcError, c.config))
+      localError(c.config, n.info, ("'$1' is not a macro or template" % expandedSym.name.s).colorError(c.config))
       return errorSym(c, n[0])
 
     result = expandedSym
   else:
-    localError(c.config, n.info, ("'$1' is not a macro or template" % n.renderTree).colorError(mcError, c.config))
+    localError(c.config, n.info, ("'$1' is not a macro or template" % n.renderTree).colorError(c.config))
     result = errorSym(c, n)
 
 proc expectString(c: PContext, n: PNode): string =
@@ -1934,7 +1934,7 @@ proc expectString(c: PContext, n: PNode): string =
   if n.kind in nkStrKinds:
     return n.strVal
   else:
-    localError(c.config, n.info, errStringLiteralExpected.colorError(mcError, c.config))
+    localError(c.config, n.info, errStringLiteralExpected.colorError(c.config))
 
 proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =
   result = newSym(kind, c.cache.idAnon, nextId c.idgen, getCurrOwner(c), info)

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -9,6 +9,7 @@
 
 # This module implements the instantiation of generic procs.
 # included from sem.nim
+import colormsg
 
 proc addObjFieldsToLocalScope(c: PContext; n: PNode) =
   template rec(n) = addObjFieldsToLocalScope(c, n)
@@ -74,10 +75,10 @@ iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym 
         # later by semAsgn in return type inference scenario
         t = q.typ
       else:
-        localError(c.config, a.info, errCannotInstantiateX % s.name.s)
+        localError(c.config, a.info, errCannotInstantiateX % s.name.s.colorError(mcError,c.config))
         t = errorType(c)
     elif t.kind == tyGenericParam:
-      localError(c.config, a.info, errCannotInstantiateX % q.name.s)
+      localError(c.config, a.info, errCannotInstantiateX % q.name.s.colorError(mcError,c.config))
       t = errorType(c)
     elif t.kind == tyGenericInvocation:
       #t = instGenericContainer(c, a, t)

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -75,10 +75,10 @@ iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym 
         # later by semAsgn in return type inference scenario
         t = q.typ
       else:
-        localError(c.config, a.info, errCannotInstantiateX % s.name.s.colorError(mcError,c.config))
+        localError(c.config, a.info, errCannotInstantiateX % s.name.s.colorError(c.config))
         t = errorType(c)
     elif t.kind == tyGenericParam:
-      localError(c.config, a.info, errCannotInstantiateX % q.name.s.colorError(mcError,c.config))
+      localError(c.config, a.info, errCannotInstantiateX % q.name.s.colorError(c.config))
       t = errorType(c)
     elif t.kind == tyGenericInvocation:
       #t = instGenericContainer(c, a, t)

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -56,7 +56,7 @@ proc pushProcCon*(c: PContext; owner: PSym) =
   rawHandleSelf(c, owner)
 
 const
-  errCannotInstantiateX = "cannot instantiate: $1"
+  errCannotInstantiateX = "cannot instantiate: '$1'"
 
 iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym =
   internalAssert c.config, n.kind == nkGenericParams

--- a/compiler/seminst.nim
+++ b/compiler/seminst.nim
@@ -56,7 +56,7 @@ proc pushProcCon*(c: PContext; owner: PSym) =
   rawHandleSelf(c, owner)
 
 const
-  errCannotInstantiateX = "cannot instantiate: '$1'"
+  errCannotInstantiateX = "cannot instantiate: $1"
 
 iterator instantiateGenericParamList(c: PContext, n: PNode, pt: TIdTable): PSym =
   internalAssert c.config, n.kind == nkGenericParams

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -505,7 +505,7 @@ proc procVarCheck(n: PNode; conf: ConfigRef) =
   if n.kind in nkSymChoices:
     for x in n: procVarCheck(x, conf)
   elif n.kind == nkSym and n.sym.magic != mNone and n.sym.kind in routineKinds:
-    localError(conf, n.info, "'$1' cannot be passed to a procvar" % n.sym.name.s)
+    localError(conf, n.info, colorError("'$1' cannot be passed to a procvar" % n.sym.name.s, conf))
 
 proc notNilCheck(tracked: PEffects, n: PNode, paramType: PType) =
   let n = n.skipConv

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -10,7 +10,7 @@
 import
   intsets, ast, astalgo, msgs, renderer, magicsys, types, idents, trees,
   wordrecg, strutils, options, guards, lineinfos, semfold, semdata,
-  modulegraphs, varpartitions, typeallowed
+  modulegraphs, varpartitions, typeallowed, colormsg
 
 when defined(useDfa):
   import dfa
@@ -1327,7 +1327,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
     when false:
       listGcUnsafety(s, onlyWarning=false, g.config)
     else:
-      localError(g.config, s.info, ("'$1' can have side effects" % s.name.s) & (g.config $ mutationInfo))
+      localError(g.config, s.info, ("'$1' can have side effects" % s.name.s).colorError(c.config) & (g.config $ mutationInfo))
   if not t.gcUnsafe:
     s.typ.flags.incl tfGcSafe
   if not t.hasSideEffect and sfSideEffect notin s.flags:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -190,10 +190,10 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
     if isImportedException(typ, c.config):
       isImported = true
     elif not isException(typ):
-      localError(c.config, typeNode.info, errExprCannotBeRaised)
+      localError(c.config, typeNode.info, errExprCannotBeRaised.colorError(c.config))
 
     if containsOrIncl(check, typ.id):
-      localError(c.config, typeNode.info, errExceptionAlreadyHandled)
+      localError(c.config, typeNode.info, errExceptionAlreadyHandled.colorError(c.config))
     typeNode = newNodeIT(nkType, typeNode.info, typ)
     isImported
 
@@ -245,11 +245,11 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
           else: isNative = true
 
         if isNative and isImported:
-          localError(c.config, a[0].info, "Mix of imported and native exception types is not allowed in one except branch")
+          localError(c.config, a[0].info, "Mix of imported and native exception types is not allowed in one except branch".colorError(c.config))
 
     elif a.kind == nkFinally:
       if i != n.len-1:
-        localError(c.config, a.info, "Only one finally is allowed after all other branches")
+        localError(c.config, a.info, "Only one finally is allowed after all other branches".colorError(c.config))
 
     else:
       illFormedAst(n, c.config)
@@ -257,7 +257,7 @@ proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
     if catchAllExcepts > 1:
       # if number of ``except: body`` blocks is greater than 1
       # or more specific exception follows a general except block, it is invalid
-      localError(c.config, a.info, "Only one general except clause is allowed after more specific exceptions")
+      localError(c.config, a.info, "Only one general except clause is allowed after more specific exceptions".colorError(c.config))
 
     # last child of an nkExcept/nkFinally branch is a statement:
     a[^1] = semExprBranchScope(c, a[^1])

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -148,6 +148,7 @@ proc getProcHeader*(conf: ConfigRef; sym: PSym; prefer: TPreferedDesc = preferNa
   assert sym != nil
   # consider using `skipGenericOwner` to avoid fun2.fun2 when fun2 is generic
   result = sym.owner.name.s & '.' & sym.name.s
+  result = result.colorError(conf)
   if sym.kind in routineKinds:
     result.add '('
     var n = sym.typ.n

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -11,7 +11,7 @@
 
 import
   intsets, ast, astalgo, trees, msgs, strutils, platform, renderer, options,
-  lineinfos, int128
+  lineinfos, int128, colormsg
 
 type
   TPreferedDesc* = enum
@@ -161,6 +161,7 @@ proc getProcHeader*(conf: ConfigRef; sym: PSym; prefer: TPreferedDesc = preferNa
       else:
         result.add renderTree(p)
     result.add(')')
+    result = result.colorError(mcError, conf)
     if n[0].typ != nil:
       result.add(": " & typeToString(n[0].typ, prefer))
   if getDeclarationPath: result.addDeclaredLoc(conf, sym)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -161,7 +161,7 @@ proc getProcHeader*(conf: ConfigRef; sym: PSym; prefer: TPreferedDesc = preferNa
       else:
         result.add renderTree(p)
     result.add(')')
-    result = result.colorError(mcError, conf)
+    result = result.colorError(conf)
     if n[0].typ != nil:
       result.add(": " & typeToString(n[0].typ, prefer))
   if getDeclarationPath: result.addDeclaredLoc(conf, sym)
@@ -1501,7 +1501,7 @@ proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType, n: P
       msg.add "\n"
     msg.add " but expected '$1'" % x
     if verbose: msg.addDeclaredLoc(conf, formal)
-    msg = msg.colorError(mcError, conf)
+    msg = msg.colorError(conf)
     if formal.kind == tyProc and actual.kind == tyProc:
       case compatibleEffects(formal, actual)
       of efCompat: discard

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1501,7 +1501,7 @@ proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType, n: P
       msg.add "\n"
     msg.add " but expected '$1'" % x
     if verbose: msg.addDeclaredLoc(conf, formal)
-
+    msg = msg.colorError(mcError, conf)
     if formal.kind == tyProc and actual.kind == tyProc:
       case compatibleEffects(formal, actual)
       of efCompat: discard

--- a/tests/concepts/t3330.nim
+++ b/tests/concepts/t3330.nim
@@ -29,9 +29,9 @@ proc add[T](x: var seq[T]; y: sink T)
   required type for x: var seq[T]
   but expression 'k' is of type: Alias
 
-t3330.nim(55, 8) template/generic instantiation of `add` from here
+t3330.nim(55, 8) template/generic instantiation of 'add' from here
 t3330.nim(62, 6) Foo: 'bar.value' cannot be assigned to
-t3330.nim(55, 8) template/generic instantiation of `add` from here
+t3330.nim(55, 8) template/generic instantiation of 'add' from here
 t3330.nim(63, 6) Foo: 'bar.x' cannot be assigned to
 
 expression: test(bar)'''

--- a/tests/concepts/texplain.nim
+++ b/tests/concepts/texplain.nim
@@ -49,7 +49,7 @@ proc e(o: ExplainedConcept): int
   first type mismatch at position: 1
   required type for o: ExplainedConcept
   but expression 'n' is of type: NonMatchingType
-texplain.nim(174, 9) template/generic instantiation of `assert` from here
+texplain.nim(174, 9) template/generic instantiation of 'assert' from here
 texplain.nim(130, 5) ExplainedConcept: concept predicate failed
 
 expression: e(n)
@@ -63,7 +63,7 @@ proc r(o: RegularConcept): int
   first type mismatch at position: 1
   required type for o: RegularConcept
   but expression 'n' is of type: NonMatchingType
-texplain.nim(175, 9) template/generic instantiation of `assert` from here
+texplain.nim(175, 9) template/generic instantiation of 'assert' from here
 texplain.nim(134, 5) RegularConcept: concept predicate failed
 proc r[T](a: SomeNumber; b: T; c: auto)
   first type mismatch at position: 1

--- a/tests/macros/tmsginfo.nim
+++ b/tests/macros/tmsginfo.nim
@@ -1,6 +1,6 @@
 discard """
   nimout: '''tmsginfo.nim(21, 1) Warning: foo1 [User]
-tmsginfo.nim(22, 13) template/generic instantiation of `foo2` from here
+tmsginfo.nim(22, 13) template/generic instantiation of 'foo2' from here
 tmsginfo.nim(15, 10) Warning: foo2 [User]
 tmsginfo.nim(23, 1) Hint: foo3 [User]
 tmsginfo.nim(19, 7) Hint: foo4 [User]

--- a/tests/pragmas/t8741.nim
+++ b/tests/pragmas/t8741.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim check --hint[processing]:off $file"
   errormsg: "3 is not two"
   nimout: '''t8741.nim(13, 9) Error: cannot attach a custom pragma to 'a'
-t8741.nim(29, 15) template/generic instantiation of `onlyTwo` from here
+t8741.nim(29, 15) template/generic instantiation of 'onlyTwo' from here
 t8741.nim(25, 12) Error: 3 is not two
 '''
 """


### PR DESCRIPTION
Sort of a duplicate PR as #16356 although done in a different way, more manual for more abillity to annotate parts of messages. A majority of errors(I can find) that can be colourised have been, although I may have missed them. Uses terminal colours, although 256 palette colours could be implemented later for more user control(May want to add error colours to the config for customization).
![image](https://user-images.githubusercontent.com/11792483/102961120-c5dd4180-44a0-11eb-97eb-f0054176aee6.png)
