### PR TITLE
[feature] Unicode support for `\U********`.

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -723,10 +723,10 @@ proc getEscapedChar(L: var Lexer, tok: var Token) =
       handleHexChar(L, xi, 3)
       handleHexChar(L, xi, 4)
       if c == 'U': 
-        handleHexChar(L, xi, 5)
-        handleHexChar(L, xi, 6)
-        handleHexChar(L, xi, 7)
-        handleHexChar(L, xi, 8)
+        handleHexChar(L, xi, 1)
+        handleHexChar(L, xi, 2)
+        handleHexChar(L, xi, 3)
+        handleHexChar(L, xi, 4)
     addUnicodeCodePoint(tok.literal, xi)
   of '0'..'9':
     if matchTwoChars(L, '0', {'0'..'9'}):

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -699,6 +699,7 @@ proc getEscapedChar(L: var Lexer, tok: var Token) =
     handleHexChar(L, xi, 2)
     tok.literal.add(chr(xi))
   of 'u', 'U':
+    let c = L.buf[L.bufpos]
     if tok.tokType == tkCharLit:
       lexMessage(L, errGenerated, "\\u not allowed in character literal")
     inc(L.bufpos)
@@ -721,6 +722,11 @@ proc getEscapedChar(L: var Lexer, tok: var Token) =
       handleHexChar(L, xi, 2)
       handleHexChar(L, xi, 3)
       handleHexChar(L, xi, 4)
+      if c == 'U': 
+        handleHexChar(L, xi, 5)
+        handleHexChar(L, xi, 6)
+        handleHexChar(L, xi, 7)
+        handleHexChar(L, xi, 8)
     addUnicodeCodePoint(tok.literal, xi)
   of '0'..'9':
     if matchTwoChars(L, '0', {'0'..'9'}):


### PR DESCRIPTION
A small feature to add support for writing unicode using the following format: `/U`. Fully compatible with C based unicode. For more information: [Escape Sequences in C](https://en.wikipedia.org/wiki/Escape_sequences_in_C)