### PR TITLE
Add assertions for jsconsole

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,7 +75,7 @@
 
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.
-- Added `jsconsole.doAssert` for JavaScript target.
+- Added `jsconsole.jsAssert` for JavaScript target.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -75,6 +75,7 @@
 
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.
+- Added `jsconsole.doAssert` for JavaScript target.
 
 
 ## Language changes

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -10,7 +10,7 @@
 ## Wrapper for the `console` object for the `JavaScript backend
 ## <backends.html#backends-the-javascript-target>`_.
 
-import std/private/since, std/private/miscdollars
+import std/private/since, std/private/miscdollars  # toLocation
 
 when not defined(js) and not defined(Nimdoc):
   {.error: "This module only works on the JavaScript platform".}

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -10,10 +10,12 @@
 ## Wrapper for the `console` object for the `JavaScript backend
 ## <backends.html#backends-the-javascript-target>`_.
 
+import std/private/since
+
 when not defined(js) and not defined(Nimdoc):
   {.error: "This module only works on the JavaScript platform".}
 
-type Console* = ref object of RootObj
+type Console* = ref object of JsRoot
 
 proc log*(console: Console) {.importcpp, varargs.}
   ## https://developer.mozilla.org/docs/Web/API/Console/log
@@ -66,5 +68,16 @@ proc timeLog*(console: Console, label = "".cstring) {.importcpp.}
 
 proc table*(console: Console) {.importcpp, varargs.}
   ## https://developer.mozilla.org/docs/Web/API/Console/table
+
+since (1, 5):
+  # proc nor func can not be used here, because may eval assertion at compile-time,
+  # writing directly false or true to the JavaScript instead of the expression.
+  # importjs nor importcpp can not be used with template.
+
+  template doAssert*(console: Console; assertion) =
+    ## https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
+    runnableExamples: console.doAssert(42 == 42)
+    {.emit: "console.assert(" & astToStr(assertion) & ");".}
+
 
 var console* {.importc, nodecl.}: Console

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -74,10 +74,16 @@ since (1, 5):
   # writing directly false or true to the JavaScript instead of the expression.
   # importjs nor importcpp can not be used with template.
 
-  template doAssert*(console: Console; assertion) =
+  template jsAssert*(console: Console; assertion) =
+    ## JavaScript `console.assert`,
+    ## assert failure just prints to console and do not quit the program.
     ## https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
-    runnableExamples: console.doAssert(42 == 42)
-    {.emit: "console.assert(" & astToStr(assertion) & ");".}
+    runnableExamples: 
+      console.jsAssert(42 == 42) # OK
+      console.jsAssert(42 != 42) # Fail, prints "Assertion failed" and continues
+    var message = ""
+    message.addQuoted(astToStr(assertion))
+    {.emit: ["console.assert(", astToStr(assertion), ", ", message.cstring, ");"].}
 
 
 var console* {.importc, nodecl.}: Console

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -70,9 +70,6 @@ proc table*(console: Console) {.importcpp, varargs.}
   ## https://developer.mozilla.org/docs/Web/API/Console/table
 
 since (1, 5):
-  # proc nor func can not be used here, because may eval assertion at compile-time,
-  # writing directly false or true to the JavaScript instead of the expression.
-  # importjs nor importcpp can not be used with template.
   type InstantiationInfo = tuple[filename: string, line: int, column: int]
 
   func getMsg(info: InstantiationInfo; msg: string): string =

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -75,10 +75,12 @@ since (1, 5):
   # importjs nor importcpp can not be used with template.
   type InstantiationInfo = tuple[filename: string, line: int, column: int]
 
-  proc `$`(info: InstantiationInfo): string =
+  func getMsg(info: InstantiationInfo; msg: string): string =
     var temp = ""
     temp.toLocation(info.filename, info.line, info.column + 1)
     result.addQuoted(temp)
+    result.add ','
+    result.addQuoted(msg)
 
   template jsAssert*(console: Console; assertion) =
     ## JavaScript `console.assert`, for NodeJS this prints to stderr,
@@ -87,7 +89,7 @@ since (1, 5):
     ## is just for when you need faster performance *and* assertions,
     ## otherwise use the normal assertions for better user experience.
     ## https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
-    runnableExamples: 
+    runnableExamples:
       console.jsAssert(42 == 42) # OK
       console.jsAssert(42 != 42) # Fail, prints "Assertion failed" and continues
       console.jsAssert('`' == '\n' and '\t' == '\0') # Message correctly formatted
@@ -95,11 +97,9 @@ since (1, 5):
 
     const
       loc = instantiationInfo(fullPaths = compileOption("excessiveStackTrace"))
-      ploc = cstring($loc)
-    var msg = ""
-    msg.addQuoted(astToStr(assertion))
+      msg = getMsg(loc, astToStr(assertion)).cstring
     {.line: loc.}:
-      {.emit: ["console.assert(", assertion, ", ", ploc, ", ", msg.cstring, ");"].}
+      {.emit: ["console.assert(", assertion, ", ", msg, ");"].}
 
 
 var console* {.importc, nodecl.}: Console

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -76,7 +76,10 @@ since (1, 5):
 
   template jsAssert*(console: Console; assertion) =
     ## JavaScript `console.assert`, for NodeJS this prints to stderr,
-    ## assert failure just prints to console and do not quit the program.
+    ## assert failure just prints to console and do not quit the program,
+    ## this is not meant to be better or even equal than normal assertions,
+    ## is just for when you need faster performance *and* assertions,
+    ## otherwise use the normal assertions for better user experience.
     ## https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
     runnableExamples: 
       console.jsAssert(42 == 42) # OK

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -75,7 +75,7 @@ since (1, 5):
   # importjs nor importcpp can not be used with template.
 
   template jsAssert*(console: Console; assertion) =
-    ## JavaScript `console.assert`,
+    ## JavaScript `console.assert`, for NodeJS this prints to stderr,
     ## assert failure just prints to console and do not quit the program.
     ## https://developer.mozilla.org/en-US/docs/Web/API/Console/assert
     runnableExamples: 


### PR DESCRIPTION
- Add assertions for `jsconsole`.
- Generates a `console.assert(expresion, message);`. You can keep using normal assertions too.
- Changelog, since, doc with links, `runnableExamples`, etc.
