### PR TITLE
Avoid creating a holey array in makeNimstrLit for JS target

### DIFF
--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -190,7 +190,7 @@ proc setConstr() {.varargs, asmNoStackFrame, compilerproc.} =
 proc makeNimstrLit(c: cstring): string {.asmNoStackFrame, compilerproc.} =
   {.emit: """
   var result = [];
-  for (var i = 0; i < ln; ++i) {
+  for (var i = 0; i < `c`.length; ++i) {
     result.push(`c`.charCodeAt(i));
   }
   return result;

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -190,9 +190,9 @@ proc setConstr() {.varargs, asmNoStackFrame, compilerproc.} =
 proc makeNimstrLit(c: cstring): string {.asmNoStackFrame, compilerproc.} =
   {.emit: """
   var ln = `c`.length;
-  var result = new Array(ln);
+  var result = [];
   for (var i = 0; i < ln; ++i) {
-    result[i] = `c`.charCodeAt(i);
+    result.push(`c`.charCodeAt(i));
   }
   return result;
   """.}

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -191,7 +191,7 @@ proc makeNimstrLit(c: cstring): string {.asmNoStackFrame, compilerproc.} =
   {.emit: """
   var result = [];
   for (var i = 0; i < `c`.length; ++i) {
-    result.push(`c`.charCodeAt(i));
+    result[i] = `c`.charCodeAt(i);
   }
   return result;
   """.}

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -189,7 +189,6 @@ proc setConstr() {.varargs, asmNoStackFrame, compilerproc.} =
 
 proc makeNimstrLit(c: cstring): string {.asmNoStackFrame, compilerproc.} =
   {.emit: """
-  var ln = `c`.length;
   var result = [];
   for (var i = 0; i < ln; ++i) {
     result.push(`c`.charCodeAt(i));


### PR DESCRIPTION
This is a subtle, but important performance improvement in the `makeNimstrLit` proc for targeting JS.

The previous code would accept a string and construct an array of character codes. The way it did this was be creating an array with `new Array(n)`. This creates a holey array (a sparse array) which V8 is very bad at optimizing compared to a packed array with no holes.

> V8 makes this distinction because operations on packed arrays can be optimized more aggressively than operations on holey arrays. For packed arrays, most operations can be performed efficiently. In comparison, operations on holey arrays require additional checks and expensive lookups on the prototype chain. - [Elements kinds in V8](https://v8.dev/blog/elements-kinds#packed-vs.-holey-kinds)

And later in that same page:

> ```js
> const array = new Array(3);
> // The array is sparse at this point, so it gets marked as
> // `HOLEY_SMI_ELEMENTS`, i.e. the most specific possibility given
> // the current information.
> ```

There are other instances where `new Array(length)` is used, which for lengths 1 and above means holey arrays. I could spend some more time going around replacing all instances of those with optimized versions if requested.