### PR TITLE
Add httpcore.toString

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@
 - `writeStackTrace` is available in JS backend now.
 
 - `strscans.scanf` now supports parsing single characters.
-- `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`. 
+- `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`.
 
 - Added `setutils.toSet` that can take any iterable and convert it to a built-in set,
   if the iterable yields a built-in settable type.
@@ -70,11 +70,13 @@
   and `lists.toDoublyLinkedList` convert from `openArray`s; `lists.copy` implements
   shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
   its argument, `addMoved`, is also supplied.
-  
+
 - Added `sequtils` import to `prelude`.
 
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.
+- Added `httpcore.toString` same as `$` but only accepts valid `HttpCode` as standarized by IANA.
+
 
 
 ## Language changes

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -357,8 +357,8 @@ func toString*(code: HttpCode): string {.since: (1, 5).} =
   runnableExamples:
     doAssert toString(Http404) == "404 Not Found"
     doAssertRaises(ValueError): discard toString(HttpCode(0))
-    doAssertRaises(ValueError): discard toString(HttpCode(50))
     doAssertRaises(ValueError): discard toString(HttpCode(99))
+    doAssertRaises(ValueError): discard toString(HttpCode(599))
   httpCodeDollarImpl(code, strict = true)
 
 func `==`*(a, b: HttpCode): bool {.borrow.}


### PR DESCRIPTION
- Continuing the work done on https://github.com/nim-lang/Nim/pull/16454
- Add `httpcore.toString` same as `$` but only accepts valid input `HttpCode` as standarized by IANA for correctness and safety.
- Changelog, docs with links, `runnableExamples` with `doAssert` and `doAssertRaises`, since, etc.
- A safer `$` basically.
