### PR TITLE
base64 use encodeSize

### DIFF
--- a/lib/pure/base64.nim
+++ b/lib/pure/base64.nim
@@ -193,6 +193,7 @@ proc encodeMime*(s: string, lineLen = 75, newLine = "\r\n"): string =
   ## * `decode proc<#decode,string>`_ for decoding a string
   runnableExamples:
     assert encodeMime("Hello World", 4, "\n") == "SGVs\nbG8g\nV29y\nbGQ="
+  result = newStringOfCap(encodeSize(s.len))
   for i, c in encode(s):
     if i != 0 and (i mod lineLen == 0):
       result.add(newLine)


### PR DESCRIPTION
- Save some alloc on `base64.encodeMime` using `encodeSize(s.len)`, the same logic that `encode`/`decode` use. 1 line diff.
- `encodeSize(s.len)` gives an approx len of the output string instead of starting with empty string and alloc on each loop.

# Before

- Starts with empty string, alloc on each loop.

# After

- Alloc string once. 
