### PR TITLE
fix nim js cmp fails at CT

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2394,14 +2394,8 @@ when notJSnotNims:
     """.}
 
 when defined(js):
-  when not defined(nimscript):
-    include "system/jssys"
-    include "system/reprjs"
-  else:
-    proc cmp(x, y: string): int =
-      if x == y: return 0
-      if x < y: return -1
-      return 1
+  include "system/jssys"
+  include "system/reprjs"
 
 when defined(js) or defined(nimscript):
   proc addInt*(result: var string; x: int64) =

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -341,7 +341,12 @@ proc cmpStrings(a, b: string): int {.asmNoStackFrame, compilerproc.} =
   """
 
 proc cmp(x, y: string): int =
-  return cmpStrings(x, y)
+  when nimvm:
+    if x == y: result = 0
+    elif x < y: result = -1
+    else: result = 1
+  else:
+    result = cmpStrings(x, y)
 
 proc eqStrings(a, b: string): bool {.asmNoStackFrame, compilerproc.} =
   asm """

--- a/tests/misc/tstrtabs.nim
+++ b/tests/misc/tstrtabs.nim
@@ -1,0 +1,20 @@
+discard """
+  targets: "c cpp js"
+"""
+
+import std/strtabs
+
+proc fun()=
+  let ret = newStringTable(modeCaseSensitive)
+  ret["foo"] = "bar"
+
+  doAssert $ret == "{foo: bar}"
+
+  let b = ret["foo"]
+  doAssert b == "bar"
+
+proc main()=
+  static: fun()
+  fun()
+
+main()

--- a/tests/stdlib/tstring.nim
+++ b/tests/stdlib/tstring.nim
@@ -1,16 +1,14 @@
 discard """
-  output: '''OK
-@[@[], @[], @[], @[], @[]]
-'''
+  targets: "c cpp js"
 """
+
 const characters = "abcdefghijklmnopqrstuvwxyz"
 const numbers = "1234567890"
-
-var s: string
 
 proc test_string_slice() =
   # test "slice of length == len(characters)":
   # replace characters completely by numbers
+  var s: string
   s = characters
   s[0..^1] = numbers
   doAssert s == numbers
@@ -51,11 +49,13 @@ proc test_string_slice() =
   s[2..0] = numbers
   doAssert s == "ab1234567890cdefghijklmnopqrstuvwxyz"
 
-  # bug #6223
-  doAssertRaises(IndexDefect):
-    discard s[0..999]
+  when nimvm:
+    discard
+  else:
+    # bug #6223
+    doAssertRaises(IndexDefect):
+      discard s[0..999]
 
-  echo("OK")
 
 proc test_string_cmp() =
   let world = "hello\0world"
@@ -76,9 +76,6 @@ proc test_string_cmp() =
   doAssert cmp(world, hello) > 0
   doAssert cmp(world, goodbye) > 0
 
-test_string_slice()
-test_string_cmp()
-
 
 #--------------------------
 # bug #7816
@@ -87,9 +84,9 @@ import sequtils
 
 proc tester[T](x: T) =
   let test = toSeq(0..4).map(i => newSeq[int]())
-  echo test
+  doAssert $test == "@[@[], @[], @[], @[], @[]]"
 
-tester(1)
+
 
 # #14497 
 func reverse*(a: string): string =
@@ -97,4 +94,13 @@ func reverse*(a: string): string =
   for i in 0 ..< a.len div 2:
     swap(result[i], result[^(i + 1)])
 
-doAssert reverse("hello") == "olleh"
+
+proc main() =
+  test_string_slice()
+  test_string_cmp()
+
+  tester(1)
+  doAssert reverse("hello") == "olleh"
+
+static: main()
+main()


### PR DESCRIPTION
fix https://github.com/timotheecour/Nim/issues/9


```nim
import std/strtabs

proc fun()=
  let ret = newStringTable(modeCaseSensitive)
  ret["foo"] = "bar"

  echo ret

  let b = ret["foo"]
  echo b

proc main()=
  static: fun()
  fun()

main()
```
- nim js -r test.nim
system/jssys.nim(319, 3) Error: cannot generate VM code for asm " if ("a