### PR TITLE
fix #16474 `unittest.check type1 is type2` gives CT error

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -670,7 +670,7 @@ macro check*(conditions: untyped): untyped =
           if exp[i].kind == nnkIdent:
             result.printOuts.add getAst(print(argStr, paramAst))
           if exp[i].kind in nnkCallKinds + {nnkDotExpr, nnkBracketExpr, nnkPar} and
-                  exp[i].typeKind notin {ntyTypeDesc}:
+                  (exp[i].typeKind notin {ntyTypeDesc} or $exp[0] notin ["is", "isnot"]):
             let callVar = newIdentNode(":c" & $counter)
             result.assigns.add getAst(asgn(callVar, paramAst))
             result.check[i] = callVar

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -669,7 +669,8 @@ macro check*(conditions: untyped): untyped =
           let paramAst = exp[i]
           if exp[i].kind == nnkIdent:
             result.printOuts.add getAst(print(argStr, paramAst))
-          if exp[i].kind in nnkCallKinds + {nnkDotExpr, nnkBracketExpr, nnkPar}:
+          if exp[i].kind in nnkCallKinds + {nnkDotExpr, nnkBracketExpr, nnkPar} and
+                  exp[i].typeKind notin {ntyTypeDesc}:
             let callVar = newIdentNode(":c" & $counter)
             result.assigns.add getAst(asgn(callVar, paramAst))
             result.check[i] = callVar

--- a/tests/stdlib/tunittestpass.nim
+++ b/tests/stdlib/tunittestpass.nim
@@ -1,0 +1,16 @@
+discard """
+  targets: "c js"
+"""
+
+
+import unittest
+
+block:
+  check (type(1.0)) is float
+  check type(1.0) is float
+  check (typeof(1)) isnot float
+  check typeof(1) isnot float
+
+  type T = type(0.1)
+  check T is float
+  check T isnot int

--- a/tests/stdlib/tunittestpass.nim
+++ b/tests/stdlib/tunittestpass.nim
@@ -11,6 +11,9 @@ block:
   check (typeof(1)) isnot float
   check typeof(1) isnot float
 
+  check 1.0 is float
+  check 1 isnot float
+
   type T = type(0.1)
   check T is float
   check T isnot int


### PR DESCRIPTION
fix #16474
fix #https://github.com/timotheecour/Nim/issues/131


fix check with pars which is a regression
```nim
when true:
  import unittest
  check (type(1.0)) is float
```

fix check without pars which is a bug
```nim
  import unittest
  check type(0.1) is float
```
