### PR TITLE
Add mimetypes.mimesLongest

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@
 - `writeStackTrace` is available in JS backend now.
 
 - `strscans.scanf` now supports parsing single characters.
-- `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`. 
+- `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`.
 
 - Added `setutils.toSet` that can take any iterable and convert it to a built-in set,
   if the iterable yields a built-in settable type.
@@ -70,11 +70,13 @@
   and `lists.toDoublyLinkedList` convert from `openArray`s; `lists.copy` implements
   shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
   its argument, `addMoved`, is also supplied.
-  
+
 - Added `sequtils` import to `prelude`.
 
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.
+
+- Added `mimetypes.mimesLongest` that returns the lenght of the longest "ext" and "mime" from `mimes`.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -76,7 +76,8 @@
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.
 
-- Added `mimetypes.mimesLongest` that returns the length of the longest "ext" and "mime" from `mimes`.
+- Added `mimetypes.mimesExtMaxLen` thats equal to the length of the longest "ext" from `mimes`.
+- Added `mimetypes.mimesMaxLen` thats equal to the length of the longest "mime" from `mimes`.
 
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -76,7 +76,7 @@
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.
 
-- Added `mimetypes.mimesLongest` that returns the lenght of the longest "ext" and "mime" from `mimes`.
+- Added `mimetypes.mimesLongest` that returns the length of the longest "ext" and "mime" from `mimes`.
 
 
 ## Language changes

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1932,10 +1932,10 @@ since (1, 5):
 
   const
     ctValue = mimesLongest() # Use 2 const instead of func, save tuple unpack.
-    extLongest*: int = ctValue[0] ## \
+    mimesExtMaxLen*: int = ctValue[0] ## \
       ## The length of the longest "ext" from `mimes`,
       ## this is useful for optimizations with `newStringOfCap` and `newString`.
-    mimeLongest*: int = ctValue[1] ## \
+    mimesMaxLen*: int = ctValue[1] ## \
       ## The length of the longest "mime" from `mimes`,
       ## this is useful for optimizations with `newStringOfCap` and `newString`.
       ##

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1917,7 +1917,7 @@ func register*(mimedb: var MimeDB, ext: string, mimetype: string) =
   {.noSideEffect.}:
     mimedb.mimes[ext.toLowerAscii()] = mimetype.toLowerAscii()
 
-func mimesLongest*(): tuple[ext: int, mime: int] {.since: (1, 5).} =
+func mimesLongest*(): tuple[ext: int, mime: int] {.compiletime, since: (1, 5).} =
   ## Returns the length of the longest "ext" and "mime" from `mimes`,
   ## this is useful for optimizations with `newStringOfCap` and `newString`.
   ##

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -8,7 +8,7 @@
 #
 
 ## This module implements a mimetypes database
-import strtabs
+import strtabs, std/private/since
 from strutils import startsWith, toLowerAscii, strip
 
 type
@@ -1916,6 +1916,24 @@ func register*(mimedb: var MimeDB, ext: string, mimetype: string) =
   assert mimetype.strip.len > 0, "mimetype argument can not be empty string"
   {.noSideEffect.}:
     mimedb.mimes[ext.toLowerAscii()] = mimetype.toLowerAscii()
+
+func mimesLongest*(): tuple[ext: int, mime: int] {.since: (1, 5).} =
+  ## Return the lenght of the longest "ext" and "mime" from `mimes`,
+  ## this is useful for optimizations with `newStringOfCap` and `newString`.
+  ##
+  ## See also:
+  ## * `newStringOfCap <system.html#newStringOfCap>`_
+  ## * `newString <system.html#newString>`_
+  runnableExamples:
+    static:
+      doAssert mimesLongest() >= (ext: 24, mime: 73)
+  var currentKeyLenght, currentValLenght: int
+  for item in mimes:
+    currentKeyLenght = item[0].len
+    currentValLenght = item[1].len
+    if currentKeyLenght > result[0]: result[0] = currentKeyLenght
+    if currentValLenght > result[1]: result[1] = currentValLenght
+
 
 runnableExamples:
   static:

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1917,22 +1917,31 @@ func register*(mimedb: var MimeDB, ext: string, mimetype: string) =
   {.noSideEffect.}:
     mimedb.mimes[ext.toLowerAscii()] = mimetype.toLowerAscii()
 
-func mimesLongest*(): tuple[ext: int, mime: int] {.compiletime, since: (1, 5).} =
-  ## Returns the length of the longest "ext" and "mime" from `mimes`,
-  ## this is useful for optimizations with `newStringOfCap` and `newString`.
-  ##
-  ## See also:
-  ## * `newStringOfCap <system.html#newStringOfCap>`_
-  ## * `newString <system.html#newString>`_
-  runnableExamples:
-    static:
-      doAssert mimesLongest() >= (ext: 24, mime: 73)
-  var currentKeyLength, currentValLength: int
-  for item in mimes:
-    currentKeyLength = item[0].len
-    currentValLength = item[1].len
-    if currentKeyLength > result[0]: result[0] = currentKeyLength
-    if currentValLength > result[1]: result[1] = currentValLength
+
+since (1, 5):
+  func mimesLongest(): array[2, int] {.compiletime.} =
+    runnableExamples:
+      static:
+        doAssert mimesLongest() >= (ext: 24, mime: 73)
+    var currentKeyLength, currentValLength: int
+    for item in mimes:
+      currentKeyLength = item[0].len
+      currentValLength = item[1].len
+      if currentKeyLength > result[0]: result[0] = currentKeyLength
+      if currentValLength > result[1]: result[1] = currentValLength
+
+  const
+    ctValue = mimesLongest() # Use 2 const instead of func, save tuple unpack.
+    extLongest*: int = ctValue[0] ## \
+      ## The length of the longest "ext" from `mimes`,
+      ## this is useful for optimizations with `newStringOfCap` and `newString`.
+    mimeLongest*: int = ctValue[1] ## \
+      ## The length of the longest "mime" from `mimes`,
+      ## this is useful for optimizations with `newStringOfCap` and `newString`.
+      ##
+      ## See also:
+      ## * `newStringOfCap <system.html#newStringOfCap>`_
+      ## * `newString <system.html#newString>`_
 
 
 runnableExamples:

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1918,7 +1918,7 @@ func register*(mimedb: var MimeDB, ext: string, mimetype: string) =
     mimedb.mimes[ext.toLowerAscii()] = mimetype.toLowerAscii()
 
 func mimesLongest*(): tuple[ext: int, mime: int] {.since: (1, 5).} =
-  ## Return the length of the longest "ext" and "mime" from `mimes`,
+  ## Returns the length of the longest "ext" and "mime" from `mimes`,
   ## this is useful for optimizations with `newStringOfCap` and `newString`.
   ##
   ## See also:

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -1918,7 +1918,7 @@ func register*(mimedb: var MimeDB, ext: string, mimetype: string) =
     mimedb.mimes[ext.toLowerAscii()] = mimetype.toLowerAscii()
 
 func mimesLongest*(): tuple[ext: int, mime: int] {.since: (1, 5).} =
-  ## Return the lenght of the longest "ext" and "mime" from `mimes`,
+  ## Return the length of the longest "ext" and "mime" from `mimes`,
   ## this is useful for optimizations with `newStringOfCap` and `newString`.
   ##
   ## See also:
@@ -1927,12 +1927,12 @@ func mimesLongest*(): tuple[ext: int, mime: int] {.since: (1, 5).} =
   runnableExamples:
     static:
       doAssert mimesLongest() >= (ext: 24, mime: 73)
-  var currentKeyLenght, currentValLenght: int
+  var currentKeyLength, currentValLength: int
   for item in mimes:
-    currentKeyLenght = item[0].len
-    currentValLenght = item[1].len
-    if currentKeyLenght > result[0]: result[0] = currentKeyLenght
-    if currentValLenght > result[1]: result[1] = currentValLenght
+    currentKeyLength = item[0].len
+    currentValLength = item[1].len
+    if currentKeyLength > result[0]: result[0] = currentKeyLength
+    if currentValLength > result[1]: result[1] = currentValLength
 
 
 runnableExamples:


### PR DESCRIPTION
- Add `mimetypes.mimesLongest` that return the length of the longest "ext" and "mime" from `mimes` database,
  this is useful for optimizations with `newStringOfCap` and `newString`.
- If you use it, all your `mimetypes` stuff can reduce allocs. Nothing changes if you do not use it.
- Changelog, since, doc with links, `runnableExamples` with `doAssert`, `strictFuncs` OK, etc.

```nim
const capForString: tuple[ext: int, mime: int] = mimesLongest()  # Use for newStringOfCap()
```
