### PR TITLE
fix `nim secret` dots interfering with prompt

### DIFF
--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -191,6 +191,8 @@ proc fillToken(L: var Token) =
 
 proc openLexer*(lex: var Lexer, fileIdx: FileIndex, inputstream: PLLStream;
                  cache: IdentCache; config: ConfigRef) =
+  # flushDot(config, stderr)
+  # s.onPrompt()
   openBaseLexer(lex, inputstream)
   lex.fileIdx = fileIdx
   lex.indentAhead = -1

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -191,8 +191,6 @@ proc fillToken(L: var Token) =
 
 proc openLexer*(lex: var Lexer, fileIdx: FileIndex, inputstream: PLLStream;
                  cache: IdentCache; config: ConfigRef) =
-  # flushDot(config, stderr)
-  # s.onPrompt()
   openBaseLexer(lex, inputstream)
   lex.fileIdx = fileIdx
   lex.indentAhead = -1

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -32,6 +32,7 @@ type
     rd*, wr*: int             # for string streams
     lineOffset*: int          # for fake stdin line numbers
     repl*: TLLRepl            # gives stdin control to clients
+    onPrompt*: proc() {.closure.}
 
   PLLStream* = ref TLLStream
 
@@ -110,6 +111,8 @@ proc llReadFromStdin(s: PLLStream, buf: pointer, bufLen: int): int =
   s.rd = 0
   var line = newStringOfCap(120)
   var triples = 0
+  # write(stdout, "\n")
+  # doAssert false
   while readLineFromStdin(if s.s.len == 0: ">>> " else: "... ", line):
     s.s.add(line)
     s.s.add("\n")
@@ -133,6 +136,7 @@ proc llStreamRead*(s: PLLStream, buf: pointer, bufLen: int): int =
   of llsFile:
     result = readBuffer(s.f, buf, bufLen)
   of llsStdIn:
+    if s.onPrompt!=nil: s.onPrompt()
     result = s.repl(s, buf, bufLen)
 
 proc llStreamReadLine*(s: PLLStream, line: var string): bool =

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -138,11 +138,7 @@ proc commandInteractive(graph: ModuleGraph) =
     var m = graph.makeStdinModule()
     incl(m.flags, sfMainModule)
     var idgen = IdGenerator(module: m.itemId.module, item: m.itemId.item)
-    # flushDot(graph.config, stdout)
-    # flushDot(graph.config, stderr)
-    let s = llStreamOpenStdIn()
-    s.onPrompt = proc() =
-      flushDot(graph.config, stderr)
+    let s = llStreamOpenStdIn(onPrompt = proc() = flushDot(graph.config, stderr))
     processModule(graph, m, idgen, s)
 
 proc commandScan(cache: IdentCache, config: ConfigRef) =

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -138,7 +138,12 @@ proc commandInteractive(graph: ModuleGraph) =
     var m = graph.makeStdinModule()
     incl(m.flags, sfMainModule)
     var idgen = IdGenerator(module: m.itemId.module, item: m.itemId.item)
-    processModule(graph, m, idgen, llStreamOpenStdIn())
+    # flushDot(graph.config, stdout)
+    # flushDot(graph.config, stderr)
+    let s = llStreamOpenStdIn()
+    s.onPrompt = proc() =
+      flushDot(graph.config, stderr)
+    processModule(graph, m, idgen, s)
 
 proc commandScan(cache: IdentCache, config: ConfigRef) =
   var f = addFileExt(AbsoluteFile mainCommandArg(config), NimExt)

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -19,9 +19,9 @@ template instLoc(): InstantiationInfo = instantiationInfo(-2, fullPaths = true)
 template toStdOrrKind(stdOrr): untyped =
   if stdOrr == stdout: stdOrrStdout else: stdOrrStderr
 
-template flushDot(conf, stdOrr) =
+template flushDot*(conf, stdOrr) =
   ## safe to call multiple times
-  let stdOrrKind = stdOrr.toStdOrrKind()
+  let stdOrrKind = toStdOrrKind(stdOrr)
   if stdOrrKind in conf.lastMsgWasDot:
     conf.lastMsgWasDot.excl stdOrrKind
     write(stdOrr, "\n")


### PR DESCRIPTION
fixes what https://github.com/nim-lang/Nim/pull/16478 was attempting to fix


after PR:
```
XDG_CONFIG_HOME= $nimb secret
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/nim.cfg' [Conf]
Hint: used config file '/Users/timothee/git_clone/nim/Nim_prs/config/config.nims' [Conf]
.....
>>> discard
>>> echo 1
1
>>> import strutils
.........
>>>
```

and doesn't have the issues mentioned in https://github.com/nim-lang/Nim/pull/16478#issuecomment-751450508

## links
* https://github.com/nim-lang/Nim/pull/14418 which introduced dots
* https://github.com/nim-lang/Nim/issues/16334 which is an issue caused by dots that was recently fixed, see https://github.com/nim-lang/Nim/pull/16335
