### PR TITLE
RST: fix directive with fields (#16490)

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1737,7 +1737,8 @@ proc parseDirective(p: var RstParser, flags: DirFlags,
   ##
   ## .. warning:: Any of the 3 children may be nil.
   result = parseDirective(p, flags)
-  if not isNil(contentParser):
+  if not isNil(contentParser) and
+      (currentTok(p).kind != tkIndent or indFollows(p)):
     var nextIndent = p.tok[tokenAfterNewline(p)-1].ival
     if nextIndent <= currInd(p):  # parse only this line
       nextIndent = currentTok(p).col

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -535,6 +535,17 @@ Test1
     doAssert count(output1, "<ul ") == 1
     doAssert count(output1, "</ul>") == 1
 
+  test "Nim (RST extension) code-block":
+    # check that presence of fields doesn't consume the following text as
+    # its code (whic is a literal block)
+    let input0 = dedent """
+      .. code-block:: nim
+         :number-lines: 0
+
+      Paragraph1"""
+    let output0 = rstToHtml(input0, {roSupportMarkdown}, defaultConfig())
+    doAssert "<p>Paragraph1</p>" in output0
+
   test "RST admonitions":
     # check that all admonitions are implemented
     let input0 = dedent """

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -537,7 +537,7 @@ Test1
 
   test "Nim (RST extension) code-block":
     # check that presence of fields doesn't consume the following text as
-    # its code (whic is a literal block)
+    # its code (which is a literal block)
     let input0 = dedent """
       .. code-block:: nim
          :number-lines: 0


### PR DESCRIPTION
After #16438 RST directives with arguments are broken, they may consume all the text after them.

E.g. nim manual is absent after this code-block:
```
.. code-block:: nim
   :file: keywords.txt
```

This is because parseLiteralBlock does not check current indentation, instead it just expects to be started at some place and continue parsing while indentation ≥ initial place. There was the check that indentation is suitable for that after parsing directive arguments, but I removed it in #16438 because the check got in a way for parsing other directives like this:

```
.. note:: Text of section without any arguments.
```

This commit adds another check that works for both cases.

EDIT: fixes #16490