### PR TITLE
fix `hintProcessing` dots interference with `static:echo` and `hintCC`; add tests for `nim secret`, add tests for hintProcessing, misc other bug fixes

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -848,7 +848,10 @@ proc callCCompiler*(conf: ConfigRef) =
   var cmds: TStringSeq
   var prettyCmds: TStringSeq
   let prettyCb = proc (idx: int) =
-    if prettyCmds[idx].len > 0: echo prettyCmds[idx]
+    if prettyCmds[idx].len > 0:
+      flushDot(conf)
+      # xxx should probably use stderr like other compiler messages, not stdout
+      echo prettyCmds[idx]
 
   for idx, it in conf.toCompile:
     # call the C compiler for the .c file:

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -78,7 +78,7 @@ when not declared(readLineFromStdin):
     stdout.write(prompt)
     result = readLine(stdin, line)
     if not result:
-      stderr.write("\n")
+      stdout.write("\n")
       quit(0)
 
 proc endsWith*(x: string, s: set[char]): bool =

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -75,7 +75,7 @@ proc llStreamClose*(s: PLLStream) =
 when not declared(readLineFromStdin):
   # fallback implementation:
   proc readLineFromStdin(prompt: string, line: var string): bool =
-    stderr.write(prompt)
+    stdout.write(prompt)
     result = readLine(stdin, line)
     if not result:
       stderr.write("\n")

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -138,7 +138,7 @@ proc commandInteractive(graph: ModuleGraph) =
     var m = graph.makeStdinModule()
     incl(m.flags, sfMainModule)
     var idgen = IdGenerator(module: m.itemId.module, item: m.itemId.item)
-    let s = llStreamOpenStdIn(onPrompt = proc() = flushDot(graph.config, stderr))
+    let s = llStreamOpenStdIn(onPrompt = proc() = flushDot(graph.config))
     processModule(graph, m, idgen, s)
 
 proc commandScan(cache: IdentCache, config: ConfigRef) =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -19,8 +19,10 @@ template instLoc(): InstantiationInfo = instantiationInfo(-2, fullPaths = true)
 template toStdOrrKind(stdOrr): untyped =
   if stdOrr == stdout: stdOrrStdout else: stdOrrStderr
 
-template flushDot*(conf, stdOrr) =
+proc flushDot*(conf: ConfigRef) =
   ## safe to call multiple times
+  # xxx one edge case not yet handled is when `printf` is called at CT with `compiletimeFFI`.
+  let stdOrr = if optStdout in conf.globalOptions: stdout else: stderr
   let stdOrrKind = toStdOrrKind(stdOrr)
   if stdOrrKind in conf.lastMsgWasDot:
     conf.lastMsgWasDot.excl stdOrrKind
@@ -311,12 +313,12 @@ proc msgWriteln*(conf: ConfigRef; s: string, flags: MsgFlags = {}) =
     conf.writelnHook(s)
   elif optStdout in conf.globalOptions or msgStdout in flags:
     if eStdOut in conf.m.errorOutputs:
-      flushDot(conf, stdout)
+      flushDot(conf)
       writeLine(stdout, s)
       flushFile(stdout)
   else:
     if eStdErr in conf.m.errorOutputs:
-      flushDot(conf, stderr)
+      flushDot(conf)
       writeLine(stderr, s)
       # On Windows stderr is fully-buffered when piped, regardless of C std.
       when defined(windows):
@@ -368,11 +370,11 @@ template styledMsgWriteln*(args: varargs[typed]) =
     callIgnoringStyle(callWritelnHook, nil, args)
   elif optStdout in conf.globalOptions:
     if eStdOut in conf.m.errorOutputs:
-      flushDot(conf, stdout)
+      flushDot(conf)
       callIgnoringStyle(writeLine, stdout, args)
       flushFile(stdout)
   elif eStdErr in conf.m.errorOutputs:
-    flushDot(conf, stderr)
+    flushDot(conf)
     if optUseColors in conf.globalOptions:
       callStyledWriteLineStderr(args)
     else:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -367,8 +367,11 @@ proc setNote*(conf: ConfigRef, note: TNoteKind, enabled = true) =
     if enabled: incl(conf.notes, note) else: excl(conf.notes, note)
 
 proc hasHint*(conf: ConfigRef, note: TNoteKind): bool =
+  # ternary states instead of binary states would simplify logic
   if optHints notin conf.options: false
-  elif note in {hintConf}: # could add here other special notes like hintSource
+  elif note in {hintConf, hintProcessing}:
+    # could add here other special notes like hintSource
+    # these notes apply globally.
     note in conf.mainPackageNotes
   else: note in conf.notes
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1153,9 +1153,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         stackTrace(c, tos, pc, "node is not a proc symbol")
     of opcEcho:
       let rb = instr.regB
-      template fn(s) =
-        flushDot(c.config, stderr)
-        msgWriteln(c.config, s, {msgStdout})
+      template fn(s) = msgWriteln(c.config, s, {msgStdout})
       if rb == 1: fn(regs[ra].node.strVal)
       else:
         var outp = ""

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1153,14 +1153,16 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         stackTrace(c, tos, pc, "node is not a proc symbol")
     of opcEcho:
       let rb = instr.regB
-      if rb == 1:
-        msgWriteln(c.config, regs[ra].node.strVal, {msgStdout})
+      template fn(s) =
+        flushDot(c.config, stderr)
+        msgWriteln(c.config, s, {msgStdout})
+      if rb == 1: fn(regs[ra].node.strVal)
       else:
         var outp = ""
         for i in ra..ra+rb-1:
           #if regs[i].kind != rkNode: debug regs[i]
           outp.add(regs[i].node.strVal)
-        msgWriteln(c.config, outp, {msgStdout})
+        fn(outp)
     of opcContainsSet:
       decodeBC(rkInt)
       regs[ra].intVal = ord(inSet(regs[rb].node, regs[rc].regToNode))

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -222,3 +222,8 @@ mmain.html
     check fmt"""{nim} {opt} --eval:"echo defined(nimscript)"""".execCmdEx == ("true\n", 0)
     check fmt"""{nim} r {opt} --eval:"echo defined(c)"""".execCmdEx == ("true\n", 0)
     check fmt"""{nim} r -b:js {opt} --eval:"echo defined(js)"""".execCmdEx == ("true\n", 0)
+
+  block: # nim secret
+    let opt = "--hints:off"
+    let (out, status) = fmt"""{nim} {opt} secret""".execCmdEx(input = "echo 1+2")
+    echo (out, status)

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -12,8 +12,7 @@ from std/sequtils import toSeq,mapIt
 from std/algorithm import sorted
 import stdtest/[specialpaths, unittest_light]
 from std/private/globs import nativeToUnixPath
-# from strutils import startsWith, strip
-from strutils import startsWith, strip, indent
+from strutils import startsWith, strip
 import "$lib/../compiler/nimpaths"
 
 proc isDots(a: string): bool =

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -98,10 +98,9 @@ else: # don't run twice the same test
       check exitCode == 0
       let ret = toSeq(walkDirRec(htmldocsDir, relative=true)).mapIt(it.nativeToUnixPath).sorted.join("\n")
       let context = $(i, ret, cmd)
-      var expected = ""
       case i
       of 0,5:
-        let htmlFile = htmldocsDir/"mmain.html"
+        let htmlFile = htmldocsDir/mainFname
         check htmlFile in outp # sanity check for `hintSuccessX`
         assertEquals ret, fmt"""
 {dotdotMangle}/imp.html
@@ -111,7 +110,7 @@ imp.html
 imp.idx
 imp2.html
 imp2.idx
-mmain.html
+{mainFname}
 mmain.idx
 {nimdocOutCss}
 {theindexFname}""", context
@@ -124,21 +123,21 @@ tests/nimdoc/sub/imp.html
 tests/nimdoc/sub/imp.idx
 tests/nimdoc/sub/imp2.html
 tests/nimdoc/sub/imp2.idx
-tests/nimdoc/sub/mmain.html
+tests/nimdoc/sub/{mainFname}
 tests/nimdoc/sub/mmain.idx
 {theindexFname}"""
       of 2, 3: assertEquals ret, fmt"""
 {docHackJsFname}
-mmain.html
+{mainFname}
 mmain.idx
 {nimdocOutCss}""", context
       of 4: assertEquals ret, fmt"""
 {docHackJsFname}
 {nimdocOutCss}
-sub/mmain.html
+sub/{mainFname}
 sub/mmain.idx""", context
       of 6: assertEquals ret, fmt"""
-mmain.html
+{mainFname}
 {nimdocOutCss}""", context
       else: doAssert false
 
@@ -228,37 +227,36 @@ mmain.html
     check fmt"""{nim} r {opt} --eval:"echo defined(c)"""".execCmdEx == ("true\n", 0)
     check fmt"""{nim} r -b:js {opt} --eval:"echo defined(js)"""".execCmdEx == ("true\n", 0)
 
-  block: # `hintProcessing` dots should not interfere with echo + friends
-    # import osproc,strformat, os, strutils
+  block: # `hintProcessing` dots should not interfere with `static: echo` + friends
     # pending https://github.com/timotheecour/Nim/issues/453, simplify to:
     # `--hints:off --hint:processing`
     let cmd = fmt"""{nim} r --hint:successx:off --hint:Exec:off --hint:Link:off --hint:CC:off --hint:Conf:off --hint:processing -f --eval:"static: echo 1+1""""
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
     doAssert exitCode == 0
     let lines = outp.splitLines
-    doAssert lines.len == 3, outp.indent(2)
-    # doAssert lines.len == 3, $(outp,)
+    doAssert lines.len == 3, $(outp,)
     doAssert lines[0].isDots
     doAssert lines[1] == "2"
     doAssert lines[2] == ""
 
   block: # nim secret
     let opt = "--hint:processing:on --hint:QuitCalled:off --hint:Conf:off"
-    let cmd = fmt"""{nim} secret {opt}"""
-    # xxx minor bug: `nim --hint:QuitCalled:off secret` ignores the hint cmdline flag
-    template run(input2): untyped =
-      execCmdEx(cmd, options = {poStdErrToStdOut}, input = input2)
-    block:
-      let (outp, exitCode) = run "echo 1+2; import strutils; echo strip(\" ab \"); quit()"
-      let lines = outp.splitLines
-      doAssert lines.len == 5, $outp
-      doAssert lines[0].isDots
-      doAssert lines[1] == "3"
-      doAssert lines[2].isDots
-      doAssert lines[3] == "ab"
-      doAssert lines[4] == ""
-      doAssert exitCode == 0
-    block:
-      let (outp, exitCode) = run "echo 1+2; quit(2)"
-      doAssert "3" in outp
-      doAssert exitCode == 2
+    for extra in ["", "--stdout"]:
+      let cmd = fmt"""{nim} secret {opt} {extra}"""
+      # xxx minor bug: `nim --hint:QuitCalled:off secret` ignores the hint cmdline flag
+      template run(input2): untyped =
+        execCmdEx(cmd, options = {poStdErrToStdOut}, input = input2)
+      block:
+        let (outp, exitCode) = run """echo 1+2; import strutils; echo strip(" ab "); quit()"""
+        let lines = outp.splitLines
+        doAssert lines.len == 5, $(outp,)
+        doAssert lines[0].isDots
+        doAssert lines[1] == "3"
+        doAssert lines[2].isDots
+        doAssert lines[3] == "ab"
+        doAssert lines[4] == ""
+        doAssert exitCode == 0
+      block:
+        let (outp, exitCode) = run "echo 1+2; quit(2)"
+        doAssert "3" in outp
+        doAssert exitCode == 2

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -237,9 +237,12 @@ sub/mmain.idx""", context
     doAssert exitCode == 0
     let lines = outp.splitLines
     check3 lines.len == 3
-    check3 lines[0].isDots
-    check3 lines[1] == "2"
-    check3 lines[2] == ""
+    when not defined(windows): # xxx: on windows, dots not properly handled, gives: `....2\n\n`
+      check3 lines[0].isDots
+      check3 lines[1] == "2"
+      check3 lines[2] == ""
+    else:
+      check3 "2" in outp
 
   block: # nim secret
     let opt = fmt"{defaultHintsOff} --hint:processing"
@@ -252,12 +255,16 @@ sub/mmain.idx""", context
       block:
         let (outp, exitCode) = run """echo 1+2; import strutils; echo strip(" ab "); quit()"""
         let lines = outp.splitLines
-        check3 lines.len == 5
-        check3 lines[0].isDots
-        check3 lines[1].dup(removePrefix(">>> ")) == "3" # prompt depends on `nimUseLinenoise`
-        check3 lines[2].isDots
-        check3 lines[3] == "ab"
-        check3 lines[4] == ""
+        when not defined(windows):
+          check3 lines.len == 5
+          check3 lines[0].isDots
+          check3 lines[1].dup(removePrefix(">>> ")) == "3" # prompt depends on `nimUseLinenoise`
+          check3 lines[2].isDots
+          check3 lines[3] == "ab"
+          check3 lines[4] == ""
+        else:
+          check3 "3" in outp
+          check3 "ab" in outp
         doAssert exitCode == 0
       block:
         let (outp, exitCode) = run "echo 1+2; quit(2)"

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -227,20 +227,23 @@ sub/mmain.idx""", context
     check fmt"""{nim} r {opt} --eval:"echo defined(c)"""".execCmdEx == ("true\n", 0)
     check fmt"""{nim} r -b:js {opt} --eval:"echo defined(js)"""".execCmdEx == ("true\n", 0)
 
-  block: # `hintProcessing` dots should not interfere with `static: echo` + friends
+  # const defaultHintsOff = "--hint:successx:off --hint:Exec:off --hint:Link:off --hint:CC:off --hint:Conf:off --hint:processing"
     # pending https://github.com/timotheecour/Nim/issues/453, simplify to:
     # `--hints:off --hint:processing`
+  block: # `hintProcessing` dots should not interfere with `static: echo` + friends
     let cmd = fmt"""{nim} r --hint:successx:off --hint:Exec:off --hint:Link:off --hint:CC:off --hint:Conf:off --hint:processing -f --eval:"static: echo 1+1""""
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
+    template check3(cond) = doAssert cond, $(outp,)
     doAssert exitCode == 0
     let lines = outp.splitLines
-    doAssert lines.len == 3, $(outp,)
-    doAssert lines[0].isDots
-    doAssert lines[1] == "2"
-    doAssert lines[2] == ""
+    check3 lines.len == 3
+    check3 lines[0].isDots
+    check3 lines[1] == "2"
+    check3 lines[2] == ""
 
   block: # nim secret
     let opt = "--hint:processing:on --hint:QuitCalled:off --hint:Conf:off"
+    template check3(cond) = doAssert cond, $(outp,)
     for extra in ["", "--stdout"]:
       let cmd = fmt"""{nim} secret {opt} {extra}"""
       # xxx minor bug: `nim --hint:QuitCalled:off secret` ignores the hint cmdline flag
@@ -249,14 +252,14 @@ sub/mmain.idx""", context
       block:
         let (outp, exitCode) = run """echo 1+2; import strutils; echo strip(" ab "); quit()"""
         let lines = outp.splitLines
-        doAssert lines.len == 5, $(outp,)
-        doAssert lines[0].isDots
-        doAssert lines[1] == "3"
-        doAssert lines[2].isDots
-        doAssert lines[3] == "ab"
-        doAssert lines[4] == ""
+        check3 lines.len == 5
+        check3 lines[0].isDots
+        check3 lines[1] == "3"
+        check3 lines[2].isDots
+        check3 lines[3] == "ab"
+        check3 lines[4] == ""
         doAssert exitCode == 0
       block:
         let (outp, exitCode) = run "echo 1+2; quit(2)"
-        doAssert "3" in outp
+        check3 "3" in outp
         doAssert exitCode == 2


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/pull/16491#issuecomment-751682492 `hintProcessing` dots interfering with `static: echo`
> This maybe solves it for nim secret, but it is not the only instance where the stuff is printed on the same line as dots.

  the logic in PR now also works with `--stdout` (see tests)

* fix `hintProcessing` dots interfering with hintCC (CC: ....)

* add basic tests for `nim secret` refs https://github.com/nim-lang/Nim/pull/16478#issuecomment-751453622

* adds tests for `hintProcessing` in particular the fact that dots (after this PR) don't interfere with for example `static: echo`

* make trunner warning free

* `--hint:processing` is now overridable, like other hints (eg --hint:link:off ... --hint:link` would end up with `--hint:link`; this is useful when assembling cmdlines, in fact i hit this bug while writing a test in trunner)

* fix bug: `readLineFromStdin` fallback now writes prompt to stdout, consistent with linenoise and rdstdin

## future work
- [ ] I disabled a line of test for windows, pre-existing issue that can be fixed later: on windows, 
`nim r --hint:processing -f --eval:"static: echo 1+1”` now works without dot interference when running  in cmd.exe, but still fails if shelling out via `execCmdEx` (refs https://github.com/xflywind/Nim/issues/15 problem 4)