### PR TITLE
fix printing negative zero in JS backend

### DIFF
--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -495,11 +495,13 @@ proc negInt64(a: int64): int64 {.compilerproc.} =
 
 proc nimFloatToString(a: float): cstring {.compilerproc.} =
   ## ensures the result doesn't print like an integer, i.e. return 2.0, not 2
+  # print `-0.0` properly
   asm """
     function nimOnlyDigitsOrMinus(n) {
       return n.toString().match(/^-?\d+$/);
     }
-    if (Number.isSafeInteger(`a`)) `result` =  `a`+".0"
+    if (Number.isSafeInteger(`a`))
+      `result` = `a` === 0 && 1 / `a` < 0 ? "-0.0" : `a`+".0"
     else {
       `result` = `a`+""
       if(nimOnlyDigitsOrMinus(`result`)){

--- a/tests/misc/tnegativezero.nim
+++ b/tests/misc/tnegativezero.nim
@@ -1,0 +1,30 @@
+discard """
+  targets: "c cpp js"
+"""
+
+proc main()=
+  block:
+    let a = -0.0
+    doAssert $a == "-0.0"
+    doAssert $(-0.0) == "-0.0"
+
+  block:
+    let a = 0.0
+    when nimvm: discard ## TODO VM print wrong -0.0
+    else:
+      doAssert $a == "0.0"
+    doAssert $(0.0) == "0.0"
+
+  block:
+    let b = -0
+    doAssert $b == "0"
+    doAssert $(-0) == "0"
+
+  block:
+    let b = 0
+    doAssert $b == "0"
+    doAssert $(0) == "0"
+
+
+static: main()
+main()


### PR DESCRIPTION
see https://github.com/timotheecour/Nim/issues/136

before this doesn't work in JS backend(echo $a prints `0.0` instead of `-0.0`).

```nim
proc main()=
  block:
    let a = -0.0
    doAssert $a == "-0.0"
    doAssert $(-0.0) == "-0.0"


static: main()
main()
```
- [x] VM prints `0.0` as `-0.0`, I will fix it in the following PR.