### PR TITLE
fix #16502

### DIFF
--- a/lib/system/io.nim
+++ b/lib/system/io.nim
@@ -783,7 +783,7 @@ when declared(stdout):
                      not defined(nintendoswitch) and not defined(freertos) and
                      hostOS != "any"
 
-  const echoDoRaise = not defined(nimLegacyEchoNoRaise) # see PR #16366
+  const echoDoRaise = not defined(nimLegacyEchoNoRaise) and not defined(guiapp) # see PR #16366
 
   template checkErrMaybe(succeeded: bool): untyped =
     if not succeeded:


### PR DESCRIPTION
see https://github.com/nim-lang/Nim/pull/16367
and https://github.com/nim-lang/Nim/issues/16502

After this PR:
`echo` is ignored silently as before.