### PR TITLE
Algorithm improvements

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -47,7 +47,7 @@ type
     Descending, Ascending
 
 proc `*`*(x: int, order: SortOrder): int {.inline.} =
-  ## Flip `x` if `order == Descending`.
+  ## Flips the sign of `x` if `order == Descending`.
   ## If `order == Ascending` then `x` is returned.
   ##
   ## `x` is supposed to be the result of a comparator, i.e.
@@ -69,9 +69,9 @@ template fillImpl[T](a: var openArray[T], first, last: int, value: T) =
     inc(x)
 
 proc fill*[T](a: var openArray[T], first, last: Natural, value: T) =
-  ## Fill the slice `a[first..last]` with `value`.
+  ## Assigns `value` to all elements of the slice `a[first..last]`.
   ##
-  ## If an invalid range is passed, it raises IndexDefect.
+  ## If an invalid range is passed, it raises `IndexDefect`.
   runnableExamples:
     var a: array[6, int]
     a.fill(1, 3, 9)
@@ -82,7 +82,7 @@ proc fill*[T](a: var openArray[T], first, last: Natural, value: T) =
   fillImpl(a, first, last, value)
 
 proc fill*[T](a: var openArray[T], value: T) =
-  ## Fill the container `a` with `value`.
+  ## Assigns `value` to all elements of the container `a`.
   runnableExamples:
     var a: array[6, int]
     a.fill(9)
@@ -93,13 +93,13 @@ proc fill*[T](a: var openArray[T], value: T) =
 
 
 proc reverse*[T](a: var openArray[T], first, last: Natural) =
-  ## Reverse the slice `a[first..last]`.
+  ## Reverses the slice `a[first..last]`.
   ##
-  ## If an invalid range is passed, it raises IndexDefect.
+  ## If an invalid range is passed, it raises `IndexDefect`.
   ##
   ## **See also:**
-  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and return a `seq[T]`
-  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and return a `seq[T]`
+  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and returns a `seq[T]`
+  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and returns a `seq[T]`
   runnableExamples:
     var a = [1, 2, 3, 4, 5, 6]
     a.reverse(1, 3)
@@ -115,11 +115,11 @@ proc reverse*[T](a: var openArray[T], first, last: Natural) =
     inc(x)
 
 proc reverse*[T](a: var openArray[T]) =
-  ## Reverse the contents of the container `a`.
+  ## Reverses the contents of the container `a`.
   ##
   ## **See also:**
-  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and return a `seq[T]`
-  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and return a `seq[T]`
+  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and returns a `seq[T]`
+  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and returns a `seq[T]`
   runnableExamples:
     var a = [1, 2, 3, 4, 5, 6]
     a.reverse()
@@ -130,9 +130,9 @@ proc reverse*[T](a: var openArray[T]) =
   reverse(a, 0, max(0, a.high))
 
 proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
-  ## Return the reverse of the slice `a[first..last]`.
+  ## Returns the reverse of the slice `a[first..last]`.
   ##
-  ## If an invalid range is passed, it raises IndexDefect.
+  ## If an invalid range is passed, it raises `IndexDefect`.
   ##
   ## **See also:**
   ## * `reverse proc<#reverse,openArray[T],Natural,Natural>`_ reverse a slice
@@ -152,7 +152,7 @@ proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
     inc(x)
 
 proc reversed*[T](a: openArray[T]): seq[T] =
-  ## Return the reverse of the container `a`.
+  ## Returns the reverse of the container `a`.
   ##
   ## **See also:**
   ## * `reverse proc<#reverse,openArray[T],Natural,Natural>`_ reverse a slice
@@ -228,14 +228,14 @@ const
 
 proc lowerBound*[T, K](a: openArray[T], key: K,
                        cmp: proc(x: T, k: K): int {.closure.}): int =
-  ## Return the index of the first element in `a` that is not less than
+  ## Returns the index of the first element in `a` that is not less than
   ## (i.e. greater or equal to) `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
   ## `insert(thing, elm, lowerBound(thing, elm))`
   ## the sequence will still be sorted.
   ## Assumes that `a` is sorted according to `cmp`.
   ##
-  ## If an invalid range is passed, it raises IndexDefect.
+  ## If an invalid range is passed, it raises `IndexDefect`.
   ##
   ## This version uses `cmp` to compare the elements.
   ## The expected return values are the same as those of `system.cmp`.
@@ -263,7 +263,7 @@ proc lowerBound*[T, K](a: openArray[T], key: K,
       count = step
 
 proc lowerBound*[T](a: openArray[T], key: T): int = lowerBound(a, key, cmp[T])
-  ## Return the index of the first element in `a` that is not less than
+  ## Returns the index of the first element in `a` that is not less than
   ## (i.e. greater or equal to) `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
   ## `insert(thing, elm, lowerBound(thing, elm))`
@@ -278,14 +278,14 @@ proc lowerBound*[T](a: openArray[T], key: T): int = lowerBound(a, key, cmp[T])
 
 proc upperBound*[T, K](a: openArray[T], key: K,
                        cmp: proc(x: T, k: K): int {.closure.}): int =
-  ## Return the index of the first element in `a` that is greater than
+  ## Returns the index of the first element in `a` that is greater than
   ## `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
   ## `insert(thing, elm, upperBound(thing, elm))`
   ## the sequence will still be sorted.
   ## Assumes that `a` is sorted according to `cmp`.
   ##
-  ## If an invalid range is passed, it raises IndexDefect.
+  ## If an invalid range is passed, it raises `IndexDefect`.
   ##
   ## This version uses `cmp` to compare the elements. The expected
   ## return values are the same as those of `system.cmp`.
@@ -313,7 +313,7 @@ proc upperBound*[T, K](a: openArray[T], key: K,
       count = step
 
 proc upperBound*[T](a: openArray[T], key: T): int = upperBound(a, key, cmp[T])
-  ## Return the index of the first element in `a` that is greater than
+  ## Returns the index of the first element in `a` that is greater than
   ## `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
   ## `insert(thing, elm, upperBound(thing, elm))`
@@ -377,8 +377,9 @@ func sort*[T](a: var openArray[T],
               cmp: proc (x, y: T): int {.closure.},
               order = SortOrder.Ascending) =
   ## Default Nim sort (an implementation of merge sort). The sorting
-  ## is guaranteed to be stable and the worst case is guaranteed to
-  ## be O(n log n).
+  ## is guaranteed to be stable (that is, equal elements stay in the same order)
+  ## and the worst case is guaranteed to be O(n log n).
+  ## Sorts by `cmp` in the specified `order`.
   ##
   ## The current implementation uses an iterative
   ## mergesort to achieve this. It uses a temporary sequence of
@@ -437,7 +438,7 @@ proc sort*[T](a: var openArray[T], order = SortOrder.Ascending) = sort[T](a,
 
 proc sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.},
                 order = SortOrder.Ascending): seq[T] =
-  ## Return `a` sorted by `cmp` in the specified `order`.
+  ## Returns `a` sorted by `cmp` in the specified `order`.
   ##
   ## **See also:**
   ## * `sort func<#sort,openArray[T],proc(T,T)>`_
@@ -481,7 +482,7 @@ template sortedByIt*(seq1, op: untyped): untyped =
   ## The template injects the `it` variable which you can use directly in an
   ## expression.
   ##
-  ## Because the underlying `cmp()` is defined for tuples you can do
+  ## Because the underlying `cmp()` is defined for tuples you can also do
   ## a nested sort.
   ##
   ## **See also:**
@@ -514,7 +515,7 @@ template sortedByIt*(seq1, op: untyped): untyped =
 func isSorted*[T](a: openArray[T],
                  cmp: proc(x, y: T): int {.closure.},
                  order = SortOrder.Ascending): bool =
-  ## Check to see whether `a` is already sorted in `order`
+  ## Checks to see whether `a` is already sorted in `order`
   ## using `cmp` for the comparison. The parameters are identical
   ## to `sort`. Requires O(n) time.
   ##
@@ -559,7 +560,9 @@ proc isSorted*[T](a: openArray[T], order = SortOrder.Ascending): bool =
   isSorted(a, system.cmp[T], order)
 
 proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
-  ## Produce the Cartesian product of the array.
+  ## Produces the Cartesian product of the array.
+  ## Every element of the result is a combination of one element from each seq in `x`,
+  ## with the ith element coming from `x[i]`.
   ## Warning: complexity may explode.
   runnableExamples:
     assert product(@[@[1], @[2]]) == @[@[1, 2]]
@@ -592,7 +595,7 @@ proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
     indices[index] -= 1
 
 proc nextPermutation*[T](x: var openArray[T]): bool {.discardable.} =
-  ## Calculate the next lexicographic permutation, directly modifying `x`.
+  ## Calculates the next lexicographic permutation, directly modifying `x`.
   ## The result is whether a permutation happened, otherwise we have reached
   ## the last-ordered permutation.
   ##
@@ -632,7 +635,7 @@ proc nextPermutation*[T](x: var openArray[T]): bool {.discardable.} =
   result = true
 
 proc prevPermutation*[T](x: var openArray[T]): bool {.discardable.} =
-  ## Calculate the previous lexicographic permutation, directly modifying
+  ## Calculates the previous lexicographic permutation, directly modifying
   ## `x`. The result is whether a permutation happened, otherwise we have
   ## reached the first-ordered permutation.
   ##
@@ -721,7 +724,7 @@ proc rotatedInternal[T](arg: openArray[T]; first, middle, last: int): seq[T] =
 
 proc rotateLeft*[T](arg: var openArray[T]; slice: HSlice[int, int];
                     dist: int): int {.discardable.} =
-  ## Perform a left rotation on a range of elements. If you want to rotate
+  ## Performs a left rotation on a range of elements. If you want to rotate
   ## right, use a negative `dist`. Specifically, `rotateLeft` rotates
   ## the elements at `slice` by `dist` positions.
   ##
@@ -732,7 +735,7 @@ proc rotateLeft*[T](arg: var openArray[T]; slice: HSlice[int, int];
   ##
   ## Elements outside of `slice` will be left unchanged.
   ## The time complexity is linear to `slice.b - slice.a + 1`.
-  ## If an invalid range (`HSlice`) is passed, it raises IndexDefect.
+  ## If an invalid range (`HSlice`) is passed, it raises `IndexDefect`.
   ##
   ## `slice`
   ##   The indices of the element range that should be rotated.
@@ -783,7 +786,7 @@ proc rotatedLeft*[T](arg: openArray[T]; slice: HSlice[int, int],
   ## not modify the argument. It creates a new `seq` instead.
   ##
   ## Elements outside of `slice` will be left unchanged.
-  ## If an invalid range (`HSlice`) is passed, it raises IndexDefect.
+  ## If an invalid range (`HSlice`) is passed, it raises `IndexDefect`.
   ##
   ## `slice`
   ##   The indices of the element range that should be rotated.

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -7,11 +7,11 @@
 #    distribution, for details about the copyright.
 #
 
-## This module implements some common generic algorithms.
+## This module implements some common generic algorithms on `openArray`s.
 ##
 ## Basic usage
 ## ===========
-## 
+##
 
 runnableExamples:
   type People = tuple
@@ -30,9 +30,7 @@ runnableExamples:
                 (year: 2010, name: "Jane")]
 
   proc myCmp(x, y: People): int =
-    if x.name < y.name: -1
-    elif x.name == y.name: 0
-    else: 1
+    cmp(x.name, y.name)
 
   # Sorting with custom proc
   a.sort(myCmp)
@@ -49,18 +47,18 @@ type
     Descending, Ascending
 
 proc `*`*(x: int, order: SortOrder): int {.inline.} =
-  ## Flips ``x`` if ``order == Descending``.
-  ## If ``order == Ascending`` then ``x`` is returned.
+  ## Flip `x` if `order == Descending`.
+  ## If `order == Ascending` then `x` is returned.
   ##
-  ## ``x`` is supposed to be the result of a comparator, i.e.
-  ## | ``< 0`` for *less than*,
-  ## | ``== 0`` for *equal*,
-  ## | ``> 0`` for *greater than*.
+  ## `x` is supposed to be the result of a comparator, i.e.
+  ## | `< 0` for *less than*,
+  ## | `== 0` for *equal*,
+  ## | `> 0` for *greater than*.
   runnableExamples:
-    assert `*`(-123, Descending) == 123
-    assert `*`(123, Descending) == -123
-    assert `*`(-123, Ascending) == -123
-    assert `*`(123, Ascending) == 123
+    assert -123 * Descending == 123
+    assert 123 * Descending == -123
+    assert -123 * Ascending == -123
+    assert 123 * Ascending == 123
   var y = order.ord - 1
   result = (x xor y) - y
 
@@ -71,7 +69,7 @@ template fillImpl[T](a: var openArray[T], first, last: int, value: T) =
     inc(x)
 
 proc fill*[T](a: var openArray[T], first, last: Natural, value: T) =
-  ## Fills the slice ``a[first..last]`` with ``value``.
+  ## Fill the slice `a[first..last]` with `value`.
   ##
   ## If an invalid range is passed, it raises IndexDefect.
   runnableExamples:
@@ -84,7 +82,7 @@ proc fill*[T](a: var openArray[T], first, last: Natural, value: T) =
   fillImpl(a, first, last, value)
 
 proc fill*[T](a: var openArray[T], value: T) =
-  ## Fills the container ``a`` with ``value``.
+  ## Fill the container `a` with `value`.
   runnableExamples:
     var a: array[6, int]
     a.fill(9)
@@ -95,13 +93,13 @@ proc fill*[T](a: var openArray[T], value: T) =
 
 
 proc reverse*[T](a: var openArray[T], first, last: Natural) =
-  ## Reverses the slice ``a[first..last]``.
+  ## Reverse the slice `a[first..last]`.
   ##
   ## If an invalid range is passed, it raises IndexDefect.
   ##
   ## **See also:**
-  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and returns a ``seq[T]``
-  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and returns a ``seq[T]``
+  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and return a `seq[T]`
+  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and return a `seq[T]`
   runnableExamples:
     var a = [1, 2, 3, 4, 5, 6]
     a.reverse(1, 3)
@@ -117,21 +115,21 @@ proc reverse*[T](a: var openArray[T], first, last: Natural) =
     inc(x)
 
 proc reverse*[T](a: var openArray[T]) =
-  ## Reverses the contents of the container ``a``.
+  ## Reverse the contents of the container `a`.
   ##
   ## **See also:**
-  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and returns a ``seq[T]``
-  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and returns a ``seq[T]``
+  ## * `reversed proc<#reversed,openArray[T],Natural,int>`_ reverse a slice and return a `seq[T]`
+  ## * `reversed proc<#reversed,openArray[T]>`_ reverse and return a `seq[T]`
   runnableExamples:
     var a = [1, 2, 3, 4, 5, 6]
     a.reverse()
     assert a == [6, 5, 4, 3, 2, 1]
     a.reverse()
     assert a == [1, 2, 3, 4, 5, 6]
-  reverse(a, 0, max(0, a.high))
+  reverse(a, 0, a.high)
 
 proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
-  ## Returns the reverse of the slice ``a[first..last]``.
+  ## Return the reverse of the slice `a[first..last]`.
   ##
   ## If an invalid range is passed, it raises IndexDefect.
   ##
@@ -143,7 +141,7 @@ proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
       a = [1, 2, 3, 4, 5, 6]
       b = a.reversed(1, 3)
     assert b == @[4, 3, 2]
-  assert last >= first-1
+  assert last >= first - 1
   var i = last - first
   var x = first.int
   result = newSeq[T](i + 1)
@@ -153,7 +151,7 @@ proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
     inc(x)
 
 proc reversed*[T](a: openArray[T]): seq[T] =
-  ## Returns the reverse of the container ``a``.
+  ## Return the reverse of the container `a`.
   ##
   ## **See also:**
   ## * `reverse proc<#reverse,openArray[T],Natural,Natural>`_ reverse a slice
@@ -166,18 +164,19 @@ proc reversed*[T](a: openArray[T]): seq[T] =
   reversed(a, 0, a.high)
 
 proc binarySearch*[T, K](a: openArray[T], key: K,
-              cmp: proc (x: T, y: K): int {.closure.}): int =
-  ## Binary search for ``key`` in ``a``. Returns -1 if not found.
+                         cmp: proc (x: T, y: K): int {.closure.}): int =
+  ## Binary search for `key` in `a`. Return the index of `key` or -1 if not found.
+  ## Assumes that `a` is sorted according to `cmp`.
   ##
-  ## ``cmp`` is the comparator function to use, the expected return values are
-  ## the same as that of system.cmp.
+  ## `cmp` is the comparator function to use, the expected return values are
+  ## the same as those of system.cmp.
   runnableExamples:
     assert binarySearch(["a", "b", "c", "d"], "d", system.cmp[string]) == 3
-    assert binarySearch(["a", "b", "d", "c"], "d", system.cmp[string]) == 2
-  if a.len == 0:
-    return -1
-
+    assert binarySearch(["a", "b", "c", "d"], "c", system.cmp[string]) == 2
   let len = a.len
+
+  if len == 0:
+    return -1
 
   if len == 1:
     if cmp(a[0], key) == 0:
@@ -196,7 +195,7 @@ proc binarySearch*[T, K](a: openArray[T], key: K,
       if cmpRes == 0:
         return i
 
-      if cmpRes < 1:
+      if cmpRes < 0:
         result = i
       step = step shr 1
     if cmp(a[result], key) != 0: result = -1
@@ -216,30 +215,32 @@ proc binarySearch*[T, K](a: openArray[T], key: K,
     if result >= len or cmp(a[result], key) != 0: result = -1
 
 proc binarySearch*[T](a: openArray[T], key: T): int =
-  ## Binary search for ``key`` in ``a``. Returns -1 if not found.
+  ## Binary search for `key` in `a`. Return the index of `key` or -1 if not found.
+  ## Assumes that `a` is sorted.
   runnableExamples:
     assert binarySearch([0, 1, 2, 3, 4], 4) == 4
-    assert binarySearch([0, 1, 4, 2, 3], 4) == 2
+    assert binarySearch([0, 1, 2, 3, 4], 2) == 2
   binarySearch(a, key, cmp[T])
 
 const
   onlySafeCode = true
 
-proc lowerBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.
-    closure.}): int =
-  ## Returns a position to the first element in the ``a`` that is greater than
-  ## ``key``, or last if no such element is found.
+proc lowerBound*[T, K](a: openArray[T], key: K,
+                       cmp: proc(x: T, k: K): int {.closure.}): int =
+  ## Return the index of the first element in `a` that is not less than
+  ## (i.e. greater or equal to) `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
-  ## ``insert(thing, elm, lowerBound(thing, elm))``
+  ## `insert(thing, elm, lowerBound(thing, elm))`
   ## the sequence will still be sorted.
+  ## Assumes that `a` is sorted according to `cmp`.
   ##
   ## If an invalid range is passed, it raises IndexDefect.
   ##
-  ## The version uses ``cmp`` to compare the elements.
-  ## The expected return values are the same as that of ``system.cmp``.
+  ## This version uses `cmp` to compare the elements.
+  ## The expected return values are the same as those of `system.cmp`.
   ##
   ## **See also:**
-  ## * `upperBound proc<#upperBound,openArray[T],K,proc(T,K)>`_ sorted by ``cmp`` in the specified order
+  ## * `upperBound proc<#upperBound,openArray[T],K,proc(T,K)>`_ sorted by `cmp` in the specified order
   ## * `upperBound proc<#upperBound,openArray[T],T>`_
   runnableExamples:
     var arr = @[1, 2, 3, 5, 6, 7, 8, 9]
@@ -261,33 +262,35 @@ proc lowerBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.
       count = step
 
 proc lowerBound*[T](a: openArray[T], key: T): int = lowerBound(a, key, cmp[T])
-  ## Returns a position to the first element in the ``a`` that is greater than
-  ## ``key``, or last if no such element is found.
+  ## Return the index of the first element in `a` that is not less than
+  ## (i.e. greater or equal to) `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
-  ## ``insert(thing, elm, lowerBound(thing, elm))``
+  ## `insert(thing, elm, lowerBound(thing, elm))`
   ## the sequence will still be sorted.
+  ## Assumes that `a` is sorted.
   ##
-  ## The version uses the default comparison function ``cmp``.
+  ## This version uses the default comparison function `cmp`.
   ##
   ## **See also:**
-  ## * `upperBound proc<#upperBound,openArray[T],K,proc(T,K)>`_ sorted by ``cmp`` in the specified order
+  ## * `upperBound proc<#upperBound,openArray[T],K,proc(T,K)>`_ sorted by `cmp` in the specified order
   ## * `upperBound proc<#upperBound,openArray[T],T>`_
 
-proc upperBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.
-    closure.}): int =
-  ## Returns a position to the first element in the ``a`` that is not less
-  ## (i.e. greater or equal to) than ``key``, or last if no such element is found.
+proc upperBound*[T, K](a: openArray[T], key: K,
+                       cmp: proc(x: T, k: K): int {.closure.}): int =
+  ## Return the index of the first element in `a` that is greater than
+  ## `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
-  ## ``insert(thing, elm, upperBound(thing, elm))``
+  ## `insert(thing, elm, upperBound(thing, elm))`
   ## the sequence will still be sorted.
+  ## Assumes that `a` is sorted according to `cmp`.
   ##
   ## If an invalid range is passed, it raises IndexDefect.
   ##
-  ## The version uses ``cmp`` to compare the elements. The expected
-  ## return values are the same as that of ``system.cmp``.
+  ## This version uses `cmp` to compare the elements. The expected
+  ## return values are the same as those of `system.cmp`.
   ##
   ## **See also:**
-  ## * `lowerBound proc<#lowerBound,openArray[T],K,proc(T,K)>`_ sorted by ``cmp`` in the specified order
+  ## * `lowerBound proc<#lowerBound,openArray[T],K,proc(T,K)>`_ sorted by `cmp` in the specified order
   ## * `lowerBound proc<#lowerBound,openArray[T],T>`_
   runnableExamples:
     var arr = @[1, 2, 3, 5, 6, 7, 8, 9]
@@ -309,19 +312,20 @@ proc upperBound*[T, K](a: openArray[T], key: K, cmp: proc(x: T, k: K): int {.
       count = step
 
 proc upperBound*[T](a: openArray[T], key: T): int = upperBound(a, key, cmp[T])
-  ## Returns a position to the first element in the ``a`` that is not less
-  ## (i.e. greater or equal to) than ``key``, or last if no such element is found.
+  ## Return the index of the first element in `a` that is greater than
+  ## `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence and you call
-  ## ``insert(thing, elm, upperBound(thing, elm))``
+  ## `insert(thing, elm, upperBound(thing, elm))`
   ## the sequence will still be sorted.
+  ## Assumes that `a` is sorted.
   ##
-  ## The version uses the default comparison function ``cmp``.
+  ## This version uses the default comparison function `cmp`.
   ##
   ## **See also:**
-  ## * `lowerBound proc<#lowerBound,openArray[T],K,proc(T,K)>`_ sorted by ``cmp`` in the specified order
+  ## * `lowerBound proc<#lowerBound,openArray[T],K,proc(T,K)>`_ sorted by `cmp` in the specified order
   ## * `lowerBound proc<#lowerBound,openArray[T],T>`_
 
-template `<-` (a, b) =
+template `<-`(a, b) =
   when defined(gcDestructors):
     a = move b
   elif onlySafeCode:
@@ -331,10 +335,10 @@ template `<-` (a, b) =
 
 proc merge[T](a, b: var openArray[T], lo, m, hi: int,
               cmp: proc (x, y: T): int {.closure.}, order: SortOrder) =
-  # optimization: If max(left) <= min(right) there is nothing to do!
-  # 1 2 3 4  ## 5 6 7 8
+  # Optimization: If max(left) <= min(right) there is nothing to do!
+  # 1 2 3 4 ## 5 6 7 8
   # -> O(n) for sorted arrays.
-  # On random data this safes up to 40% of merge calls
+  # On random data this saves up to 40% of merge calls.
   if cmp(a[m], a[m+1]) * order <= 0: return
   var j = lo
   # copy a[j..m] into b:
@@ -377,9 +381,9 @@ func sort*[T](a: var openArray[T],
   ##
   ## The current implementation uses an iterative
   ## mergesort to achieve this. It uses a temporary sequence of
-  ## length ``a.len div 2``. If you do not wish to provide your own
-  ## ``cmp``, you may use ``system.cmp`` or instead call the overloaded
-  ## version of ``sort``, which uses ``system.cmp``.
+  ## length `a.len div 2`. If you do not wish to provide your own
+  ## `cmp`, you may use `system.cmp` or instead call the overloaded
+  ## version of `sort`, which uses `system.cmp`.
   ##
   ## .. code-block:: nim
   ##
@@ -400,7 +404,7 @@ func sort*[T](a: var openArray[T],
   ##
   ## **See also:**
   ## * `sort proc<#sort,openArray[T]>`_
-  ## * `sorted proc<#sorted,openArray[T],proc(T,T)>`_ sorted by ``cmp`` in the specified order
+  ## * `sorted proc<#sorted,openArray[T],proc(T,T)>`_ sorted by `cmp` in the specified order
   ## * `sorted proc<#sorted,openArray[T]>`_
   ## * `sortedByIt template<#sortedByIt.t,untyped,untyped>`_
   runnableExamples:
@@ -411,8 +415,7 @@ func sort*[T](a: var openArray[T],
     sort(d, myCmp)
     assert d == ["fo", "qux", "boo", "barr"]
   var n = a.len
-  var b: seq[T]
-  newSeq(b, n div 2)
+  var b = newSeq[T](n div 2)
   var s = 1
   while s < n:
     var m = n-1-s
@@ -423,17 +426,17 @@ func sort*[T](a: var openArray[T],
 
 proc sort*[T](a: var openArray[T], order = SortOrder.Ascending) = sort[T](a,
     system.cmp[T], order)
-  ## Shortcut version of ``sort`` that uses ``system.cmp[T]`` as the comparison function.
+  ## Shortcut version of `sort` that uses `system.cmp[T]` as the comparison function.
   ##
   ## **See also:**
   ## * `sort func<#sort,openArray[T],proc(T,T)>`_
-  ## * `sorted proc<#sorted,openArray[T],proc(T,T)>`_ sorted by ``cmp`` in the specified order
+  ## * `sorted proc<#sorted,openArray[T],proc(T,T)>`_ sorted by `cmp` in the specified order
   ## * `sorted proc<#sorted,openArray[T]>`_
   ## * `sortedByIt template<#sortedByIt.t,untyped,untyped>`_
 
 proc sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.},
                 order = SortOrder.Ascending): seq[T] =
-  ## Returns ``a`` sorted by ``cmp`` in the specified ``order``.
+  ## Return `a` sorted by `cmp` in the specified `order`.
   ##
   ## **See also:**
   ## * `sort func<#sort,openArray[T],proc(T,T)>`_
@@ -454,7 +457,7 @@ proc sorted*[T](a: openArray[T], cmp: proc(x, y: T): int {.closure.},
   sort(result, cmp, order)
 
 proc sorted*[T](a: openArray[T], order = SortOrder.Ascending): seq[T] =
-  ## Shortcut version of ``sorted`` that uses ``system.cmp[T]`` as the comparison function.
+  ## Shortcut version of `sorted` that uses `system.cmp[T]` as the comparison function.
   ##
   ## **See also:**
   ## * `sort func<#sort,openArray[T],proc(T,T)>`_
@@ -472,18 +475,18 @@ proc sorted*[T](a: openArray[T], order = SortOrder.Ascending): seq[T] =
   sorted[T](a, system.cmp[T], order)
 
 template sortedByIt*(seq1, op: untyped): untyped =
-  ## Convenience template around the ``sorted`` proc to reduce typing.
+  ## Convenience template around the `sorted` proc to reduce typing.
   ##
-  ## The template injects the ``it`` variable which you can use directly in an
+  ## The template injects the `it` variable which you can use directly in an
   ## expression.
   ##
-  ## Because the underlying ``cmp()`` is defined for tuples you can do
+  ## Because the underlying `cmp()` is defined for tuples you can do
   ## a nested sort.
   ##
   ## **See also:**
   ## * `sort func<#sort,openArray[T],proc(T,T)>`_
   ## * `sort proc<#sort,openArray[T]>`_
-  ## * `sorted proc<#sorted,openArray[T],proc(T,T)>`_ sorted by ``cmp`` in the specified order
+  ## * `sorted proc<#sorted,openArray[T],proc(T,T)>`_ sorted by `cmp` in the specified order
   ## * `sorted proc<#sorted,openArray[T]>`_
   runnableExamples:
     type Person = tuple[name: string, age: int]
@@ -510,9 +513,9 @@ template sortedByIt*(seq1, op: untyped): untyped =
 func isSorted*[T](a: openArray[T],
                  cmp: proc(x, y: T): int {.closure.},
                  order = SortOrder.Ascending): bool =
-  ## Checks to see whether ``a`` is already sorted in ``order``
-  ## using ``cmp`` for the comparison. Parameters identical
-  ## to ``sort``. Requires O(n) time.
+  ## Check to see whether `a` is already sorted in `order`
+  ## using `cmp` for the comparison. The parameters are identical
+  ## to `sort`. Requires O(n) time.
   ##
   ## **See also:**
   ## * `isSorted proc<#isSorted,openArray[T]>`_
@@ -535,7 +538,7 @@ func isSorted*[T](a: openArray[T],
       return false
 
 proc isSorted*[T](a: openArray[T], order = SortOrder.Ascending): bool =
-  ## Shortcut version of ``isSorted`` that uses ``system.cmp[T]`` as the comparison function.
+  ## Shortcut version of `isSorted` that uses `system.cmp[T]` as the comparison function.
   ##
   ## **See also:**
   ## * `isSorted func<#isSorted,openArray[T],proc(T,T)>`_
@@ -555,8 +558,8 @@ proc isSorted*[T](a: openArray[T], order = SortOrder.Ascending): bool =
   isSorted(a, system.cmp[T], order)
 
 proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
-  ## Produces the Cartesian product of the array. Warning: complexity
-  ## may explode.
+  ## Produce the Cartesian product of the array.
+  ## Warning: complexity may explode.
   runnableExamples:
     assert product(@[@[1], @[2]]) == @[@[1, 2]]
     assert product(@[@["A", "K"], @["Q"]]) == @[@["K", "Q"], @["A", "Q"]]
@@ -567,34 +570,33 @@ proc product*[T](x: openArray[seq[T]]): seq[seq[T]] =
     result = @x
     return
   var
-    indexes = newSeq[int](x.len)
+    indices = newSeq[int](x.len)
     initial = newSeq[int](x.len)
     index = 0
-  var next = newSeq[T]()
-  next.setLen(x.len)
+  var next = newSeq[T](x.len)
   for i in 0..(x.len-1):
     if len(x[i]) == 0: return
-    initial[i] = len(x[i])-1
-  indexes = initial
+    initial[i] = len(x[i]) - 1
+  indices = initial
   while true:
-    while indexes[index] == -1:
-      indexes[index] = initial[index]
+    while indices[index] == -1:
+      indices[index] = initial[index]
       index += 1
       if index == x.len: return
-      indexes[index] -= 1
-    for ni, i in indexes:
+      indices[index] -= 1
+    for ni, i in indices:
       next[ni] = x[ni][i]
     result.add(next)
     index = 0
-    indexes[index] -= 1
+    indices[index] -= 1
 
 proc nextPermutation*[T](x: var openArray[T]): bool {.discardable.} =
-  ## Calculates the next lexicographic permutation, directly modifying ``x``.
+  ## Calculate the next lexicographic permutation, directly modifying `x`.
   ## The result is whether a permutation happened, otherwise we have reached
   ## the last-ordered permutation.
   ##
   ## If you start with an unsorted array/seq, the repeated permutations
-  ## will **not** give you all permutations but stop with last.
+  ## will **not** give you all permutations but stop with the last.
   ##
   ## **See also:**
   ## * `prevPermutation proc<#prevPermutation,openArray[T]>`_
@@ -629,8 +631,8 @@ proc nextPermutation*[T](x: var openArray[T]): bool {.discardable.} =
   result = true
 
 proc prevPermutation*[T](x: var openArray[T]): bool {.discardable.} =
-  ## Calculates the previous lexicographic permutation, directly modifying
-  ## ``x``. The result is whether a permutation happened, otherwise we have
+  ## Calculate the previous lexicographic permutation, directly modifying
+  ## `x`. The result is whether a permutation happened, otherwise we have
   ## reached the first-ordered permutation.
   ##
   ## **See also:**
@@ -664,7 +666,8 @@ proc prevPermutation*[T](x: var openArray[T]): bool {.discardable.} =
   result = true
 
 proc rotateInternal[T](arg: var openArray[T]; first, middle, last: int): int =
-  ## A port of std::rotate from c++. Ported from `this reference <http://www.cplusplus.com/reference/algorithm/rotate/>`_.
+  ## A port of std::rotate from C++.
+  ## Ported from [this reference](http://www.cplusplus.com/reference/algorithm/rotate/).
   result = first + last - middle
 
   if first == middle or middle == last:
@@ -716,30 +719,30 @@ proc rotatedInternal[T](arg: openArray[T]; first, middle, last: int): seq[T] =
     result[i] = arg[i]
 
 proc rotateLeft*[T](arg: var openArray[T]; slice: HSlice[int, int];
-    dist: int): int {.discardable.} =
-  ## Performs a left rotation on a range of elements. If you want to rotate
-  ## right, use a negative ``dist``. Specifically, ``rotateLeft`` rotates
-  ## the elements at ``slice`` by ``dist`` positions.
+                    dist: int): int {.discardable.} =
+  ## Perform a left rotation on a range of elements. If you want to rotate
+  ## right, use a negative `dist`. Specifically, `rotateLeft` rotates
+  ## the elements at `slice` by `dist` positions.
   ##
-  ## | The element at index ``slice.a + dist`` will be at index ``slice.a``.
-  ## | The element at index ``slice.b`` will be at ``slice.a + dist -1``.
-  ## | The element at index ``slice.a`` will be at ``slice.b + 1 - dist``.
-  ## | The element at index ``slice.a + dist - 1`` will be at ``slice.b``.
+  ## | The element at index `slice.a + dist` will be at index `slice.a`.
+  ## | The element at index `slice.b` will be at `slice.a + dist - 1`.
+  ## | The element at index `slice.a` will be at `slice.b + 1 - dist`.
+  ## | The element at index `slice.a + dist - 1` will be at `slice.b`.
   ##
-  ## Elements outside of ``slice`` will be left unchanged.
-  ## The time complexity is linear to ``slice.b - slice.a + 1``.
-  ## If an invalid range (``HSlice``) is passed, it raises IndexDefect.
+  ## Elements outside of `slice` will be left unchanged.
+  ## The time complexity is linear to `slice.b - slice.a + 1`.
+  ## If an invalid range (`HSlice`) is passed, it raises IndexDefect.
   ##
-  ## ``slice``
+  ## `slice`
   ##   The indices of the element range that should be rotated.
   ##
-  ## ``dist``
+  ## `dist`
   ##   The distance in amount of elements that the data should be rotated.
   ##   Can be negative, can be any number.
   ##
   ## **See also:**
   ## * `rotateLeft proc<#rotateLeft,openArray[T],int>`_ for a version which rotates the whole container
-  ## * `rotatedLeft proc<#rotatedLeft,openArray[T],HSlice[int,int],int>`_ for a version which returns a ``seq[T]``
+  ## * `rotatedLeft proc<#rotatedLeft,openArray[T],HSlice[int,int],int>`_ for a version which returns a `seq[T]`
   runnableExamples:
     var a = [0, 1, 2, 3, 4, 5]
     a.rotateLeft(1 .. 4, 3)
@@ -751,15 +754,16 @@ proc rotateLeft*[T](arg: var openArray[T]; slice: HSlice[int, int];
     doAssertRaises(IndexDefect, a.rotateLeft(1 .. 7, 2))
   let sliceLen = slice.b + 1 - slice.a
   let distLeft = ((dist mod sliceLen) + sliceLen) mod sliceLen
-  arg.rotateInternal(slice.a, slice.a+distLeft, slice.b + 1)
+  arg.rotateInternal(slice.a, slice.a + distLeft, slice.b + 1)
 
 proc rotateLeft*[T](arg: var openArray[T]; dist: int): int {.discardable.} =
-  ## Default arguments for slice, so that this procedure operates on the entire
-  ## ``arg``, and not just on a part of it.
+  ## Same as `rotateLeft`, but with default arguments for slice,
+  ## so that this procedure operates on the entire
+  ## `arg`, and not just on a part of it.
   ##
   ## **See also:**
   ## * `rotateLeft proc<#rotateLeft,openArray[T],HSlice[int,int],int>`_ for a version which rotates a range
-  ## * `rotatedLeft proc<#rotatedLeft,openArray[T],int>`_ for a version which returns a ``seq[T]``
+  ## * `rotatedLeft proc<#rotatedLeft,openArray[T],int>`_ for a version which returns a `seq[T]`
   runnableExamples:
     var a = [1, 2, 3, 4, 5]
     a.rotateLeft(2)
@@ -773,17 +777,17 @@ proc rotateLeft*[T](arg: var openArray[T]; dist: int): int {.discardable.} =
   arg.rotateInternal(0, distLeft, arglen)
 
 proc rotatedLeft*[T](arg: openArray[T]; slice: HSlice[int, int],
-    dist: int): seq[T] =
-  ## Same as ``rotateLeft``, just with the difference that it does
-  ## not modify the argument. It creates a new ``seq`` instead.
+                     dist: int): seq[T] =
+  ## Same as `rotateLeft`, just with the difference that it does
+  ## not modify the argument. It creates a new `seq` instead.
   ##
-  ## Elements outside of ``slice`` will be left unchanged.
-  ## If an invalid range (``HSlice``) is passed, it raises IndexDefect.
+  ## Elements outside of `slice` will be left unchanged.
+  ## If an invalid range (`HSlice`) is passed, it raises IndexDefect.
   ##
-  ## ``slice``
+  ## `slice`
   ##   The indices of the element range that should be rotated.
   ##
-  ## ``dist``
+  ## `dist`
   ##   The distance in amount of elements that the data should be rotated.
   ##   Can be negative, can be any number.
   ##
@@ -803,8 +807,8 @@ proc rotatedLeft*[T](arg: openArray[T]; slice: HSlice[int, int],
   arg.rotatedInternal(slice.a, slice.a+distLeft, slice.b+1)
 
 proc rotatedLeft*[T](arg: openArray[T]; dist: int): seq[T] =
-  ## Same as ``rotateLeft``, just with the difference that it does
-  ## not modify the argument. It creates a new ``seq`` instead.
+  ## Same as `rotateLeft`, just with the difference that it does
+  ## not modify the argument. It creates a new `seq` instead.
   ##
   ## **See also:**
   ## * `rotateLeft proc<#rotateLeft,openArray[T],int>`_ for the in-place version of this proc

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -126,7 +126,8 @@ proc reverse*[T](a: var openArray[T]) =
     assert a == [6, 5, 4, 3, 2, 1]
     a.reverse()
     assert a == [1, 2, 3, 4, 5, 6]
-  reverse(a, 0, a.high)
+  # the max is needed, since a.high is -1 if a is empty
+  reverse(a, 0, max(0, a.high))
 
 proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T] =
   ## Return the reverse of the slice `a[first..last]`.

--- a/tests/stdlib/talgorithm.nim
+++ b/tests/stdlib/talgorithm.nim
@@ -3,7 +3,7 @@ discard """
 '''
 """
 #12928,10456
-import sequtils, strutils, algorithm, json
+import sequtils, algorithm, json
 
 proc test() = 
   try: 
@@ -14,7 +14,7 @@ proc test() =
     echo prefixes
   except:
     discard
-  
+
 test()
 
 block:


### PR DESCRIPTION
This PR aims to improve the documentation for the algorithm module. It replaces double with single backticks and changes the descriptions to imperative form (as recommended in the contributing guideline). It also fixes some grammar issues and typos.

Some noteworthy changes:
* There was a bug in the `binarySearch` proc where the result of a comparison was compared to 1 instead of 0 (line 199). In practice this probably didn't cause any issues, because most comparison functions return -1, 0 or 1, but that isn't guaranteed.
* Changes the examples for `binarySearch` to use sorted arrays, since the algorithm assumes that the input is sorted. The previous examples did work, but that was only a special case and it invokes the impression that it works fine if the input is unsorted.
* The documentation for `lowerBound` and `upperBound` was swapped.

Two things I noticed:
* [`sort`](https://nim-lang.github.io/Nim/algorithm.html#sort%2CopenArray%5BT%5D%2Cproc%28T%2CT%29) and [`isSorted`](https://nim-lang.github.io/Nim/algorithm.html#isSorted%2CopenArray%5BT%5D%2Cproc%28T%2CT%29) are `func`s when given a custom `cmp`, but the other versions are `proc`s, eventhough they just delegate to the first version.
* The `last` parameter of [`reversed`](https://nim-lang.github.io/Nim/algorithm.html#reversed%2CopenArray%5BT%5D%2CNatural%2Cint) has type `int`, while the `first` parameter and the `last` parameter of [`reverse`](https://nim-lang.github.io/Nim/algorithm.html#reverse%2CopenArray%5BT%5D%2CNatural%2CNatural) have type `Natural`. I think this is so that `reversed` works on empty `openArray`s, but that could be changed by calling `reversed(a, 0, max(0, a.high))`.

I assume these are unintended, but I didn't change it, because I'm not sure and it's probably backwards incompatible.