### PR TITLE
Revert "Make config processing order test more robust"

### DIFF
--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -225,7 +225,7 @@ sub/mmain.idx""", context
     check execCmdEx(cmd) == ("witness\n", 0)
 
   block: # config.nims, nim.cfg, hintConf, bug #16557
-    let cmd = fmt"{nim} r {defaultHintsOff} --hint:conf --skipParentCfg tests/newconfig/bar/mfoo.nim"
+    let cmd = fmt"{nim} r {defaultHintsOff} --hint:conf tests/newconfig/bar/mfoo.nim"
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
     doAssert exitCode == 0
     let dir = getCurrentDir()


### PR DESCRIPTION
This reverts commit cf714c129f7dd598863d1cc588e685df2438c658.