### PR TITLE
stdlib/os: Add getHostname, setHostname

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -92,6 +92,10 @@
 - `math.round` now is rounded "away from zero" in JS backend which is consistent
 with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
+- Added `os.setHostname`; for consistency reasons `nativesockets.getHostname` is now available under `os.getHostname`
+  name, `os.getHostname` now raises assertion error when it's called from OS, different from Windows and POSIX, and does
+  not require calling WSAStartup anymore.
+
 
 ## Language changes
 

--- a/lib/pure/nativesockets.nim
+++ b/lib/pure/nativesockets.nim
@@ -35,7 +35,7 @@ else:
 export SocketHandle, Sockaddr_in, Addrinfo, INADDR_ANY, SockAddr, SockLen,
   Sockaddr_in6, Sockaddr_storage,
   inet_ntoa, recv, `==`, connect, send, accept, recvfrom, sendto,
-  freeAddrInfo
+  freeAddrInfo, getHostname
 
 export
   SO_ERROR,
@@ -433,22 +433,6 @@ proc getHostByName*(name: string): Hostent {.tags: [ReadIOEffect].} =
   else:
     result.addrList = cstringArrayToSeq(s.h_addr_list)
   result.length = int(s.h_length)
-
-proc getHostname*(): string {.tags: [ReadIOEffect].} =
-  ## Returns the local hostname (not the FQDN)
-  # https://tools.ietf.org/html/rfc1035#section-2.3.1
-  # https://tools.ietf.org/html/rfc2181#section-11
-  const size = 64
-  result = newString(size)
-  when useWinVersion:
-    let success = winlean.gethostname(result, size)
-  else:
-    # Posix
-    let success = posix.gethostname(result, size)
-  if success != 0.cint:
-    raiseOSError(osLastError())
-  let x = len(cstring(result))
-  result.setLen(x)
 
 proc getSockDomain*(socket: SocketHandle): Domain =
   ## Returns the socket's domain (AF_INET or AF_INET6).

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3310,3 +3310,71 @@ func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1
     find(f.name, invalidFilenameChars) != -1): return false
   for invalid in invalidFilenames:
     if cmpIgnoreCase(f.name, invalid) == 0: return false
+
+when defined(windows):
+  # https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ne-sysinfoapi-computer_name_format
+  const ComputerNamePhysicalNetBIOS = 4
+  const ComputerNamePhysicalDnsHostname = 5
+
+proc getHostname*(): string {.tags: [ReadIOEffect], noWeirdTarget.} =
+  ## Returns the local hostname (not the FQDN).
+  ## On Windows (see
+  ## https://docs.microsoft.com/en-us/windows/win32/sysinfo/computer-names)
+  ## returns ComputerNamePhysicalDnsHostname.
+  # On POSIX SUSv2 guarantees that "Host names are limited to 255 bytes".
+  # https://tools.ietf.org/html/rfc1035#section-2.3.1
+  # https://tools.ietf.org/html/rfc2181#section-11
+  const size = 256
+  result = newString(size)
+  when defined(windows):
+    proc getComputerNameExA(nameType: cint, name: cstring, len: PDWORD): WINBOOL
+      {.stdcall, dynlib: "kernel32", importc: "GetComputerNameExA", sideEffect.}
+    var resultLen: DWORD = DWORD(size)
+    let success = getComputerNameExA(ComputerNamePhysicalDnsHostname, 
+                                     result.cstring, resultLen.addr) != 0
+  elif defined(posix):
+    let success = posix.gethostname(result, size) == 0
+    let resultLen = len(cstring(result))
+  else:
+    doAssert false, "getHostname failed: OS is not supported"
+  if not success:
+    raiseOSError(osLastError())
+  result.setLen(resultLen)
+
+proc setHostname*(name: string) {.since: (1, 5), noWeirdTarget.} =
+  ## Sets host name.
+  ## Available in Windows, Linux (including Android), OS X, BSD, Haiku, and QNX
+  ## distributions.
+  ## Requires root priviledges on POSIX and administrator privileges on
+  ## Windows.
+  ## Windows notes (see
+  ## https://docs.microsoft.com/en-us/windows/win32/sysinfo/computer-names):
+  ## * Sets both ComputerNamePhysicalNetBIOS and
+  ##   ComputerNamePhysicalDnsHostname.
+  ## * Name changes made by this function call do not take effect until the user
+  ##   restarts the computer.
+  var success: bool
+  when (defined(android) or defined(haiku) or defined(linux) or
+        defined(netbsd) or defined(openbsd) or defined(qnx)):
+    proc setHostname(name: cstring, len: csize_t): cint
+      {.importc: "sethostname", header: "<unistd.h>", sideEffect.}
+    success = setHostname(name.cstring, csize_t(name.len)) == 0
+  elif defined(dragonfly) or defined(freebsd) or defined(osx):
+    proc setHostname(name: cstring, len: cint): cint
+      {.importc: "sethostname", header: "<unistd.h>", sideEffect.}
+    success = setHostname(name.cstring, cint(name.len)) == 0
+  elif defined(windows):
+    proc setComputerNameExA(nameType: cint, name: cstring): WINBOOL
+      {.stdcall, dynlib: "kernel32", importc: "SetComputerNameExA", sideEffect.}
+    let oldName = getHostname()
+    success = setComputerNameExA(ComputerNamePhysicalNetBIOS, name.cstring) != 0
+    if not success:
+      raiseOSError(osLastError(), name)
+    success = setComputerNameExA(ComputerNamePhysicalDnsHostname,
+                                 name.cstring) != 0
+    if not success:
+      discard setComputerNameExA(ComputerNamePhysicalNetBIOS, oldName)
+  else:
+    doAssert false, "setHostname failed: OS is not supported"
+  if not success:
+    raiseOSError(osLastError(), name)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -539,3 +539,6 @@ block: # normalizeExe
     doAssert "foo/../bar".dup(normalizeExe) == "foo/../bar"
   when defined(windows):
     doAssert "foo".dup(normalizeExe) == "foo"
+
+block: # getHostname
+  doAssert getHostname().len > 0


### PR DESCRIPTION
Tested manually as a root and a normal user on Fedora 33 and on as an administrator and a normal user on Windows Server 2019.

> why not use winlean.gethostname instead of getComputerNameExA

The latter is better because it doesn't require a WSAStartup call.
