### PR TITLE
[backport 1.0] add backend support for js bigint

### DIFF
--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -123,3 +123,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasEffectTraitsModule")
   defineSymbol("nimHasCastPragmaBlocks")
   defineSymbol("nimHasDeclaredLocs")
+  defineSymbol("nimHasJsBigIntBackend")

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -1673,20 +1673,11 @@ proc arrayTypeForElemType(typ: PType): string =
   of tyFloat64, tyFloat: "Float64Array"
   else: ""
 
-import astalgo
 proc createVar(p: PProc, typ: PType, indirect: bool): Rope =
   var t = skipTypes(typ, abstractInst)
   case t.kind
   of tyInt..tyInt64, tyUInt..tyUInt64, tyEnum, tyChar:
-    # if typ.
-    # dbg typ.kind, typ
-    # if typ.name.s == "JsBigInt":
     if $t.sym.loc.r == "bigint":
-    # if $typ == "JsBigInt":
-    #   dbg t
-    #   dbg t.sym.loc.r == "bigint"
-    #   debug(typ)
-    #   debug(t)
       result = putToSeq("0n", indirect)
     else:
       result = putToSeq("0", indirect)
@@ -1764,24 +1755,18 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
     useReloadingGuard = sfGlobal in v.flags and p.config.hcrOn
     useGlobalPragmas = sfGlobal in v.flags and ({sfPure, sfThread} * v.flags != {})
 
-  dbg p.prc, v, p.config$n.info, n.kind, n.renderTree, v.constraint.isNil
-
   if v.constraint.isNil:
     if useReloadingGuard:
-      dbg()
       lineF(p, "var $1;$n", varName)
       lineF(p, "if ($1 === undefined) {$n", varName)
       varCode = $varName
       inc p.extraIndent
     elif useGlobalPragmas:
-      dbg()
       lineF(p, "if (globalThis.$1 === undefined) {$n", varName)
       varCode = $varName
       inc p.extraIndent
     else:
-      dbg()
       varCode = "var $2"
-    dbg varCode
   else:
     # Is this really a thought through feature?  this basically unused
     # feature makes it impossible for almost all format strings in
@@ -1789,23 +1774,12 @@ proc genVarInit(p: PProc, v: PSym, n: PNode) =
     varCode = v.constraint.strVal
 
   if n.kind == nkEmpty:
-    dbg()
     if not isIndirect(v) and
       v.typ.kind in {tyVar, tyPtr, tyLent, tyRef, tyOwned} and mapType(p, v.typ) == etyBaseIndex:
-      dbg()
       lineF(p, "var $1 = null;$n", [varName])
       lineF(p, "var $1_Idx = 0;$n", [varName])
     else:
-      dbg()
-      dbg v.typ
-      dbg v.typ.kind
-      dbg returnType
-      dbg varName
-      dbg createVar(p, v.typ, isIndirect(v))
-      let temp = runtimeFormat(varCode & " = $3;$n", [returnType, varName, createVar(p, v.typ, isIndirect(v))])
-      dbg temp
-      line(p, temp)
-      # line(p, runtimeFormat(varCode & " = $3;$n", [returnType, varName, createVar(p, v.typ, isIndirect(v))]))
+      line(p, runtimeFormat(varCode & " = $3;$n", [returnType, varName, createVar(p, v.typ, isIndirect(v))]))
   else:
     gen(p, n, a)
     case mapType(p, v.typ)

--- a/tests/js/tbigint_backend.nim
+++ b/tests/js/tbigint_backend.nim
@@ -1,0 +1,36 @@
+proc jsTypeOf*[T](x: T): cstring {.importjs: "typeof(#)".}
+  ## Returns the name of the JsObject's JavaScript type as a cstring.
+  # xxx replace jsffi.jsTypeOf with this definition and add tests
+
+type JsBigIntImpl {.importc: "bigint".} = int
+type JsBigInt = distinct JsBigIntImpl
+
+doAssert JsBigInt isnot int
+func big*(integer: SomeInteger): JsBigInt {.importjs: "BigInt(#)".}
+func big*(integer: cstring): JsBigInt {.importjs: "BigInt(#)".}
+func `<=`*(x, y: JsBigInt): bool {.importjs: "(# $1 #)".}
+func `==`*(x, y: JsBigInt): bool {.importjs: "(# === #)".}
+func inc*(x: var JsBigInt) {.importjs: "[#][0][0]++".}
+func inc2*(x: var JsBigInt) {.importjs: "#++".}
+func toString*(this: JsBigInt): cstring {.importjs: "#.toString()".}
+func `$`*(this: JsBigInt): string =
+  $toString(this)
+
+let z1=big"10"
+let z2=big"15"
+doAssert z1 == big"10"
+doAssert z1 == z1
+doAssert z1 != z2
+var s: seq[cstring]
+for i in z1 .. z2:
+  s.add $i
+doAssert s == @["10".cstring, "11", "12", "13", "14", "15"]
+block:
+  var a=big"3"
+  a.inc
+  doAssert a == big"4"
+var z: JsBigInt
+doAssert $z == "0"
+doAssert z.jsTypeOf == "bigint" # would fail without codegen change
+doAssert z != big(1)
+doAssert z == big"0" # ditto

--- a/tests/js/tbigint_backend.nim
+++ b/tests/js/tbigint_backend.nim
@@ -12,14 +12,14 @@ func `<=`*(x, y: JsBigInt): bool {.importjs: "(# $1 #)".}
 func `==`*(x, y: JsBigInt): bool {.importjs: "(# === #)".}
 func inc*(x: var JsBigInt) {.importjs: "[#][0][0]++".}
 func inc2*(x: var JsBigInt) {.importjs: "#++".}
-func toString*(this: JsBigInt): cstring {.importjs: "#.toString()".}
+func toCstring*(this: JsBigInt): cstring {.importjs: "#.toString()".}
 func `$`*(this: JsBigInt): string =
-  $toString(this)
+  $toCstring(this)
 
 block:
   doAssert defined(nimHasJsBigIntBackend)
-  let z1=big"10"
-  let z2=big"15"
+  let z1 = big"10"
+  let z2 = big"15"
   doAssert z1 == big"10"
   doAssert z1 == z1
   doAssert z1 != z2

--- a/tests/js/tbigint_backend.nim
+++ b/tests/js/tbigint_backend.nim
@@ -31,8 +31,28 @@ block:
     var a=big"3"
     a.inc
     doAssert a == big"4"
-  var z: JsBigInt
-  doAssert $z == "0"
-  doAssert z.jsTypeOf == "bigint" # would fail without codegen change
-  doAssert z != big(1)
-  doAssert z == big"0" # ditto
+  block:
+    var z: JsBigInt
+    doAssert $z == "0"
+    doAssert z.jsTypeOf == "bigint" # would fail without codegen change
+    doAssert z != big(1)
+    doAssert z == big"0" # ditto
+
+  # ditto below
+  block:
+    let z: JsBigInt = big"1"
+    doAssert $z == "1"
+    doAssert z.jsTypeOf == "bigint"
+    doAssert z == big"1"
+
+  block:
+    let z = JsBigInt.default
+    doAssert $z == "0"
+    doAssert z.jsTypeOf == "bigint"
+    doAssert z == big"0"
+
+  block:
+    var a: seq[JsBigInt]
+    a.setLen 3
+    doAssert a[^1].jsTypeOf == "bigint"
+    doAssert a[^1] == big"0"

--- a/tests/js/tbigint_backend.nim
+++ b/tests/js/tbigint_backend.nim
@@ -16,21 +16,23 @@ func toString*(this: JsBigInt): cstring {.importjs: "#.toString()".}
 func `$`*(this: JsBigInt): string =
   $toString(this)
 
-let z1=big"10"
-let z2=big"15"
-doAssert z1 == big"10"
-doAssert z1 == z1
-doAssert z1 != z2
-var s: seq[cstring]
-for i in z1 .. z2:
-  s.add $i
-doAssert s == @["10".cstring, "11", "12", "13", "14", "15"]
 block:
-  var a=big"3"
-  a.inc
-  doAssert a == big"4"
-var z: JsBigInt
-doAssert $z == "0"
-doAssert z.jsTypeOf == "bigint" # would fail without codegen change
-doAssert z != big(1)
-doAssert z == big"0" # ditto
+  doAssert defined(nimHasJsBigIntBackend)
+  let z1=big"10"
+  let z2=big"15"
+  doAssert z1 == big"10"
+  doAssert z1 == z1
+  doAssert z1 != z2
+  var s: seq[cstring]
+  for i in z1 .. z2:
+    s.add $i
+  doAssert s == @["10".cstring, "11", "12", "13", "14", "15"]
+  block:
+    var a=big"3"
+    a.inc
+    doAssert a == big"4"
+  var z: JsBigInt
+  doAssert $z == "0"
+  doAssert z.jsTypeOf == "bigint" # would fail without codegen change
+  doAssert z != big(1)
+  doAssert z == big"0" # ditto


### PR DESCRIPTION
* needed for https://github.com/nim-lang/Nim/pull/16409 to give jsBigInts sane semantics
* backport all the way to 1.0.x, so that std/jsbigints can work for old nim (trivial and innocuous backend change)
* see test which shows a trimmed down implementation just to show the semantics (the full library implementation is done in https://github.com/nim-lang/Nim/pull/16409 and should use this simple replacement:
```nim
type JsBigInt* = ref object of JsRoot
=>
type JsBigIntImpl {.importc: "bigint".} = int
type JsBigInt* = distinct JsBigIntImpl
```
