### PR TITLE
make copySign for js consistent with other backends

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -222,20 +222,18 @@ func copySign*[T: SomeFloat](x, y: T): T {.inline, since: (1, 5, 1).} =
     doAssert copySign(1.0, copySign(NaN, -1.0)) == -1.0
 
   # TODO: use signbit for examples
-  template implVM() =
-    if y > 0.0 or (y == 0.0 and 1.0 / y > 0.0):
-      result = abs(x)
-    elif y <= 0.0:
-      result = -abs(x)
-    else: # must be NaN
-      result = abs(x)
-
   when defined(js):
     let uintBuffer = toBitsImpl(y)
     let sgn = (uintBuffer[1] shr 31) != 0
     result = jsSetSign(x, sgn)
   else:
-    when nimvm: implVM()
+    when nimvm: # not exact but we have a vmops for recent enough nim
+      if y > 0.0 or (y == 0.0 and 1.0 / y > 0.0):
+        result = abs(x)
+      elif y <= 0.0:
+        result = -abs(x)
+      else: # must be NaN
+        result = abs(x)
     else: result = c_copysign(x, y)
 
 func classify*(x: float): FloatClass =

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -175,20 +175,17 @@ when defined(js):
 
   proc toBitsImpl(x: float): array[2, uint32] =
     let buffer = newArrayBuffer(8)
-    let floatBuffer = newFloat64Array(buffer)
-    let uintBuffer = newUint32Array(buffer)
-    floatBuffer[0] = x
-    {.emit: "`result` = `uintBuffer`;".}
-    # result = cast[array[2, uint32]](uintBuffer)
+    let a = newFloat64Array(buffer)
+    let b = newUint32Array(buffer)
+    a[0] = x
+    {.emit: "`result` = `b`;".}
+    # result = cast[array[2, uint32]](b)
 
   proc jsSetSign(x: float, sgn: bool): float =
     asm """
     function updateBit(num, bitPos, bitVal) {
-      const bitVal2 = bitVal ? 1 : 0;
-      const mask = ~(1 << bitPos);
-      return (num & mask) | (bitVal2 << bitPos);
+      return (num & ~(1 << bitPos)) | (bitVal << bitPos);
     }
-
     const buffer = new ArrayBuffer(8);
     const a = new Float64Array(buffer);
     const b = new Uint32Array(buffer);

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -182,16 +182,16 @@ when defined(js):
     # result = cast[array[2, uint32]](b)
 
   proc jsSetSign(x: float, sgn: bool): float =
+    let buffer = newArrayBuffer(8)
+    let a = newFloat64Array(buffer)
+    let b = newUint32Array(buffer)
+    a[0] = x
     asm """
     function updateBit(num, bitPos, bitVal) {
       return (num & ~(1 << bitPos)) | (bitVal << bitPos);
     }
-    const buffer = new ArrayBuffer(8);
-    const a = new Float64Array(buffer);
-    const b = new Uint32Array(buffer);
-    a[0] = `x`;
-    b[1] = updateBit(b[1], 31, `sgn`);
-    `result` = a[0]
+    `b`[1] = updateBit(`b`[1], 31, `sgn`);
+    `result` = `a`[0]
     """
 
 proc signbit*(x: SomeFloat): bool {.inline, since: (1, 5, 1).} =

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -226,16 +226,6 @@ template main() =
     doAssert signbit(x2)
     doAssert signbit(x3)
 
-  block: # almostEqual
-    doAssert almostEqual(3.141592653589793, 3.1415926535897936)
-    doAssert almostEqual(1.6777215e7'f32, 1.6777216e7'f32)
-    doAssert almostEqual(Inf, Inf)
-    doAssert almostEqual(-Inf, -Inf)
-    doAssert not almostEqual(Inf, -Inf)
-    doAssert not almostEqual(-Inf, Inf)
-    doAssert not almostEqual(Inf, NaN)
-    doAssert not almostEqual(NaN, NaN)
-
   block: # copySign
     doAssert copySign(10.0, 1.0) == 10.0
     doAssert copySign(10.0, -1.0) == -10.0
@@ -282,6 +272,16 @@ template main() =
     doAssert copySign(-1.0, NaN) == 1.0
     doAssert copySign(-1.0, -NaN) == -1.0
     doAssert copySign(1.0, copySign(NaN, -1.0)) == -1.0
+
+  block: # almostEqual
+    doAssert almostEqual(3.141592653589793, 3.1415926535897936)
+    doAssert almostEqual(1.6777215e7'f32, 1.6777216e7'f32)
+    doAssert almostEqual(Inf, Inf)
+    doAssert almostEqual(-Inf, -Inf)
+    doAssert not almostEqual(Inf, -Inf)
+    doAssert not almostEqual(-Inf, Inf)
+    doAssert not almostEqual(Inf, NaN)
+    doAssert not almostEqual(NaN, NaN)
 
   block: # round
     block: # Round to 0 decimal places

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -226,6 +226,16 @@ template main() =
     doAssert signbit(x2)
     doAssert signbit(x3)
 
+  block: # almostEqual
+    doAssert almostEqual(3.141592653589793, 3.1415926535897936)
+    doAssert almostEqual(1.6777215e7'f32, 1.6777216e7'f32)
+    doAssert almostEqual(Inf, Inf)
+    doAssert almostEqual(-Inf, -Inf)
+    doAssert not almostEqual(Inf, -Inf)
+    doAssert not almostEqual(-Inf, Inf)
+    doAssert not almostEqual(Inf, NaN)
+    doAssert not almostEqual(NaN, NaN)
+
   block: # copySign
     doAssert copySign(10.0, 1.0) == 10.0
     doAssert copySign(10.0, -1.0) == -10.0
@@ -269,17 +279,12 @@ template main() =
     doAssert copySign(-NaN, 0.0).isNaN
     doAssert copySign(-NaN, -0.0).isNaN
 
-  block: # almostEqual
-    doAssert almostEqual(3.141592653589793, 3.1415926535897936)
-    doAssert almostEqual(1.6777215e7'f32, 1.6777216e7'f32)
-    doAssert almostEqual(Inf, Inf)
-    doAssert almostEqual(-Inf, -Inf)
-    doAssert not almostEqual(Inf, -Inf)
-    doAssert not almostEqual(-Inf, Inf)
-    doAssert not almostEqual(Inf, NaN)
-    doAssert not almostEqual(NaN, NaN)
+    doAssert copySign(-1.0, NaN) == 1.0
+    doAssert copySign(-1.0, -NaN) == -1.0
+    doAssert copySign(1.0, copySign(NaN, -1.0)) == -1.0
+    doAssert copySign(1.0, -NaN) == -1.0 # pending https://github.com/timotheecour/Nim/issues/499
 
-  block: # round() tests
+  block: # round
     block: # Round to 0 decimal places
       doAssert round(54.652) == 55.0
       doAssert round(54.352) == 54.0
@@ -300,6 +305,7 @@ template main() =
       doAssert round(2.5) == 3.0
       doAssert round(2.5'f32) == 3.0'f32
       doAssert round(2.5'f64) == 3.0'f64
+
     block: # func round*[T: float32|float64](x: T, places: int): T
       doAssert round(54.345, 0) == 54.0
       template fn(x) =
@@ -311,15 +317,7 @@ template main() =
       fn(54.346)
       fn(54.346'f32)
 
-    when nimvm:
-      discard
-    else:
-      when not defined(js):
-        doAssert copySign(-1.0, -NaN) == -1.0
-        doAssert copySign(10.0, -NaN) == -10.0
-        doAssert copySign(1.0, copySign(NaN, -1.0)) == -1.0 # fails in VM
-
-  block:
+  block: # abs
     doAssert 1.0 / abs(-0.0) == Inf
     doAssert 1.0 / abs(0.0) == Inf
     doAssert -1.0 / abs(-0.0) == -Inf

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -197,6 +197,14 @@ template main() =
     doAssert: compiles(5.5 ^ 2.uint8)
     doAssert: not compiles(5.5 ^ 2.2)
 
+  block: # isNaN
+    doAssert NaN.isNaN
+    doAssert not Inf.isNaN
+    doAssert isNaN(Inf - Inf)
+    doAssert not isNaN(0.0)
+    doAssert not isNaN(3.1415926)
+    doAssert not isNaN(0'f32)
+
   block: # signbit
     doAssert not signbit(0.0)
     doAssert signbit(-0.0)
@@ -207,14 +215,6 @@ template main() =
     doAssert signbit(-Inf)
     doAssert not signbit(NaN)
 
-  block: # isNaN
-    doAssert NaN.isNaN
-    doAssert not Inf.isNaN
-    doAssert isNaN(Inf - Inf)
-    doAssert not isNaN(3.1415926)
-    doAssert not isNaN(0'f32)
-
-  block: # signbit
     let x1 = NaN
     let x2 = -NaN
     let x3 = -x1
@@ -282,7 +282,6 @@ template main() =
     doAssert copySign(-1.0, NaN) == 1.0
     doAssert copySign(-1.0, -NaN) == -1.0
     doAssert copySign(1.0, copySign(NaN, -1.0)) == -1.0
-    doAssert copySign(1.0, -NaN) == -1.0 # pending https://github.com/timotheecour/Nim/issues/499
 
   block: # round
     block: # Round to 0 decimal places

--- a/tests/vm/tcastint.nim
+++ b/tests/vm/tcastint.nim
@@ -1,7 +1,3 @@
-discard """
-  output: "OK"
-"""
-
 import macros
 
 type
@@ -292,16 +288,12 @@ proc test_float32_castB() =
   # any surprising content.
   doAssert cast[uint64](c) == 3270918144'u64
 
-test()
-test_float_cast()
-test_float32_cast()
-free_integer_casting()
-test_float32_castB()
-static:
+template main() =
   test()
   test_float_cast()
   test_float32_cast()
   free_integer_casting()
   test_float32_castB()
 
-echo "OK"
+static: main()
+main()


### PR DESCRIPTION
see updated tests

## future work
followup PR:
- [ ] toBitsImpl and jsSetSign should be merged into one proc, then they can use the same buffer.
https://github.com/nim-lang/Nim/pull/16609#discussion_r567196060