### PR TITLE
refactor cmpNimIdentifier

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1390,7 +1390,6 @@ when defined(nimVmEqIdent):
 
 else:
   from std/private/strimpl import cmpNimIdentifier
-  # this procedure is optimized for native code, it should not be compiled to nimVM bytecode.
 
   proc eqIdent*(a, b: string): bool = cmpNimIdentifier(a, b) == 0
     ## Check if two idents are equal.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1389,12 +1389,10 @@ when defined(nimVmEqIdent):
     ## these nodes will be unwrapped.
 
 else:
-  from std/private/strimpl import cmpIgnoreStyleImpl
+  from std/private/strimpl import cmpNimIdentifier
   # this procedure is optimized for native code, it should not be compiled to nimVM bytecode.
-  proc cmpIgnoreStyle(a, b: cstring): int {.noSideEffect.} =
-    cmpIgnoreStyleImpl(a, b, true)
 
-  proc eqIdent*(a, b: string): bool = cmpIgnoreStyle(a, b) == 0
+  proc eqIdent*(a, b: string): bool = cmpNimIdentifier(a, b) == 0
     ## Check if two idents are equal.
 
   proc eqIdent*(node: NimNode; s: string): bool {.compileTime.} =

--- a/lib/core/typeinfo.nim
+++ b/lib/core/typeinfo.nim
@@ -91,7 +91,7 @@ when not defined(gcDestructors):
 else:
   include system/seqs_v2_reimpl
 
-from std/private/strimpl import cmpIgnoreStyleImpl
+from std/private/strimpl import cmpNimIdentifier
 
 when not defined(js):
   template rawType(x: Any): PNimType =
@@ -367,9 +367,6 @@ iterator fields*(x: Any): tuple[name: string, any: Any] =
     fieldsAux(p, t.node, ret)
   for name, any in items(ret):
     yield ($name, any)
-
-proc cmpNimIdentifier(a, b: cstring): int {.noSideEffect.} =
-  cmpIgnoreStyleImpl(a, b, true)
 
 proc getFieldNode(p: pointer, n: ptr TNimNode,
                   name: cstring): ptr TNimNode =

--- a/lib/std/private/strimpl.nim
+++ b/lib/std/private/strimpl.nim
@@ -72,5 +72,5 @@ template endsWithImpl*[T: string | cstring](s, suffix: T) =
   if i >= suffixLen: return true
 
 
-func cmpNimIdentifier*[T: string | cstring](a, b: T): int {.noSideEffect.} =
+func cmpNimIdentifier*[T: string | cstring](a, b: T): int =
   cmpIgnoreStyleImpl(a, b, true)

--- a/lib/std/private/strimpl.nim
+++ b/lib/std/private/strimpl.nim
@@ -70,3 +70,7 @@ template endsWithImpl*[T: string | cstring](s, suffix: T) =
     if s[i+j] != suffix[i]: return false
     inc(i)
   if i >= suffixLen: return true
+
+
+func cmpNimIdentifier*[T: string | cstring](a, b: T): int {.noSideEffect.} =
+  cmpIgnoreStyleImpl(a, b, true)


### PR DESCRIPTION
I think some modules uses `cmpIgnoreStyle` instead of `cmpNimIdentifier` which seems wrong.

Though I don't change them in this PR.