### PR TITLE
RST: implement internal targets

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -560,7 +560,7 @@ proc getAllRunnableExamplesImpl(d: PDoc; n: PNode, dest: var Rope, state: Runnab
           "\n\\textbf{$1}\n", [msg.rope])
       inc d.listingCounter
       let id = $d.listingCounter
-      dest.add(d.config.getOrDefault"doc.listing_start" % [id, "langNim"])
+      dest.add(d.config.getOrDefault"doc.listing_start" % [id, "langNim", ""])
       var dest2 = ""
       renderNimCode(dest2, code, isLatex = d.conf.cmd == cmdRst2tex)
       dest.add dest2

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -206,6 +206,7 @@ $moduledesc
 $content
 """
 
+# $1 - number of listing in document, $2 - language (e.g. langNim), $3 - anchor
 doc.listing_start = "<pre$3 class=\"listing\">"
 doc.listing_end = "</pre>"
 

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -206,7 +206,7 @@ $moduledesc
 $content
 """
 
-doc.listing_start = "<pre class=\"listing\">"
+doc.listing_start = "<pre$3 class=\"listing\">"
 doc.listing_end = "</pre>"
 
 # * $analytics: Google analytics location, includes <script> tags

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -677,8 +677,8 @@ proc isInlineMarkupStart(p: RstParser, markup: string, twoTokens=false): bool =
   if not twoTokens:
     result = currentTok(p).symbol == markup
   else:
-    result = currentTok(p).symbol == markup[0..0] and
-               nextTok(p).symbol == markup[1..1]
+    result = currentTok(p).symbol == $markup[0] and
+               nextTok(p).symbol == $markup[1]
   if not result: return
   # Rule 6:
   result = p.idx == 0 or prevTok(p).kind in {tkIndent, tkWhite} or

--- a/lib/packages/docutils/rstast.nim
+++ b/lib/packages/docutils/rstast.nim
@@ -42,7 +42,7 @@ type
     rnLabel,                  # used for footnotes and other things
     rnFootnote,               # a footnote
     rnCitation,               # similar to footnote
-    rnStandaloneHyperlink, rnHyperlink, rnRef,
+    rnStandaloneHyperlink, rnHyperlink, rnRef, rnInternalRef,
     rnDirective,              # a general directive
     rnDirArg,                 # a directive argument (for some directives).
                               # here are directives that are not rnDirective:
@@ -62,6 +62,7 @@ type
     rnTripleEmphasis,         # "***"
     rnInterpretedText,        # "`"
     rnInlineLiteral,          # "``"
+    rnInlineTarget,           # "_`target`"
     rnSubstitutionReferences, # "|"
     rnSmiley,                 # some smiley
     rnLeaf                    # a leaf; the node's text field contains the
@@ -75,7 +76,9 @@ type
     text*: string             ## valid for leafs in the AST; and the title of
                               ## the document or the section; and rnEnumList
                               ## and rnAdmonition; and rnLineBlockItem
-    level*: int               ## valid for some node kinds
+    level*: int               ## valid for headlines/overlines only
+    anchor*: string           ## anchor, internal link target
+                              ## (aka HTML id tag, aka Latex label/hypertarget)
     sons*: RstNodeSeq        ## the node's sons
 
 proc len*(n: PRstNode): int =
@@ -330,8 +333,9 @@ proc renderRstToStr*(node: PRstNode, indent=0): string =
   if node == nil:
     result.add " ".repeat(indent) & "[nil]\n"
     return
-  result.add " ".repeat(indent) & $node.kind & "\t" &
-      (if node.text == "": "" else: "'" & node.text & "'") &
-      (if node.level == 0: "" else: "\tlevel=" & $node.level) & "\n"
+  result.add " ".repeat(indent) & $node.kind &
+      (if node.text == "":   "" else: "\t'" & node.text & "'") &
+      (if node.level == 0:   "" else: "\tlevel=" & $node.level) &
+      (if node.anchor == "": "" else: "\tanchor='" & node.anchor & "'") & "\n"
   for son in node.sons:
     result.add renderRstToStr(son, indent=indent+2)

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -625,6 +625,164 @@ Test1
     doAssert "endOfNote</div>" in output3
     doAssert "class=\"admonition admonition-info\"" in output3
 
+  test "RST internal links":
+    let input1 = dedent """
+      Start.
+
+      .. _target000:
+
+      Paragraph.
+
+      .. _target001:
+
+      * bullet list
+      * Y
+
+      .. _target002:
+
+      1. enumeration list
+      2. Y
+
+      .. _target003:
+
+      term 1
+        Definition list 1.
+
+      .. _target004:
+
+      | line block
+
+      .. _target005:
+
+      :a: field list value
+
+      .. _target006:
+
+      -a  option description
+
+      .. _target007:
+
+      ::
+
+        Literal block
+
+      .. _target008:
+
+      Doctest blocks are not implemented.
+
+      .. _target009:
+
+          block quote
+
+      .. _target010:
+
+      =====  =====  =======
+        A      B    A and B
+      =====  =====  =======
+      False  False  False
+      =====  =====  =======
+
+      .. _target100:
+
+      .. CAUTION:: admonition
+
+      .. _target101:
+
+      .. code:: nim
+
+         const pi = 3.14
+
+      .. _target102:
+
+      .. code-block::
+
+         const pi = 3.14
+
+      Paragraph2.
+
+      .. _target202:
+
+      ----
+
+      That was a transition.
+    """
+    let output1 = rstToHtml(input1, {roSupportMarkdown}, defaultConfig())
+    doAssert "<p id=\"target000\""     in output1
+    doAssert "<ul id=\"target001\""    in output1
+    doAssert "<ol id=\"target002\""    in output1
+    doAssert "<dl id=\"target003\""    in output1
+    doAssert "<p id=\"target004\""     in output1
+    doAssert "<table id=\"target005\"" in output1  # field list
+    doAssert "<table id=\"target006\"" in output1  # option list
+    doAssert "<pre id=\"target007\""   in output1
+    doAssert "<blockquote id=\"target009\"" in output1
+    doAssert "<table id=\"target010\"" in output1  # just table
+    doAssert "<span id=\"target100\""  in output1
+    doAssert "<pre id=\"target101\""   in output1  # code
+    doAssert "<pre id=\"target102\""   in output1  # code-block
+    doAssert "<hr id=\"target202\""    in output1
+
+  test "RST internal links for sections":
+    let input1 = dedent """
+      .. _target101:
+      .. _target102:
+
+      Section xyz
+      -----------
+
+      Ref. target101_
+    """
+    let output1 = rstToHtml(input1, {roSupportMarkdown}, defaultConfig())
+    # "target101" should be erased and changed to "section-xyz":
+    doAssert "href=\"#target101\"" notin output1
+    doAssert "id=\"target101\""    notin output1
+    doAssert "href=\"#target102\"" notin output1
+    doAssert "id=\"target102\""    notin output1
+    doAssert "id=\"section-xyz\""     in output1
+    doAssert "href=\"#section-xyz\""  in output1
+
+    let input2 = dedent """
+      .. _target300:
+
+      Section xyz
+      ===========
+
+      .. _target301:
+
+      SubsectionA
+      -----------
+
+      Ref. target300_ and target301_.
+    """
+    let output2 = rstToHtml(input2, {roSupportMarkdown}, defaultConfig())
+    # "target101" should be erased and changed to "section-xyz":
+    doAssert "href=\"#target300\"" notin output2
+    doAssert "id=\"target300\""    notin output2
+    doAssert "href=\"#target301\"" notin output2
+    doAssert "id=\"target301\""    notin output2
+    doAssert "<h1 id=\"section-xyz\"" in output2
+    doAssert "<h2 id=\"subsectiona\"" in output2
+    # links should preserve their original names but point to section labels:
+    doAssert "href=\"#section-xyz\">target300" in output2
+    doAssert "href=\"#subsectiona\">target301" in output2
+
+    let output2l = rstToLatex(input2, {})
+    doAssert "\\label{section-xyz}\\hypertarget{section-xyz}{}" in output2l
+    doAssert "\\hyperlink{section-xyz}{target300}"  in output2l
+    doAssert "\\hyperlink{subsectiona}{target301}"  in output2l
+
+  test "RST internal links (inline)":
+    let input1 = dedent """
+      Paragraph with _`some definition`.
+
+      Ref. `some definition`_.
+    """
+    let output1 = rstToHtml(input1, {roSupportMarkdown}, defaultConfig())
+    doAssert "<span class=\"target\" " &
+        "id=\"some-definition\">some definition</span>" in output1
+    doAssert "Ref. <a class=\"reference internal\" " &
+        "href=\"#some-definition\">some definition</a>" in output1
+
 suite "RST/Code highlight":
   test "Basic Python code highlight":
     let pythonCode = """


### PR DESCRIPTION
Currently rst.nim supports only
1. automatic generating anchors for sections
2. automatic generating anchors for procs and other Nim code in HTML

This PR implements ability to **manually** mark any RST body elements and text as anchors. 

Both ["outline" internal hyperlink targets](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-targets) and [inline internal targets](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-internal-targets) are supported according to the spec.

Examples of "outline" targets:
``` RST
.. _`concept definition`:

Paragraph.

.. _`my code example`:

.. code:: nim
   const pi = 3.14
```

Those targets can mark any top-level body elements, not only paragraphs and code, but also images, block quotes, line blocks, etc.

To anchor something inside a top level element, use inline targets, e.g. to make an anchor inside a paragraph:
``` RST
A _`concept definition` is a thing, that...
```

They can be referenced with the standard RST link syntax:

``` RST
Ref. `concept definition`_. See `my code example`_.
```

CC @narimiran .