### PR TITLE
DELETE requests should always have a content-length header

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -980,7 +980,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url, httpMethod: string,
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
-  elif httpMethod in ["POST", "PATCH", "PUT"] or body.len != 0:
+  elif httpMethod in ["POST", "PATCH", "PUT", "DELETE"] or body.len != 0:
     client.headers["Content-Length"] = $body.len
 
   when client is AsyncHttpClient:

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -980,8 +980,11 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url, httpMethod: string,
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
-  elif httpMethod in ["POST", "PATCH", "PUT", "DELETE"] or body.len != 0:
-    client.headers["Content-Length"] = $body.len
+  else:
+    if body.len != 0:
+      client.headers["Content-Length"] = $body.len
+    elif httpMethod notin ["GET", "HEAD"] and not client.headers.hasKey("Content-Length"):
+      client.headers["Content-Length"] = "0"
 
   when client is AsyncHttpClient:
     if not client.parseBodyFut.isNil:


### PR DESCRIPTION
Not having DELETE in this list is causing hanging when trying to close webdriver sessions in [halonium](https://github.com/halonium/halonium/issues/10) and likely any other implementation of the webdriver protocol. Both at least chromedriver and geckodriver are affected by this issue.