### PR TITLE
Refactoring `bitops.rotateLeftBits()` and `bitops.rotateRightBits()`; adding builtins and intrinsics.

### DIFF
--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -735,24 +735,24 @@ when useBuiltinsRotate:
     # GCC was tested until version 4.8.1 and intrinsics were present. Not tested
     # in previous versions.
     func builtin_rotl8(value: cuchar, shift: cint): cuchar
-                       {.importc: "__rolb", header: "x86intrin.h".}
+                      {.importc: "__rolb", header: "<x86intrin.h>".}
     func builtin_rotl16(value: cushort, shift: cint): cushort
-                       {.importc: "__rolw", header: "x86intrin.h".}
+                       {.importc: "__rolw", header: "<x86intrin.h>".}
     func builtin_rotl32(value: cuint, shift: cint): cuint
-                       {.importc: "__rold", header: "x86intrin.h".}
+                       {.importc: "__rold", header: "<x86intrin.h>".}
     when defined(amd64):
       func builtin_rotl64(value: culonglong, shift: cint): culonglong
-                         {.importc: "__rolq", header: "x86intrin.h".}
+                         {.importc: "__rolq", header: "<x86intrin.h>".}
 
     func builtin_rotr8(value: cuchar, shift: cint): cuchar
-                      {.importc: "__rorb", header: "x86intrin.h".}
+                      {.importc: "__rorb", header: "<x86intrin.h>".}
     func builtin_rotr16(value: cushort, shift: cint): cushort
-                       {.importc: "__rorw", header: "x86intrin.h".}
+                       {.importc: "__rorw", header: "<x86intrin.h>".}
     func builtin_rotr32(value: cuint, shift: cint): cuint
-                       {.importc: "__rord", header: "x86intrin.h".}
+                       {.importc: "__rord", header: "<x86intrin.h>".}
     when defined(amd64):
       func builtin_rotr64(value: culonglong, shift: cint): culonglong
-                         {.importc: "__rorq", header: "x86intrin.h".}
+                         {.importc: "__rorq", header: "<x86intrin.h>".}
   elif defined(clang):
     # In CLANG, builtins have been present since version 8.0.0 and intrinsics
     # since version 9.0.0. This implementation chose the builtins, as they have
@@ -760,7 +760,7 @@ when useBuiltinsRotate:
     # https://releases.llvm.org/8.0.0/tools/clang/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release
     # https://releases.llvm.org/8.0.0/tools/clang/docs/LanguageExtensions.html#builtin-rotateleft
     func builtin_rotl8(value: cuchar, shift: cuchar): cuchar
-                       {.importc: "__builtin_rotateleft8".}
+                      {.importc: "__builtin_rotateleft8".}
     func builtin_rotl16(value: cushort, shift: cushort): cushort
                        {.importc: "__builtin_rotateleft16".}
     func builtin_rotl32(value: cuint, shift: cuint): cuint
@@ -785,54 +785,56 @@ when useBuiltinsRotate:
     # https://docs.microsoft.com/en-us/cpp/intrinsics/rotr8-rotr16?view=msvc-160
     # https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/rotl-rotl64-rotr-rotr64?view=msvc-160
     func builtin_rotl8(value: cuchar, shift: cuchar): cuchar
-                      {.importc: "_rotl8", header: "intrin.h".}
+                      {.importc: "_rotl8", header: "<intrin.h>".}
     func builtin_rotl16(value: cushort, shift: cuchar): cushort
-                       {.importc: "_rotl16", header: "intrin.h".}
+                       {.importc: "_rotl16", header: "<intrin.h>".}
     func builtin_rotl32(value: cuint, shift: cint): cuint
-                       {.importc: "_rotl", header: "stdlib.h".}
+                       {.importc: "_rotl", header: "<stdlib.h>".}
     when defined(amd64):
       func builtin_rotl64(value: culonglong, shift: cint): culonglong
-                         {.importc: "_rotl64", header: "stdlib.h".}
+                         {.importc: "_rotl64", header: "<stdlib.h>".}
 
     func builtin_rotr8(value: cuchar, shift: cuchar): cuchar
-                      {.importc: "_rotr8", header: "intrin.h".}
+                      {.importc: "_rotr8", header: "<intrin.h>".}
     func builtin_rotr16(value: cushort, shift: cuchar): cushort
-                       {.importc: "_rotr16", header: "intrin.h".}
+                       {.importc: "_rotr16", header: "<intrin.h>".}
     func builtin_rotr32(value: cuint, shift: cint): cuint
-                       {.importc: "_rotr", header: "stdlib.h".}
+                       {.importc: "_rotr", header: "<stdlib.h>".}
     when defined(amd64):
       func builtin_rotr64(value: culonglong, shift: cint): culonglong
-                         {.importc: "_rotr64", header: "stdlib.h".}
+                         {.importc: "_rotr64", header: "<stdlib.h>".}
   elif defined(icl):
     # Tested on Intel(R) C++ Intel(R) 64 Compiler Classic Version 2021.1.2 Build
     # 20201208_000000 x64 and x86. Not tested in previous versions.
     func builtin_rotl8(value: cuchar, shift: cint): cuchar
-                      {.importc: "__rolb", header: "immintrin.h".}
+                      {.importc: "__rolb", header: "<immintrin.h>".}
     func builtin_rotl16(value: cushort, shift: cint): cushort
-                       {.importc: "__rolw", header: "immintrin.h".}
+                       {.importc: "__rolw", header: "<immintrin.h>".}
     func builtin_rotl32(value: cuint, shift: cint): cuint
-                       {.importc: "__rold", header: "immintrin.h".}
+                       {.importc: "__rold", header: "<immintrin.h>".}
     when defined(amd64):
       func builtin_rotl64(value: culonglong, shift: cint): culonglong
-                         {.importc: "__rolq", header: "immintrin.h".}
+                         {.importc: "__rolq", header: "<immintrin.h>".}
 
     func builtin_rotr8(value: cuchar, shift: cint): cuchar
-                      {.importc: "__rorb", header: "immintrin.h".}
+                      {.importc: "__rorb", header: "<immintrin.h>".}
     func builtin_rotr16(value: cushort, shift: cint): cushort
-                       {.importc: "__rorw", header: "immintrin.h".}
+                       {.importc: "__rorw", header: "<immintrin.h>".}
     func builtin_rotr32(value: cuint, shift: cint): cuint
-                       {.importc: "__rord", header: "immintrin.h".}
+                       {.importc: "__rord", header: "<immintrin.h>".}
     when defined(amd64):
       func builtin_rotr64(value: culonglong, shift: cint): culonglong
-                         {.importc: "__rorq", header: "immintrin.h".}
+                         {.importc: "__rorq", header: "<immintrin.h>".}
 
 func rotl[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
+  ## Left-rotate bits in a `SomeUnsignedInt` value.
   # https://stackoverflow.com/a/776523
   const mask = 8 * sizeof(value) - 1
   let rot = rot and mask
   (value shl rot) or (value shr ((-rot) and mask))
 
 func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
+  ## Right-rotate bits in a `SomeUnsignedInt` value.
   const mask = 8 * sizeof(value) - 1
   let rot = rot and mask
   (value shr rot) or (value shl ((-rot) and mask))

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -759,6 +759,7 @@ when useBuiltinsRotate:
     # been around for longer.
     # https://releases.llvm.org/8.0.0/tools/clang/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release
     # https://releases.llvm.org/8.0.0/tools/clang/docs/LanguageExtensions.html#builtin-rotateleft
+    # source for correct declarations: https://github.com/llvm/llvm-project/blob/main/clang/include/clang/Basic/Builtins.def
     func builtin_rotl8(value: cuchar, shift: cuchar): cuchar
                       {.importc: "__builtin_rotateleft8", nodecl.}
     func builtin_rotl16(value: cushort, shift: cushort): cushort

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -760,24 +760,24 @@ when useBuiltinsRotate:
     # https://releases.llvm.org/8.0.0/tools/clang/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release
     # https://releases.llvm.org/8.0.0/tools/clang/docs/LanguageExtensions.html#builtin-rotateleft
     func builtin_rotl8(value: cuchar, shift: cuchar): cuchar
-                      {.importc: "__builtin_rotateleft8".}
+                      {.importc: "__builtin_rotateleft8", noDecl.}
     func builtin_rotl16(value: cushort, shift: cushort): cushort
-                       {.importc: "__builtin_rotateleft16".}
+                       {.importc: "__builtin_rotateleft16", noDecl.}
     func builtin_rotl32(value: cuint, shift: cuint): cuint
-                       {.importc: "__builtin_rotateleft32".}
+                       {.importc: "__builtin_rotateleft32", noDecl.}
     when defined(amd64):
       func builtin_rotl64(value: culonglong, shift: culonglong): culonglong
-                         {.importc: "__builtin_rotateleft64".}
+                         {.importc: "__builtin_rotateleft64", noDecl.}
     
     func builtin_rotr8(value: cuchar, shift: cuchar): cuchar
-                      {.importc: "__builtin_rotateright8".}
+                      {.importc: "__builtin_rotateright8", noDecl.}
     func builtin_rotr16(value: cushort, shift: cushort): cushort
-                       {.importc: "__builtin_rotateright16".}
+                       {.importc: "__builtin_rotateright16", noDecl.}
     func builtin_rotr32(value: cuint, shift: cuint): cuint
-                       {.importc: "__builtin_rotateright32".}
+                       {.importc: "__builtin_rotateright32", noDecl.}
     when defined(amd64):
       func builtin_rotr64(value: culonglong, shift: culonglong): culonglong
-                         {.importc: "__builtin_rotateright64".}
+                         {.importc: "__builtin_rotateright64", noDecl.}
   elif defined(vcc):
     # Tested on Microsoft (R) C/C++ Optimizing Compiler 19.28.29335 x64 and x86.
     # Not tested in previous versions.

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -776,6 +776,7 @@ when useBuiltinsRotate:
     func builtin_rotr32(value: cuint, shift: cuint): cuint
                        {.importc: "__builtin_rotateright32", nodecl.}
     when defined(amd64):
+      # shift is unsigned, refs https://github.com/llvm-mirror/clang/commit/892de415b7fde609dafc4e6c1643b7eaa0150a4d
       func builtin_rotr64(value: culonglong, shift: culonglong): culonglong
                          {.importc: "__builtin_rotateright64", nodecl.}
   elif defined(vcc):

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -760,24 +760,24 @@ when useBuiltinsRotate:
     # https://releases.llvm.org/8.0.0/tools/clang/docs/ReleaseNotes.html#non-comprehensive-list-of-changes-in-this-release
     # https://releases.llvm.org/8.0.0/tools/clang/docs/LanguageExtensions.html#builtin-rotateleft
     func builtin_rotl8(value: cuchar, shift: cuchar): cuchar
-                      {.importc: "__builtin_rotateleft8", noDecl.}
+                      {.importc: "__builtin_rotateleft8", nodecl.}
     func builtin_rotl16(value: cushort, shift: cushort): cushort
-                       {.importc: "__builtin_rotateleft16", noDecl.}
+                       {.importc: "__builtin_rotateleft16", nodecl.}
     func builtin_rotl32(value: cuint, shift: cuint): cuint
-                       {.importc: "__builtin_rotateleft32", noDecl.}
+                       {.importc: "__builtin_rotateleft32", nodecl.}
     when defined(amd64):
       func builtin_rotl64(value: culonglong, shift: culonglong): culonglong
-                         {.importc: "__builtin_rotateleft64", noDecl.}
+                         {.importc: "__builtin_rotateleft64", nodecl.}
     
     func builtin_rotr8(value: cuchar, shift: cuchar): cuchar
-                      {.importc: "__builtin_rotateright8", noDecl.}
+                      {.importc: "__builtin_rotateright8", nodecl.}
     func builtin_rotr16(value: cushort, shift: cushort): cushort
-                       {.importc: "__builtin_rotateright16", noDecl.}
+                       {.importc: "__builtin_rotateright16", nodecl.}
     func builtin_rotr32(value: cuint, shift: cuint): cuint
-                       {.importc: "__builtin_rotateright32", noDecl.}
+                       {.importc: "__builtin_rotateright32", nodecl.}
     when defined(amd64):
       func builtin_rotr64(value: culonglong, shift: culonglong): culonglong
-                         {.importc: "__builtin_rotateright64", noDecl.}
+                         {.importc: "__builtin_rotateright64", nodecl.}
   elif defined(vcc):
     # Tested on Microsoft (R) C/C++ Optimizing Compiler 19.28.29335 x64 and x86.
     # Not tested in previous versions.

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -845,10 +845,10 @@ func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
 func rotateLeftBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
   ## Left-rotate bits in a 8-bits value.
   runnableExamples:
-    doAssert rotateLeftBits(0b0000_0001'u8, 1) == 0b0000_0010'u8
-    doAssert rotateLeftBits(0b0000_0001'u8, 2) == 0b0000_0100'u8
-    doAssert rotateLeftBits(0b0100_0001'u8, 1) == 0b1000_0010'u8
-    doAssert rotateLeftBits(0b0100_0001'u8, 2) == 0b0000_0101'u8
+    doAssert rotateLeftBits(0b0110_1001'u8, 1) == 0b1101_0010'u8
+    doAssert rotateLeftBits(0b0110_1001'u8, 2) == 0b1010_0101'u8
+    doAssert rotateLeftBits(0b0110_1001'u8, 3) == 0b0100_1011'u8
+    doAssert rotateLeftBits(0b0110_1001'u8, 4) == 0b1001_0110'u8
   
   when nimvm:
     rotl(value, shift.int32)
@@ -865,9 +865,16 @@ func rotateLeftBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
 
 func rotateLeftBits*(value: uint16, shift: range[0..16]): uint16 {.inline.} =
   ## Left-rotate bits in a 16-bits value.
-  ##
-  ## See also:
-  ## * `rotateLeftBits proc <#rotateLeftBits,uint8,range[]>`_
+  runnableExamples:
+    doAssert rotateLeftBits(0b00111100_11000011'u16, 1) ==
+      0b01111001_10000110'u16
+    doAssert rotateLeftBits(0b00111100_11000011'u16, 3) ==
+      0b11100110_00011001'u16
+    doAssert rotateLeftBits(0b00111100_11000011'u16, 6) ==
+      0b00110000_11001111'u16
+    doAssert rotateLeftBits(0b00111100_11000011'u16, 8) ==
+      0b11000011_00111100'u16
+
   when nimvm:
     rotl(value, shift.int32)
   else:
@@ -883,9 +890,16 @@ func rotateLeftBits*(value: uint16, shift: range[0..16]): uint16 {.inline.} =
 
 func rotateLeftBits*(value: uint32, shift: range[0..32]): uint32 {.inline.} =
   ## Left-rotate bits in a 32-bits value.
-  ##
-  ## See also:
-  ## * `rotateLeftBits proc <#rotateLeftBits,uint8,range[]>`_
+  runnableExamples:
+    doAssert rotateLeftBits(0b0000111111110000_1111000000001111'u32, 1) ==
+      0b0001111111100001_1110000000011110'u32
+    doAssert rotateLeftBits(0b0000111111110000_1111000000001111'u32, 5) ==
+      0b1111111000011110_0000000111100001'u32
+    doAssert rotateLeftBits(0b0000111111110000_1111000000001111'u32, 12) ==
+      0b0000111100000000_1111000011111111'u32
+    doAssert rotateLeftBits(0b0000111111110000_1111000000001111'u32, 16) ==
+      0b1111000000001111_0000111111110000'u32
+  
   when nimvm:
     rotl(value, shift.int32)
   else:
@@ -899,9 +913,16 @@ func rotateLeftBits*(value: uint32, shift: range[0..32]): uint32 {.inline.} =
 
 func rotateLeftBits*(value: uint64, shift: range[0..64]): uint64 {.inline.} =
   ## Left-rotate bits in a 64-bits value.
-  ##
-  ## See also:
-  ## * `rotateLeftBits proc <#rotateLeftBits,uint8,range[]>`_
+  runnableExamples:
+    doAssert rotateLeftBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 1) ==
+      0b00000001111111111111111000000001_11111110000000000000000111111110'u64
+    doAssert rotateLeftBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 9) ==
+      0b11111111111111100000000111111110_00000000000000011111111000000001'u64
+    doAssert rotateLeftBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 24) ==
+      0b00000000111111110000000000000000_11111111000000001111111111111111'u64
+    doAssert rotateLeftBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 32) ==
+      0b11111111000000000000000011111111_00000000111111111111111100000000'u64
+
   when nimvm:
     rotl(value, shift.int32)
   else:
@@ -916,10 +937,10 @@ func rotateLeftBits*(value: uint64, shift: range[0..64]): uint64 {.inline.} =
 func rotateRightBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
   ## Right-rotate bits in a 8-bits value.
   runnableExamples:
-    doAssert rotateRightBits(0b0000_0001'u8, 1) == 0b1000_0000'u8
-    doAssert rotateRightBits(0b0000_0001'u8, 2) == 0b0100_0000'u8
-    doAssert rotateRightBits(0b0100_0001'u8, 1) == 0b1010_0000'u8
-    doAssert rotateRightBits(0b0100_0001'u8, 2) == 0b0101_0000'u8
+    doAssert rotateRightBits(0b0110_1001'u8, 1) == 0b1011_0100'u8
+    doAssert rotateRightBits(0b0110_1001'u8, 2) == 0b0101_1010'u8
+    doAssert rotateRightBits(0b0110_1001'u8, 3) == 0b0010_1101'u8
+    doAssert rotateRightBits(0b0110_1001'u8, 4) == 0b1001_0110'u8
 
   when nimvm:
     rotr(value, shift.int32)
@@ -936,9 +957,16 @@ func rotateRightBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
 
 func rotateRightBits*(value: uint16, shift: range[0..16]): uint16 {.inline.} =
   ## Right-rotate bits in a 16-bits value.
-  ##
-  ## See also:
-  ## * `rotateRightBits proc <#rotateRightBits,uint8,range[]>`_
+  runnableExamples:
+    doAssert rotateRightBits(0b00111100_11000011'u16, 1) ==
+      0b10011110_01100001'u16
+    doAssert rotateRightBits(0b00111100_11000011'u16, 3) ==
+      0b01100111_10011000'u16
+    doAssert rotateRightBits(0b00111100_11000011'u16, 6) ==
+      0b00001100_11110011'u16
+    doAssert rotateRightBits(0b00111100_11000011'u16, 8) ==
+      0b11000011_00111100'u16
+
   when nimvm:
     rotr(value, shift.int32)
   else:
@@ -954,9 +982,16 @@ func rotateRightBits*(value: uint16, shift: range[0..16]): uint16 {.inline.} =
 
 func rotateRightBits*(value: uint32, shift: range[0..32]): uint32 {.inline.} =
   ## Right-rotate bits in a 32-bits value.
-  ##
-  ## See also:
-  ## * `rotateRightBits proc <#rotateRightBits,uint8,range[]>`_
+  runnableExamples:
+    doAssert rotateRightBits(0b0000111111110000_1111000000001111'u32, 1) ==
+      0b1000011111111000_0111100000000111'u32
+    doAssert rotateRightBits(0b0000111111110000_1111000000001111'u32, 5) ==
+      0b0111100001111111_1000011110000000'u32
+    doAssert rotateRightBits(0b0000111111110000_1111000000001111'u32, 12) ==
+      0b0000000011110000_1111111100001111'u32
+    doAssert rotateRightBits(0b0000111111110000_1111000000001111'u32, 16) ==
+      0b1111000000001111_0000111111110000'u32
+
   when nimvm:
     rotr(value, shift.int32)
   else:
@@ -970,9 +1005,16 @@ func rotateRightBits*(value: uint32, shift: range[0..32]): uint32 {.inline.} =
 
 func rotateRightBits*(value: uint64, shift: range[0..64]): uint64 {.inline.} =
   ## Right-rotate bits in a 64-bits value.
-  ##
-  ## See also:
-  ## * `rotateRightBits proc <#rotateRightBits,uint8,range[]>`_
+  runnableExamples:
+    doAssert rotateRightBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 1) ==
+      0b10000000011111111111111110000000_01111111100000000000000001111111'u64
+    doAssert rotateRightBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 9) ==
+      0b01111111100000000111111111111111_10000000011111111000000000000000'u64
+    doAssert rotateRightBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 24) ==
+      0b00000000000000001111111100000000_11111111111111110000000011111111'u64
+    doAssert rotateRightBits(0b00000000111111111111111100000000_11111111000000000000000011111111'u64, 32) ==
+      0b11111111000000000000000011111111_00000000111111111111111100000000'u64
+
   when nimvm:
     rotr(value, shift.int32)
   else:

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -739,7 +739,7 @@ when useBuiltinsRotate:
                        {.importc: "__rolw", header: "x86intrin.h".}
     func builtin_rotl32(value: uint32, shift: int32): uint32
                        {.importc: "__rold", header: "x86intrin.h".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotl64(value: uint64, shift: int32): uint64
                          {.importc: "__rolq", header: "x86intrin.h".}
 
@@ -749,7 +749,7 @@ when useBuiltinsRotate:
                        {.importc: "__rorw", header: "x86intrin.h".}
     func builtin_rotr32(value: uint32, shift: int32): uint32
                        {.importc: "__rord", header: "x86intrin.h".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotr64(value: uint64, shift: int32): uint64
                          {.importc: "__rorq", header: "x86intrin.h".}
   elif defined(clang):
@@ -762,7 +762,7 @@ when useBuiltinsRotate:
                        {.importc: "__builtin_rotateleft16".}
     func builtin_rotl32(value: cuint, shift: cuint): cuint
                        {.importc: "__builtin_rotateleft32".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotl64(value: culonglong, shift: culonglong): culonglong
                          {.importc: "__builtin_rotateleft64".}
     
@@ -772,7 +772,7 @@ when useBuiltinsRotate:
                        {.importc: "__builtin_rotateright16".}
     func builtin_rotr32(value: cuint, shift: cuint): cuint
                        {.importc: "__builtin_rotateright32".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotr64(value: culonglong, shift: culonglong): culonglong
                          {.importc: "__builtin_rotateright64".}
   elif defined(vcc):
@@ -785,7 +785,7 @@ when useBuiltinsRotate:
                        {.importc: "_rotl16", header: "intrin.h".}
     func builtin_rotl32(value: uint32, shift: int32): uint32
                        {.importc: "_rotl", header: "stdlib.h".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotl64(value: uint64, shift: int32): uint64
                          {.importc: "_rotl64", header: "stdlib.h".}
 
@@ -795,7 +795,7 @@ when useBuiltinsRotate:
                        {.importc: "_rotr16", header: "intrin.h".}
     func builtin_rotr32(value: uint32, shift: int32): uint32
                        {.importc: "_rotr", header: "stdlib.h".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotr64(value: uint64, shift: int32): uint64
                          {.importc: "_rotr64", header: "stdlib.h".}
   elif defined(icl):
@@ -805,7 +805,7 @@ when useBuiltinsRotate:
                        {.importc: "__rolw", header: "immintrin.h".}
     func builtin_rotl32(value: uint32, shift: int32): uint32
                        {.importc: "__rold", header: "immintrin.h".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotl64(value: uint64, shift: int32): uint64
                          {.importc: "__rolq", header: "immintrin.h".}
 
@@ -815,22 +815,21 @@ when useBuiltinsRotate:
                        {.importc: "__rorw", header: "immintrin.h".}
     func builtin_rotr32(value: uint32, shift: int32): uint32
                        {.importc: "__rord", header: "immintrin.h".}
-    when arch64:
+    when defined(amd64):
       func builtin_rotr64(value: uint64, shift: int32): uint64
                          {.importc: "__rorq", header: "immintrin.h".}
 
-when not useBuiltinsRotate or not arch64:
-  # https://blog.regehr.org/archives/1063
-  # https://stackoverflow.com/a/776523
-  # The GCC compiler recognizes this code as rotation and inserts a single x86/x86_64 rol/ror instruction since version 4.9.0 for SomeUnsignedInt.
-  # The CLANG compiler recognizes this code as rotation and inserts a single x86/x86_64 rol/ror instruction on version 8.0.0 and 11.0.0 for SomeUnsignedInt. CLANG from 7.0.0, 9.0.0 to 10.0.0 does not recognize for uint8 and uint16.
-  func rotl[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
-    const mask: int32 = 8 * sizeof(value) - 1
-    (value shl rot) or (value shr (-rot and mask))
+# https://blog.regehr.org/archives/1063
+# https://stackoverflow.com/a/776523
+# The GCC compiler recognizes this code as rotation and inserts a single x86/x86_64 rol/ror instruction since version 4.9.0 for SomeUnsignedInt.
+# The CLANG compiler recognizes this code as rotation and inserts a single x86/x86_64 rol/ror instruction on version 8.0.0 and 11.0.0 for SomeUnsignedInt. CLANG from 7.0.0, 9.0.0 to 10.0.0 does not recognize for uint8 and uint16.
+func rotl[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
+  const mask: int32 = 8 * sizeof(value) - 1
+  (value shl rot) or (value shr (-rot and mask))
 
-  func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
-    const mask: int32 = 8 * sizeof(value) - 1
-    (value shr rot) or (value shl (-rot and mask))
+func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
+  const mask: int32 = 8 * sizeof(value) - 1
+  (value shr rot) or (value shl (-rot and mask))
 
 func rotateLeftBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
   ## Left-rotate bits in a 8-bits value.
@@ -839,57 +838,69 @@ func rotateLeftBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
     doAssert rotateLeftBits(0b0000_0001'u8, 2) == 0b0000_0100'u8
     doAssert rotateLeftBits(0b0100_0001'u8, 1) == 0b1000_0010'u8
     doAssert rotateLeftBits(0b0100_0001'u8, 2) == 0b0000_0101'u8
-
-  when useBuiltinsRotate:
-    when defined(gcc) or defined(icl):
-      builtin_rotl8(value, shift.int32)
-    elif defined(clang):
-      builtin_rotl8(value.cuchar, shift.cuchar).uint8
-    elif defined(vcc):
-      builtin_rotl8(value, shift.uint8)
-  else:
+  
+  when nimvm:
     rotl(value, shift.int32)
+  else:
+    when useBuiltinsRotate:
+      when defined(gcc) or defined(icl):
+        builtin_rotl8(value, shift.int32)
+      elif defined(clang):
+        builtin_rotl8(value.cuchar, shift.cuchar).uint8
+      elif defined(vcc):
+        builtin_rotl8(value, shift.uint8)
+    else:
+      rotl(value, shift.int32)
 
 func rotateLeftBits*(value: uint16, shift: range[0..16]): uint16 {.inline.} =
   ## Left-rotate bits in a 16-bits value.
   ##
   ## See also:
   ## * `rotateLeftBits proc <#rotateLeftBits,uint8,range[]>`_
-  when useBuiltinsRotate:
-    when defined(gcc) or defined(icl):
-      builtin_rotl16(value, shift.int32)
-    elif defined(clang):
-      builtin_rotl16(value.cushort, shift.cushort).uint16
-    elif defined(vcc):
-      builtin_rotl16(value, shift.uint8)
-  else:
+  when nimvm:
     rotl(value, shift.int32)
+  else:
+    when useBuiltinsRotate:
+      when defined(gcc) or defined(icl):
+        builtin_rotl16(value, shift.int32)
+      elif defined(clang):
+        builtin_rotl16(value.cushort, shift.cushort).uint16
+      elif defined(vcc):
+        builtin_rotl16(value, shift.uint8)
+    else:
+      rotl(value, shift.int32)
 
 func rotateLeftBits*(value: uint32, shift: range[0..32]): uint32 {.inline.} =
   ## Left-rotate bits in a 32-bits value.
   ##
   ## See also:
   ## * `rotateLeftBits proc <#rotateLeftBits,uint8,range[]>`_
-  when useBuiltinsRotate:
-    when defined(clang):
-      builtin_rotl32(value.cuint, shift.cuint).uint32
-    else:
-      builtin_rotl32(value, shift.int32)
-  else:
+  when nimvm:
     rotl(value, shift.int32)
+  else:
+    when useBuiltinsRotate:
+      when defined(clang):
+        builtin_rotl32(value.cuint, shift.cuint).uint32
+      else:
+        builtin_rotl32(value, shift.int32)
+    else:
+      rotl(value, shift.int32)
 
 func rotateLeftBits*(value: uint64, shift: range[0..64]): uint64 {.inline.} =
   ## Left-rotate bits in a 64-bits value.
   ##
   ## See also:
   ## * `rotateLeftBits proc <#rotateLeftBits,uint8,range[]>`_
-  when useBuiltinsRotate and arch64:
-    when defined(clang):
-      builtin_rotl64(value.culonglong, shift.culonglong).uint64
-    else:
-      builtin_rotl64(value, shift.int32)
-  else:
+  when nimvm:
     rotl(value, shift.int32)
+  else:
+    when useBuiltinsRotate and defined(amd64):
+      when defined(clang):
+        builtin_rotl64(value.culonglong, shift.culonglong).uint64
+      else:
+        builtin_rotl64(value, shift.int32)
+    else:
+      rotl(value, shift.int32)
 
 func rotateRightBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
   ## Right-rotate bits in a 8-bits value.
@@ -899,56 +910,68 @@ func rotateRightBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
     doAssert rotateRightBits(0b0100_0001'u8, 1) == 0b1010_0000'u8
     doAssert rotateRightBits(0b0100_0001'u8, 2) == 0b0101_0000'u8
 
-  when useBuiltinsRotate:
-    when defined(gcc) or defined(icl):
-      builtin_rotr8(value, shift.int32)
-    elif defined(clang):
-      builtin_rotr8(value.cuchar, shift.cuchar).uint8
-    elif defined(vcc):
-      builtin_rotr8(value, shift.uint8)
-  else:
+  when nimvm:
     rotr(value, shift.int32)
+  else:
+    when useBuiltinsRotate:
+      when defined(gcc) or defined(icl):
+        builtin_rotr8(value, shift.int32)
+      elif defined(clang):
+        builtin_rotr8(value.cuchar, shift.cuchar).uint8
+      elif defined(vcc):
+        builtin_rotr8(value, shift.uint8)
+    else:
+      rotr(value, shift.int32)
 
 func rotateRightBits*(value: uint16, shift: range[0..16]): uint16 {.inline.} =
   ## Right-rotate bits in a 16-bits value.
   ##
   ## See also:
   ## * `rotateRightBits proc <#rotateRightBits,uint8,range[]>`_
-  when useBuiltinsRotate:
-    when defined(gcc) or defined(icl):
-      builtin_rotr16(value, shift.int32)
-    elif defined(clang):
-      builtin_rotr16(value.cushort, shift.cushort).uint16
-    elif defined(vcc):
-      builtin_rotr16(value, shift.uint8)
-  else:
+  when nimvm:
     rotr(value, shift.int32)
+  else:
+    when useBuiltinsRotate:
+      when defined(gcc) or defined(icl):
+        builtin_rotr16(value, shift.int32)
+      elif defined(clang):
+        builtin_rotr16(value.cushort, shift.cushort).uint16
+      elif defined(vcc):
+        builtin_rotr16(value, shift.uint8)
+    else:
+      rotr(value, shift.int32)
 
 func rotateRightBits*(value: uint32, shift: range[0..32]): uint32 {.inline.} =
   ## Right-rotate bits in a 32-bits value.
   ##
   ## See also:
   ## * `rotateRightBits proc <#rotateRightBits,uint8,range[]>`_
-  when useBuiltinsRotate:
-    when defined(clang):
-      builtin_rotr32(value.cuint, shift.cuint).uint32
-    else:
-      builtin_rotr32(value, shift.int32)
-  else:
+  when nimvm:
     rotr(value, shift.int32)
+  else:
+    when useBuiltinsRotate:
+      when defined(clang):
+        builtin_rotr32(value.cuint, shift.cuint).uint32
+      else:
+        builtin_rotr32(value, shift.int32)
+    else:
+      rotr(value, shift.int32)
 
 func rotateRightBits*(value: uint64, shift: range[0..64]): uint64 {.inline.} =
   ## Right-rotate bits in a 64-bits value.
   ##
   ## See also:
   ## * `rotateRightBits proc <#rotateRightBits,uint8,range[]>`_
-  when useBuiltinsRotate and arch64:
-    when defined(clang):
-      builtin_rotr64(value.culonglong, shift.culonglong).uint64
-    else:
-      builtin_rotr64(value, shift.int32)
-  else:
+  when nimvm:
     rotr(value, shift.int32)
+  else:
+    when useBuiltinsRotate and defined(amd64):
+      when defined(clang):
+        builtin_rotr64(value.culonglong, shift.culonglong).uint64
+      else:
+        builtin_rotr64(value, shift.int32)
+    else:
+      rotr(value, shift.int32)
 
 proc repeatBits[T: SomeUnsignedInt](x: SomeUnsignedInt; retType: type[T]): T {.
   noSideEffect.} =

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -826,21 +826,16 @@ when useBuiltinsRotate:
       func builtin_rotr64(value: culonglong, shift: cint): culonglong
                          {.importc: "__rorq", header: "immintrin.h".}
 
-# https://blog.regehr.org/archives/1063
-# https://stackoverflow.com/a/776523
-# - The GCC compiler recognizes this code as rotation and inserts a single
-#   x86/x86_64 rol/ror instruction since version 4.9.0 for `SomeUnsignedInt`.
-# - The CLANG compiler recognizes this code as rotation and inserts a single
-#   x86/x86_64 rol/ror instruction on version 8.0.0 and 11.0.0 to 12.0.0 for
-#   `SomeUnsignedInt`. CLANG from 7.0.0, 9.0.0 to 10.0.0 does not recognize for
-#   uint8 and uint16.
 func rotl[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
-  const mask: int32 = 8 * sizeof(value) - 1
-  (value shl rot) or (value shr (-rot and mask))
+  # https://stackoverflow.com/a/776523
+  const mask = 8 * sizeof(value) - 1
+  let rot = rot and mask
+  (value shl rot) or (value shr ((-rot) and mask))
 
 func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
-  const mask: int32 = 8 * sizeof(value) - 1
-  (value shr rot) or (value shl (-rot and mask))
+  const mask = 8 * sizeof(value) - 1
+  let rot = rot and mask
+  (value shr rot) or (value shl ((-rot) and mask))
 
 func rotateLeftBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
   ## Left-rotate bits in a 8-bits value.

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -758,7 +758,7 @@ when useBuiltinsRotate:
     # https://releases.llvm.org/8.0.0/tools/clang/docs/LanguageExtensions.html#builtin-rotateleft
     func builtin_rotl8(value: cuchar, shift: cuchar): cuchar
                        {.importc: "__builtin_rotateleft8".}
-    func builtin_rotl16(value: cushort, shift: cushort): cuchar
+    func builtin_rotl16(value: cushort, shift: cushort): cushort
                        {.importc: "__builtin_rotateleft16".}
     func builtin_rotl32(value: cuint, shift: cuint): cuint
                        {.importc: "__builtin_rotateleft32".}

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -840,10 +840,7 @@ func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
   let rot = rot and mask
   (value shr rot) or (value shl ((-rot) and mask))
 
-func shiftTypeTo[T](value: T, shift: int): auto {.inline.} =
-  ## Returns the `shift` for the rotation according to the compiler and the size
-  ## of the` value`.
-  const size = sizeof(value)
+func shiftTypeToImpl(size: static int, shift: int): auto {.inline.} =
   when (defined(vcc) and (size == 4 or size == 8)) or defined(gcc) or
        defined(icl):
     cint(shift)
@@ -857,6 +854,11 @@ func shiftTypeTo[T](value: T, shift: int): auto {.inline.} =
       cuint(shift)
     elif size == 8:
       culonglong(shift)
+
+template shiftTypeTo[T](value: T, shift: int): auto =
+  ## Returns the `shift` for the rotation according to the compiler and the size
+  ## of the` value`.
+  shiftTypeToImpl(sizeof(value), shift)
 
 func rotateLeftBits*(value: uint8, shift: range[0..8]): uint8 {.inline.} =
   ## Left-rotate bits in a 8-bits value.

--- a/lib/pure/bitops.nim
+++ b/lib/pure/bitops.nim
@@ -842,11 +842,9 @@ func rotr[T: SomeUnsignedInt](value: T, rot: int32): T {.inline.} =
   (value shr rot) or (value shl ((-rot) and mask))
 
 func shiftTypeToImpl(size: static int, shift: int): auto {.inline.} =
-  when (defined(vcc) and (size == 4 or size == 8)) or defined(gcc) or
-       defined(icl):
+  when (defined(vcc) and (size in [4, 8])) or defined(gcc) or defined(icl):
     cint(shift)
-  elif (defined(vcc) and (size == 1 or size == 2)) or
-       (defined(clang) and size == 1):
+  elif (defined(vcc) and (size in [1, 2])) or (defined(clang) and size == 1):
     cuchar(shift)
   elif defined(clang):
     when size == 2:


### PR DESCRIPTION
Refactoring the Nim code to `bitops.rotateLeftBits()` and `bitops.rotateRightBits()`; adding builtins and intrinsics.

I was unable to establish which version of GCC the intrinsics were added to. However, I managed to test up to version 4.8.1 and it worked correctly.

In CLANG, builtins were added in version 8.0.0, which can cause linking problems when compiling with previous versions without `-d:noIntrinsicsBitOpts`.

At VCC and ICL I only tested with the current versions.

I was unable to test and add builtins or intrinsics for LLVCM_GCC (I don't even know the difference between it for CLANG) and ICC (my installation of the Intel compiler has only ICL).

fix [#16621](https://github.com/nim-lang/Nim/issues/16621)