### PR TITLE
promote math.isNaN

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -252,6 +252,10 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
     else:
       result.n.add semConstExpr(c, range[i])
 
+  when not declared(isNaN):
+    static: doAssert (NimMajor, NimMinor, NimPatch) < (1, 5, 1) # sanity check to ensure this workaround isn't taken in recent nim
+    template isNaN(a): untyped = classify(a) == fcNan)
+
   if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[0].floatVal)) or
       (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[1].floatVal)):
     localError(c.config, n.info, "NaN is not a valid start or end for a range")

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -253,7 +253,6 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
       result.n.add semConstExpr(c, range[i])
 
   when not declared(isNaN):
-    static: doAssert (NimMajor, NimMinor, NimPatch) < (1, 5, 1) # sanity check to ensure this workaround isn't taken in recent nim
     template isNaN(a): untyped = classify(a) == fcNan
 
   if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[0].floatVal)) or

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -254,7 +254,7 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
 
   when not declared(isNaN):
     static: doAssert (NimMajor, NimMinor, NimPatch) < (1, 5, 1) # sanity check to ensure this workaround isn't taken in recent nim
-    template isNaN(a): untyped = classify(a) == fcNan)
+    template isNaN(a): untyped = classify(a) == fcNan
 
   if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[0].floatVal)) or
       (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[1].floatVal)):

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -10,7 +10,7 @@
 # this module does the semantic checking of type declarations
 # included from sem.nim
 
-import math
+import std/math
 
 const
   errStringOrIdentNodeExpected = "string or ident node expected"
@@ -252,8 +252,8 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
     else:
       result.n.add semConstExpr(c, range[i])
 
-  if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and classify(result.n[0].floatVal) == fcNan) or
-      (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and classify(result.n[1].floatVal) == fcNan):
+  if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[0].floatVal)) or
+      (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and isNaN(result.n[1].floatVal)):
     localError(c.config, n.info, "NaN is not a valid start or end for a range")
 
   if weakLeValue(result.n[0], result.n[1]) == impNo:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1508,7 +1508,7 @@ const
     ## Contains an IEEE floating point value of *Not A Number*.
     ##
     ## Note that you cannot compare a floating point value to this value
-    ## and expect a reasonable result - use the `classify` procedure
+    ## and expect a reasonable result - use the `isNaN` or `classify` procedure
     ## in the `math module <math.html>`_ for checking for NaN.
 
 


### PR DESCRIPTION
`isNaN` is more efficient than `classify(x) == fcNan`.

Ref https://github.com/timotheecour/Nim/issues/64#issuecomment-755101462