### PR TITLE
fix negative nan

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2485,7 +2485,10 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
     let f = n.floatVal
     case classify(f)
     of fcNan:
-      r.res = rope"NaN"
+      if signbit(f):
+        r.res = rope"-NAN"
+      else:
+        r.res = rope"NAN"
     of fcNegZero:
       r.res = rope"-0.0"
     of fcZero:

--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2486,9 +2486,9 @@ proc gen(p: PProc, n: PNode, r: var TCompRes) =
     case classify(f)
     of fcNan:
       if signbit(f):
-        r.res = rope"-NAN"
+        r.res = rope"-NaN"
       else:
-        r.res = rope"NAN"
+        r.res = rope"NaN"
     of fcNegZero:
       r.res = rope"-0.0"
     of fcZero:

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -34,7 +34,7 @@ when defined(windows) and defined(bcc):
 proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
 
 
-when (NimMajor, NimMinor, NimPatch) < (1, 5, 1):
+when not declared(signbit):
   proc c_signbit(x: SomeFloat): cint {.importc: "signbit", header: "<math.h>".}
   proc signbit*(x: SomeFloat): bool {.inline.} =
     result = c_signbit(x) != 0

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -33,6 +33,12 @@ when defined(windows) and defined(bcc):
 
 proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
 
+
+when (NimMajor, NimMinor, NimPatch) < (1, 5, 1):
+  proc c_signbit(x: SomeFloat): cint {.importc: "signbit", header: "<math.h>".}
+  proc signbit*(x: SomeFloat): bool {.inline.} =
+    result = c_signbit(x) != 0
+
 proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
   case classify(f)
   of fcNan:

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -8,7 +8,7 @@
 #
 
 ## Serialization utilities for the compiler.
-import strutils, math
+import std/[strutils, math]
 
 # bcc on windows doesn't have C99 functions
 when defined(windows) and defined(bcc):
@@ -33,10 +33,19 @@ when defined(windows) and defined(bcc):
 
 proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
 
+
+when (NimMajor, NimMinor, NimPatch) <= (1, 5, 1):
+  proc c_signbit(x: SomeFloat): cint {.importc: "signbit", header: "<math.h>".}
+  proc signbit*(x: SomeFloat): bool {.inline.} =
+    result = c_signbit(x) != 0
+
 proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
   case classify(f)
   of fcNan:
-    result = "NAN"
+    if signbit(f):
+      result = "-NAN"
+    else:
+      result = "NAN"
   of fcNegZero:
     result = "-0.0" & literalPostfix
   of fcZero:

--- a/compiler/rodutils.nim
+++ b/compiler/rodutils.nim
@@ -33,12 +33,6 @@ when defined(windows) and defined(bcc):
 
 proc c_snprintf(s: cstring; n:uint; frmt: cstring): cint {.importc: "snprintf", header: "<stdio.h>", nodecl, varargs.}
 
-
-when (NimMajor, NimMinor, NimPatch) <= (1, 5, 1):
-  proc c_signbit(x: SomeFloat): cint {.importc: "signbit", header: "<math.h>".}
-  proc signbit*(x: SomeFloat): bool {.inline.} =
-    result = c_signbit(x) != 0
-
 proc toStrMaxPrecision*(f: BiggestFloat, literalPostfix = ""): string =
   case classify(f)
   of fcNan:

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -397,8 +397,8 @@ template main =
       discard
     else:
       when not defined(js):
-        doAssert copySign(-1.0, -NaN) == 1.0
-        doAssert copySign(10.0, -NaN) == 10.0
+        doAssert copySign(-1.0, -NaN) == -1.0
+        doAssert copySign(10.0, -NaN) == -10.0
         doAssert copySign(1.0, copySign(NaN, -1.0)) == -1.0 # fails in VM
 
   block:

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -319,6 +319,18 @@ template main =
     doAssert not Inf.isNaN
     doAssert isNaN(Inf - Inf)
 
+  block: # signbit
+    let x1 = NaN
+    let x2 = -NaN
+    let x3 = -x1
+
+    doAssert isNaN(x1)
+    doAssert isNaN(x2)
+    doAssert isNaN(x3)
+    doAssert not signbit(x1)
+    doAssert signbit(x2)
+    doAssert signbit(x3)
+
   block: # copySign
     doAssert copySign(10.0, -1.0) == -10.0
     doAssert copySign(-10.0, -1.0) == -10.0


### PR DESCRIPTION
doesn't change the string form of nan and negative nan, just fix the wrong behaviour(I just keep the sign in the generated codes).

fix https://github.com/timotheecour/Nim/issues/499

For example

Part one
```nim
var a1 = NaN
var a2 = -NaN
```
before
```c
NF a1;
NF a2;
a1 = NAN;
a2 = NAN;
```
After this PR:
```c
NF a1;
NF a2;
a1 = NAN;
a2 = -NAN;
```

Part two
```nim
var a1 = NaN
var a2 = -a1
```
before/after
```c
NF a1;
NF a2;
a1 = NAN;
a2 = -a1;
```