### PR TITLE
Add support for Transfer-Encoding: chunked

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -144,15 +144,14 @@ proc sendStatus(client: AsyncSocket, status: string): Future[void] =
 
 func hasChunkedEncoding(request: Request): bool = 
   ## Searches for a chunked transfer encoding
-  var isChunked = false
-  for encoding in request.headers.iter("Transfer-Encoding"):
-    if "chunked" == encoding.strip:
-      isChunked = true
-      break
+  const transferEncoding = "Transfer-Encoding"
 
-  return (request.reqMethod == HttpPost and
-          request.headers.hasKey("Transfer-Encoding") and
-          isChunked)
+  if request.headers.hasKey(transferEncoding):
+    for encoding in seq[string](request.headers[transferEncoding]):
+      if "chunked" == encoding.strip:
+        # Returns true if it is both an HttpPost and has chunked encoding
+        return request.reqMethod == HttpPost
+  return false
 
 proc processRequest(
   server: AsyncHttpServer,

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -301,8 +301,9 @@ proc processRequest(
           break
 
         # Read bytesToRead and add to body
-        await client.recvLineInto(lineFut, maxLength = bytesToRead)
-        request.body = request.body & lineFut.mget
+        # Note we add +2 because the line must be terminated by \r\n
+        let chunk = await client.recv(bytesToRead + 2)
+        request.body = request.body & chunk
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -183,13 +183,6 @@ proc `[]=`*(headers: HttpHeaders, key, value: string) =
   ## Replaces any existing values.
   headers.table[headers.toCaseInsensitive(key)] = @[value]
 
-iterator iter*(headers: HttpHeaders, key: string): string =
-  ## Yields each value associated with the requested key
-  ## If no such key exists, this does nothing.
-  if headers.table.contains(headers.toCaseInsensitive(key)):
-    for value in headers.table[headers.toCaseInsensitive(key)]:
-      yield value
-
 proc `[]=`*(headers: HttpHeaders, key: string, value: seq[string]) =
   ## Sets the header entries associated with ``key`` to the specified list of
   ## values. Replaces any existing values. If ``value`` is empty,

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -185,10 +185,10 @@ proc `[]=`*(headers: HttpHeaders, key, value: string) =
 
 iterator iter*(headers: HttpHeaders, key: string): string =
   ## Yields each value associated with the requested key
-  ## If no such key exists, this does nothing
+  ## If no such key exists, this does nothing.
   if headers.table.contains(headers.toCaseInsensitive(key)):
     for value in headers.table[headers.toCaseInsensitive(key)]:
-        yield value
+      yield value
 
 proc `[]=`*(headers: HttpHeaders, key: string, value: seq[string]) =
   ## Sets the header entries associated with ``key`` to the specified list of

--- a/lib/pure/httpcore.nim
+++ b/lib/pure/httpcore.nim
@@ -183,6 +183,13 @@ proc `[]=`*(headers: HttpHeaders, key, value: string) =
   ## Replaces any existing values.
   headers.table[headers.toCaseInsensitive(key)] = @[value]
 
+iterator iter*(headers: HttpHeaders, key: string): string =
+  ## Yields each value associated with the requested key
+  ## If no such key exists, this does nothing
+  if headers.table.contains(headers.toCaseInsensitive(key)):
+    for value in headers.table[headers.toCaseInsensitive(key)]:
+        yield value
+
 proc `[]=`*(headers: HttpHeaders, key: string, value: seq[string]) =
   ## Sets the header entries associated with ``key`` to the specified list of
   ## values. Replaces any existing values. If ``value`` is empty,


### PR DESCRIPTION
I've spent the past few days trying to use Nim with OpenFaas (my first Nim project, just a proof-of-concept, see: https://gitlab.com/vabresto/nim-sudoku-faas/-/tree/master/) and had some issues with the Nim HTTP server because the OpenFaas of-watchdog proxy doesn't pass the `Content-Length` header, but rather uses chunked encoding (see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding).

I've added support for this for my own uses and wanted to contribute it back to Nim.

I'd like to add tests but I'm not sure what the best way to do so is. Additionally, I can't actually compile and run the devel branch locally (OSX 15.6), so I made these changes based on the Nim 1.4 code I have locally.

Any feedback would be very welcome. Thanks!