### PR TITLE
kochdocs: fusion needs the js backend too

### DIFF
--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -15,7 +15,9 @@ const
 
 var nimExe*: string
 
-template isJsOnly(file: string): bool = file.isRelativeTo("lib/js")
+template isJsOnly(file: string): bool =
+  file.isRelativeTo("lib/js") or
+  file.isRelativeTo("lib/fusion/js")
 
 proc exe*(f: string): string =
   result = addFileExt(f, ExeExt)


### PR DESCRIPTION
Without this `./koch docs` will fail upon processing JS modules in `fusion`, which break nightlies: https://github.com/nim-lang/nightlies/runs/1665983048?check_suite_focus=true#step:9:4571