### PR TITLE
skip docs for `lib/fusion` (docs already run in fusion repo)

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -26,7 +26,7 @@ on:
       - 'tools/dochack/dochack.nim'
       - 'tools/kochdocs.nim'
       - '.github/workflows/ci_docs.yml'
-
+      - 'koch.nim'
 
 jobs:
   build:

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -185,7 +185,8 @@ lib/system/widestrs.nim
 """.splitWhitespace()
 
   proc follow(a: PathEntry): bool =
-    a.path.lastPathPart notin ["nimcache", "htmldocs", "includes", "deprecated", "genode"]
+    result = a.path.lastPathPart notin ["nimcache", "htmldocs", "includes", "deprecated", "genode"] and
+      not a.path.isRelativeTo("lib/fusion")
   for entry in walkDirRecFilter("lib", follow = follow):
     let a = entry.path
     if entry.kind != pcFile or a.splitFile.ext != ".nim" or

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -15,9 +15,7 @@ const
 
 var nimExe*: string
 
-template isJsOnly(file: string): bool =
-  file.isRelativeTo("lib/js") or
-  file.isRelativeTo("lib/fusion/js")
+template isJsOnly(file: string): bool = file.isRelativeTo("lib/js")
 
 proc exe*(f: string): string =
   result = addFileExt(f, ExeExt)


### PR DESCRIPTION
fixes following bugs:
* https://github.com/nim-lang/Nim/pull/16630 broke docs for future CI's but CI was green in that PR because of a micro-optimization that avoided running ci docs when koch.nim was changed; I've removed this micro-optimization to avoid future regressions
* avoid running docs for lib/fusion since docs already run in fusion repo (via a one-shot approach using `--project` instead of 1 compilation per file as was done in kochdocs)
* this will also avoid showing fusion modules in https://nim-lang.github.io/Nim/theindex.html (or fusion files eg  https://nim-lang.github.io/Nim/pointers.html), which already exist in their own index and sub-directory: https://nim-lang.github.io/fusion/theindex.html and https://nim-lang.github.io/fusion/src/fusion/pointers.html, and also remove risk of module clashes between stdlib and fusion modules

(note: also fixed ci docs but https://github.com/nim-lang/Nim/pull/16644 was merged in meantime; but the other points remain)

## future work: don't copy fusion inside lib/fusion
* un-bundle nim and fusion (which was a root cause for this issue). As I've argued in https://github.com/nim-lang/fusion/issues/25, copying over fusion in nim lib/fusion/ is a terrible idea.
  * It breaks repo modularity
  * prevents switching between branches (which have a different fusion hash in koch.nim)
  * affects tooling (as this issue showed)
  * will cause nasty issues if user imports external fusion (since each fusion module will end up as 2 distinct module, breaking exportc and other things), etc
