### PR TITLE
close #6215 add syntax sugar `..<` for array construction

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -331,7 +331,8 @@ proc semArray(c: PContext, n: PNode, prev: PType): PType =
   var base: PType
   if n.len == 3:
     # 3 = length(array indx base)
-    if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<" and n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
+    if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<" and 
+                  n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
       dec n[1][2].intVal
     let indx = semArrayIndex(c, n[1])
     var indxB = indx

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1715,9 +1715,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       let b = newNodeI(nkBracketExpr, n.info)
       for i in 1..<n.len: b.add(n[i])
       result = semTypeNode(c, b, prev)
-    elif ident != nil and (ident.id == ord(wDotDot)):
+    elif ident != nil and ident.id == ord(wDotDot):
       result = semRangeAux(c, n, prev)
-    elif ident != nil and (ident.id == ord(wDotDotLt)):
+    elif ident != nil and ident.id == ord(wDotDotLt):
       if n.kind == nkInfix and n[2].kind in {nkCharLit..nkUInt64Lit} and n[2].intVal != low(BiggestInt):
         dec n[2].intVal
       result = semRangeAux(c, n, prev)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -265,8 +265,8 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
   result = nil
   if n.len == 2:
     if isRange(n[1]):
-      if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<":
-        if n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
+      if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<" and 
+                    n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
           dec n[1][2].intVal
       result = semRangeAux(c, n[1], prev)
       let n = result.n

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -265,9 +265,11 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
   result = nil
   if n.len == 2:
     if isRange(n[1]):
-      if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<" and 
-                    n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
+      if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<":
+        if n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
           dec n[1][2].intVal
+        else:
+          localError(c.config, n.info, "ordinal type expected")
       result = semRangeAux(c, n[1], prev)
       let n = result.n
       if n[0].kind in {nkCharLit..nkUInt64Lit} and n[0].intVal > 0:
@@ -1721,6 +1723,8 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     elif ident != nil and ident.id == ord(wDotDotLt):
       if n.kind == nkInfix and n[2].kind in {nkCharLit..nkUInt64Lit} and n[2].intVal != low(BiggestInt):
         dec n[2].intVal
+      else:
+        localError(c.config, n.info, "ordinal type expected")
       result = semRangeAux(c, n, prev)
     elif n[0].kind == nkNilLit and n.len == 2:
       result = semTypeNode(c, n[1], prev)

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1719,7 +1719,6 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
       result = semRangeAux(c, n, prev)
     elif ident != nil and ident.id == ord(wDotDotLt):
       localError(c.config, n.info, "range types need to be constructed with '..', '..<' is not supported")
-      result = semRangeAux(c, n, prev)
     elif n[0].kind == nkNilLit and n.len == 2:
       result = semTypeNode(c, n[1], prev)
       if result.skipTypes({tyGenericInst, tyAlias, tySink, tyOwned}).kind in NilableTypes+GenericTypes:

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -266,10 +266,7 @@ proc semRange(c: PContext, n: PNode, prev: PType): PType =
   if n.len == 2:
     if isRange(n[1]):
       if n[1].kind == nkInfix and considerQuotedIdent(c, n[1][0]).s == "..<":
-        if n[1][2].kind in {nkCharLit..nkUInt64Lit} and n[1][2].intVal != low(BiggestInt):
-          dec n[1][2].intVal
-        else:
-          localError(c.config, n.info, "ordinal type expected")
+        localError(c.config, n[1].info, "range types need to be constructed with '..', '..<' is not supported")
       result = semRangeAux(c, n[1], prev)
       let n = result.n
       if n[0].kind in {nkCharLit..nkUInt64Lit} and n[0].intVal > 0:
@@ -1721,10 +1718,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
     elif ident != nil and ident.id == ord(wDotDot):
       result = semRangeAux(c, n, prev)
     elif ident != nil and ident.id == ord(wDotDotLt):
-      if n.kind == nkInfix and n[2].kind in {nkCharLit..nkUInt64Lit} and n[2].intVal != low(BiggestInt):
-        dec n[2].intVal
-      else:
-        localError(c.config, n.info, "ordinal type expected")
+      localError(c.config, n.info, "range types need to be constructed with '..', '..<' is not supported")
       result = semRangeAux(c, n, prev)
     elif n[0].kind == nkNilLit and n.len == 2:
       result = semTypeNode(c, n[1], prev)

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -120,12 +120,13 @@ proc isDeepConstExpr*(n: PNode; preventInheritance = false): bool =
   else: discard
 
 proc isRange*(n: PNode): bool {.inline.} =
+  const rangeOpt = {ord(wDotDot), ord(wDotDotLt)}
   if n.kind in nkCallKinds:
     let callee = n[0]
-    if (callee.kind == nkIdent and callee.ident.id == ord(wDotDot)) or
-       (callee.kind == nkSym and callee.sym.name.id == ord(wDotDot)) or
-       (callee.kind in {nkClosedSymChoice, nkOpenSymChoice} and
-        callee[1].sym.name.id == ord(wDotDot)):
+    if (callee.kind == nkIdent and callee.ident.id in rangeOpt) or
+       (callee.kind == nkSym and callee.sym.name.id in rangeOpt) or
+       ((callee.kind in {nkClosedSymChoice, nkOpenSymChoice} and
+        callee[1].sym.name.id in rangeOpt)):
       result = true
 
 proc whichPragma*(n: PNode): TSpecialWord =

--- a/compiler/trees.nim
+++ b/compiler/trees.nim
@@ -125,8 +125,8 @@ proc isRange*(n: PNode): bool {.inline.} =
     let callee = n[0]
     if (callee.kind == nkIdent and callee.ident.id in rangeOpt) or
        (callee.kind == nkSym and callee.sym.name.id in rangeOpt) or
-       ((callee.kind in {nkClosedSymChoice, nkOpenSymChoice} and
-        callee[1].sym.name.id in rangeOpt)):
+       (callee.kind in {nkClosedSymChoice, nkOpenSymChoice} and
+        callee[1].sym.name.id in rangeOpt):
       result = true
 
 proc whichPragma*(n: PNode): TSpecialWord =

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -31,7 +31,7 @@ type
     wVar = "var", wWhen = "when", wWhile = "while", wXor = "xor", wYield = "yield",
 
     wColon = ":", wColonColon = "::", wEquals = "=", wDot = ".", wDotDot = "..",
-    wStar = "*", wMinus = "-",
+    wStar = "*", wMinus = "-", wDotDotLt = "..<", # dotdotlt is not operator(it is syntax sugar for dotdot)
     wMagic = "magic", wThread = "thread", wFinal = "final", wProfiler = "profiler", 
     wMemTracker = "memtracker", wObjChecks = "objchecks",
     wIntDefine = "intdefine", wStrDefine = "strdefine", wBoolDefine = "booldefine", 

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -31,7 +31,7 @@ type
     wVar = "var", wWhen = "when", wWhile = "while", wXor = "xor", wYield = "yield",
 
     wColon = ":", wColonColon = "::", wEquals = "=", wDot = ".", wDotDot = "..",
-    wStar = "*", wMinus = "-", wDotDotLt = "..<", # dotdotlt is not operator(it is syntax sugar for dotdot)
+    wStar = "*", wMinus = "-", wDotDotLt = "..<", # wDotDotLt is syntax sugar(it is only used for array construction)
     wMagic = "magic", wThread = "thread", wFinal = "final", wProfiler = "profiler", 
     wMemTracker = "memtracker", wObjChecks = "objchecks",
     wIntDefine = "intdefine", wStrDefine = "strdefine", wBoolDefine = "booldefine", 

--- a/tests/array/tarrayconstruct.nim
+++ b/tests/array/tarrayconstruct.nim
@@ -3,26 +3,14 @@ discard """
 """
 
 block:
-  var x: range[1 ..< 12] = 4
 
   var stuff: array[0 ..< 1024, int]
 
   doAssert stuff[0 ..< 3] == [0, 0, 0]
 
   doAssert stuff.len == 1024
-  doAssert $typeof(x) == "range 1..11(int)"
   doAssert $typeof(stuff) == "array[0..1023, int]"
-
-block:
-  var y: 1..<13 = 12
-  doAssert $typeof(y) == "range 1..12(int)"
-  doAssert y == 12
 
 block:
   var x = @[1, 4, 5, 6, 7, 8]
   doAssert x[0..<3] == @[1, 4, 5]
-
-block:
-  var y: range[1..<13] = 11
-  doAssert $typeof(y) == "range 1..12(int)"
-  doAssert y == 11

--- a/tests/range/tnewrange.nim
+++ b/tests/range/tnewrange.nim
@@ -1,0 +1,28 @@
+discard """
+  targets: "c cpp js"
+"""
+
+block:
+  var x: range[1 ..< 12] = 4
+
+  var stuff: array[0 ..< 1024, int]
+
+  doAssert stuff[0 ..< 3] == [0, 0, 0]
+
+  doAssert stuff.len == 1024
+  doAssert $typeof(x) == "range 1..11(int)"
+  doAssert $typeof(stuff) == "array[0..1023, int]"
+
+block:
+  var y: 1..<13 = 12
+  doAssert $typeof(y) == "range 1..12(int)"
+  doAssert y == 12
+
+block:
+  var x = @[1, 4, 5, 6, 7, 8]
+  doAssert x[0..<3] == @[1, 4, 5]
+
+block:
+  var y: range[1..<13] = 11
+  doAssert $typeof(y) == "range 1..12(int)"
+  doAssert y == 11

--- a/tests/range/trangeerror.nim
+++ b/tests/range/trangeerror.nim
@@ -1,0 +1,11 @@
+discard """
+  cmd: "nim check $file"
+  errormsg: "range types need to be constructed with '..', '..<' is not supported"
+  nimout: '''trangeerror.nim(8, 16) Error: range types need to be constructed with '..', '..<' is not supported
+trangeerror.nim(9, 9) Error: range types need to be constructed with '..', '..<' is not supported'''
+"""
+
+var x: range[1 ..< 12] = 4
+var y: 1..<13 = 12
+discard x
+discard y


### PR DESCRIPTION
- close #6215 add syntax sugar `..<` for array construction
- make error messages better(which is consistent with `var x: range[1 ..< 10]`)
```nim
var x: 1 ..< 10
```
before:
```
Error: expected type, but got:
1 .. 9
```
after:
```
Error: range types need to be constructed with '..', '..<' is not supported
```