### PR TITLE
fix #16650

### DIFF
--- a/compiler/semfold.nim
+++ b/compiler/semfold.nim
@@ -15,6 +15,8 @@ import
   platform, math, msgs, idents, renderer, types,
   commands, magicsys, modulegraphs, strtabs, lineinfos
 
+from system/memory import nimCStrLen
+
 proc errorType*(g: ModuleGraph): PType =
   ## creates a type representing an error state
   result = newType(tyError, nextTypeId(g.idgen), g.owners[^1])
@@ -133,7 +135,10 @@ proc evalOp(m: TMagic, n, a, b, c: PNode; g: ModuleGraph): PNode =
     if a.kind == nkNilLit:
       result = newIntNodeT(Zero, n, g)
     elif a.kind in {nkStrLit..nkTripleStrLit}:
-      result = newIntNodeT(toInt128(a.strVal.len), n, g)
+      if a.typ.kind == tyString:
+        result = newIntNodeT(toInt128(a.strVal.len), n, g)
+      elif a.typ.kind == tyCString:
+        result = newIntNodeT(toInt128(nimCStrLen(a.strVal)), n, g)
     else:
       result = newIntNodeT(toInt128(a.len), n, g)
   of mUnaryPlusI, mUnaryPlusF64: result = a # throw `+` away

--- a/tests/system/tostring.nim
+++ b/tests/system/tostring.nim
@@ -1,7 +1,3 @@
-discard """
-  output: "DONE: tostring.nim"
-"""
-
 doAssert "@[23, 45]" == $(@[23, 45])
 doAssert "[32, 45]" == $([32, 45])
 doAssert """@["", "foo", "bar"]""" == $(@["", "foo", "bar"])
@@ -108,7 +104,7 @@ bar(nilstring)
 static:
   stringCompare()
 
-# bug 8847
+# issue #8847
 var a2: cstring = "fo\"o2"
 
 block:
@@ -116,5 +112,14 @@ block:
   s.addQuoted a2
   doAssert s == "\"fo\\\"o2\""
 
-
-echo "DONE: tostring.nim"
+# issue #16650
+template fn() =
+  doAssert len(cstring"ab\0c") == 5
+  doAssert len(cstring("ab\0c")) == 2
+  when nimvm:
+    discard
+  else:
+    let c = cstring("ab\0c")
+    doAssert len(c) == 2
+fn()
+static: fn()


### PR DESCRIPTION
fix #16650

```nim
when defined case1:
  template fn() =
    echo len(cstring"ab\0c") # ok: \0 is escaped, like r"ab\0c")
    echo len(cstring("ab\0c")) # bug
    let c = cstring("ab\0c") # ok
    echo len(c)
  fn()
  static: fn()
```
Before:
```
VM:
5
4
4

RT:
5
4
2
```
After
```
VM:
5
4
2

RT:
5
2
2
```
