### PR TITLE
Improve documentation of strmisc

### DIFF
--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -8,12 +8,12 @@
 #
 
 ## This module contains various string utility routines that are uncommonly
-## used in comparison to `strutils <strutils.html>`_.
+## used in comparison to the ones in `strutils <strutils.html>`_.
 
-import strutils
+import std/strutils
 
-proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect.} =
-  ## Expand tab characters in `s` replacing them by spaces.
+func expandTabs*(s: string, tabSize: int = 8): string =
+  ## Expands tab characters in `s`, replacing them by spaces.
   ##
   ## The amount of inserted spaces for each tab character is the difference
   ## between the current column number and the next tab position. Tab positions
@@ -24,9 +24,7 @@ proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect.} =
   runnableExamples:
     doAssert expandTabs("\t", 4) == "    "
     doAssert expandTabs("\tfoo\t", 4) == "    foo "
-    doAssert expandTabs("\tfoo\tbar", 4) == "    foo bar"
-    doAssert expandTabs("\tfoo\tbar\t", 4) == "    foo bar "
-    doAssert expandTabs("ab\tcd\n\txy\t", 3) == "ab cd\n   xy "
+    doAssert expandTabs("a\tb\n\txy\t", 3) == "a  b\n   xy "
 
   result = newStringOfCap(s.len + s.len shr 2)
   var pos = 0
@@ -50,37 +48,39 @@ proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect.} =
     if c == '\l':
       pos = 0
 
-proc partition*(s: string, sep: string,
-                right: bool = false): (string, string, string)
-                {.noSideEffect.} =
-  ## Split the string at the first or last occurrence of `sep` into a 3-tuple
+func partition*(s: string, sep: string,
+                right: bool = false): (string, string, string) =
+  ## Splits the string at the first (if `right` is false)
+  ## or last (if `right` is true) occurrence of `sep` into a 3-tuple.
   ##
-  ## Returns a 3 string tuple of (beforeSep, `sep`, afterSep) or
-  ## (`s`, "", "") if `sep` is not found and `right` is false or
-  ## ("", "", `s`) if `sep` is not found and `right` is true
+  ## Returns a 3-tuple of strings, `(beforeSep, sep, afterSep)` or
+  ## `(s, "", "")` if `sep` is not found and `right` is false or
+  ## `("", "", s)` if `sep` is not found and `right` is true.
+  ##
+  ## **See also:**
+  ## * `rpartition proc <#rpartition,string,string>`_
   runnableExamples:
-    doAssert partition("foo:bar", ":") == ("foo", ":", "bar")
-    doAssert partition("foobarbar", "bar") == ("foo", "bar", "bar")
-    doAssert partition("foobarbar", "bank") == ("foobarbar", "", "")
-    doAssert partition("foobarbar", "foo") == ("", "foo", "barbar")
-    doAssert partition("foofoobar", "bar") == ("foofoo", "bar", "")
+    doAssert partition("foo:bar:baz", ":") == ("foo", ":", "bar:baz")
+    doAssert partition("foo:bar:baz", ":", right = true) == ("foo:bar", ":", "baz")
+    doAssert partition("foobar", ":") == ("foobar", "", "")
+    doAssert partition("foobar", ":", right = true) == ("", "", "foobar")
 
   let position = if right: s.rfind(sep) else: s.find(sep)
   if position != -1:
     return (s[0 ..< position], sep, s[position + sep.len ..< s.len])
   return if right: ("", "", s) else: (s, "", "")
 
-proc rpartition*(s: string, sep: string): (string, string, string)
-                {.noSideEffect.} =
-  ## Split the string at the last occurrence of `sep` into a 3-tuple
+func rpartition*(s: string, sep: string): (string, string, string) =
+  ## Splits the string at the last occurrence of `sep` into a 3-tuple.
   ##
-  ## Returns a 3 string tuple of (beforeSep, `sep`, afterSep) or
-  ## ("", "", `s`) if `sep` is not found
+  ## Returns a 3-tuple of strings, `(beforeSep, sep, afterSep)` or
+  ## `("", "", s)` if `sep` is not found. This is the same as
+  ## `partition(s, sep, right = true)`.
+  ##
+  ## **See also:**
+  ## * `partition proc <#partition,string,string,bool>`_
   runnableExamples:
-    doAssert rpartition("foo:bar", ":") == ("foo", ":", "bar")
-    doAssert rpartition("foobarbar", "bar") == ("foobar", "bar", "")
-    doAssert rpartition("foobarbar", "bank") == ("", "", "foobarbar")
-    doAssert rpartition("foobarbar", "foo") == ("", "foo", "barbar")
-    doAssert rpartition("foofoobar", "bar") == ("foofoo", "bar", "")
+    doAssert rpartition("foo:bar:baz", ":") == ("foo:bar", ":", "baz")
+    doAssert rpartition("foobar", ":") == ("", "", "foobar")
 
-  return partition(s, sep, right = true)
+  partition(s, sep, right = true)


### PR DESCRIPTION
* Fix grammar issues
* Make documentation more clear
* Turn procs with `{.noSideEffect.}` into funcs
* Simplify the examples