### PR TITLE
A new request should always have a new content-length

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -1041,7 +1041,7 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
   ## You need to make sure that the ``url`` doesn't contain any newline
   ## characters. Failing to do so will raise ``AssertionDefect``.
   ##
-  ## ``headers`` are HTTP headers that override the ``client.headers`` for
+  ## `headers` are HTTP headers that override the `client.headers` for
   ## this specific request only and will not be persisted.
   ##
   ## **Deprecated since v1.5**: use HttpMethod enum instead; string parameter httpMethod is deprecated

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -973,19 +973,6 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   if url.scheme == "":
     raise newException(ValueError, "No uri scheme supplied.")
 
-  var data: seq[string]
-  if multipart != nil and multipart.content.len > 0:
-    data = await client.format(multipart)
-  else:
-    # A new request should always have a new content length
-    if client.headers.hasKey("Content-Length"):
-      client.headers.del("Content-Length")
-  
-    if body.len != 0:
-      client.headers["Content-Length"] = $body.len
-    elif httpMethod notin {HttpGet, HttpHead}:
-      client.headers["Content-Length"] = "0"
-
   when client is AsyncHttpClient:
     if not client.parseBodyFut.isNil:
       # let the current operation finish before making another request
@@ -995,6 +982,18 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   await newConnection(client, url)
 
   let newHeaders = client.headers.override(headers)
+
+  var data: seq[string]
+  if multipart != nil and multipart.content.len > 0:
+    data = await client.format(multipart)
+  else:
+    # Only change headers if they have not been specified already
+    if not newHeaders.hasKey("Content-Length"):
+      if body.len != 0:
+        newHeaders["Content-Length"] = $body.len
+      elif httpMethod notin {HttpGet, HttpHead}:
+        newHeaders["Content-Length"] = "0"
+
   if not newHeaders.hasKey("user-agent") and client.userAgent.len > 0:
     newHeaders["User-Agent"] = client.userAgent
 
@@ -1041,6 +1040,9 @@ proc request*(client: HttpClient | AsyncHttpClient, url: Uri | string,
   ##
   ## You need to make sure that the ``url`` doesn't contain any newline
   ## characters. Failing to do so will raise ``AssertionDefect``.
+  ##
+  ## ``headers`` are HTTP headers that override the ``client.headers`` for
+  ## this specific request only and will not be persisted.
   ##
   ## **Deprecated since v1.5**: use HttpMethod enum instead; string parameter httpMethod is deprecated
   when url is string:

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -977,9 +977,13 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
   else:
+    # A new request should always have a new content length
+    if client.headers.hasKey("Content-Length"):
+      client.headers.del("Content-Length")
+  
     if body.len != 0:
       client.headers["Content-Length"] = $body.len
-    elif httpMethod notin [HttpGet, HttpHead] and not client.headers.hasKey("Content-Length"):
+    elif httpMethod notin {HttpGet, HttpHead}:
       client.headers["Content-Length"] = "0"
 
   when client is AsyncHttpClient:


### PR DESCRIPTION
In [my last PR](https://github.com/nim-lang/Nim/pull/16618) I made a mistake by assuming that the client.headers were cleared on every request, like the Python version. So, due to the fact that Nim keeps the client headers, we need to clear the Content-Length header on each request (which makes sense because you almost never want to use the same Content-Length twice, but you may want to reuse other headers)