### PR TITLE
Add strmisc.wordsToCap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -101,6 +101,9 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Added `math.signbit`.
 
+- Added `strmisc.wordsToCap` that returns an approximation of `string` capacity from a `wordCount` with optional `threshold`.
+
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -86,7 +86,7 @@ proc rpartition*(s: string, sep: string): (string, string, string)
   return partition(s, sep, right = true)
 
 
-proc wordsToCap*(wordCount: Positive, threshold = 80.Positive): int {.since: (1, 5).} =
+proc wordsToCap*(wordCount: Positive; threshold = 80.Positive): int {.since: (1, 5).} =
   ## Returns an "approximation" of `string` capacity from a `wordCount` with an optional `threshold`,
   ## using the average length of words world-wide, like a cache you hit *the happy path* frequently.
   ## This is useful for optimizations with `newStringOfCap` and `newString`.

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -101,6 +101,7 @@ proc wordsToCap*(wordCount: Positive; threshold = 80.Positive): int {.since: (1,
   ## * `newStringOfCap <system.html#newStringOfCap>`_
   ## * `newString <system.html#newString>`_
   runnableExamples:
+    import strutils
     const sentence0 = "Hello World" ## Random sentences; You can try your own sentences...
     doAssert wordsToCap(wordCount = sentence0.split.len) >= sentence0.len
     const sentence1 = "The quick brown fox jumps over the lazy dog"

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -110,5 +110,5 @@ proc wordsToCap*(wordCount: Positive, threshold = 80.Positive): int {.since: (1,
     const sentence3 = "She tore a hole in our universe, a gateway to another dimension, a dimension of pure chaos, pure evil"
     doAssert wordsToCap(wordCount = sentence3.split.len) >= sentence3.len
   # max((9 * wordCount) + (len(whitespace or newline) * wordCount), threshold)
-  const nimAverageWordLength {.strdefine.}: Positive = 9
+  const nimAverageWordLength {.intdefine.}: Positive = 9
   result = max((nimAverageWordLength * wordCount) + wordCount , threshold) # Still better than a random hardcoded "guess".

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -93,7 +93,7 @@ proc wordsToCap*(wordCount: Positive, threshold = 80.Positive): int {.since: (1,
   ##
   ## Average length of words:
   ## * World `9`, English `6` (Wikipedia, Wolfram, Oxford, etc).
-  ## * Theres shorter and longer words but this is the most frequently used words.
+  ## * There are shorter and longer words but this is the most frequently used words.
   ## * Define a customized average length of words by defining `nimAverageWordLength`.
   ## * See http://ravi.io/language-word-lengths
   ##

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -86,7 +86,7 @@ proc rpartition*(s: string, sep: string): (string, string, string)
   return partition(s, sep, right = true)
 
 
-proc wordsToCap*(wordCount: Positive; threshold = 80.Positive): int {.since: (1, 5).} =
+func wordsToCap*(wordCount: Positive; threshold = 80.Positive): int {.since: (1, 5), inline.} =
   ## Returns an "approximation" of `string` capacity from a `wordCount` with an optional `threshold`,
   ## using the average length of words world-wide, like a cache you hit *the happy path* frequently.
   ## This is useful for optimizations with `newStringOfCap` and `newString`.

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -9,7 +9,7 @@
 
 ## This module contains various string utility routines that are uncommonly
 ## used in comparison to `strutils <strutils.html>`_.
-
+import std/private/since
 import strutils
 
 proc expandTabs*(s: string, tabSize: int = 8): string {.noSideEffect.} =
@@ -84,3 +84,31 @@ proc rpartition*(s: string, sep: string): (string, string, string)
     doAssert rpartition("foofoobar", "bar") == ("foofoo", "bar", "")
 
   return partition(s, sep, right = true)
+
+
+proc wordsToCap*(wordCount: Positive, threshold = 80.Positive): int {.since: (1, 5).} =
+  ## Returns an "approximation" of `string` capacity from a `wordCount` with an optional `threshold`,
+  ## using the average length of words world-wide, like a cache you hit *the happy path* frequently.
+  ## This is useful for optimizations with `newStringOfCap` and `newString`.
+  ##
+  ## Average length of words:
+  ## * World `9`, English `6` (Wikipedia, Wolfram, Oxford, etc).
+  ## * Theres shorter and longer words but this is the most frequently used words.
+  ## * Define a customized average length of words by defining `nimAverageWordLength`.
+  ## * See http://ravi.io/language-word-lengths
+  ##
+  ## See also:
+  ## * `newStringOfCap <system.html#newStringOfCap>`_
+  ## * `newString <system.html#newString>`_
+  runnableExamples:
+    const sentence0 = "Hello World" ## Random sentences; You can try your own sentences...
+    doAssert wordsToCap(wordCount = sentence0.split.len) >= sentence0.len
+    const sentence1 = "The quick brown fox jumps over the lazy dog"
+    doAssert wordsToCap(wordCount = sentence1.split.len) >= sentence1.len
+    const sentence2 = "Nim is a statically typed compiled systems programming language."
+    doAssert wordsToCap(wordCount = sentence2.split.len) >= sentence2.len
+    const sentence3 = "She tore a hole in our universe, a gateway to another dimension, a dimension of pure chaos, pure evil"
+    doAssert wordsToCap(wordCount = sentence3.split.len) >= sentence3.len
+  # max((9 * wordCount) + (len(whitespace or newline) * wordCount), threshold)
+  const nimAverageWordLength {.strdefine.}: Positive = 9
+  result = max((nimAverageWordLength * wordCount) + wordCount , threshold) # Still better than a random hardcoded "guess".

--- a/lib/pure/strmisc.nim
+++ b/lib/pure/strmisc.nim
@@ -102,14 +102,15 @@ proc wordsToCap*(wordCount: Positive; threshold = 80.Positive): int {.since: (1,
   ## * `newString <system.html#newString>`_
   runnableExamples:
     import strutils
-    const sentence0 = "Hello World" ## Random sentences; You can try your own sentences...
-    doAssert wordsToCap(wordCount = sentence0.split.len) >= sentence0.len
-    const sentence1 = "The quick brown fox jumps over the lazy dog"
-    doAssert wordsToCap(wordCount = sentence1.split.len) >= sentence1.len
-    const sentence2 = "Nim is a statically typed compiled systems programming language."
-    doAssert wordsToCap(wordCount = sentence2.split.len) >= sentence2.len
-    const sentence3 = "She tore a hole in our universe, a gateway to another dimension, a dimension of pure chaos, pure evil"
-    doAssert wordsToCap(wordCount = sentence3.split.len) >= sentence3.len
+    static:
+      const sentence0 = "Hello World" ## Random sentences; You can try your own sentences...
+      doAssert wordsToCap(wordCount = sentence0.split.len) >= sentence0.len
+      const sentence1 = "The quick brown fox jumps over the lazy dog"
+      doAssert wordsToCap(wordCount = sentence1.split.len) >= sentence1.len
+      const sentence2 = "Nim is a statically typed compiled systems programming language."
+      doAssert wordsToCap(wordCount = sentence2.split.len) >= sentence2.len
+      const sentence3 = "She tore a hole in our universe, a gateway to another dimension, a dimension of pure chaos, pure evil"
+      doAssert wordsToCap(wordCount = sentence3.split.len) >= sentence3.len
   # max((9 * wordCount) + (len(whitespace or newline) * wordCount), threshold)
   const nimAverageWordLength {.intdefine.}: Positive = 9
   result = max((nimAverageWordLength * wordCount) + wordCount , threshold) # Still better than a random hardcoded "guess".


### PR DESCRIPTION
- Add `strmisc.wordsToCap` that returns the `string` Capacity from a `wordCount` with an optional `threshold`.
- Documentation with links, `runnableExamples` with `doAssert` using arbitrary strings, `since`, etc.
- Continuation of https://github.com/nim-lang/Nim/pull/16480#issuecomment-752630190


# Why?

Theres a lot of "hardcoded random guess" values for `newStringOfCap`:

- https://github.com/nim-lang/Nim/blob/662c5080755eb5a42df2c3acb84c044876571a46/compiler/filters.nim#L55
- https://github.com/nim-lang/Nim/blob/662c5080755eb5a42df2c3acb84c044876571a46/compiler/filters.nim#L69
- https://github.com/nim-lang/Nim/blob/662c5080755eb5a42df2c3acb84c044876571a46/compiler/ndi.nim#L39
- https://github.com/nim-lang/Nim/blob/662c5080755eb5a42df2c3acb84c044876571a46/lib/system/fatal.nim#L34
- https://github.com/nim-lang/Nim/blob/662c5080755eb5a42df2c3acb84c044876571a46/compiler/syntaxes.nim#L42
- https://github.com/nim-lang/Nim/blob/555cfd1d59e773e92a7158b7c3b5908017f1ddac/testament/testament.nim#L124
- https://github.com/nim-lang/Nim/blob/662c5080755eb5a42df2c3acb84c044876571a46/compiler/llstream.nim#L111
- https://github.com/nim-lang/Nim/blob/226595515c25785eaf078834dfb6f0ac337a5278/compiler/rodimpl.nim#L362
- https://github.com/nim-lang/Nim/blob/226595515c25785eaf078834dfb6f0ac337a5278/compiler/rodimpl.nim#L25
- https://github.com/nim-lang/Nim/blob/23d23ecb081be6702d74024be8f96d92d9f88a59/lib/system/io.nim#L486
- https://github.com/nim-lang/Nim/blob/122f22d1632255cf7d0539c620a30155dc84fd69/lib/pure/asynchttpserver.nim#L299
- ... theres tons of it, just search `newStringOfCap(`

Hardcoding `80` is kinda frequent, but totally random and made up, and in my experience in practice always wrong by far.

```nim
static:
  const sentence0 = "Hello World" ## Random sentences; You can try your own sentences...
  doAssert wordsToCap(wordCount = sentence0.split.len) >= sentence0.len

  const sentence1 = "The quick brown fox jumps over the lazy dog"
  doAssert wordsToCap(wordCount = sentence1.split.len) >= sentence1.len

  const sentence2 = "Nim is a statically typed compiled systems programming language."
  doAssert wordsToCap(wordCount = sentence2.split.len) >= sentence2.len
```

Logic is simple and allows single alloc strings everywhere.

Worse case scenario is always better than a hardcoded arbitrary guess number, like a cache you hit the happy path frequently.
