### PR TITLE
improve formatting of error message when runnableExamples fails

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -59,7 +59,7 @@ type
 
 proc prettyString(a: object): string =
   # xxx pending std/prettyprint refs https://github.com/nim-lang/RFCs/issues/203#issuecomment-602534906
-  for k,v in fieldPairs(a):
+  for k, v in fieldPairs(a):
     result.add k & ": " & $v & "\n"
 
 proc presentationPath*(conf: ConfigRef, file: AbsoluteFile, isTitle = false): RelativeFile =

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -57,6 +57,11 @@ type
 
   PDoc* = ref TDocumentor ## Alias to type less.
 
+proc prettyString(a: object): string =
+  # xxx pending std/prettyprint refs https://github.com/nim-lang/RFCs/issues/203#issuecomment-602534906
+  for k,v in fieldPairs(a):
+    result.add k & ": " & $v & "\n"
+
 proc presentationPath*(conf: ConfigRef, file: AbsoluteFile, isTitle = false): RelativeFile =
   ## returns a relative file that will be appended to outDir
   let file2 = $file
@@ -480,7 +485,7 @@ proc runAllExamples(d: PDoc) =
       "docCmd", group.docCmd,
     ]
     if os.execShellCmd(cmd) != 0:
-      quit "[runnableExamples] failed: generated file: '$1' group: '$2' cmd: $3" % [outp.string, $group[], cmd]
+      quit "[runnableExamples] failed: generated file: '$1' group: '$2' cmd: $3" % [outp.string, group[].prettyString, cmd]
     else:
       # keep generated source file `outp` to allow inspection.
       rawMessage(d.conf, hintSuccess, ["runnableExamples: " & outp.string])


### PR DESCRIPTION
fix bug 9 from https://github.com/nim-lang/Nim/issues/16521

## example 1
before PR:
```
[runnableExamples] failed: generated file: '/Users/timothee/.cache/nim/system_d/runnableExamples/system_group0_examples.nim' group: '(rdoccmd: "", docCmd: "", code: "# autogenerated by docgen\n# source: /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim\n# rdoccmd: \nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples1.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples2.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples3.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples4.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples5.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples6.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples7.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples8.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples9.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples10.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples11.nim\"\nimport
... r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples35.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples36.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples37.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples38.nim\"\nimport r\"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples39.nim\"\n", index: 0)' cmd: /Users/timothee/git_clone/nim/Nim_devel/bin/nim c -r --lib:/Users/timothee/git_clone/nim/Nim_prs/lib --warning:UnusedImport:off --path:/Users/timothee/git_clone/nim/Nim_prs/lib --nimcache:/Users/timothee/.cache/nim/system_d/runnableExamples   /Users/timothee/.cache/nim/system_d/runnableExamples/system_group0_examples.nim
```

after PR:
```
[runnableExamples] failed: generated file: '/Users/timothee/.cache/nim/system_d/runnableExamples/system_group0_examples.nim' group: 'rdoccmd:
docCmd:
code: # autogenerated by docgen
# source: /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim
# rdoccmd:
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples1.nim"
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples2.nim"
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples3.nim"
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples4.nim"
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples5.nim"

...

import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples37.nim"
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples38.nim"
import r"/Users/timothee/.cache/nim/system_d/runnableExamples/system_examples39.nim"

index: 0
' cmd: /Users/timothee/git_clone/nim/Nim_prs/bin/nim.pr_fix_runnableExamples_errors c -r --lib:/Users/timothee/git_clone/nim/Nim_prs/lib --warning:UnusedImport:off --path:/Users/timothee/git_clone/nim/Nim_prs/lib --nimcache:/Users/timothee/.cache/nim/system_d/runnableExamples   /Users/timothee/.cache/nim/system_d/runnableExamples/system_group0_examples.nim
```

## example 2
you can also look at the output using an invalid runnableExamples, eg:
```nim
when true:
  proc main*()=
    runnableExamples:
      nonexistant # either CT or RT error
  main()
```
