### PR TITLE
Transfer-Encoding:chunked tests

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -300,9 +300,10 @@ proc processRequest(
           break
 
         # Read bytesToRead and add to body
-        # Note we add +2 because the line must be terminated by \r\n
-        let chunk = await client.recv(bytesToRead + 2)
-        request.body.add(chunk[0 ..< bytesToRead])
+        let chunk = await client.recv(bytesToRead)
+        request.body.add(chunk)
+        # Skip \r\n (chunk terminating bytes per spec)
+        discard await client.recv(2)
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -79,6 +79,7 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
   ## was chosen automatically.
   runnableExamples:
     let server = newAsyncHttpServer()
+    server.listen(Port(0)) # Socket is not bound until this point
     let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]
   a.socket
 

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -302,7 +302,7 @@ proc processRequest(
         # Read bytesToRead and add to body
         # Note we add +2 because the line must be terminated by \r\n
         let chunk = await client.recv(bytesToRead + 2)
-        request.body = request.body & chunk
+        request.body = request.body & chunk[0 ..< bytesToRead]
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -73,6 +73,13 @@ type
     maxFDs: int
 
 func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
+  ## Returns the ``AsyncHttpServer``s internal ``AsyncSocket`` instance.
+  ## 
+  ## Useful for identifying what port the AsyncHttpServer is bound to, if it
+  ## was chosen automatically.
+  runnableExamples:
+    let server = newAsyncHttpServer()
+    let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]
   a.socket
 
 proc newAsyncHttpServer*(reuseAddr = true, reusePort = false,
@@ -307,11 +314,8 @@ proc processRequest(
         let chunk = await client.recv(bytesToRead)
         request.body.add(chunk)
         # Skip \r\n (chunk terminating bytes per spec)
-        when compileOption("assertions"):
-          let separator = await client.recv(2)
-          assert separator == "\r\n"
-        else:
-          discard await client.recv(2)
+        let separator = await client.recv(2)
+        assert separator == "\r\n"
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -79,8 +79,8 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
   ## was chosen automatically.
   runnableExamples:
     from asyncdispatch import Port
-    from asyncnet import getLocalAddr, getFd
-    from nativesockets import AF_INET
+    from asyncnet import getFd
+    from nativesockets import getLocalAddr, AF_INET
     let server = newAsyncHttpServer()
     server.listen(Port(0)) # Socket is not bound until this point
     let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -78,6 +78,7 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
   ## Useful for identifying what port the AsyncHttpServer is bound to, if it
   ## was chosen automatically.
   runnableExamples:
+    import asyncdispatch
     let server = newAsyncHttpServer()
     server.listen(Port(0)) # Socket is not bound until this point
     let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -303,7 +303,11 @@ proc processRequest(
         let chunk = await client.recv(bytesToRead)
         request.body.add(chunk)
         # Skip \r\n (chunk terminating bytes per spec)
-        discard await client.recv(2)
+        when compileOption("assertions"):
+          let separator = await client.recv(2)
+          assert separator == "\r\n"
+        else:
+          discard await client.recv(2)
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -302,7 +302,7 @@ proc processRequest(
         # Read bytesToRead and add to body
         # Note we add +2 because the line must be terminated by \r\n
         let chunk = await client.recv(bytesToRead + 2)
-        request.body = request.body & chunk[0 ..< bytesToRead]
+        request.body.add(chunk[0 ..< bytesToRead])
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -79,7 +79,7 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
   ## was chosen automatically.
   runnableExamples:
     from asyncdispatch import Port
-    from asyncnet import getLocalAddr
+    from asyncnet import getLocalAddr, getFd
     from nativesockets import AF_INET
     let server = newAsyncHttpServer()
     server.listen(Port(0)) # Socket is not bound until this point

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -78,12 +78,14 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
   ## Useful for identifying what port the AsyncHttpServer is bound to, if it
   ## was chosen automatically.
   runnableExamples:
-    import asyncdispatch # Port
-    import asyncnet # getLocalAddr
-    import nativesockets # AF_INET
+    from asyncdispatch import Port
+    from asyncnet import getLocalAddr
+    from nativesockets import AF_INET
     let server = newAsyncHttpServer()
     server.listen(Port(0)) # Socket is not bound until this point
     let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]
+    doAssert port > 0
+    server.close()
   a.socket
 
 proc newAsyncHttpServer*(reuseAddr = true, reusePort = false,

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -315,7 +315,9 @@ proc processRequest(
         request.body.add(chunk)
         # Skip \r\n (chunk terminating bytes per spec)
         let separator = await client.recv(2)
-        assert separator == "\r\n"
+        if separator != "\r\n":
+          await request.respond(Http400, "Bad Request. Encoding separator must be \\r\\n")
+          return true
 
       inc sizeOrData
   elif request.reqMethod == HttpPost:

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -43,6 +43,7 @@ runnableExamples:
 
 import asyncnet, asyncdispatch, parseutils, uri, strutils
 import httpcore
+import std/private/since
 
 export httpcore except parseHeader
 
@@ -70,6 +71,9 @@ type
     reusePort: bool
     maxBody: int ## The maximum content-length that will be read for the body.
     maxFDs: int
+
+func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
+  a.socket
 
 proc newAsyncHttpServer*(reuseAddr = true, reusePort = false,
                          maxBody = 8388608): AsyncHttpServer =

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -78,7 +78,9 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
   ## Useful for identifying what port the AsyncHttpServer is bound to, if it
   ## was chosen automatically.
   runnableExamples:
-    import asyncdispatch
+    import asyncdispatch # Port
+    import asyncnet # getLocalAddr
+    import nativesockets # AF_INET
     let server = newAsyncHttpServer()
     server.listen(Port(0)) # Socket is not bound until this point
     let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -84,7 +84,7 @@ func getSocket*(a: AsyncHttpServer): AsyncSocket {.since: (1, 5, 1).} =
     let server = newAsyncHttpServer()
     server.listen(Port(0)) # Socket is not bound until this point
     let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]
-    doAssert port > 0
+    doAssert uint16(port) > 0
     server.close()
   a.socket
 

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -1,6 +1,9 @@
 import httpclient, asynchttpserver, asyncdispatch, asyncfutures
 import net
 
+import std/asyncnet
+import std/nativesockets
+
 const postBegin = """
 POST / HTTP/1.1
 Host: 127.0.0.1:64123
@@ -19,9 +22,9 @@ template genTest(input, expected) =
       sanity = true
       await request.respond(Http200, "Good")
 
-  let port = Port(64123)
   let server = newAsyncHttpServer()
-  discard server.serve(port, handler)
+  discard server.serve(Port(0), handler)
+  let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]
   let data = postBegin & input
   var socket = newSocket()
   socket.connect("127.0.0.1", port)

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -19,8 +19,14 @@ template genTest(input, expected) =
       sanity = true
       await request.respond(Http200, "Good")
 
+  proc runSleepLoop(server: AsyncHttpServer) {.async.} = 
+    server.listen(Port(0))
+    proc wrapper() = 
+      waitFor server.acceptRequest(handler)
+    asyncdispatch.callSoon wrapper
+
   let server = newAsyncHttpServer()
-  discard server.serve(Port(0), handler)
+  waitFor runSleepLoop(server)
   let port = getLocalAddr(server.getSocket.getFd, AF_INET)[1]
   let data = postBegin & input
   var socket = newSocket()

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -1,0 +1,155 @@
+import httpclient, asynchttpserver, asyncdispatch, asyncfutures
+import net
+
+const postBegin = """
+POST / HTTP/1.1
+Host: 127.0.0.1:64123
+Accept: */*
+Transfer-Encoding:chunked
+Content-Type: application/x-www-form-urlencoded
+
+"""
+var
+    sanitySimpleHelloWorldTest = false
+    sanitySimpleEncodingTest = false
+    sanitySimpleChunksTest = false
+    sanityComplexChunksTest = false
+
+proc testSimpleHelloWorld() =
+    let exampleWorld = ("b\r\n" &
+                        "hello=world\r\n" &
+                        "0\r\n" &
+                        "\r\n")
+    let expected = "hello=world"
+
+    proc handler(request: Request) {.async.} =
+        doAssert(request.body == expected)
+        doAssert(request.headers.hasKey("Transfer-Encoding"))
+        doAssert(not request.headers.hasKey("Content-Length"))
+        sanitySimpleHelloWorldTest = true
+        echo "simpleHelloWorldTest ok"
+        await request.respond(Http200, "Good")
+
+    let server = newAsyncHttpServer()
+    discard server.serve(Port(64123), handler)
+
+    let data = postBegin & exampleWorld
+
+    var socket = newSocket()
+    socket.connect("127.0.0.1", Port(64123))
+    socket.send(data)
+
+    waitFor sleepAsync(10)
+
+    socket.close()
+    server.close()
+
+proc testSimpleEncoding() =
+    let exampleWorld = ("e\r\n" &
+                        "hello=encoding\r\n" &
+                        "0\r\n" &
+                        "\r\n")
+    let expected = "hello=encoding"
+
+    proc handler(request: Request) {.async.} =
+        doAssert(request.body == expected)
+        doAssert(request.headers.hasKey("Transfer-Encoding"))
+        doAssert(not request.headers.hasKey("Content-Length"))
+        sanitySimpleEncodingTest = true
+        echo "simpleEncodingTest ok"
+        await request.respond(Http200, "Good")
+
+    let server = newAsyncHttpServer()
+    discard server.serve(Port(64123), handler)
+
+    let data = postBegin & exampleWorld
+
+    var socket = newSocket()
+    socket.connect("127.0.0.1", Port(64123))
+    socket.send(data)
+
+    waitFor sleepAsync(10)
+
+    socket.close()
+    server.close()
+
+proc testSimpleChunks() =
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
+    let exampleMozilla = ("7\r\n" &
+                         "Mozilla\r\n" &
+                         "9\r\n" &
+                         "Developer\r\n" &
+                         "7\r\n" &
+                         "Network\r\n" &
+                         "0\r\n" &
+                         "\r\n")
+    let expected = "MozillaDeveloperNetwork"
+
+    proc handler(request: Request) {.async.} =
+        doAssert(request.body == expected)
+        doAssert(request.headers.hasKey("Transfer-Encoding"))
+        doAssert(not request.headers.hasKey("Content-Length"))
+        sanitySimpleChunksTest = true
+        echo "simpleChunksTest ok"
+        await request.respond(Http200, "Good")
+
+    let server = newAsyncHttpServer()
+    discard server.serve(Port(64123), handler)
+
+    let data = postBegin & exampleMozilla
+
+    var socket = newSocket()
+    socket.connect("127.0.0.1", Port(64123))
+    socket.send(data)
+
+    waitFor sleepAsync(10)
+
+    socket.close()
+    server.close()
+
+proc testComplexChunks() =
+    # https://en.wikipedia.org/wiki/Chunked_transfer_encoding#Example
+    let exampleWikipedia = ("4\r\n" &
+                            "Wiki\r\n" &
+                            "6\r\n" &
+                            "pedia \r\n" &
+                            "E\r\n" &
+                            "in \r\n" &
+                            "\r\n" &
+                            "chunks.\r\n" &
+                            "0\r\n" &
+                            "\r\n")
+    let expected = "Wikipedia in \r\n\r\nchunks."
+
+    proc handler(request: Request) {.async.} =
+        doAssert(request.body == expected)
+        doAssert(request.headers.hasKey("Transfer-Encoding"))
+        doAssert(not request.headers.hasKey("Content-Length"))
+        sanityComplexChunksTest = true
+        echo "complexChunksTest ok"
+        await request.respond(Http200, "Good")
+
+    let server = newAsyncHttpServer()
+    discard server.serve(Port(64123), handler)
+
+    let data = postBegin & exampleWikipedia
+
+    var socket = newSocket()
+    socket.connect("127.0.0.1", Port(64123))
+    socket.send(data)
+
+    waitFor sleepAsync(10)
+
+    socket.close()
+    server.close()
+
+testSimpleHelloWorld()
+testSimpleEncoding()
+testSimpleChunks()
+testComplexChunks()
+
+doAssert(sanitySimpleHelloWorldTest)
+doAssert(sanitySimpleEncodingTest)
+doAssert(sanitySimpleChunksTest)
+doAssert(sanityComplexChunksTest)
+echo "Ok"

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -27,7 +27,6 @@ proc testSimpleHelloWorld() =
         doAssert(request.headers.hasKey("Transfer-Encoding"))
         doAssert(not request.headers.hasKey("Content-Length"))
         sanitySimpleHelloWorldTest = true
-        echo "simpleHelloWorldTest ok"
         await request.respond(Http200, "Good")
 
     let server = newAsyncHttpServer()
@@ -56,7 +55,6 @@ proc testSimpleEncoding() =
         doAssert(request.headers.hasKey("Transfer-Encoding"))
         doAssert(not request.headers.hasKey("Content-Length"))
         sanitySimpleEncodingTest = true
-        echo "simpleEncodingTest ok"
         await request.respond(Http200, "Good")
 
     let server = newAsyncHttpServer()
@@ -90,7 +88,6 @@ proc testSimpleChunks() =
         doAssert(request.headers.hasKey("Transfer-Encoding"))
         doAssert(not request.headers.hasKey("Content-Length"))
         sanitySimpleChunksTest = true
-        echo "simpleChunksTest ok"
         await request.respond(Http200, "Good")
 
     let server = newAsyncHttpServer()
@@ -126,7 +123,6 @@ proc testComplexChunks() =
         doAssert(request.headers.hasKey("Transfer-Encoding"))
         doAssert(not request.headers.hasKey("Content-Length"))
         sanityComplexChunksTest = true
-        echo "complexChunksTest ok"
         await request.respond(Http200, "Good")
 
     let server = newAsyncHttpServer()
@@ -152,4 +148,3 @@ doAssert(sanitySimpleHelloWorldTest)
 doAssert(sanitySimpleEncodingTest)
 doAssert(sanitySimpleChunksTest)
 doAssert(sanityComplexChunksTest)
-echo "Ok"

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -6,10 +6,7 @@ import std/nativesockets
 
 const postBegin = """
 POST / HTTP/1.1
-Host: 127.0.0.1:64123
-Accept: */*
 Transfer-Encoding:chunked
-Content-Type: application/x-www-form-urlencoded
 
 """
 

--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -9,142 +9,67 @@ Transfer-Encoding:chunked
 Content-Type: application/x-www-form-urlencoded
 
 """
-var
-    sanitySimpleHelloWorldTest = false
-    sanitySimpleEncodingTest = false
-    sanitySimpleChunksTest = false
-    sanityComplexChunksTest = false
 
-proc testSimpleHelloWorld() =
-    let exampleWorld = ("b\r\n" &
-                        "hello=world\r\n" &
-                        "0\r\n" &
-                        "\r\n")
-    let expected = "hello=world"
+template genTest(input, expected) =
+  var sanity = false
+  proc handler(request: Request) {.async.} =
+      doAssert(request.body == expected)
+      doAssert(request.headers.hasKey("Transfer-Encoding"))
+      doAssert(not request.headers.hasKey("Content-Length"))
+      sanity = true
+      await request.respond(Http200, "Good")
 
-    proc handler(request: Request) {.async.} =
-        doAssert(request.body == expected)
-        doAssert(request.headers.hasKey("Transfer-Encoding"))
-        doAssert(not request.headers.hasKey("Content-Length"))
-        sanitySimpleHelloWorldTest = true
-        await request.respond(Http200, "Good")
+  let port = Port(64123)
+  let server = newAsyncHttpServer()
+  discard server.serve(port, handler)
+  let data = postBegin & input
+  var socket = newSocket()
+  socket.connect("127.0.0.1", port)
+  socket.send(data)
+  waitFor sleepAsync(10)
+  socket.close()
+  server.close()
 
-    let server = newAsyncHttpServer()
-    discard server.serve(Port(64123), handler)
+  # Verify we ran the handler and its asserts
+  doAssert(sanity)
 
-    let data = postBegin & exampleWorld
-
-    var socket = newSocket()
-    socket.connect("127.0.0.1", Port(64123))
-    socket.send(data)
-
-    waitFor sleepAsync(10)
-
-    socket.close()
-    server.close()
-
-proc testSimpleEncoding() =
-    let exampleWorld = ("e\r\n" &
-                        "hello=encoding\r\n" &
-                        "0\r\n" &
-                        "\r\n")
-    let expected = "hello=encoding"
-
-    proc handler(request: Request) {.async.} =
-        doAssert(request.body == expected)
-        doAssert(request.headers.hasKey("Transfer-Encoding"))
-        doAssert(not request.headers.hasKey("Content-Length"))
-        sanitySimpleEncodingTest = true
-        await request.respond(Http200, "Good")
-
-    let server = newAsyncHttpServer()
-    discard server.serve(Port(64123), handler)
-
-    let data = postBegin & exampleWorld
-
-    var socket = newSocket()
-    socket.connect("127.0.0.1", Port(64123))
-    socket.send(data)
-
-    waitFor sleepAsync(10)
-
-    socket.close()
-    server.close()
-
-proc testSimpleChunks() =
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
-    let exampleMozilla = ("7\r\n" &
-                         "Mozilla\r\n" &
-                         "9\r\n" &
-                         "Developer\r\n" &
-                         "7\r\n" &
-                         "Network\r\n" &
-                         "0\r\n" &
-                         "\r\n")
-    let expected = "MozillaDeveloperNetwork"
-
-    proc handler(request: Request) {.async.} =
-        doAssert(request.body == expected)
-        doAssert(request.headers.hasKey("Transfer-Encoding"))
-        doAssert(not request.headers.hasKey("Content-Length"))
-        sanitySimpleChunksTest = true
-        await request.respond(Http200, "Good")
-
-    let server = newAsyncHttpServer()
-    discard server.serve(Port(64123), handler)
-
-    let data = postBegin & exampleMozilla
-
-    var socket = newSocket()
-    socket.connect("127.0.0.1", Port(64123))
-    socket.send(data)
-
-    waitFor sleepAsync(10)
-
-    socket.close()
-    server.close()
-
-proc testComplexChunks() =
-    # https://en.wikipedia.org/wiki/Chunked_transfer_encoding#Example
-    let exampleWikipedia = ("4\r\n" &
-                            "Wiki\r\n" &
-                            "6\r\n" &
-                            "pedia \r\n" &
-                            "E\r\n" &
-                            "in \r\n" &
-                            "\r\n" &
-                            "chunks.\r\n" &
-                            "0\r\n" &
-                            "\r\n")
-    let expected = "Wikipedia in \r\n\r\nchunks."
-
-    proc handler(request: Request) {.async.} =
-        doAssert(request.body == expected)
-        doAssert(request.headers.hasKey("Transfer-Encoding"))
-        doAssert(not request.headers.hasKey("Content-Length"))
-        sanityComplexChunksTest = true
-        await request.respond(Http200, "Good")
-
-    let server = newAsyncHttpServer()
-    discard server.serve(Port(64123), handler)
-
-    let data = postBegin & exampleWikipedia
-
-    var socket = newSocket()
-    socket.connect("127.0.0.1", Port(64123))
-    socket.send(data)
-
-    waitFor sleepAsync(10)
-
-    socket.close()
-    server.close()
-
-testSimpleHelloWorld()
-testSimpleEncoding()
-testSimpleChunks()
-testComplexChunks()
-
-doAssert(sanitySimpleHelloWorldTest)
-doAssert(sanitySimpleEncodingTest)
-doAssert(sanitySimpleChunksTest)
-doAssert(sanityComplexChunksTest)
+block:
+  const expected = "hello=world"
+  const input = ("b\r\n" &
+                 "hello=world\r\n" &
+                 "0\r\n" &
+                 "\r\n")
+  genTest(input, expected)
+block:
+  const expected = "hello encoding"
+  const input = ("e\r\n" &
+                 "hello encoding\r\n" &
+                 "0\r\n" &
+                 "\r\n")
+  genTest(input, expected)
+block:
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding
+  const expected = "MozillaDeveloperNetwork"
+  const input = ("7\r\n" &
+                "Mozilla\r\n" &
+                "9\r\n" &
+                "Developer\r\n" &
+                "7\r\n" &
+                "Network\r\n" &
+                "0\r\n" &
+                "\r\n")
+  genTest(input, expected)
+block:
+  # https://en.wikipedia.org/wiki/Chunked_transfer_encoding#Example
+  const expected = "Wikipedia in \r\n\r\nchunks."
+  const input = ("4\r\n" &
+                "Wiki\r\n" &
+                "6\r\n" &
+                "pedia \r\n" &
+                "E\r\n" &
+                "in \r\n" &
+                "\r\n" &
+                "chunks.\r\n" &
+                "0\r\n" &
+                "\r\n")
+  genTest(input, expected)


### PR DESCRIPTION
Follow up of PR #16636

This PR makes an important fix of excluding the newline separators from the final body, as this didn't come up in my use case and thus testing. 

Additionally, it includes 4 tests:
* basic validation test
* basic validation test of different size
* multi-part example from the Mozilla Developer Network docs on Transfer-Encoding: chunked (see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding)
* multi-part and multi-line example from Wikipedia on Transfer-Encoding: chunked (see: https://en.wikipedia.org/wiki/Chunked_transfer_encoding#Example)