### PR TITLE
close #9708 remove deprecated specs

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -303,10 +303,6 @@ proc parseSpec*(filename: string): TSpec =
       of "exitcode":
         discard parseInt(e.value, result.exitCode)
         result.action = actionRun
-      of "msg":
-        result.msg = e.value
-        if result.action != actionRun:
-          result.action = actionCompile
       of "errormsg":
         result.msg = e.value
         result.action = actionReject

--- a/testament/tests/shouldfail/tmsg.nim
+++ b/testament/tests/shouldfail/tmsg.nim
@@ -1,6 +1,0 @@
-discard """
-msg: "Hello World"
-"""
-
-static:
-  echo "something else"


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/commit/562d185cb73fa31d901685a15e92b8904f9b077b
close #9708

`msgs` is useless and replaced by `nimout` three years ago.