### PR TITLE
httpclient Response object references original Request; refs #16685

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -210,7 +210,7 @@ import nativesockets
 export httpcore except parseHeader # TODO: The ``except`` doesn't work
 
 type
-  Request* = ref object
+  PreparedRequest* = ref object
     reqMethod*: HttpMethod
     headers*: string
     url*: Uri
@@ -222,7 +222,7 @@ type
     headers*: HttpHeaders
     body: string
     bodyStream*: Stream
-    request*: Request
+    request*: PreparedRequest
 
   AsyncResponse* = ref object
     version*: string
@@ -230,7 +230,7 @@ type
     headers*: HttpHeaders
     body: string
     bodyStream*: FutureStream[string]
-    request*: Request
+    request*: PreparedRequest
 
 proc code*(response: Response | AsyncResponse): HttpCode
            {.raises: [ValueError, OverflowDefect].} =
@@ -908,7 +908,7 @@ proc newConnection(client: HttpClient | AsyncHttpClient,
             newHttpHeaders(), client.proxy)
         await client.socket.send(proxyHeaderString)
         let proxyResp = await parseResponse(client, false)
-        proxyResp.request = Request(
+        proxyResp.request = PreparedRequest(
           reqMethod: HttpConnect,
           headers: proxyHeaderString,
           url: connectUrl,
@@ -1032,7 +1032,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   let getBody = httpMethod notin {HttpHead, HttpConnect} and
                 client.getBody
   result = await parseResponse(client, getBody)
-  result.request = Request(
+  result.request = PreparedRequest(
     reqMethod: httpMethod,
     headers: headerString,
     url: url,

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -210,9 +210,9 @@ import nativesockets
 export httpcore except parseHeader # TODO: The ``except`` doesn't work
 
 type
-  PreparedRequest* = ref object
+  PreparedRequest* = object
     reqMethod*: HttpMethod
-    headers*: string
+    headers*: HttpHeaders
     url*: Uri
     body*: string
 
@@ -904,13 +904,14 @@ proc newConnection(client: HttpClient | AsyncHttpClient,
         connectUrl.hostname = url.hostname
         connectUrl.port = if url.port != "": url.port else: "443"
 
+        let newHeaders = newHttpHeaders()
         let proxyHeaderString = generateHeaders(connectUrl, HttpConnect,
-            newHttpHeaders(), client.proxy)
+            newHeaders, client.proxy)
         await client.socket.send(proxyHeaderString)
         let proxyResp = await parseResponse(client, false)
         proxyResp.request = PreparedRequest(
           reqMethod: HttpConnect,
-          headers: proxyHeaderString,
+          headers: newHeaders,
           url: connectUrl,
         )
 
@@ -1034,7 +1035,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
   result = await parseResponse(client, getBody)
   result.request = PreparedRequest(
     reqMethod: httpMethod,
-    headers: headerString,
+    headers: newHeaders,
     url: url,
     body: body,
   )

--- a/tests/stdlib/tasynchttpserver.nim
+++ b/tests/stdlib/tasynchttpserver.nim
@@ -11,7 +11,7 @@ from net import TimeoutError
 import httpclient, asynchttpserver, asyncdispatch, asyncfutures
 
 template runTest(
-    handler: proc (request: Request): Future[void] {.gcsafe.},
+    handler: proc (request: asynchttpserver.Request): Future[void] {.gcsafe.},
     request: proc (server: AsyncHttpServer): Future[AsyncResponse],
     test: proc (response: AsyncResponse, body: string): Future[void]) =
 
@@ -26,7 +26,7 @@ template runTest(
   discard test(response, body)
 
 proc test200() {.async.} =
-  proc handler(request: Request) {.async.} =
+  proc handler(request: asynchttpserver.Request) {.async.} =
     await request.respond(Http200, "Hello World, 200")
 
   proc request(server: AsyncHttpServer): Future[AsyncResponse] {.async.} =
@@ -47,7 +47,7 @@ proc test200() {.async.} =
   runTest(handler, request, test)
 
 proc test404() {.async.} =
-  proc handler(request: Request) {.async.} =
+  proc handler(request: asynchttpserver.Request) {.async.} =
     await request.respond(Http404, "Hello World, 404")
 
   proc request(server: AsyncHttpServer): Future[AsyncResponse] {.async.} =
@@ -68,7 +68,7 @@ proc test404() {.async.} =
   runTest(handler, request, test)
 
 proc testCustomEmptyHeaders() {.async.} =
-  proc handler(request: Request) {.async.} =
+  proc handler(request: asynchttpserver.Request) {.async.} =
     await request.respond(Http200, "Hello World, 200", newHttpHeaders())
 
   proc request(server: AsyncHttpServer): Future[AsyncResponse] {.async.} =
@@ -89,7 +89,7 @@ proc testCustomEmptyHeaders() {.async.} =
   runTest(handler, request, test)
 
 proc testCustomContentLength() {.async.} =
-  proc handler(request: Request) {.async.} =
+  proc handler(request: asynchttpserver.Request) {.async.} =
     let headers = newHttpHeaders()
     headers["Content-Length"] = "0"
     await request.respond(Http200, "Hello World, 200", headers)

--- a/tests/stdlib/tasynchttpserver.nim
+++ b/tests/stdlib/tasynchttpserver.nim
@@ -11,7 +11,7 @@ from net import TimeoutError
 import httpclient, asynchttpserver, asyncdispatch, asyncfutures
 
 template runTest(
-    handler: proc (request: asynchttpserver.Request): Future[void] {.gcsafe.},
+    handler: proc (request: Request): Future[void] {.gcsafe.},
     request: proc (server: AsyncHttpServer): Future[AsyncResponse],
     test: proc (response: AsyncResponse, body: string): Future[void]) =
 
@@ -26,7 +26,7 @@ template runTest(
   discard test(response, body)
 
 proc test200() {.async.} =
-  proc handler(request: asynchttpserver.Request) {.async.} =
+  proc handler(request: Request) {.async.} =
     await request.respond(Http200, "Hello World, 200")
 
   proc request(server: AsyncHttpServer): Future[AsyncResponse] {.async.} =
@@ -47,7 +47,7 @@ proc test200() {.async.} =
   runTest(handler, request, test)
 
 proc test404() {.async.} =
-  proc handler(request: asynchttpserver.Request) {.async.} =
+  proc handler(request: Request) {.async.} =
     await request.respond(Http404, "Hello World, 404")
 
   proc request(server: AsyncHttpServer): Future[AsyncResponse] {.async.} =
@@ -68,7 +68,7 @@ proc test404() {.async.} =
   runTest(handler, request, test)
 
 proc testCustomEmptyHeaders() {.async.} =
-  proc handler(request: asynchttpserver.Request) {.async.} =
+  proc handler(request: Request) {.async.} =
     await request.respond(Http200, "Hello World, 200", newHttpHeaders())
 
   proc request(server: AsyncHttpServer): Future[AsyncResponse] {.async.} =
@@ -89,7 +89,7 @@ proc testCustomEmptyHeaders() {.async.} =
   runTest(handler, request, test)
 
 proc testCustomContentLength() {.async.} =
-  proc handler(request: asynchttpserver.Request) {.async.} =
+  proc handler(request: Request) {.async.} =
     let headers = newHttpHeaders()
     headers["Content-Length"] = "0"
     await request.respond(Http200, "Hello World, 200", headers)

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -8,7 +8,7 @@ discard """
 import strutils
 from net import TimeoutError
 
-import nativesockets, os, httpclient, asyncdispatch
+import nativesockets, os, httpclient, asyncdispatch, uri
 
 const manualTests = false
 
@@ -41,6 +41,8 @@ proc asyncTest() {.async.} =
   var client = newAsyncHttpClient()
   var resp = await client.request("http://example.com/", HttpGet)
   doAssert(resp.code.is2xx)
+  doAssert(resp.request.reqMethod == HttpGet)
+  doAssert($(resp.request.url) == "http://example.com/")
   var body = await resp.body
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
@@ -104,6 +106,8 @@ proc syncTest() =
   var client = newHttpClient()
   var resp = client.request("http://example.com/", HttpGet)
   doAssert(resp.code.is2xx)
+  doAssert(resp.request.reqMethod == HttpGet)
+  doAssert($(resp.request.url) == "http://example.com/")
   doAssert("<title>Example Domain</title>" in resp.body)
 
   resp = client.request("http://example.com/404")

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -37,7 +37,7 @@ proc makeIPv6HttpServer(hostname: string, port: Port,
       serverFd.accept().callback = onAccept
   serverFd.accept().callback = onAccept
 
-template testPreparedRequest(req: PreparedRequest) =
+proc testPreparedRequest(req: PreparedRequest) =
   doAssert req.reqMethod == HttpGet
   doAssert $req.url == "http://example.com/"
   let clientAgent = $req.headers["user-agent"]

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -43,6 +43,8 @@ proc asyncTest() {.async.} =
   doAssert(resp.code.is2xx)
   doAssert(resp.request.reqMethod == HttpGet)
   doAssert($(resp.request.url) == "http://example.com/")
+  var clientAgent = $(resp.request.headers["user-agent"])
+  doAssert(clientAgent.contains("Nim httpclient"))
   var body = await resp.body
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
@@ -108,6 +110,8 @@ proc syncTest() =
   doAssert(resp.code.is2xx)
   doAssert(resp.request.reqMethod == HttpGet)
   doAssert($(resp.request.url) == "http://example.com/")
+  var clientAgent = $(resp.request.headers["user-agent"])
+  doAssert(clientAgent.contains("Nim httpclient"))
   doAssert("<title>Example Domain</title>" in resp.body)
 
   resp = client.request("http://example.com/404")

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -41,13 +41,15 @@ proc asyncTest() {.async.} =
   var client = newAsyncHttpClient()
   var resp = await client.request("http://example.com/", HttpGet)
   doAssert(resp.code.is2xx)
-  doAssert(resp.request.reqMethod == HttpGet)
-  doAssert($(resp.request.url) == "http://example.com/")
-  var clientAgent = $(resp.request.headers["user-agent"])
-  doAssert(clientAgent.contains("Nim httpclient"))
   var body = await resp.body
   body = await resp.body # Test caching
   doAssert("<title>Example Domain</title>" in body)
+
+  # PreparedRequest
+  doAssert resp.request.reqMethod == HttpGet
+  doAssert $resp.request.url == "http://example.com/"
+  let clientAgent = $resp.request.headers["user-agent"]
+  doAssert clientAgent.contains("Nim httpclient")
 
   resp = await client.request("http://example.com/404")
   doAssert(resp.code.is4xx)
@@ -108,11 +110,13 @@ proc syncTest() =
   var client = newHttpClient()
   var resp = client.request("http://example.com/", HttpGet)
   doAssert(resp.code.is2xx)
-  doAssert(resp.request.reqMethod == HttpGet)
-  doAssert($(resp.request.url) == "http://example.com/")
-  var clientAgent = $(resp.request.headers["user-agent"])
-  doAssert(clientAgent.contains("Nim httpclient"))
   doAssert("<title>Example Domain</title>" in resp.body)
+
+  # PreparedRequest
+  doAssert resp.request.reqMethod == HttpGet
+  doAssert $resp.request.url == "http://example.com/"
+  let clientAgent = $resp.request.headers["user-agent"]
+  doAssert clientAgent.contains("Nim httpclient")
 
   resp = client.request("http://example.com/404")
   doAssert(resp.code.is4xx)


### PR DESCRIPTION
* Add `request` field to `Response` & `AsyncResponse` objects,
* Update related tests in `thttpclient.nim`
* Clear "ambiguous identifier" error on `tasynchttpserver.nim`