### PR TITLE
add -d:nimEchoNimQuittingError to ensure nim check quits properly on error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -141,3 +141,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
   - cell alignment is not supported, i.e. alignment annotations in a delimiter
     row (`:---`, `:--:`, `---:`) are ignored,
   - every table row must start with `|`, e.g. `| cell 1 | cell 2 |`.
+
+- When nim quits with error via `msgQuit`,  `NimQuittingError` is now printed
+  (enabled via `-d:nimEchoNimQuittingError` in tests/config.nims), which helps tests
+  determine that nim quit gracefully instead of via some signal.

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -69,7 +69,7 @@ proc getCommandLineDesc(conf: ConfigRef): string =
 proc helpOnError(conf: ConfigRef; pass: TCmdLinePass) =
   if pass == passCmd1:
     msgWriteln(conf, getCommandLineDesc(conf), {msgStdout})
-    msgQuit(0)
+    msgQuit(conf, 0)
 
 proc writeAdvancedUsage(conf: ConfigRef; pass: TCmdLinePass) =
   if pass == passCmd1:
@@ -78,7 +78,7 @@ proc writeAdvancedUsage(conf: ConfigRef; pass: TCmdLinePass) =
                                  CPU[conf.target.hostCPU].name, CompileDate]) &
                                  AdvancedUsage,
                {msgStdout})
-    msgQuit(0)
+    msgQuit(conf, 0)
 
 proc writeFullhelp(conf: ConfigRef; pass: TCmdLinePass) =
   if pass == passCmd1:
@@ -87,7 +87,7 @@ proc writeFullhelp(conf: ConfigRef; pass: TCmdLinePass) =
                                  CPU[conf.target.hostCPU].name, CompileDate]) &
                                  Usage & AdvancedUsage,
                {msgStdout})
-    msgQuit(0)
+    msgQuit(conf, 0)
 
 proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
   if pass == passCmd1:
@@ -104,7 +104,7 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
       usedTinyC & useLinenoise & usedNativeStacktrace &
       usedFFI & usedBoehm & usedMarkAndSweep & usedGenerational & usedGoGC & usedNoGC,
                {msgStdout})
-    msgQuit(0)
+    msgQuit(conf, 0)
 
 proc writeCommandLineUsage*(conf: ConfigRef) =
   msgWriteln(conf, getCommandLineDesc(conf), {msgStdout})

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -411,7 +411,8 @@ proc quit(conf: ConfigRef; msg: TMsgKind) {.gcsafe.} =
 No stack traceback available
 To create a stacktrace, rerun compilation with './koch temp $1 <file>', see $2 for details""" %
           [conf.command, "intern.html#debugging-the-compiler".createDocLink])
-  beforeQuit(conf)
+  # we could call something similar to `beforeQuit(conf)` here; maybe a different
+  # message to allow tests to distinguish
   quit 1
 
 proc handleError(conf: ConfigRef; msg: TMsgKind, eh: TErrorHandling, s: string) =

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -321,12 +321,11 @@ proc msgWriteln*(conf: ConfigRef; s: string, flags: MsgFlags = {}) =
       when defined(windows):
         flushFile(stderr)
 
-proc beforeQuit(conf: ConfigRef) {.inline.} =
-  if conf.isDefined("nimEchoQuitting"):
-    msgWriteln(conf, "nim quitting")
-
-proc msgQuit*(conf: ConfigRef, x: string | int8) =
-  beforeQuit(conf)
+proc msgQuit*(conf: ConfigRef, x: int8) =
+  if x!=0 and conf.isDefined("nimEchoNimQuittingError"):
+    # this is used in tests to ensure nim quits gracefully instead of via some
+    # signal (e.g. SIGSEGV) or other error.
+    msgWriteln(conf, "NimQuittingError")
   quit x
 
 macro callIgnoringStyle(theProc: typed, first: typed,
@@ -411,7 +410,7 @@ proc quit(conf: ConfigRef; msg: TMsgKind) {.gcsafe.} =
 No stack traceback available
 To create a stacktrace, rerun compilation with './koch temp $1 <file>', see $2 for details""" %
           [conf.command, "intern.html#debugging-the-compiler".createDocLink])
-  # we could call something similar to `beforeQuit(conf)` here; maybe a different
+  # we could call something similar to `nimEchoNimQuittingError` here; maybe a different
   # message to allow tests to distinguish
   quit 1
 

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -119,4 +119,4 @@ when not defined(selftest):
   handleCmdLine(newIdentCache(), conf)
   when declared(GC_setMaxPause):
     echo GC_getStatistics()
-  msgQuit(int8(conf.errorCounter > 0))
+  msgQuit(conf, int8(conf.errorCounter > 0))

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1459,7 +1459,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcQuit:
       if c.mode in {emRepl, emStaticExpr, emStaticStmt}:
         message(c.config, c.debug[pc], hintQuitCalled)
-        msgQuit(int8(toInt(getOrdValue(regs[ra].regToNode, onError = toInt128(1)))))
+        msgQuit(c.config, int8(toInt(getOrdValue(regs[ra].regToNode, onError = toInt128(1)))))
       else:
         return TFullReg(kind: rkNone)
     of opcInvalidField:

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -59,7 +59,7 @@ proc getCommandLineDesc(conf: ConfigRef): string =
 
 proc helpOnError(conf: ConfigRef) =
   msgWriteln(conf, getCommandLineDesc(conf), {msgStdout})
-  msgQuit(0)
+  msgQuit(conf, 0)
 
 type
   CannotMapToZ3Error = object of ValueError
@@ -1280,4 +1280,4 @@ when not defined(selftest):
   handleCmdLine(newIdentCache(), conf)
   when declared(GC_setMaxPause):
     echo GC_getStatistics()
-  msgQuit(int8(conf.errorCounter > 0))
+  msgQuit(conf, int8(conf.errorCounter > 0))

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -13,7 +13,9 @@ switch("excessiveStackTrace", "off")
 switch("define", "nimUnittestOutputLevel:PRINT_FAILURES")
 switch("define", "nimUnittestColor:off")
 
+# other
 switch("define", "nimLegacyTypeMismatch")
+switch("define", "nimEchoNimQuittingError")
 
 hint("Processing", off)
   # dots can cause annoyances; instead, a single test can test `hintProcessing`

--- a/tests/errmsgs/tnim_echo_quitting.nim
+++ b/tests/errmsgs/tnim_echo_quitting.nim
@@ -1,8 +1,12 @@
 discard """
   cmd: "nim check -d:nimEchoQuitting $file"
   action: "reject"
-  nimout: "nim quitting"
+  nimout: '''
+tnim_echo_quitting.nim(12, 1) Error: undeclared identifier: 'nonexistant'
+nim quitting
+'''
 """
+
 static: echo "ok1"
 static: echo "ok2"
 nonexistant

--- a/tests/errmsgs/tnim_echo_quitting.nim
+++ b/tests/errmsgs/tnim_echo_quitting.nim
@@ -1,9 +1,9 @@
 discard """
-  cmd: "nim check -d:nimEchoQuitting $file"
+  cmd: "nim check $file"
   action: "reject"
   nimout: '''
 tnim_echo_quitting.nim(12, 1) Error: undeclared identifier: 'nonexistant'
-nim quitting
+NimQuittingError
 '''
 """
 

--- a/tests/errmsgs/tnim_echo_quitting.nim
+++ b/tests/errmsgs/tnim_echo_quitting.nim
@@ -1,0 +1,8 @@
+discard """
+  cmd: "nim check -d:nimEchoQuitting $file"
+  action: "reject"
+  nimout: "nim quitting"
+"""
+static: echo "ok1"
+static: echo "ok2"
+nonexistant


### PR DESCRIPTION
## example use case
refs https://github.com/nim-lang/Nim/pull/16690#pullrequestreview-566034721

writing simple and correct regression tests to make sure nim (eg nim check) doesn't crash with a SIGSEGV or other signal on some input; note that prior to this PR, simply writing `nimout` with some expected output of eg, `nim check`, would not be enough to guarantee that since it nim check could potentially write those expected outputs and then crash. Whereas after this PR, all you need is:
write in nimout what you expect to get (just the part that you want to check) plus a trailing `nim quitting` that ensures nim exits gracefully (even if with an error, as is typically case with nim check tests)

## see test
tests/errmsgs/tnim_echo_quitting.nim

## future work
- [ ] simplify test case added in https://github.com/nim-lang/Nim/pull/16690 thanks to this PR (refs https://github.com/nim-lang/Nim/pull/16690#pullrequestreview-566034721)