### PR TITLE
Check for errors after sendPendingSslData

### DIFF
--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -260,10 +260,9 @@ when defineSsl:
       # Call the desired operation.
       opResult = op
       # Bit hackish here.
-      # TODO: Introduce an async template transformation pragma?
 
       # Send any remaining pending SSL data.
-      yield sendPendingSslData(socket, flags)
+      await sendPendingSslData(socket, flags)
 
       # If the operation failed, try to see if SSL has some data to read
       # or write.
@@ -321,10 +320,8 @@ template readInto(buf: pointer, size: int, socket: AsyncSocket,
         sslRead(socket.sslHandle, cast[cstring](buf), size.cint))
       res = opResult
   else:
-    var recvIntoFut = asyncdispatch.recvInto(socket.fd.AsyncFD, buf, size, flags)
-    yield recvIntoFut
     # Not in SSL mode.
-    res = recvIntoFut.read()
+    res = await asyncdispatch.recvInto(socket.fd.AsyncFD, buf, size, flags)
   res
 
 template readIntoBuf(socket: AsyncSocket,

--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -259,7 +259,6 @@ when defineSsl:
       ErrClearError()
       # Call the desired operation.
       opResult = op
-      # Bit hackish here.
 
       # Send any remaining pending SSL data.
       await sendPendingSslData(socket, flags)


### PR DESCRIPTION
Not that I reproduced any issues related to this, but it just looks wrong. It is the only yielded future in the file that is not checked for errors. Also git blame shows that this line was intact since the very beginning. Other similar lines gained their error checking over time, so I assume this one just got missed.