### PR TITLE
system/excpt: let the OS handle termination on signal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -110,6 +110,14 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Removed the optional `longestMatch` parameter of the `critbits._WithPrefix` iterators (it never worked reliably)
 
+- On POSIX systems, the default signal handlers used for Nim programs (it's
+  used for printing the stacktrace on fatal signals) will now re-raise the
+  signal for the OS default handlers to handle.
+
+  This lets the OS perform its default actions, which might include core
+  dumping (on select signals) and notifying the parent process about the cause
+  of termination.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -42,6 +42,7 @@ else:
     C_JmpBuf* {.importc: "jmp_buf", header: "<setjmp.h>".} = object
 
 
+type CSighandlerT = proc (a: cint) {.noconv.}
 when defined(windows):
   const
     SIGABRT* = cint(22)
@@ -50,7 +51,7 @@ when defined(windows):
     SIGINT* = cint(2)
     SIGSEGV* = cint(11)
     SIGTERM = cint(15)
-    SIG_DFL* = cast[proc (a: cint) {.noconv.}](0)
+    SIG_DFL* = cast[CSighandlerT](0)
 elif defined(macosx) or defined(linux) or defined(freebsd) or
      defined(openbsd) or defined(netbsd) or defined(solaris) or
      defined(dragonfly) or defined(nintendoswitch) or defined(genode) or
@@ -63,7 +64,7 @@ elif defined(macosx) or defined(linux) or defined(freebsd) or
     SIGSEGV* = cint(11)
     SIGTERM* = cint(15)
     SIGPIPE* = cint(13)
-    SIG_DFL* = cast[proc (a: cint) {.noconv.}](0)
+    SIG_DFL* = cast[CSighandlerT](0)
 elif defined(haiku):
   const
     SIGABRT* = cint(6)
@@ -73,7 +74,7 @@ elif defined(haiku):
     SIGSEGV* = cint(11)
     SIGTERM* = cint(15)
     SIGPIPE* = cint(7)
-    SIG_DFL* = cast[proc (a: cint) {.noconv.}](0)
+    SIG_DFL* = cast[CSighandlerT](0)
 else:
   when NoFakeVars:
     {.error: "SIGABRT not ported to your platform".}
@@ -84,7 +85,7 @@ else:
       SIGABRT* {.importc: "SIGABRT", nodecl.}: cint
       SIGFPE* {.importc: "SIGFPE", nodecl.}: cint
       SIGILL* {.importc: "SIGILL", nodecl.}: cint
-      SIG_DFL* {.importc: "SIG_DFL", nodecl.}: proc(a: cint) {.noconv.}
+      SIG_DFL* {.importc: "SIG_DFL", nodecl.}: CSighandlerT
     when defined(macosx) or defined(linux):
       var SIGPIPE* {.importc: "SIGPIPE", nodecl.}: cint
 
@@ -111,11 +112,9 @@ else:
   proc c_setjmp*(jmpb: C_JmpBuf): cint {.
     header: "<setjmp.h>", importc: "setjmp".}
 
-type CSighandlerT = proc (a: cint) {.noconv.}
-proc c_signal*(sign: cint, handler: proc (a: cint) {.noconv.}): CSighandlerT {.
+proc c_signal*(sign: cint, handler: CSighandlerT): CSighandlerT {.
   importc: "signal", header: "<signal.h>", discardable.}
-proc c_raise*(sign: cint): cint {.importc: "raise", header: "<signal.h>",
-  discardable.}
+proc c_raise*(sign: cint): cint {.importc: "raise", header: "<signal.h>".}
 
 type
   CFile {.importc: "FILE", header: "<stdio.h>",

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -50,6 +50,7 @@ when defined(windows):
     SIGINT* = cint(2)
     SIGSEGV* = cint(11)
     SIGTERM = cint(15)
+    SIG_DFL* = cast[proc (a: cint) {.noconv.}](0)
 elif defined(macosx) or defined(linux) or defined(freebsd) or
      defined(openbsd) or defined(netbsd) or defined(solaris) or
      defined(dragonfly) or defined(nintendoswitch) or defined(genode) or
@@ -62,6 +63,7 @@ elif defined(macosx) or defined(linux) or defined(freebsd) or
     SIGSEGV* = cint(11)
     SIGTERM* = cint(15)
     SIGPIPE* = cint(13)
+    SIG_DFL* = cast[proc (a: cint) {.noconv.}](0)
 elif defined(haiku):
   const
     SIGABRT* = cint(6)
@@ -71,6 +73,7 @@ elif defined(haiku):
     SIGSEGV* = cint(11)
     SIGTERM* = cint(15)
     SIGPIPE* = cint(7)
+    SIG_DFL* = cast[proc (a: cint) {.noconv.}](0)
 else:
   when NoFakeVars:
     {.error: "SIGABRT not ported to your platform".}
@@ -81,6 +84,7 @@ else:
       SIGABRT* {.importc: "SIGABRT", nodecl.}: cint
       SIGFPE* {.importc: "SIGFPE", nodecl.}: cint
       SIGILL* {.importc: "SIGILL", nodecl.}: cint
+      SIG_DFL* {.importc: "SIG_DFL", nodecl.}: proc(a: cint) {.noconv.}
     when defined(macosx) or defined(linux):
       var SIGPIPE* {.importc: "SIGPIPE", nodecl.}: cint
 
@@ -110,6 +114,8 @@ else:
 type CSighandlerT = proc (a: cint) {.noconv.}
 proc c_signal*(sign: cint, handler: proc (a: cint) {.noconv.}): CSighandlerT {.
   importc: "signal", header: "<signal.h>", discardable.}
+proc c_raise*(sign: cint): cint {.importc: "raise", header: "<signal.h>",
+  discardable.}
 
 type
   CFile {.importc: "FILE", header: "<stdio.h>",

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -655,7 +655,7 @@ when not defined(noSignalHandler) and not defined(useNimRtl):
       # re-raise the signal, which will arrive once this handler exit.
       # this lets the OS perform actions like core dumping and will
       # also return the correct exit code to the shell.
-      c_raise(sign)
+      discard c_raise(sign)
     else:
       quit(1)
 

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -647,7 +647,17 @@ when not defined(noSignalHandler) and not defined(useNimRtl):
       # unless there's a good reason to use cstring in signal handler to avoid
       # using gc?
       showErrorMessage(msg, msg.len)
-    quit(1) # always quit when SIGABRT
+
+    when defined(posix):
+      # reset the signal handler to OS default
+      c_signal(sign, SIG_DFL)
+
+      # re-raise the signal, which will arrive once this handler exit.
+      # this lets the OS perform actions like core dumping and will
+      # also return the correct exit code to the shell.
+      c_raise(sign)
+    else:
+      quit(1)
 
   proc registerSignalHandler() =
     c_signal(SIGINT, signalHandler)

--- a/tests/system/tsigexitcode.nim
+++ b/tests/system/tsigexitcode.nim
@@ -1,4 +1,5 @@
 discard """
+  joinable: false
   disabled: windows
 """
 

--- a/tests/system/tsigexitcode.nim
+++ b/tests/system/tsigexitcode.nim
@@ -1,0 +1,19 @@
+discard """
+  disabled: windows
+"""
+
+import os, osproc, posix, strutils
+
+proc main() =
+  if paramCount() > 0:
+    let signal = cint parseInt paramStr(1)
+    discard posix.raise(signal)
+  else:
+    # synchronize this list with lib/system/except.nim:registerSignalHandler()
+    const fatalSigs = [SIGINT, SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS,
+                       SIGPIPE]
+    for s in fatalSigs:
+      let (_, exitCode) = execCmdEx(quoteShellCommand [getAppFilename(), $s])
+      doAssert exitCode == 128 + s, "mismatched exit code for signal " & $s
+
+main()

--- a/tests/system/tsigexitcode.nim
+++ b/tests/system/tsigexitcode.nim
@@ -10,8 +10,8 @@ proc main() =
     discard posix.raise(signal)
   else:
     # synchronize this list with lib/system/except.nim:registerSignalHandler()
-    const fatalSigs = [SIGINT, SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS,
-                       SIGPIPE]
+    let fatalSigs = [SIGINT, SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS,
+                     SIGPIPE]
     for s in fatalSigs:
       let (_, exitCode) = execCmdEx(quoteShellCommand [getAppFilename(), $s])
       doAssert exitCode == 128 + s, "mismatched exit code for signal " & $s


### PR DESCRIPTION
Re-raise the fatal signal received in Nim's default handler for the OS to
handle.

This make sure that core dumps can be generated, which is useful for
debugging long-running processes. Additionally, this lets the calling process
be informed of actual cause of crash.