### PR TITLE
fix #16706

### DIFF
--- a/lib/system/assign.nim
+++ b/lib/system/assign.nim
@@ -122,7 +122,9 @@ proc genericAssignAux(dest, src: pointer, mt: PNimType, shallow: bool) =
       #     var tbObj = TB(p)
       #     tbObj of TC # needs to be false!
       #c_fprintf(stdout, "%s %s\n", pint[].name, mt.name)
-      chckObjAsgn(cast[ptr PNimType](src)[], mt)
+      let srcType = cast[ptr PNimType](src)[] # object is not initialized properly(for example std/times.DateTime)
+      if srcType != nil:
+        chckObjAsgn(srcType, mt)
       pint[] = mt # cast[ptr PNimType](src)[]
   of tyTuple:
     genericAssignAux(dest, src, mt.node, shallow)

--- a/tests/assign/tobject_assign.nim
+++ b/tests/assign/tobject_assign.nim
@@ -1,0 +1,37 @@
+import std/[options, tables, times]
+
+type
+  Data* = object
+    shifts*: OrderedTable[int64, Shift]
+    balance*: float
+
+  Shift* = object
+    quoted*: bool
+    date*: DateTime
+    description*: string
+    start*: Option[DateTime]
+    finish*: Option[DateTime]
+    breakTime*: Option[Duration]
+    rate*: float
+    qty: Option[float]
+    id*: int64
+
+let shift = Shift(
+  quoted: true,
+  date: parse("2000-01-01", "yyyy-MM-dd"),
+  description: "abcdef",
+  start: none(DateTime),
+  finish: none(DateTime),
+  breakTime: none(Duration),
+  rate: 462.11,
+  qty: some(10.0),
+  id: getTime().toUnix()
+)
+
+var shifts: OrderedTable[int64, Shift]
+shifts[shift.id] = shift
+
+discard Data(
+  shifts: shifts,
+  balance: 0.00
+)


### PR DESCRIPTION
another workaround:
change `times.DateTime` from `object of RootObj` to `object`.

```nim
import std/times

type
  Data = object
    shifts*: seq[DateTime]

var shifts = newSeq[DateTime](5)
var data = Data(shifts: shifts)
```
`newSeq` doesn't initialize DateTime properly. 