### PR TITLE
followup for #16717: minimized example + improved comment

### DIFF
--- a/lib/system/assign.nim
+++ b/lib/system/assign.nim
@@ -122,8 +122,10 @@ proc genericAssignAux(dest, src: pointer, mt: PNimType, shallow: bool) =
       #     var tbObj = TB(p)
       #     tbObj of TC # needs to be false!
       #c_fprintf(stdout, "%s %s\n", pint[].name, mt.name)
-      let srcType = cast[ptr PNimType](src)[] # object is not initialized properly(for example std/times.DateTime)
+      let srcType = cast[ptr PNimType](src)[]
       if srcType != nil:
+        # `!= nil` needed because of cases where object is not initialized properly (see bug #16706)
+        # note that you can have `srcType == nil` yet `src != nil`
         chckObjAsgn(srcType, mt)
       pint[] = mt # cast[ptr PNimType](src)[]
   of tyTuple:

--- a/tests/assign/tobject_assign.nim
+++ b/tests/assign/tobject_assign.nim
@@ -1,37 +1,49 @@
-import std/[options, tables, times]
+# bug #16706
 
-type
-  Data* = object
-    shifts*: OrderedTable[int64, Shift]
-    balance*: float
+block: # reduced example
+  type
+    A = object of RootObj
+      a0: string
+    B = object
+      b0: seq[A]
+  var c = newSeq[A](2)
+  var d = B(b0: c)
 
-  Shift* = object
-    quoted*: bool
-    date*: DateTime
-    description*: string
-    start*: Option[DateTime]
-    finish*: Option[DateTime]
-    breakTime*: Option[Duration]
-    rate*: float
-    qty: Option[float]
-    id*: int64
+when true: # original example
+  import std/[options, tables, times]
 
-let shift = Shift(
-  quoted: true,
-  date: parse("2000-01-01", "yyyy-MM-dd"),
-  description: "abcdef",
-  start: none(DateTime),
-  finish: none(DateTime),
-  breakTime: none(Duration),
-  rate: 462.11,
-  qty: some(10.0),
-  id: getTime().toUnix()
-)
+  type
+    Data* = object
+      shifts*: OrderedTable[int64, Shift]
+      balance*: float
 
-var shifts: OrderedTable[int64, Shift]
-shifts[shift.id] = shift
+    Shift* = object
+      quoted*: bool
+      date*: DateTime
+      description*: string
+      start*: Option[DateTime]
+      finish*: Option[DateTime]
+      breakTime*: Option[Duration]
+      rate*: float
+      qty: Option[float]
+      id*: int64
 
-discard Data(
-  shifts: shifts,
-  balance: 0.00
-)
+  let shift = Shift(
+    quoted: true,
+    date: parse("2000-01-01", "yyyy-MM-dd"),
+    description: "abcdef",
+    start: none(DateTime),
+    finish: none(DateTime),
+    breakTime: none(Duration),
+    rate: 462.11,
+    qty: some(10.0),
+    id: getTime().toUnix()
+  )
+
+  var shifts: OrderedTable[int64, Shift]
+  shifts[shift.id] = shift
+
+  discard Data(
+    shifts: shifts,
+    balance: 0.00
+  )


### PR DESCRIPTION
followup for #16717

adds a minimized example so that regression test case stays valid even if implementation in tables/times changes