### PR TITLE
conservative approach to fix #15184

### DIFF
--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -76,6 +76,24 @@ Note that without the `*` following the name of the type, the documentation for
 this type would not be generated. Documentation will only be generated for
 *exported* types/procedures/etc.
 
+It's recommended to always add exactly **one** space after `##` for readability
+of comments — this extra space will be cropped from the parsed comments and
+won't influence RST formatting.
+
+.. note:: Generally, this baseline indentation level inside a documentation
+   comment may not be 1: it can be any since it is determined by the offset
+   of the first non-whitespace character in the comment.
+   After that indentation **must** be consistent on the following lines of
+   the same comment.
+   If you still need to add an additional indentation at the very beginning
+   (for RST block quote syntax) use backslash \\ before it:
+
+   .. code-block:: nim
+      ## \
+      ##
+      ##    Block quote at the first line.
+      ##
+      ## Paragraph.
 
 Nim file input
 -----------------

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -247,7 +247,7 @@ Multiline documentation comments also exist and support nesting too:
 .. code-block:: nim
   proc foo =
     ##[Long documentation comment
-    here.
+       here.
     ]##
 
 

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -191,6 +191,11 @@ window.addEventListener('DOMContentLoaded', main);
     title="z6(): int">z6</a></li>
 
   </ul>
+  <ul class="simple nested-toc-section">anything
+      <li><a class="reference" href="#anything"
+    title="anything()">anything</a></li>
+
+  </ul>
   <ul class="simple nested-toc-section">low
       <li><a class="reference" href="#low%2CT"
     title="low[T: Ordinal | enum | range](x: T): T">low,<wbr>T</a></li>
@@ -793,6 +798,13 @@ ok1
 
 <p><strong class="examples_text">Example:</strong></p>
 <pre class="listing"><span class="Keyword">discard</span></pre>ok1
+
+</dd>
+<a id="anything"></a>
+<dt><pre><span class="Keyword">proc</span> <a href="#anything"><span class="Identifier">anything</span></a><span class="Other">(</span><span class="Other">)</span> <span><span class="Other">{</span><span class="Other pragmadots">...</span><span class="Other">}</span></span><span class="pragmawrap"><span class="Other">{.</span><span class="pragma"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span><span class="Other">.}</span></span></pre></dt>
+<dd>
+
+There is no block quote after blank lines at the beginning.
 
 </dd>
 

--- a/nimdoc/testproject/expected/testproject.idx
+++ b/nimdoc/testproject/expected/testproject.idx
@@ -59,3 +59,4 @@ Circle	testproject.html#Circle	Shapes.Circle
 Triangle	testproject.html#Triangle	Shapes.Triangle	
 Rectangle	testproject.html#Rectangle	Shapes.Rectangle	
 Shapes	testproject.html#Shapes	testproject: Shapes	
+anything	testproject.html#anything	testproject: anything()	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -78,6 +78,10 @@ window.addEventListener('DOMContentLoaded', main);
 <li><a class="reference external"
           data-doc-search-tag="utils: aEnum(): untyped" href="subdir/subdir_b/utils.html#aEnum.t">utils: aEnum(): untyped</a></li>
           </ul></dd>
+<dt><a name="anything" href="#anything"><span>anything:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: anything()" href="testproject.html#anything">testproject: anything()</a></li>
+          </ul></dd>
 <dt><a name="asyncFun1" href="#asyncFun1"><span>asyncFun1:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="testproject: asyncFun1(): Future[int]" href="testproject.html#asyncFun1">testproject: asyncFun1(): Future[int]</a></li>

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -375,3 +375,9 @@ when true: # issue #15702
       Circle,     ## A circle
       Triangle,   ## A three-sided shape
       Rectangle   ## A four-sided shape
+
+when true: # issue #15184
+  proc anything* =
+    ##
+    ##  There is no block quote after blank lines at the beginning.
+  discard


### PR DESCRIPTION
Another approach w.r.t. PR #16699

Removes appearance of block quote when first line in a doc comment is empty:
```
##
## x
```

Now blank lines at the beginning of a doc comment are ignored in setting of baseline indentation level inside the comment.

Also the similar situation was wrong for multi-line doc comments:
``` nim
proc foo1* =
  ##[

  Long documentation comment1
  here.
  ]##
```