### PR TITLE
remove all instances of: raises: [Defect]

### DIFF
--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -434,14 +434,16 @@ Annotating procs with raised exceptions
 ---------------------------------------
 
 Through the use of the optional ``{.raises.}`` pragma you can specify that a
-proc is meant to raise a specific set of exceptions, or none at all. If the
-``{.raises.}`` pragma is used, the compiler will verify that this is true. For
-instance, if you specify that a proc raises ``IOError``, and at some point it
+proc is meant to raise a specific set of `CatchableError` exceptions, or none at all. If the
+``{.raises.}`` pragma is used, the compiler will verify that this is true. Note
+that procs are always assumed they can raise a `Defect` so `.raises` shouldn't
+be used for `Defect`'s.
+For instance, if you specify that a proc raises ``IOError``, and at some point it
 (or one of the procs it calls) starts raising a new exception the compiler will
 prevent that proc from compiling. Usage example:
 
 .. code-block:: nim
-  proc complexProc() {.raises: [IOError, ArithmeticDefect].} =
+  proc complexProc() {.raises: [IOError].} =
     ...
 
   proc simpleProc() {.raises: [].} =

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -225,7 +225,7 @@ type
     bodyStream*: FutureStream[string]
 
 proc code*(response: Response | AsyncResponse): HttpCode
-           {.raises: [ValueError, OverflowDefect].} =
+           {.raises: [ValueError].} =
   ## Retrieves the specified response's ``HttpCode``.
   ##
   ## Raises a ``ValueError`` if the response's ``status`` does not have a

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -115,27 +115,27 @@ type
     closeImpl*: proc (s: Stream)
       {.nimcall, raises: [Exception, IOError, OSError], tags: [WriteIOEffect], gcsafe.}
     atEndImpl*: proc (s: Stream): bool
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [], gcsafe.}
     setPositionImpl*: proc (s: Stream, pos: int)
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [], gcsafe.}
     getPositionImpl*: proc (s: Stream): int
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [], gcsafe.}
 
     readDataStrImpl*: proc (s: Stream, buffer: var string, slice: Slice[int]): int
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [ReadIOEffect], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [ReadIOEffect], gcsafe.}
 
     readLineImpl*: proc(s: Stream, line: var TaintedString): bool
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [ReadIOEffect], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [ReadIOEffect], gcsafe.}
 
     readDataImpl*: proc (s: Stream, buffer: pointer, bufLen: int): int
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [ReadIOEffect], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [ReadIOEffect], gcsafe.}
     peekDataImpl*: proc (s: Stream, buffer: pointer, bufLen: int): int
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [ReadIOEffect], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [ReadIOEffect], gcsafe.}
     writeDataImpl*: proc (s: Stream, buffer: pointer, bufLen: int)
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [WriteIOEffect], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [WriteIOEffect], gcsafe.}
 
     flushImpl*: proc (s: Stream)
-      {.nimcall, raises: [Defect, IOError, OSError], tags: [WriteIOEffect], gcsafe.}
+      {.nimcall, raises: [IOError, OSError], tags: [WriteIOEffect], gcsafe.}
 
 proc flush*(s: Stream) =
   ## Flushes the buffers that the stream `s` might use.

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2049,7 +2049,7 @@ template formatValue*(result: var string; value: Time, specifier: string) =
 
 proc parse*(input: string, f: TimeFormat, zone: Timezone = local(),
     loc: DateTimeLocale = DefaultLocale): DateTime
-    {.raises: [TimeParseError, Defect].} =
+    {.raises: [TimeParseError].} =
   ## Parses ``input`` as a ``DateTime`` using the format specified by ``f``.
   ## If no UTC offset was parsed, then ``input`` is assumed to be specified in
   ## the ``zone`` timezone. If a UTC offset was parsed, the result will be
@@ -2093,7 +2093,7 @@ proc parse*(input: string, f: TimeFormat, zone: Timezone = local(),
 
 proc parse*(input, f: string, tz: Timezone = local(),
     loc: DateTimeLocale = DefaultLocale): DateTime
-    {.raises: [TimeParseError, TimeFormatParseError, Defect].} =
+    {.raises: [TimeParseError, TimeFormatParseError].} =
   ## Shorthand for constructing a ``TimeFormat`` and using it to parse
   ## ``input`` as a ``DateTime``.
   ##
@@ -2107,13 +2107,13 @@ proc parse*(input, f: string, tz: Timezone = local(),
 
 proc parse*(input: string, f: static[string], zone: Timezone = local(),
     loc: DateTimeLocale = DefaultLocale):
-  DateTime {.raises: [TimeParseError, Defect].} =
+  DateTime {.raises: [TimeParseError].} =
   ## Overload that validates ``f`` at compile time.
   const f2 = initTimeFormat(f)
   result = input.parse(f2, zone, loc = loc)
 
 proc parseTime*(input, f: string, zone: Timezone): Time
-    {.raises: [TimeParseError, TimeFormatParseError, Defect].} =
+    {.raises: [TimeParseError, TimeFormatParseError].} =
   ## Shorthand for constructing a ``TimeFormat`` and using it to parse
   ## ``input`` as a ``DateTime``, then converting it a ``Time``.
   ##
@@ -2125,7 +2125,7 @@ proc parseTime*(input, f: string, zone: Timezone): Time
   parse(input, f, zone).toTime()
 
 proc parseTime*(input: string, f: static[string], zone: Timezone): Time
-    {.raises: [TimeParseError, Defect].} =
+    {.raises: [TimeParseError].} =
   ## Overload that validates ``format`` at compile time.
   const f2 = initTimeFormat(f)
   result = input.parse(f2, zone).toTime()


### PR DESCRIPTION
## rationale 1
procs should be able to raise a Defect by default. Future work can add ability to specify that a proc does not (recursively) generate a Defect. This PR doesn't contradict such design.

## rationale 2
compiler (correctly) gives: `Hint: 'fn' cannot raise 'Defect' [XCannotRaiseY]` here:
```nim
when true:
  proc fn*(input: string) {.raises: [Defect].} =
    if input == "asdfadfadf1": raise newException(AssertionDefect, "asdf")
    if input == "asdfadfadf2": doAssert false
    if input == "asdfadfadf3": (var a = 500; var b = a.int8)
  fn("bar")
```

## rationale 3
this doesn't give any warnings/errors
```nim
when true:
  proc fn*(input: string) {.raises: [].} =
    if input == "asdfadfadf1": raise newException(AssertionDefect, "asdf")
    if input == "asdfadfadf2": doAssert false
    if input == "asdfadfadf3": (var a = 500; var b = a.int8)
  fn("bar")
```

## rationale 4
nim doc generates: `proc fn(input: string) {.raises: [], tags: [].}`
```nim
  proc fn*(input: string) =
    if input == "asdfadfadf1": raise newException(AssertionDefect, "asdf")
    if input == "asdfadfadf2": doAssert false
    if input == "asdfadfadf3": (var a = 500; var b = a.int8)
  fn("bar")
```


## note
this holds true regardless of `--panics:on|off`

## TODO
- [ ] this seems to fail because of bootstrap, eg:
```
$nim_1402_X c --lib:lib koch # works
$nim_csources_local_X c --lib:lib koch # fails: options.nim(176, 5) Error: can raise an unlisted exception: ref UnpackDefect
$nim_120_X c --lib:lib koch # ditto
```

- [ ] simplify assert/doAssert: the cast isn't needed anymore since 1.4.0:
```nim
proc failedAssertImpl*(msg: string) {.raises: [], tags: [].} =
  # trick the compiler to not list ``AssertionDefect`` when called
  # by ``assert``.
  type Hide = proc (msg: string) {.noinline, raises: [], noSideEffect,
                                    tags: [].}
  cast[Hide](raiseAssert)(msg)
```

## links
* https://github.com/nim-lang/Nim/issues/17399