### PR TITLE
perpare for more compact bit operations in JS

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -159,14 +159,15 @@ func isNaN*(x: SomeFloat): bool {.inline, since: (1,5,1).} =
     else: result = c_isnan(x)
 
 when defined(js):
+  import std/private/jsutils
+
   proc toBitsImpl(x: float): array[2, uint32] =
-    asm """
-    const buffer = new ArrayBuffer(8);
-    const floatBuffer = new Float64Array(buffer);
-    const uintBuffer = new Uint32Array(buffer);
-    floatBuffer[0] = `x`;
-    `result` = uintBuffer
-    """
+    let buffer = newArrayBuffer(8)
+    let floatBuffer = newFloat64Array(buffer)
+    let uintBuffer = newUint32Array(buffer)
+    floatBuffer[0] = x
+    {.emit: "`result` = `uintBuffer`;".}
+    # result = cast[array[2, uint32]](uintBuffer)
 
 proc signbit*(x: SomeFloat): bool {.inline, since: (1, 5, 1).} =
   ## Returns true if `x` is negative, false otherwise.

--- a/lib/std/private/jsutils.nim
+++ b/lib/std/private/jsutils.nim
@@ -1,0 +1,12 @@
+when defined(js):
+  type
+    ArrayBuffer* = ref object of JsRoot
+    Float64Array* = ref object of JsRoot
+    Uint32Array* = ref object of JsRoot
+
+  func newArrayBuffer*(n: int): ArrayBuffer {.importjs: "new ArrayBuffer(#)".}
+  func newFloat64Array*(buffer: ArrayBuffer): Float64Array {.importjs: "new Float64Array(#)".}
+  func newUint32Array*(buffer: ArrayBuffer): Uint32Array {.importjs: "new Uint32Array(#)".}
+
+  func `[]`*(arr: Uint32Array, i: int): uint32 {.importjs: "#[#]".}
+  func `[]=`*(arr: Float64Array, i: int, v: float) {.importjs: "#[#] = #".}


### PR DESCRIPTION
Before: it is hard to reuse same variables by emitting JS(see https://github.com/nim-lang/Nim/pull/16609)
```nim
when defined(js):
  proc toBitsImpl(x: float): array[2, uint32] =
    asm """
    const buffer = new ArrayBuffer(8);
    const a = new Float64Array(buffer);
    const b = new Uint32Array(buffer);
    a[0] = `x`;
    `result` = b
    """

  proc jsSetSign(x: float, sgn: bool): float =
    asm """
    function updateBit(num, bitPos, bitVal) {
      return (num & ~(1 << bitPos)) | (bitVal << bitPos);
    }
    const buffer = new ArrayBuffer(8);
    const a = new Float64Array(buffer);
    const b = new Uint32Array(buffer);
    a[0] = `x`;
    b[1] = updateBit(b[1], 31, `sgn`);
    `result` = a[0]
    """
```
After
You could reuse these variables in a proc.
```nim
   const buffer = new ArrayBuffer(8);
   const a = new Float64Array(buffer);
   const b = new Uint32Array(buffer);
```