### PR TITLE
[backport 1.0.x] fix config/nim.cfg: `@if not bsd or haiku:` was buggy

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -111,26 +111,24 @@ path="$lib/pure"
 @end
 
 @if unix:
-  @if not bsd or haiku:
+  @if bsd:
+    # BSD got posix_spawn only recently, so we deactivate it for osproc:
+    define:useFork
+    # at least NetBSD has problems with thread local storage:
+    tlsEmulation:on
+  @elif haiku:
+    gcc.options.linker = "-Wl,--as-needed -lnetwork"
+    gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork"
+    clang.options.linker = "-Wl,--as-needed -lnetwork"
+    clang.cpp.options.linker = "-Wl,--as-needed -lnetwork"
+    tcc.options.linker = "-Wl,--as-needed -lnetwork"
+  @else:
     # -fopenmp
     gcc.options.linker = "-ldl"
     gcc.cpp.options.linker = "-ldl"
     clang.options.linker = "-ldl"
     clang.cpp.options.linker = "-ldl"
     tcc.options.linker = "-ldl"
-  @end
-  @if bsd:
-    # BSD got posix_spawn only recently, so we deactivate it for osproc:
-    define:useFork
-    # at least NetBSD has problems with thread local storage:
-    tlsEmulation:on
-  @end
-  @if haiku:
-    gcc.options.linker = "-Wl,--as-needed -lnetwork"
-    gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork"
-    clang.options.linker = "-Wl,--as-needed -lnetwork"
-    clang.cpp.options.linker = "-Wl,--as-needed -lnetwork"
-    tcc.options.linker = "-Wl,--as-needed -lnetwork"
   @end
 @end
 


### PR DESCRIPTION
bug was introduced in 3813af63f50a1f5a62cba6517fe5b8c2f709656f