### PR TITLE
Replace most occurences of intsets with packedsets

### DIFF
--- a/compiler/aliases.nim
+++ b/compiler/aliases.nim
@@ -10,15 +10,15 @@
 ## Simple alias analysis for the HLO and the code generators.
 
 import
-  ast, astalgo, types, trees, intsets
+  ast, astalgo, types, trees, std/packedsets
 
 type
   TAnalysisResult* = enum
     arNo, arMaybe, arYes
 
-proc isPartOfAux(a, b: PType, marker: var IntSet): TAnalysisResult
+proc isPartOfAux(a, b: PType, marker: var PackedSet[int]): TAnalysisResult
 
-proc isPartOfAux(n: PNode, b: PType, marker: var IntSet): TAnalysisResult =
+proc isPartOfAux(n: PNode, b: PType, marker: var PackedSet[int]): TAnalysisResult =
   result = arNo
   case n.kind
   of nkRecList:
@@ -39,7 +39,7 @@ proc isPartOfAux(n: PNode, b: PType, marker: var IntSet): TAnalysisResult =
     result = isPartOfAux(n.sym.typ, b, marker)
   else: discard
 
-proc isPartOfAux(a, b: PType, marker: var IntSet): TAnalysisResult =
+proc isPartOfAux(a, b: PType, marker: var PackedSet[int]): TAnalysisResult =
   result = arNo
   if a == nil or b == nil: return
   if containsOrIncl(marker, a.id): return
@@ -59,7 +59,7 @@ proc isPartOfAux(a, b: PType, marker: var IntSet): TAnalysisResult =
 
 proc isPartOf(a, b: PType): TAnalysisResult =
   ## checks iff 'a' can be part of 'b'. Iterates over VALUE types!
-  var marker = initIntSet()
+  var marker = initPackedSet[int]()
   # watch out: parameters reversed because I'm too lazy to change the code...
   result = isPartOfAux(b, a, marker)
 

--- a/compiler/ccgmerge.nim
+++ b/compiler/ccgmerge.nim
@@ -12,7 +12,7 @@
 
 import
   ast, ropes, options, strutils, nimlexbase, cgendata, rodutils,
-  intsets, llstream, tables, modulegraphs, pathutils
+  std/packedsets, llstream, tables, modulegraphs, pathutils
 
 # Careful! Section marks need to contain a tabulator so that they cannot
 # be part of C string literals.
@@ -87,7 +87,7 @@ proc writeTypeCache(a: TypeCache, s: var string) =
     inc i
   s.add('}')
 
-proc writeIntSet(a: IntSet, s: var string) =
+proc writeIntSet(a: PackedSet[int], s: var string) =
   var i = 0
   for x in items(a):
     if i == 10:
@@ -191,7 +191,7 @@ proc readTypeCache(L: var TBaseLexer, result: var TypeCache) =
     discard decodeStr(L.buf, L.bufpos)
   inc L.bufpos
 
-proc readIntSet(L: var TBaseLexer, result: var IntSet) =
+proc readIntSet(L: var TBaseLexer, result: var PackedSet[int]) =
   if ^L.bufpos != '{': doAssert(false, "ccgmerge: '{' expected")
   inc L.bufpos
   while ^L.bufpos != '}':

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -10,7 +10,7 @@
 ## This module implements the C code generator.
 
 import
-  ast, astalgo, hashes, trees, platform, magicsys, extccomp, options, intsets,
+  ast, astalgo, hashes, trees, platform, magicsys, extccomp, options, std/packedsets,
   nversion, nimsets, msgs, bitsets, idents, types,
   ccgutils, os, ropes, math, passes, wordrecg, treetab, cgmeth,
   rodutils, renderer, cgendata, ccgmerge, aliases,
@@ -984,7 +984,7 @@ proc getProcTypeCast(m: BModule, prc: PSym): Rope =
   result = getTypeDesc(m, prc.loc.t)
   if prc.typ.callConv == ccClosure:
     var rettype, params: Rope
-    var check = initIntSet()
+    var check = initPackedSet[int]()
     genProcParams(m, prc.typ, rettype, params, check)
     result = "$1(*)$2" % [rettype, params]
 
@@ -1809,8 +1809,8 @@ proc rawNewModule(g: BModuleList; module: PSym, filename: AbsoluteFile): BModule
   result.g = g
   result.tmpBase = rope("TM" & $hashOwner(module) & "_")
   result.headerFiles = @[]
-  result.declaredThings = initIntSet()
-  result.declaredProtos = initIntSet()
+  result.declaredThings = initPackedSet[int]()
+  result.declaredProtos = initPackedSet[int]()
   result.cfilename = filename
   result.filename = filename
   result.typeCache = initTable[SigHash, Rope]()

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -29,7 +29,7 @@
 ## "A Graph–Free Approach to Data–Flow Analysis" by Markus Mohnen.
 ## https://link.springer.com/content/pdf/10.1007/3-540-45937-5_6.pdf
 
-import ast, types, intsets, lineinfos, renderer
+import ast, types, std/packedsets, lineinfos, renderer
 import std/private/asciitables
 
 from patterns import sameTrees
@@ -65,7 +65,7 @@ type
 proc codeListing(c: ControlFlowGraph, start = 0; last = -1): string =
   # for debugging purposes
   # first iteration: compute all necessary labels:
-  var jumpTargets = initIntSet()
+  var jumpTargets = initPackedSet[int]()
   let last = if last < 0: c.len-1 else: min(last, c.len-1)
   for i in start..last:
     if c[i].kind in {goto, fork}:

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -15,7 +15,7 @@ import
   wordrecg, syntaxes, renderer, lexer, packages/docutils/rstast,
   packages/docutils/rst, packages/docutils/rstgen,
   json, xmltree, trees, types,
-  typesrenderer, astalgo, lineinfos, intsets,
+  typesrenderer, astalgo, lineinfos, std/packedsets,
   pathutils, trees, tables, nimpaths, renderverbatim, osproc
 
 from uri import encodeUrl
@@ -49,8 +49,8 @@ type
     conf*: ConfigRef
     cache*: IdentCache
     exampleCounter: int
-    emitted: IntSet # we need to track which symbols have been emitted
-                    # already. See bug #3655
+    emitted: PackedSet[int] # we need to track which symbols have been emitted
+                            # already. See bug #3655
     thisDir*: AbsoluteDir
     exampleGroups: OrderedTable[string, ExampleGroup]
     wroteSupportFiles*: bool
@@ -236,7 +236,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
       let (output, gotten) = execCmdEx(cmd)
       if gotten != status:
         rawMessage(conf, errGenerated, "snippet failed: cmd: '$1' status: $2 expected: $3 output: $4" % [cmd, $gotten, $status, output])
-  result.emitted = initIntSet()
+  result.emitted = initPackedSet[int]()
   result.destFile = getOutFile2(conf, presentationPath(conf, filename), outExt, false).string
   result.thisDir = result.destFile.AbsoluteFile.splitFile.dir
 

--- a/compiler/ic/to_packed_ast.nim
+++ b/compiler/ic/to_packed_ast.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std / [hashes, tables, intsets, sha1]
+import std / [hashes, tables, packedsets, sha1]
 import packed_ast, bitabs, rodfiles
 import ".." / [ast, idents, lineinfos, msgs, ropes, options,
   pathutils, condsyms]
@@ -46,8 +46,8 @@ type
     filenames*: Table[FileIndex, LitId]
     pendingTypes*: seq[PType]
     pendingSyms*: seq[PSym]
-    typeMarker*: IntSet #Table[ItemId, TypeId]  # ItemId.item -> TypeId
-    symMarker*: IntSet #Table[ItemId, SymId]    # ItemId.item -> SymId
+    typeMarker*: PackedSet[int] #Table[ItemId, TypeId]  # ItemId.item -> TypeId
+    symMarker*: PackedSet[int] #Table[ItemId, SymId]    # ItemId.item -> SymId
     config*: ConfigRef
 
 template primConfigFields(fn: untyped) {.dirty.} =

--- a/compiler/isolation_check.nim
+++ b/compiler/isolation_check.nim
@@ -11,11 +11,11 @@
 ## https://github.com/nim-lang/RFCs/issues/244 for more details.
 
 import
-  ast, types, renderer, intsets
+  ast, types, renderer, std/packedsets
 
-proc canAlias(arg, ret: PType; marker: var IntSet): bool
+proc canAlias(arg, ret: PType; marker: var PackedSet[int]): bool
 
-proc canAliasN(arg: PType; n: PNode; marker: var IntSet): bool =
+proc canAliasN(arg: PType; n: PNode; marker: var PackedSet[int]): bool =
   case n.kind
   of nkRecList:
     for i in 0..<n.len:
@@ -35,7 +35,7 @@ proc canAliasN(arg: PType; n: PNode; marker: var IntSet): bool =
     result = canAlias(arg, n.sym.typ, marker)
   else: discard
 
-proc canAlias(arg, ret: PType; marker: var IntSet): bool =
+proc canAlias(arg, ret: PType; marker: var PackedSet[int]): bool =
   if containsOrIncl(marker, ret.id):
     return false
 
@@ -64,7 +64,7 @@ proc canAlias(arg, ret: PType; marker: var IntSet): bool =
   else:
     result = false
 
-proc isValueOnlyType(t: PType): bool = 
+proc isValueOnlyType(t: PType): bool =
   # t doesn't contain pointers and references
   proc wrap(t: PType): bool {.nimcall.} = t.kind in {tyRef, tyPtr, tyVar, tyLent}
   result = not types.searchTypeFor(t, wrap)
@@ -74,7 +74,7 @@ proc canAlias*(arg, ret: PType): bool =
     # can alias only with unsafeAddr(arg.x) and we don't care if it is not safe
     result = false
   else:
-    var marker = initIntSet()
+    var marker = initPackedSet[int]()
     result = canAlias(arg, ret, marker)
 
 proc checkIsolate*(n: PNode): bool =

--- a/compiler/lambdalifting.nim
+++ b/compiler/lambdalifting.nim
@@ -10,7 +10,7 @@
 # This file implements lambda lifting for the transformator.
 
 import
-  intsets, strutils, options, ast, astalgo, msgs,
+  std/packedsets, strutils, options, ast, astalgo, msgs,
   idents, renderer, types, magicsys, lowerings, tables, modulegraphs, lineinfos,
   transf, liftdestructors
 
@@ -302,15 +302,15 @@ proc markAsClosure(g: ModuleGraph; owner: PSym; n: PNode) =
 
 type
   DetectionPass = object
-    processed, capturedVars: IntSet
+    processed, capturedVars: PackedSet[int]
     ownerToType: Table[int, PType]
     somethingToDo: bool
     graph: ModuleGraph
     idgen: IdGenerator
 
 proc initDetectionPass(g: ModuleGraph; fn: PSym; idgen: IdGenerator): DetectionPass =
-  result.processed = initIntSet()
-  result.capturedVars = initIntSet()
+  result.processed = initPackedSet[int]()
+  result.capturedVars = initPackedSet[int]()
   result.ownerToType = initTable[int, PType]()
   result.processed.incl(fn.id)
   result.graph = g
@@ -510,13 +510,13 @@ proc detectCapturedVars(n: PNode; owner: PSym; c: var DetectionPass) =
 
 type
   LiftingPass = object
-    processed: IntSet
+    processed: PackedSet[int]
     envVars: Table[int, PNode]
     inContainer: int
     unownedEnvVars: Table[int, PNode] # only required for --newruntime
 
 proc initLiftingPass(fn: PSym): LiftingPass =
-  result.processed = initIntSet()
+  result.processed = initPackedSet[int]()
   result.processed.incl(fn.id)
   result.envVars = initTable[int, PNode]()
 

--- a/compiler/optimizer.nim
+++ b/compiler/optimizer.nim
@@ -12,7 +12,7 @@
 ## - recognize "all paths lead to 'wasMoved(x)'"
 
 import
-  ast, renderer, idents, intsets
+  ast, renderer, idents, std/packedsets
 
 from trees import exprStructuralEquivalent
 
@@ -61,7 +61,7 @@ proc mergeBasicBlockInfo(parent: var BasicBlock; this: BasicBlock) {.inline.} =
     parent.wasMovedLocs.setLen 0
     parent.hasReturn = true
 
-proc wasMovedTarget(matches: var IntSet; branch: seq[PNode]; moveTarget: PNode): bool =
+proc wasMovedTarget(matches: var PackedSet[int]; branch: seq[PNode]; moveTarget: PNode): bool =
   result = false
   for i in 0..<branch.len:
     if exprStructuralEquivalent(branch[i][1].skipAddr, moveTarget,
@@ -72,7 +72,7 @@ proc wasMovedTarget(matches: var IntSet; branch: seq[PNode]; moveTarget: PNode):
 proc intersect(summary: var seq[PNode]; branch: seq[PNode]) =
   # keep all 'wasMoved(x)' calls in summary that are also in 'branch':
   var i = 0
-  var matches = initIntSet()
+  var matches = initPackedSet[int]()
   while i < summary.len:
     if wasMovedTarget(matches, branch, summary[i][1].skipAddr):
       inc i

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -14,7 +14,7 @@ import
   wordrecg, ropes, msgs, idents, renderer, types, platform, math,
   magicsys, nversion, nimsets, semfold, modulepaths, importer,
   procfind, lookups, pragmas, passes, semdata, semtypinst, sigmatch,
-  intsets, transf, vmdef, vm, aliases, cgmeth, lambdalifting,
+  std/packedsets, transf, vmdef, vm, aliases, cgmeth, lambdalifting,
   evaltempl, patterns, parampatterns, sempass2, linter, semmacrosanity,
   lowerings, plugins/active, lineinfos, strtabs, int128,
   isolation_check, typeallowed

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -10,7 +10,7 @@
 ## This module contains the data structures for the semantic checking phase.
 
 import
-  intsets, options, ast, astalgo, msgs, idents, renderer,
+  std/packedsets, options, ast, astalgo, msgs, idents, renderer,
   magicsys, vmdef, modulegraphs, lineinfos, sets, pathutils
 
 import ic / to_packed_ast
@@ -79,9 +79,9 @@ type
     case mode*: ImportMode
     of importAll: discard
     of importSet:
-      imported*: IntSet          # of PIdent.id
+      imported*: PackedSet[int]          # of PIdent.id
     of importExcept:
-      exceptSet*: IntSet         # of PIdent.id
+      exceptSet*: PackedSet[int]         # of PIdent.id
 
   PContext* = ref TContext
   TContext* = object of TPassContext # a context represents the module
@@ -129,12 +129,12 @@ type
     semInferredLambda*: proc(c: PContext, pt: TIdTable, n: PNode): PNode
     semGenerateInstance*: proc (c: PContext, fn: PSym, pt: TIdTable,
                                 info: TLineInfo): PSym
-    includedFiles*: IntSet    # used to detect recursive include files
+    includedFiles*: PackedSet[int]    # used to detect recursive include files
     pureEnumFields*: TStrTable   # pure enum fields that can be used unambiguously
     userPragmas*: TStrTable
     evalContext*: PEvalContext
-    unknownIdents*: IntSet     # ids of all unknown identifiers to prevent
-                               # naming it multiple times
+    unknownIdents*: PackedSet[int]     # ids of all unknown identifiers to prevent
+                                       # naming it multiple times
     generics*: seq[TInstantiationPair] # pending list of instantiated generics to compile
     topStmts*: int # counts the number of encountered top level statements
     lastGenericIdx*: int      # used for the generics stack
@@ -298,11 +298,11 @@ proc newContext*(graph: ModuleGraph; module: PSym): PContext =
   result.friendModules = @[module]
   result.converters = @[]
   result.patterns = @[]
-  result.includedFiles = initIntSet()
+  result.includedFiles = initPackedSet[int]()
   initStrTable(result.pureEnumFields)
   initStrTable(result.userPragmas)
   result.generics = @[]
-  result.unknownIdents = initIntSet()
+  result.unknownIdents = initPackedSet[int]()
   result.cache = graph.cache
   result.graph = graph
   initStrTable(result.signatures)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2458,7 +2458,7 @@ proc semTupleFieldsConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
   result = newNodeI(nkTupleConstr, n.info)
   var typ = newTypeS(tyTuple, c)
   typ.n = newNodeI(nkRecList, n.info) # nkIdentDefs
-  var ids = initIntSet()
+  var ids = initPackedSet[int]()
   for i in 0..<n.len:
     if n[i].kind != nkExprColonExpr:
       illFormedAst(n[i], c.config)

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -28,7 +28,7 @@ proc getIdentNode(c: PContext; n: PNode): PNode =
 
 type
   GenericCtx = object
-    toMixin, toBind: IntSet
+    toMixin, toBind: PackedSet[int]
     cursorInBody: bool # only for nimsuggest
     bracketExpr: PNode
 
@@ -498,15 +498,15 @@ proc semGenericStmt(c: PContext, n: PNode,
 
 proc semGenericStmt(c: PContext, n: PNode): PNode =
   var ctx: GenericCtx
-  ctx.toMixin = initIntSet()
-  ctx.toBind = initIntSet()
+  ctx.toMixin = initPackedSet[int]()
+  ctx.toBind = initPackedSet[int]()
   result = semGenericStmt(c, n, {}, ctx)
   semIdeForTemplateOrGeneric(c, result, ctx.cursorInBody)
 
 proc semConceptBody(c: PContext, n: PNode): PNode =
   var ctx: GenericCtx
-  ctx.toMixin = initIntSet()
-  ctx.toBind = initIntSet()
+  ctx.toMixin = initPackedSet[int]()
+  ctx.toBind = initPackedSet[int]()
   result = semGenericStmt(c, n, {withinConcept}, ctx)
   semIdeForTemplateOrGeneric(c, result, ctx.cursorInBody)
 

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -93,9 +93,9 @@ proc caseBranchMatchesExpr(branch, matched: PNode): bool =
   return false
 
 proc branchVals(c: PContext, caseNode: PNode, caseIdx: int,
-                isStmtBranch: bool): IntSet =
+                isStmtBranch: bool): PackedSet[int] =
   if caseNode[caseIdx].kind == nkOfBranch:
-    result = initIntSet()
+    result = initPackedSet[int]()
     for val in processBranchVals(caseNode[caseIdx]):
       result.incl(val)
   else:

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -8,7 +8,7 @@
 #
 
 import
-  intsets, ast, astalgo, msgs, renderer, magicsys, types, idents, trees,
+  std/packedsets, ast, astalgo, msgs, renderer, magicsys, types, idents, trees,
   wordrecg, strutils, options, guards, lineinfos, semfold, semdata,
   modulegraphs, varpartitions, typeallowed, nilcheck
 
@@ -230,7 +230,7 @@ else:
     if not a.inEnforcedNoSideEffects: a.hasSideEffect = true
     markGcUnsafe(a, reason)
 
-proc listGcUnsafety(s: PSym; onlyWarning: bool; cycleCheck: var IntSet; conf: ConfigRef) =
+proc listGcUnsafety(s: PSym; onlyWarning: bool; cycleCheck: var PackedSet[int]; conf: ConfigRef) =
   let u = s.gcUnsafetyReason
   if u != nil and not cycleCheck.containsOrIncl(u.id):
     let msgKind = if onlyWarning: warnGcUnsafe2 else: errGenerated
@@ -255,7 +255,7 @@ proc listGcUnsafety(s: PSym; onlyWarning: bool; cycleCheck: var IntSet; conf: Co
         "'$#' is not GC-safe as it performs an indirect call here" % s.name.s)
 
 proc listGcUnsafety(s: PSym; onlyWarning: bool; conf: ConfigRef) =
-  var cycleCheck = initIntSet()
+  var cycleCheck = initPackedSet[int]()
   listGcUnsafety(s, onlyWarning, cycleCheck, conf)
 
 proc useVarNoInitCheck(a: PEffects; n: PNode; s: PSym) =
@@ -1149,7 +1149,7 @@ proc checkRaisesSpec(g: ModuleGraph; spec, real: PNode, msg: string, hints: bool
                      hintsArg: PNode = nil) =
   # check that any real exception is listed in 'spec'; mark those as used;
   # report any unused exception
-  var used = initIntSet()
+  var used = initPackedSet[int]()
   for r in items(real):
     block search:
       for s in 0..<spec.len:
@@ -1344,7 +1344,7 @@ proc trackProc*(c: PContext; s: PSym, body: PNode) =
   when defined(useDfa):
     if s.name.s == "testp":
       dataflowAnalysis(s, body)
-                                                                                                                   
+
       when false: trackWrites(s, body)
   if strictNotNil in c.features and s.kind == skProc:
     checkNil(s, body, g.config, c.idgen)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -182,7 +182,7 @@ proc semIf(c: PContext, n: PNode; flags: TExprFlags): PNode =
     result.typ = typ
 
 proc semTry(c: PContext, n: PNode; flags: TExprFlags): PNode =
-  var check = initIntSet()
+  var check = initPackedSet[int]()
   template semExceptBranchType(typeNode: PNode): bool =
     # returns true if exception type is imported type
     let typ = semTypeNode(c, typeNode, nil).toObject()

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -85,7 +85,7 @@ proc symChoice(c: PContext, n: PNode, s: PSym, r: TSymChoiceRule;
         onUse(info, a)
       a = nextOverloadIter(o, c, n)
 
-proc semBindStmt(c: PContext, n: PNode, toBind: var IntSet): PNode =
+proc semBindStmt(c: PContext, n: PNode, toBind: var PackedSet[int]): PNode =
   for i in 0..<n.len:
     var a = n[i]
     # If 'a' is an overloaded symbol, we used to use the first symbol
@@ -105,7 +105,7 @@ proc semBindStmt(c: PContext, n: PNode, toBind: var IntSet): PNode =
       illFormedAst(a, c.config)
   result = newNodeI(nkEmpty, n.info)
 
-proc semMixinStmt(c: PContext, n: PNode, toMixin: var IntSet): PNode =
+proc semMixinStmt(c: PContext, n: PNode, toMixin: var PackedSet[int]): PNode =
   for i in 0..<n.len:
     toMixin.incl(considerQuotedIdent(c, n[i]).id)
   result = newNodeI(nkEmpty, n.info)
@@ -120,7 +120,7 @@ proc replaceIdentBySym(c: PContext; n: var PNode, s: PNode) =
 type
   TemplCtx = object
     c: PContext
-    toBind, toMixin, toInject: IntSet
+    toBind, toMixin, toInject: PackedSet[int]
     owner: PSym
     cursorInBody: bool # only for nimsuggest
     scopeN: int
@@ -642,9 +642,9 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   if n[patternPos].kind != nkEmpty:
     n[patternPos] = semPattern(c, n[patternPos])
   var ctx: TemplCtx
-  ctx.toBind = initIntSet()
-  ctx.toMixin = initIntSet()
-  ctx.toInject = initIntSet()
+  ctx.toBind = initPackedSet[int]()
+  ctx.toMixin = initPackedSet[int]()
+  ctx.toInject = initPackedSet[int]()
   ctx.c = c
   ctx.owner = s
   if sfDirty in s.flags:
@@ -791,9 +791,9 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
 proc semPattern(c: PContext, n: PNode): PNode =
   openScope(c)
   var ctx: TemplCtx
-  ctx.toBind = initIntSet()
-  ctx.toMixin = initIntSet()
-  ctx.toInject = initIntSet()
+  ctx.toBind = initPackedSet[int]()
+  ctx.toMixin = initPackedSet[int]()
+  ctx.toInject = initPackedSet[int]()
   ctx.c = c
   ctx.owner = getCurrOwner(c)
   result = flattenStmts(semPatternBody(ctx, n))

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -11,7 +11,7 @@
 ## the call to overloaded procs, generic procs and operators.
 
 import
-  intsets, ast, astalgo, semdata, types, msgs, renderer, lookups, semtypinst,
+  std/packedsets, ast, astalgo, semdata, types, msgs, renderer, lookups, semtypinst,
   magicsys, idents, lexer, options, parampatterns, strutils, trees,
   linter, lineinfos, lowerings, modulegraphs
 
@@ -2311,10 +2311,10 @@ proc incrIndexType(t: PType) =
 template isVarargsUntyped(x): untyped =
   x.kind == tyVarargs and x[0].kind == tyUntyped
 
-proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var IntSet) =
+proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var PackedSet[int]) =
 
   template noMatch() =
-    c.mergeShadowScope #merge so that we don't have to resem for later overloads
+    c.mergeShadowScope # merge so that we don't have to resem for later overloads
     m.state = csNoMatch
     m.firstMismatch.arg = a
     m.firstMismatch.formal = formal
@@ -2518,7 +2518,7 @@ proc semFinishOperands*(c: PContext, n: PNode) =
 
 proc partialMatch*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
   # for 'suggest' support:
-  var marker = initIntSet()
+  var marker = initPackedSet[int]()
   matchesAux(c, n, nOrig, m, marker)
 
 proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
@@ -2531,7 +2531,7 @@ proc matches*(c: PContext, n, nOrig: PNode, m: var TCandidate) =
       inc m.genericMatches
       inc m.exactMatches
     return
-  var marker = initIntSet()
+  var marker = initPackedSet[int]()
   matchesAux(c, n, nOrig, m, marker)
   if m.state == csNoMatch: return
   # check that every formal parameter got a value:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -29,7 +29,7 @@
 
 import
   strutils, ast, types, msgs, renderer, vmdef,
-  intsets, magicsys, options, lowerings, lineinfos, transf
+  std/packedsets, magicsys, options, lowerings, lineinfos, transf
 
 from modulegraphs import getBody
 
@@ -51,10 +51,10 @@ type
 proc debugInfo(c: PCtx; info: TLineInfo): string =
   result = toFileLineCol(c.config, info)
 
-proc codeListing(c: PCtx, result: var string, start=0; last = -1) =
+proc codeListing(c: PCtx, result: var string, start = 0; last = -1) =
   ## for debugging purposes
   # first iteration: compute all necessary labels:
-  var jumpTargets = initIntSet()
+  var jumpTargets = initPackedSet[int]()
   let last = if last < 0: c.code.len-1 else: min(last, c.code.len-1)
   for i in start..last:
     let x = c.code[i]

--- a/compiler/vmmarshal.nim
+++ b/compiler/vmmarshal.nim
@@ -9,7 +9,7 @@
 
 ## Implements marshaling for the VM.
 
-import streams, json, intsets, tables, ast, astalgo, idents, types, msgs,
+import streams, json, std/packedsets, tables, ast, astalgo, idents, types, msgs,
   options, lineinfos
 
 proc ptrToInt(x: PNode): int {.inline.} =
@@ -34,9 +34,9 @@ proc getField(n: PNode; position: int): PSym =
     if n.sym.position == position: result = n.sym
   else: discard
 
-proc storeAny(s: var string; t: PType; a: PNode; stored: var IntSet; conf: ConfigRef)
+proc storeAny(s: var string; t: PType; a: PNode; stored: var PackedSet[int]; conf: ConfigRef)
 
-proc storeObj(s: var string; typ: PType; x: PNode; stored: var IntSet; conf: ConfigRef) =
+proc storeObj(s: var string; typ: PType; x: PNode; stored: var PackedSet[int]; conf: ConfigRef) =
   assert x.kind == nkObjConstr
   let start = 1
   for i in start..<x.len:
@@ -54,7 +54,7 @@ proc storeObj(s: var string; typ: PType; x: PNode; stored: var IntSet; conf: Con
       s.add(": ")
       storeAny(s, field.typ, it, stored, conf)
 
-proc storeAny(s: var string; t: PType; a: PNode; stored: var IntSet;
+proc storeAny(s: var string; t: PType; a: PNode; stored: var PackedSet[int];
               conf: ConfigRef) =
   case t.kind
   of tyNone: assert false
@@ -130,7 +130,7 @@ proc storeAny(s: var string; t: PType; a: PNode; stored: var IntSet;
     internalError conf, a.info, "cannot marshal at compile-time " & t.typeToString
 
 proc storeAny*(s: var string; t: PType; a: PNode; conf: ConfigRef) =
-  var stored = initIntSet()
+  var stored = initPackedSet[int]()
   storeAny(s, t, a, stored, conf)
 
 proc loadAny(p: var JsonParser, t: PType,

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -18,7 +18,7 @@
 ]#
 
 import std / [
-  parseopt, strutils, os, tables, times, intsets, hashes
+  parseopt, strutils, os, tables, times, packedsets, hashes
 ]
 
 import ".." / compiler / [
@@ -987,7 +987,7 @@ proc traverseIf(c: DrnimContext; n: PNode) =
   for f in newFacts: c.facts.add((f, condVersion))
   # build the 'Phi' information:
   let varsWithoutFinals = c.varVersions.len
-  var mutatedVars = initIntSet()
+  var mutatedVars = initPackedSet[int]()
   for i in oldVars ..< varsWithoutFinals:
     let vv = c.varVersions[i]
     if not mutatedVars.containsOrIncl(vv):

--- a/lib/system_overview.rst
+++ b/lib/system_overview.rst
@@ -62,7 +62,7 @@ Proc                                               Usage
 `pop<#pop,seq[T]>`_                                Remove and return last item of a sequence
 `x & y<#&,seq[T],seq[T]>`_                         Concatenate two sequences
 `x[a .. b]<#[],openArray[T],HSlice[U,V]>`_         Slice of a sequence (both ends included)
-`x[a .. ^b]<#[],openArray[T],HSlice[U,V]>`_        Slice of a sequence but `b` is a 
+`x[a .. ^b]<#[],openArray[T],HSlice[U,V]>`_        Slice of a sequence but `b` is a
                                                    reversed index (both ends included)
 `x[a ..\< b]<#[],openArray[T],HSlice[U,V]>`_       Slice of a sequence (excluded upper bound)
 ==============================================     ==========================================
@@ -96,7 +96,7 @@ Proc                                Usage
 
 **See also:**
 * `sets module <sets.html>`_ for hash sets
-* `intsets module <intsets.html>`_ for efficient int sets
+* `packedsets module <packedsets.html>`_ for efficient `Ordinal` sets
 
 
 

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -9,10 +9,12 @@
 
 ## This program verifies Nim against the testcases.
 
-import
+import backend, specs, htmlgen, azure
+import std/[
   strutils, pegs, os, osproc, streams, json,
-  backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, times, md5, sequtils, azure, intsets
+  parseopt, browsers, terminal,
+  algorithm, times, md5, sequtils, packedsets
+]
 from std/sugar import dup
 import compiler/nodejs
 import lib/stdtest/testutils
@@ -323,7 +325,7 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
 
 proc checkForInlineErrors(r: var TResults, expected, given: TSpec, test: TTest, target: TTarget) =
   let pegLine = peg"{[^(]*} '(' {\d+} ', ' {\d+} ') ' {[^:]*} ':' \s* {.*}"
-  var covered = initIntSet()
+  var covered = initPackedSet[int]()
   for line in splitLines(given.nimout):
 
     if line =~ pegLine:

--- a/tests/gc/weakrefs.nim
+++ b/tests/gc/weakrefs.nim
@@ -2,7 +2,7 @@ discard """
   output: "true"
 """
 
-import intsets
+import std/packedsets
 
 type
   TMyObject = object
@@ -14,7 +14,7 @@ type
 
 var
   gid: int # for id generation
-  valid = initIntSet()
+  valid = initPackedSet[int]()
 
 proc finalizer(x: StrongObject) =
   valid.excl(x.id)

--- a/tools/heapdumprepl.nim
+++ b/tools/heapdumprepl.nim
@@ -1,6 +1,6 @@
 
 include prelude
-import intsets
+import std/packedsets
 
 type
   NodeKind = enum
@@ -17,7 +17,6 @@ type
     roots: Table[int, NodeKind]
 
 proc add(father: Node; son: int) =
-  if father.kids.isNil: father.kids = @[]
   father.kids.add(son)
 
 proc renderNode(g: Graph; id: int) =
@@ -36,7 +35,7 @@ proc parseHex(s: string): int =
   discard parseutils.parseHex(s, result, 0)
 
 proc reachable(g: Graph; stack: var seq[int]; goal: int): bool =
-  var t = initIntSet()
+  var t = initPackedSet[int]()
   while stack.len > 0:
     let it = stack.pop
     if not t.containsOrIncl(it):
@@ -59,7 +58,7 @@ reachable,r  l|g|node  dest   -- outputs TRUE or FALSE depending on whether
 """
 
 proc repl(g: Graph) =
-  var aliases = initTable[string,int]()
+  var aliases = initTable[string, int]()
   while true:
     let line = stdin.readLine()
     let data = line.split()


### PR DESCRIPTION
Followup to #16715. Since the `intsets` module now has a deprecated pragma, there are a lot of deprecation warnings. This PR replaces most occurences of intsets with packedsets, that is

* `import intsets` -> `import std/packedsets`
* `IntSet` -> `PackedSet[int]`
* `initIntSet()` -> `initPackedSet[int]()`

The only remaining (relevant) occurences are

* `tests/system/tuse_version.nim`
* `tests/js/tstdlib_imports.nim`
* `tests/test_nimscript.nim`

Apparently these tests are used to test if importing the stdlib modules compiles. In that case, packedsets should be added to (or replace intsets?) those tests, however so should probably a lot of other modules. I'm leaving this for another PR, unless you want me to add it here.