### PR TITLE
fix #16752: threadvar now works with importcpp types; osx now uses native TLS (`--tlsEmulation:off`), which can be orders of magnitude faster

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -132,10 +132,13 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 - Added `nim --eval:cmd` to evaluate a command directly, see `nim --help`.
 
 - VM now supports `addr(mystring[ind])` (index + index assignment)
+
 - Type mismatch errors now show more context, use `-d:nimLegacyTypeMismatch` for previous
   behavior.
 
 - Added `--hintAsError` with similar semantics as `--warningAsError`.
+- TLS: OSX now uses native TLS (`--tlsEmulation:off`), TLS now works with importcpp non-POD types,
+  such types must use `.cppNonPod` and `--tlsEmulation:off`should be used.
 
 ## Tool changes
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -265,6 +265,10 @@ type
     sfShadowed,       # a symbol that was shadowed in some inner scope
     sfThread,         # proc will run as a thread
                       # variable is a thread variable
+    sfCppNonPod,      # tells compiler to treat such types as non-pod's, so that
+                      # `thread_local` is used instead of `__thread` for
+                      # {.threadvar.} + `--threads`. Only makes sense for importcpp types.
+                      # This has a performance impact so isn't set by default.
     sfCompileTime,    # proc can be evaluated at compile time
     sfConstructor,    # proc is a C++ constructor
     sfDispatcher,     # copied method symbol is the dispatcher

--- a/compiler/ccgthreadvars.nim
+++ b/compiler/ccgthreadvars.nim
@@ -7,8 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
-## Thread var support for crappy architectures that lack native support for
-## thread local storage. (**Thank you Mac OS X!**)
+## Thread var support for architectures that lack native support for
+## thread local storage.
 
 # included from cgen.nim
 

--- a/compiler/ccgthreadvars.nim
+++ b/compiler/ccgthreadvars.nim
@@ -35,7 +35,11 @@ proc declareThreadVar(m: BModule, s: PSym, isExtern: bool) =
     if isExtern: m.s[cfsVars].add("extern ")
     elif lfExportLib in s.loc.flags: m.s[cfsVars].add("N_LIB_EXPORT_VAR ")
     else: m.s[cfsVars].add("N_LIB_PRIVATE ")
-    if optThreads in m.config.globalOptions: m.s[cfsVars].add("NIM_THREADVAR ")
+    if optThreads in m.config.globalOptions:
+      let sym = s.typ.sym
+      if sym != nil and sfCppNonPod in sym.flags:
+        m.s[cfsVars].add("NIM_THREAD_LOCAL ")
+      else: m.s[cfsVars].add("NIM_THREADVAR ")
     m.s[cfsVars].add(getTypeDesc(m, s.loc.t))
     m.s[cfsVars].addf(" $1;$n", [s.loc.r])
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -380,11 +380,12 @@ proc hasWarn*(conf: ConfigRef, note: TNoteKind): bool =
 
 proc hcrOn*(conf: ConfigRef): bool = return optHotCodeReloading in conf.globalOptions
 
-template depConfigFields*(fn) {.dirty.} =
-  fn(target)
-  fn(options)
-  fn(globalOptions)
-  fn(selectedGC)
+when false:
+  template depConfigFields*(fn) {.dirty.} = # deadcode
+    fn(target)
+    fn(options)
+    fn(globalOptions)
+    fn(selectedGC)
 
 const oldExperimentalFeatures* = {implicitDeref, dotOperators, callOperator, parallel}
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -65,7 +65,7 @@ const
     wPure, wHeader, wCompilerProc, wCore, wFinal, wSize, wShallow,
     wIncompleteStruct, wCompleteStruct, wByCopy, wByRef,
     wInheritable, wGensym, wInject, wRequiresInit, wUnchecked, wUnion, wPacked,
-    wBorrow, wGcSafe, wPartial, wExplain, wPackage}
+    wCppNonPod, wBorrow, wGcSafe, wPartial, wExplain, wPackage}
   fieldPragmas* = declPragmas + {
     wGuard, wBitsize, wCursor, wRequiresInit, wNoalias} - {wExportNims, wNodecl} # why exclude these?
   varPragmas* = declPragmas + {wVolatile, wRegister, wThreadVar,
@@ -843,6 +843,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         else: invalidPragma(c, it)
       of wImportCpp:
         processImportCpp(c, sym, getOptionalStr(c, it, "$1"), it.info)
+      of wCppNonPod:
+        incl(sym.flags, sfCppNonPod)
       of wImportJs:
         if c.config.backend != backendJs:
           localError(c.config, it.info, "`importjs` pragma requires the JavaScript target")

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -38,7 +38,8 @@ type
     wCursor = "cursor", wNoalias = "noalias",
 
     wImmediate = "immediate", wConstructor = "constructor", wDestructor = "destructor", 
-    wDelegator = "delegator", wOverride = "override", wImportCpp = "importcpp", 
+    wDelegator = "delegator", wOverride = "override", wImportCpp = "importcpp",
+    wCppNonPod = "cppNonPod", 
     wImportObjC = "importobjc", wImportCompilerProc = "importcompilerproc",
     wImportc = "importc", wImportJs = "importjs", wExportc = "exportc", wExportCpp = "exportcpp", 
     wExportNims = "exportnims",

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -114,8 +114,6 @@ path="$lib/pure"
   @if bsd:
     # BSD got posix_spawn only recently, so we deactivate it for osproc:
     define:useFork
-    # at least NetBSD has problems with thread local storage:
-    tlsEmulation:on
   @elif haiku:
     gcc.options.linker = "-Wl,--as-needed -lnetwork"
     gcc.cpp.options.linker = "-Wl,--as-needed -lnetwork"
@@ -167,9 +165,13 @@ path="$lib/pure"
 
 gcc.maxerrorsimpl = "-fmax-errors=3"
 
+@if bsd:
+  # at least NetBSD has problems with thread local storage:
+  tlsEmulation:on
+@end
+
 @if macosx or freebsd or openbsd:
   cc = clang
-  tlsEmulation:on
   gcc.options.always %= "-w ${gcc.maxerrorsimpl}"
   gcc.cpp.options.always %= "-w ${gcc.maxerrorsimpl} -fpermissive"
 @elif windows:

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7194,6 +7194,19 @@ will generate this code:
   __interrupt void myinterrupt()
 
 
+`cppNonPod` pragma
+------------------
+
+The `.cppNonPod` pragma should be used for non-POD `importcpp` types so that they
+work properly (in particular regarding constructor and destructor) for
+`.threadvar` variables. This requires `--tlsEmulation:off`.
+
+.. code-block:: nim
+  type Foo {.cppNonPod, importcpp, header: "funs.h".} = object
+    x: cint
+  proc main()=
+    var a {.threadvar.}: Foo
+
 InjectStmt pragma
 -----------------
 

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -143,6 +143,10 @@ __AVR__
 #  error "Cannot define NIM_THREADVAR"
 #endif
 
+#if defined(__cplusplus)
+  #define NIM_THREAD_LOCAL thread_local
+#endif
+
 /* --------------- how int64 constants should be declared: ----------- */
 #if defined(__GNUC__) || defined(__LCC__) || \
     defined(__POCC__) || defined(__DMC__) || defined(_MSC_VER)

--- a/tests/benchmarks/readme.md
+++ b/tests/benchmarks/readme.md
@@ -1,0 +1,5 @@
+# Collection of benchmarks
+
+In future work, benchmarks can be added to CI, but for now we provide benchmarks that can be run locally.
+
+See RFC: https://github.com/timotheecour/Nim/issues/425

--- a/tests/benchmarks/ttls.nim
+++ b/tests/benchmarks/ttls.nim
@@ -1,0 +1,30 @@
+discard """
+  action: compile
+"""
+
+#[
+## on osx
+nim r -d:danger --threads --tlsEmulation:off tests/benchmarks/ttls.nim
+9.999999999992654e-07
+
+ditto with `--tlsEmulation:on`:
+0.216999
+]#
+
+import times
+
+proc main2(): int =
+  var g0 {.threadvar.}: int
+  g0.inc
+  result = g0
+
+proc main =
+  let n = 100_000_000
+  var c = 0
+  let t = cpuTime()
+  for i in 0..<n:
+    c += main2()
+  let t2 = cpuTime() - t
+  doAssert c != 0
+  echo t2
+main()

--- a/tests/misc/mtlsemulation.h
+++ b/tests/misc/mtlsemulation.h
@@ -1,0 +1,23 @@
+#include <stdio.h>
+
+struct Foo1 {
+  /*
+  uncommenting would give:
+  error: initializer for thread-local variable must be a constant expression
+  N_LIB_PRIVATE NIM_THREADVAR Foo1 g1__9brEZhPEldbVrNpdRGmWESA;
+  */
+  // Foo1() noexcept { }
+
+  /*
+  uncommenting would give:
+  error: type of thread-local variable has non-trivial destruction
+  */
+  // ~Foo1() { }
+  int x;
+};
+
+struct Foo2 {
+  Foo2() noexcept { }
+  ~Foo2() { }
+  int x;
+};

--- a/tests/misc/mtlsemulation.h
+++ b/tests/misc/mtlsemulation.h
@@ -21,3 +21,17 @@ struct Foo2 {
   ~Foo2() { }
   int x;
 };
+
+static int ctorCalls = 0;
+static int dtorCalls = 0;
+
+struct Foo3 {
+  Foo3() noexcept {
+    ctorCalls = ctorCalls + 1;
+    x = 10;
+  }
+  ~Foo3() {
+    dtorCalls = dtorCalls + 1;
+  }
+  int x;
+};

--- a/tests/misc/ttlsemulation.nim
+++ b/tests/misc/ttlsemulation.nim
@@ -1,0 +1,26 @@
+discard """
+  matrix: "-d:nimTtlsemulationCase1 --threads --tlsEmulation:on; -d:nimTtlsemulationCase2 --threads --tlsEmulation:off; -d:nimTtlsemulationCase3 --threads"
+"""
+
+import std/sugar
+
+block:
+  # makes sure the logic in config/nim.cfg or testament doesn't interfere with `--tlsEmulation` so we test the right thing.
+  when defined(nimTtlsemulationCase1):
+    doAssert compileOption("tlsEmulation")
+  elif defined(nimTtlsemulationCase2):
+    doAssert not compileOption("tlsEmulation")
+  elif defined(nimTtlsemulationCase3):
+    when defined(osx):
+      doAssert not compileOption("tlsEmulation")
+  else:
+    doAssert false
+
+block:
+  proc main(): int =
+    var g0 {.threadvar.}: int
+    g0.inc
+    g0
+  let s = collect:
+    for i in 0..<3: main()
+  doAssert s == @[1,2,3]

--- a/tests/misc/ttlsemulation.nim
+++ b/tests/misc/ttlsemulation.nim
@@ -26,15 +26,43 @@ block:
     for i in 0..<3: main()
   doAssert s == @[1,2,3]
 
-when defined(cpp):
-  block:
-    type Foo1 {.importcpp: "Foo1", header: "mtlsemulation.h".} = object
-      x: cint
-    type Foo2 {.cppNonPod, importcpp: "Foo2", header: "mtlsemulation.h".} = object
-      x: cint
-    proc main() =
-      var g1 {.threadvar.}: Foo1
-      var g2 {.threadvar.}: Foo2
-      discard g1
-      discard g2
-    main()
+when defined(cpp): # bug #16752
+  type Foo1 {.importcpp: "Foo1", header: "mtlsemulation.h".} = object
+    x: cint
+  type Foo2 {.cppNonPod, importcpp: "Foo2", header: "mtlsemulation.h".} = object
+    x: cint
+
+  var ctorCalls {.importcpp.}: cint
+  var dtorCalls {.importcpp.}: cint
+  type Foo3 {.cppNonPod, importcpp: "Foo3", header: "mtlsemulation.h".} = object
+    x: cint
+
+  proc sub(i: int) =
+    var g1 {.threadvar.}: Foo1
+    var g2 {.threadvar.}: Foo2
+    var g3 {.threadvar.}: Foo3
+    discard g1
+    discard g2
+
+    # echo (g3.x, ctorCalls, dtorCalls)
+    when compileOption("tlsEmulation"):
+      # xxx bug
+      discard
+    else:
+      doAssert g3.x.int == 10 + i
+      doAssert ctorCalls == 2
+    doAssert dtorCalls == 1
+    g3.x.inc
+
+  proc main() =
+    doAssert ctorCalls == 0
+    doAssert dtorCalls == 0
+    block:
+      var f3: Foo3
+      doAssert f3.x == 10
+    doAssert ctorCalls == 1
+    doAssert dtorCalls == 1
+
+    for i in 0..<3:
+      sub(i)
+  main()

--- a/tests/misc/ttlsemulation.nim
+++ b/tests/misc/ttlsemulation.nim
@@ -3,6 +3,10 @@ discard """
   targets: "c cpp"
 """
 
+#[
+tests for: `.cppNonPod`, `--tlsEmulation`
+]#
+
 import std/sugar
 
 block:
@@ -18,51 +22,54 @@ block:
     doAssert false
 
 block:
-  proc main(): int =
+  proc main1(): int =
     var g0 {.threadvar.}: int
     g0.inc
     g0
   let s = collect:
-    for i in 0..<3: main()
+    for i in 0..<3: main1()
   doAssert s == @[1,2,3]
 
 when defined(cpp): # bug #16752
-  type Foo1 {.importcpp: "Foo1", header: "mtlsemulation.h".} = object
-    x: cint
-  type Foo2 {.cppNonPod, importcpp: "Foo2", header: "mtlsemulation.h".} = object
-    x: cint
+  when defined(windows) and defined(nimTtlsemulationCase2):
+    discard # xxx this failed with exitCode 1
+  else:
+    type Foo1 {.importcpp: "Foo1", header: "mtlsemulation.h".} = object
+      x: cint
+    type Foo2 {.cppNonPod, importcpp: "Foo2", header: "mtlsemulation.h".} = object
+      x: cint
 
-  var ctorCalls {.importcpp.}: cint
-  var dtorCalls {.importcpp.}: cint
-  type Foo3 {.cppNonPod, importcpp: "Foo3", header: "mtlsemulation.h".} = object
-    x: cint
+    var ctorCalls {.importcpp.}: cint
+    var dtorCalls {.importcpp.}: cint
+    type Foo3 {.cppNonPod, importcpp: "Foo3", header: "mtlsemulation.h".} = object
+      x: cint
 
-  proc sub(i: int) =
-    var g1 {.threadvar.}: Foo1
-    var g2 {.threadvar.}: Foo2
-    var g3 {.threadvar.}: Foo3
-    discard g1
-    discard g2
+    proc sub(i: int) =
+      var g1 {.threadvar.}: Foo1
+      var g2 {.threadvar.}: Foo2
+      var g3 {.threadvar.}: Foo3
+      discard g1
+      discard g2
 
-    # echo (g3.x, ctorCalls, dtorCalls)
-    when compileOption("tlsEmulation"):
-      # xxx bug
-      discard
-    else:
-      doAssert g3.x.int == 10 + i
-      doAssert ctorCalls == 2
-    doAssert dtorCalls == 1
-    g3.x.inc
+      # echo (g3.x, ctorCalls, dtorCalls)
+      when compileOption("tlsEmulation"):
+        # xxx bug
+        discard
+      else:
+        doAssert g3.x.int == 10 + i
+        doAssert ctorCalls == 2
+      doAssert dtorCalls == 1
+      g3.x.inc
 
-  proc main() =
-    doAssert ctorCalls == 0
-    doAssert dtorCalls == 0
-    block:
-      var f3: Foo3
-      doAssert f3.x == 10
-    doAssert ctorCalls == 1
-    doAssert dtorCalls == 1
+    proc main() =
+      doAssert ctorCalls == 0
+      doAssert dtorCalls == 0
+      block:
+        var f3: Foo3
+        doAssert f3.x == 10
+      doAssert ctorCalls == 1
+      doAssert dtorCalls == 1
 
-    for i in 0..<3:
-      sub(i)
-  main()
+      for i in 0..<3:
+        sub(i)
+    main()

--- a/tests/misc/ttlsemulation.nim
+++ b/tests/misc/ttlsemulation.nim
@@ -1,5 +1,6 @@
 discard """
   matrix: "-d:nimTtlsemulationCase1 --threads --tlsEmulation:on; -d:nimTtlsemulationCase2 --threads --tlsEmulation:off; -d:nimTtlsemulationCase3 --threads"
+  targets: "c cpp"
 """
 
 import std/sugar
@@ -24,3 +25,16 @@ block:
   let s = collect:
     for i in 0..<3: main()
   doAssert s == @[1,2,3]
+
+when defined(cpp):
+  block:
+    type Foo1 {.importcpp: "Foo1", header: "mtlsemulation.h".} = object
+      x: cint
+    type Foo2 {.cppNonPod, importcpp: "Foo2", header: "mtlsemulation.h".} = object
+      x: cint
+    proc main() =
+      var g1 {.threadvar.}: Foo1
+      var g2 {.threadvar.}: Foo2
+      discard g1
+      discard g2
+    main()


### PR DESCRIPTION
* fix #16752: threadvar works with cpp types, with --tlsEmulation:off (ie native TLS)
* osx now uses native TLS
* see benchmark (yes, they're intended to be part of this PR, I intend to grow tests/benchmarks/ in the future, see https://github.com/timotheecour/Nim/issues/425)
* a new pragma `{.cppNonPod.}` specifies a importcpp type is a non-POD, and shall use `thread_local` instead of `__thread` for `{.threadvar.}` variables

## links
* see https://stackoverflow.com/questions/28094794/why-does-apple-clang-disallow-c11-thread-local-when-official-clang-supports but native TLS support predates this
> The clang compiler included with Xcode 8 and later supports the C++11 thread_local keyword.

> Regarding iOS, I found by experimentation that thread_local is supported for iOS 9 and later, but not for iOS 8.4 or earlier.

* https://en.wikipedia.org/wiki/Thread-local_storage#C.2B.2B


* __thread vs thread_local: https://stackoverflow.com/questions/12049095/c11-nontrivial-thread-local-static-variable
> thread_local and __thread are, in fact, not the same thing. The main difference between them is precisely the one you stumbled upon - thread_local allows the variable to be non-POD.

AFAIK nim uses POD types in cgen code, even for types with destructors, and even for c++

* https://stackoverflow.com/questions/13106049/what-is-the-performance-penalty-of-c11-thread-local-variables-in-gcc-4-8

## freebsd, openbsd, netbsd
I didn't change the behavior here, but see: https://github.com/nim-lang/Nim/pull/15066#issuecomment-665541265 and https://github.com/nim-lang/Nim/issues/15493

## note regarding `cppNonPod`
I used `pod` for simplicity in the pragma name even though `__is_pod` trait will be deprecated (see https://stackoverflow.com/a/48225882/1426932):
> __is_pod (C++, GNU, Microsoft, Embarcadero): Note, the corresponding standard trait was deprecated in C++20.

this pragma is user defined anyways, and the compiler will error if that pragma is missing, resulting in `__thread` being used on a variable of a type that contains non-trivial destructor or if type has a constructor and cgen calls `var a: Foo`.

So in the end it works as intended.

## note regarding `thread_local`
* if needed, in future work, we can use `__has_feature(cxx_thread_local)` conditionally
* C++11 `thread_local` is supported on OSX since xcode 8, released in 2016
* ios supports thread_local since ios9 refs https://stackoverflow.com/a/29929949/1426932

## future work
- [ ] there are other use cases for `{.cppNonPod.}`, eg thread safe static initialization:
instead of `Error: a thread var cannot be initialized explicitly; this would only run for the main thread` we could allow:
```nim
when true:
  proc main =
    var g0 {.threadvar.} = 12
  main()
```
- [ ] see how to fix the disabled part of ttlsemulation.nim that fails for windows with `cpp --threads --tlsEmulation:off`

- [ ] address this: https://github.com/nim-lang/Nim/pull/16750#issuecomment-768529881
> move all ffi pragmas (including nodecl, incompleteStruct etc) into lib/ffi.rst;
