### PR TITLE
fix noDecl => nodecl

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6692,16 +6692,16 @@ in C/C++).
 **Note**: This pragma will not exist for the LLVM backend.
 
 
-NoDecl pragma
+`nodecl` pragma
 -------------
-The ``noDecl`` pragma can be applied to almost any symbol (variable, proc,
+The `nodecl` pragma can be applied to almost any symbol (variable, proc,
 type, etc.) and is sometimes useful for interoperability with C:
 It tells Nim that it should not generate a declaration for the symbol in
 the C code. For example:
 
 .. code-block:: Nim
   var
-    EACCES {.importc, noDecl.}: cint # pretend EACCES was a variable, as
+    EACCES {.importc, nodecl.}: cint # pretend EACCES was a variable, as
                                      # Nim does not know its value
 
 However, the ``header`` pragma is often the better alternative.
@@ -6711,7 +6711,7 @@ However, the ``header`` pragma is often the better alternative.
 
 Header pragma
 -------------
-The ``header`` pragma is very similar to the ``noDecl`` pragma: It can be
+The `header` pragma is very similar to the `nodecl` pragma: It can be
 applied to almost any symbol and specifies that it should not be declared
 and instead, the generated code should contain an ``#include``:
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6692,7 +6692,7 @@ in C/C++).
 **Note**: This pragma will not exist for the LLVM backend.
 
 
-`nodecl` pragma
+nodecl pragma
 -------------
 The `nodecl` pragma can be applied to almost any symbol (variable, proc,
 type, etc.) and is sometimes useful for interoperability with C:

--- a/tests/js/tclosures.nim
+++ b/tests/js/tclosures.nim
@@ -22,7 +22,7 @@ asm """
     function print (text) { console.log (text); }
 """
 
-proc consoleprint (str:cstring): void {.importc: "print", noDecl.}
+proc consoleprint (str:cstring): void {.importc: "print", nodecl.}
 proc print* (a: varargs[string, `$`]) = consoleprint "$1: $2" % [consolePrefix, join(a, " ")]
 
 type CallbackProc {.importc.} = proc () : cstring

--- a/tests/stdlib/thttpclient.nim
+++ b/tests/stdlib/thttpclient.nim
@@ -1,6 +1,7 @@
 discard """
   cmd: "nim c --threads:on -d:ssl $file"
   disabled: "openbsd"
+  disabled: "freebsd"
   disabled: "windows"
 """
 


### PR DESCRIPTION
this would otherwise cause --stylecheck:error to fail as was case in https://github.com/nim-lang/Nim/pull/16622

I also disable tests/stdlib/thttpclient.nim for freebsd (refs https://github.com/timotheecour/Nim/issues/528); this test was recently enabled (used to be globally disabled), but it was flaky on freebsd