### PR TITLE
fix testament regression: installed testament works again with testament r path

### DIFF
--- a/testament/lib/stdtest/specialpaths.nim
+++ b/testament/lib/stdtest/specialpaths.nim
@@ -35,7 +35,7 @@ const
 proc splitTestFile*(file: string): tuple[cat: string, path: string] =
   ## At least one directory is required in the path, to use as a category name
   runnableExamples:
-    doAssert splitTestFile("tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim")
+    doAssert splitTestFile("tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim".unixToNativePath)
   for p in file.parentDirs(inclusive = false):
     let parent = p.parentDir
     if parent.lastPathPart == testsFname:

--- a/testament/lib/stdtest/specialpaths.nim
+++ b/testament/lib/stdtest/specialpaths.nim
@@ -24,12 +24,29 @@ const
     # robust way to derive other paths here
     # We don't depend on PATH so this is robust to having multiple nim binaries
   nimRootDir* = sourcePath.parentDir.parentDir.parentDir.parentDir ## root of Nim repo
+  testsFname* = "tests"
   stdlibDir* = nimRootDir / "lib"
   systemPath* = stdlibDir / "system.nim"
-  testsDir* = nimRootDir / "tests"
+  testsDir* = nimRootDir / testsFname
   buildDir* = nimRootDir / "build"
     ## refs #10268: all testament generated files should go here to avoid
     ## polluting .gitignore
+
+proc splitTestFile*(file: string): tuple[cat: string, path: string] =
+  ## At least one directory is required in the path, to use as a category name
+  runnableExamples:
+    doAssert splitTestFile("tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim")
+  for p in file.parentDirs(inclusive = false):
+    let parent = p.parentDir
+    if parent.lastPathPart == testsFname:
+      result.cat = p.lastPathPart
+      let dir = getCurrentDir()
+      if file.isRelativeTo(dir):
+        result.path = file.relativePath(dir)
+      else:
+        result.path = file
+      return result
+  doAssert false, "file must match this pattern: '/pathto/tests/dir/**/tfile.nim', got: '" & file & "'"
 
 static:
   # sanity check

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -16,6 +16,7 @@ import
 from std/sugar import dup
 import compiler/nodejs
 import lib/stdtest/testutils
+from lib/stdtest/specialpaths import splitTestFile
 
 var useColors = true
 var backendLogging = true
@@ -791,16 +792,9 @@ proc main() =
     p.next
     processPattern(r, pattern, p.cmdLineRest.string, simulate)
   of "r", "run":
-    # "/pathto/tests/stdlib/nre/captures.nim" -> "stdlib" + "tests/stdlib/nre/captures.nim"
-    var subPath = p.key.string
-    let nimRoot = currentSourcePath / "../.."
-      # makes sure points to this regardless of cwd or which nim is used to compile this.
-    doAssert(dirExists(nimRoot/testsDir), nimRoot/testsDir & " doesn't exist!") # sanity check
-    if subPath.isAbsolute: subPath = subPath.relativePath(nimRoot)
-    # at least one directory is required in the path, to use as a category name
-    let pathParts = subPath.relativePath(testsDir).split({DirSep, AltSep})
-    let cat = Category(pathParts[0])
-    processSingleTest(r, cat, p.cmdLineRest.string, subPath, gTargets, targetsSet)
+    var subPath = p.key
+    let (cat, path) = splitTestFile(subPath)
+    processSingleTest(r, cat.Category, p.cmdLineRest, path, gTargets, targetsSet)
   of "html":
     generateHtml(resultsFile, optFailing)
   else:

--- a/tests/testament/tspecialpaths.nim
+++ b/tests/testament/tspecialpaths.nim
@@ -1,9 +1,9 @@
 import stdtest/specialpaths
 import std/os
 block: # splitTestFile
-  doAssert splitTestFile("tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim")
-  doAssert splitTestFile("/pathto/tests/fakedir/tfakename.nim") == ("fakedir", "/pathto/tests/fakedir/tfakename.nim")
-  doAssert splitTestFile(getCurrentDir() / "tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim")
-  doAssert splitTestFile(getCurrentDir() / "sub/tests/fakedir/tfakename.nim") == ("fakedir", "sub/tests/fakedir/tfakename.nim")
+  doAssert splitTestFile("tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim".unixToNativePath)
+  doAssert splitTestFile("/pathto/tests/fakedir/tfakename.nim") == ("fakedir", "/pathto/tests/fakedir/tfakename.nim".unixToNativePath)
+  doAssert splitTestFile(getCurrentDir() / "tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim".unixToNativePath)
+  doAssert splitTestFile(getCurrentDir() / "sub/tests/fakedir/tfakename.nim") == ("fakedir", "sub/tests/fakedir/tfakename.nim".unixToNativePath)
   doAssertRaises(AssertionDefect): discard splitTestFile("testsbad/fakedir/tfakename.nim")
   doAssertRaises(AssertionDefect): discard splitTestFile("tests/tfakename.nim")

--- a/tests/testament/tspecialpaths.nim
+++ b/tests/testament/tspecialpaths.nim
@@ -1,0 +1,9 @@
+import stdtest/specialpaths
+import std/os
+block: # splitTestFile
+  doAssert splitTestFile("tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim")
+  doAssert splitTestFile("/pathto/tests/fakedir/tfakename.nim") == ("fakedir", "/pathto/tests/fakedir/tfakename.nim")
+  doAssert splitTestFile(getCurrentDir() / "tests/fakedir/tfakename.nim") == ("fakedir", "tests/fakedir/tfakename.nim")
+  doAssert splitTestFile(getCurrentDir() / "sub/tests/fakedir/tfakename.nim") == ("fakedir", "sub/tests/fakedir/tfakename.nim")
+  doAssertRaises(AssertionDefect): discard splitTestFile("testsbad/fakedir/tfakename.nim")
+  doAssertRaises(AssertionDefect): discard splitTestFile("tests/tfakename.nim")


### PR DESCRIPTION
* fixes https://github.com/nim-lang/Nim/pull/16163#discussion_r560641690
* closes https://github.com/timotheecour/Nim/issues/519 (seems good enough)

to mimic installing testament and reproduce the bug that gets fixed here, do as follows:
nim c -o:/tmp/testament2 testament/testament.nim
move . to somewhere else to make sure the source files can't be read anymore

then:
mkdir -p tests/somedir
echo "doAssert 1 == 1" > tests/somedir/texample.nim

now these work:
/tmp/testament2 r tests/somedir/texample.nim
/tmp/testament2 r $PWD/tests/somedir/texample.nim
/tmp/testament2 r /patho/tests/somedir2/texample2.nim # can use external tests not relative to PWD

this doesn't work, because we can't get the category:
/tmp/testament2 r tests/texample.nim

(pre-existing issue IIRC, this could be relaxed in future work, by making `.` a special category of its own for eg)
