### PR TITLE
Added possibility to cancel the futures using complete() and fail()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -308,6 +308,9 @@
 
 - Added `copyWithin` [for `seq` and `array` for JavaScript targets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin).
 
+- Changed the behaviour of `future.complete` and `future.fail`. Now they are cancelling the
+  the future which they are called on in cancellation points and cancel all recursive running futures.
+  The callbacks connected to all those futures are triggered upon cancellation.
 
 ## Language changes
 

--- a/tests/arc/tasyncleak.nim
+++ b/tests/arc/tasyncleak.nim
@@ -1,5 +1,5 @@
 discard """
-  outputsub: "(allocCount: 4302, deallocCount: 4300)"
+  outputsub: "(allocCount: 4338, deallocCount: 4334)"
   cmd: "nim c --gc:orc -d:nimAllocStats $file"
 """
 

--- a/tests/async/tasync_noasync.nim
+++ b/tests/async/tasync_noasync.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "'yield' only allowed in an iterator"
+  errormsg: "undeclared identifier: 'internalRetFuture'"
   cmd: "nim c $file"
   file: "asyncmacro.nim"
 """

--- a/tests/async/tasync_traceback.nim
+++ b/tests/async/tasync_traceback.nim
@@ -83,7 +83,7 @@ Async traceback:
     asyncmacro\.nim\(\d+?\)\s+?aNimAsyncContinue
       ## Resumes an async procedure
     asyncmacro\.nim\(\d+?\)\s+?aIter
-    asyncfutures\.nim\(\d+?\)\s+?read
+    asyncfutures\.nim\(\d+?\)\s+?internalCheckExcept
   \]#
 Exception message: b failure
 Exception type:
@@ -111,7 +111,7 @@ Async traceback:
     asyncmacro\.nim\(\d+?\)\s+?fooNimAsyncContinue
       ## Resumes an async procedure
     asyncmacro\.nim\(\d+?\)\s+?fooIter
-    asyncfutures\.nim\(\d+?\)\s+?read
+    asyncfutures\.nim\(\d+?\)\s+?internalCheckExcept
   \]#
 Exception message: bar failure
 Exception type:

--- a/tests/async/tcomplete_async.nim
+++ b/tests/async/tcomplete_async.nim
@@ -1,0 +1,37 @@
+discard """
+  output: "OK"
+"""
+
+import asyncdispatch
+import std/asyncfutures
+
+proc recursiveWaiter2() {.async.} =
+  try:
+    await sleepAsync(500)
+    await sleepAsync(500)
+  except FutureCancelledError:
+    discard
+  await sleepAsync(500)
+
+proc recursiveWaiter1() {.async.} =
+  try:
+    await recursiveWaiter2()
+    await sleepAsync(1200)
+  except FutureCancelledError:
+    discard
+  await sleepAsync(1200)
+
+proc main() {.async.} =
+  var fut = recursiveWaiter1()
+  await sleepAsync(500)
+  fut.complete()
+  await fut
+  await sleepAsync(2000)
+
+try:
+  waitFor(main())
+  echo "OK"
+except FutureError as e:
+  echo "NOT OK " & e.msg
+except FutureCancelledError:
+  echo "CANCELLED"

--- a/tests/async/tfail_async.nim
+++ b/tests/async/tfail_async.nim
@@ -1,0 +1,28 @@
+discard """
+  output: "FAIL OK"
+"""
+
+import asyncdispatch
+
+proc recursiveWaiter2() {.async.} =
+  await sleepAsync(500)
+  await sleepAsync(500)
+  echo "NOT OK"
+
+proc recursiveWaiter1() {.async.} =
+  await recursiveWaiter2()
+  await sleepAsync(1200)
+  echo "NOT OK"
+
+proc main() {.async.} =
+  var fut = recursiveWaiter1()
+  await sleepAsync(1000)
+  fut.fail(newException(ValueError, "ACHTUNG"))
+  await fut
+  await sleepAsync(2000)
+
+try:
+  waitFor(main())
+  echo "NOT OK"
+except ValueError:
+  echo "FAIL OK"


### PR DESCRIPTION
I've made a fix to asyncfutures and asyncmacro to be able to complete or fail any pending future at a cancellation points, like I've asked in [https://forum.nim-lang.org/t/7287](https://forum.nim-lang.org/t/7287)