### PR TITLE
typetraits: make genericHead docs reflect reality; use runnableExamples

### DIFF
--- a/tests/metatype/ttypetraits.nim
+++ b/tests/metatype/ttypetraits.nim
@@ -282,7 +282,12 @@ block genericHead:
   doAssert not compiles(genericHead(Foo))
   type Bar = object
   doAssert not compiles(genericHead(Bar))
-  # doAssert seq[int].genericHead is seq
+
+  when false: # xxx not supported yet
+    doAssert seq[int].genericHead is seq
+  when false: # xxx not supported yet, gives: Error: identifier expected
+    type Hoo[T] = object
+    doAssert genericHead(Hoo[int])[float] is Hoo[float]
 
 block: # elementType
   iterator myiter(n: int): auto =


### PR DESCRIPTION
* refs https://github.com/nim-lang/Nim/pull/13303#issuecomment-763704489
* fix a regression introduced in https://github.com/nim-lang/Nim/pull/15230 which added `echo ai.typeKind` when calling `genericParams`

## future work
fix the 2 pre-existing issues in `genericHead`