### PR TITLE
fix manual for .nosideeffect

### DIFF
--- a/tests/effects/tnosideeffect.nim
+++ b/tests/effects/tnosideeffect.nim
@@ -1,0 +1,24 @@
+block: # `.noSideEffect`
+  func foo(bar: proc(): int): int = bar()
+  var count = 0
+  proc fn1(): int = 1
+  proc fn2(): int = (count.inc; count)
+
+  template accept(body) =
+    doAssert compiles(block:
+      body)
+
+  template reject(body) =
+    doAssert not compiles(block:
+      body)
+
+  accept:
+    func fun1() = discard foo(fn1)
+  reject:
+    func fun1() = discard foo(fn2)
+
+  var foo2: type(foo) = foo
+  accept:
+    func main() = discard foo(fn1)
+  reject:
+    func main() = discard foo2(fn1)


### PR DESCRIPTION
* closes https://github.com/nim-lang/Nim/issues/16303
  the manual is now consistent with the implementation; the implementation was already doing the correct thing, as mentioned in https://github.com/nim-lang/Nim/issues/16303#issuecomment-742679969
* add regression test

this enables for eg procs like `sort` to be `func`, yet still allow passing in callbacks that may have side effects; if the callback does have side effects, the resulting proc would then not be usable inside a nosideEffect context.

## future work
- [ ] clarify effects through proc params for other annotations besides `.nosideeffect`