### PR TITLE
Finer analysis for array access

### DIFF
--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -617,8 +617,8 @@ proc aliases*(obj, field: PNode): AliasKind =
 
   result = yes
   for i in 1..objImportantNodes.len:
-    template currFieldPath: untyped = fieldImportantNodes[^i]
-    template currObjPath: untyped = objImportantNodes[^i]
+    let currFieldPath = fieldImportantNodes[^i]
+    let currObjPath = objImportantNodes[^i]
 
     if currFieldPath.kind != currObjPath.kind:
       return no

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -577,8 +577,6 @@ proc skipConvDfa*(n: PNode): PNode =
 type AliasKind* = enum
   yes, no, maybe
 
-from trees import exprStructuralEquivalent
-
 proc aliases*(obj, field: PNode): AliasKind =
   # obj -> field:
   # x -> x: true
@@ -592,8 +590,8 @@ proc aliases*(obj, field: PNode): AliasKind =
   # x[0] -> x[1]: false
   # x -> x[i]: true
   # x[i] -> x: false
-  # x[i] -> x[i]: MAYBE Further analysis could make this return true when i is a runtime-constant
-  # x[i] -> x[j]: MAYBE also returns MAYBE if only one of i or j is a compiletime-constant
+  # x[i] -> x[i]: maybe; Further analysis could make this return true when i is a runtime-constant
+  # x[i] -> x[j]: maybe; also returns maybe if only one of i or j is a compiletime-constant
   template collectImportantNodes(result, n) =
     var result: seq[PNode]
     var n = n
@@ -630,7 +628,7 @@ proc aliases*(obj, field: PNode): AliasKind =
       if currFieldPath[1].sym != currObjPath[1].sym: return no
     of nkBracketExpr:
       if currFieldPath[1].kind in nkLiterals and currObjPath[1].kind in nkLiterals:
-        if not exprStructuralEquivalent(currFieldPath[1], currObjPath[1]):
+        if currFieldPath[1].intVal != currObjPath[1].intVal:
           return no
       else:
         result = maybe

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -640,10 +640,10 @@ type InstrTargetKind* = enum
   None, Full, Partial
 
 proc instrTargets*(insloc, loc: PNode): InstrTargetKind =
-  let inslocAliasesLoc = insloc.aliases(loc)
-  if inslocAliasesLoc == yes:
+  case insloc.aliases(loc)
+  of yes:
     Full    # x -> x; x -> x.f
-  elif inslocAliasesLoc == maybe:
+  of maybe:
     Partial # We treat this like a partial write/read
   elif loc.aliases(insloc) != no:
     Partial # x.f -> x
@@ -653,14 +653,10 @@ proc isAnalysableFieldAccess*(orig: PNode; owner: PSym): bool =
   var n = orig
   while true:
     case n.kind
-    of PathKinds0 - {nkBracketExpr, nkHiddenDeref, nkDerefExpr}:
+    of PathKinds0 - {nkHiddenDeref, nkDerefExpr}:
       n = n[0]
     of PathKinds1:
       n = n[1]
-    of nkBracketExpr:
-      # in a[i] the 'i' must be known
-      assert n.len > 1
-      n = n[0]
     of nkHiddenDeref, nkDerefExpr:
       # We "own" sinkparam[].loc but not ourVar[].location as it is a nasty
       # pointer indirection.

--- a/compiler/dfa.nim
+++ b/compiler/dfa.nim
@@ -611,10 +611,18 @@ proc aliases*(obj, field: PNode): AliasKind =
   collectImportantNodes(objImportantNodes, obj)
   collectImportantNodes(fieldImportantNodes, field)
 
+  # If field is less nested than obj, then it cannot be part of/aliased by obj
   if fieldImportantNodes.len < objImportantNodes.len: return no
 
   result = yes
   for i in 1..objImportantNodes.len:
+    # We compare the nodes leading to the location of obj and field
+    # with each other.
+    # We continue until they diverge, in which case we return no, or
+    # until we reach the location of obj, in which case we do not need
+    # to look further, since field must be part of/aliased by obj now.
+    # If we encounter an element access using an index which is a runtime value,
+    # we simply return maybe instead of yes; should further nodes not diverge.
     let currFieldPath = fieldImportantNodes[^i]
     let currObjPath = objImportantNodes[^i]
 

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -969,7 +969,7 @@ proc p(n: PNode; c: var Con; s: var Scope; mode: ProcessMode): PNode =
 
 proc sameLocation*(a, b: PNode): bool =
   proc sameConstant(a, b: PNode): bool =
-    a.kind in nkLiterals and exprStructuralEquivalent(a, b)
+    a.kind in nkLiterals and (a.intVal != b.intVal)
 
   const nkEndPoint = {nkSym, nkDotExpr, nkCheckedFieldExpr, nkBracketExpr}
   if a.kind in nkEndPoint and b.kind in nkEndPoint:

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -969,7 +969,7 @@ proc p(n: PNode; c: var Con; s: var Scope; mode: ProcessMode): PNode =
 
 proc sameLocation*(a, b: PNode): bool =
   proc sameConstant(a, b: PNode): bool =
-    a.kind in nkLiterals and (a.intVal != b.intVal)
+    a.kind in nkLiterals and a.intVal == b.intVal
 
   const nkEndPoint = {nkSym, nkDotExpr, nkCheckedFieldExpr, nkBracketExpr}
   if a.kind in nkEndPoint and b.kind in nkEndPoint:

--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -1006,7 +1006,7 @@ proc moveOrCopy(dest, ri: PNode; c: var Con; s: var Scope, isDecl = false): PNod
         # unpacking of tuple: take over the elements
         result = c.genSink(dest, p(ri, c, s, consumed), isDecl)
       elif isAnalysableFieldAccess(ri, c.owner) and isLastRead(ri, c):
-        if not aliases(dest, ri):
+        if aliases(dest, ri) == no:
           # Rule 3: `=sink`(x, z); wasMoved(z)
           var snk = c.genSink(dest, ri, isDecl)
           result = newTree(nkStmtList, snk, c.genWasMoved(ri))

--- a/tests/arc/tmovebug.nim
+++ b/tests/arc/tmovebug.nim
@@ -92,7 +92,17 @@ copy
 destroy
 destroy
 destroy
+sink
+sink
+destroy
+copy
+(f: 1)
+destroy
+destroy
 part-to-whole assigment:
+sink
+(children: @[])
+destroy
 sink
 (children: @[])
 destroy
@@ -675,6 +685,16 @@ proc caseNotAConstant =
 
 caseNotAConstant()
 
+proc potentialSelfAssign(i: var int) =
+  var a: array[2, OO]
+  a[i] = OO(f: 1)
+  a[1] = OO(f: 2)
+  a[i+1] = a[i] # This must not =sink, but =copy
+  inc i
+  echo a[i-1] # (f: 1)
+
+potentialSelfAssign (var xi = 0; xi)
+
 
 #--------------------------------------------------------------------
 echo "part-to-whole assigment:"
@@ -699,6 +719,17 @@ proc partToWholeSeq =
   echo tc             #        then it would crash because t.children[0] does not exist after the call to `=sink`
 
 partToWholeSeq()
+
+proc partToWholeSeqRTIndex =
+  var i = 0
+  var t = Tree(children: @[Tree()])
+  t = t.children[i] # This should be sunk, but with the special transform (tmp = t.children[0]; wasMoved(0); `=sink`(t, tmp))
+
+  var tc = TreeDefaultHooks(children: @[TreeDefaultHooks()])
+  tc = tc.children[i] # Ditto; if this were sunk with the normal transform (`=sink`(t, t.children[0]); wasMoved(t.children[0]))
+  echo tc             #        then it would crash because t.children[0] does not exist after the call to `=sink`
+
+partToWholeSeqRTIndex()
 
 type List = object
   next: ref List

--- a/tests/arc/tmovebug.nim
+++ b/tests/arc/tmovebug.nim
@@ -723,11 +723,11 @@ partToWholeSeq()
 proc partToWholeSeqRTIndex =
   var i = 0
   var t = Tree(children: @[Tree()])
-  t = t.children[i] # This should be sunk, but with the special transform (tmp = t.children[0]; wasMoved(0); `=sink`(t, tmp))
+  t = t.children[i] # See comment in partToWholeSeq
 
   var tc = TreeDefaultHooks(children: @[TreeDefaultHooks()])
-  tc = tc.children[i] # Ditto; if this were sunk with the normal transform (`=sink`(t, t.children[0]); wasMoved(t.children[0]))
-  echo tc             #        then it would crash because t.children[0] does not exist after the call to `=sink`
+  tc = tc.children[i] # See comment in partToWholeSeq
+  echo tc
 
 partToWholeSeqRTIndex()
 


### PR DESCRIPTION
This also allows optimizing assignments such as `a = a[i]` where `i` is a runtime value into sinks.