### PR TITLE
show msys2 as foreignDep for windows

### DIFF
--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -222,7 +222,7 @@ proc foreignDepInstallCmd*(foreignPackageName: string): (string, bool) =
   ## and whether it requires root/admin rights.
   let p = foreignPackageName
   when defined(windows):
-    result = ("Chocolatey install " & p, false)
+    result = ("pacman -S " & p, false)
   elif defined(bsd):
     result = ("ports install " & p, true)
   elif defined(linux):


### PR DESCRIPTION
The `distros` module provides example install commands for installation packages declared with `foreignDep`.

Of course, on windows it is unclear which one to use, because there are no package managers provided by the OS and many 3rd party ones.

The current one chosen, `Chocolatey`, is unlikely to be useful for installing build dependencies- for example, the Nim version provided is 1.0.0. Also, `Chocolatey` is no longer the current install command used by Chocolatey- the command is `choco`.

Instead, I would like to suggest using `pacman` from `msys2`- msys2 provides current versions for nim, mingw64, autoconf, libtool, bash, perl and pretty much any tool that might be needed to build code, as well as many C libraries and other unixy packages, rendering foreignDep for Windows actually useful.

I just used it to build 3 different nimterop packages with very little fuss.