### PR TITLE
fix winlean definitions

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -28,8 +28,8 @@ else:
 type
   Handle* = int
   LONG* = int32
-  ULONG* = int32
-  PULONG* = ptr int
+  ULONG* = culong
+  PULONG* = ptr ULONG
   WINBOOL* = int32
     ## `WINBOOL` uses opposite convention as posix, !=0 meaning success.
     # xxx this should be distinct int32, distinct would make code less error prone


### PR DESCRIPTION
I'm not sure whether there exists some good solutions to make them type safe.
Ref https://github.com/nim-lang/Nim/issues/12327

Or
```nim
type
  ULONG* {.deprecated: "use `ULONG_t` instead".} = int32
  ULONG_t* = cuint
  PULONG* {.deprecated: "use `PULONG_t` instead".} = ptr int
  PULONG_t* = ptr ULONG_t
```



