### PR TITLE
added enum indexed array support to json

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1103,10 +1103,7 @@ when defined(nimFixedForwardGeneric):
       jsonPath.add '['
       jsonPath.addInt i
       jsonPath.add ']'
-      when S is enum: # To support serializing enum indexed arrays
-        initFromJson(dst[i.S], jsonNode[i], jsonPath)
-      else:
-        initFromJson(dst[i], jsonNode[i], jsonPath)
+      initFromJson(dst[i.S], jsonNode[i], jsonPath) # `.S` for enum indexed arrays
       jsonPath.setLen originalJsonPathLen
 
   proc initFromJson[T](dst: var Table[string,T]; jsonNode: JsonNode; jsonPath: var string) =

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -1103,7 +1103,10 @@ when defined(nimFixedForwardGeneric):
       jsonPath.add '['
       jsonPath.addInt i
       jsonPath.add ']'
-      initFromJson(dst[i], jsonNode[i], jsonPath)
+      when S is enum: # To support serializing enum indexed arrays
+        initFromJson(dst[i.S], jsonNode[i], jsonPath)
+      else:
+        initFromJson(dst[i], jsonNode[i], jsonPath)
       jsonPath.setLen originalJsonPathLen
 
   proc initFromJson[T](dst: var Table[string,T]; jsonNode: JsonNode; jsonPath: var string) =

--- a/tests/stdlib/tjson_enum_index.nim
+++ b/tests/stdlib/tjson_enum_index.nim
@@ -1,0 +1,11 @@
+import json
+type Test = enum
+  one, two, three, four, five
+let a = [
+  one: 300,
+  two: 20,
+  three: 10,
+  four: 0,
+  five: -10
+]
+doAssert (%* a).to(a.typeof) == a


### PR DESCRIPTION
Prior to this attempting to serialize an enum indexed array threw a undefined operator error for indexing it with an integer.