### PR TITLE
remove unused warning

### DIFF
--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -1,11 +1,11 @@
-import std/private/since
-
 proc `$`*(x: int): string {.magic: "IntToStr", noSideEffect.}
   ## The stringify operator for an integer argument. Returns `x`
   ## converted to a decimal string. ``$`` is Nim's general way of
   ## spelling `toString`:idx:.
 
 when defined(js):
+  import std/private/since
+
   since (1, 3):
     proc `$`*(x: uint): string =
       ## Caveat: currently implemented as $(cast[int](x)), tied to current


### PR DESCRIPTION
The warning:

When generating docs from some my modules, it gave this warning(`nim doc -r --lib:lib lib/std/secrets.nim` https://github.com/nim-lang/Nim/pull/16459)
```
D:\QQPCmgr\Desktop\Nim\lib\system\dollars.nim(1, 19) Warning: imported and not used: 'since' [UnusedImport]
```