### PR TITLE
fixed nim-lang/nimsuggest#48 type aware sug

### DIFF
--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -70,11 +70,11 @@ proc cmpSuggestions(a, b: Suggest): int =
     result = b.field.int - a.field.int
     if result != 0: return result
 
-  cf scope
   cf prefix
+  cf contextFits
+  cf scope
   # when the first type matches, it's better when it's a generic match:
   cf quality
-  cf contextFits
   cf localUsages
   cf globalUsages
   # if all is equal, sort alphabetically for deterministic output,
@@ -600,6 +600,11 @@ proc sugExpr(c: PContext, n: PNode, outputs: var Suggestions) =
     #if optIdeDebug in gGlobalOptions:
     #  echo "expression ", renderTree(obj), " has type ", typeToString(obj.typ)
     #writeStackTrace()
+  elif n.kind == nkIdent:
+    let
+      prefix = if c.config.m.trackPosAttached: nil else: n
+      info = n.info
+    wholeSymTab(filterSym(it, prefix, pm), ideSug)
   else:
     let prefix = if c.config.m.trackPosAttached: nil else: n
     suggestEverything(c, n, prefix, outputs)

--- a/nimsuggest/tests/tsug_template.nim
+++ b/nimsuggest/tests/tsug_template.nim
@@ -6,7 +6,7 @@ tmp#[!]#
 discard """
 $nimsuggest --tester $file
 >sug $1
-sug;;skMacro;;tsug_template.tmpb;;macro (){.noSideEffect, gcsafe, locks: 0.};;$file;;2;;6;;"";;0;;Prefix
-sug;;skConverter;;tsug_template.tmpc;;converter ();;$file;;3;;10;;"";;0;;Prefix
-sug;;skTemplate;;tsug_template.tmpa;;template ();;$file;;1;;9;;"";;0;;Prefix
+sug;;skMacro;;tsug_template.tmpb;;macro (){.noSideEffect, gcsafe, locks: 0.};;$file;;2;;6;;"";;100;;Prefix
+sug;;skConverter;;tsug_template.tmpc;;converter ();;$file;;3;;10;;"";;100;;Prefix
+sug;;skTemplate;;tsug_template.tmpa;;template ();;$file;;1;;9;;"";;100;;Prefix
 """

--- a/nimsuggest/tests/tsug_typedecl.nim
+++ b/nimsuggest/tests/tsug_typedecl.nim
@@ -1,0 +1,26 @@
+# suggestions for type declarations
+
+from system import string, int, bool
+
+type
+  super = int
+  someType = bool
+
+let str = "hello"
+
+proc main() =
+  let a: s#[!]#
+
+# This output show seq, even though that's not imported. This is due to the
+# entire symbol table, regardless of import visibility is currently being
+# scanned. This is hardly ideal, but changing it with the current level of test
+# coverage is unwise as it might break more than it fixes.
+
+discard """
+$nimsuggest --tester $file
+>sug $1
+sug;;skType;;tsug_typedecl.someType;;someType;;*nimsuggest/tests/tsug_typedecl.nim;;7;;2;;"";;100;;Prefix
+sug;;skType;;tsug_typedecl.super;;super;;*nimsuggest/tests/tsug_typedecl.nim;;6;;2;;"";;100;;Prefix
+sug;;skType;;system.string;;string;;*lib/system.nim;;*;;*;;*;;100;;Prefix
+sug;;skType;;system.seq;;seq;;*lib/system.nim;;*;;*;;*;;100;;Prefix
+"""


### PR DESCRIPTION
* suggesting identifiers accounts context over scope (distance)
* key takeaway: context fit is prioritized over a heuristics like scope