### PR TITLE
`dumpToString`: improves on `sugar.dump`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -104,7 +104,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
   `-d:nimLegacyParseQueryStrict`. `cgi.decodeData` which uses the same
   underlying code is also updated the same way.
 
-- Added `sugar.dumpToString` which improves on `suugar.dump`.
+- Added `sugar.dumpToString` which improves on `sugar.dump`.
 
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -104,6 +104,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
   `-d:nimLegacyParseQueryStrict`. `cgi.decodeData` which uses the same
   underlying code is also updated the same way.
 
+- Added `sugar.dumpToString` which improves on `suugar.dump`.
 
 
 

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -158,12 +158,13 @@ macro dump*(x: untyped): untyped =
   ## source code - together with the value of the expression.
   ##
   ## Deprecated: use `dumpToString` which is more convenient and useful since
-  ## it expands intermediate templates/macros.
+  ## it expands intermediate templates/macros, returns a string instead of
+  ## calling `echo`, and works with statements and expressions.
   runnableExamples:
     let
       x = 10
       y = 20
-    dump(x + y) # will print `x + y = 30`
+    if false: dump(x + y) # if true would print `x + y = 30`
 
   let s = x.toStrLit
   result = quote do:

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -157,7 +157,7 @@ macro dump*(x: untyped): untyped =
   ## of the tree representing the expression - as it would appear in
   ## source code - together with the value of the expression.
   ##
-  ## Deprecated: use `dumpToString` which is more convenient and useful since
+  ## See also: `dumpToString` which is more convenient and useful since
   ## it expands intermediate templates/macros, returns a string instead of
   ## calling `echo`, and works with statements and expressions.
   runnableExamples:

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -190,6 +190,8 @@ macro dumpToString*(x: untyped): string =
     template square(x): untyped = x * x
     doAssert dumpToString(square(x)) == "square(x): x * x = 100"
     doAssert not compiles dumpToString(1 + nonexistant)
+    import std/strutils
+    doAssert "failedAssertImpl" in dumpToString(doAssert true) # example with a statement
   result = newCall(bindSym"dumpToStringImpl")
   result.add newLit repr(x)
   result.add x

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -163,9 +163,13 @@ macro dump*(x: untyped): untyped =
     dump(x + y) # will print `x + y = 30`
 
   let s = x.toStrLit
-  let r = quote do:
+  result = quote do:
     debugEcho `s`, " = ", `x`
-  return r
+
+macro dumpToString*(x: untyped): string =
+  let s = x.toStrLit
+  result = quote do:
+    `s` & " = " & $`x`
 
 # TODO: consider exporting this in macros.nim
 proc freshIdentNodes(ast: NimNode): NimNode =

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -185,7 +185,7 @@ macro dumpToString*(x: untyped): string =
     const a = 1
     let x = 10
     doAssert dumpToString(a + 2) == "a + 2: 3 = 3"
-    echo dumpToString(a + x)
+    doAssert dumpToString(a + x) == "a + x: 1 + x = 11"
     template square(x): untyped = x * x
     doAssert dumpToString(square(x)) == "square(x): x * x = 100"
     doAssert not compiles dumpToString(1 + nonexistant)

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -113,3 +113,8 @@ block: # dumpToString
   template square(x): untyped = x * x
   let x = 10
   doAssert dumpToString(square(x)) == "square(x): x * x = 100"
+  let s = dumpToString(doAssert 1+1 == 2)
+  doAssert "failedAssertImpl" in s
+  let s2 = dumpToString:
+    doAssertRaises(AssertionDefect): doAssert false
+  doAssert "except AssertionDefect" in s2

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -108,3 +108,8 @@ doAssert collect(for d in data.items: {d}) == data.toHashSet
 template foo =
   discard collect(newSeq, for i in 1..3: i)
 foo()
+
+block: # dumpToString
+  template square(x): untyped = x * x
+  let x = 10
+  doAssert dumpToString(square(x)) == "square(x): x * x = 100"


### PR DESCRIPTION
background: https://github.com/nim-lang/Nim/pull/14580 changed dump from `macro dump*(x: typed): untyped =` to `macro dump*(x: untyped): untyped =`, so that it gives sensible results in presence of const-folding such as `dump(123 + 456)`.

However, the major drawback is that it isn't so useful as a template/macro debugging tool with untyped, given that it won't expand a template/macro expression passed to it.

Another drawback is that `dump` calls `echo` instead of returning a string; as I argued in https://github.com/nim-lang/Nim/pull/16802#discussion_r563445173 it's a bad API (hard to test, and not flexible)

And finally, `dump` can only be used with expressions, not statements.

## `dumpToString`
this PR fixes all those issues via a new `dumpToString` API:
* can be used with expressions and statements
for example:
```nim
let s = dumpToString:
  doAssertRaises(AssertionDefect): doAssert false
```
`echo s` prints:
```
try:
  if true:
    const
      expr`gensym112 = "false"
...
except AssertionDefect:
  discard
except Exception as e`gensym111:
...
if wrong`gensym111:
  raiseAssert("expected raising \'AssertionDefect\', instead nothing was raised by: \ndoAssert false")
```

* this does expand templates/macros, as shown in above example or with following example:
```nim
template square(x): untyped = x * x
let x = 10
doAssert dumpToString(square(x)) == "square(x): x * x = 100"
```
in contrast, `dump` would print `square(x) = 100`, which isn't very useful as it doesn't show how the square template is expanded:
```nim
template square(x): untyped = x * x
let x = 10
dump(square(x))
```

* and yet, this still isnt' isn't impacted by const folding (which was what https://github.com/nim-lang/Nim/pull/14580 was "fixing" with dump at the cost of making dump not expand templates/macros passed to it).

This is achieved by what I'd call the "nested macro pattern" (see PR; simply a macro calling a macro).

* finally, this returns a string instead of calling echo, which is much easier to test (see test in tsugar.nim), and more flexible (user can manipulate the resulting string at their will, or simply echo it)