### PR TITLE
jsbigints: add missing bitwise ops

### DIFF
--- a/lib/std/jsbigints.nim
+++ b/lib/std/jsbigints.nim
@@ -105,6 +105,14 @@ func `**`*(x, y: JsBigInt): JsBigInt {.importjs: "((#) $1 #)".} =
   # pending https://github.com/nim-lang/Nim/pull/15940, simplify to:
   # doAssertRaises: discard big"2" ** big"-1" # raises foreign `RangeError`
 
+func `and`*(x, y: JsBigInt): JsBigInt {.importjs: "(# & #)".} =
+  runnableExamples:
+    doAssert (big"555" and big"2") == big"2"
+
+func `or`*(x, y: JsBigInt): JsBigInt {.importjs: "(# | #)".} =
+  runnableExamples:
+    doAssert (big"555" or big"2") == big"555"
+
 func `xor`*(x, y: JsBigInt): JsBigInt {.importjs: "(# ^ #)".} =
   runnableExamples:
     doAssert (big"555" xor big"2") == big"553"

--- a/tests/stdlib/tjsbigints.nim
+++ b/tests/stdlib/tjsbigints.nim
@@ -11,6 +11,8 @@ var big3: JsBigInt = big"2"
 
 doAssert big3 == big"2"
 doAssert (big3 xor big2) == big"664"
+doAssert (big"555" and big"2") == big"2"
+doAssert (big"555" or big"2") == big"555"
 doAssert (big1 mod big2) == big"613"
 doAssert -big1 == big"-2147483647"
 doAssert big1 div big2 == big"3224449"


### PR DESCRIPTION
jsbigints is a new module(since Nim v1.5), so no changelog.

The PR is useful to refactor `std/hashes`.