### PR TITLE
improve code in categories.nim; add std/private/gitutils; fix flakyness in nim CI (cloneDependency in deps.nim)

### DIFF
--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -4,7 +4,9 @@ internal API for now, API subject to change
 
 # xxx move other git utilities here; candidate for stdlib.
 
-import std/[os]
+import std/[os, osproc, strutils]
+
+const commitHead* = "HEAD"
 
 template retryCall*(maxRetry = 3, backoffDuration = 1.0, call: untyped): bool =
   ## Retry `call` up to `maxRetry` times with exponential backoff and initial

--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -1,0 +1,26 @@
+##[
+internal API for now, API subject to change
+]##
+
+#[
+PRTEMP: was: actionRetry 621384b8efce7def08faeb9bc63289a4a88c3a59
+]#
+
+import std/[os]
+
+proc retryCall*(maxRetry = 3, backoffDuration = 1.0, call: proc(): bool): bool =
+  ## retry `call` up to `maxRetry` times with exponential backoff and initial
+  ## duraton of `backoffDuration` seconds
+  runnableExamples:
+    doAssert not retryCall(maxRetry = 2, backoffDuration = 0.1, proc(): bool = false)
+    var i = 0
+    doAssert retryCall(maxRetry = 3, backoffDuration = 0.1, proc(): bool = (i.inc; i >= 3))
+    doAssert retryCall(call = proc(): bool = true)
+
+  var t = backoffDuration
+  for i in 0..<maxRetry:
+    if call(): return true
+    if i == maxRetry - 1: break
+    sleep(int(t * 1000))
+    t = t * 2 # exponential backoff
+  return false

--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -2,25 +2,37 @@
 internal API for now, API subject to change
 ]##
 
-#[
-PRTEMP: was: actionRetry 621384b8efce7def08faeb9bc63289a4a88c3a59
-]#
+# xxx move other git utilities here; candidate for stdlib.
 
 import std/[os]
 
-proc retryCall*(maxRetry = 3, backoffDuration = 1.0, call: proc(): bool): bool =
-  ## retry `call` up to `maxRetry` times with exponential backoff and initial
-  ## duraton of `backoffDuration` seconds
+template retryCall*(maxRetry = 3, backoffDuration = 1.0, call: untyped): bool =
+  ## Retry `call` up to `maxRetry` times with exponential backoff and initial
+  ## duraton of `backoffDuration` seconds.
+  ## This is in particular useful for network commands that can fail.
   runnableExamples:
-    doAssert not retryCall(maxRetry = 2, backoffDuration = 0.1, proc(): bool = false)
+    doAssert not retryCall(maxRetry = 2, backoffDuration = 0.1, false)
     var i = 0
-    doAssert retryCall(maxRetry = 3, backoffDuration = 0.1, proc(): bool = (i.inc; i >= 3))
-    doAssert retryCall(call = proc(): bool = true)
-
+    doAssert: retryCall(maxRetry = 3, backoffDuration = 0.1, (i.inc; i >= 3))
+    doAssert retryCall(call = true)
+  var result = false
   var t = backoffDuration
   for i in 0..<maxRetry:
-    if call(): return true
+    if call:
+      result = true
+      break
     if i == maxRetry - 1: break
     sleep(int(t * 1000))
     t = t * 2 # exponential backoff
-  return false
+  result
+
+proc isGitRepo*(dir: string): bool =
+  ## This command is used to get the relative path to the root of the repository.
+  ## Using this, we can verify whether a folder is a git repository by checking
+  ## whether the command success and if the output is empty.
+  let (output, status) = execCmdEx("git rev-parse --show-cdup", workingDir = dir)
+  # On Windows there will be a trailing newline on success, remove it.
+  # The value of a successful call typically won't have a whitespace (it's
+  # usually a series of ../), so we know that it's safe to unconditionally
+  # remove trailing whitespaces from the result.
+  result = status == 0 and output.strip() == ""

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -1,4 +1,4 @@
-import os, uri, strformat, osproc, strutils
+import os, uri, strformat, strutils
 import std/private/gitutils
 
 proc exec(cmd: string) =
@@ -14,8 +14,6 @@ proc execRetry(cmd: string) =
       echo fmt"failed command: '{cmd}', status: {status}"
     result)
   doAssert ok, cmd
-
-const commitHead* = "HEAD"
 
 proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
                       appendRepoName = true, allowBundled = false) =

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -1,34 +1,19 @@
 import os, uri, strformat, osproc, strutils
+import std/private/gitutils
 
 proc exec(cmd: string) =
   echo "deps.cmd: " & cmd
   let status = execShellCmd(cmd)
   doAssert status == 0, cmd
 
-proc execOK(cmd: string): bool =
-  let status = execShellCmd(cmd)
-  result = status == 0
-  if not result:
-    echo fmt"failed command: '{cmd}'"
-
 proc execRetry(cmd: string) =
-  ## for network commands that can fail
-  doAssert retryCall(proc(): bool = execOK(cmd)), cmd
-
-proc execEx(cmd: string): tuple[output: string, exitCode: int] =
-  echo "deps.cmd: " & cmd
-  execCmdEx(cmd, {poStdErrToStdOut, poUsePath, poEvalCommand})
-
-proc isGitRepo(dir: string): bool =
-  # This command is used to get the relative path to the root of the repository.
-  # Using this, we can verify whether a folder is a git repository by checking
-  # whether the command success and if the output is empty.
-  let (output, status) = execEx fmt"git -C {quoteShell(dir)} rev-parse --show-cdup"
-  # On Windows there will be a trailing newline on success, remove it.
-  # The value of a successful call typically won't have a whitespace (it's
-  # usually a series of ../), so we know that it's safe to unconditionally
-  # remove trailing whitespaces from the result.
-  result = status == 0 and output.strip() == ""
+  let ok = retryCall(call = block:
+    let status = execShellCmd(cmd)
+    let result = status == 0
+    if not result:
+      echo fmt"failed command: '{cmd}', status: {status}"
+    result)
+  doAssert ok, cmd
 
 const commitHead* = "HEAD"
 


### PR DESCRIPTION
* add std/private/gitutils containing reusable git utilities, for now a private module so API can evolve, in future this could be candidate for stdlib since it's useful in many places
* fix https://github.com/timotheecour/Nim/issues/558 (cloneDependency was flaky, causing nim CI to sometimes fail, as is the case currently as of b0f38a63c4916be139f1a289264a5df68bcb4c07) via a reusable `gitutils.retryCall`
* refactor categories.nim to remove code duplication

## future work
* `gitutils` could collect more procs that are currently duplicated/spread out in various tools, tests
* `gitutils` would also be useful for fixing things like https://github.com/nim-lang/Nim/issues/15708