### PR TITLE
add widestrs.newWideCString overload

### DIFF
--- a/lib/system/widestrs.nim
+++ b/lib/system/widestrs.nim
@@ -142,6 +142,9 @@ iterator runes(s: cstring, L: int): int =
     fastRuneAt(s, i, L, result, true)
     yield result
 
+proc newWideCString*(size: int): WideCStringObj =
+  createWide(result, size * 2 + 2)
+
 proc newWideCString*(source: cstring, L: int): WideCStringObj =
   createWide(result, L * 2 + 2)
   var d = 0


### PR DESCRIPTION
It's a very useful api, so I don't mark it with `{.since.}`

```nim
type
  DWORD = culong

proc getTempPath*(
  nBufferLength: DWORD, lpBuffer: WideCString
): DWORD {.stdcall, dynlib: "kernel32.dll", importc: "GetTempPathW".} =
  ## Retrieves the path of the directory designated for temporary files.


let size = getTempPath(0, nil)


var x = newString(size)
let y = newWideCString(x)
echo getTempPath(size, y)


# With this PR
let m = newWideCString(size.int)
echo getTempPath(size, m)
```

When `ffi` with win32, we pass buffer to c api, then we don't need allocate unnecessary strings.

Ref https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw