### PR TITLE
remove conditionals on nimHasUserErrors, nimNoNilSeqs2, nimNoNilSeqs

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1127,11 +1127,7 @@ proc discardSons*(father: PNode)
 type Indexable = PNode | PType
 
 proc len*(n: Indexable): int {.inline.} =
-  when defined(nimNoNilSeqs):
-    result = n.sons.len
-  else:
-    if isNil(n.sons): result = 0
-    else: result = n.sons.len
+  result = n.sons.len
 
 proc safeLen*(n: PNode): int {.inline.} =
   ## works even for leaves.
@@ -1146,8 +1142,6 @@ proc safeArrLen*(n: PNode): int {.inline.} =
 
 proc add*(father, son: Indexable) =
   assert son != nil
-  when not defined(nimNoNilSeqs):
-    if isNil(father.sons): father.sons = @[]
   father.sons.add(son)
 
 proc addAllowNil*(father, son: Indexable) {.inline.} =
@@ -1308,10 +1302,7 @@ proc copyObjectSet*(dest: var TObjectSet, src: TObjectSet) =
   for i in 0..high(src.data): dest.data[i] = src.data[i]
 
 proc discardSons*(father: PNode) =
-  when defined(nimNoNilSeqs):
-    father.sons = @[]
-  else:
-    father.sons = nil
+  father.sons = @[]
 
 proc withInfo*(n: PNode, info: TLineInfo): PNode =
   n.info = info
@@ -1436,13 +1427,7 @@ proc mergeLoc(a: var TLoc, b: TLoc) =
   if a.r == nil: a.r = b.r
 
 proc newSons*(father: Indexable, length: int) =
-  when defined(nimNoNilSeqs):
-    setLen(father.sons, length)
-  else:
-    if isNil(father.sons):
-      newSeq(father.sons, length)
-    else:
-      setLen(father.sons, length)
+  setLen(father.sons, length)
 
 proc assignType*(dest, src: PType) =
   dest.kind = src.kind
@@ -1576,26 +1561,17 @@ proc propagateToOwner*(owner, elem: PType; propagateHasAsgn = true) =
       owner.flags.incl tfHasGCedMem
 
 proc rawAddSon*(father, son: PType; propagateHasAsgn = true) =
-  when not defined(nimNoNilSeqs):
-    if isNil(father.sons): father.sons = @[]
   father.sons.add(son)
   if not son.isNil: propagateToOwner(father, son, propagateHasAsgn)
 
 proc rawAddSonNoPropagationOfTypeFlags*(father, son: PType) =
-  when not defined(nimNoNilSeqs):
-    if isNil(father.sons): father.sons = @[]
   father.sons.add(son)
 
 proc addSonNilAllowed*(father, son: PNode) =
-  when not defined(nimNoNilSeqs):
-    if isNil(father.sons): father.sons = @[]
   father.sons.add(son)
 
 proc delSon*(father: PNode, idx: int) =
-  when defined(nimNoNilSeqs):
-    if father.len == 0: return
-  else:
-    if isNil(father.sons): return
+  if father.len == 0: return
   for i in idx..<father.len - 1: father[i] = father[i + 1]
   father.sons.setLen(father.len - 1)
 
@@ -1766,10 +1742,7 @@ proc getStr*(a: PNode): string =
   of nkStrLit..nkTripleStrLit: result = a.strVal
   of nkNilLit:
     # let's hope this fixes more problems than it creates:
-    when defined(nimNoNilSeqs):
-      result = ""
-    else:
-      result = nil
+    result = ""
   else:
     raiseRecoverableError("cannot extract string from invalid AST node")
     #doAssert false, "getStr"

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -71,7 +71,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimNewRuntime")
   defineSymbol("nimIncrSeqV3")
   defineSymbol("nimAshr")
-  defineSymbol("nimNoNilSeqs")
+  defineSymbol("nimNoNilSeqs") # deadcode
   defineSymbol("nimNoNilSeqs2") # deadcode
   defineSymbol("nimHasUserErrors") # deadcode
   defineSymbol("nimUncheckedArrayTyp")

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -73,7 +73,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimAshr")
   defineSymbol("nimNoNilSeqs")
   defineSymbol("nimNoNilSeqs2")
-  defineSymbol("nimHasUserErrors")
+  defineSymbol("nimHasUserErrors") # deadcode
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")
   defineSymbol("nimErrorProcCanHaveBody")

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -72,7 +72,7 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimIncrSeqV3")
   defineSymbol("nimAshr")
   defineSymbol("nimNoNilSeqs")
-  defineSymbol("nimNoNilSeqs2")
+  defineSymbol("nimNoNilSeqs2") # deadcode
   defineSymbol("nimHasUserErrors") # deadcode
   defineSymbol("nimUncheckedArrayTyp")
   defineSymbol("nimHasTypeof")

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -329,8 +329,7 @@ proc genRecCommentAux(d: PDoc, n: PNode): Rope =
         result = genRecCommentAux(d, n[i])
         if result != nil: return
   else:
-    when defined(nimNoNilSeqs): n.comment = ""
-    else: n.comment = nil
+    n.comment = ""
 
 proc genRecComment(d: PDoc, n: PNode): Rope =
   if n == nil: return nil

--- a/compiler/magicsys.nim
+++ b/compiler/magicsys.nim
@@ -98,8 +98,6 @@ proc skipIntLit*(t: PType; id: IdGenerator): PType {.inline.} =
     result = t
 
 proc addSonSkipIntLit*(father, son: PType; id: IdGenerator) =
-  when not defined(nimNoNilSeqs):
-    if isNil(father.sons): father.sons = @[]
   let s = son.skipIntLit(id)
   father.sons.add(s)
   propagateToOwner(father, s)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -164,8 +164,6 @@ proc validInd(p: var Parser): bool {.inline.} =
 proc rawSkipComment(p: var Parser, node: PNode) =
   if p.tok.tokType == tkComment:
     if node != nil:
-      when not defined(nimNoNilSeqs):
-        if node.comment == nil: node.comment = ""
       when defined(nimpretty):
         if p.tok.commentOffsetB > p.tok.commentOffsetA:
           node.comment.add fileSection(p.lex.config, p.lex.fileIdx, p.tok.commentOffsetA, p.tok.commentOffsetB)

--- a/compiler/patterns.nim
+++ b/compiler/patterns.nim
@@ -210,11 +210,8 @@ proc matchStmtList(c: PPatternContext, p, n: PNode): PNode =
     for j in 0..<p.len:
       if not matches(c, p[j], n[i+j]):
         # we need to undo any bindings:
-        when defined(nimNoNilSeqs):
-          c.mapping = @[]
-          c.mappingIsFull = false
-        else:
-          if not isNil(c.mapping): c.mapping = nil
+        c.mapping = @[]
+        c.mappingIsFull = false
         return false
     result = true
 

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1237,10 +1237,7 @@ proc typeSectionRightSidePass(c: PContext, n: PNode) =
             var body = s.typ.lastSon
             if body.kind == tyObject:
               # erases all declared fields
-              when defined(nimNoNilSeqs):
-                body.n.sons = @[]
-              else:
-                body.n.sons = nil
+              body.n.sons = @[]
 
       popOwner(c)
       closeScope(c)

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -895,8 +895,6 @@ proc initSameTypeClosure: TSameTypeClosure =
 proc containsOrIncl(c: var TSameTypeClosure, a, b: PType): bool =
   result = c.s.len > 0 and c.s.contains((a.id, b.id))
   if not result:
-    when not defined(nimNoNilSeqs):
-      if isNil(c.s): c.s = @[]
     c.s.add((a.id, b.id))
 
 proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -271,8 +271,6 @@ template getstr(a: untyped): untyped =
   (if a.kind == rkNode: a.node.strVal else: $chr(int(a.intVal)))
 
 proc pushSafePoint(f: PStackFrame; pc: int) =
-  when not defined(nimNoNilSeqs):
-    if f.safePoints.isNil: f.safePoints = @[]
   f.safePoints.add(pc)
 
 proc popSafePoint(f: PStackFrame) =
@@ -2092,8 +2090,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       inc pc
       let typ = c.types[c.code[pc].regBx - wordExcess]
       createStrKeepNode(regs[ra])
-      when not defined(nimNoNilSeqs):
-        if regs[ra].node.strVal.isNil: regs[ra].node.strVal = newStringOfCap(1000)
       storeAny(regs[ra].node.strVal, typ, regs[rb].regToNode, c.config)
 
     c.profiler.leave(c)

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -1150,10 +1150,7 @@ when (NimMajor, NimMinor) < (1, 3) and defined(js):
 
   proc ssClose(s: Stream) {.compileTime.} =
     var s = StringStream(s)
-    when defined(nimNoNilSeqs):
-      s.data = ""
-    else:
-      s.data = nil
+    s.data = ""
 
   proc newStringStream*(s: string = ""): owned StringStream {.compileTime.} =
     new(result)
@@ -1253,10 +1250,7 @@ else: # after 1.3 or JS not defined
 
   proc ssClose(s: Stream) =
     var s = StringStream(s)
-    when defined(nimNoNilSeqs):
-      s.data = ""
-    else:
-      s.data = nil
+    s.data = ""
 
   proc newStringStream*(s: string = ""): owned StringStream =
     ## Creates a new stream from the string `s`.

--- a/lib/std/packedsets.nim
+++ b/lib/std/packedsets.nim
@@ -180,7 +180,7 @@ proc initPackedSet*[A]: PackedSet[A] =
     counter: 0,
     max: 0,
     head: nil,
-    data: when defined(nimNoNilSeqs): @[] else: nil)
+    data: @[])
   #  a: array[0..33, int] # profiling shows that 34 elements are enough
 
 proc contains*[A](s: PackedSet[A], key: A): bool =
@@ -392,10 +392,7 @@ proc clear*[A](result: var PackedSet[A]) =
   # setLen(result.data, InitIntSetSize)
   # for i in 0..InitIntSetSize - 1: result.data[i] = nil
   # result.max = InitIntSetSize - 1
-  when defined(nimNoNilSeqs):
-    result.data = @[]
-  else:
-    result.data = nil
+  result.data = @[]
   result.max = 0
   result.counter = 0
   result.head = nil
@@ -426,10 +423,7 @@ proc assign*[A](dest: var PackedSet[A], src: PackedSet[A]) =
     assert len(a) == 2
 
   if src.elems <= src.a.len:
-    when defined(nimNoNilSeqs):
-      dest.data = @[]
-    else:
-      dest.data = nil
+    dest.data = @[]
     dest.max = 0
     dest.counter = src.counter
     dest.head = nil

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1559,11 +1559,8 @@ proc len*[U: Ordinal; V: Ordinal](x: HSlice[U, V]): int {.noSideEffect, inline.}
   ##   assert((5..2).len == 0)
   result = max(0, ord(x.b) - ord(x.a) + 1)
 
-when defined(nimNoNilSeqs2):
-  when not compileOption("nilseqs"):
-    {.pragma: nilError, error.}
-  else:
-    {.pragma: nilError.}
+when not compileOption("nilseqs"):
+  {.pragma: nilError, error.}
 else:
   {.pragma: nilError.}
 
@@ -2942,7 +2939,7 @@ proc `==`*(x, y: cstring): bool {.magic: "EqCString", noSideEffect,
   elif x.isNil or y.isNil: result = false
   else: result = strcmp(x, y) == 0
 
-when defined(nimNoNilSeqs2) and not compileOption("nilseqs"):
+when not compileOption("nilseqs"):
   # bug #9149; ensure that 'type(nil)' does not match *too* well by using 'type(nil) | type(nil)',
   # especially for converters, see tests/overload/tconverter_to_string.nim
   # Eventually we will be able to remove this hack completely.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2943,7 +2943,7 @@ when not compileOption("nilseqs"):
   # bug #9149; ensure that 'type(nil)' does not match *too* well by using 'type(nil) | type(nil)',
   # especially for converters, see tests/overload/tconverter_to_string.nim
   # Eventually we will be able to remove this hack completely.
-  proc `==`*(x: string; y: type(nil)): bool {.
+  proc `==`*(x: string; y: type(nil) | type(nil)): bool {.
       error: "'nil' is now invalid for 'string'; compile with --nilseqs:on for a migration period".} =
     discard
   proc `==`*(x: type(nil) | type(nil); y: string): bool {.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2943,18 +2943,15 @@ proc `==`*(x, y: cstring): bool {.magic: "EqCString", noSideEffect,
   else: result = strcmp(x, y) == 0
 
 when defined(nimNoNilSeqs2) and not compileOption("nilseqs"):
-  when defined(nimHasUserErrors):
-    # bug #9149; ensure that 'type(nil)' does not match *too* well by using 'type(nil) | type(nil)'.
-    # Eventually (in 0.20?) we will be able to remove this hack completely.
-    proc `==`*(x: string; y: type(nil) | type(nil)): bool {.
-        error: "'nil' is now invalid for 'string'; compile with --nilseqs:on for a migration period".} =
-      discard
-    proc `==`*(x: type(nil) | type(nil); y: string): bool {.
-        error: "'nil' is now invalid for 'string'; compile with --nilseqs:on for a migration period".} =
-      discard
-  else:
-    proc `==`*(x: string; y: type(nil) | type(nil)): bool {.error.} = discard
-    proc `==`*(x: type(nil) | type(nil); y: string): bool {.error.} = discard
+  # bug #9149; ensure that 'type(nil)' does not match *too* well by using 'type(nil) | type(nil)',
+  # especially for converters, see tests/overload/tconverter_to_string.nim
+  # Eventually we will be able to remove this hack completely.
+  proc `==`*(x: string; y: type(nil)): bool {.
+      error: "'nil' is now invalid for 'string'; compile with --nilseqs:on for a migration period".} =
+    discard
+  proc `==`*(x: type(nil) | type(nil); y: string): bool {.
+      error: "'nil' is now invalid for 'string'; compile with --nilseqs:on for a migration period".} =
+    discard
 
 template closureScope*(body: untyped): untyped =
   ## Useful when creating a closure in a loop to capture local loop variables by

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -477,8 +477,6 @@ proc deduplicateFiles(c: var ConfigData) =
   let build = getOutputDir(c)
   for osA in countup(1, c.oses.len):
     for cpuA in countup(1, c.cpus.len):
-      when not defined(nimNoNilSeqs):
-        if c.cfiles[osA][cpuA].isNil: c.cfiles[osA][cpuA] = @[]
       if c.explicitPlatforms and not c.platforms[osA][cpuA]: continue
       for dup in mitems(c.cfiles[osA][cpuA]):
         let key = $secureHashFile(build / dup)


### PR DESCRIPTION
* fix partially https://github.com/nim-lang/RFCs/issues/293
* make docs for `type(nil) | type(nil)` reflect reality (problem is still there)

## note
any condsyms define flag that passes this test is fine to remove:
`nim c -r main` for nim bootstrap (currently 0.20.0)
```nim
doAssert defined(nimNoNilSeqs2)
doAssert defined(nimHasUserErrors)
doAssert defined(nimNoNilSeqs)
```


## future work
- [x] remaining part for https://github.com/nim-lang/RFCs/issues/293 is removing nilseqs flag
=> PR https://github.com/nim-lang/Nim/pull/17211