### PR TITLE
asyncjs: add `then`, `catch` for promise pipelining

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -203,7 +203,7 @@ provided by the operating system.
 
 - Added `-d:nimStrictMode` in CI in several places to ensure code doesn't have certain hints/warnings
 
-- Added `then`, `catch` to `asyncjs`.
+- Added `then`, `catch` to `asyncjs`, for now hidden behind `-d:nimExperimentalAsyncjsThen`.
 
 ## Tool changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -203,6 +203,8 @@ provided by the operating system.
 
 - Added `-d:nimStrictMode` in CI in several places to ensure code doesn't have certain hints/warnings
 
+- Added `then`, `catch` to `asyncjs`.
+
 ## Tool changes
 
 - The rst parser now supports markdown table syntax.

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -95,9 +95,16 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       var cmdPrefix = ""
       case conf.backend
       of backendC, backendCpp, backendObjc: discard
-      of backendJs: cmdPrefix = findNodeJs() & " "
+      of backendJs:
+        cmdPrefix = findNodeJs()
+        cmdPrefix.add " --unhandled-rejections=strict"
+          #[
+          D20210217T215950:here
+          this flag is needed for node < v15.0.0, otherwise `tasyncjs_fail` would fail,
+          refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+          ]#
       else: doAssert false, $conf.backend
-      execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)
+      execExternalProgram(conf, cmdPrefix & ' ' & output.quoteShell & ' ' & conf.arguments)
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -96,15 +96,14 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       case conf.backend
       of backendC, backendCpp, backendObjc: discard
       of backendJs:
-        cmdPrefix = findNodeJs()
-        cmdPrefix.add " --unhandled-rejections=strict"
-          #[
-          D20210217T215950:here
-          this flag is needed for node < v15.0.0, otherwise `tasyncjs_fail` would fail,
-          refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-          ]#
+        # D20210217T215950:here this flag is needed for node < v15.0.0, otherwise
+        # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+        cmdPrefix = findNodeJs() & " --unhandled-rejections=strict "
       else: doAssert false, $conf.backend
-      execExternalProgram(conf, cmdPrefix & ' ' & output.quoteShell & ' ' & conf.arguments)
+      # No space before command otherwise on windows you'd get a cryptic:
+      # `The parameter is incorrect`
+      execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)
+      # execExternalProgram(conf, cmdPrefix & ' ' & output.quoteShell & ' ' & conf.arguments)
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -154,3 +154,25 @@ proc newPromise*[T](handler: proc(resolve: proc(response: T))): Future[T] {.impo
 proc newPromise*(handler: proc(resolve: proc())): Future[void] {.importcpp: "(new Promise(#))".}
   ## A helper for wrapping callback-based functions
   ## into promises and async procedures.
+
+type OnReject* = proc(reason: JsObject)
+
+proc then*[T, T2](future: Future[T], onSuccess: proc(value: T): T2, onReject: OnReject = nil): Future[T2] =
+  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+proc then*[T](future: Future[T], onSuccess: proc(value: T), onReject: OnReject = nil): Future[void] =
+  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+proc then*(future: Future[void], onSuccess: proc(), onReject: OnReject = nil): Future[void] =
+  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+proc then*[T2](future: Future[void], onSuccess: proc(): T2, onReject: OnReject = nil): Future[T2] =
+  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+proc catch*[T](a: Future[T], onReject: OnReject): Future[void] =
+  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
+  asm "`result` = `a`.catch(`onReject`)"

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -169,7 +169,7 @@ when defined(nimExperimentalAsyncjsThen):
     and https://stackoverflow.com/questions/61377358/javascript-wait-for-async-call-to-finish-before-returning-from-function-witho
     ]#
 
-    type Error*  {.importjs: "Error".} = ref object of RootObj
+    type Error*  {.importjs: "Error".} = ref object of JsRoot
       ## https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
       message*: cstring
       name*: cstring

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -57,11 +57,12 @@
 ## If you need to use this module with older versions of JavaScript, you can
 ## use a tool that backports the resulting JavaScript code, as babel.
 
-import std/jsffi
-import std/macros
-
 when not defined(js) and not defined(nimsuggest):
   {.fatal: "Module asyncjs is designed to be used with the JavaScript backend.".}
+
+import std/jsffi
+import std/macros
+import std/private/since
 
 type
   Future*[T] = ref object
@@ -155,24 +156,64 @@ proc newPromise*(handler: proc(resolve: proc())): Future[void] {.importcpp: "(ne
   ## A helper for wrapping callback-based functions
   ## into promises and async procedures.
 
-type OnReject* = proc(reason: JsObject)
+when defined(nimExperimentalAsyncjsThen):
+  since (1, 5, 1):
+    #[
+    TODO:
+    * map `Promise.all()`
+    * proc toString*(a: Error): cstring {.importjs: "#.toString()".}
 
-proc then*[T, T2](future: Future[T], onSuccess: proc(value: T): T2, onReject: OnReject = nil): Future[T2] =
-  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+    Note:
+    We probably can't have a `waitFor` in js in browser (single threaded), but maybe it would be possible
+    in in nodejs, see https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options
+    and https://stackoverflow.com/questions/61377358/javascript-wait-for-async-call-to-finish-before-returning-from-function-witho
+    ]#
 
-proc then*[T](future: Future[T], onSuccess: proc(value: T), onReject: OnReject = nil): Future[void] =
-  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+    type Error*  {.importjs: "Error".} = ref object of RootObj
+      ## https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+      message*: cstring
+      name*: cstring
 
-proc then*(future: Future[void], onSuccess: proc(), onReject: OnReject = nil): Future[void] =
-  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+    type OnReject* = proc(reason: Error)
 
-proc then*[T2](future: Future[void], onSuccess: proc(): T2, onReject: OnReject = nil): Future[T2] =
-  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-  asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+    proc then*[T, T2](future: Future[T], onSuccess: proc(value: T): T2, onReject: OnReject = nil): Future[T2] =
+      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+      asm "`result` = `future`.then(`onSuccess`, `onReject`)"
 
-proc catch*[T](a: Future[T], onReject: OnReject): Future[void] =
-  ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
-  asm "`result` = `a`.catch(`onReject`)"
+    proc then*[T](future: Future[T], onSuccess: proc(value: T), onReject: OnReject = nil): Future[void] =
+      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+      asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+    proc then*(future: Future[void], onSuccess: proc(), onReject: OnReject = nil): Future[void] =
+      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+      asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+    proc then*[T2](future: Future[void], onSuccess: proc(): T2, onReject: OnReject = nil): Future[T2] =
+      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+      asm "`result` = `future`.then(`onSuccess`, `onReject`)"
+
+    proc catch*[T](future: Future[T], onReject: OnReject): Future[void] =
+      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
+      runnableExamples:
+        from std/sugar import `=>`
+        from std/strutils import contains
+        proc fn(n: int): Future[int] {.async.} =
+          if n >= 7: raise newException(ValueError, "foobar: " & $n)
+          else: result = n * 2
+        proc main() {.async.} =
+          let x1 = await fn(3)
+          assert x1 == 3*2
+          let x2 = await fn(4)
+            .then((a: int) => a.float)
+            .then((a: float) => $a)
+          assert x2 == "8.0"
+
+          var reason: Error
+          await fn(6).catch((r: Error) => (reason = r))
+          assert reason == nil
+          await fn(7).catch((r: Error) => (reason = r))
+          assert reason != nil
+          assert  "foobar: 7" in $reason.message
+        discard main()
+
+      asm "`result` = `future`.catch(`onReject`)"

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -12,7 +12,7 @@
 import
   strutils, pegs, os, osproc, streams, json, std/exitprocs,
   backend, parseopt, specs, htmlgen, browsers, terminal,
-  algorithm, times, md5, sequtils, azure, intsets, macros
+  algorithm, times, md5, azure, intsets, macros
 from std/sugar import dup
 import compiler/nodejs
 import lib/stdtest/testutils
@@ -501,7 +501,8 @@ proc testSpecHelper(r: var TResults, test: var TTest, expected: TSpec,
           var args = test.args
           if isJsTarget:
             exeCmd = nodejs
-            args = concat(@[exeFile], args)
+            # see D20210217T215950
+            args = @["--unhandled-rejections=strict", exeFile] & args
           else:
             exeCmd = exeFile.dup(normalizeExe)
             if expected.useValgrind != disabled:
@@ -510,6 +511,7 @@ proc testSpecHelper(r: var TResults, test: var TTest, expected: TSpec,
                 valgrindOptions.add "--leak-check=yes"
               args = valgrindOptions & exeCmd & args
               exeCmd = "valgrind"
+          # xxx honor `testament --verbose` here
           var (_, buf, exitCode) = execCmdEx2(exeCmd, args, input = expected.input)
           # Treat all failure codes from nodejs as 1. Older versions of nodejs used
           # to return other codes, but for us it is sufficient to know that it's not 0.

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -23,3 +23,6 @@ hint("Processing", off)
 # switch("define", "nimTestsEnableFlaky")
 
 # switch("hint", "ConvFromXtoItselfNotNeeded")
+
+# experimental API's are enabled in testament, refs https://github.com/timotheecour/Nim/issues/575
+switch("define", "nimExperimentalAsyncjsThen")

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -7,27 +7,49 @@ e
 
 import asyncjs
 
-# demonstrate forward definition
-# for js
-proc y(e: int): Future[string] {.async.}
+block:
+  # demonstrate forward definition for js
+  proc y(e: int): Future[string] {.async.}
 
-proc e: int {.discardable.} =
-  echo "e"
-  return 2
+  proc e: int {.discardable.} =
+    echo "e"
+    return 2
 
-proc x(e: int): Future[void] {.async.} =
-  var s = await y(e)
-  if e > 2:
-    return
-  echo s
-  e()
+  proc x(e: int): Future[void] {.async.} =
+    var s = await y(e)
+    if e > 2:
+      return
+    echo s
+    e()
 
-proc y(e: int): Future[string] {.async.} =
-  if e > 0:
-    return await y(0)
-  else:
-    return "x"
+  proc y(e: int): Future[string] {.async.} =
+    if e > 0:
+      return await y(0)
+    else:
+      return "x"
 
 
-discard x(2)
+  discard x(2)
 
+import sugar
+block:
+  proc fn(n: int): Future[int] {.async.} =
+    if n > 0:
+      var ret = 1 + await fn(n-1)
+      echo ret
+      return ret
+    else:
+      return 10
+  discard fn(4)
+  # discard fn(4).then(a=>a*3)
+  # discard fn(4).then((a: int) => (echo "gook1"))
+  # discard fn(4).then((a: int) => (echo "gook1")).then((a: int) => (echo "gook2"))
+  # discard fn(4).then((a: int) => (echo "gook1")).then(() => (echo "gook2"))
+
+  # discard fn(4).then((a: int) => (echo "gook1"; a*a)).then((a: int) => (echo a))
+  # discard fn(4).then((a: int) => (echo "gook1"; float(a*a))).then((a: float) => (echo a))
+  # discard fn(4).then((a: int) => a*10).then((a: int) => (echo a))
+  # discard fn(4).then(a => a*10).then((a: int) => (echo a))
+
+  var witness: seq[string]
+  discard fn(4).then((a: int) => (witness.add $a; a.float*2)).then((a: float) => (witness.add $a)).then(()=>(echo witness)).then(()=>1)

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -41,15 +41,6 @@ block:
     else:
       return 10
   discard fn(4)
-  # discard fn(4).then(a=>a*3)
-  # discard fn(4).then((a: int) => (echo "gook1"))
-  # discard fn(4).then((a: int) => (echo "gook1")).then((a: int) => (echo "gook2"))
-  # discard fn(4).then((a: int) => (echo "gook1")).then(() => (echo "gook2"))
-
-  # discard fn(4).then((a: int) => (echo "gook1"; a*a)).then((a: int) => (echo a))
-  # discard fn(4).then((a: int) => (echo "gook1"; float(a*a))).then((a: float) => (echo a))
-  # discard fn(4).then((a: int) => a*10).then((a: int) => (echo a))
-  # discard fn(4).then(a => a*10).then((a: int) => (echo a))
-
   var witness: seq[string]
-  discard fn(4).then((a: int) => (witness.add $a; a.float*2)).then((a: float) => (witness.add $a)).then(()=>(echo witness)).then(()=>1)
+  discard fn(4).
+    then((a: int) => (witness.add $a; a.float*2)).then((a: float) => (witness.add $a)).then(()=>(echo witness)).then(()=>1)

--- a/tests/js/tasync.nim
+++ b/tests/js/tasync.nim
@@ -32,6 +32,7 @@ block:
   discard x(2)
 
 import sugar
+
 block:
   proc fn(n: int): Future[int] {.async.} =
     if n > 0:
@@ -42,5 +43,7 @@ block:
       return 10
   discard fn(4)
   var witness: seq[string]
-  discard fn(4).
-    then((a: int) => (witness.add $a; a.float*2)).then((a: float) => (witness.add $a)).then(()=>(echo witness)).then(()=>1)
+  discard fn(3)
+    .then((a: int) => (witness.add $a; a.float*2))
+    .then((a: float) => (witness.add $a))
+    .then(()=>(echo witness)).then(()=>1)

--- a/tests/js/tasyncjs_fail.nim
+++ b/tests/js/tasyncjs_fail.nim
@@ -1,0 +1,19 @@
+discard """
+ outputsub: "Error: unhandled exception: foobar: 13"
+"""
+
+import std/asyncjs
+from std/sugar import `=>`
+
+proc fn(n: int): Future[int] {.async.} =
+  if n >= 7: raise newException(ValueError, "foobar: " & $n)
+  else: result = n
+
+proc main() {.async.} =
+  let x1 = await fn(6)
+  doAssert x1 == 6
+  await fn(7).catch((a: Error) => (discard))
+  let x3 = await fn(13)
+  doAssert false # shouldn't go here, should fail before
+
+discard main()

--- a/tests/js/tasyncjs_fail.nim
+++ b/tests/js/tasyncjs_fail.nim
@@ -1,6 +1,9 @@
 discard """
+  exitCode: 1
  outputsub: "Error: unhandled exception: foobar: 13"
 """
+
+# note: this needs `--unhandled-rejections=strict`, see D20210217T215950
 
 import std/asyncjs
 from std/sugar import `=>`


### PR DESCRIPTION
prerequisite for things like `jsfetch` https://github.com/nim-lang/Nim/pull/12531

## note
* `--unhandled-rejections=strict` node flag is now passed in testament for nodejs tests, so that `tests/js/tasyncjs_fail.nim` returns exit code != 0 (and so that this test succeeds). This flag is explained in https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode and is the default starting with node >= 15.0.0


with this flag, for nodejs < 15.0.0 (all except freebsd CI), you'd get exit code 0 and this message:

(Use `node --trace-warnings ...` to show where the warning was created)
(node:72796) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:72796) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

* I'm hiding the new API under `nimExperimentalAsyncjsThen`, refs https://github.com/timotheecour/Nim/issues/575

* I'm using this pattern https://github.com/timotheecour/Nim/issues/596 for cross referencing an explanation


## links
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch etc

## future work
- [x] upgrade node version in CI from 12.0 (everyhing except freebsd) to 15.0 (freebsd)
=> https://github.com/nim-lang/Nim/pull/18003
- [ ] allow passing flags to nodejs (`--passnode` maybe), which we'd use as follows:

`nim r -b:js --lib:lib -d:nodejs --passnode:--unhandled-rejections=strict tests/js/tasyncjs_fail.nim`

after which i can mark expected exitcode as != 0 for `tests/js/tasyncjs_fail.nim`

it'd be handled here: in compiler/nim.nim near `execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)`
