### PR TITLE
Fix #12595

### DIFF
--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -555,6 +555,10 @@ proc semTemplBody(c: var TemplCtx, n: PNode): PNode =
       result[1] = semTemplBody(c, n[1])
     else:
       result = semTemplBodySons(c, n)
+  of nkTableConstr:
+    # also transform the keys (bug #12595)
+    for i in 0..<n.len:
+      result[i] = semTemplBodySons(c, n[i])
   else:
     result = semTemplBodySons(c, n)
 

--- a/tests/template/template_issues.nim
+++ b/tests/template/template_issues.nim
@@ -256,7 +256,7 @@ discard foo()
 type
   IteratorF*[In] = iterator() : In {.closure.}
 
-template foof(In: untyped) : untyped = 
+template foof(In: untyped) : untyped =
   proc ggg*(arg: IteratorF[In]) =
     for i in arg():
       echo "foo"
@@ -265,7 +265,7 @@ template foof(In: untyped) : untyped =
 iterator hello() : int {.closure.} =
   for i in 1 .. 3:
     yield i
-    
+
 foof(int)
 ggg(hello)
 
@@ -290,3 +290,9 @@ proc bar(t: var int) =
 
 foo(bar)
 
+block: # bug #12595
+  template test() =
+    let i = 42
+    discard {i: ""}
+
+  test()


### PR DESCRIPTION
Fixes #12595.

The problem was that `ExprColonExpr` wasn't treated specially inside `TableConstr` (for the other uses, like object constructors, the key should not be gensym'd), which is fixed now, by using `semTemplBodySons` on the elements (which are `ExprColonExpr`s).