### PR TITLE
critbits: fix error from strictFuncs

### DIFF
--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -518,7 +518,7 @@ func commonPrefixLen*[T](c: CritBitTree[T]): int {.inline, since((1, 3)).} =
     else: c.root.byte
   else: 0
 
-func toCritBitTree*[T](pairs: openArray[(string, T)]): CritBitTree[T] {.since: (1, 3).} =
+proc toCritBitTree*[T](pairs: openArray[(string, T)]): CritBitTree[T] {.since: (1, 3).} =
   ## Creates a new `CritBitTree` that contains the given `pairs`.
   runnableExamples:
     doAssert {"a": "0", "b": "1", "c": "2"}.toCritBitTree is CritBitTree[string]
@@ -526,7 +526,7 @@ func toCritBitTree*[T](pairs: openArray[(string, T)]): CritBitTree[T] {.since: (
 
   for item in pairs: result.incl item[0], item[1]
 
-func toCritBitTree*(items: openArray[string]): CritBitTree[void] {.since: (1, 3).} =
+proc toCritBitTree*(items: openArray[string]): CritBitTree[void] {.since: (1, 3).} =
   ## Creates a new `CritBitTree` that contains the given `items`.
   runnableExamples:
     doAssert ["a", "b", "c"].toCritBitTree is CritBitTree[void]

--- a/tests/effects/tstrict_funcs.nim
+++ b/tests/effects/tstrict_funcs.nim
@@ -7,6 +7,7 @@ import tables, streams, parsecsv
 # They are otherwise unused in this file.
 import
   complex,
+  critbits,
   httpcore,
   math,
   nre,


### PR DESCRIPTION
This might be the wrong fix, but I don't know what the right one is.

At least this fixes the regression in `devel`.

---

Previously, compiling a file containing just `import critbits` with
`nim c --experimental:strictFuncs` would produce the following error:
```
    critbits.nim(529, 6) Error: 'toCritBitTree' can have side effects
```

This was introduced by 2aed4186989e (#16564).

Fixes: #16873