### PR TITLE
link compile-time options together in docs

### DIFF
--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -43,14 +43,26 @@ type
 
 proc querySetting*(setting: SingleValueSetting): string {.
   compileTime, noSideEffect.} = discard
-  ## Can be used to get a string compile-time option. Example:
+  ## Can be used to get a string compile-time option.
+  ##
+  ## See also:
+  ## * `compileOption <system.html#compileOption,string>`_ for `on|off` options
+  ## * `compileOption <system.html#compileOption,string,string>`_ for enum options
+  ##
+  ## Example:
   ##
   ## .. code-block:: Nim
   ##   const nimcache = querySetting(SingleValueSetting.nimcacheDir)
 
 proc querySettingSeq*(setting: MultipleValueSetting): seq[string] {.
   compileTime, noSideEffect.} = discard
-  ## Can be used to get a multi-string compile-time option. Example:
+  ## Can be used to get a multi-string compile-time option.
+  ##
+  ## See also:
+  ## * `compileOption <system.html#compileOption,string>`_ for `on|off` options
+  ## * `compileOption <system.html#compileOption,string,string>`_ for enum options
+  ##
+  ## Example:
   ##
   ## .. code-block:: Nim
   ##   const nimblePaths = compileSettingSeq(MultipleValueSetting.nimblePaths)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -60,9 +60,9 @@ proc compileOption*(option: string): bool {.
   ## Can be used to determine an `on|off` compile-time option.
   ##
   ## See also:
-  ## * `compileOption <#string,string>`_ for enum options
+  ## * `compileOption <#compileOption,string,string>`_ for enum options
   ## * `declared <#declared,untyped>`_
-  ## * `defined <#string>`_
+  ## * `defined <#defined,string>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -82,7 +82,6 @@ proc compileOption*(option, arg: string): bool {.
   ## Example:
   ##
   ## .. code-block:: Nim
-  ##
   ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
   ##     echo "compiled with optimization for size and uses Boehm's GC"
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -113,7 +113,6 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## See also:
   ## * `compileOption <#compileOption,string>`_ for `on|off` options
   ## * `compileOption <#compileOption,string,string>`_ for enum options
-  ## * `declared <#declared,untyped>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## `x` is an external symbol introduced through the compiler's

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -82,6 +82,7 @@ proc compileOption*(option, arg: string): bool {.
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:
+  ##
   ## .. code-block:: Nim
   ##
   ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -63,7 +63,6 @@ proc compileOption*(option: string): bool {.
   ## * `compileOption <#compileOption,string,string>`_ for enum options
   ## * `defined <#defined,untyped>`_
   ## * `std/compilesettings module <compilesettings.html>`_
-  ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:
   ##
@@ -79,7 +78,6 @@ proc compileOption*(option, arg: string): bool {.
   ## * `compileOption <#compileOption,string>`_ for `on|off` options
   ## * `defined <#defined,untyped>`_
   ## * `std/compilesettings module <compilesettings.html>`_
-  ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:
   ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -62,10 +62,11 @@ proc compileOption*(option: string): bool {.
   ## See also:
   ## * `compileOption <#compileOption,string,string>`_ for enum options
   ## * `declared <#declared,untyped>`_
-  ## * `defined <#defined,string>`_
+  ## * `defined <#defined,untyped>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:
+  ##
   ## .. code-block:: Nim
   ##   when compileOption("floatchecks"):
   ##     echo "compiled with floating point NaN and Inf checks"
@@ -77,11 +78,12 @@ proc compileOption*(option, arg: string): bool {.
   ## See also:
   ## * `compileOption <#compileOption,string>`_ for `on|off` options
   ## * `declared <#declared,untyped>`_
-  ## * `defined <#defined,string>`_
+  ## * `defined <#defined,untyped>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:
   ## .. code-block:: Nim
+  ##
   ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
   ##     echo "compiled with optimization for size and uses Boehm's GC"
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -61,7 +61,6 @@ proc compileOption*(option: string): bool {.
   ##
   ## See also:
   ## * `compileOption <#compileOption,string,string>`_ for enum options
-  ## * `declared <#declared,untyped>`_
   ## * `defined <#defined,untyped>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
@@ -77,7 +76,6 @@ proc compileOption*(option, arg: string): bool {.
   ##
   ## See also:
   ## * `compileOption <#compileOption,string>`_ for `on|off` options
-  ## * `declared <#declared,untyped>`_
   ## * `defined <#defined,untyped>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -62,6 +62,7 @@ proc compileOption*(option: string): bool {.
   ## See also:
   ## * `compileOption <#compileOption,string,string>`_ for enum options
   ## * `defined <#defined,untyped>`_
+  ## * `std/compilesettings module <compilesettings.html>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:
@@ -77,6 +78,7 @@ proc compileOption*(option, arg: string): bool {.
   ## See also:
   ## * `compileOption <#compileOption,string>`_ for `on|off` options
   ## * `defined <#defined,untyped>`_
+  ## * `std/compilesettings module <compilesettings.html>`_
   ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## Example:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -57,16 +57,30 @@ include "system/basic_types"
 
 proc compileOption*(option: string): bool {.
   magic: "CompileOption", noSideEffect.}
-  ## Can be used to determine an `on|off` compile-time option. Example:
+  ## Can be used to determine an `on|off` compile-time option.
   ##
+  ## See also:
+  ## * `compileOption <#string,string>`_ for enum options
+  ## * `declared <#declared,untyped>`_
+  ## * `defined <#string>`_
+  ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
+  ##
+  ## Example:
   ## .. code-block:: Nim
   ##   when compileOption("floatchecks"):
   ##     echo "compiled with floating point NaN and Inf checks"
 
 proc compileOption*(option, arg: string): bool {.
   magic: "CompileOptionArg", noSideEffect.}
-  ## Can be used to determine an enum compile-time option. Example:
+  ## Can be used to determine an enum compile-time option.
   ##
+  ## See also:
+  ## * `compileOption <#compileOption,string>`_ for `on|off` options
+  ## * `declared <#declared,untyped>`_
+  ## * `defined <#defined,string>`_
+  ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
+  ##
+  ## Example:
   ## .. code-block:: Nim
   ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
   ##     echo "compiled with optimization for size and uses Boehm's GC"
@@ -94,6 +108,12 @@ type
 proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## Special compile-time procedure that checks whether `x` is
   ## defined.
+  ##
+  ## See also:
+  ## * `compileOption <#compileOption,string>`_ for `on|off` options
+  ## * `compileOption <#compileOption,string,string>`_ for enum options
+  ## * `declared <#declared,untyped>`_
+  ## * `define pragmas <manual.html#implementation-specific-pragmas-compileminustime-define-pragmas>`_
   ##
   ## `x` is an external symbol introduced through the compiler's
   ## `-d:x switch <nimc.html#compiler-usage-compileminustime-symbols>`_ to enable


### PR DESCRIPTION
I am unsure if it is appropriate to link [`delcared`](https://nim-lang.github.io/Nim/system.html#declared%2Cuntyped) with [`defined`](https://nim-lang.github.io/Nim/system.html#defined%2Cuntyped). Happy to remove it if preferred.