### PR TITLE
2.5x- 3x faster copyFile on osx

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -121,7 +121,8 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - `typetraits.distinctBase` now is identity instead of error for non distinct types.
 
-- `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`.
+- `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`;
+  use `-d:nimLegacyCopyFile` for OSX < 10.5.
 
 
 ## Compiler changes

--- a/changelog.md
+++ b/changelog.md
@@ -120,8 +120,9 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
 
 - `typetraits.distinctBase` now is identity instead of error for non distinct types.
-- `os.copyFile` is now 2.5x faster on OSX.
+
 - `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`.
+
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -121,6 +121,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - `typetraits.distinctBase` now is identity instead of error for non distinct types.
 - `os.copyFile` is now 2.5x faster on OSX.
+- `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`.
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -120,6 +120,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
 
 - `typetraits.distinctBase` now is identity instead of error for non distinct types.
+- `os.copyFile` is now 2.5x faster on OSX.
 
 ## Compiler changes
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1635,6 +1635,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
 const hasCopyfileOsx = defined(osx) # since osx 10.5
+# const hasCopyfileOsx = false
 
 const nimHasImportcLet = compiles(block:
   let foo {.nodecl, importc.}: cint) # xxx move, and replace with `nimVersionCT`
@@ -1646,7 +1647,8 @@ when hasCopyfileOsx:
     {.push nodecl, header: "<copyfile.h>", styleChecks: off.}
   else:
     {.push nodecl, header: "<copyfile.h>".}
-  type copyfile_state_t = ptr object
+  type copyfile_state_t {.nodecl.} = object
+    # xxx it really should be a ptr object but not sure how to do that
   type copyfile_flags_t = cint
   proc copyfile_state_alloc(): copyfile_state_t
   proc copyfile_state_free(state: copyfile_state_t): cint

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1634,13 +1634,13 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-const hasCopyfileBsd = defined(osx) or defined(freebsd)
+const hasCopyfileOsx = defined(osx) # since osx 10.5
 
 const nimHasImportcLet = compiles(block:
   let foo {.nodecl, importc.}: cint) # xxx move, and replace with `nimVersionCT`
     # pending bootstrap >= https://github.com/nim-lang/Nim/pull/14258, remove this
 
-when hasCopyfileBsd:
+when hasCopyfileOsx:
   when defined(nimHasStyleChecks):
     # {.push nodecl, header: "<copyfile.h>", styleChecksOff2.} # xxx how come this even compiles?
     {.push nodecl, header: "<copyfile.h>", styleChecks: off.}
@@ -1694,7 +1694,7 @@ proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",
       if copyFileW(s, d, 0'i32) == 0'i32: raiseOSError(osLastError(), $(source, dest))
     else:
       if copyFileA(source, dest, 0'i32) == 0'i32: raiseOSError(osLastError(), $(source, dest))
-  elif hasCopyfileBsd:
+  elif hasCopyfileOsx:
     let state = copyfile_state_alloc()
     var status = c_copyfile(source.cstring, dest.cstring, state, COPYFILE_DATA)
     if status != 0: raiseOSError(osLastError(), $(source, dest))

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1634,9 +1634,11 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-const hasCCopyfile = defined(osx) # since osx 10.5
+const hasCCopyfile = defined(osx) and not defined(nimLegacyCopyFile)
+  # xxx instead of `nimLegacyCopyFile`, support something like: `when osxVersion >= (10, 5)`
 
 when hasCCopyfile:
+  # `copyfile` API available since osx 10.5.
   {.push nodecl, header: "<copyfile.h>".}
   type
     copyfile_state_t {.nodecl.} = pointer
@@ -1669,6 +1671,9 @@ proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",
   ##
   ## If `dest` already exists, the file attributes
   ## will be preserved and the content overwritten.
+  ## 
+  ## On OSX, `copyfile` C api will be used (available since OSX 10.5) unless
+  ## `-d:nimLegacyCopyFile` is used.
   ##
   ## See also:
   ## * `copyDir proc <#copyDir,string,string>`_

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1634,7 +1634,7 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
       var res2 = setFileAttributesA(filename, res)
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
-const hasCopyfileBsd = defined(osx) or defined(bsd)
+const hasCopyfileBsd = defined(osx) or defined(freebsd)
 
 const nimHasImportcLet = compiles(block:
   let foo {.nodecl, importc.}: cint) # xxx move, and replace with `nimVersionCT`

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1696,9 +1696,7 @@ proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",
     if status2 != 0: raiseOSError(osLastError(), $(source, dest))
   else:
     # generic version of copyFile which works for any platform:
-    const bufSize = 8192
-      # This could be refined dynamically if `source` turns out to be a large file
-      # Another good default would be based on `getFileInfo(a).blockSize`.
+    const bufSize = 8000 # better for memory manager
     var d, s: File
     if not open(s, source): raiseOSError(osLastError(), source)
     if not open(d, dest, fmWrite):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1643,8 +1643,9 @@ when hasCopyfileBsd:
   proc copyfile_state_free(state: copyfile_state_t): cint
   proc c_copyfile(src, dst: cstring,  state: copyfile_state_t, flags: copyfile_flags_t): cint {.importc: "copyfile".}
   # let COPYFILE_DATA: copyfile_flags_t # xxx bug: push nodecl didn't apply to let
-  let COPYFILE_DATA {.nodecl.}: copyfile_flags_t
-  let COPYFILE_XATTR {.nodecl.}: copyfile_flags_t
+  # pending bootstrap >= https://github.com/nim-lang/Nim/pull/14258, remove initializer
+  let COPYFILE_DATA {.nodecl.}: copyfile_flags_t = 0
+  let COPYFILE_XATTR {.nodecl.}: copyfile_flags_t = 0
   {.pop.}
 
 proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1638,8 +1638,6 @@ const hasCCopyfile = defined(osx) # since osx 10.5
 
 when hasCCopyfile:
   {.push nodecl, header: "<copyfile.h>".}
-  when defined(nimHasStyleChecks): {.push styleChecks: off.}
-  else: {.push.}
   type
     copyfile_state_t {.nodecl.} = pointer
     copyfile_flags_t = cint
@@ -1650,7 +1648,6 @@ when hasCCopyfile:
   var
     COPYFILE_DATA {.nodecl.}: copyfile_flags_t
     COPYFILE_XATTR {.nodecl.}: copyfile_flags_t
-  {.pop.}
   {.pop.}
 
 proc copyFile*(source, dest: string) {.rtl, extern: "nos$1",

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1635,7 +1635,6 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission]) {.
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
 const hasCopyfileOsx = defined(osx) # since osx 10.5
-# const hasCopyfileOsx = false
 
 const nimHasImportcLet = compiles(block:
   let foo {.nodecl, importc.}: cint) # xxx move, and replace with `nimVersionCT`

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -40,20 +40,25 @@ block fileOperations:
     doAssertRaises(OSError): copyFile(dname/"nonexistant.txt", dname/"nonexistant.txt")
     let fname = "D20201009T112235"
     let fname2 = "D20201009T112235.2"
-    writeFile(dname/fname, "foo")
+    let str = "foo1\0foo2\nfoo3\0"
+    let file = dname/fname
+    let file2 = dname/fname2
+    writeFile(file, str)
+    doAssert readFile(file) == str
     let sub = "sub"
-    doAssertRaises(OSError): copyFile(dname/fname, dname/sub/fname2)
-    doAssertRaises(OSError): copyFileToDir(dname/fname, dname/sub)
-    doAssertRaises(ValueError): copyFileToDir(dname/fname, "")
-    copyFile(dname/fname, dname/fname2)
-    doAssert fileExists(dname/fname2)
+    doAssertRaises(OSError): copyFile(file, dname/sub/fname2)
+    doAssertRaises(OSError): copyFileToDir(file, dname/sub)
+    doAssertRaises(ValueError): copyFileToDir(file, "")
+    copyFile(file, file2)
+    doAssert fileExists(file2)
+    doAssert readFile(file2) == str
     createDir(dname/sub)
-    copyFileToDir(dname/fname, dname/sub)
+    copyFileToDir(file, dname/sub)
     doAssert fileExists(dname/sub/fname)
     removeDir(dname/sub)
     doAssert not dirExists(dname/sub)
-    removeFile(dname/fname)
-    removeFile(dname/fname2)
+    removeFile(file)
+    removeFile(file2)
 
   # Test creating files and dirs
   for dir in dirs:


### PR DESCRIPTION
* fix proposal 1 from https://github.com/nim-lang/RFCs/issues/330

## benchmarks
## example 1
download https://releases.ubuntu.com/16.04.7/ubuntu-16.04.6-desktop-i386.iso
```nim
when true:
  import std/[times, os, algorithm]
  proc main()=
    let file = "/Users/timothee/Downloads/ubuntu-16.04.6-desktop-i386.iso"
    let file2 = "/tmp/D20210130T183001"
    echo getFileSize(file)
    for i in 0..<3:
      let t = epochTime()
      copyFile(file, file2)
      let t2 = epochTime()
      let dt = t2 - t
      echo dt
  main()
```

on osx with -d:danger:
before PR:
1677721600
3.034269094467163
3.089644908905029
3.209890127182007

after PR:
1677721600
1.278779029846191
1.217450857162476
1.241599082946777


nim --eval:'echo 3.034269094467163/1.217450857162476'
2.492313407655042

(this could be added to `tests/benchmarks/tos_copyfile.nim` in future work)

## example 2: example with copyDir
`copyDir("/Users/timothee/git_clone/llvm-project/build/tools", "/tmp/d01")`
before PR: 40s
after PR: 13.8s => 2.9x speedup

```
du -sh /Users/timothee/git_clone/llvm-project/build/tools
7.5G    /Users/timothee/git_clone/llvm-project/build/tools
find /Users/timothee/git_clone/llvm-project/build/tools | wc -l
    3798
```

## future work
* investigate why shell command `cp` is still faster; perhaps multithreading is used? but note that the speedup also occurs for single files.
  * example 1 gives: 0.00s user 0.78s system 93% cpu 0.846 total (1.4X faster than this PR)

  * example 2 gives: 0.09s user 5.96s system 51% cpu 11.690 total (1.18x faster than this PR)

(the disk is "hot", ie we don't measure cold start here; i'm using macbook pro 64 GB 2667 MHz DDR4, 2TB flash storage in all experiments)
