### PR TITLE
let's assume littleEndian in JS backend

### DIFF
--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -220,7 +220,7 @@ const
     (name: "arm", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "arm64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
     (name: "js", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
-    (name: "nimvm", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
+    (name: "nimvm", intSize: 32, endian: bigEndian, floatSize: 64, bit: 32),
       # xxx this seems buggy; on a 64bit machine, sizeof(int) is 64 in nimvm.
     (name: "avr", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "msp430", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),

--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -219,8 +219,8 @@ const
     (name: "mipsel", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "arm", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
     (name: "arm64", intSize: 64, endian: littleEndian, floatSize: 64, bit: 64),
-    (name: "js", intSize: 32, endian: bigEndian,floatSize: 64,bit: 32),
-    (name: "nimvm", intSize: 32, endian: bigEndian, floatSize: 64, bit: 32),
+    (name: "js", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
+    (name: "nimvm", intSize: 32, endian: littleEndian, floatSize: 64, bit: 32),
       # xxx this seems buggy; on a 64bit machine, sizeof(int) is 64 in nimvm.
     (name: "avr", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),
     (name: "msp430", intSize: 16, endian: littleEndian, floatSize: 32, bit: 16),


### PR DESCRIPTION
Most systems are little endians(especially for JS, it's more meaningful to assume little endians.


Ref https://hacks.mozilla.org/2017/01/typedarray-or-dataview-understanding-byte-order

> So, in summary, here’s what we’ve learned:
It is safe to assume systems to be little-endian.