### PR TITLE
JS: fix div uint64 no truncation

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -670,7 +670,10 @@ proc arith(p: PProc, n: PNode, r: var TCompRes, op: TMagic) =
   of mAddU: binaryUintExpr(p, n, r, "+")
   of mSubU: binaryUintExpr(p, n, r, "-")
   of mMulU: binaryUintExpr(p, n, r, "*")
-  of mDivU: binaryUintExpr(p, n, r, "/")
+  of mDivU:
+    binaryUintExpr(p, n, r, "/")
+    if n[1].typ.skipTypes(abstractRange).size == 8:
+      r.res = "Math.trunc($1)" % [r.res]
   of mDivI:
     arithAux(p, n, r, op)
   of mModI:

--- a/tests/arithm/tdiv.nim
+++ b/tests/arithm/tdiv.nim
@@ -1,0 +1,19 @@
+discard """
+  targets: "c js"
+"""
+
+
+block divUint64:
+  proc divTest() =
+    let x1 = 12'u16
+    let y = x1 div 5'u16
+    let x2 = 1345567'u32
+    let z = x2 div 5'u32
+    let a = 1345567'u64 div uint64(x1)
+    doAssert y == 2
+    doAssert z == 269113
+    doAssert a == 112130
+
+  static: divTest()
+  divTest()
+


### PR DESCRIPTION
Before this PR:
```nim
let x = 12'u64
echo x div 5
```
Compile this with `nim js`
```js
var x_369098753 = 12;
rawEcho(HEX24_285212699(((x_369098753 / 5) )));
```
```
2.4
```
After this PR
```js
var x_369098753 = 12;
rawEcho(HEX24_285212699(Math.trunc(((x_369098753 / 5) ))));
```
```
2
```