### PR TITLE
refs #16702 make DirSep + friends work with cross-compilation and VM

### DIFF
--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -19,6 +19,10 @@ proc setResult*(a: VmArgs; v: bool) =
   let v = v.ord
   setX(rkInt, intVal)
 
+proc setResult*(a: VmArgs; v: char) =
+  let v = v.ord
+  setX(rkInt, intVal)
+
 proc setResult*(a: VmArgs; v: string) =
   a.slots[a.ra].ensureKind(rkNode)
   a.slots[a.ra].node = newNode(nkStrLit)

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -19,7 +19,7 @@ when declared(math.copySign):
 when declared(math.signbit):
   from math import signbit
 
-from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename
+from os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir, getAppFilename, DirSep
 from md5 import getMD5
 from sighashes import symBodyDigest
 from times import cpuTime
@@ -220,6 +220,9 @@ proc registerAdditionalOps*(c: PCtx) =
 
   registerCallback c, "stdlib.os.getCurrentCompilerExe", proc (a: VmArgs) {.nimcall.} =
     setResult(a, getAppFilename())
+
+  registerCallback c, "stdlib.os.dirSepImpl", proc (a: VmArgs) {.nimcall.} =
+    setResult(a, DirSep())
 
   registerCallback c, "stdlib.macros.symBodyHash", proc (a: VmArgs) =
     let n = getNode(a, 0)

--- a/lib/pure/includes/osseps.nim
+++ b/lib/pure/includes/osseps.nim
@@ -24,15 +24,19 @@ const
     ##
     ## For example: `".."` for POSIX or `"::"` for the classic Macintosh.
 
-  DirSep* =
-    when defined(macos): ':'
-    elif doslikeFileSystem or defined(vxworks): '\\'
-    elif defined(RISCOS): '.'
-    else: '/'
-    ## The character used by the operating system to separate pathname
-    ## components, for example: `'/'` for POSIX, `':'` for the classic
-    ## Macintosh, and `'\\'` on Windows.
+proc dirSepImpl(): char {.inline.} =
+  when defined(macos): ':'
+  elif doslikeFileSystem or defined(vxworks): '\\'
+  elif defined(RISCOS): '.'
+  else: '/'
 
+template DirSep*(): untyped = dirSepImpl()
+  ## The character used by the operating system to separate pathname
+  ## components, for example: `'/'` for POSIX, `':'` for the classic
+  ## Macintosh, and `'\\'` on Windows.
+  # xxx: simplify this pattern, allowing `vmops` to apply to const symbols instead of just procs
+
+const
   AltSep* =
     when doslikeFileSystem: '/'
     else: DirSep

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -507,7 +507,7 @@ proc parentDir*(path: string): string {.
       assert parentDir("/./foo//./") == "/"
       assert parentDir("a//./") == "."
       assert parentDir("a/b/c/..") == "a"
-  result = pathnorm.normalizePath(path)
+  result = pathnorm.normalizePath(path, DirSep)
   var sepPos = parentDirPos(result)
   if sepPos >= 0:
     result = substr(result, 0, sepPos)

--- a/tests/misc/tcross_compilation.nim
+++ b/tests/misc/tcross_compilation.nim
@@ -1,0 +1,28 @@
+discard """
+  cmd: "nim $target --os:windows --compileonly $file"
+  action: compile
+  disabled: windows # so that test runs on posix host but windows target
+"""
+
+# xxx add a way to test this at RT to make sure windows semantics are used.
+
+import os, strutils
+
+proc main() =
+  doAssert not defined(posix)
+  doAssert defined(windows)
+  doAssert "foo" / "bar" == "foo/bar"
+  const s = currentSourcePath
+  doAssert '\\' notin s
+  doAssert '/' in s
+  doAssert DirSep == '/'
+  let s2 = currentSourcePath
+  doAssert s2 == s
+  let s3 = s2.parentDir / "baz"
+  doAssert s3.endsWith "tests/misc/baz"
+  doAssert s3.isAbsolute
+
+static: main()
+main()
+  # the doAsserts inside here would need to be adjusted, this is just used
+  # to make sure it compiles without `static`

--- a/tests/misc/tcross_compilation.nim
+++ b/tests/misc/tcross_compilation.nim
@@ -9,18 +9,19 @@ discard """
 import os, strutils
 
 proc main() =
-  doAssert not defined(posix)
-  doAssert defined(windows)
-  doAssert "foo" / "bar" == "foo/bar"
-  const s = currentSourcePath
-  doAssert '\\' notin s
-  doAssert '/' in s
-  doAssert DirSep == '/'
-  let s2 = currentSourcePath
-  doAssert s2 == s
-  let s3 = s2.parentDir / "baz"
-  doAssert s3.endsWith "tests/misc/baz"
-  doAssert s3.isAbsolute
+  block: # bug #16702
+    doAssert not defined(posix)
+    doAssert defined(windows)
+    doAssert "foo" / "bar" == "foo/bar"
+    const s = currentSourcePath
+    doAssert '\\' notin s
+    doAssert '/' in s
+    doAssert DirSep == '/'
+    let s2 = currentSourcePath
+    doAssert s2 == s
+    let s3 = s2.parentDir / "baz"
+    doAssert s3.endsWith "tests/misc/baz"
+    doAssert s3.isAbsolute
 
 static: main()
 main()

--- a/tests/misc/tcross_compilation.nim
+++ b/tests/misc/tcross_compilation.nim
@@ -4,11 +4,19 @@ discard """
   disabled: windows # so that test runs on posix host but windows target
 """
 
+#[
+Tests for cross compilation.
+]#
+
 # xxx add a way to test this at RT to make sure windows semantics are used.
 
 import os, strutils
 
 proc main() =
+  block:
+    const dir = "foo" / "bar"
+    static: doAssert dir == "foo/bar"
+
   block: # bug #16702
     doAssert not defined(posix)
     doAssert defined(windows)


### PR DESCRIPTION
**warning:** I'm not necessarily endorsing this approach, but it's one of the options worth considering.

refs https://github.com/nim-lang/Nim/issues/16702

investigates one approach to solve cross-compilation problems involving semantics mismatch between CT and RT. Doesn't fix all issues obviously but this shows at least the most obvious issues can be fixed by simply adding a few key vmops.

```nim
import os

proc main()=
  echo "foo" / "bar"
  const s = currentSourcePath
  echo s
  echo currentSourcePath.parentDir
  echo s.parentDir
  echo currentSourcePath / "baz"

static: main()
main()
```

## this works:
`nim c -f --os:windows --skipparentcfg --skipusercfg --compileonly main`

foo/bar
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11799.nim
/Users/timothee/git_clone/nim/timn/tests/nim/all
/Users/timothee/git_clone/nim/timn/tests/nim/all
/Users/timothee/git_clone/nim/timn/tests/nim/all/t11799.nim/baz

## this gives errors because I don't have a cross compilation toolchain for windows on osx
`nim r -f --os:windows --skipparentcfg --skipusercfg main`

on osx this shows:
```
/Users/timothee/.cache/nim/t11799_d/stdlib_io.nim.c:11:10: fatal error: 'io.h' file not found
#include <io.h>
         ^~~~~~
/Users/timothee/.cache/nim/t11799_d/stdlib_system.nim.c:13:10: fatal error: 'windows.h' file not found
#include <windows.h>
         ^~~~~~~~~~~
/Users/timothee/.cache/nim/t11799_d/stdlib_dynlib.nim.c:11:10: fatal error: 'windows.h' file not found
#include <windows.h>
         ^~~~~~~~~~~
```

which (ignoring errors because i don't have the windows headers on my system) shows that such an approach might work

@jangko
* could you please try this and run the generated code on windows to see if it has windows semantics at RT?
* *what's the simplest way to get a working cross compilation windows toolchain (headers, etc) working on osx?

## future work
This could be further simplified by extending vmops to work in more contexts, including const, so that if a const is used in an already static context, it'd use the vmops definition if present.
