### PR TITLE
unbundle fusion

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -126,10 +126,6 @@ jobs:
         shell: bash
         run: ./koch boot -d:release
 
-      - name: 'Clone fusion'
-        shell: bash
-        run: ./koch fusion
-
       - name: 'Build documentation'
         shell: bash
         run: ./koch doc --git.commit:devel

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -126,10 +126,6 @@ jobs:
         shell: bash
         run: ./koch boot -d:release
 
-      - name: './koch fusion'
-        shell: bash
-        run: ./koch fusion
-
       - name: 'Build documentation'
         shell: bash
         run: ./koch doc --git.commit:devel

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -126,6 +126,10 @@ jobs:
         shell: bash
         run: ./koch boot -d:release
 
+      - name: './koch fusion'
+        shell: bash
+        run: ./koch fusion
+
       - name: 'Build documentation'
         shell: bash
         run: ./koch doc --git.commit:devel

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ testament.db
 /tests/**/*.js
 /csources
 /dist/
-/lib/fusion
+# /lib/fusion # fusion is now unbundled; `git status` should reveal if it's there so users can act on it
 
 # Private directories and files (IDEs)
 .*/

--- a/changelog.md
+++ b/changelog.md
@@ -187,3 +187,6 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
   - cell alignment is not supported, i.e. alignment annotations in a delimiter
     row (`:---`, `:--:`, `---:`) are ignored,
   - every table row must start with `|`, e.g. `| cell 1 | cell 2 |`.
+
+- `fusion` is now un-bundled from nim, `./koch fusion` will result in an error.
+  `nimble install fusion` should be used instead.

--- a/changelog.md
+++ b/changelog.md
@@ -188,5 +188,5 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
     row (`:---`, `:--:`, `---:`) are ignored,
   - every table row must start with `|`, e.g. `| cell 1 | cell 2 |`.
 
-- `fusion` is now un-bundled from nim, `./koch fusion` will result in an error.
-  `nimble install fusion` should be used instead.
+- `fusion` is now un-bundled from nim, `./koch fusion` will
+  install it via nimble at a fixed hash.

--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -76,7 +76,6 @@ Files: "lib"
 [Other]
 Files: "examples"
 Files: "dist/nimble"
-Files: "dist/fusion"
 
 Files: "tests"
 

--- a/koch.nim
+++ b/koch.nim
@@ -11,7 +11,6 @@
 
 const
   NimbleStableCommit = "324de9202fb3db82b266e7350731d1ec41013a2b" # master
-  FusionStableCommit = "372ee4313827ef9f2ea388840f7d6b46c2b1b014"
 
 when not defined(windows):
   const
@@ -181,7 +180,6 @@ proc bundleWinTools(args: string) =
                options = r"--cc:vcc --app:gui -d:ssl --noNimblePath --path:..\ui " & args)
 
 proc zip(latest: bool; args: string) =
-  bundleFusion(latest)
   bundleNimbleExe(latest, args)
   bundleNimsuggest(args)
   bundleNimpretty(args)
@@ -221,7 +219,6 @@ proc buildTools(args: string = "") =
                  options = "-d:release " & args)
 
 proc nsis(latest: bool; args: string) =
-  bundleFusion(latest)
   bundleNimbleExe(latest, args)
   bundleNimsuggest(args)
   bundleWinTools(args)
@@ -688,7 +685,6 @@ when isMainModule:
       of "tools":
         buildTools(op.cmdLineRest)
         bundleNimbleExe(latest, op.cmdLineRest)
-        bundleFusion(latest)
       of "pushcsource", "pushcsources": pushCsources()
       of "valgrind": valgrind(op.cmdLineRest)
       of "c2nim": bundleC2nim(op.cmdLineRest)

--- a/koch.nim
+++ b/koch.nim
@@ -12,7 +12,7 @@
 const
   NimbleStableCommit = "324de9202fb3db82b266e7350731d1ec41013a2b" # master
   # examples of possible values: #head, #ea82b54, 1.2.3
-  FusionStableCommitHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
+  FusionStableHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
   HeadHash = "#head"
 when not defined(windows):
   const
@@ -693,7 +693,7 @@ when isMainModule:
       of "c2nim": bundleC2nim(op.cmdLineRest)
       of "drnim": buildDrNim(op.cmdLineRest)
       of "fusion":
-        let suffix = if latest: HeadHash else: FusionStableCommitHash
+        let suffix = if latest: HeadHash else: FusionStableHash
         exec("nimble install -y fusion@$#" % suffix)
       else: showHelp()
       break

--- a/koch.nim
+++ b/koch.nim
@@ -11,7 +11,9 @@
 
 const
   NimbleStableCommit = "324de9202fb3db82b266e7350731d1ec41013a2b" # master
-
+  # examle of possible values: #head, #ea82b54, 1.2.3
+  FusionStableCommitHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
+  HeadHash = "#head"
 when not defined(windows):
   const
     Z3StableCommit = "65de3f748a6812eecd7db7c478d5fc54424d368b" # the version of Z3 that DrNim uses
@@ -65,6 +67,7 @@ Possible Commands:
                            e.g. nimble)
                            doesn't require network connectivity
   nimble                   builds the Nimble tool
+  fusion                   installs fusion via Nimble
 
 Boot options:
   -d:release               produce a release version of the compiler
@@ -689,7 +692,9 @@ when isMainModule:
       of "valgrind": valgrind(op.cmdLineRest)
       of "c2nim": bundleC2nim(op.cmdLineRest)
       of "drnim": buildDrNim(op.cmdLineRest)
-      of "fusion": doAssert false, "`./koch fusion` was deprecated, use `nimble install fusion` instead"
+      of "fusion":
+        let suffix = if latest: HeadHash else: FusionStableCommitHash
+        exec("nimble install -y fusion@$#" % suffix)
       else: showHelp()
       break
     of cmdEnd: break

--- a/koch.nim
+++ b/koch.nim
@@ -11,7 +11,7 @@
 
 const
   NimbleStableCommit = "324de9202fb3db82b266e7350731d1ec41013a2b" # master
-  # examle of possible values: #head, #ea82b54, 1.2.3
+  # examples of possible values: #head, #ea82b54, 1.2.3
   FusionStableCommitHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
   HeadHash = "#head"
 when not defined(windows):

--- a/koch.nim
+++ b/koch.nim
@@ -66,7 +66,7 @@ Possible Commands:
                            e.g. nimble)
                            doesn't require network connectivity
   nimble                   builds the Nimble tool
-  fusion                   clone fusion into the working tree
+
 Boot options:
   -d:release               produce a release version of the compiler
   -d:nimUseLinenoise       use the linenoise library for interactive mode
@@ -179,12 +179,6 @@ proc bundleWinTools(args: string) =
     # not yet a tool worth including
     nimCompile(r"tools\downloader.nim",
                options = r"--cc:vcc --app:gui -d:ssl --noNimblePath --path:..\ui " & args)
-
-proc bundleFusion(latest: bool) =
-  let commit = if latest: "HEAD" else: FusionStableCommit
-  cloneDependency(distDir, "https://github.com/nim-lang/fusion.git", commit,
-                  allowBundled = true)
-  copyDir(distDir / "fusion" / "src" / "fusion", "lib" / "fusion")
 
 proc zip(latest: bool; args: string) =
   bundleFusion(latest)
@@ -699,7 +693,7 @@ when isMainModule:
       of "valgrind": valgrind(op.cmdLineRest)
       of "c2nim": bundleC2nim(op.cmdLineRest)
       of "drnim": buildDrNim(op.cmdLineRest)
-      of "fusion": bundleFusion(latest)
+      of "fusion": doAssert false, "`./koch fusion` was deprecated, use `nimble install fusion` instead"
       else: showHelp()
       break
     of cmdEnd: break

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -190,7 +190,7 @@ lib/system/widestrs.nim
   proc follow(a: PathEntry): bool =
     result = a.path.lastPathPart notin ["nimcache", htmldocsDirname,
                                         "includes", "deprecated", "genode"] and
-      not a.path.isRelativeTo("lib/fusion")
+      not a.path.isRelativeTo("lib/fusion") # fusion was un-bundled but we need to keep this in case user has it installed
   for entry in walkDirRecFilter("lib", follow = follow):
     let a = entry.path
     if entry.kind != pcFile or a.splitFile.ext != ".nim" or


### PR DESCRIPTION
fixes https://github.com/nim-lang/fusion/issues/25

`nimble install fusion` or `--path:/pathto/fusion/src` or `--path:fusion:/pathto/fusion/src/fusion` (https://github.com/nim-lang/RFCs/issues/291) (and possibly with a fixed hash/tag `nimble install fusion@#1234`) is a much saner approach than copying fusion sources (at a fixed hash) to `$nim/lib/fusion`, which can only cause problems down the line when user also has `nimble install fusion` as it'd lead to duplicate fusion modules (eg: link error if there's an exportc symbol, or surprising module resolution in case of `import fusion/foo`)

note, this doesn't preclude using fusion from within `tools/` or `compiler/` (refs https://github.com/nim-lang/fusion/issues/22), in fact it makes it easier to, by avoiding the above mentioned issues of potential duplicate modules.

## future work
* add fusion to important_packages.nim, just like other regular nimble packages
* start adopting semver in fusion just like any other nimble package (refs https://github.com/nim-lang/fusion/issues/30)

## links
> The current plan is that we don't bundle Fusion anymore with Nim

https://github.com/nim-lang/Nim/pull/16875#issuecomment-775934298