### PR TITLE
nep1: prefer `self` to `this`

### DIFF
--- a/doc/nep1.rst
+++ b/doc/nep1.rst
@@ -162,10 +162,13 @@ to keep the names short but meaningful.
 -------------------     ------------   --------------------------------------
 English word            To use         Notes
 -------------------     ------------   --------------------------------------
-initialize              initT          ``init`` is used to create a
-                                       value type ``T``
-new                     newP           ``new`` is used to create a
-                                       reference type ``P``
+initialize              initFoo        initializes a value type ``Foo``
+new                     newFoo         initializes a reference type ``Foo``
+                                       via ``new``
+this or self            self           for method like procs, e.g.:
+                                       `proc fun(self: Foo, a: int)`
+                                       rationale: `self` is more unique in english
+                                       than `this`, and `foo` would not be DRY.
 find                    find           should return the position where
                                        something was found; for a bool result
                                        use ``contains``


### PR DESCRIPTION
settles [Anybody using `self` or `this` for procedures operating on "class" style object types? - Nim forum](https://forum.nim-lang.org/t/7465)

## rationale
* self is better (more DRY) than repeating type name with underscore:
```nim
proc fun(someLongTypeName: SomeLongTypeName, a: int)
```
* `self` is more common than `this` for this purpose:
in nim repo:
rg '\(this: '| wc -l
      56
rg '\(self: '| wc -l
     235
* `self` is more searchable than `this` because `this` is more common in english:

crude stats because some references might correspond to this as a param name, but still illustrative:
```
rg '\bthis\b' | wc -l
    3580
rg '\bself\b' | wc -l
     764
```

* 50-50 argument: `self` is common in python (but this is common in js)

## future work
- [ ] see https://github.com/nim-lang/Nim/pull/16927#issuecomment-772841888