### PR TITLE
VM: 'nim e' etc, default to the VM's sandboxing behaviour

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -59,7 +59,7 @@ proc loadConfigsAndProcessCmdLine*(self: NimProg, cache: IdentCache; conf: Confi
                                    graph: ModuleGraph): bool =
   if self.suggestMode:
     conf.setCmd cmdIdeTools
-  if conf.cmd == cmdNimscript:
+  if conf.cmd in {cmdNimscriptSecure, cmdNimscriptDanger}:
     incl(conf.globalOptions, optWasNimscript)
   loadConfigs(DefaultConfig, cache, conf, graph.idgen) # load all config files
 
@@ -67,8 +67,8 @@ proc loadConfigsAndProcessCmdLine*(self: NimProg, cache: IdentCache; conf: Confi
     let scriptFile = conf.projectFull.changeFileExt("nims")
     # 'nim foo.nims' means to just run the NimScript file and do nothing more:
     if fileExists(scriptFile) and scriptFile == conf.projectFull:
-      if conf.cmd == cmdNone: conf.setCmd cmdNimscript
-      if conf.cmd == cmdNimscript: return false
+      if conf.cmd == cmdNone: conf.setCmd cmdNimscriptSecure
+      if conf.cmd == cmdNimscriptSecure: return false
   # now process command line arguments again, because some options in the
   # command line can overwrite the config file's settings
   extccomp.initVars(conf)

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -330,7 +330,7 @@ proc mainCommand*(graph: ModuleGraph) =
     commandView(graph)
     #msgWriteln(conf, "Beware: Indentation tokens depend on the parser's state!")
   of cmdInteractive: commandInteractive(graph)
-  of cmdNimscript:
+  of cmdNimscriptSecure, cmdNimscriptDanger:
     if conf.projectIsCmd or conf.projectIsStdin: discard
     elif not fileExists(conf.projectFull):
       rawMessage(conf, errGenerated, "NimScript file does not exist: " & conf.projectFull.string)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -64,7 +64,8 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
       if processArgument(pass, p, argsCount, config): break
   if pass == passCmd2:
     if {optRun, optWasNimscript} * config.globalOptions == {} and
-        config.arguments.len > 0 and config.cmd notin {cmdTcc, cmdNimscript, cmdCrun}:
+        config.arguments.len > 0 and
+        config.cmd notin {cmdTcc, cmdNimscriptSecure, cmdNimscriptDanger, cmdCrun}:
       rawMessage(config, errGenerated, errArgsNeedRunOption)
 
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -125,7 +125,8 @@ type
     cmdParse # parse a single file (for debugging)
     cmdRod # .rod to some text representation (for debugging)
     cmdIdeTools # ide tools (e.g. nimsuggest)
-    cmdNimscript # evaluate nimscript
+    cmdNimscriptSecure # evaluate nimscript
+    cmdNimscriptDanger # evaluate nimscript including 'gorge' and 'writeFile'
     cmdDoc0
     cmdDoc2
     cmdRst2html # convert a reStructuredText file to HTML

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -1710,7 +1710,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
       inc pc
       let rd = c.code[pc].regA
       createStr regs[ra]
-      if defined(nimsuggest) or c.config.cmd == cmdCheck:
+      if defined(nimsuggest) or c.config.cmd in {cmdCheck, cmdNimscriptSecure}:
         discard "don't run staticExec for 'nim suggest'"
         regs[ra].node.strVal = ""
       else:

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -92,7 +92,7 @@ template wrap2svoid(op, modop) {.dirty.} =
   modop op
 
 template wrapDangerous(op, modop) {.dirty.} =
-  if vmopsDanger notin c.config.features and (defined(nimsuggest) or c.config.cmd == cmdCheck):
+  if vmopsDanger notin c.config.features and (defined(nimsuggest) or c.config.cmd in {cmdCheck, cmdNimscriptSecure}):
     proc `op Wrapper`(a: VmArgs) {.nimcall.} =
       discard
     modop op
@@ -212,7 +212,7 @@ proc registerAdditionalOps*(c: PCtx) =
       registerCallback c, "stdlib.compilesettings.querySettingSeq", proc (a: VmArgs) =
         setResult(a, querySettingSeqImpl(c.config, getInt(a, 0)))
 
-    if defined(nimsuggest) or c.config.cmd == cmdCheck:
+    if defined(nimsuggest) or c.config.cmd in {cmdCheck, cmdNimscriptSecure}:
       discard "don't run staticExec for 'nim suggest'"
     else:
       systemop gorgeEx

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -3,7 +3,8 @@ Advanced commands:
   //compileToCpp, cpp       compile project to C++ code
   //compileToOC, objc       compile project to Objective C code
   //js                      compile project to Javascript
-  //e                       run a Nimscript file
+  //e                       run a Nimscript file in the sandbox
+  //edanger                 run a Nimscript file **without** the sandbox
   //rst2html                convert a reStructuredText file to HTML
                             use `--docCmd:skip` to skip compiling snippets
   //rst2tex                 convert a reStructuredText file to TeX


### PR DESCRIPTION
- affects Nimble's Nimscript integration
- New default is the sandboxed VM.
- Use 'nim edanger' to run without the sandbox.

