### PR TITLE
Add initRand() with seed based on time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -124,6 +124,8 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
   (instead of skipping them sometimes as it was before).
 - Added optional `followSymlinks` argument to `setFilePermissions`.
 
+- Added `random.initRand()` overload with no argument which uses the current time as a seed.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -635,25 +635,43 @@ proc shuffle*[T](x: var openArray[T]) =
 
 when not defined(nimscript) and not defined(standalone):
   import times
+  
+  proc initRand(): Rand =
+    ## Initializes a new Rand state with a seed based on the current time.
+    ##
+    ## The resulting state is independent of the default random number generator's state.
+    ##
+    ## **Note:** Does not work for NimScript or the compile-time VM.
+    ##
+    ## See also:
+    ## * `initRand proc<#initRand,int64>`_ that accepts a seed for a new Rand state
+    ## * `randomize proc<#randomize>`_ that initializes the default random
+    ##   number generator using the current time
+    ## * `randomize proc<#randomize,int64>`_ that accepts a seed for the default
+    ##   random number generator
+    when defined(js):
+      let time = int64(times.epochTime() * 1000) and 0x7fff_ffff
+      result = initRand(time)
+    else:
+      let now = times.getTime()
+      result = initRand(convert(Seconds, Nanoseconds, now.toUnix) + now.nanosecond)
+  
+  since (1, 5, 1):
+    export initRand
 
   proc randomize*() {.benign.} =
-    ## Initializes the default random number generator with a value based on
+    ## Initializes the default random number generator with a seed based on
     ## the current time.
     ##
     ## This proc only needs to be called once, and it should be called before
     ## the first usage of procs from this module that use the default random
     ## number generator.
     ##
-    ## **Note:** Does not work for NimScript.
+    ## **Note:** Does not work for NimScript or the compile-time VM.
     ##
     ## See also:
     ## * `randomize proc<#randomize,int64>`_ that accepts a seed
     ## * `initRand proc<#initRand,int64>`_
-    when defined(js):
-      let time = int64(times.epochTime() * 1000) and 0x7fff_ffff
-      randomize(time)
-    else:
-      let now = times.getTime()
-      randomize(convert(Seconds, Nanoseconds, now.toUnix) + now.nanosecond)
+    state = initRand()
 
 {.pop.}

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -566,6 +566,7 @@ proc initRand*(seed: int64): Rand =
   ## generator's state.
   ##
   ## See also:
+  ## * `initRand proc<#initRand>`_ that uses the current time
   ## * `randomize proc<#randomize,int64>`_ that accepts a seed for the default
   ##   random number generator
   ## * `randomize proc<#randomize>`_ that initializes the default random
@@ -589,8 +590,11 @@ proc randomize*(seed: int64) {.benign.} =
   ## the same results for that seed each time.
   ##
   ## See also:
-  ## * `initRand proc<#initRand,int64>`_
+  ## * `initRand proc<#initRand,int64>`_ that initializes a Rand state
+  ##   with a given seed
   ## * `randomize proc<#randomize>`_ that uses the current time instead
+  ## * `initRand proc<#initRand>`_ that initializes a Rand state using
+  ##   the current time
   runnableExamples:
     from times import getTime, toUnix, nanosecond
 
@@ -671,7 +675,10 @@ when not defined(nimscript) and not defined(standalone):
     ##
     ## See also:
     ## * `randomize proc<#randomize,int64>`_ that accepts a seed
-    ## * `initRand proc<#initRand,int64>`_
+    ## * `initRand proc<#initRand>`_ that initializes a Rand state using
+    ##   the current time
+    ## * `initRand proc<#initRand,int64>`_ that initializes a Rand state
+    ##   with a given seed
     state = initRand()
 
 {.pop.}


### PR DESCRIPTION
I assumed there was a reason for this not existing, but now I'm not sure. This proc saves a `times` import and possible incorrect implementations from `Rand` initializations that want to use the current time, but don't want to use the global random state. Is there a reason this only exists for `randomize`?

The `randomize` with default time seed isn't tested, so I'm assuming this can't be tested either. Will add changelog entry after possible changes are considered

## future work
EDIT(timotheecour)
- [ ] use monotimes.getMonoTime instead, which has higher resolution.
Otherwise, low res means lower quality initRand() (esp for multiple threads which would have their numbers more correlated, etc)
- [ ] remove dependency on times (a heavy dependency) and use system/timers directly after we address https://github.com/timotheecour/Nim/issues/572
- [ ] std/oids also needs to be updated, ideally calling common refactored code (possibly via some `std/private/x` if needed) in 2 places:
```nim
let t = getTime().toUnix.int32
...
var time = getTime().toUnix.int32
```
- [ ] after this is fixed, we can add tests for initRand (it fails currently because of poor resolution):
```nim
  block: # initRand
    for i in 0..<100:
      var r1 = initRand()
      var r2 = initRand()
      doAssert r1.rand(0..high(int)) != r2.rand(0..high(int)), $i
```
- [ ] this should work in VM (at least with --experimental:vmops enabled)
- [ ] maybe also `randomize` could use the upcoming std/sysrand [add system random to stdlib by xflywind · Pull Request #16459 · nim-lang/Nim](https://github.com/nim-lang/Nim/pull/16459)

## links
* https://github.com/nim-lang/Nim/issues/8588
* https://dlang.org/library/std/random/unpredictable_seed.html
* [unpredictableSeed - D Programming Language Discussion Forum](https://forum.dlang.org/post/mailman.166.1362246057.14496.digitalmars-d-learn@puremagic.com)
> Process ID, thread ID and system tick
