### PR TITLE
avoid doAssert on contents of osReleaseFile

### DIFF
--- a/lib/posix/posix_utils.nim
+++ b/lib/posix/posix_utils.nim
@@ -120,7 +120,7 @@ proc osReleaseFile*(): Config {.since: (1, 5).} =
     import parsecfg
     when defined(linux):
       let data = osReleaseFile()
-      doAssert data.getSectionValue("", "NAME").len > 0 ## the data is up to each distro.
+      echo "OS name: ", data.getSectionValue("", "NAME") ## the data is up to each distro.
 
   # We do not use a {.strdefine.} because Standard says it *must* be that path.
   for osReleaseFile in ["/etc/os-release", "/usr/lib/os-release"]:


### PR DESCRIPTION
On my Linux OS, both of these files exist
https://github.com/nim-lang/Nim/blob/065264eae1785b3cfb63840745df63b83fbd330b/lib/posix/posix_utils.nim#L126
but only `/usr/lib/os-release` contains a line beginning with `NAME=`. Because `osReleaseFile()` prioritizes `/etc/os-release` (which is correct behavior, according to https://www.freedesktop.org/software/systemd/man/os-release.html), the `doAssert` in the `runnableExample` fails, causing `./koch docs` to always fail on my OS. This PR replaces the assertion with an `echo`.