### PR TITLE
add linenoise.readLineStatus to get status (eg: ctrl-D or ctrl-C)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -129,6 +129,8 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Added `random.initRand()` overload with no argument which uses the current time as a seed.
 
+- Added experimental `linenoise.readLineStatus` to get line and status (e.g. ctrl-D or ctrl-C).
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -12,16 +12,18 @@
 ## (e.g. you can navigate with the arrow keys). On Windows ``system.readLine``
 ## is used. This suffices because Windows' console already provides the
 ## wanted functionality.
-##
-## **Examples:**
-##
-## .. code-block:: nim
-##   echo readLineFromStdin("Is Nim awesome? (Y/n):")
-##   var userResponse: string
-##   doAssert readLineFromStdin("How are you?:", line = userResponse)
-##   echo userResponse
 
-when defined(Windows):
+runnableExamples:
+  if false:
+    echo readLineFromStdin("Is Nim awesome? (Y/n): ")
+    var line: string
+    while true:
+      let ok = readLineFromStdin("How are you? ", line)
+      if not ok: break # ctrl-C or ctrl-D will cause a break
+      if line.len > 0: echo line
+    echo "exiting"
+
+when defined(windows):
   proc readLineFromStdin*(prompt: string): string {.
                           tags: [ReadIOEffect, WriteIOEffect].} =
     ## Reads a line from stdin.

--- a/lib/wrappers/linenoise/linenoise.h
+++ b/lib/wrappers/linenoise/linenoise.h
@@ -48,6 +48,16 @@ typedef struct linenoiseCompletions {
   char **cvec;
 } linenoiseCompletions;
 
+typedef enum linenoiseStatus {
+  linenoiseStatus_ctrl_unknown,
+  linenoiseStatus_ctrl_C,
+  linenoiseStatus_ctrl_D
+} linenoiseStatus;
+
+typedef struct linenoiseData {
+  linenoiseStatus status;
+} linenoiseData;
+
 typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
 typedef char*(linenoiseHintsCallback)(const char *, int *color, int *bold);
 typedef void(linenoiseFreeHintsCallback)(void *);
@@ -57,6 +67,7 @@ void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
 void linenoiseAddCompletion(linenoiseCompletions *, const char *);
 
 char *linenoise(const char *prompt);
+char *linenoiseExtra(const char *prompt, linenoiseData* data);
 void linenoiseFree(void *ptr);
 int linenoiseHistoryAdd(const char *line);
 int linenoiseHistorySetMaxLen(int len);

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -9,7 +9,7 @@
 
 type
   Completions* = object
-    len*: csize
+    len*: csize_t
     cvec*: cstringArray
 
   CompletionCallback* = proc (a2: cstring; a3: ptr Completions) {.cdecl.}
@@ -32,3 +32,40 @@ proc printKeyCodes*() {.importc: "linenoisePrintKeyCodes".}
 
 proc free*(s: cstring) {.importc: "free", header: "<stdlib.h>".}
 
+when defined nimExperimentalLinenoiseExtra:
+  # C interface
+  type linenoiseStatus = enum
+    linenoiseStatus_ctrl_unknown
+    linenoiseStatus_ctrl_C
+    linenoiseStatus_ctrl_D
+
+  type linenoiseData* = object
+    status: linenoiseStatus
+
+  proc linenoiseExtra(prompt: cstring, data: ptr linenoiseData): cstring {.importc.}
+
+  # stable nim interface
+  type Status* = enum
+    lnCtrlUnkown
+    lnCtrlC
+    lnCtrlD
+
+  type ReadLineResult* = object
+    line*: string
+    status*: Status
+
+  proc readLineStatus*(prompt: string, result: var ReadLineResult) =
+    ## line editing API that allows returning the line status
+    runnableExamples("-d:nimExperimentalLinenoiseExtra"):
+      if false:
+        var ret: ReadLineResult
+        while true:
+          readLineStatus("name: ", ret) # ctrl-D will exit, ctrl-C will go to next prompt
+          if ret.line.len > 0: echo ret.line
+          if ret.status == lnCtrlD: break
+        echo "exiting"
+    var data: linenoiseData
+    let buf = linenoiseExtra(prompt, data.addr)
+    result.line = $buf
+    free(buf)
+    result.status = data.status.ord.Status

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -55,7 +55,9 @@ when defined nimExperimentalLinenoiseExtra:
     status*: Status
 
   proc readLineStatus*(prompt: string, result: var ReadLineResult) =
-    ## line editing API that allows returning the line status
+    ## line editing API that allows returning the line entered and an indicator
+    ## of which control key was entered, allowing user to distinguish between
+    ## for example ctrl-C vs ctrl-D.
     runnableExamples("-d:nimExperimentalLinenoiseExtra"):
       if false:
         var ret: ReadLineResult


### PR DESCRIPTION
* close https://github.com/nim-lang/Nim/issues/5795 by providing a suitable workaround; since we're now returning a status indicator, user can forward this to call into `exitHandler` if status was ctrl-C for example
* allows fixing `nim secret` being un-quittable, as described in https://github.com/timotheecour/Nim/issues/533: in a next PR, we can use the new API `readLineStatus` and exit the nim secret REPL if status was ctrl-D
* allows user to implement a very common shell/REPL feature (found in bash, python, and pretty much all REPL I've used) which is to quit the REPL loop on ctrl-D, but just abort the prompt and go to next prompt on ctrl-C without exiting the loop

## note
* another recent linenoise PR was closed see https://github.com/nim-lang/Nim/pull/16451#issuecomment-750426884
> Please rewrite all the C code in Nim. We don't need more "static" variables, it's a desaster for multi-threading.

however this PR doesn't add more static variables, insted the state is propagated as a side variable allocated on the stack.

* This is a small diff on the c side and the re-implementing in nim could be handled later; furthermore it's not clear re-implementing in nim is the correct approach, instead we should leverage nimble packages (eg https://github.com/jangko/nim-noise or https://github.com/de-odex/linenoise-nim) as described in https://github.com/nim-lang/Nim/pull/16451#issuecomment-750759693

* I'm using the `nimExperimentalFoo` pattern described in https://github.com/timotheecour/Nim/issues/575

## links
* https://fossies.org/linux/txr/linenoise/linenoise.h seems to have a `lino_error` exposed which has a similar goal, but this is a different port
```
   40 typedef enum lino_error {
   41     lino_no_error,      /* No error has occurred. */
   42     lino_error,         /* Unspecified error */
   43     lino_eof,           /* Line input terminated by Ctrl-D or EOF. */
   44     lino_ioerr,         /* Line input terminated by I/O error. */
   45     lino_notty,         /* Input is not a terminal. */
   46     lino_intr           /* Line innput terminated by Ctrl-C or interrupt */
   47 } lino_error_t;
```

* see also https://github.com/jangko/nim-noise/issues/18 (similar thing for pkg nim-noise

## future work
- [x] make `nim secret` + friends recognize ctrl-D => https://github.com/nim-lang/Nim/pull/18442
> allows fixing nim secret being un-quittable, as described in timotheecour#533: in a next PR, we can use the new API readLineStatus and exit the nim secret REPL if status was ctrl-D
