### PR TITLE
[backport:1.4] JS cstring null fixes

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2055,23 +2055,23 @@ proc genMagic(p: PProc, n: PNode, r: var TCompRes) =
   of mDestroy: discard "ignore calls to the default destructor"
   of mOrd: genOrd(p, n, r)
   of mLengthStr, mLengthSeq, mLengthOpenArray, mLengthArray:
+    var x: TCompRes
+    gen(p, n[1], x)
     if skipTypes(n[1].typ, abstractInst).kind == tyCString:
-      var x: TCompRes
-      gen(p, n[1], x)
       let (a, tmp) = maybeMakeTemp(p, n[1], x)
       r.res = "(($1) == null ? 0 : ($2).length)" % [a, tmp]
-      r.kind = resExpr
     else:
-      unaryExpr(p, n, r, "", "($1).length")
+      r.res = "($1).length" % [x.rdLoc]
+    r.kind = resExpr
   of mHigh:
+    var x: TCompRes
+    gen(p, n[1], x)
     if skipTypes(n[1].typ, abstractInst).kind == tyCString:
-      var x: TCompRes
-      gen(p, n[1], x)
       let (a, tmp) = maybeMakeTemp(p, n[1], x)
-      r.res = "(($1) == null ? -1 : ($2).length-1)" % [a, tmp]
-      r.kind = resExpr
+      r.res = "(($1) == null ? -1 : ($2).length - 1)" % [a, tmp]
     else:
-      unaryExpr(p, n, r, "", "(($1).length - 1)")
+      r.res = "($1).length - 1" % [x.rdLoc]
+    r.kind = resExpr
   of mInc:
     if n[1].typ.skipTypes(abstractRange).kind in {tyUInt..tyUInt64}:
       binaryUintExpr(p, n, r, "+", true)

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2029,8 +2029,14 @@ type
     when NimStackTraceMsgs:
       frameMsgLen*: int   ## end position in frameMsgBuf for this frame.
 
-when defined(js):
+when defined(js) or defined(nimdoc):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =
+    ## Appends `y` to `x` in place.
+    runnableExamples:
+      var tmp = ""
+      tmp.add(cstring("ab"))
+      tmp.add(cstring("cd"))
+      doAssert tmp == "abcd"
     asm """
       if (`x` === null) { `x` = []; }
       var off = `x`.length;
@@ -2039,7 +2045,15 @@ when defined(js):
         `x`[off+i] = `y`.charCodeAt(i);
       }
     """
-  proc add*(x: var cstring, y: cstring) {.magic: "AppendStrStr".}
+  proc add*(x: var cstring, y: cstring) {.magic: "AppendStrStr".} =
+    ## Appends `y` to `x` in place.
+    ## Only implemented for JS backend.
+    runnableExamples:
+      when defined(js):
+        var tmp: cstring = ""
+        tmp.add(cstring("ab"))
+        tmp.add(cstring("cd"))
+        doAssert tmp == cstring("abcd")
 
 elif hasAlloc:
   {.push stackTrace: off, profiler: off.}

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -645,7 +645,7 @@ proc genericReset(x: JSRef, ti: PNimType): JSRef {.compilerproc.} =
       asm "`result` = {m_type: `ti`};"
     else:
       asm "`result` = {};"
-  of tySequence, tyOpenArray:
+  of tySequence, tyOpenArray, tyString:
     asm """
       `result` = [];
     """

--- a/tests/js/tnilstrs.nim
+++ b/tests/js/tnilstrs.nim
@@ -15,3 +15,11 @@ block:
   var y: string
   add(y, x)
   doAssert y == "foo"
+
+block:
+  type Foo = object
+    a: string
+  var foo = Foo(a: "foo")
+  var y = move foo.a
+  doAssert foo.a.len == 0
+  doAssert y == "foo"

--- a/tests/system/tdollars.nim
+++ b/tests/system/tdollars.nim
@@ -71,12 +71,35 @@ block: # `$`(SomeInteger)
     testType int64
     testType BiggestInt
 
-block: # #14350 for JS
+block: # #14350, #16674, #16686 for JS
   var cstr: cstring
   doAssert cstr == cstring(nil)
   doAssert cstr == nil
   doAssert cstr.isNil
   doAssert cstr != cstring("")
+  doAssert cstr.len == 0
+
+  when defined(js):
+    cstr.add(cstring("abc"))
+    doAssert cstr == cstring("abc")
+
+    var nil1, nil2: cstring = nil
+
+    nil1.add(nil2)
+    doAssert nil1 == cstring(nil)
+    doAssert nil2 == cstring(nil)
+
+    nil1.add(cstring(""))
+    doAssert nil1 == cstring("")
+    doAssert nil2 == cstring(nil)
+
+    nil1.add(nil2)
+    doAssert nil1 == cstring("")
+    doAssert nil2 == cstring(nil)
+
+    nil2.add(nil1)
+    doAssert nil1 == cstring("")
+    doAssert nil2 == cstring("")
 
 
 proc main()=


### PR DESCRIPTION
Fixes #16674, fixes #16686

I special cased `cstring` for AppendStrStr here because it's not disruptive, but `add(var cstring, cstring)` could just be emitted/`asm`'d and not use a magic, or it could as well just not exist since it wasn't documented before and it's very easy to wrap `+=` yourself. This is good enough now though.

Also fixed `move` turning strings `null`.