### PR TITLE
fix ./koch pdf command

### DIFF
--- a/doc/koch.rst
+++ b/doc/koch.rst
@@ -81,3 +81,10 @@ be rerun in serial fashion so that meaningful error output can be gathered for
 inspection. The ``--parallelBuild:n`` switch or configuration option can be
 used to force a specific number of parallel jobs or run everything serially
 from the start (``n == 1``).
+
+pdf command
+-----------
+
+The `pdf`:idx: command builds PDF versions of Nim documentation: Manual,
+Tutorial and a few other documents. To run it one needs to
+`install Latex/pdflatex <https://www.latex-project.org/get>`_ first.


### PR DESCRIPTION
`./koch pdf` does not work for me because of paths convention changed — now `rst2tex` saves directly into `htmldocs` dir relative to the processed `*.rst` file.

(probably it started from refactoring in #14324 though I did not check that)