### PR TITLE
improve ./koch docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ deinstall.sh
 
 doc/html/
 doc/*.html
-doc/*.pdf
+doc/pdf
 doc/*.idx
 /web/upload
 /build/*

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -305,7 +305,7 @@ proc buildPdfDoc*(nimArgs, destPath: string) =
       let dst = destPath / src.lastPathPart.changeFileExt("pdf")
       pdfList.add dst
       nim2pdf(src, dst, nimArgs)
-  echo "\nOutput PDF files: \n  ", pdfList.join(" ") # because pdflatex is very verbose
+  echo "\nOutput PDF files: \n  ", pdfList.join(" ") # because `nim2pdf` is a bit verbose
 
 proc buildJS(): string =
   let nim = findNim()

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -287,10 +287,8 @@ proc nim2pdf(src: string, dst: string, nimArgs: string) =
   let outDir = "build" / "pdflatextmp" # xxx use reusable std/private/paths shared with other modules
   # note: this will generate temporary files in gitignored `outDir`: aux toc log out tex
   exec("$# rst2tex $# --outdir:$# $#" % [findNim().quoteShell(), nimArgs, outDir.quoteShell, src.quoteShell])
-  # call LaTeX twice to get cross references right:
   let texFile = outDir / src.lastPathPart.changeFileExt("tex")
-  for i in 0..<2:
-    # xxx very verbose; consider redirecting output to a log file
+  for i in 0..<2: # call LaTeX twice to get cross references right:
     let pdflatexLog = outDir / "pdflatex.log"
     # `>` should work on windows, if not, we can use `execCmdEx`
     let cmd = "pdflatex -interaction=nonstopmode -output-directory=$# $# > $#" % [outDir.quoteShell, texFile.quoteShell, pdflatexLog.quoteShell]


### PR DESCRIPTION
followup https://github.com/nim-lang/Nim/pull/16989 /cc @a-mr

* fixes points raised in https://github.com/nim-lang/Nim/pull/16989#issuecomment-776300027
* make `./koch pdf` much less verbose (instead a log file can be inspected if user ever wants to)
* all pdflatex temp files are now generated under already gitignored build/pdflatextmp (and not deleted) instead of creating them somewhere and then having to delete them
* use quoteShell as appropriate so it works with paths with spaces
* refactor so that we have a reusable simple `proc nim2pdf(src: string, dst: string, nimArgs: string)` that could later be exposed
* various other improvements

## future work
- [ ] consider exposing `nim2pdf`, eg via `nim doc2pdf main.nim|rst` to make it easier to use
- [ ] instead of having hardcoded paths (eg: "build" + many others) duplicated in several places (tools, stdlib, tests, testament), refactor via a single module `std/private/paths`; these could be absolute or relative to nim root, TBD.
