### PR TITLE
nep1: prefer `a..b` to `a .. b` except if `b` has an operator (eg: `a .. -1`)

### DIFF
--- a/doc/nep1.rst
+++ b/doc/nep1.rst
@@ -281,5 +281,5 @@ Conventions for multi-line statements and expressions
     startProcess(nimExecutable, currentDirectory, compilerArguments
                  environment, processOptions)
 
-- Use `a..b` instead of `a .. b`, except when `b` contains an operator, e.g `a .. -3`
+- Use `a..b` instead of `a .. b`, except when `b` contains an operator, for example `a .. -3`.
   Likewise with `a..<b`.

--- a/doc/nep1.rst
+++ b/doc/nep1.rst
@@ -280,3 +280,6 @@ Conventions for multi-line statements and expressions
   .. code-block:: nim
     startProcess(nimExecutable, currentDirectory, compilerArguments
                  environment, processOptions)
+
+- Use `a..b` instead of `a .. b`, except when `b` contains an operator, e.g `a .. -3`
+  Likewise with `a..<b`.

--- a/doc/nep1.rst
+++ b/doc/nep1.rst
@@ -282,4 +282,4 @@ Conventions for multi-line statements and expressions
                  environment, processOptions)
 
 - Use `a..b` instead of `a .. b`, except when `b` contains an operator, for example `a .. -3`.
-  Likewise with `a..<b`.
+  Likewise with `a..<b`, `a..^b` and other operators starting with `..`.


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/16981#discussion_r573371075

nep1 concentrates debate in 1 place instead of debating it in each PR