### PR TITLE
fix warning nim nim doc posix

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -878,14 +878,18 @@ proc CMSG_NXTHDR*(mhdr: ptr Tmsghdr, cmsg: ptr Tcmsghdr): ptr Tcmsghdr {.
 proc CMSG_FIRSTHDR*(mhdr: ptr Tmsghdr): ptr Tcmsghdr {.
   importc, header: "<sys/socket.h>".}
 
+{.push warning[deprecated]: off.}
 proc CMSG_SPACE*(len: csize): csize {.
   importc, header: "<sys/socket.h>", deprecated: "argument `len` should be of type `csize_t`".}
+{.pop.}
 
 proc CMSG_SPACE*(len: csize_t): csize_t {.
   importc, header: "<sys/socket.h>".}
 
+{.push warning[deprecated]: off.}
 proc CMSG_LEN*(len: csize): csize {.
   importc, header: "<sys/socket.h>", deprecated: "argument `len` should be of type `csize_t`".}
+{.pop.}
 
 proc CMSG_LEN*(len: csize_t): csize_t {.
   importc, header: "<sys/socket.h>".}


### PR DESCRIPTION
`nim doc lib/posix/posix.nim` now doesn't generate a warning anymore

but this still generates a warning, as it should:
```nim
import posix
let a = CMSG_SPACE(1.csize)
```
