### PR TITLE
implement std/wrapnils without using `experimental:dotOperators`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -140,6 +140,10 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Added experimental `linenoise.readLineStatus` to get line and status (e.g. ctrl-D or ctrl-C).
 
+- `std/wrapnils` doesn't use `experimental:dotOperators` anymore, avoiding
+  issues like https://github.com/nim-lang/Nim/issues/13063 (which affected error messages)
+  for modules importing `std/wrapnils`.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.


### PR DESCRIPTION
avoids issues like https://github.com/nim-lang/Nim/issues/13063 for modules importing std/wrapnils.

```nim
when true:
  import std/wrapnils
  type Foo = object
  discard Foo().nonexistant
```
## before PR
```
t11843.nim(25, 16) Error: type mismatch: got <Foo>
but expected one of:
template `.`(a: Wrapnil; b): untyped [template declared in /Users/timothee/git_clone/nim/Nim_devel/lib/std/wrapnils.nim(44, 10)]
  first type mismatch at position: 1
  required type for a: Wrapnil [compositeTypeClass declared in /Users/timothee/git_clone/nim/Nim_devel/lib/std/wrapnils.nim(44, 15)]
  but expression 'Foo()' is of type: Foo [object declared in t11843.nim(24, 8)]
```

## after PR
```
t11843.nim(25, 16) Error: undeclared field: 'nonexistant' for type t11843.Foo [type declared in t11843.nim(24, 8)]
    discard Foo().nonexistant
```

## note
`experimental:dotOperators` still has it's use, the fate of `experimental:dotOperators` is out of scope for this PR