### PR TITLE
compilesettings: add libpath

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -140,6 +140,8 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Added experimental `linenoise.readLineStatus` to get line and status (e.g. ctrl-D or ctrl-C).
 
+- Added `compilesettings.SingleValueSetting.libPath`
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/compiler/nimeval.nim
+++ b/compiler/nimeval.nim
@@ -12,7 +12,7 @@ import
   ast, astalgo, modules, passes, condsyms,
   options, sem, llstream, lineinfos, vm,
   vmdef, modulegraphs, idents, os, pathutils,
-  passaux, scriptconfig
+  passaux, scriptconfig, std/compilesettings
 
 type
   Interpreter* = ref object ## Use Nim as an interpreter with this object
@@ -92,10 +92,9 @@ proc findNimStdLib*(): string =
     return ""
 
 proc findNimStdLibCompileTime*(): string =
-  ## Same as ``findNimStdLib`` but uses source files used at compile time,
+  ## Same as `findNimStdLib` but uses source files used at compile time,
   ## and asserts on error.
-  const exe = getCurrentCompilerExe()
-  result = exe.splitFile.dir.parentDir / "lib"
+  result = querySetting(libPath)
   doAssert fileExists(result / "system.nim"), "result:" & result
 
 proc createInterpreter*(scriptName: string;

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -131,6 +131,7 @@ when defined(nimHasInvariant):
     of compileOptions: result = conf.compileOptions
     of ccompilerPath: result = conf.cCompilerPath
     of backend: result = $conf.backend
+    of libPath: result = conf.libpath.string
 
   proc querySettingSeqImpl(conf: ConfigRef, switch: BiggestInt): seq[string] =
     template copySeq(field: untyped): untyped =

--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -31,6 +31,7 @@ type
     ccompilerPath     ## the path to the C/C++ compiler
     backend           ## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`
                       ## and `nim js` would imply backend=js
+    libPath           ## the absolute path to the stdlib library, i.e. nim's `--lib`, since 1.5.1
 
   MultipleValueSetting* {.pure.} = enum ## \
                       ## settings resulting in a seq of string values

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -24,6 +24,7 @@ proc parseTest(filename: string; epcMode=false): Test =
   const cursorMarker = "#[!]#"
   let nimsug = curDir & addFileExt("nimsuggest", ExeExt)
   const libpath = querySetting(libPath)
+  result.filename = filename
   result.dest = getTempDir() / extractFilename(filename)
   result.cmd = nimsug & " --tester " & result.dest
   result.script = @[]

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -18,11 +18,12 @@ const
 
 template tpath(): untyped = getAppDir() / "tests"
 
+import std/compilesettings
+
 proc parseTest(filename: string; epcMode=false): Test =
   const cursorMarker = "#[!]#"
   let nimsug = curDir & addFileExt("nimsuggest", ExeExt)
-  let libpath = findExe("nim").splitFile().dir /../ "lib"
-  result.filename = filename
+  const libpath = querySetting(libPath)
   result.dest = getTempDir() / extractFilename(filename)
   result.cmd = nimsug & " --tester " & result.dest
   result.script = @[]
@@ -329,7 +330,7 @@ proc main() =
     failures += runTest(xx)
     failures += runEpcTest(xx)
   else:
-    for x in walkFiles(getAppDir() / "tests/t*.nim"):
+    for x in walkFiles(tpath() / "t*.nim"):
       echo "Test ", x
       let xx = expandFilename x
       when not defined(windows):

--- a/tests/vm/tcompilesetting.nim
+++ b/tests/vm/tcompilesetting.nim
@@ -3,18 +3,15 @@ cmd: "nim c --nimcache:build/myNimCache --nimblePath:myNimblePath $file"
 joinable: false
 """
 
-import strutils
+import std/[strutils,compilesettings]
+from std/os import fileExists, `/`
 
-import std / compilesettings
+template main =
+  doAssert querySetting(nimcacheDir) == nimcacheDir.querySetting
+  doAssert "myNimCache" in nimcacheDir.querySetting
+  doAssert "myNimblePath" in nimblePaths.querySettingSeq[0]
+  doAssert querySetting(backend) == "c"
+  doAssert fileExists(libPath.querySetting / "system.nim")
 
-const
-  nc = querySetting(nimcacheDir)
-  np = querySettingSeq(nimblePaths)
-
-static:
-  echo nc
-  echo np
-
-doAssert "myNimCache" in nc
-doAssert "myNimblePath" in np[0]
-doAssert querySetting(backend) == "c"
+static: main()
+main()


### PR DESCRIPTION
* add `libPath.querySetting`
* improve tests/vm/tcompilesetting.nim
* make API's that tried to infer libpath more robust (in particular now honoring `--lib`) instead of trying to replicate what the compiler did, eg `findNimStdLibCompileTime`; likewise with `nimsuggest/tester.nim` (note that `nimsuggest/tester.nim` is not installed but compiled on the fly; previous behavior was wrong as it used `findExe("nim").splitFile().dir /../ "lib"`, honoring neither the nim binary that was used in `nim c -r nimsuggest/tester.nim`, nor an eventual `--lib` flag)
