### PR TITLE
fix #16973 ; nim doc now shows correct, canonical import name in title

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1251,7 +1251,6 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
   var
     code, content: Rope
     title = ""
-    titleAlt = ""
   var j = 0
   var tmp = ""
   renderTocEntries(d[], j, 1, tmp)
@@ -1269,12 +1268,11 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
     title = d.meta[metaTitle]
     let external = presentationPath(d.conf, AbsoluteFile d.filename).changeFileExt(HtmlExt).string.nativeToUnixPath
     setIndexTerm(d[], external, "", title)
-    titleAlt = title
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.
     # better than `extractFilename(changeFileExt(d.filename, ""))` as it disambiguates dups
-    title = $presentationPath(d.conf, AbsoluteFile d.filename, isTitle = true).changeFileExt("")
-    titleAlt = moduleTitle(d.conf, AbsoluteFile d.filename).changeFileExt("")
+    # title = $presentationPath(d.conf, AbsoluteFile d.filename, isTitle = true).changeFileExt("")
+    title = moduleTitle(d.conf, AbsoluteFile d.filename).changeFileExt("")
   var subtitle = "".rope
   if d.meta[metaSubtitle] != "":
     dispA(d.conf, subtitle, "<h2 class=\"subtitle\">$1</h2>",

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -74,7 +74,7 @@ proc moduleTitle*(conf: ConfigRef, file: AbsoluteFile): string =
     ret = relativeTo(file, conf.projectPath)
   result = ret.string.nativeToUnixPath
 
-proc presentationPath*(conf: ConfigRef, file: AbsoluteFile, isTitle = false): RelativeFile =
+proc presentationPath*(conf: ConfigRef, file: AbsoluteFile): RelativeFile =
   ## returns a relative file that will be appended to outDir
   let file2 = $file
   template bail() =
@@ -108,10 +108,7 @@ proc presentationPath*(conf: ConfigRef, file: AbsoluteFile, isTitle = false): Re
     bail()
   if isAbsolute(result.string):
     result = file.string.splitPath()[1].RelativeFile
-  if isTitle:
-    result = result.string.nativeToUnixPath.RelativeFile
-  else:
-    result = result.string.replace("..", dotdotMangle).RelativeFile
+  result = result.string.replace("..", dotdotMangle).RelativeFile
   doAssert not result.isEmpty
   doAssert not isAbsolute(result.string)
 
@@ -1270,8 +1267,6 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
     setIndexTerm(d[], external, "", title)
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.
-    # better than `extractFilename(changeFileExt(d.filename, ""))` as it disambiguates dups
-    # title = $presentationPath(d.conf, AbsoluteFile d.filename, isTitle = true).changeFileExt("")
     title = moduleTitle(d.conf, AbsoluteFile d.filename).changeFileExt("")
   var subtitle = "".rope
   if d.meta[metaSubtitle] != "":

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -66,7 +66,7 @@ proc prettyString(a: object): string =
 proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
   ##[
   Shows the canonical module import, e.g.:
-  std/tables, fusion/pointers, system/assertions, std/private/asciitables
+  system, std/tables, fusion/pointers, system/assertions, std/private/asciitables
   ]##
   var ret = getRelativePathFromConfigPath(conf, file, isTitle = true)
   let dir = getNimbleFile(conf, $file).parentDir.AbsoluteDir

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -761,8 +761,25 @@ when (NimMajor, NimMinor) < (1, 1) or not declared(isRelativeTo):
     let ret = relativePath(path, base)
     result = path.len > 0 and not ret.startsWith ".."
 
-proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile): RelativeFile =
+const stdlibDirs = [
+  "pure", "core", "arch",
+  "pure/collections",
+  "pure/concurrency",
+  "pure/unidecode", "impure",
+  "wrappers", "wrappers/linenoise",
+  "windows", "posix", "js"]
+
+const
+  pkgPrefix = "pkg/"
+  stdPrefix = "std/"
+
+proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile, isTitle: bool): RelativeFile =
   let f = $f
+  if isTitle:
+    for dir in stdlibDirs:
+      let path = conf.libpath.string / dir / f.lastPathPart
+      if path.cmpPaths(f) == 0:
+        return RelativeFile(stdPrefix & f.splitFile.name)
   template search(paths) =
     for it in paths:
       let it = $it
@@ -784,18 +801,8 @@ proc findFile*(conf: ConfigRef; f: string; suppressStdlib = false): AbsoluteFile
           result = rawFindFile2(conf, RelativeFile f.toLowerAscii)
   patchModule(conf)
 
-const stdlibDirs = [
-  "pure", "core", "arch",
-  "pure/collections",
-  "pure/concurrency",
-  "pure/unidecode", "impure",
-  "wrappers", "wrappers/linenoise",
-  "windows", "posix", "js"]
-
 proc findModule*(conf: ConfigRef; modulename, currentModule: string): AbsoluteFile =
   # returns path to module
-  const pkgPrefix = "pkg/"
-  const stdPrefix = "std/"
   var m = addFileExt(modulename, NimExt)
   if m.startsWith(pkgPrefix):
     result = findFile(conf, m.substr(pkgPrefix.len), suppressStdlib = true)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -773,7 +773,7 @@ const
   pkgPrefix = "pkg/"
   stdPrefix = "std/"
 
-proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile, isTitle: bool): RelativeFile =
+proc getRelativePathFromConfigPath*(conf: ConfigRef; f: AbsoluteFile, isTitle = false): RelativeFile =
   let f = $f
   if isTitle:
     for dir in stdlibDirs:

--- a/nimdoc/test_out_index_dot_html/expected/index.html
+++ b/nimdoc/test_out_index_dot_html/expected/index.html
@@ -17,7 +17,7 @@
 <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,500,600' rel='stylesheet' type='text/css'/>
 
 <!-- CSS -->
-<title>foo</title>
+<title>nimdoc/test_out_index_dot_html/foo</title>
 <link rel="stylesheet" type="text/css" href="nimdoc.out.css">
 
 <script type="text/javascript" src="dochack.js"></script>
@@ -64,7 +64,7 @@ window.addEventListener('DOMContentLoaded', main);
 <body>
 <div class="document" id="documentId">
   <div class="container">
-    <h1 class="title">foo</h1>
+    <h1 class="title">nimdoc/test_out_index_dot_html/foo</h1>
     <div class="row">
   <div class="three columns">
   <div class="theme-switch-wrapper">


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/16973

refs https://github.com/nim-lang/Nim/pull/16970#discussion_r572259671
> It should be obvious, since it's linked as std/sha1 and the other std/ modules don't include this note either. But I can put the note back, if you prefer, though a better solution IMO would be to make nim doc generate std/sha1 as heading.

try it out locally with: `./koch --nim:bin/nim --localdocs:/tmp/d01 docs --doccmd:skip` (takes < 30 seconds)

it all seems to work.

## examples

![image](https://user-images.githubusercontent.com/2194784/107513961-d5ead680-6b5d-11eb-8adb-d9e9b0195c81.png)

![image](https://user-images.githubusercontent.com/2194784/107514112-10547380-6b5e-11eb-9c97-7d43a9c2e2b5.png)

![image](https://user-images.githubusercontent.com/2194784/107514158-24987080-6b5e-11eb-8346-bd1dea1bc9f3.png)

## future work
- [x] this PR is needed to implement https://github.com/nim-lang/RFCs/issues/352 ( i have a branch ready after this PR is merged: pr_fix_rfc_17282_runnableExamples_show_import) => https://github.com/nim-lang/Nim/pull/17542
- [ ] make `--docroot` the default now that this works (EDIT: now unrelated to this PR)
- [x] remove std/ prefix from modules in https://nim-lang.github.io/Nim/lib.html since we'd show it in each module's page and it looks weird to have it just for some modules (and breaks alphabetical ordering etc) => https://github.com/nim-lang/Nim/pull/17543