### PR TITLE
followup #17001: improve coverage for tests/openarray/topenarray.nim

### DIFF
--- a/tests/openarray/topenarray.nim
+++ b/tests/openarray/topenarray.nim
@@ -2,12 +2,28 @@ discard """
   targets: "c cpp js"
 """
 
-proc pro[T](a: var openArray[T]) = discard
+proc fn1[T](a: openArray[T]): seq[T] =
+  for ai in a: result.add ai
+
+proc fn2[T](a: var openArray[T]): seq[T] =
+  for ai in a: result.add ai
+
+proc fn3[T](a: var openArray[T]) =
+  echo a
+  for i, ai in mpairs(a): ai = i * 10
+  echo a
 
 proc main =
   var a = [1,2,3,4,5]
 
-  pro(toOpenArray(a, 1, 3))
-  pro(a.toOpenArray(1,3))
+  doAssert fn1(a.toOpenArray(1,3)) == @[2,3,4]
+
+  doAssert fn2(toOpenArray(a, 1, 3)) == @[2,3,4]
+  doAssert fn2(a.toOpenArray(1,3)) == @[2,3,4]
+
+  fn3(a.toOpenArray(1,3))
+  when defined(js): discard # xxx bug #15952: `a` left unchanged
+  else: doAssert a == [1, 0, 10, 20, 5]
 
 main()
+# static: main() # xxx bug #15952: Error: cannot generate code for: mSlice

--- a/tests/openarray/topenarray.nim
+++ b/tests/openarray/topenarray.nim
@@ -9,9 +9,7 @@ proc fn2[T](a: var openArray[T]): seq[T] =
   for ai in a: result.add ai
 
 proc fn3[T](a: var openArray[T]) =
-  echo a
   for i, ai in mpairs(a): ai = i * 10
-  echo a
 
 proc main =
   var a = [1,2,3,4,5]


### PR DESCRIPTION
followup #17001

note that `toOpenArray` with var param doesn't seem to actually work (ie source data isn't mutated), so it's not clear that https://github.com/nim-lang/Nim/pull/17001 actually improved things (it turned an error into a silent non-mutation) /cc @xflywind 

maybe to fix this we'd need `slice` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) ?

EDIT: `slice` won't help, but i have another idea for how to fix this (in my views PR, I need to push latest commits, looks very promising)