### PR TITLE
typeToString: type float => typedesc[float]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -160,6 +160,8 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 - The required name of case statement macros for the experimental
   `caseStmtMacros` feature has changed from `match` to `` `case` ``.
 
+- `typedesc[Foo]` now renders as such instead of `type Foo` in compiler messages.
+
 ## Compiler changes
 
 - Added `--declaredlocs` to show symbol declaration location in messages.

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -448,6 +448,7 @@ proc rangeToStr(n: PNode): string =
 const
   typeToStr: array[TTypeKind, string] = ["None", "bool", "char", "empty",
     "Alias", "typeof(nil)", "untyped", "typed", "typeDesc",
+    # xxx typeDesc=>typedesc: typedesc is declared as such, and is 10x more common.
     "GenericInvocation", "GenericBody", "GenericInst", "GenericParam",
     "distinct $1", "enum", "ordinal[$1]", "array[$1, $2]", "object", "tuple",
     "set[$1]", "range[$1]", "ptr ", "ref ", "var ", "seq[$1]", "proc",
@@ -550,7 +551,7 @@ proc typeToString(typ: PType, prefer: TPreferedDesc = preferName): string =
       result.add(']')
     of tyTypeDesc:
       if t[0].kind == tyNone: result = "typedesc"
-      else: result = "type " & typeToString(t[0])
+      else: result = "typedesc[" & typeToString(t[0]) & "]"
     of tyStatic:
       if prefer == preferGenericArg and t.n != nil:
         result = t.n.renderTree

--- a/tests/array/t9932.nim
+++ b/tests/array/t9932.nim
@@ -1,9 +1,9 @@
 discard """
 cmd: "nim check $file"
-errormsg: "invalid type: 'type int' in this context: 'array[0..0, type int]' for var"
+errormsg: "invalid type: 'typedesc[int]' in this context: 'array[0..0, typedesc[int]]' for var"
 nimout: '''
 t9932.nim(10, 5) Error: invalid type: 'type' in this context: 'array[0..0, type]' for var
-t9932.nim(11, 5) Error: invalid type: 'type int' in this context: 'array[0..0, type int]' for var
+t9932.nim(11, 5) Error: invalid type: 'typedesc[int]' in this context: 'array[0..0, typedesc[int]]' for var
 '''
 """
 

--- a/tests/bind/tinvalidbindtypedesc.nim
+++ b/tests/bind/tinvalidbindtypedesc.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <type float, string>"
+  errormsg: "type mismatch: got <typedesc[float], string>"
   line: 10
 """
 

--- a/tests/errmsgs/t8610.nim
+++ b/tests/errmsgs/t8610.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "invalid type: 'type int' for const"
+  errormsg: "invalid type: 'typedesc[int]' for const"
 """
-## issue #8610
+## bug #8610
 const Foo = int

--- a/tests/errmsgs/tconceptconstraint.nim
+++ b/tests/errmsgs/tconceptconstraint.nim
@@ -2,7 +2,7 @@ discard """
   errormsg: "cannot instantiate B"
   line: 20
   nimout: '''
-got: <type string>
+got: <typedesc[string]>
 but expected: <T: A>
 '''
 """

--- a/tests/errmsgs/tgenericconstraint.nim
+++ b/tests/errmsgs/tgenericconstraint.nim
@@ -2,7 +2,7 @@ discard """
   errormsg: "cannot instantiate B"
   line: 14
   nimout: '''
-got: <type int>
+got: <typedesc[int]>
 but expected: <T: string or float>
 '''
 """

--- a/tests/errmsgs/twrong_at_operator.nim
+++ b/tests/errmsgs/twrong_at_operator.nim
@@ -1,17 +1,17 @@
 discard """
-errormsg: "type mismatch: got <array[0..0, type int]>"
+errormsg: "type mismatch: got <array[0..0, typedesc[int]]>"
 line: 22
 nimout: '''
-twrong_at_operator.nim(22, 30) Error: type mismatch: got <array[0..0, type int]>
+twrong_at_operator.nim(22, 30) Error: type mismatch: got <array[0..0, typedesc[int]]>
 but expected one of:
 proc `@`[IDX, T](a: sink array[IDX, T]): seq[T]
   first type mismatch at position: 1
   required type for a: sink array[IDX, T]
-  but expression '[int]' is of type: array[0..0, type int]
+  but expression '[int]' is of type: array[0..0, typedesc[int]]
 proc `@`[T](a: openArray[T]): seq[T]
   first type mismatch at position: 1
   required type for a: openArray[T]
-  but expression '[int]' is of type: array[0..0, type int]
+  but expression '[int]' is of type: array[0..0, typedesc[int]]
 
 expression: @[int]
 '''

--- a/tests/metatype/typedesc_as_value.nim
+++ b/tests/metatype/typedesc_as_value.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "invalid type: 'type int' for var"
+  errormsg: "invalid type: 'typedesc[int]' for var"
 """
 
 

--- a/tests/typerel/ttypedesc_as_genericparam1.nim
+++ b/tests/typerel/ttypedesc_as_genericparam1.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <type int>"
+  errormsg: "type mismatch: got <typedesc[int]>"
   line: 6
 """
 # bug #3079, #1146

--- a/tests/typerel/ttypenoval.nim
+++ b/tests/typerel/ttypenoval.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <type int> but expected 'int'"
+  errormsg: "type mismatch: got <typedesc[int]> but expected 'int'"
   file: "ttypenoval.nim"
   line: 38
 """

--- a/tests/typerel/ttypenovalue.nim
+++ b/tests/typerel/ttypenovalue.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "invalid type: 'type seq[tuple[title: string, body: string]]' for var"
+  errormsg: "invalid type: 'typedesc[seq[tuple[title: string, body: string]]]' for var"
   line: 7
 """
 

--- a/tests/typerel/typedescs2.nim
+++ b/tests/typerel/typedescs2.nim
@@ -1,10 +1,10 @@
 discard """
-  errormsg: "invalid type: 'type Table' for const"
+  errormsg: "invalid type: 'typedesc[Table]' for const"
   file: "typedescs2.nim"
   line: 16
 """
 
-# issue #9961
+# bug #9961
 
 import typetraits
 import tables


### PR DESCRIPTION
`type Foo` is now rendered as `typedesc[Foo]`, which is more consistent with the definition and less confusing in error messages

## example
```
when true:
  proc fn(T: typedesc[SomeInteger]): int = T.high
  echo fn(int)
  echo fn(float)
```

before PR:
```nim
t11849.nim(5, 1) template/generic instantiation from here
t11849.nim(21, 10) Error: type mismatch: got <type float>
but expected one of:
proc fn(T: typedesc[SomeInteger]): int [proc declared in t11849.nim(19, 8)]
  first type mismatch at position: 1
  required type for T: type SomeInteger [or declared in /Users/timothee/git_clone/nim/Nim_devel/lib/system/basic_types.nim(29, 3)]
  but expression 'float' is of type: type float [float declared in /Users/timothee/git_clone/nim/Nim_devel/lib/system.nim(26, 3)]

```
after PR:
```
t11849.nim(5, 1) template/generic instantiation from here
t11849.nim(21, 10) Error: type mismatch: got <typedesc[float]>
but expected one of:
proc fn(T: typedesc[SomeInteger]): int [proc declared in t11849.nim(19, 8)]
  first type mismatch at position: 1
  required type for T: typedesc[SomeInteger] [or declared in /Users/timothee/git_clone/nim/Nim_prs/lib/system/basic_types.nim(29, 3)]
  but expression 'float' is of type: typedesc[float] [float declared in /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim(26, 3)]
```
