### PR TITLE
stdlib/os: add isAdmin

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -154,6 +154,8 @@ provided by the operating system.
   arguments passed to it, so `initOptParser` has been changed to raise
   `ValueError` when the real command line is not available. `parseopt` was
   previously excluded from `prelude` for JS, as it could not be imported.
+- Added `os.isAdmin` to tell whether the caller's process is a member of the
+  Administrators local group (on Windows) or a root (on POSIX).
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -138,6 +138,9 @@ provided by the operating system.
   (instead of skipping them sometimes as it was before).
 - Added optional `followSymlinks` argument to `setFilePermissions`.
 
+- Added `os.isAdmin` to tell whether the caller's process is a member of the
+  Administrators local group (on Windows) or a root (on POSIX).
+
 - Added `random.initRand()` overload with no argument which uses the current time as a seed.
 
 - Added experimental `linenoise.readLineStatus` to get line and status (e.g. ctrl-D or ctrl-C).
@@ -154,8 +157,6 @@ provided by the operating system.
   arguments passed to it, so `initOptParser` has been changed to raise
   `ValueError` when the real command line is not available. `parseopt` was
   previously excluded from `prelude` for JS, as it could not be imported.
-- Added `os.isAdmin` to tell whether the caller's process is a member of the
-  Administrators local group (on Windows) or a root (on POSIX).
 
 ## Language changes
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1658,7 +1658,7 @@ proc isAdmin*: bool {.noWeirdTarget.} =
     # https://doxygen.postgresql.org/win32security_8c.html#ae6b61e106fa5d6c5d077a9d14ee80569
     var ntAuthority = SID_IDENTIFIER_AUTHORITY(Value: SECURITY_NT_AUTHORITY)
     var administratorsGroup: PSID
-    if not isSuccess(AllocateAndInitializeSid(addr ntAuthority,
+    if not isSuccess(allocateAndInitializeSid(addr ntAuthority,
                                               BYTE(2),
                                               SECURITY_BUILTIN_DOMAIN_RID,
                                               DOMAIN_ALIAS_RID_ADMINS,
@@ -1667,10 +1667,10 @@ proc isAdmin*: bool {.noWeirdTarget.} =
       raiseOSError(osLastError(), "could not get SID for Administrators group")
 
     var b: WINBOOL
-    if not isSuccess(CheckTokenMembership(0, administratorsGroup, addr b)):
+    if not isSuccess(checkTokenMembership(0, administratorsGroup, addr b)):
       raiseOSError(osLastError(), "could not check access token membership")
 
-    if FreeSid(administratorsGroup) != nil:
+    if freeSid(administratorsGroup) != nil:
       raiseOSError(osLastError(), "failed to free SID for Administrators group")
 
     return isSuccess(b)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1666,12 +1666,13 @@ proc isAdmin*: bool {.noWeirdTarget.} =
                                               addr administratorsGroup)):
       raiseOSError(osLastError(), "could not get SID for Administrators group")
 
+    defer:
+      if freeSid(administratorsGroup) != nil:
+        raiseOSError(osLastError(), "failed to free SID for Administrators group")
+
     var b: WINBOOL
     if not isSuccess(checkTokenMembership(0, administratorsGroup, addr b)):
       raiseOSError(osLastError(), "could not check access token membership")
-
-    if freeSid(administratorsGroup) != nil:
-      raiseOSError(osLastError(), "failed to free SID for Administrators group")
 
     return isSuccess(b)
   else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1654,22 +1654,19 @@ proc isAdmin*: bool {.noWeirdTarget.} =
   when defined(windows):
     # Rewrite of the example from Microsoft Docs:
     # https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-checktokenmembership#examples
-    var b: WINBOOL
-    var ntAuthority = SID_IDENTIFIER_AUTHORITY(value: [
-      BYTE(0), BYTE(0), BYTE(0), BYTE(0), BYTE(0), BYTE(SECURITY_NT_AUTHORITY)
-    ])
+    var ntAuthority = SID_IDENTIFIER_AUTHORITY(Value: SECURITY_NT_AUTHORITY)
     var administratorsGroup: PSID
-    b = AllocateAndInitializeSid(addr ntAuthority,
-                                 BYTE(2),
-                                 SECURITY_BUILTIN_DOMAIN_RID,
-                                 DOMAIN_ALIAS_RID_ADMINS,
-                                 0, 0, 0, 0, 0, 0,
-                                 addr administratorsGroup)
-    if bool(b):
-      if not bool(CheckTokenMembership(0, administratorsGroup, addr b)):
+    var b: WINBOOL = AllocateAndInitializeSid(addr ntAuthority,
+                                              BYTE(2),
+                                              SECURITY_BUILTIN_DOMAIN_RID,
+                                              DOMAIN_ALIAS_RID_ADMINS,
+                                              0, 0, 0, 0, 0, 0,
+                                              addr administratorsGroup)
+    if isSuccess(b):
+      if not isSuccess(CheckTokenMembership(0, administratorsGroup, addr b)):
         b = 0
       discard FreeSid(administratorsGroup)
-    return bool(b)
+    return isSuccess(b)
   else:
     return geteuid() == 0
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1656,11 +1656,11 @@ proc isAdmin*: bool {.noWeirdTarget.} =
     # https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-checktokenmembership#examples
     var b: WINBOOL
     var ntAuthority = SID_IDENTIFIER_AUTHORITY(value: [
-      0'u8, 0'u8, 0'u8, 0'u8, 0'u8, BYTE(SECURITY_NT_AUTHORITY)
+      BYTE(0), BYTE(0), BYTE(0), BYTE(0), BYTE(0), BYTE(SECURITY_NT_AUTHORITY)
     ])
     var administratorsGroup: PSID
     b = AllocateAndInitializeSid(addr ntAuthority,
-                                 2,
+                                 BYTE(2),
                                  SECURITY_BUILTIN_DOMAIN_RID,
                                  DOMAIN_ALIAS_RID_ADMINS,
                                  0, 0, 0, 0, 0, 0,

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1656,7 +1656,7 @@ proc isAdmin*: bool {.noWeirdTarget.} =
     # https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-checktokenmembership#examples
     # and corresponding PostgreSQL function:
     # https://doxygen.postgresql.org/win32security_8c.html#ae6b61e106fa5d6c5d077a9d14ee80569
-    var ntAuthority = SID_IDENTIFIER_AUTHORITY(Value: SECURITY_NT_AUTHORITY)
+    var ntAuthority = SID_IDENTIFIER_AUTHORITY(value: SECURITY_NT_AUTHORITY)
     var administratorsGroup: PSID
     if not isSuccess(allocateAndInitializeSid(addr ntAuthority,
                                               BYTE(2),

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1654,6 +1654,8 @@ proc isAdmin*: bool {.noWeirdTarget.} =
   when defined(windows):
     # Rewrite of the example from Microsoft Docs:
     # https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-checktokenmembership#examples
+    # and corresponding PostgreSQL function:
+    # https://doxygen.postgresql.org/win32security_8c.html#ae6b61e106fa5d6c5d077a9d14ee80569
     var ntAuthority = SID_IDENTIFIER_AUTHORITY(Value: SECURITY_NT_AUTHORITY)
     var administratorsGroup: PSID
     if not isSuccess(AllocateAndInitializeSid(addr ntAuthority,
@@ -1668,7 +1670,8 @@ proc isAdmin*: bool {.noWeirdTarget.} =
     if not isSuccess(CheckTokenMembership(0, administratorsGroup, addr b)):
       raiseOSError(osLastError(), "could not check access token membership")
 
-    discard FreeSid(administratorsGroup)
+    if FreeSid(administratorsGroup) != nil:
+      raiseOSError(osLastError(), "failed to free SID for Administrators group")
 
     return isSuccess(b)
   else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1649,8 +1649,8 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission],
     if res2 == - 1'i32: raiseOSError(osLastError(), $(filename, permissions))
 
 proc isAdmin*: bool {.noWeirdTarget.} =
-  ## Tell whether the caller's process is a member of the Administrators local
-  ## group (on Windows) or a root (on POSIX).
+  ## Returns whether the caller's process is a member of the Administrators local
+  ## group (on Windows) or a root (on POSIX), via `geteuid() == 0`.
   when defined(windows):
     # Rewrite of the example from Microsoft Docs:
     # https://docs.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-checktokenmembership#examples

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -1151,7 +1151,7 @@ const
   SECURITY_BUILTIN_DOMAIN_RID* = 32
   DOMAIN_ALIAS_RID_ADMINS* = 544
 
-proc AllocateAndInitializeSid*(pIdentifierAuthority: PSID_IDENTIFIER_AUTHORITY,
+proc allocateAndInitializeSid*(pIdentifierAuthority: PSID_IDENTIFIER_AUTHORITY,
                                nSubAuthorityCount: BYTE,
                                nSubAuthority0: DWORD,
                                nSubAuthority1: DWORD,
@@ -1162,11 +1162,12 @@ proc AllocateAndInitializeSid*(pIdentifierAuthority: PSID_IDENTIFIER_AUTHORITY,
                                nSubAuthority6: DWORD,
                                nSubAuthority7: DWORD,
                                pSid: ptr PSID): WINBOOL
-     {.stdcall, dynlib: "Advapi32", importc.}
-proc CheckTokenMembership*(tokenHandle: Handle, sidToCheck: PSID,
+     {.stdcall, dynlib: "Advapi32", importc: "AllocateAndInitializeSid".}
+proc checkTokenMembership*(tokenHandle: Handle, sidToCheck: PSID,
                            isMember: PBOOL): WINBOOL
-     {.stdcall, dynlib: "Advapi32", importc.}
-proc FreeSid*(pSid: PSID): PSID {.stdcall, dynlib: "Advapi32", importc.}
+     {.stdcall, dynlib: "Advapi32", importc: "CheckTokenMembership".}
+proc freeSid*(pSid: PSID): PSID
+     {.stdcall, dynlib: "Advapi32", importc: "FreeSid".}
 
 when defined(nimHasStyleChecks):
   {.pop.} # {.push styleChecks: off.}

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -139,6 +139,7 @@ const
 
   HANDLE_FLAG_INHERIT* = 0x00000001'i32
 
+proc isSuccess*(a: WINBOOL): bool {.inline.} = a != 0
 proc getVersionExW*(lpVersionInfo: ptr OSVERSIONINFO): WINBOOL {.
     stdcall, dynlib: "kernel32", importc: "GetVersionExW", sideEffect.}
 proc getVersionExA*(lpVersionInfo: ptr OSVERSIONINFO): WINBOOL {.
@@ -1133,19 +1134,20 @@ proc setFileTime*(hFile: Handle, lpCreationTime: LPFILETIME,
      {.stdcall, dynlib: "kernel32", importc: "SetFileTime".}
 
 type
-  SID_IDENTIFIER_AUTHORITY* = object
-    value*: array[6, BYTE]
-  PSID_IDENTIFIER_AUTHORITY* = ptr SID_IDENTIFIER_AUTHORITY
-  SID* = object
-    revision: BYTE
-    subAuthorityCount: BYTE
-    identifierAuthority: SID_IDENTIFIER_AUTHORITY
-    subAuthority: ptr ptr DWORD
-  PSID* = ptr SID
+  SID_IDENTIFIER_AUTHORITY* {.importc, header: "windows.h".} = object
+    Value*: array[6, BYTE]
+  PSID_IDENTIFIER_AUTHORITY* {.importc, header: "windows.h".} = ptr SID_IDENTIFIER_AUTHORITY
+  SID* {.importc, header: "windows.h".} = object
+    Revision: BYTE
+    SubAuthorityCount: BYTE
+    IdentifierAuthority: SID_IDENTIFIER_AUTHORITY
+    SubAuthority: ptr ptr DWORD
+  PSID* {.importc, header: "windows.h".} = ptr SID
 
 const
   # https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-components
-  SECURITY_NT_AUTHORITY* = 5
+  # https://github.com/mirror/mingw-w64/blob/84c950bdab7c999ace49fe8383856be77f88c4a8/mingw-w64-headers/include/winnt.h#L2994
+  SECURITY_NT_AUTHORITY* = [BYTE(0), BYTE(0), BYTE(0), BYTE(0), BYTE(0), BYTE(5)]
   SECURITY_BUILTIN_DOMAIN_RID* = 32
   DOMAIN_ALIAS_RID_ADMINS* = 544
 

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -25,6 +25,7 @@ when useWinUnicode:
 else:
   type WinChar* = char
 
+# See https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
 type
   Handle* = int
   LONG* = int32
@@ -41,7 +42,7 @@ type
   PULONG_PTR* = ptr uint
   HDC* = Handle
   HGLRC* = Handle
-  BYTE* = uint8
+  BYTE* = cuchar
 
   SECURITY_ATTRIBUTES* {.final, pure.} = object
     nLength*: int32

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -653,5 +653,5 @@ block: # normalizeExe
     doAssert "foo".dup(normalizeExe) == "foo"
 
 block: # isAdmin
-  let isAzure = existsEnv("TF_BUILD") # xxx factor with testament.specs.isAzure
+  let isAzure = defined(windows) and existsEnv("TF_BUILD") # xxx factor with testament.specs.isAzure
   if isAzure: doAssert isAdmin()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -653,4 +653,5 @@ block: # normalizeExe
     doAssert "foo".dup(normalizeExe) == "foo"
 
 block: # isAdmin
-  echo("Running as admin: ", isAdmin())
+  let isAzure = existsEnv("TF_BUILD") # xxx factor with testament.specs.isAzure
+  if isAzure: doAssert isAdmin()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -653,5 +653,8 @@ block: # normalizeExe
     doAssert "foo".dup(normalizeExe) == "foo"
 
 block: # isAdmin
-  let isAzure = defined(windows) and existsEnv("TF_BUILD") # xxx factor with testament.specs.isAzure
-  if isAzure: doAssert isAdmin()
+  let isAzure = existsEnv("TF_BUILD") # xxx factor with testament.specs.isAzure
+  # In Azure on Windows tests run as an admin user
+  if isAzure and defined(windows): doAssert isAdmin()
+  # In Azure on POSIX tests run as a normal user
+  if isAzure and defined(posix): doAssert not isAdmin()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -651,3 +651,6 @@ block: # normalizeExe
     doAssert "foo/../bar".dup(normalizeExe) == "foo/../bar"
   when defined(windows):
     doAssert "foo".dup(normalizeExe) == "foo"
+
+block: # isAdmin
+  echo("Running as admin: ", isAdmin())


### PR DESCRIPTION
Tested on Windows 10 as a normal user and as an administrator; on Fedora 33 as a normal user and as a root.

(EDIT(timotheecour))
fixes https://github.com/nim-lang/RFCs/issues/329