### PR TITLE
Better error message for rand(153 .. 102)

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -309,7 +309,7 @@ proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
     doAssert r.rand(1..6) == 4
     doAssert r.rand(1..6) == 6
     let f = r.rand(-1.0 .. 1.0) # 0.8741183448756229
-
+  assert x.a <= x.b, "Start of slice must be less than end."
   when T is SomeFloat:
     result = rand(r, x.b - x.a) + x.a
   else: # Integers and Enum types

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -309,7 +309,7 @@ proc rand*[T: Ordinal or SomeFloat](r: var Rand; x: HSlice[T, T]): T =
     doAssert r.rand(1..6) == 4
     doAssert r.rand(1..6) == 6
     let f = r.rand(-1.0 .. 1.0) # 0.8741183448756229
-  assert x.a <= x.b, "Start of slice must be less than end."
+  assert x.a <= x.b
   when T is SomeFloat:
     result = rand(r, x.b - x.a) + x.a
   else: # Integers and Enum types


### PR DESCRIPTION
The original error message is:

```
C:\Users\morfe\.choosenim\toolchains\nim-1.0.6\lib\pure\random.nim(367) rand
C:\Users\morfe\.choosenim\toolchains\nim-1.0.6\lib\pure\random.nim(341) rand
C:\Users\morfe\.choosenim\toolchains\nim-1.0.6\lib\system\fatal.nim(48) sysFatal
Error: unhandled exception: value out of range: -51 [RangeError]
```

Which isn't informative about what's happening.