### PR TITLE
Fix bug in removeDotSegments when path ends with dot

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -355,7 +355,7 @@ func removeDotSegments(path: string): string =
           discard collection.pop()
           i.inc 3
           continue
-      elif path[i+1] == '/':
+      elif i + 1 < path.len and path[i+1] == '/':
         i.inc 2
         continue
       currentSegment.add path[i]


### PR DESCRIPTION
removeDotSegments in uri fails when the url path ends in a dot.

Example:
```
import uri

echo combine(parseUri("x"), parseUri("."))
```

Output:
```
/home/favre/saved/devel/nim/gemini/examples/test.nim(3) test
/home/favre/.choosenim/toolchains/nim-1.4.2/lib/pure/uri.nim(383) combine
/home/favre/.choosenim/toolchains/nim-1.4.2/lib/pure/uri.nim(314) removeDotSegments
/home/favre/.choosenim/toolchains/nim-1.4.2/lib/system/fatal.nim(49) sysFatal
Error: unhandled exception: index 1 not in 0 .. 0 [IndexDefect]
```