### PR TITLE
JsString and CString aliases for cstring

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -155,6 +155,15 @@ provided by the operating system.
   `ValueError` when the real command line is not available. `parseopt` was
   previously excluded from `prelude` for JS, as it could not be imported.
 
+- There are now backend-specific `JsString` and `CString` aliases for
+  `cstring`. The purpose is to make library definitions clearer, as `cstring`
+  can behave differently across backends.
+  
+  Currently the only way the types are used differently is that `JsString` has
+  an `add(var JsString, JsString)` overload. This overload was originally added
+  in version 0.8.14, but was never documented due to the `when` check
+  defining it not accounting for documentation.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1274,16 +1274,17 @@ cstring type
 ------------
 
 The ``cstring`` type meaning `compatible string` is the native representation
-of a string for the compilation backend. For the C backend the ``cstring`` type
-represents a pointer to a zero-terminated char array
-compatible with the type ``char*`` in Ansi C. Its primary purpose lies in easy
-interfacing with C. The index operation ``s[i]`` means the i-th *char* of
-``s``; however no bounds checking for ``cstring`` is performed making the
-index operation unsafe.
+of a string for the compilation backend. For the C, C++ and Objective-C
+backends the ``cstring`` type represents a pointer to a zero-terminated char
+array compatible with the type ``char*`` in Ansi C. For the JavaScript backend
+the ``cstring`` type represents the native JavaScript primitive string type.
+Its primary purpose lies in easy interfacing with backends. The index operation
+``s[i]`` means the i-th *char* of ``s``; however no bounds checking for
+``cstring`` is performed making the index operation unsafe.
 
-A Nim ``string`` is implicitly convertible
-to ``cstring`` for convenience. If a Nim string is passed to a C-style
-variadic proc, it is implicitly converted to ``cstring`` too:
+A Nim ``string`` is implicitly convertible to ``cstring`` for convenience.
+If a Nim string is passed to a C-style variadic proc, it is implicitly
+converted to ``cstring`` too:
 
 .. code-block:: nim
   proc printf(formatstr: cstring) {.importc: "printf", varargs,

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2034,6 +2034,23 @@ when defined(js) or defined(nimdoc):
     ## Alias for `cstring` on JS backend. Corresponds to native JS strings.
     ## Use if you specifically want to support JS `cstring`s.
 
+  proc add*(x: var JsString, y: JsString) {.magic: "AppendStrStr".} =
+    ## Appends `y` to `x` in place.
+    ## Only implemented for JS `cstring`.
+    runnableExamples:
+      when defined(js):
+        var tmp: JsString = ""
+        tmp.add(JsString("ab"))
+        tmp.add(JsString("cd"))
+        doAssert tmp == JsString("abcd")
+
+when not defined(js) or defined(nimdoc):
+  type CString* = cstring
+    ## Alias for `cstring` on C-like backends.
+    ## Corresponds to a zero-terminated ``char*``. 
+    ## Use if you specifically want to support `cstring`s for C-like backends.
+
+when defined(js) or defined(nimdoc):
   proc add*(x: var string, y: cstring) {.asmNoStackFrame.} =
     ## Appends `y` to `x` in place.
     runnableExamples:
@@ -2049,32 +2066,15 @@ when defined(js) or defined(nimdoc):
         `x`[off+i] = `y`.charCodeAt(i);
       }
     """
-
-  proc add*(x: var JsString, y: JsString) {.magic: "AppendStrStr".} =
-    ## Appends `y` to `x` in place.
-    ## Only implemented for JS `cstring`.
-    runnableExamples:
-      when defined(js):
-        var tmp: JsString = ""
-        tmp.add(JsString("ab"))
-        tmp.add(JsString("cd"))
-        doAssert tmp == JsString("abcd")
-
-when hasAlloc or defined(nimdoc):
-  type CString* = cstring
-    ## Alias for `cstring` on C-like backends.
-    ## Corresponds to a zero-terminated ``char*``. 
-    ## Use if you specifically want to support `cstring`s for C-like backends.
-
-  when not defined(nimdoc): # duplicate procs
-    {.push stackTrace: off, profiler: off.}
-    proc add*(x: var string, y: cstring) =
-      var i = 0
-      if y != nil:
-        while y[i] != '\0':
-          add(x, y[i])
-          inc(i)
-    {.pop.}
+elif hasAlloc:
+  {.push stackTrace: off, profiler: off.}
+  proc add*(x: var string, y: cstring) =
+    var i = 0
+    if y != nil:
+      while y[i] != '\0':
+        add(x, y[i])
+        inc(i)
+  {.pop.}
 
 when defined(nimvarargstyped):
   proc echo*(x: varargs[typed, `$`]) {.magic: "Echo", tags: [WriteIOEffect],


### PR DESCRIPTION
closes https://github.com/nim-lang/RFCs/issues/342

Barebones implementation of the RFC. Changes to individual standard library modules (like just verbatim replacing `cstring` with `JsString` in lib/js) and implementing/stubbing `JsString` and `CString` for other backends can be done later. This amount of change is sufficient for user libraries.