### PR TITLE
Fixes #17039 - checked field addr analysis

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -707,6 +707,10 @@ proc analyseIfAddressTaken(c: PContext, n: PNode): PNode =
     if skipTypes(n[0].typ, abstractInst-{tyTypeDesc}).kind notin {tyVar, tyLent}:
       if n[0].kind == nkSym: incl(n[0].sym.flags, sfAddrTaken)
       result = newHiddenAddrTaken(c, n)
+  of nkCheckedFieldExpr:
+    checkMinSonsLen(n, 1, c.config)
+    n[0] = analyseIfAddressTaken(c, n[0])
+    result = n
   else:
     result = newHiddenAddrTaken(c, n)
 

--- a/tests/vm/t17039.nim
+++ b/tests/vm/t17039.nim
@@ -1,0 +1,10 @@
+type
+  Obj1 = object
+    case kind: bool
+    of false:
+      field: seq[int]
+    else: discard
+
+static:
+  var obj1 = Obj1()
+  obj1.field.add(@[])


### PR DESCRIPTION
Checked field expressions, such as an object variant field access were
not being unwrapped during analysis of address taken.

This unwraps them to ensure the analysis is done for the field access,
but doesn't discard them.

PS: did some initial analysis, at least going by tests, opcLdObjAddr
should not require the conditional check based on kind for the src.
Will revisit later.