### PR TITLE
document type bound operators

### DIFF
--- a/doc/destructors.rst
+++ b/doc/destructors.rst
@@ -89,8 +89,9 @@ Lifetime-tracking hooks
 
 The memory management for Nim's standard ``string`` and ``seq`` types as
 well as other standard collections is performed via so-called
-"Lifetime-tracking hooks" or "type-bound operators". There are 3 different
-hooks for each (generic or concrete) object type ``T`` (``T`` can also be a
+"Lifetime-tracking hooks", which are particular `type bound routines <manual.html#procedures-type-bound-routines>`_.
+
+There are 3 different hooks for each (generic or concrete) object type ``T`` (``T`` can also be a
 ``distinct`` type) that are called implicitly by the compiler.
 
 (Note: The word "hook" here does not imply any kind of dynamic binding

--- a/doc/destructors.rst
+++ b/doc/destructors.rst
@@ -89,7 +89,7 @@ Lifetime-tracking hooks
 
 The memory management for Nim's standard ``string`` and ``seq`` types as
 well as other standard collections is performed via so-called
-"Lifetime-tracking hooks", which are particular `type bound routines <manual.html#procedures-type-bound-routines>`_.
+"Lifetime-tracking hooks", which are particular `type bound operators <manual.html#procedures-type-bound-operators>`_.
 
 There are 3 different hooks for each (generic or concrete) object type ``T`` (``T`` can also be a
 ``distinct`` type) that are called implicitly by the compiler.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3687,7 +3687,8 @@ Type bound routines
 -------------------
 
 A type bound routine is a routine whose name starts with `=` but isn't an operator
-(i.e. containing only symbols, such as `==`).
+(i.e. containing only symbols, such as `==`). These are unrelated to setters
+(see `properties <manual.html#procedures-properties>`_), which instead end in `=`.
 A type bound routine declared for a type applies to the type regardless of whether
 the routine is in scope (including if the routine is private).
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3678,6 +3678,46 @@ Is short for:
 
 
 
+Routines
+--------
+
+A routine is a symbol of kind: `proc`, `func`, `iterator`, `macro`, `template`, `converter`.
+
+Type bound routines
+-------------------
+
+A type bound routine is a routine whose name starts with `=` but isn't an operator
+(i.e. containing only symbols, such as `==`).
+A type bound routine declared for a type applies to the type regardless of whether
+the routine is in scope (including if the routine is private).
+
+.. code-block:: nim
+  # foo.nim:
+  var witness* = 0
+  type Foo[T] = object
+  proc initFoo*(T: typedesc): Foo[T] = discard
+  proc `=destroy`[T](x: var Foo[T]) = witness.inc # type bound routine
+
+  # main.nim:
+  import t11861b
+  block:
+    var a = initFoo(int)
+    doAssert witness == 0
+  doAssert witness == 1
+  block:
+    var a = initFoo(int)
+    doAssert witness == 1
+    `=destroy`(a) # can be called explicitly, even without being in scope
+    doAssert witness == 2
+  # will still be called upon exiting scope
+  doAssert witness == 3
+
+Type bound routines allowed names are in `ast.AttachedOpToStr`, currently include:
+ "=destroy", "=copy", "=sink", "=trace", "=dispose", "=deepcopy".
+
+For more details on some of those routines, see
+`lifetimeminustracking-hooks <destructors.html#lifetimeminustracking-hooks>`_.
+
 Nonoverloadable builtins
 ------------------------
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3713,7 +3713,7 @@ the operator is in scope (including if it is private).
   # will still be called upon exiting scope
   doAssert witness == 3
 
-Type bound operators allowed names are in ``ast.AttachedOpToStr``, currently include:
+Type bound operators currently include:
 ``=destroy``, ``=copy``, ``=sink``, ``=trace``, ``=dispose``, ``=deepcopy``
 (some of which are still implementation defined and not yet documented).
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3681,23 +3681,23 @@ Is short for:
 Routines
 --------
 
-A routine is a symbol of kind: `proc`, `func`, `iterator`, `macro`, `template`, `converter`.
+A routine is a symbol of kind: `proc`, `func`, `method`, `iterator`, `macro`, `template`, `converter`.
 
-Type bound routines
--------------------
+Type bound operators
+--------------------
 
-A type bound routine is a routine whose name starts with `=` but isn't an operator
+A type bound operator is a `proc` or `func` whose name starts with `=` but isn't an operator
 (i.e. containing only symbols, such as `==`). These are unrelated to setters
 (see `properties <manual.html#procedures-properties>`_), which instead end in `=`.
-A type bound routine declared for a type applies to the type regardless of whether
-the routine is in scope (including if the routine is private).
+A type bound operator declared for a type applies to the type regardless of whether
+the operator is in scope (including if it is private).
 
 .. code-block:: nim
   # foo.nim:
   var witness* = 0
   type Foo[T] = object
   proc initFoo*(T: typedesc): Foo[T] = discard
-  proc `=destroy`[T](x: var Foo[T]) = witness.inc # type bound routine
+  proc `=destroy`[T](x: var Foo[T]) = witness.inc # type bound operator
 
   # main.nim:
   import foo
@@ -3713,10 +3713,11 @@ the routine is in scope (including if the routine is private).
   # will still be called upon exiting scope
   doAssert witness == 3
 
-Type bound routines allowed names are in ``ast.AttachedOpToStr``, currently include:
-``=destroy``, ``=copy``, ``=sink``, ``=trace``, ``=dispose``, ``=deepcopy``.
+Type bound operators allowed names are in ``ast.AttachedOpToStr``, currently include:
+``=destroy``, ``=copy``, ``=sink``, ``=trace``, ``=dispose``, ``=deepcopy``
+(some of which are still implementation defined and not yet documented).
 
-For more details on some of those routines, see
+For more details on some of those procs, see
 `lifetimeminustracking-hooks <destructors.html#lifetimeminustracking-hooks>`_.
 
 Nonoverloadable builtins

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3700,7 +3700,7 @@ the routine is in scope (including if the routine is private).
   proc `=destroy`[T](x: var Foo[T]) = witness.inc # type bound routine
 
   # main.nim:
-  import t11861b
+  import foo
   block:
     var a = initFoo(int)
     doAssert witness == 0
@@ -3713,8 +3713,8 @@ the routine is in scope (including if the routine is private).
   # will still be called upon exiting scope
   doAssert witness == 3
 
-Type bound routines allowed names are in `ast.AttachedOpToStr`, currently include:
- "=destroy", "=copy", "=sink", "=trace", "=dispose", "=deepcopy".
+Type bound routines allowed names are in ``ast.AttachedOpToStr``, currently include:
+``=destroy``, ``=copy``, ``=sink``, ``=trace``, ``=dispose``, ``=deepcopy``.
 
 For more details on some of those routines, see
 `lifetimeminustracking-hooks <destructors.html#lifetimeminustracking-hooks>`_.


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/17062#issuecomment-780192544

just reflects my understanding of it, please correct if needed

## future work
- [x] document `=trace` and `=dispose`, even if it comes with a disclaimer that these may change