### PR TITLE
uri: document removeDotSegments, add tests, show failure modes

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -344,9 +344,9 @@ func removeDotSegments(path: string): string =
   runnableExamples:
     assert removeDotSegments("a1/a2/../a3/a4/a5/./a6/a7/.//./") == "a1/a3/a4/a5/a6/a7/"
     assert removeDotSegments("http://www.ai.") == "http://www.ai."
-  # xxx adapt code from `os.normalizedPath` to make this more reliable, but
+  # xxx adapt or reuse ```pathnorm.normalizePath(path, `/`)``` to make this more reliable, but
   # taking into account url specificities such as not collapsing leading `//` in scheme
-  # `https://`, and using `/` on all OS.
+  # `https://`.
   # see `turi` for failing tests.
   if path.len == 0: return ""
   var collection: seq[string] = @[]

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -339,15 +339,14 @@ func parseUri*(uri: string): Uri =
   parseUri(uri, result)
 
 func removeDotSegments(path: string): string =
-  ## collapses `..` and `.` in `path` in a similar way as done in `os.normalizedPath`
+  ## Collapses `..` and `.` in `path` in a similar way as done in `os.normalizedPath`
   ## Caution: this is buggy.
   runnableExamples:
     assert removeDotSegments("a1/a2/../a3/a4/a5/./a6/a7/.//./") == "a1/a3/a4/a5/a6/a7/"
     assert removeDotSegments("http://www.ai.") == "http://www.ai."
-  # xxx adapt or reuse ```pathnorm.normalizePath(path, `/`)``` to make this more reliable, but
+  # xxx adapt or reuse `pathnorm.normalizePath(path, '/')` to make this more reliable, but
   # taking into account url specificities such as not collapsing leading `//` in scheme
-  # `https://`.
-  # see `turi` for failing tests.
+  # `https://`. see `turi` for failing tests.
   if path.len == 0: return ""
   var collection: seq[string] = @[]
   let endsWithSlash = path.endsWith '/'
@@ -557,6 +556,24 @@ proc getDataUri*(data, mime: string, encoding = "utf-8"): string {.since: (1, 3)
   assert encoding.len > 0 and mime.len > 0 # Must *not* be URL-Safe, see RFC-2397
   result = "data:" & mime & ";charset=" & encoding & ";base64," & base64.encode(data)
 
-when defined(testing):
-  # pending https://github.com/nim-lang/Nim/pull/11865
-  export removeDotSegments
+when isMainModule and defined(testing):
+  # needed (pending https://github.com/nim-lang/Nim/pull/11865) because
+  # `removeDotSegments` is private, the other tests are in `turi`.
+  block: # removeDotSegments
+    # `removeDotSegments` is exported for -d:testing only
+    doAssert removeDotSegments("/foo/bar/baz") == "/foo/bar/baz"
+    doAssert removeDotSegments("") == "" # empty test
+    doAssert removeDotSegments(".") == "." # trailing period
+    doAssert removeDotSegments("a1/a2/../a3/a4/a5/./a6/a7/././") == "a1/a3/a4/a5/a6/a7/"
+    doAssert removeDotSegments("https://a1/a2/../a3/a4/a5/./a6/a7/././") == "https://a1/a3/a4/a5/a6/a7/"
+    doAssert removeDotSegments("http://a1/a2") == "http://a1/a2"
+    doAssert removeDotSegments("http://www.ai.") == "http://www.ai."
+    when false: # xxx these cases are buggy
+      # this should work, refs https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
+      doAssert removeDotSegments("http://www.ai./") == "http://www.ai./" # fails
+      echo removeDotSegments("http://www.ai./")  # http://www.ai/
+      echo removeDotSegments("a/b.../c") # b.c
+      echo removeDotSegments("a/b../c") # bc
+      echo removeDotSegments("a/.../c") # .c
+      echo removeDotSegments("a//../b") # a/b
+      echo removeDotSegments("a/b/c//") # a/b/c//

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -179,7 +179,7 @@ template main() =
     doAssert removeDotSegments("http://a1/a2") == "http://a1/a2"
     doAssert removeDotSegments("http://www.ai.") == "http://www.ai."
     when false: # xxx these cases are buggy
-      # trailing to should work, refs https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
+      # this should work, refs https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
       doAssert removeDotSegments("http://www.ai./") == "http://www.ai./" # fails
       echo removeDotSegments("http://www.ai./")  # http://www.ai/
       echo removeDotSegments("a/b.../c") # b.c

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -169,25 +169,6 @@ template main() =
       let test = parseUri("http://example.com/foo/") / "/bar/asd"
       doAssert test.path == "/foo/bar/asd"
 
-  block: # removeDotSegments
-    # `removeDotSegments` is exported for -d:testing only
-    doAssert removeDotSegments("/foo/bar/baz") == "/foo/bar/baz"
-    doAssert removeDotSegments("") == "" # empty test
-    doAssert removeDotSegments(".") == "." # trailing period
-    doAssert removeDotSegments("a1/a2/../a3/a4/a5/./a6/a7/././") == "a1/a3/a4/a5/a6/a7/"
-    doAssert removeDotSegments("https://a1/a2/../a3/a4/a5/./a6/a7/././") == "https://a1/a3/a4/a5/a6/a7/"
-    doAssert removeDotSegments("http://a1/a2") == "http://a1/a2"
-    doAssert removeDotSegments("http://www.ai.") == "http://www.ai."
-    when false: # xxx these cases are buggy
-      # this should work, refs https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
-      doAssert removeDotSegments("http://www.ai./") == "http://www.ai./" # fails
-      echo removeDotSegments("http://www.ai./")  # http://www.ai/
-      echo removeDotSegments("a/b.../c") # b.c
-      echo removeDotSegments("a/b../c") # bc
-      echo removeDotSegments("a/.../c") # .c
-      echo removeDotSegments("a//../b") # a/b
-      echo removeDotSegments("a/b/c//") # a/b/c//
-
   block: # bug #3207
     doAssert parseUri("http://qq/1").combine(parseUri("https://qqq")).`$` == "https://qqq"
 


### PR DESCRIPTION
## links
(somewhat relevant)
* https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
* http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2002-0288
* https://cwe.mitre.org/data/definitions/32.html
* https://beamtic.com/dots-in-urls
## future work
- [ ] fix `removeDotSegments`, if possibly reusing ```pathnorm.normalizePath(path, `/`)``` to avoid duplication; the scheme (eg: `https://`) prefix may need to be handled separately