### PR TITLE
Add setutils.complement, setutils.fullSet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -75,10 +75,10 @@
 - `strscans.scanf` now supports parsing single characters.
 - `strscans.scanTuple` added which uses `strscans.scanf` internally, returning a tuple which can be unpacked for easier usage of `scanf`.
 
-- Added `setutils.toSet` that can take any iterable and convert it to a built-in set,
+- Added `setutils.toSet` that can take any iterable and convert it to a built-in `set`,
   if the iterable yields a built-in settable type.
-- Added `setutils.fullSet` which returns a full built-in set for a valid type.
-- Added `setutils.not` which inverts a built-in set.
+- Added `setutils.fullSet` which returns a full built-in `set` for a valid type.
+- Added `setutils.not` which returns the complement of a built-in `set`.
 
 
 - Added `math.isNaN`.

--- a/changelog.md
+++ b/changelog.md
@@ -77,6 +77,9 @@
 
 - Added `setutils.toSet` that can take any iterable and convert it to a built-in set,
   if the iterable yields a built-in settable type.
+- Added `setutils.fullSet` which returns a full built-in set for a valid type.
+- Added `setutils.not` which inverts a built-in set.
+
 
 - Added `math.isNaN`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -78,7 +78,7 @@
 - Added `setutils.toSet` that can take any iterable and convert it to a built-in `set`,
   if the iterable yields a built-in settable type.
 - Added `setutils.fullSet` which returns a full built-in `set` for a valid type.
-- Added `setutils.not` which returns the complement of a built-in `set`.
+- Added `setutils.complement` which returns the complement of a built-in `set`.
 
 
 - Added `math.isNaN`.

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -38,16 +38,16 @@ template toSet*(iter: untyped): untyped =
 
 macro enmRange(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
-template fullSet*(T: typedesc): untyped =
+proc fullSet*(T: typedesc): auto {.inline.} =
   ## Returns a full set of all valid elements.
   runnableExamples:
     assert {true, false} == fullSet(bool)
-  when T is enum:
-    enmRange(T)
-  else:
+  when T is Ordinal:
     {T.low..T.high}
+  else: # Hole filled enum
+    enmRange(T)
 
-proc `not`*[T](s: set[T]): set[T] = 
+proc `not`*[T](s: set[T]): set[T] =
   ## Returns the complement of the set.
   ## Can also be thought of as inverting the set.
   runnableExamples:

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -14,10 +14,7 @@
 ## * `std/packedsets <packedsets.html>`_
 ## * `std/sets <sets.html>`_
 
-import std/[
-  typetraits,
-  macros
-]
+import std/[typetraits, macros]
 
 #[
   type SetElement* = char|byte|bool|int16|uint16|enum|uint8|int8

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -42,7 +42,7 @@ template toSet*(iter: untyped): untyped =
 macro enmRange(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
 template fullSet*(T: typedesc): untyped =
-  ## Returns a full set of all valid elements
+  ## Returns a full built-in set of all valid elements
   runnableExamples:
     assert {true, false} == fullSet(bool)
   var res: set[T]
@@ -53,8 +53,8 @@ template fullSet*(T: typedesc): untyped =
   res
 
 proc `not`*[T](s: set[T]): set[T] = 
-  ## Returns the complement of the set.
-  ## Can also be thought of as inverting the set.
+  ## Returns the complement of the built-in set.
+  ## Can also be thought of as inverting the built-in set.
   runnableExamples:
     type Colors = enum
       red, green = 3, blue

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -47,7 +47,7 @@ proc fullSet*(T: typedesc): auto {.inline.} =
   else: # Hole filled enum
     enmRange(T)
 
-proc complement*[T](s: set[T]): set[T] =
+proc complement*[T](s: set[T]): set[T] {.inline.} =
   ## Returns the complement of the set.
   ## Can also be thought of as inverting the set.
   runnableExamples:

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -47,14 +47,14 @@ proc fullSet*(T: typedesc): auto {.inline.} =
   else: # Hole filled enum
     enmRange(T)
 
-proc `not`*[T](s: set[T]): set[T] =
+proc complement*[T](s: set[T]): set[T] =
   ## Returns the complement of the set.
   ## Can also be thought of as inverting the set.
   runnableExamples:
     type Colors = enum
       red, green = 3, blue
-    assert {red, blue}.not == {green}
-    assert (not {red, green, blue}).card == 0
-    assert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
-    assert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
+    assert complement({red, blue}) == {green}
+    assert complement({red, green, blue}).card == 0
+    assert complement({range[0..10](0), 1, 2, 3}) == {range[0..10](4), 5, 6, 7, 8, 9, 10}
+    assert complement({'0'..'9'}) == {0.char..255.char} - {'0'..'9'}
   fullSet(T) - s

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -35,3 +35,15 @@ template toSet*(iter: untyped): untyped =
   for x in iter:
     incl(result, x)
   result
+
+proc `not`*[T](s: set[T]): set[T] = 
+  ## Returns the complement of the set.
+  ## Can also be thought of as inverting the set.
+  runnableExamples:
+    type Colors = enum
+      red, green, blue
+    assert {red, blue}.not == {green}
+    assert (not {red, green, blue}).card == 0
+    assert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
+    assert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
+  {T.low..T.high} - s

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -42,19 +42,17 @@ template toSet*(iter: untyped): untyped =
 macro enmRange(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
 template fullSet*(T: typedesc): untyped =
-  ## Returns a full built-in set of all valid elements
+  ## Returns a full set of all valid elements.
   runnableExamples:
     assert {true, false} == fullSet(bool)
-  var res: set[T]
   when T is enum:
-    res = enmRange(T)
+    enmRange(T)
   else:
-    res = {T.low..T.high}
-  res
+    {T.low..T.high}
 
 proc `not`*[T](s: set[T]): set[T] = 
-  ## Returns the complement of the built-in set.
-  ## Can also be thought of as inverting the built-in set.
+  ## Returns the complement of the set.
+  ## Can also be thought of as inverting the set.
   runnableExamples:
     type Colors = enum
       red, green = 3, blue

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -13,9 +13,9 @@ template main =
     doAssert [A('x')].toSet == {A('x')}
 
   block: # fullSet
-    doAssert {true, false} == fullSet(bool)
-    doAssert {red, green, blue} == fullSet(Colors)
-    doAssert {0.chr..255.chr} == fullSet(char)
+    doAssert fullSet(bool) == {true, false}
+    doAssert fullSet(Colors) == {red, green, blue}
+    doAssert fullSet(char) == {0.chr..255.chr}
 
   block: # not
     doAssert {red, blue}.not == {green}

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -2,8 +2,11 @@ discard """
   targets: "c js"
 """
 import std/setutils
-type Colors = enum
-  red, green = 5, blue = 10
+type 
+  Colors = enum
+    red, green = 5, blue = 10
+  Bar = enum
+    bar0 = -1, bar1, bar2
 template main =
   block: # toSet
     doAssert "abcbb".toSet == {'a', 'b', 'c'}
@@ -16,10 +19,12 @@ template main =
     doAssert fullSet(bool) == {true, false}
     doAssert fullSet(Colors) == {red, green, blue}
     doAssert fullSet(char) == {0.chr..255.chr}
+    doAssert fullSet(Bar) == {bar0, bar1, bar2}
 
   block: # not
     doAssert {red, blue}.not == {green}
     doAssert (not {red, green, blue}).card == 0
+    doAssert {bar0}.not == {bar1, bar2}
     doAssert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
     doAssert (not {false}) == {true}

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -16,7 +16,6 @@ template main =
     doAssert [A('x')].toSet == {A('x')}
 
   block: # fullSet
-    doAssert fullSet(bool) == {true, false}
     doAssert fullSet(Colors) == {red, green, blue}
     doAssert fullSet(char) == {0.chr..255.chr}
     doAssert fullSet(Bar) == {bar0, bar1, bar2}
@@ -27,7 +26,15 @@ template main =
     doAssert {bar0}.not == {bar1, bar2}
     doAssert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
-    doAssert (not {false}) == {true}
+
+  block: # bugs
+    template impl =
+      doAssert (not {false}) == {true}
+      doAssert fullSet(bool) == {true, false}
+    when defined(js):
+      when nimvm: impl()
+      else: discard # pending bug #17076
+    else: impl()
 
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -17,18 +17,24 @@ template main =
 
   block: # fullSet
     doAssert fullSet(Colors) == {red, green, blue}
-    doAssert fullSet(bool) == {true, false}
     doAssert fullSet(char) == {0.chr..255.chr}
     doAssert fullSet(Bar) == {bar0, bar1, bar2}
 
   block: # complement
     doAssert {red, blue}.complement == {green}
     doAssert (complement {red, green, blue}).card == 0
-    doAssert (complement {false}) == {true}
     doAssert {bar0}.complement == {bar1, bar2}
     doAssert {range[0..10](0), 1, 2, 3}.complement == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.complement == {0.char..255.char} - {'0'..'9'}
 
+  block: # bugs
+    template impl =
+      doAssert (complement {false}) == {true}
+      doAssert fullSet(bool) == {true, false}
+    when defined(js) and defined(bsd):
+      when nimvm: impl()
+      else: discard # pending bug #17093
+    else: impl()
 
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -4,11 +4,19 @@ discard """
 import std/setutils
 
 template main =
-  doAssert "abcbb".toSet == {'a', 'b', 'c'}
-  doAssert toSet([10u8, 12, 13]) == {10u8, 12, 13}
-  doAssert toSet(0u16..30) == {0u16..30}
-  type A = distinct char
-  doAssert [A('x')].toSet == {A('x')}
-  
+  block toSetTest:
+    doAssert "abcbb".toSet == {'a', 'b', 'c'}
+    doAssert toSet([10u8, 12, 13]) == {10u8, 12, 13}
+    doAssert toSet(0u16..30) == {0u16..30}
+    type A = distinct char
+    doAssert [A('x')].toSet == {A('x')}
+  block notTest:
+    type Colors{.inject.} = enum
+      red, green, blue
+    doAssert {red, blue}.not == {green}
+    doAssert (not {red, green, blue}).card == 0
+    doAssert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
+    doAssert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
+    doAssert (not {false}) == {true}
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -17,24 +17,18 @@ template main =
 
   block: # fullSet
     doAssert fullSet(Colors) == {red, green, blue}
+    doAssert fullSet(bool) == {true, false}
     doAssert fullSet(char) == {0.chr..255.chr}
     doAssert fullSet(Bar) == {bar0, bar1, bar2}
 
-  block: # not
-    doAssert {red, blue}.not == {green}
-    doAssert (not {red, green, blue}).card == 0
-    doAssert {bar0}.not == {bar1, bar2}
-    doAssert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
-    doAssert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
+  block: # complement
+    doAssert {red, blue}.complement == {green}
+    doAssert (complement {red, green, blue}).card == 0
+    doAssert (complement {false}) == {true}
+    doAssert {bar0}.complement == {bar1, bar2}
+    doAssert {range[0..10](0), 1, 2, 3}.complement == {range[0..10](4), 5, 6, 7, 8, 9, 10}
+    doAssert {'0'..'9'}.complement == {0.char..255.char} - {'0'..'9'}
 
-  block: # bugs
-    template impl =
-      doAssert (not {false}) == {true}
-      doAssert fullSet(bool) == {true, false}
-    when defined(js):
-      when nimvm: impl()
-      else: discard # pending bug #17076
-    else: impl()
 
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -2,27 +2,27 @@ discard """
   targets: "c js"
 """
 import std/setutils
-
+type Colors = enum
+  red, green = 5, blue = 10
 template main =
-  block toSetTest:
+  block: # toSet
     doAssert "abcbb".toSet == {'a', 'b', 'c'}
     doAssert toSet([10u8, 12, 13]) == {10u8, 12, 13}
     doAssert toSet(0u16..30) == {0u16..30}
     type A = distinct char
     doAssert [A('x')].toSet == {A('x')}
-  block fullSetTest:
-    type Colors{.inject.} = enum
-      red, green = 5, blue = 10
+
+  block: # fullSet
     doAssert {true, false} == fullSet(bool)
     doAssert {red, green, blue} == fullSet(Colors)
     doAssert {0.chr..255.chr} == fullSet(char)
-  block notTest:
-    type Colors{.inject.} = enum
-      red, green = 5, blue = 10
+
+  block: # not
     doAssert {red, blue}.not == {green}
     doAssert (not {red, green, blue}).card == 0
     doAssert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.not == {0.char..255.char} - {'0'..'9'}
     doAssert (not {false}) == {true}
+
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -1,5 +1,6 @@
 discard """
   targets: "c js"
+  disabled: "bsd" # pending #17093
 """
 import std/setutils
 type 
@@ -19,22 +20,15 @@ template main =
     doAssert fullSet(Colors) == {red, green, blue}
     doAssert fullSet(char) == {0.chr..255.chr}
     doAssert fullSet(Bar) == {bar0, bar1, bar2}
+    doAssert fullSet(bool) == {true, false}
 
   block: # complement
     doAssert {red, blue}.complement == {green}
     doAssert (complement {red, green, blue}).card == 0
+    doAssert (complement {false}) == {true}
     doAssert {bar0}.complement == {bar1, bar2}
     doAssert {range[0..10](0), 1, 2, 3}.complement == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.complement == {0.char..255.char} - {'0'..'9'}
-
-  block: # bugs
-    template impl =
-      doAssert (complement {false}) == {true}
-      doAssert fullSet(bool) == {true, false}
-    when defined(js) and defined(bsd):
-      when nimvm: impl()
-      else: discard # pending bug #17093
-    else: impl()
 
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -10,9 +10,15 @@ template main =
     doAssert toSet(0u16..30) == {0u16..30}
     type A = distinct char
     doAssert [A('x')].toSet == {A('x')}
+  block fullSetTest:
+    type Colors{.inject.} = enum
+      red, green = 5, blue = 10
+    doAssert {true, false} == fullSet(bool)
+    doAssert {red, green, blue} == fullSet(Colors)
+    doAssert {0.chr..255.chr} == fullSet(char)
   block notTest:
     type Colors{.inject.} = enum
-      red, green, blue
+      red, green = 5, blue = 10
     doAssert {red, blue}.not == {green}
     doAssert (not {red, green, blue}).card == 0
     doAssert {range[0..10](0), 1, 2, 3}.not == {range[0..10](4), 5, 6, 7, 8, 9, 10}


### PR DESCRIPTION
Adds `complement` for builtin sets which inverts the set. Adds `fullset` by extension as it was required. Breaks the JS testing for an unevident reason.

(EDIT)
## notes
`proc fullSet*(T: typedesc): auto {.inline.} =`
=>
`proc fullSet*(T: typedesc): set[T] {.inline.} =` would give a BUG