### PR TITLE
Fixing inexistant word in PT

### DIFF
--- a/doc/nims.rst
+++ b/doc/nims.rst
@@ -286,7 +286,7 @@ translations.cfg
 
   [cat]
   ES = gato
-  PT = minino
+  IT = gatto
   RU = kot
   FR = chat
 


### PR DESCRIPTION
In line 289 it said PT =minino for cat. Cat in Portugues is Gato, like in spanish. minino sounds like a foreigner trying to pronounce menino, which means boy, not cat.
For variation's sake, my suggestion is to use the italian(IT) version Gatto, since it keeps in line with being close to ES, alternatively the german(DE) version Katze could be used instead.