### PR TITLE
add enumutils.items for sparse enums, typetraits.SomeSparseEnum

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,8 +41,9 @@
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 
-- Added `std/enumutils` module containing `genEnumCaseStmt` macro that generates
-  case statement to parse string to enum.
+- Added `std/enumutils` module.
+
+- Added `enumutils.genEnumCaseStmt` macro that generates case statement to parse string to enum.
 
 - Added `enumutils.items` for enums with holes
 

--- a/changelog.md
+++ b/changelog.md
@@ -41,11 +41,8 @@
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 
-- Added `std/enumutils` module.
-
-- Added `enumutils.genEnumCaseStmt` macro that generates case statement to parse string to enum.
-
-- Added `enumutils.items` for sparse enums.
+- Added `std/enumutils` module. Added `genEnumCaseStmt` macro that generates case statement to parse string to enum.
+  Added `items` for sparse enums.
 
 - Added `typetraits.SomeSparseEnum` for sparse enums.
 

--- a/changelog.md
+++ b/changelog.md
@@ -41,8 +41,12 @@
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 
-- Added std/enumutils module containing `genEnumCaseStmt` macro that generates
+- Added `std/enumutils` module containing `genEnumCaseStmt` macro that generates
   case statement to parse string to enum.
+
+- Added `enumutils.items` for enums with holes
+
+- Added `typetraits.SomeHolyEnum` for enums with holes
 
 - Removed deprecated `iup` module from stdlib, it has already moved to
   [nimble](https://github.com/nim-lang/iup).

--- a/changelog.md
+++ b/changelog.md
@@ -45,9 +45,9 @@
 
 - Added `enumutils.genEnumCaseStmt` macro that generates case statement to parse string to enum.
 
-- Added `enumutils.items` for enums with holes
+- Added `enumutils.items` for sparse enums.
 
-- Added `typetraits.SomeHolyEnum` for enums with holes
+- Added `typetraits.SomeSparseEnum` for sparse enums.
 
 - Removed deprecated `iup` module from stdlib, it has already moved to
   [nimble](https://github.com/nim-lang/iup).

--- a/changelog.md
+++ b/changelog.md
@@ -42,9 +42,9 @@
   Useful for library authors.
 
 - Added `std/enumutils` module. Added `genEnumCaseStmt` macro that generates case statement to parse string to enum.
-  Added `items` for sparse enums.
+  Added `items` for enums with holes.
 
-- Added `typetraits.SomeSparseEnum` for sparse enums.
+- Added `typetraits.SomeEnumWithHoles` for enums with holes.
 
 - Removed deprecated `iup` module from stdlib, it has already moved to
   [nimble](https://github.com/nim-lang/iup).

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -85,9 +85,15 @@ Algorithms
 * `algorithm <algorithm.html>`_
   This module implements some common generic algorithms like sort or binary search.
 
+* `std/enumutils <enumutils.html>`_
+  This module adds functionality for the built-in ``enum`` type.
+
 * `sequtils <sequtils.html>`_
   This module implements operations for the built-in ``seq`` type
   which were inspired by functional programming languages.
+
+* `std/setutils <setutils.html>`_
+  This module adds functionality for the built-in ``set`` type.
 
 
 Collections
@@ -119,12 +125,6 @@ Collections
 
 * `sets <sets.html>`_
   Nim hash and bit set support.
-
-* `std/setutils <setutils.html>`_
-  This module adds functionality for the built-in ``set`` type.
-
-* `std/enumutils <enumutils.html>`_
-  This module adds functionality for the built-in ``enum`` type.
 
 * `sharedlist <sharedlist.html>`_
   Nim shared linked list support. Contains a shared singly-linked list.

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -89,9 +89,6 @@ Algorithms
   This module implements operations for the built-in ``seq`` type
   which were inspired by functional programming languages.
 
-* `std/setutils <setutils.html>`_
-  This module adds functionality for the built-in ``set`` type.
-
 
 Collections
 -----------
@@ -122,6 +119,12 @@ Collections
 
 * `sets <sets.html>`_
   Nim hash and bit set support.
+
+* `std/setutils <setutils.html>`_
+  This module adds functionality for the built-in ``set`` type.
+
+* `std/enumutils <enumutils.html>`_
+  This module adds functionality for the built-in ``enum`` type.
 
 * `sharedlist <sharedlist.html>`_
   Nim shared linked list support. Contains a shared singly-linked list.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -15,7 +15,7 @@
 import std/private/since
 export system.`$` # for backward compatibility
 
-type SomeSparseEnum* = (not Ordinal) and enum ## sparse enum's, a.k.a enum with holes
+type SomeSparseEnum* = (not Ordinal) and enum ## Sparse enum's, a.k.a enum with holes.
 
 #[
 xxx `runnableExamples` isn't run if inside:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -15,6 +15,22 @@
 import std/private/since
 export system.`$` # for backward compatibility
 
+type SomeHolyEnum* = concept x ## Type class for enum's with holes.
+  x is enum and x isnot Ordinal
+
+#[
+xxx `runnableExamples` isn't run if inside:
+type SomeHolyEnum* = concept x
+  runnableExamples: assert false
+  x is enum and x isnot Ordinal
+]#
+
+runnableExamples:
+  type Goo = enum g0 = 2, g1, g2
+  type Hoo = enum h0 = 2, h1 = 4, h2
+  assert Goo isnot SomeHolyEnum
+  assert Hoo is SomeHolyEnum
+
 proc name*(t: typedesc): string {.magic: "TypeTrait".} =
   ## Returns the name of the given type.
   ##

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -15,7 +15,7 @@
 import std/private/since
 export system.`$` # for backward compatibility
 
-type SomeSparseEnum* = concept x ## Type class for enum's with holes.
+type SomeSparseEnum* = concept x ## Type class for sparse enum's.
   x is enum and x isnot Ordinal
 
 #[

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -15,8 +15,7 @@
 import std/private/since
 export system.`$` # for backward compatibility
 
-type SomeSparseEnum* = concept x ## Type class for sparse enum's.
-  x is enum and x isnot Ordinal
+type SomeSparseEnum* = (not Ordinal) and enum ## sparse enum's, a.k.a enum with holes
 
 #[
 xxx `runnableExamples` isn't run if inside:

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -26,10 +26,13 @@ type SomeHolyEnum* = concept x
 ]#
 
 runnableExamples:
-  type Goo = enum g0 = 2, g1, g2
-  type Hoo = enum h0 = 2, h1 = 4, h2
-  assert Goo isnot SomeHolyEnum
-  assert Hoo is SomeHolyEnum
+  type A = enum a0 = 2, a1 = 4, a2
+  type B = enum b0 = 2, b1, b2
+  assert A is SomeHolyEnum
+  assert B isnot SomeHolyEnum
+  assert int isnot SomeHolyEnum
+  type C[T] = enum h0 = 2, h1 = 4
+  assert C[float] is SomeHolyEnum
 
 proc name*(t: typedesc): string {.magic: "TypeTrait".} =
   ## Returns the name of the given type.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -15,23 +15,16 @@
 import std/private/since
 export system.`$` # for backward compatibility
 
-type SomeSparseEnum* = (not Ordinal) and enum ## Sparse enum's, a.k.a enum with holes.
-
-#[
-xxx `runnableExamples` isn't run if inside:
-type Foo* = concept x
-  runnableExamples: assert false
-  x is int
-]#
+type SomeEnumWithHoles* = (not Ordinal) and enum ## Enum with holes.
 
 runnableExamples:
   type A = enum a0 = 2, a1 = 4, a2
   type B = enum b0 = 2, b1, b2
-  assert A is SomeSparseEnum
-  assert B isnot SomeSparseEnum
-  assert int isnot SomeSparseEnum
+  assert A is SomeEnumWithHoles
+  assert B isnot SomeEnumWithHoles
+  assert int isnot SomeEnumWithHoles
   type C[T] = enum h0 = 2, h1 = 4
-  assert C[float] is SomeSparseEnum
+  assert C[float] is SomeEnumWithHoles
 
 proc name*(t: typedesc): string {.magic: "TypeTrait".} =
   ## Returns the name of the given type.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -15,24 +15,24 @@
 import std/private/since
 export system.`$` # for backward compatibility
 
-type SomeHolyEnum* = concept x ## Type class for enum's with holes.
+type SomeSparseEnum* = concept x ## Type class for enum's with holes.
   x is enum and x isnot Ordinal
 
 #[
 xxx `runnableExamples` isn't run if inside:
-type SomeHolyEnum* = concept x
+type Foo* = concept x
   runnableExamples: assert false
-  x is enum and x isnot Ordinal
+  x is int
 ]#
 
 runnableExamples:
   type A = enum a0 = 2, a1 = 4, a2
   type B = enum b0 = 2, b1, b2
-  assert A is SomeHolyEnum
-  assert B isnot SomeHolyEnum
-  assert int isnot SomeHolyEnum
+  assert A is SomeSparseEnum
+  assert B isnot SomeSparseEnum
+  assert int isnot SomeSparseEnum
   type C[T] = enum h0 = 2, h1 = 4
-  assert C[float] is SomeHolyEnum
+  assert C[float] is SomeSparseEnum
 
 proc name*(t: typedesc): string {.magic: "TypeTrait".} =
   ## Returns the name of the given type.

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-import macros
+import std/macros
 
 macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed, 
             userMin, userMax: static[int], normalizer: static[proc(s :string): string]): untyped =
@@ -62,3 +62,12 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
   else:
     expectKind(default, nnkSym)
     result.add nnkElse.newTree(default)
+
+macro holyEnumFullRange(a: typed): untyped = result = newNimNode(nnkCurly).add(a.getType[1][1..^1])
+
+iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
+  runnableExamples:
+    type Hoo = enum h0 = 2, h1 = 4, h2
+    from sequtils import toSeq
+    assert Hoo.toSeq == [h0, h1, h2]
+  for a in holyEnumFullRange(E): yield a

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -67,7 +67,9 @@ macro holyEnumFullRange(a: typed): untyped = result = newNimNode(nnkCurly).add(a
 
 iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
   runnableExamples:
-    type Hoo = enum h0 = 2, h1 = 4, h2
+    type A = enum a0 = 2, a1 = 4, a2
+    type B[T] = enum b0 = 2, b1 = 4
     from sequtils import toSeq
-    assert Hoo.toSeq == [h0, h1, h2]
+    assert A.toSeq == [a0, a1, a2]
+    assert B[float].toSeq == [B[float].b0, B[float].b1]
   for a in holyEnumFullRange(E): yield a

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -65,15 +65,15 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
     expectKind(default, nnkSym)
     result.add nnkElse.newTree(default)
 
-macro sparseEnumFullRange(a: typed): untyped = 
+macro enumWithHolesFullRange(a: typed): untyped = 
   newNimNode(nnkCurly).add(a.getType[1][1..^1])
 
 iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
-  ## Iterates over a sparse enum.
+  ## Iterates over an enum with holes.
   runnableExamples:
     type A = enum a0 = 2, a1 = 4, a2
     type B[T] = enum b0 = 2, b1 = 4
     from std/sequtils import toSeq
     assert A.toSeq == [a0, a1, a2]
     assert B[float].toSeq == [B[float].b0, B[float].b1]
-  for a in sparseEnumFullRange(E): yield a
+  for a in enumWithHolesFullRange(E): yield a

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -69,7 +69,7 @@ macro sparseEnumFullRange(a: typed): untyped =
   newNimNode(nnkCurly).add(a.getType[1][1..^1])
 
 iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
-  ## iterates over a sparse enum
+  ## Iterates over a sparse enum.
   runnableExamples:
     type A = enum a0 = 2, a1 = 4, a2
     type B[T] = enum b0 = 2, b1 = 4

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -63,13 +63,14 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
     expectKind(default, nnkSym)
     result.add nnkElse.newTree(default)
 
-macro holyEnumFullRange(a: typed): untyped = result = newNimNode(nnkCurly).add(a.getType[1][1..^1])
+macro sparseEnumFullRange(a: typed): untyped = result = newNimNode(nnkCurly).add(a.getType[1][1..^1])
 
 iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
+  ## iterates over a sparse enum
   runnableExamples:
     type A = enum a0 = 2, a1 = 4, a2
     type B[T] = enum b0 = 2, b1 = 4
     from sequtils import toSeq
     assert A.toSeq == [a0, a1, a2]
     assert B[float].toSeq == [B[float].b0, B[float].b1]
-  for a in holyEnumFullRange(E): yield a
+  for a in sparseEnumFullRange(E): yield a

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -9,6 +9,8 @@
 
 import std/macros
 
+# xxx `genEnumCaseStmt` needs tests and runnableExamples
+
 macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed, 
             userMin, userMax: static[int], normalizer: static[proc(s :string): string]): untyped =
   # generates a case stmt, which assigns the correct enum field given
@@ -63,7 +65,8 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
     expectKind(default, nnkSym)
     result.add nnkElse.newTree(default)
 
-macro sparseEnumFullRange(a: typed): untyped = result = newNimNode(nnkCurly).add(a.getType[1][1..^1])
+macro sparseEnumFullRange(a: typed): untyped = 
+  newNimNode(nnkCurly).add(a.getType[1][1..^1])
 
 iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
   ## iterates over a sparse enum

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -73,7 +73,7 @@ iterator items*[T: enum and not Ordinal](E: typedesc[T]): T =
   runnableExamples:
     type A = enum a0 = 2, a1 = 4, a2
     type B[T] = enum b0 = 2, b1 = 4
-    from sequtils import toSeq
+    from std/sequtils import toSeq
     assert A.toSeq == [a0, a1, a2]
     assert B[float].toSeq == [B[float].b0, B[float].b1]
   for a in sparseEnumFullRange(E): yield a

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -82,8 +82,13 @@ iterator mitems*(a: var cstring): var char {.inline.} =
       yield a[i]
       inc(i)
 
-iterator items*[T: enum](E: typedesc[T]): T =
-  ## Iterates over the values of the enum ``E``.
+iterator items*[T: enum and Ordinal](E: typedesc[T]): T =
+  ## Iterates over the values of `E`.
+  ## See also `enumutils.items` for enums with holes.
+  runnableExamples:
+    type Goo = enum g0 = 2, g1, g2
+    from std/sequtils import toSeq
+    assert Goo.toSeq == [g0, g1, g2]
   for v in low(E) .. high(E):
     yield v
 

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -84,7 +84,7 @@ iterator mitems*(a: var cstring): var char {.inline.} =
 
 iterator items*[T: enum and Ordinal](E: typedesc[T]): T =
   ## Iterates over the values of `E`.
-  ## See also `enumutils.items` for sparse enums.
+  ## See also `enumutils.items` for enums with holes.
   runnableExamples:
     type Goo = enum g0 = 2, g1, g2
     from std/sequtils import toSeq

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -84,7 +84,7 @@ iterator mitems*(a: var cstring): var char {.inline.} =
 
 iterator items*[T: enum and Ordinal](E: typedesc[T]): T =
   ## Iterates over the values of `E`.
-  ## See also `enumutils.items` for enums with holes.
+  ## See also `enumutils.items` for sparse enums.
   runnableExamples:
     type Goo = enum g0 = 2, g1, g2
     from std/sequtils import toSeq

--- a/tests/stdlib/tenumutils.nim
+++ b/tests/stdlib/tenumutils.nim
@@ -9,8 +9,8 @@ template main =
   block: # items
     type A = enum a0 = 2, a1 = 4, a2
     type B[T] = enum b0 = 2, b1 = 4
-    assert A.toSeq == [a0, a1, a2]
-    assert B[float].toSeq == [B[float].b0, B[float].b1]
+    doAssert A.toSeq == [a0, a1, a2]
+    doAssert B[float].toSeq == [B[float].b0, B[float].b1]
 
 static: main()
 main()

--- a/tests/stdlib/tenumutils.nim
+++ b/tests/stdlib/tenumutils.nim
@@ -1,0 +1,16 @@
+discard """
+  targets: "c js"
+"""
+
+import std/enumutils
+from std/sequtils import toSeq
+
+template main =
+  block: # items
+    type A = enum a0 = 2, a1 = 4, a2
+    type B[T] = enum b0 = 2, b1 = 4
+    assert A.toSeq == [a0, a1, a2]
+    assert B[float].toSeq == [B[float].b0, B[float].b1]
+
+static: main()
+main()


### PR DESCRIPTION
(inspired by `enmRange` in https://github.com/nim-lang/Nim/pull/17066, thanks @beef331 !)
* fixes https://github.com/nim-lang/Nim/issues/1982

## future work
- [x] I suggest changing holey enum in manual (and doc comments etc) to sparse enum, IMO it's just better. No code would break since (until this PR) we dont' have public API's mentioning hole/holey (IIRC); EDIT: after review comments, I changed it back to enum with holes
- [ ] `genEnumCaseStmt` needs tests and runnableExamples
- [ ] `proc nativeString*(a: enum): string {.compileTime.}` magic proc which would by pass enum string definitions:
```nim
type Foo = enum
  kf0 = "F0"
  kf1 = "F1"
var a = kf0
doAsert $a == "F0"
doAsert a.nativeString == "kf0"
```

