### PR TITLE
enable bsd for tsetutils; improve setutils API

### DIFF
--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -38,18 +38,21 @@ template toSet*(iter: untyped): untyped =
 
 macro enmRange(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
-proc fullSet*(T: typedesc): auto {.inline.} =
-  ## Returns a full set of all valid elements.
+# proc fullSet*(T: typedesc): set[T] {.inline.} = # xxx would give: Error: ordinal type expected
+proc fullSet*[T](U: typedesc[T]): set[T] {.inline.} =
+  ## Returns a set containing all elements in `U`.
   runnableExamples:
-    assert {true, false} == fullSet(bool)
+    assert bool.fullSet == {true, false}
+    type A = range[1..3]
+    assert A.fullSet == {1.A, 2, 3}
+    assert int8.fullSet.len == 256
   when T is Ordinal:
     {T.low..T.high}
   else: # Hole filled enum
     enmRange(T)
 
 proc complement*[T](s: set[T]): set[T] {.inline.} =
-  ## Returns the complement of the set.
-  ## Can also be thought of as inverting the set.
+  ## Returns the set complement of `a`.
   runnableExamples:
     type Colors = enum
       red, green = 3, blue

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -1,13 +1,15 @@
 discard """
   targets: "c js"
-  disabled: "bsd" # pending #17093
 """
+
 import std/setutils
+
 type 
   Colors = enum
     red, green = 5, blue = 10
   Bar = enum
     bar0 = -1, bar1, bar2
+
 template main =
   block: # toSet
     doAssert "abcbb".toSet == {'a', 'b', 'c'}


### PR DESCRIPTION
* followup #17066
* refs https://github.com/nim-lang/Nim/issues/17097 for understanding why bsd was failing in CI
* make API more typesafe

## future work
- [ ] figure out why `proc fullSet*(T: typedesc): set[T] {.inline.} =` gives `Error: ordinal type expected` and fix it