### PR TITLE
fix #17097 -builds.sr.ht  CI: merge PRs into devel before testing

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -15,6 +15,12 @@ environment:
 tasks:
 - setup: |
     cd Nim
+    if [[ -v GITHUB_PR_NUMBER ]]; then
+      # this was a PR, so we need to checkout devel and try to merge into it
+      REVISION=$(git rev-parse HEAD)
+      git checkout devel
+      git merge "$REVISION"
+    fi
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)
     bin/nim c --skipUserCfg --skipParentCfg koch

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -15,7 +15,7 @@ environment:
 tasks:
 - setup: |
     cd Nim
-    if [[ -v GITHUB_PR_NUMBER ]]; then
+    if [ "${GITHUB_PR_NUMBER+1}" ]; then
       # this was a PR, so we need to checkout devel and try to merge into it
       REVISION=$(git rev-parse HEAD)
       git checkout devel

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -17,6 +17,11 @@ tasks:
     cd Nim
     if [ "${GITHUB_PR_NUMBER+1}" ]; then
       # this was a PR, so we need to checkout devel and try to merge into it
+      # see https://man.sr.ht/dispatch.sr.ht/github.md#environment-variables
+      # actual values for a job can be accessed with urls like: https://builds.sr.ht/api/jobs/430827/manifest
+      git remote -v
+      git branch
+
       git pull origin devel
     fi
     git clone --depth 1 -q https://github.com/nim-lang/csources.git

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -17,9 +17,7 @@ tasks:
     cd Nim
     if [ "${GITHUB_PR_NUMBER+1}" ]; then
       # this was a PR, so we need to checkout devel and try to merge into it
-      REVISION=$(git rev-parse HEAD)
-      git checkout devel
-      git merge "$REVISION"
+      git pull origin devel
     fi
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpu)

--- a/.builds/openbsd_0.yml
+++ b/.builds/openbsd_0.yml
@@ -18,6 +18,12 @@ environment:
 tasks:
 - setup: |
     cd Nim
+    if [[ -v GITHUB_PR_NUMBER ]]; then
+      # this was a PR, so we need to checkout devel and try to merge into it
+      REVISION=$(git rev-parse HEAD)
+      git checkout devel
+      git merge "$REVISION"
+    fi
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpuonline)
     bin/nim c koch

--- a/.builds/openbsd_0.yml
+++ b/.builds/openbsd_0.yml
@@ -18,7 +18,7 @@ environment:
 tasks:
 - setup: |
     cd Nim
-    if [[ -v GITHUB_PR_NUMBER ]]; then
+    if [ "${GITHUB_PR_NUMBER+1}" ]; then
       # this was a PR, so we need to checkout devel and try to merge into it
       REVISION=$(git rev-parse HEAD)
       git checkout devel

--- a/.builds/openbsd_1.yml
+++ b/.builds/openbsd_1.yml
@@ -18,6 +18,12 @@ environment:
 tasks:
 - setup: |
     cd Nim
+    if [[ -v GITHUB_PR_NUMBER ]]; then
+      # this was a PR, so we need to checkout devel and try to merge into it
+      REVISION=$(git rev-parse HEAD)
+      git checkout devel
+      git merge "$REVISION"
+    fi
     git clone --depth 1 -q https://github.com/nim-lang/csources.git
     gmake -C csources -j $(sysctl -n hw.ncpuonline)
     bin/nim c koch

--- a/.builds/openbsd_1.yml
+++ b/.builds/openbsd_1.yml
@@ -18,7 +18,7 @@ environment:
 tasks:
 - setup: |
     cd Nim
-    if [[ -v GITHUB_PR_NUMBER ]]; then
+    if [ "${GITHUB_PR_NUMBER+1}" ]; then
       # this was a PR, so we need to checkout devel and try to merge into it
       REVISION=$(git rev-parse HEAD)
       git checkout devel


### PR DESCRIPTION
Fixes #17097

This alters the build scripts to checkout `devel`, and merge the commit being built into it. This only happens for PRs - commits straight the repository will act as they did before.

Note that this page documents the available environment variables: https://man.sr.ht/dispatch.sr.ht/github.md#environment-variables

The environment variables can also be seen by viewing the manifest for a given build, such as: https://builds.sr.ht/api/jobs/430827/manifest