### PR TITLE
move prelude so that `include std/prelude` also works

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,8 @@
   `typetraits.nim` module.
 
 - `prelude` now works with the JavaScript target.
+  Added `sequtils` import to `prelude`.
+  `prelude` can now be used via `include std/prelude`, but `include prelude` still works.
 
 - Added `almostEqual` in `math` for comparing two float values using a machine epsilon.
 
@@ -93,8 +95,6 @@
   and `lists.toDoublyLinkedList` convert from `openArray`s; `lists.copy` implements
   shallow copying; `lists.add` concatenates two lists - an O(1) variation that consumes
   its argument, `addMoved`, is also supplied.
-
-- Added `sequtils` import to `prelude`.
 
 - Added `euclDiv` and `euclMod` to `math`.
 - Added `httpcore.is1xx` and missing HTTP codes.

--- a/doc/prelude.rst
+++ b/doc/prelude.rst
@@ -4,12 +4,12 @@ Prelude
 This is an include file that simply imports common modules for your convenience:
 
 .. code-block:: nim
-  include prelude
+  include std/prelude
 
 Same as:
 
 .. code-block:: nim
-  import os, strutils, times, parseutils, parseopt, hashes, tables, sets
+  import std/[os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt]
 
 
 Examples
@@ -18,7 +18,7 @@ Examples
 Get the basic most common imports ready to start coding using ``prelude``:
 
 .. code-block:: nim
-  include prelude
+  include std/prelude
 
   echo now()
   echo getCurrentDir()

--- a/lib/pure/prelude.nim
+++ b/lib/pure/prelude.nim
@@ -11,11 +11,14 @@
 ## convenience:
 ##
 ## .. code-block:: nim
-##   include prelude
+##   include std/prelude
 ##
 ## Same as:
 ##
 ## .. code-block:: nim
-##   import os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt
+##   import std/[os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt]
 
-import os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt
+# xxx deduplicate with prelude.rst
+
+import std/[os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt]
+

--- a/tests/stdlib/tprelude.nim
+++ b/tests/stdlib/tprelude.nim
@@ -1,0 +1,14 @@
+discard """
+  targets: "c js"
+  matrix: "; -d:nimTestTpreludeCase1"
+"""
+
+when defined nimTestTpreludeCase1:
+  include std/prelude
+else:
+  include prelude
+
+template main() =
+  doAssert toSeq(1..3) == @[1,2,3]
+static: main()
+main()

--- a/tools/heapdump2dot.nim
+++ b/tools/heapdump2dot.nim
@@ -1,5 +1,5 @@
 
-include prelude
+include std/prelude
 
 proc main(input, output: string) =
   type NodeKind = enum

--- a/tools/heapdumprepl.nim
+++ b/tools/heapdumprepl.nim
@@ -1,5 +1,5 @@
 
-include prelude
+include std/prelude
 import intsets
 
 type

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -143,7 +143,7 @@ lib/posix/termios.nim
 
   # some of these are include files so shouldn't be docgen'd
   ignoredModules = """
-lib/prelude.nim
+lib/pure/prelude.nim
 lib/pure/future.nim
 lib/pure/collections/hashcommon.nim
 lib/pure/collections/tableimpl.nim


### PR DESCRIPTION
* refs https://github.com/nim-lang/Nim/pull/17105
* fixes bug2 from https://github.com/nim-lang/Nim/issues/16238
* add test

we still should offer a better alternative to `include prelude`, see https://github.com/timotheecour/Nim/issues/388, but that's a separate topic