### PR TITLE
disable most flaky test in CI (refs #16338)

### DIFF
--- a/tests/untestable/thttpclient_ssl_remotenetwork.nim
+++ b/tests/untestable/thttpclient_ssl_remotenetwork.nim
@@ -162,8 +162,6 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
 
   suite "SSL certificate check - httpclient - threaded":
     when defined(nimTestsEnableFlaky) or not defined(linux): # xxx pending bug #16338
-      # see also tests/misc/t16338.nim
-
       # Spawn threads before the "test" blocks
       var outcomes = newSeq[FlowVar[TTOutcome]](certificate_tests.len)
       for i, ct in certificate_tests:

--- a/tests/untestable/thttpclient_ssl_remotenetwork.nim
+++ b/tests/untestable/thttpclient_ssl_remotenetwork.nim
@@ -13,7 +13,7 @@
 ## for a comparison with other clients.
 
 from stdtest/testutils import enableRemoteNetworking
-when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(windows) and not defined(openbsd) and not defined(i386)):
+when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(windows) and not defined(openbsd)):
   # Not supported on Windows due to old openssl version
   import
     httpclient,
@@ -95,7 +95,7 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
 
 
   template evaluate(exception_msg: string, category: Category, desc: string) =
-    # Evaluate test outcome. Testes flagged as _broken are evaluated and skipped
+    # Evaluate test outcome. Tests flagged as `_broken` are evaluated and skipped
     let raised = (exception_msg.len > 0)
     let should_not_raise = category in {good, dubious_broken, bad_broken}
     if should_not_raise xor raised:
@@ -161,21 +161,22 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
 
 
   suite "SSL certificate check - httpclient - threaded":
+    when defined(nimTestsEnableFlaky) or not defined(linux): # xxx pending bug #16338
+      # see also tests/misc/t16338.nim
 
-    # Spawn threads before the "test" blocks
-    var outcomes = newSeq[FlowVar[TTOutcome]](certificate_tests.len)
-    for i, ct in certificate_tests:
-      let t = spawn run_t_test(ct)
-      outcomes[i] = t
+      # Spawn threads before the "test" blocks
+      var outcomes = newSeq[FlowVar[TTOutcome]](certificate_tests.len)
+      for i, ct in certificate_tests:
+        let t = spawn run_t_test(ct)
+        outcomes[i] = t
 
-    # create "test" blocks and handle thread outputs
-    for t in outcomes:
-      let outcome = ^t  # wait for a thread to terminate
-
-      test outcome.desc:
-
-        evaluate(outcome.exception_msg, outcome.category, outcome.desc)
-
+      # create "test" blocks and handle thread outputs
+      for t in outcomes:
+        let outcome = ^t  # wait for a thread to terminate
+        test outcome.desc:
+          evaluate(outcome.exception_msg, outcome.category, outcome.desc)
+    else:
+      echo "skipped test"
 
   # net tests
 


### PR DESCRIPTION
* refs https://github.com/nim-lang/Nim/issues/16338
* this is the most flaky test in CI; it's not clear how to fix it or minimize it, so the problematic part of the test is now disabled and the bug should stay open until it's fixed so we can re-enable this section.
* enable i386 (previously disabled for the whole test) but, like for linux 64, the problematic section of the test is disabled

## note
* seems to only affect linux
* i can't reproduce this bug locally (on linux via docker), it only occurs in CI for some reason
* underlying bug needs to be fixed (in future work) as it could re-occur in other contexts
* followup in https://github.com/nim-lang/Nim/pull/17310 to investigate this failure