### PR TITLE
Add example for pattern matching on options

### DIFF
--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -64,7 +64,7 @@ supports pattern matching on `Option`s, with the `Some(<pattern>)` and
   of None():
     assert false
 
-  assertMatch(Some(Some(None())), some(some(none(int))))
+  assertMatch(some(some(none(int))), Some(Some(None())))
 ]##
 # xxx pending https://github.com/timotheecour/Nim/issues/376 use `runnableExamples` and `whichModule`
 

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -7,22 +7,24 @@
 #    distribution, for details about the copyright.
 #
 
-## This module implements types which encapsulate an optional value.
-##
-## A value of type `Option[T]` either contains a value `x` (represented as
-## `some(x)`) or is empty (`none(T)`).
-##
-## This can be useful when you have a value that can be present or not. The
-## absence of a value is often represented by `nil`, but that is not always
-## available, nor is it always a good solution.
-##
-##
-## Basic usage
-## ===========
-##
-## Let's start with an example: a procedure that finds the index of a character
-## in a string.
-##
+##[
+This module implements types which encapsulate an optional value.
+
+A value of type `Option[T]` either contains a value `x` (represented as
+`some(x)`) or is empty (`none(T)`).
+
+This can be useful when you have a value that can be present or not. The
+absence of a value is often represented by `nil`, but that is not always
+available, nor is it always a good solution.
+
+
+Basic usage
+===========
+
+Let's start with an example: a procedure that finds the index of a character
+in a string.
+]##
+
 runnableExamples:
   proc find(haystack: string, needle: char): Option[int] =
     for i, c in haystack:
@@ -34,35 +36,37 @@ runnableExamples:
   let found = "abc".find('c')
   assert found.isSome and found.get() == 2
 
-## The `get` operation demonstrated above returns the underlying value, or
-## raises `UnpackDefect` if there is no value. Note that `UnpackDefect`
-## inherits from `system.Defect` and should therefore never be caught.
-## Instead, rely on checking if the option contains a value with the
-## `isSome <#isSome,Option[T]>`_ and `isNone <#isNone,Option[T]>`_ procs.
-##
-##
-## Pattern matching
-## ================
-##
-## .. note:: This requires the [fusion](https://github.com/nim-lang/fusion) package.
-##
-## [fusion/matching](https://nim-lang.github.io/fusion/src/fusion/matching.html)
-## supports pattern matching on `Option`s, with the `Some(<pattern>)` and
-## `None()` patterns.
-##
-## .. code-block:: nim
-##   {.experimental: "caseStmtMacros".}
-##
-##   import fusion/matching
-##
-##   case some(42)
-##   of Some(@a):
-##     assert a == 42
-##   of None():
-##     assert false
-##
-##   assertMatch(Some(Some(None())), some(some(none(int))))
-# xxx pending https://github.com/timotheecour/Nim/issues/376 use `whichModule`
+##[
+The `get` operation demonstrated above returns the underlying value, or
+raises `UnpackDefect` if there is no value. Note that `UnpackDefect`
+inherits from `system.Defect` and should therefore never be caught.
+Instead, rely on checking if the option contains a value with the
+`isSome <#isSome,Option[T]>`_ and `isNone <#isNone,Option[T]>`_ procs.
+
+
+Pattern matching
+================
+
+.. note:: This requires the [fusion](https://github.com/nim-lang/fusion) package.
+
+[fusion/matching](https://nim-lang.github.io/fusion/src/fusion/matching.html)
+supports pattern matching on `Option`s, with the `Some(<pattern>)` and
+`None()` patterns.
+
+.. code-block:: nim
+  {.experimental: "caseStmtMacros".}
+
+  import fusion/matching
+
+  case some(42)
+  of Some(@a):
+    assert a == 42
+  of None():
+    assert false
+
+  assertMatch(Some(Some(None())), some(some(none(int))))
+]##
+# xxx pending https://github.com/timotheecour/Nim/issues/376 use `runnableExamples` and `whichModule`
 
 
 import std/typetraits

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -44,22 +44,24 @@ runnableExamples:
 ## Pattern matching
 ## ================
 ##
+## **Note:** This requires the [fusion](https://github.com/nim-lang/fusion) package.
+##
 ## [fusion/matching](https://nim-lang.github.io/fusion/src/fusion/matching.html)
 ## supports pattern matching on `Option`s, with the `Some(<pattern>)` and
 ## `None()` patterns.
-
-runnableExamples:
-  {.experimental: "caseStmtMacros".}
-
-  import fusion/matching
-
-  case some(42)
-  of Some(@a):
-    assert a == 42
-  of None():
-    assert false
-
-  Some(Some(None())) := some(some(none(int)))
+##
+## .. code-block:: nim
+##   {.experimental: "caseStmtMacros".}
+##
+##   import fusion/matching
+##
+##   case some(42)
+##   of Some(@a):
+##     assert a == 42
+##   of None():
+##     assert false
+##
+##   Some(Some(None())) := some(some(none(int)))
 
 
 import std/typetraits

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -44,7 +44,7 @@ runnableExamples:
 ## Pattern matching
 ## ================
 ##
-## **Note:** This requires the [fusion](https://github.com/nim-lang/fusion) package.
+## .. note:: This requires the [fusion](https://github.com/nim-lang/fusion) package.
 ##
 ## [fusion/matching](https://nim-lang.github.io/fusion/src/fusion/matching.html)
 ## supports pattern matching on `Option`s, with the `Some(<pattern>)` and
@@ -61,7 +61,8 @@ runnableExamples:
 ##   of None():
 ##     assert false
 ##
-##   Some(Some(None())) := some(some(none(int)))
+##   assertMatch(Some(Some(None())), some(some(none(int))))
+# xxx pending https://github.com/timotheecour/Nim/issues/376 use `whichModule`
 
 
 import std/typetraits

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -39,6 +39,27 @@ runnableExamples:
 ## inherits from `system.Defect` and should therefore never be caught.
 ## Instead, rely on checking if the option contains a value with the
 ## `isSome <#isSome,Option[T]>`_ and `isNone <#isNone,Option[T]>`_ procs.
+##
+##
+## Pattern matching
+## ================
+##
+## [fusion/matching](https://nim-lang.github.io/fusion/src/fusion/matching.html)
+## supports pattern matching on `Option`s, with the `Some(<pattern>)` and
+## `None()` patterns.
+
+runnableExamples:
+  {.experimental: "caseStmtMacros".}
+
+  import fusion/matching
+
+  case some(42)
+  of Some(@a):
+    assert a == 42
+  of None():
+    assert false
+
+  Some(Some(None())) := some(some(none(int)))
 
 
 import std/typetraits


### PR DESCRIPTION
Follow-up to #17036. This PR adds an example for pattern matching on options. It uses `code-block`, since `fusion` isn't bundled anymore (see #16925). If there is a way to turn this into a `runnableExamples`, please let me know.