### PR TITLE
Fixes #17039 - checked field addr analysis

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -711,7 +711,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     of opcLdObj:
       # a = b.c
       decodeBC(rkNode)
-      let src = regs[rb].node
+      let src = if regs[rb].kind == rkNode: regs[rb].node else: regs[rb].nodeAddr[]
       case src.kind
       of nkEmpty..nkNilLit:
         # for nkPtrLit, this could be supported in the future, use something like:

--- a/tests/vm/t17039.nim
+++ b/tests/vm/t17039.nim
@@ -1,0 +1,10 @@
+type
+  Obj1 = object
+    case kind: bool
+    of false:
+      field: seq[int]
+    else: discard
+
+static:
+  var obj1 = Obj1()
+  obj1.field.add(@[])


### PR DESCRIPTION
Checked field expressions, such as an object variant field access results in
occasionally broken address analysis crashing the VM. This guard added here
mimics guarded access in ldObjAddr. This is to prevent a crash, while a fix is
devised.