### PR TITLE
when statements branches exit early

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2364,6 +2364,7 @@ proc semWhen(c: PContext, n: PNode, semCheck = true): PNode =
           discard
         elif e.intVal != 0 and result == nil:
           setResult(it[1])
+          return # we're not in nimvm and we already have a result
     of nkElse, nkElseExpr:
       checkSonsLen(it, 1, c.config)
       if result == nil or whenNimvm:

--- a/tests/whenstmt/twhen.nim
+++ b/tests/whenstmt/twhen.nim
@@ -1,0 +1,47 @@
+discard """
+  nimout: '''
+nimvm - when
+nimvm - whenElif
+nimvm - whenElse
+'''
+  output: '''
+when
+whenElif
+whenElse
+'''
+"""
+
+# test both when and when nimvm to ensure proper evaluation
+
+proc compileOrRuntimeProc(s: string) =
+  when nimvm:
+    echo "nimvm - " & s
+  else:
+     echo s
+
+template output(s: string) =
+  static:
+    compileOrRuntimeProc(s)
+  compileOrRuntimeProc(s)
+
+when compiles(1):
+  output("when")
+elif compiles(2):
+  output("fail - whenElif")
+else:
+  output("fail - whenElse")
+
+when compiles(nonexistent):
+  output("fail - when")
+elif compiles(1):
+  output("whenElif")
+else:
+  output("fail - whenElse")
+
+when compiles(nonexistent):
+  output("fail - when")
+elif compiles(nonexistent):
+  output("fail - whenElif")
+else:
+  output("whenElse")
+

--- a/tests/whenstmt/twhen_macro.nim
+++ b/tests/whenstmt/twhen_macro.nim
@@ -1,0 +1,24 @@
+import macros
+
+discard """
+  output: '''
+when - test
+'''
+"""
+
+# test that when stmt works from within a macro
+
+macro output(s: string, xs: varargs[untyped]): auto =
+  result = quote do:
+    when compiles(`s`):
+      "when - " & `s`
+    elif compiles(`s`):
+      "elif - " & `s`
+      # should never get here so this should not break
+      broken.xs
+    else:
+      "else - " & `s`
+      # should never get here so this should not break
+      more.broken.xs
+
+echo output("test")


### PR DESCRIPTION
When statements branches, outside of nimvim, exit early. In nimvim it
seems that all sides of the branches must be evaluated as the code gen
happens at a later stage, this remains intact.

This likely used to work prior to the recent changes in #16922, which likely
masked the issue by short circuiting of vm execution of macro, const, etc.