### PR TITLE
`std/options`: `$some(3)` is now `"some(3)"`, etc.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -170,6 +170,9 @@ provided by the operating system.
   of termination.
 
 
+- `std/options` changed `$some(3)` to `"some(3)"` instead of `"Some(3)"`
+  and `$none(int)` to `"none(int)"` instead of `"None[int]"`.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -306,8 +306,8 @@ proc flatMap*[T, R](self: Option[T],
 proc filter*[T](self: Option[T], callback: proc (input: T): bool): Option[T] {.inline.} =
   ## Applies a `callback` to the value of the `Option`.
   ##
-  ## If the `callback` returns `true`, the option is returned as `Some`.
-  ## If it returns `false`, it is returned as `None`.
+  ## If the `callback` returns `true`, the option is returned as `some`.
+  ## If it returns `false`, it is returned as `none`.
   ##
   ## **See also:**
   ## * `flatMap proc <#flatMap,Option[A],proc(A)>`_
@@ -325,8 +325,8 @@ proc filter*[T](self: Option[T], callback: proc (input: T): bool): Option[T] {.i
     self
 
 proc `==`*[T](a, b: Option[T]): bool {.inline.} =
-  ## Returns `true` if both `Option`s are `None`,
-  ## or if they are both `Some` and have equal values.
+  ## Returns `true` if both `Option`s are `none`,
+  ## or if they are both `some` and have equal values.
   runnableExamples:
     let
       a = some(42)
@@ -346,18 +346,24 @@ proc `==`*[T](a, b: Option[T]): bool {.inline.} =
 proc `$`*[T](self: Option[T]): string =
   ## Get the string representation of the `Option`.
   runnableExamples:
-    assert $some(42) == "Some(42)"
-    assert $none(int) == "None[int]"
+    assert $some(42) == "some(42)"
+    assert $none(int) == "none(int)"
 
   if self.isSome:
-    result = "Some("
+    when defined(nimLagacyOptionsDollar):
+      result = "Some("
+    else:
+      result = "some("
     result.addQuoted self.val
     result.add ")"
   else:
-    result = "None[" & name(T) & "]"
+    when defined(nimLagacyOptionsDollar):
+      result = "None[" & name(T) & "]"
+    else:
+      result = "none(" & name(T) & ")"
 
 proc unsafeGet*[T](self: Option[T]): lent T {.inline.}=
-  ## Returns the value of a `Some`. The behavior is undefined for `None`.
+  ## Returns the value of a `some`. The behavior is undefined for `none`.
   ##
   ## **Note:** Use this only when you are **absolutely sure** the value is present
   ## (e.g. after checking with `isSome <#isSome,Option[T]>`_).

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -114,7 +114,7 @@ pkg2 "nimwc", "nim c nimwc.nim"
 pkg2 "norm", "nim c -r tests/sqlite/trows.nim"
 pkg2 "npeg", "nimble testarc"
 pkg2 "numericalnim", "nim c -r tests/test_integrate.nim"
-pkg2 "optionsutils"
+# pkg2 "optionsutils" # pending changing test from `Some` to `some` (etc) in tests/test2.nim, refs #17147
 pkg2 "ormin", "nim c -o:orminn ormin.nim"
 pkg2 "parsetoml"
 pkg2 "patty"

--- a/tests/generics/tgenerics_issues.nim
+++ b/tests/generics/tgenerics_issues.nim
@@ -24,9 +24,9 @@ G:0,1:0.1
 G:0,1:0.1
 H:1:0.1
 0
-(foo: None[seq[Foo]], s: "")
-(foo: Some(@[(a: "world", bar: None[Bar])]), s: "hello,")
-@[(a: "hey", bar: None[Bar])]
+(foo: none(seq[Foo]), s: "")
+(foo: some(@[(a: "world", bar: none(Bar))]), s: "hello,")
+@[(a: "hey", bar: none(Bar))]
 '''
 joinable: false
 """

--- a/tests/stdlib/tmarshal.nim
+++ b/tests/stdlib/tmarshal.nim
@@ -116,8 +116,8 @@ block:
   let
     a1 = some(newJNull())
     a2 = none(JsonNode)
-  doAssert $($$a1).to[:Option[JsonNode]] == "Some(null)"
-  doAssert $($$a2).to[:Option[JsonNode]] == "None[JsonNode]"
+  doAssert $($$a1).to[:Option[JsonNode]] == "some(null)"
+  doAssert $($$a2).to[:Option[JsonNode]] == "none(JsonNode)"
   doAssert ($$a1).to[:Option[JsonNode]] == some(newJNull())
   doAssert ($$a2).to[:Option[JsonNode]] == none(JsonNode)
 

--- a/tests/stdlib/toptions.nim
+++ b/tests/stdlib/toptions.nim
@@ -82,8 +82,8 @@ proc main() =
       doAssert(stringNone.get("Correct") == "Correct")
 
     block stringify:
-      doAssert($(some("Correct")) == "Some(\"Correct\")")
-      doAssert($(stringNone) == "None[string]")
+      doAssert($(some("Correct")) == "some(\"Correct\")")
+      doAssert($(stringNone) == "none(string)")
 
     disableJsVm:
       block map_with_a_void_result:
@@ -155,7 +155,7 @@ proc main() =
         name: string
 
       let nobody = none(Named)
-      doAssert($nobody == "None[Named]")
+      doAssert($nobody == "none(Named)")
 
     # "$ on type with name()"
     block:
@@ -163,7 +163,7 @@ proc main() =
         myname: string
 
       let noperson = none(Person)
-      doAssert($noperson == "None[Person]")
+      doAssert($noperson == "none(Person)")
 
     # "Ref type with overloaded `==`"
     block:
@@ -190,7 +190,7 @@ proc main() =
       block:
         let x = none(cstring)
         doAssert x.isNone
-        doAssert $x == "None[cstring]"
+        doAssert $x == "none(cstring)"
 
 
 static: main()


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/17036#discussion_r577988573
* $some(3) is now "some(3)", not "Some(3)", `$none(int)` is now `"none(int)"` instead of `"None[int]"`
* use `-dnimLagacyOptionsDollar` for previous behavior.

rationale:
* Some and None don't exist as symbols
* `Some(3)` would imply you'd have a type `Some`, but then `Some(3)` syntax would be illegal
* it also makes more sense in the syntax of fusion/matching, see below

## note
I've disabled `optionsutils` which had a failing test due to this change:
```nim
tests/test2.nim(57, 17): Check failed: echoed == "Some(10)"
      echoed was some(10)
tests/test2.nim(61, 17): Check failed: echoed == "None[int]"
      echoed was none(int)
```

## Future work
- [x] I can send a PR to optionsutils (=> PR https://github.com/PMunch/nim-optionsutils/pull/4)
- [x] re-enable this package after this PR is merged
=> https://github.com/nim-lang/Nim/pull/17231
- [ ] `fusion/matching` should also use some and none instead of Some and None:
```nim
{.experimental: "caseStmtMacros".}
import fusion/matching
case some(42)
of Some(@a): assert a == 42
of None(): assert false
assertMatch(some(some(none(int))), Some(Some(None())))
```
=> this:
```nim
{.experimental: "caseStmtMacros".}
import fusion/matching
case some(42)
of some(@a): assert a == 42
of none(): assert false # or maybe `none` instead of `none()`
assertMatch(some(some(none(int))), some(some(none())))
```
(EDIT: followup discussing this point here: https://github.com/timotheecour/Nim/issues/612)