### PR TITLE
os.sleep: change type to: `milsecs: Natural`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -128,7 +128,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Deprecated `any`. See https://github.com/nim-lang/RFCs/issues/281
 
-- Added `std/sysrand` module to get random numbers from a secure source 
+- Added `std/sysrand` module to get random numbers from a secure source
 provided by the operating system.
 
 - Added optional `options` argument to `copyFile`, `copyFileToDir`, and
@@ -168,6 +168,9 @@ provided by the operating system.
   This lets the OS perform its default actions, which might include core
   dumping (on select signals) and notifying the parent process about the cause
   of termination.
+
+
+- Changed `os.sleep` argument from `int` to `Natural`, because negative values make no sense.
 
 
 ## Language changes

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -961,7 +961,7 @@ proc getTempDir*(): string {.rtl, extern: "nos$1",
   ##
   ## You can override this implementation
   ## by adding `-d:tempDir=mytempname` to your compiler invocation.
-  ## 
+  ##
   ## **Note:** This proc does not check whether the returned path exists.
   ##
   ## See also:
@@ -1785,7 +1785,7 @@ proc copyFile*(source, dest: string, options = {cfSymlinkFollow}) {.rtl,
   ##
   ## If `dest` already exists, the file attributes
   ## will be preserved and the content overwritten.
-  ## 
+  ##
   ## On OSX, `copyfile` C api will be used (available since OSX 10.5) unless
   ## `-d:nimLegacyCopyFile` is used.
   ##
@@ -2797,7 +2797,7 @@ when defined(nimdoc):
     ##
     ## `i` should be in the range `1..paramCount()`, the `IndexDefect`
     ## exception will be raised for invalid values. Instead of iterating
-    ## over `paramCount() <#paramCount>`_ with this proc you can 
+    ## over `paramCount() <#paramCount>`_ with this proc you can
     ## call the convenience `commandLineParams() <#commandLineParams>`_.
     ##
     ## Similarly to `argv`:idx: in C,
@@ -3140,7 +3140,7 @@ proc getAppDir*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noWeirdT
   ## * `getAppFilename proc <#getAppFilename>`_
   result = splitFile(getAppFilename()).dir
 
-proc sleep*(milsecs: int) {.rtl, extern: "nos$1", tags: [TimeEffect], noWeirdTarget.} =
+proc sleep*(milsecs: Natural) {.rtl, extern: "nos$1", tags: [TimeEffect], noWeirdTarget.} =
   ## Sleeps `milsecs` milliseconds.
   when defined(windows):
     winlean.sleep(int32(milsecs))

--- a/tests/osproc/texitsignal.nim
+++ b/tests/osproc/texitsignal.nim
@@ -36,4 +36,4 @@ if paramCount() == 0:
     echo p.waitForExit() == 128 + SIGKILL
 
 else:
-  sleep(5000)  # should get killed before this
+  os.sleep(5000)  # should get killed before this


### PR DESCRIPTION
- Changed `os.sleep` argument from `int` to `Natural`, because negative values make no sense.
- You can not sleep negative time, is buggy and breaks laws of thermodynamics or something.
