### PR TITLE
fix `UnusedImport` for `nim c compiler/nim`

### DIFF
--- a/compiler/ic/cbackend.nim
+++ b/compiler/ic/cbackend.nim
@@ -18,11 +18,12 @@
 ## also doing cross-module dependency tracking and DCE that we don't need
 ## anymore. DCE is now done as prepass over the entire packed module graph.
 
-import std / [intsets, algorithm]
-import ".." / [ast, options, lineinfos, modulegraphs, cgendata, cgen,
+import std/[packedsets, algorithm]
+  # std/intsets would give `UnusedImport`, pending https://github.com/nim-lang/Nim/issues/14246
+import ".."/[ast, options, lineinfos, modulegraphs, cgendata, cgen,
   pathutils, extccomp, msgs]
 
-import packed_ast, to_packed_ast, bitabs, dce, rodfiles
+import packed_ast, to_packed_ast, dce, rodfiles
 
 proc unpackTree(g: ModuleGraph; thisModule: int;
                 tree: PackedTree; n: NodePos): PNode =


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/issues/14246

avoids those 2 warnings:
/Users/timothee/git_clone/nim/Nim_prs/compiler/ic/cbackend.nim(21, 12) Warning: imported and not used: 'intsets' [UnusedImport]
/Users/timothee/git_clone/nim/Nim_prs/compiler/ic/cbackend.nim(25, 35) Warning: imported and not used: 'bitabs' [UnusedImport]
