### PR TITLE
disable `mitems(cstring)` in js + rt (not js + vm)

### DIFF
--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -85,7 +85,7 @@ iterator items*(a: cstring): char {.inline.} =
 
 iterator mitems*(a: var cstring): var char {.inline.} =
   ## Iterates over each item of `a` so that you can modify the yielded value.
-  # xxx this should give CT error in js RT.
+  ## In js at RT, this will raise a defect since js strings are immutable.
   runnableExamples:
     from std/sugar import collect
     var a = "abc\0def"
@@ -98,15 +98,16 @@ iterator mitems*(a: var cstring): var char {.inline.} =
     assert b == "aBc"
     assert a == "aBc\0def"
 
-  template impl() =
+  when nimvm:
     var i = 0
     let n = len(a)
     while i < n:
       yield a[i]
       inc(i)
-  when defined(js): impl()
   else:
-    when nimvm: impl()
+    when defined(js):
+      # xxx this should give CT error in js RT
+      doAssert false, "js cstring cannot be mutated"
     else:
       var i = 0
       while a[i] != '\0':

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -106,7 +106,9 @@ iterator mitems*(a: var cstring): var char {.inline.} =
       inc(i)
   else:
     when defined(js):
-      # xxx this should give CT error in js RT
+      # xxx this could give a CT error in js RT, for example
+      # using similar approach as https://github.com/nim-lang/Nim/pull/15877,
+      # but note this isn't perfect as `compiles(block: someCstring[0] = 'x')` is true.
       doAssert false, "js cstring cannot be mutated"
     else:
       var i2 = 0

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -85,7 +85,7 @@ iterator items*(a: cstring): char {.inline.} =
 
 iterator mitems*(a: var cstring): var char {.inline.} =
   ## Iterates over each item of `a` so that you can modify the yielded value.
-  ## In js at RT, this will raise a defect since js strings are immutable.
+  ## In js at runtime, this will raise a defect since js strings are immutable.
   runnableExamples:
     from std/sugar import collect
     var a = "abc\0def"

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -109,10 +109,10 @@ iterator mitems*(a: var cstring): var char {.inline.} =
       # xxx this should give CT error in js RT
       doAssert false, "js cstring cannot be mutated"
     else:
-      var i = 0
-      while a[i] != '\0':
-        yield a[i]
-        inc(i)
+      var i2 = 0
+      while a[i2] != '\0':
+        yield a[i2]
+        inc(i2)
 
 iterator items*[T: enum and Ordinal](E: typedesc[T]): T =
   ## Iterates over the values of `E`.

--- a/tests/stdlib/tcstring.nim
+++ b/tests/stdlib/tcstring.nim
@@ -7,28 +7,29 @@ from std/sugar import collect
 from stdtest/testutils import whenRuntimeJs, whenVMorJs
 
 template testMitems() =
-  block:
-    var a = "abc"
-    var b = a.cstring
-    let s = collect:
-      for bi in mitems(b):
-        if bi == 'b': bi = 'B'
-        bi
-    whenRuntimeJs:
-      discard # xxx mitems should give CT error instead of @['\x00', '\x00', '\x00']
-    do:
+  whenRuntimeJs:
+    block:
+      var a = "abc"
+      var b = a.cstring
+      doAssertRaises(AssertionDefect):
+        for ai in mitems(b): discard
+  do:
+    block:
+      var a = "abc"
+      var b = a.cstring
+      let s = collect:
+        for bi in mitems(b):
+          if bi == 'b': bi = 'B'
+          bi
       doAssert s == @['a', 'B', 'c']
 
-  block:
-    var a = "abc\0def"
-    var b = a.cstring
-    let s = collect:
-      for bi in mitems(b):
-        if bi == 'b': bi = 'B'
-        bi
-    whenRuntimeJs:
-      discard # ditto
-    do:
+    block:
+      var a = "abc\0def"
+      var b = a.cstring
+      let s = collect:
+        for bi in mitems(b):
+          if bi == 'b': bi = 'B'
+          bi
       doAssert s == @['a', 'B', 'c']
 
 proc mainProc() =


### PR DESCRIPTION
followup after https://github.com/nim-lang/Nim/pull/17160

## future work
- [ ] maybe turn it into a CT error instead of RT assert when mitems(cstring) is used in js backend at RT (not nimvm in which this is valid), but we'll need to see whether this is more annoying than useful (eg if user has to patch their code with `when defined(js)` in a bunch of places, that would be bad)