### PR TITLE
compiler/installer.ini: package cacert.pem on Windows [backport:1.2]

### DIFF
--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -109,6 +109,7 @@ Download: r"Aporia Text Editor|dist|aporia.zip|97997|https://nim-lang.org/downlo
 Files: "bin/makelink.exe"
 Files: "bin/7zG.exe"
 Files: "bin/*.dll"
+Files: "bin/cacert.pem"
 
 [UnixBin]
 Files: "bin/nim"


### PR DESCRIPTION
Follow up of https://github.com/nim-lang/nightlies/commit/5dc544e1f521e94874c22ee5209d38460b968243

After updating windeps.zip, it appears that Windows' build was
unchanged. As it turns out, cacert.pem is not set for packaging by the
compiler package manifest.

This commit add cacert.pem to the Windows package.

/cc @Araq