### PR TITLE
Fix unicode.split with seperators examples

### DIFF
--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -971,14 +971,14 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
   ## And the following code:
   ##
   ## .. code-block:: nim
-  ##   for word in split("this:is;an$example", {';', ':', '$'}):
+  ##   for word in split("this:is;an$example", ";:$".toRunes):
   ##     writeLine(stdout, word)
   ##
   ## ...produces the same output as the first example. The code:
   ##
   ## .. code-block:: nim
   ##   let date = "2012-11-20T22:08:08.398990"
-  ##   let separators = {' ', '-', ':', 'T'}
+  ##   let separators = " -:T".toRunes
   ##   for number in split(date, separators):
   ##     writeLine(stdout, number)
   ##

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -962,18 +962,13 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
       @["hÃllo", "this", "is", "an", "example", "是"]
 
     # And the following code splits the same string using a sequence of Runes.
-    import std/sugar
-
-    let separators = collect(for separator in ";:$".runes: separator)
-
-    assert toSeq(split("añyóng:hÃllo;是$example", separators)) ==
+    assert toSeq(split("añyóng:hÃllo;是$example", ";:$".toRunes)) ==
       @["añyóng", "hÃllo", "是", "example"]
 
     # Another example that splits a string containing a date.
     let date = "2012-11-20T22:08:08.398990"
-    let separatorsDate = collect(for separator in " -:T".runes: separator)
 
-    assert toSeq(split(date, separatorsDate)) ==
+    assert toSeq(split(date,  " -:T".toRunes)) ==
       @["2012", "11", "20", "22", "08", "08.398990"]
 
   splitCommon(s, seps, maxsplit)

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -956,11 +956,10 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
   ##
   ## Substrings are separated by a substring containing only ``seps``.
   runnableExamples:
-    var splitted = newSeq[string]()
-    for word in split("this\lis an\texample"):
-        splitted.add(word)
+    import std/sequtils
 
-    assert splitted == @["this", "is", "an", "example"]
+    assert toSeq("hÃllo\lthis\lis an\texample\l是".split) ==
+      @["hÃllo", "this", "is", "an", "example", "是"]
 
     # And the following code splits the same string using a sequence of Runes.
     import std/sugar
@@ -1003,12 +1002,10 @@ iterator split*(s: string, sep: Rune, maxsplit: int = -1): string =
   ## Splits the unicode string ``s`` into substrings using a single separator.
   ## Substrings are separated by the rune ``sep``.
   runnableExamples:
-    var splitted = newSeq[string]()
+    import std/sequtils
 
-    for word in split(";;this;is;an;;example;;;", ";".runeAt(0)):
-      splitted.add(word)
-
-    assert splitted == @["", "", "this", "is", "an", "", "example", "", "", ""]
+    assert toSeq(split(";;hÃllo;this;is;an;;example;;;是", ";".runeAt(0))) ==
+      @["", "", "hÃllo", "this", "is", "an", "", "example", "", "", "是"]
 
   splitCommon(s, sep, maxsplit)
 

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -965,6 +965,9 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
     assert toSeq(split("añyóng:hÃllo;是$example", ";:$".toRunes)) ==
       @["añyóng", "hÃllo", "是", "example"]
 
+    # example with a `Rune` separator and unused one `;`:
+    assert toSeq(split("ab是de:f:", ";:是".toRunes)) == @["ab", "de", "f", ""]
+
     # Another example that splits a string containing a date.
     let date = "2012-11-20T22:08:08.398990"
 

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -968,7 +968,7 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
     # Another example that splits a string containing a date.
     let date = "2012-11-20T22:08:08.398990"
 
-    assert toSeq(split(date,  " -:T".toRunes)) ==
+    assert toSeq(split(date, " -:T".toRunes)) ==
       @["2012", "11", "20", "22", "08", "08.398990"]
 
   splitCommon(s, seps, maxsplit)

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -1001,28 +1001,15 @@ proc splitWhitespace*(s: string): seq[string] {.noSideEffect,
 
 iterator split*(s: string, sep: Rune, maxsplit: int = -1): string =
   ## Splits the unicode string ``s`` into substrings using a single separator.
-  ##
   ## Substrings are separated by the rune ``sep``.
-  ## The code:
-  ##
-  ## .. code-block:: nim
-  ##   for word in split(";;this;is;an;;example;;;", ';'):
-  ##     writeLine(stdout, word)
-  ##
-  ## Results in:
-  ##
-  ## .. code-block::
-  ##   ""
-  ##   ""
-  ##   "this"
-  ##   "is"
-  ##   "an"
-  ##   ""
-  ##   "example"
-  ##   ""
-  ##   ""
-  ##   ""
-  ##
+  runnableExamples:
+    var splitted = newSeq[string]()
+
+    for word in split(";;this;is;an;;example;;;", ";".runeAt(0)):
+      splitted.add(word)
+
+    assert splitted == @["", "", "this", "is", "an", "", "example", "", "", ""]
+
   splitCommon(s, sep, maxsplit)
 
 proc split*(s: string, seps: openArray[Rune] = unicodeSpaces, maxsplit: int = -1):

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -964,23 +964,17 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
     # And the following code splits the same string using a sequence of Runes.
     import std/sugar
 
-    var splittedBySequence = newSeq[string]()
     let separators = collect(for separator in ";:$".runes: separator)
 
-    for word in split("this:is;an$example", separators):
-      splittedBySequence.add(word)
-
-    assert splittedBySequence == @["this", "is", "an", "example"]
+    assert toSeq(split("añyóng:hÃllo;是$example", separators)) ==
+      @["añyóng", "hÃllo", "是", "example"]
 
     # Another example that splits a string containing a date.
-    var splittedDate = newSeq[string]()
     let date = "2012-11-20T22:08:08.398990"
     let separatorsDate = collect(for separator in " -:T".runes: separator)
 
-    for word in split(date, separatorsDate):
-      splittedDate.add(word)
-
-    assert splittedDate == @["2012", "11", "20", "22", "08", "08.398990"]
+    assert toSeq(split(date, separatorsDate)) ==
+      @["2012", "11", "20", "22", "08", "08.398990"]
 
   splitCommon(s, seps, maxsplit)
 

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -955,43 +955,34 @@ iterator split*(s: string, seps: openArray[Rune] = unicodeSpaces,
   ## Splits the unicode string ``s`` into substrings using a group of separators.
   ##
   ## Substrings are separated by a substring containing only ``seps``.
-  ##
-  ## .. code-block:: nim
-  ##   for word in split("this\lis an\texample"):
-  ##     writeLine(stdout, word)
-  ##
-  ## ...generates this output:
-  ##
-  ## .. code-block::
-  ##   "this"
-  ##   "is"
-  ##   "an"
-  ##   "example"
-  ##
-  ## And the following code:
-  ##
-  ## .. code-block:: nim
-  ##   for word in split("this:is;an$example", ";:$".toRunes):
-  ##     writeLine(stdout, word)
-  ##
-  ## ...produces the same output as the first example. The code:
-  ##
-  ## .. code-block:: nim
-  ##   let date = "2012-11-20T22:08:08.398990"
-  ##   let separators = " -:T".toRunes
-  ##   for number in split(date, separators):
-  ##     writeLine(stdout, number)
-  ##
-  ## ...results in:
-  ##
-  ## .. code-block::
-  ##   "2012"
-  ##   "11"
-  ##   "20"
-  ##   "22"
-  ##   "08"
-  ##   "08.398990"
-  ##
+  runnableExamples:
+    var splitted = newSeq[string]()
+    for word in split("this\lis an\texample"):
+        splitted.add(word)
+
+    assert splitted == @["this", "is", "an", "example"]
+
+    # And the following code splits the same string using a sequence of Runes.
+    import std/sugar
+
+    var splittedBySequence = newSeq[string]()
+    let separators = collect(for separator in ";:$".runes: separator)
+
+    for word in split("this:is;an$example", separators):
+      splittedBySequence.add(word)
+
+    assert splittedBySequence == @["this", "is", "an", "example"]
+
+    # Another example that splits a string containing a date.
+    var splittedDate = newSeq[string]()
+    let date = "2012-11-20T22:08:08.398990"
+    let separatorsDate = collect(for separator in " -:T".runes: separator)
+
+    for word in split(date, separatorsDate):
+      splittedDate.add(word)
+
+    assert splittedDate == @["2012", "11", "20", "22", "08", "08.398990"]
+
   splitCommon(s, seps, maxsplit)
 
 iterator splitWhitespace*(s: string): string =


### PR DESCRIPTION
Fixes: https://github.com/nim-lang/Nim/issues/17174
https://nim-lang.org/docs/unicode.html#split.i%2Cstring%2CRune%2Cint didn't work with the set constructor `{}` so replaced it with a string that's converted to an openArray compatible type containing `Rune`s. 

If there is a better/more idiomatic way to get Runes from a set/string, then please do tell, first time interacting with Unicode module.