### PR TITLE
make jsconsole.assertion errors less confusing in logs

### DIFF
--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -75,7 +75,7 @@ since (1, 5):
   func getMsg(info: InstantiationInfo; msg: string): string =
     var temp = ""
     temp.toLocation(info.filename, info.line, info.column + 1)
-    result.addQuoted(temp)
+    result.addQuoted("(non-fatal) "& temp)
     result.add ','
     result.addQuoted(msg)
 

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -75,7 +75,7 @@ since (1, 5):
   func getMsg(info: InstantiationInfo; msg: string): string =
     var temp = ""
     temp.toLocation(info.filename, info.line, info.column + 1)
-    result.addQuoted("[jsAssert] "& temp)
+    result.addQuoted("[jsAssert] " & temp)
     result.add ','
     result.addQuoted(msg)
 

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -75,7 +75,7 @@ since (1, 5):
   func getMsg(info: InstantiationInfo; msg: string): string =
     var temp = ""
     temp.toLocation(info.filename, info.line, info.column + 1)
-    result.addQuoted("(non-fatal) "& temp)
+    result.addQuoted("[jsAssert] "& temp)
     result.add ','
     result.addQuoted(msg)
 


### PR DESCRIPTION
/cc @juancarlospaco since you introduced this ~~module~~ proc

before this PR, you'd get confusing logs in CI and would wonder whether something was wrong; furthermore, when something unrelated in CI goes wrong, it adds to the confusion leading one to investigate whether the resulting assertion error would have anything to do with the actual error

after PR `nim doc -b:js lib/js/jsconsole.nim` prints:
```
Assertion failed: [jsAssert] /Users/timothee/git_clone/nim/Nim_prs/lib/js/nimcache/runnableExamples/jsconsole_examples1.nim(9, 8) 42 != 42
Assertion failed: [jsAssert] /Users/timothee/git_clone/nim/Nim_prs/lib/js/nimcache/runnableExamples/jsconsole_examples1.nim(10, 8) '`' == '\n' and '\t' == '\x00'
```
