### PR TITLE
fix code-block test bugs: fix #17183, fix https://github.com/timotheecour/Nim/issues/620

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -205,7 +205,6 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
   result.onTestSnippet =
     proc (gen: var RstGenerator; filename, cmd: string; status: int; content: string) =
       if conf.docCmd == docCmdSkip: return
-      echo ("D20210224T233153: ", filename, cmd)
       inc(gen.id)
       var d = TDocumentor(gen)
       var outp: AbsoluteFile
@@ -221,7 +220,6 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
         let nameOnly = splitFile(d.filename).name
         outp = AbsoluteDir(nameOnly) / RelativeFile(filename)
       # Make sure the destination directory exists
-      echo ("outp.splitFile.dir: ", outp, outp.splitFile.dir, filename)
       createDir(outp.splitFile.dir)
       # Include the current file if we're parsing a nim file
       let importStmt = if d.isPureRst: "" else: "import \"$1\"\n" % [d.filename.replace("\\", "/")]
@@ -232,7 +230,6 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
         if cmd.startsWith "nim ": result = "$nim " & cmd[4..^1]
         else: result = cmd
         # factor with D20210224T221756
-        echo (result, outp)
         result = result.replace("$1", "$options") % [
           "nim", os.getAppFilename().quoteShell,
           "libpath", quoteShell(d.conf.libpath),
@@ -241,11 +238,7 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
           "options", outp.quoteShell,
             # xxx `quoteShell` seems buggy if user passes options = "-d:foo somefile.nim"
         ]
-        echo result
-      echo "D20210224T230333"
-      echo cmd
       let cmd = cmd.interpSnippetCmd
-      echo cmd
       rawMessage(conf, hintExecuting, cmd)
       let (output, gotten) = execCmdEx(cmd)
       if gotten != status:

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -920,8 +920,12 @@ proc parseCodeBlockField(d: PDoc, n: PRstNode, params: var CodeBlockParams) =
   of "test":
     params.testCmd = n.getFieldValue.strip
     if params.testCmd.len == 0:
-      params.testCmd = "$nim r --backend:$backend $options" # see `interpSnippetCmd`
+      # factor with D20210224T221756, see `interpSnippetCmd`. Note that
+      # `docCmd` should appear before $file but after all other options, but
+      # currently $options merges both options and $file so it's tricky.
+      params.testCmd = "$nim r --backend:$backend --lib:$libpath $docCmd $options"
     else:
+      # consider whether `$docCmd` should be appended here too
       params.testCmd = unescape(params.testCmd)
   of "status", "exitcode":
     var status: int

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -920,9 +920,8 @@ proc parseCodeBlockField(d: PDoc, n: PRstNode, params: var CodeBlockParams) =
   of "test":
     params.testCmd = n.getFieldValue.strip
     if params.testCmd.len == 0:
-      # factor with D20210224T221756, see `interpSnippetCmd`. Note that
-      # `docCmd` should appear before $file but after all other options, but
-      # currently $options merges both options and $file so it's tricky.
+      # factor with D20210224T221756. Note that `$docCmd` should appear before `$file`
+      # but after all other options, but currently `$options` merges both options and `$file` so it's tricky.
       params.testCmd = "$nim r --backend:$backend --lib:$libpath $docCmd $options"
     else:
       # consider whether `$docCmd` should be appended here too

--- a/tests/nimdoc/trunnableexamples.nim
+++ b/tests/nimdoc/trunnableexamples.nim
@@ -120,3 +120,13 @@ runnableExamples:
 
 # note: there are yet other examples where putting runnableExamples at module
 # scope is needed, for example when using an `include` before an `import`, etc.
+
+##[
+snippet:
+
+.. code-block:: Nim
+    :test:
+
+  doAssert defined(testFooExternal)
+
+]##


### PR DESCRIPTION
fix code-block test bugs and makes code-block more similar to runnableExamples logic

* fix #17183 : code-block nim test snippets now generated under a snippets subdir to avoid this bug
* fix https://github.com/timotheecour/Nim/issues/620: code-block nim test snippets now forwards `computed `--lib` (see example below)
* also honor `--docCmd`, see test

## example
### before PR:
with an external nim:
`nim doc lib/pure/htmlparser.nim`

Error: snippet failed: cmd: '/Users/timothee/git_clone/nim/Nim_devel/bin/nim r --backend:c /Users/timothee/.cache/nim/htmlparser_d/htmlparser/htmlparser_snippet_101.nim' status: 1 expected: 0 output: /Users/timothee/.cache/nim/htmlparser_d/htmlparser/htmlparser_snippet_101.nim(3, 8) Error: redefinition of 'htmlparser'; previous declaration here: /Users/timothee/git_clone/nim/Nim_devel/lib/pure/htmlparser.nim(1, 2)
  import htmlparser

adding `--lib:lib` doesn't help

### after PR:
`nim doc lib/pure/htmlparser.nim` works

