### PR TITLE
use `-r:off` for runnableExamples that should compile but not run

### DIFF
--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -13,15 +13,14 @@
 ## is used. This suffices because Windows' console already provides the
 ## wanted functionality.
 
-runnableExamples:
-  if false:
-    echo readLineFromStdin("Is Nim awesome? (Y/n): ")
-    var line: string
-    while true:
-      let ok = readLineFromStdin("How are you? ", line)
-      if not ok: break # ctrl-C or ctrl-D will cause a break
-      if line.len > 0: echo line
-    echo "exiting"
+runnableExamples("-r:off"):
+  echo readLineFromStdin("Is Nim awesome? (Y/n): ")
+  var line: string
+  while true:
+    let ok = readLineFromStdin("How are you? ", line)
+    if not ok: break # ctrl-C or ctrl-D will cause a break
+    if line.len > 0: echo line
+  echo "exiting"
 
 when defined(windows):
   proc readLineFromStdin*(prompt: string): string {.

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -14,32 +14,30 @@
 ## application in production you should use a reverse proxy (for example nginx)
 ## instead of allowing users to connect directly to this server.
 
-runnableExamples:
+runnableExamples("-r:off"):
   # This example will create an HTTP server on port 8080. The server will
   # respond to all requests with a `200 OK` response code and "Hello World"
-  # as the response body. Run locally with:
-  # `nim doc --doccmd:-d:nimAsyncHttpServerEnableTest --lib:lib lib/pure/asynchttpserver.nim`
+  # as the response body.
   import std/asyncdispatch
-  if defined(nimAsyncHttpServerEnableTest):
-    proc main {.async.} =
-      const port = 8080
-      var server = newAsyncHttpServer()
-      proc cb(req: Request) {.async.} =
-        echo (req.reqMethod, req.url, req.headers)
-        let headers = {"Content-type": "text/plain; charset=utf-8"}
-        await req.respond(Http200, "Hello World", headers.newHttpHeaders())
+  proc main {.async.} =
+    const port = 8080
+    var server = newAsyncHttpServer()
+    proc cb(req: Request) {.async.} =
+      echo (req.reqMethod, req.url, req.headers)
+      let headers = {"Content-type": "text/plain; charset=utf-8"}
+      await req.respond(Http200, "Hello World", headers.newHttpHeaders())
 
-      echo "test this with: curl localhost:" & $port & "/"
-      server.listen(Port(port))
-      while true:
-        if server.shouldAcceptRequest():
-          await server.acceptRequest(cb)
-        else:
-          # too many concurrent connections, `maxFDs` exceeded
-          # wait 500ms for FDs to be closed
-          await sleepAsync(500)
+    echo "test this with: curl localhost:" & $port & "/"
+    server.listen(Port(port))
+    while true:
+      if server.shouldAcceptRequest():
+        await server.acceptRequest(cb)
+      else:
+        # too many concurrent connections, `maxFDs` exceeded
+        # wait 500ms for FDs to be closed
+        await sleepAsync(500)
 
-    waitFor main()
+  waitFor main()
 
 import asyncnet, asyncdispatch, parseutils, uri, strutils
 import httpcore

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -100,8 +100,8 @@ proc genOid*(): Oid =
   ## Generates a new OID.
   runnableExamples:
     doAssert ($genOid()).len == 24
-    if false: doAssert $genOid() == "5fc7f546ddbbc84800006aaf"
-
+  runnableExamples("-r:off"):
+    echo $genOid() # for example, "5fc7f546ddbbc84800006aaf"
   genOid(result, incr, fuzz)
 
 proc generatedTime*(oid: Oid): Time =

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -168,11 +168,11 @@ macro dump*(x: untyped): untyped =
   ## See also: `dumpToString` which is more convenient and useful since
   ## it expands intermediate templates/macros, returns a string instead of
   ## calling `echo`, and works with statements and expressions.
-  runnableExamples:
+  runnableExamples("-r:off"):
     let
       x = 10
       y = 20
-    if false: dump(x + y) # if true would print `x + y = 30`
+    dump(x + y) # prints: `x + y = 30`
 
   let s = x.toStrLit
   result = quote do:

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -58,14 +58,13 @@ when defined nimExperimentalLinenoiseExtra:
     ## line editing API that allows returning the line entered and an indicator
     ## of which control key was entered, allowing user to distinguish between
     ## for example ctrl-C vs ctrl-D.
-    runnableExamples("-d:nimExperimentalLinenoiseExtra"):
-      if false:
-        var ret: ReadLineResult
-        while true:
-          readLineStatus("name: ", ret) # ctrl-D will exit, ctrl-C will go to next prompt
-          if ret.line.len > 0: echo ret.line
-          if ret.status == lnCtrlD: break
-        echo "exiting"
+    runnableExamples("-d:nimExperimentalLinenoiseExtra -r:off"):
+      var ret: ReadLineResult
+      while true:
+        readLineStatus("name: ", ret) # ctrl-D will exit, ctrl-C will go to next prompt
+        if ret.line.len > 0: echo ret.line
+        if ret.status == lnCtrlD: break
+      echo "exiting"
     var data: linenoiseData
     let buf = linenoiseExtra(prompt, data.addr)
     result.line = $buf


### PR DESCRIPTION
followup https://github.com/nim-lang/Nim/pull/16586
fixes concern raised in https://github.com/nim-lang/Nim/pull/16586#issuecomment-787503028

and fulfills these goals:
* DRY: examples should't be duplicated
* CI makes sure code at least compiles
* simpler example in docs (both to read and write)
* pattern generalizes to all similar instances where runnableExample shouldn't run in CI

note that users can still run the code without copy pasting, via:
`nim doc --doccmd:-r --lib:lib lib/pure/asynchttpserver.nim`

## future work
- [ ] maybe add a way to run a specific example via a (preferably guid-like) label, eg:
`runnableExamples("-r:off", example = "D20210228T120657"): ...`
`nim r --example:D20210228T120657 lib/pure/asynchttpserver.nim`
benefits:
* just runs specified example(s) and nothing else (no doc generation etc); useful in many cases eg when editing a runnableExample, or if more than one example has `-r:off` etc
* tooling, manual, doc comments, and tests could also refer to those, avoiding duplicating examples in runnableExamples and tests or using fragile non-unique names; eg docs can transform those in hyperlinks
* see https://github.com/timotheecour/Nim/issues/596 for further details more generally on rationale for  such guid-like patterns