### PR TITLE
`macros.asMacro`: calls a proc with NimNode as a macro

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -244,6 +244,8 @@
 
 - Added dollar `$` and `len` for `jsre.RegExp`.
 
+- Added `macros.asMacro` to call proc with `NimNode` params as a macro.
+
 
 ## Language changes
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1688,7 +1688,7 @@ template typeOrVoid[T](a: T): type =
   ## Workaround for the fact that `typeof(procReturningVoid())` doesn't work (yet).
   T
 
-macro asMacro*(fn: untyped, args: varargs[untyped]): untyped =
+macro asMacro*(fn: untyped, args: varargs[untyped]): untyped {.since: (1,5,1).} =
   ## Calls a proc `fn` with `NimNode` params as a macro. This avoids having to
   ## define a corresponding macro manually.
   runnableExamples:

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1683,3 +1683,45 @@ proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
         result.add ni
       else: break
     else: break
+
+template typeOrVoid[T](a: T): type =
+  ## Workaround for the fact that `typeof(procReturningVoid())` doesn't work (yet).
+  T
+
+macro asMacro*(fn: untyped, args: varargs[untyped]): untyped =
+  ## Calls a proc `fn` with `NimNode` params as a macro. This avoids having to
+  ## define a corresponding macro manually.
+  runnableExamples:
+    assert treeRepr.asMacro(1 + 2) == """
+Infix
+  Ident "+"
+  IntLit 1
+  IntLit 2"""
+    # non-NimNode arguments can be passed via an explicit `static`:
+    proc foo(a: NimNode, b: int): auto = (a.repr, b * 10)
+    assert foo.asMacro("a" & nonexistant, static(3)) == ("\"a\" & nonexistant", 3 * 10)
+
+    # `foo.asMacro` generates a proc like this, and avoids having to define it manually:
+    macro foo2(a: untyped, b: static int): untyped = newLit foo(a, b)
+    assert foo2("a" & nonexistant, 3) == ("\"a\" & nonexistant", 3 * 10)
+
+  let body = newCall(fn)
+  let args2 = ident"args"
+  for i in 0..<args.len:
+    let ai = args[i]
+    if ai.kind == nnkCall and ai[0].kind == nnkIdent and ai[0].strVal == "static":
+      body.add ai
+    else:
+      body.add newTree(nnkBracketExpr, [args2, newLit i])
+  result = quote do:
+    block:
+      macro impl(`args2`: varargs[untyped]): untyped =
+        when typeOrVoid(`body`) is void:
+          `body`
+        else:
+          type T = typeof(`body`)
+          when T is NimNode: # or we could add a `newLit(a: NimNode)` overload
+            result = `body`
+          else:
+            result = newLit(`body`)
+      impl(`args`)

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -53,3 +53,11 @@ nnkInfix.newTree(
 
   block: # static params
     doAssert test6.asMacro("a" & "b", static(32)) == ("\"a\" & \"b\"", 32)
+
+  block:
+    doAssert lispRepr.asMacro(1+2) == """(Infix (Ident "+") (IntLit 1) (IntLit 2))"""
+    doAssert lispRepr.asMacro(1+2, static(true)) == """
+(Infix
+ (Ident "+")
+ (IntLit 1)
+ (IntLit 2))"""

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -1,5 +1,7 @@
 import std/macros
 
+# xxx merge these into here: tmacros1.nim, tmacros_issues.nim, tmacros_various.nim, tmacrostmt.nim
+
 block: # hasArgOfName
   macro m(u: untyped): untyped =
     for name in ["s","i","j","k","b","xs","ys"]:
@@ -10,3 +12,44 @@ block: # hasArgOfName
 
 block: # bug #17454
   proc f(v: NimNode): string {.raises: [].} = $v
+
+block: # asMacro
+  proc test1(a: NimNode): NimNode = a
+  proc test2(a: NimNode) = doAssert a.len == 3
+  proc test3(a: NimNode): auto = a.repr
+  proc test4(a, b: NimNode): auto = (a.repr, b.repr)
+  proc test5(a: NimNode): auto = a.treeRepr
+  proc test6(a: NimNode, b: int): auto = (a.repr, b)
+
+  doAssert test3.asMacro("a" & "b") == """"a" & "b""""
+  let a = test3.asMacro "a" & "b"
+  doAssert a ==  """"a" & "b""""
+  doAssert test3.asMacro(nonexistant) == "nonexistant"
+  doAssert test4.asMacro("a" & "b", 12) == ("\"a\" & \"b\"", "12")
+
+  doAssert test5.asMacro("a" & "b") == """
+Infix
+  Ident "&"
+  StrLit "a"
+  StrLit "b""""
+  doAssert compiles(test2.asMacro("a" & "b"))
+  doAssert not compiles(test2.asMacro("b"))
+  doAssert test1.asMacro("a" & "b") == "ab"
+
+  block: # shows lots of `macros` procs are made redundant by to `astGenRepr`
+    doAssert repr.asMacro("a" & "b") == """"a" & "b""""
+    doAssert treeRepr.asMacro("a" & "b") == """
+Infix
+  Ident "&"
+  StrLit "a"
+  StrLit "b""""
+
+    doAssert astGenRepr.asMacro("a" & "b") == """
+nnkInfix.newTree(
+  newIdentNode("&"),
+  newLit("a"),
+  newLit("b")
+)"""
+
+  block: # static params
+    doAssert test6.asMacro("a" & "b", static(32)) == ("\"a\" & \"b\"", 32)

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -61,3 +61,9 @@ nnkInfix.newTree(
  (Ident "+")
  (IntLit 1)
  (IntLit 2))"""
+
+  block:
+    parseStmt.asMacro(static("proc fn(): int = 3*5"))
+    parseStmt.asMacro(static("proc fn2(): int = 3*5")) # no redefinition error, thanks to `genSym(nskMacro, "impl")`
+    assert fn() == 3*5
+    assert fn2() == 3*5


### PR DESCRIPTION
avoids having to define a corresponding macro for each proc with a `NimNode` param.

## future work
- [ ] maybe deprecate `dumpTree`, `dumpLisp`, `dumpAstGen`, since we can now use:
```nim
dumpTree(foo)
=>
echo treeRepr.asMacro(foo)

dumpAstGen(foo)
=>
echo astGenRepr.asMacro(foo)

dumpLisp(foo)
=>
echo lispRepr.asMacro(foo, static(true))
echo lispRepr.asMacro(foo) # gives flexibility, here uses indented = false
```

note also that `treeRepr.asMacro(foo)` is more flexible than `dumpTree(foo)` because user can choose what to do with the returned string (eg: write a test, or append somewhere), whereas you can't do that with `dumpTree` which calls `echo`; more generally, API's should rarely call `echo`, that should be up to user code.