### PR TITLE
fixes #17198, DFA failure on large case stmts

### DIFF
--- a/tests/destructor/t17198.nim
+++ b/tests/destructor/t17198.nim
@@ -1,0 +1,32 @@
+discard """
+  cmd: '''nim c --gc:arc $file'''
+  output: '''
+other
+'''
+"""
+
+import std/macros
+
+macro bigCaseStmt(arg: untyped): untyped =
+  result = nnkCaseStmt.newTree(arg)
+
+  # try to change 2000 to a bigger value if it doesn't crash
+  for x in 0 ..< 2000:
+    result.add nnkOfBranch.newTree(newStrLitNode($x), newStrLitNode($x))
+
+  result.add nnkElse.newTree(newStrLitNode("other"))
+
+macro bigIfElseExpr(): untyped =
+  result = nnkIfExpr.newTree()
+
+  for x in 0 ..< 1000:
+    result.add nnkElifExpr.newTree(newLit(false), newStrLitNode($x))
+
+  result.add nnkElseExpr.newTree(newStrLitNode("other"))
+
+proc test(arg: string): string =
+  echo bigIfElseExpr()
+
+  result = bigCaseStmt(arg)
+
+discard test("test")


### PR DESCRIPTION
This alters the DFA control flow graph generation for case statments.
Gotos are now generated as a chained link, this ensures that evaluation
of variant branches collapses as early as possible, without hitting the
2k call limit.

Additionally, while testing this issue a further problem arose wherein
recent removal of nil seq support broke the ast/len proc. Fixed along
with a test.