### PR TITLE
fixes #17173

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -173,7 +173,6 @@ provided by the operating system.
   dumping (on select signals) and notifying the parent process about the cause
   of termination.
 
-- Added `strip` and `setSlice` to `std/strbasics`.
 - Added `system.prepareStrMutation` for better support of low
   level `moveMem`, `copyMem` operations for Orc's copy-on-write string
   implementation.

--- a/changelog.md
+++ b/changelog.md
@@ -130,7 +130,7 @@ with other backends. see #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
 - Deprecated `any`. See https://github.com/nim-lang/RFCs/issues/281
 
-- Added `std/sysrand` module to get random numbers from a secure source 
+- Added `std/sysrand` module to get random numbers from a secure source
 provided by the operating system.
 
 - Added optional `options` argument to `copyFile`, `copyFileToDir`, and
@@ -174,6 +174,9 @@ provided by the operating system.
   of termination.
 
 - Added `strip` and `setSlice` to `std/strbasics`.
+- Added `system.prepareStrMutation` for better support of low
+  level `moveMem`, `copyMem` operations for Orc's copy-on-write string
+  implementation.
 
 
 - Added to `wrapnils` an option-like API via `??.`, `isSome`, `get`.

--- a/lib/std/strbasics.nim
+++ b/lib/std/strbasics.nim
@@ -64,7 +64,7 @@ func setSlice*(s: var string, slice: Slice[int]) =
       when not declared(moveMem):
         impl()
       else:
-        when defined(gcDestructors):
+        when defined(nimSeqsV2):
           prepareStrMutation(s)
         moveMem(addr s[0], addr s[first], last - first + 1)
   s.setLen(last - first + 1)

--- a/lib/std/strbasics.nim
+++ b/lib/std/strbasics.nim
@@ -64,11 +64,13 @@ func setSlice*(s: var string, slice: Slice[int]) =
       when not declared(moveMem):
         impl()
       else:
+        when defined(gcDestructors):
+          prepareStrMutation(s)
         moveMem(addr s[0], addr s[first], last - first + 1)
   s.setLen(last - first + 1)
 
 func strip*(a: var string, leading = true, trailing = true, chars: set[char] = whitespaces) {.inline.} =
-  ## Inplace version of `strip`. Strips leading or 
+  ## Inplace version of `strip`. Strips leading or
   ## trailing `chars` (default: whitespace characters).
   ##
   ## If `leading` is true (default), leading `chars` are stripped.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3127,5 +3127,8 @@ export io
 when not defined(createNimHcr) and not defined(nimscript):
   include nimhcr
 
-when not defined(gcDestructors):
-  proc prepareStrMutation*(s: var string) {.inline.} = discard
+when notJSnotNims and defined(nimSeqsV2):
+  proc prepareStrMutation*(s: var string) {.inline.} =
+    ## String literals(i.e. "abc", etc) in ARC/ORC mode are "copy on write",
+    ## therefore you should call `prepareStrMutation` before modifying the strings.
+    discard

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3129,6 +3129,6 @@ when not defined(createNimHcr) and not defined(nimscript):
 
 when notJSnotNims and not defined(nimSeqsV2):
   proc prepareStrMutation*(s: var string) {.inline.} =
-    ## String literals(e.g. "abc", etc) in the ARC/ORC mode are "copy on write",
+    ## String literals (e.g. "abc", etc) in the ARC/ORC mode are "copy on write",
     ## therefore you should call `prepareStrMutation` before modifying the strings.
     discard

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3127,7 +3127,7 @@ export io
 when not defined(createNimHcr) and not defined(nimscript):
   include nimhcr
 
-when notJSnotNims and defined(nimSeqsV2):
+when notJSnotNims and not defined(nimSeqsV2):
   proc prepareStrMutation*(s: var string) {.inline.} =
     ## String literals(i.e. "abc", etc) in ARC/ORC mode are "copy on write",
     ## therefore you should call `prepareStrMutation` before modifying the strings.

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3129,6 +3129,6 @@ when not defined(createNimHcr) and not defined(nimscript):
 
 when notJSnotNims and not defined(nimSeqsV2):
   proc prepareStrMutation*(s: var string) {.inline.} =
-    ## String literals(i.e. "abc", etc) in ARC/ORC mode are "copy on write",
+    ## String literals(e.g. "abc", etc) in the ARC/ORC mode are "copy on write",
     ## therefore you should call `prepareStrMutation` before modifying the strings.
     discard

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3126,3 +3126,6 @@ export io
 
 when not defined(createNimHcr) and not defined(nimscript):
   include nimhcr
+
+when not defined(gcDestructors):
+  proc prepareStrMutation*(s: var string) {.inline.} = discard

--- a/lib/system/strs_v2.nim
+++ b/lib/system/strs_v2.nim
@@ -170,6 +170,8 @@ proc nimPrepareStrMutationV2(s: var NimStringV2) {.compilerRtl, inline.} =
     nimPrepareStrMutationImpl(s)
 
 proc prepareStrMutation*(s: var string) {.inline.} =
+  # string literals are "copy on write", so you need to call
+  # `prepareStrMutation` before modifying the strings.
   {.cast(noSideEffect).}:
     let s = unsafeAddr s
     nimPrepareStrMutationV2(cast[ptr NimStringV2](s)[])

--- a/lib/system/strs_v2.nim
+++ b/lib/system/strs_v2.nim
@@ -168,3 +168,8 @@ proc nimPrepareStrMutationImpl(s: var NimStringV2) =
 proc nimPrepareStrMutationV2(s: var NimStringV2) {.compilerRtl, inline.} =
   if s.p != nil and (s.p.cap and strlitFlag) == strlitFlag:
     nimPrepareStrMutationImpl(s)
+
+proc prepareStrMutation*(s: var string) {.inline.} =
+  {.cast(noSideEffect).}:
+    let s = unsafeAddr s
+    nimPrepareStrMutationV2(cast[ptr NimStringV2](s)[])

--- a/tests/arc/t17173.nim
+++ b/tests/arc/t17173.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: "nim c -r --gc:arc $file"
+  matrix: "--gc:refc; --gc:arc; --newruntime"
 """
 
 import std/strbasics

--- a/tests/arc/t17173.nim
+++ b/tests/arc/t17173.nim
@@ -1,0 +1,10 @@
+discard """
+  cmd: "nim c -r --gc:arc $file"
+"""
+
+import std/strbasics
+
+
+var a = "  vhellov   "
+strip(a)
+doAssert a == "vhellov"


### PR DESCRIPTION
fixes #17173

Todo: 

- [x] Documentation for `prepareStrMutation`
- [x] Add the test case.

Follow up

- [x] Documentation of ORC's COW strings