### PR TITLE
Add Week-Of-Year Implementation to Times Module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,11 +25,11 @@
 
 - Sends `ehlo` first. If the mail server does not understand, it sends `helo` as a fallback.
 
-- Added `IsoWeekRange`, a range type to represent the number of weeks in an ISO week-based year
-- Added `IsoYear`, a distinct int type to prevent bugs from confusing the week-based year and the regular year
+- Added `IsoWeekRange`, a range type to represent the number of weeks in an ISO week-based year.
+- Added `IsoYear`, a distinct int type to prevent bugs from confusing the week-based year and the regular year.
 - Added `initDateTime` in `times` to create a datetime from a weekday, and ISO 8601 week number and week-based year.
 - Added `getIsoWeekAndYear` in `times` to get an ISO week number along with the corresponding ISO week-based year from a datetime.
-- Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year
+- Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,9 +25,11 @@
 
 - Sends `ehlo` first. If the mail server does not understand, it sends `helo` as a fallback.
 
-- Added `initDateTime` in `times` to create a datetime from weekday, ISO 8601 week number and year.
-- Added `getWeekInYear` in `times` to get ISO 8601 week number from datetime.
-- Added `getWeeksInYear` in `times` to number of ISO 8601 weeks in a year
+- Added `IsoWeekRange`, a range type to represent the number of weeks in an ISO week-based year
+- Added `IsoYear`, a distinct int type to prevent bugs from confusing the week-based year and the regular year
+- Added `initDateTime` in `times` to create a datetime from a weekday, and ISO 8601 week number and week-based year.
+- Added `getIsoWeekAndYear` in `times` to get an ISO week number along with the corresponding ISO week-based year from a datetime.
+- Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,10 @@
 
 - Sends `ehlo` first. If the mail server does not understand, it sends `helo` as a fallback.
 
+- Added `initDateTime` in `times` to create a datetime from weekday, ISO 8601 week number and year.
+- Added `getWeekInYear` in `times` to get ISO 8601 week number from datetime.
+- Added `getWeeksInYear` in `times` to number of ISO 8601 weeks in a year
+
 ## Language changes
 
 - Pragma macros on type definitions can now return `nnkTypeSection` nodes as well as `nnkTypeDef`,

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -549,9 +549,9 @@ proc getWeeksInYear*(y: int): YearweekRange {.since: (1, 5).} =
 proc getWeekOfYear*(dt: DateTime): YearweekRange {.since: (1, 5).} =
   ## Returns the ISO 8601 calendar week number a datetime is part of
   runnableExamples:
-    assert getWeekOfYear(initDateTime(2018, mApr, 21, 00, 00, 00)) == 16
-    assert getWeekOfYear(initDateTime(2019, mJul, 8, 00, 00, 00)) == 28
-    assert getWeekOfYear(initDateTime(2020, mSept, 13, 00, 00, 00)) == 37
+    assert getWeekOfYear(initDateTime(21, mApr, 2018, 00, 00, 00)) == 16
+    assert getWeekOfYear(initDateTime(08, mJul, 2019, 00, 00, 00)) == 28
+    assert getWeekOfYear(initDateTime(13, mSep, 2020, 00, 00, 00)) == 37
 
   # source: https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm
   let w = (dt.yearday.int - dt.weekday.int + 10) div 7

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2629,10 +2629,10 @@ proc initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
   ## Create a new `DateTime <#DateTime>`_ from a year, week number, and weekday
   ## in the specified timezone.
   runnableExamples:
-    initDateTime(dSun, 29, 2020, 00, 00, 00) == initDateTime(19, mJul, 2020, 00, 00, 00)
-    initDateTime(dMon, 30, 2020, 00, 00, 00) == initDateTime(20, mJul, 2020, 00, 00, 00)
-    initDateTime(dSun, 53, 2020, 00, 00, 00) == initDateTime(03, mJan, 2021, 00, 00, 00)
-    initDateTime(dMon, 01, 2021, 00, 00, 00) == initDateTime(04, mJan, 2021, 00, 00, 00)
+    assert initDateTime(dSun, 29, 2020, 00, 00, 00) == initDateTime(19, mJul, 2020, 00, 00, 00)
+    assert initDateTime(dMon, 30, 2020, 00, 00, 00) == initDateTime(20, mJul, 2020, 00, 00, 00)
+    assert initDateTime(dSun, 53, 2020, 00, 00, 00) == initDateTime(03, mJan, 2021, 00, 00, 00)
+    assert initDateTime(dMon, 01, 2021, 00, 00, 00) == initDateTime(04, mJan, 2021, 00, 00, 00)
   initDateTime(weekday, yearweek, year, hour, minute, second, 0, zone)
 
 #

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2616,7 +2616,7 @@ proc initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
                    nanosecond: NanosecondRange,
                    zone: Timezone = local()): DateTime =
-  ## Create a new `DateTime <#DateTime>`_ from a year, week number, and weekday
+  ## Create a new `DateTime <#DateTime>`_ from a weekday, week number, and year
   ## in the specified timezone.
 
   # source https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -534,7 +534,7 @@ proc getWeeksInYear*(y: int): YearweekRange =
   ## Returns the number of weeks in a year, which can be
   ## either 53 or 52
   runnableExamples:
-    assert getWeekInYear(2000) == 52
+    assert getWeeksInYear(2000) == 52
     assert getWeeksInYear(2001) == 53
 
   # source: https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -530,7 +530,7 @@ proc getDaysInYear*(year: int): int =
     doAssert getDaysInYear(2001) == 365
   result = 365 + (if isLeapYear(year): 1 else: 0)
 
-proc getWeeksInYear*(y: int): YearweekRange =
+proc getWeeksInYear*(y: int): YearweekRange {.since: (1, 5).} =
   ## Returns the number of weeks in a year, which can be
   ## either 53 or 52
   runnableExamples:
@@ -543,7 +543,7 @@ proc getWeeksInYear*(y: int): YearweekRange =
   let p1 = (y1 + (y1 div 4) - (y1 div 100) + (y1 div 400)) mod 7
   if p == 4 or p1 == 3: 53 else: 52
 
-proc getWeekOfYear*(dt: DateTime): YearweekRange =
+proc getWeekOfYear*(dt: DateTime): YearweekRange {.since: (1, 5).} =
   ## Returns the ISO 8601 calendar week number a datetime is part of
   runnableExamples:
     doAssert getWeekOfYear(initDateTime(2018, mApr, 21, 00, 00, 00)) == 16
@@ -2615,7 +2615,7 @@ proc `-=`*(t: var Time, b: TimeInterval) =
 proc initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
                    nanosecond: NanosecondRange,
-                   zone: Timezone = local()): DateTime =
+                   zone: Timezone = local()): DateTime {.since: (1, 5).} =
   ## Create a new `DateTime <#DateTime>`_ from a weekday, week number, and year
   ## in the specified timezone.
 
@@ -2623,9 +2623,9 @@ proc initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
   let d = yearweek * 7 + weekday.int - initDateTime(4, mJan, year, 00, 00, 00).weekday.int - 4
   initDateTime(1, mJan, year, hour, minute, second, nanosecond, zone) + initTimeInterval(days=d)
 
-template initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
+proc initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
-                   zone: Timezone = local()): DateTime =
+                   zone: Timezone = local()): DateTime {.since: (1, 5).} =
   ## Create a new `DateTime <#DateTime>`_ from a year, week number, and weekday
   ## in the specified timezone.
   runnableExamples:

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -534,8 +534,8 @@ proc getWeeksInYear*(y: int): YearweekRange =
   ## Returns the number of weeks in a year, which can be
   ## either 53 or 52
   runnableExamples:
-    doAssert getWeekInYear(2000) == 52
-    doAssert getWeeksInYear(2001) == 53
+    assert getWeekInYear(2000) == 52
+    assert getWeeksInYear(2001) == 53
 
   # source: https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm
   let p = (y + (y div 4) - (y div 100) + (y div 400)) mod 7

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -556,7 +556,8 @@ proc getWeeksInIsoYear*(y: IsoYear): IsoWeekRange {.since: (1, 5).} =
 proc getIsoWeekAndYear*(dt: DateTime):
   tuple[isoweek: IsoWeekRange, isoyear: IsoYear] {.since: (1, 5).} =
   ## Returns the ISO 8601 week and year.
-  ## **Warning** The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
+  ##
+  ## .. warning:: The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
   runnableExamples:
     assert getIsoWeekAndYear(initDateTime(21, mApr, 2018, 00, 00, 00)) == (isoweek: 16.IsoWeekRange, isoyear: 2018.IsoYear)
     block:
@@ -2638,7 +2639,8 @@ proc initDateTime*(weekday: WeekDay, isoweek: IsoWeekRange, isoyear: IsoYear,
                    zone: Timezone = local()): DateTime {.since: (1, 5).} =
   ## Create a new `DateTime <#DateTime>`_ from a weekday and an ISO 8601 week number and year
   ## in the specified timezone.
-  ## **Warning** The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
+  ##
+  ## .. warning:: The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
   runnableExamples:
     assert initDateTime(21, mApr, 2018, 00, 00, 00) == initDateTime(dSat, 16, 2018.IsoYear, 00, 00, 00)
     assert initDateTime(30, mDec, 2019, 00, 00, 00) == initDateTime(dMon, 01, 2020.IsoYear, 00, 00, 00)
@@ -2652,9 +2654,6 @@ proc initDateTime*(weekday: WeekDay, isoweek: IsoWeekRange, isoyear: IsoYear,
 proc initDateTime*(weekday: WeekDay, isoweek: IsoWeekRange, isoyear: IsoYear,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
                    zone: Timezone = local()): DateTime {.since: (1, 5).} =
-  ## Create a new `DateTime <#DateTime>`_ from a weekday and an ISO 8601 week number and year
-  ## in the specified timezone.
-  ## **Warning** The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
   initDateTime(weekday, isoweek, isoyear, hour, minute, second, 0, zone)
 
 #

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -546,9 +546,9 @@ proc getWeeksInYear*(y: int): YearweekRange {.since: (1, 5).} =
 proc getWeekOfYear*(dt: DateTime): YearweekRange {.since: (1, 5).} =
   ## Returns the ISO 8601 calendar week number a datetime is part of
   runnableExamples:
-    doAssert getWeekOfYear(initDateTime(2018, mApr, 21, 00, 00, 00)) == 16
-    doAssert getWeekOfYear(initDateTime(2019, mJul, 8, 00, 00, 00)) == 28
-    doAssert getWeekOfYear(initDateTime(2020, mSept, 13, 00, 00, 00)) == 37
+    assert getWeekOfYear(initDateTime(2018, mApr, 21, 00, 00, 00)) == 16
+    assert getWeekOfYear(initDateTime(2019, mJul, 8, 00, 00, 00)) == 28
+    assert getWeekOfYear(initDateTime(2020, mSept, 13, 00, 00, 00)) == 37
 
   # source: https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm
   let w = (dt.yearday.int - dt.weekday.int + 10) div 7

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -289,9 +289,9 @@ type
   NanosecondRange* = range[0..999_999_999]
 
   IsoWeekRange* = range[1 .. 53]
-    ## An ISO 8601 calendar week number
+    ## An ISO 8601 calendar week number.
   IsoYear* = distinct int
-    ## An ISO 8601 calendar year number
+    ## An ISO 8601 calendar year number.
     ##
     ## .. warning:: The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
 

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -289,7 +289,11 @@ type
   NanosecondRange* = range[0..999_999_999]
 
   IsoWeekRange* = range[1 .. 53]
+    ## An ISO 8601 calendar week number
   IsoYear* = distinct int
+    ## An ISO 8601 calendar year number
+    ##
+    ## .. warning:: The ISO week-based year can correspond to the following or previous year from 29 December to January 3.
 
   Time* = object ## Represents a point in time.
     seconds: int64

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -537,6 +537,9 @@ proc getWeeksInYear*(y: int): YearweekRange {.since: (1, 5).} =
     assert getWeeksInYear(2000) == 52
     assert getWeeksInYear(2001) == 53
 
+  # support negative years
+  let y = if y < 0: 400 + y mod 400 else: y
+
   # source: https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm
   let p = (y + (y div 4) - (y div 100) + (y div 400)) mod 7
   let y1 = y - 1

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -2628,6 +2628,11 @@ template initDateTime*(weekday: WeekDay, yearweek: YearweekRange, year: int,
                    zone: Timezone = local()): DateTime =
   ## Create a new `DateTime <#DateTime>`_ from a year, week number, and weekday
   ## in the specified timezone.
+  runnableExamples:
+    initDateTime(dSun, 29, 2020, 00, 00, 00) == initDateTime(19, mJul, 2020, 00, 00, 00)
+    initDateTime(dMon, 30, 2020, 00, 00, 00) == initDateTime(20, mJul, 2020, 00, 00, 00)
+    initDateTime(dSun, 53, 2020, 00, 00, 00) == initDateTime(03, mJan, 2021, 00, 00, 00)
+    initDateTime(dMon, 01, 2021, 00, 00, 00) == initDateTime(04, mJan, 2021, 00, 00, 00)
   initDateTime(weekday, yearweek, year, hour, minute, second, 0, zone)
 
 #

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -708,3 +708,36 @@ block: # ttimes
     doAssert initDateTime(dWed, 14, -0002, 00, 00, 00) == initDateTime(01, mApr, -0002, 00, 00, 00)
     doAssert getWeekOfYear(initDateTime(01, mApr, -0753, 00, 00, 00)) == 14
     doAssert initDateTime(dMon, 14, -0753, 00, 00, 00) == initDateTime(01, mApr, -0753, 00, 00, 00)
+
+  block: # getWeeksInYear
+    doAssert getWeeksInYear(-0014) == 52
+    doAssert getWeeksInYear(-0013) == 53
+    doAssert getWeeksInYear(-0012) == 52
+
+    doAssert getWeeksInYear(-0009) == 52
+    doAssert getWeeksInYear(-0008) == 53
+    doAssert getWeeksInYear(-0007) == 52
+
+    doAssert getWeeksInYear(-0003) == 52
+    doAssert getWeeksInYear(-0002) == 53
+    doAssert getWeeksInYear(-0001) == 52
+
+    doAssert getWeeksInYear(0003) == 52
+    doAssert getWeeksInYear(0004) == 53
+    doAssert getWeeksInYear(0005) == 52
+
+    doAssert getWeeksInYear(1653) == 52
+    doAssert getWeeksInYear(1654) == 53
+    doAssert getWeeksInYear(1655) == 52
+
+    doAssert getWeeksInYear(1997) == 52
+    doAssert getWeeksInYear(1998) == 53
+    doAssert getWeeksInYear(1999) == 52
+
+    doAssert getWeeksInYear(2008) == 52
+    doAssert getWeeksInYear(2009) == 53
+    doAssert getWeeksInYear(2010) == 52
+
+    doAssert getWeeksInYear(2014) == 52
+    doAssert getWeeksInYear(2015) == 53
+    doAssert getWeeksInYear(2016) == 52

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -697,3 +697,14 @@ block: # ttimes
 
     doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))) == 05
     doAssert initDateTime(dMon, 05, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1)) == initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))
+
+    doAssert getWeekOfYear(initDateTime(01, mApr, +0001, 00, 00, 00)) == 13
+    doAssert initDateTime(dSun, 13, +0001, 00, 00, 00) == initDateTime(01, mApr, +0001, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mApr, +0000, 00, 00, 00)) == 13
+    doAssert initDateTime(dSat, 13, +0000, 00, 00, 00) == initDateTime(01, mApr, +0000, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mApr, -0001, 00, 00, 00)) == 13
+    doAssert initDateTime(dThu, 13, -0001, 00, 00, 00) == initDateTime(01, mApr, -0001, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mApr, -0002, 00, 00, 00)) == 14
+    doAssert initDateTime(dWed, 14, -0002, 00, 00, 00) == initDateTime(01, mApr, -0002, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mApr, -0753, 00, 00, 00)) == 14
+    doAssert initDateTime(dMon, 14, -0753, 00, 00, 00) == initDateTime(01, mApr, -0753, 00, 00, 00)

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -650,10 +650,18 @@ block: # ttimes
   block: # week in year
     doAssert getWeekOfYear(initDateTime(04, mNov, 2019, 00, 00, 00)) == 45
     doAssert initDateTime(dMon, 45, 2019, 00, 00, 00) == initDateTime(04, mNov, 2019, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(28, mDec, 2019, 00, 00, 00)) == 52
+    doAssert initDateTime(dSat, 52, 2019, 00, 00, 00) == initDateTime(28, mDec, 2019, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(29, mDec, 2019, 00, 00, 00)) == 52
+    doAssert initDateTime(dSun, 52, 2019, 00, 00, 00) == initDateTime(29, mDec, 2019, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(30, mDec, 2019, 00, 00, 00)) == 01
+    doAssert initDateTime(dMon, 01, 2020, 00, 00, 00) == initDateTime(30, mDec, 2019, 00, 00, 00)
     doAssert getWeekOfYear(initDateTime(31, mDec, 2019, 00, 00, 00)) == 01
     doAssert initDateTime(dTue, 01, 2020, 00, 00, 00) == initDateTime(31, mDec, 2019, 00, 00, 00)
     doAssert getWeekOfYear(initDateTime(01, mJan, 2020, 00, 00, 00)) == 01
-    doAssert initDateTime(dWed, 01, 2020, 00, 00, 00) == initDateTime(1, mJan, 2020, 00, 00, 00)
+    doAssert initDateTime(dWed, 01, 2020, 00, 00, 00) == initDateTime(01, mJan, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(02, mJan, 2020, 00, 00, 00)) == 01
+    doAssert initDateTime(dThu, 01, 2020, 00, 00, 00) == initDateTime(02, mJan, 2020, 00, 00, 00)
     doAssert getWeekOfYear(initDateTime(05, mApr, 2020, 00, 00, 00)) == 14
     doAssert initDateTime(dSun, 14, 2020, 00, 00, 00) == initDateTime(05, mApr, 2020, 00, 00, 00)
     doAssert getWeekOfYear(initDateTime(06, mApr, 2020, 00, 00, 00)) == 15
@@ -687,4 +695,6 @@ block: # ttimes
     doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 00, 00, 00)) == 05
     doAssert initDateTime(dMon, 05, 2021, 00, 00, 00) == initDateTime(01, mFeb, 2021, 00, 00, 00)
 
+    doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))) == 05
+    doAssert initDateTime(dMon, 05, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1)) == initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))
 

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -647,7 +647,7 @@ block: # ttimes
     doAssert initDuration(milliseconds = -500).inMilliseconds == -500
     doAssert initDuration(nanoseconds = -999999999).inMilliseconds == -999
 
-  block: # week in year
+  block: # getWeekOfYear
     doAssert getWeekOfYear(initDateTime(04, mNov, 2019, 00, 00, 00)) == 45
     doAssert initDateTime(dMon, 45, 2019, 00, 00, 00) == initDateTime(04, mNov, 2019, 00, 00, 00)
     doAssert getWeekOfYear(initDateTime(28, mDec, 2019, 00, 00, 00)) == 52
@@ -697,4 +697,3 @@ block: # ttimes
 
     doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))) == 05
     doAssert initDateTime(dMon, 05, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1)) == initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))
-

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -647,97 +647,97 @@ block: # ttimes
     doAssert initDuration(milliseconds = -500).inMilliseconds == -500
     doAssert initDuration(nanoseconds = -999999999).inMilliseconds == -999
 
-  block: # getWeekOfYear
-    doAssert getWeekOfYear(initDateTime(04, mNov, 2019, 00, 00, 00)) == 45
-    doAssert initDateTime(dMon, 45, 2019, 00, 00, 00) == initDateTime(04, mNov, 2019, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(28, mDec, 2019, 00, 00, 00)) == 52
-    doAssert initDateTime(dSat, 52, 2019, 00, 00, 00) == initDateTime(28, mDec, 2019, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(29, mDec, 2019, 00, 00, 00)) == 52
-    doAssert initDateTime(dSun, 52, 2019, 00, 00, 00) == initDateTime(29, mDec, 2019, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(30, mDec, 2019, 00, 00, 00)) == 01
-    doAssert initDateTime(dMon, 01, 2020, 00, 00, 00) == initDateTime(30, mDec, 2019, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(31, mDec, 2019, 00, 00, 00)) == 01
-    doAssert initDateTime(dTue, 01, 2020, 00, 00, 00) == initDateTime(31, mDec, 2019, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mJan, 2020, 00, 00, 00)) == 01
-    doAssert initDateTime(dWed, 01, 2020, 00, 00, 00) == initDateTime(01, mJan, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(02, mJan, 2020, 00, 00, 00)) == 01
-    doAssert initDateTime(dThu, 01, 2020, 00, 00, 00) == initDateTime(02, mJan, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(05, mApr, 2020, 00, 00, 00)) == 14
-    doAssert initDateTime(dSun, 14, 2020, 00, 00, 00) == initDateTime(05, mApr, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(06, mApr, 2020, 00, 00, 00)) == 15
-    doAssert initDateTime(dMon, 15, 2020, 00, 00, 00) == initDateTime(06, mApr, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(10, mApr, 2020, 00, 00, 00)) == 15
-    doAssert initDateTime(dFri, 15, 2020, 00, 00, 00) == initDateTime(10, mApr, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(12, mApr, 2020, 00, 00, 00)) == 15
-    doAssert initDateTime(dSun, 15, 2020, 00, 00, 00) == initDateTime(12, mApr, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(13, mApr, 2020, 00, 00, 00)) == 16
-    doAssert initDateTime(dMon, 16, 2020, 00, 00, 00) == initDateTime(13, mApr, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(15, mApr, 2020, 00, 00, 00)) == 16
-    doAssert initDateTime(dThu, 16, 2020, 00, 00, 00) == initDateTime(16, mApr, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(17, mJul, 2020, 00, 00, 00)) == 29
-    doAssert initDateTime(dFri, 29, 2020, 00, 00, 00) == initDateTime(17, mJul, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(19, mJul, 2020, 00, 00, 00)) == 29
-    doAssert initDateTime(dSun, 29, 2020, 00, 00, 00) == initDateTime(19, mJul, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(20, mJul, 2020, 00, 00, 00)) == 30
-    doAssert initDateTime(dMon, 30, 2020, 00, 00, 00) == initDateTime(20, mJul, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(23, mJul, 2020, 00, 00, 00)) == 30
-    doAssert initDateTime(dThu, 30, 2020, 00, 00, 00) == initDateTime(23, mJul, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(31, mDec, 2020, 00, 00, 00)) == 53
-    doAssert initDateTime(dThu, 53, 2020, 00, 00, 00) == initDateTime(31, mDec, 2020, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mJan, 2021, 00, 00, 00)) == 53
-    doAssert initDateTime(dFri, 53, 2020, 00, 00, 00) == initDateTime(01, mJan, 2021, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(02, mJan, 2021, 00, 00, 00)) == 53
-    doAssert initDateTime(dSat, 53, 2020, 00, 00, 00) == initDateTime(02, mJan, 2021, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(03, mJan, 2021, 00, 00, 00)) == 53
-    doAssert initDateTime(dSun, 53, 2020, 00, 00, 00) == initDateTime(03, mJan, 2021, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(04, mJan, 2021, 00, 00, 00)) == 01
-    doAssert initDateTime(dMon, 01, 2021, 00, 00, 00) == initDateTime(04, mJan, 2021, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 00, 00, 00)) == 05
-    doAssert initDateTime(dMon, 05, 2021, 00, 00, 00) == initDateTime(01, mFeb, 2021, 00, 00, 00)
+  block: # getIsoWeekAndYear
+    doAssert getIsoWeekAndYear(initDateTime(04, mNov, 2019, 00, 00, 00)) == (isoweek: 45.IsoWeekRange, isoyear: 2019.IsoYear)
+    doAssert initDateTime(dMon, 45, 2019.IsoYear, 00, 00, 00) == initDateTime(04, mNov, 2019, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(28, mDec, 2019, 00, 00, 00)) == (isoweek: 52.IsoWeekRange, isoyear: 2019.IsoYear)
+    doAssert initDateTime(dSat, 52, 2019.IsoYear, 00, 00, 00) == initDateTime(28, mDec, 2019, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(29, mDec, 2019, 00, 00, 00)) == (isoweek: 52.IsoWeekRange, isoyear: 2019.IsoYear)
+    doAssert initDateTime(dSun, 52, 2019.IsoYear, 00, 00, 00) == initDateTime(29, mDec, 2019, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(30, mDec, 2019, 00, 00, 00)) == (isoweek: 01.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dMon, 01, 2020.IsoYear, 00, 00, 00) == initDateTime(30, mDec, 2019, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(31, mDec, 2019, 00, 00, 00)) == (isoweek: 01.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dTue, 01, 2020.IsoYear, 00, 00, 00) == initDateTime(31, mDec, 2019, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mJan, 2020, 00, 00, 00)) == (isoweek: 01.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dWed, 01, 2020.IsoYear, 00, 00, 00) == initDateTime(01, mJan, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(02, mJan, 2020, 00, 00, 00)) == (isoweek: 01.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dThu, 01, 2020.IsoYear, 00, 00, 00) == initDateTime(02, mJan, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(05, mApr, 2020, 00, 00, 00)) == (isoweek: 14.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dSun, 14, 2020.IsoYear, 00, 00, 00) == initDateTime(05, mApr, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(06, mApr, 2020, 00, 00, 00)) == (isoweek: 15.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dMon, 15, 2020.IsoYear, 00, 00, 00) == initDateTime(06, mApr, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(10, mApr, 2020, 00, 00, 00)) == (isoweek: 15.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dFri, 15, 2020.IsoYear, 00, 00, 00) == initDateTime(10, mApr, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(12, mApr, 2020, 00, 00, 00)) == (isoweek: 15.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dSun, 15, 2020.IsoYear, 00, 00, 00) == initDateTime(12, mApr, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(13, mApr, 2020, 00, 00, 00)) == (isoweek: 16.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dMon, 16, 2020.IsoYear, 00, 00, 00) == initDateTime(13, mApr, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(15, mApr, 2020, 00, 00, 00)) == (isoweek: 16.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dThu, 16, 2020.IsoYear, 00, 00, 00) == initDateTime(16, mApr, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(17, mJul, 2020, 00, 00, 00)) == (isoweek: 29.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dFri, 29, 2020.IsoYear, 00, 00, 00) == initDateTime(17, mJul, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(19, mJul, 2020, 00, 00, 00)) == (isoweek: 29.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dSun, 29, 2020.IsoYear, 00, 00, 00) == initDateTime(19, mJul, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(20, mJul, 2020, 00, 00, 00)) == (isoweek: 30.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dMon, 30, 2020.IsoYear, 00, 00, 00) == initDateTime(20, mJul, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(23, mJul, 2020, 00, 00, 00)) == (isoweek: 30.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dThu, 30, 2020.IsoYear, 00, 00, 00) == initDateTime(23, mJul, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(31, mDec, 2020, 00, 00, 00)) == (isoweek: 53.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dThu, 53, 2020.IsoYear, 00, 00, 00) == initDateTime(31, mDec, 2020, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mJan, 2021, 00, 00, 00)) == (isoweek: 53.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dFri, 53, 2020.IsoYear, 00, 00, 00) == initDateTime(01, mJan, 2021, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(02, mJan, 2021, 00, 00, 00)) == (isoweek: 53.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dSat, 53, 2020.IsoYear, 00, 00, 00) == initDateTime(02, mJan, 2021, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(03, mJan, 2021, 00, 00, 00)) == (isoweek: 53.IsoWeekRange, isoyear: 2020.IsoYear)
+    doAssert initDateTime(dSun, 53, 2020.IsoYear, 00, 00, 00) == initDateTime(03, mJan, 2021, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(04, mJan, 2021, 00, 00, 00)) == (isoweek: 01.IsoWeekRange, isoyear: 2021.IsoYear)
+    doAssert initDateTime(dMon, 01, 2021.IsoYear, 00, 00, 00) == initDateTime(04, mJan, 2021, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mFeb, 2021, 00, 00, 00)) == (isoweek: 05.IsoWeekRange, isoyear: 2021.IsoYear)
+    doAssert initDateTime(dMon, 05, 2021.IsoYear, 00, 00, 00) == initDateTime(01, mFeb, 2021, 00, 00, 00)
 
-    doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))) == 05
-    doAssert initDateTime(dMon, 05, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1)) == initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))
+    doAssert getIsoWeekAndYear(initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))) == (isoweek: 05.IsoWeekRange, isoyear: 2021.IsoYear)
+    doAssert initDateTime(dMon, 05, 2021.IsoYear, 01, 02, 03, 400_000_000, staticTz(hours=1)) == initDateTime(01, mFeb, 2021, 01, 02, 03, 400_000_000, staticTz(hours=1))
 
-    doAssert getWeekOfYear(initDateTime(01, mApr, +0001, 00, 00, 00)) == 13
-    doAssert initDateTime(dSun, 13, +0001, 00, 00, 00) == initDateTime(01, mApr, +0001, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mApr, +0000, 00, 00, 00)) == 13
-    doAssert initDateTime(dSat, 13, +0000, 00, 00, 00) == initDateTime(01, mApr, +0000, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mApr, -0001, 00, 00, 00)) == 13
-    doAssert initDateTime(dThu, 13, -0001, 00, 00, 00) == initDateTime(01, mApr, -0001, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mApr, -0002, 00, 00, 00)) == 14
-    doAssert initDateTime(dWed, 14, -0002, 00, 00, 00) == initDateTime(01, mApr, -0002, 00, 00, 00)
-    doAssert getWeekOfYear(initDateTime(01, mApr, -0753, 00, 00, 00)) == 14
-    doAssert initDateTime(dMon, 14, -0753, 00, 00, 00) == initDateTime(01, mApr, -0753, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mApr, +0001, 00, 00, 00)) == (isoweek: 13.IsoWeekRange, isoyear: 0001.IsoYear)
+    doAssert initDateTime(dSun, 13, 0001.IsoYear, 00, 00, 00) == initDateTime(01, mApr, 0001, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mApr, +0000, 00, 00, 00)) == (isoweek: 13.IsoWeekRange, isoyear: 0000.IsoYear)
+    doAssert initDateTime(dSat, 13, 0000.IsoYear, 00, 00, 00) == initDateTime(01, mApr, 0000, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mApr, -0001, 00, 00, 00)) == (isoweek: 13.IsoWeekRange, isoyear: (-0001).IsoYear)
+    doAssert initDateTime(dThu, 13, (-0001).IsoYear, 00, 00, 00) == initDateTime(01, mApr, -0001, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mApr, -0002, 00, 00, 00)) == (isoweek: 14.IsoWeekRange, isoyear: (-0002).IsoYear)
+    doAssert initDateTime(dWed, 14, (-0002).IsoYear, 00, 00, 00) == initDateTime(01, mApr, -0002, 00, 00, 00)
+    doAssert getIsoWeekAndYear(initDateTime(01, mApr, -0753, 00, 00, 00)) == (isoweek: 14.IsoWeekRange, isoyear: (-0753).IsoYear)
+    doAssert initDateTime(dMon, 14, (-0753).IsoYear, 00, 00, 00) == initDateTime(01, mApr, -0753, 00, 00, 00)
 
-  block: # getWeeksInYear
-    doAssert getWeeksInYear(-0014) == 52
-    doAssert getWeeksInYear(-0013) == 53
-    doAssert getWeeksInYear(-0012) == 52
+  block: # getWeeksInIsoYear
+    doAssert getWeeksInIsoYear((-0014).IsoYear) == 52
+    doAssert getWeeksInIsoYear((-0013).IsoYear) == 53
+    doAssert getWeeksInIsoYear((-0012).IsoYear) == 52
 
-    doAssert getWeeksInYear(-0009) == 52
-    doAssert getWeeksInYear(-0008) == 53
-    doAssert getWeeksInYear(-0007) == 52
+    doAssert getWeeksInIsoYear((-0009).IsoYear) == 52
+    doAssert getWeeksInIsoYear((-0008).IsoYear) == 53
+    doAssert getWeeksInIsoYear((-0007).IsoYear) == 52
 
-    doAssert getWeeksInYear(-0003) == 52
-    doAssert getWeeksInYear(-0002) == 53
-    doAssert getWeeksInYear(-0001) == 52
+    doAssert getWeeksInIsoYear((-0003).IsoYear) == 52
+    doAssert getWeeksInIsoYear((-0002).IsoYear) == 53
+    doAssert getWeeksInIsoYear((-0001).IsoYear) == 52
 
-    doAssert getWeeksInYear(0003) == 52
-    doAssert getWeeksInYear(0004) == 53
-    doAssert getWeeksInYear(0005) == 52
+    doAssert getWeeksInIsoYear(0003.IsoYear) == 52
+    doAssert getWeeksInIsoYear(0004.IsoYear) == 53
+    doAssert getWeeksInIsoYear(0005.IsoYear) == 52
 
-    doAssert getWeeksInYear(1653) == 52
-    doAssert getWeeksInYear(1654) == 53
-    doAssert getWeeksInYear(1655) == 52
+    doAssert getWeeksInIsoYear(1653.IsoYear) == 52
+    doAssert getWeeksInIsoYear(1654.IsoYear) == 53
+    doAssert getWeeksInIsoYear(1655.IsoYear) == 52
 
-    doAssert getWeeksInYear(1997) == 52
-    doAssert getWeeksInYear(1998) == 53
-    doAssert getWeeksInYear(1999) == 52
+    doAssert getWeeksInIsoYear(1997.IsoYear) == 52
+    doAssert getWeeksInIsoYear(1998.IsoYear) == 53
+    doAssert getWeeksInIsoYear(1999.IsoYear) == 52
 
-    doAssert getWeeksInYear(2008) == 52
-    doAssert getWeeksInYear(2009) == 53
-    doAssert getWeeksInYear(2010) == 52
+    doAssert getWeeksInIsoYear(2008.IsoYear) == 52
+    doAssert getWeeksInIsoYear(2009.IsoYear) == 53
+    doAssert getWeeksInIsoYear(2010.IsoYear) == 52
 
-    doAssert getWeeksInYear(2014) == 52
-    doAssert getWeeksInYear(2015) == 53
-    doAssert getWeeksInYear(2016) == 52
+    doAssert getWeeksInIsoYear(2014.IsoYear) == 52
+    doAssert getWeeksInIsoYear(2015.IsoYear) == 53
+    doAssert getWeeksInIsoYear(2016.IsoYear) == 52

--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -646,3 +646,45 @@ block: # ttimes
     doAssert initDuration(milliseconds = 500).inMilliseconds == 500
     doAssert initDuration(milliseconds = -500).inMilliseconds == -500
     doAssert initDuration(nanoseconds = -999999999).inMilliseconds == -999
+
+  block: # week in year
+    doAssert getWeekOfYear(initDateTime(04, mNov, 2019, 00, 00, 00)) == 45
+    doAssert initDateTime(dMon, 45, 2019, 00, 00, 00) == initDateTime(04, mNov, 2019, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(31, mDec, 2019, 00, 00, 00)) == 01
+    doAssert initDateTime(dTue, 01, 2020, 00, 00, 00) == initDateTime(31, mDec, 2019, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mJan, 2020, 00, 00, 00)) == 01
+    doAssert initDateTime(dWed, 01, 2020, 00, 00, 00) == initDateTime(1, mJan, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(05, mApr, 2020, 00, 00, 00)) == 14
+    doAssert initDateTime(dSun, 14, 2020, 00, 00, 00) == initDateTime(05, mApr, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(06, mApr, 2020, 00, 00, 00)) == 15
+    doAssert initDateTime(dMon, 15, 2020, 00, 00, 00) == initDateTime(06, mApr, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(10, mApr, 2020, 00, 00, 00)) == 15
+    doAssert initDateTime(dFri, 15, 2020, 00, 00, 00) == initDateTime(10, mApr, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(12, mApr, 2020, 00, 00, 00)) == 15
+    doAssert initDateTime(dSun, 15, 2020, 00, 00, 00) == initDateTime(12, mApr, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(13, mApr, 2020, 00, 00, 00)) == 16
+    doAssert initDateTime(dMon, 16, 2020, 00, 00, 00) == initDateTime(13, mApr, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(15, mApr, 2020, 00, 00, 00)) == 16
+    doAssert initDateTime(dThu, 16, 2020, 00, 00, 00) == initDateTime(16, mApr, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(17, mJul, 2020, 00, 00, 00)) == 29
+    doAssert initDateTime(dFri, 29, 2020, 00, 00, 00) == initDateTime(17, mJul, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(19, mJul, 2020, 00, 00, 00)) == 29
+    doAssert initDateTime(dSun, 29, 2020, 00, 00, 00) == initDateTime(19, mJul, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(20, mJul, 2020, 00, 00, 00)) == 30
+    doAssert initDateTime(dMon, 30, 2020, 00, 00, 00) == initDateTime(20, mJul, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(23, mJul, 2020, 00, 00, 00)) == 30
+    doAssert initDateTime(dThu, 30, 2020, 00, 00, 00) == initDateTime(23, mJul, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(31, mDec, 2020, 00, 00, 00)) == 53
+    doAssert initDateTime(dThu, 53, 2020, 00, 00, 00) == initDateTime(31, mDec, 2020, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mJan, 2021, 00, 00, 00)) == 53
+    doAssert initDateTime(dFri, 53, 2020, 00, 00, 00) == initDateTime(01, mJan, 2021, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(02, mJan, 2021, 00, 00, 00)) == 53
+    doAssert initDateTime(dSat, 53, 2020, 00, 00, 00) == initDateTime(02, mJan, 2021, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(03, mJan, 2021, 00, 00, 00)) == 53
+    doAssert initDateTime(dSun, 53, 2020, 00, 00, 00) == initDateTime(03, mJan, 2021, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(04, mJan, 2021, 00, 00, 00)) == 01
+    doAssert initDateTime(dMon, 01, 2021, 00, 00, 00) == initDateTime(04, mJan, 2021, 00, 00, 00)
+    doAssert getWeekOfYear(initDateTime(01, mFeb, 2021, 00, 00, 00)) == 05
+    doAssert initDateTime(dMon, 05, 2021, 00, 00, 00) == initDateTime(01, mFeb, 2021, 00, 00, 00)
+
+


### PR DESCRIPTION
ISO Week-of-year implementation for the times module using [algorithm from wikipedia](https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_from_a_month_and_day_of_the_month_or_ordinal_date), which is in turn from [Van Gent, Math Department of Uttrecht University](https://webspace.science.uu.nl/~gent0113/calendar/isocalendar.htm). Previously [referenced on the forum](https://forum.nim-lang.org/t/6320#39062), used for a year in production with no issues. Fairly comprehensive unit tests. Performance should be ok, additional bit twiddling possible but probably won't be needed by anyone. Nimble package also possible but very small / seems to fit better here. Feedback welcome.