### PR TITLE
followup #17225: simplify code after removing gc2, generational

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -116,7 +116,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
 when declared(GC_setMaxPause):
   GC_setMaxPause 2_000
 
-when compileOption("gc", "v2") or compileOption("gc", "refc"):
+when compileOption("gc", "refc"):
   # the new correct mark&sweet collector is too slow :-/
   GC_disableMarkAndSweep()
 

--- a/compiler/nimfix/nimfix.nim
+++ b/compiler/nimfix/nimfix.nim
@@ -103,7 +103,7 @@ proc handleCmdLine(config: ConfigRef) =
     processCmdLine(passCmd2, "", config)
     mainCommand()
 
-when compileOption("gc", "v2") or compileOption("gc", "refc"):
+when compileOption("gc", "refc"):
   GC_disableMarkAndSweep()
 
 condsyms.initDefines()

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1271,7 +1271,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   mainCommand(graph)
   if conf.hasHint(hintGCStats): echo(GC_getStatistics())
 
-when compileOption("gc", "v2") or compileOption("gc", "refc"):
+when compileOption("gc", "refc"):
   # the new correct mark&sweep collector is too slow :-/
   GC_disableMarkAndSweep()
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1909,9 +1909,8 @@ include "system/gc_interface"
 const NimStackTrace = compileOption("stacktrace")
 
 template coroutinesSupportedPlatform(): bool =
-  when defined(sparc) or defined(ELATE) or compileOption("gc", "v2") or
-    defined(boehmgc) or defined(gogc) or defined(nogc) or defined(gcRegions) or
-    defined(gcMarkAndSweep):
+  when defined(sparc) or defined(ELATE) or defined(boehmgc) or defined(gogc) or
+    defined(nogc) or defined(gcRegions) or defined(gcMarkAndSweep):
     false
   else:
     true

--- a/lib/system/gc2.nim
+++ b/lib/system/gc2.nim
@@ -7,6 +7,9 @@
 #    distribution, for details about the copyright.
 #
 
+# xxx deadcode, consider removing unless something could be reused.
+
+
 #            Garbage Collector
 #
 # The basic algorithm is an incremental mark

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -68,9 +68,7 @@ else:
       include "system/cellsets"
     when not leakDetector and not useCellIds and not defined(nimV2):
       sysAssert(sizeof(Cell) == sizeof(FreeCell), "sizeof FreeCell")
-  when compileOption("gc", "v2"):
-    include "system/gc2"
-  elif defined(gcRegions):
+  when defined(gcRegions):
     # XXX due to bootstrapping reasons, we cannot use  compileOption("gc", "stack") here
     include "system/gc_regions"
   elif defined(nimV2) or usesDestructors:

--- a/lib/system/sysstr.nim
+++ b/lib/system/sysstr.nim
@@ -304,7 +304,7 @@ proc setLengthSeq(seq: PGenericSeq, elemSize, elemAlign, newLen: int): PGenericS
     when not defined(boehmGC) and not defined(nogc) and
          not defined(gcMarkAndSweep) and not defined(gogc) and
          not defined(gcRegions):
-      when false: # compileOption("gc", "v2"):
+      when false: # deadcode: was used by `compileOption("gc", "v2")`
         for i in newLen..result.len-1:
           let len0 = gch.tempStack.len
           forAllChildrenAux(dataPointer(result, elemAlign, elemSize, i),


### PR DESCRIPTION
* followup #17225
* remove warning when compiling nim `compiler/nim.nim(119, 19) Warning: 'v2' is deprecated, now a noop [Deprecated]`

## future work
- [x] remove lib/system/gc2.nim
- [ ] remove `nilchecks` and associated code which is a noop since https://github.com/nim-lang/Nim/pull/11570 and https://github.com/nim-lang/Nim/pull/14028; see also exp_SIGSEGV_debug D20200406T115434 where i implemented a (IIRC) working version of this feature (EDIT: refs https://github.com/nim-lang/Nim/pull/17274)