### PR TITLE
`\r` now renders as `\r`, not `\c` which was very non-standard

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -189,6 +189,8 @@ provided by the operating system.
 - `std/options` changed `$some(3)` to `"some(3)"` instead of `"Some(3)"`
   and `$none(int)` to `"none(int)"` instead of `"None[int]"`.
 
+- `system.addEscapedChar` now renders `\r` as `\r` instead of `\c`, to be compatible
+  with most other languages.
 
 ## Language changes
 

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2838,7 +2838,7 @@ proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   ## * replaces any `\n` by `\\n`
   ## * replaces any `\v` by `\\v`
   ## * replaces any `\f` by `\\f`
-  ## * replaces any `\c` by `\\c`
+  ## * replaces any `\r` by `\\r`
   ## * replaces any `\e` by `\\e`
   ## * replaces any other character not in the set `{'\21..'\126'}
   ##   by `\xHH` where `HH` is its hexadecimal value.
@@ -2851,10 +2851,10 @@ proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   of '\a': s.add "\\a" # \x07
   of '\b': s.add "\\b" # \x08
   of '\t': s.add "\\t" # \x09
-  of '\L': s.add "\\n" # \x0A
+  of '\n': s.add "\\n" # \x0A
   of '\v': s.add "\\v" # \x0B
   of '\f': s.add "\\f" # \x0C
-  of '\c': s.add "\\c" # \x0D
+  of '\r': (when defined(nimLegacyAddEscapedCharx0D): s.add "\\c" else: s.add "\\r") # \x0D
   of '\e': s.add "\\e" # \x1B
   of '\\': s.add("\\\\")
   of '\'': s.add("\\'")


### PR DESCRIPTION
This changes how `\r` is rendered via `addEscapedChar`, use `-d:nimLegacyAddEscapedCharx0D` for previous behavior for a transition time.

I don't know where `\c` comes from, but `\r` is IMO what's standard, recognized by lots of languages whereas `\c` is not.

eg: these languages recognize `\r` but choke on `\c`:
* D
* python [1]
* C
* C++
* ruby
* https://en.wikipedia.org/wiki/Newline
* https://en.wikipedia.org/wiki/Carriage_return

for example:
[1]
```
>>> print(ord('\r'))
13
>>> print(ord('\c'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: ord() expected a character, but string of length 2 found
```

## future work
- [ ] replace `\c` by `\r`
- [ ] replace `\L` by `\n`
- [ ] replace `\l` by `\n`
in nim repo (this would not be a breaking change since these are the same via nim lexer)
