### PR TITLE
Fix sleepAsync

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -194,6 +194,10 @@ provided by the operating system.
 - `system.addEscapedChar` now renders `\r` as `\r` instead of `\c`, to be compatible
   with most other languages.
 
+- `asyncdispatch.sleepAsync` do not take `float` anymore, to be consistent with `withTimeout`,
+  also avoids Bugs like `sleepAsync(NaN)`, `sleepAsync(Inf)`, etc.
+
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1830,17 +1830,13 @@ proc connect*(socket: AsyncFD, address: string, port: Port,
     socket.SocketHandle.bindToDomain(domain)
   asyncAddrInfoLoop(aiList, socket)
 
-proc sleepAsync*(ms: int | float): owned(Future[void]) =
+proc sleepAsync*(ms: int): owned(Future[void]) =
   ## Suspends the execution of the current async procedure for the next
   ## `ms` milliseconds.
   var retFuture = newFuture[void]("sleepAsync")
   let p = getGlobalDispatcher()
-  when ms is int:
-    p.timers.push((getMonoTime() + initDuration(milliseconds = ms), retFuture))
-  elif ms is float:
-    let ns = (ms * 1_000_000).int64
-    p.timers.push((getMonoTime() + initDuration(nanoseconds = ns), retFuture))
-  return retFuture
+  p.timers.push((getMonoTime() + initDuration(milliseconds = ms), retFuture))
+  result = retFuture
 
 proc withTimeout*[T](fut: Future[T], timeout: int): owned(Future[bool]) =
   ## Returns a future which will complete once `fut` completes or after


### PR DESCRIPTION
```nim
import asyncdispatch, times

proc main(a: float or int) {.async.} =
  let t = now()
  echo "BEFORE\T", t, '\T', a
  await sleepAsync(a)
  echo "AFTER\T", t - now(), '\n'

waitFor main(1)  # Control
waitFor main(0.0)
waitFor main(-0.0)
waitFor main(1.0)
waitFor main(-1.0)
waitFor main(-1.0)
waitFor main(NaN)
waitFor main(+Inf)
waitFor main(-Inf)
waitFor main(Inf)
```

- Only package `ws` is failing CI. /c @treeform 
