### PR TITLE
fix RST parsing when no indent after enum.item (fix #17249)

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1366,8 +1366,8 @@ proc commandRstAux(cache: IdentCache, conf: ConfigRef;
   var d = newDocumentor(filen, cache, conf, outExt)
 
   d.isPureRst = true
-  var rst = parseRst(readFile(filen.string), filen.string, 1, 1, d.hasToc,
-                     {roSupportRawDirective, roSupportMarkdown}, conf)
+  var rst = parseRst(readFile(filen.string), filen.string, line=1, column=0,
+                     d.hasToc, {roSupportRawDirective, roSupportMarkdown}, conf)
   var modDesc = newStringOfCap(30_000)
   renderRstToOut(d[], rst, modDesc)
   d.modDesc = rope(modDesc)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1366,7 +1366,8 @@ proc commandRstAux(cache: IdentCache, conf: ConfigRef;
   var d = newDocumentor(filen, cache, conf, outExt)
 
   d.isPureRst = true
-  var rst = parseRst(readFile(filen.string), filen.string, line=1, column=0,
+  var rst = parseRst(readFile(filen.string), filen.string,
+                     line=LineRstInit, column=ColRstInit,
                      d.hasToc, {roSupportRawDirective, roSupportMarkdown}, conf)
   var modDesc = newStringOfCap(30_000)
   renderRstToOut(d[], rst, modDesc)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1366,7 +1366,7 @@ proc commandRstAux(cache: IdentCache, conf: ConfigRef;
   var d = newDocumentor(filen, cache, conf, outExt)
 
   d.isPureRst = true
-  var rst = parseRst(readFile(filen.string), filen.string, 0, 1, d.hasToc,
+  var rst = parseRst(readFile(filen.string), filen.string, 1, 1, d.hasToc,
                      {roSupportRawDirective, roSupportMarkdown}, conf)
   var modDesc = newStringOfCap(30_000)
   renderRstToOut(d[], rst, modDesc)

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -599,14 +599,16 @@ to existing modules is acceptable. For two reasons:
 
 Conventions
 -----------
-1. New stdlib modules should go under `Nim/lib/std/`. The rationale is to require
-users to import via `import std/foo` instead of `import foo`, which would cause
-potential conflicts with nimble packages. Note that this still applies for new modules
-in existing logical directories, e.g.:
-use `lib/std/collections/foo.nim`, not `lib/pure/collections/foo.nim`.
+1. New stdlib modules should go under `Nim/lib/std/`. The rationale is to
+   require users to import via `import std/foo` instead of `import foo`,
+   which would cause potential conflicts with nimble packages.
+   Note that this still applies for new modules in existing logical
+   directories, e.g.: use `lib/std/collections/foo.nim`,
+   not `lib/pure/collections/foo.nim`.
 
 2. New module names should prefer plural form whenever possible, e.g.:
-`std/sums.nim` instead of `std/sum.nim`. In particular, this reduces chances of conflicts
-between module name and the symbols it defines. Furthermore, module names should
-use `snake_case` and not use capital letters, which cause issues when going
-from an OS without case sensitivity to an OS with it.
+   `std/sums.nim` instead of `std/sum.nim`. In particular, this reduces
+   chances of conflicts between module name and the symbols it defines.
+   Furthermore, module names should use `snake_case` and not use capital
+   letters, which cause issues when going from an OS without case
+   sensitivity to an OS with it.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -6073,13 +6073,14 @@ avoid ambiguity when there are multiple modules with the same path.
 
 There are two pseudo directories:
 
-1. ``std``: The ``std`` pseudo directory is the abstract location of Nim's standard
-library. For example, the syntax ``import std / strutils`` is used to unambiguously
-refer to the standard library's ``strutils`` module.
-2. ``pkg``: The ``pkg`` pseudo directory is used to unambiguously refer to a Nimble
-package. However, for technical details that lie outside the scope of this document,
-its semantics are: *Use the search path to look for module name but ignore the standard
-library locations*. In other words, it is the opposite of ``std``.
+1. ``std``: The ``std`` pseudo directory is the abstract location of
+   Nim's standard library. For example, the syntax ``import std / strutils``
+   is used to unambiguously refer to the standard library's ``strutils`` module.
+2. ``pkg``: The ``pkg`` pseudo directory is used to unambiguously refer to
+   a Nimble package. However, for technical details that lie outside the
+   scope of this document, its semantics are: *Use the search path to look for
+   module name but ignore the standard library locations*.
+   In other words, it is the opposite of ``std``.
 
 
 From import statement

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -154,7 +154,7 @@
 ## The reasoning is as follows:
 ## 1. it's close to what many DBs offer natively (char**)
 ## 2. it hides the number of types that the DB supports
-## (int? int64? decimal up to 10 places? geo coords?)
+##    (int? int64? decimal up to 10 places? geo coords?)
 ## 3. it's convenient when all you do is to forward the data to somewhere else (echo, log, put the data into a new query)
 ##
 ## See also

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1439,8 +1439,11 @@ proc countTitles(p: var RstParser, n: PRstNode) =
         if p.s.hTitleCnt >= 2:
           break
 
-proc tokenAfterNewline(p: RstParser, start=p.idx): int =
-  result = start
+proc tokenAfterNewline(p: RstParser, start = -1): int =
+  if start == -1:
+    result = p.idx
+  else:
+    result = start
   while true:
     case p.tok[result].kind
     of tkEof:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -467,7 +467,12 @@ type
     s*: PSharedState
     indentStack*: seq[int]
     filename*: string
-    line*, col*: int
+    line*, col*: int            ## initial line/column of whole text or
+                                ## documenation fragment that will be added
+                                ## in case of error/warning reporting to
+                                ## (relative) line/column of the token.
+                                ## For standalone text should be line=1 and
+                                ## col=0 (Nim global reporting adds ColOffset=1)
     hasToc*: bool
     curAnchor*: string          # variable to track latest anchor in s.anchors
 
@@ -2359,7 +2364,8 @@ proc selectDir(p: var RstParser, d: string): PRstNode =
   of "warning": result = dirAdmonition(p, d)
   of "default-role": result = dirDefaultRole(p)
   else:
-    rstMessage(p, meInvalidDirective, d)
+    let tok = p.tok[p.idx-2]  # report on directive in ".. directive::"
+    rstMessage(p, meInvalidDirective, d, tok.line, tok.col)
 
 proc prefix(ftnType: FootnoteType): string =
   case ftnType

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1444,11 +1444,8 @@ proc countTitles(p: var RstParser, n: PRstNode) =
         if p.s.hTitleCnt >= 2:
           break
 
-proc tokenAfterNewline(p: RstParser, start = -1): int =
-  if start == -1:
-    result = p.idx
-  else:
-    result = start
+proc tokenAfterNewline(p: RstParser, start: int): int =
+  result = start
   while true:
     case p.tok[result].kind
     of tkEof:
@@ -1457,6 +1454,9 @@ proc tokenAfterNewline(p: RstParser, start = -1): int =
       inc result
       break
     else: inc result
+
+proc tokenAfterNewline(p: RstParser): int {.inline.} =
+  result = tokenAfterNewline(p, p.idx)
 
 proc isAdornmentHeadline(p: RstParser, adornmentIdx: int): bool =
   ## check that underline/overline length is enough for the heading.

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1961,13 +1961,13 @@ proc parseEnumList(p: var RstParser): PRstNode =
       # subsequent enum.items parseEnumList will be called second time
       if result == nil:
         let n = p.line + p.tok[j].line
-        rstMessage(p, mwRstStyle, ("\n  not enough indentation on line $2" &
-          " (if it's continuation of enumeration list) or " &
-          "\n  no blank line after line $1" &
-          " (if it should be the next paragraph) or" &
-          "\n  no escaping \\ at the beginning of line $1" &
-          "\n    (if lines $1..$2 are a normal paragraph, not enum. list)") %
-          [$(n-1), $n])
+        let msg = "\n" & """
+          not enough indentation on line $2
+              (if it's continuation of enumeration list),
+          or no blank line after line $1 (if it should be the next paragraph),
+          or no escaping \ at the beginning of line $1
+              (if lines $1..$2 are a normal paragraph, not enum. list)"""
+        rstMessage(p, mwRstStyle, msg % [$(n-1), $n])
       return
   checkAfterNewline
   result = newRstNodeA(p, rnEnumList)

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1973,7 +1973,8 @@ proc parseEnumList(p: var RstParser): PRstNode =
       result = false
     else:
       result = true
-  if not checkAfterNewline(p, report = true): return nil
+  if not checkAfterNewline(p, report = true):
+    return nil
   result = newRstNodeA(p, rnEnumList)
   let autoEnums = if roSupportMarkdown in p.s.options: @["#", "1"] else: @["#"]
   var prevAE = ""  # so as not allow mixing auto-enumerators `1` and `#`
@@ -1996,7 +1997,8 @@ proc parseEnumList(p: var RstParser): PRstNode =
         match(p, p.idx+1, wildcards[w]):
       # don't report to avoid duplication of warning since for
       # subsequent enum. items parseEnumList will be called second time:
-      if not checkAfterNewline(p, report = false): return nil
+      if not checkAfterNewline(p, report = false):
+        break
       let enumerator = p.tok[p.idx + 1 + wildIndex[w]].symbol
       # check that it's in sequence: enumerator == next(prevEnum)
       if "n" in wildcards[w]:  # arabic numeral

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1961,13 +1961,13 @@ proc parseEnumList(p: var RstParser): PRstNode =
       # subsequent enum.items parseEnumList will be called second time
       if result == nil:
         let n = p.line + p.tok[j].line
-        let msg = "\n" & """
+        let msg = "\n" & dedent """
           not enough indentation on line $2
               (if it's continuation of enumeration list),
           or no blank line after line $1 (if it should be the next paragraph),
           or no escaping \ at the beginning of line $1
               (if lines $1..$2 are a normal paragraph, not enum. list)"""
-        rstMessage(p, mwRstStyle, msg % [$(n-1), $n])
+        rstMessage(p, mwRstStyle, indent(msg, 2) % [$(n-1), $n])
       return
   checkAfterNewline
   result = newRstNodeA(p, rnEnumList)

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1506,7 +1506,7 @@ proc rstToHtml*(s: string, options: RstParseOptions,
   initRstGenerator(d, outHtml, config, filen, options, myFindFile,
                    rst.defaultMsgHandler)
   var dummyHasToc = false
-  var rst = rstParse(s, filen, 1, 1, dummyHasToc, options)
+  var rst = rstParse(s, filen, line=1, column=0, dummyHasToc, options)
   result = ""
   renderRstToOut(d, rst, result)
 
@@ -1518,4 +1518,6 @@ proc rstToLatex*(rstSource: string; options: RstParseOptions): string {.inline, 
   var option: bool
   var rstGenera: RstGenerator
   rstGenera.initRstGenerator(outLatex, defaultConfig(), "input", options)
-  rstGenera.renderRstToOut(rstParse(rstSource, "", 1, 1, option, options), result)
+  rstGenera.renderRstToOut(
+      rstParse(rstSource, "", line=1, column=0, option, options),
+      result)

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1506,7 +1506,8 @@ proc rstToHtml*(s: string, options: RstParseOptions,
   initRstGenerator(d, outHtml, config, filen, options, myFindFile,
                    rst.defaultMsgHandler)
   var dummyHasToc = false
-  var rst = rstParse(s, filen, line=1, column=0, dummyHasToc, options)
+  var rst = rstParse(s, filen, line=LineRstInit, column=ColRstInit,
+                     dummyHasToc, options)
   result = ""
   renderRstToOut(d, rst, result)
 
@@ -1519,5 +1520,6 @@ proc rstToLatex*(rstSource: string; options: RstParseOptions): string {.inline, 
   var rstGenera: RstGenerator
   rstGenera.initRstGenerator(outLatex, defaultConfig(), "input", options)
   rstGenera.renderRstToOut(
-      rstParse(rstSource, "", line=1, column=0, option, options),
+      rstParse(rstSource, "", line=LineRstInit, column=ColRstInit,
+               option, options),
       result)

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1506,7 +1506,7 @@ proc rstToHtml*(s: string, options: RstParseOptions,
   initRstGenerator(d, outHtml, config, filen, options, myFindFile,
                    rst.defaultMsgHandler)
   var dummyHasToc = false
-  var rst = rstParse(s, filen, 0, 1, dummyHasToc, options)
+  var rst = rstParse(s, filen, 1, 1, dummyHasToc, options)
   result = ""
   renderRstToOut(d, rst, result)
 

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1438,47 +1438,43 @@ func unindent*(s: string, count: Natural = int.high,
     result.add(line[indentCount*padding.len .. ^1])
     i.inc
 
-since (1, 3):
-  func indentation*(s: string): Natural =
-    ## Returns the amount of indentation all lines of `s` have in common,
-    ## ignoring lines that consist only of whitespace.
-    result = int.high
-    for line in s.splitLines:
-      for i, c in line:
-        if i >= result: break
-        elif c != ' ':
-          result = i
-          break
-    if result == int.high:
-      result = 0
+func indentation*(s: string): Natural {.since: (1, 3).} =
+  ## Returns the amount of indentation all lines of `s` have in common,
+  ## ignoring lines that consist only of whitespace.
+  result = int.high
+  for line in s.splitLines:
+    for i, c in line:
+      if i >= result: break
+      elif c != ' ':
+        result = i
+        break
+  if result == int.high:
+    result = 0
 
-  func dedent*(s: string, count: Natural): string {.rtl, extern: "nsuDedent".} =
-    unindent(s, count, " ")
+func dedent*(s: string, count: Natural = indentation(s)): string {.rtl,
+    extern: "nsuDedent", since: (1, 3).} =
+  ## Unindents each line in `s` by `count` amount of `padding`.
+  ## The only difference between this and the
+  ## `unindent func<#unindent,string,Natural,string>`_ is that this by default
+  ## only cuts off the amount of indentation that all lines of `s` share as
+  ## opposed to all indentation. It only supports spaces as padding.
+  ##
+  ## **Note:** This does not preserve the new line characters used in `s`.
+  ##
+  ## See also:
+  ## * `unindent func<#unindent,string,Natural,string>`_
+  ## * `align func<#align,string,Natural,char>`_
+  ## * `alignLeft func<#alignLeft,string,Natural,char>`_
+  ## * `spaces func<#spaces,Natural>`_
+  ## * `indent func<#indent,string,Natural,string>`_
+  runnableExamples:
+    let x = """
+      Hello
+        There
+    """.dedent()
 
-  proc dedent*(a: string): string {.inline.} =
-    ## Unindents each line in `s` by `count` amount of `padding`.
-    ## The only difference between this and the
-    ## `unindent func<#unindent,string,Natural,string>`_ is that this by default
-    ## only cuts off the amount of indentation that all lines of `s` share as
-    ## opposed to all indentation. It only supports spaces as padding.
-    ##
-    ## **Note:** This does not preserve the new line characters used in `s`.
-    ##
-    ## See also:
-    ## * `unindent func<#unindent,string,Natural,string>`_
-    ## * `align func<#align,string,Natural,char>`_
-    ## * `alignLeft func<#alignLeft,string,Natural,char>`_
-    ## * `spaces func<#spaces,Natural>`_
-    ## * `indent func<#indent,string,Natural,string>`_
-    # workaround, see https://github.com/timotheecour/Nim/issues/521
-    runnableExamples:
-      let x = """
-        Hello
-          There
-      """.dedent()
-
-      doAssert x == "Hello\n  There\n"
-    dedent(a, indentation(a))
+    doAssert x == "Hello\n  There\n"
+  unindent(s, count, " ")
 
 func delete*(s: var string, first, last: int) {.rtl, extern: "nsuDelete".} =
   ## Deletes in `s` (must be declared as `var`) the characters at positions

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1455,7 +1455,7 @@ since (1, 3):
   func dedent*(s: string, count: Natural): string {.rtl, extern: "nsuDedent".} =
     unindent(s, count, " ")
 
-  proc dedent*(a: string): string =
+  proc dedent*(a: string): string {.inline.} =
     ## Unindents each line in `s` by `count` amount of `padding`.
     ## The only difference between this and the
     ## `unindent func<#unindent,string,Natural,string>`_ is that this by default
@@ -1478,9 +1478,7 @@ since (1, 3):
       """.dedent()
 
       doAssert x == "Hello\n  There\n"
-    let b = a
-    let i = indentation(b)
-    dedent(a, i)
+    dedent(a, indentation(a))
 
 func delete*(s: var string, first, last: int) {.rtl, extern: "nsuDelete".} =
   ## Deletes in `s` (must be declared as `var`) the characters at positions

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1438,43 +1438,49 @@ func unindent*(s: string, count: Natural = int.high,
     result.add(line[indentCount*padding.len .. ^1])
     i.inc
 
-func indentation*(s: string): Natural {.since: (1, 3).} =
-  ## Returns the amount of indentation all lines of `s` have in common,
-  ## ignoring lines that consist only of whitespace.
-  result = int.high
-  for line in s.splitLines:
-    for i, c in line:
-      if i >= result: break
-      elif c != ' ':
-        result = i
-        break
-  if result == int.high:
-    result = 0
+since (1, 3):
+  func indentation*(s: string): Natural =
+    ## Returns the amount of indentation all lines of `s` have in common,
+    ## ignoring lines that consist only of whitespace.
+    result = int.high
+    for line in s.splitLines:
+      for i, c in line:
+        if i >= result: break
+        elif c != ' ':
+          result = i
+          break
+    if result == int.high:
+      result = 0
 
-func dedent*(s: string, count: Natural = indentation(s)): string {.rtl,
-    extern: "nsuDedent", since: (1, 3).} =
-  ## Unindents each line in `s` by `count` amount of `padding`.
-  ## The only difference between this and the
-  ## `unindent func<#unindent,string,Natural,string>`_ is that this by default
-  ## only cuts off the amount of indentation that all lines of `s` share as
-  ## opposed to all indentation. It only supports spaces as padding.
-  ##
-  ## **Note:** This does not preserve the new line characters used in `s`.
-  ##
-  ## See also:
-  ## * `unindent func<#unindent,string,Natural,string>`_
-  ## * `align func<#align,string,Natural,char>`_
-  ## * `alignLeft func<#alignLeft,string,Natural,char>`_
-  ## * `spaces func<#spaces,Natural>`_
-  ## * `indent func<#indent,string,Natural,string>`_
-  runnableExamples:
-    let x = """
-      Hello
-        There
-    """.dedent()
+  func dedent*(s: string, count: Natural): string {.rtl, extern: "nsuDedent".} =
+    unindent(s, count, " ")
 
-    doAssert x == "Hello\n  There\n"
-  unindent(s, count, " ")
+  proc dedent*(a: string): string =
+    ## Unindents each line in `s` by `count` amount of `padding`.
+    ## The only difference between this and the
+    ## `unindent func<#unindent,string,Natural,string>`_ is that this by default
+    ## only cuts off the amount of indentation that all lines of `s` share as
+    ## opposed to all indentation. It only supports spaces as padding.
+    ##
+    ## **Note:** This does not preserve the new line characters used in `s`.
+    ##
+    ## See also:
+    ## * `unindent func<#unindent,string,Natural,string>`_
+    ## * `align func<#align,string,Natural,char>`_
+    ## * `alignLeft func<#alignLeft,string,Natural,char>`_
+    ## * `spaces func<#spaces,Natural>`_
+    ## * `indent func<#indent,string,Natural,string>`_
+    # workaround, see https://github.com/timotheecour/Nim/issues/521
+    runnableExamples:
+      let x = """
+        Hello
+          There
+      """.dedent()
+
+      doAssert x == "Hello\n  There\n"
+    let b = a
+    let i = indentation(b)
+    dedent(a, i)
 
 func delete*(s: var string, first, last: int) {.rtl, extern: "nsuDelete".} =
   ## Deletes in `s` (must be declared as `var`) the characters at positions

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -708,6 +708,15 @@ Test1
     doAssert count(output7, "<li>") == 3
     doAssert "start=\"3\"" in output7 and "class=\"upperalpha simple\"" in output7
 
+    # check that it's not recognized as enum.list without indentation on 2nd line
+    let input8 = dedent """
+      A. string1
+      string2
+      """
+    # TODO: find out hot to catch warning here instead of throwing a defect
+    expect(AssertionDefect):
+      let output8 = input8.toHtml
+
   test "Markdown enumerated lists":
     let input1 = dedent """
       Below are 2 enumerated lists: Markdown-style (5 items) and RST (1 item)


### PR DESCRIPTION
According to [RST spec](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#enumerated-lists) this fragment
```RST
1. Nim is a statically typed compiled systems
programming language.
```
should be parsed as normal paragraph, not an enum.list, because there is no necessary indentation on the second line.

This PR makes rst.nim handle it in compliance with the spec and also adds a warning with suggestions how to fix it. Original python rst does not emit any warning but I think it's necessary since this behavior confuses people that are used to Markdown.

- also change docs in 2 other places appropriately
- fix that rst2html started numeration of lines from 0 - now it will be from 1 as in all text editors. It should have been done long ago. In this PR it's essential since human interpretation of the warning depends on proper line numbers

cc @narimiran 

EDIT(timotheecour) fix https://github.com/nim-lang/Nim/issues/17249 (needed to put in body otherwise this PR won't show up in the ref'd issue: the link in title isn't enough) /cc @a-mr 