### PR TITLE
add setutils.[]=

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -89,7 +89,7 @@
   if the iterable yields a built-in settable type.
 - Added `setutils.fullSet` which returns a full built-in `set` for a valid type.
 - Added `setutils.complement` which returns the complement of a built-in `set`.
-
+- Added `setutils.[]=`.
 
 - Added `math.isNaN`.
 

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -61,3 +61,17 @@ proc complement*[T](s: set[T]): set[T] {.inline.} =
     assert complement({range[0..10](0), 1, 2, 3}) == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     assert complement({'0'..'9'}) == {0.char..255.char} - {'0'..'9'}
   fullSet(T) - s
+
+proc `[]=`*[T](t: var set[T], key: T, val: bool) {.inline.} =
+  ## Syntax sugar for `if val: t.incl key else: t.excl key`
+  runnableExamples:
+    type A = enum
+      a0, a1, a2, a3
+    var s = {a0, a3}
+    s[a0] = false
+    s[a1] = false
+    assert s == {a3}
+    s[a2] = true
+    s[a3] = true
+    assert s == {a2, a3}
+  if val: t.incl key else: t.excl key

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -38,8 +38,8 @@ template toSet*(iter: untyped): untyped =
 
 macro enmRange(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
-# proc fullSet*(T: typedesc): set[T] {.inline.} = # xxx would give: Error: ordinal type expected
-proc fullSet*[T](U: typedesc[T]): set[T] {.inline.} =
+# func fullSet*(T: typedesc): set[T] {.inline.} = # xxx would give: Error: ordinal type expected
+func fullSet*[T](U: typedesc[T]): set[T] {.inline.} =
   ## Returns a set containing all elements in `U`.
   runnableExamples:
     assert bool.fullSet == {true, false}
@@ -51,7 +51,7 @@ proc fullSet*[T](U: typedesc[T]): set[T] {.inline.} =
   else: # Hole filled enum
     enmRange(T)
 
-proc complement*[T](s: set[T]): set[T] {.inline.} =
+func complement*[T](s: set[T]): set[T] {.inline.} =
   ## Returns the set complement of `a`.
   runnableExamples:
     type Colors = enum
@@ -62,7 +62,7 @@ proc complement*[T](s: set[T]): set[T] {.inline.} =
     assert complement({'0'..'9'}) == {0.char..255.char} - {'0'..'9'}
   fullSet(T) - s
 
-proc `[]=`*[T](t: var set[T], key: T, val: bool) {.inline.} =
+func `[]=`*[T](t: var set[T], key: T, val: bool) {.inline.} =
   ## Syntax sugar for `if val: t.incl key else: t.excl key`
   runnableExamples:
     type A = enum

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -41,6 +41,7 @@ template main =
     doAssert s == {a3}
     s[a2] = true
     s[a3] = true
+    doAssert s == {a2, a3}
 
 main()
 static: main()

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -38,7 +38,7 @@ template main =
     var s = {a0, a3}
     s[a0] = false
     s[a1] = false
-    assert s == {a3}
+    doAssert s == {a3}
     s[a2] = true
     s[a3] = true
 

--- a/tests/stdlib/tsetutils.nim
+++ b/tests/stdlib/tsetutils.nim
@@ -32,5 +32,15 @@ template main =
     doAssert {range[0..10](0), 1, 2, 3}.complement == {range[0..10](4), 5, 6, 7, 8, 9, 10}
     doAssert {'0'..'9'}.complement == {0.char..255.char} - {'0'..'9'}
 
+  block: # `[]=`
+    type A = enum
+      a0, a1, a2, a3
+    var s = {a0, a3}
+    s[a0] = false
+    s[a1] = false
+    assert s == {a3}
+    s[a2] = true
+    s[a3] = true
+
 main()
 static: main()


### PR DESCRIPTION
now that we have a dedicated `std/setutils`, it makes sense to add this syntax sugar, which is useful in particular when the value (true or false) isn't hard-coded, thus avoiding `if ... incl else ... excl`

## future work
- [x] see https://github.com/timotheecour/Nim/pull/643, add `func `[]=`*[T](s: var set[T], arg: set[T], val: bool) {.inline.} =` => https://github.com/nim-lang/Nim/pull/17302