### PR TITLE
fix #3023 make expandSymlink work on Windows

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1736,6 +1736,8 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   ## * `symlinkExists proc <#symlinkExists,string>`_
   when defined(windows):
     const bufsize = 32
+    const VOLUME_NAME_DOS = 0
+
     var handle = openHandle(symlinkPath, false)
     defer: discard closeHandle(handle)
 
@@ -1744,10 +1746,10 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
 
     var
       buffer = newWideCString("", bufsize)
-      length = getFinalPathNameByHandleW(handle, buffer, bufsize, 0)
+      length = getFinalPathNameByHandleW(handle, buffer, bufsize, VOLUME_NAME_DOS)
 
     buffer = newWideCString(length.int)
-    length = getFinalPathNameByHandleW(handle, buffer, length.DWORD, 0)
+    length = getFinalPathNameByHandleW(handle, buffer, length.DWORD, VOLUME_NAME_DOS)
 
     if length == 0:
       raiseOSError(osLastError())

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1717,11 +1717,8 @@ proc createSymlink*(src, dest: string) {.noWeirdTarget.} =
       raiseOSError(osLastError(), $(src, dest))
 
 when defined(windows) and not weirdTarget:
-  proc getFinalPathNameByHandleW(
-    hFile: Handle,
-    lpszFilePath: WideCStringObj,
-    cchFilePath: DWORD,
-    dwFlags: DWORD
+  proc getFinalPathNameByHandleW(hFile: Handle, lpszFilePath: WideCStringObj,
+    cchFilePath: DWORD, dwFlags: DWORD
   ): DWORD {.importc: "GetFinalPathNameByHandleW",
     stdcall, dynlib: "Kernel32.dll".}
 
@@ -1734,15 +1731,16 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   ## * `symlinkExists proc <#symlinkExists,string>`_
   when defined(windows):
     if not symlinkExists(symlinkPath):
-      raise newException(OSError, symlinkPath & " is not symlink or doesn't exist!")
+      raise newException(OSError, symlinkPath & " is not symlink or does not exist")
     const bufsize = 32
     const VOLUME_NAME_DOS = 0
 
-    var handle = openHandle(symlinkPath, false)
-    defer: discard closeHandle(handle)
+    let handle = openHandle(symlinkPath)
 
     if handle == INVALID_HANDLE_VALUE:
       raiseOSError(osLastError(), symlinkPath)
+
+    defer: discard closeHandle(handle)
 
     var
       buffer = newWideCString("", bufsize)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1759,7 +1759,7 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
     if length > 4:
       if result.startsWith(r"\\?\"):
         # In case of a local path, remove the prefix `\\?\`
-        result.setSlice(4 .. result.high)
+        result.setSlice(4 .. result.high) # https://nim-lang.github.io/Nim/strbasics.html
       elif result.startsWith(r"\\?\UNC\"):
         # In case of a network path, replace `\\?\UNC\` with `\\`
         result[6] = '\\'

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1736,7 +1736,7 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   ## * `symlinkExists proc <#symlinkExists,string>`_
   when defined(windows):
     if not symlinkExists(symlinkPath):
-      raise newException(OsError, symlinkPath & " is not symlink or doesn't exist!")
+      raise newException(OSError, symlinkPath & " is not symlink or doesn't exist!")
     const bufsize = 32
     const VOLUME_NAME_DOS = 0
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1725,7 +1725,6 @@ when defined(windows) and not weirdTarget:
 proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   ## Returns a string representing the path to which the symbolic link points.
   ##
-  ##
   ## See also:
   ## * `createSymlink proc <#createSymlink,string,string>`_
   ## * `symlinkExists proc <#symlinkExists,string>`_

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -1728,8 +1728,6 @@ when defined(windows) and not weirdTarget:
 proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   ## Returns a string representing the path to which the symbolic link points.
   ##
-  ## .. Note:: The function fails if `symlinkPath` is not a symlink, except on Windows, 
-  ##    where the full path will be returned.
   ##
   ## See also:
   ## * `createSymlink proc <#createSymlink,string,string>`_

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -164,13 +164,15 @@ block fileOperations:
     const subDir2 = dname/"sub2"
     const brokenSymlinkName = "D20210101T191320_BROKEN_SYMLINK"
     const brokenSymlink = dname/brokenSymlinkName
-    const brokenSymlinkSrc = "D20210101T191320_nonexistant"
+    const brokenSymlinkSrc = buildDir.parentDir/"D20210101T191320_nonexistant"
     const brokenSymlinkCopy = brokenSymlink & "_COPY"
     const brokenSymlinkInSubDir = subDir/brokenSymlinkName
     const brokenSymlinkInSubDir2 = subDir2/brokenSymlinkName
 
     createDir(subDir)
     createSymlink(brokenSymlinkSrc, brokenSymlink)
+
+    doAssert expandSymlink(brokenSymlink).extractFilename == brokenSymlinkSrc.extractFilename
 
     # Test copyFile
     when symlinksAreHandled:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -164,7 +164,7 @@ block fileOperations:
     const subDir2 = dname/"sub2"
     const brokenSymlinkName = "D20210101T191320_BROKEN_SYMLINK"
     const brokenSymlink = dname/brokenSymlinkName
-    const brokenSymlinkSrc = buildDir.parentDir/"D20210101T191320_nonexistant"
+    const brokenSymlinkSrc = "D20210101T191320_nonexistant"
     const brokenSymlinkCopy = brokenSymlink & "_COPY"
     const brokenSymlinkInSubDir = subDir/brokenSymlinkName
     const brokenSymlinkInSubDir2 = subDir2/brokenSymlinkName
@@ -172,7 +172,7 @@ block fileOperations:
     createDir(subDir)
     createSymlink(brokenSymlinkSrc, brokenSymlink)
 
-    doAssert expandSymlink(brokenSymlink).extractFilename == brokenSymlinkSrc.extractFilename
+    doAssert expandSymlink(brokenSymlink).extractFilename == brokenSymlinkSrc.extractFilename, $expandSymlink(brokenSymlink)
 
     # Test copyFile
     when symlinksAreHandled:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -172,8 +172,6 @@ block fileOperations:
     createDir(subDir)
     createSymlink(brokenSymlinkSrc, brokenSymlink)
 
-    doAssert expandSymlink(brokenSymlink).extractFilename == brokenSymlinkSrc.extractFilename, $expandSymlink(brokenSymlink)
-
     # Test copyFile
     when symlinksAreHandled:
       doAssertRaises(OSError):
@@ -262,6 +260,21 @@ block fileOperations:
       doAssert symlinkExists(brokenSymlinkInSubDir2)
 
     removeDir(dname)
+
+
+    block:
+      const dname = buildDir/"D20210116T1406234"
+      const symlinkName = dname/"D20210101T191320_BROKEN_SYMLINK"
+      const symlinkSrc = buildDir.parentDir/"D20210101T1920_nonexistant"
+
+      createDir(dname)
+
+      let f = open(symlinkSrc, fmWrite)
+      f.close()
+
+      createSymlink(symlinkSrc, symlinkName)
+
+      doAssert expandSymlink(symlinkName).extractFilename == symlinkSrc.extractFilename, $expandSymlink(symlinkName)
 
 import times
 block modificationTime:


### PR DESCRIPTION
fix #3023

followup
- [ ] `expandFileName` should use `GetFinalPathNameByHandleW` too.