### PR TITLE
fix #17260 render `\` properly in nim doc, rst2html

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1086,6 +1086,8 @@ proc parseUntil(p: var RstParser, father: PRstNode, postfix: string,
     line = currentTok(p).line
     col = currentTok(p).col
   inc p.idx
+
+  var pTmp: PRstNode
   while true:
     dbg currentTok(p).kind, currentTok(p).symbol
     case currentTok(p).kind
@@ -1096,13 +1098,21 @@ proc parseUntil(p: var RstParser, father: PRstNode, postfix: string,
         break
       else:
         dbg postfix, interpretBackslash, prevTok(p).symbol, currentTok(p).symbol
-        if postfix == "`" and currentTok(p).symbol == "\\":
+        if postfix == "`":
+          if prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
+            # father[^1] = newLeaf(p)
+            father.sons[^1] = newLeaf(p)
+          else:
+            father.add(newLeaf(p))
           inc p.idx
-        elif postfix == "`" and prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
-          dbg "gook1"
-          # parseBackslash(p, father)
-          father.add(newLeaf(p))
-          inc p.idx
+          # if currentTok(p).symbol == "\\":
+          #   pTmp = newLeaf(p)
+          # elif prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
+          #   father.add(newLeaf(p))
+          # else:
+          #   father.add(pTmp)
+          #   father.add(newLeaf(p))
+          # inc p.idx
         else:
           # dbg p
           if interpretBackslash:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -852,7 +852,8 @@ proc isInlineMarkupEnd(p: RstParser, markup: string): bool =
   if not result: return
   # Rule 4:
   if p.idx > 0:
-    if markup != "``" and prevTok(p).symbol == "\\":
+    # refs bug #17260
+    if markup notin ["``", "`"] and prevTok(p).symbol == "\\":
       result = false
 
 proc isInlineMarkupStart(p: RstParser, markup: string): bool =
@@ -1243,7 +1244,7 @@ proc parseInline(p: var RstParser, father: PRstNode) =
       father.add(n)
     elif isInlineMarkupStart(p, "`"):
       var n = newRstNode(rnInterpretedText)
-      parseUntil(p, n, "`", true)
+      parseUntil(p, n, "`", false) # bug #17260
       n = parsePostfix(p, n)
       father.add(n)
     elif isInlineMarkupStart(p, "|"):

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1086,8 +1086,6 @@ proc parseUntil(p: var RstParser, father: PRstNode, postfix: string,
     line = currentTok(p).line
     col = currentTok(p).col
   inc p.idx
-
-  var pTmp: PRstNode
   while true:
     case currentTok(p).kind
     of tkPunct:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1089,32 +1089,19 @@ proc parseUntil(p: var RstParser, father: PRstNode, postfix: string,
 
   var pTmp: PRstNode
   while true:
-    dbg currentTok(p).kind, currentTok(p).symbol
     case currentTok(p).kind
     of tkPunct:
       if isInlineMarkupEnd(p, postfix):
-        dbg "end..."
         inc p.idx
         break
       else:
-        dbg postfix, interpretBackslash, prevTok(p).symbol, currentTok(p).symbol
         if postfix == "`":
           if prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
-            # father[^1] = newLeaf(p)
-            father.sons[^1] = newLeaf(p)
+            father.sons[^1] = newLeaf(p) # instead, we should use lookahead
           else:
             father.add(newLeaf(p))
           inc p.idx
-          # if currentTok(p).symbol == "\\":
-          #   pTmp = newLeaf(p)
-          # elif prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
-          #   father.add(newLeaf(p))
-          # else:
-          #   father.add(pTmp)
-          #   father.add(newLeaf(p))
-          # inc p.idx
         else:
-          # dbg p
           if interpretBackslash:
             parseBackslash(p, father)
           else:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1087,16 +1087,29 @@ proc parseUntil(p: var RstParser, father: PRstNode, postfix: string,
     col = currentTok(p).col
   inc p.idx
   while true:
+    dbg currentTok(p).kind, currentTok(p).symbol
     case currentTok(p).kind
     of tkPunct:
       if isInlineMarkupEnd(p, postfix):
+        dbg "end..."
         inc p.idx
         break
-      elif interpretBackslash:
-        parseBackslash(p, father)
       else:
-        father.add(newLeaf(p))
-        inc p.idx
+        dbg postfix, interpretBackslash, prevTok(p).symbol, currentTok(p).symbol
+        if postfix == "`" and currentTok(p).symbol == "\\":
+          inc p.idx
+        elif postfix == "`" and prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
+          dbg "gook1"
+          # parseBackslash(p, father)
+          father.add(newLeaf(p))
+          inc p.idx
+        else:
+          # dbg p
+          if interpretBackslash:
+            parseBackslash(p, father)
+          else:
+            father.add(newLeaf(p))
+            inc p.idx
     of tkAdornment, tkWord, tkOther:
       father.add(newLeaf(p))
       inc p.idx

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -852,8 +852,10 @@ proc isInlineMarkupEnd(p: RstParser, markup: string): bool =
   if not result: return
   # Rule 4:
   if p.idx > 0:
-    # refs bug #17260
-    if markup notin ["``", "`"] and prevTok(p).symbol == "\\":
+    # see bug #17260; for now `\` must be written ``\``, likewise with sequences
+    # ending in an un-escaped `\`; `\\` is legal but not `\\\` for example;
+    # for this reason we can't use `["``", "`"]` here.
+    if markup != "``" and prevTok(p).symbol == "\\":
       result = false
 
 proc isInlineMarkupStart(p: RstParser, markup: string): bool =

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2837,7 +2837,7 @@ proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   ## * replaces any `\f` by `\\f`
   ## * replaces any `\r` by `\\r`
   ## * replaces any `\e` by `\\e`
-  ## * replaces any other character not in the set `{'\21..'\126'}
+  ## * replaces any other character not in the set `{\21..\126}`
   ##   by `\xHH` where `HH` is its hexadecimal value.
   ##
   ## The procedure has been designed so that its output is usable for many

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2826,7 +2826,7 @@ when declared(initDebugger):
 proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   ## Adds a char to string `s` and applies the following escaping:
   ##
-  ## * replaces any `\` by `\\`
+  ## * replaces any ``\`` by `\\`
   ## * replaces any `'` by `\'`
   ## * replaces any `"` by `\"`
   ## * replaces any `\a` by `\\a`

--- a/nimdoc/rst2html/expected/rst_examples.html
+++ b/nimdoc/rst2html/expected/rst_examples.html
@@ -300,7 +300,7 @@ stmt = IND{&gt;} stmt ^+ IND{=} DED  # list of statements
 <p>However, this does not work. The problem is that the procedure should not only <tt class="docutils literal"><span class="pre">return</span></tt>, but return and <strong>continue</strong> after an iteration has finished. This <em>return and continue</em> is called a <tt class="docutils literal"><span class="pre">yield</span></tt> statement. Now the only thing left to do is to replace the <tt class="docutils literal"><span class="pre">proc</span></tt> keyword by <tt class="docutils literal"><span class="pre">iterator</span></tt> and here it is - our first iterator:</p>
 <table border="1" class="docutils"><tr><th>A1 header</th><th>A2 | not fooled</th></tr>
 <tr><td>C1</td><td>C2 <strong>bold</strong></td></tr>
-<tr><td>D1 <tt class="docutils literal"><span class="pre">code |</span></tt></td><td>D2</td></tr>
+<tr><td>D1 <tt class="docutils literal"><span class="pre">code \|</span></tt></td><td>D2</td></tr>
 <tr><td>E1 | text</td><td></td></tr>
 <tr><td></td><td>F2 without pipe</td></tr>
 </table><p>not in table </p>

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -196,7 +196,11 @@ suite "RST/Markdown general":
 |              | F2 without pipe
 not in table"""
     let output1 = input1.toHtml
-    # xxx we should support: `code \|`:litteral so that we can escape `|` inside a table.
+    #[
+    xxx `\|` inside a table cell should render as `|`
+        `|` outside a table cell should render as `\|`
+    consistently with markdown, see https://stackoverflow.com/a/66557930/1426932
+    ]#
     doAssert output1 == """
 <table border="1" class="docutils"><tr><th>A1 header</th><th>A2 | not fooled</th></tr>
 <tr><td>C1</td><td>C2 <strong>bold</strong></td></tr>

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -197,7 +197,7 @@ suite "RST/Markdown general":
 not in table"""
     let output1 = input1.toHtml
     #[
-    xxx `\|` inside a table cell should render as `|`
+    TODO: `\|` inside a table cell should render as `|`
         `|` outside a table cell should render as `\|`
     consistently with markdown, see https://stackoverflow.com/a/66557930/1426932
     ]#

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -555,6 +555,18 @@ let x = 1
     let output2 = input2.toHtml
     doAssert "<pre" in output2 and "class=\"Keyword\"" in output2
 
+  test "interpreted text":
+    check """`foo.bar`""".toHtml == """<tt class="docutils literal"><span class="pre">foo.bar</span></tt>"""
+    check """`foo\`\`bar`""".toHtml == """<tt class="docutils literal"><span class="pre">foo``bar</span></tt>"""
+    check """`foo\`bar`""".toHtml == """<tt class="docutils literal"><span class="pre">foo`bar</span></tt>"""
+    check """`\`bar`""".toHtml == """<tt class="docutils literal"><span class="pre">`bar</span></tt>"""
+    check """`a\b\x\\ar`""".toHtml == """<tt class="docutils literal"><span class="pre">a\b\x\\ar</span></tt>"""
+
+  test "inline literal":
+    check """``foo.bar``""".toHtml == """<tt class="docutils literal"><span class="pre">foo.bar</span></tt>"""
+    check """``foo\bar``""".toHtml == """<tt class="docutils literal"><span class="pre">foo\bar</span></tt>"""
+    check """``f\`o\\o\b`ar``""".toHtml == """<tt class="docutils literal"><span class="pre">f\`o\\o\b`ar</span></tt>"""
+
   test "RST comments":
     let input1 = """
 Check that comment disappears:

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -196,9 +196,11 @@ suite "RST/Markdown general":
 |              | F2 without pipe
 not in table"""
     let output1 = input1.toHtml
-    doAssert output1 == """<table border="1" class="docutils"><tr><th>A1 header</th><th>A2 | not fooled</th></tr>
+    # xxx we should support: `code \|`:litteral so that we can escape `|` inside a table.
+    doAssert output1 == """
+<table border="1" class="docutils"><tr><th>A1 header</th><th>A2 | not fooled</th></tr>
 <tr><td>C1</td><td>C2 <strong>bold</strong></td></tr>
-<tr><td>D1 <tt class="docutils literal"><span class="pre">code |</span></tt></td><td>D2</td></tr>
+<tr><td>D1 <tt class="docutils literal"><span class="pre">code \|</span></tt></td><td>D2</td></tr>
 <tr><td>E1 | text</td><td></td></tr>
 <tr><td></td><td>F2 without pipe</td></tr>
 </table><p>not in table</p>


### PR DESCRIPTION
/cc @a-mr 

* fix #17260
* unblocks #17259 and #17258 (/cc @quantimnot)

## before PR:
https://nim-lang.github.io/Nim/system.html#addEscapedChar%2Cstring%2Cchar
![image](https://user-images.githubusercontent.com/2194784/110565573-8cad8880-8103-11eb-900b-05934920959f.png)

## after PR:
![image](https://user-images.githubusercontent.com/2194784/110565447-61c33480-8103-11eb-83ed-d3a0f69d978a.png)

## note 1
the fix for this should not be controversial:
```
`/x` (`/` not followed by a backtick)
`//` (ditto, the `/` is paired)
```

## note 2
the fix for this is more controversial but IMO is the correct approach:
I'm treating this as legal:
```
`/` (`/` followed by a backtick)
```
because:
* it's legal in markdown and is what users will expect (and in fact nim docs already uses it even though, prior to this PR, it didn't render properly, eg see `addEscapedChar` docs)
* nim rst spec technically allows it, although it's vague about it see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#interpreted-text
> Interpreted text is text that is meant to be related, indexed, linked, summarized, or otherwise processed, but the text itself is typically left alone. Interpreted text is enclosed by single backquote characters:

*  as mentioned in https://github.com/nim-lang/Nim/issues/17260#issuecomment-794468681:
> The RST spec does not cover escaping in interpreted text explicitly but the idea is mostly clear.
> The code role is not really documented about that behavior

* the rst behavior has design flaws / limitations, eg https://github.com/sphinx-doc/sphinx/issues/8396

* this does behave differently from rst2html as noted there

* backticks are rarely needed, eg we can use:
```nim
## see `system.[]=` # no need to render a backtick inside the backtick pair
```
for simpler doc links (https://github.com/nim-lang/RFCs/issues/125) this also shouldn't be a problem:
```nim
## see `system.[]=`_
```

## note 3
for the rare cases where we'll want to show a backtick character in docs (outside of code blocks/runnableExamples where this works fine), eg to distinguish ```case``` from ``` `case` ``` , we should use markdown syntax:
```
foo1 ``` ` ``` # strips leading and trailing space and we end up with a single backtick rendered
foo2 ``` `` ``` # ditto, we end up with 2 backticks
foo2 ```` ``` ```` # ditto, we end up with 3 backticks
```
it's flexible and has saner escaping semantics (just increase the number of surrounding backticks)


## future work
- [ ] (refs https://github.com/nim-lang/Nim/issues/17340#issuecomment-806059316) as mentioned in https://stackoverflow.com/a/66557930/1426932 `\|` inside a table cell should render as `|`, not `\|` (but outside a table cell, it should render as in this PR); I've edited the test to make it pass but in future work we should address this edge case
```
| A1 header    | A2 \| not fooled
| :---         | ----:       |
| C1           | C2 **bold** | ignored |
| D1 `code \|` | D2          | also ignored
| E1 \| text   |
|              | F2 without pipe
not in table
```

there are workarounds until this is addressed, eg:
split the rendered pipe in 2:
```
`x` \| `y`
```
or using a different unicode char for the pipe https://stackoverflow.com/a/43070960/1426932

