### PR TITLE
Change parameter names in lists module from `L`

### DIFF
--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -189,21 +189,21 @@ func toDoublyLinkedList*[T](elems: openArray[T]): DoublyLinkedList[T] {.since: (
     result.add(elem)
 
 template itemsListImpl() {.dirty.} =
-  var it = L.head
+  var it = list.head
   while it != nil:
     yield it.value
     it = it.next
 
 template itemsRingImpl() {.dirty.} =
-  var it = L.head
+  var it = ring.head
   if it != nil:
     while true:
       yield it.value
       it = it.next
-      if it == L.head: break
+      if it == ring.head: break
 
-iterator items*[T](L: SomeLinkedList[T]): T =
-  ## Yields every value of `L`.
+iterator items*[T](list: SomeLinkedList[T]): T =
+  ## Yields every value of `list`.
   ##
   ## **See also:**
   ## * `mitems iterator <#mitems.i,SomeLinkedList[T]>`_
@@ -218,8 +218,8 @@ iterator items*[T](L: SomeLinkedList[T]): T =
 
   itemsListImpl()
 
-iterator items*[T](L: SomeLinkedRing[T]): T =
-  ## Yields every value of `L`.
+iterator items*[T](ring: SomeLinkedRing[T]): T =
+  ## Yields every value of `ring`.
   ##
   ## **See also:**
   ## * `mitems iterator <#mitems.i,SomeLinkedRing[T]>`_
@@ -234,8 +234,8 @@ iterator items*[T](L: SomeLinkedRing[T]): T =
 
   itemsRingImpl()
 
-iterator mitems*[T](L: var SomeLinkedList[T]): var T =
-  ## Yields every value of `L` so that you can modify it.
+iterator mitems*[T](list: var SomeLinkedList[T]): var T =
+  ## Yields every value of `list` so that you can modify it.
   ##
   ## **See also:**
   ## * `items iterator <#items.i,SomeLinkedList[T]>`_
@@ -251,8 +251,8 @@ iterator mitems*[T](L: var SomeLinkedList[T]): var T =
 
   itemsListImpl()
 
-iterator mitems*[T](L: var SomeLinkedRing[T]): var T =
-  ## Yields every value of `L` so that you can modify it.
+iterator mitems*[T](ring: var SomeLinkedRing[T]): var T =
+  ## Yields every value of `ring` so that you can modify it.
   ##
   ## **See also:**
   ## * `items iterator <#items.i,SomeLinkedRing[T]>`_
@@ -268,7 +268,7 @@ iterator mitems*[T](L: var SomeLinkedRing[T]): var T =
 
   itemsRingImpl()
 
-iterator nodes*[T](L: SomeLinkedList[T]): SomeLinkedNode[T] =
+iterator nodes*[T](list: SomeLinkedList[T]): SomeLinkedNode[T] =
   ## Iterates over every node of `x`. Removing the current node from the
   ## list during traversal is supported.
   ##
@@ -287,13 +287,13 @@ iterator nodes*[T](L: SomeLinkedList[T]): SomeLinkedNode[T] =
         x.value = 5 * x.value - 1
     assert $a == "[49, 99, 199, 249]"
 
-  var it = L.head
+  var it = list.head
   while it != nil:
     let nxt = it.next
     yield it
     it = nxt
 
-iterator nodes*[T](L: SomeLinkedRing[T]): SomeLinkedNode[T] =
+iterator nodes*[T](ring: SomeLinkedRing[T]): SomeLinkedNode[T] =
   ## Iterates over every node of `x`. Removing the current node from the
   ## list during traversal is supported.
   ##
@@ -312,27 +312,27 @@ iterator nodes*[T](L: SomeLinkedRing[T]): SomeLinkedNode[T] =
         x.value = 5 * x.value - 1
     assert $a == "[49, 99, 199, 249]"
 
-  var it = L.head
+  var it = ring.head
   if it != nil:
     while true:
       let nxt = it.next
       yield it
       it = nxt
-      if it == L.head: break
+      if it == ring.head: break
 
-proc `$`*[T](L: SomeLinkedCollection[T]): string =
+proc `$`*[T](l: SomeLinkedCollection[T]): string =
   ## Turns a list into its string representation for logging and printing.
   runnableExamples:
     let a = [1, 2, 3, 4].toSinglyLinkedList
     assert $a == "[1, 2, 3, 4]"
 
   result = "["
-  for x in nodes(L):
+  for x in nodes(l):
     if result.len > 1: result.add(", ")
     result.addQuoted(x.value)
   result.add("]")
 
-proc find*[T](L: SomeLinkedCollection[T], value: T): SomeLinkedNode[T] =
+proc find*[T](l: SomeLinkedCollection[T], value: T): SomeLinkedNode[T] =
   ## Searches in the list for a value. Returns `nil` if the value does not
   ## exist.
   ##
@@ -343,10 +343,10 @@ proc find*[T](L: SomeLinkedCollection[T], value: T): SomeLinkedNode[T] =
     assert a.find(9).value == 9
     assert a.find(1) == nil
 
-  for x in nodes(L):
+  for x in nodes(l):
     if x.value == value: return x
 
-proc contains*[T](L: SomeLinkedCollection[T], value: T): bool {.inline.} =
+proc contains*[T](l: SomeLinkedCollection[T], value: T): bool {.inline.} =
   ## Searches in the list for a value. Returns `false` if the value does not
   ## exist, `true` otherwise. This allows the usage of the `in` and `notin`
   ## operators.
@@ -360,7 +360,7 @@ proc contains*[T](L: SomeLinkedCollection[T], value: T): bool {.inline.} =
     assert(not a.contains(1))
     assert 2 notin a
 
-  result = find(L, value) != nil
+  result = find(l, value) != nil
 
 proc prepend*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5, 1).} =
   ## Prepends a shallow copy of `b` to the beginning of `a`.
@@ -411,8 +411,8 @@ proc prependMoved*[T: SomeLinkedList](a, b: var T) {.since: (1, 5, 1).} =
     (b, a) = (a, b)
   else: swap a, b
 
-proc add*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) {.inline.} =
-  ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
+proc add*[T](list: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) {.inline.} =
+  ## Appends (adds to the end) a node `n` to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedList[T],T>`_ for appending a value
@@ -426,14 +426,14 @@ proc add*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]) {.inline.} =
     assert a.contains(9)
 
   n.next = nil
-  if L.tail != nil:
-    assert(L.tail.next == nil)
-    L.tail.next = n
-  L.tail = n
-  if L.head == nil: L.head = n
+  if list.tail != nil:
+    assert(list.tail.next == nil)
+    list.tail.next = n
+  list.tail = n
+  if list.head == nil: list.head = n
 
-proc add*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
-  ## Appends (adds to the end) a value to `L`. Efficiency: O(1).
+proc add*[T](list: var SinglyLinkedList[T], value: T) {.inline.} =
+  ## Appends (adds to the end) a value to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedList[T],T>`_ for appending a value
@@ -446,11 +446,11 @@ proc add*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     a.add(8)
     assert a.contains(9)
 
-  add(L, newSinglyLinkedNode(value))
+  add(list, newSinglyLinkedNode(value))
 
-proc prepend*[T](L: var SinglyLinkedList[T],
+proc prepend*[T](list: var SinglyLinkedList[T],
                  n: SinglyLinkedNode[T]) {.inline.} =
-  ## Prepends (adds to the beginning) a node to `L`. Efficiency: O(1).
+  ## Prepends (adds to the beginning) a node to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedList[T],SinglyLinkedNode[T]>`_
@@ -463,12 +463,12 @@ proc prepend*[T](L: var SinglyLinkedList[T],
     a.prepend(n)
     assert a.contains(9)
 
-  n.next = L.head
-  L.head = n
-  if L.tail == nil: L.tail = n
+  n.next = list.head
+  list.head = n
+  if list.tail == nil: list.tail = n
 
-proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
-  ## Prepends (adds to the beginning) a node to `L`. Efficiency: O(1).
+proc prepend*[T](list: var SinglyLinkedList[T], value: T) {.inline.} =
+  ## Prepends (adds to the beginning) a node to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedList[T],SinglyLinkedNode[T]>`_
@@ -482,7 +482,7 @@ proc prepend*[T](L: var SinglyLinkedList[T], value: T) {.inline.} =
     a.prepend(8)
     assert a.contains(9)
 
-  prepend(L, newSinglyLinkedNode(value))
+  prepend(list, newSinglyLinkedNode(value))
 
 func copy*[T](a: SinglyLinkedList[T]): SinglyLinkedList[T] {.since: (1, 5, 1).} =
   ## Creates a shallow copy of `a`.
@@ -540,8 +540,8 @@ proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
     b.head = nil
     b.tail = nil
 
-proc add*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
-  ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
+proc add*[T](list: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
+  ## Appends (adds to the end) a node `n` to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedList[T],T>`_ for appending a value
@@ -557,15 +557,15 @@ proc add*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
     assert a.contains(9)
 
   n.next = nil
-  n.prev = L.tail
-  if L.tail != nil:
-    assert(L.tail.next == nil)
-    L.tail.next = n
-  L.tail = n
-  if L.head == nil: L.head = n
+  n.prev = list.tail
+  if list.tail != nil:
+    assert(list.tail.next == nil)
+    list.tail.next = n
+  list.tail = n
+  if list.head == nil: list.head = n
 
-proc add*[T](L: var DoublyLinkedList[T], value: T) =
-  ## Appends (adds to the end) a value to `L`. Efficiency: O(1).
+proc add*[T](list: var DoublyLinkedList[T], value: T) =
+  ## Appends (adds to the end) a value to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedList[T],DoublyLinkedNode[T]>`_
@@ -581,10 +581,10 @@ proc add*[T](L: var DoublyLinkedList[T], value: T) =
     a.add(8)
     assert a.contains(9)
 
-  add(L, newDoublyLinkedNode(value))
+  add(list, newDoublyLinkedNode(value))
 
-proc prepend*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
-  ## Prepends (adds to the beginning) a node `n` to `L`. Efficiency: O(1).
+proc prepend*[T](list: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
+  ## Prepends (adds to the beginning) a node `n` to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedList[T],DoublyLinkedNode[T]>`_
@@ -600,15 +600,15 @@ proc prepend*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
     assert a.contains(9)
 
   n.prev = nil
-  n.next = L.head
-  if L.head != nil:
-    assert(L.head.prev == nil)
-    L.head.prev = n
-  L.head = n
-  if L.tail == nil: L.tail = n
+  n.next = list.head
+  if list.head != nil:
+    assert(list.head.prev == nil)
+    list.head.prev = n
+  list.head = n
+  if list.tail == nil: list.tail = n
 
-proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
-  ## Prepends (adds to the beginning) a value to `L`. Efficiency: O(1).
+proc prepend*[T](list: var DoublyLinkedList[T], value: T) =
+  ## Prepends (adds to the beginning) a value to `list`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedList[T],DoublyLinkedNode[T]>`_
@@ -624,7 +624,7 @@ proc prepend*[T](L: var DoublyLinkedList[T], value: T) =
     a.prepend(8)
     assert a.contains(9)
 
-  prepend(L, newDoublyLinkedNode(value))
+  prepend(list, newDoublyLinkedNode(value))
 
 func copy*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] {.since: (1, 5, 1).} =
   ## Creates a shallow copy of `a`.
@@ -705,9 +705,9 @@ proc add*[T: SomeLinkedList](a: var T, b: T) {.since: (1, 5, 1).} =
   var tmp = b.copy
   a.addMoved(tmp)
 
-proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.discardable.} =
-  ## Removes a node `n` from `L`.
-  ## Returns `true` if `n` was found in `L`.
+proc remove*[T](list: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.discardable.} =
+  ## Removes a node `n` from `list`.
+  ## Returns `true` if `n` was found in `list`.
   ## Efficiency: O(n); the list is traversed until `n` is found.
   ## Attempting to remove an element not contained in the list is a no-op.
   ## When the list is cyclic, the cycle is preserved after removal.
@@ -728,12 +728,12 @@ proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.disc
         ai
     assert s == [2, 2, 2, 2]
 
-  if n == L.head:
-    L.head = n.next
-    if L.tail.next == n:
-      L.tail.next = L.head # restore cycle
+  if n == list.head:
+    list.head = n.next
+    if list.tail.next == n:
+      list.tail.next = list.head # restore cycle
   else:
-    var prev = L.head
+    var prev = list.head
     while prev.next != n and prev.next != nil:
       prev = prev.next
     if prev.next == nil:
@@ -741,9 +741,9 @@ proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.disc
     prev.next = n.next
   true
 
-proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
-  ## Removes a node `n` from `L`. Efficiency: O(1).
-  ## This function assumes, for the sake of efficiency, that `n` is contained in `L`,
+proc remove*[T](list: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
+  ## Removes a node `n` from `list`. Efficiency: O(1).
+  ## This function assumes, for the sake of efficiency, that `n` is contained in `list`,
   ## otherwise the effects are undefined.
   ## When the list is cyclic, the cycle is preserved after removal.
   runnableExamples:
@@ -763,15 +763,15 @@ proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =
         ai
     assert s == [2, 2, 2, 2]
 
-  if n == L.tail: L.tail = n.prev
-  if n == L.head: L.head = n.next
+  if n == list.tail: list.tail = n.prev
+  if n == list.head: list.head = n.next
   if n.next != nil: n.next.prev = n.prev
   if n.prev != nil: n.prev.next = n.next
 
 
 
-proc add*[T](L: var SinglyLinkedRing[T], n: SinglyLinkedNode[T]) =
-  ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
+proc add*[T](ring: var SinglyLinkedRing[T], n: SinglyLinkedNode[T]) =
+  ## Appends (adds to the end) a node `n` to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedRing[T],T>`_ for appending a value
@@ -784,17 +784,17 @@ proc add*[T](L: var SinglyLinkedRing[T], n: SinglyLinkedNode[T]) =
     a.add(n)
     assert a.contains(9)
 
-  if L.head != nil:
-    n.next = L.head
-    assert(L.tail != nil)
-    L.tail.next = n
+  if ring.head != nil:
+    n.next = ring.head
+    assert(ring.tail != nil)
+    ring.tail.next = n
   else:
     n.next = n
-    L.head = n
-  L.tail = n
+    ring.head = n
+  ring.tail = n
 
-proc add*[T](L: var SinglyLinkedRing[T], value: T) =
-  ## Appends (adds to the end) a value to `L`. Efficiency: O(1).
+proc add*[T](ring: var SinglyLinkedRing[T], value: T) =
+  ## Appends (adds to the end) a value to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedRing[T],SinglyLinkedNode[T]>`_
@@ -808,10 +808,10 @@ proc add*[T](L: var SinglyLinkedRing[T], value: T) =
     a.add(8)
     assert a.contains(9)
 
-  add(L, newSinglyLinkedNode(value))
+  add(ring, newSinglyLinkedNode(value))
 
-proc prepend*[T](L: var SinglyLinkedRing[T], n: SinglyLinkedNode[T]) =
-  ## Prepends (adds to the beginning) a node `n` to `L`. Efficiency: O(1).
+proc prepend*[T](ring: var SinglyLinkedRing[T], n: SinglyLinkedNode[T]) =
+  ## Prepends (adds to the beginning) a node `n` to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedRing[T],SinglyLinkedNode[T]>`_
@@ -824,17 +824,17 @@ proc prepend*[T](L: var SinglyLinkedRing[T], n: SinglyLinkedNode[T]) =
     a.prepend(n)
     assert a.contains(9)
 
-  if L.head != nil:
-    n.next = L.head
-    assert(L.tail != nil)
-    L.tail.next = n
+  if ring.head != nil:
+    n.next = ring.head
+    assert(ring.tail != nil)
+    ring.tail.next = n
   else:
     n.next = n
-    L.tail = n
-  L.head = n
+    ring.tail = n
+  ring.head = n
 
-proc prepend*[T](L: var SinglyLinkedRing[T], value: T) =
-  ## Prepends (adds to the beginning) a value to `L`. Efficiency: O(1).
+proc prepend*[T](ring: var SinglyLinkedRing[T], value: T) =
+  ## Prepends (adds to the beginning) a value to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,SinglyLinkedRing[T],SinglyLinkedNode[T]>`_
@@ -848,12 +848,12 @@ proc prepend*[T](L: var SinglyLinkedRing[T], value: T) =
     a.prepend(8)
     assert a.contains(9)
 
-  prepend(L, newSinglyLinkedNode(value))
+  prepend(ring, newSinglyLinkedNode(value))
 
 
 
-proc add*[T](L: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
-  ## Appends (adds to the end) a node `n` to `L`. Efficiency: O(1).
+proc add*[T](ring: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
+  ## Appends (adds to the end) a node `n` to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedRing[T],T>`_ for appending a value
@@ -868,18 +868,18 @@ proc add*[T](L: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
     a.add(n)
     assert a.contains(9)
 
-  if L.head != nil:
-    n.next = L.head
-    n.prev = L.head.prev
-    L.head.prev.next = n
-    L.head.prev = n
+  if ring.head != nil:
+    n.next = ring.head
+    n.prev = ring.head.prev
+    ring.head.prev.next = n
+    ring.head.prev = n
   else:
     n.prev = n
     n.next = n
-    L.head = n
+    ring.head = n
 
-proc add*[T](L: var DoublyLinkedRing[T], value: T) =
-  ## Appends (adds to the end) a value to `L`. Efficiency: O(1).
+proc add*[T](ring: var DoublyLinkedRing[T], value: T) =
+  ## Appends (adds to the end) a value to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedRing[T],DoublyLinkedNode[T]>`_
@@ -895,10 +895,10 @@ proc add*[T](L: var DoublyLinkedRing[T], value: T) =
     a.add(8)
     assert a.contains(9)
 
-  add(L, newDoublyLinkedNode(value))
+  add(ring, newDoublyLinkedNode(value))
 
-proc prepend*[T](L: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
-  ## Prepends (adds to the beginning) a node `n` to `L`. Efficiency: O(1).
+proc prepend*[T](ring: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
+  ## Prepends (adds to the beginning) a node `n` to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedRing[T],DoublyLinkedNode[T]>`_
@@ -913,18 +913,18 @@ proc prepend*[T](L: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
     a.prepend(n)
     assert a.contains(9)
 
-  if L.head != nil:
-    n.next = L.head
-    n.prev = L.head.prev
-    L.head.prev.next = n
-    L.head.prev = n
+  if ring.head != nil:
+    n.next = ring.head
+    n.prev = ring.head.prev
+    ring.head.prev.next = n
+    ring.head.prev = n
   else:
     n.prev = n
     n.next = n
-  L.head = n
+  ring.head = n
 
-proc prepend*[T](L: var DoublyLinkedRing[T], value: T) =
-  ## Prepends (adds to the beginning) a value to `L`. Efficiency: O(1).
+proc prepend*[T](ring: var DoublyLinkedRing[T], value: T) =
+  ## Prepends (adds to the beginning) a value to `ring`. Efficiency: O(1).
   ##
   ## **See also:**
   ## * `add proc <#add,DoublyLinkedRing[T],DoublyLinkedNode[T]>`_
@@ -940,11 +940,11 @@ proc prepend*[T](L: var DoublyLinkedRing[T], value: T) =
     a.prepend(8)
     assert a.contains(9)
 
-  prepend(L, newDoublyLinkedNode(value))
+  prepend(ring, newDoublyLinkedNode(value))
 
-proc remove*[T](L: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
-  ## Removes `n` from `L`. Efficiency: O(1).
-  ## This function assumes, for the sake of efficiency, that `n` is contained in `L`,
+proc remove*[T](ring: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
+  ## Removes `n` from `ring`. Efficiency: O(1).
+  ## This function assumes, for the sake of efficiency, that `n` is contained in `ring`,
   ## otherwise the effects are undefined.
   runnableExamples:
     var a = initDoublyLinkedRing[int]()
@@ -956,13 +956,13 @@ proc remove*[T](L: var DoublyLinkedRing[T], n: DoublyLinkedNode[T]) =
 
   n.next.prev = n.prev
   n.prev.next = n.next
-  if n == L.head:
-    let p = L.head.prev
-    if p == L.head:
+  if n == ring.head:
+    let p = ring.head.prev
+    if p == ring.head:
       # only one element left:
-      L.head = nil
+      ring.head = nil
     else:
-      L.head = p
+      ring.head = p
 
 proc append*[T](a: var (SinglyLinkedList[T] | SinglyLinkedRing[T]),
                 b: SinglyLinkedList[T] | SinglyLinkedNode[T] | T) =


### PR DESCRIPTION
* `L` -> `list` for linked lists
* `L` -> `ring` for linked rings
* `L` -> `l` for linked collections

Followup to #17312.