### PR TITLE
remove 'stats' from help document of testament tool

### DIFF
--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -35,7 +35,6 @@ Command:
   c|cat|category <category>   run all the tests of a certain category
   r|run <test>                run single test file
   html                        generate $1 from the database
-  stats                       generate statistics about test cases
 Arguments:
   arguments are passed to the compiler
 Options:


### PR DESCRIPTION
`stats` sub command is not existed.
(https://github.com/nim-lang/Nim/blob/devel/testament/testament.nim#L806-L809)

This sub command was renamed from `stats` to `megatest`. 
see: https://github.com/nim-lang/Nim/commit/ac785b06236dbc228a3b755c11bb3b1330ccc3ab#diff-6bc101e8b7567725cf59c242672546abd610a495f3f9737a4b9fcb74a3a315c2R584 

And `megatest` sub command was removed.
see: https://github.com/nim-lang/Nim/commit/0d99ff6113245fc105b34940ab9a111cf4576361#diff-6bc101e8b7567725cf59c242672546abd610a495f3f9737a4b9fcb74a3a315c2L584 .