### PR TITLE
[FIX] use `mixin` for strscans.scanp

### DIFF
--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -577,6 +577,7 @@ macro scanp*(input, idx: typed; pattern: varargs[untyped]): bool =
     of nnkCallKinds:
       # *{'A'..'Z'} !! s.add(!_)
       template buildWhile(input, idx, init, cond, action): untyped =
+        mixin hasNxt
         while hasNxt(input, idx):
           init
           if not cond: break


### PR DESCRIPTION
Cannot compile `scanp` patterns for custom type because `haxNxt` implementation is not being `mixin`'ed. Fixed that.