### PR TITLE
fix #17351

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -86,7 +86,7 @@ compiler gcc:
     asmStmtFrmt: "asm($1);$n",
     structStmtFmt: "$1 $3 $2 ", # struct|union [packed] $name
     produceAsm: gnuAsmListing,
-    cppXsupport: "-std=gnu++14 -funsigned-char",
+    cppXsupport: "-std=gnu++17 -funsigned-char",
     props: {hasSwitchRange, hasComputedGoto, hasCpp, hasGcGuard, hasGnuAsm,
             hasAttribute})
 
@@ -113,7 +113,7 @@ compiler nintendoSwitchGCC:
     asmStmtFrmt: "asm($1);$n",
     structStmtFmt: "$1 $3 $2 ", # struct|union [packed] $name
     produceAsm: gnuAsmListing,
-    cppXsupport: "-std=gnu++14 -funsigned-char",
+    cppXsupport: "-std=gnu++17 -funsigned-char",
     props: {hasSwitchRange, hasComputedGoto, hasCpp, hasGcGuard, hasGnuAsm,
             hasAttribute})
 

--- a/tests/arc/texceptions.nim
+++ b/tests/arc/texceptions.nim
@@ -14,3 +14,13 @@ block: # issue #13071
       a = e.msg & $e.name # was segfaulting here for `nim cpp --gc:arc`
     doAssert a == "foo:MyExcept"
   fun()
+
+
+block: # issue #17351
+  type
+    Foo {.inheritable.} = object
+    Foo2 = object of Foo
+    Bar = object
+      x: Foo2
+
+  var b = Bar()


### PR DESCRIPTION
fix #17351. Initialization of parent struct in C++ appeared only in C++17.
https://stackoverflow.com/questions/47333843/using-initializer-list-for-a-struct-with-inheritance