### PR TITLE
rst snippets can now go in tests/examples tested by testament

### DIFF
--- a/doc/destructors.rst
+++ b/doc/destructors.rst
@@ -29,60 +29,7 @@ With the language mechanisms described here, a custom seq could be
 written as:
 
 .. code-block:: nim
-
-  type
-    myseq*[T] = object
-      len, cap: int
-      data: ptr UncheckedArray[T]
-
-  proc `=destroy`*[T](x: var myseq[T]) =
-    if x.data != nil:
-      for i in 0..<x.len: `=destroy`(x.data[i])
-      dealloc(x.data)
-
-  proc `=copy`*[T](a: var myseq[T]; b: myseq[T]) =
-    # do nothing for self-assignments:
-    if a.data == b.data: return
-    `=destroy`(a)
-    wasMoved(a)
-    a.len = b.len
-    a.cap = b.cap
-    if b.data != nil:
-      a.data = cast[typeof(a.data)](alloc(a.cap * sizeof(T)))
-      for i in 0..<a.len:
-        a.data[i] = b.data[i]
-
-  proc `=sink`*[T](a: var myseq[T]; b: myseq[T]) =
-    # move assignment, optional.
-    # Compiler is using `=destroy` and `copyMem` when not provided
-    `=destroy`(a)
-    wasMoved(a)
-    a.len = b.len
-    a.cap = b.cap
-    a.data = b.data
-
-  proc add*[T](x: var myseq[T]; y: sink T) =
-    if x.len >= x.cap: resize(x)
-    x.data[x.len] = y
-    inc x.len
-
-  proc `[]`*[T](x: myseq[T]; i: Natural): lent T =
-    assert i < x.len
-    x.data[i]
-
-  proc `[]=`*[T](x: var myseq[T]; i: Natural; y: sink T) =
-    assert i < x.len
-    x.data[i] = y
-
-  proc createSeq*[T](elems: varargs[T]): myseq[T] =
-    result.cap = elems.len
-    result.len = elems.len
-    result.data = cast[typeof(result.data)](alloc(result.cap * sizeof(T)))
-    for i in 0..<result.len: result.data[i] = elems[i]
-
-  proc len*[T](x: myseq[T]): int {.inline.} = x.len
-
-
+   :file: tests/examples/tdestructors1.nim
 
 Lifetime-tracking hooks
 =======================

--- a/tests/examples/readme.md
+++ b/tests/examples/readme.md
@@ -1,0 +1,25 @@
+Each example in this directory is referenced by some test snippet, for example:
+
+```
+Example snippet:
+
+.. code-block:: nim
+   :file: tests/examples/tdestructors1.nim
+
+Rest of docs.
+```
+
+
+This ensures the examples keep working, and allows using all testament features.
+The alternative is to use:
+```
+Example snippet:
+
+.. code-block:: nim
+    :test: "nim r $1"
+
+Rest of docs.
+```
+
+but this is less flexible, for example it prevents reusing tests, or using testament spec such
+as `matrix`, etc.

--- a/tests/examples/tdestructors1.nim
+++ b/tests/examples/tdestructors1.nim
@@ -1,0 +1,69 @@
+type
+  myseq*[T] = object
+    len, cap: int
+    data: ptr UncheckedArray[T]
+
+proc `=destroy`*[T](x: var myseq[T]) =
+  if x.data != nil:
+    for i in 0..<x.len: `=destroy`(x.data[i])
+    dealloc(x.data)
+
+proc `=copy`*[T](a: var myseq[T]; b: myseq[T]) =
+  # do nothing for self-assignments:
+  if a.data == b.data: return
+  `=destroy`(a)
+  wasMoved(a)
+  a.len = b.len
+  a.cap = b.cap
+  if b.data != nil:
+    a.data = cast[typeof(a.data)](alloc(a.cap * sizeof(T)))
+    for i in 0..<a.len:
+      a.data[i] = b.data[i]
+
+proc `=sink`*[T](a: var myseq[T]; b: myseq[T]) =
+  # move assignment, optional.
+  # Compiler is using `=destroy` and `copyMem` when not provided
+  `=destroy`(a)
+  wasMoved(a)
+  a.len = b.len
+  a.cap = b.cap
+  a.data = b.data
+
+proc add*[T](x: var myseq[T]; y: sink T) =
+  if x.len >= x.cap:
+    x.cap = max(x.len + 1, x.cap * 2)
+    x.data = cast[typeof(x.data)](realloc(x.data, x.cap * sizeof(T)))
+  # if x.len >= x.cap: resize(x)
+  x.data[x.len] = y
+  inc x.len
+
+proc `[]`*[T](x: myseq[T]; i: Natural): lent T =
+  assert i < x.len
+  x.data[i]
+
+proc `[]=`*[T](x: var myseq[T]; i: Natural; y: sink T) =
+  assert i < x.len
+  x.data[i] = y
+
+proc createSeq*[T](elems: varargs[T]): myseq[T] =
+  result.cap = elems.len
+  result.len = elems.len
+  result.data = cast[typeof(result.data)](alloc(result.cap * sizeof(T)))
+  for i in 0..<result.len: result.data[i] = elems[i]
+
+proc len*[T](x: myseq[T]): int {.inline.} = x.len
+
+var witness: seq[int]
+
+type Foo = object
+  x: int
+
+proc `=destroy`(a: var Foo) =
+  witness.add a.x
+
+var s = createSeq(Foo(x: 0), Foo(x: 1))
+s.add Foo(x: 2)
+assert s.len == 3
+s[1] = Foo(x: 11)
+assert s[1] == Foo(x: 11)
+assert witness.len >= 2


### PR DESCRIPTION
this PR introduces a new way to write rst test snippets:
* tested by testament just like any other test
* allows using all testament features (matrix, etc), unlike the existing alternative:
```
.. code-block:: nim
    :test: "nim r $1"
```
* increases coverage since testament is tested in more machines via azure-pipelines compared to ones that run in CI docs
* faster since it benefits from parallel tests

## note
I wrote `assert witness.len >= 2` which is a weak test, unfortunately, some destructors aren't called (even with --gc:arc), which seems like a bug indedpent of this PR
