### PR TITLE
Documentation only jsconsole

### DIFF
--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -13,7 +13,7 @@
 ## Styled Messages
 ## ===============
 ##
-## CSS styled messages for debugging purposes are supported in the browser,
+## CSS styled messages in the browser are useful for debugging purposes,
 ## prefix the string message with one or more `%c`,
 ## and provide a CSS style inside another string as the last argument,
 ## the amount of `%c` must match the amount of CSS style strings.

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -18,10 +18,9 @@
 ## and provide the CSS style as the last argument.
 ## The amount of `%c`'s must match the amount of CSS-styled strings.
 ##
-## .. code-block:: nim
-##   import std/jsconsole
-##   console.log "%c My Debug Message", "color: red" # Notice the "%c"
-##   console.log "%c My Debug %c Message", "color: red", "font-size: 2em"
+runnableExamples("-r:off"):
+  console.log "%c My Debug Message", "color: red" # Notice the "%c"
+  console.log "%c My Debug %c Message", "color: red", "font-size: 2em"
 
 import std/private/since, std/private/miscdollars  # toLocation
 

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -9,6 +9,16 @@
 
 ## Wrapper for the `console` object for the `JavaScript backend
 ## <backends.html#backends-the-javascript-target>`_.
+##
+## Styled Messages
+## ===============
+##
+## CSS styled messages for debugging purposes are supported in the browser:
+##
+## .. code-block:: nim
+##   import std/jsconsole
+##   console.log "%c My Debug Message", "color: red" ## Notice the "%c"
+##   console.log "%c My Debug %c Message", "color: red", "font-size: 2em"
 
 import std/private/since, std/private/miscdollars  # toLocation
 

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -13,14 +13,14 @@
 ## Styled Messages
 ## ===============
 ##
-## CSS styled messages in the browser are useful for debugging purposes,
-## prefix the string message with one or more `%c`,
-## and provide a CSS style inside another string as the last argument,
-## the amount of `%c` must match the amount of CSS style strings.
+## CSS-styled messages in the browser are useful for debugging purposes.
+## To use them, prefix the message with one or more `%c`,
+## and provide the CSS style as the last argument.
+## The amount of `%c`'s must match the amount of CSS-styled strings.
 ##
 ## .. code-block:: nim
 ##   import std/jsconsole
-##   console.log "%c My Debug Message", "color: red" ## Notice the "%c"
+##   console.log "%c My Debug Message", "color: red" # Notice the "%c"
 ##   console.log "%c My Debug %c Message", "color: red", "font-size: 2em"
 
 import std/private/since, std/private/miscdollars  # toLocation

--- a/lib/js/jsconsole.nim
+++ b/lib/js/jsconsole.nim
@@ -13,7 +13,10 @@
 ## Styled Messages
 ## ===============
 ##
-## CSS styled messages for debugging purposes are supported in the browser:
+## CSS styled messages for debugging purposes are supported in the browser,
+## prefix the string message with one or more `%c`,
+## and provide a CSS style inside another string as the last argument,
+## the amount of `%c` must match the amount of CSS style strings.
 ##
 ## .. code-block:: nim
 ##   import std/jsconsole


### PR DESCRIPTION
- CSS Styled `console.log` for Debug. Documentation only.

I know this is not "Nim exclusive" but I think that all possible help we can provide to the users for Debugging the better.

## future work
- [x] console.dir see https://developer.mozilla.org/en-US/docs/Web/API/Console/log#difference_between_log_and_dir => https://github.com/nim-lang/Nim/pull/17414