### PR TITLE
followup #16067 --spellSuggest

### DIFF
--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -129,3 +129,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasJsBigIntBackend")
   defineSymbol("nimHasWarningAsError")
   defineSymbol("nimHasHintAsError")
+  defineSymbol("nimHasSpellSuggest")

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -101,8 +101,23 @@ type                          # please make sure we have under 32 options
   TGlobalOptions* = set[TGlobalOption]
 
 const
-  harmlessOptions* = {optForceFullMake, optNoLinking, optRun,
-                      optUseColors, optStdout}
+  harmlessOptions* = {optForceFullMake, optNoLinking, optRun, optUseColors, optStdout}
+  genSubDir* = RelativeDir"nimcache"
+  NimExt* = "nim"
+  RodExt* = "rod"
+  HtmlExt* = "html"
+  JsonExt* = "json"
+  TagsExt* = "tags"
+  TexExt* = "tex"
+  IniExt* = "ini"
+  DefaultConfig* = RelativeFile"nim.cfg"
+  DefaultConfigNims* = RelativeFile"config.nims"
+  DocConfig* = RelativeFile"nimdoc.cfg"
+  DocTexConfig* = RelativeFile"nimdoc.tex.cfg"
+  htmldocsDir* = htmldocsDirname.RelativeDir
+  docRootDefault* = "@default" # using `@` instead of `$` to avoid shell quoting complications
+  oKeepVariableNames* = true
+  spellSuggestSecretSauce* = -1
 
 type
   TBackend* = enum
@@ -483,6 +498,7 @@ proc newConfigRef*(): ConfigRef =
     suggestMaxResults: 10_000,
     maxLoopIterationsVM: 10_000_000,
     vmProfileData: newProfileData(),
+    spellSuggestMax: spellSuggestSecretSauce,
   )
   setTargetFromSystem(result.target)
   # enable colors by default on terminals
@@ -559,24 +575,6 @@ template compilationCachePresent*(conf: ConfigRef): untyped =
 
 template optPreserveOrigSource*(conf: ConfigRef): untyped =
   optEmbedOrigSrc in conf.globalOptions
-
-const
-  genSubDir* = RelativeDir"nimcache"
-  NimExt* = "nim"
-  RodExt* = "rod"
-  HtmlExt* = "html"
-  JsonExt* = "json"
-  TagsExt* = "tags"
-  TexExt* = "tex"
-  IniExt* = "ini"
-  DefaultConfig* = RelativeFile"nim.cfg"
-  DefaultConfigNims* = RelativeFile"config.nims"
-  DocConfig* = RelativeFile"nimdoc.cfg"
-  DocTexConfig* = RelativeFile"nimdoc.tex.cfg"
-  htmldocsDir* = htmldocsDirname.RelativeDir
-  docRootDefault* = "@default" # using `@` instead of `$` to avoid shell quoting complications
-  oKeepVariableNames* = true
-  spellSuggestSecretSauce* = -1
 
 proc mainCommandArg*(conf: ConfigRef): string =
   ## This is intended for commands like check or parse

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -8,6 +8,7 @@ switch("path", "$lib/../testament/lib")
 switch("colors", "off")
 switch("listFullPaths", "off")
 switch("excessiveStackTrace", "off")
+switch("spellSuggestMax", 0)
 
 # for std/unittest
 switch("define", "nimUnittestOutputLevel:PRINT_FAILURES")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -8,7 +8,7 @@ switch("path", "$lib/../testament/lib")
 switch("colors", "off")
 switch("listFullPaths", "off")
 switch("excessiveStackTrace", "off")
-switch("spellSuggestMax", 0)
+switch("spellSuggest", "0")
 
 # for std/unittest
 switch("define", "nimUnittestOutputLevel:PRINT_FAILURES")


### PR DESCRIPTION
* address https://github.com/nim-lang/Nim/pull/16067#discussion_r595003877
* add `condsyms` (although IMO `nimVersionCT` + patch bump is the way to go refs https://github.com/nim-lang/Nim/pull/14648) so users can add `--spellsuggest:N` it to their user config
* enable --spellSuggest by default (but tests/config.nims sets it to 0; tests/misc/tspellsuggest.nim and tests/misc/tspellsuggest2.nim still test for it)