### PR TITLE
adjust spellSuggestSecretSauce logic to avoid too many matches for small symbols

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -408,10 +408,16 @@ proc fixSpelling(c: PContext, n: PNode, ident: PIdent, result: var string) =
     if list.len == 0: break
     let e = list.pop()
     if c.config.spellSuggestMax == spellSuggestSecretSauce:
-      if e.dist > e0.dist: break
+      const
+        smallThres = 2
+        maxCountForSmall = 4
+        # avoids ton of operator matches when mis-matching short symbols such as `i`
+        # other heuristics could be devised, such as only suggesting operators if `name0`
+        # is an operator (likewise with non-operators).
+      if e.dist > e0.dist or (name0.len <= smallThres and count >= maxCountForSmall): break
     elif count >= c.config.spellSuggestMax: break
     if count == 0:
-      result.add "\ncandidate misspellings (edit distance, lexical scope distance): "
+      result.add "\ncandidates (edit distance, scope distance); see '--spellSuggest': "
     result.add e.msg
     count.inc
 

--- a/tests/misc/tspellsuggest.nim
+++ b/tests/misc/tspellsuggest.nim
@@ -4,7 +4,7 @@ discard """
   action: "reject"
   nimout: '''
 tspellsuggest.nim(45, 13) Error: undeclared identifier: 'fooBar'
-candidate misspellings (edit distance, lexical scope distance):
+candidates (edit distance, scope distance); see '--spellSuggest':
  (1, 0): 'fooBar8' [var declared in tspellsuggest.nim(43, 9)]
  (1, 1): 'fooBar7' [var declared in tspellsuggest.nim(41, 7)]
  (1, 3): 'fooBar1' [var declared in tspellsuggest.nim(33, 5)]

--- a/tests/misc/tspellsuggest2.nim
+++ b/tests/misc/tspellsuggest2.nim
@@ -4,7 +4,7 @@ discard """
   action: "reject"
   nimout: '''
 tspellsuggest2.nim(45, 13) Error: undeclared identifier: 'fooBar'
-candidate misspellings (edit distance, lexical scope distance):
+candidates (edit distance, scope distance); see '--spellSuggest':
  (1, 0): 'fooBar8' [var declared in tspellsuggest2.nim(43, 9)]
  (1, 1): 'fooBar7' [var declared in tspellsuggest2.nim(41, 7)]
  (1, 3): 'fooBar1' [var declared in tspellsuggest2.nim(33, 5)]


### PR DESCRIPTION
before this PR, it returned too many candidates when you mistyped a small symbol (returning lots of operators)

other refinements could be made later if needed, such as only returning operators if mistyped identifier is an operator, and vice versa.