### PR TITLE
Fixed embedded nimscript imports

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -805,10 +805,11 @@ proc findModule*(conf: ConfigRef; modulename, currentModule: string): AbsoluteFi
       for candidate in stdlibDirs:
         let path = (conf.libpath.string / candidate / stripped)
         if fileExists(path):
-          m = path
+          result = AbsoluteFile path
           break
-    let currentPath = currentModule.splitFile.dir
-    result = AbsoluteFile currentPath / m
+    else: # If prefixed with std/ why would we add the current module path!
+      let currentPath = currentModule.splitFile.dir
+      result = AbsoluteFile currentPath / m
     if not fileExists(result):
       result = findFile(conf, m)
   patchModule(conf)


### PR DESCRIPTION
Previously when using embedded nimscript if a module inside the stdlib had `import std/macros` for example `typetraits` it'd find `core/macros` then append `stdlib/pure/` to it making it so it wouldnt properly resolve the path to it.