### PR TITLE
strutils: improve doc comments for `replace` funcs

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2037,7 +2037,7 @@ func contains*(s: string, chars: set[char]): bool =
 
 func replace*(s, sub: string, by = ""): string {.rtl,
     extern: "nsuReplaceStr".} =
-  ## Replaces every occurence of `sub` in `s` by the string `by`.
+  ## Replaces every occurrence of the string `sub` in `s` with the string `by`.
   ##
   ## See also:
   ## * `find func<#find,string,string,Natural,int>`_
@@ -2079,7 +2079,8 @@ func replace*(s, sub: string, by = ""): string {.rtl,
 
 func replace*(s: string, sub, by: char): string {.rtl,
     extern: "nsuReplaceChar".} =
-  ## Replaces every occurence of character `sub` in `s` by the character `by`.
+  ## Replaces every occurrence of the character `sub` in `s` with the character
+  ## `by`.
   ##
   ## Optimized version of `replace <#replace,string,string,string>`_ for
   ## characters.
@@ -2097,7 +2098,7 @@ func replace*(s: string, sub, by: char): string {.rtl,
 
 func replaceWord*(s, sub: string, by = ""): string {.rtl,
     extern: "nsuReplaceWord".} =
-  ## Replaces `sub` in `s` by the string `by`.
+  ## Replaces every occurrence of the string `sub` in `s` with the string `by`.
   ##
   ## Each occurrence of `sub` has to be surrounded by word boundaries
   ## (comparable to `\b` in regular expressions), otherwise it is not


### PR DESCRIPTION
This commit fixes mispellings of "occurrence" introduced by:
- 76a3b350ce0f (#17337)
- 8e8bea9044f0 (#17339)
and adds the same "every occurrence of" in the `replaceWord` func.

Other changes:
- Prefer "replace with" to "replace by".
- Be more consistent with "the" - prefer "of the character" given that
  we wrote "by the character".
- Try to be more consistent with writing the types - add
  "the string `sub`" given that we wrote "the character `sub`".

---

See e.g.:
- https://en.wiktionary.org/wiki/occurence
- [ngrams occurence vs occurrence](https://books.google.com/ngrams/graph?content=occurence%2C+occurrence&year_start=1800&year_end=2000&corpus=15&smoothing=3&share=&direct_url=t1%3B%2Coccurence%3B%2Cc0%3B.t1%3B%2Coccurrence%3B%2Cc0)
- https://english.stackexchange.com/questions/431928/is-occurence-a-word
- https://english.stackexchange.com/questions/151309/replace-with-versus-replace-by - I didn't find an particularly authoritative source for this exact "replace with" vs "replace by" thing, but the sentence "this replaces every apple by a banana" sounds plain wrong to me.
- https://hinative.com/en-US/questions/24604

However, I'm aware that the name of the parameter is `by`, so it helps to write "by" in the doc comment.

This is hardly the most critical issue, but here are some alternatives to the current change in this PR:
1. Rephrase the doc comment to allow using "by", like:
```Nim
func replace*(s: string, sub, by: char): string {.rtl,
    extern: "nsuReplaceChar".} =
  ## Returns a new string in which every occurrence of the character `sub`
  ## in `s` is replaced by the character `by`.
```
2. Add a new proc with the parameter name `with`, and deprecate the `by` one. But I don't love how this reads either: 
```Nim
func replace*(s: string, sub, with: char): string {.rtl,
    extern: "nsuReplaceChar".} =
  ## Replaces every occurrence of the character `sub` in `s` with the character
  ## `with`.
```