### PR TITLE
Close #8545 by add a test case

### DIFF
--- a/tests/misc/t8545.nim
+++ b/tests/misc/t8545.nim
@@ -2,7 +2,7 @@ discard """
   targets: "c cpp js"
 """
 
-# https://github.com/nim-lang/Nim/issues/8545
+# bug #8545
 
 template bar(a: static[bool]): untyped = int
 

--- a/tests/misc/t8545.nim
+++ b/tests/misc/t8545.nim
@@ -1,0 +1,23 @@
+discard """
+  targets: "c cpp js"
+"""
+
+# https://github.com/nim-lang/Nim/issues/8545
+
+template bar(a: static[bool]): untyped = int
+
+proc main() =
+  proc foo1(a: static[bool]): auto = 1
+  doAssert foo1(true) == 1
+
+  proc foo2(a: static[bool]): bar(a) = 1
+  doAssert foo2(true) == 1
+
+  proc foo3(a: static[bool]): bar(cast[static[bool]](a)) = 1
+  doAssert foo3(true) == 1
+
+  proc foo4(a: static[bool]): bar(static(a)) = 1
+  doAssert foo4(true) == 1
+
+static: main()
+main()


### PR DESCRIPTION
@timotheecour

Closes #8545.

While writing this test, I found another template bug, where names aren't correctly gensym'd, so I used `proc main() =`.