### PR TITLE
Bring back i386 CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,9 @@ jobs:
       Linux_amd64:
         vmImage: 'ubuntu-16.04'
         CPU: amd64
-      # Linux_i386:
-      #   # bug #17325: fails on 'ubuntu-16.04' because it now errors with:
-      #   # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
-      #   vmImage: 'ubuntu-18.04'
-      #   CPU: i386
+      Linux_i386:
+        vmImage: 'ubuntu-18.04'
+        CPU: i386
       OSX_amd64:
         vmImage: 'macOS-10.15'
         CPU: amd64
@@ -66,34 +64,29 @@ jobs:
       displayName: 'Install node.js 12.x'
 
     - bash: |
-        set -e
-        . ci/funs.sh
-        echo_run sudo apt-fast update -qq
+        sudo apt-fast update -qq
         DEBIAN_FRONTEND='noninteractive' \
-          echo_run sudo apt-fast install --no-install-recommends -yq \
+          sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
       displayName: 'Install dependencies (amd64 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 
     - bash: |
-        set -e
-        . ci/funs.sh
-        echo_run sudo dpkg --add-architecture i386
+        sudo dpkg --add-architecture i386
+
         # Downgrade llvm:
         # - llvm has to be downgraded to have 32bit version installed for sfml.
-
         cat << EOF | sudo tee /etc/apt/preferences.d/pin-to-rel
         Package: libllvm6.0
         Pin: origin "azure.archive.ubuntu.com"
         Pin-Priority: 1001
         EOF
 
-        # echo_run sudo apt-fast update -qq
-        echo_run sudo apt-fast update -qq || echo "failed, see bug #17343"
+        sudo apt-fast update -qq
         # `:i386` (e.g. in `libffi-dev:i386`) is needed otherwise you may get:
         # `could not load: libffi.so` during dynamic loading.
         DEBIAN_FRONTEND='noninteractive' \
-          echo_run sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
+          sudo apt-fast install --no-install-recommends --allow-downgrades -yq \
             g++-multilib gcc-multilib libcurl4-openssl-dev:i386 libgc-dev:i386 \
             libsdl1.2-dev:i386 libsfml-dev:i386 libglib2.0-dev:i386 libffi-dev:i386
 
@@ -109,8 +102,8 @@ jobs:
         exec $(which g++) -m32 "\$@"
         EOF
 
-        echo_run chmod 755 bin/gcc
-        echo_run chmod 755 bin/g++
+        chmod 755 bin/gcc
+        chmod 755 bin/g++
 
       displayName: 'Install dependencies (i386 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
@@ -120,14 +113,12 @@ jobs:
       condition: eq(variables['Agent.OS'], 'Darwin')
 
     - bash: |
-        set -e
-        . ci/funs.sh
-        echo_run mkdir dist
-        echo_run curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
-        echo_run curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
-        echo_run 7z x dist/mingw64.7z -odist
-        echo_run 7z x dist/dlls.zip -obin
-        echo_run echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
+        mkdir dist
+        curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
+        curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
+        7z x dist/mingw64.7z -odist
+        7z x dist/dlls.zip -obin
+        echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
 
       displayName: 'Install dependencies (Windows)'
       condition: eq(variables['Agent.OS'], 'Windows_NT')
@@ -136,15 +127,13 @@ jobs:
       displayName: 'Add build binaries to PATH'
 
     - bash: |
-        set -e
-        . ci/funs.sh
-        echo_run echo 'PATH:' "$PATH"
-        echo_run echo '##[section]gcc version'
-        echo_run gcc -v
-        echo_run echo '##[section]nodejs version'
-        echo_run node -v
-        echo_run echo '##[section]make version'
-        echo_run make -v
+        echo 'PATH:' "$PATH"
+        echo '##[section]gcc version'
+        gcc -v
+        echo '##[section]nodejs version'
+        node -v
+        echo '##[section]make version'
+        make -v
       displayName: 'System information'
 
     - bash: echo '##vso[task.setvariable variable=csources_version]'"$(git -C csources rev-parse HEAD)"
@@ -157,8 +146,6 @@ jobs:
       displayName: 'Restore built csources'
 
     - bash: |
-        set -e
-        . ci/funs.sh
         ncpu=
         ext=
         case '$(Agent.OS)' in
@@ -176,12 +163,12 @@ jobs:
         [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
 
         if [[ -x csources/bin/nim$ext ]]; then
-          echo_run echo "Found cached compiler, skipping build"
+          echo "Found cached compiler, skipping build"
         else
-          echo_run make -C csources -j $ncpu CC=gcc ucpu=$(CPU) koch=no
+          make -C csources -j $ncpu CC=gcc ucpu=$(CPU) koch=no
         fi
 
-        echo_run cp csources/bin/nim$ext bin
+        cp csources/bin/nim$ext bin
       displayName: 'Build 1-stage compiler from csources'
 
     - bash: nim c koch

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -1,8 +1,0 @@
-# utilities used in CI pipelines to avoid duplication.
-
-echo_run () {
-  # echo's a command before running it, which helps understanding logs
-  echo ""
-  echo "$@"
-  "$@"
-}


### PR DESCRIPTION
This basically just reverts #17327, leaving bumping the Ubuntu version to 18.04 as the only change from the situation from before that PR.

This now finally makes it past the installing the dependencies part, and now reveals that json stuff (part of https://github.com/nim-lang/Nim/pull/17389, from what I can tell) is failing on 32-bit machines.

cc @timotheecour 