### PR TITLE
refs #17292 fix `repr`: `(discard)` now does't render as `discard` which gave illegal code

### DIFF
--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1004,7 +1004,6 @@ proc isCustomLit(n: PNode): bool =
     (n[1].kind == nkSym and n[1].sym.name.s.startsWith('\''))
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
-  dbg n.kind, n
   if isNil(n): return
   var
     a: TContext
@@ -1199,7 +1198,6 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     else:
       gsub(g, n, 0)
   of nkPar, nkClosure:
-    dbg "D20210322T025150"
     put(g, tkParLe, "(")
     gcomma(g, n, c)
     put(g, tkParRi, ")")
@@ -1457,14 +1455,10 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     putWithSpace(g, tkEquals, "=")
     gsub(g, n, 1)
   of nkStmtList, nkStmtListExpr, nkStmtListType:
-    dbg n.kind, n.len
-    for i in 0..<n.len:
-      dbg n[i].kind
     if n.len == 1 and n[0].kind == nkDiscardStmt:
       put(g, tkParLe, "(")
       gsub(g, n[0])
       put(g, tkParRi, ")")
-      # gstmts(g, n, emptyContext)
     else:
       gstmts(g, n, emptyContext)
   of nkIfStmt:

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1004,6 +1004,7 @@ proc isCustomLit(n: PNode): bool =
     (n[1].kind == nkSym and n[1].sym.name.s.startsWith('\''))
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
+  dbg n.kind, n
   if isNil(n): return
   var
     a: TContext
@@ -1198,6 +1199,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     else:
       gsub(g, n, 0)
   of nkPar, nkClosure:
+    dbg "D20210322T025150"
     put(g, tkParLe, "(")
     gcomma(g, n, c)
     put(g, tkParRi, ")")
@@ -1454,7 +1456,17 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     put(g, tkSpaces, Space)
     putWithSpace(g, tkEquals, "=")
     gsub(g, n, 1)
-  of nkStmtList, nkStmtListExpr, nkStmtListType: gstmts(g, n, emptyContext)
+  of nkStmtList, nkStmtListExpr, nkStmtListType:
+    dbg n.kind, n.len
+    for i in 0..<n.len:
+      dbg n[i].kind
+    if n.len == 1 and n[0].kind == nkDiscardStmt:
+      put(g, tkParLe, "(")
+      gsub(g, n[0])
+      put(g, tkParRi, ")")
+      # gstmts(g, n, emptyContext)
+    else:
+      gstmts(g, n, emptyContext)
   of nkIfStmt:
     putWithSpace(g, tkIf, "if")
     gif(g, n)

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -141,6 +141,38 @@ do:
 do:
   4"""
 
+  block: # bug #17292 repr with `(discard)` (`discard` would result in illegal code)
+    let a = deb:
+      let f {.inject.} = () => (discard)
+    doAssert a == """
+let f {.inject.} = () =>
+    (discard )"""
+
+    let a2 = deb:
+      block:
+        discard
+      discard
+
+      block:
+        when true: discard
+
+      # let a = b => discard # illegal
+      discard b => (discard) # legal
+
+      block:
+        return
+    doAssert a2 == """
+block:
+  discard
+discard
+block:
+  when true:
+    discard
+discard b =>
+    (discard )
+block:
+  return"""
+
   block: # bug #17292 (bug 4)
     let a = deb:
       proc `=destroy`() = discard
@@ -154,16 +186,8 @@ proc `'foo`(): int =
   discard
 
 proc `foo bar baz`(): int =
-  discard
-"""
+  discard"""
     doAssert a2 == a
-
-  block: # bug #17292 repr with `(discard)` (`discard` would result in illegal code)
-    let a = deb:
-      let f {.inject.} = () => (discard)
-    doAssert a == """
-let f {.inject.} = () =>
-    (discard )"""
 
 static: main()
 main()


### PR DESCRIPTION
refs #17292

```nim
let f = () => (discard)
```
now renders as:
```nim
let f = () => (discard)
```
instead of this:
```nim
let f = () => discard
```
which is illegal (it was making runnableExamples invalid prior to https://github.com/nim-lang/Nim/pull/17282, but the underlying bug remained and affected things like parseExpr, parseStmt, or operations based on renderModule)

