### PR TITLE
refs #16338 make thttpclient_ssl_remotenetwork.nim less flaky: ignore http 500

### DIFF
--- a/tests/untestable/thttpclient_ssl_remotenetwork.nim
+++ b/tests/untestable/thttpclient_ssl_remotenetwork.nim
@@ -115,12 +115,23 @@ when enableRemoteNetworking and (defined(nimTestsEnableFlaky) or not defined(win
 
     else:
       # this is unexpected
+      var fatal = true
+      var msg = ""
       if raised:
-        echo "         $# ($#) raised: $#" % [desc, $category, exception_msg]
+        msg = "         $# ($#) raised: $#" % [desc, $category, exception_msg]
+        if "500 Internal Server Error" in exception_msg:
+          # refs https://github.com/nim-lang/Nim/issues/16338#issuecomment-804300278
+          # we got: `good (good) raised: 500 Internal Server Error`
+          fatal = false
+          msg.add " (http 500 => assuming this is not our problem)"
       else:
-        echo "         $# ($#) did not raise" % [desc, $category]
-      if category in {good, dubious, bad}:
+        msg = "         $# ($#) did not raise" % [desc, $category]
+
+      if category in {good, dubious, bad} and fatal:
+        echo "D20210322T121353: error: " & msg
         fail()
+      else:
+        echo "D20210322T121353: warning: " & msg
 
 
   suite "SSL certificate check - httpclient":


### PR DESCRIPTION
* refs #16338 
* fixes https://github.com/nim-lang/Nim/issues/16338#issuecomment-804300278: `500 Internal Server Error` now gets ignored as this shouldn't be our problem
* refs https://github.com/timotheecour/Nim/issues/596 to make the error message easier to locate where it came from (it wasn't obvious from th CI logs before that)

