### PR TITLE
remove {.compileTime.} for procs with NimNode: redundant because of `tfTriggersCompileTime`

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -404,29 +404,29 @@ proc warning*(msg: string, n: NimNode = nil) {.magic: "NWarning", benign.}
 proc hint*(msg: string, n: NimNode = nil) {.magic: "NHint", benign.}
   ## Writes a hint message at compile time.
 
-proc newStrLitNode*(s: string): NimNode {.compileTime, noSideEffect.} =
+proc newStrLitNode*(s: string): NimNode {.noSideEffect.} =
   ## Creates a string literal node from `s`.
   result = newNimNode(nnkStrLit)
   result.strVal = s
 
-proc newCommentStmtNode*(s: string): NimNode {.compileTime, noSideEffect.} =
+proc newCommentStmtNode*(s: string): NimNode {.noSideEffect.} =
   ## Creates a comment statement node.
   result = newNimNode(nnkCommentStmt)
   result.strVal = s
 
-proc newIntLitNode*(i: BiggestInt): NimNode {.compileTime.} =
+proc newIntLitNode*(i: BiggestInt): NimNode =
   ## Creates an int literal node from `i`.
   result = newNimNode(nnkIntLit)
   result.intVal = i
 
-proc newFloatLitNode*(f: BiggestFloat): NimNode {.compileTime.} =
+proc newFloatLitNode*(f: BiggestFloat): NimNode =
   ## Creates a float literal node from `f`.
   result = newNimNode(nnkFloatLit)
   result.floatVal = f
 
 {.push warnings: off.}
 
-proc newIdentNode*(i: NimIdent): NimNode {.compileTime, deprecated.} =
+proc newIdentNode*(i: NimIdent): NimNode {.deprecated: "use ident(string)".} =
   ## Creates an identifier node from `i`.
   result = newNimNode(nnkIdent)
   result.ident = i
@@ -478,7 +478,7 @@ proc callsite*(): NimNode {.magic: "NCallSite", benign, deprecated:
   "Deprecated since v0.18.1; use varargs[untyped] in the macro prototype instead".}
   ## Returns the AST of the invocation expression that invoked this macro.
 
-proc toStrLit*(n: NimNode): NimNode {.compileTime.} =
+proc toStrLit*(n: NimNode): NimNode =
   ## Converts the AST `n` to the concrete Nim code and wraps that
   ## in a string literal node.
   return newStrLitNode(repr(n))
@@ -504,11 +504,11 @@ proc getFile(arg: NimNode): string {.magic: "NLineInfo", noSideEffect.}
 proc copyLineInfo*(arg: NimNode, info: NimNode) {.magic: "NLineInfo", noSideEffect.}
   ## Copy lineinfo from `info`.
 
-proc lineInfoObj*(n: NimNode): LineInfo {.compileTime.} =
+proc lineInfoObj*(n: NimNode): LineInfo =
   ## Returns `LineInfo` of `n`, using absolute path for `filename`.
   result = LineInfo(filename: n.getFile, line: n.getLine, column: n.getColumn)
 
-proc lineInfo*(arg: NimNode): string {.compileTime.} =
+proc lineInfo*(arg: NimNode): string =
   ## Return line info in the form `filepath(line, column)`.
   $arg.lineInfoObj
 
@@ -522,14 +522,14 @@ proc internalErrorFlag*(): string {.magic: "NError", noSideEffect.}
   ## Some builtins set an error flag. This is then turned into a proper
   ## exception. **Note**: Ordinary application code should not call this.
 
-proc parseExpr*(s: string): NimNode {.noSideEffect, compileTime.} =
+proc parseExpr*(s: string): NimNode {.noSideEffect.} =
   ## Compiles the passed string to its AST representation.
   ## Expects a single expression. Raises `ValueError` for parsing errors.
   result = internalParseExpr(s)
   let x = internalErrorFlag()
   if x.len > 0: raise newException(ValueError, x)
 
-proc parseStmt*(s: string): NimNode {.noSideEffect, compileTime.} =
+proc parseStmt*(s: string): NimNode {.noSideEffect.} =
   ## Compiles the passed string to its AST representation.
   ## Expects one or more statements. Raises `ValueError` for parsing errors.
   result = internalParseStmt(s)
@@ -626,25 +626,25 @@ proc quote*(bl: typed, op = "``"): NimNode {.magic: "QuoteAst", noSideEffect.} =
         doAssert y == 3
     bar2()
 
-proc expectKind*(n: NimNode, k: NimNodeKind) {.compileTime.} =
+proc expectKind*(n: NimNode, k: NimNodeKind) =
   ## Checks that `n` is of kind `k`. If this is not the case,
   ## compilation aborts with an error message. This is useful for writing
   ## macros that check the AST that is passed to them.
   if n.kind != k: error("Expected a node of kind " & $k & ", got " & $n.kind, n)
 
-proc expectMinLen*(n: NimNode, min: int) {.compileTime.} =
+proc expectMinLen*(n: NimNode, min: int) =
   ## Checks that `n` has at least `min` children. If this is not the case,
   ## compilation aborts with an error message. This is useful for writing
   ## macros that check its number of arguments.
   if n.len < min: error("Expected a node with at least " & $min & " children, got " & $n.len, n)
 
-proc expectLen*(n: NimNode, len: int) {.compileTime.} =
+proc expectLen*(n: NimNode, len: int) =
   ## Checks that `n` has exactly `len` children. If this is not the case,
   ## compilation aborts with an error message. This is useful for writing
   ## macros that check its number of arguments.
   if n.len != len: error("Expected a node with " & $len & " children, got " & $n.len, n)
 
-proc expectLen*(n: NimNode, min, max: int) {.compileTime.} =
+proc expectLen*(n: NimNode, min, max: int) =
   ## Checks that `n` has a number of children in the range `min..max`.
   ## If this is not the case, compilation aborts with an error message.
   ## This is useful for writing macros that check its number of arguments.
@@ -652,13 +652,12 @@ proc expectLen*(n: NimNode, min, max: int) {.compileTime.} =
     error("Expected a node with " & $min & ".." & $max & " children, got " & $n.len, n)
 
 proc newTree*(kind: NimNodeKind,
-              children: varargs[NimNode]): NimNode {.compileTime.} =
+              children: varargs[NimNode]): NimNode =
   ## Produces a new node with children.
   result = newNimNode(kind)
   result.add(children)
 
-proc newCall*(theProc: NimNode,
-              args: varargs[NimNode]): NimNode {.compileTime.} =
+proc newCall*(theProc: NimNode, args: varargs[NimNode]): NimNode =
   ## Produces a new call node. `theProc` is the proc that is called with
   ## the arguments `args[0..]`.
   result = newNimNode(nnkCall)
@@ -667,7 +666,7 @@ proc newCall*(theProc: NimNode,
 
 {.push warnings: off.}
 
-proc newCall*(theProc: NimIdent, args: varargs[NimNode]): NimNode {.compileTime, deprecated:
+proc newCall*(theProc: NimIdent, args: varargs[NimNode]): NimNode {.deprecated:
   "Deprecated since v0.18.1; use 'newCall(string, ...)' or 'newCall(NimNode, ...)' instead".} =
   ## Produces a new call node. `theProc` is the proc that is called with
   ## the arguments `args[0..]`.
@@ -678,128 +677,128 @@ proc newCall*(theProc: NimIdent, args: varargs[NimNode]): NimNode {.compileTime,
 {.pop.}
 
 proc newCall*(theProc: string,
-              args: varargs[NimNode]): NimNode {.compileTime.} =
+              args: varargs[NimNode]): NimNode =
   ## Produces a new call node. `theProc` is the proc that is called with
   ## the arguments `args[0..]`.
   result = newNimNode(nnkCall)
   result.add(newIdentNode(theProc))
   result.add(args)
 
-proc newLit*(c: char): NimNode {.compileTime.} =
+proc newLit*(c: char): NimNode =
   ## Produces a new character literal node.
   result = newNimNode(nnkCharLit)
   result.intVal = ord(c)
 
-proc newLit*(i: int): NimNode {.compileTime.} =
+proc newLit*(i: int): NimNode =
   ## Produces a new integer literal node.
   result = newNimNode(nnkIntLit)
   result.intVal = i
 
-proc newLit*(i: int8): NimNode {.compileTime.} =
+proc newLit*(i: int8): NimNode =
   ## Produces a new integer literal node.
   result = newNimNode(nnkInt8Lit)
   result.intVal = i
 
-proc newLit*(i: int16): NimNode {.compileTime.} =
+proc newLit*(i: int16): NimNode =
   ## Produces a new integer literal node.
   result = newNimNode(nnkInt16Lit)
   result.intVal = i
 
-proc newLit*(i: int32): NimNode {.compileTime.} =
+proc newLit*(i: int32): NimNode =
   ## Produces a new integer literal node.
   result = newNimNode(nnkInt32Lit)
   result.intVal = i
 
-proc newLit*(i: int64): NimNode {.compileTime.} =
+proc newLit*(i: int64): NimNode =
   ## Produces a new integer literal node.
   result = newNimNode(nnkInt64Lit)
   result.intVal = i
 
-proc newLit*(i: uint): NimNode {.compileTime.} =
+proc newLit*(i: uint): NimNode =
   ## Produces a new unsigned integer literal node.
   result = newNimNode(nnkUIntLit)
   result.intVal = BiggestInt(i)
 
-proc newLit*(i: uint8): NimNode {.compileTime.} =
+proc newLit*(i: uint8): NimNode =
   ## Produces a new unsigned integer literal node.
   result = newNimNode(nnkUInt8Lit)
   result.intVal = BiggestInt(i)
 
-proc newLit*(i: uint16): NimNode {.compileTime.} =
+proc newLit*(i: uint16): NimNode =
   ## Produces a new unsigned integer literal node.
   result = newNimNode(nnkUInt16Lit)
   result.intVal = BiggestInt(i)
 
-proc newLit*(i: uint32): NimNode {.compileTime.} =
+proc newLit*(i: uint32): NimNode =
   ## Produces a new unsigned integer literal node.
   result = newNimNode(nnkUInt32Lit)
   result.intVal = BiggestInt(i)
 
-proc newLit*(i: uint64): NimNode {.compileTime.} =
+proc newLit*(i: uint64): NimNode =
   ## Produces a new unsigned integer literal node.
   result = newNimNode(nnkUInt64Lit)
   result.intVal = BiggestInt(i)
 
-proc newLit*(b: bool): NimNode {.compileTime.} =
+proc newLit*(b: bool): NimNode =
   ## Produces a new boolean literal node.
   result = if b: bindSym"true" else: bindSym"false"
 
-proc newLit*(s: string): NimNode {.compileTime.} =
+proc newLit*(s: string): NimNode =
   ## Produces a new string literal node.
   result = newNimNode(nnkStrLit)
   result.strVal = s
 
 when false:
   # the float type is not really a distinct type as described in https://github.com/nim-lang/Nim/issues/5875
-  proc newLit*(f: float): NimNode {.compileTime.} =
+  proc newLit*(f: float): NimNode =
     ## Produces a new float literal node.
     result = newNimNode(nnkFloatLit)
     result.floatVal = f
 
-proc newLit*(f: float32): NimNode {.compileTime.} =
+proc newLit*(f: float32): NimNode =
   ## Produces a new float literal node.
   result = newNimNode(nnkFloat32Lit)
   result.floatVal = f
 
-proc newLit*(f: float64): NimNode {.compileTime.} =
+proc newLit*(f: float64): NimNode =
   ## Produces a new float literal node.
   result = newNimNode(nnkFloat64Lit)
   result.floatVal = f
 
 when declared(float128):
-  proc newLit*(f: float128): NimNode {.compileTime.} =
+  proc newLit*(f: float128): NimNode =
     ## Produces a new float literal node.
     result = newNimNode(nnkFloat128Lit)
     result.floatVal = f
 
-proc newLit*(arg: enum): NimNode {.compileTime.} =
+proc newLit*(arg: enum): NimNode =
   result = newCall(
     arg.typeof.getTypeInst[1],
     newLit(int(arg))
   )
 
-proc newLit*[N,T](arg: array[N,T]): NimNode {.compileTime.}
-proc newLit*[T](arg: seq[T]): NimNode {.compileTime.}
-proc newLit*[T](s: set[T]): NimNode {.compileTime.}
-proc newLit*[T: tuple](arg: T): NimNode {.compileTime.}
+proc newLit*[N,T](arg: array[N,T]): NimNode
+proc newLit*[T](arg: seq[T]): NimNode
+proc newLit*[T](s: set[T]): NimNode
+proc newLit*[T: tuple](arg: T): NimNode
 
-proc newLit*(arg: object): NimNode {.compileTime.} =
+proc newLit*(arg: object): NimNode =
   result = nnkObjConstr.newTree(arg.typeof.getTypeInst[1])
   for a, b in arg.fieldPairs:
     result.add nnkExprColonExpr.newTree( newIdentNode(a), newLit(b) )
 
-proc newLit*(arg: ref object): NimNode {.compileTime.} =
+proc newLit*(arg: ref object): NimNode =
   ## produces a new ref type literal node.
   result = nnkObjConstr.newTree(arg.typeof.getTypeInst[1])
   for a, b in fieldPairs(arg[]):
     result.add nnkExprColonExpr.newTree(newIdentNode(a), newLit(b))
 
-proc newLit*[N,T](arg: array[N,T]): NimNode {.compileTime.} =
+proc newLit*[N,T](arg: array[N,T]): NimNode =
   result = nnkBracket.newTree
   for x in arg:
     result.add newLit(x)
 
-proc newLit*[T](arg: seq[T]): NimNode {.compileTime.} =
+proc newLit*[T](arg: seq[T]): NimNode =
   let bracket = nnkBracket.newTree
   for x in arg:
     bracket.add newLit(x)
@@ -812,7 +811,7 @@ proc newLit*[T](arg: seq[T]): NimNode {.compileTime.} =
     var typ = getTypeInst(typeof(arg))[1]
     result = newCall(typ,result)
 
-proc newLit*[T](s: set[T]): NimNode {.compileTime.} =
+proc newLit*[T](s: set[T]): NimNode =
   result = nnkCurly.newTree
   for x in s:
     result.add newLit(x)
@@ -824,7 +823,7 @@ proc newLit*[T](s: set[T]): NimNode {.compileTime.} =
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
   ## See `typetraits.isNamedTuple`
 
-proc newLit*[T: tuple](arg: T): NimNode {.compileTime.} =
+proc newLit*[T: tuple](arg: T): NimNode =
   ## use -d:nimHasWorkaround14720 to restore behavior prior to PR, forcing
   ## a named tuple even when `arg` is unnamed.
   result = nnkTupleConstr.newTree
@@ -835,7 +834,7 @@ proc newLit*[T: tuple](arg: T): NimNode {.compileTime.} =
     for b in arg.fields:
       result.add newLit(b)
 
-proc nestList*(op: NimNode; pack: NimNode): NimNode {.compileTime.} =
+proc nestList*(op: NimNode; pack: NimNode): NimNode =
   ## Nests the list `pack` into a tree of call expressions:
   ## `[a, b, c]` is transformed into `op(a, op(c, d))`.
   ## This is also known as fold expression.
@@ -845,7 +844,7 @@ proc nestList*(op: NimNode; pack: NimNode): NimNode {.compileTime.} =
   for i in countdown(pack.len - 2, 0):
     result = newCall(op, pack[i], result)
 
-proc nestList*(op: NimNode; pack: NimNode; init: NimNode): NimNode {.compileTime.} =
+proc nestList*(op: NimNode; pack: NimNode; init: NimNode): NimNode =
   ## Nests the list `pack` into a tree of call expressions:
   ## `[a, b, c]` is transformed into `op(a, op(c, d))`.
   ## This is also known as fold expression.
@@ -887,21 +886,21 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
   if isLisp:
     res.add(")")
 
-proc treeRepr*(n: NimNode): string {.compileTime, benign.} =
+proc treeRepr*(n: NimNode): string {.benign.} =
   ## Convert the AST `n` to a human-readable tree-like string.
   ##
   ## See also `repr`, `lispRepr`, and `astGenRepr`.
   result = ""
   n.treeTraverse(result, isLisp = false, indented = true)
 
-proc lispRepr*(n: NimNode; indented = false): string {.compileTime, benign.} =
+proc lispRepr*(n: NimNode; indented = false): string {.benign.} =
   ## Convert the AST `n` to a human-readable lisp-like string.
   ##
   ## See also `repr`, `treeRepr`, and `astGenRepr`.
   result = ""
   n.treeTraverse(result, isLisp = true, indented = indented)
 
-proc astGenRepr*(n: NimNode): string {.compileTime, benign.} =
+proc astGenRepr*(n: NimNode): string {.benign.} =
   ## Convert the AST `n` to the code required to generate that AST.
   ##
   ## See also `repr`, `treeRepr`, and `lispRepr`.
@@ -1020,56 +1019,56 @@ macro dumpAstGen*(s: untyped): untyped = echo s.astGenRepr
   ##
   ## Also see `dumpTree` and `dumpLisp`.
 
-proc newEmptyNode*(): NimNode {.compileTime, noSideEffect.} =
+proc newEmptyNode*(): NimNode {.noSideEffect.} =
   ## Create a new empty node.
   result = newNimNode(nnkEmpty)
 
-proc newStmtList*(stmts: varargs[NimNode]): NimNode {.compileTime.}=
+proc newStmtList*(stmts: varargs[NimNode]): NimNode=
   ## Create a new statement list.
   result = newNimNode(nnkStmtList).add(stmts)
 
-proc newPar*(exprs: varargs[NimNode]): NimNode {.compileTime.}=
+proc newPar*(exprs: varargs[NimNode]): NimNode=
   ## Create a new parentheses-enclosed expression.
   newNimNode(nnkPar).add(exprs)
 
-proc newBlockStmt*(label, body: NimNode): NimNode {.compileTime.} =
+proc newBlockStmt*(label, body: NimNode): NimNode =
   ## Create a new block statement with label.
   return newNimNode(nnkBlockStmt).add(label, body)
 
-proc newBlockStmt*(body: NimNode): NimNode {.compileTime.} =
+proc newBlockStmt*(body: NimNode): NimNode =
   ## Create a new block: stmt.
   return newNimNode(nnkBlockStmt).add(newEmptyNode(), body)
 
-proc newVarStmt*(name, value: NimNode): NimNode {.compileTime.} =
+proc newVarStmt*(name, value: NimNode): NimNode =
   ## Create a new var stmt.
   return newNimNode(nnkVarSection).add(
     newNimNode(nnkIdentDefs).add(name, newNimNode(nnkEmpty), value))
 
-proc newLetStmt*(name, value: NimNode): NimNode {.compileTime.} =
+proc newLetStmt*(name, value: NimNode): NimNode =
   ## Create a new let stmt.
   return newNimNode(nnkLetSection).add(
     newNimNode(nnkIdentDefs).add(name, newNimNode(nnkEmpty), value))
 
-proc newConstStmt*(name, value: NimNode): NimNode {.compileTime.} =
+proc newConstStmt*(name, value: NimNode): NimNode =
   ## Create a new const stmt.
   newNimNode(nnkConstSection).add(
     newNimNode(nnkConstDef).add(name, newNimNode(nnkEmpty), value))
 
-proc newAssignment*(lhs, rhs: NimNode): NimNode {.compileTime.} =
+proc newAssignment*(lhs, rhs: NimNode): NimNode =
   return newNimNode(nnkAsgn).add(lhs, rhs)
 
-proc newDotExpr*(a, b: NimNode): NimNode {.compileTime.} =
+proc newDotExpr*(a, b: NimNode): NimNode =
   ## Create new dot expression.
   ## a.dot(b) -> `a.b`
   return newNimNode(nnkDotExpr).add(a, b)
 
-proc newColonExpr*(a, b: NimNode): NimNode {.compileTime.} =
+proc newColonExpr*(a, b: NimNode): NimNode =
   ## Create new colon expression.
   ## newColonExpr(a, b) -> `a: b`
   newNimNode(nnkExprColonExpr).add(a, b)
 
 proc newIdentDefs*(name, kind: NimNode;
-                   default = newEmptyNode()): NimNode {.compileTime.} =
+                   default = newEmptyNode()): NimNode =
   ## Creates a new `nnkIdentDefs` node of a specific kind and value.
   ##
   ## `nnkIdentDefs` need to have at least three children, but they can have
@@ -1100,11 +1099,11 @@ proc newIdentDefs*(name, kind: NimNode;
   ##       newStrLitNode("Hello"))
   newNimNode(nnkIdentDefs).add(name, kind, default)
 
-proc newNilLit*(): NimNode {.compileTime.} =
+proc newNilLit*(): NimNode =
   ## New nil literal shortcut.
   result = newNimNode(nnkNilLit)
 
-proc last*(node: NimNode): NimNode {.compileTime.} = node[node.len-1]
+proc last*(node: NimNode): NimNode = node[node.len-1]
   ## Return the last item in nodes children. Same as `node[^1]`.
 
 
@@ -1115,7 +1114,7 @@ const
   CallNodes* = {nnkCall, nnkInfix, nnkPrefix, nnkPostfix, nnkCommand,
     nnkCallStrLit, nnkHiddenCallConv}
 
-proc expectKind*(n: NimNode; k: set[NimNodeKind]) {.compileTime.} =
+proc expectKind*(n: NimNode; k: set[NimNodeKind]) =
   ## Checks that `n` is of kind `k`. If this is not the case,
   ## compilation aborts with an error message. This is useful for writing
   ## macros that check the AST that is passed to them.
@@ -1125,7 +1124,7 @@ proc newProc*(name = newEmptyNode();
               params: openArray[NimNode] = [newEmptyNode()];
               body: NimNode = newStmtList();
               procType = nnkProcDef;
-              pragmas: NimNode = newEmptyNode()): NimNode {.compileTime.} =
+              pragmas: NimNode = newEmptyNode()): NimNode =
   ## Shortcut for creating a new proc.
   ##
   ## The `params` array must start with the return type of the proc,
@@ -1142,8 +1141,7 @@ proc newProc*(name = newEmptyNode();
     newEmptyNode(),
     body)
 
-proc newIfStmt*(branches: varargs[tuple[cond, body: NimNode]]):
-                NimNode {.compileTime.} =
+proc newIfStmt*(branches: varargs[tuple[cond, body: NimNode]]): NimNode =
   ## Constructor for `if` statements.
   ##
   ## .. code-block:: nim
@@ -1160,7 +1158,7 @@ proc newIfStmt*(branches: varargs[tuple[cond, body: NimNode]]):
     result.add(newTree(nnkElifBranch, i.cond, i.body))
 
 proc newEnum*(name: NimNode, fields: openArray[NimNode],
-              public, pure: bool): NimNode {.compileTime.} =
+              public, pure: bool): NimNode =
 
   ## Creates a new enum. `name` must be an ident. Fields are allowed to be
   ## either idents or EnumFieldDef
@@ -1203,7 +1201,7 @@ proc newEnum*(name: NimNode, fields: openArray[NimNode],
 
   return typeSect
 
-proc copyChildrenTo*(src, dest: NimNode) {.compileTime.}=
+proc copyChildrenTo*(src, dest: NimNode) =
   ## Copy all children from `src` to `dest`.
   for i in 0 ..< src.len:
     dest.add src[i].copyNimTree
@@ -1211,7 +1209,7 @@ proc copyChildrenTo*(src, dest: NimNode) {.compileTime.}=
 template expectRoutine(node: NimNode) =
   expectKind(node, RoutineNodes)
 
-proc name*(someProc: NimNode): NimNode {.compileTime.} =
+proc name*(someProc: NimNode): NimNode =
   someProc.expectRoutine
   result = someProc[0]
   if result.kind == nnkPostfix:
@@ -1222,21 +1220,21 @@ proc name*(someProc: NimNode): NimNode {.compileTime.} =
   elif result.kind == nnkAccQuoted:
     result = result[0]
 
-proc `name=`*(someProc: NimNode; val: NimNode) {.compileTime.} =
+proc `name=`*(someProc: NimNode; val: NimNode) =
   someProc.expectRoutine
   if someProc[0].kind == nnkPostfix:
     someProc[0][1] = val
   else: someProc[0] = val
 
-proc params*(someProc: NimNode): NimNode {.compileTime.} =
+proc params*(someProc: NimNode): NimNode =
   someProc.expectRoutine
   result = someProc[3]
-proc `params=`* (someProc: NimNode; params: NimNode) {.compileTime.}=
+proc `params=`* (someProc: NimNode; params: NimNode) =
   someProc.expectRoutine
   expectKind(params, nnkFormalParams)
   someProc[3] = params
 
-proc pragma*(someProc: NimNode): NimNode {.compileTime.} =
+proc pragma*(someProc: NimNode): NimNode =
   ## Get the pragma of a proc type.
   ## These will be expanded.
   if someProc.kind == nnkProcTy:
@@ -1244,7 +1242,7 @@ proc pragma*(someProc: NimNode): NimNode {.compileTime.} =
   else:
     someProc.expectRoutine
     result = someProc[4]
-proc `pragma=`*(someProc: NimNode; val: NimNode) {.compileTime.}=
+proc `pragma=`*(someProc: NimNode; val: NimNode) =
   ## Set the pragma of a proc type.
   expectKind(val, {nnkEmpty, nnkPragma})
   if someProc.kind == nnkProcTy:
@@ -1253,7 +1251,7 @@ proc `pragma=`*(someProc: NimNode; val: NimNode) {.compileTime.}=
     someProc.expectRoutine
     someProc[4] = val
 
-proc addPragma*(someProc, pragma: NimNode) {.compileTime.} =
+proc addPragma*(someProc, pragma: NimNode) =
   ## Adds pragma to routine definition.
   someProc.expectKind(RoutineNodes + {nnkProcTy})
   var pragmaNode = someProc.pragma
@@ -1265,7 +1263,7 @@ proc addPragma*(someProc, pragma: NimNode) {.compileTime.} =
 template badNodeKind(n, f) =
   error("Invalid node kind " & $n.kind & " for macros.`" & $f & "`", n)
 
-proc body*(someProc: NimNode): NimNode {.compileTime.} =
+proc body*(someProc: NimNode): NimNode =
   case someProc.kind:
   of RoutineNodes:
     return someProc[6]
@@ -1276,7 +1274,7 @@ proc body*(someProc: NimNode): NimNode {.compileTime.} =
   else:
     badNodeKind someProc, "body"
 
-proc `body=`*(someProc: NimNode, val: NimNode) {.compileTime.} =
+proc `body=`*(someProc: NimNode, val: NimNode) =
   case someProc.kind
   of RoutineNodes:
     someProc[6] = val
@@ -1287,7 +1285,7 @@ proc `body=`*(someProc: NimNode, val: NimNode) {.compileTime.} =
   else:
     badNodeKind someProc, "body="
 
-proc basename*(a: NimNode): NimNode {.raises: [].} =
+proc basename*(a: NimNode): NimNode =
   ## Pull an identifier from prefix/postfix expressions.
   case a.kind
   of nnkIdent: result = a
@@ -1297,7 +1295,7 @@ proc basename*(a: NimNode): NimNode {.raises: [].} =
     error("Do not know how to get basename of (" & treeRepr(a) & ")\n" &
       repr(a), a)
 
-proc `$`*(node: NimNode): string {.compileTime.} =
+proc `$`*(node: NimNode): string =
   ## Get the string of an identifier node.
   case node.kind
   of nnkPostfix:
@@ -1340,7 +1338,7 @@ template findChild*(n: NimNode; cond: untyped): NimNode {.dirty.} =
         break
     res
 
-proc insert*(a: NimNode; pos: int; b: NimNode) {.compileTime.} =
+proc insert*(a: NimNode; pos: int; b: NimNode) =
   ## Insert node `b` into node `a` at `pos`.
   if len(a)-1 < pos:
     # add some empty nodes first
@@ -1355,7 +1353,7 @@ proc insert*(a: NimNode; pos: int; b: NimNode) {.compileTime.} =
       a[i + 1] = a[i]
     a[pos] = b
 
-proc `basename=`*(a: NimNode; val: string) {.compileTime.}=
+proc `basename=`*(a: NimNode; val: string) =
   case a.kind
   of nnkIdent:
     a.strVal = val
@@ -1366,32 +1364,29 @@ proc `basename=`*(a: NimNode; val: string) {.compileTime.}=
     error("Do not know how to get basename of (" & treeRepr(a) & ")\n" &
       repr(a), a)
 
-proc postfix*(node: NimNode; op: string): NimNode {.compileTime.} =
+proc postfix*(node: NimNode; op: string): NimNode =
   newNimNode(nnkPostfix).add(ident(op), node)
 
-proc prefix*(node: NimNode; op: string): NimNode {.compileTime.} =
+proc prefix*(node: NimNode; op: string): NimNode =
   newNimNode(nnkPrefix).add(ident(op), node)
 
 proc infix*(a: NimNode; op: string;
-            b: NimNode): NimNode {.compileTime.} =
+            b: NimNode): NimNode =
   newNimNode(nnkInfix).add(ident(op), a, b)
 
-proc unpackPostfix*(node: NimNode): tuple[node: NimNode; op: string] {.
-  compileTime.} =
+proc unpackPostfix*(node: NimNode): tuple[node: NimNode; op: string] =
   node.expectKind nnkPostfix
   result = (node[1], $node[0])
 
-proc unpackPrefix*(node: NimNode): tuple[node: NimNode; op: string] {.
-  compileTime.} =
+proc unpackPrefix*(node: NimNode): tuple[node: NimNode; op: string] =
   node.expectKind nnkPrefix
   result = (node[1], $node[0])
 
-proc unpackInfix*(node: NimNode): tuple[left: NimNode; op: string;
-                                        right: NimNode] {.compileTime.} =
+proc unpackInfix*(node: NimNode): tuple[left: NimNode; op: string; right: NimNode] =
   expectKind(node, nnkInfix)
   result = (node[1], $node[0], node[2])
 
-proc copy*(node: NimNode): NimNode {.compileTime.} =
+proc copy*(node: NimNode): NimNode =
   ## An alias for `copyNimTree<#copyNimTree,NimNode>`_.
   return node.copyNimTree()
 
@@ -1416,14 +1411,14 @@ proc eqIdent*(a: NimNode; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
   ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
   ## these nodes will be unwrapped.
 
-proc expectIdent*(n: NimNode, name: string) {.compileTime, since: (1,1).} =
+proc expectIdent*(n: NimNode, name: string) {.since: (1,1).} =
   ## Check that `eqIdent(n,name)` holds true. If this is not the
   ## case, compilation aborts with an error message. This is useful
   ## for writing macros that check the AST that is passed to them.
   if not eqIdent(n, name):
     error("Expected identifier to be `" & name & "` here", n)
 
-proc hasArgOfName*(params: NimNode; name: string): bool {.compileTime.}=
+proc hasArgOfName*(params: NimNode; name: string): bool=
   ## Search `nnkFormalParams` for an argument.
   expectKind(params, nnkFormalParams)
   for i in 1..<params.len:
@@ -1431,7 +1426,7 @@ proc hasArgOfName*(params: NimNode; name: string): bool {.compileTime.}=
       if name.eqIdent($params[i][j]):
         return true
 
-proc addIdentIfAbsent*(dest: NimNode, ident: string) {.compileTime.} =
+proc addIdentIfAbsent*(dest: NimNode, ident: string) =
   ## Add `ident` to `dest` if it is not present. This is intended for use
   ## with pragmas.
   for node in dest.children:
@@ -1443,7 +1438,7 @@ proc addIdentIfAbsent*(dest: NimNode, ident: string) {.compileTime.} =
     else: discard
   dest.add(ident(ident))
 
-proc boolVal*(n: NimNode): bool {.compileTime, noSideEffect.} =
+proc boolVal*(n: NimNode): bool {.noSideEffect.} =
   if n.kind == nnkIntLit: n.intVal != 0
   else: n == bindSym"true" # hacky solution for now
 

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -53,8 +53,7 @@ template createCb(retFutureSym, iteratorNameSym,
         retFutureSym.fail(getCurrentException())
   identName()
 
-proc createFutureVarCompletions(futureVarIdents: seq[NimNode],
-    fromNode: NimNode): NimNode {.compileTime.} =
+proc createFutureVarCompletions(futureVarIdents: seq[NimNode], fromNode: NimNode): NimNode =
   result = newNimNode(nnkStmtList, fromNode)
   # Add calls to complete each FutureVar parameter.
   for ident in futureVarIdents:
@@ -71,7 +70,7 @@ proc createFutureVarCompletions(futureVarIdents: seq[NimNode],
 
 proc processBody(node, retFutureSym: NimNode,
                  subTypeIsVoid: bool,
-                 futureVarIdents: seq[NimNode]): NimNode {.compileTime.} =
+                 futureVarIdents: seq[NimNode]): NimNode =
   #echo(node.treeRepr)
   result = node
   case node.kind
@@ -107,7 +106,7 @@ proc processBody(node, retFutureSym: NimNode,
 
   # echo result.repr
 
-proc getName(node: NimNode): string {.compileTime.} =
+proc getName(node: NimNode): string =
   case node.kind
   of nnkPostfix:
     return node[1].strVal
@@ -118,7 +117,7 @@ proc getName(node: NimNode): string {.compileTime.} =
   else:
     error("Unknown name.", node)
 
-proc getFutureVarIdents(params: NimNode): seq[NimNode] {.compileTime.} =
+proc getFutureVarIdents(params: NimNode): seq[NimNode] =
   result = @[]
   for i in 1 ..< len(params):
     expectKind(params[i], nnkIdentDefs)
@@ -130,7 +129,7 @@ proc getFutureVarIdents(params: NimNode): seq[NimNode] {.compileTime.} =
 proc isInvalidReturnType(typeName: string): bool =
   return typeName notin ["Future"] #, "FutureStream"]
 
-proc verifyReturnType(typeName: string, node: NimNode = nil) {.compileTime.} =
+proc verifyReturnType(typeName: string, node: NimNode = nil) =
   if typeName.isInvalidReturnType:
     error("Expected return type of 'Future' got '$1'" %
           typeName, node)
@@ -144,7 +143,7 @@ template await*[T](f: Future[T]): auto {.used.} =
   yield internalTmpFuture
   (cast[typeof(f)](internalTmpFuture)).read()
 
-proc asyncSingleProc(prc: NimNode): NimNode {.compileTime.} =
+proc asyncSingleProc(prc: NimNode): NimNode =
   ## This macro transforms a single procedure into a closure iterator.
   ## The `async` macro supports a stmtList holding multiple async procedures.
   if prc.kind == nnkProcTy:

--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -56,7 +56,7 @@ const
   ariaAttr* = " role "                           ## HTML DOM Aria Attributes
   commonAttr* = coreAttr & eventAttr & ariaAttr  ## HTML DOM Common Attributes
 
-proc getIdent(e: NimNode): string {.compileTime.} =
+proc getIdent(e: NimNode): string =
   case e.kind
   of nnkIdent:
     result = e.strVal.normalize
@@ -75,7 +75,7 @@ proc delete[T](s: var seq[T], attr: T): bool =
     result = true
 
 proc xmlCheckedTag*(argsList: NimNode, tag: string, optAttr = "", reqAttr = "",
-    isLeaf = false): NimNode {.compileTime.} =
+    isLeaf = false): NimNode =
   ## use this procedure to define a new XML tag
 
   # copy the attributes; when iterating over them these lists

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -398,7 +398,7 @@ proc `%`*(o: enum): JsonNode =
   ## string. Creates a new `JString JsonNode`.
   result = %($o)
 
-proc toJsonImpl(x: NimNode): NimNode {.compileTime.} =
+proc toJsonImpl(x: NimNode): NimNode =
   case x.kind
   of nnkBracket: # array
     if x.len == 0: return newCall(bindSym"newJArray")
@@ -1169,7 +1169,7 @@ when defined(nimFixedForwardGeneric):
     if typeExpr.kind == nnkTupleConstr:
       error("Use a named tuple instead of: " & typeExpr.repr, lineinfoNode)
 
-  proc foldObjectBody(dst, typeNode, tmpSym, jsonNode, jsonPath, originalJsonPathLen: NimNode): void {.compileTime.} =
+  proc foldObjectBody(dst, typeNode, tmpSym, jsonNode, jsonPath, originalJsonPathLen: NimNode) =
     case typeNode.kind
     of nnkEmpty:
       discard

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -19,7 +19,7 @@ proc checkPragma(ex, prag: var NimNode) =
       prag = ex[1]
       ex = ex[0]
 
-proc createProcType(p, b: NimNode): NimNode {.compileTime.} =
+proc createProcType(p, b: NimNode): NimNode =
   result = newNimNode(nnkProcTy)
   var
     formalParams = newNimNode(nnkFormalParams).add(b)

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -744,7 +744,7 @@ proc findAll*(n: XmlNode, tag: string, caseInsensitive = false): seq[XmlNode] =
   newSeq(result, 0)
   findAll(n, tag, result, caseInsensitive)
 
-proc xmlConstructor(a: NimNode): NimNode {.compileTime.} =
+proc xmlConstructor(a: NimNode): NimNode =
   if a.kind == nnkCall:
     result = newCall("newXmlTree", toStrLit(a[0]))
     var attrs = newNimNode(nnkBracket, a)


### PR DESCRIPTION
refs:
```
  of mPNimrodNode:
    incl m.typ.flags, tfTriggersCompileTime
    incl m.typ.flags, tfCheckedForDestructor

  if tfTriggersCompileTime in result.typ.flags:
    incl(result.flags, sfCompileTime)
```
