### PR TITLE
fix #17467 1st call to rand is now non-skewed; allow seed == 0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -119,7 +119,7 @@
 
 - Added `random.initRand()` overload with no argument which uses the current time as a seed.
 
-- `random.initRand(seed)` now allows `seed == 0`
+- `random.initRand(seed)` now allows `seed == 0`.
 
 - `random.initRand(seed)` now produces non-skewed values for the 1st call to rand() after
   initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore

--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,10 @@
 - Nim compiler now adds ASCII unit separator `\31` before a newline for every generated
   message (potentially multiline), so tooling can tell when messages start and end.
 
+- `random.initRand(seed)` now produces non-skewed values for the 1st call to `rand()` after
+  initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
+  previous behavior for a transition time, see PR #17467.
+
 
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`
@@ -120,10 +124,6 @@
 - Added `random.initRand()` overload with no argument which uses the current time as a seed.
 
 - `random.initRand(seed)` now allows `seed == 0`.
-
-- `random.initRand(seed)` now produces non-skewed values for the 1st call to rand() after
-  initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
-  previous behavior for a transition time, see PR #17467.
 
 - Added `std/sysrand` module to get random numbers from a secure source
   provided by the operating system.

--- a/changelog.md
+++ b/changelog.md
@@ -117,6 +117,17 @@
 - Added `randState` template that exposes the default random number generator.
   Useful for library authors.
 
+- Added `random.initRand()` overload with no argument which uses the current time as a seed.
+
+- `random.initRand(seed)` now allows `seed == 0`
+
+- `random.initRand(seed)` now produces non-skewed values for the 1st call to rand() after
+  initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
+  previous behavior for a transition time, see PR #17467.
+
+- Added `std/sysrand` module to get random numbers from a secure source
+  provided by the operating system.
+
 - Added `std/enumutils` module. Added `genEnumCaseStmt` macro that generates case statement to parse string to enum.
   Added `items` for enums with holes.
   Added `symbolName` to return the enum symbol name ignoring the human readable name.
@@ -203,9 +214,6 @@
 
 - Deprecated `any`. See https://github.com/nim-lang/RFCs/issues/281
 
-- Added `std/sysrand` module to get random numbers from a secure source
-  provided by the operating system.
-
 - Added optional `options` argument to `copyFile`, `copyFileToDir`, and
   `copyFileWithPermissions`. By default, on non-Windows OSes, symlinks are
   followed (copy files symlinks point to); on Windows, `options` argument is
@@ -222,8 +230,6 @@
 
 - Added `os.isAdmin` to tell whether the caller's process is a member of the
   Administrators local group (on Windows) or a root (on POSIX).
-
-- Added `random.initRand()` overload with no argument which uses the current time as a seed.
 
 - Added experimental `linenoise.readLineStatus` to get line and status (e.g. ctrl-D or ctrl-C).
 

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -135,9 +135,8 @@ proc next*(r: var Rand): uint64 =
   ## * `skipRandomNumbers proc<#skipRandomNumbers,Rand>`_
   runnableExamples:
     var r = initRand(2019)
-    doAssert r.next() == 138_744_656_611_299'u64
-    doAssert r.next() == 979_810_537_855_049_344'u64
-    doAssert r.next() == 3_628_232_584_225_300_704'u64
+    assert r.next() == 13223559681708962501'u64 # implementation defined
+    assert r.next() == 7229677234260823147'u64 # ditto
 
   let s0 = r.a0
   var s1 = r.a1
@@ -216,9 +215,10 @@ proc rand*(r: var Rand; max: Natural): int {.benign.} =
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
   runnableExamples:
     var r = initRand(123)
-    doAssert r.rand(100) == 0
-    doAssert r.rand(100) == 96
-    doAssert r.rand(100) == 66
+    echo r.rand(100)
+    # doAssert r.rand(100) == 0
+    # doAssert r.rand(100) == 96
+    # doAssert r.rand(100) == 66
 
   if max == 0: return
   while true:

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -549,7 +549,8 @@ proc initRand*(seed: int64): Rand =
   ##
   ## Providing a specific seed will produce the same results for that seed each time.
   ##
-  ## The resulting state is independent of the default RNG's state.
+  ## The resulting state is independent of the default RNG's state. When `seed == 0`,
+  ## we internally set the seed to an implementation defined non-zero value.
   ##
   ## **See also:**
   ## * `initRand proc<#initRand>`_ that uses the current time
@@ -559,10 +560,10 @@ proc initRand*(seed: int64): Rand =
     from std/times import getTime, toUnix, nanosecond
 
     var r1 = initRand(123)
-
     let now = getTime()
     var r2 = initRand(now.toUnix * 1_000_000_000 + now.nanosecond)
-  let seed = if seed != 0: seed else: 1 # because 0 is a fixed point
+  const seedFallback0 = int32.high # arbitrary
+  let seed = if seed != 0: seed else: seedFallback0 # because 0 is a fixed point
   result.a0 = Ui(seed shr 16)
   result.a1 = Ui(seed and 0xffff)
   when not defined(nimLegacyRandomInitRand):

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -133,7 +133,7 @@ proc next*(r: var Rand): uint64 =
   ##   that accepts a slice
   ## * `rand proc<#rand,typedesc[T]>`_ that accepts an integer or range type
   ## * `skipRandomNumbers proc<#skipRandomNumbers,Rand>`_
-  runnableExamples:
+  runnableExamples("-r:off"):
     var r = initRand(2019)
     assert r.next() == 13223559681708962501'u64 # implementation defined
     assert r.next() == 7229677234260823147'u64 # ditto
@@ -349,7 +349,8 @@ proc rand*[T: SomeInteger](t: typedesc[T]): T =
       assert rand(int8) == -42
       assert rand(uint32) == 578980729'u32
       assert rand(range[1..16]) == 11
-  # pending csources >= 1.4.0, use `runnableExamples("-r:off")` instead (a strang error)
+  # pending csources >= 1.4.0 or fixing https://github.com/timotheecour/Nim/issues/251#issuecomment-831599772,
+  # use `runnableExamples("-r:off")` instead of `if false`
   when T is range:
     result = rand(state, low(T)..high(T))
   else:

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -565,7 +565,10 @@ proc initRand*(seed: int64): Rand =
   let seed = if seed != 0: seed else: 1 # because 0 is a fixed point
   result.a0 = Ui(seed shr 16)
   result.a1 = Ui(seed and 0xffff)
-  skipRandomNumbers(result)
+  when not defined(nimLegacyRandomInitRand):
+    # calling `discard next(result)` (even a few times) would still produce
+    # skewed numbers for the 1st call to `rand()`.
+    skipRandomNumbers(result)
   discard next(result)
 
 proc randomize*(seed: int64) {.benign.} =

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -547,8 +547,7 @@ proc gauss*(mu = 0.0, sigma = 1.0): float {.since: (1, 3).} =
 proc initRand*(seed: int64): Rand =
   ## Initializes a new `Rand <#Rand>`_ state using the given seed.
   ##
-  ## `seed` must not be zero. Providing a specific seed will produce
-  ## the same results for that seed each time.
+  ## Providing a specific seed will produce the same results for that seed each time.
   ##
   ## The resulting state is independent of the default RNG's state.
   ##
@@ -563,17 +562,16 @@ proc initRand*(seed: int64): Rand =
 
     let now = getTime()
     var r2 = initRand(now.toUnix * 1_000_000_000 + now.nanosecond)
-
-  doAssert seed != 0 # 0 causes `rand(int)` to always return 0 for example.
+  let seed = if seed != 0: seed else: 1 # because 0 is a fixed point
   result.a0 = Ui(seed shr 16)
   result.a1 = Ui(seed and 0xffff)
+  skipRandomNumbers(result)
   discard next(result)
 
 proc randomize*(seed: int64) {.benign.} =
   ## Initializes the default random number generator with the given seed.
   ##
-  ## `seed` must not be zero. Providing a specific seed will produce
-  ## the same results for that seed each time.
+  ## Providing a specific seed will produce the same results for that seed each time.
   ##
   ## **See also:**
   ## * `initRand proc<#initRand,int64>`_ that initializes a Rand state

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -79,7 +79,7 @@ pkg "itertools", "nim doc src/itertools.nim"
 pkg "iterutils"
 pkg "jstin"
 pkg "karax", "nim c -r tests/tester.nim"
-pkg "kdtree", "nimble test", "https://github.com/jblindsay/kdtree"
+pkg "kdtree", "nimble test", "https://github.com/jblindsay/kdtree", allowFailure = true # pending hard-coded rand tests
 pkg "loopfusion"
 pkg "macroutils"
 pkg "manu"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -79,7 +79,7 @@ pkg "itertools", "nim doc src/itertools.nim"
 pkg "iterutils"
 pkg "jstin"
 pkg "karax", "nim c -r tests/tester.nim"
-pkg "kdtree", "nimble test", "https://github.com/jblindsay/kdtree", allowFailure = true # pending hard-coded rand tests
+pkg "kdtree", "nimble test -d:nimLegacyRandomInitRand", "https://github.com/jblindsay/kdtree"
 pkg "loopfusion"
 pkg "macroutils"
 pkg "manu"

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -179,7 +179,7 @@ block:
   var r2 = initRand(124)
   doAssert r1.rand(1.0) != r2.rand(1.0)
 
-block: # bug https://github.com/timotheecour/Nim/issues/435
+block: # bug #17467
   let n = 1000
   for i in -n .. n:
     var r = initRand(i)

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -1,5 +1,5 @@
 discard """
-  joinable: false
+  joinable: false # to avoid messing with global rand state
   targets: "c js"
 """
 
@@ -37,11 +37,14 @@ main()
 
 block:
   when not defined(js):
-    doAssert almostEqual(rand(12.5), 4.012897747078944)
-    doAssert almostEqual(rand(2233.3322), 879.702755321298)
+    doAssert almostEqual(rand(12.5), 7.355175342026979)
+    doAssert almostEqual(rand(2233.3322), 499.342386778917)
 
   type DiceRoll = range[0..6]
-  doAssert rand(DiceRoll).int == 4
+  when not defined(js):
+    doAssert rand(DiceRoll).int == 3
+  else:
+    doAssert rand(DiceRoll).int == 6
 
 var rs: RunningStat
 for j in 1..5:
@@ -164,3 +167,23 @@ block: # random sample
       let stdDev = sqrt(n * p * (1.0 - p))
       # NOTE: like unnormalized int CDF test, P(wholeTestFails) =~ 0.01.
       doAssert abs(float(histo[values[i]]) - expected) <= 3.0 * stdDev
+
+block:
+  # 0 is a valid seed
+  var r = initRand(0)
+  doAssert r.rand(1.0) != r.rand(1.0)
+  r = initRand(10)
+  doAssert r.rand(1.0) != r.rand(1.0)
+  # changing the seed changes the sequence
+  var r1 = initRand(123)
+  var r2 = initRand(124)
+  doAssert r1.rand(1.0) != r2.rand(1.0)
+
+block: # bug https://github.com/timotheecour/Nim/issues/435
+  let n = 1000
+  for i in -n .. n:
+    var r = initRand(i)
+    let x = r.rand(1.0)
+    doAssert x > 1e-4, $(x, i)
+      # This used to fail for each i in 0..<26844, i.e. the 1st produced value
+      # was predictable and < 1e-4, skewing distributions.


### PR DESCRIPTION
* fix #17467: 1st call to rand is now non-skewed; this avoids skewing distributions
* use `-d:nimLegacyRandomInitRand` for restoring previous behavior, for a transition time
* allow passing arbitrary seed including 0

* (EDIT) fixes https://github.com/nim-lang/Nim/issues/8589 (see https://github.com/nim-lang/Nim/issues/8589#issuecomment-838612351)
* (EDIT) fixes https://github.com/nim-lang/Nim/issues/18658