### PR TITLE
RST: enable parsing of prefix roles (ref #17340)

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -285,6 +285,15 @@ or
 
 the first is preferred.
 
+When you specify an *RST role* (highlighting/interpretation marker) do it
+in the postfix form for uniformity, that is after \`text in backticks\`.
+For example an ``:idx:`` role for referencing a topic ("SQLite" in the
+example below) from `Nim Index`_ can be used in doc comment this way:
+
+.. code-block:: nim
+  ## A higher level `SQLite`:idx: database wrapper.
+
+.. _`Nim Index`: https://nim-lang.org/docs/theindex.html
 
 Best practices
 ==============

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1682,7 +1682,7 @@ proc whichSection(p: RstParser): RstNodeKind =
     elif predNL(p) and
         currentTok(p).symbol in ["+", "*", "-"] and nextTok(p).kind == tkWhite:
       result = rnBulletList
-    elif match(p, p.idx, ":w: ") and predNL(p):
+    elif match(p, p.idx, ":w:E") and predNL(p):
       # (currentTok(p).symbol == ":")
       result = rnFieldList
     elif match(p, p.idx, "(e) ") or match(p, p.idx, "e) ") or

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1319,7 +1319,7 @@ proc parseInline(p: var RstParser, father: PRstNode) =
       father.add(n)
     elif match(p, p.idx, ":w:") and p.tok[p.idx+3].symbol == "`":
       let k = whichRole(nextTok(p).symbol)
-      var n = newRstNode(k)
+      let n = newRstNode(k)
       inc p.idx, 3
       parseUntil(p, n, "`", false) # bug #17260
       father.add(n)

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -68,7 +68,7 @@
 ##     substitution references, standalone hyperlinks,
 ##     internal links (inline and outline)
 ##   + \`interpreted text\` with roles ``:literal:``, ``:strong:``,
-##     ``emphasis``, ``:sub:``/``:subscript:``, ``:sup:``/``:supscript:``
+##     ``emphasis``, ``:sub:``/``:subscript:``, ``:sup:``/``:superscript:``
 ##     (see `RST roles list`_ for description).
 ##   + inline internal targets
 ##
@@ -1021,6 +1021,16 @@ proc fixupEmbeddedRef(n, a, b: PRstNode) =
   for i in countup(0, sep - incr): a.add(n.sons[i])
   for i in countup(sep + 1, n.len - 2): b.add(n.sons[i])
 
+proc whichRole(sym: string): RstNodeKind =
+  case sym
+  of "idx": result = rnIdx
+  of "literal": result = rnInlineLiteral
+  of "strong": result = rnStrongEmphasis
+  of "emphasis": result = rnEmphasis
+  of "sub", "subscript": result = rnSub
+  of "sup", "superscript": result = rnSup
+  else: result = rnGeneralRole
+
 proc parsePostfix(p: var RstParser, n: PRstNode): PRstNode =
   var newKind = n.kind
   var newSons = n.sons
@@ -1045,22 +1055,8 @@ proc parsePostfix(p: var RstParser, n: PRstNode): PRstNode =
     result = newRstNode(newKind, newSons)
   elif match(p, p.idx, ":w:"):
     # a role:
-    if nextTok(p).symbol == "idx":
-      newKind = rnIdx
-    elif nextTok(p).symbol == "literal":
-      newKind = rnInlineLiteral
-    elif nextTok(p).symbol == "strong":
-      newKind = rnStrongEmphasis
-    elif nextTok(p).symbol == "emphasis":
-      newKind = rnEmphasis
-    elif nextTok(p).symbol == "sub" or
-        nextTok(p).symbol == "subscript":
-      newKind = rnSub
-    elif nextTok(p).symbol == "sup" or
-        nextTok(p).symbol == "supscript":
-      newKind = rnSup
-    else:
-      newKind = rnGeneralRole
+    newKind = whichRole(nextTok(p).symbol)
+    if newKind == rnGeneralRole:
       let newN = newRstNode(rnInner, n.sons)
       newSons = @[newN, newLeaf(nextTok(p).symbol)]
     inc p.idx, 3
@@ -1320,6 +1316,12 @@ proc parseInline(p: var RstParser, father: PRstNode) =
     elif isInlineMarkupStart(p, "``"):
       var n = newRstNode(rnInlineLiteral)
       parseUntil(p, n, "``", false)
+      father.add(n)
+    elif match(p, p.idx, ":w:") and p.tok[p.idx+3].symbol == "`":
+      let k = whichRole(nextTok(p).symbol)
+      var n = newRstNode(k)
+      inc p.idx, 3
+      parseUntil(p, n, "`", false) # bug #17260
       father.add(n)
     elif isInlineMarkupStart(p, "`"):
       var n = newRstNode(rnInterpretedText)
@@ -1680,7 +1682,7 @@ proc whichSection(p: RstParser): RstNodeKind =
     elif predNL(p) and
         currentTok(p).symbol in ["+", "*", "-"] and nextTok(p).kind == tkWhite:
       result = rnBulletList
-    elif match(p, p.idx, ":w:") and predNL(p):
+    elif match(p, p.idx, ":w: ") and predNL(p):
       # (currentTok(p).symbol == ":")
       result = rnFieldList
     elif match(p, p.idx, "(e) ") or match(p, p.idx, "e) ") or

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -1361,6 +1361,14 @@ Test1
             """<tbody valign="top"><tr><th class="docinfo-name">field:</th>""" &
             """<td> text</td></tr>""" & "\n</tbody></table>")
 
+  test "Field list: body after newline":
+    let output = dedent """
+      :field:
+        text1""".toHtml
+    check "<table class=\"docinfo\"" in output
+    check ">field:</th>" in output
+    check "<td>text1</td>" in output
+
   test "Field list (incorrect)":
     let output = ":field:text".toHtml
     check(output == ":field:text")

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -1326,6 +1326,45 @@ Test1
           output)
     check("""<th align="left">-d</th><td align="left">option</td>""" in
           output)
+
+  test "Roles: subscript prefix/postfix":
+    let outputPrefix  = "See :subscript:`some text`.".toHtml
+    let outputPostfix = "See `some text`:subscript:.".toHtml
+    check(outputPrefix == outputPostfix)
+    check(outputPrefix == "See <sub>some text</sub>.")
+
+  test "Roles: correct parsing from beginning of line":
+    let output1 = """:superscript:`3`\ He is an isotope of helium.""".toHtml
+    check(output1 == "<sup>3</sup>He is an isotope of helium.")
+    let output2 = """:sup:`3`\ He is an isotope of helium.""".toHtml
+    let output3 = """`3`:sup:\ He is an isotope of helium.""".toHtml
+    let output4 = """`3`:superscript:\ He is an isotope of helium.""".toHtml
+    check(output2 == output1)
+    check(output3 == output1)
+    check(output4 == output1)
+
+  test "(not) Roles: check escaping 1":
+    let output1 = """See \:subscript:`some text`.""".toHtml
+    let output2 = """See :subscript\:`some text`.""".toHtml
+    check(output1 == output2)
+    check(output1 == """See :subscript:<tt class="docutils literal">""" &
+                     """<span class="pre">some text</span></tt>.""")
+
+  test "(not) Roles: check escaping 2":
+    let output = """See :subscript:\`some text\`.""".toHtml
+    check(output == "See :subscript:`some text`.")
+
+  test "Field list":
+    let output = ":field: text".toHtml
+    check(output == """<table class="docinfo" frame="void" rules="none">""" &
+            """<col class="docinfo-name" /><col class="docinfo-content" />""" &
+            """<tbody valign="top"><tr><th class="docinfo-name">field:</th>""" &
+            """<td> text</td></tr>""" & "\n</tbody></table>")
+
+  test "Field list (incorrect)":
+    let output = ":field:text".toHtml
+    check(output == ":field:text")
+
 suite "RST/Code highlight":
   test "Basic Python code highlight":
     let pythonCode = """

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -1328,35 +1328,30 @@ Test1
           output)
 
   test "Roles: subscript prefix/postfix":
-    let outputPrefix  = "See :subscript:`some text`.".toHtml
-    let outputPostfix = "See `some text`:subscript:.".toHtml
-    check(outputPrefix == outputPostfix)
-    check(outputPrefix == "See <sub>some text</sub>.")
+    let expected = "See <sub>some text</sub>."
+    check "See :subscript:`some text`.".toHtml == expected
+    check "See `some text`:subscript:.".toHtml == expected
 
   test "Roles: correct parsing from beginning of line":
-    let output1 = """:superscript:`3`\ He is an isotope of helium.""".toHtml
-    check(output1 == "<sup>3</sup>He is an isotope of helium.")
-    let output2 = """:sup:`3`\ He is an isotope of helium.""".toHtml
-    let output3 = """`3`:sup:\ He is an isotope of helium.""".toHtml
-    let output4 = """`3`:superscript:\ He is an isotope of helium.""".toHtml
-    check(output2 == output1)
-    check(output3 == output1)
-    check(output4 == output1)
+    let expected = "<sup>3</sup>He is an isotope of helium."
+    check """:superscript:`3`\ He is an isotope of helium.""".toHtml == expected
+    check """:sup:`3`\ He is an isotope of helium.""".toHtml == expected
+    check """`3`:sup:\ He is an isotope of helium.""".toHtml == expected
+    check """`3`:superscript:\ He is an isotope of helium.""".toHtml == expected
 
   test "(not) Roles: check escaping 1":
-    let output1 = """See \:subscript:`some text`.""".toHtml
-    let output2 = """See :subscript\:`some text`.""".toHtml
-    check(output1 == output2)
-    check(output1 == """See :subscript:<tt class="docutils literal">""" &
-                     """<span class="pre">some text</span></tt>.""")
+    let expected = """See :subscript:<tt class="docutils literal">""" &
+                   """<span class="pre">some text</span></tt>."""
+    check """See \:subscript:`some text`.""".toHtml == expected
+    check """See :subscript\:`some text`.""".toHtml == expected
 
   test "(not) Roles: check escaping 2":
-    let output = """See :subscript:\`some text\`.""".toHtml
-    check(output == "See :subscript:`some text`.")
+    check("""See :subscript:\`some text\`.""".toHtml ==
+          "See :subscript:`some text`.")
 
   test "Field list":
-    let output = ":field: text".toHtml
-    check(output == """<table class="docinfo" frame="void" rules="none">""" &
+    check(":field: text".toHtml ==
+            """<table class="docinfo" frame="void" rules="none">""" &
             """<col class="docinfo-name" /><col class="docinfo-content" />""" &
             """<tbody valign="top"><tr><th class="docinfo-name">field:</th>""" &
             """<td> text</td></tr>""" & "\n</tbody></table>")
@@ -1370,8 +1365,7 @@ Test1
     check "<td>text1</td>" in output
 
   test "Field list (incorrect)":
-    let output = ":field:text".toHtml
-    check(output == ":field:text")
+    check ":field:text".toHtml == ":field:text"
 
 suite "RST/Code highlight":
   test "Basic Python code highlight":


### PR DESCRIPTION
```
See :subscript:`some text` and `some text`:subscript:.
```

Before:
![image](https://user-images.githubusercontent.com/1299583/112551647-63af1800-8dd2-11eb-8ad0-6a94408609d2.png)

After:
![image](https://user-images.githubusercontent.com/1299583/112551706-788bab80-8dd2-11eb-944a-233584b8af0a.png)

Also the role at beginning of line triggered error:
```
:sup:`3`\ He is an isotope of helium.
```
`Error: ':' expected`

Now it's OK:
![image](https://user-images.githubusercontent.com/1299583/112551876-d15b4400-8dd2-11eb-92cf-9d8eb594042a.png)

The problem was that it was attempted to be parsed as a field list. Now field lists require space after second `:`, the appropriate test was added.

- also `superscript` was misspelled as `supscript` ([proof](https://docutils.sourceforge.io/docs/ref/rst/roles.html#superscript))

cc @narimiran 
