### PR TITLE
testament: remove unused tfile,tline,tcolumn

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -79,8 +79,6 @@ type
     sortoutput*: bool
     output*: string
     line*, column*: int
-    tfile*: string
-    tline*, tcolumn*: int
     exitCode*: int
     msg*: string
     ccodeCheck*: seq[string]
@@ -277,12 +275,6 @@ proc parseSpec*(filename: string): TSpec =
         if result.msg.len == 0 and result.nimout.len == 0:
           result.parseErrors.addLine "errormsg or msg needs to be specified before column"
         discard parseInt(e.value, result.column)
-      of "tfile":
-        result.tfile = e.value
-      of "tline":
-        discard parseInt(e.value, result.tline)
-      of "tcolumn":
-        discard parseInt(e.value, result.tcolumn)
       of "output":
         if result.outputCheck != ocSubstr:
           result.outputCheck = ocEqual


### PR DESCRIPTION
it was introduced in 2240fd3f3fb32fc4b1c8c7815d6d59982df44406, is not used anymore and not worth using either (simpler to directly test with nimout or similar)

