### PR TITLE
revert #17315 (keeping good parts)

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1161,19 +1161,11 @@ proc parseUntil(p: var RstParser, father: PRstNode, postfix: string,
       if isInlineMarkupEnd(p, postfix):
         inc p.idx
         break
+      elif interpretBackslash:
+        parseBackslash(p, father)
       else:
-        if postfix == "`":
-          if prevTok(p).symbol == "\\" and currentTok(p).symbol == "`":
-            father.sons[^1] = newLeaf(p) # instead, we should use lookahead
-          else:
-            father.add(newLeaf(p))
-          inc p.idx
-        else:
-          if interpretBackslash:
-            parseBackslash(p, father)
-          else:
-            father.add(newLeaf(p))
-            inc p.idx
+        father.add(newLeaf(p))
+        inc p.idx
     of tkAdornment, tkWord, tkOther:
       father.add(newLeaf(p))
       inc p.idx
@@ -1323,7 +1315,7 @@ proc parseInline(p: var RstParser, father: PRstNode) =
       father.add(n)
     elif isInlineMarkupStart(p, "`"):
       var n = newRstNode(rnInterpretedText)
-      parseUntil(p, n, "`", false) # bug #17260
+      parseUntil(p, n, "`", true)
       n = parsePostfix(p, n)
       father.add(n)
     elif isInlineMarkupStart(p, "|"):

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2827,19 +2827,19 @@ when declared(initDebugger):
 proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   ## Adds a char to string `s` and applies the following escaping:
   ##
-  ## * replaces any ``\`` by `\\`
-  ## * replaces any `'` by `\'`
-  ## * replaces any `"` by `\"`
-  ## * replaces any `\a` by `\\a`
-  ## * replaces any `\b` by `\\b`
-  ## * replaces any `\t` by `\\t`
-  ## * replaces any `\n` by `\\n`
-  ## * replaces any `\v` by `\\v`
-  ## * replaces any `\f` by `\\f`
-  ## * replaces any `\r` by `\\r`
-  ## * replaces any `\e` by `\\e`
-  ## * replaces any other character not in the set `{\21..\126}`
-  ##   by `\xHH` where `HH` is its hexadecimal value.
+  ## * replaces any ``\`` by two ``\``
+  ## * replaces any `'` by ``\`` and `'`
+  ## * replaces any `"` by ``\`` and `"`
+  ## * replaces any ``\a`` by ``\`` and `a`
+  ## * replaces any ``\b`` by ``\`` and `b`
+  ## * replaces any ``\t`` by ``\`` and `t`
+  ## * replaces any ``\n`` by ``\`` and `n`
+  ## * replaces any ``\v`` by ``\`` and `v`
+  ## * replaces any ``\f`` by ``\`` and `f`
+  ## * replaces any ``\r`` by ``\`` and `r`
+  ## * replaces any ``\e`` by ``\`` and `e`
+  ## * replaces any other character not in the set ``{\21..\126}``
+  ##   by ``\xHH`` where `HH` is its hexadecimal value.
   ##
   ## The procedure has been designed so that its output is usable for many
   ## different common syntaxes.

--- a/nimdoc/rst2html/expected/rst_examples.html
+++ b/nimdoc/rst2html/expected/rst_examples.html
@@ -300,7 +300,7 @@ stmt = IND{&gt;} stmt ^+ IND{=} DED  # list of statements
 <p>However, this does not work. The problem is that the procedure should not only <tt class="docutils literal"><span class="pre">return</span></tt>, but return and <strong>continue</strong> after an iteration has finished. This <em>return and continue</em> is called a <tt class="docutils literal"><span class="pre">yield</span></tt> statement. Now the only thing left to do is to replace the <tt class="docutils literal"><span class="pre">proc</span></tt> keyword by <tt class="docutils literal"><span class="pre">iterator</span></tt> and here it is - our first iterator:</p>
 <table border="1" class="docutils"><tr><th>A1 header</th><th>A2 | not fooled</th></tr>
 <tr><td>C1</td><td>C2 <strong>bold</strong></td></tr>
-<tr><td>D1 <tt class="docutils literal"><span class="pre">code \|</span></tt></td><td>D2</td></tr>
+<tr><td>D1 <tt class="docutils literal"><span class="pre">code |</span></tt></td><td>D2</td></tr>
 <tr><td>E1 | text</td><td></td></tr>
 <tr><td></td><td>F2 without pipe</td></tr>
 </table><p>not in table </p>

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -204,7 +204,7 @@ not in table"""
     doAssert output1 == """
 <table border="1" class="docutils"><tr><th>A1 header</th><th>A2 | not fooled</th></tr>
 <tr><td>C1</td><td>C2 <strong>bold</strong></td></tr>
-<tr><td>D1 <tt class="docutils literal"><span class="pre">code \|</span></tt></td><td>D2</td></tr>
+<tr><td>D1 <tt class="docutils literal"><span class="pre">code |</span></tt></td><td>D2</td></tr>
 <tr><td>E1 | text</td><td></td></tr>
 <tr><td></td><td>F2 without pipe</td></tr>
 </table><p>not in table</p>
@@ -560,7 +560,8 @@ let x = 1
     check """`foo\`\`bar`""".toHtml == """<tt class="docutils literal"><span class="pre">foo``bar</span></tt>"""
     check """`foo\`bar`""".toHtml == """<tt class="docutils literal"><span class="pre">foo`bar</span></tt>"""
     check """`\`bar`""".toHtml == """<tt class="docutils literal"><span class="pre">`bar</span></tt>"""
-    check """`a\b\x\\ar`""".toHtml == """<tt class="docutils literal"><span class="pre">a\b\x\\ar</span></tt>"""
+    check("""`a\\b\\x\\ar`""".toHtml ==
+      """<tt class="docutils literal"><span class="pre">a\b\x\ar</span></tt>""")
 
   test "inline literal":
     check """``foo.bar``""".toHtml == """<tt class="docutils literal"><span class="pre">foo.bar</span></tt>"""


### PR DESCRIPTION
@timotheecour , @xflywind.,  I have to take back my approve of #17315 . I'm very sorry because I also added some confusion.

New examples presented by @timotheecour in https://github.com/nim-lang/RFCs/issues/355#issuecomment-808451071 showed that #17315 was a really bad idea.

We lost the way to format code like:
```
See this Bash code: `export VAR=\`pwd\`; \\`.
```

It worked fine before:

![image](https://user-images.githubusercontent.com/1299583/112693093-0ded7500-8e91-11eb-8b67-ef8e97befb81.png)

The essence of the entire problem is that rst2html.py has 2 backslash modes:
1. escape backslashes, which was used between backticks before
2. not escape which #17315 moved to. (This also matches the actual behavior of rst2html.py with `:code:` role)

We really should stick to number 1 because:

- it's the only mode that is described in the RST spec. It's obvious that @Araq wrote rst.nim code with accordance with the spec.
- it's simple and easy to remember. Even if it requires to type double `\\` it's OK — it matches Nim programming languages escaping in strings `"\\"`
- it applies to any other part of RST in general
- it's universal: see the example above. (it even allows trailing whitespaces via syntax `` `beginning of code \ ` ``, though that currently did not work in Nim)

The good things of 2. is that it matches Markdown behavior better and that it allows to type backslashe as single backslash (unescaped).

Now I actually think that the behavior of rst2html.py with `:code:`  role **should never be replicated** in Nim. It's a wrong design. Let us just proclaim that we conform to the spec better.

In this PR I left relevant test cases from #17315 and changed the function doc comment from original bug #17260 to render properly with **old** syntax.

cc @narimiran 