### PR TITLE
add no-copy `ast.getStrVal` for `{nkIdent, nkSym, kStrLit..nkTripleStrLit}`

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1054,6 +1054,26 @@ const
   defaultOffset = -1
 
 
+var emptyString = ""
+
+proc getStrValImpl(a: PNode): ptr string {.inline.} =
+  case a.kind
+  of nkStrLit..nkTripleStrLit: a.strVal.addr
+  of nkSym: a.sym.name.s.addr
+  of nkIdent:  a.ident.s.addr
+  else: emptyString.addr
+
+when defined(nimExperimentalViews):
+  # workaround for tests/views/tcan_compile_nim.nim, refs https://github.com/nim-lang/Nim/issues/17519
+  proc getStrVal*(a: PNode): string {.inline.} =
+    getStrValImpl(a)[]
+else:
+  proc getStrVal*(a: PNode): lent string {.inline.} =
+    ## Returns underlying string for `{nkStrLit..nkTripleStrLit,nkSym,nkIdent}`,
+    ## without introducing a copy.
+    # xxx generalize this pattern, possibly with a {.byAddr.} generalization for procs.
+    getStrValImpl(a)[]
+
 proc getnimblePkg*(a: PSym): PSym =
   result = a
   while result != nil:

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -942,14 +942,11 @@ proc skipHiddenNodes(n: PNode): PNode =
     else: break
 
 proc accentedName(g: var TSrcGen, n: PNode) =
+  # This is for cases where ident should've really been a `nkAccQuoted`, e.g. `:tmp`
+  # or if user writes a macro with `ident":foo"`. It's unclear whether these should be legal.
   const backticksNeeded = OpChars + {'[', '{', '\''}
   if n == nil: return
-  let isOperator =
-    if n.kind == nkIdent and n.ident.s.len > 0 and n.ident.s[0] in backticksNeeded: true
-    elif n.kind == nkSym and n.sym.name.s.len > 0 and n.sym.name.s[0] in backticksNeeded: true
-    else: false
-
-  if isOperator:
+  if n.kind in {nkIdent, nkSym} and n.getStrVal[0] in backticksNeeded:
     put(g, tkAccent, "`")
     gident(g, n)
     put(g, tkAccent, "`")
@@ -977,9 +974,7 @@ proc infixArgument(g: var TSrcGen, n: PNode, i: int) =
     put(g, tkParRi, ")")
 
 proc isCustomLit(n: PNode): bool =
-  n.len == 2 and n[0].kind == nkRStrLit and
-    (n[1].kind == nkIdent and n[1].ident.s.startsWith('\'')) or
-    (n[1].kind == nkSym and n[1].sym.name.s.startsWith('\''))
+  n.len == 2 and n[0].kind == nkRStrLit and n[1].kind in {nkIdent, nkSym} and n[1].getStrVal.startsWith('\'')
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
   if isNil(n): return
@@ -1206,8 +1201,8 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
     else:
       gsub(g, n, 0)
       put(g, tkDot, ".")
-      if n.len > 1:
-        accentedName(g, n[1])
+      assert n.len == 2, $n.len
+      accentedName(g, n[1])
   of nkBind:
     putWithSpace(g, tkBind, "bind")
     gsub(g, n, 0)

--- a/tests/views/tcan_compile_nim.nim
+++ b/tests/views/tcan_compile_nim.nim
@@ -1,4 +1,7 @@
 discard """
-  cmd: "nim check --hints:on --experimental:strictFuncs --experimental:views compiler/nim.nim"
+  cmd: "nim check --hints:on --experimental:strictFuncs --experimental:views -d:nimExperimentalViews compiler/nim.nim"
   action: "compile"
 """
+
+# xxx pending bug #8644, no need to pass `-d:nimExperimentalViews` and affected
+# code will be able to use `compileOption` or compilesettings API.


### PR DESCRIPTION
(migrated from https://github.com/nim-lang/Nim/pull/17500#issuecomment-808702340)

add a no-copy `getStrVal`; see discussion in https://github.com/nim-lang/Nim/pull/17500#discussion_r601972687
