### PR TITLE
fix a bug: handle `conf.m.fileInfos.len <= fileIdx` edge case

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -200,13 +200,21 @@ template toFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
 proc toProjPath*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:
     (if fileIdx == commandLineIdx: commandLineDesc else: "???")
-  else: conf.m.fileInfos[fileIdx.int32].projPath.string
+  elif fileIdx.int32 < conf.m.fileInfos.len:
+    conf.m.fileInfos[fileIdx.int32].projPath.string
+  else:
+    # this can happen for some reason when `conf.m.fileInfos` is not yet initialized
+    # during debugging; instead of aborting (which would make debugging harder, since
+    # this code is called in error messages), we return an easy to search fake file name.
+    "BUG_D20210325T150904_" & $fileIdx.int32
 
 proc toFullPath*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:
     result = (if fileIdx == commandLineIdx: commandLineDesc else: "???")
-  else:
+  elif fileIdx.int32 < conf.m.fileInfos.len:
     result = conf.m.fileInfos[fileIdx.int32].fullPath.string
+  else: # see remark in `toProjPath`.
+    result = "BUG_D20210325T151009_" & $fileIdx.int32
 
 proc setDirtyFile*(conf: ConfigRef; fileIdx: FileIndex; filename: AbsoluteFile) =
   assert fileIdx.int32 >= 0

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -983,7 +983,6 @@ proc isCustomLit(n: PNode): bool =
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
   if isNil(n): return
-  echo "D20210327T133002: ", g.config$n.info # this would trigger the bug: index out of bounds, the container is empty [IndexDefect]
   var
     a: TContext
   if shouldRenderComment(g, n): pushCom(g, n)

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -983,6 +983,7 @@ proc isCustomLit(n: PNode): bool =
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
   if isNil(n): return
+  echo "D20210327T133002: ", g.config$n.info # this would trigger the bug: index out of bounds, the container is empty [IndexDefect]
   var
     a: TContext
   if shouldRenderComment(g, n): pushCom(g, n)


### PR DESCRIPTION
(migrated from https://github.com/nim-lang/Nim/pull/17500#issuecomment-808702340)

to reproduce the bug that would occur before PR, see commit history, or simply add:
```
  echo "D20210327T133002: ", g.config$n.info
```

below this in `compiler/renderer.nim`:
```nim
proc gsub(g: var TSrcGen, n: PNode, c: TContext) =
  if isNil(n): return
```
before PR this would trigger a crash: `index out of bounds, the container is empty [IndexDefect]`, and, in debug mode, show this stacktrace for eg: https://gist.github.com/timotheecour/fac4d205e3f0710513da496b7da7143c

(of course, there are other ways this bug could've triggered, especially during debugging compiler)

