### PR TITLE
remove std/ prefix from doc/lib.rst now that canonical import is shown in module docs

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -90,14 +90,14 @@ Algorithms
 * `algorithm <algorithm.html>`_
   This module implements some common generic algorithms like sort or binary search.
 
-* `std/enumutils <enumutils.html>`_
+* `enumutils <enumutils.html>`_
   This module adds functionality for the built-in `enum` type.
 
 * `sequtils <sequtils.html>`_
   This module implements operations for the built-in `seq` type
   which were inspired by functional programming languages.
 
-* `std/setutils <setutils.html>`_
+* `setutils <setutils.html>`_
   This module adds functionality for the built-in `set` type.
 
 
@@ -125,7 +125,7 @@ Collections
 * `options <options.html>`_
   The option type encapsulates an optional value.
 
-* `std/packedsets <packedsets.html>`_
+* `packedsets <packedsets.html>`_
   Efficient implementation of a set of ordinals as a sparse bit set.
 
 * `sets <sets.html>`_
@@ -147,7 +147,7 @@ String handling
 * `cstrutils <cstrutils.html>`_
   Utilities for `cstring` handling.
 
-* `std/editdistance <editdistance.html>`_
+* `editdistance <editdistance.html>`_
   This module contains an algorithm to compute the edit distance between two
   Unicode strings.
 
@@ -197,14 +197,14 @@ String handling
   It provides a single proc that does Unicode to ASCII transliterations.
   Based on Python's Unidecode module.
 
-* `std/wordwrap <wordwrap.html>`_
+* `wordwrap <wordwrap.html>`_
   This module contains an algorithm to wordwrap a Unicode string.
 
 
 Time handling
 -------------
 
-* `std/monotimes <monotimes.html>`_
+* `monotimes <monotimes.html>`_
   The `monotimes` module implements monotonic timestamps.
 
 * `times <times.html>`_
@@ -272,7 +272,7 @@ Math libraries
 * `random <random.html>`_
   Fast and tiny random number generator.
 
-* `std/sysrand <sysrand.html>`_
+* `sysrand <sysrand.html>`_
   Cryptographically secure pseudorandom number generator.
 
 * `rationals <rationals.html>`_
@@ -281,7 +281,7 @@ Math libraries
 * `stats <stats.html>`_
   Statistical analysis
 
-* `std/sums <sums.html>`_
+* `sums <sums.html>`_
   Accurate summation functions.
 
 
@@ -357,7 +357,7 @@ Parsers
 * `json <json.html>`_
   High-performance JSON parser.
 
-* `std/jsonutils <jsonutils.html>`_
+* `jsonutils <jsonutils.html>`_
   This module implements a hookable (de)serialization for arbitrary types.
 
 * `lexbase <lexbase.html>`_
@@ -448,7 +448,7 @@ Hashing
   produce a globally distributed unique ID. This implementation was extracted
   from the Mongodb interface and it thus binary compatible with a Mongo OID.
 
-* `std/sha1 <sha1.html>`_
+* `sha1 <sha1.html>`_
   This module implements a sha1 encoder and decoder.
 
 
@@ -465,7 +465,7 @@ Miscellaneous
 * `coro <coro.html>`_
   This module implements experimental coroutines in Nim.
 
-* `std/enumerate <enumerate.html>`_
+* `enumerate <enumerate.html>`_
   This module implements `enumerate` syntactic sugar based on Nim's macro system.
 
 * `logging <logging.html>`_
@@ -480,10 +480,10 @@ Miscellaneous
 * `unittest <unittest.html>`_
   Implements a Unit testing DSL.
 
-* `std/varints <varints.html>`_
+* `varints <varints.html>`_
   Decode variable-length integers that are compatible with SQLite.
 
-* `std/with <with.html>`_
+* `with <with.html>`_
   This module implements the `with` macro for easy function chaining.
 
 

--- a/lib/std/sha1.nim
+++ b/lib/std/sha1.nim
@@ -6,32 +6,25 @@
 #    See the file "copying.txt", included in this
 #    distribution, for details about the copyright.
 #
-## **Note:** Import `std/sha1` to use this module.
-##
 ## [SHA-1 (Secure Hash Algorithm 1)](https://en.wikipedia.org/wiki/SHA-1)
 ## is a cryptographic hash function which takes an input and produces
 ## a 160-bit (20-byte) hash value known as a message digest.
-##
-## Basic usage
-## ===========
-##
-runnableExamples:
-  let accessName = secureHash("John Doe")
-  assert $accessName == "AE6E4D1209F17B460503904FAD297B31E9CF6362"
-
-## .. code-block::
-##   let
-##     a = secureHashFile("myFile.nim")
-##     b = parseSecureHash("10DFAEBF6BFDBC7939957068E2EFACEC4972933C")
-##
-##   if a == b:
-##     echo "Files match"
 ##
 ## See also
 ## ========
 ## * `base64 module<base64.html>`_ implements a Base64 encoder and decoder
 ## * `hashes module<hashes.html>`_ for efficient computations of hash values for diverse Nim types
 ## * `md5 module<md5.html>`_ implements the MD5 checksum algorithm
+
+runnableExamples:
+  let accessName = secureHash("John Doe")
+  assert $accessName == "AE6E4D1209F17B460503904FAD297B31E9CF6362"
+
+runnableExamples("-r:off"):
+  let
+    a = secureHashFile("myFile.nim")
+    b = parseSecureHash("10DFAEBF6BFDBC7939957068E2EFACEC4972933C")
+  assert a == b, "files don't match"
 
 import std/strutils
 from std/endians import bigEndian32, bigEndian64


### PR DESCRIPTION
* avoids inconsistencies like this:
![image](https://user-images.githubusercontent.com/2194784/112735345-7cb9e500-8f08-11eb-866b-33266186a4ba.png)

the canonical name is now show in each module docs so there's no need to specify it here (and it was also breaking alphabetical ordering etc)

follows https://github.com/nim-lang/Nim/pull/16999

* similarly, remove redundant note in std/sha1 (and cleanup doc headers)