### PR TITLE
remove docutils.nimble (not a real nimble package, and affected canonical imports)

### DIFF
--- a/lib/packages/docutils/docutils.nimble
+++ b/lib/packages/docutils/docutils.nimble
@@ -1,4 +1,0 @@
-version       = "0.10.0"
-author        = "Andreas Rumpf"
-description   = "Nim's reStructuredText processor."
-license       = "MIT"

--- a/lib/packages/docutils/docutils.nimble.old
+++ b/lib/packages/docutils/docutils.nimble.old
@@ -1,0 +1,7 @@
+# xxx disabled this as this isn't really a nimble package and it affects logic
+# used to compute canonical imports, refs https://github.com/nim-lang/Nim/pull/16999#issuecomment-805442914
+
+version       = "0.10.0"
+author        = "Andreas Rumpf"
+description   = "Nim's reStructuredText processor."
+license       = "MIT"

--- a/lib/packages/docutils/highlite.nim
+++ b/lib/packages/docutils/highlite.nim
@@ -11,8 +11,6 @@
 ## Currently only few languages are supported, other languages may be added.
 ## The interface supports one language nested in another.
 ##
-## **Note:** Import `packages/docutils/highlite` to use this module
-##
 ## You can use this to build your own syntax highlighting, check this example:
 ##
 ## .. code::nim

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -142,9 +142,6 @@
 ## See `packages/docutils/rstgen module <rstgen.html>`_ to know how to
 ## generate HTML or Latex strings to embed them into your documents.
 ##
-## .. Tip:: Import ``packages/docutils/rst`` to use this module
-##    programmatically.
-##
 ## .. _quick introduction: https://docutils.sourceforge.io/docs/user/rst/quickstart.html
 ## .. _RST reference: https://docutils.sourceforge.io/docs/user/rst/quickref.html
 ## .. _RST specification: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html

--- a/lib/packages/docutils/rstast.nim
+++ b/lib/packages/docutils/rstast.nim
@@ -8,8 +8,6 @@
 #
 
 ## This module implements an AST for the `reStructuredText`:idx: parser.
-##
-## **Note:** Import ``packages/docutils/rstast`` to use this module
 
 import strutils, json
 

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -38,8 +38,6 @@
 ## * The same goes for footnotes/citations links: they point to themselves.
 ##   No backreferences are generated since finding all references of a footnote
 ##   can be done by simply searching for [footnoteName].
-##
-## .. Tip: Import ``packages/docutils/rstgen`` to use this module
 
 import strutils, os, hashes, strtabs, rstast, rst, highlite, tables, sequtils,
   algorithm, parseutils


### PR DESCRIPTION
follows https://github.com/nim-lang/Nim/pull/16999
refs https://github.com/nim-lang/Nim/pull/16999#issuecomment-805442914

after PR, docs for highlight show as `packages/docutils/highlite` which is now correct, instead of `highlite`; indeed, `packages/docutils/highlite` works, `import highlight` doesn't work

## future work
- [ ] I've removed the only use of `Tip::`, docs for rst should mention this admonication somewhere

![image](https://user-images.githubusercontent.com/2194784/112735682-1f736300-8f0b-11eb-87f7-fcdf1dbbe1f0.png)

```
## .. Tip:: Import ``packages/docutils/rst`` to use this module
##    programmatically.
```


- [ ] figure out what to do with nimsuggest/sexp.nim; it has an incorrect nimble package structure since we have:
```
nimsuggest/nimsuggest.nimble
nimsuggest/sexp.nim
```
as a result, its docs have this note:
```
## **Note:** Import ``nimsuggest/sexp`` to use this module
```
because the computed canonical import is `sexp` instead of `nimsuggest/sexp`

- [ ] add nimforum to important_packages 