### PR TITLE
fix #15708, fix #9073

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -28,7 +28,7 @@ bootSwitch(usedNoGC, defined(nogc), "--gc:none")
 import
   os, msgs, options, nversion, condsyms, strutils, extccomp, platform,
   wordrecg, parseutils, nimblecmd, parseopt, sequtils, lineinfos,
-  pathutils, strtabs
+  pathutils, strtabs, std/private/gitutils
 
 from ast import eqTypeFlags, tfGcSafe, tfNoSideEffect
 
@@ -95,9 +95,9 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
                                  CPU[conf.target.hostCPU].name, CompileDate]),
                {msgStdout})
 
-    const gitHash {.strdefine.} = gorge("git log -n 1 --format=%H").strip
-      # xxx move this logic to std/private/gitutils
-    when gitHash.len == 40:
+    # xxx {.strdefine.}?
+    const gitHash = getGitHashHuman()
+    when gitHash.len > 0:
       msgWriteln(conf, "git hash: " & gitHash, {msgStdout})
 
     msgWriteln(conf, "active boot switches:" & usedRelease & usedDanger &

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -16,11 +16,14 @@ import
   packages/docutils/rst, packages/docutils/rstgen,
   json, xmltree, trees, types,
   typesrenderer, astalgo, lineinfos, intsets,
-  pathutils, trees, tables, nimpaths, renderverbatim, osproc, std/wrapnils, std/private/gitutils
+  pathutils, trees, tables, nimpaths, renderverbatim, osproc, std/private/gitutils
 
 from uri import encodeUrl
 from std/private/globs import nativeToUnixPath
 
+const isRecentNim = defined(nimHasCustomLiterals) # PRTEMP
+when isRecentNim:
+  import std/wrapnils
 
 const
   exportSection = skField
@@ -1258,7 +1261,8 @@ proc relLink(outDir: AbsoluteDir, destFile: AbsoluteFile, linkto: RelativeFile):
   rope($relativeTo(outDir / linkto, destFile.splitFile().dir, '/'))
 
 proc interpDocFile(d: PDoc, conf: ConfigRef, destFile: AbsoluteFile, title: string, content: Rope, toc: Rope = nil, subtitle: Rope = nil): Rope =
-  result = ropeFormatNamedVars(conf, getConfigVar(conf, "doc.file"), [
+  when isRecentNim:
+    result = ropeFormatNamedVars(conf, getConfigVar(conf, "doc.file"), [
       "nimdoccss", "dochackjs", "title", "subtitle", "tableofcontents", "moduledesc", "date", "time",
       "content", "author", "version", "analytics", "deprecationMsg", "projectMetadata"],
       [relLink(conf.outDir, destFile, nimdocOutCss.RelativeFile),

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -16,7 +16,7 @@ import
   packages/docutils/rst, packages/docutils/rstgen,
   json, xmltree, trees, types,
   typesrenderer, astalgo, lineinfos, intsets,
-  pathutils, trees, tables, nimpaths, renderverbatim, osproc
+  pathutils, trees, tables, nimpaths, renderverbatim, osproc, std/wrapnils, std/private/gitutils
 
 from uri import encodeUrl
 from std/private/globs import nativeToUnixPath
@@ -55,6 +55,7 @@ type
     thisDir*: AbsoluteDir
     exampleGroups: OrderedTable[string, ExampleGroup]
     wroteSupportFiles*: bool
+    projectMetadata*: string
 
   PDoc* = ref TDocumentor ## Alias to type less.
 
@@ -184,6 +185,9 @@ proc getOutFile2(conf: ConfigRef; filename: RelativeFile,
   else:
     result = getOutFile(conf, filename, ext)
 
+proc computeprojectMetadata(filename: AbsoluteFile): string =
+  result = "githash: $1" % [filename.string.parentDir.getGitHashHuman]
+
 proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, outExt: string = HtmlExt, module: PSym = nil): PDoc =
   declareClosures()
   new(result)
@@ -212,6 +216,11 @@ proc newDocumentor*(filename: AbsoluteFile; cache: IdentCache; conf: ConfigRef, 
     result.analytics = ""
 
   result.seenSymbols = newStringTable(modeCaseInsensitive)
+
+  if module!=nil and module.owner.id == conf.mainPackageId:
+    doAssert result.projectMetadata.len == 0
+    result.projectMetadata = computeprojectMetadata(filename)
+
   result.id = 100
   result.jArray = newJArray()
   initStrTable result.types
@@ -1248,6 +1257,15 @@ proc genSection(d: PDoc, kind: TSymKind, groupedToc = false) =
 proc relLink(outDir: AbsoluteDir, destFile: AbsoluteFile, linkto: RelativeFile): Rope =
   rope($relativeTo(outDir / linkto, destFile.splitFile().dir, '/'))
 
+proc interpDocFile(d: PDoc, conf: ConfigRef, destFile: AbsoluteFile, title: string, content: Rope, toc: Rope = nil, subtitle =""): Rope =
+  result = ropeFormatNamedVars(conf, getConfigVar(conf, "doc.file"), [
+      "nimdoccss", "dochackjs", "title", "subtitle", "tableofcontents", "moduledesc", "date", "time",
+      "content", "author", "version", "analytics", "deprecationMsg", "projectMetadata"],
+      [relLink(conf.outDir, destFile, nimdocOutCss.RelativeFile),
+      relLink(conf.outDir, destFile, docHackJsFname.RelativeFile),
+      title.rope, subtitle.rope, toc, ?.d.modDesc, rope(getDateStr()), rope(getClockStr()),
+      content, ?.d.meta[metaAuthor].rope, ?.d.meta[metaVersion].rope, ?.d.analytics.rope, ?.d.modDeprecationMsg, ?.d.projectMetadata.rope])
+
 proc genOutFile(d: PDoc, groupedToc = false): Rope =
   var
     code, content: Rope
@@ -1272,9 +1290,9 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.
     title = canonicalImport(d.conf, AbsoluteFile d.filename)
-  var subtitle = "".rope
+  var subtitle = "" # xxx is that actually used?
   if d.meta[metaSubtitle] != "":
-    dispA(d.conf, subtitle, "<h2 class=\"subtitle\">$1</h2>",
+    dispA(d.conf, subtitle.rope, "<h2 class=\"subtitle\">$1</h2>",
         "\\\\\\vspace{0.5em}\\large $1", [d.meta[metaSubtitle].rope])
 
   var groupsection = getConfigVar(d.conf, "doc.body_toc_groupsection")
@@ -1286,17 +1304,11 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
   let seeSrcRope = genSeeSrcRope(d, d.filename, 1)
   content = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, bodyname), ["title", "subtitle",
       "tableofcontents", "moduledesc", "date", "time", "content", "deprecationMsg", "theindexhref", "body_toc_groupsection", "seeSrc"],
-      [title.rope, subtitle, toc, d.modDesc, rope(getDateStr()),
+      [title.rope, subtitle.rop, toc, d.modDesc, rope(getDateStr()),
       rope(getClockStr()), code, d.modDeprecationMsg, relLink(d.conf.outDir, d.destFile.AbsoluteFile, theindexFname.RelativeFile), groupsection.rope, seeSrcRope])
   if optCompileOnly notin d.conf.globalOptions:
     # XXX what is this hack doing here? 'optCompileOnly' means raw output!?
-    code = ropeFormatNamedVars(d.conf, getConfigVar(d.conf, "doc.file"), [
-        "nimdoccss", "dochackjs",  "title", "subtitle", "tableofcontents", "moduledesc", "date", "time",
-        "content", "author", "version", "analytics", "deprecationMsg"],
-        [relLink(d.conf.outDir, d.destFile.AbsoluteFile, nimdocOutCss.RelativeFile),
-        relLink(d.conf.outDir, d.destFile.AbsoluteFile, docHackJsFname.RelativeFile),
-        title.rope, subtitle, toc, d.modDesc, rope(getDateStr()), rope(getClockStr()),
-        content, d.meta[metaAuthor].rope, d.meta[metaVersion].rope, d.analytics.rope, d.modDeprecationMsg])
+    code = interpDocFile(d, d.conf, d.destFile, title = title, content=content, toc=toc, subtitle = subtitle)
   else:
     code = content
   result = code
@@ -1445,16 +1457,7 @@ proc commandBuildIndex*(conf: ConfigRef, dir: string, outFile = RelativeFile"") 
   var outFile = outFile
   if outFile.isEmpty: outFile = theindexFname.RelativeFile.changeFileExt("")
   let filename = getOutFile(conf, outFile, HtmlExt)
-
-  let code = ropeFormatNamedVars(conf, getConfigVar(conf, "doc.file"), [
-      "nimdoccss", "dochackjs",
-      "title", "subtitle", "tableofcontents", "moduledesc", "date", "time",
-      "content", "author", "version", "analytics"],
-      [relLink(conf.outDir, filename, nimdocOutCss.RelativeFile),
-      relLink(conf.outDir, filename, docHackJsFname.RelativeFile),
-      rope"Index", rope"", nil, nil, rope(getDateStr()),
-      rope(getClockStr()), content, nil, nil, nil])
   # no analytics because context is not available
-
+  let code = interpDocFile(d = nil, conf, filename, title = "Index", content=content)
   if not writeRope(code, filename):
     rawMessage(conf, errCannotOpenFile, filename.string)

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1290,7 +1290,7 @@ proc genOutFile(d: PDoc, groupedToc = false): Rope =
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.
     title = canonicalImport(d.conf, AbsoluteFile d.filename)
-  var subtitle = rope""
+  var subtitle = "".rope
   if d.meta[metaSubtitle] != "":
     dispA(d.conf, subtitle, "<h2 class=\"subtitle\">$1</h2>",
         "\\\\\\vspace{0.5em}\\large $1", [d.meta[metaSubtitle].rope])

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -19,7 +19,7 @@ import
   cgen, json, nversion,
   platform, nimconf, passaux, depends, vm,
   modules,
-  modulegraphs, tables, lineinfos, pathutils, vmprofiler
+  modulegraphs, tables, lineinfos, pathutils, vmprofiler, std/private/gitutils
 
 import ic / cbackend
 from ic / ic import rodViewer
@@ -307,6 +307,7 @@ proc mainCommand*(graph: ModuleGraph) =
 
       var dumpdata = %[
         (key: "version", val: %VersionAsString),
+        (key: "githash", val: %getGitHashHuman()),
         (key: "nimExe", val: %(getAppFilename())),
         (key: "prefixdir", val: %conf.getPrefixDir().string),
         (key: "libpath", val: %conf.libpath.string),

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -287,7 +287,7 @@ window.addEventListener('DOMContentLoaded', main);
       <div class="twelve-columns footer">
         <span class="nim-sprite"></span>
         <br/>
-        <small style="color: var(--hint);">Made with Nim. Generated: $date $time UTC</small>
+        <small style="color: var(--hint);">Made with Nim. Generated: $date $time UTC $projectMetadata </small>
       </div>
     </div>
   </div>

--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -44,6 +44,10 @@ template retryCall*(maxRetry = 3, backoffDuration = 1.0, call: untyped): bool =
     t = t * 2 # exponential backoff
   result
 
+proc stripLineEnd2(a: string): string =
+  result = a
+  stripLineEnd(result)
+
 proc execCmdEx2(cmd: string, dir = "."): (string, int) =
   when nimvm:
     doAssert dir == "." # PRTEMP: this needs adjustment
@@ -51,7 +55,9 @@ proc execCmdEx2(cmd: string, dir = "."): (string, int) =
     result = gorgeEx(cmd)
   else:
     result = execCmdEx(cmd, workingDir = dir)
-  result[0].stripLineEnd
+  # when (NimMajor, NimMinor, NimPatch) >= (1,5,1):
+  when defined(nimHasCustomLiterals):
+    result[0].stripLineEnd
 
 proc isGitRepo*(dir: string): bool =
   ## This command is used to get the relative path to the root of the repository.

--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -1,8 +1,24 @@
 ##[
+common git utilities to avoid re-implementing the same thing in different modules.
+Eventually can migrate to stdlib or fusion once stabilizes.
+
 internal API for now, API subject to change
 ]##
 
 # xxx move other git utilities here; candidate for stdlib.
+
+runnableExamples("-r:off"):
+  ## not a test, just examples
+  template test() = 
+    let dir = "."
+    template fn(a): untyped =
+      echo astToStr(a) & ": " & $a
+    fn getGitHash(dir)
+    fn getGitDirty(dir, ignoreUntracked = true)
+    fn getGitDirty(dir, ignoreUntracked = false)
+    fn getGitHashHuman(dir)
+  test()
+  static: test()
 
 import std/[os, osproc, strutils]
 
@@ -28,6 +44,15 @@ template retryCall*(maxRetry = 3, backoffDuration = 1.0, call: untyped): bool =
     t = t * 2 # exponential backoff
   result
 
+proc execCmdEx2(cmd: string, dir = "."): (string, int) =
+  when nimvm:
+    doAssert dir == "." # PRTEMP: this needs adjustment
+    # consider using `{.experimental: "vmopsDanger".}` once it can be pushed
+    result = gorgeEx(cmd)
+  else:
+    result = execCmdEx(cmd, workingDir = dir)
+  result[0].stripLineEnd
+
 proc isGitRepo*(dir: string): bool =
   ## This command is used to get the relative path to the root of the repository.
   ## Using this, we can verify whether a folder is a git repository by checking
@@ -38,3 +63,26 @@ proc isGitRepo*(dir: string): bool =
   # usually a series of ../), so we know that it's safe to unconditionally
   # remove trailing whitespaces from the result.
   result = status == 0 and output.strip() == ""
+
+proc getGitHash*(dir = "."): string =
+  # `git rev-parse` is plumbing, preferable for scripting to `git log -n 1 --format=%H`
+  # which is porcelain, and may change with user gitconfig
+  let (outp, status) = execCmdEx2("git rev-parse HEAD", dir = dir)
+  if status == 0: result = outp
+
+proc getGitDirty*(dir = ".", ignoreUntracked: bool): bool =
+  if ignoreUntracked:
+    let (outp, status) = execCmdEx2("git diff --no-ext-diff --quiet", dir = dir)
+    result = status != 0
+  else:
+    let (outp, status) = execCmdEx2("git status --porcelain --ignore-submodules -unormal", dir = dir)
+    result = outp.len > 0
+
+proc getGitHashHuman*(dir = "."): string =
+  ## dirty bit helps when considering reproducibility
+  result = getGitHash(dir)
+  if result.len > 0:
+    if getGitDirty(dir, ignoreUntracked = false):
+      result.add "-dirty"
+  else:
+    result = "unknown"


### PR DESCRIPTION
(not ready for review)

fix https://github.com/nim-lang/Nim/issues/15708
fix https://github.com/nim-lang/Nim/issues/9073

## TODO
* show also tag when git hash matches a tag
* consider whether `--putenv:nimversion` can be turned into a nop now that this auto-generates
