### PR TITLE
system: fix link in `delete` proc

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1321,7 +1321,7 @@ proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
   ## This is an `O(n)` operation.
   ##
   ## See also:
-  ## * `del <#delete,seq[T],Natural>`_ for O(1) operation
+  ## * `del <#del,seq[T],Natural>`_ for O(1) operation
   ##
   ## .. code-block:: Nim
   ##  var i = @[1, 2, 3, 4, 5]


### PR DESCRIPTION
The `delete` proc had a "See also" link that linked to itself.