### PR TITLE
Small doc improvements for `std/with`

### DIFF
--- a/lib/std/with.nim
+++ b/lib/std/with.nim
@@ -12,15 +12,16 @@
 ## and https://github.com/nim-lang/RFCs/issues/192 for details leading to this
 ## particular design.
 ##
-## **Since** version 1.2.
+## **Since:** version 1.2.
 
 import macros, private / underscored_calls
 
 macro with*(arg: typed; calls: varargs[untyped]): untyped =
-  ## This macro provides the `chaining`:idx: of function calls.
+  ## This macro provides `chaining`:idx: of function calls.
   ## It does so by patching every call in `calls` to
   ## use `arg` as the first argument.
-  ## **This evaluates `arg` multiple times!**
+  ##
+  ## .. caution:: This evaluates `arg` multiple times!
   runnableExamples:
     var x = "yay"
     with x:


### PR DESCRIPTION
Some notes:
* The `since` pragma can't be used here (see #15920), at least it has no effect on the generated documentation.
* Is there any particular reason why `with` is not part of the `sugar` module? If not, should this perhaps be reexported by `sugar` in the future?
* Currently, the `with` macro evaluates `arg` multiple times, should this be changed to only evaluate it once? If not, what are the reasons for this (should be documented imo)?