### PR TITLE
support skip ci  in azure pipelines, and support it properly in github actions pipelines

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -28,7 +28,6 @@ on:
       - '.github/workflows/ci_docs.yml'
       - 'koch.nim'
 
-
 jobs:
   build:
     if: |

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -30,8 +30,9 @@ on:
 
 jobs:
   build:
+    # `github.event.head_commit.message` doesn't work for PR's
     if: |
-      !contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[skip ci]')
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     strategy:
       fail-fast: false
       matrix:
@@ -50,6 +51,16 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: 'Check whether to skip CI'
+        shell: bash
+        run: |
+          # see D20210329T004830
+          commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
+          echo commitMsg: $commitMsg
+          echo $commitMsg | grep -v '\[skip ci\]'
 
       - name: 'Install build dependencies (macOS)'
         if: runner.os == 'macOS'

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -28,6 +28,7 @@ on:
       - '.github/workflows/ci_docs.yml'
       - 'koch.nim'
 
+
 jobs:
   build:
     if: |

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build:
-    # `github.event.head_commit.message` doesn't work for PR's
+    # see D20210329T004830
     if: |
       !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     strategy:

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     if: |
-      !contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[skip ci]')
+      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +19,17 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: 'Check whether to skip CI'
+        shell: bash
+        run: |
+          # see D20210329T004830
+          commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
+          echo commitMsg: $commitMsg
+          echo $commitMsg | grep -v '\[skip ci\]'
+
       - name: 'Checkout csources'
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    # see D20210329T004830
     if: |
       !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
     - bash: |
         # D20210329T004830:here refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
         # `--no-merges` is needed to avoid merge commits which occur for PR's.
-        # $(Build.SourceVersionMessage) isn't helpful
+        # $(Build.SourceVersionMessage) is not helpful
         # nor is `github.event.head_commit.message` for github actions.
         commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
         echo commitMsg: $commitMsg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
 
     - bash: |
         # refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
-        # `--no-merges` needed to avoid merge commits which occur for PR's.
+        # `--no-merges` is needed to avoid merge commits which occur for PR's.
         # $(Build.SourceVersionMessage) isn't helpful
         commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
         echo commitMsg: $commitMsg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
       fetchDepth: 2 # needed for skip CI logic
 
     - bash: |
-        # refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
+        # D20210329T004830:here refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
         # `--no-merges` is needed to avoid merge commits which occur for PR's.
         # $(Build.SourceVersionMessage) isn't helpful
         commitMsg=$(git log --no-merges -1 --pretty=format:"%s")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ jobs:
 
     - bash: |
         # refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
-        # --no-merges needed to avoid merge commits which occur for PR's.
+        # `--no-merges` needed to avoid merge commits which occur for PR's.
         # $(Build.SourceVersionMessage) isn't helpful
         commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
         echo commitMsg: $commitMsg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,12 +55,13 @@ jobs:
       condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
     - checkout: self
-      fetchDepth: 2 # needed for skip CI logic
+      fetchDepth: 2 # see D20210329T004830
 
     - bash: |
         # D20210329T004830:here refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
         # `--no-merges` is needed to avoid merge commits which occur for PR's.
         # $(Build.SourceVersionMessage) isn't helpful
+        # nor is `github.event.head_commit.message` for github actions.
         commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
         echo commitMsg: $commitMsg
         echo $commitMsg | grep -v '\[skip ci\]' # fails if [skip ci] not in commit msg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,10 +52,19 @@ jobs:
   steps:
     - bash: git config --global core.autocrlf false
       displayName: 'Disable auto conversion to CRLF by git (Windows-only)'
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
     - checkout: self
-      fetchDepth: 1
+      fetchDepth: 2 # needed for skip CI logic
+
+    - bash: |
+        # refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
+        # --no-merges needed to avoid merge commits which occur for PR's.
+        # $(Build.SourceVersionMessage) isn't helpful
+        commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
+        echo commitMsg: $commitMsg
+        echo $commitMsg | grep -v '\[skip ci\]' # fails if [skip ci] not in commit msg
+      displayName: 'Check whether to skip CI'
 
     - bash: git clone --depth 1 https://github.com/nim-lang/csources
       displayName: 'Checkout Nim csources'
@@ -73,7 +82,7 @@ jobs:
           echo_run sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
       displayName: 'Install dependencies (amd64 Linux)'
-      condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 
     - bash: |
         set -e
@@ -113,11 +122,11 @@ jobs:
         echo_run chmod 755 bin/g++
 
       displayName: 'Install dependencies (i386 Linux)'
-      condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
     - bash: brew install boehmgc make sfml
       displayName: 'Install dependencies (OSX)'
-      condition: eq(variables['Agent.OS'], 'Darwin')
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
     - bash: |
         set -e
@@ -130,7 +139,7 @@ jobs:
         echo_run echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
 
       displayName: 'Install dependencies (Windows)'
-      condition: eq(variables['Agent.OS'], 'Windows_NT')
+      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
     - bash: echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/bin'
       displayName: 'Add build binaries to PATH'

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -461,9 +461,10 @@ Continuous Integration (CI)
 
 1. Continuous Integration is by default run on every push in a PR; this clogs
    the CI pipeline and affects other PR's; if you don't need it (e.g. for WIP or
-   documentation only changes), add `[ci skip]` to your commit message title.
-   This convention is supported by `Appveyor
-   <https://www.appveyor.com/docs/how-to/filtering-commits/#skip-directive-in-commit-message>`_
+   documentation only changes), add `[skip ci]` to your commit message title.
+   This convention is supported by our github actions pipelines, as our azure pipeline
+   and these piplines (now unused in this repository):
+   `Appveyor <https://www.appveyor.com/docs/how-to/filtering-commits/#skip-directive-in-commit-message>`_
    and `Travis <https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build>`_.
 
 2. Consider enabling CI (azure, GitHub actions and builds.sr.ht) in your own Nim fork, and

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -462,8 +462,8 @@ Continuous Integration (CI)
 1. Continuous Integration is by default run on every push in a PR; this clogs
    the CI pipeline and affects other PR's; if you don't need it (e.g. for WIP or
    documentation only changes), add `[skip ci]` to your commit message title.
-   This convention is supported by our github actions pipelines, as our azure pipeline
-   and these piplines (now unused in this repository):
+   This convention is supported by our github actions pipelines and our azure pipeline
+   as well as our former other pipelines:
    `Appveyor <https://www.appveyor.com/docs/how-to/filtering-commits/#skip-directive-in-commit-message>`_
    and `Travis <https://docs.travis-ci.com/user/customizing-the-build/#skipping-a-build>`_.
 


### PR DESCRIPTION
* `skip ci` now works in azure pipelines; it was tricky to implement (see https://github.com/microsoft/azure-pipelines-agent/issues/2944 long standing upstream feature request) but the way I implemented it seems to work
* `skip ci` now works properly in github actions

in both cases, whether CI is triggered or not after pushing a commit now depends only on the last commit pushed; before this PR azure completely ignored `[skip ci]`, and github actions would honor `[skip ci]` as a default behavior, but would also incorrectly skip CI if head commit of a PR would contain `[skip ci]`, even if latest commit didn't contain it, which didn't make sense, in particular for WIP work that sometimes starts with `[skip ci]` and then has subsequent commits where CI is intended to run. Note that github actions still also considers the PR title for presence of `[skip ci]`; I haven't changed that behavior but future work can harmonize this with azure pipelines

## example
after `[skip ci] example of a commit that skips CI` commit:
* github actions pipeline are skipped (as was case before this PR)
* azure pipeline starts, and the step `Check whether to skip CI` step are skipped:` completes with with an (intended) failure:
```
commitMsg: [skip ci] example of a commit that skips CI
##[error]Bash exited with code '1'.
Finishing: Check whether to skip CI
```
and then subsequent steps are skipped, ending in 
CI for azure completes in only 47 seconds with an error (as intended), and all steps after the `Check whether to skip CI` step are skipped, and pipeline ends with an error
* CI comples in 47 seconds:
![image](https://user-images.githubusercontent.com/2194784/112799482-445af980-9023-11eb-8881-24c09eda4e7c.png)
