### PR TITLE
Fix void async in templates

### DIFF
--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -184,8 +184,9 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     verifyReturnType(repr(returnType), returnType)
 
   let subtypeIsVoid = returnType.kind == nnkEmpty or
-        (baseType.kind == nnkIdent and returnType[1].eqIdent("void"))
-
+        (baseType.kind == nnkIdent and returnType[1].eqIdent("void")) or
+        (baseType.kind == nnkSym and returnType[2].eqIdent("void"))
+  
   let futureVarIdents = getFutureVarIdents(prc.params)
 
   var outerProcBody = newNimNode(nnkStmtList, prc.body)

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -184,8 +184,8 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     verifyReturnType(repr(returnType), returnType)
 
   let subtypeIsVoid = returnType.kind == nnkEmpty or
-        (baseType.kind == nnkIdent and returnType[1].eqIdent("void")) or
-        (baseType.kind == nnkSym and returnType[2].eqIdent("void"))
+        ((baseType.kind == nnkIdent or baseType.kind == nnkSym) and
+         baseType.eqIdent("void"))
   
   let futureVarIdents = getFutureVarIdents(prc.params)
 

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -184,7 +184,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     verifyReturnType(repr(returnType), returnType)
 
   let subtypeIsVoid = returnType.kind == nnkEmpty or
-        ((baseType.kind == nnkIdent or baseType.kind == nnkSym) and
+        (baseType.kind in {nnkIdent, nnkSym} and
          baseType.eqIdent("void"))
   
   let futureVarIdents = getFutureVarIdents(prc.params)

--- a/tests/async/tasyncintemplate.nim
+++ b/tests/async/tasyncintemplate.nim
@@ -1,0 +1,12 @@
+discard """
+  output: 42
+"""
+
+import asyncdispatch
+
+template foo() =
+  proc temp(): Future[int] {.async.} = return 42
+  proc tempVoid(): Future[void] {.async.} = echo await temp()
+
+foo()
+waitFor tempVoid()


### PR DESCRIPTION
Fix #16159
(EDIT(timotheecour) potentially also fixes https://github.com/nim-lang/Nim/issues/16786)

It appears that the issue is caused by `subtypeIsVoid` failing to catch `baseType` if `returnType` is not `nnkBracketExpr`, which seems to happen in templates. I'm not sure why that happens, but this case is already covered at 
https://github.com/nim-lang/Nim/blob/c27cd83265558195316e0d3b6d13ccadcaecc728/lib/pure/asyncmacro.nim#L177
knowing that non-void asyncs in templates work fine, and `returnType` was `nnkCall` in my debugging.

While checking -d:nimDumpAsync, I found that what happens is that normally, if the baseType is not void, the macro expands something like this:
```nim
...
var result: T
...
```
where T is the baseType. This happens both inside and outside a template.
If T is void, the line isnt generated because it is obviously incorrect syntax.
When inside a template, the macro fails to find the `void` in `Future[void]`, so it assumes it isnt void, generating something like:
```nim
...
var result: void
...
```
Which correctly causes the exact error in the issue.

What I did to fix this was to add another condition to `subtypeIsVoid`, checking if `baseType.kind` is `nnkSym`, which is the kind after this assignment https://github.com/nim-lang/Nim/blob/c27cd83265558195316e0d3b6d13ccadcaecc728/lib/pure/asyncmacro.nim#L180 
(correct me if i'm wrong), and then I normally check with `eqIdent` if the symbol is `void` at the according index (~~I tried to keep the new condition similar to the other one, I could've also compare variable `baseType` directly~~ I shortened the expression based on the fact that `baseType` is already assigned depending on the case).

I also added a test to check if both void and non-void procedure work inside templates.

## future work
- [x] this is fragile and doesn't work with aliasing etc, see https://github.com/nim-lang/Nim/pull/17562#issuecomment-809637968 which also shows a potential way to fix this
=> https://github.com/nim-lang/Nim/pull/17633
- [x] add tests refs https://github.com/nim-lang/Nim/pull/17562#discussion_r603664142
=> https://github.com/nim-lang/Nim/pull/17633