### PR TITLE
add os.pathExists; fix RFCs/issues/121

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -78,6 +78,8 @@
 - `os.FileInfo` (returned by `getFileInfo`) now contains `blockSize`,
   determining preferred I/O block size for this file object.
 
+- Added `os.pathExists`.
+
 - Added a simpler to use `io.readChars` overload.
 
 - `repr` now doesn't insert trailing newline; previous behavior was very inconsistent,


### PR DESCRIPTION
do not review yet, I'm still trying to figure whether `pathExists` or `pathKind` is the most sensible API to add.

* fixes https://github.com/nim-lang/RFCs/issues/121
* refactor/simplify existing code to remove code duplication

## TODO
- [ ] all Xexists procs (including this one) are wrong wrt permission errors, they return false when a file can't be stat'd due to permission error, instead they should either raise, or raise when a check bool flag is provided, or some other behavior
- [ ] instead of `pathExists`, maybe we should have `pathKind` which could return:
```
{symLink, file, dir, device, none, permissionError}
```
note: `PathComponent` is IMO the wrong thing to return here, it's not what the OS provides directly, doesn't distinguish broken symlinks, doesn't have a category for device files etc