### PR TITLE
fix #17572 `distinct T` conversion to T now works correctly in VM

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -415,7 +415,8 @@ proc opConv(c: PCtx; dest: var TFullReg, src: TFullReg, desttyp, srctyp: PType):
     else:
       internalError(c.config, "cannot convert to string " & desttyp.typeToString)
   else:
-    case skipTypes(desttyp, abstractVarRange).kind
+    let desttyp = skipTypes(desttyp, abstractVarRange)
+    case desttyp.kind
     of tyInt..tyInt64:
       dest.ensureKind(rkInt)
       case skipTypes(srctyp, abstractRange).kind

--- a/tests/misc/tunsignedconv.nim
+++ b/tests/misc/tunsignedconv.nim
@@ -79,3 +79,19 @@ except RangeDefect:
   success = true
 
 doAssert success, "conversion should fail at runtime"
+
+template main() =
+  # xxx move all tests under here so it gets tested in CT and RT
+  block: # bug #17572
+    type T = distinct uint64
+    func f(x: uint64): auto =
+      let a = T(x)
+      (x, a.uint64)
+    const x = 1'u64 shl 63 or 7
+    const b = T(x)
+    doAssert b.uint64 == 9223372036854775815'u64
+    doAssert $b.uint64 == "9223372036854775815"
+    doAssert f(x) == (9223372036854775815'u64, 9223372036854775815'u64)
+
+static: main()
+main()


### PR DESCRIPTION
fix #17572

`let destDist = (sizeof(dest.intVal) - desttyp.size) * 8` was returning bad results because desttyp.size was -1