### PR TITLE
misc fixes: build_all.sh, changelog

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -42,7 +42,7 @@ build_nim_csources(){
   echo_run cp bin/nim $nim_csources
 }
 
-[ -f $nim_csources ] || echo_run build_nim_csources $@
+[ -f $nim_csources ] || echo_run build_nim_csources "$@"
 
 # Note: if fails, may need to `cd csources && git pull`
 echo_run bin/nim c --skipUserCfg --skipParentCfg koch

--- a/changelog.md
+++ b/changelog.md
@@ -73,7 +73,7 @@
 - Added `asyncdispatch.activeDescriptors` that returns the number of currently
   active async event handles/file descriptors.
 
-- Added to `asynchttpserver` `getPort` and `getSocket`.
+- Added `getPort` to `asynchttpserver`.
 
 - `--gc:orc` is now 10% faster than previously for common workloads. If
   you have trouble with its changed behavior, compile with `-d:nimOldOrc`.

--- a/compiler/errorhandling.nim
+++ b/compiler/errorhandling.nim
@@ -10,7 +10,7 @@
 ## This module contains support code for new-styled error
 ## handling via an `nkError` node kind.
 
-import ast, renderer, options, lineinfos, strutils, types
+import ast, renderer, options, strutils, types
 
 type
   ErrorKind* = enum ## expand as you need.


### PR DESCRIPTION
* fix a bug in build_all.sh: $@ => "$@" see [1]
* build_all.sh is now passes https://www.shellcheck.net/ modulo other warnings that arent' bugs
* remove getSocket from changelog following #17587

## details
[1]
test.sh:
```
foo(){
  echo nargs2: "$#"
}
echo nargs1: "$#"
foo "$@" # ok
foo $@ # bug
```

sh test.sh ok1 ok2 "ab cd ef"
nargs1: 3
nargs2: 3
nargs2: 5
