### PR TITLE
Follow up #17562

### DIFF
--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -185,7 +185,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
 
   let subtypeIsVoid = returnType.kind == nnkEmpty or
         (baseType.kind == nnkSym and
-         baseType.getType[1] == ntyVoid) or
+         baseType.getType[1].typeKind == ntyVoid) or
         (baseType.kind == nnkIdent and
          baseType.eqIdent("void")) #TODO: Make it work properly
   

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -184,8 +184,10 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     verifyReturnType(repr(returnType), returnType)
 
   let subtypeIsVoid = returnType.kind == nnkEmpty or
-        (baseType.kind in {nnkIdent, nnkSym} and
-         baseType.eqIdent("void"))
+        (baseType.kind == nnkSym and
+         baseType.getType[1] == ntyVoid) or
+        (baseType.kind == nnkIdent and
+         baseType.eqIdent("void")) #TODO: Make it work properly
   
   let futureVarIdents = getFutureVarIdents(prc.params)
 


### PR DESCRIPTION
Follow up: https://github.com/nim-lang/Nim/pull/17562

I'm working on adding support for checking aliased void, but so far I only got  alias checking working for the cases when `baseType` is a symbol.
I couldn't get `sameType` to work as wanted, as it was comparing the NimNode types, not what the actual parameters represented. I got a solution using `sameType` that worked for symbols, but I reduced it to what is now in the code.
I'm not exactly sure what to do when `baseType` is an identifier, bindSym wouldn't work and using `sameType` would just check if the other parameter is also an identifier or not.

The code is a bit ugly now but I'll pretify it once I find a solution.