### PR TITLE
misc improvements

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -619,6 +619,7 @@ var
 
 type
   TMagic* = enum # symbols that require compiler magic:
+    # see also: magicsAfterOverloadResolution, getConstExpr, semMagic
     mNone,
     mDefined, mDeclared, mDeclaredInScope, mCompiles, mArrGet, mArrPut, mAsgn,
     mLow, mHigh, mSizeOf, mAlignOf, mOffsetOf, mTypeTrait,

--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -17,3 +17,6 @@ proc onNewConfigRef*(conf: ConfigRef) {.inline.} =
 proc getConfigRef*(): ConfigRef =
   ## nil, if -d:nimDebugUtils wasn't specified
   result = conf0
+
+proc nimDebugutilsGetConfigRef*(): ConfigRef {.exportc.} =
+  conf0

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -12,7 +12,7 @@
 import
   intsets, ast, astalgo, msgs, options, idents, lookups,
   semdata, modulepaths, sigmatch, lineinfos, sets,
-  modulegraphs
+  modulegraphs, wordrecg
 
 proc readExceptSet*(c: PContext, n: PNode): IntSet =
   assert n.kind in {nkImportExceptStmt, nkExportExceptStmt}
@@ -83,7 +83,7 @@ proc rawImportSymbol(c: PContext, s, origin: PSym; importSet: var IntSet) =
   else:
     importSet.incl s.id
   if s.kind == skType:
-    var etyp = s.typ
+    let etyp = s.typ
     if etyp.kind in {tyBool, tyEnum}:
       for j in 0..<etyp.n.len:
         var e = etyp.n[j].sym
@@ -253,7 +253,7 @@ proc myImportModule(c: PContext, n: PNode; importStmtResult: PNode): PSym =
     #newStrNode(toFullPath(c.config, f), n.info)
 
 proc transformImportAs(c: PContext; n: PNode): PNode =
-  if n.kind == nkInfix and considerQuotedIdent(c, n[0]).s == "as":
+  if n.kind == nkInfix and considerQuotedIdent(c, n[0]).s == $wAs:
     result = newNodeI(nkImportAs, n.info)
     result.add n[1]
     result.add n[2]
@@ -282,7 +282,7 @@ proc evalImport*(c: PContext, n: PNode): PNode =
       imp.add sep # dummy entry, replaced in the loop
       for x in it[2]:
         # transform `a/b/[c as d]` to `/a/b/c as d`
-        if x.kind == nkInfix and x[0].ident.s == "as":
+        if x.kind == nkInfix and x[0].ident.s == $wAs:
           let impAs = copyTree(x)
           imp[2] = x[1]
           impAs[1] = imp

--- a/compiler/magicsys.nim
+++ b/compiler/magicsys.nim
@@ -46,10 +46,13 @@ proc sysTypeFromName*(g: ModuleGraph; info: TLineInfo; name: string): PType =
   result = getSysSym(g, info, name).typ
 
 proc getSysType*(g: ModuleGraph; info: TLineInfo; kind: TTypeKind): PType =
+  # `info` is only used for error reporting.
+  # xxx instead, use something like `lastInfo`.
   template sysTypeFromName(s: string): untyped = sysTypeFromName(g, info, s)
   result = g.sysTypes[kind]
   if result == nil:
     case kind
+    of tyVoid: result = sysTypeFromName("void")
     of tyInt: result = sysTypeFromName("int")
     of tyInt8: result = sysTypeFromName("int8")
     of tyInt16: result = sysTypeFromName("int16")

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -201,6 +201,9 @@ proc toProjPath*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:
     (if fileIdx == commandLineIdx: commandLineDesc else: "???")
   else: conf.m.fileInfos[fileIdx.int32].projPath.string
+    # this and similar procs can give `IndexDefect` in some cases when debugging
+    # the compiler, see PR #17541. In such cases, you can try compiling nim with
+    # `-d:nimDebugUtils`, see PR #17652.
 
 proc toFullPath*(conf: ConfigRef; fileIdx: FileIndex): string =
   if fileIdx.int32 < 0 or conf == nil:

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -57,7 +57,7 @@ proc semOperand(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
       localError(c.config, n.info, errProcHasNoConcreteType % n.renderTree)
     if result.typ.kind in {tyVar, tyLent}: result = newDeref(result)
   elif {efWantStmt, efAllowStmt} * flags != {}:
-    result.typ = newTypeS(tyVoid, c)
+    result.typ = getSysType(c.graph, n.info, tyVoid)
   else:
     localError(c.config, n.info, errExprXHasNoType %
                renderTree(result, {renderNoComments}))

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -30,6 +30,7 @@ runnableExamples:
     let mag = sigma * sqrt(-2 * ln(u1))
     result[0] = mag * cos(2 * PI * u2) + mu
     result[1] = mag * sin(2 * PI * u2) + mu
+
   assert randGaussian() != randGaussian()
 
 ## This module is available for the `JavaScript target

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -19,21 +19,18 @@ runnableExamples:
   from std/fenv import epsilon
   from std/random import rand
 
-  proc generateGaussianNoise(mu: float = 0.0, sigma: float = 1.0): (float, float) =
+  proc randGaussian(mu = 0.0, sigma = 1.0): (float, float) =
     # Generates values from a normal distribution.
     # Translated from https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform#Implementation.
-    var u1: float
-    var u2: float
+    var u1, u2: float
     while true:
       u1 = rand(1.0)
       u2 = rand(1.0)
       if u1 > epsilon(float): break
     let mag = sigma * sqrt(-2 * ln(u1))
-    let z0 = mag * cos(2 * PI * u2) + mu
-    let z1 = mag * sin(2 * PI * u2) + mu
-    (z0, z1)
-
-  echo generateGaussianNoise()
+    result[0] = mag * cos(2 * PI * u2) + mu
+    result[1] = mag * sin(2 * PI * u2) + mu
+  assert randGaussian() != randGaussian()
 
 ## This module is available for the `JavaScript target
 ## <backends.html#backends-the-javascript-target>`_.

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -484,15 +484,6 @@ proc testNimblePackages(r: var TResults; cat: Category; packageFilter: string) =
 # ---------------- IC tests ---------------------------------------------
 
 proc icTests(r: var TResults; testsDir: string, cat: Category, options: string) =
-  const
-    tooltests = ["compiler/nim.nim", "tools/nimgrep.nim"]
-    writeOnly = " --incremental:writeonly "
-    readOnly = " --incremental:readonly "
-    incrementalOn = " --incremental:on -d:nimIcIntegrityChecks "
-
-  template test(x: untyped) =
-    testSpecWithNimcache(r, makeRawTest(file, x & options, cat), nimcache)
-
   template editedTest(x: untyped) =
     var test = makeTest(file, x & options, cat)
     test.spec.targets = {getTestSpecTarget()}
@@ -509,10 +500,16 @@ proc icTests(r: var TResults; testsDir: string, cat: Category, options: string) 
         let file = it.replace(".nim", tempExt)
         writeFile(file, fragment)
         let oldPassed = r.passed
-        editedTest incrementalOn
+        editedTest " --incremental:on -d:nimIcIntegrityChecks "
         if r.passed != oldPassed+1: break
 
   when false:
+    template test(x: untyped) =
+      testSpecWithNimcache(r, makeRawTest(file, x & options, cat), nimcache)
+    const
+      tooltests = ["compiler/nim.nim", "tools/nimgrep.nim"]
+      writeOnly = " --incremental:writeonly "
+      readOnly = " --incremental:readonly "
     for file in tooltests:
       let nimcache = nimcacheDir(file, options, getTestSpecTarget())
       removeDir(nimcache)


### PR DESCRIPTION
* improve an example
* fix XDeclaredButNotUsed hints in testament/categories.nim
* use getSysType instead of newTypeS in 1 place (reuse type)
* add some comments
* add nimDebugutilsGetConfigRef which helps during debugging by allowing external code to use:
```nim
from compiler/options import ConfigRef, isDefined
proc nimDebugutilsGetConfigRef(): ConfigRef {.importc.}
# eg: `if isDefined(nimDebugutilsGetConfigRef(), "foo"): ...`
```
without introducing cyclic deps. This has no effect without -d:nimDebugUtils

