### PR TITLE
fix #14850: `repr` now correctly renders `do`

### DIFF
--- a/tests/errmsgs/twrongcolon.nim
+++ b/tests/errmsgs/twrongcolon.nim
@@ -1,7 +1,7 @@
 discard """
-errormsg: "in expression ':"
+errormsg: "in expression ' do:"
 nimout: '''
-Error: in expression ':
+Error: in expression ' do:
   890': identifier expected, but found ''
 '''
 

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -163,5 +163,54 @@ proc `foo bar baz`(): int =
 """
     doAssert a2 == a
 
+  block: # bug #14850
+    block:
+      let a = deb:
+        template bar(): untyped =
+          foo1:
+            discard
+            4
+          foo2(1):
+            discard
+            4
+          foo3(1):
+            discard
+            4
+          do: 1
+          do: 2
+          x.add foo4
+          x.add: foo5: 3
+          x.add foo6 do: 4
+          a.add(foo7 do:
+            echo "baz"
+            4)
+
+      doAssert a == """
+
+template bar(): untyped =
+  foo1:
+    discard
+    4
+  foo2(1):
+    discard
+    4
+  foo3(1):
+    discard
+    4
+  do:
+    1
+  do:
+    2
+  x.add foo4
+  x.add:
+    foo5:
+      3
+  x.add foo6 do:
+    4
+  a.add(foo7 do:
+    echo "baz"
+    4)
+"""
+
 static: main()
 main()


### PR DESCRIPTION
* follows https://github.com/nim-lang/Nim/pull/17449
* fixes #14850
`fromStmtList` tells whether we're a child of a nnkStmtList, and depending on this we use `foo:` or `foo do:` which avoids writing illegal code while at same time avoiding spurious `do` in rendering