### PR TITLE
`repr`: fix rendering of `'big`, `=destroy` etc

### DIFF
--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -145,5 +145,23 @@ do:
 do:
   4"""
 
+  block: # bug #17292 (bug 4)
+    let a = deb:
+      proc `=destroy`() = discard
+      proc `'foo`(): int = discard
+      proc `foo bar baz`(): int = discard
+    let a2 = """
+
+proc `=destroy`() =
+  discard
+
+proc `'foo`(): int =
+  discard
+
+proc `foo bar baz`(): int =
+  discard
+"""
+    doAssert a2 == a
+
 static: main()
 main()


### PR DESCRIPTION
* fix bug 4 from https://github.com/nim-lang/Nim/issues/17292