### PR TITLE
remove un-needed `{.push hint[ConvFromXtoItselfNotNeeded]: off.}` in asyncfutures, asyncmacro

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -363,12 +363,10 @@ proc read*[T](future: Future[T] | FutureVar[T]): T =
   ## this function will fail with a `ValueError` exception.
   ##
   ## If the result of the future is an error then that error will be raised.
-  {.push hint[ConvFromXtoItselfNotNeeded]: off.}
   when future is Future[T]:
     let fut = future
   else:
     let fut = Future[T](future)
-  {.pop.}
   if fut.finished:
     if fut.error != nil:
       injectStacktrace(fut)

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -35,14 +35,11 @@ template createCb(retFutureSym, iteratorNameSym,
 
         if next == nil:
           if not retFutureSym.finished:
-            let msg = "Async procedure ($1) yielded `nil`, are you await'ing a " &
-                    "`nil` Future?"
+            let msg = "Async procedure ($1) yielded `nil`, are you await'ing a `nil` Future?"
             raise newException(AssertionDefect, msg % strName)
         else:
           {.gcsafe.}:
-            {.push hint[ConvFromXtoItselfNotNeeded]: off.}
             next.addCallback cast[proc() {.closure, gcsafe.}](identName)
-            {.pop.}
     except:
       futureVarCompletions
       if retFutureSym.finished:


### PR DESCRIPTION
possible thanks to #16764 which added:
`when future is Future[T]: let fut = future else: let fut = Future[T](future)`
