### PR TITLE
simplify asyncfutures, asyncmacro

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -189,36 +189,22 @@ proc add(callbacks: var CallbackList, function: CallbackFunc) =
         last = last.next
       last.next = newCallback
 
-proc complete*[T](future: Future[T], val: T) =
-  ## Completes `future` with value `val`.
+proc completeImpl[T, U](future: Future[T], val: U, isVoid: static bool) =
   #assert(not future.finished, "Future already finished, cannot finish twice.")
   checkFinished(future)
   assert(future.error == nil)
-  # when T isnot tuple[]:
-  #   future.value = val
-  future.value = val
+  when not isVoid:
+    future.value = val
   future.finished = true
   future.callbacks.call()
   when isFutureLoggingEnabled: logFutureFinish(future)
 
-proc complete*(future: Future[void]) =
-  # PRTEMP
-  # complete(future, ())
-  checkFinished(future)
-  assert(future.error == nil)
-  future.finished = true
-  future.callbacks.call()
-  when isFutureLoggingEnabled: logFutureFinish(future)
+proc complete*[T](future: Future[T], val: T) =
+  ## Completes `future` with value `val`.
+  completeImpl(future, val, false)
 
-# proc complete*(future: Future[void], val: tuple[]) =
-proc complete*(future: Future[void], val: Future[void]) =
-  # PRTEMP
-  # complete(future, ())
-  checkFinished(future)
-  assert(future.error == nil)
-  future.finished = true
-  future.callbacks.call()
-  when isFutureLoggingEnabled: logFutureFinish(future)
+proc complete*(future: Future[void], val = Future[void].default) =
+  completeImpl(future, (), true)
 
 proc complete*[T](future: FutureVar[T]) =
   ## Completes a `FutureVar`.

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -194,14 +194,26 @@ proc complete*[T](future: Future[T], val: T) =
   #assert(not future.finished, "Future already finished, cannot finish twice.")
   checkFinished(future)
   assert(future.error == nil)
+  # when T isnot tuple[]:
+  #   future.value = val
   future.value = val
   future.finished = true
   future.callbacks.call()
   when isFutureLoggingEnabled: logFutureFinish(future)
 
 proc complete*(future: Future[void]) =
-  ## Completes a void `future`.
-  #assert(not future.finished, "Future already finished, cannot finish twice.")
+  # PRTEMP
+  # complete(future, ())
+  checkFinished(future)
+  assert(future.error == nil)
+  future.finished = true
+  future.callbacks.call()
+  when isFutureLoggingEnabled: logFutureFinish(future)
+
+# proc complete*(future: Future[void], val: tuple[]) =
+proc complete*(future: Future[void], val: Future[void]) =
+  # PRTEMP
+  # complete(future, ())
   checkFinished(future)
   assert(future.error == nil)
   future.finished = true

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -11,7 +11,6 @@
 
 import macros, strutils, asyncfutures
 
-
 # TODO: Ref https://github.com/nim-lang/Nim/issues/5617
 # TODO: Add more line infos
 proc newCallWithLineInfo(fromNode: NimNode; theProc: NimNode, args: varargs[NimNode]): NimNode =
@@ -242,6 +241,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   result = prc
   # Add discardable pragma.
   if returnType.kind == nnkEmpty:
+    # xxx consider removing `owned`? it's inconsistent with non-void case
     result.params[0] = quote do: owned(Future[void])
 
   # based on the yglukhov's patch to chronos: https://github.com/status-im/nim-chronos/pull/47

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -65,9 +65,7 @@ proc createFutureVarCompletions(futureVarIdents: seq[NimNode], fromNode: NimNode
       )
     )
 
-proc processBody(node, retFutureSym: NimNode,
-                 subTypeIsVoid: bool,
-                 futureVarIdents: seq[NimNode]): NimNode =
+proc processBody(node, retFutureSym: NimNode, futureVarIdents: seq[NimNode]): NimNode =
   #echo(node.treeRepr)
   result = node
   case node.kind
@@ -78,14 +76,9 @@ proc processBody(node, retFutureSym: NimNode,
     result.add createFutureVarCompletions(futureVarIdents, node)
 
     if node[0].kind == nnkEmpty:
-      if not subTypeIsVoid:
-        result.add newCall(newIdentNode("complete"), retFutureSym,
-            newIdentNode("result"))
-      else:
-        result.add newCall(newIdentNode("complete"), retFutureSym)
+      result.add newCall(newIdentNode("complete"), retFutureSym, newIdentNode("result"))
     else:
-      let x = node[0].processBody(retFutureSym, subTypeIsVoid,
-                                  futureVarIdents)
+      let x = node[0].processBody(retFutureSym, futureVarIdents)
       if x.kind == nnkYieldStmt: result.add x
       else:
         result.add newCall(newIdentNode("complete"), retFutureSym, x)
@@ -98,8 +91,7 @@ proc processBody(node, retFutureSym: NimNode,
   else: discard
 
   for i in 0 ..< result.len:
-    result[i] = processBody(result[i], retFutureSym, subTypeIsVoid,
-                            futureVarIdents)
+    result[i] = processBody(result[i], retFutureSym, futureVarIdents)
 
   # echo result.repr
 
@@ -146,7 +138,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   if prc.kind == nnkProcTy:
     result = prc
     if prc[0][0].kind == nnkEmpty:
-      result[0][0] = parseExpr("Future[void]")
+      result[0][0] = quote do: Future[void]
     return result
 
   if prc.kind notin {nnkProcDef, nnkLambda, nnkMethodDef, nnkDo}:
@@ -180,12 +172,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   else:
     verifyReturnType(repr(returnType), returnType)
 
-  let subtypeIsVoid = returnType.kind == nnkEmpty or
-        (baseType.kind in {nnkIdent, nnkSym} and
-         baseType.eqIdent("void"))
-  
   let futureVarIdents = getFutureVarIdents(prc.params)
-
   var outerProcBody = newNimNode(nnkStmtList, prc.body)
 
   # Extract the documentation comment from the original procedure declaration.
@@ -198,6 +185,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   var subRetType =
     if returnType.kind == nnkEmpty: newIdentNode("void")
     else: baseType
+  echo (baseType.kind, "D20210403T121503")
   outerProcBody.add(
     newVarStmt(retFutureSym,
       newCall(
@@ -213,42 +201,33 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   # ->   <proc_body>
   # ->   complete(retFuture, result)
   var iteratorNameSym = genSym(nskIterator, $prcName & "Iter")
-  var procBody = prc.body.processBody(retFutureSym, subtypeIsVoid,
-                                    futureVarIdents)
+  var procBody = prc.body.processBody(retFutureSym, futureVarIdents)
   # don't do anything with forward bodies (empty)
   if procBody.kind != nnkEmpty:
     # fix #13899, defer should not escape its original scope
     procBody = newStmtList(newTree(nnkBlockStmt, newEmptyNode(), procBody))
-
     procBody.add(createFutureVarCompletions(futureVarIdents, nil))
+    let resultIdent = ident"result"
+    procBody.insert(0): quote do:
+      static: echo "D20210403T122406.1"
+      static: echo `subRetType`
+      when `subRetType` isnot void:
+        {.push warning[resultshadowed]: off.}
+        var `resultIdent`: `baseType`
+        {.pop.}
+    procBody.add quote do:
+      when `subRetType` isnot void:
+        complete(`retFutureSym`, `resultIdent`)
+      else:
+        complete(`retFutureSym`)
 
-    if not subtypeIsVoid:
-      procBody.insert(0, newNimNode(nnkPragma).add(newIdentNode("push"),
-        newNimNode(nnkExprColonExpr).add(newNimNode(nnkBracketExpr).add(
-          newIdentNode("warning"), newIdentNode("resultshadowed")),
-        newIdentNode("off")))) # -> {.push warning[resultshadowed]: off.}
-
-      procBody.insert(1, newNimNode(nnkVarSection, prc.body).add(
-        newIdentDefs(newIdentNode("result"), baseType))) # -> var result: T
-
-      procBody.insert(2, newNimNode(nnkPragma).add(
-        newIdentNode("pop"))) # -> {.pop.})
-
-      procBody.add(
-        newCall(newIdentNode("complete"),
-          retFutureSym, newIdentNode("result"))) # -> complete(retFuture, result)
-    else:
-      # -> complete(retFuture)
-      procBody.add(newCall(newIdentNode("complete"), retFutureSym))
-
-    var closureIterator = newProc(iteratorNameSym, [parseExpr("owned(FutureBase)")],
+    var closureIterator = newProc(iteratorNameSym, [quote do: owned(FutureBase)],
                                   procBody, nnkIteratorDef)
     closureIterator.pragma = newNimNode(nnkPragma, lineInfoFrom = prc.body)
     closureIterator.addPragma(newIdentNode("closure"))
 
     # If proc has an explicit gcsafe pragma, we add it to iterator as well.
-    if prc.pragma.findChild(it.kind in {nnkSym, nnkIdent} and $it ==
-        "gcsafe") != nil:
+    if prc.pragma.findChild(it.kind in {nnkSym, nnkIdent} and $it == "gcsafe") != nil:
       closureIterator.addPragma(newIdentNode("gcsafe"))
     outerProcBody.add(closureIterator)
 
@@ -266,22 +245,16 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     outerProcBody.add newNimNode(nnkReturnStmt, prc.body[^1]).add(retFutureSym)
 
   result = prc
-
-  if subtypeIsVoid:
-    # Add discardable pragma.
-    if returnType.kind == nnkEmpty:
-      # Add Future[void]
-      result.params[0] = parseExpr("owned(Future[void])")
+  # Add discardable pragma.
+  if returnType.kind == nnkEmpty:
+    result.params[0] = quote do: owned(Future[void])
 
   # based on the yglukhov's patch to chronos: https://github.com/status-im/nim-chronos/pull/47
   if procBody.kind != nnkEmpty:
     body2.add quote do:
       `outerProcBody`
     result.body = body2
-
-  #echo(treeRepr(result))
-  #if prcName == "recvLineInto":
-  #  echo(toStrLit(result))
+  echo result.repr
 
 macro async*(prc: untyped): untyped =
   ## Macro which processes async procedures into the appropriate

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -209,17 +209,17 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     procBody.add(createFutureVarCompletions(futureVarIdents, nil))
     let resultIdent = ident"result"
     procBody.insert(0): quote do:
-      static: echo "D20210403T122406.1"
-      static: echo `subRetType`
       when `subRetType` isnot void:
         {.push warning[resultshadowed]: off.}
         var `resultIdent`: `baseType`
         {.pop.}
-    procBody.add quote do:
-      when `subRetType` isnot void:
-        complete(`retFutureSym`, `resultIdent`)
       else:
-        complete(`retFutureSym`)
+        # const `resultIdent` = ()
+        # var `resultIdent` = ()
+        # var `resultIdent` = newFuture[void]
+        var `resultIdent`: Future[void]
+    procBody.add quote do:
+      complete(`retFutureSym`, `resultIdent`)
 
     var closureIterator = newProc(iteratorNameSym, [quote do: owned(FutureBase)],
                                   procBody, nnkIteratorDef)

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -208,7 +208,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     procBody.insert(0): quote do:
       {.push warning[resultshadowed]: off.}
       when `subRetType` isnot void:
-        var `resultIdent`: `baseType`
+        var `resultIdent`: `subRetType`
       else:
         var `resultIdent`: Future[void]
       {.pop.}

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -185,7 +185,6 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   var subRetType =
     if returnType.kind == nnkEmpty: newIdentNode("void")
     else: baseType
-  echo (baseType.kind, "D20210403T121503")
   outerProcBody.add(
     newVarStmt(retFutureSym,
       newCall(
@@ -214,9 +213,6 @@ proc asyncSingleProc(prc: NimNode): NimNode =
         var `resultIdent`: `baseType`
         {.pop.}
       else:
-        # const `resultIdent` = ()
-        # var `resultIdent` = ()
-        # var `resultIdent` = newFuture[void]
         var `resultIdent`: Future[void]
     procBody.add quote do:
       complete(`retFutureSym`, `resultIdent`)
@@ -254,7 +250,6 @@ proc asyncSingleProc(prc: NimNode): NimNode =
     body2.add quote do:
       `outerProcBody`
     result.body = body2
-  echo result.repr
 
 macro async*(prc: untyped): untyped =
   ## Macro which processes async procedures into the appropriate

--- a/tests/async/tasyncintemplate.nim
+++ b/tests/async/tasyncintemplate.nim
@@ -10,17 +10,13 @@ discard """
 '''
 """
 
-#[
-xxx move to tests/async/tasyncintemplate.nim
-]#
-
+# xxx move to tests/async/tasyncintemplate.nim
 import asyncdispatch
 
 block: # bug #16159
   template foo() =
     proc temp(): Future[int] {.async.} = return 42
     proc tempVoid(): Future[void] {.async.} = echo await temp()
-
   foo()
   waitFor tempVoid()
 
@@ -30,7 +26,6 @@ block: # aliasing `void`
     proc temp(): Future[int] {.async.} = return 43
     proc tempVoid(): Future[Foo] {.async.} = echo await temp()
     proc tempVoid2() {.async.} = echo await temp()
-
   foo()
   waitFor tempVoid()
   waitFor tempVoid2()

--- a/tests/async/tasyncintemplate.nim
+++ b/tests/async/tasyncintemplate.nim
@@ -1,6 +1,8 @@
 discard """
   output: '''
 42
+43
+43
 1
 2
 3
@@ -8,16 +10,35 @@ discard """
 '''
 """
 
+#[
+xxx move to tests/async/tasyncintemplate.nim
+]#
+
 import asyncdispatch
 
-# bug #16159
-template foo() =
-  proc temp(): Future[int] {.async.} = return 42
-  proc tempVoid(): Future[void] {.async.} = echo await temp()
+block: # bug #16159
+  template foo() =
+    proc temp(): Future[int] {.async.} = return 42
+    proc tempVoid(): Future[void] {.async.} = echo await temp()
 
-foo()
-waitFor tempVoid()
+  foo()
+  waitFor tempVoid()
 
+block: # aliasing `void`
+  template foo() =
+    type Foo = void
+    proc temp(): Future[int] {.async.} = return 43
+    proc tempVoid(): Future[Foo] {.async.} = echo await temp()
+    proc tempVoid2() {.async.} = echo await temp()
+
+  foo()
+  waitFor tempVoid()
+  waitFor tempVoid2()
+
+block: # aliasing `void`
+  template foo() =
+    proc bad(): int {.async.} = discard
+  doAssert not compiles(bad())
 
 block: # bug #16786
   block:

--- a/tests/async/tasyncintemplate.nim
+++ b/tests/async/tasyncintemplate.nim
@@ -35,7 +35,7 @@ block: # aliasing `void`
   waitFor tempVoid()
   waitFor tempVoid2()
 
-block: # aliasing `void`
+block: # sanity check
   template foo() =
     proc bad(): int {.async.} = discard
   doAssert not compiles(bad())

--- a/tests/errmsgs/tgcsafety.nim
+++ b/tests/errmsgs/tgcsafety.nim
@@ -6,7 +6,8 @@ type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.vo
 but expected one of:
 proc serve(server: AsyncHttpServer; port: Port;
            callback: proc (request: Request): Future[void] {.closure, gcsafe.};
-           address = ""; assumedDescriptorsPerRequest = -1): owned(Future[void])
+           address = ""; assumedDescriptorsPerRequest = -1): owned(
+    Future[void])
   first type mismatch at position: 3
   required type for callback: proc (request: Request): Future[system.void]{.closure, gcsafe.}
   but expression 'cb' is of type: proc (req: Request): Future[system.void]{.locks: <unknown>.}

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -255,6 +255,10 @@ block:
     doAssert input.treeRepr & "\n" == expectedRepr
     return input
 
+  macro expectedAstRepr(expectedRepr: static[string], input: untyped): untyped =
+    doAssert input.repr == expectedRepr
+    return input
+
   const procTypeAst = """
 ProcTy
   FormalParams
@@ -273,20 +277,10 @@ ProcTy
   static: doAssert Foo is proc(x: int): Future[void]
 
   const asyncProcTypeAst = """
-ProcTy
-  FormalParams
-    BracketExpr
-      Ident "Future"
-      Ident "void"
-    IdentDefs
-      Ident "s"
-      Ident "string"
-      Empty
-  Pragma
-"""
-
+proc (s: string): Future[void] {..}"""
+  # using expectedAst would show `OpenSymChoice` for Future[void], which is fragile.
   type
-    Bar = proc (s: string) {.async, expectedAst(asyncProcTypeAst).}
+    Bar = proc (s: string) {.async, expectedAstRepr(asyncProcTypeAst).}
 
   static: doAssert Bar is proc(x: string): Future[void]
 


### PR DESCRIPTION
* greatly simplifies code by using quote (genAst would've worked too) instead building AST by hand
* fixese fragility of async (refs https://github.com/nim-lang/Nim/pull/17562#issuecomment-809637968)
* adds test case https://github.com/nim-lang/Nim/pull/17562#discussion_r603664142
* adds test case https://github.com/nim-lang/Nim/pull/17562#issuecomment-809637968

followup PR's can further simplify async macros.