### PR TITLE
fix rst option list at EOF (follow-up #17442)

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -2067,7 +2067,7 @@ proc parseOptionList(p: var RstParser): PRstNode =
       c.add(b)
       result.add(c)
     else:
-      dec p.idx  # back to tkIndent
+      if currentTok(p).kind != tkEof: dec p.idx  # back to tkIndent
       break
 
 proc parseDefinitionList(p: var RstParser): PRstNode =

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -1362,6 +1362,7 @@ Test1
           output)
     check("""<th align="left">-d</th><td align="left">option</td>""" in
           output)
+    check "<p>option</p>" notin output
 
   test "Option list 3 (double /)":
     let input = dedent """
@@ -1378,6 +1379,7 @@ Test1
           output)
     check("""<th align="left">-d</th><td align="left">option</td>""" in
           output)
+    check "<p>option</p>" notin output
 
   test "Roles: subscript prefix/postfix":
     let expected = "See <sub>some text</sub>."


### PR DESCRIPTION
#17442 introduced a minor mistake when option list item is immediately finished with EOF without newline (e.g. on Windows) or when `.. include` directive is used. 

Example:

```
Options:
  --deepcopy    description lastword
```

`truncate -s 1 <file.rst>`

![image](https://user-images.githubusercontent.com/1299583/113513907-78c73c00-9574-11eb-948e-049422909b7f.png)
