### PR TITLE
fix :number-lines: regression

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -980,7 +980,7 @@ proc buildLinesHtmlTable(d: PDoc; params: CodeBlockParams, code: string,
     result.beginTable.add($line & "\n")
     line.inc
     codeLines.dec
-  result.beginTable.add("</pre$3></td><td>" & (
+  result.beginTable.add("</pre></td><td>" & (
       d.config.getOrDefault"doc.listing_start" %
         [id, sourceLanguageToStr[params.lang], idStr]))
   result.endTable = (d.config.getOrDefault"doc.listing_end" % id) &

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -1089,6 +1089,16 @@ Test1
     let output0 = input0.toHtml
     doAssert "<p>Paragraph1</p>" in output0
 
+  test "Nim code-block :number-lines:":
+    let input = dedent """
+      .. code-block:: nim
+         :number-lines: 55
+
+         x
+         y
+      """
+    check "<pre class=\"line-nums\">55\n56\n</pre>" in input.toHtml
+
   test "RST admonitions":
     # check that all admonitions are implemented
     let input0 = dedent """


### PR DESCRIPTION
Any non-empty code-block containing `:number-lines:` crashes:
```
.. code-block:: nim
   :number-lines: 35

   x
```

`Error: unhandled exception: invalid format string [ValueError]`

The regression is introduced in #16614, it seems I accidentally inserted anchor format in the wrong place.

cc @timotheecour @narimiran 