### PR TITLE
fix #8212; add std/reflection module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -271,6 +271,9 @@
 - Added `genasts.genAst` that avoids the problems inherent with `quote do` and can
   be used as a replacement.
 
+- Added `reflection` module.
+
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/std/reflection.nim
+++ b/lib/std/reflection.nim
@@ -67,11 +67,13 @@ macro getProcnameImpl(a: typed, withType: static bool): string =
   newLit ret
 
 template getProcname*(withType = false): string =
-  ## Returns the name of proc/func/iterator/method in which caller is running.
+  ## Returns the name of proc/func/iterator/method/macro in which caller is running.
   ## When `withType = true`, the result contains an implementation defined
   ## representation of the type of the routine.
   ##
   ## .. note:: at the top-level, it returns the module name.
+  ## .. note:: this cannot be used to retrieve the name of an enclosing template,
+  ##   they are expanded early.
   block:
     template dummy(a: int) = discard
     const result = getProcnameImpl(dummy, withType)

--- a/lib/std/reflection.nim
+++ b/lib/std/reflection.nim
@@ -1,0 +1,76 @@
+##[
+This module implements some reflection API's.
+It is supported in c, cpp, js backends.
+
+Experimental API, subject to change.
+]##
+
+runnableExamples:
+  # `getProcname`
+  proc fn1(a: int, b = 'x') =
+    assert getProcname() == "fn1"
+    static: assert getProcname(withType = true) == "fn1: proc (a: int; b: char)"
+  fn1(1)
+
+  iterator fn3[T](a: T): string =
+    static: doAssert getProcname() == "fn3"
+    yield getProcname(withType = true)
+
+  from std/sequtils import toSeq
+  assert toSeq(fn3(1.5)) == @["fn3: proc (a: float64): string"]
+
+runnableExamples:
+  # `getExportcName`
+  from std/strutils import contains
+  proc fn1 =
+    assert "fn1" in getExportcName() # implementation defined, e.g. `fn1_reflection95examples49_1`
+  fn1()
+
+  proc fn2: auto {.exportc.} = getExportcName()
+  assert fn2() == "fn2"
+
+  iterator fn3[T](a: T): string {.closure.} =
+    yield getExportcName()
+
+  from std/sequtils import toSeq
+  let s1 = toSeq(fn3(1.5))[0]
+  let s2 = toSeq(fn3(1))[0]
+  assert "fn3" in s1
+  assert s2 != s1
+
+import std/macros
+
+template getExportcName*(): string =
+  ## Returns the name of the function containing the caller scope after codegen.
+  ## This is only valid inside a proc/func/method/closure iterator.
+  ## See also `getProcname`.
+  ##
+  ## .. note:: not supported in VM.
+  block:
+    var name {.inject.}: cstring
+    when defined(js):
+      {.emit: "`name` = arguments.callee.name;".}
+    else:
+      # C cast needed for cpp.
+      {.emit: "`name` = (char*)__func__;".}
+    $name
+
+macro getProcnameImpl(a: typed, withType: static bool): string =
+  let n = a.owner
+  var ret = n.repr
+  case n.symKind
+  of nskModule:
+    discard
+  elif withType:
+    ret.add ": " 
+    ret.add n.getTypeInst.repr
+  newLit ret
+
+template getProcname*(withType = false): string =
+  ## Returns the name of proc/func/iterator/method in which caller is running.
+  ## When `withType = true`, the result contains an implementation defined
+  ## representation of the type of the routine.
+  block:
+    template dummy(a: int) = discard
+    const result = getProcnameImpl(dummy, withType)
+    result

--- a/lib/std/reflection.nim
+++ b/lib/std/reflection.nim
@@ -70,6 +70,8 @@ template getProcname*(withType = false): string =
   ## Returns the name of proc/func/iterator/method in which caller is running.
   ## When `withType = true`, the result contains an implementation defined
   ## representation of the type of the routine.
+  ##
+  ## .. note:: at the top-level, it returns the module name.
   block:
     template dummy(a: int) = discard
     const result = getProcnameImpl(dummy, withType)

--- a/lib/std/stackframes.nim
+++ b/lib/std/stackframes.nim
@@ -1,7 +1,7 @@
 const NimStackTrace = compileOption("stacktrace")
 const NimStackTraceMsgs = compileOption("stacktraceMsgs")
 
-template procName*(): string =
+template procName*(): string {.deprecated: "use `reflection.getBackendProcName`".} =
   ## returns current C/C++ function name
   when defined(c) or defined(cpp):
     var name {.inject, noinit.}: cstring

--- a/tests/stdlib/treflection.nim
+++ b/tests/stdlib/treflection.nim
@@ -62,7 +62,8 @@ method fn7(self: Foo): int {.base.} =
 var a = Foo()
 doAssert fn7(a) == 3
 
-const moduleName = getProcname
+const moduleName = "treflection"
+
 doAssert getProcname() == moduleName
 block:
   doAssert getProcname() == moduleName

--- a/tests/stdlib/treflection.nim
+++ b/tests/stdlib/treflection.nim
@@ -6,46 +6,54 @@ import std/reflection
 from std/strutils import contains
 
 
-block:
+block: # getOwnerName, getBackendProcName
   proc fn1 =
-    doAssert getProcname() == "fn1"
-    static: doAssert getProcname() == "fn1"
-    doAssert "fn1" in getExportcName()
+    doAssert getOwnerName() == "fn1"
+    static: doAssert getOwnerName() == "fn1"
+    doAssert "fn1" in getBackendProcName()
   fn1()
 
   proc fn3(a: int, b = 3.4, c: static string = "def") =
-    let s1 = getProcname()
-    let s2 = getProcname() # check we can call this twice
+    let s1 = getOwnerName()
+    let s2 = getOwnerName() # check we can call this twice
     doAssert s1 == s2
     doAssert s1 == "fn3"
-    doAssert getProcname(withType = true) == """fn3: proc (a: int; b: float64; c: "def")"""
-    const x = getProcname()
+    doAssert getOwnerName(withType = true) == """fn3: proc (a: int; b: float64; c: "def")"""
+    const x = getOwnerName()
     doAssert x == s1
-    let s3 = getExportcName()
+    let s3 = getBackendProcName()
     doAssert "fn3" in s3
     doAssert s3 != "fn3"
-    let s4 = getExportcName() # check we can call this twice
+    let s4 = getBackendProcName() # check we can call this twice
     doAssert s4 == s3
   fn3(3)
 
-  proc `fn1b aux`(): auto =
-    doAssert "fn1b" in getExportcName()
-    doAssert "aux" in getExportcName()
-    (getProcname(), getProcname(withType = true))
+  var other: string
+  proc fn3b(): auto =
+    result = getOwnerName(withType = true)
+    other = getOwnerName(withType = true)
+  doAssert fn3b() == "fn3b: proc (): untyped"
+    # note: `untyped` is returned when return type is not yet known at the point
+    # where getOwnerName(withType = true) is called
+  doAssert other == "fn3b: proc (): string" # now the return type is known since `result` was set
 
-  # xxx bug: `untyped` is returned when return type is auto (it's a bug with `getTypeInst.repr`)
-  doAssert `fn1b aux`() == ("fn1baux", "fn1baux: proc (): untyped")
+  proc `fn1b aux`(): (string, string) =
+    doAssert "fn1b" in getBackendProcName()
+    doAssert "aux" in getBackendProcName()
+    (getOwnerName(), getOwnerName(withType = true))
 
-  proc `fn1c+aux`(): auto =
-    doAssert "fn1c" in getExportcName()
-    doAssert "aux" in getExportcName()
-    (getProcname(), getProcname(withType = true))
-  doAssert `fn1c+aux`() == ("fn1c+aux", "fn1c+aux: proc (): untyped")
+  doAssert `fn1b aux`() == ("fn1baux", "fn1baux: proc (): (string, string)")
+
+  proc `fn1c+aux`(): (string, string) =
+    doAssert "fn1c" in getBackendProcName()
+    doAssert "aux" in getBackendProcName()
+    (getOwnerName(), getOwnerName(withType = true))
+  doAssert `fn1c+aux`() == ("fn1c+aux", "fn1c+aux: proc (): (string, string)")
 
   var witness = 0
   iterator fn4(): int =
-    doAssert getProcname() == "fn4"
-    doAssert getProcname(withType = true) == "fn4: proc (): int"
+    doAssert getOwnerName() == "fn4"
+    doAssert getOwnerName(withType = true) == "fn4: proc (): int"
     witness.inc
   for a in fn4(): discard
   doAssert witness == 1
@@ -53,26 +61,26 @@ block:
   when not defined(js):
     witness = 0
     iterator fn5(): int {.closure.} =
-      doAssert getProcname() == "fn5"
-      doAssert getProcname(withType = true) == "fn5: proc (): int"
-      doAssert "fn5" in getExportcName()
+      doAssert getOwnerName() == "fn5"
+      doAssert getOwnerName(withType = true) == "fn5: proc (): int"
+      doAssert "fn5" in getBackendProcName()
       witness.inc
     for a in fn5(): discard
     doAssert witness == 1
 
   func fn6 =
-    doAssert getProcname() == "fn6"
-    doAssert getProcname(withType = true) == "fn6: proc ()"
-    doAssert "fn6" in getExportcName()
+    doAssert getOwnerName() == "fn6"
+    doAssert getOwnerName(withType = true) == "fn6: proc ()"
+    doAssert "fn6" in getBackendProcName()
   fn6()
 
 
 type Foo = ref object of RootObj
 
 method fn7(self: Foo): int {.base.} =
-  doAssert getProcname() == "fn7"
-  doAssert getProcname(withType = true) == "fn7: proc (self: Foo): int"
-  doAssert "fn7" in getExportcName()
+  doAssert getOwnerName() == "fn7"
+  doAssert getOwnerName(withType = true) == "fn7: proc (self: Foo): int"
+  doAssert "fn7" in getBackendProcName()
   3
 
 var a = Foo()
@@ -80,19 +88,19 @@ doAssert fn7(a) == 3
 
 const moduleName = "treflection"
 
-doAssert getProcname() == moduleName
+doAssert getOwnerName() == moduleName
 block:
-  doAssert getProcname() == moduleName
+  doAssert getOwnerName() == moduleName
   template fn8(): string =
-    let x = getProcname()
+    let x = getOwnerName()
     x
   doAssert fn8() == moduleName
 
 import std/macros
 
 macro fn8(a: int, b: static int = 0): (string, string) =
-  let a1 = getProcname()
-  let a2 = getProcname(withType = true)
+  let a1 = getOwnerName()
+  let a2 = getOwnerName(withType = true)
   result = quote: (`a1`, `a2`)
 
 doAssert fn8(1) == ("fn8", "fn8: proc (a: int; b: b:type): (string, string)")

--- a/tests/stdlib/treflection.nim
+++ b/tests/stdlib/treflection.nim
@@ -1,0 +1,62 @@
+discard """
+  targets: "c cpp js"
+"""
+
+import std/reflection
+from std/strutils import contains
+
+block:
+  proc fn1 =
+    doAssert getProcname() == "fn1"
+    static: doAssert getProcname() == "fn1"
+    doAssert "fn1" in getExportcName()
+  fn1()
+
+  proc fn3(a: int, b = 3.4, c: static string = "def") =
+    let s1 = getProcname()
+    let s2 = getProcname() # check we can call this twice
+    doAssert s1 == s2
+    doAssert s1 == "fn3"
+    doAssert getProcname(withType = true) == """fn3: proc (a: int; b: float64; c: "def")"""
+    const x = getProcname()
+    doAssert x == s1
+    let s3 = getExportcName()
+    doAssert "fn3" in s3
+    doAssert s3 != "fn3"
+  fn3(3)
+
+  var witness = 0
+  iterator fn4(): int =
+    doAssert getProcname() == "fn4"
+    doAssert getProcname(withType = true) == "fn4: proc (): int"
+    witness.inc
+  for a in fn4(): discard
+  doAssert witness == 1
+
+  when not defined(js):
+    witness = 0
+    iterator fn5(): int {.closure.} =
+      doAssert getProcname() == "fn5"
+      doAssert getProcname(withType = true) == "fn5: proc (): int"
+      doAssert "fn5" in getExportcName()
+      witness.inc
+    for a in fn5(): discard
+    doAssert witness == 1
+
+  func fn6 =
+    doAssert getProcname() == "fn6"
+    doAssert getProcname(withType = true) == "fn6: proc ()"
+    doAssert "fn6" in getExportcName()
+  fn6()
+
+
+type Foo = ref object of RootObj
+
+method fn7(self: Foo): int {.base.} =
+  doAssert getProcname() == "fn7"
+  doAssert getProcname(withType = true) == "fn7: proc (self: Foo): int"
+  doAssert "fn7" in getExportcName()
+  3
+
+var a = Foo()
+doAssert fn7(a) == 3

--- a/tests/stdlib/treflection.nim
+++ b/tests/stdlib/treflection.nim
@@ -5,26 +5,27 @@ discard """
 import std/reflection
 from std/strutils import contains
 
-
 block: # getOwnerName, getBackendProcName
   proc fn1 =
-    doAssert getOwnerName() == "fn1"
-    static: doAssert getOwnerName() == "fn1"
-    doAssert "fn1" in getBackendProcName()
+    doAssert getOwnerName == "fn1"
+    static: doAssert getOwnerName == "fn1"
+    doAssert "fn1" in getBackendProcName
   fn1()
 
   proc fn3(a: int, b = 3.4, c: static string = "def") =
-    let s1 = getOwnerName()
-    let s2 = getOwnerName() # check we can call this twice
+    let s1 = getOwnerName
+    let s2 = getOwnerName # check we can call this twice
+    let s2b = getOwnerName() # check we can call this with `()`
     doAssert s1 == s2
+    doAssert s1 == s2b
     doAssert s1 == "fn3"
     doAssert getOwnerTypeString == """proc (a: int; b: float64; c: "def")"""
-    const x = getOwnerName()
+    const x = getOwnerName
     doAssert x == s1
-    let s3 = getBackendProcName()
+    let s3 = getBackendProcName
     doAssert "fn3" in s3
     doAssert s3 != "fn3"
-    let s4 = getBackendProcName() # check we can call this twice
+    let s4 = getBackendProcName # check we can call this twice
     doAssert s4 == s3
   fn3(3)
 
@@ -37,21 +38,21 @@ block: # getOwnerName, getBackendProcName
   doAssert fn3b() == 3
 
   proc `fn1b aux`(): (string, string) =
-    doAssert "fn1b" in getBackendProcName()
-    doAssert "aux" in getBackendProcName()
-    (getOwnerName(), getOwnerTypeString)
+    doAssert "fn1b" in getBackendProcName
+    doAssert "aux" in getBackendProcName
+    (getOwnerName, getOwnerTypeString)
 
   doAssert `fn1b aux`() == ("fn1baux", "proc (): (string, string)")
 
   proc `fn1c+aux`(): (string, string) =
-    doAssert "fn1c" in getBackendProcName()
-    doAssert "aux" in getBackendProcName()
-    (getOwnerName(), getOwnerTypeString)
+    doAssert "fn1c" in getBackendProcName
+    doAssert "aux" in getBackendProcName
+    (getOwnerName, getOwnerTypeString)
   doAssert `fn1c+aux`() == ("fn1c+aux", "proc (): (string, string)")
 
   var witness = 0
   iterator fn4(): int =
-    doAssert getOwnerName() == "fn4"
+    doAssert getOwnerName == "fn4"
     doAssert getOwnerTypeString == "proc (): int"
     witness.inc
   for a in fn4(): discard
@@ -60,26 +61,26 @@ block: # getOwnerName, getBackendProcName
   when not defined(js):
     witness = 0
     iterator fn5(): int {.closure.} =
-      doAssert getOwnerName() == "fn5"
+      doAssert getOwnerName == "fn5"
       doAssert getOwnerTypeString == "proc (): int"
-      doAssert "fn5" in getBackendProcName()
+      doAssert "fn5" in getBackendProcName
       witness.inc
     for a in fn5(): discard
     doAssert witness == 1
 
   func fn6 =
-    doAssert getOwnerName() == "fn6"
+    doAssert getOwnerName == "fn6"
     doAssert getOwnerTypeString == "proc ()"
-    doAssert "fn6" in getBackendProcName()
+    doAssert "fn6" in getBackendProcName
   fn6()
 
 
 type Foo = ref object of RootObj
 
 method fn7(self: Foo): int {.base.} =
-  doAssert getOwnerName() == "fn7"
+  doAssert getOwnerName == "fn7"
   doAssert getOwnerTypeString == "proc (self: Foo): int"
-  doAssert "fn7" in getBackendProcName()
+  doAssert "fn7" in getBackendProcName
   3
 
 var a = Foo()
@@ -87,10 +88,13 @@ doAssert fn7(a) == 3
 
 const moduleName = "treflection"
 
-doAssert getOwnerName() == moduleName
+doAssert getOwnerName == moduleName
+doAssert getOwnerTypeString == ""
 block:
-  doAssert getOwnerName() == moduleName
+  doAssert getOwnerName == moduleName
+  doAssert getOwnerTypeString == ""
   template fn8(): string =
+    doAssert getOwnerTypeString() == "" # must be called with `()` inside a template
     let x = getOwnerName()
     x
   doAssert fn8() == moduleName
@@ -98,7 +102,7 @@ block:
 import std/macros
 
 macro fn8(a: int, b: static int = 0): (string, string) =
-  let a1 = getOwnerName()
+  let a1 = getOwnerName
   let a2 = getOwnerTypeString
   result = quote: (`a1`, `a2`)
 

--- a/tests/stdlib/treflection.nim
+++ b/tests/stdlib/treflection.nim
@@ -24,7 +24,23 @@ block:
     let s3 = getExportcName()
     doAssert "fn3" in s3
     doAssert s3 != "fn3"
+    let s4 = getExportcName() # check we can call this twice
+    doAssert s4 == s3
   fn3(3)
+
+  proc `fn1b aux`(): auto =
+    doAssert "fn1b" in getExportcName()
+    doAssert "aux" in getExportcName()
+    (getProcname(), getProcname(withType = true))
+
+  # xxx bug: `untyped` is returned when return type is auto (it's a bug with `getTypeInst.repr`)
+  doAssert `fn1b aux`() == ("fn1baux", "fn1baux: proc (): untyped")
+
+  proc `fn1c+aux`(): auto =
+    doAssert "fn1c" in getExportcName()
+    doAssert "aux" in getExportcName()
+    (getProcname(), getProcname(withType = true))
+  doAssert `fn1c+aux`() == ("fn1c+aux", "fn1c+aux: proc (): untyped")
 
   var witness = 0
   iterator fn4(): int =
@@ -71,3 +87,12 @@ block:
     let x = getProcname()
     x
   doAssert fn8() == moduleName
+
+import std/macros
+
+macro fn8(a: int, b: static int = 0): (string, string) =
+  let a1 = getProcname()
+  let a2 = getProcname(withType = true)
+  result = quote: (`a1`, `a2`)
+
+doAssert fn8(1) == ("fn8", "fn8: proc (a: int; b: b:type): (string, string)")

--- a/tests/stdlib/treflection.nim
+++ b/tests/stdlib/treflection.nim
@@ -5,6 +5,7 @@ discard """
 import std/reflection
 from std/strutils import contains
 
+
 block:
   proc fn1 =
     doAssert getProcname() == "fn1"
@@ -60,3 +61,12 @@ method fn7(self: Foo): int {.base.} =
 
 var a = Foo()
 doAssert fn7(a) == 3
+
+const moduleName = getProcname
+doAssert getProcname() == moduleName
+block:
+  doAssert getProcname() == moduleName
+  template fn8(): string =
+    let x = getProcname()
+    x
+  doAssert fn8() == moduleName


### PR DESCRIPTION
fix #8212
close #17640

I've been using this code for a while, it's very helpful in particular for improving debugging, logging etc. I finally made a PR for it. `withType = true` is in particular useful when enclosing proc is generic and caller must distinguish which proc (eg, think procs like fromJson, jsonTo etc)

(i added the tests for `fn1b aux`, `fn1c+aux` and `fn8` which i stole/borrowed from #17640 :) )

this module can grow more API's over time.

## future work
- [ ] add isTopLevel or some API that can retrieve this
- [ ] at least link other reflection APIs from this module, eg `locals`
- [ ] see also https://github.com/nim-lang/Nim/pull/9560