### PR TITLE
document caveats of `quit`

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1185,10 +1185,6 @@ when defined(nimdoc):
     ##
     ## Before stopping the program the "exit procedures" are called in the
     ## opposite order they were added with `addExitProc <exitprocs.html#addExitProc,proc)>`_.
-    ## `quit` never returns and ignores any exception that may have been raised
-    ## by the quit procedures.  It does *not* call the garbage collector to free
-    ## all the memory, unless a quit procedure calls `GC_fullCollect
-    ## <#GC_fullCollect>`_.
     ##
     ## The proc `quit(QuitSuccess)` is called implicitly when your nim
     ## program finishes without incident for platforms where this is the
@@ -1199,6 +1195,14 @@ when defined(nimdoc):
     ## have any compile time effect. If you need to stop the compiler inside a
     ## macro, use the `error <manual.html#pragmas-error-pragma>`_ or `fatal
     ## <manual.html#pragmas-fatal-pragma>`_ pragmas.
+    ##
+    ## .. danger:: In almost all cases, in particular in library code, prefer
+    ##   alternatives, e.g. `doAssert false` or raise a `Defect`.
+    ##   `quit` bypasses regular control flow in particular `defer`,
+    ##   `try`, `catch`, `finally` and `destructors`, and exceptions that may have been
+    ##   raised by an `addExitProc` proc, as well as cleanup code in other threads.
+    ##   It does *not* call the garbage collector to free all the memory,
+    ##   unless an `addExitProc` proc calls `GC_fullCollect <#GC_fullCollect>`_.
 
 elif defined(genode):
   include genode/env


### PR DESCRIPTION
refs [quit considered evil: bypasses `defer` and `try/catch/finally` which might do important cleanups - Nim forum](https://forum.nim-lang.org/t/4042#25152)

`quit` should almost never be used in library code, and even if it's used in application code, it prevents code reuse, breaking expectations and control flow of client code (try/finally, destructors, cleanup in other threads etc). `doAssert false` + friends (including `fail`, see future work) should almost always be prefered.

## future work
- [ ] add an API `proc fail*(msg = "") {.noreturn.}` which raises a `Defect`, honors control flow, and provides a better alternative to both `quit` and `doAssert false` (which cannot be `{.noreturn.}`)

