### PR TITLE
add `NotImplementedDefect`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -271,6 +271,8 @@
 - Added `genasts.genAst` that avoids the problems inherent with `quote do` and can
   be used as a replacement.
 
+- Added `NotImplementedDefect`.
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.

--- a/lib/impure/db_odbc.nim
+++ b/lib/impure/db_odbc.nim
@@ -523,10 +523,10 @@ proc open*(connection, user, password, database: string): DbConn {.
     result.dbError()
 
 proc setEncoding*(connection: DbConn, encoding: string): bool {.
-  tags: [ReadDbEffect, WriteDbEffect], raises: [DbError].} =
+  tags: [ReadDbEffect, WriteDbEffect].} =
   ## Currently not implemented for ODBC.
   ##
   ## Sets the encoding of a database connection, returns true for
   ## success, false for failure.
-  ##result = set_character_set(connection, encoding) == 0
-  dbError("setEncoding() is currently not implemented by the db_odbc module")
+  # result = set_character_set(connection, encoding) == 0
+  raise newException(NotImplementedDefect, "")

--- a/lib/pure/dynlib.nim
+++ b/lib/pure/dynlib.nim
@@ -136,19 +136,19 @@ elif defined(nintendoswitch):
   #
 
   proc dlclose(lib: LibHandle) =
-    raise newException(OSError, "dlclose not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
   proc dlopen(path: cstring, mode: int): LibHandle =
-    raise newException(OSError, "dlopen not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
   proc dlsym(lib: LibHandle, name: cstring): pointer =
-    raise newException(OSError, "dlsym not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
   proc loadLib(path: string, global_symbols = false): LibHandle =
-    raise newException(OSError, "loadLib not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
   proc loadLib(): LibHandle =
-    raise newException(OSError, "loadLib not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
   proc unloadLib(lib: LibHandle) =
-    raise newException(OSError, "unloadLib not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
   proc symAddr(lib: LibHandle, name: cstring): pointer =
-    raise newException(OSError, "symAddr not implemented on Nintendo Switch!")
+    raise newException(NotImplementedDefect, "")
 
 elif defined(windows) or defined(dos):
   #

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2891,10 +2891,10 @@ elif defined(nodejs):
       raise newException(IndexDefect, formatErrorIndexBound(i - 1, argv.len - 2))
 elif defined(nintendoswitch):
   proc paramStr*(i: int): string {.tags: [ReadIOEffect].} =
-    raise newException(OSError, "paramStr is not implemented on Nintendo Switch")
+    raise newException(NotImplementedDefect, "")
 
   proc paramCount*(): int {.tags: [ReadIOEffect].} =
-    raise newException(OSError, "paramCount is not implemented on Nintendo Switch")
+    raise newException(NotImplementedDefect, "")
 
 elif defined(windows):
   # Since we support GUI applications with Nim, we sometimes generate
@@ -2926,16 +2926,16 @@ elif defined(windows):
 
 elif defined(genode):
   proc paramStr*(i: int): string =
-    raise newException(OSError, "paramStr is not implemented on Genode")
+    raise newException(NotImplementedDefect, "")
 
   proc paramCount*(): int =
-    raise newException(OSError, "paramCount is not implemented on Genode")
+    raise newException(NotImplementedDefect, "")
 elif weirdTarget:
   proc paramStr*(i: int): string {.tags: [ReadIOEffect].} =
-    raise newException(OSError, "paramStr is not implemented on current platform")
+    raise newException(NotImplementedDefect, "")
 
   proc paramCount*(): int {.tags: [ReadIOEffect].} =
-    raise newException(OSError, "paramCount is not implemented on current platform")
+    raise newException(NotImplementedDefect, "")
 elif not defined(createNimRtl) and
   not(defined(posix) and appType == "lib"):
   # On Posix, there is no portable way to get the command line from a DLL.

--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -45,7 +45,7 @@ iterator walkDirRecFilter*(dir: string, follow: proc(entry: PathEntry): bool = n
 
 proc nativeToUnixPath*(path: string): string =
   # pending https://github.com/nim-lang/Nim/pull/13265
-  doAssert not path.isAbsolute # not implemented here; absolute files need more care for the drive
+  doAssert not path.isAbsolute, path # not implemented here; absolute files need more care for the drive
   when DirSep == '\\':
     result = replace(path, '\\', '/')
   else: result = path

--- a/lib/system/dyncalls.nim
+++ b/lib/system/dyncalls.nim
@@ -165,34 +165,15 @@ elif defined(windows) or defined(dos):
       if result != nil: return
     procAddrError(name)
 
-elif defined(genode):
-
-  proc nimUnloadLibrary(lib: LibHandle) {.
-    error: "nimUnloadLibrary not implemented".}
-
-  proc nimLoadLibrary(path: string): LibHandle {.
-    error: "nimLoadLibrary not implemented".}
-
-  proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr {.
-    error: "nimGetProcAddr not implemented".}
-
-elif defined(nintendoswitch) or defined(freertos):
+elif defined(genode) or defined(nintendoswitch) or defined(freertos):
   proc nimUnloadLibrary(lib: LibHandle) =
-    cstderr.rawWrite("nimUnLoadLibrary not implemented")
-    cstderr.rawWrite("\n")
-    quit(1)
+    raise newException(NotImplementedDefect, "")
 
   proc nimLoadLibrary(path: string): LibHandle =
-    cstderr.rawWrite("nimLoadLibrary not implemented")
-    cstderr.rawWrite("\n")
-    quit(1)
-
+    raise newException(NotImplementedDefect, "")
 
   proc nimGetProcAddr(lib: LibHandle, name: cstring): ProcAddr =
-    cstderr.rawWrite("nimGetProAddr not implemented")
-    cstderr.rawWrite(name)
-    cstderr.rawWrite("\n")
-    quit(1)
+    raise newException(NotImplementedDefect, "")
 
 else:
   {.error: "no implementation for dyncalls".}

--- a/lib/system/exceptions.nim
+++ b/lib/system/exceptions.nim
@@ -96,6 +96,8 @@ type
     ## Raised for unsuccessful attempts to allocate memory.
   IndexDefect* = object of Defect ## \
     ## Raised if an array index is out of bounds.
+  NotImplementedDefect* = object of Defect ## \
+    ## Raised if an API is not implemented for some configuration / environment.
 
   FieldDefect* = object of Defect ## \
     ## Raised if a record field is not accessible because its discriminant's

--- a/lib/system/mm/go.nim
+++ b/lib/system/mm/go.nim
@@ -68,10 +68,10 @@ proc alloc0Impl(size: Natural): pointer =
   result = goMalloc(size.uint)
 
 proc reallocImpl(p: pointer, newsize: Natural): pointer =
-  doAssert false, "not implemented"
+  raise newException(NotImplementedDefect, "")
 
 proc realloc0Impl(p: pointer, oldsize, newsize: Natural): pointer =
-  doAssert false, "not implemented"
+  raise newException(NotImplementedDefect, "")
 
 proc deallocImpl(p: pointer) =
   discard


### PR DESCRIPTION
* using a non implemented API is a Defect, not a CatchableError
* this is a common pattern, and using `NotImplementedDefect` is self-documenting (no need to add redundant error message "X is not implemented", the error message will already show the same information content)