### PR TITLE
add compiler/debugutils.nim to help debugging compiler

### DIFF
--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -4,7 +4,7 @@ Utilities to help with debugging nim compiler.
 Experimental API, subject to change.
 ]##
 
-import ./options
+import options
 
 var conf0: ConfigRef
 

--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -1,0 +1,19 @@
+##[
+Utilities to help with debugging nim compiler.
+
+Experimental API, subject to change.
+]##
+
+import ./options
+
+var conf0: ConfigRef
+
+proc onNewConfigRef*(conf: ConfigRef) {.inline.} =
+  ## Caches `conf`, which can be retrieved with `getConfigRef`.
+  ## This avoids having to forward `conf` all the way down the call chain to
+  ## procs that need it during a debugging session.
+  conf0 = conf
+
+proc getConfigRef*(): ConfigRef =
+  ## nil, if -d:nimDebugUtils wasn't specified
+  result = conf0

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -446,6 +446,9 @@ proc newProfileData(): ProfileData =
 const foreignPackageNotesDefault* = {
   hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser}
 
+proc isDefined*(conf: ConfigRef; symbol: string): bool
+import ./debugutils
+
 proc newConfigRef*(): ConfigRef =
   result = ConfigRef(
     selectedGC: gcRefc,
@@ -504,16 +507,21 @@ proc newConfigRef*(): ConfigRef =
   # enable colors by default on terminals
   if terminal.isatty(stderr):
     incl(result.globalOptions, optUseColors)
+  when defined(nimDebugUtils):
+    onNewConfigRef(result)
 
 proc newPartialConfigRef*(): ConfigRef =
   ## create a new ConfigRef that is only good enough for error reporting.
-  result = ConfigRef(
-    selectedGC: gcRefc,
-    verbosity: 1,
-    options: DefaultOptions,
-    globalOptions: DefaultGlobalOptions,
-    foreignPackageNotes: foreignPackageNotesDefault,
-    notes: NotesVerbosity[1], mainPackageNotes: NotesVerbosity[1])
+  when defined(nimDebugUtils):
+    result = getConfigRef()
+  else:
+    result = ConfigRef(
+      selectedGC: gcRefc,
+      verbosity: 1,
+      options: DefaultOptions,
+      globalOptions: DefaultGlobalOptions,
+      foreignPackageNotes: foreignPackageNotesDefault,
+      notes: NotesVerbosity[1], mainPackageNotes: NotesVerbosity[1])
 
 proc cppDefine*(c: ConfigRef; define: string) =
   c.cppDefines.incl define

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -447,7 +447,8 @@ const foreignPackageNotesDefault* = {
   hintProcessing, warnUnknownMagic, hintQuitCalled, hintExecuting, hintUser, warnUser}
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
-import ./debugutils
+
+import debugutils
 
 proc newConfigRef*(): ConfigRef =
   result = ConfigRef(


### PR DESCRIPTION
add compiler/debugutils.nim; this module (intended to grow) adds utilities to help debugging the compiler. 

When nim is built without -d:nimDebugUtils, it has no effect; with -d:nimDebugUtils, it enables some callbacks that help with debugging.

For now this helps with the issue mentioned in https://github.com/nim-lang/Nim/pull/17541, by providing a better fix: instead of SIGSEGV (as before this PR) or returning a dummy path (as with https://github.com/nim-lang/Nim/pull/17541), we return a valid path (see https://github.com/nim-lang/Nim/pull/17541#issue-602138528 for how to reproduce).

We cache a global ConfigRef (again, this is only enabled via `-d:nimDebugUtils`), which allows client code to access it in any context, without having to forward ConfigRef all the way to the code that requires it during a debugging session, thus making debugging easier.

## future work
I've already implemented a number of those in a private fork, so this is a start.
* add more debugging functionality, counters, etc, all hidden unless `-d:nimDebugUtils` is specified.
* better debugging utilities for PNode, PType, PSym; we already have `astalgo.debug`, but its functionality is limited. I've been using the (fully generic) pretty printing described in https://github.com/nim-lang/RFCs/issues/203#issuecomment-602534906 which really helps with debugging some compiler issues, when you easily need to inspect recursive cyclic data structures such as PNode, PType, PSym.
* etc.

more debugging utilies lowers the barrier for fixing compiler bugs.
