### PR TITLE
use sink in deques

### DIFF
--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -50,7 +50,7 @@ runnableExamples:
 
 import std/private/since
 
-import math
+import std/math
 
 type
   Deque*[T] = object


### PR DESCRIPTION
Object which can only be move need sink parameters, otherwise it causes error at compile time.