### PR TITLE
don't run one example on 32-bit machines

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -951,9 +951,10 @@ func frexp*[T: float32|float64](x: T): tuple[frac: T, exp: int] {.inline.} =
     doAssert frexp(0.0) == (0.0, 0)
 
     # special cases:
-    doAssert frexp(-0.0).frac.signbit # signbit preserved for +-0
-    doAssert frexp(Inf).frac == Inf # +- Inf preserved
-    doAssert frexp(NaN).frac.isNaN
+    when sizeof(int) == 8:
+      doAssert frexp(-0.0).frac.signbit # signbit preserved for +-0
+      doAssert frexp(Inf).frac == Inf # +- Inf preserved
+      doAssert frexp(NaN).frac.isNaN
 
   when not defined(js):
     var exp: cint


### PR DESCRIPTION
This example seems to break our 32-bit nightlies builds.

This is just a temporary solution (TM) until we figure out a better one.