### PR TITLE
removing warning imported and not used debugutils

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -448,7 +448,8 @@ const foreignPackageNotesDefault* = {
 
 proc isDefined*(conf: ConfigRef; symbol: string): bool
 
-import debugutils
+when defined(nimDebugUtils):
+  import debugutils
 
 proc newConfigRef*(): ConfigRef =
   result = ConfigRef(


### PR DESCRIPTION
I believe there is no reason to import unless specified `-d:nimDebugUtils`. Generates an unnecessary warning when compiling the Nim compiler.