### PR TITLE
fixes #6981; #9831

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -512,6 +512,9 @@ proc overloadedCallOpr(c: PContext, n: PNode): PNode =
   var amb = false
   if searchInScopes(c, par, amb) == nil:
     result = nil
+  elif n.kind == nkCall and n[0].kind == nkClosedSymChoice:
+    # fix for #6981,#9831
+    result = nil
   else:
     result = newNodeI(nkCall, n.info)
     result.add newIdentNode(par, n.info)
@@ -1005,6 +1008,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode =
     if result == nil:
       # XXX: hmm, what kind of symbols will end up here?
       # do we really need to try the overload resolution?
+      # answer: nkCall(nkClosedSymChoice), i.e. overloaded generics
       n[0] = prc
       nOrig[0] = prc
       n.flags.incl nfExprCall

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -505,15 +505,14 @@ proc semOpAux(c: PContext, n: PNode) =
       a.typ = a[1].typ
     else:
       n[i] = semExprWithType(c, a, flags)
-
 proc overloadedCallOpr(c: PContext, n: PNode): PNode =
   # quick check if there is *any* () operator overloaded:
   var par = getIdent(c.cache, "()")
   var amb = false
   if searchInScopes(c, par, amb) == nil:
     result = nil
-  elif n.kind == nkCall and n[0].kind == nkClosedSymChoice:
-    # fix for #6981,#9831
+  elif n.hasSubnodeWith(nkClosedSymChoice):
+      # fix for #6981,#9831
     result = nil
   else:
     result = newNodeI(nkCall, n.info)

--- a/tests/specialops/tcallops.nim
+++ b/tests/specialops/tcallops.nim
@@ -33,12 +33,19 @@ let a = "1"
 let b = "2"
 let c = "3"
 
+doAssert a(b) == "(12)"
+doAssert a.b(c) == `()`(b, a, c)
+doAssert (a.b)(c) == `()`(a.b, c)
+doAssert `()`(a.b, c) == `()`(`()`(b, a), c)
 block: #issues 6981,9831
   proc bar[T]() = discard
   proc bar[T](a:int) = discard
   bar[int]()#must compile, not be rewritten as `()`(bar)
 
-doAssert a(b) == "(12)"
-doAssert a.b(c) == `()`(b, a, c)
-doAssert (a.b)(c) == `()`(a.b, c)
-doAssert `()`(a.b, c) == `()`(`()`(b, a), c)
+block: #templates, macros should work too
+  template bar[T]() = discard
+  template bar[T](a:int) = discard
+  bar[int]()
+  macro baz[T]() = discard
+  macro baz[T](a:int) = discard
+  baz[int]()

--- a/tests/specialops/tcallops.nim
+++ b/tests/specialops/tcallops.nim
@@ -33,6 +33,11 @@ let a = "1"
 let b = "2"
 let c = "3"
 
+block: #issues 6981,9831
+  proc bar[T]() = discard
+  proc bar[T](a:int) = discard
+  bar[int]()#must compile, not be rewritten as `()`(bar)
+
 doAssert a(b) == "(12)"
 doAssert a.b(c) == `()`(b, a, c)
 doAssert (a.b)(c) == `()`(a.b, c)


### PR DESCRIPTION
fix #6981
fix #9831

Is this too hacky? i basically added "if bug#6981: don't" 

the fact is, nkCall(nkClosedSymChoice) have been passing through `overloadedCallOpr` and then the `else` branch in `semIndirectOp` for >12years, so I went with changing the least amount possible.