### PR TITLE
ast: add getPIdent

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1054,6 +1054,12 @@ const
   defaultAlignment = -1
   defaultOffset = -1
 
+proc getPIdent*(a: PNode): PIdent {.inline.} =
+  ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
+  case a.kind
+  of nkSym: a.sym.name
+  of nkIdent:  a.ident
+  else: nil
 
 proc getnimblePkg*(a: PSym): PSym =
   result = a

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1056,6 +1056,8 @@ const
 
 proc getPIdent*(a: PNode): PIdent {.inline.} =
   ## Returns underlying `PIdent` for `{nkSym, nkIdent}`, or `nil`.
+  # xxx consider whether also returning the 1st ident for {nkOpenSymChoice, nkClosedSymChoice}
+  # which may simplify code.
   case a.kind
   of nkSym: a.sym.name
   of nkIdent:  a.ident

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -964,14 +964,12 @@ proc skipHiddenNodes(n: PNode): PNode =
     else: break
 
 proc accentedName(g: var TSrcGen, n: PNode) =
+  # This is for cases where ident should've really been a `nkAccQuoted`, e.g. `:tmp`
+  # or if user writes a macro with `ident":foo"`. It's unclear whether these should be legal.
   const backticksNeeded = OpChars + {'[', '{', '\''}
   if n == nil: return
-  let isOperator =
-    if n.kind == nkIdent and n.ident.s.len > 0 and n.ident.s[0] in backticksNeeded: true
-    elif n.kind == nkSym and n.sym.name.s.len > 0 and n.sym.name.s[0] in backticksNeeded: true
-    else: false
-
-  if isOperator:
+  let ident = n.getPIdent
+  if ident != nil and ident.s[0] in backticksNeeded:
     put(g, tkAccent, "`")
     gident(g, n)
     put(g, tkAccent, "`")
@@ -999,9 +997,9 @@ proc infixArgument(g: var TSrcGen, n: PNode, i: int) =
     put(g, tkParRi, ")")
 
 proc isCustomLit(n: PNode): bool =
-  n.len == 2 and n[0].kind == nkRStrLit and
-    (n[1].kind == nkIdent and n[1].ident.s.startsWith('\'')) or
-    (n[1].kind == nkSym and n[1].sym.name.s.startsWith('\''))
+  if n.len == 2 and n[0].kind == nkRStrLit:
+    let ident = n[1].getPIdent
+    result = ident != nil and ident.s.startsWith('\'')
 
 proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
   if isNil(n): return
@@ -1234,8 +1232,8 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     else:
       gsub(g, n, 0)
       put(g, tkDot, ".")
-      if n.len > 1:
-        accentedName(g, n[1])
+      assert n.len == 2, $n.len
+      accentedName(g, n[1])
   of nkBind:
     putWithSpace(g, tkBind, "bind")
     gsub(g, n, 0)

--- a/compiler/reorder.nim
+++ b/compiler/reorder.nim
@@ -36,11 +36,8 @@ proc newDepN(id: int, pnode: PNode): DepN =
 proc accQuoted(cache: IdentCache; n: PNode): PIdent =
   var id = ""
   for i in 0..<n.len:
-    let x = n[i]
-    case x.kind
-    of nkIdent: id.add(x.ident.s)
-    of nkSym: id.add(x.sym.name.s)
-    else: discard
+    let ident = n[i].getPIdent
+    if ident != nil: id.add(ident.s)
   result = getIdent(cache, id)
 
 proc addDecl(cache: IdentCache; n: PNode; declares: var IntSet) =


### PR DESCRIPTION
alternative to https://github.com/nim-lang/Nim/pull/17540

closes https://github.com/nim-lang/Nim/pull/17540
(but the pattern in https://github.com/nim-lang/Nim/pull/17540 (via an intermediate `ptr`) is IMO sane and could be reused in other settings)