### PR TITLE
[feature] add arbitrary code execution to strformat

### DIFF
--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -646,3 +646,4 @@ macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
           elif i mod 3 == 0: "Fizz"
           else: $i) & " "
       res}""".fmt('{','}','_') == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
+  strformatImpl(pattern, openChar.intVal.char, closeChar.intVal.char,fmtChar.intVal.char)

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -588,7 +588,7 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
 
         var subexpr = ""
         var inParens = 0
-        while i < f.len and f[i] != closeChar and (f[i] != fmtChar or inParens!=0):
+        while i < f.len and f[i] != closeChar and (f[i] != ':' or inParens!=0):
           case f[i]
           of '(': inc inParens
           of ')': dec inParens
@@ -596,7 +596,7 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
             let start = i
             inc i
             i += f.skipWhitespace(i)
-            if f[i] == closeChar or f[i] == fmtChar:
+            if f[i] == closeChar or f[i] == ':':
               result.add newCall(bindSym"add", res, newLit(subexpr & f[start ..< i]))
             else:
               subexpr.add f[start ..< i]
@@ -651,7 +651,6 @@ macro fmt*(pattern: string): untyped = strformatImpl(pattern, '{', '}')
 macro fmt*(pattern: string; openChar, closeChar: char): untyped =
   ## The same as `fmt <#fmt.m,string>`_, but uses `openChar` instead of `'{'`
   ## and `closeChar` instead of `'}'`.
-  ## Change `fmtChar` to allow use of colons inside expressions
   runnableExamples:
     let testInt = 123
     assert "<testInt>".fmt('<', '>') == "123"

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -629,7 +629,7 @@ macro `&`*(pattern: string): untyped = strformatImpl(pattern, '{', '}')
 macro fmt*(pattern: string): untyped = strformatImpl(pattern, '{', '}')
   ## An alias for `& <#&.m,string>`_.
 
-macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
+macro fmt*(pattern: string; openChar, closeChar: char; fmtChar=':'): untyped =
   ## The same as `fmt <#fmt.m,string>`_, but uses `openChar` instead of `'{'`
   ## and `closeChar` instead of `'}'`.
   ## Change `fmtChar` to allow use of colons inside expressions

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -75,18 +75,18 @@ runnableExamples:
 
 ##[
 # Expressions
+]##
 runnableExamples:
   let x = 3.14
   assert fmt"{(if x!=0: 1.0/x else: 0):.5}" == "0.31847"
   assert fmt"""{(block:
-    var res:string
+    var res: string
     for i in 1..15:
       res.add (if i mod 15 == 0: "FizzBuzz"
         elif i mod 5 == 0: "Buzz"
         elif i mod 3 == 0: "Fizz"
         else: $i) & " "
     res)}""" == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
-]##
 ##[
 # Debugging strings
 

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -545,7 +545,7 @@ template formatValue(result: var string; value: char; specifier: string) =
 template formatValue(result: var string; value: cstring; specifier: string) =
   result.add value
 
-proc strformatImpl(pattern: NimNode; openChar, closeChar: char,fmtChar=':'): NimNode =
+proc strformatImpl(pattern: NimNode; openChar, closeChar: char; fmtChar=':'): NimNode =
   if pattern.kind notin {nnkStrLit..nnkTripleStrLit}:
     error "string formatting (fmt(), &) only works with string literals", pattern
   if openChar == fmtChar or closeChar == fmtChar:

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -646,4 +646,5 @@ macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
           elif i mod 3 == 0: "Fizz"
           else: $i) & " "
       res}""".fmt('{','}','_') == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
+      
   strformatImpl(pattern, openChar.intVal.char, closeChar.intVal.char,fmtChar.intVal.char)

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -641,7 +641,7 @@ macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
     assert """{block:
       var res:string
       for i in 1..15:
-        res.add(if i mod 15 == 0: "FizzBuzz"
+        res.add (if i mod 15 == 0: "FizzBuzz"
           elif i mod 5 == 0: "Buzz"
           elif i mod 3 == 0: "Fizz"
           else: $i) & " "


### PR DESCRIPTION
https://github.com/nim-lang/RFCs/issues/366

allowing colons inside fmt by replacing the format specifier delimiter allows arbitrary nim code to be run within fmt expressions.
this should have no effect on existing code, as there is a default parameter.

fixed a bug whereby fmt"{foo}}" would error with "index 6 not in [0..5]" rather than raise an exception

changed error messages to reflect the open/closeChars passed to fmt

perhaps the runnableExample is a bit over the top, and doesn't highlight how one can still use the format delimiter?
wanted to show all the colons, and that the parser doesn't trip on the '=' either.