### PR TITLE
followup strformat PR. backslash escapes, tests, docs

### DIFF
--- a/changelogs/changelog_X_XX_X.md
+++ b/changelogs/changelog_X_XX_X.md
@@ -13,6 +13,7 @@ The changes should go to changelog.md!
 
 - Changed `example.foo` to take additional `bar` parameter.
 
+- Added support for evaluating parenthesised expressions in strformat
 
 ## Language changes
 

--- a/changelogs/changelog_X_XX_X.md
+++ b/changelogs/changelog_X_XX_X.md
@@ -9,9 +9,7 @@ The changes should go to changelog.md!
 
 ## Standard library additions and changes
 
-- Added `example.exampleProc`.
-
-- Changed `example.foo` to take additional `bar` parameter.
+- Added support for evaluating `if`/`for`/etc expressions in strformat
 
 
 ## Language changes

--- a/changelogs/changelog_X_XX_X.md
+++ b/changelogs/changelog_X_XX_X.md
@@ -9,7 +9,9 @@ The changes should go to changelog.md!
 
 ## Standard library additions and changes
 
-- Added support for evaluating `if`/`for`/etc expressions in strformat
+- Added `example.exampleProc`.
+
+- Changed `example.foo` to take additional `bar` parameter.
 
 
 ## Language changes

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -646,3 +646,4 @@ macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
           elif i mod 3 == 0: "Fizz"
           else: $i) & " "
       res}""".fmt('{','}','_') == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
+  strformatImpl(pattern, openChar.intVal.char, closeChar.intVal.char,fmtChar.intVal.char)

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -588,7 +588,7 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
 
         var subexpr = ""
         var inParens = 0
-        while i < f.len and f[i] != closeChar and (f[i] != fmtChar or inParens!=0):
+        while i < f.len and f[i] != closeChar and (f[i] != ':' or inParens!=0):
           case f[i]
           of '(': inc inParens
           of ')': dec inParens
@@ -596,7 +596,7 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
             let start = i
             inc i
             i += f.skipWhitespace(i)
-            if f[i] == closeChar or f[i] == fmtChar:
+            if f[i] == closeChar or f[i] == ':':
               result.add newCall(bindSym"add", res, newLit(subexpr & f[start ..< i]))
             else:
               subexpr.add f[start ..< i]
@@ -651,7 +651,6 @@ macro fmt*(pattern: string): untyped = strformatImpl(pattern, '{', '}')
 macro fmt*(pattern: string; openChar, closeChar: char): untyped =
   ## The same as `fmt <#fmt.m,string>`_, but uses `openChar` instead of `'{'`
   ## and `closeChar` instead of `'}'`.
-  ## Change `fmtChar` to allow use of colons inside expressions
   runnableExamples:
     let testInt = 123
     assert "<testInt>".fmt('<', '>') == "123"

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -608,11 +608,10 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
         while i < f.len and f[i] != closeChar and (f[i] != ':' or inParens != 0):
           case f[i]
           of '\\':
-            if i < f.len-1 and f[i+1] in {openChar,closeChar,':'}:
-              inc i
-          of '\'': 
+            if i < f.len-1 and f[i+1] in {openChar,closeChar,':'}: inc i
+          of '\'':
             if not inDoubleQuotes and notEscaped: inSingleQuotes = not inSingleQuotes
-          of '\"': 
+          of '\"':
             if notEscaped: inDoubleQuotes = not inDoubleQuotes
           of '(':
             if not (inSingleQuotes or inDoubleQuotes): inc inParens

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -629,7 +629,7 @@ macro `&`*(pattern: string): untyped = strformatImpl(pattern, '{', '}')
 macro fmt*(pattern: string): untyped = strformatImpl(pattern, '{', '}')
   ## An alias for `& <#&.m,string>`_.
 
-macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
+macro fmt*(pattern: string; openChar, closeChar: char; fmtChar=':'): untyped =
   ## The same as `fmt <#fmt.m,string>`_, but uses `openChar` instead of `'{'`
   ## and `closeChar` instead of `'}'`.
   ## Change `fmtChar` to allow use of colons inside expressions

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -609,8 +609,10 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
           of '\\':
             if i < f.len-1 and f[i+1] in {'(',')','{','}',':'}:
               inc i
-          of '\'': inSingleQuotes = not inSingleQuotes
-          of '\"': inDoubleQuotes = not inDoubleQuotes
+          of '\'': 
+            if f[i-1]!='\\': inSingleQuotes = not inSingleQuotes
+          of '\"': 
+            if f[i-1]!='\\': inDoubleQuotes = not inDoubleQuotes
           of '(':
             if not (inSingleQuotes or inDoubleQuotes): inc inParens
           of ')':

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -75,18 +75,18 @@ runnableExamples:
 
 ##[
 # Expressions
+]##
 runnableExamples:
   let x = 3.14
   assert fmt"{(if x!=0: 1.0/x else: 0):.5}" == "0.31847"
   assert fmt"""{(block:
-    var res:string
+    var res: string
     for i in 1..15:
       res.add (if i mod 15 == 0: "FizzBuzz"
         elif i mod 5 == 0: "Buzz"
         elif i mod 3 == 0: "Fizz"
         else: $i) & " "
     res)}""" == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
-]##
 ##[
 # Debugging strings
 

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -545,7 +545,7 @@ template formatValue(result: var string; value: char; specifier: string) =
 template formatValue(result: var string; value: cstring; specifier: string) =
   result.add value
 
-proc strformatImpl(pattern: NimNode; openChar, closeChar: char,fmtChar=':'): NimNode =
+proc strformatImpl(pattern: NimNode; openChar, closeChar: char; fmtChar=':'): NimNode =
   if pattern.kind notin {nnkStrLit..nnkTripleStrLit}:
     error "string formatting (fmt(), &) only works with string literals", pattern
   if openChar == fmtChar or closeChar == fmtChar:

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -646,4 +646,5 @@ macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
           elif i mod 3 == 0: "Fizz"
           else: $i) & " "
       res}""".fmt('{','}','_') == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
+      
   strformatImpl(pattern, openChar.intVal.char, closeChar.intVal.char,fmtChar.intVal.char)

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -641,7 +641,7 @@ macro fmt*(pattern: string; openChar, closeChar: char,fmtChar=':'): untyped =
     assert """{block:
       var res:string
       for i in 1..15:
-        res.add(if i mod 15 == 0: "FizzBuzz"
+        res.add (if i mod 15 == 0: "FizzBuzz"
           elif i mod 5 == 0: "Buzz"
           elif i mod 3 == 0: "Fizz"
           else: $i) & " "

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -604,15 +604,16 @@ proc strformatImpl(pattern: NimNode; openChar, closeChar: char): NimNode =
         var inParens = 0
         var inSingleQuotes = false
         var inDoubleQuotes = false
+        template notEscaped:bool = f[i-1]!='\\'
         while i < f.len and f[i] != closeChar and (f[i] != ':' or inParens != 0):
           case f[i]
           of '\\':
-            if i < f.len-1 and f[i+1] in {'(',')','{','}',':'}:
+            if i < f.len-1 and f[i+1] in {openChar,closeChar,':'}:
               inc i
           of '\'': 
-            if f[i-1]!='\\': inSingleQuotes = not inSingleQuotes
+            if not inDoubleQuotes and notEscaped: inSingleQuotes = not inSingleQuotes
           of '\"': 
-            if f[i-1]!='\\': inDoubleQuotes = not inDoubleQuotes
+            if notEscaped: inDoubleQuotes = not inDoubleQuotes
           of '(':
             if not (inSingleQuotes or inDoubleQuotes): inc inParens
           of ')':

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -543,6 +543,7 @@ proc main() =
     doAssert fmt"""{\{"a"\:1,"b"\:2\}.toTable() = }""" == """{"a":1,"b":2}.toTable() = {"a": 1, "b": 2}"""
     doAssert fmt"""{(\{3: (1,"hi",0.9),4: (4,"lo",1.1)\}).toTable()}""" == """{3: (1, "hi", 0.9), 4: (4, "lo", 1.1)}"""
     doAssert fmt"""{ (%* \{"name": "Isaac", "books": ["Robot Dreams"]\}) }""" == """{"name":"Isaac","books":["Robot Dreams"]}"""
+    doAssert """%( \%\* {"name": "Isaac"})*""".fmt('%','*') == """{"name":"Isaac"}"""
   block: #parens in quotes that fool my syntax highlighter
     doAssert fmt"{(if true: ')' else: '(')}" == ")"
     doAssert fmt"{(if true: ']' else: ')')}" == "]"

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -549,5 +549,10 @@ proc main() =
     doAssert fmt"""{(if true: "\")\"" else: "\"(")}""" == """")""""
     doAssert &"""{(if true: "\")" else: "")}""" == "\")"
     doAssert &"{(if true: \"\\\")\" else: \"\")}" == "\")"
+    doAssert fmt"""{(if true: "')" else: "")}""" == "')"
+    doAssert fmt"""{(if true: "'" & "'" & ')' else: "")}""" == "'')"
+    doAssert &"""{(if true: "'" & "'" & ')' else: "")}""" == "'')"
+    doAssert &"{(if true: \"\'\" & \"'\" & ')' else: \"\")}" == "'')"
+
 # xxx static: main()
 main()

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,4 +1,4 @@
-# xxx: test js target
+
 
 import genericstrformat
 import std/[strformat, strutils, times,tables,json]
@@ -546,5 +546,8 @@ proc main() =
   block: #parens in quotes
     doAssert fmt"{(if true: ')' else: '(')}" == ")"
     doAssert fmt"{(if true: ']' else: ')')}" == "]"
+    doAssert fmt"""{(if true: "\")\"" else: "\"(")}""" == """")""""
+    doAssert &"""{(if true: "\")" else: "")}""" == "\")"
+    doAssert &"{(if true: \"\\\")\" else: \"\")}" == "\")"
 # xxx static: main()
 main()

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,7 +1,7 @@
 # xxx: test js target
 
 import genericstrformat
-import std/[strformat, strutils, times]
+import std/[strformat, strutils, times,tables]
 
 proc main() =
   block: # issue #7632
@@ -284,6 +284,20 @@ proc main() =
     doAssert fmt"{123.456=:>13e}" == "123.456= 1.234560e+02"
     doAssert fmt"{123.456=:13e}" == "123.456= 1.234560e+02"
 
+    let x = 3.14
+    doAssert fmt"{(if x!=0: 1.0/x else: 0):.5}" == "0.31847"
+    doAssert fmt"""{(block:
+      var res: string
+      for i in 1..15:
+        res.add (if i mod 15 == 0: "FizzBuzz"
+          elif i mod 5 == 0: "Buzz"
+          elif i mod 3 == 0: "Fizz"
+          else: $i) & " "
+      res)}""" == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
+
+    doAssert fmt"""{ "\{\(" & msg & "\)\}" }""" == "{(hello)}"
+    doAssert fmt"""{{({ msg })}}""" == "{(hello)}"
+    doAssert fmt"""{ $(\{msg:1,"world":2\}) }""" == """[("hello", 1), ("world", 2)]"""
   block: # tests for debug format string
     var name = "hello"
     let age = 21
@@ -496,6 +510,39 @@ proc main() =
 
   block: # test low(int64)
     doAssert &"{low(int64):-}" == "-9223372036854775808"
+  block: #expressions plus formatting
+    doAssert fmt"{if true\: 123.456 else\: 0=:>9.3f}" == "if true: 123.456 else: 0=  123.456"
+    doAssert fmt"{(if true: 123.456 else: 0)=}" == "(if true: 123.456 else: 0)=123.456"
+    doAssert fmt"{if true\: 123.456 else\: 0=:9.3f}" == "if true: 123.456 else: 0=  123.456"
+    doAssert fmt"{(if true: 123.456 else: 0)=:9.4f}" == "(if true: 123.456 else: 0)= 123.4560"
+    doAssert fmt"{(if true: 123.456 else: 0)=:>9.0f}" == "(if true: 123.456 else: 0)=     123."
+    doAssert fmt"{if true\: 123.456 else\: 0=:<9.4f}" == "if true: 123.456 else: 0=123.4560 "
 
+    doAssert fmt"""{(case true
+      of false: 0.0
+      of true: 123.456)=:e}""" == """(case true
+      of false: 0.0
+      of true: 123.456)=1.234560e+02"""
+
+    doAssert fmt"""{block\:
+      var res = 0.000123456
+      for _ in 0..5\:
+        res *= 10
+      res=:>13e}""" == """block:
+      var res = 0.000123456
+      for _ in 0..5:
+        res *= 10
+      res= 1.234560e+02"""
+    #side effects
+    var x = 5
+    doAssert fmt"{(x=7;123.456)=:13e}" == "(x=7;123.456)= 1.234560e+02"
+    doAssert x==7
+  block: #curly bracket expressions and tuples
+    proc formatValue(result: var string; value:Table|bool; specifier:string) = result.add $value
+
+    doAssert fmt"""{\{"a"\:1,"b"\:2\}.toTable() = }""" == """{"a":1,"b":2}.toTable() = {"a": 1, "b": 2}"""
+    doAssert fmt"""{(\{3: (1,"hi",0.9),4: (4,"lo",1.1)\}).toTable()}""" == """{3: (1, "hi", 0.9), 4: (4, "lo", 1.1)}"""
+    let x,y = 1
+    doAssert fmt"{x==y = }" == "x==y = true"
 # xxx static: main()
 main()

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -543,7 +543,7 @@ proc main() =
     doAssert fmt"""{\{"a"\:1,"b"\:2\}.toTable() = }""" == """{"a":1,"b":2}.toTable() = {"a": 1, "b": 2}"""
     doAssert fmt"""{(\{3: (1,"hi",0.9),4: (4,"lo",1.1)\}).toTable()}""" == """{3: (1, "hi", 0.9), 4: (4, "lo", 1.1)}"""
     doAssert fmt"""{ (%* \{"name": "Isaac", "books": ["Robot Dreams"]\}) }""" == """{"name":"Isaac","books":["Robot Dreams"]}"""
-  block: #parens in quotes
+  block: #parens in quotes that fool my syntax highlighter
     doAssert fmt"{(if true: ')' else: '(')}" == ")"
     doAssert fmt"{(if true: ']' else: ')')}" == "]"
     doAssert fmt"""{(if true: "\")\"" else: "\"(")}""" == """")""""
@@ -553,6 +553,6 @@ proc main() =
     doAssert fmt"""{(if true: "'" & "'" & ')' else: "")}""" == "'')"
     doAssert &"""{(if true: "'" & "'" & ')' else: "")}""" == "'')"
     doAssert &"{(if true: \"\'\" & \"'\" & ')' else: \"\")}" == "'')"
-
+    doAssert fmt"""{(if true: "'" & ')' else: "")}""" == "')"
 # xxx static: main()
 main()

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,4 +1,4 @@
-
+# xxx: test js target
 
 import genericstrformat
 import std/[strformat, strutils, times,tables,json]

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,7 +1,7 @@
 # xxx: test js target
 
 import genericstrformat
-import std/[strformat, strutils, times,tables,json]
+import std/[strformat, strutils, times, tables, json]
 
 proc main() =
   block: # issue #7632

--- a/tests/stdlib/tstrformat.nim
+++ b/tests/stdlib/tstrformat.nim
@@ -1,7 +1,7 @@
 # xxx: test js target
 
 import genericstrformat
-import std/[strformat, strutils, times,tables]
+import std/[strformat, strutils, times,tables,json]
 
 proc main() =
   block: # issue #7632
@@ -295,7 +295,7 @@ proc main() =
           else: $i) & " "
       res)}""" == "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz "
 
-    doAssert fmt"""{ "\{\(" & msg & "\)\}" }""" == "{(hello)}"
+    doAssert fmt"""{ "\{(" & msg & ")\}" }""" == "{(hello)}"
     doAssert fmt"""{{({ msg })}}""" == "{(hello)}"
     doAssert fmt"""{ $(\{msg:1,"world":2\}) }""" == """[("hello", 1), ("world", 2)]"""
   block: # tests for debug format string
@@ -538,11 +538,13 @@ proc main() =
     doAssert fmt"{(x=7;123.456)=:13e}" == "(x=7;123.456)= 1.234560e+02"
     doAssert x==7
   block: #curly bracket expressions and tuples
-    proc formatValue(result: var string; value:Table|bool; specifier:string) = result.add $value
+    proc formatValue(result: var string; value:Table|bool|JsonNode; specifier:string) = result.add $value
 
     doAssert fmt"""{\{"a"\:1,"b"\:2\}.toTable() = }""" == """{"a":1,"b":2}.toTable() = {"a": 1, "b": 2}"""
     doAssert fmt"""{(\{3: (1,"hi",0.9),4: (4,"lo",1.1)\}).toTable()}""" == """{3: (1, "hi", 0.9), 4: (4, "lo", 1.1)}"""
-    let x,y = 1
-    doAssert fmt"{x==y = }" == "x==y = true"
+    doAssert fmt"""{ (%* \{"name": "Isaac", "books": ["Robot Dreams"]\}) }""" == """{"name":"Isaac","books":["Robot Dreams"]}"""
+  block: #parens in quotes
+    doAssert fmt"{(if true: ')' else: '(')}" == ")"
+    doAssert fmt"{(if true: ']' else: ')')}" == "]"
 # xxx static: main()
 main()


### PR DESCRIPTION
Adding support for evaluating expressions by special-casing parentheses causes this regression:  unbalanced parentheses in quotes, in curly brackets:` i.e. &"""{ '(' }"""` no longer parses.  

so now it works

while i was there, though, I thought about enabling the use of curly brackets within curly expressions, which enables nice stuff like tables and json

 - curly brackets are permitted within curly expressions, if backslash-escaped
 
and while there, i thought i might as well allow colons to be escaped, which probably isn't necessary, because the content of a curly expression has to be an expression, but when there are still occasional weirdnesses with things like `collect`, i thought it might just come in handy.

- added tests, a changelog entry, and documentation explaining the escape mechanism.             

TODO
- [x] write a real parser that doesn't count parentheses within quotes
- [x] think about whether getting an nkError back from parseExpr could make this better in some way
