### PR TITLE
remove unnecessary assignment

### DIFF
--- a/lib/pure/coro.nim
+++ b/lib/pure/coro.nim
@@ -274,7 +274,6 @@ proc start*(c: proc(), stacksize: int = defaultStackSize): CoroutineRef {.discar
     coro.execContext = CreateFiberEx(stacksize, stacksize,
       FIBER_FLAG_FLOAT_SWITCH,
       (proc(p: pointer) {.stdcall.} = runCurrentTask()), nil)
-    coro.stack.size = stacksize
   else:
     coro = cast[CoroutinePtr](alloc0(sizeof(Coroutine) + stacksize))
     coro.stack.top = cast[pointer](cast[ByteAddress](coro) + sizeof(Coroutine))


### PR DESCRIPTION
Before: `coro.stack.size = stacksize` is called twice for windows backend.

![image](https://user-images.githubusercontent.com/43030857/114348046-96119100-9b98-11eb-8929-42ffa4985d82.png)
