### PR TITLE
Fix array's high & low return type for empty arrays

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -378,6 +378,8 @@ proc semLowHigh(c: PContext, n: PNode, m: TMagic): PNode =
       n.typ = getSysType(c.graph, n.info, tyInt)
     of tyArray:
       n.typ = typ[0] # indextype
+      if n.typ.kind == tyRange and emptyRange(n.typ.n[0], n.typ.n[1]): #Invalid range
+        n.typ = getSysType(c.graph, n.info, tyInt)
     of tyInt..tyInt64, tyChar, tyBool, tyEnum, tyUInt..tyUInt64, tyFloat..tyFloat64:
       n.typ = n[1].typ.skipTypes({tyTypeDesc})
     of tyGenericParam:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -348,6 +348,8 @@ proc high*[T](x: openArray[T]): int {.magic: "High", noSideEffect.}
 proc high*[I, T](x: array[I, T]): I {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of an array `x`.
   ##
+  ## For empty arrays, the return type is `int`.
+  ##
   ## See also:
   ## * `low(array) <#low,array[I,T]>`_
   ##
@@ -359,6 +361,8 @@ proc high*[I, T](x: array[I, T]): I {.magic: "High", noSideEffect.}
 
 proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
   ## Returns the highest possible index of an array type.
+  ##
+  ## For empty arrays, the return type is `int`.
   ##
   ## See also:
   ## * `low(typedesc[array]) <#low,typedesc[array[I,T]]>`_
@@ -420,6 +424,8 @@ proc low*[T](x: openArray[T]): int {.magic: "Low", noSideEffect.}
 proc low*[I, T](x: array[I, T]): I {.magic: "Low", noSideEffect.}
   ## Returns the lowest possible index of an array `x`.
   ##
+  ## For empty arrays, the return type is `int`.
+  ##
   ## See also:
   ## * `high(array) <#high,array[I,T]>`_
   ##
@@ -431,6 +437,8 @@ proc low*[I, T](x: array[I, T]): I {.magic: "Low", noSideEffect.}
 
 proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
   ## Returns the lowest possible index of an array type.
+  ##
+  ## For empty arrays, the return type is `int`.
   ##
   ## See also:
   ## * `high(typedesc[array]) <#high,typedesc[array[I,T]]>`_

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -587,3 +587,8 @@ block t12466:
     a[0'u16 + i] = i
   for i in 0'u16 ..< 8'u16:
     a[0'u16 + i] = i
+
+block t17705:
+  # https://github.com/nim-lang/Nim/pull/17705
+  var a = array[0, int].high
+  a = int a

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -590,5 +590,7 @@ block t12466:
 
 block t17705:
   # https://github.com/nim-lang/Nim/pull/17705
-  var a = array[0, int].high
-  a = int a
+  var a = array[0, int].low
+  a = int(a)
+  var b = array[0, int].high
+  b = int(b)


### PR DESCRIPTION
Hi,
In the current version
```
var a = array[0, int].high
a = int a
```
Fails, because `a` is of type `range 0..-1`, and the compilers checks for `range.min <= x <= range.max` (and 0 < x < -1 can't work)

I've tried to fix this by switching the return type of `high` to a `range -1..0` in various ways, but haven't been successful.
This commit simply change the check to `range.min <= x <= range.max OR range.max <= x <= range.min`, which is not ideal but works fine.