### PR TITLE
[std/channels] change the order of signal and unlock

### DIFF
--- a/lib/std/channels.nim
+++ b/lib/std/channels.nim
@@ -307,8 +307,8 @@ proc sendUnbufferedMpmc(chan: ChannelRaw, data: sink pointer, size: int, nonBloc
 
   chan.head = 1
 
-  release(chan.headLock)
   signal(chan.notEmptyCond)
+  release(chan.headLock)
   result = true
 
 proc sendMpmc(chan: ChannelRaw, data: sink pointer, size: int, nonBlocking: bool): bool =
@@ -343,8 +343,8 @@ proc sendMpmc(chan: ChannelRaw, data: sink pointer, size: int, nonBlocking: bool
   if chan.tail == 2 * chan.size:
     chan.tail = 0
 
-  release(chan.tailLock)
   signal(chan.notEmptyCond)
+  release(chan.tailLock)
   result = true
 
 proc recvUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, nonBlocking: bool): bool =
@@ -368,8 +368,8 @@ proc recvUnbufferedMpmc(chan: ChannelRaw, data: pointer, size: int, nonBlocking:
 
   chan.head = 0
 
-  release(chan.headLock)
   signal(chan.notFullCond)
+  release(chan.headLock)
   result = true
 
 proc recvMpmc(chan: ChannelRaw, data: pointer, size: int, nonBlocking: bool): bool =
@@ -404,8 +404,8 @@ proc recvMpmc(chan: ChannelRaw, data: pointer, size: int, nonBlocking: bool): bo
   if chan.head == 2 * chan.size:
     chan.head = 0
 
-  release(chan.headLock)
   signal(chan.notFullCond)
+  release(chan.headLock)
   result = true
 
 proc channelCloseMpmc(chan: ChannelRaw): bool =


### PR DESCRIPTION
Related https://github.com/nim-lang/Nim/issues/17392

> The pthread_cond_broadcast() or pthread_cond_signal() functions may be called by a thread whether or not it currently owns the mutex that threads calling pthread_cond_wait() or  pthread_cond_timedwait() have associated with the condition variable during their waits; however, if predictable scheduling behavior is required, then that mutex shall be locked by the thread calling  pthread_cond_broadcast() or pthread_cond_signal().

Especially we need predictable scheduling behavior

>  if predictable scheduling behavior is required, then that mutex shall be locked by the thread calling  pthread_cond_broadcast() or pthread_cond_signal().