### PR TITLE
std/tasks: callback cannot be nil

### DIFF
--- a/lib/std/tasks.nim
+++ b/lib/std/tasks.nim
@@ -75,6 +75,7 @@ proc `=destroy`*(t: var Task) {.inline.} =
 
 proc invoke*(task: Task) {.inline.} =
   ## Invokes the `task`.
+  assert task.callback != nil
   task.callback(task.args)
 
 template checkIsolate(scratchAssignList: seq[NimNode], procParam, scratchDotExpr: NimNode) =


### PR DESCRIPTION
`Task.callback` cannot be nil, we need to raise it at debug and release modes

Situations:
- if users create a Task object without using `toTask` and invoke the Task
- if users already move the Task and invoke the original Task