### PR TITLE
fix CI tests/errmsgs/tgcsafety.nim

### DIFF
--- a/tests/errmsgs/tgcsafety.nim
+++ b/tests/errmsgs/tgcsafety.nim
@@ -2,7 +2,7 @@ discard """
 cmd: "nim check $file"
 errormsg: "type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.void]{.locks: <unknown>.}>"
 nimout: '''
-tgcsafety.nim(30, 18) Error: type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.void]{.locks: <unknown>.}>
+tgcsafety.nim(31, 18) Error: type mismatch: got <AsyncHttpServer, Port, proc (req: Request): Future[system.void]{.locks: <unknown>.}>
 but expected one of:
 proc serve(server: AsyncHttpServer; port: Port;
            callback: proc (request: Request): Future[void] {.closure, gcsafe.};


### PR DESCRIPTION
fixes nim broken CI.

postmortem:
* https://github.com/nim-lang/Nim/pull/17633 CI was green for a while and as of the time of its last commit
* in the meantime, https://github.com/nim-lang/Nim/issues/16698 got merged and CI for https://github.com/nim-lang/Nim/pull/17633 was not re-run after #16698 was merged
* when #17633 got merged, nim CI broke, because the test in tests/errmsgs/tgcsafety.nim as a result of intermediate #16698

this fixes nim CI.

one way to avoid such problems in the future would be to re-run CI for each PR before merging if some PR was merged before the CI for that PR was last run; this could be automated. But that could be costly. Another way would be to manually do this for very old PR's that have been green for a long time and for which many PR's were merged in the meantime.

