### PR TITLE
prevent sets with empty range

### DIFF
--- a/tests/sets/tsets.nim
+++ b/tests/sets/tsets.nim
@@ -218,3 +218,14 @@ type Foo = enum
 
 let x = { Foo1, Foo2 }
 # bug #8425
+
+# empty range should not compile
+doAssert not compiles({hintUser..errUser})
+doAssert compiles({errUser..hintUser})
+
+# Check runtime sets
+block:
+  var
+    a = errUser
+    b = hintUser
+    r = {a..b}


### PR DESCRIPTION
Currently,
```
echo {5..0}
```
Compiles, even though empty range should not be allowed.
This is error prone, as demonstrated by the typo in `compiler/sigmatch.nim`

This commit blocks empty range when possible (ie, when params are const-able) in sets constructions.