### PR TITLE
std/hashes: hash(ref|ptr|pointer) + other improvements

### DIFF
--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -193,32 +193,6 @@ proc hashData*(data: pointer, size: int): Hash =
     dec(s)
   result = !$h
 
-when defined(js):
-  var objectID = 0
-
-proc hash*(x: pointer): Hash {.inline.} =
-  ## Efficient hashing of pointers.
-  when defined(js):
-    asm """
-      if (typeof `x` == "object") {
-        if ("_NimID" in `x`)
-          `result` = `x`["_NimID"];
-        else {
-          `result` = ++`objectID`;
-          `x`["_NimID"] = `result`;
-        }
-      }
-    """
-  else:
-    result = cast[Hash](cast[uint](x) shr 3) # skip the alignment
-
-proc hash*[T: proc](x: T): Hash {.inline.} =
-  ## Efficient hashing of proc vars. Closures are supported too.
-  when T is "closure":
-    result = hash(rawProc(x)) !& hash(rawEnv(x))
-  else:
-    result = hash(pointer(x))
-
 proc hashIdentity*[T: Ordinal|enum](x: T): Hash {.inline, since: (1, 3).} =
   ## The identity hash, i.e. `hashIdentity(x) = x`.
   cast[Hash](ord(x))
@@ -231,6 +205,56 @@ else:
   proc hash*[T: Ordinal|enum](x: T): Hash {.inline.} =
     ## Efficient hashing of integers.
     hashWangYi1(uint64(ord(x)))
+
+when defined(js):
+  var objectID = 0
+  proc getObjectId(x: pointer): int =
+    asm """
+      if (typeof `x` == "object") {
+        if ("_NimID" in `x`)
+          `result` = `x`["_NimID"];
+        else {
+          `result` = ++`objectID`;
+          `x`["_NimID"] = `result`;
+        }
+      }
+    """
+
+proc hash*(x: pointer | ref | ptr): Hash {.inline.} =
+  ## Efficient `hash` overload.
+  runnableExamples:
+    var a: array[10, uint8]
+    assert a[0].addr.hash != a[1].addr.hash
+    assert cast[pointer](a[0].addr).hash == a[0].addr.hash
+  runnableExamples:
+    type A = ref object
+      x: int
+    let a = A(x: 3)
+    let ha = a.hash
+    assert ha != A(x: 3).hash # A(x: 3) is a different ref object from `a`.
+    a.x = 4
+    assert ha == a.hash # the hash only depends on the address
+  runnableExamples:
+    # you can overload `hash` if you want to customize semantics
+    type A[T] = ref object
+      x, y: T
+    proc hash(a: A): Hash = hash(a.x)
+    assert A[int](x: 3, y: 4).hash == A[int](x: 3, y: 5).hash
+
+  when defined(js):
+    let id = getObjectId(cast[pointer](x))
+    result = hash(id)
+      # consistent with c backend and code expecting scrambled
+      # hashes depending on `nimIntHash1`.
+  else:
+    result = hash(cast[int](x))
+
+proc hash*[T: proc](x: T): Hash {.inline.} =
+  ## Efficient hashing of proc vars. Closures are supported too.
+  when T is "closure":
+    result = hash((rawProc(x), rawEnv(x)))
+  else:
+    result = hash(pointer(x))
 
 proc hash*(x: float): Hash {.inline.} =
   ## Efficient hashing of floats.
@@ -484,10 +508,10 @@ proc hashIgnoreCase*(sBuf: string, sPos, ePos: int): Hash =
     h = h !& ord(c)
   result = !$h
 
-proc hash*[T: tuple | object | ref | ptr](x: T): Hash =
-  ## Efficient hashing overload.
+proc hash*[T: tuple | object](x: T): Hash =
+  ## Efficient `hash` overload.
+  ## `hash` must be defined for each component of `x`.
   runnableExamples:
-    # For tuple | object, `hash` should be defined for each of the field types.
     type Obj = object
       x: int
       y: string
@@ -498,21 +522,9 @@ proc hash*[T: tuple | object | ref | ptr](x: T): Hash =
     # you can define custom hashes for objects (even if they're generic):
     proc hash(a: Obj2): Hash = hash((a.x))
     assert hash(Obj2[float](x: 520, y: "Nim")) == hash(Obj2[float](x: 520, y: "Nim2"))
-  runnableExamples:
-    # For ref | ptr, `hash(cast[int](x))` is used.
-    discard
-  when T is tuple | object:
-    for f in fields(x):
-      result = result !& hash(f)
-    result = !$result
-  elif T is ref: result = hash(cast[int](x))
-  elif T is ptr:
-    when defined(nimLegacyHashPtr):
-      result = hash(cast[cstring](x))
-    else:
-      result = hash(cast[int](x))
-  else:
-    static: doAssert(false, $T)
+  for f in fields(x):
+    result = result !& hash(f)
+  result = !$result
 
 proc hash*[A](x: openArray[A]): Hash =
   ## Efficient hashing of arrays and sequences.

--- a/lib/pure/hashes.nim
+++ b/lib/pure/hashes.nim
@@ -223,7 +223,7 @@ when defined(js):
 proc hash*(x: pointer): Hash {.inline.} =
   ## Efficient `hash` overload.
   when defined(js):
-    let y = getObjectId(cast[pointer](x))
+    let y = getObjectId(x)
   else:
     let y = cast[int](x)
   hash(y) # consistent with code expecting scrambled hashes depending on `nimIntHash1`.

--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -85,3 +85,7 @@ template accept*(a) =
 
 template reject*(a) =
   doAssert not compiles(a)
+
+template disableVm*(body) =
+  when nimvm: discard
+  else: body

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -10,6 +10,8 @@ joinable: false
 targets: "c cpp js"
 """
 
+# xxx wrap in a template to test in VM, see https://github.com/timotheecour/Nim/issues/534#issuecomment-769565033
+
 import hashes, sequtils, tables, algorithm
 
 proc sortedPairs[T](t: T): auto = toSeq(t.pairs).sorted

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -7,7 +7,9 @@ And we get here
 3
 '''
 joinable: false
+targets: "c cpp js"
 """
+
 import hashes, sequtils, tables, algorithm
 
 proc sortedPairs[T](t: T): auto = toSeq(t.pairs).sorted
@@ -444,3 +446,13 @@ block emptyOrdered:
   var t2: OrderedTable[int, string]
   doAssert t1 == t2
 
+block: # Table[ref, int]
+  type A = ref object
+    x: int
+  var t: OrderedTable[A, int]
+  let a1 = A(x: 3)
+  let a2 = A(x: 3)
+  t[a1] = 10
+  t[a2] = 11
+  doAssert t[a1] == 10
+  doAssert t[a2] == 11

--- a/tests/stdlib/thashes.nim
+++ b/tests/stdlib/thashes.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 import std/hashes
-
+from stdtest/testutils import disableVm
 
 when not defined(js) and not defined(cpp):
   block:
@@ -176,6 +176,22 @@ proc main() =
     doAssert hash(Obj5(t: false, x: 1)) != hash(Obj5(t: false, x: 2))
     doAssert hash(Obj5(t: false, x: 1)) == hash(Obj5(t: true, y: 1))
     doAssert hash(Obj5(t: false, x: 1)) != hash(Obj5(t: true, y: 2))
+
+  block: # hash(ref|ptr|pointer)
+    var a: array[10, uint8]
+    disableVm:
+      assert a[0].addr.hash != a[1].addr.hash
+      assert cast[pointer](a[0].addr).hash == a[0].addr.hash
+
+  block: # hash(ref)
+    type A = ref object
+      x: int
+    let a = A(x: 3)
+    disableVm: # xxx Error: VM does not support 'cast' from tyRef to tyPointer
+      let ha = a.hash
+      assert ha != A(x: 3).hash # A(x: 3) is a different ref object from `a`.
+      a.x = 4
+      assert ha == a.hash # the hash only depends on the address
 
 static: main()
 main()

--- a/tests/stdlib/thashes.nim
+++ b/tests/stdlib/thashes.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 import std/hashes
-from stdtest/testutils import disableVm
+from stdtest/testutils import disableVm, whenVMorJs
 
 when not defined(js) and not defined(cpp):
   block:
@@ -179,7 +179,11 @@ proc main() =
 
   block: # hash(ref|ptr|pointer)
     var a: array[10, uint8]
-    disableVm:
+    # disableVm:
+    whenVMorJs:
+      # pending fix proposed in https://github.com/nim-lang/Nim/issues/15952#issuecomment-786312417
+      discard
+    do:
       assert a[0].addr.hash != a[1].addr.hash
       assert cast[pointer](a[0].addr).hash == a[0].addr.hash
 

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -3,7 +3,7 @@ discard """
 """
 
 import std/strutils
-
+from stdtest/testutils import disableVm
 # xxx each instance of `disableVm` and `when not defined js:` should eventually be fixed
 
 template rejectParse(e) =
@@ -11,10 +11,6 @@ template rejectParse(e) =
     discard e
     raise newException(AssertionDefect, "This was supposed to fail: $#!" % astToStr(e))
   except ValueError: discard
-
-template disableVm(body) =
-  when nimvm: discard
-  else: body
 
 template main() =
   block: # strip


### PR DESCRIPTION
* `hash(ref)` now supported
refs https://forum.nim-lang.org/t/7765#49360
> Yeah, I agree. It's a strange omission that ref doesn't have a default hash implementation
* changes a behavior that was introduced all the way back in 405b86068e6a3d39970b9129ceec0a9108464b28
```
function hashPtr(p: Pointer): THash;
begin
  result := ({@cast}THash(p)) shr 3; // skip the alignment
end;
```
and doesn't make sense to me (1 of the tests in this PR would fail with this rule)
* make `hash(pointer)` use the same scrambling as for `hash(int)` (ie, honors `nimIntHash1`) so that code expecting scrambled hashes works with pointer (and ref|ptr) too, without performance drop, ie treats all those types that can be cast to int in an identical way; note that I still consider https://github.com/nim-lang/Nim/pull/13440 the superior, more performant alternative (see benchmarks) but that's a separate issue and can be addressed in future work when i revisit it)
* improve `hash(closure)`; it was using `hash(rawProc(x)) !& hash(rawEnv(x))` which violates hash API's by not finalizing it with `!$` (ie, can give bad distributions); instead I'm now using `hash((rawProc(x), rawEnv(x)))` which "does the right thing"
* workaround for the issue mentioned in https://github.com/nim-lang/Nim/pull/17722#issuecomment-820583061 that makes the rendering of std/hashes terrible because of `asm """`p` = `Data`;"""`
* test ttables.nim in js + cpp (in addition to c)
* refactor `disableVm`

## future work
* support VM for `hash(ref|ptr|pointer)`