### PR TITLE
turi: use `from uri {.all.} import removeDotSegments` 

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -555,25 +555,3 @@ proc getDataUri*(data, mime: string, encoding = "utf-8"): string {.since: (1, 3)
   runnableExamples: static: doAssert getDataUri("Nim", "text/plain") == "data:text/plain;charset=utf-8;base64,Tmlt"
   assert encoding.len > 0 and mime.len > 0 # Must *not* be URL-Safe, see RFC-2397
   result = "data:" & mime & ";charset=" & encoding & ";base64," & base64.encode(data)
-
-when isMainModule and defined(testing):
-  # needed (pending https://github.com/nim-lang/Nim/pull/11865) because
-  # `removeDotSegments` is private, the other tests are in `turi`.
-  block: # removeDotSegments
-    # `removeDotSegments` is exported for -d:testing only
-    doAssert removeDotSegments("/foo/bar/baz") == "/foo/bar/baz"
-    doAssert removeDotSegments("") == "" # empty test
-    doAssert removeDotSegments(".") == "." # trailing period
-    doAssert removeDotSegments("a1/a2/../a3/a4/a5/./a6/a7/././") == "a1/a3/a4/a5/a6/a7/"
-    doAssert removeDotSegments("https://a1/a2/../a3/a4/a5/./a6/a7/././") == "https://a1/a3/a4/a5/a6/a7/"
-    doAssert removeDotSegments("http://a1/a2") == "http://a1/a2"
-    doAssert removeDotSegments("http://www.ai.") == "http://www.ai."
-    when false: # xxx these cases are buggy
-      # this should work, refs https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
-      doAssert removeDotSegments("http://www.ai./") == "http://www.ai./" # fails
-      echo removeDotSegments("http://www.ai./")  # http://www.ai/
-      echo removeDotSegments("a/b.../c") # b.c
-      echo removeDotSegments("a/b../c") # bc
-      echo removeDotSegments("a/.../c") # .c
-      echo removeDotSegments("a//../b") # a/b
-      echo removeDotSegments("a/b/c//") # a/b/c//

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -3,6 +3,7 @@ discard """
 """
 
 import std/uri
+from std/uri {.all.} as uri2 import removeDotSegments
 from std/sequtils import toSeq
 
 template main() =
@@ -13,6 +14,24 @@ template main() =
     doAssert encodeUrl(test1, false) == "abc%0A%2Bdef%20xyz"
     doAssert decodeUrl(encodeUrl(test1, false), false) == test1
     doAssert decodeUrl(encodeUrl(test1)) == test1
+
+  block: # removeDotSegments
+    doAssert removeDotSegments("/foo/bar/baz") == "/foo/bar/baz"
+    doAssert removeDotSegments("") == "" # empty test
+    doAssert removeDotSegments(".") == "." # trailing period
+    doAssert removeDotSegments("a1/a2/../a3/a4/a5/./a6/a7/././") == "a1/a3/a4/a5/a6/a7/"
+    doAssert removeDotSegments("https://a1/a2/../a3/a4/a5/./a6/a7/././") == "https://a1/a3/a4/a5/a6/a7/"
+    doAssert removeDotSegments("http://a1/a2") == "http://a1/a2"
+    doAssert removeDotSegments("http://www.ai.") == "http://www.ai."
+    when false: # xxx these cases are buggy
+      # this should work, refs https://webmasters.stackexchange.com/questions/73934/how-can-urls-have-a-dot-at-the-end-e-g-www-bla-de
+      doAssert removeDotSegments("http://www.ai./") == "http://www.ai./" # fails
+      echo removeDotSegments("http://www.ai./")  # http://www.ai/
+      echo removeDotSegments("a/b.../c") # b.c
+      echo removeDotSegments("a/b../c") # bc
+      echo removeDotSegments("a/.../c") # .c
+      echo removeDotSegments("a//../b") # a/b
+      echo removeDotSegments("a/b/c//") # a/b/c//
 
   block: # parseUri
     block:


### PR DESCRIPTION
starts gathering real world use, other modules still using isMainModule for the same reason (testing private symbols) can use this too in future work