### PR TITLE
fix tls-psk in net

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
       displayName: 'Install dependencies (i386 Linux)'
       condition: and(eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
-    - bash: brew install boehmgc make sfml
+    - bash: brew install boehmgc make sfml openssl
       displayName: 'Install dependencies (OSX)'
       condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -672,7 +672,7 @@ when defineSsl:
     ## Sets the identity hint passed to server.
     ##
     ## Only used in PSK ciphersuites.
-    if ctx.context.SSL_CTX_use_psk_identity_hint(hint.cstring) == 0:#1 on success, 0 on failure
+    if ctx.context.SSL_CTX_use_psk_identity_hint(hint.cstring) <= 0:
       raiseSSLError()
 
   template genpskServerCallback(pskfunc:SslServerGetPskFunc):auto =

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -606,6 +606,9 @@ when defineSsl:
     when not defined(openssl10) and not defined(libressl):
       let sslVersion = getOpenSSLVersion()
       if sslVersion >= 0x010101000 and not sslVersion == 0x020000000:
+        # XXX always false!
+        # XXX however, setting non-1.3 ciphers with ciphersuites will
+        # XXX cause an error, cipherList needs to be split into 1.3 and non-1.3
         # In OpenSSL >= 1.1.1, TLSv1.3 cipher suites can only be configured via
         # this API.
         if newCTX.SSL_CTX_set_ciphersuites(cipherList) != 1:
@@ -671,7 +674,7 @@ when defineSsl:
     ## Only used in PSK ciphersuites.
     if ctx.context.SSL_CTX_use_psk_identity_hint(hint.cstring) == 0:#1 on success, 0 on failure
       raiseSSLError()
-  
+
   template genpskServerCallback(pskfunc:SslServerGetPskFunc):auto =
     proc pskServerCallback(ssl: SslCtx; identity: cstring; psk: ptr cuchar;
         max_psk_len: cint): cuint {.cdecl.} =
@@ -738,7 +741,6 @@ when defineSsl:
     socket.sslNoShutdown = false
     if socket.sslHandle == nil:
       raiseSSLError()
-
     if SSL_set_fd(socket.sslHandle, socket.fd) != 1:
       raiseSSLError()
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -675,25 +675,25 @@ when defineSsl:
     if ctx.context.SSL_CTX_use_psk_identity_hint(hint.cstring) <= 0:
       raiseSSLError()
 
-  template genpskServerCallback(pskfunc:SslServerGetPskFunc):auto =
+  template genpskServerCallback(pskfunc: SslServerGetPskFunc): auto =
     proc pskServerCallback(ssl: SslCtx; identity: cstring; psk: ptr cuchar;
         max_psk_len: cint): cuint {.cdecl.} =
       let pskString = pskfunc($identity)
       if pskString.len.cint > max_psk_len:
         return 0
       copyMem(psk, pskString.cstring, pskString.len)
-
       return pskString.len.cuint
+
     pskServerCallback
 
-  proc `serverGetPskFunc=`*(ctx: SslContext, fun:static SslServerGetPskFunc) =
+  proc `serverGetPskFunc=`*(ctx: SslContext, fun: static SslServerGetPskFunc) =
     ## Sets function that returns PSK based on the client identity.
     ##
     ## Only used in PSK ciphersuites.
     if not fun.isNil:
       ctx.context.SSL_CTX_set_psk_server_callback(genpskServerCallback(fun))
 
-  template genpskClientCallback(pskfunc:SslClientGetPskFunc):auto =
+  template genpskClientCallback(pskfunc: SslClientGetPskFunc): auto =
       proc pskClientCallback(ssl: SslPtr; hint: cstring; identity: cstring;
           max_identity_len: cuint; psk: ptr cuchar;
           max_psk_len: cuint): cuint {.cdecl.} =
@@ -704,11 +704,11 @@ when defineSsl:
           return 0
         copyMem(identity, identityString.cstring, identityString.len + 1) # with the last zero byte
         copyMem(psk, pskString.cstring, pskString.len)
-
         return pskString.len.cuint
+
       pskClientCallback
 
-  proc `clientGetPskFunc=`*(ctx: SslContext, fun:static SslClientGetPskFunc) =
+  proc `clientGetPskFunc=`*(ctx: SslContext, fun: static SslClientGetPskFunc) =
     ## Sets function that returns the client identity and the PSK based on identity
     ## hint from the server.
     ##

--- a/tests/stdlib/tnetpsk.nim
+++ b/tests/stdlib/tnetpsk.nim
@@ -1,0 +1,91 @@
+discard """
+  joinable:false
+  batchable:false
+  action: "run"
+  matrix: "--threads:on -d:ssl"
+  targets: "c cpp"
+  timeout:5
+  output:'''
+accepted connection
+connected with aethelfridda
+identity hint "bartholomew"
+hello from aethelfridda
+goodbye from bartholomew
+'''
+  sortoutput:true
+"""
+import net
+from openssl import SSL_CTX_ctrl
+#using channels_builtin
+var serverChannel:Channel[bool]
+
+proc clientFunc(identityHint: string): tuple[identity: string, psk: string] =
+  echo "identity hint \"", identityHint,"\""
+  return ("aethelfridda","aethelfridda-loves-"&identityHint)
+
+proc servfunc(identity:string):string =
+  echo "got id:",identity
+  "psk-of-" & identity
+
+proc client(){.thread.}=
+  let context = newContext(cipherList="PSK-AES256-CBC-SHA")
+  defer: context.destroyContext()
+
+  #turn off tls1_3 to force connection over psk
+  assert context.context.SSL_CTX_ctrl(124,0x0303,nil) > 0#SSL_CTX_set_max_proto_version(TLS1_2)
+
+  context.clientGetPskFunc = clientFunc
+
+  let sock = newSocket()
+  defer: sock.close()
+
+  sock.connect("localhost", Port(8800))
+  context.wrapConnectedSocket(sock, handshakeAsClient)
+  #send some data
+  sock.send("hello from aethelfridda\r\l")
+  echo sock.recvLine()
+
+proc server(){.thread.}=
+  let context = newContext(cipherList="PSK-AES256-CBC-SHA")
+  context.pskIdentityHint = "bartholomew"
+  context.serverGetPskFunc = proc(identity: string): string = identity & "-loves-bartholomew"
+  context.sessionIdContext= "anything"
+
+  let sock = newSocket()
+  defer:
+    sock.close()
+    context.destroyContext()
+  var boundAddr = true
+  try:
+    sock.bindAddr(Port(8800))
+  except ValueError,OsError:
+    boundAddr = false
+
+  serverChannel.send(boundAddr)
+  if not boundAddr:
+    return
+
+  sock.listen()
+  var client = new(Socket)
+  sock.accept(client)
+  sock.setSockOpt(OptReuseAddr, true)
+  echo "accepted connection"
+  context.wrapConnectedSocket(client, handshakeAsServer)
+  echo "connected with ", client.getPskIdentity()
+  echo recvLine(client)
+  client.send("goodbye from bartholomew\r\l")
+proc main()=
+
+  var
+    srv,cli:Thread[void]
+  serverChannel.open()
+  defer: serverChannel.close()
+
+  createThread(srv,server)
+  #wait till we are signalled that server has bound the port
+  if not serverChannel.recv():
+    quit "failed to bind port"
+  createThread(cli,client)
+  joinThreads(srv,cli)
+
+main()

--- a/tests/stdlib/tnetpsk.nim
+++ b/tests/stdlib/tnetpsk.nim
@@ -5,10 +5,10 @@ discard """
   targets: "c cpp"
   timeout:5
 """
-import net
-from openssl import SSL_CTX_ctrl
-#using channels_builtin
-var serverChannel:Channel[Port]
+import std/net
+from std/openssl import SSL_CTX_ctrl
+# using channels_builtin
+var serverChannel: Channel[Port]
 
 proc clientFunc(identityHint: string): tuple[identity: string, psk: string] =
   doAssert identityHint == "bartholomew"

--- a/tests/stdlib/tnetpsk.nim
+++ b/tests/stdlib/tnetpsk.nim
@@ -12,14 +12,14 @@ var serverChannel:Channel[Port]
 
 proc clientFunc(identityHint: string): tuple[identity: string, psk: string] =
   doAssert identityHint == "bartholomew"
-  return ("aethelfridda","aethelfridda-loves-"&identityHint)
+  return ("aethelfridda", "aethelfridda-loves-" & identityHint)
 
-proc client(p:Port){.thread.}=
-  let context = newContext(cipherList="PSK-AES256-CBC-SHA")
+proc client(p: Port){.thread.}=
+  let context = newContext(cipherList = "PSK-AES256-CBC-SHA")
   defer: context.destroyContext()
 
-  #turn off tls1_3 to force connection over psk
-  doAssert context.context.SSL_CTX_ctrl(124,0x0303,nil) > 0#SSL_CTX_set_max_proto_version(TLS1_2)
+  # turn off tls1_3 to force connection over psk
+  doAssert context.context.SSL_CTX_ctrl(124, 0x0303, nil) > 0 # SSL_CTX_set_max_proto_version(TLS1_2)
   context.clientGetPskFunc = clientFunc
 
   let sock = newSocket()
@@ -42,7 +42,7 @@ proc server(){.thread.}=
     sock.close()
     context.destroyContext()
   sock.bindAddr(Port(0))
-  let (_,port) = sock.getLocalAddr()
+  let (_, port) = sock.getLocalAddr()
   serverChannel.send(port)
   sock.listen()
   var client = new(Socket)
@@ -62,10 +62,10 @@ proc main()=
 
   createThread(srv,server)
 
-  #wait for server to bind a port
+  # wait for server to bind a port
   let port = serverChannel.recv()
 
-  createThread(cli,client,port)
+  createThread(cli, client, port)
 
   joinThread(srv)
   joinThread(cli)

--- a/tests/stdlib/tnetpsk.nim
+++ b/tests/stdlib/tnetpsk.nim
@@ -1,45 +1,35 @@
 discard """
   joinable:false
   batchable:false
-  action: "run"
   matrix: "--threads:on -d:ssl"
   targets: "c cpp"
   timeout:5
-  output:'''
-accepted connection
-connected with aethelfridda
-goodbye from bartholomew
-hello from aethelfridda
-identity hint "bartholomew"
-'''
-  sortoutput:true
 """
 import net
 from openssl import SSL_CTX_ctrl
 #using channels_builtin
-var serverChannel:Channel[bool]
+var serverChannel:Channel[Port]
 
 proc clientFunc(identityHint: string): tuple[identity: string, psk: string] =
-  echo "identity hint \"", identityHint,"\""
+  doAssert identityHint == "bartholomew"
   return ("aethelfridda","aethelfridda-loves-"&identityHint)
 
-proc client(){.thread.}=
+proc client(p:Port){.thread.}=
   let context = newContext(cipherList="PSK-AES256-CBC-SHA")
   defer: context.destroyContext()
 
   #turn off tls1_3 to force connection over psk
-  assert context.context.SSL_CTX_ctrl(124,0x0303,nil) > 0#SSL_CTX_set_max_proto_version(TLS1_2)
-
+  doAssert context.context.SSL_CTX_ctrl(124,0x0303,nil) > 0#SSL_CTX_set_max_proto_version(TLS1_2)
   context.clientGetPskFunc = clientFunc
 
   let sock = newSocket()
   defer: sock.close()
 
-  sock.connect("localhost", Port(8800))
+  sock.connect("localhost", p)
   context.wrapConnectedSocket(sock, handshakeAsClient)
-  #send some data
+
   sock.send("hello from aethelfridda\r\l")
-  echo sock.recvLine()
+  doAssert sock.recvLine() == "goodbye from bartholomew"
 
 proc server(){.thread.}=
   let context = newContext(cipherList="PSK-AES256-CBC-SHA")
@@ -51,37 +41,33 @@ proc server(){.thread.}=
   defer:
     sock.close()
     context.destroyContext()
-  var boundAddr = true
-  try:
-    sock.bindAddr(Port(8800))
-  except ValueError,OsError:
-    boundAddr = false
-
-  serverChannel.send(boundAddr)
-  if not boundAddr:
-    return
-
+  sock.bindAddr(Port(0))
+  let (_,port) = sock.getLocalAddr()
+  serverChannel.send(port)
   sock.listen()
   var client = new(Socket)
   sock.accept(client)
   sock.setSockOpt(OptReuseAddr, true)
-  echo "accepted connection"
   context.wrapConnectedSocket(client, handshakeAsServer)
-  echo "connected with ", client.getPskIdentity()
-  echo recvLine(client)
+  doAssert client.getPskIdentity() == "aethelfridda"
+  doAssert recvLine(client) == "hello from aethelfridda"
   client.send("goodbye from bartholomew\r\l")
-proc main()=
 
+proc main()=
   var
-    srv,cli:Thread[void]
+    srv:Thread[void]
+    cli:Thread[Port]
   serverChannel.open()
   defer: serverChannel.close()
 
   createThread(srv,server)
-  #wait till we are signalled that server has bound the port
-  if not serverChannel.recv():
-    quit "failed to bind port"
-  createThread(cli,client)
-  joinThreads(srv,cli)
+
+  #wait for server to bind a port
+  let port = serverChannel.recv()
+
+  createThread(cli,client,port)
+
+  joinThread(srv)
+  joinThread(cli)
 
 main()

--- a/tests/stdlib/tnetpsk.nim
+++ b/tests/stdlib/tnetpsk.nim
@@ -8,9 +8,9 @@ discard """
   output:'''
 accepted connection
 connected with aethelfridda
-identity hint "bartholomew"
-hello from aethelfridda
 goodbye from bartholomew
+hello from aethelfridda
+identity hint "bartholomew"
 '''
   sortoutput:true
 """
@@ -22,10 +22,6 @@ var serverChannel:Channel[bool]
 proc clientFunc(identityHint: string): tuple[identity: string, psk: string] =
   echo "identity hint \"", identityHint,"\""
   return ("aethelfridda","aethelfridda-loves-"&identityHint)
-
-proc servfunc(identity:string):string =
-  echo "got id:",identity
-  "psk-of-" & identity
 
 proc client(){.thread.}=
   let context = newContext(cipherList="PSK-AES256-CBC-SHA")

--- a/tests/stdlib/tnetpsk.nim
+++ b/tests/stdlib/tnetpsk.nim
@@ -7,6 +7,8 @@ discard """
 """
 import net
 from openssl import SSL_CTX_ctrl
+when defined(osx):
+  {.passl:"-Wl,-rpath,/usr/local/opt/openssl/lib".}
 #using channels_builtin
 var serverChannel:Channel[Port]
 


### PR DESCRIPTION
fixes #11280
much explanatory stream-of-conciousness of mine on that issue.
i'll try to summarize:
### tls-psk overview:
  psk in openssl allows the setting of callbacks for the client to select a psk based on a server hint, and for the server to validate this psk based on the client's identity.  
  the implementation of these callbacks involves dealing with c strings and char buffers, and is prone to buffer overruns, c.f. #17728
  `net` therefore provides an abstraction for creating this callback, and instead the user provides a second, simpler callback
### tls-psk use case
  Limited as far as I know.  embedded (but that probably wouldn't link against openssl). custom services running in inhospitable infrastructure.  Situations where speed, ease of implementation, and not setting up a pki are more important than security.  Note that libressl does not support psk at all.  
### the first problem
  the ssl callback needs to know the whereabouts of this second user-supplied callback.  Two places have been tried for storing it., in ex_data, and inside the Nim SslContext.
### ex_data
  this is an opaque storage location provided by openssl that stores void pointers. it's global, not per-context, and to insert data into it one needs to first get a unique index (by calling one ssl function) and then set the exdata at that index to said pointer.  (when getting this index it's also possible to attach callbacks that will be called when an ssl_ctx is created, copied, or destroyed)
  This was the original place chosen to store the secondary callback.
### the second problem
  the ssl callback knows which ssl_ctx it's attached to, but doesn't know which index to use to get out the secondary callback
  a solution tried was to assume that this index would be zero, but as  https://github.com/nim-lang/Nim/issues/4406 shows, this can't be relied upon.
### when it broke
  #5069
  this pr removed all the indexing shenanigans, and placed the callbacks inside of the SslContext.  as previously mentioned, this can't work, as the ssl callback has no access to the wrapper.
### this solution
  instead of storing the secondary callback anywhere, require that it be accessible at compile-time (a not overly-hampering restriction) and generate the ssl callback with a template.
   the api is maintained for  `clientGetPskFunc=` and lambdas work, but not closures.

Since none of the psk-associated functions have worked since v0.16, removing any of them is not a breaking change.
I've removed clientGetPskFunc and serverGetPskFunc; they do not seem useful to me, as these functions will be declared in the user's code, and the user can access them by name if they need.
### limitations:
  Only tls1.2 psk is implemented, tls1.3 of course uses a completely different set of functions.  supporting tls1.3psk could be added, but this is a bug/regressionfix, not a feature addition
### alternatives:
   deprecate and remove psk functionality.  it's a lot of work for a very small user base.