### PR TITLE
declaredlocs followup: handle `cannot instantiate` errors

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1463,9 +1463,9 @@ proc semGeneric(c: PContext, n: PNode, s: PSym, prev: PType): PType =
     matches(c, n, copyTree(n), m)
 
     if m.state != csMatch:
-      let err = "cannot instantiate " & typeToString(t) & "\n" &
-                "got: <" & describeArgs(c, n) & ">\n" &
-                "but expected: <" & describeArgs(c, t.n, 0) & ">"
+      var err = "cannot instantiate "
+      err.addTypeHeader(c.config, t)
+      err.add "\ngot: <$1>\nbut expected: <$2>" % [describeArgs(c, n), describeArgs(c, t.n, 0)]
       localError(c.config, n.info, errGenerated, err)
       return newOrPrevType(tyError, prev, c)
 


### PR DESCRIPTION
follows https://github.com/nim-lang/Nim/pull/15666 and https://github.com/nim-lang/Nim/pull/15673

IIRC that was the last remaining case
```nim
when true:
  type Foo[T: SomeInteger] = object
  var a: Foo[float]
```

before PR:
```
t12178.nim(8, 13) Error: cannot instantiate Foo
got: <typedesc[float]>
but expected: <T: SomeInteger>
    var a: Foo[float]
```

after PR:

```
t12178.nim(8, 13) Error: cannot instantiate Foo [type declared in t12178.nim(7, 8)]
got: <typedesc[float]>
but expected: <T: SomeInteger>
    var a: Foo[float]
```
