### PR TITLE
`--filenames:abs|canonical|legacyRelProj` for filenames in compiler msgs (replaces `--listfullpaths:on|off`)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -338,6 +338,8 @@
 
 - Added `--spellSuggest` to show spelling suggestions on typos.
 
+- Added `--filenames:abs|canonical|magic` which replaces --listFullPaths:on|off
+
 - Source+Edit links now appear on top of every docgen'd page when
   `nim doc --git.url:url ...` is given.
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -141,6 +141,15 @@ proc splitSwitch(conf: ConfigRef; switch: string, cmd, arg: var string, pass: TC
   elif switch[i] == '[': arg = substr(switch, i)
   else: invalidCmdLineOption(conf, pass, switch, info)
 
+template switchOn(arg: string): bool =
+  # xxx use `switchOn` wherever appropriate
+  case arg.normalize
+  of "", "on": true
+  of "off": false
+  else:
+    localError(conf, info, errOnOrOffExpectedButXFound % arg)
+    false
+
 proc processOnOffSwitch(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                         info: TLineInfo) =
   case arg.normalize
@@ -885,8 +894,15 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     trackIde(conf, ideDus, arg, info)
   of "stdout":
     processOnOffSwitchG(conf, {optStdout}, arg, pass, info)
+  of "filenames":
+    case arg.normalize
+    of "abs": conf.filenameOption = foAbs
+    of "canonical": conf.filenameOption = foCanonical
+    of "magic": conf.filenameOption = foMagicSauce
+    else: localError(conf, info, "expected: abs|canonical|magic, got: $1" % arg)
   of "listfullpaths":
-    processOnOffSwitchG(conf, {optListFullPaths}, arg, pass, info)
+    conf.filenameOption = if switchOn(arg): foAbs else: foMagicSauce
+      # xxx in future work, s/foMagicSauce/foCanonical/ here
   of "spellsuggest":
     if arg.len == 0: conf.spellSuggestMax = spellSuggestSecretSauce
     elif arg == "auto": conf.spellSuggestMax = spellSuggestSecretSauce

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -898,11 +898,11 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     case arg.normalize
     of "abs": conf.filenameOption = foAbs
     of "canonical": conf.filenameOption = foCanonical
-    of "magic": conf.filenameOption = foMagicSauce
-    else: localError(conf, info, "expected: abs|canonical|magic, got: $1" % arg)
+    of "legacyrelproj": conf.filenameOption = foLegacyRelProj
+    else: localError(conf, info, "expected: abs|canonical|legacyRelProj, got: $1" % arg)
   of "listfullpaths":
-    conf.filenameOption = if switchOn(arg): foAbs else: foMagicSauce
-      # xxx in future work, s/foMagicSauce/foCanonical/ here
+    # xxx in future work, use `warningDeprecated`
+    conf.filenameOption = if switchOn(arg): foAbs else: foCanonical
   of "spellsuggest":
     if arg.len == 0: conf.spellSuggestMax = spellSuggestSecretSauce
     elif arg == "auto": conf.spellSuggestMax = spellSuggestSecretSauce

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -63,21 +63,6 @@ proc prettyString(a: object): string =
   for k, v in fieldPairs(a):
     result.add k & ": " & $v & "\n"
 
-proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
-  ##[
-  Shows the canonical module import, e.g.:
-  system, std/tables, fusion/pointers, system/assertions, std/private/asciitables
-  ]##
-  var ret = getRelativePathFromConfigPath(conf, file, isTitle = true)
-  let dir = getNimbleFile(conf, $file).parentDir.AbsoluteDir
-  if not dir.isEmpty:
-    let relPath = relativeTo(file, dir)
-    if not relPath.isEmpty and (ret.isEmpty or relPath.string.len < ret.string.len):
-      ret = relPath
-  if ret.isEmpty:
-    ret = relativeTo(file, conf.projectPath)
-  result = ret.string.nativeToUnixPath.changeFileExt("")
-
 proc presentationPath*(conf: ConfigRef, file: AbsoluteFile): RelativeFile =
   ## returns a relative file that will be appended to outDir
   let file2 = $file

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -362,6 +362,7 @@ proc mainCommand*(graph: ModuleGraph) =
     rawMessage(conf, errGenerated, "invalid command: " & conf.command)
 
   if conf.errorCounter == 0 and conf.cmd notin {cmdTcc, cmdDump, cmdNop}:
+    # D20210419T170230:here
     let mem =
       when declared(system.getMaxMem): formatSize(getMaxMem()) & " peakmem"
       else: formatSize(getTotalMem()) & " totmem"
@@ -370,8 +371,8 @@ proc mainCommand*(graph: ModuleGraph) =
                 elif isDefined(conf, "release"): "Release"
                 else: "Debug"
     let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
-    let project = if optListFullPaths in conf.globalOptions: $conf.projectFull else: $conf.projectName
-
+    let project = if conf.filenameOption == foAbs: $conf.projectFull else: $conf.projectName
+      # xxx honor conf.filenameOption more accurately
     var output: string
     if optCompileOnly in conf.globalOptions and conf.cmd != cmdJsonscript:
       output = $conf.jsonBuildFile
@@ -380,7 +381,8 @@ proc mainCommand*(graph: ModuleGraph) =
       output = "unknownOutput"
     else:
       output = $conf.absOutFile
-    if optListFullPaths notin conf.globalOptions: output = output.AbsoluteFile.extractFilename
+    if conf.filenameOption != foAbs: output = output.AbsoluteFile.extractFilename
+      # xxx honor filenameOption more accurately
     if optProfileVM in conf.globalOptions:
       echo conf.dump(conf.vmProfileData)
     rawMessage(conf, hintSuccessX, [

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -255,14 +255,10 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
   of foRelProject: result = toProjPath(conf, fileIdx)
   of foMagicSauce:
     let absPath = toFullPath(conf, fileIdx)
-    result = canonicalImport(conf, absPath.AbsoluteFile)
-    #   relPath = toProjPath(conf, fileIdx)
-    # result = if (optListFullPaths in conf.globalOptions) or
-    #             (relPath.len > absPath.len) or
-    #             (relPath.count("..") > 2):
-    #            absPath
-    #          else:
-    #            relPath
+    if optListFullPaths in conf.globalOptions:
+      result = absPath
+    else:
+      result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
   of foStacktrace:
     if optExcessiveStackTrace in conf.globalOptions:

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -249,7 +249,7 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
     let absPath = toFullPath(conf, fileIdx)
     result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
-  of foMagicSauce:
+  of foLegacyRelProj:
     let
       absPath = toFullPath(conf, fileIdx)
       relPath = toProjPath(conf, fileIdx)
@@ -551,6 +551,7 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
         styledMsgWriteln(styleBright, loc, resetStyle, color, title, resetStyle, s, KindColor, kindmsg,
                          resetStyle, conf.getSurroundingSrc(info), UnitSep)
         if hintMsgOrigin in conf.mainPackageNotes:
+          # xxx needs a bit of refactoring to honor `conf.filenameOption`
           styledMsgWriteln(styleBright, toFileLineCol(info2), resetStyle,
             " compiler msg initiated here", KindColor,
             KindFormat % $hintMsgOrigin,

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -254,15 +254,15 @@ proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption)
   of foAbs: result = toFullPath(conf, fileIdx)
   of foRelProject: result = toProjPath(conf, fileIdx)
   of foMagicSauce:
-    let
-      absPath = toFullPath(conf, fileIdx)
-      relPath = toProjPath(conf, fileIdx)
-    result = if (optListFullPaths in conf.globalOptions) or
-                (relPath.len > absPath.len) or
-                (relPath.count("..") > 2):
-               absPath
-             else:
-               relPath
+    let absPath = toFullPath(conf, fileIdx)
+    result = canonicalImport(conf, absPath.AbsoluteFile)
+    #   relPath = toProjPath(conf, fileIdx)
+    # result = if (optListFullPaths in conf.globalOptions) or
+    #             (relPath.len > absPath.len) or
+    #             (relPath.count("..") > 2):
+    #            absPath
+    #          else:
+    #            relPath
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
   of foStacktrace:
     if optExcessiveStackTrace in conf.globalOptions:

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -241,33 +241,30 @@ template toFullPath*(conf: ConfigRef; info: TLineInfo): string =
 template toFullPathConsiderDirty*(conf: ConfigRef; info: TLineInfo): string =
   string toFullPathConsiderDirty(conf, info.fileIndex)
 
-type
-  FilenameOption* = enum
-    foAbs # absolute path, e.g.: /pathto/bar/foo.nim
-    foRelProject # relative to project path, e.g.: ../foo.nim
-    foMagicSauce # magic sauce, shortest of (foAbs, foRelProject)
-    foName # lastPathPart, e.g.: foo.nim
-    foStacktrace # if optExcessiveStackTrace: foAbs else: foName
-
 proc toFilenameOption*(conf: ConfigRef, fileIdx: FileIndex, opt: FilenameOption): string =
   case opt
   of foAbs: result = toFullPath(conf, fileIdx)
   of foRelProject: result = toProjPath(conf, fileIdx)
-  of foMagicSauce:
+  of foCanonical:
     let absPath = toFullPath(conf, fileIdx)
-    if optListFullPaths in conf.globalOptions:
-      result = absPath
-    else:
-      result = canonicalImportAux(conf, absPath.AbsoluteFile)
+    result = canonicalImportAux(conf, absPath.AbsoluteFile)
   of foName: result = toProjPath(conf, fileIdx).lastPathPart
+  of foMagicSauce:
+    let
+      absPath = toFullPath(conf, fileIdx)
+      relPath = toProjPath(conf, fileIdx)
+    result = if (relPath.len > absPath.len) or (relPath.count("..") > 2):
+               absPath
+             else:
+               relPath
   of foStacktrace:
     if optExcessiveStackTrace in conf.globalOptions:
       result = toFilenameOption(conf, fileIdx, foAbs)
     else:
       result = toFilenameOption(conf, fileIdx, foName)
 
-proc toMsgFilename*(conf: ConfigRef; info: FileIndex): string =
-  toFilenameOption(conf, info, foMagicSauce)
+proc toMsgFilename*(conf: ConfigRef; fileIdx: FileIndex): string =
+  toFilenameOption(conf, fileIdx, conf.filenameOption)
 
 template toMsgFilename*(conf: ConfigRef; info: TLineInfo): string =
   toMsgFilename(conf, info.fileIndex)

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -902,7 +902,7 @@ proc canonicalImportAux*(conf: ConfigRef, file: AbsoluteFile): string =
 
 proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
   let ret = canonicalImportAux(conf, file)
-  result = ret.string.nativeToUnixPath.changeFileExt("")
+  result = ret.nativeToUnixPath.changeFileExt("")
 
 proc canonDynlibName(s: string): string =
   let start = if s.startsWith("lib"): 3 else: 0

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -885,7 +885,7 @@ proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
     if dir == "": break
   return ""
 
-proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
+proc canonicalImportAux*(conf: ConfigRef, file: AbsoluteFile): string =
   ##[
   Shows the canonical module import, e.g.:
   system, std/tables, fusion/pointers, system/assertions, std/private/asciitables
@@ -898,6 +898,10 @@ proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
       ret = relPath
   if ret.isEmpty:
     ret = relativeTo(file, conf.projectPath)
+  result = ret.string
+
+proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
+  let ret = canonicalImportAux(conf, file)
   result = ret.string.nativeToUnixPath.changeFileExt("")
 
 proc canonDynlibName(s: string): string =

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -13,7 +13,7 @@ import
 
 from terminal import isatty
 from times import utc, fromUnix, local, getTime, format, DateTime
-
+from std/private/globs import nativeToUnixPath
 const
   hasTinyCBackend* = defined(tinyc)
   useEffectSystem* = true
@@ -884,6 +884,21 @@ proc findProjectNimFile*(conf: ConfigRef; pkg: string): string =
     dir = parentDir(dir)
     if dir == "": break
   return ""
+
+proc canonicalImport*(conf: ConfigRef, file: AbsoluteFile): string =
+  ##[
+  Shows the canonical module import, e.g.:
+  system, std/tables, fusion/pointers, system/assertions, std/private/asciitables
+  ]##
+  var ret = getRelativePathFromConfigPath(conf, file, isTitle = true)
+  let dir = getNimbleFile(conf, $file).parentDir.AbsoluteDir
+  if not dir.isEmpty:
+    let relPath = relativeTo(file, dir)
+    if not relPath.isEmpty and (ret.isEmpty or relPath.string.len < ret.string.len):
+      ret = relPath
+  if ret.isEmpty:
+    ret = relativeTo(file, conf.projectPath)
+  result = ret.string.nativeToUnixPath.changeFileExt("")
 
 proc canonDynlibName(s: string): string =
   let start = if s.startsWith("lib"): 3 else: 0

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -261,7 +261,7 @@ type
     foAbs # absolute path, e.g.: /pathto/bar/foo.nim
     foRelProject # relative to project path, e.g.: ../foo.nim
     foCanonical # canonical module name
-    foMagicSauce # magic sauce, shortest of (foAbs, foRelProject)
+    foLegacyRelProj # legacy, shortest of (foAbs, foRelProject)
     foName # lastPathPart, e.g.: foo.nim
     foStacktrace # if optExcessiveStackTrace: foAbs else: foName
 

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -36,7 +36,7 @@ Advanced options:
                             to after all options have been processed
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
-  --filenames:abs|canonical|magic
+  --filenames:abs|canonical|legacyRelProj
                             customize how filenames are rendered in compiler messages,
                             defaults to `abs` (absolute)
   --declaredLocs:on|off     show declaration locations in messages

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -36,7 +36,9 @@ Advanced options:
                             to after all options have been processed
   --stdout:on|off           output to stdout
   --colors:on|off           turn compiler messages coloring on|off
-  --listFullPaths:on|off    list full paths in messages
+  --filenames:abs|canonical|magic
+                            customize how filenames are rendered in compiler messages,
+                            defaults to `abs` (absolute)
   --declaredLocs:on|off     show declaration locations in messages
   --spellSuggest|:num       show at most `num >= 0` spelling suggestions on typos.
                             if `num` is not specified (or `auto`), return

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1205,6 +1205,7 @@ proc mainCommand(graph: ModuleGraph) =
   registerPass graph, semPass
   compileProject(graph)
   if conf.errorCounter == 0:
+    # xxx deduplicate with D20210419T170230
     let mem =
       when declared(system.getMaxMem): formatSize(getMaxMem()) & " peakmem"
       else: formatSize(getTotalMem()) & " totmem"
@@ -1213,7 +1214,7 @@ proc mainCommand(graph: ModuleGraph) =
                 elif isDefined(conf, "release"): "Release"
                 else: "Debug"
     let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
-    let project = if optListFullPaths in conf.globalOptions: $conf.projectFull else: $conf.projectName
+    let project = if conf.filenameOption == foAbs: $conf.projectFull else: $conf.projectName
     rawMessage(conf, hintSuccessX, [
       "loc", loc,
       "sec", sec,

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -6,7 +6,7 @@ switch("path", "$lib/../testament/lib")
 ## prevent common user config settings to interfere with testament expectations
 ## Indifidual tests can override this if needed to test for these options.
 switch("colors", "off")
-switch("filenames", "magic")
+switch("filenames", "legacyRelProj")
 switch("excessiveStackTrace", "off")
 switch("spellSuggest", "0")
 

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -6,7 +6,7 @@ switch("path", "$lib/../testament/lib")
 ## prevent common user config settings to interfere with testament expectations
 ## Indifidual tests can override this if needed to test for these options.
 switch("colors", "off")
-switch("listFullPaths", "off")
+switch("filenames", "magic")
 switch("excessiveStackTrace", "off")
 switch("spellSuggest", "0")
 


### PR DESCRIPTION
* introduces `--filenames:abs|canonical|legacyRelProj` for filenames in compiler msgs (replaces `--listfullpaths:on|off` which is kept for backward compatibility)
--filenames:abs is same as the old --listfullpaths:on
--filenames:legacyRelProj is the same as the old --listfullpaths:off
--filenames:canonical reuses the code from https://github.com/nim-lang/Nim/pull/16999
--listfullpaths:off is now mapped to `--filenames:canonical` (but i could change it to `--filenames:legacyRelProj` if needed)
* supersedes and closes https://github.com/nim-lang/Nim/pull/13058, it'll be very easy to add `--filenames:relative` after this PR if needed

* `--filenames:canonical` is more context-independent, stable (independent of where nimble packages are installed) and less surprising than `--filenames:legacyRelProj` which was sometimes showing relative paths wrt main project name, sometimes show `../` in path, and sometimes show absolute paths

## example 1
```nim
when true:
  import compiler/options
  var a: ConfigRef2
```

--filenames:canonical
```
tests/nim/all/t12177.nim(21, 10) Error: undeclared identifier: 'ConfigRef2'
candidates (edit distance, scope distance); see '--spellSuggest':
 (1, 2): 'ConfigRef' [type declared in compiler/options.nim(268, 3)]
    var a: ConfigRef2
```
--filenames:legacyRelProj
```
t12177.nim(21, 10) Error: undeclared identifier: 'ConfigRef2'
candidates (edit distance, scope distance); see '--spellSuggest':
 (1, 2): 'ConfigRef' [type declared in /Users/timothee/git_clone/nim/Nim_prs/compiler/options.nim(268, 3)]
    var a: ConfigRef2
```
=> as you can see the relative vs absolute paths with `--filenames:legacyRelProj` (old `--listfullpaths:off`)are non-intuitive

## example 2
with a nimble package

```nim
when true:
  import pkg/regex
  var a = re(12)
```

nim r --filenames:canonical /pathto/tests/nim/all/t12177.nim
```
tests/nim/all/t12177.nim(17, 13) Error: type mismatch: got <int literal(12)>
but expected one of:
func re(s: static string): static[Regex] [func declared in regex.nim(289, 8)]
  first type mismatch at position: 1
  required type for s: static[string] [static declared in regex.nim(290, 5)]
  but expression '12' is of type: int literal(12) [int declared in system/basic_types.nim(2, 3)]
...
```

## note
* for files that aren't rooted inside a nimble package, it just shows the file name (lastPathPart), as is also case in docs since https://github.com/nim-lang/Nim/pull/16999; that's the simplest but other options are reasonable

## future work
- [x] `declaredlocs` has a minor bug: static (and typedesc and ...?) should be skipped:
required type for s: static[string] [static declared in regex(290, 5)]
=>
required type for s: static[string] [string declared in system(34, 3)]
EDIT => PR https://github.com/nim-lang/Nim/pull/17795

- [ ] (pre-existing issue) honor `conf.filenameOption` for `--hint:msgorigin` (right now hardcoded to absolute paths because of `toFileLineCol(InstantiationInfo)`) (see also https://github.com/timotheecour/Nim/issues/463)
- [ ] maybe prefix nimble packages (other than one from main project file) with `pkg/` for clarity
