### PR TITLE
[std/locks]remove workaround for `withLock`

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -76,7 +76,6 @@ proc signal*(cond: var Cond) {.inline.} =
 template withLock*(a: Lock, body: untyped) =
   ## Acquires the given lock, executes the statements in body and
   ## releases the lock after the statements finish executing.
-  mixin acquire, release
   acquire(a)
   {.locks: [a].}:
     try:


### PR DESCRIPTION
Ref https://github.com/nim-lang/Nim/pull/6113 and https://github.com/nim-lang/Nim/issues/6049

The workaround for generics instantiation is unnecessary. It seems to be fixed by another PR I guess.

The test still works. So the changes should be harmless.
https://github.com/nim-lang/Nim/blob/devel/tests/stdlib/tlocks.nim