### PR TITLE
fix #17749 ignore SIGPIPE signals, fix nim CI  #17748 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,18 @@
 - In `std/os`, `getHomeDir`, `expandTilde`, `getTempDir`, `getConfigDir` now do not include trailing `DirSep`,
   unless `-d:nimLegacyHomeDir` is specified (for a transition period).
 
+- On POSIX systems, the default signal handlers used for Nim programs (it's
+  used for printing the stacktrace on fatal signals) will now re-raise the
+  signal for the OS default handlers to handle.
+
+  This lets the OS perform its default actions, which might include core
+  dumping (on select signals) and notifying the parent process about the cause
+  of termination.
+
+- On POSIX systems, we now ignore `SIGPIPE` signals, use `-d:nimLegacySigpipeHandler`
+  for previous behavior.
+
+
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`
 
@@ -218,14 +230,6 @@
   arguments passed to it, so `initOptParser` has been changed to raise
   `ValueError` when the real command line is not available. `parseopt` was
   previously excluded from `prelude` for JS, as it could not be imported.
-
-- On POSIX systems, the default signal handlers used for Nim programs (it's
-  used for printing the stacktrace on fatal signals) will now re-raise the
-  signal for the OS default handlers to handle.
-
-  This lets the OS perform its default actions, which might include core
-  dumping (on select signals) and notifying the parent process about the cause
-  of termination.
 
 - Added `system.prepareStrMutation` for better support of low
   level `moveMem`, `copyMem` operations for Orc's copy-on-write string

--- a/koch.nim
+++ b/koch.nim
@@ -542,6 +542,10 @@ proc runCI(cmd: string) =
   # boot without -d:nimHasLibFFI to make sure this still works
   kochExecFold("Boot in release mode", "boot -d:release -d:nimStrictMode")
 
+  when false: # debugging: when you need to run only 1 test in CI, use something like this:
+    execFold("debugging test", "nim r tests/stdlib/tosproc.nim")
+    doAssert false, "debugging only"
+
   ## build nimble early on to enable remainder to depend on it if needed
   kochExecFold("Build Nimble", "nimble")
 

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -206,8 +206,8 @@ else: # main driver
       var line = newStringOfCap(120)
       while true:
         if outp.readLine(line):
-          result[0].string.add(line.string)
-          result[0].string.add("\n")
+          result[0].add(line)
+          result[0].add("\n")
         else:
           result[1] = peekExitCode(p)
           if result[1] != -1: break
@@ -279,3 +279,16 @@ else: # main driver
     when defined(posix):
       doAssert execCmdEx("echo $FO", env = newStringTable({"FO": "B"})) == ("B\n", 0)
       doAssert execCmdEx("echo $PWD", workingDir = "/") == ("/\n", 0)
+
+  block: # bug #17749
+    let output = compileNimProg("-d:case_testfile4", "D20210417T011153")
+    var p = startProcess(output, dir)
+    let inp = p.inputStream
+    var count = 0
+    doAssertRaises(IOError):
+      for i in 0..<100000:
+        count.inc
+        inp.writeLine "ok" # was giving SIGPIPE and crashing
+    doAssert count >= 100
+    doAssert waitForExit(p) == QuitFailure
+    close(p) # xxx isn't that missing in other places?

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -285,7 +285,13 @@ else: # main driver
     var p = startProcess(output, dir)
     let inp = p.inputStream
     var count = 0
-    doAssertRaises(IOError):
+    when defined(windows):
+      # xxx we should make osproc.hsWriteData raise IOError on windows, consistent
+      # with posix; we could also (in addition) make IOError a subclass of OSError.
+      type SIGPIPEError = OSError
+    else:
+      type SIGPIPEError = IOError
+    doAssertRaises(SIGPIPEError):
       for i in 0..<100000:
         count.inc
         inp.writeLine "ok" # was giving SIGPIPE and crashing

--- a/tests/system/tsigexitcode.nim
+++ b/tests/system/tsigexitcode.nim
@@ -11,10 +11,13 @@ proc main() =
     discard posix.raise(signal)
   else:
     # synchronize this list with lib/system/except.nim:registerSignalHandler()
-    let fatalSigs = [SIGINT, SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS,
-                     SIGPIPE]
-    for s in fatalSigs:
+    let sigs = [SIGINT, SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGBUS, SIGPIPE]
+    for s in sigs:
       let (_, exitCode) = execCmdEx(quoteShellCommand [getAppFilename(), $s])
-      doAssert exitCode == 128 + s, "mismatched exit code for signal " & $s
+      if s == SIGPIPE:
+        # SIGPIPE should be ignored
+        doAssert exitCode == 0, $(exitCode, s)
+      else:
+        doAssert exitCode == 128+s, $(exitCode, s)
 
 main()


### PR DESCRIPTION
* fix #17749 
* fix https://github.com/nim-lang/Nim/issues/17748 although it's not 100% clear why, but the change in this PR is good anyways
(install issues for i386 seemed intermittent refs https://github.com/nim-lang/Nim/issues/17325)
* posix is now consistent with windows in that regard (raising exception instead of raising signal that aborts process); however as noted in PR, windows raises OSError, posix raises IOError; this can be fixed in future work

## future work
- [ ] add a lib/std/private/signals module to refactor posix signal specific code and avoid duplicating logic in several places (ansi_c, system/excpt, posix, segfaults, as well as simplify code eg: stdlib/tssl, rawsockets, blockSigpipe in lib/pure/net.nim
- [ ] use sigaction instead of blockSigpipe, sigaction is deprecated and comes with many caveats, in particular for multithreaded programs
https://stackoverflow.com/questions/231912/what-is-the-difference-between-sigaction-and-signal
> Use sigaction() unless you've got very compelling reasons not to do so.
* https://stackoverflow.com/questions/108183/how-to-prevent-sigpipes-or-handle-them-properly etc
* https://stackoverflow.com/questions/7774569/using-signals-and-sigpipe
- [ ] use the approach suggested in http://www.microhowto.info/howto/ignore_sigpipe_without_affecting_other_threads_in_a_process.html (maybe it's `blockSigpipe` in  lib/pure/net.nim) instead of ` c_signal(SIGPIPE, SIG_IGN)`, but this would require quite a bit of refactoring and should be done when we migrate signal to sigaction
- [ ] windows should raise IOError on pipe error, consistent with posix

## links
refs https://github.com/nim-lang/Nim/issues/9867#issuecomment-650291264
> Also I'd recommend that everyone running their Nim program as a SSL server should install SIG_IGN as the SIGPIPE handler (actually we might want to do this in the stdlib). SIGPIPE is a pretty old signal and is largely obsoleted by EPIPE that's returned from any failed send()/write() attempt on a closed socket/pipe (we don't get to handle this one because SIGPIPE got in the way).