### PR TITLE
fix range to unsigned conversion

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -409,7 +409,7 @@ proc handleRange(f, a: PType, min, max: TTypeKind): TTypeRelation =
     elif a.kind == tyRange and
       # Make sure the conversion happens between types w/ same signedness
       (f.kind in {tyInt..tyInt64} and a[0].kind in {tyInt..tyInt64} or
-       f.kind in {tyUInt8..tyUInt32} and a[0].kind in {tyUInt8..tyInt32}) and
+       f.kind in {tyUInt8..tyUInt32} and a[0].kind in {tyUInt8..tyUInt32}) and
       a.n[0].intVal >= firstOrd(nil, f) and a.n[1].intVal <= lastOrd(nil, f):
       # passing 'nil' to firstOrd/lastOrd here as type checking rules should
       # not depend on the target integer size configurations!

--- a/tests/range/trange.nim
+++ b/tests/range/trange.nim
@@ -142,3 +142,15 @@ var a: array[4'u, string]
 
 for i in 0..<a.len:
   a[i] = "foo"
+
+# Check range to ordinal conversions
+block:
+  var
+    a: int16
+    b: range[0'i32..45'i32] = 3
+    c: uint16
+    d: range[0'u32..46'u32] = 3
+  a = b
+  c = d
+  doAssert a == b
+  doAssert c == d


### PR DESCRIPTION
A typo in compiler/sigmatch.nim caused
```nim
block:
  var
    a: int16
    b: range[0'i32..45'i32] = 3
    c: uint16
    d: range[0'u32..46'u32] = 3
  a = b
  c = d #This one
```
to fail