### PR TITLE
Add median and relatives to std/stats

### DIFF
--- a/lib/pure/stats.nim
+++ b/lib/pure/stats.nim
@@ -42,7 +42,7 @@ runnableExamples:
 
   template `~=`(a, b: float): bool = almostEqual(a, b)
 
-  var statistics: RunningStat  ## Must be var
+  var statistics: RunningStat ## Must be var
   statistics.push(@[1.0, 2.0, 1.0, 4.0, 1.0, 4.0, 1.0, 2.0])
   doAssert statistics.n == 8
   doAssert statistics.mean() ~= 2.0
@@ -53,36 +53,17 @@ runnableExamples:
   doAssert statistics.kurtosis() ~= -1.0
   doAssert statistics.kurtosisS() ~= -0.7000000000000008
 
-  var 
-    ASv = [7,4,6,3,9,1]        #  sorted   1 3 4 6 7 9
-    A   : array[len(ASv),int]
+  block:
+    var
+      ASv = [4, 6, 3, 9, 1] #  sorted   1 3 4 6 9
+      A: array[len(ASv), int]
 
-  func myCmp(x,y:int):int =
-    if x==y : 0 elif x<y : -1 else: 1
+    func myCmp(x, y: int): int =
+      if x == y: 0 elif x < y: -1 else: 1
 
-  A= ASv;  doAssert quickSelect(A, 2, 5, 2, myCmp) == 1  # smallest element
-  A= ASv;  doAssert quickSelect(A, 2, 5, 5, myCmp) == 9  # largest element
-  #
-  A= ASv;  doAssert median(A,0,5,myCmp)      == 5.0
-  A= ASv;  doAssert median_low(A,0,5,myCmp)  == 4
-  A= ASv;  doAssert median_high(A,0,5,myCmp) == 6
-  #
-  A= ASv;  doAssert median(A,2,5)            == 4.5
-  A= ASv;  doAssert median_low(A,2,5)        == 3
-  A= ASv;  doAssert median_high(A,2,5)       == 6
-  #
-  A= ASv;  doAssert median(A,0,4,myCmp)      == 6.0
-  A= ASv;  doAssert median_low(A,0,4,myCmp)  == 6
-  A= ASv;  doAssert median_high(A,0,4,myCmp) == 6
-
-  func FCmp(x,y:float):int =
-    if x==y : 0
-    elif x<y : -1
-    else     : 1
-
-  var  F = [7.0,4.0,6.0,3.0,9.0,1.0]
-
-  doAssert median(F,0,5,FCmp) == 5.0
+    A = ASv; doAssert median(A, 1, 4) == 4.5
+    A = ASv; doAssert median(A, 1, 4, mdlow) == 3
+    A = ASv; doAssert median(A, 1, 4, mdhigh) == 6
 
 from std/math import FloatClass, sqrt, pow, round
 
@@ -292,15 +273,15 @@ proc kurtosisS*[T](x: openArray[T]): float =
   rs.push(x)
   result = rs.kurtosisS()
 
-import random
+import std/random
 
 # Partition using Lomuto partition scheme
-proc partition[T](A: var openArray[T], left, right, K : Natural,
-                                      myCmp : proc(x,y:T):int ): int =
-  assert(left<=K and K<=right)
-  var pInd = K  # Pick `pIndex` as a pivot from the list
+proc partition[T](A: var openArray[T], left, right, K: Natural,
+                                      myCmp: proc(x, y: T): int): int =
+  assert(left <= K and K <= right)
+  var pInd = K # Pick `pIndex` as a pivot from the list
   let pivot = A[pInd]
-  if likely(pInd != right) : swap(A[pInd],A[right])  # Move pivot to end
+  if pInd != right: swap(A[pInd], A[right]) # Move pivot to end
   
   #[
     elements less than the pivot will be pushed to the left of `pIndex`;
@@ -309,104 +290,102 @@ proc partition[T](A: var openArray[T], left, right, K : Natural,
 
   pInd = left
   #[ each time we find an element less than or equal to the pivot, `pInd`
-     is incremented, and that element would be placed before the pivot. ]#
-  
-  for i in left ..< right :
-    if myCmp(A[i],pivot) <= 0 :    # A[i] <= pivot
-      if likely(i != pInd) :  swap(A[i],A[pInd])
+    is incremented, and that element would be placed before the pivot. ]#
+
+  for i in left ..< right:
+    if myCmp(A[i], pivot) <= 0: # A[i] <= pivot
+      if i != pInd: swap(A[i], A[pInd])
       inc(pInd)
 
   # Move pivot to its place
-  if likely(pInd < right) :  swap(A[pInd],A[right])
-  
-  result= pInd   # A[i] <= pivot  for i in left..pInd 
+  if pInd < right: swap(A[pInd], A[right])
+
+  result = pInd # A[i] <= pivot  for i in left..pInd
 
 
-proc quickSelect*[T](A: var openArray[T], left, right, K : Natural, 
-                                          myCmp : proc(x,y:T):int {.nimcall} = cmp[T]): T =
+proc quickSelect*[T](A: var openArray[T], left, right, K: Natural,
+                     myCmp: proc(x, y: T): int {.nimcall.} = cmp[T]): T =
   ##[
     Returns the ``K``'th smallest element in a list within `left / right`
     (i.e., ``left <= K <= right``).
     
-    If ``K == left`` the smallest element, and if ``K == right`` the largest element of **A** will be returned.
+    If ``K == left`` the smallest element, and 
+    if ``K == right`` the largest element of **A** will be returned.
     
     >>> **A** will be modified
-    
-  Timings for random arrays on an amd64 / 4GHz machine with  nim c -d:release -d:danger -z 
-   
-   ..table::
-   =============         ==============
-       Length            time (seconds)
-   =============         ============== 
-       1,000,000          0.0013
-      10,000,000          0.014
-     100,000,000          0.15
-   1,000,000,000          1.5
   ]##
 
-  assert(left<=K and K<=right)
+  assert(left <= K and K <= right)
   # If the list contains only one element, return that element
-  if left == right:  return A[left]
+  if left == right: return A[left]
 
   # select `pInd` between left and right
   var pInd = left + rand(right-left)
   pInd = partition(A, left, right, pInd, myCmp)
 
   # The pivot is in its sorted position
-  if K == pInd:  return A[K]
+  if K == pInd: 
+    result= A[K]
 
-  elif K < pInd:  # if K is less than the pivot index
-    return quickSelect(A, left, pInd - 1, K, myCmp)
+  elif K < pInd: # if K is less than the pivot index
+    result= quickSelect(A, left, pInd - 1, K, myCmp)
 
   # if K is greater than the pivot index
   else:
-    return quickSelect(A, pInd + 1, right, K, myCmp)
+    result= quickSelect(A, pInd + 1, right, K, myCmp)
 
+type MedianMode* = enum
+  mdlow, mdhigh
 
-proc median_low*[T](A: var openArray[T], left, right : Natural, 
-                         myCmp : proc(x,y:T):int {.nimcall} = cmp[T]): T =
+proc median*[T](A: var openArray[T], left, right: Natural, Mode:MedianMode,
+                    myCmp: proc(x, y: T): int {.nimcall.} = cmp[T]): T =
   ##[
   The **median M** of an array/sequence of comparable items is defined such that 
   
   in case the array/sequence has *odd* length ``(right-left+1)`` : 
-     ``(m-1)/2`` elements are lower or equal and ``(m-1)/2`` elements are higher or equal than **M**
+     ``(m-1)/2`` elements are lower or equal and 
+     ``(m-1)/2`` elements are higher or equal than **M** .
 
-     In this case  ``median_low(A) == median_high(A)``
+     In this case  ``Mode == mdlow`` and ``Mode == mdhigh`` are equal.
 
   in case the array/sequence has *even* length the median is only defined for
      arrays of ``SomeNumber`` elements - see below -
 
-     In general **median_low(A)** has the property that ``m/2`` elements are less than or equal this value
-     and ``m/2+1`` elements are greater than or equal this value.
+     In general **median Mode:mdlow** has the property that 
+     ``m/2``   elements are less than or equal this value  and
+     ``m/2+1`` elements are greater than or equal this value.
 
-     **median_high(A)** has the property that ``m/2`` elements are greater or equal than this value and
+     **median Mode:mdhigh** has the property that 
+     ``m/2``   elements are greater or equal than this value and
      ``m/2+1`` elements are less or equal than this value.
 
   >>> **A** will be modified
   ]##
-  quickSelect(A, left,right,(right+left) div 2, myCmp)
+
+  if  Mode == mdlow :
+    quickSelect(A, left, right, (right+left) div 2, myCmp)
+  else :
+    quickSelect(A, left, right, (right+left+1) div 2, myCmp)
 
 
-proc median_high*[T](A: var openArray[T], left, right : Natural, 
-                         myCmp : proc(x,y:T):int {.nimcall} = cmp[T]): T =
-  quickSelect(A, left,right,(right+left+1) div 2, myCmp)
-
-proc median*[T:SomeNumber](A: var openArray[T], left, right : Natural,
-                    myCmp : proc(x,y:T):int {.nimcall} = cmp[T]): float =
-  ##[This is a special version which returns a float value. 
-    If the length (right+1-left) is *even*, it returns (median_low + median_high)*0.5
+proc median*[T: SomeNumber](A: var openArray[T], left, right: Natural,
+                    myCmp: proc(x, y: T): int {.nimcall.} = cmp[T]): float =
+  ##[This is a special version which returns a float value.
+    If the length (right+1-left) is *even*,
+    it returns (medianLow + medianHigh)*0.5
 
   >>> **A** will be modified
   ]##
-  let
-    N= (right-left+1) 
-    K= left + (N-1) div 2
 
-  if  (N and 1) == 1 :  # N is odd
-    result= float(quickSelect(A, left,right, K, myCmp))
-  else :
-    result= float( quickSelect(A, left,right, K, myCmp) +
-                   quickSelect(A, left,right, K+1, myCmp) )*0.5
+  let
+    N = (right-left+1)
+    K = left + (N-1) div 2
+
+  if (N and 1) == 1: # N is odd
+    result = float(quickSelect(A, left, right, K, myCmp))
+  else:
+    result = float(quickSelect(A, left, right, K, myCmp) +
+                   quickSelect(A, left, right, K+1, myCmp))*0.5
 
 
 # ---------------------- Running Regression -----------------------------

--- a/tests/benchmarks/tstats.nim
+++ b/tests/benchmarks/tstats.nim
@@ -1,4 +1,4 @@
-{.passC: "-march=native -O3".}
+{.passC: "-march=native -O3 -fPIC".}
 # nim c -d:release -d:danger -x -r tstats.nim
 import algorithm, math, random, sequtils, stats, strformat, times
 
@@ -18,10 +18,10 @@ block:
     B = A
     t0, t1 : float
   t0 = cpuTime()
-  let xS = quickSelect(A,0,Dim,dimH)
+  discard quickSelect(A,0,Dim,dimH)
   t0 = cpuTime()-t0
   t1 = cpuTime()
-  let xN = selectNaive(B,dimH)
+  discard selectNaive(B,dimH)
   t1 = cpuTime()-t1
   
   echo &"quickSelect is {100.0*(1.0-t0/t1):6.2f}% faster than sort-based method for a sequence of length {Dim}"

--- a/tests/benchmarks/tstats.nim
+++ b/tests/benchmarks/tstats.nim
@@ -1,0 +1,38 @@
+{.passC: "-march=native -O3".}
+# nim c -d:release -d:danger -x -r tstats.nim
+import algorithm, math, random, sequtils, stats, strformat, times
+
+block:
+  proc selectNaive[T](a: var seq[T], index: int): T =
+    a.sort()
+    a[index]
+
+  
+  const
+    NT = 7
+    Dim = 10^NT
+    dimH = Dim div 2
+
+  var
+    A = newSeqWith(Dim+1,rand(100.0))
+    B = A
+    t0, t1 : float
+  t0 = cpuTime()
+  let xS = quickSelect(A,0,Dim,dimH)
+  t0 = cpuTime()-t0
+  t1 = cpuTime()
+  let xN = selectNaive(B,dimH)
+  t1 = cpuTime()-t1
+  
+  echo &"quickSelect is {100.0*(1.0-t0/t1):6.2f}% faster than sort-based method for a sequence of length {Dim}"
+  # quickSelect is  93.13% faster than sort-based method for a sequence of length 10000000
+  
+  
+  
+#[
+(we should also have in future work a sortN which returns sorted results for bottom N items; 
+ easy to do at least with quicksort; and then in future work your API can be compared to:
+
+proc selectNaive2[T](a: seq[T], index: int): T =
+  a.sortN(index)[index]
+]#

--- a/tests/stdlib/tstats.nim
+++ b/tests/stdlib/tstats.nim
@@ -30,6 +30,37 @@ rs1.push(@[1.0, 2.2, 1.4, 4.9])
 doAssert(rs1.sum == 9.5)
 doAssert(rs1.mean() == 2.375)
 
+var 
+  ASv = [7,4,6,3,9,1]        #  sorted   1 3 4 6 7 9
+  A   : array[len(ASv),int]
+
+func myCmp(x,y:int):int =
+  if x==y : 0 elif x<y : -1 else: 1
+
+A= ASv;  doAssert quickSelect(A, 2, 5, 2, myCmp) == 1  # smallest element
+A= ASv;  doAssert quickSelect(A, 2, 5, 5, myCmp) == 9  # largest element
+#
+A= ASv;  doAssert median(A,0,5,myCmp)      == 5.0
+A= ASv;  doAssert median_low(A,0,5,myCmp)  == 4
+A= ASv;  doAssert median_high(A,0,5,myCmp) == 6
+#
+A= ASv;  doAssert median(A,2,5)            == 4.5
+A= ASv;  doAssert median_low(A,2,5)        == 3
+A= ASv;  doAssert median_high(A,2,5)       == 6
+#
+A= ASv;  doAssert median(A,0,4,myCmp)      == 6.0
+A= ASv;  doAssert median_low(A,0,4,myCmp)  == 6
+A= ASv;  doAssert median_high(A,0,4,myCmp) == 6
+
+func FCmp(x,y:float):int =
+  if x==y : 0
+  elif x<y : -1
+  else     : 1
+
+var  F = [7.0,4.0,6.0,3.0,9.0,1.0]
+
+doAssert median(F,0,5,FCmp) == 5.0
+
 when not defined(cpu32):
   # XXX For some reason on 32bit CPUs these results differ
   var rr: RunningRegress

--- a/tests/stdlib/tstats.nim
+++ b/tests/stdlib/tstats.nim
@@ -1,78 +1,38 @@
-include stats
-
-proc clean(x: float): float =
-  result = round(1.0e8*x).float * 1.0e-8
-
-var rs: RunningStat
-rs.push(@[1.0, 2.0, 1.0, 4.0, 1.0, 4.0, 1.0, 2.0])
-doAssert(rs.n == 8)
-doAssert(clean(rs.mean) == 2.0)
-doAssert(clean(rs.variance()) == 1.5)
-doAssert(clean(rs.varianceS()) == 1.71428571)
-doAssert(clean(rs.skewness()) == 0.81649658)
-doAssert(clean(rs.skewnessS()) == 1.01835015)
-doAssert(clean(rs.kurtosis()) == -1.0)
-doAssert(clean(rs.kurtosisS()) == -0.7000000000000001)
-
-var rs1, rs2: RunningStat
-rs1.push(@[1.0, 2.0, 1.0, 4.0])
-rs2.push(@[1.0, 4.0, 1.0, 2.0])
-let rs3 = rs1 + rs2
-doAssert(clean(rs3.mom2) == clean(rs.mom2))
-doAssert(clean(rs3.mom3) == clean(rs.mom3))
-doAssert(clean(rs3.mom4) == clean(rs.mom4))
-rs1 += rs2
-doAssert(clean(rs1.mom2) == clean(rs.mom2))
-doAssert(clean(rs1.mom3) == clean(rs.mom3))
-doAssert(clean(rs1.mom4) == clean(rs.mom4))
-rs1.clear()
-rs1.push(@[1.0, 2.2, 1.4, 4.9])
-doAssert(rs1.sum == 9.5)
-doAssert(rs1.mean() == 2.375)
+{.passC: "-march=native -O3 -fPIC".}
+# nim c -d:release -d:danger -x -r tstats.nim
+import algorithm, math, random, sequtils, stats, strformat, times
 
 block:
-  var 
-    ASv = [7,4,6,3,9,1]        #  sorted   1 3 4 6 7 9
-    A   : array[len(ASv),int]
+  proc selectNaive[T](a: var seq[T], index: int): T =
+    a.sort()
+    a[index]
 
-  func myCmp(x,y:int):int =
-    if x==y : 0 elif x<y : -1 else: 1
+  
+  const
+    NT = 7
+    Dim = 10^NT
+    dimH = Dim div 2
 
-  A= ASv;  doAssert quickSelect(A, 2, 5, 2, myCmp) == 1  # smallest element
-  A= ASv;  doAssert quickSelect(A, 2, 5, 5, myCmp) == 9  # largest element
-  #
-  A= ASv;  doAssert median(A,0,5,myCmp) == 5.0
-  A= ASv;  doAssert median(A,0,5,mdlow,myCmp) == 4
-  A= ASv;  doAssert median(A,0,5,mdhigh,myCmp) == 6
-  #
-  A= ASv;  doAssert median(A,2,5) == 4.5
-  A= ASv;  doAssert median(A,2,5,mdlow) == 3
-  A= ASv;  doAssert median(A,2,5,mdhigh) == 6
-  #
-  A= ASv;  doAssert median(A,0,4,myCmp) == 6.0
-  A= ASv;  doAssert median(A,0,4,mdlow,myCmp) == 6
-  A= ASv;  doAssert median(A,0,4,mdhigh,myCmp) == 6
+  var
+    A = newSeqWith(Dim+1,rand(100.0))
+    B = A
+    t0, t1 : float
+  t0 = cpuTime()
+  discard quickSelect(A,0,Dim,dimH)
+  t0 = cpuTime()-t0
+  t1 = cpuTime()
+  discard selectNaive(B,dimH)
+  t1 = cpuTime()-t1
+  
+  echo &"quickSelect is {100.0*(1.0-t0/t1):6.2f}% faster than sort-based method for a sequence of length {Dim}"
+  # quickSelect is  93.13% faster than sort-based method for a sequence of length 10000000
+  
+  
+  
+#[
+(we should also have in future work a sortN which returns sorted results for bottom N items; 
+ easy to do at least with quicksort; and then in future work your API can be compared to:
 
-  func FCmp(x,y:float):int =
-    if x==y : 0
-    elif x<y : -1
-    else     : 1
-
-  var  F = [7.0,4.0,6.0,3.0,9.0,1.0]
-
-  doAssert median(F,0,5,FCmp) == 5.0
-
-when not defined(cpu32):
-  # XXX For some reason on 32bit CPUs these results differ
-  var rr: RunningRegress
-  rr.push(@[0.0, 1.0, 2.8, 3.0, 4.0], @[0.0, 1.0, 2.3, 3.0, 4.0])
-  doAssert(rr.slope() == 0.9695585996955861)
-  doAssert(rr.intercept() == -0.03424657534246611)
-  doAssert(rr.correlation() == 0.9905100362239381)
-  var rr1, rr2: RunningRegress
-  rr1.push(@[0.0, 1.0], @[0.0, 1.0])
-  rr2.push(@[2.8, 3.0, 4.0], @[2.3, 3.0, 4.0])
-  let rr3 = rr1 + rr2
-  doAssert(rr3.correlation() == rr.correlation())
-  doAssert(clean(rr3.slope()) == clean(rr.slope()))
-  doAssert(clean(rr3.intercept()) == clean(rr.intercept()))
+proc selectNaive2[T](a: seq[T], index: int): T =
+  a.sortN(index)[index]
+]#

--- a/tests/stdlib/tstats.nim
+++ b/tests/stdlib/tstats.nim
@@ -1,38 +1,84 @@
-{.passC: "-march=native -O3 -fPIC".}
-# nim c -d:release -d:danger -x -r tstats.nim
-import algorithm, math, random, sequtils, stats, strformat, times
+include stats
+
+proc clean(x: float): float =
+  result = round(1.0e8*x).float * 1.0e-8
+
+var rs: RunningStat
+rs.push(@[1.0, 2.0, 1.0, 4.0, 1.0, 4.0, 1.0, 2.0])
+doAssert(rs.n == 8)
+doAssert(clean(rs.mean) == 2.0)
+doAssert(clean(rs.variance()) == 1.5)
+doAssert(clean(rs.varianceS()) == 1.71428571)
+doAssert(clean(rs.skewness()) == 0.81649658)
+doAssert(clean(rs.skewnessS()) == 1.01835015)
+doAssert(clean(rs.kurtosis()) == -1.0)
+doAssert(clean(rs.kurtosisS()) == -0.7000000000000001)
+
+var rs1, rs2: RunningStat
+rs1.push(@[1.0, 2.0, 1.0, 4.0])
+rs2.push(@[1.0, 4.0, 1.0, 2.0])
+let rs3 = rs1 + rs2
+doAssert(clean(rs3.mom2) == clean(rs.mom2))
+doAssert(clean(rs3.mom3) == clean(rs.mom3))
+doAssert(clean(rs3.mom4) == clean(rs.mom4))
+rs1 += rs2
+doAssert(clean(rs1.mom2) == clean(rs.mom2))
+doAssert(clean(rs1.mom3) == clean(rs.mom3))
+doAssert(clean(rs1.mom4) == clean(rs.mom4))
+rs1.clear()
+rs1.push(@[1.0, 2.2, 1.4, 4.9])
+doAssert(rs1.sum == 9.5)
+doAssert(rs1.mean() == 2.375)
 
 block:
-  proc selectNaive[T](a: var seq[T], index: int): T =
-    a.sort()
-    a[index]
+  var 
+    a4 = [6, 3, 9, 1]
+    a5 = [4, 6, 3, 9, 1]
+    a: array[len(a4), int]
+    ax: array[len(a5), int]
 
-  
-  const
-    NT = 7
-    Dim = 10^NT
-    dimH = Dim div 2
+  func myCmp(x,y:int):int =
+    if x==y : 0 elif x<y : -1 else: 1
 
-  var
-    A = newSeqWith(Dim+1,rand(100.0))
-    B = A
-    t0, t1 : float
-  t0 = cpuTime()
-  discard quickSelect(A,0,Dim,dimH)
-  t0 = cpuTime()-t0
-  t1 = cpuTime()
-  discard selectNaive(B,dimH)
-  t1 = cpuTime()-t1
-  
-  echo &"quickSelect is {100.0*(1.0-t0/t1):6.2f}% faster than sort-based method for a sequence of length {Dim}"
-  # quickSelect is  93.13% faster than sort-based method for a sequence of length 10000000
-  
-  
-  
-#[
-(we should also have in future work a sortN which returns sorted results for bottom N items; 
- easy to do at least with quicksort; and then in future work your API can be compared to:
+  a= a4
+  doAssert quickSelect(a, 0, len(a4)-1, 0, myCmp) == 1  # smallest element
+  a= a4
+  doAssert quickSelect(a, 0, len(a4)-1, len(a4)-1, myCmp) == 9  # largest element
+  #
+  a= a4
+  doAssert median(a,myCmp) == 4.5
+  a= a4
+  doAssert median(a,mdlow,myCmp) == 3
+  a= a4
+  doAssert median(a,mdhigh,myCmp) == 6
+  #
+  ax= a5
+  doAssert median(ax,myCmp) == 4.0
+  ax= a5
+  doAssert median(ax,mdlow,myCmp) == 4
+  ax= a5
+  doAssert median(ax,mdhigh,myCmp) == 4
 
-proc selectNaive2[T](a: seq[T], index: int): T =
-  a.sortN(index)[index]
-]#
+  func fltCmp(x,y:float):int =
+    if x==y : 0
+    elif x<y : -1
+    else     : 1
+
+  var  f = [7.0,4.0,6.0,3.0,9.0,1.0]
+
+  doAssert median(f,fltCmp) == 5.0
+
+when not defined(cpu32):
+  # XXX For some reason on 32bit CPUs these results differ
+  var rr: RunningRegress
+  rr.push(@[0.0, 1.0, 2.8, 3.0, 4.0], @[0.0, 1.0, 2.3, 3.0, 4.0])
+  doAssert(rr.slope() == 0.9695585996955861)
+  doAssert(rr.intercept() == -0.03424657534246611)
+  doAssert(rr.correlation() == 0.9905100362239381)
+  var rr1, rr2: RunningRegress
+  rr1.push(@[0.0, 1.0], @[0.0, 1.0])
+  rr2.push(@[2.8, 3.0, 4.0], @[2.3, 3.0, 4.0])
+  let rr3 = rr1 + rr2
+  doAssert(rr3.correlation() == rr.correlation())
+  doAssert(clean(rr3.slope()) == clean(rr.slope()))
+  doAssert(clean(rr3.intercept()) == clean(rr.intercept()))

--- a/tests/stdlib/tstats.nim
+++ b/tests/stdlib/tstats.nim
@@ -30,36 +30,37 @@ rs1.push(@[1.0, 2.2, 1.4, 4.9])
 doAssert(rs1.sum == 9.5)
 doAssert(rs1.mean() == 2.375)
 
-var 
-  ASv = [7,4,6,3,9,1]        #  sorted   1 3 4 6 7 9
-  A   : array[len(ASv),int]
+block:
+  var 
+    ASv = [7,4,6,3,9,1]        #  sorted   1 3 4 6 7 9
+    A   : array[len(ASv),int]
 
-func myCmp(x,y:int):int =
-  if x==y : 0 elif x<y : -1 else: 1
+  func myCmp(x,y:int):int =
+    if x==y : 0 elif x<y : -1 else: 1
 
-A= ASv;  doAssert quickSelect(A, 2, 5, 2, myCmp) == 1  # smallest element
-A= ASv;  doAssert quickSelect(A, 2, 5, 5, myCmp) == 9  # largest element
-#
-A= ASv;  doAssert median(A,0,5,myCmp)      == 5.0
-A= ASv;  doAssert median_low(A,0,5,myCmp)  == 4
-A= ASv;  doAssert median_high(A,0,5,myCmp) == 6
-#
-A= ASv;  doAssert median(A,2,5)            == 4.5
-A= ASv;  doAssert median_low(A,2,5)        == 3
-A= ASv;  doAssert median_high(A,2,5)       == 6
-#
-A= ASv;  doAssert median(A,0,4,myCmp)      == 6.0
-A= ASv;  doAssert median_low(A,0,4,myCmp)  == 6
-A= ASv;  doAssert median_high(A,0,4,myCmp) == 6
+  A= ASv;  doAssert quickSelect(A, 2, 5, 2, myCmp) == 1  # smallest element
+  A= ASv;  doAssert quickSelect(A, 2, 5, 5, myCmp) == 9  # largest element
+  #
+  A= ASv;  doAssert median(A,0,5,myCmp) == 5.0
+  A= ASv;  doAssert median(A,0,5,mdlow,myCmp) == 4
+  A= ASv;  doAssert median(A,0,5,mdhigh,myCmp) == 6
+  #
+  A= ASv;  doAssert median(A,2,5) == 4.5
+  A= ASv;  doAssert median(A,2,5,mdlow) == 3
+  A= ASv;  doAssert median(A,2,5,mdhigh) == 6
+  #
+  A= ASv;  doAssert median(A,0,4,myCmp) == 6.0
+  A= ASv;  doAssert median(A,0,4,mdlow,myCmp) == 6
+  A= ASv;  doAssert median(A,0,4,mdhigh,myCmp) == 6
 
-func FCmp(x,y:float):int =
-  if x==y : 0
-  elif x<y : -1
-  else     : 1
+  func FCmp(x,y:float):int =
+    if x==y : 0
+    elif x<y : -1
+    else     : 1
 
-var  F = [7.0,4.0,6.0,3.0,9.0,1.0]
+  var  F = [7.0,4.0,6.0,3.0,9.0,1.0]
 
-doAssert median(F,0,5,FCmp) == 5.0
+  doAssert median(F,0,5,FCmp) == 5.0
 
 when not defined(cpu32):
   # XXX For some reason on 32bit CPUs these results differ


### PR DESCRIPTION
The statistics module is missing the computation of the median of a sequence.
This PR adds
**quickSelect** : quick selecting the  k-th smallest or k-th largest element of a sequence using the _Lomuto_ partition scheme

For a sequence of odd length ``N``  the **median** is that element which is larger-or-equal to ``(N-1)/2)`` elements and greater-or-equal than ``(N-1)/2)`` elements of the sequence.

**median_low** computes the **median** for a sequence of odd length. In case of even length ``N``, ``median_low`` has the property that ``N/2`` elements are less than or equal this value   and ``N/2+1`` elements are greater than or equal this value.
It can be computed for any sequence of _comparable items_.

**median_high** computes the **median** for a sequence of odd length. In case of even length ``N``, ``median_high`` has the property that ``N/2`` elements are greater than or equal this value   and ``N/2+1`` elements are less than or equal this value.
It can be computed for any sequence of _comparable items_.

**median** computes the ``median`` of a sequence of _numeric items_. For a sequence of odd length it is equivalent to ``median_low`` and ``median_high``.  In case of a sequence of even length it computes the arithmetic mean of  ``median_low`` and ``median_high``.