### PR TITLE
[std/locks]remove workaround for withLock

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -42,16 +42,16 @@ proc deinitLock*(lock: var Lock) {.inline.} =
   ## Frees the resources associated with the lock.
   deinitSys(lock)
 
-proc tryAcquire*(lock: var Lock): bool =
+proc tryAcquire*(lock: var Lock): bool {.inline.} =
   ## Tries to acquire the given lock. Returns `true` on success.
   result = tryAcquireSys(lock)
 
-proc acquire*(lock: var Lock) =
+proc acquire*(lock: var Lock) {.inline.} =
   ## Acquires the given lock.
   when not defined(js):
     acquireSys(lock)
 
-proc release*(lock: var Lock) =
+proc release*(lock: var Lock) {.inline.} =
   ## Releases the given lock.
   when not defined(js):
     releaseSys(lock)
@@ -76,7 +76,6 @@ proc signal*(cond: var Cond) {.inline.} =
 template withLock*(a: Lock, body: untyped) =
   ## Acquires the given lock, executes the statements in body and
   ## releases the lock after the statements finish executing.
-  mixin acquire, release
   acquire(a)
   {.locks: [a].}:
     try:


### PR DESCRIPTION
Ref #6113 and #6049

The workaround for generics instantiation is unnecessary. It seems to be fixed by another PR I guess.

The test still works. So the changes should be harmless.
https://github.com/nim-lang/Nim/blob/devel/tests/stdlib/tlocks.nim

I also add some inline pragmas.