### PR TITLE
more informative error msg for undeclared field (`A(badfield: 1)` and `a.badfield = expr`)

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -411,14 +411,19 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
 
     if overloadsState == csEmpty and result.state == csEmpty:
       if efNoUndeclared notin flags: # for tests/pragmas/tcustom_pragma.nim
-        if n[0].kind == nkIdent and n[0].ident.s == ".=" and n[2].kind == nkIdent:
-          let sym = n[1].typ.sym
-          let field = n[2].ident.s
-          let msg = errUndeclaredField % field & " for type " & getProcHeader(c.config, sym)
-          localError(c.config, orig[2].info, msg)
-        else:
+        template impl() =
           # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
           localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
+        if n[0].kind == nkIdent and n[0].ident.s == ".=" and n[2].kind == nkIdent:
+          let sym = n[1].typ.sym
+          if sym == nil:
+            impl()
+          else:
+            let field = n[2].ident.s
+            let msg = errUndeclaredField % field & " for type " & getProcHeader(c.config, sym)
+            localError(c.config, orig[2].info, msg)
+        else:
+          impl()
       return
     elif result.state != csMatch:
       if nfExprCall in n.flags:

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -411,8 +411,14 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
 
     if overloadsState == csEmpty and result.state == csEmpty:
       if efNoUndeclared notin flags: # for tests/pragmas/tcustom_pragma.nim
-        # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
-        localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
+        if n[0].kind == nkIdent and n[0].ident.s == ".=" and n[2].kind == nkIdent:
+          let sym = n[1].typ.sym
+          let field = n[2].ident.s
+          let msg = errUndeclaredField % field & " for type " & getProcHeader(c.config, sym)
+          localError(c.config, orig[2].info, msg)
+        else:
+          # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
+          localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
       return
     elif result.state != csMatch:
       if nfExprCall in n.flags:

--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -429,7 +429,8 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
           hasError = true
           break
       # 2) No such field exists in the constructed type
-      localError(c.config, field.info, errUndeclaredFieldX % id.s)
+      let msg = errUndeclaredField % id.s & " for type " & getProcHeader(c.config, t.sym)
+      localError(c.config, field.info, msg)
       hasError = true
       break
 

--- a/tests/errmsgs/tundeclared_field.nim
+++ b/tests/errmsgs/tundeclared_field.nim
@@ -1,0 +1,40 @@
+discard """
+cmd: '''nim check --hints:off $file'''
+action: reject
+nimout: '''
+tundeclared_field.nim(25, 12) Error: undeclared field: 'bad' for type tundeclared_field.A [type declared in tundeclared_field.nim(22, 8)]
+tundeclared_field.nim(30, 16) Error: undeclared field: 'bad' for type tundeclared_field.A [type declared in tundeclared_field.nim(28, 8)]
+tundeclared_field.nim(36, 4) Error: undeclared field: 'bad' for type tundeclared_field.A [type declared in tundeclared_field.nim(33, 8)]
+tundeclared_field.nim(40, 13) Error: cannot instantiate Foo [type declared in tundeclared_field.nim(39, 8)]
+'''
+"""
+
+
+
+
+
+
+
+
+
+# line 20
+block:
+  type A = object
+    a0: int
+  var a: A
+  discard a.bad
+
+block:
+  type A = object
+    a0: int
+  var a = A(bad: 0)
+
+block:
+  type A = object
+    a0: int
+  var a: A
+  a.bad = 0
+
+block:
+  type Foo[T: SomeInteger] = object
+  var a: Foo[float]


### PR DESCRIPTION
followup https://github.com/nim-lang/Nim/pull/17745, https://github.com/nim-lang/Nim/pull/9766

```nim
type A = object
  x: int

when defined case1:
  type A2 = A
  var b: A
  let c = b.x2

when defined case2:
  let a = A(x: 1, y: 2)

when defined case3:
  var a: A
  a.x2 = 3
```

## before PR:
case1: t12184.nim(28, 12) Error: undeclared field: 'x2' for type t12184.A [type declared in t12184.nim(22, 6)]
case2: t12184.nim(31, 20) Error: undeclared field: 'y'
case3: t12184.nim(35, 8) Error: attempting to call undeclared routine: 'x2='


## after PR:
case1: t12184.nim(28, 12) Error: undeclared field: 'x2' for type t12184.A [type declared in t12184.nim(22, 6)]
case2: t12184.nim(31, 20) Error: undeclared field: 'y' for type t12184.A [type declared in t12184.nim(22, 6)]
case3: t12184.nim(35, 8) Error: undeclared field: 'x2' for type t12184.A [type declared in t12184.nim(22, 6)]

(in more complex cases it may not be obvious where the underlying object is declared)

## future work
- [x] similarly support generics eg: => https://github.com/nim-lang/Nim/pull/18259
```nim
block:
  type Foo[T] = object
  var a: Foo[int]
  discard a.bad2 # should improve error
  a.bad2 = 0 # should improve error
  let a2 = Foo[int](bad: 0) # should improve error
```
