### PR TITLE
`--declaredlocs` now shows location for `T` instead of `static` in `proc fn(a: static T)`

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -124,9 +124,6 @@ proc isFloatLit*(t: PType): bool {.inline.} =
   result = t.kind == tyFloat and t.n != nil and t.n.kind == nkFloatLit
 
 proc addDeclaredLoc*(result: var string, conf: ConfigRef; sym: PSym) =
-  var sym = sym
-  while sym.typ.kind in {tyStatic}:
-    sym = sym.typ[0].sym
   result.add " [$1 declared in $2]" % [sym.kind.toHumanStr, toFileLineCol(conf, sym.info)]
 
 proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =


### PR DESCRIPTION
## example
```nim
when true:
  proc fn(a: static string) = discard
  fn(2)
```
nim r --declaredlocs --filenames:canonical /pathto/t12190.nim

## before PR
```
tests/nim/all/t12190.nim(7, 5) Error: type mismatch: got <int literal(2)>
but expected one of:
proc fn(a: static string) [proc declared in tests/nim/all/t12190.nim(6, 8)]
  first type mismatch at position: 1
  required type for a: static[string] [static declared in tests/nim/all/t12190.nim(6, 11)]
  but expression '2' is of type: int literal(2) [int declared in system/basic_types.nim(2, 3)]
```

## after PR
```
tests/nim/all/t12190.nim(7, 5) Error: type mismatch: got <int literal(2)>
but expected one of:
proc fn(a: static string) [proc declared in tests/nim/all/t12190.nim(6, 8)]
  first type mismatch at position: 1
  required type for a: static[string] [string declared in system.nim(34, 3)]
  but expression '2' is of type: int literal(2) [int declared in system/basic_types.nim(2, 3)]
```

## note
~~the fact that it shows absolute paths despite `--listfullpaths:off` is a pre-existing issue with `--listfullpaths:off` and is being fixed in https://github.com/nim-lang/Nim/pull/17746~~ EDIT: fixed in https://github.com/nim-lang/Nim/pull/17746