### PR TITLE
[std/deques] move data instead of copy + destroy

### DIFF
--- a/lib/pure/collections/deques.nim
+++ b/lib/pure/collections/deques.nim
@@ -379,8 +379,7 @@ proc popFirst*[T](deq: var Deque[T]): T {.inline, discardable.} =
 
   emptyCheck(deq)
   dec deq.count
-  result = deq.data[deq.head]
-  destroy(deq.data[deq.head])
+  result = move deq.data[deq.head]
   deq.head = (deq.head + 1) and deq.mask
 
 proc popLast*[T](deq: var Deque[T]): T {.inline, discardable.} =
@@ -398,8 +397,7 @@ proc popLast*[T](deq: var Deque[T]): T {.inline, discardable.} =
   emptyCheck(deq)
   dec deq.count
   deq.tail = (deq.tail - 1) and deq.mask
-  result = deq.data[deq.tail]
-  destroy(deq.data[deq.tail])
+  result = move deq.data[deq.tail]
 
 proc clear*[T](deq: var Deque[T]) {.inline.} =
   ## Resets the deque so that it is empty.


### PR DESCRIPTION
I need it for non-copyable object, so they are moved instead of being copied.