### PR TITLE
closes #17793 ; improve errmsg when ctor called on non-tyObject kind

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -11,6 +11,8 @@
 
 # included from sem.nim
 
+from sugar import dup
+
 type
   ObjConstrContext = object
     typ: PType               # The constructed type
@@ -389,7 +391,8 @@ proc semObjConstr(c: PContext, n: PNode, flags: TExprFlags): PNode =
       # multiple times as long as they don't have closures.
       result.typ.flags.incl tfHasOwned
   if t.kind != tyObject:
-    return localErrorNode(c, result, "object constructor needs an object type")
+    return localErrorNode(c, result,
+      "object constructor needs an object type".dup(addDeclaredLoc(c.config, t)))
 
   # Check if the object is fully initialized by recursively testing each
   # field (if this is a case object, initialized fields in two different

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -130,7 +130,7 @@ proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
   if optDeclaredLocs in conf.globalOptions and sym != nil:
     addDeclaredLoc(result, conf, sym)
 
-proc addDeclaredLoc(result: var string, conf: ConfigRef; typ: PType) =
+proc addDeclaredLoc*(result: var string, conf: ConfigRef; typ: PType) =
   let typ = typ.skipTypes(abstractInst - {tyRange})
   result.add " [$1" % typ.kind.toHumanStr
   if typ.sym != nil:


### PR DESCRIPTION
* closes #17793 (if you agree with what i said in https://github.com/nim-lang/Nim/issues/17793#issuecomment-823674407)
* refs #16533 for eg in #16533 erromsg is now:
```
t12194.nim(24, 11) Error: object constructor needs an object type [genericBody declared in t12194.nim(9, 3)]
      F = cf(f: fs)
```

instead of:
```
t12194.nim(24, 11) Error: object constructor needs an object type
      F = cf(f: fs)
```
which is clear enough.
the feature request in #16533 is still valid though, so this doesn't close it.
