### PR TITLE
`typeof(voidStmt)` now works

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -331,7 +331,7 @@
 - Added a new module `std/importutils`, and an API `privateAccess`, which allows access to private fields
   for an object type in the current scope.
 
-- `typeof(stmt)` now works and returns `void`.
+- `typeof(voidStmt)` now works and returns `void`.
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -331,6 +331,8 @@
 - Added a new module `std/importutils`, and an API `privateAccess`, which allows access to private fields
   for an object type in the current scope.
 
+- `typeof(stmt)` now works and returns `void`.
+
 ## Compiler changes
 
 - Added `--declaredlocs` to show symbol declaration location in messages.

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -133,3 +133,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasCustomLiterals")
   defineSymbol("nimHasUnifiedTuple")
   defineSymbol("nimHasIterable")
+  defineSymbol("nimHasTypeofVoid")

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -525,6 +525,7 @@ proc myOpen(graph: ModuleGraph; module: PSym; idgen: IdGenerator): PPassContext 
   var c = newContext(graph, module)
   c.idgen = idgen
   c.enforceVoidContext = newType(tyTyped, nextTypeId(idgen), nil)
+  c.voidType = newType(tyVoid, nextTypeId(idgen), nil)
 
   if c.p != nil: internalError(graph.config, module.info, "sem.myOpen")
   c.semConstExpr = semConstExpr

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -90,6 +90,9 @@ type
   TContext* = object of TPassContext # a context represents the module
                                      # that is currently being compiled
     enforceVoidContext*: PType
+      # for `if cond: stmt else: foo`, `foo` will be evaluated under
+      # enforceVoidContext != nil
+    voidType*: PType # for typeof(stmt)
     module*: PSym              # the module sym belonging to the context
     currentScope*: PScope      # current scope
     moduleScope*: PScope       # scope for modules

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -83,7 +83,9 @@ proc semExprCheck(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
 proc semExprWithType(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   result = semExprCheck(c, n, flags)
-  if result.typ == nil or result.typ == c.enforceVoidContext:
+  if result.typ == nil and efInTypeof in flags:
+    result.typ = c.voidType
+  elif result.typ == nil or result.typ == c.enforceVoidContext:
     localError(c.config, n.info, errExprXHasNoType %
                 renderTree(result, {renderNoComments}))
     result.typ = errorType(c)

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -158,10 +158,6 @@ proc newPromise*(handler: proc(resolve: proc())): Future[void] {.importjs: "(new
   ## A helper for wrapping callback-based functions
   ## into promises and async procedures.
 
-template typeOrVoid[T](a: T): type =
-  # xxx this is useful, make it public in std/typetraits in future work
-  T
-
 template maybeFuture(T): untyped =
   # avoids `Future[Future[T]]`
   when T is Future: T
@@ -221,7 +217,8 @@ when defined(nimExperimentalAsyncjsThen):
             assert witness == 3
 
       template impl(call): untyped =
-        when typeOrVoid(call) is void:
+        # see D20210421T014713
+        when typeof(block: call) is void:
           var ret: Future[void]
         else:
           var ret = default(maybeFuture(typeof(call)))

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -51,7 +51,7 @@ pkg "cello"
 pkg "chroma"
 pkg "chronicles", "nim c -o:chr -r chronicles.nim"
 pkg "chronos", "nim c -r -d:release tests/testall", allowFailure = true # pending https://github.com/nim-lang/Nim/issues/17130
-pkg "cligen", "nim c --path:. -r cligen.nim", allowFailure = true # pending https://github.com/c-blake/cligen/pull/193
+pkg "cligen", "nim c --path:. -r cligen.nim"
 pkg "combparser", "nimble test --gc:orc"
 pkg "compactdict"
 pkg "comprehension", "nimble test", "https://github.com/alehander42/comprehension"
@@ -106,7 +106,8 @@ pkg "nimpy", "nim c -r tests/nimfrompy.nim"
 pkg "nimquery", allowFailure = true # pending https://github.com/GULPF/nimquery/pull/10
 pkg "nimsl"
 pkg "nimsvg"
-pkg "nimterop", "nimble minitest"
+pkg "nimterop", "nimble minitest", allowFailure = true
+  # pending https://github.com/c-blake/cligen/pull/193 (yes, cligen is the thing that breaks here)
 pkg "nimwc", "nim c nimwc.nim"
 pkg "nimx", "nim c --threads:on test/main.nim", allowFailure = true
 pkg "nitter", "nim c src/nitter.nim", "https://github.com/zedeus/nitter"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -106,8 +106,7 @@ pkg "nimpy", "nim c -r tests/nimfrompy.nim"
 pkg "nimquery", allowFailure = true # pending https://github.com/GULPF/nimquery/pull/10
 pkg "nimsl"
 pkg "nimsvg"
-pkg "nimterop", "nimble minitest", allowFailure = true
-  # pending https://github.com/c-blake/cligen/pull/193 (yes, cligen is the thing that breaks here)
+pkg "nimterop", "nimble minitest"
 pkg "nimwc", "nim c nimwc.nim"
 pkg "nimx", "nim c --threads:on test/main.nim", allowFailure = true
 pkg "nitter", "nim c src/nitter.nim", "https://github.com/zedeus/nitter"
@@ -122,8 +121,7 @@ pkg "pixie", useHead = false
 pkg "plotly", "nim c examples/all.nim"
 pkg "pnm"
 pkg "polypbren"
-pkg "prologue", "nimble tcompile", allowFailure = true
-  # pending https://github.com/c-blake/cligen/pull/193 (yes, cligen is the thing that breaks here)
+pkg "prologue", "nimble tcompile"
 pkg "protobuf", "nim c -o:protobuff -r src/protobuf.nim"
 pkg "pylib"
 pkg "rbtree"

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -51,7 +51,7 @@ pkg "cello"
 pkg "chroma"
 pkg "chronicles", "nim c -o:chr -r chronicles.nim"
 pkg "chronos", "nim c -r -d:release tests/testall", allowFailure = true # pending https://github.com/nim-lang/Nim/issues/17130
-pkg "cligen", "nim c --path:. -r cligen.nim"
+pkg "cligen", "nim c --path:. -r cligen.nim", allowFailure = true # pending https://github.com/c-blake/cligen/pull/193
 pkg "combparser", "nimble test --gc:orc"
 pkg "compactdict"
 pkg "comprehension", "nimble test", "https://github.com/alehander42/comprehension"
@@ -121,7 +121,8 @@ pkg "pixie", useHead = false
 pkg "plotly", "nim c examples/all.nim"
 pkg "pnm"
 pkg "polypbren"
-pkg "prologue", "nimble tcompile"
+pkg "prologue", "nimble tcompile", allowFailure = true
+  # pending https://github.com/c-blake/cligen/pull/193 (yes, cligen is the thing that breaks here)
 pkg "protobuf", "nim c -o:protobuff -r src/protobuf.nim"
 pkg "pylib"
 pkg "rbtree"

--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -91,10 +91,6 @@ template disableVm*(body) =
   when nimvm: discard
   else: body
 
-template typeOrVoid[T](a: T): type =
-  # FACTOR with asyncjs.typeOrVoid
-  T
-
 macro assertAll*(body) =
   ## works in VM, unlike `check`, `require`
   runnableExamples:
@@ -106,6 +102,9 @@ macro assertAll*(body) =
   result = newStmtList()
   for a in body:
     result.add genAst(a) do:
-      # better than: `when not compiles(typeof(a)):`
-      when typeOrVoid(a) is void: a
+      # D20210421T014713:here
+      # xxx pending https://github.com/nim-lang/Nim/issues/12030,
+      # `typeof` should introduce its own scope, so that this
+      # is sufficient: `typeof(a)` instead of `typeof(block: a)`
+      when typeof(block: a) is void: a
       else: doAssert a

--- a/tests/typerel/tvoid.nim
+++ b/tests/typerel/tvoid.nim
@@ -35,3 +35,64 @@ ReturnT[void]()
 echo ReturnT[string]("abc")
 nothing()
 
+block: # typeof(stmt)
+  proc fn1(): auto =
+    discard
+  proc fn2(): auto =
+    1
+  doAssert type(fn1()) is void
+  doAssert typeof(fn1()) is void
+  doAssert typeof(fn1()) isnot int
+
+  doAssert type(fn2()) isnot void
+  doAssert typeof(fn2()) isnot void
+  when typeof(fn1()) is void: discard
+  else: doAssert false
+
+  doAssert typeof(1+1) is int
+  doAssert typeof((discard)) is void
+
+  type A1 = typeof(fn1())
+  doAssert A1 is void
+  type A2 = type(fn1())
+  doAssert A2 is void
+  doAssert A2 is A1
+
+  when false:
+    # xxx: MCS/UFCS doesn't work here: Error: expression 'fn1()' has no type (or is ambiguous)
+    type A3 = fn1().type
+  proc bar[T](a: T): string = $T
+  doAssert bar(1) == "int"
+  doAssert bar(fn1()) == "void"
+
+  proc bar2[T](a: T): bool = T is void
+  doAssert not bar2(1)
+  doAssert bar2(fn1())
+
+  block:
+    proc bar3[T](a: T): T = a
+    let a1 = bar3(1)
+    doAssert compiles(block:
+      let a1 = bar3(fn2()))
+    doAssert not compiles(block:
+      let a2 = bar3(fn1()))
+    doAssert compiles(block: bar3(fn1()))
+    doAssert compiles(bar3(fn1()))
+    doAssert typeof(bar3(fn1())) is void
+    doAssert not compiles(sizeof(bar3(fn1())))
+
+  block:
+    var a = 1
+    doAssert typeof((a = 2)) is void
+    doAssert typeof((a = 2; a = 3)) is void
+    doAssert typeof(block:
+      a = 2; a = 3) is void
+
+  block:
+    var a = 1
+    template bad1 = echo (a; a = 2)
+    doAssert not compiles(bad1())
+
+  block:
+    template bad2 = echo (nonexistant; discard)
+    doAssert not compiles(bad2())


### PR DESCRIPTION
preferably merge https://github.com/nim-lang/Nim/pull/17813 before this so that CI is green (EDIT: ended up pushing a dummy commit to rerun CI so that it's green because  https://github.com/nim-lang/Nim/pull/17813 wasn't merged yet)

* refs https://github.com/nim-lang/Nim/pull/17761/files#r615348636
* closes #17761

this now works:
```nim
proc fn() = discard
assert typeof(fn()) is void
```

likewise with other statements that return void, see tests.

I also added a `-d:nimHasTypeofVoid` condsyms


## note
only 1 place was broken (in `cligen`) and that was because it used `when compiles(type(p))`, which is the very thing i'm fixing here. It affected 2 packages (nimterop, prologue) but both orginated from this line; i've sent out https://github.com/c-blake/cligen/pull/193 to fix this with a fwd and backward compatible change, and it was merged (and tagged, which was needed), fixing those 2 packages.

## added new PTAL label to help triage issues where ball is in reviewer's camp
@Araq I've added a label `PTAL`, this is something i've wanted to add for a while and discussed with @xflywind before, the intent is to indicate that a PR is ready for (first or next) round of reviews, meaning some reviewer action is needed, eg:
* all comments are addressed or some comments need reviewer action
* CI is either green or only contains CI failures unrelated to PR (or a `[skip ci]` was passed before https://github.com/nim-lang/Nim/pull/17813) makes CI for azure red; the benefit being: faster turnaround and avoid wasting CI resources when a commit is deemed safe, eg changelog entry or comment that was verified locally to work with nim doc)
* the PR author, reviewer or anyone can remove the PTAL label when the ball is in PR author's camp

(this feature exists in some form or another in other code review tools) 

The goal of PTAL label is to make it easier to identify which PR's need reviewer attention (via github labels) without requiring annoying pings; simply looking at green/red CI status is not a good indication for that (because CI can be green but with unaddressed review comments, or red but still mergeable because of `[skip ci]` and unrelated CI failures). Of course, both PR author and reviewer need to make sure that this is indeed the case.

## example
as you can see in this PR, last commit made it red (changelog only entry with `[skip ci]` before https://github.com/nim-lang/Nim/pull/17813) but previous commit was green, therefore it is mergeable:

![image](https://user-images.githubusercontent.com/2194784/115599773-d22bac80-a290-11eb-84c8-9c8881e3f57d.png)

## future work
- [ ] (pre-existing issue) very similar to https://github.com/nim-lang/Nim/issues/12030, we should evaluate `typeof(x)` in its own scope, so that code like this works:
```nim
when true:
  var a = 1
  type B = typeof((let a = 2; a))
```
(see also D20210421T014713 in this PR)
- [ ] consider whether we also want this to work: 
```nim
proc fn() = discard
assert fn() is void
```
