### PR TITLE
Fix Httpclient headers from being modified accidentally

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -962,12 +962,15 @@ proc format(client: HttpClient | AsyncHttpClient,
 
 proc override(fallback, override: HttpHeaders): HttpHeaders =
   # Right-biased map union for `HttpHeaders`
-  if override.isNil:
-    return fallback
 
   result = newHttpHeaders()
   # Copy by value
   result.table[] = fallback.table[]
+
+  if override.isNil:
+    # Return the copy of fallback so it does not get modified
+    return result
+
   for k, vs in override.table:
     result[k] = vs
 


### PR DESCRIPTION
This was resulting in multiple requests using the same client having the same content-length due to `newHeaders` sneakily being a reference to `client.headers`, which would store the content-length permanently.