### PR TITLE
manual: fix rendering of Identifiers & Keywords

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -261,8 +261,9 @@ and underscores, with the following restrictions:
 
 * begins with a letter
 * does not end with an underscore `_`
-* two immediate following underscores `__` are not allowed::
+* two immediate following underscores `__` are not allowed:
 
+.. code-block::
   letter ::= 'A'..'Z' | 'a'..'z' | '\x80'..'\xff'
   digit ::= '0'..'9'
   IDENTIFIER ::= letter ( ['_'] (letter | digit) )*


### PR DESCRIPTION
https://github.com/nim-lang/Nim/pull/17813 could be merged first so that this is green

the `[skip ci]` in commit msg is intentional, which causes:
* CI to be skipped for github actions
* CI to complete with error after < 30 seconds for azure (now possible since https://github.com/nim-lang/Nim/pull/17561), thus saving CI time / resources

I verified locally that this works, via `nim rst2html -r --doccmd:skip doc/manual.rst`:

## before PR

![image](https://user-images.githubusercontent.com/2194784/115594457-9beb2e80-a28a-11eb-866c-ab2b1de7b154.png)

## after PR:
![image](https://user-images.githubusercontent.com/2194784/115593930-fcc63700-a289-11eb-9576-8f819c9b6622.png)
