### PR TITLE
followup #17561, skipping ci now implies green

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -49,19 +49,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: 'Checkout'
+      - name: 'Checkout2'
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
 
-      - name: 'Check whether to skip CI'
-        shell: bash
-        run: |
-          # see D20210329T004830
-          # xxx reuse nimIsCiSkip
-          commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
-          echo commitMsg: $commitMsg
-          echo $commitMsg | grep -v '\[skip ci\]'
+      # - name: 'Check whether to skip CI'
+      #   shell: bash
+      #   run: |
+      #     # see D20210329T004830
+      #     # xxx reuse nimIsCiSkip
+      #     commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
+      #     echo commitMsg: $commitMsg
+      #     echo $commitMsg | grep -v '\[skip ci\]'
 
       - name: 'Install build dependencies (macOS)'
         if: runner.os == 'macOS'

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: 'Checkout2'
+      - name: 'Checkout3'
         uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -58,6 +58,7 @@ jobs:
         shell: bash
         run: |
           # see D20210329T004830
+          # xxx reuse nimIsCiSkip
           commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
           echo commitMsg: $commitMsg
           echo $commitMsg | grep -v '\[skip ci\]'

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -30,9 +30,6 @@ on:
 
 jobs:
   build:
-    # see D20210329T004830
-    if: |
-      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     strategy:
       fail-fast: false
       matrix:
@@ -49,19 +46,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: 'Checkout3'
+      - name: 'Checkout'
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
-      # - name: 'Check whether to skip CI'
-      #   shell: bash
-      #   run: |
-      #     # see D20210329T004830
-      #     # xxx reuse nimIsCiSkip
-      #     commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
-      #     echo commitMsg: $commitMsg
-      #     echo $commitMsg | grep -v '\[skip ci\]'
 
       - name: 'Install build dependencies (macOS)'
         if: runner.os == 'macOS'

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -3,9 +3,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-    # see D20210329T004830
-    if: |
-      !contains(format('{0}', github.event.pull_request.title), '[skip ci]')
     strategy:
       fail-fast: false
       matrix:
@@ -22,14 +19,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-
-      - name: 'Check whether to skip CI'
-        shell: bash
-        run: |
-          # see D20210329T004830
-          commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
-          echo commitMsg: $commitMsg
-          echo $commitMsg | grep -v '\[skip ci\]'
 
       - name: 'Checkout csources'
         uses: actions/checkout@v2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,10 @@ pr:
     include:
     - '*'
 
+variables:
+- name: skipci
+  value: false 
+
 jobs:
 - job: packages
 
@@ -63,17 +67,22 @@ jobs:
         # $(Build.SourceVersionMessage) is not helpful
         # nor is `github.event.head_commit.message` for github actions.
         commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
+        if [[ $commitMsg == *"[skip ci]"* ]]; then
+          echo '##vso[task.setvariable variable=skipci]true' # sets `skipci` to true
+        fi
         echo commitMsg: $commitMsg
-        echo $commitMsg | grep -v '\[skip ci\]' # fails if [skip ci] not in commit msg
+        echo skipci: $(skipci)
       displayName: 'Check whether to skip CI'
 
     - bash: git clone --depth 1 https://github.com/nim-lang/csources_v1 csources
       displayName: 'Checkout Nim csources'
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
 
     - task: NodeTool@0
       inputs:
         versionSpec: '12.x'
       displayName: 'Install node.js 12.x'
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
 
     - bash: |
         set -e
@@ -83,7 +92,7 @@ jobs:
           echo_run sudo apt-fast install --no-install-recommends -yq \
             libcurl4-openssl-dev libgc-dev libsdl1.2-dev libsfml-dev valgrind libc6-dbg
       displayName: 'Install dependencies (amd64 Linux)'
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
+      condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'amd64'))
 
     - bash: |
         set -e
@@ -123,11 +132,11 @@ jobs:
         echo_run chmod 755 bin/g++
 
       displayName: 'Install dependencies (i386 Linux)'
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
+      condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Linux'), eq(variables['CPU'], 'i386'))
 
     - bash: brew install boehmgc make sfml
       displayName: 'Install dependencies (OSX)'
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+      condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Darwin'))
 
     - bash: |
         set -e
@@ -140,7 +149,7 @@ jobs:
         echo_run echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
 
       displayName: 'Install dependencies (Windows)'
-      condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+      condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Windows_NT'))
 
     - bash: echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/bin'
       displayName: 'Add build binaries to PATH'
@@ -155,15 +164,18 @@ jobs:
         echo_run node -v
         echo_run echo '##[section]make version'
         echo_run make -v
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'System information'
 
     - bash: echo '##vso[task.setvariable variable=csources_version]'"$(git -C csources rev-parse HEAD)"
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'Get csources version'
 
     - task: Cache@2
       inputs:
         key: 'csources | "$(Agent.OS)" | $(CPU) | $(csources_version)'
         path: csources/bin
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'Restore built csources'
 
     - bash: |
@@ -192,13 +204,16 @@ jobs:
         fi
 
         echo_run cp csources/bin/nim$ext bin
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'Build 1-stage compiler from csources'
 
     - bash: nim c koch
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'Build koch'
 
       # set result to omit the "bash exited with error code '1'" message
     - bash: ./koch runCI || echo '##vso[task.complete result=Failed]'
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'Run CI'
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,12 @@ jobs:
     - checkout: self
       fetchDepth: 2 # see D20210329T004830
 
-    - bash: . ci/funs.sh && set_skipci_azure
+    - bash: |
+        set -e
+        . ci/funs.sh
+        if nimIsCiSkip; then
+          echo '##vso[task.setvariable variable=skipci]true'
+        fi
       displayName: 'Check whether to skip CI'
 
     - bash: git clone --depth 1 https://github.com/nim-lang/csources_v1 csources

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,6 +152,7 @@ jobs:
       condition: and(succeeded(), eq(variables['skipci'], 'false'), eq(variables['Agent.OS'], 'Windows_NT'))
 
     - bash: echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/bin'
+      condition: and(succeeded(), eq(variables['skipci'], 'false'))
       displayName: 'Add build binaries to PATH'
 
     - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,17 +61,7 @@ jobs:
     - checkout: self
       fetchDepth: 2 # see D20210329T004830
 
-    - bash: |
-        # D20210329T004830:here refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
-        # `--no-merges` is needed to avoid merge commits which occur for PR's.
-        # $(Build.SourceVersionMessage) is not helpful
-        # nor is `github.event.head_commit.message` for github actions.
-        commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
-        if [[ $commitMsg == *"[skip ci]"* ]]; then
-          echo '##vso[task.setvariable variable=skipci]true' # sets `skipci` to true
-        fi
-        echo commitMsg: $commitMsg
-        echo skipci: $(skipci)
+    - bash: . ci/funs.sh && set_skipci_azure2
       displayName: 'Check whether to skip CI'
 
     - bash: git clone --depth 1 https://github.com/nim-lang/csources_v1 csources

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,7 @@ jobs:
     - checkout: self
       fetchDepth: 2 # see D20210329T004830
 
-    - bash: . ci/funs.sh && set_skipci_azure2
+    - bash: . ci/funs.sh && set_skipci_azure
       displayName: 'Check whether to skip CI'
 
     - bash: git clone --depth 1 https://github.com/nim-lang/csources_v1 csources

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -8,17 +8,22 @@ echo_run () {
   "$@"
 }
 
-set_skipci_azure () {
+nimGetLastCommit() {
+  git log --no-merges -1 --pretty=format:"%s"
+}
+
+nimIsCiSkip(){
   # D20210329T004830:here refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
   # `--no-merges` is needed to avoid merge commits which occur for PR's.
   # $(Build.SourceVersionMessage) is not helpful
   # nor is `github.event.head_commit.message` for github actions.
-  commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
-  echo commitMsg: $commitMsg
+  commitMsg=$(nimGetLastCommit)
+  echo_run echo $commitMsg
   if [[ $commitMsg == *"[skip ci]"* ]]; then
     echo "skipci: true"
-    echo '##vso[task.setvariable variable=skipci]true' # sets `skipci` to true
+    return 0
   else
     echo "skipci: false"
+    return 1
   fi
 }

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -18,7 +18,7 @@ nimIsCiSkip(){
   # $(Build.SourceVersionMessage) is not helpful
   # nor is `github.event.head_commit.message` for github actions.
   commitMsg=$(nimGetLastCommit)
-  echo_run echo $commitMsg
+  echo commitMsg: "$commitMsg"
   if [[ $commitMsg == *"[skip ci]"* ]]; then
     echo "skipci: true"
     return 0

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -17,6 +17,7 @@ nimIsCiSkip(){
   # `--no-merges` is needed to avoid merge commits which occur for PR's.
   # $(Build.SourceVersionMessage) is not helpful
   # nor is `github.event.head_commit.message` for github actions.
+  # Note: `[skip ci]` is now handled automatically for github actions, see https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
   commitMsg=$(nimGetLastCommit)
   echo commitMsg: "$commitMsg"
   if [[ $commitMsg == *"[skip ci]"* ]]; then

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -1,8 +1,22 @@
 # utilities used in CI pipelines to avoid duplication.
+# Avoid top-level statements.
 
 echo_run () {
   # echo's a command before running it, which helps understanding logs
   echo ""
   echo "$@"
   "$@"
+}
+
+set_skipci_azure () {
+  # D20210329T004830:here refs https://github.com/microsoft/azure-pipelines-agent/issues/2944
+  # `--no-merges` is needed to avoid merge commits which occur for PR's.
+  # $(Build.SourceVersionMessage) is not helpful
+  # nor is `github.event.head_commit.message` for github actions.
+  commitMsg=$(git log --no-merges -1 --pretty=format:"%s")
+  echo commitMsg: $commitMsg
+  if [[ $commitMsg == *"[skip ci]"* ]]; then
+    echo "skipci: true"
+    echo '##vso[task.setvariable variable=skipci]true' # sets `skipci` to true
+  fi
 }

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -18,5 +18,7 @@ set_skipci_azure () {
   if [[ $commitMsg == *"[skip ci]"* ]]; then
     echo "skipci: true"
     echo '##vso[task.setvariable variable=skipci]true' # sets `skipci` to true
+  else
+    echo "skipci: false"
   fi
 }


### PR DESCRIPTION
follows #17561

* remove all `[skip ci]` logic from github actions pipelines because github actions now supports this, see https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
* `[skip ci]` now makes CI appear green, not red, which is more intuitive (eg in https://github.com/nim-lang/Nim/pull/17807, i added a changelog with a `[skip ci]` commit, it turned CI red which was undesirable); note that reviewers + authors must still understand semantics of `[skip ci]` and ensure that, wherever appropriate, a prior commit should have a non-skipped green CI in the general case