### PR TITLE
add `--processing:dots|filenames|off` to customize `hintProcessing`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -343,6 +343,8 @@
 
 - Added `--filenames:abs|canonical|magic` which replaces --listFullPaths:on|off
 
+- Added `--processing:dots|filenames|off` which customizes `hintProcessing`
+
 - Source+Edit links now appear on top of every docgen'd page when
   `nim doc --git.url:url ...` is given.
 

--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -1018,7 +1018,7 @@ proc genTypeInfoAuxBase(m: BModule; typ, origType: PType;
   var flags = 0
   if not containsGarbageCollectedRef(typ): flags = flags or 1
   if not canFormAcycle(typ): flags = flags or 2
-  #else MessageOut("can contain a cycle: " & typeToString(typ))
+  #else echo("can contain a cycle: " & typeToString(typ))
   if flags != 0:
     m.s[cfsTypeInit3].addf("$1.flags = $2;$n", [nameHcr, rope(flags)])
   discard cgsym(m, "TNimType")

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -900,6 +900,16 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
     of "canonical": conf.filenameOption = foCanonical
     of "legacyrelproj": conf.filenameOption = foLegacyRelProj
     else: localError(conf, info, "expected: abs|canonical|legacyRelProj, got: $1" % arg)
+  of "processing":
+    incl(conf.notes, hintProcessing)
+    incl(conf.mainPackageNotes, hintProcessing)
+    case arg.normalize
+    of "dots": conf.hintProcessingDots = true
+    of "filenames": conf.hintProcessingDots = false
+    of "off":
+      excl(conf.notes, hintProcessing)
+      excl(conf.mainPackageNotes, hintProcessing)
+    else: localError(conf, info, "expected: dots|filenames|off, got: $1" % arg)
   of "listfullpaths":
     # xxx in future work, use `warningDeprecated`
     conf.filenameOption = if switchOn(arg): foAbs else: foCanonical

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -545,7 +545,7 @@ proc liMessage*(conf: ConfigRef; info: TLineInfo, msg: TMsgKind, arg: string,
     if conf.structuredErrorHook != nil:
       conf.structuredErrorHook(conf, info, s & kindmsg, sev)
     if not ignoreMsgBecauseOfIdeTools(conf, msg):
-      if msg == hintProcessing:
+      if msg == hintProcessing and conf.hintProcessingDots:
         msgWrite(conf, ".")
       else:
         styledMsgWriteln(styleBright, loc, resetStyle, color, title, resetStyle, s, KindColor, kindmsg,

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -460,15 +460,15 @@ when defined(nimDebugUtils):
   import debugutils
 
 proc initConfigRefCommon(conf: ConfigRef) =
-    conf.selectedGC = gcRefc
-    conf.verbosity = 1
-    conf.hintProcessingDots = true
-    conf.options = DefaultOptions
-    conf.globalOptions = DefaultGlobalOptions
-    conf.filenameOption = foAbs
-    conf.foreignPackageNotes = foreignPackageNotesDefault
-    conf.notes = NotesVerbosity[1]
-    conf.mainPackageNotes = NotesVerbosity[1]
+  conf.selectedGC = gcRefc
+  conf.verbosity = 1
+  conf.hintProcessingDots = true
+  conf.options = DefaultOptions
+  conf.globalOptions = DefaultGlobalOptions
+  conf.filenameOption = foAbs
+  conf.foreignPackageNotes = foreignPackageNotesDefault
+  conf.notes = NotesVerbosity[1]
+  conf.mainPackageNotes = NotesVerbosity[1]
 
 proc newConfigRef*(): ConfigRef =
   result = ConfigRef(

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -287,6 +287,7 @@ type
     implicitCmd*: bool # whether some flag triggered an implicit `command`
     selectedGC*: TGCMode       # the selected GC (+)
     exc*: ExceptionSystem
+    hintProcessingDots*: bool # true for dots, false for filenames
     verbosity*: int            # how verbose the compiler is
     numberOfProcessors*: int   # number of processors
     lastCmdTime*: float        # when caas is enabled, we measure each command
@@ -458,20 +459,25 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool
 when defined(nimDebugUtils):
   import debugutils
 
+proc initConfigRefCommon(conf: ConfigRef) =
+    conf.selectedGC = gcRefc
+    conf.verbosity = 1
+    conf.hintProcessingDots = true
+    conf.options = DefaultOptions
+    conf.globalOptions = DefaultGlobalOptions
+    conf.filenameOption = foAbs
+    conf.foreignPackageNotes = foreignPackageNotesDefault
+    conf.notes = NotesVerbosity[1]
+    conf.mainPackageNotes = NotesVerbosity[1]
+
 proc newConfigRef*(): ConfigRef =
   result = ConfigRef(
-    selectedGC: gcRefc,
     cCompiler: ccGcc,
-    verbosity: 1,
-    options: DefaultOptions,
-    globalOptions: DefaultGlobalOptions,
     macrosToExpand: newStringTable(modeStyleInsensitive),
     arcToExpand: newStringTable(modeStyleInsensitive),
     m: initMsgConfig(),
-    filenameOption: foAbs,
     cppDefines: initHashSet[string](),
-    headerFile: "", features: {}, legacyFeatures: {}, foreignPackageNotes: foreignPackageNotesDefault,
-    notes: NotesVerbosity[1], mainPackageNotes: NotesVerbosity[1],
+    headerFile: "", features: {}, legacyFeatures: {},
     configVars: newStringTable(modeStyleInsensitive),
     symbols: newStringTable(modeStyleInsensitive),
     packageCache: newPackageCache(),
@@ -513,6 +519,7 @@ proc newConfigRef*(): ConfigRef =
     vmProfileData: newProfileData(),
     spellSuggestMax: spellSuggestSecretSauce,
   )
+  initConfigRefCommon(result)
   setTargetFromSystem(result.target)
   # enable colors by default on terminals
   if terminal.isatty(stderr):
@@ -522,18 +529,11 @@ proc newConfigRef*(): ConfigRef =
 
 proc newPartialConfigRef*(): ConfigRef =
   ## create a new ConfigRef that is only good enough for error reporting.
-  # xxx FACTOR with `newConfigRef`
   when defined(nimDebugUtils):
     result = getConfigRef()
   else:
-    result = ConfigRef(
-      selectedGC: gcRefc,
-      verbosity: 1,
-      options: DefaultOptions,
-      globalOptions: DefaultGlobalOptions,
-      filenameOption: foAbs,
-      foreignPackageNotes: foreignPackageNotesDefault,
-      notes: NotesVerbosity[1], mainPackageNotes: NotesVerbosity[1])
+    result = ConfigRef()
+    initConfigRefCommon(result)
 
 proc cppDefine*(c: ConfigRef; define: string) =
   c.cppDefines.incl define

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -20,8 +20,10 @@ type
 
 proc verboseOpen(graph: ModuleGraph; s: PSym; idgen: IdGenerator): PPassContext =
   #MessageOut('compiling ' + s.name.s);
+  let flag = if optListFullPaths in graph.config.globalOptions: foAbs else: foShort
+  let fname = graph.config.toFilenameOption(s.position.FileIndex, flag)
   result = VerboseRef(config: graph.config, idgen: idgen)
-  rawMessage(graph.config, hintProcessing, s.name.s)
+  rawMessage(graph.config, hintProcessing, fname)
 
 proc verboseProcess(context: PPassContext, n: PNode): PNode =
   result = n

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -19,11 +19,10 @@ type
     config: ConfigRef
 
 proc verboseOpen(graph: ModuleGraph; s: PSym; idgen: IdGenerator): PPassContext =
-  #MessageOut('compiling ' + s.name.s);
-  let flag = if optListFullPaths in graph.config.globalOptions: foAbs else: foShort
-  let fname = graph.config.toFilenameOption(s.position.FileIndex, flag)
-  result = VerboseRef(config: graph.config, idgen: idgen)
-  rawMessage(graph.config, hintProcessing, fname)
+  let conf = graph.config
+  result = VerboseRef(config: conf, idgen: idgen)
+  let path = toFilenameOption(conf, s.position.FileIndex, conf.filenameOption)
+  rawMessage(conf, hintProcessing, path)
 
 proc verboseProcess(context: PPassContext, n: PNode): PNode =
   result = n

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -39,6 +39,8 @@ Advanced options:
   --filenames:abs|canonical|legacyRelProj
                             customize how filenames are rendered in compiler messages,
                             defaults to `abs` (absolute)
+  --processing:dots|filenames|off
+                            show files as they're being processed by nim compiler
   --declaredLocs:on|off     show declaration locations in messages
   --spellSuggest|:num       show at most `num >= 0` spelling suggestions on typos.
                             if `num` is not specified (or `auto`), return

--- a/drnim/tests/config.nims
+++ b/drnim/tests/config.nims
@@ -3,7 +3,7 @@ switch("path", "$nim/testament/lib") # so we can `import stdtest/foo` in this di
 ## prevent common user config settings to interfere with testament expectations
 ## Indifidual tests can override this if needed to test for these options.
 switch("colors", "off")
-switch("listFullPaths", "off")
+switch("filenames", "canonical")
 switch("excessiveStackTrace", "off")
 
 # we only want to check the marked parts in the tests:

--- a/nimsuggest/config.nims
+++ b/nimsuggest/config.nims
@@ -1,0 +1,2 @@
+# xxx not sure why this flag isn't needed: switch("processing", "filenames")
+switch("filenames", "canonical")

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -255,7 +255,6 @@ proc runEpcTest(filename: string): int =
                        options={poStdErrToStdOut, poUsePath,
                        poInteractive, poDaemon})
   let outp = p.outputStream
-  let inp = p.inputStream
   var report = ""
   var socket = newSocket()
   try:
@@ -315,8 +314,12 @@ proc runTest(filename: string): int =
           answer.add '\L'
         doReport(filename, answer, resp, report)
   finally:
-    inp.writeLine("quit")
-    inp.flush()
+    try:
+      inp.writeLine("quit")
+      inp.flush()
+    except:
+      # assume it's SIGPIPE, ie, the child already died
+      discard
     close(p)
   if report.len > 0:
     echo "==== STDIN ======================================"

--- a/nimsuggest/tests/tchk1.nim
+++ b/nimsuggest/tests/tchk1.nim
@@ -17,7 +17,7 @@ proc main =
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tchk1 [Processing]";;0
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tests/tchk1.nim [Processing]";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but got \'keyword template\'";;0
 chk;;skUnknown;;;;Error;;$file;;14;;0;;"nestable statement requires indentation";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"implementation of \'foo\' expected";;0

--- a/nimsuggest/tests/tchk_compiles.nim
+++ b/nimsuggest/tests/tchk_compiles.nim
@@ -4,5 +4,5 @@ discard compiles(2 + "hello")
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tchk_compiles [Processing]";;0
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tests/tchk_compiles.nim [Processing]";;0
 """

--- a/nimsuggest/tests/ttempl_inst.nim
+++ b/nimsuggest/tests/ttempl_inst.nim
@@ -7,7 +7,7 @@ foo()
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Hint;;???;;0;;-1;;"ttempl_inst [Processing]";;0
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tests/ttempl_inst.nim [Processing]";;0
 chk;;skUnknown;;;;Hint;;$file;;4;;3;;"template/generic instantiation from here";;0
 chk;;skUnknown;;;;Warning;;$file;;2;;11;;"foo [User]";;0
 """

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -104,7 +104,7 @@ proc isSuccess(input: string): bool =
   # not clear how to do the equivalent of pkg/regex's: re"FOO(.*?)BAR" in pegs
   # note: this doesn't handle colors, eg: `\e[1m\e[0m\e[32mHint:`; while we
   # could handle colors, there would be other issues such as handling other flags
-  # that may appear in user config (eg: `--listFullPaths`).
+  # that may appear in user config (eg: `--filenames`).
   # Passing `XDG_CONFIG_HOME= testament args...` can be used to ignore user config
   # stored in XDG_CONFIG_HOME, refs https://wiki.archlinux.org/index.php/XDG_Base_Directory
   input.startsWith("Hint: ") and input.endsWith("[SuccessX]")

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -92,7 +92,7 @@ else: # don't run twice the same test
       of 5: nimcache / htmldocsDirname
       else: file.parentDir / htmldocsDirname
 
-      var cmd = fmt"{nim} doc --index:on --listFullPaths --hint:successX:on --nimcache:{nimcache} {options[i]} {file}"
+      var cmd = fmt"{nim} doc --index:on --filenames:abs --hint:successX:on --nimcache:{nimcache} {options[i]} {file}"
       removeDir(htmldocsDir)
       let (outp, exitCode) = execCmdEx(cmd)
       check exitCode == 0


### PR DESCRIPTION
* add --processing:dots|filenames|off to customize hintProcessing, which allows bringing back the old `hintProcessing` (but better, because it honors `--filenames:...`)
* fixes https://github.com/timotheecour/Nim/issues/502
* remove duplication bw newPartialConfigRef and newConfigRef
* minor cleanups post https://github.com/nim-lang/Nim/pull/17746 (removing remaining uses of --listfullpaths)

## example 1
```
nim r --processing:filenames --filenames:canonical --hint:msgorigin:off --eval:'import times'
Hint: system.nim [Processing]
Hint: system/widestrs.nim [Processing]
Hint: system/io.nim [Processing]
Hint: cmdfile.nim [Processing]
Hint: std/times [Processing]
Hint: std/strutils [Processing]
Hint: std/parseutils [Processing]
Hint: std/math [Processing]
Hint: std/bitops [Processing]
Hint: std/macros [Processing]
Hint: std/fenv [Processing]
Hint: std/algorithm [Processing]
Hint: std/enumutils.nim [Processing]
Hint: std/typetraits [Processing]
Hint: std/unicode [Processing]
Hint: std/private/strimpl.nim [Processing]
Hint: std/options [Processing]
Hint: std/posix [Processing]
cmdfile.nim(1, 8) Warning: imported and not used: 'times' [UnusedImport]
```
## example 2
```
nim r --processing:dots --filenames:canonical --hint:msgorigin:off --eval:'import times'
..................
cmdfile.nim(1, 8) Warning: imported and not used: 'times' [UnusedImport]
```
## example 3
```
nim r --processing:filenames --filenames:abs --hint:msgorigin:off --eval:'import times'
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/widestrs.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/io.nim [Processing]
Hint: cmdfile.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/times.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/strutils.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/parseutils.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/math.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/bitops.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/core/macros.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/fenv.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/algorithm.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/std/enumutils.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/typetraits.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/unicode.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/std/private/strimpl.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/options.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/posix/posix.nim [Processing]
cmdfile.nim(1, 8) Warning: imported and not used: 'times' [UnusedImport]
```

## future work
- [ ] also report include files, either as default or as an option eg `--processing:filenames,includes`