### PR TITLE
`--usenimcache` (implied by `nim r main`) now caches some compile options to avoid recompiling when project was previously compiled with such options.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -375,7 +375,16 @@
 
 - `--hint:CC` now goes to stderr (like all other hints) instead of stdout.
 
+- json build instructions are now generated in `$nimcache/outFileBasename.json`
+  instead of `$nimcache/projectName.json`. This allows avoiding recompiling a given project
+  compiled with different options if the output file differs.
 
+- `--usenimcache` (implied by `nim r main`) now generates an output file that includes a hash of
+  some of the compilation options, which allows caching generated binaries:
+  nim r main # recompiles
+  nim r -d:foo main # recompiles
+  nim r main # uses cached binary
+  nim r main arg1 arg2 # ditto (runtime arguments are irrelevant)
 
 ## Tool changes
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -978,10 +978,9 @@ proc setOutFile*(conf: ConfigRef) =
   if conf.outFile.isEmpty:
     let base = conf.projectName
     let targetName =
-      if optGenDynLib in conf.globalOptions:
+      if conf.backend == backendJs: base & ".js"
+      elif optGenDynLib in conf.globalOptions:
         platform.OS[conf.target.targetOS].dllFrmt % base
-      elif optGenStaticLib in conf.globalOptions:
-        libNameTmpl(conf) % base
-      else:
-        base & platform.OS[conf.target.targetOS].exeExt
+      elif optGenStaticLib in conf.globalOptions: libNameTmpl(conf) % base
+      else: base & platform.OS[conf.target.targetOS].exeExt
     conf.outFile = RelativeFile targetName

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -970,17 +970,3 @@ proc floatInt64Align*(conf: ConfigRef): int16 =
       # to 4bytes (except with -malign-double)
       return 4
   return 8
-
-proc setOutFile*(conf: ConfigRef) =
-  proc libNameTmpl(conf: ConfigRef): string {.inline.} =
-    result = if conf.target.targetOS == osWindows: "$1.lib" else: "lib$1.a"
-
-  if conf.outFile.isEmpty:
-    let base = conf.projectName
-    let targetName =
-      if conf.backend == backendJs: base & ".js"
-      elif optGenDynLib in conf.globalOptions:
-        platform.OS[conf.target.targetOS].dllFrmt % base
-      elif optGenStaticLib in conf.globalOptions: libNameTmpl(conf) % base
-      else: base & platform.OS[conf.target.targetOS].exeExt
-    conf.outFile = RelativeFile targetName

--- a/tests/misc/mbetterrun.nim
+++ b/tests/misc/mbetterrun.nim
@@ -1,0 +1,3 @@
+const mbetterrunVal {.strdefine.} = ""
+static: echo "compiling: " & mbetterrunVal
+echo "running: " & mbetterrunVal


### PR DESCRIPTION
this PR improves the compilation cache, and in particular `nim r`, `--usenimcache`, `-d:nimbetterrun`

`--usenimcache` (implied by `nim r main`) now generates an output file that includes a hash of some of the compilation options, which allows caching generated binaries

## example
```
nim r main # recompiles
nim r -d:foo main # recompiles
nim r main # uses cached binary
nim r main arg1 arg2 # ditto (runtime arguments are irrelevant)
```

see tests

## before this PR
```
nim r main # recompiles
nim r -d:foo main # recompiles
nim r main # bad: recompiles (after this PR, does not recompile)
nim r sub/main # recompiles
nim r main # bad: recompiles (after this PR, does not recompile)
```

## notes
* follows https://github.com/nim-lang/Nim/pull/13382
* this feature exists in D with rdmd
* fixes https://github.com/timotheecour/Nim/issues/698
* closes https://github.com/timotheecour/Nim/issues/199
* see also https://github.com/ziglang/zig/issues/466, https://github.com/ziglang/zig/pull/874
* fixes most of https://github.com/nim-lang/RFCs/issues/107

## future work
- [ ] (preexisting limitation) `nimbetterrun` (and writeJsonBuildInstructions etc) isn't supported with js backend, but there's not reason it shouldn't
- [ ] writeJsonBuildInstructions + friends should just reuse std/json, it'll simplify code. simpler = better.
- [ ] https://github.com/nim-lang/RFCs/issues/107 meantions another useful features that would be nice to implement: garbage collection, using an LRU cache of cached binaries