### PR TITLE
Ref #17831(synchapi.h: No such file or directory)

### DIFF
--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -24,9 +24,8 @@ when defined(windows):
       LockSemaphore: int
       SpinCount: int
 
-    RTL_CONDITION_VARIABLE {.importc: "RTL_CONDITION_VARIABLE", header: "windows.h".} = object
+    SysCond = {.importc: "RTL_CONDITION_VARIABLE", header: "<windows.h>".} = object
       thePtr {.importc: "ptr".} : Handle
-    SysCond = RTL_CONDITION_VARIABLE
 
   proc initSysLock(L: var SysLock) {.importc: "InitializeCriticalSection",
                                      header: "<windows.h>".}
@@ -52,20 +51,20 @@ when defined(windows):
 
   proc initializeConditionVariable(
     conditionVariable: var SysCond
-  ) {.stdcall, noSideEffect, header: "windows.h", importc: "InitializeConditionVariable".}
+  ) {.stdcall, noSideEffect, dynlib: "kernel32", importc: "InitializeConditionVariable".}
 
   proc sleepConditionVariableCS(
     conditionVariable: var SysCond,
     PCRITICAL_SECTION: var SysLock,
     dwMilliseconds: int
-  ): int32 {.stdcall, noSideEffect, header: "windows.h", importc: "SleepConditionVariableCS".}
+  ): int32 {.stdcall, noSideEffect, dynlib: "kernel32", importc: "SleepConditionVariableCS".}
 
 
   proc signalSysCond(hEvent: var SysCond) {.stdcall, noSideEffect,
-    header: "windows.h", importc: "WakeConditionVariable".}
+    dynlib: "kernel32", importc: "WakeConditionVariable".}
 
   proc broadcastSysCond(hEvent: var SysCond) {.stdcall, noSideEffect,
-    header: "windows.h", importc: "WakeAllConditionVariable".}
+    dynlib: "kernel32", importc: "WakeAllConditionVariable".}
 
   proc initSysCond(cond: var SysCond) {.inline.} =
     initializeConditionVariable(cond)

--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -24,7 +24,7 @@ when defined(windows):
       LockSemaphore: int
       SpinCount: int
 
-    SysCond = {.importc: "RTL_CONDITION_VARIABLE", header: "<windows.h>".} = object
+    SysCond {.importc: "RTL_CONDITION_VARIABLE", header: "<windows.h>".} = object
       thePtr {.importc: "ptr".} : Handle
 
   proc initSysLock(L: var SysLock) {.importc: "InitializeCriticalSection",

--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -52,20 +52,20 @@ when defined(windows):
 
   proc initializeConditionVariable(
     conditionVariable: var SysCond
-  ) {.stdcall, noSideEffect, dynlib: "kernel32", importc: "InitializeConditionVariable".}
+  ) {.stdcall, noSideEffect, header: "windows.h", importc: "InitializeConditionVariable".}
 
   proc sleepConditionVariableCS(
     conditionVariable: var SysCond,
     PCRITICAL_SECTION: var SysLock,
     dwMilliseconds: int
-  ): int32 {.stdcall, noSideEffect, dynlib: "kernel32", importc: "SleepConditionVariableCS".}
+  ): int32 {.stdcall, noSideEffect, header: "windows.h", importc: "SleepConditionVariableCS".}
 
 
   proc signalSysCond(hEvent: var SysCond) {.stdcall, noSideEffect,
-    dynlib: "kernel32", importc: "WakeConditionVariable".}
+    header: "windows.h", importc: "WakeConditionVariable".}
 
   proc broadcastSysCond(hEvent: var SysCond) {.stdcall, noSideEffect,
-    dynlib: "kernel32", importc: "WakeAllConditionVariable".}
+    header: "windows.h", importc: "WakeAllConditionVariable".}
 
   proc initSysCond(cond: var SysCond) {.inline.} =
     initializeConditionVariable(cond)

--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -24,7 +24,7 @@ when defined(windows):
       LockSemaphore: int
       SpinCount: int
 
-    RTL_CONDITION_VARIABLE {.importc: "RTL_CONDITION_VARIABLE", header: "synchapi.h".} = object
+    RTL_CONDITION_VARIABLE {.importc: "RTL_CONDITION_VARIABLE", header: "windows.h".} = object
       thePtr {.importc: "ptr".} : Handle
     SysCond = RTL_CONDITION_VARIABLE
 


### PR DESCRIPTION
Ref #17831

> synchapi.h (include Windows Server 2003, Windows Vista, Windows 7, Windows Server 2008 Windows Server 2008 R2, Windows.h)

According to MSDN, `syncapi.h` is only available on high version windows. So I use `windows.h` as a workaround just like what `SysLock` does.


```nim
type
    SysLock {.importc: "CRITICAL_SECTION",
              header: "<windows.h>", final, pure.} = object # CRITICAL_SECTION in WinApi
      DebugInfo: pointer
      LockCount: int32
      RecursionCount: int32
      OwningThread: int
      LockSemaphore: int
      SpinCount: int
```