### PR TITLE
RST opt.list to have priority over def.list

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1867,10 +1867,10 @@ proc whichSection(p: RstParser): RstNodeKind =
     elif match(p, p.idx, "(e) ") or match(p, p.idx, "e) ") or
          match(p, p.idx, "e. "):
       result = rnEnumList
-    elif isDefList(p):
-      result = rnDefList
     elif isOptionList(p):
       result = rnOptionList
+    elif isDefList(p):
+      result = rnDefList
     else:
       result = rnParagraph
   of tkWord, tkOther, tkWhite:

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -1,6 +1,8 @@
 discard """
   output: '''
 
+[Suite] RST parsing
+
 [Suite] RST indentation
 
 [Suite] RST include directive
@@ -54,6 +56,30 @@ proc toAst(input: string,
     result = renderRstToStr(rst)
   except EParseError:
     discard
+
+suite "RST parsing":
+  test "option list has priority over definition list":
+    check(dedent"""
+        --defusages
+                      file
+        -o            set
+        """.toAst ==
+      dedent"""
+        rnOptionList
+          rnOptionListItem  order=1
+            rnOptionGroup
+              rnLeaf  '--'
+              rnLeaf  'defusages'
+            rnDescription
+              rnInner
+                rnLeaf  'file'
+          rnOptionListItem  order=2
+            rnOptionGroup
+              rnLeaf  '-'
+              rnLeaf  'o'
+            rnDescription
+              rnLeaf  'set'
+        """)
 
 suite "RST indentation":
   test "nested bullet lists":


### PR DESCRIPTION
Found in doc/advopt.txt.

```
Advanced options:
  --defusages:FILE,LINE,COL
                            find the definition and all usages of a symbol
  -o:FILE, --out:FILE       set the output filename
```

**Before:**
![image](https://user-images.githubusercontent.com/1299583/115993581-29f14d00-a5dc-11eb-97b0-d81c0c79b4ad.png)

RST spec does not specify priorities of body/block elements. Here it makes perfect sense to prioritize option lists higher than definition lists.
**After:**
![image](https://user-images.githubusercontent.com/1299583/115993600-3aa1c300-a5dc-11eb-86c2-3cd07c7da140.png)

cc @narimiran 