### PR TITLE
support `--hint:all:off --hint:x` (ditto with `--warnings` + friends)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -427,7 +427,7 @@
 
 - `--hint:CC` now goes to stderr (like all other hints) instead of stdout.
 
-- `--hints` and `--warnings` has new options all|none to select or deselect all hints; it
+- `--hints` and `--warnings` has new options `all|none` to select or deselect all hints; it
   differs from `on|off` which acts as a (reversible) gate.
 
 - json build instructions are now generated in `$nimcache/outFileBasename.json`

--- a/changelog.md
+++ b/changelog.md
@@ -427,6 +427,9 @@
 
 - `--hint:CC` now goes to stderr (like all other hints) instead of stdout.
 
+- `--hints` and `--warnings` has new options all|none to select or deselect all hints; it
+  differs from `on|off` which acts as a (reversible) gate.
+
 - json build instructions are now generated in `$nimcache/outFileBasename.json`
   instead of `$nimcache/projectName.json`. This allows avoiding recompiling a given project
   compiled with different options if the output file differs.

--- a/changelog.md
+++ b/changelog.md
@@ -427,8 +427,9 @@
 
 - `--hint:CC` now goes to stderr (like all other hints) instead of stdout.
 
-- `--hints` and `--warnings` has new options `all|none` to select or deselect all hints; it
-  differs from `on|off` which acts as a (reversible) gate.
+- `--hint:all:on|off` is now supported to select or deselect all hints; it
+  differs from `--hints:on|off` which acts as a (reversible) gate.
+  Likewise with `--warning:all:on|off`.
 
 - json build instructions are now generated in `$nimcache/outFileBasename.json`
   instead of `$nimcache/projectName.json`. This allows avoiding recompiling a given project

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -25,10 +25,10 @@ bootSwitch(usedMarkAndSweep, defined(gcmarkandsweep), "--gc:markAndSweep")
 bootSwitch(usedGoGC, defined(gogc), "--gc:go")
 bootSwitch(usedNoGC, defined(nogc), "--gc:none")
 
+import std/[setutils, os, strutils, parseutils, parseopt, sequtils, strtabs]
 import
-  os, msgs, options, nversion, condsyms, strutils, extccomp, platform,
-  wordrecg, parseutils, nimblecmd, parseopt, sequtils, lineinfos,
-  pathutils, strtabs, pathnorm
+  msgs, options, nversion, condsyms, extccomp, platform,
+  wordrecg, nimblecmd, lineinfos, pathutils, pathnorm
 
 from ast import eqTypeFlags, tfGcSafe, tfNoSideEffect
 
@@ -160,19 +160,12 @@ proc processSpecificNoteImpl(conf: ConfigRef, pass: TCmdLinePass, n: TNoteKind, 
   if n notin conf.cmdlineNotes or pass == passCmd1:
     if pass == passCmd1: incl(conf.cmdlineNotes, n)
     incl(conf.modifiedyNotes, n)
-    if isOn:
-      if noteAsError:
-        incl(conf.warningAsErrors, n) # xxx rename warningAsErrors to noteAsErrors
-      else:
-        incl(conf.notes, n)
-        incl(conf.mainPackageNotes, n)
+    if noteAsError:
+      conf.warningAsErrors[n] = isOn # xxx rename warningAsErrors to noteAsErrors
     else:
-      if noteAsError:
-        excl(conf.warningAsErrors, n)
-      else:
-        excl(conf.notes, n)
-        excl(conf.mainPackageNotes, n)
-        excl(conf.foreignPackageNotes, n)
+      conf.notes[n] = isOn
+      conf.mainPackageNotes[n] = isOn
+    if not isOn: excl(conf.foreignPackageNotes, n)
 
 proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                               info: TLineInfo): bool =

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -174,25 +174,15 @@ proc processSpecificNoteImpl(conf: ConfigRef, pass: TCmdLinePass, n: TNoteKind, 
 
 proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                               info: TLineInfo, noteSet: set[TMsgKind]): bool =
+  # xxx in future work we should also allow users to have control over `foreignPackageNotes`
+  # so that they can enable hints|warnings|warningAsErrors for all the code they depend on.
   result = false
   case arg.normalize
   of "on": conf.options.incl op
   of "off": conf.options.excl op
-  of "all":
-    # xxx either of these give a codegen error:
-    # conf.notes = noteSet
-    # conf.notes.incl noteSet
-    # for a in noteSet: conf.notes.incl a
-    # for a in noteSet: conf.foreignPackageNotes.incl a
-    # for a in noteSet: conf.mainPackageNotes.incl a
-    for note in noteSet:
-      processSpecificNoteImpl(conf, pass, note, true, noteAsError = false)
-  of "none":
-    for note in noteSet:
-      processSpecificNoteImpl(conf, pass, note, false, noteAsError = false)
-    # conf.notes = {}
-    # conf.foreignPackageNotes = {}
-    # conf.mainPackageNotes = {}
+  of "all", "none":
+    let isOn = arg.normalize == "all"
+    for n in noteSet: processSpecificNoteImpl(conf, pass, n, isOn, noteAsError = false)
   of "list": result = true
   else: localError(conf, info, errOnOffOrListExpectedButXFound % arg)
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -154,6 +154,24 @@ proc processOnOffSwitch(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLi
   of "off": conf.options.excl op
   else: localError(conf, info, errOnOrOffExpectedButXFound % arg)
 
+proc processSpecificNoteImpl(conf: ConfigRef, pass: TCmdLinePass, n: TNoteKind, isOn: bool, noteAsError: bool) =
+  if n notin conf.cmdlineNotes or pass == passCmd1:
+    if pass == passCmd1: incl(conf.cmdlineNotes, n)
+    incl(conf.modifiedyNotes, n)
+    if isOn:
+      if noteAsError:
+        incl(conf.warningAsErrors, n) # xxx rename warningAsErrors to noteAsErrors
+      else:
+        incl(conf.notes, n)
+        incl(conf.mainPackageNotes, n)
+    else:
+      if noteAsError:
+        excl(conf.warningAsErrors, n)
+      else:
+        excl(conf.notes, n)
+        excl(conf.mainPackageNotes, n)
+        excl(conf.foreignPackageNotes, n)
+
 proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: TCmdLinePass,
                               info: TLineInfo, noteSet: set[TMsgKind]): bool =
   result = false
@@ -164,13 +182,17 @@ proc processOnOffSwitchOrList(conf: ConfigRef; op: TOptions, arg: string, pass: 
     # xxx either of these give a codegen error:
     # conf.notes = noteSet
     # conf.notes.incl noteSet
-    for a in noteSet: conf.notes.incl a
-    for a in noteSet: conf.foreignPackageNotes.incl a
-    for a in noteSet: conf.mainPackageNotes.incl a
+    # for a in noteSet: conf.notes.incl a
+    # for a in noteSet: conf.foreignPackageNotes.incl a
+    # for a in noteSet: conf.mainPackageNotes.incl a
+    for note in noteSet:
+      processSpecificNoteImpl(conf, pass, note, true, noteAsError = false)
   of "none":
-    conf.notes = {}
-    conf.foreignPackageNotes = {}
-    conf.mainPackageNotes = {}
+    for note in noteSet:
+      processSpecificNoteImpl(conf, pass, note, false, noteAsError = false)
+    # conf.notes = {}
+    # conf.foreignPackageNotes = {}
+    # conf.mainPackageNotes = {}
   of "list": result = true
   else: localError(conf, info, errOnOffOrListExpectedButXFound % arg)
 
@@ -188,24 +210,6 @@ proc expectArg(conf: ConfigRef; switch, arg: string, pass: TCmdLinePass, info: T
 proc expectNoArg(conf: ConfigRef; switch, arg: string, pass: TCmdLinePass, info: TLineInfo) =
   if arg != "":
     localError(conf, info, "invalid argument for command line option: '$1'" % addPrefix(switch))
-
-proc processSpecificNoteImpl(conf: ConfigRef, pass: TCmdLinePass, state: TSpecialWord, n: TNoteKind, isOn: bool) =
-  if n notin conf.cmdlineNotes or pass == passCmd1:
-    if pass == passCmd1: incl(conf.cmdlineNotes, n)
-    incl(conf.modifiedyNotes, n)
-    if isOn:
-      if state in {wWarningAsError, wHintAsError}:
-        incl(conf.warningAsErrors, n) # xxx rename warningAsErrors to noteAsErrors
-      else:
-        incl(conf.notes, n)
-        incl(conf.mainPackageNotes, n)
-    else:
-      if state in {wWarningAsError, wHintAsError}:
-        excl(conf.warningAsErrors, n)
-      else:
-        excl(conf.notes, n)
-        excl(conf.mainPackageNotes, n)
-        excl(conf.foreignPackageNotes, n)
 
 proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
                          info: TLineInfo; orig: string; conf: ConfigRef) =
@@ -241,7 +245,7 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
   if val notin ["on", "off"]:
     localError(conf, info, errOnOrOffExpectedButXFound % arg)
   else:
-    processSpecificNoteImpl(conf, pass, state, n, val == "on")
+    processSpecificNoteImpl(conf, pass, n, val == "on", noteAsError = state in {wWarningAsError, wHintAsError})
 
 proc processCompile(conf: ConfigRef; filename: string) =
   var found = findFile(conf, filename)

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -134,5 +134,5 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasUnifiedTuple")
   defineSymbol("nimHasIterable")
   defineSymbol("nimHasTypeofVoid")
-
   defineSymbol("nimHasDragonBox")
+  defineSymbol("nimHasHintsNoneAll")

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -135,4 +135,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasIterable")
   defineSymbol("nimHasTypeofVoid")
   defineSymbol("nimHasDragonBox")
-  defineSymbol("nimHasHintsNoneAll")
+  defineSymbol("nimHasHintAll")

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -48,12 +48,15 @@ Advanced options:
   --spellSuggest|:num       show at most `num >= 0` spelling suggestions on typos.
                             if `num` is not specified (or `auto`), return
                             an implementation defined set of suggestions.
-  -w:on|off|list, --warnings:on|off|list
-                            turn all warnings on|off or list all available
-  --warning:X:on|off        turn specific warning X on|off.
-                            `warning:X` means `warning:X:on`, as with similar flags.
-  --hints:on|off|list       turn all hints on|off or list all available
-  --hint:X:on|off           turn specific hint X on|off.
+  --hints:on|off|all|none|list
+                            `on|off` enables or disables currently selected hints and acts
+                            as a reversible gate, whereas `all|none` selects or deselects
+                            all hints. `list` reports which hints are selected.
+  --hint:X:on|off           turn specific hint X on|off. `hint:X` means `hint:X:on`,
+                            as with similar flags
+  -w:on|off|all|none|list, --warnings:...
+                            same as `--hints` but for warnings.
+  --warning:X:on|off        turn specific warning X on|off
   --warningAsError:X:on|off turn specific warning X into an error on|off
   --hintAsError:X:on|off    turn specific hint X into an error on|off
   --styleCheck:off|hint|error

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -49,9 +49,9 @@ Advanced options:
                             if `num` is not specified (or `auto`), return
                             an implementation defined set of suggestions.
   --hints:on|off|all|none|list
-                            `on|off` enables or disables currently selected hints and acts
-                            as a reversible gate, whereas `all|none` selects or deselects
-                            all hints. `list` reports which hints are selected.
+                            `on|off` enables or disables hints selected by previous
+                            flags (it acts as a gate), whereas `all|none` selects or
+                            deselects all hints. `list` reports which hints are selected.
   --hint:X:on|off           turn specific hint X on|off. `hint:X` means `hint:X:on`,
                             as with similar flags
   -w:on|off|all|none|list, --warnings:...

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -53,9 +53,10 @@ Advanced options:
   --hint:X:on|off           turn specific hint X on|off. `hint:X` means `hint:X:on`,
                             as with similar flags. `all` can be used for "all hints".
   --hintAsError:X:on|off    turn specific hint X into an error on|off
-  -w:on|off|all|none|list, --warnings:...
-  --warning:X:on|off
-  --warningAsError:X:on|off same as `--hints` but for warnings.
+  -w:on|off|list, --warnings:on|off|list
+                            same as `--hints` but for warnings.
+  --warning:X:on|off        ditto
+  --warningAsError:X:on|off ditto
   --styleCheck:off|hint|error
                             produce hints or errors for Nim identifiers that
                             do not adhere to Nim's official style guide

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -48,17 +48,14 @@ Advanced options:
   --spellSuggest|:num       show at most `num >= 0` spelling suggestions on typos.
                             if `num` is not specified (or `auto`), return
                             an implementation defined set of suggestions.
-  --hints:on|off|all|none|list
-                            `on|off` enables or disables hints selected by previous
-                            flags (it acts as a gate), whereas `all|none` selects or
-                            deselects all hints. `list` reports which hints are selected.
+  --hints:on|off|list.      `on|off` enables or disables hints.
+                            `list` reports which hints are selected.
   --hint:X:on|off           turn specific hint X on|off. `hint:X` means `hint:X:on`,
-                            as with similar flags
-  -w:on|off|all|none|list, --warnings:...
-                            same as `--hints` but for warnings.
-  --warning:X:on|off        turn specific warning X on|off
-  --warningAsError:X:on|off turn specific warning X into an error on|off
+                            as with similar flags. `all` can be used for "all hints".
   --hintAsError:X:on|off    turn specific hint X into an error on|off
+  -w:on|off|all|none|list, --warnings:...
+  --warning:X:on|off
+  --warningAsError:X:on|off same as `--hints` but for warnings.
   --styleCheck:off|hint|error
                             produce hints or errors for Nim identifiers that
                             do not adhere to Nim's official style guide

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -233,7 +233,7 @@ sub/mmain.idx""", context
     check execCmdEx(cmd) == ("witness\n", 0)
 
   block: # config.nims, nim.cfg, hintConf, bug #16557
-    let cmd = fmt"{nim} r --hints:none --hint:conf tests/newconfig/bar/mfoo.nim"
+    let cmd = fmt"{nim} r --hint:all:off --hint:conf tests/newconfig/bar/mfoo.nim"
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
     doAssert exitCode == 0
     let dir = getCurrentDir()
@@ -265,7 +265,7 @@ tests/newconfig/bar/mfoo.nims""".splitLines
     check fmt"""{nim} r -b:js {opt} --eval:"echo defined(js)"""".execCmdEx == ("true\n", 0)
 
   block: # `hintProcessing` dots should not interfere with `static: echo` + friends
-    let cmd = fmt"""{nim} r --hints:none --hint:processing -f --eval:"static: echo 1+1""""
+    let cmd = fmt"""{nim} r --hint:all:off --hint:processing -f --eval:"static: echo 1+1""""
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
     template check3(cond) = doAssert cond, $(outp,)
     doAssert exitCode == 0
@@ -279,7 +279,7 @@ tests/newconfig/bar/mfoo.nims""".splitLines
       check3 "2" in outp
 
   block: # nim secret
-    let opt = "--hints:none --hint:processing"
+    let opt = "--hint:all:off --hint:processing"
     template check3(cond) = doAssert cond, $(outp,)
     for extra in ["", "--stdout"]:
       let cmd = fmt"""{nim} secret {opt} {extra}"""

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -279,7 +279,7 @@ tests/newconfig/bar/mfoo.nims""".splitLines
       check3 "2" in outp
 
   block: # nim secret
-    let opt = fmt"--hints:none --hint:processing"
+    let opt = "--hints:none --hint:processing"
     template check3(cond) = doAssert cond, $(outp,)
     for extra in ["", "--stdout"]:
       let cmd = fmt"""{nim} secret {opt} {extra}"""

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -23,9 +23,6 @@ proc isDots(a: string): bool =
   a.startsWith(".") and a.strip(chars = {'.'}) == ""
 
 const
-  defaultHintsOff = "--hint:successx:off --hint:exec:off --hint:link:off --hint:cc:off --hint:conf:off --hint:processing:off --hint:QuitCalled:off"
-    # useful when you want to turn only some hints on, and some common ones off.
-    # pending https://github.com/timotheecour/Nim/issues/453, simplify to: `--hints:off`
   nim = getCurrentCompilerExe()
   mode = querySetting(backend)
   nimcache = buildDir / "nimcacheTrunner"
@@ -236,7 +233,7 @@ sub/mmain.idx""", context
     check execCmdEx(cmd) == ("witness\n", 0)
 
   block: # config.nims, nim.cfg, hintConf, bug #16557
-    let cmd = fmt"{nim} r {defaultHintsOff} --hint:conf tests/newconfig/bar/mfoo.nim"
+    let cmd = fmt"{nim} r --hints:none --hint:conf tests/newconfig/bar/mfoo.nim"
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
     doAssert exitCode == 0
     let dir = getCurrentDir()
@@ -268,7 +265,7 @@ tests/newconfig/bar/mfoo.nims""".splitLines
     check fmt"""{nim} r -b:js {opt} --eval:"echo defined(js)"""".execCmdEx == ("true\n", 0)
 
   block: # `hintProcessing` dots should not interfere with `static: echo` + friends
-    let cmd = fmt"""{nim} r {defaultHintsOff} --hint:processing -f --eval:"static: echo 1+1""""
+    let cmd = fmt"""{nim} r --hints:none --hint:processing -f --eval:"static: echo 1+1""""
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})
     template check3(cond) = doAssert cond, $(outp,)
     doAssert exitCode == 0
@@ -282,7 +279,7 @@ tests/newconfig/bar/mfoo.nims""".splitLines
       check3 "2" in outp
 
   block: # nim secret
-    let opt = fmt"{defaultHintsOff} --hint:processing"
+    let opt = fmt"--hints:none --hint:processing"
     template check3(cond) = doAssert cond, $(outp,)
     for extra in ["", "--stdout"]:
       let cmd = fmt"""{nim} secret {opt} {extra}"""


### PR DESCRIPTION
* closes https://github.com/timotheecour/Nim/issues/453
* `--hints` and `--warnings` has new options all|none to select or deselect all hints; it
  differs from `on|off` which act as a (reversible) gate. This allows users to have more control about which hints/warnings are enabled, for eg for writing tests that test 1 hint at a time, eg `--hints:none --hint:processing` will only enable `--hint:processing` and turn off all other hints.
* `--hint:on|off` is still useful eg in code with `{.hints:off.}` when you want to turn off hints in a scope but then restore the previously selected hints when returning from the scope; I have not modified that behavior so this change is not a breaking change

* see tests in trunner (and its improvement thanks to this PR)

in future work, other tests could use `--hints:none --hint:x` (likewise with `--warnings:none --warning:x`) when testing for 1 hint or warning

