### PR TITLE
Add a note to windows users to avoid blanks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,11 @@ Next, to build from source you will need:
     * [MinGW32.7z](https://nim-lang.org/download/mingw32.7z)
     * [MinGW64.7z](https://nim-lang.org/download/mingw64.7z)
 
-**Windows Note: Cygwin and similar POSIX runtime environments are not supported.**
+**Windows Notes:**
+
+**- Cygwin and similar POSIX runtime environments are not supported**
+
+- Avoid spaces (blanks) in the path to MinGW and Nim sources it may break the build process
 
 Then, if you are on a \*nix system or Windows, the following steps should compile
 Nim from source using ``gcc``, ``git``, and the ``koch`` build tool.

--- a/readme.md
+++ b/readme.md
@@ -62,9 +62,9 @@ Next, to build from source you will need:
 
 **Windows Notes:**
 
-**- Cygwin and similar POSIX runtime environments are not supported**
+* **Cygwin and similar POSIX runtime environments are not supported**
 
-- Avoid spaces (blanks) in the path to MinGW and Nim sources it may break the build process
+* Avoid spaces (blanks) in the path to MinGW and Nim sources it may break the build process
 
 Then, if you are on a \*nix system or Windows, the following steps should compile
 Nim from source using ``gcc``, ``git``, and the ``koch`` build tool.


### PR DESCRIPTION
Blank in path to mingw/nim sources will break compilation with build_all.bat