### PR TITLE
add -d:nimLegacyNoHashRef for a transition period which avoids defining hash(ref)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@
   for previous behavior.
 
 - `hashes.hash` now supports `object` and `ref` (can be overloaded in user code).
+  For a transition period, use `-d:nimLegacyNoHashRef` to avoid defining `hash(ref)`.
 - `hashes.hash(proc|ptr|ref|pointer)` now calls `hash(int)` and honors `-d:nimIntHash1`,
   `hashes.hash(closure)` has also been improved.
 


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/17731#issuecomment-824064074

affected users can opt-out with `-d:nimLegacyNoHashRef` for a transition period (say, in their user or project config)
