### PR TITLE
nim check: fix Example 2 from bug #16178

### DIFF
--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -321,7 +321,8 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
     var o: TOverloadIter
     var sym = initOverloadIter(o, c, f)
     while sym != nil:
-      result &= "\n  found $1" % [getSymRepr(c.config, sym)]
+      if sym.kind == skUnknown: discard # fixes Example 2 from bug #16178
+      else: result &= "\n  found $1" % [getSymRepr(c.config, sym)]
       sym = nextOverloadIter(o, c, f)
 
   let ident = considerQuotedIdent(c, f, n).s


### PR DESCRIPTION
nim check: fix Example 2 from bug #16178

Example 3 is the bigger issue, but can be addressed in future work

## Example
```nim
block:
  let a = bad5(1)
```
## before PR
```
nim check --hint:msgorigin:off --hints:off --spellsuggest:0 $timn_D/tests/nim/all/t12213.nim
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 11) Error: undeclared identifier: 'bad5'
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: attempting to call routine: 'bad5'
  found 'bad5' [unknown declared in /Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 11)]
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: attempting to call routine: 'bad5'
  found 'bad5' [unknown declared in /Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 11)]
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: expression 'bad5' cannot be called
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: expression '' has no type (or is ambiguous)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 7) Error: 'let' symbol requires an initialization
```

## after PR
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 11) Error: undeclared identifier: 'bad5'
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: attempting to call undeclared routine: 'bad5'
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: attempting to call undeclared routine: 'bad5'
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: expression 'bad5' cannot be called
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 15) Error: expression '' has no type (or is ambiguous)
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12213.nim(6, 7) Error: 'let' symbol requires an initialization
```

## EDIT
i've converted to draft because https://github.com/nim-lang/Nim/pull/17865 may make this PR redundant, TBD