### PR TITLE
nim check: make error msgs less redundant

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2830,6 +2830,11 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
       of skProc, skFunc, skMethod, skConverter, skIterator:
         if s.magic == mNone: result = semDirectOp(c, n, flags)
         else: result = semMagic(c, n, s, flags)
+      of skUnknown:
+        # xxx: see also `errorSubNode`, `newError`; `errorNode` uses `skEmpty`
+        # which causes redundant errors in D20210426T153714 for `let a = nonexistant`,
+        # because nim can't distinguish with `let a {.importc:"foo".}` which is valid.
+        result = errorNode(c, n)
       else:
         #liMessage(n.info, warnUser, renderTree(n));
         result = semIndirectOp(c, n, flags)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2834,7 +2834,11 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
         # xxx: see also `errorSubNode`, `newError`; `errorNode` uses `skEmpty`
         # which causes redundant errors in D20210426T153714 for `let a = nonexistant`,
         # because nim can't distinguish with `let a {.importc:"foo".}` which is valid.
-        result = errorNode(c, n)
+        when defined(nimsuggest):
+          # hack, see D20210427T164219. Maybe there's a better way but this works for now.
+          result = semIndirectOp(c, n, flags)
+        else:
+          result = errorNode(c, n)
       else:
         #liMessage(n.info, warnUser, renderTree(n));
         result = semIndirectOp(c, n, flags)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -633,6 +633,7 @@ proc semVarOrLet(c: PContext, n: PNode, symkind: TSymKind): PNode =
           checkNilable(c, v)
         # allow let to not be initialised if imported from C:
         if v.kind == skLet and sfImportc notin v.flags:
+          # D20210426T153714:here
           localError(c.config, a.info, errLetNeedsInit)
       if sfCompileTime in v.flags:
         var x = newNodeI(result.kind, v.info)

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -16,6 +16,7 @@ type
 
 const
   DummyEof = "!EOF!"
+  bin = "bin"
   tpath = "nimsuggest/tests"
   # we could also use `stdtest/specialpaths`
 

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -6,6 +6,7 @@
 # `nim r nimsuggest/tester.nim nimsuggest/tests/tsug_accquote.nim`
 
 import os, osproc, strutils, streams, re, sexp, net
+from sequtils import toSeq
 
 type
   Test = object
@@ -336,8 +337,9 @@ proc main() =
     failures += runTest(xx)
     failures += runEpcTest(xx)
   else:
-    for x in walkFiles(tpath / "t*.nim"):
-      echo "Test ", x
+    let files = toSeq(walkFiles(tpath / "t*.nim"))
+    for i, x in files:
+      echo ("Test ", x, i, files.len)
       when defined(i386):
         if x == "nimsuggest/tests/tmacro_highlight.nim":
           echo "skipping" # workaround bug #17945

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -2,8 +2,6 @@
 # Every test file can have a #[!]# comment that is deleted from the input
 # before 'nimsuggest' is invoked to ensure this token doesn't make a
 # crucial difference for Nim's parser.
-# When debugging, to run a single test, use for e.g.:
-# `nim r nimsuggest/tester.nim nimsuggest/tests/tsug_accquote.nim`
 
 import os, osproc, strutils, streams, re, sexp, net
 
@@ -15,17 +13,16 @@ type
     disabled: bool
 
 const
+  curDir = when defined(windows): "" else: ""
   DummyEof = "!EOF!"
-  bin = "bin"
-  tpath = "nimsuggest/tests"
-  # we could also use `stdtest/specialpaths`
+
+template tpath(): untyped = getAppDir() / "tests"
 
 import std/compilesettings
 
 proc parseTest(filename: string; epcMode=false): Test =
   const cursorMarker = "#[!]#"
-  let nimsug = "bin" / addFileExt("nimsuggest", ExeExt)
-  doAssert nimsug.fileExists, nimsug
+  let nimsug = curDir & addFileExt("nimsuggest", ExeExt)
   const libpath = querySetting(libPath)
   result.filename = filename
   result.dest = getTempDir() / extractFilename(filename)
@@ -66,7 +63,7 @@ proc parseTest(filename: string; epcMode=false): Test =
       elif x.startsWith(">"):
         # since 'markers' here are not complete yet, we do the $substitutions
         # afterwards
-        result.script.add((x.substr(1).replaceWord("$path", tpath), ""))
+        result.script.add((x.substr(1).replaceWord("$path", tpath()), ""))
       elif x.len > 0:
         # expected output line:
         let x = x % ["file", filename, "lib", libpath]
@@ -107,7 +104,7 @@ proc parseCmd(c: string): seq[string] =
 proc edit(tmpfile: string; x: seq[string]) =
   if x.len != 3 and x.len != 4:
     quit "!edit takes two or three arguments"
-  let f = if x.len >= 4: tpath / x[3] else: tmpfile
+  let f = if x.len >= 4: tpath() / x[3] else: tmpfile
   try:
     let content = readFile(f)
     let newcontent = content.replace(x[1], x[2])
@@ -124,12 +121,12 @@ proc exec(x: seq[string]) =
 
 proc copy(x: seq[string]) =
   if x.len != 3: quit "!copy takes two arguments"
-  let rel = tpath
+  let rel = tpath()
   copyFile(rel / x[1], rel / x[2])
 
 proc del(x: seq[string]) =
   if x.len != 2: quit "!del takes one argument"
-  removeFile(tpath / x[1])
+  removeFile(tpath() / x[1])
 
 proc runCmd(cmd, dest: string): bool =
   result = cmd[0] == '!'
@@ -320,7 +317,7 @@ proc runTest(filename: string): int =
     try:
       inp.writeLine("quit")
       inp.flush()
-    except IOError, OSError:
+    except:
       # assume it's SIGPIPE, ie, the child already died
       discard
     close(p)
@@ -337,7 +334,7 @@ proc main() =
     failures += runTest(xx)
     failures += runEpcTest(xx)
   else:
-    for x in walkFiles(tpath / "t*.nim"):
+    for x in walkFiles(tpath() / "t*.nim"):
       echo "Test ", x
       when defined(i386):
         if x == "nimsuggest/tests/tmacro_highlight.nim":

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -315,6 +315,8 @@ proc runTest(filename: string): int =
           if a == DummyEof: break
           answer.add a
           answer.add '\L'
+        echo answer
+        doAssert false
         doReport(filename, answer, resp, report)
   finally:
     try:

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -315,8 +315,6 @@ proc runTest(filename: string): int =
           if a == DummyEof: break
           answer.add a
           answer.add '\L'
-        echo answer
-        doAssert false
         doReport(filename, answer, resp, report)
   finally:
     try:

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -2,6 +2,8 @@
 # Every test file can have a #[!]# comment that is deleted from the input
 # before 'nimsuggest' is invoked to ensure this token doesn't make a
 # crucial difference for Nim's parser.
+# When debugging, to run a single test, use for e.g.:
+# `nim r nimsuggest/tester.nim nimsuggest/tests/tsug_accquote.nim`
 
 import os, osproc, strutils, streams, re, sexp, net
 
@@ -13,16 +15,16 @@ type
     disabled: bool
 
 const
-  curDir = when defined(windows): "" else: ""
   DummyEof = "!EOF!"
-
-template tpath(): untyped = getAppDir() / "tests"
+  tpath = "nimsuggest/tests"
+  # we could also use `stdtest/specialpaths`
 
 import std/compilesettings
 
 proc parseTest(filename: string; epcMode=false): Test =
   const cursorMarker = "#[!]#"
-  let nimsug = curDir & addFileExt("nimsuggest", ExeExt)
+  let nimsug = "bin" / addFileExt("nimsuggest", ExeExt)
+  doAssert nimsug.fileExists, nimsug
   const libpath = querySetting(libPath)
   result.filename = filename
   result.dest = getTempDir() / extractFilename(filename)
@@ -63,7 +65,7 @@ proc parseTest(filename: string; epcMode=false): Test =
       elif x.startsWith(">"):
         # since 'markers' here are not complete yet, we do the $substitutions
         # afterwards
-        result.script.add((x.substr(1).replaceWord("$path", tpath()), ""))
+        result.script.add((x.substr(1).replaceWord("$path", tpath), ""))
       elif x.len > 0:
         # expected output line:
         let x = x % ["file", filename, "lib", libpath]
@@ -104,7 +106,7 @@ proc parseCmd(c: string): seq[string] =
 proc edit(tmpfile: string; x: seq[string]) =
   if x.len != 3 and x.len != 4:
     quit "!edit takes two or three arguments"
-  let f = if x.len >= 4: tpath() / x[3] else: tmpfile
+  let f = if x.len >= 4: tpath / x[3] else: tmpfile
   try:
     let content = readFile(f)
     let newcontent = content.replace(x[1], x[2])
@@ -121,12 +123,12 @@ proc exec(x: seq[string]) =
 
 proc copy(x: seq[string]) =
   if x.len != 3: quit "!copy takes two arguments"
-  let rel = tpath()
+  let rel = tpath
   copyFile(rel / x[1], rel / x[2])
 
 proc del(x: seq[string]) =
   if x.len != 2: quit "!del takes one argument"
-  removeFile(tpath() / x[1])
+  removeFile(tpath / x[1])
 
 proc runCmd(cmd, dest: string): bool =
   result = cmd[0] == '!'
@@ -317,7 +319,7 @@ proc runTest(filename: string): int =
     try:
       inp.writeLine("quit")
       inp.flush()
-    except:
+    except IOError, OSError:
       # assume it's SIGPIPE, ie, the child already died
       discard
     close(p)
@@ -334,7 +336,7 @@ proc main() =
     failures += runTest(xx)
     failures += runEpcTest(xx)
   else:
-    for x in walkFiles(tpath() / "t*.nim"):
+    for x in walkFiles(tpath / "t*.nim"):
       echo "Test ", x
       when defined(i386):
         if x == "nimsuggest/tests/tmacro_highlight.nim":

--- a/nimsuggest/tests/tsug_accquote.nim
+++ b/nimsuggest/tests/tsug_accquote.nim
@@ -1,3 +1,4 @@
+proc `gook`(a: int) = discard
 proc `%%%`(a: int) = discard
 proc `cast`() = discard
 tsug_accquote.#[!]#

--- a/nimsuggest/tests/tsug_accquote.nim
+++ b/nimsuggest/tests/tsug_accquote.nim
@@ -1,7 +1,7 @@
 proc `%%%`(a: int) = discard
 proc `cast`() = discard
-proc `gook1`(a: int) = discard
-proc gook2(a: int) = discard
+proc `zook1`(a: int) = discard
+proc zook2(a: int) = discard
 tsug_accquote.#[!]#
 
 # ## foo # this would remove the bug
@@ -13,8 +13,8 @@ $nimsuggest --tester $file
 >sug $1
 sug;;skProc;;tsug_accquote.`%%%`;;proc (a: int);;$file;;1;;5;;"";;100;;None
 sug;;skProc;;tsug_accquote.`cast`;;proc ();;$file;;2;;5;;"";;100;;None
-sug;;skProc;;tsug_accquote.gook1;;proc (a: int);;$file;;3;;5;;"";;100;;None
-sug;;skProc;;tsug_accquote.gook2;;proc (a: int);;$file;;4;;5;;"";;100;;None
+sug;;skProc;;tsug_accquote.zook1;;proc (a: int);;$file;;3;;5;;"";;100;;None
+sug;;skProc;;tsug_accquote.zook2;;proc (a: int);;$file;;4;;5;;"";;100;;None
 """
 
 #[
@@ -25,5 +25,5 @@ What happens is that after removing `cursorMarker`, the code nim sees is:
 `tsug_accquote.discard """ ... """`
 which then gets (without the hack) transformed into `result = errorNode(c, n)`
 
-What's not clear is why `gook1`, `gook2` get listed in suggestions but not the other ones.
+What's not clear is why `zook1`, `zook2` get listed in suggestions but not the other ones.
 ]#

--- a/nimsuggest/tests/tsug_accquote.nim
+++ b/nimsuggest/tests/tsug_accquote.nim
@@ -1,11 +1,29 @@
-proc `gook`(a: int) = discard
 proc `%%%`(a: int) = discard
 proc `cast`() = discard
+proc `gook1`(a: int) = discard
+proc gook2(a: int) = discard
 tsug_accquote.#[!]#
+
+# ## foo # this would remove the bug
+# nonexistant # this would remove the bug
+# var bam = 123 # this would not remove the bug
 
 discard """
 $nimsuggest --tester $file
 >sug $1
 sug;;skProc;;tsug_accquote.`%%%`;;proc (a: int);;$file;;1;;5;;"";;100;;None
 sug;;skProc;;tsug_accquote.`cast`;;proc ();;$file;;2;;5;;"";;100;;None
+sug;;skProc;;tsug_accquote.gook1;;proc (a: int);;$file;;3;;5;;"";;100;;None
+sug;;skProc;;tsug_accquote.gook2;;proc (a: int);;$file;;4;;5;;"";;100;;None
 """
+
+#[
+D20210427T164219:here un-commenting `foo` doc comment (or `nonexistant`) would
+make this test pass even without the linked hack with `result = semIndirectOp(c, n, flags)`.
+
+What happens is that after removing `cursorMarker`, the code nim sees is:
+`tsug_accquote.discard """ ... """`
+which then gets (without the hack) transformed into `result = errorNode(c, n)`
+
+What's not clear is why `gook1`, `gook2` get listed in suggestions but not the other ones.
+]#

--- a/tests/errmsgs/t16178_nimcheck_redundant.nim
+++ b/tests/errmsgs/t16178_nimcheck_redundant.nim
@@ -1,0 +1,34 @@
+discard """
+cmd: '''nim check --hints:off $file'''
+action: reject
+# nimoutFull: true # pending https://github.com/nim-lang/Nim/pull/17865
+nimout: '''
+t16178_nimcheck_redundant.nim(22, 11) Error: undeclared identifier: 'bad5'
+t16178_nimcheck_redundant.nim(22, 15) Error: expression '' has no type (or is ambiguous)
+t16178_nimcheck_redundant.nim(22, 7) Error: 'let' symbol requires an initialization
+t16178_nimcheck_redundant.nim(26, 11) Error: expression '' has no type (or is ambiguous)
+t16178_nimcheck_redundant.nim(26, 7) Error: 'let' symbol requires an initialization
+t16178_nimcheck_redundant.nim(30, 11) Error: expression '' has no type (or is ambiguous)
+t16178_nimcheck_redundant.nim(34, 15) Error: expression '' has no type (or is ambiguous)
+
+'''
+"""
+#[
+xxx the line `Error: 'let' symbol requires an initialization` is redundant and should not
+be reported; likewise with `t16178_nimcheck_redundant.nim(22, 15) Error: expression '' has no type (or is ambiguous)`
+]#
+# line 20
+block:
+  let a = bad5(1)
+
+block: # bug #12741
+  macro foo = discard
+  let x = foo
+
+block:
+  macro foo2 = discard
+  discard foo2
+
+block:
+  macro foo3() = discard
+  discard foo3()

--- a/tests/errmsgs/t16178_nimcheck_redundant.nim
+++ b/tests/errmsgs/t16178_nimcheck_redundant.nim
@@ -1,7 +1,7 @@
 discard """
 cmd: '''nim check --hints:off $file'''
 action: reject
-# nimoutFull: true # pending https://github.com/nim-lang/Nim/pull/17865
+nimoutFull: true
 nimout: '''
 t16178_nimcheck_redundant.nim(22, 11) Error: undeclared identifier: 'bad5'
 t16178_nimcheck_redundant.nim(22, 15) Error: expression '' has no type (or is ambiguous)
@@ -10,13 +10,13 @@ t16178_nimcheck_redundant.nim(26, 11) Error: expression '' has no type (or is am
 t16178_nimcheck_redundant.nim(26, 7) Error: 'let' symbol requires an initialization
 t16178_nimcheck_redundant.nim(30, 11) Error: expression '' has no type (or is ambiguous)
 t16178_nimcheck_redundant.nim(34, 15) Error: expression '' has no type (or is ambiguous)
-
 '''
 """
 #[
 xxx the line `Error: 'let' symbol requires an initialization` is redundant and should not
 be reported; likewise with `t16178_nimcheck_redundant.nim(22, 15) Error: expression '' has no type (or is ambiguous)`
 ]#
+
 # line 20
 block:
   let a = bad5(1)

--- a/tests/errmsgs/tundeclared_routine.nim
+++ b/tests/errmsgs/tundeclared_routine.nim
@@ -9,7 +9,7 @@ tundeclared_routine.nim(29, 28) Error: invalid pragma: myPragma
 tundeclared_routine.nim(36, 13) Error: undeclared field: 'bar3' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(33, 8)]
   found tundeclared_routine.bar3() [iterator declared in tundeclared_routine.nim(35, 12)]
 tundeclared_routine.nim(41, 13) Error: undeclared field: 'bar4' for type tundeclared_routine.Foo [type declared in tundeclared_routine.nim(39, 8)]
-tundeclared_routine.nim(44, 15) Error: attempting to call routine: 'bad5'
+tundeclared_routine.nim(44, 11) Error: undeclared identifier: 'bad5'
 '''
 """
 


### PR DESCRIPTION
## improve Example 3 from https://github.com/nim-lang/Nim/issues/16178
```nim
block:
  let a = bad5(1)
```

`XDG_CONFIG_HOME= nim check --spellsuggest:0 --hints:off --filenames:canonical $timn_D/tests/nim/all/t12213.nim`


### before PR
```
tests/nim/all/t12213.nim(8, 13) Error: undeclared identifier: 'bad5'
tests/nim/all/t12213.nim(8, 17) Error: attempting to call routine: 'bad5'
  found 'bad5' [unknown declared in tests/nim/all/t12213.nim(8, 13)]
tests/nim/all/t12213.nim(8, 17) Error: attempting to call routine: 'bad5'
  found 'bad5' [unknown declared in tests/nim/all/t12213.nim(8, 13)]
tests/nim/all/t12213.nim(8, 17) Error: expression 'bad5' cannot be called
tests/nim/all/t12213.nim(8, 17) Error: expression '' has no type (or is ambiguous)
tests/nim/all/t12213.nim(8, 9) Error: 'let' symbol requires an initialization
```

### after PR
```
tests/nim/all/t12213.nim(8, 13) Error: undeclared identifier: 'bad5'
tests/nim/all/t12213.nim(8, 17) Error: expression '' has no type (or is ambiguous)
tests/nim/all/t12213.nim(8, 9) Error: 'let' symbol requires an initialization
```

* add test for #12741 (since I'm changing related code)
* closes https://github.com/nim-lang/Nim/pull/17863 (because it's a more general fix)

## note
if you have a concrete idea for how to avoid `when defined(nimsuggest): ...` I'm all ears, otherwise the change is good enough for now

## future work
- [ ] use `errorSubNode` or `newError`(which uses the new `nkError`) instead of `errorNode` (which uses `nkEmpty`) so that we can also remove the 2nd and 3rd line; as explained in PR; this is a bigger change so can be done in future work (it's already hard enough because it interferes with nimsuggest)
