### PR TITLE
[std/encodings] fix iconv headers on OpenBSD

### DIFF
--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -285,7 +285,7 @@ else:
   when defined(bsd):
     {.pragma: importIconv, cdecl, header: "<iconv.h>".}
     when defined(openbsd):
-      {.passL: "/usr/local/lib/libiconv.a".}
+      {.passL: "-liconv".}
   else:
     {.pragma: importIconv, cdecl, dynlib: iconvDll.}
 

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -285,7 +285,7 @@ else:
   when defined(bsd):
     {.pragma: importIconv, cdecl, header: "<iconv.h>".}
     when defined(openbsd):
-      {.passL: "-I/usr/local/include".}
+      {.passL: "/usr/local/include/libiconv.a".}
   else:
     {.pragma: importIconv, cdecl, dynlib: iconvDll.}
 

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -285,7 +285,7 @@ else:
   when defined(bsd):
     {.pragma: importIconv, cdecl, header: "<iconv.h>".}
     when defined(openbsd):
-      {.passL: "/usr/local/include/libiconv.a".}
+      {.passL: "/usr/local/lib/libiconv.a".}
   else:
     {.pragma: importIconv, cdecl, dynlib: iconvDll.}
 

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -282,7 +282,7 @@ else:
 
   var errno {.importc, header: "<errno.h>".}: cint
 
-  when defined(freebsd) or defined(netbsd):
+  when defined(freebsd) or defined(netbsd) or defined(openbsd):
     {.pragma: importIconv, cdecl, header: "<iconv.h>".}
   else:
     {.pragma: importIconv, cdecl, dynlib: iconvDll.}

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -282,8 +282,10 @@ else:
 
   var errno {.importc, header: "<errno.h>".}: cint
 
-  when defined(freebsd) or defined(netbsd) or defined(openbsd):
+  when defined(bsd):
     {.pragma: importIconv, cdecl, header: "<iconv.h>".}
+    when defined(openbsd):
+      {.passL: "-I/usr/local/include".}
   else:
     {.pragma: importIconv, cdecl, dynlib: iconvDll.}
 


### PR DESCRIPTION
see http://www.polarhome.com/service/man/?qf=iconv_open&tf=2&of=OpenBSD&sf=3

see CI failures: https://builds.sr.ht/~araq/job/496268
> could not import: iconv_open

fix https://github.com/nim-lang/gtk2/issues/12