### PR TITLE
WIP: Added missing functions to jsre module

### DIFF
--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -33,8 +33,8 @@ func compile*(self: RegExp; pattern: cstring; flags: cstring) {.importjs: "#.com
 func replace*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
   ## Returns a new string with some or all matches of a pattern replaced by given replacement
 
-func replaceAll*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
-  ## Returns a new string with all matches of a pattern replaced by given replacement
+# func replaceAll*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
+#   ## Returns a new string with all matches of a pattern replaced by given replacement
 
 func split*(pattern: cstring; self: RegExp): seq[cstring] {.importjs: "#.split(#)".}
   ## Divides a string into an ordered list of substrings and returns the array
@@ -94,5 +94,5 @@ runnableExamples:
   assert "do1ne".split(jsregex) == @["do".cstring, "ne".cstring]
   jsregex.compile(r"[lw]", r"i")
   assert "hello world".replace(jsregex,"X") == "heXlo world"
-  jsregex.compile(r"[lw]", r"g")
-  assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd" 
+  # jsregex.compile(r"[lw]", r"g")
+  # assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd" 

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -36,7 +36,7 @@ func replace*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.i
 func replaceAll*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
   ## Returns a new string with all matches of a pattern replaced by given replacement
 
-func split*(pattern: cstring; self: RegExp; sep: cstring): seq[cstring] {.importjs: "#.split(#,#)".}
+func split*(pattern: cstring; self: RegExp): seq[cstring] {.importjs: "#.split(#)".}
   ## Divides a string into an ordered list of substrings and returns the array
 
 func match*(pattern: cstring; self: RegExp): seq[cstring] {.importjs: "#.match(#)".}

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -67,7 +67,7 @@ func startsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string starts with given RegExp
   runnableExamples:
     let jsregex: RegExp = newRegExp(r"abc", r"i")
-    assert "abcde".startsWith jsregex
+    assert "abcd".startsWith jsregex
   pattern.contains(newRegExp(("^" & $(self.source)).cstring))
 
 func endsWith*(pattern: cstring; self: RegExp): bool =
@@ -87,3 +87,7 @@ runnableExamples:
   jsregex.compile(r"[0-9]", r"i")
   assert "0123456789abcd".contains jsregex
   assert $jsregex == "/[0-9]/i"
+  jsregex.compile(r"abc", r"i")
+  assert "abcd".startsWith jsregex
+  assert "dabc".endsWith jsregex
+  

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -92,3 +92,7 @@ runnableExamples:
   assert "dabc".endsWith jsregex
   jsregex.compile(r"\d", r"i")
   assert "do1ne".split(jsregex) == @["do".cstring, "ne".cstring]
+  jsregex.compile(r"[lw]", r"i")
+  assert "hello world".replace(jsregex),"X") == "heXlo world"
+  jsregex.compile(r"[lw]", r"g")
+  assert "hello world".replaceAll(jsregex),"X") == "heXXo XorXd"

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -30,18 +30,6 @@ func newRegExp*(pattern: cstring): RegExp {.importjs: "new RegExp(@)".}
 func compile*(self: RegExp; pattern: cstring; flags: cstring) {.importjs: "#.compile(@)".}
   ## Recompiles a regular expression during execution of a script.
 
-func replace*(pattern: cstring, self: RegExp, replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
-  ## Returns a new string with some or all matches of a pattern replaced by given replacement
-
-func replaceAll*(pattern: cstring, self: RegExp, replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
-  ## Returns a new string with all matches of a pattern replaced by given replacement
-
-func split*(pattern: cstring, self: RegExp, sep: cstring): seq[cstring] {.importjs: "#.split(#,#)".}
-  ## Divides a string into an ordered list of substrings and returns the array
-
-func match*(pattern: cstring, self: RegExp): seq[cstring] {.importjs: "#.match(#)".}
-  ## Returns an array of matches of a RegExp against given string
-
 func exec*(self: RegExp; pattern: cstring): seq[cstring] {.importjs: "#.exec(#)".}
   ## Executes a search for a match in its string parameter.
 

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -93,6 +93,6 @@ runnableExamples:
   jsregex.compile(r"\d", r"i")
   assert "do1ne".split(jsregex) == @["do".cstring, "ne".cstring]
   jsregex.compile(r"[lw]", r"i")
-  assert "hello world".replace(jsregex),"X" == "heXlo world"
+  assert "hello world".replace(jsregex,"X") == "heXlo world"
   jsregex.compile(r"[lw]", r"g")
-  assert "hello world".replaceAll(jsregex),"X" == "heXXo XorXd"
+  assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd"

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -95,4 +95,4 @@ runnableExamples:
   jsregex.compile(r"[lw]", r"i")
   assert "hello world".replace(jsregex,"X") == "heXlo world"
   jsregex.compile(r"[lw]", r"g")
-  assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd"
+  assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd" 

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -30,16 +30,16 @@ func newRegExp*(pattern: cstring): RegExp {.importjs: "new RegExp(@)".}
 func compile*(self: RegExp; pattern: cstring; flags: cstring) {.importjs: "#.compile(@)".}
   ## Recompiles a regular expression during execution of a script.
 
-func replace*(pattern: cstring, self: RegExp, replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
+func replace*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
   ## Returns a new string with some or all matches of a pattern replaced by given replacement
 
-func replaceAll*(pattern: cstring, self: RegExp, replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
+func replaceAll*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
   ## Returns a new string with all matches of a pattern replaced by given replacement
 
-func split*(pattern: cstring, self: RegExp, sep: cstring): seq[cstring] {.importjs: "#.split(#,#)".}
+func split*(pattern: cstring; self: RegExp; sep: cstring): seq[cstring] {.importjs: "#.split(#,#)".}
   ## Divides a string into an ordered list of substrings and returns the array
 
-func match*(pattern: cstring, self: RegExp): seq[cstring] {.importjs: "#.match(#)".}
+func match*(pattern: cstring; self: RegExp): seq[cstring] {.importjs: "#.match(#)".}
   ## Returns an array of matches of a RegExp against given string
 
 func exec*(self: RegExp; pattern: cstring): seq[cstring] {.importjs: "#.exec(#)".}

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -90,4 +90,5 @@ runnableExamples:
   jsregex.compile(r"abc", r"i")
   assert "abcd".startsWith jsregex
   assert "dabc".endsWith jsregex
-  
+  jsregex.compile(r"\d", r"i")
+  assert "do1ne".split(jsregex) == @["do".cstring, "ne".cstring]

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -54,14 +54,6 @@ func test*(self: RegExp; pattern: cstring): bool {.importjs: "#.test(#)", deprec
 
 func toString*(self: RegExp): cstring {.importjs: "#.toString()", deprecated: "Use toCstring instead".}
 
-func startsWith*(pattern: cstring; self: RegExp): bool =
-  ## Tests if string starts with given RegExp
-  newRegExp(("^" & $(self.source)).cstring).test(pattern)
-
-func endsWith*(pattern: cstring; self: RegExp): bool =
-  ## Tests if string ends with given RegExp
-  newRegExp(($(self.source) & "$").cstring).test(pattern)
-
 func contains*(pattern: cstring; self: RegExp): bool =
   ## Tests for a substring match in its string parameter.
   runnableExamples:
@@ -81,3 +73,11 @@ runnableExamples:
   jsregex.compile(r"[0-9]", r"i")
   assert "0123456789abcd".contains jsregex
   assert $jsregex == "/[0-9]/i"
+
+func startsWith*(pattern: cstring; self: RegExp): bool =
+  ## Tests if string starts with given RegExp
+  pattern.contains(newRegExp(("^" & $(self.source)).cstring))
+
+func endsWith*(pattern: cstring; self: RegExp): bool =
+  ## Tests if string ends with given RegExp
+  pattern.contains(newRegExp(($(self.source) & "$").cstring))

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -95,4 +95,4 @@ runnableExamples:
   jsregex.compile(r"[lw]", r"i")
   assert "hello world".replace(jsregex,"X") == "heXlo world"
   # jsregex.compile(r"[lw]", r"g")
-  # assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd" 
+  # assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd"

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -30,7 +30,7 @@ func newRegExp*(pattern: cstring): RegExp {.importjs: "new RegExp(@)".}
 func compile*(self: RegExp; pattern: cstring; flags: cstring) {.importjs: "#.compile(@)".}
   ## Recompiles a regular expression during execution of a script.
 
-func replace*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
+func replace*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replace(#, #)".}
   ## Returns a new string with some or all matches of a pattern replaced by given replacement
 
 func split*(pattern: cstring; self: RegExp): seq[cstring] {.importjs: "#.split(#)".}

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -93,6 +93,6 @@ runnableExamples:
   jsregex.compile(r"\d", r"i")
   assert "do1ne".split(jsregex) == @["do".cstring, "ne".cstring]
   jsregex.compile(r"[lw]", r"i")
-  assert "hello world".replace(jsregex),"X") == "heXlo world"
+  assert "hello world".replace(jsregex),"X" == "heXlo world"
   jsregex.compile(r"[lw]", r"g")
-  assert "hello world".replaceAll(jsregex),"X") == "heXXo XorXd"
+  assert "hello world".replaceAll(jsregex),"X" == "heXXo XorXd"

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -30,6 +30,18 @@ func newRegExp*(pattern: cstring): RegExp {.importjs: "new RegExp(@)".}
 func compile*(self: RegExp; pattern: cstring; flags: cstring) {.importjs: "#.compile(@)".}
   ## Recompiles a regular expression during execution of a script.
 
+func replace*(pattern: cstring, self: RegExp, replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
+  ## Returns a new string with some or all matches of a pattern replaced by given replacement
+
+func replaceAll*(pattern: cstring, self: RegExp, replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
+  ## Returns a new string with all matches of a pattern replaced by given replacement
+
+func split*(pattern: cstring, self: RegExp, sep: cstring): seq[cstring] {.importjs: "#.split(#,#)".}
+  ## Divides a string into an ordered list of substrings and returns the array
+
+func match*(pattern: cstring, self: RegExp): seq[cstring] {.importjs: "#.match(#)".}
+  ## Returns an array of matches of a RegExp against given string
+
 func exec*(self: RegExp; pattern: cstring): seq[cstring] {.importjs: "#.exec(#)".}
   ## Executes a search for a match in its string parameter.
 

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -68,14 +68,14 @@ func startsWith*(pattern: cstring; self: RegExp): bool =
   runnableExamples:
     let jsregex: RegExp = newRegExp(r"abc", r"i")
     assert "abcd".startsWith jsregex
-  pattern.contains(newRegExp(("^" & $(self.source)).cstring))
+  pattern.contains(newRegExp(("^" & $(self.source)).cstring, self.flags))
 
 func endsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string ends with given RegExp
   runnableExamples:
     let jsregex: RegExp = newRegExp(r"bcd", r"i")
     assert "abcd".endsWith jsregex
-  pattern.contains(newRegExp(($(self.source) & "$").cstring))
+  pattern.contains(newRegExp(($(self.source) & "$").cstring, self.flags))
 
 
 runnableExamples:

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -54,6 +54,14 @@ func test*(self: RegExp; pattern: cstring): bool {.importjs: "#.test(#)", deprec
 
 func toString*(self: RegExp): cstring {.importjs: "#.toString()", deprecated: "Use toCstring instead".}
 
+func startsWith*(pattern: cstring; self: RegExp): bool =
+  ## Tests if string starts with given RegExp
+  newRegExp("^" + self.source).test(pattern)
+
+func endsWith*(pattern: cstring; self: RegExp): bool =
+  ## Tests if string ends with given RegExp
+  newRegExp(self.source + "$").test(pattern)
+
 func contains*(pattern: cstring; self: RegExp): bool =
   ## Tests for a substring match in its string parameter.
   runnableExamples:

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -63,17 +63,6 @@ func contains*(pattern: cstring; self: RegExp): bool =
     assert "xabc".contains jsregex
   asm "`result` = `self`.test(`pattern`);"
 
-
-runnableExamples:
-  let jsregex: RegExp = newRegExp(r"\s+", r"i")
-  jsregex.compile(r"\w+", r"i")
-  assert "nim javascript".contains jsregex
-  assert jsregex.exec(r"nim javascript") == @["nim".cstring]
-  assert jsregex.toCstring() == r"/\w+/i"
-  jsregex.compile(r"[0-9]", r"i")
-  assert "0123456789abcd".contains jsregex
-  assert $jsregex == "/[0-9]/i"
-
 func startsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string starts with given RegExp
   runnableExamples:
@@ -87,3 +76,14 @@ func endsWith*(pattern: cstring; self: RegExp): bool =
     let jsregex: RegExp = newRegExp(r"bcd", r"i")
     assert "abcd".endsWith jsregex
   pattern.contains(newRegExp(($(self.source) & "$").cstring))
+
+
+runnableExamples:
+  let jsregex: RegExp = newRegExp(r"\s+", r"i")
+  jsregex.compile(r"\w+", r"i")
+  assert "nim javascript".contains jsregex
+  assert jsregex.exec(r"nim javascript") == @["nim".cstring]
+  assert jsregex.toCstring() == r"/\w+/i"
+  jsregex.compile(r"[0-9]", r"i")
+  assert "0123456789abcd".contains jsregex
+  assert $jsregex == "/[0-9]/i"

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -76,8 +76,14 @@ runnableExamples:
 
 func startsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string starts with given RegExp
+  runnableExamples:
+    let jsregex: RegExp = newRegExp(r"abc", r"i")
+    assert "abcde".startsWith jsregex
   pattern.contains(newRegExp(("^" & $(self.source)).cstring))
 
 func endsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string ends with given RegExp
+  runnableExamples:
+    let jsregex: RegExp = newRegExp(r"bcd", r"i")
+    assert "abcd".endsWith jsregex
   pattern.contains(newRegExp(($(self.source) & "$").cstring))

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -56,11 +56,11 @@ func toString*(self: RegExp): cstring {.importjs: "#.toString()", deprecated: "U
 
 func startsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string starts with given RegExp
-  newRegExp("^" + self.source).test(pattern)
+  newRegExp(("^" & $(self.source)).cstring).test(pattern)
 
 func endsWith*(pattern: cstring; self: RegExp): bool =
   ## Tests if string ends with given RegExp
-  newRegExp(self.source + "$").test(pattern)
+  newRegExp(($(self.source) & "$").cstring).test(pattern)
 
 func contains*(pattern: cstring; self: RegExp): bool =
   ## Tests for a substring match in its string parameter.

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -33,9 +33,6 @@ func compile*(self: RegExp; pattern: cstring; flags: cstring) {.importjs: "#.com
 func replace*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replace(#,#)".}
   ## Returns a new string with some or all matches of a pattern replaced by given replacement
 
-# func replaceAll*(pattern: cstring; self: RegExp; replacement: cstring): cstring {.importjs: "#.replaceAll(#,#)".}
-#   ## Returns a new string with all matches of a pattern replaced by given replacement
-
 func split*(pattern: cstring; self: RegExp): seq[cstring] {.importjs: "#.split(#)".}
   ## Divides a string into an ordered list of substrings and returns the array
 
@@ -94,5 +91,3 @@ runnableExamples:
   assert "do1ne".split(jsregex) == @["do".cstring, "ne".cstring]
   jsregex.compile(r"[lw]", r"i")
   assert "hello world".replace(jsregex,"X") == "heXlo world"
-  # jsregex.compile(r"[lw]", r"g")
-  # assert "hello world".replaceAll(jsregex,"X") == "heXXo XorXd"


### PR DESCRIPTION
I have added the following functions to the *jsre* module:

- replace
- ~~replaceAll~~
- split
- match
- startsWith
- endsWith

According to the specifications here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions