### PR TITLE
restructure the ChannelObj

### DIFF
--- a/lib/std/channels.nim
+++ b/lib/std/channels.nim
@@ -101,13 +101,14 @@ type
   ChannelObj = object
     headLock, tailLock: Lock
     notFullCond, notEmptyCond: Cond
-    closed: Atomic[bool]
     size: int
     itemsize: int # up to itemsize bytes can be exchanged over this channel
-    head {.align: cacheLineSize.} : int     # Items are taken from head and new items are inserted at tail
-    tail: int
     buffer: ptr UncheckedArray[byte]
     atomicCounter: Atomic[int]
+    closed: Atomic[bool]
+    head {.align: cacheLineSize.} : int     # Items are taken from head and new items are inserted at tail
+    pad: array[cacheLineSize-sizeof(int), byte] # Separate by at-least a cache line
+    tail: int
 
   ChannelCache = ptr ChannelCacheObj
   ChannelCacheObj = object


### PR DESCRIPTION
- the unchanged data members are put together
- combine align with pad array

may fix false sharing

see https://trishagee.com/2011/07/22/dissecting_the_disruptor_why_its_so_fast_part_two__magic_cache_line_padding

What do you think of alignment and false sharing? @timotheecour

Ref https://github.com/nim-lang/Nim/issues/17392