### PR TITLE
close #16646; `since` now works with bootstrap nim post csources_v1

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -256,8 +256,8 @@ proc semRangeAux(c: PContext, n: PNode, prev: PType): PType =
     else:
       result.n.add semConstExpr(c, range[i])
 
-  if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and classify(result.n[0].floatVal) == fcNan) or
-      (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and classify(result.n[1].floatVal) == fcNan):
+  if (result.n[0].kind in {nkFloatLit..nkFloat64Lit} and result.n[0].floatVal.isNaN) or
+      (result.n[1].kind in {nkFloatLit..nkFloat64Lit} and result.n[1].floatVal.isNaN):
     localError(c.config, n.info, "NaN is not a valid start or end for a range")
 
   if weakLeValue(result.n[0], result.n[1]) == impNo:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -2253,8 +2253,7 @@ proc parseEnumList(p: var RstParser): PRstNode =
               (should be at column $3 if it's a continuation of enum. list),
           or no blank line after line $1 (if it should be the next paragraph),
           or no escaping \ at the beginning of line $1
-              (if lines $1..$2 are a normal paragraph, not enum. list)""".
-          unindent(8)
+              (if lines $1..$2 are a normal paragraph, not enum. list)""".dedent
         let c = p.col + requiredIndent + ColRstOffset
         rstMessage(p, mwRstStyle, msg % [$(n-1), $n, $c],
                    p.tok[j].line, p.tok[j].col)

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -2250,10 +2250,10 @@ proc parseEnumList(p: var RstParser): PRstNode =
         let n = p.line + p.tok[j].line
         let msg = "\n" & """
           not enough indentation on line $2
-              (should be at column $3 if it's a continuation of enum. list),
+            (should be at column $3 if it's a continuation of enum. list),
           or no blank line after line $1 (if it should be the next paragraph),
           or no escaping \ at the beginning of line $1
-              (if lines $1..$2 are a normal paragraph, not enum. list)""".dedent
+            (if lines $1..$2 are a normal paragraph, not enum. list)""".dedent
         let c = p.col + requiredIndent + ColRstOffset
         rstMessage(p, mwRstStyle, msg % [$(n-1), $n, $c],
                    p.tok[j].line, p.tok[j].col)

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -849,7 +849,7 @@ Test1
     let output8 = input8.toHtml(warnings = warnings8)
     check(warnings8[].len == 1)
     check("input(6, 1) Warning: RST style: \n" &
-          "  not enough indentation on line 6" in warnings8[0])
+          "not enough indentation on line 6" in warnings8[0])
     doAssert output8 == "Paragraph.<ol class=\"upperalpha simple\">" &
         "<li>stringA</li>\n<li>stringB</li>\n</ol>\n<p>C. string1 string2 </p>\n"
 


### PR DESCRIPTION
* close #16646 (follows csources_v1 https://github.com/nim-lang/Nim/pull/16282 and ci changes to use it throughout in https://github.com/nim-lang/Nim/pull/17815)
* revive #16627 (/cc @xflywind) now that csources_v1 was merged
* things like `dedent` can now be used without worrying about bootstrap (/cc @a-mr for things like https://github.com/nim-lang/Nim/pull/16699#issuecomment-758936794, https://github.com/nim-lang/Nim/pull/16699 could be revived if needed, see also https://github.com/nim-lang/Nim/pull/17257#discussion_r589025683)
* improve rendering of a rst warning:
```
Paragraph.

A. stringA
B. stringB
C. string1
string2
```
before PR:
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12224.rst(6, 1) Warning: RST style:
  not enough indentation on line 6
      (should be at column 4 if it's a continuation of enum. list),
  or no blank line after line 5 (if it should be the next paragraph),
  or no escaping \ at the beginning of line 5
      (if lines 5..6 are a normal paragraph, not enum. list) [warnRstStyle]
```
after PR:
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12224.rst(6, 1) Warning: RST style:
not enough indentation on line 6
  (should be at column 4 if it's a continuation of enum. list),
or no blank line after line 5 (if it should be the next paragraph),
or no escaping \ at the beginning of line 5
  (if lines 5..6 are a normal paragraph, not enum. list) [warnRstStyle]
```

(note that nim now has ascii unit separator to separate messages so there is no ambiguity here); this is now consistent with other messages which don't indent on the line right after the note eg:
```
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12225.nim(6, 1) Error: undeclared identifier: 'bar3'
candidates (edit distance, scope distance); see '--spellSuggest':
 (1, 0): 'bar1' [proc declared in /Users/timothee/git_clone/nim/timn/tests/nim/all/t12225.nim(4, 6)]
 (1, 0): 'bar2' [proc declared in /Users/timothee/git_clone/nim/timn/tests/nim/all/t12225.nim(5, 6)]
  bar3()
```

## future work
in future work, `dedent` itself could be improved though:
- [ ] it doesn't work at CT
- [ ] it (or indent) should have an optional pram to allow specifying indentation level after dedenting, so that this would be possible:

```nim
block:
  block:
    let a = """
    foo1
    foo2
    """.indent(2, fromMargin = true)
```
producing:
```
  foo1
  foo2
```

but note that in the case of this PR, this is note needed.
  
