### PR TITLE
misc fixes: remove `forceConst` (obsolete by static), add more runnableExamples to system

### DIFF
--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -8,7 +8,7 @@
 #
 
 ## This module allows querying the compiler about
-## diverse configuration settings.
+## diverse configuration settings. See also `compileOption`.
 
 # Note: Only add new enum values at the end to ensure binary compatibility with
 # other Nim compiler versions!

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -55,35 +55,62 @@ type
 include "system/basic_types"
 
 
+proc runnableExamples*(rdoccmd = "", body: untyped) {.magic: "RunnableExamples".}
+  ## A section you should use to mark `runnable example`:idx: code with.
+  ##
+  ## - In normal debug and release builds code within
+  ##   a `runnableExamples` section is ignored.
+  ## - The documentation generator is aware of these examples and considers them
+  ##   part of the `##` doc comment. As the last step of documentation
+  ##   generation each runnableExample is put in its own file `$file_examples$i.nim`,
+  ##   compiled and tested. The collected examples are
+  ##   put into their own module to ensure the examples do not refer to
+  ##   non-exported symbols.
+  ##
+  ## Usage:
+  ##
+  ## .. code-block:: Nim
+  ##   proc double*(x: int): int =
+  ##     ## This proc doubles a number.
+  ##     runnableExamples:
+  ##       ## at module scope
+  ##       assert double(5) == 10
+  ##       block: ## at block scope
+  ##         defer: echo "done"
+  ##     result = 2 * x
+  ##     runnableExamples "-d:foo -b:cpp":
+  ##       import std/compilesettings
+  ##       doAssert querySetting(backend) == "cpp"
+  ##     runnableExamples "-r:off": ## this one is only compiled
+  ##        import std/browsers
+  ##        openDefaultBrowser "https://forum.nim-lang.org/"
+
 proc compileOption*(option: string): bool {.
-  magic: "CompileOption", noSideEffect.}
+  magic: "CompileOption", noSideEffect.} =
   ## Can be used to determine an `on|off` compile-time option.
   ##
   ## See also:
   ## * `compileOption <#compileOption,string,string>`_ for enum options
   ## * `defined <#defined,untyped>`_
   ## * `std/compilesettings module <compilesettings.html>`_
-  ##
-  ## Example:
-  ##
-  ## .. code-block:: Nim
-  ##   when compileOption("floatchecks"):
-  ##     echo "compiled with floating point NaN and Inf checks"
+  runnableExamples("--floatChecks:off"):
+    static: doAssert not compileOption("floatchecks")
+    {.push floatChecks: on.}
+    static: doAssert compileOption("floatchecks")
+    # floating point NaN and Inf checks enabled in this scope
+    {.pop.}
 
 proc compileOption*(option, arg: string): bool {.
-  magic: "CompileOptionArg", noSideEffect.}
+  magic: "CompileOptionArg", noSideEffect.} =
   ## Can be used to determine an enum compile-time option.
   ##
   ## See also:
   ## * `compileOption <#compileOption,string>`_ for `on|off` options
   ## * `defined <#defined,untyped>`_
   ## * `std/compilesettings module <compilesettings.html>`_
-  ##
-  ## Example:
-  ##
-  ## .. code-block:: Nim
-  ##   when compileOption("opt", "size") and compileOption("gc", "boehm"):
-  ##     echo "compiled with optimization for size and uses Boehm's GC"
+  runnableExamples:
+    when compileOption("opt", "size") and compileOption("gc", "boehm"):
+      discard "compiled with optimization for size and uses Boehm's GC"
 
 {.push warning[GcMem]: off, warning[Uninit]: off.}
 {.push hints: off.}
@@ -138,36 +165,6 @@ else:
   type
     OrdinalImpl[T] {.magic: Ordinal.}
     Ordinal* = OrdinalImpl | uint | uint64
-
-proc runnableExamples*(rdoccmd = "", body: untyped) {.magic: "RunnableExamples".}
-  ## A section you should use to mark `runnable example`:idx: code with.
-  ##
-  ## - In normal debug and release builds code within
-  ##   a `runnableExamples` section is ignored.
-  ## - The documentation generator is aware of these examples and considers them
-  ##   part of the `##` doc comment. As the last step of documentation
-  ##   generation each runnableExample is put in its own file `$file_examples$i.nim`,
-  ##   compiled and tested. The collected examples are
-  ##   put into their own module to ensure the examples do not refer to
-  ##   non-exported symbols.
-  ##
-  ## Usage:
-  ##
-  ## .. code-block:: Nim
-  ##   proc double*(x: int): int =
-  ##     ## This proc doubles a number.
-  ##     runnableExamples:
-  ##       ## at module scope
-  ##       assert double(5) == 10
-  ##       block: ## at block scope
-  ##         defer: echo "done"
-  ##     result = 2 * x
-  ##     runnableExamples "-d:foo -b:cpp":
-  ##       import std/compilesettings
-  ##       doAssert querySetting(backend) == "cpp"
-  ##     runnableExamples "-r:off": ## this one is only compiled
-  ##        import std/browsers
-  ##        openDefaultBrowser "https://forum.nim-lang.org/"
 
 when defined(nimHasDeclaredMagic):
   proc declared*(x: untyped): bool {.magic: "Declared", noSideEffect, compileTime.}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -55,7 +55,7 @@ type
 include "system/basic_types"
 
 
-proc runnableExamples*(rdoccmd = "", body: untyped) {.magic: "RunnableExamples".}
+proc runnableExamples*(rdoccmd = "", body: untyped) {.magic: "RunnableExamples".} =
   ## A section you should use to mark `runnable example`:idx: code with.
   ##
   ## - In normal debug and release builds code within
@@ -66,24 +66,23 @@ proc runnableExamples*(rdoccmd = "", body: untyped) {.magic: "RunnableExamples".
   ##   compiled and tested. The collected examples are
   ##   put into their own module to ensure the examples do not refer to
   ##   non-exported symbols.
-  ##
-  ## Usage:
-  ##
-  ## .. code-block:: Nim
-  ##   proc double*(x: int): int =
-  ##     ## This proc doubles a number.
-  ##     runnableExamples:
-  ##       ## at module scope
-  ##       assert double(5) == 10
-  ##       block: ## at block scope
-  ##         defer: echo "done"
-  ##     result = 2 * x
-  ##     runnableExamples "-d:foo -b:cpp":
-  ##       import std/compilesettings
-  ##       doAssert querySetting(backend) == "cpp"
-  ##     runnableExamples "-r:off": ## this one is only compiled
-  ##        import std/browsers
-  ##        openDefaultBrowser "https://forum.nim-lang.org/"
+  runnableExamples:
+    proc timesTwo*(x: int): int =
+      ## This proc doubles a number.
+      runnableExamples:
+        # at module scope
+        const exported* = 123
+        assert timesTwo(5) == 10
+        block: # at block scope
+          defer: echo "done"
+      runnableExamples "-d:foo -b:cpp":
+        import std/compilesettings
+        assert querySetting(backend) == "cpp"
+        assert defined(foo)
+      runnableExamples "-r:off": ## this one is only compiled
+         import std/browsers
+         openDefaultBrowser "https://forum.nim-lang.org/"
+      2 * x
 
 proc compileOption*(option: string): bool {.
   magic: "CompileOption", noSideEffect.} =

--- a/tests/vm/tconst.nim
+++ b/tests/vm/tconst.nim
@@ -1,8 +1,8 @@
 discard """
-action: compile
+  targets: "c cpp js"
 """
 
-import strutils
+import std/strutils
 
 const
   HelpText = """
@@ -26,6 +26,11 @@ Possible Commands:
   zip                      builds the installation ZIP package
   inno                     builds the Inno Setup installer
 """ % [NimVersion & spaces(44-len(NimVersion)),
-       CompileDate, CompileTime]
+       CompileDate, CompileTime] # xxx this could be simplified  for this test
 
-echo HelpText
+template main() =
+  block:
+    let a = $HelpText
+    doAssert a.len == 929
+static: main()
+main()

--- a/tests/vm/tconst.nim
+++ b/tests/vm/tconst.nim
@@ -4,33 +4,32 @@ discard """
 
 import std/strutils
 
-const
-  HelpText = """
-+-----------------------------------------------------------------+
-|         Maintenance program for Nim                             |
-|             Version $1|
-|             (c) 2012 Andreas Rumpf                              |
-+-----------------------------------------------------------------+
-Compiled at: $2, $3
+template forceConst(a: untyped): untyped =
+  ## Force evaluation at CT, but `static(a)` is simpler
+  const ret = a
+  ret
 
-Usage:
-  koch [options] command [options for command]
-Options:
-  --force, -f, -B, -b      forces rebuild
-  --help, -h               shows this help and quits
-Possible Commands:
-  boot [options]           bootstraps with given command line options
-  clean                    cleans Nim project; removes generated files
-  web                      generates the website
-  csource [options]        builds the C sources for installation
-  zip                      builds the installation ZIP package
-  inno                     builds the Inno Setup installer
-""" % [NimVersion & spaces(44-len(NimVersion)),
-       CompileDate, CompileTime] # xxx this could be simplified  for this test
+proc isNimVm(): bool =
+  when nimvm: result = true
+  else: result = false
+
+block:
+  doAssert forceConst(isNimVm())
+  doAssert not isNimVm()
+  doAssert forceConst(isNimVm()) == static(isNimVm())
+  doAssert forceConst(isNimVm()) == isNimVm().static
 
 template main() =
+  # xxx merge more const related tests here
   block:
-    let a = $HelpText
-    doAssert a.len == 929
+    const
+      a = """
+    Version $1|
+    Compiled at: $2, $3
+    """ % [NimVersion & spaces(44-len(NimVersion)), CompileDate, CompileTime]
+    let b = $a
+    doAssert CompileTime in b
+    doAssert NimVersion in b
+
 static: main()
 main()

--- a/tests/vm/tvmops.nim
+++ b/tests/vm/tvmops.nim
@@ -9,16 +9,6 @@ import os
 import math
 import strutils
 
-template forceConst(a: untyped): untyped =
-  ## Force evaluation at CT, useful for example here:
-  ## `callFoo(forceConst(getBar1()), getBar2())`
-  ## instead of:
-  ##  block:
-  ##    const a = getBar1()
-  ##    `callFoo(a, getBar2())`
-  const ret = a
-  ret
-
 static:
   # TODO: add more tests
   block: #getAppFilename, gorgeEx, gorge
@@ -51,6 +41,6 @@ static:
 
 block:
   # Check against bugs like #9176
-  doAssert getCurrentCompilerExe() == forceConst(getCurrentCompilerExe())
+  doAssert getCurrentCompilerExe() == getCurrentCompilerExe().static
   if false: #pending #9176
-    doAssert gorgeEx("unexistant") == forceConst(gorgeEx("unexistant"))
+    doAssert gorgeEx("unexistant") == gorgeEx("unexistant").static


### PR DESCRIPTION
remove forceConst (obsolete by static)
add runnableExamples to compileOption
add runnableExamples to runnableExamples and improve the existing examples a bit
