### PR TITLE
Implemented stronger type inference for enums and literals

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -564,6 +564,8 @@ type
       # (for importc types); type is fully specified, allowing to compute
       # sizeof, alignof, offsetof at CT
     tfExplicitCallConv
+    tfHasExpected  # Used for type inference, 
+                   # so we know the `typ` is to be inferred
 
   TTypeFlags* = set[TTypeFlag]
 

--- a/compiler/semdata.nim
+++ b/compiler/semdata.nim
@@ -268,7 +268,6 @@ proc considerGenSyms*(c: PContext; n: PNode) =
   else:
     for i in 0..<n.safeLen:
       considerGenSyms(c, n[i])
-
 proc newOptionEntry*(conf: ConfigRef): POptionEntry =
   new(result)
   result.options = conf.options

--- a/tests/casestmt/tcasestmt.nim
+++ b/tests/casestmt/tcasestmt.nim
@@ -272,7 +272,6 @@ func foo2(b, input: string): int =
                   else: continue
     else: return
 
-
 static:
   doAssert(foo("3") == 3)
   doAssert(foo("a") == 0)

--- a/tests/inference/tinference.nim
+++ b/tests/inference/tinference.nim
@@ -1,0 +1,43 @@
+type
+    A {.pure.} = enum
+      left, right, up, down
+    B {.pure.} = enum
+      left, right, up, down
+    Test = object
+      case kind: A # Tests rec case inference
+      of left:
+        a: int
+      of {right, down}:
+        b: float
+      else:
+        c: string
+block: # Tests case inference
+  let test = A.left
+  case test:
+  of left: discard
+  of up: discard
+  else: discard
+
+block: # Tests array inference
+  var
+    t: array[4, A] = [left, right, down, up]
+    y: array[4, B] = [left, right, down, up]
+
+block: # Tests set inference
+  type ASet = set[A]
+  var
+    t: ASet = {left..right, down, up}
+    y: set[B] = {left, right, down, up}
+
+block: # Tests left enum inference
+  var 
+    t: A = left
+    y: A = left
+  
+
+
+block: # Tests literal inference
+  var 
+    a: array[4, byte] = [255, 2, 3, 4]
+    b: array[4, uint32] = [1, 2, 3, 4]
+    c: int8 = 126


### PR DESCRIPTION
This PR aims to strenghten the type inference when the type can be resolved from the left hand.
Following is the added features:
```nim
type
  A {.pure.} = enum
    left, right, up, down
  B {.pure.} = enum
    left, right, up, down
  Test = object
    case kind: A
    of left:
      a: int
    of {right, down}:
      b: float
    else:
      c: string
  ASet = set[A]

let test = A.left
case test:
of left: discard
of up: discard
else: discard

var
  a: array[4, A] = [left, right, down, up]
  b: array[4, B] = [left, right, down, up]
  c: ASet = {left..right, down, up}
  d: A = left
  e: array[4, byte] = [255, 2, 3, 4]
```