### PR TITLE
increase the support version requirement for MacOS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ architecture combinations:
 
   * Windows (Windows XP or greater) - x86 and x86_64
   * Linux (most, if not all, distributions) - x86, x86_64, ppc64 and armv6l
-  * Mac OS X (10.04 or greater) - x86, x86_64 and ppc64
+  * Mac OS X (10.12 or greater) - x86, x86_64 and ppc64
 
 More platforms are supported, however, they are not tested regularly and they
 may not be as stable as the above-listed platforms.


### PR DESCRIPTION
macOS 10.12 was born at June 13, 2016, and the end of support date is October 2019(ref https://en.wikipedia.org/wiki/MacOS_Sierra)

This version introduces many useful features.

For example, `getentropy`, `clock_gettime` which is beneficial. See also https://github.com/zeromq/libzmq/issues/2175

Related: https://github.com/nim-lang/Nim/pull/17901

However we don't have a reliable way to use different system apis for different system versions. More terribly, it makes it hard to register these apis in the VM because it causes building latest Nim to fail.

see https://github.com/nim-lang/Nim/issues/17370

So maybe we should increase the support version requirement for MacOS