### PR TITLE
Fix nim-lang/nimforum#285 - punctuation after URL

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1224,8 +1224,9 @@ proc parseUrl(p: var RstParser): PRstNode =
   while lastIdx >= p.idx and p.tok[lastIdx].kind == tkPunct and
       p.tok[lastIdx].symbol != "/":
     dec lastIdx
-  for i in p.idx .. lastIdx:
-    result.add newLeaf(p.tok[i].symbol)
+  var s = ""
+  for i in p.idx .. lastIdx: s.add p.tok[i].symbol
+  result.add s
   p.idx = lastIdx + 1
 
 proc parseWordOrRef(p: var RstParser, father: PRstNode) =

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -428,3 +428,46 @@ suite "RST inline markup":
           rnLeaf  'lnk'
           rnLeaf  '___'
       """)
+
+  test "no punctuation in the end of a standalone URI is allowed":
+    check(dedent"""
+        [see (http://no.org)], end""".toAst ==
+      dedent"""
+        rnInner
+          rnLeaf  '['
+          rnLeaf  'see'
+          rnLeaf  ' '
+          rnLeaf  '('
+          rnStandaloneHyperlink
+            rnLeaf  'http'
+            rnLeaf  ':'
+            rnLeaf  '//'
+            rnLeaf  'no'
+            rnLeaf  '.'
+            rnLeaf  'org'
+          rnLeaf  ')'
+          rnLeaf  ']'
+          rnLeaf  ','
+          rnLeaf  ' '
+          rnLeaf  'end'
+        """)
+
+    # but `/` at the end is OK
+    check(
+      dedent"""
+        See http://no.org/ end""".toAst ==
+      dedent"""
+        rnInner
+          rnLeaf  'See'
+          rnLeaf  ' '
+          rnStandaloneHyperlink
+            rnLeaf  'http'
+            rnLeaf  ':'
+            rnLeaf  '//'
+            rnLeaf  'no'
+            rnLeaf  '.'
+            rnLeaf  'org'
+            rnLeaf  '/'
+          rnLeaf  ' '
+          rnLeaf  'end'
+        """)

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -460,3 +460,21 @@ suite "RST inline markup":
           rnLeaf  ' '
           rnLeaf  'end'
         """)
+
+    # a more complex URL with some made-up ending '&='.
+    # Github Markdown would include final &= and
+    # so would rst2html.py in contradiction with RST spec.
+    check(
+      dedent"""
+        See https://www.google.com/url?sa=t&source=web&cd=&cad=rja&url=https%3A%2F%2Fnim-lang.github.io%2FNim%2Frst.html%23features&usg=AO&= end""".toAst ==
+      dedent"""
+        rnInner
+          rnLeaf  'See'
+          rnLeaf  ' '
+          rnStandaloneHyperlink
+            rnLeaf  'https://www.google.com/url?sa=t&source=web&cd=&cad=rja&url=https%3A%2F%2Fnim-lang.github.io%2FNim%2Frst.html%23features&usg=AO'
+          rnLeaf  '&'
+          rnLeaf  '='
+          rnLeaf  ' '
+          rnLeaf  'end'
+        """)

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -439,12 +439,7 @@ suite "RST inline markup":
           rnLeaf  ' '
           rnLeaf  '('
           rnStandaloneHyperlink
-            rnLeaf  'http'
-            rnLeaf  ':'
-            rnLeaf  '//'
-            rnLeaf  'no'
-            rnLeaf  '.'
-            rnLeaf  'org'
+            rnLeaf  'http://no.org'
           rnLeaf  ')'
           rnLeaf  ']'
           rnLeaf  ','
@@ -461,13 +456,7 @@ suite "RST inline markup":
           rnLeaf  'See'
           rnLeaf  ' '
           rnStandaloneHyperlink
-            rnLeaf  'http'
-            rnLeaf  ':'
-            rnLeaf  '//'
-            rnLeaf  'no'
-            rnLeaf  '.'
-            rnLeaf  'org'
-            rnLeaf  '/'
+            rnLeaf  'http://no.org/'
           rnLeaf  ' '
           rnLeaf  'end'
         """)


### PR DESCRIPTION
e.g. in such a link
```
(http://no.org),
```
final `)` was included into URL, which contradicts to RST spec and Markdown behavior.