### PR TITLE
refs #17913 workaround for build_all.sh on M1 mac with broken(?) `cp`

### DIFF
--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -95,6 +95,8 @@ nimBuildCsourcesIfNeeded(){
       _nimBuildCsourcesIfNeeded "$@"
     fi
 
+    echo_run rm -f bin/nim
+      # fixes bug #17913, but it's unclear why it's needed, maybe specific to MacOS Big Sur 11.3 on M1 arch?
     echo_run cp $nim_csources bin/nim
     echo_run $nim_csources -v
   )


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/issues/17913#issuecomment-830671116
> It works. Inserting this line in funs.sh makes it work every time for me:

it's not clear why it's needed (i can't reproduce this), trying to figure this out here https://github.com/nim-lang/Nim/issues/17913#issuecomment-830685669

looks like M1 mac or OP's system has a broken `cp`:
> It does not work with cp -f either. For a sanity check, I tried copying the bin/nimble binary to bin/nimble2 and then copying over it again. I can confirm that the same behavior is exhibited. This is the weirdest thing ever.

