### PR TITLE
highlite: fix #17890 - tokenize Nim escape seq-s

### DIFF
--- a/tests/stdlib/thighlite.nim
+++ b/tests/stdlib/thighlite.nim
@@ -1,0 +1,13 @@
+
+import unittest
+import ../../lib/packages/docutils/highlite
+
+suite "Nim tokenizing":
+  test "string literals and escape seq":
+    check("\"ok1\\nok2\\nok3\"".tokenize(langNim) ==
+       @[("\"ok1", gtStringLit), ("\\n", gtEscapeSequence), ("ok2", gtStringLit),
+         ("\\n", gtEscapeSequence), ("ok3\"", gtStringLit)
+      ])
+    check("\"\"\"ok1\\nok2\\nok3\"\"\"".tokenize(langNim) ==
+       @[("\"\"\"ok1\\nok2\\nok3\"\"\"", gtLongStringLit)
+      ])

--- a/tests/stdlib/thighlite.nim
+++ b/tests/stdlib/thighlite.nim
@@ -2,7 +2,7 @@
 import unittest
 import ../../lib/packages/docutils/highlite
 
-suite "Nim tokenizing":
+block: # Nim tokenizing"
   test "string literals and escape seq":
     check("\"ok1\\nok2\\nok3\"".tokenize(langNim) ==
        @[("\"ok1", gtStringLit), ("\\n", gtEscapeSequence), ("ok2", gtStringLit),


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/1299583/116795934-2cbed700-aae1-11eb-9d8f-35f5a31a6820.png)

**After:**

![image](https://user-images.githubusercontent.com/1299583/116795947-42cc9780-aae1-11eb-9c09-f3ed644f0574.png)
