### PR TITLE
improve std/tempfiles

### DIFF
--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -126,14 +126,15 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
   ## 
   ## If failing to create a temporary file, `OSError` will be raised.
   ##
-  ## .. note:: It is the caller's responsibility to remove the file when no longer needed.
+  ## .. note:: It is the caller's responsibility to close `result.cfile` and
+  ## remove `result.file` when no longer needed.
   runnableExamples:
-    import std/[os, nre]
+    import std/os
     doAssertRaises(OSError): discard createTempFile("", "", "nonexistent")
-    let (cfile, path) = createTempFile("D20210501T170028", "end")
+    let (cfile, path) = createTempFile("tmpprefix_", "_end.tmp")
+    # path looks like: getTempDir() / "tmpprefix_FDCIRZA0_end.tmp"
     cfile.write "foo"
     cfile.setFilePos 0
-    assert path.lastPathPart.contains(re"^D20210501T170028(\w+)end$")
     assert readAll(cfile) == "foo"
     close cfile
     assert readFile(path) == "foo"
@@ -160,10 +161,10 @@ proc createTempDir*(prefix, suffix: string, dir = ""): string =
   ##
   ## .. note:: It is the caller's responsibility to remove the directory when no longer needed.
   runnableExamples:
-    import std/[os, nre]
+    import std/os
     doAssertRaises(OSError): discard createTempDir("", "", "nonexistent")
-    let dir = createTempDir("D20210501T171932", "end")
-    assert dir.lastPathPart.contains(re"^D20210501T171932(\w+)end$")
+    let dir = createTempDir("tmpprefix_", "_end")
+    # dir looks like: getTempDir() / "tmpprefix_YEl9VuVj_end"
     assert dirExists(dir)
     removeDir(dir)
   let dir = getTempDirImpl(dir)

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -11,6 +11,12 @@
 ##
 ## Experimental API, subject to change.
 
+#[
+See also:
+* `GetTempFileName` (on windows), refs https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamea
+* `mkstemp` (posix), refs https://man7.org/linux/man-pages/man3/mkstemp.3.html
+]#
+
 import os, random
 
 

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -117,8 +117,7 @@ proc genTempPath*(prefix, suffix: string, dir = ""): string =
   result = dir / (prefix & randomPathName(nimTempPathLength) & suffix)
 
 proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path: string] =
-  ## Creates a new temporary file in the directory `dir`, which must exist
-  ## (empty `dir` will resolve to `getTempDir()`).
+  ## Creates a new temporary file in the directory `dir`.
   ## 
   ## This generates a path name using `genTempPath(prefix, suffix, dir)` and
   ## returns a file handle to an open file and the path of that file, possibly after
@@ -127,7 +126,8 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
   ## If failing to create a temporary file, `OSError` will be raised.
   ##
   ## .. note:: It is the caller's responsibility to close `result.cfile` and
-  ## remove `result.file` when no longer needed.
+  ##    remove `result.file` when no longer needed.
+  ## .. note:: `dir` must exist (empty `dir` will resolve to `getTempDir()`).
   runnableExamples:
     import std/os
     doAssertRaises(OSError): discard createTempFile("", "", "nonexistent")
@@ -150,8 +150,7 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
   raise newException(OSError, "Failed to create a temporary file under directory " & dir)
 
 proc createTempDir*(prefix, suffix: string, dir = ""): string =
-  ## Creates a new temporary directory in the directory `dir`, which must exist
-  ## (empty `dir` will resolve to `getTempDir()`).
+  ## Creates a new temporary directory in the directory `dir`.
   ##
   ## This generates a dir name using `genTempPath(prefix, suffix, dir)`, creates
   ## the directory and returns it, possibly after retrying to ensure it doesn't
@@ -160,6 +159,7 @@ proc createTempDir*(prefix, suffix: string, dir = ""): string =
   ## If failing to create a temporary directory, `OSError` will be raised.
   ##
   ## .. note:: It is the caller's responsibility to remove the directory when no longer needed.
+  ## .. note:: `dir` must exist (empty `dir` will resolve to `getTempDir()`).
   runnableExamples:
     import std/os
     doAssertRaises(OSError): discard createTempDir("", "", "nonexistent")

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -56,7 +56,7 @@ proc safeOpen(filename: string): File =
                               nil, dwCreation, dwFlags, Handle(0))
 
     if handle == INVALID_HANDLE_VALUE:
-      if errno == ERROR_FILE_EXISTS:
+      if getLastError() == ERROR_FILE_EXISTS:
         return nil
       else:
         raiseOSError(osLastError(), filename)
@@ -80,6 +80,7 @@ proc safeOpen(filename: string): File =
     let fileHandle = posix.open(filename, flags, mode)
     if fileHandle == -1:
       if errno == EEXIST:
+        # xxx `getLastError()` should be defined on posix too and resolve to `errno`?
         return nil
       else:
         raiseOSError(osLastError(), filename)

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -717,13 +717,14 @@ const
   FILE_WRITE_DATA* = 0x00000002 # file & pipe
 
 # Error Constants
-const
-  ERROR_FILE_NOT_FOUND* = 2
+const 
+  ERROR_FILE_NOT_FOUND* = 2 ## https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
   ERROR_PATH_NOT_FOUND* = 3
   ERROR_ACCESS_DENIED* = 5
   ERROR_NO_MORE_FILES* = 18
   ERROR_LOCK_VIOLATION* = 33
   ERROR_HANDLE_EOF* = 38
+  ERROR_FILE_EXISTS* = 80
   ERROR_BAD_ARGUMENTS* = 165
 
 proc duplicateHandle*(hSourceProcessHandle: Handle, hSourceHandle: Handle,

--- a/tests/stdlib/ttempfiles.nim
+++ b/tests/stdlib/ttempfiles.nim
@@ -1,11 +1,17 @@
-import std/[os, tempfiles]
+discard """
+  joinable: false # not strictly necessary
+"""
 
+import std/tempfiles
+import std/[os, nre]
 
-doAssert createTempDir("nim", "tmp") != createTempDir("nim", "tmp")
+const
+  prefix = "D20210502T100442" # safety precaution to only affect files/dirs with this prefix
+  suffix = ".tmp"
 
 block:
-  var t1 = createTempFile("nim", ".tmp")
-  var t2 = createTempFile("nim", ".tmp")
+  var t1 = createTempFile(prefix, suffix)
+  var t2 = createTempFile(prefix, suffix)
   defer:
     close(t1.cfile)
     close(t2.cfile)
@@ -21,3 +27,23 @@ block:
   t1.cfile.setFilePos 0
   doAssert readAll(t1.cfile) == s
 
+block: # createTempDir
+  doAssertRaises(OSError): discard createTempDir(prefix, suffix, "nonexistent")
+
+  block:
+    let dir1 = createTempDir(prefix, suffix)
+    let dir2 = createTempDir(prefix, suffix)
+    defer:
+      removeDir(dir1)
+      removeDir(dir2)
+    doAssert dir1 != dir2
+
+    doAssert dirExists(dir1)
+    doAssert dir1.lastPathPart.contains(re"^D20210502T100442(\w+).tmp$")
+    doAssert dir1.parentDir == getTempDir()
+
+  block:
+    let dir3 = createTempDir(prefix, "_mytmp", ".")
+    doAssert dir3.lastPathPart.contains(re"^D20210502T100442(\w+)_mytmp$")
+    doAssert dir3.parentDir == "." # not getCurrentDir(): we honor the absolute/relative state of input `dir`
+    removeDir(dir3)

--- a/tests/stdlib/ttempfiles.nim
+++ b/tests/stdlib/ttempfiles.nim
@@ -6,12 +6,18 @@ doAssert createTempDir("nim", "tmp") != createTempDir("nim", "tmp")
 block:
   var t1 = createTempFile("nim", ".tmp")
   var t2 = createTempFile("nim", ".tmp")
+  defer:
+    close(t1.cfile)
+    close(t2.cfile)
+    removeFile(t1.path)
+    removeFile(t2.path)
+
   doAssert t1.path != t2.path
 
-  write(t1.fd, "1234")
-  doAssert readAll(t2.fd) == ""
+  let s = "1234"
+  write(t1.cfile, s)
+  doAssert readAll(t2.cfile) == ""
+  doAssert readAll(t1.cfile) == ""
+  t1.cfile.setFilePos 0
+  doAssert readAll(t1.cfile) == s
 
-  close(t1.fd)
-  close(t2.fd)
-  removeFile(t1.path)
-  removeFile(t2.path)


### PR DESCRIPTION
* closes https://github.com/nim-lang/Nim/pull/17914 by proposing different semantics: we don't check whether dir exists (TOCTOU etc), and instead let the OS report errors directly; `genTempPath` doesn't require `dir` to exist since it doesn't touch the filesystem, unlike `createTempFile`, `createTempDir`
* avoid using exceptions in the regular case and only keep generating candidates when candidatefile/dir exists, otherwise just let the code raise as usual. As a result, if it fails (because say the directory doesn't exist or isn't writable), it'll fail immediately, instead of after `nimTempPathLength` pointless attempts, furthermore and as consequence, it'll now report the OS's error and correct stacktrace (eg: `Error: unhandled exception: Permission denied, Additional info: "/tmp/d01/d02/a1x6ZRD63xa2" [OSError]`) instead of a generic one (eg: `Failed to create a temporary file under directory /tmp/d01/d02 [IOError]`) which doesn't tell you why it failed
* changed exception to form IOError to OSError because that's what the other failures (eg permission errors etc) would give anyways
* rename `fd` to `cfile`, IMO `cfile` is a great name for a `File` variable (maybe we can add ot `nep1`?) that can be used in different APIs in future, to make it clear it's a File and not a filename, or file descriptor (a `cint`) etc
* added `runnableExamples`, they're intentionally a bit more rich than simply calling `createTempDir`, `createTempFile` and illustrate how user can use those, promote stdlib, etc

## future work
- [ ] address this comment: https://github.com/nim-lang/Nim/pull/17914#discussion_r624575717
> What kind of API is that anyway... "prefix" and "suffix"? What if "prefix" contains a slash? Strings suck.

- [ ] how about making `getLastError()` work on both posix + windows instead of having only errno on posix and `getLastError()` on windows?
- [ ] add more tests (to `ttempfiles.nim`)
- [ ] we need a new API `os.pathMatches`, to replace:
```
assert path.lastPathPart.contains(re"^D20210501T170028(\w+)end$")
with:
assert path.lastPathPart.pathMatches("D20210501T170028*end")
```
(ie, glob pattern) => https://github.com/timotheecour/Nim/issues/719
- [ ] figure out whether we should make IOError a subclass of IOError, at least it's weird that `epipe` gives IOError vs OSError on posix vs windows (refs `except IOError, OSError:` in nimsuggest/tester.nim)
- [ ] make prefix, suffix optional; expose `nimTempPathLength` as parameter (named `randLen` maybe) to allow caller to specify length
- [ ] offer a destructor based API so that the file cleans up by itself (or gets forwarded via uniqueptr)