### PR TITLE
add os.isPortableFilename

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -63,6 +63,8 @@
 - Nim compiler now adds ASCII unit separator `\31` before a newline for every generated
   message (potentially multiline), so tooling can tell when messages start and end.
 
+- Added `os.isPortableFilename` and deprecated `os.isValidFilename`.
+
 
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -82,6 +82,7 @@ since (1, 1):
     ## See also `isPortableFilename`.
     ##
     ## Mac bans ``{':', `/`, '\0'}``, Linux bans ``{`/`, '\0'}``, Windows bans all of these.
+    ##
     ## .. Note:: other characters that may cause problems are non-printable characters, e.g.
     ##    ascii characters in the range `0..31`, or characters not in the range `128..255`.
     invalidFilenames* = [
@@ -3524,11 +3525,12 @@ func isPortableFilename*(filename: string, maxLen = windowsFilenameMaxLen): bool
   ##
   ## This is useful if you want to copy or save files across Windows, Linux, Mac, etc.
   ## It uses `invalidFilenameChars`, `invalidFilenames` and `maxLen` to verify `filename`.
+  ##
   ## .. Note:: this can also be used for validating dir components, but note that
   ##   windows paths have other limits, see `windowsPathMaxLen`, `windowsDirPartMaxLen`, `windowsDirMaxLen`.
   runnableExamples:
     block:
-      assert isPortableFilename("abc", maxLen = 3) # `maxLen` excludes the trailing '\0'
+      assert isPortableFilename("abc", maxLen = 3) # `maxLen` excludes the trailing ``\0``
       assert not isPortableFilename("abcd", maxLen = 3)
 
     for name in [

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -49,18 +49,57 @@ import strutils, pathnorm
 const weirdTarget = defined(nimscript) or defined(js)
 
 since (1, 1):
+  const 
+    windowsPathMaxLen* = 259 ## Maximum path length on windows excluding a terminating '\0'.
+      # See also https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
+      # This is intentionally exposed for all platforms, and prefixed with `windows`,
+      # so clients can write portable code.
+      # This corresponds to `MAX_PATH` = 260 which include trailings '\0'.
+
   const
-    invalidFilenameChars* = {'/', '\\', ':', '*', '?', '"', '<', '>', '|', '^', '\0'} ## \
-    ## Characters that may produce invalid filenames across Linux, Windows, Mac, etc.
-    ## You can check if your filename contains these char and strip them for safety.
-    ## Mac bans ``':'``, Linux bans ``'/'``, Windows bans all others.
+    windowsFilenameMaxLen* = 255 ## Maximum filename length on windows, e.g., 255 consecutive 'a' is valid.
+    # it's hard to find official docs regarding whether it includes or excludes terminating '\0', but
+    # this link shows it excludes it: https://arstechnica.com/civis/viewtopic.php?f=17&t=1466908
+    # the doc comment makes this hopefully clear. '\0' is only meaningful for the whole path, not a path component.
+    # see also `lpMaximumComponentLength`.
+
+  const
+    windowsDirPartMaxLen* = 243
+      ## Maximum length of a directory component on windows, e.g. `foo` has length 3.
+
+    windowsDirMaxLen* = 246
+      ## Maximum length of a directory name on windows, including the drive prefix, e.g. `C:\a\foo` has length 8.
+      ##
+      ## This is such that you can always create an `8.3` file (e.g. `12345678.txt`) inside it, e.g.:
+      ## 246 + 1('\') + 12 + 1('\0') = 259 + 1
+      # refs https://social.technet.microsoft.com/Forums/windows/en-US/43945b2c-f123-46d7-9ba9-dd6abc967dd4/maximum-path-length-limitation-on-windows-is-255-or-247?forum=w7itprogeneral
+      # offers a good explanation; see also: https://en.wikipedia.org/wiki/8.3_filename
+
+  const
+    invalidFilenameChars* = {'/', '\\', ':', '*', '?', '"', '<', '>', '|', '\0'} ## \
+    ## Chars that may produce invalid filenames across Linux, Windows, Mac, etc.
+    ## You can check if your filename contains these chars and strip them for safety,
+    ## See also `isPortableFilename`.
+    ##
+    ## Mac bans `{':', `/`, '\0'}`, Linux bans `{`/`, '\0'}`, Windows bans all of these.
+    ## .. Note:: other characters that may cause problems are non-printable characters, e.g.
+    ##    ascii characters in the range 0..31, or characters not in the range `128..255`.
     invalidFilenames* = [
       "CON", "PRN", "AUX", "NUL",
-      "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-      "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"] ## \
+      "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+      "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"] ## \
     ## Filenames that may be invalid across Linux, Windows, Mac, etc.
     ## You can check if your filename match these and rename it for safety
     ## (Currently all invalid filenames are from Windows only).
+    ##
+    ## Example: `con.txt` and `CON` are invalid, but `con.bar.txt` is valid.
+
+#[
+xxx add `runnableExamples` pending https://github.com/timotheecour/Nim/issues/716
+xxx we also need to handle this rule: `Use any character in the current code page for a name, including Unicode characters and characters in the extended character set (128–255), except for the following: [...]`
+for e.g., `char(1)` may be invalid.
+refs: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+]#
 
 when weirdTarget:
   discard
@@ -3480,31 +3519,55 @@ proc setLastModificationTime*(file: string, t: times.Time) {.noWeirdTarget.} =
     discard h.closeHandle
     if res == 0'i32: raiseOSError(osLastError(), file)
 
-func isValidFilename*(filename: string, maxLen = 259.Positive): bool {.since: (1, 1).} =
-  ## Returns true if ``filename`` is valid for crossplatform use.
+func isPortableFilename*(filename: string, maxLen = windowsFilenameMaxLen): bool {.since: (1, 5, 1).} =
+  ## Returns true if `filename` is portable for cross-platform use.
   ##
   ## This is useful if you want to copy or save files across Windows, Linux, Mac, etc.
-  ## You can pass full paths as argument too, but func only checks filenames.
-  ## It uses ``invalidFilenameChars``, ``invalidFilenames`` and ``maxLen`` to verify the specified ``filename``.
-  ##
-  ## .. code-block:: nim
-  ##   assert not isValidFilename(" foo")    ## Leading white space
-  ##   assert not isValidFilename("foo ")    ## Trailing white space
-  ##   assert not isValidFilename("foo.")    ## Ends with Dot
-  ##   assert not isValidFilename("con.txt") ## "CON" is invalid (Windows)
-  ##   assert not isValidFilename("OwO:UwU") ## ":" is invalid (Mac)
-  ##   assert not isValidFilename("aux.bat") ## "AUX" is invalid (Windows)
-  ##
+  ## It uses `invalidFilenameChars`, `invalidFilenames` and `maxLen` to verify `filename`.
+  ## .. Note:: this can also be used for validating dir components, but note that
+  ##   windows paths have other limits, see `windowsPathMaxLen`, `windowsDirPartMaxLen`, `windowsDirMaxLen`.
+  runnableExamples:
+    block:
+      assert isPortableFilename("abc", maxLen = 3) # `maxLen` excludes the trailing '\0'
+      assert not isPortableFilename("abcd", maxLen = 3)
+
+    for name in [
+      "\xA0foo", # no break-space is valid
+      "files.tar.gz", ".htaccess",
+      "with some internal spaces .txt", # so long ' ' is not leading/trailing
+      "mixed_CASE_",
+      "con.foo.txt", # despite `con` being in `invalidFilenames`.
+    ]:
+      assert isPortableFilename(name), name
+
+    for name in [
+        "", # empty
+        "foo/bar", r"foo\bar", # contains `/` or ``\``
+        "foo:bar", # doesn't work in some osx programs
+        " foo", "foo ", # leading/trailing ' ' is invalid in some windows programs
+        "foo.", # trailing `.`
+        "con", "CON", "con.txt", "AUX.bat", # see `invalidFilenames`.
+      ]:
+      assert not isPortableFilename(name), name
   # https://docs.microsoft.com/en-us/dotnet/api/system.io.pathtoolongexception
+  # https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
   # https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx
-  result = true
-  let f = filename.splitFile()
-  if unlikely(f.name.len + f.ext.len > maxLen or
-    f.name[0] == ' ' or f.name[^1] == ' ' or f.name[^1] == '.' or
-    find(f.name, invalidFilenameChars) != -1): return false
-  for invalid in invalidFilenames:
-    if cmpIgnoreCase(f.name, invalid) == 0: return false
+  # https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/file-folder-name-whitespace-characters
+  # Note, a trailing '\0' is only meaningful when discussing path length, not filename length.
+  # https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
+  # super helpful explanation regarding path length limitations: https://social.technet.microsoft.com/Forums/windows/en-US/43945b2c-f123-46d7-9ba9-dd6abc967dd4/maximum-path-length-limitation-on-windows-is-255-or-247?forum=w7itprogeneral
+  if filename.len > maxLen: result = false
+  elif filename.len == 0: result = false
+  elif filename[0] == ' ': result = false
+  elif filename[^1] in {' ', '.'}: result = false
+  elif find(filename, invalidFilenameChars) != -1: result = false
+    # xxx also exclude characters not in `128..255` ?
+  else:
+    let f = filename.splitFile
+    for a in invalidFilenames:
+      if cmpIgnoreCase(f.name, a) == 0: return false
+    result = true
 
 # deprecated declarations
 when not defined(nimscript):
@@ -3514,3 +3577,7 @@ when not defined(nimscript):
     template existsDir*(args: varargs[untyped]): untyped {.deprecated: "use dirExists".} =
       dirExists(args)
   # {.deprecated: [existsFile: fileExists].} # pending bug #14819; this would avoid above mentioned issue
+
+func isValidFilename*(path: string, maxLen = windowsFilenameMaxLen): bool {.since: (1, 1), deprecated: "use `path.extractFilename.isPortableFilename`".} =
+  ## Returns `path.extractFilename.isPortableFilename(maxLen)`.
+  result = path.extractFilename.isPortableFilename(maxLen)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -50,17 +50,17 @@ const weirdTarget = defined(nimscript) or defined(js)
 
 since (1, 1):
   const 
-    windowsPathMaxLen* = 259 ## Maximum path length on windows excluding a terminating '\0'.
+    windowsPathMaxLen* = 259 ## Maximum path length on windows excluding a terminating ``\0``.
       # See also https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
       # This is intentionally exposed for all platforms, and prefixed with `windows`,
       # so clients can write portable code.
-      # This corresponds to `MAX_PATH` = 260 which include trailings '\0'.
+      # This corresponds to `MAX_PATH` = 260 which include trailings ``\0``.
 
   const
-    windowsFilenameMaxLen* = 255 ## Maximum filename length on windows, e.g., 255 consecutive 'a' is valid.
-    # it's hard to find official docs regarding whether it includes or excludes terminating '\0', but
+    windowsFilenameMaxLen* = 255 ## Maximum filename length on windows, e.g., 255 consecutive `a` is valid.
+    # it's hard to find official docs regarding whether it includes or excludes terminating ``\0``, but
     # this link shows it excludes it: https://arstechnica.com/civis/viewtopic.php?f=17&t=1466908
-    # the doc comment makes this hopefully clear. '\0' is only meaningful for the whole path, not a path component.
+    # the doc comment makes this hopefully clear. ``\0`` is only meaningful for the whole path, not a path component.
     # see also `lpMaximumComponentLength`.
 
   const
@@ -68,10 +68,10 @@ since (1, 1):
       ## Maximum length of a directory component on windows, e.g. `foo` has length 3.
 
     windowsDirMaxLen* = 246
-      ## Maximum length of a directory name on windows, including the drive prefix, e.g. `C:\a\foo` has length 8.
+      ## Maximum length of a directory name on windows, including the drive prefix, e.g. ``C:\a\foo`` has length 8.
       ##
-      ## This is such that you can always create an `8.3` file (e.g. `12345678.txt`) inside it, e.g.:
-      ## 246 + 1('\') + 12 + 1('\0') = 259 + 1
+      ## This is such that you can always create an ``8.3`` file (e.g. ``12345678.txt``) inside it, e.g.:
+      ## ``246 + 1('\') + 12 + 1('\0') = 259 + 1``
       # refs https://social.technet.microsoft.com/Forums/windows/en-US/43945b2c-f123-46d7-9ba9-dd6abc967dd4/maximum-path-length-limitation-on-windows-is-255-or-247?forum=w7itprogeneral
       # offers a good explanation; see also: https://en.wikipedia.org/wiki/8.3_filename
 
@@ -81,9 +81,9 @@ since (1, 1):
     ## You can check if your filename contains these chars and strip them for safety,
     ## See also `isPortableFilename`.
     ##
-    ## Mac bans `{':', `/`, '\0'}`, Linux bans `{`/`, '\0'}`, Windows bans all of these.
+    ## Mac bans ``{':', `/`, '\0'}``, Linux bans ``{`/`, '\0'}``, Windows bans all of these.
     ## .. Note:: other characters that may cause problems are non-printable characters, e.g.
-    ##    ascii characters in the range 0..31, or characters not in the range `128..255`.
+    ##    ascii characters in the range `0..31`, or characters not in the range `128..255`.
     invalidFilenames* = [
       "CON", "PRN", "AUX", "NUL",
       "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -619,32 +619,13 @@ block: # normalizePathEnd
     doAssert r"E:/".normalizePathEnd(trailingSep = true) == r"E:\"
     doAssert "/".normalizePathEnd == r"\"
 
-block: # isValidFilename
-  # Negative Tests.
-  doAssert not isValidFilename("abcd", maxLen = 2)
-  doAssert not isValidFilename("0123456789", maxLen = 8)
-  doAssert not isValidFilename("con")
-  doAssert not isValidFilename("aux")
-  doAssert not isValidFilename("prn")
-  doAssert not isValidFilename("OwO|UwU")
-  doAssert not isValidFilename(" foo")
-  doAssert not isValidFilename("foo ")
-  doAssert not isValidFilename("foo.")
-  doAssert not isValidFilename("con.txt")
-  doAssert not isValidFilename("aux.bat")
-  doAssert not isValidFilename("prn.exe")
-  doAssert not isValidFilename("nim>.nim")
-  doAssert not isValidFilename(" foo.log")
-  # Positive Tests.
-  doAssert isValidFilename("abcd", maxLen = 42.Positive)
-  doAssert isValidFilename("c0n")
-  doAssert isValidFilename("foo.aux")
-  doAssert isValidFilename("bar.prn")
-  doAssert isValidFilename("OwO_UwU")
-  doAssert isValidFilename("cron")
-  doAssert isValidFilename("ux.bat")
-  doAssert isValidFilename("nim.nim")
-  doAssert isValidFilename("foo.log")
+block: # isPortableFilename
+  doAssert isPortableFilename("abc", maxLen = 3)
+  doAssert not isPortableFilename("abcd", maxLen = 3)
+  for a in ["con", "aux", "prn", "OwO|UwU", " foo", "foo ", "foo.", "con.txt", "aux.bat", "prn.exe", "nim>.nim", " foo.log"]:
+    doAssert not isPortableFilename(a), a
+  for a in ["c0n", "foo.aux", "bar.prn", "OwO_UwU", "cron", "ux.bat", "nim.nim", "foo.log", "foo.bar.baz", "foo bar .baz"]:
+    doAssert isPortableFilename(a), a
 
 import sugar
 


### PR DESCRIPTION
* add os.isPortableFilename, deprecate `isValidFilename`
* close https://github.com/nim-lang/Nim/issues/17922
* every change is intentional, please read carefully

## future work
- [ ] consider what to do with chars not in the range `128..255` (pre-existing so can be deferred to future work)

## links
* https://superuser.com/questions/326103/what-are-invalid-characters-for-a-file-name-under-os-x discusses `:` on osx
* https://stackoverflow.com/a/2703882/1426932
> The control characters 0x00-0x1f and 0x7f are also invalid on Windows
* https://en.wikipedia.org/wiki/Filename
* com0, lpt0 seem valid according to https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN (and unlike what's mentioned in https://en.wikipedia.org/wiki/Filename)
* https://www.boost.org/doc/libs/1_36_0/libs/filesystem/doc/portability_guide.htm