### PR TITLE
add logging to help investigate why tests/vm/tconst.nim is flaky

### DIFF
--- a/tests/vm/tconst.nim
+++ b/tests/vm/tconst.nim
@@ -28,7 +28,7 @@ template main() =
     Compiled at: $2, $3
     """ % [NimVersion & spaces(44-len(NimVersion)), CompileDate, CompileTime]
     let b = $a
-    doAssert CompileTime in b
+    doAssert CompileTime in b, $(b, CompileTime)
     doAssert NimVersion in b
 
 static: main()


### PR DESCRIPTION
refs https://github.com/timotheecour/Nim/issues/718

CompileTime should be cached (as can be verified by writing tests), so it's not clear how https://github.com/timotheecour/Nim/issues/718 could've ever happened but at least next time this happens we'll have more info