### PR TITLE
`{.used: symbol}`: fixes lots of issues with UnusedImport, XDeclaredButNotUsed, etc; fix #13185,  #17511, #17510, #14246

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -344,6 +344,9 @@
 
 - `typeof(voidStmt)` now works and returns `void`.
 
+- `{.used.}` now accepts symbols, e.g. `{.used: mymodule.}` or `{.used: myFun.}`.
+
+
 ## Compiler changes
 
 - Added `--declaredlocs` to show symbol declaration location in messages.

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -851,6 +851,8 @@ type
   TSym* {.acyclic.} = object of TIdObj # Keep in sync with PackedSym
     # proc and type instantiations are cached in the generic symbol
     case kind*: TSymKind
+    of skModule:
+      realModule*: PSym # for `createModuleAlias`
     of routineKinds:
       #procInstCache*: seq[PInstantiation]
       gcUnsafetyReason*: PSym  # for better error messages wrt gcsafe
@@ -1493,6 +1495,13 @@ proc createModuleAlias*(s: PSym, id: ItemId, newIdent: PIdent, info: TLineInfo;
   result.position = s.position
   result.loc = s.loc
   result.annex = s.annex
+  result.realModule = s # xxx can we just use id ?
+
+proc resolveModuleAlias*(s: PSym): PSym =
+  assert s.kind == skModule
+  result = s
+  if result.realModule != nil: # owner is unrelated
+    result = result.realModule
 
 proc initStrTable*(x: var TStrTable) =
   x.counter = 0

--- a/compiler/ic/ic.nim
+++ b/compiler/ic/ic.nim
@@ -394,11 +394,15 @@ proc storeSym*(s: PSym; c: var PackedEncoder; m: var PackedModule): PackedItemId
     storeNode(p, s, ast)
     storeNode(p, s, constraint)
 
-    if s.kind in {skLet, skVar, skField, skForVar}:
+    case s.kind
+    of {skLet, skVar, skField, skForVar}:
       c.addMissing s.guard
       p.guard = s.guard.safeItemId(c, m)
       p.bitsize = s.bitsize
       p.alignment = s.alignment
+    of skModule:
+      p.realModule = s.realModule.safeItemId(c, m)
+    else: discard
 
     p.externalName = toLitId(if s.loc.r.isNil: "" else: $s.loc.r, m)
     p.locFlags = s.loc.flags
@@ -847,10 +851,14 @@ proc symBodyFromPacked(c: var PackedDecoder; g: var PackedModuleGraph;
   when hasFFI:
     result.cname = g[si].fromDisk.strings[s.cname]
 
-  if s.kind in {skLet, skVar, skField, skForVar}:
+  case s.kind
+  of {skLet, skVar, skField, skForVar}:
     result.guard = loadSym(c, g, si, s.guard)
     result.bitsize = s.bitsize
     result.alignment = s.alignment
+  of skModule:
+    result.realModule = loadSym(c, g, si, s.realModule)
+  else: discard
   result.owner = loadSym(c, g, si, s.owner)
   let externalName = g[si].fromDisk.strings[s.externalName]
   if externalName != "":

--- a/compiler/ic/packed_ast.nim
+++ b/compiler/ic/packed_ast.nim
@@ -67,6 +67,7 @@ type
     when hasFFI:
       cname*: LitId
     constraint*: NodeId
+    realModule*: PackedItemId
 
   PackedType* = object
     kind*: TTypeKind

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -285,13 +285,14 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
     c.graph.importStack.setLen(L)
     # we cannot perform this check reliably because of
     # test: modules/import_in_config) # xxx is that still true?
-    if result.resolveModuleAlias == c.module:
+    let realModuule = result.resolveModuleAlias
+    if realModuule == c.module:
       localError(c.config, n.info, "module '$1' cannot import itself" % c.module.name.s)
-    if sfDeprecated in result.flags:
-      if result.constraint != nil:
-        message(c.config, n.info, warnDeprecated, result.constraint.strVal & "; " & result.name.s & " is deprecated")
+    if sfDeprecated in realModuule.flags:
+      if realModuule.constraint != nil:
+        message(c.config, n.info, warnDeprecated, realModuule.constraint.strVal & "; " & realModuule.name.s & " is deprecated")
       else:
-        message(c.config, n.info, warnDeprecated, result.name.s & " is deprecated")
+        message(c.config, n.info, warnDeprecated, realModuule.name.s & " is deprecated")
     suggestSym(c.graph, n.info, result, c.graph.usageSym, false)
     importStmtResult.add newSymNode(result, n.info)
     #newStrNode(toFullPath(c.config, f), n.info)

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -305,6 +305,9 @@ proc impMod(c: PContext; it: PNode; importStmtResult: PNode) =
     addDecl(c, m, it.info) # add symbol to symbol table of module
     importAllSymbols(c, m)
     #importForwarded(c, m.ast, emptySet, m)
+    for s in allSyms(c.graph, m): # fixes bug #17510, for re-exported symbols
+      if s.owner != m.resolveModuleAlias:
+        c.exportIndirections.incl((m.id, s.id))
 
 proc evalImport*(c: PContext, n: PNode): PNode =
   result = newNodeI(nkImportStmt, n.info)

--- a/compiler/importer.nim
+++ b/compiler/importer.nim
@@ -285,14 +285,14 @@ proc myImportModule(c: PContext, n: var PNode, importStmtResult: PNode): PSym =
     c.graph.importStack.setLen(L)
     # we cannot perform this check reliably because of
     # test: modules/import_in_config) # xxx is that still true?
-    let realModuule = result.resolveModuleAlias
-    if realModuule == c.module:
+    let realModule = result.resolveModuleAlias
+    if realModule == c.module:
       localError(c.config, n.info, "module '$1' cannot import itself" % c.module.name.s)
-    if sfDeprecated in realModuule.flags:
-      if realModuule.constraint != nil:
-        message(c.config, n.info, warnDeprecated, realModuule.constraint.strVal & "; " & realModuule.name.s & " is deprecated")
+    if sfDeprecated in realModule.flags:
+      if realModule.constraint != nil:
+        message(c.config, n.info, warnDeprecated, realModule.constraint.strVal & "; " & realModule.name.s & " is deprecated")
       else:
-        message(c.config, n.info, warnDeprecated, realModuule.name.s & " is deprecated")
+        message(c.config, n.info, warnDeprecated, realModule.name.s & " is deprecated")
     suggestSym(c.graph, n.info, result, c.graph.usageSym, false)
     importStmtResult.add newSymNode(result, n.info)
     #newStrNode(toFullPath(c.config, f), n.info)

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -62,6 +62,7 @@ type
     warnStrictNotNil = "StrictNotNil",
     warnCannotOpen = "CannotOpen",
     warnFileChanged = "FileChanged",
+    warnDuplicateModuleImport = "DuplicateModuleImport",
     warnUser = "User",
 
     hintSuccess = "Success", hintSuccessX = "SuccessX", hintBuildMode = "BuildMode",
@@ -140,6 +141,7 @@ const
     warnStrictNotNil: "$1",
     warnCannotOpen: "cannot open: $1",
     warnFileChanged: "file changed: $1",
+    warnDuplicateModuleImport: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -282,6 +282,8 @@ proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope) =
         # maybe they can be made skGenericParam as well.
         if s.typ != nil and tfImplicitTypeParam notin s.typ.flags and
            s.typ.kind != tyGenericParam:
+          # xxx D20210504T200053:here these should be sorted to have reproducible errors, in particular
+          # across 32 vs 64 bit; can be done by buffering those and then sorting.
           message(c.config, s.info, hintXDeclaredButNotUsed, s.name.s)
     s = nextIter(it, scope.symbols)
 

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -10,7 +10,7 @@
 ## implements some little helper passes
 
 import
-  ast, passes, idents, msgs, options, lineinfos
+  ast, passes, msgs, options, lineinfos
 
 from modulegraphs import ModuleGraph, PPassContext
 

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -14,7 +14,7 @@ import
   options, ast, llstream, msgs,
   idents,
   syntaxes, modulegraphs, reorder,
-  lineinfos, pathutils, wordrecg
+  lineinfos, pathutils
 from parser import parseString
 from sugar import dup
 from strutils import `%`

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1219,6 +1219,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
             let ni = it[1]
             block:
               let sym2 = qualifiedLookUp(c, ni, {checkUndeclared, checkModule})
+              # dbg sym2, it, ni
               sym2.flags.incl sfUsed
         else:
           noVal(c, it)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1212,22 +1212,13 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wBoolDefine:
         sym.magic = mBoolDefine
       of wUsed:
-        dbg sym
         if sym == nil or sym.kind == skModule:
-          dbg it.kind, it
           if it.kind != nkExprColonExpr:
-          # if it.kind notin nkCallKinds:
             invalidPragma(c, it)
           else:
             let ni = it[1]
             block:
-            # for i in 1..it.len:
-              # let ni = it[i]
-              # dbg ni, ni.kind
               let sym2 = qualifiedLookUp(c, ni, {checkUndeclared, checkModule})
-              # let sym2 = considerQuotedIdent(c, it)
-              dbg sym2
-              dbg sym2, sym2.kind
               sym2.flags.incl sfUsed
         else:
           noVal(c, it)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1214,8 +1214,6 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wUsed:
         case it.kind
         of nkExprColonExpr: # {.used: mysym.}
-          # if sym != nil or sym.kind != skModule:
-          # localError(c.config, it.info, "'this' pragma is allowed to have zero or one arguments")
           let sym2 = qualifiedLookUp(c, it[1], {checkUndeclared, checkModule})
           assert sym2 != nil # PRTEMP: localError
           sym2.flags.incl sfUsed

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1212,18 +1212,17 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wBoolDefine:
         sym.magic = mBoolDefine
       of wUsed:
-        if sym == nil or sym.kind == skModule:
-          if it.kind != nkExprColonExpr:
-            invalidPragma(c, it)
-          else:
-            let ni = it[1]
-            block:
-              let sym2 = qualifiedLookUp(c, ni, {checkUndeclared, checkModule})
-              # dbg sym2, it, ni
-              sym2.flags.incl sfUsed
-        else:
-          noVal(c, it)
-          sym.flags.incl sfUsed
+        case it.kind
+        of nkExprColonExpr: # {.used: mysym.}
+          # if sym != nil or sym.kind != skModule:
+          # localError(c.config, it.info, "'this' pragma is allowed to have zero or one arguments")
+          let sym2 = qualifiedLookUp(c, it[1], {checkUndeclared, checkModule})
+          assert sym2 != nil # PRTEMP: localError
+          sym2.flags.incl sfUsed
+        of nkIdent: # {.used.}
+          if sym == nil: invalidPragma(c, it)
+          else: sym.flags.incl sfUsed
+        else: invalidPragma(c, it)
       of wLiftLocals: discard
       of wRequires, wInvariant, wAssume, wAssert:
         pragmaProposition(c, it)

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1212,9 +1212,26 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wBoolDefine:
         sym.magic = mBoolDefine
       of wUsed:
-        noVal(c, it)
-        if sym == nil: invalidPragma(c, it)
-        else: sym.flags.incl sfUsed
+        dbg sym
+        if sym == nil or sym.kind == skModule:
+          dbg it.kind, it
+          if it.kind != nkExprColonExpr:
+          # if it.kind notin nkCallKinds:
+            invalidPragma(c, it)
+          else:
+            let ni = it[1]
+            block:
+            # for i in 1..it.len:
+              # let ni = it[i]
+              # dbg ni, ni.kind
+              let sym2 = qualifiedLookUp(c, ni, {checkUndeclared, checkModule})
+              # let sym2 = considerQuotedIdent(c, it)
+              dbg sym2
+              dbg sym2, sym2.kind
+              sym2.flags.incl sfUsed
+        else:
+          noVal(c, it)
+          sym.flags.incl sfUsed
       of wLiftLocals: discard
       of wRequires, wInvariant, wAssume, wAssert:
         pragmaProposition(c, it)

--- a/compiler/suggest.nim
+++ b/compiler/suggest.nim
@@ -572,7 +572,8 @@ proc markOwnerModuleAsUsed(c: PContext; s: PSym) =
     var i = 0
     while i <= high(c.unusedImports):
       let candidate = c.unusedImports[i][0]
-      if candidate == module or c.exportIndirections.contains((candidate.id, s.id)):
+      let candidate2 = candidate.resolveModuleAlias
+      if candidate2 == module or c.exportIndirections.contains((candidate.id, s.id)):
         # mark it as used:
         c.unusedImports.del(i)
       else:

--- a/compiler/vmconv.nim
+++ b/compiler/vmconv.nim
@@ -1,4 +1,8 @@
+from std/strutils import cmpIgnoreStyle
+import std/macros
 import ast
+from idents import PIdent, IdentCache
+from lineinfos import TLineInfo
 
 template elementType*(T: typedesc): typedesc =
   typeof(block:
@@ -19,7 +23,12 @@ proc fromLit*(a: PNode, T: typedesc): auto =
 proc toLit*[T](a: T): PNode =
   ## generic type => PNode
   ## see also reverse operation `fromLit`
-  when T is string: newStrNode(nkStrLit, a)
+  # xxx also allow an optional `info` param
+  when false: discard
+  elif T is string: newStrNode(nkStrLit, a)
+  elif T is PIdent:
+    result = newNode(nkIdent)
+    result.ident = a
   elif T is Ordinal: newIntNode(nkIntLit, a.ord)
   elif T is (proc): newNode(nkNilLit)
   elif T is ref:
@@ -28,7 +37,7 @@ proc toLit*[T](a: T): PNode =
   elif T is tuple:
     result = newTree(nkTupleConstr)
     for ai in fields(a): result.add toLit(ai)
-  elif T is seq:
+  elif T is seq | array:
     result = newNode(nkBracket)
     for ai in a:
       result.add toLit(ai)
@@ -43,3 +52,80 @@ proc toLit*[T](a: T): PNode =
   else:
     static: doAssert false, "not yet supported: " & $T # add as needed
 
+type
+  GenContext* = object
+    cache*: IdentCache
+    info*: TLineInfo
+  ContextVars = seq[tuple[name: string, val: NimNode]]
+
+proc genPNodeImpl(c: NimNode, code: var NimNode, vals: ContextVars, n: NimNode): NimNode =
+  if n.kind == nnkIdent:
+    for v in vals:
+      if n.strVal.cmpIgnoreStyle(v.name) == 0:
+        return v.val
+  result = genSym(nskVar, "ret")
+  let kind2 = n.kind.ord.TNodeKind.newLit
+  code.add quote do:
+    # alternatively, get `info` from `n.info`, which requires exposing this in macros.
+    var `result` = newNodeI(`kind2`, `c`.info)
+  # keep in sync with `ast.TNode`
+  case n.kind
+  of nnkCharLit..nnkUInt64Lit:
+    let val = n.intVal.newLit
+    code.add quote do:
+      `result`.intVal = `val`
+  of nnkFloatLit..nnkFloat128Lit:
+    let val = n.floatVal.newLit
+    code.add quote do:
+      `result`.floatVal = `val`
+    let tmp = quote do:
+      `result`.floatVal = `val`
+  of nnkStrLit..nnkTripleStrLit:
+    let val = n.strVal.newLit
+    code.add quote do:
+      `result`.strVal = `val`
+  of nnkIdent:
+    let val = n.strVal.newLit
+    code.add quote do:
+      `result`.ident = getIdent(`c`.cache, `val`)
+  of nnkSym: doAssert false # not implemented, but shouldn't be needed
+  else:
+    for ni in n:
+      let reti = genPNodeImpl(c, code, vals, ni)
+      code.add quote do:
+        `result`.add `reti`
+
+macro genPNode*(c: GenContext, args: varargs[untyped]): PNode =
+  ## Converts an AST into a PNode, and works similarly to std/genasts.
+  ## This can simplify writing compiler code, avoiding to manually write `PNode` ASTs.
+  runnableExamples:
+    import idents, renderer
+    let cache = newIdentCache()
+    let a = [1,2]
+    let b = cache.getIdent("foo")
+    var c = GenContext(cache: cache)
+    let node = genPNode(c, a, b):
+      for i in 0..<3:
+        let b = @[i, 1]
+        echo (a, b, i, "abc")
+    let s = node.renderTree
+    assert s == """
+
+for i in 0 ..< 3:
+  let foo = @[i, 1]
+  echo ([1, 2], foo, i, "abc")""", s
+
+  result = newStmtList()
+  let m = args.len - 1
+  var vals: ContextVars
+  vals.setLen m
+  for i in 0..<m:
+    let ai = args[i]
+    assert ai.kind == nnkIdent, $ai.kind
+    vals[i].name = ai.repr
+    let ni = genSym(nskVar, vals[i].name)
+    vals[i].val = ni
+    result.add quote do:
+      var `ni` = toLit(`ai`)
+  let ret = genPNodeImpl(c, result, vals, args[^1])
+  result.add ret

--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -519,6 +519,7 @@ proc icTests(r: var TResults; testsDir: string, cat: Category, options: string;
 
   const tempExt = "_temp.nim"
   for it in walkDirRec(testsDir):
+  # for it in ["tests/ic/timports.nim"]: # debugging: to try a specific test
     if isTestFile(it) and not it.endsWith(tempExt):
       let nimcache = nimcacheDir(it, options, getTestSpecTarget())
       removeDir(nimcache)

--- a/tests/modules/tselfimport.nim
+++ b/tests/modules/tselfimport.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "A module cannot import itself"
+  errormsg: "module 'tselfimport' cannot import itself"
   file: "tselfimport.nim"
   line: 7
 """

--- a/tests/pragmas/mused2a.nim
+++ b/tests/pragmas/mused2a.nim
@@ -1,0 +1,29 @@
+import std/strutils
+import std/sugar
+from std/os import fileExists
+import std/enumutils as enumutils2
+import std/typetraits as typetraits2
+from std/setutils import complement
+
+{.used: strutils.}
+{.used: enumutils2.}
+{.used: complement.}
+
+proc fn1() = discard
+proc fn2*() = discard
+proc fn3() = discard
+
+let fn4 = 0
+let fn5* = 0
+let fn6 = 0
+
+const fn7 = 0
+const fn8* = 0
+const fn9 = 0
+type T1 = object
+type T2 = object
+
+{.used: fn3.}
+{.used: fn6.}
+{.used: fn9.}
+{.used: T2.}

--- a/tests/pragmas/mused2b.nim
+++ b/tests/pragmas/mused2b.nim
@@ -1,0 +1,3 @@
+import mused2c
+export mused2c
+

--- a/tests/pragmas/mused2c.nim
+++ b/tests/pragmas/mused2c.nim
@@ -1,0 +1,1 @@
+proc baz*() = discard

--- a/tests/pragmas/mused2e.nim
+++ b/tests/pragmas/mused2e.nim
@@ -1,0 +1,1 @@
+proc fnMused2e*() = discard

--- a/tests/pragmas/tused2.nim
+++ b/tests/pragmas/tused2.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--hint:conf:off --hint:link:off --hint:cc:off --hint:SuccessX:off --import:tests/pragmas/mused2e"
+  matrix: "--hint:conf:off --hint:link:off --hint:cc:off --hint:SuccessX:off --path:. --import:tests/pragmas/mused2e"
   joinable: false
   nimoutFull: true
   nimout: '''
@@ -7,16 +7,22 @@ mused2a.nim(20, 7) Hint: 'fn7' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(23, 6) Hint: 'T1' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(12, 6) Hint: 'fn1' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(16, 5) Hint: 'fn4' is declared but not used [XDeclaredButNotUsed]
+mused2a.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
 mused2a.nim(2, 11) Warning: imported and not used: 'sugar' [UnusedImport]
 mused2a.nim(3, 9) Warning: imported and not used: 'os' [UnusedImport]
 mused2a.nim(5, 23) Warning: imported and not used: 'typetraits2' [UnusedImport]
 mused2a.nim(6, 9) Warning: imported and not used: 'setutils' [UnusedImport]
-tused2.nim(31, 8) Warning: imported and not used: 'mused2a' [UnusedImport]
-tused2.nim(32, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
-tused2.nim(34, 11) Warning: imported and not used: 'strutils' [UnusedImport]
+mused2c.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
+mused2b.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
+mused2d.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
+tused2.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
+tused2.nim(42, 8) Warning: imported and not used: 'mused2a' [UnusedImport]
+tused2.nim(43, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
+tused2.nim(45, 11) Warning: imported and not used: 'strutils' [UnusedImport]
 Hint: ***SLOW, DEBUG BUILD***; -d:release makes code run faster. [BuildMode]
 '''
 """
+  # matrix: "--hint:conf:off --hint:link:off --hint:cc:off --hint:SuccessX:off --import:tests/pragmas/mused2e"
 
 #[
 xxx the `testament.isSuccess` logic makes `nimoutFull` awkward to use, forcing it to show `BuildMode`; 
@@ -27,7 +33,12 @@ should not be generated (refs bug #17510)
 ]#
 
 
-# line 30
+
+
+
+
+# line 40
+fnMused2e() # ensures `--import:tests/pragmas/mused2e` works
 import mused2a
 import mused2b
 import mused2d

--- a/tests/pragmas/tused2.nim
+++ b/tests/pragmas/tused2.nim
@@ -16,8 +16,8 @@ tused2.nim(43, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
 tused2.nim(45, 11) Warning: imported and not used: 'strutils' [UnusedImport]
 Hint: ***SLOW, DEBUG BUILD***; -d:release makes code run faster. [BuildMode]
 '''
+  disabled: "i386" # see D20210504T200053 for reason and how to fix
 """
-  # matrix: "--hint:conf:off --hint:link:off --hint:cc:off --hint:SuccessX:off --import:tests/pragmas/mused2e"
 
 #[
 xxx the `testament.isSuccess` logic makes `nimoutFull` awkward to use, forcing it to show `BuildMode`; 

--- a/tests/pragmas/tused2.nim
+++ b/tests/pragmas/tused2.nim
@@ -7,15 +7,10 @@ mused2a.nim(20, 7) Hint: 'fn7' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(23, 6) Hint: 'T1' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(12, 6) Hint: 'fn1' is declared but not used [XDeclaredButNotUsed]
 mused2a.nim(16, 5) Hint: 'fn4' is declared but not used [XDeclaredButNotUsed]
-mused2a.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
 mused2a.nim(2, 11) Warning: imported and not used: 'sugar' [UnusedImport]
 mused2a.nim(3, 9) Warning: imported and not used: 'os' [UnusedImport]
 mused2a.nim(5, 23) Warning: imported and not used: 'typetraits2' [UnusedImport]
 mused2a.nim(6, 9) Warning: imported and not used: 'setutils' [UnusedImport]
-mused2c.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
-mused2b.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
-mused2d.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
-tused2.nim(1, 2) Warning: imported and not used: 'mused2e' [UnusedImport]
 tused2.nim(42, 8) Warning: imported and not used: 'mused2a' [UnusedImport]
 tused2.nim(43, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
 tused2.nim(45, 11) Warning: imported and not used: 'strutils' [UnusedImport]
@@ -31,6 +26,11 @@ we should improve this.
 xxx tused2.nim(32, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
 should not be generated (refs bug #17510)
 ]#
+
+
+
+
+
 
 
 

--- a/tests/pragmas/tused2.nim
+++ b/tests/pragmas/tused2.nim
@@ -1,0 +1,36 @@
+discard """
+  matrix: "--hint:conf:off --hint:link:off --hint:cc:off --hint:SuccessX:off --import:tests/pragmas/mused2e"
+  joinable: false
+  nimoutFull: true
+  nimout: '''
+mused2a.nim(20, 7) Hint: 'fn7' is declared but not used [XDeclaredButNotUsed]
+mused2a.nim(23, 6) Hint: 'T1' is declared but not used [XDeclaredButNotUsed]
+mused2a.nim(12, 6) Hint: 'fn1' is declared but not used [XDeclaredButNotUsed]
+mused2a.nim(16, 5) Hint: 'fn4' is declared but not used [XDeclaredButNotUsed]
+mused2a.nim(2, 11) Warning: imported and not used: 'sugar' [UnusedImport]
+mused2a.nim(3, 9) Warning: imported and not used: 'os' [UnusedImport]
+mused2a.nim(5, 23) Warning: imported and not used: 'typetraits2' [UnusedImport]
+mused2a.nim(6, 9) Warning: imported and not used: 'setutils' [UnusedImport]
+tused2.nim(31, 8) Warning: imported and not used: 'mused2a' [UnusedImport]
+tused2.nim(32, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
+tused2.nim(34, 11) Warning: imported and not used: 'strutils' [UnusedImport]
+Hint: ***SLOW, DEBUG BUILD***; -d:release makes code run faster. [BuildMode]
+'''
+"""
+
+#[
+xxx the `testament.isSuccess` logic makes `nimoutFull` awkward to use, forcing it to show `BuildMode`; 
+we should improve this.
+
+xxx tused2.nim(32, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
+should not be generated (refs bug #17510)
+]#
+
+
+# line 30
+import mused2a
+import mused2b
+import mused2d
+import std/strutils
+baz()
+{.used: mused2d.}

--- a/tests/pragmas/tused2.nim
+++ b/tests/pragmas/tused2.nim
@@ -12,7 +12,6 @@ mused2a.nim(3, 9) Warning: imported and not used: 'os' [UnusedImport]
 mused2a.nim(5, 23) Warning: imported and not used: 'typetraits2' [UnusedImport]
 mused2a.nim(6, 9) Warning: imported and not used: 'setutils' [UnusedImport]
 tused2.nim(42, 8) Warning: imported and not used: 'mused2a' [UnusedImport]
-tused2.nim(43, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
 tused2.nim(45, 11) Warning: imported and not used: 'strutils' [UnusedImport]
 Hint: ***SLOW, DEBUG BUILD***; -d:release makes code run faster. [BuildMode]
 '''
@@ -22,10 +21,11 @@ Hint: ***SLOW, DEBUG BUILD***; -d:release makes code run faster. [BuildMode]
 #[
 xxx the `testament.isSuccess` logic makes `nimoutFull` awkward to use, forcing it to show `BuildMode`; 
 we should improve this.
-
-xxx tused2.nim(32, 8) Warning: imported and not used: 'mused2b' [UnusedImport]
-should not be generated (refs bug #17510)
 ]#
+
+
+
+
 
 
 

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -274,7 +274,7 @@ block:
   fails(foo)
 
 
-import macros, tables
+import tables
 
 var foo{.compileTime.} = [
   "Foo",


### PR DESCRIPTION
* `{.used.}` now accepts symbols, e.g. `{.used: mymodule.}` or `{.used: myFun.}`. This allows using a clean approach instead of hacks/workarounds like `discard mymodule.someSymbol` that also don't always work
* fix #13185 (`UnusedImport should not be triggered for --import:mymodule`)
* module imports are now consistently creating a module alias for all forms of imports, eg `import foo` vs `import foo as foo2` both call `createModuleAliasImpl`; this allows keeping module modifications  (eg `moduleSym.flags`) isolated from the actual imported module
* fix #17511, see [1]
* add new warning `DuplicateModuleImport` that triggers for eg on `import foo; import foo`
* fix a bug where `import foo as bar` would not show deprecation msg for foo (before PR, only `import foo` would show the deprecation msg), eg with `{.deprecated: "blah".}`
* fix #17510
* fix #14246
* relies on the recent `nimoutFull` which is critical for this kind of test

## note
* [1] #17511 has 2 components A and B, I'm fixing both:
A is the `test.nim(1, 17) Warning: imported and not used: 'sequtils' [UnusedImport]` (warning in the imported module referring to:
```nim
import sequtils as su2
export su2
```
B is the 2nd warning `test2.nim(1, 11) Warning: imported and not used: 'test' [UnusedImport]` which is a regression

## this PR also introduces `genPNode`
it simplify writing PNode-based compiler code

see the full runnableExamples in the PR:
```nim
    let a = [1,2]
    let b = cache.getIdent("foo")
    let node: PNode = genPNode(c, a, b):
      for i in 0..<3:
        let b = @[i, 1]
        echo (a, b, i, "abc")
```

## future work
(all pre-existing)
- [x] https://github.com/nim-lang/Nim/issues/17941 (generics + var/let/const/type) => https://github.com/nim-lang/Nim/pull/17942
- [ ] add tests for https://github.com/nim-lang/Nim/pull/17942
- [ ] use `{.used: module.}` to fix https://github.com/nim-lang/Nim/issues/11819 in a better, more targeted way
- [ ] add `switch("warningAsError", "UnusedImport")` to `nimStrictMode` now that it works more reliably
- [ ] see note D20210504T200053: XDeclaredButNotUsed notes should be sorted to avoid getting different results in 32 vs 64 bit