### PR TITLE
fix #14873 properly by skipping `abi` field in importc type

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -28,11 +28,6 @@ type
 
 {.push stackTrace: off.}
 
-
-proc `$`*(lock: Lock): string =
-  # workaround bug #14873
-  result = "()"
-
 proc initLock*(lock: var Lock) {.inline.} =
   ## Initializes the given lock.
   when not defined(js):

--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -102,26 +102,18 @@ else:
     SysLockObj {.importc: "pthread_mutex_t", pure, final,
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
-      when defined(linux) and defined(amd64):
-        abi: array[40 div sizeof(clong), clong]
 
     SysLockAttr {.importc: "pthread_mutexattr_t", pure, final
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
-      when defined(linux) and defined(amd64):
-        abi: array[4 div sizeof(cint), cint]  # actually a cint
 
     SysCondObj {.importc: "pthread_cond_t", pure, final,
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
-      when defined(linux) and defined(amd64):
-        abi: array[48 div sizeof(clonglong), clonglong]
 
     SysCondAttr {.importc: "pthread_condattr_t", pure, final
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
-      when defined(linux) and defined(amd64):
-        abi: array[4 div sizeof(cint), cint]  # actually a cint
 
     SysLockType = distinct cint
 

--- a/tests/stdlib/uselocks.nim
+++ b/tests/stdlib/uselocks.nim
@@ -11,5 +11,6 @@ proc use* (m: var MyType): int =
     result = 3
 
 block:
+  # bug #14873
   var l: Lock
   doAssert $l == "()"

--- a/tests/stdlib/uselocks.nim
+++ b/tests/stdlib/uselocks.nim
@@ -14,3 +14,16 @@ block:
   # bug #14873
   var l: Lock
   doAssert $l == "()"
+
+when true: # intentional
+  # bug https://github.com/nim-lang/Nim/issues/14873#issuecomment-784241605
+  type
+    Test = object
+      path: string # Removing this makes both cases work.
+      lock: Lock
+  # A: This is not fine.
+  var a = Test()
+  proc main(): void =
+    # B: This is fine.
+    var b = Test()
+  main()

--- a/tests/stdlib/uselocks.nim
+++ b/tests/stdlib/uselocks.nim
@@ -13,7 +13,9 @@ proc use* (m: var MyType): int =
 block:
   # bug #14873
   var l: Lock
-  doAssert $l == "()"
+  doAssert ($l).len > 0
+    # on posix, "()", on windows, something else, but that shouldn't be part of the spec
+    # what matters is that `$` doesn't cause the codegen bug mentioned
 
 when true: # intentional
   # bug https://github.com/nim-lang/Nim/issues/14873#issuecomment-784241605


### PR DESCRIPTION
fix #14873

I can't reproduce https://github.com/nim-lang/Nim/issues/14873 locally, can someone that can reproduces those issues please check that it fails before this PR and works after this PR?

## links:
* https://github.com/nim-lang/Nim/issues/14873#issuecomment-784241605
* https://github.com/nim-lang/Nim/issues/14873#issuecomment-832870351

/cc @shirleyquirk @xflywind @tdely

## note
if this works, we should probably do the same with other apis, eg:
```
lib/posix/posix_linux_amd64.nim:153:5:    abi: array[56 div sizeof(clong), clong]
lib/posix/posix_linux_amd64.nim:157:5:    abi: array[32 div sizeof(clong), clong]
lib/posix/posix_linux_amd64.nim:160:5:    abi: array[4 div sizeof(cint), cint]
lib/posix/posix_linux_amd64.nim:164:5:    abi: array[48 div sizeof(clonglong), clonglong]
lib/posix/posix_linux_amd64.nim:167:5:    abi: array[4 div sizeof(cint), cint]
lib/posix/posix_linux_amd64.nim:171:5:    abi: array[48 div sizeof(clong), clong]
lib/posix/posix_linux_amd64.nim:174:5:    abi: array[4 div sizeof(cint), cint]
lib/posix/posix_linux_amd64.nim:178:5:    abi: array[56 div sizeof(clong), clong]
lib/posix/posix_linux_amd64.nim:181:5:    abi: array[8 div sizeof(clong), clong]
lib/posix/posix_linux_amd64.nim:204:5:    abi: array[32 div sizeof(clong), clong]
lib/posix/posix_linux_amd64.nim:289:5:    abi: array[1024 div (8 * sizeof(culong)), culong]
lib/posix/posix_linux_amd64.nim:298:5:    abi: array[12, int]
lib/posix/posix_linux_amd64.nim:353:5:    abi: array[1024 div (8 * sizeof(clong)), clong]
lib/posix/posix_nintendoswitch.nim:132:5:    abi: array[56 div sizeof(clong), clong]
lib/posix/posix_nintendoswitch.nim:136:5:    abi: array[32 div sizeof(clong), clong]
lib/posix/posix_nintendoswitch.nim:139:5:    abi: array[4 div sizeof(cint), cint]
lib/posix/posix_nintendoswitch.nim:143:5:    abi: array[48 div sizeof(clonglong), clonglong]
lib/posix/posix_nintendoswitch.nim:146:5:    abi: array[4 div sizeof(cint), cint]
lib/posix/posix_nintendoswitch.nim:150:5:    abi: array[48 div sizeof(clong), clong]
lib/posix/posix_nintendoswitch.nim:153:5:    abi: array[4 div sizeof(cint), cint]
lib/posix/posix_nintendoswitch.nim:157:5:    abi: array[56 div sizeof(clong), clong]
lib/posix/posix_nintendoswitch.nim:160:5:    abi: array[8 div sizeof(clong), clong]
lib/posix/posix_nintendoswitch.nim:183:5:    abi: array[32 div sizeof(clong), clong]
lib/posix/posix_nintendoswitch.nim:310:5:    abi: array[((64+(sizeof(clong) * 8)-1) div (sizeof(clong) * 8)), clong]
lib/system/ansi_c.nim:37:9:        abi: array[200 div sizeof(clong), clong]
lib/system/threadlocalstorage.nim:135:9:        abi: array[56 div sizeof(clong), clong]
lib/system/threadlocalstorage.nim:194:8:       abi: array[1024 div (8 * sizeof(culong)), culong]
```
