### PR TITLE
testament :show duration also for failed tests; improve `tshould_not_work`; mitigate #17946 tchannels timeouts

### DIFF
--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -29,11 +29,17 @@ template flakyAssert*(cond: untyped, msg = "", notifySuccess = true) =
 when not defined(js):
   import std/strutils
 
-  proc greedyOrderedSubsetLines*(lhs, rhs: string): bool =
+  proc greedyOrderedSubsetLines*(lhs, rhs: string, allowPrefixMatch = false): bool =
     ## Returns true if each stripped line in `lhs` appears in rhs, using a greedy matching.
+    # xxx improve error reporting by showing the last matched pair
     iterator splitLinesClosure(): string {.closure.} =
       for line in splitLines(rhs.strip):
         yield line
+    template isMatch(lhsi, rhsi): bool =
+      if allowPrefixMatch:
+        startsWith(rhsi, lhsi):
+      else:
+        lhsi == rhsi
 
     var rhsIter = splitLinesClosure
     var currentLine = strip(rhsIter())
@@ -41,7 +47,7 @@ when not defined(js):
     for line in lhs.strip.splitLines:
       let line = line.strip
       if line.len != 0:
-        while line != currentLine:
+        while not isMatch(line, currentLine):
           currentLine = strip(rhsIter())
           if rhsIter.finished:
             return false

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -288,16 +288,18 @@ proc addResult(r: var TResults, test: TTest, target: TTarget,
                             expected = expected,
                             given = given)
   r.data.addf("$#\t$#\t$#\t$#", name, expected, given, $success)
+  template dispNonSkipped(color, outcome) =
+    maybeStyledEcho color, outcome, fgCyan, test.debugInfo, alignLeft(name, 60), fgBlue, " (", durationStr, " sec)"
   template disp(msg) =
     maybeStyledEcho styleDim, fgYellow, msg & ' ', styleBright, fgCyan, name
   if success == reSuccess:
-    maybeStyledEcho fgGreen, "PASS: ", fgCyan, test.debugInfo, alignLeft(name, 60), fgBlue, " (", durationStr, " sec)"
+    dispNonSkipped(fgGreen, "PASS: ")
   elif success == reDisabled:
     if test.spec.inCurrentBatch: disp("SKIP:")
     else: disp("NOTINBATCH:")
   elif success == reJoined: disp("JOINED:")
   else:
-    maybeStyledEcho styleBright, fgRed, failString, fgCyan, name
+    dispNonSkipped(fgRed, failString)
     maybeStyledEcho styleBright, fgCyan, "Test \"", test.name, "\"", " in category \"", test.cat.string, "\""
     maybeStyledEcho styleBright, fgRed, "Failure: ", $success
     if success in {reBuildFailed, reNimcCrash, reInstallFailed}:

--- a/testament/tests/shouldfail/tccodecheck.nim
+++ b/testament/tests/shouldfail/tccodecheck.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   ccodecheck: "baz"
 """
 

--- a/testament/tests/shouldfail/tcolumn.nim
+++ b/testament/tests/shouldfail/tcolumn.nim
@@ -1,6 +1,5 @@
 discard """
   errormsg: "undeclared identifier: 'undeclared'"
-  targets: "c"
   line: 9
   column: 7
 """

--- a/testament/tests/shouldfail/terrormsg.nim
+++ b/testament/tests/shouldfail/terrormsg.nim
@@ -1,6 +1,5 @@
 discard """
   errormsg: "wrong error message"
-  targets: "c"
   line: 9
   column: 6
 """

--- a/testament/tests/shouldfail/texitcode1.nim
+++ b/testament/tests/shouldfail/texitcode1.nim
@@ -1,4 +1,3 @@
 discard """
-  targets: "c"
   exitcode: 1
 """

--- a/testament/tests/shouldfail/tfile.nim
+++ b/testament/tests/shouldfail/tfile.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   errormsg: "undeclared identifier: 'undefined'"
   file: "notthisfile.nim"
 """

--- a/testament/tests/shouldfail/tline.nim
+++ b/testament/tests/shouldfail/tline.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   errormsg: "undeclared identifier: 'undeclared'"
   line: 10
   column: 6

--- a/testament/tests/shouldfail/tmaxcodesize.nim
+++ b/testament/tests/shouldfail/tmaxcodesize.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   maxcodesize: 1
 """
 

--- a/testament/tests/shouldfail/tnimout.nim
+++ b/testament/tests/shouldfail/tnimout.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   nimout: "Hello World!"
   action: compile
 """

--- a/testament/tests/shouldfail/tnimoutfull.nim
+++ b/testament/tests/shouldfail/tnimoutfull.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   nimout: '''
 msg1
 msg2

--- a/testament/tests/shouldfail/toutput.nim
+++ b/testament/tests/shouldfail/toutput.nim
@@ -1,5 +1,4 @@
 discard """
-  targets: "c"
   output: '''
   done
   '''

--- a/testament/tests/shouldfail/toutputsub.nim
+++ b/testament/tests/shouldfail/toutputsub.nim
@@ -1,6 +1,5 @@
 discard """
   outputsub: "something else"
-  targets: "c"
 """
 
 echo "Hello World!"

--- a/testament/tests/shouldfail/treject.nim
+++ b/testament/tests/shouldfail/treject.nim
@@ -1,6 +1,5 @@
 discard """
   action: "reject"
-  targets: "c"
 """
 
 # Because we set action="reject", we expect this line not to compile. But the

--- a/testament/tests/shouldfail/tsortoutput.nim
+++ b/testament/tests/shouldfail/tsortoutput.nim
@@ -1,6 +1,5 @@
 discard """
   sortoutput: true
-  targets: "c"
   output: '''
   2
   1

--- a/testament/tests/shouldfail/ttimeout.nim
+++ b/testament/tests/shouldfail/ttimeout.nim
@@ -1,6 +1,5 @@
 discard """
   timeout: "0.1"
-  targets: "c"
 """
 
 import os

--- a/testament/tests/shouldfail/tvalgrind.nim
+++ b/testament/tests/shouldfail/tvalgrind.nim
@@ -1,6 +1,5 @@
 discard """
   valgrind: true
-  targets: "c"
   cmd: "nim $target --gc:arc -d:useMalloc $options $file"
 """
 

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -6,6 +6,8 @@ discard """
 ## tests that don't quite fit the mold and are easier to handle via `execCmdEx`
 ## A few others could be added to here to simplify code.
 ## Note: this test is a bit slow but tests a lot of things; please don't disable.
+## Note: if needed, we could use `matrix: "-d:case1; -d:case2"` to split this
+## into several independent tests while retaining the common test helpers.
 
 import std/[strformat,os,osproc,unittest,compilesettings]
 from std/sequtils import toSeq,mapIt

--- a/tests/stdlib/tchannels.nim
+++ b/tests/stdlib/tchannels.nim
@@ -1,5 +1,5 @@
 discard """
-  timeout:  5.0 # but typically < 1s
+  timeout:  20.0 # but typically < 1s (in isolation but other tests running in parallel can affect this since based on epochTime)
   disabled: "freebsd"
   matrix: "--gc:arc --threads:on; --gc:arc --threads:on -d:danger"
 """

--- a/tests/stdlib/ttestutils.nim
+++ b/tests/stdlib/ttestutils.nim
@@ -22,3 +22,18 @@ block: # greedyOrderedSubsetLines
     not greedyOrderedSubsetLines("a1\na5", "a0\na1\na2\na3\na4\na5:suffix")
     not greedyOrderedSubsetLines("a5", "a0\na1\na2\na3\na4\nprefix:a5")
     not greedyOrderedSubsetLines("a5", "a0\na1\na2\na3\na4\na5:suffix")
+
+block: # greedyOrderedSubsetLines with allowPrefixMatch = true
+  template fn(a, b): bool =
+    greedyOrderedSubsetLines(a, b, allowPrefixMatch = true)
+  assertAll:
+    fn("a1\na3", "a0\na1\na2\na3_suffix\na4")
+    not fn("a1\na3", "a0\na1\na2\nprefix_a3\na4")
+    # these are same as above, could be refactored
+    not fn("a3\na1", "a0\na1\na2\na3\na4") # out of order
+    not fn("a1\na5", "a0\na1\na2\na3\na4") # a5 not in lhs
+
+    not fn("a1\na5", "a0\na1\na2\na3\na4\nprefix:a5")
+    fn("a1\na5", "a0\na1\na2\na3\na4\na5:suffix")
+    not fn("a5", "a0\na1\na2\na3\na4\nprefix:a5")
+    fn("a5", "a0\na1\na2\na3\na4\na5:suffix")

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -1,39 +1,50 @@
-discard """
-cmd: "testament/testament --directory:testament --colors:off --backendLogging:off --nim:$nim category shouldfail"
-action: compile
-nimout: '''
-FAIL: tests/shouldfail/tccodecheck.nim c
+const expected = """
+FAIL: tests/shouldfail/tccodecheck.nim
 Failure: reCodegenFailure
 Expected:
 baz
-FAIL: tests/shouldfail/tcolumn.nim c
+FAIL: tests/shouldfail/tcolumn.nim
 Failure: reLinesDiffer
-FAIL: tests/shouldfail/terrormsg.nim c
+FAIL: tests/shouldfail/terrormsg.nim
 Failure: reMsgsDiffer
-FAIL: tests/shouldfail/texitcode1.nim c
+FAIL: tests/shouldfail/texitcode1.nim
 Failure: reExitcodesDiffer
-FAIL: tests/shouldfail/tfile.nim c
+FAIL: tests/shouldfail/tfile.nim
 Failure: reFilesDiffer
-FAIL: tests/shouldfail/tline.nim c
+FAIL: tests/shouldfail/tline.nim
 Failure: reLinesDiffer
-FAIL: tests/shouldfail/tmaxcodesize.nim c
+FAIL: tests/shouldfail/tmaxcodesize.nim
 Failure: reCodegenFailure
 max allowed size: 1
-FAIL: tests/shouldfail/tnimout.nim c
+FAIL: tests/shouldfail/tnimout.nim
 Failure: reMsgsDiffer
-FAIL: tests/shouldfail/tnimoutfull.nim c
+FAIL: tests/shouldfail/tnimoutfull.nim
 Failure: reMsgsDiffer
-FAIL: tests/shouldfail/toutput.nim c
+FAIL: tests/shouldfail/toutput.nim
 Failure: reOutputsDiffer
-FAIL: tests/shouldfail/toutputsub.nim c
+FAIL: tests/shouldfail/toutputsub.nim
 Failure: reOutputsDiffer
-FAIL: tests/shouldfail/treject.nim c
+FAIL: tests/shouldfail/treject.nim
 Failure: reFilesDiffer
-FAIL: tests/shouldfail/tsortoutput.nim c
+FAIL: tests/shouldfail/tsortoutput.nim
 Failure: reOutputsDiffer
-FAIL: tests/shouldfail/ttimeout.nim c
+FAIL: tests/shouldfail/ttimeout.nim
 Failure: reTimeout
-FAIL: tests/shouldfail/tvalgrind.nim c
+FAIL: tests/shouldfail/tvalgrind.nim
 Failure: reExitcodesDiffer
-'''
 """
+
+import std/[os,strformat,osproc]
+import stdtest/testutils
+
+proc main =
+  const nim = getCurrentCompilerExe()
+  # TODO: bin/testament instead? like other tools (eg bin/nim, bin/nimsuggest etc)
+  let testamentExe = "testament/testament"
+  let cmd = fmt"{testamentExe} --directory:testament --colors:off --backendLogging:off --nim:{nim} category shouldfail"
+  let (outp, status) = execCmdEx(cmd)
+  doAssert status == 1, $status
+
+  let ok = greedyOrderedSubsetLines(expected, outp, allowPrefixMatch = true)
+  doAssert ok, &"\nexpected:\n{expected}\noutp:\n{outp}"
+main()

--- a/tests/testament/tshould_not_work.nim
+++ b/tests/testament/tshould_not_work.nim
@@ -1,3 +1,7 @@
+discard """
+  joinable: false
+"""
+
 const expected = """
 FAIL: tests/shouldfail/tccodecheck.nim
 Failure: reCodegenFailure


### PR DESCRIPTION
* refs #17946: mitigate tchannels timeouts (reasoning is explained in PR; let's see if it helps with #17946 at least)
* small refactor of testament test summaries, show test duration for failures (instead of just for success before this PR); useful in particular for timeout errors, but not just that
* fixes https://github.com/nim-lang/Nim/pull/16698#pullrequestreview-627522307: that PR https://github.com/nim-lang/Nim/pull/16698 had added `targets: c` to `testament/tests/shouldfail/*.nim` just to satisfy the new stricter nimout checks, which was a good thing in general but not in this case; I've fixed that by adding an optional `allowPrefixMatch = false` to `greedyOrderedSubsetLines` so that we can match by prefix instead of whole lines in such cases; it was in fact needed for this PR because of the formatting changes (with the added duration for failed tests); in fact that test was the reason the duration wasn't being shown for failed tests, until now.

## future work
(all pre-existing issues)
- [ ] the `reTimeout` logic is still buggy for several reasons: 
* because of https://github.com/nim-lang/Nim/issues/17407
* and also because the timeout is based on wall clock and if too many tests are run in parallel, other unrelated tests may affect the time it takes to run a test and exceed the timeout; maybe tests with a timeout should not run in parallel to other tests
- [ ] in tests/testament/tshould_not_work.nim, change testament/testament to bin/testament (and sync with runCI)

## EDIT
~~ugh, `tests/shouldfail/` fails because formatting changed; we need a better solution, as this keeps causing problems (eg for the same reason we had to disable non-c backend for those tests, which is an un-reasonable arbitrary limiation)~~

EDIT: fixed see update to `tests/testament/tshould_not_work.nim`
