### PR TITLE
disable tmacro_highlight on i386, refs  #17945 

### DIFF
--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -338,6 +338,10 @@ proc main() =
   else:
     for x in walkFiles(tpath / "t*.nim"):
       echo "Test ", x
+      when defined(i386):
+        if x == "nimsuggest/tests/tmacro_highlight.nim":
+          echo "skipping" # workaround bug #17945
+          continue
       let xx = expandFilename x
       when not defined(windows):
         # XXX Windows IO redirection seems bonkers:


### PR DESCRIPTION
workaround refs #17945 which keeps causing issues (3 recent unrelated PRs)

## CI failures unrelated
* https://github.com/nim-lang/Nim/issues/17325
* https://github.com/nim-lang/Nim/issues/17456