### PR TITLE
remove unsused OsPlatform.nimVM

### DIFF
--- a/lib/system/platforms.nim
+++ b/lib/system/platforms.nim
@@ -40,7 +40,7 @@ type
   OsPlatform* {.pure.} = enum ## the OS this program will run on.
     none, dos, windows, os2, linux, morphos, skyos, solaris,
     irix, netbsd, freebsd, openbsd, aix, palmos, qnx, amiga,
-    atari, netware, macos, macosx, haiku, android, js, nimVM,
+    atari, netware, macos, macosx, haiku, android, js,
     standalone, nintendoswitch
 
 const
@@ -66,7 +66,6 @@ const
               elif defined(haiku): OsPlatform.haiku
               elif defined(android): OsPlatform.android
               elif defined(js): OsPlatform.js
-              elif defined(nimVM): OsPlatform.nimVM
               elif defined(standalone): OsPlatform.standalone
               elif defined(nintendoswitch): OsPlatform.nintendoswitch
               else: OsPlatform.none


### PR DESCRIPTION
note that `nim r --eval:'echo static(defined(nimvm))'` (even before this PR), ie, nimvm isn't a defined symbol inside vm, and `OsPlatform.nimVM` doesn't make sense (besides adding confusion), so i'm removing it

example where it causes confusion: this code is wrong:
`tests/vm/tcastint.nim:101:16:  when defined nimvm:`
(i'm fixing this in https://github.com/nim-lang/Nim/pull/17954)