### PR TITLE
add astmsgs; add `declared in` msg for usage lint errors

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -464,6 +464,8 @@ const
   # consider renaming as `tyAbstractVarRange`
   abstractVarRange* = {tyGenericInst, tyRange, tyVar, tyDistinct, tyOrdinal,
                        tyTypeDesc, tyAlias, tyInferred, tySink, tyOwned}
+  abstractInst* = {tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias,
+                   tyInferred, tySink, tyOwned} # xxx what about tyStatic?
 
 type
   TTypeKinds* = set[TTypeKind]

--- a/compiler/astmsgs.nim
+++ b/compiler/astmsgs.nim
@@ -1,0 +1,23 @@
+# this module avoids ast depending on msgs or vice versa
+import std/strutils
+import options, ast, msgs
+
+proc addDeclaredLoc*(result: var string, conf: ConfigRef; sym: PSym) =
+  result.add " [$1 declared in $2]" % [sym.kind.toHumanStr, toFileLineCol(conf, sym.info)]
+
+proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
+  if optDeclaredLocs in conf.globalOptions and sym != nil:
+    addDeclaredLoc(result, conf, sym)
+
+proc addDeclaredLoc*(result: var string, conf: ConfigRef; typ: PType) =
+  # xxx figure out how to resolve `tyGenericParam`, e.g. for
+  # proc fn[T](a: T, b: T) = discard
+  # fn(1.1, "a")
+  let typ = typ.skipTypes(abstractInst + {tyStatic} - {tyRange})
+  result.add " [$1" % typ.kind.toHumanStr
+  if typ.sym != nil:
+    result.add " declared in " & toFileLineCol(conf, typ.sym.info)
+  result.add "]"
+
+proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; typ: PType) =
+  if optDeclaredLocs in conf.globalOptions: addDeclaredLoc(result, conf, typ)

--- a/compiler/linter.nim
+++ b/compiler/linter.nim
@@ -10,8 +10,9 @@
 ## This module implements the style checker.
 
 import strutils
+from sugar import dup
 
-import options, ast, msgs, idents, lineinfos, wordrecg
+import options, ast, msgs, idents, lineinfos, wordrecg, astmsgs
 
 const
   Letters* = {'a'..'z', 'A'..'Z', '0'..'9', '\x80'..'\xFF', '_'}
@@ -129,7 +130,7 @@ proc styleCheckUse*(conf: ConfigRef; info: TLineInfo; s: PSym) =
   if badName.len > 0:
     # special rules for historical reasons
     let forceHint = badName == "nnkArgList" and newName == "nnkArglist" or badName == "nnkArglist" and newName == "nnkArgList"
-    lintReport(conf, info, newName, badName, forceHint = forceHint)
+    lintReport(conf, info, newName, badName, forceHint = forceHint, extraMsg = "".dup(addDeclaredLoc(conf, s)))
 
 proc checkPragmaUse*(conf: ConfigRef; info: TLineInfo; w: TSpecialWord; pragmaName: string) =
   let wanted = $w

--- a/compiler/linter.nim
+++ b/compiler/linter.nim
@@ -9,8 +9,8 @@
 
 ## This module implements the style checker.
 
-import strutils
-from sugar import dup
+import std/strutils
+from std/sugar import dup
 
 import options, ast, msgs, idents, lineinfos, wordrecg, astmsgs
 

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -12,7 +12,7 @@
 import
   intsets, ast, astalgo, idents, semdata, types, msgs, options,
   renderer, nimfix/prettybase, lineinfos, strutils,
-  modulegraphs
+  modulegraphs, astmsgs
 
 proc ensureNoMissingOrUnusedSymbols(c: PContext; scope: PScope)
 

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -616,8 +616,8 @@ template internalAssert*(conf: ConfigRef, e: bool) =
     let arg = info2.toFileLineCol
     internalErrorImpl(conf, unknownLineInfo, arg, info2)
 
-template lintReport*(conf: ConfigRef; info: TLineInfo, beau, got: string, forceHint = false) =
-  let m = "'$1' should be: '$2'" % [got, beau]
+template lintReport*(conf: ConfigRef; info: TLineInfo, beau, got: string, forceHint = false, extraMsg = "") =
+  let m = "'$1' should be: '$2'$3" % [got, beau, extraMsg]
   let msg = if optStyleError in conf.globalOptions and not forceHint: errGenerated else: hintName
   liMessage(conf, info, msg, m, doNothing, instLoc())
 

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -17,7 +17,7 @@ import
   intsets, transf, vmdef, vm, aliases, cgmeth, lambdalifting,
   evaltempl, patterns, parampatterns, sempass2, linter, semmacrosanity,
   lowerings, plugins/active, lineinfos, strtabs, int128,
-  isolation_check, typeallowed, modulegraphs, enumtostr, concepts
+  isolation_check, typeallowed, modulegraphs, enumtostr, concepts, astmsgs
 
 when defined(nimfix):
   import nimfix/prettybase

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -11,7 +11,7 @@
 
 import
   intsets, ast, astalgo, trees, msgs, strutils, platform, renderer, options,
-  lineinfos, int128, modulegraphs
+  lineinfos, int128, modulegraphs, astmsgs
 
 type
   TPreferedDesc* = enum
@@ -65,9 +65,6 @@ const
                   tyAlias, tyInferred, tySink, tyLent, tyOwned}
   abstractRange* = {tyGenericInst, tyRange, tyDistinct, tyOrdinal, tyTypeDesc,
                     tyAlias, tyInferred, tySink, tyOwned}
-  # see also ast.abstractVarRange
-  abstractInst* = {tyGenericInst, tyDistinct, tyOrdinal, tyTypeDesc, tyAlias,
-                   tyInferred, tySink, tyOwned} # xxx what about tyStatic?
   abstractInstOwned* = abstractInst + {tyOwned}
   skipPtrs* = {tyVar, tyPtr, tyRef, tyGenericInst, tyTypeDesc, tyAlias,
                tyInferred, tySink, tyLent, tyOwned}
@@ -122,26 +119,6 @@ proc isIntLit*(t: PType): bool {.inline.} =
 
 proc isFloatLit*(t: PType): bool {.inline.} =
   result = t.kind == tyFloat and t.n != nil and t.n.kind == nkFloatLit
-
-proc addDeclaredLoc*(result: var string, conf: ConfigRef; sym: PSym) =
-  result.add " [$1 declared in $2]" % [sym.kind.toHumanStr, toFileLineCol(conf, sym.info)]
-
-proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; sym: PSym) =
-  if optDeclaredLocs in conf.globalOptions and sym != nil:
-    addDeclaredLoc(result, conf, sym)
-
-proc addDeclaredLoc*(result: var string, conf: ConfigRef; typ: PType) =
-  # xxx figure out how to resolve `tyGenericParam`, e.g. for
-  # proc fn[T](a: T, b: T) = discard
-  # fn(1.1, "a")
-  let typ = typ.skipTypes(abstractInst + {tyStatic} - {tyRange})
-  result.add " [$1" % typ.kind.toHumanStr
-  if typ.sym != nil:
-    result.add " declared in " & toFileLineCol(conf, typ.sym.info)
-  result.add "]"
-
-proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; typ: PType) =
-  if optDeclaredLocs in conf.globalOptions: addDeclaredLoc(result, conf, typ)
 
 proc addTypeHeader*(result: var string, conf: ConfigRef; typ: PType; prefer: TPreferedDesc = preferMixed; getDeclarationPath = true) =
   result.add typeToString(typ, prefer)

--- a/tests/stylecheck/tusages.nim
+++ b/tests/stylecheck/tusages.nim
@@ -1,8 +1,10 @@
 discard """
-  cmd: "nim c --styleCheck:error --styleCheck:usages $file"
-  errormsg: "'BAD_STYLE' should be: 'BADSTYLE'"
-  line: 20
+  action: reject
+  nimout: '''tusages.nim(22, 5) Error: 'BAD_STYLE' should be: 'BADSTYLE' [proc declared in tusages.nim(11, 6)]'''
+  cmd: "nim $target --styleCheck:error --styleCheck:usages $file"
 """
+
+# xxx pending bug #17960, use: matrix: "--styleCheck:error --styleCheck:usages"
 
 import strutils
 
@@ -20,4 +22,3 @@ proc toSnakeCase(s: string): string =
     BAD_STYLE(s[i])
 
 echo toSnakeCase("fooBarBaz Yes")
-

--- a/tests/tools/tlinter.nim
+++ b/tests/tools/tlinter.nim
@@ -2,12 +2,12 @@ discard """
   cmd: '''nim c --styleCheck:hint $file'''
   nimout: '''
 tlinter.nim(21, 14) Hint: 'nosideeffect' should be: 'noSideEffect' [Name]
-tlinter.nim(21, 28) Hint: 'myown' should be: 'myOwn' [Name]
+tlinter.nim(21, 28) Hint: 'myown' should be: 'myOwn' [template declared in tlinter.nim(19, 9)] [Name]
 tlinter.nim(21, 35) Hint: 'inLine' should be: 'inline' [Name]
 tlinter.nim(25, 1) Hint: 'tyPE' should be: 'type' [Name]
-tlinter.nim(23, 1) Hint: 'foO' should be: 'foo' [Name]
-tlinter.nim(27, 14) Hint: 'Foo_bar' should be: 'FooBar' [Name]
-tlinter.nim(29, 6) Hint: 'someVAR' should be: 'someVar' [Name]
+tlinter.nim(23, 1) Hint: 'foO' should be: 'foo' [proc declared in tlinter.nim(21, 6)] [Name]
+tlinter.nim(27, 14) Hint: 'Foo_bar' should be: 'FooBar' [type declared in tlinter.nim(25, 6)] [Name]
+tlinter.nim(29, 6) Hint: 'someVAR' should be: 'someVar' [var declared in tlinter.nim(27, 5)] [Name]
 tlinter.nim(32, 7) Hint: 'i_fool' should be: 'iFool' [Name]
 tlinter.nim(39, 5) Hint: 'meh_field' should be: 'mehField' [Name]
 '''


### PR DESCRIPTION
`addDeclaredLoc` really improves error messages, this PR allows using it in more context in future work, and also adds it to lint errors