### PR TITLE
Fix parseUri to sanitize urls containing ASCII newline or tab

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -299,6 +299,7 @@
 
 - Added `copyWithin` [for `seq` and `array` for JavaScript targets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin).
 
+- Added optional `strict` argument to `parseUri` of `uri` module to raise a `UriParseError` if input contains newline or tab characters, or [remove them in non-strict case](https://url.spec.whatwg.org/#concept-basic-url-parser).
 
 ## Language changes
 

--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -54,6 +54,7 @@ type
 
   UriParseError* = object of ValueError
 
+# https://url.spec.whatwg.org/#concept-basic-url-parser
 const unsafeUrlBytesToRemove = {'\t', '\r', '\n'}
 
 proc uriParseError*(msg: string) {.noreturn.} =
@@ -295,26 +296,24 @@ func parseUri*(uri: string, result: var Uri, strict = true) =
     assert res.hostname == "nim-lang.org"
     assert res.path == "/docs/manual.html"
 
-    res = initUri()
-
     # Non-strict
-    parseUri("https://nim-lang\n.org\t/docs/\nalert('msg\r\n')/?query\n=\tvalue#frag\nment", res, strict=false)
+    res = initUri()
+    parseUri("https://nim-lang\n.org\t/docs/", res, strict=false)
     assert res.scheme == "https"
     assert res.hostname == "nim-lang.org"
-    assert res.path == "/docs/alert('msg')/"
-    assert res.query == "query=value"
-    assert res.anchor == "fragment"
+    assert res.path == "/docs/"
 
-    # Strict by default
+    # Strict
     res = initUri()
     doAssertRaises(UriParseError):
-      parseUri("https://nim-lang\n.org\t/docs/\nalert('msg\r\n')/?query\n=\tvalue#frag\nment", res)
+      parseUri("https://nim-lang\n.org\t/docs/", res)
 
+  var uri = uri
   if strict:
     for c in uri:
       if c in unsafeUrlBytesToRemove: uriParseError("Invalid uri '$#'" % uri)
-
-  let uri = removeUnsafeBytesFromUri(uri)
+  else:
+    uri = removeUnsafeBytesFromUri(uri)
 
   resetUri(result)
 

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -141,6 +141,18 @@ template main() =
       doAssert test.port == ""
       doAssert test.path == "/foo/bar/baz.txt"
 
+    block: # Strict
+      doAssertRaises(UriParseError):
+        discard parseUri("https://nim-lang\n.org\t/docs/\nalert('msg\r\n')/?query\n=\tvalue#frag\nment")
+
+      # Non-strict would sanitize newline and tab characters from input
+      let test = parseUri("https://nim-lang\n.org\t/docs/\nalert('msg\r\n')/?query\n=\tvalue#frag\nment", strict=false)
+      assert test.scheme == "https"
+      assert test.hostname == "nim-lang.org"
+      assert test.path == "/docs/alert('msg')/"
+      assert test.query == "query=value"
+      assert test.anchor == "fragment"
+
   block: # combine
     block:
       let concat = combine(parseUri("http://google.com/foo/bar/"), parseUri("baz"))


### PR DESCRIPTION
This fixes `parseUri` function in `uri` lib to sanitize provided url string from ascii newline and tabs. The URL standard
from WHATWG specifies that a parser should strip all tabs and newlines from input: https://url.spec.whatwg.org/#concept-basic-url-parser

Example (on `1.4.6`):

```nim
import uri
var res = initUri()
parseUri("java\nscript:alert('bad')", res)
echo res.path
```

Will output:
```sh
java
script:alert('bad')
```

This is a security issue that was fixed in Python 3.9.5 a couple of days ago ([issue43882](https://bugs.python.org/issue43882)) and it could allow some forms of attacks.

WARNING: This PR has been reverted. See https://github.com/nim-lang/Nim/pull/19128