### PR TITLE
make testament `isSuccess` more robust and allow tests with `--hints:off` to succeed

### DIFF
--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -99,6 +99,7 @@ type
     timeout*: float # in seconds, fractions possible,
                       # but don't rely on much precision
     inlineErrors*: seq[InlineError] # line information to error message
+    debugInfo*: string # debug info to give more context
 
 proc getCmd*(s: TSpec): string =
   if s.cmd.len == 0:

--- a/tests/misc/thints_off.nim
+++ b/tests/misc/thints_off.nim
@@ -1,0 +1,4 @@
+discard """
+  matrix: "--hints:off"
+"""
+doAssert true

--- a/tests/statictypes/tstatictypes.nim
+++ b/tests/statictypes/tstatictypes.nim
@@ -11,7 +11,6 @@ staticAlialProc instantiated with 368
 1: Bar
 0: Foo
 1: Bar
-Hint: ***SLOW, DEBUG BUILD***; -d:release makes code run faster. [BuildMode]
 '''
 output: '''
 16
@@ -23,10 +22,8 @@ heyho
 Val1
 Val1
 '''
-matrix: "--hint:XDeclaredButNotUsed:off --hint:cc:off --hint:link:off --hint:SuccessX:off --hint:conf:off"
+matrix: "--hints:off"
 """
-
-# pending https://github.com/nim-lang/Nim/pull/17852 use `--hints:none --hint:SuccessX:off`, or improve `isSuccess`
 
 import macros
 


### PR DESCRIPTION
* add `debugInfo` field to `TSpec` to allow giving more context on testament errors
* allow forwarding the given `TSpec` to `addResult` so we show fields (eg `debugInfo`) when needed (better than forwarding individual fields)
* improve testament `isSuccess`:
  * it now considers process exitcode instead of ignoring it
  * it detects mismatches based on foundSuccessMsg, foundErrorMsg, exitCode

most importantly, it allows tests like `tests/statictypes/tstatictypes.nim` (with hints disabled) to pass, which is important eg for tests with `nimoutFull`, where we want to only test a specific hint and don't want to show hintSuccessX or hintBuild in the nimout spec