### PR TITLE
followup #17944, remove other `abi` fields

### DIFF
--- a/lib/posix/posix_linux_amd64.nim
+++ b/lib/posix/posix_linux_amd64.nim
@@ -150,35 +150,24 @@ type
   Pid* {.importc: "pid_t", header: "<sys/types.h>".} = cint
   Pthread_attr* {.importc: "pthread_attr_t", header: "<sys/types.h>",
                   pure, final.} = object
-    abi: array[56 div sizeof(clong), clong]
-
   Pthread_barrier* {.importc: "pthread_barrier_t",
                       header: "<sys/types.h>", pure, final.} = object
-    abi: array[32 div sizeof(clong), clong]
   Pthread_barrierattr* {.importc: "pthread_barrierattr_t",
                           header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
-
   Pthread_cond* {.importc: "pthread_cond_t", header: "<sys/types.h>",
                   pure, final.} = object
-    abi: array[48 div sizeof(clonglong), clonglong]
   Pthread_condattr* {.importc: "pthread_condattr_t",
                        header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
   Pthread_key* {.importc: "pthread_key_t", header: "<sys/types.h>".} = cuint
   Pthread_mutex* {.importc: "pthread_mutex_t", header: "<sys/types.h>",
                    pure, final.} = object
-    abi: array[48 div sizeof(clong), clong]
   Pthread_mutexattr* {.importc: "pthread_mutexattr_t",
                         header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
   Pthread_once* {.importc: "pthread_once_t", header: "<sys/types.h>".} = cint
   Pthread_rwlock* {.importc: "pthread_rwlock_t",
                      header: "<sys/types.h>", pure, final.} = object
-    abi: array[56 div sizeof(clong), clong]
   Pthread_rwlockattr* {.importc: "pthread_rwlockattr_t",
                          header: "<sys/types.h>".} = object
-    abi: array[8 div sizeof(clong), clong]
   Pthread_spinlock* {.importc: "pthread_spinlock_t",
                        header: "<sys/types.h>".} = cint
   Pthread* {.importc: "pthread_t", header: "<sys/types.h>".} = culong
@@ -201,8 +190,6 @@ type
       domainname*: array[65, char]
 
   Sem* {.importc: "sem_t", header: "<semaphore.h>", final, pure.} = object
-    abi: array[32 div sizeof(clong), clong]
-
   Ipc_perm* {.importc: "struct ipc_perm",
                header: "<sys/ipc.h>", final, pure.} = object ## struct ipc_perm
     key: Key
@@ -286,8 +273,6 @@ type
     ## accessed as an atomic entity, even in the presence of asynchronous
     ## interrupts.
   Sigset* {.importc: "sigset_t", header: "<signal.h>", final, pure.} = object
-    abi: array[1024 div (8 * sizeof(culong)), culong]
-
   SigEvent* {.importc: "struct sigevent",
                header: "<signal.h>", final, pure.} = object ## struct sigevent
     sigev_value*: SigVal          ## Signal value.
@@ -295,7 +280,6 @@ type
     sigev_notify*: cint           ## Notification type.
     sigev_notify_function*: proc (x: SigVal) {.noconv.} ## Notification func.
     sigev_notify_attributes*: ptr Pthread_attr ## Notification attributes.
-    abi: array[12, int]
 
   SigVal* {.importc: "union sigval",
              header: "<signal.h>", final, pure.} = object ## struct sigval
@@ -350,7 +334,6 @@ type
     tv_usec*: Suseconds ## Microseconds.
   TFdSet* {.importc: "fd_set", header: "<sys/select.h>",
            final, pure.} = object
-    abi: array[1024 div (8 * sizeof(clong)), clong]
 
   Mcontext* {.importc: "mcontext_t", header: "<ucontext.h>",
                final, pure.} = object

--- a/lib/posix/posix_nintendoswitch.nim
+++ b/lib/posix/posix_nintendoswitch.nim
@@ -129,35 +129,24 @@ type
   Pid* {.importc: "pid_t", header: "<sys/types.h>".} = cint
   Pthread_attr* {.importc: "pthread_attr_t", header: "<sys/types.h>",
                   pure, final.} = object
-    abi: array[56 div sizeof(clong), clong]
-
   Pthread_barrier* {.importc: "pthread_barrier_t",
                       header: "<sys/types.h>", pure, final.} = object
-    abi: array[32 div sizeof(clong), clong]
   Pthread_barrierattr* {.importc: "pthread_barrierattr_t",
                           header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
-
   Pthread_cond* {.importc: "pthread_cond_t", header: "<sys/types.h>",
                   pure, final.} = object
-    abi: array[48 div sizeof(clonglong), clonglong]
   Pthread_condattr* {.importc: "pthread_condattr_t",
                        header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
   Pthread_key* {.importc: "pthread_key_t", header: "<sys/types.h>".} = cuint
   Pthread_mutex* {.importc: "pthread_mutex_t", header: "<sys/types.h>",
                    pure, final.} = object
-    abi: array[48 div sizeof(clong), clong]
   Pthread_mutexattr* {.importc: "pthread_mutexattr_t",
                         header: "<sys/types.h>", pure, final.} = object
-    abi: array[4 div sizeof(cint), cint]
   Pthread_once* {.importc: "pthread_once_t", header: "<sys/types.h>".} = cint
   Pthread_rwlock* {.importc: "pthread_rwlock_t",
                      header: "<sys/types.h>", pure, final.} = object
-    abi: array[56 div sizeof(clong), clong]
   Pthread_rwlockattr* {.importc: "pthread_rwlockattr_t",
                          header: "<sys/types.h>".} = object
-    abi: array[8 div sizeof(clong), clong]
   Pthread_spinlock* {.importc: "pthread_spinlock_t",
                        header: "<sys/types.h>".} = cint
   Pthread* {.importc: "pthread_t", header: "<sys/types.h>".} = culong
@@ -180,7 +169,6 @@ type
       domainname*: array[65, char]
 
   Sem* {.importc: "sem_t", header: "<semaphore.h>", final, pure.} = object
-    abi: array[32 div sizeof(clong), clong]
 
   Stat* {.importc: "struct stat",
            header: "<sys/stat.h>", final, pure.} = object ## struct stat
@@ -305,9 +293,7 @@ type
              final, pure.} = object ## struct timeval
     tv_sec*: Time       ## Seconds.
     tv_usec*: Suseconds ## Microseconds.
-  TFdSet* {.importc: "fd_set", header: "<sys/select.h>",
-           final, pure.} = object
-    abi: array[((64+(sizeof(clong) * 8)-1) div (sizeof(clong) * 8)), clong]
+  TFdSet* {.importc: "fd_set", header: "<sys/select.h>", final, pure.} = object
 
 proc si_pid*(info: SigInfo): Pid =
   ## This might not be correct behavior. si_pid doesn't exist in Switch's

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -34,7 +34,7 @@ proc c_abort*() {.
 when defined(linux) and defined(amd64):
   type
     C_JmpBuf* {.importc: "jmp_buf", header: "<setjmp.h>", bycopy.} = object
-        abi: array[200 div sizeof(clong), clong]
+      # xxx why `bycopy` only here and not in other `C_JmpBuf` declaration?
 else:
   type
     C_JmpBuf* {.importc: "jmp_buf", header: "<setjmp.h>".} = object

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -132,7 +132,6 @@ else:
                   header: "<sys/types.h>" .} = distinct culong
       Pthread_attr {.importc: "pthread_attr_t",
                     header: "<sys/types.h>".} = object
-        abi: array[56 div sizeof(clong), clong]
       ThreadVarSlot {.importc: "pthread_key_t",
                     header: "<sys/types.h>".} = distinct cuint
   elif defined(openbsd) and defined(amd64):
@@ -190,8 +189,6 @@ else:
     result = pthread_getspecific(s)
 
   type CpuSet {.importc: "cpu_set_t", header: schedh.} = object
-     when defined(linux) and defined(amd64):
-       abi: array[1024 div (8 * sizeof(culong)), culong]
 
   proc cpusetZero(s: var CpuSet) {.importc: "CPU_ZERO", header: schedh.}
   proc cpusetIncl(cpu: cint; s: var CpuSet) {.


### PR DESCRIPTION
followup #17944

question for reviewer (not blocking this PR though): why `bycopy` only for one of the `C_JmpBuf` declarations? what was the reason for bycopy here?

## future work
- [ ] this gives me an idea: we could report `sizeof`, `alignof` in `nim doc` for all types (importc in particular but not limited to), which can be computed at RT; it's platform specific, but then again, we can also run `nim doc` on a per-platform basis if needed
- [ ] consider also removing other hidden padding fields, eg:
```
lib/posix/posix_linux_amd64.nim:122:5:    pad: array[4, clong]
lib/posix/posix_linux_amd64.nim:201:5:    pad1: cshort
lib/posix/posix_linux_amd64.nim:203:5:    pad2: cshort
lib/posix/posix_linux_amd64.nim:215:5:    pad0 {.importc: "__pad0".}: cint
lib/posix/posix_linux_amd64.nim:321:5:    pad {.importc: "_pad"}: array[128 - 56, uint8]
lib/posix/posix_linux_amd64.nim:384:7:      pad: array[16, cint]
lib/posix/posix_linux_amd64.nim:391:7:      pad: array[16, cint]
lib/posix/posix_linux_amd64.nim:414:8:    ss_padding: array[128 - sizeof(cshort) - sizeof(culong), char]
lib/posix/posix_nintendoswitch.nim:191:7:      pad1: clong
lib/posix/posix_nintendoswitch.nim:193:7:      pad2: clong
lib/posix/posix_nintendoswitch.nim:195:7:      pad3: clong
lib/posix/posix_nintendoswitch.nim:198:7:      pad1: clong
lib/posix/posix_nintendoswitch.nim:200:7:      pad2: clong
lib/posix/posix_nintendoswitch.nim:202:7:      pad3: clong
lib/posix/posix_nintendoswitch.nim:345:8:    ss_padding1: array[64 - sizeof(cuchar) - sizeof(cshort), char]
```
