### PR TITLE
Fixes #5034 illformed AST from getImpl with proc returning value

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1440,8 +1440,7 @@ proc semBorrow(c: PContext, n: PNode, s: PSym) =
 proc swapResult(n: PNode, sRes: PSym, dNode: PNode) =
   ## Swap nodes that are (skResult) symbols to d(estination)Node.
   for i in 0..<n.safeLen:
-    if n[i].kind == nkSym:
-      if n[i].sym == sRes:
+    if n[i].kind == nkSym and n[i].sym == sRes:
         n[i] = dNode
     swapResult(n[i], sRes, dNode)
 

--- a/tests/macros/tmacrogetimpl.nim
+++ b/tests/macros/tmacrogetimpl.nim
@@ -1,0 +1,40 @@
+discard """
+output: '''
+1.0
+10.0
+1.0
+buzz lightyear
+macros
+'''
+"""
+import macros
+
+# 5034
+
+macro copyImpl(srsProc: typed, toSym: untyped) =
+  result = copyNimTree(getImplTransformed(srsProc))
+  result[0] = ident $toSym.toStrLit()
+
+proc foo1(x: float, one: bool = true): float =
+  if one:
+    return 1'f
+  result = x
+
+proc bar1(what: string): string =
+  ## be a little more adversarial with `skResult`
+  proc buzz: string =
+    result = "lightyear"
+  if what == "buzz":
+    result = ("buzz " & buzz())
+  else:
+    result = what
+  return result
+
+copyImpl(foo1, foo2)
+echo foo1(1'f)
+echo foo2(10.0, false)
+echo foo2(10.0)
+
+copyImpl(bar1, bar2)
+echo bar1("buzz")
+echo bar1("macros")

--- a/tests/macros/tmacrogetimpl.nim
+++ b/tests/macros/tmacrogetimpl.nim
@@ -1,15 +1,6 @@
-discard """
-output: '''
-1.0
-10.0
-1.0
-buzz lightyear
-macros
-'''
-"""
 import macros
 
-# 5034
+# bug #5034
 
 macro copyImpl(srsProc: typed, toSym: untyped) =
   result = copyNimTree(getImplTransformed(srsProc))
@@ -25,16 +16,16 @@ proc bar1(what: string): string =
   proc buzz: string =
     result = "lightyear"
   if what == "buzz":
-    result = ("buzz " & buzz())
+    result = "buzz " & buzz()
   else:
     result = what
   return result
 
 copyImpl(foo1, foo2)
-echo foo1(1'f)
-echo foo2(10.0, false)
-echo foo2(10.0)
+doAssert foo1(1'f) == 1.0
+doAssert foo2(10.0, false) == 10.0
+doAssert foo2(10.0) == 1.0
 
 copyImpl(bar1, bar2)
-echo bar1("buzz")
-echo bar1("macros")
+doAssert bar1("buzz") == "buzz lightyear"
+doAssert bar1("macros") == "macros"


### PR DESCRIPTION
This is an attempt at fixing #5034, whereby macros that attempt to re-define a proc run into a variety of issues relating to the ownership of the `result` symbol. For example:

- `addResult`, on the 'second pass' would fail because `n[resultPos].sym.owner != getCurrOwner(c)` which gives `"incorrect result proc symbol"`
- `result = ...` gets re-written to `result = result = ...` because `semReturn` in `semexprs` does transformations twice due to `c.p.resultSym != n[0][0].sym` in the case of returning nodes sourced from `getImpl(Transformed)?`

As a fix, ownership mismatch is responded to by re-writing `result` nodes equal to `n[resultPos].sym`. As a less-preferred alternative to this PR, the error message for attempting to do this kind of redefinition could be improved to be discouraged. 
