### PR TITLE
Revert "fix #14873 properly by skipping `abi` field in importc type"

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -28,6 +28,11 @@ type
 
 {.push stackTrace: off.}
 
+
+proc `$`*(lock: Lock): string =
+  # workaround bug #14873
+  result = "()"
+
 proc initLock*(lock: var Lock) {.inline.} =
   ## Initializes the given lock.
   when not defined(js):

--- a/lib/system/syslocks.nim
+++ b/lib/system/syslocks.nim
@@ -102,18 +102,26 @@ else:
     SysLockObj {.importc: "pthread_mutex_t", pure, final,
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
+      when defined(linux) and defined(amd64):
+        abi: array[40 div sizeof(clong), clong]
 
     SysLockAttr {.importc: "pthread_mutexattr_t", pure, final
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
+      when defined(linux) and defined(amd64):
+        abi: array[4 div sizeof(cint), cint]  # actually a cint
 
     SysCondObj {.importc: "pthread_cond_t", pure, final,
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
+      when defined(linux) and defined(amd64):
+        abi: array[48 div sizeof(clonglong), clonglong]
 
     SysCondAttr {.importc: "pthread_condattr_t", pure, final
                header: """#include <sys/types.h>
                           #include <pthread.h>""".} = object
+      when defined(linux) and defined(amd64):
+        abi: array[4 div sizeof(cint), cint]  # actually a cint
 
     SysLockType = distinct cint
 

--- a/tests/stdlib/uselocks.nim
+++ b/tests/stdlib/uselocks.nim
@@ -11,21 +11,5 @@ proc use* (m: var MyType): int =
     result = 3
 
 block:
-  # bug #14873
   var l: Lock
-  doAssert ($l).len > 0
-    # on posix, "()", on windows, something else, but that shouldn't be part of the spec
-    # what matters is that `$` doesn't cause the codegen bug mentioned
-
-when true: # intentional
-  # bug https://github.com/nim-lang/Nim/issues/14873#issuecomment-784241605
-  type
-    Test = object
-      path: string # Removing this makes both cases work.
-      lock: Lock
-  # A: This is not fine.
-  var a = Test()
-  proc main(): void =
-    # B: This is fine.
-    var b = Test()
-  main()
+  doAssert $l == "()"


### PR DESCRIPTION
Reverts nim-lang/Nim#17944