### PR TITLE
jsonutils: handle holey enum as regular enum, via `ord`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -67,6 +67,9 @@
   initialization with a small (< 30000) seed. Use `-d:nimLegacyRandomInitRand` to restore
   previous behavior for a transition time, see PR #17467.
 
+- `jsonutils` now serializes/deserializes holey enums as regular enums (via `ord`) instead of as strings.
+  Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period.
+
 
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -282,6 +282,9 @@ proc toJson*[T](a: T): JsonNode =
   elif T is bool: result = %(a)
   elif T is SomeInteger: result = %a
   elif T is Ordinal: result = %(a.ord)
+  elif T is enum:
+    when defined(nimLegacyJsonutilsHoleyEnum): result = %a
+    else: result = %(a.ord)
   elif T is cstring: (if a == nil: result = newJNull() else: result = % $a)
   else: result = %a
 

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -72,9 +72,9 @@ template fn() =
 
   block: # set
     type Foo = enum f1, f2, f3, f4, f5
-    # type Goo = enum g1 = 10, g2 = 15, g3 = 17, g4 # in future PR, elements for holey enum should be treated as enum, not string
-    let a = ({f1, f3}, {1'u8, 7'u8}, {'0'..'9'}, {123'u16, 456, 789, 1121, 1122, 1542})
-    testRoundtrip(a): """[[0,2],[1,7],[48,49,50,51,52,53,54,55,56,57],[123,456,789,1121,1122,1542]]"""
+    type Goo = enum g1 = 10, g2 = 15, g3 = 17, g4
+    let a = ({f1, f3}, {1'u8, 7'u8}, {'0'..'9'}, {123'u16, 456, 789, 1121, 1122, 1542}, {g2, g3})
+    testRoundtrip(a): """[[0,2],[1,7],[48,49,50,51,52,53,54,55,56,57],[123,456,789,1121,1122,1542],[15,17]]"""
 
   block: # bug #17383
     block:


### PR DESCRIPTION
this fixes an oversight
