### PR TITLE
refs #18011 disable some newly failing tests on cpp windows; refs #17946 increase timeout for tchannels

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1317,10 +1317,10 @@ proc del*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
   ##
   ## See also:
   ## * `delete <#delete,seq[T],Natural>`_ for preserving the order
-  ##
-  ## .. code-block:: Nim
-  ##  var i = @[1, 2, 3, 4, 5]
-  ##  i.del(2) # => @[1, 2, 5, 4]
+  runnableExamples:
+    var a = @[10, 11, 12, 13, 14]
+    a.del(2)
+    assert a == @[10, 11, 14, 13]
   let xl = x.len - 1
   movingCopy(x[i], x[xl])
   setLen(x, xl)

--- a/tests/cpp/temitlist.nim
+++ b/tests/cpp/temitlist.nim
@@ -1,7 +1,9 @@
 discard """
   targets: "cpp"
-  output: '''6.0
+  output: '''
+6.0
 0'''
+disabled: "windows" # pending bug #18011
 """
 
 # bug #4730

--- a/tests/cpp/tempty_generic_obj.nim
+++ b/tests/cpp/tempty_generic_obj.nim
@@ -1,7 +1,9 @@
 discard """
   targets: "cpp"
-  output: '''int
+  output: '''
+int
 float'''
+disabled: "windows" # pending bug #18011
 """
 
 import typetraits

--- a/tests/exception/tcpp_imported_exc.nim
+++ b/tests/exception/tcpp_imported_exc.nim
@@ -1,6 +1,7 @@
 discard """
 targets: "cpp"
-output: '''caught as std::exception
+output: '''
+caught as std::exception
 expected
 finally1
 finally2
@@ -12,6 +13,7 @@ finally 2
 expected
 cpp exception caught
 '''
+disabled: "windows" # pending bug #18011
 """
 
 type

--- a/tests/stdlib/tchannels.nim
+++ b/tests/stdlib/tchannels.nim
@@ -1,5 +1,5 @@
 discard """
-  timeout:  20.0 # but typically < 1s (in isolation but other tests running in parallel can affect this since based on epochTime)
+  timeout:  60.0 # but typically < 1s (in isolation but other tests running in parallel can affect this since based on epochTime)
   disabled: "freebsd"
   matrix: "--gc:arc --threads:on; --gc:arc --threads:on -d:danger"
 """


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/issues/18011

(innocuous change to see if i can reproduce https://github.com/nim-lang/Nim/issues/18011 before disabling failing tests)
EDIT: indeed, I can

## CI failures:
* osx tasynchttpserver_transferencoding  fails because of https://github.com/nim-lang/Nim/issues/17456
* windows tests/stdlib/tchannels.nim fails because of https://github.com/nim-lang/Nim/issues/17946
thanks to https://github.com/nim-lang/Nim/pull/17947 we now know why:
> 2021-05-14T20:20:29.9353041Z FAIL: tests/stdlib/tchannels.nim c                                 (21.81 sec)
* windows tcpp_imported_exc.nim, tests/cpp/temitlist.nim, tests/cpp/tempty_generic_obj.nim fails because of https://github.com/nim-lang/Nim/issues/18011
