### PR TITLE
db_postgres: escape `\0` in `dbQuote`

### DIFF
--- a/lib/impure/db_postgres.nim
+++ b/lib/impure/db_postgres.nim
@@ -110,7 +110,9 @@ proc dbQuote*(s: string): string =
   ## DB quotes the string.
   result = "'"
   for c in items(s):
-    if c == '\'': add(result, "''")
+    case c
+    of '\'': add(result, "''")
+    of '\0': add(result, "\\0")
     else: add(result, c)
   add(result, '\'')
 


### PR DESCRIPTION
Fix https://github.com/nim-lang/Nim/issues/17925

The `\0` is not escaped and results in ``unterminated quoted string at or near "'"``.

Updated to `case` for same style as `db_mysql`.