### PR TITLE
fix #18007: std/json now serializes nan,inf,-inf as strings instead of invalid json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -71,7 +71,7 @@
   Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period.
 
 - `json` and `jsonutils` now serialize NaN, Inf, -Inf as strings, so that
-  `%[NaN, -Inf]` is the string `["nan","-inf"]` insetad of `[nan,-inf]` which was invalid json.
+  `%[NaN, -Inf]` is the string `["nan","-inf"]` instead of `[nan,-inf]` which was invalid json.
 
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`

--- a/changelog.md
+++ b/changelog.md
@@ -70,8 +70,8 @@
 - `jsonutils` now serializes/deserializes holey enums as regular enums (via `ord`) instead of as strings.
   Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period.
 
-- `json` and `jsonutils` now serialize NaN, Inf, -Inf as "nan", "inf", "-inf", using raw strings (the same
-  that are used to encode numbers that can't fit in native number types).
+- `json` and `jsonutils` now serialize NaN, Inf, -Inf as strings, so that
+  `%[NaN, -Inf]` is the string `["nan","-inf"]` insetad of `[nan,-inf]` which was invalid json.
 
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`

--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,8 @@
 - `jsonutils` now serializes/deserializes holey enums as regular enums (via `ord`) instead of as strings.
   Use `-d:nimLegacyJsonutilsHoleyEnum` for a transition period.
 
+- `json` and `jsonutils` now serialize NaN, Inf, -Inf as "nan", "inf", "-inf", using raw strings (the same
+  that are used to encode numbers that can't fit in native number types).
 
 ## Standard library additions and changes
 - Added support for parenthesized expressions in `strformat`

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -333,9 +333,12 @@ proc `%`*(n: BiggestInt): JsonNode =
 
 proc `%`*(n: float): JsonNode =
   ## Generic constructor for JSON data. Creates a new `JFloat JsonNode`.
+  runnableExamples:
+    assert $(%[NaN, Inf, -Inf, 0.0, -0.0, 1.0, 1e-2]) == """["nan","inf","-inf",0.0,-0.0,1.0,0.01]"""
+    assert (%NaN).kind == JString
+    assert (%0.0).kind == JFloat
   # for those special cases, we could also have used `newJRawNumber` but then
-  # it would've been inconsisten with the case of `parseJson` vs `%` for representing
-  # nan|inf.
+  # it would've been inconsisten with the case of `parseJson` vs `%` for representing them.
   if n != n: newJString("nan")
   elif n == Inf: newJString("inf")
   elif n == -Inf: newJString("-inf")

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -12,6 +12,9 @@ runnableExamples:
   let a = (1.5'f32, (b: "b2", a: "a2"), 'x', @[Foo(t: true, z1: -3), nil], [{"name": "John"}.newStringTable])
   let j = a.toJson
   assert j.jsonTo(typeof(a)).toJson == j
+  assert $[NaN, Inf, -Inf, 0.0, -0.0, 1.0, 1e-2].toJson == """["nan","inf","-inf",0.0,-0.0,1.0,0.01]"""
+  assert 0.0.toJson.kind == JFloat
+  assert Inf.toJson.kind == JString
 
 import json, strutils, tables, sets, strtabs, options
 

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -301,6 +301,12 @@ block: # bug #17383
     testRoundtrip(int64.high): "9223372036854775807"
     testRoundtrip(uint64.high): "18446744073709551615"
 
+block: # bug #18007
+  testRoundtrip([NaN, Inf, -Inf, 0.0, -0.0, 1.0]): "[nan,inf,-inf,0.0,-0.0,1.0]"
+  # pending https://github.com/nim-lang/Nim/issues/18025 use:
+  # testRoundtrip([float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0]): "[nan,inf,-inf,0.0,-0.0,1.0]"
+  let inf = float32(Inf)
+  testRoundtrip([float32(NaN), inf, -inf, 0.0, -0.0, 1.0]): "[nan,inf,-inf,0.0,-0.0,1.0]"
 
 block:
   let a = "18446744073709551615"

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -302,11 +302,11 @@ block: # bug #17383
     testRoundtrip(uint64.high): "18446744073709551615"
 
 block: # bug #18007
-  testRoundtrip([NaN, Inf, -Inf, 0.0, -0.0, 1.0]): "[nan,inf,-inf,0.0,-0.0,1.0]"
+  testRoundtrip([NaN, Inf, -Inf, 0.0, -0.0, 1.0]): """["nan","inf","-inf",0.0,-0.0,1.0]"""
   # pending https://github.com/nim-lang/Nim/issues/18025 use:
-  # testRoundtrip([float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0]): "[nan,inf,-inf,0.0,-0.0,1.0]"
+  # testRoundtrip([float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0])
   let inf = float32(Inf)
-  testRoundtrip([float32(NaN), inf, -inf, 0.0, -0.0, 1.0]): "[nan,inf,-inf,0.0,-0.0,1.0]"
+  testRoundtrip([float32(NaN), inf, -inf, 0.0, -0.0, 1.0]): """["nan","inf","-inf",0.0,-0.0,1.0]"""
 
 block:
   let a = "18446744073709551615"

--- a/tests/stdlib/tjson.nim
+++ b/tests/stdlib/tjson.nim
@@ -8,13 +8,26 @@ Note: Macro tests are in tests/stdlib/tjsonmacro.nim
 ]#
 
 import std/[json,parsejson,strutils]
+from std/math import isNaN
 when not defined(js):
   import std/streams
 
 proc testRoundtrip[T](t: T, expected: string) =
+  # checks that `T => json => T2 => json2` is such that json2 = json
   let j = %t
   doAssert $j == expected, $j
   doAssert %(j.to(T)) == j
+
+proc testRoundtripVal[T](t: T, expected: string) =
+  # similar to testRoundtrip, but also checks that the `T => json => T2` is such that `T2 == T`
+  # note that this isn't always possible, e.g. for pointer-like types or nans
+  let j = %t
+  doAssert $j == expected, $j
+  let j2 = ($j).parseJson
+  doAssert $j2 == expected, $(j2, t)
+  let t2 = j2.to(T)
+  doAssert t2 == t
+  doAssert $(%* t2) == expected # sanity check, because -0.0 = 0.0 but their json representation differs
 
 let testJson = parseJson"""{ "a": [1, 2, 3, 4], "b": "asd", "c": "\ud83c\udf83", "d": "\u00E6"}"""
 # nil passthrough
@@ -307,6 +320,10 @@ block: # bug #18007
   # testRoundtrip([float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0])
   let inf = float32(Inf)
   testRoundtrip([float32(NaN), inf, -inf, 0.0, -0.0, 1.0]): """["nan","inf","-inf",0.0,-0.0,1.0]"""
+  when not defined(js): # because of Infinity vs inf
+    testRoundtripVal([inf, -inf, 0.0, -0.0, 1.0]): """["inf","-inf",0.0,-0.0,1.0]"""
+  let a = parseJson($(%NaN)).to(float)
+  doAssert a.isNaN
 
 block:
   let a = "18446744073709551615"

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -23,13 +23,7 @@ proc testRoundtripVal[T](t: T, expected: string) =
   doAssert j2 == expected, j2
   let j3 = j2.parseJson
   let t2 = j3.jsonTo(T)
-  when T is float: # special case to test NaN
-    if t.isNaN:
-      doAssert t2.isNaN
-    else:
-      doAssert t2 == t
-  else:
-    doAssert t2 == t
+  doAssert t2 == t
   doAssert $t2.toJson == j2 # still needed, because -0.0 = 0.0 but their json representation differs
 
 import tables, sets, algorithm, sequtils, options, strtabs
@@ -114,7 +108,7 @@ template fn() =
     testRoundtrip((NaN, Inf, -Inf, 0.0, -0.0, 1.0)): """["nan","inf","-inf",0.0,-0.0,1.0]"""
     testRoundtrip((float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0)): """["nan","inf","-inf",0.0,-0.0,1.0]"""
     testRoundtripVal((Inf, -Inf, 0.0, -0.0, 1.0)): """["inf","-inf",0.0,-0.0,1.0]"""
-    testRoundtripVal(NaN): """"nan""""
+    doAssert ($NaN.toJson).parseJson.jsonTo(float).isNaN
 
   block: # case object
     type Foo = object

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -91,6 +91,10 @@ template fn() =
       else:
         testRoundtrip(a): "[9223372036854775807,18446744073709551615]"
 
+  block: # bug #18007
+    testRoundtrip((NaN, Inf, -Inf, 0.0, -0.0, 1.0)): "[nan,inf,-inf,0.0,-0.0,1.0]"
+    testRoundtrip((float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0)): "[nan,inf,-inf,0.0,-0.0,1.0]"
+
   block: # case object
     type Foo = object
       x0: float

--- a/tests/stdlib/tjsonutils.nim
+++ b/tests/stdlib/tjsonutils.nim
@@ -4,14 +4,33 @@ discard """
 
 import std/jsonutils
 import std/json
+from std/math import isNaN
 
 proc testRoundtrip[T](t: T, expected: string) =
+  # checks that `T => json => T2 => json2` is such that json2 = json
   let j = t.toJson
-  doAssert $j == expected, $j
+  doAssert $j == expected, "\n" & $j & "\n" & expected
   doAssert j.jsonTo(T).toJson == j
   var t2: T
   t2.fromJson(j)
   doAssert t2.toJson == j
+
+proc testRoundtripVal[T](t: T, expected: string) =
+  # similar to testRoundtrip, but also checks that the `T => json => T2` is such that `T2 == T`
+  # note that this isn't always possible, e.g. for pointer-like types.
+  let j = t.toJson
+  let j2 = $j
+  doAssert j2 == expected, j2
+  let j3 = j2.parseJson
+  let t2 = j3.jsonTo(T)
+  when T is float: # special case to test NaN
+    if t.isNaN:
+      doAssert t2.isNaN
+    else:
+      doAssert t2 == t
+  else:
+    doAssert t2 == t
+  doAssert $t2.toJson == j2 # still needed, because -0.0 = 0.0 but their json representation differs
 
 import tables, sets, algorithm, sequtils, options, strtabs
 from strutils import contains
@@ -92,8 +111,10 @@ template fn() =
         testRoundtrip(a): "[9223372036854775807,18446744073709551615]"
 
   block: # bug #18007
-    testRoundtrip((NaN, Inf, -Inf, 0.0, -0.0, 1.0)): "[nan,inf,-inf,0.0,-0.0,1.0]"
-    testRoundtrip((float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0)): "[nan,inf,-inf,0.0,-0.0,1.0]"
+    testRoundtrip((NaN, Inf, -Inf, 0.0, -0.0, 1.0)): """["nan","inf","-inf",0.0,-0.0,1.0]"""
+    testRoundtrip((float32(NaN), Inf, -Inf, 0.0, -0.0, 1.0)): """["nan","inf","-inf",0.0,-0.0,1.0]"""
+    testRoundtripVal((Inf, -Inf, 0.0, -0.0, 1.0)): """["inf","-inf",0.0,-0.0,1.0]"""
+    testRoundtripVal(NaN): """"nan""""
 
   block: # case object
     type Foo = object


### PR DESCRIPTION
fix #18007
closes #18020

i could add a `-d:nimLegacyJsonNaNInf` if needed, but doesn't seem like it's needed in this case because the json that was previously generated was invalid

the serialization/deserialization is now rountrip safe and uses valid json

## note
`testRoundtripVal` are from https://github.com/nim-lang/Nim/pull/18008 but since that PR wasn't merged yet and I needed those test procs, I've added those here
