### PR TITLE
[std/re] fix findBounds and find procs

### DIFF
--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -200,7 +200,7 @@ proc findBounds*(s: string, pattern: Regex,
   result = findBounds(cstring(s), pattern, matches, start, s.len)
 
 proc findBounds*(buf: cstring, pattern: Regex,
-                 start = 0, bufSize: int): tuple[first, last: int] =
+                 start = 0, bufSize = 0): tuple[first, last: int] =
   ## returns the `first` and `last` position of `pattern` in `buf`,
   ## where `buf` has length `bufSize` (not necessarily `'\0'` terminated).
   ## If it does not match, `(-1,0)` is returned.

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -142,7 +142,7 @@ proc matchOrFind(buf: cstring, pattern: Regex, matches: var openArray[string],
   return rawMatches[1] - rawMatches[0]
 
 proc findBounds*(buf: cstring, pattern: Regex, matches: var openArray[string],
-                 start = 0, bufSize = 0): tuple[first, last: int] =
+                 start = 0, bufSize: int): tuple[first, last: int] =
   ## returns the starting position and end position of `pattern` in `buf`
   ## (where `buf` has length `bufSize` and is not necessarily `'\0'` terminated),
   ## and the captured
@@ -171,7 +171,7 @@ proc findBounds*(s: string, pattern: Regex, matches: var openArray[string],
 
 proc findBounds*(buf: cstring, pattern: Regex,
                  matches: var openArray[tuple[first, last: int]],
-                 start = 0, bufSize = 0): tuple[first, last: int] =
+                 start = 0, bufSize: int): tuple[first, last: int] =
   ## returns the starting position and end position of `pattern` in `buf`
   ## (where `buf` has length `bufSize` and is not necessarily `'\0'` terminated),
   ## and the captured substrings in the array `matches`.
@@ -200,7 +200,7 @@ proc findBounds*(s: string, pattern: Regex,
   result = findBounds(cstring(s), pattern, matches, start, s.len)
 
 proc findBounds*(buf: cstring, pattern: Regex,
-                 start = 0, bufSize = 0): tuple[first, last: int] =
+                 start = 0, bufSize: int): tuple[first, last: int] =
   ## returns the `first` and `last` position of `pattern` in `buf`,
   ## where `buf` has length `bufSize` (not necessarily `'\0'` terminated).
   ## If it does not match, `(-1,0)` is returned.
@@ -290,7 +290,7 @@ proc match*(buf: cstring, pattern: Regex, matches: var openArray[string],
   result = matchLen(buf, pattern, matches, start, bufSize) != -1
 
 proc find*(buf: cstring, pattern: Regex, matches: var openArray[string],
-           start = 0, bufSize = 0): int =
+           start = 0, bufSize: int): int =
   ## returns the starting position of `pattern` in `buf` and the captured
   ## substrings in the array `matches`. If it does not match, nothing
   ## is written into `matches` and `-1` is returned.
@@ -315,7 +315,7 @@ proc find*(s: string, pattern: Regex, matches: var openArray[string],
   ## is written into `matches` and `-1` is returned.
   result = find(cstring(s), pattern, matches, start, s.len)
 
-proc find*(buf: cstring, pattern: Regex, start = 0, bufSize = 0): int =
+proc find*(buf: cstring, pattern: Regex, start = 0, bufSize: int): int =
   ## returns the starting position of `pattern` in `buf`,
   ## where `buf` has length `bufSize` (not necessarily `'\0'` terminated).
   ## If it does not match, `-1` is returned.

--- a/lib/impure/re.nim
+++ b/lib/impure/re.nim
@@ -142,7 +142,7 @@ proc matchOrFind(buf: cstring, pattern: Regex, matches: var openArray[string],
   return rawMatches[1] - rawMatches[0]
 
 proc findBounds*(buf: cstring, pattern: Regex, matches: var openArray[string],
-                 start = 0, bufSize: int): tuple[first, last: int] =
+                 start = 0, bufSize = 0): tuple[first, last: int] =
   ## returns the starting position and end position of `pattern` in `buf`
   ## (where `buf` has length `bufSize` and is not necessarily `'\0'` terminated),
   ## and the captured
@@ -315,7 +315,7 @@ proc find*(s: string, pattern: Regex, matches: var openArray[string],
   ## is written into `matches` and `-1` is returned.
   result = find(cstring(s), pattern, matches, start, s.len)
 
-proc find*(buf: cstring, pattern: Regex, start = 0, bufSize: int): int =
+proc find*(buf: cstring, pattern: Regex, start = 0, bufSize = 0): int =
   ## returns the starting position of `pattern` in `buf`,
   ## where `buf` has length `bufSize` (not necessarily `'\0'` terminated).
   ## If it does not match, `-1` is returned.


### PR DESCRIPTION
The pre-existing interfaces have two invariants. Some procs give `bufSize` a default value, which is error-prone.

> silently doing the wrong thing (treating input as length 0), which is surprising

Before

```nim
proc findBounds*(buf: cstring, pattern: Regex, matches: var openArray[string],
                 start = 0, bufSize: int): tuple[first, last: int]

proc findBounds*(s: string, pattern: Regex, matches: var openArray[string],
                 start = 0): tuple[first, last: int] {.inline.}

proc findBounds*(buf: cstring, pattern: Regex,
                 matches: var openArray[tuple[first, last: int]],
                 start = 0, bufSize = 0): tuple[first, last: int] 

proc findBounds*(s: string, pattern: Regex,
                 matches: var openArray[tuple[first, last: int]],
                 start = 0): tuple[first, last: int] {.inline.}

proc findBounds*(buf: cstring, pattern: Regex,
                 start = 0, bufSize: int): tuple[first, last: int]

proc findBounds*(s: string, pattern: Regex,
                 start = 0): tuple[first, last: int] {.inline.}
```
After
```nim
proc findBounds*(buf: cstring, pattern: Regex, matches: var openArray[string],
                 start = 0, bufSize: int): tuple[first, last: int]

proc findBounds*(s: string, pattern: Regex, matches: var openArray[string],
                 start = 0): tuple[first, last: int] {.inline.}

proc findBounds*(buf: cstring, pattern: Regex,
                 matches: var openArray[tuple[first, last: int]],
                 start = 0, bufSize: int): tuple[first, last: int]

proc findBounds*(s: string, pattern: Regex,
                 matches: var openArray[tuple[first, last: int]],
                 start = 0): tuple[first, last: int] {.inline.} 

proc findBounds*(buf: cstring, pattern: Regex,
                 start = 0, bufSize: int): tuple[first, last: int] 
proc findBounds*(s: string, pattern: Regex,
                 start = 0): tuple[first, last: int] {.inline.}
````

It might be a breaking changes, while I don't think it is a big deal, because in reality `buf` should not be zero length. With the former interface, it gives wrong or surprise result. So it is worthy fixing it.


See the former implementation, if it is called like `find("......", pat, matches)`, it will cause dangerous consequence.
```nim
proc find*(buf: cstring, pattern: Regex, matches: var openArray[string],
           start = 0, bufSize = 0): int =
  ## returns the starting position of `pattern` in `buf` and the captured
  ## substrings in the array `matches`. If it does not match, nothing
  ## is written into `matches` and `-1` is returned.
  ## `buf` has length `bufSize` (not necessarily `'\0'` terminated).
  var
    rtarray = initRtArray[cint]((matches.len+1)*3)
    rawMatches = rtarray.getRawData
    res = pcre.exec(pattern.h, pattern.e, buf, bufSize.cint, start.cint, 0'i32,
      cast[ptr cint](rawMatches), (matches.len+1).cint*3)
  if res < 0'i32: return res
  for i in 1..int(res)-1:
    var a = rawMatches[i * 2]
    var b = rawMatches[i * 2 + 1]
    if a >= 0'i32: matches[i-1] = bufSubstr(buf, int(a), int(b))
    else: matches[i-1] = ""
  return rawMatches[0]
```