### PR TITLE
don't silence hints in system.nim

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -112,7 +112,7 @@ proc compileOption*(option, arg: string): bool {.
       discard "compiled with optimization for size and uses Boehm's GC"
 
 {.push warning[GcMem]: off, warning[Uninit]: off.}
-{.push hints: off.}
+# {.push hints: off.}
 
 proc `or`*(a, b: typedesc): typedesc {.magic: "TypeTrait", noSideEffect.}
   ## Constructs an `or` meta class.
@@ -2471,7 +2471,7 @@ proc quit*(errormsg: string, errorcode = QuitFailure) {.noreturn.} =
   quit(errorcode)
 
 {.pop.} # checks: off
-{.pop.} # hints: off
+# {.pop.} # hints: off
 
 proc `/`*(x, y: int): float {.inline, noSideEffect.} =
   ## Division of integers that results in a float.


### PR DESCRIPTION
(moved out this change from https://github.com/nim-lang/Nim/pull/18008)

I'm not sure what was the point of silencing those hints in system in the first place, but it prevented useful things, eg honoring `--processing:filenames`, or `--hint:cc` for modules (recursively) imported by system, which I want to see when compiling with those options (instead of obfuscating those). 

`{.push hints: off.}` was also preventing seeing the `CC` hint for the dragonbox sources in https://github.com/nim-lang/Nim/pull/18008

## example
`XDG_CONFIG_HOME= nim r --hint:cc:off --hint:conf:off --processing:filenames --skipparentcfg -f --lib:lib $timn_D/tests/nim/all/t12278.nim`
(or simply `--hints:none --processing:filenames` pending https://github.com/nim-lang/Nim/pull/17852)

before PR, i get misleading information, the compiler doesn't tell me which modules are being processed and they get needlessly obfuscated.

after PR, it doesn't hide this information.

before PR:
```
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/widestrs.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/io.nim [Processing]
Hint: /Users/timothee/git_clone/nim/timn/tests/nim/all/t12278.nim [Processing]
Hint:  [Link]
```

after PR:
```
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/std/private/since.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/ansi_c.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/memory.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/std/private/miscdollars.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/iterators.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/coro_detection.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/dollars.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/stacktraces.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/countbits_impl.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/std/private/vmutils.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/formatfloat.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/widestrs.nim [Processing]
Hint: /Users/timothee/git_clone/nim/Nim_prs/lib/system/io.nim [Processing]
Hint: /Users/timothee/git_clone/nim/timn/tests/nim/all/t12278.nim [Processing]
Hint:  [Link]
...
```
which tells the truth
(note the argument "don't show those because they're in a foreign package" doesn't apply, because the logic is already in place (see `hasHint`) to disable certain notes depending on whether they're in a foreign package; and indeed with hintProcessing, we already show those for foreign packages)