### PR TITLE
refactor common code in CI pipelines

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -22,15 +22,11 @@ tasks:
     set -e
     cd Nim
     . ci/funs.sh && nimBuildCsourcesIfNeeded
-    $nim_csources c --skipUserCfg --skipParentCfg koch
     echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     set -e
     cd Nim
-    if ! ./koch runCI; then
-      nim r tools/ci_testresults.nim
-      exit 1
-    fi
+    . ci/funs.sh && nimInternalBuildKochAndRunCI
 triggers:
 - action: email
   condition: failure

--- a/.builds/openbsd_0.yml
+++ b/.builds/openbsd_0.yml
@@ -22,15 +22,11 @@ tasks:
     set -e
     cd Nim
     . ci/funs.sh && nimBuildCsourcesIfNeeded
-    $nim_csources c --skipUserCfg --skipParentCfg koch
     echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     set -e
     cd Nim
-    if ! ./koch runCI; then
-      nim r tools/ci_testresults.nim
-      exit 1
-    fi
+    . ci/funs.sh && nimInternalBuildKochAndRunCI
 triggers:
 - action: email
   condition: failure

--- a/.builds/openbsd_1.yml
+++ b/.builds/openbsd_1.yml
@@ -22,15 +22,11 @@ tasks:
     set -e
     cd Nim
     . ci/funs.sh && nimBuildCsourcesIfNeeded
-    $nim_csources c --skipUserCfg --skipParentCfg koch
     echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     set -e
     cd Nim
-    if ! ./koch runCI; then
-      nim r tools/ci_testresults.nim
-      exit 1
-    fi
+    . ci/funs.sh && nimInternalBuildKochAndRunCI
 triggers:
 - action: email
   condition: failure

--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -59,11 +59,9 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          mkdir dist
-          curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
-          curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
-          7z x dist/mingw64.7z -odist
-          7z x dist/dlls.zip -obin
+          set -e
+          . ci/funs.sh
+          nimInternalInstallDepsWindows
           echo "${{ github.workspace }}/dist/mingw64/bin" >> "${GITHUB_PATH}"
 
       - name: 'Add build binaries to PATH'

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -57,14 +57,6 @@ jobs:
         shell: bash
         run: . ci/funs.sh && nimBuildCsourcesIfNeeded CC=gcc ucpu='${{ matrix.cpu }}'
 
-      - name: 'Build koch'
+      - name: 'koch, Run CI'
         shell: bash
-        run: nim c koch
-      - name: 'Run CI'
-        shell: bash
-        run: ./koch runCI
-
-      - name: 'Show failed tests'
-        if: failure()
-        shell: bash
-        run: nim c -r tools/ci_testresults.nim
+        run: . ci/funs.sh && nimInternalBuildKochAndRunCI

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -40,12 +40,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          mkdir dist
-          curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
-          curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
-          7z x dist/mingw64.7z -odist
-          7z x dist/dlls.zip -obin
-          echo "${{ github.workspace }}/dist/mingw64/bin" >> "${GITHUB_PATH}"
+          set -e
+          . ci/funs.sh
+          nimInternalInstallDepsWindows
+          echo_run echo "${{ github.workspace }}/dist/mingw64/bin" >> "${GITHUB_PATH}"
 
       - name: 'Add build binaries to PATH'
         shell: bash

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,13 +159,9 @@ jobs:
     #   condition: and(succeeded(), eq(variables['skipci'], 'false'))
     #   displayName: 'Restore built csourcesAny'
 
-    - bash: nim c koch
+    - bash: . ci/funs.sh && nimInternalBuildKochAndRunCI
+      # would could also show on failure: echo '##vso[task.complete result=Failed]'
       condition: and(succeeded(), eq(variables['skipci'], 'false'))
-      displayName: 'Build koch'
-
-      # set result to omit the "bash exited with error code '1'" message
-    - bash: ./koch runCI || echo '##vso[task.complete result=Failed]'
-      condition: and(succeeded(), eq(variables['skipci'], 'false'))
-      displayName: 'Run CI'
+      displayName: 'koch, Run CI'
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,11 +133,7 @@ jobs:
     - bash: |
         set -e
         . ci/funs.sh
-        echo_run mkdir dist
-        echo_run curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
-        echo_run curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
-        echo_run 7z x dist/mingw64.7z -odist
-        echo_run 7z x dist/dlls.zip -obin
+        nimInternalInstallDepsWindows
         echo_run echo '##vso[task.prependpath]$(System.DefaultWorkingDirectory)/dist/mingw64/bin'
 
       displayName: 'Install dependencies (Windows)'

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -31,6 +31,24 @@ nimIsCiSkip(){
   fi
 }
 
+nimInternalInstallDepsWindows(){
+  echo_run mkdir dist
+  echo_run curl -L https://nim-lang.org/download/mingw64.7z -o dist/mingw64.7z
+  echo_run curl -L https://nim-lang.org/download/dlls.zip -o dist/dlls.zip
+  echo_run 7z x dist/mingw64.7z -odist
+  echo_run 7z x dist/dlls.zip -obin
+}
+
+nimInternalBuildKochAndRunCI(){
+  echo_run nim c koch
+  echo_run ./koch runCI
+  if [ $? -ne 0 ]; then
+    echo_run echo "runCI failed"
+    echo_run nim r tools/ci_testresults.nim
+    exit 1
+  fi
+}
+
 nimDefineVars(){
   . config/build_config.txt
   nim_csources=bin/nim_csources_$nim_csourcesHash

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -41,11 +41,10 @@ nimInternalInstallDepsWindows(){
 
 nimInternalBuildKochAndRunCI(){
   echo_run nim c koch
-  echo_run ./koch runCI
-  if [ $? -ne 0 ]; then
+  if ! echo_run ./koch runCI; then
     echo_run echo "runCI failed"
-    echo_run nim r tools/ci_testresults.nim
-    exit 1
+    echo_run nim r -tools/ci_testresults.nim
+    return 1
   fi
 }
 

--- a/tools/ci_generate.nim
+++ b/tools/ci_generate.nim
@@ -29,15 +29,11 @@ tasks:
     set -e
     cd Nim
     . ci/funs.sh && nimBuildCsourcesIfNeeded
-    $nim_csources c --skipUserCfg --skipParentCfg koch
     echo 'export PATH=$HOME/Nim/bin:$PATH' >> $HOME/.buildenv
 - test: |
     set -e
     cd Nim
-    if ! ./koch runCI; then
-      nim r tools/ci_testresults.nim
-      exit 1
-    fi
+    . ci/funs.sh && nimInternalBuildKochAndRunCI
 triggers:
 - action: email
   condition: failure


### PR DESCRIPTION
now that there's interest in adding yet more CI pipelines (eg https://github.com/nim-lang/Nim/pull/16396 and https://github.com/nim-lang/RFCs/issues/363), we should refactor a bit more to reduce duplication

fixes a minor bug where `nim c -r tools/ci_testresults.nim` would run even if nim wasn't built (as it sometimes happen)

make `nim c -r tools/ci_testresults.nim`  run consistently after runCI failed across CIs (wasn't consistent before)

## CI failure unrelated (TLDR: it works)
see https://builds.sr.ht/~timotheecour/job/507976 `Not updating GitHub status; unauthorized build owner`
(i don't run bsd CI's in my PR's except for this one (via `git push -u origin $branch`) since i'm changing `tools/ci_generate.nim`; note that freebsd.yml and openbsd_1.yml  run fine, and the openbsd_0.yml CI failure is unrelated)

EDIT: after clicking resubmit build, it finally worked (see https://builds.sr.ht/~timotheecour/job/508367) but for some reason it doesn't update the status to green for openbsd_0.yml; some weird builds.sh.rt quirk i guess.