### PR TITLE
add `staticUnroll` (aka `static for`)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -310,6 +310,8 @@
 
 - Added `copyWithin` [for `seq` and `array` for JavaScript targets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin).
 
+- Added `enumerate.staticUnroll`, aka in other languages as `static for`.
+
 
 ## Language changes
 

--- a/lib/std/enumerate.nim
+++ b/lib/std/enumerate.nim
@@ -68,27 +68,17 @@ macro enumerate*(x: ForLoopStmt): untyped {.since: (1, 3).} =
   # now wrap the whole macro in a block to create a new scope
   result = newBlockStmt(result)
 
-# FACTOR PRTEMP replaceIdentBySym
-proc replaceIdent(n: NimNode, identOld: NimNode, nNew: NimNode): NimNode =
-  case n.kind
-  of nnkIdent: # TODO: nnkSym?
-    if eqIdent(n, identOld): return nNew
-    else: return n
-  else:
-    for i in 0..<len(n):
-      n[i] = replaceIdent(n[i], identOld, nNew)
-    return n
-
-macro staticFor*(x: ForLoopStmt): untyped =
+macro staticUnroll*(x: ForLoopStmt): untyped =
+  ## Also known as `static for` in some other languages.
   runnableExamples:
-    for i, T in staticFor([int, float]):
+    for i, T in staticUnroll([int, float]):
       when i == 0: assert T is int
       else: assert T is float
 
     proc fn1(x: auto): auto = x
     proc fn2(x: auto): auto = x * x
-    # for i, fn in staticFor([fn1, fn2]):
-    #   for j, T in staticFor([int, float]):
+    # for i, fn in staticUnroll([fn1, fn2]):
+    #   for j, T in staticUnroll([int, float]):
     #     let a = fn(T.default)
 
     #     const i2 = i + j
@@ -105,15 +95,11 @@ macro staticFor*(x: ForLoopStmt): untyped =
   var varName = x[1] # PRTEMP
   let varIndex2 = genSym(nskConst, varIndex.strVal)
   for i, ai in elems[1]:
-    echo (i, ai.repr)
     let i2 = newLit(i)
-    var n2 = replaceIdent(body.copyNimTree, varName, ai)
-    n2 = replaceIdent(n2, varIndex2, i2)
     let ret = quote do:
-      template tmp =
-        `n2`
-      tmp
-    # result.add n2
+      template impl(`varIndex`, `varName`) {.gensym.}=
+        `body`
+      impl(`i2`, `ai`)
     result.add ret
   echo result.repr
 
@@ -121,12 +107,14 @@ when isMainModule:
   #[
   TODO: see also: fieldPairs, fields
   ]#
-  for i, bi in staticFor([int, float]):
-    for j, bj in staticFor([fn1, fn2]):
+  # for T in staticUnroll([int, float]):
+  #   echo $T
+  for i, bi in staticUnroll([int, float]):
+    for j, bj in staticUnroll([fn1, fn2]):
       const i2 = i + j
       echo ($bi, astToStr(bj), i, j, i2)
 
-  for i, T in staticFor([int, float]):
+  for i, T in staticUnroll([int, float]):
     var z = i
     const z2 = i
     var z3: T

--- a/lib/std/enumerate.nim
+++ b/lib/std/enumerate.nim
@@ -102,12 +102,6 @@ macro staticUnroll*(x: ForLoopStmt): untyped =
       const name = i
     assert name1 == 1
 
-  runnableExamples:
-    template baz =
-      for i, name in staticUnroll([name0, name1]):
-        const name = i
-      assert name1 == 1
-    baz()
   # xxx maybe `fieldPairs`, `fields` implementation in compiler could reuse this trick
   expectKind x, nnkForStmt
   var varIndex: NimNode

--- a/lib/std/enumerate.nim
+++ b/lib/std/enumerate.nim
@@ -12,7 +12,7 @@
 import std/private/since
 import macros
 
-
+# xxx this code should be simplified using quote/genAst (e.g. as done in PR #17633)
 macro enumerate*(x: ForLoopStmt): untyped {.since: (1, 3).} =
   ## Enumerating iterator for collections.
   ##

--- a/lib/system/iterators.nim
+++ b/lib/system/iterators.nim
@@ -274,6 +274,7 @@ iterator fields*[T: tuple|object](x: T): RootObj {.
   ## .. warning:: This really transforms the 'for' and unrolls the loop.
   ##   The current implementation also has a bug
   ##   that affects symbol binding in the loop body.
+  # see also `enumerate.staticUnroll`
   runnableExamples:
     var t = (1, "foo")
     for v in fields(t): v = default(typeof(v))

--- a/tests/stdlib/tenumerate.nim
+++ b/tests/stdlib/tenumerate.nim
@@ -1,19 +1,59 @@
+discard """
+  targets: "c js"
+"""
+
 import std/enumerate
 
-let a = @[1, 3, 5, 7]
+template main() = 
+  block: # enumerate
+    let a = @[1, 3, 5, 7]
+    block:
+      var res: seq[(int, int)]
+      for i, x in enumerate(a):
+        res.add (i, x)
+      doAssert res == @[(0, 1), (1, 3), (2, 5), (3, 7)]
+    block:
+      var res: seq[(int, int)]
+      for (i, x) in enumerate(a.items):
+        res.add (i, x)
+      doAssert res == @[(0, 1), (1, 3), (2, 5), (3, 7)]
+    block:
+      var res: seq[(int, int)]
+      for i, x in enumerate(3, a):
+        res.add (i, x)
+      doAssert res == @[(3, 1), (4, 3), (5, 5), (6, 7)]
 
-block:
-  var res: seq[(int, int)]
-  for i, x in enumerate(a):
-    res.add (i, x)
-  doAssert res == @[(0, 1), (1, 3), (2, 5), (3, 7)]
-block:
-  var res: seq[(int, int)]
-  for (i, x) in enumerate(a.items):
-    res.add (i, x)
-  doAssert res == @[(0, 1), (1, 3), (2, 5), (3, 7)]
-block:
-  var res: seq[(int, int)]
-  for i, x in enumerate(3, a):
-    res.add (i, x)
-  doAssert res == @[(3, 1), (4, 3), (5, 5), (6, 7)]
+  block: # staticUnroll
+    for i, name in staticUnroll([name0, name1]):
+      const name = i
+    assert name0 == 0
+    assert name1 == 1
+
+    # works inside a template too
+    template baz =
+      for i, name in staticUnroll([name0, name1]):
+        const name = i
+      assert name1 == 1
+    baz()
+
+    block:
+      for i, T in staticUnroll([int, float, string]):
+        when i == 1:
+          var a0 {.inject.}: T
+      assert a0 == 0.0
+
+    block:
+      proc bar: auto =
+        for i, val in staticUnroll([10, 11]):
+          return i + val
+      assert bar() == 0 + 10
+
+    block:
+      var c = 0
+      for i in staticUnroll([0, 1]):
+        for j in staticUnroll([0, 1]):
+          c += i + j
+      assert c == 4
+
+static: main()
+main()


### PR DESCRIPTION
finally gotten around to publishing a PR for this.

this is essentially D's `static foreach` (https://dlang.org/spec/version.html#staticforeach), which is very useful, but more flexible, and implemented in library code.

by design, it:
* unrolls in caller scope, but the template/gensym/inject rules apply, see examples.
* allows unrolling not just values, but also types, undefined idents, etc...

## examples
```nim
  runnableExamples:
    var msg = ""
    for T in staticUnroll([int, float]):
      var a: T # a is gensym'd so won't cause a redefinition error
      proc fn() {.gensym.} = discard # gensym needed here
      proc fn2(a: T): auto = a # regular overloading here
      msg.add $T & " "
    assert msg == "int float "
    assert fn2(1.1) == 1.1 # `staticUnroll` is evaluated in caller scope

    # with 2 loop parameters, the 1st one is a const int indexing the element
    for i, T in staticUnroll([int, float, string]):
      when i == 0: assert T is int
      elif i == 1: assert T is float
      else: assert T is string

  runnableExamples:
    # example showing nested loops
    var msg = ""
    proc fn1(a: auto) = msg.add $("fn1", a)
    proc fn2(a: auto) = msg.add $("fn1", a)
    for fn in staticUnroll([fn1, fn2]):
      for T in staticUnroll([int, float]):
        fn(T.default)
    assert msg == """("fn1", 0)("fn1", 0.0)("fn1", 0)("fn1", 0.0)"""

  runnableExamples:
    # example showing passing untyped arguments to define variables
    for i, name in staticUnroll([name0, name1]):
      const name = i
    assert name1 == 1
```

## note 1
I didn't name it `unroll` to avoid confusion with the deprecated `{.unroll.}`, and which could also be revived as a library solution, but has slightly different semantics

