### PR TITLE
Use gmake for NetBSD as well as FreeBSD/OpenBSD

### DIFF
--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -55,6 +55,8 @@ _nimBuildCsourcesIfNeeded(){
     makeX=gmake
   elif [ "$unamestr" = 'OpenBSD' ]; then
     makeX=gmake
+  elif [ "$unamestr" = 'NetBSD' ]; then
+    makeX=gmake
   else
     makeX=make
   fi


### PR DESCRIPTION
When using the CI functions on NetBSD, `gmake` should be used rather than `make` as it is on FreeBSD and OpenBSD.

`make` does not support the `-l` flag on NetBSD.