### PR TITLE
macros.treeRepr + friends: collapse SymChoice

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -81,6 +81,9 @@
 
 - Deprecated `proc reversed*[T](a: openArray[T], first: Natural, last: int): seq[T]` in `std/algorithm`.
 
+-  In `std/macros`, `treeRepr,lispRepr,astGenRepr` now represent SymChoice nodes in a collapsed way,
+   use `-d:nimLegacyMacrosCollapseSymChoice` to get previous behavior.
+
 - The configuration subsystem now allows for `-d:release` and `-d:danger` to work as expected.
   The downside is that these defines now have custom logic that doesn't apply for
   other defines.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -877,9 +877,9 @@ proc eqIdent*(a: NimNode; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
   ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
   ## these nodes will be unwrapped.
 
-const collapseSymChoiceDefault = not defined(nimLegacyMacrosCollapseSymChoice)
+const collapseSymChoice = not defined(nimLegacyMacrosCollapseSymChoice)
 
-proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indented = false, collapseSymChoice = collapseSymChoiceDefault) {.benign.} =
+proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indented = false) {.benign.} =
   if level > 0:
     if indented:
       res.add("\n")
@@ -918,29 +918,29 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
         res.add(" " & $n[0].strVal.newLit.repr)
       else:
         for j in 0 ..< n.len:
-          n[j].treeTraverse(res, level+1, isLisp, indented, collapseSymChoice)
+          n[j].treeTraverse(res, level+1, isLisp, indented)
   else:
     for j in 0 ..< n.len:
-      n[j].treeTraverse(res, level+1, isLisp, indented, collapseSymChoice)
+      n[j].treeTraverse(res, level+1, isLisp, indented)
 
   if isLisp:
     res.add(")")
 
-proc treeRepr*(n: NimNode, collapseSymChoice = collapseSymChoiceDefault): string {.benign.} =
+proc treeRepr*(n: NimNode): string {.benign.} =
   ## Convert the AST `n` to a human-readable tree-like string.
   ##
   ## See also `repr`, `lispRepr`, and `astGenRepr`.
   result = ""
-  n.treeTraverse(result, isLisp = false, indented = true, collapseSymChoice = collapseSymChoice)
+  n.treeTraverse(result, isLisp = false, indented = true)
 
-proc lispRepr*(n: NimNode; indented = false, collapseSymChoice = collapseSymChoiceDefault): string {.benign.} =
+proc lispRepr*(n: NimNode; indented = false): string {.benign.} =
   ## Convert the AST `n` to a human-readable lisp-like string.
   ##
   ## See also `repr`, `treeRepr`, and `astGenRepr`.
   result = ""
-  n.treeTraverse(result, isLisp = true, indented = indented, collapseSymChoice = collapseSymChoice)
+  n.treeTraverse(result, isLisp = true, indented = indented)
 
-proc astGenRepr*(n: NimNode, collapseSymChoice = collapseSymChoiceDefault): string {.benign.} =
+proc astGenRepr*(n: NimNode): string {.benign.} =
   ## Convert the AST `n` to the code required to generate that AST.
   ##
   ## See also `repr`, `treeRepr`, and `lispRepr`.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -856,6 +856,27 @@ proc nestList*(op: NimNode; pack: NimNode; init: NimNode): NimNode =
   for i in countdown(pack.len - 1, 0):
     result = newCall(op, pack[i], result)
 
+proc eqIdent*(a: string; b: string): bool {.magic: "EqIdent", noSideEffect.}
+  ## Style insensitive comparison.
+
+proc eqIdent*(a: NimNode; b: string): bool {.magic: "EqIdent", noSideEffect.}
+  ## Style insensitive comparison.  `a` can be an identifier or a
+  ## symbol. `a` may be wrapped in an export marker
+  ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
+  ## these nodes will be unwrapped.
+
+proc eqIdent*(a: string; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
+  ## Style insensitive comparison.  `b` can be an identifier or a
+  ## symbol. `b` may be wrapped in an export marker
+  ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
+  ## these nodes will be unwrapped.
+
+proc eqIdent*(a: NimNode; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
+  ## Style insensitive comparison.  `a` and `b` can be an
+  ## identifier or a symbol. Both may be wrapped in an export marker
+  ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
+  ## these nodes will be unwrapped.
+
 const collapseSymChoiceDefault = not defined(nimLegacyMacrosCollapseSymChoice)
 
 proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indented = false, collapseSymChoice = collapseSymChoiceDefault) {.benign.} =
@@ -888,10 +909,19 @@ proc treeTraverse(n: NimNode; res: var string; level = 0; isLisp = false, indent
   elif n.kind in {nnkOpenSymChoice, nnkClosedSymChoice} and collapseSymChoice:
     res.add(" " & $n.len)
     if n.len > 0:
-      res.add(" " & $n[0].strVal.newLit.repr)
+      var allSameSymName = true
+      for i in 0..<n.len:
+        if n[i].kind != nnkSym or not eqIdent(n[i], n[0]):
+          allSameSymName = false
+          break
+      if allSameSymName:
+        res.add(" " & $n[0].strVal.newLit.repr)
+      else:
+        for j in 0 ..< n.len:
+          n[j].treeTraverse(res, level+1, isLisp, indented, collapseSymChoice)
   else:
     for j in 0 ..< n.len:
-      n[j].treeTraverse(res, level+1, isLisp, indented)
+      n[j].treeTraverse(res, level+1, isLisp, indented, collapseSymChoice)
 
   if isLisp:
     res.add(")")
@@ -1403,27 +1433,6 @@ proc unpackInfix*(node: NimNode): tuple[left: NimNode; op: string; right: NimNod
 proc copy*(node: NimNode): NimNode =
   ## An alias for `copyNimTree<#copyNimTree,NimNode>`_.
   return node.copyNimTree()
-
-proc eqIdent*(a: string; b: string): bool {.magic: "EqIdent", noSideEffect.}
-  ## Style insensitive comparison.
-
-proc eqIdent*(a: NimNode; b: string): bool {.magic: "EqIdent", noSideEffect.}
-  ## Style insensitive comparison.  `a` can be an identifier or a
-  ## symbol. `a` may be wrapped in an export marker
-  ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
-  ## these nodes will be unwrapped.
-
-proc eqIdent*(a: string; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
-  ## Style insensitive comparison.  `b` can be an identifier or a
-  ## symbol. `b` may be wrapped in an export marker
-  ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
-  ## these nodes will be unwrapped.
-
-proc eqIdent*(a: NimNode; b: NimNode): bool {.magic: "EqIdent", noSideEffect.}
-  ## Style insensitive comparison.  `a` and `b` can be an
-  ## identifier or a symbol. Both may be wrapped in an export marker
-  ## (`nnkPostfix`) or quoted with backticks (`nnkAccQuoted`),
-  ## these nodes will be unwrapped.
 
 proc expectIdent*(n: NimNode, name: string) {.since: (1,1).} =
   ## Check that `eqIdent(n,name)` holds true. If this is not the

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -1,3 +1,9 @@
+#[
+xxx macros tests need to be reorganized to makes sure each API is tested once
+See also:
+  tests/macros/tdumpast.nim for treeRepr + friends
+]#
+
 import std/macros
 
 block: # hasArgOfName


### PR DESCRIPTION
## example
```nim
when true:
  import macros
  macro deb(a: typed): untyped =
    echo a.repr
    echo a.treeRepr
  deb:
    proc bar(a: auto): auto = $a
```
## before PR
```
proc bar(a: auto): auto =
  $a

StmtList
  ProcDef
    Sym "bar"
    Empty
    GenericParams
      Sym "a:type"
    FormalParams
      Sym "auto"
      IdentDefs
        Sym "a"
        Sym "auto"
        Empty
    Empty
    Bracket
      Empty
      Empty
    StmtList
      Prefix
        OpenSymChoice
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
          Sym "$"
        Ident "a"
```

=> shows redundant information which hurts readability

## after PR
```
proc bar(a: auto): auto =
  $a

StmtList
  ProcDef
    Sym "bar"
    Empty
    GenericParams
      Sym "a:type"
    FormalParams
      Sym "auto"
      IdentDefs
        Sym "a"
        Sym "auto"
        Empty
    Empty
    Bracket
      Empty
      Empty
    StmtList
      Prefix
        OpenSymChoice 22 "$"
        Ident "a"
```
