### PR TITLE
fix #16993, #18054, #17835 runnableExamples now works with templates and nested templates

### DIFF
--- a/compiler/evaltempl.nim
+++ b/compiler/evaltempl.nim
@@ -83,10 +83,14 @@ proc evalTemplateAux(templ, actual: PNode, c: var TemplCtx, result: PNode) =
         not c.isDeclarative:
       c.isDeclarative = true
       isDeclarative = true
-    var res = copyNode(c, templ, actual)
-    for i in 0..<templ.len:
-      evalTemplateAux(templ[i], actual, c, res)
-    result.add res
+    if (not c.isDeclarative) and templ.kind in nkCallKinds and isRunnableExamples(templ[0]):
+      # fixes bug #16993, bug #18054
+      discard
+    else:
+      var res = copyNode(c, templ, actual)
+      for i in 0..<templ.len:
+        evalTemplateAux(templ[i], actual, c, res)
+      result.add res
     if isDeclarative: c.isDeclarative = false
 
 const

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.html
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.html
@@ -206,9 +206,9 @@ constructor.
 <dt><pre><span class="Keyword">template</span> <a href="#fromUtilsGen.t"><span class="Identifier">fromUtilsGen</span></a><span class="Other">(</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">untyped</span></pre></dt>
 <dd>
 
-this should be shown in utils.html
+should be shown in utils.html only
 <p><strong class="examples_text">Example:</strong></p>
-<pre class="listing"><span class="Identifier">assert</span> <span class="DecNumber">3</span><span class="Operator">*</span><span class="DecNumber">2</span> <span class="Operator">==</span> <span class="DecNumber">6</span></pre>ditto
+<pre class="listing"><span class="Keyword">discard</span> <span class="StringLit">&quot;should be in utils.html only, not in module that calls fromUtilsGen&quot;</span></pre>ditto
 
 </dd>
 

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -431,10 +431,7 @@ window.addEventListener('DOMContentLoaded', main);
 <span class="Keyword">discard</span> <span class="StringLit">&quot;in top2&quot;</span></pre>top2 after
 <p><strong class="examples_text">Example:</strong></p>
 <pre class="listing"><span class="Keyword">import</span> <span class="Identifier">testproject</span>
-<span class="Keyword">discard</span> <span class="StringLit">&quot;in top3&quot;</span></pre>top3 after
-<p><strong class="examples_text">Example:</strong></p>
-<pre class="listing"><span class="Keyword">import</span> <span class="Identifier">testproject</span>
-<span class="Identifier">assert</span> <span class="DecNumber">3</span><span class="Operator">*</span><span class="DecNumber">2</span> <span class="Operator">==</span> <span class="DecNumber">6</span></pre></p>
+<span class="Keyword">discard</span> <span class="StringLit">&quot;in top3&quot;</span></pre>top3 after</p>
   <div class="section" id="6">
 <h1><a class="toc-backref" href="#6">Imports</a></h1>
 <dl class="item">
@@ -574,7 +571,8 @@ My someFunc. Stuff in <tt class="docutils literal"><span class="pre"><span class
 
 came form utils but should be shown where <tt class="docutils literal"><span class="pre"><span class="Identifier">fromUtilsGen</span></span></tt> is called
 <p><strong class="examples_text">Example:</strong></p>
-<pre class="listing"><span class="Keyword">discard</span> <span class="DecNumber">1</span></pre>
+<pre class="listing"><span class="Keyword">discard</span> <span class="LongStringLit">&quot;&quot;&quot;should be shown as examples for fromUtils3
+       in module calling fromUtilsGen&quot;&quot;&quot;</span></pre>
 
 </dd>
 <a id="isValid,T"></a>
@@ -957,6 +955,9 @@ cz18
 <dd>
 
 ok3
+<p><strong class="examples_text">Example:</strong></p>
+<pre class="listing"><span class="Keyword">discard</span> <span class="LongStringLit">&quot;&quot;&quot;should be shown as examples for fromUtils2
+       in module calling fromUtilsGen&quot;&quot;&quot;</span></pre>
 
 </dd>
 <a id="z6t.t"></a>

--- a/nimdoc/testproject/subdir/subdir_b/utils.nim
+++ b/nimdoc/testproject/subdir/subdir_b/utils.nim
@@ -50,9 +50,9 @@ template bEnum*(): untyped =
     discard
 
 template fromUtilsGen*(): untyped =
-  ## this should be shown in utils.html
+  ## should be shown in utils.html only
   runnableExamples:
-    assert 3*2 == 6
+    discard "should be in utils.html only, not in module that calls fromUtilsGen"
   ## ditto
 
   iterator fromUtils1*(): int =
@@ -64,7 +64,11 @@ template fromUtilsGen*(): untyped =
 
   template fromUtils2*() =
     ## ok3
+    runnableExamples:
+      discard """should be shown as examples for fromUtils2
+       in module calling fromUtilsGen"""
 
   proc fromUtils3*() =
     ## came form utils but should be shown where `fromUtilsGen` is called
-    runnableExamples: discard 1
+    runnableExamples: discard """should be shown as examples for fromUtils3
+       in module calling fromUtilsGen"""

--- a/tests/js/tstdlib_various.nim
+++ b/tests/js/tstdlib_various.nim
@@ -153,7 +153,7 @@ block tsplit2:
   var errored = false
   try:
     discard "hello".split("")
-  except AssertionError:
+  except AssertionDefect:
     errored = true
   doAssert errored
 

--- a/tests/nimdoc/trunnableexamples.nim
+++ b/tests/nimdoc/trunnableexamples.nim
@@ -152,6 +152,16 @@ when true: # bug #18054
     inner1()
     inner2()
 
+when true: # bug #17835
+  template anyItFake*(s, pred: untyped): bool =
+    ## Foo
+    runnableExamples: discard
+    true
+
+  proc anyItFakeMain*(n: seq[int]): bool =
+    result = anyItFake(n, it == 0)
+      # this was giving: Error: runnableExamples must appear before the first non-comment statement
+
 runnableExamples:
   block: # bug #17279
     when int.sizeof == 8:

--- a/tests/nimdoc/trunnableexamples2.nim
+++ b/tests/nimdoc/trunnableexamples2.nim
@@ -1,0 +1,11 @@
+discard """
+cmd: "nim doc --doccmd:-d:testFooExternal --hints:off $file"
+action: "compile"
+joinable: false
+"""
+
+# pending bug #18077, merge back inside trunnableexamples.nim
+when true: # runnableExamples with rdoccmd
+  runnableExamples "-d:testFoo -d:testBar":
+    doAssert defined(testFoo) and defined(testBar)
+    doAssert defined(testFooExternal)


### PR DESCRIPTION
fix #16993
fix #18054
fix #17835
close #17842 as this is a proper fix whereas #17842 was a workaround

the diff in nimdoc/testproject/subdir/subdir_b/utils.nim sums it up.

## future work
- [ ] after this PR, `code-block` has almost no use cases left in nim sources and should be replaced by  `runnableExamples`
- [ ] we could also introduce a flag `runnableExamples(inject = true)` to inject the runnableExamples of a template `foo` at the place where `foo` is called, but this is a niche feature, and the main use case is the one implemented by this PR (as evidenced by those bug reports)

## notes
related past issues (dealing with doc comments instead of runnableExamples):
https://github.com/nim-lang/Nim/issues/9596, https://github.com/nim-lang/Nim/issues/9432, https://github.com/nim-lang/Nim/issues/9626, https://github.com/nim-lang/Nim/issues/9473, https://github.com/nim-lang/Nim/issues/9469

I also encountered https://github.com/nim-lang/Nim/issues/18077 while fixing this (EDIT: fixing it here: https://github.com/nim-lang/Nim/pull/18086)