### PR TITLE
fix #18077 testament now parses `cmd` properly

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -108,8 +108,9 @@ proc runBasicDLLTest(c, r: var TResults, cat: Category, options: string) =
     var hcri = makeTest("tests/dll/nimhcr_integration.nim",
                                    options & " --forceBuild --hotCodeReloading:on" & rpath, cat)
     let nimcache = nimcacheDir(hcri.name, hcri.options, getTestSpecTarget())
-    hcri.args = prepareTestArgs(hcri.spec.getCmd, hcri.name,
+    let cmd = prepareTestCmd(hcri.spec.getCmd, hcri.name,
                                 hcri.options, nimcache, getTestSpecTarget())
+    hcri.testArgs = cmd.parseCmdLine
     testSpec r, hcri
 
 proc dllTests(r: var TResults, cat: Category, options: string) =

--- a/tests/misc/t18077.nim
+++ b/tests/misc/t18077.nim
@@ -1,0 +1,21 @@
+discard """
+  cmd: '''nim doc -d:nimTestsT18077b:4 --doccmd:"-d:nimTestsT18077 -d:nimTestsT18077b:3 --hints:off" $file'''
+  action: compile
+"""
+
+# bug #18077
+
+const nimTestsT18077b {.intdefine.} = 1
+
+static:
+  when defined(nimdoc):
+    doAssert nimTestsT18077b == 4
+    doAssert not defined(nimTestsT18077)
+  else:
+    doAssert defined(nimTestsT18077)
+    doAssert nimTestsT18077b == 3
+
+runnableExamples:
+  const nimTestsT18077b {.intdefine.} = 2
+  doAssert nimTestsT18077b == 3
+  doAssert defined(nimTestsT18077)


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/18077
this PR avoids using `parseCmdLine` which is buggy (see https://github.com/nim-lang/Nim/issues/14343), and calls startProcess with input cmd directly instead of converting it via `parseCmdLine`

in future work we should still fix https://github.com/nim-lang/Nim/issues/14343, for other reasons

see test: tests/misc/t18077.nim (which would fail before this PR)

## future work
- [x] remove callCCompiler + related code as explained in this PR => https://github.com/nim-lang/Nim/pull/18087

