### PR TITLE
simplify extccomp.nim json logic via jsonutils; fix #18084

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -994,15 +994,14 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
   conf.jsonBuildFile.string.writeFile(bcache.toJson.pretty)
 
 proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile): bool =
-  if not fileExists(jsonFile): return true
-  if not fileExists(conf.absOutFile): return true
-  result = false
+  if not fileExists(jsonFile) or not fileExists(conf.absOutFile): return true
   var bcache: BuildCache
   try: bcache.fromJson(jsonFile.string.parseFile)
   except IOError, OSError, ValueError:
     stderr.write "Warning: JSON processing failed: $#\n" % getCurrentExceptionMsg()
     return true
   if bcache.currentDir != getCurrentDir() or # fixes bug #16271
+     bcache.outputFile != conf.absOutFile.string or
      bcache.cmdline != conf.commandLine or bcache.nimexe != hashNimExe() or
      bcache.projectIsCmd != conf.projectIsCmd or conf.cmdInput != bcache.cmdInput: return true
   if bcache.stdinInput or conf.projectIsStdin: return true

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -14,8 +14,7 @@
 
 import ropes, platform, condsyms, options, msgs, lineinfos, pathutils
 
-import os, strutils, osproc, std/sha1, streams, sequtils, times, strtabs, json
-from sugar import collect
+import std/[os, strutils, osproc, sha1, streams, sequtils, times, strtabs, json, jsonutils, sugar]
 
 type
   TInfoCCProp* = enum         # properties of the C compiler:
@@ -943,8 +942,6 @@ proc jsonBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
   # works out of the box with `hashMainCompilationParams`.
   result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
 
-import std/jsonutils
-
 const cacheVersion = "D20210525T193831" # update when `BuildCache` spec changes
 type BuildCache = object
   cacheVersion: string
@@ -994,7 +991,6 @@ proc writeJsonBuildInstructions*(conf: ConfigRef) =
 proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; jsonFile: AbsoluteFile): bool =
   if not fileExists(jsonFile) or not fileExists(conf.absOutFile): return true
   var bcache: BuildCache
-  # bcache.fromJson(jsonFile.string.parseFile)
   try: bcache.fromJson(jsonFile.string.parseFile)
   except IOError, OSError, ValueError:
     stderr.write "Warning: JSON processing failed for $#: $#\n" % [jsonFile.string, getCurrentExceptionMsg()]

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -943,11 +943,11 @@ proc jsonBuildInstructionsFile*(conf: ConfigRef): AbsoluteFile =
   result = getNimcacheDir(conf) / conf.outFile.changeFileExt("json")
 
 import std/jsonutils
+
 proc writeJsonBuildInstructions*(conf: ConfigRef) =
   proc cfiles(clist: CfileList): JsonNode =
     result = newJArray()
     for i, it in clist:
-      echo (it.cname, it.flags, "D20210525T094642")
       if CfileFlag.Cached in it.flags: continue
       result.add toJson([it.cname.string, getCompileCFileCmd(conf, it)])
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -307,7 +307,7 @@ type
                        ## should be run
     ideCmd*: IdeCmd
     oldNewlines*: bool
-    cCompiler*: TSystemCC
+    cCompiler*: TSystemCC # the used compiler
     modifiedyNotes*: TNoteKinds # notes that have been set/unset from either cmdline/configs
     cmdlineNotes*: TNoteKinds # notes that have been set/unset from cmdline
     foreignPackageNotes*: TNoteKinds
@@ -352,7 +352,7 @@ type
     docRoot*: string ## see nim --fullhelp for --docRoot
     docCmd*: string ## see nim --fullhelp for --docCmd
 
-     # the used compiler
+    configFiles*: seq[AbsoluteFile]     # config files (cfg,nims)
     cIncludes*: seq[AbsoluteDir]  # directories to search for included files
     cLibs*: seq[AbsoluteDir]      # directories to search for lib files
     cLinkedLibs*: seq[string]     # libraries to link

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -286,8 +286,12 @@ proc toJson*[T](a: T, opt = initToJsonOptions()): JsonNode =
       result = newJArray()
       for v in a.fields: result.add toJson(v, opt)
   elif T is ref | ptr:
-    if system.`==`(a, nil): result = newJNull()
-    else: result = toJson(a[], opt)
+    when T is JsonNode:
+      # xxx we could customize this by ignoring json special case
+      result = a
+    else:
+      if system.`==`(a, nil): result = newJNull()
+      else: result = toJson(a[], opt)
   elif T is array | seq | set:
     result = newJArray()
     for ai in a: result.add toJson(ai, opt)

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -34,6 +34,23 @@ import macros
 from enumutils import symbolName
 from typetraits import OrdinalEnum
 
+when not defined(nimFixedForwardGeneric):
+  # xxx remove pending csources_v1 update >= 1.2.0
+  proc to[T](node: JsonNode, t: typedesc[T]): T =
+    when T is string: node.getStr
+    elif T is bool: node.getBool
+    else: static: doAssert false, $T # support as needed (only needed during bootstrap)
+  proc isNamedTuple(T: typedesc): bool = # old implementation
+    when T isnot tuple: result = false
+    else:
+      var t: T
+      for name, _ in t.fieldPairs:
+        when name == "Field0": return compiles(t.Field0)
+        else: return true
+      return false
+else:
+  proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
+
 type
   Joptions* = object # xxx rename FromJsonOptions
     ## Options controlling the behavior of `fromJson`.
@@ -56,7 +73,6 @@ proc initToJsonOptions*(): ToJsonOptions =
   ## initializes `ToJsonOptions` with sane options.
   ToJsonOptions(enumMode: joptEnumOrd)
 
-proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
 proc distinctBase(T: typedesc): typedesc {.magic: "TypeTrait".}
 template distinctBase[T](a: T): untyped = distinctBase(typeof(a))(a)
 

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -286,12 +286,8 @@ proc toJson*[T](a: T, opt = initToJsonOptions()): JsonNode =
       result = newJArray()
       for v in a.fields: result.add toJson(v, opt)
   elif T is ref | ptr:
-    when T is JsonNode:
-      # xxx we could customize this by ignoring json special case
-      result = a
-    else:
-      if system.`==`(a, nil): result = newJNull()
-      else: result = toJson(a[], opt)
+    if system.`==`(a, nil): result = newJNull()
+    else: result = toJson(a[], opt)
   elif T is array | seq | set:
     result = newJArray()
     for ai in a: result.add toJson(ai, opt)


### PR DESCRIPTION
* fix #18084
* simplify extccomp.nim json logic via jsonutils
the resulting code is much simpler, concise and maintainable (removes 100 LOC, and more after we'll remove the bootstrap workaround)
