### PR TITLE
document macros.unpackVarargs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -82,6 +82,8 @@
   The downside is that these defines now have custom logic that doesn't apply for
   other defines.
 
+- Deprecated `macros.unpackVarargs` which wasn't useful.
+
 
 
 ## Standard library additions and changes

--- a/changelog.md
+++ b/changelog.md
@@ -82,8 +82,6 @@
   The downside is that these defines now have custom logic that doesn't apply for
   other defines.
 
-- Deprecated `macros.unpackVarargs` which wasn't useful.
-
 
 
 ## Standard library additions and changes

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1681,8 +1681,18 @@ macro getCustomPragmaVal*(n: typed, cp: typed): untyped =
   else:
     error(n.repr & " doesn't have a pragma named " & cp.repr, n)
 
-macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped
-  {.deprecated: "use directly `callee(args)`".} =
+macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped =
+  ## Calls `callee` with `args` unpacked as individual arguments.
+  ## This is only useful in the case where `args` can potentially be empty, due
+  ## to a compiler limitation, see examples.
+  runnableExamples:
+    template call(fun: typed; args: varargs[untyped]): untyped =
+      unpackVarargs(fun, args)
+      # when varargsLen(args) > 0: fun(args) else: fun() # this would also work
+    proc fn1(a = 0, b = 1) = discard (a, b)
+    call(fn1, 10, 11)
+    call(fn1, 10)
+    call(fn1) # `args` is empty in this case
   result = newCall(callee)
   for i in 0 ..< args.len:
     result.add args[i]

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1681,7 +1681,8 @@ macro getCustomPragmaVal*(n: typed, cp: typed): untyped =
   else:
     error(n.repr & " doesn't have a pragma named " & cp.repr, n)
 
-macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped =
+macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped
+  {.deprecated: "use directly `callee(args)`".} =
   result = newCall(callee)
   for i in 0 ..< args.len:
     result.add args[i]

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1683,16 +1683,20 @@ macro getCustomPragmaVal*(n: typed, cp: typed): untyped =
 
 macro unpackVarargs*(callee: untyped; args: varargs[untyped]): untyped =
   ## Calls `callee` with `args` unpacked as individual arguments.
-  ## This is only useful in the case where `args` can potentially be empty, due
-  ## to a compiler limitation, see examples.
+  ## This is useful in 2 cases:
+  ## * when forwarding `varargs[T]` for some typed `T`
+  ## * when forwarding `varargs[untyped]` when `args` can potentially be empty,
+  ##   due to a compiler limitation
   runnableExamples:
-    template call(fun: typed; args: varargs[untyped]): untyped =
+    template call1(fun: typed; args: varargs[untyped]): untyped =
       unpackVarargs(fun, args)
       # when varargsLen(args) > 0: fun(args) else: fun() # this would also work
+    template call2(fun: typed; args: varargs[typed]): untyped =
+      unpackVarargs(fun, args)
     proc fn1(a = 0, b = 1) = discard (a, b)
-    call(fn1, 10, 11)
-    call(fn1, 10)
-    call(fn1) # `args` is empty in this case
+    call1(fn1, 10, 11)
+    call1(fn1) # `args` is empty in this case
+    if false: call2(echo, 10, 11) # would print 1011
   result = newCall(callee)
   for i in 0 ..< args.len:
     result.add args[i]

--- a/tests/destructor/tatomicptrs.nim
+++ b/tests/destructor/tatomicptrs.nim
@@ -72,7 +72,8 @@ template `.=`*[T](s: SharedPtr[T]; field, value: untyped) =
 from macros import unpackVarargs
 
 template `.()`*[T](s: SharedPtr[T]; field: untyped, args: varargs[untyped]): untyped =
-  s.x.field(args)
+  # xxx this isn't used, the test should be improved
+  unpackVarargs(s.x.field, args)
 
 
 type

--- a/tests/destructor/tatomicptrs.nim
+++ b/tests/destructor/tatomicptrs.nim
@@ -72,7 +72,7 @@ template `.=`*[T](s: SharedPtr[T]; field, value: untyped) =
 from macros import unpackVarargs
 
 template `.()`*[T](s: SharedPtr[T]; field: untyped, args: varargs[untyped]): untyped =
-  unpackVarargs(s.x.field, args)
+  s.x.field(args)
 
 
 type

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -10,3 +10,14 @@ block: # hasArgOfName
 
 block: # bug #17454
   proc f(v: NimNode): string {.raises: [].} = $v
+
+block: # unpackVarargs
+  proc bar1(a: varargs[int]): string =
+    for ai in a: result.add " " & $ai
+  proc bar2(a: varargs[int]) =
+    let s1 = bar1(a)
+    let s2 = unpackVarargs(bar1, a) # `unpackVarargs` doesn't seem useful...
+    doAssert s1 == s2
+  bar2(1, 2, 3)
+  bar2(1)
+  bar2()

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -12,12 +12,31 @@ block: # bug #17454
   proc f(v: NimNode): string {.raises: [].} = $v
 
 block: # unpackVarargs
-  proc bar1(a: varargs[int]): string =
-    for ai in a: result.add " " & $ai
-  proc bar2(a: varargs[int]) =
-    let s1 = bar1(a)
-    let s2 = unpackVarargs(bar1, a) # `unpackVarargs` doesn't seem useful...
-    doAssert s1 == s2
-  bar2(1, 2, 3)
-  bar2(1)
-  bar2()
+  block:
+    proc bar1(a: varargs[int]): string =
+      for ai in a: result.add " " & $ai
+    proc bar2(a: varargs[int]) =
+      let s1 = bar1(a)
+      let s2 = unpackVarargs(bar1, a) # `unpackVarargs` makes no difference here
+      doAssert s1 == s2
+    bar2(1, 2, 3)
+    bar2(1)
+    bar2()
+
+  block:
+    template call1(fun: typed; args: varargs[untyped]): untyped =
+      unpackVarargs(fun, args)
+    template call2(fun: typed; args: varargs[untyped]): untyped =
+      # fun(args) # works except for last case with empty `args`, pending bug #9996
+      when varargsLen(args) > 0: fun(args)
+      else: fun()
+
+    proc fn1(a = 0, b = 1) = discard (a, b)
+
+    call1(fn1, 10, 11)
+    call1(fn1, 10)
+    call1(fn1)
+
+    call2(fn1, 10, 11)
+    call2(fn1, 10)
+    call2(fn1)


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/18101#issuecomment-848455188
closes https://github.com/nim-lang/Nim/pull/18101

~~(unless a reviewer can point to a use case, I think this is ready for deprecation)~~ see discussion below, in particular https://github.com/nim-lang/Nim/pull/18106#issuecomment-849316282