### PR TITLE
revive Linux_i386; upgrade ubuntu 16.04 (not supported starting dec 2021) => 18.04

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,6 @@
-image: ubuntu:16.04
+# xxx unused, out of date
+
+image: ubuntu:18.04
 
 stages:
   - pre-build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,14 +19,14 @@ jobs:
   strategy:
     matrix:
       Linux_amd64:
-        vmImage: 'ubuntu-16.04'
+        vmImage: 'ubuntu-18.04'
         CPU: amd64
-      # pending bug #17325 (broken again)
-      # Linux_i386:
-      #   # bug #17325: fails on 'ubuntu-16.04' because it now errors with:
-      #   # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
-      #   vmImage: 'ubuntu-18.04'
-      #   CPU: i386
+      # regularly breaks, refs bug #17325
+      Linux_i386:
+        # on 'ubuntu-16.04' (not supported anymore anyways) it errored with:
+        # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
+        vmImage: 'ubuntu-18.04'
+        CPU: i386
       OSX_amd64:
         vmImage: 'macOS-10.15'
         CPU: amd64


### PR DESCRIPTION
* upgrade ubuntu 16.04 (not supported starting dec 2021) => 18.04
* revive Linux_i386 (refs #17325) ; looks like working now (might break again in future but at least we can keep it on while it behaves )

refs:
```
##[warning]Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021. Migrate to ubuntu-latest instead. For more details, see https://github.com/actions/virtual-environments/issues/3287.
,##[error]The job running on agent Hosted Agent ran longer than the maximum time of 90 minutes. For more information, see https://go.microsoft.com/fwlink/?linkid=2077134
,##[warning]Agent Hosted Agent did not respond to a cancelation request with 00:05:00.
Agent: Hosted Agent
Started: Today at 2:46 PM
Duration: 1h 34m 59s

Job preparation parameters
7 queue time variables used
```
