### PR TITLE
`nimdigger`: build nim at any revision since v0.12.0~157,  1 liner `git bisect` to help find regressions

### DIFF
--- a/compiler/index.nim
+++ b/compiler/index.nim
@@ -1,5 +1,5 @@
 ##[
-This module only exists to generate docs for the compiler.
+This module only exists to generate internal docs for the compiler.
 
 ## links
 * [main docs](../lib.html)

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -140,6 +140,9 @@ doc.body_toc_group = """
         <a href="compiler/$theindexhref">Compiler docs</a>
       </li>
       <li>
+        <a href="tools/$theindexhref">Tools docs</a>
+      </li>
+      <li>
         <a href="https://nim-lang.github.io/fusion/theindex.html">Fusion docs</a>
       </li>
     </ul>

--- a/tests/tools/tnimdigger.nim
+++ b/tests/tools/tnimdigger.nim
@@ -1,0 +1,11 @@
+import tools/nimdigger {.all.}
+
+block: # parseNimGitTag
+  doAssert parseNimGitTag("v1.4.2") == (1, 4, 2)
+  doAssertRaises(ValueError): discard parseNimGitTag("v1.4")
+  doAssertRaises(ValueError): discard parseNimGitTag("v1.4.2a")
+  doAssertRaises(ValueError): discard parseNimGitTag("av1.4.2")
+
+block: # isGitNimTag
+  doAssert isGitNimTag("v1.4.2")
+  doAssert not isGitNimTag("v1.4.2a")

--- a/tools/ci_generate.nim
+++ b/tools/ci_generate.nim
@@ -5,7 +5,7 @@ duplication that could be removed.
 
 ## usage
 edit this file as needed and then re-generate via:
-```
+```bash
 nim r tools/ci_generate.nim
 ```
 ]##

--- a/tools/digger.nim
+++ b/tools/digger.nim
@@ -1,0 +1,227 @@
+#[
+
+## notes
+can build as far back as: v0.12.0~157
+]#
+
+import std/[os, osproc, strformat, macros, strutils, tables, algorithm]
+import timn/dbgs
+
+type
+  CsourcesOpt = ref object
+    url: string
+    dir: string
+    rev: string
+    binDir: string
+    csourcesBuildArgs: string
+    revs: seq[string]
+    fetch: bool
+    name: string
+    nimCsourcesExe: string
+  DiggerOpt = object
+    # input fields
+    rev: string
+    nimDir: string
+    compileNim: bool
+    fetch: bool
+    csourcesBuildArgs: string
+    buildAllCsources: bool
+    verbose: bool
+
+    # bisect cmds
+    # TODO: specify whether we should compile nim
+    bisectCmd: string
+    bisectBugfix: bool
+    oldrev, newrev: string
+
+    # state fieles (TODO: split out these)
+    coptv0: CsourcesOpt
+    coptv1: CsourcesOpt
+    binDir: string
+
+const
+  nimUrl = "https://github.com/nim-lang/Nim"
+  csourcesUrl = "https://github.com/nim-lang/csources.git"
+  csourcesV1Url = "https://github.com/nim-lang/csources_v1.git"
+  csourcesName = "csources"
+  csourcesV1Name = "csources_v1"
+  csourcesRevs = "v0.9.4 v0.13.0 v0.15.2 v0.16.0 v0.17.0 v0.17.2 v0.18.0 v0.19.0 v0.20.0 64e3477".split
+  csourcesV1Revs = "a8a5241f9475099c823cfe1a5e0ca4022ac201ff".split
+  NimDiggerEnv = "NIMDIGGER_HOME"
+
+var verbose = false
+proc isSimulate(): bool =
+  defined(nimDiggerSimulate)
+
+proc runCmd(cmd: string) =
+  # TODO: allow `dir` param
+  if isSimulate():
+    dbg cmd
+  else:
+    if verbose: dbg cmd
+    doAssert execShellCmd(cmd) == 0, cmd
+
+proc runCmdOutput(cmd: string, dir = ""): string =
+  if verbose: dbg cmd, dir
+  let (outp, status) = execCmdEx(cmd, workingDir = dir)
+  doAssert status == 0, &"status: {status}\ncmd: {cmd}\ndir: {dir}\noutput: {outp}"
+  result = outp
+  stripLineEnd(result)
+
+macro ctor(obj: untyped, a: varargs[untyped]): untyped =
+  ## Generates an object constructor call from a list of fields.
+  # xxx expose in some `fusion/macros` or std/macros; FACTOR with pr_fusion_globs PR
+  runnableExamples:
+    type Foo = object
+      a, b: int
+    doAssert Foo.ctor(a,b) == Foo(a: a, b: b)
+  result = nnkObjConstr.newTree(obj)
+  for ai in a: result.add nnkExprColonExpr.newTree(ai, ai)
+
+proc gitClone(url: string, dir: string) = runCmd fmt"git clone -q {url} {dir.quoteShell}"
+proc gitResetHard(dir: string, rev: string) = runCmd fmt"git -C {dir.quoteShell} reset --hard {rev}"
+proc gitFetch(dir: string) = runCmd fmt"git -C {dir.quoteShell} fetch"
+proc gitLatestTag(dir: string): string = runCmdOutput("git describe --abbrev=0 HEAD", dir)
+proc gitCheck(dir: string) =
+  # checks whether we're in a valid git repo; there may be better ways
+  discard runCmdOutput("git describe HEAD", dir)
+
+proc gitIsAncestorOf(dir: string, rev1, rev2: string): bool =
+  gitCheck(dir)
+  execShellCmd(fmt"git -C {dir.quoteShell} merge-base --is-ancestor {rev1} {rev2}") == 0
+
+proc isGitNimTag(tag: string): bool =
+  if not tag.startsWith "v":
+    return false
+  let ver = tag[1..^1].split(".")
+  return ver.len == 3
+
+proc parseNimGitTag(tag: string): (int, int, int) =
+  doAssert tag.isGitNimTag, tag
+  let ver = tag[1..^1].split(".")
+  template impl(i) =
+    # improve pending https://github.com/nim-lang/Nim/pull/18038
+    result[i] = ver[i].parseInt
+  impl 0
+  impl 1
+  impl 2
+
+proc toNimCsourcesExe(binDir: string, name: string, rev: string): string =
+  let rev2 = rev.replace(".", "_")
+  result = binDir / fmt"nim_digger_{name}_{rev2}"
+
+proc buildCsourcesRev(copt: CsourcesOpt) =
+  # sync with `_nimBuildCsourcesIfNeeded`
+  let csourcesExe = toNimCsourcesExe(copt.binDir, copt.name, copt.rev)
+  if csourcesExe.fileExists:
+    return
+  if verbose: dbg copt
+  if not copt.dir.dirExists: gitClone(copt.url, copt.dir)
+  if copt.fetch: gitFetch(copt.dir)
+  gitResetHard(copt.dir, copt.rev)
+  when defined(bsd):
+    let make = "gmake"
+  else:
+    let make = "make"
+  let ncpu = countProcessors()
+  if copt.rev.isGitNimTag and copt.rev.parseNimGitTag < (0,15,2):
+    # avoids: make: *** No rule to make target `c_code/3_2/compiler_testability.o', needed by `../bin/nim'.  Stop.
+    discard runCmdOutput(fmt"sh build.sh {copt.csourcesBuildArgs}", copt.dir)
+  else:
+    discard runCmdOutput(fmt"{make} -j {ncpu + 2} -l {ncpu} {copt.csourcesBuildArgs}", copt.dir)
+  if isSimulate():
+    dbg csourcesExe
+  else:
+    copyFile(copt.binDir / "nim", csourcesExe) # TODO: windows exe etc?
+
+proc buildCsourcesAnyRevs(copt: CsourcesOpt) =
+  for rev in copt.revs:
+    copt.rev = rev
+    buildCsourcesRev(copt)
+
+proc parseKeyVal(a: string): OrderedTable[string, string] =
+  ## parse bash-like entries of the form key=val
+  let a2 = a.splitLines
+  for i, ai in a2:
+    if ai.len == 0 or ai.startsWith "#": continue
+    let b = split(ai, "=", maxsplit = 1)
+    doAssert b.len == 2, $(ai, b)
+    result[b[0]] = b[1]
+
+proc toCsourcesRev(rev: string): string =
+  let ver = rev.parseNimGitTag
+  if ver >= (1, 0, 0): return csourcesRevs[^1]
+  for a in csourcesRevs[1 ..< ^1].reversed:
+    if ver >= a.parseNimGitTag: return a
+  # v0.9.4 seems broken
+  return csourcesRevs[1]
+
+proc getNimCsourcesAnyExe(opt: DiggerOpt): CsourcesOpt =
+  let file = opt.nimDir/"config/build_config.txt" # for newer nim versions, this file specifies correct csources_v1 to use
+  if file.fileExists:
+    let tab = file.readFile.parseKeyVal
+    result = opt.coptv1
+    result.rev = tab["nim_csourcesHash"]
+  elif gitIsAncestorOf(opt.nimDir, "a9b62de", opt.rev): # commit that introduced csources_v1
+    result = opt.coptv1
+    result.rev = csourcesV1Revs[0]
+  else:
+    let tag = gitLatestTag(opt.nimDir)
+    result = opt.coptv0
+    result.rev = tag.toCsourcesRev
+  result.nimCsourcesExe = toNimCsourcesExe(opt.binDir, result.name, result.rev)
+
+proc main2(opt: DiggerOpt) =
+  var opt = opt
+  let nimdiggerHome = getEnv(NimDiggerEnv, getHomeDir() / ".nimdigger")
+  if opt.nimDir.len == 0:
+    opt.nimDir = nimdiggerHome / "cache/Nim"
+  if verbose: dbg opt
+  let nimDir = opt.nimDir
+  let csourcesDir = nimDir/csourcesName
+  let csourcesV1Dir = nimDir/csourcesV1Name
+  opt.binDir = nimDir/"bin"
+  let nimDiggerExe = opt.binDir / "nim_digger"
+
+  if nimDir.dirExists:
+    doAssert fileExists(nimDir / "lib/system.nim"), fmt"nimDir is not a nim repo: {nimDir}"
+  else:
+    createDir nimDir.parentDir
+    gitClone(nimUrl, nimDir)
+
+  opt.coptv0 = CsourcesOpt(dir: csourcesDir, url: csourcesUrl, name: csourcesName, revs: csourcesRevs)
+  opt.coptv1 = CsourcesOpt(dir: csourcesV1Dir, url: csourcesV1Url, name: csourcesV1Name, revs: csourcesV1Revs)
+  for copt in [opt.coptv0, opt.coptv1]:
+    copt.binDir = opt.binDir
+    copt.fetch = opt.fetch
+    if opt.buildAllCsources:
+      buildCsourcesAnyRevs(copt)
+
+  if opt.fetch: gitFetch(nimDir)
+  if opt.rev.len > 0: gitResetHard(nimDir, opt.rev)
+  else: opt.rev = "HEAD"
+
+  if opt.compileNim:
+    let copt = getNimCsourcesAnyExe(opt)
+    buildCsourcesRev(copt)
+    # TODO: we could also cache those, optionally maybe (could get large?) or use this as hint in nim bisect to prefer those
+    discard runCmdOutput(fmt"{copt.nimCsourcesExe} c -o:{nimDiggerExe} --hints:off --skipUserCfg compiler/nim.nim", nimDir)
+
+  if opt.bisectCmd.len > 0:
+    doAssert opt.oldrev.len > 0 # for regressions, aka goodrev
+    doAssert opt.newrev.len > 0 # for a regressions, aka badrev 
+    runCmd(fmt"git -C {opt.nimDir.quoteShell} bisect start {opt.newrev} {opt.oldrev}")
+    let exe = getAppFileName()
+    var msg2 = opt.bisectCmd
+    if opt.bisectBugfix:
+      msg2 = fmt"! ({msg2})" # negate exit code
+    let bisectCmd2 = fmt"{exe} --compileNim && cp {nimDiggerExe.quoteShell} bin/nim && {msg2}"
+    runCmd(fmt"git -C {opt.nimDir.quoteShell} bisect run bash -c {bisectCmd2.quoteShell}")
+
+proc main(rev = "", nimDir = "", compileNim = false, fetch = false, bisectCmd = "", newrev = "", oldrev = "", bisectBugfix = false, verbose = false) =
+  digger.verbose = verbose
+  main2(DiggerOpt.ctor(rev, nimDir, compileNim, fetch, bisectCmd, newrev, oldrev, bisectBugfix))
+
+when isMainModule:
+  import pkg/cligen
+  dispatch main

--- a/tools/index.nim
+++ b/tools/index.nim
@@ -1,0 +1,15 @@
+##[
+This module only exists to generate docs for `tools/`.
+
+## links
+* [main docs](../lib.html)
+* [compiler user guide](../nimc.html)
+* [Internals of the Nim Compiler](../intern.html)
+]##
+
+#[
+* see also `compiler/index.nim`
+* move src/fusion/docutils.nim to std/private/docutils so it can be reused here too
+]#
+
+import nimdigger, ci_generate, nimgrep

--- a/tools/index.nim
+++ b/tools/index.nim
@@ -1,5 +1,5 @@
 ##[
-This module only exists to generate docs for `tools/`.
+This module only exists to generate internal docs for `tools/`.
 
 ## links
 * [main docs](../lib.html)

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -320,9 +320,9 @@ proc buildDocsDir*(args: string, dir: string) =
   let args = nimArgs & " " & args
   let docHackJsSource = buildJS()
   createDir(dir)
-  # buildDocSamples(args, dir)
-  # buildDoc(args, dir) # bottleneck
-  # copyFile(dir / "overview.html", dir / "index.html")
+  buildDocSamples(args, dir)
+  buildDoc(args, dir) # bottleneck
+  copyFile(dir / "overview.html", dir / "index.html")
   buildDocPackages(args, dir)
   copyFile(docHackJsSource, dir / docHackJsSource.lastPathPart)
 

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -243,6 +243,8 @@ proc buildDocPackages(nimArgs, destPath: string) =
   # xxx keep in sync with what's in $nim_prs_D/config/nimdoc.cfg, or, rather,
   # start using nims instead of nimdoc.cfg
   docProject(destPath/"compiler", extra, "compiler/index.nim")
+  docProject(destPath/"tools", extra & " --threads", "tools/index.nim")
+    # --threads needed for nimgrep
 
 proc buildDoc(nimArgs, destPath: string) =
   # call nim for the documentation:
@@ -318,9 +320,9 @@ proc buildDocsDir*(args: string, dir: string) =
   let args = nimArgs & " " & args
   let docHackJsSource = buildJS()
   createDir(dir)
-  buildDocSamples(args, dir)
-  buildDoc(args, dir) # bottleneck
-  copyFile(dir / "overview.html", dir / "index.html")
+  # buildDocSamples(args, dir)
+  # buildDoc(args, dir) # bottleneck
+  # copyFile(dir / "overview.html", dir / "index.html")
   buildDocPackages(args, dir)
   copyFile(docHackJsSource, dir / docHackJsSource.lastPathPart)
 

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -282,10 +282,12 @@ proc main2(opt: DiggerOpt) =
   state.rev = gitCurrentRev(state.nimDir)
   let nimDiggerExe = state.binDir / fmt"nim_nimdigger_nim_{state.rev}{ExeExt2}"
   if opt.compileNim:
-    if not nimDiggerExe.fileExists:
+    let isCached = nimDiggerExe.fileExists
+    echo fmt"digger getting nim: {nimDiggerExe} cached: {isCached}"
+    if not isCached:
       let copt = getNimCsourcesAnyExe(state)
       buildCsourcesRev(copt)
-      discard runCmdOutput(fmt"{copt.nimCsourcesExe} c -o:{nimDiggerExe} --hints:off --skipUserCfg compiler/nim.nim", nimDir)
+      discard runCmdOutput(fmt"{copt.nimCsourcesExe} c -o:{nimDiggerExe} -d:release --hints:off --skipUserCfg compiler/nim.nim", nimDir)
     copyFile(nimDiggerExe, state.binDir / "nim" & ExeExt2)
 
   if opt.oldnew.len > 0:

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -307,10 +307,10 @@ proc main2(opt: DiggerOpt) =
     if opt.bisectBugfix: bisectStart("BROKEN", "BUGFIX")
     else: bisectStart("WORKS", "REGRESSION")
     let exe = getAppFileName()
-    var msg2 = opt.bisectCmd
+    var msg = opt.bisectCmd
     if opt.bisectBugfix:
-      msg2 = fmt"! ({msg2})" # negate exit code
-    let bisectCmd2 = fmt"{exe} --compileNim && ( {msg2} )"
+      msg = fmt"! ({msg})" # negate exit code
+    let bisectCmd2 = fmt"{exe} --compileNim && ( {msg} )"
     runCmd(fmt"git -C {state.nimDir.quoteShell} bisect run bash -c {bisectCmd2.quoteShell}")
 
 proc main(rev = "", nimDir = "", compileNim = false, fetch = false, oldnew = "", bisectBugfix = false, verbose = false, bisectCmd = "", args: seq[string]) =

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -104,7 +104,8 @@ type
     csourceV0, csourceV1: CsourcesState
 
 const
-  csourcesRevs = "v0.9.4 v0.13.0 v0.15.2 v0.16.0 v0.17.0 v0.17.2 v0.18.0 v0.19.0 v0.20.0 64e34778fa7e114b4afc753c7845dee250584167".split
+  csourcesRevs = "v0.9.4 v0.13.0 v0.15.2 v0.16.0 v0.17.0 v0.17.2 v0.18.0 v0.19.0 v0.20.0".split &
+    "64e34778fa7e114b4afc753c7845dee250584167"
   csourcesV1Revs = "a8a5241f9475099c823cfe1a5e0ca4022ac201ff".split
   NimDiggerEnv = "NIMDIGGER_HOME"
   ExeExt2 = when ExeExt.len > 0: "." & ExeExt else: ""

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -10,27 +10,29 @@ care of details such as figuring out automatically the correct csources/csources
 
 ## examples
 build at any revision >= v0.12.0~157
-```
+```bash
 $ nim r tools/nimdigger.nim --compileNim --rev:v0.15.2~10
 $ $HOME/.nimdigger/cache/Nim/bin/nim -v
 Nim Compiler Version 0.15.2 (2021-05-28) [MacOSX: amd64] [...]
 ```
 
 find a which commit introduced a regression
-```
-$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 --bisectCmd:'bin/nim -v | grep 0.19.0'
+```bash
+$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 \
+  --bisectCmd:'bin/nim -v | grep 0.19.0'
 66c0f7c3fb214485ca6cfd799af6e50798fcdf6d is the first REGRESSION commit
 ```
 
 find a which commit introduced a bugfix
-```
-$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 --bisectBugfix --bisectCmd:'bin/nim -v | grep 0.20.0'
+```bash
+$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 --bisectBugfix \
+  --bisectCmd:'bin/nim -v | grep 0.20.0'
 be9c38d2659496f918fb39e129b9b5b055eafd88 is the first BUGFIX commit
 ```
 Note that this is fast (e.g. 3s) if intermediate nim binaries have already been built/cached in prior runs.
 
 find an actual regression, e.g. for https://github.com/nim-lang/Nim/issues/16376,
-copy this snippet to /tmp/t16376.nim:
+copy this snippet to /tmp/t16376.nim
 ```nim
 type Matrix[T] = object
   data: T
@@ -39,8 +41,9 @@ proc randMatrix*[T](m, n: int, x: Slice[T]): Matrix[T] = discard
 template randMatrix*[T](m, n: int): Matrix[T] = randMatrix[T](m, n, T(1.0))
 let B = randMatrix[float32](20, 10)
 ```
-```
-$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 -- bin/nim c --hints:off --skipparentcfg --skipusercfg /tmp/t16376.nim
+```bash
+$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 -- \
+  bin/nim c --hints:off --skipparentcfg --skipusercfg /tmp/t16376.nim
 fd16875561634e3ef24072631cf85eeead6213f2 is the first REGRESSION commit
 ```
 

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -48,7 +48,8 @@ fd16875561634e3ef24072631cf85eeead6213f2 is the first REGRESSION commit
 ```
 
 ## notes
-Unstable API, subject to change
+* this uses `git` (in particular `bisect`), `csources`, `csources_v`, `bash`, `make`/`gmake`
+* Unstable API, subject to change
 ]##
 
 #[

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -142,12 +142,11 @@ macro ctor(obj: untyped, a: varargs[untyped]): untyped =
 
 proc parseKeyVal(a: string): OrderedTable[string, string] =
   ## parse bash-like entries of the form key=val
-  let a2 = a.splitLines
-  for i, ai in a2:
+  for ai in a.splitLines:
     if ai.len == 0 or ai.startsWith "#": continue
-    let b = split(ai, "=", maxsplit = 1)
-    doAssert b.len == 2, $(ai, b)
-    result[b[0]] = b[1]
+    let kv = split(ai, "=", maxsplit = 1)
+    doAssert kv.len == 2, $(ai, kv)
+    result[kv[0]] = kv[1]
 
 # xxx move some of these to std/private/gitutils.nim
 proc gitClone(url: string, dir: string) = runCmd fmt"git clone -q {url.quoteShell} {dir.quoteShell}"

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -12,7 +12,7 @@ care of details such as figuring out automatically the correct csources/csources
 build at any revision >= v0.12.0~157
 ```bash
 $ nim r tools/nimdigger.nim --compileNim --rev:v0.15.2~10
-$ $HOME/.nimdigger/cache/Nim/bin/nim -v
+$ $NIMDIGGER_CACHE/Nim/bin/nim -v
 Nim Compiler Version 0.15.2 (2021-05-28) [MacOSX: amd64] [...]
 ```
 
@@ -107,7 +107,7 @@ const
   csourcesRevs = "v0.9.4 v0.13.0 v0.15.2 v0.16.0 v0.17.0 v0.17.2 v0.18.0 v0.19.0 v0.20.0".split &
     "64e34778fa7e114b4afc753c7845dee250584167"
   csourcesV1Revs = "a8a5241f9475099c823cfe1a5e0ca4022ac201ff".split
-  NimDiggerEnv = "NIMDIGGER_HOME"
+  NimDiggerEnv = "NIMDIGGER_CACHE"
   ExeExt2 = when ExeExt.len > 0: "." & ExeExt else: ""
 
 var verbose = false
@@ -156,7 +156,7 @@ proc gitCleanDanger(dir: string, requireConfirmation = true) =
   This is needed to avoid `git bisect` aborting with this error: The following untracked working tree files would be overwritten by checkout.
   For example, this would happen in cases like this:
   ```
-  cd $HOME/.nimdigger/cache/Nim
+  cd $NIMDIGGER_CACHE/Nim
   git checkout abaa42fd8a239ea62ddb39f6f58c3180137d750c
   touch testament/testamenthtml.templ
   cd -
@@ -258,8 +258,8 @@ proc getCsourcesState(state: DiggerState): CsourcesState =
 proc main2(opt: DiggerOpt) =
   let state = DiggerState(nimDir: opt.nimDir, rev: opt.rev)
   if state.nimDir.len == 0:
-    let nimdiggerHome = getEnv(NimDiggerEnv, getHomeDir() / ".nimdigger")
-    state.nimDir = nimdiggerHome / "cache/Nim"
+    let nimdiggerCache = getEnv(NimDiggerEnv, getCacheDir("nimdigger"))
+    state.nimDir = nimdiggerCache / "Nim"
   if verbose: dbg state
   let nimDir = state.nimDir
   state.binDir = nimDir/"bin"

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -58,7 +58,13 @@ https://stackoverflow.com/a/22592593/1426932 (Magic exit statuses)
 ]#
 
 import std/[os, osproc, strformat, macros, strutils, tables, algorithm]
-import timn/dbgs
+
+proc `$`(a: ref): string =
+  if a == nil: "nil" else: $a[]
+
+template dbg(args: varargs[untyped]): untyped =
+  # so users can swap in their own better logging until stdlib has one
+  echo args
 
 type
   DiggerOpt = object ## nimdigger input
@@ -300,7 +306,8 @@ proc main2(opt: DiggerOpt) =
     runCmd(fmt"git -C {state.nimDir.quoteShell} bisect run bash -c {bisectCmd2.quoteShell}")
 
 proc main(rev = "", nimDir = "", compileNim = false, fetch = false, oldnew = "", bisectBugfix = false, verbose = false, bisectCmd = "", args: seq[string]) =
-  nimdigger.verbose = verbose
+  # nimdigger.verbose = verbose
+  nimdigger.verbose = true
   var bisectCmd = bisectCmd
   if bisectCmd.len == 0:
     bisectCmd = args.quoteShellCommand

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -5,7 +5,6 @@ can build as far back as: v0.12.0~157
 
 ##
 nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 -- bin/nim c --hints:off --skipparentcfg --skipusercfg $timn_D/tests/nim/all/t12329.nim
-
 ]#
 
 import std/[os, osproc, strformat, macros, strutils, tables, algorithm]
@@ -25,8 +24,8 @@ type
     # TODO: specify whether we should compile nim
     bisectCmd: string
     bisectBugfix: bool
-    oldnew: string
-    args: seq[string]
+    oldnew: string # eg: v0.20.0~10..v0.20.0
+    args: seq[string] # eg: bin/nim c --hints:off --skipparentcfg --skipusercfg $timn_D/tests/nim/all/t12329.nim 'arg1 bar' 'arg2'
   CsourcesOpt = ref object
     url: string
     dir: string
@@ -181,7 +180,6 @@ proc main2(opt: DiggerOpt) =
   if verbose: dbg state
   let nimDir = state.nimDir
   state.binDir = nimDir/"bin"
-  let nimDiggerExe = state.binDir / "nim_nimdigger"
 
   if nimDir.dirExists:
     doAssert fileExists(nimDir / "lib/system.nim"), fmt"nimDir is not a nim repo: {nimDir}"
@@ -204,6 +202,7 @@ proc main2(opt: DiggerOpt) =
   if state.rev.len > 0: gitResetHard(nimDir, state.rev)
   else: state.rev = "HEAD"
 
+  let nimDiggerExe = state.binDir / "nim_nimdigger"
   if opt.compileNim:
     let copt = getNimCsourcesAnyExe(state)
     buildCsourcesRev(copt)

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -18,6 +18,7 @@ type
     fetch: bool
     name: string
     nimCsourcesExe: string
+  # DiggerState = ref object
   DiggerOpt = object
     # input fields
     rev: string
@@ -40,11 +41,6 @@ type
     binDir: string
 
 const
-  nimUrl = "https://github.com/nim-lang/Nim"
-  csourcesUrl = "https://github.com/nim-lang/csources.git"
-  csourcesV1Url = "https://github.com/nim-lang/csources_v1.git"
-  csourcesName = "csources"
-  csourcesV1Name = "csources_v1"
   csourcesRevs = "v0.9.4 v0.13.0 v0.15.2 v0.16.0 v0.17.0 v0.17.2 v0.18.0 v0.19.0 v0.20.0 64e3477".split
   csourcesV1Revs = "a8a5241f9475099c823cfe1a5e0ca4022ac201ff".split
   NimDiggerEnv = "NIMDIGGER_HOME"
@@ -175,14 +171,15 @@ proc getNimCsourcesAnyExe(opt: DiggerOpt): CsourcesOpt =
   result.nimCsourcesExe = toNimCsourcesExe(opt.binDir, result.name, result.rev)
 
 proc main2(opt: DiggerOpt) =
+  const
+    csourcesName = "csources"
+    csourcesV1Name = "csources_v1"
   var opt = opt
   let nimdiggerHome = getEnv(NimDiggerEnv, getHomeDir() / ".nimdigger")
   if opt.nimDir.len == 0:
     opt.nimDir = nimdiggerHome / "cache/Nim"
   if verbose: dbg opt
   let nimDir = opt.nimDir
-  let csourcesDir = nimDir/csourcesName
-  let csourcesV1Dir = nimDir/csourcesV1Name
   opt.binDir = nimDir/"bin"
   let nimDiggerExe = opt.binDir / "nim_nimdigger"
 
@@ -190,10 +187,10 @@ proc main2(opt: DiggerOpt) =
     doAssert fileExists(nimDir / "lib/system.nim"), fmt"nimDir is not a nim repo: {nimDir}"
   else:
     createDir nimDir.parentDir
-    gitClone(nimUrl, nimDir)
+    gitClone("https://github.com/nim-lang/Nim", nimDir)
 
-  opt.coptv0 = CsourcesOpt(dir: csourcesDir, url: csourcesUrl, name: csourcesName, revs: csourcesRevs)
-  opt.coptv1 = CsourcesOpt(dir: csourcesV1Dir, url: csourcesV1Url, name: csourcesV1Name, revs: csourcesV1Revs)
+  opt.coptv0 = CsourcesOpt(dir: nimDir/csourcesName, url: "https://github.com/nim-lang/csources.git", name: csourcesName, revs: csourcesRevs)
+  opt.coptv1 = CsourcesOpt(dir: nimDir/csourcesV1Name, url: "https://github.com/nim-lang/csources_v1.git", name: csourcesV1Name, revs: csourcesV1Revs)
   for copt in [opt.coptv0, opt.coptv1]:
     copt.binDir = opt.binDir
     copt.fetch = opt.fetch

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -150,7 +150,7 @@ proc parseKeyVal(a: string): OrderedTable[string, string] =
     result[b[0]] = b[1]
 
 # xxx move some of these to std/private/gitutils.nim
-proc gitClone(url: string, dir: string) = runCmd fmt"git clone -q {url} {dir.quoteShell}"
+proc gitClone(url: string, dir: string) = runCmd fmt"git clone -q {url.quoteShell} {dir.quoteShell}"
 proc gitResetHard(dir: string, rev: string) = runCmd fmt"git -C {dir.quoteShell} reset --hard {rev}"
 proc gitCleanDanger(dir: string, requireConfirmation = true) =
   #[

--- a/tools/nimdigger.nim
+++ b/tools/nimdigger.nim
@@ -130,13 +130,13 @@ proc runCmdOutput(cmd: string, dir = ""): string =
   result = outp
   stripLineEnd(result)
 
-macro ctor(obj: untyped, a: varargs[untyped]): untyped =
+macro construct(obj: untyped, a: varargs[untyped]): untyped =
   ## Generates an object constructor call from a list of fields.
   # xxx expose in std/sugar, factor with https://github.com/nim-lang/fusion/pull/32
   runnableExamples:
     type Foo = object
       a, b: int
-    doAssert Foo.ctor(a,b) == Foo(a: a, b: b)
+    doAssert Foo.construct(a,b) == Foo(a: a, b: b)
   result = nnkObjConstr.newTree(obj)
   for ai in a: result.add nnkExprColonExpr.newTree(ai, ai)
 
@@ -317,7 +317,7 @@ proc main(rev = "", nimDir = "", compileNim = false, fetch = false, oldnew = "",
     bisectCmd = args.quoteShellCommand
   else:
     doAssert args.len == 0
-  main2(DiggerOpt.ctor(rev, nimDir, compileNim, fetch, bisectCmd, oldnew, bisectBugfix))
+  main2(DiggerOpt.construct(rev, nimDir, compileNim, fetch, bisectCmd, oldnew, bisectBugfix))
 
 when isMainModule:
   import pkg/cligen


### PR DESCRIPTION
`nimdigger` is a tool to:
* build nim at any revision (including custom branches), taking
care of details such as figuring out automatically the correct csources/csources_v1 revision to use.
* allow 1-liner git bisect to find nim regressions, take care of building nim (if not cached) at intermediate revisions 

## design goals
* ease of use: 1 liner for running `git bisect` workflows, or to build nim at past revisions
* performance: via caching both csources built binaries, and intermediate nim binaries
* lazyness: build artifacts on demand
* go as far back as possible, currently oldest buildable nim version is v0.12.0~157
* isolated: all artifacts are kept under a (configurable) `$HOME/.nimdigger/cache/Nim`

## examples
build at any revision >= v0.12.0~157
```
$ nim r tools/nimdigger.nim --compileNim --rev:v0.15.2~10
$ $HOME/.nimdigger/cache/Nim/bin/nim -v
Nim Compiler Version 0.15.2 (2021-05-28) [MacOSX: amd64] [...]
```
find a which commit introduced a regression
```
$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 --bisectCmd:'bin/nim -v | grep 0.19.0'
66c0f7c3fb214485ca6cfd799af6e50798fcdf6d is the first REGRESSION commit
```
find a which commit introduced a bugfix
```
$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 --bisectBugfix --bisectCmd:'bin/nim -v | grep 0.20.0'
be9c38d2659496f918fb39e129b9b5b055eafd88 is the first BUGFIX commit
```

## actual examples
for regression https://github.com/nim-lang/Nim/issues/16376:
copy this snippet to /tmp/t16376.nim:
```nim
type Matrix[T] = object
  data: T
proc randMatrix*[T](m, n: int, max: T): Matrix[T] = discard
proc randMatrix*[T](m, n: int, x: Slice[T]): Matrix[T] = discard
template randMatrix*[T](m, n: int): Matrix[T] = randMatrix[T](m, n, T(1.0))
let B = randMatrix[float32](20, 10)
```
```
$ nim r tools/nimdigger.nim --oldnew:v0.19.0..v0.20.0 -- bin/nim c --hints:off --skipparentcfg --skipusercfg /tmp/t16376.nim
fd16875561634e3ef24072631cf85eeead6213f2 is the first REGRESSION commit
```

for regression https://github.com/nim-lang/Nim/issues/16496:
```
$ nim r tools/nimdigger.nim --oldnew:v1.2.0..v1.4.0 -- bin/nim c -r -d:case2 --hints:off --skipparentcfg --skipusercfg /tmp/t16376.nim
8b66412a8bfebcd53f09d0e608b418a05d13516a is the first REGRESSION commit
```
for regression https://github.com/nim-lang/Nim/issues/18113:
```
$ nim r tools/nimdigger.nim --oldnew:v1.2.0..origin/devel -- bin/nim c -r -d:case3 --hints:off --skipparentcfg --skipusercfg /tmp/t16376.nim
e5873b3a9300897443f0f2e2db128e3463089003 is the first REGRESSION commit
```

## speed
the more you use the tool, the faster it gets because binaries get cached, eg re-running this takes 10 seconds:
```
nim r tools/nimdigger.nim --oldnew:v1.2.0..origin/devel -- bin/nim c -r -d:case3 --hints:off --skipparentcfg --skipusercfg /tmp/t16376.nim
```

## links
* fixes https://github.com/timotheecour/Nim/issues/332
* fixes https://github.com/timotheecour/Nim/issues/702
* addresses 1st part of https://github.com/juancarlospaco/nimbug/issues/8
* analog to D's https://github.com/CyberShadow/Digger

## future work
- [ ] enable running a command at specified set of past revisions (eg a whole range) to plot performance benchmarks across time (refs: https://github.com/timotheecour/Nim/issues/425)
- [ ] nimdustmite (refs https://github.com/nim-lang/Nim/issues/8276) for bug minimization, analog to D's excellent https://github.com/CyberShadow/DustMite
- [ ] machine readable output: `--dump:output.json` (refs https://github.com/nim-lang/Nim/pull/18119#discussion_r641869871)
