### PR TITLE
Disable tasynchttpserver_transferencoding on FreeBSD

### DIFF
--- a/tests/stdlib/tasynchttpserver_transferencoding.nim
+++ b/tests/stdlib/tasynchttpserver_transferencoding.nim
@@ -1,5 +1,6 @@
 discard """
   matrix: "--gc:arc --threads:on; --gc:arc --threads:on -d:danger; --threads:on"
+  disabled: "freebsd"
 """
 
 import httpclient, asynchttpserver, asyncdispatch, asyncfutures


### PR DESCRIPTION
Disable the test on FreeBSD. A quick investigation https://github.com/nim-lang/Nim/issues/18120#issuecomment-850753742 suggests that the issue is caused by `--gc:arc --threads:on` (and no `-d:danger`).

@dom96 @timotheecour 