### PR TITLE
add `os.getCacheDir`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -171,9 +171,10 @@
 - `--gc:orc` is now 10% faster than previously for common workloads. If
   you have trouble with its changed behavior, compile with `-d:nimOldOrc`.
 
-
 - `os.FileInfo` (returned by `getFileInfo`) now contains `blockSize`,
   determining preferred I/O block size for this file object.
+
+- Added `os.getCacheDir()` to return platform specific cache directory.
 
 - Added a simpler to use `io.readChars` overload.
 

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -922,9 +922,7 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
   ## See also:
   ## * `getHomeDir proc <#getHomeDir>`_
   ## * `getTempDir proc <#getTempDir>`_
-  ## * `expandTilde proc <#expandTilde,string>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
-  ## * `setCurrentDir proc <#setCurrentDir,string>`_
+  ## * `getCacheDir proc <#getCacheDir>`_
   runnableExamples:
     from std/strutils import endsWith
     # See `getHomeDir` for behavior regarding trailing DirSep.
@@ -934,6 +932,43 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
   else:
     result = getEnv("XDG_CONFIG_HOME", getEnv("HOME") / ".config")
   result.normalizePathEnd(trailingSep = defined(nimLegacyHomeDir))
+
+proc getCacheDir*(): string =
+  ## Returns the cache directory of the current user for applications.
+  ## 
+  ## on windows: `getEnv("LOCALAPPDATA")`
+  ##
+  ## on osx: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches")`
+  ##
+  ## else: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")`
+  ##
+  ## See also:
+  ## * `getHomeDir proc <#getHomeDir>`_
+  ## * `getTempDir proc <#getTempDir>`_
+  ## * `getConfigDir proc <#getConfigDir>`_
+  # follows https://crates.io/crates/platform-dirs
+  runnableExamples:
+    from std/strutils import endsWith
+    assert not getCacheDir().endsWith DirSep
+  when defined(windows):
+    result = getEnv("LOCALAPPDATA")
+  elif defined(osx):
+    result = getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches")
+  else:
+    result = getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")
+  result.normalizePathEnd(false)
+
+proc getCacheDir*(app: string): string =
+  ## Returns the cache directory for an application `app`.
+  ##
+  ## on windows: `getCacheDir() / app / "cache"`
+  ##
+  ## else:: `getCacheDir() / "cache"`
+  when defined(windows):
+    getCacheDir() / app / "cache"
+  else:
+    getCacheDir() / app
+
 
 when defined(windows):
   type DWORD = uint32
@@ -972,9 +1007,7 @@ proc getTempDir*(): string {.rtl, extern: "nos$1",
   ## See also:
   ## * `getHomeDir proc <#getHomeDir>`_
   ## * `getConfigDir proc <#getConfigDir>`_
-  ## * `expandTilde proc <#expandTilde,string>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
-  ## * `setCurrentDir proc <#setCurrentDir,string>`_
+  ## * `getCacheDir proc <#getCacheDir>`_
   runnableExamples:
     from std/strutils import endsWith
     # See `getHomeDir` for behavior regarding trailing DirSep.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -947,9 +947,6 @@ proc getCacheDir*(): string =
   ## * `getTempDir proc <#getTempDir>`_
   ## * `getConfigDir proc <#getConfigDir>`_
   # follows https://crates.io/crates/platform-dirs
-  runnableExamples:
-    from std/strutils import endsWith
-    assert not getCacheDir().endsWith DirSep
   when defined(windows):
     result = getEnv("LOCALAPPDATA")
   elif defined(osx):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -936,13 +936,15 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
 proc getCacheDir*(): string =
   ## Returns the cache directory of the current user for applications.
   ## 
-  ## on windows: `getEnv("LOCALAPPDATA")`
+  ## This makes use of the following environment variables:
   ##
-  ## on osx: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches")`
+  ## * On Windows: `getEnv("LOCALAPPDATA")`
   ##
-  ## else: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")`
+  ## * On macOS: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / "Library/Caches")`
   ##
-  ## See also:
+  ## * On other platforms: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")`
+  ##
+  ## **See also:**
   ## * `getHomeDir proc <#getHomeDir>`_
   ## * `getTempDir proc <#getTempDir>`_
   ## * `getConfigDir proc <#getConfigDir>`_
@@ -958,9 +960,9 @@ proc getCacheDir*(): string =
 proc getCacheDir*(app: string): string =
   ## Returns the cache directory for an application `app`.
   ##
-  ## on windows: `getCacheDir() / app / "cache"`
+  ## * On windows, this uses: `getCacheDir() / app / "cache"`
   ##
-  ## else:: `getCacheDir() / "cache"`
+  ## * On other platforms, this uses: `getCacheDir() / app`
   when defined(windows):
     getCacheDir() / app / "cache"
   else:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -556,6 +556,9 @@ block getTempDir:
       else:
         doAssert getTempDir() == "/tmp"
 
+block: # getCacheDir
+  doAssert getCacheDir().fileExists
+
 block osenv:
   block delEnv:
     const dummyEnvVar = "DUMMY_ENV_VAR" # This env var wouldn't be likely to exist to begin with

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -557,7 +557,7 @@ block getTempDir:
         doAssert getTempDir() == "/tmp"
 
 block: # getCacheDir
-  doAssert getCacheDir().fileExists
+  doAssert getCacheDir().dirExists
 
 block osenv:
   block delEnv:


### PR DESCRIPTION
from reading at various reference materials, this seems like the most commonly accepted setting overall

## example use case
* nimdigger (https://github.com/nim-lang/Nim/pull/18119) can use this instead of polluting user home with ~/.nimdigger (which is usually for config files, not cache data)
* for nimcache location (instead of `~/.cache/nim` which is a non-standard location on osx for eg)

## links
* https://www.npmjs.com/package/app-cache-dir?activeTab=readme
* https://crates.io/crates/platform-dirs
* https://pypi.org/project/appdirs/