### PR TITLE
initRand now uses strict monotonic counter to guarantee uniqueness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -121,6 +121,9 @@
 
 - Fixed buffer overflow bugs in `net`
 
+- Added `std/cputicks` containing APIs for nanosecond resolution CPU counters, providing strictly monotonic
+  counters with highest available resolution.
+
 - Exported `sslHandle` from `net` and `asyncnet`.
 
 - Added `sections` iterator in `parsecfg`.

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -33,6 +33,7 @@ from sighashes import symBodyDigest
 
 # There are some useful procs in vmconv.
 import vmconv
+from std/cputicks import getCpuTicks
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -340,3 +341,6 @@ proc registerAdditionalOps*(c: PCtx) =
     let p = a.getVar(0)
     let x = a.getFloat(1)
     addFloatSprintf(p.strVal, x)
+
+  registerCallback c, "stdlib.cputicks.getCpuTicksImpl", proc(a: VmArgs) =
+    setResult(a, getCpuTicks())

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -625,7 +625,7 @@ when not defined(nimscript) and not defined(standalone):
     ##
     ## The resulting state is independent of the default RNG's state.
     ##
-    ## **Note:** In VM, requires `--experimental:vmops`
+    ## **Note:** Does not work for NimScript or the compile-time VM.
     ##
     ## See also:
     ## * `initRand proc<#initRand,int64>`_ that accepts a seed for a new Rand state

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -618,25 +618,20 @@ proc shuffle*[T](x: var openArray[T]) =
   shuffle(state, x)
 
 when not defined(nimscript) and not defined(standalone):
-  import times
+  import std/monotimes
 
   proc initRand(): Rand =
     ## Initializes a new Rand state with a seed based on the current time.
     ##
     ## The resulting state is independent of the default RNG's state.
     ##
-    ## **Note:** Does not work for NimScript or the compile-time VM.
+    ## **Note:** In VM, requires `--experimental:vmops`
     ##
     ## See also:
     ## * `initRand proc<#initRand,int64>`_ that accepts a seed for a new Rand state
     ## * `randomize proc<#randomize>`_ that initializes the default RNG using the current time
     ## * `randomize proc<#randomize,int64>`_ that accepts a seed for the default RNG
-    when defined(js):
-      let time = int64(times.epochTime() * 1000) and 0x7fff_ffff
-      result = initRand(time)
-    else:
-      let now = times.getTime()
-      result = initRand(convert(Seconds, Nanoseconds, now.toUnix) + now.nanosecond)
+    result = initRand(getMonoTime().ticks)
 
   since (1, 5, 1):
     export initRand

--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -618,10 +618,10 @@ proc shuffle*[T](x: var openArray[T]) =
   shuffle(state, x)
 
 when not defined(nimscript) and not defined(standalone):
-  import std/monotimes
+  import std/cputicks
 
   proc initRand(): Rand =
-    ## Initializes a new Rand state with a seed based on the current time.
+    ## Initializes a new Rand state with a seed based on the current cpu tick.
     ##
     ## The resulting state is independent of the default RNG's state.
     ##
@@ -631,7 +631,7 @@ when not defined(nimscript) and not defined(standalone):
     ## * `initRand proc<#initRand,int64>`_ that accepts a seed for a new Rand state
     ## * `randomize proc<#randomize>`_ that initializes the default RNG using the current time
     ## * `randomize proc<#randomize,int64>`_ that accepts a seed for the default RNG
-    result = initRand(getMonoTime().ticks)
+    result = initRand(getCpuTicks())
 
   since (1, 5, 1):
     export initRand

--- a/lib/std/cputicks.nim
+++ b/lib/std/cputicks.nim
@@ -1,0 +1,90 @@
+##[
+Experimental API, subject to change
+]##
+
+#[
+Future work:
+* convert ticks to time; see some approaches here: https://quick-bench.com/q/WcbqUWBCoNBJvCP4n8h3kYfZDXU
+* provide feature detection to test whether the CPU supports it (on linux, via /proc/cpuinfo)
+
+## further links
+* https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/ia-32-ia-64-benchmark-code-execution-paper.pdf
+* https://gist.github.com/savanovich/f07eda9dba9300eb9ccf
+* https://developers.redhat.com/blog/2016/03/11/practical-micro-benchmarking-with-ltrace-and-sched#
+]#
+
+when defined(js):
+  proc getCpuTicksImpl(): int64 =
+    ## Returns ticks in nanoseconds.
+    # xxx consider returning JsBigInt instead of float
+    when defined(nodejs):
+      {.emit: """
+      let process = require('process');
+      `result` = Number(process.hrtime.bigint());
+      """.}
+    else:
+      proc jsNow(): int64 {.importjs: "window.performance.now()".}
+      result = jsNow() * 1_000_000
+else:
+  const header =
+    when defined(posix): "<x86intrin.h>"
+    else: "<intrin.h>"
+  proc getCpuTicksImpl(): uint64 {.importc: "__rdtsc", header: header.}
+
+template getCpuTicks*(): int64 =
+  ## Returns number of CPU ticks as given by `RDTSC` instruction.
+  ## Unlike `std/monotimes.ticks`, this gives a strictly monotonic counter
+  ## and has higher resolution and lower overhead,
+  ## allowing to measure individual instructions (corresponding to time offsets in
+  ## the nanosecond range).
+  ##
+  ## Note that the CPU may reorder instructions.
+  runnableExamples:
+    for i in 0..<100:
+      let t1 = getCpuTicks()
+      # code to benchmark can go here
+      let t2 = getCpuTicks()
+      assert t2 > t1
+  cast[int64](getCpuTicksImpl())
+
+template toInt64(a, b): untyped =
+  cast[int64](cast[uint](a) or (cast[uint](d) shl 32))
+
+proc getCpuTicksStart*(): int64 {.inline.} =
+  ## Variant of `getCpuTicks` which uses the `RDTSCP` instruction. Compared to
+  ## `getCpuTicks`, this avoids introducing noise in the measurements caused by
+  ## CPU instruction reordering, and can result in more deterministic results,
+  ## at the expense of extra overhead and requiring asymetric start/stop APIs.
+  runnableExamples:
+    var a = 0
+    for i in 0..<100:
+      let t1 = getCpuTicksStart()
+      # code to benchmark can go here
+      let t2 = getCpuTicksEnd()
+      assert t2 > t1, $(t1, t2)
+  when nimvm: result = getCpuTicks()
+  else:
+    when defined(js): result = getCpuTicks()
+    else:
+      var a {.noinit.}: cuint
+      var d {.noinit.}: cuint
+      # See https://developers.redhat.com/blog/2016/03/11/practical-micro-benchmarking-with-ltrace-and-sched
+      {.emit:"""
+      asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx");
+      asm volatile("rdtsc" : "=a" (a), "=d" (d)); 
+      """.}
+      result = toInt64(a, b)
+
+proc getCpuTicksEnd*(): int64 {.inline.} =
+  ## See `getCpuTicksStart`.
+  when nimvm: result = getCpuTicks()
+  else:
+    when defined(js): result = getCpuTicks()
+    else:
+      var a {.noinit.}: cuint
+      var d {.noinit.}: cuint
+      {.emit:"""
+      asm volatile("rdtscp" : "=a" (a), "=d" (d)); 
+      asm volatile("cpuid" ::: "%rax", "%rbx", "%rcx", "%rdx");
+      """.}
+      result = toInt64(a, b)

--- a/lib/std/cputicks.nim
+++ b/lib/std/cputicks.nim
@@ -48,7 +48,7 @@ template getCpuTicks*(): int64 =
   cast[int64](getCpuTicksImpl())
 
 template toInt64(a, b): untyped =
-  cast[int64](cast[uint](a) or (cast[uint](d) shl 32))
+  cast[int64](cast[uint64](a) or (cast[uint64](d) shl 32))
 
 proc getCpuTicksStart*(): int64 {.inline.} =
   ## Variant of `getCpuTicks` which uses the `RDTSCP` instruction. Compared to

--- a/lib/std/monotimes.nim
+++ b/lib/std/monotimes.nim
@@ -34,6 +34,7 @@ that the actual supported time resolution differs for different systems.
 See also
 ========
 * `times module <times.html>`_
+* `cputicks module <times.html>`_ which provides strictly monotonic cpu counter
 ]##
 
 import times

--- a/tests/stdlib/tcputicks.nim
+++ b/tests/stdlib/tcputicks.nim
@@ -1,0 +1,22 @@
+discard """
+  targets: "c cpp js"
+  matrix: "; -d:danger"
+"""
+
+import std/cputicks
+
+template main =
+  let n = 100
+  for i in 0..<n:
+    let t1 = getCpuTicks()
+    let t2 = getCpuTicks()
+    doAssert t2 > t1
+
+  for i in 0..<100:
+    let t1 = getCpuTicksStart()
+    # code to benchmark can go here
+    let t2 = getCpuTicksEnd()
+    doAssert t2 > t1
+
+static: main()
+main()

--- a/tests/stdlib/tmonotimes.nim
+++ b/tests/stdlib/tmonotimes.nim
@@ -27,7 +27,10 @@ template main =
       # this could fail with getTime instead of getMonoTime, as expected
       let a = getMonoTime()
       let b = getMonoTime()
-      doAssert b > a
+      when defined(js) or defined(osx):
+        doAssert b > a # we have strict monotonicity
+      else:
+        doAssert b >= a # we only have monotonicity
 
 main()
 # static: main() # xxx support

--- a/tests/stdlib/tmonotimes.nim
+++ b/tests/stdlib/tmonotimes.nim
@@ -4,17 +4,29 @@ discard """
 
 import std/[monotimes, times]
 
-let d = initDuration(nanoseconds = 10)
-let t1 = getMonoTime()
-let t2 = t1 + d
+template main =
+  block:
+    let d = initDuration(nanoseconds = 10)
+    let t1 = getMonoTime()
+    let t2 = t1 + d
 
-doAssert t2 - t1 == d
-doAssert t1 == t1
-doAssert t1 != t2
-doAssert t2 - d == t1
-doAssert t1 < t2
-doAssert t1 <= t2
-doAssert t1 <= t1
-doAssert not(t2 < t1)
-doAssert t1 < high(MonoTime)
-doAssert low(MonoTime) < t1
+    doAssert t2 - t1 == d
+    doAssert t1 == t1
+    doAssert t1 != t2
+    doAssert t2 - d == t1
+    doAssert t1 < t2
+    doAssert t1 <= t2
+    doAssert t1 <= t1
+    doAssert not(t2 < t1)
+    doAssert t1 < high(MonoTime)
+    doAssert low(MonoTime) < t1
+
+  block:
+    for i in 0..<1000000: # test should take ~ 1sec
+      # this would fail with getTime instead of getMonoTime, as expected
+      let a = getMonoTime()
+      let b = getMonoTime()
+      doAssert b > a
+
+main()
+# static: main() # xxx support

--- a/tests/stdlib/tmonotimes.nim
+++ b/tests/stdlib/tmonotimes.nim
@@ -21,16 +21,10 @@ template main =
     doAssert t1 < high(MonoTime)
     doAssert low(MonoTime) < t1
 
-  block:
-    const n = when defined(js): 20000 else: 1000000 # keep test under ~ 1sec
-    for i in 0..<n:
-      # this could fail with getTime instead of getMonoTime, as expected
-      let a = getMonoTime()
-      let b = getMonoTime()
-      when defined(js) or defined(osx):
-        doAssert b > a # we have strict monotonicity
-      else:
-        doAssert b >= a # we only have monotonicity
+  block: # getMonoTime is non-decreasing
+    let a = getMonoTime()
+    let b = getMonoTime()
+    doAssert b >= a
 
 main()
 # static: main() # xxx support

--- a/tests/stdlib/tmonotimes.nim
+++ b/tests/stdlib/tmonotimes.nim
@@ -22,8 +22,9 @@ template main =
     doAssert low(MonoTime) < t1
 
   block:
-    for i in 0..<1000000: # test should take ~ 1sec
-      # this would fail with getTime instead of getMonoTime, as expected
+    const n = when defined(js): 20000 else: 1000000 # keep test under ~ 1sec
+    for i in 0..<n:
+      # this could fail with getTime instead of getMonoTime, as expected
       let a = getMonoTime()
       let b = getMonoTime()
       doAssert b > a

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -258,20 +258,14 @@ block: # bug #17898
     # this should do as little as possible besides calling initRand to
     # ensure the test is meaningful
   template isUnique[T](a: iterable[T]): bool =
-    # xxx move to std/algorithm
+    ## Returns whether `a` contains only unique elements.
+    # xxx move to std/iterutils, refs https://github.com/timotheecour/Nim/issues/746
     var s: HashSet[T]
     var ret = true
     for ai in a:
-      if ai in s:
+      if containsOrIncl(s, ai):
         ret = false
         break
-      else:
-        s.incl ai
     ret
 
   doAssert isUnique(items(vals))
-
-  # unrelated to trandom but related to `isUnique`
-  iterator iota(n: int): int =
-    for i in 0..<n: yield i
-  doAssert isUnique(iota(100))

--- a/tests/stdlib/trandom.nim
+++ b/tests/stdlib/trandom.nim
@@ -10,7 +10,7 @@ when not defined(js):
 
 randomize(233)
 
-proc main() =
+proc main1() =
   var occur: array[1000, int]
 
   for i in 0..100_000:
@@ -36,7 +36,7 @@ proc main() =
   # don't use causes integer overflow
   doAssert compiles(rand[int](low(int) .. high(int)))
 
-main()
+main1()
 
 block:
   when not defined(js):
@@ -269,3 +269,13 @@ block: # bug #17898
     ret
 
   doAssert isUnique(items(vals))
+
+
+template main =
+  # xxx move all tests here to test also in VM
+  var s = initRand()
+  let b = s.rand(2)
+  doAssert b <= 2 and b >= 0
+
+static: main()
+main()


### PR DESCRIPTION
## note
~~the CI failure seems to suggest `getMonoTime` is in fact not monotonic on some OS? that's worrysome~~ (EDIT: that's expected; getCpuTicks would be strict monotonic at least on modern cpus)

## future work
- [x] std/tempfiles should still not call `initRand()` on each call to `randomPathName` but should instead use a `threadvar` rand state, maybe (code doesn't look re-entrant)
- [ ] docs should clarify whether getMonoTime can return same timestamp in 2 different threads; if so, then initRand should mix getMonoTime() with `getThreadId()` to guarantee uniqueness (EDIT: even within same thread there is no such guarantee because it's not strict monotonic; but getCpuTicks would be strict monotonic at least on modern cpus)
- [x] investigate #18158 (marking checkbox because issue has a tracker)
- [ ] make `initRand()` work with `--experimental:vmopsDanger`
- [ ] `proc mach_absolute_time(): int64 {.importc, header: "<mach/mach.h>".}` in std/monotimes has wrong signature, differing from one in system/timers (see https://developer.apple.com/documentation/kernel/1462446-mach_absolute_time)