### PR TITLE
[std/hashcommon]improve docs a bit

### DIFF
--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -34,10 +34,10 @@ proc slotsNeeded(count: Natural): int {.inline.} =
   result = nextPowerOfTwo(count * 3 div 2 + 4)
 
 proc rightSize*(count: Natural): int {.inline, deprecated: "Deprecated since 1.4.0".} =
-  ## **Deprecated since Nim v1.4.0**, it is not needed anymore
+  ## It is not needed anymore
   ## because picking the correct size is done internally.
   ##
-  ## Return the value of `initialSize` to support `count` items.
+  ## Returns the value of `initialSize` to support `count` items.
   ##
   ## If more items are expected to be added, simply add that
   ## expected extra amount to the parameter before calling this.

--- a/lib/pure/collections/hashcommon.nim
+++ b/lib/pure/collections/hashcommon.nim
@@ -34,8 +34,8 @@ proc slotsNeeded(count: Natural): int {.inline.} =
   result = nextPowerOfTwo(count * 3 div 2 + 4)
 
 proc rightSize*(count: Natural): int {.inline, deprecated: "Deprecated since 1.4.0".} =
-  ## It is not needed anymore
-  ## because picking the correct size is done internally.
+  ## It is not needed anymore because
+  ## picking the correct size is done internally.
   ##
   ## Returns the value of `initialSize` to support `count` items.
   ##


### PR DESCRIPTION
This PR reduces duplicated deprecated messages.

The deprecated pragmas seems to generate comments automatically on devel, which causes the duplicated comments.

![image](https://user-images.githubusercontent.com/43030857/120473718-e8717000-c3d9-11eb-9f45-906ecb3b9f2d.png)


