### PR TITLE
fix #7295: use move(result) inside template to avoid copy with --gc:refc

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1015,19 +1015,19 @@ template applyIt*(varSeq, op: untyped) =
 
 template newSeqWith*(len: int, init: untyped): untyped =
   ## Creates a new `seq` of length `len`, calling `init` to initialize
-  ## each value of the sequence.
+  ## each value of the seq.
   ##
-  ## Useful for creating "2D" sequences - sequences containing other sequences
-  ## or to populate fields of the created sequence.
+  ## Useful for creating "2D" seqs - seqs containing other seqs
+  ## or to populate fields of the created seq.
   runnableExamples:
-    ## Creates a sequence containing 5 bool sequences, each of length of 3.
+    ## Creates a seq containing 5 bool seqs, each of length of 3.
     var seq2D = newSeqWith(5, newSeq[bool](3))
     assert seq2D.len == 5
     assert seq2D[0].len == 3
     assert seq2D[4][2] == false
 
-    ## Creates a sequence of 20 random numbers from 1 to 10
-    import random
+    ## Creates a seq with random numbers
+    import std/random
     var seqRand = newSeqWith(20, rand(1.0))
     assert seqRand[0] != seqRand[1]
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1014,12 +1014,11 @@ template applyIt*(varSeq, op: untyped) =
 
 
 template newSeqWith*(len: int, init: untyped): untyped =
-  ## Creates a new sequence of length `len`, calling `init` to initialize
+  ## Creates a new `seq` of length `len`, calling `init` to initialize
   ## each value of the sequence.
   ##
   ## Useful for creating "2D" sequences - sequences containing other sequences
   ## or to populate fields of the created sequence.
-  ##
   runnableExamples:
     ## Creates a sequence containing 5 bool sequences, each of length of 3.
     var seq2D = newSeqWith(5, newSeq[bool](3))
@@ -1029,12 +1028,13 @@ template newSeqWith*(len: int, init: untyped): untyped =
 
     ## Creates a sequence of 20 random numbers from 1 to 10
     import random
-    var seqRand = newSeqWith(20, rand(10))
+    var seqRand = newSeqWith(20, rand(1.0))
+    assert seqRand[0] != seqRand[1]
 
   var result = newSeq[typeof(init)](len)
   for i in 0 ..< len:
     result[i] = init
-  result
+  move(result) # refs bug #7295
 
 func mapLitsImpl(constructor: NimNode; op: NimNode; nested: bool;
                  filter = nnkLiterals): NimNode =


### PR DESCRIPTION
fix #7295

## future work
- [ ] the same approach should be used in similar settings, or, we should improve compiler so that the copy gets elided/turned into a move even with --gc:refc
- [ ] this is still not as efficient as could be; we need `newSeq[typeof(init)](len, init = false)` which would, when safe to do so (eg no nontrivial destructor), skip the filling with `0`