### PR TITLE
workaround bug in sharedtables.withValue to unblock frozen CI on OSX

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -18,7 +18,7 @@ runnableExamples("-r:off"):
   # This example will create an HTTP server on an automatically chosen port.
   # It will respond to all requests with a `200 OK` response code and "Hello World"
   # as the response body.
-  import std/asyncdispatch, asynchttpserver
+  import std/asyncdispatch
   proc main {.async.} =
     var server = newAsyncHttpServer()
     proc cb(req: Request) {.async.} =

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -108,10 +108,14 @@ template withValue*[A, B](t: var SharedTable[A, B], key: A,
     table.withValue("a", value):
       value[] = "m"
 
+    var flag = false
     table.withValue("d", value):
       discard value
       doAssert false
     do: # if "d" notin table
+      flag = true
+
+    if flag:
       table["d"] = "n"
 
     assert table.mget("a") == "m"


### PR DESCRIPTION
With the help of @timotheecour , this PR corrects a wrong example.

Ref https://github.com/nim-lang/Nim/runs/2733501387


Debug report from @timotheecour 
> ^CTraceback (most recent call last)
/Users/timothee/git_clone/nim/Nim_devel/koch.nim(672) koch
/Users/timothee/git_clone/nim/Nim_devel/tools/kochdocs.nim(337) buildDocs
/Users/timothee/git_clone/nim/Nim_devel/tools/kochdocs.nim(322) buildDocsDir
/Users/timothee/git_clone/nim/Nim_devel/tools/kochdocs.nim(277) buildDoc
/Users/timothee/git_clone/nim/Nim_devel/tools/kochdocs.nim(214) mexec
/Users/timothee/git_clone/nim/Nim_devel/lib/pure/osproc.nim(391) execProcesses
SIGINT: Interrupted by Ctrl-C.
Traceback (most recent call last)
/Users/timothee/.cache/nim/sharedtables_d/runnableExamples/sharedtables_examples2.nim(22) sharedtables_examples2
/Users/timothee/git_clone/nim/Nim_devel/lib/pure/collections/sharedtables.nim(57) []=
SIGINT: Interrupted by Ctrl-C.
Error: execution of an external program failed: '/Users/timothee/.cache/nim/sharedtables_d/runnableExamples/sharedtables_group0_examples '


https://github.com/nim-lang/Nim/pull/18154 is the cause of CI failure.

Because the same lock is acquired twice in a row, and neither of them is released. So it causes dead lock.