### PR TITLE
default last in strutils.find to -1

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1813,21 +1813,6 @@ func initSkipTable*(a: var SkipTable, sub: string) {.rtl,
   ## Deprecated: Does nothing. Exists solely for backwards compatibility.
   discard
 
-# Forward declare
-func find*(s, sub: string, start: Natural = 0, last = 0): int {.rtl,
-    extern: "nsuFindStr", deprecated: "use strbasics.indexOf", raises: [].}
-
-func find*(a: SkipTable, s, sub: string, start: Natural = 0, last = 0): int {.
-    rtl, extern: "nsuFindStrA", deprecated: "use strbasics.indexOf".} =
-  ## Deprecated: use `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],openArray[char]>`_.
-  ##
-  ## Shorthand for `find(s, sub, start, last)`. Makes no use of the `SkipTable`.
-  ##
-  ## See also:
-  ## * `find func<#find,string,string,Natural,int>`_
-  ## * `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],openArray[char]>`_
-  return strutils.find(s, sub, start=start, last=last)
-
 func find*(s: string, sub: char, start: Natural = 0, last = 0): int {.rtl,
     extern: "nsuFindChar", deprecated: "use strbasics.indexOf", raises: [].} =
   ## Deprecated: use `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],char>`_.
@@ -1917,6 +1902,17 @@ func find*(s, sub: string, start: Natural = 0, last = 0): int {.rtl,
     return -1
   else:
     return start + index
+
+func find*(a: SkipTable, s, sub: string, start: Natural = 0, last = 0): int {.
+    rtl, extern: "nsuFindStrA", deprecated: "use strbasics.indexOf".} =
+  ## Deprecated: use `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],openArray[char]>`_.
+  ##
+  ## Shorthand for `find(s, sub, start, last)`. Makes no use of the `SkipTable`.
+  ##
+  ## See also:
+  ## * `find func<#find,string,string,Natural,int>`_
+  ## * `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],openArray[char]>`_
+  return strutils.find(s, sub, start=start, last=last)
 
 func rfind*(s: string, sub: char, start: Natural = 0, last = -1): int {.rtl,
     extern: "nsuRFindChar".} =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1843,6 +1843,8 @@ func find*(s: string, sub: char, start: Natural = 0, last = 0): int {.rtl,
   ## * `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],char>`_
   ## * `rfind func<#rfind,string,char,Natural>`_
   ## * `replace func<#replace,string,char,char>`_
+  if s.len == 0:
+    return -1
   let last = if last == 0: s.high else: last
   if last < 0:
     return -1
@@ -1868,6 +1870,8 @@ func find*(s: string, chars: set[char], start: Natural = 0, last = 0): int {.
   ## * `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],set[char]>`_
   ## * `rfind func<#rfind,string,set[char],Natural>`_
   ## * `multiReplace func<#multiReplace,string,varargs[]>`_
+  if s.len == 0:
+    return -1
   let start: int = min(start, s.high)
   let last: int = if last == 0: s.high else: min(last, s.high)
   let index: int = strbasics.indexOf(s[start..last], chars)
@@ -1891,7 +1895,7 @@ func find*(s, sub: string, start: Natural = 0, last = 0): int {.rtl,
   ## * `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],openArray[char]>`_
   ## * `rfind func<#rfind,string,string,Natural>`_
   ## * `replace func<#replace,string,string,string>`_
-
+  if sub.len > s.len - start: return -1
   if sub.len == 0:
     if last <= 0:
       if start <= s.len:

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1815,7 +1815,7 @@ func initSkipTable*(a: var SkipTable, sub: string) {.rtl,
 
 # Forward declare
 func find*(s, sub: string, start: Natural = 0, last = 0): int {.rtl,
-    extern: "nsuFindStr", deprecated: "use strbasics.indexOf".}
+    extern: "nsuFindStr", deprecated: "use strbasics.indexOf", raises: [].}
 
 func find*(a: SkipTable, s, sub: string, start: Natural = 0, last = 0): int {.
     rtl, extern: "nsuFindStrA", deprecated: "use strbasics.indexOf".} =
@@ -1829,7 +1829,7 @@ func find*(a: SkipTable, s, sub: string, start: Natural = 0, last = 0): int {.
   return strutils.find(s, sub, start=start, last=last)
 
 func find*(s: string, sub: char, start: Natural = 0, last = 0): int {.rtl,
-    extern: "nsuFindChar", deprecated: "use strbasics.indexOf".} =
+    extern: "nsuFindChar", deprecated: "use strbasics.indexOf", raises: [].} =
   ## Deprecated: use `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],char>`_.
   ##
   ## Searches for `sub` in `s` inside range `start..last` (both ends included).
@@ -1853,7 +1853,8 @@ func find*(s: string, sub: char, start: Natural = 0, last = 0): int {.rtl,
     return start + index
 
 func find*(s: string, chars: set[char], start: Natural = 0, last = 0): int {.
-    rtl, extern: "nsuFindCharSet", deprecated: "use strbasics.indexOf".} =
+    rtl, extern: "nsuFindCharSet", deprecated: "use strbasics.indexOf",
+    raises: [].} =
   ## Deprecated: use `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],set[char]>`_.
   ##
   ## Searches for `chars` in `s` inside range `start..last` (both ends included).
@@ -1876,7 +1877,7 @@ func find*(s: string, chars: set[char], start: Natural = 0, last = 0): int {.
     return start + index
 
 func find*(s, sub: string, start: Natural = 0, last = 0): int {.rtl,
-    extern: "nsuFindStr", deprecated: "use strbasics.indexOf".} =
+    extern: "nsuFindStr", deprecated: "use strbasics.indexOf", raises: [].} =
   ## Deprecated: use `strbasics.indexOf func<strbasics.html#indexOf,openArray[char],openArray[char]>`_.
   ##
   ## Searches for `sub` in `s` inside range `start..last` (both ends included).

--- a/lib/std/strbasics.nim
+++ b/lib/std/strbasics.nim
@@ -11,6 +11,8 @@
 ##
 ## Experimental API, subject to change.
 
+from algorithm import fill
+
 const whitespaces = {' ', '\t', '\v', '\r', '\l', '\f'}
 
 proc add*(x: var string, y: openArray[char]) =
@@ -113,3 +115,128 @@ func strip*(a: var string, leading = true, trailing = true, chars: set[char] = w
     assert c == "X"
 
   setSlice(a, stripSlice(a, leading, trailing, chars))
+
+func indexOfUsingBoyerMooreHorspool(
+  haystack: openArray[char],
+  needle: openArray[char]
+): int =
+  ## This is an implementation of the Boyer-Moore-Horspool algorithm
+  ## https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore%E2%80%93Horspool_algorithm
+
+  # Compute the lookup table
+  var table {.noinit.}: array[char, int]
+  fill(table, needle.len)
+  for i in 0 ..< needle.len - 1:
+    table[needle[i]] = needle.len - 1 - i
+
+  var skip: int = 0
+  let rightEndpoint: int = haystack.len - needle.len
+  while skip <= rightEndpoint:
+    var i: int = needle.high
+    while haystack[skip + i] == needle[i]:
+      if i == 0:
+        return skip
+      dec i
+    skip += table[haystack[skip + needle.high]]
+  return -1
+
+when not (defined(js) or defined(nimdoc) or defined(nimscript)):
+  func c_memchr(cstr: pointer, c: char, n: csize_t): pointer {.
+                importc: "memchr", header: "<string.h>".}
+  func c_strstr(haystack, needle: cstring): cstring {.
+    importc: "strstr", header: "<string.h>".}
+
+  const hasCStringBuiltin: bool = false
+else:
+  const hasCStringBuiltin: bool = false
+
+func indexOf*(haystack: openArray[char], needle: char): int =
+  ## Searches for the leftmost occurrence in `haystack` of `needle` and returns
+  ## its index if it is found. Otherwise, returns -1. Note that this
+  ## differs from
+  ## `strutils.find <strutils.html#find,string,char,Natural,int>`_ in that
+  ## `strutils.find` returns an index based on the start of the string, not the
+  ## start of the slice.
+  ##
+  ## See also:
+  ## * `deprecated strutils.find<strutils.html#find,string,char,Natural,int>`_
+  runnableExamples:
+    doAssert "abcabc".indexOf('b') == 1
+    doAssert "abcdef".toOpenArray(3, 5).indexOf('e') == 1
+    doAssert "abc".indexOf('z') == -1
+  if haystack.len == 0:
+    return -1
+  when nimvm:
+    return system.find(haystack, needle)
+  else:
+    when hasCStringBuiltin:
+      let found = c_memchr(haystack[0].unsafeAddr, needle, csize_t(haystack.len))
+      if not found.isNil:
+        return cast[ByteAddress](found) -% cast[ByteAddress](haystack[0].unsafeAddr)
+      else:
+        return -1
+    else:
+      return system.find(haystack, needle)
+
+func indexOf*(haystack: openArray[char], needles: set[char]): int =
+  ## Searches for the leftmost character in `haystack` that is in `needles` and
+  ## returns its index if it is found. Otherwise, returns -1. Note that this
+  ## differs from
+  ## `strutils.find <strutils.html#find,string,set[char],Natural,int>`_ in that
+  ## `strutils.find` returns an index based on the start of the string, not the
+  ## start of the slice.
+  ##
+  ## See also:
+  ## * `deprecated strutils.find<strutils.html#find,string,set[char],Natural,int>`_
+  runnableExamples:
+    doAssert "abcabc".indexOf({'b', 'c', 'z'}) == 1
+    doAssert "abcabc".toOpenArray(3, 5).indexOf({'c', 'z'}) == 2
+    doAssert "abcabc".indexOf({'x'}) == -1
+  for index in low(haystack) .. high(haystack):
+    if haystack[index] in needles:
+      return index
+  return -1
+
+func indexOf*(haystack: openArray[char], needle: openArray[char]): int =
+  ## Searches for `needle` in `haystack`. Returns the leftmost index of `needle`
+  ## if it is found. Otherwise, returns -1. Note that this differs from
+  ## `strutils.find <strutils.html#find,string,string,Natural,int>`_ in that
+  ## `strutils.find` returns an index based on the start of the string, not the
+  ## start of the slice.
+  ##
+  ## See also:
+  ## * `deprecated strutils.find<strutils.html#find,string,string,Natural,int>`_
+  runnableExamples:
+    doAssert "abcabc".indexOf("") == 0
+    doAssert "abcabc".indexOf("a") == 0
+    doAssert "abcabc".indexOf("bc") == 1
+    doAssert "abcabc".toOpenArray(2, 5).indexOf("bc") == 2
+    doAssert "abcabc".indexOf("z") == -1
+  if needle.len == 0:
+    return 0
+  elif haystack.len < needle.len:
+    return -1
+
+  when not hasCStringBuiltin:
+    result = indexOfUsingBoyerMooreHorspool(haystack, needle)
+  else:
+    when nimvm:
+      result = indexOfUsingBoyerMooreHorspool(haystack, needle)
+    else:
+      when hasCStringBuiltin:
+        if haystack.len > 0:
+          let found = c_strstr(haystack[0].unsafeAddr, needle[0].unsafeAddr)
+          if not found.isNil:
+            result = cast[ByteAddress](found) -% cast[ByteAddress](haystack[0].unsafeAddr)
+
+            if result > haystack.len - needle.len:
+              # c_strstr will look all the way until a null byte is found, so
+              # we must ensure that the return value is inside the
+              # openArray-defined bounds of the strings
+              result = -1
+          else:
+            result = -1
+        else:
+          result = indexOfUsingBoyerMooreHorspool(haystack, needle)
+      else:
+        result = indexOfUsingBoyerMooreHorspool(haystack, needle)

--- a/tests/stdlib/tstrbasics.nim
+++ b/tests/stdlib/tstrbasics.nim
@@ -13,6 +13,55 @@ template strip2(input: string, args: varargs[untyped]): untyped =
     strip(a)
   a
 
+proc runtimeMain() =
+  block: # indexOf
+    block:
+      const haystack: string = "0123456789ABCDEFGH"
+      doAssert haystack.len == 18
+
+      doAssert haystack.indexOf('A') == 10
+      doAssert haystack.toOpenArray(5, 17).indexOf('A') == 5
+      doAssert haystack.toOpenArray(5, 9).indexOf('A') == -1
+      doAssert haystack.toOpenArray(5, haystack.high).indexOf("A") == 5
+      doAssert haystack.toOpenArray(5, 9).indexOf("A") == -1
+
+      doAssert haystack.indexOf({'A'..'C'}) == 10
+      doAssert haystack.toOpenArray(5, haystack.high).indexOf({'A'..'C'}) == 5
+      doAssert haystack.toOpenArray(5, 10).indexOf({'A'..'C'}) == 5
+      doAssert haystack.toOpenArray(5, 9).indexOf({'A'..'C'}) == -1
+
+    block:
+      const haystack: string = "ABCABABABABCAB"
+      doAssert len(haystack) == 14
+
+      doAssert haystack.indexOf("ABC") == 0
+      doAssert haystack.toOpenArray(0, 13).indexOf("ABC") == 0
+      doAssert haystack.toOpenArray(1, 13).indexOf("ABC") == 8
+      doAssert haystack.toOpenArray(9, 13).indexOf("ABC") == 0
+      doAssert haystack.toOpenArray(10, 13).indexOf("ABC") == -1
+
+      doAssert haystack.toOpenArray(0, 12).indexOf("ABC") == 0
+      doAssert haystack.toOpenArray(1, 12).indexOf("ABC") == 8
+      doAssert haystack.toOpenArray(1, 11).indexOf("ABC") == 8
+      doAssert haystack.toOpenArray(1, 10).indexOf("ABC") == -1
+      doAssert haystack.toOpenArray(1, 3).indexOf("ABC") == -1
+
+    block:
+      const haystack: seq[char] = @['a', 'b', 'c']
+      doAssert haystack.indexOf("abc") == 0
+      doAssert haystack.indexOf("abcd".toOpenArray(0, 3)) == -1
+
+      const needle: seq[char] = @['a', 'b', 'c', 'd']
+      doAssert haystack.indexOf(needle.toOpenArray(0, 3)) == -1
+      doAssert haystack.indexOf(needle.toOpenArray(0, 2)) == 0
+      doAssert haystack.indexOf(needle.toOpenArray(0, 1)) == 0
+      doAssert haystack.indexOf(needle.toOpenArray(1, 2)) == 1
+
+    # searching for empty string
+    doAssert "".indexOf("") == 0
+    doAssert "abc".toOpenArray(1, 2).indexOf("") == 0
+    doAssert "abc".toOpenArray(2, 2).indexOf("") == 0
+
 proc main() =
   block: # strip
     block: # bug #17173
@@ -99,5 +148,36 @@ proc main() =
     doAssert fn("def") == "def"
     doAssert fn(['d','\0', 'f'])[2] == 'f'
 
+  block: # indexOf
+    block:
+      const haystack: string = "0123456789ABCDEFGH"
+      doAssert haystack.len == 18
+
+      doAssert haystack.indexOf("A") == 10
+      doAssert haystack.indexOf({'A'..'C'}) == 10
+
+    block:
+      const haystack: string = "ABCABABABABCAB"
+      doAssert len(haystack) == 14
+
+      doAssert haystack.indexOf("ABC") == 0
+
+    block: # using seq
+      const haystack: seq[char] = @['a', 'b', 'c']
+      doAssert haystack.indexOf("abc") == 0
+
+      doAssert haystack.indexOf(@['a', 'b', 'c']) == 0
+      doAssert haystack.indexOf(@['b', 'c']) == 1
+      doAssert haystack.indexOf(@['a', 'b', 'c', 'd']) == -1
+
+    doAssert "".indexOf("/") == -1
+    doAssert "/".indexOf("/") == 0
+    doAssert "/".indexOf("//") == -1
+
+    # searching for empty string
+    doAssert "".indexOf("") == 0
+    doAssert "abc".indexOf("") == 0
+
 static: main()
 main()
+runtimeMain()

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -308,6 +308,22 @@ template main() =
       doAssert "abcd".find("bc", start=1, last=last) == -1
       doAssert "abcd".find("bc", start=2, last=last) == -1
 
+    # using openArray variant
+    block:
+      doAssert "abcde".toOpenArray(0, 4).find("") == 0
+      doAssert "abcde".toOpenArray(1, 4).find("") == 0
+      doAssert "abcde".toOpenArray(3, 4).find("") == 0
+      doAssert "abcde".toOpenArray(4, 4).find("") == 0
+
+      doAssert "abcde".toOpenArray(0, 4).find("c") == 2
+      doAssert "abcde".toOpenArray(1, 4).find("c") == 1
+      doAssert "abcde".toOpenArray(2, 4).find("c") == 0
+      doAssert "abcde".toOpenArray(3, 4).find("c") == -1
+
+      doAssert "abcde".toOpenArray(0, 4).find("cd") == 2
+      doAssert "abcde".toOpenArray(1, 4).find("cd") == 1
+      doAssert "abcde".toOpenArray(3, 4).find("cd") == -1
+
   block: # rfind
     doAssert "0123456789ABCDEFGAH".rfind('A') == 17
     doAssert "0123456789ABCDEFGAH".rfind('A', last=13) == 10

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -308,22 +308,6 @@ template main() =
       doAssert "abcd".find("bc", start=1, last=last) == -1
       doAssert "abcd".find("bc", start=2, last=last) == -1
 
-    # using openArray variant
-    block:
-      doAssert "abcde".toOpenArray(0, 4).find("") == 0
-      doAssert "abcde".toOpenArray(1, 4).find("") == 0
-      doAssert "abcde".toOpenArray(3, 4).find("") == 0
-      doAssert "abcde".toOpenArray(4, 4).find("") == 0
-
-      doAssert "abcde".toOpenArray(0, 4).find("c") == 2
-      doAssert "abcde".toOpenArray(1, 4).find("c") == 1
-      doAssert "abcde".toOpenArray(2, 4).find("c") == 0
-      doAssert "abcde".toOpenArray(3, 4).find("c") == -1
-
-      doAssert "abcde".toOpenArray(0, 4).find("cd") == 2
-      doAssert "abcde".toOpenArray(1, 4).find("cd") == 1
-      doAssert "abcde".toOpenArray(3, 4).find("cd") == -1
-
   block: # rfind
     doAssert "0123456789ABCDEFGAH".rfind('A') == 17
     doAssert "0123456789ABCDEFGAH".rfind('A', last=13) == 10


### PR DESCRIPTION
Refs https://github.com/nim-lang/Nim/pull/18127#issue-657572888. The docs for `find` say that `last` represents an inclusive end index, but `last=0` is not treated as the 0th index. This PR fixes that.

Future directions:
1. Raise an `IndexDefect` if `last < start`, which will help with edge cases for #18128.
1. `last` being restricted to union(-1, `Natural`) is a bit inconvenient. Is there room for something adjacent to [`Natural`](https://nim-lang.github.io/Nim/system.html#Natural) like this?
```nim
type
  # Natural* = range[0..high(int)]
  StringIndex* = range[-1..high(int)]
```
This would be like `ssize_t` and this type could also be used as the return type of `find` and `rfind`. Alternatively, we could change the paramter in `find` to
```nim
func find(..., last: Natural = high(Natural))
```
instead of what it is in the current state of this PR, which is
```nim
func find(..., last: int = -1)
```