### PR TITLE
fix #18178, set a CI timeout for github action pipelines instead of the 6 hour default

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -44,6 +44,7 @@ jobs:
 
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60 # refs bug #18178
 
     steps:
       - name: 'Checkout'

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -11,6 +11,7 @@ jobs:
         batch: ["allowed_failures", "0_3", "1_3", "2_3"] # list of `index_num`
     name: '${{ matrix.os }} (batch: ${{ matrix.batch }})'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60 # refs bug #18178
     env:
       NIM_TEST_PACKAGES: "1"
       NIM_TESTAMENT_BATCH: ${{ matrix.batch }}


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/18178 
(6 hour as a default makes no sense; just filed https://github.com/github/feedback/discussions/4109)