### PR TITLE
Ref #18177 - lbgc.so.5.0 on OpenBSD 6.9

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1146,7 +1146,7 @@ when defined(boehmgc):
   elif defined(macosx):
     const boehmLib = "libgc.dylib"
   elif defined(openbsd):
-    const boehmLib = "libgc.so.4.0"
+    const boehmLib = "libgc.so.(4|5).0"
   elif defined(freebsd):
     const boehmLib = "libgc-threaded.so.1"
   else:


### PR DESCRIPTION
Fixes #18177 - OpenBSD 6.9 has `libgc.so.5.0` rather than 4.0.