### PR TITLE
up to 20x faster jsonutils deserialization

### DIFF
--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -128,7 +128,7 @@ macro initCaseObject(T: typedesc, fun: untyped): untyped =
         `fun`(`key2`, typedesc[`typ`])
       result.add newTree(nnkExprColonExpr, key, val)
 
-proc raiseJsonException(condStr: string, msg: string) =
+proc raiseJsonException(condStr: string, msg: string) {.noinline.} =
   # just pick 1 exception type for simplicity; other choices would be:
   # JsonError, JsonParser, JsonKindError
   raise newException(ValueError, condStr & " failed: " & msg)

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -128,14 +128,14 @@ macro initCaseObject(T: typedesc, fun: untyped): untyped =
         `fun`(`key2`, typedesc[`typ`])
       result.add newTree(nnkExprColonExpr, key, val)
 
-proc checkJsonImpl(cond: bool, condStr: string, msg = "") =
-  if not cond:
-    # just pick 1 exception type for simplicity; other choices would be:
-    # JsonError, JsonParser, JsonKindError
-    raise newException(ValueError, msg)
+proc raiseJsonException(condStr: string, msg: string) =
+  # just pick 1 exception type for simplicity; other choices would be:
+  # JsonError, JsonParser, JsonKindError
+  raise newException(ValueError, condStr & " failed: " & msg)
 
 template checkJson(cond: untyped, msg = "") =
-  checkJsonImpl(cond, astToStr(cond), msg)
+  if not cond:
+    raiseJsonException(astToStr(cond), msg)
 
 proc hasField[T](obj: T, field: string): bool =
   for k, _ in fieldPairs(obj):


### PR DESCRIPTION
* fix https://forum.nim-lang.org/t/8074#51731
* jsonutils deserialization (jsonTo, fromJson) is now up to 20x faster
* `condStr` is now used instead of ignored (unrelated bugfix)

`nim r -d:danger main`
(taking best of 5 runs)

## before PR
0.27

## after PR
0.012

example directly adapted from https://forum.nim-lang.org/t/8074

```nim
when true:
  import times, std/json, std/jsonutils

  type OptionContract* = ref object
    id*:               string
    right*:            string
    expiration*:       string
    strike_raw*:       float
    premium_raw*:      float
    data_type*:        string

  type OptionChain* = object
    contracts*: seq[OptionContract]

  proc stub_data(): OptionChain =
    result = OptionChain()
    for _ in 1..6000:
      result.contracts.add OptionContract(
        id: "AMZN CALL 2021-03-19 1460.0 USD",
        right: "call",
        expiration: "2021-03-19",
        strike_raw: 1460.0,
        premium_raw: 1676.03,
        data_type: "some type"
      )
  let json_str = stub_data().toJson.pretty

  let j = json_str.parseJson
  let time = cpuTime()
  for i in 1..5:
    discard j.jsonTo(OptionChain)
  let t2 = cpuTime()
  echo "Time taken: ", t2 - time, " sec"
```

## performance lesson learned
~~avoid function calls in hotspots (even `{.inline.}` or `--passc:-flto` would not help here)~~

actually the real explanation is instead explained here: https://github.com/nim-lang/Nim/pull/18183#issuecomment-855197540, which is that templates, unlike procs, allow lazy parameter evaluation eg:
```nim
checkJson ok, $(json.len, num, numMatched, $T, json)
  # The `msg` is only evaluated on failure if checkJson is a template, but not if it's a proc
```

