### PR TITLE
readAsText supports both Blob and File (fixes #18187)

### DIFF
--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1767,7 +1767,5 @@ since (1, 3):
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsBinaryString
   proc readAsDataURL*(f: FileReader, b: Blob) {.importcpp: "#.readAsDataURL(#)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
-  proc readAsText*(f: FileReader, b: Blob, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
-    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText
-  proc readAsText*(f: FileReader, b: File, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
+  proc readAsText*(f: FileReader, b: Blob|File, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1769,3 +1769,5 @@ since (1, 3):
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL
   proc readAsText*(f: FileReader, b: Blob, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
     ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText
+  proc readAsText*(f: FileReader, b: File, encoding = cstring"UTF-8") {.importcpp: "#.readAsText(#, #)".}
+    ## https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText


### PR DESCRIPTION
This fixes https://github.com/nim-lang/Nim/issues/18187

The proc signature shouldcover both `Blob` and `File`.