### PR TITLE
make changeDetectedViaJsonBuildInstructions warning less verbose when json file invalid (eg due to spec change)

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -993,7 +993,7 @@ proc changeDetectedViaJsonBuildInstructions*(conf: ConfigRef; jsonFile: Absolute
   var bcache: BuildCache
   try: bcache.fromJson(jsonFile.string.parseFile)
   except IOError, OSError, ValueError:
-    stderr.write "Warning: JSON processing failed for $#: $#\n" % [jsonFile.string, getCurrentExceptionMsg()]
+    stderr.write "Warning: JSON processing failed for: $#\n" % jsonFile.string
     return true
   if bcache.currentDir != getCurrentDir() or # fixes bug #16271
      bcache.configFiles != conf.configFiles.mapIt(it.string) or


### PR DESCRIPTION
follows #18100

the error msg was turning out to be too verbose in practice