### PR TITLE
Fix for #18161 AsyncHttpServer Issue Too many open files.

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -281,11 +281,11 @@ proc processRequest(
   # connection will not be closed and will be kept in the connection pool.
 
   # Persistent connections
-  if (not request.disableKeepalive and
-     request.protocol == HttpVer11 and
+  if not request.disableKeepalive and
+     (request.protocol == HttpVer11 and
       cmpIgnoreCase(request.headers.getOrDefault("connection"), "close") != 0) or
      (request.protocol == HttpVer10 and
-      cmpIgnoreCase(request.headers.getOrDefault("connection"), "keep-alive") == 0):
+      cmpIgnoreCase(request.headers.getOrDefault("connection"), "keep-alive") == 0)):
     # In HTTP 1.1 we assume that connection is persistent. Unless connection
     # header states otherwise.
     # In HTTP 1.0 we assume that the connection should not be persistent.


### PR DESCRIPTION
I've been checking the code in asynchttpserver file and found that in the processClient function the connection is never closed after the "while" loop. So even if the keepalive header is off the number of open files is always increasing. With the keepalive off and if the connection is closed after the "while" loop the server never dies.

If the header keepalive is on and if it exceeds the pre-defined number of file descriptors it automatically closes the connection! I also added a timeout for keepalive connections.