### PR TITLE
alternative to #18185

### DIFF
--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -11,7 +11,10 @@
 
 
 when not compileOption("threads") and not defined(nimdoc):
-  {.error: "Rlocks requires --threads:on option.".}
+  when false:
+    # make rlocks modlue consistent with locks module,
+    # so they can replace each other seamlessly.
+    {.error: "Rlocks requires --threads:on option.".}
 
 const insideRLocksModule = true
 include "system/syslocks"

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -18,7 +18,7 @@ runnableExamples("-r:off"):
   # This example will create an HTTP server on an automatically chosen port.
   # It will respond to all requests with a `200 OK` response code and "Hello World"
   # as the response body.
-  import std/asyncdispatch, asynchttpserver
+  import std/asyncdispatch
   proc main {.async.} =
     var server = newAsyncHttpServer()
     proc cb(req: Request) {.async.} =


### PR DESCRIPTION
close #18185

## Pros
The rlocks module is more consistent with locks module, so they can replace each other seamlessly.
## Cons
The error messages may be worse as #12231 said(link error instead of compilation error without threads options)

## Other possible solution:
make `threads:on` options default may solve this problem(ref https://github.com/nim-lang/Nim/pull/10781 and https://github.com/nim-lang/RFCs/issues/361)