### PR TITLE
httpclient.nim Fixes #14794 and an issue where content-header is not set on postContent 

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -997,7 +997,7 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
 
   await newConnection(client, url)
 
-  var newHeaders:HttpHeaders
+  var newHeaders: HttpHeaders
 
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -1001,6 +1001,8 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
 
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
+    # `format` modifies `client.headers`, see 
+    # https://github.com/nim-lang/Nim/pull/18208#discussion_r647036979
     data = await client.format(multipart)
     newHeaders = client.headers.override(headers)
   else:

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -962,7 +962,7 @@ proc format(client: HttpClient | AsyncHttpClient,
     if entry.isFile:
       length += entry.fileSize + httpNewLine.len
 
-  result.add "--" & bound & "--"
+  result.add "--" & bound & "--" & httpNewLine
 
   for s in result: length += s.len
   client.headers["Content-Length"] = $length
@@ -997,12 +997,14 @@ proc requestAux(client: HttpClient | AsyncHttpClient, url: Uri,
 
   await newConnection(client, url)
 
-  let newHeaders = client.headers.override(headers)
+  var newHeaders:HttpHeaders
 
   var data: seq[string]
   if multipart != nil and multipart.content.len > 0:
     data = await client.format(multipart)
+    newHeaders = client.headers.override(headers)
   else:
+    newHeaders = client.headers.override(headers)
     # Only change headers if they have not been specified already
     if not newHeaders.hasKey("Content-Length"):
       if body.len != 0:

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -34,7 +34,6 @@ block: # bug #14794 (And test for presence of content-length header when using p
       doAssert(req.headers.hasKey("content-length"), "Content-Length header is not present.")
       killServer = true
       asyncCheck req.respond(Http200, "OK")
-      
 
     var server = newAsyncHttpServer()
     server.listen(Port(5556))
@@ -48,7 +47,6 @@ block: # bug #14794 (And test for presence of content-length header when using p
     let c = newAsyncHttpClient()
     var data = newMultipartData()
     data.add("file.txt", "This is intended to be an example text file.\r\nThis would be the second line.\r\n")
-
     let r = await c.postContent("http://127.0.0.1:5556", multipart = data)
     c.close()
 

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -28,7 +28,7 @@ block: # bug #14794 (And test for presence of content-length header when using p
     proc cb(req: Request) {.async.} =
       doAssert(req.body.endsWith(httpNewLine), "Multipart body does not end with a newline.")
       # this next line is probably not required because asynchttpserver does not call
-      # the callback when there is no content-lenght header.  It instead errors with 
+      # the callback when there is no content-length header.  It instead errors with 
       # Error: unhandled exception: 411 Length Required
       # Added for good measure in case the server becomes more permissive.
       doAssert(req.headers.hasKey("content-length"), "Content-Length header is not present.")

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim c --threads:on $file"
 """
 
-import asynchttpserver, httpclient, asyncdispatch
+import asynchttpserver, httpclient, asyncdispatch, strutils
 
 block: # bug #16436
   proc startServer() {.async.} =
@@ -21,3 +21,36 @@ block: # bug #16436
   asyncCheck startServer()
   doAssertRaises(ProtocolError):
     waitFor runClient()
+
+block: # bug #14794 (And test for presence of content-length header when using postContent)
+  proc startServer() {.async.} =
+    var killServer = false
+    proc cb(req: Request) {.async.} =
+      doAssert(req.body.endsWith(httpNewLine), "Multipart body does not end with a newline.")
+      # this next line is probably not required because asynchttpserver does not call
+      # the callback when there is no content-lenght header.  It instead errors with 
+      # Error: unhandled exception: 411 Length Required
+      # Added for good measure in case the server becomes more permissive.
+      doAssert(req.headers.hasKey("content-length"), "Content-Length header is not present.")
+      killServer = true
+      asyncCheck req.respond(Http200, "OK")
+      
+
+    var server = newAsyncHttpServer()
+    server.listen(Port(5556))
+    while not killServer:
+      if server.shouldAcceptRequest():
+        await server.acceptRequest(cb)
+      else:
+        poll()
+
+  proc runClient() {.async.} =
+    let c = newAsyncHttpClient()
+    var data = newMultipartData()
+    data.add("file.txt", "This is intended to be an example text file.\r\nThis would be the second line.\r\n")
+
+    let r = await c.postContent("http://127.0.0.1:5556", multipart = data)
+    c.close()
+
+  asyncCheck startServer()
+  waitFor runClient()


### PR DESCRIPTION
EDIT(timotheecour) fix #14794

Fixed missing newline after bound marker in mulipart post (#14794) and a problem where calling postContent with multipart data does not set content-length header.