### PR TITLE
[superseded]  #18216 make moveDir work across partitions on windows

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2405,10 +2405,9 @@ proc moveDir*(source, dest: string) {.tags: [ReadIOEffect, WriteIOEffect], noWei
   ## * `existsOrCreateDir proc <#existsOrCreateDir,string>`_
   ## * `createDir proc <#createDir,string>`_
   if not tryMoveFSObject(source, dest):
-    when not defined(windows):
-      # Fallback to copy & del
-      copyDir(source, dest)
-      removeDir(source)
+    # Fallback to copy & del
+    copyDir(source, dest)
+    removeDir(source)
 
 proc createSymlink*(src, dest: string) {.noWeirdTarget.} =
   ## Create a symbolic link at `dest` which points to the item specified


### PR DESCRIPTION
if `tryMoveFSObject` fails, copy & remove regardless of system
fixes #18216