### PR TITLE
avoid re-exporting `options` from std/wrapnils

### DIFF
--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -25,7 +25,6 @@ runnableExamples:
   assert (?.f2.x2.x2).x3 == nil  # this terminates ?. early
 
 from options import Option, isSome, get, option, unsafeGet, UnpackDefect
-export options.get, options.isSome, options.isNone
 
 template fakeDot*(a: Option, b): untyped =
   ## See top-level example.
@@ -90,6 +89,7 @@ macro `?.`*(a: untyped): auto =
 macro `??.`*(a: untyped): Option =
   ## Same as `?.` but returns an `Option`.
   runnableExamples:
+    import std/options
     type Foo = ref object
       x1: ref int
       x2: int

--- a/tests/stdlib/twrapnils.nim
+++ b/tests/stdlib/twrapnils.nim
@@ -1,4 +1,5 @@
 import std/wrapnils
+from std/options import get, isSome
 
 proc checkNotZero(x: float): float =
   doAssert x != 0


### PR DESCRIPTION
small cleanup PR (not a big deal if this PR is rejected)

## rationale:

the main use case of wrapnils doesn't involve the use of `Options`, and in the case where Options APIs are needed (for `??.`), user can import options themselves. In my use case I had a conflict involving `isNone` when using wrapnils in the compiler, causing me to use: `export wrapnils except isNone`. 

Note that import/re-export pattern is not bad in itself (in particular, I'd like std/times to import/re-export smaller modules (std/durations), ditto with std/os (std/paths etc)) in cases where the parent module is considered encompassing the other functionalities, but this wasn't the case with wrapnils which merely was using options.