### PR TITLE
update changelog for wrapnils

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -285,9 +285,6 @@
 - Added `std/strbasics` for high performance string operations.
   Added `strip`, `setSlice`, `add(a: var string, b: openArray[char])`.
 
-
-- Added to `wrapnils` an option-like API via `??.`, `isSome`, `get`.
-
 - `std/options` changed `$some(3)` to `"some(3)"` instead of `"Some(3)"`
   and `$none(int)` to `"none(int)"` instead of `"None[int]"`.
 


### PR DESCRIPTION
there was a duplicate entry (due to changelog merge strategy, a known tradeoff) with:
```
Added `??.` macro which returns an `Option`.`
```
(#16931 which re-exported options was done in 1.5.1 so no need to mention that the re-export of options was removed in https://github.com/nim-lang/Nim/pull/18222)

(addresses https://github.com/nim-lang/Nim/pull/18222#issuecomment-858300847 )