### PR TITLE
getOrDefault default argument is sink

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -415,7 +415,7 @@ proc getOrDefault*[A, B](t: Table[A, B], key: A): B =
 
   getOrDefaultImpl(t, key)
 
-proc getOrDefault*[A, B](t: Table[A, B], key: A, default: B): B =
+proc getOrDefault*[A, B](t: Table[A, B], key: A, default: sink B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -946,7 +946,7 @@ proc getOrDefault*[A, B](t: TableRef[A, B], key: A): B =
 
   getOrDefault(t[], key)
 
-proc getOrDefault*[A, B](t: TableRef[A, B], key: A, default: B): B =
+proc getOrDefault*[A, B](t: TableRef[A, B], key: A, default: sink B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -1449,7 +1449,7 @@ proc getOrDefault*[A, B](t: OrderedTable[A, B], key: A): B =
 
   getOrDefaultImpl(t, key)
 
-proc getOrDefault*[A, B](t: OrderedTable[A, B], key: A, default: B): B =
+proc getOrDefault*[A, B](t: OrderedTable[A, B], key: A, default: sink B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -1935,7 +1935,7 @@ proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A): B =
 
   getOrDefault(t[], key)
 
-proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A, default: B): B =
+proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A, default: sink B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##


### PR DESCRIPTION
Avoids a copy. Testing: I made a snippet: 

```nim
import std/tables

proc main =
  var
    s = initTable[int, string]()
  var tmp = "books"
  prepareMutation(tmp)
  echo getOrDefault(s, 0, tmp)
  #tmp[0] = 'r'
  #echo tmp

main()
```

Confirmed that it works with `-t:"-fsanitize=address,undefined" -l:"-fsanitize=address,undefined"`