### PR TITLE
getType now works with tyInferred (arising from concepts); refs #18220

### DIFF
--- a/compiler/vmdeps.nim
+++ b/compiler/vmdeps.nim
@@ -289,7 +289,7 @@ proc mapTypeToAstX(cache: IdentCache; t: PType; info: TLineInfo;
   of tyNot: result = mapTypeToBracket("not", mNot, t, info)
   of tyIterable: result = mapTypeToBracket("iterable", mIterableType, t, info)
   of tyAnything: result = atomicType("anything", mNone)
-  of tyInferred: assert false
+  of tyInferred: result = mapTypeToAstX(cache, t.lastSon, info, idgen, inst, allowRecursion)
   of tyStatic, tyFromExpr:
     if inst:
       if t.n != nil: result = t.n.copyTree

--- a/tests/macros/tgettype.nim
+++ b/tests/macros/tgettype.nim
@@ -47,11 +47,16 @@ block:
     arity(U) == 2
 
   proc map1[T, R, U](a: T, fn: Callable1[R, T, U]): R =
-    let fn = cast[U](fn)
+    let fn = U(fn)
+      # `cast[U](fn)` would also work;
+      # this is currently needed otherwise, sigmatch errors with:
+      # Error: attempting to call routine: 'fn'
+      #  found 'fn' [param declared in tgettype.nim(53, 28)]
+      # this can be fixed in future work
     fn(a)
 
   proc map2[T, R, U](a: T, fn: Callable2[R, T, U]): R =
-    let fn = cast[U](fn)
+    let fn = U(fn)
     fn(a)
 
   proc fn1(a: int, a2 = 'x'): string = $(a, a2, "fn1")

--- a/tests/macros/tgettype.nim
+++ b/tests/macros/tgettype.nim
@@ -66,12 +66,18 @@ block:
   proc fn5(a: int): string = $(a, "fn5")
 
   assertAll:
+    # Callable1
     1.map1(fn1) == """(1, 'x', "fn1")"""
     1.map1(fn2) == """(1, "zoo", "fn2")"""
     1.map1(fn3) == """(1, "zoo", "fn3")"""
+      # fn3's optional param is not honored, because fn3 and fn2 yield same
+      # generic instantiation; this is a caveat with this approach
+      # There are several possible ways to improve things in future work.
     1.map1(fn4) == """(1, "fn4")"""
     1.map1(fn5) == """(1, "fn5")"""
 
+    # Callable2; prevents passing procs with optional params to avoid above
+    # mentioned caveat, but more restrictive
     not compiles(1.map2(fn1))
     not compiles(1.map2(fn2))
     not compiles(1.map2(fn3))


### PR DESCRIPTION
* getType now works with tyInferred (arising from concepts); the test i added exercises that
* refs #18220 (not a fix but a starting point)

## future work
in future work I'm considering using concept syntax for symbol aliasing/forwarding (templates, iterators, generics, overloaded symchoices, etc; any symbol), ie allowing constraining alias params (from https://github.com/nim-lang/Nim/pull/11992) with concepts, to address https://github.com/nim-lang/Nim/pull/11992#issuecomment-721414001 ; 
I'm not committing to this idea, but it's worth exploring at least, eg:
```nim
# pass by alias: 1 instantiation per symbol
proc call[T](a: T, fn: alias Callable[R, T]): R =
  fn(a)
template bar(a: SomeFloat): auto = a * 2.0
proc bar[T: SomeInteger](a: T): auto = a * 3
assert call(1.0, alias bar) == 2.0
assert call(3, alias bar) == 2 * 3

# pass by unique type: 1 instantiation per type (only accepts proc|func|closure iterator)
# not sure if this form can also accept symChoices and generics, TBD
# there's also a question regarding optional params, see the
# `1.map1(fn3) == """(1, "zoo", "fn3")"""` caveat mentioned in this PR's tests
proc call2[T](a: T, fn: Callable[R, T]): R =
  fn(a)
proc bar2(a: int): auto = a * 4
assert call2(3, bar2) == 3 * 4
```  
