### PR TITLE
enable VM tracing in user code via  `{.define(nimVmTrace).}`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -387,6 +387,9 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 
+- You can now enable/disable VM tracing in a user code section via `{.define(nimVmTrace).}`
+  and `{.undef(nimVmTrace).}`.
+
 - Deprecated `TaintedString` and `--taintmode`.
 
 - Deprecated `--nilseqs` which is now a noop.

--- a/changelog.md
+++ b/changelog.md
@@ -387,8 +387,7 @@
 
 - Added `--declaredlocs` to show symbol declaration location in messages.
 
-- You can now enable/disable VM tracing in a user code section via `{.define(nimVmTrace).}`
-  and `{.undef(nimVmTrace).}`.
+- You can now enable/disable VM tracing in user code via `vmutils.vmTrace`.
 
 - Deprecated `TaintedString` and `--taintmode`.
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -330,14 +330,11 @@ type
     warnCounter*: int
     errorMax*: int
     maxLoopIterationsVM*: int ## VM: max iterations of all loops
+    isVmTrace*: bool
     configVars*: StringTableRef
     symbols*: StringTableRef ## We need to use a StringTableRef here as defined
                              ## symbols are always guaranteed to be style
                              ## insensitive. Otherwise hell would break lose.
-    symbolsCacheId*: int
-      ## allows skipping checks involving `symbols` {.define.}, {.undef.} in
-      ## performance sensitive code; in future work, this could be moved to `StringTableObj`
-      ## as it's a generally useful feature.
     packageCache*: StringTableRef
     nimblePaths*: seq[AbsoluteDir]
     searchPaths*: seq[AbsoluteDir]
@@ -388,15 +385,6 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
     vmProfileData*: ProfileData
-
-proc hasKeyCached*(config: ConfigRef, key: string, symbolsCacheId: var int, val: var bool): bool =
-  ## checks whether `key in config.symbols` in a lazy way, so that if `symbols`
-  ## was not modified since last check, the result is computed with a single int comparison.
-  if symbolsCacheId != config.symbolsCacheId:
-    # we avoid the more expensive check `c.config.symbols.hasKey(key)`
-    symbolsCacheId = config.symbolsCacheId
-    val = config.symbols.hasKey(key)
-  val
 
 proc assignIfDefault*[T](result: var T, val: T, def = default(T)) =
   ## if `result` was already assigned to a value (that wasn't `def`), this is a noop.

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -334,6 +334,10 @@ type
     symbols*: StringTableRef ## We need to use a StringTableRef here as defined
                              ## symbols are always guaranteed to be style
                              ## insensitive. Otherwise hell would break lose.
+    symbolsCacheId*: int
+      ## allows skipping checks involving `symbols` {.define.}, {.undef.} in
+      ## performance sensitive code; in future work, this could be moved to `StringTableObj`
+      ## as it's a generally useful feature.
     packageCache*: StringTableRef
     nimblePaths*: seq[AbsoluteDir]
     searchPaths*: seq[AbsoluteDir]
@@ -384,6 +388,15 @@ type
                                 severity: Severity) {.closure, gcsafe.}
     cppCustomNamespace*: string
     vmProfileData*: ProfileData
+
+proc hasKeyCached*(config: ConfigRef, key: string, symbolsCacheId: var int, val: var bool): bool =
+  ## checks whether `key in config.symbols` in a lazy way, so that if `symbols`
+  ## was not modified since last check, the result is computed with a single int comparison.
+  if symbolsCacheId != config.symbolsCacheId:
+    # we avoid the more expensive check `c.config.symbols.hasKey(key)`
+    symbolsCacheId = config.symbolsCacheId
+    val = config.symbols.hasKey(key)
+  val
 
 proc assignIfDefault*[T](result: var T, val: T, def = default(T)) =
   ## if `result` was already assigned to a value (that wasn't `def`), this is a noop.

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -473,12 +473,14 @@ proc processPop(c: PContext, n: PNode) =
 proc processDefine(c: PContext, n: PNode) =
   if (n.kind in nkPragmaCallKinds and n.len == 2) and (n[1].kind == nkIdent):
     defineSymbol(c.config.symbols, n[1].ident.s)
+    c.config.symbolsCacheId.inc
   else:
     invalidPragma(c, n)
 
 proc processUndef(c: PContext, n: PNode) =
   if (n.kind in nkPragmaCallKinds and n.len == 2) and (n[1].kind == nkIdent):
     undefSymbol(c.config.symbols, n[1].ident.s)
+    c.config.symbolsCacheId.inc
   else:
     invalidPragma(c, n)
 

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -473,14 +473,12 @@ proc processPop(c: PContext, n: PNode) =
 proc processDefine(c: PContext, n: PNode) =
   if (n.kind in nkPragmaCallKinds and n.len == 2) and (n[1].kind == nkIdent):
     defineSymbol(c.config.symbols, n[1].ident.s)
-    c.config.symbolsCacheId.inc
   else:
     invalidPragma(c, n)
 
 proc processUndef(c: PContext, n: PNode) =
   if (n.kind in nkPragmaCallKinds and n.len == 2) and (n[1].kind == nkIdent):
     undefSymbol(c.config.symbols, n[1].ident.s)
-    c.config.symbolsCacheId.inc
   else:
     invalidPragma(c, n)
 

--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -517,7 +517,6 @@ template maybeHandlePtr(node2: PNode, reg: TFullReg, isAssign2: bool): bool =
 
 when not defined(nimHasSinkInference):
   {.pragma: nosinks.}
-import strtabs
 
 proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
   var pc = start
@@ -525,8 +524,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
   # Used to keep track of where the execution is resumed.
   var savedPC = -1
   var savedFrame: PStackFrame
-  var nimVmTrace = false
-  var symbolsCacheId = c.config.symbolsCacheId - 1 # forces a check
   when defined(gcArc) or defined(gcOrc):
     template updateRegsAlias = discard
     template regs: untyped = tos.slots
@@ -536,7 +533,6 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
     var regs: seq[TFullReg] # alias to tos.slots for performance
     updateRegsAlias
   #echo "NEW RUN ------------------------"
-
   while true:
     #{.computedGoto.}
     let instr = c.code[pc]
@@ -551,7 +547,7 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         "pc", $pc, "opcode", alignLeft($c.code[pc].opcode, 15),
         "ra", regDescr("ra", ra), "rb", regDescr("rb", instr.regB),
         "rc", regDescr("rc", instr.regC)]
-    if hasKeyCached(c.config, "nimVmTrace", symbolsCacheId, nimVmTrace):
+    if c.config.isVmTrace:
       # unlike nimVMDebug, this doesn't require re-compiling nim and is controlled by user code
       let info = c.debug[pc]
       # other useful variables: c.loopIterations

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -249,6 +249,9 @@ proc registerAdditionalOps*(c: PCtx) =
                   "isExported() requires a symbol. '" & $n & "' is of kind '" & $n.kind & "'", n.info)
     setResult(a, sfExported in n.sym.flags)
 
+  registerCallback c, "stdlib.vmutils.vmTrace", proc (a: VmArgs) =
+    c.config.isVmTrace = getBool(a, 0)
+
   proc hashVmImpl(a: VmArgs) =
     var res = hashes.hash(a.getString(0), a.getInt(1).int, a.getInt(2).int)
     if c.config.backend == backendJs:

--- a/lib/std/vmutils.nim
+++ b/lib/std/vmutils.nim
@@ -1,0 +1,11 @@
+##[
+Experimental API, subject to change.
+]##
+
+proc vmTrace*(on: bool) {.compileTime.} =
+  runnableExamples:
+    static: vmTrace(true)
+    proc fn =
+      var a = 1
+      vmTrace(false)
+    static: fn()

--- a/tests/stdlib/tvmutils.nim
+++ b/tests/stdlib/tvmutils.nim
@@ -1,0 +1,31 @@
+discard """
+  joinable: false
+  nimout: '''
+0
+1
+2
+tvmutils.nim(28, 13) [opcLdImmInt]     if i == 4:
+tvmutils.nim(28, 10) [opcEqInt]     if i == 4:
+tvmutils.nim(28, 10) [opcFJmp]     if i == 4:
+tvmutils.nim(28, 13) [opcLdImmInt]     if i == 4:
+tvmutils.nim(28, 10) [opcEqInt]     if i == 4:
+tvmutils.nim(28, 10) [opcFJmp]     if i == 4:
+tvmutils.nim(29, 7) [opcLdConst]       vmTrace(false)
+tvmutils.nim(29, 15) [opcLdImmInt]       vmTrace(false)
+tvmutils.nim(29, 14) [opcIndCall]       vmTrace(false)
+5
+6
+'''
+"""
+# line 20 (only showing a subset of nimout to avoid making the test rigid)
+import std/vmutils
+
+proc main() =
+  for i in 0..<7:
+    echo i
+    if i == 2:
+      vmTrace(true)
+    if i == 4:
+      vmTrace(false)
+
+static: main()


### PR DESCRIPTION
## features
This PR allows user code to enable/disable VM tracing in a code section via `{.define(nimVmTrace).}` and `{.undef(nimVmTrace).}`.

Unlike `-d:nimVMDebug`, this doesn't require re-compiling nim and allows user code to control what sections of code should be traced ( `-d:nimVMDebug` by contrast generates lots of noise and cannot be controlled by user code). The check whether to trace doesn't slow down VM thanks to a caching mechanism.

## example
```nim
proc main1() =
  var a = 1
  a.inc

proc main2() =
  var a = 1
  a.inc
  a+=2

{.define(nimVmTrace).}
static: main1()
{.undef(nimVmTrace).}
static: main2()
```

```
nim r --filenames:canonical -f main

tests/nim/all/t12391.nim(15, 9) [opcLdConst] static: main1()
tests/nim/all/t12391.nim(15, 14) [opcIndCall] static: main1()
tests/nim/all/t12391.nim(6, 11) [opcLdImmInt]   var a = 1
tests/nim/all/t12391.nim(7, 4) [opcAddImmInt]   a.inc
tests/nim/all/t12391.nim(6, 3) [opcRet]   var a = 1
tests/nim/all/t12391.nim(6, 3) [opcJmp]   var a = 1
tests/nim/all/t12391.nim(6, 3) [opcEof]   var a = 1
```


## future work
- [ ] if this doesn't result in a performance penalty, consider also moving the `when traceCode:` into a similar flag that can be set similarly, without recompiling nim
- [ ] likewise for VM profiling
- [ ] likewise for VM counters (counting the number of times a certain event happens)
