### PR TITLE
system/excpt: check if the exception is not nil before pop

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -135,8 +135,9 @@ proc pushCurrentException(e: sink(ref Exception)) {.compilerRtl, inl.} =
   #showErrorMessage2 "A"
 
 proc popCurrentException {.compilerRtl, inl.} =
-  currException = currException.up
-  #showErrorMessage2 "B"
+  if currException != nil:
+    currException = currException.up
+    #showErrorMessage2 "B"
 
 proc popCurrentExceptionEx(id: uint) {.compilerRtl.} =
   discard "only for bootstrapping compatbility"

--- a/tests/exception/tsetexceptions.nim
+++ b/tests/exception/tsetexceptions.nim
@@ -6,3 +6,10 @@ let ex = newException(CatchableError, "test")
 setCurrentException(ex)
 doAssert getCurrentException().msg == ex.msg
 doAssert getCurrentExceptionMsg() == ex.msg
+setCurrentException(nil)
+
+try:
+  raise newException(CatchableError, "test2")
+except:
+  setCurrentException(nil)
+doAssert getCurrentException() == nil


### PR DESCRIPTION
In CPS we would consume an exception in the except branch by stashing it
into a local then remove the exception from Nim environment so as not to
leak it to other code that would be running before the continuation
continues

However since popCurrentException() assumes that the exception always
exist, removing the exception from an except branch will cause a
SIGSEGV to happen. This commit fixes that.