### PR TITLE
fixes #18235 - proc annotation type macro sym leak

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -363,7 +363,7 @@ proc openShadowScope*(c: PContext) =
                           depthLevel: c.scopeDepth)
 
 proc closeShadowScope*(c: PContext) =
-  ## closes the shadow scope, but doesn't merge any of the symbols  
+  ## closes the shadow scope, but doesn't merge any of the symbols
   c.closeScope
 
 proc mergeShadowScope*(c: PContext) =

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -314,6 +314,7 @@ proc addDeclAt*(c: PContext; scope: PScope, sym: PSym) =
 from ic / ic import addHidden
 
 proc addInterfaceDeclAux*(c: PContext, sym: PSym, forceExport = false) =
+  ## adds symbol to the module for either private or public access.
   if sfExported in sym.flags or forceExport:
     # add to interface:
     if c.module != nil: exportSym(c, sym)
@@ -324,12 +325,15 @@ proc addInterfaceDeclAux*(c: PContext, sym: PSym, forceExport = false) =
       addHidden(c.encoder, c.packedRepr, sym)
 
 proc addInterfaceDeclAt*(c: PContext, scope: PScope, sym: PSym) =
+  ## adds a symbol on the scope and the interface if appropriate
   addDeclAt(c, scope, sym)
   if not scope.isShadowScope:
     # adding into a non-shadow scope, we need to handle exports, etc
     addInterfaceDeclAux(c, sym)
 
 proc addOverloadableSymAt*(c: PContext; scope: PScope, fn: PSym) =
+  ## adds an symbol to the given scope, will check for and raise errors if it's
+  ## a redefinition as opposed to an overload.
   if fn.kind notin OverloadableSyms:
     internalError(c.config, fn.info, "addOverloadableSymAt")
     return
@@ -340,17 +344,15 @@ proc addOverloadableSymAt*(c: PContext; scope: PScope, fn: PSym) =
     scope.addSym(fn)
 
 proc addInterfaceDecl*(c: PContext, sym: PSym) =
-  # it adds the symbol to the interface if appropriate
+  ## adds a decl and the interface if appropriate
   addDecl(c, sym)
   if not c.currentScope.isShadowScope:
-    # adding into a non-shadow scope, we need to handle exports, etc
     addInterfaceDeclAux(c, sym)
 
 proc addInterfaceOverloadableSymAt*(c: PContext, scope: PScope, sym: PSym) =
-  # it adds the symbol to the interface if appropriate
+  ## adds an overloadable symbol on the scope and the interface if appropriate
   addOverloadableSymAt(c, scope, sym)
   if not scope.isShadowScope:
-    # adding into a non-shadow scope, we need to handle exports, etc
     addInterfaceDeclAux(c, sym)
 
 proc openShadowScope*(c: PContext) =
@@ -361,7 +363,7 @@ proc openShadowScope*(c: PContext) =
                           depthLevel: c.scopeDepth)
 
 proc closeShadowScope*(c: PContext) =
-  ## closes the shadow scope, but doesn't merge any of the symbols
+  ## closes the shadow scope, but doesn't merge any of the symbols  
   c.closeScope
 
 proc mergeShadowScope*(c: PContext) =

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -325,7 +325,9 @@ proc addInterfaceDeclAux*(c: PContext, sym: PSym, forceExport = false) =
 
 proc addInterfaceDeclAt*(c: PContext, scope: PScope, sym: PSym) =
   addDeclAt(c, scope, sym)
-  addInterfaceDeclAux(c, sym)
+  if not scope.isShadowScope:
+    # adding into a non-shadow scope, we need to handle exports, etc
+    addInterfaceDeclAux(c, sym)
 
 proc addOverloadableSymAt*(c: PContext; scope: PScope, fn: PSym) =
   if fn.kind notin OverloadableSyms:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1497,6 +1497,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
                        validPragmas: TSpecialWords): PNode =
   var n = prc[pragmasPos]
   if n == nil or n.kind == nkEmpty: return
+  c.openShadowScope()
   for i in 0..<n.len:
     let it = n[i]
     let key = if it.kind in nkPragmaCallKinds and it.len >= 1: it[0] else: it
@@ -1558,7 +1559,8 @@ proc semProcAnnotation(c: PContext, prc: PNode;
         result[pragmasPos].kind != nkEmpty:
       pragma(c, result[namePos].sym, result[pragmasPos], validPragmas)
 
-    return
+    break # don't return, we need to clean-up the shadowscope
+  c.mergeShadowScope()
 
 proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
   ## used for resolving 'auto' in lambdas based on their callsite
@@ -1844,7 +1846,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
 
   # before compiling the proc params & body, set as current the scope
   # where the proc was declared
-  let delcarationScope = c.currentScope
+  let declarationScope = c.currentScope
   pushOwner(c, s)
   openScope(c)
 
@@ -1889,7 +1891,7 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
 
   var (proto, comesFromShadowScope) =
       if isAnon: (nil, false)
-      else: searchForProc(c, delcarationScope, s)
+      else: searchForProc(c, declarationScope, s)
   if proto == nil and sfForward in s.flags:
     ## In cases such as a macro generating a proc with a gensymmed name we
     ## know `searchForProc` will not find it and sfForward will be set. In
@@ -1916,9 +1918,9 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
 
   if not hasProto and sfGenSym notin s.flags: #and not isAnon:
     if s.kind in OverloadableSyms:
-      addInterfaceOverloadableSymAt(c, delcarationScope, s)
+      addInterfaceOverloadableSymAt(c, declarationScope, s)
     else:
-      addInterfaceDeclAt(c, delcarationScope, s)
+      addInterfaceDeclAt(c, declarationScope, s)
 
   pragmaCallable(c, s, n, validPragmas)
   if not hasProto:

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1497,7 +1497,6 @@ proc semProcAnnotation(c: PContext, prc: PNode;
                        validPragmas: TSpecialWords): PNode =
   var n = prc[pragmasPos]
   if n == nil or n.kind == nkEmpty: return
-  c.openShadowScope()
   for i in 0..<n.len:
     let it = n[i]
     let key = if it.kind in nkPragmaCallKinds and it.len >= 1: it[0] else: it
@@ -1559,8 +1558,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
         result[pragmasPos].kind != nkEmpty:
       pragma(c, result[namePos].sym, result[pragmasPos], validPragmas)
 
-    break # don't return, we need to clean-up the shadowscope
-  c.mergeShadowScope()
+    return
 
 proc semInferredLambda(c: PContext, pt: TIdTable, n: PNode): PNode {.nosinks.} =
   ## used for resolving 'auto' in lambdas based on their callsite

--- a/tests/macros/m18235.nim
+++ b/tests/macros/m18235.nim
@@ -17,3 +17,4 @@ macro unexport(n: typed): untyped =
   result[0] = n.name.strVal.ident
 
 proc foo*() {.unexport.} = discard
+proc bar() {.rename.} = discard

--- a/tests/macros/m18235.nim
+++ b/tests/macros/m18235.nim
@@ -23,11 +23,13 @@ proc foooof*() {.unexport, eexport, unexport.} = discard
 proc barrab() {.eexport, unexport, eexport.} = discard
 
 macro eexportMulti(n: typed): untyped =
+  # use the call version of `eexport` macro for one or more decls
   result = copyNimTree(n)
   for i in 0..<result.len:
     result[i] = newCall(ident"eexport", result[i])
 
 macro unexportMulti(n: typed): untyped =
+  # use the call version of `unexport` macro for one or more decls
   result = copyNimTree(n)
   for i in 0..<result.len:
     result[i] = newCall(ident"unexport", result[i])
@@ -37,3 +39,4 @@ unexportMulti:
 
 eexportMulti:
   proc rab() = discard
+  proc baz*() = discard

--- a/tests/macros/m18235.nim
+++ b/tests/macros/m18235.nim
@@ -1,0 +1,19 @@
+import macros
+
+# Necessary code to update the AST on a symbol across module boundaries when
+# processed by a type macro. Used by a test of a corresponding name of this
+# file.
+
+macro rename(n: typed): untyped =
+  result = copyNimTree(n)
+  # turn exported nnkSym -> nnkPostfix(*, nnkIdent), forcing re-sem
+  result[0] = nnkPostfix.newTree(ident"*").add:
+    n.name.strVal.ident
+
+macro unexport(n: typed): untyped =
+  result = copyNimTree(n)
+  # turn nnkSym -> nnkIdent, forcing re-sem and dropping any exported-ness
+  # that might be present
+  result[0] = n.name.strVal.ident
+
+proc foo*() {.unexport.} = discard

--- a/tests/macros/m18235.nim
+++ b/tests/macros/m18235.nim
@@ -4,7 +4,7 @@ import macros
 # processed by a type macro. Used by a test of a corresponding name of this
 # file.
 
-macro rename(n: typed): untyped =
+macro eexport(n: typed): untyped =
   result = copyNimTree(n)
   # turn exported nnkSym -> nnkPostfix(*, nnkIdent), forcing re-sem
   result[0] = nnkPostfix.newTree(ident"*").add:
@@ -17,4 +17,23 @@ macro unexport(n: typed): untyped =
   result[0] = n.name.strVal.ident
 
 proc foo*() {.unexport.} = discard
-proc bar() {.rename.} = discard
+proc bar() {.eexport.} = discard
+
+proc foooof*() {.unexport, eexport, unexport.} = discard
+proc barrab() {.eexport, unexport, eexport.} = discard
+
+macro eexportMulti(n: typed): untyped =
+  result = copyNimTree(n)
+  for i in 0..<result.len:
+    result[i] = newCall(ident"eexport", result[i])
+
+macro unexportMulti(n: typed): untyped =
+  result = copyNimTree(n)
+  for i in 0..<result.len:
+    result[i] = newCall(ident"unexport", result[i])
+
+unexportMulti:
+  proc oof*() = discard
+
+eexportMulti:
+  proc rab() = discard

--- a/tests/macros/t18235.nim
+++ b/tests/macros/t18235.nim
@@ -1,0 +1,7 @@
+discard """
+errormsg: '''
+undeclared identifier: 'foo'
+'''
+"""
+import m18235
+foo()

--- a/tests/macros/t18235.nim
+++ b/tests/macros/t18235.nim
@@ -4,4 +4,7 @@ undeclared identifier: 'foo'
 '''
 """
 import m18235
+
+# this must error out because it was never actually exported
+
 foo()

--- a/tests/macros/t18235.nim
+++ b/tests/macros/t18235.nim
@@ -7,7 +7,12 @@ doAssert not compiles(foo())
 doAssert(not declared(foooof))
 doAssert not compiles(foooof())
 
+doAssert(not declared(oof))
+doAssert not compiles(oof())
+
 # this should have been exported just fine
 
 bar()
 barrab()
+rab()
+baz()

--- a/tests/macros/t18235.nim
+++ b/tests/macros/t18235.nim
@@ -1,10 +1,13 @@
-discard """
-errormsg: '''
-undeclared identifier: 'foo'
-'''
-"""
 import m18235
 
 # this must error out because it was never actually exported
+doAssert(not declared(foo))
+doAssert not compiles(foo())
 
-foo()
+doAssert(not declared(foooof))
+doAssert not compiles(foooof())
+
+# this should have been exported just fine
+
+bar()
+barrab()

--- a/tests/macros/t18235_rename_export.nim
+++ b/tests/macros/t18235_rename_export.nim
@@ -1,5 +1,0 @@
-import m18235
-
-# this should have been exported just fine
-
-bar()

--- a/tests/macros/t18235_rename_export.nim
+++ b/tests/macros/t18235_rename_export.nim
@@ -1,0 +1,5 @@
+import m18235
+
+# this should have been exported just fine
+
+bar()


### PR DESCRIPTION
- also fixed a typo
- proc annotations guard symbol exports with shadow scopes
- symbol handling is shadow scope aware

fixes #18235