### PR TITLE
merge BuildMode into SuccessX, remove code duplication w drnim, add useful info to successx, add gc to compilesettings

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -65,7 +65,7 @@ type
     warnFileChanged = "FileChanged",
     warnUser = "User",
 
-    hintSuccess = "Success", hintSuccessX = "SuccessX", hintBuildMode = "BuildMode",
+    hintSuccess = "Success", hintSuccessX = "SuccessX",
     hintCC = "CC",
     hintLineTooLong = "LineTooLong", hintXDeclaredButNotUsed = "XDeclaredButNotUsed",
     hintXCannotRaiseY = "XCannotRaiseY", hintConvToBaseNotNeeded = "ConvToBaseNotNeeded",
@@ -145,8 +145,7 @@ const
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`
-    hintSuccessX: "$loc lines; ${sec}s; $mem; proj: $project; out: $output",
-    hintBuildMode: "$1",
+    hintSuccessX: "$build\n$loc lines; ${sec}s; $mem; proj: $project; out: $output",
     hintCC: "CC: $1",
     hintLineTooLong: "line too long",
     hintXDeclaredButNotUsed: "'$1' is declared but not used",
@@ -200,7 +199,7 @@ proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin, hintPerformance}
-  result[0] = result[1] - {hintSuccessX, hintBuildMode, hintSuccess, hintConf,
+  result[0] = result[1] - {hintSuccessX, hintSuccess, hintConf,
     hintProcessing, hintPattern, hintExecuting, hintLinking, hintCC}
 
 const

--- a/compiler/main.nim
+++ b/compiler/main.nim
@@ -388,43 +388,9 @@ proc mainCommand*(graph: ModuleGraph) =
     rawMessage(conf, errGenerated, "invalid command: " & conf.command)
 
   if conf.errorCounter == 0 and conf.cmd notin {cmdTcc, cmdDump, cmdNop}:
-    # D20210419T170230:here
-    let mem =
-      when declared(system.getMaxMem): formatSize(getMaxMem()) & " peakmem"
-      else: formatSize(getTotalMem()) & " totmem"
-    let loc = $conf.linesCompiled
-    var build = ""
-    if conf.cmd in cmdBackends:
-      build.add "gc: $#; " % $conf.selectedGC
-      if optThreads in conf.globalOptions: build.add "threads: on; "
-      build.add "opt: "
-      if optOptimizeSpeed in conf.options: build.add "speed"
-      elif optOptimizeSize in conf.options: build.add "size"
-      else: build.add "none DEBUG BUILD (`-d:release` is faster)"
-        # pending https://github.com/timotheecour/Nim/issues/752, point to optimization.html
-    let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
-    let project = if conf.filenameOption == foAbs: $conf.projectFull else: $conf.projectName
-      # xxx honor conf.filenameOption more accurately
-    var output: string
-    if optCompileOnly in conf.globalOptions and conf.cmd != cmdJsonscript:
-      output = $conf.jsonBuildFile
-    elif conf.outFile.isEmpty and conf.cmd notin {cmdJsonscript} + cmdDocLike + cmdBackends:
-      # for some cmd we expect a valid absOutFile
-      output = "unknownOutput"
-    else:
-      output = $conf.absOutFile
-    if conf.filenameOption != foAbs: output = output.AbsoluteFile.extractFilename
-      # xxx honor filenameOption more accurately
     if optProfileVM in conf.globalOptions:
       echo conf.dump(conf.vmProfileData)
-    rawMessage(conf, hintSuccessX, [
-      "build", build,
-      "loc", loc,
-      "sec", sec,
-      "mem", mem,
-      "project", project,
-      "output", output,
-      ])
+    genSuccessX(conf)
 
   when PrintRopeCacheStats:
     echo "rope cache stats: "

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -668,7 +668,7 @@ proc genSuccessX*(conf: ConfigRef) =
     build.add "opt: "
     if optOptimizeSpeed in conf.options: build.add "speed"
     elif optOptimizeSize in conf.options: build.add "size"
-    else: build.add "none DEBUG BUILD (`-d:release` is faster)"
+    else: build.add "none (DEBUG BUILD, `-d:release` generates faster code)"
       # pending https://github.com/timotheecour/Nim/issues/752, point to optimization.html
   let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
   let project = if conf.filenameOption == foAbs: $conf.projectFull else: $conf.projectName

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -167,8 +167,17 @@ const
 type
   TStringSeq* = seq[string]
   TGCMode* = enum             # the selected GC
-    gcUnselected, gcNone, gcBoehm, gcRegions, gcArc, gcOrc,
-    gcMarkAndSweep, gcHooks, gcRefc, gcV2, gcGo
+    gcUnselected = "unselected"
+    gcNone = "none"
+    gcBoehm = "boehm"
+    gcRegions = "regions"
+    gcArc = "arc"
+    gcOrc = "orc"
+    gcMarkAndSweep = "markAndSweep"
+    gcHooks = "hooks"
+    gcRefc = "refc"
+    gcV2 = "v2"
+    gcGo = "go"
     # gcRefc and the GCs that follow it use a write barrier,
     # as far as usesWriteBarrier() is concerned
 

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -136,6 +136,7 @@ when defined(nimHasInvariant):
     of ccompilerPath: result = conf.cCompilerPath
     of backend: result = $conf.backend
     of libPath: result = conf.libpath.string
+    of gc: result = $conf.selectedGC
 
   proc querySettingSeqImpl(conf: ConfigRef, switch: BiggestInt): seq[string] =
     template copySeq(field: untyped): untyped =

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -108,7 +108,6 @@ Source                           The source line that triggered a diagnostic
                                  message.
 StackTrace
 Success, SuccessX                Successful compilation of a library or a binary.
-BuildMode                        Kind of build: debug, release, danger
 User
 UserRaw
 XDeclaredButNotUsed              Unused symbols in the code.

--- a/drnim/drnim.nim
+++ b/drnim/drnim.nim
@@ -1205,24 +1205,7 @@ proc mainCommand(graph: ModuleGraph) =
   registerPass graph, semPass
   compileProject(graph)
   if conf.errorCounter == 0:
-    # xxx deduplicate with D20210419T170230
-    let mem =
-      when declared(system.getMaxMem): formatSize(getMaxMem()) & " peakmem"
-      else: formatSize(getTotalMem()) & " totmem"
-    let loc = $conf.linesCompiled
-    let build = if isDefined(conf, "danger"): "Dangerous Release build"
-                elif isDefined(conf, "release"): "Release build"
-                else: "***SLOW, DEBUG BUILD***; -d:release makes code run faster."
-    let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
-    let project = if conf.filenameOption == foAbs: $conf.projectFull else: $conf.projectName
-    rawMessage(conf, hintSuccessX, [
-      "loc", loc,
-      "sec", sec,
-      "mem", mem,
-      "project", project,
-      "output", ""
-      ])
-    rawMessage(conf, hintBuildMode, build)
+    genSuccessX(graph.config)
 
 proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
   var p = parseopt.initOptParser(cmd)

--- a/lib/std/compilesettings.nim
+++ b/lib/std/compilesettings.nim
@@ -32,6 +32,7 @@ type
     backend           ## the backend (eg: c|cpp|objc|js); both `nim doc --backend:js`
                       ## and `nim js` would imply backend=js
     libPath           ## the absolute path to the stdlib library, i.e. nim's `--lib`, since 1.5.1
+    gc                ## gc selected
 
   MultipleValueSetting* {.pure.} = enum ## \
                       ## settings resulting in a seq of string values

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -108,8 +108,7 @@ proc isSuccess(input: string): bool =
   # that may appear in user config (eg: `--filenames`).
   # Passing `XDG_CONFIG_HOME= testament args...` can be used to ignore user config
   # stored in XDG_CONFIG_HOME, refs https://wiki.archlinux.org/index.php/XDG_Base_Directory
-  input.startsWith("Hint: ") and
-    (input.endsWith("[SuccessX]") or input.endsWith("[BuildMode]"))
+  input.startsWith("Hint: ") and input.endsWith("[SuccessX]")
 
 proc getFileDir(filename: string): string =
   result = filename.splitFile().dir

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -23,7 +23,7 @@ proc isDots(a: string): bool =
   a.startsWith(".") and a.strip(chars = {'.'}) == ""
 
 const
-  defaultHintsOff = "--hint:successx:off --hint:buildmode:off --hint:exec:off --hint:link:off --hint:cc:off --hint:conf:off --hint:processing:off --hint:QuitCalled:off"
+  defaultHintsOff = "--hint:successx:off --hint:exec:off --hint:link:off --hint:cc:off --hint:conf:off --hint:processing:off --hint:QuitCalled:off"
     # useful when you want to turn only some hints on, and some common ones off.
     # pending https://github.com/timotheecour/Nim/issues/453, simplify to: `--hints:off`
   nim = getCurrentCompilerExe()


### PR DESCRIPTION
* follows #17874
* address all points in https://github.com/nim-lang/Nim/pull/17874#issuecomment-828990910:
  * remove hintBuildMode and merge into SuccessX (but using 2 lines instead of 1 to address the concern ` it's already a very long/noisy line of text` mentioned in https://github.com/nim-lang/Nim/pull/17874#issuecomment-829051773)
  * add more info, striking balance between usefulness and excess noise
  * remove duplication with drnim
  * I'm using optOptimizeSpeed, optOptimizeSize to assess whether it's a debug build or not instead of checking for -d:danger, -d:release, since absence of those flags don't imply slow debug build (because of --opt:speed for eg)

## example
```
nim r --filenames:canonical /pathto/thello.nim
compiling /pathto/thello.nim
Hint: gc: refc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
57214 lines; 0.289s; 76.637MiB peakmem; proj: thello; out: thello_BBBC1CE3E9A417D7FDE0015CEE874FF9AE128FD3 [SuccessX]
```

* also shows `threads: on` if threads are enabled

## unrelated change
* add gc to compilesettings