### PR TITLE
tables: add `getPtr` to return a value by address, refs #18250

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -332,7 +332,10 @@
 
 - Added setCurrentException for JS backend.
 
+- Added `tables.getPtr`.
+
 - Added `dom.scrollIntoView` proc with options
+
 
 ## Language changes
 

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -182,6 +182,12 @@ template getOrDefaultImpl(t, key): untyped =
   var index = rawGet(t, key, hc)
   if index >= 0: result = t.data[index].val
 
+template getPtrImpl(t, key): untyped =
+  mixin rawGet
+  var hc: Hash
+  var index = rawGet(t, key, hc)
+  if index >= 0: result = t.data[index].val.unsafeAddr
+
 template getOrDefaultImpl(t, key, default: untyped): untyped =
   mixin rawGet
   var hc: Hash

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2878,3 +2878,23 @@ iterator mvalues*[A](t: CountTableRef[A]): var int =
     if t.data[h].val != 0:
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
+
+type SomeTable[A, B] = Table[A, B] | TableRef[A, B] | OrderedTable[A, B] | OrderedTableRef[A, B]
+  # in future work, refactor so that more procs can reuse this, and
+  # consider exporting `SomeTable`.
+
+proc getPtr*[A, B](t: SomeTable[A, B], key: A): ptr B =
+  ## Returns the address of the value stored at `key` if
+  ## it exists, or `nil`.
+  ##
+  ## This can be useful for performance reasons, but is unsafe to use
+  ## if table mutations occur before you use the address,
+  ## as with table iterators.
+  runnableExamples:
+    let t = {1: "foo", 2: "bar"}.toTable
+    assert t.getPtr(3) == nil
+    let a = t.getPtr(2)
+    assert a[] == "bar"
+    assert t.getPtr(2) == a
+      # same because we return by address, unlike `[]`
+  getPtrImpl(t, key)

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -11,7 +11,7 @@ targets: "c cpp js"
 matrix: "-d:nimEnableHashRef"
 """
 
-# xxx wrap in a template to test in VM, see https://github.com/timotheecour/Nim/issues/534#issuecomment-769565033
+# xxx move all blocks inside `main` to test in VM, see https://github.com/timotheecour/Nim/issues/534#issuecomment-769565033
 
 import hashes, sequtils, tables, algorithm
 
@@ -434,7 +434,6 @@ block: # https://github.com/nim-lang/Nim/issues/13496
   testDel(): (var t: CountTable[int])
   testDel(): (let t = newCountTable[int]())
 
-
 block testNonPowerOf2:
   var a = initTable[int, int](7)
   a[1] = 10
@@ -459,3 +458,19 @@ block: # Table[ref, int]
   t[a2] = 11
   doAssert t[a1] == 10
   doAssert t[a2] == 11
+
+proc main =
+  # xxx all blocks here
+  block: # getPtr
+    let t = {1: "foo", 2: "bar"}.toTable
+    doAssert t.getPtr(3) == nil
+    let a = t.getPtr(2)
+    doAssert a[] == "bar"
+    doAssert t.getPtr(2) == a
+    # with `[]`, you get a copy instead:
+    let a2 = t[2]
+    let a3 = t[2]
+    doAssert a2[0].unsafeAddr != a3[0].unsafeAddr
+
+static: main()
+main()


### PR DESCRIPTION
* refs #18250
* this is useful for performance reasons (eg, avoiding double lookups and avoiding copies)
* `mgetOrPut`, `getOrDefault`, `hasKeyOrPut`, `[]` are not a replacement for this (different semantics and performance)

## why not `get` returning `Option`?
(refs: https://github.com/timotheecour/Nim/issues/758)
I'm not sure we actually need `proc get[A, B](t: Table[A, B]; key: A): Option[B]` because `getPtr` subsumes this; we could add a `proc toOption[T](a: ptr T): Options[T]` to std/options instead.

Even if we end up adding `proc get[A, B](t: Table[A, B]; key: A): Option[B]` (refs #18250), it would not be a replacement for this feature as this would involve a copy

note that a hypothetical `Option[lent B]` would not be any safer than `getPtr` as the same caveats would apply in case the table is mutated before disposing of the value

it wouldn't be able to distinguish between a nil value for an existing key and a nil value for a non-existing key, for values of type ref|ptr|pointer (this is IMO a design flaw of `Option` which makes it ambiguous when dealing with pointer-like types).
Instead we should remove this "optimization" and introduce  `maybeOption`:
```nim
# in std/options:
template MaybeOption*(T): untyped =
  when T is ptr|pointer|ref: T
  else: Option[T]
```
and then APIs can decide whether to use `MaybeOption[T]` or `Option[T]` depending on whether they want poiinter-like types collapsed or not