### PR TITLE
fix #18250; tables: make getOrDefault a template

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -332,7 +332,10 @@
 
 - Added setCurrentException for JS backend.
 
+- Added `tables.getPtr`.
+
 - Added `dom.scrollIntoView` proc with options
+
 
 ## Language changes
 

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -176,12 +176,6 @@ template insertImpl() = # for CountTable
   ctRawInsert(t, t.data, key, val)
   inc(t.counter)
 
-template getOrDefaultImpl(t, key): untyped =
-  mixin rawGet
-  var hc: Hash
-  var index = rawGet(t, key, hc)
-  if index >= 0: result = t.data[index].val
-
 template getPtrImpl(t, key): untyped =
   mixin rawGet
   var hc: Hash
@@ -191,8 +185,9 @@ template getPtrImpl(t, key): untyped =
 template getOrDefaultImpl(t, key, default: untyped): untyped =
   mixin rawGet
   var hc: Hash
-  var index = rawGet(t, key, hc)
-  result = if index >= 0: t.data[index].val else: default
+  let t2 = t.unsafeAddr # prevent double evaluation
+  var index = rawGet(t2[], key, hc)
+  if index >= 0: t2[].data[index].val else: default
 
 template dollarImpl(): untyped {.dirty.} =
   if t.len == 0:
@@ -213,4 +208,5 @@ template equalsImpl(s, t: typed) =
     for key, val in s:
       if not t.hasKey(key): return false
       if t.getOrDefault(key) != val: return false
+        # xxx why not t[key] since we already checked hasKey ?
     return true

--- a/lib/pure/collections/tableimpl.nim
+++ b/lib/pure/collections/tableimpl.nim
@@ -182,6 +182,12 @@ template getOrDefaultImpl(t, key): untyped =
   var index = rawGet(t, key, hc)
   if index >= 0: result = t.data[index].val
 
+template getPtrImpl(t, key): untyped =
+  mixin rawGet
+  var hc: Hash
+  var index = rawGet(t, key, hc)
+  if index >= 0: result = t.data[index].val.unsafeAddr
+
 template getOrDefaultImpl(t, key, default: untyped): untyped =
   mixin rawGet
   var hc: Hash

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2250,8 +2250,9 @@ proc rawGet[A](t: CountTable[A], key: A): int =
   result = -1 - h # < 0 => MISSING; insert idx = -1 - result
 
 template ctget(t, key, default: untyped): untyped =
-  var index = rawGet(t, key)
-  result = if index >= 0: t.data[index].val else: default
+  let t2 = t.unsafeAddr
+  var index = rawGet(t2[], key)
+  if index >= 0: t2[].data[index].val else: default
 
 proc inc*[A](t: var CountTable[A], key: A, val = 1)
 

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -396,7 +396,7 @@ proc hasKeyOrPut*[A, B](t: var Table[A, B], key: A, val: B): bool =
 
   hasKeyOrPutImpl(enlarge)
 
-proc getOrDefault*[A, B](t: Table[A, B], key: A): B =
+template getOrDefault*[A, B](t: Table[A, B], key: A): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`. Otherwise, the
   ## default initialization value for type `B` is returned (e.g. 0 for any
   ## integer type).
@@ -412,10 +412,9 @@ proc getOrDefault*[A, B](t: Table[A, B], key: A): B =
     let a = {'a': 5, 'b': 9}.toTable
     doAssert a.getOrDefault('a') == 5
     doAssert a.getOrDefault('z') == 0
+  getOrDefaultImpl(t, key, default(t.B))
 
-  getOrDefaultImpl(t, key)
-
-proc getOrDefault*[A, B](t: Table[A, B], key: A, default: B): B =
+template getOrDefault*[A, B](t: Table[A, B], key: A, default: B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -927,7 +926,7 @@ proc hasKeyOrPut*[A, B](t: var TableRef[A, B], key: A, val: B): bool =
 
   t[].hasKeyOrPut(key, val)
 
-proc getOrDefault*[A, B](t: TableRef[A, B], key: A): B =
+template getOrDefault*[A, B](t: TableRef[A, B], key: A): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`. Otherwise, the
   ## default initialization value for type `B` is returned (e.g. 0 for any
   ## integer type).
@@ -944,9 +943,9 @@ proc getOrDefault*[A, B](t: TableRef[A, B], key: A): B =
     doAssert a.getOrDefault('a') == 5
     doAssert a.getOrDefault('z') == 0
 
-  getOrDefault(t[], key)
+  getOrDefault(t[], key, default(t.B))
 
-proc getOrDefault*[A, B](t: TableRef[A, B], key: A, default: B): B =
+template getOrDefault*[A, B](t: TableRef[A, B], key: A, default: B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -1430,7 +1429,7 @@ proc hasKeyOrPut*[A, B](t: var OrderedTable[A, B], key: A, val: B): bool =
 
   hasKeyOrPutImpl(enlarge)
 
-proc getOrDefault*[A, B](t: OrderedTable[A, B], key: A): B =
+template getOrDefault*[A, B](t: OrderedTable[A, B], key: A): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`. Otherwise, the
   ## default initialization value for type `B` is returned (e.g. 0 for any
   ## integer type).
@@ -1447,9 +1446,9 @@ proc getOrDefault*[A, B](t: OrderedTable[A, B], key: A): B =
     doAssert a.getOrDefault('a') == 5
     doAssert a.getOrDefault('z') == 0
 
-  getOrDefaultImpl(t, key)
+  getOrDefaultImpl(t, key, default(t.B))
 
-proc getOrDefault*[A, B](t: OrderedTable[A, B], key: A, default: B): B =
+template getOrDefault*[A, B](t: OrderedTable[A, B], key: A, default: B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -1916,7 +1915,7 @@ proc hasKeyOrPut*[A, B](t: var OrderedTableRef[A, B], key: A, val: B): bool =
 
   result = t[].hasKeyOrPut(key, val)
 
-proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A): B =
+template getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`. Otherwise, the
   ## default initialization value for type `B` is returned (e.g. 0 for any
   ## integer type).
@@ -1933,9 +1932,9 @@ proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A): B =
     doAssert a.getOrDefault('a') == 5
     doAssert a.getOrDefault('z') == 0
 
-  getOrDefault(t[], key)
+  getOrDefaultImpl(t[], key, default(t.B))
 
-proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A, default: B): B =
+template getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A, default: B): B =
   ## Retrieves the value at `t[key]` if `key` is in `t`.
   ## Otherwise, `default` is returned.
   ##
@@ -1951,7 +1950,7 @@ proc getOrDefault*[A, B](t: OrderedTableRef[A, B], key: A, default: B): B =
     doAssert a.getOrDefault('a', 99) == 5
     doAssert a.getOrDefault('z', 99) == 99
 
-  getOrDefault(t[], key, default)
+  getOrDefaultImpl(t[], key, default)
 
 proc mgetOrPut*[A, B](t: OrderedTableRef[A, B], key: A, val: B): var B =
   ## Retrieves value at `t[key]` or puts `val` if not present, either way
@@ -2376,7 +2375,7 @@ proc contains*[A](t: CountTable[A], key: A): bool =
   ## the `in` operator.
   return hasKey[A](t, key)
 
-proc getOrDefault*[A](t: CountTable[A], key: A; default: int = 0): int =
+template getOrDefault*[A](t: CountTable[A], key: A; default: int = 0): int =
   ## Retrieves the value at `t[key]` if`key` is in `t`. Otherwise, the
   ## integer value of `default` is returned.
   ##
@@ -2696,7 +2695,7 @@ proc contains*[A](t: CountTableRef[A], key: A): bool =
   ## the `in` operator.
   return hasKey[A](t, key)
 
-proc getOrDefault*[A](t: CountTableRef[A], key: A, default: int): int =
+template getOrDefault*[A](t: CountTableRef[A], key: A, default: int): int =
   ## Retrieves the value at `t[key]` if`key` is in `t`. Otherwise, the
   ## integer value of `default` is returned.
   ##
@@ -2704,7 +2703,7 @@ proc getOrDefault*[A](t: CountTableRef[A], key: A, default: int): int =
   ## * `[] proc<#[],CountTableRef[A],A>`_ for retrieving a value of a key
   ## * `hasKey proc<#hasKey,CountTableRef[A],A>`_ for checking if a key
   ##   is in the table
-  result = t[].getOrDefault(key, default)
+  getOrDefault(t[], key, default)
 
 proc len*[A](t: CountTableRef[A]): int =
   ## Returns the number of keys in `t`.

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2878,3 +2878,23 @@ iterator mvalues*[A](t: CountTableRef[A]): var int =
     if t.data[h].val != 0:
       yield t.data[h].val
       assert(len(t) == L, "the length of the table changed while iterating over it")
+
+type SomeTable[A, B] = Table[A, B] | TableRef[A, B] | OrderedTable[A, B] | OrderedTableRef[A, B]
+  # in future work, refactor so that more procs can reuse this, and
+  # consider exporting `SomeTable`.
+
+proc getPtr*[A, B](t: SomeTable[A, B], key: A): ptr B =
+  ## Returns the address of the value stored at `key` if
+  ## it exists, or `nil`.
+  ##
+  ## This can be useful for performance reasons, but is unsafe to use
+  ## if table mutations occur before you use the address,
+  ## as with table iterators.
+  runnableExamples:
+    let t = {1: "foo", 2: "bar"}.toTable
+    assert t.getPtr(3) == nil
+    let a = t.getPtr(2)
+    assert a[] == "bar"
+    assert t.getPtr(2) == a
+      # same because we return by address, unlike `[]`
+  getPtrImpl(t, key)

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -472,5 +472,24 @@ proc main =
     let a3 = t[2]
     doAssert a2[0].unsafeAddr != a3[0].unsafeAddr
 
+  block: # getOrDefault
+    template test(toTableFn) =
+      block:
+        var witness = 0
+        proc getVal(): string =
+          witness.inc
+          "baz"
+        let t = toTableFn({1: "foo", 2: "bar"})
+        doAssert t.getOrDefault(1) == "foo"
+        doAssert t.getOrDefault(1, getVal()) == "foo"
+        doAssert witness == 0
+        doAssert t.getOrDefault(3) == ""
+        doAssert t.getOrDefault(3, getVal()) == "baz"
+        doAssert witness == 1
+    test(toTable)
+    test(toOrderedTable)
+    test(newTable)
+    test(newOrderedTable)
+
 static: main()
 main()

--- a/tests/collections/ttables.nim
+++ b/tests/collections/ttables.nim
@@ -11,7 +11,7 @@ targets: "c cpp js"
 matrix: "-d:nimEnableHashRef"
 """
 
-# xxx wrap in a template to test in VM, see https://github.com/timotheecour/Nim/issues/534#issuecomment-769565033
+# xxx move all blocks inside `main` to test in VM, see https://github.com/timotheecour/Nim/issues/534#issuecomment-769565033
 
 import hashes, sequtils, tables, algorithm
 
@@ -434,7 +434,6 @@ block: # https://github.com/nim-lang/Nim/issues/13496
   testDel(): (var t: CountTable[int])
   testDel(): (let t = newCountTable[int]())
 
-
 block testNonPowerOf2:
   var a = initTable[int, int](7)
   a[1] = 10
@@ -459,3 +458,19 @@ block: # Table[ref, int]
   t[a2] = 11
   doAssert t[a1] == 10
   doAssert t[a2] == 11
+
+proc main =
+  # xxx all blocks here
+  block: # getPtr
+    let t = {1: "foo", 2: "bar"}.toTable
+    doAssert t.getPtr(3) == nil
+    let a = t.getPtr(2)
+    doAssert a[] == "bar"
+    doAssert t.getPtr(2) == a
+    # with `[]`, you get a copy instead:
+    let a2 = t[2]
+    let a3 = t[2]
+    doAssert a2[0].unsafeAddr != a3[0].unsafeAddr
+
+static: main()
+main()


### PR DESCRIPTION
follows #18253 (depends on it; to be reviewed after it is merged)

fix #18250; tables: make getOrDefault a template

## future work
use `SomeTable` to remove code duplication in tables APIs