### PR TITLE
followup #17777: declaredloc field error msgs now work with generics

### DIFF
--- a/compiler/astmsgs.nim
+++ b/compiler/astmsgs.nim
@@ -2,6 +2,11 @@
 import std/strutils
 import options, ast, msgs
 
+proc typSym*(t: PType): PSym =
+  result = t.sym
+  if result == nil and t.kind == tyGenericInst: # this might need to be refined
+    result = t[0].sym
+
 proc addDeclaredLoc*(result: var string, conf: ConfigRef; sym: PSym) =
   result.add " [$1 declared in $2]" % [sym.kind.toHumanStr, toFileLineCol(conf, sym.info)]
 

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -326,7 +326,6 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
 
   let ident = considerQuotedIdent(c, f, n).s
   if {nfDotField, nfExplicitCall} * n.flags == {nfDotField}:
-    # let sym = n[1].typ.sym
     let sym = n[1].typ.typSym
     var typeHint = ""
     if sym == nil:
@@ -338,8 +337,8 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
       discard
     else:
       typeHint = " for type " & getProcHeader(c.config, sym)
-    var old = if result.len > 0: " " & result else: ""
-    result = errUndeclaredField % ident & typeHint & old
+    let suffix = if result.len > 0: " " & result else: ""
+    result = errUndeclaredField % ident & typeHint & suffix
   else:
     if result.len == 0: result = errUndeclaredRoutine % ident
     else: result = errBadRoutine % [ident, result]
@@ -417,8 +416,6 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
           # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
           localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
         if n[0].kind == nkIdent and n[0].ident.s == ".=" and n[2].kind == nkIdent:
-        # if n[0].kind == nkIdent and (n[0].ident.s == ".=" or n[0].ident.s == ".") and n[2].kind == nkIdent:
-          # let sym = n[1].typ.typSym
           let sym = n[1].typ.sym
           if sym == nil:
             impl()
@@ -426,7 +423,6 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
             let field = n[2].ident.s
             let msg = errUndeclaredField % field & " for type " & getProcHeader(c.config, sym)
             localError(c.config, orig[2].info, msg)
-            # impl()
         else:
           impl()
       return

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -326,7 +326,8 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
 
   let ident = considerQuotedIdent(c, f, n).s
   if {nfDotField, nfExplicitCall} * n.flags == {nfDotField}:
-    let sym = n[1].typ.sym
+    # let sym = n[1].typ.sym
+    let sym = n[1].typ.typSym
     var typeHint = ""
     if sym == nil:
       # Perhaps we're in a `compiles(foo.bar)` expression, or
@@ -337,7 +338,8 @@ proc getMsgDiagnostic(c: PContext, flags: TExprFlags, n, f: PNode): string =
       discard
     else:
       typeHint = " for type " & getProcHeader(c.config, sym)
-    result = errUndeclaredField % ident & typeHint & " " & result
+    var old = if result.len > 0: " " & result else: ""
+    result = errUndeclaredField % ident & typeHint & old
   else:
     if result.len == 0: result = errUndeclaredRoutine % ident
     else: result = errBadRoutine % [ident, result]
@@ -414,14 +416,17 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
         template impl() =
           # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
           localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
-        if n[0].kind == nkIdent and (n[0].ident.s == ".=" or n[0].ident.s == ".") and n[2].kind == nkIdent:
-          let sym = n[1].typ.typSym
+        if n[0].kind == nkIdent and n[0].ident.s == ".=" and n[2].kind == nkIdent:
+        # if n[0].kind == nkIdent and (n[0].ident.s == ".=" or n[0].ident.s == ".") and n[2].kind == nkIdent:
+          # let sym = n[1].typ.typSym
+          let sym = n[1].typ.sym
           if sym == nil:
             impl()
           else:
             let field = n[2].ident.s
             let msg = errUndeclaredField % field & " for type " & getProcHeader(c.config, sym)
             localError(c.config, orig[2].info, msg)
+            # impl()
         else:
           impl()
       return

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -414,8 +414,8 @@ proc resolveOverloads(c: PContext, n, orig: PNode,
         template impl() =
           # xxx adapt/use errorUndeclaredIdentifierHint(c, n, f.ident)
           localError(c.config, n.info, getMsgDiagnostic(c, flags, n, f))
-        if n[0].kind == nkIdent and n[0].ident.s == ".=" and n[2].kind == nkIdent:
-          let sym = n[1].typ.sym
+        if n[0].kind == nkIdent and (n[0].ident.s == ".=" or n[0].ident.s == ".") and n[2].kind == nkIdent:
+          let sym = n[1].typ.typSym
           if sym == nil:
             impl()
           else:

--- a/tests/errmsgs/tundeclared_field.nim
+++ b/tests/errmsgs/tundeclared_field.nim
@@ -2,38 +2,48 @@ discard """
 cmd: '''nim check --hints:off $file'''
 action: reject
 nimout: '''
-tundeclared_field.nim(25, 12) Error: undeclared field: 'bad' for type tundeclared_field.A [type declared in tundeclared_field.nim(22, 8)]
-tundeclared_field.nim(30, 16) Error: undeclared field: 'bad' for type tundeclared_field.A [type declared in tundeclared_field.nim(28, 8)]
-tundeclared_field.nim(36, 4) Error: undeclared field: 'bad' for type tundeclared_field.A [type declared in tundeclared_field.nim(33, 8)]
-tundeclared_field.nim(40, 13) Error: cannot instantiate Foo [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(25, 13) Error: undeclared field: 'bad1' for type tundeclared_field.A [type declared in tundeclared_field.nim(22, 8)]
+tundeclared_field.nim(30, 17) Error: undeclared field: 'bad2' for type tundeclared_field.A [type declared in tundeclared_field.nim(28, 8)]
+tundeclared_field.nim(36, 5) Error: undeclared field: 'bad3' for type tundeclared_field.A [type declared in tundeclared_field.nim(33, 8)]
+tundeclared_field.nim(42, 13) Error: undeclared field: 'bad4' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(43, 10) Error: undeclared field: 'bad5' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(44, 23) Error: undeclared field: 'bad6' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(46, 19) Error: undeclared field: 'bad7' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(50, 13) Error: cannot instantiate Foo [type declared in tundeclared_field.nim(49, 8)]
 '''
 """
 
-
-
-
-
-
-
-
-
+#[
+xxx in future work, generic instantiations (e.g. `B[int]`) should be shown with their instantiation instead of `tundeclared_field.B`,
+maybe using TPreferedDesc.preferResolved or preferMixed
+]#
 # line 20
 block:
   type A = object
     a0: int
   var a: A
-  discard a.bad
+  discard a.bad1
 
 block:
   type A = object
     a0: int
-  var a = A(bad: 0)
+  var a = A(bad2: 0)
 
 block:
   type A = object
     a0: int
   var a: A
-  a.bad = 0
+  a.bad3 = 0
+
+block:
+  type B[T] = object
+    b0: int
+  var b: B[int]
+  discard b.bad4
+  b.bad5 = 0
+  var b2 = B[int](bad6: 0)
+  type Bi = B[int]
+  var b3 = Bi(bad7: 0)
 
 block:
   type Foo[T: SomeInteger] = object

--- a/tests/errmsgs/tundeclared_field.nim
+++ b/tests/errmsgs/tundeclared_field.nim
@@ -2,11 +2,11 @@ discard """
 cmd: '''nim check --hints:off $file'''
 action: reject
 nimout: '''
-tundeclared_field.nim(25, 13) Error: undeclared field: 'bad1' for type tundeclared_field.A [type declared in tundeclared_field.nim(22, 8)]
+tundeclared_field.nim(25, 12) Error: undeclared field: 'bad1' for type tundeclared_field.A [type declared in tundeclared_field.nim(22, 8)]
 tundeclared_field.nim(30, 17) Error: undeclared field: 'bad2' for type tundeclared_field.A [type declared in tundeclared_field.nim(28, 8)]
-tundeclared_field.nim(36, 5) Error: undeclared field: 'bad3' for type tundeclared_field.A [type declared in tundeclared_field.nim(33, 8)]
-tundeclared_field.nim(42, 13) Error: undeclared field: 'bad4' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
-tundeclared_field.nim(43, 10) Error: undeclared field: 'bad5' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(36, 4) Error: undeclared field: 'bad3' for type tundeclared_field.A [type declared in tundeclared_field.nim(33, 8)]
+tundeclared_field.nim(42, 12) Error: undeclared field: 'bad4' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
+tundeclared_field.nim(43, 4) Error: undeclared field: 'bad5' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
 tundeclared_field.nim(44, 23) Error: undeclared field: 'bad6' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
 tundeclared_field.nim(46, 19) Error: undeclared field: 'bad7' for type tundeclared_field.B [type declared in tundeclared_field.nim(39, 8)]
 tundeclared_field.nim(50, 13) Error: cannot instantiate Foo [type declared in tundeclared_field.nim(49, 8)]


### PR DESCRIPTION
followup #17777: declaredloc field error msgs now work with generics

addresses all the points mentioned in future work of https://github.com/nim-lang/Nim/pull/17777#issue-617715895

someVar.badField now gives errors like this:
```
main.nim(46, 19) Error: undeclared field: 'badField' for type foo.Bar [type declared in tundeclared_field.nim(39, 8)]
```
instead of:
```
main.nim(46, 19) Error: undeclared field: 'badField'
```
when typeof(someVar) is generic
ditto with other cases (see tests)