### PR TITLE
make tests/exception/tsetexceptions.nim not joinable (because of `setCurrentException(nil)`)

### DIFF
--- a/tests/exception/tsetexceptions.nim
+++ b/tests/exception/tsetexceptions.nim
@@ -1,6 +1,9 @@
 discard """
   targets: "c cpp js"
+  joinable: false
 """
+
+# refs https://github.com/nim-lang/Nim/pull/18247#issuecomment-860877161
 
 let ex = newException(CatchableError, "test")
 setCurrentException(ex)


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/18247#issuecomment-860877161; `setCurrentException(nil)` doesn't seem sound and should at least be isolated from other tests

EDIT: even with the revert https://github.com/nim-lang/Nim/pull/18265, this PR still makes sense because `setCurrentException` would still be called (and can affect other code)