### PR TITLE
Revert "system/excpt: check if the exception is not nil before pop"

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -135,9 +135,8 @@ proc pushCurrentException(e: sink(ref Exception)) {.compilerRtl, inl.} =
   #showErrorMessage2 "A"
 
 proc popCurrentException {.compilerRtl, inl.} =
-  if currException != nil:
-    currException = currException.up
-    #showErrorMessage2 "B"
+  currException = currException.up
+  #showErrorMessage2 "B"
 
 proc popCurrentExceptionEx(id: uint) {.compilerRtl.} =
   discard "only for bootstrapping compatbility"

--- a/tests/exception/tsetexceptions.nim
+++ b/tests/exception/tsetexceptions.nim
@@ -6,10 +6,3 @@ let ex = newException(CatchableError, "test")
 setCurrentException(ex)
 doAssert getCurrentException().msg == ex.msg
 doAssert getCurrentExceptionMsg() == ex.msg
-setCurrentException(nil)
-
-try:
-  raise newException(CatchableError, "test2")
-except:
-  setCurrentException(nil)
-doAssert getCurrentException() == nil


### PR DESCRIPTION
Reverts nim-lang/Nim#18247

We need to find a better solution. How about a dummy exception as @timotheecour suggested?