### PR TITLE
Fix #18215

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1092,6 +1092,8 @@ proc genProcAux(m: BModule, prc: PSym) =
     generatedProc.add(p.s(cpsInit))
     generatedProc.add(p.s(cpsStmts))
     if beforeRetNeeded in p.flags: generatedProc.add(~"\t}BeforeRet_: ;$n")
+    if {sfExportc, sfCompilerProc} * prc.flags == {sfExportc} and m.config.exc == excGoto:
+      p.module.appcg(generatedProc, "\t#nimTestErrorFlag();$n", [])
     if optStackTrace in prc.options: generatedProc.add(deinitFrame(p))
     generatedProc.add(returnStmt)
     generatedProc.add(~"}$N")


### PR DESCRIPTION
Add nimTestErrorFlag on exportc procs, in order to catch unhandled exceptions
I have omitted the check:

```nim
if getCompilerProc(m.g.graph, "nimTestErrorFlag") != nil:
```
Is it important :P But it seems to work