### PR TITLE
[backport] link stable and devel docs in nim docs

### DIFF
--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -127,21 +127,12 @@ doc.body_toc_group = """
   </div>
   <div id="global-links">
     <ul class="simple-boot">
-      <li>
-        <a href="manual.html">Manual</a>
-      </li>
-      <li>
-        <a href="lib.html">Standard library</a>
-      </li>
-      <li>
-        <a href="$theindexhref">Index</a>
-      </li>
-      <li>
-        <a href="compiler/$theindexhref">Compiler docs</a>
-      </li>
-      <li>
-        <a href="https://nim-lang.github.io/fusion/theindex.html">Fusion docs</a>
-      </li>
+      <li><a href="manual.html">Manual</a></li>
+      <li><a href="lib.html">Standard library</a></li>
+      <li> <a href="$theindexhref">Index</a></li>
+      <li><a href="compiler/$theindexhref">Compiler docs</a></li>
+      <li><a href="https://nim-lang.github.io/fusion/theindex.html">Fusion docs</a></li>
+      <li><a href="https://nim-lang.github.io/Nim/">devel</a>, <a href="https://nim-lang.org/documentation.html">stable</a></li>
     </ul>
   </div>
   <div id="searchInputDiv">


### PR DESCRIPTION
this should be backported so that you can easily switch between devel and stable docs and makes this more discoverable

refs https://github.com/nim-lang/Nim/pull/18267#discussion_r651670652 + other similar cases

EDIT: fixes https://github.com/nim-lang/Nim/issues/10744