### PR TITLE
strformat.fmt now supports non-literal const strings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -103,9 +103,7 @@
 
 - Added `sections` iterator in `parsecfg`.
 
-- `macros`:
-  Make custom op in `quote` work for all statements.
-  Undeprecate `callsite`.
+- Make custom op in macros.quote work for all statements.
 
 - On Windows the SSL library now checks for valid certificates.
   It uses the `cacert.pem` file for this purpose which was extracted

--- a/changelog.md
+++ b/changelog.md
@@ -93,7 +93,9 @@
 
 ## Standard library additions and changes
 
-- Added support for parenthesized expressions in `strformat`
+- `strformat`:
+  added support for parenthesized expressions.
+  added support for const string's instead of just string literals
 
 - Fixed buffer overflow bugs in `net`
 
@@ -101,7 +103,9 @@
 
 - Added `sections` iterator in `parsecfg`.
 
-- Make custom op in macros.quote work for all statements.
+- `macros`:
+  Make custom op in `quote` work for all statements.
+  Undeprecate `callsite`.
 
 - On Windows the SSL library now checks for valid certificates.
   It uses the `cacert.pem` file for this purpose which was extracted

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -475,9 +475,9 @@ proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   ## Generates a fresh symbol that is guaranteed to be unique. The symbol
   ## needs to occur in a declaration context.
 
-proc callsite*(): NimNode {.magic: "NCallSite", benign, deprecated:
-  "Deprecated since v0.18.1; use varargs[untyped] in the macro prototype instead".}
+proc callsite*(): NimNode {.magic: "NCallSite", benign.}
   ## Returns the AST of the invocation expression that invoked this macro.
+  ## This can often be avoided by using alternatives, e.g. a `varargs[untyped]`.
 
 proc toStrLit*(n: NimNode): NimNode =
   ## Converts the AST `n` to the concrete Nim code and wraps that

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -475,9 +475,10 @@ proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   ## Generates a fresh symbol that is guaranteed to be unique. The symbol
   ## needs to occur in a declaration context.
 
-proc callsite*(): NimNode {.magic: "NCallSite", benign.}
+proc callsite*(): NimNode {.magic: "NCallSite", benign, deprecated:
+  "Deprecated since v0.18.1; use `varargs[untyped]` in the macro prototype instead".}
   ## Returns the AST of the invocation expression that invoked this macro.
-  ## This can often be avoided by using alternatives, e.g. a `varargs[untyped]`.
+  # see https://github.com/nim-lang/RFCs/issues/387 as candidate replacement.
 
 proc toStrLit*(n: NimNode): NimNode =
   ## Converts the AST `n` to the concrete Nim code and wraps that

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -684,8 +684,8 @@ template fmt*(pattern: static string): untyped =
   fmt(pattern, '{', '}')
 
 macro `&`*(pattern: string{lit}): string =
-  ## `&pattern` is the same as `pattern.fmt`; prefer `fmt` since it's more
-  ## flexible and readable (`&` can be confused with binary append operator).
+  ## `&pattern` is the same as `pattern.fmt`.
+  ## For a specification of the `&` macro, see the module level documentation.
   # pending bug #18275, bug #18278, use `pattern: static string`
   # consider deprecating this, it's redundant with `fmt` and `fmt` is strictly
   # more flexible, readable (no confusion with the binary `&`), self-documenting,

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -661,8 +661,13 @@ proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
   when defined(debugFmtDsl):
     echo repr result
 
-macro `&`*(pattern: static string): untyped = strformatImpl(pattern, '{', '}')
-  ## For a specification of the `&` macro, see the module level documentation.
+when defined(nimscript):
+  # pending bug #18275
+  macro `&`*(pattern: string): untyped = strformatImpl(pattern.strVal, '{', '}')
+    ## For a specification of the `&` macro, see the module level documentation.
+else:
+  macro `&`*(pattern: static string): untyped = strformatImpl(pattern, '{', '}')
+    ## For a specification of the `&` macro, see the module level documentation.
 
 macro fmt*(pattern: static string): untyped = strformatImpl(pattern, '{', '}')
   ## An alias for `& <#&.m,string>`_.

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -575,6 +575,7 @@ template formatValue(result: var string; value: cstring; specifier: string) =
 
 proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
   let info = callsite()
+  # pending https://github.com/nim-lang/RFCs/issues/387, use `callTree`
   if openChar == ':' or closeChar == ':':
     error "openChar and closeChar must not be ':'"
   var i = 0
@@ -661,26 +662,34 @@ proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
   when defined(debugFmtDsl):
     echo repr result
 
-when defined(nimscript):
-  # pending bug #18275
-  macro `&`*(pattern: string): untyped = strformatImpl(pattern.strVal, '{', '}')
-    ## For a specification of the `&` macro, see the module level documentation.
-else:
-  macro `&`*(pattern: static string): untyped = strformatImpl(pattern, '{', '}')
-    ## For a specification of the `&` macro, see the module level documentation.
-
-macro fmt*(pattern: static string): untyped = strformatImpl(pattern, '{', '}')
-  ## An alias for `& <#&.m,string>`_.
-
-macro fmt*(pattern: static string; openChar, closeChar: char): untyped =
-  ## The same as `fmt <#fmt.m,string>`_, but uses `openChar` instead of `'{'`
-  ## and `closeChar` instead of `'}'`.
+macro fmt*(pattern: static string; openChar: static char = '{', closeChar: static char = '}'): string =
+  ## Interpolates `pattern` using symbols in scope.
   runnableExamples:
-    let testInt = 123
-    assert "<testInt>".fmt('<', '>') == "123"
-    assert """(()"foo" & "bar"())""".fmt(')', '(') == "(foobar)"
-    assert """ ""{"123+123"}"" """.fmt('"', '"') == " \"{246}\" "
-    const s = "foo: {testInt}"
-    assert s.fmt == "foo: 123" # also works with const strings
+    let x = 7
+    assert "var is {x * 2}".fmt == "var is 14"
+    assert "var is {{x}}".fmt == "var is {x}" # escape via doubling
+    const s = "foo: {x}"
+    assert s.fmt == "foo: 7" # also works with const strings
 
-  strformatImpl(pattern, openChar.intVal.char, closeChar.intVal.char)
+    assert fmt"\n" == r"\n" # raw string literal
+    assert "\n".fmt == "\n" # regular literal
+  runnableExamples:
+    # custom `openChar`, `closeChar`
+    let x = 7
+    assert "<x>".fmt('<', '>') == "7"
+    assert "<<<x>>>".fmt('<', '>') == "<7>"
+  strformatImpl(pattern, openChar, closeChar)
+
+macro `&`*(pattern: string{lit}): string =
+  ## `&pattern` is the same as `pattern.fmt`; prefer `fmt` since it's more
+  ## flexible and readable (`&` can be confused with binary append operator).
+  # pending bug #18275, bug #18278, use `pattern: static string`
+  # consider deprecating this, it's redundant with `fmt` and `fmt` is strictly
+  # more flexible, readable (no confusion with the binary `&`), self-documenting,
+  # not to mention #18275, bug #18278.
+  runnableExamples:
+    let x = 7
+    assert &"{x}\n" == "7\n" # regular string literal
+    assert &"{x}\n" == "7\n".fmt # `fmt` can be used instead
+    assert &"{x}\n" != fmt"7\n" # see `fmt` docs, this would use a raw string literal
+  strformatImpl(pattern.strVal, '{', '}')

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -631,12 +631,8 @@ proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
         var x: NimNode
         try:
           x = parseExpr(subexpr)
-        except ValueError:
-          when declared(getCurrentExceptionMsg):
-            let msg = getCurrentExceptionMsg()
-            error("could not parse `" & subexpr & "`.\n" & msg, info)
-          else:
-            error("could not parse `" & subexpr & "`.\n", info)
+        except ValueError as e:
+          error("could not parse `" & subexpr & "`.\n" & e.msg, info)
         let formatSym = bindSym("formatValue", brOpen)
         var options = ""
         if f[i] == ':':

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -662,7 +662,7 @@ proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
   when defined(debugFmtDsl):
     echo repr result
 
-macro fmt*(pattern: static string; openChar: static char = '{', closeChar: static char = '}'): string =
+macro fmt*(pattern: static string; openChar: static char, closeChar: static char): string =
   ## Interpolates `pattern` using symbols in scope.
   runnableExamples:
     let x = 7
@@ -672,13 +672,18 @@ macro fmt*(pattern: static string; openChar: static char = '{', closeChar: stati
     assert s.fmt == "foo: 7" # also works with const strings
 
     assert fmt"\n" == r"\n" # raw string literal
-    assert "\n".fmt == "\n" # regular literal
+    assert "\n".fmt == "\n" # regular literal (likewise with `fmt("\n")` or `fmt "\n"`)
   runnableExamples:
     # custom `openChar`, `closeChar`
     let x = 7
     assert "<x>".fmt('<', '>') == "7"
     assert "<<<x>>>".fmt('<', '>') == "<7>"
+    assert "`x`".fmt('`', '`') == "7"
   strformatImpl(pattern, openChar, closeChar)
+
+template fmt*(pattern: static string): untyped =
+  ## Alias for `fmt(pattern, '{', '}')`.
+  fmt(pattern, '{', '}')
 
 macro `&`*(pattern: string{lit}): string =
   ## `&pattern` is the same as `pattern.fmt`; prefer `fmt` since it's more

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -574,13 +574,11 @@ template formatValue(result: var string; value: cstring; specifier: string) =
   result.add value
 
 proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
-  let info = callsite()
-  # pending https://github.com/nim-lang/RFCs/issues/387, use `callTree`
   if openChar == ':' or closeChar == ':':
     error "openChar and closeChar must not be ':'"
   var i = 0
   let res = genSym(nskVar, "fmtRes")
-  result = newNimNode(nnkStmtListExpr, lineInfoFrom = info)
+  result = newNimNode(nnkStmtListExpr)
   # XXX: https://github.com/nim-lang/Nim/issues/8405
   # When compiling with -d:useNimRtl, certain procs such as `count` from the strutils
   # module are not accessible at compile-time:
@@ -633,7 +631,7 @@ proc strformatImpl(f: string; openChar, closeChar: char): NimNode =
         try:
           x = parseExpr(subexpr)
         except ValueError as e:
-          error("could not parse `" & subexpr & "`.\n" & e.msg, info)
+          error("could not parse `$#` in `$#`.\n$#" % [subexpr, f, e.msg])
         let formatSym = bindSym("formatValue", brOpen)
         var options = ""
         if f[i] == ':':


### PR DESCRIPTION
* strformat.fmt now supports non-literal const strings
* undeprecate callsite:
  * it's useful in this PR
  * see also rationale i gave in https://github.com/nim-lang/Nim/pull/11864#issuecomment-517392813

## note 1
I'm not supporting `&` with non-constant string literals in this PR because it's hitting https://github.com/nim-lang/Nim/issues/18278 and https://github.com/nim-lang/Nim/issues/18275, and because fmt can aways be used instead of & (see details in PR)

## note 2
after this PR, we get clean sigmatch errors (or allow overload resolution to favor other overloads) rather than error inside the instantiation eg in cases like this:

```nim
when defined case11:
  import std/strformat
  proc main =
    let c1 = '{'
    let c2 = '}'
    let b = "abc".fmt(c1, c2)
    echo b
  main()
```

this also improves the siganture for & to use the `string{lit}` instead of a hiddent assumption