### PR TITLE
Patch niminst (de)install to be usable for distros

### DIFF
--- a/compiler/modulepaths.nim
+++ b/compiler/modulepaths.nim
@@ -87,6 +87,10 @@ when false:
           result = findInNimbleDir(pkg, subdir, nimbleDir / "pkgs")
           if result.len > 0: return result
           when not defined(windows):
+            result = findInNimbleDir(pkg, subdir, "/usr/share/nimble/pkgs")
+            if result.len > 0: return result
+            result = findInNimbleDir(pkg, subdir, "/usr/local/share/nimble/pkgs")
+            if result.len > 0: return result
             result = findInNimbleDir(pkg, subdir, "/opt/nimble/pkgs")
             if result.len > 0: return result
 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -44,7 +44,7 @@ path="$lib/core"
 path="$lib/pure"
 
 @if not windows:
-  nimblepath="/opt/nimble/pkgs/"
+  nimblepath="/usr/share/nimble/pkgs/"
 @else:
   # TODO:
 @end

--- a/tools/niminst/deinstall.nimf
+++ b/tools/niminst/deinstall.nimf
@@ -19,17 +19,17 @@ if [ $# -eq 1 ] ; then
       bindir=/usr/bin
       configdir=/etc/?proj
       libdir=/usr/lib/?proj
-      docdir=/usr/share/?proj/doc
+      docdir=/usr/share/doc/?proj
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/usr/share/nimble/pkgs/?c.nimblePkgName-?c.version"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
       configdir=/etc/?proj
       libdir=/usr/local/lib/?proj
-      docdir=/usr/local/share/?proj/doc
+      docdir=/usr/local/share/doc/?proj
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/usr/share/nimble/pkgs/?c.nimblePkgName-?c.version"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -96,28 +96,35 @@ if [ $# -eq 1 ] ; then
 #end for
 
 #for f in items(c.cat[fcUnixBin]):
-  install -D -m 755 ?f.toUnix $bindir/?f.skipRoot.toUnix
+  cp ?f.toUnix $bindir/?f.skipRoot.toUnix
+  chmod 755 $bindir/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcConfig]):
-  install -D -m 755 ?f.toUnix $configdir/?f.skipRoot.toUnix
+  cp ?f.toUnix $configdir/?f.skipRoot.toUnix
+  chmod 644 $configdir/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcData]):
   if [ -f ?f.toUnix ]; then
-    install -D -m 644 ?f.toUnix $datadir/?f.skipRoot.toUnix
+    cp ?f.toUnix $datadir/?f.skipRoot.toUnix
+    chmod 644 $datadir/?f.skipRoot.toUnix
   fi
 #end for
 #for f in items(c.cat[fcDoc]):
   if [ -f ?f.toUnix ]; then
-    install -D -m 644 ?f.toUnix $docdir/?f.skipRoot.toUnix
+    cp ?f.toUnix $docdir/?f.skipRoot.toUnix
+    chmod 644 $docdir/?f.skipRoot.toUnix
   fi
 #end for
 #for f in items(c.cat[fcLib]):
-  install -D -m 644 ?f.toUnix $libdir/?f.skipRoot.toUnix
+  cp ?f.toUnix $libdir/?f.skipRoot.toUnix
+  chmod 644 $libdir/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcNimble]):
-  install -D -m 644 ?f.toUnix $nimbleDir/?f.toUnix
+  cp ?f.toUnix $nimbleDir/?f.toUnix
+  chmod 644 $nimbleDir/?f.toUnix
 #end for
-install -D -m 644 ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
+cp ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
+chmod 644 $nimbleDir/?{c.nimblePkgName}.nimble
 
   echo "installation successful"
 else

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -5,6 +5,8 @@
 
 set -e
 
+: ${DESTDIR:=}
+
 if [ $# -eq 1 ] ; then
 # if c.cat[fcUnixBin].len > 0:
   if test -f ?{c.cat[fcUnixBin][0].toUnix}
@@ -26,43 +28,47 @@ if [ $# -eq 1 ] ; then
       echo "  <some other dir> (treated similar to '/opt')"
       echo "To deinstall, use the command:"
       echo "sh deinstall.sh DIR"
+      echo ""
+      echo "You may also use environment variable DESTDIR for staged installs"
+      echo "(DESTDIR is prepended to each install target file). Note that this"
+      echo "is added by Alpine Linux, it's not supported by standard niminst."
       exit 1
       ;;
     "/usr/bin")
-      bindir=/usr/bin
-      configdir=/etc/?proj
-      libdir=/usr/lib/?proj
-      docdir=/usr/share/?proj/doc
-      datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      bindir="$DESTDIR/usr/bin"
+      configdir="$DESTDIR/etc/?proj"
+      libdir="$DESTDIR/usr/lib/?proj"
+      docdir="$DESTDIR/usr/share/doc/?proj"
+      datadir="$DESTDIR/usr/share/?proj/data"
+      nimbleDir="$DESTDIR/usr/share/nimble/pkgs/?c.nimblePkgName-?c.version"
       ;;
     "/usr/local/bin")
-      bindir=/usr/local/bin
-      configdir=/etc/?proj
-      libdir=/usr/local/lib/?proj
-      docdir=/usr/local/share/?proj/doc
-      datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      bindir="$DESTDIR/usr/local/bin"
+      configdir="$DESTDIR/etc/?proj"
+      libdir="$DESTDIR/usr/local/lib/?proj"
+      docdir="$DESTDIR/usr/local/share/doc/?proj"
+      datadir="$DESTDIR/usr/local/share/?proj/data"
+      nimbleDir="$DESTDIR/usr/local/share/nimble/pkgs/?c.nimblePkgName-?c.version"
       ;;
     "/opt")
-      bindir="/opt/?proj/bin"
-      configdir="/opt/?proj/config"
-      libdir="/opt/?proj/lib"
-      docdir="/opt/?proj/doc"
-      datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
-      mkdir -p /opt/?proj
+      bindir="$DESTDIR/opt/?proj/bin"
+      configdir="$DESTDIR/opt/?proj/config"
+      libdir="$DESTDIR/opt/?proj/lib"
+      docdir="$DESTDIR/opt/?proj/doc"
+      datadir="$DESTDIR/opt/?proj/data"
+      nimbleDir="$DESTDIR/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      mkdir -p $DESTDIR/opt/?proj
       mkdir -p $bindir
       mkdir -p $configdir
       ;;
     *)
-      bindir="$1/?proj/bin"
-      configdir="$1/?proj/config"
-      libdir="$1/?proj/lib"
-      docdir="$1/?proj/doc"
-      datadir="$1/?proj/data"
-      nimbleDir="$1/?proj"
-      mkdir -p $1/?proj
+      bindir="$DESTDIR$1/?proj/bin"
+      configdir="$DESTDIR$1/?proj/config"
+      libdir="$DESTDIR$1/?proj/lib"
+      docdir="$DESTDIR$1/?proj/doc"
+      datadir="$DESTDIR$1/?proj/data"
+      nimbleDir="$DESTDIR$1/?proj"
+      mkdir -p $DESTDIR$1/?proj
       mkdir -p $bindir
       mkdir -p $configdir
       ;;
@@ -90,35 +96,28 @@ if [ $# -eq 1 ] ; then
 #end for
 
 #for f in items(c.cat[fcUnixBin]):
-  cp ?f.toUnix $bindir/?f.skipRoot.toUnix
-  chmod 755 $bindir/?f.skipRoot.toUnix
+  install -D -m 755 ?f.toUnix $bindir/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcConfig]):
-  cp ?f.toUnix $configdir/?f.skipRoot.toUnix
-  chmod 644 $configdir/?f.skipRoot.toUnix
+  install -D -m 755 ?f.toUnix $configdir/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcData]):
   if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $datadir/?f.skipRoot.toUnix
-    chmod 644 $datadir/?f.skipRoot.toUnix
+    install -D -m 644 ?f.toUnix $datadir/?f.skipRoot.toUnix
   fi
 #end for
 #for f in items(c.cat[fcDoc]):
   if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $docdir/?f.skipRoot.toUnix
-    chmod 644 $docdir/?f.skipRoot.toUnix
+    install -D -m 644 ?f.toUnix $docdir/?f.skipRoot.toUnix
   fi
 #end for
 #for f in items(c.cat[fcLib]):
-  cp ?f.toUnix $libdir/?f.skipRoot.toUnix
-  chmod 644 $libdir/?f.skipRoot.toUnix
+  install -D -m 644 ?f.toUnix $libdir/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcNimble]):
-  cp ?f.toUnix $nimbleDir/?f.toUnix
-  chmod 644 $nimbleDir/?f.toUnix
+  install -D -m 644 ?f.toUnix $nimbleDir/?f.toUnix
 #end for
-cp ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
-chmod 644 $nimbleDir/?{c.nimblePkgName}.nimble
+install -D -m 644 ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
 
   echo "installation successful"
 else
@@ -131,5 +130,9 @@ else
   echo "  <some other dir> (treated similar to '/opt')"
   echo "To deinstall, use the command:"
   echo "sh deinstall.sh DIR"
+  echo ""
+  echo "You may also use environment variable DESTDIR for staged installs"
+  echo "(DESTDIR is prepended to each install target file). Note that this"
+  echo "is added by Alpine Linux, it's not supported by standard niminst."
   exit 1
 fi


### PR DESCRIPTION
* Add support for DESTDIR variable (staged installs).
* Change paths to be FHS/Alpine compliant.
<del>* Use "install" command instead of mkdir/cp/chmod.</del>

cc @jirutka