### PR TITLE
Fix doubly typed forward declarations

### DIFF
--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1890,14 +1890,16 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   var (proto, comesFromShadowScope) =
       if isAnon: (nil, false)
       else: searchForProc(c, declarationScope, s)
-  if proto == nil and {sfForward, sfGenSym} <= s.flags:
+  if proto == nil and sfForward in s.flags and n[bodyPos].kind != nkEmpty:
     ## In cases such as a macro generating a proc with a gensymmed name we
     ## know `searchForProc` will not find it and sfForward will be set. In
     ## such scenarios the sym is shared between forward declaration and we
     ## can treat the `s` as the proto.
     ## To differentiate between that happening and a macro just returning a
-    ## forward declaration that has been typed before we check for sfGenSym
-    ## too. See tmacros_issues:"doubly-typed" forward decls
+    ## forward declaration that has been typed before we check if the body
+    ## is not empty. This has the sideeffect of allowing multiple forward
+    ## declarations if they share the same sym.
+    ## See the "doubly-typed forward decls" case in tmacros_issues.nim
     proto = s
   let hasProto = proto != nil
 

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -1890,11 +1890,14 @@ proc semProcAux(c: PContext, n: PNode, kind: TSymKind,
   var (proto, comesFromShadowScope) =
       if isAnon: (nil, false)
       else: searchForProc(c, declarationScope, s)
-  if proto == nil and sfForward in s.flags:
+  if proto == nil and {sfForward, sfGenSym} <= s.flags:
     ## In cases such as a macro generating a proc with a gensymmed name we
     ## know `searchForProc` will not find it and sfForward will be set. In
     ## such scenarios the sym is shared between forward declaration and we
     ## can treat the `s` as the proto.
+    ## To differentiate between that happening and a macro just returning a
+    ## forward declaration that has been typed before we check for sfGenSym
+    ## too. See tmacros_issues:"doubly-typed" forward decls
     proto = s
   let hasProto = proto != nil
 

--- a/tests/errmsgs/treportunused.nim
+++ b/tests/errmsgs/treportunused.nim
@@ -27,3 +27,11 @@ let s8 = 0
 var s9: int
 type s10 = object
 type s11 = type(1.2)
+
+# bug #18203
+import std/macros
+
+macro foo(x: typed) = newProc ident"bar"
+proc bar() {.foo.} = raise
+bar()
+

--- a/tests/errmsgs/treportunused.nim
+++ b/tests/errmsgs/treportunused.nim
@@ -27,11 +27,3 @@ let s8 = 0
 var s9: int
 type s10 = object
 type s11 = type(1.2)
-
-# bug #18203
-import std/macros
-
-macro foo(x: typed) = newProc ident"bar"
-proc bar() {.foo.} = raise
-bar()
-

--- a/tests/macros/tmacros_issues.nim
+++ b/tests/macros/tmacros_issues.nim
@@ -484,6 +484,26 @@ func expMin: float {.aadMin.} = 1
 echo expMin()
 
 
+# doubly-typed forward decls
+macro noop(x: typed) = x
+noop:
+  proc cally() = discard
+
+cally()
+
+noop:
+  proc barry()
+
+proc barry() = discard
+
+# some more:
+proc barry2() {.noop.}
+proc barry2() = discard
+
+proc barry3() {.noop.}
+proc barry3() {.noop.} = discard
+
+
 # issue #15389
 block double_sem_for_procs:
 
@@ -499,16 +519,3 @@ block double_sem_for_procs:
     result = 10.0
 
   discard exp(5.0)
-
-
-# "doubly-typed" forward decls
-macro noop(x: typed) = x
-noop:
-  proc cally() = discard
-
-cally()
-
-noop:
-  proc barry()
-
-proc barry() = discard

--- a/tests/macros/tmacros_issues.nim
+++ b/tests/macros/tmacros_issues.nim
@@ -499,3 +499,16 @@ block double_sem_for_procs:
     result = 10.0
 
   discard exp(5.0)
+
+
+# "doubly-typed" forward decls
+macro noop(x: typed) = x
+noop:
+  proc cally() = discard
+
+cally()
+
+noop:
+  proc barry()
+
+proc barry() = discard


### PR DESCRIPTION
"doubly typed" here means: semmed once because it was for example passed to a macros typed param and twice because it was then returned and semmed again.