### PR TITLE
PCRE, nimgrep: add limit for buffer size

### DIFF
--- a/tools/nimgrep.nim
+++ b/tools/nimgrep.nim
@@ -649,7 +649,7 @@ template updateCounters(output: Output) =
 proc printInfo(filename:string, output: Output) =
   case output.kind
   of openError:
-    printError("can not open path " & filename & " " & output.msg)
+    printError("cannot open path '" & filename & "': " & output.msg)
   of rejected:
     if optVerbose in options:
       echo "(rejected: ", output.reason, ")"
@@ -719,6 +719,9 @@ iterator searchFile(pattern: Pattern; buffer: string): Output =
                      pre: pre,
                      match: move(curMi))
     i = t.last+1
+  when typeof(pattern) is Regex:
+    if buffer.len > MaxReBufSize:
+      yield Output(kind: openError, msg: "PCRE size limit is " & $MaxReBufSize)
 
 func detectBin(buffer: string): bool =
   for i in 0 ..< min(1024, buffer.len):


### PR DESCRIPTION
When `nimgrep` is attempted to be used on Linux 64-bit system for file size > 2GB, it crashes on attempt to convert `int` -> `cint` in `findBounds`, because `cint` is 32-bit!

```
fatal.nim(49)            sysFatal
Error: unhandled exception: value out of range: 9017231451 notin -2147483648 .. 2147483647 [RangeDefect]
```

Usage of C int is a limitation of PCRE1 API. (Ideally it would be better to switch to PCRE2 API.)