### PR TITLE
increase backoffDuration to avoid timeouts

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -429,7 +429,7 @@ proc testNimblePackages(r: var TResults; cat: Category; packageFilter: string) =
       let buildPath = packagesDir / pkg.name
       template tryCommand(cmd: string, workingDir2 = buildPath, reFailed = reInstallFailed, maxRetries = 1): string =
         var outp: string
-        let ok = retryCall(maxRetry = maxRetries, backoffDuration = 1.0):
+        let ok = retryCall(maxRetry = maxRetries, backoffDuration = 10.0):
           var status: int
           (outp, status) = execCmdEx(cmd, workingDir = workingDir2)
           status == QuitSuccess


### PR DESCRIPTION
refs CI failures in https://github.com/nim-lang/Nim/pull/18265

```
PASS: [11/35] karax c                                                      (31.18 sec)
  FAIL: [12/35] macroutils c                                                 (26.93 sec)
  Test "macroutils" in category "nimble-packages"
  Failure: reInstallFailed
  git clone PMunch/macroutils pkgstemp/macroutils
  Cloning into 'pkgstemp/macroutils'...
  fatal: unable to access 'PMunch/macroutils': Failed to connect to github.com port 443: Operation timed out
  
  FAIL: [13/35] memo c                                                       (49.66 sec)
  Test "memo" in category "nimble-packages"
  Failure: reInstallFailed
  git clone andreaferretti/memo pkgstemp/memo
  Cloning into 'pkgstemp/memo'...
  fatal: unable to access 'andreaferretti/memo': Could not resolve host: github.com
```

retrying after 1 second probably didn't give enough time for underlying issue to be fixed; this should be a bit more robust
