### PR TITLE
followup #16400; use use -d:nimCompilerStackraceHints in more places

### DIFF
--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -35,6 +35,9 @@ import
 
 from modulegraphs import getBody
 
+when defined(nimCompilerStackraceHints):
+  import std/stackframes
+
 const
   debugEchoCode* = defined(nimVMDebug)
 
@@ -2000,6 +2003,8 @@ proc procIsCallback(c: PCtx; s: PSym): bool =
     dec i
 
 proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
+  when defined(nimCompilerStackraceHints):
+    setFrameMsg c.config$n.info & " " & $n.kind & " " & $flags
   case n.kind
   of nkSym:
     let s = n.sym


### PR DESCRIPTION
followup #16400

this helped me a lot to reduce the bug in https://github.com/nim-lang/Nim/issues/18278 (original failure was from complicated code in nimterop in which stacktrace contained no useful hint as to where it originated from in user code).

The design I'm following is to add `setFrameMsg` in key places in the compiler that are often visited, which increases chances we find the relevant location in user code. 

with `--stacktrace:on --stacktracemsgs -d:nimCompilerStackraceHints`:

## before PR
```
...
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(1039) semDirectOp
/Users/timothee/git_clone/nim/Nim_devel/compiler/semexprs.nim(870) semOverloadedCallAnalyseEffects
/Users/timothee/git_clone/nim/Nim_devel/compiler/semcall.nim(582) semOverloadedCall
/Users/timothee/git_clone/nim/Nim_devel/compiler/semcall.nim(365) resolveOverloads
/Users/timothee/git_clone/nim/Nim_devel/compiler/semcall.nim(95) pickBestCandidate
/Users/timothee/git_clone/nim/Nim_devel/compiler/sigmatch.nim(2551) matches
/Users/timothee/git_clone/nim/Nim_devel/compiler/sigmatch.nim(2485) matchesAux
/Users/timothee/git_clone/nim/Nim_devel/compiler/sigmatch.nim(2207) paramTypesMatch
/Users/timothee/git_clone/nim/Nim_devel/compiler/sigmatch.nim(2032) paramTypesMatchAux
/Users/timothee/git_clone/nim/Nim_devel/compiler/sem.nim(338) tryConstExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/vm.nim(2213) evalConstExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/vm.nim(2201) evalConstExprAux
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(2179) genExpr
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(2043) gen
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(1139) genMagic
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(815) genVarargsABC
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(293) gen
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(2099) gen
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(2009) gen
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(1670) genRdVar
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(1460) genAsgn
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(305) genx
/Users/timothee/git_clone/nim/Nim_devel/compiler/vmgen.nim(2009) gen
/Users/timothee/git_clone/nim/Nim_devel/compiler/msgs.nim(612) genRdVar
/Users/timothee/git_clone/nim/Nim_devel/compiler/msgs.nim(599) internalErrorImpl
/Users/timothee/git_clone/nim/Nim_devel/compiler/msgs.nim(555) liMessage
/Users/timothee/git_clone/nim/Nim_devel/compiler/msgs.nim(413) handleError
/Users/timothee/git_clone/nim/Nim_devel/compiler/msgs.nim(402) quit

```


## after PR
```
...
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(1039) semDirectOp
/Users/timothee/git_clone/nim/Nim_prs/compiler/semexprs.nim(870) semOverloadedCallAnalyseEffects
/Users/timothee/git_clone/nim/Nim_prs/compiler/semcall.nim(582) semOverloadedCall
/Users/timothee/git_clone/nim/Nim_prs/compiler/semcall.nim(365) resolveOverloads
/Users/timothee/git_clone/nim/Nim_prs/compiler/semcall.nim(95) pickBestCandidate
/Users/timothee/git_clone/nim/Nim_prs/compiler/sigmatch.nim(2551) matches
/Users/timothee/git_clone/nim/Nim_prs/compiler/sigmatch.nim(2485) matchesAux
/Users/timothee/git_clone/nim/Nim_prs/compiler/sigmatch.nim(2207) paramTypesMatch
/Users/timothee/git_clone/nim/Nim_prs/compiler/sigmatch.nim(2032) paramTypesMatchAux
/Users/timothee/git_clone/nim/Nim_prs/compiler/sem.nim(338) tryConstExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/vm.nim(2213) evalConstExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/vm.nim(2201) evalConstExprAux
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(2184) genExpr
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(2048) gen /Users/timothee/git_clone/nim/timn/tests/nim/all/t12412.nim(33, 23) nkCall {}
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(1142) genMagic
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(818) genVarargsABC
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(296) gen
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(2104) gen /Users/timothee/git_clone/nim/timn/tests/nim/all/t12412.nim(33, 20) nkStmtListExpr {}
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(2014) gen /Users/timothee/git_clone/nim/timn/tests/nim/all/t12412.nim(33, 20) nkSym {}
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(1673) genRdVar
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(1463) genAsgn
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(308) genx
/Users/timothee/git_clone/nim/Nim_prs/compiler/vmgen.nim(2014) gen /Users/timothee/git_clone/nim/timn/tests/nim/all/t12412.nim(33, 20) nkSym {}
/Users/timothee/git_clone/nim/Nim_prs/compiler/msgs.nim(612) genRdVar
/Users/timothee/git_clone/nim/Nim_prs/compiler/msgs.nim(599) internalErrorImpl
/Users/timothee/git_clone/nim/Nim_prs/compiler/msgs.nim(555) liMessage
/Users/timothee/git_clone/nim/Nim_prs/compiler/msgs.nim(413) handleError
/Users/timothee/git_clone/nim/Nim_prs/compiler/msgs.nim(402) quit
```

