### PR TITLE
Renamed `-d:nimCompilerStackraceHints` to `-d:nimCompilerStacktraceHints`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -88,6 +88,7 @@
   The downside is that these defines now have custom logic that doesn't apply for
   other defines.
 
+- Renamed `-d:nimCompilerStackraceHints` to `-d:nimCompilerStacktraceHints`.
 
 
 ## Standard library additions and changes

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -9,7 +9,7 @@
 
 # included from cgen.nim
 
-when defined(nimCompilerStackraceHints):
+when defined(nimCompilerStacktraceHints):
   import std/stackframes
 
 proc getNullValueAuxT(p: BProc; orig, t: PType; obj, constOrNil: PNode,
@@ -2694,7 +2694,7 @@ proc genConstStmt(p: BProc, n: PNode) =
         genConstDefinition(m, p, sym)
 
 proc expr(p: BProc, n: PNode, d: var TLoc) =
-  when defined(nimCompilerStackraceHints):
+  when defined(nimCompilerStacktraceHints):
     setFrameMsg p.config$n.info & " " & $n.kind
   p.currLineInfo = n.info
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -10,7 +10,7 @@
 # this module does the semantic checking for expressions
 # included from sem.nim
 
-when defined(nimCompilerStackraceHints):
+when defined(nimCompilerStacktraceHints):
   import std/stackframes
 
 const
@@ -2714,7 +2714,7 @@ proc getNilType(c: PContext): PType =
     c.nilTypeCache = result
 
 proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
-  when defined(nimCompilerStackraceHints):
+  when defined(nimCompilerStacktraceHints):
     setFrameMsg c.config$n.info & " " & $n.kind
   result = n
   if c.config.cmd == cmdIdeTools: suggestExpr(c, n)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -35,7 +35,7 @@ import
 
 from modulegraphs import getBody
 
-when defined(nimCompilerStackraceHints):
+when defined(nimCompilerStacktraceHints):
   import std/stackframes
 
 const
@@ -2003,7 +2003,7 @@ proc procIsCallback(c: PCtx; s: PSym): bool =
     dec i
 
 proc gen(c: PCtx; n: PNode; dest: var TDest; flags: TGenFlags = {}) =
-  when defined(nimCompilerStackraceHints):
+  when defined(nimCompilerStacktraceHints):
     setFrameMsg c.config$n.info & " " & $n.kind & " " & $flags
   case n.kind
   of nkSym:


### PR DESCRIPTION
thanks to @Clyybber for noticing the typo; the switch is undocumented, renaming it and mentioning it in changelog should be enough