### PR TITLE
fix for #18284 int32 should be int

### DIFF
--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -997,7 +997,7 @@ when not defined(js):
     # taken from Go-lang Math.Log2
     const ln2 = 0.693147180559945309417232121458176568075500134360255254120680009
     template log2Impl[T](x: T): T =
-      var exp: int32
+      var exp: int
       var frac = frexp(x, exp)
       # Make sure exact powers of two give an exact answer.
       # Don't depend on Log(0.5)*(1/Ln2)+exp being exactly exp-1.


### PR DESCRIPTION
the var exp was typed as int32 - it should be int since frep expects an int