### PR TITLE
Make the existence of high(type) clearer, especially near subranges

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -989,10 +989,12 @@ Ordinal types have the following characteristics:
 - Ordinal types are countable and ordered. This property allows the operation
   of functions such as `inc`, `ord`, and `dec` on ordinal types to
   be defined.
-- Ordinal values have the smallest possible value. Trying to count further
-  down than the smallest value produces a panic or a static error.
-- Ordinal values have the largest possible value. Trying to count further
-  than the largest value produces a panic or a static error.
+- Ordinal values have the smallest possible value, accessible with `low(type)`.
+  Trying to count further down than the smallest value produces a panic or
+  a static error.
+- Ordinal values have the largest possible value, accessible with `high(type)`.
+  Trying to count further than the largest value produces a panic or
+  a static error.
 
 Integers, bool, characters, and enumeration types (and subranges of these
 types) belong to ordinal types.
@@ -1095,6 +1097,7 @@ lowest and highest value of the type. For example:
   type
     Subrange = range[0..5]
     PositiveFloat = range[0.0..Inf]
+    PositiveInt = range[0..high(int)]
 
 
 `Subrange` is a subrange of an integer which can only hold the values 0

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -989,11 +989,11 @@ Ordinal types have the following characteristics:
 - Ordinal types are countable and ordered. This property allows the operation
   of functions such as `inc`, `ord`, and `dec` on ordinal types to
   be defined.
-- Ordinal values have the smallest possible value, accessible with `low(type)`.
+- Ordinal types have a smallest possible value, accessible with `low(type)`.
   Trying to count further down than the smallest value produces a panic or
   a static error.
-- Ordinal values have the largest possible value, accessible with `high(type)`.
-  Trying to count further than the largest value produces a panic or
+- Ordinal types have a largest possible value, accessible with `high(type)`.
+  Trying to count further up than the largest value produces a panic or
   a static error.
 
 Integers, bool, characters, and enumeration types (and subranges of these
@@ -1097,7 +1097,7 @@ lowest and highest value of the type. For example:
   type
     Subrange = range[0..5]
     PositiveFloat = range[0.0..Inf]
-    PositiveInt = range[0..high(int)]
+    Positive* = range[1..high(int)] # as defined in `system`
 
 
 `Subrange` is a subrange of an integer which can only hold the values 0


### PR DESCRIPTION
This PR just mentions `high(type)` and `low(type)` in a couple of key places: the definition of ordinal types and the section on subranges.

Since these sections (especially subranges!) are very dependent on `high(type)` and `low(type)` and since the manual is used primarily as a reference, I thought it would be valuable to mention and have an example of those functions nearby.