### PR TITLE
`./koch tools` now builds `bin/nim_dbg`, a debug version of nim

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -215,8 +215,14 @@ proc buildTools(args: string = "") =
                  options = "-d:release " & args)
   when defined(windows): buildVccTool(args)
   bundleNimpretty(args)
-  nimCompileFold("Compile testament", "testament/testament.nim",
-                 options = "-d:release " & args)
+  nimCompileFold("Compile testament", "testament/testament.nim", options = "-d:release" & args)
+
+  # pre-packages a debug version of nim which can help in many cases investigate issuses
+  # withouth having to rebuild compiler.
+  # `-d:nimDebugUtils` only makes sense when temporarily editing/debugging compiler
+  # `-d:debug` should be changed to a flag that doesn't require re-compiling nim
+  # `--opt:speed` is a sensible default even for a debug build, it doesn't affect nim stacktraces
+  nimCompileFold("Compile nim_dbg", "compiler/nim.nim", options = "--opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints" & args, outputName = "nim_dbg")
 
 proc nsis(latest: bool; args: string) =
   bundleNimbleExe(latest, args)

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -97,8 +97,9 @@ proc nimCompile*(input: string, outputDir = "bin", mode = "c", options = "") =
   let cmd = findNim().quoteShell() & " " & mode & " -o:" & output & " " & options & " " & input
   exec cmd
 
-proc nimCompileFold*(desc, input: string, outputDir = "bin", mode = "c", options = "") =
-  let output = outputDir / input.splitFile.name.exe
+proc nimCompileFold*(desc, input: string, outputDir = "bin", mode = "c", options = "", outputName = "") =
+  let outputName2 = if outputName.len == 0: input.splitFile.name.exe else: outputName.exe
+  let output = outputDir / outputName2
   let cmd = findNim().quoteShell() & " " & mode & " -o:" & output & " " & options & " " & input
   execFold(desc, cmd)
 


### PR DESCRIPTION
often times, simples issues can be investigated with a debug build of nim, it makes sense to bundle it along with the other tools (nimgrep, nimpretty, testament etc shipped with nim releases) and simplify workflows for user. Pretending compiler bugs don't exist or get in the way of regular users doesn't help.

This adds about 10 seconds (and a 8MB binary vs 5MB for bin/nim) to `./koch tools`, a very acceptable tradeoff since that command is typically run only once per release.

In more complex cases, building it by hand is needed (eg with custom options), in those cases `./koch temp` or calling `bin/nim c -o:bin/nim_dbg2 <extra debug options> compiler/nim.nim` (possibly with modifications) will still nbe needed, but at least this makes a common case easier.

## future work
- [ ] consider mentioning `bin/nim_dbg` in this error msg:
```
        styledMsgWriteln(fgRed, """
No stack traceback available
To create a stacktrace, rerun compilation with './koch temp $1 <file>', see $2 for details""" %
          [conf.command, "intern.html#debugging-the-compiler".createDocLink], conf.unitSep)
```