### PR TITLE
add `typetraits.pointerBase` to return `T` in `ref T|ptr T`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -118,7 +118,7 @@
   Added `enumLen` to return the number of elements in an enum
   Added `HoleyEnum` for enums with holes, `OrdinalEnum` for enums without holes.
   Added `hasClosure`.
-  Added `refBase` to return `T` for `ref T | ptr T`.
+  Added `pointerBase` to return `T` for `ref T | ptr T`.
 
 - `prelude` now works with the JavaScript target.
   Added `sequtils` import to `prelude`.

--- a/changelog.md
+++ b/changelog.md
@@ -118,7 +118,7 @@
   Added `enumLen` to return the number of elements in an enum
   Added `HoleyEnum` for enums with holes, `OrdinalEnum` for enums without holes.
   Added `hasClosure`.
-  Added `deref` to return `T` for `ref T | ptr T`.
+  Added `refBase` to return `T` for `ref T | ptr T`.
 
 - `prelude` now works with the JavaScript target.
   Added `sequtils` import to `prelude`.

--- a/changelog.md
+++ b/changelog.md
@@ -113,8 +113,12 @@
 
 - Make `{.requiresInit.}` pragma to work for `distinct` types.
 
-- Added a macros `enumLen` for returning the number of items in an enum to the
-  `typetraits.nim` module.
+- `typetraits`:
+  `distinctBase` now is identity instead of error for non distinct types.
+  Added `enumLen` to return the number of elements in an enum
+  Added `HoleyEnum` for enums with holes, `OrdinalEnum` for enums without holes.
+  Added `hasClosure`.
+  Added `deref` to return `T` for `ref T | ptr T`.
 
 - `prelude` now works with the JavaScript target.
   Added `sequtils` import to `prelude`.
@@ -161,8 +165,6 @@
   Added `items` for enums with holes.
   Added `symbolName` to return the enum symbol name ignoring the human readable name.
   Added `symbolRank` to return the index in which an enum member is listed in an enum.
-
-- Added `typetraits.HoleyEnum` for enums with holes, `OrdinalEnum` for enums without holes.
 
 - Removed deprecated `iup` module from stdlib, it has already moved to
   [nimble](https://github.com/nim-lang/iup).
@@ -293,7 +295,6 @@
 
 - Added `algorithm.merge`.
 
-
 - Added `std/jsfetch` module [Fetch](https://developer.mozilla.org/docs/Web/API/Fetch_API) wrapper for JavaScript target.
 
 - Added `std/jsheaders` module [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) wrapper for JavaScript target.
@@ -322,8 +323,6 @@
 
 - Added `hasDataBuffered` to `asyncnet`.
 
-- Added `hasClosure` to `std/typetraits`.
-
 - Added `std/tempfiles`.
 
 - Added `genasts.genAst` that avoids the problems inherent with `quote do` and can
@@ -344,8 +343,6 @@
 - The `cstring` doesn't support `[]=` operator in JS backend.
 
 - nil dereference is not allowed at compile time. `cast[ptr int](nil)[]` is rejected at compile time.
-
-- `typetraits.distinctBase` now is identity instead of error for non distinct types.
 
 - `os.copyFile` is now 2.5x faster on OSX, by using `copyfile` from `copyfile.h`;
   use `-d:nimLegacyCopyFile` for OSX < 10.5.

--- a/changelog.md
+++ b/changelog.md
@@ -115,7 +115,7 @@
 
 - `typetraits`:
   `distinctBase` now is identity instead of error for non distinct types.
-  Added `enumLen` to return the number of elements in an enum
+  Added `enumLen` to return the number of elements in an enum.
   Added `HoleyEnum` for enums with holes, `OrdinalEnum` for enums without holes.
   Added `hasClosure`.
   Added `pointerBase` to return `T` for `ref T | ptr T`.

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -100,6 +100,16 @@ proc isNamedTuple*(T: typedesc): bool {.magic: "TypeTrait".} =
     doAssert not isNamedTuple((string, int))
     doAssert isNamedTuple(tuple[name: string, age: int])
 
+template refBase*[T](_: typedesc[ptr T | ref T]): typedesc =
+  ## Returns `T` for `ref T | ptr T`
+  runnableExamples:
+    assert (ref int).refBase is int
+    type A = ptr seq[float]
+    assert A.refBase is seq[float]
+    assert (ref A).refBase is A # not seq[float]
+    assert (var s = "abc"; s[0].addr).typeof.refBase is char
+  T
+
 proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".} =
   ## Returns the base type for distinct types, or the type itself otherwise.
   ##
@@ -166,16 +176,6 @@ since (1, 3, 5):
       doAssert elementType(myiter(3)) is int
 
     typeof(block: (for ai in a: ai))
-
-template deref*[T](_: typedesc[ptr T | ref T]): typedesc =
-  ## Returns `T` for `ref T | ptr T`
-  runnableExamples:
-    assert (ref int).deref is int
-    type A = ptr seq[float]
-    assert A.deref is seq[float]
-    assert (ref A).deref is A # not seq[float]
-    assert (var s = "abc"; s[0].addr).typeof.deref is char
-  T
 
 import macros
 

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -101,7 +101,7 @@ proc isNamedTuple*(T: typedesc): bool {.magic: "TypeTrait".} =
     doAssert isNamedTuple(tuple[name: string, age: int])
 
 template pointerBase*[T](_: typedesc[ptr T | ref T]): typedesc =
-  ## Returns `T` for `ref T | ptr T`
+  ## Returns `T` for `ref T | ptr T`.
   runnableExamples:
     assert (ref int).pointerBase is int
     type A = ptr seq[float]

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -167,6 +167,16 @@ since (1, 3, 5):
 
     typeof(block: (for ai in a: ai))
 
+template deref*[T](_: typedesc[ptr T | ref T]): typedesc =
+  ## Returns `T` for `ref T | ptr T`
+  runnableExamples:
+    assert (ref int).deref is int
+    type A = ptr seq[float]
+    assert A.deref is seq[float]
+    assert (ref A).deref is A # not seq[float]
+    assert (var s = "abc"; s[0].addr).typeof.deref is char
+  T
+
 import macros
 
 macro enumLen*(T: typedesc[enum]): int =

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -100,14 +100,14 @@ proc isNamedTuple*(T: typedesc): bool {.magic: "TypeTrait".} =
     doAssert not isNamedTuple((string, int))
     doAssert isNamedTuple(tuple[name: string, age: int])
 
-template refBase*[T](_: typedesc[ptr T | ref T]): typedesc =
+template pointerBase*[T](_: typedesc[ptr T | ref T]): typedesc =
   ## Returns `T` for `ref T | ptr T`
   runnableExamples:
-    assert (ref int).refBase is int
+    assert (ref int).pointerBase is int
     type A = ptr seq[float]
-    assert A.refBase is seq[float]
-    assert (ref A).refBase is A # not seq[float]
-    assert (var s = "abc"; s[0].addr).typeof.refBase is char
+    assert A.pointerBase is seq[float]
+    assert (ref A).pointerBase is A # not seq[float]
+    assert (var s = "abc"; s[0].addr).typeof.pointerBase is char
   T
 
 proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".} =


### PR DESCRIPTION
IIRC there was a previous PR (from araq?) that had added the same feature but with the syntax `T[]`, but that was problematic and caused issues because of ambiguities; this PR instead uses typetraits.deref for this

(for the same reason, in `typetraits` we have `tup.get(i)` instead of `tup[i]`)