### PR TITLE
testutils.assertAll: show correct location on assert failure

### DIFF
--- a/testament/lib/stdtest/testutils.nim
+++ b/testament/lib/stdtest/testutils.nim
@@ -107,10 +107,12 @@ macro assertAll*(body) =
   # remove this once these support VM, pending #10129 (closed but not yet fixed)
   result = newStmtList()
   for a in body:
-    result.add genAst(a) do:
+    result.add genAst(a, a2 = a.repr, info = lineInfo(a)) do:
       # D20210421T014713:here
       # xxx pending https://github.com/nim-lang/Nim/issues/12030,
       # `typeof` should introduce its own scope, so that this
       # is sufficient: `typeof(a)` instead of `typeof(block: a)`
       when typeof(block: a) is void: a
-      else: doAssert a
+      else:
+        if not a:
+          raise newException(AssertionDefect, info & " " & a2)


### PR DESCRIPTION
after this PR, a failing condition in `testutils.assertAll` will show its location in the error (before this PR, this information was not present in the whole stacktrace or error message)

```nim
import stdtest/testutils
proc main()=
  var a = 1
  assertAll:
    a + 1 == 2
    a + 1 == 2
    a + 1 == 5 # line 11
    a + 1 == 2
main() # line 13
```

## before PR
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12429.nim(13) t12429
/Users/timothee/git_clone/nim/Nim_devel/testament/lib/stdtest/testutils.nim(116) main
/Users/timothee/git_clone/nim/Nim_devel/lib/system/assertions.nim(39) failedAssertImpl
/Users/timothee/git_clone/nim/Nim_devel/lib/system/assertions.nim(29) raiseAssert
/Users/timothee/git_clone/nim/Nim_devel/lib/system/fatal.nim(53) sysFatal
Error: unhandled exception: /Users/timothee/git_clone/nim/Nim_devel/testament/lib/stdtest/testutils.nim(116, 22) `a + 1 == 5`  [AssertionDefect]


## after PR
/Users/timothee/git_clone/nim/timn/tests/nim/all/t12429.nim(13) t12429
/Users/timothee/git_clone/nim/Nim_prs/testament/lib/stdtest/testutils.nim(119) main
Error: unhandled exception: /Users/timothee/git_clone/nim/timn/tests/nim/all/t12429.nim(11, 10) a + 1 == 5 [AssertionDefect]

likewise if you replace proc main by template main