### PR TITLE
move {.injectStmt.} to experimental; add a test

### DIFF
--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -1183,6 +1183,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
         if sym == nil: invalidPragma(c, it)
         else: magicsys.registerNimScriptSymbol(c.graph, sym)
       of wInjectStmt:
+        warningDeprecated(c.config, it.info, "'.injectStmt' pragma is deprecated")
         if it.kind notin nkPragmaCallKinds or it.len != 2:
           localError(c.config, it.info, "expression expected")
         else:
@@ -1194,10 +1195,10 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wThis:
         if it.kind in nkPragmaCallKinds and it.len == 2:
           c.selfName = considerQuotedIdent(c, it[1])
-          message(c.config, n.info, warnDeprecated, "the '.this' pragma is deprecated")
+          message(c.config, n.info, warnDeprecated, "'.this' pragma is deprecated")
         elif it.kind == nkIdent or it.len == 1:
           c.selfName = getIdent(c.cache, "self")
-          message(c.config, n.info, warnDeprecated, "the '.this' pragma is deprecated")
+          message(c.config, n.info, warnDeprecated, "'.this' pragma is deprecated")
         else:
           localError(c.config, it.info, "'this' pragma is allowed to have zero or one arguments")
       of wNoRewrite:

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7432,17 +7432,6 @@ work properly (in particular regarding constructor and destructor) for
   proc main()=
     var a {.threadvar.}: Foo
 
-InjectStmt pragma
------------------
-
-The `injectStmt` pragma can be used to inject a statement before every
-other statement in the current module. It is only supposed to be used for
-debugging:
-
-.. code-block:: nim
-  {.injectStmt: gcInvariants().}
-
-  # ... complex code here that produces crashes ...
 
 compile-time define pragmas
 ---------------------------

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -380,24 +380,6 @@ pass multiple blocks to a macro:
     # code to undo it
 
 
-Experimental Pragmas
-====================
-
-InjectStmt pragma
------------------
-
-The `injectStmt` pragma can be used to inject a statement before every
-other statement in the current module. It is only supposed to be used for
-debugging and comes with limitations (e.g. doesn't work in VM):
-
-.. code-block:: nim
-  from system/ansi_c import c_printf
-  var count = 0
-  proc onInject() =
-    count.inc
-    c_printf("onInject: %d\n", cast[int](count))
-  {.injectStmt: onInject().}
-
 
 Special Operators
 =================

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -380,6 +380,25 @@ pass multiple blocks to a macro:
     # code to undo it
 
 
+Experimental Pragmas
+====================
+
+InjectStmt pragma
+-----------------
+
+The `injectStmt` pragma can be used to inject a statement before every
+other statement in the current module. It is only supposed to be used for
+debugging and comes with limitations (e.g. doesn't work in VM):
+
+.. code-block:: nim
+  from system/ansi_c import c_printf
+  var count = 0
+  proc onInject() =
+    count.inc
+    c_printf("onInject: %d\n", cast[int](count))
+  {.injectStmt: onInject().}
+
+
 Special Operators
 =================
 

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -176,8 +176,6 @@ export Port, SocketFlag
 export asyncfutures except callSoon
 export asyncstreams
 
-#{.injectStmt: newGcInvariant().}
-
 # TODO: Check if yielded future is nil and throw a more meaningful exception
 
 type

--- a/lib/system/gc_ms.nim
+++ b/lib/system/gc_ms.nim
@@ -429,6 +429,7 @@ proc sweep(gch: var GcHeap) =
         else: freeCyclicCell(gch, c)
 
 when false:
+  # meant to be used with the now-deprected `.injectStmt`: {.injectStmt: newGcInvariant().}
   proc newGcInvariant*() =
     for x in allObjects(gch.region):
       if isCell(x):

--- a/tests/pragmas/tinjectstmt.nim
+++ b/tests/pragmas/tinjectstmt.nim
@@ -19,7 +19,14 @@ onInject: 9
 '''
 """
 
-# test injectStmt
+# test {.injectStmt.}
+
+#[
+{.injectStmt.} pragma can be used to inject a statement before every
+other statement in the current module. It's now undocumented and may be removed
+in the future and replaced with something more general and without its limitations.
+e.g. (e.g. doesn't work in VM or js backends).
+]#
 
 from system/ansi_c import c_printf
 

--- a/tests/pragmas/tinjectstmt.nim
+++ b/tests/pragmas/tinjectstmt.nim
@@ -1,0 +1,41 @@
+discard """
+  joinable: false
+  output:'''
+onInject: 1
+onInject: 2
+ok0
+ok1
+onInject: 3
+onInject: 4
+0
+onInject: 5
+onInject: 6
+1
+onInject: 7
+onInject: 8
+2
+ok2
+onInject: 9
+'''
+"""
+
+# test injectStmt
+
+from system/ansi_c import c_printf
+
+var count = 0
+proc onInject*() =
+  count.inc
+  # echo count # xxx would fail, probably infinite recursion
+  c_printf("onInject: %d\n", cast[int](count))
+
+{.injectStmt: onInject().}
+echo "ok0"
+proc main()=
+  echo "ok1"
+  for a in 0..<3:
+    echo a
+  echo "ok2"
+
+static: main() # xxx injectStmt not honred in VM
+main()


### PR DESCRIPTION
* closes https://github.com/timotheecour/Nim/issues/759
* IMO we should replace `{.injectStmt.}` by something much more useful and customizable based on user defined macros that can transform input modules before they're semchecked (refs https://github.com/timotheecour/Nim/issues/75) which would generalize these:
```
{.injectStmt.}
--import
--include
--trmacros
--expandMacro:MACRO
patchFile (nimscript)
```
allow user to take advantage of macros to patch a module (or any module) in whatever way they need
