### PR TITLE
followup #17852, disallow all:on for now for hint + friends

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -217,6 +217,8 @@ proc processSpecificNote*(arg: string, state: TSpecialWord, pass: TCmdLinePass,
     localError(conf, info, errOnOrOffExpectedButXFound % arg)
   else:
     let isOn = val == "on"
+    if isOn and id.normalize == "all":
+      localError(conf, info, "only 'all:off' is supported")
     for n in notes:
       if n notin conf.cmdlineNotes or pass == passCmd1:
         if pass == passCmd1: incl(conf.cmdlineNotes, n)

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -51,7 +51,8 @@ Advanced options:
   --hints:on|off|list.      `on|off` enables or disables hints.
                             `list` reports which hints are selected.
   --hint:X:on|off           turn specific hint X on|off. `hint:X` means `hint:X:on`,
-                            as with similar flags. `all` can be used for "all hints".
+                            as with similar flags. `all` is the set of all hints
+                            (only `all:off` is supported).
   --hintAsError:X:on|off    turn specific hint X into an error on|off
   -w:on|off|list, --warnings:on|off|list
                             same as `--hints` but for warnings.


### PR DESCRIPTION
followup #17852

rationale: hints, warnings are a moving target

## future work
- [ ] update https://github.com/nim-lang/Nim/pull/14068 accordingly
- [ ] add more groups, eg: `--warningAsError:v1.4:on`, `--warning:performance:on`
- [ ] turn some notes into groups to allow finer grain control, eg deprecated could become a group representing all deprecation warnings, where each deprecation can be listed individually, eg: `--warning:deprecated:errorDefect:on`
