### PR TITLE
fixes #17768 [backport:1.4]

### DIFF
--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -333,7 +333,7 @@ proc runeReverseOffset*(s: string, rev: Positive): (int, int) =
   ## from the end (starting with 1) and the total
   ## number of runes in the string.
   ##
-  ## Returns a negative value for offset if there are to few runes in
+  ## Returns a negative value for offset if there are too few runes in
   ## the string to satisfy the request.
   ##
   ## **Beware:** This can lead to unoptimized code and slow execution!
@@ -346,16 +346,15 @@ proc runeReverseOffset*(s: string, rev: Positive): (int, int) =
     a = rev.int
     o = 0
     x = 0
+  let
+    times = 2*rev.int-s.runeLen # transformed from rev.int - a < s.runeLen - rev.int
   while o < s.len:
     let r = runeLenAt(s, o)
     o += r
-    if a < 0:
+    if a > times:
       x += r
     dec a
-
-  if a > 0:
-    return (-a, rev.int-a)
-  return (x, -a+rev.int)
+  result = if a > 0: (-a, rev.int-a) else: (x, -a+rev.int)
 
 proc runeAtPos*(s: string, pos: int): Rune =
   ## Returns the rune at position ``pos``.

--- a/lib/pure/unicode.nim
+++ b/lib/pure/unicode.nim
@@ -346,8 +346,7 @@ proc runeReverseOffset*(s: string, rev: Positive): (int, int) =
     a = rev.int
     o = 0
     x = 0
-  let
-    times = 2*rev.int-s.runeLen # transformed from rev.int - a < s.runeLen - rev.int
+  let times = 2*rev.int-s.runeLen # transformed from rev.int - a < s.runeLen - rev.int
   while o < s.len:
     let r = runeLenAt(s, o)
     o += r

--- a/tests/stdlib/tunicode.nim
+++ b/tests/stdlib/tunicode.nim
@@ -1,4 +1,4 @@
-import unicode
+import std/unicode
 
 
 proc asRune(s: static[string]): Rune =
@@ -213,3 +213,10 @@ block differentSizes:
   doAssert swapCase("ⱥbCd") == "ȺBcD"
   doAssert swapCase("XyꟆaB") == "xYᶎAb"
   doAssert swapCase("aᵹcᲈd") == "AꝽCꙊD"
+
+block: # bug #17768
+  let s1 = "abcdef"
+  let s2 = "abcdéf"
+
+  doAssert s1.runeSubstr(0, -1) == "abcde"
+  doAssert s2.runeSubstr(0, -1) == "abcdé"


### PR DESCRIPTION
fixes #17768
closes #17798

If I didn't misunderstand what `runeReverseOffset` does, it seems `runeReverseOffset` never work and happen to pass the test if the test is right. Before it skip the preceding few runes, but I think it should skip the last few runes.

The PR fixes the original issue posted by #17768. Other issues posted by me seems unrelated. They can be done in the following PR.

- [ ] followup task
https://github.com/nim-lang/Nim/issues/17768#issuecomment-825604721