### PR TITLE
rst: allow comment to continue on second line

### DIFF
--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -83,6 +83,72 @@ suite "RST parsing":
               rnLeaf  'set'
         """)
 
+  test "RST comment":
+    check(dedent"""
+        .. comment1
+         comment2
+        someParagraph""".toAst ==
+      dedent"""
+        rnLeaf  'someParagraph'
+        """)
+
+    check(dedent"""
+        ..
+         comment1
+         comment2
+        someParagraph""".toAst ==
+      dedent"""
+        rnLeaf  'someParagraph'
+        """)
+
+  test "check that additional line right after .. ends comment":
+    check(dedent"""
+        ..
+
+         notAcomment1
+         notAcomment2
+        someParagraph""".toAst ==
+      dedent"""
+        rnInner
+          rnBlockQuote
+            rnInner
+              rnLeaf  'notAcomment1'
+              rnLeaf  ' '
+              rnLeaf  'notAcomment2'
+          rnParagraph
+            rnLeaf  'someParagraph'
+        """)
+
+  test "but blank lines after 2nd non-empty line don't end the comment":
+    check(dedent"""
+        ..
+           comment1
+
+
+         comment2
+        someParagraph""".toAst ==
+      dedent"""
+        rnLeaf  'someParagraph'
+        """)
+
+  test "using .. as separator b/w directives and block quotes":
+    check(dedent"""
+        .. note:: someNote
+    
+        ..
+    
+          someBlockQuote""".toAst ==
+      dedent"""
+        rnInner
+          rnAdmonition  adType=note
+            [nil]
+            [nil]
+            rnLeaf  'someNote'
+          rnBlockQuote
+            rnInner
+              rnLeaf  'someBlockQuote'
+        """)
+
 suite "RST indentation":
   test "nested bullet lists":
     let input = dedent """


### PR DESCRIPTION
fixes bug 19 from #17340, in situations like:

```rst
.. comment
   continuation
```

(see syntax diagram in [RST spec comments section](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#comments))