### PR TITLE
docs now show nimExperimentalX APIs

### DIFF
--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -3,7 +3,7 @@
 when not defined(js):
   {.fatal: "Module jsfetch is designed to be used with the JavaScript backend.".}
 
-when defined(nimExperimentalJsfetch) or defined(nimdoc):
+when defined(nimExperimentalJsfetch):
   import std/[asyncjs, jsheaders, jsformdata]
   from std/httpcore import HttpMethod
   from std/jsffi import JsObject

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -34,15 +34,15 @@ proc free*(s: cstring) {.importc: "free", header: "<stdlib.h>".}
 
 when defined nimExperimentalLinenoiseExtra:
   # C interface
-  type linenoiseStatus = enum
+  type LinenoiseStatus = enum
     linenoiseStatus_ctrl_unknown
     linenoiseStatus_ctrl_C
     linenoiseStatus_ctrl_D
 
-  type linenoiseData* = object
-    status: linenoiseStatus
+  type LinenoiseData* = object
+    status: LinenoiseStatus
 
-  proc linenoiseExtra(prompt: cstring, data: ptr linenoiseData): cstring {.importc.}
+  proc linenoiseExtra(prompt: cstring, data: ptr LinenoiseData): cstring {.importc.}
 
   # stable nim interface
   type Status* = enum
@@ -65,7 +65,7 @@ when defined nimExperimentalLinenoiseExtra:
         if ret.line.len > 0: echo ret.line
         if ret.status == lnCtrlD: break
       echo "exiting"
-    var data: linenoiseData
+    var data: LinenoiseData
     let buf = linenoiseExtra(prompt, data.addr)
     result.line = $buf
     free(buf)

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -32,7 +32,7 @@ proc printKeyCodes*() {.importc: "linenoisePrintKeyCodes".}
 
 proc free*(s: cstring) {.importc: "free", header: "<stdlib.h>".}
 
-when defined nimExperimentalLinenoiseExtra:
+when defined(nimExperimentalLinenoiseExtra) and not defined(windows):
   # C interface
   type LinenoiseStatus = enum
     linenoiseStatus_ctrl_unknown

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -30,4 +30,7 @@ hint("Processing", off)
 # switch("hint", "ConvFromXtoItselfNotNeeded")
 
 # experimental API's are enabled in testament, refs https://github.com/timotheecour/Nim/issues/575
+# sync with `kochdocs.docDefines` or refactor.
 switch("define", "nimExperimentalAsyncjsThen")
+switch("define", "nimExperimentalJsfetch")
+switch("define", "nimExperimentalLinenoiseExtra")

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -8,7 +8,8 @@ const
   gaCode* = " --doc.googleAnalytics:UA-48159761-1"
   # errormax: subsequent errors are probably consequences of 1st one; a simple
   # bug could cause unlimited number of errors otherwise, hard to debug in CI.
-  nimArgs = "--errormax:3 --hint:Conf:off --hint:Path:off --hint:Processing:off --hint:XDeclaredButNotUsed:off --warning:UnusedImport:off -d:boot --putenv:nimversion=$#" % system.NimVersion
+  docDefines = "-d:nimExperimentalAsyncjsThen -d:nimExperimentalJsfetch -d:nimExperimentalLinenoiseExtra"
+  nimArgs = "--errormax:3 --hint:Conf:off --hint:Path:off --hint:Processing:off --hint:XDeclaredButNotUsed:off --warning:UnusedImport:off -d:boot --putenv:nimversion=$# $#" % [system.NimVersion, docDefines]
   gitUrl = "https://github.com/nim-lang/Nim"
   docHtmlOutput = "doc/html"
   webUploadOutput = "web/upload"


### PR DESCRIPTION
after this PR, things like asyncjs.then will now show up in docs (and the runnableExamples will show something like `Example: cmd: -d:nimExperimentalAsyncjsThen` in header which indicates that the API requires that flag)

## before PR
asyncjs.then doesn't appear in docs (ditto with other nimExperimentalX APIs, except nimExperimentalJsfetch which was hardcoded in a IMO bad way [1])

## after PR
![image](https://user-images.githubusercontent.com/2194784/123311312-e03db980-d4db-11eb-997c-d704fee832ba.png)

[1]
since it would make things inconsistent if that flag were used in other places