### PR TITLE
improvements to hint:processing: show import stack, distinguish nims, show includes etc

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -75,7 +75,7 @@ type
     hintXDeclaredButNotUsed = "XDeclaredButNotUsed", hintDuplicateModuleImport = "DuplicateModuleImport",
     hintXCannotRaiseY = "XCannotRaiseY", hintConvToBaseNotNeeded = "ConvToBaseNotNeeded",
     hintConvFromXtoItselfNotNeeded = "ConvFromXtoItselfNotNeeded", hintExprAlwaysX = "ExprAlwaysX",
-    hintQuitCalled = "QuitCalled", hintProcessing = "Processing", hintCodeBegin = "CodeBegin",
+    hintQuitCalled = "QuitCalled", hintProcessing = "Processing", hintProcessingStmt = "ProcessingStmt", hintCodeBegin = "CodeBegin",
     hintCodeEnd = "CodeEnd", hintConf = "Conf", hintPath = "Path",
     hintConditionAlwaysTrue = "CondTrue", hintConditionAlwaysFalse = "CondFalse", hintName = "Name",
     hintPattern = "Pattern", hintExecuting = "Exec", hintLinking = "Link", hintDependency = "Dependency",
@@ -163,6 +163,7 @@ const
     hintExprAlwaysX: "expression evaluates always to '$1'",
     hintQuitCalled: "quit() called",
     hintProcessing: "$1",
+    hintProcessingStmt: "$1",
     hintCodeBegin: "generated code listing:",
     hintCodeEnd: "end of listing",
     hintConf: "used config file '$1'",
@@ -202,7 +203,7 @@ type
 
 proc computeNotesVerbosity(): array[0..3, TNoteKinds] =
   result[3] = {low(TNoteKind)..high(TNoteKind)} - {warnObservableStores, warnResultUsed}
-  result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext, hintDeclaredLoc}
+  result[2] = result[3] - {hintStackTrace, warnUninit, hintExtendedContext, hintDeclaredLoc, hintProcessingStmt}
   result[1] = result[2] - {warnProveField, warnProveIndex,
     warnGcUnsafe, hintPath, hintDependency, hintCodeBegin, hintCodeEnd,
     hintSource, hintGlobalVar, hintGCStats, hintMsgOrigin, hintPerformance}

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -582,3 +582,13 @@ proc moduleFromRodFile*(g: ModuleGraph; fileIdx: FileIndex;
 
 proc configComplete*(g: ModuleGraph) =
   rememberStartupConfig(g.startupPackedConfig, g.config)
+
+from std/strutils import repeat, `%`
+
+proc onProcessing*(graph: ModuleGraph, fileIdx: FileIndex, moduleStatus: string, fromModule: PSym, ) =
+  let conf = graph.config
+  let path = toFilenameOption(conf, fileIdx, conf.filenameOption)
+  let indent = ">".repeat(graph.importStack.len)
+  let fromModule2 = if fromModule != nil: $fromModule.name.s else: "(toplevel)"
+  let mode = if conf.isDefined("nimscript"): "(nims) " else: ""
+  rawMessage(conf, hintProcessing, "$#$# $#: $#: $#" % [mode, indent, fromModule2, moduleStatus, path])

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -587,8 +587,11 @@ from std/strutils import repeat, `%`
 
 proc onProcessing*(graph: ModuleGraph, fileIdx: FileIndex, moduleStatus: string, fromModule: PSym, ) =
   let conf = graph.config
-  let path = toFilenameOption(conf, fileIdx, conf.filenameOption)
-  let indent = ">".repeat(graph.importStack.len)
-  let fromModule2 = if fromModule != nil: $fromModule.name.s else: "(toplevel)"
-  let mode = if conf.isDefined("nimscript"): "(nims) " else: ""
-  rawMessage(conf, hintProcessing, "$#$# $#: $#: $#" % [mode, indent, fromModule2, moduleStatus, path])
+  let isNimscript = conf.isDefined("nimscript")
+  if not isNimscript or conf.isDefined("nimHintProcessingNims"):
+    # `nimHintProcessingNims` is un-documented for now, this could turn into a proper flag if needed
+    let path = toFilenameOption(conf, fileIdx, conf.filenameOption)
+    let indent = ">".repeat(graph.importStack.len)
+    let fromModule2 = if fromModule != nil: $fromModule.name.s else: "(toplevel)"
+    let mode = if isNimscript: "(nims) " else: ""
+    rawMessage(conf, hintProcessing, "$#$# $#: $#: $#" % [mode, indent, fromModule2, moduleStatus, path])

--- a/compiler/modulegraphs.nim
+++ b/compiler/modulegraphs.nim
@@ -588,8 +588,7 @@ from std/strutils import repeat, `%`
 proc onProcessing*(graph: ModuleGraph, fileIdx: FileIndex, moduleStatus: string, fromModule: PSym, ) =
   let conf = graph.config
   let isNimscript = conf.isDefined("nimscript")
-  if not isNimscript or conf.isDefined("nimHintProcessingNims"):
-    # `nimHintProcessingNims` is un-documented for now, this could turn into a proper flag if needed
+  if (not isNimscript) or hintProcessing in conf.cmdlineNotes:
     let path = toFilenameOption(conf, fileIdx, conf.filenameOption)
     let indent = ">".repeat(graph.importStack.len)
     let fromModule2 = if fromModule != nil: $fromModule.name.s else: "(toplevel)"

--- a/compiler/modules.nim
+++ b/compiler/modules.nim
@@ -84,12 +84,13 @@ proc newModule(graph: ModuleGraph; fileIdx: FileIndex): PSym =
   partialInitModule(result, graph, fileIdx, filename)
   graph.registerModule(result)
 
-proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): PSym =
+proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags, fromModule: PSym = nil): PSym =
   var flags = flags
   if fileIdx == graph.config.projectMainIdx2: flags.incl sfMainModule
   result = graph.getModule(fileIdx)
 
-  template processModuleAux =
+  template processModuleAux(moduleStatus) =
+    onProcessing(graph, fileIdx, moduleStatus, fromModule = fromModule)
     var s: PLLStream
     if sfMainModule in flags:
       if graph.config.projectIsStdin: s = stdin.llStreamOpen
@@ -103,7 +104,7 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): P
       result = newModule(graph, fileIdx)
       result.flags.incl flags
       registerModule(graph, result)
-      processModuleAux()
+      processModuleAux("import")
     else:
       if sfSystemModule in flags:
         graph.systemModule = result
@@ -117,13 +118,13 @@ proc compileModule*(graph: ModuleGraph; fileIdx: FileIndex; flags: TSymFlags): P
     # reset module fields:
     initStrTables(graph, result)
     result.ast = nil
-    processModuleAux()
+    processModuleAux("import(dirty)")
     graph.markClientsDirty(fileIdx)
 
 proc importModule*(graph: ModuleGraph; s: PSym, fileIdx: FileIndex): PSym =
   # this is called by the semantic checking phase
   assert graph.config != nil
-  result = compileModule(graph, fileIdx, {})
+  result = compileModule(graph, fileIdx, {}, s)
   graph.addDep(s, fileIdx)
   # keep track of import relationships
   if graph.config.hcrOn:

--- a/compiler/passaux.nim
+++ b/compiler/passaux.nim
@@ -19,18 +19,13 @@ type
     config: ConfigRef
 
 proc verboseOpen(graph: ModuleGraph; s: PSym; idgen: IdGenerator): PPassContext =
-  let conf = graph.config
-  result = VerboseRef(config: conf, idgen: idgen)
-  let path = toFilenameOption(conf, s.position.FileIndex, conf.filenameOption)
-  rawMessage(conf, hintProcessing, path)
+  # xxx consider either removing this or keeping for documentation for how to add a pass
+  result = VerboseRef(config: graph.config, idgen: idgen)
 
 proc verboseProcess(context: PPassContext, n: PNode): PNode =
+  # called from `process` in `processTopLevelStmt`.
   result = n
   let v = VerboseRef(context)
-  if v.config.verbosity == 3:
-    # system.nim deactivates all hints, for verbosity:3 we want the processing
-    # messages nonetheless, so we activate them again (but honor cmdlineNotes)
-    v.config.setNote(hintProcessing)
-    message(v.config, n.info, hintProcessing, $v.idgen[])
+  message(v.config, n.info, hintProcessingStmt, $v.idgen[])
 
 const verbosePass* = makePass(open = verboseOpen, process = verboseProcess)

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -2158,6 +2158,7 @@ proc incMod(c: PContext, n: PNode, it: PNode, includeStmtResult: PNode) =
   var f = checkModuleName(c.config, it)
   if f != InvalidFileIdx:
     addIncludeFileDep(c, f)
+    onProcessing(c.graph, f, "include", c.module)
     if containsOrIncl(c.includedFiles, f.int):
       localError(c.config, n.info, errRecursiveDependencyX % toMsgFilename(c.config, f))
     else:

--- a/nimsuggest/tests/tchk1.nim
+++ b/nimsuggest/tests/tchk1.nim
@@ -17,7 +17,7 @@ proc main =
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tests/tchk1.nim [Processing]";;0
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;">> (toplevel): import(dirty): tests/tchk1.nim [Processing]";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"identifier expected, but got \'keyword template\'";;0
 chk;;skUnknown;;;;Error;;$file;;14;;0;;"nestable statement requires indentation";;0
 chk;;skUnknown;;;;Error;;$file;;12;;0;;"implementation of \'foo\' expected";;0

--- a/nimsuggest/tests/tchk_compiles.nim
+++ b/nimsuggest/tests/tchk_compiles.nim
@@ -4,5 +4,5 @@ discard compiles(2 + "hello")
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tests/tchk_compiles.nim [Processing]";;0
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;">> (toplevel): import(dirty): tests/tchk_compiles.nim [Processing]";;0
 """

--- a/nimsuggest/tests/ttempl_inst.nim
+++ b/nimsuggest/tests/ttempl_inst.nim
@@ -7,7 +7,7 @@ foo()
 discard """
 $nimsuggest --tester $file
 >chk $1
-chk;;skUnknown;;;;Hint;;???;;0;;-1;;"tests/ttempl_inst.nim [Processing]";;0
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;">> (toplevel): import(dirty): tests/ttempl_inst.nim [Processing]";;0
 chk;;skUnknown;;;;Hint;;$file;;4;;3;;"template/generic instantiation from here";;0
 chk;;skUnknown;;;;Warning;;$file;;2;;11;;"foo [User]";;0
 """


### PR DESCRIPTION
`hint:processing` is very useful during debugging; this PR improves it further:
* show a `(nims)` prefix for files processing during nimscript processing to avoid confusion
* show includes as well
* show the importing module (or `(toplevel)`) and the import stack depth (with `>`); this makes it easy to trace how we got to process a given file by simply lookup up the import stack
* `verboseProcess` (which showed a hintProcessing for each top-level statement) wasn't working since a while ago; after this PR it now works again; and you can show those without verbosity:3 (which is very verbose), instead you can use a new `hint:processingstmt` 

## example snippet
```
Hint: (nims)  (toplevel): import: /Users/timothee/git_clone/nim/Nim_prs/lib/system.nim [Processing]
Hint: (nims)  system: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/basic_types.nim [Processing]
Hint: (nims)  system: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/arithmetics.nim [Processing]
Hint: (nims)  system: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/comparisons.nim [Processing]
Hint: (nims)  system: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/inclrtl.nim [Processing]
Hint: (nims)  system: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/exceptions.nim [Processing]
Hint: (nims)  system: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/setops.nim [Processing]
Hint: (nims) > system: import: /Users/timothee/git_clone/nim/Nim_prs/lib/std/private/since.nim [Processing]

...
Hint: > (toplevel): import: /Users/timothee/git_clone/nim/Nim_prs/compiler/nim.nim [Processing]
Hint: >> nim: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/os.nim [Processing]
Hint: >> os: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/inclrtl.nim [Processing]
Hint: >>> os: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/strutils.nim [Processing]
Hint: >>>> strutils: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/parseutils.nim [Processing]
Hint: >>>> parseutils: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/inclrtl.nim [Processing]
Hint: >>>> strutils: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/math.nim [Processing]
Hint: >>>>> math: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/bitops.nim [Processing]
Hint: >>>>>> bitops: import: /Users/timothee/git_clone/nim/Nim_prs/lib/core/macros.nim [Processing]
Hint: >>>>>> macros: include: /Users/timothee/git_clone/nim/Nim_prs/lib/system/inclrtl.nim [Processing]
Hint: >>>>> math: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/fenv.nim [Processing]
Hint: >>>> strutils: import: /Users/timothee/git_clone/nim/Nim_prs/lib/pure/algorithm.nim [Processing]
...
```

## full example
nim c --hint:all:off --warnings:off --processing:filenames --skipusercfg --skipparentcfg compiler/nim

* before PR
https://gist.github.com/timotheecour/f9152b92c537596d04b2f08bf67f32ed

* after PR
https://gist.github.com/timotheecour/af72c7f3f4cdeb039c2f8d2ab57c9776
