### PR TITLE
Removed hard coded ports from thttpclient_standalone.nim.

### DIFF
--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -18,7 +18,7 @@ block: # bug #16436
 
   proc runClient(port: Port) {.async.} =
     let c = newAsyncHttpClient(headers = {"Connection": "close"}.newHttpHeaders)
-    discard await c.getContent("http://127.0.0.1:" & $uint16(port))
+    discard await c.getContent("http://127.0.0.1:" & $port)
     doAssert false, "should fail earlier"
 
   let server = startServer()

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -28,10 +28,9 @@ block: # bug #16436
     discard await c.getContent("http://127.0.0.1:" & $uint16(port))
     doAssert false, "should fail earlier"
 
-  #var port = asyncCheck startServer()
-  var server = startServer()
+  let server = startServer()
   asyncCheck runServer(server)
-  var port = server.getPort()
+  let port = server.getPort()
   doAssertRaises(ProtocolError):
     waitFor runClient(port)
 
@@ -60,12 +59,12 @@ block: # bug #14794 (And test for presence of content-length header when using p
 
   proc runClient(port: Port) {.async.} =
     let c = newAsyncHttpClient()
-    var data = newMultipartData()
+    let data = newMultipartData()
     data.add("file.txt", "This is intended to be an example text file.\r\nThis would be the second line.\r\n")
     discard await c.postContent("http://127.0.0.1:" & $uint16(port), multipart = data)
     c.close()
 
-  var server = startServer()
-  var port = server.getPort()
+  let server = startServer()
+  let port = server.getPort()
   asyncCheck runServer(server)
   waitFor runClient(port)

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -2,7 +2,7 @@ discard """
   cmd: "nim c --threads:on $file"
 """
 
-import asynchttpserver, httpclient, asyncdispatch, strutils
+import asynchttpserver, httpclient, asyncdispatch, strutils, net
 
 block: # bug #16436
   proc startServer(): AsyncHttpServer =

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -9,7 +9,7 @@ block: # bug #16436
     result = newAsyncHttpServer()
     result.listen(Port(0))
 
-  proc runServer(server: AsyncHttpServer) {.async.} =
+  proc processRequest(server: AsyncHttpServer) {.async.} =
     proc cb(req: Request) {.async.} =
       let headers = { "Content-length": "15"} # Provide invalid content-length
       await req.respond(Http200, "Hello World", headers.newHttpHeaders())

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -25,7 +25,7 @@ block: # bug #16436
 
   proc runClient(port: Port) {.async.} =
     let c = newAsyncHttpClient(headers = {"Connection": "close"}.newHttpHeaders)
-    discard await c.getContent("http://127.0.0.1:" & $(uint16)port)
+    discard await c.getContent("http://127.0.0.1:" & $uint16(port))
     doAssert false, "should fail earlier"
 
   #var port = asyncCheck startServer()
@@ -62,7 +62,7 @@ block: # bug #14794 (And test for presence of content-length header when using p
     let c = newAsyncHttpClient()
     var data = newMultipartData()
     data.add("file.txt", "This is intended to be an example text file.\r\nThis would be the second line.\r\n")
-    discard await c.postContent("http://127.0.0.1:" & $(uint16)port, multipart = data)
+    discard await c.postContent("http://127.0.0.1:" & $uint16(port), multipart = data)
     c.close()
 
   var server = startServer()

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -28,7 +28,7 @@ block: # bug #16436
     waitFor runClient(port)
 
 block: # bug #14794 (And test for presence of content-length header when using postContent)
-  proc startServer():AsyncHttpServer =
+  proc startServer(): AsyncHttpServer =
     result = newAsyncHttpServer()
     result.listen(Port(0))
 

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -48,7 +48,7 @@ block: # bug #14794 (And test for presence of content-length header when using p
     let c = newAsyncHttpClient()
     let data = newMultipartData()
     data.add("file.txt", "This is intended to be an example text file.\r\nThis would be the second line.\r\n")
-    discard await c.postContent("http://127.0.0.1:" & $uint16(port), multipart = data)
+    discard await c.postContent("http://127.0.0.1:" & $port, multipart = data)
     c.close()
 
   let server = startServer()

--- a/tests/stdlib/thttpclient_standalone.nim
+++ b/tests/stdlib/thttpclient_standalone.nim
@@ -22,7 +22,7 @@ block: # bug #16436
     doAssert false, "should fail earlier"
 
   let server = startServer()
-  asyncCheck runServer(server)
+  asyncCheck processRequest(server)
   let port = server.getPort()
   doAssertRaises(ProtocolError):
     waitFor runClient(port)


### PR DESCRIPTION
Follow up from  #18208 removes hard coded ports from test.