### PR TITLE
improve `--declaredLocs` to help disambiguate types (generics, aliases etc)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -395,7 +395,7 @@
 
 ## Compiler changes
 
-- Added `--declaredlocs` to show symbol declaration location in messages.
+- Added `--declaredLocs` to show symbol declaration location in messages.
 
 - You can now enable/disable VM tracing in user code via `vmutils.vmTrace`.
 

--- a/compiler/astmsgs.nim
+++ b/compiler/astmsgs.nim
@@ -1,6 +1,6 @@
 # this module avoids ast depending on msgs or vice versa
 import std/strutils
-import options, ast, msgs
+import options, ast, msgs, types
 
 proc typSym*(t: PType): PSym =
   result = t.sym
@@ -18,7 +18,7 @@ proc addDeclaredLoc*(result: var string, conf: ConfigRef; typ: PType) =
   # xxx figure out how to resolve `tyGenericParam`, e.g. for
   # proc fn[T](a: T, b: T) = discard
   # fn(1.1, "a")
-  let typ = typ.skipTypes(abstractInst + {tyStatic, tyUserTypeClassInst} - {tyRange})
+  let typ = typ.skipTypes(abstractInst + {tyStatic, tySequence, tyArray, tySet, tyUserTypeClassInst, tyVar, tyRef, tyPtr} - {tyRange})
   result.add " [$1" % typ.kind.toHumanStr
   if typ.sym != nil:
     result.add " declared in " & toFileLineCol(conf, typ.sym.info)
@@ -26,3 +26,10 @@ proc addDeclaredLoc*(result: var string, conf: ConfigRef; typ: PType) =
 
 proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; typ: PType) =
   if optDeclaredLocs in conf.globalOptions: addDeclaredLoc(result, conf, typ)
+
+proc addTypeDeclVerboseMaybe*(result: var string, conf: ConfigRef; typ: PType) =
+  if optDeclaredLocs in conf.globalOptions:
+    result.add typeToString(typ, preferMixed)
+    result.addDeclaredLoc(conf, typ)
+  else:
+    result.add typeToString(typ)

--- a/compiler/astmsgs.nim
+++ b/compiler/astmsgs.nim
@@ -1,6 +1,6 @@
 # this module avoids ast depending on msgs or vice versa
 import std/strutils
-import options, ast, msgs, types
+import options, ast, msgs
 
 proc typSym*(t: PType): PSym =
   result = t.sym
@@ -26,10 +26,3 @@ proc addDeclaredLoc*(result: var string, conf: ConfigRef; typ: PType) =
 
 proc addDeclaredLocMaybe*(result: var string, conf: ConfigRef; typ: PType) =
   if optDeclaredLocs in conf.globalOptions: addDeclaredLoc(result, conf, typ)
-
-proc addTypeDeclVerboseMaybe*(result: var string, conf: ConfigRef; typ: PType) =
-  if optDeclaredLocs in conf.globalOptions:
-    result.add typeToString(typ, preferMixed)
-    result.addDeclaredLoc(conf, typ)
-  else:
-    result.add typeToString(typ)

--- a/compiler/semcall.nim
+++ b/compiler/semcall.nim
@@ -231,11 +231,10 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
       of kMissingParam: candidates.add("\n  missing parameter: " & nameParam)
       of kTypeMismatch, kVarNeeded:
         doAssert nArg != nil
-        var wanted = err.firstMismatch.formal.typ
+        let wanted = err.firstMismatch.formal.typ
         doAssert err.firstMismatch.formal != nil
         candidates.add("\n  required type for " & nameParam &  ": ")
-        candidates.add typeToString(wanted)
-        candidates.addDeclaredLocMaybe(c.config, wanted)
+        candidates.addTypeDeclVerboseMaybe(c.config, wanted)
         candidates.add "\n  but expression '"
         if err.firstMismatch.kind == kVarNeeded:
           candidates.add renderNotLValue(nArg)
@@ -243,9 +242,8 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
         else:
           candidates.add renderTree(nArg)
           candidates.add "' is of type: "
-          var got = nArg.typ
-          candidates.add typeToString(got)
-          candidates.addDeclaredLocMaybe(c.config, got)
+          let got = nArg.typ
+          candidates.addTypeDeclVerboseMaybe(c.config, got)
           doAssert wanted != nil
           if got != nil:
             if got.kind == tyProc and wanted.kind == tyProc:
@@ -274,7 +272,7 @@ proc presentFailedCandidates(c: PContext, n: PNode, errors: CandidateErrors):
 
 const
   errTypeMismatch = "type mismatch: got <"
-  errButExpected = "but expected one of: "
+  errButExpected = "but expected one of:"
   errUndeclaredField = "undeclared field: '$1'"
   errUndeclaredRoutine = "attempting to call undeclared routine: '$1'"
   errBadRoutine = "attempting to call routine: '$1'$2"

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -988,7 +988,7 @@ proc semIndirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode =
             break
         if not hasErrorType:
           let typ = n[0].typ
-          msg.add(">\nbut expected one of: \n" &
+          msg.add(">\nbut expected one of:\n" &
               typeToString(typ))
           # prefer notin preferToResolveSymbols
           # t.sym != nil

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -11,7 +11,7 @@
 
 import
   intsets, ast, astalgo, trees, msgs, strutils, platform, renderer, options,
-  lineinfos, int128, modulegraphs
+  lineinfos, int128, modulegraphs, astmsgs
 
 type
   TPreferedDesc* = enum
@@ -51,7 +51,12 @@ type
 
 proc typeToString*(typ: PType; prefer: TPreferedDesc = preferName): string
 
-import astmsgs
+proc addTypeDeclVerboseMaybe*(result: var string, conf: ConfigRef; typ: PType) =
+  if optDeclaredLocs in conf.globalOptions:
+    result.add typeToString(typ, preferMixed)
+    result.addDeclaredLoc(conf, typ)
+  else:
+    result.add typeToString(typ)
 
 template `$`*(typ: PType): string = typeToString(typ)
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -11,7 +11,7 @@
 
 import
   intsets, ast, astalgo, trees, msgs, strutils, platform, renderer, options,
-  lineinfos, int128, modulegraphs, astmsgs
+  lineinfos, int128, modulegraphs
 
 type
   TPreferedDesc* = enum
@@ -50,6 +50,9 @@ type
     pcmDifferentCallConv
 
 proc typeToString*(typ: PType; prefer: TPreferedDesc = preferName): string
+
+import astmsgs
+
 template `$`*(typ: PType): string = typeToString(typ)
 
 proc base*(t: PType): PType =

--- a/tests/errmsgs/tdeclaredlocs.nim
+++ b/tests/errmsgs/tdeclaredlocs.nim
@@ -1,0 +1,92 @@
+discard """
+  action: reject
+  matrix: "--declaredLocs --hints:off"
+  nimoutFull: true
+  nimout: '''
+tdeclaredlocs.nim(92, 3) Error: type mismatch: got <seq[MyInt2]>
+but expected one of:
+proc fn(a: Bam) [proc declared in tdeclaredlocs.nim(86, 6)]
+  first type mismatch at position: 1
+  required type for a: Bam [object declared in tdeclaredlocs.nim(78, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: Goo[MyInt2]) [proc declared in tdeclaredlocs.nim(89, 6)]
+  first type mismatch at position: 1
+  required type for a: Goo[MyInt2{char}] [object declared in tdeclaredlocs.nim(79, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: Goo[cint]) [proc declared in tdeclaredlocs.nim(88, 6)]
+  first type mismatch at position: 1
+  required type for a: Goo[cint{int32}] [object declared in tdeclaredlocs.nim(79, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: array[3, Bar]) [proc declared in tdeclaredlocs.nim(82, 6)]
+  first type mismatch at position: 1
+  required type for a: array[0..2, Bar] [object declared in tdeclaredlocs.nim(74, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: seq[Bar]) [proc declared in tdeclaredlocs.nim(81, 6)]
+  first type mismatch at position: 1
+  required type for a: seq[Bar] [object declared in tdeclaredlocs.nim(74, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: seq[MyInt1]) [proc declared in tdeclaredlocs.nim(80, 6)]
+  first type mismatch at position: 1
+  required type for a: seq[MyInt1{int}] [int declared in tdeclaredlocs.nim(72, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: set[Baz]) [proc declared in tdeclaredlocs.nim(84, 6)]
+  first type mismatch at position: 1
+  required type for a: set[Baz{enum}] [enum declared in tdeclaredlocs.nim(75, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: set[MyInt2]) [proc declared in tdeclaredlocs.nim(83, 6)]
+  first type mismatch at position: 1
+  required type for a: set[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: var SetBaz) [proc declared in tdeclaredlocs.nim(85, 6)]
+  first type mismatch at position: 1
+  required type for a: var SetBaz [enum declared in tdeclaredlocs.nim(75, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+proc fn(a: var ref ptr Bam) [proc declared in tdeclaredlocs.nim(87, 6)]
+  first type mismatch at position: 1
+  required type for a: var ref ptr Bam [object declared in tdeclaredlocs.nim(78, 3)]
+  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
+
+expression: fn(a)
+'''
+"""
+
+#[
+see also: tests/errmsgs/tsigmatch.nim
+]#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+# line 70
+type
+  MyInt1 = int
+  MyInt2 = char
+  Bar = object
+  Baz = enum k0, k1
+  Baz2 = Baz
+  SetBaz = set[Baz2]
+  Bam = ref object
+  Goo[T] = object
+proc fn(a: seq[MyInt1]) = discard
+proc fn(a: seq[Bar]) = discard
+proc fn(a: array[3, Bar]) = discard
+proc fn(a: set[MyInt2]) = discard
+proc fn(a: set[Baz]) = discard
+proc fn(a: var SetBaz) = discard
+proc fn(a: Bam) = discard
+proc fn(a: var ref ptr Bam) = discard
+proc fn(a: Goo[cint]) = discard
+proc fn(a: Goo[MyInt2]) = discard
+
+var a: seq[MyInt2]
+fn(a)

--- a/tests/errmsgs/tproc_mismatch.nim
+++ b/tests/errmsgs/tproc_mismatch.nim
@@ -6,7 +6,7 @@ discard """
 tproc_mismatch.nim(35, 52) Error: type mismatch: got <proc (a: int, c: float){.cdecl, noSideEffect, gcsafe, locks: 0.}> but expected 'proc (a: int, c: float){.closure, noSideEffect.}'
   Calling convention mismatch: got '{.cdecl.}', but expected '{.closure.}'.
 tproc_mismatch.nim(39, 6) Error: type mismatch: got <proc (){.inline, noSideEffect, gcsafe, locks: 0.}>
-but expected one of: 
+but expected one of:
 proc bar(a: proc ())
   first type mismatch at position: 1
   required type for a: proc (){.closure.}

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -89,9 +89,9 @@ expression: fun1(default(Mystring), "asdf")
 
 
 
-
-
-
+#[
+see also: tests/errmsgs/tdeclaredlocs.nim
+]#
 
 
 


### PR DESCRIPTION
* `addDeclaredLoc` now handles a few more type kinds by chasing the underlying declaration (follows https://github.com/nim-lang/Nim/pull/18236)
* with `--declaredlocs` we now use `preferMixed` (introduced in https://github.com/nim-lang/Nim/pull/11678) which resolves types recursively, eg: `seq[MyInt2{char}]` instead of `seq[MyInt2]`

# Example
`nim r --declaredLocs --hints:off tests/errmsgs/tdeclaredlocs.nim`

## before PR
```nim
tdeclaredlocs.nim(92, 3) Error: type mismatch: got <seq[MyInt2]>
but expected one of:
proc fn(a: Bam) [proc declared in tdeclaredlocs.nim(86, 6)]
  first type mismatch at position: 1
  required type for a: Bam [ref declared in tdeclaredlocs.nim(78, 3)]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: Goo[MyInt2]) [proc declared in tdeclaredlocs.nim(89, 6)]
  first type mismatch at position: 1
  required type for a: Goo[tdeclaredlocs.MyInt2] [object declared in tdeclaredlocs.nim(79, 3)]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: Goo[cint]) [proc declared in tdeclaredlocs.nim(88, 6)]
  first type mismatch at position: 1
  required type for a: Goo[system.cint] [object declared in tdeclaredlocs.nim(79, 3)]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: array[3, Bar]) [proc declared in tdeclaredlocs.nim(82, 6)]
  first type mismatch at position: 1
  required type for a: array[0..2, Bar] [array]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: seq[Bar]) [proc declared in tdeclaredlocs.nim(81, 6)]
  first type mismatch at position: 1
  required type for a: seq[Bar] [sequence]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: seq[MyInt1]) [proc declared in tdeclaredlocs.nim(80, 6)]
  first type mismatch at position: 1
  required type for a: seq[MyInt1] [sequence]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: set[Baz]) [proc declared in tdeclaredlocs.nim(84, 6)]
  first type mismatch at position: 1
  required type for a: set[Baz] [set]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: set[MyInt2]) [proc declared in tdeclaredlocs.nim(83, 6)]
  first type mismatch at position: 1
  required type for a: set[MyInt2] [set]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: var SetBaz) [proc declared in tdeclaredlocs.nim(85, 6)]
  first type mismatch at position: 1
  required type for a: var SetBaz [var]
  but expression 'a' is of type: seq[MyInt2] [sequence]
proc fn(a: var ref ptr Bam) [proc declared in tdeclaredlocs.nim(87, 6)]
  first type mismatch at position: 1
  required type for a: var ref ptr Bam [var]
  but expression 'a' is of type: seq[MyInt2] [sequence]

expression: fn(a)
```
## after PR
```nim
tdeclaredlocs.nim(92, 3) Error: type mismatch: got <seq[MyInt2]>
but expected one of:
proc fn(a: Bam) [proc declared in tdeclaredlocs.nim(86, 6)]
  first type mismatch at position: 1
  required type for a: Bam [object declared in tdeclaredlocs.nim(78, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: Goo[MyInt2]) [proc declared in tdeclaredlocs.nim(89, 6)]
  first type mismatch at position: 1
  required type for a: Goo[MyInt2{char}] [object declared in tdeclaredlocs.nim(79, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: Goo[cint]) [proc declared in tdeclaredlocs.nim(88, 6)]
  first type mismatch at position: 1
  required type for a: Goo[cint{int32}] [object declared in tdeclaredlocs.nim(79, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: array[3, Bar]) [proc declared in tdeclaredlocs.nim(82, 6)]
  first type mismatch at position: 1
  required type for a: array[0..2, Bar] [object declared in tdeclaredlocs.nim(74, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: seq[Bar]) [proc declared in tdeclaredlocs.nim(81, 6)]
  first type mismatch at position: 1
  required type for a: seq[Bar] [object declared in tdeclaredlocs.nim(74, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: seq[MyInt1]) [proc declared in tdeclaredlocs.nim(80, 6)]
  first type mismatch at position: 1
  required type for a: seq[MyInt1{int}] [int declared in tdeclaredlocs.nim(72, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: set[Baz]) [proc declared in tdeclaredlocs.nim(84, 6)]
  first type mismatch at position: 1
  required type for a: set[Baz{enum}] [enum declared in tdeclaredlocs.nim(75, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: set[MyInt2]) [proc declared in tdeclaredlocs.nim(83, 6)]
  first type mismatch at position: 1
  required type for a: set[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: var SetBaz) [proc declared in tdeclaredlocs.nim(85, 6)]
  first type mismatch at position: 1
  required type for a: var SetBaz [enum declared in tdeclaredlocs.nim(75, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
proc fn(a: var ref ptr Bam) [proc declared in tdeclaredlocs.nim(87, 6)]
  first type mismatch at position: 1
  required type for a: var ref ptr Bam [object declared in tdeclaredlocs.nim(78, 3)]
  but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]

expression: fn(a)
```

## future work
- [ ] we shouldn't repeat arguments already expanded eg:
```
but expression 'a' is of type: seq[MyInt2{char}] [char declared in tdeclaredlocs.nim(73, 3)]
```
should be mentioned only once