### PR TITLE
align type mismatch errors to make it visually obvious

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,9 +39,6 @@
 - There is a new warning for *any* type conversion to enum that can be enabled via
   `.warning[AnyEnumConv]:on` or `--warning:AnyEnumConv:on`.
 
-- Type mismatch errors now show more context, use `-d:nimLegacyTypeMismatch` for previous
-  behavior.
-
 - `math.round` now is rounded "away from zero" in JS backend which is consistent
   with other backends. See #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 

--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,8 @@
 - There is a new warning for *any* type conversion to enum that can be enabled via
   `.warning[AnyEnumConv]:on` or `--warning:AnyEnumConv:on`.
 
+- Type mismatch errors now show more context.
+
 - `math.round` now is rounded "away from zero" in JS backend which is consistent
   with other backends. See #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1574,13 +1574,13 @@ proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType, n: P
     var msg = "type mismatch:"
     if verbose: msg.add "\n"
     if conf.isDefined("nimLegacyTypeMismatch"):
-      msg.add  " got <$1>" % actualStr
+      msg.add  " obtained <$1>" % actualStr
     else:
-      msg.add  " got '$1' for '$2'" % [actualStr, n.renderTree]
+      msg.add  " obtained '$1' for '$2'" % [actualStr, n.renderTree]
     if verbose:
       msg.addDeclaredLoc(conf, actual)
       msg.add "\n"
-    msg.add " but expected '$1'" % x
+    msg.add " expected '$1'" % x
     if verbose: msg.addDeclaredLoc(conf, formal)
 
     if formal.kind == tyProc and actual.kind == tyProc:

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1573,13 +1573,15 @@ proc typeMismatch*(conf: ConfigRef; info: TLineInfo, formal, actual: PType, n: P
     let verbose = actualStr == formalStr or optDeclaredLocs in conf.globalOptions
     var msg = "type mismatch:"
     if verbose: msg.add "\n"
-    if conf.isDefined("nimLegacyTypeMismatch"):
-      msg.add  " obtained <$1>" % actualStr
+    if verbose:
+      msg.add  " got      '$1' for '$2'" % [actualStr, n.renderTree]
     else:
-      msg.add  " obtained '$1' for '$2'" % [actualStr, n.renderTree]
+      msg.add  " got '$1' for '$2'" % [actualStr, n.renderTree]
     if verbose:
       msg.addDeclaredLoc(conf, actual)
       msg.add "\n"
+    else:
+      msg.add ", but"
     msg.add " expected '$1'" % x
     if verbose: msg.addDeclaredLoc(conf, formal)
 

--- a/tests/array/tarraycons_ptr_generic2.nim
+++ b/tests/array/tarraycons_ptr_generic2.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <ptr Hard[system.string]> but expected 'Book[system.string]'"
+  errormsg: "type mismatch: obtained <ptr Hard[system.string]> expected 'Book[system.string]'"
   file: "tarraycons_ptr_generic2.nim"
   line: 17
 """

--- a/tests/array/tarraycons_ptr_generic2.nim
+++ b/tests/array/tarraycons_ptr_generic2.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <ptr Hard[system.string]> expected 'Book[system.string]'"
+  errormsg: "type mismatch: got 'ptr Hard[system.string]' for 'addr(hs)', but expected 'Book[system.string]'"
   file: "tarraycons_ptr_generic2.nim"
   line: 17
 """

--- a/tests/casestmt/tcaseexpr1.nim
+++ b/tests/casestmt/tcaseexpr1.nim
@@ -3,7 +3,7 @@ discard """
   action: "reject"
   nimout: '''
 tcaseexpr1.nim(33, 10) Error: not all cases are covered; missing: {C}
-tcaseexpr1.nim(39, 12) Error: type mismatch: got <string> but expected 'int literal(10)'
+tcaseexpr1.nim(39, 12) Error: type mismatch: obtained <string> expected 'int literal(10)'
 '''
 """
 

--- a/tests/casestmt/tcaseexpr1.nim
+++ b/tests/casestmt/tcaseexpr1.nim
@@ -3,7 +3,7 @@ discard """
   action: "reject"
   nimout: '''
 tcaseexpr1.nim(33, 10) Error: not all cases are covered; missing: {C}
-tcaseexpr1.nim(39, 12) Error: type mismatch: obtained <string> expected 'int literal(10)'
+tcaseexpr1.nim(39, 12) Error: type mismatch: got 'string' for '"23"', but expected 'int literal(10)'
 '''
 """
 

--- a/tests/closure/tinvalidclosure5.nim
+++ b/tests/closure/tinvalidclosure5.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <proc (){.closure, gcsafe, locks: 0.}> but expected 'A = proc (){.nimcall.}'"
+  errormsg: "type mismatch: obtained <proc (){.closure, gcsafe, locks: 0.}> expected 'A = proc (){.nimcall.}'"
   line: 9
 """
 

--- a/tests/closure/tinvalidclosure5.nim
+++ b/tests/closure/tinvalidclosure5.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <proc (){.closure, gcsafe, locks: 0.}> expected 'A = proc (){.nimcall.}'"
+  errormsg: "type mismatch: got 'proc (){.closure, gcsafe, locks: 0.}' for 'proc () = echo [b]', but expected 'A = proc (){.nimcall.}'"
   line: 9
 """
 

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -18,8 +18,6 @@ when (NimMajor, NimMinor, NimPatch) >= (1,5,1):
 switch("define", "nimUnittestOutputLevel:PRINT_FAILURES")
 switch("define", "nimUnittestColor:off")
 
-switch("define", "nimLegacyTypeMismatch")
-
 hint("Processing", off)
   # dots can cause annoyances; instead, a single test can test `hintProcessing`
 

--- a/tests/effects/teffects1.nim
+++ b/tests/effects/teffects1.nim
@@ -3,7 +3,7 @@ discard """
   nimout: '''teffects1.nim(22, 28) template/generic instantiation from here
 teffects1.nim(23, 13) Error: can raise an unlisted exception: ref IOError
 teffects1.nim(22, 29) Hint: 'lier' cannot raise 'IO2Error' [XCannotRaiseY]
-teffects1.nim(38, 21) Error: type mismatch: got <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> but expected 'MyProcType = proc (x: int): string{.closure.}'
+teffects1.nim(38, 21) Error: type mismatch: obtained <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> expected 'MyProcType = proc (x: int): string{.closure.}'
 .raise effects differ'''
 """
 
@@ -37,7 +37,7 @@ proc foo(x: int): string {.raises: [ValueError].} =
 
 var p: MyProcType = foo #[tt.Error
                     ^
-type mismatch: got <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> but expected 'MyProcType = proc (x: int): string{.closure.}'
+type mismatch: obtained <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> expected 'MyProcType = proc (x: int): string{.closure.}'
 
 ]#
 {.pop.}

--- a/tests/effects/teffects1.nim
+++ b/tests/effects/teffects1.nim
@@ -3,7 +3,7 @@ discard """
   nimout: '''teffects1.nim(22, 28) template/generic instantiation from here
 teffects1.nim(23, 13) Error: can raise an unlisted exception: ref IOError
 teffects1.nim(22, 29) Hint: 'lier' cannot raise 'IO2Error' [XCannotRaiseY]
-teffects1.nim(38, 21) Error: type mismatch: obtained <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> expected 'MyProcType = proc (x: int): string{.closure.}'
+teffects1.nim(38, 21) Error: type mismatch: got 'proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}' for 'foo', but expected 'MyProcType = proc (x: int): string{.closure.}'
 .raise effects differ'''
 """
 
@@ -37,7 +37,7 @@ proc foo(x: int): string {.raises: [ValueError].} =
 
 var p: MyProcType = foo #[tt.Error
                     ^
-type mismatch: obtained <proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}> expected 'MyProcType = proc (x: int): string{.closure.}'
+type mismatch: got 'proc (x: int): string{.noSideEffect, gcsafe, locks: 0.}' for 'foo', but expected 'MyProcType = proc (x: int): string{.closure.}'
 
 ]#
 {.pop.}

--- a/tests/errmsgs/t8339.nim
+++ b/tests/errmsgs/t8339.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <seq[int]> but expected 'seq[float]'"
+  errormsg: "type mismatch: obtained <seq[int]> expected 'seq[float]'"
   line: 8
 """
 

--- a/tests/errmsgs/t8339.nim
+++ b/tests/errmsgs/t8339.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <seq[int]> expected 'seq[float]'"
+  errormsg: "type mismatch: got 'seq[int]' for '"
   line: 8
 """
 

--- a/tests/errmsgs/tproc_mismatch.nim
+++ b/tests/errmsgs/tproc_mismatch.nim
@@ -3,7 +3,7 @@ discard """
   cmd: '''nim check --hints:off $options $file'''
   nimoutFull: true
   nimout: '''
-tproc_mismatch.nim(35, 52) Error: type mismatch: got <proc (a: int, c: float){.cdecl, noSideEffect, gcsafe, locks: 0.}> but expected 'proc (a: int, c: float){.closure, noSideEffect.}'
+tproc_mismatch.nim(35, 52) Error: type mismatch: got 'proc (a: int, c: float){.cdecl, noSideEffect, gcsafe, locks: 0.}' for 'a', but expected 'proc (a: int, c: float){.closure, noSideEffect.}'
   Calling convention mismatch: got '{.cdecl.}', but expected '{.closure.}'.
 tproc_mismatch.nim(39, 6) Error: type mismatch: got <proc (){.inline, noSideEffect, gcsafe, locks: 0.}>
 but expected one of:
@@ -14,18 +14,18 @@ proc bar(a: proc ())
   Calling convention mismatch: got '{.inline.}', but expected '{.closure.}'.
 
 expression: bar(fn1)
-tproc_mismatch.nim(43, 8) Error: type mismatch: got <proc (){.inline, noSideEffect, gcsafe, locks: 0.}> but expected 'proc (){.closure.}'
+tproc_mismatch.nim(43, 8) Error: type mismatch: got 'proc (){.inline, noSideEffect, gcsafe, locks: 0.}' for 'fn1', but expected 'proc (){.closure.}'
   Calling convention mismatch: got '{.inline.}', but expected '{.closure.}'.
-tproc_mismatch.nim(48, 8) Error: type mismatch: got <proc (){.locks: 0.}> but expected 'proc (){.closure, noSideEffect.}'
+tproc_mismatch.nim(48, 8) Error: type mismatch: got 'proc (){.locks: 0.}' for 'fn1', but expected 'proc (){.closure, noSideEffect.}'
   Pragma mismatch: got '{..}', but expected '{.noSideEffect.}'.
-tproc_mismatch.nim(52, 8) Error: type mismatch: got <proc (a: int){.noSideEffect, gcsafe, locks: 0.}> but expected 'proc (a: float){.closure.}'
-tproc_mismatch.nim(61, 9) Error: type mismatch: got <proc (a: int){.locks: 0.}> but expected 'proc (a: int){.closure, gcsafe.}'
+tproc_mismatch.nim(52, 8) Error: type mismatch: got 'proc (a: int){.noSideEffect, gcsafe, locks: 0.}' for 'fn1', but expected 'proc (a: float){.closure.}'
+tproc_mismatch.nim(61, 9) Error: type mismatch: got 'proc (a: int){.locks: 0.}' for 'fn1', but expected 'proc (a: int){.closure, gcsafe.}'
   Pragma mismatch: got '{..}', but expected '{.gcsafe.}'.
-tproc_mismatch.nim(69, 9) Error: type mismatch: got <proc (a: int): int{.nimcall.}> but expected 'proc (a: int): int{.cdecl.}'
+tproc_mismatch.nim(69, 9) Error: type mismatch: got 'proc (a: int): int{.nimcall.}' for 'fn1', but expected 'proc (a: int): int{.cdecl.}'
   Calling convention mismatch: got '{.nimcall.}', but expected '{.cdecl.}'.
-tproc_mismatch.nim(70, 9) Error: type mismatch: got <proc (a: int): int{.cdecl.}> but expected 'proc (a: int): int{.nimcall.}'
+tproc_mismatch.nim(70, 9) Error: type mismatch: got 'proc (a: int): int{.cdecl.}' for 'fn2', but expected 'proc (a: int): int{.nimcall.}'
   Calling convention mismatch: got '{.cdecl.}', but expected '{.nimcall.}'.
-tproc_mismatch.nim(74, 9) Error: type mismatch: got <proc (a: int){.closure, locks: 3.}> but expected 'proc (a: int){.closure, locks: 1.}'
+tproc_mismatch.nim(74, 9) Error: type mismatch: got 'proc (a: int){.closure, locks: 3.}' for 'fn1', but expected 'proc (a: int){.closure, locks: 1.}'
   Pragma mismatch: got '{.locks: 3.}', but expected '{.locks: 1.}'.
 lock levels differ
 '''

--- a/tests/errmsgs/tshow_asgn.nim
+++ b/tests/errmsgs/tshow_asgn.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <int> but expected 'cshort = int16'"
+  errormsg: "type mismatch: obtained <int> expected 'cshort = int16'"
   line: 12
   column: 27
   file: "tshow_asgn.nim"

--- a/tests/errmsgs/tshow_asgn.nim
+++ b/tests/errmsgs/tshow_asgn.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <int> expected 'cshort = int16'"
+  errormsg: "type mismatch: got 'int' for 'int(x.b - x.a) + x.a', but expected 'cshort = int16'"
   line: 12
   column: 27
   file: "tshow_asgn.nim"

--- a/tests/iter/titerautoerr1.nim
+++ b/tests/iter/titerautoerr1.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <int literal(1)> but expected 'string'"
+  errormsg: "type mismatch: obtained <int literal(1)> expected 'string'"
   line: 8
 """
 

--- a/tests/iter/titerautoerr1.nim
+++ b/tests/iter/titerautoerr1.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <int literal(1)> expected 'string'"
+  errormsg: "type mismatch: got 'int literal(1)' for '1', but expected 'string'"
   line: 8
 """
 

--- a/tests/iter/titerautoerr2.nim
+++ b/tests/iter/titerautoerr2.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <string> but expected 'int literal(1)'"
+  errormsg: "type mismatch: obtained <string> expected 'int literal(1)'"
   line: 8
 """
 

--- a/tests/iter/titerautoerr2.nim
+++ b/tests/iter/titerautoerr2.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <string> expected 'int literal(1)'"
+  errormsg: '''type mismatch: got 'string' for '"str"', but expected 'int literal(1)'''
   line: 8
 """
 

--- a/tests/metatype/typeclassinference.nim
+++ b/tests/metatype/typeclassinference.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <string> but expected 'ptr'"
+  errormsg: "type mismatch: obtained <string> expected 'ptr'"
   line: 20
 """
 

--- a/tests/metatype/typeclassinference.nim
+++ b/tests/metatype/typeclassinference.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <string> expected 'ptr'"
+  errormsg: "type mismatch: got 'string' for 'str2', but expected 'ptr'"
   line: 20
 """
 

--- a/tests/misc/tsimtych.nim
+++ b/tests/misc/tsimtych.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <bool> but expected \'string\'"
+  errormsg: "type mismatch: obtained <bool> expected 'string'"
   file: "tsimtych.nim"
   line: 10
 """

--- a/tests/misc/tsimtych.nim
+++ b/tests/misc/tsimtych.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <bool> expected 'string'"
+  errormsg: "type mismatch: got 'bool' for 'false', but expected 'string'"
   file: "tsimtych.nim"
   line: 10
 """

--- a/tests/typerel/tno_int_in_bool_context.nim
+++ b/tests/typerel/tno_int_in_bool_context.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <int literal(1)> but expected 'bool'"
+  errormsg: "type mismatch: obtained <int literal(1)> expected 'bool'"
   line: 6
 """
 

--- a/tests/typerel/tno_int_in_bool_context.nim
+++ b/tests/typerel/tno_int_in_bool_context.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <int literal(1)> expected 'bool'"
+  errormsg: "type mismatch: got 'int literal(1)' for '1', but expected 'bool'"
   line: 6
 """
 

--- a/tests/typerel/tptrs.nim
+++ b/tests/typerel/tptrs.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <ptr int16> but expected 'ptr int'"
+  errormsg: "type mismatch: obtained <ptr int16> expected 'ptr int'"
   line: 8
 """
 

--- a/tests/typerel/tptrs.nim
+++ b/tests/typerel/tptrs.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <ptr int16> expected 'ptr int'"
+  errormsg: "type mismatch: got 'ptr int16' for 'addr n', but expected 'ptr int'"
   line: 8
 """
 

--- a/tests/typerel/tregionptrs.nim
+++ b/tests/typerel/tregionptrs.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <BPtr> but expected 'APtr = ptr[RegionA, int]'"
+  errormsg: "type mismatch: obtained <BPtr> expected 'APtr = ptr[RegionA, int]'"
   line: 16
 """
 

--- a/tests/typerel/tregionptrs.nim
+++ b/tests/typerel/tregionptrs.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <BPtr> expected 'APtr = ptr[RegionA, int]'"
+  errormsg: "type mismatch: got 'BPtr' for 'y', but expected 'APtr = ptr[RegionA, int]'"
   line: 16
 """
 

--- a/tests/typerel/ttypenoval.nim
+++ b/tests/typerel/ttypenoval.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: got <typedesc[int]> but expected 'int'"
+  errormsg: "type mismatch: obtained <typedesc[int]> expected 'int'"
   file: "ttypenoval.nim"
   line: 38
 """

--- a/tests/typerel/ttypenoval.nim
+++ b/tests/typerel/ttypenoval.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "type mismatch: obtained <typedesc[int]> expected 'int'"
+  errormsg: "type mismatch: got 'typedesc[int]' for 'int', but expected 'int'"
   file: "ttypenoval.nim"
   line: 38
 """


### PR DESCRIPTION
```nim
when true:
  proc fn1(a: int) = discard
  var fn: proc(a: float)
  fn = fn1
```

## before PR
```
Error: type mismatch:
 got 'proc (a: int){.noSideEffect, gcsafe, locks: 0.}' for 'fn1' [proc]
 but expected 'proc (a: float){.closure.}' [proc]
```

## after PR
```
Error: type mismatch:
 obtained 'proc (a: int){.noSideEffect, gcsafe, locks: 0.}' for 'fn1' [proc]
 expected 'proc (a: float){.closure.}' [proc]
```

