### PR TITLE
genDepend: fix for module names that are reserved DOT keywords

### DIFF
--- a/compiler/depends.nim
+++ b/compiler/depends.nim
@@ -25,7 +25,7 @@ type
     dotGraph: Rope
 
 proc addDependencyAux(b: Backend; importing, imported: string) =
-  b.dotGraph.addf("$1 -> \"$2\";$n", [rope(importing), rope(imported)])
+  b.dotGraph.addf("\"$1\" -> \"$2\";$n", [rope(importing), rope(imported)])
   # s1 -> s2_4[label="[0-9]"];
 
 proc addDotDependency(c: PPassContext, n: PNode): PNode =


### PR DESCRIPTION
(like "node" and "edge")

This completes the module name quoting started in https://github.com/nim-lang/Nim/commit/4910a87c6f8ceded56750bd2dc4cd3fe4db55966