### PR TITLE
`toSet(iter, typedesc)` overload, allows converting between set types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -208,7 +208,8 @@
   returning a tuple which can be unpacked for easier usage of `scanf`.
 
 - Added `setutils.toSet` that can take any iterable and convert it to a built-in `set`,
-  if the iterable yields a built-in settable type.
+  if the iterable yields a built-in settable type; it also allows specifying set type
+  to convert between set types.
 
 - Added `setutils.fullSet` which returns a full built-in `set` for a valid type.
 

--- a/changelog.md
+++ b/changelog.md
@@ -208,7 +208,7 @@
   returning a tuple which can be unpacked for easier usage of `scanf`.
 
 - Added `setutils.toSet` that can take any iterable and convert it to a built-in `set`,
-  if the iterable yields a built-in settable type; it also allows specifying set type
+  if the iterable yields a built-in settable type; it also allows specifying the set type
   to convert between set types.
 
 - Added `setutils.fullSet` which returns a full built-in `set` for a valid type.

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -30,6 +30,8 @@ template toSet*[T: set](iter: untyped, _: typedesc[T]): T =
     s1 = s1 + s2.toSet(typeof(s1))
     var s3: set['a'..'z'] = {'a', 'b', 'c'}
     assert s1 == s3
+    assert "abc".toSet(set['a'..'z']) == s3
+    doAssertRaises(RangeDefect): discard "abc".toSet(set['a'..'b'])
   # xxx `s1 == {'a', 'b', 'c'}` fails in above example;
   # it should either succeed or give CT error, refs bug #18396
   var result: T

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -14,14 +14,14 @@
 ## * `std/packedsets <packedsets.html>`_
 ## * `std/sets <sets.html>`_
 
-import macros
+import typetraits, macros
 
 #[
   type SetElement* = char|byte|bool|int16|uint16|enum|uint8|int8
     ## The allowed types of a built-in set.
 ]#
 
-template toSet*[T](iter: iterable[T]): set[T] =
+template toSet*(iter: untyped): untyped =
   ## Returns a built-in set from the elements of the iterable `iter`.
   runnableExamples:
     assert "helloWorld".toSet == {'W', 'd', 'e', 'h', 'l', 'o', 'r'}
@@ -30,20 +30,12 @@ template toSet*[T](iter: iterable[T]): set[T] =
     assert toSet(@[1321i16, 321, 90]) == {90i16, 321, 1321}
     assert toSet([false]) == {false}
     assert toSet(0u8..10) == {0u8..10}
-  var result: set[T]
+
+  var result: set[elementType(iter)]
   for x in iter:
     incl(result, x)
   result
 
-template toSet*[T](iter: openArray[T]): set[T] = toSet(items(iter))
-
-template toSet2*[T, T2](iter: iterable[T], _: typedesc[T2]): set[T2] =
-  var result: set[T2]
-  for x in iter:
-    incl(result, x)
-  result
-
-# template toSet3*[T, T2](iter: iterable[T], _: typedesc[T2]): T2 =
 template toSet3*[T2](iter: untyped, _: typedesc[T2]): T2 =
   var result: T2
   for x in iter:

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -14,14 +14,14 @@
 ## * `std/packedsets <packedsets.html>`_
 ## * `std/sets <sets.html>`_
 
-import typetraits, macros
+import macros
 
 #[
   type SetElement* = char|byte|bool|int16|uint16|enum|uint8|int8
     ## The allowed types of a built-in set.
 ]#
 
-template toSet*(iter: untyped): untyped =
+template toSet*[T](iter: iterable[T]): set[T] =
   ## Returns a built-in set from the elements of the iterable `iter`.
   runnableExamples:
     assert "helloWorld".toSet == {'W', 'd', 'e', 'h', 'l', 'o', 'r'}
@@ -30,8 +30,15 @@ template toSet*(iter: untyped): untyped =
     assert toSet(@[1321i16, 321, 90]) == {90i16, 321, 1321}
     assert toSet([false]) == {false}
     assert toSet(0u8..10) == {0u8..10}
+  var result: set[T]
+  for x in iter:
+    incl(result, x)
+  result
 
-  var result: set[elementType(iter)]
+template toSet*[T](iter: openArray[T]): set[T] = toSet(items(iter))
+
+template toSet2*[T, T2](iter: iterable[T], _: typedesc[T2]): set[T2] =
+  var result: set[T2]
   for x in iter:
     incl(result, x)
   result

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -30,7 +30,8 @@ template toSet*[T: set](iter: untyped, _: typedesc[T]): T =
     s1 = s1 + s2.toSet(typeof(s1))
     var s3: set['a'..'z'] = {'a', 'b', 'c'}
     assert s1 == s3
-  # xxx `s1 == {'a', 'b', 'c'}` fails in above example; it should either succeed or give CT error
+  # xxx `s1 == {'a', 'b', 'c'}` fails in above example;
+  # it should either succeed or give CT error, refs bug #18396
   var result: T
   for x in iter:
     incl(result, x)

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -43,6 +43,13 @@ template toSet2*[T, T2](iter: iterable[T], _: typedesc[T2]): set[T2] =
     incl(result, x)
   result
 
+# template toSet3*[T, T2](iter: iterable[T], _: typedesc[T2]): T2 =
+template toSet3*[T2](iter: untyped, _: typedesc[T2]): T2 =
+  var result: T2
+  for x in iter:
+    incl(result, x)
+  result
+
 macro enumElementsAsSet(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 
 # func fullSet*(T: typedesc): set[T] {.inline.} = # xxx would give: Error: ordinal type expected

--- a/lib/std/setutils.nim
+++ b/lib/std/setutils.nim
@@ -21,8 +21,23 @@ import typetraits, macros
     ## The allowed types of a built-in set.
 ]#
 
-template toSet*(iter: untyped): untyped =
+template toSet*[T: set](iter: untyped, _: typedesc[T]): T =
   ## Returns a built-in set from the elements of the iterable `iter`.
+  runnableExamples:
+    var s1: set['a'..'z'] = {'a', 'c'}
+    var s2: set[char] = {'a', 'b'}
+    assert not compiles(s1 + s2) # incompatible type
+    s1 = s1 + s2.toSet(typeof(s1))
+    var s3: set['a'..'z'] = {'a', 'b', 'c'}
+    assert s1 == s3
+  # xxx `s1 == {'a', 'b', 'c'}` fails in above example; it should either succeed or give CT error
+  var result: T
+  for x in iter:
+    incl(result, x)
+  result
+
+template toSet*(iter: untyped): untyped =
+  ## Overload that infers the set type.
   runnableExamples:
     assert "helloWorld".toSet == {'W', 'd', 'e', 'h', 'l', 'o', 'r'}
     assert toSet([10u16, 20, 30]) == {10u16, 20, 30}
@@ -30,17 +45,7 @@ template toSet*(iter: untyped): untyped =
     assert toSet(@[1321i16, 321, 90]) == {90i16, 321, 1321}
     assert toSet([false]) == {false}
     assert toSet(0u8..10) == {0u8..10}
-
-  var result: set[elementType(iter)]
-  for x in iter:
-    incl(result, x)
-  result
-
-template toSet3*[T2](iter: untyped, _: typedesc[T2]): T2 =
-  var result: T2
-  for x in iter:
-    incl(result, x)
-  result
+  toSet(iter, set[elementType(iter)])
 
 macro enumElementsAsSet(enm: typed): untyped = result = newNimNode(nnkCurly).add(enm.getType[1][1..^1])
 

--- a/tests/sets/tsets.nim
+++ b/tests/sets/tsets.nim
@@ -1,5 +1,15 @@
 # Test builtin sets
 
+template main =
+  var s1: set[char] = {'a', 'b'}
+  var s2: set['a'..'z'] = {'a', 'c'}
+  s2 = s2 + s1
+  echo s2
+
+static: main()
+main()
+
+
 # xxx these tests are not very good, this should be revisited.
 
 when defined nimTestsTsetsGenerate:

--- a/tests/sets/tsets.nim
+++ b/tests/sets/tsets.nim
@@ -1,16 +1,30 @@
+discard """
+  targets: "c cpp js"
+"""
+
 # Test builtin sets
 
 template main =
-  var s1: set[char] = {'a', 'b'}
-  var s2: set['a'..'z'] = {'a', 'c'}
-  s2 = s2 + s1
-  echo s2
+  block:
+    var s1: set[char] = {'a', 'b'}
+    var s2: set['a'..'z'] = {'a', 'c'}
+    doAssert not compiles(s1 + s2)
+    doAssert not compiles(s2 + s1)
+    doAssert not compiles(s1 == s2)
+    doAssert not compiles(s2 == s1)
+    doAssert s1 + s1 == s1
+    doAssert s2 + s2 == s2
+    doAssert s1 + s1 == {'a', 'b'}
+    when false:
+      # xxx this fails in c, js, vm and gives cgen error in cpp
+      # it should either give CT error or succeed (special casing literal)
+      doAssert s2 == {'a', 'b'}
 
 static: main()
 main()
 
 
-# xxx these tests are not very good, this should be revisited.
+# xxx the tests below should be improved and merged inside `main`.
 
 when defined nimTestsTsetsGenerate:
   # to generate enums for this test

--- a/tests/sets/tsets.nim
+++ b/tests/sets/tsets.nim
@@ -16,9 +16,9 @@ template main =
     doAssert s2 + s2 == s2
     doAssert s1 + s1 == {'a', 'b'}
     when false:
-      # xxx this fails in c, js, vm and gives cgen error in cpp
-      # it should either give CT error or succeed (special casing literal)
-      doAssert s2 == {'a', 'b'}
+      # xxx this fails in c, , succeeds in vm,js, and gives cgen error in cpp.
+      # refs bug #18396
+      doAssert s2 == {'a', 'c'}
 
 static: main()
 main()


### PR DESCRIPTION
follows https://github.com/nim-lang/Nim/pull/18388

## example
```nim
var s1: set['a'..'z'] = {'a', 'c'}
var s2: set[char] = {'a', 'b'}
# let s = s1 + s2 # now a CT error (as it should) now that https://github.com/nim-lang/Nim/issues/16270 was fixed
let s = s1 + s2.toSet(typeof(s1)) # ok
```