### PR TITLE
Missing spaces when compiling testament and nim_dbg.

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -215,14 +215,14 @@ proc buildTools(args: string = "") =
                  options = "-d:release " & args)
   when defined(windows): buildVccTool(args)
   bundleNimpretty(args)
-  nimCompileFold("Compile testament", "testament/testament.nim", options = "-d:release" & args)
+  nimCompileFold("Compile testament", "testament/testament.nim", options = "-d:release " & args)
 
   # pre-packages a debug version of nim which can help in many cases investigate issuses
   # withouth having to rebuild compiler.
   # `-d:nimDebugUtils` only makes sense when temporarily editing/debugging compiler
   # `-d:debug` should be changed to a flag that doesn't require re-compiling nim
   # `--opt:speed` is a sensible default even for a debug build, it doesn't affect nim stacktraces
-  nimCompileFold("Compile nim_dbg", "compiler/nim.nim", options = "--opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints" & args, outputName = "nim_dbg")
+  nimCompileFold("Compile nim_dbg", "compiler/nim.nim", options = "--opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints " & args, outputName = "nim_dbg")
 
 proc nsis(latest: bool; args: string) =
   bundleNimbleExe(latest, args)

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -913,7 +913,7 @@ proc getTime*(): Time {.tags: [TimeEffect], benign.} =
     result = initTime(ts.tv_sec.int64, ts.tv_nsec.int)
   elif defined(windows):
     var f {.noinit.}: FILETIME
-    getSystemTimePreciseAsFileTime(f)
+    getSystemTimeAsFileTime(f)
     result = fromWinTime(rdFileTime(f))
 
 proc `-`*(a, b: Time): Duration {.operator, extern: "ntDiffTime".} =
@@ -2596,7 +2596,7 @@ proc epochTime*(): float {.tags: [TimeEffect].} =
       toBiggestFloat(ts.tv_nsec.int64) / 1_000_000_000
   elif defined(windows):
     var f {.noinit.}: winlean.FILETIME
-    getSystemTimePreciseAsFileTime(f)
+    getSystemTimeAsFileTime(f)
     var i64 = rdFileTime(f) - epochDiff
     var secs = i64 div rateDiff
     var subsecs = i64 mod rateDiff


### PR DESCRIPTION
Looks like koch tools are failing for testament and nim_dbg if additional args are passed, like this:
`koch tools -d:release`