### PR TITLE
don't use `{.rtl.}` for generics, otherwise `-d:useNimRtl` gives `ambiguous identifier` nimrtl error

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1760,7 +1760,7 @@ func join*(a: openArray[string], sep: string = ""): string {.rtl,
   else:
     result = ""
 
-func join*[T: not string](a: openArray[T], sep: string = ""): string {.rtl.} =
+func join*[T: not string](a: openArray[T], sep: string = ""): string =
   ## Converts all elements in the container `a` to strings using `$`,
   ## and concatenates them with `sep`.
   runnableExamples:

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -30,15 +30,17 @@ when defined(createNimRtl):
   {.pragma: inl.}
   {.pragma: compilerRtl, compilerproc, exportc: "nimrtl_$1", dynlib.}
 elif defined(useNimRtl):
-  when defined(windows):
-    const nimrtl* = "nimrtl.dll"
-  elif defined(macosx):
-    const nimrtl* = "libnimrtl.dylib"
-  else:
-    const nimrtl* = "libnimrtl.so"
-  {.pragma: rtl, importc: "nimrtl_$1", dynlib: nimrtl, gcsafe.}
+  when not declared(nimrtlInclrtl):
+    # `when` needed because otherwise this could give `ambiguous identifier:` errors.
+    # xxx we should instead improve pragmas so that symbol binding happens,
+    # as well as allow a way to export pragamas, to avoid inclrtl being an include.
+    const nimrtlInclrtl* =
+      when defined(windows): "nimrtl.dll"
+      elif defined(macosx): "libnimrtl.dylib"
+      else: "libnimrtl.so"
+  {.pragma: rtl, importc: "nimrtl_$1", dynlib: nimrtlInclrtl, gcsafe.}
   {.pragma: inl.}
-  {.pragma: compilerRtl, compilerproc, importc: "nimrtl_$1", dynlib: nimrtl.}
+  {.pragma: compilerRtl, compilerproc, importc: "nimrtl_$1", dynlib: nimrtlInclrtl.}
 else:
   {.pragma: rtl, gcsafe.}
   {.pragma: inl, inline.}

--- a/lib/system/inclrtl.nim
+++ b/lib/system/inclrtl.nim
@@ -30,17 +30,16 @@ when defined(createNimRtl):
   {.pragma: inl.}
   {.pragma: compilerRtl, compilerproc, exportc: "nimrtl_$1", dynlib.}
 elif defined(useNimRtl):
-  when not declared(nimrtlInclrtl):
-    # `when` needed because otherwise this could give `ambiguous identifier:` errors.
-    # xxx we should instead improve pragmas so that symbol binding happens,
-    # as well as allow a way to export pragamas, to avoid inclrtl being an include.
-    const nimrtlInclrtl* =
-      when defined(windows): "nimrtl.dll"
-      elif defined(macosx): "libnimrtl.dylib"
-      else: "libnimrtl.so"
-  {.pragma: rtl, importc: "nimrtl_$1", dynlib: nimrtlInclrtl, gcsafe.}
+  #[
+  `{.rtl.}` should only be used for non-generic procs.
+  ]#
+  const nimrtl* =
+    when defined(windows): "nimrtl.dll"
+    elif defined(macosx): "libnimrtl.dylib"
+    else: "libnimrtl.so"
+  {.pragma: rtl, importc: "nimrtl_$1", dynlib: nimrtl, gcsafe.}
   {.pragma: inl.}
-  {.pragma: compilerRtl, compilerproc, importc: "nimrtl_$1", dynlib: nimrtlInclrtl.}
+  {.pragma: compilerRtl, compilerproc, importc: "nimrtl_$1", dynlib: nimrtl.}
 else:
   {.pragma: rtl, gcsafe.}
   {.pragma: inl, inline.}

--- a/tests/dll/client.nim
+++ b/tests/dll/client.nim
@@ -1,5 +1,4 @@
 discard """
-  output: "Done"
   cmd: "nim $target --debuginfo --hints:on --define:useNimRtl $options $file"
 """
 
@@ -37,5 +36,8 @@ proc eval(n: PNode): int =
 for i in 0..100_000:
   discard eval(buildTree(2))
 
-echo "Done"
-
+# bug https://forum.nim-lang.org/t/8176; Error: ambiguous identifier: 'nimrtl'
+import std/strutils
+doAssert join(@[1, 2]) == "12"
+doAssert join(@[1.5, 2.5]) == "1.52.5"
+doAssert join(@["a", "bc"]) == "abc"


### PR DESCRIPTION
* fix https://forum.nim-lang.org/t/8176 /cc @bung87


## future work
- [ ] make pragmas do symbol resolution so that symbols are bound, to avoid exporting something from an include file
- [x] test -d:useNimRtl in nim CI (it started to bitrot, see also https://github.com/nim-lang/Nim/pull/18399)
- [ ] allow exporting pragmas so that we don't need include files like inclrlt (IIRC i had some PRs for that that need revisiting)

## CI failure seems unrelated
```
2021-06-30T19:35:21.9740340Z Test nimsuggest/tests/tdef_forward.nim
2021-06-30T19:35:23.9987130Z Test nimsuggest/tests/tdot1.nim
2021-06-30T19:35:25.4153050Z Test nimsuggest/tests/tdot2.nim
2021-06-30T19:35:27.5948280Z Test nimsuggest/tests/tdot3.nim
2021-06-30T19:35:31.4240770Z ==== EPC ========================================
2021-06-30T19:35:31.4241080Z 
2021-06-30T19:35:31.4241460Z Test failed: /Users/runner/work/1/s/nimsuggest/tests/tdot3.nim
2021-06-30T19:35:31.4241900Z   Expected:  Field	x	int	*dep.nim	8	4	""	100	None
2021-06-30T19:35:31.4242350Z sug	skField	y	int	*dep.nim	8	8	""	100	None
2021-06-30T19:35:31.4242890Z sug	skField	z	string	*dep.nim	9	4	""	100	None
2021-06-30T19:35:31.4243350Z sug	skProc	tdot3.main	proc (f: Foo)	/Users/runner/work/1/s/nimsuggest/tests
2021-06-30T19:35:31.4244030Z   But got:   Proc	tdot3.main	proc (f: Error Type)	/Users/runner/work/1/s/nimsuggest/tests/tdot3.nim	5	5	""	100	None
2021-06-30T19:35:31.4244720Z sug	skProc	system.add	proc (x: var string, y: string){.noSideEffect, gcsafe, locks: 0.}	/Users/run
2021-06-30T19:35:31.4245240Z Test nimsuggest/tests/tdot4.nim
2021-06-30T19:35:32.7939540Z Test nimsuggest/tests/tgeneric_highlight.nim
```