### PR TITLE
fix #17898(alternative to #18149 randomPathName called twice in a row can return the same string on windows)

### DIFF
--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -5,7 +5,7 @@ internal API for now, API subject to change
 # xxx move other git utilities here; candidate for stdlib.
 
 import std/[os, osproc, strutils, random]
-from std/tempfiles {.all.} import genTempPath
+from std/tempfiles import genTempPath
 
 const commitHead* = "HEAD"
 

--- a/lib/std/private/gitutils.nim
+++ b/lib/std/private/gitutils.nim
@@ -4,7 +4,8 @@ internal API for now, API subject to change
 
 # xxx move other git utilities here; candidate for stdlib.
 
-import std/[os, osproc, strutils, tempfiles]
+import std/[os, osproc, strutils, random]
+from std/tempfiles {.all.} import genTempPath
 
 const commitHead* = "HEAD"
 
@@ -66,12 +67,13 @@ proc diffStrings*(a, b: string): tuple[output: string, same: bool] =
     let b = "ok1\nok2 alt\nok3\nok4\n"
     echo diffStrings(a, b).output
 
-  template tmpFileImpl(prefix, str): auto =
-    let path = genTempPath(prefix, "")
+  template tmpFileImpl(state, prefix, str): auto =
+    let path = genTempPath(state, prefix, "")
     writeFile(path, str)
     path
-  let patha = tmpFileImpl("diffStrings_a_", a)
-  let pathb = tmpFileImpl("diffStrings_b_", b)
+  var state = initRand()
+  let patha = tmpFileImpl(state, "diffStrings_a_", a)
+  let pathb = tmpFileImpl(state, "diffStrings_b_", b)
   defer:
     removeFile(patha)
     removeFile(pathb)

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -137,9 +137,8 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
   # xxx why does above work without `cfile.flushFile` ?
   let dir = getTempDirImpl(dir)
 
-  var state: Rand
+  var state = initRand()
   for i in 0 ..< maxRetry:
-    state = initRand()
     result.path = genTempPath(state, prefix, suffix, dir)
     result.cfile = safeOpen(result.path)
     if result.cfile != nil:
@@ -165,9 +164,8 @@ proc createTempDir*(prefix, suffix: string, dir = ""): string =
     assert dirExists(dir)
     removeDir(dir)
   let dir = getTempDirImpl(dir)
-  var state: Rand
+  var state = initRand()
   for i in 0 ..< maxRetry:
-    state = initRand()
     result = genTempPath(state, prefix, suffix, dir)
     if not existsOrCreateDir(result):
       return

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -107,7 +107,7 @@ proc getTempDirImpl(dir: string): string {.inline.} =
   if result.len == 0:
     result = getTempDir()
 
-proc genTempPath(state: var Rand, prefix, suffix: string, dir = ""): string {.inline.} =
+proc genTempPath*(state: var Rand, prefix, suffix: string, dir = ""): string {.inline.} =
   ## Generates a path name in `dir`.
   ##
   ## If `dir` is empty, (`getTempDir <os.html#getTempDir>`_) will be used.
@@ -118,9 +118,9 @@ proc genTempPath(state: var Rand, prefix, suffix: string, dir = ""): string {.in
 proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path: string] =
   ## Creates a new temporary file in the directory `dir`.
   ## 
-  ## This generates a path name and returns a file handle
-  ## to an open file and the path of that file, possibly after
-  ## retrying to ensure it doesn't already exist.
+  ## This generates a path name using `genTempPath(state, prefix, suffix, dir)` and
+  ## returns a file handle and returns a file handle to an open file and 
+  ## the path of that file, possibly after retrying to ensure it doesn't already exist.
   ## 
   ## If failing to create a temporary file, `OSError` will be raised.
   ##
@@ -153,7 +153,8 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
 proc createTempDir*(prefix, suffix: string, dir = ""): string =
   ## Creates a new temporary directory in the directory `dir`.
   ##
-  ## This generates a dir name and creates the directory and returns it,
+  ## This generates a dir name using `genTempPath(state prefix, suffix, dir)`,
+  ## returns a file handle and creates the directory and returns it,
   ## possibly after retrying to ensure it doesn't already exist.
   ##
   ## If failing to create a temporary directory, `OSError` will be raised.

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -137,8 +137,9 @@ proc createTempFile*(prefix, suffix: string, dir = ""): tuple[cfile: File, path:
   # xxx why does above work without `cfile.flushFile` ?
   let dir = getTempDirImpl(dir)
 
+  var state: Rand
   for i in 0 ..< maxRetry:
-    var state = initRand()
+    state = initRand()
     result.path = genTempPath(state, prefix, suffix, dir)
     result.cfile = safeOpen(result.path)
     if result.cfile != nil:
@@ -164,8 +165,9 @@ proc createTempDir*(prefix, suffix: string, dir = ""): string =
     assert dirExists(dir)
     removeDir(dir)
   let dir = getTempDirImpl(dir)
+  var state: Rand
   for i in 0 ..< maxRetry:
-    var state = initRand()
+    state = initRand()
     result = genTempPath(state, prefix, suffix, dir)
     if not existsOrCreateDir(result):
       return

--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -108,6 +108,10 @@ proc getTempDirImpl(dir: string): string {.inline.} =
     result = getTempDir()
 
 proc genTempPath(state: var Rand, prefix, suffix: string, dir = ""): string {.inline.} =
+  ## Generates a path name in `dir`.
+  ##
+  ## If `dir` is empty, (`getTempDir <os.html#getTempDir>`_) will be used.
+  ## The path begins with `prefix` and ends with `suffix`.
   let dir = getTempDirImpl(dir)
   result = dir / (prefix & randomPathName(state, nimTempPathLength) & suffix)
 


### PR DESCRIPTION
close #17898