### PR TITLE
Add compilers and hints to default nim.cfg

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -2,6 +2,7 @@
 # (c) 2017 Andreas Rumpf
 
 # Feel free to edit the default values as you need.
+# See https://nim-lang.org/docs/nimc.html
 
 # You may set environment variables with
 # @putenv "key" "val"
@@ -17,11 +18,21 @@ hint[LineTooLong]=off
 #hint[XDeclaredButNotUsed]=off
 
 # Examples of how to setup a cross-compiler:
+# Nim can target architectures and OSes different than the local host
+# Syntax: <arch>.<os>.gcc.exe = "<compiler executable>"
+#         <arch>.<os>.gcc.linkerexe = "<linker executable>"
 
-# Cross-compiling for Raspberry Pi.
-# (This compiler is available in gcc-arm-linux-gnueabihf package on Ubuntu)
+# ARM e.g. Raspberry Pi 2: gcc-arm-linux-gnueabihf package on Debian/Ubuntu
 arm.linux.gcc.exe = "arm-linux-gnueabihf-gcc"
 arm.linux.gcc.linkerexe = "arm-linux-gnueabihf-gcc"
+# ARM64/aarch64 e.g. Raspberry Pi 3: gcc-aarch64-linux-gnu package on Debian/Ubuntu
+arm64.linux.gcc.exe = "aarch64-linux-gnu-gcc"
+arm64.linux.gcc.linkerexe = "aarch64-linux-gnu-gcc"
+# RISC-V: gcc-riscv64-linux-gnu package on Debian/Ubuntu
+riscv32.linux.gcc.exe = "riscv64-linux-gnu-gcc"
+riscv32.linux.gcc.linkerexe = "riscv64-linux-gnu-gcc"
+riscv64.linux.gcc.exe = "riscv64-linux-gnu-gcc"
+riscv64.linux.gcc.linkerexe = "arm-linux-gnueabihf-gcc"
 
 # For OpenWRT, you will also need to adjust PATH to point to your toolchain.
 mips.linux.gcc.exe = "mips-openwrt-linux-gcc"


### PR DESCRIPTION
Add a bit of documentation and a default configuration for some common use cases.

Perhaps it's worth splitting nim.cfg in multiple files for different (local) OSes and pick the right one in the installer or during packaging.
