### PR TITLE
Arrow sugar for funcs

### DIFF
--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -28,8 +28,7 @@ proc insertPragma(ex: var NimNode; p: NimNode) =
       )
     ex[1].add p
 
-proc createProcType(p, b: NimNode):
-    NimNode =
+proc createProcType(p, b: NimNode): NimNode =
   result = newNimNode(nnkProcTy)
   var
     formalParams = newNimNode(nnkFormalParams).add(b)

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -63,6 +63,18 @@ template main() =
     doAssert $((float) {.inline.} -> int) == "proc (i0: float): int{.inline.}"
     doAssert $((float, bool) {.inline.} -> int) == "proc (i0: float, i1: bool): int{.inline.}"
 
+  block: # `!=>`
+    block:
+      let f1 = (x: int) !=> x + 1
+      doAssert f1(42) == 43
+
+    block:
+      proc call1(f: () !-> int): int = f()
+      doAssert call1(() !=> 12) == 12
+
+  block: # `!->`
+    doAssert $(float !-> int) == "proc (i0: float): int{.closure, noSideEffect.}"
+    
   block: # capture
     var closure1: () -> int
     for i in 0 .. 10:

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -74,7 +74,7 @@ template main() =
 
   block: # `!->`
     doAssert $(float !-> int) == "proc (i0: float): int{.closure, noSideEffect.}"
-    
+
   block: # capture
     var closure1: () -> int
     for i in 0 .. 10:


### PR DESCRIPTION
Description
---------------
Introduces `!->` as sugar for `func` types and `!=>` for `func` definitions, analogous to the arrow operators for `proc`. The `!` symbolizes the stricter context rules of `func`.

Motivation
--------------
- Consistency: since there are separate keywords `proc` and `func`, there should be sugar for both.
- Convenience:  `int !-> int` vs `int {.noSideEffect.} -> int`