### PR TITLE
fix compilation on Debian 7 (no git -C)

### DIFF
--- a/build_all.bat
+++ b/build_all.bat
@@ -10,7 +10,7 @@ SET nim_csources=bin\nim_csources_%nim_csourcesHash%.exe
 echo "building from csources: %nim_csources%"
 
 if not exist %nim_csourcesDir% (
-  git clone -q --depth 1 %nim_csourcesUrl% %nim_csourcesDir%
+  git clone -q --depth 1 -b %nim_csourcesBranch% %nim_csourcesUrl% %nim_csourcesDir%
 )
 
 if not exist %nim_csources% (

--- a/ci/build_autogen.bat
+++ b/ci/build_autogen.bat
@@ -10,7 +10,7 @@ SET nim_csources=bin\nim_csources_%nim_csourcesHash%.exe
 echo "building from csources: %nim_csources%"
 
 if not exist %nim_csourcesDir% (
-  git clone -q --depth 1 %nim_csourcesUrl% %nim_csourcesDir%
+  git clone -q --depth 1 -b %nim_csourcesBranch% %nim_csourcesUrl% %nim_csourcesDir%
 )
 
 if not exist %nim_csources% (

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -120,7 +120,8 @@ nimBuildCsourcesIfNeeded(){
       else
         # Note: using git tags would allow fetching just what's needed, unlike git hashes, e.g.
         # via `git clone -q --depth 1 --branch $tag $nim_csourcesUrl`.
-        echo_run git clone -q --depth 1 $nim_csourcesUrl "$nim_csourcesDir"
+        echo_run git clone -q --depth 1 -b $nim_csourcesBranch \
+            $nim_csourcesUrl "$nim_csourcesDir"
         # old `git` versions don't support -C option, using `cd` explicitly:
         echo_run cd "$nim_csourcesDir"
         echo_run git checkout $nim_csourcesHash

--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -121,7 +121,10 @@ nimBuildCsourcesIfNeeded(){
         # Note: using git tags would allow fetching just what's needed, unlike git hashes, e.g.
         # via `git clone -q --depth 1 --branch $tag $nim_csourcesUrl`.
         echo_run git clone -q --depth 1 $nim_csourcesUrl "$nim_csourcesDir"
-        echo_run git -C "$nim_csourcesDir" checkout $nim_csourcesHash
+        # old `git` versions don't support -C option, using `cd` explicitly:
+        echo_run cd "$nim_csourcesDir"
+        echo_run git checkout $nim_csourcesHash
+        echo_run cd "$OLDPWD"
         # if needed we could also add: `git reset --hard $nim_csourcesHash`
       fi
       _nimBuildCsourcesIfNeeded "$@"

--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,5 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
 nim_csourcesUrl=https://github.com/nim-lang/csources_v1.git
-nim_csourcesBranch=fix-old-glibc
-nim_csourcesHash=fix-old-glibc
+nim_csourcesBranch=master
+nim_csourcesHash=9a7f751d23c49c75a0b6f63a234c575dc0df7231

--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,5 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
-nim_csourcesUrl=https://github.com/nim-lang/csources_v1.git
+nim_csourcesUrl=https://github.com/a-mr/csources_v1.git
 nim_csourcesBranch=fix-old-glibc
 nim_csourcesHash=fix-old-glibc

--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,4 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
 nim_csourcesUrl=https://github.com/nim-lang/csources_v1.git
-nim_csourcesHash=a8a5241f9475099c823cfe1a5e0ca4022ac201ff
+nim_csourcesBranch=fix-old-glibc
+nim_csourcesHash=fix-old-glibc

--- a/config/build_config.txt
+++ b/config/build_config.txt
@@ -1,5 +1,5 @@
 nim_comment="key-value pairs for windows/posix bootstrapping build scripts"
 nim_csourcesDir=csources_v1
-nim_csourcesUrl=https://github.com/a-mr/csources_v1.git
+nim_csourcesUrl=https://github.com/nim-lang/csources_v1.git
 nim_csourcesBranch=fix-old-glibc
 nim_csourcesHash=fix-old-glibc

--- a/tools/ci_generate.nim
+++ b/tools/ci_generate.nim
@@ -61,7 +61,7 @@ SET nim_csources=bin\nim_csources_%nim_csourcesHash%.exe
 echo "building from csources: %nim_csources%"
 
 if not exist %nim_csourcesDir% (
-  git clone -q --depth 1 %nim_csourcesUrl% %nim_csourcesDir%
+  git clone -q --depth 1 -b %nim_csourcesBranch% %nim_csourcesUrl% %nim_csourcesDir%
 )
 
 if not exist %nim_csources% (

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -31,7 +31,7 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
     let saveDir = getCurrentDir()
     setCurrentDir(destDir2)
     try:
-      execRetry fmt"git fetch -q"
+      execRetry "git fetch -q"
       exec fmt"git checkout -q {commit}"
     finally:
       setCurrentDir(saveDir)

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -28,13 +28,13 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
     # from failing
     execRetry fmt"git clone -q {url} {destDir2}"
   if isGitRepo(destDir):
-    let saveDir = getCurrentDir()
+    let oldDir = getCurrentDir()
     setCurrentDir(destDir2)
     try:
       execRetry fmt"git fetch -q"
       exec fmt"git checkout -q {commit}"
     finally:
-      setCurrentDir(saveDir)
+      setCurrentDir(oldDir)
   elif allowBundled:
     discard "this dependency was bundled with Nim, don't do anything"
   else:

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -30,9 +30,11 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
   if isGitRepo(destDir):
     let saveDir = getCurrentDir()
     setCurrentDir(destDir2)
-    execRetry fmt"git fetch -q"
-    exec fmt"git checkout -q {commit}"
-    setCurrentDir(saveDir)
+    try:
+      execRetry fmt"git fetch -q"
+      exec fmt"git checkout -q {commit}"
+    finally:
+      setCurrentDir(saveDir)
   elif allowBundled:
     discard "this dependency was bundled with Nim, don't do anything"
   else:

--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -28,8 +28,11 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
     # from failing
     execRetry fmt"git clone -q {url} {destDir2}"
   if isGitRepo(destDir):
-    execRetry fmt"git -C {destDir2} fetch -q"
-    exec fmt"git -C {destDir2} checkout -q {commit}"
+    let saveDir = getCurrentDir()
+    setCurrentDir(destDir2)
+    execRetry fmt"git fetch -q"
+    exec fmt"git checkout -q {commit}"
+    setCurrentDir(saveDir)
   elif allowBundled:
     discard "this dependency was bundled with Nim, don't do anything"
   else:

--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -25,7 +25,8 @@ endif
 
 ifeq ($(uos),linux)
   myos = linux
-  LDFLAGS += -ldl -lm
+  # add -lrt to avoid "undefined reference to `clock_gettime'" with glibc<2.17
+  LDFLAGS += -ldl -lm -lrt
 endif
 ifeq ($(uos),dragonfly)
   myos = freebsd


### PR DESCRIPTION
`git -C` is not available on older Linux'es
> The -C option was added in version 1.8.5 of git, which was released in 2013

Also https://github.com/nim-lang/csources_v1/pull/2 is required to compile it successfully.

May help with https://github.com/nim-lang/Nim/pull/18213 (cc @FedericoCeratto )