### PR TITLE
major improvements to `std/wrapnils`: optimal codegen, case objects, lvalue semantics

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -280,8 +280,8 @@
   for modules importing `std/wrapnils`.
   Added `??.` macro which returns an `Option`.
   `std/wrapnils` can now be used to protect against `FieldDefect` errors in
-  case objects. It now generates optimal code (no overhead compared to manual
-  if-else branches). It preserves lvalue semantics which allows modifying
+  case objects, generates optimal code (no overhead compared to manual
+  if-else branches), and preserves lvalue semantics which allows modifying
   an expression.
 
 - Added `math.frexp` overload procs. Deprecated `c_frexp`, use `frexp` instead.

--- a/changelog.md
+++ b/changelog.md
@@ -279,6 +279,10 @@
   issues like https://github.com/nim-lang/Nim/issues/13063 (which affected error messages)
   for modules importing `std/wrapnils`.
   Added `??.` macro which returns an `Option`.
+  `std/wrapnils` can now be used to protect against `FieldDefect` errors in
+  case objects. It now generates optimal code (no overhead compared to manual
+  if-else branches). It preserves lvalue semantics which allows modifying
+  an expression.
 
 - Added `math.frexp` overload procs. Deprecated `c_frexp`, use `frexp` instead.
 

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -63,7 +63,7 @@ proc finalize(n: NimNode, lhs: NimNode, level: int): NimNode =
 proc process(n: NimNode, lhs: NimNode, level: int): NimNode =
   var n = n.copyNimTree
   var it = n
-  let unsafeAddr2 = bindSym"unsafeAddr"
+  let addr2 = bindSym"addr"
   var old: tuple[n: NimNode, index: int]
   while true:
     if it.len == 0:
@@ -72,7 +72,7 @@ proc process(n: NimNode, lhs: NimNode, level: int): NimNode =
     elif it.kind == nnkCheckedFieldExpr:
       let dot = it[0]
       let obj = dot[0]
-      let objRef = quote do: `unsafeAddr2`(`obj`)
+      let objRef = quote do: `addr2`(`obj`)
         # avoids a copy and preserves lvalue semantics, see tests
       let check = it[1]
       let okSet = check[1]

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -103,7 +103,6 @@ macro `?.`*(a: typed): auto =
     block:
       `body`
     `lhs`
-  dbg result.repr
 
 # the code below is not needed for `?.`
 from options import Option, isSome, get, option, unsafeGet, UnpackDefect

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -41,6 +41,7 @@ import timn/dbgs
 proc process(n: NimNode, lhs: NimNode, level: int): NimNode =
   var n = n.copyNimTree
   var it = n
+  var pit = n.addr
   let unsafeAddr2 = bindSym"unsafeAddr"
   while true:
     dbg it.repr
@@ -52,7 +53,6 @@ proc process(n: NimNode, lhs: NimNode, level: int): NimNode =
       let obj = dot[0]
       let objRef = quote do: `unsafeAddr2`(`obj`)
         # avoids a copy and preserves lvalue semantics
-      # let check = n[1]
       let check = it[1]
       dbg check.repr
       dbg check.treeRepr

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -2,7 +2,7 @@
 ## * nil dereferences
 ## * field accesses with incorrect discriminant in case objects
 ##
-## A default value is returned in those cases.
+## `default(T)` is returned in those cases when evaluating an expression of type `T`.
 ## This simplifies code by reducing need for if-else branches.
 ##
 ## Note: experimental module, unstable API.

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -103,6 +103,7 @@ macro `?.`*(a: typed): auto =
     block:
       `body`
     `lhs`
+  dbg result.repr
 
 # the code below is not needed for `?.`
 from options import Option, isSome, get, option, unsafeGet, UnpackDefect

--- a/tests/stdlib/twrapnils.nim
+++ b/tests/stdlib/twrapnils.nim
@@ -175,12 +175,13 @@ proc main() =
     doAssert ?.identity(a.d) == nil
     doAssert ?.identity(a.d.i4) == 0
 
-  block: # ref semantic propagation
+  block: # lvalue semantic propagation
     type
       A = ref object
         a0: A
         a1: seq[A]
         a2: int
+
       B = object
         b0: int
         case cond: bool
@@ -202,13 +203,17 @@ proc main() =
 
     block:
       var b = B(cond: false, b0: 3)
-      let p = ?.addr(b.b1)
+      let p = ?.b.b1.addr
       doAssert p == nil
       b = B(cond: true, b1: 4.5)
-      let p2 = ?.addr(b.b1)
+      let p2 = ?.b.b1.addr
       doAssert p2 != nil
       p2[] = 4.6
       doAssert b.b1 == 4.6
+      # useful pattern, impossible with Options
+      if (let p3 = ?.b.b1.addr; p3 != nil):
+        p3[] = 4.7
+      doAssert b.b1 == 4.7
 
 main()
 static: main()

--- a/tests/stdlib/twrapnils.nim
+++ b/tests/stdlib/twrapnils.nim
@@ -175,14 +175,13 @@ proc main() =
     doAssert ?.identity(a.d) == nil
     doAssert ?.identity(a.d.i4) == 0
 
-  block:
+  block: # ref semantic propagation
     type
       A = ref object
         a0: A
         a1: seq[A]
         a2: int
       B = object
-      # B = ref object
         b0: int
         case cond: bool
         of false: discard
@@ -203,12 +202,13 @@ proc main() =
 
     block:
       var b = B(cond: false, b0: 3)
-      when false:
-        let p = ?.addr(b.b1)
-      # let p = ?.b.b1.addr
-      # let p = ?.b.b1.unsafeAddr
-      # let p = ?.b.b1
-      # doAssert p == nil
+      let p = ?.addr(b.b1)
+      doAssert p == nil
+      b = B(cond: true, b1: 4.5)
+      let p2 = ?.addr(b.b1)
+      doAssert p2 != nil
+      p2[] = 4.6
+      doAssert b.b1 == 4.6
 
 main()
 static: main()

--- a/tests/stdlib/twrapnils.nim
+++ b/tests/stdlib/twrapnils.nim
@@ -7,80 +7,208 @@ proc checkNotZero(x: float): float =
 
 proc main() =
   var witness = 0
-  type Bar = object
-    b1: int
-    b2: ptr string
+  block:
+    type Bar = object
+      b1: int
+      b2: ptr string
 
-  type Foo = ref object
-    x1: float
-    x2: Foo
-    x3: string
-    x4: Bar
-    x5: seq[int]
-    x6: ptr Bar
-    x7: array[2, string]
-    x8: seq[int]
-    x9: ref Bar
+    type Foo = ref object
+      x1: float
+      x2: Foo
+      x3: string
+      x4: Bar
+      x5: seq[int]
+      x6: ptr Bar
+      x7: array[2, string]
+      x8: seq[int]
+      x9: ref Bar
 
-  type Gook = ref object
-    foo: Foo
+    type Gook = ref object
+      foo: Foo
 
-  proc fun(a: Bar): auto = a.b2
+    proc fun(a: Bar): auto = a.b2
 
-  var a: Foo
+    var a: Foo
 
-  var x6: ptr Bar
-  when nimvm: discard # pending https://github.com/timotheecour/Nim/issues/568
-  else:
-    x6 = create(Bar)
-    x6.b1 = 42
-  var a2 = Foo(x1: 1.0, x5: @[10, 11], x6: x6)
-  var a3 = Foo(x1: 1.2, x3: "abc")
-  a3.x2 = a3
+    var x6: ptr Bar
+    when nimvm: discard # pending https://github.com/timotheecour/Nim/issues/568
+    else:
+      x6 = create(Bar)
+      x6.b1 = 42
+    var a2 = Foo(x1: 1.0, x5: @[10, 11], x6: x6)
+    var a3 = Foo(x1: 1.2, x3: "abc")
+    a3.x2 = a3
 
-  var gook = Gook(foo: a)
+    var gook = Gook(foo: a)
 
-  proc initFoo(x1: float): auto =
-    witness.inc
-    result = Foo(x1: x1)
+    proc initFoo(x1: float): auto =
+      witness.inc
+      result = Foo(x1: x1)
 
-  doAssert ?.a.x2.x2.x1 == 0.0
-  doAssert ?.a3.x2.x2.x1 == 1.2
-  doAssert ?.a3.x2.x2.x3[1] == 'b'
+    doAssert ?.a.x2.x2.x1 == 0.0
+    doAssert ?.a3.x2.x2.x1 == 1.2
+    doAssert ?.a3.x2.x2.x3[1] == 'b'
 
-  doAssert ?.a3.x2.x2.x5.len == 0
-  doAssert a3.x2.x2.x3.len == 3
+    doAssert ?.a3.x2.x2.x5.len == 0
+    doAssert a3.x2.x2.x3.len == 3
 
-  doAssert ?.a.x2.x2.x3[1] == default(char)
-  # here we only apply wrapnil around gook.foo, not gook (and assume gook is not nil)
-  doAssert ?.(gook.foo).x2.x2.x1 == 0.0
+    doAssert ?.a.x2.x2.x3[1] == default(char)
+    # here we only apply wrapnil around gook.foo, not gook (and assume gook is not nil)
+    doAssert ?.(gook.foo).x2.x2.x1 == 0.0
 
-  when nimvm: discard
-  else:
-    doAssert ?.a2.x6[] == Bar(b1: 42) # deref for ptr Bar
+    when nimvm: discard
+    else:
+      doAssert ?.a2.x6[] == Bar(b1: 42) # deref for ptr Bar
 
-  doAssert ?.a2.x1.checkNotZero == 1.0
-  doAssert a == nil
-  # shows that checkNotZero won't be called if a nil is found earlier in chain
-  doAssert ?.a.x1.checkNotZero == 0.0
+    doAssert ?.a2.x1.checkNotZero == 1.0
+    doAssert a == nil
+    # shows that checkNotZero won't be called if a nil is found earlier in chain
+    doAssert ?.a.x1.checkNotZero == 0.0
 
-  when nimvm: discard
-  else:
-    # checks that a chain without nil but with an empty seq still raises
-    doAssertRaises(IndexDefect): discard ?.a2.x8[3]
+    when nimvm: discard
+    else:
+      # checks that a chain without nil but with an empty seq still raises
+      doAssertRaises(IndexDefect): discard ?.a2.x8[3]
 
-  # make sure no double evaluation bug
-  doAssert witness == 0
-  doAssert ?.initFoo(1.3).x1 == 1.3
-  doAssert witness == 1
+    # make sure no double evaluation bug
+    doAssert witness == 0
+    doAssert ?.initFoo(1.3).x1 == 1.3
+    doAssert witness == 1
 
-  # here, it's used twice, to deref `ref Bar` and then `ptr string`
-  doAssert ?.a.x9[].fun[] == ""
+    # here, it's used twice, to deref `ref Bar` and then `ptr string`
+    doAssert ?.a.x9[].fun[] == ""
 
-  block: # `??.`
-    doAssert (??.a3.x2.x2.x3.len).get == 3
-    doAssert (??.a2.x4).isSome
-    doAssert not (??.a.x4).isSome
+    block: # `??.`
+      doAssert (??.a3.x2.x2.x3.len).get == 3
+      doAssert (??.a2.x4).isSome
+      doAssert not (??.a.x4).isSome
+
+  block:
+    type
+      A = object
+        b: B
+      B = object
+        c: C
+      C = object
+        d: D
+      D = ref object
+        e: E
+        e2: array[2, E]
+        e3: seq[E]
+        d3: D
+        i4: int
+      E = object
+        f: int
+        d2: D
+    proc identity[T](a: T): T = a
+    proc identity2[T](a: T, ignore: int): T = a
+    var a: A
+    doAssert ?.a.b.c.d.e.f == 0
+    doAssert ?.a.b.c.d.e.d2.d3[].d3.e.d2.e.f == 0
+    doAssert ?.a.b.c.d.d3[].e.f == 0
+    doAssert ?.a.b.c.d.e2[0].d2.e3[0].f == 0
+    doAssert ?.a == A.default
+    doAssert ?.a.b.c.d.e == E.default
+    doAssert ?.a.b.c.d.e.d2 == nil
+
+    doAssert ?.a.identity.b.c.identity2(12).d.d3.e.f == 0
+    doAssert ?.a.b.c.d.d3.e2[0].f == 0
+    a.b.c.d = D()
+    a.b.c.d.d3 = a.b.c.d
+    a.b.c.d.e2[0].f = 5
+    doAssert ?.a.b.c.d.d3.e2[0].f == 5
+
+    var d: D = nil
+    doAssert ?.d.identity.i4 == 0
+    doAssert ?.d.i4.identity == 0
+
+  block: # case objects
+    type
+      Kind = enum k0, k1, k2
+      V = object
+        case kind: Kind
+        of k0:
+          x0: int
+        of k1:
+          x1: int
+        of k2:
+          x2: int
+      A = object
+        v0: V
+
+    block:
+      var a = V(kind: k0, x0: 3)
+      doAssert ?.a.x0 == 3
+      doAssert ?.a.x1 == 0
+      a = V(kind: k1, x1: 5)
+      doAssert ?.a.x0 == 0
+      doAssert ?.a.x1 == 5
+
+    block:
+      var a = A(v0: V(kind: k0, x0: 10))
+      doAssert ?.a.v0.x0 == 10
+      doAssert ?.a.v0.x1 == 0
+      a.v0 = V(kind: k2, x2: 8)
+      doAssert ?.a.v0.x0 == 0
+      doAssert ?.a.v0.x1 == 0
+      doAssert ?.a.v0.x2 == 8
+
+  block: # `nnkCall`
+    type
+      A = object
+        a0: int
+        d: D
+      D = ref object
+        i4: int
+
+    proc identity[T](a: T): T = a
+    var d: D = nil
+    doAssert ?.d.i4.identity == 0
+    doAssert ?.identity(?.d.i4) == 0
+    doAssert ?.identity(d.i4) == 0
+    doAssert ?.identity(d) == nil
+    doAssert ?.identity(d[]) == default(typeof(d[]))
+    doAssert ?.identity(d[]).i4 == 0
+    var a: A
+    doAssert ?.identity(a) == default(A)
+    doAssert ?.identity(a.a0) == 0
+    doAssert ?.identity(a.d) == nil
+    doAssert ?.identity(a.d.i4) == 0
+
+  block:
+    type
+      A = ref object
+        a0: A
+        a1: seq[A]
+        a2: int
+      B = object
+      # B = ref object
+        b0: int
+        case cond: bool
+        of false: discard
+        of true:
+          b1: float
+
+    block:
+      var a: A
+      doAssert ?.a.a0.a1[0].a2.addr == nil
+      a = A(a2: 3)
+      doAssert ?.a.a0.a1[0].a2.addr == nil
+      a.a0 = a
+      a.a1 = @[a]
+      let p = ?.a.a0.a1[0].a2.addr
+      doAssert p != nil
+      p[] = 5
+      doAssert a.a2 == 5
+
+    block:
+      var b = B(cond: false, b0: 3)
+      when false:
+        let p = ?.addr(b.b1)
+      # let p = ?.b.b1.addr
+      # let p = ?.b.b1.unsafeAddr
+      # let p = ?.b.b1
+      # doAssert p == nil
 
 main()
 static: main()


### PR DESCRIPTION
* `std/wrapnils` now generates optimal code, as good (and in fact better [1]) as manually hand-written code to handle intermediate nils (or other conditions introduced in this PR); in particular, no copies are involved. It can therefore be used to replace code involving manual branches around nil/discriminant field accesses
* `std/wrapnils` now handle `FieldDefect` so it can be used with wrong discriminant value, returning a default value in such cases
* `std/wrapnils` now preserves lvalue semantics, so it can be used to modify underlying object with the following pattern:
```nim
# lvalue semantics are preserved:
if (let p = ?.b.b1.addr; p != nil): p[] = 4.7
doAssert b.b1 == 4.7
```
* `?.` now doesn't depend on options anymore (but `??.` is still offered to return an Option on top of `?.`)


Plenty of examples are provided in tests.

## example
```nim
when true:
  import std/[wrapnils,sugar]
  type
    B = object
      a0: A
    A = ref object
      a0: A
      a1: seq[A]
      b2: B
      i3: int
  var a: A
  echo dumpToString(?.a.a0.b2.a0.i3)
```
## before PR
```nim
?.a.a0.b2.a0.i3: safeGet do:
  let a1`gensym13 =
    let a1`gensym12 =
      let a1`gensym11 =
        let a1`gensym10 = option(a)
        type
          T`gensym10 = Option[typeof(unsafeGet(a1`gensym10).a0)]
        if isSome(a1`gensym10):
          let a2`gensym10 = unsafeGet(a1`gensym10)
          if a2`gensym10 == nil: default(T`gensym10)
          else:
            option(a2`gensym10.a0)
        else:
          default(T`gensym10)
      type
        T`gensym11 = Option[typeof(unsafeGet(a1`gensym11).b2)]
      if isSome(a1`gensym11):
        let a2`gensym11 = unsafeGet(a1`gensym11)
        if a2`gensym11 == nil: default(T`gensym11)
        else:
          option(a2`gensym11.b2)
      else:
        default(T`gensym11)
    type
      T`gensym12 = Option[typeof(unsafeGet(a1`gensym12).a0)]
    if isSome(a1`gensym12):
      let a2`gensym12 = unsafeGet(a1`gensym12)
      option(a2`gensym12.a0)
    else:
      default(T`gensym12)
  type
    T`gensym13 = Option[typeof(unsafeGet(a1`gensym13).i3)]
  if isSome(a1`gensym13):
    let a2`gensym13 = unsafeGet(a1`gensym13)
    if a2`gensym13 == nil: default(T`gensym13)
    else:
      option(a2`gensym13.i3)
  else:
    default(T`gensym13) = 0
```

## after PR
```nim
var lhs_771751948: type(a.a0.b2.a0.i3)
block:
  let tmp_771751956 = a
  if tmp_771751956 == nil:
    break
  let tmp_771751955 = tmp_771751956.a0
  if tmp_771751955 == nil:
    break
  let tmp_771751954 = tmp_771751955.b2.a0
  if tmp_771751954 == nil:
    break
  lhs_771751948 = tmp_771751954.i3
lhs_771751948
```

## [1] wrapnil can generate better code than manually written code
the generated code via wrapnils is in fact typically better than manually generated code, eg:
for `?.n.strVal`, you'd write:
```nim
let val = if n!=nil and n.kind in {nkStrLit..nkTripleStrLit} n.strVal else: ""
```
which is bad for 2 reasons:
* the field discriminant is checked twice (1 in `n.kind in {nkStrLit..nkTripleStrLit}`, and 1 in the  codegen for `n.strVal` unless `-d:danger` is used, whereas wrapnils removes the 2nd check and turns it into an unchecked field access
* the above code generates a copy because of the if expression, whereas wrapnil code allows user to keep lvalue semantics (no copy) for eg via:
```nim
if (let p = ?.n.strVal.addr; p != nil): foo(p[]) # no copy involved
```

## future work
- [ ] consider allowing index out of bounds with `?.`, eg:
`?.@[1][4]` or at least `?.default(seq[int])[2]` (ditto with string and other openArray-like types)