### PR TITLE
`^D` now works with `readLineFromStdin` (in particular in `nim secret`)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -345,6 +345,10 @@
 
 - Added `dom.setInterval`, `dom.clearInterval` overloads.
 
+- `rdstdin.readLineFromStdin` (used by `nim secret`) now supports `^D` to indicate
+  end of file for platforms that support `linenoise`.
+
+
 ## Language changes
 
 - `nimscript` now handles `except Exception as e`.
@@ -456,10 +460,6 @@
   enforces that every symbol is written as it was declared, not enforcing
   the official Nim style guide. To be enabled, this has to be combined either
   with `--styleCheck:error` or `--styleCheck:hint`.
-
-- `nim secret` and other tools relying on `rdstdin.readLineFromStdin` now supports
-  exiting via `^D` for platforms that support `linenoise`.
-
 
 
 ## Tool changes

--- a/changelog.md
+++ b/changelog.md
@@ -457,6 +457,9 @@
   the official Nim style guide. To be enabled, this has to be combined either
   with `--styleCheck:error` or `--styleCheck:hint`.
 
+- `nim secret` and other tools relying on `rdstdin.readLineFromStdin` now supports
+  exiting via `^D` for platforms that support `linenoise`.
+
 
 
 ## Tool changes

--- a/compiler/llstream.nim
+++ b/compiler/llstream.nim
@@ -98,9 +98,7 @@ proc llReadFromStdin(s: PLLStream, buf: pointer, bufLen: int): int =
   s.rd = 0
   var triples = 0
   var data: ReadLine
-  var iter = 0
   while true:
-    iter.inc
     data.prompt = if s.s.len == 0: ">>> " else: "... "
     readLineFromStdin(data)
     if isEndOfFile(data.status) or isError(data.status):

--- a/compiler/passes.nim
+++ b/compiler/passes.nim
@@ -185,7 +185,7 @@ proc processModule*(graph: ModuleGraph; module: PSym; idgen: IdGenerator;
         #echo "----- single\n", n
         if not processTopLevelStmt(graph, n, a): break
     closeParser(p)
-    if s.kind != llsStdIn: break
+    if s.kind != llsStdIn or s.closed: break
   closePasses(graph, a)
   if graph.config.backend notin {backendC, backendCpp, backendObjc}:
     # We only write rod files here if no C-like backend is active.

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -22,69 +22,59 @@ runnableExamples("-r:off"):
     if line.len > 0: echo line
   echo "exiting"
 
-when defined(windows):
-  proc readLineFromStdin*(prompt: string): string {.
-                          tags: [ReadIOEffect, WriteIOEffect].} =
-    ## Reads a line from stdin.
-    stdout.write(prompt)
-    result = readLine(stdin)
-
-  proc readLineFromStdin*(prompt: string, line: var string): bool {.
-                          tags: [ReadIOEffect, WriteIOEffect].} =
-    ## Reads a `line` from stdin. `line` must not be
-    ## `nil`! May throw an IO exception.
-    ## A line of text may be delimited by `CR`, `LF` or
-    ## `CRLF`. The newline character(s) are not part of the returned string.
-    ## Returns `false` if the end of the file has been reached, `true`
-    ## otherwise. If `false` is returned `line` contains no new data.
-    stdout.write(prompt)
-    result = readLine(stdin, line)
-
-elif defined(genode):
-  proc readLineFromStdin*(prompt: string): string {.
-                          tags: [ReadIOEffect, WriteIOEffect].} =
-    stdin.readLine()
-
-  proc readLineFromStdin*(prompt: string, line: var string): bool {.
-                          tags: [ReadIOEffect, WriteIOEffect].} =
-    stdin.readLine(line)
-
-else:
-  import linenoise
-
-  proc readLineFromStdin*(prompt: string, line: var string): bool {.
-                          tags: [ReadIOEffect, WriteIOEffect].} =
-    var buffer = linenoise.readLine(prompt)
-    if isNil(buffer):
-      line.setLen(0)
-      return false
-    line = $buffer
-    if line.len > 0:
-      historyAdd(buffer)
-    linenoise.free(buffer)
-    result = true
-
-  proc readLineFromStdin*(prompt: string): string {.inline.} =
-    if not readLineFromStdin(prompt, result):
-      raise newException(IOError, "Linenoise returned nil")
+import std/private/rdstdin_impl
 
 type ReadLine* = object
   # Opaque object to allow changing implementation
-  prompt: string
-  line: string
+  prompt*: string
+  line*: string
+  status*: ReadlineStatus
 
 proc initReadLine*(prompt: string): ReadLine = ReadLine(prompt: prompt)
 
-proc readLineFromStdin*(data: var ReadLine) {.tags: [ReadIOEffect, WriteIOEffect].} =
-  readLineStatus(data.prompt, result)
-  var buffer = linenoise.readLine(prompt)
-  if isNil(buffer):
-    line.setLen(0)
-    return false
-  line = $buffer
-  if line.len > 0:
-    historyAdd(buffer)
-  linenoise.free(buffer)
-  result = true
+proc isError*(a: ReadlineStatus): bool {.inline.} =
+  a == lnCtrlUnkown
 
-  export ReadLineResult, Status
+proc isEndOfFile*(a: ReadlineStatus): bool {.inline.} =
+  a == lnCtrlD
+
+proc isInterrupt*(a: ReadlineStatus): bool {.inline.} =
+  a == lnCtrlC
+
+proc isNormal*(a: ReadlineStatus): bool {.inline.} =
+  a == lnNormal
+
+import std/os
+
+const hasReadline = not (defined(windows) or defined(genode)) and fileExists(currentSourcePath.parentDir.parentDir / "wrappers/linenoise/linenoise.c")
+
+when hasReadline:
+  import linenoise
+
+proc readLineFromStdin*(data: var ReadLine) {.tags: [ReadIOEffect, WriteIOEffect].} =
+  when hasReadline:
+    var data2 = ReadLineResult(line: data.line)
+    readLineStatus(data.prompt, data2)
+    data.line = data2.line
+    data.status = data2.status
+    if data.line.len > 0:
+      historyAdd data.line.cstring
+  else:
+    stdout.write(data.prompt)
+    let ok = stdin.readLine(data.line)
+    data.status = if ok: lnNormal else: lnCtrlUnkown
+
+proc readLineFromStdin*(prompt: string, line: var string): bool =
+  ## Reads a `line` from stdin. May throw an IO exception.
+  ## A line of text may be delimited by `CR`, `LF` or
+  ## `CRLF`. The newline character(s) are not part of the returned string.
+  ## Returns `false` if the end of the file has been reached, `true`
+  ## otherwise. If `false` is returned `line` contains no new data.
+  var data = ReadLine(prompt: prompt)
+  line = data.line
+  result = not data.status.isError()
+
+proc readLineFromStdin*(prompt: string): string {.inline.} =
+  ## Reads a line from stdin.
+  if not readLineFromStdin(prompt, result):
+    raise newException(IOError, "Linenoise returned nil")

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -25,13 +25,13 @@ runnableExamples("-r:off"):
 import std/private/rdstdin_impl
 
 type ReadLine* = object
-  # Opaque object to allow changing implementation
   prompt*: string
   line*: string
   status*: ReadlineStatus
 
 proc initReadLine*(prompt: string): ReadLine = ReadLine(prompt: prompt)
 
+# These APIs are recommended to allow growing `ReadlineStatus`.
 proc isError*(a: ReadlineStatus): bool {.inline.} =
   a == lnCtrlUnkown
 

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -67,3 +67,9 @@ else:
   proc readLineFromStdin*(prompt: string): string {.inline.} =
     if not readLineFromStdin(prompt, result):
       raise newException(IOError, "Linenoise returned nil")
+
+  proc readLineFromStdin*(prompt: string, result: var ReadLineResult)
+    {.tags: [ReadIOEffect, WriteIOEffect].} =
+    readLineStatus(prompt, result)
+
+  export ReadLineResult, Status

--- a/lib/impure/rdstdin.nim
+++ b/lib/impure/rdstdin.nim
@@ -68,8 +68,23 @@ else:
     if not readLineFromStdin(prompt, result):
       raise newException(IOError, "Linenoise returned nil")
 
-  proc readLineFromStdin*(prompt: string, result: var ReadLineResult)
-    {.tags: [ReadIOEffect, WriteIOEffect].} =
-    readLineStatus(prompt, result)
+type ReadLine* = object
+  # Opaque object to allow changing implementation
+  prompt: string
+  line: string
+
+proc initReadLine*(prompt: string): ReadLine = ReadLine(prompt: prompt)
+
+proc readLineFromStdin*(data: var ReadLine) {.tags: [ReadIOEffect, WriteIOEffect].} =
+  readLineStatus(data.prompt, result)
+  var buffer = linenoise.readLine(prompt)
+  if isNil(buffer):
+    line.setLen(0)
+    return false
+  line = $buffer
+  if line.len > 0:
+    historyAdd(buffer)
+  linenoise.free(buffer)
+  result = true
 
   export ReadLineResult, Status

--- a/lib/std/private/rdstdin_impl.nim
+++ b/lib/std/private/rdstdin_impl.nim
@@ -1,0 +1,5 @@
+type ReadlineStatus* = enum
+  lnCtrlUnkown
+  lnCtrlC
+  lnCtrlD
+  lnNormal

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -34,10 +34,6 @@ proc printKeyCodes*() {.importc: "linenoisePrintKeyCodes".}
 
 proc free*(s: cstring) {.importc: "free", header: "<stdlib.h>".}
 
-type ReadLineResult* = object
-  line*: string
-  status*: ReadlineStatus
-
 when not defined(windows):
   # C interface
   type LinenoiseStatus = enum
@@ -46,23 +42,6 @@ when not defined(windows):
     linenoiseStatus_ctrl_D
 
   type LinenoiseData* = object
-    status: LinenoiseStatus
+    status*: LinenoiseStatus
 
-  proc linenoiseExtra(prompt: cstring, data: ptr LinenoiseData): cstring {.importc.}
-
-  proc readLineStatus*(prompt: string, result: var ReadLineResult) =
-    ## line editing API that allows returning the line entered and an indicator
-    ## of which control key was entered, allowing user to distinguish between
-    ## for example ctrl-C vs ctrl-D.
-    runnableExamples("-r:off"):
-      var ret: ReadLineResult
-      while true:
-        readLineStatus("name: ", ret) # ctrl-D will exit, ctrl-C will go to next prompt
-        if ret.line.len > 0: echo ret.line
-        if ret.status == lnCtrlD: break
-      echo "exiting"
-    var data: LinenoiseData
-    let buf = linenoiseExtra(prompt, data.addr)
-    result.line = $buf
-    free(buf)
-    result.status = if buf != nil: lnNormal else: data.status.ord.ReadlineStatus
+  proc linenoiseExtra*(prompt: cstring, data: ptr LinenoiseData): cstring {.importc.}

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -7,6 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
+import std/private/rdstdin_impl
+
 type
   Completions* = object
     len*: csize_t
@@ -32,15 +34,9 @@ proc printKeyCodes*() {.importc: "linenoisePrintKeyCodes".}
 
 proc free*(s: cstring) {.importc: "free", header: "<stdlib.h>".}
 
-# stable nim interface
-type Status* = enum
-  lnCtrlUnkown
-  lnCtrlC
-  lnCtrlD
-
 type ReadLineResult* = object
   line*: string
-  status*: Status
+  status*: ReadlineStatus
 
 # when defined(nimExperimentalLinenoiseExtra) and not defined(windows):
 when not defined(windows):
@@ -70,4 +66,7 @@ when not defined(windows):
     let buf = linenoiseExtra(prompt, data.addr)
     result.line = $buf
     free(buf)
-    result.status = data.status.ord.Status
+    if buf != nil:
+      result.status = lnNormal
+    else:
+      result.status = data.status.ord.ReadlineStatus

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -65,7 +65,4 @@ when not defined(windows):
     let buf = linenoiseExtra(prompt, data.addr)
     result.line = $buf
     free(buf)
-    if buf != nil:
-      result.status = lnNormal
-    else:
-      result.status = data.status.ord.ReadlineStatus
+    result.status = if buf != nil: lnNormal else: data.status.ord.ReadlineStatus

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -32,7 +32,18 @@ proc printKeyCodes*() {.importc: "linenoisePrintKeyCodes".}
 
 proc free*(s: cstring) {.importc: "free", header: "<stdlib.h>".}
 
-when defined(nimExperimentalLinenoiseExtra) and not defined(windows):
+# stable nim interface
+type Status* = enum
+  lnCtrlUnkown
+  lnCtrlC
+  lnCtrlD
+
+type ReadLineResult* = object
+  line*: string
+  status*: Status
+
+# when defined(nimExperimentalLinenoiseExtra) and not defined(windows):
+when not defined(windows):
   # C interface
   type LinenoiseStatus = enum
     linenoiseStatus_ctrl_unknown
@@ -43,16 +54,6 @@ when defined(nimExperimentalLinenoiseExtra) and not defined(windows):
     status: LinenoiseStatus
 
   proc linenoiseExtra(prompt: cstring, data: ptr LinenoiseData): cstring {.importc.}
-
-  # stable nim interface
-  type Status* = enum
-    lnCtrlUnkown
-    lnCtrlC
-    lnCtrlD
-
-  type ReadLineResult* = object
-    line*: string
-    status*: Status
 
   proc readLineStatus*(prompt: string, result: var ReadLineResult) =
     ## line editing API that allows returning the line entered and an indicator

--- a/lib/wrappers/linenoise/linenoise.nim
+++ b/lib/wrappers/linenoise/linenoise.nim
@@ -38,7 +38,6 @@ type ReadLineResult* = object
   line*: string
   status*: ReadlineStatus
 
-# when defined(nimExperimentalLinenoiseExtra) and not defined(windows):
 when not defined(windows):
   # C interface
   type LinenoiseStatus = enum
@@ -55,7 +54,7 @@ when not defined(windows):
     ## line editing API that allows returning the line entered and an indicator
     ## of which control key was entered, allowing user to distinguish between
     ## for example ctrl-C vs ctrl-D.
-    runnableExamples("-d:nimExperimentalLinenoiseExtra -r:off"):
+    runnableExamples("-r:off"):
       var ret: ReadLineResult
       while true:
         readLineStatus("name: ", ret) # ctrl-D will exit, ctrl-C will go to next prompt

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -334,7 +334,7 @@ proc main() =
     let x = os.paramStr(1)
     let xx = expandFilename x
     failures += runTest(xx)
-    # failures += runEpcTest(xx)
+    failures += runEpcTest(xx)
   else:
     for x in walkFiles(tpath / "t*.nim"):
       echo "Test ", x

--- a/nimsuggest/tester.nim
+++ b/nimsuggest/tester.nim
@@ -334,7 +334,7 @@ proc main() =
     let x = os.paramStr(1)
     let xx = expandFilename x
     failures += runTest(xx)
-    failures += runEpcTest(xx)
+    # failures += runEpcTest(xx)
   else:
     for x in walkFiles(tpath / "t*.nim"):
       echo "Test ", x

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -33,4 +33,3 @@ hint("Processing", off)
 # sync with `kochdocs.docDefines` or refactor.
 switch("define", "nimExperimentalAsyncjsThen")
 switch("define", "nimExperimentalJsfetch")
-switch("define", "nimExperimentalLinenoiseExtra")

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -8,7 +8,7 @@ const
   gaCode* = " --doc.googleAnalytics:UA-48159761-1"
   # errormax: subsequent errors are probably consequences of 1st one; a simple
   # bug could cause unlimited number of errors otherwise, hard to debug in CI.
-  docDefines = "-d:nimExperimentalAsyncjsThen -d:nimExperimentalJsfetch -d:nimExperimentalLinenoiseExtra"
+  docDefines = "-d:nimExperimentalAsyncjsThen -d:nimExperimentalJsfetch"
   nimArgs = "--errormax:3 --hint:Conf:off --hint:Path:off --hint:Processing:off --hint:XDeclaredButNotUsed:off --warning:UnusedImport:off -d:boot --putenv:nimversion=$# $#" % [system.NimVersion, docDefines]
   gitUrl = "https://github.com/nim-lang/Nim"
   docHtmlOutput = "doc/html"


### PR DESCRIPTION
* follows https://github.com/nim-lang/Nim/pull/16977
* fixes https://github.com/timotheecour/Nim/issues/533 (`quit` doesn't always allow quitting, and is a hack as it prevents cleanup work; `^D` can now be used instead on platforms supporting linenoise)
* `^D` now works with `readLineFromStdin` (in particular in `nim secret`; in particular `echo 'echo 1' | nim secret` now works and exits instead of hanging)
* various other improvements and refactorings (the diff is smaller despite added functionality)
* bugfix for genode which wasn't printing prompt