### PR TITLE
improve rendering of newOSError.additionalInfo

### DIFF
--- a/lib/pure/includes/oserr.nim
+++ b/lib/pure/includes/oserr.nim
@@ -82,7 +82,7 @@ proc newOSError*(
     if e.msg.len > 0 and e.msg[^1] != '\n': e.msg.add '\n'
     e.msg.add "Additional info: "
     e.msg.add additionalInfo
-    e.msg.add "." # makes it obvious where line ends in case of trailing spaces.
+      # don't add trailing `.` etc, which negatively impacts "jump to file" in IDEs.
   if e.msg == "":
     e.msg = "unknown OS error"
   return e

--- a/lib/pure/includes/oserr.nim
+++ b/lib/pure/includes/oserr.nim
@@ -80,8 +80,9 @@ proc newOSError*(
   e.msg = osErrorMsg(errorCode)
   if additionalInfo.len > 0:
     if e.msg.len > 0 and e.msg[^1] != '\n': e.msg.add '\n'
-    e.msg.add  "Additional info: "
-    e.msg.addQuoted additionalInfo
+    e.msg.add "Additional info: "
+    e.msg.add additionalInfo
+    e.msg.add "." # makes it obvious where line ends in case of trailing spaces.
   if e.msg == "":
     e.msg = "unknown OS error"
   return e

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -958,7 +958,9 @@ proc bindAddr*(socket: Socket, port = Port(0), address = "") {.
   var aiList = getAddrInfo(realaddr, port, socket.domain)
   if bindAddr(socket.fd, aiList.ai_addr, aiList.ai_addrlen.SockLen) < 0'i32:
     freeaddrinfo(aiList)
-    raiseOSError(osLastError(), "address: $# port: $#" % [address, $port])
+    var address2: string
+    address2.addQuoted address
+    raiseOSError(osLastError(), "address: $# port: $#" % [address2, $port])
   freeaddrinfo(aiList)
 
 proc acceptAddr*(server: Socket, client: var owned(Socket), address: var string,


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/pull/18428#issuecomment-874092796

I'm removing addQuoted from newOSError to avoid double addQuoted which would render `""` as `\"\"` (ditto in similar cases)

## example 1
before PR:
```
Additional info: "address:  port: 1234" [OSError]
```
after PR:
```
Additional info: address: "" port: 1234 [OSError]
```
=> more readable

## example 2
```nim
import os
# echo expandFilename("/nonexistant.txt")
copyFile("/nonexistant.txt", "/nonexistant.txt")
```
before PR:
```
Additional info: "(\"/nonexistant.txt\", \"/nonexistant.txt\")" [OSError]
```
after PR:
```
Additional info: ("/nonexistant.txt", "/nonexistant.txt") [OSError]
```

=> more readable