### PR TITLE
Fresh attempt on smartptrs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -100,6 +100,8 @@
 
 ## Standard library additions and changes
 
+- Added module `std/smartptrs`.
+
 - `strformat`:
   added support for parenthesized expressions.
   added support for const string's instead of just string literals

--- a/lib/std/smartptrs.nim
+++ b/lib/std/smartptrs.nim
@@ -1,0 +1,130 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2021 Nim contributors
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+
+## C++11 like smart pointers. They always use the shared allocator.
+import std/isolation
+
+type
+  UniquePtr*[T] = object
+    ## Non copyable pointer to a value of type `T` with exclusive ownership.
+    val: ptr T
+
+proc `=destroy`*[T](p: var UniquePtr[T]) =
+  if p.val != nil:
+    `=destroy`(p.val[])
+    deallocShared(p.val)
+
+proc `=copy`*[T](dest: var UniquePtr[T], src: UniquePtr[T]) {.error.}
+  ## The copy operation is disallowed for `UniquePtr`, it
+  ## can only be moved.
+
+proc newUniquePtr[T](val: sink Isolated[T]): UniquePtr[T] {.nodestroy.} =
+  ## Returns a unique pointer which has exclusive ownership of the value.
+  result.val = cast[ptr T](allocShared(sizeof(T)))
+  # thanks to '.nodestroy' we don't have to use allocShared0 here.
+  # This is compiled into a copyMem operation, no need for a sink
+  # here either.
+  result.val[] = extract val
+  # no destructor call for 'val: sink T' here either.
+
+template newUniquePtr*[T](val: T): UniquePtr[T] =
+  ## .. warning:: Using this template in a loop causes multiple evaluations of `value`.
+  newUniquePtr(isolate(val))
+
+proc isNil*[T](p: UniquePtr[T]): bool {.inline.} =
+  p.val == nil
+
+proc `[]`*[T](p: UniquePtr[T]): var T {.inline.} =
+  ## Returns a mutable view of the internal value of `p`.
+  when compileOption("boundChecks"):
+    assert(p.val != nil, "deferencing nil unique pointer")
+  p.val[]
+
+proc `[]=`*[T](p: UniquePtr[T], val: T) {.inline.} =
+  (p[]) = val
+
+proc `$`*[T](p: UniquePtr[T]): string {.inline.} =
+  if p.val == nil: "nil"
+  else: "UniquePtr(" & $p.val[] & ")"
+
+#------------------------------------------------------------------------------
+
+type
+  SharedPtr*[T] = object
+    ## Shared ownership reference counting pointer.
+    val: ptr tuple[value: T, atomicCounter: int]
+
+proc `=destroy`*[T](p: var SharedPtr[T]) =
+  if p.val != nil:
+    if atomicLoadN(addr p.val[].atomicCounter, AtomicConsume) == 0:
+      `=destroy`(p.val[])
+      deallocShared(p.val)
+    else:
+      discard atomicDec(p.val[].atomicCounter)
+
+proc `=copy`*[T](dest: var SharedPtr[T], src: SharedPtr[T]) =
+  if src.val != nil:
+    discard atomicInc(src.val[].atomicCounter)
+  if dest.val != nil:
+    `=destroy`(dest)
+  dest.val = src.val
+
+proc newSharedPtr[T](val: sink Isolated[T]): SharedPtr[T] {.nodestroy.} =
+  ## Returns a shared pointer which shares
+  ## ownership of the object by reference counting.
+  result.val = cast[typeof(result.val)](allocShared(sizeof(result.val[])))
+  result.val.atomicCounter = 0
+  result.val.value = extract val
+
+template newSharedPtr*[T](val: T): SharedPtr[T] =
+  ## .. warning:: Using this template in a loop causes multiple evaluations of `value`.
+  newSharedPtr(isolate(val))
+
+proc isNil*[T](p: SharedPtr[T]): bool {.inline.} =
+  p.val == nil
+
+proc `[]`*[T](p: SharedPtr[T]): var T {.inline.} =
+  when compileOption("boundChecks"):
+    assert(p.val != nil, "deferencing nil shared pointer")
+  p.val.value
+
+proc `[]=`*[T](p: SharedPtr[T], val: T) {.inline.} =
+  (p[]) = val
+
+proc `$`*[T](p: SharedPtr[T]): string {.inline.} =
+  if p.val == nil: "nil"
+  else: "SharedPtr(" & $p.val.value & ")"
+
+#------------------------------------------------------------------------------
+
+type
+  ConstPtr*[T] = distinct SharedPtr[T]
+    ## Distinct version of `SharedPtr[T]`, which doesn't allow mutating the underlying value.
+
+proc newConstPtr*[T](val: sink Isolated[T]): ConstPtr[T] =
+  ## Similar to `newSharedPtr<#newSharedPtr,T>`_, but the underlying value can't be mutated.
+  ConstPtr[T](newSharedPtr(val))
+
+template newConstPtr*[T](val: T): ConstPtr[T] =
+  ## .. warning:: Using this template in a loop causes multiple evaluations of `value`.
+  newConstPtr(isolate(val))
+
+proc isNil*[T](p: ConstPtr[T]): bool {.inline.} =
+  SharedPtr[T](p).val == nil
+
+proc `[]`*[T](p: ConstPtr[T]): lent T {.inline.} =
+  ## Returns an immutable view of the internal value of `p`.
+  when compileOption("boundChecks"):
+    assert(SharedPtr[T](p).val != nil, "deferencing nil const pointer")
+  SharedPtr[T](p).val.value
+
+proc `[]=`*[T](p: ConstPtr[T], v: T) = {.error: "`ConstPtr` cannot be assigned.".}
+
+proc `$`*[T](p: ConstPtr[T]): string {.inline.} =
+  if SharedPtr[T](p).val == nil: "nil"
+  else: "ConstPtr(" & $SharedPtr[T](p).val.value & ")"

--- a/lib/std/smartptrs.nim
+++ b/lib/std/smartptrs.nim
@@ -9,6 +9,11 @@
 ## C++11 like smart pointers. They always use the shared allocator.
 import std/isolation
 
+template checkNotNil() =
+  when compileOption("boundChecks"):
+    if SharedPtr[T](p).val == nil:
+      raise newException(NilAccessDefect, "deferencing nil const pointer")
+
 type
   UniquePtr*[T] = object
     ## Non copyable pointer to a value of type `T` with exclusive ownership.
@@ -33,7 +38,7 @@ proc newUniquePtr[T](val: sink Isolated[T]): UniquePtr[T] {.nodestroy.} =
   # no destructor call for 'val: sink T' here either.
 
 template newUniquePtr*[T](val: T): UniquePtr[T] =
-  ## .. warning:: Using this template in a loop causes multiple evaluations of `value`.
+  ## .. warning:: Using this template in a loop causes multiple evaluations of `val`.
   newUniquePtr(isolate(val))
 
 proc isNil*[T](p: UniquePtr[T]): bool {.inline.} =
@@ -41,16 +46,16 @@ proc isNil*[T](p: UniquePtr[T]): bool {.inline.} =
 
 proc `[]`*[T](p: UniquePtr[T]): var T {.inline.} =
   ## Returns a mutable view of the internal value of `p`.
-  when compileOption("boundChecks"):
-    assert(p.val != nil, "deferencing nil unique pointer")
+  checkNotNil()
   p.val[]
 
 proc `[]=`*[T](p: UniquePtr[T], val: T) {.inline.} =
-  (p[]) = val
+  checkNotNil()
+  p.val[] = val
 
 proc `$`*[T](p: UniquePtr[T]): string {.inline.} =
   if p.val == nil: "nil"
-  else: "UniquePtr(" & $p.val[] & ")"
+  else: "(val: " & $p.val[] & ")"
 
 #------------------------------------------------------------------------------
 
@@ -82,23 +87,23 @@ proc newSharedPtr[T](val: sink Isolated[T]): SharedPtr[T] {.nodestroy.} =
   result.val.value = extract val
 
 template newSharedPtr*[T](val: T): SharedPtr[T] =
-  ## .. warning:: Using this template in a loop causes multiple evaluations of `value`.
+  ## .. warning:: Using this template in a loop causes multiple evaluations of `val`.
   newSharedPtr(isolate(val))
 
 proc isNil*[T](p: SharedPtr[T]): bool {.inline.} =
   p.val == nil
 
 proc `[]`*[T](p: SharedPtr[T]): var T {.inline.} =
-  when compileOption("boundChecks"):
-    assert(p.val != nil, "deferencing nil shared pointer")
+  checkNotNil()
   p.val.value
 
 proc `[]=`*[T](p: SharedPtr[T], val: T) {.inline.} =
-  (p[]) = val
+  checkNotNil()
+  p.val.value = val
 
 proc `$`*[T](p: SharedPtr[T]): string {.inline.} =
   if p.val == nil: "nil"
-  else: "SharedPtr(" & $p.val.value & ")"
+  else: "(val: " & $p.val.value & ")"
 
 #------------------------------------------------------------------------------
 
@@ -111,7 +116,7 @@ proc newConstPtr*[T](val: sink Isolated[T]): ConstPtr[T] =
   ConstPtr[T](newSharedPtr(val))
 
 template newConstPtr*[T](val: T): ConstPtr[T] =
-  ## .. warning:: Using this template in a loop causes multiple evaluations of `value`.
+  ## .. warning:: Using this template in a loop causes multiple evaluations of `val`.
   newConstPtr(isolate(val))
 
 proc isNil*[T](p: ConstPtr[T]): bool {.inline.} =
@@ -119,12 +124,10 @@ proc isNil*[T](p: ConstPtr[T]): bool {.inline.} =
 
 proc `[]`*[T](p: ConstPtr[T]): lent T {.inline.} =
   ## Returns an immutable view of the internal value of `p`.
-  when compileOption("boundChecks"):
-    assert(SharedPtr[T](p).val != nil, "deferencing nil const pointer")
+  checkNotNil()
   SharedPtr[T](p).val.value
 
 proc `[]=`*[T](p: ConstPtr[T], v: T) = {.error: "`ConstPtr` cannot be assigned.".}
 
 proc `$`*[T](p: ConstPtr[T]): string {.inline.} =
-  if SharedPtr[T](p).val == nil: "nil"
-  else: "ConstPtr(" & $SharedPtr[T](p).val.value & ")"
+  $SharedPtr[T](p)

--- a/tests/stdlib/tsmartptrs.nim
+++ b/tests/stdlib/tsmartptrs.nim
@@ -1,3 +1,10 @@
+discard """
+  matrix: "--threads"
+  targets: "c cpp"
+  exitcode: 0
+  disabled: false
+"""
+
 import std/smartptrs
 
 block:

--- a/tests/stdlib/tsmartptrs.nim
+++ b/tests/stdlib/tsmartptrs.nim
@@ -4,7 +4,6 @@ discard """
   exitcode: 0
   disabled: false
 """
-
 import std/smartptrs
 
 block:
@@ -13,7 +12,7 @@ block:
 
   assert $a1 == "nil"
   assert a1.isNil
-  assert $a2 == "UniquePtr(0)"
+  assert $a2 == "(val: 0)"
   assert not a2.isNil
   assert a2[] == 0
 
@@ -23,7 +22,7 @@ block:
   assert $a2 == "nil"
   assert a2.isNil
 
-  assert $a3 == "UniquePtr(0)"
+  assert $a3 == "(val: 0)"
   assert not a3.isNil
   assert a3[] == 0
 
@@ -34,10 +33,10 @@ block:
 
   assert $a1 == "nil"
   assert a1.isNil
-  assert $a2 == "SharedPtr(0)"
+  assert $a2 == "(val: 0)"
   assert not a2.isNil
   assert a2[] == 0
-  assert $a3 == "SharedPtr(0)"
+  assert $a3 == "(val: 0)"
   assert not a3.isNil
   assert a3[] == 0
 
@@ -48,9 +47,10 @@ block:
 
   assert $a1 == "nil"
   assert a1.isNil
-  assert $a2 == "ConstPtr(0)"
+  assert $a2 == "(val: 0)"
   assert not a2.isNil
   assert a2[] == 0
-  assert $a3 == "ConstPtr(0)"
+  assert $a3 == "(val: 0)"
   assert not a3.isNil
   assert a3[] == 0
+

--- a/tests/stdlib/tsmartptrs.nim
+++ b/tests/stdlib/tsmartptrs.nim
@@ -1,0 +1,49 @@
+import std/smartptrs
+
+block:
+  var a1: UniquePtr[float]
+  var a2 = newUniquePtr(0)
+
+  assert $a1 == "nil"
+  assert a1.isNil
+  assert $a2 == "UniquePtr(0)"
+  assert not a2.isNil
+  assert a2[] == 0
+
+  # UniquePtr can't be copied but can be moved
+  let a3 = move a2
+
+  assert $a2 == "nil"
+  assert a2.isNil
+
+  assert $a3 == "UniquePtr(0)"
+  assert not a3.isNil
+  assert a3[] == 0
+
+block:
+  var a1: SharedPtr[float]
+  let a2 = newSharedPtr(0)
+  let a3 = a2
+
+  assert $a1 == "nil"
+  assert a1.isNil
+  assert $a2 == "SharedPtr(0)"
+  assert not a2.isNil
+  assert a2[] == 0
+  assert $a3 == "SharedPtr(0)"
+  assert not a3.isNil
+  assert a3[] == 0
+
+block:
+  var a1: ConstPtr[float]
+  let a2 = newConstPtr(0)
+  let a3 = a2
+
+  assert $a1 == "nil"
+  assert a1.isNil
+  assert $a2 == "ConstPtr(0)"
+  assert not a2.isNil
+  assert a2[] == 0
+  assert $a3 == "ConstPtr(0)"
+  assert not a3.isNil
+  assert a3[] == 0


### PR DESCRIPTION
Thanks to everyone who helped and those who gave their feedback on the previous attempt #17333 .
Changes include:
- Remove `-d:nimExperimentalSmartptrs` it makes no sense to disable the whole module.
- Create separate test
- `get` is gone, use `[]` as with every pointer in Nim
- Revert https://github.com/nim-lang/fusion/pull/37
- Added https://github.com/nim-lang/fusion/pull/52

Todo:
- Multithreaded tests
- More docs, explain the purpose better.