### PR TITLE
followup #18252: show special flags -d:danger, -d:release when given

### DIFF
--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -677,6 +677,10 @@ proc genSuccessX*(conf: ConfigRef) =
     elif optOptimizeSize in conf.options: build.add "size"
     else: build.add "none (DEBUG BUILD, `-d:release` generates faster code)"
       # pending https://github.com/timotheecour/Nim/issues/752, point to optimization.html
+    var flags = ""
+    if isDefined(conf, "danger"): flags.add " -d:danger"
+    elif isDefined(conf, "release"): flags.add " -d:release"
+    if flags.len > 0: build.add "; options:" & flags
   let sec = formatFloat(epochTime() - conf.lastCmdTime, ffDecimal, 3)
   let project = if conf.filenameOption == foAbs: $conf.projectFull else: $conf.projectName
     # xxx honor conf.filenameOption more accurately


### PR DESCRIPTION
follows #18252, refs https://github.com/nim-lang/Nim/pull/18252#issuecomment-866361876

nim r main
nim r -d:release main
nim r -d:danger main

## before PR:
```
Hint: gc: refc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
Hint: gc: refc; opt: speed
Hint: gc: refc; opt: speed
```

## after PR:
```
Hint: gc: refc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
Hint: gc: refc; opt: speed; options: -d:release
Hint: gc: refc; opt: speed; options: -d:danger
```

## rationale for doing it this way:
* good enough IMO, no need for more bold, asterisks, etc which just get annoying after the 1st few times you see it.
* extensible to other special flags besides -d:danger -d:release
 