### PR TITLE
runnableExamples now show originating location in stacktraces on failure

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -482,7 +482,8 @@ proc prepareExample(d: PDoc; n: PNode, topLevel: bool): tuple[rdoccmd: string, c
     if n1.kind notin nkStrKinds: globalError(d.conf, n1.info, "string litteral expected")
     rdoccmd = n1.strVal
 
-  let useRenderModule = false
+  # let useRenderModule = false
+  let useRenderModule = true
   let loc = d.conf.toFileLineCol(n.info)
   let code = extractRunnableExamplesSource(d.conf, n)
 
@@ -508,6 +509,7 @@ proc prepareExample(d: PDoc; n: PNode, topLevel: bool): tuple[rdoccmd: string, c
     # still worth fixing as it can affect other code relying on `renderModule`,
     # so we keep this code path here for now, which could still be useful in some
     # other situations.
+    echo (outp.string, "D20210707T232134")
     renderModule(runnableExamples, outp.string, conf = d.conf)
 
   else:

--- a/compiler/renderverbatim.nim
+++ b/compiler/renderverbatim.nim
@@ -83,7 +83,7 @@ proc startOfLineInsideTriple(ldata: LineData, line: int): bool =
   if index >= ldata.lines.len: false
   else: ldata.lines[index]
 
-proc extractRunnableExamplesSource*(conf: ConfigRef; n: PNode): string =
+proc extractRunnableExamplesSource*(conf: ConfigRef; n: PNode, indent = 0): string =
   ## TLineInfo.offsetA,offsetB would be cleaner but it's only enabled for nimpretty,
   ## we'd need to check performance impact to enable it for nimdoc.
   var first = n.lastSon.info
@@ -102,7 +102,7 @@ proc extractRunnableExamplesSource*(conf: ConfigRef; n: PNode): string =
 
   let last = n.lastNodeRec.info
   var info = first
-  var indent = info.col
+  var indent2 = info.col
   let numLines = numLines(conf, info.fileIndex).uint16
   var lastNonemptyPos = 0
 
@@ -118,14 +118,15 @@ proc extractRunnableExamplesSource*(conf: ConfigRef; n: PNode): string =
     info.line = line
     let src = sourceLine(conf, info)
     let special = startOfLineInsideTriple(ldata, line.int)
-    if line > last.line and not special and not isInIndentationBlock(src, indent):
+    if line > last.line and not special and not isInIndentationBlock(src, indent2):
       break
     if line > first.line: result.add "\n"
     if special:
       result.add src
       lastNonemptyPos = result.len
-    elif src.len > indent:
-      result.add src[indent..^1]
+    elif src.len > indent2:
+      for i in 0..<indent: result.add ' '
+      result.add src[indent2..^1]
       lastNonemptyPos = result.len
   result.setLen lastNonemptyPos
 


### PR DESCRIPTION
## example
insert some bug in some runnableExamples, eg:
`assert normalizePathEnd("", trailingSep = true) == "foo"` in std/os normalizePathEnd examples

before PR:
```
/Users/timothee/.cache/nim/os_d/runnableExamples/os_examples1.nim(11) os_examples1
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(39) failedAssertImpl
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(29) raiseAssert
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(53) sysFatal
Error: unhandled exception: /Users/timothee/.cache/nim/os_d/runnableExamples/os_examples1.nim(11, 10) `normalizePathEnd("", trailingSep = true) == "foo"`  [AssertionDefect]
```

after PR:
```
/Users/timothee/git_clone/nim/Nim_prs/lib/pure/os.nim(136) os_examples_1
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(39) failedAssertImpl
/Users/timothee/git_clone/nim/Nim_prs/lib/system/assertions.nim(29) raiseAssert
/Users/timothee/git_clone/nim/Nim_prs/lib/system/fatal.nim(53) sysFatal
Error: unhandled exception: /Users/timothee/.cache/nim/os_d/runnableExamples/os_examples_1.nim(12, 12) `normalizePathEnd("", trailingSep = true) == "foo"`  [AssertionDefect]
```

=> shows `/Users/timothee/git_clone/nim/Nim_prs/lib/pure/os.nim(136) os_examples_1` which makes it 1 click away to see where the example came from
