### PR TITLE
Revert "Raise IndexDefect when deleting element at out of bounds index (#17821)"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,9 +30,6 @@
 - `math.round` now is rounded "away from zero" in JS backend which is consistent
   with other backends. See #9125. Use `-d:nimLegacyJsRound` for previous behavior.
 
-- Instead of deleting the element at the last index,
-  `system.delete()` now raises `IndexDefect` when given index is out of bounds.
-
 - Changed the behavior of `uri.decodeQuery` when there are unencoded `=`
   characters in the decoded values. Prior versions would raise an error. This is
   no longer the case to comply with the HTML spec and other languages

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1325,6 +1325,30 @@ proc del*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
   movingCopy(x[i], x[xl])
   setLen(x, xl)
 
+proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
+  ## Deletes the item at index `i` by moving all `x[i+1..]` items by one position.
+  ##
+  ## This is an `O(n)` operation.
+  ##
+  ## See also:
+  ## * `del <#del,seq[T],Natural>`_ for O(1) operation
+  ##
+  ## .. code-block:: Nim
+  ##  var i = @[1, 2, 3, 4, 5]
+  ##  i.delete(2) # => @[1, 2, 4, 5]
+  template defaultImpl =
+    let xl = x.len
+    for j in i.int..xl-2: movingCopy(x[j], x[j+1])
+    setLen(x, xl-1)
+
+  when nimvm:
+    defaultImpl()
+  else:
+    when defined(js):
+      {.emit: "`x`.splice(`i`, 1);".}
+    else:
+      defaultImpl()
+
 proc insert*[T](x: var seq[T], item: sink T, i = 0.Natural) {.noSideEffect.} =
   ## Inserts `item` into `x` at position `i`.
   ##
@@ -2128,40 +2152,6 @@ const
 
 import system/dollars
 export dollars
-
-proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect.} =
-  ## Deletes the item at index `i` by moving all `x[i+1..^1]` items by one position.
-  ##
-  ## This is an `O(n)` operation.
-  ##
-  ## See also:
-  ## * `del <#del,seq[T],Natural>`_ for O(1) operation
-  ##
-  runnableExamples:
-    var s = @[1, 2, 3, 4, 5]
-    s.delete(2)
-    doAssert s == @[1, 2, 4, 5]
-
-    doAssertRaises(IndexDefect):
-      s.delete(4)
-
-  if i > high(x):
-    # xxx this should call `raiseIndexError2(i, high(x))` after some refactoring
-    raise (ref IndexDefect)(msg: "index out of bounds: '" & $i & "' < '" & $x.len & "' failed")
-
-  template defaultImpl =
-    let xl = x.len
-    for j in i.int..xl-2: movingCopy(x[j], x[j+1])
-    setLen(x, xl-1)
-
-  when nimvm:
-    defaultImpl()
-  else:
-    when defined(js):
-      {.emit: "`x`.splice(`i`, 1);".}
-    else:
-      defaultImpl()
-
 
 const
   NimVersion*: string = $NimMajor & "." & $NimMinor & "." & $NimPatch

--- a/tests/gc/gcleak3.nim
+++ b/tests/gc/gcleak3.nim
@@ -18,9 +18,12 @@ for i in 0..1024:
 
 proc limit*[t](a: var seq[t]) =
   while s.len > 0:
+    #echo i
+    #GC_fullCollect()
     if getOccupiedMem() > 3000_000: quit("still a leak!")
     s.delete(0)
 
 s.limit()
+
 echo "no leak: ", getOccupiedMem()
 

--- a/tests/stdlib/tsystem.nim
+++ b/tests/stdlib/tsystem.nim
@@ -2,10 +2,9 @@ discard """
   targets: "c cpp js"
 """
 
-import stdtest/testutils
-
 # TODO: in future work move existing `system` tests here, where they belong
 
+import stdtest/testutils
 
 template main =
   block: # closure
@@ -42,35 +41,6 @@ template main =
         doAssert rawEnv(inner2) == rawEnv(inner1) # because both use `a`
         # doAssert rawEnv(inner3) != rawEnv(inner1) # because `a` vs `b` # this doesn't hold
     outer()
-
-  block: # system.delete
-    block:
-      var s = @[1]
-      s.delete(0)
-      doAssert s == @[]
-
-    block:
-      var s = @["foo", "bar"]
-      s.delete(1)
-      doAssert s == @["foo"]
-  
-    block:
-      var s: seq[string]
-      doAssertRaises(IndexDefect):
-        s.delete(0)
-
-    block:
-      doAssert not compiles(@["foo"].delete(-1))
-
-    block: # bug #6710
-      var s = @["foo"]
-      s.delete(0)
-      doAssert s == @[]
-  
-    block: # bug #16544: deleting out of bounds index should raise
-      var s = @["foo"]
-      doAssertRaises(IndexDefect):
-        s.delete(1)
 
 static: main()
 main()

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -59,6 +59,11 @@ doAssert high(float) > low(float)
 doAssert high(float32) > low(float32)
 doAssert high(float64) > low(float64)
 
+# bug #6710
+var s = @[1]
+s.delete(0)
+
+
 proc foo(a: openArray[int]) =
   for x in a: echo x
 


### PR DESCRIPTION
This is a too big breaking change to be part of Nim 1.x