### PR TITLE
Fix a bug with starting of asynchronous processes

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1022,7 +1022,7 @@ when defined(windows) or defined(nimdoc):
       raiseOSError(osLastError())
 
     var pcd = cast[PostCallbackDataPtr](allocShared0(sizeof(PostCallbackData)))
-    var flags = WT_EXECUTEINWAITTHREAD.DWORD
+    var flags = WT_EXECUTEINWAITTHREAD.DWORD or WT_EXECUTEONLYONCE.DWORD
 
     proc proccb(fd: AsyncFD, bytesCount: DWORD, errcode: OSErrorCode) =
       closeWaitable(hProcess)


### PR DESCRIPTION
The asynchronous process completion handler callback should be called only once. This is achieved by passing `WT_EXECUTEONLYONCE` flag to the `registerWaitForSingleObject` Windows API procedure.