### PR TITLE
rst: remove redundant blank lines before literal blocks

### DIFF
--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1762,7 +1762,7 @@ proc parseLiteralBlock(p: var RstParser): PRstNode =
   var n = newLeaf("")
   if currentTok(p).kind == tkIndent:
     var indent = currentTok(p).ival
-    inc p.idx
+    while currentTok(p).kind == tkIndent: inc p.idx  # skip blank lines
     while true:
       case currentTok(p).kind
       of tkEof:

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1258,7 +1258,7 @@ proc renderRstToOut(d: PDoc, n: PRstNode, result: var string) =
     doAssert false, "renderRstToOut"
   of rnLiteralBlock:
     renderAux(d, n, "<pre$2>$1</pre>\n",
-                    "\n\n\\begin{rstpre}\n$2\n$1\n\\end{rstpre}\n\n", result)
+                    "\n\n$2\\begin{rstpre}\n$1\n\\end{rstpre}\n\n", result)
   of rnQuotedLiteralBlock:
     doAssert false, "renderRstToOut"
   of rnLineBlock:

--- a/nimdoc/rst2html/expected/rst_examples.html
+++ b/nimdoc/rst2html/expected/rst_examples.html
@@ -133,8 +133,7 @@ window.addEventListener('DOMContentLoaded', main);
 <p><strong>Note</strong>: Assignments, moves, and destruction are specified in the <a class="reference external" href="destructors.html">destructors</a> document.</p>
 <p>The language constructs are explained using an extended BNF, in which <tt class="docutils literal"><span class="pre">(a)*</span></tt> means 0 or more <tt class="docutils literal"><span class="pre">a</span></tt>'s, <tt class="docutils literal"><span class="pre">a+</span></tt> means 1 or more <tt class="docutils literal"><span class="pre">a</span></tt>'s, and <tt class="docutils literal"><span class="pre">(a)?</span></tt> means an optional <em>a</em>. Parentheses may be used to group elements.</p>
 <p><tt class="docutils literal"><span class="pre">&amp;</span></tt> is the lookahead operator; <tt class="docutils literal"><span class="pre">&amp;a</span></tt> means that an <tt class="docutils literal"><span class="pre">a</span></tt> is expected but not consumed. It will be consumed in the following rule.</p>
-<p>Non-terminals start with a lowercase letter, abstract terminal symbols are in UPPERCASE. Verbatim terminal symbols (including keywords) are quoted with <tt class="docutils literal"><span class="pre">'</span></tt>. An example:<pre>
-ifStmt = 'if' expr ':' stmts ('elif' expr ':' stmts)* ('else' stmts)?</pre>
+<p>Non-terminals start with a lowercase letter, abstract terminal symbols are in UPPERCASE. Verbatim terminal symbols (including keywords) are quoted with <tt class="docutils literal"><span class="pre">'</span></tt>. An example:<pre>ifStmt = 'if' expr ':' stmts ('elif' expr ':' stmts)* ('else' stmts)?</pre>
 </p>
 <p>In a typical Nim program, most of the code is compiled into the executable. However, some of the code may be executed at <span id="compileminustime_1">compile-time</span>. This can include constant expressions, macro definitions, and Nim procedures used by macro definitions. Most of the Nim language is supported at compile-time, but there are some restrictions -- see <a class="reference external" href="#restrictions-on-compileminustime-execution">Restrictions on Compile-Time Execution</a> for details. We use the term <span id="runtime_1">runtime</span> to cover both compile-time execution and code execution in the executable.</p>
 <pre class="listing"><span class="Keyword">var</span> <span class="Identifier">a</span><span class="Punctuation">:</span> <span class="Identifier">array</span><span class="Punctuation">[</span><span class="FloatNumber">0.</span><span class="Operator">.</span><span class="DecNumber">1</span><span class="Punctuation">,</span> <span class="Identifier">char</span><span class="Punctuation">]</span>
@@ -146,8 +145,7 @@ ifStmt = 'if' expr ':' stmts ('elif' expr ':' stmts)* ('else' stmts)?</pre>
 <h2><a class="toc-backref" id="about-this-document-encoding" href="#about-this-document-encoding">Encoding</a></h2><p>All Nim source files are in the UTF-8 encoding (or its ASCII subset). Other encodings are not supported. Any of the standard platform line termination sequences can be used - the Unix form using ASCII LF (linefeed), the Windows form using the ASCII sequence CR LF (return followed by linefeed), or the old Macintosh form using the ASCII CR (return) character. All of these forms can be used equally, regardless of the platform.</p>
 
 <h2><a class="toc-backref" id="about-this-document-indentation" href="#about-this-document-indentation">Indentation</a></h2><p>Nim's standard grammar describes an <span id="indentation-sensitive_1">indentation sensitive</span> language. This means that all the control structures are recognized by indentation. Indentation consists only of spaces; tabulators are not allowed.</p>
-<p>With this notation we can now easily define the core of the grammar: A block of statements (simplified example):<pre>
-ifStmt = 'if' expr ':' stmt
+<p>With this notation we can now easily define the core of the grammar: A block of statements (simplified example):<pre>ifStmt = 'if' expr ':' stmt
          (IND{=} 'elif' expr ':' stmt)*
          (IND{=} 'else' ':' stmt)?
 
@@ -174,18 +172,15 @@ stmt = IND{&gt;} stmt ^+ IND{=} DED  # list of statements
 <tr><td><tt class="docutils literal"><span class="pre">\x</span></tt> HH</td><td><span id="character-with-hex-value-hh_1">character with hex value HH</span>; exactly two hex digits are allowed</td></tr>
 <tr><td><tt class="docutils literal"><span class="pre">\u</span></tt> HHHH</td><td><span id="unicode-codepoint-with-hex-value-hhhh_1">unicode codepoint with hex value HHHH</span>; exactly four hex digits are allowed</td></tr>
 <tr><td><tt class="docutils literal"><span class="pre">\u</span></tt> {H+}</td><td><span id="unicode-codepoint_1">unicode codepoint</span>; all hex digits enclosed in <tt class="docutils literal"><span class="pre">{}</span></tt> are used for the codepoint</td></tr>
-</table><pre class="listing"><span class="LongStringLit">&quot;&quot;&quot;&quot;long string within quotes&quot;&quot;&quot;&quot;</span></pre><p>Produces:<pre>
-&quot;long string within quotes&quot;</pre>
+</table><pre class="listing"><span class="LongStringLit">&quot;&quot;&quot;&quot;long string within quotes&quot;&quot;&quot;&quot;</span></pre><p>Produces:<pre>&quot;long string within quotes&quot;</pre>
 </p>
 
-<h2><a class="toc-backref" id="about-this-document-operators" href="#about-this-document-operators">Operators</a></h2><p>Nim allows user defined operators. An operator is any combination of the following characters:<pre>
-=     +     -     *     /     &lt;     &gt;
+<h2><a class="toc-backref" id="about-this-document-operators" href="#about-this-document-operators">Operators</a></h2><p>Nim allows user defined operators. An operator is any combination of the following characters:<pre>=     +     -     *     /     &lt;     &gt;
 @     $     ~     &amp;     %     |
 !     ?     ^     .     :     \</pre>
 </p>
 <p>(The grammar uses the terminal OPR to refer to operator symbols as defined here.)</p>
-<p>The following strings denote other tokens:<pre>
-`   (    )     {    }     [    ]    ,  ;   [.    .]  {.   .}  (.  .)  [:</pre>
+<p>The following strings denote other tokens:<pre>`   (    )     {    }     [    ]    ,  ;   [.    .]  {.   .}  (.  .)  [:</pre>
 </p>
 <p>Otherwise, precedence is determined by the first character.</p>
 <table border="1" class="docutils"><tr><th>Precedence level</th><th>Operators</th><th>First character</th><th>Terminal symbol</th></tr>

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -196,6 +196,22 @@ suite "RST parsing":
               rnLeaf  'someBlockQuote'
         """)
 
+  test "no redundant blank lines in literal blocks":
+    check(dedent"""
+      Check::
+
+
+        code
+
+      """.toAst ==
+      dedent"""
+        rnInner
+          rnLeaf  'Check'
+          rnLeaf  ':'
+          rnLiteralBlock
+            rnLeaf  'code'
+      """)
+
 suite "RST indentation":
   test "nested bullet lists":
     let input = dedent """


### PR DESCRIPTION
E.g.
```
See::


  code
```

added 1 extra line in HTML:
![image](https://user-images.githubusercontent.com/1299583/124983874-331d8200-e041-11eb-9925-086df1834ac5.png)

(or 2 lines in Latex).

After:
![image](https://user-images.githubusercontent.com/1299583/124983981-56e0c800-e041-11eb-9914-86606f78e975.png)
