### PR TITLE
deprecated `nameToCodePage` and `codePageToName`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -95,6 +95,9 @@
 - In `std/dom`, `Interval` is now a `ref object`, same as `Timeout`. Definitions of `setTimeout`,
   `clearTimeout`, `setInterval`, `clearInterval` were updated.
 
+- Deprecated `codePageToName` and `codePageToName` procs
+  in `std/encodings`.
+
 ## Standard library additions and changes
 
 - `strformat`:

--- a/changelog.md
+++ b/changelog.md
@@ -95,7 +95,7 @@
 - In `std/dom`, `Interval` is now a `ref object`, same as `Timeout`. Definitions of `setTimeout`,
   `clearTimeout`, `setInterval`, `clearInterval` were updated.
 
-- Deprecated `codePageToName` and `codePageToName` procs
+- Deprecated `nameToCodePage` and `codePageToName` procs
   in `std/encodings`.
 
 ## Standard library additions and changes

--- a/lib/pure/encodings.nim
+++ b/lib/pure/encodings.nim
@@ -258,7 +258,7 @@ when defined(windows):
   proc nameToCodePage*(name: string): CodePage {.deprecated.} =
     result = nameToCodePageImpl(name)
 
-  proc codePageToNameImpl(c: CodePage): string =
+  proc codePageToNameImpl(c: CodePage): string {.inline.} =
     for no, na in items(winEncodings):
       if no == int(c):
         return if na.len != 0: na else: $no


### PR DESCRIPTION
- Not used in other modules, not documented on docs.
- They are windows specific procs and should not be exported. We should only export what is needed, which can reduce surprise. It can pollute variable namespace, hinder future's refactor ...
- The type `CodePage` is not even exported(though you can argue it is "self-contained") :P


```nim
proc nameToCodePage*(name: string): CodePage
proc codePageToName*(c: CodePage): string 
```