### PR TITLE
[source code filter]fix Nightlies bug

### DIFF
--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -25,6 +25,7 @@ endif
 
 ifeq ($(uos),linux)
   myos = linux
+  ## add -lrt to avoid "undefined reference to `clock_gettime'" with glibc<2.17
   LDFLAGS += -ldl -lm -lrt
 endif
 ifeq ($(uos),dragonfly)

--- a/tools/niminst/makefile.nimf
+++ b/tools/niminst/makefile.nimf
@@ -25,7 +25,6 @@ endif
 
 ifeq ($(uos),linux)
   myos = linux
-  # add -lrt to avoid "undefined reference to `clock_gettime'" with glibc<2.17
   LDFLAGS += -ldl -lm -lrt
 endif
 ifeq ($(uos),dragonfly)


### PR DESCRIPTION
The bug
https://github.com/nim-lang/nightlies/runs/3037976760?check_suite_focus=true#step:11:11

Ref https://github.com/nim-lang/Nim/pull/18427

```
bin/nim cc -d:danger -d:gitHash:3645f5fc7ae885e22cb52b9f865edf062cfb8e59 -r tools/niminst/niminst --var:version=1.5.1 --var:mingw=none csource --main:compiler/nim.nim compiler/installer.ini -d:danger -d:gitHash:3645f5fc7ae885e22cb52b9f865edf062cfb8e59
Hint: used config file '/home/runner/work/nightlies/nightlies/nim/config/nim.cfg' [Conf]
Hint: used config file '/home/runner/work/nightlies/nightlies/nim/config/config.nims' [Conf]
...............................................................................................................
/home/runner/work/nightlies/nightlies/nim/tools/niminst/makefile.nimf(28, 8) Error: undeclared identifier: 'lrt'
```

It may be a bit hacky, at least we should document it. Another issue is how can we escape `#`?