### PR TITLE
fix #18142: nim doc now works across windows partitions (and make `nativeToUnixPath` work with abs paths)

### DIFF
--- a/lib/std/private/globs.nim
+++ b/lib/std/private/globs.nim
@@ -45,10 +45,15 @@ iterator walkDirRecFilter*(dir: string, follow: proc(entry: PathEntry): bool = n
 
 proc nativeToUnixPath*(path: string): string =
   # pending https://github.com/nim-lang/Nim/pull/13265
-  doAssert not path.isAbsolute # not implemented here; absolute files need more care for the drive
+  result = path
+  when defined(windows):
+    if path.len >= 2 and path[0] in {'a'..'z', 'A'..'Z'} and path[1] == ':':
+      result[0] = '/'
+      result[1] = path[0]
+      if path.len > 2 and path[2] != '\\':
+        doAssert false, "paths like `C:foo` are currently unsupported, path: " & path
   when DirSep == '\\':
-    result = replace(path, '\\', '/')
-  else: result = path
+    result = replace(result, '\\', '/')
 
 when isMainModule:
   import sugar

--- a/tests/stdlib/tglobs.nim
+++ b/tests/stdlib/tglobs.nim
@@ -1,0 +1,20 @@
+import std/private/globs
+
+template main =
+  when defined(windows):
+    doAssert nativeToUnixPath("C:") == "/C"
+    doAssert nativeToUnixPath(r"D:\") == "/D/"
+    doAssert nativeToUnixPath(r"E:\a") == "/E/a"
+    doAssert nativeToUnixPath(r"E:\a1\") == "/E/a1/"
+    doAssert nativeToUnixPath(r"E:\a1\bc") == "/E/a1/bc"
+    doAssert nativeToUnixPath(r"\a1\bc") == "/a1/bc"
+    doAssert nativeToUnixPath(r"a1\bc") == "a1/bc"
+    doAssert nativeToUnixPath("a1") == "a1"
+    doAssert nativeToUnixPath("") == ""
+    doAssert nativeToUnixPath(".") == "."
+    doAssert nativeToUnixPath("..") == ".."
+    doAssert nativeToUnixPath(r"..\") == "../"
+    doAssert nativeToUnixPath(r"..\..\.\") == "../.././"
+
+static: main()
+main()


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/18142 (and this was also needed in another PR)

follows cygwin convention which is the most reasonable way to convert C:\foo to a unix path