### PR TITLE
Make error message for empty new-styled concept more descriptive

### DIFF
--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -58,8 +58,6 @@ proc semConceptDecl(c: PContext; n: PNode): PNode =
     for i in 0..<n.len-1:
       result[i] = n[i]
     result[^1] = semConceptDecl(c, n[^1])
-  of nkEmpty:
-    result = n
   else:
     localError(c.config, n.info, "unexpected construct in the new-styled concept: " & renderTree(n))
     result = n
@@ -303,8 +301,6 @@ proc conceptMatchNode(c: PContext; n: PNode; m: var MatchCon): bool =
     result = matchSyms(c, n, {skMethod}, m)
   of nkIteratorDef:
     result = matchSyms(c, n, {skIterator}, m)
-  of nkEmpty:
-    result = true
   else:
     # error was reported earlier.
     result = false

--- a/compiler/concepts.nim
+++ b/compiler/concepts.nim
@@ -11,8 +11,7 @@
 ## for details. Note this is a first implementation and only the "Concept matching"
 ## section has been implemented.
 
-import ast, astalgo, semdata, lookups, lineinfos, idents, msgs, renderer,
-  types, intsets
+import ast, astalgo, semdata, lookups, lineinfos, idents, msgs, renderer, types, intsets
 
 from magicsys import addSonSkipIntLit
 
@@ -23,7 +22,7 @@ const
 ## --------------------------------------
 
 proc declareSelf(c: PContext; info: TLineInfo) =
-  ## adds the magical 'Self' symbols to the current scope.
+  ## Adds the magical 'Self' symbols to the current scope.
   let ow = getCurrOwner(c)
   let s = newSym(skType, getIdent(c.cache, "Self"), nextSymId(c.idgen), ow, info)
   s.typ = newType(tyTypeDesc, nextTypeId(c.idgen), ow)
@@ -32,7 +31,7 @@ proc declareSelf(c: PContext; info: TLineInfo) =
   addDecl(c, s, info)
 
 proc isSelf*(t: PType): bool {.inline.} =
-  ## is this the magical 'Self' type?
+  ## Is this the magical 'Self' type?
   t.kind == tyTypeDesc and tfPacked in t.flags
 
 proc makeTypeDesc*(c: PContext, typ: PType): PType =
@@ -45,8 +44,8 @@ proc makeTypeDesc*(c: PContext, typ: PType): PType =
 
 proc semConceptDecl(c: PContext; n: PNode): PNode =
   ## Recursive helper for semantic checking for the concept declaration.
-  ## Currently we only support lists of statements containing 'proc'
-  ## declarations and the like.
+  ## Currently we only support (possibly empty) lists of statements
+  ## containing 'proc' declarations and the like.
   case n.kind
   of nkStmtList, nkStmtListExpr:
     result = shallowCopy(n)
@@ -59,8 +58,10 @@ proc semConceptDecl(c: PContext; n: PNode): PNode =
     for i in 0..<n.len-1:
       result[i] = n[i]
     result[^1] = semConceptDecl(c, n[^1])
+  of nkEmpty:
+    result = n
   else:
-    localError(c.config, n.info, "unexpected construct in the new-styled concept " & renderTree(n))
+    localError(c.config, n.info, "unexpected construct in the new-styled concept: " & renderTree(n))
     result = n
 
 proc semConceptDeclaration*(c: PContext; n: PNode): PNode =
@@ -97,7 +98,7 @@ proc existingBinding(m: MatchCon; key: PType): PType =
 proc conceptMatchNode(c: PContext; n: PNode; m: var MatchCon): bool
 
 proc matchType(c: PContext; f, a: PType; m: var MatchCon): bool =
-  ## the heart of the concept matching process. 'f' is the formal parameter of some
+  ## The heart of the concept matching process. 'f' is the formal parameter of some
   ## routine inside the concept that we're looking for. 'a' is the formal parameter
   ## of a routine that might match.
   const
@@ -302,6 +303,8 @@ proc conceptMatchNode(c: PContext; n: PNode; m: var MatchCon): bool =
     result = matchSyms(c, n, {skMethod}, m)
   of nkIteratorDef:
     result = matchSyms(c, n, {skIterator}, m)
+  of nkEmpty:
+    result = true
   else:
     # error was reported earlier.
     result = false

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -2058,6 +2058,8 @@ proc parseTypeClass(p: var Parser): PNode =
     skipComment(p, result)
   # an initial IND{>} HAS to follow:
   if not realInd(p):
+    if result.isNewStyleConcept:
+      parMessage(p, "routine expected, but found '$1' (empty new-styled concepts are not allowed)", p.tok)
     result.add(p.emptyNode)
   else:
     result.add(parseStmt(p))

--- a/tests/concepts/tspec.nim
+++ b/tests/concepts/tspec.nim
@@ -103,13 +103,3 @@ proc z(x: typedesc[int]): int = 0
 
 doAssert int is Monoid
 
-
-# empty concept
-
-type
-  Test = object
-  Empty = concept
-
-doAssert int is Empty
-doAssert seq[int] is Empty
-doAssert Test is Empty

--- a/tests/concepts/tspec.nim
+++ b/tests/concepts/tspec.nim
@@ -7,8 +7,7 @@ discard """
 2
 3
 yes int
-string int
-true'''
+string int'''
   joinable: false
 """
 
@@ -102,5 +101,15 @@ type Monoid = concept
 
 proc z(x: typedesc[int]): int = 0
 
-echo(int is Monoid)
+doAssert int is Monoid
 
+
+# empty concept
+
+type
+  Test = object
+  Empty = concept
+
+doAssert int is Empty
+doAssert seq[int] is Empty
+doAssert Test is Empty


### PR DESCRIPTION
Refs #17419.

This PR solves problem 2 of #17419 by allowing empty (new-styled) concepts and making them match for every type.

It also slightly improves the error messages for invalid concepts, by adding a colon before rendering the invalid statement. In the long run, I think this problem should be solved in the parser (separating between old and new concepts) by only allowing routine declarations. Then something like
```nim
type
  A = concept
    if true:
      1
    else:
      2
```
could return `routine expected, but got 'keyword if'` instead of the current error message:
```
unexpected construct in the new-styled concept: if true:
  1
else:
  2
```
However, I don't know how the compiler (and the parser in particular) works (yet?), so unfortunately I can't really help there.