### PR TITLE
std/os on windows: `isAbsolute("C:foo")` is now false, `normalizedPath(r"C:\")` is now `C:\`, etc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,6 +42,12 @@
 - In `std/os`, `getHomeDir`, `expandTilde`, `getTempDir`, `getConfigDir` now do not include trailing `DirSep`,
   unless `-d:nimLegacyHomeDir` is specified (for a transition period).
 
+- In `std/os`, on windows, APIs are now correctly handling relative paths starting with a drive:
+  `isAbsolute("C:")` is now false
+  `isAbsolute("C:foo")` is now false
+  `normalizePathEnd(r"C:\")` is now `C:\` instead of r"C:"
+  `normalizedPath(r"C:\")` is now `C:\` instead of r"C:", likewise with `normalizePath`
+
 - On POSIX systems, the default signal handlers used for Nim programs (it's
   used for printing the stacktrace on fatal signals) will now re-raise the
   signal for the OS default handlers to handle.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -291,7 +291,10 @@ proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raise
   runnableExamples:
     assert not "".isAbsolute
     assert not ".".isAbsolute
-    when defined(posix):
+    when defined(windows):
+      assert r"C:\".isAbsolute
+      assert not r"D:foo\bar".isAbsolute # relative path in ``D:\``
+    elif defined(posix):
       assert "/".isAbsolute
       assert not "a/".isAbsolute
       assert "/a/".isAbsolute
@@ -301,7 +304,7 @@ proc isAbsolute*(path: string): bool {.rtl, noSideEffect, extern: "nos$1", raise
   when doslikeFileSystem:
     var len = len(path)
     result = (path[0] in {'/', '\\'}) or
-              (len > 1 and path[0] in {'a'..'z', 'A'..'Z'} and path[1] == ':')
+              (len >= 3 and path[0] in {'a'..'z', 'A'..'Z'} and path[1] == ':' and path[2] in {'/', '\\'})
   elif defined(macos):
     # according to https://perldoc.perl.org/File/Spec/Mac.html `:a` is a relative path
     result = path[0] != ':'

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -27,6 +27,7 @@ Raises
 
 import os, strutils, pathnorm
 from stdtest/specialpaths import buildDir
+import stdtest/testutils
 
 block fileOperations:
   let files = @["these.txt", "are.x", "testing.r", "files.q"]
@@ -427,12 +428,6 @@ block ospaths:
   doAssert unixToNativePath("") == ""
   doAssert unixToNativePath(".") == $CurDir
   doAssert unixToNativePath("..") == $ParDir
-  doAssert isAbsolute(unixToNativePath("/"))
-  doAssert isAbsolute(unixToNativePath("/", "a"))
-  doAssert isAbsolute(unixToNativePath("/a"))
-  doAssert isAbsolute(unixToNativePath("/a", "a"))
-  doAssert isAbsolute(unixToNativePath("/a/b"))
-  doAssert isAbsolute(unixToNativePath("/a/b", "a"))
   doAssert unixToNativePath("a/b") == joinPath("a", "b")
 
   when defined(macos):
@@ -710,3 +705,35 @@ block: # isAdmin
   if isAzure and defined(windows): doAssert isAdmin()
   # In Azure on POSIX tests run as a normal user
   if isAzure and defined(posix): doAssert not isAdmin()
+
+template main =
+  # xxx move all tests here so they get tested in VM (disabling as needed)
+  block: # isAbsolute
+    assertAll:
+      isAbsolute(r"/")
+      isAbsolute(r"/foo")
+      not isAbsolute(r"foo")
+      not isAbsolute(r"")
+      not isAbsolute(r".")
+      not isAbsolute(r"..")
+    when defined(windows):
+      assertAll:
+        isAbsolute(r"C:\")
+        isAbsolute(r"B:/")
+        isAbsolute(r"c:\a")
+        isAbsolute(r"X://ab/")
+        isAbsolute(r"\")
+        not isAbsolute(r"C:")
+        not isAbsolute(r"C:foo")
+        not isAbsolute(r"foo\bar")
+    assertAll:
+      isAbsolute(unixToNativePath("/"))
+      isAbsolute(unixToNativePath("/", "a"))
+      isAbsolute(unixToNativePath("/a"))
+      isAbsolute(unixToNativePath("/a", "a"))
+      isAbsolute(unixToNativePath("/a/b"))
+      isAbsolute(unixToNativePath("/a/b", "a"))
+
+static: main()
+main()
+

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -656,9 +656,8 @@ block: # normalizePathEnd
   when defined(windows):
     doAssert r"C:\foo\\".normalizePathEnd == r"C:\foo"
     doAssert r"C:\foo".normalizePathEnd(trailingSep = true) == r"C:\foo\"
-    # this one is controversial: we could argue for returning `D:\` instead,
-    # but this is simplest.
-    doAssert r"D:\".normalizePathEnd == r"D:"
+    doAssert r"D:\".normalizePathEnd == r"D:\"
+    doAssert r"D:foo\".normalizePathEnd == r"D:foo"
     doAssert r"E:/".normalizePathEnd(trailingSep = true) == r"E:\"
     doAssert "/".normalizePathEnd == r"\"
 
@@ -709,31 +708,14 @@ block: # isAdmin
 template main =
   # xxx move all tests here so they get tested in VM (disabling as needed)
   block: # isAbsolute
-    assertAll:
-      isAbsolute(r"/")
-      isAbsolute(r"/foo")
-      not isAbsolute(r"foo")
-      not isAbsolute(r"")
-      not isAbsolute(r".")
-      not isAbsolute(r"..")
+    for a in ["/", "/foo", "//"]: doAssert isAbsolute(a)
+    for a in ["", "foo", ".", ".."]: doAssert not isAbsolute(a)
+    for a in ["/", "/a", "/a/b"]:
+      doAssert isAbsolute(unixToNativePath(a))
+      doAssert isAbsolute(unixToNativePath(a, "a"))
     when defined(windows):
-      assertAll:
-        isAbsolute(r"C:\")
-        isAbsolute(r"B:/")
-        isAbsolute(r"c:\a")
-        isAbsolute(r"X://ab/")
-        isAbsolute(r"\")
-        not isAbsolute(r"C:")
-        not isAbsolute(r"C:foo")
-        not isAbsolute(r"foo\bar")
-    assertAll:
-      isAbsolute(unixToNativePath("/"))
-      isAbsolute(unixToNativePath("/", "a"))
-      isAbsolute(unixToNativePath("/a"))
-      isAbsolute(unixToNativePath("/a", "a"))
-      isAbsolute(unixToNativePath("/a/b"))
-      isAbsolute(unixToNativePath("/a/b", "a"))
+      for a in [r"C:\", r"B:/", r"c:\a", r"X://ab/", r"\"]: doAssert isAbsolute(a)
+      for a in [r"C:", r"C:foo", r"foo\bar"]: doAssert not isAbsolute(a)
 
 static: main()
 main()
-

--- a/tests/stdlib/tpathnorm.nim
+++ b/tests/stdlib/tpathnorm.nim
@@ -1,0 +1,5 @@
+when defined(windows):
+  block: # isWindowsDrive
+    assert isWindowsDrive(r"c:\")
+    assert isWindowsDrive(r"c:/")
+    for a in [r"c:\abc", r"c:abc", r"c:", "abc", r"\", "/", ""]: assert not isWindowsDrive(a)


### PR DESCRIPTION
`C:foo` is a relative path in drive C:\, not an absolute path

* refs: https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats
* ditto in python
* normalizePath and normalizedPath are now consistent with python3's `os.path.normpath` for C:, C:foo, C:\, as well as with windows semantics

## other related fixes:
* `isAbsolute("C:")` is now false
* `isAbsolute("C:foo")` is now false
* `normalizePathEnd(r"C:\")` is now `C:\` instead of r"C:"
* `normalizedPath(r"C:\")` is now `C:\` instead of r"C:", likewise with `normalizePath`
