### PR TITLE
add NIM_STATIC_ASSERT(CHAR_BIT == 8, "") to fail-fast where assumption is violated

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -325,6 +325,9 @@ typedef unsigned char NIM_BOOL; // best effort
 #endif
 
 NIM_STATIC_ASSERT(sizeof(NIM_BOOL) == 1, ""); // check whether really needed
+NIM_STATIC_ASSERT(CHAR_BIT == 8, "");
+  // fail fast for (rare) environments where this doesn't hold, as some implicit
+  // assumptions would need revisiting (e.g. `uint8` or https://github.com/nim-lang/Nim/pull/18505)
 
 #define NIM_TRUE true
 #define NIM_FALSE false


### PR DESCRIPTION
refs:
* https://stackoverflow.com/questions/32091992/is-char-bit-ever-8
* https://stackoverflow.com/questions/2098149/what-platforms-have-something-other-than-8-bit-char

some machines in use today violate CHAR_BIT == 8 which is implicitly assumed in parts of compiler (eg uint8 or things like https://github.com/nim-lang/Nim/pull/18505), so it's better to fail-fast
