### PR TITLE
nim doc now correctly renders deprecated pragmas for routines and types

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1169,6 +1169,22 @@ template `[]`*(n: Indexable, i: BackwardsIndex): Indexable = n[n.len - i.int]
 template `[]=`*(n: Indexable, i: BackwardsIndex; x: Indexable) = n[n.len - i.int] = x
 
 proc getDeclPragma*(n: PNode): PNode =
+  #[
+  type F3*{.deprecated: "x3".} = int
+
+  TypeSection
+    TypeDef
+      PragmaExpr
+        Postfix
+          Ident "*"
+          Ident "F3"
+        Pragma
+          ExprColonExpr
+            Ident "deprecated"
+            StrLit "x3"
+      Empty
+      Ident "int"
+  ]#
   case n.kind
   of routineDefs:
     if n[pragmasPos].kind != nkEmpty: result = n[pragmasPos]

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1169,26 +1169,28 @@ template `[]`*(n: Indexable, i: BackwardsIndex): Indexable = n[n.len - i.int]
 template `[]=`*(n: Indexable, i: BackwardsIndex; x: Indexable) = n[n.len - i.int] = x
 
 proc getDeclPragma*(n: PNode): PNode =
-  #[
-  type F3*{.deprecated: "x3".} = int
-
-  TypeSection
-    TypeDef
-      PragmaExpr
-        Postfix
-          Ident "*"
-          Ident "F3"
-        Pragma
-          ExprColonExpr
-            Ident "deprecated"
-            StrLit "x3"
-      Empty
-      Ident "int"
-  ]#
+  ## return the `nkPragma` node for declaration `n`, or `nil` if no pragma was found.
+  ## Currently only supports routineDefs + {nkTypeDef}.
   case n.kind
   of routineDefs:
     if n[pragmasPos].kind != nkEmpty: result = n[pragmasPos]
   of nkTypeDef:
+    #[
+    type F3*{.deprecated: "x3".} = int
+
+    TypeSection
+      TypeDef
+        PragmaExpr
+          Postfix
+            Ident "*"
+            Ident "F3"
+          Pragma
+            ExprColonExpr
+              Ident "deprecated"
+              StrLit "x3"
+        Empty
+        Ident "int"
+    ]#
     if n[0].kind == nkPragmaExpr:
       result = n[0][1]
   else:

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1168,6 +1168,19 @@ template `[]=`*(n: Indexable, i: int; x: Indexable) = n.sons[i] = x
 template `[]`*(n: Indexable, i: BackwardsIndex): Indexable = n[n.len - i.int]
 template `[]=`*(n: Indexable, i: BackwardsIndex; x: Indexable) = n[n.len - i.int] = x
 
+proc getDeclPragma*(n: PNode): PNode =
+  case n.kind
+  of routineDefs:
+    if n[pragmasPos].kind != nkEmpty: result = n[pragmasPos]
+  of nkTypeDef:
+    if n[0].kind == nkPragmaExpr:
+      result = n[0][1]
+  else:
+    # support as needed
+    doAssert false, "getDeclPragma: unsupported: " & $n.kind
+  if result != nil:
+    assert result.kind == nkPragma, $(result.kind, n.kind)
+
 when defined(useNodeIds):
   const nodeIdToDebug* = -1 # 2322968
   var gNodeId: int

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1192,8 +1192,8 @@ proc getDeclPragma*(n: PNode): PNode =
     if n[0].kind == nkPragmaExpr:
       result = n[0][1]
   else:
-    # support as needed
-    doAssert false, "getDeclPragma: unsupported: " & $n.kind
+    # support as needed for `nkIdentDefs` etc.
+    result = nil
   if result != nil:
     assert result.kind == nkPragma, $(result.kind, n.kind)
 

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -856,25 +856,6 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
 
   var pragmaNode = getDeclPragma(n)
   if pragmaNode != nil: pragmaNode = findPragma(pragmaNode, wDeprecated)
-#[
-compensate for a very non-intuitive AST; if it gets updated (and an API is added),
-this can be udpated.
-
-type F3*{.deprecated: "x3".} = int
-
-TypeSection
-  TypeDef
-    PragmaExpr
-      Postfix
-        Ident "*"
-        Ident "F3"
-      Pragma
-        ExprColonExpr
-          Ident "deprecated"
-          StrLit "x3"
-    Empty
-    Ident "int"
-]#
 
   inc(d.id)
   let

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -764,14 +764,6 @@ proc complexName(k: TSymKind, n: PNode, baseName: string): string =
       result.add(defaultParamSeparator)
       result.add(params)
 
-proc isCallable(n: PNode): bool =
-  ## Returns true if `n` contains a callable node.
-  case n.kind
-  of nkProcDef, nkMethodDef, nkIteratorDef, nkMacroDef, nkTemplateDef,
-    nkConverterDef, nkFuncDef: result = true
-  else:
-    result = false
-
 proc docstringSummary(rstText: string): string =
   ## Returns just the first line or a brief chunk of text from a rst string.
   ##
@@ -862,9 +854,27 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
       break
     plainName.add(literal)
 
-  var pragmaNode: PNode = nil
-  if n.isCallable and n[pragmasPos].kind != nkEmpty:
-    pragmaNode = findPragma(n[pragmasPos], wDeprecated)
+  var pragmaNode = getDeclPragma(n)
+  if pragmaNode != nil: pragmaNode = findPragma(pragmaNode, wDeprecated)
+#[
+compensate for a very non-intuitive AST; if it gets updated (and an API is added),
+this can be udpated.
+
+type F3*{.deprecated: "x3".} = int
+
+TypeSection
+  TypeDef
+    PragmaExpr
+      Postfix
+        Ident "*"
+        Ident "F3"
+      Pragma
+        ExprColonExpr
+          Ident "deprecated"
+          StrLit "x3"
+    Empty
+    Ident "int"
+]#
 
   inc(d.id)
   let
@@ -920,7 +930,7 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   # because it doesn't include object fields or documentation comments. So we
   # use the plain one for callable elements, and the complex for the rest.
   var linkTitle = changeFileExt(extractFilename(d.filename), "") & ": "
-  if n.isCallable: linkTitle.add(xmltree.escape(plainName.strip))
+  if n.kind in routineDefs: linkTitle.add(xmltree.escape(plainName.strip))
   else: linkTitle.add(xmltree.escape(complexSymbol.strip))
 
   setIndexTerm(d[], external, symbolOrId, name, linkTitle,

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -593,8 +593,8 @@ proc isHideable(config: ConfigRef, n: PNode): bool =
   # xxx compare `ident` directly with `getIdent(cache, wRaises)`, but
   # this requires a `cache`.
   case n.kind
-  of nkExprColonExpr: result = n[0].kind == nkIdent and n[0].ident.s in ["raises", "tags", "extern"]
-  of nkIdent: result = n.ident.s in ["gcsafe"]
+  of nkExprColonExpr: result = n[0].kind == nkIdent and n[0].ident.s in ["raises", "tags", "extern", "deprecated"]
+  of nkIdent: result = n.ident.s in ["gcsafe", "deprecated"]
   else: result = false
 
 proc gcommaAux(g: var TSrcGen, n: PNode, ind: int, start: int = 0,

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -107,7 +107,9 @@ window.addEventListener('DOMContentLoaded', main);
 <li>
   <a class="reference reference-toplevel" href="#7" id="57">Types</a>
   <ul class="simple simple-toc-section">
-      <li><a class="reference" href="#A"
+      <li><a class="reference" href="#FooBuzz"
+    title="FooBuzz {.deprecated: &quot;FooBuzz msg&quot;.} = int">FooBuzz</a></li>
+  <li><a class="reference" href="#A"
     title="A {.inject.} = enum
   aA">A</a></li>
   <li><a class="reference" href="#B"
@@ -445,6 +447,16 @@ window.addEventListener('DOMContentLoaded', main);
 <div class="section" id="7">
 <h1><a class="toc-backref" href="#7">Types</a></h1>
 <dl class="item">
+<a id="FooBuzz"></a>
+<dt><pre><a href="testproject.html#FooBuzz"><span class="Identifier">FooBuzz</span></a> {.<span><span class="Other pragmadots">...</span></span><span class="pragmawrap"><span class="Identifier">deprecated</span><span class="Other">:</span> <span class="StringLit">&quot;FooBuzz msg&quot;</span></span>.} <span class="Other">=</span> <span class="Identifier">int</span></pre></dt>
+<dd>
+  <div class="deprecation-message">
+    <b>Deprecated:</b> FooBuzz msg
+  </div>
+
+
+
+</dd>
 <a id="A"></a>
 <dt><pre><a href="testproject.html#A"><span class="Identifier">A</span></a> {.<span class="Identifier">inject</span>.} <span class="Other">=</span> <span class="Keyword">enum</span>
   <span class="Identifier">aA</span></pre></dt>
@@ -544,7 +556,7 @@ This should be visible.
 
 </dd>
 <a id="baz,T,T"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#baz%2CT%2CT"><span class="Identifier">baz</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span> {.<span class="Identifier">deprecated</span>.}</pre></dt>
+<dt><pre><span class="Keyword">proc</span> <a href="#baz%2CT%2CT"><span class="Identifier">baz</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span> {.<span><span class="Other pragmadots">...</span></span><span class="pragmawrap"><span class="Identifier">deprecated</span></span>.}</pre></dt>
 <dd>
   <div class="deprecation-message">
     <b>Deprecated</b> 
@@ -554,7 +566,7 @@ This is deprecated without message.
 
 </dd>
 <a id="buzz,T,T"></a>
-<dt><pre><span class="Keyword">proc</span> <a href="#buzz%2CT%2CT"><span class="Identifier">buzz</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span> {.<span class="Identifier">deprecated</span><span class="Other">:</span> <span class="StringLit">&quot;since v0.20&quot;</span>.}</pre></dt>
+<dt><pre><span class="Keyword">proc</span> <a href="#buzz%2CT%2CT"><span class="Identifier">buzz</span></a><span class="Other">[</span><span class="Identifier">T</span><span class="Other">]</span><span class="Other">(</span><span class="Identifier">a</span><span class="Other">,</span> <span class="Identifier">b</span><span class="Other">:</span> <span class="Identifier">T</span><span class="Other">)</span><span class="Other">:</span> <span class="Identifier">T</span> {.<span><span class="Other pragmadots">...</span></span><span class="pragmawrap"><span class="Identifier">deprecated</span><span class="Other">:</span> <span class="StringLit">&quot;since v0.20&quot;</span></span>.}</pre></dt>
 <dd>
   <div class="deprecation-message">
     <b>Deprecated:</b> since v0.20

--- a/nimdoc/testproject/expected/testproject.idx
+++ b/nimdoc/testproject/expected/testproject.idx
@@ -6,6 +6,7 @@ C_D	testproject.html#C_D	testproject: C_D
 bar	testproject.html#bar,T,T	testproject: bar[T](a, b: T): T	
 baz	testproject.html#baz,T,T	testproject: baz[T](a, b: T): T	
 buzz	testproject.html#buzz,T,T	testproject: buzz[T](a, b: T): T	
+FooBuzz	testproject.html#FooBuzz	testproject: FooBuzz	
 aVariable	testproject.html#aVariable	testproject: aVariable	
 A	testproject.html#A	testproject: A	
 B	testproject.html#B	testproject: B	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -179,6 +179,10 @@ window.addEventListener('DOMContentLoaded', main);
 <li><a class="reference external"
           data-doc-search-tag="testproject: foo(a, b: SomeType)" href="testproject.html#foo.t%2CSomeType%2CSomeType">testproject: foo(a, b: SomeType)</a></li>
           </ul></dd>
+<dt><a name="FooBuzz" href="#FooBuzz"><span>FooBuzz:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="testproject: FooBuzz" href="testproject.html#FooBuzz">testproject: FooBuzz</a></li>
+          </ul></dd>
 <dt><a name="fromUtils1" href="#fromUtils1"><span>fromUtils1:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="testproject: fromUtils1(): int" href="testproject.html#fromUtils1.i">testproject: fromUtils1(): int</a></li>

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -39,6 +39,9 @@ proc buzz*[T](a, b: T): T {.deprecated: "since v0.20".} =
   ## This is deprecated with a message.
   result = a + b
 
+type
+  FooBuzz* {.deprecated: "FooBuzz msg".} = int
+
 import std/macros
 
 var aVariable*: array[1, int]


### PR DESCRIPTION
* follows https://github.com/nim-lang/Nim/pull/17054
* types now render deprecated pragma like routines
* we now hide by default deprecation pragma since a deprecated msg is now generated in all cases

## example
```nim
when true:
  proc fn1*() {.deprecated.} = discard
  proc fn2*() {.deprecated: "bar".} = discard
  type F3*{.deprecated: "x3".} = int
```

## before PR:
![image](https://user-images.githubusercontent.com/2194784/126050977-585b55d6-acda-4e10-9b2a-c0e802fc5aa8.png)

## after PR
![image](https://user-images.githubusercontent.com/2194784/126050985-887a4d74-8b88-48d6-bbe8-c8a086ff7474.png)

