### PR TITLE
termux, look for SSL ca file from package `ca-certificates`

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -647,7 +647,7 @@ when defineSsl:
       if verifyMode != CVerifyNone:
         # Use the caDir and caFile parameters if set
         if caDir != "" or caFile != "":
-          if newCTX.SSL_CTX_load_verify_locations(caFile, caDir) != VerifySuccess:
+          if newCTX.SSL_CTX_load_verify_locations(if caFile == "": nil else: caFile.cstring, if caDir == "": nil else: caDir.cstring) != VerifySuccess:
             raise newException(IOError, "Failed to load SSL/TLS CA certificate(s).")
 
         else:

--- a/lib/pure/ssl_certs.nim
+++ b/lib/pure/ssl_certs.nim
@@ -34,6 +34,7 @@ elif defined(linux):
     # Fedora/RHEL
     "/etc/pki/tls/certs",
     # Android
+    "/data/data/com.termux/files/usr/etc/tls/cert.pem",
     "/system/etc/security/cacerts",
   ]
 elif defined(bsd):


### PR DESCRIPTION
Android does have it's own certificate store which nim will find (from`ssl_certs.nim`):

```nim
elif defined(linux):
  const certificatePaths = [
     # ...
     # Android
    "/system/etc/security/cacerts",
  ]
```

however it is actually a bit sparse and isn't neccessarily suited to general purpose communications. Apps like Firefox on Android use their own certificate stores.

As such termux has the `ca-certificates` package which provides the common file that curl provides :

```
$ pkg info ca-certificates
Package: ca-certificates
Version: 20210603
Maintainer: @termux
Installed-Size: 250 kB
Homepage: https://curl.se/docs/caextract.html
Download-Size: 112 kB
APT-Manual-Installed: yes
APT-Sources: https://grimler.se/termux-packages-24 stable/main aarch64 Packages
Description: Common CA certificates
$ dpkg -L ca-certificates             /.
/data
/data/data
/data/data/com.termux
/data/data/com.termux/files
/data/data/com.termux/files/usr
/data/data/com.termux/files/usr/etc
/data/data/com.termux/files/usr/etc/tls
/data/data/com.termux/files/usr/etc/tls/cert.pem
/data/data/com.termux/files/usr/share
/data/data/com.termux/files/usr/share/doc
/data/data/com.termux/files/usr/share/doc/ca-certificates
/data/data/com.termux/files/usr/share/doc/ca-certificates/LICENSE
```
Seems sensible to use this as a possible path.

Additionally, when trying to add this file manually by creating my own ssl context using `newContext()` I found I couldn't because of issue #18519 , and I have also included in this PR a simple fix for that issue.