### PR TITLE
Docs(manual): add clarification for default params

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3543,7 +3543,8 @@ separation of types and subsequent identifiers more distinct.
   proc foo(a; b: int; c, d: bool): int
 
 A parameter may be declared with a default value which is used if the caller
-does not provide a value for the argument.
+does not provide a value for the argument. The value is just replace by the
+compiler and therefore, if applicable, will be reevaluated at runtime.
 
 .. code-block:: nim
   # b is optional with 47 as its default value

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3543,8 +3543,8 @@ separation of types and subsequent identifiers more distinct.
   proc foo(a; b: int; c, d: bool): int
 
 A parameter may be declared with a default value which is used if the caller
-does not provide a value for the argument. The value is just replace by the
-compiler and therefore, if applicable, will be reevaluated at call time.
+does not provide a value for the argument. The value will be reevaluated
+every time the function is called.
 
 .. code-block:: nim
   # b is optional with 47 as its default value

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3544,7 +3544,7 @@ separation of types and subsequent identifiers more distinct.
 
 A parameter may be declared with a default value which is used if the caller
 does not provide a value for the argument. The value is just replace by the
-compiler and therefore, if applicable, will be reevaluated at runtime.
+compiler and therefore, if applicable, will be reevaluated at call time.
 
 .. code-block:: nim
   # b is optional with 47 as its default value


### PR DESCRIPTION
Add a clarification that default parameters are reevaluated at each call.