### PR TITLE
add [1..2] for JArray

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -536,15 +536,18 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
   ##
   ## Returns the inclusive range `[a[x.a], a[x.b]]`:
   runnableExamples:
+    import json
     let arr = %[0,1,2,3,4,5]
     doAssert arr[2..4] == %[2,3,4]
     doAssert arr[2..^2] == %[2,3,4]
+    doAssert arr[^4..^2] == %[2,3,4]
 
   assert(a.kind == JArray)
   result = newJArray()
-  let xb = (when x.b is BackwardsIndex: a.len - int(x.b) else: int(x.b))
-  for i in x.a .. xb:
-    result.add(a[i])
+  let xa = (when x.a is BackwardsIndex: a.len - int(x.a) else: int(x.a))
+  let L = (when x.b is BackwardsIndex: a.len - int(x.b) else: int(x.b)) - xa + 1
+  for i in 0..<L:
+    result.add(a[i + xa])
 
 proc hasKey*(node: JsonNode, key: string): bool =
   ## Checks if `key` exists in `node`.

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -534,10 +534,6 @@ proc `[]`*(node: JsonNode, index: BackwardsIndex): JsonNode {.inline, since: (1,
 proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
   ## Slice operation for JArray.
   ## Returns the inclusive range `[a[x.a], a[x.b]]`:
-  ##
-  ## .. code-block:: Nim
-  ##    let a = %[1, 2, 3, 4]
-  ##    assert a[0..2] == %[1, 2, 3]
   runnableExamples:
     let arr = %[0,1,2,3,4,5]
     doAssert arr[2..4] == %[2,3,4]

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -531,6 +531,23 @@ proc `[]`*(node: JsonNode, index: BackwardsIndex): JsonNode {.inline, since: (1,
 
   `[]`(node, node.len - int(index))
 
+proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
+  ## Slice operation for JArray.
+  ## Returns the inclusive range `[a[x.a], a[x.b]]`:
+  ##
+  ## .. code-block:: Nim
+  ##    var a = %[1, 2, 3, 4]
+  ##    assert a[0..2] == %[1, 2, 3]
+  if a.kind != JArray:
+    let msg = "Incorrect JSON kind. Wanted '$1' but got '$2'." % [
+      $JArray,
+      $a.kind
+    ]
+    raise newException(JsonKindError, msg)
+  result = newJArray()
+  for i in x.a .. x.b:
+    result.add(a[i])
+
 proc hasKey*(node: JsonNode, key: string): bool =
   ## Checks if `key` exists in `node`.
   assert(node.kind == JObject)

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -533,8 +533,8 @@ proc `[]`*(node: JsonNode, index: BackwardsIndex): JsonNode {.inline, since: (1,
 
 proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
   ## Slice operation for JArray.
-  ## Returns the inclusive range `[a[x.a], a[x.b]]`:
   ##
+  ## Returns the inclusive range `[a[x.a], a[x.b]]`:
   runnableExamples:
     let arr = %[0,1,2,3,4,5]
     doAssert arr[2..4] == %[2,3,4]

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -545,7 +545,7 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
     ]
     raise newException(JsonKindError, msg)
   result = newJArray()
-  for i in x.a .. x.b:
+  for i in x.a .. x.b.int:
     result.add(a[i])
 
 proc hasKey*(node: JsonNode, key: string): bool =

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -540,7 +540,7 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
     doAssert arr[2..4] == %[2,3,4]
     doAssert arr[2..^2] == %[2,3,4]
 
-  assert(node.kind == JArray)
+  assert(a.kind == JArray)
   result = newJArray()
   let xb = (when x.b is BackwardsIndex: a.len - int(x.b) else: int(x.b))
   for i in x.a .. xb:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -536,16 +536,21 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
   ## Returns the inclusive range `[a[x.a], a[x.b]]`:
   ##
   ## .. code-block:: Nim
-  ##    var a = %[1, 2, 3, 4]
+  ##    let a = %[1, 2, 3, 4]
   ##    assert a[0..2] == %[1, 2, 3]
+  runnableExamples:
+    let arr = %[0,1,2,3,4,5]
+    doAssert arr[2..4] == %[2,3,4]
+    doAssert arr[2..^2] == %[2,3,4]
+
   if a.kind != JArray:
     let msg = "Incorrect JSON kind. Wanted '$1' but got '$2'." % [
       $JArray,
       $a.kind
     ]
     raise newException(JsonKindError, msg)
-  result = newJArray()
-  for i in x.a .. x.b.int:
+  let xb = (when x.b is BackwardsIndex: a.len - int(x.b) else: int(x.b))
+  for i in x.a .. xb:
     result.add(a[i])
 
 proc hasKey*(node: JsonNode, key: string): bool =

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -540,12 +540,7 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
     doAssert arr[2..4] == %[2,3,4]
     doAssert arr[2..^2] == %[2,3,4]
 
-  if a.kind != JArray:
-    let msg = "Incorrect JSON kind. Wanted '$1' but got '$2'." % [
-      $JArray,
-      $a.kind
-    ]
-    raise newException(JsonKindError, msg)
+  assert(node.kind == JArray)
   result = newJArray()
   let xb = (when x.b is BackwardsIndex: a.len - int(x.b) else: int(x.b))
   for i in x.a .. xb:

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -534,6 +534,7 @@ proc `[]`*(node: JsonNode, index: BackwardsIndex): JsonNode {.inline, since: (1,
 proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
   ## Slice operation for JArray.
   ## Returns the inclusive range `[a[x.a], a[x.b]]`:
+  ##
   runnableExamples:
     let arr = %[0,1,2,3,4,5]
     doAssert arr[2..4] == %[2,3,4]
@@ -545,6 +546,7 @@ proc `[]`*[U, V](a: JsonNode, x: HSlice[U, V]): JsonNode =
       $a.kind
     ]
     raise newException(JsonKindError, msg)
+  result = newJArray()
   let xb = (when x.b is BackwardsIndex: a.len - int(x.b) else: int(x.b))
   for i in x.a .. xb:
     result.add(a[i])


### PR DESCRIPTION
Slice operation for JArray
Returns the inclusive range `[a[x.a], a[x.b]]`:

```nim
var a = %[1, 2, 3, 4]
assert a[0..2] == %[1, 2, 3]
```