### PR TITLE
complement notes of two doc strings of tables module

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -496,7 +496,7 @@ template tabCellHash(i)  = t.data[i].hcode
 proc del*[A, B](t: var Table[A, B], key: A) =
   ## Deletes `key` from hash table `t`. Does nothing if the key does not exist.
   ##
-  ## **If duplicate keys were added, this may need to be called multiple times.**
+  ## .. warning:: If duplicate keys were added, this may need to be called multiple times.
   ##
   ## See also:
   ## * `pop proc<#pop,Table[A,B],A,B>`_

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -516,7 +516,7 @@ proc pop*[A, B](t: var Table[A, B], key: A, val: var B): bool =
   ## mapping of the key. Otherwise, returns `false`, and the `val` is
   ## unchanged.
   ##
-  ## **If duplicate keys were added, this may need to be called multiple times.**
+  ## .. warning:: If duplicate keys were added, this may need to be called multiple times.
   ##
   ## See also:
   ## * `del proc<#del,Table[A,B],A>`_

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -496,6 +496,8 @@ template tabCellHash(i)  = t.data[i].hcode
 proc del*[A, B](t: var Table[A, B], key: A) =
   ## Deletes `key` from hash table `t`. Does nothing if the key does not exist.
   ##
+  ## **If duplicate keys were added, this may need to be called multiple times.**
+  ##
   ## See also:
   ## * `pop proc<#pop,Table[A,B],A,B>`_
   ## * `clear proc<#clear,Table[A,B]>`_ to empty the whole table
@@ -513,6 +515,8 @@ proc pop*[A, B](t: var Table[A, B], key: A, val: var B): bool =
   ## Returns `true`, if the `key` existed, and sets `val` to the
   ## mapping of the key. Otherwise, returns `false`, and the `val` is
   ## unchanged.
+  ##
+  ## **If duplicate keys were added, this may need to be called multiple times.**
   ##
   ## See also:
   ## * `del proc<#del,Table[A,B],A>`_


### PR DESCRIPTION
`del` and `pop` procedure of `Table` object should also need multiple times in case `add` was applied before, which is not mentioned in the document. As long as the `add` is still deprecated and not removed, the notes should be retained just like `TableRef`'s two corresponding procedures.