### PR TITLE
Replace calls to `putenv` with `setenv`

### DIFF
--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -45,8 +45,8 @@ else:
 
   proc c_getenv(env: cstring): cstring {.
     importc: "getenv", header: "<stdlib.h>".}
-  proc c_putenv(env: cstring): cint {.
-    importc: "putenv", header: "<stdlib.h>".}
+  proc c_setenv(envname: cstring, envval: cstring, overwrite: cint): cint {.
+    importc: "setenv", header: "<stdlib.h>".}
   proc c_unsetenv(env: cstring): cint {.
     importc: "unsetenv", header: "<stdlib.h>".}
 
@@ -221,7 +221,7 @@ else:
         else:
           if setEnvironmentVariableA(key, val) == 0'i32: raiseOSError(osLastError())
       else:
-        if c_putenv(environment[indx]) != 0'i32:
+        if c_setenv(key, val, 1'i32) != 0'i32:
           raiseOSError(osLastError())
 
   proc delEnv*(key: string) {.tags: [WriteEnvEffect].} =

--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -45,8 +45,10 @@ else:
 
   proc c_getenv(env: cstring): cstring {.
     importc: "getenv", header: "<stdlib.h>".}
-  proc c_setenv(envname: cstring, envval: cstring, overwrite: cint): cint {.
-    importc: "setenv", header: "<stdlib.h>".}
+  when defined(vcc):
+    proc c_putenv_s(envname: cstring, envval: cstring): cint {.importc: "_putenv_s", header: "<stdlib.h>".}
+  else:
+    proc c_setenv(envname: cstring, envval: cstring, overwrite: cint): cint {.importc: "setenv", header: "<stdlib.h>".}
   proc c_unsetenv(env: cstring): cint {.
     importc: "unsetenv", header: "<stdlib.h>".}
 
@@ -220,6 +222,9 @@ else:
           if setEnvironmentVariableW(k, v) == 0'i32: raiseOSError(osLastError())
         else:
           if setEnvironmentVariableA(key, val) == 0'i32: raiseOSError(osLastError())
+      elif defined(vcc):
+        if c_putenv_s(key, val) != 0'i32:
+          raiseOSError(osLastError())
       else:
         if c_setenv(key, val, 1'i32) != 0'i32:
           raiseOSError(osLastError())

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -614,6 +614,10 @@ block osenv:
     doAssert existsEnv(dummyEnvVar) == false
     delEnv(dummyEnvVar)         # deleting an already deleted env var
     doAssert existsEnv(dummyEnvVar) == false
+  block putEnv:
+    # raises OSError on invalid input
+    doAssertRaises(OSError, putEnv("DUMMY_ENV_VAR_PUT=DUMMY_VALUE", "NEW_DUMMY_VALUE"))
+    doAssertRaises(OSError, putEnv("", "NEW_DUMMY_VALUE"))
   block:
     doAssert getEnv("DUMMY_ENV_VAR_NONEXISTENT", "") == ""
     doAssert getEnv("DUMMY_ENV_VAR_NONEXISTENT", " ") == " "

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -614,7 +614,7 @@ block osenv:
     doAssert existsEnv(dummyEnvVar) == false
     delEnv(dummyEnvVar)         # deleting an already deleted env var
     doAssert existsEnv(dummyEnvVar) == false
-  block putEnv:
+  block: # putEnv
     # raises OSError on invalid input
     doAssertRaises(OSError, putEnv("DUMMY_ENV_VAR_PUT=DUMMY_VALUE", "NEW_DUMMY_VALUE"))
     doAssertRaises(OSError, putEnv("", "NEW_DUMMY_VALUE"))

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -615,7 +615,6 @@ block osenv:
     delEnv(dummyEnvVar)         # deleting an already deleted env var
     doAssert existsEnv(dummyEnvVar) == false
   block: # putEnv
-    # raises OSError on invalid input
     doAssertRaises(OSError, putEnv("DUMMY_ENV_VAR_PUT=DUMMY_VALUE", "NEW_DUMMY_VALUE"))
     doAssertRaises(OSError, putEnv("", "NEW_DUMMY_VALUE"))
   block:

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -615,8 +615,8 @@ block osenv:
     delEnv(dummyEnvVar)         # deleting an already deleted env var
     doAssert existsEnv(dummyEnvVar) == false
   block: # putEnv
-    doAssertRaises(OSError, putEnv("DUMMY_ENV_VAR_PUT=DUMMY_VALUE", "NEW_DUMMY_VALUE"))
-    doAssertRaises(OSError, putEnv("", "NEW_DUMMY_VALUE"))
+    doAssertRaises(OSError): putEnv("DUMMY_ENV_VAR_PUT=DUMMY_VALUE", "NEW_DUMMY_VALUE")
+    doAssertRaises(OSError): putEnv("", "NEW_DUMMY_VALUE")
   block:
     doAssert getEnv("DUMMY_ENV_VAR_NONEXISTENT", "") == ""
     doAssert getEnv("DUMMY_ENV_VAR_NONEXISTENT", " ") == " "

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -614,7 +614,7 @@ block osenv:
     doAssert existsEnv(dummyEnvVar) == false
     delEnv(dummyEnvVar)         # deleting an already deleted env var
     doAssert existsEnv(dummyEnvVar) == false
-  block: # putEnv
+  block: # putEnv, bug #18502
     doAssertRaises(OSError): putEnv("DUMMY_ENV_VAR_PUT=DUMMY_VALUE", "NEW_DUMMY_VALUE")
     doAssertRaises(OSError): putEnv("", "NEW_DUMMY_VALUE")
   block:


### PR DESCRIPTION
Fixes #18502 which could lead to memory leaks if left unchecked

in `os.putenv(k, v)`, replaces calls to C `putenv("k=v")` with calls to C `setenv(k, v, 1)`

First time contributor here, let me know if anything else is needed of me