### PR TITLE
use moveMem for string add to guard against overlapping memory

### DIFF
--- a/lib/system/strs_v2.nim
+++ b/lib/system/strs_v2.nim
@@ -39,8 +39,8 @@ proc resize(old: int): int {.inline.} =
   elif old < 65536: result = old * 2
   else: result = old * 3 div 2 # for large arrays * 3/2 is better
 
-proc prepareAdd(s: var NimStringV2; addlen: int) {.compilerRtl.} =
-  let newLen = s.len + addlen
+proc prepareAdd(s: var NimStringV2; addLen: int) {.compilerRtl.} =
+  let newLen = s.len + addLen
   if isLiteral(s):
     let oldP = s.p
     # can't mutate a literal, so we need a fresh copy here:
@@ -94,7 +94,7 @@ proc nimToCStringConv(s: NimStringV2): cstring {.compilerproc, nonReloadable, in
 proc appendString(dest: var NimStringV2; src: NimStringV2) {.compilerproc, inline.} =
   if src.len > 0:
     # also copy the \0 terminator:
-    copyMem(unsafeAddr dest.p.data[dest.len], unsafeAddr src.p.data[0], src.len+1)
+    moveMem(unsafeAddr dest.p.data[dest.len], unsafeAddr src.p.data[0], src.len+1)
     inc dest.len, src.len
 
 proc appendChar(dest: var NimStringV2; c: char) {.compilerproc, inline.} =


### PR DESCRIPTION
Code like this triggers ASan error:

```nim
proc main =
  var a = newStringOfCap(10)
  a.add 'h'
  a.add a
  echo a

main()
```

Sample error:
`==1225609==ERROR: AddressSanitizer: memcpy-param-overlap: memory ranges [0x603000000049,0x60300000004b) and [0x603000000048, 0x60300000004a) overlap`

This commit uses moveMem instead of copyMem to fix the errors. I am not sure if its serious bug or benign in practice.