### PR TITLE
clean unused imports on runnableExamples

### DIFF
--- a/lib/std/monotimes.nim
+++ b/lib/std/monotimes.nim
@@ -15,8 +15,6 @@ meaning that that the following is guaranteed to work:
 ]##
 
 runnableExamples:
-  import std/os
-
   let a = getMonoTime()
   let b = getMonoTime()
   assert a <= b


### PR DESCRIPTION
As far as I recall, `os.sleep` was removed but the import statement isn't.