### PR TITLE
fix `setCommand` so it behaves like regular nim invocation and so that projectName, outFile, json file etc are correct

### DIFF
--- a/compiler/cmdlinehelper.nim
+++ b/compiler/cmdlinehelper.nim
@@ -44,14 +44,7 @@ proc processCmdLineAndProjectPath*(self: NimProg, conf: ConfigRef) =
   elif self.supportsStdinFile and conf.projectName == "-":
     handleStdinInput(conf)
   elif conf.projectName != "":
-    try:
-      conf.projectFull = canonicalizePath(conf, AbsoluteFile conf.projectName)
-    except OSError:
-      conf.projectFull = AbsoluteFile conf.projectName
-    let p = splitFile(conf.projectFull)
-    let dir = if p.dir.isEmpty: AbsoluteDir getCurrentDir() else: p.dir
-    conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile dir)
-    conf.projectName = p.name
+    setFromProjectName(conf, conf.projectName)
   else:
     conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile getCurrentDir())
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -695,6 +695,16 @@ proc setDefaultLibpath*(conf: ConfigRef) =
 proc canonicalizePath*(conf: ConfigRef; path: AbsoluteFile): AbsoluteFile =
   result = AbsoluteFile path.string.expandFilename
 
+proc setFromProjectName*(conf: ConfigRef; projectName: string) =
+  try:
+    conf.projectFull = canonicalizePath(conf, AbsoluteFile projectName)
+  except OSError:
+    conf.projectFull = AbsoluteFile projectName
+  let p = splitFile(conf.projectFull)
+  let dir = if p.dir.isEmpty: AbsoluteDir getCurrentDir() else: p.dir
+  conf.projectPath = AbsoluteDir canonicalizePath(conf, AbsoluteFile dir)
+  conf.projectName = p.name
+
 proc removeTrailingDirSep*(path: string): string =
   if (path.len > 0) and (path[^1] == DirSep):
     result = substr(path, 0, path.len - 2)

--- a/compiler/scriptconfig.nim
+++ b/compiler/scriptconfig.nim
@@ -151,18 +151,9 @@ proc setupVM*(module: PSym; cache: IdentCache; scriptName: string;
     setResult(a, strutils.cmpIgnoreCase(a.getString 0, a.getString 1))
   cbconf setCommand:
     conf.setCommandEarly(a.getString 0)
-    # xxx move remaining logic to commands.nim or other
     let arg = a.getString 1
     incl(conf.globalOptions, optWasNimscript)
-    if arg.len > 0:
-      conf.projectName = arg
-      let path =
-        if conf.projectName.isAbsolute: AbsoluteFile(conf.projectName)
-        else: conf.projectPath / RelativeFile(conf.projectName)
-      try:
-        conf.projectFull = canonicalizePath(conf, path)
-      except OSError:
-        conf.projectFull = path
+    if arg.len > 0: setFromProjectName(conf, arg)
   cbconf getCommand:
     setResult(a, conf.command)
   cbconf switch:


### PR DESCRIPTION
* fix issue 2 (see https://github.com/nim-lang/Nim/issues/18543#issuecomment-883483721)
* remove code duplication between processCmdLineAndProjectPath and setCommand
* paths set after `setCommand` are now correct and consistent with what you'd have if you'd use a regular nim compilation command, as can be seen with adding this to test/tlex.nim in  https://github.com/flyx/NimYAML:
```nim
import std/compilesettings
static: echo "recompiling"
static: echo (querySetting(outFile), querySetting(outDir), querySetting(projectName), querySetting(projectPath), querySetting(projectFull), querySetting(command))
```

before PR, those paths were wrong (outFile is assumed to be base name in rest of code):
("test/tlex", "/private/tmp/d13/NimYAML", "test/tlex", "/private/tmp/d13/NimYAML", "/private/tmp/d13/NimYAML/test/tlex", "c")

after PR, those paths are correct:
("tlex", "/private/tmp/d13/NimYAML/test", "tlex", "/private/tmp/d13/NimYAML/test", "/private/tmp/d13/NimYAML/test/tlex", "c")

and they're the same as what you'd have with:
`nim c -r --nimcache:/tmp/c09f test/tlex`

## note
before https://github.com/nim-lang/Nim/pull/18100, writeJsonBuildInstructions would silently not write the json file (because of the above bug in setCommand which resulted in a wrong value for `jsonBuildInstructionsFile`); after https://github.com/nim-lang/Nim/pull/18100 it would crash as mentioned in https://github.com/nim-lang/Nim/issues/18543#issuecomment-883483721 as a result of this; 
after this PR, the paths computed after `setCommand` are now correct, so `jsonBuildInstructionsFile` is also correct and the json file is indeed written (and `-d:nimBetterRun` is honored)

## azure CI keeps getting cancelled for some unrelated reason
```
##[error]An error occurred while provisioning resources (Error Type: Failure).
,##[error]The remote provider was unable to process the request.
```
EDIT: upstream issue, refs https://docs.microsoft.com/en-us/answers/questions/484649/an-error-occurred-while-provisioning-resources-err.html
