### PR TITLE
add macros.getChildPtr; add wrapnils.checkNil

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -123,6 +123,8 @@
 
 - Make custom op in macros.quote work for all statements.
 
+- Added `macros.getChildPtr(n: NimNode, i: int)` to get a ptr to the ith child of `n`.
+
 - On Windows the SSL library now checks for valid certificates.
   It uses the `cacert.pem` file for this purpose which was extracted
   from `https://curl.se/ca/cacert.pem`. Besides
@@ -292,6 +294,7 @@
   case objects, generates optimal code (no overhead compared to manual
   if-else branches), and preserves lvalue semantics which allows modifying
   an expression.
+  Added `checkNil` to return a default value if an argument with `checkNil` is nil.
 
 - Added `math.frexp` overload procs. Deprecated `c_frexp`, use `frexp` instead.
 

--- a/compiler/vmhooks.nim
+++ b/compiler/vmhooks.nim
@@ -28,6 +28,10 @@ proc setResult*(a: VmArgs; n: PNode) =
   a.slots[a.ra].ensureKind(rkNode)
   a.slots[a.ra].node = n
 
+proc setResult*(a: VmArgs; n: ptr PNode) =
+  a.slots[a.ra].ensureKind(rkNodeAddr)
+  a.slots[a.ra].nodeAddr = n
+
 proc setResult*(a: VmArgs; v: AbsoluteDir) = setResult(a, v.string)
 
 proc setResult*(a: VmArgs; v: seq[string]) =

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -336,3 +336,8 @@ proc registerAdditionalOps*(c: PCtx) =
     let p = a.getVar(0)
     let x = a.getFloat(1)
     addFloatSprintf(p.strVal, x)
+
+  registerCallback c, "stdlib.macros.getChildPtr", proc(a: VmArgs) =
+    let p = a.getNode(0)
+    let index = a.getInt(1)
+    setResult(a, p.sons[index])

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -173,6 +173,9 @@ proc `[]`*(n: NimNode, i: int): NimNode {.magic: "NChild", noSideEffect.}
 proc `[]`*(n: NimNode, i: BackwardsIndex): NimNode = n[n.len - i.int]
   ## Get `n`'s `i`'th child.
 
+proc getChildPtr*(n: NimNode, i: int): ptr NimNode =
+  doAssert false, "nimvm"
+
 template `^^`(n: NimNode, i: untyped): untyped =
   (when i is BackwardsIndex: n.len - int(i) else: int(i))
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -174,6 +174,16 @@ proc `[]`*(n: NimNode, i: BackwardsIndex): NimNode = n[n.len - i.int]
   ## Get `n`'s `i`'th child.
 
 proc getChildPtr*(n: NimNode, i: int): ptr NimNode =
+  ## Return a ptr to the ith child of `n`; note that `n[i]` doesn't have an address
+  ## so `n[i].addr` or `n[i].unsafeAddr` won't work.
+  runnableExamples:
+    proc process(n: NimNode): NimNode =
+      let n2 = getChildPtr(n, 0)
+      n2[] = quote do: 123
+      result = n
+    macro fn(n: auto): untyped =
+      result = process(n)
+    doAssert fn(("foo1", "foo2")) == (123, "foo2")
   doAssert false, "nimvm"
 
 template `^^`(n: NimNode, i: untyped): untyped =

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -78,7 +78,6 @@ proc process(n: NimNode, lhs: NimNode, level: int): NimNode =
   var n = n.copyNimTree
   var it = n.addr
   let addr2 = bindSym"addr"
-  let checkNil2 = bindSym("checkNil")
   while true:
     if it[].len == 0:
       result = finalize(n, lhs, level)

--- a/lib/std/wrapnils.nim
+++ b/lib/std/wrapnils.nim
@@ -73,15 +73,13 @@ proc finalize(n: NimNode, lhs: NimNode, level: int): NimNode =
     result = quote: `lhs` = `n`
   else:
     result = quote: (let `lhs` = `n`)
-import timn/dbgs
+
 proc process(n: NimNode, lhs: NimNode, level: int): NimNode =
-  dbg n.repr, level, lhs, "process"
   var n = n.copyNimTree
   var it = n.addr
   let addr2 = bindSym"addr"
   let checkNil2 = bindSym("checkNil")
   while true:
-    dbg it.repr, n.repr, it[].len, it[].kind
     if it[].len == 0:
       result = finalize(n, lhs, level)
       break
@@ -139,14 +137,11 @@ macro `?.`*(a: typed): auto =
   ## value is produced.
   let lhs = genSym(nskVar, "lhs")
   let body = process(a, lhs, 0)
-  echo a.repr
-  echo a.treeRepr
   result = quote do:
     var `lhs`: type(`a`)
     block:
       `body`
     `lhs`
-  echo result.repr
 
 # the code below is not needed for `?.`
 from options import Option, isSome, get, option, unsafeGet, UnpackDefect

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -66,3 +66,18 @@ block: # unpackVarargs
     doAssert call1(toString) == ""
     doAssert call1(toString, 10) == "10"
     doAssert call1(toString, 10, 11) == "1011"
+
+template main =
+  # xxx move all under here
+  block: # getChildPtr
+    proc process(n: NimNode): NimNode =
+      let n2 = getChildPtr(n, 0)
+      # let n2 = n[0].unsafeAddr # would not work
+      n2[] = quote do: 123
+      result = n
+    macro fn(n: auto): untyped =
+      result = process(n)
+    doAssert fn(("foo1", "foo2")) == (123, "foo2")
+
+static: main()
+main()


### PR DESCRIPTION
## add `macros.getChildPtr`
it allows returning a ptr to ith child of a NimNode (`n[i]` itself doesn't have an address so `n[i].addr` or `n[i].unsafeAddr` can't be used).
It's useful when you need to operate recursively on children of a NimNode and tracking the parent and index (and in fact the path from root node, eg `n[1][2][0]`) so a sub-node can be re-assigned is either not possible or makes the code much more complex.

## add `wrapnils.checkNil`
wrapnils only checks for nil dereferences (ptr-like types) and field checks (variant types), but it doesn't check whether an argument passed to a proc is nil, since the proc could accept nil inputs and wrapnils has no way to know that. This PR adds an API `checkNil` which ensures that a sub-expression is not nil before being passed to a proc, making the check explicit in the call chain.

It uses `getChildPtr`, which allows to get rid of tracking the parent `var old: tuple[n: NimNode, index: int]` (which was used for discriminant field checks, since https://github.com/nim-lang/Nim/pull/18435) and also enables implementing `checkNil` in a much simpler way than if `getChildPtr` were not available; in fact, I was not able to implement `checkNil` without it.

## Examples
see tests in tests/stdlib/twrapnils.nim and example in lib/std/wrapnils.nim
