### PR TITLE
Fixed template const tuple unpacking

### DIFF
--- a/tests/vm/tconst.nim
+++ b/tests/vm/tconst.nim
@@ -34,5 +34,15 @@ template main() =
     doAssert ct in b, $(b, ct)
     doAssert NimVersion in b
 
+  block: # Test for fix on broken const unpacking
+    template mytemp() =
+      const
+        (x, increment) = (4, true)
+        a = 100
+      discard (x, increment, a)
+    mytemp()
+
+
+
 static: main()
 main()


### PR DESCRIPTION
Prior to this PR unpacking a const tuple in a template resulted in an illformed AST error, for example:
```nim
const (x, y) = (4, true) # works fine
template mytemp() =
  const (x, y) = (4, true) # ast error
mytemp()
```