### PR TITLE
rename nimFpRoundtrips => nimPreviewFloatRoundtrip

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -113,7 +113,7 @@
 - `system.addFloat` and `system.$` now can produce string representations of floating point numbers
   that are minimal in size and that "roundtrip" (via the "Dragonbox" algorithm). This currently has
   to be enabled via `-d:nimPreviewFloatRoundtrip`. It is expected that this behavior becomes the new default
-  in upcoming versions, as with other `nimTransition` define flags.
+  in upcoming versions, as with other `nimPreviewX` define flags.
 
 - Fixed buffer overflow bugs in `net`
 

--- a/changelog.md
+++ b/changelog.md
@@ -112,8 +112,8 @@
 
 - `system.addFloat` and `system.$` now can produce string representations of floating point numbers
   that are minimal in size and that "roundtrip" (via the "Dragonbox" algorithm). This currently has
-  to be enabled via `-d:nimFpRoundtrips`. It is expected that this behavior becomes the new default
-  in upcoming versions.
+  to be enabled via `-d:nimTransitionFloatRoundtrip`. It is expected that this behavior becomes the new default
+  in upcoming versions, as with other `nimTransition` define flags.
 
 - Fixed buffer overflow bugs in `net`
 

--- a/changelog.md
+++ b/changelog.md
@@ -112,7 +112,7 @@
 
 - `system.addFloat` and `system.$` now can produce string representations of floating point numbers
   that are minimal in size and that "roundtrip" (via the "Dragonbox" algorithm). This currently has
-  to be enabled via `-d:nimTransitionFloatRoundtrip`. It is expected that this behavior becomes the new default
+  to be enabled via `-d:nimPreviewFloatRoundtrip`. It is expected that this behavior becomes the new default
   in upcoming versions, as with other `nimTransition` define flags.
 
 - Fixed buffer overflow bugs in `net`

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -4,7 +4,7 @@ hint:XDeclaredButNotUsed:off
 
 define:booting
 define:nimcore
-define:nimFpRoundtrips
+define:nimTransitionFloatRoundtrip
 
 #import:"$projectpath/testability"
 

--- a/compiler/nim.cfg
+++ b/compiler/nim.cfg
@@ -4,7 +4,7 @@ hint:XDeclaredButNotUsed:off
 
 define:booting
 define:nimcore
-define:nimTransitionFloatRoundtrip
+define:nimPreviewFloatRoundtrip
 
 #import:"$projectpath/testability"
 

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -74,7 +74,7 @@ proc writeFloatToBufferSprintf*(buf: var array[65, char]; value: BiggestFloat): 
       result = 3
 
 proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat | float32): int {.inline.} =
-  when defined(nimTransitionFloatRoundtrip):
+  when defined(nimPreviewFloatRoundtrip):
     writeFloatToBufferRoundtrip(buf, value)
   else:
     writeFloatToBufferSprintf(buf, value)
@@ -121,7 +121,7 @@ proc addFloat*(result: var string; x: float | float32) {.inline.} =
     s.addFloat(45.67)
     assert s == "foo:45.67"
   template impl =
-    when defined(nimTransitionFloatRoundtrip):
+    when defined(nimPreviewFloatRoundtrip):
       addFloatRoundtrip(result, x)
     else:
       addFloatSprintf(result, x)

--- a/lib/system/formatfloat.nim
+++ b/lib/system/formatfloat.nim
@@ -74,7 +74,7 @@ proc writeFloatToBufferSprintf*(buf: var array[65, char]; value: BiggestFloat): 
       result = 3
 
 proc writeFloatToBuffer*(buf: var array[65, char]; value: BiggestFloat | float32): int {.inline.} =
-  when defined(nimFpRoundtrips):
+  when defined(nimTransitionFloatRoundtrip):
     writeFloatToBufferRoundtrip(buf, value)
   else:
     writeFloatToBufferSprintf(buf, value)
@@ -121,7 +121,7 @@ proc addFloat*(result: var string; x: float | float32) {.inline.} =
     s.addFloat(45.67)
     assert s == "foo:45.67"
   template impl =
-    when defined(nimFpRoundtrips):
+    when defined(nimTransitionFloatRoundtrip):
       addFloatRoundtrip(result, x)
     else:
       addFloatSprintf(result, x)

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -35,4 +35,4 @@ switch("define", "nimExperimentalAsyncjsThen")
 switch("define", "nimExperimentalJsfetch")
 switch("define", "nimExperimentalLinenoiseExtra")
 
-switch("define", "nimTransitionFloatRoundtrip")
+switch("define", "nimPreviewFloatRoundtrip")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -35,4 +35,4 @@ switch("define", "nimExperimentalAsyncjsThen")
 switch("define", "nimExperimentalJsfetch")
 switch("define", "nimExperimentalLinenoiseExtra")
 
-switch("define", "nimFpRoundtrips")
+switch("define", "nimTransitionFloatRoundtrip")

--- a/tests/errmsgs/treportunused.nim
+++ b/tests/errmsgs/treportunused.nim
@@ -32,7 +32,7 @@ var s9: int
 type s10 = object
 type s11 = type(1.2)
 
-# bug #14407 (requires `compiler/nim.cfg` containing define:nimTransitionFloatRoundtrip)
+# bug #14407 (requires `compiler/nim.cfg` containing define:nimPreviewFloatRoundtrip)
 let
   `v0.99` = "0.99"
   `v0.99.99` = "0.99.99"

--- a/tests/errmsgs/treportunused.nim
+++ b/tests/errmsgs/treportunused.nim
@@ -32,7 +32,7 @@ var s9: int
 type s10 = object
 type s11 = type(1.2)
 
-# bug #14407 (requires `compiler/nim.cfg` containing define:nimFpRoundtrips)
+# bug #14407 (requires `compiler/nim.cfg` containing define:nimTransitionFloatRoundtrip)
 let
   `v0.99` = "0.99"
   `v0.99.99` = "0.99.99"

--- a/tests/float/tfloats.nim
+++ b/tests/float/tfloats.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "-d:nimFpRoundtrips; -u:nimFpRoundtrips"
+  matrix: "-d:nimTransitionFloatRoundtrip; -u:nimTransitionFloatRoundtrip"
   targets: "c cpp js"
 """
 
@@ -67,14 +67,14 @@ template main =
     block: # example 1
       let a = 0.1+0.2
       doAssert a != 0.3
-      when defined(nimFpRoundtrips):
+      when defined(nimTransitionFloatRoundtrip):
         doAssert $a == "0.30000000000000004"
       else:
         whenRuntimeJs: discard
         do: doAssert $a == "0.3"
     block: # example 2
       const a = 0.1+0.2
-      when defined(nimFpRoundtrips):
+      when defined(nimTransitionFloatRoundtrip):
         doAssert $($a, a) == """("0.30000000000000004", 0.30000000000000004)"""
       else:
         whenRuntimeJs: discard
@@ -83,13 +83,13 @@ template main =
       const a1 = 0.1+0.2
       let a2 = a1
       doAssert a1 != 0.3
-      when defined(nimFpRoundtrips):
+      when defined(nimTransitionFloatRoundtrip):
         doAssert $[$a1, $a2] == """["0.30000000000000004", "0.30000000000000004"]"""
       else:
         whenRuntimeJs: discard
         do: doAssert $[$a1, $a2] == """["0.3", "0.3"]"""
 
-  when defined(nimFpRoundtrips):
+  when defined(nimTransitionFloatRoundtrip):
     block: # bug #18148
       var a = 1.1'f32
       doAssert $a == "1.1", $a # was failing

--- a/tests/float/tfloats.nim
+++ b/tests/float/tfloats.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "-d:nimTransitionFloatRoundtrip; -u:nimTransitionFloatRoundtrip"
+  matrix: "-d:nimPreviewFloatRoundtrip; -u:nimPreviewFloatRoundtrip"
   targets: "c cpp js"
 """
 
@@ -67,14 +67,14 @@ template main =
     block: # example 1
       let a = 0.1+0.2
       doAssert a != 0.3
-      when defined(nimTransitionFloatRoundtrip):
+      when defined(nimPreviewFloatRoundtrip):
         doAssert $a == "0.30000000000000004"
       else:
         whenRuntimeJs: discard
         do: doAssert $a == "0.3"
     block: # example 2
       const a = 0.1+0.2
-      when defined(nimTransitionFloatRoundtrip):
+      when defined(nimPreviewFloatRoundtrip):
         doAssert $($a, a) == """("0.30000000000000004", 0.30000000000000004)"""
       else:
         whenRuntimeJs: discard
@@ -83,13 +83,13 @@ template main =
       const a1 = 0.1+0.2
       let a2 = a1
       doAssert a1 != 0.3
-      when defined(nimTransitionFloatRoundtrip):
+      when defined(nimPreviewFloatRoundtrip):
         doAssert $[$a1, $a2] == """["0.30000000000000004", "0.30000000000000004"]"""
       else:
         whenRuntimeJs: discard
         do: doAssert $[$a1, $a2] == """["0.3", "0.3"]"""
 
-  when defined(nimTransitionFloatRoundtrip):
+  when defined(nimPreviewFloatRoundtrip):
     block: # bug #18148
       var a = 1.1'f32
       doAssert $a == "1.1", $a # was failing


### PR DESCRIPTION
~~`nimTransitionX`~~ `nimPreviewX` is the name we agreed on for transition flags, and float instead of fp is more searcheable; these flags are rarely used on cmdline (instead they are typically placed in a user/project or cmdline written in code) so the length is a minor concern compared to adhering to a convention