### PR TITLE
delEnv now works at CT

### DIFF
--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -20,7 +20,7 @@ when declared(math.copySign):
 when declared(math.signbit):
   from std/math import signbit
 
-from std/os import getEnv, existsEnv, dirExists, fileExists, putEnv, walkDir,
+from std/os import getEnv, existsEnv, delEnv, putEnv, dirExists, fileExists, walkDir,
                    getAppFilename, raiseOSError, osLastError
 
 from std/md5 import getMD5
@@ -215,6 +215,7 @@ proc registerAdditionalOps*(c: PCtx) =
     wrap2s(getEnv, osop)
     wrap1s(existsEnv, osop)
     wrap2svoid(putEnv, osop)
+    wrap1svoid(delEnv, osop)
     wrap1s(dirExists, osop)
     wrap1s(fileExists, osop)
     wrapDangerous(writeFile, ioop)


### PR DESCRIPTION
before PR:
* putEnv works at CT
* delEnv silently noop at CT (makes no sense to make this an exception given that putEnv works at CT)

after PR:
* putEnv works at CT
* delEnv works at CT
* the tests in tests/stdlib/tosenv.nim from https://github.com/nim-lang/Nim/pull/18535 can be run at CT via:
```nim
template main = ...
static: main()
main()
```
except for a few tests which would require https://github.com/nim-lang/Nim/pull/13714 to pass (and except for the ones that rely on threads:on)

I can add a changelog if requested but I consider this more of a bugfix.