### PR TITLE
Deprecate unnecessary `initDateTime` variant

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1350,13 +1350,13 @@ proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
     hour: hour,
     minute: minute,
     second: second,
-    nanosecond: nanosecond
+    nanosecond: nanosecond,
   )
   result = initDateTime(zone.zonedTimeFromAdjTime(dt.toAdjTime), zone)
 
 proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
-                   zone: Timezone = local()): DateTime =
+                   zone: Timezone = local()): DateTime {.deprecated: "use the other `initDateTime` instead".} =
   ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
   runnableExamples:
     let dt1 = initDateTime(30, mMar, 2017, 00, 00, 00, utc())


### PR DESCRIPTION
This variant is completely subsumed by the other `initDataTime` (in fact, it just forwards to the other variant), I'm not sure why it was added in the first place...

I didn't remove it, because currently
```nim
initDateTime(monthday, month, year, hour, minute, second, zone)
```
is allowed, which would break if this variant got removed completely. 