### PR TITLE
don't use plus instead of space

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -919,9 +919,9 @@ proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
     sortName = if k in routineKinds: plainName.strip else: name
     cleanPlainSymbol = renderPlainSymbolName(nameNode)
     complexSymbol = complexName(k, n, cleanPlainSymbol)
-    plainSymbolEnc = encodeUrl(cleanPlainSymbol)
+    plainSymbolEnc = encodeUrl(cleanPlainSymbol, usePlus = false)
     symbolOrId = d.newUniquePlainSymbol(complexSymbol)
-    symbolOrIdEnc = encodeUrl(symbolOrId)
+    symbolOrIdEnc = encodeUrl(symbolOrId, usePlus = false)
     deprecationMsg = genDeprecationMsg(d, pragmaNode)
 
   nodeToHighlightedHtml(d, n, result, {renderNoBody, renderNoComments,


### PR DESCRIPTION
Stuff like https://nim-lang.github.io/Nim/system.html#%5B%5D,array%5BIdx,T%5D,HSlice%5BU:+Ordinal,V:+Ordinal%5D doesn't point to the proc because of `+` in the url.

Using the space (not converting it to a `+`, keeping it as `%20`) works correctly on my machine.