### PR TITLE
fix #17072: add times.dateTime with ISO 8601 order

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -332,8 +332,11 @@
 
 - Added `htmlgen.portal` for [making "SPA style" pages using HTML only](https://web.dev/hands-on-portals).
 
-- Added `ZZZ` and `ZZZZ` patterns to `times.nim` `DateTime` parsing, to match time
+- `std/times`:
+  Added `ZZZ` and `ZZZZ` patterns to `times.nim` `DateTime` parsing, to match time
   zone offsets without colons, e.g. `UTC+7 -> +0700`.
+
+  Added `dateTime` and deprecated `initDateTime`.
 
 - Added `jsconsole.dir`, `jsconsole.dirxml`, `jsconsole.timeStamp`.
 
@@ -357,6 +360,7 @@
 - Added `dom.scrollIntoView` proc with options
 
 - Added `dom.setInterval`, `dom.clearInterval` overloads.
+
 
 - Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect
   if the slice is out of bounds, likewise with `strutils.delete`.

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1334,12 +1334,12 @@ proc now*(): DateTime {.tags: [TimeEffect], benign.} =
   getTime().local
 
 proc dateTime*(year: int, month: Month, monthday: MonthdayRange, 
-                   hour: HourRange = 0, minute: MinuteRange = 0, second: SecondRange = 0,
-                   nanosecond: NanosecondRange = 0,
-                   zone: Timezone = local()): DateTime =
+               hour: HourRange = 0, minute: MinuteRange = 0, second: SecondRange = 0,
+               nanosecond: NanosecondRange = 0,
+               zone: Timezone = local()): DateTime =
   ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
   runnableExamples:
-    doAssert $dateTime(2017, mMar, 30, zone = utc()) == "2017-03-30T00:00:00Z"
+    assert $dateTime(2017, mMar, 30, zone = utc()) == "2017-03-30T00:00:00Z"
 
   assertValidDate monthday, month, year
   let dt = DateTime(
@@ -1358,30 +1358,17 @@ proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
                    nanosecond: NanosecondRange,
                    zone: Timezone = local()): DateTime {.deprecated: "use `dateTime`".} =
   ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
-  runnableExamples:
-    let dt1 = initDateTime(30, mMar, 2017, 00, 00, 00, 00, utc())
-    doAssert $dt1 == "2017-03-30T00:00:00Z"
-
-  assertValidDate monthday, month, year
-  let dt = DateTime(
-    monthdayZero: monthday,
-    year: year,
-    monthZero: month.int,
-    hour: hour,
-    minute: minute,
-    second: second,
-    nanosecond: nanosecond
-  )
-  result = initDateTime(zone.zonedTimeFromAdjTime(dt.toAdjTime), zone)
+  runnableExamples("--warning:deprecated:off"):
+    assert $initDateTime(30, mMar, 2017, 00, 00, 00, 00, utc()) == "2017-03-30T00:00:00Z"
+  dateTime(year, month, monthday, hour, minute, second, nanosecond, zone)
 
 proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
                    zone: Timezone = local()): DateTime {.deprecated: "use `dateTime`".} =
   ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
-  runnableExamples:
-    let dt1 = initDateTime(30, mMar, 2017, 00, 00, 00, utc())
-    doAssert $dt1 == "2017-03-30T00:00:00Z"
-  initDateTime(monthday, month, year, hour, minute, second, 0, zone)
+  runnableExamples("--warning:deprecated:off"):
+    assert $initDateTime(30, mMar, 2017, 00, 00, 00, utc()) == "2017-03-30T00:00:00Z"
+  dateTime(year, month, monthday, hour, minute, second, 0, zone)
 
 proc `+`*(dt: DateTime, dur: Duration): DateTime =
   runnableExamples:

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -1333,10 +1333,30 @@ proc now*(): DateTime {.tags: [TimeEffect], benign.} =
   ##    `cpuTime` instead, depending on the use case.
   getTime().local
 
+proc dateTime*(year: int, month: Month, monthday: MonthdayRange, 
+                   hour: HourRange = 0, minute: MinuteRange = 0, second: SecondRange = 0,
+                   nanosecond: NanosecondRange = 0,
+                   zone: Timezone = local()): DateTime =
+  ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
+  runnableExamples:
+    doAssert $dateTime(2017, mMar, 30, zone = utc()) == "2017-03-30T00:00:00Z"
+
+  assertValidDate monthday, month, year
+  let dt = DateTime(
+    monthdayZero: monthday,
+    year: year,
+    monthZero: month.int,
+    hour: hour,
+    minute: minute,
+    second: second,
+    nanosecond: nanosecond
+  )
+  result = initDateTime(zone.zonedTimeFromAdjTime(dt.toAdjTime), zone)
+
 proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
                    nanosecond: NanosecondRange,
-                   zone: Timezone = local()): DateTime =
+                   zone: Timezone = local()): DateTime {.deprecated: "use `dateTime`".} =
   ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
   runnableExamples:
     let dt1 = initDateTime(30, mMar, 2017, 00, 00, 00, 00, utc())
@@ -1356,7 +1376,7 @@ proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
 
 proc initDateTime*(monthday: MonthdayRange, month: Month, year: int,
                    hour: HourRange, minute: MinuteRange, second: SecondRange,
-                   zone: Timezone = local()): DateTime =
+                   zone: Timezone = local()): DateTime {.deprecated: "use `dateTime`".} =
   ## Create a new `DateTime <#DateTime>`_ in the specified timezone.
   runnableExamples:
     let dt1 = initDateTime(30, mMar, 2017, 00, 00, 00, utc())


### PR DESCRIPTION
fix #17072
closes #18584

## links
* https://en.wikipedia.org/wiki/ISO_8601
* https://www.iso.org/iso-8601-date-and-time-format.html