### PR TITLE
add `vmutils.debugNimNode`, allows using astalgo.debug in user code

### DIFF
--- a/compiler/astalgo.nim
+++ b/compiler/astalgo.nim
@@ -663,6 +663,14 @@ proc debug(n: PNode; conf: ConfigRef) =
   this.value(n)
   echo($this.res)
 
+proc debugNimNodeImpl*(n: PNode; conf: ConfigRef): string =
+  var this: DebugPrinter
+  this.visited = initTable[pointer, int]()
+  #this.renderSymType = true # can be customized later
+  this.useColor = not defined(windows)
+  this.value(n)
+  result = $this.res
+
 proc nextTry(h, maxHash: Hash): Hash =
   result = ((5 * h) + 1) and maxHash
   # For any initial h in range(maxHash), repeating that maxHash times

--- a/compiler/vmops.nim
+++ b/compiler/vmops.nim
@@ -33,6 +33,7 @@ from sighashes import symBodyDigest
 
 # There are some useful procs in vmconv.
 import vmconv
+from astalgo import debugNimNodeImpl
 
 template mathop(op) {.dirty.} =
   registerCallback(c, "stdlib.math." & astToStr(op), `op Wrapper`)
@@ -337,3 +338,7 @@ proc registerAdditionalOps*(c: PCtx) =
     let p = a.getVar(0)
     let x = a.getFloat(1)
     addFloatSprintf(p.strVal, x)
+
+  registerCallback c, "stdlib.vmutils.debugNimNode", proc(a: VmArgs) =
+    let n = getNode(a, 0)
+    setResult(a, debugNimNodeImpl(n, c.config))

--- a/lib/std/vmutils.nim
+++ b/lib/std/vmutils.nim
@@ -9,3 +9,14 @@ proc vmTrace*(on: bool) {.compileTime.} =
       var a = 1
       vmTrace(false)
     static: fn()
+
+proc debugNimNode*(a: NimNode): string =
+  ## Implementation-specific rendering of `a` in the compiler, unstable.
+  runnableExamples:
+    import std/[macros, strutils]
+    macro dbg1(a: auto): string =
+      newLit(debugNimNode(a))
+    macro dbg2(a): string =
+      newLit(debugNimNode(a))
+    assert "nfSem" in dbg1(1+2)
+    assert "nfSem" notin dbg2(1+2)

--- a/lib/std/vmutils.nim
+++ b/lib/std/vmutils.nim
@@ -12,6 +12,7 @@ proc vmTrace*(on: bool) {.compileTime.} =
 
 proc debugNimNode*(a: NimNode): string =
   ## Implementation-specific rendering of `a` in the compiler, unstable.
+  # This is a vmops, see implementation in `astalgo.debugNimNodeImpl`.
   runnableExamples:
     import std/[macros, strutils]
     macro dbg1(a: auto): string =


### PR DESCRIPTION
intended to help investigate compiler issues, which to this day remains difficult and time consuming.

`macros.treeRepr` is still what should be used for regular users, but `treeRepr` is a lossy representation, and oftentimes to debug issues you need access to the full PNode fields (recursively), which (currently) is the most faithfully rendered via `astalgo.debug` which doesn't hide fields (eg flags, comment field etc); this PR allows exposing it in user code so that recompiling the compiler isn't needed (which is time consuming in a multi edit-debug session)

Here's how debugutils relates to vmutils:
* compiler/debugutils.nim: importable from compiler code
* std/vmutils.nim: importable from user code

## future work
- [ ] improve rendering of `debug`, eg to render as a tree (like treeRepr) or via an html file with collapsable nodes as shown in https://github.com/nim-lang/RFCs/issues/385 (I've implemented this in a private branch, it helps a lot debugging issues as it gives a full snapshot of the AST with all the information present)