### PR TITLE
Fixed const tuples in inferred generics

### DIFF
--- a/tests/tuples/tinferred_generic_const.nim
+++ b/tests/tuples/tinferred_generic_const.nim
@@ -1,0 +1,14 @@
+discard """
+  action: run
+"""
+block:
+  proc something(a: string or int or float) =
+    const (c, d) = (default a.type, default a.type)
+
+block:
+  proc something(a: string or int) =
+    const c = default a.type
+
+block:
+  proc something(a: string or int) =
+    const (c, d, e) = (default a.type, default a.type, default a.type)


### PR DESCRIPTION
Much like my last PR in inferred generics const tuples have an illformed AST errors.
Example:
```nim
proc doSomething(a: int or float) =
  const (c, d) = (10, 100)
  ```