### PR TITLE
added `sequtils.mapItLit`, replaces `mapLiterals`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -366,7 +366,7 @@
 - `std/sequtils`:
   * Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect
     if the slice is out of bounds, likewise with `strutils.delete`.
-  * Deprecated `mapLiterals` and added `mapItLit`.
+  * Added `mapItLit`.
 
 ## Language changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -363,6 +363,10 @@
 
 - Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect
   if the slice is out of bounds, likewise with `strutils.delete`.
+- `std/sequtils`:
+  * Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect
+    if the slice is out of bounds, likewise with `strutils.delete`.
+  * Deprecated `mapLiterals` and added `mapItLit`.
 
 ## Language changes
 

--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -1141,10 +1141,13 @@ func mapLitsImpl(constructor: NimNode; op: NimNode; nested: bool;
         result.add v
 
 macro mapLiterals*(constructor, op: untyped;
-                   nested = true): untyped {.deprecated: "use `mapItLit`".} =
+                   nested = true): untyped =
   ## Applies `op` to each of the **atomic** literals like `3`
-  ## or `"abc"` in the specified `constructor` AST. This can
-  ## be used to map every array element to some target type:
+  ## or `"abc"` in the specified `constructor` AST.
+  ##
+  ## See also `mapItLit`.
+  ##
+  ## This can be used to map every array element to some target type:
   runnableExamples:
     let x = mapLiterals([0.1, 1.2, 2.3, 3.4], int)
     doAssert x is array[4, int]


### PR DESCRIPTION
* `mapItLit` is error prone and not flexible enough, see https://github.com/nim-lang/Nim/pull/18577#issuecomment-886231715
* `mapIt` returns a seq so isn't appropriate in cases where you want to return an array|set|etc

This PR introduces `mapItLit` which is more useful and intuitive than  `mapLiterals`, see examples; lots of examples wouldn't work with `mapLiterals`, which is just the wrong abstraction

## example 0:
mapLiterals can't handle simple transformations
```nim
import sequtils
# echo mapLiterals([(1, 'a'), (2, 'b')], ??) # impossible
echo mapItLit([(1, 'a'), (2, 'b')], (it[0].float, it[1])) # [(1.0, 'a'), (2.0, 'b')]
```

## example 1:
mapLiterals doesn't work with user defined literals
```nim
import sequtils, strutils
proc `'big`(a: string): int = a.parseInt
echo mapLiterals((2, 3'big), `$`) # ("2", 3) instead of ("2", "3")
echo mapItLit((2, 3'big), $it) # ("2", "3")
```

## example 2:
mapLiterals doesn't work with const elements
```nim
import sequtils, strutils, math
const a = 3
echo mapLiterals((PI, Inf, a, 4), `$`) # (3.141592653589793, inf, 3, "4")
echo mapItLit((PI, Inf, a, 4), $it) # ("3.141592653589793", "inf", "3", "4")
```

## example 3:
mapLiterals can't reuse a const array-like literal
```nim
import sequtils
const vals = [1,2,3]
echo mapLiterals(vals, float) # [1, 2, 3]
echo mapLiterals(vals, int8) # [1, 2, 3] (not actually transformed)

echo mapItLit(vals, it.float) # [1.0, 2.0, 3.0]
echo mapItLit(vals, it.int8) # [1, 2, 3]
```

## example 4:
mapLiterals requires an auxiliary routine whereas mapItLit can inline the expression:
```nim
import sequtils
template doubleIt(it): untyped = (it, it)
echo mapLiterals([1,2,3], doubleIt)

echo mapItLit([1,2,3], (it, it))
echo mapItLit([1,2,3], doubleIt(it)) # also works
```

