### PR TITLE
Update `lib.rst`

### DIFF
--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -49,6 +49,9 @@ Automatic imports
 Core
 ----
 
+* `atomics <atomics.html>`_
+  Types and operations for atomic operations and lockless algorithms.
+
 * `bitops <bitops.html>`_
   Provides a series of low-level methods for bit manipulation.
 
@@ -169,6 +172,9 @@ String handling
   Ropes can represent very long strings efficiently;
   in particular, concatenation is done in O(1) instead of O(n).
 
+* `strbasics <strbasics.html>`_
+  This module provides some high performance string operations.
+
 * `strformat <strformat.html>`_
   Macro based standard string interpolation/formatting. Inspired by
   Python's f-strings.
@@ -275,6 +281,9 @@ Math libraries
 * `stats <stats.html>`_
   Statistical analysis.
 
+* `sums <sums.html>`_
+  Accurate summation functions.
+
 * `sysrand <sysrand.html>`_
   Cryptographically secure pseudorandom number generator.
 
@@ -333,6 +342,13 @@ Internet Protocols and Support
 
 * `uri <uri.html>`_
   This module provides functions for working with URIs.
+
+
+Threading
+---------
+
+* `threadpool <threadpool.html>`_
+  Implements Nim's `spawn <manual_experimental.html#parallel-amp-spawn>`_.
 
 
 Parsers
@@ -442,8 +458,15 @@ Hashing
 Miscellaneous
 -------------
 
+* `browsers <browsers.html>`_
+  This module implements procs for opening URLs with the user's default
+  browser.
+
 * `colors <colors.html>`_
   This module implements color handling for Nim.
+
+* `coro <coro.html>`_
+  This module implements experimental coroutines in Nim.
 
 * `enumerate <enumerate.html>`_
   This module implements `enumerate` syntactic sugar based on Nim's macro system.
@@ -459,6 +482,9 @@ Miscellaneous
 
 * `unittest <unittest.html>`_
   Implements a Unit testing DSL.
+
+* `varints <varints.html>`_
+  Decode variable-length integers that are compatible with SQLite.
 
 * `with <with.html>`_
   This module implements the `with` macro for easy function chaining.
@@ -571,23 +597,3 @@ Network Programming and Internet Protocols
 
 * `openssl <openssl.html>`_
   Wrapper for OpenSSL.
-
-
-Unstable
-========
-
-* `atomics <atomics.html>`_
-  Types and operations for atomic operations and lockless algorithms.
-
-* `browsers <browsers.html>`_
-  This module implements procs for opening URLs with the user's default
-  browser.
-
-* `coro <coro.html>`_
-  This module implements experimental coroutines in Nim.
-
-* `threadpool <threadpool.html>`_
-  Implements Nim's `spawn <manual_experimental.html#parallel-amp-spawn>`_.
-
-* `varints <varints.html>`_
-  Decode variable-length integers that are compatible with SQLite.

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -41,7 +41,7 @@ Automatic imports
   Basic Nim thread support. **Note:** This is part of the system module. Do not
   import it explicitly. Enabled with `--threads:on`:option:.
 
-* `channels <channels_builtin.html>`_
+* `channels_builtin <channels_builtin.html>`_
   Nim message passing support for threads. **Note:** This is part of the
   system module. Do not import it explicitly. Enabled with `--threads:on`:option:.
 
@@ -66,7 +66,7 @@ Core
 
 * `macrocache <macrocache.html>`_
   Provides an API for macros to collect compile-time information across modules.
-  
+
 * `macros <macros.html>`_
   Contains the AST API and documentation of Nim for writing macros.
 
@@ -88,10 +88,10 @@ Algorithms
 ----------
 
 * `algorithm <algorithm.html>`_
-  This module implements some common generic algorithms like sort or binary search.
+  This module implements some common generic algorithms on `openArray`s.
 
 * `enumutils <enumutils.html>`_
-  This module adds functionality for the built-in `enum` type.
+  This module adds functionality for `enum`s.
 
 * `sequtils <sequtils.html>`_
   This module implements operations for the built-in `seq` type
@@ -113,7 +113,7 @@ Collections
   The underlying implementation uses a `seq`.
 
 * `heapqueue <heapqueue.html>`_
-  Implementation of a heap data structure that can be used as a priority queue.
+  Implementation of a binary heap data structure that can be used as a priority queue.
 
 * `intsets <intsets.html>`_
   Efficient implementation of a set of ints as a sparse bit set.
@@ -129,7 +129,7 @@ Collections
   Efficient implementation of a set of ordinals as a sparse bit set.
 
 * `sets <sets.html>`_
-  Nim hash and bit set support.
+  Nim hash set support.
 
 * `sharedlist <sharedlist.html>`_
   Nim shared linked list support. Contains a shared singly-linked list.
@@ -167,11 +167,11 @@ String handling
 * `ropes <ropes.html>`_
   This module contains support for a *rope* data type.
   Ropes can represent very long strings efficiently;
-  especially concatenation is done in O(1) instead of O(n).
+  in particular, concatenation is done in O(1) instead of O(n).
 
 * `strformat <strformat.html>`_
   Macro based standard string interpolation/formatting. Inspired by
-  Python's `f`-strings.
+  Python's f-strings.
 
 * `strmisc <strmisc.html>`_
   This module contains uncommon string handling operations that do not
@@ -266,9 +266,6 @@ Math libraries
 * `math <math.html>`_
   Mathematical operations like cosine, square root.
 
-* `mersenne <mersenne.html>`_
-  Mersenne twister random number generator.
-
 * `random <random.html>`_
   Fast and tiny random number generator.
 
@@ -277,9 +274,6 @@ Math libraries
 
 * `stats <stats.html>`_
   Statistical analysis.
-
-* `sums <sums.html>`_
-  Accurate summation functions.
 
 * `sysrand <sysrand.html>`_
   Cryptographically secure pseudorandom number generator.
@@ -339,13 +333,6 @@ Internet Protocols and Support
 
 * `uri <uri.html>`_
   This module provides functions for working with URIs.
-
-
-Threading
----------
-
-* `threadpool <threadpool.html>`_
-  Implements Nim's `spawn <manual_experimental.html#parallel-amp-spawn>`_.
 
 
 Parsers
@@ -433,7 +420,7 @@ Hashing
 -------
 
 * `base64 <base64.html>`_
-  This module implements a base64 encoder and decoder.
+  This module implements a Base64 encoder and decoder.
 
 * `hashes <hashes.html>`_
   This module implements efficient computations of hash values for diverse
@@ -446,7 +433,7 @@ Hashing
   An OID is a global ID that consists of a timestamp,
   a unique counter, and a random value. This combination should suffice to
   produce a globally distributed unique ID. This implementation was extracted
-  from the Mongodb interface and it thus binary compatible with a Mongo OID.
+  from the MongoDB interface and it thus binary compatible with a MongoDB OID.
 
 * `sha1 <sha1.html>`_
   This module implements a sha1 encoder and decoder.
@@ -455,15 +442,8 @@ Hashing
 Miscellaneous
 -------------
 
-* `browsers <browsers.html>`_
-  This module implements procs for opening URLs with the user's default
-  browser.
-
 * `colors <colors.html>`_
   This module implements color handling for Nim.
-
-* `coro <coro.html>`_
-  This module implements experimental coroutines in Nim.
 
 * `enumerate <enumerate.html>`_
   This module implements `enumerate` syntactic sugar based on Nim's macro system.
@@ -480,22 +460,21 @@ Miscellaneous
 * `unittest <unittest.html>`_
   Implements a Unit testing DSL.
 
-* `varints <varints.html>`_
-  Decode variable-length integers that are compatible with SQLite.
-
 * `with <with.html>`_
   This module implements the `with` macro for easy function chaining.
 
 
-
-Modules for JS backend
-----------------------
+Modules for the JS backend
+--------------------------
 
 * `asyncjs <asyncjs.html>`_
   Types and macros for writing asynchronous procedures in JavaScript.
 
 * `dom <dom.html>`_
   Declaration of the Document Object Model for the JS backend.
+
+* `jsbigints <jsbigints.html>`_
+  Arbitrary precision integers.
 
 * `jsconsole <jsconsole.html>`_
   Wrapper for the `console` object.
@@ -517,7 +496,6 @@ Regular expressions
 * `re <re.html>`_
   This module contains procedures and operators for handling regular
   expressions. The current implementation uses PCRE.
-
 
 
 Database support
@@ -583,7 +561,7 @@ Database support
 * `mysql <mysql.html>`_
   Contains a wrapper for the mySQL API.
 * `sqlite3 <sqlite3.html>`_
-  Contains a wrapper for SQLite 3 API.
+  Contains a wrapper for the SQLite 3 API.
 * `odbcsql <odbcsql.html>`_
   interface to the ODBC driver.
 
@@ -595,9 +573,21 @@ Network Programming and Internet Protocols
   Wrapper for OpenSSL.
 
 
-
 Unstable
 ========
 
 * `atomics <atomics.html>`_
   Types and operations for atomic operations and lockless algorithms.
+
+* `browsers <browsers.html>`_
+  This module implements procs for opening URLs with the user's default
+  browser.
+
+* `coro <coro.html>`_
+  This module implements experimental coroutines in Nim.
+
+* `threadpool <threadpool.html>`_
+  Implements Nim's `spawn <manual_experimental.html#parallel-amp-spawn>`_.
+
+* `varints <varints.html>`_
+  Decode variable-length integers that are compatible with SQLite.

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -94,7 +94,7 @@ Algorithms
   This module implements some common generic algorithms like sort or binary search.
 
 * `enumutils <enumutils.html>`_
-  This module adds functionality for `enum`s.
+  This module adds functionality for the built-in `enum` type.
 
 * `sequtils <sequtils.html>`_
   This module implements operations for the built-in `seq` type

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -91,7 +91,7 @@ Algorithms
 ----------
 
 * `algorithm <algorithm.html>`_
-  This module implements some common generic algorithms on `openArray`s.
+  This module implements some common generic algorithms like sort or binary search.
 
 * `enumutils <enumutils.html>`_
   This module adds functionality for `enum`s.


### PR DESCRIPTION
Changes
* improved wording
* renamed `channels` to `channels_builtin` (since that's what it's called now)
* removed `mersenne` and `sums` because they're deprecated (assuming #18439 gets merged)
* added `jsbigints`
* moved `browsers`, `coro`, `threadpool`, `varints` to the "Unstable" section (since their module documentation says they're unstable and they don't belong in a particular category (except `threadpool`, but it was the only module listed under "Threading"))

There are a few other modules that are marked as unstable (`endians`, `typetraits`, `sharedtables`, `sharedlists`, `asynstreams`, `base64`), but I didn't move them to the "Unstable" section, because I think they fit better in their current category. There are also some modules that aren't currently listed in `lib.rst` and are marked as experimental (for example `isolation` and `channels` (new)). Are unstable and experimental considered to be equivalent? Should I maybe rename "Unstable" to "Unstable/Experimental" and add those modules there?