### PR TITLE
Allow `nnkAccQuoted` in `genEnumCaseStmt`

### DIFF
--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -36,6 +36,10 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
     case f.kind
     of nnkEmpty: continue # skip first node of `enumTy`
     of nnkSym, nnkIdent: fStr = f.strVal
+    of nnkAccQuoted:
+      fStr = ""
+      for ch in f:
+        fStr.add ch.strVal
     of nnkEnumFieldDef:
       case f[1].kind
       of nnkStrLit: fStr = f[1].strVal

--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -46,7 +46,7 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
         fStr = f[0].strVal
         fNum = f[1].intVal
       else: error("Invalid tuple syntax!", f[1])
-    else: error("Invalid node for enum type!", f)
+    else: error("Invalid node for enum type `" & $f.kind & "`!", f)
     # add field if string not already added
     if fNum >= userMin and fNum <= userMax:
       fStr = normalizer(fStr)


### PR DESCRIPTION
While trying to build the docs for [latexdsl](https://github.com/Vindaar/LatexDSL) I got some weird "Invalid node for enum type" CT errors during the `nim doc` call on the main file.

Turns out this is due to enum fields using accented quotes. I'm not sure why this is only an issue when running `nim doc` though. Compiling the file (even individually) works perfectly fine.

This PR simply adds support for accented quotes to the macro. In addition it adds the node kind to the error, as it's extremely annoying to see "invalid node kind" but not having any idea what the node is we're looking at!

I'm not sure if the simple concatenation of the possible `nnkAccQuoted` children is the desired behavior. 