### PR TITLE
refs #16613: check opcWrDeref for nil

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -812,11 +812,10 @@ proc rawExecute(c: PCtx, start: int, tos: PStackFrame): TFullReg =
         # vmgen generates opcWrDeref, which means that we must dereference
         # twice.
         # TODO: This should likely be handled differently in vmgen.
-        if (nfIsRef notin regs[ra].nodeAddr[].flags and
-            nfIsRef notin n.flags):
-          regs[ra].nodeAddr[][] = n[]
-        else:
-          regs[ra].nodeAddr[] = n
+        let nAddr = regs[ra].nodeAddr
+        if nAddr[] == nil: stackTrace(c, tos, pc, "opcWrDeref internal error") # refs bug #16613
+        if (nfIsRef notin nAddr[].flags and nfIsRef notin n.flags): nAddr[][] = n[]
+        else: nAddr[] = n
       of rkRegisterAddr: regs[ra].regAddr[] = regs[rc]
       of rkNode:
          # xxx: also check for nkRefTy as in opcLdDeref?


### PR DESCRIPTION
refs https://github.com/nim-lang/Nim/issues/16613 /cc @yglukhov

before PR: SIGSEGV

after PR:
```
stack trace: (most recent call last)
/Users/timothee/git_clone/nim/temp/iface/tests/test1.nim(34, 23) test1
/Users/timothee/git_clone/nim/temp/iface/tests/test1.nim(24, 7) template/generic instantiation of `suite` from here
/Users/timothee/git_clone/nim/temp/iface/tests/test1.nim(34, 23) Error: opcWrDeref internal error
```

(so you at least got a stacktrace in user code instead of nothing with default nim)

see https://github.com/nim-lang/Nim/issues/16613#issuecomment-889468902 for more info, workaround and a proposal for a fix