### PR TITLE
fix #14343, parseCmdLine

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -112,6 +112,8 @@
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
 - `os.parseCmdLine` now raises on posix for invalid inputs, and now returns correct results, such
   that `parseCmdLine(quoteShellCommand(a)) == a`.
+- `os.parseCmdLine` with `-d:nimPreviewParseCmdLine` (enabled on devel) now raises on posix for invalid inputs,
+  and now returns correct results, such that `parseCmdLine(quoteShellCommand(a)) == a`.
 
 
 ## Standard library additions and changes

--- a/changelog.md
+++ b/changelog.md
@@ -110,6 +110,9 @@
 
 - The allocator for Nintendo Switch, which was nonfunctional because
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
+- `os.parseCmdLine` now raises on posix for invalid inputs, and now returns correct results, such
+  that `parseCmdLine(quoteShellCommand(a)) == a`.
+
 
 ## Standard library additions and changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -110,11 +110,6 @@
 
 - The allocator for Nintendo Switch, which was nonfunctional because
   of breaking changes in libnx, was removed, in favour of the new `-d:nimAllocPagesViaMalloc` option.
-- `os.parseCmdLine` now raises on posix for invalid inputs, and now returns correct results, such
-  that `parseCmdLine(quoteShellCommand(a)) == a`.
-- `os.parseCmdLine` with `-d:nimPreviewParseCmdLine` (enabled on devel) now raises on posix for invalid inputs,
-  and now returns correct results, such that `parseCmdLine(quoteShellCommand(a)) == a`.
-
 
 ## Standard library additions and changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -222,7 +222,7 @@
 
 - Added `os.getCacheDir()` to return platform specific cache directory.
 
-- Added `os.parseShellCommand` such that `parseShellCommand(quoteShellCommand(a)) == a`.
+- Added `os.splitShellCmd` such that `splitShellCmd(quoteShellCommand(a)) == a`.
 
 - Added a simpler to use `io.readChars` overload.
 

--- a/changelog.md
+++ b/changelog.md
@@ -222,6 +222,8 @@
 
 - Added `os.getCacheDir()` to return platform specific cache directory.
 
+- Added `os.parseShellCommand` such that `parseShellCommand(quoteShellCommand(a)) == a`.
+
 - Added a simpler to use `io.readChars` overload.
 
 - Added `**` to jsffi.

--- a/config/config.nims
+++ b/config/config.nims
@@ -14,3 +14,11 @@ when defined(nimStrictMode):
     # switch("hint", "ConvFromXtoItselfNotNeeded")
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
+
+when (NimMajor, NimMinor) == (1,6) or (NimMajor, NimMinor) <= (1,4):
+  discard
+else:
+  # devel gets bugfixes right away; next release gets bugfixes via a preview flag.
+  # these can be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
+  # other `nimPreview` switches can go here, as needed.
+  switch("define", "nimPreviewParseCmdLine")

--- a/config/config.nims
+++ b/config/config.nims
@@ -14,11 +14,3 @@ when defined(nimStrictMode):
     # switch("hint", "ConvFromXtoItselfNotNeeded")
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
-
-when (NimMajor, NimMinor) == (1,6) or (NimMajor, NimMinor) <= (1,4):
-  discard
-else:
-  # devel gets bugfixes right away; next release gets bugfixes via a preview flag.
-  # these can be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
-  # other `nimPreview` switches can go here, as needed.
-  switch("define", "nimPreviewParseCmdLine")

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2789,7 +2789,10 @@ proc parseShellCommand*(a: string): seq[string] =
   ##
   ## On windows, it follows the shell quoting rules for `"`, ``\`` .
   ##
-  ## On either platform, it verifies that `parseCmdLine(quoteShellCommand(a)) == a`.
+  ## On either platform, it satisfies `parseCmdLine(quoteShellCommand(a)) == a`,
+  ## but `quoteShellCommand(parseCmdLine(a)) == a` doesn't necessarily hold.
+  ##
+  ## Special chars (`!, {, }, $, |` etc) are treated as regular chars.
   runnableExamples:
     let a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
     assert a.quoteShellCommand.parseShellCommand == a
@@ -2799,8 +2802,6 @@ proc parseShellCommand*(a: string): seq[string] =
       doAssertRaises(ValueError): discard parseShellCommand("abc'bar") # unclosed `'`
       doAssertRaises(ValueError): discard parseShellCommand("abc\"bar") # unclosed `"`
       doAssertRaises(ValueError): discard parseShellCommand("abc\\") # unfinished escape
-  # Future work can add optional params to specify how to handle special chars:
-  # `!, {, }, $, |` etc.
   # note: `parseCmdLine(quoteShellCommand(a)) == a` requires https://github.com/nim-lang/Nim/pull/18671
   # on windows.
   when defined(windows):

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2739,7 +2739,7 @@ proc exclFilePermissions*(filename: string,
 when not defined(windows):
   import std/private/shlexutils
 
-func parseShellCommandWindows(c: string): seq[string] =
+func splitShellCmdWindows(c: string): seq[string] =
   var i = 0
   var a = ""
   while true:
@@ -2782,7 +2782,7 @@ func parseShellCommandWindows(c: string): seq[string] =
         inc(i)
     add(result, a)
 
-func parseShellCommand*(a: string): seq[string] =
+func splitShellCmd*(a: string): seq[string] =
   ## On posix, it follows the shell quoting rules for `"`, `'`, ``\`` and
   ## raises `ValueError` on invalid inputs
   ## (unclosed single or double quotes or unfinished escape sequences).
@@ -2795,15 +2795,15 @@ func parseShellCommand*(a: string): seq[string] =
   ## Special chars (`!, {, }, $, |` etc) are treated as regular chars.
   runnableExamples:
     let a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
-    assert a.quoteShellCommand.parseShellCommand == a
+    assert a.quoteShellCommand.splitShellCmd == a
     when defined(posix):
-      assert """  \ \ ab\ cd\ ef\  \ gh\   """.parseShellCommand == @["  ab cd ef ", " gh "]
-      assert """ ab\"cd " ef\"gh "\   """.parseShellCommand == @["ab\"cd", " ef\"gh  "]
-      doAssertRaises(ValueError): discard parseShellCommand("abc'bar") # unclosed `'`
-      doAssertRaises(ValueError): discard parseShellCommand("abc\"bar") # unclosed `"`
-      doAssertRaises(ValueError): discard parseShellCommand("abc\\") # unfinished escape
+      assert """  \ \ ab\ cd\ ef\  \ gh\   """.splitShellCmd == @["  ab cd ef ", " gh "]
+      assert """ ab\"cd " ef\"gh "\   """.splitShellCmd == @["ab\"cd", " ef\"gh  "]
+      doAssertRaises(ValueError): discard splitShellCmd("abc'bar") # unclosed `'`
+      doAssertRaises(ValueError): discard splitShellCmd("abc\"bar") # unclosed `"`
+      doAssertRaises(ValueError): discard splitShellCmd("abc\\") # unfinished escape
   when defined(windows):
-    result = parseShellCommandWindows(a)
+    result = splitShellCmdWindows(a)
   else:
     for val in shlex(a): result.add val
 
@@ -2811,7 +2811,7 @@ func parseCmdLine*(c: string): seq[string] {.rtl, extern: "nos$1".} =
   ## Splits a `command line`:idx: into several components.
   ##
   ## **Note**: This proc is only occasionally useful, better use the
-  ## `parseopt module <parseopt.html>`_ or `os.parseShellCommand`.
+  ## `parseopt module <parseopt.html>`_ or `os.splitShellCmd`.
   ##
   ## On Windows, it uses the `following parsing rules
   ## <http://msdn.microsoft.com/en-us/library/17w5ykft.aspx>`_:
@@ -2847,7 +2847,7 @@ func parseCmdLine*(c: string): seq[string] {.rtl, extern: "nos$1".} =
   ## * `commandLineParams proc <#commandLineParams>`_
 
   when defined(windows):
-    result = parseShellCommandWindows(c)
+    result = splitShellCmdWindows(c)
   else:
     var i = 0
     var a = ""

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2753,6 +2753,8 @@ proc parseShellCommand*(a: string): seq[string] =
       doAssertRaises(ValueError): discard parseShellCommand("abc'bar") # unclosed `'`
       doAssertRaises(ValueError): discard parseShellCommand("abc\"bar") # unclosed `"`
       doAssertRaises(ValueError): discard parseShellCommand("abc\\") # unfinished escape
+  # Future work can add optional params to specify how to handle special chars:
+  # `!, {, }, $, |` etc.
   for val in shlex(a): result.add val
 
 proc parseCmdLine*(c: string): seq[string] {.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2739,9 +2739,28 @@ proc exclFilePermissions*(filename: string,
 when not defined(windows):
   import std/private/shlexutils
 
+proc parseShellCommand*(a: string): seq[string] =
+  ## On Posix systems, it follows the shell quoting rules for `"`, `'`, ``\``
+  ## and is such that `parseCmdLine(quoteShellCommand(a)) == a`;
+  ## it raises ValueError on invalid inputs
+  ## (unclosed single or double quotes or unfinished escape sequences).
+  runnableExamples:
+    let a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
+    assert a.quoteShellCommand.parseShellCommand == a
+    when defined(posix):
+      assert """  \ \ ab\ cd\ ef\  \ gh\   """.parseShellCommand == @["  ab cd ef ", " gh "]
+      assert """ ab\"cd " ef\"gh "\   """.parseShellCommand == @["ab\"cd", " ef\"gh  "]
+      doAssertRaises(ValueError): discard parseShellCommand("abc'bar") # unclosed `'`
+      doAssertRaises(ValueError): discard parseShellCommand("abc\"bar") # unclosed `"`
+      doAssertRaises(ValueError): discard parseShellCommand("abc\\") # unfinished escape
+  for val in shlex(a): result.add val
+
 proc parseCmdLine*(c: string): seq[string] {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Splits a `command line`:idx: into several components.
+  ##
+  ## **Note**: This proc is only occasionally useful, better use the
+  ## `parseopt module <parseopt.html>`_ or `os.parseShellCommand`.
   ##
   ## On Windows, it uses the `following parsing rules
   ## <http://msdn.microsoft.com/en-us/library/17w5ykft.aspx>`_:
@@ -2766,12 +2785,7 @@ proc parseCmdLine*(c: string): seq[string] {.
   ##   and the double quotation mark is "escaped" by the remaining backslash,
   ##   causing a literal double quotation mark (") to be placed in argv.
   ##
-  ## On Posix systems, with `-d:nimPreviewParseCmdLine`, it follows the shell
-  ## quoting rules for `"`, `'`, ``\`` and is such that
-  ## `parseCmdLine(quoteShellCommand(a)) == a`; it raises ValueError on invalid
-  ## inputs (unclosed single or double quotes or unfinished escape sequences).
-  ##
-  ## Without `-d:nimPreviewParseCmdLine`, it uses the following parsing rules:
+  ## On Posix systems, it uses the following parsing rules:
   ## Components are separated by whitespace unless the whitespace
   ## occurs within ``"`` or ``'`` quotes.
   ##
@@ -2780,74 +2794,63 @@ proc parseCmdLine*(c: string): seq[string] {.
   ## * `paramCount proc <#paramCount>`_
   ## * `paramStr proc <#paramStr,int>`_
   ## * `commandLineParams proc <#commandLineParams>`_
-  runnableExamples("-d:nimPreviewParseCmdLine"):
-    let a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
-    assert a.quoteShellCommand.parseCmdLine == a
-    when defined(posix):
-      assert """  \ \ ab\ cd\ ef\  \ gh\   """.parseCmdLine == @["  ab cd ef ", " gh "]
-      assert """ ab\"cd " ef\"gh "\   """.parseCmdLine == @["ab\"cd", " ef\"gh  "]
-      doAssertRaises(ValueError): discard parseCmdLine("abc'bar") # unclosed `'`
-      doAssertRaises(ValueError): discard parseCmdLine("abc\"bar") # unclosed `"`
-      doAssertRaises(ValueError): discard parseCmdLine("abc\\") # unfinished escape
-  when not defined(windows) and defined(nimPreviewParseCmdLine):
-    for val in shlex(c): result.add val
-  else:
-    result = @[]
-    var i = 0
-    var a = ""
-    while true:
-      setLen(a, 0)
-      # eat all delimiting whitespace
-      while i < c.len and c[i] in {' ', '\t', '\l', '\r'}: inc(i)
-      if i >= c.len: break
-      when defined(windows):
-        # parse a single argument according to the above rules:
-        var inQuote = false
-        while i < c.len:
-          case c[i]
-          of '\\':
-            var j = i
-            while j < c.len and c[j] == '\\': inc(j)
-            if j < c.len and c[j] == '"':
-              for k in 1..(j-i) div 2: a.add('\\')
-              if (j-i) mod 2 == 0:
-                i = j
-              else:
-                a.add('"')
-                i = j+1
+
+  result = @[]
+  var i = 0
+  var a = ""
+  while true:
+    setLen(a, 0)
+    # eat all delimiting whitespace
+    while i < c.len and c[i] in {' ', '\t', '\l', '\r'}: inc(i)
+    if i >= c.len: break
+    when defined(windows):
+      # parse a single argument according to the above rules:
+      var inQuote = false
+      while i < c.len:
+        case c[i]
+        of '\\':
+          var j = i
+          while j < c.len and c[j] == '\\': inc(j)
+          if j < c.len and c[j] == '"':
+            for k in 1..(j-i) div 2: a.add('\\')
+            if (j-i) mod 2 == 0:
+              i = j
             else:
-              a.add(c[i])
-              inc(i)
-          of '"':
-            inc(i)
-            if not inQuote: inQuote = true
-            elif i < c.len and c[i] == '"':
-              a.add(c[i])
-              inc(i)
-            else:
-              inQuote = false
-              break
-          of ' ', '\t':
-            if not inQuote: break
-            a.add(c[i])
-            inc(i)
+              a.add('"')
+              i = j+1
           else:
             a.add(c[i])
             inc(i)
-      else:
-        case c[i]
-        of '\'', '\"':
-          var delim = c[i]
-          inc(i) # skip ' or "
-          while i < c.len and c[i] != delim:
-            add a, c[i]
+        of '"':
+          inc(i)
+          if not inQuote: inQuote = true
+          elif i < c.len and c[i] == '"':
+            a.add(c[i])
             inc(i)
-          if i < c.len: inc(i)
+          else:
+            inQuote = false
+            break
+        of ' ', '\t':
+          if not inQuote: break
+          a.add(c[i])
+          inc(i)
         else:
-          while i < c.len and c[i] > ' ':
-            add(a, c[i])
-            inc(i)
-      add(result, a)
+          a.add(c[i])
+          inc(i)
+    else:
+      case c[i]
+      of '\'', '\"':
+        var delim = c[i]
+        inc(i) # skip ' or "
+        while i < c.len and c[i] != delim:
+          add a, c[i]
+          inc(i)
+        if i < c.len: inc(i)
+      else:
+        while i < c.len and c[i] > ' ':
+          add(a, c[i])
+          inc(i)
+    add(result, a)
 
 when defined(nimdoc):
   # Common forward declaration docstring block for parameter retrieval procs.

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2739,7 +2739,7 @@ proc exclFilePermissions*(filename: string,
 when not defined(windows):
   import std/private/shlexutils
 
-proc parseShellCommandWindows(c: string): seq[string] =
+func parseShellCommandWindows(c: string): seq[string] =
   var i = 0
   var a = ""
   while true:
@@ -2782,7 +2782,7 @@ proc parseShellCommandWindows(c: string): seq[string] =
         inc(i)
     add(result, a)
 
-proc parseShellCommand*(a: string): seq[string] =
+func parseShellCommand*(a: string): seq[string] =
   ## On posix, it follows the shell quoting rules for `"`, `'`, ``\`` and
   ## raises `ValueError` on invalid inputs
   ## (unclosed single or double quotes or unfinished escape sequences).
@@ -2809,8 +2809,7 @@ proc parseShellCommand*(a: string): seq[string] =
   else:
     for val in shlex(a): result.add val
 
-proc parseCmdLine*(c: string): seq[string] {.
-  noSideEffect, rtl, extern: "nos$1".} =
+func parseCmdLine*(c: string): seq[string] {.rtl, extern: "nos$1".} =
   ## Splits a `command line`:idx: into several components.
   ##
   ## **Note**: This proc is only occasionally useful, better use the

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2802,8 +2802,6 @@ func parseShellCommand*(a: string): seq[string] =
       doAssertRaises(ValueError): discard parseShellCommand("abc'bar") # unclosed `'`
       doAssertRaises(ValueError): discard parseShellCommand("abc\"bar") # unclosed `"`
       doAssertRaises(ValueError): discard parseShellCommand("abc\\") # unfinished escape
-  # note: `parseCmdLine(quoteShellCommand(a)) == a` requires https://github.com/nim-lang/Nim/pull/18671
-  # on windows.
   when defined(windows):
     result = parseShellCommandWindows(a)
   else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2787,9 +2787,7 @@ proc parseShellCommand*(a: string): seq[string] =
   ## raises `ValueError` on invalid inputs
   ## (unclosed single or double quotes or unfinished escape sequences).
   ##
-  ## On windows, it follows the shell quoting rules for `"`, ``\`` and
-  ## raises `ValueError` on invalid inputs (unclosed double quotes or unfinished
-  ## escape sequences).
+  ## On windows, it follows the shell quoting rules for `"`, ``\`` .
   ##
   ## On either platform, it verifies that `parseCmdLine(quoteShellCommand(a)) == a`.
   runnableExamples:
@@ -2803,6 +2801,8 @@ proc parseShellCommand*(a: string): seq[string] =
       doAssertRaises(ValueError): discard parseShellCommand("abc\\") # unfinished escape
   # Future work can add optional params to specify how to handle special chars:
   # `!, {, }, $, |` etc.
+  # note: `parseCmdLine(quoteShellCommand(a)) == a` requires https://github.com/nim-lang/Nim/pull/18671
+  # on windows.
   when defined(windows):
     result = parseShellCommandWindows(a)
   else:

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2779,7 +2779,8 @@ proc parseCmdLine*(c: string): seq[string] {.
   ## * `paramStr proc <#paramStr,int>`_
   ## * `commandLineParams proc <#commandLineParams>`_
   when not defined(windows):
-    result = parseCmdLineImpl(c)
+    for val in shlex(c):
+      result.add val
   else:
     result = @[]
     var i = 0

--- a/lib/std/private/shlexutils.nim
+++ b/lib/std/private/shlexutils.nim
@@ -1,0 +1,89 @@
+#[
+KEY shlex
+parseCmdLine D20200513T195153
+]#
+
+type State = enum
+  sInStart
+  sInRegular
+  sInSpace
+  sInSingleQuote
+  sInDoubleQuote
+  sFinished
+
+type ShlexError = enum
+  seOk
+  seMissingDoubleQuote
+  seMissingSingleQuote
+
+iterator shlex*(a: openArray[char], error: var ShlexError): string =
+  var i = 0
+  var buf: string
+  var state = sInStart
+  var ready = false
+  error = seOk
+  while true:
+    # echo (i, state, buf)
+    if i >= a.len:
+      case state
+      of sInSingleQuote:
+        error = seMissingSingleQuote
+      of sInDoubleQuote:
+        error = seMissingDoubleQuote
+      else:
+        ready = true
+      state = sFinished
+    var c: char
+    if i < a.len:
+      c = a[i]
+    i.inc
+    case state
+    of sFinished: discard
+    of sInStart:
+      case c
+      of ' ': discard
+      of '\'': state = sInSingleQuote
+      of '\"': state = sInDoubleQuote
+      else:
+        state = sInRegular
+        buf.add c
+    of sInRegular:
+      case c
+      of ' ': ready = true
+      of '\'': state = sInSingleQuote
+      of '\"': state = sInDoubleQuote
+      else: buf.add c
+    of sInSingleQuote:
+      case c
+      of '\'': state = sInRegular
+      else: buf.add c
+    of sInDoubleQuote:
+      case c
+      of '\"': state = sInRegular
+      # of '\'': state = sInRegular
+      else: buf.add c
+    of sInSpace:
+      case c
+      of ' ': discard
+      of '\'': state = sInSingleQuote
+      of '\"': state = sInDoubleQuote
+      else:
+        state = sInRegular
+        buf.add c
+    if ready:
+      ready = false
+      # echo (buf,)
+      yield buf
+      buf.setLen 0
+      if state != sFinished:
+        state = sInStart
+    if state == sFinished:
+      break
+
+proc parseCmdLineImpl*(a: string): seq[string] {.inline.} =
+  var err: ShlexError
+  for val in shlex(a, err):
+    if err == seOk:
+      result.add val
+    else:
+      raise newException(ValueError, $(a, err))

--- a/lib/std/private/shlexutils.nim
+++ b/lib/std/private/shlexutils.nim
@@ -24,7 +24,6 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
     Quote = '\''
     DoubleQuote = '"'
     BackSlash = '\\'
-    Special = {'$', '{', '}'}
 
   template eatEscape(state2) =
     if i >= a.len:
@@ -51,9 +50,6 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
     of sFinished: discard
     of sInStart:
       case c
-      of Special:
-        buf.add c
-        ready = true
       of ShellWhiteSpace: discard
       of Quote: state = sInSingleQuote
       of DoubleQuote: state = sInDoubleQuote
@@ -67,9 +63,6 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
       of Quote: state = sInSingleQuote
       of DoubleQuote: state = sInDoubleQuote
       of BackSlash: eatEscape(state)
-      of Special:
-        ready = true
-        i.dec
       else: buf.add c
     of sInSingleQuote:
       case c

--- a/lib/std/private/shlexutils.nim
+++ b/lib/std/private/shlexutils.nim
@@ -24,6 +24,7 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
     Quote = '\''
     DoubleQuote = '"'
     BackSlash = '\\'
+    Special = {'$', '{', '}'}
 
   template eatEscape(state2) =
     if i >= a.len:
@@ -50,6 +51,9 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
     of sFinished: discard
     of sInStart:
       case c
+      of Special:
+        buf.add c
+        ready = true
       of ShellWhiteSpace: discard
       of Quote: state = sInSingleQuote
       of DoubleQuote: state = sInDoubleQuote
@@ -63,6 +67,9 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
       of Quote: state = sInSingleQuote
       of DoubleQuote: state = sInDoubleQuote
       of BackSlash: eatEscape(state)
+      of Special:
+        ready = true
+        i.dec
       else: buf.add c
     of sInSingleQuote:
       case c

--- a/lib/std/private/shlexutils.nim
+++ b/lib/std/private/shlexutils.nim
@@ -17,15 +17,17 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
   var state = sInStart
   var ready = false
   error = seOk
-  const ShellWhiteSpace = {' ', '\t'} # not \n
+  const
+    ShellWhiteSpace = {' ', '\t'} # not \n
+    Quote = '\''
+    DoubleQuote = '"'
   while true:
     if i >= a.len:
       case state
       of sInSingleQuote: error = seMissingSingleQuote
       of sInDoubleQuote: error = seMissingDoubleQuote
       of sInStart: discard
-      else:
-        ready = true
+      else: ready = true
       state = sFinished
     var c: char
     if i < a.len:
@@ -36,30 +38,30 @@ iterator shlex*(a: openArray[char], error: var ShlexError): string =
     of sInStart:
       case c
       of ShellWhiteSpace: discard
-      of '\'': state = sInSingleQuote
-      of '\"': state = sInDoubleQuote
+      of Quote: state = sInSingleQuote
+      of DoubleQuote: state = sInDoubleQuote
       else:
         state = sInRegular
         buf.add c
     of sInRegular:
       case c
       of ShellWhiteSpace: ready = true
-      of '\'': state = sInSingleQuote
-      of '\"': state = sInDoubleQuote
+      of Quote: state = sInSingleQuote
+      of DoubleQuote: state = sInDoubleQuote
       else: buf.add c
     of sInSingleQuote:
       case c
-      of '\'': state = sInRegular
+      of Quote: state = sInRegular
       else: buf.add c
     of sInDoubleQuote:
       case c
-      of '\"': state = sInRegular
+      of DoubleQuote: state = sInRegular
       else: buf.add c
     of sInSpace:
       case c
       of ShellWhiteSpace: discard
-      of '\'': state = sInSingleQuote
-      of '\"': state = sInDoubleQuote
+      of Quote: state = sInSingleQuote
+      of DoubleQuote: state = sInDoubleQuote
       else:
         state = sInRegular
         buf.add c

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -711,29 +711,29 @@ block: # isAdmin
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
   block: # parseCmdLine, bug #14343
-    doAssertRaises(ValueError): discard "\"".parseCmdLine
-    doAssertRaises(ValueError): discard "  \"  ".parseCmdLine
-    doAssertRaises(ValueError): discard "  \'  ".parseCmdLine
-    let a = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
+    var a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
+    when defined(posix):
+      a = a & @["\\", "  a   \\"]
     let a2 = a.quoteShellCommand
     let b2 = a2.parseCmdLine
+    doAssert b2 == a, $(a, a2, b2)
+
+    let a3 = a2.quoteShell
+    let b3 = a3.parseCmdLine
+    doAssert b3 == @[a2]
+
+    let a4 = a3.quoteShell
+    let b4 = a4.parseCmdLine
+    doAssert b4 == @[a3]
+    
+    doAssert "".parseCmdLine == @[]
+    doAssert " \t\t   \t".parseCmdLine == @[]
+    doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
+    doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
     when defined(posix):
-      doAssert b2 == a, $(a, a2, b2)
-
-      let a3 = a2.quoteShell
-      let b3 = a3.parseCmdLine
-      doAssert b3 == @[a2]
-
-      let a4 = a3.quoteShell
-      let b4 = a4.parseCmdLine
-      doAssert b4 == @[a3]
-      
-      doAssert "".parseCmdLine == @[]
-      doAssert " \t\t   \t".parseCmdLine == @[]
-      doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
-      doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
-    elif defined(windows):
-      discard # xxx add tests
+      doAssertRaises(ValueError): discard "\"".parseCmdLine
+      doAssertRaises(ValueError): discard "  \"  ".parseCmdLine
+      doAssertRaises(ValueError): discard "  \'  ".parseCmdLine
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -708,9 +708,6 @@ block: # isAdmin
   # In Azure on POSIX tests run as a normal user
   if isAzure and defined(posix): doAssert not isAdmin()
 
-  # import std/strutils
-  # from std/sequtils import toSeq
-  # from std/os import commandLineParams, quoteShellCommand, parseCmdLine
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
   block: # parseCmdLine, bug #14343

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -723,6 +723,10 @@ template main =
     let a4 = a3.quoteShell
     let b4 = a4.parseCmdLine
     doAssert b4 == @[a3]
+    
+    doAssert "".parseCmdLine == @[]
+    doAssert " \t\t   \t".parseCmdLine == @[]
+    doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -711,10 +711,18 @@ block: # isAdmin
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
   block: # parseCmdLine, bug #14343
-    let s = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
-    let s2 = s.quoteShellCommand
-    let s3 = s2.parseCmdLine
-    doAssert s3 == s, $(s, s3, s2)
+    let a = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
+    let a2 = a.quoteShellCommand
+    let b2 = a2.parseCmdLine
+    doAssert b2 == a, $(a, a2, b2)
+
+    let a3 = a2.quoteShell
+    let b3 = a3.parseCmdLine
+    doAssert b3 == @[a2]
+
+    let a4 = a3.quoteShell
+    let b4 = a4.parseCmdLine
+    doAssert b4 == @[a3]
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -776,11 +776,11 @@ template main =
       chk "b\nc", @["b", "c"]
       chk "b\\\nc", @["b\nc"]
 
-      when false: # xxx dollar, {, } in regular section: left for future work
-        chk "bb$cc dd", @["bb", "$", "cc", "dd"]
-        chk "bb${cc}dd", @["bb", "$", "{", "cc", "}", "dd"]
-        chk "bb\\${cc}dd", @["bb$", "{", "cc", "}", "dd"]
-        chk "bb\\$cc dd", @["bb$cc", "dd"]
+      # dollar, {, } in regular section: left for future work
+      chk "bb$cc dd", @["bb", "$", "cc", "dd"]
+      chk "bb${cc}dd", @["bb", "$", "{", "cc", "}", "dd"]
+      chk "bb\\${cc}dd", @["bb$", "{", "cc", "}", "dd"]
+      chk "bb\\$cc dd", @["bb$cc", "dd"]
 
       # invalid inputs
       doAssertRaises(ValueError): discard """\""".parseShellCommand

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -714,19 +714,22 @@ template main =
     let a = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
     let a2 = a.quoteShellCommand
     let b2 = a2.parseCmdLine
-    doAssert b2 == a, $(a, a2, b2)
+    when defined(posix):
+      doAssert b2 == a, $(a, a2, b2)
 
-    let a3 = a2.quoteShell
-    let b3 = a3.parseCmdLine
-    doAssert b3 == @[a2]
+      let a3 = a2.quoteShell
+      let b3 = a3.parseCmdLine
+      doAssert b3 == @[a2]
 
-    let a4 = a3.quoteShell
-    let b4 = a4.parseCmdLine
-    doAssert b4 == @[a3]
-    
-    doAssert "".parseCmdLine == @[]
-    doAssert " \t\t   \t".parseCmdLine == @[]
-    doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
+      let a4 = a3.quoteShell
+      let b4 = a4.parseCmdLine
+      doAssert b4 == @[a3]
+      
+      doAssert "".parseCmdLine == @[]
+      doAssert " \t\t   \t".parseCmdLine == @[]
+      doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
+    elif defined(windows):
+      discard # xxx add tests
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -731,6 +731,15 @@ template main =
     doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
     doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
     when defined(posix):
+      doAssert """ ab\"cd  """.parseCmdLine == @["ab\"cd"]
+      doAssert """ ab\'cd  """.parseCmdLine == @["ab'cd"]
+      doAssert """ ab\\cd  """.parseCmdLine == @["ab\\cd"]
+      doAssert """ ab\ncd  """.parseCmdLine == @["abncd"]
+      doAssert """ " ab\"cd " def  """.parseCmdLine == @[" ab\"cd ", "def"]
+      doAssert """  \ \ ab\ cd\ ef\  \ gh\   """.parseCmdLine == @["  ab cd ef ", " gh "]
+
+      doAssertRaises(ValueError): discard """\""".parseCmdLine
+      doAssertRaises(ValueError): discard """abc\""".parseCmdLine
       doAssertRaises(ValueError): discard "\"".parseCmdLine
       doAssertRaises(ValueError): discard "  \"  ".parseCmdLine
       doAssertRaises(ValueError): discard "  \'  ".parseCmdLine

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -776,10 +776,10 @@ template main =
       chk "b\nc", @["b", "c"]
       chk "b\\\nc", @["b\nc"]
 
-      # dollar, {, } in regular section: left for future work
-      chk "bb$cc dd", @["bb", "$", "cc", "dd"]
-      chk "bb${cc}dd", @["bb", "$", "{", "cc", "}", "dd"]
-      chk "bb\\${cc}dd", @["bb$", "{", "cc", "}", "dd"]
+      # edge case: dollar, {, } in regular section:
+      chk "bb$cc dd", @["bb$cc", "dd"]
+      chk "bb${cc}dd", @["bb${cc}dd"]
+      chk "bb\\${cc}dd", @["bb${cc}dd"]
       chk "bb\\$cc dd", @["bb$cc", "dd"]
 
       # invalid inputs

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -711,10 +711,12 @@ block: # isAdmin
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
   block: # parseCmdLine, bug #14343
-    let s = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'"]
+    let s = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
     let s2 = s.quoteShellCommand
+    echo s2
     let s3 = s2.parseCmdLine
     doAssert s3 == s, $(s, s3, s2)
+    echo s3
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -713,10 +713,8 @@ template main =
   block: # parseCmdLine, bug #14343
     let s = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
     let s2 = s.quoteShellCommand
-    echo s2
     let s3 = s2.parseCmdLine
     doAssert s3 == s, $(s, s3, s2)
-    echo s3
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -711,6 +711,9 @@ block: # isAdmin
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
   block: # parseCmdLine, bug #14343
+    doAssertRaises(ValueError): discard "\"".parseCmdLine
+    doAssertRaises(ValueError): discard "  \"  ".parseCmdLine
+    doAssertRaises(ValueError): discard "  \'  ".parseCmdLine
     let a = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\\", "\n\a\b\t\0abc", " ", "  a   \\", " '   ' '", """  ' " \ '' "" """]
     let a2 = a.quoteShellCommand
     let b2 = a2.parseCmdLine
@@ -727,6 +730,7 @@ template main =
       
       doAssert "".parseCmdLine == @[]
       doAssert " \t\t   \t".parseCmdLine == @[]
+      doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
       doAssert " \t  abc   \t def  \t\t  ".parseCmdLine == @["abc", "def"]
     elif defined(windows):
       discard # xxx add tests

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -711,9 +711,8 @@ block: # isAdmin
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
   block: # parseShellCommand, bug #14343
-    var a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
-    when defined(posix):
-      a = a & @["\\", "  a   \\"]
+    var a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "",
+      "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """, "\\", "  a   \\"]
     let a2 = a.quoteShellCommand
     let b2 = a2.parseShellCommand
     doAssert b2 == a, $(a, a2, b2)

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -707,3 +707,17 @@ block: # isAdmin
   if isAzure and defined(windows): doAssert isAdmin()
   # In Azure on POSIX tests run as a normal user
   if isAzure and defined(posix): doAssert not isAdmin()
+
+  # import std/strutils
+  # from std/sequtils import toSeq
+  # from std/os import commandLineParams, quoteShellCommand, parseCmdLine
+template main =
+  # xxx move all tests under here so they get tested in VM, for ones which can
+  block: # parseCmdLine, bug #14343
+    let s = ["foo", "ba'r", "b\"az", "", "'", "''", "\"\'"]
+    let s2 = s.quoteShellCommand
+    let s3 = s2.parseCmdLine
+    doAssert s3 == s, $(s, s3, s2)
+
+static: main()
+main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -710,26 +710,26 @@ block: # isAdmin
 
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
-  block: # parseCmdLine, bug #14343
+  block: # parseShellCommand, bug #14343
     var a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "", "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """]
     when defined(posix):
       a = a & @["\\", "  a   \\"]
     let a2 = a.quoteShellCommand
-    let b2 = a2.parseCmdLine
+    let b2 = a2.parseShellCommand
     doAssert b2 == a, $(a, a2, b2)
 
     let a3 = a2.quoteShell
-    let b3 = a3.parseCmdLine
+    let b3 = a3.parseShellCommand
     doAssert b3 == @[a2]
 
     let a4 = a3.quoteShell
-    let b4 = a4.parseCmdLine
+    let b4 = a4.parseShellCommand
     doAssert b4 == @[a3]
 
     proc chk(a: string, b: seq[string]) =
-      let b2 = parseCmdLine(a)
+      let b2 = parseShellCommand(a)
       doAssert b2 == b, $(a, b, b2)
-    
+
     chk "", seq[string].default
     chk " \t\t   \t", seq[string].default
     chk " \t  abc   \t def  \t\t  ", @["abc", "def"]
@@ -783,12 +783,12 @@ template main =
         chk "bb\\$cc dd", @["bb$cc", "dd"]
 
       # invalid inputs
-      doAssertRaises(ValueError): discard """\""".parseCmdLine
-      doAssertRaises(ValueError): discard """abc\""".parseCmdLine
-      doAssertRaises(ValueError): discard "\"".parseCmdLine
-      doAssertRaises(ValueError): discard "  \"  ".parseCmdLine
-      doAssertRaises(ValueError): discard "  \'  ".parseCmdLine
-      doAssertRaises(ValueError): discard "aa'bb\\'cc'dd".parseCmdLine # `'` cannot be escaped within single quotes
+      doAssertRaises(ValueError): discard """\""".parseShellCommand
+      doAssertRaises(ValueError): discard """abc\""".parseShellCommand
+      doAssertRaises(ValueError): discard "\"".parseShellCommand
+      doAssertRaises(ValueError): discard "  \"  ".parseShellCommand
+      doAssertRaises(ValueError): discard "  \'  ".parseShellCommand
+      doAssertRaises(ValueError): discard "aa'bb\\'cc'dd".parseShellCommand # `'` cannot be escaped within single quotes
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -710,23 +710,23 @@ block: # isAdmin
 
 template main =
   # xxx move all tests under here so they get tested in VM, for ones which can
-  block: # parseShellCommand, bug #14343
+  block: # splitShellCmd, bug #14343
     var a = @["foo", "ba'r", "b\"az", "", "'", "''", "\"\'", "", "",
       "\n\a\b\t\0abc", " ", " '   ' '", """  ' " \ '' "" """, "\\", "  a   \\"]
     let a2 = a.quoteShellCommand
-    let b2 = a2.parseShellCommand
+    let b2 = a2.splitShellCmd
     doAssert b2 == a, $(a, a2, b2)
 
     let a3 = a2.quoteShell
-    let b3 = a3.parseShellCommand
+    let b3 = a3.splitShellCmd
     doAssert b3 == @[a2]
 
     let a4 = a3.quoteShell
-    let b4 = a4.parseShellCommand
+    let b4 = a4.splitShellCmd
     doAssert b4 == @[a3]
 
     proc chk(a: string, b: seq[string]) =
-      let b2 = parseShellCommand(a)
+      let b2 = splitShellCmd(a)
       doAssert b2 == b, $(a, b, b2)
 
     chk "", seq[string].default
@@ -782,12 +782,12 @@ template main =
       chk "bb\\$cc dd", @["bb$cc", "dd"]
 
       # invalid inputs
-      doAssertRaises(ValueError): discard """\""".parseShellCommand
-      doAssertRaises(ValueError): discard """abc\""".parseShellCommand
-      doAssertRaises(ValueError): discard "\"".parseShellCommand
-      doAssertRaises(ValueError): discard "  \"  ".parseShellCommand
-      doAssertRaises(ValueError): discard "  \'  ".parseShellCommand
-      doAssertRaises(ValueError): discard "aa'bb\\'cc'dd".parseShellCommand # `'` cannot be escaped within single quotes
+      doAssertRaises(ValueError): discard """\""".splitShellCmd
+      doAssertRaises(ValueError): discard """abc\""".splitShellCmd
+      doAssertRaises(ValueError): discard "\"".splitShellCmd
+      doAssertRaises(ValueError): discard "  \"  ".splitShellCmd
+      doAssertRaises(ValueError): discard "  \'  ".splitShellCmd
+      doAssertRaises(ValueError): discard "aa'bb\\'cc'dd".splitShellCmd # `'` cannot be escaped within single quotes
 
 static: main()
 main()

--- a/tests/stdlib/tos.nim
+++ b/tests/stdlib/tos.nim
@@ -726,7 +726,7 @@ template main =
     let b4 = a4.parseCmdLine
     doAssert b4 == @[a3]
 
-    template chk(a: string, b: seq[string]) =
+    proc chk(a: string, b: seq[string]) =
       let b2 = parseCmdLine(a)
       doAssert b2 == b, $(a, b, b2)
     
@@ -734,8 +734,8 @@ template main =
     chk " \t\t   \t", seq[string].default
     chk " \t  abc   \t def  \t\t  ", @["abc", "def"]
     chk " \t  abc   \t def  \t\t  ", @["abc", "def"]
-    chk "\n\n  aa\nbb\n \t \ncc \n\n  ", @["aa", "bb", "cc"]
     when defined(posix):
+      chk "\n\n  aa\nbb\n \t \ncc \n\n  ", @["aa", "bb", "cc"]
       chk "aa\nbb\\\ncc", @["aa", "bb\ncc"]
       chk """ ab\"cd  """, @["ab\"cd"]
       chk """ ab\'cd  """, @["ab'cd"]
@@ -751,6 +751,11 @@ template main =
       chk "aa\"bb\\\\\\cc\"dd3", @["aabb\\\\ccdd3"]
       chk "aa\"bb\ncc\"dd4", @["aabb\nccdd4"]
       chk "aa\"bb\\\ncc\"dd5", @["aabb\\\nccdd5"]
+      # $
+      chk "aa\"bb$xcc\"dd6", @["aabb$xccdd6"]
+      chk "aa\"bb${x}cc\"dd6", @["aabb${x}ccdd6"]
+      chk "aa\"bb\\$xcc\"dd6", @["aabb\\$xccdd6"]
+      chk "aa\"bb\\${x}cc\"dd6", @["aabb\\${x}ccdd6"]
 
       # BackSlash inside single quotes, behavior does not depend on character following it
       chk "aa'bb\\cc'dd1", @["aabb\\ccdd1"]
@@ -758,6 +763,11 @@ template main =
       chk "aa'bb\\\\\\cc'dd1", @["aabb\\\\\\ccdd1"]
       chk "aa'bb\ncc'dd1", @["aabb\nccdd1"]
       chk "aa'bb\\\ncc'dd1", @["aabb\\\nccdd1"]
+      # $
+      chk "aa'bb$xcc'dd6", @["aabb$xccdd6"]
+      chk "aa'bb${x}cc'dd6", @["aabb${x}ccdd6"]
+      chk "aa'bb\\$xcc'dd6", @["aabb\\$xccdd6"]
+      chk "aa'bb\\${x}cc'dd6", @["aabb\\${x}ccdd6"]
 
       # BackSlash inside regular section
       chk "b\\c", @["bc"]
@@ -765,6 +775,12 @@ template main =
       chk "b\\\\\\c", @["b\\c"]
       chk "b\nc", @["b", "c"]
       chk "b\\\nc", @["b\nc"]
+
+      when false: # xxx dollar, {, } in regular section: left for future work
+        chk "bb$cc dd", @["bb", "$", "cc", "dd"]
+        chk "bb${cc}dd", @["bb", "$", "{", "cc", "}", "dd"]
+        chk "bb\\${cc}dd", @["bb$", "{", "cc", "}", "dd"]
+        chk "bb\\$cc dd", @["bb$cc", "dd"]
 
       # invalid inputs
       doAssertRaises(ValueError): discard """\""".parseCmdLine


### PR DESCRIPTION
fix #14343, parseCmdLine

## backward compatibility
* `parseCmdLine` now returns correct results on posix and is such that:
`parseCmdLine(quoteShellCommand(a)) == a`
* `parseCmdLine` now raises on posix for invalid inputs (e.g. quotes not properly closed).

## future work
- [ ] expose `iterator shlex`
- [ ] add tests for windows and consider whether  `CommandLineToArgvW` should be used there
## links
* https://docs.microsoft.com/en-us/cpp/cpp/main-function-command-line-args?redirectedfrom=MSDN&view=msvc-160