### PR TITLE
fix #18620

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -524,10 +524,7 @@ proc getStackTrace(e: ref Exception): string =
 proc getStackTraceEntries*(e: ref Exception): seq[StackTraceEntry] =
   ## Returns the attached stack trace to the exception `e` as
   ## a `seq`. This is not yet available for the JS backend.
-  when not defined(nimSeqsV2):
-    shallowCopy(result, e.trace)
-  else:
-    result = move(e.trace)
+  shallowCopy(result, e.trace)
 
 proc getStackTraceEntries*(): seq[StackTraceEntry] =
   ## Returns the stack trace entries for the current stack trace.

--- a/tests/exception/t18620.nim
+++ b/tests/exception/t18620.nim
@@ -1,0 +1,17 @@
+discard """
+  matrix: "--gc:arc; --gc:refc"
+"""
+
+proc hello() =
+  raise newException(ValueError, "You are wrong")
+
+var flag = false
+
+try:
+  hello()
+except ValueError as e:
+  flag = true
+  doAssert len(getStackTraceEntries(e)) > 0
+  doAssert len(getStackTraceEntries(e)) > 0
+
+doAssert flag


### PR DESCRIPTION
close #18620

IMO, `e.trace` shouldn't be moved. Maybe I'm missing something.

If the `e.trace` is cleared as long as `getStackTraceEntries` is called, we can't trace the exception properly. For instance, we cannot decide whether the current error is re-raised. 
```
      if e.trace.len == 0:
        rawWriteStackTrace(e.trace)
      else:
        e.trace.add reraisedFrom(reraisedFromBegin)
        auxWriteStackTraceWithOverride(e.trace)
        e.trace.add reraisedFrom(reraisedFromEnd)
```


The stack trace with `nim c -r --lib:lib --gc:arc test3.nim`

```nim
firstTrampoline
async1
async2
async3
async4
C:\Users\blue\Documents\GitHub\Nim\test3.nim(27) test3
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391) runOnce
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206) processPendingCallbacks
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28) async4NimAsyncContinue
C:\Users\blue\Documents\GitHub\Nim\test3.nim(6) async4Iter
[[reraised from:
C:\Users\blue\Documents\GitHub\Nim\test3.nim(27) test3
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391) runOnce
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206) processPendingCallbacks
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28) async3NimAsyncContinue
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131) async3Iter
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389) read
]]
[[reraised from:
C:\Users\blue\Documents\GitHub\Nim\test3.nim(27) test3
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391) runOnce
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206) processPendingCallbacks
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28) async2NimAsyncContinue
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131) async2Iter
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389) read
]]
[[reraised from:
C:\Users\blue\Documents\GitHub\Nim\test3.nim(27) test3
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391) runOnce
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206) processPendingCallbacks
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28) async1NimAsyncContinue
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131) async1Iter
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389) read
]]
[[reraised from:
C:\Users\blue\Documents\GitHub\Nim\test3.nim(27) test3
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391) runOnce
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206) processPendingCallbacks
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28) firstTrampolineNimAsyncContinue
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131) firstTrampolineIter
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389) read
]]
[[reraised from:
C:\Users\blue\Documents\GitHub\Nim\test3.nim(27) test3
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1935) waitFor
C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389) read
]]
Error: unhandled exception: Fooo
Async traceback:
  C:\Users\blue\Documents\GitHub\Nim\test3.nim(27)                    test3
  C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
  C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
  C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391)  runOnce
  C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206)  processPendingCallbacks
  C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28)      async4NimAsyncContinue
  C:\Users\blue\Documents\GitHub\Nim\test3.nim(6)                     async4Iter
  #[
    C:\Users\blue\Documents\GitHub\Nim\test3.nim(27)                    test3
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391)  runOnce
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206)  processPendingCallbacks
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28)      async3NimAsyncContinue
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131)     async3Iter
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389)   read
  ]#
  #[
    C:\Users\blue\Documents\GitHub\Nim\test3.nim(27)                    test3
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391)  runOnce
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206)  processPendingCallbacks
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28)      async2NimAsyncContinue
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131)     async2Iter
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389)   read
  ]#
  #[
    C:\Users\blue\Documents\GitHub\Nim\test3.nim(27)                    test3
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391)  runOnce
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206)  processPendingCallbacks
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28)      async1NimAsyncContinue
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131)     async1Iter
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389)   read
  ]#
  #[
    C:\Users\blue\Documents\GitHub\Nim\test3.nim(27)                    test3
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1933) waitFor
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(1625) poll
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(391)  runOnce
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncdispatch.nim(206)  processPendingCallbacks
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(28)      firstTrampolineNimAsyncContinue
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncmacro.nim(131)     firstTrampolineIter
    C:\Users\blue\Documents\GitHub\Nim\lib\pure\asyncfutures.nim(389)   read
  ]#
Exception message: Fooo
 [Exception]
```