### PR TITLE
make proc names consistent

### DIFF
--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1700,14 +1700,14 @@ proc semStaticType(c: PContext, childNode: PNode, prev: PType): PType =
   result.rawAddSon(base)
   result.flags.incl tfHasStatic
 
-proc semTypeof(c: PContext; n: PNode; prev: PType): PType =
+proc semTypeOf(c: PContext; n: PNode; prev: PType): PType =
   openScope(c)
   let t = semExprWithType(c, n, {efInTypeof})
   closeScope(c)
   fixupTypeOf(c, prev, t)
   result = t.typ
 
-proc semTypeof2(c: PContext; n: PNode; prev: PType): PType =
+proc semTypeOf2(c: PContext; n: PNode; prev: PType): PType =
   openScope(c)
   var m = BiggestInt 1 # typeOfIter
   if n.len == 3:
@@ -1731,7 +1731,7 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
   of nkTypeOfExpr:
     # for ``typeof(countup(1,3))``, see ``tests/ttoseq``.
     checkSonsLen(n, 1, c.config)
-    result = semTypeof(c, n[0], prev)
+    result = semTypeOf(c, n[0], prev)
     if result.kind == tyTypeDesc: result.flags.incl tfExplicit
   of nkPar:
     if n.len == 1: result = semTypeNode(c, n[0], prev)
@@ -1833,9 +1833,9 @@ proc semTypeNode(c: PContext, n: PNode, prev: PType): PType =
         result = semAnyRef(c, n, tyRef, prev)
       elif op.id == ord(wType):
         checkSonsLen(n, 2, c.config)
-        result = semTypeof(c, n[1], prev)
+        result = semTypeOf(c, n[1], prev)
       elif op.s == "typeof" and n[0].kind == nkSym and n[0].sym.magic == mTypeOf:
-        result = semTypeof2(c, n, prev)
+        result = semTypeOf2(c, n, prev)
       elif op.s == "owned" and optOwnedRefs notin c.config.globalOptions and n.len == 2:
         result = semTypeExpr(c, n[1], prev)
       else:

--- a/tests/arc/tasyncawait.nim
+++ b/tests/arc/tasyncawait.nim
@@ -40,7 +40,7 @@ proc readMessages(client: AsyncFD) {.async.} =
       clientCount.inc
       break
     else:
-      if line.startswith("Message "):
+      if line.startsWith("Message "):
         msgCount.inc
       else:
         doAssert false

--- a/tests/async/tasyncawait.nim
+++ b/tests/async/tasyncawait.nim
@@ -34,7 +34,7 @@ proc readMessages(client: AsyncFD) {.async.} =
       clientCount.inc
       break
     else:
-      if line.startswith("Message "):
+      if line.startsWith("Message "):
         msgCount.inc
       else:
         doAssert false

--- a/tests/async/tasyncnetudp.nim
+++ b/tests/async/tasyncnetudp.nim
@@ -59,7 +59,7 @@ proc readMessages(server: AsyncSocket) {.async.} =
   while i < maxResponses:
     let (data, fromIp, fromPort) = await recvFrom(server, 16384)
 
-    if data.startswith("Message ") and fromIp == "127.0.0.1":
+    if data.startsWith("Message ") and fromIp == "127.0.0.1":
       await sendTo(server, fromIp, fromPort, data)
 
       inc(msgCount)

--- a/tests/async/tasyncssl.nim
+++ b/tests/async/tasyncssl.nim
@@ -36,7 +36,7 @@ when defined(ssl):
         inc(clientCount)
         break
       else:
-        if line.startswith("Message "):
+        if line.startsWith("Message "):
           inc(msgCount)
         else:
           doAssert false

--- a/tests/async/tnewasyncudp.nim
+++ b/tests/async/tnewasyncudp.nim
@@ -81,7 +81,7 @@ proc readMessages(server: AsyncFD) {.async.} =
                                   addr(slen))
     size = 0
     var grammString = $cstring(addr buffer)
-    if grammString.startswith("Message ") and
+    if grammString.startsWith("Message ") and
        saddr.sin_addr.s_addr == nativesockets.ntohl(INADDR_LOOPBACK.uint32):
       await sendTo(server, addr grammString[0], len(grammString),
                    cast[ptr SockAddr](addr saddr), slen)

--- a/tests/async/twinasyncrw.nim
+++ b/tests/async/twinasyncrw.nim
@@ -220,7 +220,7 @@ when defined(windows):
         clientCount.inc
         break
       else:
-        if line.startswith("Message "):
+        if line.startsWith("Message "):
           msgCount.inc
         else:
           doAssert false

--- a/tools/atlas/osutils.nim
+++ b/tools/atlas/osutils.nim
@@ -17,7 +17,7 @@ proc cloneUrl*(url, dest: string; cloneUsingHttps: bool): string =
   # github + https + trailing url slash causes a
   # checkout/ls-remote to fail with Repository not found
   var isGithub = false
-  if modUrl.contains("github.com") and modUrl.endswith("/"):
+  if modUrl.contains("github.com") and modUrl.endsWith("/"):
     modUrl = modUrl[0 .. ^2]
     isGithub = true
 

--- a/tools/trimcc.nim
+++ b/tools/trimcc.nim
@@ -31,7 +31,7 @@ proc processIncludes(dir: string, whitelist: StringTableRef) =
       if ('.' notin name and "include" in path) or ("c++" in path):
         let n = whitelist.getOrDefault(name)
         if n != "processed": whitelist[name] = "found"
-      if name.endswith(".h"):
+      if name.endsWith(".h"):
         let n = whitelist.getOrDefault(name)
         if n == "found": includes(path, name, whitelist)
     of pcDir: processIncludes(path, whitelist)


### PR DESCRIPTION
- `startswith` => `startsWith`; `endswith` => `endsWith`


- I also rename `semTypeof` to `semTypeOf`,  `semTypeof2` to `semTypeOf2`
Because there is already a `semTypeOf` proc in `semmagic.nim`, unifying the case style makes search a bit easier.
Namely(in semmagic.nim): `proc semTypeOf(c: PContext; n: PNode): PNode =`
```nim
  of mTypeOf:
    result = semTypeOf(c, n)
  of mSizeOf:
    result = foldSizeOf(c.config, n, n)
  of mAlignOf:
    result = foldAlignOf(c.config, n, n)
  of mOffsetOf:
    result = foldOffsetOf(c.config, n, n)
  of mArrGet:
    result = semArrGet(c, n, flags)
  of mArrPut:
    result = semArrPut(c, n, flags)
```