### PR TITLE
sigmatch: support optional params with last block arg(s)

### DIFF
--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -54,4 +54,3 @@ proc isCompilerDebug*(): bool =
       {.undef(nimCompilerDebug).}
       echo 'x'
   conf0.isDefined("nimCompilerDebug")
-include timn/exp/nim_compiler_debugutils

--- a/compiler/debugutils.nim
+++ b/compiler/debugutils.nim
@@ -54,3 +54,4 @@ proc isCompilerDebug*(): bool =
       {.undef(nimCompilerDebug).}
       echo 'x'
   conf0.isDefined("nimCompilerDebug")
+include timn/exp/nim_compiler_debugutils

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2346,6 +2346,22 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
     formal = if formalLen > 1: m.callee.n[1].sym else: nil # current routine parameter
     container: PNode = nil # constructed container
 
+  # for i in 0..<n.len:
+  #   dbgIf n[i].kind, n[i], i
+  # if isCompilerDebug():
+  #   dbgIf m.callee.n[^1], m.callee.n[^1]
+  #   debug2 n[^1]
+  #   debug2 m.callee.n[^1]
+  #   debug2 m.callee.n[^1].sym
+  #   debug2 m.callee.n[^1].sym.ast
+  #   debug2 m.callee.n
+  #   debug2 m.callee
+
+  var forceLastBlockMatch = false
+  if nfBlockArg in n[^1].flags:
+    if m.callee.n[^1].sym.ast == nil:
+      forceLastBlockMatch = true
+  dbgIf forceLastBlockMatch
   while a < n.len:
     c.openShadowScope
 
@@ -2441,6 +2457,8 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if m.callee.n[f].kind != nkSym:
           internalError(c.config, n[a].info, "matches")
           noMatch()
+        if forceLastBlockMatch and a == n.len - 1:
+          f = m.callee.n.len - 1
         formal = m.callee.n[f].sym
         m.firstMismatch.kind = kTypeMismatch
         if containsOrIncl(marker, formal.position) and container.isNil:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2348,7 +2348,8 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
 
   var forceLastBlockMatch = false
   if n[^1].kind == nkStmtList: # this wouldn't work inside templates: `if nfBlockArg in n[^1].flags`
-    if m.callee.n[^1].sym.ast == nil:
+    let formalLast = m.callee.n[^1]
+    if formalLast.kind == nkSym and formalLast.sym.ast == nil:
       forceLastBlockMatch = true
   while a < n.len:
     c.openShadowScope

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2346,23 +2346,10 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
     formal = if formalLen > 1: m.callee.n[1].sym else: nil # current routine parameter
     container: PNode = nil # constructed container
 
-  # for i in 0..<n.len:
-  #   dbgIf n[i].kind, n[i], i
-  # if isCompilerDebug():
-  #   dbgIf m.callee.n[^1], m.callee.n[^1]
-  #   debug2 n[^1]
-  #   debug2 m.callee.n[^1]
-  #   debug2 m.callee.n[^1].sym
-  #   debug2 m.callee.n[^1].sym.ast
-  #   debug2 m.callee.n
-  #   debug2 m.callee
-
   var forceLastBlockMatch = false
-  # dbgIf n, n[^1].flags, n[^1], m.callee.n[^1].sym.ast, m.callee.n[^1].sym, m.callee.n[^1].sym
   if n[^1].kind == nkStmtList: # this wouldn't work inside templates: `if nfBlockArg in n[^1].flags`
     if m.callee.n[^1].sym.ast == nil:
       forceLastBlockMatch = true
-  dbgIf forceLastBlockMatch
   while a < n.len:
     c.openShadowScope
 
@@ -2458,12 +2445,9 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if m.callee.n[f].kind != nkSym:
           internalError(c.config, n[a].info, "matches")
           noMatch()
-        dbgIf forceLastBlockMatch, a, n.len, n, m.callee.n.len, m.callee.n
         if forceLastBlockMatch and a == n.len - 1:
           f = m.callee.n.len - 1
-          dbgIf f
         formal = m.callee.n[f].sym
-        dbgIf formal
         m.firstMismatch.kind = kTypeMismatch
         if containsOrIncl(marker, formal.position) and container.isNil:
           m.firstMismatch.kind = kPositionalAlreadyGiven

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2450,10 +2450,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if m.callee.n[f].kind != nkSym:
           internalError(c.config, n[a].info, "matches")
           noMatch()
-        if a >= firstArgBlock:
-          let fOld = f
-          f = m.callee.n.len - (n.len - a)
-          assert f >= fOld
+        if a >= firstArgBlock: f = max(f, m.callee.n.len - (n.len - a))
         formal = m.callee.n[f].sym
         m.firstMismatch.kind = kTypeMismatch
         if containsOrIncl(marker, formal.position) and container.isNil:

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2358,7 +2358,8 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
   #   debug2 m.callee
 
   var forceLastBlockMatch = false
-  if nfBlockArg in n[^1].flags:
+  # dbgIf n, n[^1].flags, n[^1], m.callee.n[^1].sym.ast, m.callee.n[^1].sym, m.callee.n[^1].sym
+  if n[^1].kind == nkStmtList: # this wouldn't work inside templates: `if nfBlockArg in n[^1].flags`
     if m.callee.n[^1].sym.ast == nil:
       forceLastBlockMatch = true
   dbgIf forceLastBlockMatch
@@ -2457,9 +2458,12 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
         if m.callee.n[f].kind != nkSym:
           internalError(c.config, n[a].info, "matches")
           noMatch()
+        dbgIf forceLastBlockMatch, a, n.len, n, m.callee.n.len, m.callee.n
         if forceLastBlockMatch and a == n.len - 1:
           f = m.callee.n.len - 1
+          dbgIf f
         formal = m.callee.n[f].sym
+        dbgIf formal
         m.firstMismatch.kind = kTypeMismatch
         if containsOrIncl(marker, formal.position) and container.isNil:
           m.firstMismatch.kind = kPositionalAlreadyGiven

--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -2305,6 +2305,17 @@ proc incrIndexType(t: PType) =
 template isVarargsUntyped(x): untyped =
   x.kind == tyVarargs and x[0].kind == tyUntyped
 
+proc findFirstArgBlock(m: var TCandidate, n: PNode): int =
+  # see https://github.com/nim-lang/RFCs/issues/405
+  result = int.high
+  for a2 in countdown(n.len-1, 0):
+    # checking `nfBlockArg in n[a2].flags` wouldn't work inside templates
+    if n[a2].kind != nkStmtList: break
+    let formalLast = m.callee.n[m.callee.n.len - (n.len - a2)]
+    if formalLast.kind == nkSym and formalLast.sym.ast == nil:
+      result = a2
+    else: break
+
 proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var IntSet) =
 
   template noMatch() =
@@ -2345,16 +2356,7 @@ proc matchesAux(c: PContext, n, nOrig: PNode, m: var TCandidate, marker: var Int
     formalLen = m.callee.n.len
     formal = if formalLen > 1: m.callee.n[1].sym else: nil # current routine parameter
     container: PNode = nil # constructed container
-
-  var firstArgBlock = int.high # see https://github.com/nim-lang/RFCs/issues/405
-  for a2 in countdown(n.len-1, 0):
-    # checking `nfBlockArg in n[a2].flags` wouldn't work inside templates
-    if n[a2].kind != nkStmtList: break
-    let formalLast = m.callee.n[m.callee.n.len - (n.len - a2)]
-    if formalLast.kind == nkSym and formalLast.sym.ast == nil:
-      firstArgBlock = a2
-    else: break
-
+  let firstArgBlock = findFirstArgBlock(m, n)
   while a < n.len:
     c.openShadowScope
 

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -1,7 +1,7 @@
 # https://github.com/nim-lang/RFCs/issues/405
 
-# template main =
-proc main =
+template main =
+# proc main =
   block:
     template fn(a = 1, b = 2, body): auto = (a, b, astToStr(body))
     let a1 = fn(10, 20):

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -26,5 +26,38 @@ template main =
   doAssert compiles(fn5(1, 2, foo))
   doAssert not compiles(fn5(1, foo))
 
+  block:
+    # with an overload
+    var witness = 0
+    template fn6() = discard
+    template fn6(procname: string, body: untyped): untyped = witness.inc
+    fn6("abc"): discard
+    assert witness == 1
+
+  block:
+    # with overloads
+    var witness = 0
+    template fn6() = discard
+    template fn6(a: int) = discard
+    template fn6(procname: string, body: untyped): untyped = witness.inc
+    fn6("abc"): discard
+    assert witness == 1
+
+    template fn6(b = 1.5, body: untyped): untyped = witness.inc
+    fn6(1.3): discard
+    assert witness == 2
+
+  block:
+    var witness = 0
+    template fn6(a: int) = discard
+    template fn6(a: string) = discard
+    template fn6(ignore: string, b = 1.5, body: untyped): untyped = witness.inc
+    fn6(""):
+      foobar1
+      foobar2
+    doAssert witness == 1
+    fn6(""): discard
+    doAssert witness == 2
+
 static: main()
 main()

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -1,0 +1,38 @@
+# https://github.com/nim-lang/RFCs/issues/405
+
+# template main =
+proc main =
+  block:
+    template fn(a = 1, b = 2, body): auto = (a, b, astToStr(body))
+    let a1 = fn(10, 20):
+      foo
+    doAssert a1 == (10, 20, "\nfoo")
+
+    template fn2(a = 1, b = 2, body) = echo (a, b, astToStr(body))
+    fn2(a = 10): foo
+
+    # fn2(a = 10):
+    #   foo
+
+    # let a2 = fn(a = 10):
+    #   foo
+    # echo a2
+  #   fn(b = 20): foo
+
+  # block:
+  #   template fn(x: int, a = 1, b = 2, body) = echo (a, b, astToStr(body))
+  #   fn(3, 10, 20): # works
+  #     foo
+  #   {.define(nimCompilerDebug).}
+  #   fn(3, a = 10): foo
+  #   fn(3, b = 20): foo
+  #   fn(3, b = 20):
+  #     foo1
+  #     foo2
+
+  # block:
+  #   template fn(x: int, y: int, body) = echo (x, y, astToStr(body))
+  #   fn(3): foo
+
+static: main()
+main()

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -1,38 +1,30 @@
 # https://github.com/nim-lang/RFCs/issues/405
 
 template main =
-# proc main =
-  block:
-    template fn(a = 1, b = 2, body): auto = (a, b, astToStr(body))
-    let a1 = fn(10, 20):
-      foo
-    doAssert a1 == (10, 20, "\nfoo")
+  template fn1(a = 1, b = 2, body): auto = (a, b, astToStr(body))
+  let a1 = fn1(10, 20):
+    foo
+  doAssert a1 == (10, 20, "\nfoo")
 
-    template fn2(a = 1, b = 2, body) = echo (a, b, astToStr(body))
-    fn2(a = 10): foo
+  template fn2(a = 1, b = 2, body): auto = (a, b, astToStr(body))
+  let a2 = fn2(a = 10): foo
+  doAssert a2 == (10, 2, "\nfoo")
+  let a2b = fn2(b = 20): foo
+  doAssert a2b == (1, 20, "\nfoo")
 
-    # fn2(a = 10):
-    #   foo
+  template fn3(x: int, a = 1, b = 2, body): auto = (a, b, astToStr(body))
+  let a3 = fn3(3, 10, 20): foo
+  doAssert a3 == (10, 20, "\nfoo")
+  let a3b = fn3(3, a = 10): foo
+  doAssert a3b == (10, 2, "\nfoo")
 
-    # let a2 = fn(a = 10):
-    #   foo
-    # echo a2
-  #   fn(b = 20): foo
+  template fn4(x: int, y: int, body): auto = (x, y, astToStr(body))
+  let a4 = fn4(1, 2): foo
+  doAssert a4 == (1, 2, "\nfoo")
 
-  # block:
-  #   template fn(x: int, a = 1, b = 2, body) = echo (a, b, astToStr(body))
-  #   fn(3, 10, 20): # works
-  #     foo
-  #   {.define(nimCompilerDebug).}
-  #   fn(3, a = 10): foo
-  #   fn(3, b = 20): foo
-  #   fn(3, b = 20):
-  #     foo1
-  #     foo2
-
-  # block:
-  #   template fn(x: int, y: int, body) = echo (x, y, astToStr(body))
-  #   fn(3): foo
+  template fn5(x = 1, y = 2, body: untyped = 3): auto = (x, y, astToStr(body))
+  doAssert compiles(fn5(1, 2, foo))
+  doAssert not compiles(fn5(1, foo))
 
 static: main()
 main()

--- a/tests/misc/trfc405.nim
+++ b/tests/misc/trfc405.nim
@@ -59,5 +59,23 @@ template main =
     fn6(""): discard
     doAssert witness == 2
 
+  block: # multi block args
+    template fn8(a = 1, b = 2, body1: untyped, body2: untyped): auto = (a, b, astToStr(body1), astToStr(body2))
+    let a1 = fn8():
+      foobar1
+      foobar2
+    do:
+      foobar3
+      foobar4
+    doAssert a1 == (1, 2, "\nfoobar1\nfoobar2", "\nfoobar3\nfoobar4")
+
+    let a2 = fn8(b = 20):
+      foobar1
+      foobar2
+    do:
+      foobar3
+      foobar4
+    doAssert a2 == (1, 20, "\nfoobar1\nfoobar2", "\nfoobar3\nfoobar4")
+
 static: main()
 main()


### PR DESCRIPTION
this PR solves a major pain point of optional params with last block arg(s)

fix https://github.com/nim-lang/RFCs/issues/405
fix https://github.com/nim-lang/Nim/issues/884
fix https://github.com/nim-lang/Nim/issues/14346

```nim
template fn(a = 1, b = 2, body) = discard
fn(1, 2): # already works
  bar
fn(a = 1): # now works
  bar
```

ditto with multiple block args via do:
```nim
template fn(a = 1, b = 2, body1, body2) = discard
fn(a = 1): # now works
  bar1
do:
  bar2
```

etc, see tests/misc/trfc405.nim
