### PR TITLE
locks and rlocks use destructors

### DIFF
--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -24,11 +24,11 @@ const useOrcArc = defined(gcArc) or defined(gcOrc)
 include "system/syslocks"
 
 type
-  Lock* = object
-    lock: SysLock ## Nim lock; whether this is re-entrant
+  Lock* = object  ## Nim lock; whether this is re-entrant
                   ## or not is unspecified!
-  Cond* = object
-    cond: SysCond ## Nim condition variable
+    lock: SysLock
+  Cond* = object  ## Nim condition variable
+    cond: SysCond
 
 {.push stackTrace: off.}
 

--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -44,6 +44,8 @@ proc initLock*(lock: var Lock) {.inline.} =
     initSysLock(lock.lock)
 
 when useOrcArc:
+  proc `=sink`*(x: var Lock, y: Lock) {.error.}
+
   proc `=copy`*(x: var Lock, y: Lock) {.error.}
 
   proc `=destroy`*(lock: var Lock) {.inline.} =
@@ -78,6 +80,8 @@ proc initCond*(cond: var Cond) {.inline.} =
 
 
 when useOrcArc:
+  proc `=sink`*(x: var Cond, y: Cond) {.error.}
+
   proc `=copy`*(x: var Cond, y: Cond) {.error.}
 
   proc `=destroy`*(cond: var Cond) {.inline.} =

--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -19,12 +19,16 @@ when not compileOption("threads") and not defined(nimdoc):
     {.error: "Locks requires --threads:on option.".}
 
 const insideRLocksModule = false
+const useOrcArc = defined(gcArc) or defined(gcOrc)
+
 include "system/syslocks"
 
 type
-  Lock* = SysLock ## Nim lock; whether this is re-entrant
+  Lock* = object
+    lock: SysLock ## Nim lock; whether this is re-entrant
                   ## or not is unspecified!
-  Cond* = SysCond ## Nim condition variable
+  Cond* = object
+    cond: SysCond ## Nim condition variable
 
 {.push stackTrace: off.}
 
@@ -36,47 +40,68 @@ proc `$`*(lock: Lock): string =
 proc initLock*(lock: var Lock) {.inline.} =
   ## Initializes the given lock.
   when not defined(js):
-    initSysLock(lock)
+    initSysLock(lock.lock)
 
-proc deinitLock*(lock: var Lock) {.inline.} =
-  ## Frees the resources associated with the lock.
-  deinitSys(lock)
+when useOrcArc:
+  proc `=copy`*(x: var Lock, y: Lock) {.error.}
+
+  proc `=destroy`*(lock: var Lock) {.inline.} =
+    deinitSys(lock.lock)
+
+  proc deinitLock*(lock: var Lock) {.inline, 
+        deprecated: "'deinitLock' is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for 'Lock'".} =
+    discard
+else:
+  proc deinitLock*(lock: var Lock) {.inline.} =
+    ## Frees the resources associated with the lock.
+    deinitSys(lock.lock)
 
 proc tryAcquire*(lock: var Lock): bool {.inline.} =
   ## Tries to acquire the given lock. Returns `true` on success.
-  result = tryAcquireSys(lock)
+  result = tryAcquireSys(lock.lock)
 
 proc acquire*(lock: var Lock) {.inline.} =
   ## Acquires the given lock.
   when not defined(js):
-    acquireSys(lock)
+    acquireSys(lock.lock)
 
 proc release*(lock: var Lock) {.inline.} =
   ## Releases the given lock.
   when not defined(js):
-    releaseSys(lock)
+    releaseSys(lock.lock)
 
 
 proc initCond*(cond: var Cond) {.inline.} =
   ## Initializes the given condition variable.
-  initSysCond(cond)
+  initSysCond(cond.cond)
 
-proc deinitCond*(cond: var Cond) {.inline.} =
-  ## Frees the resources associated with the condition variable.
-  deinitSysCond(cond)
+
+when useOrcArc:
+  proc `=copy`*(x: var Cond, y: Cond) {.error.}
+
+  proc `=destroy`*(cond: var Cond) {.inline.} =
+    deinitSysCond(cond.cond)
+
+  proc deinitCond*(cond: var Cond) {.inline, 
+        deprecated: "'deinitCond' is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for 'Cond'".} =
+    discard
+else:
+  proc deinitCond*(cond: var Cond) {.inline.} =
+    ## Frees the resources associated with the condition variable.
+    deinitSysCond(cond.cond)
 
 proc wait*(cond: var Cond, lock: var Lock) {.inline.} =
   ## Waits on the condition variable `cond`.
-  waitSysCond(cond, lock)
+  waitSysCond(cond.cond, lock.lock)
 
 proc signal*(cond: var Cond) {.inline.} =
   ## Sends a signal to the condition variable `cond`.
-  signalSysCond(cond)
+  signalSysCond(cond.cond)
 
 proc broadcast*(cond: var Cond) {.inline.} =
   ## Unblocks all threads currently blocked on the
   ## specified condition variable `cond`.
-  broadcastSysCond(cond)
+  broadcastSysCond(cond.cond)
 
 template withLock*(a: Lock, body: untyped) =
   ## Acquires the given lock, executes the statements in body and

--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -24,10 +24,11 @@ const useOrcArc = defined(gcArc) or defined(gcOrc)
 include "system/syslocks"
 
 type
-  Lock* = object  ## Nim lock; whether this is re-entrant
-                  ## or not is unspecified!
+  Lock* = object
+    ## Nim lock; whether this is re-entrant or not is unspecified!
     lock: SysLock
-  Cond* = object  ## Nim condition variable
+  Cond* = object
+    ## Nim condition variable
     cond: SysCond
 
 {.push stackTrace: off.}
@@ -49,7 +50,7 @@ when useOrcArc:
     deinitSys(lock.lock)
 
   proc deinitLock*(lock: var Lock) {.inline, 
-        deprecated: "'deinitLock' is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for 'Lock'".} =
+        deprecated: "`deinitLock` is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for `Lock`".} =
     discard
 else:
   proc deinitLock*(lock: var Lock) {.inline.} =
@@ -83,7 +84,7 @@ when useOrcArc:
     deinitSysCond(cond.cond)
 
   proc deinitCond*(cond: var Cond) {.inline, 
-        deprecated: "'deinitCond' is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for 'Cond'".} =
+        deprecated: "`deinitCond` is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for `Cond`".} =
     discard
 else:
   proc deinitCond*(cond: var Cond) {.inline.} =

--- a/lib/core/locks.nim
+++ b/lib/core/locks.nim
@@ -28,7 +28,7 @@ type
     ## Nim lock; whether this is re-entrant or not is unspecified!
     lock: SysLock
   Cond* = object
-    ## Nim condition variable
+    ## Nim condition variable.
     cond: SysCond
 
 {.push stackTrace: off.}
@@ -50,7 +50,7 @@ when useOrcArc:
     deinitSys(lock.lock)
 
   proc deinitLock*(lock: var Lock) {.inline, 
-        deprecated: "`deinitLock` is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for `Lock`".} =
+        deprecated: "`deinitLock` is not needed anymore in ARC/ORC (it is a no-op now); `=destroy` is already defined for `Lock`".} =
     discard
 else:
   proc deinitLock*(lock: var Lock) {.inline.} =
@@ -84,7 +84,7 @@ when useOrcArc:
     deinitSysCond(cond.cond)
 
   proc deinitCond*(cond: var Cond) {.inline, 
-        deprecated: "`deinitCond` is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for `Cond`".} =
+        deprecated: "`deinitCond` is not needed anymore in ARC/ORC (it is a no-op now); `=destroy` is already defined for `Cond`".} =
     discard
 else:
   proc deinitCond*(cond: var Cond) {.inline.} =

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -23,7 +23,7 @@ include "system/syslocks"
 
 type
   RLock* = object
-    ## Nim lock, re-entrant
+    ## Nim lock, re-entrant.
     lock: SysLock
 
 proc initRLock*(lock: var RLock) {.inline.} =
@@ -43,7 +43,7 @@ when useOrcArc:
     deinitSys(lock.lock)
 
   proc deinitRLock*(lock: var RLock) {.inline, 
-        deprecated: "`deinitRLock` is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for `RLock`".} =
+        deprecated: "`deinitRLock` is not needed anymore in ARC/ORC (it is a no-op now); `=destroy` is already defined for `RLock`".} =
     discard
 else:
   proc deinitRLock*(lock: var RLock) {.inline.} =

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -37,6 +37,8 @@ proc initRLock*(lock: var RLock) {.inline.} =
     initSysLock(lock.lock)
 
 when useOrcArc:
+  proc `=sink`*(x: var RLock, y: RLock) {.error.}
+
   proc `=copy`*(x: var RLock, y: RLock) {.error.}
 
   proc `=destroy`*(lock: var RLock) {.inline.} =

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -22,7 +22,8 @@ const useOrcArc = defined(gcArc) or defined(gcOrc)
 include "system/syslocks"
 
 type
-  RLock* = object ## Nim lock, re-entrant
+  RLock* = object
+    ## Nim lock, re-entrant
     lock: SysLock
 
 proc initRLock*(lock: var RLock) {.inline.} =
@@ -42,7 +43,7 @@ when useOrcArc:
     deinitSys(lock.lock)
 
   proc deinitRLock*(lock: var RLock) {.inline, 
-        deprecated: "'deinitRLock' is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for 'RLock'".} =
+        deprecated: "`deinitRLock` is not needed anymore in ARC/ORC(it is a no-op now); `=destroy` is already defined for `RLock`".} =
     discard
 else:
   proc deinitRLock*(lock: var RLock) {.inline.} =

--- a/lib/core/rlocks.nim
+++ b/lib/core/rlocks.nim
@@ -22,8 +22,8 @@ const useOrcArc = defined(gcArc) or defined(gcOrc)
 include "system/syslocks"
 
 type
-  RLock* = object
-    lock: SysLock ## Nim lock, re-entrant
+  RLock* = object ## Nim lock, re-entrant
+    lock: SysLock
 
 proc initRLock*(lock: var RLock) {.inline.} =
   ## Initializes the given lock.

--- a/tests/stdlib/treusetavr.nim
+++ b/tests/stdlib/treusetavr.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:refc"
+  matrix: "--gc:refc; --gc:arc"
   outputsub: "65"
 """
 

--- a/tests/stdlib/treusetvar.nim
+++ b/tests/stdlib/treusetvar.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--gc:refc; --gc:arc"
+  matrix: "--gc:refc --threads:on; --gc:arc --threads:on"
   outputsub: "65"
 """
 

--- a/tests/stdlib/trlocks.nim
+++ b/tests/stdlib/trlocks.nim
@@ -3,7 +3,7 @@ discard """
   # Disallow joining to ensure it can compile in isolation.
   # See #15584
   joinable: false
-  cmd: "nim $target --threads:on $options $file"
+  matrix: "--threads:on --gc:refc; --threads:on --gc:arc"
 """
 
 # bugfix #15584

--- a/tests/stdlib/trlocks.nim
+++ b/tests/stdlib/trlocks.nim
@@ -3,7 +3,7 @@ discard """
   # Disallow joining to ensure it can compile in isolation.
   # See #15584
   joinable: false
-  matrix: "--threads:on --gc:refc; --threads:on --gc:arc"
+  matrix: "--threads:on --gc:refc; --threads:on --gc:arc; --threads:on --gc:orc"
 """
 
 # bugfix #15584

--- a/tests/stdlib/tuserlocks.nim
+++ b/tests/stdlib/tuserlocks.nim
@@ -1,5 +1,5 @@
 discard """
-  matrix: "--threads:on"
+  matrix: "--threads:on --gc:refc; --threads:on --gc:arc"
 """
 
 import std/rlocks

--- a/tests/threads/treusetvar.nim
+++ b/tests/threads/treusetvar.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--gc:refc; --gc:arc"
   outputsub: "65"
 """
 


### PR DESCRIPTION
This PR wants to adding destructors for Lock/Rlock/Cond for ARC/ORC and does less harm. It turns `deinitLock`, `deinitRlock`, `deinitCond` into a no-op and deprecates them. Then it also adds destructors for these objects.

Same transition method could be applied to `Stream`, `File`, `socket` or so if it were fine. It should cause less harm and less breaking changes. Then we don't need to close `File`, `Stream` manually.