### PR TITLE
[superseded] Add optional `recursive` argument to `typetraits.distinctBase`

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -192,7 +192,7 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     var arg = operand.skipTypes({tyGenericInst})
     let rec =
       if traitCall.len >= 2:
-        operand2.intVal != 0
+        traitCall[2].intVal != 0
       else:
         true
     

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -190,9 +190,20 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
     result = newIntNodeT(toInt128(operand.len), traitCall, c.idgen, c.graph)
   of "distinctBase":
     var arg = operand.skipTypes({tyGenericInst})
-    while arg.kind == tyDistinct:
+    let rec =
+      if traitCall.len >= 2:
+        operand2.intVal != 0
+      else:
+        true
+    
+    if arg.kind == tyDistinct:
       arg = arg.base
       arg = arg.skipTypes(skippedTypes + {tyGenericInst})
+      if rec:
+        while arg.kind == tyDistinct:
+          arg = arg.base
+          arg = arg.skipTypes(skippedTypes + {tyGenericInst})
+    
     result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
   else:
     localError(c.config, traitCall.info, "unknown trait: " & s)

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -110,7 +110,7 @@ template pointerBase*[T](_: typedesc[ptr T | ref T]): typedesc =
     assert (var s = "abc"; s[0].addr).typeof.pointerBase is char
   T
 
-proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".} =
+proc distinctBase*(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".} =
   ## Returns the base type for distinct types, or the type itself otherwise.
   ##
   ## **See also:**
@@ -121,14 +121,14 @@ proc distinctBase*(T: typedesc): typedesc {.magic: "TypeTrait".} =
     doAssert distinctBase(int) is int
 
 since (1, 1):
-  template distinctBase*[T](a: T): untyped =
+  template distinctBase*[T](a: T, recursive: static bool = true): untyped =
     ## Overload of `distinctBase <#distinctBase,typedesc>`_ for values.
     runnableExamples:
       type MyInt = distinct int
       doAssert 12.MyInt.distinctBase == 12
       doAssert 12.distinctBase == 12
     when T is distinct:
-      distinctBase(typeof(a))(a)
+      distinctBase(typeof(a), recursive)(a)
     else: # avoids hint ConvFromXtoItselfNotNeeded
       a
 

--- a/lib/pure/typetraits.nim
+++ b/lib/pure/typetraits.nim
@@ -112,20 +112,27 @@ template pointerBase*[T](_: typedesc[ptr T | ref T]): typedesc =
 
 proc distinctBase*(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".} =
   ## Returns the base type for distinct types, or the type itself otherwise.
+  ## If `recursive` is false, only the immediate distinct base will be returned.
   ##
   ## **See also:**
-  ## * `distinctBase template <#distinctBase.t,T>`_
+  ## * `distinctBase template <#distinctBase.t,T,static[bool]>`_
   runnableExamples:
     type MyInt = distinct int
+    type MyOtherInt = distinct MyInt
     doAssert distinctBase(MyInt) is int
+    doAssert distinctBase(MyOtherInt) is int
+    doAssert distinctBase(MyOtherInt, false) is MyInt
     doAssert distinctBase(int) is int
 
 since (1, 1):
   template distinctBase*[T](a: T, recursive: static bool = true): untyped =
-    ## Overload of `distinctBase <#distinctBase,typedesc>`_ for values.
+    ## Overload of `distinctBase <#distinctBase,typedesc,static[bool]>`_ for values.
     runnableExamples:
       type MyInt = distinct int
+      type MyOtherInt = distinct MyInt
       doAssert 12.MyInt.distinctBase == 12
+      doAssert 12.MyOtherInt.distinctBase == 12
+      doAssert 12.MyOtherInt.distinctBase(false) == 12.MyInt
       doAssert 12.distinctBase == 12
     when T is distinct:
       distinctBase(typeof(a), recursive)(a)

--- a/lib/std/jsonutils.nim
+++ b/lib/std/jsonutils.nim
@@ -78,8 +78,8 @@ proc initToJsonOptions*(): ToJsonOptions =
   ## initializes `ToJsonOptions` with sane options.
   ToJsonOptions(enumMode: joptEnumOrd, jsonNodeMode: joptJsonNodeAsRef)
 
-proc distinctBase(T: typedesc): typedesc {.magic: "TypeTrait".}
-template distinctBase[T](a: T): untyped = distinctBase(typeof(a))(a)
+proc distinctBase(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".}
+template distinctBase[T](a: T, recursive: static bool = true): untyped = distinctBase(typeof(a), recursive)(a)
 
 macro getDiscriminants(a: typedesc): seq[string] =
   ## return the discriminant keys

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -1,7 +1,7 @@
 proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
   ## imported from typetraits
 
-proc distinctBase(T: typedesc): typedesc {.magic: "TypeTrait".}
+proc distinctBase(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".}
   ## imported from typetraits
 
 proc repr*(x: NimNode): string {.magic: "Repr", noSideEffect.}


### PR DESCRIPTION
Should be self-explanatory.

Example code:
```nim
import typetraits

type
    A = distinct int
    B = distinct A

echo B.distinctBase        #=> int
echo B.distinctBase(false) #=> A
```

This theoretically shouldn't break anything because `recursive` is true by default