### PR TITLE
fix a sqlite bug

### DIFF
--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -171,7 +171,7 @@ import sqlite3, macros
 import db_common
 export db_common
 
-import std/private/since
+import std/private/[since, dbutils]
 
 type
   DbConn* = PSqlite3  ## Encapsulates a database connection.
@@ -211,14 +211,7 @@ proc dbQuote*(s: string): string =
   add(result, '\'')
 
 proc dbFormat(formatstr: SqlQuery, args: varargs[string]): string =
-  result = ""
-  var a = 0
-  for c in items(string(formatstr)):
-    if c == '?':
-      add(result, dbQuote(args[a]))
-      inc(a)
-    else:
-      add(result, c)
+  dbFormatImpl(formatstr, dbQuote, args)
 
 proc prepare*(db: DbConn; q: string): SqlPrepared {.since: (1, 3).} =
   ## Creates a new `SqlPrepared` statement.
@@ -642,7 +635,7 @@ proc getValue*(db: DbConn,  stmtName: SqlPrepared): string
 
 proc tryInsertID*(db: DbConn, query: SqlQuery,
                   args: varargs[string, `$`]): int64
-                  {.tags: [WriteDbEffect], raises: [].} =
+                  {.tags: [WriteDbEffect].} =
   ## Executes the query (typically "INSERT") and returns the
   ## generated ID for the row or -1 in case of an error.
   ##
@@ -699,7 +692,7 @@ proc insertID*(db: DbConn, query: SqlQuery,
 
 proc tryInsert*(db: DbConn, query: SqlQuery, pkName: string,
                 args: varargs[string, `$`]): int64
-               {.tags: [WriteDbEffect], raises: [], since: (1, 3).} =
+               {.tags: [WriteDbEffect], since: (1, 3).} =
   ## same as tryInsertID
   tryInsertID(db, query, args)
 

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -635,7 +635,7 @@ proc getValue*(db: DbConn,  stmtName: SqlPrepared): string
 
 proc tryInsertID*(db: DbConn, query: SqlQuery,
                   args: varargs[string, `$`]): int64
-                  {.tags: [WriteDbEffect], raises: [].} =
+                  {.tags: [WriteDbEffect], raises: [DbError].} =
   ## Executes the query (typically "INSERT") and returns the
   ## generated ID for the row or -1 in case of an error.
   ##
@@ -692,7 +692,7 @@ proc insertID*(db: DbConn, query: SqlQuery,
 
 proc tryInsert*(db: DbConn, query: SqlQuery, pkName: string,
                 args: varargs[string, `$`]): int64
-               {.tags: [WriteDbEffect], raises: [DbError]], since: (1, 3).} =
+               {.tags: [WriteDbEffect], raises: [DbError], since: (1, 3).} =
   ## same as tryInsertID
   tryInsertID(db, query, args)
 

--- a/lib/impure/db_sqlite.nim
+++ b/lib/impure/db_sqlite.nim
@@ -635,7 +635,7 @@ proc getValue*(db: DbConn,  stmtName: SqlPrepared): string
 
 proc tryInsertID*(db: DbConn, query: SqlQuery,
                   args: varargs[string, `$`]): int64
-                  {.tags: [WriteDbEffect].} =
+                  {.tags: [WriteDbEffect], raises: [].} =
   ## Executes the query (typically "INSERT") and returns the
   ## generated ID for the row or -1 in case of an error.
   ##
@@ -692,7 +692,7 @@ proc insertID*(db: DbConn, query: SqlQuery,
 
 proc tryInsert*(db: DbConn, query: SqlQuery, pkName: string,
                 args: varargs[string, `$`]): int64
-               {.tags: [WriteDbEffect], since: (1, 3).} =
+               {.tags: [WriteDbEffect], raises: [DbError]], since: (1, 3).} =
   ## same as tryInsertID
   tryInsertID(db, query, args)
 

--- a/lib/std/private/dbutils.nim
+++ b/lib/std/private/dbutils.nim
@@ -1,0 +1,15 @@
+import db_common
+
+
+template dbFormatImpl*(formatstr: SqlQuery, dbQuote: proc (s: string): string, args: varargs[string]): string =
+  var res = ""
+  var a = 0
+  for c in items(string(formatstr)):
+    if c == '?':
+      if a == args.len:
+        dbError("""The number of parameter doesn't match that of "?" """)
+      add(res, dbQuote(args[a]))
+      inc(a)
+    else:
+      add(res, c)
+  res

--- a/lib/std/private/dbutils.nim
+++ b/lib/std/private/dbutils.nim
@@ -7,7 +7,7 @@ template dbFormatImpl*(formatstr: SqlQuery, dbQuote: proc (s: string): string, a
   for c in items(string(formatstr)):
     if c == '?':
       if a == args.len:
-        dbError("""The number of parameter doesn't match that of "?" """)
+        dbError("""The number of "?" given exceeds the number of parameters present in the query.""")
       add(res, dbQuote(args[a]))
       inc(a)
     else:

--- a/tests/stdlib/tsqlitebindatas.nim
+++ b/tests/stdlib/tsqlitebindatas.nim
@@ -48,3 +48,25 @@ block tsqlitebindatas: ## db_sqlite binary data
 
   db.close()
   doAssert tryRemoveFile(dbName)
+
+
+block:
+  block:
+    var db = db_sqlite.open("db.sqlite3", "", "", "")
+    try:
+      db.exec(sql("CREATE TABLE table1 (url TEXT, other_field INT);"))
+      db.exec(sql("REPLACE INTO table (url, another_field) VALUES (?, '123');"))
+    except DbError as e:
+      doAssert e.msg == "The number of parameter doesn't match that of \"?\" "
+    finally:
+      db.close()
+      removeFile("db.sqlite3")
+
+  block:
+    var db = db_sqlite.open("db.sqlite3", "", "", "")
+    try:
+      db.exec(sql("CREATE TABLE table1 (url TEXT, other_field INT);"))
+      db.exec(sql("INSERT INTO table1 (url, other_field) VALUES (?, ?);"), "http://domain.com/test?param=1", 123)
+    finally:
+      db.close()
+      removeFile("db.sqlite3")

--- a/tests/stdlib/tsqlitebindatas.nim
+++ b/tests/stdlib/tsqlitebindatas.nim
@@ -52,21 +52,27 @@ block tsqlitebindatas: ## db_sqlite binary data
 
 block:
   block:
-    var db = db_sqlite.open("db.sqlite3", "", "", "")
+    const dbName = buildDir / "db.sqlite3"
+    var db = db_sqlite.open(dbName, "", "", "")
+    var witness = false
     try:
       db.exec(sql("CREATE TABLE table1 (url TEXT, other_field INT);"))
       db.exec(sql("REPLACE INTO table (url, another_field) VALUES (?, '123');"))
     except DbError as e:
-      doAssert e.msg == "The number of parameter doesn't match that of \"?\" "
+      witness = true
+      doAssert e.msg == "The number of \"?\" given exceeds the number of parameters present in the query."
     finally:
       db.close()
-      removeFile("db.sqlite3")
+      removeFile(dbName)
+
+    doAssert witness
 
   block:
-    var db = db_sqlite.open("db.sqlite3", "", "", "")
+    const dbName = buildDir / "db.sqlite3"
+    var db = db_sqlite.open(dbName, "", "", "")
     try:
       db.exec(sql("CREATE TABLE table1 (url TEXT, other_field INT);"))
       db.exec(sql("INSERT INTO table1 (url, other_field) VALUES (?, ?);"), "http://domain.com/test?param=1", 123)
     finally:
       db.close()
-      removeFile("db.sqlite3")
+      removeFile(dbName)


### PR DESCRIPTION
## Case One(The bug)
Before:
```nim
import std/[db_sqlite, os]


block:
  var db = db_sqlite.open("db.sqlite3", "", "", "")
  try:
    db.exec(sql("CREATE TABLE table1 (url TEXT, other_field INT);"))
    db.exec(sql("REPLACE INTO table (url, another_field) VALUES (?, '123');"))
  except DbError as e:
    doAssert e.msg == "The number of parameter doesn't match that of \"?\" "
  finally:
    db.close()
    removeFile("db.sqlite3")
```

raise IndexDefect

```
C:\Users\blue\Documents\GitHub\Nim\test6.nim(8) test6
C:\Users\blue\.choosenim\toolchains\nim-#devel\lib\impure\db_sqlite.nim(278) exec
C:\Users\blue\.choosenim\toolchains\nim-#devel\lib\impure\db_sqlite.nim(243) tryExec
C:\Users\blue\.choosenim\toolchains\nim-#devel\lib\impure\db_sqlite.nim(218) dbFormat
C:\Users\blue\.choosenim\toolchains\nim-#devel\lib\system\fatal.nim(53) sysFatal
Error: unhandled exception: index out of bounds, the container is empty [IndexDefect]
```

## Case Two(silent ignored bug)

When the number of parameter exceeds, still no raises like before.
```nim
block:
  var db = db_sqlite.open("db.sqlite3", "", "", "")
  try:
    db.exec(sql("CREATE TABLE table1 (url TEXT, other_field INT);"))
    db.exec(sql("INSERT INTO table1 (url, other_field) VALUES (?, ?);"), "http://domain.com/test?param=1", 123, 134)
  finally:
    db.close()
    removeFile("db.sqlite3")
```

But it can be fixed later(it is controversial to be fixed in this PR)

add a line before `res` variable
```nim
  if a != args.len:
    dbError("""The number of parameter doesn't match that of "?" """)
```

## future work
- [ ] https://github.com/nim-lang/Nim/pull/18669/files#r686051480