### PR TITLE
--cc:env now works correctly to assign linker executable, allowing to cross-compile/run for windows on osx via wine

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -252,7 +252,8 @@ compiler envcc:
     buildGui: "",
     buildDll: " -shared ",
     buildLib: "", # XXX: not supported yet
-    linkerExe: "cc",
+    # linkerExe: "cc",
+    linkerExe: "/usr/local/opt/mingw-w64/toolchain-x86_64/bin/x86_64-w64-mingw32-gcc",
     linkTmpl: "-o $exefile $buildgui $builddll $objfiles $options",
     includeCmd: " -I",
     linkDirCmd: "", # XXX: not supported yet

--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -252,8 +252,7 @@ compiler envcc:
     buildGui: "",
     buildDll: " -shared ",
     buildLib: "", # XXX: not supported yet
-    # linkerExe: "cc",
-    linkerExe: "/usr/local/opt/mingw-w64/toolchain-x86_64/bin/x86_64-w64-mingw32-gcc",
+    linkerExe: "",
     linkTmpl: "-o $exefile $buildgui $builddll $objfiles $options",
     includeCmd: " -I",
     linkDirCmd: "", # XXX: not supported yet


### PR DESCRIPTION
* fixes https://forum.nim-lang.org/t/7464 ("compiling and running nim progam via wine on osx: almost works, help welcome"), we can now compile and run a nim program via wine on osx, for example, via `--cc:env`

```
CC=/usr/local/opt/mingw-w64/toolchain-x86_64/bin/x86_64-w64-mingw32-gcc nim c --os:windows --cc:env -o:/tmp/main main
```

## before PR
```
  "_main", referenced from:
     implicit entry/start for main executable
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: execution of an external program failed: 'cc -o /tmp/c28z    '/Users/timothee/git_clone/nim/Nim_prs/\Users\timothee\git_clone\nim\timn\build\nimcache\/stdlib_assertions.nim.c.o' '
```
fails, because `cc` is used as the linker literally instead of using the CC passed via the environment via CC=... as indicated via `--cc:env`

## after PR
works, and generates a working binary that can be run from osx via:
`wine64 /tmp/main.exe`, producing:
```
foo\bar
```

## note
* some wine-specific warnings are shown, but that's unrelated to this PR
* `nim r main` doesn't work with wine yet, but that can be addressed in future work and shouldn't be hard (EDIT: fixing it in https://github.com/nim-lang/Nim/pull/18673)

## links
* see also `nim check --os:windows main` which allows at least running some VM code for windows on osx, but this is a more limited approach compared to running via wine, as enabled by this PR