### PR TITLE
[superseded] `nim r --runexe:exe`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -443,6 +443,8 @@
 
 - Added `nim --eval:cmd` to evaluate a command directly, see `nim --help`.
 
+- Added `nim --runexe:exe` flag, see `nim --help`.
+
 - VM now supports `addr(mystring[ind])` (index + index assignment)
 
 - Added `--hintAsError` with similar semantics as `--warningAsError`.

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -809,6 +809,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       setTarget(conf.target, conf.target.targetOS, cpu)
   of "run", "r":
     processOnOffSwitchG(conf, {optRun}, arg, pass, info)
+  of "runexe":
+    expectArg(conf, switch, arg, pass, info)
+    conf.runExe = arg
   of "maxloopiterationsvm":
     expectArg(conf, switch, arg, pass, info)
     conf.maxLoopIterationsVM = parseInt(arg)

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -95,18 +95,19 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
     let output = conf.absOutFile
     case conf.cmd
     of cmdBackends, cmdTcc:
-      var cmdPrefix = ""
+      var cmdPrefix = conf.runExe
       case conf.backend
       of backendC, backendCpp, backendObjc: discard
       of backendJs:
         # D20210217T215950:here this flag is needed for node < v15.0.0, otherwise
         # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-        cmdPrefix = findNodeJs() & " --unhandled-rejections=strict "
+        if cmdPrefix.len == 0: cmdPrefix = findNodeJs()
+        cmdPrefix.add " --unhandled-rejections=strict"
       else: doAssert false, $conf.backend
-      # No space before command otherwise on windows you'd get a cryptic:
-      # `The parameter is incorrect`
+      if cmdPrefix.len > 0: cmdPrefix.add " "
+        # without the `cmdPrefix.len > 0` check, on windows you'd get a cryptic:
+        # `The parameter is incorrect`
       execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)
-      # execExternalProgram(conf, cmdPrefix & ' ' & output.quoteShell & ' ' & conf.arguments)
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -376,6 +376,7 @@ type
     linkOptions*: string          # (*)
     compileOptions*: string       # (*)
     cCompilerPath*: string
+    runExe*: string
     toCompile*: CfileList         # (*)
     suggestionResultHook*: proc (result: Suggest) {.closure.}
     suggestVersion*: int

--- a/doc/basicopt.txt
+++ b/doc/basicopt.txt
@@ -30,7 +30,10 @@ Options:
   --debugger:native         Use native debugger (gdb)
   --app:console|gui|lib|staticlib
                             generate a console app|GUI app|DLL|static library
-  -r, --run                 run the compiled program with given arguments
+  -r, --run.                run the compiled program with given arguments.
+  --runexe:exe              Prepends `exe` to the command line, when `-r` is specified.
+                            e.g. `nim r --runexe:wine64 --os:windows main` or
+                            `nim r -b:js --run:/pathto/node -d:nodejs main`
   --eval:cmd                evaluates nim code directly; e.g.: `nim --eval:"echo 1"`
                             defaults to `e` (nimscript) but customizable:
                             `nim r --eval:'for a in stdin.lines: echo a'`


### PR DESCRIPTION
follows https://github.com/nim-lang/Nim/pull/18672, https://github.com/nim-lang/Nim/pull/18675

this allows specifying how `r` (aka `--run`) should run.

## before PR
* `nim r main` doesn't work with cross-compilation via `wine` on osx or  `-d:mingw`
* you can't specify a custom nodejs with `nim r`

## after PR
these work, eg:

* cross compilation via wine: --runexe:wine64
```
CC=/usr/local/opt/mingw-w64/toolchain-x86_64/bin/x86_64-w64-mingw32-gcc nim r --os:windows --cc:env -o:/tmp/main --runexe:wine64 main
```

* --eval via wine:
```
CC=/usr/local/opt/mingw-w64/toolchain-x86_64/bin/x86_64-w64-mingw32-gcc nim r --os:windows --cc:env --runexe:wine64 --eval:'import os; echo getAppFileName()'
```
prints:
`Z:\Users\timothee\.cache\nim\cmdfile_d\cmdfile_44472E8FBB5DC0305B6692C1BC0D669A76FD2517.exe`

* via -d:mingw:
`nim r -d:mingw --runexe:wine64 --eval:'import os; echo getAppFileName()'`

* custom nodejs: --runexe:/pathto/node
```
nim r -b:js --runexe:/pathto/node -d:nodejs --eval:'import jsconsole; console.log(12)'
```

## note 1
I could've re-used existing flag `--run:exe` but chose not to because `--run:off|on` already has a meaning, and because `--runexe:exe` can be put in your project/user config without affecting whether `r` is being used or not, so that `--runexe:exe` only takes effect in conjunction with `-r` (or other commands that imply it, ie `nim r` or `nim --run`)

## note 2 (EDIT: fixed by https://github.com/nim-lang/Nim/pull/18675)
1 un-related caveat is that if nimcache is set in a nims config file, eg via:
```nim
import os
let dir = "/tmp/D20210811T023837" / "nimcache1"
# echo dir: \tmp\D20210811T023837\nimcache1
switch("nimcache", dir)
```
it will not work intuitively, producing this:
```
110073 lines; 0.655s; 148.203MiB peakmem; proj: /Users/timothee/git_clone/nim/timn/tests/nim/all/t12707.nim; out: /Users/timothee/git_clone/nim/Nim_prs/\tmp\D20210811T023837\nimcache1/t12707_5C46284A9B5CD49C3C1E361DA0735181032A82B7.exe [SuccessX]
wine: cannot find '/Users/timothee/git_clone/nim/Nim_prs/\tmp\D20210811T023837\nimcache1/t12707_5C46284A9B5CD49C3C1E361DA0735181032A82B7.exe'
```

```
git status
 "\\tmp\\D20210811T023837\\nimcache1/"
```
places this in cwd (via a weird looking file with backslashes) instead of /tmp/D20210811T023837


## after PR
* maybe update `Cross-compilation for Windows` in nimc.rst to mention this