### PR TITLE
`addQuoted` now renders ' as ' instead of \'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -327,8 +327,8 @@
 
 - `system.addEscapedChar` now renders `\r` as `\r` instead of `\c`, to be compatible
   with most other languages.
- `system.addEscapedChar` now renders `'` as `'` instead of `\'`, to be compatible
-  with most other languages, with `-d:nimPreviewAddEscapedCharQuote`.
+
+- `system.addQuoted` now renders `'` as `'` instead of `\'`.
 
 - Removed support for named procs in `sugar.=>`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -327,6 +327,8 @@
 
 - `system.addEscapedChar` now renders `\r` as `\r` instead of `\c`, to be compatible
   with most other languages.
+ `system.addEscapedChar` now renders `'` as `'` instead of `\'`, to be compatible
+  with most other languages, with `-d:nimPreviewAddEscapedCharQuote`.
 
 - Removed support for named procs in `sugar.=>`.
 

--- a/config/config.nims
+++ b/config/config.nims
@@ -14,3 +14,11 @@ when defined(nimStrictMode):
     # switch("hint", "ConvFromXtoItselfNotNeeded")
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
+
+when (NimMajor, NimMinor) == (1,6) or (NimMajor, NimMinor) <= (1,4):
+  discard
+else:
+  # devel gets bugfixes right away; next release gets bugfixes via a preview flag.
+  # these can be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
+  # other `nimPreview` switches can go here, as needed.
+  switch("define", "nimPreviewAddEscapedCharQuote")

--- a/config/config.nims
+++ b/config/config.nims
@@ -14,11 +14,3 @@ when defined(nimStrictMode):
     # switch("hint", "ConvFromXtoItselfNotNeeded")
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
-
-when (NimMajor, NimMinor) == (1,6) or (NimMajor, NimMinor) <= (1,4):
-  discard
-else:
-  # devel gets bugfixes right away; next release gets bugfixes via a preview flag.
-  # these can be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
-  # other `nimPreview` switches can go here, as needed.
-  switch("define", "nimPreviewAddEscapedCharQuote")

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2843,14 +2843,14 @@ proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   ## * replaces any ``\`` by `\\`
   ## * replaces any `'` by `\'`
   ## * replaces any `"` by `\"`
-  ## * replaces any `\a` by `\\a`
-  ## * replaces any `\b` by `\\b`
-  ## * replaces any `\t` by `\\t`
-  ## * replaces any `\n` by `\\n`
-  ## * replaces any `\v` by `\\v`
-  ## * replaces any `\f` by `\\f`
-  ## * replaces any `\r` by `\\r`
-  ## * replaces any `\e` by `\\e`
+  ## * replaces any `\a` (`\x07`) by `\\a`
+  ## * replaces any `\b` (`\x08`) by `\\b`
+  ## * replaces any `\t` (`\x09`) by `\\t`
+  ## * replaces any `\n` (`\x0A`) by `\\n`
+  ## * replaces any `\v` (`\x0B`) by `\\v`
+  ## * replaces any `\f` (`\x0C`) by `\\f`
+  ## * replaces any `\r` (`\x0D`) by `\\r`
+  ## * replaces any `\e` (`\x1B`) by `\\e`
   ## * replaces any other character not in the set `{\21..\126}`
   ##   by `\xHH` where `HH` is its hexadecimal value
   ##
@@ -2869,7 +2869,7 @@ proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   of '\r': (when defined(nimLegacyAddEscapedCharx0D): s.add "\\c" else: s.add "\\r") # \x0D
   of '\e': s.add "\\e" # \x1B
   of '\\': s.add("\\\\")
-  of '\'': s.add("\\'")
+  of '\'': (when defined(nimLegacyAddEscapedCharQuote): s.add "\\'" else: s.add '\'')
   of '\"': s.add("\\\"")
   of {'\32'..'\126'} - {'\\', '\'', '\"'}: s.add(c)
   else:

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2840,36 +2840,40 @@ when declared(initDebugger):
 proc addEscapedChar*(s: var string, c: char) {.noSideEffect, inline.} =
   ## Adds a char to string `s` and applies the following escaping:
   ##
-  ## * replaces any ``\`` by `\\`
-  ## * replaces any `'` by `\'`
-  ## * replaces any `"` by `\"`
-  ## * replaces any `\a` (`\x07`) by `\\a`
-  ## * replaces any `\b` (`\x08`) by `\\b`
-  ## * replaces any `\t` (`\x09`) by `\\t`
-  ## * replaces any `\n` (`\x0A`) by `\\n`
-  ## * replaces any `\v` (`\x0B`) by `\\v`
-  ## * replaces any `\f` (`\x0C`) by `\\f`
-  ## * replaces any `\r` (`\x0D`) by `\\r`
-  ## * replaces any `\e` (`\x1B`) by `\\e`
-  ## * replaces any other character not in the set `{\21..\126}`
+  ## * replaces ``\`` by `\\`
+  ## * replaces `"` by `\"`
+  ## * replaces `\a` (`\x07`) by `\\a`
+  ## * replaces `\b` (`\x08`) by `\\b`
+  ## * replaces `\t` (`\x09`) by `\\t`
+  ## * replaces `\n` (`\x0A`) by `\\n`
+  ## * replaces `\v` (`\x0B`) by `\\v`
+  ## * replaces `\f` (`\x0C`) by `\\f`
+  ## * replaces `\r` (`\x0D`) by `\\r`
+  ## * replaces `\e` (`\x1B`) by `\\e`
+  ## * replaces other character not in the set `{\21..\126}`
   ##   by `\xHH` where `HH` is its hexadecimal value
+  ## * `'` is replaced by `\'` only if `nimPreviewAddEscapedCharQuote` is undefined.
   ##
   ## The procedure has been designed so that its output is usable for many
   ## different common syntaxes.
   ##
   ## .. warning:: This is **not correct** for producing ANSI C code!
-  ##
+  runnableExamples:
+    from std/sugar import dup
+    assert "".dup(addEscapedChar('\"')) == "\\\""
+    assert "".dup(addEscapedChar('a')) == "a"
+    assert "".dup(addEscapedChar(0x13.char)) == r"\x13"
   case c
-  of '\a': s.add "\\a" # \x07
-  of '\b': s.add "\\b" # \x08
-  of '\t': s.add "\\t" # \x09
-  of '\n': s.add "\\n" # \x0A
-  of '\v': s.add "\\v" # \x0B
-  of '\f': s.add "\\f" # \x0C
-  of '\r': (when defined(nimLegacyAddEscapedCharx0D): s.add "\\c" else: s.add "\\r") # \x0D
-  of '\e': s.add "\\e" # \x1B
+  of '\a': s.add "\\a"
+  of '\b': s.add "\\b"
+  of '\t': s.add "\\t"
+  of '\n': s.add "\\n"
+  of '\v': s.add "\\v"
+  of '\f': s.add "\\f"
+  of '\r': (when defined(nimLegacyAddEscapedCharx0D): s.add "\\c" else: s.add "\\r")
+  of '\e': s.add "\\e"
   of '\\': s.add("\\\\")
-  of '\'': (when defined(nimLegacyAddEscapedCharQuote): s.add "\\'" else: s.add '\'')
+  of '\'': (when defined(nimPreviewAddEscapedCharQuote): s.add '\'' else: s.add "\\'")
   of '\"': s.add("\\\"")
   of {'\32'..'\126'} - {'\\', '\'', '\"'}: s.add(c)
   else:

--- a/tests/lexer/tcustom_numeric_literals.nim
+++ b/tests/lexer/tcustom_numeric_literals.nim
@@ -13,7 +13,7 @@ assertAST dedent """
   StmtList
     ProcDef
       AccQuoted
-        Ident "\'"
+        Ident "'"
         Ident "wrap"
       Empty
       Empty
@@ -42,12 +42,12 @@ assertAST dedent """
   StmtList
     DotExpr
       RStrLit "-38383839292839283928392839283928392839283.928493849385935898243e-50000"
-      Ident "\'wrap"""":
+      Ident "'wrap"""":
   -38383839292839283928392839283928392839283.928493849385935898243e-50000'wrap
 
 proc `'wrap`(number: string): string = "[[" & number & "]]"
 proc wrap2(number: string): string = "[[" & number & "]]"
-doAssert lispReprStr(-1'wrap) == """(DotExpr (RStrLit "-1") (Ident "\'wrap"))"""
+doAssert lispReprStr(-1'wrap) == """(DotExpr (RStrLit "-1") (Ident "'wrap"))"""
 
 template main =
   block: # basic suffix usage
@@ -101,7 +101,7 @@ template main =
     doAssert 1234.56'wrap == 1234.56'd9
     doAssert 1234.56'wrap == 1234.56'i9
     doAssert 1234.56'wrap == 1234.56'u9
-    doAssert lispReprStr(1234.56'u9) == """(DotExpr (RStrLit "1234.56") (Ident "\'u9"))""":
+    doAssert lispReprStr(1234.56'u9) == """(DotExpr (RStrLit "1234.56") (Ident "'u9"))""":
       "failed to properly build AST for suffix that starts with u"
     doAssert -128'i8 == (-128).int8
 
@@ -137,14 +137,14 @@ template main =
     macro deb2(a): untyped = newLit a.lispRepr
     doAssert deb1(-12'wrap) == "-12'wrap"
     doAssert deb1(-12'nonexistent) == "-12'nonexistent"
-    doAssert deb2(-12'nonexistent) == """(DotExpr (RStrLit "-12") (Ident "\'nonexistent"))"""
+    doAssert deb2(-12'nonexistent) == """(DotExpr (RStrLit "-12") (Ident "'nonexistent"))"""
     when false: # xxx bug:
       # this holds:
       doAssert deb2(-12.wrap2) == """(DotExpr (IntLit -12) (Sym "wrap2"))"""
-      doAssert deb2(-12'wrap) == """(DotExpr (RStrLit "-12") (Sym "\'wrap"))"""
+      doAssert deb2(-12'wrap) == """(DotExpr (RStrLit "-12") (Sym "'wrap"))"""
       # but instead this should hold:
       doAssert deb2(-12.wrap2) == """(DotExpr (IntLit -12) (Ident "wrap2"))"""
-      doAssert deb2(-12'wrap) == """(DotExpr (RStrLit "-12") (Ident "\'wrap"))"""
+      doAssert deb2(-12'wrap) == """(DotExpr (RStrLit "-12") (Ident "'wrap"))"""
 
   block: # bug 2 from https://github.com/nim-lang/Nim/pull/17020#issuecomment-803193947
     template toSuf(`'suf`): untyped =

--- a/tests/misc/tparseopt.nim
+++ b/tests/misc/tparseopt.nim
@@ -122,7 +122,7 @@ else:
     stripLineEnd(ret.output)
     assertEquals ret.output,
       """
-@["a1b", "a2 b", "", "a4\"b", "a5\'b", "a6\\b", "a7\'b"]
+@["a1b", "a2 b", "", "a4\"b", "a5'b", "a6\\b", "a7'b"]
 arg 0 ai.len:3 :{a1b}
 arg 1 ai.len:4 :{a2 b}
 arg 2 ai.len:0 :{}


### PR DESCRIPTION
`addQuoted` now renders `'` as `'` instead of `\'`

Since `addQuoted` renders inside a double quote literal, the single quote doesn't need to be escaped.

## example 1
```nim
var a = "abc'def"
echo (a,)
  # before PR: ("abc\'def",)
  # after PR: ("abc'def",)
```

`addEscapedChar` behavior was not changed, since `addEscapedChar` isn't assumed to render inside a double quote literal.

## example 2
```nim
macro deb(a) = echo a.repr
deb:
  var a = {'a','b','\'', '\"'}
  var a2 = "abc'defå∫"
```

before PR: `repr` renders the code differently that what it appears in source code
```nim
var a = {'a', 'b', '\'', '\"'}
var a2 = "abc\'defå∫"
```

after PR: `repr` renders the code the same as what it appears in source code
```nim
var a = {'a', 'b', '\'', '\"'}
var a2 = "abc'defå∫"
```
