### PR TITLE
don't use space after proc names

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2726,7 +2726,7 @@ func addf*(s: var string, formatstr: string, a: varargs[string, `$`]) {.rtl,
       add s, formatstr[i]
       inc(i)
 
-func `%` *(formatstr: string, a: openArray[string]): string {.rtl,
+func `%`*(formatstr: string, a: openArray[string]): string {.rtl,
     extern: "nsuFormatOpenArray".} =
   ## Interpolates a format string with the values from `a`.
   ##
@@ -2774,7 +2774,7 @@ func `%` *(formatstr: string, a: openArray[string]): string {.rtl,
   result = newStringOfCap(formatstr.len + a.len shl 4)
   addf(result, formatstr, a)
 
-func `%` *(formatstr, a: string): string {.rtl,
+func `%`*(formatstr, a: string): string {.rtl,
     extern: "nsuFormatSingleElem".} =
   ## This is the same as `formatstr % [a]` (see
   ## `% func<#%25,string,openArray[string]>`_).


### PR DESCRIPTION
Before it gave me a bad search user-experience. I rely heavily on `proc` name + `*` character to search procs.

![image](https://user-images.githubusercontent.com/43030857/129205651-1b1ceb36-28bf-440a-b8dc-679d4d5b0e6b.png)

If I just search `%`, many unhelpful usages of `%` appear

![image](https://user-images.githubusercontent.com/43030857/129208487-72a1ec2b-8669-4906-971f-3e69e73fd4c6.png)

And I don't know whether `%` is a `proc` or a `func` or a `template` or a `macro` or even a `converter`. That's dull if I try all of the combinations. Of course if a proc is exported by keyword `export`, I must use a prefix to find it. But we could make it slightly better than before. 

It is impossible for to find `%` * by simply search `%`*`. I don't know why the space existed. IMO a consistent style makes life easier. Especially for something like symbol overload(they are harder to search than normal procs).

Is is correct for you? If so, I'm happy to change the contributing guide or whatsoever too.

