### PR TITLE
cross compilation targetting windows now supports `nim r`: `nim r -d:mingw main`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -482,6 +482,10 @@
   nim r main # uses cached binary
   nim r main arg1 arg2 # ditto (runtime arguments are irrelevant)
 
+- `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using wine,
+  e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`
+  Use `--nimrun.exe:/pathto/wine64` to override.
+
 - The style checking of the compiler now supports a `--styleCheck:usages` switch. This switch
   enforces that every symbol is written as it was declared, not enforcing
   the official Nim style guide. To be enabled, this has to be combined either

--- a/changelog.md
+++ b/changelog.md
@@ -484,7 +484,6 @@
 
 - `nim r` now supports cross compilation from unix to windows when specifying `-d:mingw` by using wine,
   e.g.: `nim r --eval:'import os; echo "a" / "b"'` prints `a\b`
-  Use `--nimrun.exe:/pathto/wine64` to override.
 
 - The style checking of the compiler now supports a `--styleCheck:usages` switch. This switch
   enforces that every symbol is written as it was declared, not enforcing

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -70,6 +70,13 @@ proc processCmdLine(pass: TCmdLinePass, cmd: string; config: ConfigRef) =
         config.arguments.len > 0 and config.cmd notin {cmdTcc, cmdNimscript, cmdCrun}:
       rawMessage(config, errGenerated, errArgsNeedRunOption)
 
+proc getNimRunExe(conf: ConfigRef): string =
+  # xxx consider defining `conf.getConfigVar("nimrun.exe")` to allow users to
+  # customize the binary to run the command with, e.g. for custom `nodejs` or `wine`.
+  if conf.isDefined("mingw"):
+    if conf.isDefined("i386"): result = "wine"
+    elif conf.isDefined("amd64"): result = "wine64"
+
 proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
   let self = NimProg(
     supportsStdinFile: true,
@@ -95,7 +102,7 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
     let output = conf.absOutFile
     case conf.cmd
     of cmdBackends, cmdTcc:
-      let nimRunExe = conf.getConfigVar("nimrun.exe")
+      let nimRunExe = getNimRunExe(conf)
       var cmdPrefix: string
       if nimRunExe.len > 0: cmdPrefix.add nimRunExe.quoteShell
       case conf.backend

--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -96,13 +96,14 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
     case conf.cmd
     of cmdBackends, cmdTcc:
       let nimRunExe = conf.getConfigVar("nimrun.exe")
-      var cmdPrefix = nimRunExe
+      var cmdPrefix: string
+      if nimRunExe.len > 0: cmdPrefix.add nimRunExe.quoteShell
       case conf.backend
       of backendC, backendCpp, backendObjc: discard
       of backendJs:
         # D20210217T215950:here this flag is needed for node < v15.0.0, otherwise
         # tasyncjs_fail` would fail, refs https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
-        if cmdPrefix.len == 0: cmdPrefix = findNodeJs()
+        if cmdPrefix.len == 0: cmdPrefix = findNodeJs().quoteShell
         cmdPrefix.add " --unhandled-rejections=strict"
       else: doAssert false, $conf.backend
       if cmdPrefix.len > 0: cmdPrefix.add " "

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -104,6 +104,11 @@ nimblepath="$home/.nimble/pkgs/"
 
   gcc.options.linker = ""
   gcc.cpp.options.linker = ""
+  @if i386:
+    nimrun.exe = "wine"
+  @else:
+    nimrun.exe = "wine64"
+  @end
 @end
 
 @if unix:

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -104,11 +104,6 @@ nimblepath="$home/.nimble/pkgs/"
 
   gcc.options.linker = ""
   gcc.cpp.options.linker = ""
-  @if i386:
-    nimrun.exe = "wine"
-  @else:
-    nimrun.exe = "wine64"
-  @end
 @end
 
 @if unix:

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -317,7 +317,7 @@ To cross-compile for Windows from Linux or macOS using the MinGW-w64 toolchain:
 .. code:: cmd
 
   nim c -d:mingw myproject.nim
-  # `nim r` also works, setting `nimrun.exe` to `wine` or `wine64`
+  # `nim r` also works, running the binary via `wine` or `wine64`:
   nim r -d:mingw --eval:'import os; echo "a" / "b"'
 
 Use `--cpu:i386`:option: or `--cpu:amd64`:option: to switch the CPU architecture.

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -317,6 +317,8 @@ To cross-compile for Windows from Linux or macOS using the MinGW-w64 toolchain:
 .. code:: cmd
 
   nim c -d:mingw myproject.nim
+  # `nim r` also works, setting `nimrun.exe` to `wine` or `wine64`
+  nim r -d:mingw --eval:'import os; echo "a" / "b"'
 
 Use `--cpu:i386`:option: or `--cpu:amd64`:option: to switch the CPU architecture.
 


### PR DESCRIPTION
alternative to https://github.com/nim-lang/Nim/pull/18673; the main difference is that I'm here using `getConfigVar` mechanism instead of adding a proper flag, and I'm setting it automatically in `config/nim.cfg` when `-d:mingw` is specified, so that the simplest `nim r -d:mingw main` works

follows https://github.com/nim-lang/Nim/pull/18672, https://github.com/nim-lang/Nim/pull/18675

`--nimrun.exe` is for now kept un-documented as a config var flag (refs `getConfigVar`), and is set automatically when passing `-d:mingw`

these now work:
```
# nimrun.exe is set automatically:
nim r -d:mingw main

# custom nimrun.exe:
nim r --nimrun.exe:/usr/local//bin/wine64 -d:mingw main
nim r --nimrun.exe:"path with spaces/wine64" -d:mingw main

# example with eval:
nim r -d:mingw --eval:'import os; echo "a" / "b"'

```

## example with nodejs:
```
nim r --nimrun.exe:/usr/local/bin/node -b:js -d:nodejs --eval:'import jsconsole; console.log(12)'
```

## note
there are pros and cons for `getConfigVar` vs a proper flag:
pros of `getConfigVar`:
* doesn't need handling logic in commands.nim, instead reuses  `getConfigVar` 
cons of `getConfigVar`:
* no error detection if flag is misused