### PR TITLE
initial fix for compiling Nim on Zephyr RTOS (issue  #18684)

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -529,7 +529,7 @@ struct TFrame_ {
 #  define NIM_UNLIKELY(x) __builtin_expect(x, 0)
 /* We need the following for the posix wrapper. In particular it will give us
    POSIX_SPAWN_USEVFORK: */
-#  ifndef _GNU_SOURCE && !defined(__ZEPHYR__)
+#  ifndef _GNU_SOURCE
 #    define _GNU_SOURCE
 #  endif
 #else

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -75,7 +75,8 @@ __AVR__
 #endif
 /* ------------------------------------------------------------------------- */
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__ZEPHYR__)
+/* Zephyr does some magic in it's headers that override the GCC stdlib. This breaks that. */
 #  define _GNU_SOURCE 1
 #endif
 
@@ -528,7 +529,7 @@ struct TFrame_ {
 #  define NIM_UNLIKELY(x) __builtin_expect(x, 0)
 /* We need the following for the posix wrapper. In particular it will give us
    POSIX_SPAWN_USEVFORK: */
-#  ifndef _GNU_SOURCE
+#  ifndef _GNU_SOURCE && !defined(__ZEPHYR__)
 #    define _GNU_SOURCE
 #  endif
 #else


### PR DESCRIPTION
This fixes compilation of generic POSIX type code when targeting Zephyr RTOS. The `nimbase.h` header sets `_GNU_SOUCE` whenever `__GNUC__` is define. However, Zephyr doesn't (necessarily) use GCC's headers even though it does generally use GCC itself. It seems best to not set `_GNU_SOURCE` when compiling for Zephyr. 

Here's the error that occurs when Zephyr's build system tries to compile Nim generated C code:

```sh
In file included from zephyrproject/zephyr/include/posix/unistd.h:9,
                 from rtos/dumb_http_server/src/output/@msocket_dumb_http.nim.c:16:
zephyrproject/zephyr/include/posix/posix_types.h:45:3: error: conflicting types for 'pthread_attr_t'
   45 | } pthread_attr_t;
      |   ^~~~~~~~~~~~~~
In file included from zephyr-sdk-0.12.4/arm-zephyr-eabi/arm-zephyr-eabi/sys-include/sys/types.h:223,
                 from zephyr-sdk-0.12.4/arm-zephyr-eabi/arm-zephyr-eabi/sys-include/stdio.h:61,
                 from rtos/dumb_http_server/src/output/@msocket_dumb_http.nim.c:10:
zephyr-sdk-0.12.4/arm-zephyr-eabi/arm-zephyr-eabi/sys-include/sys/_pthreadtypes.h:75:3: note: previous declaration of 'pthread_attr_t' was here
   75 | } pthread_attr_t;
      |   ^~~~~~~~~~~~~~
```

