### PR TITLE
fix #18680 ; making {.passc: "-DWIN32_LEAN_AND_MEAN".} optional

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -15,7 +15,7 @@ import dynlib
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 
-when defined(Win32LeanAndMean):
+when not defined(nimFullWindowsHeader):
   {.passc: "-DWIN32_LEAN_AND_MEAN".}
 
 const

--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -15,7 +15,8 @@ import dynlib
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 
-{.passc: "-DWIN32_LEAN_AND_MEAN".}
+when defined(Win32LeanAndMean):
+  {.passc: "-DWIN32_LEAN_AND_MEAN".}
 
 const
   useWinUnicode* = not defined(useWinAnsi)


### PR DESCRIPTION
- fix #18680

this PR #3880 introduced new passC line into stdlib.
I believe that if a programmer wants to define WIN32_LEAN_AND_MEAN he can do it inside his own .nim file, and not in Nim Standard Library.

how to deal with winsock errors is written in Microsoft Docs:
https://docs.microsoft.com/en-us/windows/win32/winsock/creating-a-basic-winsock-application

> For historical reasons, the Windows.h header defaults to including the Winsock.h header file for Windows Sockets 1.1. The declarations in the Winsock.h header file will conflict with the declarations in the Winsock2.h header file required by Windows Sockets 2.0. The WIN32_LEAN_AND_MEAN macro prevents the Winsock.h from being included by the Windows.h header.

so that macro one must define in his own code.
