### PR TITLE
Remove `Covariance` section from the experimental manual

### DIFF
--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -669,7 +669,6 @@ in any required way. For example, here is how one might define the classic
 type is an instance of it:
 
 .. code-block:: nim
-
     :test: "nim c $1"
 
   import std/[sugar, typetraits]
@@ -919,7 +918,6 @@ simplistic form of pattern matching for tuples, leveraging the existing
 equality operator for tuples (as provided in `system.==`):
 
 .. code-block:: nim
-
     :test: "nim c $1"
 
   {.experimental: "caseStmtMacros".}
@@ -1436,7 +1434,6 @@ Parallel statement
 Example:
 
 .. code-block:: nim
-
     :test: "nim c --threads:on $1"
 
   # Compute PI in an inefficient way

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -42,6 +42,7 @@ type information for `T` is available.
 Example:
 
 .. code-block:: nim
+
   # module A (in an arbitrary package)
   type
     Pack.SomeObject = object ## declare as incomplete object of package 'Pack'
@@ -53,6 +54,7 @@ Example:
 
 
 .. code-block:: nim
+
   # module B (in package "Pack")
   type
     SomeObject* {.package.} = object ## Use 'package' to complete the object
@@ -68,6 +70,7 @@ type `void` are treated as non-existent, `void` as a return type means that
 the procedure does not return a value:
 
 .. code-block:: nim
+
   proc nothing(x, y: void): void =
     echo "ha"
 
@@ -76,6 +79,7 @@ the procedure does not return a value:
 The `void` type is particularly useful for generic code:
 
 .. code-block:: nim
+
   proc callProc[T](p: proc (x: T), x: T) =
     when T is void:
       p()
@@ -91,6 +95,7 @@ The `void` type is particularly useful for generic code:
 However, a `void` type cannot be inferred in generic code:
 
 .. code-block:: nim
+
   callProc(emptyProc)
   # Error: type mismatch: got (proc ())
   # but expected one of:
@@ -107,6 +112,7 @@ Automatic dereferencing is performed for the first argument of a routine call.
 This feature has to be enabled via `{.experimental: "implicitDeref".}`:
 
 .. code-block:: nim
+
   {.experimental: "implicitDeref".}
 
   proc depth(x: NodeObj): int = ...
@@ -163,6 +169,7 @@ preface definitions inside a module.
 Example:
 
 .. code-block:: nim
+
   {.experimental: "codeReordering".}
 
   proc foo(x: int) =
@@ -179,6 +186,7 @@ statement) can have their entire initialization statement reordered. Be wary of
 what code is executed at the top level:
 
 .. code-block:: nim
+
   {.experimental: "codeReordering".}
 
   proc a() =
@@ -198,6 +206,7 @@ what code is executed at the top level:
    code is the same as it would be with code reordering disabled.
 
    .. code-block:: nim
+
      {.experimental: "codeReordering".}
 
      proc x() =
@@ -211,6 +220,7 @@ It is important to note that reordering *only* works for symbols at top level
 scope. Therefore, the following will *fail to compile:*
 
 .. code-block:: nim
+
   {.experimental: "codeReordering".}
 
   proc a() =
@@ -229,6 +239,7 @@ has different names. This does not need an `experimental` switch, but is an
 unstable feature.
 
 .. code-block:: Nim
+
   proc foo(x: int) =
     echo "Using x: ", x
   proc foo(y: int) =
@@ -247,6 +258,7 @@ As a special more convenient notation, proc expressions involved in procedure
 calls can use the `do` keyword:
 
 .. code-block:: nim
+
   sort(cities) do (x,y: string) -> int:
     cmp(x.len, y.len)
 
@@ -269,6 +281,7 @@ parentheses is just a block of code. The `do` notation can be used to
 pass multiple blocks to a macro:
 
 .. code-block:: nim
+
   macro performWithUndo(task, undo: untyped) = ...
 
   performWithUndo do:
@@ -301,6 +314,7 @@ the expression, where the unknown field or proc name is passed to
 an `untyped` parameter:
 
 .. code-block:: nim
+
   a.b # becomes `.`(a, b)
   a.b(c, d) # becomes `.`(a, b, c, d)
 
@@ -308,6 +322,7 @@ The matched dot operators can be symbols of any callable kind (procs,
 templates and macros), depending on the desired effect:
 
 .. code-block:: nim
+
   template `.`(js: PJsonNode, field: untyped): JSON = js[astToStr(field)]
 
   var js = parseJson("{ x: 1, y: 2}")
@@ -332,6 +347,7 @@ operator `.=`
 This operator will be matched against assignments to missing fields.
 
 .. code-block:: nim
+
   a.b = c # becomes `.=`(a, b, c)
 
 Call operator
@@ -342,6 +358,7 @@ for existing routines. The experimental `callOperator` switch must be enabled
 to use this operator.
 
 .. code-block:: nim
+
   {.experimental: "callOperator".}
 
   template `()`(a: int, b: float): untyped = $(a, b)
@@ -377,6 +394,7 @@ All types for which `nil` is a valid value can be annotated with the
 `not nil` annotation to exclude `nil` as a valid value:
 
 .. code-block:: nim
+
   {.experimental: "notnil".}
 
   type
@@ -409,6 +427,7 @@ arbitrary set of requirements that the matched type must satisfy.
 Concepts are written in the following form:
 
 .. code-block:: nim
+
   type
     Comparable = concept x, y
       (x < y) is bool
@@ -434,6 +453,7 @@ instance. You can also apply the `type` modifier to create a named instance of
 the type itself:
 
 .. code-block:: nim
+
   type
     MyConcept = concept x, var v, ref r, ptr p, static s, type T
       ...
@@ -443,6 +463,7 @@ and parameters are expected. This provides a more convenient way to check for
 the presence of callable symbols with specific signatures:
 
 .. code-block:: nim
+
   type
     OutputStream = concept var s
       s.write(string)
@@ -453,6 +474,7 @@ type, following the `concept` keyword is also considered to have the
 explicit modifier and will be matched only as a type.
 
 .. code-block:: nim
+
   type
     # Let's imagine a user-defined casting framework with operators
     # such as `val.to(string)` and `val.to(JSonValue)`. We can test
@@ -490,6 +512,7 @@ concept and, as a result, a wrong overload is selected, you can apply the
 `explain` pragma to either the concept body or a particular call-site.
 
 .. code-block:: nim
+
   type
     MyConcept {.explain.} = concept ...
 
@@ -505,6 +528,7 @@ Generic concepts and type binding rules
 The concept types can be parametric just like the regular generic types:
 
 .. code-block:: nim
+
   ### matrixalgo.nim
 
   import std/typetraits
@@ -578,6 +602,7 @@ Unbound static params will be inferred from expressions involving the `==`
 operator and also when types dependent on them are being matched:
 
 .. code-block:: nim
+
   type
     MatrixReducer[M, N: static int; T] = concept x
       x.reduce(SquareMatrix[N, T]) is array[M, int]
@@ -592,6 +617,7 @@ matched without permanently inferring it. This may be useful when you need
 to match several procs accepting the same wide class of types:
 
 .. code-block:: nim
+
   type
     Enumerable[T] = concept e
       for v in e:
@@ -614,6 +640,7 @@ types used in multiple signatures, without actually requiring any concrete
 types, thus allowing you to encode implementation-defined types:
 
 .. code-block:: nim
+
   type
     MyConcept = concept x
       type T1 = auto
@@ -642,6 +669,7 @@ in any required way. For example, here is how one might define the classic
 type is an instance of it:
 
 .. code-block:: nim
+
     :test: "nim c $1"
 
   import std/[sugar, typetraits]
@@ -674,6 +702,7 @@ accessible through the dot operator in procs where the concept was successfully
 matched to a concrete type:
 
 .. code-block:: nim
+
   type
     DateTime = concept t1, t2, type T
       const Min = T.MinDate
@@ -708,6 +737,7 @@ one. As an alternative way of defining concept refinements, you can use the
 object inheritance syntax involving the `of` keyword:
 
 .. code-block:: nim
+
   type
     Graph = concept g, type G of EquallyComparable, Copyable
       type
@@ -751,6 +781,7 @@ object inheritance syntax involving the `of` keyword:
   the concept body:
 
   .. code-block:: nim
+
     type
       Stringable = concept x
         $x is string
@@ -802,6 +833,7 @@ object inheritance syntax involving the `of` keyword:
   types to the corresponding VTable type.
 
   .. code-block:: nim
+
     type
       IntEnumerable = vtref Enumerable[int]
 
@@ -868,6 +900,7 @@ language may weaken this restriction.)
 The signature has to be:
 
 .. code-block:: nim
+
   proc `=deepCopy`(x: T): T
 
 This mechanism will be used by most data structures that support shared memory
@@ -886,6 +919,7 @@ simplistic form of pattern matching for tuples, leveraging the existing
 equality operator for tuples (as provided in `system.==`):
 
 .. code-block:: nim
+
     :test: "nim c $1"
 
   {.experimental: "caseStmtMacros".}
@@ -935,6 +969,7 @@ phase of the compiler: This means they provide an easy way to enhance the
 compilation pipeline with user defined optimizations:
 
 .. code-block:: nim
+
   template optMul{`*`(a, 2)}(a: int): int = a+a
 
   let x = 3
@@ -957,6 +992,7 @@ Unfortunately optimizations are hard to get right and even the tiny example
 is **wrong**:
 
 .. code-block:: nim
+
   template optMul{`*`(a, 2)}(a: int): int = a+a
 
   proc f(): int =
@@ -969,6 +1005,7 @@ We cannot duplicate 'a' if it denotes an expression that has a side effect!
 Fortunately Nim supports side effect analysis:
 
 .. code-block:: nim
+
   template optMul{`*`(a, 2)}(a: int{noSideEffect}): int = a+a
 
   proc f(): int =
@@ -986,11 +1023,13 @@ cannot really do that however as the following code only swaps arguments
 blindly:
 
 .. code-block:: nim
+
   template mulIsCommutative{`*`(a, b)}(a, b: int): int = b*a
 
 What optimizers really need to do is a *canonicalization*:
 
 .. code-block:: nim
+
   template canonMul{`*`(a, b)}(a: int{lit}, b: int): int = b*a
 
 The `int{lit}` parameter pattern matches against an expression of
@@ -1050,6 +1089,7 @@ but also to every other bound parameter; syntactically they need to occur after
 the ordinary AST predicates:
 
 .. code-block:: nim
+
   template ex{a = b + c}(a: int{noalias}, b, c: int) =
     # this transformation is only valid if 'b' and 'c' do not alias 'a':
     a = b
@@ -1058,6 +1098,7 @@ the ordinary AST predicates:
 Another example:
 
 .. code-block:: nim
+
   proc somefunc(s: string)                 = assert s == "variable"
   proc somefunc(s: string{nkStrLit})       = assert s == "literal"
   proc somefunc(s: string{nkRStrLit})      = assert s == r"raw"
@@ -1087,6 +1128,7 @@ The `|` operator
 The `|` operator if used as infix operator creates an ordered choice:
 
 .. code-block:: nim
+
   template t{0|1}(): untyped = 3
   let a = 1
   # outputs 3:
@@ -1096,6 +1138,7 @@ The matching is performed after the compiler performed some optimizations like
 constant folding, so the following does not work:
 
 .. code-block:: nim
+
   template t{0|1}(): untyped = 3
   # outputs 1:
   echo 1
@@ -1113,6 +1156,7 @@ A pattern expression can be bound to a pattern parameter via the `expr{param}`
 notation:
 
 .. code-block:: nim
+
   template t{(0|1|2){x}}(x: untyped): untyped = x+1
   let a = 1
   # outputs 2:
@@ -1125,6 +1169,7 @@ The `~` operator
 The `~` operator is the **not** operator in patterns:
 
 .. code-block:: nim
+
   template t{x = (~x){y} and (~x){z}}(x, y, z: bool) =
     x = y
     if x: x = z
@@ -1144,6 +1189,7 @@ The `*` operator can *flatten* a nested binary expression like `a & b & c`
 to `&(a, b, c)`:
 
 .. code-block:: nim
+
   var
     calls = 0
 
@@ -1168,6 +1214,7 @@ which is flattened into a call expression; thus the invocation of `optConc`
 produces:
 
 .. code-block:: nim
+
    `&&`("my", space & "awe", "some ", "concat")
 
 
@@ -1178,6 +1225,7 @@ The `**` is much like the `*` operator, except that it gathers not only
 all the arguments, but also the matched operators in reverse polish notation:
 
 .. code-block:: nim
+
   import std/macros
 
   type
@@ -1222,6 +1270,7 @@ parameter is of the type `varargs` it is treated specially and it can match
 0 or more arguments in the AST to be matched against:
 
 .. code-block:: nim
+
   template optWrite{
     write(f, x)
     ((write|writeLine){w})(f, y)
@@ -1237,6 +1286,7 @@ The following example shows how some simple partial evaluation can be
 implemented with term rewriting:
 
 .. code-block:: nim
+
   proc p(x, y: int; cond: bool): int =
     result = if cond: x + y else: x - y
 
@@ -1250,6 +1300,7 @@ Example: Hoisting
 The following example shows how some form of hoisting can be implemented:
 
 .. code-block:: nim
+
   import std/pegs
 
   template optPeg{peg(pattern)}(pattern: string{lit}): Peg =
@@ -1273,6 +1324,7 @@ Parameter constraints can also be used for ordinary routine parameters; these
 constraints affect ordinary overloading resolution then:
 
 .. code-block:: nim
+
   proc optLit(a: string{lit|`const`}) =
     echo "string literal"
   proc optLit(a: string) =
@@ -1324,6 +1376,7 @@ Spawn statement
 `spawn`:idx: can be used to pass a task to the thread pool:
 
 .. code-block:: nim
+
   import std/threadpool
 
   proc processLine(line: string) =
@@ -1356,6 +1409,7 @@ with the `^` operator is **blocking**. However, one can use `blockUntilAny` to
 wait on multiple flow variables at the same time:
 
 .. code-block:: nim
+
   import std/threadpool, ...
 
   # wait until 2 out of 3 servers received the update:
@@ -1382,6 +1436,7 @@ Parallel statement
 Example:
 
 .. code-block:: nim
+
     :test: "nim c --threads:on $1"
 
   # Compute PI in an inefficient way
@@ -1450,6 +1505,7 @@ Protecting global variables
 Object fields and global variables can be annotated via a `guard` pragma:
 
 .. code-block:: nim
+
   var glock: TLock
   var gdata {.guard: glock.}: int
 
@@ -1457,6 +1513,7 @@ The compiler then ensures that every access of `gdata` is within a `locks`
 section:
 
 .. code-block:: nim
+
   proc invalid =
     # invalid: unguarded access:
     echo gdata
@@ -1475,6 +1532,7 @@ semantics and should not be used directly! It should only be used in templates
 that also implement some form of locking at runtime:
 
 .. code-block:: nim
+
   template lock(a: TLock; body: untyped) =
     pthread_mutex_lock(a)
     {.locks: [a].}:
@@ -1488,6 +1546,7 @@ The guard does not need to be of any particular type. It is flexible enough to
 model low level lockfree mechanisms:
 
 .. code-block:: nim
+
   var dummyLock {.compileTime.}: int
   var atomicCounter {.guard: dummyLock.}: int
 
@@ -1515,6 +1574,7 @@ Since objects can reside on the heap or on the stack this greatly enhances the
 expressivity of the language:
 
 .. code-block:: nim
+
   type
     ProtectedCounter = object
       v {.guard: L.}: int
@@ -1529,6 +1589,7 @@ The access to field `x.v` is allowed since its guard `x.L`  is active.
 After template expansion, this amounts to:
 
 .. code-block:: nim
+
   proc incCounters(counters: var openArray[ProtectedCounter]) =
     for i in 0..counters.high:
       pthread_mutex_lock(counters[i].L)
@@ -1549,6 +1610,7 @@ Two paths are considered equivalent if they are syntactically the same.
 This means the following compiles (for now) even though it really should not:
 
 .. code-block:: nim
+
   {.locks: [a[i].L].}:
     inc i
     access a[i].v
@@ -1569,6 +1631,7 @@ of the same level can only be acquired *at the same time* within a
 single `locks` section:
 
 .. code-block:: nim
+
   var a, b: TLock[2]
   var x: TLock[1]
   # invalid locking order: TLock[1] cannot be acquired before TLock[2]:
@@ -1595,6 +1658,7 @@ the runtime check is required to ensure a global ordering for two locks `a`
 and `b` of the same lock level:
 
 .. code-block:: nim
+
   template multilock(a, b: ptr TLock; body: untyped) =
     if cast[ByteAddress](a) < cast[ByteAddress](b):
       pthread_mutex_lock(a)
@@ -1615,6 +1679,7 @@ level. This then means that the routine may acquire locks of up to this level.
 This is essential so that procs can be called within a `locks` section:
 
 .. code-block:: nim
+
   proc p() {.locks: 3.} = discard
 
   var a: TLock[4]
@@ -1637,6 +1702,7 @@ cannot be inferred statically, leading to compiler warnings. By using
 having unknown lock level as well:
 
 .. code-block:: nim
+
   type SomeBase* = ref object of RootObj
   type SomeDerived* = ref object of SomeBase
     memberProc*: proc ()
@@ -1659,6 +1725,7 @@ e.g. when rewriting term to same term plus extra content.
 e.g. with given example `echo("ab")` will be rewritten just once:
 
 .. code-block:: nim
+
   template pwnEcho{echo(x)}(x: untyped) =
     {.noRewrite.}: echo("pwned!")
 
@@ -1720,6 +1787,7 @@ via a parameter that is not declared as a `var` parameter.
 For example:
 
 .. code-block:: nim
+
   {.experimental: "strictFuncs".}
 
   type
@@ -1759,6 +1827,7 @@ A view type is a type that is or contains one of the following types:
 For example:
 
 .. code-block:: nim
+
   type
     View1 = openArray[byte]
     View2 = lent string
@@ -1769,6 +1838,7 @@ Exceptions to this rule are types constructed via `ptr` or `proc`.
 For example, the following types are **not** view types:
 
 .. code-block:: nim
+
   type
     NotView1 = proc (x: openArray[int])
     NotView2 = ptr openArray[char]
@@ -1790,6 +1860,7 @@ it was borrowed from.
 For example:
 
 .. code-block:: nim
+
   {.experimental: "views".}
 
   proc take(a: openArray[int]) =
@@ -1870,6 +1941,7 @@ may be performed except via the view that borrowed from the
 location. The borrowed location is said to be *sealed* during the borrow.
 
 .. code-block:: nim
+
   {.experimental: "views".}
 
   type
@@ -1885,6 +1957,7 @@ location. The borrowed location is said to be *sealed* during the borrow.
 The scope of the view does not matter:
 
 .. code-block:: nim
+
   proc valid(s: var seq[Obj]) =
     let v: lent Obj = s[0]  # begin of borrow
     echo v.field            # end of borrow
@@ -1899,6 +1972,7 @@ with `--experimental:strictFuncs`:option:.
 The analysis is currently control flow insensitive:
 
 .. code-block:: nim
+
   proc invalid(s: var seq[Obj]) =
     let v: lent Obj = s[0]
     if false:


### PR DESCRIPTION
It is not possible (anymore?) to define covariant/contravariant type parameters. I'm not sure if the section regarding the covariance of pointer types should be kept (but then it's not experimental, is it?) or even if it's still true.

Also some small formatting changes.