### PR TITLE
fix #18692 AsyncHttpServer was hanging because client.close was not called

### DIFF
--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -362,7 +362,9 @@ proc processClient(server: AsyncHttpServer, client: AsyncSocket, address: string
     let retry = await processRequest(
       server, request, client, address, lineFut, callback
     )
-    if not retry: break
+    if not retry:
+      client.close()
+      break
 
 const
   nimMaxDescriptorsFallback* {.intdefine.} = 16_000 ## fallback value for \


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/18692

what was happening is that in processRequest, client.close() was called before each return false, except for 2 places:
```
        await request.respondError(Http413)
        return false
```

```
  if "upgrade" in request.headers.getOrDefault("connection"):
    return false
```

on aws, it was hitting the 2nd case, and you ended up with this pattern:
1st request succeeds
2nd request hangs forever (until ^C)
3st request succeeds
4th request hangs forever
...

this PR fixes that
