### PR TITLE
nimIdentNormalize removes spaces

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -291,7 +291,7 @@ func nimIdentNormalize*(s: string): string =
       inc j
   if j != s.len: setLen(result, j)
 
-func nimIdentBackticksNormalize*(s: string): string =
+func nimIdentBackticksNormalize*(s: string): string {.since: (1, 5).} =
   ## Normalizes the string `s` as a Nim identifier.
   ##
   ## Unlike `nimIdentNormalize` removes spaces and backticks.


### PR DESCRIPTION
Just to conform to the compiler behavior.