### PR TITLE
[docs]fix a missing item 

### DIFF
--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -364,6 +364,7 @@ AST:
     nnkExprColonExpr(nnkIdent("a"), nnkIntLit(1)),
     nnkExprColonExpr(nnkIdent("b"), nnkIntLit(2)),
     nnkExprColonExpr(nnkIdent("c"), nnkIntLit(3)))
+  nnkTupleConstr()
 
 Since the one tuple would be syntactically identical to parentheses
 with an expression in them, the parser expects a trailing comma for


### PR DESCRIPTION
Ref https://nim-lang.github.io/Nim/macros.html#callsslashexpressions-tuple-constructors

![image](https://user-images.githubusercontent.com/43030857/130253228-c2532de6-1998-421a-acbb-21207e48ca4a.png)

The ast of the empty tupleConstr is missing in docs.