### PR TITLE
fix deprecated example and update test spec

### DIFF
--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -1081,7 +1081,7 @@ its entirety to see some of the complexities.
 Concrete syntax:
 
 .. code-block:: nim
-  type Obj[T] = object {.inheritable.}
+  type Obj[T] {.inheritable.} = object
     name: string
     case isFat: bool
     of true:
@@ -1093,10 +1093,18 @@ AST:
 
 .. code-block:: nim
   # ...
+  nnkPragmaExpr(
+    nnkIdent("Obj"),
+    nnkPragma(nnkIdent("inheritable"))
+  ),
+  nnkGenericParams(
+  nnkIdentDefs(
+    nnkIdent("T"),
+    nnkEmpty(),
+    nnkEmpty())
+  ),
   nnkObjectTy(
-    nnkPragma(
-      nnkIdent("inheritable")
-    ),
+    nnkEmpty(),
     nnkEmpty(),
     nnkRecList( # list of object parameters
       nnkIdentDefs(

--- a/tests/astspec/tastspec.nim
+++ b/tests/astspec/tastspec.nim
@@ -871,11 +871,20 @@ static:
 
   scope:
     macro testRecCase(ast: untyped): untyped =
-      ast.peelOff({nnkStmtList, nnkTypeSection})[2].matchAst:
-      of nnkObjectTy(
-        nnkPragma(
-          ident"inheritable"
+      ast.peelOff({nnkStmtList, nnkTypeSection}).matchAst:
+      of nnkTypeDef(
+        nnkPragmaExpr(
+          ident"Obj",
+          nnkPragma(ident"inheritable")
         ),
+        nnkGenericParams(
+        nnkIdentDefs(
+          ident"T",
+          nnkEmpty(),
+          nnkEmpty())
+        ),
+        nnkObjectTy(
+        nnkEmpty(),
         nnkEmpty(),
         nnkRecList( # list of object parameters
           nnkIdentDefs(
@@ -914,6 +923,7 @@ static:
                     ident"T"
                   ),
                   nnkEmpty()
+                  )
                 )
               )
             )
@@ -922,10 +932,8 @@ static:
       ):
         echo "ok"
 
-
-
     testRecCase:
-      type Obj[T] = object {.inheritable.}
+      type Obj[T] {.inheritable.} = object
         name: string
         case isFat: bool
         of true:


### PR DESCRIPTION
The preceding example gives `Warning: type pragmas follow the type name; this form of writing pragmas is deprecated`, so I changed it.