### PR TITLE
fix #17898(randomPathName called twice in a row can return the same string on windows)

### DIFF
--- a/lib/std/tempfiles.nim
+++ b/lib/std/tempfiles.nim
@@ -108,7 +108,7 @@ template randomPathName(length: Natural): string =
   var res = newString(length)
   if not nimTempPathState.isInit:
     var time = getMonoTime().ticks
-    when not defined(js) and compileOption("threads"):
+    when compileOption("threads"):
       time = time xor int64(getThreadId())
     nimTempPathState.isInit = true
     nimTempPathState.state = initRand(time)


### PR DESCRIPTION
fix #17898
ref #18149