### PR TITLE
test `experimental:compiletimeFFI` on windows

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -582,7 +582,7 @@ proc runCI(cmd: string) =
     block: # nimHasLibFFI:
       # xxx remove hash once a release is tagged
       execFold("nimble install -y libffi", "nimble install -y libffi@#153322d744666b312dd04b5cbd4e2444415e2260")
-      const nimFFI = "bin/nim_ctffi"
+      const nimFFI = "bin" / "nim_ctffi"
       # no need to bootstrap with koch boot (would be slower)
       let backend = if doUseCpp(): "cpp" else: "c"
       execFold("build with -d:nimHasLibFFI", "nim $1 -d:release -d:nimHasLibFFI -o:$2 compiler/nim.nim" % [backend, nimFFI])

--- a/koch.nim
+++ b/koch.nim
@@ -580,7 +580,8 @@ proc runCI(cmd: string) =
     execFold("Run tester", "nim c -r --putenv:NIM_TESTAMENT_REMOTE_NETWORKING:1 -d:nimStrictMode testament/testament $# all -d:nimCoroutines" % batchParam)
 
     block: # nimHasLibFFI:
-      execFold("nimble install -y libffi", "nimble install -y libffi")
+      # xxx remove hash once a release is tagged
+      execFold("nimble install -y libffi", "nimble install -y libffi@#153322d744666b312dd04b5cbd4e2444415e2260")
       const nimFFI = "bin/nim_ctffi"
       # no need to bootstrap with koch boot (would be slower)
       let backend = if doUseCpp(): "cpp" else: "c"

--- a/koch.nim
+++ b/koch.nim
@@ -580,13 +580,12 @@ proc runCI(cmd: string) =
     execFold("Run tester", "nim c -r --putenv:NIM_TESTAMENT_REMOTE_NETWORKING:1 -d:nimStrictMode testament/testament $# all -d:nimCoroutines" % batchParam)
 
     block: # nimHasLibFFI:
-      when defined(posix): # windows can be handled in future PR's
-        execFold("nimble install -y libffi", "nimble install -y libffi")
-        const nimFFI = "bin/nim.ctffi"
-        # no need to bootstrap with koch boot (would be slower)
-        let backend = if doUseCpp(): "cpp" else: "c"
-        execFold("build with -d:nimHasLibFFI", "nim $1 -d:release -d:nimHasLibFFI -o:$2 compiler/nim.nim" % [backend, nimFFI])
-        execFold("test with -d:nimHasLibFFI", "$1 $2 -r testament/testament --nim:$1 r tests/misc/trunner.nim -d:nimTrunnerFfi" % [nimFFI, backend])
+      execFold("nimble install -y libffi", "nimble install -y libffi")
+      const nimFFI = "bin/nim_ctffi"
+      # no need to bootstrap with koch boot (would be slower)
+      let backend = if doUseCpp(): "cpp" else: "c"
+      execFold("build with -d:nimHasLibFFI", "nim $1 -d:release -d:nimHasLibFFI -o:$2 compiler/nim.nim" % [backend, nimFFI])
+      execFold("test with -d:nimHasLibFFI", "$1 $2 -r testament/testament --nim:$1 r tests/misc/trunner.nim -d:nimTrunnerFfi" % [nimFFI, backend])
 
     execFold("Run nimdoc tests", "nim r nimdoc/tester")
     execFold("Run rst2html tests", "nim r nimdoc/rsttester")


### PR DESCRIPTION
follows https://github.com/nim-lang/Nim/pull/10150 and the recently merged https://github.com/Araq/libffi/pull/6 which adds win64 support for libffi