### PR TITLE
enable select preview flags after a certain version

### DIFF
--- a/config/config.nims
+++ b/config/config.nims
@@ -15,10 +15,9 @@ when defined(nimStrictMode):
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
 
-when (NimMajor, NimMinor) == (1,6) or (NimMajor, NimMinor) <= (1,4):
-  discard
-else:
-  # devel gets bugfixes and some preview flags right away; next release gets bugfixes via a preview flag.
-  # these can be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
+when (NimMajor, NimMinor) >= (1, 7):
+  # consider using instead: `when (NimMajor, NimMinor) > (1,4) and (NimMajor, NimMinor) != (1,6)`
+  # to make those flags available in devel but not 1.6.
+  # These flags be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
   # other `nimPreview` switches can go here, as needed.
   switch("define", "nimPreviewFloatRoundtrip")

--- a/config/config.nims
+++ b/config/config.nims
@@ -14,3 +14,11 @@ when defined(nimStrictMode):
     # switch("hint", "ConvFromXtoItselfNotNeeded")
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
+
+when (NimMajor, NimMinor) == (1,6) or (NimMajor, NimMinor) <= (1,4):
+  discard
+else:
+  # devel gets bugfixes and some preview flags right away; next release gets bugfixes via a preview flag.
+  # these can be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
+  # other `nimPreview` switches can go here, as needed.
+  switch("define", "nimPreviewFloatRoundtrip")

--- a/config/config.nims
+++ b/config/config.nims
@@ -15,9 +15,8 @@ when defined(nimStrictMode):
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
 
-when (NimMajor, NimMinor) >= (1, 7):
-  # consider using instead: `when (NimMajor, NimMinor) > (1,4) and (NimMajor, NimMinor) != (1,6)`
-  # to make those flags available in devel but not 1.6.
+when (NimMajor, NimMinor) >= (1, 5) and (NimMinor mod 2) == 1:
+  # We enable these in devel; the stable release in which these will be enabled is not yet specified.
   # These flags be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
   # other `nimPreview` switches can go here, as needed.
   switch("define", "nimPreviewFloatRoundtrip")

--- a/config/config.nims
+++ b/config/config.nims
@@ -21,3 +21,4 @@ when (NimMajor, NimMinor) >= (1, 7):
   # These flags be overridden using user/project/cmdline flags using `switch("undef", "nimPreviewX")`
   # other `nimPreview` switches can go here, as needed.
   switch("define", "nimPreviewFloatRoundtrip")
+  switch("define", "nimPreviewDotLikeOps")


### PR DESCRIPTION
refs discussion in https://github.com/nim-lang/Nim/pull/18711#discussion_r695583291, see all the arguments presented in that thread.

I'd prefer `when (NimMajor, NimMinor) > (1,4) and (NimMajor, NimMinor) != (1,6)` but using 1.7 as done here is a compromise in the meantime which at least ensures that 1.7 will have those flags enabled.

As discussed in that thread, there's no automatic feature activation going on; these are hand-selected preview flags, each of which can be debated as comment to this PR.

Note that there's no gain in delaying switching on preview flags past next release, all it'd achieve is causing extra work for client code to benefit from what's going to be the default.

## links
see also https://github.com/nim-lang/Nim/wiki/Creating-a-release
