### PR TITLE
fix lots of issues with atlas

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -599,7 +599,8 @@ proc runCI(cmd: string) =
       execFold("build nimsuggest_testing", "nim c -o:bin/nimsuggest_testing -d:release nimsuggest/nimsuggest")
       execFold("Run nimsuggest tests", "nim r nimsuggest/tester")
 
-    execFold("Run atlas tests", "nim c -r -d:atlasTests tools/atlas/atlas.nim clone https://github.com/disruptek/balls")
+    # `outFileCfg` is being read with `-d:atlasTests`, not written to.
+    execFold("Run atlas tests", "nim r -d:atlasTests tools/atlas/atlas.nim --atlasDir:build/atlas --outFileCfg:tools/atlas/tests/nim.cfg clone https://github.com/disruptek/balls")
 
   when not defined(bsd):
     if not doUseCpp:

--- a/tools/atlas/atlas.nim
+++ b/tools/atlas/atlas.nim
@@ -70,7 +70,6 @@ type
       mockupSuccess: bool
 
 const
-  InvalidCommit = "<invalid commit>" # xxx REMOVE, unused
   ProduceTest = false
 
 type
@@ -189,7 +188,7 @@ proc versionToCommit(c: var AtlasContext; d: Dependency): string =
           if commitsAndTags[1].sameVersionAs(d.commit):
             return commitsAndTags[0]
         of strictlyLess:
-          if d.commit == InvalidCommit or not commitsAndTags[1].sameVersionAs(d.commit):
+          if not commitsAndTags[1].sameVersionAs(d.commit):
             return commitsAndTags[0]
         of strictlyGreater:
           if commitsAndTags[1].sameVersionAs(d.commit):
@@ -249,7 +248,7 @@ proc toName(p: string): PackageName =
     result = PackageName p
 
 proc needsCommitLookup(commit: string): bool {.inline.} =
-  '.' in commit or commit == InvalidCommit
+  '.' in commit
 
 proc isShortCommitHash(commit: string): bool {.inline.} =
   commit.len >= 4 and commit.len < 40
@@ -271,10 +270,7 @@ proc checkoutCommit(c: var AtlasContext; w: Dependency) =
         let (cc, status) = exec(c, GitCurrentCommit, [])
         let currentCommit = strutils.strip(cc)
         if requiredCommit == "" or status != 0:
-          if requiredCommit == "" and w.commit == InvalidCommit:
-            warn c, w.name, "package has no tagged releases"
-          else:
-            warn c, w.name, "cannot find specified version/commit", w.commit
+          warn c, w.name, "cannot find specified version/commit", w.commit
         else:
           if currentCommit != requiredCommit:
             # checkout the later commit:

--- a/tools/atlas/atlas.nim
+++ b/tools/atlas/atlas.nim
@@ -156,7 +156,6 @@ proc message(c: var AtlasContext; category: string; p: PackageName; args: vararg
     msg.add ' '
     msg.add a
   stdout.writeLine msg
-  doAssert false, msg
   inc c.errors
 
 proc warn(c: var AtlasContext; p: PackageName; args: varargs[string]) =
@@ -244,7 +243,6 @@ proc toUrl(c: var AtlasContext; p: string): string =
     result = c.p.getOrDefault(unicode.toLower p)
   if result.len == 0:
     inc c.errors
-    doAssert false
 
 proc toName(p: string): PackageName =
   if p.isUrl:
@@ -344,12 +342,12 @@ proc collectNewDeps(c: var AtlasContext; work: var seq[Dependency];
           tokens[1] = "=="
           tokens.add commit
         if tokens.len >= 3:
-          # xxx handle tokens.len > 3
+          # xxx handle tokens.len > 3, refs bug #18755
           dep.commit = tokens[2]
           dep.rel = case tokens[1]
           of "<": strictlyLess
           of ">": strictlyGreater
-          else: normal # xxx support other
+          else: normal # xxx support other tokens, refs bug #18755
           maybeAdd()
 
     result.add dep.name.string / nimbleInfo.srcDir
@@ -461,8 +459,7 @@ proc main =
     let deps = clone(c, args[0])
     patchNimCfg c, deps
     when MockupRun:
-      if not c.mockupSuccess:
-        error "There were problems."
+      doAssert c.mockupSuccess
     else:
       if c.errors > 0:
         error "There were problems."

--- a/tools/atlas/testdata.nim
+++ b/tools/atlas/testdata.nim
@@ -46,8 +46,7 @@ const
     toData("grok", GitMergeBase, 0, "4e6526a91a23eaec778184e16ce9a34d25d48bdc\n62707b8ac684efac35d301dbde57dc750880268e\n349c15fd1e03f1fcdd81a1edefba3fa6116ab911\n"),
     toData("grok", GitCheckout, 0, "62707b8ac684efac35d301dbde57dc750880268e"),
 
-    toData("nim-bytes2human", GitDiff, 0, ""),
-    toData("nim-bytes2human", GitTags, 0, ""),
+    toData("nim-bytes2human", GitPull, 0, "Already up to date.\n"),
     toData("nim-bytes2human", GitCurrentcommit, 0, "ec2c1a758cabdd4751a06c8ebf2b923f19e32731\n")
   ]
 

--- a/tools/atlas/tests/nim.cfg
+++ b/tools/atlas/tests/nim.cfg
@@ -1,11 +1,11 @@
 ############# begin Atlas config section ##########
 --noNimblePath
---path:"../balls"
---path:"../grok"
---path:"../ups"
---path:"../sync"
---path:"../npeg/src"
---path:"../testes"
---path:"../grok"
---path:"../nim-bytes2human/src"
+--path:"../../../build/atlas/balls"
+--path:"../../../build/atlas/grok"
+--path:"../../../build/atlas/ups"
+--path:"../../../build/atlas/sync"
+--path:"../../../build/atlas/npeg/src"
+--path:"../../../build/atlas/testes"
+--path:"../../../build/atlas/grok"
+--path:"../../../build/atlas/nim-bytes2human/src"
 ############# end Atlas config section   ##########


### PR DESCRIPTION
* fix https://github.com/nim-lang/Nim/issues/18753
* fix https://github.com/nim-lang/Nim/issues/18750
* fix https://github.com/nim-lang/Nim/issues/18751
* adds add (for now required) flag `--atlasdir:dir` specifying root of atlas dirs; the previous hard-coded logic was flawed (refs https://github.com/nim-lang/Nim/issues/18750)
* adds a (for now required) flag specifying where to write cfg file `--outfilecfg:file`
* lots of code cleanups

## after this PR
this now works instead of failing (with several unrelated errors)
```
bin/nim r tools/atlas/atlas.nim --atlasdir:/tmp/d06e/atlas --outfilecfg:/tmp/d06e/my.nim.cfg clone https://github.com/disruptek/balls
```

note, the --path generated are correct wrt --atlasDir and --outFileCfg

## future work
- [ ] add support for `NIM_ATLAS_DIR`, analog to `NIMBLE_DIR`
- [ ] atlas should eventually be able to install a dependencies as part of bootstrapping process (`sh build_all.sh`), not just for tools/compiler but also for stdlib; this is the only way to avoid endless discussions regarding whether something should belong to stdlib or nimble package (while allowing stdlib modules to depend on such modules); towards this end, we should make atlas install a dummy dependency as part of bootstrap to ensure this process works and keeps working (eg a lib/std/private/usesatlas.nim can be added which imports some atlas-installed package); once this is stable, actual dependencies can be used.

## questions for reviewer
`outfilecfg` will contain `--noNimblePath`; how can this work? won't that prevent users from using nimble installed packages?
```
############# begin Atlas config section ##########
--noNimblePath
--path:"../balls"
--path:"../grok"
...
############# end Atlas config section   ##########
```

what's the exact intention behind `--noNimblePath`, and can we use https://github.com/nim-lang/RFCs/issues/291 instead, which would be far more flexible?
