### PR TITLE
add missing docs

### DIFF
--- a/lib/nimrtl.nim
+++ b/lib/nimrtl.nim
@@ -26,6 +26,7 @@ batchable: false
 ## * unicode
 ## * pegs
 ## * ropes
+## * cstrutils
 ##
 
 when system.appType != "lib":


### PR DESCRIPTION
Before the `cstrutils` module is missing

![image](https://user-images.githubusercontent.com/43030857/131125670-c883f11b-fad1-4a10-bca5-448ae3e4cf79.png)
