### PR TITLE
move PNode.comment to a side channel, reducing memory usage during compilation by a factor 1.25x

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -997,11 +997,15 @@ type Gconfig = object
   # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
   # reduces memory usage given that `PNode` is the most allocated type by far.
   comments: Table[int, string] # nodeId => comment
+  useIc*: bool
 
 var gconfig {.threadvar.}: Gconfig
 
+proc setUseIc*(useIc: bool) = gconfig.useIc = useIc
+
 proc comment*(n: PNode): string =
-  if nfHasComment in n.flags:
+  if nfHasComment in n.flags and not gconfig.useIc:
+    # IC doesn't track comments, see `packed_ast`, so this could fail
     result = gconfig.comments[n.nodeId]
 
 proc `comment=`*(n: PNode, a: string) =

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -1003,10 +1003,11 @@ proc comment*(n: PNode): string =
   gconfig.comments.getOrDefault(n.nodeId)
 
 proc `comment=`*(n: PNode, a: string) =
+  let id = n.nodeId
   if a.len > 0:
-    gconfig.comments[n.nodeId] = a
+    gconfig.comments[id] = a
   else:
-    gconfig.comments.del(n.nodeId)
+    gconfig.comments.del(id)
 
 # BUGFIX: a module is overloadable so that a proc can have the
 # same name as an imported module. This is necessary because of

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -8,7 +8,7 @@
 #
 
 # This module handles the parsing of command line arguments.
-
+from ast import setUseIc
 
 # We do this here before the 'import' statement so 'defined' does not get
 # confused with 'TGCMode.gcMarkAndSweep' etc.
@@ -862,6 +862,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       of "v2": conf.symbolFiles = v2Sf
       of "stress": conf.symbolFiles = stressTest
       else: localError(conf, info, "invalid option for --incremental: " & arg)
+    setUseIc(conf.symbolFiles != disabledSf)
   of "skipcfg":
     processOnOffSwitchG(conf, {optSkipSystemConfigFile}, arg, pass, info)
   of "skipprojcfg":

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -178,7 +178,7 @@ proc rawSkipComment(p: var Parser, node: PNode) =
           rhs.add p.tok.literal
       else:
         rhs.add p.tok.literal
-      node.comment = rhs
+      node.comment = move rhs
     else:
       parMessage(p, errInternal, "skipComment")
     getTok(p)

--- a/compiler/parser.nim
+++ b/compiler/parser.nim
@@ -1826,13 +1826,10 @@ proc parseRoutine(p: var Parser, kind: TNodeKind): PNode =
     if result.comment.len == 0:
       # proc fn*(a: int): int = a ## foo
       # => moves comment `foo` to `fn`
-      var c1 = result.comment
-      var c2 = body[0].comment
-      if c1.len > 0 or c2.len > 0:
-        swap(c1, c2)
-        result.comment = c1
-        body[0].comment = c2
-    else: discard # xxx either `assert false` or issue a warning (otherwise we'll never know of this edge case)
+      result.comment = body[0].comment
+      body[0].comment = ""
+    else:
+      assert false, p.lex.config$body.info # avoids hard to track bugs, fail early.
 
 proc newCommentStmt(p: var Parser): PNode =
   #| commentStmt = COMMENT


### PR DESCRIPTION
the comment field is rarely used yet each PNode has to pay the price, until this PR.

TNode.sizeof reduces from 40 to 32; interestingly, the peakmem usage drops by a very similar factor:

nim --eval:'echo 40/32'
1.25

nim --eval:'echo 847 / 670'
1.264179104477612

which can be attributed to fact that TNode allocations dwarf all other gc allocations, as demonstrated in other PRs (eg https://github.com/nim-lang/Nim/pull/13067)

result with --hint:GCStats:


## before
Hint: gc: refc; opt: speed; options: -d:release
187965 lines; 23.781s; 847.062MiB peakmem; proj: /Users/timothee/git_clone/nim/Nim_temp6/compiler/nim.nim; out: /Users/timothee/git_clone/nim/Nim_temp6/bin/nim.devel.d4 [SuccessX]
[GC] total memory: 888209408
[GC] occupied memory: 718308016
[GC] stack scans: 50083
[GC] stack cells: 4230
[GC] cycle collections: 0
[GC] max threshold: 0
[GC] zct capacity: 2304
[GC] max cycle table size: 0
[GC] max pause time [ms]: 0
[GC] max stack size: 95952

## after
Hint: gc: refc; opt: speed; options: -d:release
187985 lines; 8.223s; 670.09MiB peakmem; proj: /Users/timothee/git_clone/nim/Nim_prs/compiler/nim.nim; out: /Users/timothee/git_clone/nim/Nim_prs/bin/nim.pr_PNode_comment_sidechannel.d1 [SuccessX]
[GC] total memory: 702640128
[GC] occupied memory: 653233632
[GC] stack scans: 50194
[GC] stack cells: 4201
[GC] cycle collections: 0
[GC] max threshold: 0
[GC] zct capacity: 2304
[GC] max cycle table size: 0
[GC] max pause time [ms]: 0
[GC] max stack size: 95024

## links
* supersedes https://github.com/nim-lang/Nim/pull/10054 (much simpler than that prior attempt)
* will possibly help with https://github.com/nim-lang/RFCs/issues/150 (see also https://github.com/nim-lang/Nim/pull/8903 to expose comments in macros), but that's entirely optional

## EDIT 1
unfortunately this involves a tradeoff bw compile times and memory consumption:
with -d:danger:
new:
188426 lines; 7.677s; 673.766MiB peakmem; 
old:
187965 lines; 7.011s; 847.379MiB peakmem

(-d:release shows similar ratios for the time)

the bulk of the performance difference lies in the table accesses; more precisely:
```nim
roc comment*(n: PNode): string {.inline.} =
  count1.inc
  count4 = max(gconfig.comments.len, count4)
  gconfig.comments.getOrDefault(n.nodeId)

proc `comment=`*(n: PNode, a: string) {.inline.} =
  let id = n.nodeId
  if a.len > 0:
    count2.inc
    gconfig.comments[id] = a
  else:
    count3.inc
    if id in gconfig.comments:
      count3b.inc
      gconfig.comments.del(id)
    # gconfig.comments.del(id)
  count4 = max(gconfig.comments.len, count4)
```
(count1, count2, count3, count3b, count4)
(8831908, 33607, 23779703, 1278, 32330)

=> biggest cost is `if id in gconfig.comments:`

better table insertion/deletion or hashing algorithms might help here (`hashWangYi1` is expensive!)

## EDIT 2
solved via https://github.com/nim-lang/Nim/pull/18760#discussion_r697919498

## future work
- [ ] revive https://github.com/nim-lang/Nim/pull/8903