### PR TITLE
fix #9778(pairs iterator calling a helper proc with tuple return type will cut the iterator yield into half)

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -191,8 +191,11 @@ proc someSymFromImportTable*(c: PContext; name: PIdent; ambiguous: var bool): PS
       for s in symbols(im, marked, name, c.graph):
         if result == nil:
           result = s
+          if result.kind notin symSet:
+            ambiguous = true
+            break outer
         else:
-          if s.kind notin symSet or result.kind notin symSet:
+          if s.kind notin symSet:
             ambiguous = true
             break outer
 

--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -75,22 +75,17 @@ proc closeScope*(c: PContext) =
   rawCloseScope(c)
 
 iterator allScopes*(scope: PScope): PScope =
-  ## Iterates the current scope and all of its parent scopes.
   var current = scope
   while current != nil:
     yield current
     current = current.parent
 
 iterator localScopesFrom*(c: PContext; scope: PScope): PScope =
-  ## Iterates the current scope and all of its parent scopes
-  ## except the top-level one.
   for s in allScopes(scope):
     if s == c.topLevelScope: break
     yield s
 
 proc skipAlias*(s: PSym; n: PNode; conf: ConfigRef): PSym =
-  ## Skips symbol of `skAlis` kind. `skAlias` is used in
-  ## deprecated rule: {.deprecated: [...].}
   if s == nil or s.kind != skAlias:
     result = s
   else:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -397,7 +397,15 @@ proc transformYield(c: PTransf, n: PNode): PNode =
         result.add(asgnTo(lhs, rhs))
   else:
     if c.transCon.forStmt[0].kind == nkVarTuple:
-      if e.kind notin {nkAddr, nkHiddenAddr}:
+      var notLiteralTuple = false
+      var ev = e.skipConv
+      if ev.kind == nkTupleConstr:
+        for i in ev:
+          if i.kind notin nkLiterals:
+            notLiteralTuple = true
+            break
+
+      if e.kind notin {nkAddr, nkHiddenAddr} and notLiteralTuple:
         var tmp = newTemp(c, e.typ, e.info)
         let v = newNodeI(nkVarSection, e.info)
         v.addVar(tmp, e)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -397,8 +397,6 @@ proc transformYield(c: PTransf, n: PNode): PNode =
         result.add(asgnTo(lhs, rhs))
   else:
     if c.transCon.forStmt[0].kind == nkVarTuple:
-
-      if false: discard
       if e.kind notin {nkAddr, nkHiddenAddr}:
         var tmp = newTemp(c, e.typ, e.info)
         let v = newNodeI(nkVarSection, e.info)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -401,7 +401,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
       var ev = e.skipConv
       if ev.kind == nkTupleConstr:
         for i in ev:
-          if i.kind notin nkLiterals:
+          if not isConstExpr(i):
             notLiteralTuple = true
             break
       else:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -377,23 +377,22 @@ proc transformYield(c: PTransf, n: PNode): PNode =
           let lhs = c.transCon.forStmt[i]
           let rhs = transform(c, v)
           result.add(asgnTo(lhs, rhs))
+    elif e.kind in nkCallKinds:
+      var tmp = newTemp(c, e.typ, e.info)
+      let v = newNodeI(nkVarSection, e.info)
+      v.addVar(tmp, e)
+
+      result.add transform(c, v)
+
+      for i in 0..<c.transCon.forStmt.len - 2:
+        let lhs = c.transCon.forStmt[i]
+        let rhs = transform(c, newTupleAccess(c.graph, tmp, i))
+        result.add(asgnTo(lhs, rhs))
     else:
-      if e.kind in nkCallKinds:
-        var tmp = newTemp(c, e.typ, e.info)
-        let v = newNodeI(nkVarSection, e.info)
-        v.addVar(tmp, e)
-
-        result.add transform(c, v)
-
-        for i in 0..<c.transCon.forStmt.len - 2:
-          let lhs = c.transCon.forStmt[i]
-          let rhs = transform(c, newTupleAccess(c.graph, tmp, i))
-          result.add(asgnTo(lhs, rhs))
-      else:
-        for i in 0..<c.transCon.forStmt.len - 2:
-          let lhs = c.transCon.forStmt[i]
-          let rhs = transform(c, newTupleAccess(c.graph, e, i))
-          result.add(asgnTo(lhs, rhs))
+      for i in 0..<c.transCon.forStmt.len - 2:
+        let lhs = c.transCon.forStmt[i]
+        let rhs = transform(c, newTupleAccess(c.graph, e, i))
+        result.add(asgnTo(lhs, rhs))
   else:
     if c.transCon.forStmt[0].kind == nkVarTuple:
       if skipConv(e).kind in nkCallKinds + {nkTupleConstr}:

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -362,8 +362,8 @@ proc transformYield(c: PTransf, n: PNode): PNode =
   # c.transCon.forStmt.len == 3 means that there is one for loop variable
   # and thus no tuple unpacking:
   if e.typ.isNil: return result # can happen in nimsuggest for unknown reasons
-  e = skipConv(e)
   if c.transCon.forStmt.len != 3:
+    e = skipConv(e)
     if e.kind == nkTupleConstr:
       for i in 0..<e.len:
         var v = e[i]
@@ -396,7 +396,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
           result.add(asgnTo(lhs, rhs))
   else:
     if c.transCon.forStmt[0].kind == nkVarTuple:
-      if e.kind in nkCallKinds + {nkTupleConstr}:
+      if skipConv(e).kind in nkCallKinds + {nkTupleConstr}:
         var tmp = newTemp(c, e.typ, e.info)
         let v = newNodeI(nkVarSection, e.info)
         v.addVar(tmp, e)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -404,6 +404,8 @@ proc transformYield(c: PTransf, n: PNode): PNode =
           if i.kind notin nkLiterals:
             notLiteralTuple = true
             break
+      else:
+        notLiteralTuple = true
 
       if e.kind notin {nkAddr, nkHiddenAddr} and notLiteralTuple:
         var tmp = newTemp(c, e.typ, e.info)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -389,6 +389,8 @@ proc transformYield(c: PTransf, n: PNode): PNode =
         let rhs = transform(c, newTupleAccess(c.graph, tmp, i))
         result.add(asgnTo(lhs, rhs))
     else:
+      # Unpack the tuple into the loop variables
+      # XXX: BUG: what if `n` is an expression with side-effects?
       for i in 0..<c.transCon.forStmt.len - 2:
         let lhs = c.transCon.forStmt[i]
         let rhs = transform(c, newTupleAccess(c.graph, e, i))

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -368,15 +368,15 @@ proc transformYield(c: PTransf, n: PNode): PNode =
       for i in 0..<e.len:
         var v = e[i]
         if v.kind == nkExprColonExpr: v = v[1]
-        # if c.transCon.forStmt[i].kind == nkVarTuple:
-        #   for j in 0..<c.transCon.forStmt[i].len-1:
-        #     let lhs = c.transCon.forStmt[i][j]
-        #     let rhs = transform(c, newTupleAccess(c.graph, v, j))
-        #     result.add(asgnTo(lhs, rhs))
-        # else:
-        let lhs = c.transCon.forStmt[i]
-        let rhs = transform(c, v)
-        result.add(asgnTo(lhs, rhs))
+        if c.transCon.forStmt[i].kind == nkVarTuple:
+          for j in 0..<c.transCon.forStmt[i].len-1:
+            let lhs = c.transCon.forStmt[i][j]
+            let rhs = transform(c, newTupleAccess(c.graph, v, j))
+            result.add(asgnTo(lhs, rhs))
+        else:
+          let lhs = c.transCon.forStmt[i]
+          let rhs = transform(c, v)
+          result.add(asgnTo(lhs, rhs))
     else:
       if e.kind in nkCallKinds:
         var tmp = newTemp(c, e.typ, e.info)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -377,8 +377,8 @@ proc transformYield(c: PTransf, n: PNode): PNode =
           let lhs = c.transCon.forStmt[i]
           let rhs = transform(c, v)
           result.add(asgnTo(lhs, rhs))
-    elif e.kind notin {nkAddr, nkHiddenAddr}: # no need to generate temporary variable for address operation
-      # XXX: do not use temporary for nodes which cannot have side-effects
+    elif e.kind notin {nkAddr, nkHiddenAddr}: # no need to generate temp for address operation
+      # TODO do not use temp for nodes which cannot have side-effects
       var tmp = newTemp(c, e.typ, e.info)
       let v = newNodeI(nkVarSection, e.info)
       v.addVar(tmp, e)
@@ -407,7 +407,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
         notLiteralTuple = true
 
       if e.kind notin {nkAddr, nkHiddenAddr} and notLiteralTuple:
-        # XXX: do not use temporary for nodes which cannot have side-effects
+        # TODO do not use temp for nodes which cannot have side-effects
         var tmp = newTemp(c, e.typ, e.info)
         let v = newNodeI(nkVarSection, e.info)
         v.addVar(tmp, e)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -435,10 +435,11 @@ proc transformYield(c: PTransf, n: PNode): PNode =
     # we need to introduce new local variables:
     result.add(introduceNewLocalVars(c, c.transCon.forLoopBody))
   if result.len > 0:
-    var changeNode = result[0]
-    changeNode.info = c.transCon.forStmt.info
-    # for i, child in changeNode:
-    #   child.info = changeNode.info
+    for idx in 0 ..< result.len:
+      var changeNode = result[idx]
+      changeNode.info = c.transCon.forStmt.info
+      for i, child in changeNode:
+        child.info = changeNode.info
 
 proc transformAddrDeref(c: PTransf, n: PNode, a, b: TNodeKind): PNode =
   result = transformSons(c, n)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -377,7 +377,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
           let lhs = c.transCon.forStmt[i]
           let rhs = transform(c, v)
           result.add(asgnTo(lhs, rhs))
-    elif e.kind in nkCallKinds + {nkIfExpr, nkBlockExpr, nkStmtListExpr}:
+    elif e.kind notin {nkAddr, nkHiddenAddr}:
       var tmp = newTemp(c, e.typ, e.info)
       let v = newNodeI(nkVarSection, e.info)
       v.addVar(tmp, e)
@@ -397,7 +397,9 @@ proc transformYield(c: PTransf, n: PNode): PNode =
         result.add(asgnTo(lhs, rhs))
   else:
     if c.transCon.forStmt[0].kind == nkVarTuple:
-      if skipConv(e).kind in nkCallKinds + {nkTupleConstr, nkIfExpr, nkBlockExpr, nkStmtListExpr}:
+
+      if false: discard
+      if e.kind notin {nkAddr, nkHiddenAddr}:
         var tmp = newTemp(c, e.typ, e.info)
         let v = newNodeI(nkVarSection, e.info)
         v.addVar(tmp, e)

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -377,7 +377,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
           let lhs = c.transCon.forStmt[i]
           let rhs = transform(c, v)
           result.add(asgnTo(lhs, rhs))
-    elif e.kind in nkCallKinds:
+    elif e.kind in nkCallKinds + {nkIfExpr, nkBlockExpr, nkStmtListExpr}:
       var tmp = newTemp(c, e.typ, e.info)
       let v = newNodeI(nkVarSection, e.info)
       v.addVar(tmp, e)
@@ -395,7 +395,7 @@ proc transformYield(c: PTransf, n: PNode): PNode =
         result.add(asgnTo(lhs, rhs))
   else:
     if c.transCon.forStmt[0].kind == nkVarTuple:
-      if skipConv(e).kind in nkCallKinds + {nkTupleConstr}:
+      if skipConv(e).kind in nkCallKinds + {nkTupleConstr, nkIfExpr, nkBlockExpr, nkStmtListExpr}:
         var tmp = newTemp(c, e.typ, e.info)
         let v = newNodeI(nkVarSection, e.info)
         v.addVar(tmp, e)

--- a/tests/stdlib/tyield.nim
+++ b/tests/stdlib/tyield.nim
@@ -1,0 +1,256 @@
+discard """
+  targets: "c cpp js"
+"""
+
+import std/[sugar, algorithm]
+
+block:
+  var x = @[(6.0, 6, '6'),
+            (5.0, 5, '5'),
+            (4.0, 4, '4'),
+            (3.0, 3, '3'),
+            (2.0, 2, '2'),
+            (1.0, 1, '1')]
+
+  let y = x.reversed
+
+  block:
+    let res = collect:
+      for (f, i, c) in x:
+        (f, i, c)
+
+    doAssert res == x
+
+  iterator popAscending[T](q: var seq[T]): T =
+    while q.len > 0: yield q.pop
+
+  block:
+    var res = collect:
+      for f, i, c in popAscending(x):
+        (f, i, c)
+
+    doAssert res == y
+
+    let z = reversed(res)
+    let res2 = collect:
+      for (f, i, c) in popAscending(res):
+        (f, i, c)
+
+    doAssert res2 == z
+
+
+block:
+  var visits = 0
+  block:
+    proc bar(): (int, int) =
+      inc visits
+      (visits, visits)
+
+    iterator foo(): (int, int) =
+      yield bar()
+
+    for a, b in foo():
+      doAssert a == b
+
+    doAssert visits == 1
+
+  block:
+    proc iterAux(a: seq[int], i: var int): (int, string) =
+      result = (a[i], $a[i])
+      inc i
+
+    iterator pairs(a: seq[int]): (int, string) =
+      var i = 0
+      while i < a.len:
+        yield iterAux(a, i)
+
+    var x = newSeq[int](10)
+    for i in 0 ..< x.len:
+      x[i] = i
+
+    let res = collect:
+      for k, v in x:
+        (k, v)
+
+    let expected = collect:
+      for i in 0 ..< x.len:
+        (i, $i)
+
+    doAssert res == expected
+
+  block:
+    proc bar(): (int, int, int) =
+      inc visits
+      (visits, visits, visits)
+
+    iterator foo(): (int, int, int) =
+      yield bar()
+
+    for a, b, c in foo():
+      doAssert a == b
+
+    doAssert visits == 2
+
+
+  block:
+
+    proc bar(): int =
+      inc visits
+      visits
+
+    proc car(): int =
+      inc visits
+      visits
+
+    iterator foo(): (int, int) =
+      yield (bar(), car())
+      yield (bar(), car())
+
+    for a, b in foo():
+      doAssert b == a + 1
+
+    doAssert visits == 6
+
+
+  block:
+    proc bar(): (int, int) =
+      inc visits
+      (visits, visits)
+
+    proc t2(): int = 99
+
+    iterator foo(): (int, int) =
+      yield (12, t2())
+      yield bar()
+
+    let res = collect:
+      for (a, b) in foo():
+        (a, b)
+
+    doAssert res == @[(12, 99), (7, 7)]
+    doAssert visits == 7
+
+  block:
+    proc bar(): (int, int) =
+      inc visits
+      (visits, visits)
+
+    proc t2(): int = 99
+
+    iterator foo(): (int, int) =
+      yield ((12, t2()))
+      yield (bar())
+
+    let res = collect:
+      for (a, b) in foo():
+        (a, b)
+
+    doAssert res == @[(12, 99), (8, 8)]
+    doAssert visits == 8
+
+  block:
+    proc bar(): (int, int) =
+      inc visits
+      (visits, visits)
+
+    proc t1(): int = 99
+    proc t2(): int = 99
+
+    iterator foo(): (int, int) =
+      yield (t1(), t2())
+      yield bar()
+
+    let res = collect:
+      for a, b in foo():
+        (a, b)
+
+    doAssert res == @[(99, 99), (9, 9)]
+    doAssert visits == 9
+
+
+  block:
+    proc bar(): ((int, int), string) =
+      inc visits
+      ((visits, visits), $visits)
+
+    proc t2(): int = 99
+
+    iterator foo(): ((int, int), string) =
+      yield ((1, 2), $t2())
+      yield bar()
+
+    let res = collect:
+      for a, b in foo():
+        (a, b)
+
+    doAssert res == @[((1, 2), "99"), ((10, 10), "10")]
+    doAssert visits == 10
+
+
+  block:
+    proc bar(): (int, int) =
+      inc visits
+      (visits, visits)
+
+    iterator foo(): (int, int) =
+      yield (for i in 0 ..< 10: discard bar(); bar())
+      yield (bar())
+
+    let res = collect:
+      for (a, b) in foo():
+        (a, b)
+
+    doAssert res == @[(21, 21), (22, 22)]
+
+  block:
+    proc bar(): (int, int) =
+      inc visits
+      (visits, visits)
+
+    proc t2(): int = 99
+
+    iterator foo(): (int, int) =
+      yield if true: bar() else: (t2(), t2())
+      yield (bar())
+
+    let res = collect:
+      for a, b in foo():
+        (a, b)
+
+    doAssert res == @[(23, 23), (24, 24)]
+
+
+block:
+  iterator foo(): (int, int, int) =
+    var time = 777
+    yield (1, time, 3)
+
+  let res = collect:
+    for a, b, c in foo():
+      (a, b, c)
+
+  doAssert res == @[(1, 777, 3)]
+
+block:
+  iterator foo(): (int, int, int) =
+    var time = 777
+    yield (1, time, 3)
+
+  let res = collect:
+    for t in foo():
+      (t[0], t[1], t[2])
+
+  doAssert res == @[(1, 777, 3)]
+
+
+block:
+  proc bar(): (int, int, int) =
+    (1, 2, 3)
+  iterator foo(): (int, int, int) =
+    yield bar()
+
+  let res = collect:
+    for a, b, c in foo():
+      (a, b, c)
+
+  doAssert res == @[(1, 2, 3)]


### PR DESCRIPTION
fix #9778

**TODO**
- [x] tests

Before it generates inefficient code for procs without side-effects and wrong code for procs with side-effects. Because these procs are called multiple times wrongly.

With this PR, it should generate better code or at least as good code as the old one for most common cases. `for (i, j) in x` still generates worse code than `for i, j in x` for some cases( see case two).

# Case
## Case 1

```nim
block:
  var visits = 0
  proc bar(): (int, int) =
    inc visits
    (visits, visits)

  proc t2(): int = 99

  iterator foo(): (int, int) =
    yield ((12, t2()))
    yield (bar())

  for (a, b) in foo():
    echo (a, b)
```
generates:

### Before

```c
T3_.Field0 = ((NI) 12);
T3_.Field1 = t2_texample_8(); // -----> here 
a_texample_11 = T3_.Field0;
T4_.Field0 = ((NI) 12);
T4_.Field1 = t2_texample_8(); // -----> here 
b_texample_12 = T4_.Field1;
nimZeroMem((void*)T5_, sizeof(tyArray__nHXaesL0DJZHyVS07ARPRA));
T6_.Field0 = a_texample_11;
T6_.Field1 = b_texample_12;
T5_[0] = dollar__texample_49(T6_);
echoBinSafe(T5_, 1);
T7_ = bar_texample_2();  // -----> here 
a_texample_11 = T7_.Field0;
T8_ = bar_texample_2(); // -----> here 
b_texample_12 = T8_.Field1;
nimZeroMem((void*)T9_, sizeof(tyArray__nHXaesL0DJZHyVS07ARPRA));
T10_.Field0 = a_texample_11;
T10_.Field1 = b_texample_12;
```

### After

```c
colontmp_.Field0 = ((NI) 12);
colontmp_.Field1 = t2_texample_8();
a_texample_11 = colontmp_.Field0;
b_texample_12 = colontmp_.Field1;
nimZeroMem((void*)T3_, sizeof(tyArray__nHXaesL0DJZHyVS07ARPRA));
T4_.Field0 = a_texample_11;
T4_.Field1 = b_texample_12;
T3_[0] = dollar__texample_49(T4_);
echoBinSafe(T3_, 1);
colontmp__2 = bar_texample_2();
a_texample_11 = colontmp__2.Field0;
b_texample_12 = colontmp__2.Field1;
nimZeroMem((void*)T5_, sizeof(tyArray__nHXaesL0DJZHyVS07ARPRA));
T6_.Field0 = a_texample_11;
T6_.Field1 = b_texample_12;
```
## Case 2
```nim
block:
  iterator foo(): (int, int, int) =
    var time = 777
    yield (1, time, 3)

  for (a, b, c) in foo():
    echo (a, b, c)
```

### Before

```c
NI time;
time = ((NI) 777);
T3_.Field0 = ((NI) 1);
T3_.Field1 = time;
T3_.Field2 = ((NI) 3);
a_texample_14 = T3_.Field0;
T4_.Field0 = ((NI) 1);
T4_.Field1 = time;
T4_.Field2 = ((NI) 3);
b_texample_15 = T4_.Field1;
T5_.Field0 = ((NI) 1);
T5_.Field1 = time;
T5_.Field2 = ((NI) 3);
c_texample_16 = T5_.Field2;
```

### After

```c
NI time;
time = ((NI) 777);
colontmp_.Field0 = ((NI) 1);
colontmp_.Field1 = time;
colontmp_.Field2 = ((NI) 3);
a_texample_12 = colontmp_.Field0;
b_texample_13 = colontmp_.Field1;
c_texample_14 = colontmp_.Field2;
```

## Case 3
```nim
block:
  iterator foo(): (int, int, int) =
    yield (1, 777, 3)

  for (a, b, c) in foo():
    echo (a, b, c)
```

### Before & After
```c
a_texample_11 = ((NI) 1);
b_texample_12 = ((NI) 777);
c_texample_13 = ((NI) 3);
```

## Case 4
```nim
block:
  proc bar(): (int, int, int) =
    (1, 2, 3)
  iterator foo(): (int, int, int) =
    yield bar()

  for a, b, c in foo():
    echo (a, b, c)
```

### Before
```nim
T3_ = bar_texample_1();
a_texample_13 = T3_.Field0;
T4_ = bar_texample_1();
b_texample_14 = T4_.Field1;
T5_ = bar_texample_1();
c_texample_15 = T5_.Field2;
```

### After
```c
colontmp_ = bar_texample_1();
a_texample_13 = colontmp_.Field0;
b_texample_14 = colontmp_.Field1;
c_texample_15 = colontmp_.Field2;
```
