### PR TITLE
testament --megatest:off now makes tests non-joinable so that they all run

### DIFF
--- a/testament/categories.nim
+++ b/testament/categories.nim
@@ -541,7 +541,7 @@ proc processSingleTest(r: var TResults, cat: Category, options, test: string, ta
 proc isJoinableSpec(spec: TSpec): bool =
   # xxx simplify implementation using a whitelist of fields that are allowed to be
   # set to non-default values (use `fieldPairs`), to avoid issues like bug #16576.
-  result = not spec.sortoutput and
+  result = useMegatest and not spec.sortoutput and
     spec.action == actionRun and
     not fileExists(spec.file.changeFileExt("cfg")) and
     not fileExists(spec.file.changeFileExt("nims")) and

--- a/testament/testament.nim
+++ b/testament/testament.nim
@@ -28,6 +28,7 @@ var useColors = true
 var backendLogging = true
 var simulate = false
 var optVerbose = false
+var useMegatest = true
 
 proc verboseCmd(cmd: string) =
   if optVerbose:
@@ -645,7 +646,6 @@ proc main() =
   var targetsStr = ""
   var isMainProcess = true
   var skipFrom = ""
-  var useMegatest = true
 
   var p = initOptParser()
   p.next()


### PR DESCRIPTION
semantics before this PR didn't make sense as we'd end up with tests that don't run