### PR TITLE
Fixed type inference for 'set` and 'tuple'

### DIFF
--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -78,7 +78,7 @@ template semIdeForTemplateOrGeneric(c: PContext; n: PNode;
 proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
   let x = arg.skipConv
   if (x.kind == nkCurly and formal.kind == tySet and formal.base.kind != tyGenericParam) or
-    (x.kind in {nkPar, nkTupleConstr} and formal.kind != tyBuiltInTypeClass):
+    (x.kind in {nkPar, nkTupleConstr}) and formal.kind notin {tyUntyped, tyBuiltInTypeClass}:
     changeType(c, x, formal, check=true)
   result = arg
   result = skipHiddenSubConv(result, c.graph, c.idgen)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -77,7 +77,8 @@ template semIdeForTemplateOrGeneric(c: PContext; n: PNode;
 
 proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
   let x = arg.skipConv
-  if x.kind in {nkPar, nkTupleConstr, nkCurly} and formal.kind != tyUntyped:
+  if (x.kind == nkCurly and formal.kind != tySet or
+    x.kind in {nkPar, nkTupleConstr}) and formal.kind != tyBuiltInTypeClass:
     changeType(c, x, formal, check=true)
   result = arg
   result = skipHiddenSubConv(result, c.graph, c.idgen)

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -77,8 +77,8 @@ template semIdeForTemplateOrGeneric(c: PContext; n: PNode;
 
 proc fitNodePostMatch(c: PContext, formal: PType, arg: PNode): PNode =
   let x = arg.skipConv
-  if (x.kind == nkCurly and formal.kind != tySet or
-    x.kind in {nkPar, nkTupleConstr}) and formal.kind != tyBuiltInTypeClass:
+  if (x.kind == nkCurly and formal.kind == tySet and formal.base.kind != tyGenericParam) or
+    (x.kind in {nkPar, nkTupleConstr} and formal.kind != tyBuiltInTypeClass):
     changeType(c, x, formal, check=true)
   result = arg
   result = skipHiddenSubConv(result, c.graph, c.idgen)

--- a/tests/metatype/typeclassinference.nim
+++ b/tests/metatype/typeclassinference.nim
@@ -19,3 +19,25 @@ var ptr1: ptr = addr(str1)
 var str2: string = "hello, world!"
 var ptr2: ptr = str2
 
+block: # built in typeclass inference
+  proc tupleA(): tuple = return (1, 2)
+  proc tupleB(): tuple = (1f, 2f)
+  assert typeof(tupleA()) is (int, int)
+  assert typeof(tupleB()) is (float32, float32)
+
+  proc a(val: int or float): tuple = 
+    when typeof(val) is int:
+      (10, 10)
+    else:
+      (30f, 30f)
+
+  assert typeof(a(10)) is (int, int)
+  assert typeof(a(10.0)) is (float32, float32)
+
+  proc b(val: int or float): set = 
+    when typeof(val) is int:
+      {10u8, 3}
+    else:
+      {'a', 'b'}
+  assert typeof(b(10)) is set[uint8]
+  assert typeof(b(10.0)) is set[char]


### PR DESCRIPTION
Closes: https://github.com/nim-lang/Nim/issues/18826
Also the following no longer crashes the compiler:
```nim
proc b(val: int or float): set = 
  when typeof(val) is int:
    {10u8, 3}
  else:
    {'a', 'b'}
assert typeof(b(10)) is set[uint8]
assert typeof(b(10.0)) is set[char]
 ```