### PR TITLE
distros.foreignDeps made public

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -380,6 +380,9 @@
 - Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect
   if the slice is out of bounds, likewise with `strutils.delete`.
 
+- Deprecated `distros.echoForeignDeps`.
+
+
 ## Language changes
 
 - The `cstring` doesn't support `[]=` operator in JS backend.

--- a/changelog.md
+++ b/changelog.md
@@ -380,8 +380,6 @@
 - Deprecated `sequtils.delete` and added an overload taking a `Slice` that raises a defect
   if the slice is out of bounds, likewise with `strutils.delete`.
 
-- Deprecated `distros.echoForeignDeps`.
-
 
 ## Language changes
 

--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -273,7 +273,7 @@ proc foreignDep*(foreignPackageName: string) =
   let (installCmd, sudo) = foreignDepInstallCmd(foreignPackageName)
   foreignCmd(installCmd, sudo)
 
-proc echoForeignDeps*() {.deprecated: "use `foreignDeps` instead".} =
+proc echoForeignDeps*() =
   ## Writes the list of registered foreign deps to stdout.
   for d in foreignDeps:
     echo d

--- a/lib/pure/distros.nim
+++ b/lib/pure/distros.nim
@@ -27,11 +27,11 @@
 ##
 ## See `packaging <packaging.html>`_ for hints on distributing Nim using OS packages.
 
-from strutils import contains, toLowerAscii
+from std/strutils import contains, toLowerAscii
 
 when not defined(nimscript):
-  from osproc import execProcess
-  from os import existsEnv
+  from std/osproc import execProcess
+  from std/os import existsEnv
 
 type
   Distribution* {.pure.} = enum ## the list of known distributions
@@ -211,7 +211,7 @@ template detectOs*(d: untyped): bool =
   detectOsImpl(Distribution.d)
 
 when not defined(nimble):
-  var foreignDeps: seq[string] = @[]
+  var foreignDeps*: seq[string] = @[]  ## Registered foreign deps.
 
 proc foreignCmd*(cmd: string; requiresSudo = false) =
   ## Registers a foreign command to the internal list of commands
@@ -273,7 +273,7 @@ proc foreignDep*(foreignPackageName: string) =
   let (installCmd, sudo) = foreignDepInstallCmd(foreignPackageName)
   foreignCmd(installCmd, sudo)
 
-proc echoForeignDeps*() =
+proc echoForeignDeps*() {.deprecated: "use `foreignDeps` instead".} =
   ## Writes the list of registered foreign deps to stdout.
   for d in foreignDeps:
     echo d


### PR DESCRIPTION
- Make `foreignDeps` public, so it can be used.
- Improve imports to use `std/ `.
- Updated `changelog`.

:)