### PR TITLE
[minor] fix docs

### DIFF
--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -603,12 +603,10 @@ proc isValid*[A](s: HashSet[A]): bool {.deprecated:
   ## Returns `true` if the set has been initialized (with `initHashSet proc
   ## <#initHashSet>`_ or `init proc <#init,HashSet[A]>`_).
   ##
-  ## **Examples:**
-  ##
-  ## .. code-block ::
-  ##   proc savePreferences(options: HashSet[string]) =
-  ##     assert options.isValid, "Pass an initialized set!"
-  ##     # Do stuff here, may crash in release builds!
+  runnableExamples:
+    proc savePreferences(options: HashSet[string]) =
+      assert options.isValid, "Pass an initialized set!"
+      # Do stuff here, may crash in release builds!
   result = s.data.len > 0
 
 


### PR DESCRIPTION
It seems that the docs generator becomes stricter as to `.. code-block ::` (It is wrong because now the doc generator requires that there should be no space after block. The right form is `.. code-block::`)

https://nim-lang.github.io/Nim/sets.html#isValid%2CHashSet%5BA%5D

## Before

![image](https://user-images.githubusercontent.com/43030857/132940396-cda01460-9f3e-4e55-b629-08f1d2ec8ec3.png)

## After

![image](https://user-images.githubusercontent.com/43030857/132940517-95346639-fd6e-4699-a5da-5f2e6598898c.png)

IMO we should eliminate most of code-blocks in stdlib eventually. Especially `strutils`, `json`, `tables`, `sets`, `system` etc. modules can be processed first.