### PR TITLE
fix #18410 (Errors initializing an object of RootObj with the C++ backend) [backport]

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -366,6 +366,7 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: var TLoc,
     else:
       linefmt(p, section, "$1.m_type = $2;$n", [r, genTypeInfoV1(p.module, t, a.lode.info)])
   of frEmbedded:
+    # inheritance in C++ does not allow struct initialization: bug #18836
     if not p.module.compileToCpp and optTinyRtti in p.config.globalOptions:
       var tmp: TLoc
       if mode == constructRefObj:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -366,7 +366,7 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: var TLoc,
     else:
       linefmt(p, section, "$1.m_type = $2;$n", [r, genTypeInfoV1(p.module, t, a.lode.info)])
   of frEmbedded:
-    if optTinyRtti in p.config.globalOptions:
+    if not p.module.compileToCpp and optTinyRtti in p.config.globalOptions:
       var tmp: TLoc
       if mode == constructRefObj:
         let objType = t.skipTypes(abstractInst+{tyRef})

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -366,7 +366,7 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: var TLoc,
     else:
       linefmt(p, section, "$1.m_type = $2;$n", [r, genTypeInfoV1(p.module, t, a.lode.info)])
   of frEmbedded:
-    # inheritance in C++ does not allow struct initialization: bug #18836
+    # inheritance in C++ does not allow struct initialization: bug ##18410
     if not p.module.compileToCpp and optTinyRtti in p.config.globalOptions:
       var tmp: TLoc
       if mode == constructRefObj:

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -366,7 +366,7 @@ proc genObjectInit(p: BProc, section: TCProcSection, t: PType, a: var TLoc,
     else:
       linefmt(p, section, "$1.m_type = $2;$n", [r, genTypeInfoV1(p.module, t, a.lode.info)])
   of frEmbedded:
-    # inheritance in C++ does not allow struct initialization: bug ##18410
+    # inheritance in C++ does not allow struct initialization: bug #18410
     if not p.module.compileToCpp and optTinyRtti in p.config.globalOptions:
       var tmp: TLoc
       if mode == constructRefObj:

--- a/tests/arc/tconst_to_sink.nim
+++ b/tests/arc/tconst_to_sink.nim
@@ -1,6 +1,7 @@
 discard """
   output: '''@[(s1: "333", s2: ""), (s1: "abc", s2: "def"), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "3x", s2: ""), (s1: "lastone", s2: "")]'''
-  cmd: "nim c --gc:arc $file"
+  matrix: "--gc:arc"
+  targets: "c cpp"
 """
 
 # bug #13240

--- a/tests/cpp/torc.nim
+++ b/tests/cpp/torc.nim
@@ -1,0 +1,15 @@
+discard """
+  targets: "cpp"
+  matrix: "--gc:orc"
+"""
+
+import std/options
+
+# bug #18410
+type
+  O = object of RootObj
+   val: pointer
+
+proc p(): Option[O] = none(O)
+
+doAssert $p() == "none(O)"


### PR DESCRIPTION
fix #18410
`Option[O]` has a data member which inherits from `RootObj`, but it is cannot be initialized by Aggregate initialization in CPP. So we must choose the expensive way to initialize it.

As a bonus, now Nim compiler can be booted by `cpp --gc:orc`.

`./koch temp cpp --gc:orc compiler/nim.nim`

```
Hint: gc: orc; opt: none (DEBUG BUILD, `-d:release` generates faster code)
169524 lines; 310.666s; 1.217GiB peakmem;
```

## Follow-up PR
- [x] enable `cpp --gc:orc` for some platforms 
- [x] add notes for removing it after bumping C++ compiler version