### PR TITLE
Revert "use new Nimble, with lockfiles (#18810)"

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -10,7 +10,7 @@
 #
 
 const
-  NimbleStableCommit = "795704833ddfd0cdaefb45c60551d3ea205279ef" # master
+  NimbleStableCommit = "d13f3b8ce288b4dc8c34c219a4e050aaeaf43fc9" # master
   # examples of possible values: #head, #ea82b54, 1.2.3
   FusionStableHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
   HeadHash = "#head"


### PR DESCRIPTION
This reverts commit f373c17ad926b669bb3b5819ae1dff4bde1da88a.

For more details, see:
- https://github.com/nim-lang/nimble/issues/940
- https://github.com/nim-lang/Nim/issues/18840
- https://forum.nim-lang.org/t/8404