### PR TITLE
add ghci like type annotation buildEchoStmt (1049)

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1055,7 +1055,7 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   else:
     result.add localErrorNode(c, n, "system needs: echo")
   result.add(n)
-  result.add(newStrNode(nkStrLit, ": " & n.typ.typeToString)) # ghci(GHC interpreter)
+  result.add(newStrNode(nkStrLit, ": " & n.typ.typeToString))
   result = semExpr(c, result)
 
 proc semExprNoType(c: PContext, n: PNode): PNode =

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1055,7 +1055,7 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   else:
     result.add localErrorNode(c, n, "system needs: echo")
   result.add(n)
-  result.add(newStrNode(nkStrLit, " ::" & n.typ.typeToString)) # ghci(GHC interpreter)
+  result.add(newStrNode(nkStrLit, ": " & n.typ.typeToString)) # ghci(GHC interpreter)
   result = semExpr(c, result)
 
 proc semExprNoType(c: PContext, n: PNode): PNode =

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1055,6 +1055,7 @@ proc buildEchoStmt(c: PContext, n: PNode): PNode =
   else:
     result.add localErrorNode(c, n, "system needs: echo")
   result.add(n)
+  result.add(newStrNode(nkStrLit, " ::" & n.typ.typeToString)) # ghci(GHC interpreter)
   result = semExpr(c, result)
 
 proc semExprNoType(c: PContext, n: PNode): PNode =


### PR DESCRIPTION
add ghci like type [annotation] in Nim REPL.
change `semexprs.nim` in `compiler/`
![nim](https://user-images.githubusercontent.com/83954070/134115363-5bd46388-4677-42f8-97be-b6f774209c0b.gif)
note: [GHCi] (https://downloads.haskell.org/ghc/latest/docs/html/users_guide/ghci.html)
command `:t` or `:type` will show one variable's type