### PR TITLE
[strutils docs] fix a typo (rename temporal to temporary)

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -2039,7 +2039,7 @@ func countLines*(s: string): int {.rtl, extern: "nsuCountLines".} =
   ## Returns the number of lines in the string `s`.
   ##
   ## This is the same as `len(splitLines(s))`, but much more efficient
-  ## because it doesn't modify the string creating temporal objects. Every
+  ## because it doesn't modify the string creating temporary objects. Every
   ## `character literal <manual.html#lexical-analysis-character-literals>`_
   ## newline combination (CR, LF, CR-LF) is supported.
   ##


### PR DESCRIPTION
It is not proper to use temporal in this situation (At least it is rarely used or less common used in the sense of temporary)
- Relating to worldly as opposed to spiritual affairs; secular.
- Relating to time.

> I've never heard the term "temporal variable", so I'm going to assume you mean "temporary variable".

https://english.stackexchange.com/questions/7539/temporal-vs-temporary

> Temporal means “pertaining to time”. Personally I have not enountered this word in normal speech at all, even in somewhat formal writing. 

https://english.stackexchange.com/questions/7539/temporal-vs-temporary