### PR TITLE
fix wrong name (rnimsyn => renderer; pnimsyn => parser; scanner => lexer)

### DIFF
--- a/compiler/filter_tmpl.nim
+++ b/compiler/filter_tmpl.nim
@@ -22,7 +22,7 @@ type
     info: TLineInfo
     indent, emitPar: int
     x: string                # the current input line
-    outp: PLLStream          # the output will be parsed by pnimsyn
+    outp: PLLStream          # the output will be parsed by parser
     subsChar, nimDirective: char
     emit, conc, toStr: string
     curly, bracket, par: int

--- a/compiler/lexer.nim
+++ b/compiler/lexer.nim
@@ -7,12 +7,12 @@
 #    distribution, for details about the copyright.
 #
 
-# This scanner is handwritten for efficiency. I used an elegant buffering
+# This lexer is handwritten for efficiency. I used an elegant buffering
 # scheme which I have not seen anywhere else:
 # We guarantee that a whole line is in the buffer. Thus only when scanning
 # the \n or \r character we have to check whether we need to read in the next
 # chunk. (\n or \r already need special handling for incrementing the line
-# counter; choosing both \n and \r allows the scanner to properly read Unix,
+# counter; choosing both \n and \r allows the lexer to properly read Unix,
 # DOS or Macintosh text files, even when it is not the native format.
 
 import

--- a/compiler/nimconf.nim
+++ b/compiler/nimconf.nim
@@ -14,7 +14,7 @@ import
   options, idents, wordrecg, strtabs, lineinfos, pathutils, scriptconfig
 
 # ---------------- configuration file parser -----------------------------
-# we use Nim's scanner here to save space and work
+# we use Nim's lexer here to save space and work
 
 proc ppGetTok(L: var Lexer, tok: var Token) =
   # simple filter

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -410,7 +410,7 @@ proc atom(g: TSrcGen; n: PNode): string =
     if (n.typ != nil) and (n.typ.sym != nil): result = n.typ.sym.name.s
     else: result = "[type node]"
   else:
-    internalError(g.config, "rnimsyn.atom " & $n.kind)
+    internalError(g.config, "renderer.atom " & $n.kind)
     result = ""
 
 proc lcomma(g: TSrcGen; n: PNode, start: int = 0, theEnd: int = - 1): int =
@@ -1699,7 +1699,7 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
     gsub(g, n[0], c)
   else:
     #nkNone, nkExplicitTypeListCall:
-    internalError(g.config, n.info, "rnimsyn.gsub(" & $n.kind & ')')
+    internalError(g.config, n.info, "renderer.gsub(" & $n.kind & ')')
 
 proc renderTree*(n: PNode, renderFlags: TRenderFlags = {}): string =
   if n == nil: return "<nil tree>"

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -216,7 +216,7 @@ comment:
 
 .. code-block:: nim
   i = 0     # This is a single comment over multiple lines.
-    # The scanner merges these two pieces.
+    # The lexer merges these two pieces.
     # The comment continues here.
 
 


### PR DESCRIPTION
`renderer.nim` was initially called `rnimsyn`, then it was renamed via https://github.com/nim-lang/Nim/commit/36c67455d4d3e5fa5222937b800f90ef811d8e86#diff-e61f20f50ef4b22e2d8bf442b52bbcaa37079f0ea548840bc82a42464cbcccf9

pnimsyn => parser
scanner => lexer (using lexer makes it more consistent)
rnimsyn => renderer

Ref https://en.wikipedia.org/wiki/Lexical_analysis

> In computer science, lexical analysis, lexing or tokenization is the process of converting a sequence of characters (such as in a computer program or web page) into a sequence of tokens (strings with an assigned and thus identified meaning). A program that performs lexical analysis may be termed a lexer, tokenizer,[1] or scanner, although scanner is also a term for the first stage of a lexer. 