### PR TITLE
fix a potential bug (negative => uint64 conversion at compile time)

### DIFF
--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -95,7 +95,7 @@ proc addInt*(result: var string; x: int64) =
     var num: uint64
     if x < 0:
       if x == low(int64):
-        num = uint64(x)
+        num = cast[uint64](x)
       else:
         num = uint64(-x)
       let base = result.len


### PR DESCRIPTION
I didn't see the spec for conversion between uint64 and other types at compile time. So I use cast to make it more robust.

```nim
static: # illegal conversion from '-2147483648' to '[0..4294967295]'
  let x = low(int32)
  echo uint32(x)

static: # pass
  let x = low(int64)
  echo uint64(x)
```
While
```nim
const x = uint64(-1) # Error: -1 can't be converted to uint64
```
errors as expected

Ref https://github.com/nim-lang/Nim/issues/12700

```nim
proc foo3(arg: int): string {.compileTime.} =
  let x = uint64(arg)
  $x

echo foo3(-1)
```
It passes the compilation but maybe shouldn't and I have a fix for this situation which makes it consistent with uint32 and so on.

One possible reason to cause this problem is that before uint64 and uint are not Ordinal types.