### PR TITLE
`set` is not allowed among types for `ord` proc

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -216,10 +216,6 @@ proc semOrd(c: PContext, n: PNode): PNode =
   let parType = n[1].typ
   if isOrdinalType(parType, allowEnumWithHoles=true):
     discard
-  elif parType.kind == tySet:
-    let a = toInt64(firstOrd(c.config, parType))
-    let b = toInt64(lastOrd(c.config, parType))
-    result.typ = makeRangeType(c, a, b, n.info)
   else:
     localError(c.config, n.info, errOrdinalTypeExpected)
     result.typ = errorType(c)


### PR DESCRIPTION
Ref https://github.com/nim-lang/Nim/blob/674a1110f0ad8b95bb6d7332c87aa1c684cd0973/lib/system.nim#L730

Ref https://github.com/nim-lang/Nim/pull/4604

The signature of the `ord` proc has already been changed to `func ord*[T: Ordinal|enum](x: T): int {.magic: "Ord".}`. It seems that there is no need to semcheck ord. At least set is not among allowed types.