### PR TITLE
fixes "sameType is not commutative when generic alias is involved"

### DIFF
--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1118,8 +1118,6 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
   assert(a != nil)
   assert(b != nil)
 
-  if a == b: return true
-
   if a.kind != b.kind:
     case c.cmp
     of dcEq: return false
@@ -1137,7 +1135,7 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
       lhs = x.skipGenericAlias
       rhs = y.skipGenericAlias
     if rhs.kind != tyGenericInst or lhs.base != rhs.base:
-      return false
+      return sameType(lhs.skipTypes({tyGenericInst}), rhs)
     for i in 1..<lhs.len - 1:
       let ff = rhs[i]
       let aa = lhs[i]

--- a/compiler/types.nim
+++ b/compiler/types.nim
@@ -1117,6 +1117,9 @@ proc sameTypeAux(x, y: PType, c: var TSameTypeClosure): bool =
     b = skipTypes(b[^1], {tyGenericInst, tyAlias})
   assert(a != nil)
   assert(b != nil)
+
+  if a == b: return true
+
   if a.kind != b.kind:
     case c.cmp
     of dcEq: return false

--- a/tests/types/t18867.nim
+++ b/tests/types/t18867.nim
@@ -1,0 +1,9 @@
+import std/macros
+
+macro assertSameType(x: typed, y: typed): untyped =
+  assert sameType(x, y)
+
+type G[T] = T
+
+assertSameType(float(1.0), G[float](1.0))
+assertSameType(G[float](1.0), float(1.0))


### PR DESCRIPTION
Fixes #18867 by handling an edge case in `sameTypeAux` that seemed to be happening in "sufficiently simple but not simple enough" types.