### PR TITLE
fix #16558 (cast[int](string) crashed when using --gc:arc)

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2061,11 +2061,13 @@ proc genSomeCast(p: BProc, e: PNode, d: var TLoc) =
           [getTypeDesc(p.module, e.typ), rdCharLoc(a)], a.storage)
 
 proc genCast(p: BProc, e: PNode, d: var TLoc) =
-  const ValueTypes = {tyFloat..tyFloat128, tyTuple, tyObject, tyArray}
+  var valueTypes = {tyFloat..tyFloat128, tyTuple, tyObject, tyArray}
+  if p.config.selectedGC in {gcArc, gcOrc}:
+    valueTypes.incl {tyString, tySequence}
   let
     destt = skipTypes(e.typ, abstractRange)
     srct = skipTypes(e[1].typ, abstractRange)
-  if destt.kind in ValueTypes or srct.kind in ValueTypes:
+  if destt.kind in valueTypes or srct.kind in valueTypes:
     # 'cast' and some float type involved? --> use a union.
     inc(p.labels)
     var lbl = p.labels.rope

--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -2061,9 +2061,11 @@ proc genSomeCast(p: BProc, e: PNode, d: var TLoc) =
           [getTypeDesc(p.module, e.typ), rdCharLoc(a)], a.storage)
 
 proc genCast(p: BProc, e: PNode, d: var TLoc) =
-  var valueTypes = {tyFloat..tyFloat128, tyTuple, tyObject, tyArray}
-  if p.config.selectedGC in {gcArc, gcOrc}:
-    valueTypes.incl {tyString, tySequence}
+  let valueTypes = if p.config.selectedGC in {gcArc, gcOrc}:
+      {tyFloat..tyFloat128, tyTuple, tyObject, tyArray, tyString, tySequence}
+    else:
+      {tyFloat..tyFloat128, tyTuple, tyObject, tyArray}
+
   let
     destt = skipTypes(e.typ, abstractRange)
     srct = skipTypes(e[1].typ, abstractRange)

--- a/tests/arc/tarcmisc.nim
+++ b/tests/arc/tarcmisc.nim
@@ -463,3 +463,12 @@ proc putValue[T](n: T) =
   echo b.n
 
 useForward()
+
+block: # bug #16558
+  var value = "hi there"
+  var keepInt: int
+  keepInt = cast[int](value)
+  doAssert keepInt == 8
+
+  var seqs = @[1.0, 2.3, 4.5]
+  doAssert cast[int](seqs) == 3


### PR DESCRIPTION
fix #16558

It is discouraged to rely on implementation details, but it should not crash. And indeed `tyString` and `tySequence` are value types for ARC and ORC at the present time instead of pointer types. If the internal details change again in the future, the test case should catch it.