### PR TITLE
Adds sourceTag to SingleTags list in htmlparser

### DIFF
--- a/lib/pure/htmlparser.nim
+++ b/lib/pure/htmlparser.nim
@@ -215,7 +215,7 @@ const
     tagMenu, tagNoframes}
   SingleTags* = {tagArea, tagBase, tagBasefont,
     tagBr, tagCol, tagFrame, tagHr, tagImg, tagIsindex,
-    tagLink, tagMeta, tagParam, tagWbr}
+    tagLink, tagMeta, tagParam, tagWbr, tagSource}
 
 proc allLower(s: string): bool =
   for c in s:


### PR DESCRIPTION
htmlparser erroneously expects a closing tag for `<source>`. This PR adds it to the single tags list, so it should not expect a closing tag anymore.

See for example https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#usage_notes