### PR TITLE
Update Nim to search for Nimble packages in "pkg2"

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -520,7 +520,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
       var path = processPath(conf, arg, info, notRelativeToProj=true)
       let nimbleDir = AbsoluteDir getEnv("NIMBLE_DIR")
       if not nimbleDir.isEmpty and pass == passPP:
-        path = nimbleDir / RelativeDir"pkgs"
+        path = nimbleDir / RelativeDir"pkgs2"
       nimblePath(conf, path, info)
   of "nonimblepath", "nobabelpath":
     if switch.normalize == "nobabelpath": deprecatedAlias(switch, "nonimblepath")

--- a/compiler/modulepaths.nim
+++ b/compiler/modulepaths.nim
@@ -84,10 +84,10 @@ when false:
         if not options.gNoNimblePath:
           var nimbleDir = getEnv("NIMBLE_DIR")
           if nimbleDir.len == 0: nimbleDir = getHomeDir() / ".nimble"
-          result = findInNimbleDir(pkg, subdir, nimbleDir / "pkgs")
+          result = findInNimbleDir(pkg, subdir, nimbleDir / "pkgs2")
           if result.len > 0: return result
           when not defined(windows):
-            result = findInNimbleDir(pkg, subdir, "/opt/nimble/pkgs")
+            result = findInNimbleDir(pkg, subdir, "/opt/nimble/pkgs2")
             if result.len > 0: return result
 
   proc scriptableImport(pkg, sub: string; info: TLineInfo): string =

--- a/compiler/nimblecmd.nim
+++ b/compiler/nimblecmd.nim
@@ -65,8 +65,8 @@ proc `<`*(ver: Version, ver2: Version): bool =
 
 proc getPathVersionChecksum*(p: string): tuple[name, version, checksum: string] =
   ## Splits path ``p`` in the format
-  ## ``/home/user/.nimble/pkgs/package-0.1-febadeaea2345e777f0f6f8433f7f0a52edd5d1b`` into
-  ## ``("/home/user/.nimble/pkgs/package", "0.1", "febadeaea2345e777f0f6f8433f7f0a52edd5d1b")``
+  ## ``/home/user/.nimble/pkgs2/package-0.1-febadeaea2345e777f0f6f8433f7f0a52edd5d1b`` into
+  ## ``("/home/user/.nimble/pkgs2/package", "0.1", "febadeaea2345e777f0f6f8433f7f0a52edd5d1b")``
 
   const checksumSeparator = '-'
   const versionSeparator = '-'

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -44,11 +44,11 @@ path="$lib/core"
 path="$lib/pure"
 
 @if not windows:
-  nimblepath="/opt/nimble/pkgs/"
+  nimblepath="/opt/nimble/pkgs2/"
 @else:
   # TODO:
 @end
-nimblepath="$home/.nimble/pkgs/"
+nimblepath="$home/.nimble/pkgs2/"
 
 # Syncronize with compiler/commands.specialDefine
 @if danger or quick:

--- a/doc/testament.rst
+++ b/doc/testament.rst
@@ -153,7 +153,7 @@ Example "template" **to edit** and write a Testament unittest:
 
     # Command the test should use to run. If left out or an empty string is
     # provided, the command is taken to be:
-    # "nim $target --hints:on -d:testing --nimblePath:build/deps/pkgs $options $file"
+    # "nim $target --hints:on -d:testing --nimblePath:build/deps/pkgs2 $options $file"
     # You can use the $target, $options, and $file placeholders in your own
     # command, too.
     cmd: "nim c -r $file"

--- a/koch.nim
+++ b/koch.nim
@@ -10,7 +10,7 @@
 #
 
 const
-  NimbleStableCommit = "d13f3b8ce288b4dc8c34c219a4e050aaeaf43fc9" # master
+  NimbleStableCommit = "c866966161c2ea0cdf122d8cb22cef4cd3cc04ae" # master
   # examples of possible values: #head, #ea82b54, 1.2.3
   FusionStableHash = "#372ee4313827ef9f2ea388840f7d6b46c2b1b014"
   HeadHash = "#head"

--- a/testament/specs.nim
+++ b/testament/specs.nim
@@ -103,7 +103,7 @@ type
 
 proc getCmd*(s: TSpec): string =
   if s.cmd.len == 0:
-    result = compilerPrefix & " $target --hints:on -d:testing --clearNimblePath --nimblePath:build/deps/pkgs $options $file"
+    result = compilerPrefix & " $target --hints:on -d:testing --clearNimblePath --nimblePath:build/deps/pkgs2 $options $file"
   else:
     result = s.cmd
 

--- a/tests/cpp/tasync_cpp.nim
+++ b/tests/cpp/tasync_cpp.nim
@@ -1,7 +1,7 @@
 discard """
   targets: "cpp"
   output: "hello"
-  cmd: "nim cpp --clearNimblePath --nimblePath:build/deps/pkgs $file"
+  cmd: "nim cpp --clearNimblePath --nimblePath:build/deps/pkgs2 $file"
 """
 
 # bug #3299

--- a/tools/niminst/deinstall.nimf
+++ b/tools/niminst/deinstall.nimf
@@ -21,7 +21,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/lib/?proj
       docdir=/usr/share/?proj/doc
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
@@ -29,7 +29,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/local/lib/?proj
       docdir=/usr/local/share/?proj/doc
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"
@@ -37,7 +37,7 @@ if [ $# -eq 1 ] ; then
       libdir="/opt/?proj/lib"
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
       ;;
     *)
       bindir="$1/?proj/bin"

--- a/tools/niminst/deinstall.nimf
+++ b/tools/niminst/deinstall.nimf
@@ -21,7 +21,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/lib/?proj
       docdir=/usr/share/?proj/doc
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.nimblePkgChecksum"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
@@ -29,7 +29,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/local/lib/?proj
       docdir=/usr/local/share/?proj/doc
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.nimblePkgChecksum"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"
@@ -37,7 +37,7 @@ if [ $# -eq 1 ] ; then
       libdir="/opt/?proj/lib"
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.nimblePkgChecksum"
       ;;
     *)
       bindir="$1/?proj/bin"

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -34,7 +34,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/lib/?proj
       docdir=/usr/share/?proj/doc
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
@@ -42,7 +42,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/local/lib/?proj
       docdir=/usr/local/share/?proj/doc
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"
@@ -50,7 +50,7 @@ if [ $# -eq 1 ] ; then
       libdir="/opt/?proj/lib"
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
       mkdir -p /opt/?proj
       mkdir -p $bindir
       mkdir -p $configdir

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -34,7 +34,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/lib/?proj
       docdir=/usr/share/?proj/doc
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.nimblePkgChecksum"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
@@ -42,7 +42,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/local/lib/?proj
       docdir=/usr/local/share/?proj/doc
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.nimblePkgChecksum"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"
@@ -50,7 +50,7 @@ if [ $# -eq 1 ] ; then
       libdir="/opt/?proj/lib"
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.checksum"
+      nimbleDir="/opt/nimble/pkgs2/?c.nimblePkgName-?c.version-?c.nimblePkgChecksum"
       mkdir -p /opt/?proj
       mkdir -p $bindir
       mkdir -p $configdir

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -63,7 +63,7 @@ type
     nimArgs: string
     debOpts: TDebOptions
     nimblePkgName: string
-    checksum: string
+    nimblePkgChecksum: string
 
 const
   unixDirVars: array[fcConfig..fcLib, string] = [
@@ -408,6 +408,8 @@ proc parseIniFile(c: var ConfigData) =
             c.nimblePkgName = v
           of "pkgfiles":
             addFiles(c.cat[fcNimble], split(v, {';'}))
+          of "pkgchecksum":
+            c.nimblePkgChecksum = v
           else:
             quit(errorStr(p, "invalid key: " & k.key))
         else: quit(errorStr(p, "invalid section: " & section))

--- a/tools/niminst/niminst.nim
+++ b/tools/niminst/niminst.nim
@@ -45,7 +45,7 @@ type
     fcUnix,       # files only for Unix; must be after ``fcWindows``
     fcUnixBin,    # binaries for Unix
     fcDocStart,   # links to documentation for Windows installer
-    fcNimble      # nimble package files to copy to /opt/nimble/pkgs/pkg-ver
+    fcNimble      # nimble package files to copy to /opt/nimble/pkgs2/pkg-ver-checksum
 
   ConfigData = object of RootObj
     actions: set[Action]
@@ -63,6 +63,7 @@ type
     nimArgs: string
     debOpts: TDebOptions
     nimblePkgName: string
+    checksum: string
 
 const
   unixDirVars: array[fcConfig..fcLib, string] = [


### PR DESCRIPTION
Update the compiler to search for nimble packages in the "pkg2" subdirectory instead of in "pkg". This should be merged when the new Nimble is released.