### PR TITLE
alternative to #18918

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -217,6 +217,8 @@ proc isCastable(c: PContext; dst, src: PType): bool =
     let s = skipTypes(src, abstractInst)
     if d.kind == tyRef and s.kind == tyRef and s[0].isFinal != d[0].isFinal:
       return false
+    elif d.kind in IntegralTypes and s.kind in {tyString, tySequence}:
+      return false
 
   var dstSize, srcSize: BiggestInt
   dstSize = computeSize(conf, dst)

--- a/tests/arc/t16558.nim
+++ b/tests/arc/t16558.nim
@@ -1,0 +1,9 @@
+discard """
+  matrix: "--gc:arc"
+  errormsg: "expression cannot be cast to int"
+"""
+
+block: # bug #16558
+  var value = "hi there"
+  var keepInt: int
+  keepInt = cast[int](value)


### PR DESCRIPTION
Disallow casting `string` or `sequence` to Integral types for ARC/ORC. 