### PR TITLE
document -d:nimStrictDelete [backport]

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2142,6 +2142,10 @@ proc delete*[T](x: var seq[T], i: Natural) {.noSideEffect, auditDelete.} =
   ##
   ## This is an `O(n)` operation.
   ##
+  ## .. note:: With `-d:nimStrictDelete`, an index error is produced when the index passed
+  ##    to it was out of bounds. `-d:nimStrictDelete` will become the default
+  ##    in upcoming versions.
+  ##
   ## See also:
   ## * `del <#del,seq[T],Natural>`_ for O(1) operation
   ##


### PR DESCRIPTION
Nim should not ask users to know the option from changelog, forum or discord. The option should be documented properly.