### PR TITLE
Fixes build_all.sh failing on Nimble builds [backport]

### DIFF
--- a/tools/deps.nim
+++ b/tools/deps.nim
@@ -22,14 +22,14 @@ proc cloneDependency*(destDirBase: string, url: string, commit = commitHead,
   let name = p.splitFile.name
   var destDir = destDirBase
   if appendRepoName: destDir = destDir / name
-  let destDir2 = destDir.quoteShell
+  let quotedDestDir = destDir.quoteShell
   if not dirExists(destDir):
     # note: old code used `destDir / .git` but that wouldn't prevent git clone
     # from failing
-    execRetry fmt"git clone -q {url} {destDir2}"
+    execRetry fmt"git clone -q {url} {quotedDestDir}"
   if isGitRepo(destDir):
     let oldDir = getCurrentDir()
-    setCurrentDir(destDir2)
+    setCurrentDir(destDir)
     try:
       execRetry "git fetch -q"
       exec fmt"git checkout -q {commit}"


### PR DESCRIPTION
When running `build_all.sh` I was getting:

```
bin/nim c -o:bin/nimsuggest -d:danger --skipUserCfg --skipParentCfg --hints:off nimsuggest/nimsuggest.nim
bin/nim c -o:bin/nimgrep -d:release --skipUserCfg --skipParentCfg --hints:off tools/nimgrep.nim
bin/nim c -o:bin/nimpretty -d:release --skipUserCfg --skipParentCfg --hints:off nimpretty/nimpretty.nim
bin/nim c -o:bin/testament -d:release --skipUserCfg --skipParentCfg --hints:off testament/testament.nim
bin/nim c -o:bin/nim_dbg --opt:speed --stacktrace -d:debug --stacktraceMsgs -d:nimCompilerStacktraceHints --skipUserCfg --skipParentCfg --hints:off compiler/nim.nim
bin/nim c -o:bin/atlas -d:release --skipUserCfg --skipParentCfg --hints:off tools/atlas/atlas.nim
/home/dom/.choosenim/toolchains/nim-#devel/koch.nim(722) koch
/home/dom/.choosenim/toolchains/nim-#devel/koch.nim(149) bundleNimbleExe
/home/dom/.choosenim/toolchains/nim-#devel/tools/deps.nim(32) cloneDependency
/home/dom/.choosenim/toolchains/nim-#devel/lib/pure/os.nim(1438) setCurrentDir
/home/dom/.choosenim/toolchains/nim-#devel/lib/pure/includes/oserr.nim(95) raiseOSError
Error: unhandled exception: No such file or directory
Additional info: '/home/dom/.choosenim/toolchains/nim-#devel/dist/nimble' [OSError]
```

With this patch it builds. This has been broken for 3 months, how?! and how did our CI not find it?