### PR TITLE
Add nimcall to isolate's =destroy

### DIFF
--- a/lib/std/isolation.nim
+++ b/lib/std/isolation.nim
@@ -24,7 +24,7 @@ proc `=sink`*[T](dest: var Isolated[T]; src: Isolated[T]) {.inline.} =
   # delegate to value's sink operation
   `=sink`(dest.value, src.value)
 
-proc `=destroy`*[T](dest: var Isolated[T]) {.inline.} =
+proc `=destroy`*[T](dest: var Isolated[T]) {.inline, nimcall.} =
   # delegate to value's destroy operation
   `=destroy`(dest.value)
 

--- a/tests/parallel/tchannel_with_isolate.nim
+++ b/tests/parallel/tchannel_with_isolate.nim
@@ -1,0 +1,27 @@
+discard """
+output: "Got: (value: (foo: 3))"
+"""
+
+import std/isolation
+
+type
+  Msg = object
+    foo: int
+
+var chan: Channel[Isolated[Msg]]
+chan.open()
+
+proc worker() {.thread.} =
+  let msg = Msg(foo: 3)
+  chan.send(isolate(msg))
+
+var workerThread: Thread[void]
+createThread(workerThread, worker)
+
+proc main() =
+  let val = chan.recv()
+  echo "Got: ", val
+
+when isMainModule:
+  main()
+  chan.close()


### PR DESCRIPTION
I'm trying to use `Isolated` with channels (to avoid copies), and without this calling convention change it won't compile.

I'm not sure if there was a reason this wasn't added before, or why it seems to be required here - if this isn't the best fix, please let me know. I'm not familiar with Nim's calling conventions - this is simply addressing the compile error I would otherwise get on 1.4.6:
```
INSTALL_PATH/lib/system/channels_builtin.nim(369, 73) Error: =destroy needs to have the 'nimcall' calling convention
```