### PR TITLE
Document how to compile a reproducible build

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -43,8 +43,8 @@ type
 
 const
   HelpMessage = "Nim Compiler Version $1 [$2: $3]\n" &
-      "Compiled at $4\n" &
       "Copyright (c) 2006-" & copyrightYear & " by Andreas Rumpf\n"
+  gitCommit {.strdefine.} = gorge("TZ=UTC git log -n 1 --date=iso-local --format='%H (%cd)'").strip
 
 proc genFeatureDesc[T: enum](t: typedesc[T]): string {.compileTime.} =
   result = ""
@@ -91,10 +91,7 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
                                  CPU[conf.target.hostCPU].name, CompileDate]),
                {msgStdout})
 
-    const gitHash {.strdefine.} = gorge("git log -n 1 --format=%H").strip
-      # xxx move this logic to std/private/gitutils
-    when gitHash.len == 40:
-      msgWriteln(conf, "git hash: " & gitHash, {msgStdout})
+    msgWriteln(conf, "git commit: " & gitCommit, {msgStdout})
 
     msgWriteln(conf, "active boot switches:" & usedRelease & usedDanger &
       usedTinyC & useLinenoise &

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -43,8 +43,8 @@ type
 
 const
   HelpMessage = "Nim Compiler Version $1 [$2: $3]\n" &
+      "Compiled at $4\n" &
       "Copyright (c) 2006-" & copyrightYear & " by Andreas Rumpf\n"
-  gitCommit {.strdefine.} = gorge("TZ=UTC git log -n 1 --date=iso-local --format='%H (%cd)'").strip
 
 proc genFeatureDesc[T: enum](t: typedesc[T]): string {.compileTime.} =
   result = ""
@@ -91,7 +91,10 @@ proc writeVersionInfo(conf: ConfigRef; pass: TCmdLinePass) =
                                  CPU[conf.target.hostCPU].name, CompileDate]),
                {msgStdout})
 
-    msgWriteln(conf, "git commit: " & gitCommit, {msgStdout})
+    const gitHash {.strdefine.} = gorge("git log -n 1 --format=%H").strip
+      # xxx move this logic to std/private/gitutils
+    when gitHash.len == 40:
+      msgWriteln(conf, "git hash: " & gitHash, {msgStdout})
 
     msgWriteln(conf, "active boot switches:" & usedRelease & usedDanger &
       usedTinyC & useLinenoise &

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -68,6 +68,17 @@ More information about its options can be found in the `koch <koch.html>`_
 documentation.
 
 
+Reproducible builds
+-------------------
+
+Set the compilation timestamp with the `SOURCE_DATE_EPOCH` environment variable.
+
+.. code:: cmd
+
+  export SOURCE_DATE_EPOCH=$(git log -n 1 --format=%at)
+  koch boot # or `./build_all.sh`
+
+
 Developing the compiler
 =======================
 

--- a/doc/packaging.rst
+++ b/doc/packaging.rst
@@ -6,6 +6,9 @@ This page provide hints on distributing Nim using OS packages.
 
 See `distros <distros.html>`_ for tools to detect Linux distribution at runtime.
 
+See `here <intern.html#bootstrapping-the-compiler-reproducible-builds>`_ for how to
+compile reproducible builds.
+
 Supported architectures
 -----------------------
 
@@ -71,3 +74,4 @@ What to install:
 - Optionally: manpages, documentation, shell completion
 - When installing documentation, .idx files are not required
 - The "compiler" directory contains compiler sources and should not be part of the compiler binary package
+

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,7 @@ Finally, once you have finished the build steps (on Windows, Mac, or Linux) you
 should add the ``bin`` directory to your PATH.
 
 See also [rebuilding the compiler](doc/intern.rst#rebuilding-the-compiler).
+
 See also [reproducible builds](doc/intern.rst#reproducible-builds).
 
 ## Koch

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,6 @@ the installation instructions on the website to do so: https://nim-lang.org/inst
 
 For package maintainers: see [packaging guidelines](https://nim-lang.github.io/Nim/packaging.html).
 
-
 First, get Nim from github:
 
 ```
@@ -88,6 +87,7 @@ Finally, once you have finished the build steps (on Windows, Mac, or Linux) you
 should add the ``bin`` directory to your PATH.
 
 See also [rebuilding the compiler](doc/intern.rst#rebuilding-the-compiler).
+See also [reproducible builds](doc/intern.rst#reproducible-builds).
 
 ## Koch
 


### PR DESCRIPTION
Removed the compile time from the version output.
Added Git commit's author's datetime in UTC timezone.

Fixes #18508

See https://reproducible-builds.org/docs/timestamps/
See https://reproducible-builds.org/docs/source-date-epoch/