### PR TITLE
fix installation with finish.exe [backport]

### DIFF
--- a/tools/finish.nim
+++ b/tools/finish.nim
@@ -41,7 +41,7 @@ proc downloadMingw(): DownloadResult =
   let curl = findExe"curl"
   var cmd: string
   if curl.len > 0:
-    cmd = quoteShell(curl) & " --out " & "dist" / mingw & " " & url
+    cmd = quoteShell(curl) & " --output " & "dist" / mingw & " " & url
   elif fileExists"bin/nimgrab.exe":
     cmd = r"bin\nimgrab.exe " & url & " dist" / mingw
   if cmd.len > 0:


### PR DESCRIPTION
fix https://github.com/nim-lang/Nim/issues/18956

Please use the latest curl(curl 7.79.1 (x86_64-pc-win32) libcurl/7.79.1) to reproduce the issue.

However according to the help of old version of curl: ` -o, --output <file> Write to file instead of stdout` , `--out` is quite outdated(or never exists) and happens to work with old version curl. With latest curl, it becomes an error.

Here is the doc: https://curl.se/docs/manpage.html#-o

Ref https://github.com/nim-lang/Nim/commit/ca42406df9355a5e392984fcbfe4edf040cb59b4#diff-a12d39d20e0a0bc9ec61e1dd9a499877e39fb99c00015255a015988483adef6b