### PR TITLE
make choosenim work on windows [backport]

### DIFF
--- a/bin/nim-gdb.bash
+++ b/bin/nim-gdb.bash
@@ -1,1 +1,25 @@
-nim-gdb
+#!/usr/bin/env bash
+
+# Exit if anything fails
+set -e
+
+which nim > /dev/null || (echo "nim not in PATH"; exit 1)
+which gdb > /dev/null || (echo "gdb not in PATH"; exit 1)
+which readlink > /dev/null || (echo "readlink not in PATH."; exit 1)
+
+if [[ "$(uname -s)" == "Darwin" || "(uname -s)" == *"BSD" ]]; then
+  NIM_SYSROOT=$(dirname $(dirname $(readlink -f $(which nim))))
+else
+  NIM_SYSROOT=$(dirname $(dirname $(readlink -e $(which nim))))
+fi
+
+# Find out where the pretty printer Python module is
+GDB_PYTHON_MODULE_PATH="$NIM_SYSROOT/tools/nim-gdb.py"
+
+# Run GDB with the additional arguments that load the pretty printers
+# Set the environment variable `NIM_GDB` to overwrite the call to a
+# different/specific command (defaults to `gdb`).
+NIM_GDB="${NIM_GDB:-gdb}"
+# exec replaces the new process of bash with gdb. It is always good to
+# have fewer processes.
+exec "${NIM_GDB}" -eval-command="source $GDB_PYTHON_MODULE_PATH" "$@"


### PR DESCRIPTION
tar on windows fails to extract symlink out of archive

```nim
Error: Unable to extract. Error was 'Execution failed with exit code 1
        ... Command: tar xf C:\Users\user\.choosenim\downloads\version-1-6.tar.gz -C C:\Users\user\AppData\Local\Temp\choosenim-extraction
        ... Output: Nim-version-1-6/bin/nim-gdb.bash: Can't create '\\\\?\\C:\\Users\\user\\AppData\\Local\\Temp\\choosenim-extraction\\Nim\\bin\\nim-gdb.bash'
        ... tar: Error exit delayed from previous errors.
```

So I copy contents from `nim-gdb` to `nim-gdb.bash` because I'm not familiar with bash script. Maybe someone have better solutions (for instance `nim-gdb.bash` executes `nim-gdb`)