### PR TITLE
changelog_1_6_0: mention breaking change in effect tracking

### DIFF
--- a/changelogs/changelog_1_6_0.md
+++ b/changelogs/changelog_1_6_0.md
@@ -905,6 +905,36 @@ Compatibility notes:
   to avoid ugly, non-portable solutions. See RFC
   [#407](https://github.com/nim-lang/RFCs/issues/407) for more details.
 
+Compatibility notes:
+- Fixed effect tracking for borrowed procs (see [#18882](https://github.com/nim-lang/Nim/pull/18882)).
+  One consequence is that, under some circumstances, Nim could previously permit a procedure with side effects to be written with `func` - you may need to change some occurrences of `func` to `proc`.
+  To illustrate, Nim versions before 1.6.0 compile the below without error
+  ```nim
+  proc print(s: string) =
+    echo s
+
+  type
+    MyString = distinct string
+
+  proc print(s: MyString) {.borrow.}
+
+  func foo(s: MyString) =
+    print(s)
+  ```
+  but Nim 1.6.0 produces the error
+  ```
+  Error: 'foo' can have side effects
+  ```
+  similar to how we expect that
+  ```nim
+  func print(s: string) =
+    echo s
+  ```
+  produces
+  ```
+  Error: 'print' can have side effects
+  ```
+
 
 ## Tools
 


### PR DESCRIPTION
Is this summary accurate and sufficiently complete?

Do we need to add a `-d:nimLegacyX` flag for this?

---

From https://github.com/nim-lang/Nim/commit/90a2b5afd8368777e5da9ab97c28130ba683e1d3 onwards, running `nim c` on 
```Nim
proc print(s: string) =
  echo s

type
  MyString = distinct string

proc print(s: MyString) {.borrow.}

func foo(s: MyString) =
  print(s)

```

produces an error:

```
/tmp/bar.nim(9, 6) Error: 'foo' can have side effects
> /tmp/bar.nim(10, 8) Hint: 'foo' calls `.sideEffect` 'print'
>> /tmp/bar.nim(7, 6) Hint: 'print' called by 'foo'
```

Note that this doesn't require `--experimental:strictFuncs`.