### PR TITLE
Fixed SIGSEGV on failing `of` test with `ptr object`. Fixes #18999

### DIFF
--- a/lib/system/chcks.nim
+++ b/lib/system/chcks.nim
@@ -132,6 +132,7 @@ when not defined(nimV2):
 
   proc isObjWithCache(obj, subclass: PNimType;
                       cache: var ObjCheckCache): bool {.compilerproc, inline.} =
+    if obj.isNil: return false
     if obj == subclass: return true
     if obj.base == subclass: return true
     if cache[0] == obj: return false

--- a/tests/objects/t18999.nim
+++ b/tests/objects/t18999.nim
@@ -1,0 +1,31 @@
+discard """
+  output: '''
+true
+true
+true
+false
+false
+false
+false
+'''
+"""
+
+type
+  Animal = ptr object of RootObj
+  Cat = ptr object of Animal
+  Plant = ptr object of RootObj
+  Tree = ptr object of Plant
+
+var cat = cast[Cat](alloc(sizeof(Cat)))
+var plant = cast[Plant](alloc(sizeof(Plant)))
+
+# true
+echo cat of Cat
+echo cat of Animal
+echo plant of Plant
+
+# false
+echo cat of Plant
+echo plant of Animal
+echo plant of Cat
+echo plant of Tree


### PR DESCRIPTION
This is a bandaid fix for #18999. I don't really understand what the code is doing, so there's probably a better place to handle this.