### PR TITLE
Add sugar.debugs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 
 ## Standard library additions and changes
 
+- Added `sugar.debugs` debug helper that injects debugging code in-between a block of code with given frequency.
 
 
 ## Language changes

--- a/lib/pure/sugar.nim
+++ b/lib/pure/sugar.nim
@@ -418,3 +418,61 @@ macro collect*(body: untyped): untyped {.since: (1, 5).} =
     assert toSeq(1..3) == @[1, 2, 3] # simpler
 
   result = collectImpl(nil, body)
+
+
+macro debugs*(frequency: static[int]; debugInBetween, codeToDebug: untyped) {.since: (1, 7).} =
+  ## Debug helper, injects `debugInBetween` in-between `codeToDebug` with given `frequency`.
+  runnableExamples"-r:off":
+    debugs 2, echo("INBETWEEN ", i > 0):
+      var i = 1
+      let x = 9
+      var s = "a"
+      i = 42
+      i = i + x
+      i = x
+      s.add 'x'
+      i = x + x
+  ## Expands to:
+  ##
+  ## .. code-block:: nim
+  ##    var i = 1
+  ##    let x = 9
+  ##    echo("INBETWEEN ", i > 0)
+  ##    var s = "a"
+  ##    i = 42
+  ##    echo("INBETWEEN ", i > 0)
+  ##    i = i + x
+  ##    i = x
+  ##    echo("INBETWEEN ", i > 0)
+  ##    s.add 'x'
+  ##    i = x + x
+  ##    echo("INBETWEEN ", i > 0)
+  ##
+  ## - `debugInBetween` can be any "debugging code", like `echo`, `assert`, procedure call, checks, dumps, etc.
+  ## - Change `frequency` to `0` then `debugInBetween` is not injected, the debug is disabled.
+  ## - Designed to debug a huge amount of lines by editing just 1 line.
+  runnableExamples"-r:off":
+    proc debuggingProc() =
+      echo "This is an Example"
+      echo getOccupiedMem()
+      # echo now()
+
+    # debuggingProc() is injected in-between every 1 line of the code block.
+    debugs 1, debuggingProc():
+      var x = 0
+      let y = 42
+      const z = 99
+      for i in x..z: echo i
+  ## .. Warning:: Designed for debugging purposes only, remove after debugging.
+  doAssert frequency >= 0, "frequency must be a positive integer >= 0"
+  if frequency == 0: return codeToDebug  # If frequency is 0 do nothing.
+  result = newTree(nnkStmtList)
+  var freqCounter, debugCounter: int
+  for line in codeToDebug.children:
+    result.add line
+    inc freqCounter
+    if freqCounter mod frequency == 0:
+      var s = $debugCounter & '\t' & lineInfo(line)
+      result.add nnkStmtList.newTree(nnkCall.newTree(newIdentNode"echo", newLit(s)))
+      result.add debugInBetween
+      inc debugCounter


### PR DESCRIPTION
- Debug helper that injects `debugInBetween` in-between `codeToDebug` with given `frequency`.
- Changelog, runnableExamples, documentation. 10 line `macro`, works for all targets.
- Help to debug Nim code is very important for user experience, specially new users.

Example:

```nim
debugs 2, echo("INBETWEEN ", i > 0):
  var i = 1
  let x = 9
  var s = "a"
  i = 42
  i = i + x
  i = x
  s.add 'x'
  i = x + x
```

Expands to:

```nim
var i = 1
let x = 9
echo("INBETWEEN ", i > 0)
var s = "a"
i = 42
echo("INBETWEEN ", i > 0)
i = i + x
i = x
echo("INBETWEEN ", i > 0)
s.add 'x'
i = x + x
echo("INBETWEEN ", i > 0)
```

- `debugInBetween` can be any "debugging code", like `echo`, `assert`, checks, dumps, etc.
- `debugInBetween` is meant to be like `echo foo`, `assert foo != nil`, `echo foo.repr`,  `sugar.dumpToString`, etc.
- `debugInBetween` can be any arbitrary procedure call too.
- Change `frequency` to `0` then `debugInBetween` is not injected.
- Change `frequency` to `1` then every `1` line `debugInBetween` is injected.
- Change `frequency` to `2` then every `2` lines `debugInBetween` is injected.
- Change `frequency` to `3` then every `3` lines `debugInBetween` is injected, etc.
- Designed to debug a huge amount of lines by editing just 1 line.
