### PR TITLE
add custom literals for `times.Duration`

### DIFF
--- a/lib/pure/includes/duration_lit.nim
+++ b/lib/pure/includes/duration_lit.nim
@@ -2,53 +2,54 @@ proc `'ns`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` nanoseconds (10^−9 seconds).
   runnableExamples:
     assert 19'ns == initTimeInterval(nanoseconds = 19)
-    assert 1000_000_000'ns == 1's
+    assert 1000_000_000'ns == 1'seconds
   nanoseconds(parseInt(num))
 
 proc `'us`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` microseconds (10^−6 seconds).
   runnableExamples:
     assert 3'us == initTimeInterval(microseconds = 3)
-    assert 1000_000'us == 1's
+    assert 1000_000'us == 1'seconds
   microseconds(parseInt(num))
 
 proc `'ms`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` milliseconds (10^−3 seconds).
   runnableExamples:
     assert 11'ms == initTimeInterval(milliseconds = 11)
-    assert 1000'ms == 1's
+    assert 1000'ms == 1'seconds
   milliseconds(parseInt(num))
 
 proc `'seconds`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` seconds.
   runnableExamples:
-    assert 2's == initTimeInterval(seconds = 2)
-    assert 60's == 1'min
+    assert 2'seconds == initTimeInterval(seconds = 2)
+    assert 60'seconds == 1'minutes
   seconds(parseInt(num))
 
 proc `'minutes`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` minutes.
   runnableExamples:
-    assert 13'min == initTimeInterval(minutes = 13)
-    assert 60'min == 1'hour
+    assert 13'minutes == initTimeInterval(minutes = 13)
+    assert 60'minutes == 1'hours
   minutes(parseInt(num))
 
 proc `'hours`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` hours.
   runnableExamples:
-    assert 17'hour == initTimeInterval(hours = 17)
-    assert 24'hour == 1'day
+    assert 17'hours == initTimeInterval(hours = 17)
+    assert 24'hours == 1'days
   hours(parseInt(num))
 
 proc `'days`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` days.
   runnableExamples:
-    assert 5'day == initTimeInterval(days = 5)
-    assert 7'day == 1'week
+    assert 5'days == initTimeInterval(days = 5)
+    assert 7'days == 1'weeks
   days(parseInt(num))
 
 proc `'weeks`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` weeks.
   runnableExamples:
-    assert 19'week == initTimeInterval(weeks = 19)
+    assert 19'weeks == initTimeInterval(weeks = 19)
+    assert 1'weeks == 7'days
   weeks(parseInt(num))

--- a/lib/pure/includes/duration_lit.nim
+++ b/lib/pure/includes/duration_lit.nim
@@ -1,54 +1,54 @@
 proc `'ns`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` nanoseconds (10^−9 seconds).
   runnableExamples:
     assert 19'ns == initTimeInterval(nanoseconds = 19)
     assert 1000_000_000'ns == 1's
   parseInt(num).nanoseconds
 
 proc `'us`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` microseconds (10^−6 seconds).
   runnableExamples:
     assert 3'us == initTimeInterval(microseconds = 3)
     assert 1000_000'us == 1's
   parseInt(num).microseconds
 
 proc `'ms`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` milliseconds (10^−3 seconds).
   runnableExamples:
     assert 11'ms == initTimeInterval(milliseconds = 11)
     assert 1000'ms == 1's
   parseInt(num).milliseconds
 
-proc `'s`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+proc `'seconds`*(num: string): TimeInterval {.inline.} =
+  ## Custom numeric literal for a TimeInterval of `num` seconds.
   runnableExamples:
     assert 2's == initTimeInterval(seconds = 2)
     assert 60's == 1'min
   parseInt(num).seconds
 
 proc `'minutes`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` minutes.
   runnableExamples:
     assert 13'min == initTimeInterval(minutes = 13)
     assert 60'min == 1'hour
   parseInt(num).minutes
 
 proc `'hours`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` hours.
   runnableExamples:
     assert 17'hour == initTimeInterval(hours = 17)
     assert 24'hour == 1'day
   parseInt(num).hours
 
 proc `'days`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` days.
   runnableExamples:
     assert 5'day == initTimeInterval(days = 5)
     assert 7'day == 1'week
   parseInt(num).days
 
 proc `'weeks`*(num: string): TimeInterval {.inline.} =
-  ## Custom 
+  ## Custom numeric literal for a TimeInterval of `num` weeks.
   runnableExamples:
     assert 19'week == initTimeInterval(weeks = 19)
   parseInt(num).weeks

--- a/lib/pure/includes/duration_lit.nim
+++ b/lib/pure/includes/duration_lit.nim
@@ -3,52 +3,52 @@ proc `'ns`*(num: string): TimeInterval {.inline.} =
   runnableExamples:
     assert 19'ns == initTimeInterval(nanoseconds = 19)
     assert 1000_000_000'ns == 1's
-  parseInt(num).nanoseconds
+  nanoseconds(parseInt(num))
 
 proc `'us`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` microseconds (10^−6 seconds).
   runnableExamples:
     assert 3'us == initTimeInterval(microseconds = 3)
     assert 1000_000'us == 1's
-  parseInt(num).microseconds
+  microseconds(parseInt(num))
 
 proc `'ms`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` milliseconds (10^−3 seconds).
   runnableExamples:
     assert 11'ms == initTimeInterval(milliseconds = 11)
     assert 1000'ms == 1's
-  parseInt(num).milliseconds
+  milliseconds(parseInt(num))
 
 proc `'seconds`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` seconds.
   runnableExamples:
     assert 2's == initTimeInterval(seconds = 2)
     assert 60's == 1'min
-  parseInt(num).seconds
+  seconds(parseInt(num))
 
 proc `'minutes`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` minutes.
   runnableExamples:
     assert 13'min == initTimeInterval(minutes = 13)
     assert 60'min == 1'hour
-  parseInt(num).minutes
+  minutes(parseInt(num))
 
 proc `'hours`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` hours.
   runnableExamples:
     assert 17'hour == initTimeInterval(hours = 17)
     assert 24'hour == 1'day
-  parseInt(num).hours
+  hours(parseInt(num))
 
 proc `'days`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` days.
   runnableExamples:
     assert 5'day == initTimeInterval(days = 5)
     assert 7'day == 1'week
-  parseInt(num).days
+  days(parseInt(num))
 
 proc `'weeks`*(num: string): TimeInterval {.inline.} =
   ## Custom numeric literal for a TimeInterval of `num` weeks.
   runnableExamples:
     assert 19'week == initTimeInterval(weeks = 19)
-  parseInt(num).weeks
+  weeks(parseInt(num))

--- a/lib/pure/includes/duration_lit.nim
+++ b/lib/pure/includes/duration_lit.nim
@@ -1,0 +1,46 @@
+proc `'ns`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 19'ns == initDuration(nanoseconds = 19)
+    assert 1000_000_000'ns == 1's
+  initDuration(nanoseconds = parseInt(num))
+
+proc `'us`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 3'us == initDuration(microseconds = 3)
+    assert 1000_000'us == 1's
+  initDuration(microseconds = parseInt(num))
+
+proc `'ms`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 11'ms == initDuration(milliseconds = 11)
+    assert 1000'ms == 1's
+  initDuration(milliseconds = parseInt(num))
+
+proc `'s`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 2's == initDuration(seconds = 2)
+    assert 60's == 1'min
+  initDuration(seconds = parseInt(num))
+
+proc `'min`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 13'min == initDuration(minutes = 13)
+    assert 60'min == 1'hour
+  initDuration(minutes = parseInt(num))
+
+proc `'hour`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 17'hour == initDuration(hours = 17)
+    assert 24'hour == 1'day
+  initDuration(hours = parseInt(num))
+
+proc `'day`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 5'day == initDuration(days = 5)
+    assert 7'day == 1'week
+  initDuration(days = parseInt(num))
+
+proc `'week`*(num: string): Duration {.inline.} =
+  runnableExamples:
+    assert 19'week == initDuration(weeks = 19)
+  initDuration(weeks = parseInt(num))

--- a/lib/pure/includes/duration_lit.nim
+++ b/lib/pure/includes/duration_lit.nim
@@ -1,46 +1,54 @@
-proc `'ns`*(num: string): Duration {.inline.} =
+proc `'ns`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 19'ns == initDuration(nanoseconds = 19)
+    assert 19'ns == initTimeInterval(nanoseconds = 19)
     assert 1000_000_000'ns == 1's
-  initDuration(nanoseconds = parseInt(num))
+  parseInt(num).nanoseconds
 
-proc `'us`*(num: string): Duration {.inline.} =
+proc `'us`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 3'us == initDuration(microseconds = 3)
+    assert 3'us == initTimeInterval(microseconds = 3)
     assert 1000_000'us == 1's
-  initDuration(microseconds = parseInt(num))
+  parseInt(num).microseconds
 
-proc `'ms`*(num: string): Duration {.inline.} =
+proc `'ms`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 11'ms == initDuration(milliseconds = 11)
+    assert 11'ms == initTimeInterval(milliseconds = 11)
     assert 1000'ms == 1's
-  initDuration(milliseconds = parseInt(num))
+  parseInt(num).milliseconds
 
-proc `'s`*(num: string): Duration {.inline.} =
+proc `'s`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 2's == initDuration(seconds = 2)
+    assert 2's == initTimeInterval(seconds = 2)
     assert 60's == 1'min
-  initDuration(seconds = parseInt(num))
+  parseInt(num).seconds
 
-proc `'min`*(num: string): Duration {.inline.} =
+proc `'minutes`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 13'min == initDuration(minutes = 13)
+    assert 13'min == initTimeInterval(minutes = 13)
     assert 60'min == 1'hour
-  initDuration(minutes = parseInt(num))
+  parseInt(num).minutes
 
-proc `'hour`*(num: string): Duration {.inline.} =
+proc `'hours`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 17'hour == initDuration(hours = 17)
+    assert 17'hour == initTimeInterval(hours = 17)
     assert 24'hour == 1'day
-  initDuration(hours = parseInt(num))
+  parseInt(num).hours
 
-proc `'day`*(num: string): Duration {.inline.} =
+proc `'days`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 5'day == initDuration(days = 5)
+    assert 5'day == initTimeInterval(days = 5)
     assert 7'day == 1'week
-  initDuration(days = parseInt(num))
+  parseInt(num).days
 
-proc `'week`*(num: string): Duration {.inline.} =
+proc `'weeks`*(num: string): TimeInterval {.inline.} =
+  ## Custom 
   runnableExamples:
-    assert 19'week == initDuration(weeks = 19)
-  initDuration(weeks = parseInt(num))
+    assert 19'week == initTimeInterval(weeks = 19)
+  parseInt(num).weeks

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -829,6 +829,8 @@ proc abs*(a: Duration): Duration =
       initDuration(milliseconds = 1500)
   initDuration(seconds = abs(a.seconds), nanoseconds = -a.nanosecond)
 
+when defined(nimHasCustomLiterals): include includes/duration_lit
+
 #
 # Time
 #

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -829,8 +829,6 @@ proc abs*(a: Duration): Duration =
       initDuration(milliseconds = 1500)
   initDuration(seconds = abs(a.seconds), nanoseconds = -a.nanosecond)
 
-when defined(nimHasCustomLiterals): include includes/duration_lit
-
 #
 # Time
 #
@@ -2651,6 +2649,9 @@ when not defined(js):
         toFloat(ts.tv_nsec.int) / 1_000_000_000
     else:
       result = toFloat(int(getClock())) / toFloat(clocksPerSec)
+
+
+when defined(nimHasCustomLiterals): include includes/duration_lit
 
 
 #


### PR DESCRIPTION
To ease usage of `times.Duration`, add some custom literal for it.