### PR TITLE
Add jsAwait Function

### DIFF
--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -150,6 +150,10 @@ macro async*(arg: untyped): untyped =
   else:
     result = generateJsasync(arg)
 
+proc jsAwait(a: JsObject): JsObject {.importjs: "await #".} 
+  ## A helper for awaiting raw JsObjects in
+  ## async procedures.
+
 proc newPromise*[T](handler: proc(resolve: proc(response: T))): Future[T] {.importjs: "(new Promise(#))".}
   ## A helper for wrapping callback-based functions
   ## into promises and async procedures.

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -150,7 +150,7 @@ macro async*(arg: untyped): untyped =
   else:
     result = generateJsasync(arg)
 
-proc jsAwait(a: JsObject): JsObject {.importjs: "await #".} 
+proc jsAwait*(a: auto): JsObject {.importjs: "(await #)".} 
   ## A helper for awaiting raw JsObjects in
   ## async procedures.
 


### PR DESCRIPTION
Example usage (using the nodejs puppeteer package):

```nim
import jsffi, asyncjs

var puppeteer = require("puppeteer")
proc main() {.async.} =
    var opts = newJsObject()
    opts.headless = false;
    var browser = jsAwait puppeteer.launch(opts);
when isMainModule:
    discard main()
```