### PR TITLE
use `gmake` in the buildscript on Solaris systems

### DIFF
--- a/ci/funs.sh
+++ b/ci/funs.sh
@@ -76,6 +76,8 @@ _nimBuildCsourcesIfNeeded(){
     makeX=gmake
   elif [ "$unamestr" = 'CROSSOS' ]; then
     makeX=gmake
+  elif [ "$unamestr" = 'SunOS' ]; then
+    makeX=gmake
   else
     makeX=make
   fi


### PR DESCRIPTION
Hello,

on Solaris/Illumos based systems there is a make installed which has no `-l` flag. However gmake is available and suited to build Nim. I tested it on a recent OpenIndiana machine. The fix is simply setting the `makeX` variable to `gmake` instead of `make`.