### PR TITLE
use the correct header for TIOCGWINSZ on Solaris

### DIFF
--- a/lib/posix/termios.nim
+++ b/lib/posix/termios.nim
@@ -237,8 +237,11 @@ proc tcFlow*(fd: cint; action: cint): cint {.importc: "tcflow",
     header: "<termios.h>".}
 # Get process group ID for session leader for controlling terminal FD.
 
-# Window size ioctl.  Should work on on any Unix that xterm has been ported to.
-var TIOCGWINSZ*{.importc, header: "<sys/ioctl.h>".}: culong
+# Window size ioctl.  Solaris based systems have an uncommen place for this.
+when defined(solaris) or defined(sunos):
+  var TIOCGWINSZ*{.importc, header: "<sys/termios.h>".}: culong
+else:
+  var TIOCGWINSZ*{.importc, header: "<sys/ioctl.h>".}: culong
 
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}


### PR DESCRIPTION
Hello,

on Solaris/Illumos based systems the `TIOCGWINSZ` variable is located in another header (for information please look [here](https://illumos.org/man/7I/termio).

Therefore I added a compile-time check which adjusts the header on import.
I sucessfully tested the change on a recent OpenIndiana machine.