### PR TITLE
`quit(errormsg, errorcode)`: Write to `stdout` if `errorcode == 0`

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2413,8 +2413,10 @@ proc quit*(errormsg: string, errorcode = QuitFailure) {.noreturn.} =
     when nimvm:
       echo errormsg
     else:
-      cstderr.rawWrite(errormsg)
-      cstderr.rawWrite("\n")
+      let strm = if errorcode == QuitSuccess: cstdout else: cstderr
+
+      strm.rawWrite(errormsg)
+      strm.rawWrite("\n")
   quit(errorcode)
 
 {.pop.} # checks: off


### PR DESCRIPTION
This modifies `proc quit*(errormsg: string, errorcode = QuitFailure)` to write to `cstdout` when errorcode is `0`/`QuitSuccess` and `cstderr` otherwise.

This closer resembles behavior outlined in the description:

> A shorthand for `echo(errormsg); quit(errorcode)`.