### PR TITLE
fix #18971

### DIFF
--- a/compiler/varpartitions.nim
+++ b/compiler/varpartitions.nim
@@ -479,7 +479,7 @@ proc destMightOwn(c: var Partitions; dest: var VarIndex; n: PNode) =
         # calls do construct, what we construct must be destroyed,
         # so dest cannot be a cursor:
         dest.flags.incl ownsData
-      elif n.typ.kind in {tyLent, tyVar}:
+      elif n.typ.kind in {tyLent, tyVar} and n.len > 1:
         # we know the result is derived from the first argument:
         var roots: seq[(PSym, int)]
         allRoots(n[1], roots, RootEscapes)

--- a/tests/arc/t18971.nim
+++ b/tests/arc/t18971.nim
@@ -1,0 +1,10 @@
+discard """
+  cmd: "nim c --gc:arc $file"
+"""
+
+type MyObj = ref object
+
+var o = MyObj()
+proc x: var MyObj = o
+
+var o2 = x()


### PR DESCRIPTION
since the example code in #18971 return value from global variable,
instead of first argument, the `n.len` is 1 which causes compiler crashes.