### PR TITLE
docstyle.rst: Do not export it to HTML as a standalone doc

### DIFF
--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -111,7 +111,10 @@ proc getRst2html(): seq[string] =
   for a in walkDirRecFilter("doc"):
     let path = a.path
     if a.kind == pcFile and path.splitFile.ext == ".rst" and path.lastPathPart notin
-        ["docs.rst", "nimfix.rst"]:
+        ["docs.rst", "nimfix.rst",
+         "docstyle.rst" # docstyle.rst shouldn't be converted to html separately;
+                        # it's included in contributing.rst.
+        ]:
           # maybe we should still show nimfix, could help reviving it
           # `docs` is redundant with `overview`, might as well remove that file?
       result.add path


### PR DESCRIPTION
This doc is included in `contributing.rst`, and so it shouldn't be exported separately.

[ The reason `docstyle.rst` was getting exported as a "module doc" was that this doc did not have any ReST Title markup. `rstgen.nim` assumes the doc to be a module doc if its .idx does not have a page title. See:

https://github.com/nim-lang/Nim/blob/4ee2ba7d489437a3591b238679439e48a65e0c86/lib/packages/docutils/rstgen.nim#L665-L666 

]

The reason `docstyle.rst` did not have a title was because it's included in `contributing.rst` as a level-1 heading section:

https://github.com/nim-lang/Nim/blob/4ee2ba7d489437a3591b238679439e48a65e0c86/doc/contributing.rst#L580

---


Fixes https://github.com/nim-lang/Nim/issues/14593.