### PR TITLE
manual: Document the use of `static` as a proc call

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2987,7 +2987,7 @@ Even some code that has side effects is permitted in a static block:
 
   # Below call evaluates the "getNum(123)" at compile time, but its
   # result gets used at run time.
-  echo getNum(123).static
+  echo static(getNum(123))
 
 There are limitations on what Nim code can be executed at compile time;
 see `Restrictions on Compile-Time Execution

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2975,6 +2975,21 @@ Even some code that has side effects is permitted in a static block:
   static:
     echo "echo at compile time"
 
+When `static` is used like a procedure call with a proc call as an argument,
+that proc call gets executed at compile-time.
+
+.. code-block:: nim
+
+  proc getNum(a: int): int = a
+
+  # Below calls "echo getNum(123)" at compile time.
+  static:
+    echo getNum(123)
+
+  # Below call evaluates the "getNum(123)" at compile time, but its
+  # result gets used at run time.
+  echo getNum(123).static
+
 There are limitations on what Nim code can be executed at compile time;
 see `Restrictions on Compile-Time Execution
 <#restrictions-on-compileminustime-execution>`_ for details.

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2975,8 +2975,7 @@ Even some code that has side effects is permitted in a static block:
   static:
     echo "echo at compile time"
 
-When `static` is used like a procedure call with a proc call as an argument,
-that proc call gets executed at compile-time.
+`static` can also be used like a routine.
 
 .. code-block:: nim
 

--- a/tests/system/tstatic_callable.nim
+++ b/tests/system/tstatic_callable.nim
@@ -1,0 +1,14 @@
+# issue# 16987
+
+proc getNum(a: int): int = a
+
+# Below calls "doAssert getNum(123) == 123" at compile time.
+static:
+  doAssert getNum(123) == 123
+
+# Below calls evaluate the "getNum(123)" at compile time, but the
+# results of those calls get used at run time.
+doAssert getNum(123).static == 123
+doAssert getNum(123).static() == 123
+doAssert (static getNum(123)) == 123
+doAssert (static(getNum(123))) == 123

--- a/tests/system/tstatic_callable.nim
+++ b/tests/system/tstatic_callable.nim
@@ -8,7 +8,5 @@ static:
 
 # Below calls evaluate the "getNum(123)" at compile time, but the
 # results of those calls get used at run time.
-doAssert getNum(123).static == 123
-doAssert getNum(123).static() == 123
 doAssert (static getNum(123)) == 123
 doAssert (static(getNum(123))) == 123

--- a/tests/system/tstatic_callable.nim
+++ b/tests/system/tstatic_callable.nim
@@ -1,4 +1,4 @@
-# issue# 16987
+# bug #16987
 
 proc getNum(a: int): int = a
 

--- a/tests/system/tstatic_callable_error.nim
+++ b/tests/system/tstatic_callable_error.nim
@@ -1,4 +1,4 @@
-# issue# 16987
+# bug #16987
 
 discard """
 errormsg: "cannot evaluate at compile time: inp"

--- a/tests/system/tstatic_callable_error.nim
+++ b/tests/system/tstatic_callable_error.nim
@@ -1,0 +1,14 @@
+# issue# 16987
+
+discard """
+errormsg: "cannot evaluate at compile time: inp"
+nimout: '''
+tstatic_callable_error.nim(14, 21) Error: cannot evaluate at compile time: inp'''
+"""
+
+
+# line 10
+proc getNum(a: int): int = a
+
+let inp = 123
+echo (static getNum(inp))


### PR DESCRIPTION
Also adds tests.

Fixes https://github.com/nim-lang/Nim/issues/16987 .

/cc @hlaaftana PTAL