### PR TITLE
Do not break interpolation for field init message string

### DIFF
--- a/compiler/semobjconstr.nim
+++ b/compiler/semobjconstr.nim
@@ -368,8 +368,7 @@ proc defaultConstructionError(c: PContext, t: PType, info: TLineInfo) =
     let initResult = semConstructTypeAux(c, constrCtx, {})
     assert constrCtx.missingFields.len > 0
     localError(c.config, info,
-      "The $1 type doesn't have a default value. The following fields must " &
-      "be initialized: $2." % [typeToString(t), listSymbolNames(constrCtx.missingFields)])
+      "The $1 type doesn't have a default value. The following fields must be initialized: $2." % [typeToString(t), listSymbolNames(constrCtx.missingFields)])
   elif objType.kind == tyDistinct:
     localError(c.config, info,
       "The $1 distinct type doesn't have a default value." % typeToString(t))


### PR DESCRIPTION
Otherwise, compiler produces broken error message - `$1` is not interpolated

`Error: The $1 type doesn't have a default value. The following fields must be initialized: importGraph.`