### PR TITLE
change os.nim doc links to new style

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -954,6 +954,13 @@ proc toLangSymbol(k: TSymKind, n: PNode, baseName: string): LangSymbol =
         if kind != tkSpaces:
           result.generics.add(literal.nimIdentNormalize)
 
+  if k == skType:
+    case n[2].kind
+    of nkEnumTy: result.symTypeKind = "enum"
+    of nkObjectTy: result.symTypeKind = "object"
+    of nkTupleTy: result.symTypeKind = "tuple"
+    else: discard
+
 proc genItem(d: PDoc, n, nameNode: PNode, k: TSymKind, docFlags: DocFlags) =
   if (docFlags != kForceExport) and not isVisible(d, nameNode): return
   let

--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -399,6 +399,13 @@ recognized fine::
       no backticks: `func [][T](x: openArray[T]): T`_
       escaped:  `func \`[]\`[T](x: openArray[T]): T`_
 
+.. Note:: Types that defined as `enum`, or `object`, or `tuple` can also be
+   referenced with those names directly (instead of `type`)::
+
+     type CopyFlag = enum
+       ...
+     ## Ref. `CopyFlag enum`_
+
 Related Options
 ===============
 

--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -56,13 +56,13 @@ when not defined(nimscript):
       ##
       ## If the variable does not exist, `""` is returned. To distinguish
       ## whether a variable exists or it's value is just `""`, call
-      ## `existsEnv(key) proc <#existsEnv,string>`_.
+      ## `existsEnv(key) proc`_.
       ##
       ## See also:
-      ## * `existsEnv proc <#existsEnv,string>`_
-      ## * `putEnv proc <#putEnv,string,string>`_
-      ## * `delEnv proc <#delEnv,string>`_
-      ## * `envPairs iterator <#envPairs.i>`_
+      ## * `existsEnv proc`_
+      ## * `putEnv proc`_
+      ## * `delEnv proc`_
+      ## * `envPairs iterator`_
       runnableExamples:
         assert getEnv("unknownEnv") == ""
         assert getEnv("unknownEnv", "doesn't exist") == "doesn't exist"
@@ -76,10 +76,10 @@ when not defined(nimscript):
       ## Returns true if it exists, false otherwise.
       ##
       ## See also:
-      ## * `getEnv proc <#getEnv,string,string>`_
-      ## * `putEnv proc <#putEnv,string,string>`_
-      ## * `delEnv proc <#delEnv,string>`_
-      ## * `envPairs iterator <#envPairs.i>`_
+      ## * `getEnv proc`_
+      ## * `putEnv proc`_
+      ## * `delEnv proc`_
+      ## * `envPairs iterator`_
       runnableExamples:
         assert not existsEnv("unknownEnv")
 
@@ -90,10 +90,10 @@ when not defined(nimscript):
       ## If an error occurs, `OSError` is raised.
       ##
       ## See also:
-      ## * `getEnv proc <#getEnv,string,string>`_
-      ## * `existsEnv proc <#existsEnv,string>`_
-      ## * `delEnv proc <#delEnv,string>`_
-      ## * `envPairs iterator <#envPairs.i>`_
+      ## * `getEnv proc`_
+      ## * `existsEnv proc`_
+      ## * `delEnv proc`_
+      ## * `envPairs iterator`_
       when defined(windows):
         if key.len == 0 or '=' in key:
           raise newException(OSError, "invalid key, got: " & $(key, val))
@@ -108,10 +108,10 @@ when not defined(nimscript):
       ## If an error occurs, `OSError` is raised.
       ##
       ## See also:ven
-      ## * `getEnv proc <#getEnv,string,string>`_
-      ## * `existsEnv proc <#existsEnv,string>`_
-      ## * `putEnv proc <#putEnv,string,string>`_
-      ## * `envPairs iterator <#envPairs.i>`_
+      ## * `getEnv proc`_
+      ## * `existsEnv proc`_
+      ## * `putEnv proc`_
+      ## * `envPairs iterator`_
       template bail = raiseOSError(osLastError(), key)
       when defined(windows):
         #[ 
@@ -190,10 +190,10 @@ iterator envPairs*(): tuple[key, value: string] {.tags: [ReadEnvEffect].} =
   ## in the second its value.
   ##
   ## Works in native backends, nodejs and vm, like the following APIs:
-  ## * `getEnv proc <#getEnv,string,string>`_
-  ## * `existsEnv proc <#existsEnv,string>`_
-  ## * `putEnv proc <#putEnv,string,string>`_
-  ## * `delEnv proc <#delEnv,string>`_
+  ## * `getEnv proc`_
+  ## * `existsEnv proc`_
+  ## * `putEnv proc`_
+  ## * `delEnv proc`_
   when nimvm:
     for ai in envPairsImplSeq(): yield ai
   else:

--- a/lib/pure/includes/oserr.nim
+++ b/lib/pure/includes/oserr.nim
@@ -18,7 +18,7 @@ proc `$`*(err: OSErrorCode): string {.borrow.}
 proc osErrorMsg*(errorCode: OSErrorCode): string =
   ## Converts an OS error code into a human readable string.
   ##
-  ## The error code can be retrieved using the `osLastError proc <#osLastError>`_.
+  ## The error code can be retrieved using the `osLastError proc`_.
   ##
   ## If conversion fails, or `errorCode` is `0` then `""` will be
   ## returned.
@@ -28,8 +28,8 @@ proc osErrorMsg*(errorCode: OSErrorCode): string =
   ## message.
   ##
   ## See also:
-  ## * `raiseOSError proc <#raiseOSError,OSErrorCode,string>`_
-  ## * `osLastError proc <#osLastError>`_
+  ## * `raiseOSError proc`_
+  ## * `osLastError proc`_
   runnableExamples:
     when defined(linux):
       assert osErrorMsg(OSErrorCode(0)) == ""
@@ -63,18 +63,17 @@ proc newOSError*(
   ## Creates a new `OSError exception <system.html#OSError>`_.
   ##
   ## The `errorCode` will determine the
-  ## message, `osErrorMsg proc <#osErrorMsg,OSErrorCode>`_ will be used
+  ## message, `osErrorMsg proc`_ will be used
   ## to get this message.
   ##
-  ## The error code can be retrieved using the `osLastError proc
-  ## <#osLastError>`_.
+  ## The error code can be retrieved using the `osLastError proc`_.
   ##
   ## If the error code is `0` or an error message could not be retrieved,
   ## the message `unknown OS error` will be used.
   ##
   ## See also:
-  ## * `osErrorMsg proc <#osErrorMsg,OSErrorCode>`_
-  ## * `osLastError proc <#osLastError>`_
+  ## * `osErrorMsg proc`_
+  ## * `osLastError proc`_
   var e: owned(ref OSError); new(e)
   e.errorCode = errorCode.int32
   e.msg = osErrorMsg(errorCode)
@@ -90,7 +89,7 @@ proc newOSError*(
 proc raiseOSError*(errorCode: OSErrorCode, additionalInfo = "") {.noinline.} =
   ## Raises an `OSError exception <system.html#OSError>`_.
   ##
-  ## Read the description of the `newOSError proc <#newOSError,OSErrorCode,string>`_ to learn
+  ## Read the description of the `newOSError proc`_ to learn
   ## how the exception object is created.
   raise newOSError(errorCode, additionalInfo)
 
@@ -109,8 +108,8 @@ proc osLastError*(): OSErrorCode {.sideEffect.} =
   ##   immediately after an OS call fails. On POSIX systems this is not a problem.
   ##
   ## See also:
-  ## * `osErrorMsg proc <#osErrorMsg,OSErrorCode>`_
-  ## * `raiseOSError proc <#raiseOSError,OSErrorCode,string>`_
+  ## * `osErrorMsg proc`_
+  ## * `raiseOSError proc`_
   when defined(nimscript):
     discard
   elif defined(windows):

--- a/lib/pure/includes/osseps.nim
+++ b/lib/pure/includes/osseps.nim
@@ -37,9 +37,9 @@ const
     when doslikeFileSystem: '/'
     else: DirSep
     ## An alternative character used by the operating system to separate
-    ## pathname components, or the same as `DirSep <#DirSep>`_ if only one separator
+    ## pathname components, or the same as DirSep_ if only one separator
     ## character exists. This is set to `'/'` on Windows systems
-    ## where `DirSep <#DirSep>`_ is a backslash (`'\\'`).
+    ## where DirSep_ is a backslash (`'\\'`).
 
   PathSep* =
     when defined(macos) or defined(RISCOS): ','
@@ -55,7 +55,7 @@ const
          defined(PalmOS) or defined(MorphOS): false
     else: true
     ## True if the file system is case sensitive, false otherwise. Used by
-    ## `cmpPaths proc <#cmpPaths,string,string>`_ to compare filenames properly.
+    ## `cmpPaths proc`_ to compare filenames properly.
 
   ExeExt* =
     when doslikeFileSystem: "exe"

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -21,9 +21,9 @@ runnableExamples:
 
 ## **See also:**
 ## * `osproc module <osproc.html>`_ for process communication beyond
-##   `execShellCmd proc <#execShellCmd,string>`_
+##   `execShellCmd proc`_
 ## * `parseopt module <parseopt.html>`_ for command-line parser beyond
-##   `parseCmdLine proc <#parseCmdLine,string>`_
+##   `parseCmdLine proc`_
 ## * `uri module <uri.html>`_
 ## * `distros module <distros.html>`_
 ## * `dynlib module <dynlib.html>`_
@@ -152,9 +152,9 @@ proc joinPath*(head, tail: string): string {.
   ## head has one).
   ##
   ## See also:
-  ## * `joinPath(varargs) proc <#joinPath,varargs[string]>`_
-  ## * `/ proc <#/,string,string>`_
-  ## * `splitPath proc <#splitPath,string>`_
+  ## * `joinPath(parts: varargs[string]) proc`_
+  ## * `/ proc`_
+  ## * `splitPath proc`_
   ## * `uri.combine proc <uri.html#combine,Uri,Uri>`_
   ## * `uri./ proc <uri.html#/,Uri,string>`_
   runnableExamples:
@@ -189,17 +189,17 @@ proc joinPath*(head, tail: string): string {.
 
 proc joinPath*(parts: varargs[string]): string {.noSideEffect,
   rtl, extern: "nos$1OpenArray".} =
-  ## The same as `joinPath(head, tail) proc <#joinPath,string,string>`_,
+  ## The same as `joinPath(head, tail) proc`_,
   ## but works with any number of directory parts.
   ##
   ## You need to pass at least one element or the proc
   ## will assert in debug builds and crash on release builds.
   ##
   ## See also:
-  ## * `joinPath(head, tail) proc <#joinPath,string,string>`_
-  ## * `/ proc <#/,string,string>`_
-  ## * `/../ proc <#/../,string,string>`_
-  ## * `splitPath proc <#splitPath,string>`_
+  ## * `joinPath(head, tail) proc`_
+  ## * `/ proc`_
+  ## * `/../ proc`_
+  ## * `splitPath proc`_
   runnableExamples:
     when defined(posix):
       assert joinPath("a") == "a"
@@ -214,13 +214,13 @@ proc joinPath*(parts: varargs[string]): string {.noSideEffect,
     joinPathImpl(result, state, parts[i])
 
 proc `/`*(head, tail: string): string {.noSideEffect, inline.} =
-  ## The same as `joinPath(head, tail) proc <#joinPath,string,string>`_.
+  ## The same as `joinPath(head, tail) proc`_.
   ##
   ## See also:
-  ## * `/../ proc <#/../,string,string>`_
-  ## * `joinPath(head, tail) proc <#joinPath,string,string>`_
-  ## * `joinPath(varargs) proc <#joinPath,varargs[string]>`_
-  ## * `splitPath proc <#splitPath,string>`_
+  ## * `/../ proc`_
+  ## * `joinPath(head, tail) proc`_
+  ## * `joinPath(parts: varargs[string]) proc`_
+  ## * `splitPath proc`_
   ## * `uri.combine proc <uri.html#combine,Uri,Uri>`_
   ## * `uri./ proc <uri.html#/,Uri,string>`_
   runnableExamples:
@@ -239,11 +239,11 @@ proc splitPath*(path: string): tuple[head, tail: string] {.
   ## ``head / tail == path`` (except for edge cases like "/usr").
   ##
   ## See also:
-  ## * `joinPath(head, tail) proc <#joinPath,string,string>`_
-  ## * `joinPath(varargs) proc <#joinPath,varargs[string]>`_
-  ## * `/ proc <#/,string,string>`_
-  ## * `/../ proc <#/../,string,string>`_
-  ## * `relativePath proc <#relativePath,string,string>`_
+  ## * `joinPath(head, tail) proc`_
+  ## * `joinPath(parts: varargs[string]) proc`_
+  ## * `/ proc`_
+  ## * `/../ proc`_
+  ## * `relativePath proc`_
   runnableExamples:
     assert splitPath("usr/local/bin") == ("usr/local", "bin")
     assert splitPath("usr/local/bin/") == ("usr/local/bin", "")
@@ -366,7 +366,7 @@ proc relativePath*(path, base: string, sep = DirSep): string {.
   rtl, extern: "nos$1".} =
   ## Converts `path` to a path relative to `base`.
   ##
-  ## The `sep` (default: `DirSep <#DirSep>`_) is used for the path normalizations,
+  ## The `sep` (default: DirSep_) is used for the path normalizations,
   ## this can be useful to ensure the relative path only contains `'/'`
   ## so that it can be used for URL constructions.
   ##
@@ -375,9 +375,9 @@ proc relativePath*(path, base: string, sep = DirSep): string {.
   ## That means an absolute path can be returned.
   ##
   ## See also:
-  ## * `splitPath proc <#splitPath,string>`_
-  ## * `parentDir proc <#parentDir,string>`_
-  ## * `tailDir proc <#tailDir,string>`_
+  ## * `splitPath proc`_
+  ## * `parentDir proc`_
+  ## * `tailDir proc`_
   runnableExamples:
     assert relativePath("/Users/me/bar/z.nim", "/Users/other/bad", '/') == "../../me/bar/z.nim"
     assert relativePath("/Users/me/bar/z.nim", "/Users/other", '/') == "../me/bar/z.nim"
@@ -476,14 +476,13 @@ proc parentDir*(path: string): string {.
   ##
   ## This is similar to ``splitPath(path).head`` when ``path`` doesn't end
   ## in a dir separator, but also takes care of path normalizations.
-  ## The remainder can be obtained with `lastPathPart(path) proc
-  ## <#lastPathPart,string>`_.
+  ## The remainder can be obtained with `lastPathPart(path) proc`_.
   ##
   ## See also:
-  ## * `relativePath proc <#relativePath,string,string>`_
-  ## * `splitPath proc <#splitPath,string>`_
-  ## * `tailDir proc <#tailDir,string>`_
-  ## * `parentDirs iterator <#parentDirs.i,string>`_
+  ## * `relativePath proc`_
+  ## * `splitPath proc`_
+  ## * `tailDir proc`_
+  ## * `parentDirs iterator`_
   runnableExamples:
     assert parentDir("") == ""
     when defined(posix):
@@ -511,9 +510,9 @@ proc tailDir*(path: string): string {.
   ## Returns the tail part of `path`.
   ##
   ## See also:
-  ## * `relativePath proc <#relativePath,string,string>`_
-  ## * `splitPath proc <#splitPath,string>`_
-  ## * `parentDir proc <#parentDir,string>`_
+  ## * `relativePath proc`_
+  ## * `splitPath proc`_
+  ## * `parentDir proc`_
   runnableExamples:
     assert tailDir("/bin") == "bin"
     assert tailDir("bin") == ""
@@ -556,7 +555,7 @@ iterator parentDirs*(path: string, fromRoot=false, inclusive=true): string =
   ## only the directories appearing in the relative path.
   ##
   ## See also:
-  ## * `parentDir proc <#parentDir,string>`_
+  ## * `parentDir proc`_
   ##
   runnableExamples:
     let g = "a/b/c"
@@ -599,8 +598,8 @@ proc `/../`*(head, tail: string): string {.noSideEffect.} =
   ## directory. Then ``head / tail`` is performed instead.
   ##
   ## See also:
-  ## * `/ proc <#/,string,string>`_
-  ## * `parentDir proc <#parentDir,string>`_
+  ## * `/ proc`_
+  ## * `parentDir proc`_
   runnableExamples:
     when defined(posix):
       assert "a/b/c" /../ "d/e" == "a/b/d/e"
@@ -621,11 +620,11 @@ proc searchExtPos*(path: string): int =
   ## of extension. Returns -1 otherwise.
   ##
   ## See also:
-  ## * `splitFile proc <#splitFile,string>`_
-  ## * `extractFilename proc <#extractFilename,string>`_
-  ## * `lastPathPart proc <#lastPathPart,string>`_
-  ## * `changeFileExt proc <#changeFileExt,string,string>`_
-  ## * `addFileExt proc <#addFileExt,string,string>`_
+  ## * `splitFile proc`_
+  ## * `extractFilename proc`_
+  ## * `lastPathPart proc`_
+  ## * `changeFileExt proc`_
+  ## * `addFileExt proc`_
   runnableExamples:
     assert searchExtPos("a/b/c") == -1
     assert searchExtPos("c.nim") == 1
@@ -645,7 +644,7 @@ proc splitFile*(path: string): tuple[dir, name, ext: string] {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Splits a filename into `(dir, name, extension)` tuple.
   ##
-  ## `dir` does not end in `DirSep <#DirSep>`_ unless it's `/`.
+  ## `dir` does not end in DirSep_ unless it's `/`.
   ## `extension` includes the leading dot.
   ##
   ## If `path` has no extension, `ext` is the empty string.
@@ -653,11 +652,11 @@ proc splitFile*(path: string): tuple[dir, name, ext: string] {.
   ## If `path` has no filename component, `name` and `ext` are empty strings.
   ##
   ## See also:
-  ## * `searchExtPos proc <#searchExtPos,string>`_
-  ## * `extractFilename proc <#extractFilename,string>`_
-  ## * `lastPathPart proc <#lastPathPart,string>`_
-  ## * `changeFileExt proc <#changeFileExt,string,string>`_
-  ## * `addFileExt proc <#addFileExt,string,string>`_
+  ## * `searchExtPos proc`_
+  ## * `extractFilename proc`_
+  ## * `lastPathPart proc`_
+  ## * `changeFileExt proc`_
+  ## * `addFileExt proc`_
   runnableExamples:
     var (dir, name, ext) = splitFile("usr/local/nimc.html")
     assert dir == "usr/local"
@@ -698,15 +697,14 @@ proc extractFilename*(path: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =
   ## Extracts the filename of a given `path`.
   ##
-  ## This is the same as ``name & ext`` from `splitFile(path) proc
-  ## <#splitFile,string>`_.
+  ## This is the same as ``name & ext`` from `splitFile(path) proc`_.
   ##
   ## See also:
-  ## * `searchExtPos proc <#searchExtPos,string>`_
-  ## * `splitFile proc <#splitFile,string>`_
-  ## * `lastPathPart proc <#lastPathPart,string>`_
-  ## * `changeFileExt proc <#changeFileExt,string,string>`_
-  ## * `addFileExt proc <#addFileExt,string,string>`_
+  ## * `searchExtPos proc`_
+  ## * `splitFile proc`_
+  ## * `lastPathPart proc`_
+  ## * `changeFileExt proc`_
+  ## * `addFileExt proc`_
   runnableExamples:
     assert extractFilename("foo/bar/") == ""
     assert extractFilename("foo/bar") == "bar"
@@ -719,15 +717,15 @@ proc extractFilename*(path: string): string {.
 
 proc lastPathPart*(path: string): string {.
   noSideEffect, rtl, extern: "nos$1".} =
-  ## Like `extractFilename proc <#extractFilename,string>`_, but ignores
+  ## Like `extractFilename proc`_, but ignores
   ## trailing dir separator; aka: `baseName`:idx: in some other languages.
   ##
   ## See also:
-  ## * `searchExtPos proc <#searchExtPos,string>`_
-  ## * `splitFile proc <#splitFile,string>`_
-  ## * `extractFilename proc <#extractFilename,string>`_
-  ## * `changeFileExt proc <#changeFileExt,string,string>`_
-  ## * `addFileExt proc <#addFileExt,string,string>`_
+  ## * `searchExtPos proc`_
+  ## * `splitFile proc`_
+  ## * `extractFilename proc`_
+  ## * `changeFileExt proc`_
+  ## * `addFileExt proc`_
   runnableExamples:
     assert lastPathPart("foo/bar/") == "bar"
     assert lastPathPart("foo/bar") == "bar"
@@ -747,11 +745,11 @@ proc changeFileExt*(filename, ext: string): string {.
   ## of none such beast.)
   ##
   ## See also:
-  ## * `searchExtPos proc <#searchExtPos,string>`_
-  ## * `splitFile proc <#splitFile,string>`_
-  ## * `extractFilename proc <#extractFilename,string>`_
-  ## * `lastPathPart proc <#lastPathPart,string>`_
-  ## * `addFileExt proc <#addFileExt,string,string>`_
+  ## * `searchExtPos proc`_
+  ## * `splitFile proc`_
+  ## * `extractFilename proc`_
+  ## * `lastPathPart proc`_
+  ## * `addFileExt proc`_
   runnableExamples:
     assert changeFileExt("foo.bar", "baz") == "foo.baz"
     assert changeFileExt("foo.bar", "") == "foo"
@@ -771,11 +769,11 @@ proc addFileExt*(filename, ext: string): string {.
   ## (Although I know of none such beast.)
   ##
   ## See also:
-  ## * `searchExtPos proc <#searchExtPos,string>`_
-  ## * `splitFile proc <#splitFile,string>`_
-  ## * `extractFilename proc <#extractFilename,string>`_
-  ## * `lastPathPart proc <#lastPathPart,string>`_
-  ## * `changeFileExt proc <#changeFileExt,string,string>`_
+  ## * `searchExtPos proc`_
+  ## * `splitFile proc`_
+  ## * `extractFilename proc`_
+  ## * `lastPathPart proc`_
+  ## * `changeFileExt proc`_
   runnableExamples:
     assert addFileExt("foo.bar", "baz") == "foo.bar"
     assert addFileExt("foo.bar", "") == "foo.bar"
@@ -875,15 +873,15 @@ proc getHomeDir*(): string {.rtl, extern: "nos$1",
   tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Returns the home directory of the current user.
   ##
-  ## This proc is wrapped by the `expandTilde proc <#expandTilde,string>`_
+  ## This proc is wrapped by the `expandTilde proc`_
   ## for the convenience of processing paths coming from user configuration files.
   ##
   ## See also:
-  ## * `getConfigDir proc <#getConfigDir>`_
-  ## * `getTempDir proc <#getTempDir>`_
-  ## * `expandTilde proc <#expandTilde,string>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
-  ## * `setCurrentDir proc <#setCurrentDir,string>`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
   runnableExamples:
     assert getHomeDir() == expandTilde("~")
 
@@ -903,11 +901,11 @@ proc getConfigDir*(): string {.rtl, extern: "nos$1",
   ## returned string: `\\` on Windows and `/` on all other OSs.
   ##
   ## See also:
-  ## * `getHomeDir proc <#getHomeDir>`_
-  ## * `getTempDir proc <#getTempDir>`_
-  ## * `expandTilde proc <#expandTilde,string>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
-  ## * `setCurrentDir proc <#setCurrentDir,string>`_
+  ## * `getHomeDir proc`_
+  ## * `getTempDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
   when defined(windows):
     result = getEnv("APPDATA")
   else:
@@ -927,9 +925,9 @@ proc getCacheDir*(): string =
   ## * On other platforms: `getEnv("XDG_CACHE_HOME", getEnv("HOME") / ".cache")`
   ##
   ## **See also:**
-  ## * `getHomeDir proc <#getHomeDir>`_
-  ## * `getTempDir proc <#getTempDir>`_
-  ## * `getConfigDir proc <#getConfigDir>`_
+  ## * `getHomeDir proc`_
+  ## * `getTempDir proc`_
+  ## * `getConfigDir proc`_
   # follows https://crates.io/crates/platform-dirs
   when defined(windows):
     result = getEnv("LOCALAPPDATA")
@@ -985,11 +983,11 @@ proc getTempDir*(): string {.rtl, extern: "nos$1",
   ## **Note:** This proc does not check whether the returned path exists.
   ##
   ## See also:
-  ## * `getHomeDir proc <#getHomeDir>`_
-  ## * `getConfigDir proc <#getConfigDir>`_
-  ## * `expandTilde proc <#expandTilde,string>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
-  ## * `setCurrentDir proc <#setCurrentDir,string>`_
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `expandTilde proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
   const tempDirDefault = "/tmp"
   when defined(tempDir):
     const tempDir {.strdefine.}: string = tempDirDefault
@@ -1015,17 +1013,17 @@ proc getTempDir*(): string {.rtl, extern: "nos$1",
 proc expandTilde*(path: string): string {.
   tags: [ReadEnvEffect, ReadIOEffect].} =
   ## Expands ``~`` or a path starting with ``~/`` to a full path, replacing
-  ## ``~`` with `getHomeDir() <#getHomeDir>`_ (otherwise returns ``path`` unmodified).
+  ## ``~`` with `getHomeDir()`_ (otherwise returns ``path`` unmodified).
   ##
   ## Windows: this is still supported despite the Windows platform not having this
   ## convention; also, both ``~/`` and ``~\`` are handled.
   ##
   ## See also:
-  ## * `getHomeDir proc <#getHomeDir>`_
-  ## * `getConfigDir proc <#getConfigDir>`_
-  ## * `getTempDir proc <#getTempDir>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
-  ## * `setCurrentDir proc <#setCurrentDir,string>`_
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `getCurrentDir proc`_
+  ## * `setCurrentDir proc`_
   runnableExamples:
     assert expandTilde("~" / "appname.cfg") == getHomeDir() / "appname.cfg"
     assert expandTilde("~/foo/bar") == getHomeDir() / "foo/bar"
@@ -1089,9 +1087,8 @@ when defined(windows) or defined(posix) or defined(nintendoswitch):
   proc quoteShell*(s: string): string {.noSideEffect, rtl, extern: "nosp$1".} =
     ## Quote ``s``, so it can be safely passed to shell.
     ##
-    ## When on Windows, it calls `quoteShellWindows proc
-    ## <#quoteShellWindows,string>`_. Otherwise, calls `quoteShellPosix proc
-    ## <#quoteShellPosix,string>`_.
+    ## When on Windows, it calls `quoteShellWindows proc`_.
+    ## Otherwise, calls `quoteShellPosix proc`_.
     when defined(windows):
       result = quoteShellWindows(s)
     else:
@@ -1158,8 +1155,8 @@ proc fileExists*(filename: string): bool {.rtl, extern: "nos$1",
   ## Directories, device files, named pipes and sockets return false.
   ##
   ## See also:
-  ## * `dirExists proc <#dirExists,string>`_
-  ## * `symlinkExists proc <#symlinkExists,string>`_
+  ## * `dirExists proc`_
+  ## * `symlinkExists proc`_
   when defined(windows):
     when useWinUnicode:
       wrapUnary(a, getFileAttributesW, filename)
@@ -1177,8 +1174,8 @@ proc dirExists*(dir: string): bool {.rtl, extern: "nos$1", tags: [ReadDirEffect]
   ## is returned. Follows symlinks.
   ##
   ## See also:
-  ## * `fileExists proc <#fileExists,string>`_
-  ## * `symlinkExists proc <#symlinkExists,string>`_
+  ## * `fileExists proc`_
+  ## * `symlinkExists proc`_
   when defined(windows):
     when useWinUnicode:
       wrapUnary(a, getFileAttributesW, dir)
@@ -1197,8 +1194,8 @@ proc symlinkExists*(link: string): bool {.rtl, extern: "nos$1",
   ## regardless of whether the link points to a directory or file.
   ##
   ## See also:
-  ## * `fileExists proc <#fileExists,string>`_
-  ## * `dirExists proc <#dirExists,string>`_
+  ## * `fileExists proc`_
+  ## * `dirExists proc`_
   when defined(windows):
     when useWinUnicode:
       wrapUnary(a, getFileAttributesW, link)
@@ -1228,7 +1225,7 @@ proc findExe*(exe: string, followSymlinks: bool = true;
   ## in directories listed in the ``PATH`` environment variable.
   ##
   ## Returns `""` if the `exe` cannot be found. `exe`
-  ## is added the `ExeExts <#ExeExts>`_ file extensions if it has none.
+  ## is added the `ExeExts`_ file extensions if it has none.
   ##
   ## If the system supports symlinks it also resolves them until it
   ## meets the actual file. This behavior can be disabled if desired
@@ -1283,9 +1280,9 @@ proc getLastModificationTime*(file: string): times.Time {.rtl, extern: "nos$1", 
   ## Returns the `file`'s last modification time.
   ##
   ## See also:
-  ## * `getLastAccessTime proc <#getLastAccessTime,string>`_
-  ## * `getCreationTime proc <#getCreationTime,string>`_
-  ## * `fileNewer proc <#fileNewer,string,string>`_
+  ## * `getLastAccessTime proc`_
+  ## * `getCreationTime proc`_
+  ## * `fileNewer proc`_
   when defined(posix):
     var res: Stat
     if stat(file, res) < 0'i32: raiseOSError(osLastError(), file)
@@ -1301,9 +1298,9 @@ proc getLastAccessTime*(file: string): times.Time {.rtl, extern: "nos$1", noWeir
   ## Returns the `file`'s last read or write access time.
   ##
   ## See also:
-  ## * `getLastModificationTime proc <#getLastModificationTime,string>`_
-  ## * `getCreationTime proc <#getCreationTime,string>`_
-  ## * `fileNewer proc <#fileNewer,string,string>`_
+  ## * `getLastModificationTime proc`_
+  ## * `getCreationTime proc`_
+  ## * `fileNewer proc`_
   when defined(posix):
     var res: Stat
     if stat(file, res) < 0'i32: raiseOSError(osLastError(), file)
@@ -1323,9 +1320,9 @@ proc getCreationTime*(file: string): times.Time {.rtl, extern: "nos$1", noWeirdT
   ## `here <https://github.com/nim-lang/Nim/issues/1058>`_ for details.
   ##
   ## See also:
-  ## * `getLastModificationTime proc <#getLastModificationTime,string>`_
-  ## * `getLastAccessTime proc <#getLastAccessTime,string>`_
-  ## * `fileNewer proc <#fileNewer,string,string>`_
+  ## * `getLastModificationTime proc`_
+  ## * `getLastAccessTime proc`_
+  ## * `fileNewer proc`_
   when defined(posix):
     var res: Stat
     if stat(file, res) < 0'i32: raiseOSError(osLastError(), file)
@@ -1342,9 +1339,9 @@ proc fileNewer*(a, b: string): bool {.rtl, extern: "nos$1", noWeirdTarget.} =
   ## modification time is later than `b`'s.
   ##
   ## See also:
-  ## * `getLastModificationTime proc <#getLastModificationTime,string>`_
-  ## * `getLastAccessTime proc <#getLastAccessTime,string>`_
-  ## * `getCreationTime proc <#getCreationTime,string>`_
+  ## * `getLastModificationTime proc`_
+  ## * `getLastAccessTime proc`_
+  ## * `getCreationTime proc`_
   when defined(posix):
     # If we don't have access to nanosecond resolution, use '>='
     when not StatHasNanoseconds:
@@ -1362,10 +1359,10 @@ when not defined(nimscript):
     ## So the path returned by this proc is determined at run time.
     ##
     ## See also:
-    ## * `getHomeDir proc <#getHomeDir>`_
-    ## * `getConfigDir proc <#getConfigDir>`_
-    ## * `getTempDir proc <#getTempDir>`_
-    ## * `setCurrentDir proc <#setCurrentDir,string>`_
+    ## * `getHomeDir proc`_
+    ## * `getConfigDir proc`_
+    ## * `getTempDir proc`_
+    ## * `setCurrentDir proc`_
     ## * `currentSourcePath template <system.html#currentSourcePath.t>`_
     ## * `getProjectPath proc <macros.html#getProjectPath>`_
     when defined(nodejs):
@@ -1421,10 +1418,10 @@ proc setCurrentDir*(newDir: string) {.inline, tags: [], noWeirdTarget.} =
   ## is raised if `newDir` cannot been set.
   ##
   ## See also:
-  ## * `getHomeDir proc <#getHomeDir>`_
-  ## * `getConfigDir proc <#getConfigDir>`_
-  ## * `getTempDir proc <#getTempDir>`_
-  ## * `getCurrentDir proc <#getCurrentDir>`_
+  ## * `getHomeDir proc`_
+  ## * `getConfigDir proc`_
+  ## * `getTempDir proc`_
+  ## * `getCurrentDir proc`_
   when defined(windows):
     when useWinUnicode:
       if setCurrentDirectoryW(newWideCString(newDir)) == 0'i32:
@@ -1441,8 +1438,8 @@ proc absolutePath*(path: string, root = getCurrentDir()): string =
   ## If `path` is absolute, return it, ignoring `root`.
   ##
   ## See also:
-  ## * `normalizedPath proc <#normalizedPath,string>`_
-  ## * `normalizePath proc <#normalizePath,string>`_
+  ## * `normalizedPath proc`_
+  ## * `normalizePath proc`_
   runnableExamples:
     assert absolutePath("a") == getCurrentDir() / "a"
 
@@ -1479,9 +1476,9 @@ proc normalizePath*(path: var string) {.rtl, extern: "nos$1", tags: [].} =
   ##   Triple dot is not handled.
   ##
   ## See also:
-  ## * `absolutePath proc <#absolutePath,string>`_
-  ## * `normalizedPath proc <#normalizedPath,string>`_ for outplace version
-  ## * `normalizeExe proc <#normalizeExe,string>`_
+  ## * `absolutePath proc`_
+  ## * `normalizedPath proc`_ for outplace version
+  ## * `normalizeExe proc`_
   runnableExamples:
     when defined(posix):
       var a = "a///b//..//c///d"
@@ -1522,8 +1519,8 @@ proc normalizedPath*(path: string): string {.rtl, extern: "nos$1", tags: [].} =
   ## Returns a normalized path for the current OS.
   ##
   ## See also:
-  ## * `absolutePath proc <#absolutePath,string>`_
-  ## * `normalizePath proc <#normalizePath,string>`_ for the in-place version
+  ## * `absolutePath proc`_
+  ## * `normalizePath proc`_ for the in-place version
   runnableExamples:
     when defined(posix):
       assert normalizedPath("a///b//..//c///d") == "a/c/d"
@@ -1561,7 +1558,7 @@ proc sameFile*(path1, path2: string): bool {.rtl, extern: "nos$1",
   ## sym-linked paths to the same file or directory.
   ##
   ## See also:
-  ## * `sameFileContent proc <#sameFileContent,string,string>`_
+  ## * `sameFileContent proc`_
   when defined(windows):
     var success = true
     var f1 = openHandle(path1)
@@ -1598,9 +1595,9 @@ type
   FilePermission* = enum   ## File access permission, modelled after UNIX.
     ##
     ## See also:
-    ## * `getFilePermissions <#getFilePermissions,string>`_
-    ## * `setFilePermissions <#setFilePermissions,string,set[FilePermission]>`_
-    ## * `FileInfo object <#FileInfo>`_
+    ## * `getFilePermissions`_
+    ## * `setFilePermissions`_
+    ## * `FileInfo object`_
     fpUserExec,            ## execute access for the file owner
     fpUserWrite,           ## write access for the file owner
     fpUserRead,            ## read access for the file owner
@@ -1620,8 +1617,8 @@ proc getFilePermissions*(filename: string): set[FilePermission] {.
   ## permission is available in any case.
   ##
   ## See also:
-  ## * `setFilePermissions proc <#setFilePermissions,string,set[FilePermission]>`_
-  ## * `FilePermission enum <#FilePermission>`_
+  ## * `setFilePermissions proc`_
+  ## * `FilePermission enum`_
   when defined(posix):
     var a: Stat
     if stat(filename, a) < 0'i32: raiseOSError(osLastError(), filename)
@@ -1666,8 +1663,8 @@ proc setFilePermissions*(filename: string, permissions: set[FilePermission],
   ## ``fpUserWrite`` permission.
   ##
   ## See also:
-  ## * `getFilePermissions <#getFilePermissions,string>`_
-  ## * `FilePermission enum <#FilePermission>`_
+  ## * `getFilePermissions proc`_
+  ## * `FilePermission enum`_
   when defined(posix):
     var p = 0.Mode
     if fpUserRead in permissions: p = p or S_IRUSR.Mode
@@ -1744,8 +1741,8 @@ proc createSymlink*(src, dest: string) {.noWeirdTarget.} =
   ##   of symlinks to root users (administrators) or users with developper mode enabled.
   ##
   ## See also:
-  ## * `createHardlink proc <#createHardlink,string,string>`_
-  ## * `expandSymlink proc <#expandSymlink,string>`_
+  ## * `createHardlink proc`_
+  ## * `expandSymlink proc`_
 
   when defined(windows):
     const SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 2
@@ -1769,7 +1766,7 @@ proc expandSymlink*(symlinkPath: string): string {.noWeirdTarget.} =
   ## On Windows this is a noop, `symlinkPath` is simply returned.
   ##
   ## See also:
-  ## * `createSymlink proc <#createSymlink,string,string>`_
+  ## * `createSymlink proc`_
   when defined(windows):
     result = symlinkPath
   else:
@@ -1823,11 +1820,11 @@ proc copyFile*(source, dest: string, options = {cfSymlinkFollow}) {.rtl,
   ## copy the source file's attributes into dest.
   ##
   ## On other platforms you need
-  ## to use `getFilePermissions <#getFilePermissions,string>`_ and
-  ## `setFilePermissions <#setFilePermissions,string,set[FilePermission]>`_
+  ## to use `getFilePermissions`_ and
+  ## `setFilePermissions`_
   ## procs
   ## to copy them by hand (or use the convenience `copyFileWithPermissions
-  ## proc <#copyFileWithPermissions,string,string>`_),
+  ## proc`_),
   ## otherwise `dest` will inherit the default permissions of a newly
   ## created file for the user.
   ##
@@ -1838,12 +1835,12 @@ proc copyFile*(source, dest: string, options = {cfSymlinkFollow}) {.rtl,
   ## `-d:nimLegacyCopyFile` is used.
   ##
   ## See also:
-  ## * `CopyFlag enum <#CopyFlag>`_
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `copyFileWithPermissions proc <#copyFileWithPermissions,string,string>`_
-  ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
-  ## * `removeFile proc <#removeFile,string>`_
-  ## * `moveFile proc <#moveFile,string,string>`_
+  ## * `CopyFlag enum`_
+  ## * `copyDir proc`_
+  ## * `copyFileWithPermissions proc`_
+  ## * `tryRemoveFile proc`_
+  ## * `removeFile proc`_
+  ## * `moveFile proc`_
 
   doAssert card(copyFlagSymlink * options) == 1, "There should be exactly " &
                                                  "one cfSymlink* in options"
@@ -1908,8 +1905,8 @@ proc copyFileToDir*(source, dir: string, options = {cfSymlinkFollow})
   ## ignored on Windows: symlinks are skipped.
   ##
   ## See also:
-  ## * `CopyFlag enum <#CopyFlag>`_
-  ## * `copyFile proc <#copyDir,string,string>`_
+  ## * `CopyFlag enum`_
+  ## * `copyFile proc`_
   if dir.len == 0: # treating "" as "." is error prone
     raise newException(ValueError, "dest is empty")
   copyFile(source, dir / source.lastPathPart, options)
@@ -1942,10 +1939,10 @@ proc tryRemoveFile*(file: string): bool {.rtl, extern: "nos$1", tags: [WriteDirE
   ## On Windows, ignores the read-only attribute.
   ##
   ## See also:
-  ## * `copyFile proc <#copyFile,string,string>`_
-  ## * `copyFileWithPermissions proc <#copyFileWithPermissions,string,string>`_
-  ## * `removeFile proc <#removeFile,string>`_
-  ## * `moveFile proc <#moveFile,string,string>`_
+  ## * `copyFile proc`_
+  ## * `copyFileWithPermissions proc`_
+  ## * `removeFile proc`_
+  ## * `moveFile proc`_
   result = true
   when defined(windows):
     when useWinUnicode:
@@ -1974,11 +1971,11 @@ proc removeFile*(file: string) {.rtl, extern: "nos$1", tags: [WriteDirEffect], n
   ## On Windows, ignores the read-only attribute.
   ##
   ## See also:
-  ## * `removeDir proc <#removeDir,string>`_
-  ## * `copyFile proc <#copyFile,string,string>`_
-  ## * `copyFileWithPermissions proc <#copyFileWithPermissions,string,string>`_
-  ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
-  ## * `moveFile proc <#moveFile,string,string>`_
+  ## * `removeDir proc`_
+  ## * `copyFile proc`_
+  ## * `copyFileWithPermissions proc`_
+  ## * `tryRemoveFile proc`_
+  ## * `moveFile proc`_
   if not tryRemoveFile(file):
     raiseOSError(osLastError(), file)
 
@@ -2022,11 +2019,11 @@ proc moveFile*(source, dest: string) {.rtl, extern: "nos$1",
   ## Can be used to `rename files`:idx:.
   ##
   ## See also:
-  ## * `moveDir proc <#moveDir,string,string>`_
-  ## * `copyFile proc <#copyFile,string,string>`_
-  ## * `copyFileWithPermissions proc <#copyFileWithPermissions,string,string>`_
-  ## * `removeFile proc <#removeFile,string>`_
-  ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
+  ## * `moveDir proc`_
+  ## * `copyFile proc`_
+  ## * `copyFileWithPermissions proc`_
+  ## * `removeFile proc`_
+  ## * `tryRemoveFile proc`_
 
   if not tryMoveFSObject(source, dest, isDir = false):
     when defined(windows):
@@ -2135,10 +2132,10 @@ iterator walkPattern*(pattern: string): string {.tags: [ReadDirEffect], noWeirdT
   ## notation is supported.
   ##
   ## See also:
-  ## * `walkFiles iterator <#walkFiles.i,string>`_
-  ## * `walkDirs iterator <#walkDirs.i,string>`_
-  ## * `walkDir iterator <#walkDir.i,string>`_
-  ## * `walkDirRec iterator <#walkDirRec.i,string>`_
+  ## * `walkFiles iterator`_
+  ## * `walkDirs iterator`_
+  ## * `walkDir iterator`_
+  ## * `walkDirRec iterator`_
   runnableExamples:
     import std/sequtils
     let paths = toSeq(walkPattern("lib/pure/*")) # works on Windows too
@@ -2154,10 +2151,10 @@ iterator walkFiles*(pattern: string): string {.tags: [ReadDirEffect], noWeirdTar
   ## notation is supported.
   ##
   ## See also:
-  ## * `walkPattern iterator <#walkPattern.i,string>`_
-  ## * `walkDirs iterator <#walkDirs.i,string>`_
-  ## * `walkDir iterator <#walkDir.i,string>`_
-  ## * `walkDirRec iterator <#walkDirRec.i,string>`_
+  ## * `walkPattern iterator`_
+  ## * `walkDirs iterator`_
+  ## * `walkDir iterator`_
+  ## * `walkDirRec iterator`_
   runnableExamples:
     import std/sequtils
     assert "lib/pure/os.nim".unixToNativePath in toSeq(walkFiles("lib/pure/*.nim")) # works on Windows too
@@ -2171,10 +2168,10 @@ iterator walkDirs*(pattern: string): string {.tags: [ReadDirEffect], noWeirdTarg
   ## notation is supported.
   ##
   ## See also:
-  ## * `walkPattern iterator <#walkPattern.i,string>`_
-  ## * `walkFiles iterator <#walkFiles.i,string>`_
-  ## * `walkDir iterator <#walkDir.i,string>`_
-  ## * `walkDirRec iterator <#walkDirRec.i,string>`_
+  ## * `walkPattern iterator`_
+  ## * `walkFiles iterator`_
+  ## * `walkDir iterator`_
+  ## * `walkDirRec iterator`_
   runnableExamples:
     import std/sequtils
     let paths = toSeq(walkDirs("lib/pure/*")) # works on Windows too
@@ -2235,15 +2232,15 @@ type
   PathComponent* = enum   ## Enumeration specifying a path component.
     ##
     ## See also:
-    ## * `walkDirRec iterator <#walkDirRec.i,string>`_
-    ## * `FileInfo object <#FileInfo>`_
+    ## * `walkDirRec iterator`_
+    ## * `FileInfo object`_
     pcFile,               ## path refers to a file
     pcLinkToFile,         ## path refers to a symbolic link to a file
     pcDir,                ## path refers to a directory
     pcLinkToDir           ## path refers to a symbolic link to a directory
 
 proc getCurrentCompilerExe*(): string {.compileTime.} = discard
-  ## This is `getAppFilename() <#getAppFilename>`_ at compile time.
+  ## This is `getAppFilename()`_ at compile time.
   ##
   ## Can be used to retrieve the currently executing
   ## Nim compiler from a Nim or nimscript program, or the nimble binary
@@ -2291,10 +2288,10 @@ iterator walkDir*(dir: string; relative = false, checkDir = false):
     assert collect(for k in walkDir("dirA"): k.path).join(" ") ==
                           "dirA/dirB dirA/dirC dirA/fileA2.txt dirA/fileA1.txt"
   ## See also:
-  ## * `walkPattern iterator <#walkPattern.i,string>`_
-  ## * `walkFiles iterator <#walkFiles.i,string>`_
-  ## * `walkDirs iterator <#walkDirs.i,string>`_
-  ## * `walkDirRec iterator <#walkDirRec.i,string>`_
+  ## * `walkPattern iterator`_
+  ## * `walkFiles iterator`_
+  ## * `walkDirs iterator`_
+  ## * `walkDirRec iterator`_
 
   when nimvm:
     for k, v in items(staticWalkDir(dir, relative)):
@@ -2401,10 +2398,10 @@ iterator walkDirRec*(dir: string,
   ##
   ##
   ## See also:
-  ## * `walkPattern iterator <#walkPattern.i,string>`_
-  ## * `walkFiles iterator <#walkFiles.i,string>`_
-  ## * `walkDirs iterator <#walkDirs.i,string>`_
-  ## * `walkDir iterator <#walkDir.i,string>`_
+  ## * `walkPattern iterator`_
+  ## * `walkFiles iterator`_
+  ## * `walkDirs iterator`_
+  ## * `walkDir iterator`_
 
   var stack = @[""]
   var checkDir = checkDir
@@ -2444,13 +2441,13 @@ proc removeDir*(dir: string, checkDir = false) {.rtl, extern: "nos$1", tags: [
   ## existed in the first place, unless `checkDir` = true.
   ##
   ## See also:
-  ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
-  ## * `removeFile proc <#removeFile,string>`_
-  ## * `existsOrCreateDir proc <#existsOrCreateDir,string>`_
-  ## * `createDir proc <#createDir,string>`_
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
-  ## * `moveDir proc <#moveDir,string,string>`_
+  ## * `tryRemoveFile proc`_
+  ## * `removeFile proc`_
+  ## * `existsOrCreateDir proc`_
+  ## * `createDir proc`_
+  ## * `copyDir proc`_
+  ## * `copyDirWithPermissions proc`_
+  ## * `moveDir proc`_
   for kind, path in walkDir(dir, checkDir = checkDir):
     case kind
     of pcFile, pcLinkToFile, pcLinkToDir: removeFile(path)
@@ -2512,11 +2509,11 @@ proc existsOrCreateDir*(dir: string): bool {.rtl, extern: "nos$1",
   ## Returns `true` if the directory already exists, and `false` otherwise.
   ##
   ## See also:
-  ## * `removeDir proc <#removeDir,string>`_
-  ## * `createDir proc <#createDir,string>`_
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
-  ## * `moveDir proc <#moveDir,string,string>`_
+  ## * `removeDir proc`_
+  ## * `createDir proc`_
+  ## * `copyDir proc`_
+  ## * `copyDirWithPermissions proc`_
+  ## * `moveDir proc`_
   result = not rawCreateDir(dir)
   if result:
     # path already exists - need to check that it is indeed a directory
@@ -2534,11 +2531,11 @@ proc createDir*(dir: string) {.rtl, extern: "nos$1",
   ## most usages this does not indicate an error.
   ##
   ## See also:
-  ## * `removeDir proc <#removeDir,string>`_
-  ## * `existsOrCreateDir proc <#existsOrCreateDir,string>`_
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
-  ## * `moveDir proc <#moveDir,string,string>`_
+  ## * `removeDir proc`_
+  ## * `existsOrCreateDir proc`_
+  ## * `copyDir proc`_
+  ## * `copyDirWithPermissions proc`_
+  ## * `moveDir proc`_
   var omitNext = false
   when doslikeFileSystem:
     omitNext = isAbsolute(dir)
@@ -2568,17 +2565,17 @@ proc copyDir*(source, dest: string) {.rtl, extern: "nos$1",
   ##
   ## On other platforms created files and directories will inherit the
   ## default permissions of a newly created file/directory for the user.
-  ## Use `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
+  ## Use `copyDirWithPermissions proc`_
   ## to preserve attributes recursively on these platforms.
   ##
   ## See also:
-  ## * `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
-  ## * `copyFile proc <#copyFile,string,string>`_
-  ## * `copyFileWithPermissions proc <#copyFileWithPermissions,string,string>`_
-  ## * `removeDir proc <#removeDir,string>`_
-  ## * `existsOrCreateDir proc <#existsOrCreateDir,string>`_
-  ## * `createDir proc <#createDir,string>`_
-  ## * `moveDir proc <#moveDir,string,string>`_
+  ## * `copyDirWithPermissions proc`_
+  ## * `copyFile proc`_
+  ## * `copyFileWithPermissions proc`_
+  ## * `removeDir proc`_
+  ## * `existsOrCreateDir proc`_
+  ## * `createDir proc`_
+  ## * `moveDir proc`_
   createDir(dest)
   for kind, path in walkDir(source):
     var noSource = splitPath(path).tail
@@ -2596,12 +2593,12 @@ proc moveDir*(source, dest: string) {.tags: [ReadIOEffect, WriteIOEffect], noWei
   ## If this fails, `OSError` is raised.
   ##
   ## See also:
-  ## * `moveFile proc <#moveFile,string,string>`_
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
-  ## * `removeDir proc <#removeDir,string>`_
-  ## * `existsOrCreateDir proc <#existsOrCreateDir,string>`_
-  ## * `createDir proc <#createDir,string>`_
+  ## * `moveFile proc`_
+  ## * `copyDir proc`_
+  ## * `copyDirWithPermissions proc`_
+  ## * `removeDir proc`_
+  ## * `existsOrCreateDir proc`_
+  ## * `createDir proc`_
   if not tryMoveFSObject(source, dest, isDir = true):
     # Fallback to copy & del
     copyDir(source, dest)
@@ -2615,7 +2612,7 @@ proc createHardlink*(src, dest: string) {.noWeirdTarget.} =
   ##   root users (administrators).
   ##
   ## See also:
-  ## * `createSymlink proc <#createSymlink,string,string>`_
+  ## * `createSymlink proc`_
   when defined(windows):
     when useWinUnicode:
       var wSrc = newWideCString(src)
@@ -2638,13 +2635,12 @@ proc copyFileWithPermissions*(source, dest: string,
   ## if `source` is a symlink, copies the file symlink points to. `options` is
   ## ignored on Windows: symlinks are skipped.
   ##
-  ## This is a wrapper proc around `copyFile <#copyFile,string,string>`_,
-  ## `getFilePermissions <#getFilePermissions,string>`_ and
-  ## `setFilePermissions<#setFilePermissions,string,set[FilePermission]>`_
+  ## This is a wrapper proc around `copyFile`_,
+  ## `getFilePermissions`_ and `setFilePermissions`_
   ## procs on non-Windows platforms.
   ##
-  ## On Windows this proc is just a wrapper for `copyFile proc
-  ## <#copyFile,string,string>`_ since that proc already copies attributes.
+  ## On Windows this proc is just a wrapper for `copyFile proc`_ since
+  ## that proc already copies attributes.
   ##
   ## On non-Windows systems permissions are copied after the file itself has
   ## been copied, which won't happen atomically and could lead to a race
@@ -2653,13 +2649,13 @@ proc copyFileWithPermissions*(source, dest: string,
   ## `OSError`.
   ##
   ## See also:
-  ## * `CopyFlag enum <#CopyFlag>`_
-  ## * `copyFile proc <#copyFile,string,string>`_
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `tryRemoveFile proc <#tryRemoveFile,string>`_
-  ## * `removeFile proc <#removeFile,string>`_
-  ## * `moveFile proc <#moveFile,string,string>`_
-  ## * `copyDirWithPermissions proc <#copyDirWithPermissions,string,string>`_
+  ## * `CopyFlag enum`_
+  ## * `copyFile proc`_
+  ## * `copyDir proc`_
+  ## * `tryRemoveFile proc`_
+  ## * `removeFile proc`_
+  ## * `moveFile proc`_
+  ## * `copyDirWithPermissions proc`_
   copyFile(source, dest, options)
   when not defined(windows):
     try:
@@ -2678,13 +2674,12 @@ proc copyDirWithPermissions*(source, dest: string,
   ## On non-Windows OSes, symlinks are copied as symlinks. On Windows, symlinks
   ## are skipped.
   ##
-  ## If this fails, `OSError` is raised. This is a wrapper proc around `copyDir
-  ## <#copyDir,string,string>`_ and `copyFileWithPermissions
-  ## <#copyFileWithPermissions,string,string>`_ procs
+  ## If this fails, `OSError` is raised. This is a wrapper proc around
+  ## `copyDir`_ and `copyFileWithPermissions`_ procs
   ## on non-Windows platforms.
   ##
-  ## On Windows this proc is just a wrapper for `copyDir proc
-  ## <#copyDir,string,string>`_ since that proc already copies attributes.
+  ## On Windows this proc is just a wrapper for `copyDir proc`_ since
+  ## that proc already copies attributes.
   ##
   ## On non-Windows systems permissions are copied after the file or directory
   ## itself has been copied, which won't happen atomically and could lead to a
@@ -2693,13 +2688,13 @@ proc copyDirWithPermissions*(source, dest: string,
   ## `OSError`.
   ##
   ## See also:
-  ## * `copyDir proc <#copyDir,string,string>`_
-  ## * `copyFile proc <#copyFile,string,string>`_
-  ## * `copyFileWithPermissions proc <#copyFileWithPermissions,string,string>`_
-  ## * `removeDir proc <#removeDir,string>`_
-  ## * `moveDir proc <#moveDir,string,string>`_
-  ## * `existsOrCreateDir proc <#existsOrCreateDir,string>`_
-  ## * `createDir proc <#createDir,string>`_
+  ## * `copyDir proc`_
+  ## * `copyFile proc`_
+  ## * `copyFileWithPermissions proc`_
+  ## * `removeDir proc`_
+  ## * `moveDir proc`_
+  ## * `existsOrCreateDir proc`_
+  ## * `createDir proc`_
   createDir(dest)
   when not defined(windows):
     try:
@@ -2769,9 +2764,9 @@ proc parseCmdLine*(c: string): seq[string] {.
   ##
   ## See also:
   ## * `parseopt module <parseopt.html>`_
-  ## * `paramCount proc <#paramCount>`_
-  ## * `paramStr proc <#paramStr,int>`_
-  ## * `commandLineParams proc <#commandLineParams>`_
+  ## * `paramCount proc`_
+  ## * `paramStr proc`_
+  ## * `commandLineParams proc`_
 
   result = @[]
   var i = 0
@@ -2838,9 +2833,8 @@ when defined(nimdoc):
     ##
     ## Unlike `argc`:idx: in C, if your binary was called without parameters this
     ## will return zero.
-    ## You can query each individual parameter with `paramStr proc <#paramStr,int>`_
-    ## or retrieve all of them in one go with `commandLineParams proc
-    ## <#commandLineParams>`_.
+    ## You can query each individual parameter with `paramStr proc`_
+    ## or retrieve all of them in one go with `commandLineParams proc`_.
     ##
     ## **Availability**: When generating a dynamic library (see `--app:lib`) on
     ## Posix this proc is not defined.
@@ -2848,9 +2842,9 @@ when defined(nimdoc):
     ##
     ## See also:
     ## * `parseopt module <parseopt.html>`_
-    ## * `parseCmdLine proc <#parseCmdLine,string>`_
-    ## * `paramStr proc <#paramStr,int>`_
-    ## * `commandLineParams proc <#commandLineParams>`_
+    ## * `parseCmdLine proc`_
+    ## * `paramStr proc`_
+    ## * `commandLineParams proc`_
     ##
     ## **Examples:**
     ##
@@ -2865,13 +2859,13 @@ when defined(nimdoc):
     ##
     ## `i` should be in the range `1..paramCount()`, the `IndexDefect`
     ## exception will be raised for invalid values. Instead of iterating
-    ## over `paramCount() <#paramCount>`_ with this proc you can
-    ## call the convenience `commandLineParams() <#commandLineParams>`_.
+    ## over `paramCount()`_ with this proc you can
+    ## call the convenience `commandLineParams()`_.
     ##
     ## Similarly to `argv`:idx: in C,
     ## it is possible to call `paramStr(0)` but this will return OS specific
     ## contents (usually the name of the invoked executable). You should avoid
-    ## this and call `getAppFilename() <#getAppFilename>`_ instead.
+    ## this and call `getAppFilename()`_ instead.
     ##
     ## **Availability**: When generating a dynamic library (see `--app:lib`) on
     ## Posix this proc is not defined.
@@ -2879,10 +2873,10 @@ when defined(nimdoc):
     ##
     ## See also:
     ## * `parseopt module <parseopt.html>`_
-    ## * `parseCmdLine proc <#parseCmdLine,string>`_
-    ## * `paramCount proc <#paramCount>`_
-    ## * `commandLineParams proc <#commandLineParams>`_
-    ## * `getAppFilename proc <#getAppFilename>`_
+    ## * `parseCmdLine proc`_
+    ## * `paramCount proc`_
+    ## * `commandLineParams proc`_
+    ## * `getAppFilename proc`_
     ##
     ## **Examples:**
     ##
@@ -2971,7 +2965,7 @@ when declared(paramCount) or defined(nimdoc):
     ## Convenience proc which returns the command line parameters.
     ##
     ## This returns **only** the parameters. If you want to get the application
-    ## executable filename, call `getAppFilename() <#getAppFilename>`_.
+    ## executable filename, call `getAppFilename()`_.
     ##
     ## **Availability**: On Posix there is no portable way to get the command
     ## line from a DLL and thus the proc isn't defined in this environment. You
@@ -2980,10 +2974,10 @@ when declared(paramCount) or defined(nimdoc):
     ##
     ## See also:
     ## * `parseopt module <parseopt.html>`_
-    ## * `parseCmdLine proc <#parseCmdLine,string>`_
-    ## * `paramCount proc <#paramCount>`_
-    ## * `paramStr proc <#paramStr,int>`_
-    ## * `getAppFilename proc <#getAppFilename>`_
+    ## * `parseCmdLine proc`_
+    ## * `paramCount proc`_
+    ## * `paramStr proc`_
+    ## * `getAppFilename proc`_
     ##
     ## **Examples:**
     ##
@@ -3133,8 +3127,8 @@ proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noW
   ## This proc will resolve symlinks.
   ##
   ## See also:
-  ## * `getAppDir proc <#getAppDir>`_
-  ## * `getCurrentCompilerExe proc <#getCurrentCompilerExe>`_
+  ## * `getAppDir proc`_
+  ## * `getCurrentCompilerExe proc`_
 
   # Linux: /proc/<pid>/exe
   # Solaris:
@@ -3198,7 +3192,7 @@ proc getAppDir*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noWeirdT
   ## Returns the directory of the application's executable.
   ##
   ## See also:
-  ## * `getAppFilename proc <#getAppFilename>`_
+  ## * `getAppFilename proc`_
   result = splitFile(getAppFilename()).dir
 
 proc sleep*(milsecs: int) {.rtl, extern: "nos$1", tags: [TimeEffect], noWeirdTarget.} =
@@ -3242,9 +3236,9 @@ type
     ## Contains information associated with a file object.
     ##
     ## See also:
-    ## * `getFileInfo(handle) proc <#getFileInfo,FileHandle>`_
-    ## * `getFileInfo(file) proc <#getFileInfo,File>`_
-    ## * `getFileInfo(path) proc <#getFileInfo,string>`_
+    ## * `getFileInfo(handle) proc`_
+    ## * `getFileInfo(file) proc`_
+    ## * `getFileInfo(path, followSymlink) proc`_
     id*: tuple[device: DeviceId, file: FileId] ## Device and file id.
     kind*: PathComponent              ## Kind of file object - directory, symlink, etc.
     size*: BiggestInt                 ## Size of file.
@@ -3334,8 +3328,8 @@ proc getFileInfo*(handle: FileHandle): FileInfo {.noWeirdTarget.} =
   ## is invalid, `OSError` is raised.
   ##
   ## See also:
-  ## * `getFileInfo(file) proc <#getFileInfo,File>`_
-  ## * `getFileInfo(path) proc <#getFileInfo,string>`_
+  ## * `getFileInfo(file) proc`_
+  ## * `getFileInfo(path, followSymlink) proc`_
 
   # Done: ID, Kind, Size, Permissions, Link Count
   when defined(windows):
@@ -3356,8 +3350,8 @@ proc getFileInfo*(file: File): FileInfo {.noWeirdTarget.} =
   ## Retrieves file information for the file object.
   ##
   ## See also:
-  ## * `getFileInfo(handle) proc <#getFileInfo,FileHandle>`_
-  ## * `getFileInfo(path) proc <#getFileInfo,string>`_
+  ## * `getFileInfo(handle) proc`_
+  ## * `getFileInfo(path, followSymlink) proc`_
   if file.isNil:
     raise newException(IOError, "File is nil")
   result = getFileInfo(file.getFileHandle())
@@ -3366,7 +3360,7 @@ proc getFileInfo*(path: string, followSymlink = true): FileInfo {.noWeirdTarget.
   ## Retrieves file information for the file object pointed to by `path`.
   ##
   ## Due to intrinsic differences between operating systems, the information
-  ## contained by the returned `FileInfo object <#FileInfo>`_ will be slightly
+  ## contained by the returned `FileInfo object`_ will be slightly
   ## different across platforms, and in some cases, incomplete or inaccurate.
   ##
   ## When `followSymlink` is true (default), symlinks are followed and the
@@ -3378,8 +3372,8 @@ proc getFileInfo*(path: string, followSymlink = true): FileInfo {.noWeirdTarget.
   ## file information, `OSError` is raised.
   ##
   ## See also:
-  ## * `getFileInfo(handle) proc <#getFileInfo,FileHandle>`_
-  ## * `getFileInfo(file) proc <#getFileInfo,File>`_
+  ## * `getFileInfo(handle) proc`_
+  ## * `getFileInfo(file) proc`_
   when defined(windows):
     var
       handle = openHandle(path, followSymlink)
@@ -3406,7 +3400,7 @@ proc sameFileContent*(path1, path2: string): bool {.rtl, extern: "nos$1",
   ## binary content.
   ##
   ## See also:
-  ## * `sameFile proc <#sameFile,string,string>`_
+  ## * `sameFile proc`_
   var
     a, b: File
   if not open(a, path1): return false

--- a/tests/stdlib/tdochelpers.nim
+++ b/tests/stdlib/tdochelpers.nim
@@ -153,3 +153,9 @@ suite "Integration with Nim":
                               outType: "T")
     check(input1.toLangSymbol == expected)
     check(input2.toLangSymbol == expected)
+
+  test "type of type":
+    check ("`CopyFlag enum`_".rstParseTest.toLangSymbol ==
+           LangSymbol(symKind: "type",
+                      symTypeKind: "enum",
+                      name: "Copyflag"))


### PR DESCRIPTION
Local doc links in `os.nim` changed to simple style (#18642 ). Also added possibility to specify just `enum` or `object` or `tuple` for the appropriate `type`s.