### PR TITLE
fix nimindexterm in rst2tex/doc2tex [backport]

### DIFF
--- a/config/nimdoc.tex.cfg
+++ b/config/nimdoc.tex.cfg
@@ -63,6 +63,11 @@ doc.file = """
 %
 % Compile it by:   xelatex    (up to 3 times to get labels generated)
 %                  -------
+% For example:
+%   xelatex file.tex
+%   xelatex file.tex
+%   makeindex file
+%   xelatex file.tex
 %
 \documentclass[a4paper,11pt]{article}
 \usepackage[a4paper,xetex,left=3cm,right=3cm,top=1.5cm,bottom=2cm]{geometry}
@@ -105,7 +110,9 @@ doc.file = """
 \usepackage{parskip}  % paragraphs delimited by vertical space, no indent
 \usepackage{graphicx}
 
-\newcommand{\nimindexterm}[2]{#2\label{#1}}
+\usepackage{makeidx}
+\newcommand{\nimindexterm}[2]{#2\index{#2}\label{#1}}
+\makeindex
 
 \usepackage{dingbat} % for \carriagereturn, etc
 \usepackage{fvextra}  % for code blocks (works better than original fancyvrb)
@@ -249,5 +256,8 @@ doc.file = """
 \maketitle
 
 $content
+
+\printindex
+
 \end{document}
 """

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -408,7 +408,7 @@ proc renderIndexTerm*(d: PDoc, n: PRstNode, result: var string) =
   var term = ""
   renderAux(d, n, term)
   setIndexTerm(d, changeFileExt(extractFilename(d.filename), HtmlExt), id, term, d.currentSection)
-  dispA(d.target, result, "<span id=\"$1\">$2</span>", "\\nimindexterm{$2}{$1}",
+  dispA(d.target, result, "<span id=\"$1\">$2</span>", "\\nimindexterm{$1}{$2}",
         [id, term])
 
 type

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -301,6 +301,12 @@ proc nim2pdf(src: string, dst: string, nimArgs: string) =
     # `>` should work on windows, if not, we can use `execCmdEx`
     let cmd = "xelatex -interaction=nonstopmode -output-directory=$# $# > $#" % [outDir.quoteShell, texFile.quoteShell, xelatexLog.quoteShell]
     exec(cmd) # on error, user can inspect `xelatexLog`
+    if i == 1:  # build .ind file
+      var texFileBase = texFile
+      texFileBase.removeSuffix(".tex")
+      let cmd = "makeindex $# > $#" % [
+          texFileBase.quoteShell, xelatexLog.quoteShell]
+      exec(cmd)
   moveFile(texFile.changeFileExt("pdf"), dst)
 
 proc buildPdfDoc*(nimArgs, destPath: string) =


### PR DESCRIPTION
I'm not sure what was original intention of #18946 , but it breaks both `rst2tex` and `doc2tex` for me whenever an `:idx:` is encountered in `.rst`, that is most large doc files, including e.g. `manual.rst` and `os.nim`.

The errors on `xelatex` compilation of `manual.rst` are like:
```
! Missing $ inserted.
<inserted text> 
                $
l.267 ...led \nimindexterm{locations}{locations_1}
                                                  . A variable is basically ...
```

The problem is that underscore `_` is special symbol that cannot be encountered in normal text but is allowed e.g. in `\label`. The order `\nimindexterm` arguments was confused, this PR switches `$1` and `$2` and then things like `\nimindexterm{locations_1}{locations}` work (since `locations_1` get into `\label{#1}`).