### PR TITLE
Deprecate `std/sharedlist` and `std/sharedtables`

### DIFF
--- a/changelogs/changelog.md
+++ b/changelogs/changelog.md
@@ -4,6 +4,8 @@
 
 ## Standard library additions and changes
 
+- `std/sharedlist` and `std/sharedtables` are now deprecated, see RFC [#433](https://github.com/nim-lang/RFCs/issues/433).
+
 ### New compile flag (`-d:nimNoGetRandom`) when building `std/sysrand` to remove dependency on linux `getrandom` syscall
 
 This compile flag only affects linux builds and is necessary if either compiling on a linux kernel version < 3.17, or if code built will be executing on kernel < 3.17.

--- a/changelogs/changelog_1_4_0.md
+++ b/changelogs/changelog_1_4_0.md
@@ -282,7 +282,7 @@
 - Removed the deprecated `asyncdispatch.newAsyncNativeSocket`.
 - Removed the deprecated `dom.releaseEvents` and `dom.captureEvents`.
 
-- Removed `sharedlists.initSharedList`, was deprecated and produces undefined behaviour.
+- Removed `sharedlist.initSharedList`, was deprecated and produces undefined behaviour.
 
 - There is a new experimental feature called "strictFuncs" which makes the definition of
   `.noSideEffect` stricter. [See here](manual_experimental.html#stricts-funcs)

--- a/doc/lib.rst
+++ b/doc/lib.rst
@@ -134,12 +134,6 @@ Collections
 * `sets <sets.html>`_
   Nim hash set support.
 
-* `sharedlist <sharedlist.html>`_
-  Nim shared linked list support. Contains a shared singly-linked list.
-
-* `sharedtables <sharedtables.html>`_
-  Nim shared hash table support. Contains shared tables.
-
 * `tables <tables.html>`_
   Nim hash table support. Contains tables, ordered tables, and count tables.
 

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -56,7 +56,6 @@ runnableExamples:
 
 ## # See also
 ## * `deques module <deques.html>`_ for double-ended queues
-## * `sharedlist module <sharedlist.html>`_ for shared singly-linked lists
 
 import std/private/since
 

--- a/lib/pure/collections/sharedlist.nim
+++ b/lib/pure/collections/sharedlist.nim
@@ -11,6 +11,8 @@
 ##
 ## Unstable API.
 
+{.deprecated.}
+
 {.push stackTrace: off.}
 
 import

--- a/lib/pure/collections/sharedtables.nim
+++ b/lib/pure/collections/sharedtables.nim
@@ -14,6 +14,8 @@
 ##
 ## Unstable API.
 
+{.deprecated.}
+
 import
   hashes, math, locks
 

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -191,7 +191,6 @@ runnableExamples:
 ##
 ## * `json module<json.html>`_ for table-like structure which allows
 ##   heterogeneous members
-## * `sharedtables module<sharedtables.html>`_ for shared hash table support
 ## * `strtabs module<strtabs.html>`_ for efficient hash tables
 ##   mapping from strings to strings
 ## * `hashes module<hashes.html>`_ for helper functions for hashing


### PR DESCRIPTION
Closes https://github.com/nim-lang/RFCs/issues/433.