### PR TITLE
Add/improve deprecation pragmas in lib/deprecated/pure

### DIFF
--- a/lib/deprecated/pure/LockFreeHash.nim
+++ b/lib/deprecated/pure/LockFreeHash.nim
@@ -1,9 +1,11 @@
 #nim c -t:-march=i686 --cpu:amd64 --threads:on -d:release lockfreehash.nim
 
-import math, hashes
-
 #------------------------------------------------------------------------------
 ## Memory Utility Functions
+
+{.deprecated.}
+
+import math, hashes
 
 proc newHeap*[T](): ptr T =
   result = cast[ptr T](alloc0(sizeof(T)))

--- a/lib/deprecated/pure/events.nim
+++ b/lib/deprecated/pure/events.nim
@@ -36,6 +36,8 @@
 ##    myobj.SomeEvent.addHandler(handleevent)
 ##    ee.emit(myobj.SomeEvent, genericargs)
 
+{.deprecated.}
+
 type
   EventArgs* = object of RootObj ## Base object for event arguments that are passed to callback functions.
   EventHandler* = tuple[name: string, handlers: seq[proc(e: EventArgs) {.closure.}]] ## An eventhandler for an event.

--- a/lib/deprecated/pure/ospaths.nim
+++ b/lib/deprecated/pure/ospaths.nim
@@ -7,8 +7,9 @@
 #    distribution, for details about the copyright.
 #
 
-## This module is deprecated, `import os` instead.
-{.deprecated: "import os.nim instead".}
+## This module is deprecated, `import std/os` instead.
+
+{.deprecated: "use `std/os` instead".}
 
 import os
 export ReadEnvEffect, WriteEnvEffect, ReadDirEffect, WriteDirEffect, OSErrorCode,

--- a/lib/deprecated/pure/securehash.nim
+++ b/lib/deprecated/pure/securehash.nim
@@ -1,6 +1,5 @@
-
-
 ## This module is a deprecated alias for the `sha1` module.
-{.deprecated.}
+
+{.deprecated: "use `std/sha1` instead".}
 
 include "../std/sha1"

--- a/lib/deprecated/pure/sharedstrings.nim
+++ b/lib/deprecated/pure/sharedstrings.nim
@@ -9,6 +9,8 @@
 
 ## Shared string support for Nim.
 
+{.deprecated.}
+
 type
   UncheckedCharArray = UncheckedArray[char]
 


### PR DESCRIPTION
Add `deprecated` pragmas to the modules in `lib/deprecated/` (that don't already have one) and improve the deprecation messages.