### PR TITLE
Remove tlsEmulation enabled from Windows + GCC config

### DIFF
--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -154,9 +154,6 @@ nimblepath="$home/.nimble/pkgs/"
 # Configuration for the GNU C/C++ compiler:
 @if windows:
   #gcc.path = r"$nim\dist\mingw\bin"
-  @if gcc or tcc:
-    tlsEmulation:on
-  @end
 @end
 
 gcc.maxerrorsimpl = "-fmax-errors=3"


### PR DESCRIPTION
This flag has a very significant performance impact on programs compiled with --threads:on. It is also apparently not needed anymore for standard circumstances. Can we remove the config? See https://github.com/nim-lang/Nim/issues/18146#issuecomment-876802676 for discussion and perf impact.