### PR TITLE
[breaking][debatable] change treatment of slices in `strutils.delete` & `sequtils.delete`

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -530,7 +530,8 @@ func delete*[T](s: var seq[T]; slice: Slice[int]) =
     a.delete(1..<1) # empty slice
     assert a == @[10, 13]
   when compileOption("boundChecks"):
-    if not (slice.a < s.len and slice.a >= 0 and slice.b < s.len):
+    if not (slice.a <= s.len and slice.a >= 0 and slice.b < s.len and
+            slice.b - slice.a >= -1):
       raise newException(IndexDefect, $(slice: slice, len: s.len))
   if slice.b >= slice.a:
     template defaultImpl =

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1499,7 +1499,8 @@ func delete*(s: var string, slice: Slice[int]) =
     a.delete(1..<1) # empty slice
     assert a == "ad"
   when compileOption("boundChecks"):
-    if not (slice.a < s.len and slice.a >= 0 and slice.b < s.len):
+    if not (slice.a <= s.len and slice.a >= 0 and slice.b < s.len and
+            slice.b - slice.a >= -1):
       raise newException(IndexDefect, $(slice: slice, len: s.len))
   if slice.b >= slice.a:
     var i = slice.a
@@ -2455,7 +2456,7 @@ func trimZeros*(x: var string; decimalSep = '.') =
     var pos = last
     while pos >= 0 and x[pos] == '0': dec(pos)
     if pos > sPos: inc(pos)
-    x.delete(pos, last)
+    x.delete(pos .. last)
 
 type
   BinaryPrefixMode* = enum ## The different names for binary prefixes.

--- a/tests/stdlib/tsequtils.nim
+++ b/tests/stdlib/tsequtils.nim
@@ -503,7 +503,7 @@ template main =
     doAssertRaises(IndexDefect): a.delete(-1 .. -1)
     doAssertRaises(IndexDefect): a.delete(5..5)
     doAssertRaises(IndexDefect): a.delete(5..3)
-    doAssertRaises(IndexDefect): a.delete(5..<5) # edge case
+    a.delete(5..<5)  # edge case
     doAssert a == @[10, 11, 12, 13, 14]
     a.delete(4..4)
     doAssert a == @[10, 11, 12, 13]
@@ -518,7 +518,8 @@ template main =
     a.delete(0..0)
     doAssert a == @[]
     doAssertRaises(IndexDefect): a.delete(0..0)
-    doAssertRaises(IndexDefect): a.delete(0..<0) # edge case
+    a.delete(0..<0)
+    doAssert a == @[]  # edge case
     block:
       type A = object
         a0: int

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -212,7 +212,8 @@ template main() =
     s = "abc"
     doAssertRaises(IndexDefect): delete(s, -1 .. -2)
     doAssertRaises(IndexDefect): delete(s, 2..3)
-    doAssertRaises(IndexDefect): delete(s, 3..2)
+    delete(s, 3..2)
+    doAssert s == "abc"
     delete(s, 2..2)
     doAssert s == "ab"
     delete(s, 1..0)


### PR DESCRIPTION
For bound checks in `s.delete`:
1) (relaxing) allow 2 slices like `[0 .. -1]` and `[s.len .. s.len - 1]` which deletes **nothing**
2) (more strict, breaking) forbid slices like `[2..0]`

Generally, new rule for slice `[a .. b]` is: `a <= 0 <= s.len` and `b - a >= -1`.

Motivation:
* closer correspondence to the current getter `[]` behavior which allows indexing like `s[0 .. -1]`, `s[1 .. 0]` etc (returns empty string/seq) but does not allow if `b - a < -1`.
* seems logical, e.g. slice `[2 .. 2]` deletes only element 2, slice `[2..1]` is an empty slice and deletes **nothing**, and `[2..0]` is illegal
*  error-resistant and efficient for most typical algorithm like:
   ```nim
   var a = b
   while someCondition(a): dec a  # can skip!
   inc a
   s.delete(a .. b)
   ```
   See such an example in `strutils.trimZeros` in  the changes.