### PR TITLE
Introduce urlencodeIRI and safeParseUri

### DIFF
--- a/lib/pure/uri.nim
+++ b/lib/pure/uri.nim
@@ -327,7 +327,7 @@ func parseUri*(uri: string): Uri =
 
 
 func urlencodeIRI*(s: string): string =
-  ## Convert string to
+  ## Encode IRI URL path to %<hex_value>
   for r in runes(s):
     if r.isAlpha:
       result &= $r
@@ -341,12 +341,12 @@ func safeParseUri*(uri: string, result: var Uri, acceptIRI = false) =
   ## The `result` variable is cleared before using it.
   const
     scheme = Letters + Digits + {'+', '-', '.'}
-    gen_delims = {':', '/', '?', '#', '[', ']', '@'}
-    sub_delims = {'!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='}
-    allowed = Letters + Digits + {'-', '.', '_', '~'} + gen_delims + sub_delims
+    genDelims = {':', '/', '?', '#', '[', ']', '@'}
+    subDelims = {'!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='}
+    allowed = Letters + Digits + {'-', '.', '_', '~'} + genDelims + subDelims
     iunreserved = Letters + Digits + {'-', '.', '_', '~', '%'} # lax on uschar
-    ihost =  iunreserved + sub_delims
-    iquery = iunreserved + sub_delims + {':', '@', '/', '?'}
+    ihost =  iunreserved + subDelims
+    iquery = iunreserved + subDelims + {':', '@', '/', '?'}
 
   parseUri(uri, result)
   for c in result.scheme:
@@ -369,7 +369,7 @@ func safeParseUri*(uri: string, result: var Uri, acceptIRI = false) =
     result.path = urlencodeIRI(result.path)
   for c in result.path:
     if c notin iquery:
-      uriParseError("Invalid character in query")
+      uriParseError("Invalid character in path")
 
   for c in result.query:
     if c notin iquery:

--- a/tests/stdlib/turi.nim
+++ b/tests/stdlib/turi.nim
@@ -141,6 +141,21 @@ template main() =
       doAssert test.port == ""
       doAssert test.path == "/foo/bar/baz.txt"
 
+  block: # urlencodeIRI
+    doAssert urlencodeIRI("a\tb\nc\0d猫e") == "a%09b%0Ac%00d%E7%8C%ABe"
+
+  block: # safeParseUri
+    doAssert $safeParseUri("https://user:pass@foo/path") == "https://user:pass@foo/path"
+    doAssertRaises(UriParseError):
+      echo repr safeParseUri("foo/猫", acceptIRI=false)
+    doAssertRaises(UriParseError):
+      echo repr safeParseUri("a\0b", acceptIRI=false)
+    doAssertRaises(UriParseError):
+      echo repr safeParseUri("a\0b")
+    doAssertRaises(UriParseError):
+      echo repr safeParseUri("https://a.org\0b.com/", acceptIRI=true)
+    doAssert $safeParseUri("https://foo.com/foo/\0猫", acceptIRI=true) == "https://foo.com/%2Ffoo%2F%00%E7%8C%AB"
+
   block: # combine
     block:
       let concat = combine(parseUri("http://google.com/foo/bar/"), parseUri("baz"))


### PR DESCRIPTION
Parse URI/IRI with some degree of safety.

Related to #17967 and https://github.com/nim-lang/security/security/advisories/GHSA-3gg2-rw3q-qwgc aka CVE-2021-41259