### PR TITLE
Enable customizing PageShift to set PageSize for embedded targets

### DIFF
--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -663,7 +663,7 @@ Adjust the page size for Nim's GC allocator. This enables using
 `nimAllocPagesViaMalloc` on devices with less RAM. The default
 page size requires too much RAM to work.
 
-Recommended settings guidelines:
+Recommended settings:
 
 - < 32 kB of RAM use `nimPage256`
 
@@ -674,7 +674,6 @@ Recommended settings guidelines:
 Initial testing hasn't shown much difference between 512B or 1kB page sizes
 in terms of performance or latency. Using `nimPages256` will limit the
 total amount of allocatable RAM.
-
 
 nimMemAlignTiny
 ===============

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -656,6 +656,31 @@ is not available but C's `malloc` is. You can use the `nimAllocPagesViaMalloc`
 define to use `malloc` instead of `mmap`. `nimAllocPagesViaMalloc` is currently
 only supported with `--gc:arc` or `--gc:orc`. (Since version 1.6)
 
+nimPage256 / nimPage512 / nimPage1k
+========================
+
+Adjust the page size for Nim's GC allocator. This enables using
+`nimAllocPagesViaMalloc` on devices with less RAM. The default
+page size requires too much RAM to work.
+
+Recommended settings guidelines:
+
+- < 32 kB of RAM use `nimPage256`
+
+- < 512 kB of RAM use `nimPage512`
+
+- < 2 MB of RAM use `nimPage1k`
+
+Initial testing hasn't shown much difference between 512B or 1kB page sizes
+in terms of performance or latency. Using `nimPages256` will limit the
+total amount of allocatable RAM.
+
+
+nimMemAlignTiny
+===============
+
+Sets `MemAlign` to `4` bytes which reduces the memory alignment
+to better match some embedded devices.
 
 Nim for realtime systems
 ========================

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -657,7 +657,7 @@ define to use `malloc` instead of `mmap`. `nimAllocPagesViaMalloc` is currently
 only supported with `--gc:arc` or `--gc:orc`. (Since version 1.6)
 
 nimPage256 / nimPage512 / nimPage1k
-========================
+===================================
 
 Adjust the page size for Nim's GC allocator. This enables using
 `nimAllocPagesViaMalloc` on devices with less RAM. The default

--- a/lib/system/bitmasks.nim
+++ b/lib/system/bitmasks.nim
@@ -10,14 +10,18 @@
 # Page size of the system; in most cases 4096 bytes. For exotic OS or
 # CPU this needs to be changed:
 const
-  PageShift = when defined(cpu16): 8 else: 12 # \
-    # my tests showed no improvements for using larger page sizes.
+  PageShift = when defined(nimPage256) or defined(cpu16): 8
+              elif defined(nimPage512): 9
+              elif defined(nimPage1k): 10
+              else: 12 # \ # my tests showed no improvements for using larger page sizes.
+
   PageSize = 1 shl PageShift
   PageMask = PageSize-1
 
 
   MemAlign = # also minimal allocatable memory block
-    when defined(useMalloc):
+    when defined(nimMemAlignTiny): 4
+    elif defined(useMalloc):
       when defined(amd64): 16 
       else: 8
     else: 16

--- a/tests/mmaptest.nim
+++ b/tests/mmaptest.nim
@@ -19,8 +19,11 @@ proc `+!!`(p: pointer, size: int): pointer {.inline.} =
   result = cast[pointer](cast[int](p) + size)
 
 const
-  PageShift = when defined(cpu16): 8 else: 12 # \
-    # my tests showed no improvements for using larger page sizes.
+  PageShift = when defined(nimPage256) or defined(cpu16): 8
+              elif defined(nimPage512): 9
+              elif defined(nimPage1k): 10
+              else: 12 # \ # my tests showed no improvements for using larger page sizes.
+
   PageSize = 1 shl PageShift
 
 var p = osAllocPages(3 * PageSize)


### PR DESCRIPTION
Without this then `StandaloneHeapSize` fails on smaller devices but which still have a few hundred kB of RAM. On targets with 256K I've been setting this to 9 or 10 and it appears to work well. Previously I'd set `-d:cpu16` but these are ARM32 devices. 

I couldn't find documentation on `StandaloneHeapSize` as that'd seem to be a good place to add docs for this. 