### PR TITLE
Fix type mismatch when using `-d:futureLogging`

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -225,7 +225,7 @@ proc complete*[T](future: FutureVar[T], val: T) =
   fut.finished = true
   fut.value = val
   fut.callbacks.call()
-  when isFutureLoggingEnabled: logFutureFinish(future)
+  when isFutureLoggingEnabled: logFutureFinish(fut)
 
 proc fail*[T](future: Future[T], error: ref Exception) =
   ## Completes `future` with `error`.


### PR DESCRIPTION
Basic example to show problem is 
```nim
import asyncdispatch
import tables
import httpclient

proc main() {.async.} =
  let client = newAsyncHttpClient() 
  echo await client.getContent("http://httpbin.org/ip")
  echo getFuturesInProgress().len()

waitFor main()
```
Running in `1.6.0` or `1.4.8` (probably others but I only tested those two) with `nim r -d:futureLogging example.nim` gives this error message
```
/home/me/.choosenim/toolchains/nim-1.4.8/lib/pure/asyncnet.nim(863, 17) template/generic instantiation of `async` from here
/home/me/.choosenim/toolchains/nim-1.4.8/lib/pure/asyncnet.nim(907, 26) template/generic instantiation of `adaptRecvFromToDomain` from here
/home/me/.choosenim/toolchains/nim-1.4.8/lib/pure/asyncnet.nim(892, 11) template/generic instantiation of `complete` from here
/home/me/.choosenim/toolchains/nim-1.4.8/lib/pure/asyncfutures.nim(230, 47) Error: type mismatch: got <FutureVar[nativesockets.Port]>
but expected one of: 
proc logFutureFinish(fut: FutureBase)
  first type mismatch at position: 1
  required type for fut: FutureBase
  but expression 'future' is of type: FutureVar[nativesockets.Port]

expression: logFutureFinish(future)
```
This PR fixes the problem by giving the actual future to `logFutureFinish` instead of the `FutureVar[T]` parameter