### PR TITLE
Various std net improvements

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -155,9 +155,9 @@ when not defined(zephyr):
   proc inet_addr*(a1: cstring): InAddrT {.importc, header: "<arpa/inet.h>".}
   proc inet_ntoa*(a1: InAddr): cstring {.importc, header: "<arpa/inet.h>".}
 
-proc inet_ntop*(a1: cint, a2: pointer, a3: cstring, a4: int32): cstring {.
+proc inet_ntop*(a1: cint, a2: pointer | ptr InAddr | ptr In6Addr, a3: cstring, a4: int32): cstring {.
   importc:"(char *)$1", header: "<arpa/inet.h>".}
-proc inet_pton*(a1: cint, a2: cstring, a3: pointer): cint {.
+proc inet_pton*(a1: cint, a2: cstring, a3: pointer | ptr InAddr | ptr In6Addr): cint {.
   importc, header: "<arpa/inet.h>".}
 
 var

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -65,6 +65,11 @@ runnableExamples("-r:off"):
   let socket = newSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
   socket.sendTo("192.168.0.1", Port(27960), "status\n")
 
+runnableExamples("-r:off"):
+  let socket = newSocket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)
+  let ip = parseIpAddress("192.168.0.1")
+  doAssert socket.sendTo(ip, Port(27960), "status\c\l") == 8
+
 ## Creating a server
 ## -----------------
 ##
@@ -1607,11 +1612,12 @@ proc recvLine*(socket: Socket, timeout = -1,
   result = ""
   readLine(socket, result, timeout, flags, maxLength)
 
-proc recvFrom*(socket: Socket, data: var string, length: int,
-               address: var string, port: var Port, flags = 0'i32): int {.
+proc recvFrom*[T: string | IpAddress](socket: Socket, data: var string, length: int,
+               address: var T, port: var Port, flags = 0'i32): int {.
                tags: [ReadIOEffect].} =
   ## Receives data from `socket`. This function should normally be used with
-  ## connection-less sockets (UDP sockets).
+  ## connection-less sockets (UDP sockets). The source address of the data
+  ## packet is stored in the `address` argument as either a string or an IpAddress.
   ##
   ## If an error occurs an OSError exception will be raised. Otherwise the return
   ## value will be the length of data received.
@@ -1620,31 +1626,37 @@ proc recvFrom*(socket: Socket, data: var string, length: int,
   ##   so when `socket` is buffered the non-buffered implementation will be
   ##   used. Therefore if `socket` contains something in its buffer this
   ##   function will make no effort to return it.
-  template adaptRecvFromToDomain(domain: Domain) =
+  template adaptRecvFromToDomain(sockAddress: untyped, domain: Domain) =
     var addrLen = sizeof(sockAddress).SockLen
     result = recvfrom(socket.fd, cstring(data), length.cint, flags.cint,
                       cast[ptr SockAddr](addr(sockAddress)), addr(addrLen))
 
     if result != -1:
       data.setLen(result)
-      address = getAddrString(cast[ptr SockAddr](addr(sockAddress)))
-      when domain == AF_INET6:
-        port = ntohs(sockAddress.sin6_port).Port
+
+      when typeof(address) is string:
+        address = getAddrString(cast[ptr SockAddr](addr(sockAddress)))
+        when domain == AF_INET6:
+          port = ntohs(sockAddress.sin6_port).Port
+        else:
+          port = ntohs(sockAddress.sin_port).Port
       else:
-        port = ntohs(sockAddress.sin_port).Port
+        data.setLen(result)
+        sockAddress.fromSockAddr(addrLen, address, port)
     else:
       raiseOSError(osLastError())
 
   assert(socket.protocol != IPPROTO_TCP, "Cannot `recvFrom` on a TCP socket")
   # TODO: Buffered sockets
   data.setLen(length)
+
   case socket.domain
   of AF_INET6:
     var sockAddress: Sockaddr_in6
-    adaptRecvFromToDomain(AF_INET6)
+    adaptRecvFromToDomain(sockAddress, AF_INET6)
   of AF_INET:
     var sockAddress: Sockaddr_in
-    adaptRecvFromToDomain(AF_INET)
+    adaptRecvFromToDomain(sockAddress, AF_INET)
   else:
     raise newException(ValueError, "Unknown socket address family")
 
@@ -1707,7 +1719,8 @@ proc sendTo*(socket: Socket, address: string, port: Port, data: pointer,
              tags: [WriteIOEffect].} =
   ## This proc sends `data` to the specified `address`,
   ## which may be an IP address or a hostname, if a hostname is specified
-  ## this function will try each IP of that hostname.
+  ## this function will try each IP of that hostname. This function
+  ## should normally be used with connection-less sockets (UDP sockets).
   ##
   ## If an error occurs an OSError exception will be raised.
   ##
@@ -1741,11 +1754,37 @@ proc sendTo*(socket: Socket, address: string, port: Port,
   ## This proc sends `data` to the specified `address`,
   ## which may be an IP address or a hostname, if a hostname is specified
   ## this function will try each IP of that hostname.
+  ## 
+  ## Generally for use with connection-less (UDP) sockets.
   ##
   ## If an error occurs an OSError exception will be raised.
   ##
   ## This is the high-level version of the above `sendTo` function.
   socket.sendTo(address, port, cstring(data), data.len, socket.domain)
+
+proc sendTo*(socket: Socket, address: IpAddress, port: Port,
+             data: string, flags = 0'i32): int {.
+              discardable, tags: [WriteIOEffect].} =
+  ## This proc sends `data` to the specified `IpAddress` and returns
+  ## the number of bytes written. 
+  ##
+  ## Generally for use with connection-less (UDP) sockets. 
+  ##
+  ## If an error occurs an OSError exception will be raised.
+  ##
+  ## This is the high-level version of the above `sendTo` function.
+  assert(socket.protocol != IPPROTO_TCP, "Cannot `sendTo` on a TCP socket")
+  assert(not socket.isClosed, "Cannot `sendTo` on a closed socket")
+
+  var sa: Sockaddr_storage
+  var sl: Socklen
+  toSockAddr(address, port, sa, sl)
+  result = sendto(socket.fd, cstring(data), data.len().cint, flags.cint,
+                  cast[ptr SockAddr](addr sa), sl)
+
+  if result == -1'i32:
+    let osError = osLastError()
+    raiseOSError(osError)
 
 
 proc isSsl*(socket: Socket): bool =

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -23,10 +23,15 @@ suite "inet_ntop tests":
       discard wsaStartup(0x101'i16, wsa.addr)
   
   test "IP V4":
-    var ip4 = InAddr(s_addr: 0x10111213)
+    var ip4 = InAddr(s_addr: 0x10111213'u32)
     var buff: array[0..255, char]
-    let r = inet_ntop(AF_INET, cast[pointer](ip4.addr), buff[0].addr, buff.len.int32)
+    let r = inet_ntop(AF_INET, cast[pointer](ip4.s_addr.addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
+    when defined(windows):
+      echo("WINDOWS inet_ntop: buff:len: " & $(buff.len))
+      echo("WINDOWS inet_ntop: buff: " & repr(buff))
+      echo("WINDOWS inet_ntop: r: " & repr(r))
+      echo("WINDOWS inet_ntop: res: " & repr(res))
     check: res == "19.18.17.16"
       
   test "IP V6":

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -23,14 +23,34 @@ suite "inet_ntop tests":
       discard wsaStartup(0x101'i16, wsa.addr)
   
   test "IP V4":
+    # regular
     var ip4 = InAddr(s_addr: 0x10111213'u32)
+    # direct assign
+    var ip4v2: InAddr
+    ip4v2.s_addr = 0x10111213'u32
+    # pointer cast
+    var ip4v3 = InAddr()
+    var ip4v3_ptr = cast[ptr uint32](ip4v3.addr)
+    ip4v3_ptr[] = 0x10111213'u32
+    # pointer as inaddr
+    var ip4v4_num = 0x10111213'u32
+    var ip4v4: ptr InAddr = cast[ptr InAddr](ip4v4_num.addr())
+
     var buff: array[0..255, char]
     let r = inet_ntop(AF_INET, cast[pointer](ip4.s_addr.addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
     when defined(windows):
       echo("WINDOWS inet_ntop: ip4: " & repr(ip4))
+      echo("WINDOWS inet_ntop: ip4.s_addr.sizeof: " & $(ip4.s_addr.sizeof()))
       echo("WINDOWS inet_ntop: ip4:s_addr: " & repr(ip4.s_addr))
+      echo("WINDOWS inet_ntop: ip4.s_addr == 0x10111213'u32: " & $(ip4.s_addr == 0x10111213'u32))
       echo("WINDOWS inet_ntop: ip4:ptr: " & repr(cast[ptr array[0..3, uint8]](ip4.s_addr.addr)))
+      echo("WINDOWS inet_ntop: ip4v2:s_addr: " & repr(ip4v2.s_addr))
+      echo("WINDOWS inet_ntop: ip4v2.s_addr == 0x10111213'u32: " & $(ip4v2.s_addr == 0x10111213'u32))
+      echo("WINDOWS inet_ntop: ip4v3:s_addr: " & repr(ip4v3.s_addr))
+      echo("WINDOWS inet_ntop: ip4v3.s_addr == 0x10111213'u32: " & $(ip4v3.s_addr == 0x10111213'u32))
+      echo("WINDOWS inet_ntop: ip4v4:s_addr: " & repr(ip4v4.s_addr))
+      echo("WINDOWS inet_ntop: ip4v4.s_addr == 0x10111213'u32: " & $(ip4v4.s_addr == 0x10111213'u32))
       echo("WINDOWS inet_ntop: buff:len: " & $(buff.len))
       echo("WINDOWS inet_ntop: buff: " & repr(buff))
       echo("WINDOWS inet_ntop: r: " & repr(r))

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -23,9 +23,9 @@ suite "inet_ntop tests":
       discard wsaStartup(0x101'i16, wsa.addr)
   
   test "IP V4":
-    var ip4 = 0x10111213
+    var ip4 = InAddr(s_addr: 0x10111213)
     var buff: array[0..255, char]
-    let r = inet_ntop(AF_INET, ip4.addr, buff[0].addr, buff.sizeof.int32)
+    let r = inet_ntop(AF_INET, cast[pointer](ip4.addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
     check: res == "19.18.17.16"
       
@@ -38,6 +38,6 @@ suite "inet_ntop tests":
           
     var ip6 = [0x1000'u16, 0x1001, 0x2000, 0x2001, 0x3000, 0x3001, 0x4000, 0x4001]
     var buff: array[0..255, char]
-    let r = inet_ntop(AF_INET6, ip6[0].addr, buff[0].addr, buff.sizeof.int32)
+    let r = inet_ntop(AF_INET6, cast[pointer](ip6[0].addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
     check: not ipv6Support or res == "10:110:20:120:30:130:40:140"

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -29,7 +29,6 @@ suite "inet_ntop tests":
     let res = if r == nil: "" else: $r
     check: res == "19.18.17.16"
       
-
   test "IP V6":
     when defined(windows):
       let ipv6Support = (getVersion() and 0xff) > 0x5

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -28,6 +28,9 @@ suite "inet_ntop tests":
     let r = inet_ntop(AF_INET, cast[pointer](ip4.s_addr.addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
     when defined(windows):
+      echo("WINDOWS inet_ntop: ip4: " & repr(ip4))
+      echo("WINDOWS inet_ntop: ip4:s_addr: " & repr(ip4.s_addr))
+      echo("WINDOWS inet_ntop: ip4:ptr: " & repr(cast[ptr array[0..3, uint8]](ip4.s_addr.addr)))
       echo("WINDOWS inet_ntop: buff:len: " & $(buff.len))
       echo("WINDOWS inet_ntop: buff: " & repr(buff))
       echo("WINDOWS inet_ntop: r: " & repr(r))

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -24,37 +24,12 @@ suite "inet_ntop tests":
   
   test "IP V4":
     # regular
-    var ip4 = InAddr(s_addr: 0x10111213'u32)
-    # direct assign
-    var ip4v2: InAddr
-    ip4v2.s_addr = 0x10111213'u32
-    # pointer cast
-    var ip4v3 = InAddr()
-    var ip4v3_ptr = cast[ptr uint32](ip4v3.addr)
-    ip4v3_ptr[] = 0x10111213'u32
-    # pointer as inaddr
-    var ip4v4_num = 0x10111213'u32
-    var ip4v4: ptr InAddr = cast[ptr InAddr](ip4v4_num.addr())
+    var ip4 = InAddr()
+    ip4.s_addr = 0x10111213'u32
 
     var buff: array[0..255, char]
     let r = inet_ntop(AF_INET, cast[pointer](ip4.s_addr.addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
-    when defined(windows):
-      echo("WINDOWS inet_ntop: ip4: " & repr(ip4))
-      echo("WINDOWS inet_ntop: ip4.s_addr.sizeof: " & $(ip4.s_addr.sizeof()))
-      echo("WINDOWS inet_ntop: ip4:s_addr: " & repr(ip4.s_addr))
-      echo("WINDOWS inet_ntop: ip4.s_addr == 0x10111213'u32: " & $(ip4.s_addr == 0x10111213'u32))
-      echo("WINDOWS inet_ntop: ip4:ptr: " & repr(cast[ptr array[0..3, uint8]](ip4.s_addr.addr)))
-      echo("WINDOWS inet_ntop: ip4v2:s_addr: " & repr(ip4v2.s_addr))
-      echo("WINDOWS inet_ntop: ip4v2.s_addr == 0x10111213'u32: " & $(ip4v2.s_addr == 0x10111213'u32))
-      echo("WINDOWS inet_ntop: ip4v3:s_addr: " & repr(ip4v3.s_addr))
-      echo("WINDOWS inet_ntop: ip4v3.s_addr == 0x10111213'u32: " & $(ip4v3.s_addr == 0x10111213'u32))
-      echo("WINDOWS inet_ntop: ip4v4:s_addr: " & repr(ip4v4.s_addr))
-      echo("WINDOWS inet_ntop: ip4v4.s_addr == 0x10111213'u32: " & $(ip4v4.s_addr == 0x10111213'u32))
-      echo("WINDOWS inet_ntop: buff:len: " & $(buff.len))
-      echo("WINDOWS inet_ntop: buff: " & repr(buff))
-      echo("WINDOWS inet_ntop: r: " & repr(r))
-      echo("WINDOWS inet_ntop: res: " & repr(res))
     check: res == "19.18.17.16"
       
   test "IP V6":


### PR DESCRIPTION
Expanding the `std/net` API for a few embedded use cases where calling `getAddrInfo` repeatedly becomes expensive (and DNS often isn't even enabled). However, it's also nice to be able to send a UDP packet directly to an IpAddress in regular environments when you know the IP upfront (e.g. multicast). Also included is a couple of tweaks to `inet_ntop` and `inet_pton` to extend their types, but in a backwards compatible way. 

One alteration to the extended API's could be to use an openArray of IpAddress's to allow binding to the first workable IP. Though that seems easy enough to implement oneself. 

I'll be testing these manually a bit more, but have included tests and tried them out briefly and they don't error out. 