### PR TITLE
Merge file size fields correctly on Windows

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3255,7 +3255,11 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
   ## 'rawInfo' is either a 'BY_HANDLE_FILE_INFORMATION' structure on Windows,
   ## or a 'Stat' structure on posix
   when defined(windows):
-    template merge(a, b): untyped = a or (b shl 32)
+    template merge(a, b): untyped =
+      int64(
+        (uint64(cast[uint32](a))) or
+        (uint64(cast[uint32](b))) shl 32)
+       )
     formalInfo.id.device = rawInfo.dwVolumeSerialNumber
     formalInfo.id.file = merge(rawInfo.nFileIndexLow, rawInfo.nFileIndexHigh)
     formalInfo.size = merge(rawInfo.nFileSizeLow, rawInfo.nFileSizeHigh)

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3258,7 +3258,7 @@ template rawToFormalFileInfo(rawInfo, path, formalInfo): untyped =
     template merge(a, b): untyped =
       int64(
         (uint64(cast[uint32](a))) or
-        (uint64(cast[uint32](b))) shl 32)
+        (uint64(cast[uint32](b)) shl 32)
        )
     formalInfo.id.device = rawInfo.dwVolumeSerialNumber
     formalInfo.id.file = merge(rawInfo.nFileIndexLow, rawInfo.nFileIndexHigh)


### PR DESCRIPTION
Merge file size fields correctly on Windows

- Merge the two 32-bit file size fields from `BY_HANDLE_FILE_INFORMATION` correctly in `rawToFormalFileInfo`.
- Fixes #19135