### PR TITLE
Implement zephyr urandom and monotime

### DIFF
--- a/lib/std/monotimes.nim
+++ b/lib/std/monotimes.nim
@@ -76,6 +76,10 @@ when defined(js):
 elif defined(posix) and not defined(osx):
   import posix
 
+when defined(zephyr):
+  proc k_uptime_ticks(): int64 {.importc: "k_uptime_ticks", header: "<kernel.h>".}
+  proc k_ticks_to_ns_floor64(ticks: int64): int64 {.importc: "k_ticks_to_ns_floor64", header: "<kernel.h>".}
+
 elif defined(windows):
   proc QueryPerformanceCounter(res: var uint64) {.
     importc: "QueryPerformanceCounter", stdcall, dynlib: "kernel32".}
@@ -98,6 +102,9 @@ proc getMonoTime*(): MonoTime {.tags: [TimeEffect].} =
     mach_timebase_info(machAbsoluteTimeFreq)
     result = MonoTime(ticks: ticks * machAbsoluteTimeFreq.numer div
       machAbsoluteTimeFreq.denom)
+  elif defined(zephyr):
+    let ticks = k_ticks_to_ns_floor64(k_uptime_ticks())
+    result = MonoTime(ticks: ticks)
   elif defined(posix):
     var ts: Timespec
     discard clock_gettime(CLOCK_MONOTONIC, ts)

--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -63,7 +63,7 @@ when defined(posix):
   import posix
 
 const
-  batchImplOS = defined(freebsd) or defined(openbsd) or (defined(macosx) and not defined(ios))
+  batchImplOS = defined(freebsd) or defined(openbsd) or defined(zephyr) or (defined(macosx) and not defined(ios))
   batchSize {.used.} = 256
 
 when batchImplOS:
@@ -206,6 +206,16 @@ elif defined(openbsd):
 
   proc getRandomImpl(p: pointer, size: int): int {.inline.} =
     result = getentropy(p, cint(size)).int
+
+elif defined(zephyr):
+  proc sys_csrand_get(dst: pointer, length: csize_t): cint {.importc: "sys_csrand_get", header: "<random/rand32.h>".}
+    # Fill the destination buffer with cryptographically secure
+    # random data values
+    # 
+
+  proc getRandomImpl(p: pointer, size: int): int {.inline.} =
+    # 0 if success, -EIO if entropy reseed error
+    result = sys_csrand_get(p, csize_t(size)).int
 
 elif defined(freebsd):
   type cssize_t {.importc: "ssize_t", header: "<sys/types.h>".} = int


### PR DESCRIPTION
- `getRandomImpl` enables most of `std/sysrand` & `std/random` with whatever secure random bytes the hardware/zephyr provides 
- `getMonoTime` provides the kernel tick time in nanoseconds, but it depends on the device how accurate they really are (it's common to see microseconds nowadays)
  + Using `getMonoTime` enables `std/monotimes` and much of `std/times` 
  + Zephyr does support some amount of POSIX times like `clock_gettime` but it's device and configuration specific. By default it returns 0 (or rather 1970-....)

I've tested this on running devices. Hopefully a CI can be setup for Zephyr using QEMU. 