### PR TITLE
Fix undeclared 'SYS_getrandom' on emscripten

### DIFF
--- a/lib/std/sysrand.nim
+++ b/lib/std/sysrand.nim
@@ -164,7 +164,7 @@ elif defined(windows):
 
     result = randomBytes(addr dest[0], size)
 
-elif defined(linux) and not defined(nimNoGetRandom):
+elif defined(linux) and not defined(nimNoGetRandom) and not defined(emscripten):
   # TODO using let, pending bootstrap >= 1.4.0
   var SYS_getrandom {.importc: "SYS_getrandom", header: "<sys/syscall.h>".}: clong
   const syscallHeader = """#include <unistd.h>


### PR DESCRIPTION
I just attempted to compile a project to WASM with emscripten, and ran into an issue similar to #19052: `linux` is defined, but `SYS_getrandom` is not declared on that target. 

`-d:nimNoGetRandom` is a functional workaround, but this is a cleaner solution for emscripten - users shouldn't need to define an extra flag to compile their programs.