### PR TITLE
execute `GC_runOrc` before exiting threads

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -152,6 +152,8 @@ else:
       threadTrouble()
     finally:
       afterThreadRuns()
+      when defined(gcOrc):
+        GC_runOrc()
 
 proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
   when defined(boehmgc):


### PR DESCRIPTION
IMHO, ORC uses shared heap and should clean the cycle before threads exit.

A leak, for example

```nim
import os

type
  WorkRequest = ref object
    id: WorkRequest
    data: string
    time: array[100000, int]

var
  thread: Thread[void]


proc workThread() {.thread.} =
  var x = WorkRequest()
  x.id = x

while true:
  createThread(thread, workThread)
  sleep(1000)
```