### PR TITLE
Implement threads on Zephyr  

### DIFF
--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -686,7 +686,7 @@ Thread stack size
 
 Nim's thread API provides a simple wrapper around more advanced
 RTOS task features. Customizing the stack size and stack guard size can
-be done by setting `-d:nimThreadStackGuard=16384` or `-d:nimThreadStackSize=8`.
+be done by setting `-d:nimThreadStackSize=16384` or `-d:nimThreadStackGuard=32`.
 
 Currently only Zephyr and FreeRTOS support these configurations. 
 

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -686,7 +686,7 @@ Thread stack size
 
 Nim's thread API provides a simple wrapper around more advanced
 RTOS task features. Customizing the stack size and stack guard size can
-be done by setting `-d:StackThreadSize=16384` or `-d:StackGuardSize:8`.
+be done by setting `-d:nimThreadStackGuard=16384` or `-d:nimThreadStackSize=8`.
 
 Currently only Zephyr and FreeRTOS support these configurations. 
 

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -675,6 +675,7 @@ Initial testing hasn't shown much difference between 512B or 1kB page sizes
 in terms of performance or latency. Using `nimPages256` will limit the
 total amount of allocatable RAM.
 
+nimMemAlignTiny
 ===============
 
 Sets `MemAlign` to `4` bytes which reduces the memory alignment

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -675,11 +675,19 @@ Initial testing hasn't shown much difference between 512B or 1kB page sizes
 in terms of performance or latency. Using `nimPages256` will limit the
 total amount of allocatable RAM.
 
-nimMemAlignTiny
 ===============
 
 Sets `MemAlign` to `4` bytes which reduces the memory alignment
 to better match some embedded devices.
+
+Thread stack size 
+=================
+
+Nim's thread API provides a simple wrapper around more advanced
+RTOS task features. Customizing the stack size and stack guard size can
+be done by setting `-d:StackThreadSize=16384` or `-d:StackGuardSize:8`.
+
+Currently only Zephyr and FreeRTOS support these configurations. 
 
 Nim for realtime systems
 ========================

--- a/lib/system/threadlocalstorage.nim
+++ b/lib/system/threadlocalstorage.nim
@@ -153,6 +153,8 @@ else:
 
   proc pthread_attr_init(a1: var Pthread_attr): cint {.
     importc, header: pthreadh.}
+  proc pthread_attr_setstack*(a1: ptr Pthread_attr, a2: pointer, a3: int): cint {.
+    importc, header: pthreadh.}
   proc pthread_attr_setstacksize(a1: var Pthread_attr, a2: int): cint {.
     importc, header: pthreadh.}
   proc pthread_attr_destroy(a1: var Pthread_attr): cint {.

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -346,8 +346,6 @@ else:
     doAssert pthread_attr_destroy(a) == 0
 
   proc pinToCpu*[Arg](t: var Thread[Arg]; cpu: Natural) =
-    when defined(zephyr):
-      {.fatal: "not implemented yet".}
     ## Pins a thread to a `CPU`:idx:.
     ##
     ## In other words sets a thread's `affinity`:idx:.

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -49,9 +49,13 @@ when not declared(ThisIsSystem):
 
 when defined(zephyr) or defined(freertos):
   const
-    StackGuardSize {.intdefine.} = 128
-    StackThreadSize {.intdefine.} = 8192 
-    ThreadStackSize = StackThreadSize - 1 - StackGuardSize
+    nimThreadStackGuard {.intdefine.} = 128
+    nimThreadStackSize {.intdefine.} = 8192 
+    StackGuardSize = nimThreadStackGuard 
+    ThreadStackSize = nimThreadStackSize - nimThreadStackGuard 
+  static:
+    echo "StackGuardSize: ", StackGuardSize
+    echo "ThreadStackSize : ", ThreadStackSize 
 else:
   const
     StackGuardSize = 4096
@@ -344,6 +348,8 @@ else:
     doAssert pthread_attr_destroy(a) == 0
 
   proc pinToCpu*[Arg](t: var Thread[Arg]; cpu: Natural) =
+    when defined(zephyr):
+      {.fatal: "not implemented yet".}
     ## Pins a thread to a `CPU`:idx:.
     ##
     ## In other words sets a thread's `affinity`:idx:.

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -47,10 +47,11 @@
 when not declared(ThisIsSystem):
   {.error: "You must not import this module explicitly".}
 
-when defined(zephyr):
+when defined(zephyr) or defined(freertos):
   const
     StackGuardSize {.intdefine.} = 128
-    ThreadStackSize {.intdefine.} = 8192 - 1 - StackGuardSize
+    StackThreadSize {.intdefine.} = 8192 
+    ThreadStackSize = StackThreadSize - 1 - StackGuardSize
 else:
   const
     StackGuardSize = 4096

--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -49,13 +49,11 @@ when not declared(ThisIsSystem):
 
 when defined(zephyr) or defined(freertos):
   const
-    nimThreadStackGuard {.intdefine.} = 128
     nimThreadStackSize {.intdefine.} = 8192 
+    nimThreadStackGuard {.intdefine.} = 128
+
     StackGuardSize = nimThreadStackGuard 
     ThreadStackSize = nimThreadStackSize - nimThreadStackGuard 
-  static:
-    echo "StackGuardSize: ", StackGuardSize
-    echo "ThreadStackSize : ", ThreadStackSize 
 else:
   const
     StackGuardSize = 4096


### PR DESCRIPTION
Enable threads on Zephyr. This uses the POSIX layer, but requires tweaking the default stack size, and making it configurable. 

Originally I tried to figure out how to allow users to set `ThreadStackSize` at runtime, but decided it wasn't worth it. There's a full featured task API that's available in Zephyr (and partly wrapped in Nephyr). These settings gives a nice tradeoff of making threads "easy" on Zephyr and a bit customizable. More advanced users can use the full API if they want fully customizable tasks. 

This has been tested on a device running with full pre-emption and so far appears stable. 