### PR TITLE
Accept nnkTypeSection from typedef macro pragmas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,36 @@
 
 ## Language changes
 
+- Pragma macros on type definitions can now return `nnkTypeSection` nodes as well as `nnkTypeDef`,
+  allowing multiple type definitions to be injected in place of the original type definition.
 
+  ```nim
+  import macros
+
+  macro multiply(amount: static int, s: untyped): untyped =
+    let name = $s[0].basename
+    result = newNimNode(nnkTypeSection)
+    for i in 1 .. amount:
+      result.add(newTree(nnkTypeDef, ident(name & $i), s[1], s[2]))
+
+  type
+    Foo = object
+    Bar {.multiply: 3.} = object
+      x, y, z: int
+    Baz = object
+
+  # becomes
+
+  type
+    Foo = object
+    Bar1 = object
+      x, y, z: int
+    Bar2 = object
+      x, y, z: int
+    Bar3 = object
+      x, y, z: int
+    Baz = object
+  ```
 
 ## Compiler changes
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7755,6 +7755,7 @@ This is translated to:
 This is translated to a call to the `schema` macro with a `nnkTypeDef`
 AST node capturing both the left-hand side and right-hand side of the
 definition. The macro can return a potentially modified `nnkTypeDef` tree
+or multiple `nnkTypeDef` trees contained in a `nnkTypeSection` node
 which will replace the original row in the type section.
 
 When multiple macro pragmas are applied to the same definition, the

--- a/tests/pragmas/ttypedef_macro.nim
+++ b/tests/pragmas/ttypedef_macro.nim
@@ -1,0 +1,66 @@
+import macros
+
+macro makeref(s): untyped =
+  expectKind s, nnkTypeDef
+  result = newTree(nnkTypeDef, s[0], s[1], newTree(nnkRefTy, s[2]))
+
+type
+  Obj {.makeref.} = object
+    a: int
+
+doAssert Obj is ref
+doAssert Obj(a: 3)[].a == 3
+
+macro multiply(amount: static int, s): untyped =
+  let name = $s[0].basename
+  result = newNimNode(nnkTypeSection)
+  for i in 1 .. amount:
+    result.add(newTree(nnkTypeDef, ident(name & $i), s[1], s[2]))
+
+type
+  Foo = object
+  Bar {.multiply: 2.} = object
+    x, y, z: int
+  Baz = object
+
+let bar1 = Bar1(x: 1, y: 2, z: 3)
+let bar2 = Bar2(x: bar1.x, y: bar1.y, z: bar1.z)
+doAssert Bar1 isnot Bar2
+doAssert not declared(Bar)
+doAssert not declared(Bar3)
+
+# https://github.com/nim-lang/RFCs/issues/219
+
+macro inferKind(td): untyped =
+  let name = $td[0].basename
+  var rhs = td[2]
+  while rhs.kind in {nnkPtrTy, nnkRefTy}: rhs = rhs[0]
+  if rhs.kind != nnkObjectTy:
+    result = td
+  else:
+    for n in rhs[^1]:
+      if n.kind == nnkRecCase and n[0][^2].eqIdent"_":
+        let kindTypeName = ident(name & "Kind")
+        let en = newTree(nnkEnumTy, newEmptyNode())
+        for i in 1 ..< n.len:
+          let branch = n[i]
+          if branch.kind == nnkOfBranch:
+            for j in 0 ..< branch.len - 1:
+              en.add(branch[j])
+        n[0][^2] = kindTypeName
+        return newTree(nnkTypeSection,
+          newTree(nnkTypeDef, kindTypeName, newEmptyNode(), en),
+          td)
+
+type Node {.inferKind.} = ref object
+  case kind: _
+  of opValue: value: int
+  of opAdd, opSub, opMul, opCall: kids: seq[Node]
+
+doAssert opValue is NodeKind
+let node = Node(kind: opMul, kids: @[
+  Node(kind: opValue, value: 3),
+  Node(kind: opValue, value: 5)
+])
+doAssert node.kind == opMul
+doAssert node.kids[0].value * node.kids[1].value == 15


### PR DESCRIPTION
Refs https://github.com/nim-lang/RFCs/issues/427, https://github.com/nim-lang/RFCs/issues/219

Also new test for this feature in general.

I don't know the best way to make the illformed AST error more informative as I cannot find an illformed AST error in the compiler that doesn't just call `illFormedAst`. Maybe it can be made better in a sweep change later.

Would also like to know if backporting makes sense, and to which versions.

I realized after that there is a dumb hack for getting any expression to work with the old behavior, though not with type section cyclic reference semantics, which some people may be fine with. Don't think it's ergonomic enough for https://github.com/nim-lang/RFCs/issues/66 and https://github.com/nim-lang/Nim/issues/13830, but maybe still a last ditch solution.
<details>
<summary>Hack</summary>

```nim
import macros

template it(x): untyped = x

macro hack(_): untyped =
  result = newTree(nnkTypeDef, ident"_", newEmptyNode(), newCall(bindSym"it",
    quote do:
      proc abc*(bar: Bar) = echo "hello ", bar.string
      static: echo 3
      void))
  
type
  Bar = distinct string
  _ {.hack.} = void

abc(Bar("world"))
```
</details>

If `inferKind` is a good addition to `sugar` I can also refine and add it but in a separate PR if this one might be backported.