### PR TITLE
`caseStmtMacros` no longer experimental, experimental manual refactor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,8 @@
       x, y, z: int
     Baz = object
   ```
+- [Case statement macros](manual.html#macros-case-statement-macros) are no longer experimental,
+  meaning you no longer need to enable the experimental switch `caseStmtMacros` to use them. 
 
 ## Compiler changes
 

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -195,7 +195,7 @@ type
     notnil,
     dynamicBindSym,
     forLoopMacros, # not experimental anymore; remains here for backwards compatibility
-    caseStmtMacros,
+    caseStmtMacros, # ditto
     codeReordering,
     compiletimeFFI,
       ## This requires building nim with `-d:nimHasLibFFI`

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -987,10 +987,10 @@ proc semCase(c: PContext, n: PNode; flags: TExprFlags): PNode =
   else:
     popCaseContext(c)
     closeScope(c)
-    if caseStmtMacros in c.features:
-      result = handleCaseStmtMacro(c, n, flags)
-      if result != nil:
-        return result
+    #if caseStmtMacros in c.features:
+    result = handleCaseStmtMacro(c, n, flags)
+    if result != nil:
+      return result
     localError(c.config, n[0].info, errSelectorMustBeOfCertainTypes)
     return
   for i in 1..<n.len:

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -497,10 +497,10 @@ backtick token and the character literal. This special case ensures that a decla
 like ``proc `'customLiteral`(s: string)`` is valid. ``proc `'customLiteral`(s: string)``
 is the same as ``proc `'\''customLiteral`(s: string)``.
 
-See also `Custom Numeric Literals <#custom-numeric-literals>`_.
+See also `custom numeric literals <#custom-numeric-literals>`_.
 
 
-Numeric Literals
+Numeric literals
 ----------------
 
 Numeric literals have the form::
@@ -625,7 +625,7 @@ Hence: 0b10000000'u8 == 0x80'u8 == 128, but, 0b10000000'i8 == 0x80'i8 == -1
 instead of causing an overflow error.
 
 
-Custom Numeric Literals
+Custom numeric literals
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 If the suffix is not predefined, then the suffix is assumed to be a call
@@ -698,26 +698,6 @@ The following strings denote other tokens::
 The `slice`:idx: operator `..`:tok: takes precedence over other tokens that
 contain a dot: `{..}` are the three tokens `{`:tok:, `..`:tok:, `}`:tok:
 and not the two tokens `{.`:tok:, `.}`:tok:.
-
-
-Unicode Operators
------------------
-
-Under the `--experimental:unicodeOperators` switch these Unicode operators are
-also parsed as operators::
-
-  ∙ ∘ × ★ ⊗ ⊘ ⊙ ⊛ ⊠ ⊡ ∩ ∧ ⊓   # same priority as * (multiplication)
-  ± ⊕ ⊖ ⊞ ⊟ ∪ ∨ ⊔             # same priority as + (addition)
-
-
-If enabled, Unicode operators can be combined with non-Unicode operator
-symbols. The usual precedence extensions then apply, for example, `⊠=` is an
-assignment like operator just like `*=` is.
-
-No Unicode normalization step is performed.
-
-**Note**: Due to parser limitations one **cannot** enable this feature via a
-pragma `{.experimental: "unicodeOperators".}` reliably.
 
 
 Syntax
@@ -1323,46 +1303,6 @@ as `MyEnum.value`:
 
 To implement bit fields with enums see `Bit fields <#set-type-bit-fields>`_
 
-Overloadable enum field names
------------------------------
-
-To be enabled via `{.experimental: "overloadableEnums".}`.
-
-Enum field names are overloadable much like routines. When an overloaded
-enum field is used, it produces a closed sym choice construct, here
-written as `(E|E)`.
-During overload resolution the right `E` is picked, if possible.
-For (array/object...) constructors the right `E` is picked, comparable to
-how `[byte(1), 2, 3]` works, one needs to use `[T.E, E2, E3]`. Ambiguous
-enum fields produce a static error:
-
-.. code-block:: nim
-    :test: "nim c $1"
-
-  {.experimental: "overloadableEnums".}
-
-  type
-    E1 = enum
-      value1,
-      value2
-    E2 = enum
-      value1,
-      value2 = 4
-
-  const
-    Lookuptable = [
-      E1.value1: "1",
-      value2: "2"
-    ]
-
-  proc p(e: E1) =
-    # disambiguation in 'case' statements:
-    case e
-    of value1: echo "A"
-    of value2: echo "B"
-
-  p value2
-
 
 String type
 -----------
@@ -1684,11 +1624,6 @@ must match the order of the tuple's definition. Different tuple-types are
 *equivalent* if they specify the same fields of the same type in the same
 order. The *names* of the fields also have to be the same.
 
-The assignment operator for tuples copies each component.
-The default assignment operator for objects copies each component. Overloading
-of the assignment operator is described `here
-<manual_experimental.html#type-bound-operations>`_.
-
 .. code-block:: nim
 
   type
@@ -1764,6 +1699,10 @@ introduce new object roots apart from `system.RootObj`.
 
     Student = ref object of Person # Error: inheritance only works with non-final objects
       id: int
+
+The assignment operator for tuples and objects copies each component.
+The methods to override this copying behavior are described `here
+<manual.html#procedures-type-bound-operations>`_.
 
 
 Object construction
@@ -2685,6 +2624,7 @@ Varargs matching
 
 See `Varargs <#types-varargs>`_.
 
+
 iterable
 --------
 
@@ -2724,6 +2664,26 @@ available. Let `p` be an overloaded symbol. These contexts are:
 - In a declaration like `x: T = p` when `T` is a `proc` type.
 
 As usual, ambiguous matches produce a compile-time error.
+
+Named argument overloading
+--------------------------
+
+Routines with the same type signature can be called individually if
+a parameter has different names between them.
+
+.. code-block:: Nim
+  proc foo(x: int) =
+    echo "Using x: ", x
+  proc foo(y: int) =
+    echo "Using y: ", y
+
+  foo(x = 2)
+  # Using x: 2
+  foo(y = 2)
+  # Using y: 2
+
+Not supplying the parameter name in such cases will result in an
+ambiguity error.
 
 
 Statements and expressions
@@ -3836,8 +3796,8 @@ behavior inside loop bodies. See `closureScope
 <system.html#closureScope.t,untyped>`_ and `capture
 <sugar.html#capture.m,varargs[typed],untyped>`_ for details on how to change this behavior.
 
-Anonymous Procs
----------------
+Anonymous procedures
+--------------------
 
 Unnamed procedures can be used as lambda expressions to pass into other
 procedures:
@@ -3845,8 +3805,8 @@ procedures:
 .. code-block:: nim
   var cities = @["Frankfurt", "Tokyo", "New York", "Kyiv"]
 
-  cities.sort(proc (x,y: string): int =
-      cmp(x.len, y.len))
+  cities.sort(proc (x, y: string): int =
+    cmp(x.len, y.len))
 
 
 Procs as expressions can appear both as nested procs and inside top-level
@@ -3854,6 +3814,42 @@ executable code. The  `sugar <sugar.html>`_ module contains the `=>` macro
 which enables a more succinct syntax for anonymous procedures resembling
 lambdas as they are in languages like JavaScript, C#, etc.
 
+Do notation
+-----------
+
+As a special convenience notation that keeps most elements of a
+regular proc expression, the `do` keyword can be used to pass
+anonymous procedures to routines:
+
+.. code-block:: nim
+  var cities = @["Frankfurt", "Tokyo", "New York", "Kyiv"]
+
+  sort(cities) do (x, y: string) -> int:
+    cmp(x.len, y.len)
+
+  # Less parentheses using the method plus command syntax:
+  cities = cities.map do (x: string) -> string:
+    "City of " & x
+
+`do` is written after the parentheses enclosing the regular proc params.
+The proc expression represented by the `do` block is appended to the routine
+call as the last argument. In calls using the command syntax, the `do` block
+will bind to the immediately preceding expression rather than the command call.
+
+`do` with a parameter list corresponds to an anonymous `proc`, however
+`do` without parameters is treated as a normal statement list. This allows
+macros to receive both indented statement lists as an argument in inline
+calls, as well as a direct mirror of Nim's routine syntax.
+
+.. code-block:: nim
+  # Passing a statement list to an inline macro:
+  macroResults.add quote do:
+    if not `ex`:
+      echo `info`, ": Check failed: ", `expString`
+  
+  # Processing a routine definition in a macro:
+  rpc(router, "add") do (a, b: int) -> int:
+    result = a + b
 
 Func
 ----
@@ -5133,7 +5129,7 @@ code:
         deletedKeys: seq[bool]
 
 
-Type Classes
+Type classes
 ------------
 
 A type class is a special pseudo-type that can be used to match against
@@ -5863,7 +5859,15 @@ twice:
 While macros enable advanced compile-time code transformations, they
 cannot change Nim's syntax.
 
-Debug Example
+**Style note**: For code readability, it is best to use the least powerful
+programming construct that remains expressive. So the "check list" is:
+
+(1) Use an ordinary proc/iterator, if possible.
+(2) Else: Use a generic proc/iterator, if possible.
+(3) Else: Use a template, if possible.
+(4) Else: Use a macro.
+
+Debug example
 -------------
 
 The following example implements a powerful `debug` command that accepts a
@@ -5921,7 +5925,7 @@ constructor expression. This is why `debug` iterates over all of `args`'s
 children.
 
 
-BindSym
+bindSym
 -------
 
 The above `debug` macro relies on the fact that `write`, `writeLine` and
@@ -5970,43 +5974,38 @@ However, the symbols `write`, `writeLine` and `stdout` are already bound
 and are not looked up again. As the example shows, `bindSym` does work with
 overloaded symbols implicitly.
 
-Case-Of Macro
--------------
+Note that the symbol names passed to `bindSym` have to be constant. The
+experimental feature `dynamicBindSym` (`experimental manual
+<manual_experimental.html#dynamic-arguments-for-bindsym>`_)
+allows this value to be computed dynamically.
 
-In Nim, it is possible to have a macro with the syntax of a *case-of*
-expression just with the difference that all *of-branches* are passed to
-and processed by the macro implementation. It is then up the macro
-implementation to transform the *of-branches* into a valid Nim
-statement. The following example should show how this feature could be
-used for a lexical analyzer.
+Post-statement blocks
+---------------------
+
+Macros can receive `of`, `elif`, `else`, `except`, `finally` and `do`
+blocks (including their different forms such as `do` with routine parameters)
+as arguments if called in statement form.
 
 .. code-block:: nim
-  import std/macros
+  macro performWithUndo(task, undo: untyped) = ...
 
-  macro case_token(args: varargs[untyped]): untyped =
-    echo args.treeRepr
-    # creates a lexical analyzer from regular expressions
-    # ... (implementation is an exercise for the reader ;-)
-    discard
-
-  case_token: # this colon tells the parser it is a macro statement
-  of r"[A-Za-z_]+[A-Za-z_0-9]*":
-    return tkIdentifier
-  of r"0-9+":
-    return tkInteger
-  of r"[\+\-\*\?]+":
-    return tkOperator
+  performWithUndo do:
+    # multiple-line block of code
+    # to perform the task
+  do:
+    # code to undo it
+  
+  let num = 12
+  # a single colon may be used if there is no initial block
+  match (num mod 3, num mod 5):
+  of (0, 0):
+    echo "FizzBuzz"
+  of (0, _):
+    echo "Fizz"
+  of (_, 0):
+    echo "Buzz"
   else:
-    return tkUnknown
-
-
-**Style note**: For code readability, it is best to use the least powerful
-programming construct that still suffices. So the "check list" is:
-
-(1) Use an ordinary proc/iterator, if possible.
-(2) Else: Use a generic proc/iterator, if possible.
-(3) Else: Use a template, if possible.
-(4) Else: Use a macro.
+    echo num
 
 
 For loop macro
@@ -6070,6 +6069,48 @@ Another example:
   # names for `a` and `b` here to avoid redefinition errors
   for a, b in enumerate(10, [1, 2, 3, 5]):
     echo a, " ", b
+
+
+Case statement macros
+---------------------
+
+Macros named `` `case` `` can provide implementations of `case` statements
+for certain types. The following is an example of such an implementation
+for tuples, leveraging the existing equality operator for tuples
+(as provided in `system.==`):
+
+.. code-block:: nim
+    :test: "nim c $1"
+  import std/macros
+
+  macro `case`(n: tuple): untyped =
+    result = newTree(nnkIfStmt)
+    let selector = n[0]
+    for i in 1 ..< n.len:
+      let it = n[i]
+      case it.kind
+      of nnkElse, nnkElifBranch, nnkElifExpr, nnkElseExpr:
+        result.add it
+      of nnkOfBranch:
+        for j in 0..it.len-2:
+          let cond = newCall("==", selector, it[j])
+          result.add newTree(nnkElifBranch, cond, it[^1])
+      else:
+        error "custom 'case' for tuple cannot handle this node", it
+
+  case ("foo", 78)
+  of ("foo", 78): echo "yes"
+  of ("bar", 88): echo "no"
+  else: discard
+
+`case` macros are subject to overload resolution. The type of the
+`case` statement's selector expression is matched against the type
+of the first argument of the `case` macro. Then the complete `case`
+statement is passed in place of the argument and the macro is evaluated.
+
+In other words, the macro needs to transform the full `case` statement
+but only the statement's selector expression is used to determine which
+macro to call.
 
 
 Special Types
@@ -6959,7 +7000,8 @@ experimental pragma
 The `experimental` pragma enables experimental language features. Depending
 on the concrete feature, this means that the feature is either considered
 too unstable for an otherwise stable release or that the future of the feature
-is uncertain (it may be removed at any time).
+is uncertain (it may be removed at any time). See the
+`experimental manual <manual_experimental.html>`_ for more details.
 
 Example:
 
@@ -7058,6 +7100,21 @@ alignment requirement of the type are ignored.
    main()
 
 This pragma has no effect on the JS backend.
+
+
+Noalias pragma
+==============
+
+Since version 1.4 of the Nim compiler, there is a `.noalias` annotation for variables
+and parameters. It is mapped directly to C/C++'s `restrict`:c: keyword and means that
+the underlying pointer is pointing to a unique location in memory, no other aliases to
+this location exist. It is *unchecked* that this alias restriction is followed, if the
+restriction is violated, the backend optimizer is free to miscompile the code.
+This is an **unsafe** language feature.
+
+Ideally in later versions of the language, the restriction will be enforced at
+compile time. (Which is also why the name `noalias` was choosen instead of a more
+verbose name like `unsafeAssumeNoAlias`.)
 
 
 Volatile pragma
@@ -8032,3 +8089,137 @@ Threads and exceptions
 The interaction between threads and exceptions is simple: A *handled* exception
 in one thread cannot affect any other thread. However, an *unhandled* exception
 in one thread terminates the whole *process*.
+
+
+Guards and locks
+================
+
+Nim provides common low level concurrency mechanisms like locks, atomic
+intrinsics or condition variables.
+
+Nim significantly improves on the safety of these features via additional
+pragmas:
+
+1) A `guard`:idx: annotation is introduced to prevent data races.
+2) Every access of a guarded memory location needs to happen in an
+   appropriate `locks`:idx: statement.
+
+
+Guards and the locks section
+----------------------------
+
+Protecting global variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Object fields and global variables can be annotated via a `guard` pragma:
+
+.. code-block:: nim
+
+  var glock: TLock
+  var gdata {.guard: glock.}: int
+
+The compiler then ensures that every access of `gdata` is within a `locks`
+section:
+
+.. code-block:: nim
+
+  proc invalid =
+    # invalid: unguarded access:
+    echo gdata
+
+  proc valid =
+    # valid access:
+    {.locks: [glock].}:
+      echo gdata
+
+Top level accesses to `gdata` are always allowed so that it can be initialized
+conveniently. It is *assumed* (but not enforced) that every top level statement
+is executed before any concurrent action happens.
+
+The `locks` section deliberately looks ugly because it has no runtime
+semantics and should not be used directly! It should only be used in templates
+that also implement some form of locking at runtime:
+
+.. code-block:: nim
+
+  template lock(a: TLock; body: untyped) =
+    pthread_mutex_lock(a)
+    {.locks: [a].}:
+      try:
+        body
+      finally:
+        pthread_mutex_unlock(a)
+
+
+The guard does not need to be of any particular type. It is flexible enough to
+model low level lockfree mechanisms:
+
+.. code-block:: nim
+
+  var dummyLock {.compileTime.}: int
+  var atomicCounter {.guard: dummyLock.}: int
+
+  template atomicRead(x): untyped =
+    {.locks: [dummyLock].}:
+      memoryReadBarrier()
+      x
+
+  echo atomicRead(atomicCounter)
+
+
+The `locks` pragma takes a list of lock expressions `locks: [a, b, ...]`
+in order to support *multi lock* statements. Why these are essential is
+explained in the `lock levels <#guards-and-locks-lock-levels>`_ section.
+
+
+Protecting general locations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `guard` annotation can also be used to protect fields within an object.
+The guard then needs to be another field within the same object or a
+global variable.
+
+Since objects can reside on the heap or on the stack this greatly enhances the
+expressivity of the language:
+
+.. code-block:: nim
+
+  type
+    ProtectedCounter = object
+      v {.guard: L.}: int
+      L: TLock
+
+  proc incCounters(counters: var openArray[ProtectedCounter]) =
+    for i in 0..counters.high:
+      lock counters[i].L:
+        inc counters[i].v
+
+The access to field `x.v` is allowed since its guard `x.L`  is active.
+After template expansion, this amounts to:
+
+.. code-block:: nim
+
+  proc incCounters(counters: var openArray[ProtectedCounter]) =
+    for i in 0..counters.high:
+      pthread_mutex_lock(counters[i].L)
+      {.locks: [counters[i].L].}:
+        try:
+          inc counters[i].v
+        finally:
+          pthread_mutex_unlock(counters[i].L)
+
+There is an analysis that checks that `counters[i].L` is the lock that
+corresponds to the protected location `counters[i].v`. This analysis is called
+`path analysis`:idx: because it deals with paths to locations
+like `obj.field[i].fieldB[j]`.
+
+The path analysis is **currently unsound**, but that doesn't make it useless.
+Two paths are considered equivalent if they are syntactically the same.
+
+This means the following compiles (for now) even though it really should not:
+
+.. code-block:: nim
+
+  {.locks: [a[i].L].}:
+    inc i
+    access a[i].v

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2677,10 +2677,8 @@ a parameter has different names between them.
   proc foo(y: int) =
     echo "Using y: ", y
 
-  foo(x = 2)
-  # Using x: 2
-  foo(y = 2)
-  # Using y: 2
+  foo(x = 2) # Using x: 2
+  foo(y = 2) # Using y: 2
 
 Not supplying the parameter name in such cases results in an
 ambiguity error.
@@ -3160,7 +3158,7 @@ Return statement
 Example:
 
 .. code-block:: nim
-  return 40+2
+  return 40 + 2
 
 The `return` statement ends the execution of the current procedure.
 It is only allowed in procedures. If there is an `expr`, this is syntactic
@@ -5859,7 +5857,7 @@ twice:
 While macros enable advanced compile-time code transformations, they
 cannot change Nim's syntax.
 
-**Style note**: For code readability, it is best to use the least powerful
+**Style note:** For code readability, it is best to use the least powerful
 programming construct that remains expressive. So the "check list" is:
 
 (1) Use an ordinary proc/iterator, if possible.
@@ -7108,12 +7106,12 @@ Noalias pragma
 Since version 1.4 of the Nim compiler, there is a `.noalias` annotation for variables
 and parameters. It is mapped directly to C/C++'s `restrict`:c: keyword and means that
 the underlying pointer is pointing to a unique location in memory, no other aliases to
-this location exist. It is *unchecked* that this alias restriction is followed, if the
+this location exist. It is *unchecked* that this alias restriction is followed. If the
 restriction is violated, the backend optimizer is free to miscompile the code.
 This is an **unsafe** language feature.
 
 Ideally in later versions of the language, the restriction will be enforced at
-compile time. (Which is also why the name `noalias` was choosen instead of a more
+compile time. (This is also why the name `noalias` was choosen instead of a more
 verbose name like `unsafeAssumeNoAlias`.)
 
 
@@ -7698,7 +7696,7 @@ Example:
     {.pragma: rtl, importc, dynlib: "client.dll", cdecl.}
 
   proc p*(a, b: int): int {.rtl.} =
-    result = a+b
+    result = a + b
 
 In the example, a new pragma named `rtl` is introduced that either imports
 a symbol from a dynamic library or exports the symbol for dynamic library
@@ -8105,8 +8103,8 @@ pragmas:
    appropriate `locks`:idx: statement.
 
 
-Guards and the locks section
-----------------------------
+Guards and locks sections
+-------------------------
 
 Protecting global variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -8179,8 +8177,8 @@ The `guard` annotation can also be used to protect fields within an object.
 The guard then needs to be another field within the same object or a
 global variable.
 
-Since objects can reside on the heap or on the stack this greatly enhances the
-expressivity of the language:
+Since objects can reside on the heap or on the stack, this greatly enhances
+the expressivity of the language:
 
 .. code-block:: nim
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -2682,7 +2682,7 @@ a parameter has different names between them.
   foo(y = 2)
   # Using y: 2
 
-Not supplying the parameter name in such cases will result in an
+Not supplying the parameter name in such cases results in an
 ambiguity error.
 
 

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -1191,15 +1191,17 @@ There are 4 operations that are bound to a type:
 3. Destruction
 4. Deep copying for communication between threads
 
-These operations can be *overridden* instead of *overloaded*. This means the
-implementation is automatically lifted to structured types. For instance if type
-`T` has an overridden assignment operator `=` this operator is also used
-for assignments of the type `seq[T]`. Since these operations are bound to a
-type they have to be bound to a nominal type for reasons of simplicity of
-implementation: This means an overridden `deepCopy` for `ref T` is really
-bound to `T` and not to `ref T`. This also means that one cannot override
-`deepCopy` for both `ptr T` and `ref T` at the same time; instead a
-distinct or object helper type has to be used for one pointer type.
+These operations can be *overridden* instead of *overloaded*. This means that
+the implementation is automatically lifted to structured types. For instance,
+if the type `T` has an overridden assignment operator `=`, this operator is
+also used for assignments of the type `seq[T]`.
+
+Since these operations are bound to a type, they have to be bound to a
+nominal type for reasons of simplicity of implementation; this means an
+overridden `deepCopy` for `ref T` is really bound to `T` and not to `ref T`.
+This also means that one cannot override `deepCopy` for both `ptr T` and
+`ref T` at the same time, instead a distinct or object helper type has to be
+used for one pointer type.
 
 Assignments, moves and destruction are specified in
 the `destructors <destructors.html>`_ document.

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -19,8 +19,8 @@ Some of these are not covered by the `.experimental` pragma or
 one may want to use Nim libraries using these features without using them
 oneself.
 
-**Note**: Unless otherwise indicated, these features are not to be removed,
-but refined and overhauled.
+.. note:: Unless otherwise indicated, these features are not to be removed,
+  but refined and overhauled.
 
 
 Void type
@@ -69,8 +69,8 @@ cannot have the type `void`.
 Unicode Operators
 =================
 
-Under the `--experimental:unicodeOperators` switch these Unicode operators are
-also parsed as operators::
+Under the `--experimental:unicodeOperators`:option: switch,
+these Unicode operators are also parsed as operators::
 
   ∙ ∘ × ★ ⊗ ⊘ ⊙ ⊛ ⊠ ⊡ ∩ ∧ ⊓   # same priority as * (multiplication)
   ± ⊕ ⊖ ⊞ ⊟ ∪ ∨ ⊔             # same priority as + (addition)
@@ -82,8 +82,8 @@ assignment like operator just like `*=` is.
 
 No Unicode normalization step is performed.
 
-**Note**: Due to parser limitations one **cannot** enable this feature via a
-pragma `{.experimental: "unicodeOperators".}` reliably.
+.. note:: Due to parser limitations one **cannot** enable this feature via a
+  pragma `{.experimental: "unicodeOperators".}` reliably.
 
 
 Overloadable enum value names
@@ -91,12 +91,11 @@ Overloadable enum value names
 
 Enabled via `{.experimental: "overloadableEnums".}`.
 
-Enum value names are overloadable much like routines. When an overloaded
-enum member is used, it produces a closed sym choice construct, here
-written as `(E|E)`. During overload resolution the right `E` is picked,
-if possible. For (array/object...) constructors the right `E` is picked,
-comparable to how `[byte(1), 2, 3]` works, one needs to use `[T.E, E2, E3]`.
-Ambiguous enum values produce a static error.
+Enum value names are overloadable, much like routines. If both of the enums
+`T` and `U` have a member named `foo`, then the identifier `foo` corresponds
+to a choice between `T.foo` and `U.foo`. During overload resolution,
+the correct type of `foo` is decided from the context. If the type of `foo` is
+ambiguous, a static error will be produced.
 
 .. code-block:: nim
     :test: "nim c $1"
@@ -114,6 +113,7 @@ Ambiguous enum values produce a static error.
   const
     Lookuptable = [
       E1.value1: "1",
+      # no need to qualify value2, known to be E1.value2
       value2: "2"
     ]
 
@@ -134,12 +134,12 @@ to the package it resides in. If that is done, the type can be referenced from
 other modules as an `incomplete`:idx: object type. This feature allows to
 break up recursive type dependencies across module boundaries. Incomplete
 object types are always passed `byref` and can only be used in pointer like
-contexts (`var/ref/ptr IncompleteObject`) in general since the compiler does
-not yet know the size of the object. To complete an incomplete object
+contexts (`var/ref/ptr IncompleteObject`) in general, since the compiler does
+not yet know the size of the object. To complete an incomplete object,
 the `package` pragma has to be used. `package` implies `byref`.
 
-As long as a type `T` is incomplete, neither `sizeof(T)` nor runtime
-type information for `T` is available.
+As long as a type `T` is incomplete, no runtime type information for `T` is
+available.
 
 
 Example:
@@ -148,11 +148,11 @@ Example:
 
   # module A (in an arbitrary package)
   type
-    Pack.SomeObject = object ## declare as incomplete object of package 'Pack'
+    Pack.SomeObject = object # declare as incomplete object of package 'Pack'
     Triple = object
-      a, b, c: ref SomeObject ## pointers to incomplete objects are allowed
+      a, b, c: ref SomeObject # pointers to incomplete objects are allowed
 
-  ## Incomplete objects can be used as parameters:
+  # Incomplete objects can be used as parameters:
   proc myproc(x: SomeObject) = discard
 
 
@@ -160,7 +160,7 @@ Example:
 
   # module B (in package "Pack")
   type
-    SomeObject* {.package.} = object ## Use 'package' to complete the object
+    SomeObject* {.package.} = object # Use 'package' to complete the object
       s, t: string
       x, y: int
 
@@ -295,9 +295,7 @@ This feature has to be enabled via `{.experimental: "implicitDeref".}`:
 
   proc depth(x: NodeObj): int = ...
 
-  var
-    n: Node
-  new(n)
+  let n = Node()
   echo n.depth
   # no need to write n[].depth
 
@@ -308,8 +306,8 @@ Special Operators
 dot operators
 -------------
 
-**Note**: Dot operators are still experimental and so need to be enabled
-via `{.experimental: "dotOperators".}`.
+.. note:: Dot operators are still experimental and so need to be enabled
+  via `{.experimental: "dotOperators".}`.
 
 Nim offers a special family of dot operators that can be used to
 intercept and rewrite proc call and field access attempts, referring
@@ -432,8 +430,8 @@ here.
 Aliasing restrictions in parameter passing
 ==========================================
 
-**Note**: The aliasing restrictions are currently not enforced by the
-implementation and need to be fleshed out further.
+.. note:: The aliasing restrictions are currently not enforced by the
+  implementation and need to be fleshed out further.
 
 "Aliasing" here means that the underlying storage locations overlap in memory
 at runtime. An "output parameter" is a parameter of type `var T`,
@@ -457,9 +455,9 @@ via `.noSideEffect`. The rules 3 and 4 can also be approximated by a different r
 Strict funcs
 ============
 
-Since version 1.4 a stricter definition of "side effect" is available. In addition
-to the existing rule that a side effect is calling a function with side effects
-the following rule is also enforced:
+Since version 1.4, a stricter definition of "side effect" is available.
+In addition to the existing rule that a side effect is calling a function
+with side effects, the following rule is also enforced:
 
 Any mutation to an object does count as a side effect if that object is reachable
 via a parameter that is not declared as a `var` parameter.
@@ -496,8 +494,8 @@ the `view types section <#view-types-algorithm>`_.
 View types
 ==========
 
-**Note**:  `--experimental:views`:option: is more effective
-with `--experimental:strictFuncs`:option:.
+.. tip::  `--experimental:views`:option: is more effective
+  with `--experimental:strictFuncs`:option:.
 
 A view type is a type that is or contains one of the following types:
 
@@ -530,7 +528,7 @@ of the locations it's derived from. More on this later.
 
 A *view* is a symbol (a let, var, const, etc.) that has a view type.
 
-Since version 1.4 Nim allows view types to be used as local variables.
+Since version 1.4, Nim allows view types to be used as local variables.
 This feature needs to be enabled via `{.experimental: "views".}`.
 
 A local variable of a view type *borrows* from the locations and
@@ -599,13 +597,13 @@ has `source` as the owner. A path expression `e` is defined recursively:
 - A cast expression `cast[T](e)` is a path expression.
 - `f(e, ...)` is a path expression if `f`'s return type is a view type.
   Because the view can only have been borrowed from `e`, we then know
-  that owner of `f(e, ...)` is `e`.
+  that the owner of `f(e, ...)` is `e`.
 
 
 If a view type is used as a return type, the location must borrow from a location
 that is derived from the first parameter that is passed to the proc.
-See https://nim-lang.org/docs/manual.html#procedures-var-return-type for
-details about how this is done for `var T`.
+See `the manual <https://nim-lang.org/docs/manual.html#procedures-var-return-type>`_
+for details about how this is done for `var T`.
 
 A mutable view can borrow from a mutable location, an immutable view can borrow
 from both a mutable or an immutable location.
@@ -700,7 +698,7 @@ The first pass over the AST computes the lifetime of each local variable based o
 a notion of an "abstract time", in the implementation it's a simple integer that is
 incremented for every visited node.
 
-In the second pass information about the underlying object "graphs" is computed.
+In the second pass, information about the underlying object "graphs" is computed.
 Let `v` be a parameter or a local variable. Let `G(v)` be the graph
 that `v` belongs to. A graph is defined by the set of variables that belong
 to the graph. Initially for all `v`: `G(v) = {v}`. Every variable can only
@@ -724,7 +722,7 @@ For strict functions it is then enforced that there is no graph that is both mut
 and has an element that is an immutable parameter (that is a parameter that is not
 of type `var T`).
 
-For borrow checking a different set of checks is performed. Let `v` be the view
+For borrow checking, a different set of checks is performed. Let `v` be the view
 and `b` the location that is borrowed from.
 
 - The lifetime of `v` must not exceed `b`'s lifetime. Note: The lifetime of
@@ -760,10 +758,10 @@ Concepts are written in the following form:
       for value in s:
         value is T
 
-The concept is a match if:
+The concept matches if:
 
-a) all of the expressions within the body can be compiled for the tested type
-b) all statically evaluable boolean expressions in the body must be true
+a) all expressions within the body can be compiled for the tested type
+b) all statically evaluable boolean expressions in the body are true
 
 The identifiers following the `concept` keyword represent instances of the
 currently matched type. You can apply any of the standard type modifiers such
@@ -1201,7 +1199,7 @@ type they have to be bound to a nominal type for reasons of simplicity of
 implementation: This means an overridden `deepCopy` for `ref T` is really
 bound to `T` and not to `ref T`. This also means that one cannot override
 `deepCopy` for both `ptr T` and `ref T` at the same time; instead a
-helper distinct or object type has to be used for one pointer type.
+distinct or object helper type has to be used for one pointer type.
 
 Assignments, moves and destruction are specified in
 the `destructors <destructors.html>`_ document.
@@ -1221,8 +1219,8 @@ The signature has to be:
 
   proc `=deepCopy`(x: T): T
 
-This mechanism will be used by most data structures that support shared memory
-like channels to implement thread safe automatic memory management.
+This mechanism will be used by most data structures that support shared memory,
+like channels, to implement thread safe automatic memory management.
 
 The builtin `deepCopy` can even clone closures and their environments. See
 the documentation of `spawn <#parallel-amp-spawn-spawn-statement>`_ for details.
@@ -1256,30 +1254,30 @@ compilation pipeline with user defined optimizations:
 
 .. code-block:: nim
 
-  template optMul{`*`(a, 2)}(a: int): int = a+a
+  template optMul{`*`(a, 2)}(a: int): int = a + a
 
   let x = 3
   echo x * 2
 
 The compiler now rewrites `x * 2` as `x + x`. The code inside the
-curlies is the pattern to match against. The operators `*`,  `**`,
+curly brackets is the pattern to match against. The operators `*`,  `**`,
 `|`, `~` have a special meaning in patterns if they are written in infix
 notation, so to match verbatim against `*` the ordinary function call syntax
 needs to be used.
 
-Term rewriting macro are applied recursively, up to a limit. This means that
+Term rewriting macros are applied recursively, up to a limit. This means that
 if the result of a term rewriting macro is eligible for another rewriting,
 the compiler will try to perform it, and so on, until no more optimizations
 are applicable. To avoid putting the compiler into an infinite loop, there is
 a hard limit on how many times a single term rewriting macro can be applied.
 Once this limit has been passed, the term rewriting macro will be ignored.
 
-Unfortunately optimizations are hard to get right and even the tiny example
+Unfortunately optimizations are hard to get right and even this tiny example
 is **wrong**:
 
 .. code-block:: nim
 
-  template optMul{`*`(a, 2)}(a: int): int = a+a
+  template optMul{`*`(a, 2)}(a: int): int = a + a
 
   proc f(): int =
     echo "side effect!"
@@ -1292,7 +1290,7 @@ Fortunately Nim supports side effect analysis:
 
 .. code-block:: nim
 
-  template optMul{`*`(a, 2)}(a: int{noSideEffect}): int = a+a
+  template optMul{`*`(a, 2)}(a: int{noSideEffect}): int = a + a
 
   proc f(): int =
     echo "side effect!"
@@ -1310,13 +1308,13 @@ blindly:
 
 .. code-block:: nim
 
-  template mulIsCommutative{`*`(a, b)}(a, b: int): int = b*a
+  template mulIsCommutative{`*`(a, b)}(a, b: int): int = b * a
 
 What optimizers really need to do is a *canonicalization*:
 
 .. code-block:: nim
 
-  template canonMul{`*`(a, b)}(a: int{lit}, b: int): int = b*a
+  template canonMul{`*`(a, b)}(a: int{lit}, b: int): int = b * a
 
 The `int{lit}` parameter pattern matches against an expression of
 type `int`, but only if it's a literal.
@@ -1431,7 +1429,7 @@ constant folding, so the following does not work:
 
 The reason is that the compiler already transformed the 1 into "1" for
 the `echo` statement. However, a term rewriting macro should not change the
-semantics anyway. In fact they can be deactivated with the `--patterns:off`:option:
+semantics anyway. In fact, they can be deactivated with the `--patterns:off`:option:
 command line option or temporarily with the `patterns` pragma.
 
 
@@ -1443,7 +1441,7 @@ notation:
 
 .. code-block:: nim
 
-  template t{(0|1|2){x}}(x: untyped): untyped = x+1
+  template t{(0|1|2){x}}(x: untyped): untyped = x + 1
   let a = 1
   # outputs 2:
   echo a
@@ -1452,7 +1450,7 @@ notation:
 The `~` operator
 ~~~~~~~~~~~~~~~~~~
 
-The `~` operator is the **not** operator in patterns:
+The `~` operator is the 'not' operator in patterns:
 
 .. code-block:: nim
 
@@ -1545,14 +1543,14 @@ an `nnkArgList` node containing::
     Sym "x"
     Sym "-"
 
-(Which is the reverse polish notation of `x + y * z - x`.)
+(This is the reverse polish notation of `x + y * z - x`.)
 
 
 Parameters
 ----------
 
 Parameters in a pattern are type checked in the matching process. If a
-parameter is of the type `varargs` it is treated specially and it can match
+parameter is of the type `varargs`, it is treated specially and can match
 0 or more arguments in the AST to be matched against:
 
 .. code-block:: nim
@@ -1628,7 +1626,7 @@ AST based overloading
 =====================
 
 Parameter constraints can also be used for ordinary routine parameters; these
-constraints affect ordinary overloading resolution then:
+constraints then affect ordinary overloading resolution:
 
 .. code-block:: nim
 
@@ -1665,16 +1663,16 @@ module to work.
 
 Somewhat confusingly, `spawn` is also used in the `parallel` statement
 with slightly different semantics. `spawn` always takes a call expression of
-the form `f(a, ...)`. Let `T` be `f`'s return type. If `T` is `void`
-then `spawn`'s return type is also `void` otherwise it is `FlowVar[T]`.
+the form `f(a, ...)`. Let `T` be `f`'s return type. If `T` is `void`,
+then `spawn`'s return type is also `void`, otherwise it is `FlowVar[T]`.
 
-Within a `parallel` section sometimes the `FlowVar[T]` is eliminated
+Within a `parallel` section, the `FlowVar[T]` is sometimes eliminated
 to `T`. This happens when `T` does not contain any GC'ed memory.
 The compiler can ensure the location in `location = spawn f(...)` is not
 read prematurely within a `parallel` section and so there is no need for
 the overhead of an indirection via `FlowVar[T]` to ensure correctness.
 
-**Note**: Currently exceptions are not propagated between `spawn`'ed tasks!
+.. note:: Currently exceptions are not propagated between `spawn`'ed tasks!
 
 This feature is likely to be removed in the future as external packages
 can have better solutions. 
@@ -1683,7 +1681,7 @@ can have better solutions.
 Spawn statement
 ---------------
 
-`spawn`:idx: can be used to pass a task to the thread pool:
+The `spawn`:idx: statement can be used to pass a task to the thread pool:
 
 .. code-block:: nim
 
@@ -1705,10 +1703,10 @@ that `spawn` takes is restricted:
 * `f`'s parameters may not be of type `var`.
   This means one has to use raw `ptr`'s for data passing reminding the
   programmer to be careful.
-* `ref` parameters are deeply copied which is a subtle semantic change and
-  can cause performance problems but ensures memory safety. This deep copy
-  is performed via `system.deepCopy` and so can be overridden.
-* For *safe* data exchange between `f` and the caller a global `TChannel`
+* `ref` parameters are deeply copied, which is a subtle semantic change and
+  can cause performance problems, but ensures memory safety. This deep copy
+  is performed via `system.deepCopy`, so it can be overridden.
+* For *safe* data exchange between `f` and the caller, a global `Channel`
   needs to be used. However, since spawn can return a result, often no further
   communication is required.
 
@@ -1732,10 +1730,10 @@ wait on multiple flow variables at the same time:
     responses.del(index)
     discard blockUntilAny(responses)
 
-Data flow variables ensure that no data races
-are possible. Due to technical limitations not every type `T` is possible in
-a data flow variable: `T` has to be of the type `ref`, `string`, `seq`
-or of a type that doesn't contain a type that is garbage collected. This
+Data flow variables ensure that no data races are possible. Due to
+technical limitations, not every type `T` can be used in
+a data flow variable: `T` has to be a `ref`, `string`, `seq`
+or of a type that doesn't contain any GC'd type. This
 restriction is not hard to work-around in practice.
 
 
@@ -1748,14 +1746,14 @@ Example:
 .. code-block:: nim
     :test: "nim c --threads:on $1"
 
-  # Compute PI in an inefficient way
+  # Compute pi in an inefficient way
   import std/[strutils, math, threadpool]
   {.experimental: "parallel".}
 
   proc term(k: float): float = 4 * math.pow(-1, k) / (2*k + 1)
 
   proc pi(n: int): float =
-    var ch = newSeq[float](n+1)
+    var ch = newSeq[float](n + 1)
     parallel:
       for k in 0..ch.high:
         ch[k] = spawn term(float(k))
@@ -1766,16 +1764,16 @@ Example:
 
 
 The parallel statement is the preferred mechanism to introduce parallelism in a
-Nim program. A subset of the Nim language is valid within a `parallel`
+Nim program. Only a subset of the Nim language is valid within a `parallel`
 section. This subset is checked during semantic analysis to be free of data
 races. A sophisticated `disjoint checker`:idx: ensures that no data races are
-possible even though shared memory is extensively supported!
+possible, even though shared memory is extensively supported!
 
 The subset is in fact the full language with the following
 restrictions / changes:
 
 * `spawn` within a `parallel` section has special semantics.
-* Every location of the form `a[i]` and `a[i..j]` and `dest` where
+* Every location of the form `a[i]`, `a[i..j]` and `dest` where
   `dest` is part of the pattern `dest = spawn f(...)` has to be
   provably disjoint. This is called the *disjoint check*.
 * Every other complex location `loc` that is used in a spawned
@@ -1798,7 +1796,7 @@ potential deadlocks during semantic analysis. A lock level is an constant
 integer in the range 0..1_000. Lock level 0 means that no lock is acquired at
 all.
 
-If a section of code holds a lock of level `M` than it can also acquire any
+If a section of code holds a lock of level `M`, it can also acquire any
 lock of level `N < M`. Another lock of level `M` cannot be acquired. Locks
 of the same level can only be acquired *at the same time* within a
 single `locks` section:
@@ -1861,7 +1859,7 @@ This is essential so that procs can be called within a `locks` section:
     p()
 
 
-As usual `locks` is an inferred effect and there is a subtype
+As usual, `locks` is an inferred effect and there is a subtype
 relation: `proc () {.locks: N.}` is a subtype of `proc () {.locks: M.}`
 iff (M <= N).
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -465,12 +465,7 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ## If `rule == brForceOpen` always an `nnkOpenSymChoice` tree is
   ## returned even if the symbol is not ambiguous.
   ##
-  ## Experimental feature:
-  ## use {.experimental: "dynamicBindSym".} to activate it.
-  ## If called from template / regular code, `ident` and `rule` must be
-  ## constant expression / literal value.
-  ## If called from macros / compile time procs / static blocks,
-  ## `ident` and `rule` can be VM computed value.
+  ## See the `manual <manual.html#macros-bindsym>`_ for more details.
 
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   magic: "NGenSym", noSideEffect.}

--- a/tests/macros/tcasestmtmacro.nim
+++ b/tests/macros/tcasestmtmacro.nim
@@ -4,8 +4,6 @@ yes
 '''
 """
 
-{.experimental: "caseStmtMacros".}
-
 import macros
 
 macro `case`(n: tuple): untyped =


### PR DESCRIPTION
Refs https://github.com/nim-lang/RFCs/issues/437, #19162 

* Reordered the experimental manual to make the more relevant/stable features appear higher up.
* Kept the `deepCopy` section because I don't know its exact details either and it seems to be tied to parallel/spawn more than ARC/ORC (which needs --deepcopy to turn it on or something).
* Moves between the manuals:
  - Case statement macros, do notation, post-statement blocks for macros (previously undocumented, `of`/`elif`/`finally` etc), named argument overloading, noalias, guards and locks sans lock levels are now in the regular manual,
  - overloadable enums, unicode operators, `dynamicBindSym` are now in the experimental manual.
* Did not:
  - document `compiletimeFFI` and `vmopsDanger` as I am unsure on the details
  - separate `strictEffects` from the stable documentation as I don't know how and it appears the plan is to graduate it from experimental soon
  - document templates-and-macros-called-as-identifiers (point me to a name if it has one), #13515 is a pretty big obstacle to them not being experimental

To ease through reading the messy diff, all the changes that aren't moves are:

* sections for noalias, guards and locks, unicode operators and overloadable enums are the same as before
* possible removal of parallel & spawn, lock levels, package level objects and code reordering are mentioned
* made changes to wording/examples of named argument overloading, do notation, case statement macros and `implicitDeref`

There are also minor paragraph moves/capitalization changes in the regular manual but the diff for the regular manual is easier to go through so I won't mention each one. Also applying review suggestions