### PR TITLE
Accept object type node from macros

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2856,7 +2856,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
   of nkBind:
     message(c.config, n.info, warnDeprecated, "bind is deprecated")
     result = semExpr(c, n[0], flags)
-  of nkTypeOfExpr, nkTupleTy, nkTupleClassTy, nkRefTy..nkEnumTy, nkStaticTy:
+  of nkTypeOfExpr..nkTupleClassTy, nkStaticTy, nkRefTy..nkEnumTy:
     if c.matchedConcept != nil and n.len == 1:
       let modifier = n.modifierTypeKindOfNode
       if modifier != tyNone:

--- a/tests/macros/ttypenodes.nim
+++ b/tests/macros/ttypenodes.nim
@@ -1,0 +1,16 @@
+import macros
+
+macro makeEnum(): untyped =
+  newTree(nnkEnumTy, newEmptyNode(), ident"a", ident"b", ident"c")
+
+macro makeObject(): untyped =
+  newTree(nnkObjectTy, newEmptyNode(), newEmptyNode(), newTree(nnkRecList,
+    newTree(nnkIdentDefs, ident"x", ident"y", ident"int", newEmptyNode())))
+
+type
+  Foo = makeEnum()
+  Bar = makeObject()
+
+doAssert {a, b, c} is set[Foo]
+let bar = Bar(x: 3, y: 4)
+doAssert (bar.x, bar.y) == (3, 4)


### PR DESCRIPTION
From the test:

```nim
import macros

macro makeEnum(): untyped =
  newTree(nnkEnumTy, newEmptyNode(), ident"a", ident"b", ident"c")

macro makeObject(): untyped =
  newTree(nnkObjectTy, newEmptyNode(), newEmptyNode(), newTree(nnkRecList,
    newTree(nnkIdentDefs, ident"x", ident"y", ident"int", newEmptyNode())))

type
  # this always worked:
  Foo = makeEnum()
  # new:
  Bar = makeObject()
```

If this is undesired in favor of using `StmtListType`, I can also disallow this for both `enum` and `object`, while allowing their respective typeclass forms.