### PR TITLE
Treat `do` with pragmas but no parameters as proc

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -3834,10 +3834,10 @@ The proc expression represented by the `do` block is appended to the routine
 call as the last argument. In calls using the command syntax, the `do` block
 will bind to the immediately preceding expression rather than the command call.
 
-`do` with a parameter list corresponds to an anonymous `proc`, however
-`do` without parameters is treated as a normal statement list. This allows
-macros to receive both indented statement lists as an argument in inline
-calls, as well as a direct mirror of Nim's routine syntax.
+`do` with a parameter list or pragma list corresponds to an anonymous `proc`,
+however `do` without parameters or pragmas is treated as a normal statement
+list. This allows macros to receive both indented statement lists as an
+argument in inline calls, as well as a direct mirror of Nim's routine syntax.
 
 .. code-block:: nim
   # Passing a statement list to an inline macro:

--- a/tests/parser/tdo.nim
+++ b/tests/parser/tdo.nim
@@ -1,8 +1,12 @@
 discard """
-  output: '''true
+  output: '''
 true
 true
-true inner B'''
+true
+true inner B
+running with pragma
+ran with pragma
+'''
 """
 
 template withValue(a, b, c, d, e: untyped) =
@@ -77,3 +81,14 @@ proc main2 =
       echo "true inner B"
 
 main2()
+
+proc withPragma(foo: int, bar: proc() {.raises: [].}) =
+  echo "running with pragma"
+  bar()
+
+withPragma(3) do {.raises: [].}:
+  echo "ran with pragma"
+
+doAssert not (compiles do:
+  withPragma(3) do {.raises: [].}:
+    raise newException(Exception))


### PR DESCRIPTION
fixes #19188

Echoes `proc foo {.pragma.} = discard`.

If the PR spam is an issue I can set these to be drafts first.