### PR TITLE
Fix group reference with capital letters in nim links

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1301,7 +1301,8 @@ proc finishGenerateDoc*(d: var PDoc) =
           let tooltip = "$1 ($2 overloads)" % [
                       k.toHumanStr & " " & plainName, $overloadChoices.len]
           addAnchorNim(d.sharedState, refn, tooltip,
-                       LangSymbol(symKind: k.toHumanStr, name: plainName,
+                       LangSymbol(symKind: k.toHumanStr,
+                                  name: nimIdentBackticksNormalize(plainName),
                                   isGroup: true),
                        priority = symbolPriority(k),
                        # select index `0` just to have any meaningful warning:

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -993,7 +993,7 @@ proc findMainAnchorNim(s: PRstSharedState, signature: PRstNode,
             result.add s
       else:  # when there are many overloads a link like foo_ points to all
              # of them, so selecting the group
-        var foundGroup = true
+        var foundGroup = false
         for s in sList:
           if s.langSym.isGroup:
             result.add s

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.html
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.html
@@ -208,6 +208,13 @@ window.addEventListener('DOMContentLoaded', main);
     title="fn10(a: int): int">fn10(a: int): int</a></li>
 
   </ul>
+  <ul class="simple nested-toc-section">fN11
+      <li><a class="reference" href="#fN11"
+    title="fN11()">fN11()</a></li>
+  <li><a class="reference" href="#fN11%2Cint"
+    title="fN11(x: int)">fN11(x: int)</a></li>
+
+  </ul>
   <ul class="simple nested-toc-section">funWithGenerics
       <li><a class="reference" href="#funWithGenerics%2CT%2CU"
     title="funWithGenerics[T, U: SomeFloat](a: T; b: U)">funWithGenerics[T, U: SomeFloat](a: T; b: U)</a></li>
@@ -290,6 +297,7 @@ window.addEventListener('DOMContentLoaded', main);
 <p>Note that <tt class="docutils literal"><span class="pre"><span class="Keyword">proc</span></span></tt> can be used in postfix form: <a class="reference internal nimdoc" title="proc binarySearch[T, K](a: openArray[T]; key: K;
                    cmp: proc (x: T; y: K): int {.closure.}): int" href="#binarySearch,openArray[T],K,proc(T,K)">binarySearch proc</a>.</p>
 <p>Ref. type like <a class="reference internal nimdoc" title="type G" href="#G">G</a> and <a class="reference internal nimdoc" title="type G" href="#G">type G</a> and <a class="reference internal nimdoc" title="type G" href="#G">G[T]</a> and <a class="reference internal nimdoc" title="type G" href="#G">type G*[T]</a>.</p>
+<p>Group ref. with capital letters works: <a class="reference internal nimdoc" title="proc fN11 (2 overloads)" href="#fN11-procs-all">fN11</a> or <a class="reference internal nimdoc" title="proc fN11 (2 overloads)" href="#fN11-procs-all">fn11</a> </p>
 Ref. <a class="reference internal nimdoc" title="proc `[]`[T](x: G[T]): T" href="#[],G[T]">[]</a> is the same as <a class="reference internal nimdoc" title="proc `[]`[T](x: G[T]): T" href="#[],G[T]">proc `[]`(G[T])</a> because there are no overloads. The full form: <a class="reference internal nimdoc" title="proc `[]`[T](x: G[T]): T" href="#[],G[T]">proc `[]`*[T](x: G[T]): T</a>Ref. <a class="reference internal nimdoc" title="proc `[]=`[T](a: var G[T]; index: int; value: T)" href="#[]=,G[T],int,T">[]=</a> aka <a class="reference internal nimdoc" title="proc `[]=`[T](a: var G[T]; index: int; value: T)" href="#[]=,G[T],int,T">`[]=`(G[T], int, T)</a>.Ref. <a class="reference internal nimdoc" title="proc $ (2 overloads)" href="#$-procs-all">$</a> aka <a class="reference internal nimdoc" title="proc $ (2 overloads)" href="#$-procs-all">proc $</a> or <a class="reference internal nimdoc" title="proc $ (2 overloads)" href="#$-procs-all">proc `$`</a>.Ref. <a class="reference internal nimdoc" title="proc `$`[T](a: ref SomeType): string" href="#$,ref.SomeType">$(a: ref SomeType)</a>.Ref. <a class="reference internal nimdoc" title="iterator fooBar(a: seq[SomeType]): int" href="#fooBar.i,seq[SomeType]">foo_bar</a> aka <a class="reference internal nimdoc" title="iterator fooBar(a: seq[SomeType]): int" href="#fooBar.i,seq[SomeType]">iterator foo_bar_</a>.Ref. <a class="reference internal nimdoc" title="proc fn[T; U, V: SomeFloat]()" href="#fn">fn[T; U,V: SomeFloat]()</a>.Ref. <a class="reference internal nimdoc" title="proc `'big`(a: string): SomeType" href="#'big,string">'big</a> or <a class="reference internal nimdoc" title="proc `'big`(a: string): SomeType" href="#'big,string">func `'big`</a> or <a class="reference internal nimdoc" title="proc `'big`(a: string): SomeType" href="#'big,string">`'big`(string)</a>.</p>
   <div class="section" id="7">
 <h1><a class="toc-backref" href="#7">Types</a></h1>
@@ -538,6 +546,26 @@ comment
 <dd>
 
 comment
+
+</dd>
+</div>
+
+</div>
+
+<div id="fN11-procs-all">
+<div id="fN11">
+<dt><pre><span class="Keyword">func</span> <a href="#fN11"><span class="Identifier">fN11</span></a><span class="Other">(</span><span class="Other">)</span> {.<span><span class="Other pragmadots">...</span></span><span class="pragmawrap"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span>.}</pre></dt>
+<dd>
+
+
+
+</dd>
+</div>
+<div id="fN11,int">
+<dt><pre><span class="Keyword">func</span> <a href="#fN11%2Cint"><span class="Identifier">fN11</span></a><span class="Other">(</span><span class="Identifier">x</span><span class="Other">:</span> <span class="Identifier">int</span><span class="Other">)</span> {.<span><span class="Other pragmadots">...</span></span><span class="pragmawrap"><span class="Identifier">raises</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span><span class="Other">,</span> <span class="Identifier">tags</span><span class="Other">:</span> <span class="Other">[</span><span class="Other">]</span></span>.}</pre></dt>
+<dd>
+
+
 
 </dd>
 </div>

--- a/nimdoc/testproject/expected/subdir/subdir_b/utils.idx
+++ b/nimdoc/testproject/expected/subdir/subdir_b/utils.idx
@@ -17,6 +17,8 @@ fn7	subdir/subdir_b/utils.html#fn7	utils: fn7()
 fn8	subdir/subdir_b/utils.html#fn8	utils: fn8(): auto	
 fn9	subdir/subdir_b/utils.html#fn9,int	utils: fn9(a: int): int	
 fn10	subdir/subdir_b/utils.html#fn10,int	utils: fn10(a: int): int	
+fN11	subdir/subdir_b/utils.html#fN11	utils: fN11()	
+fN11	subdir/subdir_b/utils.html#fN11,int	utils: fN11(x: int)	
 aEnum	subdir/subdir_b/utils.html#aEnum.t	utils: aEnum(): untyped	
 bEnum	subdir/subdir_b/utils.html#bEnum.t	utils: bEnum(): untyped	
 fromUtilsGen	subdir/subdir_b/utils.html#fromUtilsGen.t	utils: fromUtilsGen(): untyped	

--- a/nimdoc/testproject/expected/theindex.html
+++ b/nimdoc/testproject/expected/theindex.html
@@ -209,6 +209,12 @@ window.addEventListener('DOMContentLoaded', main);
 <li><a class="reference external"
           data-doc-search-tag="utils: fn10(a: int): int" href="subdir/subdir_b/utils.html#fn10%2Cint">utils: fn10(a: int): int</a></li>
           </ul></dd>
+<dt><a name="fN11" href="#fN11"><span>fN11:</span></a></dt><dd><ul class="simple">
+<li><a class="reference external"
+          data-doc-search-tag="utils: fN11()" href="subdir/subdir_b/utils.html#fN11">utils: fN11()</a></li>
+          <li><a class="reference external"
+          data-doc-search-tag="utils: fN11(x: int)" href="subdir/subdir_b/utils.html#fN11%2Cint">utils: fN11(x: int)</a></li>
+          </ul></dd>
 <dt><a name="fn2" href="#fn2"><span>fn2:</span></a></dt><dd><ul class="simple">
 <li><a class="reference external"
           data-doc-search-tag="utils: fn2()" href="subdir/subdir_b/utils.html#fn2">utils: fn2()</a></li>

--- a/nimdoc/testproject/subdir/subdir_b/utils.nim
+++ b/nimdoc/testproject/subdir/subdir_b/utils.nim
@@ -36,6 +36,7 @@ Note that `proc` can be used in postfix form: `binarySearch proc`_.
 
 Ref. type like G_ and `type G`_ and `G[T]`_ and `type G*[T]`_.
 
+Group ref. with capital letters works: fN11_ or fn11_
 ]##
 
 include ./utils_helpers
@@ -76,6 +77,11 @@ proc fn8*(): auto =
   1+1
 func fn9*(a: int): int = 42  ## comment
 func fn10*(a: int): int = a  ## comment
+
+# Note capital letter N will be handled correctly in
+# group references like fN11_ or fn11_:
+func fN11*() = discard
+func fN11*(x: int) = discard
 
 # bug #9235
 


### PR DESCRIPTION
Group names were added as not normalized to the hash table, which broke any reference an to overload group with camel case.