### PR TITLE
nimRawSetjmp: support Windows

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1356,8 +1356,19 @@ proc genTrySetjmp(p: BProc, t: PNode, d: var TLoc) =
       linefmt(p, cpsStmts, "$1.status = setjmp($1.context);$n", [safePoint])
     elif isDefined(p.config, "nimSigSetjmp"):
       linefmt(p, cpsStmts, "$1.status = sigsetjmp($1.context, 0);$n", [safePoint])
+    elif isDefined(p.config, "nimBuiltinSetjmp"):
+      linefmt(p, cpsStmts, "$1.status = __builtin_setjmp($1.context);$n", [safePoint])
     elif isDefined(p.config, "nimRawSetjmp"):
-      linefmt(p, cpsStmts, "$1.status = _setjmp($1.context);$n", [safePoint])
+      if isDefined(p.config, "mswindows"):
+        # The Windows `_setjmp()` takes two arguments, with the second being an
+        # undocumented buffer used by the SEH mechanism for stack unwinding.
+        # Mingw-w64 has been trying to get it right for years, but it's still
+        # prone to stack corruption during unwinding, so we disable that by setting
+        # it to NULL.
+        # More details: https://github.com/status-im/nimbus-eth2/issues/3121
+        linefmt(p, cpsStmts, "$1.status = _setjmp($1.context, 0);$n", [safePoint])
+      else:
+        linefmt(p, cpsStmts, "$1.status = _setjmp($1.context);$n", [safePoint])
     else:
       linefmt(p, cpsStmts, "$1.status = setjmp($1.context);$n", [safePoint])
     lineCg(p, cpsStmts, "if ($1.status == 0) {$n", [safePoint])

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -165,6 +165,20 @@ ignored too. `--define:FOO`:option: and `--define:foo`:option: are identical.
 Compile-time symbols starting with the `nim` prefix are reserved for the
 implementation and should not be used elsewhere.
 
+==========================       ============================================
+Name                             Description
+==========================       ============================================
+nimStdSetjmp                     Use the standard `setjmp()/longjmp()` library
+                                 functions for setjmp-based exceptions. This is
+                                 the default on most platforms.
+nimSigSetjmp                     Use `sigsetjmp()/siglongjmp()` for setjmp-based exceptions.
+nimRawSetjmp                     Use `_setjmp()/_longjmp()` on POSIX and `_setjmp()/longjmp()`
+                                 on Windows, for setjmp-based exceptions. It's the default on
+                                 BSDs and BSD-like platforms, where it's significantly faster
+                                 than the standard functions.
+nimBuiltinSetjmp                 Use `__builtin_setjmp()/__builtin_longjmp()` for setjmp-based
+                                 exceptions. This will not work if an exception is being thrown
+                                 and caught inside the same procedure. Useful for benchmarking.
 
 Configuration files
 -------------------

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -31,7 +31,10 @@ proc c_abort*() {.
   importc: "abort", header: "<stdlib.h>", noSideEffect, noreturn.}
 
 
-when defined(linux) and defined(amd64):
+when defined(nimBuiltinSetjmp):
+  type
+    C_JmpBuf* = array[5, int]
+elif defined(linux) and defined(amd64):
   type
     C_JmpBuf* {.importc: "jmp_buf", header: "<setjmp.h>", bycopy.} = object
         abi: array[200 div sizeof(clong), clong]
@@ -92,18 +95,40 @@ when defined(macosx):
 elif defined(haiku):
   const SIGBUS* = cint(30)
 
-when defined(nimSigSetjmp) and not defined(nimStdSetjmp):
+# "nimRawSetjmp" is defined by default for certain platforms, so we need the
+# "nimStdSetjmp" escape hatch with it.
+when defined(nimSigSetjmp):
   proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
     header: "<setjmp.h>", importc: "siglongjmp".}
-  template c_setjmp*(jmpb: C_JmpBuf): cint =
+  proc c_setjmp*(jmpb: C_JmpBuf): cint =
     proc c_sigsetjmp(jmpb: C_JmpBuf, savemask: cint): cint {.
       header: "<setjmp.h>", importc: "sigsetjmp".}
     c_sigsetjmp(jmpb, 0)
-elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
+elif defined(nimBuiltinSetjmp):
   proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
-    header: "<setjmp.h>", importc: "_longjmp".}
+    importc: "__builtin_longjmp", nodecl.}
   proc c_setjmp*(jmpb: C_JmpBuf): cint {.
-    header: "<setjmp.h>", importc: "_setjmp".}
+    importc: "__builtin_setjmp", nodecl.}
+elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
+  when defined(windows):
+    # No `_longjmp()` on Windows.
+    proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
+      header: "<setjmp.h>", importc: "longjmp".}
+    # The Windows `_setjmp()` takes two arguments, with the second being an
+    # undocumented buffer used by the SEH mechanism for stack unwinding.
+    # Mingw-w64 has been trying to get it right for years, but it's still
+    # prone to stack corruption during unwinding, so we disable that by setting
+    # it to NULL.
+    # More details: https://github.com/status-im/nimbus-eth2/issues/3121
+    proc c_setjmp*(jmpb: C_JmpBuf): cint =
+      proc c_setjmp_win(jmpb: C_JmpBuf, ctx: pointer): cint {.
+        header: "<setjmp.h>", importc: "_setjmp".}
+      c_setjmp_win(jmpb, nil)
+  else:
+    proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
+      header: "<setjmp.h>", importc: "_longjmp".}
+    proc c_setjmp*(jmpb: C_JmpBuf): cint {.
+      header: "<setjmp.h>", importc: "_setjmp".}
 else:
   proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
     header: "<setjmp.h>", importc: "longjmp".}

--- a/tests/exception/texceptions2.nim
+++ b/tests/exception/texceptions2.nim
@@ -1,6 +1,6 @@
 discard """
-  disabled: "windows" # no sigsetjmp() there
-  matrix: "-d:nimStdSetjmp; -d:nimSigSetjmp; -d:nimRawSetjmp; -d:nimBuiltinSetjmp"
+  disabled: "posix" # already covered by texceptions.nim
+  matrix: "-d:nimStdSetjmp; -d:nimRawSetjmp; -d:nimBuiltinSetjmp"
   output: '''
 
 BEFORE


### PR DESCRIPTION
Using `_setjmp()` directly is required to avoid some rare (but very annoying) exception-related stack corruption leading to segfaults on Windows, with Mingw-w64 and SEH.

More details: https://github.com/status-im/nimbus-eth2/issues/3121

Also added "nimBuiltinSetjmp" - mostly for benchmarking.

---

After some serious testing, we'll probably want to make `nimRawSetjmp` the default on Windows. Debugging that kind of CRT-level memory corruption is never fun.

As you can tell, the whole point of this PR is correctness, but that doesn't mean we can't have some fun with benchmarks. My Windows 10 instance is running inside VirtualBox, but the differences are big enough to matter.

```nim
# modified from https://nim-lang.org/araq/gotobased_exceptions.html

import strutils

proc fib(m: string): int {.noinline.} =
  let n = parseInt(m)
  if n <= 1:
    raise newException(ValueError, "out of range")
  else:
    fib($(n-1)) + fib($(n-2))

import std / [times, monotimes, stats]

when defined(cpp):
  echo "C++"
elif compileOption("exceptions", "setjmp"):
  echo "setjmp"
  when defined(nimStdSetjmp):
    echo "nimStdSetjmp"
  elif defined(nimRawSetjmp):
    echo "nimRawSetjmp"
  elif defined(nimSigSetjmp):
    echo "nimSigSetjmp"
  elif defined(nimBuiltinSetjmp):
    echo "nimBuiltinSetjmp"
elif compileOption("exceptions", "goto"):
  echo "goto"

var
  r: RunningStat
  res: int
  sum: int
for iterations in 1..5:
  let start = getMonoTime()

  for i in 0 ..< 1000000:
    res = 0
    try:
      res = fib("24") # 1 1 2 3 5 8 13
    except ValueError:
      res = 1
    sum += res

  r.push float((getMonoTime() - start).inMilliseconds)

echo r
echo sum
```

```bash
user@DESKTOP-JJ7DJA5 MINGW64 /c/Users/user/Desktop/status/nimbus-eth2
$ ./env.sh nim c -f --gc:arc --exceptions:setjmp -d:danger -d:nimStdSetjmp --skipParentCfg:on --skipUserCfg:on --verbosity:0 --hints:off --passC:"-fno-inline -fno-optimize-sibling-calls" tmp/test19.nim

user@DESKTOP-JJ7DJA5 MINGW64 /c/Users/user/Desktop/status/nimbus-eth2
$ ./tmp/test19
setjmp
nimStdSetjmp
RunningStat(
  number of probes: 5
  max: 22446.0
  min: 20899.0
  sum: 106085.0
  mean: 21217.0
  std deviation: 614.5320170666455
)
5000000

user@DESKTOP-JJ7DJA5 MINGW64 /c/Users/user/Desktop/status/nimbus-eth2
$ ./env.sh nim c -f --gc:arc --exceptions:setjmp -d:danger -d:nimRawSetjmp --skipParentCfg:on --skipUserCfg:on --verbosity:0 --hints:off --passC:"-fno-inline -fno-optimize-sibling-calls" tmp/test19.nim

user@DESKTOP-JJ7DJA5 MINGW64 /c/Users/user/Desktop/status/nimbus-eth2
$ ./tmp/test19
setjmp
nimRawSetjmp
RunningStat(
  number of probes: 5
  max: 3594.0
  min: 3536.0
  sum: 17823.0
  mean: 3564.6
  std deviation: 18.7787113508888
)
5000000

user@DESKTOP-JJ7DJA5 MINGW64 /c/Users/user/Desktop/status/nimbus-eth2
$ ./env.sh nim c -f --gc:arc --exceptions:setjmp -d:danger -d:nimBuiltinSetjmp --skipParentCfg:on --skipUserCfg:on --verbosity:0 --hints:off --passC:"-fno-inline -fno-optimize-sibling-calls" tmp/test19.nim

user@DESKTOP-JJ7DJA5 MINGW64 /c/Users/user/Desktop/status/nimbus-eth2
$ ./tmp/test19
setjmp
nimBuiltinSetjmp
RunningStat(
  number of probes: 5
  max: 2836.0
  min: 2750.0
  sum: 13931.0
  mean: 2786.2
  std deviation: 33.27100840070826
)
5000000
```

So yeah, that SEH stack unwinding is pretty expensive, besides being buggy.