### PR TITLE
Atomic inc/dec should use ATOMIC_SEQ_CST

### DIFF
--- a/lib/system/atomics.nim
+++ b/lib/system/atomics.nim
@@ -217,7 +217,7 @@ else:
 
 proc atomicInc*(memLoc: var int, x: int = 1): int =
   when someGcc and hasThreadSupport:
-    result = atomicAddFetch(memLoc.addr, x, ATOMIC_RELAXED)
+    result = atomicAddFetch(memLoc.addr, x, ATOMIC_SEQ_CST)
   elif someVcc and hasThreadSupport:
     result = addAndFetch(memLoc.addr, x)
     inc(result, x)
@@ -228,9 +228,9 @@ proc atomicInc*(memLoc: var int, x: int = 1): int =
 proc atomicDec*(memLoc: var int, x: int = 1): int =
   when someGcc and hasThreadSupport:
     when declared(atomicSubFetch):
-      result = atomicSubFetch(memLoc.addr, x, ATOMIC_RELAXED)
+      result = atomicSubFetch(memLoc.addr, x, ATOMIC_SEQ_CST)
     else:
-      result = atomicAddFetch(memLoc.addr, -x, ATOMIC_RELAXED)
+      result = atomicAddFetch(memLoc.addr, -x, ATOMIC_SEQ_CST)
   elif someVcc and hasThreadSupport:
     result = addAndFetch(memLoc.addr, -x)
     dec(result, x)


### PR DESCRIPTION
It was introduced by https://github.com/nim-lang/Nim/commit/6fbc96fec49d8376911dcf7a827b802bc942ca70#diff-f533629679edcd5f0af7eef220728c122d4fc577f81590ced7fe8028ea129808
which replaced `sync_add_and_fetch` with `atomicAddFetch(memLoc.addr, x, ATOMIC_RELAXED)`. However `sync_add_and_fetch` is close to ATOMIC_SEQ_CST instead of ATOMIC_RELAXED. It is a regression since 2013.

> If you need a memory order of std::memory_order_seq_cst (which is probably the closest to the GCC __sync_fetch_and_add), 

Ref https://stackoverflow.com/questions/14858770/c11-stdatomic-fetch-add-vs-sync-fetch-and-add

Also it is not correct. We cannot assume ATOMIC_RELAXED order works for all conditions. It should use stricter memory order. For example `std/atomics` and C++ use `ATOMIC_SEQ_CST ` order which is correct.

> operator++(int) and operator++() on atomic<integral> types are specified to have the effect of fetch_add(1), which ends up calling the member function with the default memory ordering memory_order_seq_cst.

Ref https://stackoverflow.com/questions/13482751/c-atomic-increment-memory-ordering
Ref https://github.com/nim-lang/Nim/blob/0d0c249074d6a1041de16108dc247396efef5513/lib/pure/concurrency/atomics.nim#L355

This PR intends to make it correct. Thanks to https://github.com/nim-works/nimskull/pull/88