### PR TITLE
Add DateTime week of year formats and getter

### DIFF
--- a/tests/stdlib/ttimes.nim
+++ b/tests/stdlib/ttimes.nim
@@ -433,6 +433,9 @@ block: # ttimes
     check dt.format("yyyy") == "+12346"
     check dt.format("uuuu") == "-12345"
 
+    check dt.format("w") == "0"
+    check dt.format("ww") == "00"
+
     expect ValueError:
       discard initTimeFormat("'")
 
@@ -489,6 +492,15 @@ block: # ttimes
     discard parse("foobar", "'foobar'")
     discard parse("foo'bar", "'foo''''bar'")
     discard parse("'", "''")
+
+    check parse("01/01/0001 1", "MM/dd/yyyy w").year == 1
+    check parse("01/01/0001 01", "MM/dd/yyyy ww").year == 1
+
+    expect TimeParseError:
+      discard parse("01/01/0001 99", "MM/dd/yyyy ww")
+
+    expect TimeParseError:
+      discard parse("01/01/0001 1", "MM/dd/yyyy ww")
 
     parseTestExcp("2000 A", "yyyy g")
 
@@ -646,3 +658,12 @@ block: # ttimes
     doAssert initDuration(milliseconds = 500).inMilliseconds == 500
     doAssert initDuration(milliseconds = -500).inMilliseconds == -500
     doAssert initDuration(nanoseconds = -999999999).inMilliseconds == -999
+
+  block: # week
+    check dateTime(2021, mJan, 1).week == 0
+    check dateTime(2021, mJan, 2).week == 0
+    check dateTime(2021, mJan, 3).week == 0
+    check dateTime(2021, mJan, 4).week == 1
+    check dateTime(2021, mDec, 29).week == 52
+    check dateTime(2021, mDec, 30).week == 52
+    check dateTime(2021, mDec, 31).week == 52


### PR DESCRIPTION
Hey, I have some Python scripts I am rewriting in Nim. They make use of the week of year while formatting datetimes into strings. 

Here I'm porting that functionality. I understand if its not desired in Nim though.

Here are some references where I got some of the code from and other people requiring it:

https://forum.nim-lang.org/t/6320
https://en.wikipedia.org/wiki/ISO_week_date#Calculating_the_week_number_from_a_month_and_day_of_the_month_or_ordinal_date

I debated making `YearWeekRange` be `1..53` but went with `0..52` to match Python.

Its worth pointing out this is my first time writing Nim and don't know the internals of `DateTime` so a strong code review is recommended.

