### PR TITLE
[ISSUE_TEMPLATE] `feature_request` should be labelled automatically

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Do you want to suggest a new feature? Use this template.
 title: ''
-labels: ''
+labels: ["Feature"]
 assignees: ''
 
 ---


### PR DESCRIPTION
Ref https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms