### PR TITLE
add comments to spawn and pinnedSpawn

### DIFF
--- a/lib/pure/concurrency/threadpool.nim
+++ b/lib/pure/concurrency/threadpool.nim
@@ -448,19 +448,21 @@ proc preferSpawn*(): bool =
   ## <#spawnX.t>`_ instead.
   result = gSomeReady.counter > 0
 
-proc spawn*(call: sink typed) {.magic: "Spawn".}
+proc spawn*(call: sink typed) {.magic: "Spawn".} =
   ## Always spawns a new task, so that the `call` is never executed on
   ## the calling thread.
   ##
   ## `call` has to be a proc call `p(...)` where `p` is gcsafe and has a
   ## return type that is either `void` or compatible with `FlowVar[T]`.
+  discard "It uses `nimSpawn3` internally"
 
-proc pinnedSpawn*(id: ThreadId; call: sink typed) {.magic: "Spawn".}
+proc pinnedSpawn*(id: ThreadId; call: sink typed) {.magic: "Spawn".} =
   ## Always spawns a new task on the worker thread with `id`, so that
   ## the `call` is **always** executed on the thread.
   ##
   ## `call` has to be a proc call `p(...)` where `p` is gcsafe and has a
   ## return type that is either `void` or compatible with `FlowVar[T]`.
+  discard "It uses `nimSpawn4` internally"
 
 template spawnX*(call) =
   ## Spawns a new task if a CPU core is ready, otherwise executes the


### PR DESCRIPTION
`spawn` uses `nimSpawn3` internally and `pinnedSpawn` uses `nimSpawn4` internally. I comment it in order to help contributors get the gist of its functionality.