### PR TITLE
Revert "Possible bug fix for std/net "

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -478,14 +478,14 @@ proc toSockAddr*(address: IpAddress, port: Port, sa: var Sockaddr_storage,
     sl = sizeof(Sockaddr_in).SockLen
     let s = cast[ptr Sockaddr_in](addr sa)
     s.sin_family = typeof(s.sin_family)(toInt(AF_INET))
-    s.sin_port = htons(port)
+    s.sin_port = port
     copyMem(addr s.sin_addr, unsafeAddr address.address_v4[0],
             sizeof(s.sin_addr))
   of IpAddressFamily.IPv6:
     sl = sizeof(Sockaddr_in6).SockLen
     let s = cast[ptr Sockaddr_in6](addr sa)
     s.sin6_family = typeof(s.sin6_family)(toInt(AF_INET6))
-    s.sin6_port = htons(port)
+    s.sin6_port = port
     copyMem(addr s.sin6_addr, unsafeAddr address.address_v6[0],
             sizeof(s.sin6_addr))
 


### PR DESCRIPTION
Reverts nim-lang/Nim#19177

Nope, this was wrong. The network order swap was already done a few lines above. 

However, there doesn't appear to be tests for the port byte order, so I'll try and add some. 