### PR TITLE
let Nim support Nimble 0.14 with lock-file support [backport:1.6]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -71,3 +71,6 @@
 - The `gc` switch has been renamed to `mm` ("memory management") in order to reflect the
   reality better. (Nim moved away from all techniques based on "tracing".)
 
+Nim now supports Nimble version 0.14 which added support for lock-files. This is done by
+a simple configuration change setting that you can do yourself too. In `$nim/config/nim.cfg`
+replace `pkgs` by `pkgs2`.

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -44,10 +44,12 @@ path="$lib/core"
 path="$lib/pure"
 
 @if not windows:
+  nimblepath="/opt/nimble/pkgs2/"
   nimblepath="/opt/nimble/pkgs/"
 @else:
   # TODO:
 @end
+nimblepath="$home/.nimble/pkgs2/"
 nimblepath="$home/.nimble/pkgs/"
 
 # Syncronize with compiler/commands.specialDefine


### PR DESCRIPTION
Note: I manually tested that Nim can use packages that are installed in `pkgs2` and other packages from `pkgs` at the same time, in the same project. The configuration addition is all it takes as the compiler always supported multiple `--nimblePath` entries.