### PR TITLE
nimc.rst: fix table markup

### DIFF
--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -179,6 +179,8 @@ nimRawSetjmp                     Use `_setjmp()/_longjmp()` on POSIX and `_setjm
 nimBuiltinSetjmp                 Use `__builtin_setjmp()/__builtin_longjmp()` for setjmp-based
                                  exceptions. This will not work if an exception is being thrown
                                  and caught inside the same procedure. Useful for benchmarking.
+==========================       ============================================
+
 
 Configuration files
 -------------------


### PR DESCRIPTION
Newly added table was missing some bottom markup. Now it looks OK: https://github.com/status-im/Nim/blob/fix_rst/doc/nimc.rst#compile-time-symbols