### PR TITLE
unit test for InAddr constructor

### DIFF
--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -22,6 +22,10 @@ suite "inet_ntop tests":
       var wsa: WSAData
       discard wsaStartup(0x101'i16, wsa.addr)
   
+  test "InAddr test":
+    var ip4 = InAddr(s_addr: 0x10111213'u32)
+    assert ip4.s_addr == 0x10111213'u32
+
   test "IP V4":
     var ip4 = 0x10111213
     var buff: array[0..255, char]


### PR DESCRIPTION
Test for Object constructor fails on Windows #19244. 