### PR TITLE
fix: fixes bug in CVerifyPeerUseEnvVars

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -680,7 +680,8 @@ when defineSsl:
           # Scan for certs in known locations. For CVerifyPeerUseEnvVars also scan
           # the SSL_CERT_FILE and SSL_CERT_DIR env vars
           var found = false
-          for fn in scanSSLCertificates():
+          let useEnvVars = (if verifyMode == CVerifyPeerUseEnvVars: true else: false)
+          for fn in scanSSLCertificates(useEnvVars = useEnvVars):
             if newCTX.SSL_CTX_load_verify_locations(fn, nil) == VerifySuccess:
               found = true
               break

--- a/tests/stdlib/thttpclient_ssl.nim
+++ b/tests/stdlib/thttpclient_ssl.nim
@@ -129,3 +129,19 @@ when not defined(windows):
           msg.contains("certificate verify failed")):
           echo "CVerifyPeer exception: " & msg
           check(false)
+
+    test "HttpClient with CVerifyPeerUseEnvVars":
+      const port = 12346.Port
+      let t = spawn runServer(port)
+      sleep(100)
+
+      putEnv("SSL_CERT_FILE", getCurrentDir() / certFile)
+      var client = newHttpClient(sslContext=newContext(verifyMode=CVerifyPeerUseEnvVars))
+      try:
+        log "client: connect"
+        discard client.getContent("https://127.0.0.1:12346")
+      except:
+        let msg = getCurrentExceptionMsg()
+        log "client: exception: " & msg
+        log "getContent should not have raised an exception"
+        fail()


### PR DESCRIPTION
Previously CVerifyPeerUseEnvVars was not being passed into
scanSslCertificates, which meant that we weren't scanning
additional certificate locations given via the SSL_CERT_FILE and
SSL_CERT_DIR environment variables

Fixes https://github.com/nim-lang/Nim/issues/19246