### PR TITLE
add proc dec*[A](t: var CountTable[A], key: A, val = 1)

### DIFF
--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2342,6 +2342,16 @@ proc inc*[A](t: var CountTable[A], key: A, val = 1) =
     if val != 0:
       insertImpl()
 
+proc dec*[A](t: var CountTable[A], key: A, val = 1) =
+  ## Decrements `t[key]` by `val` (default: 1).
+  runnableExamples:
+    var a = toCountTable("aaabbbbbbbbbbb")
+    a.dec('a')
+    a.dec('b', 10)
+    doAssert a == toCountTable("aab")
+
+  inc(t, key, -val)
+
 proc len*[A](t: CountTable[A]): int =
   ## Returns the number of keys in `t`.
   result = t.counter

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2324,8 +2324,14 @@ proc `[]=`*[A](t: var CountTable[A], key: A, val: int) =
     else:
       insertImpl()
 
-template incTempl[A](t: var CountTable[A], key: A, val = 1) =
+proc inc*[A](t: var CountTable[A], key: A, val = 1) =
   ## Increments `t[key]` by `val` (default: 1).
+  runnableExamples:
+    var a = toCountTable("aab")
+    a.inc('a')
+    a.inc('b', 10)
+    doAssert a == toCountTable("aaabbbbbbbbbbb")
+
   assert(not t.isSorted, "CountTable must not be used after sorting")
   var index = rawGet(t, key)
   if index >= 0:
@@ -2336,17 +2342,6 @@ template incTempl[A](t: var CountTable[A], key: A, val = 1) =
     if val != 0:
       insertImpl()
 
-
-proc inc*[A](t: var CountTable[A], key: A, val = 1) =
-  ## Increments `t[key]` by `val` (default: 1).
-  runnableExamples:
-    var a = toCountTable("aab")
-    a.inc('a')
-    a.inc('b', 10)
-    doAssert a == toCountTable("aaabbbbbbbbbbb")
-  
-  incTempl(t, key, val)
-
 proc dec*[A](t: var CountTable[A], key: A, val = 1) =
   ## Decrements `t[key]` by `val` (default: 1).
   runnableExamples:
@@ -2355,7 +2350,15 @@ proc dec*[A](t: var CountTable[A], key: A, val = 1) =
     a.dec('b', 10)
     doAssert a == toCountTable("aab")
 
-  incTempl(t, key, -val)
+  assert(not t.isSorted, "CountTable must not be used after sorting")
+  var index = rawGet(t, key)
+  if index >= 0:
+    dec(t.data[index].val, val)
+    if t.data[index].val == 0:
+      delImplIdx(t, index, cntMakeEmpty, cntCellEmpty, cntCellHash)
+  else:
+    if val != 0:
+      insertImpl()
 
 proc len*[A](t: CountTable[A]): int =
   ## Returns the number of keys in `t`.

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -2324,14 +2324,8 @@ proc `[]=`*[A](t: var CountTable[A], key: A, val: int) =
     else:
       insertImpl()
 
-proc inc*[A](t: var CountTable[A], key: A, val = 1) =
+template incTempl[A](t: var CountTable[A], key: A, val = 1) =
   ## Increments `t[key]` by `val` (default: 1).
-  runnableExamples:
-    var a = toCountTable("aab")
-    a.inc('a')
-    a.inc('b', 10)
-    doAssert a == toCountTable("aaabbbbbbbbbbb")
-
   assert(not t.isSorted, "CountTable must not be used after sorting")
   var index = rawGet(t, key)
   if index >= 0:
@@ -2342,6 +2336,17 @@ proc inc*[A](t: var CountTable[A], key: A, val = 1) =
     if val != 0:
       insertImpl()
 
+
+proc inc*[A](t: var CountTable[A], key: A, val = 1) =
+  ## Increments `t[key]` by `val` (default: 1).
+  runnableExamples:
+    var a = toCountTable("aab")
+    a.inc('a')
+    a.inc('b', 10)
+    doAssert a == toCountTable("aaabbbbbbbbbbb")
+  
+  incTempl(t, key, val)
+
 proc dec*[A](t: var CountTable[A], key: A, val = 1) =
   ## Decrements `t[key]` by `val` (default: 1).
   runnableExamples:
@@ -2350,7 +2355,7 @@ proc dec*[A](t: var CountTable[A], key: A, val = 1) =
     a.dec('b', 10)
     doAssert a == toCountTable("aab")
 
-  inc(t, key, -val)
+  incTempl(t, key, -val)
 
 proc len*[A](t: CountTable[A]): int =
   ## Returns the number of keys in `t`.


### PR DESCRIPTION
The CountTable only provided `inc` but not `dec`. I'm not sure what was the reason for this assymetry, but I think that users would expect there to be `dec` if there's `inc`.