### PR TITLE
suggestion to respect typedarray type

### DIFF
--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -587,7 +587,33 @@ proc nimCopy(dest, src: JSRef, ti: PNimType): JSRef =
     else:
       asm "`result` = (`dest` === null || `dest` === undefined) ? {} : `dest`;"
     nimCopyAux(result, src, ti.node)
-  of tySequence, tyArrayConstr, tyOpenArray, tyArray:
+  of tyArrayConstr:
+    # In order to prevent a type change (TypedArray -> Array) and to have better copying performance,
+    # arrays constructors are considered separately
+    asm """
+      if(ArrayBuffer.isView(`src`)) { 
+        if(`dest` === null || `dest` === undefined || `dest`.length != `src`.length) {
+          `dest` = new `src`.constructor(`src`);
+        } else {
+          `dest`.set(`src`, 0);
+        }
+        `result` = `dest`;
+      } else {
+        if (`src` === null) {
+          `result` = null;
+        }
+        else {
+          if (`dest` === null || `dest` === undefined || `dest`.length != `src`.length) {
+            `dest` = new Array(`src`.length);
+          }
+          `result` = `dest`;
+          for (var i = 0; i < `src`.length; ++i) {
+            `result`[i] = nimCopy(`result`[i], `src`[i], `ti`.base);
+          }
+        }
+      }
+    """
+  of tySequence, tyOpenArray, tyArray:
     asm """
       if (`src` === null) {
         `result` = null;

--- a/lib/system/jssys.nim
+++ b/lib/system/jssys.nim
@@ -587,7 +587,7 @@ proc nimCopy(dest, src: JSRef, ti: PNimType): JSRef =
     else:
       asm "`result` = (`dest` === null || `dest` === undefined) ? {} : `dest`;"
     nimCopyAux(result, src, ti.node)
-  of tyArrayConstr:
+  of tyArrayConstr, tyArray:
     # In order to prevent a type change (TypedArray -> Array) and to have better copying performance,
     # arrays constructors are considered separately
     asm """
@@ -613,7 +613,7 @@ proc nimCopy(dest, src: JSRef, ti: PNimType): JSRef =
         }
       }
     """
-  of tySequence, tyOpenArray, tyArray:
+  of tySequence, tyOpenArray:
     asm """
       if (`src` === null) {
         `result` = null;


### PR DESCRIPTION
I have a suggestion here to respect the type of the typedarray when copying. I myself wrote a math module that deals with matrices. For opengl and canvas they have to be organized flat as typedarrays.


Maybe someone also has a better suggestion?

The js tests are all ok.