### PR TITLE
fix #19244 - solves the problem of the InAddr object constructor in Windows.

### DIFF
--- a/lib/windows/winlean.nim
+++ b/lib/windows/winlean.nim
@@ -478,7 +478,7 @@ type
 
   PSockAddr = ptr SockAddr
 
-  InAddr* {.importc: "IN_ADDR", header: "winsock2.h".} = object
+  InAddr* {.importc: "IN_ADDR", header: "winsock2.h", union.} = object
     s_addr*: uint32  # IP address
 
   Sockaddr_in* {.importc: "SOCKADDR_IN",

--- a/tests/stdlib/tnet_ll.nim
+++ b/tests/stdlib/tnet_ll.nim
@@ -26,6 +26,7 @@ suite "inet_ntop tests":
     # regular
     var ip4 = InAddr()
     ip4.s_addr = 0x10111213'u32
+    check: ip4.s_addr == 0x10111213'u32
 
     var buff: array[0..255, char]
     let r = inet_ntop(AF_INET, cast[pointer](ip4.s_addr.addr), buff[0].addr, buff.len.int32)
@@ -43,3 +44,8 @@ suite "inet_ntop tests":
     let r = inet_ntop(AF_INET6, cast[pointer](ip6[0].addr), buff[0].addr, buff.len.int32)
     let res = if r == nil: "" else: $r
     check: not ipv6Support or res == "10:110:20:120:30:130:40:140"
+
+  test "InAddr":
+    # issue 19244
+    var ip4 = InAddr(s_addr: 0x10111213'u32)
+    check: ip4.s_addr == 0x10111213'u32


### PR DESCRIPTION
fix [#19244](https://github.com/nim-lang/Nim/issues/19244)

Currently the C code generated by Nim is [this](https://gist.github.com/rockcavera/86e6f9fd9671ce56254e75a5830be866#file-mtest-nim-c). Note that `ipv4` is initialized at global scope like this:
```c
N_LIB_PRIVATE IN_ADDR ipv4__test_2 = {((NU32) 269554195)}
;
```

The variable `ipv4` is declared and initialized with `(NU32) 269554195)`. It turns out that the [IN_ADDR](https://docs.microsoft.com/en-us/windows/win32/api/winsock2/ns-winsock2-in_addr) structure is a union in Windows, in which the first element is 4 `u_char`, one for each byte of IPv4. And as the initialization of a union is done on top of this first structure, then a wrong assignment occurs, assigning only 1 byte of the 4 bytes of Nim's `uint32`. To solve this, I envisioned two paths.

The first one is marking with pragma `union` the declaration of the type `InAddr` in `winlean`, because it generates a C code practically the same as the one generated for variable `ipv4v2`. See the generated C code [here](https://gist.github.com/rockcavera/86e6f9fd9671ce56254e75a5830be866#file-new_-mtest-nim-c).

The second solution is a little uglier and looks a lot more like a hack since, in my view, it just tricks the Nim compiler to satisfy it. Also, it would break old codes. Look here:
```nim
type
  InAddrUint8 = object
    s_b1, s_b2, s_b3, s_b4: uint8
  InAddrUint16 = object
    s_w1, s_w2: uint16
  InAddrUnion {.union.} = object
    S_un_b: InAddrUint8
    S_un_w: InAddrUint16
    S_addr: uint32
  
  InAddr* {.importc: "IN_ADDR", header: "winsock2.h".} = object
    S_un: InAddrUnion

var ipv4 = InAddr(S_un: InAddrUnion(S_addr: 0x10111213'u32))
var ipv4v2: InAddr

ipv4v2.S_un.S_addr = 0x10111213'u32

echo ipv4.S_un.S_addr
echo ipv4v2.S_un.S_addr
```
See [here](https://gist.github.com/rockcavera/86e6f9fd9671ce56254e75a5830be866#file-mteste-nim-c) C code.