### PR TITLE
[formatter] async.nim uses two spaces

### DIFF
--- a/lib/pure/async.nim
+++ b/lib/pure/async.nim
@@ -1,6 +1,6 @@
 when defined(js):
-    import asyncjs
-    export asyncjs
+  import asyncjs
+  export asyncjs
 else:
-    import asyncmacro, asyncfutures
-    export asyncmacro, asyncfutures
+  import asyncmacro, asyncfutures
+  export asyncmacro, asyncfutures


### PR DESCRIPTION
according to https://nim-lang.org/docs/nep1.html#introduction-spacing-and-whitespace-conventions, two spaces should be preferred in stdlib.

> Two spaces should be used for indentation of blocks; tabstops are not allowed (the compiler enforces this). Using spaces means that the appearance of code is more consistent across editors. Unlike spaces, tabstop width varies across editors, and not all editors provide means of changing this width.