### PR TITLE
Extract runnables that specify `rdoccmd`

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1715,8 +1715,8 @@ proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
     case ni.kind
     of nnkCommentStmt:
       result.add ni
-    of nnkCall:
-      if ni[0].kind == nnkIdent and ni[0].strVal == "runnableExamples":
+    of nnkCall, nnkCommand:
+      if ni[0].kind == nnkIdent and ni[0].eqIdent "runnableExamples":
         result.add ni
       else: break
     else: break

--- a/tests/stdlib/tmacros.nim
+++ b/tests/stdlib/tmacros.nim
@@ -124,3 +124,23 @@ block: # SameType
     assert not testTensorInt(x1)
     assert testTensorInt(x2)
     assert not testTensorInt(x3)
+
+block: # extractDocCommentsAndRunnables
+  macro checkRunnables(prc: untyped) =
+    let runnables = prc.body.extractDocCommentsAndRunnables()
+    doAssert runnables[0][0].eqIdent("runnableExamples")
+
+  macro checkComments(comment: static[string], prc: untyped) =
+    let comments = prc.body.extractDocCommentsAndRunnables()
+    doAssert comments[0].strVal == comment
+    
+  proc a() {.checkRunnables.} =
+    runnableExamples: discard
+    discard
+
+  proc b() {.checkRunnables.} =
+    runnableExamples "-d:ssl": discard
+    discard
+    
+  proc c() {.checkComments("Hello world").} =
+    ## Hello world


### PR DESCRIPTION
Fixes issue where `extractDocCommentsAndRunnables()` doesn't extract runnable which has the `rdoccmd` parameter

example code
```nim
import std/macros

macro printR(prc: untyped) =
  echo prc.name
  echo extractDocCommentsAndRunnables(prc.body).treeRepr
  echo ""
  
proc a*() {.printR.} =
  runnableExamples: discard

proc b*() {.printR.} =
  runnableExamples "-d:ssl": discard
```

Output before fix
```
a
StmtList
  Call
    Ident "runnableExamples"
    StmtList
      DiscardStmt
        Empty

b
StmtList
```

Output after fix
```
a
StmtList
  Call
    Ident "runnableExamples"
    StmtList
      DiscardStmt
        Empty

b
StmtList
  Command
    Ident "runnableExamples"
    StrLit "-d:ssl"
    StmtList
      DiscardStmt
        Empty
```
