### PR TITLE
Remove `Edit` link in generated documentation

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -898,10 +898,9 @@ proc genSeeSrc(d: PDoc, path: string, line: int): string =
         if NimPatch mod 2 == 1: "devel"
         else: "version-$1-$2" % [$NimMajor, $NimMinor]
       let commit = getConfigVar(d.conf, "git.commit", defaultBranch)
-      let develBranch = getConfigVar(d.conf, "git.devel", "devel")
       dispA(d.conf, result, "$1", "", [docItemSeeSrc % [
           "path", path.string, "line", $line, "url", gitUrl,
-          "commit", commit, "devel", develBranch]])
+          "commit", commit]])
 
 proc symbolPriority(k: TSymKind): int =
   result = case k

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -89,7 +89,6 @@ doc.item.tocTable = """
 # the empty string if you don't pass anything through --git.url. Available
 # substitutaion variables here are:
 # * $commit: branch/commit to use in source link.
-# * $devel: branch to use in edit link.
 # * $path: relative path to the file being processed.
 # * $line: line of the item in the original source file.
 # * $url: whatever you did pass through the --git.url switch (which also

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -97,7 +97,6 @@ doc.item.tocTable = """
 doc.item.seesrc = """&nbsp;&nbsp;<a
 href="${url}/tree/${commit}/${path}#L${line}"
 class="link-seesrc" target="_blank">Source</a>
-&nbsp;&nbsp;<a href="${url}/edit/${devel}/${path}#L${line}" class="link-seesrc" target="_blank" >Edit</a>
 """
 
 doc.deprecationmsg = """

--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -460,13 +460,6 @@ or to a tag e.g. `--git.commit:1.2.3`:option: or a commit.
 Source URLs are generated as ``href="${url}/tree/${commit}/${path}#L${line}"``
 by default and thus compatible with GitHub but not with GitLab.
 
-Similarly, `git.devel`:option: switch overrides the hardcoded `devel` branch
-for the `Edit` link which is also useful if you have a different working
-branch than `devel` e.g. `--git.devel:master`:option:.
-
-Edit URLs are generated as ``href="${url}/tree/${devel}/${path}#L${line}"``
-by default.
-
 You can edit ``config/nimdoc.cfg`` and modify the ``doc.item.seesrc`` value
 with a hyperlink to your own code repository.
 

--- a/tools/nimweb.nim
+++ b/tools/nimweb.nim
@@ -95,7 +95,6 @@ Options:
   --onlyDocs          build only the documentation
   --git.url           override base url in generated doc links
   --git.commit        override commit/branch in generated doc links 'source'
-  --git.devel         override devel branch in generated doc links 'edit'
 Compile_options:
   will be passed to the Nim compiler
 """
@@ -180,8 +179,6 @@ proc parseCmdLine(c: var TConfigData) =
         c.gitURL = val
       of "git.commit":
         c.nimArgs.add("--git.commit:" & val & " ")
-      of "git.devel":
-        c.nimArgs.add("--git.devel:" & val & " ")
       else:
         echo("Invalid argument '$1'" % [key])
         quit(usage)


### PR DESCRIPTION
The `Edit` link isn't very useful imo (I personally never did or wanted to use it), as most of the time you want to edit files locally in your cloned repo instead of in GitHub. It's also not useful for people that don't have a GitHub account or aren't logged in. Additionally, I often accidentally click on `Edit` when I actually wanted to click on `Source`.

I also removed the `git.devel` option, since afaict it was only used for the `Edit` links.
Note that I don't really know how docgen or HTML works, so I just guessed what needs to be changed. Please review carefully!