### PR TITLE
Object field access of static objects in generics now work

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1414,7 +1414,7 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
 
   if ty.kind in tyUserTypeClasses and ty.isResolvedUserTypeClass:
     ty = ty.lastSon
-  ty = skipTypes(ty, {tyGenericInst, tyVar, tyLent, tyPtr, tyRef, tyOwned, tyAlias, tySink})
+  ty = skipTypes(ty, {tyGenericInst, tyVar, tyLent, tyPtr, tyRef, tyOwned, tyAlias, tySink, tyStatic})
   while tfBorrowDot in ty.flags: ty = ty.skipTypes({tyDistinct, tyGenericInst, tyAlias})
   var check: PNode = nil
   if ty.kind == tyObject:

--- a/tests/system/tstatic.nim
+++ b/tests/system/tstatic.nim
@@ -44,6 +44,14 @@ template main() =
       proc parseInt(f: static[bool]): int {.used.} = discard
 
       doAssert "123".parseInt == 123
+  block:
+    type
+      MyType = object
+        field: float32
+      AType[T: static MyType] = distinct range[0f32 .. T.field]
+    var a: AType[MyType(field: 5f32)]
+    proc n(S: static Slice[int]): range[S.a..S.b] = discard
+    assert typeof(n 1..2) is range[1..2]
 
 
 static: main()


### PR DESCRIPTION
Could not find if this closes any issues, but nonetheless fixes and probably should be backported.