### PR TITLE
add compile time option for POSIX sigwait on Illumos/Solaris

### DIFF
--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -772,6 +772,12 @@ else:
   proc sigtimedwait*(a1: var Sigset, a2: var SigInfo,
                      a3: var Timespec): cint {.importc, header: "<signal.h>".}
 
+when defined(sunos) or defined(solaris):
+  # The following compile time flag is needed on Illumos/Solaris to use the POSIX
+  # `sigwait` implementation. See the documentation here:
+  # https://docs.oracle.com/cd/E19455-01/806-5257/gen-75415/index.html
+  {.passc: "-D_POSIX_PTHREAD_SEMANTICS".}
+
 proc sigwait*(a1: var Sigset, a2: var cint): cint {.
   importc, header: "<signal.h>".}
 proc sigwaitinfo*(a1: var Sigset, a2: var SigInfo): cint {.

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -775,7 +775,8 @@ else:
 when defined(sunos) or defined(solaris):
   # The following compile time flag is needed on Illumos/Solaris to use the POSIX
   # `sigwait` implementation. See the documentation here:
-  # https://docs.oracle.com/cd/E19455-01/806-5257/gen-75415/index.html
+  # https://docs.oracle.com/cd/E19455-01/806-5257/6je9h033k/index.html
+  # https://www.illumos.org/man/2/sigwait
   {.passc: "-D_POSIX_PTHREAD_SEMANTICS".}
 
 proc sigwait*(a1: var Sigset, a2: var cint): cint {.


### PR DESCRIPTION
Hello,

the PR fixes this [issue](https://github.com/nim-lang/Nim/issues/19039).
It adds the correct C compile time definition for the `sigwait` function on Illumos/Solaris.
This switches the `sigwait` function from the Solaris Operating Environment 2.5 to the POSIX.1c version, see [here](https://docs.oracle.com/cd/E19455-01/806-5257/gen-75415/index.html)