### PR TITLE
change int32 to BiggestInt in contentLength assertion

### DIFF
--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -260,7 +260,7 @@ proc contentLength*(response: Response | AsyncResponse): int =
   ## A `ValueError` exception will be raised if the value is not an integer.
   var contentLengthHeader = response.headers.getOrDefault("Content-Length")
   result = contentLengthHeader.parseInt()
-  doAssert(result >= 0 and result <= high(BiggestInt))
+  doAssert result >= 0
 
 proc lastModified*(response: Response | AsyncResponse): DateTime =
   ## Retrieves the specified response's last modified time.

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -260,7 +260,7 @@ proc contentLength*(response: Response | AsyncResponse): int =
   ## A `ValueError` exception will be raised if the value is not an integer.
   var contentLengthHeader = response.headers.getOrDefault("Content-Length")
   result = contentLengthHeader.parseInt()
-  doAssert(result >= 0 and result <= high(int32))
+  doAssert(result >= 0 and result <= high(BiggestInt))
 
 proc lastModified*(response: Response | AsyncResponse): DateTime =
   ## Retrieves the specified response's last modified time.


### PR DESCRIPTION
I don't know why this assertion is using int32 (compatibility?) but it causes assertion failures when calling this proc on moderately large requests. e.g. the content-length for a Linux ISO I was attempting to download is 2480579971 which fails the assertion and crashes.