### PR TITLE
Fix #19297 - fixing broken list after adding empty list

### DIFF
--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -531,11 +531,10 @@ proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
     assert s == [0, 1, 0, 1, 0, 1]
 
   if b.head != nil:
-    if a.tail != nil:
-      a.tail.next = b.head
     if a.head == nil:
       a.head = b.head
-  if b.tail != nil:
+    else:
+      a.tail.next = b.head
     a.tail = b.tail
   if a.addr != b.addr:
     b.head = nil

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -530,11 +530,13 @@ proc addMoved*[T](a, b: var SinglyLinkedList[T]) {.since: (1, 5, 1).} =
         ci
     assert s == [0, 1, 0, 1, 0, 1]
 
-  if a.tail != nil:
-    a.tail.next = b.head
-  a.tail = b.tail
-  if a.head == nil:
-    a.head = b.head
+  if b.head != nil:
+    if a.tail != nil:
+      a.tail.next = b.head
+    if a.head == nil:
+      a.head = b.head
+  if b.tail != nil:
+    a.tail = b.tail
   if a.addr != b.addr:
     b.head = nil
     b.tail = nil

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -233,6 +233,18 @@ template main =
     doAssert l.toSeq == [1]
     doAssert l.remove(l.head) == true
     doAssert l.toSeq == []
+  
+  block issue19297: # add (appends a shallow copy)
+    var a: SinglyLinkedList[int]
+    var b: SinglyLinkedList[int]
+
+    doAssert a.toSeq == @[]
+    a.add(1)
+    doAssert a.toSeq == @[1]
+    a.add(b)
+    doAssert a.toSeq == @[1]
+    a.add(2)
+    doAssert a.toSeq == @[1, 2]
 
 static: main()
 main()


### PR DESCRIPTION
Fix #19297

The lack of `nil` checking for `head` and `tail` can cause this bug. So checks were added to fix the problem.