### PR TITLE
add std/private/win_getsysteminfo; refactor the usage of `GetSystemInfo`

### DIFF
--- a/lib/pure/concurrency/cpuinfo.nim
+++ b/lib/pure/concurrency/cpuinfo.nim
@@ -58,8 +58,8 @@ proc countProcessors*(): int {.rtl, extern: "ncpi$1".} =
   ## Returns 0 if it cannot be detected.
   when defined(windows):
     var
-      si: SYSTEM_INFO
-    GetSystemInfo(addr si)
+      si: SystemInfo
+    getSystemInfo(addr si)
     result = int(si.dwNumberOfProcessors)
   elif defined(macosx) or defined(bsd):
     var

--- a/lib/pure/concurrency/cpuinfo.nim
+++ b/lib/pure/concurrency/cpuinfo.nim
@@ -18,6 +18,9 @@ include "system/inclrtl"
 when defined(posix) and not (defined(macosx) or defined(bsd)):
   import posix
 
+when defined(windows):
+  import std/private/win_getsysteminfo
+
 when defined(freebsd) or defined(macosx):
   {.emit: "#include <sys/types.h>".}
 
@@ -54,8 +57,6 @@ proc countProcessors*(): int {.rtl, extern: "ncpi$1".} =
   ## Returns the number of the processors/cores the machine has.
   ## Returns 0 if it cannot be detected.
   when defined(windows):
-    import std/private/win_getsysteminfo
-
     var
       si: SYSTEM_INFO
     GetSystemInfo(addr si)

--- a/lib/pure/concurrency/cpuinfo.nim
+++ b/lib/pure/concurrency/cpuinfo.nim
@@ -54,25 +54,12 @@ proc countProcessors*(): int {.rtl, extern: "ncpi$1".} =
   ## Returns the number of the processors/cores the machine has.
   ## Returns 0 if it cannot be detected.
   when defined(windows):
-    type
-      SYSTEM_INFO {.final, pure.} = object
-        u1: int32
-        dwPageSize: int32
-        lpMinimumApplicationAddress: pointer
-        lpMaximumApplicationAddress: pointer
-        dwActiveProcessorMask: ptr int32
-        dwNumberOfProcessors: int32
-        dwProcessorType: int32
-        dwAllocationGranularity: int32
-        wProcessorLevel: int16
-        wProcessorRevision: int16
-
-    proc GetSystemInfo(lpSystemInfo: var SYSTEM_INFO) {.stdcall, dynlib: "kernel32", importc: "GetSystemInfo".}
+    import std/private/win_getsysteminfo
 
     var
       si: SYSTEM_INFO
-    GetSystemInfo(si)
-    result = si.dwNumberOfProcessors
+    GetSystemInfo(addr si)
+    result = int(si.dwNumberOfProcessors)
   elif defined(macosx) or defined(bsd):
     var
       mib: array[0..3, cint]

--- a/lib/pure/reservedmem.nim
+++ b/lib/pure/reservedmem.nim
@@ -45,8 +45,8 @@ when defined(windows):
   import std/private/win_getsysteminfo
 
   proc getAllocationGranularity: uint =
-    var sysInfo: SYSTEM_INFO
-    GetSystemInfo(addr sysInfo)
+    var sysInfo: SystemInfo
+    getSystemInfo(addr sysInfo)
     return uint(sysInfo.dwAllocationGranularity)
 
   let allocationGranularity = getAllocationGranularity().int

--- a/lib/pure/reservedmem.nim
+++ b/lib/pure/reservedmem.nim
@@ -42,26 +42,11 @@ type
 
 when defined(windows):
   import winlean
-
-  type
-    SYSTEM_INFO {.final, pure.} = object
-      u1: uint32
-      dwPageSize: uint32
-      lpMinimumApplicationAddress: pointer
-      lpMaximumApplicationAddress: pointer
-      dwActiveProcessorMask: ptr uint32
-      dwNumberOfProcessors: uint32
-      dwProcessorType: uint32
-      dwAllocationGranularity: uint32
-      wProcessorLevel: uint16
-      wProcessorRevision: uint16
-
-  proc getSystemInfo(lpSystemInfo: ptr SYSTEM_INFO) {.stdcall,
-      dynlib: "kernel32", importc: "GetSystemInfo".}
+  import std/private/win_getsysteminfo
 
   proc getAllocationGranularity: uint =
     var sysInfo: SYSTEM_INFO
-    getSystemInfo(addr sysInfo)
+    GetSystemInfo(addr sysInfo)
     return uint(sysInfo.dwAllocationGranularity)
 
   let allocationGranularity = getAllocationGranularity().int

--- a/lib/std/private/win_getsysteminfo.nim
+++ b/lib/std/private/win_getsysteminfo.nim
@@ -1,5 +1,5 @@
 type
-  SystemInfo* {.final, pure.} = object
+  SystemInfo* = object
     u1: uint32
     dwPageSize: uint32
     lpMinimumApplicationAddress: pointer

--- a/lib/std/private/win_getsysteminfo.nim
+++ b/lib/std/private/win_getsysteminfo.nim
@@ -1,0 +1,15 @@
+type
+  SYSTEM_INFO* {.final, pure.} = object
+    u1: uint32
+    dwPageSize: uint32
+    lpMinimumApplicationAddress: pointer
+    lpMaximumApplicationAddress: pointer
+    dwActiveProcessorMask: ptr uint32
+    dwNumberOfProcessors*: uint32
+    dwProcessorType: uint32
+    dwAllocationGranularity*: uint32
+    wProcessorLevel: uint16
+    wProcessorRevision: uint16
+
+proc GetSystemInfo*(lpSystemInfo: ptr SYSTEM_INFO) {.stdcall,
+    dynlib: "kernel32", importc: "GetSystemInfo".}

--- a/lib/std/private/win_getsysteminfo.nim
+++ b/lib/std/private/win_getsysteminfo.nim
@@ -1,5 +1,5 @@
 type
-  SYSTEM_INFO* {.final, pure.} = object
+  SystemInfo* {.final, pure.} = object
     u1: uint32
     dwPageSize: uint32
     lpMinimumApplicationAddress: pointer
@@ -11,5 +11,5 @@ type
     wProcessorLevel: uint16
     wProcessorRevision: uint16
 
-proc GetSystemInfo*(lpSystemInfo: ptr SYSTEM_INFO) {.stdcall,
+proc getSystemInfo*(lpSystemInfo: ptr SystemInfo) {.stdcall,
     dynlib: "kernel32", importc: "GetSystemInfo".}


### PR DESCRIPTION
Make the definition of `SYSTEM_INFO` more correct because the definition should use unsigned types instead of signed types; the PR doesn't move the function to winlean module and then `lib/pure/concurrency/cpuinfo.nim` won't carry the burden of the whole winlean module. 

Ref https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info

