### PR TITLE
enable multiple packages (arraymancer, fidget ...)

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -35,7 +35,7 @@ proc pkg(name: string; cmd = "nimble test"; url = "", useHead = true, allowFailu
 
 pkg "alea", allowFailure = true
 pkg "argparse"
-pkg "arraymancer", "nim c tests/tests_cpu.nim", allowFailure = true
+pkg "arraymancer", "nim c tests/tests_cpu.nim"
 pkg "ast_pattern_matching", "nim c -r --oldgensym:on tests/test1.nim", allowFailure = true
 pkg "asyncthreadpool"
 pkg "awk"
@@ -63,7 +63,7 @@ pkg "delaunay"
 pkg "docopt"
 pkg "easygl", "nim c -o:egl -r src/easygl.nim", "https://github.com/jackmott/easygl"
 pkg "elvis"
-pkg "fidget", allowFailure = true
+pkg "fidget"
 pkg "fragments", "nim c -r fragments/dsl.nim"
 pkg "fusion"
 pkg "gara"
@@ -91,7 +91,7 @@ pkg "memo"
 pkg "msgpack4nim", "nim c -r tests/test_spec.nim"
 pkg "nake", "nim c nakefile.nim"
 pkg "neo", "nim c -d:blas=openblas tests/all.nim"
-pkg "nesm", "nimble tests", allowFailure = true # notice plural 'tests'
+pkg "nesm", "nimble tests" # notice plural 'tests'
 pkg "netty"
 pkg "nico", allowFailure = true
 pkg "nicy", "nim c -r src/nicy.nim"


### PR DESCRIPTION
The cause of arraymancer failure has been tracked here: https://github.com/mratsim/Arraymancer/issues/505
And it was fixed by https://github.com/mratsim/Arraymancer/pull/542

enable: arraymancer, fidget and nesm according to the latest allow-failures branch CI

See https://github.com/nim-lang/Nim/runs/4689551387?check_suite_focus=true and search "PASS"