### PR TITLE
Fix #19314 - fixing broken `DoublyLinkedList` after adding empty `DoublyLinkedList`

### DIFF
--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -675,12 +675,12 @@ proc addMoved*[T](a, b: var DoublyLinkedList[T]) {.since: (1, 5, 1).} =
     assert s == [0, 1, 0, 1, 0, 1]
 
   if b.head != nil:
-    b.head.prev = a.tail
-  if a.tail != nil:
-    a.tail.next = b.head
-  a.tail = b.tail
-  if a.head == nil:
-    a.head = b.head
+    if a.head == nil:
+      a.head = b.head
+    else:
+      b.head.prev = a.tail
+      a.tail.next = b.head
+    a.tail = b.tail
   if a.addr != b.addr:
     b.head = nil
     b.tail = nil

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -245,6 +245,18 @@ template main =
     doAssert a.toSeq == @[1]
     a.add(2)
     doAssert a.toSeq == @[1, 2]
+  
+  block issue19314: # add (appends a shallow copy)
+    var a: DoublyLinkedList[int]
+    var b: DoublyLinkedList[int]
+
+    doAssert a.toSeq == @[]
+    a.add(1)
+    doAssert a.toSeq == @[1]
+    a.add(b)
+    doAssert a.toSeq == @[1]
+    a.add(2)
+    doAssert a.toSeq == @[1, 2]
 
 static: main()
 main()


### PR DESCRIPTION
Fix #19314

Added check for empty list before adding.