### PR TITLE
style usages part one (openarray => openArray)

### DIFF
--- a/tests/arc/tmovebug.nim
+++ b/tests/arc/tmovebug.nim
@@ -292,7 +292,7 @@ when false:
 
 # bug #13456
 
-iterator combinations[T](s: openarray[T], k: int): seq[T] =
+iterator combinations[T](s: openArray[T], k: int): seq[T] =
   let n = len(s)
   assert k >= 0 and k <= n
   var pos = newSeq[int](k)
@@ -455,7 +455,7 @@ initFoo7(2)
 
 
 # bug #14902
-iterator zip[T](s: openarray[T]): (T, T) =
+iterator zip[T](s: openArray[T]): (T, T) =
   var i = 0
   while i < 10:
     yield (s[i mod 2], s[i mod 2 + 1])

--- a/tests/arc/tmovebugcopy.nim
+++ b/tests/arc/tmovebugcopy.nim
@@ -253,7 +253,7 @@ when false:
 
 # bug #13456
 
-iterator combinations[T](s: openarray[T], k: int): seq[T] =
+iterator combinations[T](s: openArray[T], k: int): seq[T] =
   let n = len(s)
   assert k >= 0 and k <= n
   var pos = newSeq[int](k)
@@ -416,7 +416,7 @@ initFoo7(2)
 
 
 # bug #14902
-iterator zip[T](s: openarray[T]): (T, T) =
+iterator zip[T](s: openArray[T]): (T, T) =
   var i = 0
   while i < 10:
     yield (s[i mod 2], s[i mod 2 + 1])

--- a/tests/array/tarray.nim
+++ b/tests/array/tarray.nim
@@ -44,7 +44,7 @@ block tarray:
       arr: TMyarray
 
 
-  proc sum(a: openarray[int]): int =
+  proc sum(a: openArray[int]): int =
     result = 0
     var i = 0
     while i < len(a):

--- a/tests/async/tioselectors.nim
+++ b/tests/async/tioselectors.nim
@@ -288,8 +288,8 @@ when not defined(windows):
         events: set[Event]
 
     proc vnode_test(): bool =
-      proc validate(test: openarray[ReadyKey],
-                    check: openarray[valType]): bool =
+      proc validate(test: openArray[ReadyKey],
+                    check: openArray[valType]): bool =
         result = false
         if len(test) == len(check):
           for checkItem in check:

--- a/tests/closure/tclosure.nim
+++ b/tests/closure/tclosure.nim
@@ -38,10 +38,10 @@ joinable: false
 
 
 block tclosure:
-  proc map(n: var openarray[int], fn: proc (x: int): int {.closure}) =
+  proc map(n: var openArray[int], fn: proc (x: int): int {.closure}) =
     for i in 0..n.len-1: n[i] = fn(n[i])
 
-  proc each(n: openarray[int], fn: proc(x: int) {.closure.}) =
+  proc each(n: openArray[int], fn: proc(x: int) {.closure.}) =
     for i in 0..n.len-1:
       fn(n[i])
 

--- a/tests/compiles/trecursive_generic_in_compiles.nim
+++ b/tests/compiles/trecursive_generic_in_compiles.nim
@@ -50,7 +50,7 @@ proc `==`*[T](xs, ys: List[T]): bool =
 
 proc asList*[T](xs: varargs[T]): List[T] =
   ## Creates list from varargs
-  proc initListImpl(i: int, xs: openarray[T]): List[T] =
+  proc initListImpl(i: int, xs: openArray[T]): List[T] =
     if i > high(xs):
       Nil[T]()
     else:

--- a/tests/concepts/tconcepts_issues.nim
+++ b/tests/concepts/tconcepts_issues.nim
@@ -324,15 +324,15 @@ block t6691:
 block t6782:
   type
     Reader = concept c
-      c.read(openarray[byte], int, int) is int
+      c.read(openArray[byte], int, int) is int
     Rdr = concept c
-      c.rd(openarray[byte], int, int) is int
+      c.rd(openArray[byte], int, int) is int
 
   type TestFile = object
 
-  proc read(r: TestFile, dest: openarray[byte], offset: int, limit: int): int =
+  proc read(r: TestFile, dest: openArray[byte], offset: int, limit: int): int =
       result = 0
-  proc rd(r: TestFile, dest: openarray[byte], offset: int, limit: int): int =
+  proc rd(r: TestFile, dest: openArray[byte], offset: int, limit: int): int =
       result = 0
 
   doAssert TestFile is Reader

--- a/tests/converter/tconverter_with_varargs.nim
+++ b/tests/converter/tconverter_with_varargs.nim
@@ -8,7 +8,7 @@ type
 converter to_py*(i: int) : PPyRef = nil
 
 when false:
-  proc to_tuple*(vals: openarray[PPyRef]): PPyRef =
+  proc to_tuple*(vals: openArray[PPyRef]): PPyRef =
     discard
 
 proc abc(args: varargs[PPyRef]) =

--- a/tests/cpp/tcovariancerules.nim
+++ b/tests/cpp/tcovariancerules.nim
@@ -79,16 +79,16 @@ proc wantsCovariantSeq2(s: seq[AnimalRef]) =
 proc wantsCovariantSeq3(s: seq[RefAlias[Animal]]) =
   for a in s: echo a.x
 
-proc wantsCovariantOpenArray(s: openarray[ref Animal]) =
+proc wantsCovariantOpenArray(s: openArray[ref Animal]) =
   for a in s: echo a.x
 
-proc modifiesCovariantOpenArray(s: var openarray[ref Animal]) =
+proc modifiesCovariantOpenArray(s: var openArray[ref Animal]) =
   for a in s: echo a.x
 
-proc modifiesDerivedOpenArray(s: var openarray[ref Dog]) =
+proc modifiesDerivedOpenArray(s: var openArray[ref Dog]) =
   for a in s: echo a.x
 
-proc wantsNonCovariantOpenArray(s: openarray[Animal]) =
+proc wantsNonCovariantOpenArray(s: openArray[Animal]) =
   for a in s: echo a.x
 
 proc wantsCovariantArray(s: array[2, ref Animal]) =

--- a/tests/destructor/tmove_objconstr.nim
+++ b/tests/destructor/tmove_objconstr.nim
@@ -178,7 +178,7 @@ proc myfuncLoop(x: int): MySeqNonCopyable =
 discard myfuncLoop(3)
 
 #------------------------------------------------------------
-# Move into table via openarray
+# Move into table via openArray
 #------------------------------------------------------------
 
 type

--- a/tests/errmsgs/t17460.nim
+++ b/tests/errmsgs/t17460.nim
@@ -3,7 +3,7 @@ discard """
   errormsg: "wrong number of variables"
 """
 
-iterator xclusters*[T](a: openarray[T]; s: static[int]): array[s, T] {.inline.} =
+iterator xclusters*[T](a: openArray[T]; s: static[int]): array[s, T] {.inline.} =
   var result: array[s, T] # iterators have no default result variable
   var i = 0
   while i < len(a):

--- a/tests/errmsgs/tproper_stacktrace.nim
+++ b/tests/errmsgs/tproper_stacktrace.nim
@@ -6,7 +6,7 @@ import strscans, strutils
 proc raiseTestException*() =
   raise newException(Exception, "test")
 
-proc matchStackTrace(actualEntries: openarray[StackTraceEntry], expected: string) =
+proc matchStackTrace(actualEntries: openArray[StackTraceEntry], expected: string) =
   var expectedEntries = newSeq[StackTraceEntry]()
   var i = 0
 

--- a/tests/errmsgs/tsigmatch.nim
+++ b/tests/errmsgs/tsigmatch.nim
@@ -132,12 +132,12 @@ block:
   echo foo(fun)
 
 block:
-  # bug #10285 Function signature don't match when inside seq/array/openarray
+  # bug #10285 Function signature don't match when inside seq/array/openArray
   # Note: the error message now shows `closure` which helps debugging the issue
   # out why it doesn't match
   proc takesFunc(f: proc (x: int) {.gcsafe, locks: 0.}) =
     echo "takes single Func"
-  proc takesFuncs(fs: openarray[proc (x: int) {.gcsafe, locks: 0.}]) =
+  proc takesFuncs(fs: openArray[proc (x: int) {.gcsafe, locks: 0.}]) =
     echo "takes multiple Func"
   takesFunc(proc (x: int) {.gcsafe, locks: 0.} = echo x)         # works
   takesFuncs([proc (x: int) {.gcsafe, locks: 0.} = echo x])      # fails

--- a/tests/generics/tgenerics_issues.nim
+++ b/tests/generics/tgenerics_issues.nim
@@ -603,7 +603,7 @@ block t7854:
 
 
 block t5864:
-  proc defaultStatic(s: openarray, N: static[int] = 1): int = N
+  proc defaultStatic(s: openArray, N: static[int] = 1): int = N
   proc defaultGeneric[T](a: T = 2): int = a
 
   let a = [1, 2, 3, 4].defaultStatic()

--- a/tests/generics/tgenerics_various.nim
+++ b/tests/generics/tgenerics_various.nim
@@ -230,8 +230,8 @@ block tvarargs_vs_generics:
     echo "direct"
   proc withDirectType[T](arg: T) =
     echo "generic"
-  proc withOpenArray(args: openarray[string]) =
-    echo "openarray"
+  proc withOpenArray(args: openArray[string]) =
+    echo "openArray"
   proc withOpenArray[T](arg: T) =
     echo "generic"
   proc withVarargs(args: varargs[string]) =

--- a/tests/iter/titer13.nim
+++ b/tests/iter/titer13.nim
@@ -72,7 +72,7 @@ block:
     echo a
 
 block t5859:
-  proc flatIterator[T](s: openarray[T]): auto {.noSideEffect.}=
+  proc flatIterator[T](s: openArray[T]): auto {.noSideEffect.}=
     result = iterator(): auto =
       when (T is not seq|array):
         for item in s:

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -135,7 +135,7 @@ block t3837_chained:
 
 
 block t3221_complex:
-  iterator permutations[T](ys: openarray[T]): seq[T] =
+  iterator permutations[T](ys: openArray[T]): seq[T] =
     var
       d = 1
       c = newSeq[int](ys.len)
@@ -228,7 +228,7 @@ block t2023_objiter:
 
 block:
   # bug #13739
-  iterator myIter(arg: openarray[int]): int =
+  iterator myIter(arg: openArray[int]): int =
     var tmp = 0
     let len = arg.len
     while tmp < len:

--- a/tests/iter/tmoditer.nim
+++ b/tests/iter/tmoditer.nim
@@ -43,7 +43,7 @@ proc `=copy`(dst: var NonCopyable, src: NonCopyable) {.error.}
 proc `=sink`(dst: var NonCopyable, src: NonCopyable) =
   dst.x = src.x
 
-iterator lentItems[T](a: openarray[T]): lent T =
+iterator lentItems[T](a: openArray[T]): lent T =
   for i in 0..a.high:
     yield a[i]
 

--- a/tests/iter/tpermutations.nim
+++ b/tests/iter/tpermutations.nim
@@ -12,7 +12,7 @@ perm: 6778800.0 det: 0.0
 
 import sequtils, sugar
 
-iterator permutations*[T](ys: openarray[T]): tuple[perm: seq[T], sign: int] =
+iterator permutations*[T](ys: openArray[T]): tuple[perm: seq[T], sign: int] =
   var
     d = 1
     c = newSeq[int](ys.len)

--- a/tests/js/t9410.nim
+++ b/tests/js/t9410.nim
@@ -447,10 +447,10 @@ template tests =
       doAssert seqOfSeqs == @[@[10, 2], @[30, 4]]
 
   when false:
-    block: # openarray
+    block: # openArray
           # Error: internal error: genAddr: nkStmtListExpr
       var calls = 0
-      proc getvarint(x: var openarray[int]): var int =
+      proc getvarint(x: var openArray[int]): var int =
         calls += 1
         if true:
           x[1]

--- a/tests/js/tbasics.nim
+++ b/tests/js/tbasics.nim
@@ -54,7 +54,7 @@ for x in someGlobal: doAssert(x == 0)
 proc tdefault =
   var x = default(int)
   doAssert(x == 0)
-  proc inner(v: openarray[string]) =
+  proc inner(v: openArray[string]) =
     doAssert(v.len == 0)
 
   inner(default(seq[string]))

--- a/tests/js/tbyvar.nim
+++ b/tests/js/tbyvar.nim
@@ -39,9 +39,9 @@ proc main =
 
 main()
 
-# Test: pass var seq to var openarray
+# Test: pass var seq to var openArray
 var s = @[2, 1]
-proc foo(a: var openarray[int]) = a[0] = 123
+proc foo(a: var openArray[int]) = a[0] = 123
 
 proc bar(s: var seq[int], a: int) =
   doAssert(a == 5)

--- a/tests/lent/tbasic_lent_check.nim
+++ b/tests/lent/tbasic_lent_check.nim
@@ -39,7 +39,7 @@ template main2 = # bug #15958
     p[] = 20.0
     doAssert byLent(p)[] == 20.0
 
-  proc byLent2[T](a: openarray[T]): lent T = a[0]
+  proc byLent2[T](a: openArray[T]): lent T = a[0]
   doAssert byLent2(a) == 11
   doAssert byLent2(a).unsafeAddr == a[0].unsafeAddr
   doAssert byLent2(b) == 21

--- a/tests/magics/tmagics.nim
+++ b/tests/magics/tmagics.nim
@@ -18,7 +18,7 @@ block tlowhigh:
   for i in low(a) .. high(a):
     a[i] = 0
 
-  proc sum(a: openarray[int]): int =
+  proc sum(a: openArray[int]): int =
     result = 0
     for i in low(a)..high(a):
       inc(result, a[i])

--- a/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/gl.nim
+++ b/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/gl.nim
@@ -53,7 +53,7 @@ else:
   const
     glRealType* = cGLfloat
 
-proc setUniformV4*[T](loc: GLint, vecs: var openarray[TV4[T]]) =
+proc setUniformV4*[T](loc: GLint, vecs: var openArray[TV4[T]]) =
   glUniform4fv(loc, vecs.len.GLsizei, cast[ptr GLfloat](vecs[0].addr))
 
 proc setUniformV4*[T](loc: GLint, vec: TV4[T]) =

--- a/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/primitive.nim
+++ b/tests/manyloc/named_argument_bug/tri_engine/gfx/gl/primitive.nim
@@ -47,7 +47,7 @@ proc newVert*(rect: rect.TRect): seq[TVert] =
 proc newVertAttrib(i: GLuint, size: GLint, stride: GLsizei, offset: GLvoid): TVertAttrib =
   TVertAttrib(i: i, size: size, stride: stride, offset: offset)
 
-proc genBuf*[T](vboTarget, objUsage: GLenum, data: var openarray[T]): GLuint =
+proc genBuf*[T](vboTarget, objUsage: GLenum, data: var openArray[T]): GLuint =
   result = 0.GLuint
   ?glGenBuffers(1, result.addr)
   ?glBindBuffer(vboTarget, result)

--- a/tests/misc/t9039.nim
+++ b/tests/misc/t9039.nim
@@ -15,7 +15,7 @@ but expression 'nesting + 1' is of type: int
 # line 15
 func default(T: typedesc[array]): T = discard
 doAssert default(array[3, int]) == [0, 0, 0]
-func shapeBad*[T: not char](s: openarray[T], rank: static[int], nesting = 0, parent_shape = default(array[rank, int])): array[rank, int] =
+func shapeBad*[T: not char](s: openArray[T], rank: static[int], nesting = 0, parent_shape = default(array[rank, int])): array[rank, int] =
   result = parent_shape
   result[nesting] = s.len
   when (T is seq|array):

--- a/tests/misc/theaproots.nim
+++ b/tests/misc/theaproots.nim
@@ -28,7 +28,7 @@ proc acc(x: var Foo): var ref Bar =
 
 proc test(maybeFoo: var Foo,
           maybeSeq: var seq[ref Bar],
-          bars: var openarray[ref Bar],
+          bars: var openArray[ref Bar],
           maybeTup: var Tup) =
   var bb: ref Bar
   maybeFoo.rmaybe = bb

--- a/tests/misc/tsimplesort.nim
+++ b/tests/misc/tsimplesort.nim
@@ -112,7 +112,7 @@ proc initTable*[A, B](initialSize=64): TTable[A, B] =
   result.counter = 0
   newSeq(result.data, initialSize)
 
-proc toTable*[A, B](pairs: openarray[tuple[key: A,
+proc toTable*[A, B](pairs: openArray[tuple[key: A,
                     val: B]]): TTable[A, B] =
   ## creates a new hash table that contains the given `pairs`.
   result = initTable[A, B](nextPowerOfTwo(pairs.len+10))

--- a/tests/openarray/topena1.nim
+++ b/tests/openarray/topena1.nim
@@ -6,4 +6,4 @@ discard """
 # Tests a special bug
 
 var
-  x: ref openarray[string] #ERROR_MSG invalid type
+  x: ref openArray[string] #ERROR_MSG invalid type

--- a/tests/openarray/topenarrayrepr.nim
+++ b/tests/openarray/topenarrayrepr.nim
@@ -2,12 +2,12 @@ discard """
   output: "5 - [1]"
 """
 type
-  TProc = proc (n: int, m: openarray[int64]) {.nimcall.}
+  TProc = proc (n: int, m: openArray[int64]) {.nimcall.}
 
 proc Foo(x: int, P: TProc) =
   P(x, [ 1'i64 ])
 
-proc Bar(n: int, m: openarray[int64]) =
+proc Bar(n: int, m: openArray[int64]) =
   echo($n & " - " & repr(m))
 
 Foo(5, Bar) #OUT 5 - [1]

--- a/tests/openarray/topenlen.nim
+++ b/tests/openarray/topenlen.nim
@@ -5,7 +5,7 @@ discard """
 
 proc choose(b: openArray[string]): string = return b[0]
 
-proc p(a, b: openarray[string]): int =
+proc p(a, b: openArray[string]): int =
   result = a.len + b.len - 1
   for j in 0 .. a.len: inc(result)
   discard choose(a)

--- a/tests/openarray/tptrarrayderef.nim
+++ b/tests/openarray/tptrarrayderef.nim
@@ -15,14 +15,14 @@ var
   raa = [11,12,13]
 
 #bug #3586
-proc mutate[T](arr:openarray[T], brr: openArray[T]) =
+proc mutate[T](arr:openArray[T], brr: openArray[T]) =
   for i in 0..arr.len-1:
     doAssert(arr[i] == brr[i])
 
 mutate(arr, arr)
 
 #bug #2240
-proc f(a: openarray[int], b: openArray[int]) =
+proc f(a: openArray[int], b: openArray[int]) =
   for i in 0..a.len-1:
    doAssert(a[i] == b[i])
 
@@ -37,7 +37,7 @@ ra[2] = 13
 f(ra[], raa)
 
 #bug #2240b
-proc fillBuffer(buf: var openarray[char]) =
+proc fillBuffer(buf: var openArray[char]) =
   for i in 0..buf.len-1:
     buf[i] = chr(i)
 

--- a/tests/overload/toverload_various.nim
+++ b/tests/overload/toverload_various.nim
@@ -264,8 +264,8 @@ proc init*[T](hmctx: HMAC[T], key: ptr byte, ulen: uint) =
   const sizeBlock = hmctx.sizeBlock
   echo sizeBlock
 
-proc hmac*[A, B](HashType: typedesc, key: openarray[A],
-                 data: openarray[B]) =
+proc hmac*[A, B](HashType: typedesc, key: openArray[A],
+                 data: openArray[B]) =
   var ctx: HMAC[HashType]
   ctx.init(nil, 0)
 

--- a/tests/showoff/tdrdobbs_examples.nim
+++ b/tests/showoff/tdrdobbs_examples.nim
@@ -40,12 +40,12 @@ const msb3999 = mostSignificantBit(3999)
 
 echo msb3999, " ", mostSignificantBit(0), " ", square(44)
 
-proc filter[T](a: openarray[T], predicate: proc (x: T): bool): seq[T] =
+proc filter[T](a: openArray[T], predicate: proc (x: T): bool): seq[T] =
   result = @[] # @[] constructs the empty seq
   for x in a:
     if predicate(x): result.add(x)
 
-proc map[T, S](a: openarray[T], fn: proc (x: T): S): seq[S] =
+proc map[T, S](a: openArray[T], fn: proc (x: T): S): seq[S] =
   newSeq(result, a.len)
   for i in 0 ..< a.len: result[i] = fn(a[i])
 

--- a/tests/stdlib/tdochelpers.nim
+++ b/tests/stdlib/tdochelpers.nim
@@ -82,7 +82,7 @@ suite "Integration with Nim":
                               name: "binarysearch",
                               generics: "[T,K]",
                               parameters: @[
-                                ("a", "openarray[T]"),
+                                ("a", "openArray[T]"),
                                 ("key", "K"),
                                 ("cmp", "proc(x:T;y:K):int")],
                               parametersProvided: true,
@@ -96,7 +96,7 @@ suite "Integration with Nim":
                               name: "binarysearch",
                               generics: "[T,K]",
                               parameters: @[
-                                ("a", "openarray[T]"),
+                                ("a", "openArray[T]"),
                                 ("key", "K"),
                                 ("cmp", "proc(x:T;y:K):int")],
                               parametersProvided: true,
@@ -111,7 +111,7 @@ suite "Integration with Nim":
     let expected = LangSymbol(symKind: "func",
                               name: "$",
                               generics: "[T]",
-                              parameters: @[("a", "openarray[T]")],
+                              parameters: @[("a", "openArray[T]")],
                               parametersProvided: true,
                               outType: "string")
     check(input1.toLangSymbol == expected)
@@ -125,7 +125,7 @@ suite "Integration with Nim":
     let expected = LangSymbol(symKind: "func",
                               name: "[]",
                               generics: "[T]",
-                              parameters: @[("a", "openarray[T]"),
+                              parameters: @[("a", "openArray[T]"),
                                             ("idx", "int")],
                               parametersProvided: true,
                               outType: "T")
@@ -147,7 +147,7 @@ suite "Integration with Nim":
     let expected = LangSymbol(symKind: "func",
                               name: "[]",
                               generics: "[T]",
-                              parameters: @[("a", "openarray[T]"),
+                              parameters: @[("a", "openArray[T]"),
                                             ("idx", "int")],
                               parametersProvided: true,
                               outType: "T")

--- a/tests/stdlib/tdochelpers.nim
+++ b/tests/stdlib/tdochelpers.nim
@@ -76,13 +76,13 @@ suite "Integration with Nim":
     check(input3.toLangSymbol == expected)
 
   test "advanced proc parsing with Nim identifier normalization":
-    let input = """`proc binarySearch*[T, K](a: openArray[T]; key: K;
+    let input = """`proc binarySearch*[T, K](a: openarray[T]; key: K;
                     cmp: proc (x: T; y: K): int)`_""".rstParseTest
     let expected = LangSymbol(symKind: "proc",
                               name: "binarysearch",
                               generics: "[T,K]",
                               parameters: @[
-                                ("a", "openArray[T]"),
+                                ("a", "openarray[T]"),
                                 ("key", "K"),
                                 ("cmp", "proc(x:T;y:K):int")],
                               parametersProvided: true,
@@ -90,13 +90,13 @@ suite "Integration with Nim":
     check(input.toLangSymbol == expected)
 
   test "the same without proc":
-    let input = """`binarySearch*[T, K](a: openArray[T]; key: K;
+    let input = """`binarySearch*[T, K](a: openarray[T]; key: K;
                     cmp: proc (x: T; y: K): int {.closure.})`_""".rstParseTest
     let expected = LangSymbol(symKind: "",
                               name: "binarysearch",
                               generics: "[T,K]",
                               parameters: @[
-                                ("a", "openArray[T]"),
+                                ("a", "openarray[T]"),
                                 ("key", "K"),
                                 ("cmp", "proc(x:T;y:K):int")],
                               parametersProvided: true,
@@ -111,7 +111,7 @@ suite "Integration with Nim":
     let expected = LangSymbol(symKind: "func",
                               name: "$",
                               generics: "[T]",
-                              parameters: @[("a", "openArray[T]")],
+                              parameters: @[("a", "openarray[T]")],
                               parametersProvided: true,
                               outType: "string")
     check(input1.toLangSymbol == expected)
@@ -125,7 +125,7 @@ suite "Integration with Nim":
     let expected = LangSymbol(symKind: "func",
                               name: "[]",
                               generics: "[T]",
-                              parameters: @[("a", "openArray[T]"),
+                              parameters: @[("a", "openarray[T]"),
                                             ("idx", "int")],
                               parametersProvided: true,
                               outType: "T")
@@ -147,7 +147,7 @@ suite "Integration with Nim":
     let expected = LangSymbol(symKind: "func",
                               name: "[]",
                               generics: "[T]",
-                              parameters: @[("a", "openArray[T]"),
+                              parameters: @[("a", "openarray[T]"),
                                             ("idx", "int")],
                               parametersProvided: true,
                               outType: "T")

--- a/tests/stdlib/tparseipv6.nim
+++ b/tests/stdlib/tparseipv6.nim
@@ -210,12 +210,12 @@ const
     "::a:b:85:e4d9:252.9.229.056",
   ]
 
-proc ok(pos: openarray[string]) =
+proc ok(pos: openArray[string]) =
   for p in pos:
     if not isIpAddress(p):
       echo "failure ", p
 
-proc notok(neg: openarray[string]) =
+proc notok(neg: openArray[string]) =
   for n in neg:
     if isIpAddress(n):
       echo "failure ", n

--- a/tests/stdlib/trepr.nim
+++ b/tests/stdlib/trepr.nim
@@ -64,7 +64,7 @@ template main() =
   doAssert repr(arr) == "[1, 2, 3]"
 
   block: # bug #7878
-    proc reprOpenarray(variable: var openarray[int]): string = repr(variable)
+    proc reprOpenarray(variable: var openArray[int]): string = repr(variable)
     when defined(js): discard # BUG: doesn't work
     else:
       doAssert reprOpenarray(arr) == "[1, 2, 3]"

--- a/tests/system/tostring.nim
+++ b/tests/system/tostring.nim
@@ -68,7 +68,7 @@ doAssert yy == ""
 proc bar(arg: cstring) =
   doAssert arg[0] == '\0'
 
-proc baz(arg: openarray[char]) =
+proc baz(arg: openArray[char]) =
   doAssert arg.len == 0
 
 proc stringCompare() =

--- a/tests/system/tsystem_misc.nim
+++ b/tests/system/tsystem_misc.nim
@@ -131,12 +131,12 @@ let str = "0123456789"
 foo(toOpenArrayByte(str, 0, str.high))
 
 
-template boundedOpenArray[T](x: seq[T], first, last: int): openarray[T] =
+template boundedOpenArray[T](x: seq[T], first, last: int): openArray[T] =
   toOpenarray(x, max(0, first), min(x.high, last))
 
 # bug #9281
 
-proc foo[T](x: openarray[T]) =
+proc foo[T](x: openArray[T]) =
   echo x.len
 
 let a = @[1, 2, 3]

--- a/tests/template/otests.nim
+++ b/tests/template/otests.nim
@@ -163,7 +163,7 @@ when true: #embeddingTest
     """
 
     # Expression template
-    proc test_expression(nums: openarray[int] = []): string =
+    proc test_expression(nums: openArray[int] = []): string =
         var i = 2
         tmpli html"""
             $(no_substitution())
@@ -171,7 +171,7 @@ when true: #embeddingTest
             <div id="age">Age: $($nums[i] & "!!")</div>
         """
 
-    proc test_statements(nums: openarray[int] = []): string =
+    proc test_statements(nums: openArray[int] = []): string =
         tmpli html"""
             $(test_expression(nums))
             $if true {

--- a/tests/template/sunset.nimf
+++ b/tests/template/sunset.nimf
@@ -1,6 +1,6 @@
 #? stdtmpl
 #proc sunsetTemplate*(current, ticker, content: string,
-#                     tabs: openarray[array[0..1, string]]): string = 
+#                     tabs: openArray[array[0..1, string]]): string = 
 #  result = ""
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">

--- a/tests/template/template_issues.nim
+++ b/tests/template/template_issues.nim
@@ -173,7 +173,7 @@ block t2585:
       st
       echo "a ", $fb
 
-  proc render(rdat: var RenderData; passes: var openarray[RenderPass]; proj: Mat2;
+  proc render(rdat: var RenderData; passes: var openArray[RenderPass]; proj: Mat2;
               indexType = 1) =
       for i in 0 ..< len(passes):
           echo "blah ", repr(passes[i])

--- a/tests/tuples/tuple_with_nil.nim
+++ b/tests/tuples/tuple_with_nil.nim
@@ -477,7 +477,7 @@ proc writeformat(o: var Writer; b: bool; fmt: Format) =
   else:
     raise newException(FormatError, "Boolean values must of one of the following types: s,b,o,x,X,d,n")
 
-proc writeformat(o: var Writer; ary: openarray[system.any]; fmt: Format) =
+proc writeformat(o: var Writer; ary: openArray[system.any]; fmt: Format) =
   ## Write array `ary` according to format `fmt` using output object
   ## `o` and output function `add`.
   if ary.len == 0: return
@@ -657,7 +657,7 @@ proc literal[T](x: T): NimNode {.compiletime, nosideeffect.} =
     result = newLit(x)
 
 proc generatefmt(fmtstr: string;
-                 args: var openarray[tuple[arg:NimNode, cnt:int]];
+                 args: var openArray[tuple[arg:NimNode, cnt:int]];
                  arg: var int;): seq[tuple[val, fmt:NimNode]] {.compiletime.} =
   ## fmtstr
   ##   the format string

--- a/tests/typerel/tcommontype.nim
+++ b/tests/typerel/tcommontype.nim
@@ -12,7 +12,7 @@ type
 
 proc newDog():PDog = new(result)
 proc newCat():PCat = new(result)
-proc test(a:openarray[PAnimal])=
+proc test(a:openArray[PAnimal])=
   echo("dummy")
 
 #test(newDog(),newCat()) #does not work

--- a/tests/typerel/texplicitcmp.nim
+++ b/tests/typerel/texplicitcmp.nim
@@ -8,7 +8,7 @@ discard """
 
 import json, tables, algorithm
 
-proc outp(a: openarray[int]) =
+proc outp(a: openArray[int]) =
   stdout.write "["
   for i in a: stdout.write($i & " ")
   stdout.write "]\n"

--- a/tests/typerel/tstr_as_openarray.nim
+++ b/tests/typerel/tstr_as_openarray.nim
@@ -3,18 +3,18 @@ discard """
 """
 var s = "HI"
 
-proc x (zz: openarray[char]) =
+proc x (zz: openArray[char]) =
   discard
 
 x s
 
-proc z [T] (zz: openarray[T]) =
+proc z [T] (zz: openArray[T]) =
   discard
 
 z s
 z([s,s,s])
 
-proc y [T] (arg: var openarray[T]) =
+proc y [T] (arg: var openArray[T]) =
   arg[0] = 'X'
 y s
 doAssert s == "XI"

--- a/tests/views/tviews1.nim
+++ b/tests/views/tviews1.nim
@@ -44,7 +44,7 @@ echo foo(x)
 
 type
   F = object
-    oa: openarray[int]
+    oa: openArray[int]
 
 let s1 = @[1,3,4,5,6]
 var test = F(oa: toOpenArray(s1, 0, 2))

--- a/tests/vm/tyaytypedesc.nim
+++ b/tests/vm/tyaytypedesc.nim
@@ -10,7 +10,7 @@ type NodeType* = enum
 type TokenType* = enum
   ttWhitespace
 
-proc enumTable*[A, B, C](a: openarray[tuple[key: A, val: B]], ret: typedesc[C]): C =
+proc enumTable*[A, B, C](a: openArray[tuple[key: A, val: B]], ret: typedesc[C]): C =
   for item in a:
     result[item.key] = item.val
 


### PR DESCRIPTION
Otherwise, tests cannot pass `--style:usages --style:errors`

ref https://github.com/nim-lang/Nim/pull/19319

Or should `openarray` be treated differently under usages check?