### PR TITLE
Fix #19326 - fixing recvFrom

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1628,7 +1628,7 @@ proc recvFrom*[T: string | IpAddress](socket: Socket, data: var string, length: 
   ##   used. Therefore if `socket` contains something in its buffer this
   ##   function will make no effort to return it.
   template adaptRecvFromToDomain(sockAddress: untyped, domain: Domain) =
-    var addrLen = sizeof(sockAddress).SockLen
+    var addrLen = SockLen(sizeof(sockAddress))
     result = recvfrom(socket.fd, cstring(data), length.cint, flags.cint,
                       cast[ptr SockAddr](addr(sockAddress)), addr(addrLen))
 


### PR DESCRIPTION
For some unknown reason the Nim compiler is assuming that the cast from `int` to `SockLen`, via dot notation, is an access of some field of an object. Does this compiler issue need further investigation?

Fix #19326 partly