### PR TITLE
Fix #19038 - making the Nim compiler work again on Windows XP

### DIFF
--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -45,7 +45,7 @@ when not defined(nimscript):
     proc c_getenv(env: cstring): cstring {.
       importc: "getenv", header: "<stdlib.h>".}
     when defined(windows):
-      proc c_putenv_s(envname: cstring, envval: cstring): cint {.importc: "_putenv_s", header: "<stdlib.h>".}
+      proc c_putenv(envstring: cstring): cint {.importc: "_putenv", header: "<stdlib.h>".}
       from std/private/win_setenv import setEnvImpl
     else:
       proc c_setenv(envname: cstring, envval: cstring, overwrite: cint): cint {.importc: "setenv", header: "<stdlib.h>".}
@@ -121,7 +121,8 @@ when not defined(nimscript):
         ]#
         if key.len == 0 or '=' in key:
           raise newException(OSError, "invalid key, got: " & key)
-        if c_putenv_s(key, "") != 0'i32: bail
+        let envToDel: cstring = key & "="
+        if c_putenv(envToDel) != 0'i32: bail
       else:
         if c_unsetenv(key) != 0'i32: bail
 

--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -121,7 +121,7 @@ when not defined(nimscript):
         ]#
         if key.len == 0 or '=' in key:
           raise newException(OSError, "invalid key, got: " & key)
-        let envToDel: cstring = key & "="
+        let envToDel = key & "="
         if c_putenv(envToDel) != 0'i32: bail
       else:
         if c_unsetenv(key) != 0'i32: bail

--- a/lib/pure/includes/osenv.nim
+++ b/lib/pure/includes/osenv.nim
@@ -122,7 +122,7 @@ when not defined(nimscript):
         if key.len == 0 or '=' in key:
           raise newException(OSError, "invalid key, got: " & key)
         let envToDel = key & "="
-        if c_putenv(envToDel) != 0'i32: bail
+        if c_putenv(cstring envToDel) != 0'i32: bail
       else:
         if c_unsetenv(key) != 0'i32: bail
 


### PR DESCRIPTION
Fix #19038

The changes are:
- use of `_putenv` instead of `_putenv_s`.
- use of `mbstowcs` instead of `mbstowcs_s`.

The so-called "secure" versions are actually not necessary, in my opinion. To learn more about the security of `_s` functions, see [here](https://docs.microsoft.com/en-us/cpp/c-runtime-library/security-features-in-the-crt?view=msvc-170).

I looked in stdlib and the compiler for other "secures" functions for Windows and couldn't find it, other than `_vsnprintf_s` for the `bcc` backend.

So I see no reason not to use `_putenv` and `mbstowcs`, making the Nim compiler functional again on Windows XP. However, this is not to say that Nim passes all tests on that operating system.