### PR TITLE
Feature: add shorthand property name to `json`

### DIFF
--- a/tests/stdlib/tjsonmacro.nim
+++ b/tests/stdlib/tjsonmacro.nim
@@ -646,6 +646,19 @@ proc testJson() =
     ]
     doAssert (%* a).to(a.typeof) == a
 
+  block:
+    # shorthand property names
+    type
+      Person = object
+        name, address: string
+        number: int
+    let
+      name = "My Name"
+      address = "1 Sesame Street"
+      number = 1234567890
+      p = Person(name: name, address: address, number: number)
+    doAssert (%* {number, name, address}).to(Person) == p
+
 
 testJson()
 static:


### PR DESCRIPTION
The allows for `%*{a, b, c}` where `a`, `b` & `c` are variables and the
resulting json is equivalent to `%*{"a": a, "b": b, "c": c}`.

MDN docs https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#new_notations_in_ecmascript_2015