### PR TITLE
disable fragments

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -64,7 +64,7 @@ pkg "docopt"
 pkg "easygl", "nim c -o:egl -r src/easygl.nim", "https://github.com/jackmott/easygl"
 pkg "elvis"
 pkg "fidget"
-pkg "fragments", "nim c -r fragments/dsl.nim"
+pkg "fragments", "nim c -r fragments/dsl.nim", allowFailure = true # pending https://github.com/nim-lang/packages/issues/2115 
 pkg "fusion"
 pkg "gara"
 pkg "glob"


### PR DESCRIPTION
The original repo has moved to Rust (ref https://github.com/fragcolor-xyz/fragments), while the package path stay unchanged. And it causes troubles to https://github.com/nim-lang/Nim/pull/19338

See also https://github.com/nim-lang/packages/issues/2115