### PR TITLE
Fix `remove` on last node of singly-linked list [backport:1.6]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
 - `macros.parseExpr` and `macros.parseStmt` now accept an optional
   filename argument for more informative errors.
 - Module `colors` expanded with missing colors from the CSS color standard.
+- Fixed `lists.SinglyLinkedList` being broken after removing the last node ([#19353](https://github.com/nim-lang/Nim/pull/19353)).
 
 ## `std/smtp`
 

--- a/lib/pure/collections/lists.nim
+++ b/lib/pure/collections/lists.nim
@@ -739,6 +739,8 @@ proc remove*[T](L: var SinglyLinkedList[T], n: SinglyLinkedNode[T]): bool {.disc
     if prev.next == nil:
       return false
     prev.next = n.next
+    if L.tail == n:
+      L.tail = prev # update tail if we removed the last node
   true
 
 proc remove*[T](L: var DoublyLinkedList[T], n: DoublyLinkedNode[T]) =

--- a/tests/stdlib/tlists.nim
+++ b/tests/stdlib/tlists.nim
@@ -258,5 +258,18 @@ template main =
     a.add(2)
     doAssert a.toSeq == @[1, 2]
 
+  block RemoveLastNodeFromSinglyLinkedList:
+    var list = initSinglyLinkedList[string]()
+    let n1 = newSinglyLinkedNode("sonic")
+    let n2 = newSinglyLinkedNode("the")
+    let n3 = newSinglyLinkedNode("tiger")
+    let n4 = newSinglyLinkedNode("hedgehog")
+    list.add(n1)
+    list.add(n2)
+    list.add(n3)
+    list.remove(n3)
+    list.add(n4)
+    doAssert list.toSeq == @["sonic", "the", "hedgehog"]
+
 static: main()
 main()


### PR DESCRIPTION
Singly linked lists would break if you removed the last element, as the tail would continue to point to the element that was removed. This PR fixes the buggy behaviour and adds a test for it.

`remove` for singly-linked lists was introduced in 1.6.0 (https://github.com/nim-lang/Nim/pull/16536), so this needs to be backported to 1.6.