### PR TITLE
Improve Zshell completion

### DIFF
--- a/tools/nim.zsh-completion
+++ b/tools/nim.zsh-completion
@@ -1,150 +1,120 @@
 #compdef nim
 
+# Installation note:
+# Please name this file as _nim (with underscore!) and copy it to a
+# completions directory, either:
+# - system wide one, like /usr/share/zsh/functions/Completion/Unix/ on Linux
+# - or to a user directory like ~/scripts. Then you also need to add
+#   that directory in your ~/.zshrc to `fpath` array like so:
+#     fpath=( ~/scripts "${fpath[@]}" )
+
 _nim() {
-  _arguments -C \
-    ':command:((
-      {compile,c}\:compile\ project\ with\ default\ code\ generator\ C
-      doc\:generate\ the\ documentation\ for\ inputfile
-      {compileToC,cc}\:compile\ project\ with\ C\ code\ generator
-      {compileToCpp,cpp}\:compile\ project\ to\ C++\ code
-      {compileToOC,objc}\:compile\ project\ to\ Objective\ C\ code
-      js\:compile\ project\ to\ Javascript
-      e\:run\ a\ Nimscript\ file
-      rst2html\:convert\ a\ reStructuredText\ file\ to\ HTML
-      rst2tex\:convert\ a\ reStructuredText\ file\ to\ TeX
-      jsondoc\:extract\ the\ documentation\ to\ a\ json\ file
-      buildIndex\:build\ an\ index\ for\ the\ whole\ documentation
-      genDepend\:generate\ a\ DOT\ file\ containing\ the\ module\ dependency\ graph
-      dump\:dump\ all\ defined\ conditionals\ and\ search\ paths
-      check\:checks\ the\ project\ for\ syntax\ and\ semantic
-    ))' \
-    '*-r[run the application]' \
-    '*--run[run the application]' \
-    '*-p=[add path to search paths]' \
-    '*--path=[add path to search paths]' \
-    '*-d=[define a conditional symbol]' \
-    '*--define=[define a conditional symbol]' \
-    '*-u=[undefine a conditional symbol]' \
-    '*--undef=[undefine a conditional symbol]' \
-    '*-f[force rebuilding of all modules]' \
-    '*--forceBuild[force rebuilding of all modules]' \
-    '*--stackTrace=on[turn stack tracing on]' \
-    '*--stackTrace=off[turn stack tracing off]' \
-    '*--lineTrace=on[turn line tracing on]' \
-    '*--lineTrace=off[turn line tracing off]' \
-    '*--threads=on[turn support for multi-threading on]' \
-    '*--threads=off[turn support for multi-threading off]' \
-    '*-x=on[turn all runtime checks on]' \
-    '*-x=off[turn all runtime checks off]' \
-    '*--checks=on[turn all runtime checks on]' \
-    '*--checks=off[turn all runtime checks off]' \
-    '*--objChecks=on[turn obj conversion checks on]' \
-    '*--objChecks=off[turn obj conversion checks off]' \
-    '*--fieldChecks=on[turn case variant field checks on]' \
-    '*--fieldChecks=off[turn case variant field checks off]' \
-    '*--rangeChecks=on[turn range checks on]' \
-    '*--rangeChecks=off[turn range checks off]' \
-    '*--boundChecks=on[turn bound checks on]' \
-    '*--boundChecks=off[turn bound checks off]' \
-    '*--overflowChecks=on[turn int over-/underflow checks on]' \
-    '*--overflowChecks=off[turn int over-/underflow checks off]' \
-    '*-a[turn assertions on]' \
-    '*-a[turn assertions off]' \
-    '*--assertions=on[turn assertions on]' \
-    '*--assertions=off[turn assertions off]' \
-    '*--floatChecks=on[turn all floating point (NaN/Inf) checks on]' \
-    '*--floatChecks=off[turn all floating point (NaN/Inf) checks off]' \
-    '*--nanChecks=on[turn NaN checks on]' \
-    '*--nanChecks=off[turn NaN checks off]' \
-    '*--infChecks=on[turn Inf checks on]' \
-    '*--infChecks=off[turn Inf checks off]' \
-    '*--nilChecks=on[turn nil checks on]' \
-    '*--nilChecks=off[turn nil checks off]' \
-    '*--opt=none[do not optimize]' \
-    '*--opt=speed[optimize for speed|size - use -d:release for a release build]' \
-    '*--opt=size[optimize for size]' \
-    '*--debugger:native[use native debugger (gdb)]' \
-    '*--app=console[generate a console app]' \
-    '*--app=gui[generate a GUI app]' \
-    '*--app=lib[generate a dynamic library]' \
-    '*--app=staticlib[generate a static library]' \
-    '*--cpu=alpha[compile for Alpha architecture]' \
-    '*--cpu=amd64[compile for x86_64 architecture]' \
-    '*--cpu=arm[compile for ARM architecture]' \
-    '*--cpu=arm64[compile for ARM64 architecture]' \
-    '*--cpu=avr[compile for AVR architecture]' \
-    '*--cpu=esp[compile for ESP architecture]' \
-    '*--cpu=e2k[compile for Elbrus 2000 architecture]' \
-    '*--cpu=hppa[compile for HPPA architecture]' \
-    '*--cpu=i386[compile for i386 architecture]' \
-    '*--cpu=ia64[compile for ia64 architecture]' \
-    '*--cpu=js[compile to JavaScript]' \
-    '*--cpu=m68k[compile for m68k architecture]' \
-    '*--cpu=mips[compile for MIPS architecture]' \
-    '*--cpu=mipsel[compile for MIPS EL architecture]' \
-    '*--cpu=mips64[compile for MIPS64 architecture]' \
-    '*--cpu=mips64el[compile for MIPS64 EL architecture]' \
-    '*--cpu=msp430[compile for msp430 architecture]' \
-    '*--cpu=nimvm[compile for Nim VM]' \
-    '*--cpu=powerpc[compile for PowerPC architecture]' \
-    '*--cpu=powerpc64[compile for PowerPC64 architecture]' \
-    '*--cpu=powerpc64el[compile for PowerPC64 EL architecture]' \
-    '*--cpu=riscv32[compile for RISC-V 32 architecture]' \
-    '*--cpu=riscv64[compile for RISC-V 64 architecture]' \
-    '*--cpu=sparc[compile for SPARC architecture]' \
-    '*--cpu=sparc64[compile for SPARC64 architecture]' \
-    '*--cpu=vm[compile for Nim VM]' \
-    '*--cpu=wasm32[compile to WASM 32]' \
-    '*--cpu=loongarch64[compile for LoongArch64 architecture]' \
-    '*--gc=refc[use reference counting garbage collection]' \
-    '*--gc=arc[use ARC garbage collection]' \
-    '*--gc=orc[use ORC garbage collection]' \
-    '*--gc=markAndSweep[use mark-and-sweep garbage collection]' \
-    '*--gc=boehm[use Boehm garbage collection]' \
-    '*--gc=go[use Go garbage collection]' \
-    '*--gc=regions[use region-based memory management]' \
-    '*--gc=none[disable garbage collection]' \
-    '*--os=Standalone[generate a stand-alone executable]' \
-    '*--os=AIX[compile for AIX]' \
-    '*--os=Amiga[compile for Amiga OS]' \
-    '*--os=Android[compile for Android]' \
-    '*--os=Any[compile for any OS]' \
-    '*--os=Atari[compile for Atari]' \
-    '*--os=DOS[compile for DOS]' \
-    '*--os=DragonFly[compile for DragonFly]' \
-    '*--os=FreeBSD[compile for FreeBSD]' \
-    '*--os=FreeRTOS[compile for FreeRTOS]' \
-    '*--os=Genode[compile for Genode]' \
-    '*--os=Haiku[compile for Haiku]' \
-    '*--os=iOS[compile for iOS]' \
-    '*--os=Irix[compile for Irix]' \
-    '*--os=Linux[compile for Linux]' \
-    '*--os=MacOS[compile for MacOS]' \
-    '*--os=MacOSX[compile for MacOSX]' \
-    '*--os=MorphOS[compile for MorphOS]' \
-    '*--os=NetBSD[compile for NetBSD]' \
-    '*--os=Netware[compile for Netware]' \
-    '*--os=NimVM[compile for NimVM]' \
-    '*--os=NintendoSwitch[compile for NintendoSwitch]' \
-    '*--os=OS2[compile for OS2]' \
-    '*--os=OpenBSD[compile for OpenBSD]' \
-    '*--os=PalmOS[compile for PalmOS]' \
-    '*--os=QNX[compile for QNX]' \
-    '*--os=SkyOS[compile for SkyOS]' \
-    '*--os=Solaris[compile for Solaris]' \
-    '*--os=VxWorks[compile for VxWorks]' \
-    '*--os=Windows[compile for Windows]' \
-    '*--os=JS[generate javascript]' \
-    '*--panics=off[turn panics into process terminations: off by default]' \
-    '*--panics=on[turn panics into process terminations]' \
-    '*--verbosity=0[set verbosity to 0]' \
-    '*--verbosity=1[set verbosity to 1 (default)]' \
-    '*--verbosity=2[set verbosity to 2]' \
-    '*--verbosity=3[set verbosity to 3]' \
-    '*--hints=on[print compilation hints]' \
-    '*--hints=off[disable compilation hints]' \
-    '*--hints=list[print compilation hints list]' \
-    ':filename:_files -g"*.nim"'
+  local -a nimCommands=(
+    {compile,c}:'compile project with default code generator C'
+    {compileToC,cc}:'compile project with C code generator'
+    {compileToCpp,cpp}:'compile project to C++ code'
+    {compileToOC,objc}:'compile project to Objective C code'
+    'js:compile project to Javascript'
+    'e:run a Nimscript file'
+    'doc:generate the HTML documentation for inputfile'
+    'rst2html:convert a reStructuredText file to HTML'
+    'doc2tex:generate the documentation for inputfile to LaTeX'
+    'rst2tex:convert a reStructuredText file to TeX'
+    'jsondoc:extract the documentation to a json file'
+    'buildIndex:build an index for the whole documentation'
+    'genDepend:generate a DOT file containing the module dependency graph'
+    'dump:dump all defined conditionals and search paths'
+    'check:checks the project for syntax and semantic'
+    {--help,-h}:'basic help'
+    '--fullhelp:show all switches'
+    {-v,--version}:'show version'
+  )
+
+  _arguments '*:: :->anyState' && return 0
+
+  if (( CURRENT == 1 )); then
+    _describe -t commands "Nim commands" nimCommands -V1
+    return
+  fi
+
+  local -a conditionalSymbols=(
+    release danger mingw androidNDK useNimRtl useMalloc noSignalHandler ssl
+    debug leanCompiler gcDestructors)
+  local -a sharedOpts=(
+    {--define\\:-,-d\\:-}'[define a conditional symbol]:x:($conditionalSymbols)'
+    {--undef\\:-,-u\\:-}'[undefine a conditional symbol]:x:($conditionalSymbols)'
+    {--path\\:-,-p\\:-}'[add path to search paths]:x:_files'
+    '--verbosity\:-[set verbosity level (default\: 1)]:x:(0 1 2 3)'
+    '--hints\:-[print compilation hints? (or `list`)]:x:(on off list)'
+  )
+  local runOpts=(
+    {--run,-r}'[run the application]'
+  )
+  local docOpts=(
+    '--index\:-[enable index .idx files?]:x:(on off)'
+    '--project\:-[output any dependency for doc?]:x:(on off)'
+    '--docInternal\:-[generate module-private documentation?]:x:(on off)'
+  )
+  local -a codeOpts=(
+    {--forceBuild,-f}'[force rebuilding of all modules]'
+    '--stackTrace\:-[enable stack tracing?]:x:(on off)'
+    '--lineTrace\:-[enable line tracing?]:x:(on off)'
+    '--threads\:-[enable support for multi-threading?]:x:(on off)'
+    {--checks\\:-,-x\\:-}'[enable/disable all runtime checks?]:x:(on off)'
+    '--objChecks\:-[enable obj conversion checks]:x:(on off)'
+    '--fieldChecks\:-[enable case variant field checks?]:x:(on off)'
+    '--rangeChecks\:-[enable range checks?]:x:(on off)'
+    '--boundChecks\:-[enable bound checks?]:x:(on off)'
+    '--overflowChecks\:-[enable integer over-/underflow checks?]:x:(on off)'
+    {--assertions\\:-,-a\\:-}'[enable assertions?]:x:(on off)'
+    '--floatChecks\:-[enable floating point (NaN/Inf) checks?]:x:(on off)'
+    '--nanChecks\:-[enable NaN checks?]:x:(on off)'
+    '--infChecks\:-[enable Inf checks?]:x:(on off)'
+    '--nilChecks\:-[enable nil checks?]:x:(on off)'
+    '--expandArc\:-[show how given proc looks before final backend pass]'
+    '--expandMacro\:-[dump every generated AST from given macro]'
+  )
+  local -a nativeOpts=(
+    '--opt\:-[optimization mode]:x:(none speed size)'
+    '--debugger\:native[use native debugger (gdb)]'
+    '--app\:-[generate this type of app (lib=dynamic)]:x:(console gui lib staticlib)'
+    '--cpu\:-[target architecture]:x:(alpha amd64 arm arm64 avr e2k esp hppa i386 ia64 js loongarch64 m68k mips mipsel mips64 mips64el msp430 nimvm powerpc powerpc64 powerpc64el riscv32 riscv64 sparc sparc64 vm wasm32)'
+    '--gc\:-[memory management algorithm to use (default\: refc)]:x:(refc arc orc markAndSweep boehm go regions none)'
+    '--os\:-[operating system to compile for]:x:(AIX Amiga Android Any Atari DOS DragonFly FreeBSD FreeRTOS Genode Haiku iOS Irix JS Linux MacOS MacOSX MorphOS NetBSD Netware NimVM NintendoSwitch OS2 OpenBSD PalmOS Standalone QNX SkyOS Solaris VxWorks Windows)'
+    '--panics\:-[turn panics into process termination (default\: off)]:x:(off on)'
+  )
+
+  case "$words[1]" in
+    compile|c|compileToC|cpp|compileToCpp|compileToOC|objc)
+      _arguments $codeOpts $runOpts $sharedOpts $nativeOpts \
+          '*:filename:_files -g"*.nim"'
+    ;;
+    js)
+      _arguments $codeOpts $runOpts $sharedOpts \
+          '*:filename:_files -g"*.nim"'
+    ;;
+    e)
+      _arguments $codeOpts $runOpts $sharedOpts \
+          '*:filename:_files -g"*.nims"'
+    ;;
+    doc|doc2tex|jsondoc)
+      _arguments $runOpts $sharedOpts '*:filename:_files -g"*.nim"'
+    ;;
+    rst2html|rst2tex)
+      _arguments $runOpts $sharedOpts $docOpts '*:filename:_files -g"*.rst"'
+    ;;
+    buildIndex|genDepend|check)
+      _arguments $sharedOpts '*:filename:_files -g"*.nim"'
+    ;;
+    dump)
+      _arguments $sharedOpts
+    ;;
+    *)
+      _arguments '*:filename:_files -g"*"'
+    ;;
+  esac
+
+  return 1
 }
 
 _nim "$@"


### PR DESCRIPTION
Zsh completions have been reworked with these changes:

* file extension completion depending on command (\*nim/\*nims/\*rst)
* fix: complete files even after options were given (previously it proposed only option completions again)
* add options depending on commands (e.g. there is no sense to add `--cpu` for `nim doc`)
* use `:` instead of `=` (e.g. `-d:variable` instead of `-d=variable`)
* also for commands like `--panics` possible values are not displayed initially, but instead appear in the completion after `--panics=<TAB>` is input
* add some common conditional symbols for `-d:` like `-d:release`
* added completions: `doc2tex`
* add `--version`, `--help`, `--expandArc`, etc
* add `--docInternal`, `--index`, `--project` for doc\* commands
* more DRY/concise definitions
* add an installation note

cc @FedericoCeratto 