### PR TITLE
remove spaces between an identifier and a star

### DIFF
--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -163,28 +163,28 @@ macro jsFromAst*(n: untyped): untyped =
 proc `&`*(a, b: cstring): cstring {.importjs: "(# + #)".}
   ## Concatenation operator for JavaScript strings.
 
-proc `+`  *(x, y: JsObject): JsObject {.importjs: "(# + #)".}
-proc `-`  *(x, y: JsObject): JsObject {.importjs: "(# - #)".}
-proc `*`  *(x, y: JsObject): JsObject {.importjs: "(# * #)".}
-proc `/`  *(x, y: JsObject): JsObject {.importjs: "(# / #)".}
-proc `%`  *(x, y: JsObject): JsObject {.importjs: "(# % #)".}
-proc `+=` *(x, y: JsObject): JsObject {.importjs: "(# += #)", discardable.}
-proc `-=` *(x, y: JsObject): JsObject {.importjs: "(# -= #)", discardable.}
-proc `*=` *(x, y: JsObject): JsObject {.importjs: "(# *= #)", discardable.}
-proc `/=` *(x, y: JsObject): JsObject {.importjs: "(# /= #)", discardable.}
-proc `%=` *(x, y: JsObject): JsObject {.importjs: "(# %= #)", discardable.}
-proc `++` *(x:    JsObject): JsObject {.importjs: "(++#)".}
-proc `--` *(x:    JsObject): JsObject {.importjs: "(--#)".}
-proc `>`  *(x, y: JsObject): JsObject {.importjs: "(# > #)".}
-proc `<`  *(x, y: JsObject): JsObject {.importjs: "(# < #)".}
-proc `>=` *(x, y: JsObject): JsObject {.importjs: "(# >= #)".}
-proc `<=` *(x, y: JsObject): JsObject {.importjs: "(# <= #)".}
-proc `**` *(x, y: JsObject): JsObject {.importjs: "((#) ** #)".}
+proc `+`*(x, y: JsObject): JsObject {.importjs: "(# + #)".}
+proc `-`*(x, y: JsObject): JsObject {.importjs: "(# - #)".}
+proc `*`*(x, y: JsObject): JsObject {.importjs: "(# * #)".}
+proc `/`*(x, y: JsObject): JsObject {.importjs: "(# / #)".}
+proc `%`*(x, y: JsObject): JsObject {.importjs: "(# % #)".}
+proc `+=`*(x, y: JsObject): JsObject {.importjs: "(# += #)", discardable.}
+proc `-=`*(x, y: JsObject): JsObject {.importjs: "(# -= #)", discardable.}
+proc `*=`*(x, y: JsObject): JsObject {.importjs: "(# *= #)", discardable.}
+proc `/=`*(x, y: JsObject): JsObject {.importjs: "(# /= #)", discardable.}
+proc `%=`*(x, y: JsObject): JsObject {.importjs: "(# %= #)", discardable.}
+proc `++`*(x:    JsObject): JsObject {.importjs: "(++#)".}
+proc `--`*(x:    JsObject): JsObject {.importjs: "(--#)".}
+proc `>`*(x, y: JsObject): JsObject {.importjs: "(# > #)".}
+proc `<`*(x, y: JsObject): JsObject {.importjs: "(# < #)".}
+proc `>=`*(x, y: JsObject): JsObject {.importjs: "(# >= #)".}
+proc `<=`*(x, y: JsObject): JsObject {.importjs: "(# <= #)".}
+proc `**`*(x, y: JsObject): JsObject {.importjs: "((#) ** #)".}
   # (#) needed, refs https://github.com/nim-lang/Nim/pull/16409#issuecomment-760550812
 proc `and`*(x, y: JsObject): JsObject {.importjs: "(# && #)".}
-proc `or` *(x, y: JsObject): JsObject {.importjs: "(# || #)".}
+proc `or`*(x, y: JsObject): JsObject {.importjs: "(# || #)".}
 proc `not`*(x:    JsObject): JsObject {.importjs: "(!#)".}
-proc `in` *(x, y: JsObject): JsObject {.importjs: "(# in #)".}
+proc `in`*(x, y: JsObject): JsObject {.importjs: "(# in #)".}
 
 proc `[]`*(obj: JsObject, field: cstring): JsObject {.importjs: getImpl.}
   ## Returns the value of a property of name `field` from a JsObject `obj`.


### PR DESCRIPTION
It makes search easier by searching `+`* instead of `+` which filter lots of unexported versions.

Follow https://github.com/nim-lang/Nim/pull/18681