### PR TITLE
let `nimscript` ignore the threads option

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -717,7 +717,7 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "linedir": processOnOffSwitch(conf, {optLineDir}, arg, pass, info)
   of "assertions", "a": processOnOffSwitch(conf, {optAssert}, arg, pass, info)
   of "threads":
-    if conf.backend == backendJs: discard
+    if conf.backend == backendJs or conf.cmd == cmdNimscript: discard
     else: processOnOffSwitchG(conf, {optThreads}, arg, pass, info)
     #if optThreads in conf.globalOptions: conf.setNote(warnGcUnsafe)
   of "tlsemulation": processOnOffSwitchG(conf, {optTlsEmulation}, arg, pass, info)


### PR DESCRIPTION
because nimscript doesn't support threads and causes troubles when the threads option is on

ref https://github.com/nim-lang/Nim/pull/19368


An example

# test.nims
```nim
var t: Thread[void]
createThread(t, proc () = echo 123)
```

`nim e --threads:on test.nims` gives `Error: undeclared identifier: 'Thread'`.