### PR TITLE
Show better error message for invalid operation to stream

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -229,6 +229,8 @@ proc peekExitCode*(p: Process): int {.rtl, extern: "nosp$1", tags: [].}
 proc inputStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [].}
   ## Returns ``p``'s input stream for writing to.
   ##
+  ## You cannot perform peek/read/setPosition/getPosition operations to this stream.
+  ##
   ## .. warning:: The returned `Stream` should not be closed manually as it
   ##   is closed when closing the Process ``p``.
   ##
@@ -239,7 +241,7 @@ proc inputStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [].}
 proc outputStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [].}
   ## Returns ``p``'s output stream for reading from.
   ##
-  ## You cannot perform peek/write/setOption operations to this stream.
+  ## You cannot perform peek/write/setPosition/getPosition operations to this stream.
   ## Use `peekableOutputStream proc <#peekableOutputStream,Process>`_
   ## if you need to peek stream.
   ##
@@ -253,7 +255,7 @@ proc outputStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [].}
 proc errorStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [].}
   ## Returns ``p``'s error stream for reading from.
   ##
-  ## You cannot perform peek/write/setOption operations to this stream.
+  ## You cannot perform peek/write/setPosition/getPosition operations to this stream.
   ## Use `peekableErrorStream proc <#peekableErrorStream,Process>`_
   ## if you need to peek stream.
   ##
@@ -267,7 +269,8 @@ proc errorStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [].}
 proc peekableOutputStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [], since: (1, 3).}
   ## Returns ``p``'s output stream for reading from.
   ##
-  ## You can peek returned stream.
+  ## You can peek returned stream, but cannot perform
+  ## peekLine/write/setPosition/getPosition operations.
   ##
   ## .. warning:: The returned `Stream` should not be closed manually as it
   ##   is closed when closing the Process ``p``.
@@ -279,7 +282,8 @@ proc peekableOutputStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: []
 proc peekableErrorStream*(p: Process): Stream {.rtl, extern: "nosp$1", tags: [], since: (1, 3).}
   ## Returns ``p``'s error stream for reading from.
   ##
-  ## You can run peek operation to returned stream.
+  ## You can peek returned stream, but cannot perform
+  ## peekLine/write/setPosition/getPosition operations.
   ##
   ## .. warning:: The returned `Stream` should not be closed manually as it
   ##   is closed when closing the Process ``p``.
@@ -1487,7 +1491,7 @@ elif not defined(useNimRtl):
                     fileMode: FileMode): owned FileStream =
     var f: File
     if not open(f, handle, fileMode): raiseOSError(osLastError())
-    return newFileStream(f)
+    return newFileStream(f, false)
 
   proc inputStream(p: Process): Stream =
     streamAccess(p)

--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -199,6 +199,7 @@ proc setPosition*(s: Stream, pos: int) =
     doAssert strm.readLine() == "The first line"
     strm.close()
 
+  assert s.setPositionImpl != nil, "You cannot use setPosition to this Stream"
   s.setPositionImpl(s, pos)
 
 proc getPosition*(s: Stream): int =
@@ -210,6 +211,7 @@ proc getPosition*(s: Stream): int =
     doAssert strm.getPosition() == 15
     strm.close()
 
+  assert s.getPositionImpl != nil, "You cannot use getPosition to this Stream"
   result = s.getPositionImpl(s)
 
 proc readData*(s: Stream, buffer: pointer, bufLen: int): int =
@@ -1322,8 +1324,10 @@ proc fsWriteData(s: Stream, buffer: pointer, bufLen: int) =
 proc fsReadLine(s: Stream, line: var string): bool =
   result = readLine(FileStream(s).f, line)
 
-proc newFileStream*(f: File): owned FileStream =
+proc newFileStream*(f: File; isSeekable = true): owned FileStream =
   ## Creates a new stream from the file `f`.
+  ##
+  ## Set `isSeekable` to false if `f` is a file you cannot seek.
   ##
   ## **Note:** Not available for JS backend.
   ##
@@ -1356,8 +1360,9 @@ proc newFileStream*(f: File): owned FileStream =
   result.f = f
   result.closeImpl = fsClose
   result.atEndImpl = fsAtEnd
-  result.setPositionImpl = fsSetPosition
-  result.getPositionImpl = fsGetPosition
+  if isSeekable:
+    result.setPositionImpl = fsSetPosition
+    result.getPositionImpl = fsGetPosition
   result.readDataStrImpl = fsReadDataStr
   result.readDataImpl = fsReadData
   result.readLineImpl = fsReadLine


### PR DESCRIPTION
Calling `setPosition`/`getPosition` to a pipe stream shows runtime error message "You cannot use setPosition to this Stream" rather than "SIGSEGV: Illegal storage access. (Attempt to readfrom nil?)".
Reading or peeking to `inputStream` in osproc module shows runtime error message "You cannot read/peek from this stream".
Writing to `outputStream`, `errorStream`, `peekableOutputStream`, and `peekableErrorStream` in osproc module shows runtime error message.
Writing to a file stream with `fmRead` and reading to a file stream with `fmWrite` shows runtime error message.

You cannot seek for pipe:
https://man7.org/linux/man-pages/man2/lseek.2.html

On windows, `Stream.setPositionImpl` and `Stream.getPositionImpl` of `inputStream`, `outputStream` and `errorStream` are nil.
As `setPosition(s: Stream, pos: int)` and `getPosition*(s: Stream): int` don't check nil, calling them to `inputStream` just cause SIGSEGV.
On other OS, `Stream.setPositionImpl` and `Stream.getPositionImpl` of `input/output/errorStream` are set while they are error.

Reading from `stdin` or writing to `stdout` of child process using pipe is meaningless.

Detecting these invalid procedure call to the pipe at compile time would be better, but I don't think that is possible with exising `Stream`.
It would requires generic Stream type like this:
```nim
type
  StreamOption* = enum
    soReadable,
    soWritable,
    soSeekable,
    soPeekable

  Stream*[SO: static[set[StreamOption]]] = ref StreamObj
  StreamObj = object

proc setPosition*[SO: static[set[StreamOption]]](s: Stream[SO], pos: int) =
  when soSeekable notin SO:
    {.fatal: "You cannot use setPosition to this stream".}
```

So set procedural types of `Stream` to nil if it should not be called and check if it is nil with `assert` when it is going to be called.