### PR TITLE
docs: Mention `import foo {.all.}` syntax

### DIFF
--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -168,6 +168,17 @@ This feature will likely be superseded in the future by support for
 recursive module dependencies.
 
 
+Importing private symbols
+=========================
+
+In some situations, it may be useful to import all symbols (public or private)
+from a module. The syntax `import foo {.all.}` can be used to import all
+symbols from the module `foo`. Note that importing private symbols is
+generally not recommended.
+
+See also the experimental `importutils <importutils.html>`_ module.
+
+
 Code reordering
 ===============
 


### PR DESCRIPTION
Mention the `import foo {.all.}` syntax in the manual,
with a caveat about private imports.
Also link to the experimental importutils module.