### PR TITLE
docs: Fix broken cross references to `rfind` in strutils

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -1865,7 +1865,7 @@ func find*(s: string, sub: char, start: Natural = 0, last = 0): int {.rtl,
   ## Use `s[start..last].rfind` for a `start`-origin index.
   ##
   ## See also:
-  ## * `rfind func<#rfind,string,char,Natural>`_
+  ## * `rfind func<#rfind,string,char,Natural,int>`_
   ## * `replace func<#replace,string,char,char>`_
   let last = if last == 0: s.high else: last
   when nimvm:
@@ -1893,7 +1893,7 @@ func find*(s: string, chars: set[char], start: Natural = 0, last = 0): int {.
   ## Use `s[start..last].find` for a `start`-origin index.
   ##
   ## See also:
-  ## * `rfind func<#rfind,string,set[char],Natural>`_
+  ## * `rfind func<#rfind,string,set[char],Natural,int>`_
   ## * `multiReplace func<#multiReplace,string,varargs[]>`_
   let last = if last == 0: s.high else: last
   for i in int(start)..last:
@@ -1910,7 +1910,7 @@ func find*(s, sub: string, start: Natural = 0, last = 0): int {.rtl,
   ## Use `s[start..last].find` for a `start`-origin index.
   ##
   ## See also:
-  ## * `rfind func<#rfind,string,string,Natural>`_
+  ## * `rfind func<#rfind,string,string,Natural,int>`_
   ## * `replace func<#replace,string,string,string>`_
   if sub.len > s.len - start: return -1
   if sub.len == 1: return find(s, sub[0], start, last)


### PR DESCRIPTION
Fixes three broken cross references to `rfind` in strutils.
Breakage due to signature changes of the `rfind` methods.