### PR TITLE
enable `-d:nimPreviewFloatRoundtrip`

### DIFF
--- a/config/config.nims
+++ b/config/config.nims
@@ -16,3 +16,5 @@ when defined(nimStrictMode):
     # future work: XDeclaredButNotUsed
 
 switch("define", "nimVersion:" & NimVersion)
+switch("define", "nimPreviewFloatRoundtrip")
+switch("define", "nimPreviewDotLikeOps")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -36,6 +36,5 @@ switch("define", "nimExperimentalAsyncjsThen")
 switch("define", "nimExperimentalLinenoiseExtra")
 
 # preview APIs are expected to be the new default in upcoming versions
-switch("define", "nimPreviewFloatRoundtrip")
 switch("define", "nimPreviewJsonutilsHoleyEnum")
 switch("define", "nimPreviewHashRef")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -36,7 +36,5 @@ switch("define", "nimExperimentalAsyncjsThen")
 switch("define", "nimExperimentalLinenoiseExtra")
 
 # preview APIs are expected to be the new default in upcoming versions
-switch("define", "nimPreviewFloatRoundtrip")
-switch("define", "nimPreviewDotLikeOps")
 switch("define", "nimPreviewJsonutilsHoleyEnum")
 switch("define", "nimPreviewHashRef")

--- a/tests/stdlib/texperimental.nim
+++ b/tests/stdlib/texperimental.nim
@@ -1,0 +1,2 @@
+doAssert defined(nimPreviewFloatRoundtrip)
+doAssert defined(nimPreviewDotLikeOps)


### PR DESCRIPTION
The test intends to find whether -d:nimPreviewFloatRoundtrip and -d:nimPreviewDotLikeOps work for important packages etc.

ref https://github.com/nim-lang/RFCs/issues/437