### PR TITLE
Optimize lent in JS [backport:1.6]

### DIFF
--- a/tests/js/tlent.nim
+++ b/tests/js/tlent.nim
@@ -1,0 +1,44 @@
+discard """
+  output: '''
+hmm
+100
+hmm
+100
+'''
+"""
+
+# #16800
+
+type A = object
+  b: int
+var t = A(b: 100)
+block:
+  proc getValues: lent int =
+    echo "hmm"
+    result = t.b
+  echo getValues()
+block:
+  proc getValues: lent int =
+    echo "hmm"
+    t.b
+  echo getValues()
+
+# #16073
+
+proc byLent[T](a: T): lent T = a
+let b = @[21,23]
+proc isSame[T](a, b: T): bool {.importjs: "(# == #)".}
+doAssert isSame(byLent(b), b)
+
+let r = new(float)
+r[] = 10.0
+doAssert byLent[ref float](r)[] == 10.0
+
+when false: # still an issue, #16908
+  template main =
+    iterator fn[T](a:T): lent T = yield a
+    let a = @[10]
+    for b in fn(a): echo b
+
+  static: main()
+  main()

--- a/tests/js/tlent.nim
+++ b/tests/js/tlent.nim
@@ -23,17 +23,6 @@ block:
     t.b
   echo getValues()
 
-# #16073
-
-proc byLent[T](a: T): lent T = a
-let b = @[21,23]
-proc isSame[T](a, b: T): bool {.importjs: "(# == #)".}
-doAssert isSame(byLent(b), b)
-
-let r = new(float)
-r[] = 10.0
-doAssert byLent[ref float](r)[] == 10.0
-
 when false: # still an issue, #16908
   template main =
     iterator fn[T](a:T): lent T = yield a

--- a/tests/lent/tbasic_lent_check.nim
+++ b/tests/lent/tbasic_lent_check.nim
@@ -20,7 +20,7 @@ template main2 = # bug #15958
   when defined(js):
     proc sameAddress[T](a, b: T): bool {.importjs: "(# === #)".}
   else:
-    template sameAddress(a, b): bool = a.addr == b.addr
+    template sameAddress(a, b): bool = a.unsafeAddr == b.unsafeAddr
   proc byLent[T](a: T): lent T = a
   let a = [11,12]
   let b = @[21,23]

--- a/tests/lent/tbasic_lent_check.nim
+++ b/tests/lent/tbasic_lent_check.nim
@@ -17,22 +17,26 @@ proc main =
 main()
 
 template main2 = # bug #15958
+  when defined(js):
+    proc sameAddress[T](a, b: T): bool {.importjs: "(# === #)".}
+  else:
+    template sameAddress(a, b): bool = a.addr == b.addr
   proc byLent[T](a: T): lent T = a
   let a = [11,12]
   let b = @[21,23]
   let ss = {1, 2, 3, 5}
   doAssert byLent(a) == [11,12]
-  doAssert byLent(a).addr == a.addr
+  doAssert sameAddress(byLent(a), a)
   doAssert byLent(b) == @[21,23]
-  when not defined(js): # pending bug #16073
-    doAssert byLent(b).addr == b.addr
+  # pending bug #16073
+  doAssert sameAddress(byLent(b), b)
   doAssert byLent(ss) == {1, 2, 3, 5}
-  doAssert byLent(ss).addr == ss.addr
+  doAssert sameAddress(byLent(ss), ss)
 
   let r = new(float)
   r[] = 10.0
-  when not defined(js): # pending bug #16073
-    doAssert byLent(r)[] == 10.0
+  # bug #16073
+  doAssert byLent(r)[] == 10.0
 
   when not defined(js): # pending bug https://github.com/timotheecour/Nim/issues/372
     let p = create(float)
@@ -41,9 +45,9 @@ template main2 = # bug #15958
 
   proc byLent2[T](a: openArray[T]): lent T = a[0]
   doAssert byLent2(a) == 11
-  doAssert byLent2(a).addr == a[0].addr
+  doAssert sameAddress(byLent2(a), a[0])
   doAssert byLent2(b) == 21
-  doAssert byLent2(b).addr == b[0].addr
+  doAssert sameAddress(byLent2(b), b[0])
 
   proc byLent3[T](a: varargs[T]): lent T = a[1]
   let 


### PR DESCRIPTION
fixes #16800, fixes #16073

`lent` is treated mostly as a no-op due to JS's reference semantics.

Can't figure out how to deal with #16908 because I don't know how the iterator is generating code. From what I understand it's some combination of generic parameter + whatever `b = a` call the iterator is generating (it's doing `b = a[0]`).