### PR TITLE
mangle names in nimbase.h using cppDefine

### DIFF
--- a/config/config.nims
+++ b/config/config.nims
@@ -3,6 +3,11 @@
 cppDefine "errno"
 cppDefine "unix"
 
+# mangle the macro names in nimbase.h
+cppDefine "NAN_INFINITY"
+cppDefine "INF"
+cppDefine "NAN"
+
 when defined(nimStrictMode):
   # xxx add more flags here, and use `-d:nimStrictMode` in more contexts in CI.
 

--- a/tests/ccgbugs/tmangle.nim
+++ b/tests/ccgbugs/tmangle.nim
@@ -1,0 +1,16 @@
+block:
+  proc hello() =
+    let NAN_INFINITY = 12
+    doAssert NAN_INFINITY == 12
+    let INF = "2.0"
+    doAssert INF == "2.0"
+    let NAN = 2.3
+    doAssert NAN == 2.3
+
+  hello()
+
+block:
+  proc hello(NAN: float) =
+    doAssert NAN == 2.0
+
+  hello(2.0)


### PR DESCRIPTION
If users name a variable as NAN_INFINITY/INF/NAN, the program will crash.

```
In file included from C:\Users\blue\nimcache\test_d\@mtest.nim.c:7:
C:\Users\blue\nimcache\test_d\@mtest.nim.c: In function 'hello__test_1':
C:\Users\blue\.choosenim\toolchains\nim-#devel\lib/nimbase.h:497:26: error: expected identifier or '(' before 'float'
  497 | #  define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
      |                          ^~~~~
C:\Users\blue\nimcache\test_d\@mtest.nim.c:83:5: note: in expansion of macro 'NAN_INFINITY'
   83 |  NI NAN_INFINITY;
      |     ^~~~~~~~~~~~
C:\Users\blue\.choosenim\toolchains\nim-#devel\lib/nimbase.h:497:32: error: expected ')' before '(' token
  497 | #  define NAN_INFINITY ((float)(_HUGE_ENUF * _HUGE_ENUF))
      |                                ^
C:\Users\blue\nimcache\test_d\@mtest.nim.c:83:5: note: in expansion of macro 'NAN_INFINITY'
   83 |  NI NAN_INFINITY;
      |     ^~~~~~~~~~~~
C:\Users\blue\nimcache\test_d\@mtest.nim.c:86:15: error: lvalue required as left operand of assignment  
   86 |  NAN_INFINITY = ((NI) 12);
```
The issue is discovered by @haxscramper 
