### PR TITLE
fix stricteffects (nimsuggest/sexp)

### DIFF
--- a/nimsuggest/sexp.nim
+++ b/nimsuggest/sexp.nim
@@ -409,7 +409,7 @@ macro convertSexp*(x: untyped): untyped =
   ## `%` for every element.
   result = toSexp(x)
 
-proc `==`* (a,b: SexpNode): bool =
+proc `==`* (a, b: SexpNode): bool {.noSideEffect.} =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true

--- a/tests/effects/tstrict_effects3.nim
+++ b/tests/effects/tstrict_effects3.nim
@@ -6,7 +6,6 @@ discard """
 
 {.experimental: "strictEffects".}
 
-
 proc fn(a: int, p1, p2: proc()) {.effectsOf: p1.} =
   if a == 7:
     p1()

--- a/tests/effects/tstrict_effects3.nim
+++ b/tests/effects/tstrict_effects3.nim
@@ -6,6 +6,8 @@ discard """
 
 {.experimental: "strictEffects".}
 
+import nimsuggest/sexp
+
 proc fn(a: int, p1, p2: proc()) {.effectsOf: p1.} =
   if a == 7:
     p1()

--- a/tests/effects/tstrict_effects3.nim
+++ b/tests/effects/tstrict_effects3.nim
@@ -6,7 +6,6 @@ discard """
 
 {.experimental: "strictEffects".}
 
-import nimsuggest/sexp
 
 proc fn(a: int, p1, p2: proc()) {.effectsOf: p1.} =
   if a == 7:


### PR DESCRIPTION
checked with `./koch temp --gc:orc --lib:lib c -r tests/effects/tstrict_effects3.nim`

ref https://github.com/nim-lang/Nim/pull/19100
ref https://github.com/nim-lang/Nim/pull/19380

Before

```
2022-01-17T04:12:53.2768195Z sexp.nim(430, 15) template/generic instantiation of `==` from here
2022-01-17T04:12:53.2771503Z system/comparisons.nim(284, 6) Error: '==' can have side effects
2022-01-17T04:12:53.2772621Z > system/comparisons.nim(309, 13) Hint: '==' calls `.sideEffect` '=='
2022-01-17T04:12:53.2773568Z >> sexp.nim(412, 6) Hint: '==' called by '=='
```