### PR TITLE
Add noQuit option

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1198,8 +1198,8 @@ proc align(address, alignment: int): int =
   else:
     result = (address + (alignment - 1)) and not (alignment - 1)
 
-when defined(nimdoc):
-  proc quit*(errorcode: int = QuitSuccess) {.magic: "Exit", noreturn.}
+when defined(noQuit):
+  proc quit*(errorcode: int = QuitSuccess) = discard "ignoring quit"
     ## Stops the program immediately with an exit code.
     ##
     ## Before stopping the program the "exit procedures" are called in the
@@ -1222,6 +1222,9 @@ when defined(nimdoc):
     ##   raised by an `addExitProc` proc, as well as cleanup code in other threads.
     ##   It does *not* call the garbage collector to free all the memory,
     ##   unless an `addExitProc` proc calls `GC_fullCollect <#GC_fullCollect>`_.
+
+elif defined(nimdoc):
+  proc quit*(errorcode: int = QuitSuccess) {.magic: "Exit", noreturn.}
 
 elif defined(genode):
   include genode/env

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1198,7 +1198,7 @@ proc align(address, alignment: int): int =
   else:
     result = (address + (alignment - 1)) and not (alignment - 1)
 
-when defined(noQuit):
+when defined(nimNoQuit):
   proc quit*(errorcode: int = QuitSuccess) = discard "ignoring quit"
     ## Stops the program immediately with an exit code.
     ##


### PR DESCRIPTION
The immediate use case is for the WASM-4 fantasy console that doesn't define wasi `proc_exit`. The presumption is that people would only use `-d:noQuit` if they really mean it for constrained environments like this.