### PR TITLE
Resolve cross file resolution errors in atomics

### DIFF
--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -293,19 +293,16 @@ else:
       AtomicInt32 {.importc: "_Atomic NI32".} = int32
       AtomicInt64 {.importc: "_Atomic NI64".} = int64
 
-    template atomicType*(T: typedesc[Trivial]): untyped =
-      # Maps the size of a trivial type to it's internal atomic type
-      when sizeof(T) == 1: AtomicInt8
-      elif sizeof(T) == 2: AtomicInt16
-      elif sizeof(T) == 4: AtomicInt32
-      elif sizeof(T) == 8: AtomicInt64
-
     type
       AtomicFlag* {.importc: "atomic_flag", size: 1.} = object
 
       Atomic*[T] = object
         when T is Trivial:
-          value: T.atomicType
+          # Maps the size of a trivial type to it's internal atomic type
+          when sizeof(T) == 1: value: AtomicInt8
+          elif sizeof(T) == 2: value: AtomicInt16
+          elif sizeof(T) == 4: value: AtomicInt32
+          elif sizeof(T) == 8: value: AtomicInt64
         else:
           nonAtomicValue: T
           guard: AtomicFlag

--- a/lib/pure/concurrency/atomics.nim
+++ b/lib/pure/concurrency/atomics.nim
@@ -364,11 +364,11 @@ else:
       cast[T](atomic_fetch_xor_explicit(addr(location.value), cast[nonAtomicType(T)](value), order))
 
   template withLock[T: not Trivial](location: var Atomic[T]; order: MemoryOrder; body: untyped): untyped =
-    while location.guard.testAndSet(moAcquire): discard
+    while testAndSet(location.guard, moAcquire): discard
     try:
       body
     finally:
-      location.guard.clear(moRelease)
+      clear(location.guard, moRelease)
 
   proc load*[T: not Trivial](location: var Atomic[T]; order: MemoryOrder = moSequentiallyConsistent): T {.inline.} =
     withLock(location, order):

--- a/tests/stdlib/concurrency/atomicSample.nim
+++ b/tests/stdlib/concurrency/atomicSample.nim
@@ -1,0 +1,9 @@
+import atomics
+
+type
+  AtomicWithGeneric*[T] = object
+    value: Atomic[T]
+
+proc initAtomicWithGeneric*[T](value: T): AtomicWithGeneric[T] =
+  result.value.store(value)
+

--- a/tests/stdlib/concurrency/tatomic_import.nim
+++ b/tests/stdlib/concurrency/tatomic_import.nim
@@ -1,0 +1,5 @@
+import atomicSample
+
+block crossFileObjectContainingAGeneric:
+  discard initAtomicWithGeneric[string]("foo")
+

--- a/tests/stdlib/concurrency/tatomic_import.nim
+++ b/tests/stdlib/concurrency/tatomic_import.nim
@@ -1,5 +1,11 @@
 import atomicSample
 
-block crossFileObjectContainingAGeneric:
+block crossFileObjectContainingAGenericWithAComplexObject:
   discard initAtomicWithGeneric[string]("foo")
 
+block crossFileObjectContainingAGenericWithAnInteger:
+  discard initAtomicWithGeneric[int](1)
+  discard initAtomicWithGeneric[int8](1)
+  discard initAtomicWithGeneric[int16](1)
+  discard initAtomicWithGeneric[int32](1)
+  discard initAtomicWithGeneric[int64](1)


### PR DESCRIPTION
This PR includes two commits to resolve two separate issues in `std/atomics`. Both errors are related to resolving symbols when a generic is involved:

```
tatomic_import.nim(7, 32) template/generic instantiation of `initAtomicWithGeneric` from here
/home/nycto/Code/Nim/lib/pure/concurrency/atomics.nim(308, 19) Error: undeclared field: 'atomicType'
```

and

```
tatomic_import.nim(4, 32) template/generic instantiation of `initAtomicWithGeneric` from here
atomicSample.nim(8, 15) template/generic instantiation of `store` from here
/home/nycto/Code/Nim/lib/pure/concurrency/atomics.nim(378, 13) template/generic instantiation of `withLock` from here
/home/nycto/Code/Nim/lib/pure/concurrency/atomics.nim(367, 25) Error: attempting to call undeclared routine: 'testAndSet'
```

What's interesting is that I couldn't repro this issue when trying to add the test cases to the existing files -- I had to split the code up into multiple files for the errors to show up.

Any feedback about better ways to fix this, or better ways to organize the tests are welcome. Cheers