### PR TITLE
Fix #11923

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1523,7 +1523,12 @@ proc customPragmaNode(n: NimNode): NimNode =
   if n.kind in {nnkDotExpr, nnkCheckedFieldExpr}:
     let name = $(if n.kind == nnkCheckedFieldExpr: n[0][1] else: n[1])
     let typInst = getTypeInst(if n.kind == nnkCheckedFieldExpr or n[0].kind == nnkHiddenDeref: n[0][0] else: n[0])
-    var typDef = getImpl(if typInst.kind == nnkVarTy: typInst[0] else: typInst)
+    var typDef = getImpl(
+      if typInst.kind == nnkVarTy or
+         typInst.kind == nnkBracketExpr:
+        typInst[0]
+      else: typInst
+    )
     while typDef != nil:
       typDef.expectKind(nnkTypeDef)
       let typ = typDef[2]

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -17,10 +17,20 @@ block:
     MyObj = object
       myField1, myField2 {.myAttr: "hi".}: int
 
+    MyGenericObj[T] = object
+      myField1, myField2 {.myAttr: "hi".}: int
+
+
   var o: MyObj
   static:
     doAssert o.myField2.hasCustomPragma(myAttr)
     doAssert(not o.myField1.hasCustomPragma(myAttr))
+
+  var ogen: MyGenericObj[int]
+  static:
+    doAssert ogen.myField2.hasCustomPragma(myAttr)
+    doAssert(not ogen.myField1.hasCustomPragma(myAttr))
+
 
 import custom_pragma
 block: # A bit more advanced case


### PR DESCRIPTION
Should fix issue #11923 so typically this would work : 
```nim
template p() {.pragma.}

type
  A[T] = object
    a {.p.}: int

  B = object
    b {.p.}: int


proc main() =
  var a: A[int]
  echo a.a.hasCustomPragma(p)

  var b: B
  echo b.b.hasCustomPragma(p)

main()
```

Work originally done by @Vindaar (https://github.com/nim-lang/Nim/commit/5da931fe811717a45f2dd272ea6281979c3e8f0b) in a PR that was never merged 

There also was https://github.com/nim-lang/Nim/pull/11526 rwhich was reverted in https://github.com/nim-lang/Nim/pull/18601 which modified those files; I don't know what the stance is on changing the pragmas related proc but in the meantime fixing this bug seems harmless enough to not do it. 