### PR TITLE
Fixing more nnkBracketExpr not being checked in hasCustomPragma calling getImpl of nnkBracketExpr

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1523,7 +1523,12 @@ proc customPragmaNode(n: NimNode): NimNode =
   if n.kind in {nnkDotExpr, nnkCheckedFieldExpr}:
     let name = $(if n.kind == nnkCheckedFieldExpr: n[0][1] else: n[1])
     let typInst = getTypeInst(if n.kind == nnkCheckedFieldExpr or n[0].kind == nnkHiddenDeref: n[0][0] else: n[0])
-    var typDef = getImpl(if typInst.kind == nnkVarTy: typInst[0] else: typInst)
+    var typDef = getImpl(
+      if typInst.kind == nnkVarTy or
+         typInst.kind == nnkBracketExpr:
+        typInst[0]
+      else: typInst
+    )
     while typDef != nil:
       typDef.expectKind(nnkTypeDef)
       let typ = typDef[2]

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1501,7 +1501,10 @@ proc customPragmaNode(n: NimNode): NimNode =
   if typ.kind == nnkBracketExpr and typ.len > 1 and typ[1].kind == nnkProcTy:
     return typ[1][1]
   elif typ.typeKind == ntyTypeDesc:
-    let impl = typ[1].getImpl()
+    let impl = getImpl(
+      if kind(typ[1]) == nnkBracketExpr: typ[1][0]
+      else: typ[1]
+    )
     if impl[0].kind == nnkPragmaExpr:
       return impl[0][1]
     else:

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -17,10 +17,20 @@ block:
     MyObj = object
       myField1, myField2 {.myAttr: "hi".}: int
 
+    MyGenericObj[T] = object
+      myField1, myField2 {.myAttr: "hi".}: int
+
+
   var o: MyObj
   static:
     doAssert o.myField2.hasCustomPragma(myAttr)
     doAssert(not o.myField1.hasCustomPragma(myAttr))
+
+  var ogen: MyGenericObj[int]
+  static:
+    doAssert ogen.myField2.hasCustomPragma(myAttr)
+    doAssert(not ogen.myField1.hasCustomPragma(myAttr))
+
 
 import custom_pragma
 block: # A bit more advanced case

--- a/tests/pragmas/tcustom_pragma.nim
+++ b/tests/pragmas/tcustom_pragma.nim
@@ -25,11 +25,14 @@ block:
   static:
     doAssert o.myField2.hasCustomPragma(myAttr)
     doAssert(not o.myField1.hasCustomPragma(myAttr))
+    doAssert(not o.myField1.hasCustomPragma(MyObj))
 
   var ogen: MyGenericObj[int]
+
   static:
     doAssert ogen.myField2.hasCustomPragma(myAttr)
     doAssert(not ogen.myField1.hasCustomPragma(myAttr))
+    doAssert(not ogen.myField1.hasCustomPragma(MyGenericObj))
 
 
 import custom_pragma


### PR DESCRIPTION
@Araq  This is a follow-up of https://github.com/nim-lang/Nim/pull/19427 

It's mostly the same issue : getImpl being called on nnkBracketExpr without checking. I can only fix it where I encounter it (necessary to fix https://github.com/moigagoo/norm/issues/132). but there may other. 

I'm wondering if a better fix wouldn't be to check for nnkBracketExpr in a ``getImpl`` wrapper (since getImpl is magic) like : 
```nim
proc getImplChecked(node: NimNode) : NimNode =
  if node.kind() == nnkBracketExpr:
    getImpl(node[0])
  else:
    getImpl(node)
```
but I do not know the ramification of such a change; or if it's better or worse than adding manual check whenever the issue arise. 