### PR TITLE
getAppFilename: mention paramStr(0)

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -3129,6 +3129,7 @@ proc getAppFilename*(): string {.rtl, extern: "nos$1", tags: [ReadIOEffect], noW
   ## See also:
   ## * `getAppDir proc`_
   ## * `getCurrentCompilerExe proc`_
+  ## * `paramStr proc`_ for `paramStr(0)`
 
   # Linux: /proc/<pid>/exe
   # Solaris:


### PR DESCRIPTION
`paramStr(0)` is useful for multi-call binaries (example: busybox)

the "not stable" warning is in 

https://github.com/nim-lang/Nim/blob/6118da68062f024cfd0aa22ce4f60cd155b83a00/lib/pure/os.nim#L2865-L2868

related https://stackoverflow.com/a/42291142/10440128