### PR TITLE
fix `parseEnum` cannot parse enums with constant fields

### DIFF
--- a/lib/std/enumutils.nim
+++ b/lib/std/enumutils.nim
@@ -14,7 +14,7 @@ from typetraits import OrdinalEnum, HoleyEnum
 
 macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
             userMin, userMax: static[int], normalizer: static[proc(s :string): string]): untyped =
-  # generates a case stmt, which assigns the correct enum field given
+  # Generates a case stmt, which assigns the correct enum field given
   # a normalized string comparison to the `argSym` input.
   # string normalization is done using passed normalizer.
   # NOTE: for an enum with fields Foo, Bar, ... we cannot generate
@@ -49,7 +49,12 @@ macro genEnumCaseStmt*(typ: typedesc, argSym: typed, default: typed,
       of nnkIntLit:
         fStr = f[0].strVal
         fNum = f[1].intVal
-      else: error("Invalid tuple syntax!", f[1])
+      else:
+        let fAst = f[0].getImpl
+        if fAst.kind == nnkStrLit:
+          fStr = fAst.strVal
+        else:
+          error("Invalid tuple syntax!", f[1])
     else: error("Invalid node for enum type `" & $f.kind & "`!", f)
     # add field if string not already added
     if fNum >= userMin and fNum <= userMax:

--- a/tests/stdlib/tstrutils.nim
+++ b/tests/stdlib/tstrutils.nim
@@ -583,6 +583,17 @@ template main() =
       let g = parseEnum[Foo]("Bar", A)
       doAssert g == A
 
+    block: # bug #19463
+      const CAMPAIGN_TABLE = "wikientries_campaign"
+      const CHARACTER_TABLE = "wikientries_character"
+
+      type Tables = enum
+        a = CAMPAIGN_TABLE,
+        b = CHARACTER_TABLE,
+
+      let myA = CAMPAIGN_TABLE
+      doAssert $parseEnum[Tables](myA) == "wikientries_campaign"
+
     block: # check enum defined in block
       type
         Bar = enum


### PR DESCRIPTION
fix #19463