### PR TITLE
No longer segfault when using a typeclass with a self referencing type

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1688,7 +1688,8 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
             var aa = a
             while aa.kind in {tyTypeDesc, tyGenericParam} and aa.len > 0:
               aa = lastSon(aa)
-            if aa.kind == tyGenericParam:
+            if aa.kind in {tyGenericParam} + tyTypeClasses:
+              # If the constraint is a genericParam or typeClass this isGeneric
               return isGeneric
             result = typeRel(c, f.base, aa, flags)
             if result > isGeneric: result = isGeneric

--- a/tests/generics/tgenerics_issues.nim
+++ b/tests/generics/tgenerics_issues.nim
@@ -860,3 +860,15 @@ type
 
 var a: Tile3[int]
 
+block: # Ensure no segfault from constraint
+  type
+    Regex[A: SomeOrdinal] = ref object
+      val: Regex[A]
+    MyConstraint = (seq or enum or set)
+    MyOtherType[A: MyConstraint] = ref object
+      val: MyOtherType[A]
+
+  var
+    a = Regex[int]()
+    b = Regex[bool]()
+    c = MyOtherType[seq[int]]()


### PR DESCRIPTION
Prior doing self referential types constrained by a typeclass would cause a segfault.
For instance:
```nim
type MyType[T: SomeOrdinal] = ref object
  val: MyType[T]
```