### PR TITLE
Fix(sigmatch): allow `varargs[T]` to accept overloaded symbol

### DIFF
--- a/tests/compiler/tsigmatch.nim
+++ b/tests/compiler/tsigmatch.nim
@@ -1,0 +1,23 @@
+discard """
+  nimout: '''nnkClosedSymChoice
+nnkSym
+'''
+"""
+# import sequils
+
+import macros
+
+# block testVarargsOverloadedSymbolResolution:
+# 
+#   echo @[1, 2, 3].map(len)
+
+block testTypedVarargsOverloadedSymbolResolution:
+
+  macro typedVarargs(x: varargs[typed]) =
+    echo x[0].kind
+
+  macro typedSingle(x: typed) =
+    echo x.kind
+
+  typedSingle(`@`)
+  typedVarargs(`@`)


### PR DESCRIPTION
Fix(sigmatch): allow `varargs[T]` to accept overloaded symbol

There was a bug that params wouldn't be matched if the param was overloaded and the candidate type was varargs. This checks the base type of the `varargs` and then will to an overloaded symbol if in a macros.

I'm not sure what should be done in the case of a template.

There is a bug (which may be reported) of the following case:
```nim
import sequtils

template map(s: seq[int], p: typed): int =
  sequtils.map(s, p)

echo @[1, 2, 3, 4].map(len)
```
which sems to the "first" `len` but not he right one because it's a closed choice sym.

It is a separate issue, but it would now apply for a case of varargs also

Fixes https://github.com/nim-lang/Nim/issues/19446
Fixes https://github.com/nim-lang/Nim/issues/13913

