### PR TITLE
Fix typo trailing space

### DIFF
--- a/compiler/nim.nim
+++ b/compiler/nim.nim
@@ -116,7 +116,8 @@ proc handleCmdLine(cache: IdentCache; conf: ConfigRef) =
       if cmdPrefix.len > 0: cmdPrefix.add " "
         # without the `cmdPrefix.len > 0` check, on windows you'd get a cryptic:
         # `The parameter is incorrect`
-      execExternalProgram(conf, cmdPrefix & output.quoteShell & ' ' & conf.arguments)
+      let cmd = cmdPrefix & output.quoteShell & ' ' & conf.arguments
+      execExternalProgram(conf, cmd.strip(leading=false,trailing=true))
     of cmdDocLike, cmdRst2html, cmdRst2tex: # bugfix(cmdRst2tex was missing)
       if conf.arguments.len > 0:
         # reserved for future use


### PR DESCRIPTION
Remove the trailing space in command in error message when I use `nim r ....`

## Before
```
Error: execution of an external program failed: '/home/user/computing/tool/nimble/buildTests/tissues_DE99FB558D566428079F83C6615350F3EB9FB1CB '
```
## After
```
Error: execution of an external program failed: '/home/user/computing/tool/nimble/buildTests/tissues_DE99FB558D566428079F83C6615350F3EB9FB1CB'
```