### PR TITLE
disable nimlsp

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -103,7 +103,7 @@ pkg "nimfp", "nim c -o:nfp -r src/fp.nim"
 pkg "nimgame2", "nim c -d:nimLegacyConvEnumEnum nimgame2/nimgame.nim"
   # XXX Doesn't work with deprecated 'randomize', will create a PR.
 pkg "nimgen", "nim c -o:nimgenn -r src/nimgen/runcfg.nim"
-pkg "nimlsp"
+pkg "nimlsp", allowFailure = true
 pkg "nimly", "nim c -r tests/test_readme_example.nim"
 pkg "nimongo", "nimble test_ci", allowFailure = true
 pkg "nimph", "nimble test", "https://github.com/disruptek/nimph", allowFailure = true


### PR DESCRIPTION
Important packages should have CI support. Otherwise, it may break the Nim CI easily.