### PR TITLE
Explicitly add KeyError to raises

### DIFF
--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -442,7 +442,7 @@ macro `%*`*(x: untyped): untyped =
   ## `%` for every element.
   result = toJsonImpl(x)
 
-proc `==`*(a, b: JsonNode): bool {.noSideEffect.} =
+proc `==`*(a, b: JsonNode): bool {.noSideEffect, raises: [KeyError].} =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -442,7 +442,7 @@ macro `%*`*(x: untyped): untyped =
   ## `%` for every element.
   result = toJsonImpl(x)
 
-proc `==`*(a, b: JsonNode): bool {.noSideEffect, raises: [KeyError].} =
+proc `==`*(a, b: JsonNode): bool {.noSideEffect, raises: [].} =
   ## Check two nodes for equality
   if a.isNil:
     if b.isNil: return true
@@ -469,11 +469,12 @@ proc `==`*(a, b: JsonNode): bool {.noSideEffect, raises: [KeyError].} =
       if a.fields.len != b.fields.len: return false
       for key, val in a.fields:
         if not b.fields.hasKey(key): return false
-        when defined(nimHasEffectsOf):
-          {.noSideEffect.}:
+        {.cast(raises: []).}:
+          when defined(nimHasEffectsOf):
+            {.noSideEffect.}:
+              if b.fields[key] != val: return false
+          else:
             if b.fields[key] != val: return false
-        else:
-          if b.fields[key] != val: return false
       result = true
 
 proc hash*(n: OrderedTable[string, JsonNode]): Hash {.noSideEffect.}


### PR DESCRIPTION
Makes other libraries depending on it being able to infer KeyError and not Exception, although the json doc corrrectly lists KeyError, maybe a bug?