### PR TITLE
tools/niminst: Proper shell quoting

### DIFF
--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -62,16 +62,16 @@ if [ $# -eq 1 ] ; then
       docdir="$1/?proj/doc"
       datadir="$1/?proj/data"
       nimbleDir="$1/?proj"
-      mkdir -p $1/?proj
-      mkdir -p $bindir
-      mkdir -p $configdir
+      mkdir -p "$1"/?proj
+      mkdir -p "$bindir"
+      mkdir -p "$configdir"
       ;;
   esac
 
-  mkdir -p $libdir
-  mkdir -p $docdir
-  mkdir -p $configdir
-  mkdir -p $nimbleDir/
+  mkdir -p "$libdir"
+  mkdir -p "$docdir"
+  mkdir -p "$configdir"
+  mkdir -p "$nimbleDir/"
   echo "copying files..."
 #var createdDirs = newStringTable()
 #for cat in {fcConfig..fcLib, fcNimble}:
@@ -84,41 +84,41 @@ if [ $# -eq 1 ] ; then
 #    end if
 #    if mk.len > 0 and not createdDirs.hasKey(mk):
 #      createdDirs[mk] = "true"
-  mkdir -p ?{mk.toUnix}
+  mkdir -p "?{mk.toUnix}"
 #    end if
 #  end for
 #end for
 
 #for f in items(c.cat[fcUnixBin]):
-  cp ?f.toUnix $bindir/?f.skipRoot.toUnix
-  chmod 755 $bindir/?f.skipRoot.toUnix
+  cp ?f.toUnix "$bindir"/?f.skipRoot.toUnix
+  chmod 755 "$bindir"/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcConfig]):
-  cp ?f.toUnix $configdir/?f.skipRoot.toUnix
-  chmod 644 $configdir/?f.skipRoot.toUnix
+  cp ?f.toUnix "$configdir"/?f.skipRoot.toUnix
+  chmod 644 "$configdir"/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcData]):
   if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $datadir/?f.skipRoot.toUnix
-    chmod 644 $datadir/?f.skipRoot.toUnix
+    cp ?f.toUnix "$datadir"/?f.skipRoot.toUnix
+    chmod 644 "$datadir"/?f.skipRoot.toUnix
   fi
 #end for
 #for f in items(c.cat[fcDoc]):
   if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $docdir/?f.skipRoot.toUnix
-    chmod 644 $docdir/?f.skipRoot.toUnix
+    cp ?f.toUnix "$docdir"/?f.skipRoot.toUnix
+    chmod 644 "$docdir"/?f.skipRoot.toUnix
   fi
 #end for
 #for f in items(c.cat[fcLib]):
-  cp ?f.toUnix $libdir/?f.skipRoot.toUnix
-  chmod 644 $libdir/?f.skipRoot.toUnix
+  cp ?f.toUnix "$libdir"/?f.skipRoot.toUnix
+  chmod 644 "$libdir"/?f.skipRoot.toUnix
 #end for
 #for f in items(c.cat[fcNimble]):
-  cp ?f.toUnix $nimbleDir/?f.toUnix
-  chmod 644 $nimbleDir/?f.toUnix
+  cp ?f.toUnix "$nimbleDir"/?f.toUnix
+  chmod 644 "$nimbleDir"/?f.toUnix
 #end for
-cp ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
-chmod 644 $nimbleDir/?{c.nimblePkgName}.nimble
+cp ?{c.nimblePkgName}.nimble "$nimbleDir"/?{c.nimblePkgName}.nimble
+chmod 644 "$nimbleDir"/?{c.nimblePkgName}.nimble
 
   echo "installation successful"
 else

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -62,7 +62,7 @@ if [ $# -eq 1 ] ; then
       docdir="$1/?proj/doc"
       datadir="$1/?proj/data"
       nimbleDir="$1/?proj"
-      mkdir -p "$1"/?proj
+      mkdir -p "$1/?proj"
       mkdir -p "$bindir"
       mkdir -p "$configdir"
       ;;
@@ -90,35 +90,35 @@ if [ $# -eq 1 ] ; then
 #end for
 
 #for f in items(c.cat[fcUnixBin]):
-  cp ?f.toUnix "$bindir"/?f.skipRoot.toUnix
-  chmod 755 "$bindir"/?f.skipRoot.toUnix
+  cp ?f.toUnix "$bindir/?f.skipRoot.toUnix"
+  chmod 755 "$bindir/?f.skipRoot.toUnix"
 #end for
 #for f in items(c.cat[fcConfig]):
-  cp ?f.toUnix "$configdir"/?f.skipRoot.toUnix
-  chmod 644 "$configdir"/?f.skipRoot.toUnix
+  cp ?f.toUnix "$configdir/?f.skipRoot.toUnix"
+  chmod 644 "$configdir/?f.skipRoot.toUnix"
 #end for
 #for f in items(c.cat[fcData]):
   if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix "$datadir"/?f.skipRoot.toUnix
-    chmod 644 "$datadir"/?f.skipRoot.toUnix
+    cp ?f.toUnix "$datadir/?f.skipRoot.toUnix"
+    chmod 644 "$datadir/?f.skipRoot.toUnix"
   fi
 #end for
 #for f in items(c.cat[fcDoc]):
   if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix "$docdir"/?f.skipRoot.toUnix
-    chmod 644 "$docdir"/?f.skipRoot.toUnix
+    cp ?f.toUnix "$docdir/?f.skipRoot.toUnix"
+    chmod 644 "$docdir/?f.skipRoot.toUnix"
   fi
 #end for
 #for f in items(c.cat[fcLib]):
-  cp ?f.toUnix "$libdir"/?f.skipRoot.toUnix
-  chmod 644 "$libdir"/?f.skipRoot.toUnix
+  cp ?f.toUnix "$libdir/?f.skipRoot.toUnix"
+  chmod 644 "$libdir/?f.skipRoot.toUnix"
 #end for
 #for f in items(c.cat[fcNimble]):
-  cp ?f.toUnix "$nimbleDir"/?f.toUnix
-  chmod 644 "$nimbleDir"/?f.toUnix
+  cp ?f.toUnix "$nimbleDir/?f.toUnix"
+  chmod 644 "$nimbleDir/?f.toUnix"
 #end for
-cp ?{c.nimblePkgName}.nimble "$nimbleDir"/?{c.nimblePkgName}.nimble
-chmod 644 "$nimbleDir"/?{c.nimblePkgName}.nimble
+cp ?{c.nimblePkgName}.nimble "$nimbleDir/?{c.nimblePkgName}.nimble"
+chmod 644 "$nimbleDir/?{c.nimblePkgName}.nimble"
 
   echo "installation successful"
 else


### PR DESCRIPTION
This fixes packaging when destroot contains a space character.