### PR TITLE
Add null byte in the whitespace char in strutils.nim

### DIFF
--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -84,9 +84,9 @@ from std/private/strimpl import cmpIgnoreStyleImpl, cmpIgnoreCaseImpl, startsWit
 
 
 const
-  Whitespace* = {' ', '\t', '\v', '\r', '\l', '\f'}
+  Whitespace* = {' ', '\t', '\v', '\r', '\l', '\f', '\x00'}
     ## All the characters that count as whitespace (space, tab, vertical tab,
-    ## carriage return, new line, form feed).
+    ## carriage return, new line, form feed, null byte).
 
   Letters* = {'A'..'Z', 'a'..'z'}
     ## The set of letters.


### PR DESCRIPTION
Null bytes are also displayed as whitespace and should be treated as well. (For example with the function strip)