### PR TITLE
Remove deprecated math.c_frexp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,9 @@ becomes an alias for `addr`.
 
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 
+- Removed deprecated `math.c_frexp`.
+
+
 ## Language changes
 
 - Pragma macros on type definitions can now return `nnkTypeSection` nodes as well as `nnkTypeDef`,

--- a/lib/pure/math.nim
+++ b/lib/pure/math.nim
@@ -69,11 +69,6 @@ when defined(c) or defined(cpp):
 
   proc c_signbit(x: SomeFloat): cint {.importc: "signbit", header: "<math.h>".}
 
-  func c_frexp*(x: cfloat, exponent: var cint): cfloat {.
-      importc: "frexpf", header: "<math.h>", deprecated: "Use `frexp` instead".}
-  func c_frexp*(x: cdouble, exponent: var cint): cdouble {.
-      importc: "frexp", header: "<math.h>", deprecated: "Use `frexp` instead".}
-
   # don't export `c_frexp` in the future and remove `c_frexp2`.
   func c_frexp2(x: cfloat, exponent: var cint): cfloat {.
       importc: "frexpf", header: "<math.h>".}

--- a/tests/stdlib/tmath.nim
+++ b/tests/stdlib/tmath.nim
@@ -437,12 +437,6 @@ template main() =
       doAssert lgamma(-0.0) == Inf
       doAssert lgamma(-1.0) == Inf
 
-      when nimvm: discard
-      else:
-        var exponent: cint
-        doAssert c_frexp(0.0, exponent) == 0.0
-        doAssert c_frexp(-0.0, exponent) == -0.0
-        doAssert classify(c_frexp(-0.0, exponent)) == fcNegZero
 
 static: main()
 main()


### PR DESCRIPTION
- Remove Deprecated math C proc `c_frexp`.
- Changelog updated.

I tried to remove this long Deprecated unused proc in the past already,
but been told that needs to be kept for backwards compatibility with older pre-1.0 versions,
now that Breaking changes are allowed, I was thinking is time to remove the dead code.
