### PR TITLE
Remove Deprecated oids.oidsToString

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -39,6 +39,8 @@ becomes an alias for `addr`.
 - Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year.
 
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
+- Removed deprecated `oids.oidToString`.
+
 
 ## Language changes
 

--- a/lib/pure/oids.nim
+++ b/lib/pure/oids.nim
@@ -67,11 +67,6 @@ template toStringImpl[T: string | cstring](result: var T, oid: Oid) =
   when T is cstring:
     result[N] = '\0'
 
-proc oidToString*(oid: Oid, str: cstring) {.deprecated: "unsafe; use `$`".} =
-  ## Converts an oid to a string which must have space allocated for 25 elements.
-  # work around a compiler bug:
-  var str = str
-  toStringImpl(str, oid)
 
 proc `$`*(oid: Oid): string =
   ## Converts an OID to a string.


### PR DESCRIPTION
- Remove Deprecated `oids.oidsToString`.
- Changelog updated.

I tried to remove this long Deprecated unused proc in the past already,
but been told that needs to be kept for backwards compatibility with older pre-1.0 versions,
now that Breaking changes are allowed, I was thinking is time to remove the dead code.
