### PR TITLE
Remove deprecated sets.isValid, sets.toSet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,7 @@ becomes an alias for `addr`.
 - Added `initDateTime` in `times` to create a datetime from a weekday, and ISO 8601 week number and week-based year.
 - Added `getIsoWeekAndYear` in `times` to get an ISO week number along with the corresponding ISO week-based year from a datetime.
 - Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year.
-- Remove deprecated `sets.isValid`, `sets.toSet`, `sets.initSet`.
+- Remove deprecated `sets.isValid`, `sets.toSet`.
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 
 ## Language changes

--- a/changelog.md
+++ b/changelog.md
@@ -37,7 +37,7 @@ becomes an alias for `addr`.
 - Added `initDateTime` in `times` to create a datetime from a weekday, and ISO 8601 week number and week-based year.
 - Added `getIsoWeekAndYear` in `times` to get an ISO week number along with the corresponding ISO week-based year from a datetime.
 - Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year.
-
+- Remove deprecated `sets.isValid`, `sets.toSet`, `sets.initSet`.
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 
 ## Language changes

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -591,6 +591,9 @@ proc `$`*[A](s: HashSet[A]): string =
   ##   # --> {no, esc'aping, is " provided}
   dollarImpl()
 
+proc initSet*[A](initialSize = defaultInitialSize): HashSet[A] {.deprecated:
+    "Deprecated since v0.20, use 'initHashSet'".} = initHashSet[A](initialSize)
+
 
 # ---------------------------------------------------------------------
 # --------------------------- OrderedSet ------------------------------

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -422,7 +422,7 @@ proc intersection*[A](s1, s2: HashSet[A]): HashSet[A] =
     assert c == toHashSet(["b"])
 
   result = initHashSet[A](max(min(s1.data.len, s2.data.len), 2))
-  
+
   # iterate over the elements of the smaller set
   if s1.data.len < s2.data.len:
     for item in s1:
@@ -430,7 +430,7 @@ proc intersection*[A](s1, s2: HashSet[A]): HashSet[A] =
   else:
     for item in s2:
       if item in s1: incl(result, item)
-  
+
 
 proc difference*[A](s1, s2: HashSet[A]): HashSet[A] =
   ## Returns the difference of the sets `s1` and `s2`.
@@ -590,25 +590,6 @@ proc `$`*[A](s: HashSet[A]): string =
   ##   echo toHashSet(["no", "esc'aping", "is \" provided"])
   ##   # --> {no, esc'aping, is " provided}
   dollarImpl()
-
-
-proc initSet*[A](initialSize = defaultInitialSize): HashSet[A] {.deprecated:
-     "Deprecated since v0.20, use 'initHashSet'".} = initHashSet[A](initialSize)
-
-proc toSet*[A](keys: openArray[A]): HashSet[A] {.deprecated:
-     "Deprecated since v0.20, use 'toHashSet'".} = toHashSet[A](keys)
-
-proc isValid*[A](s: HashSet[A]): bool {.deprecated:
-     "Deprecated since v0.20; sets are initialized by default".} =
-  ## Returns `true` if the set has been initialized (with `initHashSet proc
-  ## <#initHashSet>`_ or `init proc <#init,HashSet[A]>`_).
-  ##
-  runnableExamples:
-    proc savePreferences(options: HashSet[string]) =
-      assert options.isValid, "Pass an initialized set!"
-      # Do stuff here, may crash in release builds!
-  result = s.data.len > 0
-
 
 
 # ---------------------------------------------------------------------

--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -64,11 +64,11 @@ pkg "docopt"
 pkg "easygl", "nim c -o:egl -r src/easygl.nim", "https://github.com/jackmott/easygl"
 pkg "elvis"
 pkg "fidget"
-pkg "fragments", "nim c -r fragments/dsl.nim", allowFailure = true # pending https://github.com/nim-lang/packages/issues/2115 
+pkg "fragments", "nim c -r fragments/dsl.nim", allowFailure = true # pending https://github.com/nim-lang/packages/issues/2115
 pkg "fusion"
 pkg "gara"
 pkg "glob"
-pkg "ggplotnim", "nim c -d:noCairo -r tests/tests.nim"
+# pkg "ggplotnim", "nim c -d:noCairo -r tests/tests.nim" # pending https://github.com/nim-lang/Nim/pull/19520
 pkg "gittyup", "nimble test", "https://github.com/disruptek/gittyup", allowFailure = true
 pkg "gnuplot", "nim c gnuplot.nim"
 # pkg "gram", "nim c -r --gc:arc --define:danger tests/test.nim", "https://github.com/disruptek/gram"


### PR DESCRIPTION
- Remove Deprecated Set `sets.isValid`, `sets.toSet`.
- Changelog updated.

I tried to remove this long Deprecated unused proc in the past already,
but been told that needs to be kept for backwards compatibility with older pre-1.0 versions,
now that Breaking changes are allowed, I was thinking is time to remove the dead code.
