### PR TITLE
use OrderedTable instead of OrderedTableRef for mimedb

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,8 @@ becomes an alias for `addr`.
 
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 
+- Changed mimedb to use an `OrderedTable` instead of `OrderedTableRef`, to use it in a const.
+
 ## Language changes
 
 - Pragma macros on type definitions can now return `nnkTypeSection` nodes as well as `nnkTypeDef`,

--- a/lib/pure/mimetypes.nim
+++ b/lib/pure/mimetypes.nim
@@ -31,7 +31,7 @@ from strutils import startsWith, toLowerAscii, strip
 
 type
   MimeDB* = object
-    mimes: OrderedTableRef[string, string]
+    mimes: OrderedTable[string, string]
 
 const mimes* = {
   "123": "application/vnd.lotus-1-2-3",
@@ -1904,7 +1904,7 @@ func newMimetypes*(): MimeDB =
   ## Creates a new Mimetypes database. The database will contain the most
   ## common mimetypes.
   {.cast(noSideEffect).}:
-    result.mimes = mimes.newOrderedTable()
+    result.mimes = mimes.toOrderedTable()
 
 func getMimetype*(mimedb: MimeDB, ext: string, default = "text/plain"): string =
   ## Gets mimetype which corresponds to `ext`. Returns `default` if `ext`

--- a/tests/stdlib/tmimetypes.nim
+++ b/tests/stdlib/tmimetypes.nim
@@ -7,6 +7,8 @@ template main() =
   var m = newMimetypes()
   doAssert m.getMimetype("mp4") == "video/mp4"
   doAssert m.getExt("application/json") == "json"
+  m.register("foo", "baa")
+  doAssert m.getMimetype("foo") == "baa"
   # see also `runnableExamples`.
   # xxx we should have a way to avoid duplicating code between runnableExamples and tests
 


### PR DESCRIPTION
use OrderedTable instead of OrderedTableRef for mimedb

this enables storing mimedb in a const.

Signed-off-by: David Krause <enthus1ast@users.noreply.github.com>