### PR TITLE
Remove define for jsfetch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,7 +40,7 @@ becomes an alias for `addr`.
 
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 - Removed deprecated `oids.oidToString`.
-
+- Remove define `nimExperimentalAsyncjsThen` for `std/asyncjs.then` and `std/jsfetch`.
 
 - Changed mimedb to use an `OrderedTable` instead of `OrderedTableRef`, to use it in a const.
 

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -64,6 +64,7 @@ when not defined(js) and not defined(nimsuggest):
 
 import std/jsffi
 import std/macros
+import std/private/since
 
 type
   Future*[T] = ref object
@@ -163,92 +164,91 @@ template maybeFuture(T): untyped =
   when T is Future: T
   else: Future[T]
 
-when defined(nimExperimentalAsyncjsThen):
-  import std/private/since
-  since (1, 5, 1):
-    #[
-    TODO:
-    * map `Promise.all()`
-    * proc toString*(a: Error): cstring {.importjs: "#.toString()".}
 
-    Note:
-    We probably can't have a `waitFor` in js in browser (single threaded), but maybe it would be possible
-    in in nodejs, see https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options
-    and https://stackoverflow.com/questions/61377358/javascript-wait-for-async-call-to-finish-before-returning-from-function-witho
-    ]#
+since (1, 5, 1):
+  #[
+  TODO:
+  * map `Promise.all()`
+  * proc toString*(a: Error): cstring {.importjs: "#.toString()".}
 
-    type Error*  {.importjs: "Error".} = ref object of JsRoot
-      ## https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
-      message*: cstring
-      name*: cstring
+  Note:
+  We probably can't have a `waitFor` in js in browser (single threaded), but maybe it would be possible
+  in in nodejs, see https://nodejs.org/api/child_process.html#child_process_child_process_execsync_command_options
+  and https://stackoverflow.com/questions/61377358/javascript-wait-for-async-call-to-finish-before-returning-from-function-witho
+  ]#
 
-    type OnReject* = proc(reason: Error)
+  type Error*  {.importjs: "Error".} = ref object of JsRoot
+    ## https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+    message*: cstring
+    name*: cstring
 
-    proc then*[T](future: Future[T], onSuccess: proc, onReject: OnReject = nil): auto =
-      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-      ## Returns a `Future` from the return type of `onSuccess(T.default)`.
-      runnableExamples("-d:nimExperimentalAsyncjsThen"):
-        from std/sugar import `=>`
+  type OnReject* = proc(reason: Error)
 
-        proc fn(n: int): Future[int] {.async.} =
-          if n >= 7: raise newException(ValueError, "foobar: " & $n)
-          else: result = n * 2
+  proc then*[T](future: Future[T], onSuccess: proc, onReject: OnReject = nil): auto =
+    ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
+    ## Returns a `Future` from the return type of `onSuccess(T.default)`.
+    runnableExamples("-r:off"):
+      from std/sugar import `=>`
 
-        proc asyncFact(n: int): Future[int] {.async.} =
-          if n > 0: result = n * await asyncFact(n-1)
-          else: result = 1
+      proc fn(n: int): Future[int] {.async.} =
+        if n >= 7: raise newException(ValueError, "foobar: " & $n)
+        else: result = n * 2
 
-        proc main() {.async.} =
-          block: # then
-            assert asyncFact(3).await == 3*2
-            assert asyncFact(3).then(asyncFact).await == 6*5*4*3*2
-            let x1 = await fn(3)
-            assert x1 == 3 * 2
-            let x2 = await fn(4)
-              .then((a: int) => a.float)
-              .then((a: float) => $a)
-            assert x2 == "8.0"
+      proc asyncFact(n: int): Future[int] {.async.} =
+        if n > 0: result = n * await asyncFact(n-1)
+        else: result = 1
 
-          block: # then with `onReject` callback
-            var witness = 1
-            await fn(6).then((a: int) => (witness = 2), (r: Error) => (witness = 3))
-            assert witness == 2
-            await fn(7).then((a: int) => (witness = 2), (r: Error) => (witness = 3))
-            assert witness == 3
+      proc main() {.async.} =
+        block: # then
+          assert asyncFact(3).await == 3*2
+          assert asyncFact(3).then(asyncFact).await == 6*5*4*3*2
+          let x1 = await fn(3)
+          assert x1 == 3 * 2
+          let x2 = await fn(4)
+            .then((a: int) => a.float)
+            .then((a: float) => $a)
+          assert x2 == "8.0"
 
-      template impl(call): untyped =
-        # see D20210421T014713
-        when typeof(block: call) is void:
-          var ret: Future[void]
-        else:
-          var ret = default(maybeFuture(typeof(call)))
-        typeof(ret)
-      when T is void:
-        type A = impl(onSuccess())
+        block: # then with `onReject` callback
+          var witness = 1
+          await fn(6).then((a: int) => (witness = 2), (r: Error) => (witness = 3))
+          assert witness == 2
+          await fn(7).then((a: int) => (witness = 2), (r: Error) => (witness = 3))
+          assert witness == 3
+
+    template impl(call): untyped =
+      # see D20210421T014713
+      when typeof(block: call) is void:
+        var ret: Future[void]
       else:
-        type A = impl(onSuccess(default(T)))
-      var ret: A
-      asm "`ret` = `future`.then(`onSuccess`, `onReject`)"
-      return ret
+        var ret = default(maybeFuture(typeof(call)))
+      typeof(ret)
+    when T is void:
+      type A = impl(onSuccess())
+    else:
+      type A = impl(onSuccess(default(T)))
+    var ret: A
+    asm "`ret` = `future`.then(`onSuccess`, `onReject`)"
+    return ret
 
-    proc catch*[T](future: Future[T], onReject: OnReject): Future[void] =
-      ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
-      runnableExamples("-d:nimExperimentalAsyncjsThen"):
-        from std/sugar import `=>`
-        from std/strutils import contains
+  proc catch*[T](future: Future[T], onReject: OnReject): Future[void] =
+    ## See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
+    runnableExamples("-r:off"):
+      from std/sugar import `=>`
+      from std/strutils import contains
 
-        proc fn(n: int): Future[int] {.async.} =
-          if n >= 7: raise newException(ValueError, "foobar: " & $n)
-          else: result = n * 2
+      proc fn(n: int): Future[int] {.async.} =
+        if n >= 7: raise newException(ValueError, "foobar: " & $n)
+        else: result = n * 2
 
-        proc main() {.async.} =
-          var reason: Error
-          await fn(6).catch((r: Error) => (reason = r)) # note: `()` are needed, `=> reason = r` would not work
-          assert reason == nil
-          await fn(7).catch((r: Error) => (reason = r))
-          assert reason != nil
-          assert  "foobar: 7" in $reason.message
+      proc main() {.async.} =
+        var reason: Error
+        await fn(6).catch((r: Error) => (reason = r)) # note: `()` are needed, `=> reason = r` would not work
+        assert reason == nil
+        await fn(7).catch((r: Error) => (reason = r))
+        assert reason != nil
+        assert  "foobar: 7" in $reason.message
 
-        discard main()
+      discard main()
 
-      asm "`result` = `future`.catch(`onReject`)"
+    asm "`result` = `future`.catch(`onReject`)"

--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -190,12 +190,11 @@ runnableExamples("-r:off"):
 
       discard example()
 
-    when defined(nimExperimentalAsyncjsThen):
-      block:
-        proc example2 {.async.} =
-          await fetch("https://api.github.com/users/torvalds".cstring)
-            .then((response: Response) => response.json())
-            .then((json: JsObject) => console.log(json))
-            .catch((err: Error) => console.log("Request Failed", err))
+    block:
+      proc example2 {.async.} =
+        await fetch("https://api.github.com/users/torvalds".cstring)
+          .then((response: Response) => response.json())
+          .then((json: JsObject) => console.log(json))
+          .catch((err: Error) => console.log("Request Failed", err))
 
-        discard example2()
+      discard example2()

--- a/tools/kochdocs.nim
+++ b/tools/kochdocs.nim
@@ -11,7 +11,7 @@ const
   gaCode* = " --doc.googleAnalytics:UA-48159761-1"
   # errormax: subsequent errors are probably consequences of 1st one; a simple
   # bug could cause unlimited number of errors otherwise, hard to debug in CI.
-  docDefines = "-d:nimExperimentalAsyncjsThen -d:nimExperimentalLinenoiseExtra"
+  docDefines = "-d:nimExperimentalLinenoiseExtra"
   nimArgs = "--errormax:3 --hint:Conf:off --hint:Path:off --hint:Processing:off --hint:XDeclaredButNotUsed:off --warning:UnusedImport:off -d:boot --putenv:nimversion=$# $#" % [system.NimVersion, docDefines]
   gitUrl = "https://github.com/nim-lang/Nim"
   docHtmlOutput = "doc/html"


### PR DESCRIPTION
- Remove Experimental define `nimExperimentalAsyncjsThen` for `std/asyncjs.then` and `std/jsfetch`.
- Diff may look bigger, but I am just removing the `when defined(nimExperimentalAsyncjsThen):`.
- Changelog updated.


I think this was added because it needed to be kept behind a define flag for backwards compatibility with older pre-1.0 versions,
now that Breaking changes are allowed, and no relevant bugs has been reported for the feature since its creation, I was thinking is time to remove the define flags.
