### PR TITLE
Fix #18662 - Error on file write issue for JS gen

### DIFF
--- a/compiler/jsgen.nim
+++ b/compiler/jsgen.nim
@@ -2796,7 +2796,9 @@ proc myClose(graph: ModuleGraph; b: PPassContext, n: PNode): PNode =
       var map: SourceMap
       (code, map) = genSourceMap($(code), outFile.string)
       writeFile(outFile.string & ".map", $(%map))
-    discard writeRopeIfNotEqual(code, outFile)
+    if not equalsFile(code, outFile):
+      if not writeRope(code, outFile):
+        rawMessage(m.config, errCannotOpenFile, outFile.string)
 
 
 proc myOpen(graph: ModuleGraph; s: PSym; idgen: IdGenerator): PPassContext =

--- a/compiler/ropes.nim
+++ b/compiler/ropes.nim
@@ -329,10 +329,3 @@ proc equalsFile*(r: Rope, filename: AbsoluteFile): bool =
   if result:
     result = equalsFile(r, f)
     close(f)
-
-proc writeRopeIfNotEqual*(r: Rope, filename: AbsoluteFile): bool =
-  # returns true if overwritten
-  if not equalsFile(r, filename):
-    result = writeRope(r, filename)
-  else:
-    result = false


### PR DESCRIPTION
Fix #18662

Not too sure of policy because first contribution but this removes the last use of `writeRopeIfNotEqual` I believe - should that be removed as well?