### PR TITLE
Make installation scripts install Nimble sources

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,3 +102,5 @@ becomes an alias for `addr`.
 
 - There is a new switch `--nimMainPrefix:prefix` to influence the `NimMain` that the
   compiler produces. This is particularly useful for generating static libraries.
+
+- `niminst` installs Nimble sources.

--- a/compiler/installer.ini
+++ b/compiler/installer.ini
@@ -51,6 +51,7 @@ Start: "doc/html/overview.html"
 [Other]
 Files: "copying.txt"
 Files: "koch.nim"
+Files: "compiler.nimble"
 
 Files: "icons/nim.ico"
 Files: "icons/nim.rc"
@@ -138,8 +139,8 @@ flags = "-w"
 buildDepends: "gcc (>= 4:4.3.2)"
 pkgDepends: "gcc (>= 4:4.3.2)"
 shortDesc: "The Nim Compiler"
-licenses: "bin/nim,MIT;lib/*,MIT;"
+licenses: "bin/nim,MIT;lib/*,MIT;dist/nimble/*,BSD-3-clause;"
 
 [nimble]
-pkgName: "compiler"
-pkgFiles: "compiler/*;doc/basicopt.txt;doc/advopt.txt;doc/nimdoc.css"
+Pkg: "compiler:compiler.nimble;compiler/*;doc/basicopt.txt;doc/advopt.txt;doc/nimdoc.css"
+Pkg: "nimble@0.14.0:dist/nimble,nimble.nimble;dist/nimble/src,nimble.nim;dist/nimble/src,nimblepkg/*"

--- a/doc/niminst.rst
+++ b/doc/niminst.rst
@@ -14,9 +14,9 @@ Introduction
 
 niminst is a tool to generate an installer for a Nim program. Currently
 it can create an installer for Windows
-via `Inno Setup <http://www.jrsoftware.org/isinfo.php>`_ as well as
-installation/deinstallation scripts for UNIX. Later versions will support
-Linux' package management systems.
+via `Inno Setup <http://www.jrsoftware.org/isinfo.php>`_ or
+`NSIS <https://nsis.sourceforge.io>`_ as well as installation/deinstallation
+scripts for UNIX. Later versions will support Linux' package management systems.
 
 niminst works by reading a configuration file that contains all the
 information that it needs to generate an installer for the different operating
@@ -184,6 +184,15 @@ Key                    description
 `flags`                Flags to pass to the C Compiler.
                        Example: `flags = "-w"`
 ====================   =======================================================
+
+
+Nimble section
+--------------
+
+The `nimble` section only supports the `Pkg` key. Its format is as follows::
+
+  [nimble]
+  Pkg: "pkgname@pkgver:pattern1;prefix,pattern2"
 
 
 Real-world example

--- a/tools/niminst/deinstall.nimf
+++ b/tools/niminst/deinstall.nimf
@@ -21,7 +21,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/lib/?proj
       docdir=/usr/share/?proj/doc
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
@@ -29,7 +29,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/local/lib/?proj
       docdir=/usr/local/share/?proj/doc
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"
@@ -37,7 +37,7 @@ if [ $# -eq 1 ] ; then
       libdir="/opt/?proj/lib"
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs"
       ;;
     *)
       bindir="$1/?proj/bin"
@@ -50,11 +50,11 @@ if [ $# -eq 1 ] ; then
   esac
   echo "removing files..."
 
-#for ff in items(c.cat[fcUnixBin]):
+#for ff in c.cat[fcUnixBin].values:
   #let f = ff.toUnix
   rm -f $bindir/?f.skipRoot
 #end for
-#for ff in items(c.cat[fcConfig]):
+#for ff in c.cat[fcConfig].values:
   #let f = ff.toUnix
   rm -f $configdir/?f.skipRoot
 #end for
@@ -63,10 +63,9 @@ if [ $# -eq 1 ] ; then
   rm -rf $libdir
 
   ## Nimble pkg stuff
-  #for f in items(c.cat[fcNimble]):
-    rm -f $nimbleDir/?f.toUnix
-  #end for
-  rm -f $nimbleDir/?{c.nimblePkgName}.nimble
+#for f in c.cat[fcNimble].values:
+  rm -f $nimbleDir/?f.toUnix
+#end for
 
   echo "deinstallation successful"
 else

--- a/tools/niminst/inno.nimf
+++ b/tools/niminst/inno.nimf
@@ -20,8 +20,8 @@ Name: english; MessagesFile: compiler:Default.isl
 
 [Files] 
   #for i in low(FileCategory)..fcWindows:
-  #  for f in items(c.cat[i]):
-Source: ${expandFilename(f).toWin}; DestDir: {app}\${splitFile(f).dir.toWin}; Flags: ignoreversion
+  #  for src, dest in c.cat[i].pairs:
+Source: ${expandFilename(src).toWin}; DestDir: {app}\${splitFile(dest).dir.toWin}; Flags: ignoreversion
   #  end for
   #end for
 
@@ -31,8 +31,8 @@ Name: {group}\Console for $c.displayName; Filename: {cmd}
   #else:
 Name: {group}\$c.displayName; Filename: {app}\${c.name}.exe
   #end if
-  #for f in items(c.cat[fcDocStart]):
-Name: {group}\Documentation; Filename: {app}\${f.toWin}
+  #for src in c.cat[fcDocStart].keys:
+Name: {group}\Documentation; Filename: {app}\${src.toWin}
   #end for
 Name: {group}\{cm:UninstallProgram,$c.displayName}; Filename: {uninstallexe}
 

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -7,7 +7,7 @@ set -e
 
 if [ $# -eq 1 ] ; then
 # if c.cat[fcUnixBin].len > 0:
-  if test -f ?{c.cat[fcUnixBin][0].toUnix}
+  if test -f ?{"bin/nim".toUnix}
   then
     echo "?c.displayName build detected"
   else
@@ -34,7 +34,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/lib/?proj
       docdir=/usr/share/?proj/doc
       datadir=/usr/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs"
       ;;
     "/usr/local/bin")
       bindir=/usr/local/bin
@@ -42,7 +42,7 @@ if [ $# -eq 1 ] ; then
       libdir=/usr/local/lib/?proj
       docdir=/usr/local/share/?proj/doc
       datadir=/usr/local/share/?proj/data
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs"
       ;;
     "/opt")
       bindir="/opt/?proj/bin"
@@ -50,7 +50,7 @@ if [ $# -eq 1 ] ; then
       libdir="/opt/?proj/lib"
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
-      nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
+      nimbleDir="/opt/nimble/pkgs"
       mkdir -p /opt/?proj
       mkdir -p $bindir
       mkdir -p $configdir
@@ -75,12 +75,12 @@ if [ $# -eq 1 ] ; then
   echo "copying files..."
 #var createdDirs = newStringTable()
 #for cat in {fcConfig..fcLib, fcNimble}:
-#  for f in items(c.cat[cat]):
-#    var mk = splitFile(f.skipRoot).dir
+#  for dest in c.cat[cat].values:
+#    var mk = splitFile(dest.skipRoot).dir
 #    if cat != fcNimble:
 #      mk = unixDirVars[cat] & "/" & mk
 #    else:
-#      mk = "$nimbleDir" / splitFile(f).dir
+#      mk = "$nimbleDir" / splitFile(dest).dir
 #    end if
 #    if mk.len > 0 and not createdDirs.hasKey(mk):
 #      createdDirs[mk] = "true"
@@ -89,36 +89,34 @@ if [ $# -eq 1 ] ; then
 #  end for
 #end for
 
-#for f in items(c.cat[fcUnixBin]):
-  cp ?f.toUnix $bindir/?f.skipRoot.toUnix
-  chmod 755 $bindir/?f.skipRoot.toUnix
+#for src, dest in c.cat[fcUnixBin].pairs:
+  cp ?src.toUnix $bindir/?dest.skipRoot.toUnix
+  chmod 755 $bindir/?dest.skipRoot.toUnix
 #end for
-#for f in items(c.cat[fcConfig]):
-  cp ?f.toUnix $configdir/?f.skipRoot.toUnix
-  chmod 644 $configdir/?f.skipRoot.toUnix
+#for src, dest in c.cat[fcConfig].pairs:
+  cp ?src.toUnix $configdir/?dest.skipRoot.toUnix
+  chmod 644 $configdir/?dest.skipRoot.toUnix
 #end for
-#for f in items(c.cat[fcData]):
-  if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $datadir/?f.skipRoot.toUnix
-    chmod 644 $datadir/?f.skipRoot.toUnix
+#for src, dest in c.cat[fcData].pairs:
+  if [ -f ?src.toUnix ]; then
+    cp ?src.toUnix $datadir/?src.skipRoot.toUnix
+    chmod 644 $datadir/?src.skipRoot.toUnix
   fi
 #end for
-#for f in items(c.cat[fcDoc]):
-  if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $docdir/?f.skipRoot.toUnix
-    chmod 644 $docdir/?f.skipRoot.toUnix
+#for src, dest in c.cat[fcDoc].pairs:
+  if [ -f ?src.toUnix ]; then
+    cp ?src.toUnix $docdir/?dest.skipRoot.toUnix
+    chmod 644 $docdir/?dest.skipRoot.toUnix
   fi
 #end for
-#for f in items(c.cat[fcLib]):
-  cp ?f.toUnix $libdir/?f.skipRoot.toUnix
-  chmod 644 $libdir/?f.skipRoot.toUnix
+#for src, dest in c.cat[fcLib].pairs:
+  cp ?src.toUnix $libdir/?dest.skipRoot.toUnix
+  chmod 644 $libdir/?dest.skipRoot.toUnix
 #end for
-#for f in items(c.cat[fcNimble]):
-  cp ?f.toUnix $nimbleDir/?f.toUnix
-  chmod 644 $nimbleDir/?f.toUnix
+#for src, dest in c.cat[fcNimble].pairs:
+  cp ?src.toUnix $nimbleDir/?dest
+  chmod 644 $nimbleDir/?dest
 #end for
-cp ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
-chmod 644 $nimbleDir/?{c.nimblePkgName}.nimble
 
   echo "installation successful"
 else

--- a/tools/niminst/nsis.nimf
+++ b/tools/niminst/nsis.nimf
@@ -110,9 +110,9 @@
 
     ; Write all the files to the output directory.
     #for i in low(FileCategory)..fcWindows:
-    #  for f in items(c.cat[i]):
-         SetOutPath "$INSTDIR\?{splitFile(f).dir.toWin}"
-         File "?{expandFilename(f).toWin}"
+    #  for src, dest in c.cat[i].pairs:
+         SetOutPath "$INSTDIR\?{splitFile(dest).dir.toWin}"
+         File "?{expandFilename(src).toWin}"
     #  end for
     #end for
 


### PR DESCRIPTION
nimble.nimble file has the following key:

`installExt = @["nim"]`

That means both binaries and sources are supposed to be installed.
https://github.com/nim-lang/nimble#hybrids