### PR TITLE
Document links repect --out in .idx file 

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1499,9 +1499,10 @@ proc genOutFile(d: PDoc, groupedToc = false): string =
   # Extract the title. Non API modules generate an entry in the index table.
   if d.meta[metaTitle].len != 0:
     title = d.meta[metaTitle]
-    let external = d.destFile.AbsoluteFile
-                    .relativeTo(d.conf.outDir, '/')
-                    .changeFileExt(HtmlExt).string
+    let external = AbsoluteFile(d.destFile)
+      .relativeTo(d.conf.outDir, '/')
+      .changeFileExt(HtmlExt)
+      .string
     setIndexTerm(d[], external, "", title)
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1499,7 +1499,9 @@ proc genOutFile(d: PDoc, groupedToc = false): string =
   # Extract the title. Non API modules generate an entry in the index table.
   if d.meta[metaTitle].len != 0:
     title = d.meta[metaTitle]
-    let external = presentationPath(d.conf, AbsoluteFile d.filename).changeFileExt(HtmlExt).string.nativeToUnixPath
+    let external = d.destFile.AbsoluteFile
+                    .relativeTo(d.conf.outDir, '/')
+                    .changeFileExt(HtmlExt).string
     setIndexTerm(d[], external, "", title)
   else:
     # Modules get an automatic title for the HTML, but no entry in the index.


### PR DESCRIPTION
The link to a document in the .idx file doesn't respect the --out flag when generating docs. 
This PR fixes that by getting the link the same way the code gets it for the other links in the index (Which do respect the --out flag)

(Command used for example `nim doc --index:on --out:foo.html test.nim`)

.idx file before
```
DSL	test.html
Getting started	foo.html#getting-started	 Getting started	
Imports	foo.html#getting-started-imports	  Imports	
Final Code	foo.html#final-code	 Final Code
```
Links are correct for other sections but the title isn't correct so it will 404 when accessing from theindex.html

.idx file after
```
DSL	foo.html
Getting started	foo.html#getting-started	 Getting started	
Imports	foo.html#getting-started-imports	  Imports	
Final Code	foo.html#final-code	 Final Code
```
