### PR TITLE
Add error message to pointer size check assert in lib/nimbase.h

### DIFF
--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -547,7 +547,7 @@ static inline void GCGuard (void *ptr) { asm volatile ("" :: "X" (ptr)); }
 #endif
 
 // Test to see if Nim and the C compiler agree on the size of a pointer.
-NIM_STATIC_ASSERT(sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(NI)*8, "");
+NIM_STATIC_ASSERT(sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(NI)*8, "Pointer size mismatch between Nim and C/C++ backend. You probably need to setup the backend compiler for target CPU.");
 
 #ifdef USE_NIM_NAMESPACE
 }


### PR DESCRIPTION
Some people try to build for 32bit CPU but their GCC compiles for 64bit CPU and the `NIM_STATIC_ASSERT` that checks pointer size in `lib/nimbase.h` fails.
They don't understand error message and ask for help.

This PR adds the error message that is displayed when the assert failed.