### PR TITLE
Remove Deprecated jsre func

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -43,7 +43,7 @@ becomes an alias for `addr`.
 
 
 - Changed mimedb to use an `OrderedTable` instead of `OrderedTableRef`, to use it in a const.
-
+- Removed deprecated `jsre.test` and `jsre.toString`.
 - Removed deprecated `math.c_frexp`.
 
 

--- a/lib/js/jsre.nim
+++ b/lib/js/jsre.nim
@@ -47,10 +47,6 @@ func toCstring*(self: RegExp): cstring {.importjs: "#.toString()".}
 
 func `$`*(self: RegExp): string = $toCstring(self)
 
-func test*(self: RegExp; pattern: cstring): bool {.importjs: "#.test(#)", deprecated: "Use contains instead".}
-
-func toString*(self: RegExp): cstring {.importjs: "#.toString()", deprecated: "Use toCstring instead".}
-
 func contains*(pattern: cstring; self: RegExp): bool =
   ## Tests for a substring match in its string parameter.
   runnableExamples:


### PR DESCRIPTION
- Remove Deprecated `jsre` func, functionality exists under a different name anyways.
