### PR TITLE
compile pragma: cache the result sooner

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -649,8 +649,10 @@ proc externalFileChanged(conf: ConfigRef; cfile: Cfile): bool =
       close(f)
 
 proc addExternalFileToCompile*(conf: ConfigRef; c: var Cfile) =
+  # we want to generate the hash file unconditionally
+  let extFileChanged = externalFileChanged(conf, c)
   if optForceFullMake notin conf.globalOptions and fileExists(c.obj) and
-      not externalFileChanged(conf, c):
+      not extFileChanged:
     c.flags.incl CfileFlag.Cached
   else:
     # make sure Nim keeps recompiling the external file on reruns


### PR DESCRIPTION
`extccomp.addExternalFileToCompile()` relies on hashes to decide whether an external C file needs recompilation or not.

Due to short-circuit evaluation of boolean expressions, the procedure that generates a corresponding hash file is not called the first time an external file is compiled, so an avoidable recompilation is triggered the next build.

This patch fixes that by moving the proc call with a desired side effect from its boolean expression, so it's executed unconditionally.