### PR TITLE
Allow iterable to be used with *It from sequtils

### DIFF
--- a/lib/pure/collections/sequtils.nim
+++ b/lib/pure/collections/sequtils.nim
@@ -638,7 +638,7 @@ template filterIt*(s, pred: untyped): untyped =
     assert notAcceptable == @[-272.15, 99.9, -113.44]
 
   var result = newSeq[typeof(s[0])]()
-  for it {.inject.} in items(s):
+  for it {.inject.} in s:
     if pred: result.add(it)
   result
 
@@ -726,7 +726,7 @@ template allIt*(s, pred: untyped): bool =
     assert numbers.allIt(it < 9) == false
 
   var result = true
-  for it {.inject.} in items(s):
+  for it {.inject.} in s:
     if not pred:
       result = false
       break
@@ -768,7 +768,7 @@ template anyIt*(s, pred: untyped): bool =
     assert numbers.anyIt(it > 9) == false
 
   var result = false
-  for it {.inject.} in items(s):
+  for it {.inject.} in s:
     if pred:
       result = true
       break


### PR DESCRIPTION
The following code won't compile in Nim 1.6.4, because `anyIt` calls `item` on `a.values`, which is already an iterator.

```nim
import std/[tables, sequtils]

var a: Table[int, int]
var b: seq[int]
echo a.values.anyIt(it > 0) # this doesn't work
echo b.anyIt(it > 0)
```

This pull requests tries to fix the problem.

To do:
- [ ] add tests
- [ ] add support for `mapIt`

Related: #12639