### PR TITLE
make compileOption("panics") work

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -332,6 +332,7 @@ proc testCompileOption*(conf: ConfigRef; switch: string, info: TLineInfo): bool 
     result = contains(conf.options, optTrMacros)
   of "excessivestacktrace": result = contains(conf.globalOptions, optExcessiveStackTrace)
   of "nilseqs", "nilchecks", "taintmode": warningOptionNoop(switch)
+  of "panics": result = contains(conf.globalOptions, optPanics)
   else: invalidCmdLineOption(conf, passCmd1, switch, info)
 
 proc processPath(conf: ConfigRef; path: string, info: TLineInfo,


### PR DESCRIPTION
before this PR:

```
$ nim c -r --panics:on --eval:'echo $compileOption("panics")'
=> cmdfile.nim(1, 20) Error: invalid command line option: '--panics'
```

Now it works.