### PR TITLE
Fix CPU detection for i386

### DIFF
--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -164,7 +164,7 @@ esac
 
 case $ucpu in
   *i386* | *i486* | *i586* | *i686* | *bepc* | *i86pc* )
-    if [ isOpenIndiana -eq "yes" ] ; then
+    if [ "$isOpenIndiana" == "yes" ] ; then
       mycpu="amd64"
     else
       mycpu="i386"

--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -164,7 +164,7 @@ esac
 
 case $ucpu in
   *i386* | *i486* | *i586* | *i686* | *bepc* | *i86pc* )
-    if [ "$isOpenIndiana" == "yes" ] ; then
+    if [ "$isOpenIndiana" = "yes" ] ; then
       mycpu="amd64"
     else
       mycpu="i386"


### PR DESCRIPTION
Commit 787def271b1cabc6f898caa42f892125de9fa908 breaks CPU detection for i386 on OpenBSD and probably on other platforms.
`[ isOpenIndiana -eq "yes" ]` always returns `0`, so `mycpu` is always set to `"amd64"`.

(If possible, this should also be backported to release branches)

