### PR TITLE
Add nosideeffect to DateTime

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -368,9 +368,9 @@ type
       ## timezones. The `times` module only supplies implementations for the
       ## system's local time and UTC.
     zonedTimeFromTimeImpl: proc (x: Time): ZonedTime
-        {.tags: [], raises: [], benign.}
+        {.tags: [], raises: [], benign, noSideEffect.}
     zonedTimeFromAdjTimeImpl: proc (x: Time): ZonedTime
-        {.tags: [], raises: [], benign.}
+        {.tags: [], raises: [], benign, noSideEffect.}
     name: string
 
   ZonedTime* = object ## Represents a point in time with an associated
@@ -1168,9 +1168,9 @@ proc initDateTime(zt: ZonedTime, zone: Timezone): DateTime =
 proc newTimezone*(
       name: string,
       zonedTimeFromTimeImpl: proc (time: Time): ZonedTime
-          {.tags: [], raises: [], benign.},
+          {.tags: [], raises: [], benign, noSideEffect.},
       zonedTimeFromAdjTimeImpl: proc (adjTime: Time): ZonedTime
-          {.tags: [], raises: [], benign.}
+          {.tags: [], raises: [], benign, noSideEffect.}
     ): owned Timezone =
   ## Create a new `Timezone`.
   ##


### PR DESCRIPTION
Enable the following code to be ran.

```nim
import std/times

func foo(a: DateTime): DateTime =
    a + 1.seconds
    
var a: DateTime = now()
echo foo(a)
```

Error:
```
/tmp/a.nim(3, 6) Error: 'foo' can have side effects
> /tmp/a.nim(4, 7) Hint: 'foo' calls `.sideEffect` '+'
>> /home/user/.choosenim/toolchains/nim-1.6.4/lib/pure/times.nim(2503, 6) Hint: '+' called by 'foo'
```

Side effect traceback is not available for `proc` in another module, like `std/times`. I have to change `+` to `func` to debug where sideeffect might be introduced. Is this intended?