### PR TITLE
Fix process lines iterator

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -477,8 +477,7 @@ iterator lines*(p: Process): string {.since: (1, 3), tags: [ReadIOEffect].} =
   while true:
     if outp.readLine(line):
       yield line
-    else:
-      if p.peekExitCode != -1: break
+    elif not running(p): break
 
 proc readLines*(p: Process): (seq[string], int) {.since: (1, 3).} =
   ## Convenience function for working with `startProcess` to read data from a

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -514,6 +514,7 @@ when not defined(useNimRtl):
     var outp = outputStream(p)
     result = ""
     var line = newStringOfCap(120)
+    # consider `p.lines(keepNewLines=true)` to circumvent `running` busy-wait
     while true:
       # FIXME: converts CR-LF to LF.
       if outp.readLine(line):
@@ -1622,6 +1623,7 @@ proc execCmdEx*(command: string, options: set[ProcessOption] = {
     inputStream(p).write(input)
   close inputStream(p)
 
+  # consider `p.lines(keepNewLines=true)` to avoid exit code test
   result = ("", -1)
   var line = newStringOfCap(120)
   while true:

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -451,7 +451,7 @@ proc execProcesses*(cmds: openArray[string],
       if afterRunEvent != nil: afterRunEvent(i, p)
       close(p)
 
-iterator lines*(p: Process): string {.since: (1, 3), tags: [ReadIOEffect].} =
+iterator lines*(p: Process, keepNewLines = false): string {.since: (1, 3), tags: [ReadIOEffect].} =
   ## Convenience iterator for working with `startProcess` to read data from a
   ## background process.
   ##
@@ -474,10 +474,11 @@ iterator lines*(p: Process): string {.since: (1, 3), tags: [ReadIOEffect].} =
   ##     p.close
   var outp = p.outputStream
   var line = newStringOfCap(120)
-  while true:
-    if outp.readLine(line):
-      yield line
-    elif not running(p): break
+  while outp.readLine(line):
+    if keepNewLines:
+      line.add("\n")
+    yield line
+  discard waitForExit(p)
 
 proc readLines*(p: Process): (seq[string], int) {.since: (1, 3).} =
   ## Convenience function for working with `startProcess` to read data from a


### PR DESCRIPTION
I discovered that the convenience iterator [`process.lines`](https://github.com/nim-lang/Nim/blob/devel/lib/pure/osproc.nim#L454-L481) does not exit when the process (in my case a Windows application) returns an exit code of `-1`. This is resolved by checking if the process is still [`running`](https://github.com/nim-lang/Nim/blob/devel/lib/pure/osproc.nim#L788-L793), as with [`execProcess`](https://github.com/nim-lang/Nim/blob/devel/lib/pure/osproc.nim#L522).