### PR TITLE
build external deps with useversion:1.6

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -142,7 +142,7 @@ proc csource(args: string) =
 proc bundleC2nim(args: string) =
   cloneDependency(distDir, "https://github.com/nim-lang/c2nim.git")
   nimCompile("dist/c2nim/c2nim",
-             options = "--noNimblePath --path:. " & args)
+             options = "--noNimblePath --useVersion:1.6 --path:. " & args)
 
 proc bundleNimbleExe(latest: bool, args: string) =
   let commit = if latest: "HEAD" else: NimbleStableCommit
@@ -150,7 +150,7 @@ proc bundleNimbleExe(latest: bool, args: string) =
                   commit = commit, allowBundled = true)
   # installer.ini expects it under $nim/bin
   nimCompile("dist/nimble/src/nimble.nim",
-             options = "-d:release --noNimblePath " & args)
+             options = "-d:release --useVersion:1.6 --noNimblePath " & args)
 
 proc bundleNimsuggest(args: string) =
   nimCompileFold("Compile nimsuggest", "nimsuggest/nimsuggest.nim",


### PR DESCRIPTION
- [x] build c2nim, nimble with `useversion:1.6` (after https://github.com/nim-lang/Nim/pull/19602 is merged, fix these two packages)
- [ ] test important packages with `useversion:1.6`