### PR TITLE
Add noSideEffect to nimStackTraceOverride (fix #19619)

### DIFF
--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -250,10 +250,11 @@ template addFrameEntry(s: var string, f: StackTraceEntry|PFrame) =
   add(s, "\n")
 
 func `$`(stackTraceEntries: seq[StackTraceEntry]): string =
-  when defined(nimStackTraceOverride):
-    let s = addDebuggingInfo(stackTraceEntries)
-  else:
-    let s = stackTraceEntries
+  let s =
+    when defined(nimStackTraceOverride):
+      addDebuggingInfo(stackTraceEntries)
+    else:
+      stackTraceEntries
 
   result = newStringOfCap(2000)
   for i in 0 .. s.len-1:

--- a/lib/system/excpt.nim
+++ b/lib/system/excpt.nim
@@ -249,7 +249,7 @@ template addFrameEntry(s: var string, f: StackTraceEntry|PFrame) =
       for i in first..<f.frameMsgLen: add(s, frameMsgBuf[i])
   add(s, "\n")
 
-proc `$`(stackTraceEntries: seq[StackTraceEntry]): string =
+func `$`(stackTraceEntries: seq[StackTraceEntry]): string =
   when defined(nimStackTraceOverride):
     let s = addDebuggingInfo(stackTraceEntries)
   else:

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -22,12 +22,12 @@ when defined(nimStackTraceOverride):
       ## This is the same as the type `uintptr_t` in C.
 
     StackTraceOverrideGetTracebackProc* = proc (): string {.
-      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
+      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline, noSideEffect.}
     StackTraceOverrideGetProgramCountersProc* = proc (maxLength: cint): seq[cuintptr_t] {.
-      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
+      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline, noSideEffect.}
     StackTraceOverrideGetDebuggingInfoProc* =
       proc (programCounters: seq[cuintptr_t], maxLength: cint): seq[StackTraceEntry] {.
-        nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
+        nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline, noSideEffect.}
 
   # Default procedures (not normally used, because people opting in on this
   # override are supposed to register their own versions).
@@ -66,7 +66,7 @@ when defined(nimStackTraceOverride):
       s.add(StackTraceEntry(programCounter: cast[uint](programCounter)))
 
   # We may have more stack trace lines in the output, due to inlined procedures.
-  proc addDebuggingInfo*(s: seq[StackTraceEntry]): seq[StackTraceEntry] =
+  func addDebuggingInfo*(s: seq[StackTraceEntry]): seq[StackTraceEntry] =
     var programCounters: seq[cuintptr_t]
     # We process program counters in groups from complete stack traces, because
     # we have logic that keeps track of certain functions being inlined or not.

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -71,9 +71,8 @@ when defined(nimStackTraceOverride):
     # We process program counters in groups from complete stack traces, because
     # we have logic that keeps track of certain functions being inlined or not.
 
-    # Here we access some global state, which is a side-effect,
-    # but this procedure is used from Exception.`$`, which is excepted to be
-    # a noSideEffect. The callback themself are noSideEffect
+    # This procedure is used from Exception.`$`, which is excepted to be
+    # a noSideEffect, so we hide the side effects under the rug
     #
     # weird syntax, cast(noSideEffect) doesn't work (probably because
     # we are too early in the standard library)

--- a/lib/system/stacktraces.nim
+++ b/lib/system/stacktraces.nim
@@ -22,12 +22,12 @@ when defined(nimStackTraceOverride):
       ## This is the same as the type `uintptr_t` in C.
 
     StackTraceOverrideGetTracebackProc* = proc (): string {.
-      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline, noSideEffect.}
+      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
     StackTraceOverrideGetProgramCountersProc* = proc (maxLength: cint): seq[cuintptr_t] {.
-      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline, noSideEffect.}
+      nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
     StackTraceOverrideGetDebuggingInfoProc* =
       proc (programCounters: seq[cuintptr_t], maxLength: cint): seq[StackTraceEntry] {.
-        nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline, noSideEffect.}
+        nimcall, gcsafe, locks: 0, raises: [], tags: [], noinline.}
 
   # Default procedures (not normally used, because people opting in on this
   # override are supposed to register their own versions).


### PR DESCRIPTION
This may break existing hooks with sideeffect, not sure if there is a better way

Fixes #19619

EDIT: only found two libraries using this,we can probably backport to 1.2 and fix them if required 