### PR TITLE
Better error message and tests for bad await

### DIFF
--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -133,9 +133,12 @@ template await*[T](f: Future[T]): auto {.used.} =
     yield internalTmpFuture
     (cast[typeof(f)](internalTmpFuture)).read()
   else:
-    static: error(
-      "Can only 'await' inside a proc marked as 'async'. Use " &
-      "'waitFor' when calling an 'async' proc in a non-async scope instead")
+    macro errorAsync(futureError: Future[T]) =
+      error(
+        "Can only 'await' inside a proc marked as 'async'. Use " &
+        "'waitFor' when calling an 'async' proc in a non-async scope instead",
+        futureError)
+    errorAsync(f)
 
 proc asyncSingleProc(prc: NimNode): NimNode =
   ## This macro transforms a single procedure into a closure iterator.

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -121,14 +121,36 @@ proc verifyReturnType(typeName: string, node: NimNode = nil) =
     error("Expected return type of 'Future' got '$1'" %
           typeName, node)
 
+macro isInAsync(n: FutureBase): bool =
+  ## Used to provide more useful error messages with 'await'.
+  var owner = n.owner
+  # We're recursing until we find something which could cause `yield FutureBase` to fail
+  while owner.symKind notin {nskProc, nskFunc, nskIterator, nskMacro} and owner.owner != nil:
+    owner = owner.owner
+
+  result = newLit(false)
+
+  # If async, owner should be an iterator returning owned[FutureBase]
+  if owner.symKind == nskIterator:
+    let returnType = owner.getImpl().params[0]
+    if returnType.kind in {nnkCall, nnkCommand, nnkBracketExpr}:
+      let returnsFuture =
+        (returnType[0].eqIdent"owned" and returnType[1].eqIdent"FutureBase") or
+        returnType[0].eqIdent"FutureBase"
+
+      result = newLit(returnsFuture)
+
 template await*(f: typed): untyped {.used.} =
   static:
     error "await expects Future[T], got " & $typeof(f)
 
 template await*[T](f: Future[T]): auto {.used.} =
   var internalTmpFuture: FutureBase = f
-  yield internalTmpFuture
-  (cast[typeof(f)](internalTmpFuture)).read()
+  when isInAsync(internalTmpFuture):
+    yield internalTmpFuture
+    (cast[typeof(f)](internalTmpFuture)).read()
+  else:
+    static: error "Can only 'await' inside a 'async' marked proc."
 
 proc asyncSingleProc(prc: NimNode): NimNode =
   ## This macro transforms a single procedure into a closure iterator.

--- a/tests/async/tasync_noasync.nim
+++ b/tests/async/tasync_noasync.nim
@@ -4,36 +4,37 @@ discard """
   nimout: '''
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  nonAsyncProc
-tasync_noasync.nim(46, 9) template/generic instantiation of `await` from here
+tasync_noasync.nim(47, 9) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  nested
-tasync_noasync.nim(48, 27) template/generic instantiation of `async` from here
-tasync_noasync.nim(50, 11) template/generic instantiation of `await` from here
+tasync_noasync.nim(49, 27) template/generic instantiation of `async` from here
+tasync_noasync.nim(51, 11) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  customIterator
-tasync_noasync.nim(53, 9) template/generic instantiation of `await` from here
+tasync_noasync.nim(54, 9) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  awaitInMacro
-tasync_noasync.nim(56, 9) template/generic instantiation of `await` from here
+tasync_noasync.nim(57, 9) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  awaitInMethod
-tasync_noasync.nim(60, 9) template/generic instantiation of `await` from here
+tasync_noasync.nim(61, 9) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  improperMultisync
-tasync_noasync.nim(62, 26) template/generic instantiation of `multisync` from here
-tasync_noasync.nim(63, 9) template/generic instantiation of `await` from here
+tasync_noasync.nim(63, 26) template/generic instantiation of `multisync` from here
+tasync_noasync.nim(64, 9) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
 asyncmacro.nim(136, 18)  tasync_noasync
-tasync_noasync.nim(65, 7) template/generic instantiation of `await` from here
+tasync_noasync.nim(66, 7) template/generic instantiation of `await` from here
 ../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 '''
   nimoutFull: true
+  disabled: "win"
   file: "asyncmacro.nim"
 """
 import async

--- a/tests/async/tasync_noasync.nim
+++ b/tests/async/tasync_noasync.nim
@@ -1,6 +1,35 @@
 discard """
-  errormsg: "'yield' only allowed in an iterator"
-  cmd: "nim c $file"
+  cmd: "nim check --hints:off --warnings:off $file"
+  action: "reject"
+  nimout:'''
+stack trace: (most recent call last)
+asyncmacro.nim(153, 19)  nonAsyncProc
+tasync_noasync.nim(42, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+stack trace: (most recent call last)
+asyncmacro.nim(153, 19)  nested
+tasync_noasync.nim(44, 27) template/generic instantiation of `async` from here
+tasync_noasync.nim(46, 11) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+stack trace: (most recent call last)
+asyncmacro.nim(153, 19)  customIterator
+tasync_noasync.nim(49, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+stack trace: (most recent call last)
+asyncmacro.nim(153, 19)  awaitInMacro
+tasync_noasync.nim(52, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+stack trace: (most recent call last)
+asyncmacro.nim(153, 19)  improperMultisync
+tasync_noasync.nim(54, 26) template/generic instantiation of `multisync` from here
+tasync_noasync.nim(55, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+stack trace: (most recent call last)
+asyncmacro.nim(153, 19)  tasync_noasync
+tasync_noasync.nim(57, 7) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+'''
+  nimoutFull: true
   file: "asyncmacro.nim"
 """
 import async
@@ -8,7 +37,37 @@ import async
 proc a {.async.} =
   discard
 
+# Bad await usage
+proc nonAsyncProc =
+  await a()
+
+proc nestedNonAsyncProc {.async.} =
+  proc nested =
+    await a()
+
+iterator customIterator: int =
+  await a()
+
+macro awaitInMacro =
+  await a()
+
+proc improperMultisync {.multisync.} =
+  await a()
+
 await a()
+
+
+# Good await usage
+proc asyncProc {.async.} =
+  await a()
+
+proc nestedAsyncProc {.async.} =
+  proc nested {.async.} =
+    await a()
+
+proc asyncBlock {.async.} =
+  block:
+    await a()
 
 # if we overload a fallback handler to get
 # await only available within {.async.}

--- a/tests/async/tasync_noasync.nim
+++ b/tests/async/tasync_noasync.nim
@@ -1,33 +1,37 @@
 discard """
   cmd: "nim check --hints:off --warnings:off $file"
   action: "reject"
-  nimout:'''
+  nimout: '''
 stack trace: (most recent call last)
-asyncmacro.nim(153, 19)  nonAsyncProc
-tasync_noasync.nim(42, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+asyncmacro.nim(136, 18)  nonAsyncProc
+tasync_noasync.nim(46, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
-asyncmacro.nim(153, 19)  nested
-tasync_noasync.nim(44, 27) template/generic instantiation of `async` from here
-tasync_noasync.nim(46, 11) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+asyncmacro.nim(136, 18)  nested
+tasync_noasync.nim(48, 27) template/generic instantiation of `async` from here
+tasync_noasync.nim(50, 11) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
-asyncmacro.nim(153, 19)  customIterator
-tasync_noasync.nim(49, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+asyncmacro.nim(136, 18)  customIterator
+tasync_noasync.nim(53, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
-asyncmacro.nim(153, 19)  awaitInMacro
-tasync_noasync.nim(52, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+asyncmacro.nim(136, 18)  awaitInMacro
+tasync_noasync.nim(56, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
-asyncmacro.nim(153, 19)  improperMultisync
-tasync_noasync.nim(54, 26) template/generic instantiation of `multisync` from here
-tasync_noasync.nim(55, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+asyncmacro.nim(136, 18)  awaitInMethod
+tasync_noasync.nim(60, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 stack trace: (most recent call last)
-asyncmacro.nim(153, 19)  tasync_noasync
-tasync_noasync.nim(57, 7) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(153, 19) Error: Can only 'await' inside a 'async' marked proc.
+asyncmacro.nim(136, 18)  improperMultisync
+tasync_noasync.nim(62, 26) template/generic instantiation of `multisync` from here
+tasync_noasync.nim(63, 9) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+stack trace: (most recent call last)
+asyncmacro.nim(136, 18)  tasync_noasync
+tasync_noasync.nim(65, 7) template/generic instantiation of `await` from here
+../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 '''
   nimoutFull: true
   file: "asyncmacro.nim"
@@ -49,6 +53,10 @@ iterator customIterator: int =
   await a()
 
 macro awaitInMacro =
+  await a()
+
+type DummyRef = ref object of RootObj
+method awaitInMethod(_: DummyRef) {.base.} =
   await a()
 
 proc improperMultisync {.multisync.} =

--- a/tests/async/tasync_noasync.nim
+++ b/tests/async/tasync_noasync.nim
@@ -2,40 +2,14 @@ discard """
   cmd: "nim check --hints:off --warnings:off $file"
   action: "reject"
   nimout: '''
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  nonAsyncProc
-tasync_noasync.nim(47, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  nested
-tasync_noasync.nim(49, 27) template/generic instantiation of `async` from here
-tasync_noasync.nim(51, 11) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  customIterator
-tasync_noasync.nim(54, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  awaitInMacro
-tasync_noasync.nim(57, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  awaitInMethod
-tasync_noasync.nim(61, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  improperMultisync
-tasync_noasync.nim(63, 26) template/generic instantiation of `multisync` from here
-tasync_noasync.nim(64, 9) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
-stack trace: (most recent call last)
-asyncmacro.nim(136, 18)  tasync_noasync
-tasync_noasync.nim(66, 7) template/generic instantiation of `await` from here
-../../lib/pure/asyncmacro.nim(136, 18) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(21, 10) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(25, 12) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(28, 10) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(31, 10) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(35, 10) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(38, 10) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
+tasync_noasync.nim(40, 8) Error: Can only 'await' inside a proc marked as 'async'. Use 'waitFor' when calling an 'async' proc in a non-async scope instead
 '''
-  nimoutFull: true
-  disabled: "win"
-  file: "asyncmacro.nim"
 """
 import async
 
@@ -64,19 +38,6 @@ proc improperMultisync {.multisync.} =
   await a()
 
 await a()
-
-
-# Good await usage
-proc asyncProc {.async.} =
-  await a()
-
-proc nestedAsyncProc {.async.} =
-  proc nested {.async.} =
-    await a()
-
-proc asyncBlock {.async.} =
-  block:
-    await a()
 
 # if we overload a fallback handler to get
 # await only available within {.async.}


### PR DESCRIPTION
Currently attempting to use `await` in a non-`async` context gives the error message `'yield' only allowed in an iterator`.
This pull request changes `await` to raise a better error by first checking if the template is used in an `async` proc, and raising an error if it is not.