### PR TITLE
Fixed exported generic false error with nimsuggest

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1416,7 +1416,7 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
     let rootf = f.skipGenericAlias
 
     if a.kind == tyGenericInst:
-      if roota.base == rootf.base:
+      if sameType(roota.base, rootf.base):
         let nextFlags = flags + {trNoCovariance}
         var hasCovariance = false
         # YYYY

--- a/nimsuggest/tests/tchk_exported_generic.nim
+++ b/nimsuggest/tests/tchk_exported_generic.nim
@@ -1,0 +1,18 @@
+# test we get some suggestion at the end of the file
+
+# Test for #19371
+type BinaryTree[T] = object
+
+proc add*[T](this: BinaryTree[T]) = discard
+proc doOtherThing[T](this: BinaryTree[T]) = discard
+
+add(BinaryTree[string]())
+doOtherThing(BinaryTree[string]())
+
+
+#[!]#
+discard """
+$nimsuggest --tester $file
+>chk $1
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;">> (toplevel): import(dirty): tests/tchk_exported_generic.nim [Processing]";;0
+"""


### PR DESCRIPTION
`==` does not always work for nimsuggest as they're different pointers, so seems `sameType` should be used here.
closes: https://github.com/nim-lang/Nim/issues/19371
Any suggestion on how to test this would be welcomed.