### PR TITLE
Remove Deprecated domextension

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@ becomes an alias for `addr`.
 - Removed deprecated `jsre.test` and `jsre.toString`.
 - Removed deprecated `math.c_frexp`.
 - Removed deprecated ``` httpcore.`==` ```.
+- Removed deprecated `std/dom_extensions`.
 
 
 ## Language changes

--- a/lib/js/dom_extensions.nim
+++ b/lib/js/dom_extensions.nim
@@ -1,3 +1,0 @@
-import std/dom
-export elementsFromPoint
-{.deprecated: "use `std/dom` instead".}


### PR DESCRIPTION
- Remove Deprecated JavaScript domextension.
- Chronos package fails CI unrelated.
