### PR TITLE
Remove deprecated typo poDemon

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,6 +47,8 @@ becomes an alias for `addr`.
 - Removed deprecated `math.c_frexp`.
 - Removed deprecated ``` httpcore.`==` ```.
 
+- Remove deprecated `osproc.poDemon`, symbol with typo.
+
 
 ## Language changes
 

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -66,11 +66,6 @@ type
 
   Process* = ref ProcessObj ## Represents an operating system process.
 
-const poDemon* {.deprecated.} = poDaemon ## Nim versions before 0.20
-                                         ## used the wrong spelling ("demon").
-                                         ## Now `ProcessOption` uses the correct spelling ("daemon"),
-                                         ## and this is needed just for backward compatibility.
-
 
 proc execProcess*(command: string, workingDir: string = "",
     args: openArray[string] = [], env: StringTableRef = nil,


### PR DESCRIPTION
- Remove Deprecated typo `osproc.poDemon`.
- Chronos package fails CI unrelated.
