### PR TITLE
Embedded Network patches - eventfd & socket getters

### DIFF
--- a/lib/pure/ioselects/ioselectors_poll.nim
+++ b/lib/pure/ioselects/ioselectors_poll.nim
@@ -200,7 +200,7 @@ proc newSelectEvent*(): SelectEvent =
     result.rfd = fds[0]
     result.wfd = fds[1]
   else: 
-    let fdci = eventfd(0, O_CLOEXEC or O_NONBLOCK)
+    let fdci = eventfd(0, posix.O_NONBLOCK)
     if fdci == -1:
       raiseIOSelectorsError(osLastError())
     result = cast[SelectEvent](allocShared0(sizeof(SelectEventImpl)))

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1798,6 +1798,15 @@ proc isSsl*(socket: Socket): bool =
 proc getFd*(socket: Socket): SocketHandle = return socket.fd
   ## Returns the socket's file descriptor
 
+proc getDomain*(socket: Socket): Domain = return socket.domain
+  ## Returns the socket's domain
+
+proc getType*(socket: Socket): SockType = return socket.sockType
+  ## Returns the socket's type
+
+proc getProtocol*(socket: Socket): Protocol = return socket.protocol
+  ## Returns the socket's protocol
+
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}
 

--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1798,14 +1798,15 @@ proc isSsl*(socket: Socket): bool =
 proc getFd*(socket: Socket): SocketHandle = return socket.fd
   ## Returns the socket's file descriptor
 
-proc getDomain*(socket: Socket): Domain = return socket.domain
-  ## Returns the socket's domain
+when defined(zephyr) or defined(nimNetSocketExtras): # Remove in future
+  proc getDomain*(socket: Socket): Domain = return socket.domain
+    ## Returns the socket's domain
 
-proc getType*(socket: Socket): SockType = return socket.sockType
-  ## Returns the socket's type
+  proc getType*(socket: Socket): SockType = return socket.sockType
+    ## Returns the socket's type
 
-proc getProtocol*(socket: Socket): Protocol = return socket.protocol
-  ## Returns the socket's protocol
+  proc getProtocol*(socket: Socket): Protocol = return socket.protocol
+    ## Returns the socket's protocol
 
 when defined(nimHasStyleChecks):
   {.push styleChecks: off.}


### PR DESCRIPTION
This PR enables support for using `event` when using `poll` as the selectors back-end. The option is gated behind `nimPollHasEventFds` or `zephyr` flags. 

Zephyr copied Linux's `eventfd` mechanism for fast selector based user events. However Nim's selector library only supports `eventfd` on Linux. The `eventfd` mechanism is significantly faster for user events which we use throughout our embedded networking services. 

Alongside the selector changes are getters for accessing a given socket's protocol and type. It's tedious to have to wrap the `Socket` type inside another type just to store (again) a given socket's domain or protocol. 
