### PR TITLE
system: thread: stack dealloction on Zephyr

### DIFF
--- a/lib/system/threads.nim
+++ b/lib/system/threads.nim
@@ -47,7 +47,10 @@
 when not declared(ThisIsSystem):
   {.error: "You must not import this module explicitly".}
 
-when defined(zephyr) or defined(freertos):
+const
+  hasAllocStack = defined(zephyr) # maybe freertos too?
+
+when hasAllocStack or defined(zephyr) or defined(freertos):
   const
     nimThreadStackSize {.intdefine.} = 8192 
     nimThreadStackGuard {.intdefine.} = 128
@@ -67,6 +70,12 @@ else:
 
 #const globalsSlot = ThreadVarSlot(0)
 #sysAssert checkSlot.int == globalsSlot.int
+
+# Zephyr doesn't include this properly without some help
+when defined(zephyr):
+  {.emit: """/*INCLUDESECTION*/
+  #include <pthread.h>
+  """.}
 
 # create for the main thread. Note: do not insert this data into the list
 # of all threads; it's not to be stopped etc.
@@ -98,6 +107,8 @@ type
     else:
       dataFn: proc (m: TArg) {.nimcall, gcsafe.}
       data: TArg
+    when hasAllocStack:
+      rawStack: pointer
 
 proc `=copy`*[TArg](x: var Thread[TArg], y: Thread[TArg]) {.error.}
 
@@ -161,6 +172,8 @@ else:
       threadTrouble()
     finally:
       afterThreadRuns()
+      when hasAllocStack:
+        deallocShared(thrd.rawStack)
 
 proc threadProcWrapStackFrame[TArg](thrd: ptr Thread[TArg]) {.raises: [].} =
   when defined(boehmgc):
@@ -330,11 +343,12 @@ else:
     when hasSharedHeap: t.core.stackSize = ThreadStackSize
     var a {.noinit.}: Pthread_attr
     doAssert pthread_attr_init(a) == 0
-    when defined(zephyr):
+    when hasAllocStack:
       var
         rawstk = allocShared0(ThreadStackSize + StackGuardSize)
         stk = cast[pointer](cast[uint](rawstk) + StackGuardSize)
       let setstacksizeResult = pthread_attr_setstack(addr a, stk, ThreadStackSize)
+      t.rawStack = rawstk
     else:
       let setstacksizeResult = pthread_attr_setstacksize(a, ThreadStackSize)
 


### PR DESCRIPTION
Try to free the stack allocation when a thread exits. Possibly works for FreeRTOS as well.