### PR TITLE
Fixed formatting error for warningAsError in advopt.txt.

### DIFF
--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -57,7 +57,8 @@ Advanced options:
   -w:on|off|list, --warnings:on|off|list
                             same as `--hints` but for warnings.
   --warning:X:on|off        ditto
-  --warningAsError:X:on|off ditto
+  --warningAsError:X:on|off
+                            ditto
   --styleCheck:off|hint|error
                             produce hints or errors for Nim identifiers that
                             do not adhere to Nim's official style guide


### PR DESCRIPTION
There was only a single space character between the warning and its description, so it shows up as part of the name (in bold) and with no description.
Copied the way hotCodeReloading was formatted, with the description in a new line.