### PR TITLE
Fixed description as option in advopt.txt

### DIFF
--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -56,7 +56,7 @@ Advanced options:
   --hintAsError:X:on|off    turn specific hint X into an error on|off
   -w:on|off|list, --warnings:on|off|list
                             `on|off` enables or disables warnings.
-                            `list` reports which hints are selected.
+                            `list` reports which warnings are selected.
   --warning:X:on|off        turn specific warning X on|off. `warning:X` means `warning:X:on`,
                             as with similar flags. `all` is the set of all warning
                             (only `all:off` is supported).

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -55,9 +55,13 @@ Advanced options:
                             (only `all:off` is supported).
   --hintAsError:X:on|off    turn specific hint X into an error on|off
   -w:on|off|list, --warnings:on|off|list
-                            same as `--hints` but for warnings.
-  --warning:X:on|off        ditto
-  --warningAsError:X:on|off ditto
+                            `on|off` enables or disables warnings.
+                            `list` reports which hints are selected.
+  --warning:X:on|off        turn specific warning X on|off. `warning:X` means `warning:X:on`,
+                            as with similar flags. `all` is the set of all warning
+                            (only `all:off` is supported).
+  --warningAsError:X:on|off
+                            turn specific warning X into an error on|off
   --styleCheck:off|hint|error
                             produce hints or errors for Nim identifiers that
                             do not adhere to Nim's official style guide


### PR DESCRIPTION
There was only a single space character between the warning and its description, so it shows up as part of the name (in bold) and with no description.

Copied the way hotCodeReloading was formatted, with the description in a new line.

This is how it looked before.
![](https://user-images.githubusercontent.com/47699779/159538722-e2ade923-5062-44b9-bbd5-28a796c9010e.png)
