### PR TITLE
Fix dial ignoring buffered parameter

### DIFF
--- a/lib/pure/net.nim
+++ b/lib/pure/net.nim
@@ -1963,7 +1963,7 @@ proc dial*(address: string, port: Port,
   closeUnusedFds(ord(domain))
 
   if success:
-    result = newSocket(lastFd, domain, sockType, protocol)
+    result = newSocket(lastFd, domain, sockType, protocol, buffered)
   elif lastError != 0.OSErrorCode:
     raiseOSError(lastError)
   else:


### PR DESCRIPTION
There is a bug in `std/net` whereby `dial` doesn't pass the `buffered` param to `newSocket` once a connection is established, this PR fixes that.