### PR TITLE
macros.error is a noreturn proc

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -398,7 +398,7 @@ proc newNimNode*(kind: NimNodeKind,
 proc copyNimNode*(n: NimNode): NimNode {.magic: "NCopyNimNode", noSideEffect.}
 proc copyNimTree*(n: NimNode): NimNode {.magic: "NCopyNimTree", noSideEffect.}
 
-proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign.}
+proc error*(msg: string, n: NimNode = nil) {.magic: "NError", benign, noreturn.}
   ## Writes an error message at compile time. The optional `n: NimNode`
   ## parameter is used as the source for file and line number information in
   ## the compilation error message.


### PR DESCRIPTION
I don't think the compilation can recover from it