### PR TITLE
Deprecate selfExe

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -50,6 +50,8 @@ becomes an alias for `addr`.
 
 - Remove deprecated `osproc.poDemon`, symbol with typo.
 
+- Deprecated `selfExe` for Nimscript.
+
 
 ## Language changes
 

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -136,9 +136,8 @@ proc dirExists*(dir: string): bool {.
   ## Checks if the directory `dir` exists.
   builtin
 
-proc selfExe*(): string =
+proc selfExe*(): string {.deprecated: "Deprecated since v1.7; Use getCurrentCompilerExe".} =
   ## Returns the currently running nim or nimble executable.
-  # TODO: consider making this as deprecated alias of `getCurrentCompilerExe`
   builtin
 
 proc toExe*(filename: string): string =


### PR DESCRIPTION
- Deprecate `selfExe`.
- Duplicated code with `getCurrentCompilerExe`.
- This is only for Nimscript.
- It had a "TODO" comment about Deprecating it.
- No code is removed.
