### PR TITLE
Rephrase 'insert' example in algorithm.nim

### DIFF
--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -224,7 +224,7 @@ proc lowerBound*[T, K](a: openArray[T], key: K,
   ## (i.e. greater or equal to) `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, lowerBound(thing, elm))`
-  ## elm will be inserted and the sequence will still be sorted.
+  ## `elm` will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted according to `cmp`.
   ##
   ## If an invalid range is passed, it raises `IndexDefect`.
@@ -259,7 +259,7 @@ proc lowerBound*[T](a: openArray[T], key: T): int = lowerBound(a, key, cmp[T])
   ## (i.e. greater or equal to) `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, lowerBound(thing, elm))`
-  ## elm will be inserted and the sequence will still be sorted.
+  ## `elm` will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted.
   ##
   ## This version uses the default comparison function `cmp`.
@@ -274,7 +274,7 @@ proc upperBound*[T, K](a: openArray[T], key: K,
   ## `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, upperBound(thing, elm))`
-  ## elm will be inserted and the sequence will still be sorted.
+  ## `elm` will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted according to `cmp`.
   ##
   ## If an invalid range is passed, it raises `IndexDefect`.
@@ -309,7 +309,7 @@ proc upperBound*[T](a: openArray[T], key: T): int = upperBound(a, key, cmp[T])
   ## `key`, or last if no such element is found.
   ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, upperBound(thing, elm))`
-  ## elm will be inserted and the sequence will still be sorted.
+  ## `elm` will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted.
   ##
   ## This version uses the default comparison function `cmp`.

--- a/lib/pure/algorithm.nim
+++ b/lib/pure/algorithm.nim
@@ -222,9 +222,9 @@ proc lowerBound*[T, K](a: openArray[T], key: K,
                        cmp: proc(x: T, k: K): int {.closure.}): int {.effectsOf: cmp.} =
   ## Returns the index of the first element in `a` that is not less than
   ## (i.e. greater or equal to) `key`, or last if no such element is found.
-  ## In other words if you have a sorted sequence and you call
+  ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, lowerBound(thing, elm))`
-  ## the sequence will still be sorted.
+  ## elm will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted according to `cmp`.
   ##
   ## If an invalid range is passed, it raises `IndexDefect`.
@@ -257,9 +257,9 @@ proc lowerBound*[T, K](a: openArray[T], key: K,
 proc lowerBound*[T](a: openArray[T], key: T): int = lowerBound(a, key, cmp[T])
   ## Returns the index of the first element in `a` that is not less than
   ## (i.e. greater or equal to) `key`, or last if no such element is found.
-  ## In other words if you have a sorted sequence and you call
+  ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, lowerBound(thing, elm))`
-  ## the sequence will still be sorted.
+  ## elm will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted.
   ##
   ## This version uses the default comparison function `cmp`.
@@ -272,9 +272,9 @@ proc upperBound*[T, K](a: openArray[T], key: K,
                        cmp: proc(x: T, k: K): int {.closure.}): int {.effectsOf: cmp.} =
   ## Returns the index of the first element in `a` that is greater than
   ## `key`, or last if no such element is found.
-  ## In other words if you have a sorted sequence and you call
+  ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, upperBound(thing, elm))`
-  ## the sequence will still be sorted.
+  ## elm will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted according to `cmp`.
   ##
   ## If an invalid range is passed, it raises `IndexDefect`.
@@ -307,9 +307,9 @@ proc upperBound*[T, K](a: openArray[T], key: K,
 proc upperBound*[T](a: openArray[T], key: T): int = upperBound(a, key, cmp[T])
   ## Returns the index of the first element in `a` that is greater than
   ## `key`, or last if no such element is found.
-  ## In other words if you have a sorted sequence and you call
+  ## In other words if you have a sorted sequence `thing` and you call
   ## `insert(thing, elm, upperBound(thing, elm))`
-  ## the sequence will still be sorted.
+  ## elm will be inserted and the sequence will still be sorted.
   ## Assumes that `a` is sorted.
   ##
   ## This version uses the default comparison function `cmp`.


### PR DESCRIPTION
Added a little more context to the example of an `insert` that keeps the sequence sorted in both `upperBounds` and `lowerBound`s.