### PR TITLE
remove useless compilation condition

### DIFF
--- a/testament/important_packages.nim
+++ b/testament/important_packages.nim
@@ -100,7 +100,7 @@ pkg "nimcrypto", "nim r --path:. tests/testall.nim" # `--path:.` workaround need
 pkg "NimData", "nim c -o:nimdataa src/nimdata.nim"
 pkg "nimes", "nim c src/nimes.nim"
 pkg "nimfp", "nim c -o:nfp -r src/fp.nim"
-pkg "nimgame2", "nim c -d:nimLegacyConvEnumEnum nimgame2/nimgame.nim"
+pkg "nimgame2", "nim c nimgame2/nimgame.nim"
   # XXX Doesn't work with deprecated 'randomize', will create a PR.
 pkg "nimgen", "nim c -o:nimgenn -r src/nimgen/runcfg.nim"
 pkg "nimlsp", allowFailure = true


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/18546

`d:nimLegacyConvEnumEnum` is reverted by #18546