### PR TITLE
std/tasks: fix spelling

### DIFF
--- a/lib/std/tasks.nim
+++ b/lib/std/tasks.nim
@@ -87,7 +87,7 @@ template checkIsolate(scratchAssignList: seq[NimNode], procParam, scratchDotExpr
   let isolatedTemp = genSym(nskTemp, "isoTemp")
   scratchAssignList.add newVarStmt(isolatedTemp, newCall(newidentNode("isolate"), procParam))
   scratchAssignList.add newAssignment(scratchDotExpr,
-      newcall(newIdentNode("extract"), isolatedTemp))
+      newCall(newIdentNode("extract"), isolatedTemp))
 
 template addAllNode(assignParam: NimNode, procParam: NimNode) =
   let scratchDotExpr = newDotExpr(scratchIdent, formalParams[i][0])
@@ -154,7 +154,7 @@ macro toTask*(e: typed{nkCall | nkInfix | nkPrefix | nkPostfix | nkCommand | nkC
             error("'toTask'ed function cannot have a 'typed' or 'untyped' parameter")
           let
             seqType = nnkBracketExpr.newTree(newIdentNode("seq"), param[1])
-            seqCallNode = newcall("@", e[i])
+            seqCallNode = newCall("@", e[i])
           addAllNode(seqType, seqCallNode)
         else:
           addAllNode(param, e[i])


### PR DESCRIPTION
why aren't these not being caught by style check options?
--styleCheck:usages finds it.