### PR TITLE
StringStreams no longer errors when intialized with literals on arc/orc

### DIFF
--- a/lib/pure/streams.nim
+++ b/lib/pure/streams.nim
@@ -1274,6 +1274,8 @@ else: # after 1.3 or JS not defined
 
     new(result)
     result.data = s
+    when defined(gcOrc) or defined(gcArc):
+      prepareMutation(result.data) # Allows us to mutate using `addr` logic like `copyMem`, otherwise it errors.
     result.pos = 0
     result.closeImpl = ssClose
     result.atEndImpl = ssAtEnd

--- a/tests/stdlib/tstreams.nim
+++ b/tests/stdlib/tstreams.nim
@@ -74,3 +74,5 @@ block:
   doAssert(ss.peekLine(str))
   doAssert(str == "uick brown fox jumped over the lazy dog.")
   doAssert(ss.getPosition == 5) # haven't moved
+  ss.setPosition(0) # Ensure we dont error with writing over literals on arc/orc #19707
+  ss.write("hello")


### PR DESCRIPTION
Closes: https://github.com/nim-lang/Nim/issues/19707
Ideally backported :smile: 