### PR TITLE
Strings can now implicitly convert to openarrays made with typeclasses

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -1244,7 +1244,8 @@ proc typeRel(c: var TCandidate, f, aOrig: PType,
       matchArrayOrSeq(a[0])
     of tyString:
       if f.kind == tyOpenArray:
-        if f[0].kind == tyChar:
+        if f[0].kind == tyChar or typeRel(c, base(f), newTypeS(tyChar, c.c), flags) >= isGeneric:
+          # if it's `openarray[char]` or any other one that'd take it like `openarray[int or char]` or `openarray[not int]`
           result = isConvertible
         elif f[0].kind == tyGenericParam and a.len > 0 and
             typeRel(c, base(f), base(a), flags) >= isGeneric:

--- a/tests/openarray/topenarray.nim
+++ b/tests/openarray/topenarray.nim
@@ -48,6 +48,14 @@ proc main =
       doAssert testing(mySeq) == mySeq
       doAssert testing(mySeq[2..^2]) == mySeq[2..^2]
 
+  ## Checks that openarrays with typeclasses still accept strings
+  proc doThing(a: openArray[char]) = discard
+  proc doOtherThing(a: openArray[char or int]) = discard
+  proc doOthererThing(a: openArray[not float]) = discard
+
+  doThing("hello")
+  doOtherThing("hello")
+  doOthererThing("hello")
 
 main()
 # static: main() # xxx bug #15952: Error: cannot generate code for: mSlice


### PR DESCRIPTION
Do not know if there is a better way to check if it's equivalent to `tyChar`.  I imagine it should be backported.