### PR TITLE
document localPassC consistently with compiler; fix ANSI capitalization

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -1370,7 +1370,7 @@ cstring type
 The `cstring` type meaning `compatible string` is the native representation
 of a string for the compilation backend. For the C backend the `cstring` type
 represents a pointer to a zero-terminated char array
-compatible with the type `char*` in Ansi C. Its primary purpose lies in easy
+compatible with the type `char*` in ANSI C. Its primary purpose lies in easy
 interfacing with C. The index operation `s[i]` means the i-th *char* of
 `s`; however no bounds checking for `cstring` is performed making the
 index operation unsafe.
@@ -7218,16 +7218,16 @@ during semantic analysis:
   {.passc: gorge("pkg-config --cflags sdl").}
 
 
-LocalPassc pragma
+localPassC pragma
 -----------------
-The `localPassc` pragma can be used to pass additional parameters to the C
+The `localPassC` pragma can be used to pass additional parameters to the C
 compiler, but only for the C/C++ file that is produced from the Nim module
 the pragma resides in:
 
 .. code-block:: Nim
   # Module A.nim
   # Produces: A.nim.cpp
-  {.localPassc: "-Wall -Werror".} # Passed when compiling A.nim.cpp
+  {.localPassC: "-Wall -Werror".} # Passed when compiling A.nim.cpp
 
 
 PassL pragma


### PR DESCRIPTION
Addresses the ANSI capitalization in https://github.com/nim-lang/website/issues/279

Used the manual's example of `localPassc`:
```nim
{.localPassc: "-Wall -Werror".}
```

Compiled with:
```
nim c --stylecheck:error localpassc.nim
```
and got
```
localpassc.nim(1, 3) Error: 'localPassc' should be: 'localPassC'
```

Checked the capitalizations the compiler expected using versions:
```
Nim Compiler Version 1.6.4 [Linux: amd64]
Compiled at 2022-02-10
Copyright (c) 2006-2021 by Andreas Rumpf

active boot switches: -d:release
```
```
Nim Compiler Version 1.7.1 [Linux: amd64]
Compiled at 2022-04-13
Copyright (c) 2006-2022 by Andreas Rumpf

git hash: 98cebad7debddfb147ee22bc6f3d81221582c4d6
active boot switches: -d:release
```

```nim
{.localPassC: "-Wall -Werror".}
```
indeed works, `stylecheck` or otherwise.

So the compiler is expecting `localPassC`. Without `stylecheck`, it doesn't matter, but with stylecheck, the manual incorrectly specifies what the compiler will accept.