### PR TITLE
Fixed nimsuggest bug comparing different pointers to the same PType/P…

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -998,6 +998,11 @@ type
 
 template nodeId(n: PNode): int = cast[int](n)
 
+when defined(nimsuggest):
+  proc `==`*[T: PIdObj](a, b: T): bool {.inline.} =
+    system.`==`(a, b) or (not(system.`==`(a, nil)) and not(system.`==`(b, nil)) and a.itemId == b.itemId)
+  proc `==`*(a, b: PType): bool {.inline.} = PIdObj(a) == PIdObj(b)
+
 type Gconfig = object
   # we put comments in a side channel to avoid increasing `sizeof(TNode)`, which
   # reduces memory usage given that `PNode` is the most allocated type by far.

--- a/nimsuggest/tests/tchk1_pointermismatch.nim
+++ b/nimsuggest/tests/tchk1_pointermismatch.nim
@@ -1,0 +1,30 @@
+type BinaryTree*[T] = ref object
+  left, right: BinaryTree[T]
+  data: T
+
+proc newNode*[T](data: T): BinaryTree[T] =
+  new(result)
+  result.data = data
+
+proc add*[T](this: var BinaryTree[T], n: BinaryTree[T]) =
+  discard
+
+type
+  MyBase = ref object of RootObj
+  MyChild = ref object of MyBase
+
+method doThing(base: MyBase) {.base.} = discard
+method doThing(base: MyChild) = discard
+
+# instantiate a BinaryTree with `string`
+var root: BinaryTree[string]
+# instantiates `newNode` and `add`
+root.add(newNode("hello"))
+
+
+#[!]#
+discard """
+$nimsuggest --tester $file
+>chk $1
+chk;;skUnknown;;;;Hint;;???;;0;;-1;;">> (toplevel): import(dirty): tests/tchk1_pointermismatch.nim [Processing]";;0
+"""


### PR DESCRIPTION
…Sym, with a new '==' op

It's the best working solution I can find and resolves @avahe-kellenberger 's issues. Though obviously would be best to resolve the source of the copies, but I cannot find where/why the duplicates are made.

Would close: https://github.com/nim-lang/Nim/issues/19371