### PR TITLE
Make sure that field usage preserves the original line info

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1436,8 +1436,10 @@ proc builtinFieldAccess(c: PContext, n: PNode, flags: TExprFlags): PNode =
         # is the access to a public field or in the same module or in a friend?
         markUsed(c, n[1].info, f)
         onUse(n[1].info, f)
+        let info = n[1].info
         n[0] = makeDeref(n[0])
         n[1] = newSymNode(f) # we now have the correct field
+        n[1].info = info # preserve the original info
         n.typ = f.typ
         if check == nil:
           result = n

--- a/nimsuggest/tests/tuse_structure.nim
+++ b/nimsuggest/tests/tuse_structure.nim
@@ -1,0 +1,15 @@
+# tests for use and structures
+
+type
+  Foo* = ref object of RootObj
+    bar*: string
+
+proc test(f: Foo) =
+  echo f.#[!]#bar
+
+discard """
+$nimsuggest --tester $file
+>use $1
+def	skField	tuse_structure.Foo.bar	string	$file	5	4	""	100
+use	skField	tuse_structure.Foo.bar	string	$file	8	9	""	100
+"""


### PR DESCRIPTION
Currently `struct.field` will generate a node with `info` that points to the
symbol definition instead of having the actual node location.