### PR TITLE
Fix link to experimental manual in macro pragmas section

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -7814,7 +7814,7 @@ the same way.
 There are a few more applications of macro pragmas, such as in type,
 variable and constant declarations, but this behavior is considered to be
 experimental and is documented in the `experimental manual
-<manual_experimental.html#extended-macro-pragmas>` instead.
+<manual_experimental.html#extended-macro-pragmas>`_ instead.
 
 
 Foreign function interface


### PR DESCRIPTION
Link to the experimental manual in the final paragraph [here](https://nim-lang.github.io/Nim/manual.html#userminusdefined-pragmas-macro-pragmas) was missing an underscore