### PR TITLE
Add 'usages' option to the --stylechecks error msg

### DIFF
--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -116,7 +116,7 @@ const
   errInvalidCmdLineOption = "invalid command line option: '$1'"
   errOnOrOffExpectedButXFound = "'on' or 'off' expected, but '$1' found"
   errOnOffOrListExpectedButXFound = "'on', 'off' or 'list' expected, but '$1' found"
-  errOffHintsError = "'off', 'hint' or 'error' expected, but '$1' found"
+  errOffHintsError = "'off', 'hint', 'error' or 'usages' expected, but '$1' found"
 
 proc invalidCmdLineOption(conf: ConfigRef; pass: TCmdLinePass, switch: string, info: TLineInfo) =
   if switch == " ": localError(conf, info, errInvalidCmdLineOption % "-")
@@ -508,7 +508,7 @@ proc registerArcOrc(pass: TCmdLinePass, conf: ConfigRef, isOrc: bool) =
   else:
     conf.selectedGC = gcArc
     defineSymbol(conf.symbols, "gcarc")
-  
+
   defineSymbol(conf.symbols, "gcdestructors")
   incl conf.globalOptions, optSeqDestructors
   incl conf.globalOptions, optTinyRtti


### PR DESCRIPTION
Adds mention of 'usages' option to the compiler's --stylechecks error message.

Previous output output on passing the wrong option:
`Error: 'off', 'hint' or 'error' expected, but 'foo' found`

Now:
`Error: 'off', 'hint', 'error' or 'usages' expected, but 'foo' found`