### PR TITLE
"ip" protocol as id 0 is long gone

### DIFF
--- a/tests/stdlib/tgetprotobyname.nim
+++ b/tests/stdlib/tgetprotobyname.nim
@@ -1,9 +1,5 @@
 import nativesockets
 
-when not defined(netbsd):
-  # Ref: https://github.com/nim-lang/Nim/issues/15452 - NetBSD doesn't define an `ip` protocol
-  doAssert getProtoByName("ip") == 0
-
 doAssert getProtoByName("ipv6") == 41
 doAssert getProtoByName("tcp") == 6
 doAssert getProtoByName("udp") == 17


### PR DESCRIPTION
IANA is using id 0 for "HOPOPT" instead of "ip"
for some time now and those systems that still
support the old mapping will stop doing so at
some point in the future.
    
Some BSDs and openSUSE are already following this
change as per IANA list here:
https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
    
As new unixes (and maybe Windows, who knows) start
to adopt the updated IANA list, this will keep
failing from time to time, so it's better to
remove the "ip" check altogether.