### PR TITLE
Remove deprecated posix proc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -47,7 +47,7 @@ becomes an alias for `addr`.
 - Removed deprecated `math.c_frexp`.
 - Removed deprecated ``` httpcore.`==` ```.
 - Removed deprecated `std/dom_extensions`.
-
+- Removed deprecated `std/posix.CMSG_SPACE` and `std/posix.CMSG_LEN` that takes wrong argument types.
 - Remove deprecated `osproc.poDemon`, symbol with typo.
 
 - Deprecated `selfExe` for Nimscript.

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -894,18 +894,8 @@ proc CMSG_NXTHDR*(mhdr: ptr Tmsghdr, cmsg: ptr Tcmsghdr): ptr Tcmsghdr {.
 proc CMSG_FIRSTHDR*(mhdr: ptr Tmsghdr): ptr Tcmsghdr {.
   importc, header: "<sys/socket.h>".}
 
-{.push warning[deprecated]: off.}
-proc CMSG_SPACE*(len: csize): csize {.
-  importc, header: "<sys/socket.h>", deprecated: "argument `len` should be of type `csize_t`".}
-{.pop.}
-
 proc CMSG_SPACE*(len: csize_t): csize_t {.
   importc, header: "<sys/socket.h>".}
-
-{.push warning[deprecated]: off.}
-proc CMSG_LEN*(len: csize): csize {.
-  importc, header: "<sys/socket.h>", deprecated: "argument `len` should be of type `csize_t`".}
-{.pop.}
 
 proc CMSG_LEN*(len: csize_t): csize_t {.
   importc, header: "<sys/socket.h>".}


### PR DESCRIPTION
- Remove deprecated `posix` proc that takes wrong argument types.
