### PR TITLE
string is missing formatting when calling fmt

### DIFF
--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -705,6 +705,6 @@ macro `&`*(pattern: string{lit}): string =
   runnableExamples:
     let x = 7
     assert &"{x}\n" == "7\n" # regular string literal
-    assert &"{x}\n" == "7\n".fmt # `fmt` can be used instead
-    assert &"{x}\n" != fmt"7\n" # see `fmt` docs, this would use a raw string literal
+    assert &"{x}\n" == "{x}\n".fmt # `fmt` can be used instead
+    assert &"{x}\n" != fmt"{x}\n" # see `fmt` docs, this would use a raw string literal
   strformatImpl(pattern.strVal, '{', '}')


### PR DESCRIPTION
it appears the documentation intends to compare & with .fmt but there is no formatting in the string. even though the assert is true it doesn't quite prove that .fmt is an equivalent formatter.