### PR TITLE
Doc preferred import style in compiler

### DIFF
--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -186,6 +186,7 @@ Coding Guidelines
 * Use a space after a colon, but not before it.
 * [deprecated] Start types with a capital `T`, unless they are
   pointers/references which start with `P`.
+* Prefer `import package`:nim: over `from package import symbol`:nim:.
 
 See also the `API naming design <apis.html>`_ document.
 


### PR DESCRIPTION
Both styles are used in the compiler.
I noticed that I was making more noise when I used the more constrained `from pkg import ...` form. I didn't know if there was a preference, so I asked on #internal and Araq said to prefer `import ...` even when only needing a few symbols.