### PR TITLE
Use vccexe when generating static lib with vcc

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -153,7 +153,7 @@ compiler vcc:
     compileTmpl: "/c$vccplatform $options $include /nologo /Fo$objfile $file",
     buildGui: " /SUBSYSTEM:WINDOWS user32.lib ",
     buildDll: " /LD",
-    buildLib: "lib /OUT:$libfile $objfiles",
+    buildLib: "vccexe --command:lib$vccplatform /nologo /OUT:$libfile $objfiles",
     linkerExe: "cl",
     linkTmpl: "$builddll$vccplatform /Fe$exefile $objfiles $buildgui /nologo $options",
     includeCmd: " /I",
@@ -675,7 +675,8 @@ proc getLinkCmd(conf: ConfigRef; output: AbsoluteFile,
     if removeStaticFile:
       removeFile output # fixes: bug #16947
     result = CC[conf.cCompiler].buildLib % ["libfile", quoteShell(output),
-                                            "objfiles", objfiles]
+                                            "objfiles", objfiles,
+                                            "vccplatform", vccplatform(conf)]
   else:
     var linkerExe = getConfigVar(conf, conf.cCompiler, ".linkerexe")
     if linkerExe.len == 0: linkerExe = getLinkerExe(conf, conf.cCompiler)


### PR DESCRIPTION
When you use vcc backend, you can build static library without running Nim on Visual studio command prompt.

Add `$vccplatform` to `buildLib` so that `vccexe` command takes parameter like `--platform:amd64` in the same way as Nim calls vcc compiler and linker.

Add `/nologo` option so that `lib` command doesn't print copyright message.