### PR TITLE
[Minor] export `nil` in system.nim so that it can appear on docs

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -42,7 +42,7 @@ type
   `ptr`*[T] {.magic: Pointer.}   ## Built-in generic untraced pointer type.
   `ref`*[T] {.magic: Pointer.}   ## Built-in generic traced pointer type.
 
-  `nil` {.magic: "Nil".}
+  `nil`* {.magic: "Nil".}
 
   void* {.magic: "VoidType".}    ## Meta type to denote the absence of any type.
   auto* {.magic: Expr.}          ## Meta type for automatic type determination.


### PR DESCRIPTION
After this change:

![image](https://user-images.githubusercontent.com/43030857/171409393-278c5b0a-18e4-4323-827b-0535c7a1cd01.png)

since https://github.com/nim-lang/Nim/commit/8b2a9401a147bd0b26cd2976ae71a1022fbde8cc
