### PR TITLE
Add `maindir` nimdoc configuration item that points to the directory of theindex.html

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1517,14 +1517,19 @@ proc genOutFile(d: PDoc, groupedToc = false): string =
                  elif d.hasToc: "doc.body_toc"
                  else: "doc.body_no_toc"
   let seeSrc = genSeeSrc(d, d.filename, 1)
+  let theindexhref = relLink(d.conf.outDir, d.destFile.AbsoluteFile,
+                             theindexFname.RelativeFile)
+  var maindir = splitPath(theindexhref)[0]
+  if maindir == "": maindir = "."
   content = getConfigVar(d.conf, bodyname) % [
       "title", title, "subtitle", subtitle,
       "tableofcontents", toc, "moduledesc", d.modDescFinal, "date", getDateStr(),
       "time", getClockStr(), "content", code,
       "deprecationMsg", d.modDeprecationMsg,
-      "theindexhref", relLink(d.conf.outDir, d.destFile.AbsoluteFile,
-                              theindexFname.RelativeFile),
-      "body_toc_groupsection", groupsection, "seeSrc", seeSrc]
+      "theindexhref", theindexhref,
+      "body_toc_groupsection", groupsection, "seeSrc", seeSrc,
+      "maindir", maindir
+      ]
   if optCompileOnly notin d.conf.globalOptions:
     # XXX what is this hack doing here? 'optCompileOnly' means raw output!?
     code = getConfigVar(d.conf, "doc.file") % [


### PR DESCRIPTION
This is done to support global links in the documentation's menu in the nimdoc.cfg as follows:

    <ul class="simple-boot">
      <li><a href="$maindir/index.html">Index</a></li>
      <li><a href="$maindir/mydoc.html">My documentation</a></li>
      <li><a href="$theindexhref">Generated index</a></li>
    </ul>

Using this $maindir configuration item, one might even get rid of the $theindexhref and use $maindir/theindex.html instead.