### PR TITLE
`changelog.md`: Add `strutils.find` changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,35 +24,39 @@ becomes an alias for `addr`.
 
 ## Standard library additions and changes
 
-- `macros.parseExpr` and `macros.parseStmt` now accept an optional
+[//]: # "Changes:"
+- `macros.parseExpr` and `macros.parseStmt` now accept an optional.
   filename argument for more informative errors.
 - Module `colors` expanded with missing colors from the CSS color standard.
 - Fixed `lists.SinglyLinkedList` being broken after removing the last node ([#19353](https://github.com/nim-lang/Nim/pull/19353)).
 - `md5` now works at compile time and in JavaScript.
-
 - `std/smtp` sends `ehlo` first. If the mail server does not understand, it sends `helo` as a fallback.
+- Changed mimedb to use an `OrderedTable` instead of `OrderedTableRef`, to use it in a const.
+- `strutils.find` now use and default to `last=-1` for whole string searches, making limiting it to just the first char (`last=0`) valid.
 
+[//]: # "Additions:"
 - Added `IsoWeekRange`, a range type to represent the number of weeks in an ISO week-based year.
 - Added `IsoYear`, a distinct int type to prevent bugs from confusing the week-based year and the regular year.
 - Added `initDateTime` in `times` to create a datetime from a weekday, and ISO 8601 week number and week-based year.
 - Added `getIsoWeekAndYear` in `times` to get an ISO week number along with the corresponding ISO week-based year from a datetime.
 - Added `getIsoWeeksInYear` in `times` to return the number of weeks in an ISO week-based year.
-- Added [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift) for JavaScript targets.
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 - Added `sep` parameter in `std/uri` to specify the query separator.
-- Removed deprecated `oids.oidToString`.
-- Remove define `nimExperimentalAsyncjsThen` for `std/asyncjs.then` and `std/jsfetch`.
-
-- Changed mimedb to use an `OrderedTable` instead of `OrderedTableRef`, to use it in a const.
-- Removed deprecated `jsre.test` and `jsre.toString`.
-- Removed deprecated `math.c_frexp`.
-- Removed deprecated ``` httpcore.`==` ```.
-- Removed deprecated `std/dom_extensions`.
-- Removed deprecated `std/posix.CMSG_SPACE` and `std/posix.CMSG_LEN` that takes wrong argument types.
-- Remove deprecated `osproc.poDemon`, symbol with typo.
+- Added [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift) for JavaScript targets.
 - Added [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask) for JavaScript targets.
+
+[//]: # "Deprecations:"
 - Deprecated `selfExe` for Nimscript.
 
+[//]: # "Removals:"
+- Removed deprecated `oids.oidToString`.
+- Removed define `nimExperimentalAsyncjsThen` for `std/asyncjs.then` and `std/jsfetch`.
+- Removed deprecated `jsre.test` and `jsre.toString`.
+- Removed deprecated `math.c_frexp`.
+- Removed deprecated `` httpcore.`==` ``.
+- Removed deprecated `std/dom_extensions`.
+- Removed deprecated `std/posix.CMSG_SPACE` and `std/posix.CMSG_LEN` that takes wrong argument types.
+- Removed deprecated `osproc.poDemon`, symbol with typo.
 
 ## Language changes
 


### PR DESCRIPTION
Mention changes to `strutils.find` https://github.com/nim-lang/Nim/pull/19761

Standard library section restructured to group by `changed/added/deprecated/removed` with paragraphs marked by markdown comments.