### PR TITLE
rst: add check for blank lines after directives

### DIFF
--- a/compiler/sigmatch.nim
+++ b/compiler/sigmatch.nim
@@ -552,6 +552,7 @@ proc procParamTypeRel(c: var TCandidate, f, a: PType): TTypeRelation =
   ## For example we have:
   ##
   ## .. code-block:: nim
+  ##
   ##   proc myMap[T,S](sIn: seq[T], f: proc(x: T): S): seq[S] = ...
   ##   proc innerProc[Q,W](q: Q): W = ...
   ##

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -17,6 +17,7 @@
 #   re-used in a register based VM. Example:
 #
 #.. code-block:: nim
+#
 #   let s = a & b  # no matter what, create fresh node
 #   s = a & b  # no matter what, keep the node
 #

--- a/doc/astspec.txt
+++ b/doc/astspec.txt
@@ -87,11 +87,13 @@ Command call
 Concrete syntax:
 
 .. code-block:: nim
+
   echo "abc", "xyz"
 
 AST:
 
 .. code-block:: nim
+
   nnkCommand(
     nnkIdent("echo"),
     nnkStrLit("abc"),
@@ -105,11 +107,13 @@ Call with ``()``
 Concrete syntax:
 
 .. code-block:: nim
+
   echo("abc", "xyz")
 
 AST:
 
 .. code-block:: nim
+
   nnkCall(
     nnkIdent("echo"),
     nnkStrLit("abc"),
@@ -123,11 +127,13 @@ Infix operator call
 Concrete syntax:
 
 .. code-block:: nim
+
   "abc" & "xyz"
 
 AST:
 
 .. code-block:: nim
+
   nnkInfix(
     nnkIdent("&"),
     nnkStrLit("abc"),
@@ -140,11 +146,13 @@ precedence.
 Concrete syntax:
 
 .. code-block:: nim
+
   5 + 3 * 4
 
 AST:
 
 .. code-block:: nim
+
   nnkInfix(
     nnkIdent("+"),
     nnkIntLit(5),
@@ -163,11 +171,13 @@ behaves as a
 Concrete syntax:
 
 .. code-block:: nim
+
   `+`(3, 4)
 
 AST:
 
 .. code-block:: nim
+
   nnkCall(
     nnkAccQuoted(
       nnkIdent("+")
@@ -182,11 +192,13 @@ Prefix operator call
 Concrete syntax:
 
 .. code-block:: nim
+
   ? "xyz"
 
 AST:
 
 .. code-block:: nim
+
   nnkPrefix(
     nnkIdent("?"),
     nnkStrLit("abc")
@@ -202,11 +214,13 @@ Postfix operator call
 Concrete syntax:
 
 .. code-block:: nim
+
   identifier*
 
 AST:
 
 .. code-block:: nim
+
   nnkPostfix(
     nnkIdent("*"),
     nnkIdent("identifier")
@@ -219,11 +233,13 @@ Call with named arguments
 Concrete syntax:
 
 .. code-block:: nim
+
   writeLine(file=stdout, "hallo")
 
 AST:
 
 .. code-block:: nim
+
   nnkCall(
     nnkIdent("writeLine"),
     nnkExprEqExpr(
@@ -243,11 +259,13 @@ This is used, for example, in the ``bindSym`` examples
 Concrete syntax:
 
 .. code-block:: nim
+
   echo"abc"
 
 AST:
 
 .. code-block:: nim
+
   nnkCallStrLit(
     nnkIdent("echo"),
     nnkRStrLit("hello")
@@ -259,11 +277,13 @@ Dereference operator ``[]``
 Concrete syntax:
 
 .. code-block:: nim
+
   x[]
 
 AST:
 
 .. code-block:: nim
+
   nnkDerefExpr(nnkIdent("x"))
 
 
@@ -273,11 +293,13 @@ Addr operator
 Concrete syntax:
 
 .. code-block:: nim
+
   addr(x)
 
 AST:
 
 .. code-block:: nim
+
   nnkAddr(nnkIdent("x"))
 
 
@@ -287,11 +309,13 @@ Cast operator
 Concrete syntax:
 
 .. code-block:: nim
+
   cast[T](x)
 
 AST:
 
 .. code-block:: nim
+
   nnkCast(nnkIdent("T"), nnkIdent("x"))
 
 
@@ -301,11 +325,13 @@ Object access operator ``.``
 Concrete syntax:
 
 .. code-block:: nim
+
   x.y
 
 AST:
 
 .. code-block:: nim
+
   nnkDotExpr(nnkIdent("x"), nnkIdent("y"))
 
 If you use Nim's flexible calling syntax (as in ``x.len()``), the result is the
@@ -318,11 +344,13 @@ Array access operator ``[]``
 Concrete syntax:
 
 .. code-block:: nim
+
   x[y]
 
 AST:
 
 .. code-block:: nim
+
   nnkBracketExpr(nnkIdent("x"), nnkIdent("y"))
 
 
@@ -334,11 +362,13 @@ Parentheses for affecting operator precedence use the ``nnkPar`` node.
 Concrete syntax:
 
 .. code-block:: nim
+
   (a + b) * c
 
 AST:
 
 .. code-block:: nim
+
   nnkInfix(nnkIdent("*"),
     nnkPar(
       nnkInfix(nnkIdent("+"), nnkIdent("a"), nnkIdent("b"))),
@@ -352,6 +382,7 @@ Nodes for tuple construction are built with the ``nnkTupleConstr`` node.
 Concrete syntax:
 
 .. code-block:: nim
+
   (1, 2, 3)
   (a: 1, b: 2, c: 3)
   ()
@@ -359,6 +390,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkTupleConstr(nnkIntLit(1), nnkIntLit(2), nnkIntLit(3))
   nnkTupleConstr(
     nnkExprColonExpr(nnkIdent("a"), nnkIntLit(1)),
@@ -371,12 +403,14 @@ with an expression in them, the parser expects a trailing comma for
 them. For tuple constructors with field names, this is not necessary.
 
 .. code-block:: nim
+
   (1,)
   (a: 1)
 
 AST:
 
 .. code-block:: nim
+
   nnkTupleConstr(nnkIntLit(1))
   nnkTupleConstr(
     nnkExprColonExpr(nnkIdent("a"), nnkIntLit(1)))
@@ -389,11 +423,13 @@ Curly braces are used as the set constructor.
 Concrete syntax:
 
 .. code-block:: nim
+
   {1, 2, 3}
 
 AST:
 
 .. code-block:: nim
+
   nnkCurly(nnkIntLit(1), nnkIntLit(2), nnkIntLit(3))
 
 When used as a table constructor, the syntax is different.
@@ -401,11 +437,13 @@ When used as a table constructor, the syntax is different.
 Concrete syntax:
 
 .. code-block:: nim
+
   {a: 3, b: 5}
 
 AST:
 
 .. code-block:: nim
+
   nnkTableConstr(
     nnkExprColonExpr(nnkIdent("a"), nnkIntLit(3)),
     nnkExprColonExpr(nnkIdent("b"), nnkIntLit(5))
@@ -420,11 +458,13 @@ Brackets are used as the array constructor.
 Concrete syntax:
 
 .. code-block:: nim
+
   [1, 2, 3]
 
 AST:
 
 .. code-block:: nim
+
   nnkBracket(nnkIntLit(1), nnkIntLit(2), nnkIntLit(3))
 
 
@@ -438,11 +478,13 @@ AST, construction with ``..`` as an infix operator should be used instead.
 Concrete syntax:
 
 .. code-block:: nim
+
   1..3
 
 AST:
 
 .. code-block:: nim
+
   nnkInfix(
     nnkIdent(".."),
     nnkIntLit(1),
@@ -452,6 +494,7 @@ AST:
 Example code:
 
 .. code-block:: nim
+
   macro genRepeatEcho() =
     result = newNimNode(nnkStmtList)
 
@@ -480,11 +523,13 @@ The representation of the ``if`` expression is subtle, but easy to traverse.
 Concrete syntax:
 
 .. code-block:: nim
+
   if cond1: expr1 elif cond2: expr2 else: expr3
 
 AST:
 
 .. code-block:: nim
+
   nnkIfExpr(
     nnkElifExpr(cond1, expr1),
     nnkElifExpr(cond2, expr2),
@@ -501,6 +546,7 @@ comments are ignored.
 Concrete syntax:
 
 .. code-block:: nim
+
   ## This is a comment
   ## This is part of the first comment
   stmt1
@@ -509,6 +555,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkCommentStmt() # only appears once for the first two lines!
   stmt1
   nnkCommentStmt() # another nnkCommentStmt because there is another comment
@@ -524,11 +571,13 @@ objects, but the standalone ``emit`` pragma shows the basics with the AST.
 Concrete syntax:
 
 .. code-block:: nim
+
   {.emit: "#include <stdio.h>".}
 
 AST:
 
 .. code-block:: nim
+
   nnkPragma(
     nnkExprColonExpr(
       nnkIdent("emit"),
@@ -542,11 +591,13 @@ the declaration of new pragmas is essentially the same:
 Concrete syntax:
 
 .. code-block:: nim
+
   {.pragma: cdeclRename, cdecl.}
 
 AST:
 
 .. code-block:: nim
+
   nnkPragma(
     nnkExprColonExpr(
       nnkIdent("pragma"), # this is always first when declaring a new pragma
@@ -567,6 +618,7 @@ there is no ``else`` branch, no ``nnkElse`` child exists.
 Concrete syntax:
 
 .. code-block:: nim
+
   if cond1:
     stmt1
   elif cond2:
@@ -579,6 +631,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkIfStmt(
     nnkElifBranch(cond1, stmt1),
     nnkElifBranch(cond2, stmt2),
@@ -599,11 +652,13 @@ Assignment
 Concrete syntax:
 
 .. code-block:: nim
+
   x = 42
 
 AST:
 
 .. code-block:: nim
+
   nnkAsgn(nnkIdent("x"), nnkIntLit(42))
 
 This is not the syntax for assignment when combined with ``var``, ``let``,
@@ -615,6 +670,7 @@ Statement list
 Concrete syntax:
 
 .. code-block:: nim
+
   stmt1
   stmt2
   stmt3
@@ -622,6 +678,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkStmtList(stmt1, stmt2, stmt3)
 
 
@@ -631,6 +688,7 @@ Case statement
 Concrete syntax:
 
 .. code-block:: nim
+
   case expr1
   of expr2, expr3..expr4:
     stmt1
@@ -644,6 +702,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkCaseStmt(
     expr1,
     nnkOfBranch(expr2, nnkRange(expr3, expr4), stmt1),
@@ -661,12 +720,14 @@ While statement
 Concrete syntax:
 
 .. code-block:: nim
+
   while expr1:
     stmt1
 
 AST:
 
 .. code-block:: nim
+
   nnkWhileStmt(expr1, stmt1)
 
 
@@ -676,12 +737,14 @@ For statement
 Concrete syntax:
 
 .. code-block:: nim
+
   for ident1, ident2 in expr1:
     stmt1
 
 AST:
 
 .. code-block:: nim
+
   nnkForStmt(ident1, ident2, expr1, stmt1)
 
 
@@ -691,6 +754,7 @@ Try statement
 Concrete syntax:
 
 .. code-block:: nim
+
   try:
     stmt1
   except e1, e2:
@@ -705,6 +769,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkTryStmt(
     stmt1,
     nnkExceptBranch(e1, e2, stmt2),
@@ -720,11 +785,13 @@ Return statement
 Concrete syntax:
 
 .. code-block:: nim
+
   return expr1
 
 AST:
 
 .. code-block:: nim
+
   nnkReturnStmt(expr1)
 
 
@@ -734,6 +801,7 @@ Yield statement
 Like ``return``, but with ``nnkYieldStmt`` kind.
 
 .. code-block:: nim
+
   nnkYieldStmt(expr1)
 
 
@@ -743,6 +811,7 @@ Discard statement
 Like ``return``, but with ``nnkDiscardStmt`` kind.
 
 .. code-block:: nim
+
   nnkDiscardStmt(expr1)
 
 
@@ -752,11 +821,13 @@ Continue statement
 Concrete syntax:
 
 .. code-block:: nim
+
   continue
 
 AST:
 
 .. code-block:: nim
+
   nnkContinueStmt()
 
 Break statement
@@ -765,11 +836,13 @@ Break statement
 Concrete syntax:
 
 .. code-block:: nim
+
   break otherLocation
 
 AST:
 
 .. code-block:: nim
+
   nnkBreakStmt(nnkIdent("otherLocation"))
 
 If ``break`` is used without a jump-to location, ``nnkEmpty`` replaces ``nnkIdent``.
@@ -780,11 +853,13 @@ Block statement
 Concrete syntax:
 
 .. code-block:: nim
+
   block name:
 
 AST:
 
 .. code-block:: nim
+
   nnkBlockStmt(nnkIdent("name"), nnkStmtList(...))
 
 A ``block`` doesn't need an name, in which case ``nnkEmpty`` is used.
@@ -795,6 +870,7 @@ Asm statement
 Concrete syntax:
 
 .. code-block:: nim
+
   asm """
     some asm
   """
@@ -802,6 +878,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   nnkAsmStmt(
     nnkEmpty(), # for pragmas
     nnkTripleStrLit("some asm"),
@@ -816,11 +893,13 @@ on what keywords are present. Let's start with the simplest form.
 Concrete syntax:
 
 .. code-block:: nim
+
   import math
 
 AST:
 
 .. code-block:: nim
+
   nnkImportStmt(nnkIdent("math"))
 
 With ``except``, we get ``nnkImportExceptStmt``.
@@ -828,11 +907,13 @@ With ``except``, we get ``nnkImportExceptStmt``.
 Concrete syntax:
 
 .. code-block:: nim
+
   import math except pow
 
 AST:
 
 .. code-block:: nim
+
   nnkImportExceptStmt(nnkIdent("math"),nnkIdent("pow"))
 
 Note that ``import math as m`` does not use a different node; rather,
@@ -841,11 +922,13 @@ we use ``nnkImportStmt`` with ``as`` as an infix operator.
 Concrete syntax:
 
 .. code-block:: nim
+
   import strutils as su
 
 AST:
 
 .. code-block:: nim
+
   nnkImportStmt(
     nnkInfix(
       nnkIdent("as"),
@@ -862,11 +945,13 @@ If we use ``from ... import``, the result is different, too.
 Concrete syntax:
 
 .. code-block:: nim
+
   from math import pow
 
 AST:
 
 .. code-block:: nim
+
   nnkFromStmt(nnkIdent("math"), nnkIdent("pow"))
 
 Using ``from math as m import pow`` works identically to the ``as`` modifier
@@ -881,11 +966,13 @@ the ``export`` syntax is pretty straightforward.
 Concrete syntax:
 
 .. code-block:: nim
+
   export unsigned
 
 AST:
 
 .. code-block:: nim
+
   nnkExportStmt(nnkIdent("unsigned"))
 
 Similar to the ``import`` statement, the AST is different for
@@ -894,11 +981,13 @@ Similar to the ``import`` statement, the AST is different for
 Concrete syntax:
 
 .. code-block:: nim
+
   export math except pow # we're going to implement our own exponentiation
 
 AST:
 
 .. code-block:: nim
+
   nnkExportExceptStmt(nnkIdent("math"),nnkIdent("pow"))
 
 Include statement
@@ -909,11 +998,13 @@ Like a plain ``import`` statement but with ``nnkIncludeStmt``.
 Concrete syntax:
 
 .. code-block:: nim
+
   include blocks
 
 AST:
 
 .. code-block:: nim
+
   nnkIncludeStmt(nnkIdent("blocks"))
 
 Var section
@@ -922,11 +1013,13 @@ Var section
 Concrete syntax:
 
 .. code-block:: nim
+
   var a = 3
 
 AST:
 
 .. code-block:: nim
+
   nnkVarSection(
     nnkIdentDefs(
       nnkIdent("a"),
@@ -952,11 +1045,13 @@ This is equivalent to ``var``, but with ``nnkLetSection`` rather than
 Concrete syntax:
 
 .. code-block:: nim
+
   let a = 3
 
 AST:
 
 .. code-block:: nim
+
   nnkLetSection(
     nnkIdentDefs(
       nnkIdent("a"),
@@ -971,11 +1066,13 @@ Const section
 Concrete syntax:
 
 .. code-block:: nim
+
   const a = 3
 
 AST:
 
 .. code-block:: nim
+
   nnkConstSection(
     nnkConstDef( # not nnkConstDefs!
       nnkIdent("a"),
@@ -993,11 +1090,13 @@ and ``const``.
 Concrete syntax:
 
 .. code-block:: nim
+
   type A = int
 
 AST:
 
 .. code-block:: nim
+
   nnkTypeSection(
     nnkTypeDef(
       nnkIdent("A"),
@@ -1012,11 +1111,13 @@ in ``nnkDistinctTy``.
 Concrete syntax:
 
 .. code-block:: nim
+
   type MyInt = distinct int
 
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkTypeDef(
     nnkIdent("MyInt"),
@@ -1031,11 +1132,13 @@ If a type section uses generic parameters, they are treated here:
 Concrete syntax:
 
 .. code-block:: nim
+
   type A[T] = expr1
 
 AST:
 
 .. code-block:: nim
+
   nnkTypeSection(
     nnkTypeDef(
       nnkIdent("A"),
@@ -1058,11 +1161,13 @@ is to work with objects.
 Concrete syntax:
 
 .. code-block:: nim
+
   type IO = object of RootObj
 
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkTypeDef(
     nnkIdent("IO"),
@@ -1082,6 +1187,7 @@ its entirety to see some of the complexities.
 Concrete syntax:
 
 .. code-block:: nim
+
   type Obj[T] {.inheritable.} = object
     name: string
     case isFat: bool
@@ -1093,6 +1199,7 @@ Concrete syntax:
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkPragmaExpr(
     nnkIdent("Obj"),
@@ -1156,12 +1263,14 @@ Using an ``enum`` is similar to using an ``object``.
 Concrete syntax:
 
 .. code-block:: nim
+
   type X = enum
     First
 
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkEnumTy(
     nnkEmpty(),
@@ -1173,12 +1282,14 @@ The usage of ``concept`` (experimental) is similar to objects.
 Concrete syntax:
 
 .. code-block:: nim
+
   type Con = concept x,y,z
     (x & y & z) is string
 
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkTypeClassTy( # note this isn't nnkConceptTy!
     nnkArgList(
@@ -1193,11 +1304,13 @@ Static types, like ``static[int]``, use ``nnkIdent`` wrapped in
 Concrete syntax:
 
 .. code-block:: nim
+
   type A[T: static[int]] = object
 
 AST:
 
 .. code-block:: nim
+
   # ... within nnkGenericParams
   nnkIdentDefs(
     nnkIdent("T"),
@@ -1235,11 +1348,13 @@ Generic parameters are treated in the type, not the ``proc`` itself.
 Concrete syntax:
 
 .. code-block:: nim
+
   type MyProc[T] = proc(x: T)
 
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkTypeDef(
     nnkIdent("MyProc"),
@@ -1262,11 +1377,13 @@ Mixin statement
 Concrete syntax:
 
 .. code-block:: nim
+
   mixin x
 
 AST:
 
 .. code-block:: nim
+
   nnkMixinStmt(nnkIdent("x"))
 
 Bind statement
@@ -1275,11 +1392,13 @@ Bind statement
 Concrete syntax:
 
 .. code-block:: nim
+
   bind x
 
 AST:
 
 .. code-block:: nim
+
   nnkBindStmt(nnkIdent("x"))
 
 Procedure declaration
@@ -1291,11 +1410,13 @@ a feel for how procedure calls are broken down.
 Concrete syntax:
 
 .. code-block:: nim
+
   proc hello*[T: SomeInteger](x: int = 3, y: float32): int {.inline.} = discard
 
 AST:
 
 .. code-block:: nim
+
   nnkProcDef(
     nnkPostfix(nnkIdent("*"), nnkIdent("hello")), # the exported proc name
     nnkEmpty(), # patterns for term rewriting in templates and macros (not procs)
@@ -1331,11 +1452,13 @@ are equivalent in the code, the AST is a little different for the latter.
 Concrete syntax:
 
 .. code-block:: nim
+
   proc(a, b: int)
 
 AST:
 
 .. code-block:: nim
+
   # ...AST as above...
   nnkFormalParams(
     nnkEmpty(), # no return here
@@ -1354,11 +1477,13 @@ is different from that of a var section.
 Concrete syntax:
 
 .. code-block:: nim
+
   proc hello(): var int
 
 AST:
 
 .. code-block:: nim
+
   # ...
   nnkFormalParams(
     nnkVarTy(
@@ -1375,11 +1500,13 @@ replacing ``nnkProcDef``.
 Concrete syntax:
 
 .. code-block:: nim
+
   iterator nonsense[T](x: seq[T]): float {.closure.} = ...
 
 AST:
 
 .. code-block:: nim
+
   nnkIteratorDef(
     nnkIdent("nonsense"),
     nnkEmpty(),
@@ -1394,11 +1521,13 @@ A converter is similar to a proc.
 Concrete syntax:
 
 .. code-block:: nim
+
   converter toBool(x: float): bool
 
 AST:
 
 .. code-block:: nim
+
   nnkConverterDef(
     nnkIdent("toBool"),
     # ...
@@ -1416,11 +1545,13 @@ the ``nnkEmpty()`` as the second argument to ``nnkProcDef`` and
 Concrete syntax:
 
 .. code-block:: nim
+
   template optOpt{expr1}(a: int): int
 
 AST:
 
 .. code-block:: nim
+
   nnkTemplateDef(
     nnkIdent("optOpt"),
     nnkStmtList( # instead of nnkEmpty()
@@ -1442,6 +1573,7 @@ Hidden Standard Conversion
 --------------------------
 
 .. code-block:: nim
+
   var f: float = 1
 
 The type of "f" is ``float`` but the type of "1" is actually ``int``. Inserting 

--- a/doc/backends.rst
+++ b/doc/backends.rst
@@ -160,6 +160,7 @@ C invocation example
 Create a ``logic.c`` file with the following content:
 
 .. code-block:: c
+
   int addTwoIntegers(int a, int b)
   {
     return a + b;

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -235,6 +235,7 @@ These `runnableExamples` are automatically run by `nim doc mymodule.nim`:cmd:
 as well as `testament`:cmd: and guarantee they stay in sync.
 
 .. code-block:: nim
+
   proc addBar*(a: string): string =
     ## Adds "Bar" to `a`.
     runnableExamples:
@@ -297,6 +298,7 @@ For example an ``:idx:`` role for referencing a topic ("SQLite" in the
 example below) from `Nim Index`_ can be used in doc comment this way:
 
 .. code-block:: nim
+
   ## A higher level `SQLite`:idx: database wrapper.
 
 .. _`Nim Index`: https://nim-lang.org/docs/theindex.html

--- a/doc/destructors.rst
+++ b/doc/destructors.rst
@@ -713,6 +713,7 @@ The copy operation is deferred until the first write.
 For example:
 
 .. code-block:: nim
+
   var x = "abc"  # no copy
   var y = x      # no copy
   y[0] = 'h'     # copy
@@ -722,6 +723,7 @@ The abstraction fails for `addr x` because whether the address is going to be us
 `prepareMutation` needs to be called before the "address of" operation. For example:
 
 .. code-block:: nim
+
   var x = "abc"
   var y = x
 

--- a/doc/docgen.rst
+++ b/doc/docgen.rst
@@ -69,6 +69,7 @@ Basic Markdown syntax is also supported inside the doc comments.
 Example:
 
 .. code-block:: nim
+
   type Person* = object
     ## This type contains a description of a person
     name: string
@@ -84,6 +85,7 @@ Outputs::
 Field documentation comments can be added to fields like so:
 
 .. code-block:: nim
+
   var numValues: int ## \
     ## `numValues` stores the number of values
 
@@ -104,6 +106,7 @@ won't influence RST formatting.
    (for RST block quote syntax) use backslash \\ before it:
 
    .. code-block:: nim
+
       ## \
       ##
       ##    Block quote at the first line.

--- a/doc/docstyle.rst
+++ b/doc/docstyle.rst
@@ -37,7 +37,8 @@ Code samples are encouraged, and should follow the general RST syntax:
   ## The `universe` module computes the answer to life, the universe, and everything.
   ##
   ## .. code-block::
-  ##  doAssert computeAnswerString() == 42
+  ##
+  ##   doAssert computeAnswerString() == 42
 
 
 Within this top-level comment, you can indicate the authorship and copyright of the code, which will be featured in the produced documentation.
@@ -72,9 +73,10 @@ Whenever an example of usage would be helpful to the user, you should include on
     ## truncating the result.
     ##
     ## .. code-block::
-    ##  # things that aren't suitable for a `runnableExamples` go in code-block:
-    ##  echo execCmdEx("git pull")
-    ##  drawOnScreen()
+    ##
+    ##   # things that aren't suitable for a `runnableExamples` go in code-block:
+    ##   echo execCmdEx("git pull")
+    ##   drawOnScreen()
     runnableExamples:
       # `runnableExamples` is usually preferred to ``code-block``, when possible.
       doAssert addThree(3, 125, 6) == -122

--- a/doc/effects.txt
+++ b/doc/effects.txt
@@ -14,6 +14,7 @@ should not be evaluated at compile time! On other occasions it can
 and should be evaluted:
 
 .. code-block:: nim
+
   proc toUpper(s: string): string =
     result = newString(len(s))
     for i in 0..len(s) - 1:

--- a/doc/filters.rst
+++ b/doc/filters.rst
@@ -42,6 +42,7 @@ If we use `generateXML` code shown above and call the SCF file `xmlGen.nimf`
 In your `main.nim`:
 
 .. code-block:: nim
+
   include "xmlGen.nimf"
   
   echo generateXML("John Smith","42")
@@ -151,6 +152,7 @@ Example::
 The filter transforms this into:
 
 .. code-block:: nim
+
   proc generateHTMLPage(title, currentTab, content: string,
                         tabs: openArray[string]): string =
     result = ""

--- a/doc/hcr.rst
+++ b/doc/hcr.rst
@@ -108,6 +108,7 @@ Compile this example via:
 Now start the program and KEEP it running!
 
 .. code:: cmd
+
   # Unix:
   mymain &
   # or Windows (click on the .exe)
@@ -147,6 +148,7 @@ One can use the special event handlers `beforeCodeReload` and
 the execution of certain statements:
 
 .. code-block:: Nim
+
   var
    settings = initTable[string, string]()
    lastReload: Time
@@ -168,6 +170,7 @@ executed. To prevent this behavior, one can guard the code with the
 `hasModuleChanged()`:idx: API:
 
 .. code-block:: Nim
+
   import mydb
 
   var myCache = initTable[Key, Value]()

--- a/doc/idetools.rst
+++ b/doc/idetools.rst
@@ -247,6 +247,7 @@ skConst
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     const SOME_SEQUENCE = @[1, 2]
     --> col 2: $MODULE.SOME_SEQUENCE
         col 3: seq[int]
@@ -261,6 +262,7 @@ skEnumField
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     Open(filename, fmWrite)
     --> col 2: system.FileMode.fmWrite
         col 3: FileMode
@@ -275,6 +277,7 @@ skForVar
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     proc looper(filename = "tests.nim") =
       for letter in filename:
         echo letter
@@ -296,6 +299,7 @@ posterior instances of the iterator.
 | **Docstring**: docstring if available.
 
 .. code-block:: nim
+
     let
       text = "some text"
       letters = toSeq(runes(text))
@@ -312,6 +316,7 @@ skLabel
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     proc test(text: string) =
       var found = -1
       block loops:
@@ -328,6 +333,7 @@ skLet
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     let
       text = "some text"
     --> col 2: $MODULE.text
@@ -348,6 +354,7 @@ posterior instances of the macro.
 | **Docstring**: docstring if available.
 
 .. code-block:: nim
+
     proc testMacro() =
       expect(EArithmetic):
     --> col 2: idetools_api.expect
@@ -385,6 +392,7 @@ This may change in the future.
 | **Docstring**: docstring if available.
 
 .. code-block:: nim
+
     method eval(e: PExpr): int = quit "to override!"
     method eval(e: PLiteral): int = e.x
     method eval(e: PPlusExpr): int = eval(e.a) + eval(e.b)
@@ -402,6 +410,7 @@ skParam
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     proc reader(filename = "tests.nim") =
       let text = readFile(filename)
     --> col 2: $MODULE.reader.filename
@@ -426,6 +435,7 @@ returned by idetools returns also the pragmas for the proc.
 | **Docstring**: docstring if available.
 
 .. code-block:: nim
+
     open(filename, fmWrite)
     --> col 2: system.Open
         col 3: proc (var File, string, FileMode, int): bool
@@ -444,6 +454,7 @@ skResult
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     proc getRandomValue() : int =
       return 4
     --> col 2: $MODULE.getRandomValue.result
@@ -464,6 +475,7 @@ posterior instances of the template.
 | **Docstring**: docstring if available.
 
 .. code-block:: nim
+
     let
       text = "some text"
       letters = toSeq(runes(text))
@@ -472,15 +484,16 @@ posterior instances of the template.
         col 7:
     "Transforms any iterator into a sequence.
 
-     Example:
+Example:
 
-     .. code-block:: nim
-       let
-         numeric = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
-         odd_numbers = toSeq(filter(numeric) do (x: int) -> bool:
-           if x mod 2 == 1:
-             result = true)
-       assert odd_numbers == @[1, 3, 5, 7, 9]"
+.. code-block:: nim
+
+  let
+    numeric = @[1, 2, 3, 4, 5, 6, 7, 8, 9]
+    odd_numbers = toSeq(filter(numeric) do (x: int) -> bool:
+      if x mod 2 == 1:
+        result = true)
+  assert odd_numbers == @[1, 3, 5, 7, 9]"
 
 
 skType
@@ -491,6 +504,7 @@ skType
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     proc writeTempFile() =
       var output: File
     --> col 2: system.File
@@ -506,6 +520,7 @@ skVar
 | **Docstring**: always the empty string.
 
 .. code-block:: nim
+
     proc writeTempFile() =
       var output: File
       output.open("/tmp/somefile", fmWrite)

--- a/doc/intern.rst
+++ b/doc/intern.rst
@@ -449,6 +449,7 @@ Proper thunk generation is harder because the proc that is to wrap
 could stem from a complex expression:
 
 .. code-block:: nim
+
   receivesClosure(returnsDefaultCC[i])
 
 A thunk would need to call 'returnsDefaultCC[i]' somehow and that would require
@@ -461,6 +462,7 @@ to pass a proc pointer around via a generic `ref` type.
 Example code:
 
 .. code-block:: nim
+
   proc add(x: int): proc (y: int): int {.closure.} =
     return proc (y: int): int =
       return x + y
@@ -471,6 +473,7 @@ Example code:
 This should produce roughly this code:
 
 .. code-block:: nim
+
   type
     Env = ref object
       x: int # data
@@ -492,6 +495,7 @@ This should produce roughly this code:
 Beware of nesting:
 
 .. code-block:: nim
+
   proc add(x: int): proc (y: int): proc (z: int): int {.closure.} {.closure.} =
     return lambda (y: int): proc (z: int): int {.closure.} =
       return lambda (z: int): int =
@@ -503,6 +507,7 @@ Beware of nesting:
 This should produce roughly this code:
 
 .. code-block:: nim
+
   type
     EnvX = ref object
       x: int # data

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -119,6 +119,7 @@ code purports to catch the `IndexDefect` from an out-of-bounds array access, the
 compiler may instead choose to allow the program to die with a fatal error.
 
 .. code-block:: nim
+
   var a: array[0..1, char]
   let i = 5
   try:
@@ -215,6 +216,7 @@ comment:
 
 
 .. code-block:: nim
+
   i = 0     # This is a single comment over multiple lines.
     # The lexer merges these two pieces.
     # The comment continues here.
@@ -232,6 +234,7 @@ Starting with version 0.13.0 of the language Nim supports multiline comments.
 They look like:
 
 .. code-block:: nim
+
   #[Comment here.
   Multiple lines
   are not a problem.]#
@@ -239,6 +242,7 @@ They look like:
 Multiline comments support nesting:
 
 .. code-block:: nim
+
   #[  #[ Multiline comment in already
      commented out code. ]#
   proc p[T](x: T) = discard
@@ -247,6 +251,7 @@ Multiline comments support nesting:
 Multiline documentation comments also exist and support nesting too:
 
 .. code-block:: nim
+
   proc foo =
     ##[Long documentation comment
        here.
@@ -264,6 +269,7 @@ and underscores, with the following restrictions:
 * two immediate following underscores `__` are not allowed:
 
 .. code-block::
+
   letter ::= 'A'..'Z' | 'a'..'z' | '\x80'..'\xff'
   digit ::= '0'..'9'
   IDENTIFIER ::= letter ( ['_'] (letter | digit) )*
@@ -288,6 +294,7 @@ Identifier equality
 Two identifiers are considered equal if the following algorithm returns true:
 
 .. code-block:: nim
+
   proc sameIdentifier(a, b: string): bool =
     a[0] == b[0] and
       a.replace("_", "").toLowerAscii == b.replace("_", "").toLowerAscii
@@ -324,9 +331,11 @@ If a keyword is enclosed in backticks it loses its keyword property and becomes 
 Examples
 
 .. code-block:: nim
+
   var `var` = "Hello Stropping"
 
 .. code-block:: nim
+
   type Obj = object
     `type`: int
 
@@ -397,6 +406,7 @@ the newline (and the preceding whitespace) is not included in the string. The
 ending of the string literal is defined by the pattern `"""[^"]`, so this:
 
 .. code-block:: nim
+
   """"long string within quotes""""
 
 Produces::
@@ -718,6 +728,7 @@ Binary operators whose first character is `^` are right-associative, all
 other binary operators are left-associative.
 
 .. code-block:: nim
+
   proc `^/`(x, y: float): float =
     # a right-associative division operator
     result = x / y
@@ -769,6 +780,7 @@ Whether an operator is used as a prefix operator is also affected by preceding
 whitespace (this parsing change was introduced with version 0.13.0):
 
 .. code-block:: nim
+
   echo $foo
   # is parsed as
   echo($foo)
@@ -778,9 +790,11 @@ Spacing also determines whether `(a, b)` is parsed as an argument list
 of a call or whether it is parsed as a tuple constructor:
 
 .. code-block:: nim
+
   echo(1, 2) # pass 1 and 2 to echo
 
 .. code-block:: nim
+
   echo (1, 2) # pass the tuple (1, 2) to echo
 
 Dot-like operators
@@ -922,6 +936,7 @@ problem.)
 
 .. code-block:: nim
     :test: "nim c $1"
+
   import std/strformat
 
   var fibN {.compileTime.}: int
@@ -1078,6 +1093,7 @@ smaller type to a larger type (for example `int16 -> int32`). In Nim only
 widening type conversions are *implicit*:
 
 .. code-block:: nim
+
   var myInt16 = 5i16
   var myInt: int
   myInt16 + 34     # of type `int16`
@@ -1100,6 +1116,7 @@ type). To define a subrange type, one must specify its limiting values -- the
 lowest and highest value of the type. For example:
 
 .. code-block:: nim
+
   type
     Subrange = range[0..5]
     PositiveFloat = range[0.0..Inf]
@@ -1164,6 +1181,7 @@ Nim provides the pragmas `nanChecks`:idx: and `infChecks`:idx: to control
 whether the IEEE exceptions are ignored or trap a Nim exception:
 
 .. code-block:: nim
+
   {.nanChecks: on, infChecks: on.}
   var a = 1.0
   var b = 0.0
@@ -1255,6 +1273,7 @@ explicitly given is assigned the value of the previous field + 1.
 An explicit ordered enum can have *holes*:
 
 .. code-block:: nim
+
   type
     TokenType = enum
       a = 2, b = 4, c = 89 # holes are valid
@@ -1330,6 +1349,7 @@ Whenever a user creates a specialized object, implementation of this procedure
 provides for `string` representation.
 
 .. code-block:: nim
+
   type
     Person = object
       name: string
@@ -1380,6 +1400,7 @@ to `cstring` for convenience. If a Nim string is passed to a C-style
 variadic proc, it is implicitly converted to `cstring` too:
 
 .. code-block:: nim
+
   proc printf(formatstr: cstring) {.importc: "printf", varargs,
                                     header: "<stdio.h>".}
 
@@ -1395,6 +1416,7 @@ A `$` proc is defined for cstrings that returns a string. Thus to get a nim
 string from a cstring:
 
 .. code-block:: nim
+
   var str: string = "Hello!"
   var cstr: cstring = str
   var newstr: string = $cstr
@@ -1402,6 +1424,7 @@ string from a cstring:
 `cstring` literals shouldn't be modified.
 
 .. code-block:: nim
+
   var x = cstring"literals"
   x[1] = 'A' # This is wrong!!!
 
@@ -1409,6 +1432,7 @@ If the `cstring` originates from a regular memory (not read-only memory),
 it can be modified:
 
 .. code-block:: nim
+
   var x = "123456"
   var s: cstring = x
   s[0] = 'u' # This is ok
@@ -1522,6 +1546,7 @@ The openarray type cannot be nested: multidimensional openarrays are not
 supported because this is seldom needed and cannot be done efficiently.
 
 .. code-block:: nim
+
   proc testOpenArray(x: openArray[int]) = echo repr(x)
 
   testOpenArray([1,2,3])  # array[]
@@ -1535,6 +1560,7 @@ allows to pass a variable number of arguments to a procedure. The compiler
 converts the list of arguments to an array implicitly:
 
 .. code-block:: nim
+
   proc myWriteln(f: File, a: varargs[string]) =
     for s in items(a):
       write(f, s)
@@ -1549,6 +1575,7 @@ last parameter in the procedure header. It is also possible to perform
 type conversions in this context:
 
 .. code-block:: nim
+
   proc myWriteln(f: File, a: varargs[string, `$`]) =
     for s in items(a):
       write(f, s)
@@ -1565,6 +1592,7 @@ Note that an explicit array constructor passed to a `varargs` parameter is
 not wrapped in another implicit array construction:
 
 .. code-block:: nim
+
   proc takeV[T](a: varargs[T]) = discard
 
   takeV([123, 2, 1]) # takeV's T is "int", not "array of int"
@@ -1575,6 +1603,7 @@ of arbitrary type but *always* constructs an implicit array. This is required
 so that the builtin `echo` proc does what is expected:
 
 .. code-block:: nim
+
   proc echo*(x: varargs[typed, `$`]) {...}
 
   echo @[1, 2, 3]
@@ -1589,6 +1618,7 @@ arrays. Additionally, an unchecked array is translated into a C array of
 undetermined size:
 
 .. code-block:: nim
+
   type
     MySeq = object
       len, cap: int
@@ -1597,6 +1627,7 @@ undetermined size:
 Produces roughly this C code:
 
 .. code-block:: C
+
   typedef struct {
     NI len;
     NI cap;
@@ -1643,6 +1674,7 @@ A tuple with one unnamed field can be constructed with the parentheses and a
 trailing comma:
 
 .. code-block:: nim
+
   proc echoUnaryTuple(a: (int,)) =
     echo a[0]
 
@@ -1658,6 +1690,7 @@ For consistency  with `object` declarations, tuples in a `type` section
 can also be defined with indentation instead of `[]`:
 
 .. code-block:: nim
+
   type
     Person = tuple   # type representing a person
       name: string   # a person consists of a name
@@ -1670,6 +1703,7 @@ can be used to determine the object's type. The `of` operator is similar to
 the `instanceof` operator in Java.
 
 .. code-block:: nim
+
   type
     Person = object of RootObj
       name*: string   # the * means that `name` is accessible from other modules
@@ -1692,6 +1726,7 @@ type information. One can use the `inheritable` pragma to
 introduce new object roots apart from `system.RootObj`.
 
 .. code-block:: nim
+
   type
     Person = object # example of a final object
       name*: string
@@ -1713,6 +1748,7 @@ has the syntax `T(fieldA: valueA, fieldB: valueB, ...)` where `T` is
 an `object` type or a `ref object` type:
 
 .. code-block:: nim
+
   type
     Student = object
       name: string
@@ -1921,6 +1957,7 @@ call, but this is an experimental feature and is described `here
 In order to simplify structural type checking, recursive tuples are not valid:
 
 .. code-block:: nim
+
   # invalid recursion
   type MyTuple = tuple[a: ref MyTuple]
 
@@ -1986,6 +2023,7 @@ the built-in procedure `reset` has to be called before freeing the untraced
 memory manually:
 
 .. code-block:: nim
+
   type
     Data = tuple[x, y: int, s: string]
 
@@ -2141,6 +2179,7 @@ Different currencies should not be mixed in monetary calculations. Distinct
 types are a perfect tool to model different currencies:
 
 .. code-block:: nim
+
   type
     Dollar = distinct int
     Euro = distinct int
@@ -2157,6 +2196,7 @@ because `+` is defined for `int` (among others), not for `Dollar`. So
 a `+` for dollars needs to be defined:
 
 .. code-block::
+
   proc `+` (x, y: Dollar): Dollar =
     result = Dollar(int(x) + int(y))
 
@@ -2164,6 +2204,7 @@ It does not make sense to multiply a dollar with a dollar, but with a
 number without unit; and the same holds for division:
 
 .. code-block::
+
   proc `*` (x: Dollar, y: int): Dollar =
     result = Dollar(int(x) * y)
 
@@ -2179,6 +2220,7 @@ The pragma `borrow`:idx: has been designed to solve this problem; in principle,
 it generates the above trivial implementations:
 
 .. code-block:: nim
+
   proc `*` (x: Dollar, y: int): Dollar {.borrow.}
   proc `*` (x: int, y: Dollar): Dollar {.borrow.}
   proc `div` (x: Dollar, y: int): Dollar {.borrow.}
@@ -2227,6 +2269,7 @@ The borrow pragma can also be used to annotate the distinct type to allow
 certain builtin operations to be lifted:
 
 .. code-block:: nim
+
   type
     Foo = object
       a, b: int
@@ -2251,6 +2294,7 @@ modeled as a string. However, using string templates and filling in the
 values is vulnerable to the famous `SQL injection attack`:idx:\:
 
 .. code-block:: nim
+
   import std/strutils
 
   proc query(db: DbHandle, statement: string) = ...
@@ -2266,6 +2310,7 @@ that don't. Distinct types provide a means to introduce a new string type
 `SQL` that is incompatible with `string`:
 
 .. code-block:: nim
+
   type
     SQL = distinct string
 
@@ -2283,6 +2328,7 @@ subtype relation between the abstract type and its base type. Explicit type
 conversions from `string` to `SQL` are allowed:
 
 .. code-block:: nim
+
   import std/[strutils, sequtils]
 
   proc properQuote(s: string): SQL =
@@ -2313,16 +2359,19 @@ The `auto` type can only be used for return types and parameters. For return
 types it causes the compiler to infer the type from the routine body:
 
 .. code-block:: nim
+
   proc returnsInt(): auto = 1984
 
 For parameters it currently creates implicitly generic routines:
 
 .. code-block:: nim
+
   proc foo(a, b: auto) = discard
 
 Is the same as:
 
 .. code-block:: nim
+
   proc foo[T1, T2](a: T1, b: T2) = discard
 
 However, later versions of the language might change this to mean "infer the
@@ -2418,6 +2467,7 @@ A type `a` is **explicitly** convertible to type `b` iff the following
 algorithm returns true:
 
 .. code-block:: nim
+
   proc isIntegralType(t: PType): bool =
     result = isOrdinal(t) or t.kind in {float, float32, float64}
 
@@ -2434,6 +2484,7 @@ The convertible relation can be relaxed by a user-defined type
 `converter`:idx:.
 
 .. code-block:: nim
+
   converter toInt(x: char): int = result = ord(x)
 
   var
@@ -2507,6 +2558,7 @@ algorithm returns true::
 Some examples:
 
 .. code-block:: nim
+
   proc takesInt(x: int) = echo "int"
   proc takesInt[T](x: T) = echo "T"
   proc takesInt(x: int16) = echo "int16"
@@ -2526,6 +2578,7 @@ and `g` of `q` via a subtyping relation, the inheritance depth is taken
 into account:
 
 .. code-block:: nim
+
   type
     A = object of RootObj
     B = object of A
@@ -2553,6 +2606,7 @@ Likewise, for generic matches, the most specialized generic type (that still
 matches) is preferred:
 
 .. code-block:: nim
+
   proc gen[T](x: ref ref T) = echo "ref ref T"
   proc gen[T](x: ref T) = echo "ref T"
   proc gen[T](x: T) = echo "T"
@@ -2570,6 +2624,7 @@ the argument is checked to be an `l-value`:idx:.
 `var T` matches better than just `T` then.
 
 .. code-block:: nim
+
   proc sayHi(x: int): string =
     # matches a non-var int
     result = $x
@@ -2598,6 +2653,7 @@ expressions to a template or macro. This is what the meta-type `untyped`
 accomplishes:
 
 .. code-block:: nim
+
   template rem(x: untyped) = discard
 
   rem unresolvedExpression(undeclaredIdentifier)
@@ -2609,6 +2665,7 @@ But one has to watch out because other overloads might trigger the
 argument's resolution:
 
 .. code-block:: nim
+
   template rem(x: untyped) = discard
   proc rem[T](x: T) = discard
 
@@ -2633,6 +2690,7 @@ a parameter typed as `untyped` (for unresolved expressions) or the type class
 `iterable` or `iterable[T]` (after type checking and overload resolution).
 
 .. code-block:: nim
+
   iterator iota(n: int): int =
     for i in 0..<n: yield i
 
@@ -2672,6 +2730,7 @@ Routines with the same type signature can be called individually if
 a parameter has different names between them.
 
 .. code-block:: Nim
+
   proc foo(x: int) =
     echo "Using x: ", x
   proc foo(y: int) =
@@ -2716,6 +2775,7 @@ Discard statement
 Example:
 
 .. code-block:: nim
+
   proc p(x, y: int): int =
     result = x + y
 
@@ -2732,6 +2792,7 @@ The return value can be ignored implicitly if the called proc/iterator has
 been declared with the `discardable`:idx: pragma:
 
 .. code-block:: nim
+
   proc p(x, y: int): int {.discardable.} =
     result = x + y
 
@@ -2740,6 +2801,7 @@ been declared with the `discardable`:idx: pragma:
 however the discardable pragma does not work on templates as templates substitute the AST in place. For example:
 
 .. code-block:: nim
+
   {.push discardable .}
   template example(): string = "https://nim-lang.org"
   {.pop.}
@@ -2751,6 +2813,7 @@ This template will resolve into "https://nim-lang.org" which is a string literal
 An empty `discard` statement is often used as a null statement:
 
 .. code-block:: nim
+
   proc classify(s: string) =
     case s[0]
     of SymChars, '_': echo "an identifier"
@@ -2766,11 +2829,13 @@ type `void`. In addition to this rule an assignment to the builtin `result`
 symbol also triggers a mandatory `void` context for the subsequent expressions:
 
 .. code-block:: nim
+
   proc invalid*(): string =
     result = "foo"
     "invalid"  # Error: value of type 'string' has to be discarded
 
 .. code-block:: nim
+
   proc valid*(): string =
     let x = 317
     "valid"
@@ -2817,6 +2882,7 @@ The implicit initialization can be avoided for optimization reasons with the
 `noinit`:idx: pragma:
 
 .. code-block:: nim
+
   var
     a {.noinit.}: array[0..1023, char]
 
@@ -2824,6 +2890,7 @@ If a proc is annotated with the `noinit` pragma, this refers to its implicit
 `result` variable:
 
 .. code-block:: nim
+
   proc returnUndefinedValue: int {.noinit.} = discard
 
 
@@ -2833,6 +2900,7 @@ and all of its fields. However, it does a `control flow analysis`:idx: to prove
 the variable has been initialized and does not rely on syntactic properties:
 
 .. code-block:: nim
+
   type
     MyObject = object {.requiresInit.}
 
@@ -2850,6 +2918,7 @@ the variable has been initialized and does not rely on syntactic properties:
 Given the following distinct type definitions:
 
 .. code-block:: nim
+
   type
     DistinctObject {.requiresInit, borrow: `.`.} = distinct MyObject
     DistinctString {.requiresInit.} = distinct string
@@ -2857,11 +2926,13 @@ Given the following distinct type definitions:
 The following code blocks will fail to compile:
 
 .. code-block:: nim
+
   var foo: DistinctFoo
   foo.x = "test"
   doAssert foo.x == "test"
 
 .. code-block:: nim
+
   var s: DistinctString
   s = "test"
   doAssert s == "test"
@@ -2869,10 +2940,12 @@ The following code blocks will fail to compile:
 But these ones will compile successfully:
 
 .. code-block:: nim
+
   let foo = DistinctFoo(Foo(x: "test"))
   doAssert foo.x == "test"
 
 .. code-block:: nim
+
   let s = "test"
   doAssert s == "test"
 
@@ -2900,6 +2973,7 @@ In a `var` or `let` statement tuple unpacking can be performed. The special
 identifier `_` can be used to ignore some parts of the tuple:
 
 .. code-block:: nim
+
     proc returnsTuple(): (int, int, int) = (4, 2, 3)
 
     let (x, _, z) = returnsTuple()
@@ -2912,6 +2986,7 @@ Const section
 A const section declares constants whose values are constant expressions:
 
 .. code-block::
+
   import std/[strutils]
   const
     roundPi = 3.1415
@@ -2986,6 +3061,7 @@ For visualization purposes the scopes have been enclosed
 in `{|  |}` in the following example:
 
 .. code-block:: nim
+
   if {| (let m = input =~ re"(\w+)=\w+"; m.isMatch):
     echo "key ", m[0], " value ", m[1]  |}
   elif {| (let m = input =~ re""; m.isMatch):
@@ -3044,6 +3120,7 @@ statement may evaluate to a set or array constructor; the set or array is then
 expanded into a list of its elements:
 
 .. code-block:: nim
+
   const
     SymChars: set[char] = {'a'..'z', 'A'..'Z', '\x80'..'\xFF'}
 
@@ -3064,6 +3141,7 @@ The `case` statement doesn't produce an l-value, so the following example
 won't work:
 
 .. code-block:: nim
+
   type
     Foo = ref object
       x: seq[string]
@@ -3082,6 +3160,7 @@ won't work:
 This can be fixed by explicitly using `result` or `return`:
 
 .. code-block:: nim
+
   proc get_x(x: Foo): var seq[string] =
     case true
     of true:
@@ -3130,6 +3209,7 @@ compile-time and the executable.
 Example:
 
 .. code-block:: nim
+
   proc someProcThatMayRunInCompileTime(): bool =
     when nimvm:
       # This branch is taken at compile time.
@@ -3158,6 +3238,7 @@ Return statement
 Example:
 
 .. code-block:: nim
+
   return 40 + 2
 
 The `return` statement ends the execution of the current procedure.
@@ -3165,6 +3246,7 @@ It is only allowed in procedures. If there is an `expr`, this is syntactic
 sugar for:
 
 .. code-block:: nim
+
   result = expr
   return result
 
@@ -3175,6 +3257,7 @@ value of the procedure. It is automatically declared by the compiler. As all
 variables, `result` is initialized to (binary) zero:
 
 .. code-block:: nim
+
   proc returnZero(): int =
     # implicitly returns 0
 
@@ -3185,6 +3268,7 @@ Yield statement
 Example:
 
 .. code-block:: nim
+
   yield (1, 2, 3)
 
 The `yield` statement is used instead of the `return` statement in
@@ -3201,6 +3285,7 @@ Block statement
 Example:
 
 .. code-block:: nim
+
   var found = false
   block myblock:
     for i in 0..3:
@@ -3222,6 +3307,7 @@ Break statement
 Example:
 
 .. code-block:: nim
+
   break
 
 The `break` statement is used to leave a block immediately. If `symbol`
@@ -3235,6 +3321,7 @@ While statement
 Example:
 
 .. code-block:: nim
+
   echo "Please tell me your password:"
   var pw = readLine(stdin)
   while pw != "12345":
@@ -3255,6 +3342,7 @@ surrounding loop construct. It is only allowed within a loop. A continue
 statement is syntactic sugar for a nested block:
 
 .. code-block:: nim
+
   while expr1:
     stmt1
     continue
@@ -3263,6 +3351,7 @@ statement is syntactic sugar for a nested block:
 Is equivalent to:
 
 .. code-block:: nim
+
   while expr1:
     block myBlockName:
       stmt1
@@ -3279,6 +3368,7 @@ Nim identifiers shall be enclosed in a special character which can be
 specified in the statement's pragmas. The default special character is `'\`'`:
 
 .. code-block:: nim
+
   {.push stackTrace:off.}
   proc addInt(a, b: int): int =
     # a in eax, and b in edx
@@ -3294,6 +3384,7 @@ specified in the statement's pragmas. The default special character is `'\`'`:
 If the GNU assembler is used, quotes and newlines are inserted automatically:
 
 .. code-block:: nim
+
   proc addInt(a, b: int): int =
     asm """
       addl %%ecx, %%eax
@@ -3307,6 +3398,7 @@ If the GNU assembler is used, quotes and newlines are inserted automatically:
 Instead of:
 
 .. code-block:: nim
+
   proc addInt(a, b: int): int =
     asm """
       "addl %%ecx, %%eax\n"
@@ -3324,6 +3416,7 @@ The `using` statement provides syntactic convenience in modules where
 the same parameter names and types are used over and over. Instead of:
 
 .. code-block:: nim
+
   proc foo(c: Context; n: Node) = ...
   proc bar(c: Context; n: Node, counter: int) = ...
   proc baz(c: Context; n: Node) = ...
@@ -3333,6 +3426,7 @@ name `c` should default to type `Context`, `n` should default to
 `Node` etc.:
 
 .. code-block:: nim
+
   using
     c: Context
     n: Node
@@ -3365,6 +3459,7 @@ This feature is similar to *ternary operators* in other languages.
 Example:
 
 .. code-block:: nim
+
   var y = if x > 8: 9 else: 10
 
 An if expression always results in a value, so the `else` part is
@@ -3381,6 +3476,7 @@ Case expression
 The `case` expression is again very similar to the case statement:
 
 .. code-block:: nim
+
   var favoriteFood = case animal
     of "dog": "bones"
     of "cat": "mice"
@@ -3402,6 +3498,7 @@ It is similar to the statement list expression, but the statement list expressio
 does not open a new block scope.
 
 .. code-block:: nim
+
   let a = block:
     var fib = @[0, 1]
     for i in 0..10:
@@ -3414,6 +3511,7 @@ Table constructor
 A table constructor is syntactic sugar for an array constructor:
 
 .. code-block:: nim
+
   {"key1": "value1", "key2", "key3": "value2"}
 
   # is the same as:
@@ -3480,12 +3578,14 @@ as if it would be of another type. Type casts are only needed for low-level
 programming and are inherently unsafe.
 
 .. code-block:: nim
+
   cast[int](x)
 
 The target type of a cast must be a concrete type, for instance, a target type
 that is a type class (which is non-concrete) would be invalid:
 
 .. code-block:: nim
+
   type Foo = int or float
   var x = cast[Foo](1) # Error: cannot cast to a non concrete type: 'Foo'
 
@@ -3525,6 +3625,7 @@ The unsafeAddr operator
 The `unsafeAddr` operator is a deprecated alias for the `addr` operator:
 
 .. code-block:: nim
+
   let myArray = [1, 2, 3]
   foreignProcThatTakesAnAddr(unsafeAddr myArray)
 
@@ -3542,6 +3643,7 @@ already typed parameter, is reached. The semicolon can be used to make
 separation of types and subsequent identifiers more distinct.
 
 .. code-block:: nim
+
   # Using only commas
   proc foo(a, b: int, c, d: bool): int
 
@@ -3556,6 +3658,7 @@ does not provide a value for the argument. The value will be reevaluated
 every time the function is called.
 
 .. code-block:: nim
+
   # b is optional with 47 as its default value.
   proc foo(a: int, b: int = 47): int
 
@@ -3564,6 +3667,7 @@ first parameter or until a semicolon is hit, it also propagates the
 default value starting from the parameter declared with it.
 
 .. code-block:: nim
+
   # Both a and b are optional with 47 as their default values.
   proc foo(a, b: int = 47): int
 
@@ -3571,6 +3675,7 @@ Parameters can be declared mutable and so allow the proc to modify those
 arguments, by using the type modifier `var`.
 
 .. code-block:: nim
+
   # "returning" a value to the caller through the 2nd argument
   # Notice that the function uses no actual return value at all (ie void)
   proc foo(inp: int, outp: var int) =
@@ -3598,6 +3703,7 @@ best match for the arguments. Example:
 Calling a procedure can be done in many different ways:
 
 .. code-block:: nim
+
   proc callme(x, y: int, s: string = "", c: char, b: bool = false) = ...
 
   # call with positional arguments      # parameter bindings:
@@ -3615,6 +3721,7 @@ A procedure may call itself recursively.
 `Operators`:idx: are procedures with a special operator symbol as identifier:
 
 .. code-block:: nim
+
   proc `$` (x: int): string =
     # converts an integer to a string; this is a prefix operator.
     result = intToStr(x)
@@ -3629,6 +3736,7 @@ Any operator can be called like an ordinary proc with the \`opr\`
 notation. (Thus an operator can have more than two parameters):
 
 .. code-block:: nim
+
   proc `*+` (a, b, c: int): int =
     # Multiply and add
     result = a * b + c
@@ -3696,6 +3804,7 @@ with the *method call syntax* achieve the same. But setting a value is
 different; for this, a special setter syntax is needed:
 
 .. code-block:: nim
+
   # Module asocket
   type
     Socket* = ref object of RootObj
@@ -3716,6 +3825,7 @@ different; for this, a special setter syntax is needed:
     s.host
 
 .. code-block:: nim
+
   # module B
   import asocket
   var s: Socket
@@ -3753,6 +3863,7 @@ means `echo f 1, f 2` is parsed as `echo(f(1), f(2))` and not as
 more argument in this case:
 
 .. code-block:: nim
+
   proc optarg(x: int, y: int = 0): int = x + y
   proc singlearg(x: int): int = 20*x
 
@@ -3796,6 +3907,7 @@ Unnamed procedures can be used as lambda expressions to pass into other
 procedures:
 
 .. code-block:: nim
+
   var cities = @["Frankfurt", "Tokyo", "New York", "Kyiv"]
 
   cities.sort(proc (x, y: string): int =
@@ -3815,6 +3927,7 @@ regular proc expression, the `do` keyword can be used to pass
 anonymous procedures to routines:
 
 .. code-block:: nim
+
   var cities = @["Frankfurt", "Tokyo", "New York", "Kyiv"]
 
   sort(cities) do (x, y: string) -> int:
@@ -3835,6 +3948,7 @@ list. This allows macros to receive both indented statement lists as an
 argument in inline calls, as well as a direct mirror of Nim's routine syntax.
 
 .. code-block:: nim
+
   # Passing a statement list to an inline macro:
   macroResults.add quote do:
     if not `ex`:
@@ -3850,11 +3964,13 @@ Func
 The `func` keyword introduces a shortcut for a `noSideEffect`:idx: proc.
 
 .. code-block:: nim
+
   func binarySearch[T](a: openArray[T]; elem: T): int
 
 Is short for:
 
 .. code-block:: nim
+
   proc binarySearch[T](a: openArray[T]; elem: T): int {.noSideEffect.}
 
 
@@ -3874,6 +3990,7 @@ A type bound operator declared for a type applies to the type regardless of whet
 the operator is in scope (including if it is private).
 
 .. code-block:: nim
+
   # foo.nim:
   var witness* = 0
   type Foo[T] = object
@@ -3935,6 +4052,7 @@ Var parameters
 The type of a parameter may be prefixed with the `var` keyword:
 
 .. code-block:: nim
+
   proc divmod(a, b: int; res, remainder: var int) =
     res = a div b
     remainder = a mod b
@@ -3953,6 +4071,7 @@ an l-value. Var parameters are implemented as hidden pointers. The
 above example is equivalent to:
 
 .. code-block:: nim
+
   proc divmod(a, b: int; res, remainder: ptr int) =
     res[] = a div b
     remainder[] = a mod b
@@ -3967,6 +4086,7 @@ In the examples, var parameters or pointers are used to provide two
 return values. This can be done in a cleaner way by returning a tuple:
 
 .. code-block:: nim
+
   proc divmod(a, b: int): tuple[res, remainder: int] =
     (a div b, a mod b)
 
@@ -3978,6 +4098,7 @@ return values. This can be done in a cleaner way by returning a tuple:
 One can use `tuple unpacking`:idx: to access the tuple's fields:
 
 .. code-block:: nim
+
   var (x, y) = divmod(8, 5) # tuple unpacking
   assert x == 1
   assert y == 3
@@ -3995,6 +4116,7 @@ A proc, converter, or iterator may return a `var` type which means that the
 returned value is an l-value and can be modified by the caller:
 
 .. code-block:: nim
+
   var g = 0
 
   proc writeAccessToG(): var int =
@@ -4007,6 +4129,7 @@ It is a static error if the implicitly introduced pointer could be
 used to access a location beyond its lifetime:
 
 .. code-block:: nim
+
   proc writeAccessToG(): var int =
     var g = 0
     result = g # Error!
@@ -4014,6 +4137,7 @@ used to access a location beyond its lifetime:
 For iterators, a component of a tuple return type can have a `var` type too:
 
 .. code-block:: nim
+
   iterator mpairs(a: var seq[string]): tuple[key: int, val: var string] =
     for i in 0..a.high:
       yield (i, a[i])
@@ -4031,6 +4155,7 @@ Later versions of Nim can be more precise about the borrowing rule with
 a syntax like:
 
 .. code-block:: nim
+
   proc foo(other: Y; container: var X): var T from container
 
 Here `var T from container` explicitly exposes that the
@@ -4058,6 +4183,7 @@ receives a hidden mutable parameter representing `result`.
 Informally:
 
 .. code-block:: nim
+
   proc p(): BigT = ...
 
   var x = p()
@@ -4123,6 +4249,7 @@ dispatch. For dynamic dispatch to work on an object it should be a reference
 type.
 
 .. code-block:: nim
+
   type
     Expression = ref object of RootObj ## abstract base class for an expression
     Literal = ref object of Expression
@@ -4241,6 +4368,7 @@ in the body of the `for` loop. The iterator's local variables and execution
 state are automatically saved between calls. Example:
 
 .. code-block:: nim
+
   # this definition exists in the system module
   iterator items*(a: string): char {.inline.} =
     var i = 0
@@ -4254,6 +4382,7 @@ state are automatically saved between calls. Example:
 The compiler generates code as if the programmer would have written this:
 
 .. code-block:: nim
+
   var i = 0
   while i < len(a):
     var ch = a[i]
@@ -4273,6 +4402,7 @@ has exactly 1 variable, the for loop expression is rewritten to `items(e)`;
 ie. an `items` iterator is implicitly invoked:
 
 .. code-block:: nim
+
   for x in [1,2,3]: echo x
 
 If the for loop has exactly 2 variables, a `pairs` iterator is implicitly
@@ -4303,6 +4433,7 @@ templates, macros, and other inline iterators.
 In contrast to that, a `closure iterator`:idx: can be passed around more freely:
 
 .. code-block:: nim
+
   iterator count0(): int {.closure.} =
     yield 0
 
@@ -4339,6 +4470,7 @@ implicitly; the following example shows how to use iterators to implement
 a `collaborative tasking`:idx: system:
 
 .. code-block:: nim
+
   # simple tasking:
   type
     Task = iterator (ticker: int)
@@ -4377,6 +4509,7 @@ Note that `system.finished` is error prone to use because it only returns
 `true` one iteration after the iterator has finished:
 
 .. code-block:: nim
+
   iterator mycount(a, b: int): int {.closure.} =
     var x = a
     while x <= b:
@@ -4396,6 +4529,7 @@ Note that `system.finished` is error prone to use because it only returns
 Instead this code has to be used:
 
 .. code-block:: nim
+
   var c = mycount # instantiate the iterator
   while true:
     let value = c(1, 3)
@@ -4412,6 +4546,7 @@ arguments to every call. To get around this limitation one can capture
 parameters of an outer factory proc:
 
 .. code-block:: nim
+
   proc mycount(a, b: int): iterator (): int =
     result = iterator (): int =
       var x = a
@@ -4427,6 +4562,7 @@ parameters of an outer factory proc:
 The call can be made more like an inline iterator with a for loop macro:
 
 .. code-block:: nim
+
   import std/macros
   macro toItr(x: ForLoopStmt): untyped =
     let expr = x[0]
@@ -4450,6 +4586,7 @@ above macro allows such recursion to look much like a recursive iterator
 would. For example:
 
 .. code-block:: nim
+
   proc recCountDown(n: int): iterator(): int =
     result = iterator(): int =
       if n > 0:
@@ -4470,6 +4607,7 @@ A converter is like an ordinary proc except that it enhances
 the "implicitly convertible" type relation (see `Convertible relation`_):
 
 .. code-block:: nim
+
   # bad style ahead: Nim is not C.
   converter toBool(x: int): bool = x != 0
 
@@ -4489,6 +4627,7 @@ Type sections
 Example:
 
 .. code-block:: nim
+
   type # example demonstrating mutually recursive types
     Node = ref object  # an object managed by the garbage collector (ref)
       le, ri: Node     # left and right subtrees
@@ -4516,6 +4655,7 @@ Try statement
 Example:
 
 .. code-block:: nim
+
   # read the first two lines of a text file that should contain numbers
   # and tries to add them
   var
@@ -4562,6 +4702,7 @@ needs to fit the types of `except` branches, but the type of the `finally`
 branch always has to be `void`:
 
 .. code-block:: nim
+
   from std/strutils import parseInt
 
   let x = try: parseInt("133a")
@@ -4573,6 +4714,7 @@ To prevent confusing code there is a parsing limitation; if the `try`
 follows a `(` it has to be written as a one liner:
 
 .. code-block:: nim
+
   let x = (try: parseInt("133a") except: -1)
 
 
@@ -4583,6 +4725,7 @@ Within an `except` clause it is possible to access the current exception
 using the following syntax:
 
 .. code-block:: nim
+
   try:
     # ...
   except IOError as e:
@@ -4593,6 +4736,7 @@ Alternatively, it is possible to use `getCurrentException` to retrieve the
 exception that has been raised:
 
 .. code-block:: nim
+
   try:
     # ...
   except IOError:
@@ -4604,6 +4748,7 @@ type. If a variable of the proper type is needed (in the example
 above, `IOError`), one must convert it explicitly:
 
 .. code-block:: nim
+
   try:
     # ...
   except IOError:
@@ -4615,6 +4760,7 @@ error message from `e`, and for such situations, it is enough to use
 `getCurrentExceptionMsg`:
 
 .. code-block:: nim
+
   try:
     # ...
   except:
@@ -4626,6 +4772,7 @@ Custom exceptions
 It is possible to create custom exceptions. A custom exception is a custom type:
 
 .. code-block:: nim
+
   type
     LoadError* = object of Exception
 
@@ -4634,6 +4781,7 @@ Ending the custom exception's name with `Error` is recommended.
 Custom exceptions can be raised just like any other exception, e.g.:
 
 .. code-block:: nim
+
   raise newException(LoadError, "Failed to load data")
 
 Defer statement
@@ -4705,6 +4853,7 @@ Raise statement
 Example:
 
 .. code-block:: nim
+
   raise newException(IOError, "IO failed")
 
 Apart from built-in operations like array indexing, memory allocation, etc.
@@ -4803,6 +4952,7 @@ allowed to raise. The compiler verifies this:
 An empty `raises` list (`raises: []`) means that no exception may be raised:
 
 .. code-block:: nim
+
   proc p(): bool {.raises: [].} =
     try:
       unsafeCall()
@@ -4884,6 +5034,7 @@ Rules 1-2 of the exception tracking inference rules (see the previous section)
 ensure the following works:
 
 .. code-block:: nim
+
   proc weDontRaiseButMaybeTheCallback(callback: proc()) {.raises: [], effectsOf: callback.} =
     callback()
 
@@ -4977,6 +5128,7 @@ so that it can be used for debugging routines marked as `noSideEffect`.
 `func` is syntactic sugar for a proc with no side effects:
 
 .. code-block:: nim
+
   func `+` (x, y: int): int
 
 
@@ -5037,6 +5189,7 @@ effects analysis. It is a statement that makes the compiler output all inferred
 effects up to the `effects`'s position:
 
 .. code-block:: nim
+
   proc p(what: bool) =
     if what:
       raise newException(IOError, "IO")
@@ -5126,6 +5279,7 @@ equivalence. It is therefore very useful for type specialization within generic
 code:
 
 .. code-block:: nim
+
   type
     Table[Key, Value] = object
       keys: seq[Key]
@@ -5166,6 +5320,7 @@ Type classes can be combined using the standard boolean operators to form
 more complex type classes:
 
 .. code-block:: nim
+
   # create a type class that will match all tuple and object types
   type RecordType = tuple or object
 
@@ -5177,6 +5332,7 @@ Type constraints on generic parameters can be grouped with `,` and propagation
 stops with `;`, similarly to parameters for macros and templates:
 
 .. code-block:: nim
+
   proc fn1[T; U, V: SomeFloat]() = discard # T is unconstrained
   template fn2(t; u, v: SomeFloat) = discard # t is unconstrained
 
@@ -5190,6 +5346,7 @@ runtime type dynamism, unlike object variants or methods.
 As an example, the following would not compile:
 
 .. code-block:: nim
+
   type TypeClass = int | string
   var foo: TypeClass = 2 # foo's type is resolved to an int here
   foo = "this will fail" # error here, because foo is an int
@@ -5198,6 +5355,7 @@ Nim allows for type classes and regular types to be specified
 as `type constraints`:idx: of the generic type parameter:
 
 .. code-block:: nim
+
   proc onlyIntOrString[T: int|string](x, y: T) = discard
 
   onlyIntOrString(450, 616) # valid
@@ -5229,6 +5387,7 @@ exactly one concrete type. We call such type classes `bind once`:idx: types.
 Here is an example taken directly from the system module to illustrate this:
 
 .. code-block:: nim
+
   proc `==`*(x, y: tuple): bool =
     ## requires `x` and `y` to be of the same tuple type
     ## generic `==` operator for tuples that is lifted from the components
@@ -5246,6 +5405,7 @@ type parameters of the matched generic type. They can be easily accessed using
 the dot syntax:
 
 .. code-block:: nim
+
   type Matrix[T, Rows, Columns] = object
     ...
 
@@ -5410,6 +5570,7 @@ the identifiers should be looked up in the scope of the template/generic
 definition):
 
 .. code-block:: nim
+
   # Module A
   var
     lastId = 0
@@ -5420,6 +5581,7 @@ definition):
     lastId
 
 .. code-block:: nim
+
   # Module B
   import A
 
@@ -5487,6 +5649,7 @@ The syntax to *invoke* a template is the same as calling a procedure.
 Example:
 
 .. code-block:: nim
+
   template `!=` (a, b: untyped): untyped =
     # this definition exists in the System module
     not (a == b)
@@ -5627,6 +5790,7 @@ A template is a `hygienic`:idx: macro and so opens a new scope. Most symbols are
 bound from the definition scope of the template:
 
 .. code-block:: nim
+
   # Module A
   var
     lastId = 0
@@ -5636,6 +5800,7 @@ bound from the definition scope of the template:
     lastId
 
 .. code-block:: nim
+
   # Module B
   import A
 
@@ -5674,6 +5839,7 @@ Thus, template arguments can be used as field names and a global symbol can be
 shadowed by the same argument name even when fully qualified:
 
 .. code-block:: nim
+
   # module 'm'
 
   type
@@ -5691,6 +5857,7 @@ shadowed by the same argument name even when fully qualified:
 But the global symbol can properly be captured by a `bind` statement:
 
 .. code-block:: nim
+
   # module 'm'
 
   type
@@ -5738,6 +5905,7 @@ is `gensym` and for `proc`, `iterator`, `converter`, `template`,
 template parameter, it is an `inject`'ed symbol:
 
 .. code-block:: nim
+
   template withFile(f, fn, mode: untyped, actions: untyped): untyped =
     block:
       var f: File  # since 'f' is a template param, it's injected implicitly
@@ -5752,6 +5920,7 @@ The `inject` and `gensym` pragmas are second class annotations; they have
 no semantics outside of a template definition and cannot be abstracted over:
 
 .. code-block:: nim
+
   {.pragma myInject: inject.}
 
   template t() =
@@ -5907,6 +6076,7 @@ variable number of arguments:
 The macro call expands to:
 
 .. code-block:: nim
+
   write(stdout, "a[0]")
   write(stdout, ": ")
   writeLine(stdout, a[0])
@@ -5958,6 +6128,7 @@ builtin can be used for that:
 The macro call expands to:
 
 .. code-block:: nim
+
   write(stdout, "a[0]")
   write(stdout, ": ")
   writeLine(stdout, a[0])
@@ -5987,6 +6158,7 @@ blocks (including their different forms such as `do` with routine parameters)
 as arguments if called in statement form.
 
 .. code-block:: nim
+
   macro performWithUndo(task, undo: untyped) = ...
 
   performWithUndo do:
@@ -6030,6 +6202,7 @@ type `system.ForLoopStmt` can rewrite the entirety of a `for` loop:
 Expands to:
 
 .. code-block:: nim
+
   for item in items([1, 2, 3]):
     echo item
 
@@ -6081,6 +6254,7 @@ for tuples, leveraging the existing equality operator for tuples
 
 .. code-block:: nim
     :test: "nim c $1"
+
   import std/macros
 
   macro `case`(n: tuple): untyped =
@@ -6162,6 +6336,7 @@ One can force an expression to be evaluated at compile time as a constant
 expression by coercing it to a corresponding `static` type:
 
 .. code-block:: nim
+
   import std/math
 
   echo static(fac(5)), " ", static[bool](16.isPowerOfTwo)
@@ -6199,6 +6374,7 @@ When multiple type params are present, they will bind freely to different
 types. To force a bind-once behavior, one can use an explicit generic param:
 
 .. code-block:: nim
+
   proc acceptOnlyTypePairs[T, U](A, B: typedesc[T]; C, D: typedesc[U])
 
 Once bound, type params can appear in the rest of the proc signature:
@@ -6307,6 +6483,7 @@ The algorithm for compiling modules is:
 This is best illustrated by an example:
 
 .. code-block:: nim
+
   # Module A
   type
     T1* = int  # Module A exports the type `T1`
@@ -6319,6 +6496,7 @@ This is best illustrated by an example:
 
 
 .. code-block:: nim
+
   # Module B
   import A  # A is not parsed here! Only the already known symbols
             # of A are imported.
@@ -6361,15 +6539,18 @@ importing a module: it merely includes the contents of a file. The `include`
 statement is useful to split up a large module into several files:
 
 .. code-block:: nim
+
   include fileA, fileB, fileC
 
 The `include` statement can be used outside of the top level, as such:
 
 .. code-block:: nim
+
   # Module A
   echo "Hello World!"
 
 .. code-block:: nim
+
   # Module B
   proc main() =
     include A
@@ -6383,6 +6564,7 @@ Module names in imports
 A module alias can be introduced via the `as` keyword:
 
 .. code-block:: nim
+
   import std/strutils as su, std/sequtils as qu
 
   echo su.format("$1", "lalelu")
@@ -6392,18 +6574,21 @@ The original module name is then not accessible. The notations
 in subdirectories:
 
 .. code-block:: nim
+
   import lib/pure/os, "lib/pure/times"
 
 Note that the module name is still `strutils` and not `lib/pure/strutils`
 and so one **cannot** do:
 
 .. code-block:: nim
+
   import lib/pure/strutils
   echo lib/pure/strutils.toUpperAscii("abc")
 
 Likewise, the following does not make sense as the name is `strutils` already:
 
 .. code-block:: nim
+
   import lib/pure/strutils as strutils
 
 
@@ -6417,6 +6602,7 @@ Path names are syntactically either Nim identifiers or string literals. If the p
 name is not a valid Nim identifier it needs to be a string literal:
 
 .. code-block:: nim
+
   import "gfx/3d/somemodule" # in quotes because '3d' is not a valid Nim identifier
 
 
@@ -6466,10 +6652,12 @@ An `export` statement can be used for symbol forwarding so that client
 modules don't need to import a module's dependencies:
 
 .. code-block:: nim
+
   # module B
   type MyObject* = object
 
 .. code-block:: nim
+
   # module A
   import B
   export B.MyObject
@@ -6478,6 +6666,7 @@ modules don't need to import a module's dependencies:
 
 
 .. code-block:: nim
+
   # module C
   import A
 
@@ -6491,6 +6680,7 @@ be forwarded. One can use an `except` list to exclude some of the symbols.
 Notice that when exporting, one needs to specify only the module name:
 
 .. code-block:: nim
+
   import foo/bar/baz
   export baz
 
@@ -6534,14 +6724,17 @@ the identifier has to be qualified unless it is an overloaded procedure or
 iterator in which case the overloading resolution takes place:
 
 .. code-block:: nim
+
   # Module A
   var x*: string
 
 .. code-block:: nim
+
   # Module B
   var x*: int
 
 .. code-block:: nim
+
   # Module C
   import A, B
   write(stdout, x) # error: x is ambiguous
@@ -6590,12 +6783,14 @@ deprecated pragma
 The deprecated pragma is used to mark a symbol as deprecated:
 
 .. code-block:: nim
+
   proc p() {.deprecated.}
   var x {.deprecated.}: char
 
 This pragma can also take in an optional warning string to relay to developers.
 
 .. code-block:: nim
+
   proc thing(x: bool) {.deprecated: "use thong instead".}
 
 
@@ -6609,12 +6804,14 @@ proc that uses `system.NimNode` within its parameter types is implicitly
 declared `compileTime`:
 
 .. code-block:: nim
+
   proc astHelper(n: NimNode): NimNode =
     result = n
 
 Is the same as:
 
 .. code-block:: nim
+
   proc astHelper(n: NimNode): NimNode {.compileTime.} =
     result = n
 
@@ -6656,6 +6853,7 @@ even though they seem to be cyclic. This is an **optimization** for the garbage
 collector to not consider objects of this type as part of a cycle:
 
 .. code-block:: nim
+
   type
     Node = ref NodeObj
     NodeObj {.acyclic.} = object
@@ -6665,6 +6863,7 @@ collector to not consider objects of this type as part of a cycle:
 Or if we directly use a ref object:
 
 .. code-block:: nim
+
   type
     Node {.acyclic.} = ref object
       left, right: Node
@@ -6697,6 +6896,7 @@ This can be expensive, especially if sequences are used to build a tree
 structure:
 
 .. code-block:: nim
+
   type
     NodeKind = enum nkLeaf, nkInner
     Node {.shallow.} = object
@@ -6740,6 +6940,7 @@ triggers a static error. This is especially useful to rule out that some
 operation is valid due to overloading and type conversions:
 
 .. code-block:: nim
+
   ## check that underlying int values are compared and not the pointers:
   proc `==`(x, y: ptr int): bool {.error.}
 
@@ -6751,6 +6952,7 @@ with the given content. In contrast to the `error` pragma, the compilation
 is guaranteed to be aborted by this pragma. Example:
 
 .. code-block:: nim
+
   when not defined(objc):
     {.fatal: "Compile this program with the objc command!".}
 
@@ -6789,6 +6991,7 @@ compile a Nim `case`:idx: statement. Syntactically it has to be used as a
 statement:
 
 .. code-block:: nim
+
   case myInt
   of 0:
     echo "most common case"
@@ -6899,6 +7102,7 @@ callconv         cdecl|...        Specifies the default calling convention for
 Example:
 
 .. code-block:: nim
+
   {.checks: off, optimization: speed.}
   # compile without runtime checks and optimize for speed
 
@@ -6909,6 +7113,7 @@ The `push/pop`:idx: pragmas are very similar to the option directive,
 but are used to override the settings temporarily. Example:
 
 .. code-block:: nim
+
   {.push checks: off.}
   # compile this section without runtime checks as it is
   # speed critical
@@ -6918,6 +7123,7 @@ but are used to override the settings temporarily. Example:
 `push/pop`:idx: can switch on/off some standard library pragmas, example:
 
 .. code-block:: nim
+
   {.push inline.}
   proc thisIsInlined(): int = 42
   func willBeInlined(): float = 42.0
@@ -6953,6 +7159,7 @@ the compiler to store it in a global location and initialize it once at program
 startup.
 
 .. code-block:: nim
+
   proc isHexNumber(s: string): bool =
     var pattern {.global.} = re"[0-9a-fA-F]+"
     result = s.match(pattern)
@@ -6971,6 +7178,7 @@ and warning message contains a symbol in brackets. This is the message's
 identifier that can be used to enable or disable it:
 
 .. code-block:: Nim
+
   {.hint[LineTooLong]: off.} # turn off the hint about too long lines
 
 This is often better than disabling all warnings at once.
@@ -6984,6 +7192,7 @@ The `used` pragma can be attached to a symbol to suppress this warning. This
 is particularly useful when the symbol was generated by a macro:
 
 .. code-block:: nim
+
   template implementArithOps(T) =
     proc echoAdd(a, b: T) {.used.} =
       echo a + b
@@ -7019,6 +7228,7 @@ is uncertain (it may be removed at any time). See the
 Example:
 
 .. code-block:: nim
+
   import std/threadpool
   {.experimental: "parallel".}
 
@@ -7070,6 +7280,7 @@ The `bitsize` pragma is for object field members. It declares the field as
 a bitfield in C/C++.
 
 .. code-block:: Nim
+
   type
     mybitfield = object
       flag {.bitsize:1.}: cuint
@@ -7077,6 +7288,7 @@ a bitfield in C/C++.
 generates:
 
 .. code-block:: C
+
   struct mybitfield {
     unsigned int flag:1;
   };
@@ -7116,7 +7328,7 @@ This pragma has no effect on the JS backend.
 
 
 Noalias pragma
-==============
+--------------
 
 Since version 1.4 of the Nim compiler, there is a `.noalias` annotation for variables
 and parameters. It is mapped directly to C/C++'s `restrict`:c: keyword and means that
@@ -7147,6 +7359,7 @@ It tells Nim that it should not generate a declaration for the symbol in
 the C code. For example:
 
 .. code-block:: Nim
+
   var
     EACCES {.importc, nodecl.}: cint # pretend EACCES was a variable, as
                                      # Nim does not know its value
@@ -7163,6 +7376,7 @@ applied to almost any symbol and specifies that it should not be declared
 and instead, the generated code should contain an `#include`:c:\:
 
 .. code-block:: Nim
+
   type
     PFile {.importc: "FILE*", header: "<stdio.h>".} = distinct pointer
       # import C's FILE* type; Nim will treat it as a new pointer type
@@ -7181,6 +7395,7 @@ The `incompleteStruct` pragma tells the compiler to not use the
 underlying C `struct`:c: in a `sizeof` expression:
 
 .. code-block:: Nim
+
   type
     DIR* {.importc: "DIR", header: "<dirent.h>",
            pure, incompleteStruct.} = object
@@ -7192,6 +7407,7 @@ The `compile` pragma can be used to compile and link a C/C++ source file
 with the project:
 
 .. code-block:: Nim
+
   {.compile: "myfile.cpp".}
 
 **Note**: Nim computes a SHA1 checksum and only recompiles the file if it
@@ -7201,6 +7417,7 @@ the recompilation of the file.
 Since 1.4 the `compile` pragma is also available with this syntax:
 
 .. code-block:: Nim
+
   {.compile("myfile.cpp", "--custom flags here").}
 
 As can be seen in the example, this new variant allows for custom flags
@@ -7212,6 +7429,7 @@ Link pragma
 The `link` pragma can be used to link an additional file with the project:
 
 .. code-block:: Nim
+
   {.link: "myfile.o".}
 
 
@@ -7221,6 +7439,7 @@ The `passc` pragma can be used to pass additional parameters to the C
 compiler like one would using the command-line switch `--passc`:option:\:
 
 .. code-block:: Nim
+
   {.passc: "-Wall -Werror".}
 
 Note that one can use `gorge` from the `system module <system.html>`_ to
@@ -7228,6 +7447,7 @@ embed parameters from an external command that will be executed
 during semantic analysis:
 
 .. code-block:: Nim
+
   {.passc: gorge("pkg-config --cflags sdl").}
 
 
@@ -7238,6 +7458,7 @@ compiler, but only for the C/C++ file that is produced from the Nim module
 the pragma resides in:
 
 .. code-block:: Nim
+
   # Module A.nim
   # Produces: A.nim.cpp
   {.localPassC: "-Wall -Werror".} # Passed when compiling A.nim.cpp
@@ -7249,6 +7470,7 @@ The `passL` pragma can be used to pass additional parameters to the linker
 like one would be using the command-line switch `--passL`:option:\:
 
 .. code-block:: Nim
+
   {.passL: "-lSDLmain -lSDL".}
 
 Note that one can use `gorge` from the `system module <system.html>`_ to
@@ -7256,6 +7478,7 @@ embed parameters from an external command that will be executed
 during semantic analysis:
 
 .. code-block:: Nim
+
   {.passL: gorge("pkg-config --libs sdl").}
 
 
@@ -7269,6 +7492,7 @@ extremely useful for interfacing with `C++`:idx: or `Objective C`:idx: code.
 Example:
 
 .. code-block:: Nim
+
   {.emit: """
   static int cvariable = 420;
   """.}
@@ -7286,6 +7510,7 @@ Example:
 `extern "C"`:cpp: code to work with both `nim c`:cmd: and `nim cpp`:cmd:, e.g.:
 
 .. code-block:: Nim
+
   proc foobar() {.importc:"$1".}
   {.emit: """
   #include <stdio.h>
@@ -7302,6 +7527,7 @@ the code should be emitted can be influenced via the prefixes
 `/*TYPESECTION*/`:c: or `/*VARSECTION*/`:c: or `/*INCLUDESECTION*/`:c:\:
 
 .. code-block:: Nim
+
   {.emit: """/*TYPESECTION*/
   struct Vector3 {
   public:
@@ -7333,6 +7559,7 @@ syntax: `obj->method(arg)`:cpp:. In combination with the `header` and `emit`
 pragmas this allows *sloppy* interfacing with libraries written in C++:
 
 .. code-block:: Nim
+
   # Horrible example of how to interface with a C++ engine ... ;-)
 
   {.link: "/usr/lib/libIrrlicht.so".}
@@ -7371,6 +7598,7 @@ declarations. It is usually much better to instead refer to the imported name
 via the `namespace::identifier`:cpp: notation:
 
 .. code-block:: nim
+
   type
     IrrlichtDeviceObj {.header: irr,
                         importcpp: "irr::IrrlichtDevice".} = object
@@ -7400,6 +7628,7 @@ language for maximum flexibility:
 For example:
 
 .. code-block:: nim
+
   proc cppMethod(this: CppObj, a, b, c: cint) {.importcpp: "#.CppMethod(@)".}
   var x: ptr CppObj
   cppMethod(x[], 1, 2, 3)
@@ -7407,6 +7636,7 @@ For example:
 Produces:
 
 .. code-block:: C
+
   x->CppMethod(1, 2, 3)
 
 As a special rule to keep backward compatibility with older versions of the
@@ -7415,12 +7645,14 @@ character (any of ``# ' @``) at all, C++'s
 dot or arrow notation is assumed, so the above example can also be written as:
 
 .. code-block:: nim
+
   proc cppMethod(this: CppObj, a, b, c: cint) {.importcpp: "CppMethod".}
 
 Note that the pattern language naturally also covers C++'s operator overloading
 capabilities:
 
 .. code-block:: nim
+
   proc vectorAddition(a, b: Vec3): Vec3 {.importcpp: "# + #".}
   proc dictLookup(a: Dict, k: Key): Value {.importcpp: "#[#]".}
 
@@ -7444,6 +7676,7 @@ For example:
 Produces:
 
 .. code-block:: C
+
   x = SystemManager::getSubsystem<System::Input>()
 
 
@@ -7455,6 +7688,7 @@ Produces:
 For example C++'s `new`:cpp: operator can be "imported" like this:
 
 .. code-block:: nim
+
   proc cnew*[T](x: T): ptr T {.importcpp: "(new '*0#@)", nodecl.}
 
   # constructor of 'Foo':
@@ -7465,12 +7699,14 @@ For example C++'s `new`:cpp: operator can be "imported" like this:
 Produces:
 
 .. code-block:: C
+
   x = new Foo(3, 4)
 
 However, depending on the use case `new Foo`:cpp: can also be wrapped like this
 instead:
 
 .. code-block:: nim
+
   proc newFoo(a, b: cint): ptr Foo {.importcpp: "new Foo(@)".}
 
   let x = newFoo(3, 4)
@@ -7487,6 +7723,7 @@ annotated with the `constructor`:idx: pragma. This pragma also helps to generate
 faster C++ code since construction then doesn't invoke the copy constructor:
 
 .. code-block:: nim
+
   # a better constructor of 'Foo':
   proc constructFoo(a, b: cint): Foo {.importcpp: "Foo(@)", constructor.}
 
@@ -7501,6 +7738,7 @@ explicitly, it needs to be wrapped. The pattern language provides
 everything that is required:
 
 .. code-block:: nim
+
   proc destroyFoo(this: var Foo) {.importcpp: "#.~Foo()".}
 
 
@@ -7526,6 +7764,7 @@ language for object types:
 Produces:
 
 .. code-block:: C
+
   std::map<int, double> x;
   x[6] = 91.4;
 
@@ -7568,6 +7807,7 @@ In addition with the `header` and `emit` pragmas this
 allows *sloppy* interfacing with libraries written in Objective C:
 
 .. code-block:: Nim
+
   # horrible example of how to interface with GNUStep ...
 
   {.passL: "-lobjc".}
@@ -7621,12 +7861,14 @@ and $2 is the name of the variable.
 The following Nim code:
 
 .. code-block:: nim
+
   var
     a {.codegenDecl: "$# progmem $#".}: int
 
 will generate this C code:
 
 .. code-block:: c
+
   int progmem a
 
 For procedures, $1 is the return type of the procedure, $2 is the name of
@@ -7635,12 +7877,14 @@ the procedure, and $3 is the parameter list.
 The following nim code:
 
 .. code-block:: nim
+
   proc myinterrupt() {.codegenDecl: "__interrupt $# $#$#".} =
     echo "realistic interrupt handler"
 
 will generate this code:
 
 .. code-block:: c
+
   __interrupt void myinterrupt()
 
 
@@ -7652,6 +7896,7 @@ work properly (in particular regarding constructor and destructor) for
 `.threadvar` variables. This requires `--tlsEmulation:off`:option:.
 
 .. code-block:: nim
+
   type Foo {.cppNonPod, importcpp, header: "funs.h".} = object
     x: cint
   proc main()=
@@ -7676,10 +7921,12 @@ pragma             description
 =================  ============================================
 
 .. code-block:: nim
+
    const FooBar {.intdefine.}: int = 5
    echo FooBar
 
 .. code:: cmd
+
    nim c -d:FooBar=42 foobar.nim
 
 In the above example, providing the `-d`:option: flag causes the symbol
@@ -7705,6 +7952,7 @@ They cannot be imported from a module.
 Example:
 
 .. code-block:: nim
+
   when appType == "lib":
     {.pragma: rtl, exportc, dynlib, cdecl.}
   else:
@@ -7725,6 +7973,7 @@ code generation directly, but their presence can be detected by macros.
 Custom pragmas are defined using templates annotated with pragma `pragma`:
 
 .. code-block:: nim
+
   template dbTable(name: string, table_space: string = "") {.pragma.}
   template dbKey(name: string = "", primary_key: bool = false) {.pragma.}
   template dbForeignKey(t: typedesc) {.pragma.}
@@ -7735,6 +7984,7 @@ Consider this stylized example of a possible Object Relation Mapping (ORM)
 implementation:
 
 .. code-block:: nim
+
   const tblspace {.strdefine.} = "dev" # switch for dev, test and prod environments
 
   type
@@ -7773,6 +8023,7 @@ More examples with custom pragmas:
 - Better serialization/deserialization control:
 
   .. code-block:: nim
+
     type MyObj = object
       a {.dontSerialize.}: int
       b {.defaultDeserialize: 5.}: int
@@ -7781,6 +8032,7 @@ More examples with custom pragmas:
 - Adopting type for gui inspector in a game engine:
 
   .. code-block:: nim
+
     type MyComponent = object
       position {.editable, animatable.}: Vector3
       alpha {.editRange: [0.0..1.0], animatable.}: float32
@@ -7795,6 +8047,7 @@ declarations or routine type expressions. The compiler will perform the
 following simple syntactic transformations:
 
 .. code-block:: nim
+
   template command(name: string, def: untyped) = discard
 
   proc p() {.command("print").} = discard
@@ -7802,18 +8055,21 @@ following simple syntactic transformations:
 This is translated to:
 
 .. code-block:: nim
+
   command("print"):
     proc p() = discard
 
 ------
 
 .. code-block:: nim
+
   type
     AsyncEventHandler = proc (x: Event) {.async.}
 
 This is translated to:
 
 .. code-block:: nim
+
   type
     AsyncEventHandler = async(proc (x: Event))
 
@@ -7846,12 +8102,14 @@ the argument is missing, the C name is the Nim identifier *exactly as
 spelled*:
 
 .. code-block::
+
   proc printf(formatstr: cstring) {.header: "<stdio.h>", importc: "printf", varargs.}
 
 When `importc` is applied to a `let` statement it can omit its value which
 will then be expected to come from C. This can be used to import a C `const`:c:\:
 
 .. code-block::
+
   {.emit: "const int cconst = 42;".}
 
   let cconst {.importc, nodecl.}: cint
@@ -7864,10 +8122,13 @@ the same feature under the same name. Also, when the target language
 is not set to C, other pragmas are available:
 
  * `importcpp <manual.html#implementation-specific-pragmas-importcpp-pragma>`_
+ * `importcpp pragma`_
+ * `ImportCpp pragma`_
  * `importobjc <manual.html#implementation-specific-pragmas-importobjc-pragma>`_
  * `importjs <manual.html#implementation-specific-pragmas-importjs-pragma>`_
 
 .. code-block:: Nim
+
   proc p(s: cstring) {.importc: "prefix$1".}
 
 In the example, the external name of `p` is set to `prefixp`. Only ``$1``
@@ -7882,6 +8143,7 @@ is a string containing the C identifier. If the argument is missing, the C
 name is the Nim identifier *exactly as spelled*:
 
 .. code-block:: Nim
+
   proc callme(formatstr: cstring) {.exportc: "callMe", varargs.}
 
 Note that this pragma is somewhat of a misnomer: Other backends do provide
@@ -7890,6 +8152,7 @@ the same feature under the same name.
 The string literal passed to `exportc` can be a format string:
 
 .. code-block:: Nim
+
   proc p(s: string) {.exportc: "prefix$1".} =
     echo s
 
@@ -7907,6 +8170,7 @@ Like `exportc` or `importc`, the `extern` pragma affects name
 mangling. The string literal passed to `extern` can be a format string:
 
 .. code-block:: Nim
+
   proc p(s: string) {.extern: "prefix$1".} =
     echo s
 
@@ -7921,6 +8185,7 @@ The `bycopy` pragma can be applied to an object or tuple type and
 instructs the compiler to pass the type by value to procs:
 
 .. code-block:: nim
+
   type
     Vector {.bycopy.} = object
       x, y, z: float
@@ -7942,6 +8207,7 @@ after the last specified parameter. Nim string values will be converted to C
 strings automatically:
 
 .. code-block:: Nim
+
   proc printf(formatstr: cstring) {.nodecl, varargs.}
 
   printf("hallo %s", "world") # "world" will be passed as C string
@@ -7978,6 +8244,7 @@ a dynamic library (``.dll`` files for Windows, ``lib*.so`` files for UNIX).
 The non-optional argument has to be the name of the dynamic library:
 
 .. code-block:: Nim
+
   proc gtk_image_new(): PGtkWidget
     {.cdecl, dynlib: "libgtk-x11-2.0.so", importc.}
 
@@ -7988,6 +8255,7 @@ packages need to be installed.
 The `dynlib` import mechanism supports a versioning scheme:
 
 .. code-block:: nim
+
   proc Tcl_Eval(interp: pTcl_Interp, script: cstring): int {.cdecl,
     importc, dynlib: "libtcl(|8.5|8.4|8.3).so.(1|0)".}
 
@@ -8006,6 +8274,7 @@ The `dynlib` pragma supports not only constant strings as an argument but also
 string expressions in general:
 
 .. code-block:: nim
+
   import std/os
 
   proc getDllName: string =
@@ -8036,6 +8305,7 @@ a dynamic library. The pragma then has no argument and has to be used in
 conjunction with the `exportc` pragma:
 
 .. code-block:: Nim
+
   proc exportme(): int {.cdecl, exportc, dynlib.}
 
 This is only useful if the program is compiled as a dynamic library via the
@@ -8086,6 +8356,7 @@ A variable can be marked with the `threadvar` pragma, which makes it a
 of the `global` pragma.
 
 .. code-block:: nim
+
   var checkpoints* {.threadvar.}: seq[string]
 
 Due to implementation restrictions, thread-local variables cannot be

--- a/doc/manual/var_t_return.rst
+++ b/doc/manual/var_t_return.rst
@@ -7,6 +7,7 @@ rule: If `result` does not refer to a location pointing to the heap
 then it has to be derived from the routine's first parameter:
 
 .. code-block:: nim
+
   proc forward[T](x: var T): var T =
     result = x # ok, derived from the first parameter.
 

--- a/doc/manual_experimental.rst
+++ b/doc/manual_experimental.rst
@@ -413,6 +413,7 @@ can also be applied to type, variable and constant declarations.
 For types:
 
 .. code-block:: nim
+
   type
     MyObject {.schema: "schema.protobuf".} = object
 
@@ -438,6 +439,7 @@ the same kind as the section containing a single definition is passed to macros,
 and macros can return any expression.
 
 .. code-block:: nim
+
   var
     a = ...
     b {.importc, foo, nodecl.} = ...
@@ -446,6 +448,7 @@ and macros can return any expression.
 Assuming `foo` is a macro or a template, this is roughly equivalent to:
 
 .. code-block:: nim
+
   var a = ...
   foo:
     var b {.importc, nodecl.} = ...
@@ -460,6 +463,7 @@ i.e. without parentheses. This is useful for repeated uses of complex
 expressions that cannot conveniently be represented as runtime values.
 
 .. code-block:: nim
+
   type Foo = object
     bar: int
   
@@ -1290,6 +1294,7 @@ This experimental feature allows the symbol name argument of `macros.bindSym`
 to be computed dynamically.
 
 .. code-block:: nim
+
   {.experimental: "dynamicBindSym".}
 
   import macros

--- a/doc/manual_experimental_strictnotnil.rst
+++ b/doc/manual_experimental_strictnotnil.rst
@@ -7,11 +7,13 @@ Strict not nil checking
 **Note:** This feature is experimental, you need to enable it with
 
 .. code-block:: nim
+
   {.experimental: "strictNotNil".}
 
 or 
 
 .. code-block:: cmd
+
   nim c --experimental:strictNotNil <program>
 
 In the second case it would check builtin and imported modules as well.
@@ -40,6 +42,7 @@ not nil
 You can annotate a type where nil isn't a valid value with `not nil`.
 
 .. code-block:: nim
+
     type
       NilableObject = ref object
         a: int
@@ -119,12 +122,14 @@ call args rules
 When we call with arguments, we have two cases when we might change the nilability.
 
 .. code-block:: nim
+
   callByVar(a)
 
 Here `callByVar` can re-assign `a`, so this might change `a`'s nilability, so we change it to `MaybeNil`.
 This is also a possible aliasing `move out` (moving out of a current alias set).
 
 .. code-block:: nim
+
   call(a)
 
 Here `call` can change a field or element of `a`, so if we have a dependant expression of `a` : e.g. `a.field`. Dependats become `MaybeNil`.
@@ -142,6 +147,7 @@ When branches "join" we usually unify their expression maps or/and nilabilities.
 Merging usually merges maps and alias sets: nilabilities are merged like this:
 
 .. code-block:: nim
+
   template union(l: Nilability, r: Nilability): Nilability =
     ## unify two states
     if l == r:
@@ -184,6 +190,7 @@ When we assign an object construction, we should track the fields as well:
 
 
 .. code-block:: nim
+
   var a = Nilable(field: Nilable()) # a : Safe, a.field: Safe
 
 Usually we just track the result of an expression: probably this should apply for elements in other cases as well.
@@ -196,6 +203,7 @@ Unstructured control flow keywords as `return`, `break`, `continue`, `raise` mea
 This means that if there is code after the finishing of the branch, it would be ran if one hasn't hit the direct parent branch of those: so it is similar to an `else`. In those cases we should use the reverse nilabilities for the local to the condition expressions. E.g.
 
 .. code-block:: nim
+
   for a in c:
     if not a.isNil:
       b()
@@ -215,6 +223,7 @@ Assignments and other changes to nilability can move / move out expressions of s
 This means it stops being aliased with its previous aliases.
 
 .. code-block:: nim
+
   var left = b
   left = right # moving left to right
 
@@ -223,6 +232,7 @@ e.g.
 
 
 .. code-block:: nim
+
   var left = b
   left = nil # moving out
 

--- a/doc/nep1.rst
+++ b/doc/nep1.rst
@@ -50,6 +50,7 @@ Spacing and Whitespace Conventions
   long sections of code by hand can quickly become tedious.
 
   .. code-block:: nim
+
     # This is bad, as the next time someone comes
     # to edit this code block, they
     # must re-align all the assignments again:
@@ -70,6 +71,7 @@ Naming Conventions
   are not required to.
 
   .. code-block:: nim
+
     # Constants can start with either a lower case or upper case letter.
     const aConstant = 42
     const FooBar = 4.2
@@ -90,6 +92,7 @@ Naming Conventions
   same applies to C/C++ wrappers.
 
   .. code-block:: nim
+
     type
       Handle = object # Will be used most often
         fd: int64
@@ -98,6 +101,7 @@ Naming Conventions
 - Exception and Error types should have the "Error" or "Defect" suffix.
 
   .. code-block:: nim
+
     type
       ValueError = object of CatchableError
       AssertionDefect = object of Defect
@@ -107,6 +111,7 @@ Naming Conventions
   identifying prefix, such as an abbreviation of the enum's name.
 
   .. code-block:: nim
+
     type
       PathComponent = enum
         pcDir
@@ -118,6 +123,7 @@ Naming Conventions
   PascalCase.
 
   .. code-block:: nim
+
     type
       PathComponent {.pure.} = enum
         Dir
@@ -231,6 +237,7 @@ Coding Conventions
   This improves readability.
 
   .. code-block:: nim
+
     proc repeat(text: string, x: int): string =
       result = ""
 
@@ -253,6 +260,7 @@ Conventions for multi-line statements and expressions
   align with the parameters above it.
 
   .. code-block:: nim
+
     type
       LongTupleA = tuple[wordyTupleMemberOne: int, wordyTupleMemberTwo: string,
                          wordyTupleMemberThree: float]
@@ -261,6 +269,7 @@ Conventions for multi-line statements and expressions
   than one line should do the same thing.
 
   .. code-block:: nim
+
     type
       EventCallback = proc (timeReceived: Time, errorCode: int, event: Event,
                             output: var string)
@@ -273,6 +282,7 @@ Conventions for multi-line statements and expressions
   parenthesis (like multi-line procedure declarations).
 
   .. code-block:: nim
+
     startProcess(nimExecutable, currentDirectory, compilerArguments
                  environment, processOptions)
 
@@ -291,6 +301,7 @@ Miscellaneous
   use this:
 
   .. code-block:: nim
+
     let a = """
     foo
     bar
@@ -299,6 +310,7 @@ Miscellaneous
   instead of:
 
   .. code-block:: nim
+
     let a = """foo
     bar
     """

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -431,6 +431,7 @@ to your usual `nim c`:cmd: or `nim cpp`:cmd: command and set the `passC`:option:
 and `passL`:option: command line switches to something like:
 
 .. code-block:: cmd
+
   nim c ... --d:nimAllocPagesViaMalloc --mm:orc --passC="-I$DEVKITPRO/libnx/include" ...
   --passL="-specs=$DEVKITPRO/libnx/switch.specs -L$DEVKITPRO/libnx/lib -lnx"
 
@@ -761,17 +762,20 @@ a procedure call, because the callee returns a new string anyway.
 Thus it is efficient to do:
 
 .. code-block:: Nim
+
   var s = procA() # assignment will not copy the string; procA allocates a new
                   # string already
 
 However, it is not efficient to do:
 
 .. code-block:: Nim
+
   var s = varA    # assignment has to copy the whole string into a new buffer!
 
 For `let` symbols a copy is not always necessary:
 
 .. code-block:: Nim
+
   let s = varA    # may only copy a pointer if it safe to do so
 
 
@@ -779,6 +783,7 @@ If you know what you're doing, you can also mark single-string (or sequence)
 objects as `shallow`:idx:\:
 
 .. code-block:: Nim
+
   var s = "abc"
   shallow(s) # mark 's' as a shallow string
   var x = s  # now might not copy the string!
@@ -792,6 +797,7 @@ if several different string constants are used. So code like this is reasonably
 efficient:
 
 .. code-block:: Nim
+
   case normalize(k.key)
   of "name": c.name = v
   of "displayname": c.displayName = v

--- a/doc/nimgrep.rst
+++ b/doc/nimgrep.rst
@@ -23,6 +23,7 @@ Installation
 Compile nimgrep with the command:
 
 .. code:: cmd
+
   nim c -d:release tools/nimgrep.nim
 
 And copy the executable somewhere in your ``$PATH``.
@@ -41,6 +42,7 @@ All examples below use default PCRE Regex patterns:
 + To search recursively in Nim files using style-insensitive identifiers:
 
   .. code:: cmd
+
     nimgrep --recursive --ext:'nim|nims' --ignoreStyle
     # short: -r --ext:'nim|nims' -y
 
@@ -51,12 +53,14 @@ All examples below use default PCRE Regex patterns:
   from the search:
 
   .. code:: cmd
+
     nimgrep --excludeDir:'^\.git$' --excludeDir:'^\.hg$' --excludeDir:'^\.svn$'
     # short: --ed:'^\.git$' --ed:'^\.hg$' --ed:'^\.svn$'
 
 + To search only in paths containing the `tests` sub-directory recursively::
 
   .. code:: cmd
+
     nimgrep --recursive --includeDir:'(^|/)tests($|/)'
     # short: -r --id:'(^|/)tests($|/)'
 

--- a/doc/nims.rst
+++ b/doc/nims.rst
@@ -119,6 +119,7 @@ NimScript. Similarly, command-line `--FOO:VAL`:option: translates to
 Here are few examples of using the `switch` proc:
 
 .. code-block:: nim
+
   # command-line: --opt:size
   switch("opt", "size")
   # command-line: --define:release or -d:release
@@ -131,6 +132,7 @@ like command-line switches written as-is in the NimScript file. So the
 above example can be rewritten as:
 
 .. code-block:: nim
+
   --opt:size
   --define:release
   --forceBuild
@@ -149,6 +151,7 @@ file to be used as a build tool. The following example defines a
 task `build` that is an alias for the `c`:option: command:
 
 .. code-block:: nim
+
   task build, "builds an example":
     setCommand "c"
 

--- a/doc/nimsuggest.rst
+++ b/doc/nimsuggest.rst
@@ -30,6 +30,7 @@ Installation
 Nimsuggest is part of Nim's core. Build it via:
 
 .. code:: cmd
+
   koch nimsuggest
 
 

--- a/doc/pegdocs.txt
+++ b/doc/pegdocs.txt
@@ -176,6 +176,7 @@ expression, identifiers are not interpreted as non-terminals, but are
 interpreted as verbatim string:
 
 .. code-block:: nim
+
   abc =~ peg"abc" # is true
 
 So it is not necessary to write ``peg" 'abc' "`` in the above example.
@@ -187,16 +188,19 @@ Examples
 Check if `s` matches Nim's "while" keyword:
 
 .. code-block:: nim
+
   s =~ peg" y'while'"
 
 Exchange (key, val)-pairs:
 
 .. code-block:: nim
+
   "key: val; key2: val2".replacef(peg"{\ident} \s* ':' \s* {\ident}", "$2: $1")
 
 Determine the ``#include``'ed files of a C file:
 
 .. code-block:: nim
+
   for line in lines("myfile.c"):
     if line =~ peg"""s <- ws '#include' ws '"' {[^"]+} '"' ws
                      comment <- '/*' @ '*/' / '//' .*

--- a/doc/refc.rst
+++ b/doc/refc.rst
@@ -17,6 +17,7 @@ file as well).
 With this switch the garbage collector supports the following operations:
 
 .. code-block:: nim
+
   proc GC_setMaxPause*(maxPauseInUs: int)
   proc GC_step*(us: int, strongAdvice = false, stackSize = -1)
 

--- a/doc/sets_fragment.txt
+++ b/doc/sets_fragment.txt
@@ -25,6 +25,7 @@ empty set is type compatible with any concrete set type. The constructor
 can also be used to include elements (and ranges of elements):
 
 .. code-block:: nim
+
   type
     CharSet = set[char]
   var

--- a/doc/spawn.txt
+++ b/doc/spawn.txt
@@ -29,6 +29,7 @@ the passed expression on the thread pool and returns a `data flow variable`:idx:
 variables at the same time:
 
 .. code-block:: nim
+
   import std/threadpool, ...
 
   # wait until 2 out of 3 servers received the update:
@@ -55,6 +56,7 @@ Parallel statement
 Example:
 
 .. code-block:: nim
+
   # Compute PI in an inefficient way
   import std/[strutils, math, threadpool]
 

--- a/doc/tut1.rst
+++ b/doc/tut1.rst
@@ -42,6 +42,7 @@ We start the tour with a modified "hello world" program:
 
 .. code-block:: Nim
     :test: "nim c $1"
+
   # This is a comment
   echo "What's your name? "
   var name: string = readLine(stdin)
@@ -91,6 +92,7 @@ inference`:idx:). So this will work too:
 
 .. code-block:: Nim
     :test: "nim c $1"
+
   var name = readLine(stdin)
 
 Note that this is basically the only form of type inference that exists in
@@ -118,6 +120,7 @@ quotes. Special characters are escaped with ``\``: ``\n`` means newline, ``\t``
 means tabulator, etc. There are also *raw* string literals:
 
 .. code-block:: Nim
+
   r"C:\program files\nim"
 
 In raw literals, the backslash is not an escape character.
@@ -136,6 +139,7 @@ hash character `#`. Documentation comments start with `##`:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   # A comment.
 
   var myVariable: int ## a documentation comment
@@ -150,6 +154,7 @@ comments can also be nested.
 
 .. code-block:: nim
     :test: "nim c $1"
+
   #[
   You can have any Nim code text commented
   out inside this with no indentation restrictions.
@@ -176,6 +181,7 @@ The var statement
 The var statement declares a new local or global variable:
 
 .. code-block::
+
   var x, y: int # declares x and y to have the type `int`
 
 Indentation can be used after the `var` keyword to list a whole section of
@@ -183,6 +189,7 @@ variables:
 
 .. code-block::
     :test: "nim c $1"
+
   var
     x, y: int
     # a comment can occur here too
@@ -198,6 +205,7 @@ constant declaration at compile time:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   const x = "abc" # the constant x contains the string "abc"
 
 Indentation can be used after the `const` keyword to list a whole section of
@@ -205,6 +213,7 @@ constants:
 
 .. code-block::
     :test: "nim c $1"
+
   const
     x = 1
     # a comment can occur here too
@@ -219,6 +228,7 @@ symbols are *single assignment* variables: After the initialization their
 value cannot change:
 
 .. code-block::
+
   let x = "abc" # introduces a new variable `x` and binds a value to it
   x = "xyz"     # Illegal: assignment to `x`
 
@@ -227,10 +237,12 @@ that can not be re-assigned, `const` means "enforce compile time evaluation
 and put it into a data section":
 
 .. code-block::
+
   const input = readLine(stdin) # Error: constant expression expected
 
 .. code-block::
     :test: "nim c $1"
+
   let input = readLine(stdin)   # works
 
 
@@ -241,6 +253,7 @@ The assignment statement assigns a new value to a variable or more generally
 to a storage location:
 
 .. code-block::
+
   var x = "abc" # introduces a new variable `x` and assigns a value to it
   x = "xyz"     # assigns a new value to `x`
 
@@ -250,6 +263,7 @@ statement and all the variables will have the same value:
 
 .. code-block::
     :test: "nim c $1"
+
   var x, y = 3  # assigns 3 to the variables `x` and `y`
   echo "x ", x  # outputs "x 3"
   echo "y ", y  # outputs "y 3"
@@ -273,6 +287,7 @@ The if statement is one way to branch the control flow:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   let name = readLine(stdin)
   if name == "":
     echo "Poor soul, you lost your name?"
@@ -295,6 +310,7 @@ a multi-branch:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   let name = readLine(stdin)
   case name
   of "":
@@ -314,6 +330,7 @@ The case statement can deal with integers, other ordinal types, and strings.
 For integers or other ordinal types value ranges are also possible:
 
 .. code-block:: nim
+
   # this statement will be explained later:
   from std/strutils import parseInt
 
@@ -330,6 +347,7 @@ every value that `n` may contain, but the code only handles the values
 the compiler that for every other value nothing should be done:
 
 .. code-block:: nim
+
   ...
   case n
   of 0..2, 4..7: echo "The number is in the set: {0, 1, 2, 4, 5, 6, 7}"
@@ -374,6 +392,7 @@ provides. The example uses the built-in `countup
 
 .. code-block:: nim
     :test: "nim c $1"
+
   echo "Counting to ten: "
   for i in countup(1, 10):
     echo i
@@ -385,6 +404,7 @@ The variable `i` is implicitly declared by the
 1, 2, .., 10. Each value is `echo`-ed. This code does the same:
 
 .. code-block:: nim
+
   echo "Counting to 10: "
   var i = 1
   while i <= 10:
@@ -396,12 +416,14 @@ Since counting up occurs so often in programs, Nim also has a `..
 <system.html#...i,T,T>`_ iterator that does the same:
 
 .. code-block:: nim
+
   for i in 1 .. 10:
     ...
 
 Counting down can be achieved as easily (but is less often needed):
 
 .. code-block:: nim
+
   echo "Counting down from 10 to 1: "
   for i in countdown(10, 1):
     echo i
@@ -412,12 +434,14 @@ Zero-indexed counting has two shortcuts `..<` and `.. ^1`
 counting to one less than the higher index:
 
 .. code-block:: nim
+
   for i in 0 ..< 10:
     ...  # the same as 0 .. 9
 
 or
 
 .. code-block:: nim
+
   var s = "some string"
   for i in 0 ..< s.len:
     ...
@@ -425,6 +449,7 @@ or
 or
 
 .. code-block:: nim
+
   var s = "some string"
   for idx, c in s[0 .. ^1]:
     ... # ^1 is the last element, ^2 would be one before it, and so on
@@ -435,6 +460,7 @@ Other useful iterators for collections (like arrays and sequences) are
 
 .. code-block:: nim
     :test: "nim c $1"
+
   for index, item in ["a","b"].pairs:
     echo item, " at index ", index
   # => a at index 0
@@ -450,6 +476,7 @@ outside the loop:
 .. code-block:: nim
     :test: "nim c $1"
     :status: 1
+
   while false:
     var x = "hi"
   echo x # does not work
@@ -461,6 +488,7 @@ statement can be used to open a new block explicitly:
 .. code-block:: nim
     :test: "nim c $1"
     :status: 1
+
   block myblock:
     var x = "hi"
   echo x # does not work either
@@ -477,6 +505,7 @@ innermost construct, unless a label of a block is given:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   block myblock:
     echo "entering block"
     while true:
@@ -502,6 +531,7 @@ the next iteration immediately:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   for i in 1 .. 5:
     if i <= 3: continue
     echo i # will only print 4 and 5
@@ -551,6 +581,7 @@ contain other statements. To avoid ambiguities, complex statements must always
 be indented, but single simple statements do not:
 
 .. code-block:: nim
+
   # no indentation needed for single-assignment statement:
   if x: x = false
 
@@ -586,6 +617,7 @@ an expression is allowed:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   # computes fac(4) at compile time:
   const fac4 = (var x = 1; for i in 1..4: x *= i; x)
 
@@ -602,6 +634,7 @@ Nim, new procedures are defined with the `proc` keyword:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc yes(question: string): bool =
     echo question, " (y/n)"
     while true:
@@ -640,6 +673,7 @@ the exit.
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc sumTillNegative(x: varargs[int]): int =
     for i in x:
       if i < 0:
@@ -663,6 +697,7 @@ this procedure
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc helloWorld(): string =
     "Hello, World!"
 
@@ -679,6 +714,7 @@ is possible, and actually an idiom:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc printSeq(s: seq, nprinted: int = -1) =
     var nprinted = if nprinted == -1: s.len else: min(nprinted, s.len)
     for i in 0 ..< nprinted:
@@ -689,6 +725,7 @@ caller, a `var` parameter can be used:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc divmod(a, b: int; res, remainder: var int) =
     res = a div b        # integer division
     remainder = a mod b  # integer modulo operation
@@ -713,6 +750,7 @@ its return value, a `discard` statement **must** be used. Nim does not
 allow silently throwing away a return value:
 
 .. code-block:: nim
+
   discard yes("May I ask a pointless question?")
 
 
@@ -721,6 +759,7 @@ been declared with the `discardable` pragma:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc p(x, y: int): int {.discardable.} =
     return x + y
 
@@ -736,6 +775,7 @@ complex data type. Therefore the arguments to a procedure can be named, so
 that it is clear which argument belongs to which parameter:
 
 .. code-block:: nim
+
   proc createWindow(x, y, width, height: int; title: string;
                     show: bool): Window =
      ...
@@ -748,6 +788,7 @@ does not matter anymore. Mixing named arguments with ordered arguments is
 also possible, but not very readable:
 
 .. code-block:: nim
+
   var w = createWindow(0, 0, title = "My Application",
                        height = 600, width = 800, true)
 
@@ -762,6 +803,7 @@ values`; these are values that are used as arguments if the caller does not
 specify them:
 
 .. code-block:: nim
+
   proc createWindow(x = 0, y = 0, width = 500, height = 700,
                     title = "unknown",
                     show = true): Window =
@@ -782,6 +824,7 @@ Overloaded procedures
 Nim provides the ability to overload procedures similar to C++:
 
 .. code-block:: nim
+
   proc toString(x: int): string =
     result =
       if x < 0: "negative"
@@ -826,6 +869,7 @@ can be `found in the manual <manual.html#syntax-precedence>`_.
 To define a new operator enclose the operator in backticks "`":
 
 .. code-block:: nim
+
   proc `$` (x: myDataType): string = ...
   # now the $ operator also works with myDataType, overloading resolution
   # ensures that $ works for built-in types just like before
@@ -835,6 +879,7 @@ procedure:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   if `==`( `+`(3, 4), 7): echo "true"
 
 
@@ -847,10 +892,12 @@ language that supports metaprogramming as extensively as Nim does.)
 However, this cannot be done for mutually recursive procedures:
 
 .. code-block:: nim
+
   # forward declaration:
   proc even(n: int): bool
 
 .. code-block:: nim
+
   proc odd(n: int): bool =
     assert(n >= 0) # makes sure we don't run into negative recursion
     if n == 0: false
@@ -908,6 +955,7 @@ Let's return to the simple counting example:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   echo "Counting to ten: "
   for i in countup(1, 10):
     echo i
@@ -916,6 +964,7 @@ Can a `countup <system.html#countup.i,T,T,Positive>`_ proc be written that
 supports this loop? Let's try:
 
 .. code-block:: nim
+
   proc countup(a, b: int): int =
     var res = a
     while res <= b:
@@ -930,6 +979,7 @@ and here it is -- our first iterator:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   iterator countup(a, b: int): int =
     var res = a
     while res <= b:
@@ -1031,6 +1081,7 @@ to specify a non-default integer type:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   let
     x = 0     # x is of type `int`
     y = 0'i8  # y is of type `int8`
@@ -1069,6 +1120,7 @@ type:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   var
     x = 0.0      # x is of type `float`
     y = 0.0'f32  # y is of type `float32`
@@ -1091,6 +1143,7 @@ type as a function:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   var
     x: int32 = 1.int32   # same as calling int32(1)
     y: int8  = int8('a') # 'a' == 97'i8
@@ -1113,6 +1166,7 @@ there is a difference between the `$` and `repr` outputs:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   var
     myBool = true
     myCharacter = 'n'
@@ -1138,6 +1192,7 @@ In Nim new types can be defined within a `type` statement:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     biggestInt = int64      # biggest integer type that is available
     biggestFloat = float64  # biggest float type that is available
@@ -1215,6 +1270,7 @@ A subrange type is a range of values from an integer or enumeration type
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     MySubrange = range[0..5]
 
@@ -1271,6 +1327,7 @@ valid index.
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     Direction = enum
       north, east, south, west
@@ -1296,6 +1353,7 @@ yet another enum, we can add the following lines to add a light tower type
 subdivided into height levels accessed through their integer index:
 
 .. code-block:: nim
+
   type
     LightTower = array[1..10, LevelSetting]
   var
@@ -1315,6 +1373,7 @@ nested nature would be to omit the previous definition of the `LevelSetting`
 type and instead write it embedded directly as the type of the first dimension:
 
 .. code-block:: nim
+
   type
     LightTower = array[1..10, array[north..west, BlinkLights]]
 
@@ -1323,6 +1382,7 @@ to specify a range from zero to the specified index minus one:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     IntArray = array[0..5, int] # an array that is indexed with 0..5
     QuickArray = array[6, int]  # an array that is indexed with 0..5
@@ -1376,6 +1436,7 @@ value. Here the `for` statement is looping over the results from the
 
 .. code-block:: nim
     :test: "nim c $1"
+
   for value in @[3, 4, 5]:
     echo value
   # --> 3
@@ -1404,6 +1465,7 @@ openarray parameter, the index type does not matter.
 
 .. code-block:: nim
     :test: "nim c $1"
+
   var
     fruits:   seq[string]       # reference to a sequence of strings that is initialized with '@[]'
     capitals: array[3, string]  # array of strings with a fixed size
@@ -1432,6 +1494,7 @@ to an array automatically:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc myWriteln(f: File, a: varargs[string]) =
     for s in items(a):
       write(f, s)
@@ -1447,6 +1510,7 @@ type conversions in this context:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc myWriteln(f: File, a: varargs[string, `$`]) =
     for s in items(a):
       write(f, s)
@@ -1529,6 +1593,7 @@ where all of its fields can be initialized. Unspecified fields will
 get their default value.
 
 .. code-block:: nim
+
   type
     Person = object
       name: string
@@ -1590,6 +1655,7 @@ integer.
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     # type representing a person:
     # A person consists of a name and an age.
@@ -1674,6 +1740,7 @@ Tuple unpacking is also supported in for-loops:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   let a = [(10, 'a'), (20, 'b'), (30, 'c')]
 
   for (x, c) in a:
@@ -1749,6 +1816,7 @@ Example:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc greet(name: string): string =
     "Hello, " & name & "!"
 
@@ -1786,6 +1854,7 @@ module by using the `import`:idx: statement. Only top-level symbols that are mar
 with an asterisk (`*`) are exported:
 
 .. code-block:: nim
+
   # Module A
   var
     x*, y: int
@@ -1815,14 +1884,17 @@ if it is defined in two (or more) different modules and both modules are
 imported by a third one:
 
 .. code-block:: nim
+
   # Module A
   var x*: string
 
 .. code-block:: nim
+
   # Module B
   var x*: int
 
 .. code-block:: nim
+
   # Module C
   import A, B
   write(stdout, x) # error: x is ambiguous
@@ -1836,14 +1908,17 @@ But this rule does not apply to procedures or iterators. Here the overloading
 rules apply:
 
 .. code-block:: nim
+
   # Module A
   proc x*(a: int): string = $a
 
 .. code-block:: nim
+
   # Module B
   proc x*(a: string): string = $a
 
 .. code-block:: nim
+
   # Module C
   import A, B
   write(stdout, x(3))   # no error: A.x is called
@@ -1861,6 +1936,7 @@ These can be limited by naming symbols that should be excluded using
 the `except` qualifier.
 
 .. code-block:: nim
+
   import mymodule except y
 
 
@@ -1872,6 +1948,7 @@ exported symbols. An alternative that only imports listed symbols is the
 `from import` statement:
 
 .. code-block:: nim
+
   from mymodule import x, y, z
 
 The `from` statement can also force namespace qualification on
@@ -1879,11 +1956,13 @@ symbols, thereby making symbols available, but needing to be qualified
 in order to be used.
 
 .. code-block:: nim
+
   from mymodule import x, y, z
 
   x()           # use x without any qualification
 
 .. code-block:: nim
+
   from mymodule import nil
 
   mymodule.x()  # must qualify x with the module name as prefix
@@ -1894,6 +1973,7 @@ Since module names are generally long to be descriptive, you can also
 define a shorter alias to use when qualifying symbols.
 
 .. code-block:: nim
+
   from mymodule as m import nil
 
   m.x()         # m is aliasing mymodule
@@ -1907,6 +1987,7 @@ importing a module: it merely includes the contents of a file. The `include`
 statement is useful to split up a large module into several files:
 
 .. code-block:: nim
+
   include fileA, fileB, fileC
 
 

--- a/doc/tut2.rst
+++ b/doc/tut2.rst
@@ -55,6 +55,7 @@ type, the `of` operator can be used.
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     Person = ref object of RootObj
       name*: string  # the * means that `name` is accessible from other modules
@@ -99,6 +100,7 @@ Example:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     Node = ref object  # a reference to an object with the following field:
       le, ri: Node     # left and right subtrees
@@ -125,6 +127,7 @@ The syntax for type conversions is `destination_type(expression_to_convert)`
 (like an ordinary call):
 
 .. code-block:: nim
+
   proc getID(x: Person): int =
     Student(x).id
 
@@ -185,6 +188,7 @@ for any type:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   import std/strutils
 
   echo "abc".len # is the same as echo len("abc")
@@ -199,6 +203,7 @@ So "pure object oriented" code is easy to write:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   import std/[strutils, sequtils]
 
   stdout.writeLine("Give a list of numbers (separated by spaces): ")
@@ -240,6 +245,7 @@ The `[]` array access operator can be overloaded to provide
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     Vector* = object
       x, y, z: float
@@ -272,6 +278,7 @@ Procedures always use static dispatch. For dynamic dispatch replace the
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     Expression = ref object of RootObj ## abstract base class for an expression
     Literal = ref object of Expression
@@ -357,6 +364,7 @@ Raising an exception is done with the `raise` statement:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   var
     e: ref OSError
   new(e)
@@ -368,6 +376,7 @@ is *re-raised*. For the purpose of avoiding repeating this common code pattern,
 the template `newException` in the `system` module can be used:
 
 .. code-block:: nim
+
   raise newException(OSError, "the request to the OS failed")
 
 
@@ -378,6 +387,7 @@ The `try` statement handles exceptions:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   from std/strutils import parseInt
 
   # read the first two lines of a text file that should contain numbers
@@ -424,6 +434,7 @@ If you need to *access* the actual exception object or message inside an
 module. Example:
 
 .. code-block:: nim
+
   try:
     doSomethingHere()
   except:
@@ -444,6 +455,7 @@ instance, if you specify that a proc raises `IOError`, and at some point it
 prevent that proc from compiling. Usage example:
 
 .. code-block:: nim
+
   proc complexProc() {.raises: [IOError, ArithmeticDefect].} =
     ...
 
@@ -476,6 +488,7 @@ containers:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   type
     BinaryTree*[T] = ref object # BinaryTree is a generic type with
                                 # generic param `T`
@@ -541,6 +554,7 @@ There is a special `[:T]` syntax when using generics with the method call syntax
 
 .. code-block:: nim
     :test: "nim c $1"
+
   proc foo[T](i: T) =
     discard
 
@@ -564,6 +578,7 @@ To *invoke* a template, call it like a procedure.
 Example:
 
 .. code-block:: nim
+
   template `!=` (a, b: untyped): untyped =
     # this definition exists in the System module
     not (a == b)
@@ -584,6 +599,7 @@ simple proc for logging:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   const
     debug = true
 
@@ -602,6 +618,7 @@ Turning the `log` proc into a template solves this problem:
 
 .. code-block:: nim
     :test: "nim c $1"
+
   const
     debug = true
 
@@ -652,6 +669,7 @@ Example: Lifting Procs
 
 .. code-block:: nim
     :test: "nim c $1"
+
   import std/math
 
   template liftScalarProc(fname) =
@@ -661,6 +679,7 @@ Example: Lifting Procs
     ## parameter of seq[T] or nested seq[seq[]] or the same type
     ##
     ## .. code-block:: Nim
+    ##
     ##  liftScalarProc(abs)
     ##  # now abs(@[@[1,-2], @[-2,-3]]) == @[@[1,2], @[2,3]]
     proc fname[T](x: openarray[T]): auto =

--- a/doc/tut3.rst
+++ b/doc/tut3.rst
@@ -189,6 +189,7 @@ generated expression.
 
 .. code-block:: nim
     :test: "nim c $1"
+
     import std/macros
     macro a(i) = quote do:
       let `i` = 0
@@ -200,6 +201,7 @@ A custom prefix operator can be defined whenever backticks are needed.
 
 .. code-block:: nim
     :test: "nim c $1"
+
     import std/macros
     macro a(i) = quote("@") do:
       assert @i == 0
@@ -211,6 +213,7 @@ The injected symbol needs accent quoted when it resolves to a symbol.
 
 .. code-block:: nim
     :test: "nim c $1"
+
     import std/macros
     macro a(i) = quote("@") do:
       let `@i` = 0
@@ -250,6 +253,7 @@ them into the tree.
 The call to `myMacro` will generate the following code:
 
 .. code-block:: nim
+
   echo "Hallo"
   echo MyType(a: 123.456'f64, b: "abcdef")
 
@@ -320,6 +324,7 @@ the last line of the macro. It is also the statement that has been
 used to get this output.
 
 .. code-block:: nim
+
   if not (a != b):
     raise newException(AssertionDefect, $a & " != " & $b)
 

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1005,12 +1005,14 @@ macro dumpTree*(s: untyped): untyped = echo s.treeRepr
   ## For example:
   ##
   ## .. code-block:: nim
+  ##
   ##    dumpTree:
   ##      echo "Hello, World!"
   ##
   ## Outputs:
   ##
   ## .. code-block::
+  ##
   ##    StmtList
   ##      Command
   ##        Ident "echo"
@@ -1029,12 +1031,14 @@ macro dumpLisp*(s: untyped): untyped = echo s.lispRepr(indented = true)
   ## For example:
   ##
   ## .. code-block:: nim
+  ##
   ##    dumpLisp:
   ##      echo "Hello, World!"
   ##
   ## Outputs:
   ##
   ## .. code-block::
+  ##
   ##    (StmtList
   ##     (Command
   ##      (Ident "echo")
@@ -1052,12 +1056,14 @@ macro dumpAstGen*(s: untyped): untyped = echo s.astGenRepr
   ## For example:
   ##
   ## .. code-block:: nim
+  ##
   ##    dumpAstGen:
   ##      echo "Hello, World!"
   ##
   ## Outputs:
   ##
   ## .. code-block:: nim
+  ##
   ##    nnkStmtList.newTree(
   ##      nnkCommand.newTree(
   ##        newIdentNode("echo"),
@@ -1383,6 +1389,7 @@ template findChild*(n: NimNode; cond: untyped): NimNode {.dirty.} =
   ## Find the first child node matching condition (or nil).
   ##
   ## .. code-block:: nim
+  ##
   ##   var res = findChild(n, it.kind == nnkPostfix and
   ##                          it.basename.ident == ident"foo")
   block:
@@ -1490,6 +1497,7 @@ macro expandMacros*(body: typed): untyped =
   ## For instance,
   ##
   ## .. code-block:: nim
+  ##
   ##   import std/[sugar, macros]
   ##
   ##   let
@@ -1607,6 +1615,7 @@ macro hasCustomPragma*(n: typed, cp: typed{nkSym}): untyped =
   ## See also `getCustomPragmaVal`_.
   ##
   ## .. code-block:: nim
+  ##
   ##   template myAttr() {.pragma.}
   ##   type
   ##     MyObj = object
@@ -1631,6 +1640,7 @@ macro getCustomPragmaVal*(n: typed, cp: typed{nkSym}): untyped =
   ## See also `hasCustomPragma`_.
   ##
   ## .. code-block:: nim
+  ##
   ##   template serializationKey(key: string) {.pragma.}
   ##   type
   ##     MyObj {.serializationKey: "mo".} = object
@@ -1726,6 +1736,7 @@ proc extractDocCommentsAndRunnables*(n: NimNode): NimNode =
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##  import std/macros
   ##  macro transf(a): untyped =
   ##    result = quote do:

--- a/lib/deprecated/pure/events.nim
+++ b/lib/deprecated/pure/events.nim
@@ -17,6 +17,7 @@
 ## events: one is a python-inspired way; the other is more of a C-style way.
 ##
 ## .. code-block:: Nim
+##
 ##    var ee = initEventEmitter()
 ##    var genericargs: EventArgs
 ##    proc handleevent(e: EventArgs) =

--- a/lib/deprecated/pure/parseopt2.nim
+++ b/lib/deprecated/pure/parseopt2.nim
@@ -116,6 +116,7 @@ iterator getopt*(p: var OptParser): GetoptResult =
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   var p = initOptParser("--left --debug:3 -l=4 -r:2")
   ##   for kind, key, val in p.getopt():
   ##     case kind
@@ -142,6 +143,7 @@ when declared(paramCount):
     ## See above for a more detailed example
     ##
     ## .. code-block:: nim
+    ##
     ##   for kind, key, val in getopt():
     ##     # this will iterate over all arguments passed to the cmdline.
     ##     continue

--- a/lib/impure/db_mysql.nim
+++ b/lib/impure/db_mysql.nim
@@ -21,6 +21,7 @@
 ## value should be placed. For example:
 ##
 ## .. code-block:: Nim
+##
 ##     sql"INSERT INTO myTable (colA, colB, colC) VALUES (?, ?, ?)"
 ##
 ##
@@ -31,6 +32,7 @@
 ## ----------------------------------
 ##
 ## .. code-block:: Nim
+##
 ##     import std/db_mysql
 ##     let db = open("localhost", "user", "password", "dbname")
 ##     db.close()
@@ -39,6 +41,7 @@
 ## ----------------
 ##
 ## .. code-block:: Nim
+##
 ##      db.exec(sql"DROP TABLE IF EXISTS myTable")
 ##      db.exec(sql("""CREATE TABLE myTable (
 ##                       id integer,
@@ -48,6 +51,7 @@
 ## --------------
 ##
 ## .. code-block:: Nim
+##
 ##     db.exec(sql"INSERT INTO myTable (id, name) VALUES (0, ?)",
 ##             "Dominik")
 ##

--- a/lib/impure/db_odbc.nim
+++ b/lib/impure/db_odbc.nim
@@ -27,6 +27,7 @@
 ## value should be placed. For example:
 ##
 ## .. code-block:: Nim
+##
 ##     sql"INSERT INTO myTable (colA, colB, colC) VALUES (?, ?, ?)"
 ##
 ##
@@ -37,6 +38,7 @@
 ## ----------------------------------
 ##
 ## .. code-block:: Nim
+##
 ##     import std/db_odbc
 ##     var db = open("localhost", "user", "password", "dbname")
 ##     db.close()
@@ -45,6 +47,7 @@
 ## ----------------
 ##
 ## .. code-block:: Nim
+##
 ##      db.exec(sql"DROP TABLE IF EXISTS myTable")
 ##      db.exec(sql("""CREATE TABLE myTable (
 ##                       id integer,
@@ -54,6 +57,7 @@
 ## --------------
 ##
 ## .. code-block:: Nim
+##
 ##     db.exec(sql"INSERT INTO myTable (id, name) VALUES (0, ?)",
 ##             "Andreas")
 ##

--- a/lib/impure/db_postgres.nim
+++ b/lib/impure/db_postgres.nim
@@ -21,6 +21,7 @@
 ## value should be placed. For example:
 ##
 ## .. code-block:: Nim
+##
 ##     sql"INSERT INTO myTable (colA, colB, colC) VALUES (?, ?, ?)"
 ##
 ## **Note**: There are two approaches to parameter substitution support by
@@ -31,6 +32,7 @@
 ## 2. `SqlPrepared` using `$1, $2, $3, ...`
 ##
 ## .. code-block:: Nim
+##
 ##   prepare(db, "myExampleInsert",
 ##           sql"""INSERT INTO myTable
 ##                 (colA, colB, colC)
@@ -47,6 +49,7 @@
 ## To use Unix sockets with `db_postgres`, change the server address to the socket file path:
 ##
 ## .. code-block:: Nim
+##
 ##   import std/db_postgres ## Change "localhost" or "127.0.0.1" to the socket file path
 ##   let db = db_postgres.open("/run/postgresql", "user", "password", "database")
 ##   echo db.getAllRows(sql"SELECT version();")
@@ -64,6 +67,7 @@
 ## ----------------------------------
 ##
 ## .. code-block:: Nim
+##
 ##     import std/db_postgres
 ##     let db = open("localhost", "user", "password", "dbname")
 ##     db.close()
@@ -72,6 +76,7 @@
 ## ----------------
 ##
 ## .. code-block:: Nim
+##
 ##      db.exec(sql"DROP TABLE IF EXISTS myTable")
 ##      db.exec(sql("""CREATE TABLE myTable (
 ##                       id integer,
@@ -81,6 +86,7 @@
 ## --------------
 ##
 ## .. code-block:: Nim
+##
 ##     db.exec(sql"INSERT INTO myTable (id, name) VALUES (0, ?)",
 ##             "Dominik")
 import strutils, postgres

--- a/lib/js/asyncjs.nim
+++ b/lib/js/asyncjs.nim
@@ -18,12 +18,14 @@
 ## This is roughly equivalent to the `async` keyword in JavaScript code.
 ##
 ## .. code-block:: nim
+##
 ##  proc loadGame(name: string): Future[Game] {.async.} =
 ##    # code
 ##
 ## should be equivalent to
 ##
 ## .. code-block:: javascript
+##
 ##   async function loadGame(name) {
 ##     // code
 ##   }
@@ -32,12 +34,14 @@
 ## the completion of the `Future`.
 ##
 ## .. code-block:: nim
+##
 ##   var game = await loadGame(name)
 ##
 ## Often, you might work with callback-based API-s. You can wrap them with
 ## asynchronous procedures using promises and `newPromise`:
 ##
 ## .. code-block:: nim
+##
 ##   proc loadGame(name: string): Future[Game] =
 ##     var promise = newPromise() do (resolve: proc(response: Game)):
 ##       cbBasedLoadGame(name) do (game: Game):
@@ -47,6 +51,7 @@
 ## Forward definitions work properly, you just need to always add the `{.async.}` pragma:
 ##
 ## .. code-block:: nim
+##
 ##   proc loadGame(name: string): Future[Game] {.async.}
 ##
 ## JavaScript compatibility

--- a/lib/js/dom.nim
+++ b/lib/js/dom.nim
@@ -1336,6 +1336,7 @@ since (1, 3):
       ## * https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
       ##
       ## .. code-block:: nim
+      ##
       ##   let prsr = newDomParser()
       ##   discard prsr.parseFromString("<html><marquee>Hello World</marquee></html>".cstring, "text/html".cstring)
 

--- a/lib/js/jsffi.nim
+++ b/lib/js/jsffi.nim
@@ -473,6 +473,7 @@ macro bindMethod*(procedure: typed): auto =
   ## We want to generate roughly this JavaScript:
   ##
   ## .. code-block:: js
+  ##
   ##  var obj = {a: 10};
   ##  obj.someMethod = function() {
   ##    return this.a + 42;
@@ -481,6 +482,7 @@ macro bindMethod*(procedure: typed): auto =
   ## We can achieve this using the `bindMethod` macro:
   ##
   ## .. code-block:: nim
+  ##
   ##  let obj = JsObject{ a: 10 }
   ##  proc someMethodImpl(that: JsObject): int =
   ##    that.a.to(int) + 42

--- a/lib/packages/docutils/highlite.nim
+++ b/lib/packages/docutils/highlite.nim
@@ -14,6 +14,7 @@
 ## You can use this to build your own syntax highlighting, check this example:
 ##
 ## .. code:: Nim
+##
 ##   let code = """for x in $int.high: echo x.ord mod 2 == 0"""
 ##   var toknizr: GeneralTokenizer
 ##   initGeneralTokenizer(toknizr, code)
@@ -35,6 +36,7 @@
 ## The proc `getSourceLanguage` can get the language `enum` from a string:
 ##
 ## .. code:: Nim
+##
 ##   for l in ["C", "c++", "jAvA", "Nim", "c#"]: echo getSourceLanguage(l)
 ##
 ## There is also a `Cmd` pseudo-language supported, which is a simple generic
@@ -43,6 +45,7 @@
 ## at the beginning of line. It supports these operators:
 ##
 ## .. code:: Cmd
+##
 ##    &  &&  |  ||  (  )  ''  ""  ;  # for comments
 ##
 ## Instead of escaping always use quotes like here

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -3008,7 +3008,7 @@ proc parseBlockContent(p: var RstParser, father: var PRstNode,
   ## footnotes, etc). Returns true if succeeded.
   if indFollows(p) and requireBlankLine and
       tkIndent notin {nextTok(p).kind, prevTok(p).kind}:
-    rstMessage(p, meGeneralParseError,
+    rstMessage(p, mwRstStyle,
                "no blank line after directive arguments")
   if currentTok(p).kind != tkIndent or indFollows(p):
     let blockIndent = getWrappableIndent(p)

--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1610,6 +1610,7 @@ proc rstToHtml*(s: string, options: RstParseOptions,
   ## ``initRstGenerator`` proc. Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   import packages/docutils/rstgen, strtabs
   ##
   ##   echo rstToHtml("*Hello* **world**!", {},

--- a/lib/posix/inotify.nim
+++ b/lib/posix/inotify.nim
@@ -77,6 +77,7 @@ iterator inotify_events*(evs: pointer, n: int): ptr InotifyEvent =
   ## Abstract the packed buffer interface to yield event object pointers.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var evs = newSeq[byte](8192)        # Already did inotify_init+add_watch
   ##   while (let n = read(fd, evs[0].addr, 8192); n) > 0:     # read forever
   ##     for e in inotify_events(evs[0].addr, n): echo e[].len # echo name lens

--- a/lib/posix/posix.nim
+++ b/lib/posix/posix.nim
@@ -1095,6 +1095,7 @@ template onSignal*(signals: varargs[cint], body: untyped) =
   ## Example:
   ##
   ## .. code-block::
+  ##
   ##   from std/posix import SIGINT, SIGTERM, onSignal
   ##   onSignal(SIGINT, SIGTERM):
   ##     echo "bye from signal ", sig

--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -43,6 +43,7 @@
 ## Code to read some data from a socket may look something like this:
 ##
 ## .. code-block:: Nim
+##
 ##    var future = socket.recv(100)
 ##    future.addCallback(
 ##      proc () =
@@ -110,6 +111,7 @@
 ##
 ##
 ## .. code-block:: Nim
+##
 ##   try:
 ##     let data = await sock.recv(100)
 ##     echo("Received ", data)
@@ -122,6 +124,7 @@
 ## then check the future's `failed` property. For example:
 ##
 ## .. code-block:: Nim
+##
 ##   var future = sock.recv(100)
 ##   yield future
 ##   if future.failed:

--- a/lib/pure/asyncfile.nim
+++ b/lib/pure/asyncfile.nim
@@ -10,6 +10,7 @@
 ## This module implements asynchronous file reading and writing.
 ##
 ## .. code-block:: Nim
+##
 ##    import std/[asyncfile, asyncdispatch, os]
 ##
 ##    proc main() {.async.} =

--- a/lib/pure/asyncftpclient.nim
+++ b/lib/pure/asyncftpclient.nim
@@ -22,6 +22,7 @@
 ## connect to an FTP server. You can do so with the `connect` procedure.
 ##
 ## .. code-block:: Nim
+##
 ##    import std/[asyncdispatch, asyncftpclient]
 ##    proc main() {.async.} =
 ##      var ftp = newAsyncFtpClient("example.com", user = "test", pass = "test")
@@ -42,6 +43,7 @@
 ## instead specify an absolute path.
 ##
 ## .. code-block:: Nim
+##
 ##    import std/[asyncdispatch, asyncftpclient]
 ##    proc main() {.async.} =
 ##      var ftp = newAsyncFtpClient("example.com", user = "test", pass = "test")
@@ -63,6 +65,7 @@
 ## `progressInterval` milliseconds.
 ##
 ## .. code-block:: Nim
+##
 ##    import std/[asyncdispatch, asyncftpclient]
 ##
 ##    proc onProgressChanged(total, progress: BiggestInt,

--- a/lib/pure/asynchttpserver.nim
+++ b/lib/pure/asynchttpserver.nim
@@ -109,6 +109,7 @@ proc respond*(req: Request, code: HttpCode, content: string,
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##    import std/json
   ##    proc handler(req: Request) {.async.} =
   ##      if req.url.path == "/hello-world":

--- a/lib/pure/browsers.nim
+++ b/lib/pure/browsers.nim
@@ -68,6 +68,7 @@ proc openDefaultBrowser*(url: string) =
   ## This proc doesn't raise an exception on error, beware.
   ##
   ## .. code-block:: nim
+  ##
   ##   block: openDefaultBrowser("https://nim-lang.org")
   doAssert url.len > 0, "URL must not be empty string"
   openDefaultBrowserImpl(url)
@@ -88,5 +89,6 @@ proc openDefaultBrowser*() {.since: (1, 1).} =
   ## * https://tools.ietf.org/html/rfc6694#section-3
   ##
   ## .. code-block:: nim
+  ##
   ##   block: openDefaultBrowser()
   openDefaultBrowserImpl("http:about:blank")  # See IETF RFC-6694 Section 3.

--- a/lib/pure/cgi.nim
+++ b/lib/pure/cgi.nim
@@ -251,6 +251,7 @@ proc setTestData*(keysvalues: varargs[string]) =
   ## provide embedded (name, value)-pairs. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##    setTestData("name", "Hanz", "password", "12345")
   putEnv("REQUEST_METHOD", "GET")
   var i = 0
@@ -268,6 +269,7 @@ proc writeContentType*() =
   ## implements this part of the CGI protocol:
   ##
   ## .. code-block:: Nim
+  ##
   ##     write(stdout, "Content-type: text/html\n\n")
   write(stdout, "Content-type: text/html\n\n")
 

--- a/lib/pure/collections/sets.nim
+++ b/lib/pure/collections/sets.nim
@@ -26,6 +26,7 @@
 ##   `symmetric difference <#symmetricDifference,HashSet[A],HashSet[A]>`_
 ##
 ## .. code-block::
+##
 ##   echo toHashSet([9, 5, 1])     # {9, 1, 5}
 ##   echo toOrderedSet([9, 5, 1])  # {9, 5, 1}
 ##
@@ -247,6 +248,7 @@ iterator items*[A](s: HashSet[A]): A =
   ## template <sequtils.html#toSeq.t,untyped>`_.
   ##
   ## .. code-block::
+  ##
   ##   type
   ##     pair = tuple[a, b: int]
   ##   var
@@ -585,6 +587,7 @@ proc `$`*[A](s: HashSet[A]): string =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   echo toHashSet([2, 4, 5])
   ##   # --> {2, 4, 5}
   ##   echo toHashSet(["no", "esc'aping", "is \" provided"])
@@ -873,6 +876,7 @@ proc `$`*[A](s: OrderedSet[A]): string =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   echo toOrderedSet([2, 4, 5])
   ##   # --> {2, 4, 5}
   ##   echo toOrderedSet(["no", "esc'aping", "is \" provided"])
@@ -888,6 +892,7 @@ iterator items*[A](s: OrderedSet[A]): A =
   ## template <sequtils.html#toSeq.t,untyped>`_.
   ##
   ## .. code-block::
+  ##
   ##   var a = initOrderedSet[int]()
   ##   for value in [9, 2, 1, 5, 1, 8, 4, 2]:
   ##     a.incl(value)

--- a/lib/pure/collections/tables.nim
+++ b/lib/pure/collections/tables.nim
@@ -677,6 +677,7 @@ iterator pairs*[A, B](t: Table[A, B]): (A, B) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   let a = {
   ##     'o': [1, 5, 7, 9],
   ##     'e': [2, 4, 6, 8]
@@ -1123,6 +1124,7 @@ iterator pairs*[A, B](t: TableRef[A, B]): (A, B) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   let a = {
   ##     'o': [1, 5, 7, 9],
   ##     'e': [2, 4, 6, 8]
@@ -1699,6 +1701,7 @@ iterator pairs*[A, B](t: OrderedTable[A, B]): (A, B) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   let a = {
   ##     'o': [1, 5, 7, 9],
   ##     'e': [2, 4, 6, 8]
@@ -2107,6 +2110,7 @@ iterator pairs*[A, B](t: OrderedTableRef[A, B]): (A, B) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   let a = {
   ##     'o': [1, 5, 7, 9],
   ##     'e': [2, 4, 6, 8]
@@ -2520,6 +2524,7 @@ iterator pairs*[A](t: CountTable[A]): (A, int) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   let a = toCountTable("abracadabra")
   ##
   ##   for k, v in pairs(a):
@@ -2796,6 +2801,7 @@ iterator pairs*[A](t: CountTableRef[A]): (A, int) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   let a = newCountTable("abracadabra")
   ##
   ##   for k, v in pairs(a):

--- a/lib/pure/colors.nim
+++ b/lib/pure/colors.nim
@@ -19,6 +19,7 @@ proc `==` *(a, b: Color): bool {.borrow.}
   ## Compares two colors.
   ##
   ## .. code-block::
+  ##
   ##   var
   ##     a = Color(0xff_00_ff)
   ##     b = colFuchsia

--- a/lib/pure/htmlgen.nim
+++ b/lib/pure/htmlgen.nim
@@ -31,6 +31,7 @@
 ## ========
 ##
 ## .. code-block:: Nim
+##
 ##   var nim = "Nim"
 ##   echo h1(a(href="https://nim-lang.org", nim))
 ##

--- a/lib/pure/httpclient.nim
+++ b/lib/pure/httpclient.nim
@@ -17,6 +17,7 @@
 ## `http://google.com`:
 ##
 ## .. code-block:: Nim
+##
 ##   import std/httpclient
 ##   var client = newHttpClient()
 ##   echo client.getContent("http://google.com")
@@ -25,6 +26,7 @@
 ## `AsyncHttpClient`:
 ##
 ## .. code-block:: Nim
+##
 ##   import std/[asyncdispatch, httpclient]
 ##
 ##   proc asyncProc(): Future[string] {.async.} =
@@ -48,6 +50,7 @@
 ## validated to the server.
 ##
 ## .. code-block:: Nim
+##
 ##   var client = newHttpClient()
 ##   var data = newMultipartData()
 ##   data["output"] = "soap12"
@@ -62,6 +65,7 @@
 ## it, you can pass your own via the `mimeDb` parameter to avoid this.
 ##
 ## .. code-block:: Nim
+##
 ##   let mimes = newMimetypes()
 ##   var client = newHttpClient()
 ##   var data = newMultipartData()
@@ -74,6 +78,7 @@
 ## and uses a json object for the body
 ##
 ## .. code-block:: Nim
+##
 ##   import std/[httpclient, json]
 ##
 ##   let client = newHttpClient()
@@ -92,6 +97,7 @@
 ## progress of the HTTP request.
 ##
 ## .. code-block:: Nim
+##
 ##    import std/[asyncdispatch, httpclient]
 ##
 ##    proc onProgressChanged(total, progress, speed: BiggestInt) {.async.} =
@@ -108,6 +114,7 @@
 ## If you would like to remove the callback simply set it to `nil`.
 ##
 ## .. code-block:: Nim
+##
 ##   client.onProgressChanged = nil
 ##
 ## .. warning:: The `total` reported by httpclient may be 0 in some cases.
@@ -131,6 +138,7 @@
 ## Example of setting SSL verification parameters in a new client:
 ##
 ## .. code-block:: Nim
+##
 ##    import httpclient
 ##    var client = newHttpClient(sslContext=newContext(verifyMode=CVerifyPeer))
 ##
@@ -162,6 +170,7 @@
 ## Here is how to set a timeout when creating an `HttpClient` instance:
 ##
 ## .. code-block:: Nim
+##
 ##    import std/httpclient
 ##
 ##    let client = newHttpClient(timeout = 42)
@@ -176,6 +185,7 @@
 ## Some examples on how to configure a Proxy for `HttpClient`:
 ##
 ## .. code-block:: Nim
+##
 ##    import std/httpclient
 ##
 ##    let myProxy = newProxy("http://myproxy.network")
@@ -184,6 +194,7 @@
 ## Get Proxy URL from environment variables:
 ##
 ## .. code-block:: Nim
+##
 ##    import std/httpclient
 ##
 ##    var url = ""
@@ -208,6 +219,7 @@
 ## Here you can see an example about how to set the `maxRedirects` of `HttpClient`:
 ##
 ## .. code-block:: Nim
+##
 ##    import std/httpclient
 ##
 ##    let client = newHttpClient(maxRedirects = 0)
@@ -397,6 +409,7 @@ proc add*(p: MultipartData, xs: MultipartEntries): MultipartData
   ## added without a filename and without a content type.
   ##
   ## .. code-block:: Nim
+  ##
   ##   data.add({"action": "login", "format": "json"})
   for name, content in xs.items:
     p.add(name, content)
@@ -407,6 +420,7 @@ proc newMultipartData*(xs: MultipartEntries): MultipartData =
   ## directly.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var data = newMultipartData({"action": "login", "format": "json"})
   result = MultipartData()
   for entry in xs:
@@ -423,6 +437,7 @@ proc addFiles*(p: MultipartData, xs: openArray[tuple[name, file: string]],
   ## manually specify file content, filename and MIME type, use `[]=` instead.
   ##
   ## .. code-block:: Nim
+  ##
   ##   data.addFiles({"uploaded_file": "public/test.html"})
   for name, file in xs.items:
     var contentType: string
@@ -438,6 +453,7 @@ proc `[]=`*(p: MultipartData, name, content: string) {.inline.} =
   ## without a filename and without a content type.
   ##
   ## .. code-block:: Nim
+  ##
   ##   data["username"] = "NimUser"
   p.add(name, content)
 
@@ -447,6 +463,7 @@ proc `[]=`*(p: MultipartData, name: string,
   ## and content manually.
   ##
   ## .. code-block:: Nim
+  ##
   ##   data["uploaded_file"] = ("test.html", "text/html",
   ##     "<html><head></head><body><p>test</p></body></html>")
   p.add(name, file.content, file.name, file.contentType, useStream = false)
@@ -660,6 +677,7 @@ proc getSocket*(client: HttpClient): Socket {.inline.} =
   ## this example shows info about local and remote endpoints
   ##
   ## .. code-block:: Nim
+  ##
   ##   if client.connected:
   ##     echo client.getSocket.getLocalAddr
   ##     echo client.getSocket.getPeerAddr

--- a/lib/pure/json.nim
+++ b/lib/pure/json.nim
@@ -42,6 +42,7 @@
 ## the `[]` operator. The following example shows how to do this:
 ##
 ## .. code-block:: Nim
+##
 ##   import std/json
 ##
 ##   let jsonNode = parseJson("""{"key": 3.14}""")
@@ -63,6 +64,7 @@
 ## To retrieve the value of `"key"` you can do the following:
 ##
 ## .. code-block:: Nim
+##
 ##   import std/json
 ##
 ##   let jsonNode = parseJson("""{"key": 3.14}""")
@@ -80,6 +82,7 @@
 ## type's default value when called on `nil`.
 ##
 ## .. code-block:: Nim
+##
 ##   import std/json
 ##
 ##   let jsonNode = parseJson("{}")
@@ -96,6 +99,7 @@
 ## you to fallback to a default value should the key's values be `null`:
 ##
 ## .. code-block:: Nim
+##
 ##   import std/json
 ##
 ##   let jsonNode = parseJson("""{"key": 3.14, "key2": null}""")
@@ -114,6 +118,7 @@
 ## responses, and backticks around keys with a reserved keyword as name.
 ##
 ## .. code-block:: Nim
+##
 ##   import std/json
 ##   import std/options
 ##
@@ -135,6 +140,7 @@
 ## operator:
 ##
 ## .. code-block:: nim
+##
 ##   import std/json
 ##
 ##   var hisName = "John"

--- a/lib/pure/logging.nim
+++ b/lib/pure/logging.nim
@@ -18,6 +18,7 @@
 ## To get started, first create a logger:
 ##
 ## .. code-block::
+##
 ##   import std/logging
 ##
 ##   var logger = newConsoleLogger()
@@ -31,6 +32,7 @@
 ## <#log.e,ConsoleLogger,Level,varargs[string,]>`_ to log a message:
 ##
 ## .. code-block::
+##
 ##   logger.log(lvlInfo, "a log message")
 ##   # Output: INFO a log message
 ##
@@ -60,6 +62,7 @@
 ## in the following example:
 ##
 ## .. code-block::
+##
 ##   import std/logging
 ##
 ##   var consoleLog = newConsoleLogger()
@@ -76,6 +79,7 @@
 ## to all registered handlers at once.
 ##
 ## .. code-block::
+##
 ##   # This example uses the loggers created above
 ##   log(lvlError, "an error occurred")
 ##   error("an error occurred")  # Equivalent to the above line
@@ -118,6 +122,7 @@
 ## The following example illustrates how to use format strings:
 ##
 ## .. code-block::
+##
 ##   import std/logging
 ##
 ##   var logger = newConsoleLogger(fmtStr="[$time] - $levelname: ")
@@ -361,6 +366,7 @@ method log*(logger: ConsoleLogger, level: Level, args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var consoleLog = newConsoleLogger()
   ##   consoleLog.log(lvlInfo, "this is a message")
   ##   consoleLog.log(lvlError, "error code is: ", 404)
@@ -403,6 +409,7 @@ proc newConsoleLogger*(levelThreshold = lvlAll, fmtStr = defaultFmtStr,
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var normalLog = newConsoleLogger()
   ##   var formatLog = newConsoleLogger(fmtStr=verboseFmtStr)
   ##   var errorLog = newConsoleLogger(levelThreshold=lvlError, useStderr=true)
@@ -438,6 +445,7 @@ when not defined(js):
     ## **Examples:**
     ##
     ## .. code-block::
+    ##
     ##   var fileLog = newFileLogger("messages.log")
     ##   fileLog.log(lvlInfo, "this is a message")
     ##   fileLog.log(lvlError, "error code is: ", 404)
@@ -468,6 +476,7 @@ when not defined(js):
     ## **Examples:**
     ##
     ## .. code-block::
+    ##
     ##   var messages = open("messages.log", fmWrite)
     ##   var formatted = open("formatted.log", fmWrite)
     ##   var errors = open("errors.log", fmWrite)
@@ -504,6 +513,7 @@ when not defined(js):
     ## **Examples:**
     ##
     ## .. code-block::
+    ##
     ##   var normalLog = newFileLogger("messages.log")
     ##   var formatLog = newFileLogger("formatted.log", fmtStr=verboseFmtStr)
     ##   var errorLog = newFileLogger("errors.log", levelThreshold=lvlError)
@@ -563,6 +573,7 @@ when not defined(js):
     ## **Examples:**
     ##
     ## .. code-block::
+    ##
     ##   var normalLog = newRollingFileLogger("messages.log")
     ##   var formatLog = newRollingFileLogger("formatted.log", fmtStr=verboseFmtStr)
     ##   var shortLog = newRollingFileLogger("short.log", maxLines=200)
@@ -616,6 +627,7 @@ when not defined(js):
     ## **Examples:**
     ##
     ## .. code-block::
+    ##
     ##   var rollingLog = newRollingFileLogger("messages.log")
     ##   rollingLog.log(lvlInfo, "this is a message")
     ##   rollingLog.log(lvlError, "error code is: ", 404)
@@ -649,6 +661,7 @@ template log*(level: Level, args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##
@@ -678,6 +691,7 @@ template debug*(args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##
@@ -699,6 +713,7 @@ template info*(args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##
@@ -720,6 +735,7 @@ template notice*(args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##
@@ -740,6 +756,7 @@ template warn*(args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##
@@ -762,6 +779,7 @@ template error*(args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##
@@ -783,6 +801,7 @@ template fatal*(args: varargs[string, `$`]) =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var logger = newConsoleLogger()
   ##   addHandler(logger)
   ##

--- a/lib/pure/memfiles.nim
+++ b/lib/pure/memfiles.nim
@@ -119,6 +119,7 @@ proc open*(filename: string, mode: FileMode = fmRead,
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   var
   ##     mm, mm_full, mm_half: MemFile
   ##
@@ -402,6 +403,7 @@ iterator memSlices*(mfile: MemFile, delim = '\l', eat = '\r'): MemSlice {.inline
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   var count = 0
   ##   for slice in memSlices(memfiles.open("foo")):
   ##     if slice.size > 0 and cast[cstring](slice.data)[0] != '#':
@@ -438,6 +440,7 @@ iterator lines*(mfile: MemFile, buf: var string, delim = '\l',
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   var buffer: string = ""
   ##   for line in lines(memfiles.open("foo"), buffer):
   ##     echo line
@@ -457,6 +460,7 @@ iterator lines*(mfile: MemFile, delim = '\l', eat = '\r'): string {.inline.} =
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   for line in lines(memfiles.open("foo")):
   ##     echo line
 

--- a/lib/pure/options.nim
+++ b/lib/pure/options.nim
@@ -54,6 +54,7 @@ supports pattern matching on `Option`s, with the `Some(<pattern>)` and
 `None()` patterns.
 
 .. code-block:: nim
+
   {.experimental: "caseStmtMacros".}
 
   import fusion/matching

--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2067,6 +2067,7 @@ proc execShellCmd*(command: string): int {.rtl, extern: "nos$1",
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   discard execShellCmd("ls -la")
   result = exitStatusLikeShell(c_system(command))
 
@@ -2719,6 +2720,7 @@ proc inclFilePermissions*(filename: string,
   ## A convenience proc for:
   ##
   ## .. code-block:: nim
+  ##
   ##   setFilePermissions(filename, getFilePermissions(filename)+permissions)
   setFilePermissions(filename, getFilePermissions(filename)+permissions)
 
@@ -2728,6 +2730,7 @@ proc exclFilePermissions*(filename: string,
   ## A convenience proc for:
   ##
   ## .. code-block:: nim
+  ##
   ##   setFilePermissions(filename, getFilePermissions(filename)-permissions)
   setFilePermissions(filename, getFilePermissions(filename)-permissions)
 
@@ -2852,6 +2855,7 @@ when defined(nimdoc):
     ## **Examples:**
     ##
     ## .. code-block:: nim
+    ##
     ##   when declared(paramCount):
     ##     # Use paramCount() here
     ##   else:
@@ -2884,6 +2888,7 @@ when defined(nimdoc):
     ## **Examples:**
     ##
     ## .. code-block:: nim
+    ##
     ##   when declared(paramStr):
     ##     # Use paramStr() here
     ##   else:
@@ -2985,6 +2990,7 @@ when declared(paramCount) or defined(nimdoc):
     ## **Examples:**
     ##
     ## .. code-block:: nim
+    ##
     ##   when declared(commandLineParams):
     ##     # Use commandLineParams() here
     ##   else:

--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -91,6 +91,7 @@ proc execProcess*(command: string, workingDir: string = "",
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##  let outp = execProcess("nim", args=["c", "-r", "mytestfile.nim"], options={poUsePath})
   ##  let outp_shell = execProcess("nim c -r mytestfile.nim")
   ##  # Note: outp may have an interleave of text from the nim compile
@@ -113,6 +114,7 @@ proc execCmd*(command: string): int {.rtl, extern: "nosp$1",
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##  let errC = execCmd("nim c -r mytestfile.nim")
 
 proc startProcess*(command: string, workingDir: string = "",
@@ -460,6 +462,7 @@ iterator lines*(p: Process, keepNewLines = false): string {.since: (1, 3), tags:
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   const opts = {poUsePath, poDaemon, poStdErrToStdOut}
   ##   var ps: seq[Process]
   ##   for prog in ["a", "b"]: # run 2 progs in parallel
@@ -489,6 +492,7 @@ proc readLines*(p: Process): (seq[string], int) {.since: (1, 3).} =
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   const opts = {poUsePath, poDaemon, poStdErrToStdOut}
   ##   var ps: seq[Process]
   ##   for prog in ["a", "b"]: # run 2 progs in parallel
@@ -1595,6 +1599,7 @@ proc execCmdEx*(command: string, options: set[ProcessOption] = {
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   var result = execCmdEx("nim r --hints:off -", options = {}, input = "echo 3*4")
   ##   import std/[strutils, strtabs]
   ##   stripLineEnd(result[0]) ## portable way to remove trailing newline, if any

--- a/lib/pure/parsecsv.nim
+++ b/lib/pure/parsecsv.nim
@@ -14,6 +14,7 @@
 ## ===========
 ##
 ## .. code-block:: nim
+##
 ##   import std/parsecsv
 ##   from std/os import paramStr
 ##   from std/streams import newFileStream
@@ -34,6 +35,7 @@
 ## reference for item access with `rowEntry <#rowEntry,CsvParser,string>`_:
 ##
 ## .. code-block:: nim
+##
 ##   import std/parsecsv
 ##
 ##   # Prepare a file

--- a/lib/pure/parseopt.nim
+++ b/lib/pure/parseopt.nim
@@ -49,6 +49,7 @@
 ## Here is an example:
 ##
 ## .. code-block::
+##
 ##   import std/parseopt
 ##
 ##   var p = initOptParser("-ab -e:5 --foo --bar=20 file.txt")
@@ -99,6 +100,7 @@
 ## arguments for those two parameters:
 ##
 ## .. code-block::
+##
 ##   import std/parseopt
 ##
 ##   proc printToken(kind: CmdLineKind, key: string, val: string) =
@@ -387,6 +389,7 @@ when declared(quoteShellCommand):
     ## **Examples:**
     ##
     ## .. code-block::
+    ##
     ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
     ##   while true:
     ##     p.next()
@@ -405,6 +408,7 @@ proc remainingArgs*(p: OptParser): seq[string] {.rtl, extern: "npo$1".} =
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   var p = initOptParser("--left -r:2 -- foo.txt bar.txt")
   ##   while true:
   ##     p.next()
@@ -428,6 +432,7 @@ iterator getopt*(p: var OptParser): tuple[kind: CmdLineKind, key,
   ## **Examples:**
   ##
   ## .. code-block::
+  ##
   ##   # these are placeholders, of course
   ##   proc writeHelp() = discard
   ##   proc writeVersion() = discard

--- a/lib/pure/parseutils.nim
+++ b/lib/pure/parseutils.nim
@@ -26,6 +26,7 @@
 ##
 ## .. code-block:: nim
 ##    :test:
+##
 ##    from std/strutils import Digits, parseInt
 ##
 ##    let

--- a/lib/pure/pegs.nim
+++ b/lib/pure/pegs.nim
@@ -886,6 +886,7 @@ macro mkHandlerTplts(handlers: untyped): untyped =
   # The AST structure of *handlers[0]*:
   #
   # .. code-block::
+  #
   #   StmtList
   #     Call
   #       Ident "pkNonTerminal"
@@ -956,6 +957,7 @@ template eventParser*(pegAst, handlers: untyped): (proc(s: string): int) =
   ## evaluates an arithmetic expression defined by a simple PEG:
   ##
   ## .. code-block:: nim
+  ##
   ##  import std/[strutils, pegs]
   ##
   ##  let
@@ -1227,6 +1229,7 @@ func replacef*(s: string, sub: Peg, by: string): string {.
   ## with the notation ``$i`` and ``$#`` (see strutils.`%`). Examples:
   ##
   ## .. code-block:: nim
+  ##
   ##   "var1=key; var2=key2".replacef(peg"{\ident}'='{\ident}", "$1<-$2$2")
   ##
   ## Results in:
@@ -1358,12 +1361,14 @@ iterator split*(s: string, sep: Peg): string =
   ## Examples:
   ##
   ## .. code-block:: nim
+  ##
   ##   for word in split("00232this02939is39an22example111", peg"\d+"):
   ##     writeLine(stdout, word)
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   "this"
   ##   "is"
   ##   "an"

--- a/lib/pure/smtp.nim
+++ b/lib/pure/smtp.nim
@@ -17,6 +17,7 @@
 ##
 ##
 ## .. code-block:: Nim
+##
 ##   var msg = createMessage("Hello from Nim's SMTP",
 ##                           "Hello!.\n Is this awesome or what?",
 ##                           @["foo@gmail.com"])
@@ -30,6 +31,7 @@
 ##
 ##
 ## .. code-block:: Nim
+##
 ##   var msg = createMessage("Hello from Nim's SMTP",
 ##                           "Hello!.\n Is this awesome or what?",
 ##                           @["foo@gmail.com"])

--- a/lib/pure/streamwrapper.nim
+++ b/lib/pure/streamwrapper.nim
@@ -93,6 +93,7 @@ proc newPipeOutStream*[T](s: sink (ref T)): owned PipeOutStream[T] =
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   import std/[osproc, streamwrapper]
   ##   var
   ##     p = startProcess(exePath)

--- a/lib/pure/strformat.nim
+++ b/lib/pure/strformat.nim
@@ -134,6 +134,7 @@ runnableExamples:
 An expression like `&"{key} is {value:arg} {{z}}"` is transformed into:
 
 .. code-block:: nim
+
   var temp = newStringOfCap(educatedCapGuess)
   temp.formatValue(key, "")
   temp.add(" is ")
@@ -273,6 +274,7 @@ Because of the well defined order how templates and macros are
 expanded, strformat cannot expand template arguments:
 
 .. code-block:: nim
+
   template myTemplate(arg: untyped): untyped =
     echo "arg is: ", arg
     echo &"--- {arg} ---"
@@ -290,6 +292,7 @@ identifier that cannot be resolved anymore.
 The workaround for this is to bind the template argument to a new local variable.
 
 .. code-block:: nim
+
   template myTemplate(arg: untyped): untyped =
     block:
       let arg1 {.inject.} = arg

--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -13,6 +13,7 @@ substrings from an input string. This is often easier than regular expressions.
 Some examples as an appetizer:
 
 .. code-block:: nim
+
   # check if input string matches a triple of integers:
   const input = "(1,2,4)"
   var x, y, z: int

--- a/lib/pure/strutils.nim
+++ b/lib/pure/strutils.nim
@@ -118,6 +118,7 @@ const
     ## find **invalid** characters in strings. Example:
     ##
     ## .. code-block:: nim
+    ##
     ##   let invalid = AllChars - Digits
     ##   doAssert "01234".find(invalid) == -1
     ##   doAssert "01A34".find(invalid) == 2
@@ -410,12 +411,14 @@ iterator split*(s: string, sep: char, maxsplit: int = -1): string =
   ## The code:
   ##
   ## .. code-block:: nim
+  ##
   ##   for word in split(";;this;is;an;;example;;;", ';'):
   ##     writeLine(stdout, word)
   ##
   ## Results in:
   ##
   ## .. code-block::
+  ##
   ##   ""
   ##   ""
   ##   "this"
@@ -441,12 +444,14 @@ iterator split*(s: string, seps: set[char] = Whitespace,
   ## Substrings are separated by a substring containing only `seps`.
   ##
   ## .. code-block:: nim
+  ##
   ##   for word in split("this\lis an\texample"):
   ##     writeLine(stdout, word)
   ##
   ## ...generates this output:
   ##
   ## .. code-block::
+  ##
   ##   "this"
   ##   "is"
   ##   "an"
@@ -455,12 +460,14 @@ iterator split*(s: string, seps: set[char] = Whitespace,
   ## And the following code:
   ##
   ## .. code-block:: nim
+  ##
   ##   for word in split("this:is;an$example", {';', ':', '$'}):
   ##     writeLine(stdout, word)
   ##
   ## ...produces the same output as the first example. The code:
   ##
   ## .. code-block:: nim
+  ##
   ##   let date = "2012-11-20T22:08:08.398990"
   ##   let separators = {' ', '-', ':', 'T'}
   ##   for number in split(date, separators):
@@ -469,6 +476,7 @@ iterator split*(s: string, seps: set[char] = Whitespace,
   ## ...results in:
   ##
   ## .. code-block::
+  ##
   ##   "2012"
   ##   "11"
   ##   "20"
@@ -490,12 +498,14 @@ iterator split*(s: string, sep: string, maxsplit: int = -1): string =
   ## The code:
   ##
   ## .. code-block:: nim
+  ##
   ##   for word in split("thisDATAisDATAcorrupted", "DATA"):
   ##     writeLine(stdout, word)
   ##
   ## Results in:
   ##
   ## .. code-block::
+  ##
   ##   "this"
   ##   "is"
   ##   "corrupted"
@@ -539,12 +549,14 @@ iterator rsplit*(s: string, sep: char,
   ## <#split.i,string,char,int>`_ except in reverse order.
   ##
   ## .. code-block:: nim
+  ##
   ##   for piece in "foo:bar".rsplit(':'):
   ##     echo piece
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   "bar"
   ##   "foo"
   ##
@@ -564,12 +576,14 @@ iterator rsplit*(s: string, seps: set[char] = Whitespace,
   ## <#split.i,string,char,int>`_ except in reverse order.
   ##
   ## .. code-block:: nim
+  ##
   ##   for piece in "foo bar".rsplit(WhiteSpace):
   ##     echo piece
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   "bar"
   ##   "foo"
   ##
@@ -589,12 +603,14 @@ iterator rsplit*(s: string, sep: string, maxsplit: int = -1,
   ## <#split.i,string,string,int>`_ except in reverse order.
   ##
   ## .. code-block:: nim
+  ##
   ##   for piece in "foothebar".rsplit("the"):
   ##     echo piece
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   "bar"
   ##   "foo"
   ##
@@ -618,12 +634,14 @@ iterator splitLines*(s: string, keepEol = false): string =
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   for line in splitLines("\nthis\nis\nan\n\nexample\n"):
   ##     writeLine(stdout, line)
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   ""
   ##   "this"
   ##   "is"
@@ -664,6 +682,7 @@ iterator splitWhitespace*(s: string, maxsplit: int = -1): string =
   ## The following code:
   ##
   ## .. code-block:: nim
+  ##
   ##   let s = "  foo \t bar  baz  "
   ##   for ms in [-1, 1, 2, 3]:
   ##     echo "------ maxsplit = ", ms, ":"
@@ -673,6 +692,7 @@ iterator splitWhitespace*(s: string, maxsplit: int = -1): string =
   ## ...results in:
   ##
   ## .. code-block::
+  ##
   ##   ------ maxsplit = -1:
   ##   "foo"
   ##   "bar"
@@ -761,11 +781,13 @@ func rsplit*(s: string, sep: char, maxsplit: int = -1): seq[string] {.rtl,
   ## do the following to get the tail of the path:
   ##
   ## .. code-block:: nim
+  ##
   ##   var tailSplit = rsplit("Root#Object#Method#Index", '#', maxsplit=1)
   ##
   ## Results in `tailSplit` containing:
   ##
   ## .. code-block:: nim
+  ##
   ##   @["Root#Object#Method", "Index"]
   ##
   ## See also:
@@ -789,11 +811,13 @@ func rsplit*(s: string, seps: set[char] = Whitespace,
   ## do the following to get the tail of the path:
   ##
   ## .. code-block:: nim
+  ##
   ##   var tailSplit = rsplit("Root#Object#Method#Index", {'#'}, maxsplit=1)
   ##
   ## Results in `tailSplit` containing:
   ##
   ## .. code-block:: nim
+  ##
   ##   @["Root#Object#Method", "Index"]
   ##
   ## See also:
@@ -816,11 +840,13 @@ func rsplit*(s: string, sep: string, maxsplit: int = -1): seq[string] {.rtl,
   ## do the following to get the tail of the path:
   ##
   ## .. code-block:: nim
+  ##
   ##   var tailSplit = rsplit("Root#Object#Method#Index", "#", maxsplit=1)
   ##
   ## Results in `tailSplit` containing:
   ##
   ## .. code-block:: nim
+  ##
   ##   @["Root#Object#Method", "Index"]
   ##
   ## See also:
@@ -1730,6 +1756,7 @@ func addSep*(dest: var string, sep = ", ", startLen: Natural = 0) {.inline.} =
   ## A shorthand for:
   ##
   ## .. code-block:: nim
+  ##
   ##   if dest.len > startLen: add(dest, sep)
   ##
   ## This is often useful for generating some code where the items need to
@@ -2762,11 +2789,13 @@ func `%`*(formatstr: string, a: openArray[string]): string {.rtl,
   ## This is best explained by an example:
   ##
   ## .. code-block:: nim
+  ##
   ##   "$1 eats $2." % ["The cat", "fish"]
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   "The cat eats fish."
   ##
   ## The substitution variables (the thing after the `$`) are enumerated
@@ -2776,6 +2805,7 @@ func `%`*(formatstr: string, a: openArray[string]): string {.rtl,
   ## variable:
   ##
   ## .. code-block:: nim
+  ##
   ##   "$# eats $#." % ["The cat", "fish"]
   ##
   ## Substitution variables can also be words (that is
@@ -2784,11 +2814,13 @@ func `%`*(formatstr: string, a: openArray[string]): string {.rtl,
   ## An example:
   ##
   ## .. code-block:: nim
+  ##
   ##   "$animal eats $food." % ["animal", "The cat", "food", "fish"]
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   "The cat eats fish."
   ##
   ## The variables are compared with `cmpIgnoreStyle`. `ValueError` is
@@ -2888,12 +2920,14 @@ iterator tokenize*(s: string, seps: set[char] = Whitespace): tuple[
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   for word in tokenize("  this is an  example  "):
   ##     writeLine(stdout, word)
   ##
   ## Results in:
   ##
   ## .. code-block:: nim
+  ##
   ##   ("  ", true)
   ##   ("this", false)
   ##   (" ", true)

--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -21,6 +21,7 @@
   ========
 
   .. code-block:: nim
+
     import std/[times, os]
     # Simple benchmarking
     let time = cpuTime()

--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -473,6 +473,7 @@ template suite*(name, body) {.dirty.} =
   ## for EACH test.
   ##
   ## .. code-block:: nim
+  ##
   ##  suite "test suite for addition":
   ##    setup:
   ##      let result = 4

--- a/lib/pure/xmltree.nim
+++ b/lib/pure/xmltree.nim
@@ -772,6 +772,7 @@ macro `<>`*(x: untyped): untyped =
   ## Constructor macro for XML. Example usage:
   ##
   ## .. code-block:: nim
+  ##
   ##   <>a(href="http://nim-lang.org", newText("Nim rules."))
   ##
   ## Produces an XML tree for::

--- a/lib/std/private/digitsutils.nim
+++ b/lib/std/private/digitsutils.nim
@@ -20,6 +20,7 @@ const
 # Inspired by https://engineering.fb.com/2013/03/15/developer-tools/three-optimization-tips-for-c
 # Generates:
 # .. code-block:: nim
+#
 #   var res = ""
 #   for i in 0 .. 99:
 #     if i < 10:

--- a/lib/std/private/since.nim
+++ b/lib/std/private/since.nim
@@ -17,6 +17,7 @@ template since*(version: (int, int), body: untyped) {.dirty.} =
   ## or equal to `version`. Usage:
   ##
   ## .. code-block:: Nim
+  ##
   ##   proc fun*() {.since: (1, 3).}
   ##   since (1, 3): fun()
   when (NimMajor, NimMinor) >= version:
@@ -27,6 +28,7 @@ template since*(version: (int, int, int), body: untyped) {.dirty.} =
   ## or equal to `version`. Usage:
   ##
   ## .. code-block:: Nim
+  ##
   ##   proc fun*() {.since: (1, 3, 1).}
   ##   since (1, 3, 1): fun()
   when (NimMajor, NimMinor, NimPatch) >= version:

--- a/lib/std/socketstreams.nim
+++ b/lib/std/socketstreams.nim
@@ -32,6 +32,7 @@
 ## ========
 ##
 ## .. code-block:: Nim
+##
 ##  import std/socketstreams
 ##
 ##  var

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -145,6 +145,7 @@ proc defined*(x: untyped): bool {.magic: "Defined", noSideEffect, compileTime.}
   ## build time conditionals:
   ##
   ## .. code-block:: Nim
+  ##
   ##   when not defined(release):
   ##     # Do here programmer friendly expensive sanity checks.
   ##   # Put here the normal code
@@ -177,6 +178,7 @@ when defined(nimHasDeclaredMagic):
     ## feature or not:
     ##
     ## .. code-block:: Nim
+    ##
     ##   when not declared(strutils.toUpper):
     ##     # provide our own toUpper proc here, because strutils is
     ##     # missing it.
@@ -203,6 +205,7 @@ proc `addr`*[T](x: T): ptr T {.magic: "Addr", noSideEffect.} =
   ## Cannot be overloaded.
   ##
   ## .. code-block:: Nim
+  ##
   ##  var
   ##    buf: seq[char] = @['a','b','c']
   ##    p = buf[1].addr
@@ -322,6 +325,7 @@ proc high*[T: Ordinal|enum|range](x: T): T {.magic: "High", noSideEffect,
   ## * `high(typedesc) <#high,typedesc[T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  high(2) # => 9223372036854775807
 
 proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffect.}
@@ -333,6 +337,7 @@ proc high*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "High", noSideEffe
   ## * `low(typedesc) <#low,typedesc[T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  high(int) # => 9223372036854775807
 
 proc high*[T](x: openArray[T]): int {.magic: "High", noSideEffect.}
@@ -342,6 +347,7 @@ proc high*[T](x: openArray[T]): int {.magic: "High", noSideEffect.}
   ## * `low(openArray) <#low,openArray[T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  var s = @[1, 2, 3, 4, 5, 6, 7]
   ##  high(s) # => 6
   ##  for i in low(s)..high(s):
@@ -356,6 +362,7 @@ proc high*[I, T](x: array[I, T]): I {.magic: "High", noSideEffect.}
   ## * `low(array) <#low,array[I,T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  var arr = [1, 2, 3, 4, 5, 6, 7]
   ##  high(arr) # => 6
   ##  for i in low(arr)..high(arr):
@@ -370,6 +377,7 @@ proc high*[I, T](x: typedesc[array[I, T]]): I {.magic: "High", noSideEffect.}
   ## * `low(typedesc[array]) <#low,typedesc[array[I,T]]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  high(array[7, int]) # => 6
 
 proc high*(x: cstring): int {.magic: "High", noSideEffect.}
@@ -386,6 +394,7 @@ proc high*(x: string): int {.magic: "High", noSideEffect.}
   ## * `low(string) <#low,string>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  var str = "Hello world!"
   ##  high(str) # => 11
 
@@ -398,6 +407,7 @@ proc low*[T: Ordinal|enum|range](x: T): T {.magic: "Low", noSideEffect,
   ## * `low(typedesc) <#low,typedesc[T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  low(2) # => -9223372036854775808
 
 proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect.}
@@ -409,6 +419,7 @@ proc low*[T: Ordinal|enum|range](x: typedesc[T]): T {.magic: "Low", noSideEffect
   ## * `high(typedesc) <#high,typedesc[T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  low(int) # => -9223372036854775808
 
 proc low*[T](x: openArray[T]): int {.magic: "Low", noSideEffect.}
@@ -418,6 +429,7 @@ proc low*[T](x: openArray[T]): int {.magic: "Low", noSideEffect.}
   ## * `high(openArray) <#high,openArray[T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  var s = @[1, 2, 3, 4, 5, 6, 7]
   ##  low(s) # => 0
   ##  for i in low(s)..high(s):
@@ -432,6 +444,7 @@ proc low*[I, T](x: array[I, T]): I {.magic: "Low", noSideEffect.}
   ## * `high(array) <#high,array[I,T]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  var arr = [1, 2, 3, 4, 5, 6, 7]
   ##  low(arr) # => 0
   ##  for i in low(arr)..high(arr):
@@ -446,6 +459,7 @@ proc low*[I, T](x: typedesc[array[I, T]]): I {.magic: "Low", noSideEffect.}
   ## * `high(typedesc[array]) <#high,typedesc[array[I,T]]>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  low(array[7, int]) # => 0
 
 proc low*(x: cstring): int {.magic: "Low", noSideEffect.}
@@ -461,6 +475,7 @@ proc low*(x: string): int {.magic: "Low", noSideEffect.}
   ## * `high(string) <#high,string>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##  var str = "Hello world!"
   ##  low(str) # => 0
 
@@ -513,6 +528,7 @@ proc `..`*[T, U](a: sink T, b: sink U): HSlice[T, U] {.noSideEffect, inline, mag
   ## statements, but then they are special-cased by the compiler.
   ##
   ## .. code-block:: Nim
+  ##
   ##   let a = [10, 20, 30, 40, 50]
   ##   echo a[2 .. 3] # @[30, 40]
   result = HSlice[T, U](a: a, b: b)
@@ -522,6 +538,7 @@ proc `..`*[T](b: sink T): HSlice[int, T]
   ## Unary `slice`:idx: operator that constructs an interval `[default(int), b]`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   let a = [10, 20, 30, 40, 50]
   ##   echo a[.. 2] # @[10, 20, 30]
   result = HSlice[int, T](a: 0, b: b)
@@ -626,6 +643,7 @@ proc sizeof*[T](x: T): int {.magic: "SizeOf", noSideEffect.}
   ## be used inside of macros.
   ##
   ## .. code-block:: Nim
+  ##
   ##  sizeof('A') # => 1
   ##  sizeof(2) # => 8
 
@@ -657,6 +675,7 @@ proc newSeq*[T](s: var seq[T], len: Natural) {.magic: "NewSeq", noSideEffect.}
   ## the sequence instead of adding them. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   var inputStrings: seq[string]
   ##   newSeq(inputStrings, 3)
   ##   assert len(inputStrings) == 3
@@ -677,6 +696,7 @@ proc newSeq*[T](len = 0.Natural): seq[T] =
   ## * `newSeqUninitialized <#newSeqUninitialized,Natural>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##   var inputStrings = newSeq[string](3)
   ##   assert len(inputStrings) == 3
   ##   inputStrings[0] = "The fourth"
@@ -691,6 +711,7 @@ proc newSeqOfCap*[T](cap: Natural): seq[T] {.
   ## `cap`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var x = newSeqOfCap[int](5)
   ##   assert len(x) == 0
   ##   x.add(10)
@@ -706,6 +727,7 @@ when not defined(js):
     ## entries to the sequence instead of adding them.
     ##
     ## .. code-block:: Nim
+    ##
     ##   var x = newSeqUninitialized[int](3)
     ##   assert len(x) == 3
     ##   x[0] = 10
@@ -823,6 +845,7 @@ proc contains*[U, V, W](s: HSlice[U, V], value: W): bool {.noSideEffect, inline.
   ## `value >= s.a and value <= s.b`
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert((1..3).contains(1) == true)
   ##   assert((1..3).contains(2) == true)
   ##   assert((1..3).contains(4) == false)
@@ -832,12 +855,14 @@ template `in`*(x, y: untyped): untyped {.dirty.} = contains(y, x)
   ## Sugar for `contains`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert(1 in (1..3) == true)
   ##   assert(5 in (1..3) == false)
 template `notin`*(x, y: untyped): untyped {.dirty.} = not contains(y, x)
   ## Sugar for `not contains`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert(1 notin (1..3) == false)
   ##   assert(5 notin (1..3) == true)
 
@@ -847,6 +872,7 @@ proc `is`*[T, S](x: T, y: S): bool {.magic: "Is", noSideEffect.}
   ## For a negated version, use `isnot <#isnot.t,untyped,untyped>`_.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert 42 is int
   ##   assert @[1, 2] is seq
   ##
@@ -862,6 +888,7 @@ template `isnot`*(x, y: untyped): untyped = not (x is y)
   ## Negated version of `is <#is,T,S>`_. Equivalent to `not(x is y)`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert 42 isnot float
   ##   assert @[1, 2] isnot enum
 
@@ -958,6 +985,7 @@ proc cmp*[T](x, y: T): int =
   ## This generic implementation uses the `==` and `<` operators.
   ##
   ## .. code-block:: Nim
+  ##
   ##  import std/algorithm
   ##  echo sorted(@[4, 2, 6, 5, 8, 7], cmp[int])
   if x == y: return 0
@@ -978,6 +1006,7 @@ proc `@`* [IDX, T](a: sink array[IDX, T]): seq[T] {.magic: "ArrToSeq", noSideEff
   ## `seq[int]`, while `[1, 2, 3]` has the type `array[0..2, int]`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   let
   ##     a = [1, 3, 5]
   ##     b = "foo"
@@ -1015,6 +1044,7 @@ proc setLen*[T](s: var seq[T], newlen: Natural) {.
   ## `s` will be truncated.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var x = @[10, 20]
   ##   x.setLen(5)
   ##   x[4] = 50
@@ -1030,6 +1060,7 @@ proc setLen*(s: var string, newlen: Natural) {.
   ## `s` will be truncated.
   ##
   ## .. code-block:: Nim
+  ##
   ##  var myS = "Nim is great!!"
   ##  myS.setLen(3) # myS <- "Nim"
   ##  echo myS, " is fantastic!!"
@@ -1055,24 +1086,28 @@ proc `&`*(x: string, y: char): string {.
   ## Concatenates `x` with `y`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert("ab" & 'c' == "abc")
 proc `&`*(x, y: char): string {.
   magic: "ConStrStr", noSideEffect, merge.}
   ## Concatenates characters `x` and `y` into a string.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert('a' & 'b' == "ab")
 proc `&`*(x, y: string): string {.
   magic: "ConStrStr", noSideEffect, merge.}
   ## Concatenates strings `x` and `y`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert("ab" & "cd" == "abcd")
 proc `&`*(x: char, y: string): string {.
   magic: "ConStrStr", noSideEffect, merge.}
   ## Concatenates `x` with `y`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert('a' & "bc" == "abc")
 
 # implementation note: These must all have the same magic value "ConStrStr" so
@@ -1082,6 +1117,7 @@ proc add*(x: var string, y: char) {.magic: "AppendStrCh", noSideEffect.}
   ## Appends `y` to `x` in place.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var tmp = ""
   ##   tmp.add('a')
   ##   tmp.add('b')
@@ -1283,6 +1319,7 @@ when false: # defined(gcDestructors):
     ## * `& proc <#&,seq[T],seq[T]>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##   var s: seq[string] = @["test2","test2"]
     ##   s.add("test") # s <- @[test2, test2, test]
     {.noSideEffect.}:
@@ -1308,6 +1345,7 @@ else:
     ## * `& proc <#&,seq[T],seq[T]>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##   var s: seq[string] = @["test2","test2"]
     ##   s.add("test") # s <- @[test2, test2, test]
     {.noSideEffect.}:
@@ -1342,6 +1380,7 @@ proc insert*[T](x: var seq[T], item: sink T, i = 0.Natural) {.noSideEffect.} =
   ## Inserts `item` into `x` at position `i`.
   ##
   ## .. code-block:: Nim
+  ##
   ##  var i = @[1, 3, 5]
   ##  i.insert(99, 0) # i <- @[99, 1, 3, 5]
   {.noSideEffect.}:
@@ -1373,6 +1412,7 @@ when not defined(nimV2):
     ## debugging tool.
     ##
     ## .. code-block:: Nim
+    ##
     ##  var s: seq[string] = @["test2", "test2"]
     ##  var i = @[1, 2, 3, 4, 5]
     ##  echo repr(s) # => 0x1055eb050[0x1055ec050"test2", 0x1055ec078"test2"]
@@ -1462,6 +1502,7 @@ proc toFloat*(i: int): float {.noSideEffect, inline.} =
   ## However, on most platforms the conversion cannot fail.
   ##
   ## .. code-block:: Nim
+  ##
   ##   let
   ##     a = 2
   ##     b = 3.7
@@ -1485,6 +1526,7 @@ proc toInt*(f: float): int {.noSideEffect.} =
   ## cannot be accurately converted.
   ##
   ## .. code-block:: Nim
+  ##
   ##   doAssert toInt(0.49) == 0
   ##   doAssert toInt(0.5) == 1
   ##   doAssert toInt(-0.5) == -1 # rounding is symmetrical
@@ -1514,6 +1556,7 @@ proc swap*[T](a, b: var T) {.magic: "Swap", noSideEffect.}
   ## Particularly useful for sorting algorithms.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var
   ##     a = 5
   ##     b = 9
@@ -1596,6 +1639,7 @@ proc len*[U: Ordinal; V: Ordinal](x: HSlice[U, V]): int {.noSideEffect, inline.}
   ## Length of ordinal slice. When x.b < x.a returns zero length.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert((0..5).len == 6)
   ##   assert((5..2).len == 0)
   result = max(0, ord(x.b) - ord(x.a) + 1)
@@ -1642,6 +1686,7 @@ when defined(nimSeqsV2):
     ## * `add(var seq[T], openArray[T]) <#add,seq[T],openArray[T]>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##   assert(@[1, 2, 3, 4] & @[5, 6] == @[1, 2, 3, 4, 5, 6])
     newSeq(result, x.len + y.len)
     for i in 0..x.len-1:
@@ -1658,6 +1703,7 @@ when defined(nimSeqsV2):
     ## * `add(var seq[T], T) <#add,seq[T],sinkT>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##   assert(@[1, 2, 3] & 4 == @[1, 2, 3, 4])
     newSeq(result, x.len + 1)
     for i in 0..x.len-1:
@@ -1670,6 +1716,7 @@ when defined(nimSeqsV2):
     ## Requires copying of the sequence.
     ##
     ## .. code-block:: Nim
+    ##
     ##   assert(1 & @[2, 3, 4] == @[1, 2, 3, 4])
     newSeq(result, y.len + 1)
     result[0] = move(x)
@@ -1687,6 +1734,7 @@ else:
     ## * `add(var seq[T], openArray[T]) <#add,seq[T],openArray[T]>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##   assert(@[1, 2, 3, 4] & @[5, 6] == @[1, 2, 3, 4, 5, 6])
     newSeq(result, x.len + y.len)
     for i in 0..x.len-1:
@@ -1703,6 +1751,7 @@ else:
     ## * `add(var seq[T], T) <#add,seq[T],sinkT>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##   assert(@[1, 2, 3] & 4 == @[1, 2, 3, 4])
     newSeq(result, x.len + 1)
     for i in 0..x.len-1:
@@ -1715,6 +1764,7 @@ else:
     ## Requires copying of the sequence.
     ##
     ## .. code-block:: Nim
+    ##
     ##   assert(1 & @[2, 3, 4] == @[1, 2, 3, 4])
     newSeq(result, y.len + 1)
     result[0] = x
@@ -1739,6 +1789,7 @@ proc instantiationInfo*(index = -1, fullPaths = false): tuple[
   ## Example:
   ##
   ## .. code-block:: nim
+  ##
   ##   import std/strutils
   ##
   ##   template testException(exception, code: untyped): typed =
@@ -1767,6 +1818,7 @@ proc compiles*(x: untyped): bool {.magic: "Compiles", noSideEffect, compileTime.
   ## This can be used to check whether a type supports some operation:
   ##
   ## .. code-block:: Nim
+  ##
   ##   when compiles(3 + 4):
   ##     echo "'+' for integers is available"
   discard
@@ -1857,6 +1909,7 @@ proc contains*[T](a: openArray[T], item: T): bool {.inline.}=
   ## `item in a`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var a = @[1, 3, 5]
   ##   assert a.contains(5)
   ##   assert 3 in a
@@ -2085,6 +2138,7 @@ template likely*(val: bool): bool =
   ## going to be run. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   for value in inputValues:
   ##     if likely(value <= 100):
   ##       process(value)
@@ -2109,6 +2163,7 @@ template unlikely*(val: bool): bool =
   ## going to be run. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   for value in inputValues:
   ##     if unlikely(value > 100):
   ##       echo "Value too big!"
@@ -2130,6 +2185,7 @@ const
     ## is the major number of Nim's version. Example:
     ##
     ## .. code-block:: Nim
+    ##
     ##   when (NimMajor, NimMinor, NimPatch) >= (1, 3, 1): discard
     # see also std/private/since
 
@@ -2325,6 +2381,7 @@ when notJSnotNims:
     ## Example:
     ##
     ## .. code-block:: Nim
+    ##
     ##   proc ctrlc() {.noconv.} =
     ##     echo "Ctrl+C fired!"
     ##     # do clean up stuff
@@ -2517,6 +2574,7 @@ proc `/`*(x, y: int): float {.inline, noSideEffect.} =
   ## * `mod <#mod,int,int>`_
   ##
   ## .. code-block:: Nim
+  ##
   ##   echo 7 / 5 # => 1.4
   result = toFloat(x) / toFloat(y)
 
@@ -2530,6 +2588,7 @@ template `^`*(x: int): BackwardsIndex = BackwardsIndex(x)
   ## `a[^x]` is a shortcut for `a[a.len-x]`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   let
   ##     a = [1, 3, 5, 7, 9]
   ##     b = "abcdefgh"
@@ -2546,6 +2605,7 @@ template `..<`*(a, b: untyped): untyped =
   ## A shortcut for `a .. pred(b)`.
   ##
   ## .. code-block:: Nim
+  ##
   ##   for i in 5 ..< 9:
   ##     echo i # => 5; 6; 7; 8
   a .. (when b is BackwardsIndex: succ(b) else: pred(b))
@@ -2576,6 +2636,7 @@ proc `[]`*[T, U: Ordinal](s: string, x: HSlice[T, U]): string {.inline.} =
   ## Returns the inclusive range `[s[x.a], s[x.b]]`:
   ##
   ## .. code-block:: Nim
+  ##
   ##    var s = "abcdef"
   ##    assert s[1..3] == "bcd"
   let a = s ^^ x.a
@@ -2606,6 +2667,7 @@ proc `[]`*[Idx, T; U, V: Ordinal](a: array[Idx, T], x: HSlice[U, V]): seq[T] =
   ## Returns the inclusive range `[a[x.a], a[x.b]]`:
   ##
   ## .. code-block:: Nim
+  ##
   ##    var a = [1, 2, 3, 4]
   ##    assert a[0..2] == @[1, 2, 3]
   let xa = a ^^ x.a
@@ -2617,6 +2679,7 @@ proc `[]=`*[Idx, T; U, V: Ordinal](a: var array[Idx, T], x: HSlice[U, V], b: ope
   ## Slice assignment for arrays.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var a = [10, 20, 30, 40, 50]
   ##   a[1..2] = @[99, 88]
   ##   assert a == [10, 99, 88, 40, 50]
@@ -2632,6 +2695,7 @@ proc `[]`*[T; U, V: Ordinal](s: openArray[T], x: HSlice[U, V]): seq[T] =
   ## Returns the inclusive range `[s[x.a], s[x.b]]`:
   ##
   ## .. code-block:: Nim
+  ##
   ##    var s = @[1, 2, 3, 4]
   ##    assert s[0..2] == @[1, 2, 3]
   let a = s ^^ x.a
@@ -2687,6 +2751,7 @@ proc staticRead*(filename: string): string {.magic: "Slurp".}
   ## near or equal to the *free* memory of the device you are using to compile.
   ##
   ## .. code-block:: Nim
+  ##
   ##     const myResource = staticRead"mydatafile.bin"
   ##
   ## `slurp <#slurp,string>`_ is an alias for `staticRead`.
@@ -2704,6 +2769,7 @@ proc staticExec*(command: string, input = "", cache = ""): string {.
   ## to the executed program.
   ##
   ## .. code-block:: Nim
+  ##
   ##     const buildInfo = "Revision " & staticExec("git rev-parse HEAD") &
   ##                       "\nCompiled on " & staticExec("uname -v")
   ##
@@ -2720,6 +2786,7 @@ proc staticExec*(command: string, input = "", cache = ""): string {.
   ## use versioning information for `cache`:
   ##
   ## .. code-block:: Nim
+  ##
   ##     const stateMachine = staticExec("dfaoptimizer", "input", "0.8.0")
 
 proc gorgeEx*(command: string, input = "", cache = ""): tuple[output: string,
@@ -2756,6 +2823,7 @@ proc `&=`*(x: var string, y: string) {.magic: "AppendStrStr", noSideEffect.}
   ## Appends in place to a string.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var a = "abc"
   ##   a &= "de" # a <- "abcde"
 
@@ -2844,6 +2912,7 @@ when hasAlloc or defined(nimscript):
     ## Inserts `item` into `x` at position `i`.
     ##
     ## .. code-block:: Nim
+    ##
     ##   var a = "abc"
     ##   a.insert("zz", 0) # a <- "zzabc"
     var xl = x.len
@@ -2919,6 +2988,7 @@ proc addQuoted*[T](s: var string, x: T) =
   ## they want to implement a customized element representation.
   ##
   ## .. code-block:: Nim
+  ##
   ##   var tmp = ""
   ##   tmp.addQuoted(1)
   ##   tmp.add(", ")
@@ -2960,6 +3030,7 @@ proc locals*(): RootObj {.magic: "Plugin", noSideEffect.} =
   ## tuple of a structure that depends on the current scope. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   proc testLocals() =
   ##     var
   ##       a = "something"
@@ -2999,6 +3070,7 @@ proc procCall*(x: untyped) {.magic: "ProcCall", compileTime.} =
   ## This is similar to `super`:idx: in ordinary OO languages.
   ##
   ## .. code-block:: Nim
+  ##
   ##   # 'someMethod' will be resolved fully statically:
   ##   procCall someMethod(a, b)
   discard
@@ -3034,6 +3106,7 @@ template closureScope*(body: untyped): untyped =
   ## Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   var myClosure : proc()
   ##   # without closureScope:
   ##   for i in 0 .. 5:

--- a/lib/system/channels_builtin.nim
+++ b/lib/system/channels_builtin.nim
@@ -27,6 +27,7 @@
 ## blocking and non-blocking.
 ##
 ## .. code-block:: Nim
+##
 ##   # Be sure to compile with --threads:on.
 ##   # The channels and threads modules are part of system and should not be
 ##   # imported.
@@ -113,6 +114,7 @@
 ## arguments:
 ##
 ## .. code-block:: Nim
+##
 ##   proc worker(channel: ptr Channel[string]) =
 ##     let greeting = channel[].recv()
 ##     echo greeting

--- a/lib/system/dollars.nim
+++ b/lib/system/dollars.nim
@@ -40,6 +40,7 @@ proc `$`*(x: char): string {.magic: "CharToStr", noSideEffect.}
   ## converted to a string.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert $'c' == "c"
 
 proc `$`*(x: cstring): string {.magic: "CStrToStr", noSideEffect.}
@@ -65,6 +66,7 @@ proc `$`*(t: typedesc): string {.magic: "TypeTrait".}
   ## `typetraits module <typetraits.html>`_.
   ##
   ## .. code-block:: Nim
+  ##
   ##   doAssert $(typeof(42)) == "int"
   ##   doAssert $(typeof("Foo")) == "string"
   ##   static: doAssert $(typeof(@['A', 'B'])) == "seq[char]"
@@ -91,6 +93,7 @@ proc `$`*[T: tuple|object](x: T): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   $(23, 45) == "(23, 45)"
   ##   $(a: 23, b: 45) == "(a: 23, b: 45)"
   ##   $() == "()"
@@ -141,6 +144,7 @@ proc `$`*[T](x: set[T]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   ${23, 45} == "{23, 45}"
   collectionToString(x, "{", ", ", "}")
 
@@ -149,6 +153,7 @@ proc `$`*[T](x: seq[T]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   $(@[23, 45]) == "@[23, 45]"
   collectionToString(x, "@[", ", ", "]")
 
@@ -157,6 +162,7 @@ proc `$`*[T, U](x: HSlice[T, U]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##  $(1 .. 5) == "1 .. 5"
   result = $x.a
   result.add(" .. ")
@@ -173,5 +179,6 @@ proc `$`*[T](x: openArray[T]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   $(@[23, 45].toOpenArray(0, 1)) == "[23, 45]"
   collectionToString(x, "[", ", ", "]")

--- a/lib/system/gc.nim
+++ b/lib/system/gc.nim
@@ -32,6 +32,7 @@ is stored on the stack or not. This is caused by var parameters.
 Consider this example:
 
 .. code-block:: Nim
+
   proc setRef(r: var ref TNode) =
     new(r)
 
@@ -46,6 +47,7 @@ We have to decide at runtime whether the reference is on the stack or not.
 The generated code looks roughly like this:
 
 .. code-block:: C
+
   void setref(TNode** ref) {
     unsureAsgnRef(ref, newObj(TNode_TI, sizeof(TNode)))
   }

--- a/lib/system/nimscript.nim
+++ b/lib/system/nimscript.nim
@@ -342,6 +342,7 @@ template withDir*(dir: string; body: untyped): untyped =
   ## Usage example:
   ##
   ## .. code-block:: nim
+  ##
   ##   # inside /some/path/
   ##   withDir "foo":
   ##     # move to /some/path/foo/
@@ -392,6 +393,7 @@ when not defined(nimble):
     ## Example:
     ##
     ## .. code-block:: nim
+    ##
     ##  task build, "default build is via the C backend":
     ##    setCommand "c"
     ##
@@ -402,6 +404,7 @@ when not defined(nimble):
     ## Example:
     ##
     ## .. code-block:: nim
+    ##
     ##  task foo, "foo":        # > nim foo
     ##    echo "Running foo"    # Running foo
     ##

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -33,6 +33,7 @@ proc repr*(x: char): string {.noSideEffect.} =
   ## converted to an escaped string.
   ##
   ## .. code-block:: Nim
+  ##
   ##   assert repr('c') == "'c'"
   result.add '\''
   # Elides string creations if not needed
@@ -123,6 +124,7 @@ proc repr*[T: tuple|object](x: T): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   $(23, 45) == "(23, 45)"
   ##   $(a: 23, b: 45) == "(a: 23, b: 45)"
   ##   $() == "()"
@@ -155,6 +157,7 @@ proc repr*[T](x: set[T]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   ${23, 45} == "{23, 45}"
   collectionToRepr(x, "{", ", ", "}")
 
@@ -163,6 +166,7 @@ proc repr*[T](x: seq[T]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   $(@[23, 45]) == "@[23, 45]"
   collectionToRepr(x, "@[", ", ", "]")
 
@@ -171,6 +175,7 @@ proc repr*[T, U](x: HSlice[T, U]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##  $(1 .. 5) == "1 .. 5"
   result = repr(x.a)
   result.add(" .. ")
@@ -185,5 +190,6 @@ proc repr*[T](x: openArray[T]): string =
   ## of `x`. Example:
   ##
   ## .. code-block:: Nim
+  ##
   ##   $(@[23, 45].toOpenArray(0, 1)) == "[23, 45]"
   collectionToRepr(x, "[", ", ", "]")

--- a/lib/wrappers/openssl.nim
+++ b/lib/wrappers/openssl.nim
@@ -18,7 +18,8 @@
 ##
 ## Build and test examples:
 ##
-## .. code-block::
+## .. code-block:: cmd
+##
 ##   ./bin/nim c -d:ssl -p:. -r tests/untestable/tssl.nim
 ##   ./bin/nim c -d:ssl -p:. --dynlibOverride:ssl --passl:-lcrypto --passl:-lssl -r tests/untestable/tssl.nim
 

--- a/nimdoc/rst2html/source/rst_examples.rst
+++ b/nimdoc/rst2html/source/rst_examples.rst
@@ -52,6 +52,7 @@ details. We use the term `runtime`:idx: to cover both compile-time execution
 and code execution in the executable.
 
 .. code-block:: nim
+
   var a: array[0..1, char]
   let i = 5
   try:
@@ -122,6 +123,7 @@ contain the following `escape sequences`:idx:\ :
 ==================         ===================================================
 
 .. code-block:: nim
+
   """"long string within quotes""""
 
 Produces::
@@ -380,6 +382,7 @@ Example:
    code is the same as it would be with code reordering disabled.
 
    .. code-block:: nim
+
      {.experimental: "codeReordering".}
 
      proc x() =

--- a/nimdoc/testproject/testproject.nim
+++ b/nimdoc/testproject/testproject.nim
@@ -200,6 +200,7 @@ when true: # tests RST inside comments
     ## * `low2(T) <#low2,T>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##  low(2) # => -9223372036854775808
 
   proc low2*[T: Ordinal|enum|range](x: T): T {.magic: "Low", noSideEffect.} =
@@ -210,6 +211,7 @@ when true: # tests RST inside comments
     ## * `low(T) <#low,T>`_
     ##
     ## .. code-block:: Nim
+    ##
     ##  low2(2) # => -9223372036854775808
     runnableExamples:
       discard "in low2"

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -987,15 +987,15 @@ suite "RST indentation":
       """
     check input1.toAst == ast
     check input2.toAst == ast
-    var error = new string
-    #check input3warning.toAst(error=error) == ast
-    check input3warning.toAst(error=error) == ""
-    check(error[] == "input(3, 1) Error: general parse error")
+    var warnings = new seq[string]
+    check input3warning.toAst(warnings=warnings) == ast
+    check(warnings[] == @["input(3, 1) Warning: RST style: " &
+                          "no blank line after directive arguments"])
 
     # "template..." should be parsed as a definition list attached to ":test:":
     check inputWrong.toAst != ast
 
-    # optional args cannot be separated by a blank line with the directive:
+    # optional args cannot be separated by a blank line from their directive:
     check(dedent"""
       .. code-block:: nim
 

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -54,6 +54,7 @@ const
 suite "YAML syntax highlighting":
   test "Basics":
     let input = """.. code-block:: yaml
+
     %YAML 1.2
     ---
     a string: string
@@ -78,6 +79,7 @@ suite "YAML syntax highlighting":
 
   test "Block scalars":
     let input = """.. code-block:: yaml
+
     a literal block scalar: |
       some text
       # not a comment
@@ -106,6 +108,7 @@ suite "YAML syntax highlighting":
 
   test "Directives":
     let input = """.. code-block:: yaml
+
     %YAML 1.2
     ---
     %not a directive
@@ -130,6 +133,7 @@ suite "YAML syntax highlighting":
 
   test "Flow Style and Numbers":
     let input = """.. code-block:: yaml
+
     {
       "quoted string": 42,
       'single quoted string': false,
@@ -167,6 +171,7 @@ suite "YAML syntax highlighting":
 
   test "Anchors, Aliases, Tags":
     let input = """.. code-block:: yaml
+
     --- !!map
     !!str string: !<tag:yaml.org,2002:int> 42
     ? &anchor !!seq []:
@@ -182,6 +187,7 @@ suite "YAML syntax highlighting":
 
   test "Edge cases":
     let input = """.. code-block:: yaml
+
     ...
      %a string:
       a:string:not:a:map


### PR DESCRIPTION
This simple PR adds a check that there should be a blank line after any RST directive according to the RST spec, e.g. this is right syntax:
```rst
 .. code-block:: nim
     :test: "nim c $1"

   import std/strformat
```
and this is wrong:
```rst
 .. code-block:: nim
     :test: "nim c $1"
   import std/strformat
```
This is important because current Github implementation interprets wrong cases as comments and they silently disappear in formatted text, which have been causing a lot of confusion all the time (e.g. [recent post](https://forum.nim-lang.org/t/9172)). For comparison see  [BEFORE](https://github.com/nim-lang/Nim/blob/devel/doc/nep1.rst) and [AFTER](https://github.com/a-mr/Nim/blob/rst-directive-blank-line-check/doc/nep1.rst).

- [x] TODO: switch error to a warning for backward compatibility when the tests pass