### PR TITLE
Templates and macros now do not expand in messages. RFC454

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -767,6 +767,7 @@ type
     typ*: PType
     info*: TLineInfo
     flags*: TNodeFlags
+    expandedFrom*: PNode
     case kind*: TNodeKind
     of nkCharLit..nkUInt64Lit:
       intVal*: BiggestInt

--- a/compiler/hlo.nim
+++ b/compiler/hlo.nim
@@ -27,7 +27,7 @@ proc evalPattern(c: PContext, n, orig: PNode): PNode =
   of skMacro:
     result = semMacroExpr(c, n, orig, s)
   of skTemplate:
-    result = semTemplateExpr(c, n, s, {efFromHlo})
+    result = semTemplateExpr(c, n, orig, s, {efFromHlo})
   else:
     result = semDirectOp(c, n, {})
   if c.config.hasHint(hintPattern):

--- a/compiler/renderer.nim
+++ b/compiler/renderer.nim
@@ -1708,6 +1708,13 @@ proc gsub(g: var TSrcGen, n: PNode, c: TContext, fromStmtList = false) =
 
 proc renderTree*(n: PNode, renderFlags: TRenderFlags = {}): string =
   if n == nil: return "<nil tree>"
+  let n =
+    if n.kind notin routineDefs and n.expandedFrom != nil:
+      # Routine defs should use unexpanded AST since source is more confusing
+      # proc(){.async.} is turned into `async(proc)`
+      n.expandedFrom
+    else:
+      n
   var g: TSrcGen
   initSrcGen(g, renderFlags, newPartialConfigRef())
   # do not indent the initial statement list so that

--- a/compiler/sem.nim
+++ b/compiler/sem.nim
@@ -271,7 +271,7 @@ proc paramsTypeCheck(c: PContext, typ: PType) {.inline.} =
 proc expectMacroOrTemplateCall(c: PContext, n: PNode): PSym
 proc semDirectOp(c: PContext, n: PNode, flags: TExprFlags): PNode
 proc semWhen(c: PContext, n: PNode, semCheck: bool = true): PNode
-proc semTemplateExpr(c: PContext, n: PNode, s: PSym,
+proc semTemplateExpr(c: PContext, n, nOrig: PNode, s: PSym,
                      flags: TExprFlags = {}): PNode
 proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
                   flags: TExprFlags = {}): PNode
@@ -501,6 +501,7 @@ proc semMacroExpr(c: PContext, n, nOrig: PNode, sym: PSym,
     message(c.config, nOrig.info, hintExpandMacro, renderTree(result))
   result = wrapInComesFrom(nOrig.info, sym, result)
   popInfoContext(c.config)
+  result.expandedFrom = nOrig.copyTree
 
 proc forceBool(c: PContext, n: PNode): PNode =
   result = fitNode(c, getSysType(c.graph, n.info, tyBool), n, n.info)

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -77,7 +77,7 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
   of skTemplate:
     if macroToExpandSym(s):
       onUse(n.info, s)
-      result = semTemplateExpr(c, n, s, {efNoSemCheck})
+      result = semTemplateExpr(c, n, n, s, {efNoSemCheck})
       result = semGenericStmt(c, result, {}, ctx)
     else:
       result = symChoice(c, n, s, scOpen)
@@ -257,7 +257,7 @@ proc semGenericStmt(c: PContext, n: PNode,
       of skTemplate:
         if macroToExpand(s) and sc.safeLen <= 1:
           onUse(fn.info, s)
-          result = semTemplateExpr(c, n, s, {efNoSemCheck})
+          result = semTemplateExpr(c, n, n, s, {efNoSemCheck})
           result = semGenericStmt(c, result, flags, ctx)
         else:
           n[0] = sc

--- a/compiler/semstmts.nim
+++ b/compiler/semstmts.nim
@@ -532,7 +532,7 @@ proc semVarMacroPragma(c: PContext, a: PNode, n: PNode): PNode =
         let m = r[0].sym
         case m.kind
         of skMacro: result = semMacroExpr(c, r, r, m, {})
-        of skTemplate: result = semTemplateExpr(c, r, m, {})
+        of skTemplate: result = semTemplateExpr(c, r, r, m, {})
         else:
           a[lhsPos] = oldExpr
           continue
@@ -964,7 +964,7 @@ proc handleStmtMacro(c: PContext; n, selector: PNode; magicType: string;
     callExpr.add n
     case match.kind
     of skMacro: result = semMacroExpr(c, callExpr, callExpr, match, flags)
-    of skTemplate: result = semTemplateExpr(c, callExpr, match, flags)
+    of skTemplate: result = semTemplateExpr(c, callExpr, callExpr, match, flags)
     else: result = nil
 
 proc handleForLoopMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
@@ -991,7 +991,7 @@ proc handleCaseStmtMacro(c: PContext; n: PNode; flags: TExprFlags): PNode =
     let toExpand = semResolvedCall(c, r, r.call, {})
     case match.kind
     of skMacro: result = semMacroExpr(c, toExpand, toExpand, match, flags)
-    of skTemplate: result = semTemplateExpr(c, toExpand, match, flags)
+    of skTemplate: result = semTemplateExpr(c, toExpand, toExpand, match, flags)
     else: result = nil
   # this would be the perfectly consistent solution with 'for loop macros',
   # but it kinda sucks for pattern matching as the matcher is not attached to
@@ -1635,7 +1635,7 @@ proc semProcAnnotation(c: PContext, prc: PNode;
       let m = r[0].sym
       case m.kind
       of skMacro: result = semMacroExpr(c, r, r, m, {})
-      of skTemplate: result = semTemplateExpr(c, r, m, {})
+      of skTemplate: result = semTemplateExpr(c, r, r, m, {})
       else:
         prc[pragmasPos] = n
         continue

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -718,7 +718,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
       elif contains(c.toBind, s.id):
         result = symChoice(c.c, n, s, scClosed)
       elif templToExpand(s):
-        result = semPatternBody(c, semTemplateExpr(c.c, n, s, {efNoSemCheck}))
+        result = semPatternBody(c, semTemplateExpr(c.c, n, n, s, {efNoSemCheck}))
       else:
         discard
         # we keep the ident unbound for matching instantiated symbols and
@@ -769,7 +769,7 @@ proc semPatternBody(c: var TemplCtx, n: PNode): PNode =
       if s.owner == c.owner and s.kind == skParam: discard
       elif contains(c.toBind, s.id): discard
       elif templToExpand(s):
-        return semPatternBody(c, semTemplateExpr(c.c, n, s, {efNoSemCheck}))
+        return semPatternBody(c, semTemplateExpr(c.c, n, n, s, {efNoSemCheck}))
 
     if n.kind == nkInfix and (let id = considerQuotedIdent(c.c, n[0]); id != nil):
       # we interpret `*` and `|` only as pattern operators if they occur in

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -1655,7 +1655,7 @@ proc applyTypeSectionPragmas(c: PContext; pragmas, operand: PNode): PNode =
             let m = r[0].sym
             case m.kind
             of skMacro: return semMacroExpr(c, r, r, m, {efNoSemCheck})
-            of skTemplate: return semTemplateExpr(c, r, m, {efNoSemCheck})
+            of skTemplate: return semTemplateExpr(c, r, r, m, {efNoSemCheck})
             else: doAssert(false, "cannot happen")
 
 proc semProcTypeWithScope(c: PContext, n: PNode,

--- a/tests/errmsgs/tdont_show_system.nim
+++ b/tests/errmsgs/tdont_show_system.nim
@@ -1,5 +1,5 @@
 discard """
-  errormsg: "expression 'true' is of type 'bool' and has to be used (or discarded)"
+  errormsg: "expression 'true notin {false}' is of type 'bool' and has to be used (or discarded)"
   line: 13
   file: "tdont_show_system.nim"
 """

--- a/tests/errmsgs/tunexpanded_macros.nim
+++ b/tests/errmsgs/tunexpanded_macros.nim
@@ -1,0 +1,38 @@
+discard """
+  cmd: "nim check --hints:off $options $file"
+  action: "reject"
+  nimout:'''
+tunexpanded_macros.nim(19, 16) Error: type mismatch: got <int64> but expected 'float'
+tunexpanded_macros.nim(22, 40) Error: expression 'await doOtherThing()' has no type (or is ambiguous)
+tunexpanded_macros.nim(29, 23) Error: type mismatch: got <string> but expected 'float'
+tunexpanded_macros.nim(32, 29) Error: type mismatch: got <int> but expected 'string'
+tunexpanded_macros.nim(37, 22) Error: type mismatch: got <proc (): Future[system.void]{.gcsafe, locks: <unknown>.}> but expected 'proc (){.closure.}'
+'''
+"""
+## For ensuring templates/macros show unexpanded messages where it makes sense
+
+template doThing(a: int): untyped =
+  case a:
+  of 100: 300i64
+  of 200: 400i64
+  else: a
+var a: float = doThing(300)
+import std/asyncdispatch
+proc doOtherThing {.async.} = discard
+proc doThing {.async.} = discard await doOtherThing()
+
+import std/macros
+
+macro doStuff(a: untyped): untyped = a
+macro doOtherStuff(a: typedesc): untyped = newCall("default" , a)
+
+var b: float = doStuff("hello")
+discard doStuff("world")
+
+var c: string = doOtherStuff(int)
+
+
+proc someAsync: Future[void] {.async.} = discard
+
+var myProc: proc() = someAsync # Ensures we dont get a confusing `'async(proc())' expected`
+

--- a/tests/stdlib/tsugar.nim
+++ b/tests/stdlib/tsugar.nim
@@ -219,7 +219,7 @@ proc mainProc() =
   block: # dumpToString
     template square(x): untyped = x * x
     let x = 10
-    doAssert dumpToString(square(x)) == "square(x): x * x = 100"
+    doAssert dumpToString(square(x)) == "square(x): square(x) = 100"
     let s = dumpToString(doAssert 1+1 == 2)
     doAssert "failedAssertImpl" in s
     let s2 = dumpToString:


### PR DESCRIPTION
Adds a `expandedFrom` PNode to TNode which is used for rendering. Also adds `expandedFrom=` for macros to allow clearing or setting custom AST for macros.