### PR TITLE
Pass headers and body correctly to FetchOptions

### DIFF
--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -90,8 +90,9 @@ func newfetchOptions*(metod: HttpMethod; body: cstring;
     headers: Headers = newHeaders()): FetchOptions =
   ## Constructor for `FetchOptions`.
   result = FetchOptions(
-    body: body, mode: cstring($mode), credentials: cstring($credentials), cache: cstring($cache), referrerPolicy: cstring($referrerPolicy),
-    keepalive: keepalive, redirect: cstring($redirect), referrer: referrer, integrity: integrity,
+    body: if metod notin {HttpHead, HttpGet}: body else nil, 
+    mode: cstring($mode), credentials: cstring($credentials), cache: cstring($cache), referrerPolicy: cstring($referrerPolicy),
+    keepalive: keepalive, redirect: cstring($redirect), referrer: referrer, integrity: integrity, headers: headers
     metod: (case metod
       of HttpHead:   "HEAD".cstring
       of HttpGet:    "GET".cstring

--- a/lib/std/jsfetch.nim
+++ b/lib/std/jsfetch.nim
@@ -90,9 +90,9 @@ func newfetchOptions*(metod: HttpMethod; body: cstring;
     headers: Headers = newHeaders()): FetchOptions =
   ## Constructor for `FetchOptions`.
   result = FetchOptions(
-    body: if metod notin {HttpHead, HttpGet}: body else nil, 
+    body: if metod notin {HttpHead, HttpGet}: body else: nil, 
     mode: cstring($mode), credentials: cstring($credentials), cache: cstring($cache), referrerPolicy: cstring($referrerPolicy),
-    keepalive: keepalive, redirect: cstring($redirect), referrer: referrer, integrity: integrity, headers: headers
+    keepalive: keepalive, redirect: cstring($redirect), referrer: referrer, integrity: integrity, headers: headers,
     metod: (case metod
       of HttpHead:   "HEAD".cstring
       of HttpGet:    "GET".cstring


### PR DESCRIPTION
Headers were not passed to `FetchOptions` during construction which made them `null` and lead to this error when trying to use the options `Uncaught (in promise) TypeError: Window.fetch: 'headers' member of RequestInit could not be converted to any of: sequence<sequence<ByteString>>, record<ByteString, ByteString>.`

This PR also stops body getting passed if the method is `GET` or `HEAD` (Same as httpclient)

Tested with
```nim
import std/[
  jsfetch,
  asyncjs,
  jsheaders,
  httpcore,
  jsffi
]

proc main() {.async.} =
  let headers = newHeaders()
  headers["Foo"] = "bar"
  let resp = await fetch("https://httpbin.org/get".cstring, newFetchOptions(
    HttpGet,
    "shouldn't be passed",
    fmCors,
    fcOmit,
    fchDefault,
    frpNoReferrer,
    false,
    headers = headers
  ))
  let j = await resp.json
  assert cast[cstring](j["headers"]["Foo"]) == "bar".cstring
discard main()
```