### PR TITLE
[cleanup] remove unnecessary procs in vm

### DIFF
--- a/compiler/vm.nim
+++ b/compiler/vm.nim
@@ -2252,7 +2252,6 @@ proc setupMacroParam(x: PNode, typ: PType): TFullReg =
   else:
     var n = x
     if n.kind in {nkHiddenSubConv, nkHiddenStdConv}: n = n[1]
-    n = n.canonValue
     n.flags.incl nfIsRef
     n.typ = x.typ
     result = TFullReg(kind: rkNode, node: n)

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -439,14 +439,11 @@ proc genAndOr(c: PCtx; n: PNode; opc: TOpcode; dest: var TDest) =
     c.gABC(n, opcAsgnInt, dest, tmp)
     freeTemp(c, tmp)
 
-proc canonValue*(n: PNode): PNode =
-  result = n
-
 proc rawGenLiteral(c: PCtx; n: PNode): int =
   result = c.constants.len
   #assert(n.kind != nkCall)
   n.flags.incl nfAllConst
-  c.constants.add n.canonValue
+  c.constants.add n
   internalAssert c.config, result < regBxMax
 
 proc sameConstant*(a, b: PNode): bool =
@@ -1857,7 +1854,7 @@ proc genVarSection(c: PCtx; n: PNode) =
           else:
             let sa = getNullValue(s.typ, a.info, c.config)
             #if s.ast.isNil: getNullValue(s.typ, a.info)
-            #else: canonValue(s.ast)
+            #else: s.ast
             assert sa.kind != nkCall
             c.globals.add(sa)
             s.position = c.globals.len


### PR DESCRIPTION
It was used to canon PNode:
```nim
proc canonValue*(n: PNode): PNode =
  if n.kind == nkExprColonExpr:
    result = n.sons[1]
  elif n.hasSubnodeWith(nkExprColonExpr):
    result = n.copyNode
    newSeq(result.sons, n.len)
    for i in 0.. <n.len:
      result.sons[i] = canonValue(n.sons[i])
  else:
    result = n
```
After https://github.com/nim-lang/Nim/commit/57cc8237f72b26cb56f8f250e382f8a0e091aea1; it just returns the original node.