### PR TITLE
Windows: enable nimRawSetjmp by default [backport]

### DIFF
--- a/config/config.nims
+++ b/config/config.nims
@@ -20,5 +20,10 @@ when defined(nimStrictMode):
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
 
+when defined(windows) and (NimMajor, NimMinor) > (1, 0):
+  # Avoid some rare stack corruption while using exceptions with a SEH-enabled
+  # toolchain: https://github.com/nim-lang/Nim/pull/19197
+  switch("define", "nimRawSetjmp")
+
 switch("define", "nimVersion:" & NimVersion)
 switch("define", "nimPreviewDotLikeOps")

--- a/config/config.nims
+++ b/config/config.nims
@@ -20,7 +20,7 @@ when defined(nimStrictMode):
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
 
-when defined(windows) and (NimMajor, NimMinor) > (1, 0):
+when defined(windows) and not defined(booting):
   # Avoid some rare stack corruption while using exceptions with a SEH-enabled
   # toolchain: https://github.com/nim-lang/Nim/pull/19197
   switch("define", "nimRawSetjmp")

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -116,6 +116,7 @@ elif defined(nimBuiltinSetjmp):
     proc c_builtin_setjmp(jmpb: ptr pointer): cint {.
       importc: "__builtin_setjmp", nodecl.}
     c_builtin_setjmp(unsafeAddr jmpb[0])
+
 elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
   when defined(windows):
     # No `_longjmp()` on Windows.
@@ -127,10 +128,16 @@ elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
     # prone to stack corruption during unwinding, so we disable that by setting
     # it to NULL.
     # More details: https://github.com/status-im/nimbus-eth2/issues/3121
+    when defined(nimHasStyleChecks):
+      {.push styleChecks: off.}
+
     proc c_setjmp*(jmpb: C_JmpBuf): cint =
       proc c_setjmp_win(jmpb: C_JmpBuf, ctx: pointer): cint {.
         header: "<setjmp.h>", importc: "_setjmp".}
       c_setjmp_win(jmpb, nil)
+
+    when defined(nimHasStyleChecks):
+      {.pop.}
   else:
     proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
       header: "<setjmp.h>", importc: "_longjmp".}


### PR DESCRIPTION
Following up on #19197. The default setjmp can randomly segfault on windows.

We've hit this bug again in our CI. In parallel, we've been running nimbus with this flag enabled since it was merged without issues