### PR TITLE
Fix nimRawSetjmp for VCC [backport: 1.2]

### DIFF
--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -118,7 +118,7 @@ elif defined(nimBuiltinSetjmp):
     c_builtin_setjmp(unsafeAddr jmpb[0])
 
 elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
-  when defined(windows):
+  when defined(windows) and not defined(vcc):
     # No `_longjmp()` on Windows.
     proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
       header: "<setjmp.h>", importc: "longjmp".}


### PR DESCRIPTION
`-d:nimRawSetjmp` was actually failing on VCC, but we didn't caught it until now (we only have a single environment using VCC)