### PR TITLE
Make imports/exports not be a dropdown in sidebar

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1470,11 +1470,21 @@ proc genSection(d: PDoc, kind: TSymKind, groupedToc = false) =
   else:
     for item in d.tocSimple[kind].sorted(cmp):
       d.toc2[kind].add item.content
+  let tocLink = getConfigVar(d.conf, "doc.section.toc_link") % [
+     "sectionID", $ord(kind), "sectionTitleID", $(ord(kind) + 50),
+     "sectionTitle", title
+  ]
 
-  d.toc[kind] = getConfigVar(d.conf, "doc.section.toc") % [
-      "sectionid", $ord(kind), "sectionTitle", title,
-      "sectionTitleID", $(ord(kind) + 50), "content", d.toc2[kind]]
-
+  if d.toc2[kind] != "":
+    # Turn it into a drop down section if the TOC entry contains 
+    # children
+    d.toc[kind] = getConfigVar(d.conf, "doc.section.toc") % [
+       "tocLink", tocLink, "content", d.toc2[kind]
+    ]
+  else:
+    # Just have the link
+    d.toc[kind] = tocLink
+    
 proc relLink(outDir: AbsoluteDir, destFile: AbsoluteFile, linkto: RelativeFile): string =
   $relativeTo(outDir / linkto, destFile.splitFile().dir, '/')
 

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1470,20 +1470,20 @@ proc genSection(d: PDoc, kind: TSymKind, groupedToc = false) =
   else:
     for item in d.tocSimple[kind].sorted(cmp):
       d.toc2[kind].add item.content
-  let tocLink = getConfigVar(d.conf, "doc.section.toc_link") % [
+
+  let sectionValues = @[
      "sectionID", $ord(kind), "sectionTitleID", $(ord(kind) + 50),
      "sectionTitle", title
   ]
 
   if d.toc2[kind] != "":
-    # Turn it into a drop down section if the TOC entry contains 
-    # children
-    d.toc[kind] = getConfigVar(d.conf, "doc.section.toc") % [
-       "tocLink", tocLink, "content", d.toc2[kind]
-    ]
+    # Use the dropdown version instead and store the children in the dropdown
+    d.toc[kind] = getConfigVar(d.conf, "doc.section.toc") % (sectionValues & @[
+       "content", d.toc2[kind]
+    ])
   else:
     # Just have the link
-    d.toc[kind] = tocLink
+    d.toc[kind] =  getConfigVar(d.conf, "doc.section.toc_item") % sectionValues
     
 proc relLink(outDir: AbsoluteDir, destFile: AbsoluteFile, linkto: RelativeFile): string =
   $relativeTo(outDir / linkto, destFile.splitFile().dir, '/')

--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1476,6 +1476,7 @@ proc genSection(d: PDoc, kind: TSymKind, groupedToc = false) =
      "sectionTitle", title
   ]
 
+  # Check if the toc has any children
   if d.toc2[kind] != "":
     # Use the dropdown version instead and store the children in the dropdown
     d.toc[kind] = getConfigVar(d.conf, "doc.section.toc") % (sectionValues & @[

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -16,10 +16,14 @@ doc.section = """
 </div>
 """
 
+doc.section.toc_link = """
+  <a class="reference reference-toplevel" href="#$sectionID" id="$sectionTitleID">$sectionTitle</a>
+"""
+
 doc.section.toc = """
 <li>
   <details open>
-    <summary><a class="reference reference-toplevel" href="#$sectionID" id="$sectionTitleID">$sectionTitle</a></summary>
+    <summary>$tocLink</summary>
     <ul class="simple simple-toc-section">
       $content
     </ul>

--- a/config/nimdoc.cfg
+++ b/config/nimdoc.cfg
@@ -16,14 +16,18 @@ doc.section = """
 </div>
 """
 
-doc.section.toc_link = """
+# Just a single item in the TOC (e.g. imports, exports)
+doc.section.toc_item = """
+<li>
   <a class="reference reference-toplevel" href="#$sectionID" id="$sectionTitleID">$sectionTitle</a>
+</li>
 """
 
+# This is a section (e.g. procs, types) in the TOC which gets turned into a drop down
 doc.section.toc = """
 <li>
   <details open>
-    <summary>$tocLink</summary>
+    <summary><a class="reference reference-toplevel" href="#$sectionID" id="$sectionTitleID">$sectionTitle</a></summary>
     <ul class="simple simple-toc-section">
       $content
     </ul>

--- a/nimdoc/testproject/expected/testproject.html
+++ b/nimdoc/testproject/expected/testproject.html
@@ -52,12 +52,7 @@
     <div id="tocRoot"></div>
     <ul class="simple simple-toc" id="toc-list">
   <li>
-  <details open>
-    <summary><a class="reference reference-toplevel" href="#6" id="56">Imports</a></summary>
-    <ul class="simple simple-toc-section">
-      
-    </ul>
-  </details>
+  <a class="reference reference-toplevel" href="#6" id="56">Imports</a>
 </li>
 <li>
   <details open>


### PR DESCRIPTION
Makes `Imports` and `Exports` sections not be a dropdown anymore
![image](https://user-images.githubusercontent.com/19339842/174465186-0eac7832-8176-4610-a2d7-3311b225b71c.png)
[Example here](https://venerable-smakager-f8d844.netlify.app/test.html)