### PR TITLE
nimRawSetJmp default on Win: light refactoring [backport]

### DIFF
--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -632,8 +632,9 @@ proc isDefined*(conf: ConfigRef; symbol: string): bool =
     of "cpu32": result = CPU[conf.target.targetCPU].bit == 32
     of "cpu64": result = CPU[conf.target.targetCPU].bit == 64
     of "nimrawsetjmp":
+      # faster on BSDs, prevents stack corruption on Windows: https://github.com/nim-lang/Nim/pull/19197
       result = conf.target.targetOS in {osSolaris, osNetbsd, osFreebsd, osOpenbsd,
-                            osDragonfly, osMacosx}
+                            osDragonfly, osMacosx, osWindows}
     else: discard
 
 template quitOrRaise*(conf: ConfigRef, msg = "") =

--- a/config/config.nims
+++ b/config/config.nims
@@ -20,10 +20,5 @@ when defined(nimStrictMode):
     switch("hintAsError", "ConvFromXtoItselfNotNeeded")
     # future work: XDeclaredButNotUsed
 
-when defined(windows) and not defined(booting):
-  # Avoid some rare stack corruption while using exceptions with a SEH-enabled
-  # toolchain: https://github.com/nim-lang/Nim/pull/19197
-  switch("define", "nimRawSetjmp")
-
 switch("define", "nimVersion:" & NimVersion)
 switch("define", "nimPreviewDotLikeOps")

--- a/doc/nimc.rst
+++ b/doc/nimc.rst
@@ -170,12 +170,13 @@ Name                             Description
 ==========================       ============================================
 nimStdSetjmp                     Use the standard `setjmp()/longjmp()` library
                                  functions for setjmp-based exceptions. This is
-                                 the default on most platforms.
+                                 the default on Linux.
 nimSigSetjmp                     Use `sigsetjmp()/siglongjmp()` for setjmp-based exceptions.
 nimRawSetjmp                     Use `_setjmp()/_longjmp()` on POSIX and `_setjmp()/longjmp()`
                                  on Windows, for setjmp-based exceptions. It's the default on
                                  BSDs and BSD-like platforms, where it's significantly faster
-                                 than the standard functions.
+                                 than the standard functions, and on Windows, where it prevents
+                                 some rare stack corruption with a SEH-enabled toolchain.
 nimBuiltinSetjmp                 Use `__builtin_setjmp()/__builtin_longjmp()` for setjmp-based
                                  exceptions. This will not work if an exception is being thrown
                                  and caught inside the same procedure. Useful for benchmarking.

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -95,8 +95,6 @@ when defined(macosx):
 elif defined(haiku):
   const SIGBUS* = cint(30)
 
-# "nimRawSetjmp" is defined by default for certain platforms, so we need the
-# "nimStdSetjmp" escape hatch with it.
 when defined(nimSigSetjmp):
   proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
     header: "<setjmp.h>", importc: "siglongjmp".}
@@ -116,8 +114,10 @@ elif defined(nimBuiltinSetjmp):
     proc c_builtin_setjmp(jmpb: ptr pointer): cint {.
       importc: "__builtin_setjmp", nodecl.}
     c_builtin_setjmp(unsafeAddr jmpb[0])
-
 elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
+  # "nimRawSetjmp" is defined by default for certain platforms, so we need the
+  # "nimStdSetjmp" escape hatch with it.
+
   when defined(windows) and not defined(vcc):
     # No `_longjmp()` on Windows.
     proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.


### PR DESCRIPTION
(small refactor of https://github.com/nim-lang/Nim/pull/19891)

Default Windows setting moved to `isDefined()` in "compiler/options.nim" because that's where it's already enabled by default for BSDs.

Documentation updated and a comment moved closer to the relevant code.