### PR TITLE
Fix nested finally handling in closureiters [backport]

### DIFF
--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -878,7 +878,7 @@ proc transformReturnsInTry(ctx: var Ctx, n: PNode): PNode =
     discard
   of nkTryStmt:
     if n.hasYields:
-      # the inner try will handle theses transformations
+      # the inner try will handle these transformations
       discard
     else:
       for i in 0..<n.len:

--- a/compiler/closureiters.nim
+++ b/compiler/closureiters.nim
@@ -832,8 +832,8 @@ proc newEndFinallyNode(ctx: var Ctx, info: TLineInfo): PNode =
           newSymNode(getClosureIterResult(ctx.g, ctx.fn, ctx.idgen), info),
           ctx.newTmpResultAccess())
 
-        let retrn = newTree(nkReturnStmt, asgn)
-        newTree(nkIfStmt, branch, newTree(nkElse, retrn))
+        let returnStmt = newTree(nkReturnStmt, asgn)
+        newTree(nkIfStmt, branch, newTree(nkElse, returnStmt))
     else:
       # the others just bubble up
       newTree(nkIfStmt, branch)

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -289,13 +289,15 @@ block:
   # try yield -> try
   iterator p1: int {.closure.} =
     try:
-     yield 0
-     try:
-       return
-     finally:
-       echo "nested finally"
+      yield 0
+      try:
+        return
+      finally:
+        echo "nested finally"
+      echo "shouldn't run"
     finally:
       echo "outer finally"
+    echo "shouldn't run"
 
   for _ in p1():
     discard
@@ -303,13 +305,15 @@ block:
   # try -> try yield
   iterator p2: int {.closure.} =
     try:
-     try:
-       yield 0
-       return
-     finally:
-       echo "nested finally"
+      try:
+        yield 0
+        return
+      finally:
+        echo "nested finally"
+      echo "shouldn't run"
     finally:
       echo "outer finally"
+    echo "shouldn't run"
 
   for _ in p2():
     discard
@@ -317,14 +321,16 @@ block:
   # try yield -> try yield
   iterator p3: int {.closure.} =
     try:
-     yield 0
-     try:
-       yield 0
-       return
-     finally:
-       echo "nested finally"
+      yield 0
+      try:
+        yield 0
+        return
+      finally:
+        echo "nested finally"
+      echo "shouldn't run"
     finally:
       echo "outer finally"
+    echo "shouldn't run"
 
   for _ in p3():
     discard
@@ -332,12 +338,14 @@ block:
   # try -> try
   iterator p4: int {.closure.} =
     try:
-     try:
-       return
-     finally:
-       echo "nested finally"
+      try:
+        return
+      finally:
+        echo "nested finally"
+      echo "shouldn't run"
     finally:
       echo "outer finally"
+    echo "shouldn't run"
 
   for _ in p4():
     discard

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -300,7 +300,7 @@ block:
   for _ in p1():
     discard
 
-  # try in try yield
+  # try -> try yield
   iterator p2: int {.closure.} =
     try:
      try:
@@ -314,7 +314,7 @@ block:
   for _ in p2():
     discard
 
-  # try yield in try yield
+  # try yield -> try yield
   iterator p3: int {.closure.} =
     try:
      yield 0
@@ -329,7 +329,7 @@ block:
   for _ in p3():
     discard
 
-  # try in try
+  # try -> try
   iterator p4: int {.closure.} =
     try:
      try:

--- a/tests/iter/titer_issues.nim
+++ b/tests/iter/titer_issues.nim
@@ -29,6 +29,14 @@ end
 9018
 @[1, 2]
 @[1, 2, 3]
+nested finally
+outer finally
+nested finally
+outer finally
+nested finally
+outer finally
+nested finally
+outer finally
 '''
 """
 
@@ -274,3 +282,62 @@ iterator cc() {.closure.} =
             break
 
 var a2 = cc
+
+block:
+  # bug #19911 (return in nested try)
+
+  # try yield -> try
+  iterator p1: int {.closure.} =
+    try:
+     yield 0
+     try:
+       return
+     finally:
+       echo "nested finally"
+    finally:
+      echo "outer finally"
+
+  for _ in p1():
+    discard
+
+  # try in try yield
+  iterator p2: int {.closure.} =
+    try:
+     try:
+       yield 0
+       return
+     finally:
+       echo "nested finally"
+    finally:
+      echo "outer finally"
+
+  for _ in p2():
+    discard
+
+  # try yield in try yield
+  iterator p3: int {.closure.} =
+    try:
+     yield 0
+     try:
+       yield 0
+       return
+     finally:
+       echo "nested finally"
+    finally:
+      echo "outer finally"
+
+  for _ in p3():
+    discard
+
+  # try in try
+  iterator p4: int {.closure.} =
+    try:
+     try:
+       return
+     finally:
+       echo "nested finally"
+    finally:
+      echo "outer finally"
+
+  for _ in p4():
+    discard


### PR DESCRIPTION
closes #19911

There was two issues:
- The outer `try` was rewriting the `return` of the inner `try` before the inner `try` had a chance to do it (swallowed the inner finally)
- The `unrollFinally` was returning before giving a chance to the outer `finally` to run (swallowed the outer finally)