### PR TITLE
fix #16253; SIGSEGV in arc.nim calling eqcopy for combination of ref objects, noInit,

### DIFF
--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -1067,6 +1067,8 @@ proc genProcAux(m: BModule, prc: PSym) =
       if sfNoInit in prc.flags and p.config.selectedGC notin {gcArc, gcOrc}: discard
       elif allPathsAsgnResult(procBody) == InitSkippable: discard
       else:
+        if sfNoInit in prc.flags and p.config.selectedGC in {gcArc, gcOrc}:
+          message(m.config, resNode.info, warnNoInitIgnored, "")
         resetLoc(p, res.loc)
       if skipTypes(res.typ, abstractInst).kind == tyArray:
         #incl(res.loc.flags, lfIndirect)

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -474,7 +474,7 @@ proc constructLoc(p: BProc, loc: var TLoc, isTemp = false) =
     genObjectInit(p, cpsStmts, loc.t, loc, constructObj)
 
 proc initLocalVar(p: BProc, v: PSym, immediateAsgn: bool) =
-  if sfNoInit notin v.flags:
+  if sfNoInit notin v.flags or p.config.selectedGC in {gcArc, gcOrc}:
     # we know it is a local variable and thus on the stack!
     # If ``not immediateAsgn`` it is not initialized in a binding like
     # ``var v = X`` and thus we need to init it.

--- a/compiler/cgen.nim
+++ b/compiler/cgen.nim
@@ -474,7 +474,7 @@ proc constructLoc(p: BProc, loc: var TLoc, isTemp = false) =
     genObjectInit(p, cpsStmts, loc.t, loc, constructObj)
 
 proc initLocalVar(p: BProc, v: PSym, immediateAsgn: bool) =
-  if sfNoInit notin v.flags or p.config.selectedGC in {gcArc, gcOrc}:
+  if sfNoInit notin v.flags:
     # we know it is a local variable and thus on the stack!
     # If ``not immediateAsgn`` it is not initialized in a binding like
     # ``var v = X`` and thus we need to init it.
@@ -1064,7 +1064,7 @@ proc genProcAux(m: BModule, prc: PSym) =
       # the 'unsureAsgn' is a nop. If it points to a global variable the
       # global is either 'nil' or points to valid memory and so the RC operation
       # succeeds without touching not-initialized memory.
-      if sfNoInit in prc.flags: discard
+      if sfNoInit in prc.flags and p.config.selectedGC notin {gcArc, gcOrc}: discard
       elif allPathsAsgnResult(procBody) == InitSkippable: discard
       else:
         resetLoc(p, res.loc)

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -78,6 +78,7 @@ type
     warnAnyEnumConv = "AnyEnumConv",
     warnHoleEnumConv = "HoleEnumConv",
     warnCstringConv = "CStringConv",
+    warnNoInitIgnored = "NoInitIgnored"
     warnEffect = "Effect",
     warnUser = "User",
     # hints
@@ -170,6 +171,7 @@ const
     warnAnyEnumConv: "$1",
     warnHoleEnumConv: "$1",
     warnCstringConv: "$1",
+    warnNoInitIgnored: "noInit is ignored",
     warnEffect: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -171,7 +171,7 @@ const
     warnAnyEnumConv: "$1",
     warnHoleEnumConv: "$1",
     warnCstringConv: "$1",
-    warnNoInitIgnored: "noInit is ignored",
+    warnNoInitIgnored: "noinit pragma is ignored",
     warnEffect: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",

--- a/tests/arc/t16253.nim
+++ b/tests/arc/t16253.nim
@@ -1,0 +1,58 @@
+discard """
+  matrix: "--gc:arc"
+"""
+
+import sequtils
+
+type
+  CpuStorage*[T] = ref CpuStorageObj[T]
+  CpuStorageObj[T] = object
+    size*: int
+    raw_buffer*: ptr UncheckedArray[T]
+  Tensor[T] = object
+    buf*: CpuStorage[T]
+
+proc `=destroy`[T](s: var CpuStorageObj[T]) =
+  s.raw_buffer.deallocShared()
+  s.size = 0
+  s.raw_buffer = nil
+
+proc `=`[T](a: var CpuStorageObj[T]; b: CpuStorageObj[T]) {.error.}
+
+proc allocCpuStorage[T](s: var CpuStorage[T], size: int) =
+  new(s)
+  s.raw_buffer = cast[ptr UncheckedArray[T]](allocShared0(sizeof(T) * size))
+  s.size = size
+
+proc newTensor[T](size: int): Tensor[T] =
+  allocCpuStorage(result.buf, size)
+
+proc `[]`[T](t: Tensor[T], idx: int): T = t.buf.raw_buffer[idx]
+proc `[]=`[T](t: Tensor[T], idx: int, val: T) = t.buf.raw_buffer[idx] = val
+func size[T](t: Tensor[T]): int = t.buf.size
+
+proc toTensor[T](s: seq[T]): Tensor[T] =
+  result = newTensor[T](s.len)
+  for i, x in s:
+    result[i] = x
+
+type
+  Column* = ref object # works if normal object
+    fCol: Tensor[float]
+
+proc asType*(t: Tensor[float]): Tensor[float] {.noInit.} = # works if `noInit` removed
+  result = t
+
+proc toColumn*(t: Tensor[float]): Column =
+  result = Column(fCol: t.asType())
+  # works with regular contruction of ref object:
+  #result = new Column
+  #result.fCol = t.asType()
+
+proc theBug =
+  # replacing toSeq.mapIt by a for loop makes it go away
+  # broken starting from `32252` on my machine, toSeq(0 .. 32251).mapIt(it.float).toTensor() works
+  let occ = toSeq(0 .. 32252).mapIt(it.float).toTensor()
+  let c = toColumn occ
+
+theBug()


### PR DESCRIPTION
For a start and a naive fix, when nrvo procs are marked with `noInit`, the compiler will zero memoryed the `result` symbols for arc/orc. The alternative solution is to prevent nrvo for procs marked with `noInit`. I'm struggling with thinking of a better solution.  

fixes #16253