### PR TITLE
Enable nim-lang to build correctly on illumos-based systems

### DIFF
--- a/tools/niminst/buildsh.nimf
+++ b/tools/niminst/buildsh.nimf
@@ -164,7 +164,7 @@ esac
 
 case $ucpu in
   *i386* | *i486* | *i586* | *i686* | *bepc* | *i86pc* )
-    if [ "$isOpenIndiana" = "yes" ] ; then
+    if [ "$isOpenIndiana" = "yes" ] || [ `uname -o` == "illumos" ] ; then
       mycpu="amd64"
     else
       mycpu="i386"


### PR DESCRIPTION
This is a very small fix, which should be quite low risk, and it is enough to let nim build correctly on a modern illumos system. I am pretty certain this is a very stable method as well. Hopefully you will be up for adopting this PR.

Thanks!