### PR TITLE
Fixing `nimRawSetJmp` for vcc and clangcl on Windows

### DIFF
--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1367,7 +1367,7 @@ proc genTrySetjmp(p: BProc, t: PNode, d: var TLoc) =
       linefmt(p, cpsStmts, "$1.status = __builtin_setjmp($1.context);$n", [safePoint])
     elif isDefined(p.config, "nimRawSetjmp"):
       if isDefined(p.config, "mswindows"):
-        if isDefined(p.config, "vcc"):
+        if isDefined(p.config, "vcc") or isDefined(p.config, "clangcl"):
           # For the vcc compiler, use `setjmp()` with one argument.
           # See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setjmp?view=msvc-170
           linefmt(p, cpsStmts, "$1.status = setjmp($1.context);$n", [safePoint])        

--- a/compiler/ccgstmts.nim
+++ b/compiler/ccgstmts.nim
@@ -1367,13 +1367,18 @@ proc genTrySetjmp(p: BProc, t: PNode, d: var TLoc) =
       linefmt(p, cpsStmts, "$1.status = __builtin_setjmp($1.context);$n", [safePoint])
     elif isDefined(p.config, "nimRawSetjmp"):
       if isDefined(p.config, "mswindows"):
-        # The Windows `_setjmp()` takes two arguments, with the second being an
-        # undocumented buffer used by the SEH mechanism for stack unwinding.
-        # Mingw-w64 has been trying to get it right for years, but it's still
-        # prone to stack corruption during unwinding, so we disable that by setting
-        # it to NULL.
-        # More details: https://github.com/status-im/nimbus-eth2/issues/3121
-        linefmt(p, cpsStmts, "$1.status = _setjmp($1.context, 0);$n", [safePoint])
+        if isDefined(p.config, "vcc"):
+          # For the vcc compiler, use `setjmp()` with one argument.
+          # See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setjmp?view=msvc-170
+          linefmt(p, cpsStmts, "$1.status = setjmp($1.context);$n", [safePoint])        
+        else:
+          # The Windows `_setjmp()` takes two arguments, with the second being an
+          # undocumented buffer used by the SEH mechanism for stack unwinding.
+          # Mingw-w64 has been trying to get it right for years, but it's still
+          # prone to stack corruption during unwinding, so we disable that by setting
+          # it to NULL.
+          # More details: https://github.com/status-im/nimbus-eth2/issues/3121
+          linefmt(p, cpsStmts, "$1.status = _setjmp($1.context, 0);$n", [safePoint])
       else:
         linefmt(p, cpsStmts, "$1.status = _setjmp($1.context);$n", [safePoint])
     else:

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -139,10 +139,14 @@ elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
     when defined(nimHasStyleChecks):
       {.pop.}
   else:
+    # For the vcc compiler, use `longjmp()`
+    # See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/longjmp?view=msvc-170
     proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
-      header: "<setjmp.h>", importc: "_longjmp".}
+      header: "<setjmp.h>", importc: "longjmp".}
+    # For the vcc compiler, use `setjmp()` with one argument.
+    # See https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setjmp?view=msvc-170
     proc c_setjmp*(jmpb: C_JmpBuf): cint {.
-      header: "<setjmp.h>", importc: "_setjmp".}
+      header: "<setjmp.h>", importc: "setjmp".}
 else:
   proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
     header: "<setjmp.h>", importc: "longjmp".}

--- a/lib/system/ansi_c.nim
+++ b/lib/system/ansi_c.nim
@@ -122,7 +122,7 @@ elif defined(nimRawSetjmp) and not defined(nimStdSetjmp):
     # No `_longjmp()` on Windows.
     proc c_longjmp*(jmpb: C_JmpBuf, retval: cint) {.
       header: "<setjmp.h>", importc: "longjmp".}
-    when defined(vcc):
+    when defined(vcc) or defined(clangcl):
       proc c_setjmp*(jmpb: C_JmpBuf): cint {.
         header: "<setjmp.h>", importc: "setjmp".}
     else:


### PR DESCRIPTION
partial fix of #19957

The first part of the error happened because the Nim compiler, to generate `try`, used `_setjmp(arg1, arg2)` for any compiler (gcc, clang, vcc...) on Windows:
```
nim c --cc:vcc -f test
Hint: used config file 'D:\Nim\config\nim.cfg' [Conf]
Hint: used config file 'D:\Nim\config\config.nims' [Conf]
.........................................................
CC: D:/Nim/lib/std/private/digitsutils.nim
CC: D:/Nim/lib/system/dollars.nim
CC: D:/Nim/lib/std/syncio.nim
CC: D:/Nim/lib/system.nim
CC: test.nim
@mtest.nim.c
@mD@c@sNim@slib@sstd@ssyncio.nim.c
@mD@c@sNim@slib@sstd@sprivate@sdigitsutils.nim.c
@mD@c@sNim@slib@ssystem@sdollars.nim.c
@mD@c@sNim@slib@ssystem.nim.c
C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@ssystem.nim.c(4559): warning C4020: '_setjmp': muitos parâmetros reais
C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@ssystem.nim.c(4559): error C2167: '_setjmp': muitos parâmetros reais para função intrínseca
Error: execution of an external compiler program 'vccexe.exe /c --platform:amd64 /nologo   /ID:\Nim\lib /IC:\Users\josep\Desktop /nologo /FoC:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@ssystem.nim.c.obj C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@ssystem.nim.c' failed with exit code: 2
```

The second part of the error was because longjmp was being imported as `_longjmp()` for vcc:
```
nim c --cc:vcc -f test
Hint: used config file 'D:\Nim\config\nim.cfg' [Conf]
Hint: used config file 'D:\Nim\config\config.nims' [Conf]
.........................................................
CC: D:/Nim/lib/std/private/digitsutils.nim
CC: D:/Nim/lib/system/dollars.nim
CC: D:/Nim/lib/std/syncio.nim
CC: D:/Nim/lib/system.nim
CC: test.nim
@mD@c@sNim@slib@ssystem@sdollars.nim.c
@mtest.nim.c
@mD@c@sNim@slib@sstd@ssyncio.nim.c
@mD@c@sNim@slib@ssystem.nim.c
@mD@c@sNim@slib@sstd@sprivate@sdigitsutils.nim.c
Hint:  [Link]
@mD@c@sNim@slib@ssystem.nim.c.obj : error LNK2019: símbolo externo não resolvido, _longjmp, referenciado na função raiseExceptionAux__system_2906
C:\Users\josep\Desktop\test.exe : fatal error LNK1120: 1 externo não resolvidos
Error: execution of an external program failed: 'vccexe.exe  --platform:amd64 /FeC:\Users\josep\Desktop\test.exe  C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@sstd@sprivate@sdigitsutils.nim.c.obj C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@ssystem@sdollars.nim.c.obj C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@sstd@ssyncio.nim.c.obj C:\Users\josep\nimcache\test_d\@mD@c@sNim@slib@ssystem.nim.c.obj C:\Users\josep\nimcache\test_d\@mtest.nim.c.obj  /nologo    '
```