### PR TITLE
Add depfile option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -117,3 +117,6 @@ becomes an alias for `addr`.
 
 - There is a new switch `--nimMainPrefix:prefix` to influence the `NimMain` that the
   compiler produces. This is particularly useful for generating static libraries.
+
+- There is a new switch `--depfile:path` to write a GCC-style depfile that can be used with
+  various build systems.

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -623,6 +623,9 @@ proc processSwitch*(switch, arg: string, pass: TCmdLinePass, info: TLineInfo;
   of "outdir":
     expectArg(conf, switch, arg, pass, info)
     conf.outDir = processPath(conf, arg, info, notRelativeToProj=true)
+  of "depfile":
+    expectArg(conf, switch, arg, pass, info)
+    conf.depfile = processPath(conf, arg, info, notRelativeToProj=true).AbsoluteFile
   of "usenimcache":
     processOnOffSwitchG(conf, {optUseNimcache}, arg, pass, info)
   of "docseesrcurl":

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -352,6 +352,7 @@ type
     lazyPaths*: seq[AbsoluteDir]
     outFile*: RelativeFile
     outDir*: AbsoluteDir
+    depfile*: AbsoluteFile
     jsonBuildFile*: AbsoluteFile
     prefixDir*, libpath*, nimcacheDir*: AbsoluteDir
     nimStdlibVersion*: NimVer

--- a/doc/advopt.txt
+++ b/doc/advopt.txt
@@ -33,6 +33,7 @@ Advanced options:
                             find the definition and all usages of a symbol
   -o:FILE, --out:FILE       set the output filename
   --outdir:DIR              set the path where the output file will be written
+  --depfile:FILE            write target dependencies in GCC format
   --usenimcache             will use `outdir=$$nimcache`, whichever it resolves
                             to after all options have been processed
   --stdout:on|off           output to stdout


### PR DESCRIPTION
It is used to produce a GCC-style depfile from target's dependencies.
I have no idea how to write tests since the implementation uses absolute paths.

Closes: https://github.com/nim-lang/RFCs/issues/463