### PR TITLE
Fixes return values of execCmd on macos

### DIFF
--- a/lib/pure/osproc.nim
+++ b/lib/pure/osproc.nim
@@ -1523,7 +1523,7 @@ elif not defined(useNimRtl):
                                      header: "<stdlib.h>".}
 
   proc execCmd(command: string): int =
-    when defined(linux):
+    when defined(posix):
       let tmp = csystem(command)
       result = if tmp == -1: tmp else: exitStatusLikeShell(tmp)
     else:

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -115,6 +115,12 @@ else: # main driver
     runTest("c_exit2_139", 139)
     runTest("quit_139", 139)
 
+  block execCmdTest:
+    doAssert execCmd("exit 0") == 0
+    doAssert execCmd("exit 1") == 1
+    doAssert execCmd("exit 2") == 2
+    doAssert execCmd("exit 42") == 42
+
   import std/streams
 
   block execProcessTest:

--- a/tests/stdlib/tosproc.nim
+++ b/tests/stdlib/tosproc.nim
@@ -29,6 +29,12 @@ when defined(case_testfile): # compiled test file for child process
     case arg
     of "exit_0":
       if true: quit(0)
+    of "exit_1":
+      if true: quit(1)
+    of "exit_2":
+      if true: quit(2)
+    of "exit_42":
+      if true: quit(42)
     of "exitnow_139":
       if true: exitnow(139)
     of "c_exit2_139":
@@ -116,10 +122,11 @@ else: # main driver
     runTest("quit_139", 139)
 
   block execCmdTest:
-    doAssert execCmd("exit 0") == 0
-    doAssert execCmd("exit 1") == 1
-    doAssert execCmd("exit 2") == 2
-    doAssert execCmd("exit 42") == 42
+    let output = compileNimProg("-d:release -d:case_testfile", "D20220705T221100")
+    doAssert execCmd(output & " exit_0") == 0
+    doAssert execCmd(output & " exit_1") == 1
+    doAssert execCmd(output & " exit_2") == 2
+    doAssert execCmd(output & " exit_42") == 42
 
   import std/streams
 


### PR DESCRIPTION
Issue details here: https://github.com/nim-lang/Nim/issues/19962#issue-1292027738