### PR TITLE
Fixes Compilation error with --app:lib

### DIFF
--- a/lib/pure/os.nim
+++ b/lib/pure/os.nim
@@ -2939,7 +2939,7 @@ elif defined(genode):
 
   proc paramCount*(): int =
     raise newException(OSError, "paramCount is not implemented on Genode")
-elif weirdTarget:
+elif weirdTarget or (defined(posix) and appType == "lib"):
   proc paramStr*(i: int): string {.tags: [ReadIOEffect].} =
     raise newException(OSError, "paramStr is not implemented on current platform")
 


### PR DESCRIPTION
Fixes Compilation error with --app:lib  when a module tries to pull os.paramStr on posix by throwing a runtime exception instead. 
More details here: #19964