### PR TITLE
reduce orc booting compiler memory usage by ~ 200 mb (~ 400 mb in release mode)

### DIFF
--- a/compiler/injectdestructors.nim
+++ b/compiler/injectdestructors.nim
@@ -81,10 +81,12 @@ import sets, hashes
 proc hash(n: PNode): Hash = hash(cast[pointer](n))
 
 proc aliasesCached(cache: var Table[(PNode, PNode), AliasKind], obj, field: PNode): AliasKind =
-  let key = (obj, field)
-  if not cache.hasKey(key):
-    cache[key] = aliases(obj, field)
-  cache[key]
+  # let key = (obj, field)
+  # if not cache.hasKey(key):
+  #   cache[key] = aliases(obj, field)
+  # cache[key]
+
+  aliases(obj, field)
 
 type
   State = ref object


### PR DESCRIPTION
I don't know. It seems that the big loop in vm.nim comsumes lots of memory, no cache alias reduces it. Let's begin our experiement.