### PR TITLE
Correct emscripten shortcoming

### DIFF
--- a/lib/pure/asyncdispatch.nim
+++ b/lib/pure/asyncdispatch.nim
@@ -1983,6 +1983,8 @@ when defined(linux) or defined(windows) or defined(macosx) or defined(bsd) or
       result = 16_700_000
     elif defined(zephyr) or defined(freertos):
       result = FD_MAX
+    elif defined(emscripten):
+      result = 1024
     else:
       var fdLim: RLimit
       if getrlimit(RLIMIT_NOFILE, fdLim) < 0:

--- a/lib/pure/selectors.nim
+++ b/lib/pure/selectors.nim
@@ -333,6 +333,8 @@ else:
         16_700_000
       elif defined(zephyr) or defined(freertos):
         FD_MAX
+      elif defined(emscripten):
+        1024
       else:
         var fdLim: RLimit
         var res = int(getrlimit(RLIMIT_NOFILE, fdLim))


### PR DESCRIPTION
emscripten reports infinity for every getrlimit() requests, which does
not work when requesting the max number of file descriptors (prlimit64
syscall). This patch provides a default of 1024 which is common on Linux.

This is used in particular in ioselectors_poll.nim and te invalid value
makes it crash.