### PR TITLE
defines the `gcRefc` symbol which allows writing specific code for refc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -100,6 +100,8 @@ becomes an alias for `addr`.
   for the right-hand side of type definitions in type sections. Previously
   they would error with "invalid indentation".
 
+- Defines the `gcRefc` symbol which allows writting specific code for refc.
+
 ## Compiler changes
 
 - `nim` can now compile version 1.4.0 as follows: `nim c --lib:lib --stylecheck:off compiler/nim`,

--- a/changelog.md
+++ b/changelog.md
@@ -100,7 +100,7 @@ becomes an alias for `addr`.
   for the right-hand side of type definitions in type sections. Previously
   they would error with "invalid indentation".
 
-- Defines the `gcRefc` symbol which allows writting specific code for refc.
+- Defines the `gcRefc` symbol which allows writting specific code for the refc GC.
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -102,7 +102,7 @@ becomes an alias for `addr`.
   for the right-hand side of type definitions in type sections. Previously
   they would error with "invalid indentation".
 
-- Defines the `gcRefc` symbol which allows writting specific code for the refc GC.
+- Defines the `gcRefc` symbol which allows writing specific code for the refc GC.
 
 ## Compiler changes
 

--- a/compiler/commands.nim
+++ b/compiler/commands.nim
@@ -539,6 +539,7 @@ proc processMemoryManagementOption(switch, arg: string, pass: TCmdLinePass,
       incl conf.globalOptions, optTlsEmulation # Boehm GC doesn't scan the real TLS
     of "refc":
       unregisterArcOrc(conf)
+      defineSymbol(conf.symbols, "gcrefc")
       conf.selectedGC = gcRefc
     of "markandsweep":
       unregisterArcOrc(conf)

--- a/tests/stdlib/tstrutils2.nim
+++ b/tests/stdlib/tstrutils2.nim
@@ -8,7 +8,7 @@ block: # setLen
   var a = "abc"
   a.setLen 0
   a.setLen 3, isInit = false
-  when defined(gcRefc):
+  when defined(gcRefc): # bug #19763
     doAssert a[1] == 'b'
   a.setLen 0
   a.setLen 3, isInit = true

--- a/tests/stdlib/tstrutils2.nim
+++ b/tests/stdlib/tstrutils2.nim
@@ -1,10 +1,15 @@
+discard """
+  matrix: "--gc:refc; --gc:orc"
+"""
+
 import "$lib/.." / compiler/strutils2
 
 block: # setLen
   var a = "abc"
   a.setLen 0
   a.setLen 3, isInit = false
-  doAssert a[1] == 'b'
+  when defined(gcRefc):
+    doAssert a[1] == 'b'
   a.setLen 0
   a.setLen 3, isInit = true
   doAssert a[1] == '\0'


### PR DESCRIPTION
After the Nim compiler defaults to Orc, users need a way to write specific code for refc.