### PR TITLE
allow dots in defined()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -102,7 +102,8 @@ becomes an alias for `addr`.
   for the right-hand side of type definitions in type sections. Previously
   they would error with "invalid indentation".
 - `defined` now accepts identifiers separated by dots, i.e. `defined(a.b.c)`.
-  In the command line, this is defined as `-d:a.b.c`.
+  In the command line, this is defined as `-d:a.b.c`. Older versions can
+  use accents as in ``defined(`a.b.c`)`` to access such defines.
 
 ## Compiler changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -101,6 +101,8 @@ becomes an alias for `addr`.
 - Full command syntax and block arguments i.e. `foo a, b: c` are now allowed
   for the right-hand side of type definitions in type sections. Previously
   they would error with "invalid indentation".
+- `defined` now accepts identifiers separated by dots, i.e. `defined(a.b.c)`.
+  In the command line, this is defined as `-d:a.b.c`.
 
 ## Compiler changes
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -1938,11 +1938,23 @@ proc semYield(c: PContext, n: PNode): PNode =
   elif c.p.owner.typ[0] != nil:
     localError(c.config, n.info, errGenerated, "yield statement must yield a value")
 
+proc considerQuotedIdentOrDot(c: PContext, n: PNode, origin: PNode = nil): PIdent =
+  if n.kind == nkDotExpr:
+    let a = considerQuotedIdentOrDot(c, n[0], origin).s
+    let b = considerQuotedIdentOrDot(c, n[1], origin).s
+    var s = newStringOfCap(a.len + b.len + 1)
+    s.add(a)
+    s.add('.')
+    s.add(b)
+    result = getIdent(c.cache, s)
+  else:
+    result = considerQuotedIdent(c, n, origin)
+
 proc semDefined(c: PContext, n: PNode): PNode =
   checkSonsLen(n, 2, c.config)
   # we replace this node by a 'true' or 'false' node:
   result = newIntNode(nkIntLit, 0)
-  result.intVal = ord isDefined(c.config, considerQuotedIdent(c, n[1], n).s)
+  result.intVal = ord isDefined(c.config, considerQuotedIdentOrDot(c, n[1], n).s)
   result.info = n.info
   result.typ = getSysType(c.graph, n.info, tyBool)
 

--- a/tests/misc/tdefine.nim
+++ b/tests/misc/tdefine.nim
@@ -1,6 +1,6 @@
 discard """
 joinable: false
-cmd: "nim c -d:booldef -d:booldef2=false -d:intdef=2 -d:strdef=foobar -r $file"
+cmd: "nim c -d:booldef -d:booldef2=false -d:intdef=2 -d:strdef=foobar -d:namespaced.define=false -d:double.namespaced.define -r $file"
 """
 
 const booldef {.booldefine.} = false
@@ -28,3 +28,18 @@ type T = object
         field2: int
     when strdef2 == "abc":
         field3: int
+
+doAssert not defined(booldef3)
+doAssert not defined(intdef2)
+doAssert not defined(strdef2)
+discard T(field1: 1, field2: 2, field3: 3)
+
+doAssert defined(namespaced.define)
+const `namespaced.define` {.booldefine.} = true
+doAssert not `namespaced.define`
+
+doAssert defined(double.namespaced.define)
+const `double.namespaced.define` {.booldefine.} = false
+doAssert `double.namespaced.define`
+
+doAssert not defined(namespaced.butnotdefined)


### PR DESCRIPTION
refs https://github.com/nim-lang/RFCs/issues/181

This is basically just a cosmetic change. You could always do ``defined(`a.b.c`)`` but directly allowing the dot syntax encourages the use of the namespace format.

Constants still need accents for these defines (``const `a.b.c` {.strdefine.}``, later used as `` `a.b.c` ``). https://github.com/nim-lang/RFCs/issues/181 mentions a `{.strdefine: "a.b.c".}` syntax but I can't implement this in a good way. We can also just have a `getDefine` magic/template like `getDefine(asyncBackend, default = "asyncdispatch")`.

This accounts for 90%+ of uses of defines. Other steps in implementing https://github.com/nim-lang/RFCs/issues/181 would be adding the alias syntax for the constant define pragmas, maybe restricting/automatically detecting the namespace part of defines.