### PR TITLE
fix #20012

### DIFF
--- a/compiler/extccomp.nim
+++ b/compiler/extccomp.nim
@@ -86,7 +86,7 @@ compiler gcc:
     linkLibCmd: " -l$1",
     debug: "",
     pic: "-fPIC",
-    asmStmtFrmt: "asm($1);$n",
+    asmStmtFrmt: "__asm__($1);$n",
     structStmtFmt: "$1 $3 $2 ", # struct|union [packed] $name
     produceAsm: gnuAsmListing,
     cppXsupport: "-std=gnu++14 -funsigned-char",

--- a/tests/compiler/tasm.nim
+++ b/tests/compiler/tasm.nim
@@ -1,0 +1,14 @@
+{.passC: "-std=c99".}
+
+block asmTest:
+  when defined(gcc):
+    let src = 41
+    var dst = 0
+
+    asm """
+      mov %1, %0\n\t
+      add $1, %0
+      : "=r" (`dst`)
+      : "r" (`src`)"""
+
+    doAssert dst == 42

--- a/tests/compiler/tasm.nim
+++ b/tests/compiler/tasm.nim
@@ -1,14 +1,15 @@
-{.passC: "-std=c99".}
+proc testAsm() =
+  let src = 41
+  var dst = 0
 
-block asmTest:
-  when defined(gcc):
-    let src = 41
-    var dst = 0
+  asm """
+    mov %1, %0\n\t
+    add $1, %0
+    : "=r" (`dst`)
+    : "r" (`src`)"""
 
-    asm """
-      mov %1, %0\n\t
-      add $1, %0
-      : "=r" (`dst`)
-      : "r" (`src`)"""
+  doAssert dst == 42
 
-    doAssert dst == 42
+when defined(gcc) or defined(clang) and not defined(cpp):
+  {.passc: "-std=c99".}
+  testAsm()


### PR DESCRIPTION
replaces `asm` with `__asm__` when compiling with gcc to satisfy `std=C99` compiler flag

Issue: https://github.com/nim-lang/Nim/issues/20012