### PR TITLE
Add sink and lent annotations to the critbits module

### DIFF
--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -368,7 +368,7 @@ iterator items*[T](c: CritBitTree[T]): string =
   ## Alias for `keys <#keys.i,CritBitTree[T]>`_.
   for x in leaves(c.root): yield x.key
 
-iterator pairs*[T](c: CritBitTree[T]): tuple[key: string, val: lent T] =
+iterator pairs*[T](c: CritBitTree[T]): tuple[key: string, val: T] =
   ## Yields all `(key, value)`-pairs of `c` in the lexicographical order of the
   ## corresponding keys.
   ##
@@ -445,7 +445,7 @@ iterator itemsWithPrefix*[T](c: CritBitTree[T], prefix: string): string =
   for x in leaves(top): yield x.key
 
 iterator pairsWithPrefix*[T](c: CritBitTree[T],
-                             prefix: string): tuple[key: string, val: lent T] =
+                             prefix: string): tuple[key: string, val: T] =
   ## Yields all (key, value)-pairs of `c` starting with `prefix`.
   ##
   ## **See also:**

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -197,7 +197,7 @@ proc missingOrExcl*[T](c: var CritBitTree[T], key: string): bool =
   discard exclImpl(c, key)
   result = c.count == oldCount
 
-proc containsOrIncl*[T](c: var CritBitTree[T], key: string, val: T): bool =
+proc containsOrIncl*[T](c: var CritBitTree[T], key: string, val: sink T): bool =
   ## Returns true if `c` contains the given `key`. If the key does not exist,
   ## `c[key] = val` is performed.
   ##
@@ -270,7 +270,7 @@ proc incl*(c: var CritBitTree[void], key: string) =
 
   discard rawInsert(c, key)
 
-proc incl*[T](c: var CritBitTree[T], key: string, val: T) =
+proc incl*[T](c: var CritBitTree[T], key: string, val: sink T) =
   ## Inserts `key` with value `val` into `c`.
   ##
   ## **See also:**
@@ -284,7 +284,7 @@ proc incl*[T](c: var CritBitTree[T], key: string, val: T) =
   var n = rawInsert(c, key)
   n.val = val
 
-proc `[]=`*[T](c: var CritBitTree[T], key: string, val: T) =
+proc `[]=`*[T](c: var CritBitTree[T], key: string, val: sink T) =
   ## Alias for `incl <#incl,CritBitTree[T],string,T>`_.
   ##
   ## **See also:**
@@ -293,14 +293,14 @@ proc `[]=`*[T](c: var CritBitTree[T], key: string, val: T) =
   var n = rawInsert(c, key)
   n.val = val
 
-template get[T](c: CritBitTree[T], key: string): T =
+template get[T](c: CritBitTree[T], key: string): lent T =
   let n = rawGet(c, key)
   if n == nil:
     raise newException(KeyError, "key not found: " & key)
 
   n.val
 
-func `[]`*[T](c: CritBitTree[T], key: string): T {.inline.} =
+func `[]`*[T](c: CritBitTree[T], key: string): lent T {.inline.} =
   ## Retrieves the value at `c[key]`. If `key` is not in `t`, the
   ## `KeyError` exception is raised. One can check with `hasKey` whether
   ## the key exists.
@@ -342,7 +342,7 @@ iterator keys*[T](c: CritBitTree[T]): string =
 
   for x in leaves(c.root): yield x.key
 
-iterator values*[T](c: CritBitTree[T]): T =
+iterator values*[T](c: CritBitTree[T]): lent T =
   ## Yields all values of `c` in the lexicographical order of the
   ## corresponding keys.
   ##
@@ -368,7 +368,7 @@ iterator items*[T](c: CritBitTree[T]): string =
   ## Alias for `keys <#keys.i,CritBitTree[T]>`_.
   for x in leaves(c.root): yield x.key
 
-iterator pairs*[T](c: CritBitTree[T]): tuple[key: string, val: T] =
+iterator pairs*[T](c: CritBitTree[T]): tuple[key: string, val: lent T] =
   ## Yields all `(key, value)`-pairs of `c` in the lexicographical order of the
   ## corresponding keys.
   ##
@@ -415,7 +415,7 @@ iterator keysWithPrefix*[T](c: CritBitTree[T], prefix: string): string =
   let top = allprefixedAux(c, prefix)
   for x in leaves(top): yield x.key
 
-iterator valuesWithPrefix*[T](c: CritBitTree[T], prefix: string): T =
+iterator valuesWithPrefix*[T](c: CritBitTree[T], prefix: string): lent T =
   ## Yields all values of `c` starting with `prefix` of the
   ## corresponding keys.
   ##
@@ -445,7 +445,7 @@ iterator itemsWithPrefix*[T](c: CritBitTree[T], prefix: string): string =
   for x in leaves(top): yield x.key
 
 iterator pairsWithPrefix*[T](c: CritBitTree[T],
-                             prefix: string): tuple[key: string, val: T] =
+                             prefix: string): tuple[key: string, val: lent T] =
   ## Yields all (key, value)-pairs of `c` starting with `prefix`.
   ##
   ## **See also:**
@@ -518,7 +518,7 @@ func commonPrefixLen*[T](c: CritBitTree[T]): int {.inline, since((1, 3)).} =
     else: c.root.byte
   else: 0
 
-proc toCritBitTree*[T](pairs: openArray[(string, T)]): CritBitTree[T] {.since: (1, 3).} =
+proc toCritBitTree*[T](pairs: sink openArray[(string, T)]): CritBitTree[T] {.since: (1, 3).} =
   ## Creates a new `CritBitTree` that contains the given `pairs`.
   runnableExamples:
     doAssert {"a": "0", "b": "1", "c": "2"}.toCritBitTree is CritBitTree[string]
@@ -526,7 +526,7 @@ proc toCritBitTree*[T](pairs: openArray[(string, T)]): CritBitTree[T] {.since: (
 
   for item in pairs: result.incl item[0], item[1]
 
-proc toCritBitTree*(items: openArray[string]): CritBitTree[void] {.since: (1, 3).} =
+proc toCritBitTree*(items: sink openArray[string]): CritBitTree[void] {.since: (1, 3).} =
   ## Creates a new `CritBitTree` that contains the given `items`.
   runnableExamples:
     doAssert ["a", "b", "c"].toCritBitTree is CritBitTree[void]

--- a/lib/pure/collections/critbits.nim
+++ b/lib/pure/collections/critbits.nim
@@ -293,7 +293,7 @@ proc `[]=`*[T](c: var CritBitTree[T], key: string, val: sink T) =
   var n = rawInsert(c, key)
   n.val = val
 
-template get[T](c: CritBitTree[T], key: string): lent T =
+template get[T](c: CritBitTree[T], key: string): T =
   let n = rawGet(c, key)
   if n == nil:
     raise newException(KeyError, "key not found: " & key)


### PR DESCRIPTION
Because of the absense of these annotations, CritBitTrees didn't work for types with with disabled `=copy`. As far as I can tell, this fixes that.