### PR TITLE
Make prelude importable

### DIFF
--- a/lib/pure/prelude.nim
+++ b/lib/pure/prelude.nim
@@ -12,7 +12,7 @@ when defined(nimdoc) and isMainModule:
   when compileSettings.querySetting(compileSettings.SingleValueSetting.projectFull) == currentSourcePath:
     ## This is an include file that simply imports common modules for your convenience.
     runnableExamples:
-      include std/prelude
+      import std/prelude
         # same as:
         # import std/[os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt]
       let x = 1
@@ -26,3 +26,4 @@ when defined(nimdoc) and isMainModule:
   # specific to `nim doc`, but the code otherwise works with nodejs.
 
 import std/[os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt, strformat]
+export os, strutils, times, parseutils, hashes, tables, sets, sequtils, parseopt, strformat

--- a/tests/stdlib/tprelude.nim
+++ b/tests/stdlib/tprelude.nim
@@ -4,9 +4,9 @@ discard """
 """
 
 when defined nimTestTpreludeCase1:
-  include std/prelude
+  import std/prelude
 else:
-  include prelude
+  import prelude
 
 template main() =
   doAssert toSeq(1..3) == @[1,2,3]


### PR DESCRIPTION
Export the modules that are imported by prelude.nim in order to make it possible to `import std/prelude` in addition to doing `include std/prelude`.

I've also updated the tprelude.nim test to use import instead of include. I wonder if I should have added a new test case that tests that include still works.