### PR TITLE
fixes #20015; document `shallowCopy` does a deep copy with ARC/ORC

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -473,6 +473,8 @@ proc shallowCopy*[T](x: var T, y: T) {.noSideEffect, magic: "ShallowCopy".}
   ## Be careful with the changed semantics though!
   ## There is a reason why the default assignment does a deep copy of sequences
   ## and strings.
+  ##
+  ## .. warning:: `shallowCopy` does a deep copy with ARC/ORC.
 
 # :array|openArray|string|seq|cstring|tuple
 proc `[]`*[I: Ordinal;T](a: T; i: I): T {.


### PR DESCRIPTION
fixes #20015

![image](https://user-images.githubusercontent.com/43030857/178953919-76be0e57-1bea-40bb-8c92-69334600205f.png)
