### PR TITLE
Add a new batteries module (which deprecates the prelude include)

### DIFF
--- a/compiler/platform.nim
+++ b/compiler/platform.nim
@@ -138,7 +138,7 @@ const
       props: {ospNeedsPIC, ospPosix, ospLacksThreadVars}),
      (name: "VxWorks", parDir: "..", dllFrmt: "lib$1.so", altDirSep: "/",
       objExt: ".o", newLine: "\x0A", pathSep: ";", dirSep: "\\",
-      scriptExt: ".sh", curDir: ".", exeExt: "", extSep: ".",
+      scriptExt: ".sh", curDir: ".", exeExt: ".vxe", extSep: ".",
       props: {ospNeedsPIC, ospPosix, ospLacksThreadVars}),
      (name: "JS", parDir: "..", 
       dllFrmt: "lib$1.so", altDirSep: "/", 

--- a/config/nim.cfg
+++ b/config/nim.cfg
@@ -112,6 +112,20 @@ hint[LineTooLong]=off
   gcc.cpp.options.always = "-w -fpermissive"
 @end
 
+# Configuration for the VxWorks GCC compiler
+# This has only been tested with VxWorks 6.9
+@if vxworks:
+  # For now we only support compiling RTPs applications (i.e. no DKMs)
+  gcc.options.always = "-mrtp -fno-strict-aliasing -D_C99 -D_HAS_C9X -std=c99 -fasm -Wall -Wno-write-strings"
+  # The linker config must add the VxWorks common library for the selected
+  # processor which is usually found in:
+  # "$WIND_BASE/target/lib/usr/lib/PROCESSOR_FAMILY/PROCESSOR_TYPE/common",
+  # where PROCESSOR_FAMILY and PROCESSOR_TYPE are those supported by the VxWorks
+  # compiler (e.g. ppc/PPC32, mips/MIPSI32R2, mips/MIPSI64, arm/ARMARCH7, etc)
+  # For now we only support the PowerPC CPU
+  gcc.options.linker %= "-L $WIND_BASE/target/lib/usr/lib/ppc/PPC32/common -mrtp -fno-strict-aliasing -D_C99 -D_HAS_C9X -std=c99 -fasm -Wall -Wno-write-strings"
+@end
+
 gcc.options.speed = "-O3 -fno-strict-aliasing"
 gcc.options.size = "-Os"
 gcc.options.debug = "-g3 -O0"

--- a/lib/batteries.nim
+++ b/lib/batteries.nim
@@ -1,0 +1,38 @@
+#
+#
+#            Nim's Runtime Library
+#        (c) Copyright 2012 Andreas Rumpf
+#
+#    See the file "copying.txt", included in this
+#    distribution, for details about the copyright.
+#
+
+## This is a module that simply imports common modules for your convenience:
+##
+## .. code-block:: nim
+##   import batteries
+##
+## Same as:
+##
+## .. code-block:: nim
+##   import os, strutils, times, parseutils, parseopt, hashes, tables, sets,
+##     sugar, options, strformat, strscans, algorithm, math, sequtils
+##
+## This module is similar to the `prelude module <prelude.html>` which it
+## deprecates.
+## The main differences with prelude are that this module must be imported
+## (while prelude had to be included), and that it imports a few more modules
+## than prelude did.
+## 
+## Importing this module never triggers a UnusedImport warning, even if you
+## don't use any if the modules it imports.
+
+# Mark this module as used to avoid getting apparently "random" UnusedImport
+# errors in the unlikely event that none of these modules is used
+{.used.}
+
+import std/[os, strutils, times, parseutils, parseopt, hashes, tables, sets,
+  sugar, options, strformat, strscans, algorithm, math, sequtils]
+
+export os, strutils, times, parseutils, parseopt, hashes, tables, sets,
+  sugar, options, strformat, strscans, algorithm, math, sequtils

--- a/lib/nimbase.h
+++ b/lib/nimbase.h
@@ -390,3 +390,12 @@ typedef int assert_numbits[sizeof(NI) == sizeof(void*) && NIM_INTBITS == sizeof(
 #else
 #  define NIM_EXTERNC
 #endif
+
+/* ---------------- platform specific includes ----------------------- */
+
+/* VxWorks related includes */
+#if defined(__VXWORKS__)
+#  include <sys/types.h>
+#  include <types/vxWind.h>
+#  include <tool/gnu/toolMacros.h>
+#endif

--- a/lib/prelude.nim
+++ b/lib/prelude.nim
@@ -7,6 +7,8 @@
 #    distribution, for details about the copyright.
 #
 
+## This module is deprecated. Import the [batteries] module instead.
+##
 ## This is an include file that simply imports common modules for your
 ## convenience:
 ##


### PR DESCRIPTION
This PR is implements a suggestion made as part of the discussion of
https://github.com/nim-lang/Nim/pull/20022

It adds a new batteries module, which is similar to prelude but which must be imported (rather than included) and which adds a few more modules than prelude.