### PR TITLE
niminst: support DESTDIR and quote variables

### DIFF
--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -18,7 +18,7 @@ if [ $# -eq 1 ] ; then
   case $1 in
     "--help"|"-h"|"help"|"h")
       echo "?c.displayName installation script"
-      echo "Usage: [sudo] sh install.sh DIR"
+      echo "Usage: [sudo] [env DESTDIR=...] sh install.sh DIR"
       echo "Where DIR may be:"
       echo "  /usr/bin"
       echo "  /usr/local/bin"
@@ -51,9 +51,6 @@ if [ $# -eq 1 ] ; then
       docdir="/opt/?proj/doc"
       datadir="/opt/?proj/data"
       nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
-      mkdir -p /opt/?proj
-      mkdir -p $bindir
-      mkdir -p $configdir
       ;;
     *)
       bindir="$1/?proj/bin"
@@ -62,16 +59,22 @@ if [ $# -eq 1 ] ; then
       docdir="$1/?proj/doc"
       datadir="$1/?proj/data"
       nimbleDir="$1/?proj"
-      mkdir -p $1/?proj
-      mkdir -p $bindir
-      mkdir -p $configdir
       ;;
   esac
 
-  mkdir -p $libdir
-  mkdir -p $docdir
-  mkdir -p $configdir
-  mkdir -p $nimbleDir/
+  bindir="${DESTDIR}${bindir}"
+  configdir="${DESTDIR}${configdir}"
+  libdir="${DESTDIR}${libdir}"
+  docdir="${DESTDIR}${docdir}"
+  datadir="${DESTDIR}${datadir}"
+  nimbleDir="${DESTDIR}${nimbleDir}"
+
+  mkdir -p "$bindir"
+  mkdir -p "$configdir"
+  mkdir -p "$libdir"
+  mkdir -p "$docdir"
+  mkdir -p "$datadir"
+  mkdir -p "$nimbleDir"
   echo "copying files..."
 #var createdDirs = newStringTable()
 #for cat in {fcConfig..fcLib, fcNimble}:
@@ -123,7 +126,7 @@ chmod 644 $nimbleDir/?{c.nimblePkgName}.nimble
   echo "installation successful"
 else
   echo "?c.displayName installation script"
-  echo "Usage: [sudo] sh install.sh DIR"
+  echo "Usage: [sudo] [env DESTDIR=...] sh install.sh DIR"
   echo "Where DIR may be:"
   echo "  /usr/bin"
   echo "  /usr/local/bin"

--- a/tools/niminst/install.nimf
+++ b/tools/niminst/install.nimf
@@ -6,15 +6,15 @@
 set -e
 
 if [ $# -eq 1 ] ; then
-# if c.cat[fcUnixBin].len > 0:
-  if test -f ?{c.cat[fcUnixBin][0].toUnix}
+#if c.cat[fcUnixBin].len > 0:
+  if [ -f "?{c.cat[fcUnixBin][0].toUnix}" ]
   then
     echo "?c.displayName build detected"
   else
     echo "Please build ?c.displayName before installing it"
     exit 1
   fi
-#  end if
+#end if
   case $1 in
     "--help"|"-h"|"help"|"h")
       echo "?c.displayName installation script"
@@ -29,19 +29,19 @@ if [ $# -eq 1 ] ; then
       exit 1
       ;;
     "/usr/bin")
-      bindir=/usr/bin
-      configdir=/etc/?proj
-      libdir=/usr/lib/?proj
-      docdir=/usr/share/?proj/doc
-      datadir=/usr/share/?proj/data
+      bindir=$1
+      configdir="/etc/?proj"
+      libdir="/usr/lib/?proj"
+      docdir="/usr/share/?proj/doc"
+      datadir="/usr/share/?proj/data"
       nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
       ;;
     "/usr/local/bin")
-      bindir=/usr/local/bin
-      configdir=/etc/?proj
-      libdir=/usr/local/lib/?proj
-      docdir=/usr/local/share/?proj/doc
-      datadir=/usr/local/share/?proj/data
+      bindir=$1
+      configdir="/etc/?proj"
+      libdir="/usr/local/lib/?proj"
+      docdir="/usr/local/share/?proj/doc"
+      datadir="/usr/local/share/?proj/data"
       nimbleDir="/opt/nimble/pkgs/?c.nimblePkgName-?c.version"
       ;;
     "/opt")
@@ -87,41 +87,41 @@ if [ $# -eq 1 ] ; then
 #    end if
 #    if mk.len > 0 and not createdDirs.hasKey(mk):
 #      createdDirs[mk] = "true"
-  mkdir -p ?{mk.toUnix}
+  mkdir -p "?{mk.toUnix}"
 #    end if
 #  end for
 #end for
 
 #for f in items(c.cat[fcUnixBin]):
-  cp ?f.toUnix $bindir/?f.skipRoot.toUnix
-  chmod 755 $bindir/?f.skipRoot.toUnix
+  cp "?f.toUnix" "$bindir/?f.skipRoot.toUnix"
+  chmod 755 "$bindir/?f.skipRoot.toUnix"
 #end for
 #for f in items(c.cat[fcConfig]):
-  cp ?f.toUnix $configdir/?f.skipRoot.toUnix
-  chmod 644 $configdir/?f.skipRoot.toUnix
+  cp "?f.toUnix" "$configdir/?f.skipRoot.toUnix"
+  chmod 644 "$configdir/?f.skipRoot.toUnix"
 #end for
 #for f in items(c.cat[fcData]):
-  if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $datadir/?f.skipRoot.toUnix
-    chmod 644 $datadir/?f.skipRoot.toUnix
+  if [ -f "?f.toUnix" ]; then
+    cp "?f.toUnix" "$datadir/?f.skipRoot.toUnix"
+    chmod 644 "$datadir/?f.skipRoot.toUnix"
   fi
 #end for
 #for f in items(c.cat[fcDoc]):
-  if [ -f ?f.toUnix ]; then
-    cp ?f.toUnix $docdir/?f.skipRoot.toUnix
-    chmod 644 $docdir/?f.skipRoot.toUnix
+  if [ -f "?f.toUnix" ]; then
+    cp "?f.toUnix" "$docdir/?f.skipRoot.toUnix"
+    chmod 644 "$docdir/?f.skipRoot.toUnix"
   fi
 #end for
 #for f in items(c.cat[fcLib]):
-  cp ?f.toUnix $libdir/?f.skipRoot.toUnix
-  chmod 644 $libdir/?f.skipRoot.toUnix
+  cp "?f.toUnix" "$libdir/?f.skipRoot.toUnix"
+  chmod 644 "$libdir/?f.skipRoot.toUnix"
 #end for
 #for f in items(c.cat[fcNimble]):
-  cp ?f.toUnix $nimbleDir/?f.toUnix
-  chmod 644 $nimbleDir/?f.toUnix
+  cp "?f.toUnix" "$nimbleDir/?f.toUnix"
+  chmod 644 "$nimbleDir/?f.toUnix"
 #end for
-cp ?{c.nimblePkgName}.nimble $nimbleDir/?{c.nimblePkgName}.nimble
-chmod 644 $nimbleDir/?{c.nimblePkgName}.nimble
+cp "?{c.nimblePkgName}.nimble" "$nimbleDir/?{c.nimblePkgName}.nimble"
+chmod 644 "$nimbleDir/?{c.nimblePkgName}.nimble"
 
   echo "installation successful"
 else


### PR DESCRIPTION
This is needed because distros are forced to carry their own patches at the
moment:

https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-lang/nim/files/nim-0.20.0-paths.patch
https://git.alpinelinux.org/aports/tree/community/nim/niminst-fix-paths.patch
https://src.fedoraproject.org/rpms/nim/blob/f33/f/nim-0001-allow-to-override-directories-in-install-script.patch