### PR TITLE
test making overloadable enums non-experimental

### DIFF
--- a/compiler/lookups.nim
+++ b/compiler/lookups.nim
@@ -182,7 +182,7 @@ iterator allSyms*(c: PContext): (PSym, int, bool) =
 proc someSymFromImportTable*(c: PContext; name: PIdent; ambiguous: var bool): PSym =
   var marked = initIntSet()
   var symSet = OverloadableSyms
-  if overloadableEnums notin c.features:
+  if false and overloadableEnums notin c.features:
     symSet.excl skEnumField
   result = nil
   block outer:

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -213,7 +213,7 @@ type
     strictFuncs,
     views,
     strictNotNil,
-    overloadableEnums,
+    overloadableEnums, # not experimental anymore
     strictEffects,
     unicodeOperators,
     flexibleOptionalParams

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2828,7 +2828,7 @@ proc semExpr(c: PContext, n: PNode, flags: TExprFlags = {}): PNode =
       if optOwnedRefs in c.config.globalOptions:
         result.typ = makeVarType(c, result.typ, tyOwned)
     of skEnumField:
-      if overloadableEnums in c.features:
+      if true or overloadableEnums in c.features:
         result = enumFieldSymChoice(c, n, s)
       else:
         result = semSym(c, n, s, flags)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2764,7 +2764,7 @@ proc enumFieldSymChoice(c: PContext, n: PNode, s: PSym): PNode =
   var i = 0
   var a = initOverloadIter(o, c, n)
   while a != nil:
-    if a.kind in OverloadableSyms-{skModule}:
+    if a.kind == skEnumField: #in OverloadableSyms-{skModule}:
       inc(i)
       if i > 1: break
     a = nextOverloadIter(o, c, n)

--- a/compiler/semgnrc.nim
+++ b/compiler/semgnrc.nim
@@ -108,7 +108,7 @@ proc semGenericStmtSymbol(c: PContext, n: PNode, s: PSym,
       result = n
     onUse(n.info, s)
   of skEnumField:
-    if overloadableEnums in c.features:
+    if true or overloadableEnums in c.features:
       result = symChoice(c, n, s, scOpen)
     else:
       result = newSymNode(s, n.info)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -261,7 +261,7 @@ proc semTemplSymbol(c: PContext, n: PNode, s: PSym; isField: bool): PNode =
     if isField and sfGenSym in s.flags: result = n
     else: result = newSymNodeTypeDesc(s, c.idgen, n.info)
   else:
-    if s.kind == skEnumField and overloadableEnums in c.features:
+    if s.kind == skEnumField and (true or overloadableEnums in c.features):
       result = symChoice(c, n, s, scOpen, isField)
     elif isField and sfGenSym in s.flags:
       result = n

--- a/compiler/semtypes.nim
+++ b/compiler/semtypes.nim
@@ -143,7 +143,7 @@ proc semEnum(c: PContext, n: PNode, prev: PType): PType =
     onDef(e.info, e)
     if sfGenSym notin e.flags:
       if not isPure:
-        if overloadableEnums in c.features:
+        if true or overloadableEnums in c.features:
           addInterfaceOverloadableSymAt(c, c.currentScope, e)
         else:
           addInterfaceDecl(c, e)

--- a/tests/enum/toverloadable_enums.nim
+++ b/tests/enum/toverloadable_enums.nim
@@ -84,3 +84,30 @@ proc g3[T](x: T, e: E2): int =
   of value2: echo "E2-B"
 
 let v5 = g3(99, E2.value2)
+
+import macros
+block: # test with macros/templates
+  type
+    Enum1 = enum
+      value01, value02
+    Enum2 = enum
+      value01, value10
+  
+  macro isOneM(a: untyped): bool =
+    result = newCall(bindSym"==", a, ident"value01")
+  
+  macro isOneMS(a: untyped): bool =
+    result = newCall(bindSym"==", a, bindSym"value01")
+  
+  template isOneT(a: untyped): bool =
+    a == value01
+
+  let e1 = Enum1.value01
+  let e2 = Enum2.value01
+  doAssert isOneM(e1)
+  doAssert isOneM(e2)
+  doAssert isOneMS(e1)
+  doAssert isOneMS(e2)
+  doAssert isOneT(e1)
+  doAssert isOneT(e2)
+


### PR DESCRIPTION
also add macro/template test as mentioned in the original PR

failing tests:

- tests/sets/tsets.nim (shadowed enum in block)
- tests/enum/tregression.nim (shadowed enum via import)