### PR TITLE
Improve --nimNoLibc support

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1144,7 +1144,7 @@ const
   # for string literals, it allows for some optimizations.
 
 const
-  hasThreadSupport = compileOption("threads") and not defined(nimscript)
+  hasThreadSupport = compileOption("threads") and not defined(nimscript) and hostOS != "standalone"
   hasSharedHeap = defined(boehmgc) or defined(gogc) # don't share heaps; every thread has its own
 
 when hasThreadSupport and defined(tcc) and not compileOption("tlsEmulation"):
@@ -1764,7 +1764,8 @@ proc compiles*(x: untyped): bool {.magic: "Compiles", noSideEffect, compileTime.
   discard
 
 when notJSnotNims:
-  import system/ansi_c
+  when not defined(nimNoLibc):
+    import system/ansi_c
   import system/memory
 
 
@@ -2236,7 +2237,7 @@ when notJSnotNims:
     when declared(memTrackerOp):
       memTrackerOp("copyMem", dest, size)
   proc moveMem(dest, source: pointer, size: Natural) =
-    c_memmove(dest, source, csize_t(size))
+    nimMoveMem(dest, source, size)
     when declared(memTrackerOp):
       memTrackerOp("moveMem", dest, size)
   proc equalMem(a, b: pointer, size: Natural): bool =
@@ -2291,7 +2292,7 @@ when not defined(js) and declared(alloc0) and declared(dealloc):
       inc(i)
     dealloc(a)
 
-when notJSnotNims:
+when notJSnotNims and not defined(nimNoLibc):
   type
     PSafePoint = ptr TSafePoint
     TSafePoint {.compilerproc, final.} = object

--- a/lib/system/embedded.nim
+++ b/lib/system/embedded.nim
@@ -19,7 +19,8 @@ proc nimFrame(s: PFrame) {.compilerRtl, inl, exportc: "nimFrame".} = discard
 proc popFrame {.compilerRtl, inl.} = discard
 
 proc setFrame(s: PFrame) {.compilerRtl, inl.} = discard
-proc pushSafePoint(s: PSafePoint) {.compilerRtl, inl.} = discard
+when declared(SafePoint):
+  proc pushSafePoint(s: PSafePoint) {.compilerRtl, inl.} = discard
 proc popSafePoint {.compilerRtl, inl.} = discard
 proc pushCurrentException(e: ref Exception) {.compilerRtl, inl.} = discard
 proc popCurrentException {.compilerRtl, inl.} = discard

--- a/lib/system/mmdisp.nim
+++ b/lib/system/mmdisp.nim
@@ -45,8 +45,12 @@ else:
 
 proc raiseOutOfMem() {.noinline.} =
   if outOfMemHook != nil: outOfMemHook()
-  cstderr.rawWrite("out of memory\n")
-  quit(1)
+  when hostOS == "standalone":
+    panic("out of memory\n")
+  else:
+    when not defined(nimNoLibc):
+      cstderr.rawWrite("out of memory\n")
+    quit(1)
 
 when defined(boehmgc):
   include system / mm / boehm

--- a/lib/system/strmantle.nim
+++ b/lib/system/strmantle.nim
@@ -17,7 +17,7 @@ proc cmpStrings(a, b: string): int {.inline, compilerproc.} =
   let blen = b.len
   let minlen = min(alen, blen)
   if minlen > 0:
-    result = c_memcmp(unsafeAddr a[0], unsafeAddr b[0], cast[csize_t](minlen))
+    result = nimCmpMem(unsafeAddr a[0], unsafeAddr b[0], cast[csize_t](minlen))
     if result == 0:
       result = alen - blen
   else:

--- a/tests/compiler/panicoverride.nim
+++ b/tests/compiler/panicoverride.nim
@@ -1,0 +1,12 @@
+{.push stack_trace: off, profiler:off.}
+
+proc rawoutput(s: string) =
+  discard
+#   printf("%s\n", s)
+
+proc panic(s: string) {.noreturn.} =
+  discard
+#   rawoutput(s)
+#   exit(1)
+
+{.pop.}

--- a/tests/compiler/tnimNoLibc.nim
+++ b/tests/compiler/tnimNoLibc.nim
@@ -1,0 +1,9 @@
+discard """
+action: compile
+ccodecheck: "\\i !@('#include <string.h>')"
+"""
+
+proc createSeq*(a, b: int): seq[int]  {.cdecl, exportc, dynlib} =
+  @[a,b,a,b,a]
+
+echo createSeq(42, 5)

--- a/tests/compiler/tnimNoLibc.nim.cfg
+++ b/tests/compiler/tnimNoLibc.nim.cfg
@@ -1,0 +1,3 @@
+os:standalone
+gc:destructors
+-d:nimNoLibc

--- a/tests/memmove/tmemmove.nim
+++ b/tests/memmove/tmemmove.nim
@@ -1,0 +1,43 @@
+import ../../lib/system/memory
+
+# "Test 1: Zero-length copy."
+var dest1: array[3, byte] = [0xa.byte, 0xb.byte, 0xc.byte]
+var source1: array[3, byte] = [0x1.byte, 0x2.byte, 0x3.byte]
+let size1: Natural = 0
+
+nimMoveMem(dest1[0].addr, source1[0].addr, size1)
+assert(dest1 == [0xa.byte, 0xb.byte, 0xc.byte])
+
+# Test 2: Overlap, left-to-right.
+var arr2: array[6, byte] = [0x1.byte, 0x2.byte, 0x3.byte, 0xa.byte, 0xb.byte, 0xc.byte]
+let size2: Natural = 4
+
+nimMoveMem(arr2[1].addr, arr2[2].addr, size2)
+assert(arr2 == [0x1.byte, 0x3.byte, 0xa.byte, 0xb.byte, 0xc.byte, 0xc.byte])
+
+# Test 3: Overlap, right-to-left.
+var arr3: array[6, byte] = [0x1.byte, 0x2.byte, 0x3.byte, 0xa.byte, 0xb.byte, 0xc.byte]
+let size3: Natural = 4
+
+nimMoveMem(arr3[2].addr, arr3[0].addr, size3)
+assert(arr3 == [0x1.byte, 0x2.byte, 0x1.byte, 0x2.byte, 0x3.byte, 0xa.byte])
+
+# Test 4: 100% overlap.
+var arr4: array[6, byte] = [0x1.byte, 0x2.byte, 0x3.byte, 0x4.byte, 0x5.byte, 0x6.byte]
+let size4: Natural = 6
+
+nimMoveMem(arr4[0].addr, arr4[0].addr, size4)
+assert(arr4 == [0x1.byte, 0x2.byte, 0x3.byte, 0x4.byte, 0x5.byte, 0x6.byte])
+
+var dest4: array[6, byte] = [0x1.byte, 0x2.byte, 0x3.byte, 0x4.byte, 0x5.byte, 0x6.byte]
+var source4: array[6, byte] = [0x6.byte, 0x5.byte, 0x4.byte, 0x3.byte, 0x2.byte, 0x1.byte]
+nimMoveMem(dest4[0].addr, source4[0].addr, size4)
+assert(dest4 == [0x6.byte, 0x5.byte, 0x4.byte, 0x3.byte, 0x2.byte, 0x1.byte])
+
+# Test 5: Basic test
+var dest5: array[7, byte] = [0x1.byte, 0x2.byte, 0x3.byte, 0x4.byte, 0x5.byte, 0x6.byte, 0x7.byte]
+var source5: array[4, byte] = [0xa.byte, 0xb.byte, 0xc.byte, 0xd.byte]
+let size5: Natural = 4
+
+nimMoveMem(dest5[1].addr, source5[0].addr, size5)
+assert(dest5 == [0x1.byte, 0xa.byte, 0xb.byte, 0xc.byte, 0xd.byte, 0x6.byte, 0x7.byte])

--- a/tests/memmove/tmemmove.nim.cfg
+++ b/tests/memmove/tmemmove.nim.cfg
@@ -1,0 +1,1 @@
+-d:nimNoLibc


### PR DESCRIPTION
While trying to compile nim to wasm, and more specifically, a simple program working with sequences, I noticed that in the wasm file were included some functions from the C standard library which were unused and unnecessary. In other words, they shouldn't have been there because I was compiling with `-d:nimNoLibc`. This PR expands the `system/memory` with a definition of `memmove`, so the `-d:nimNoLibc` directive can be properly honored.