### PR TITLE
fixes broken CI; bump macOS version to macos-11

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -40,7 +40,7 @@ jobs:
           - target: windows
             os: windows-2019
           - target: osx
-            os: macos-10.15
+            os: macos-11
 
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         cpu: [amd64]
         batch: ["allowed_failures", "0_3", "1_3", "2_3"] # list of `index_num`
     name: '${{ matrix.os }} (batch: ${{ matrix.batch }})'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,10 +28,10 @@ jobs:
         vmImage: 'ubuntu-18.04'
         CPU: i386
       OSX_amd64:
-        vmImage: 'macOS-10.15'
+        vmImage: 'macOS-11'
         CPU: amd64
       OSX_amd64_cpp:
-        vmImage: 'macOS-10.15'
+        vmImage: 'macOS-11'
         CPU: amd64
         NIM_COMPILE_TO_CPP: true
       Windows_amd64_batch0_3:


### PR DESCRIPTION
##[warning]The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583