### PR TITLE
Warn when casting to a larger type

### DIFF
--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -80,6 +80,7 @@ type
     warnHoleEnumConv = "HoleEnumConv",
     warnCstringConv = "CStringConv",
     warnEffect = "Effect",
+    warnCastSizes = "CastSizes"
     warnUser = "User",
     # hints
     hintSuccess = "Success", hintSuccessX = "SuccessX",
@@ -173,6 +174,7 @@ const
     warnHoleEnumConv: "$1",
     warnCstringConv: "$1",
     warnEffect: "$1",
+    warnCastSizes: "$1",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -360,7 +360,7 @@ proc semCast(c: PContext, n: PNode): PNode =
   let targetType = semTypeNode(c, n[0], nil)
   let castedExpr = semExprWithType(c, n[1])
   if tfHasMeta in targetType.flags:
-    localError(c.config, n[0].info, "cannot cast to a non-concrete type: '$1'" % $targetType)
+    localError(c.config, n[0].info, "cannot cast to a non concrete type: '$1'" % $targetType)
   if not isCastable(c, targetType, castedExpr.typ, n.info):
     let tar = $targetType
     let alt = typeToString(targetType, preferDesc)


### PR DESCRIPTION
Fixes #19101.

I'm open to suggestions for improving the warning, I'm not quite happy with it yet.

This produces a bunch of warnings in `compiler/int128.nim`, which should be fixed in a followup PR.