### PR TITLE
[ORC] replace threadpool with createThread in the runnableExamples

### DIFF
--- a/lib/pure/random.nim
+++ b/lib/pure/random.nim
@@ -178,24 +178,31 @@ proc skipRandomNumbers*(s: var Rand) =
   ## **See also:**
   ## * `next proc<#next,Rand>`_
   runnableExamples("--threads:on"):
-    import std/[random, threadpool]
+    import std/random
 
-    const spawns = 4
     const numbers = 100000
 
-    proc randomSum(r: Rand): int =
-      var r = r
+    var
+      thr: array[0..3, Thread[(Rand, int)]]
+      vals: array[0..3, int]
+
+    proc randomSum(params: tuple[r: Rand, index: int]) {.thread.} =
+      var r = params.r
       for i in 1..numbers:
-        result += r.rand(0..10)
+        vals[params.index] += r.rand(0..10)
 
     var r = initRand(2019)
-    var vals: array[spawns, FlowVar[int]]
-    for val in vals.mitems:
-      val = spawn randomSum(r)
+    for i in 0..<thr.len:
+      createThread(thr[i], randomSum, (r, i))
       r.skipRandomNumbers()
 
+    joinThreads(thr)
+
     for val in vals:
-      doAssert abs(^val - numbers * 5) / numbers < 0.1
+      doAssert abs(val - numbers * 5) / numbers < 0.1
+
+    doAssert vals == [501737, 497901, 500683, 500157]
+
 
   when defined(js):
     const helper = [0xbeac0467u32, 0xd86b048bu32]


### PR DESCRIPTION
`threadpool` doesn't work with ORC, so I replace threadpool with createThread.