### PR TITLE
remove `shallow` usages for ORC

### DIFF
--- a/compiler/ccgtypes.nim
+++ b/compiler/ccgtypes.nim
@@ -84,7 +84,8 @@ proc mangleLocalName(p: BProc; s: PSym): Rope =
   result = s.loc.r
   if result == nil:
     var key = s.name.s.mangle
-    shallow(key)
+    when not defined(nimSeqsV2):
+      shallow(key)
     let counter = p.sigConflicts.getOrDefault(key)
     result = key.rope
     if s.kind == skTemp:
@@ -102,7 +103,8 @@ proc scopeMangledParam(p: BProc; param: PSym) =
   ## generate unique identifiers reliably (consider that ``var a = a`` is
   ## even an idiom in Nim).
   var key = param.name.s.mangle
-  shallow(key)
+  when not defined(nimSeqsV2):
+    shallow(key)
   p.sigConflicts.inc(key)
 
 const

--- a/compiler/msgs.nim
+++ b/compiler/msgs.nim
@@ -101,7 +101,8 @@ proc fileInfoIdx*(conf: ConfigRef; filename: AbsoluteFile; isKnownFile: var bool
 
   try:
     canon = canonicalizePath(conf, filename)
-    shallow(canon.string)
+    when not defined(nimSeqsV2):
+      shallow(canon.string)
   except OSError:
     canon = filename
     # The compiler uses "filenames" such as `command line` or `stdin`

--- a/lib/pure/asyncnet.nim
+++ b/lib/pure/asyncnet.nim
@@ -399,7 +399,8 @@ proc recv*(socket: AsyncSocket, size: int,
   ## to be read then the future will complete with a value of `""`.
   if socket.isBuffered:
     result = newString(size)
-    shallow(result)
+    when not defined(nimSeqsV2):
+      shallow(result)
     let originalBufPos = socket.currPos
 
     if socket.bufLen == 0:


### PR DESCRIPTION
`shallow` doesn't work for ARC/ORC.

```nim
proc shallow*[T](s: var seq[T]) {.noSideEffect, inline.} =
  ## Marks a sequence `s` as `shallow`:idx:. Subsequent assignments will not
  ## perform deep copies of `s`.
  ##
  ## This is only useful for optimization purposes.
  if s.len == 0: return
  when not defined(js) and not defined(nimscript) and not defined(nimSeqsV2):
    var s = cast[PGenericSeq](s)
    s.reserved = s.reserved or seqShallowFlag
```

Should we remove it from system for ARC/ORC? or deprecated it since it can only be used for optimizations.