### PR TITLE
Highlight Nim default in Markdown code in .nim

### DIFF
--- a/lib/packages/docutils/rstgen.nim
+++ b/lib/packages/docutils/rstgen.nim
@@ -1074,7 +1074,7 @@ proc renderCode(d: PDoc, n: PRstNode, result: var string) =
       blockEnd = "}"
   dispA(d.target, result, blockStart, blockStart, [])
   if params.lang == langNone:
-    if len(params.langStr) > 0:
+    if len(params.langStr) > 0 and params.langStr.toLowerAscii != "none":
       rstMessage(d.filenames, d.msgHandler, n.info, mwUnsupportedLanguage,
                  params.langStr)
     for letter in m.text: escChar(d.target, result, letter, emText)

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -474,7 +474,12 @@ suite "RST parsing":
   let expectCodeBlock = dedent"""
       rnCodeBlock
         [nil]
-        [nil]
+        rnFieldList
+          rnField
+            rnFieldName
+              rnLeaf  'default-language'
+            rnFieldBody
+              rnLeaf  'Nim'
         rnLiteralBlock
           rnLeaf  '
       let a = 1

--- a/tests/stdlib/trstgen.nim
+++ b/tests/stdlib/trstgen.nim
@@ -582,8 +582,13 @@ Test literal block
 ```
 let x = 1
 ``` """
-    let output1 = input1.toHtml
+    let output1 = input1.toHtml({roSupportMarkdown, roPreferMarkdown})
     doAssert "<pre" in output1 and "class=\"Keyword\"" notin output1
+
+    # Check Nim highlighting by default in .nim files:
+    let output1nim = input1.toHtml({roSupportMarkdown, roPreferMarkdown,
+                                    roNimFile})
+    doAssert "<pre" in output1nim and "class=\"Keyword\"" in output1nim
 
     let input2 = """
 Parse the block with language specifier:


### PR DESCRIPTION
The proposal is to highlight code in Markdown code blocks in .nim files as Nim by default without explicit language string.
The other question is whether we want to use it in this repo or not: it may be confusing for some people that `.md` files have ```` ```nim```` and `.nim` files have just ```` ``` ````

To turn off syntax highlighting one would need to use ```` ```none````