### PR TITLE
The internal link to koch.rst docs was broken

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ can run a subset of tests by specifying a category (for example
 ``./koch tests cat async``).
 
 For more information on the ``koch`` build tool please see the documentation
-within the [doc/koch.rst](doc/koch.rst) file.
+within the [doc/koch.md](doc/koch.md) file.
 
 ## Nimble
 


### PR DESCRIPTION
The Current internal link was broken. Updated with a [new link](https://github.com/nim-lang/Nim/blob/devel/doc/koch.md) to the same path