### PR TITLE
[wip] fixes #19931; make Async stack traces better

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -333,12 +333,9 @@ proc `$`*(stackTraceEntries: seq[StackTraceEntry]): string =
 
     if procname == "":
       if entry.line == reraisedFromBegin:
-        result.add(spaces(indent) & "#[\n")
-        indent.inc(2)
+        break
       elif entry.line == reraisedFromEnd:
-        indent.dec(2)
-        result.add(spaces(indent) & "]#\n")
-      break
+        doAssert false
     elif procname.endsWith("Iter"): # generates more unique suffix?
       procname.setLen(procname.len-4)
     elif find(nativeToUnixPath(filename), "lib/pure/async") > 0: # is it stdlib?


### PR DESCRIPTION
```
C:\Users\blue\Desktop\Nim\texe2.nim(17) texe2
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1993) waitFor
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1685) poll
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(451) runOnce
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(266) processPendingCallbacks
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(31) processRequestNimAsyncContinue
C:\Users\blue\Desktop\Nim\lib\pure\asynchttpserver.nim(330) processRequestIter
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(242) callMeMaybe
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(28) callMeMaybeNimAsyncContinue
C:\Users\blue\Desktop\Nim\texe2.nim(8) callMeMaybeIter
C:\Users\blue\Desktop\Nim\lib\system\fatal.nim(53) sysFatal
[[reraised from:
C:\Users\blue\Desktop\Nim\texe2.nim(17) texe2
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1993) waitFor
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1685) poll
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(451) runOnce
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(266) processPendingCallbacks
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(31) processRequestNimAsyncContinue
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(134) processRequestIter
C:\Users\blue\Desktop\Nim\lib\pure\asyncfutures.nim(391) read
]]
[[reraised from:
C:\Users\blue\Desktop\Nim\texe2.nim(17) texe2
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1993) waitFor
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1685) poll
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(451) runOnce
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(266) processPendingCallbacks
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(28) processClientNimAsyncContinue
C:\Users\blue\Desktop\Nim\lib\pure\asyncmacro.nim(134) processClientIter
C:\Users\blue\Desktop\Nim\lib\pure\asyncfutures.nim(391) read
]]
[[reraised from:
C:\Users\blue\Desktop\Nim\texe2.nim(17) texe2
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1993) waitFor
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(1685) poll
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(451) runOnce
C:\Users\blue\Desktop\Nim\lib\pure\asyncdispatch.nim(266) processPendingCallbacks
C:\Users\blue\Desktop\Nim\lib\pure\asyncfutures.nim(439) asyncCheckCallback
]]
Error: unhandled exception: index out of bounds, the container is empty
Async traceback:
  C:\Users\blue\Desktop\Nim\texe2.nim(17)                     texe2
  C:\Users\blue\Desktop\Nim\lib\pure\asynchttpserver.nim(330) processRequest
  C:\Users\blue\Desktop\Nim\texe2.nim(8)                      callMeMaybe
  C:\Users\blue\Desktop\Nim\lib\system\fatal.nim(53)          sysFatal
Exception message: index out of bounds, the container is empty
 [IndexDefect]
```
The current async traceback is good enough even though some stacktracks are lost. Or we can merge reraised statck traces later.                  

Anyway the traceback already shows verbose information, so the async traceback should provide precise information instead.