### PR TITLE
move experimental `dynamicBindSym` to its own proc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -204,6 +204,10 @@
   need to convert to `string`. On the JS backend, this is translated directly
   to a `switch` statement.
 
+- `macros.dynamicBindSym` has been added as a variant of `bindSym` with an
+  [experimental feature](https://nim-lang.github.io/Nim/manual_experimental.html#dynamic-arguments-for-bindsym)
+  enabled that allows computed argument values.
+
 ## Compiler changes
 
 - The `gc` switch has been renamed to `mm` ("memory management") in order to reflect the

--- a/changelog.md
+++ b/changelog.md
@@ -204,9 +204,10 @@
   need to convert to `string`. On the JS backend, this is translated directly
   to a `switch` statement.
 
-- `macros.dynamicBindSym` has been added as a variant of `bindSym` with an
-  [experimental feature](https://nim-lang.github.io/Nim/manual_experimental.html#dynamic-arguments-for-bindsym)
-  enabled that allows computed argument values.
+- `macros.dynamicBindSym` has been added as an alternative to the
+  [`dynamicBindSym` experimental switch](https://nim-lang.github.io/Nim/manual_experimental.html#dynamic-arguments-for-bindsym)
+  that does not modify the behavior of the original `bindSym` proc.
+  To use this new proc, enable the `dynamicBindSymProc` experimental switch.
 
 ## Compiler changes
 

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -706,7 +706,7 @@ type
     mNIntVal, mNFloatVal, mNSymbol, mNIdent, mNGetType, mNStrVal, mNSetIntVal,
     mNSetFloatVal, mNSetSymbol, mNSetIdent, mNSetType, mNSetStrVal, mNLineInfo,
     mNNewNimNode, mNCopyNimNode, mNCopyNimTree, mStrToIdent, mNSigHash, mNSizeOf,
-    mNBindSym, mNCallSite,
+    mNBindSym, mNDynamicBindSym, mNCallSite,
     mEqIdent, mEqNimrodNode, mSameNodeType, mGetImpl, mNGenSym,
     mNHint, mNWarning, mNError,
     mInstantiationInfo, mGetTypeInfo, mGetTypeInfoV2,

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -143,3 +143,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasTopDownInference")
   defineSymbol("nimHasTemplateRedefinitionPragma")
   defineSymbol("nimHasCstringCase")
+  defineSymbol("nimHasDynamicBindSymMagic")

--- a/compiler/options.nim
+++ b/compiler/options.nim
@@ -217,6 +217,7 @@ type
     strictEffects,
     unicodeOperators, # deadcode
     flexibleOptionalParams
+    dynamicBindSymProc # moves dynamicBindSym behavior to separate proc
 
   LegacyFeature* = enum
     allowSemcheckedAstModification,

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -547,6 +547,7 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = semBindSym(c, n)
     else:
       result = semDynamicBindSym(c, n)
+  of mNDynamicBindSym: result = semDynamicBindSym(c, n)
   of mProcCall:
     result = n
     result.typ = n[1].typ

--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -547,7 +547,10 @@ proc magicsAfterOverloadResolution(c: PContext, n: PNode,
       result = semBindSym(c, n)
     else:
       result = semDynamicBindSym(c, n)
-  of mNDynamicBindSym: result = semDynamicBindSym(c, n)
+  of mNDynamicBindSym:
+    if dynamicBindSymProc notin c.features:
+      localError(c.config, n.info, "experimental switch 'dynamicBindSymProc' must be enabled to call `dynamicBindSym`")
+    result = semDynamicBindSym(c, n)
   of mProcCall:
     result = n
     result.typ = n[1].typ

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -879,7 +879,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
         mergeRaises(tracked, effectList[exceptionEffects], n)
         mergeTags(tracked, effectList[tagEffects], n)
         gcsafeAndSideeffectCheck()
-    if a.kind != nkSym or a.sym.magic notin {mNBindSym, mFinished, mExpandToAst, mQuoteAst}:
+    if a.kind != nkSym or a.sym.magic notin {mNBindSym, mNDynamicBindSym, mFinished, mExpandToAst, mQuoteAst}:
       for i in 1..<n.len:
         trackOperandForIndirectCall(tracked, n[i], op, i, a)
     if a.kind == nkSym and a.sym.magic in {mNew, mNewFinalize, mNewSeq}:
@@ -904,7 +904,7 @@ proc trackCall(tracked: PEffects; n: PNode) =
         optStaticBoundsCheck in tracked.currOptions:
       checkBounds(tracked, n[1], n[2])
 
-    if a.kind != nkSym or a.sym.magic notin {mRunnableExamples, mNBindSym, mExpandToAst, mQuoteAst}:
+    if a.kind != nkSym or a.sym.magic notin {mRunnableExamples, mNBindSym, mNDynamicBindSym, mExpandToAst, mQuoteAst}:
       for i in 0..<n.safeLen:
         track(tracked, n[i])
 

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -849,7 +849,7 @@ proc transformCall(c: PTransf, n: PNode): PNode =
     result = newTransNode(nkAddr, n, 1)
     result[0] = n[1]
     result = transformAddrDeref(c, result, nkDerefExpr, nkHiddenDeref)
-  elif magic in {mNBindSym, mTypeOf, mRunnableExamples}:
+  elif magic in {mNBindSym, mNDynamicBindSym, mTypeOf, mRunnableExamples}:
     # for bindSym(myconst) we MUST NOT perform constant folding:
     result = n
   elif magic == mProcCall:

--- a/compiler/vmgen.nim
+++ b/compiler/vmgen.nim
@@ -1303,7 +1303,7 @@ proc genMagic(c: PCtx; n: PNode; dest: var TDest; m: TMagic) =
   of mNNewNimNode: genBinaryABC(c, n, dest, opcNNewNimNode)
   of mNCopyNimNode: genUnaryABC(c, n, dest, opcNCopyNimNode)
   of mNCopyNimTree: genUnaryABC(c, n, dest, opcNCopyNimTree)
-  of mNBindSym: genBindSym(c, n, dest)
+  of mNBindSym, mNDynamicBindSym: genBindSym(c, n, dest)
   of mStrToIdent: genUnaryABC(c, n, dest, opcStrToIdent)
   of mEqIdent: genBinaryABC(c, n, dest, opcEqIdent)
   of mEqNimrodNode: genBinaryABC(c, n, dest, opcEqNimNode)

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -1302,8 +1302,21 @@ to be computed dynamically.
   echo callOp("-", 5, 4)
   ```
 
-The proc `dynamicBindSym` may also be used instead of `bindSym`
-to access this behavior without enabling the experimental switch.  
+The experimental switch `dynamicBindSymProc` may instead be enabled to
+use a proc named `dynamicBindSym` to achieve this behavior instead of
+modifying the behavior of `bindSym`.
+
+  ```nim
+  {.experimental: "dynamicBindSymProc".}
+
+  import macros
+
+  macro callOp(opName, arg1, arg2): untyped =
+    result = newCall(dynamicBindSym($opName), arg1, arg2)
+
+  echo callOp("+", 1, 2)
+  echo callOp("-", 5, 4)
+  ```
 
 
 Term rewriting macros

--- a/doc/manual_experimental.md
+++ b/doc/manual_experimental.md
@@ -1302,6 +1302,9 @@ to be computed dynamically.
   echo callOp("-", 5, 4)
   ```
 
+The proc `dynamicBindSym` may also be used instead of `bindSym`
+to access this behavior without enabling the experimental switch.  
+
 
 Term rewriting macros
 =====================

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -492,6 +492,25 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ## returned even if the symbol is not ambiguous.
   ##
   ## See the `manual <manual.html#macros-bindsym>`_ for more details.
+  ## 
+  ## See also `dynamicBindSym`_.
+
+proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
+              magic: "NBindSym", noSideEffect.}
+  ## Creates a node that binds `ident` to a symbol node. The bound symbol
+  ## may be an overloaded symbol.
+  ## if `ident` is a NimNode, it must have `nnkIdent` kind.
+  ## If `rule == brClosed` either an `nnkClosedSymChoice` tree is
+  ## returned or `nnkSym` if the symbol is not ambiguous.
+  ## If `rule == brOpen` either an `nnkOpenSymChoice` tree is
+  ## returned or `nnkSym` if the symbol is not ambiguous.
+  ## If `rule == brForceOpen` always an `nnkOpenSymChoice` tree is
+  ## returned even if the symbol is not ambiguous.
+  ## 
+  ## In contrast to `bindSym`_, `ident` does not have to be a constant value,
+  ## and instead may be a computed value. Note that this behavior is experimental.
+  ##
+  ## See the `manual <manual.html#macros-bindsym>`_ for more details.
 
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   magic: "NGenSym", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -495,8 +495,11 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ## 
   ## See also `dynamicBindSym`_.
 
-proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
+proc dynamicBindSymImpl(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
               magic: "NBindSym", noSideEffect.}
+
+proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
+              noSideEffect.} =
   ## Creates a node that binds `ident` to a symbol node. The bound symbol
   ## may be an overloaded symbol.
   ## if `ident` is a NimNode, it must have `nnkIdent` kind.
@@ -508,9 +511,11 @@ proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): Nim
   ## returned even if the symbol is not ambiguous.
   ## 
   ## In contrast to `bindSym`_, `ident` does not have to be a constant value,
-  ## and instead may be a computed value. Note that this behavior is experimental.
+  ## and instead may be a computed value (however still only at compile time).
+  ## Note that this behavior is experimental.
   ##
   ## See the `manual <manual.html#macros-bindsym>`_ for more details.
+  result = dynamicBindSymImpl(ident, rule) # impl call here to work around #11496
 
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   magic: "NGenSym", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -495,23 +495,16 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ## 
   ## See also `dynamicBindSym`_.
 
-proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
-              magic: "NBindSym", noSideEffect.}
-  ## Creates a node that binds `ident` to a symbol node. The bound symbol
-  ## may be an overloaded symbol.
-  ## if `ident` is a NimNode, it must have `nnkIdent` kind.
-  ## If `rule == brClosed` either an `nnkClosedSymChoice` tree is
-  ## returned or `nnkSym` if the symbol is not ambiguous.
-  ## If `rule == brOpen` either an `nnkOpenSymChoice` tree is
-  ## returned or `nnkSym` if the symbol is not ambiguous.
-  ## If `rule == brForceOpen` always an `nnkOpenSymChoice` tree is
-  ## returned even if the symbol is not ambiguous.
-  ## 
-  ## In contrast to `bindSym`_, `ident` does not have to be a constant value,
-  ## and instead may be a computed value (however still only at compile time).
-  ## Note that this behavior is experimental.
-  ##
-  ## See the `manual <manual.html#macros-bindsym>`_ for more details.
+when defined(nimHasDynamicBindSymMagic):
+  proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
+                magic: "NDynamicBindSym", noSideEffect.}
+    ## Same as `bindSym`_, except `ident` does not have to be constant,
+    ## and instead may be a computed value.
+    ## 
+    ## The `dynamicBindSymProc` experimental switch must be enabled
+    ## to use this proc.
+    ##
+    ## See the `experimental manual <manual_experimental.html#dynamic-arguments-for-bindsym>`_ for more details.
 
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   magic: "NGenSym", noSideEffect.}

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -495,11 +495,8 @@ proc bindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
   ## 
   ## See also `dynamicBindSym`_.
 
-proc dynamicBindSymImpl(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
-              magic: "NBindSym", noSideEffect.}
-
 proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): NimNode {.
-              noSideEffect.} =
+              magic: "NBindSym", noSideEffect.}
   ## Creates a node that binds `ident` to a symbol node. The bound symbol
   ## may be an overloaded symbol.
   ## if `ident` is a NimNode, it must have `nnkIdent` kind.
@@ -515,7 +512,6 @@ proc dynamicBindSym*(ident: string | NimNode, rule: BindSymRule = brClosed): Nim
   ## Note that this behavior is experimental.
   ##
   ## See the `manual <manual.html#macros-bindsym>`_ for more details.
-  result = dynamicBindSymImpl(ident, rule) # impl call here to work around #11496
 
 proc genSym*(kind: NimSymKind = nskLet; ident = ""): NimNode {.
   magic: "NGenSym", noSideEffect.}

--- a/tests/macros/tbindsym.nim
+++ b/tests/macros/tbindsym.nim
@@ -68,18 +68,18 @@ macro mixer(): untyped =
 
 mixer()
 
-block: # #11496
-  proc foo(x: int; y: float): int = x
+# #11496
+proc foo(x: int; y: float): int = x
 
-  macro macroA(call: untyped): untyped =
-    let
-      name = call.findChild(it.kind == nnkIdent).strVal
-      inst = name.dynamicBindSym().getTypeInst()
-    echo inst.repr
+macro macroA(call: untyped): untyped =
+  let
+    name = call.findChild(it.kind == nnkIdent).strVal
+    inst = name.dynamicBindSym().getTypeInst()
+  echo inst.repr
 
-  macro macroB(call: untyped): untyped =
-    let inst = call.findChild(it.kind == nnkIdent).strVal.dynamicBindSym().getTypeInst()
-    echo inst.repr
+macro macroB(call: untyped): untyped =
+  let inst = call.findChild(it.kind == nnkIdent).strVal.dynamicBindSym().getTypeInst()
+  echo inst.repr
 
-  macroA(foo(2, 2'f))
-  macroB(foo(2, 2'f))
+macroA(foo(2, 2'f))
+macroB(foo(2, 2'f))

--- a/tests/macros/tbindsym.nim
+++ b/tests/macros/tbindsym.nim
@@ -4,7 +4,6 @@ deinitApple
 Coral
 enum
   redCoral, blackCoral
-proc (x: int; y: float): int
 proc (x: int; y: float): int'''
   output: '''TFoo
 TBar'''
@@ -68,18 +67,18 @@ macro mixer(): untyped =
 
 mixer()
 
-# #11496
-proc foo(x: int; y: float): int = x
+block: # #11496
+  proc foo(x: int; y: float): int = x
 
-macro macroA(call: untyped): untyped =
-  let
-    name = call.findChild(it.kind == nnkIdent).strVal
-    inst = name.dynamicBindSym().getTypeInst()
-  echo inst.repr
+  macro macroA(call: untyped): untyped =
+    let
+      name = call.findChild(it.kind == nnkIdent).strVal
+      inst = name.dynamicBindSym().getTypeInst()
+    echo inst.repr
 
-macro macroB(call: untyped): untyped =
-  let inst = call.findChild(it.kind == nnkIdent).strVal.dynamicBindSym().getTypeInst()
-  echo inst.repr
+  #macro macroB(call: untyped): untyped =
+  #  let inst = call.findChild(it.kind == nnkIdent).strVal.#,dynamicBindSym().getTypeInst()
+  #  echo inst.repr
 
-macroA(foo(2, 2'f))
-macroB(foo(2, 2'f))
+  macroA(foo(2, 2'f))
+  #macroB(foo(2, 2'f))

--- a/tests/macros/tbindsym.nim
+++ b/tests/macros/tbindsym.nim
@@ -46,7 +46,7 @@ proc deinitApple(x: Apple) =
 macro wrapObject(obj: typed, n: varargs[untyped]): untyped =
   let m = n[0]
   for x in m:
-    var z = bindSym x
+    var z = dynamicBindSym x
     echo z.repr
 
 wrapObject(Apple):
@@ -60,7 +60,7 @@ type
 
 macro mixer(): untyped =
   let m = "Co" & "ral"
-  let x = bindSym(m)
+  let x = dynamicBindSym(m)
   echo x.repr
   echo getType(x).repr
 

--- a/tests/macros/tbindsym.nim
+++ b/tests/macros/tbindsym.nim
@@ -3,7 +3,9 @@ discard """
 deinitApple
 Coral
 enum
-  redCoral, blackCoral'''
+  redCoral, blackCoral
+proc (x: int; y: float): int
+proc (x: int; y: float): int'''
   output: '''TFoo
 TBar'''
 """
@@ -46,7 +48,7 @@ proc deinitApple(x: Apple) =
 macro wrapObject(obj: typed, n: varargs[untyped]): untyped =
   let m = n[0]
   for x in m:
-    var z = dynamicBindSym x
+    var z = bindSym x
     echo z.repr
 
 wrapObject(Apple):
@@ -65,3 +67,19 @@ macro mixer(): untyped =
   echo getType(x).repr
 
 mixer()
+
+block: # #11496
+  proc foo(x: int; y: float): int = x
+
+  macro macroA(call: untyped): untyped =
+    let
+      name = call.findChild(it.kind == nnkIdent).strVal
+      inst = name.dynamicBindSym().getTypeInst()
+    echo inst.repr
+
+  macro macroB(call: untyped): untyped =
+    let inst = call.findChild(it.kind == nnkIdent).strVal.dynamicBindSym().getTypeInst()
+    echo inst.repr
+
+  macroA(foo(2, 2'f))
+  macroB(foo(2, 2'f))


### PR DESCRIPTION
refs https://github.com/nim-lang/RFCs/issues/485

Alternative to universally enabling `--experimental:dynamicBindSym`. This keeps the `dynamicBindSym` feature opt-in (which I assume is intended since no effort was made to make it universal) while also not modifying the behavior of regular `bindSym`.

No changes are made to the behavior of the experimental switch. This just adds another way of accessing the feature.