### PR TITLE
only allow enums to overload enums + extra test

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2766,7 +2766,7 @@ proc enumFieldSymChoice(c: PContext, n: PNode, s: PSym): PNode =
   var i = 0
   var a = initOverloadIter(o, c, n)
   while a != nil:
-    if a.kind in OverloadableSyms-{skModule}:
+    if a.kind == skEnumField:
       inc(i)
       if i > 1: break
     a = nextOverloadIter(o, c, n)
@@ -2782,7 +2782,7 @@ proc enumFieldSymChoice(c: PContext, n: PNode, s: PSym): PNode =
     result = newNodeIT(nkClosedSymChoice, info, newTypeS(tyNone, c))
     a = initOverloadIter(o, c, n)
     while a != nil:
-      if a.kind in OverloadableSyms-{skModule}:
+      if a.kind == skEnumField:
         incl(a.flags, sfUsed)
         markOwnerModuleAsUsed(c, a)
         result.add newSymNode(a, info)

--- a/tests/enum/toverloadable_enums.nim
+++ b/tests/enum/toverloadable_enums.nim
@@ -84,3 +84,37 @@ proc g3[T](x: T, e: E2): int =
   of value2: echo "E2-B"
 
 let v5 = g3(99, E2.value2)
+
+block: # only allow enums to overload enums
+  # mirrors behavior without overloadableEnums
+  proc foo() = discard
+  block:
+    type Foo = enum foo
+    doAssert foo is Foo
+    foo()
+
+import macros
+block: # test with macros/templates
+  type
+    Enum1 = enum
+      value01, value02
+    Enum2 = enum
+      value01, value10
+
+  macro isOneM(a: untyped): bool =
+    result = newCall(bindSym"==", a, ident"value01")
+
+  macro isOneMS(a: untyped): bool =
+    result = newCall(bindSym"==", a, bindSym"value01")
+
+  template isOneT(a: untyped): bool =
+    a == value01
+
+  let e1 = Enum1.value01
+  let e2 = Enum2.value01
+  doAssert isOneM(e1)
+  doAssert isOneM(e2)
+  doAssert isOneMS(e1)
+  doAssert isOneMS(e2)
+  doAssert isOneT(e1)
+  doAssert isOneT(e2)


### PR DESCRIPTION
When a symbol has both enum and non-enum (e.g. routine) overloads, and the first resolved overload (i.e. last declared) for that symbol is an enum, only consider the enum overloads for that symbol and ignore non-enum overloads. This mirrors behavior without `overloadableEnums`.

The need for this was discovered in #20076 in some packages and standard library/tests