### PR TITLE
[Changelog] Add Wider Ascii Chars sets string formatting in strutils.nim

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,9 @@
 - Added bindings to [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift)
   and [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
   in `jscore` for JavaScript targets.
+- Added `UppercaseLetters`, `LowercaseLetters` The set of UppercaseLetters and lowercase ASCII letters.
+- Added `PunctuationChars` The set of all ASCII punctuation characters.
+- Added `PrintableChars` The set of all printable ASCII characters (letters, digits, whitespace, and punctuation characters).
 
 [//]: # "Deprecations:"
 - Deprecated `selfExe` for Nimscript.

--- a/changelog.md
+++ b/changelog.md
@@ -53,9 +53,7 @@
 - Added bindings to [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift)
   and [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
   in `jscore` for JavaScript targets.
-- Added `UppercaseLetters`, `LowercaseLetters` The set of UppercaseLetters and lowercase ASCII letters.
-- Added `PunctuationChars` The set of all ASCII punctuation characters.
-- Added `PrintableChars` The set of all printable ASCII characters (letters, digits, whitespace, and punctuation characters).
+- Added `UppercaseLetters`, `LowercaseLetters`, `PunctuationChars`,`PrintableChars` sets
 
 [//]: # "Deprecations:"
 - Deprecated `selfExe` for Nimscript.

--- a/changelog.md
+++ b/changelog.md
@@ -53,7 +53,7 @@
 - Added bindings to [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift)
   and [`queueMicrotask`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask)
   in `jscore` for JavaScript targets.
-- Added `UppercaseLetters`, `LowercaseLetters`, `PunctuationChars`,`PrintableChars` sets
+- Added `UppercaseLetters`, `LowercaseLetters`, `PunctuationChars`, `PrintableChars` sets to `std/strutils`.
 
 [//]: # "Deprecations:"
 - Deprecated `selfExe` for Nimscript.


### PR DESCRIPTION
Add Wider Ascii Chars sets for string formatting (#19994) (#20120):
- Added `UppercaseLetters`, `LowercaseLetters` The set of UppercaseLetters and lowercase ASCII letters.
- Added `PunctuationChars` The set of all ASCII punctuation characters.
- Added `PrintableChars` The set of all printable ASCII characters (letters, digits, whitespace, and punctuation characters).