### PR TITLE
Update message for checking `cast`

### DIFF
--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -240,7 +240,10 @@ proc isCastable(c: PContext; dst, src: PType, info: TLineInfo): bool =
         (skipTypes(dst, abstractInst).kind in IntegralTypes) or
         (skipTypes(src, abstractInst-{tyTypeDesc}).kind in IntegralTypes)
     if result and (dstSize > srcSize):
-      message(conf, info, warnCastSizes, "target type is larger than source type")
+      var warnMsg = "target type is larger than source type"
+      warnMsg.add("\n  target type: '$1' ($2)" % [$dst, if dstSize == 1: "1 byte" else: $dstSize & " bytes"])
+      warnMsg.add("\n  source type: '$1' ($2)" % [$src, if srcSize == 1: "1 byte" else: $srcSize & " bytes"])
+      message(conf, info, warnCastSizes, warnMsg)
   if result and src.kind == tyNil:
     return dst.size <= conf.target.ptrSize
 
@@ -362,10 +365,7 @@ proc semCast(c: PContext, n: PNode): PNode =
   if tfHasMeta in targetType.flags:
     localError(c.config, n[0].info, "cannot cast to a non concrete type: '$1'" % $targetType)
   if not isCastable(c, targetType, castedExpr.typ, n.info):
-    let tar = $targetType
-    let alt = typeToString(targetType, preferDesc)
-    let msg = if tar != alt: tar & "=" & alt else: tar
-    localError(c.config, n.info, "expression cannot be cast to " & msg)
+    localError(c.config, n.info, "expression cannot be cast to '$1'" % $targetType)
   result = newNodeI(nkCast, n.info)
   result.typ = targetType
   result.add copyTree(n[0])

--- a/tests/arc/t16558.nim
+++ b/tests/arc/t16558.nim
@@ -1,6 +1,6 @@
 discard """
   matrix: "--gc:arc"
-  errormsg: "expression cannot be cast to int"
+  errormsg: "expression cannot be cast to 'int'"
 """
 
 block: # bug #16558

--- a/tests/arc/tref_cast_error.nim
+++ b/tests/arc/tref_cast_error.nim
@@ -1,6 +1,6 @@
 discard """
   cmd: "nim c --gc:arc $file"
-  errormsg: "expression cannot be cast to ref RootObj"
+  errormsg: "expression cannot be cast to 'ref RootObj'"
   joinable: false
 """
 


### PR DESCRIPTION
Followup to #20103.

As an example, casting a `uint32` to a `uint64` (as is done in `compiler/int128.nim`), now produces the following message:
```
Warning: target type is larger than source type
  target type: 'uint64' (8 bytes)
  source type: 'uint32' (4 bytes) [CastSizes]
```
It currently shows the sizes in bytes, maybe it would be better to show the amount of bits?