### PR TITLE
fixes #20155; repr range with distinct types is broken with ORC

### DIFF
--- a/compiler/semmagic.nim
+++ b/compiler/semmagic.nim
@@ -190,6 +190,9 @@ proc evalTypeTrait(c: PContext; traitCall: PNode, operand: PType, context: PSym)
       arg = arg.base.skipTypes(skippedTypes + {tyGenericInst})
       if not rec: break
     result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
+  of "skipRanges":
+    var arg = operand.skipTypes({tyRange})
+    result = getTypeDescNode(c, arg, operand.owner, traitCall.info)
   else:
     localError(c.config, traitCall.info, "unknown trait: " & s)
     result = newNodeI(nkEmpty, traitCall.info)

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -93,7 +93,10 @@ proc repr*(p: proc): string =
   repr(cast[ptr pointer](unsafeAddr p)[])
 
 template repr*(x: distinct): string =
-  repr(distinctBase(typeof(x))(x))
+  when x is range: # hacks for ranges with distinct sub types
+    repr(distinctBase(skipRanges(typeof(x)))(x))
+  else:
+    repr(distinctBase(typeof(x))(x))
 
 template repr*(t: typedesc): string = $t
 

--- a/lib/system/repr_v2.nim
+++ b/lib/system/repr_v2.nim
@@ -6,6 +6,8 @@ proc isNamedTuple(T: typedesc): bool {.magic: "TypeTrait".}
 proc distinctBase(T: typedesc, recursive: static bool = true): typedesc {.magic: "TypeTrait".}
   ## imported from typetraits
 
+proc skipRanges(T: typedesc): typedesc {.magic: "TypeTrait".}
+
 proc repr*(x: NimNode): string {.magic: "Repr", noSideEffect.}
 
 proc repr*(x: int): string =

--- a/tests/metatype/tmetatype_various.nim
+++ b/tests/metatype/tmetatype_various.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''[1, 0, 0, 0, 0, 0, 0, 0] CTBool[Ct[system.uint32]]'''
 """
 


### PR DESCRIPTION
fixes #20155; I tried my best and had to do some hacks with typetrait support to my knowledge.

`template repr*(x: distinct): string` will match range types with distinct subtypes. To repr the real distinct type,  we need to skip the range types, otherwise it causes endless recursion.

