### PR TITLE
fixes #20162; locals doesn't work with ORC [backport]

### DIFF
--- a/compiler/plugins/locals.nim
+++ b/compiler/plugins/locals.nim
@@ -15,7 +15,7 @@ import ".." / [ast, astalgo,
 proc semLocals*(c: PContext, n: PNode): PNode =
   var counter = 0
   var tupleType = newTypeS(tyTuple, c)
-  result = newNodeIT(nkPar, n.info, tupleType)
+  result = newNodeIT(nkTupleConstr, n.info, tupleType)
   tupleType.n = newNodeI(nkRecList, n.info)
   let owner = getCurrOwner(c)
   # for now we skip openarrays ...

--- a/tests/misc/tlocals.nim
+++ b/tests/misc/tlocals.nim
@@ -1,4 +1,5 @@
 discard """
+  matrix: "--mm:refc; --mm:orc"
   output: '''(x: "string here", a: 1)
 b is 5
 x is 12'''


### PR DESCRIPTION
fixes #20162

Actually `nkPar` should be disabled for tuple construction, otherwise it probably breaks things.