### PR TITLE
more changelog changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@
   You may instead import `std/syncio` and `std/assertions`.
   The `-d:nimPreviewSlimSystem` option makes these imports required.
 
+- The `gc` switch has been renamed to `mm` ("memory management") in order to reflect the
+  reality better. (Nim moved away from all techniques based on "tracing".)
+
 - The `gc:v2` option is removed.
 
 - The `threads:on` option is now the default.
@@ -18,17 +21,17 @@
   `experimental:flexibleOptionalParams`.
 
 - The `Math.trunc` polyfill for targeting Internet Explorer was
-  previously emitted for every JavaScript output file except if
-  the symbol `nodejs` was defined via `-d:nodejs`. Now, it is only
-  emitted if the symbol `nimJsMathTruncPolyfill` is defined. If you are
-  targeting Internet Explorer, you may choose to enable this option
-  or define your own `Math.trunc` polyfill using the [`emit` pragma](https://nim-lang.org/docs/manual.html#implementation-specific-pragmas-emit-pragma). Nim uses
-  `Math.trunc` for the division and modulo operators for integers.
+  previously included in most JavaScript output files.
+  Now, it is only included with `-d:nimJsMathTruncPolyfill`.
+  If you are targeting Internet Explorer, you may choose to enable this option
+  or define your own `Math.trunc` polyfill using the [`emit` pragma](https://nim-lang.org/docs/manual.html#implementation-specific-pragmas-emit-pragma).
+  Nim uses `Math.trunc` for the division and modulo operators for integers.
 
 - `shallowCopy` is removed for ARC/ORC. Use `move` when possible or combine assignment and
 `sink` for optimization purposes.
 
-- `nimPreviewDotLikeOps` is going to be removed or deprecated.
+- The `nimPreviewDotLikeOps` switch is now enabled by default.
+  This switch may be ignored in the future.
 
 ## Standard library additions and changes
 
@@ -38,18 +41,20 @@
 - Module `colors` expanded with missing colors from the CSS color standard.
   `colPaleVioletRed` and `colMediumPurple` have also been changed to match the CSS color standard.
 - Fixed `lists.SinglyLinkedList` being broken after removing the last node ([#19353](https://github.com/nim-lang/Nim/pull/19353)).
-- `md5` now works at compile time and in JavaScript.
+- The `md5` module now works at compile time and in JavaScript.
 - `std/smtp` sends `ehlo` first. If the mail server does not understand, it sends `helo` as a fallback.
 - Changed `mimedb` to use an `OrderedTable` instead of `OrderedTableRef` to support `const` tables.
-- `strutils.find` now use and default to `last=-1` for whole string searches, making limiting it to just the first char (`last=0`) valid.
+- `strutils.find` now uses and defaults to `last = -1` for whole string searches,
+  making limiting it to just the first char (`last = 0`) valid.
 - `random.rand` now works with `Ordinal`s.
 
 [//]: # "Additions:"
-- Added `times.IsoWeekRange`, a range type to represent the number of weeks in an ISO week-based year.
-- Added `times.IsoYear`, a distinct int type to prevent bugs from confusing the week-based year and the regular year.
-- Added `times.initDateTime` to create a datetime from a weekday, and ISO 8601 week number and week-based year.
-- Added `times.getIsoWeekAndYear` to get an ISO week number along with the corresponding ISO week-based year from a datetime.
-- Added `times.getIsoWeeksInYear` to return the number of weeks in an ISO week-based year.
+- Added ISO 8601 week date utilities in `times`:
+  - Added `IsoWeekRange`, a range type for weeks in a week-based year.
+  - Added `IsoYear`, a distinct type for a week-based year in contrast to a regular year.
+  - Added a `initDateTime` overload to create a datetime from an ISO week date.
+  - Added `getIsoWeekAndYear` to get an ISO week number and week-based year from a datetime.
+  - Added `getIsoWeeksInYear` to return the number of weeks in a week-based year.
 - Added `std/oserrors` for OS error reporting. Added `std/envvars` for environment variables handling.
 - Added `sep` parameter in `std/uri` to specify the query separator.
 - Added bindings to [`Array.shift`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift)
@@ -74,52 +79,51 @@
 
 ## Language changes
 
-- [Tag tracking](manual.html#tag-tracking) supports the definition of forbidden tags by the `.forbids` pragma
+- [Tag tracking](https://nim-lang.github.io/Nim/manual.html#effect-system-tag-tracking) supports the definition of forbidden tags by the `.forbids` pragma
   which can be used to disable certain effects in proc types.
-- [Case statement macros](manual.html#macros-case-statement-macros) are no longer experimental,
+- [Case statement macros](https://nim-lang.github.io/Nim/manual.html#macros-case-statement-macros) are no longer experimental,
   meaning you no longer need to enable the experimental switch `caseStmtMacros` to use them.
-- Templates now accept [macro pragmas](https://nim-lang.github.io/Nim/manual.html#userminusdefined-pragmas-macro-pragmas).
-- Macro pragmas for var/let/const sections have been redesigned in a way that works
-  similarly to routine macro pragmas. The new behavior is documented in the
-  [experimental manual](https://nim-lang.github.io/Nim/manual_experimental.html#extended-macro-pragmas).
-- Pragma macros on type definitions can now return `nnkTypeSection` nodes as well as `nnkTypeDef`,
-  allowing multiple type definitions to be injected in place of the original type definition.
-
-  ```nim
-  import macros
-
-  macro multiply(amount: static int, s: untyped): untyped =
-    let name = $s[0].basename
-    result = newNimNode(nnkTypeSection)
-    for i in 1 .. amount:
-      result.add(newTree(nnkTypeDef, ident(name & $i), s[1], s[2]))
-
-  type
-    Foo = object
-    Bar {.multiply: 3.} = object
-      x, y, z: int
-    Baz = object
-
-  # becomes
-
-  type
-    Foo = object
-    Bar1 = object
-      x, y, z: int
-    Bar2 = object
-      x, y, z: int
-    Bar3 = object
-      x, y, z: int
-    Baz = object
-  ```
 - Full command syntax and block arguments i.e. `foo a, b: c` are now allowed
   for the right-hand side of type definitions in type sections. Previously
   they would error with "invalid indentation".
 - `defined` now accepts identifiers separated by dots, i.e. `defined(a.b.c)`.
   In the command line, this is defined as `-d:a.b.c`. Older versions can
   use accents as in ``defined(`a.b.c`)`` to access such defines.
+- [Macro pragmas](https://nim-lang.github.io/Nim/manual.html#userminusdefined-pragmas-macro-pragmas) changes:
+  - Templates now accept macro pragmas.
+  - Macro pragmas for var/let/const sections have been redesigned in a way that works
+    similarly to routine macro pragmas. The new behavior is documented in the
+    [experimental manual](https://nim-lang.github.io/Nim/manual_experimental.html#extended-macro-pragmas).
+  - Pragma macros on type definitions can now return `nnkTypeSection` nodes as well as `nnkTypeDef`,
+    allowing multiple type definitions to be injected in place of the original type definition.
 
-- Defines the `gcRefc` symbol which allows writing specific code for the refc GC.
+    ```nim
+    import macros
+
+    macro multiply(amount: static int, s: untyped): untyped =
+      let name = $s[0].basename
+      result = newNimNode(nnkTypeSection)
+      for i in 1 .. amount:
+        result.add(newTree(nnkTypeDef, ident(name & $i), s[1], s[2]))
+
+    type
+      Foo = object
+      Bar {.multiply: 3.} = object
+        x, y, z: int
+      Baz = object
+
+    # becomes
+
+    type
+      Foo = object
+      Bar1 = object
+        x, y, z: int
+      Bar2 = object
+        x, y, z: int
+      Bar3 = object
+        x, y, z: int
+      Baz = object
+    ```
 
 ## Compiler changes
 
@@ -128,15 +132,15 @@
 
 - `--styleCheck` now only applies to the current package.
 
+- The `gcRefc` symbol is now defined when the refc GC is used.
+
+- The new switch `--nimMainPrefix:prefix` adds a prefix to the names of `NimMain` and
+  related functions produced on the backend. This prevents conflicts when generating
+  static libraries.
+
 
 ## Tool changes
-
-- The `gc` switch has been renamed to `mm` ("memory management") in order to reflect the
-  reality better. (Nim moved away from all techniques based on "tracing".)
 
 - Nim now supports Nimble version 0.14 which added support for lock-files. This is done by
   a simple configuration change setting that you can do yourself too. In `$nim/config/nim.cfg`
   replace `pkgs` by `pkgs2`.
-
-- There is a new switch `--nimMainPrefix:prefix` to influence the `NimMain` that the
-  compiler produces. This is particularly useful for generating static libraries.


### PR DESCRIPTION
Sorry to make another changelog PR

* Added sublists for the `times` and macro pragmas changes.
* Moved some changes between breaking/language/compiler/tool changes
  - `gc` -> `mm` is "breaking"
  - `gcRefc` define/`--nimMainPrefix` are compiler specific features
* ~~Reword nimPreviewDotLikeOps change (original is misleading and makes it seem like dotlike ops were removed)~~
* Fix manual links to work in github preview page

Edit: Postponed