### PR TITLE
CI upgrade to ubuntu-20.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,13 +19,13 @@ jobs:
   strategy:
     matrix:
       Linux_amd64:
-        vmImage: 'ubuntu-18.04'
+        vmImage: 'ubuntu-20.04'
         CPU: amd64
       # regularly breaks, refs bug #17325
       Linux_i386:
         # on 'ubuntu-16.04' (not supported anymore anyways) it errored with:
         # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
-        vmImage: 'ubuntu-18.04'
+        vmImage: 'ubuntu-20.04'
         CPU: i386
       OSX_amd64:
         vmImage: 'macOS-11'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
       Linux_i386:
         # on 'ubuntu-16.04' (not supported anymore anyways) it errored with:
         # g++-multilib : Depends: gcc-multilib (>= 4:5.3.1-1ubuntu1) but it is not going to be installed
-        vmImage: 'ubuntu-20.04'
+        vmImage: 'ubuntu-18.04'
         CPU: i386
       OSX_amd64:
         vmImage: 'macOS-11'


### PR DESCRIPTION
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002