### PR TITLE
fix broken runnableExamples for getWeeksInIsoYear

### DIFF
--- a/lib/pure/times.nim
+++ b/lib/pure/times.nim
@@ -547,8 +547,8 @@ proc getWeeksInIsoYear*(y: IsoYear): IsoWeekRange {.since: (1, 5).} =
   ## Returns the number of weeks in the specified ISO 8601 week-based year, which can be
   ## either 53 or 52.
   runnableExamples:
-    assert getWeeksInIsoYear(IsoYear(2000)) == 52
-    assert getWeeksInIsoYear(IsoYear(2001)) == 53
+    assert getWeeksInIsoYear(IsoYear(2019)) == 52
+    assert getWeeksInIsoYear(IsoYear(2020)) == 53
 
   var y = int(y)
 


### PR DESCRIPTION
Based on what I understand from [Wikipedia](https://en.wikipedia.org/wiki/ISO_week_date#Weeks_per_year), 2001 does not have 53 weeks, but 2004, 2009, 2015, 2020 do. The years 2000 and 2001 seem to be copy pasted from the `getDaysInYear` example above. The result of `getWeeksInIsoYear` also seem to match up with Wikipedia.

That means these runnableExamples were never tested. Why is this the case? I only discovered this in #20091.