### PR TITLE
fixes nimPreviewSlimSystem; register echoBinSafe for nimPreviewSlimSystem

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3162,6 +3162,8 @@ when not defined(nimPreviewSlimSystem):
                 import `std/syncio`.""".}
   import std/syncio
   export syncio
+else:
+  import std/syncio
 
 when not defined(createNimHcr) and not defined(nimscript):
   include nimhcr

--- a/tests/system/tslimsystem.nim
+++ b/tests/system/tslimsystem.nim
@@ -1,5 +1,6 @@
 discard """
-  --matrix: "-d:nimPreviewSlimSystem"
+  output: "123"
+  matrix: "-d:nimPreviewSlimSystem"
 """
 
 echo 123

--- a/tests/system/tslimsystem.nim
+++ b/tests/system/tslimsystem.nim
@@ -1,0 +1,5 @@
+discard """
+  --matrix: "-d:nimPreviewSlimSystem"
+"""
+
+echo 123


### PR DESCRIPTION
we can extract common parts (stdout/stderr/stdin) to avoid import std/syncio later.