### PR TITLE
Show beatutiful html instead of ugly markdown preview

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ can run a subset of tests by specifying a category (for example
 ``./koch tests cat async``).
 
 For more information on the ``koch`` build tool please see the documentation
-within the [doc/koch.md](doc/koch.md) file.
+within the [doc/koch.md](https://nim-lang.github.io/Nim/koch.html) file.
 
 ## Nimble
 


### PR DESCRIPTION
The markdown preview looks pretty ugly. Instead we should link our beautiful documentation.


![image](https://user-images.githubusercontent.com/43030857/184058345-1e4695c3-6c72-4445-8107-06618e759640.png)
