### PR TITLE
fixes #11953; jsondoc creates no files unless the htmldocs dir is created

### DIFF
--- a/compiler/docgen.nim
+++ b/compiler/docgen.nim
@@ -1617,6 +1617,8 @@ proc writeOutputJson*(d: PDoc, useWarning = false) =
   if optStdout in d.conf.globalOptions:
     write(stdout, $content)
   else:
+    let dir = d.destFile.splitFile.dir
+    createDir(dir)
     var f: File
     if open(f, d.destFile, fmWrite):
       write(f, $content)

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -232,6 +232,23 @@ sub/mmain.idx""", context
     doAssert doSomething["col"].getInt == 0
     doAssert doSomething["code"].getStr == "proc doSomething(x, y: int): int {.raises: [], tags: [], forbids: [].}"
 
+  block: # nim jsondoc # bug #11953
+    let file = testsDir / "misc/mjsondoc.nim"
+    const destDir = "htmldoc"
+    removeDir(destDir)
+    defer: removeDir(destDir)
+    let (msg, exitCode) = execCmdEx(fmt"{nim} jsondoc {file}")
+    doAssert exitCode == 0, msg
+
+    let data = parseJson(readFile(destDir / "mjsondoc.json"))["entries"]
+    doAssert data.len == 4
+    let doSomething = data[0]
+    doAssert doSomething["name"].getStr == "doSomething"
+    doAssert doSomething["type"].getStr == "skProc"
+    doAssert doSomething["line"].getInt == 1
+    doAssert doSomething["col"].getInt == 0
+    doAssert doSomething["code"].getStr == "proc doSomething(x, y: int): int {.raises: [], tags: [], forbids: [].}"
+
 
   block: # further issues with `--backend`
     let file = testsDir / "misc/mbackend.nim"

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -234,7 +234,7 @@ sub/mmain.idx""", context
 
   block: # nim jsondoc # bug #11953
     let file = testsDir / "misc/mjsondoc.nim"
-    const destDir = "htmldoc"
+    const destDir = "htmldocs"
     removeDir(destDir)
     defer: removeDir(destDir)
     let (msg, exitCode) = execCmdEx(fmt"{nim} jsondoc {file}")

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -234,7 +234,7 @@ sub/mmain.idx""", context
 
   block: # nim jsondoc # bug #11953
     let file = testsDir / "misc/mjsondoc.nim"
-    const destDir = "htmldocs"
+    let destDir = testsDir / "misc/htmldocs"
     removeDir(destDir)
     defer: removeDir(destDir)
     let (msg, exitCode) = execCmdEx(fmt"{nim} jsondoc {file}")
@@ -248,7 +248,6 @@ sub/mmain.idx""", context
     doAssert doSomething["line"].getInt == 1
     doAssert doSomething["col"].getInt == 0
     doAssert doSomething["code"].getStr == "proc doSomething(x, y: int): int {.raises: [], tags: [], forbids: [].}"
-
 
   block: # further issues with `--backend`
     let file = testsDir / "misc/mbackend.nim"


### PR DESCRIPTION
fixes #11953