### PR TITLE
remove unused sfProcvar, "procvar" mentions

### DIFF
--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -260,7 +260,8 @@ type
                       # *OR*: a proc is indirectly called (used as first class)
     sfCompilerProc,   # proc is a compiler proc, that is a C proc that is
                       # needed for the code generator
-    sfProcvar,        # proc can be passed to a proc var
+    sfEscapes         # param escapes
+                      # currently unimplemented
     sfDiscriminant,   # field is a discriminant in a record/object
     sfRequiresInit,   # field must be initialized during construction
     sfDeprecated,     # symbol is deprecated
@@ -331,7 +332,7 @@ const
   sfExperimental* = sfOverriden       # module uses the .experimental switch
   sfGoto* = sfOverriden               # var is used for 'goto' code generation
   sfWrittenTo* = sfBorrow             # param is assigned to
-  sfEscapes* = sfProcvar              # param escapes
+                                      # currently unimplemented
   sfBase* = sfDiscriminant
   sfIsSelf* = sfOverriden             # param is 'self'
   sfCustomPragma* = sfRegister        # symbol is custom pragma template

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -990,8 +990,8 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wNonReloadable:
         sym.flags.incl sfNonReloadable
       of wProcVar:
+        # old procvar annotation, no longer needed
         noVal(c, it)
-        incl(sym.flags, sfProcvar)
       of wExplain:
         sym.flags.incl sfExplain
       of wDeprecated:
@@ -1040,7 +1040,6 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wThread:
         noVal(c, it)
         incl(sym.flags, sfThread)
-        incl(sym.flags, sfProcvar)
         if sym.typ != nil:
           incl(sym.typ.flags, tfThread)
           if sym.typ.callConv == ccClosure: sym.typ.callConv = ccNimCall

--- a/compiler/sempass2.nim
+++ b/compiler/sempass2.nim
@@ -562,7 +562,8 @@ proc procVarCheck(n: PNode; conf: ConfigRef) =
   if n.kind in nkSymChoices:
     for x in n: procVarCheck(x, conf)
   elif n.kind == nkSym and n.sym.magic != mNone and n.sym.kind in routineKinds:
-    localError(conf, n.info, "'$1' cannot be passed to a procvar" % n.sym.name.s)
+    localError(conf, n.info, ("'$1' is a built-in and cannot be used as " &
+      "a first-class procedure") % n.sym.name.s)
 
 proc notNilCheck(tracked: PEffects, n: PNode, paramType: PType) =
   let n = n.skipConv

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -8317,8 +8317,7 @@ violations of the `no heap sharing restriction`:idx:\: This restriction implies
 that it is invalid to construct a data structure that consists of memory
 allocated from different (thread-local) heaps.
 
-A thread proc is passed to `createThread` or `spawn` and invoked
-indirectly; so the `thread` pragma implies `procvar`.
+A thread proc can be passed to `createThread` or `spawn`.
 
 
 

--- a/tests/errmsgs/tcannot_capture_builtin.nim
+++ b/tests/errmsgs/tcannot_capture_builtin.nim
@@ -1,5 +1,5 @@
 discard """
-errormsg: "'+' cannot be passed to a procvar"
+errormsg: "'+' is a built-in and cannot be used as a first-class procedure"
 line: 8
 """
 


### PR DESCRIPTION
refs #12975. doesn't close it because the procvar annotation isn't completely removed, just does nothing (packages like `nimgame2` still use it)