### PR TITLE
new .redefine pragma for templates, warn on redefinition without it

### DIFF
--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: ${{ false }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_packages.yml
+++ b/.github/workflows/ci_packages.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   build:
-    if: ${{ false }}
     strategy:
       fail-fast: false
       matrix:

--- a/changelog.md
+++ b/changelog.md
@@ -121,6 +121,12 @@
 
 - Defines the `gcRefc` symbol which allows writing specific code for the refc GC.
 
+- Redefining templates with the same signature implicitly was previously
+  allowed to support certain macro code. A `{.redefine.}` pragma has been
+  added to make this work explicitly, and a warning is generated in the case
+  where it is implicit. This behavior only applies to templates, redefinition
+  is generally disallowed for other symbols.
+
 ## Compiler changes
 
 - `nim` can now compile version 1.4.0 as follows: `nim c --lib:lib --stylecheck:off compiler/nim`,

--- a/compiler/ast.nim
+++ b/compiler/ast.nim
@@ -335,6 +335,7 @@ const
   sfBase* = sfDiscriminant
   sfIsSelf* = sfOverriden             # param is 'self'
   sfCustomPragma* = sfRegister        # symbol is custom pragma template
+  sfTemplateRedefinition* = sfExportc # symbol is a redefinition of an earlier template
 
 const
   # getting ready for the future expr/stmt merge

--- a/compiler/condsyms.nim
+++ b/compiler/condsyms.nim
@@ -140,3 +140,4 @@ proc initDefines*(symbols: StringTableRef) =
   defineSymbol("nimHasEffectsOf")
 
   defineSymbol("nimHasEnforceNoRaises")
+  defineSymbol("nimHasTemplateRedefinitionPragma")

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -176,7 +176,7 @@ const
     warnCstringConv: "$1",
     warnEffect: "$1",
     warnCastSizes: "$1",
-    warnTemplateRedefinition: "template '$1' is implicitly redefined, consider adding explicit .redefine pragma",
+    warnTemplateRedefinition: "template '$1' is implicitly redefined, consider adding an explicit .redefine pragma",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`

--- a/compiler/lineinfos.nim
+++ b/compiler/lineinfos.nim
@@ -81,6 +81,7 @@ type
     warnCstringConv = "CStringConv",
     warnEffect = "Effect",
     warnCastSizes = "CastSizes"
+    warnTemplateRedefinition = "TemplateRedefinition",
     warnUser = "User",
     # hints
     hintSuccess = "Success", hintSuccessX = "SuccessX",
@@ -175,6 +176,7 @@ const
     warnCstringConv: "$1",
     warnEffect: "$1",
     warnCastSizes: "$1",
+    warnTemplateRedefinition: "template '$1' is implicitly redefined, consider adding explicit .redefine pragma",
     warnUser: "$1",
     hintSuccess: "operation successful: $#",
     # keep in sync with `testament.isSuccess`

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -38,7 +38,7 @@ const
   converterPragmas* = procPragmas
   methodPragmas* = procPragmas+{wBase}-{wImportCpp}
   templatePragmas* = {wDeprecated, wError, wGensym, wInject, wDirty,
-    wDelegator, wExportNims, wUsed, wPragma, wOverride}
+    wDelegator, wExportNims, wUsed, wPragma, wRedefine}
   macroPragmas* = declPragmas + {FirstCallConv..LastCallConv,
     wMagic, wNoSideEffect, wCompilerProc, wNonReloadable, wCore,
     wDiscardable, wGensym, wInject, wDelegator}
@@ -870,7 +870,7 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wDirty:
         if sym.kind == skTemplate: incl(sym.flags, sfDirty)
         else: invalidPragma(c, it)
-      of wOverride:
+      of wRedefine:
         if sym.kind == skTemplate: incl(sym.flags, sfTemplateRedefinition)
         else: invalidPragma(c, it)
       of wImportCpp:

--- a/compiler/pragmas.nim
+++ b/compiler/pragmas.nim
@@ -38,7 +38,7 @@ const
   converterPragmas* = procPragmas
   methodPragmas* = procPragmas+{wBase}-{wImportCpp}
   templatePragmas* = {wDeprecated, wError, wGensym, wInject, wDirty,
-    wDelegator, wExportNims, wUsed, wPragma}
+    wDelegator, wExportNims, wUsed, wPragma, wOverride}
   macroPragmas* = declPragmas + {FirstCallConv..LastCallConv,
     wMagic, wNoSideEffect, wCompilerProc, wNonReloadable, wCore,
     wDiscardable, wGensym, wInject, wDelegator}
@@ -869,6 +869,9 @@ proc singlePragma(c: PContext, sym: PSym, n: PNode, i: var int,
       of wExtern: setExternName(c, sym, expectStrLit(c, it), it.info)
       of wDirty:
         if sym.kind == skTemplate: incl(sym.flags, sfDirty)
+        else: invalidPragma(c, it)
+      of wOverride:
+        if sym.kind == skTemplate: incl(sym.flags, sfTemplateRedefinition)
         else: invalidPragma(c, it)
       of wImportCpp:
         processImportCpp(c, sym, getOptionalStr(c, it, "$1"), it.info)

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2139,10 +2139,12 @@ proc semQuoteAst(c: PContext, n: PNode): PNode =
   ids[0] = newAnonSym(c, skParam, n.info).newSymNode
   processQuotations(c, quotedBlock, op, quotes, ids)
 
+  let dummyTemplateSym = newAnonSym(c, skTemplate, n.info)
+  incl(dummyTemplateSym.flags, sfTemplateRedefinition)
   var dummyTemplate = newProcNode(
     nkTemplateDef, quotedBlock.info, body = quotedBlock,
     params = c.graph.emptyNode,
-    name = newAnonSym(c, skTemplate, n.info).newSymNode,
+    name = dummyTemplateSym.newSymNode,
               pattern = c.graph.emptyNode, genericParams = c.graph.emptyNode,
               pragmas = c.graph.emptyNode, exceptions = c.graph.emptyNode)
 

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2024,7 +2024,7 @@ proc expectString(c: PContext, n: PNode): string =
 proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =
   result = newSym(kind, c.cache.idAnon, nextSymId c.idgen, getCurrOwner(c), info)
   if kind == skTemplate:
-    result.flags.add(sfTemplateRedefinition)
+    incl(result.flags, sfTemplateRedefinition)
 
 proc semExpandToAst(c: PContext, n: PNode): PNode =
   let macroCall = n[1]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2023,8 +2023,6 @@ proc expectString(c: PContext, n: PNode): string =
 
 proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =
   result = newSym(kind, c.cache.idAnon, nextSymId c.idgen, getCurrOwner(c), info)
-  if kind == skTemplate:
-    incl(result.flags, sfTemplateRedefinition)
 
 proc semExpandToAst(c: PContext, n: PNode): PNode =
   let macroCall = n[1]

--- a/compiler/semexprs.nim
+++ b/compiler/semexprs.nim
@@ -2023,6 +2023,8 @@ proc expectString(c: PContext, n: PNode): string =
 
 proc newAnonSym(c: PContext; kind: TSymKind, info: TLineInfo): PSym =
   result = newSym(kind, c.cache.idAnon, nextSymId c.idgen, getCurrOwner(c), info)
+  if kind == skTemplate:
+    result.flags.add(sfTemplateRedefinition)
 
 proc semExpandToAst(c: PContext, n: PNode): PNode =
   let macroCall = n[1]

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -691,7 +691,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   if proto == nil:
     addInterfaceOverloadableSymAt(c, c.currentScope, s)
   elif not comesFromShadowscope:
-    if {sfGenSym, sfTemplateRedefinition} * s.flags != {}:
+    if sfTemplateRedefinition in s.flags:
       symTabReplace(c.currentScope.symbols, proto, s)
     else:
       wrongRedefinition(c, n.info, proto.name.s, proto.info)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -691,7 +691,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   if proto == nil:
     addInterfaceOverloadableSymAt(c, c.currentScope, s)
   elif not comesFromShadowscope:
-    if sfTemplateRedefinition in s.flags:
+    if {sfTemplateRedefinition, sfGenSym} * s.flags != {}:
       symTabReplace(c.currentScope.symbols, proto, s)
     else:
       wrongRedefinition(c, n.info, proto.name.s, proto.info)

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -691,7 +691,10 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   if proto == nil:
     addInterfaceOverloadableSymAt(c, c.currentScope, s)
   elif not comesFromShadowscope:
-    symTabReplace(c.currentScope.symbols, proto, s)
+    if sfTemplateRedefinition in s.flags:
+      symTabReplace(c.currentScope.symbols, proto, s)
+    else:
+      wrongRedefinition(c, n.info, proto.name.s, proto.info)
   if n[patternPos].kind != nkEmpty:
     c.patterns.add(s)
 

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -691,10 +691,10 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   if proto == nil:
     addInterfaceOverloadableSymAt(c, c.currentScope, s)
   elif not comesFromShadowscope:
-    if {sfTemplateRedefinition, sfGenSym} * s.flags != {}:
-      symTabReplace(c.currentScope.symbols, proto, s)
-    else:
-      wrongRedefinition(c, n.info, proto.name.s, proto.info)
+    if {sfTemplateRedefinition, sfGenSym} * s.flags == {}:
+      #wrongRedefinition(c, n.info, proto.name.s, proto.info)
+      message(c.config, n.info, warnTemplateRedefinition, s.name.s)
+    symTabReplace(c.currentScope.symbols, proto, s)
   if n[patternPos].kind != nkEmpty:
     c.patterns.add(s)
 

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -691,7 +691,7 @@ proc semTemplateDef(c: PContext, n: PNode): PNode =
   if proto == nil:
     addInterfaceOverloadableSymAt(c, c.currentScope, s)
   elif not comesFromShadowscope:
-    if sfTemplateRedefinition in s.flags:
+    if {sfGenSym, sfTemplateRedefinition} * s.flags != {}:
       symTabReplace(c.currentScope.symbols, proto, s)
     else:
       wrongRedefinition(c, n.info, proto.name.s, proto.info)

--- a/compiler/wordrecg.nim
+++ b/compiler/wordrecg.nim
@@ -87,6 +87,7 @@ type
     wGlobal = "global", wCodegenDecl = "codegenDecl", wUnchecked = "unchecked",
     wGuard = "guard", wLocks = "locks", wPartial = "partial", wExplain = "explain",
     wLiftLocals = "liftlocals", wEnforceNoRaises = "enforceNoRaises",
+    wRedefine = "redefine",
 
     wAuto = "auto", wBool = "bool", wCatch = "catch", wChar = "char",
     wClass = "class", wCompl = "compl", wConstCast = "const_cast", wDefault = "default",

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -7049,6 +7049,22 @@ immediate pragma
 The immediate pragma is obsolete. See `Typed vs untyped parameters
 <#templates-typed-vs-untyped-parameters>`_.
 
+redefine pragma
+---------------
+
+Redefinition of template symbols with the same signature is allowed.
+This can be made explicit with the `redefine` pragma:
+
+```nim
+template foo: int = 1
+echo foo() # 1
+template foo: int {.redefine.} = 2
+echo foo() # 2
+# warning: implicit redefinition of template
+template foo: int = 3
+```
+
+This is mostly intended for macro generated code. 
 
 compilation option pragmas
 --------------------------

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -126,7 +126,9 @@ template await*(f: typed): untyped {.used.} =
     error "await expects Future[T], got " & $typeof(f)
 
 template await*[T](f: Future[T]): auto {.used.} =
-  template yieldFuture {.override.} = yield FutureBase()
+  when not defined(nimHasTemplateRedefinitionPragma):
+    {.pragma: redefine.}
+  template yieldFuture {.redefine.} = yield FutureBase()
 
   when compiles(yieldFuture):
     var internalTmpFuture: FutureBase = f

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -126,7 +126,7 @@ template await*(f: typed): untyped {.used.} =
     error "await expects Future[T], got " & $typeof(f)
 
 template await*[T](f: Future[T]): auto {.used.} =
-  template yieldFuture = yield FutureBase()
+  template yieldFuture {.override.} = yield FutureBase()
 
   when compiles(yieldFuture):
     var internalTmpFuture: FutureBase = f

--- a/lib/pure/ioselects/ioselectors_select.nim
+++ b/lib/pure/ioselects/ioselectors_select.nim
@@ -398,18 +398,6 @@ proc contains*[T](s: Selector[T], fd: SocketHandle|int): bool {.inline.} =
       if s.fds[i].ident == fdi:
         return true
 
-when hasThreadSupport:
-  template withSelectLock[T](s: Selector[T], body: untyped) =
-    acquire(s.lock)
-    {.locks: [s.lock].}:
-      try:
-        body
-      finally:
-        release(s.lock)
-else:
-  template withSelectLock[T](s: Selector[T], body: untyped) =
-    body
-
 proc getData*[T](s: Selector[T], fd: SocketHandle|int): var T =
   s.withSelectLock():
     let fdi = int(fd)

--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -95,27 +95,28 @@ template doAssertRaises*(exception: typedesc, code: untyped) =
     doAssertRaises(ValueError): raise newException(ValueError, "Hello World")
     doAssertRaises(CatchableError): raise newException(ValueError, "Hello World")
     doAssertRaises(AssertionDefect): doAssert false
-  var wrong = false
-  const begin = "expected raising '" & astToStr(exception) & "', instead"
-  const msgEnd = " by: " & astToStr(code)
-  template raisedForeign = raiseAssert(begin & " raised foreign exception" & msgEnd)
-  when Exception is exception:
-    try:
-      if true:
-        code
-      wrong = true
-    except Exception as e: discard
-    except: raisedForeign()
-  else:
-    try:
-      if true:
-        code
-      wrong = true
-    except exception:
-      discard
-    except Exception as e:
-      mixin `$` # alternatively, we could define $cstring in this module
-      raiseAssert(begin & " raised '" & $e.name & "'" & msgEnd)
-    except: raisedForeign()
-  if wrong:
-    raiseAssert(begin & " nothing was raised" & msgEnd)
+  block:
+    var wrong = false
+    const begin = "expected raising '" & astToStr(exception) & "', instead"
+    const msgEnd = " by: " & astToStr(code)
+    template raisedForeign = raiseAssert(begin & " raised foreign exception" & msgEnd)
+    when Exception is exception:
+      try:
+        if true:
+          code
+        wrong = true
+      except Exception as e: discard
+      except: raisedForeign()
+    else:
+      try:
+        if true:
+          code
+        wrong = true
+      except exception:
+        discard
+      except Exception as e:
+        mixin `$` # alternatively, we could define $cstring in this module
+        raiseAssert(begin & " raised '" & $e.name & "'" & msgEnd)
+      except: raisedForeign()
+    if wrong:
+      raiseAssert(begin & " nothing was raised" & msgEnd)

--- a/lib/std/assertions.nim
+++ b/lib/std/assertions.nim
@@ -85,7 +85,9 @@ template onFailedAssert*(msg, code: untyped): untyped {.dirty.} =
     onFailedAssert(msg):
       raise (ref MyError)(msg: msg, lineinfo: instantiationInfo(-2))
     doAssertRaises(MyError): doAssert false
-  template failedAssertImpl(msgIMPL: string): untyped {.dirty, override.} =
+  when not defined(nimHasTemplateRedefinitionPragma):
+    {.pragma: redefine.}
+  template failedAssertImpl(msgIMPL: string): untyped {.dirty, redefine.} =
     let msg = msgIMPL
     code
 

--- a/tests/lookups/tredef.nim
+++ b/tests/lookups/tredef.nim
@@ -4,7 +4,7 @@ foo(1, "test")
 proc bar(a: int, b: string) = discard
 bar(1, "test")
 
-template foo(a: int, b: string) {.override.} = bar(a, b)
+template foo(a: int, b: string) {.redefine.} = bar(a, b)
 foo(1, "test")
 
 block:

--- a/tests/lookups/tredef.nim
+++ b/tests/lookups/tredef.nim
@@ -4,7 +4,7 @@ foo(1, "test")
 proc bar(a: int, b: string) = discard
 bar(1, "test")
 
-template foo(a: int, b: string) = bar(a, b)
+template foo(a: int, b: string) {.override.} = bar(a, b)
 foo(1, "test")
 
 block:

--- a/tests/macros/tstructuredlogging.nim
+++ b/tests/macros/tstructuredlogging.nim
@@ -66,7 +66,7 @@ macro mergeScopes(scopeHolders: typed, newBindings: untyped): untyped =
     newScopeDefinition.add newAssignment(newIdentNode(k), v)
 
   result = quote:
-    template scopeHolder = `newScopeDefinition`
+    template scopeHolder {.override.} = `newScopeDefinition`
 
 template scope(newBindings: untyped) {.dirty.} =
   mergeScopes(bindSym"scopeHolder", newBindings)

--- a/tests/macros/tstructuredlogging.nim
+++ b/tests/macros/tstructuredlogging.nim
@@ -66,7 +66,7 @@ macro mergeScopes(scopeHolders: typed, newBindings: untyped): untyped =
     newScopeDefinition.add newAssignment(newIdentNode(k), v)
 
   result = quote:
-    template scopeHolder {.override.} = `newScopeDefinition`
+    template scopeHolder {.redefine.} = `newScopeDefinition`
 
 template scope(newBindings: untyped) {.dirty.} =
   mergeScopes(bindSym"scopeHolder", newBindings)

--- a/tests/parser/tstmtlists.nim
+++ b/tests/parser/tstmtlists.nim
@@ -158,7 +158,7 @@ template dim2: int =
    else:
     int.high)
 
-template dim: int =
+template dim3: int =
   (
    if int.high == 0:
      int.high

--- a/tests/template/template_various.nim
+++ b/tests/template/template_various.nim
@@ -274,10 +274,10 @@ parse9:
 block gensym1:
   template x: untyped = -1
   template t1() =
-    template x: untyped {.gensym.} = 1
+    template x: untyped {.gensym, override.} = 1
     echo x()  # 1
   template t2() =
-    template x: untyped = 1  # defaults to {.inject.}
+    template x: untyped {.override.} = 1  # defaults to {.inject.}
     echo x()  # -1  injected x not available during template definition
   t1()
   t2()

--- a/tests/template/template_various.nim
+++ b/tests/template/template_various.nim
@@ -274,10 +274,10 @@ parse9:
 block gensym1:
   template x: untyped = -1
   template t1() =
-    template x: untyped {.gensym, override.} = 1
+    template x: untyped {.gensym, redefine.} = 1
     echo x()  # 1
   template t2() =
-    template x: untyped {.override.} = 1  # defaults to {.inject.}
+    template x: untyped {.redefine.} = 1  # defaults to {.inject.}
     echo x()  # -1  injected x not available during template definition
   t1()
   t2()

--- a/tests/template/tredefinition_override.nim
+++ b/tests/template/tredefinition_override.nim
@@ -4,6 +4,26 @@ doAssert not (compiles do:
 doAssert (compiles do:
   template foo(): int = 1
   template foo(): int {.override.} = 2)
-template foo(): int = 1
-template foo(): int {.override.} = 2
-doAssert foo() == 2
+doAssert not (compiles do:
+  block:
+    template foo() =
+      template bar: string {.gensym.} = "a"
+      template bar: string {.gensym.} = "b"
+    foo())
+doAssert (compiles do:
+  block:
+    template foo() =
+      template bar: string {.gensym.} = "a"
+      template bar: string {.gensym, override.} = "b"
+    foo())
+
+block:
+  template foo(): int = 1
+  template foo(): int {.override.} = 2
+  doAssert foo() == 2
+block:
+  template foo(): string =
+    template bar: string {.gensym.} = "a"
+    template bar: string {.gensym, override.} = "b"
+    bar()
+  doAssert foo() == "b"

--- a/tests/template/tredefinition_override.nim
+++ b/tests/template/tredefinition_override.nim
@@ -1,9 +1,11 @@
+{.push warningAsError[TemplateRedefinition]: on.}
+
 doAssert not (compiles do:
   template foo(): int = 1
   template foo(): int = 2)
 doAssert (compiles do:
   template foo(): int = 1
-  template foo(): int {.override.} = 2)
+  template foo(): int {.redefine.} = 2)
 doAssert not (compiles do:
   block:
     template foo() =
@@ -14,16 +16,18 @@ doAssert (compiles do:
   block:
     template foo() =
       template bar: string {.gensym.} = "a"
-      template bar: string {.gensym, override.} = "b"
+      template bar: string {.gensym, redefine.} = "b"
     foo())
 
 block:
   template foo(): int = 1
-  template foo(): int {.override.} = 2
+  template foo(): int {.redefine.} = 2
   doAssert foo() == 2
 block:
   template foo(): string =
     template bar: string {.gensym.} = "a"
-    template bar: string {.gensym, override.} = "b"
+    template bar: string {.gensym, redefine.} = "b"
     bar()
   doAssert foo() == "b"
+
+{.pop.}

--- a/tests/template/tredefinition_override.nim
+++ b/tests/template/tredefinition_override.nim
@@ -1,0 +1,9 @@
+doAssert not (compiles do:
+  template foo(): int = 1
+  template foo(): int = 2)
+doAssert (compiles do:
+  template foo(): int = 1
+  template foo(): int {.override.} = 2)
+template foo(): int = 1
+template foo(): int {.override.} = 2
+doAssert foo() == 2

--- a/tests/template/utemplates.nim
+++ b/tests/template/utemplates.nim
@@ -22,7 +22,7 @@ block: # templates can be redefined multiple times
     if not cond: fail(msg)
 
   template assertionFailed(body: untyped) {.dirty.} =
-    template fail(msg: string): typed {.override.} =
+    template fail(msg: string): typed {.redefine.} =
       body
 
   assertionFailed:

--- a/tests/template/utemplates.nim
+++ b/tests/template/utemplates.nim
@@ -22,7 +22,7 @@ block: # templates can be redefined multiple times
     if not cond: fail(msg)
 
   template assertionFailed(body: untyped) {.dirty.} =
-    template fail(msg: string): typed =
+    template fail(msg: string): typed {.override.} =
       body
 
   assertionFailed:

--- a/tests/trmacros/trmacros_various2.nim
+++ b/tests/trmacros/trmacros_various2.nim
@@ -33,8 +33,8 @@ block tpartial:
   proc p(x, y: int; cond: bool): int =
     result = if cond: x + y else: x - y
 
-  template optP{p(x, y, true)}(x, y): untyped = x - y
-  template optP{p(x, y, false)}(x, y): untyped = x + y
+  template optPTrue{p(x, y, true)}(x, y): untyped = x - y
+  template optPFalse{p(x, y, false)}(x, y): untyped = x + y
 
   echo p(2, 4, true)
 


### PR DESCRIPTION
closes #8275

A fair amount of packages seem to use template redefinitions. For documentation's sake:

* yaml (error says serializeImpl)
* stint (error says mtoIsZero)
* arraymancer (error says rewriteTensor_MultiplyAdd)
* macroutils (`template result()`)
* serialization (error says readFieldIMPL)
