### PR TITLE
closes #15316; add testcase

### DIFF
--- a/tests/misc/m15316.nim
+++ b/tests/misc/m15316.nim
@@ -1,0 +1,1 @@
+proc foo = (if)

--- a/tests/misc/trunner.nim
+++ b/tests/misc/trunner.nim
@@ -249,6 +249,12 @@ sub/mmain.idx""", context
     let cmd = fmt"{nim} r -b:cpp --hints:off --nimcache:{nimcache} --warningAsError:ProveInit {file}"
     check execCmdEx(cmd) == ("witness\n", 0)
 
+  block: # bug #15316
+    let file = testsDir / "misc/m15316.nim"
+    let cmd = fmt"{nim} check --hints:off --nimcache:{nimcache} {file}"
+    check execCmdEx(cmd) == ("m15316.nim(1, 15) Error: expression expected, but found \')\'\nm15316.nim(2, 1) Error: expected: \':\', but got: \'[EOF]\'\nm15316.nim(2, 1) Error: expression expected, but found \'[EOF]\'\nm15316.nim(2, 1) " &
+          "Error: expected: \')\', but got: \'[EOF]\'\nError: illformed AST: \n", 1)
+
   block: # config.nims, nim.cfg, hintConf, bug #16557
     let cmd = fmt"{nim} r --hint:all:off --hint:conf tests/newconfig/bar/mfoo.nim"
     let (outp, exitCode) = execCmdEx(cmd, options = {poStdErrToStdOut})


### PR DESCRIPTION
I reproduced the issue with the command below

```
choosenim "#f1f694dccb7ea0c7a6f10793dc05849da01970b7"
nim check test.nim
```

It seems that it works since 1.4.0