### PR TITLE
Don't require blank line before Markdown code (1.6)

### DIFF
--- a/compiler/ic/rodfiles.nim
+++ b/compiler/ic/rodfiles.nim
@@ -34,8 +34,7 @@ from typetraits import supportsCopyMem
 ##
 ## Now read the bits below to understand what's missing.
 ##
-## Issues with the Example
-## ```````````````````````
+## ### Issues with the Example
 ## Missing Sections:
 ## This is a low level API, so headers and sections need to be stored and
 ## loaded by the user, see `storeHeader` & `loadHeader` and `storeSection` &

--- a/lib/packages/docutils/rst.nim
+++ b/lib/packages/docutils/rst.nim
@@ -1864,10 +1864,15 @@ proc countTitles(s: PRstSharedState, n: PRstNode) =
         if s.hTitleCnt >= 2:
           break
 
+proc isMarkdownCodeBlock(p: RstParser, idx: int): bool =
+  roSupportMarkdown in p.s.options and p.tok[idx].symbol == "```"
+
 proc isAdornmentHeadline(p: RstParser, adornmentIdx: int): bool =
   ## check that underline/overline length is enough for the heading.
   ## No support for Unicode.
   if p.tok[adornmentIdx].symbol in ["::", "..", "|"]:
+    return false
+  if isMarkdownCodeBlock(p, adornmentIdx):
     return false
   var headlineLen = 0
   var failure = ""
@@ -1946,7 +1951,7 @@ proc findPipe(p: RstParser, start: int): bool =
 proc whichSection(p: RstParser): RstNodeKind =
   if currentTok(p).kind in {tkAdornment, tkPunct}:
     # for punctuation sequences that can be both tkAdornment and tkPunct
-    if roSupportMarkdown in p.s.options and currentTok(p).symbol == "```":
+    if isMarkdownCodeBlock(p, p.idx):
       return rnCodeBlock
     elif currentTok(p).symbol == "::":
       return rnLiteralBlock

--- a/tests/stdlib/trst.nim
+++ b/tests/stdlib/trst.nim
@@ -106,6 +106,33 @@ suite "RST parsing":
               rnLeaf  'desc2'
       """)
 
+  test "no blank line is required before or after Markdown code block":
+    check(dedent"""
+        Some text
+        ```
+        CodeBlock()
+        ```
+        Other text""".toAst ==
+      dedent"""
+        rnInner
+          rnParagraph
+            rnLeaf  'Some'
+            rnLeaf  ' '
+            rnLeaf  'text'
+          rnParagraph
+            rnCodeBlock
+              [nil]
+              [nil]
+              rnLiteralBlock
+                rnLeaf  '
+        CodeBlock()
+        '
+            rnLeaf  ' '
+            rnLeaf  'Other'
+            rnLeaf  ' '
+            rnLeaf  'text'
+      """)
+
   test "option list has priority over definition list":
     check(dedent"""
         defName


### PR DESCRIPTION
Fixes bug reported in https://github.com/nim-lang/Nim/pull/20189
affecting nimforum.
(manually backported version to 1.6 from devel)