### PR TITLE
Pass check condition directly to if

### DIFF
--- a/lib/pure/unittest.nim
+++ b/lib/pure/unittest.nim
@@ -704,7 +704,9 @@ macro check*(conditions: untyped): untyped =
     result = quote do:
       block:
         `assigns`
-        if not `check`:
+        if `check`:
+          discard
+        else:
           checkpoint(`lineinfo` & ": Check failed: " & `callLit`)
           `printOuts`
           fail()
@@ -720,7 +722,9 @@ macro check*(conditions: untyped): untyped =
     let callLit = checked.toStrLit
 
     result = quote do:
-      if not `checked`:
+      if `checked`:
+        discard
+      else:
         checkpoint(`lineinfo` & ": Check failed: " & `callLit`)
         fail()
 


### PR DESCRIPTION
When checking conditions, pass `check` untyped argument directly to if. This results in better error messages when the condition is malformed.

Previously `check 1` would fail at compile time with `Error: type mismatch: got 'int literal(-2)' for '-2' but expected 'bool'`
Now it fails with `Error: type mismatch: got 'int literal(1)' for '1' but expected 'bool'`.

Similarly `check "foo"` would fail with
```
Error: type mismatch: got <string>
but expected one of:
proc `not`(a: typedesc): typedesc
  first type mismatch at position: 1
  required type for a: typedesc
  but expression '"somestring"' is of type: string
...
```
Now it fails with `Error: type mismatch: got 'string' for '"somestring"' but expected 'bool'`