### PR TITLE
Remove string == nil/nil == string error

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -1604,18 +1604,6 @@ proc len*[U: Ordinal; V: Ordinal](x: HSlice[U, V]): int {.noSideEffect, inline.}
   ##   assert((5..2).len == 0)
   result = max(0, ord(x.b) - ord(x.a) + 1)
 
-when true: # PRTEMP: remove?
-  proc isNil*[T](x: seq[T]): bool {.noSideEffect, magic: "IsNil", error.}
-    ## Seqs are no longer nil by default, but set and empty.
-    ## Check for zero length instead.
-    ##
-    ## See also:
-    ## * `isNil(string) <#isNil,string>`_
-
-  proc isNil*(x: string): bool {.noSideEffect, magic: "IsNil", error.}
-    ## See also:
-    ## * `isNil(seq[T]) <#isNil,seq[T]>`_
-
 proc isNil*[T](x: ref T): bool {.noSideEffect, magic: "IsNil".}
 
 proc isNil*[T](x: ptr T): bool {.noSideEffect, magic: "IsNil".}

--- a/lib/system.nim
+++ b/lib/system.nim
@@ -3019,17 +3019,6 @@ proc `==`*(x, y: cstring): bool {.magic: "EqCString", noSideEffect,
   elif x.isNil or y.isNil: result = false
   else: result = strcmp(x, y) == 0
 
-when true: # xxx PRTEMP remove
-  # bug #9149; ensure that 'typeof(nil)' does not match *too* well by using 'typeof(nil) | typeof(nil)',
-  # especially for converters, see tests/overload/tconverter_to_string.nim
-  # Eventually we will be able to remove this hack completely.
-  proc `==`*(x: string; y: typeof(nil) | typeof(nil)): bool {.
-      error: "'nil' is now invalid for 'string'".} =
-    discard
-  proc `==`*(x: typeof(nil) | typeof(nil); y: string): bool {.
-      error: "'nil' is now invalid for 'string'".} =
-    discard
-
 template closureScope*(body: untyped): untyped =
   ## Useful when creating a closure in a loop to capture local loop variables by
   ## their current iteration values.


### PR DESCRIPTION
following up #17211

This was to help migration for `nil` strings being removed, but `nil` strings have been gone for a while now.