### PR TITLE
Adds missing SEEK_ POSIX constants for FreeRTOS

### DIFF
--- a/lib/posix/posix_freertos_consts.nim
+++ b/lib/posix/posix_freertos_consts.nim
@@ -500,3 +500,7 @@ const F_TEST* = cint(3)
 const F_TLOCK* = cint(2)
 const F_ULOCK* = cint(0)
 
+# <stdio.h>
+const SEEK_SET* = cint(0)
+const SEEK_CUR* = cint(1)
+const SEEK_END* = cint(2)


### PR DESCRIPTION
When trying to use `httpclient` or some other core async/socket/file based modules on FreeRTOS, these constants were missing.