### PR TITLE
Make cmp raise error for incomparables

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -2205,7 +2205,7 @@ proc cmp*[T](x, y: T): int =
   ## * a value greater than zero, if `x > y`
   ## * zero, if `x == y`
   ## 
-  ## Throws ValueError if not (x <= y or y <= x)
+  ## Throws a `ValueError` if neither `x <= y` nor `y <= x` is true.
   ##
   ## This is useful for writing generic algorithms without performance loss.
   ## This generic implementation uses the `<=` operator.


### PR DESCRIPTION
The comparison proc `cmp` previously returned a nonsensical value `1` when two values were incomparable (e.g. one is NaN; e.g. two sets which both contain elements not in the other set).

Now `cmp` raises an error when values are incomparable.

Fixes https://github.com/nim-lang/Nim/issues/20226

NB: I'm not sure that this is the best fix. Maybe instead of this, the comparison operators `<`, `>`, etc. should be based on the value of `cmp` in the case of sequences, tuples, etc. so that `cmp` is left undefined for `set` and other partially ordered types.