### PR TITLE
document compiler procs regarding `&`

### DIFF
--- a/compiler/ccgexprs.nim
+++ b/compiler/ccgexprs.nim
@@ -1197,7 +1197,7 @@ proc strLoc(p: BProc; d: TLoc): Rope =
 
 proc genStrConcat(p: BProc, e: PNode, d: var TLoc) =
   #   <Nim code>
-  #   s = 'Hello ' & name & ', how do you feel?' & 'z'
+  #   s = "Hello " & name & ", how do you feel?" & 'z'
   #
   #   <generated C code>
   #  {
@@ -1240,7 +1240,7 @@ proc genStrConcat(p: BProc, e: PNode, d: var TLoc) =
 
 proc genStrAppend(p: BProc, e: PNode, d: var TLoc) =
   #  <Nim code>
-  #  s &= 'Hello ' & name & ', how do you feel?' & 'z'
+  #  s &= "Hello " & name & ", how do you feel?" & 'z'
   #  // BUG: what if s is on the left side too?
   #  <generated C code>
   #  {

--- a/compiler/hlo.nim
+++ b/compiler/hlo.nim
@@ -8,6 +8,7 @@
 #
 
 # This include implements the high level optimization pass.
+# included from sem.nim
 
 when defined(nimPreviewSlimSystem):
   import std/assertions

--- a/compiler/transf.nim
+++ b/compiler/transf.nim
@@ -806,6 +806,8 @@ proc getMergeOp(n: PNode): PSym =
   else: discard
 
 proc flattenTreeAux(d, a: PNode, op: PSym) =
+  ## Optimizes away the `&` calls in the children nodes and
+  ## lifts the leaf nodes to the same level as `op2`.
   let op2 = getMergeOp(a)
   if op2 != nil and
       (op2.id == op.id or op.magic != mNone and op2.magic == op.magic):
@@ -898,6 +900,9 @@ proc transformExceptBranch(c: PTransf, n: PNode): PNode =
     result = transformSons(c, n)
 
 proc commonOptimizations*(g: ModuleGraph; idgen: IdGenerator; c: PSym, n: PNode): PNode =
+  ## Merges adjacent constant expressions of the children of the `&` call into
+  ## a single constant expression. It also inlines constant expressions which are not
+  ## complex.
   result = n
   for i in 0..<n.safeLen:
     result[i] = commonOptimizations(g, idgen, c, n[i])


### PR DESCRIPTION
I'm working on a [draft](https://github.com/ringabout/Nim/issues/22) which intends to improve the documentation of the compiler. In my opinion, comments smooth the development of the compiler. Though, the obsolete comments are a bit misleading. It is worthwhile updating the comments periodically since the code and comments are read thousands of times. Second, we need a documentation which introduces the internals of the Nim compiler. It should help the contributors gain the insights of the Nim compiler.

I'm writing some simple notes regarding how `&` is handled in the compiler at the same time:

![image](https://user-images.githubusercontent.com/43030857/185860168-a3b8fe10-f7d7-4ed6-83f0-9d40a5aec692.png)
