### PR TITLE
minor updates on manual

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -3943,7 +3943,7 @@ argument in inline calls, as well as a direct mirror of Nim's routine syntax.
   macroResults.add quote do:
     if not `ex`:
       echo `info`, ": Check failed: ", `expString`
-  
+
   # Processing a routine definition in a macro:
   rpc(router, "add") do (a, b: int) -> int:
     result = a + b
@@ -6159,7 +6159,7 @@ as arguments if called in statement form.
     # to perform the task
   do:
     # code to undo it
-  
+
   let num = 12
   # a single colon may be used if there is no initial block
   match (num mod 3, num mod 5):
@@ -6498,7 +6498,7 @@ This is best illustrated by an example:
 Import statement
 ----------------
 
-After the `import` statement, a list of module names can follow or a single
+After the `import` keyword, a list of module names can follow or a single
 module name followed by an `except` list to prevent some symbols from being
 imported:
 
@@ -6511,8 +6511,8 @@ imported:
 
 
 It is not checked that the `except` list is really exported from the module.
-This feature allows us to compile against an older version of the module that
-does not export these identifiers.
+This feature allows us to compile against different versions of the module
+even though one version does not export some of these identifiers.
 
 The `import` statement is only allowed at the top level.
 
@@ -6547,7 +6547,8 @@ The `include` statement can be used outside the top level, as such:
 Module names in imports
 -----------------------
 
-A module alias can be introduced via the `as` keyword:
+A module alias can be introduced via the `as` keyword (The original module name
+is then not accessible):
 
   ```nim
   import std/strutils as su, std/sequtils as qu
@@ -6555,8 +6556,7 @@ A module alias can be introduced via the `as` keyword:
   echo su.format("$1", "lalelu")
   ```
 
-The original module name is then not accessible. The notations
-`path/to/module` or `"path/to/module"` can be used to refer to a module
+The notations `path/to/module` or `"path/to/module"` can be used to refer to a module
 in subdirectories:
 
   ```nim
@@ -6613,7 +6613,7 @@ It is recommended and preferred but not currently enforced that all stdlib modul
 From import statement
 ---------------------
 
-After the `from` statement, a module name followed by
+After the `from` keyword, a module name followed by
 an `import` to list the symbols one likes to use without explicit
 full qualification:
 
@@ -7158,8 +7158,9 @@ Disabling certain messages
 --------------------------
 Nim generates some warnings and hints ("line too long") that may annoy the
 user. A mechanism for disabling certain messages is provided: Each hint
-and warning message contains a symbol in brackets. This is the message's
-identifier that can be used to enable or disable it:
+and warning message is associated with a symbol. This is the message's
+identifier that can be used to enable or disable the message by putting it
+in brackets following the pragma:
 
   ```Nim
   {.hint[LineTooLong]: off.} # turn off the hint about too long lines

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -6513,8 +6513,8 @@ imported:
 
 
 It is not checked that the `except` list is really exported from the module.
-This feature allows us to compile against different versions of the module
-even though one version does not export some of these identifiers.
+This feature allows us to compile against different versions of the module,
+even when one version does not export some of these identifiers.
 
 The `import` statement is only allowed at the top level.
 
@@ -7161,7 +7161,7 @@ Disabling certain messages
 Nim generates some warnings and hints ("line too long") that may annoy the
 user. A mechanism for disabling certain messages is provided: Each hint
 and warning message is associated with a symbol. This is the message's
-identifier that can be used to enable or disable the message by putting it
+identifier, which can be used to enable or disable the message by putting it
 in brackets following the pragma:
 
   ```Nim

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -6547,8 +6547,8 @@ The `include` statement can be used outside the top level, as such:
 Module names in imports
 -----------------------
 
-A module alias can be introduced via the `as` keyword (The original module name
-is then not accessible):
+A module alias can be introduced via the `as` keyword (the original module name
+is not accessible then):
 
   ```nim
   import std/strutils as su, std/sequtils as qu

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -6549,8 +6549,8 @@ The `include` statement can be used outside the top level, as such:
 Module names in imports
 -----------------------
 
-A module alias can be introduced via the `as` keyword (the original module name
-is not accessible then):
+A module alias can be introduced via the `as` keyword, and the original module name
+is not accessible then:
 
   ```nim
   import std/strutils as su, std/sequtils as qu

--- a/doc/manual.md
+++ b/doc/manual.md
@@ -6549,8 +6549,8 @@ The `include` statement can be used outside the top level, as such:
 Module names in imports
 -----------------------
 
-A module alias can be introduced via the `as` keyword, and the original module name
-is not accessible then:
+A module alias can be introduced via the `as` keyword, after which the original module name
+is inaccessible:
 
   ```nim
   import std/strutils as su, std/sequtils as qu


### PR DESCRIPTION
I had been involved in a collaborative Chinese translation of the manual. I propose these minor updates
to the manual, hoping to make it more clear.

1. statement -> keyword:

1. re-phase the explanation of `import except`: maybe the newer version does not export some of the identifiers;

1. "The original module name is then not accessible" is moved up to the previous paragraph, since it is strongly
    coupled with the previous paragraph, but not the current one.

1. re-phase the explanation of _Disabling certain messages_.