### PR TITLE
fixes deref nkStmtListExpr for ORC; ref #20246

### DIFF
--- a/tests/ccgbugs/tderefblock.nim
+++ b/tests/ccgbugs/tderefblock.nim
@@ -1,5 +1,5 @@
 discard """
-  cmd: "nim c -d:release -d:danger $file"
+  matrix: "-d:release -d:danger; -d:release -d:danger --mm:orc"
   output: "42"
 """
 


### PR DESCRIPTION
ref #20246

ORC likes to create temporaries for blocks and as a result it produces `nkStmtListExpr` in some cases. However, it doesn't seem that we can deref `nkStmtListExpr` properly. In this PR, I add some hacks to circumvent it. Otherwise, `tests/ccgbugs/tderefblock.nim` gives `nilAccess` defect with ARC/ORC.