### PR TITLE
clarify that `char` may not be unsigned

### DIFF
--- a/lib/system.nim
+++ b/lib/system.nim
@@ -30,7 +30,7 @@ type
 # 'float64' is now an alias to 'float'; this solves many problems
 
 type
-  char* {.magic: Char.}         ## Built-in 8 bit character type (unsigned).
+  char* {.magic: Char.}         ## Built-in 8 bit character type.
   string* {.magic: String.}     ## Built-in string type.
   cstring* {.magic: Cstring.}   ## Built-in cstring (*compatible string*) type.
   pointer* {.magic: Pointer.}   ## Built-in pointer type, use the `addr`


### PR DESCRIPTION
According to C11 standard, it may be either signed or unsigned, which is decided by implementation.

>  The three types char, signed char, and unsigned char are collectively called
the character types. The implementation shall define char to have the same range,
representation, and behavior as either signed char or unsigned char.

see also https://stackoverflow.com/questions/46463064/what-causes-a-char-to-be-signed-or-unsigned-when-using-gcc

