### PR TITLE
give a deprecate warning when using `newPar` to construct tuple expressions

### DIFF
--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1078,7 +1078,9 @@ proc newPar*(exprs: NimNode): NimNode =
   newNimNode(nnkPar).add(exprs)
 
 proc newPar*(exprs: varargs[NimNode]): NimNode {.deprecated:
-        "don't use newPar/nnkPar to construct tuple expressions; use nnkTupleConstr instead".}
+        "don't use newPar/nnkPar to construct tuple expressions; use nnkTupleConstr instead".} =
+  ## Create a new parentheses-enclosed expression.
+  newNimNode(nnkPar).add(exprs)
 
 proc newBlockStmt*(label, body: NimNode): NimNode =
   ## Create a new block statement with label.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1073,9 +1073,12 @@ proc newStmtList*(stmts: varargs[NimNode]): NimNode =
   ## Create a new statement list.
   result = newNimNode(nnkStmtList).add(stmts)
 
-proc newPar*(exprs: varargs[NimNode]): NimNode =
+proc newPar*(exprs: NimNode): NimNode =
   ## Create a new parentheses-enclosed expression.
   newNimNode(nnkPar).add(exprs)
+
+proc newPar*(exprs: varargs[NimNode]): NimNode {.error:
+        "don't use newPar/nnkPar to construct tuple expressions; use nnkTupleConstr instead".}
 
 proc newBlockStmt*(label, body: NimNode): NimNode =
   ## Create a new block statement with label.

--- a/lib/core/macros.nim
+++ b/lib/core/macros.nim
@@ -1077,7 +1077,7 @@ proc newPar*(exprs: NimNode): NimNode =
   ## Create a new parentheses-enclosed expression.
   newNimNode(nnkPar).add(exprs)
 
-proc newPar*(exprs: varargs[NimNode]): NimNode {.error:
+proc newPar*(exprs: varargs[NimNode]): NimNode {.deprecated:
         "don't use newPar/nnkPar to construct tuple expressions; use nnkTupleConstr instead".}
 
 proc newBlockStmt*(label, body: NimNode): NimNode =

--- a/lib/pure/strscans.nim
+++ b/lib/pure/strscans.nim
@@ -512,7 +512,7 @@ macro scanTuple*(input: untyped; pattern: static[string]; matcherTypes: varargs[
           inc userMatches
       else: discard
     inc p
-  result.add newPar(newCall(ident("scanf"), input, newStrLitNode(pattern)))
+  result.add nnkTupleConstr.newTree(newCall(ident("scanf"), input, newStrLitNode(pattern)))
   for arg in arguments:
     result[^1][0].add arg
     result[^1].add arg
@@ -588,7 +588,7 @@ macro scanp*(input, idx: typed; pattern: varargs[untyped]): bool =
           action
 
       # (x) a  # bind action a to (x)
-      if it[0].kind == nnkPar and it.len == 2:
+      if it[0].kind in {nnkPar, nnkTupleConstr} and it.len == 2:
         result = atm(it[0], input, idx, placeholder(it[1], input, idx))
       elif it.kind == nnkInfix and it[0].eqIdent"->":
         # bind matching to some action:


### PR DESCRIPTION
follow up https://github.com/nim-lang/Nim/pull/13793