### PR TITLE
fix #13515 [backport]

### DIFF
--- a/compiler/nilcheck.nim
+++ b/compiler/nilcheck.nim
@@ -551,7 +551,7 @@ template event(b: History): string =
   of TAssign: "assigns a value which might be nil"
   of TVarArg: "passes it as a var arg which might change to nil"
   of TResult: "it is nil by default"
-  of TType: "it has ref type"
+  of TransitionKind.TType: "it has ref type"
   of TSafe: "it is safe here as it returns false for isNil"
   of TPotentialAlias: "it might be changed directly or through an alias"
   of TDependant: "it might be changed because its base might be changed"

--- a/compiler/nilcheck.nim
+++ b/compiler/nilcheck.nim
@@ -551,7 +551,7 @@ template event(b: History): string =
   of TAssign: "assigns a value which might be nil"
   of TVarArg: "passes it as a var arg which might change to nil"
   of TResult: "it is nil by default"
-  of TransitionKind.TType: "it has ref type"
+  of TType: "it has ref type"
   of TSafe: "it is safe here as it returns false for isNil"
   of TPotentialAlias: "it might be changed directly or through an alias"
   of TDependant: "it might be changed because its base might be changed"

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -269,6 +269,7 @@ proc semTemplSymbol(c: PContext, n: PNode, s: PSym; isField: bool): PNode =
     # field access (dot expr) will be handled by builtinFieldAccess
     if not isField:
       styleCheckUse(c, n.info, s)
+  result.typ = nil # for typ.isNil checks that sem this node again
 
 proc semRoutineInTemplName(c: var TemplCtx, n: PNode): PNode =
   result = n

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -250,8 +250,14 @@ proc semTemplSymbol(c: PContext, n: PNode, s: PSym; isField: bool): PNode =
   of skUnknown:
     # Introduced in this pass! Leave it as an identifier.
     result = n
-  of OverloadableSyms:
+  of OverloadableSyms-{skTemplate,skMacro}:
     result = symChoice(c, n, s, scOpen, isField)
+  of skTemplate, skMacro:
+    result = symChoice(c, n, s, scOpen, isField)
+    if result.kind == nkSym:
+      # template/macro symbols might need to be semchecked again
+      # prepareOperand etc don't do this without setting the type to nil
+      result.typ = nil
   of skGenericParam:
     if isField and sfGenSym in s.flags: result = n
     else: result = newSymNodeTypeDesc(s, c.idgen, n.info)
@@ -269,10 +275,6 @@ proc semTemplSymbol(c: PContext, n: PNode, s: PSym; isField: bool): PNode =
     # field access (dot expr) will be handled by builtinFieldAccess
     if not isField:
       styleCheckUse(c, n.info, s)
-  if result.kind == nkSym:
-    # symbols resolved in templates might need to be semchecked again
-    # sometimes this doesn't happen without setting the type to nil
-    result.typ = nil
 
 proc semRoutineInTemplName(c: var TemplCtx, n: PNode): PNode =
   result = n

--- a/compiler/semtempl.nim
+++ b/compiler/semtempl.nim
@@ -269,7 +269,10 @@ proc semTemplSymbol(c: PContext, n: PNode, s: PSym; isField: bool): PNode =
     # field access (dot expr) will be handled by builtinFieldAccess
     if not isField:
       styleCheckUse(c, n.info, s)
-  result.typ = nil # for typ.isNil checks that sem this node again
+  if result.kind == nkSym:
+    # symbols resolved in templates might need to be semchecked again
+    # sometimes this doesn't happen without setting the type to nil
+    result.typ = nil
 
 proc semRoutineInTemplName(c: var TemplCtx, n: PNode): PNode =
   result = n

--- a/tests/template/t13515.nim
+++ b/tests/template/t13515.nim
@@ -1,3 +1,7 @@
+discard """
+  action: compile
+"""
+
 template test: bool = true
 
 # compiles:

--- a/tests/template/t13515.nim
+++ b/tests/template/t13515.nim
@@ -1,0 +1,12 @@
+template test: bool = true
+
+# compiles:
+if not test:
+  echo "wtf"
+
+# does not compile:
+template x =
+  if not test:
+    echo "wtf"
+
+x


### PR DESCRIPTION
fixes #13515

Really prepareOperand's behavior of [checking for nil node types](https://github.com/nim-lang/Nim/blob/f433d9cccf1a05da1a24e9fed9b914b7a2a35945/compiler/sigmatch.nim#L2288) is questionable, but I think this change is the most harmless for now, it's partially justified as templates resolving symbols early is unexpected.

Does not specifically need to be backported.